### PR TITLE
Graph tracing: Python I/O, stack traces, and SQLite importer for ttnn-visualizer

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1145,6 +1145,67 @@ def reset_tensix(tt_open_devices=None):
         logger.info("tt-smi reset completed successfully")
 
 
+@pytest.fixture(autouse=True)
+def ttnn_graph_report(request):
+    """
+    Automatically generate graph reports when config enables it.
+
+    Only activates when enable_logging, enable_graph_report, and report_path
+    are all set. Skipped when a graph capture is already active (e.g. a test
+    that manages its own capture).
+    """
+    import ttnn
+
+    if not getattr(ttnn.CONFIG, "enable_logging", False):
+        yield
+        return
+    if not getattr(ttnn.CONFIG, "enable_graph_report", False):
+        yield
+        return
+    report_path = getattr(ttnn.CONFIG, "report_path", None)
+    report_name = getattr(ttnn.CONFIG, "report_name", None)
+    if report_path is None or not report_name or str(report_name).strip() == "":
+        yield
+        return
+    if ttnn.graph.is_graph_capture_active():
+        yield
+        return
+
+    # Ensure we are torn down before device fixtures: request whichever device
+    # the test uses so pytest tears us down first, then the device.
+    if "mesh_device" in request.fixturenames:
+        request.getfixturevalue("mesh_device")
+    if "device" in request.fixturenames:
+        request.getfixturevalue("device")
+
+    report_path = Path(report_path)
+    enable_detailed_buffer_report = getattr(ttnn.CONFIG, "enable_detailed_buffer_report", False)
+
+    if enable_detailed_buffer_report:
+        ttnn.graph.enable_detailed_buffer_tracing()
+
+    ttnn.graph.begin_graph_capture(ttnn.graph.RunMode.NORMAL)
+    try:
+        yield
+    finally:
+        if not ttnn.graph.is_graph_capture_active():
+            logger.warning("Graph capture was already stopped (device may have been closed); skipping report.")
+        else:
+            report_path.mkdir(parents=True, exist_ok=True)
+            json_path = report_path / "graph_capture.json"
+            ttnn.graph.end_graph_capture_to_file(str(json_path))
+            if json_path.exists():
+                from ttnn.graph_report import import_report
+
+                import_report(json_path, report_path)
+
+            config_path = report_path / "config.json"
+            ttnn.save_config_to_json_file(config_path)
+
+        if enable_detailed_buffer_report:
+            ttnn.graph.disable_detailed_buffer_tracing()
+
+
 @pytest.fixture(scope="function", autouse=True)
 def record_test_timestamp(record_property):
     start_timestamp = datetime.strftime(datetime.now(), "%Y-%m-%dT%H:%M:%S%z")

--- a/tech_reports/ttnn/graph-tracing.md
+++ b/tech_reports/ttnn/graph-tracing.md
@@ -1,1258 +1,916 @@
-# TT-NN Graph Trace
-TT-NN provides a mechanism for tracing operations and memory activities in a neural network's execution.
+# TT-NN Graph Tracing
 
-Using this trace it is possible to analyze the operation even without executing it on the accelerator.
-The output trace can then be processed to get a single number like Peak Memory Load or to print tabular data or visualize a call graph.
+TT-NN provides a mechanism for tracing operations and memory activities during neural network execution. This enables performance analysis, memory profiling, and visualization without modifying your code.
 
-## 🪄 How to Use
-Wrap any number of TT-NN calls with `GraphProcessor::begin_graph_capture` and `GraphProcessor::end_graph_capture` or use with any callable.
-In the example below `ttnn::zeros` is not included in a trace, but `ttnn::add` is
-https://github.com/tenstorrent/tt-metal/blob/4ae4ac3c30cd24ea27cbac8cc5811c90d077e9c0/tests/ttnn/unit_tests/gtests/test_graph_add.cpp#L50-L58
+## Table of Contents
 
-You can then analyze the trace with some of the provided utility functions
-https://github.com/tenstorrent/tt-metal/blob/4ae4ac3c30cd24ea27cbac8cc5811c90d077e9c0/tests/ttnn/unit_tests/gtests/test_graph_add.cpp#L64-L66
-or process it manually to extract whatever data in whatever format, like this table
+- [Quick Start](#quick-start)
+- [Core Concepts](#core-concepts)
+- [Basic Usage](#basic-usage)
+- [Saving Reports](#saving-reports)
+- [Advanced Features](#advanced-features)
+  - [Reducing Capture Overhead](#reducing-capture-overhead)
+- [Levelized Graph](#levelized-graph)
+- [Testing & Validation](#testing--validation)
+- [Reference: Node Types](#reference-node-types)
+- [Reference: Sample Trace](#reference-sample-trace)
+
+---
+
+## Quick Start
+
+### Python (5 lines)
+
+```python
+import ttnn
+
+ttnn.graph.begin_graph_capture(ttnn.graph.RunMode.NORMAL)
+result = ttnn.add(tensor_a, tensor_b)  # Your operations here
+graph = ttnn.graph.end_graph_capture()
+print(graph)  # List of traced nodes
 ```
-        current_op                           event  total_cb  total_buffer                                                                                                                   info
-0            ttnn::add                        begin_op         0       9011200                                                                                {'inputs': '8', 'name': 'ttnn::add'}
-1         ttnn::repeat                        begin_op         0       9011200                                                                             {'inputs': '2', 'name': 'ttnn::repeat'}
-2         ttnn::repeat                 buffer_allocate         0      17203200                                   {'address': '753696', 'layout': 'INTERLEAVED', 'size': '8192000', 'type': 'DRAM'}
-3         ttnn::repeat                 buffer_allocate         0      17209344                                  {'address': '1073735680', 'layout': 'INTERLEAVED', 'size': '6144', 'type': 'DRAM'}
-4         ttnn::repeat        circular_buffer_allocate      4096      17209344    {'addr': '107360', 'core_range_set': '{[(x=0,y=0) - (x=7,y=7)]}', 'size': '4096', 'globally_allocated': 'false'}
-5         ttnn::repeat               buffer_deallocate      4096      17203200                                                              {'layout': 'INTERLEAVED', 'size': '0', 'type': 'DRAM'}
-6         ttnn::repeat  circular_buffer_deallocate_all         0      17203200                                                                                                                  {}
-7   ttnn::prim::binary                        begin_op         0      17203200                                                                      {'inputs': '10', 'name': 'ttnn::prim::binary'}
-8   ttnn::prim::binary                 buffer_allocate         0      25395200                                  {'address': '1437728', 'layout': 'INTERLEAVED', 'size': '8192000', 'type': 'DRAM'}
-9   ttnn::prim::binary                 buffer_allocate         0      25409536                                 {'address': '1073735680', 'layout': 'INTERLEAVED', 'size': '14336', 'type': 'DRAM'}
-10  ttnn::prim::binary        circular_buffer_allocate      4096      25409536    {'addr': '107360', 'core_range_set': '{[(x=0,y=0) - (x=7,y=7)]}', 'size': '4096', 'globally_allocated': 'false'}
-11  ttnn::prim::binary        circular_buffer_allocate      8192      25409536    {'addr': '111456', 'core_range_set': '{[(x=0,y=0) - (x=7,y=7)]}', 'size': '4096', 'globally_allocated': 'false'}
-12  ttnn::prim::binary        circular_buffer_allocate     12288      25409536    {'addr': '115552', 'core_range_set': '{[(x=0,y=0) - (x=7,y=7)]}', 'size': '4096', 'globally_allocated': 'false'}
-13  ttnn::prim::binary               buffer_deallocate     12288      25395200                                                              {'layout': 'INTERLEAVED', 'size': '0', 'type': 'DRAM'}
-14  ttnn::prim::binary  circular_buffer_deallocate_all         0      25395200                                                                                                                  {}
-15           ttnn::add               buffer_deallocate         0      17203200                                                              {'layout': 'INTERLEAVED', 'size': '0', 'type': 'DRAM'}
-16           ttnn::add  circular_buffer_deallocate_all         0      17203200                                                                                                                  {}
+
+### C++
+
+```cpp
+#include "ttnn/graph/graph_processor.hpp"
+
+ttnn::graph::GraphProcessor::begin_graph_capture(ttnn::graph::RunMode::NORMAL);
+auto result = ttnn::add(tensor_a, tensor_b);  // Your operations here
+auto graph = ttnn::graph::GraphProcessor::end_graph_capture();
 ```
-or a graph
+
+### Save to File (for ttnn-visualizer)
+
+For a complete capture with all data (per-op sub-graphs, buffer pages, stack traces):
+
+```python
+import ttnn
+
+with ttnn.manage_config("enable_fast_runtime_mode", False):
+    ttnn.graph.enable_detailed_buffer_tracing()
+    ttnn.graph.begin_graph_capture(ttnn.graph.RunMode.NORMAL)
+    # ... your operations ...
+    ttnn.graph.end_graph_capture_to_file("my_report.json")
+    ttnn.graph.disable_detailed_buffer_tracing()
+```
+
+Then import into the visualizer database:
+
+```bash
+python -m ttnn.graph_report my_report.json ./visualizer_db/
+```
+
+> **Note**: `enable_fast_runtime_mode=False` uses `Operation` (slow dispatch) which produces per-operation captured sub-graphs. The default `FastOperation` (fast dispatch) records arguments and tensor IDs but reconstructs sub-graphs synthetically. See [FastOperation vs Operation](#fastoperation-vs-operation) for details. Stack traces are enabled by default. To reduce overhead, see [Reducing Capture Overhead](#reducing-capture-overhead).
+
+---
+
+## Core Concepts
+
+### What Gets Captured
+
+The trace records:
+- **Operations**: Function calls (`ttnn::add`, `ttnn::matmul`, etc.)
+- **Tensors**: Shape, dtype, layout, memory location
+- **Memory events**: Buffer allocations/deallocations, circular buffers
+- **Timing**: Operation durations (wall-clock time)
+- **Call hierarchy**: Nested operations (e.g., `ttnn::add` → `ttnn::prim::binary`)
+- **Stack traces**: C++ call stacks for each operation (enabled by default); Python call stacks (opt-in via `enable_python_stack_traces()`)
+- **Deallocations**: `Tensor::deallocate` is tracked at the C++ level when a device buffer is actually freed (both explicit via `ttnn.deallocate()` and implicit via destructor)
+- **Python I/O**: Function arguments, input tensor IDs, and output tensor IDs recorded by the Python decorators
+
+### Two-Phase Architecture
+
+Graph capture is split into two phases:
+
+1. **C++ runtime capture** — During model execution, the C++ `GraphProcessor` records an in-memory graph of operations, tensors, buffers, and timing. The Python decorators (`FastOperation`, `Operation`) additionally record Python-level arguments and tensor IDs into a `python_io` list. At the end, both are serialized to a JSON report file.
+
+2. **Offline Python import** — A separate step reads the JSON report and imports it into a SQLite database that the ttnn-visualizer can consume. No database operations happen during model execution.
+
+### How Operations Are Tracked
+
+Operations are captured at two levels:
+
+1. **Python-level**: The `ttnn` decorators (`FastOperation`, `Operation`) automatically inject `function_start`/`function_end` graph nodes when capture is active. This produces high-level operation names like `ttnn.conv2d`, `ttnn.linear`, `ttnn.deallocate`. Both decorators also record Python-visible arguments and tensor IDs into `python_io` records that are embedded in the JSON report.
+
+2. **C++ level**: Internal C++ operations emit their own `function_start`/`function_end` nodes (e.g., `ttnn::matmul`, `Tensor::to_device`). These appear nested inside the Python-level operation.
+
+The result is a hierarchical graph: `ttnn.conv2d` (Python) → `ttnn::conv2d` (C++) → `Device Operation` → `create_device_tensor`, etc.
+
+**Deallocate tracking**: `Tensor::deallocate` emits tracking only when a device buffer is actually freed (not for host tensors or shared-reference tensors that skip deallocation). When called via Python `ttnn.deallocate()`, it appears nested: `ttnn.deallocate` → `Tensor::deallocate` → `buffer_deallocate`.
+
+### FastOperation vs Operation
+
+Both decorator classes participate in graph capture, but they differ in scope:
+
+| Feature | `FastOperation` | `Operation` (slow dispatch) |
+|---|---|---|
+| `function_start`/`function_end` nodes | Yes | Yes |
+| Python-level arguments in `python_io` | Yes | Yes |
+| Input tensor ID tracking | Yes | Yes |
+| Output tensor IDs (versioned, `force=True`) | Yes | Yes |
+| Per-operation C++ captured sub-graph | No | Yes |
+
+`FastOperation` is the default when `enable_fast_runtime_mode=True`. It records arguments and tensor IDs but does not wrap each operation in a nested `begin_graph_capture`/`end_graph_capture` call, so the per-operation captured sub-graph is synthetically reconstructed by the importer from the flat graph.
+
+### Tensor Connectivity
+
+The visualizer relies on tensor IDs to show data flow between operations:
+
+```
+op A  →  output tensor (id=42)  →  op B (consumes tensor id=42 as input)
+```
+
+Each `ttnn.Tensor` gets a unique `tensor_id` attribute assigned by `set_tensor_id()` in the decorators. Output tensors always get a fresh ID (`force=True`) so that in-place operations produce a distinct ID. The importer uses `python_io.input_tensor_ids` and `python_io.output_tensor_ids` to establish these connections in the `input_tensors` and `output_tensors` database tables.
+
+### Run Modes
+
+| Mode | Description | Use Case |
+|------|-------------|----------|
+| `NORMAL` | Real device execution with actual memory allocation | Production profiling, real addresses |
+| `NO_DISPATCH` | Simulated execution, no device dispatch | Fast analysis, memory estimation |
+
+```python
+# Fast analysis without device
+ttnn.graph.begin_graph_capture(ttnn.graph.RunMode.NO_DISPATCH)
+
+# Real execution with actual addresses
+ttnn.graph.begin_graph_capture(ttnn.graph.RunMode.NORMAL)
+```
+
+**Note**: In `NO_DISPATCH` mode, you can trace unrealistically large tensors for memory estimation since no real allocation occurs.
+
+---
+
+## Basic Usage
+
+### Extracting Operation Durations
+
+```python
+graph = ttnn.graph.end_graph_capture()
+
+for node in graph:
+    if node["node_type"] == "function_end" and "duration_ns" in node:
+        name = node["params"]["name"]
+        duration_ms = node["duration_ns"] / 1_000_000
+        print(f"{name}: {duration_ms:.2f} ms")
+```
+
+### Tracking Memory Usage
+
+```python
+def get_peak_memory(graph):
+    total_buffer = 0
+    peak_buffer = 0
+
+    for node in graph:
+        if node["node_type"] == "buffer_allocate":
+            total_buffer += int(node["params"]["size"])
+            peak_buffer = max(peak_buffer, total_buffer)
+        elif node["node_type"] == "buffer_deallocate":
+            # Get size from connected buffer node
+            buffer_id = node["connections"][0]
+            buffer_node = graph[buffer_id]
+            total_buffer -= int(buffer_node["params"]["size"])
+
+    return peak_buffer
+```
+
+### Generating Visualizations
+
+The trace can be visualized as a call graph:
+
 ![trace](https://github.com/user-attachments/assets/42501a1f-8354-4b3b-a5d9-707f30b23f4f)
 
-## Trace Format
-Trace is captured as a JSON and you can find the code producing it [here](https://github.com/tenstorrent/tt-metal/blob/main/ttnn/cpp/ttnn/graph/graph_processor.cpp).
-Below you can find a detailed description of the schema.
+Or as tabular data:
 
-### Node Types
-The trace is represented as a directed graph, where each node corresponds to a specific operation or memory event. Below is an overview of the various types of nodes that can be present in the trace:
-
-First, each node has these parameters
-
-* `counter`: The unique identifier of the node within the graph.
-* `node_type`: node type, available types are listed below
-* `params`: the map of parameters \[mapping a string string property name to a string value\]
-* `connections`: An array of connections to subsequent nodes.
-* `input_tensors`: An array of incoming nodes. Useful for determining the order of args.
-
-### Node Connections
-Each node in the graph maintains a list of connections to other nodes. These connections represent the flow of data and control through the various operations and memory events during the execution of the network.
-
-### 1\. capture\_start
-Marks the beginning of the graph capture process. This node is the root of the graph and does not have any parent nodes.
-
-#### Parameters
-* Empty, as this is a marker node.
-
-#### Connections
-* First element is next operation call
-* Last element is the corresponding `capture_end`
-
-### 2\. capture\_end
-Marks the end of the graph capture process.
-
-#### Parameters
-* Empty, as this is a marker node.
-
-### 3\. function\_start
-Represents the beginning of a function or operation within the graph. This node captures details about the function name and the number of input parameters it received.
-
-#### Parameters
-* `inputs`: Number of input parameters.
-* `name`: The name of the function or operation.
-
-#### Connections
-* Another op call, primitive op call, or a corresponding `function_end`
-
-#### Functions types
-* TT-NN operation: for example ttnn::add, ttnn::repeat
-* TT-NN primitive operation: for example ttnn::prim::binary (if it uses TMP infra) or ttnn::prim::old\_infra\_device\_operation (if not)
-* TT-NN device operation: name “Device Operation” (should change in future)
-* Unregistered, but manually tracked functions: (will change)
-  create\_device\_tensor, Tensor::to, Tensor::cpu, Tensor::cpu\_sharded, Tensor::print, Tensor::pad, Tensor::unpad, Tensor::reshape
-  tt::tt\_metal::detail::convert\_python\_tensor\_to\_tt\_tensor, tt::tt\_metal::detail::convert\_tt\_tensor\_to\_torch\_tensor
-
-### 4\. function\_end
-Marks the end of a function or operation. This node is paired with the corresponding `begin_function` node and records the outputs or final state of the function.
-
-#### Parameters
-* `name`: The name of the function or operation.
-
-#### Connections
-* Output tensor/s
-* Next control flow node (potentially `capture_end` node)
-
-### 5\. buffer
-Represents the allocation of a memory buffer. This node records details about the buffer's size, type (e.g., DRAM or L1 cache), and layout.
-
-#### Parameters
-* `size`: The size of the buffer in bytes.
-* `type`: The type of memory (e.g., "DRAM", "L1").
-* `layout`: The memory layout (e.g., "INTERLEAVED", "SINGLE\_BANK").
-* `device_id`: Id of the device.
-
-#### Connections
-* Single element in the connection list specifies the associated Tensor ID
-
-### 6\. buffer\_allocate
-Denotes the allocation of a buffer in memory. This node captures the specifics of the memory allocation event, including the buffer's address and type.
-
-#### Parameters
-* `size`: The size of the buffer in bytes.
-* `address`: The memory address of the buffer.
-* `type`: The type of memory (e.g., "DRAM", "L1").
-* `layout`: The memory layout.
-* `device_id`: Id of the device.
-
-#### Connections
-* Single element in the connections list specifies the allocated buffer ID
-
-### 7\. buffer\_deallocate
-Represents the deallocation of a buffer from memory. This node records the details of the buffer being deallocated.
-
-#### Parameters
-* `size`: The size of the buffer in bytes.
-* `type`: The type of memory (e.g., "DRAM", "L1").
-* `layout`: The memory layout.
-* `device_id`: Id of the device.
-
-#### Connections
-* Single element in the connections list specifies the deallocated buffer ID
-
-### 8\. circular\_buffer\_allocate
-Represents the allocation of a circular buffer, typically used in handling streaming data or multi-buffering strategies. This node captures details like the core range set involved and the buffer size.
-
-#### Parameters
-* `size`: The size of the circular buffer in bytes.
-* `address`: The memory address associated with the buffer.
-* `core_range_set`: The range of cores involved in the circular buffer.
-* `globally_allocated`: Does the circular buffer has global address set, i.e., does it share space with the corresponding operand.
-* `device_id`: Id of the device.
-
-#### Connections
-Usually empty
-
-### 9\. circular\_buffer\_deallocate\_all
-Marks the deallocation of all circular buffers. This is a bulk operation and is connected to all circular buffer nodes that are being deallocated.
-
-#### Parameters
-Empty, as this operation deallocates all circular buffers.
-
-#### Connections
-Usually empty
-
-### 10\. tensor
-Represents a tensor in the graph. This node captures the tensor's shape and is connected to the memory buffer it uses, if applicable.
-`[#]` means that each tensor is indexed, and instead of \# in real trace you will see an id
-
-#### Parameters
-* `tensor_id`: The identified of the tensor.
-* `shape`: The shape of the tensor.
-
-#### Connections
-Usually specifies function\_start of a function where given tensor is passed as an argument/used
-
-## Operation Dispatching
-When run in `NO_DISPATCH` run mode, real allocations do not happen, so trace collection does not have side effects on the allocator state.
-You can pass unrealistically big tensors in this mode and unless an operation does upper limit validation, you still can collect the trace.
-
-**Important: Program caching is disabled during `NO_DISPATCH` mode.** In this mode, buffer allocations are mocked with `address=0`, which means compiled programs contain invalid buffer addresses. If these programs were cached, subsequent runs in `NORMAL` mode would reuse programs with invalid addresses, causing device hangs. By disabling program caching during graph capture, we ensure that `NORMAL` mode always creates fresh programs with valid buffer addresses.
-
-When run in the `NORMAL` mode, memory can be fragmented, which can lead to a different trace and you see real addresses where everything is allocated. Programs are cached normally in this mode for reuse in future executions.
-
-## Getting operation arguments data
-Another capability of the Graph, is to collect the whole set of arguments provided for each operation executed in a ttnn call. This can be done in an individual operation, or a model as a whole, providing additional information about the internals of the operations
-
-### How to add it to python?
 ```
+        current_op                           event  total_cb  total_buffer
+0            ttnn::add                        begin_op         0       9011200
+1         ttnn::repeat                        begin_op         0       9011200
+2         ttnn::repeat                 buffer_allocate         0      17203200
+...
+```
+
+---
+
+## Saving Reports
+
+### Save Complete Report to File
+
+For offline analysis or ttnn-visualizer integration:
+
+```python
 ttnn.graph.begin_graph_capture(ttnn.graph.RunMode.NORMAL)
-.... # Your code here
+# ... your operations ...
+ttnn.graph.end_graph_capture_to_file("my_report.json")
+```
+
+The report file contains:
+- `version`: Report format version
+- `graph`: Full graph trace (list of nodes)
+- `devices`: Device information (architecture, grid size, memory)
+- `metadata`: Capture timestamp
+- `python_io`: Python-level I/O records (arguments, input/output tensor IDs per operation)
+- `per_operation_buffers`: Real buffer snapshots per operation (from `get_buffers()`)
+- `buffer_pages_by_address`: Compact per-address page data (when buffer pages are enabled)
+- `cluster_descriptor`: Cluster configuration YAML (if available)
+- `mesh_coordinate_mapping`: Physical chip mesh coordinate mapping YAML (if available, saved as `physical_chip_mesh_coordinate_mapping_1_of_1.yaml`)
+
+### Import into Visualizer Database
+
+```bash
+# Import a single report
+python -m ttnn.graph_report my_report.json ./visualizer_db/
+
+# Import all reports from a directory
+python -m ttnn.graph_report ./reports/ ./visualizer_db/
+
+# Generate SVG visualizations during import
+python -m ttnn.graph_report --svg my_report.json ./visualizer_db/
+```
+
+The importer creates these database tables:
+- `operations`: Operations with names and durations (IDs start at 1)
+- `operation_arguments`: Python-level arguments (from `python_io`), falling back to C++ arguments
+- `tensors`: Shape, dtype, layout, memory_config, device_id, address, buffer_type, size (bytes = volume * element_size)
+- `device_tensors`: Per-device addresses for multi-device tensors
+- `input_tensors`, `output_tensors`: Tensor-to-operation relationships (from `python_io` tensor IDs)
+- `buffers`: Cumulative memory allocation snapshots per operation (prefers `per_operation_buffers`)
+- `buffer_pages`: Per-page buffer detail (when enabled)
+- `captured_graph`: Per-operation subgraph JSON for the visualizer
+- `stack_traces`: C++ call stacks (captured by default) and/or Python call stacks (opt-in)
+- `edges`: Graph edges extracted from captured subgraphs
+- `errors`: Error information
+
+#### Import Behavior
+
+The importer produces output compatible with the ttnn-visualizer:
+
+**Operation filtering**: The raw C++ graph contains many nested internal operations (`create_device_tensor`, `Device Operation`, etc.). The importer keeps only top-level operations that are meaningful to the user:
+- Nested operations (those inside another `function_start`/`function_end` pair) are automatically filtered, with their inputs and outputs lifted to the parent
+- Certain C++ wrapper operations are always treated as transparent (their children are still visible but they themselves don't become top-level operations):
+  - `ttnn::convert_python_tensor_to_tt_tensor`
+  - `tt::tt_metal::detail::convert_tt_tensor_to_framework_tensor`
+  - `Tensor::deallocate`
+  - `Tensor::to_device`
+  - `Tensor::reshape`
+  - `tt::tt_metal::to_dtype`
+- Leading `ttnn.from_torch` operations (weight loading before any compute) are filtered; subsequent `from_torch` calls after the first real compute operation are kept
+
+**Python I/O resolution**: When `python_io` records are present in the report, the importer uses them as the primary source for:
+- Operation arguments (instead of C++ serialized arguments)
+- Input tensor IDs (instead of heuristic extraction from C++ graph connections)
+- Output tensor IDs (instead of C++ function_end connections)
+
+The importer matches `python_io` records to graph nodes by operation name, consuming them in order.
+
+**Tensor lifting**: When nested operations are filtered, their input/output tensor associations are "lifted" to the parent operation. For example, `ttnn.conv2d` might internally call `ttnn::matmul` which produces an output tensor — that tensor is attributed to `ttnn.conv2d` in the database. Internal tensors (produced and consumed within the same parent scope) are excluded.
+
+**Tensor reconciliation**: Python decorators may assign fresh tensor IDs (via `set_tensor_id(force=True)`) that don't correspond to any C++ graph tensor node. The importer reconciles these by:
+1. Looking up the memory address of the C++ tensor and cloning its properties
+2. Falling back to the `pyid_to_cpp_tensor` mapping (built during import) to associate Python output IDs with their C++ counterpart nodes
+
+**Deallocate synthesis**: If a `buffer_deallocate` event occurs outside any `function_start`/`function_end` pair, the importer synthesizes a `ttnn::deallocate` operation for it.
+
+**Tensor deduplication**:
+- Device tensors are deduplicated by address
+- Host tensors are kept only when referenced as operation inputs or outputs
+
+**Buffer type mapping**:
+
+| String | Integer |
+|---|---|
+| `DRAM` | 0 |
+| `L1` | 1 |
+| `SYSTEM_MEMORY` | 2 |
+| `L1_SMALL` | 3 |
+| `TRACE` | 4 |
+
+The importer prioritizes the `exact_buffer_type` field from `buffer_allocate` nodes (which uses the precise C++ enum) over the generic `type` field.
+
+```bash
+python -m ttnn.graph_report my_report.json ./visualizer_db/
+```
+
+Or from Python:
+
+```python
+from ttnn.graph_report import import_report
+db_path = import_report("my_report.json", "./output/")
+```
+
+---
+
+## Advanced Features
+
+### Stack Trace Capture
+
+Python stack traces are **enabled by default**. When enabled, each operation invoked through the Python decorators records the Python call stack at invocation time, filtered to exclude ttnn internals and test-runner noise:
+
+```python
 ttnn.graph.begin_graph_capture(ttnn.graph.RunMode.NORMAL)
-captured_graph = ttnn.graph.end_graph_capture()
+result = ttnn.add(tensor_a, tensor_b)
+ttnn.graph.end_graph_capture_to_file("report.json")
 ```
 
-### How to add it in C++?
-https://github.com/tenstorrent/tt-metal/blob/a24a9be806feec4c3bf980443a35ce02e2498d0a/tests/ttnn/unit_tests/gtests/test_graph_capture_arguments_morehdot.cpp#L27-L30
+To disable Python stack traces for reduced overhead:
 
-### How do I get the output?
-
-#### For C++
-https://github.com/tenstorrent/tt-metal/blob/main/tests/ttnn/unit_tests/gtests/test_graph_capture_arguments_morehdot.cpp
-
-#### For Python
-https://github.com/tenstorrent/tt-metal/blob/a24a9be806feec4c3bf980443a35ce02e2498d0a/tests/ttnn/unit_tests/test_graph_capture.py#L189
-
-### What about getting the information in Json?
-Since not everybody is familiar with TT format to present the trace data, we have created a tool to convert it to json, so it can be parsed in any way of your convenience, to use it just do the following after calling
-
-https://github.com/tenstorrent/tt-metal/blob/de8049beac0a2fe81f50a91c9f56543731fecfcb/tests/ttnn/unit_tests/test_graph_capture.py#L372-L375
-
-Please remember to import the following function:
-```
-from ttnn.graph_tracer_utils import GraphTracerUtils
+```python
+ttnn.graph.disable_python_stack_traces()
+# ... capture ...
+ttnn.graph.enable_python_stack_traces()  # Restore default
 ```
 
-You can also check an example here: https://github.com/tenstorrent/tt-metal/blob/de8049beac0a2fe81f50a91c9f56543731fecfcb/tests/ttnn/unit_tests/test_graph_capture.py#L372-L375
+Python stack traces are stored in the `python_io` section of the JSON report and imported into the `stack_traces` table. Internal C++ operations (nested ops that don't go through the Python decorators) will not have stack traces.
 
-
-### How does the expected JSon looks like?
-
-Let's do the exercise of tracing the following demo: https://github.com/tenstorrent/tt-metal/blob/main/models/demos/bert/demo/demo.py#L64-L166
-
-We are going to add the begin_capture before the first operation here: https://github.com/tenstorrent/tt-metal/blob/de8049beac0a2fe81f50a91c9f56543731fecfcb/models/demos/bert/demo/demo.py#L64
-
-and closing the capture here:
-https://github.com/tenstorrent/tt-metal/blob/de8049beac0a2fe81f50a91c9f56543731fecfcb/models/demos/bert/demo/demo.py#L157
-
-Giving as a result a code like this:
+Example `stack_traces` entry (innermost frame first):
 
 ```
-def run_bert_question_and_answering_inference(
-    device,
+  File "resnet50.py", line 196, in __call__
+    out, [h, w], [weight, bias] = ttnn.conv2d(
 
-    model_name,
-    batch_size,
-    sequence_size,
-    bert,
-    model_location_generator,
-    input_path,
-):
-    ttnn.graph.begin_graph_capture(ttnn.graph.RunMode.NORMAL)
-    model = str(model_location_generator(model_name, model_subdir="Bert"))
-    hugging_face_reference_model = BertForQuestionAnswering.from_pretrained(model, torchscript=False)
-    hugging_face_reference_model.eval()
-
-    # set up tokenizer
-    tokenizer_name = str(model_location_generator(model_name, model_subdir="Bert"))
-    tokenizer = BertTokenizer.from_pretrained(tokenizer_name)
-    config = hugging_face_reference_model.config
-    nlp = pipeline("question-answering", model=hugging_face_reference_model, tokenizer=tokenizer)
-
-    if bert == ttnn_bert:
-        tt_model_name = f"ttnn_{model_name}"
-    elif bert == ttnn_optimized_bert:
-        tt_model_name = f"ttnn_{model_name}_optimized"
-    else:
-        raise ValueError(f"Unknown bert: {bert}")
-
-    profiler.start(f"preprocessing_parameter")
-    parameters = preprocess_model_parameters(
-        model_name=tt_model_name,
-        initialize_model=lambda: transformers.BertForQuestionAnswering.from_pretrained(
-            model_name, torchscript=False
-        ).eval(),
-        custom_preprocessor=bert.custom_preprocessor,
-        device=device,
-    )
-    profiler.end(f"preprocessing_parameter")
-
-    context, question = load_inputs(input_path, batch_size)
-
-    preprocess_params, _, postprocess_params = nlp._sanitize_parameters()
-    preprocess_params["max_seq_len"] = sequence_size
-    inputs = nlp._args_parser({"context": context, "question": question})
-    preprocessed_inputs = []
-    for i in range(batch_size):
-        model_input = next(nlp.preprocess(inputs[0][i], **preprocess_params))
-        single_input = {
-            "example": model_input["example"],
-            "inputs": model_input,
-        }
-        preprocessed_inputs.append(single_input)
-
-    bert_input = tokenizer.batch_encode_plus(
-        zip(question, context),
-        max_length=sequence_size,
-        padding="max_length",
-        truncation=True,
-        return_attention_mask=True,
-        return_token_type_ids=True,
-        return_tensors="pt",
-    )
-
-    position_ids = positional_ids(config, bert_input.input_ids)
-    profiler.start(f"preprocessing_input")
-    ttnn_bert_inputs = bert.preprocess_inputs(
-        bert_input["input_ids"],
-        bert_input["token_type_ids"],
-        position_ids,
-        bert_input["attention_mask"],
-        device=device,
-    )
-    profiler.end(f"preprocessing_input")
-
-    profiler.start(f"inference_time")
-    tt_output = bert.bert_for_question_answering(
-        config,
-        *ttnn_bert_inputs,
-        parameters=parameters,
-    )
-    profiler.end(f"inference_time")
-
-    tt_output = ttnn.to_torch(ttnn.from_device(tt_output)).reshape(batch_size, 1, sequence_size, -1).to(torch.float32)
-
-    tt_start_logits = tt_output[..., :, 0].squeeze(1)
-    tt_end_logits = tt_output[..., :, 1].squeeze(1)
-
-    model_answers = {}
-    profiler.start("post_processing_output_to_string")
-    for i in range(batch_size):
-        tt_res = {
-            "start": tt_start_logits[i],
-            "end": tt_end_logits[i],
-            "example": preprocessed_inputs[i]["example"],
-            **preprocessed_inputs[i]["inputs"],
-        }
-
-        tt_answer = nlp.postprocess([tt_res], **postprocess_params)
-
-        logger.info(f"answer: {tt_answer['answer']}\n")
-        model_answers[i] = tt_answer["answer"]
-
-    profiler.end("post_processing_output_to_string")
-    captured_graph = ttnn.graph.end_graph_capture()
-    data = GraphTracerUtils.serialize_graph(captured_graph)
-    measurements = {
-        "preprocessing_parameter": profiler.get("preprocessing_parameter"),
-        "preprocessing_input": profiler.get("preprocessing_input"),
-        "inference_time": profiler.get("inference_time"),
-        "post_processing": profiler.get("post_processing_output_to_string"),
-    }
-    logger.info(f"preprocessing_parameter: {measurements['preprocessing_parameter']} s")
-    logger.info(f"preprocessing_input: {measurements['preprocessing_input']} s")
-    logger.info(f"inference_time: {measurements['inference_time']} s")
-    logger.info(f"post_processing : {measurements['post_processing']} s")
+  File "my_model.py", line 42, in forward
+    out = ttnn.add(x, y)
 ```
 
-The output of this should like like this:
-https://gist.github.com/dgomezTT/ad5af9cf42f245a9a220458f431919c4
-
-Please note that we have over 300.000 lines in the json file, so we just included a few in the gist.
-
-### How to trace a hanging operation?
-Sometimes there might be cases where an operation hangs and the arguments can be quite handy to troubleshoot the issue or even adding extra coverage.
-We have added the following configuration
-
+```python
+# Check status
+print(ttnn.graph.is_python_stack_trace_enabled())  # True by default
 ```
+
+Stack traces are imported into the `stack_traces` table in the visualizer database (one row per operation).
+
+### Buffer Page Capture
+
+Capture detailed per-page information for L1 buffers:
+
+```python
+ttnn.graph.enable_detailed_buffer_tracing()
+
+ttnn.graph.begin_graph_capture(ttnn.graph.RunMode.NORMAL)
+# ... your operations ...
+ttnn.graph.end_graph_capture_to_file("report.json")
+
+ttnn.graph.disable_detailed_buffer_tracing()
+```
+
+The report includes `buffer_pages_by_address` (compact, per-address snapshots with versioned timelines for re-allocations) combined with `per_operation_buffers` to reconstruct per-operation page data. Fields per page:
+- `device_id`, `address`: Buffer location
+- `core_x`, `core_y`, `bank_id`: Core and bank placement
+- `page_index`, `page_address`, `page_size`: Page details
+- `buffer_type`: 0=DRAM, 1=L1, 2=SYSTEM_MEMORY, 3=L1_SMALL, 4=TRACE
+
+### Reducing Capture Overhead
+
+By default, examples in this guide capture all available data (slow dispatch, buffer pages, stack traces). To reduce overhead or report size, disable individual features:
+
+| Feature | Disable With | Effect |
+|---|---|---|
+| Per-op captured sub-graphs | Keep `enable_fast_runtime_mode=True` (default) | Uses `FastOperation`; sub-graphs are reconstructed synthetically by the importer |
+| Buffer pages | Don't call `ttnn.graph.enable_detailed_buffer_tracing()` | Skips per-page L1 detail (~5.8M rows for ResNet-50) |
+| Python stack traces | `ttnn.graph.disable_python_stack_traces()` | Omits Python call stacks from `python_io` records |
+
+```python
+# Minimal capture: fast dispatch, no buffer pages, no stack traces
+ttnn.graph.disable_python_stack_traces()
+ttnn.graph.begin_graph_capture(ttnn.graph.RunMode.NORMAL)
+# ... your operations ...
+ttnn.graph.end_graph_capture_to_file("lightweight_report.json")
+ttnn.graph.enable_python_stack_traces()  # Restore default
+```
+
+### Operation Arguments
+
+Python-level arguments are automatically captured by both `FastOperation` and `Operation` decorators when graph capture is active. They are embedded in the `python_io` section of the JSON report and imported into the `operation_arguments` table.
+
+For C++ level arguments:
+
+```python
+graph = ttnn.graph.end_graph_capture()
+
+for node in graph:
+    if node["node_type"] == "function_start" and "arguments" in node:
+        print(f"{node['params']['name']}: {node['arguments']}")
+```
+
+### Debugging Hanging Operations
+
+Set a timeout for operations:
+
+```bash
 export TT_METAL_OPERATION_TIMEOUT_SECONDS=30
 ```
 
-This environment variable will enable a timeout mechanism for operations, the value is the amount of seconds we will wait for the operation to finish.
+Then wrap in try/catch to capture the trace even on timeout:
 
-
-Here is an example of how to use all this:
+```python
+ttnn.graph.begin_graph_capture(ttnn.graph.RunMode.NORMAL)
+try:
+    result = some_operation(tensor)
+    ttnn._ttnn.device.synchronize_device(device)
+except Exception as e:
+    graph = ttnn.graph.end_graph_capture()
+    print(f"Operation hung. Captured trace: {graph}")
+    raise
 ```
-def test_graph_capture_with_hang_device_operation(device):
-    # Create input tensor
-    tt_input = ttnn.empty(
-        shape=(1, 1, 2048, 512),
-        dtype=ttnn.DataType.BFLOAT16,
-        layout=ttnn.TILE_LAYOUT,
-        device=device,
-        memory_config=ttnn.L1_MEMORY_CONFIG,
-    )
 
+---
+
+## Levelized Graph
+
+The `LevelizedGraph` provides a simplified, hierarchical view focused on operation-level data flow. Useful for IR generation and understanding operation composition.
+
+### Basic Usage
+
+```python
+graph = ttnn.graph.end_graph_capture()
+
+# Extract with max_level=1 (top-level operations only)
+levelized = ttnn.graph.extract_levelized_graph(graph)
+
+# Or expand to see internal operations
+levelized = ttnn.graph.extract_levelized_graph(graph, max_level=2)
+
+for vertex in levelized:
+    print(f"{vertex['name']} (level {vertex['stacking_level']})")
+    print(f"  inputs: {vertex['in_edges']}")
+    print(f"  outputs: {vertex['out_edges']}")
+    print(f"  internals: {vertex['internals']}")
+```
+
+### Vertex Structure
+
+Each vertex contains:
+- `counter`: Unique ID
+- `stacking_level`: Nesting depth (1=top-level)
+- `name`: Operation name or `"tensor[id]"` for inputs
+- `in_edges`: IDs of input vertices
+- `out_edges`: IDs of consumers
+- `internals`: IDs of nested operations
+- `output_shape`: Output tensor shapes
+- `arguments`: Serialized arguments
+
+### Example: Level 1 vs Level 2
+
+For `ttnn::add(a, ttnn::multiply(b, c))`:
+
+**Level 1** shows:
+```
+tensor[a] → ttnn::multiply → ttnn::add
+tensor[b] ↗               ↗
+tensor[c] ↗
+```
+
+**Level 2** expands internal operations:
+```
+tensor[a] → ttnn::multiply ──────────→ ttnn::add
+          ↘ ttnn::prim::binary_ng     ↘ ttnn::prim::binary_ng
+```
+
+---
+
+## Testing & Validation
+
+### Test Structure
+
+Graph tracing tests are in `tests/ttnn/unit_tests/base_functionality/test_graph_report.py` and are organized into:
+
+#### Unit Tests (no hardware required)
+
+| Test Class | Description |
+|---|---|
+| `TestImportGraphUnit` | Core import logic: JSON graph → SQLite (operations, tensors, buffers, edges) |
+| `TestInputTensorResolution` | Input tensor deduplication and resolution by address |
+| `TestImportValidation` | Referential integrity validation of imported data |
+| `TestBufferMaxSizePerBank` | Buffer size computation with various layouts and bank counts |
+| `TestLinearModelImport` | Mock linear model import with detailed structural assertions |
+| `TestDurationExtraction` | Extracting operation durations from graph nodes |
+| `TestGraphReportImport` | End-to-end JSON file → SQLite import via `import_report()` |
+| `TestReportVersion` | Version mismatch handling |
+| `TestResNet50Patterns` | Mock ResNet50 patterns (deallocate synthesis, conv2d lifting, buffer snapshots) |
+| `TestSafeArgStr` | Safe argument stringification (avoids triggering graph-tracked ops) |
+| `TestRecordPythonOperation` | Python I/O recording (arguments, tensor IDs, stack traces) |
+| `TestStoreCapturedGraph` | Attaching captured sub-graphs to `_python_io_data` |
+| `TestBeginGraphCaptureClearing` | Python I/O state clearing on capture start |
+| `TestPythonIOArgumentImport` | Python I/O arguments used during import (with C++ fallback) |
+| `TestPerOpCapturedGraphImport` | Per-operation captured graph import (with fallback extraction) |
+| `TestFromTorchFiltering` | Leading `from_torch` ops filtered, post-compute ones kept |
+| `TestFilteredOpPrefixes` | All filtered C++ wrapper operation prefixes excluded |
+| `TestPythonIONameMatching` | Multi-op same-name matching and unmatched record handling |
+| `TestCapturedGraphFallbackExtraction` | Synthetic sub-graph extraction with counter remapping |
+| `TestVersionedBufferPages` | Buffer page timeline with re-allocation snapshots |
+| `TestPyIdToCppTensorReconciliation` | Python-assigned tensor IDs reconciled with C++ tensor nodes |
+| `TestPythonStackTraceImport` | Python stack traces stored alone, merged with C++, or absent |
+
+#### Device Tests (require hardware)
+
+| Test Class / Function | Hardware | Description |
+|---|---|---|
+| `TestGraphCaptureToFile` | Any device | Real capture API (file output, device info, stack traces) |
+| `TestStackTraces` | Any device | Stack trace enable/disable and capture verification |
+| `TestFastOperationGraphTracking` | Any device | FastOperation records function names, tensor IDs, and connectivity |
+| `TestLinearModelE2E` | Wormhole B0 | Structural validation: linear model (ones + linear) |
+| `test_resnet50_e2e_graph_capture` | Wormhole B0 | Full ResNet50 E2E graph capture and structural validation |
+
+### Generating a Database for ttnn-visualizer
+
+To generate a complete database with all data for the ttnn-visualizer:
+
+```python
+import ttnn
+from ttnn import graph_report
+
+device = ttnn.open_device(device_id=0, l1_small_size=24576)
+
+# Full capture: slow dispatch for per-op sub-graphs, buffer pages, python stacks
+with ttnn.manage_config("enable_fast_runtime_mode", False):
+    ttnn.graph.enable_detailed_buffer_tracing()
     ttnn.graph.begin_graph_capture(ttnn.graph.RunMode.NORMAL)
+    # ... run your model ...
+    ttnn.graph.end_graph_capture_to_file("my_report.json")
+    ttnn.graph.disable_detailed_buffer_tracing()
 
-    try:
-        ttnn.test_hang_device_operation(tt_input)
-        # this allows the device to throw the exception inside the try block
-        ttnn._ttnn.device.synchronize_device(device)
-    except Exception as e:
-        print("Exception captured")
-        captured_graph = ttnn.graph.end_graph_capture()
-        print(captured_graph)
-        assert "TIMEOUT" in str(e)
+# Import to SQLite (creates db.sqlite, cluster_descriptor.yaml, etc.)
+graph_report.import_report("my_report.json", "./my_visualizer_db/")
+
+ttnn.close_device(device)
 ```
 
+For a lighter-weight capture (faster, smaller reports), see [Reducing Capture Overhead](#reducing-capture-overhead).
 
-In this case, we are using a ttnn.test.test_hang_operation, which is a test operation that runs a while(true) loop.
-The idea behind it is to simulate an unresponsive operation, so we can test the graph capture and the arguments that generated the hang.
-Please never use this operation in production code, it is only for testing purposes.
+### What the E2E Tests Validate
 
-### What is next for this tool?
-- Supporting more operations
-- Bringing more tooling to the output
+The golden comparison test performs structural checks across every table:
 
+| Table | Compared Properties |
+|---|---|
+| `operations` | `operation_id`, `name` |
+| `tensors` | `shape`, `dtype`, `layout`, `memory_config`, `address`, `buffer_type`, `size` |
+| `input_tensors` | `operation_id`, `input_index`, resolved tensor `address` |
+| `output_tensors` | `operation_id`, `output_index`, resolved tensor `address` |
+| `device_tensors` | `address` |
+| `buffers` | `operation_id`, `address`, `max_size_per_bank`, `buffer_type`, `buffer_layout` |
+| `captured_graph` | `operation_id` |
+| `stack_traces` | `operation_id` |
+| `buffer_pages` | `address`, `core_y`, `core_x`, `bank_id`, `page_index`, `page_address`, `page_size`, `buffer_type` |
 
-## Python
-Tracing is available through Python too
-https://github.com/tenstorrent/tt-metal/blob/4ae4ac3c30cd24ea27cbac8cc5811c90d077e9c0/tests/ttnn/unit_tests/test_graph_capture.py#L21-L25
+Plus structural integrity checks:
+- **No dangling references**: every `tensor_id` in input/output tables exists in `tensors`
+- **No orphaned host tensors**: host tensors must be referenced by at least one I/O
+- **No backwards edges**: an output of operation N must not be consumed by an earlier operation M (M < N)
 
-Here is a sample code to print a table from the beginning of this document
+---
 
-```py
-def process_allocations(graph):
-   df = pd.DataFrame(columns=['current_op', 'event', 'total_cb', 'total_buffer', 'info'])
+## Reference: Node Types
 
-   cur_op = []
-   total_cb = 0
-   total_buffer = 0
-   tensors = set()
-   i = 1 # lets skip initial node
-   while i < len(graph):
-       params = ''
-       v = graph[i]
-       params = v.params
-       print(v, len(df))
-       i += 1
-       if v.node_type == 'function_start':
-           if len(cur_op) == 0:
-               #entring first op, lets get all input tensors
-               while i < len(graph):
-                   print(graph[i], len(df))
-                   if graph[i].node_type == 'buffer':
-                       total_buffer += int(graph[i].params['size'])
-                       i += 1
-                   elif graph[i].node_type == 'tensor':
-                       i += 1
-                   else:
-                       break
-          name = v.params['name']
-          cur_op.append(name)
-       if v.node_type == 'circular_buffer_allocate':
-           total_cb += int(v.params['size'])
-       if v.node_type == 'circular_buffer_deallocate_all':
-           total_cb = 0
-       if v.node_type == 'buffer_allocate':
-           total_buffer += int(v.params['size'])
-       if v.node_type == 'function_end':
-           cur_op.pop()
-           #continue
-       if v.node_type == 'tensor':
-           continue
-       if v.node_type == 'buffer_deallocate':
-           total_buffer -= int(graph[v.connections[0]].params['size'])
-       if v.node_type == 'buffer':
-           continue
-       if len(cur_op) > 0:
-           data =  {'current_op': cur_op[-1], 'event' : v.node_type, 'total_cb': total_cb, 'total_buffer': total_buffer, 'info' : params}
-           df.loc[len(df)] = data
-   return df
-```
+The trace is a directed graph where each node has:
+- `counter`: Unique node ID
+- `node_type`: Type (see below)
+- `params`: Key-value parameters
+- `connections`: IDs of connected nodes
 
-## Sample Trace
+### capture_start / capture_end
 
-This is a sample trace of running `ttnn::add(Shape\[1, 1, 32, 32\], Shape\[4, 1, 32, 32\])`.
-This setup requires to broadcast the first tensor, so trace contains a call to ttnn::repeat.
-High level call stack here is:
+Markers for trace boundaries. `capture_end` includes `duration_ns` for total capture time.
+
+### function_start / function_end
+
+Operation boundaries.
+
+**function_start params:**
+- `name`: Operation name (e.g., `"ttnn::add"`)
+- `inputs`: Number of input parameters
+
+**function_start fields:**
+- `arguments`: Serialized operation arguments
+
+**function_end params:**
+- `name`: Operation name
+- `duration_ns`: Wall-clock duration (optional)
+
+### tensor
+
+Tensor metadata.
+
+**params:**
+- `tensor_id`: Unique tensor ID
+- `shape`: Tensor shape
+- `dtype`: Data type (`"bfloat16"`, `"float32"`, etc.)
+- `layout`: Memory layout (`"TILE"`, `"ROW_MAJOR"`)
+- `size`: Data size in bytes (logical volume * element size)
+
+**Device tensor params (when on device):**
+- `memory_config`: Memory configuration string
+- `device_id`: Device ID
+- `address`: Memory address
+- `buffer_type`: Buffer type (`"DRAM"`, `"L1"`, `"L1_SMALL"`)
+- `device_tensors`: Array of per-device addresses (multi-device)
+
+### buffer
+
+Buffer metadata.
+
+**params:**
+- `size`: Size in bytes
+- `type`: Memory type (`"DRAM"`, `"L1"`)
+- `layout`: Memory layout
+- `device_id`: Device ID
+
+### buffer_allocate / buffer_deallocate
+
+Memory allocation/deallocation events.
+
+**buffer_allocate params:**
+- `size`, `address`, `type`, `layout`, `device_id`
+- `exact_buffer_type`: Precise C++ buffer type enum (`"DRAM"`, `"L1"`, `"L1_SMALL"`, `"TRACE"`)
+- `max_size_per_bank`: Pre-computed per-bank buffer size (from C++ allocator)
+
+### circular_buffer_allocate / circular_buffer_deallocate_all
+
+Circular buffer events for streaming/multi-buffering.
+
+**circular_buffer_allocate params:**
+- `size`, `address`, `core_range_set`, `globally_allocated`, `device_id`
+
+### error
+
+The C++ graph processor does not emit error nodes directly. Instead, the Python importer detects **orphan operations** — `function_start` nodes without a matching `function_end` — and records them as `incomplete_operation` errors. Legacy JSON files with explicit error nodes are also supported.
+
+**Database `errors` table columns:**
+- `operation_id`: The operation where the error was detected
+- `operation_name`: Name of the operation
+- `error_type`: `"incomplete_operation"` (inferred) or explicit type from JSON
+- `error_message`: Human-readable description
+- `stack_trace`: Empty (reserved for future use)
+- `timestamp`: Empty (reserved for future use)
+
+---
+
+## Reference: Sample Trace
+
+Below is a trace of `ttnn::add(Shape[1,1,32,32], Shape[4,1,32,32])` which requires broadcasting via `ttnn::repeat`.
+
+### Call Hierarchy
 
 ```
 ttnn::add
-ttnn::repeat
-ttnn::prim::repeat (calling ttnn primitive operation)
-Device Operation (dispatching device operation)
-create_device_tensor (creates intermediate output for ttnn::repeat)
-ttnn::prim::binary (calling ttnn primitive operation)
-Device Operation (dispatching device operation)
-create_device_tensor (creates final output)
+├── ttnn::repeat
+│   ├── ttnn::prim::repeat
+│   │   └── Device Operation
+│   │       └── create_device_tensor
+├── ttnn::prim::binary
+│   └── Device Operation
+│       └── create_device_tensor
 ```
 
-And you can see when each Buffer and CB is allocated / deallocated.
-
-### PrettyPrint
+### Pretty Print
 
 ```
 Capture Start
-Begin: tt::tt_metal::detail::convert_python_tensor_to_tt_tensor
-End:   tt::tt_metal::detail::convert_python_tensor_to_tt_tensor
-Add Tensor: 0
-Begin: ttnn::to_layout
-    Begin: Tensor::reshape
-    End:   Tensor::reshape
-    Add Tensor: 1
-    Begin: Tensor::pad
-    End:   Tensor::pad
-    Add Tensor: 2
-    Begin: Tensor::to
-    End:   Tensor::to
-    Add Tensor: 3
-End:   ttnn::to_layout
-Begin: Tensor::to
-    Add Device Buffer
-    Allocate Device Buffer
-End:   Tensor::to
-Add Tensor: 4
 Begin: ttnn::add
-    Begin: Tensor::to
-        Add Tensor: -1
-        Add Device Buffer
-        Allocate Device Buffer
-    End:   Tensor::to
-    Add Tensor: 5
+    Begin: ttnn::repeat
+        Begin: ttnn::prim::repeat
+            Begin: Device Operation
+                Begin: create_device_tensor
+                    Add Device Buffer
+                    Allocate Device Buffer
+                End: create_device_tensor
+                Add Tensor: 2
+                Allocate Circular Buffer
+            End: Device Operation
+        End: ttnn::prim::repeat
+    End: ttnn::repeat
     Begin: ttnn::prim::binary
-        Begin: BinaryDeviceOperation
-            Begin: tt::tt_metal::create_device_tensor
+        Begin: Device Operation
+            Begin: create_device_tensor
                 Add Device Buffer
                 Allocate Device Buffer
-            End:   tt::tt_metal::create_device_tensor
-            Add Tensor: 6
-            Add Tensor: 6
-            Add Device Buffer
-            Allocate Device Buffer
-            Allocate Device Buffer
-            Allocate Device Buffer
-            Allocate Device Buffer
-            Deallocate Device Buffer
-        End:   BinaryDeviceOperation
-        Add Tensor: 7
-    End:   ttnn::prim::binary
+            End: create_device_tensor
+            Add Tensor: 3
+            Allocate Circular Buffer (x3)
+        End: Device Operation
+    End: ttnn::prim::binary
     Deallocate Device Buffer
-End:   ttnn::add
-Begin: Tensor::cpu
-End:   Tensor::cpu
-Add Tensor: 8
-Begin: Tensor::to
-End:   Tensor::to
-Add Tensor: 9
-Begin: tt::tt_metal::detail::convert_tt_tensor_to_torch_tensor
-End:   tt::tt_metal::detail::convert_tt_tensor_to_torch_tensor
+End: ttnn::add
 Deallocate Device Buffer
-Deallocate Device Buffer
+Capture End
 ```
 
-### Visualizer
+### Visualizer View
 
 ![visualizer](https://github.com/user-attachments/assets/03df00c6-4902-416d-a26a-6ffe874537a5)
 
+<details>
+<summary><b>Full JSON Trace (click to expand)</b></summary>
 
-## Raw JSON
-```
+```json
 [
     {
-        "connections": [
-            1,
-            32
-        ],
+        "connections": [1, 32],
         "counter": 0,
         "node_type": "capture_start",
         "params": {}
     },
     {
-        "connections": [
-            3,
-            5,
-            6,
-            18,
-            30,
-            31
-        ],
+        "connections": [3, 5, 6, 18, 30, 31],
         "counter": 1,
         "node_type": "function_start",
-        "params": {
-            "inputs": "2",
-            "name": "ttnn::add"
-        }
+        "params": {"inputs": "2", "name": "ttnn::add"}
     },
     {
-        "connections": [
-            1,
-            18
-        ],
+        "connections": [1, 18],
         "counter": 2,
         "node_type": "tensor",
-        "params": {
-            "shape": "ttnn.Shape([4, 3, 32, 32])"
-        }
+        "params": {"shape": "ttnn.Shape([4, 3, 32, 32])"}
     },
     {
-        "connections": [
-            2,
-            2
-        ],
+        "connections": [2, 2],
         "counter": 3,
-        "name": "buffer",
-        "params": {
-            "layout": "INTERLEAVED",
-            "size": "24576",
-            "type": "L1"
-        }
+        "node_type": "buffer",
+        "params": {"layout": "INTERLEAVED", "size": "24576", "type": "L1"}
     },
     {
-        "connections": [
-            1,
-            6
-        ],
+        "connections": [1, 6],
         "counter": 4,
-        "name": "tensor[1]",
-        "params": {
-            "shape": "ttnn.Shape([1, 3, 32, 32])"
-        }
+        "node_type": "tensor",
+        "params": {"shape": "ttnn.Shape([1, 3, 32, 32])"}
     },
     {
-        "connections": [
-            4,
-            4
-        ],
+        "connections": [4, 4],
         "counter": 5,
-        "name": "buffer",
-        "params": {
-            "layout": "INTERLEAVED",
-            "size": "6144",
-            "type": "L1"
-        }
+        "node_type": "buffer",
+        "params": {"layout": "INTERLEAVED", "size": "6144", "type": "L1"}
     },
     {
-        "connections": [
-            7,
-            17
-        ],
+        "connections": [7, 17],
         "counter": 6,
-        "name": "function_start",
-        "params": {
-            "inputs": "2",
-            "name": "ttnn::repeat"
-        }
+        "node_type": "function_start",
+        "params": {"inputs": "2", "name": "ttnn::repeat"}
     },
     {
-        "connections": [
-            8,
-            16
-        ],
+        "connections": [8, 16],
         "counter": 7,
-        "name": "function_start",
-        "params": {
-            "inputs": "5",
-            "name": "ttnn::prim::repeat"
-        }
+        "node_type": "function_start",
+        "params": {"inputs": "5", "name": "ttnn::prim::repeat"}
     },
     {
-        "connections": [
-            9,
-            14,
-            15
-        ],
+        "connections": [9, 14, 15],
         "counter": 8,
-        "name": "function_start",
-        "params": {
-            "inputs": "2",
-            "name": "Device Operation"
-        }
+        "node_type": "function_start",
+        "params": {"inputs": "2", "name": "Device Operation"}
     },
     {
-        "connections": [
-            10,
-            11,
-            12
-        ],
+        "connections": [10, 11, 12],
         "counter": 9,
-        "name": "function_start",
-        "params": {
-            "inputs": "5",
-            "name": "create_device_tensor"
-        }
+        "node_type": "function_start",
+        "params": {"inputs": "5", "name": "create_device_tensor"}
     },
     {
-        "connections": [
-            13,
-            13,
-            13,
-            13,
-            13
-        ],
+        "connections": [13, 13, 13, 13, 13],
         "counter": 10,
-        "name": "buffer",
-        "params": {
-            "layout": "INTERLEAVED",
-            "size": "24576",
-            "type": "L1"
-        }
+        "node_type": "buffer",
+        "params": {"layout": "INTERLEAVED", "size": "24576", "type": "L1"}
     },
     {
-        "connections": [
-            10
-        ],
+        "connections": [10],
         "counter": 11,
-        "name": "buffer_allocate",
-        "params": {
-            "address": "1953396066",
-            "layout": "INTERLEAVED",
-            "size": "24576",
-            "type": "L1"
-        }
+        "node_type": "buffer_allocate",
+        "params": {"address": "1953396066", "layout": "INTERLEAVED", "size": "24576", "type": "L1"}
     },
     {
-        "connections": [
-            13
-        ],
+        "connections": [13],
         "counter": 12,
-        "name": "function_end",
-        "params": {
-            "name": "create_device_tensor"
-        }
+        "node_type": "function_end",
+        "params": {"name": "create_device_tensor"}
     },
     {
-        "connections": [
-            18
-        ],
+        "connections": [18],
         "counter": 13,
-        "name": "tensor[2]",
-        "params": {
-            "shape": "ttnn.Shape([4, 3, 32, 32])"
-        }
+        "node_type": "tensor",
+        "params": {"shape": "ttnn.Shape([4, 3, 32, 32])"}
     },
     {
         "connections": [],
         "counter": 14,
-        "name": "circular_buffer_allocate",
-        "params": {
-            "address": "0",
-            "core_range_set": "{[(x=0,y=0) - (x=0,y=7)], [(x=1,y=0) - (x=1,y=3)]}",
-            "size": "4096",
-            "globally_allocated": "false"
-        }
+        "node_type": "circular_buffer_allocate",
+        "params": {"address": "0", "core_range_set": "{[(x=0,y=0) - (x=0,y=7)], [(x=1,y=0) - (x=1,y=3)]}", "size": "4096", "globally_allocated": "false"}
     },
     {
-        "connections": [
-            13
-        ],
+        "connections": [13],
         "counter": 15,
-        "name": "function_end",
-        "params": {
-            "name": "Device Operation"
-        }
+        "node_type": "function_end",
+        "params": {"name": "Device Operation"}
     },
     {
-        "connections": [
-            13
-        ],
+        "connections": [13],
         "counter": 16,
-        "name": "function_end",
-        "params": {
-            "name": "ttnn::prim::repeat"
-        }
+        "node_type": "function_end",
+        "params": {"name": "ttnn::prim::repeat"}
     },
     {
-        "connections": [
-            13,
-            18
-        ],
+        "connections": [13, 18],
         "counter": 17,
-        "name": "function_end",
-        "params": {
-            "name": "ttnn::repeat"
-        }
+        "node_type": "function_end",
+        "params": {"name": "ttnn::repeat"}
     },
     {
-        "connections": [
-            19,
-            29
-        ],
+        "connections": [19, 29],
         "counter": 18,
-        "name": "function_start",
-        "params": {
-            "inputs": "10",
-            "name": "ttnn::prim::binary"
-        }
+        "node_type": "function_start",
+        "params": {"inputs": "10", "name": "ttnn::prim::binary"}
     },
     {
-        "connections": [
-            20,
-            25,
-            26,
-            27,
-            28
-        ],
+        "connections": [20, 25, 26, 27, 28],
         "counter": 19,
-        "name": "function_start",
-        "params": {
-            "inputs": "2",
-            "name": "Device Operation"
-        }
+        "node_type": "function_start",
+        "params": {"inputs": "2", "name": "Device Operation"}
     },
     {
-        "connections": [
-            21,
-            22,
-            23
-        ],
+        "connections": [21, 22, 23],
         "counter": 20,
-        "name": "function_start",
-        "params": {
-            "inputs": "5",
-            "name": "create_device_tensor"
-        }
+        "node_type": "function_start",
+        "params": {"inputs": "5", "name": "create_device_tensor"}
     },
     {
-        "connections": [
-            24,
-            24,
-            24,
-            24
-        ],
+        "connections": [24, 24, 24, 24],
         "counter": 21,
-        "name": "buffer",
-        "params": {
-            "layout": "INTERLEAVED",
-            "size": "24576",
-            "type": "L1"
-        }
+        "node_type": "buffer",
+        "params": {"layout": "INTERLEAVED", "size": "24576", "type": "L1"}
     },
     {
-        "connections": [
-            21
-        ],
+        "connections": [21],
         "counter": 22,
-        "name": "buffer_allocate",
-        "params": {
-            "address": "0",
-            "layout": "INTERLEAVED",
-            "size": "24576",
-            "type": "L1"
-        }
+        "node_type": "buffer_allocate",
+        "params": {"address": "0", "layout": "INTERLEAVED", "size": "24576", "type": "L1"}
     },
     {
-        "connections": [
-            24
-        ],
+        "connections": [24],
         "counter": 23,
-        "name": "function_end",
-        "params": {
-            "name": "create_device_tensor"
-        }
+        "node_type": "function_end",
+        "params": {"name": "create_device_tensor"}
     },
     {
         "connections": [],
         "counter": 24,
-        "name": "tensor[3]",
-        "params": {
-            "shape": "ttnn.Shape([4, 3, 32, 32])"
-        }
+        "node_type": "tensor",
+        "params": {"shape": "ttnn.Shape([4, 3, 32, 32])"}
     },
     {
         "connections": [],
         "counter": 25,
-        "name": "circular_buffer_allocate",
-        "params": {
-            "address": "0",
-            "core_range_set": "{[(x=0,y=0) - (x=7,y=7)]}",
-            "size": "4096",
-            "globally_allocated": "false"
-        }
+        "node_type": "circular_buffer_allocate",
+        "params": {"address": "0", "core_range_set": "{[(x=0,y=0) - (x=7,y=7)]}", "size": "4096", "globally_allocated": "false"}
     },
     {
         "connections": [],
         "counter": 26,
-        "name": "circular_buffer_allocate",
-        "params": {
-            "address": "0",
-            "core_range_set": "{[(x=0,y=0) - (x=7,y=7)]}",
-            "size": "4096",
-            "globally_allocated": "false"
-        }
+        "node_type": "circular_buffer_allocate",
+        "params": {"address": "0", "core_range_set": "{[(x=0,y=0) - (x=7,y=7)]}", "size": "4096", "globally_allocated": "false"}
     },
     {
         "connections": [],
         "counter": 27,
-        "name": "circular_buffer_allocate",
-        "params": {
-            "address": "0",
-            "core_range_set": "{[(x=0,y=0) - (x=7,y=7)]}",
-            "size": "4096",
-            "globally_allocated": "false"
-        }
+        "node_type": "circular_buffer_allocate",
+        "params": {"address": "0", "core_range_set": "{[(x=0,y=0) - (x=7,y=7)]}", "size": "4096", "globally_allocated": "false"}
     },
     {
-        "connections": [
-            24
-        ],
+        "connections": [24],
         "counter": 28,
-        "name": "function_end",
-        "params": {
-            "name": "Device Operation"
-        }
+        "node_type": "function_end",
+        "params": {"name": "Device Operation"}
     },
     {
-        "connections": [
-            24
-        ],
+        "connections": [24],
         "counter": 29,
-        "name": "function_end",
-        "params": {
-            "name": "ttnn::prim::binary"
-        }
+        "node_type": "function_end",
+        "params": {"name": "ttnn::prim::binary"}
     },
     {
-        "connections": [
-            10
-        ],
+        "connections": [10],
         "counter": 30,
-        "name": "buffer_deallocate",
-        "params": {
-            "layout": "INTERLEAVED",
-            "size": "0",
-            "type": "L1"
-        }
+        "node_type": "buffer_deallocate",
+        "params": {"layout": "INTERLEAVED", "size": "0", "type": "L1"}
     },
     {
-        "connections": [
-            24,
-            33
-        ],
+        "connections": [24, 33],
         "counter": 31,
-        "name": "function_end",
-        "params": {
-            "name": "ttnn::add"
-        }
+        "node_type": "function_end",
+        "params": {"name": "ttnn::add"}
     },
     {
-        "connections": [
-            21
-        ],
+        "connections": [21],
         "counter": 32,
-        "name": "buffer_deallocate",
-        "params": {
-            "layout": "INTERLEAVED",
-            "size": "0",
-            "type": "L1"
-        }
+        "node_type": "buffer_deallocate",
+        "params": {"layout": "INTERLEAVED", "size": "0", "type": "L1"}
     },
     {
         "connections": [],
         "counter": 33,
-        "name": "capture_end",
+        "node_type": "capture_end",
         "params": {}
     }
 ]
 ```
 
-## Levelized Graph
-
-While the standard graph trace provides comprehensive information about operations, memory allocations, and execution flow, it can be overwhelming when you only need a simplified view focused on operation-level data flow. The `LevelizedGraph` provides a hierarchical, simplified representation of the graph trace that is particularly useful for generating IR from `ttnn` call traces.
-
-### What is LevelizedGraph?
-
-A `LevelizedGraph` is a simplified, hierarchical representation of traced operations extracted from a graph trace. Unlike the full graph trace which includes all node types (buffer allocations, circular buffers, etc.), a `LevelizedGraph` focuses on operation nodes (`function_start` nodes) and input tensor nodes (tensor nodes at stacking_level 1), organizing them hierarchically based on their stacking level.
-
-#### Key Differences from Standard Graph Trace
-
-1. **Simplified Node Set**: Stores `function_start` nodes (operations) at or below the specified max_level, and tensor nodes at stacking_level 1 (input tensors). Other node types like `buffer`, `buffer_allocate`, `circular_buffer_allocate`, intermediate tensor nodes, etc. are not stored directly, though their information is used to populate vertex metadata.
-
-2. **Bidirectional Edges**: Each vertex stores both `in_edges` (incoming) and `out_edges` (outgoing), representing data flow between operations. This enables constant-time lookup of input tensors for any operation.
-
-3. **Hierarchical Structure**: Vertices are organized by `stacking_level`, which represents the depth of nesting. For example, `ttnn::add` at level 1 may have `ttnn::prim::binary_ng` as an internal operation at level 2.
-
-4. **Internals Tracking**: Each vertex stores its `internals` - a list of vertex IDs representing operations that are called within it at the next stacking level. For instance, a `ttnn::multiply` vertex will have `ttnn::prim::binary_ng` in its `internals` list when extracted with `max_level >= 2`.
-
-5. **Output Information**: Each vertex stores `output_shape` (the shape of tensors produced) and `output_info` (layout and memory configuration information) when available.
-
-6. **Data Flow Focus**: Edges represent pure data flow between nodes. This includes edges from tensor vertices to operations (for input tensors) and edges from operations to operations (for intermediate results), not parent-child relationships or memory management events.
-
-### Vertex Structure
-
-Each vertex in a `LevelizedGraph` contains:
-
-* `counter` (or `id`): Unique identifier within the levelized graph
-* `stacking_level`: The depth level of this vertex (1 = top-level, 2 = nested, etc.). Tensor vertices are always at level 1.
-* `name`: The operation name (e.g., `"ttnn::add"`, `"ttnn::prim::binary_ng"`) or tensor identifier (e.g., `"tensor[3]"`)
-* `arguments`: Array of serialized arguments passed to the operation (empty for tensor vertices)
-* `in_edges`: Array of vertex IDs representing vertices that produce inputs to this vertex. Empty for input tensor vertices (tensors created outside the capture).
-* `out_edges`: Array of vertex IDs representing vertices that consume outputs from this vertex
-* `internals`: Array of vertex IDs representing operations called within this operation (at `stacking_level + 1`). Always empty for tensor vertices.
-* `output_info`: Array of strings containing layout and memory configuration information (when available).
-* `output_shape`: Array of strings representing the shapes. For operations, these are output shapes; for tensors, this is the tensor's shape.
-
-### Tensor Vertices
-
-Input tensors (tensors created outside the graph capture) are now explicitly represented as vertices in the levelized graph. These tensor vertices have the following characteristics:
-
-* **Name**: Format is `"tensor[<tensor_id>]"` where `tensor_id` is from the original trace
-* **Stacking Level**: Always 1
-* **In Edges**: Always empty (no producers within the captured graph)
-* **Out Edges**: Contains IDs of operations that consume this tensor
-* **Internals**: Always empty (tensors don't have internal operations)
-* **Arguments**: Always empty
-* **Output Shape**: Contains the shape of the tensor
-* **Output Info**: Contains the memory layout and sharding specs of the tensor
-
-**Identifying Tensor Vertices**: You can identify tensor vertices by checking if the name contains "tensor" or by checking if `in_edges` is empty at stacking_level 1.
-
-**Use Case Example**: When generating IR from a levelized graph, tensor vertices represent the function parameters or inputs to your computation graph.
-
-### How to Use
-
-#### In C++
-
-```cpp
-#include "ttnn/graph/graph_processor.hpp"
-#include "ttnn/graph/levelized_graph.hpp"
-
-// Capture a graph trace first
-auto capture = ttnn::graph::ScopedGraphCapture(IGraphProcessor::RunMode::NO_DISPATCH);
-// ... your ttnn operations ...
-auto trace = capture.end_graph_capture();
-
-// Extract levelized graph with max_level = 1 (default)
-ttnn::graph::LevelizedGraph levelized_graph(trace, 1);
-
-// Or extract as JSON directly
-auto levelized_json = ttnn::graph::extract_levelized_graph(trace, 1);
-
-// Access vertices
-for (const auto& vertex : levelized_graph.vertices()) {
-    std::cout << "Operation: " << vertex.name
-              << ", Level: " << vertex.stacking_level
-              << ", Inputs: " << vertex.in_edges.size()
-              << ", Outputs: " << vertex.out_edges.size() << std::endl;
-}
-```
-
-#### In Python
-
-```python
-import ttnn
-
-# Begin graph capture
-ttnn.graph.begin_graph_capture(ttnn.graph.RunMode.NO_DISPATCH)
-# ... your ttnn operations ...
-captured_graph = ttnn.graph.end_graph_capture()
-
-# Extract levelized graph with default max_level = 1
-levelized_graph = ttnn.graph.extract_levelized_graph(captured_graph)
-
-# Or with explicit max_level
-levelized_graph_level_2 = ttnn.graph.extract_levelized_graph(captured_graph, max_level=2)
-
-# The result is a list of dictionaries, each representing a vertex
-for vertex in levelized_graph:
-    print(f"Vertex: {vertex['name']}, Level: {vertex['stacking_level']}")
-    print(f"  Inputs: {vertex['in_edges']}")
-    print(f"  Outputs: {vertex['out_edges']}")
-    print(f"  Internals: {vertex['internals']}")
-
-    # Check if this is a tensor vertex (input tensor)
-    if 'tensor[' in vertex['name'] and not vertex['in_edges']:
-        print(f"  -> This is an input tensor with shape: {vertex['output_shape']}")
-```
-
-### Example: Multiply-Add Operation
-
-Consider the following operation sequence where input tensors are created **outside** the capture (simulating runtime inputs):
-
-```cpp
-// Create input tensors outside the capture
-const auto input_a = ttnn::TensorSpec(ttnn::Shape(tt::tt_metal::Array2D{32, 64}), ...);
-const auto input_tensor_a = tt::tt_metal::create_device_tensor(input_a, device);
-const auto input_b = ttnn::TensorSpec(ttnn::Shape(tt::tt_metal::Array2D{32, 64}), ...);
-const auto input_tensor_b = tt::tt_metal::create_device_tensor(input_b, device);
-const auto input_c = ttnn::TensorSpec(ttnn::Shape(tt::tt_metal::Array2D{32, 64}), ...);
-const auto input_tensor_c = tt::tt_metal::create_device_tensor(input_c, device);
-
-// Capture the operations
-auto capture = ttnn::graph::ScopedGraphCapture(IGraphProcessor::RunMode::NO_DISPATCH);
-const auto output_tensor = ttnn::multiply(input_tensor_b, input_tensor_c, std::nullopt, std::nullopt);
-const auto output_tensor_1 = ttnn::add(input_tensor_a, output_tensor, std::nullopt, std::nullopt);
-auto trace = capture.end_graph_capture();
-```
-
-#### Levelized Graph with max_level = 1
-
-With `max_level = 1`, the levelized graph shows top-level operations and input tensors (tensors at stacking_level 1):
-
-```json
-[
-    {
-        "counter": 0,
-        "stacking_level": 1,
-        "name": "tensor[129]",
-        "arguments": [],
-        "in_edges": [],
-        "out_edges": [4],
-        "internals": [],
-        "output_info": ["Tensor(...)"],
-        "output_shape": ["Shape([32, 64])"]
-    },
-    {
-        "counter": 1,
-        "stacking_level": 1,
-        "name": "tensor[130]",
-        "arguments": [],
-        "in_edges": [],
-        "out_edges": [3],
-        "internals": [],
-        "output_info": ["Tensor(...)"],
-        "output_shape": ["Shape([32, 64])"]
-    },
-    {
-        "counter": 2,
-        "stacking_level": 1,
-        "name": "tensor[128]",
-        "arguments": [],
-        "in_edges": [],
-        "out_edges": [3],
-        "internals": [],
-        "output_info": ["Tensor(...)"],
-        "output_shape": ["Shape([32, 64])"]
-    },
-    {
-        "counter": 3,
-        "stacking_level": 1,
-        "name": "ttnn::multiply",
-        "arguments": ["Tensor(...)", "Tensor(...)", ...],
-        "in_edges": [1, 2],
-        "out_edges": [4],
-        "internals": [],
-        "output_info": ["Tensor(...)"],
-        "output_shape": ["Shape([32, 64])"]
-    },
-    {
-        "counter": 4,
-        "stacking_level": 1,
-        "name": "ttnn::add",
-        "arguments": ["Tensor(...)", "Tensor(...)", ...],
-        "in_edges": [0, 3],
-        "out_edges": [],
-        "internals": [],
-        "output_info": [],
-        "output_shape": ["Shape([32, 64])"]
-    }
-]
-```
-
-At level 1, you see:
-- Three input tensor vertices (`tensor[128]`, `tensor[129]`, `tensor[130]`) representing tensors created outside the capture
-- One `ttnn::multiply` operation consuming inputs from tensor vertices 1 and 2
-- One `ttnn::add` operation consuming inputs from tensor vertex 0 and the multiply operation (vertex 3)
-
-The `internals` arrays are empty because nested operations are not included at this level. Note that tensor vertices have empty `in_edges` (no producers within the captured graph) and their names include the tensor_id from the trace.
-
-You can think of this graph at level 1 like this (showing tensor nodes as inputs):
-
-![muladd1](images/muladd_level1.png)
-
-Note: The diagram shows the conceptual flow. In the actual implementation, tensor vertices are explicitly included with names like `tensor[128]`, `tensor[129]`, etc.
-
-#### Levelized Graph with max_level = 2
-
-With `max_level = 2`, the levelized graph expands to show internal operations:
-
-```json
-[
-    {
-        "counter": 0,
-        "stacking_level": 1,
-        "name": "tensor[129]",
-        "arguments": [],
-        "in_edges": [],
-        "out_edges": [5, 6],
-        "internals": [],
-        "output_info": ["Tensor(...)"],
-        "output_shape": ["Shape([32, 64])"]
-    },
-    {
-        "counter": 1,
-        "stacking_level": 1,
-        "name": "tensor[130]",
-        "arguments": [],
-        "in_edges": [],
-        "out_edges": [3, 4],
-        "internals": [],
-        "output_info": ["Tensor(...)"],
-        "output_shape": ["Shape([32, 64])"]
-    },
-    {
-        "counter": 2,
-        "stacking_level": 1,
-        "name": "tensor[128]",
-        "arguments": [],
-        "in_edges": [],
-        "out_edges": [3, 4],
-        "internals": [],
-        "output_info": ["Tensor(...)"],
-        "output_shape": ["Shape([32, 64])"]
-    },
-    {
-        "counter": 3,
-        "stacking_level": 1,
-        "name": "ttnn::multiply",
-        "arguments": ["Tensor(...)", "Tensor(...)", ...],
-        "in_edges": [1, 2],
-        "out_edges": [5, 6],
-        "internals": [4],
-        "output_info": ["Tensor(...)"],
-        "output_shape": ["Shape([32, 64])"]
-    },
-    {
-        "counter": 4,
-        "stacking_level": 2,
-        "name": "ttnn::prim::binary_ng",
-        "arguments": ["Tensor(...)", "Tensor(...)", "BinaryOpType::MUL", ...],
-        "in_edges": [1, 2],
-        "out_edges": [],
-        "internals": [],
-        "output_info": [],
-        "output_shape": ["Shape([32, 64])"]
-    },
-    {
-        "counter": 5,
-        "stacking_level": 1,
-        "name": "ttnn::add",
-        "arguments": ["Tensor(...)", "Tensor(...)", ...],
-        "in_edges": [0, 3],
-        "out_edges": [],
-        "internals": [6],
-        "output_info": [],
-        "output_shape": ["Shape([32, 64])"]
-    },
-    {
-        "counter": 6,
-        "stacking_level": 2,
-        "name": "ttnn::prim::binary_ng",
-        "arguments": ["Tensor(...)", "Tensor(...)", "BinaryOpType::ADD", ...],
-        "in_edges": [0, 3],
-        "out_edges": [],
-        "internals": [],
-        "output_info": [],
-        "output_shape": ["Shape([32, 64])"]
-    }
-]
-```
-
-At level 2, you can see:
-- Three input tensor vertices (0, 1, 2) at stacking_level 1 representing tensors created outside the capture
-- Vertex 3 (`ttnn::multiply`) now has `internals: [4]`, indicating it internally calls `ttnn::prim::binary_ng` (vertex 4)
-- Vertex 5 (`ttnn::add`) has `internals: [6]`, indicating it internally calls `ttnn::prim::binary_ng` (vertex 6)
-- Vertices 4 and 6 are at `stacking_level: 2`, showing they are nested operations
-- The `out_edges` of tensor vertex 0 now include both 5 and 6, showing it feeds both the top-level `add` and its internal `binary_ng`
-- Tensor vertices 1 and 2 feed both the top-level `multiply` (vertex 3) and its internal `binary_ng` (vertex 4)
-
-You can think of this graph at level 2 like this:
-
-![muladd2](images/muladd_level2.png)
-
-### Use Cases
-
-The `LevelizedGraph` is particularly useful for:
-
-1. **IR Generation**: When building an IR from `ttnn` traces, you can traverse the levelized graph and decide whether to visit a vertex directly or expand its internals based on your needs. Input tensors are explicitly represented as vertices, making it easier to identify and handle function parameters.
-
-2. **Dynamic Op Decomposition**: By varying `max_level`, you can dynamically decompose composite operations (like `cosh` or `digamma`) to different depths.
-
-3. **Shape Inference**: The `output_shape` field provides immediate access to output shapes for both operations and input tensors, which is essential for operations like `ttnn::sum` that may have different input and output shapes.
-
-4. **Layout Information**: The `output_info` field captures layout and memory configuration details when available, which is crucial for understanding tensor properties.
-
-5. **Fork/Join Analysis**: The bidirectional edge structure makes it easy to identify cases where a tensor is used by multiple operations (forks) or where multiple tensors feed into one operation (joins). Input tensors are explicitly represented, making fork analysis straightforward.
-
-6. **Input Tensor Tracking**: Input tensors (created outside the capture) are now explicit vertices in the graph with empty `in_edges`, making it easy to distinguish them from intermediate tensors and identify the inputs to a captured operation sequence.
-
-### Limitations
-
-1. **Output Info Availability**: Complete `output_info` for operations without a consumer cannot be inferred from the graph trace. As a result, the return type and layout information of the top-level function may not always be available. Tensor vertices also have empty `output_info` since they don't produce outputs in the traditional sense.
-
-We're working to fix these limitations soon.
+</details>

--- a/tests/ttnn/unit_tests/base_functionality/test_graph_capture.py
+++ b/tests/ttnn/unit_tests/base_functionality/test_graph_capture.py
@@ -24,11 +24,11 @@ def test_graph_capture(tmp_path, device, scalar, size, mode):
     captured_graph = ttnn.graph.end_graph_capture()
     calltrace = ttnn.graph.extract_calltrace(captured_graph)
 
-    assert "ttnn::convert_python_tensor_to_tt_tensor" in calltrace
+    assert "ttnn.from_torch" in calltrace or "ttnn::convert_python_tensor_to_tt_tensor" in calltrace
     assert captured_graph[0]["node_type"] == "capture_start"
     assert captured_graph[1]["node_type"] == "function_start"
-    assert captured_graph[1]["params"]["name"] == "ttnn::convert_python_tensor_to_tt_tensor"
-    assert captured_graph[-2]["node_type"] == "buffer_deallocate"
+    first_op = captured_graph[1]["params"]["name"]
+    assert first_op in ("ttnn.from_torch", "ttnn::convert_python_tensor_to_tt_tensor")
     assert captured_graph[-1]["node_type"] == "capture_end"
 
     ttnn.graph.pretty_print(captured_graph)
@@ -521,3 +521,88 @@ def test_program_cache_invalidation_across_dispatch_modes(device):
         assert False
 
     assert True
+
+
+# Tests for new features: buffer pages, full tensor info
+
+
+def test_detailed_buffer_tracing_control():
+    """Test detailed buffer tracing enable/disable API"""
+    # Default should be disabled
+    assert not ttnn.graph.is_detailed_buffer_tracing_enabled()
+
+    # Enable
+    ttnn.graph.enable_detailed_buffer_tracing()
+    assert ttnn.graph.is_detailed_buffer_tracing_enabled()
+
+    # Disable
+    ttnn.graph.disable_detailed_buffer_tracing()
+    assert not ttnn.graph.is_detailed_buffer_tracing_enabled()
+
+
+@pytest.mark.parametrize("mode", [ttnn.graph.RunMode.NO_DISPATCH, ttnn.graph.RunMode.NORMAL])
+def test_full_tensor_info_captured(device, mode):
+    """Test that full tensor info (dtype, layout, memory_config, etc.) is captured"""
+    ttnn.graph.begin_graph_capture(mode)
+    ttnn.from_torch(
+        torch.rand((1, 1, 32, 32), dtype=torch.bfloat16),
+        dtype=ttnn.DataType.BFLOAT16,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        memory_config=ttnn.L1_MEMORY_CONFIG,
+    )
+    captured_graph = ttnn.graph.end_graph_capture()
+
+    # Find tensor nodes and verify they have full info
+    found_tensor_with_full_info = False
+    for node in captured_graph:
+        if node["node_type"] == "tensor":
+            params = node["params"]
+            # Check for required fields
+            assert "tensor_id" in params
+            assert "shape" in params
+
+            # Check for extended tensor info (dtype, layout)
+            if "dtype" in params:
+                found_tensor_with_full_info = True
+                assert isinstance(params["dtype"], str)
+                assert "layout" in params
+                assert isinstance(params["layout"], str)
+
+                # For device tensors, check device-specific fields
+                if "device_id" in params:
+                    assert isinstance(params["device_id"], (int, str))
+                    assert "address" in params
+                    assert isinstance(params["address"], (int, str))
+
+    assert found_tensor_with_full_info, "Expected at least one tensor with full info"
+
+
+@pytest.mark.parametrize("mode", [ttnn.graph.RunMode.NO_DISPATCH, ttnn.graph.RunMode.NORMAL])
+def test_duration_captured(device, mode):
+    """Test that durations are captured for function_end and capture_end nodes"""
+    ttnn.graph.begin_graph_capture(mode)
+    input_tensor = ttnn.from_torch(torch.rand((32,), dtype=torch.bfloat16), layout=ttnn.TILE_LAYOUT, device=device)
+    ttnn.relu(input_tensor)
+    captured_graph = ttnn.graph.end_graph_capture()
+
+    # Check function_end nodes have duration
+    found_function_end_with_duration = False
+    for node in captured_graph:
+        if node["node_type"] == "function_end":
+            if "duration_ns" in node:
+                found_function_end_with_duration = True
+                assert isinstance(node["duration_ns"], int)
+                assert node["duration_ns"] >= 0
+
+    # Check capture_end node has duration
+    found_capture_end_with_duration = False
+    for node in captured_graph:
+        if node["node_type"] == "capture_end":
+            if "duration_ns" in node:
+                found_capture_end_with_duration = True
+                assert isinstance(node["duration_ns"], int)
+                assert node["duration_ns"] >= 0
+
+    assert found_function_end_with_duration, "Expected function_end nodes to have duration"
+    assert found_capture_end_with_duration, "Expected capture_end node to have duration"

--- a/tests/ttnn/unit_tests/base_functionality/test_graph_report.py
+++ b/tests/ttnn/unit_tests/base_functionality/test_graph_report.py
@@ -1,0 +1,3453 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Tests for the C++-based graph capture and offline import workflow.
+
+This tests the decoupled workflow:
+1. C++ captures graph to JSON file
+2. Offline import to SQLite for visualization
+"""
+
+import json
+import os
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+import torch
+
+# Add local ttnn to path for graph_report module (before importing ttnn)
+_local_ttnn_path = str(Path(__file__).parent.parent.parent.parent.parent / "ttnn" / "ttnn")
+sys.path.insert(0, _local_ttnn_path)
+
+# Import graph_report directly (doesn't need ttnn._ttnn)
+import graph_report
+
+# Now import ttnn for device tests
+import ttnn
+from models.common.utility_functions import is_wormhole_b0
+
+
+def is_simulator():
+    return os.environ.get("TT_METAL_SIMULATOR") is not None
+
+
+@pytest.fixture
+def tmp_report_dir(tmp_path):
+    """Create a temporary directory for reports."""
+    report_dir = tmp_path / "reports"
+    report_dir.mkdir()
+    return report_dir
+
+
+def _make_report(
+    graph,
+    devices=None,
+    per_operation_buffers=None,
+    python_io=None,
+    metadata=None,
+):
+    """Build a complete JSON report dict matching C++ output format."""
+    report = {"version": 1, "graph": graph, "devices": devices or [], "metadata": metadata or {}}
+    if per_operation_buffers is not None:
+        report["per_operation_buffers"] = per_operation_buffers
+    if python_io is not None:
+        report["python_io"] = python_io
+    return report
+
+
+def _import_to_db(report_dict, tmp_path):
+    """Write report JSON, import via import_report(), return (connection, cursor)."""
+    report_path = tmp_path / "report.json"
+    with open(report_path, "w") as f:
+        json.dump(report_dict, f)
+    db_path = graph_report.import_report(report_path, tmp_path / "output")
+    conn = sqlite3.connect(db_path)
+    return conn, conn.cursor()
+
+
+class TestImportGraphUnit:
+    """Pure unit tests for import_graph function - no device required."""
+
+    def test_output_tensors_extracted_from_function_end(self, tmp_path):
+        """Test that output tensors are extracted from function_end connections."""
+        mock_graph = [
+            {"counter": 0, "node_type": "capture_start", "params": {}, "connections": [1, 5]},
+            {
+                "counter": 1,
+                "node_type": "tensor",
+                "params": {"tensor_id": "42", "shape": "[1,1,32,32]"},
+                "connections": [],
+            },
+            {
+                "counter": 2,
+                "node_type": "function_start",
+                "params": {"name": "ttnn::relu", "inputs": "1"},
+                "connections": [],
+                "input_tensors": [1],
+            },
+            {
+                "counter": 3,
+                "node_type": "tensor",
+                "params": {"tensor_id": "101", "shape": "[1,1,32,32]"},
+                "connections": [],
+            },
+            {
+                "counter": 4,
+                "node_type": "function_end",
+                "params": {"name": "ttnn::relu"},
+                "connections": [3],
+                "duration_ns": 1000,
+            },
+            {"counter": 5, "node_type": "capture_end", "params": {}, "connections": []},
+        ]
+
+        report = _make_report(mock_graph)
+        conn, cursor = _import_to_db(report, tmp_path)
+
+        cursor.execute("SELECT operation_id, output_index, tensor_id FROM output_tensors")
+        output_rows = cursor.fetchall()
+
+        assert len(output_rows) == 1, f"Expected 1 output tensor, got {len(output_rows)}"
+        assert str(output_rows[0][2]) == "101", f"Expected tensor_id '101', got {output_rows[0][2]}"
+
+        # input_tensors[1] points to node counter 1 (tensor with tensor_id="42")
+        cursor.execute("SELECT operation_id, input_index, tensor_id FROM input_tensors")
+        input_rows = cursor.fetchall()
+        assert len(input_rows) == 1, f"Expected 1 input tensor, got {len(input_rows)}"
+        assert input_rows[0][2] == 42, f"Expected tensor_id 42 (resolved from node 1), got {input_rows[0][2]}"
+
+        conn.close()
+
+    def test_multiple_output_tensors(self, tmp_path):
+        """Test function_end with multiple output tensor connections."""
+        mock_graph = [
+            {"counter": 0, "node_type": "capture_start", "params": {}, "connections": [1, 5]},
+            {
+                "counter": 1,
+                "node_type": "function_start",
+                "params": {"name": "ttnn::split", "inputs": "1"},
+                "connections": [],
+                "input_tensors": [],
+            },
+            {
+                "counter": 2,
+                "node_type": "tensor",
+                "params": {"tensor_id": "201", "shape": "[1,1,16,32]"},
+                "connections": [],
+            },
+            {
+                "counter": 3,
+                "node_type": "tensor",
+                "params": {"tensor_id": "202", "shape": "[1,1,16,32]"},
+                "connections": [],
+            },
+            {
+                "counter": 4,
+                "node_type": "function_end",
+                "params": {"name": "ttnn::split"},
+                "connections": [2, 3],
+                "duration_ns": 2000,
+            },
+            {"counter": 5, "node_type": "capture_end", "params": {}, "connections": []},
+        ]
+
+        report = _make_report(mock_graph)
+        conn, cursor = _import_to_db(report, tmp_path)
+
+        cursor.execute("SELECT tensor_id FROM output_tensors ORDER BY output_index")
+        output_rows = cursor.fetchall()
+
+        assert len(output_rows) == 2, f"Expected 2 output tensors, got {len(output_rows)}"
+        assert str(output_rows[0][0]) == "201"
+        assert str(output_rows[1][0]) == "202"
+
+        conn.close()
+
+    def test_error_nodes_imported(self, tmp_path):
+        """Test that error nodes are imported."""
+        mock_graph = [
+            {"counter": 0, "node_type": "capture_start", "params": {}, "connections": [1, 3]},
+            {
+                "counter": 1,
+                "node_type": "function_start",
+                "params": {"name": "ttnn::bad_op", "inputs": "1"},
+                "connections": [2],
+                "input_tensors": [],
+            },
+            {
+                "counter": 2,
+                "node_type": "error",
+                "params": {
+                    "error_type": "exception",
+                    "error_message": "Something went wrong",
+                    "error_operation": "ttnn::bad_op",
+                },
+                "connections": [],
+            },
+            {"counter": 3, "node_type": "capture_end", "params": {}, "connections": []},
+        ]
+
+        report = _make_report(mock_graph)
+        conn, cursor = _import_to_db(report, tmp_path)
+
+        cursor.execute("SELECT operation_name, error_type, error_message FROM errors")
+        rows = cursor.fetchall()
+
+        assert len(rows) == 1
+        assert rows[0][0] == "ttnn::bad_op"
+        assert rows[0][1] == "exception"
+        assert rows[0][2] == "Something went wrong"
+
+        conn.close()
+
+    def test_operation_arguments_imported(self, tmp_path):
+        """Test that operation arguments are imported from function_start."""
+        mock_graph = [
+            {"counter": 0, "node_type": "capture_start", "params": {}, "connections": [1, 3]},
+            {
+                "counter": 1,
+                "node_type": "function_start",
+                "params": {"name": "ttnn::add", "inputs": "2"},
+                "connections": [],
+                "input_tensors": [],
+                "arguments": ["tensor_a", "tensor_b", "alpha=1.0"],
+            },
+            {
+                "counter": 2,
+                "node_type": "function_end",
+                "params": {"name": "ttnn::add"},
+                "connections": [],
+                "duration_ns": 5000,
+            },
+            {"counter": 3, "node_type": "capture_end", "params": {}, "connections": []},
+        ]
+
+        report = _make_report(mock_graph)
+        conn, cursor = _import_to_db(report, tmp_path)
+
+        cursor.execute("SELECT name, value FROM operation_arguments ORDER BY name")
+        rows = cursor.fetchall()
+
+        assert len(rows) == 3
+        # arg_0, arg_1, arg_2
+        values = [r[1] for r in rows]
+        assert "tensor_a" in values
+        assert "tensor_b" in values
+        assert "alpha=1.0" in values
+
+        conn.close()
+
+    def test_buffers_imported(self, tmp_path):
+        """Test that buffer allocations are imported."""
+        mock_graph = [
+            {"counter": 0, "node_type": "capture_start", "params": {}, "connections": [1, 4]},
+            {
+                "counter": 1,
+                "node_type": "function_start",
+                "params": {"name": "ttnn::relu", "inputs": "1"},
+                "connections": [],
+                "input_tensors": [],
+            },
+            {
+                "counter": 2,
+                "node_type": "buffer_allocate",
+                "params": {"device_id": "0", "address": "12345", "size": "4096", "type": "L1", "layout": "INTERLEAVED"},
+                "connections": [],
+            },
+            {
+                "counter": 3,
+                "node_type": "function_end",
+                "params": {"name": "ttnn::relu"},
+                "connections": [],
+                "duration_ns": 1000,
+            },
+            {"counter": 4, "node_type": "capture_end", "params": {}, "connections": []},
+        ]
+
+        report = _make_report(mock_graph)
+        conn, cursor = _import_to_db(report, tmp_path)
+
+        cursor.execute("SELECT operation_id, device_id, address, max_size_per_bank, buffer_type FROM buffers")
+        rows = cursor.fetchall()
+
+        assert len(rows) == 1
+        assert rows[0][0] == 1  # operation_id
+        assert rows[0][1] == 0  # device_id
+        assert rows[0][2] == 12345  # address
+        assert rows[0][3] == 4096  # size
+        assert rows[0][4] == 1  # buffer_type (1=L1)
+
+        conn.close()
+
+    def test_buffer_type_mapping_all_types(self, tmp_path):
+        """All buffer types (DRAM, L1, L1_SMALL, SYSTEM_MEMORY, TRACE) map to correct integers."""
+        type_map = {"DRAM": 0, "L1": 1, "SYSTEM_MEMORY": 2, "L1_SMALL": 3, "TRACE": 4}
+        nodes = [
+            {
+                "counter": 0,
+                "node_type": "capture_start",
+                "params": {},
+                "connections": list(range(1, 1 + 3 * len(type_map), 3)),
+            },
+        ]
+        counter = 1
+        for type_name in type_map:
+            nodes.append(
+                {
+                    "counter": counter,
+                    "node_type": "function_start",
+                    "params": {"name": f"ttnn::op_{type_name}", "inputs": "0"},
+                    "connections": [],
+                    "input_tensors": [],
+                }
+            )
+            nodes.append(
+                {
+                    "counter": counter + 1,
+                    "node_type": "buffer_allocate",
+                    "params": {
+                        "device_id": "0",
+                        "address": str(counter * 10000),
+                        "size": "4096",
+                        "page_size": "1024",
+                        "type": type_name,
+                        "layout": "INTERLEAVED",
+                    },
+                    "connections": [],
+                }
+            )
+            nodes.append(
+                {
+                    "counter": counter + 2,
+                    "node_type": "function_end",
+                    "params": {"name": f"ttnn::op_{type_name}"},
+                    "connections": [],
+                    "duration_ns": 100,
+                }
+            )
+            counter += 3
+        nodes.append({"counter": counter, "node_type": "capture_end", "params": {}, "connections": []})
+
+        report = _make_report(nodes)
+        conn, cursor = _import_to_db(report, tmp_path)
+
+        cursor.execute("SELECT address, buffer_type FROM buffers ORDER BY address")
+        rows = cursor.fetchall()
+        addr_to_type = {addr: bt for addr, bt in rows}
+
+        for i, (type_name, expected_int) in enumerate(type_map.items()):
+            addr = (1 + i * 3) * 10000
+            actual_val = addr_to_type.get(addr)
+            assert (
+                actual_val == expected_int
+            ), f"Buffer type '{type_name}' at addr {addr}: expected {expected_int}, got {actual_val}"
+
+        conn.close()
+
+    def test_l1_small_buffer_type_not_collapsed_to_dram(self, tmp_path):
+        """Regression: L1_SMALL must map to 3, not 0 (DRAM)."""
+        mock_graph = [
+            {"counter": 0, "node_type": "capture_start", "params": {}, "connections": [1]},
+            {
+                "counter": 1,
+                "node_type": "function_start",
+                "params": {"name": "ttnn::relu", "inputs": "0"},
+                "connections": [],
+                "input_tensors": [],
+            },
+            {
+                "counter": 2,
+                "node_type": "buffer_allocate",
+                "params": {
+                    "device_id": "0",
+                    "address": "99999",
+                    "size": "2048",
+                    "page_size": "512",
+                    "type": "L1_SMALL",
+                    "layout": "INTERLEAVED",
+                },
+                "connections": [],
+            },
+            {
+                "counter": 3,
+                "node_type": "function_end",
+                "params": {"name": "ttnn::relu"},
+                "connections": [],
+                "duration_ns": 100,
+            },
+            {"counter": 4, "node_type": "capture_end", "params": {}, "connections": []},
+        ]
+
+        report = _make_report(mock_graph)
+        conn, cursor = _import_to_db(report, tmp_path)
+
+        cursor.execute("SELECT buffer_type FROM buffers WHERE address=99999")
+        (bt,) = cursor.fetchone()
+        assert bt == 3, f"buffer_type should be 3 (L1_SMALL), got {bt}"
+
+        conn.close()
+
+    def test_mixed_buffer_types_cumulative(self, tmp_path):
+        """Cumulative snapshots preserve correct buffer_type for mixed DRAM/L1/L1_SMALL."""
+        mock_graph = [
+            {"counter": 0, "node_type": "capture_start", "params": {}, "connections": [1, 5]},
+            # Op 1: allocates DRAM + L1_SMALL
+            {
+                "counter": 1,
+                "node_type": "function_start",
+                "params": {"name": "ttnn::op_a", "inputs": "0"},
+                "connections": [],
+                "input_tensors": [],
+            },
+            {
+                "counter": 2,
+                "node_type": "buffer_allocate",
+                "params": {
+                    "device_id": "0",
+                    "address": "1000",
+                    "size": "8192",
+                    "page_size": "1024",
+                    "type": "DRAM",
+                    "layout": "INTERLEAVED",
+                },
+                "connections": [],
+            },
+            {
+                "counter": 3,
+                "node_type": "buffer_allocate",
+                "params": {
+                    "device_id": "0",
+                    "address": "2000",
+                    "size": "512",
+                    "page_size": "256",
+                    "type": "L1_SMALL",
+                    "layout": "INTERLEAVED",
+                },
+                "connections": [],
+            },
+            {
+                "counter": 4,
+                "node_type": "function_end",
+                "params": {"name": "ttnn::op_a"},
+                "connections": [],
+                "duration_ns": 100,
+            },
+            # Op 2: allocates L1 (cumulative snapshot should have all 3)
+            {
+                "counter": 5,
+                "node_type": "function_start",
+                "params": {"name": "ttnn::op_b", "inputs": "0"},
+                "connections": [],
+                "input_tensors": [],
+            },
+            {
+                "counter": 6,
+                "node_type": "buffer_allocate",
+                "params": {
+                    "device_id": "0",
+                    "address": "3000",
+                    "size": "4096",
+                    "page_size": "512",
+                    "type": "L1",
+                    "layout": "INTERLEAVED",
+                },
+                "connections": [],
+            },
+            {
+                "counter": 7,
+                "node_type": "function_end",
+                "params": {"name": "ttnn::op_b"},
+                "connections": [],
+                "duration_ns": 200,
+            },
+            {"counter": 8, "node_type": "capture_end", "params": {}, "connections": []},
+        ]
+
+        report = _make_report(mock_graph)
+        conn, cursor = _import_to_db(report, tmp_path)
+
+        cursor.execute("SELECT address, buffer_type FROM buffers WHERE operation_id=2 ORDER BY address")
+        rows = cursor.fetchall()
+        assert len(rows) == 3, f"Op 2 should have 3 cumulative buffers, got {len(rows)}"
+        type_by_addr = {addr: bt for addr, bt in rows}
+        assert type_by_addr[1000] == 0, f"DRAM buffer should be 0, got {type_by_addr[1000]}"
+        assert type_by_addr[2000] == 3, f"L1_SMALL buffer should be 3, got {type_by_addr[2000]}"
+        assert type_by_addr[3000] == 1, f"L1 buffer should be 1, got {type_by_addr[3000]}"
+
+        conn.close()
+
+    def test_buffers_cumulative_per_operation(self, tmp_path):
+        """Buffers must be cumulative: each operation includes all currently-allocated buffers."""
+        mock_graph = [
+            {"counter": 0, "node_type": "capture_start", "params": {}, "connections": [1, 10]},
+            {
+                "counter": 1,
+                "node_type": "function_start",
+                "params": {"name": "op_A", "inputs": "0"},
+                "connections": [],
+                "input_tensors": [],
+            },
+            {
+                "counter": 2,
+                "node_type": "buffer_allocate",
+                "params": {
+                    "device_id": "0",
+                    "address": "1000",
+                    "size": "4096",
+                    "type": "DRAM",
+                    "layout": "INTERLEAVED",
+                },
+                "connections": [],
+            },
+            {
+                "counter": 3,
+                "node_type": "function_end",
+                "params": {"name": "op_A"},
+                "connections": [],
+                "duration_ns": 100,
+            },
+            {
+                "counter": 4,
+                "node_type": "function_start",
+                "params": {"name": "op_B", "inputs": "0"},
+                "connections": [],
+                "input_tensors": [],
+            },
+            {
+                "counter": 5,
+                "node_type": "buffer_allocate",
+                "params": {
+                    "device_id": "0",
+                    "address": "2000",
+                    "size": "8192",
+                    "type": "DRAM",
+                    "layout": "INTERLEAVED",
+                },
+                "connections": [],
+            },
+            {
+                "counter": 6,
+                "node_type": "function_end",
+                "params": {"name": "op_B"},
+                "connections": [],
+                "duration_ns": 200,
+            },
+            {
+                "counter": 7,
+                "node_type": "function_start",
+                "params": {"name": "op_C", "inputs": "0"},
+                "connections": [],
+                "input_tensors": [],
+            },
+            {
+                "counter": 8,
+                "node_type": "buffer_allocate",
+                "params": {"device_id": "0", "address": "3000", "size": "2048", "type": "L1", "layout": "INTERLEAVED"},
+                "connections": [],
+            },
+            {
+                "counter": 9,
+                "node_type": "function_end",
+                "params": {"name": "op_C"},
+                "connections": [],
+                "duration_ns": 300,
+            },
+            {"counter": 10, "node_type": "capture_end", "params": {}, "connections": []},
+        ]
+
+        report = _make_report(mock_graph)
+        conn, cursor = _import_to_db(report, tmp_path)
+
+        cursor.execute("SELECT operation_id, address FROM buffers ORDER BY operation_id, address")
+        rows = cursor.fetchall()
+
+        op_1_buffers = [r[1] for r in rows if r[0] == 1]
+        op_2_buffers = [r[1] for r in rows if r[0] == 2]
+        op_3_buffers = [r[1] for r in rows if r[0] == 3]
+
+        assert op_1_buffers == [1000], f"op_A should have 1 buffer, got {op_1_buffers}"
+        assert op_2_buffers == [1000, 2000], f"op_B should have 2 cumulative buffers, got {op_2_buffers}"
+        assert op_3_buffers == [1000, 2000, 3000], f"op_C should have 3 cumulative buffers, got {op_3_buffers}"
+
+        assert len(rows) == 6  # 1 + 2 + 3
+        conn.close()
+
+    def test_device_tensors_imported(self, tmp_path):
+        """Test that device_tensors are imported for multi-device tensors."""
+        mock_graph = [
+            {"counter": 0, "node_type": "capture_start", "params": {}, "connections": [1, 3]},
+            {
+                "counter": 1,
+                "node_type": "function_start",
+                "params": {"name": "ttnn::all_gather", "inputs": "1"},
+                "connections": [],
+                "input_tensors": [],
+            },
+            {
+                "counter": 2,
+                "node_type": "tensor",
+                "params": {
+                    "tensor_id": "100",
+                    "shape": "[1, 32, 32]",
+                    "dtype": "bfloat16",
+                    "layout": "TILE",
+                    "device_id": "0",
+                    "address": "12345678",
+                    "buffer_type": "L1",
+                    "device_tensors": '[{"device_id": 0, "address": 12345678}, {"device_id": 1, "address": 22345678}, {"device_id": 2, "address": 32345678}, {"device_id": 3, "address": 42345678}]',
+                },
+                "connections": [],
+            },
+            {"counter": 3, "node_type": "capture_end", "params": {}, "connections": []},
+        ]
+
+        report = _make_report(mock_graph)
+        conn, cursor = _import_to_db(report, tmp_path)
+
+        cursor.execute("SELECT tensor_id, device_id, address FROM device_tensors ORDER BY device_id")
+        rows = cursor.fetchall()
+
+        assert len(rows) == 4, f"Expected 4 device tensor entries, got {len(rows)}"
+        assert rows[0] == (100, 0, 12345678)
+        assert rows[1] == (100, 1, 22345678)
+        assert rows[2] == (100, 2, 32345678)
+        assert rows[3] == (100, 3, 42345678)
+
+        conn.close()
+
+    def test_device_tensors_prefers_mesh_device_id(self, tmp_path):
+        """Test that mesh_device_id is used over device_id when present in device_tensors JSON."""
+        mock_graph = [
+            {"counter": 0, "node_type": "capture_start", "params": {}, "connections": [1, 3]},
+            {
+                "counter": 1,
+                "node_type": "function_start",
+                "params": {"name": "ttnn::to_device", "inputs": "1"},
+                "connections": [],
+                "input_tensors": [],
+            },
+            {
+                "counter": 2,
+                "node_type": "tensor",
+                "params": {
+                    "tensor_id": "50",
+                    "shape": "[1024, 1024]",
+                    "dtype": "bfloat16",
+                    "layout": "TILE",
+                    "device_id": "1",
+                    "address": "1920032",
+                    "buffer_type": "DRAM",
+                    "device_tensors": '[{"device_id": 0, "mesh_device_id": 1, "address": 1920032}]',
+                },
+                "connections": [],
+            },
+            {"counter": 3, "node_type": "capture_end", "params": {}, "connections": []},
+        ]
+
+        report = _make_report(mock_graph)
+        conn, cursor = _import_to_db(report, tmp_path)
+
+        cursor.execute("SELECT tensor_id, device_id, address FROM device_tensors")
+        rows = cursor.fetchall()
+
+        assert len(rows) == 1
+        assert rows[0] == (50, 1, 1920032), f"Should use mesh_device_id (1) not physical device_id (0). Got {rows[0]}"
+        conn.close()
+
+    def test_full_tensor_info_imported(self, tmp_path):
+        """Test that full tensor info (dtype, layout, memory_config, device_id, address, buffer_type) is imported."""
+        mock_graph = [
+            {"counter": 0, "node_type": "capture_start", "params": {}, "connections": [1, 3]},
+            {
+                "counter": 1,
+                "node_type": "function_start",
+                "params": {"name": "ttnn::relu", "inputs": "1"},
+                "connections": [],
+                "input_tensors": [],
+            },
+            {
+                "counter": 2,
+                "node_type": "tensor",
+                "params": {
+                    "tensor_id": "100",
+                    "shape": "[1, 32, 32]",
+                    "dtype": "bfloat16",
+                    "layout": "TILE",
+                    "memory_config": "MemoryConfig(DRAM, INTERLEAVED)",
+                    "device_id": "0",
+                    "address": "12345678",
+                    "buffer_type": "BufferType::DRAM",
+                    "buffer_type_value": "0",
+                    "size": "2048",
+                },
+                "connections": [],
+            },
+            {"counter": 3, "node_type": "capture_end", "params": {}, "connections": []},
+        ]
+
+        report = _make_report(mock_graph)
+        conn, cursor = _import_to_db(report, tmp_path)
+
+        cursor.execute(
+            "SELECT tensor_id, shape, dtype, layout, memory_config, device_id, address, buffer_type FROM tensors"
+        )
+        rows = cursor.fetchall()
+
+        assert len(rows) == 1
+        row = rows[0]
+        assert str(row[0]) == "100"  # tensor_id
+        assert row[1] == "[1, 32, 32]"  # shape
+        assert row[2] == "bfloat16"  # dtype
+        assert row[3] == "TILE"  # layout
+        assert "DRAM" in row[4]  # memory_config
+        assert row[5] == 0  # device_id
+        assert row[6] == 12345678  # address
+        assert row[7] == 0  # buffer_type (0=DRAM)
+
+        conn.close()
+
+    def test_edges_populated_from_captured_graph(self, tmp_path):
+        """Test that edges are extracted from captured_graph subgraphs."""
+        mock_graph = [
+            {"counter": 0, "node_type": "capture_start", "params": {}, "connections": [1, 4]},
+            {
+                "counter": 1,
+                "node_type": "function_start",
+                "params": {"name": "ttnn::relu", "inputs": "1"},
+                "connections": [2],
+                "input_tensors": [],
+            },
+            {
+                "counter": 2,
+                "node_type": "tensor",
+                "params": {"tensor_id": "100", "shape": "[1,32,32]"},
+                "connections": [3],
+            },
+            {
+                "counter": 3,
+                "node_type": "function_end",
+                "params": {"name": "ttnn::relu"},
+                "connections": [4],
+                "duration_ns": 1000,
+            },
+            {"counter": 4, "node_type": "capture_end", "params": {}, "connections": []},
+        ]
+
+        report = _make_report(mock_graph)
+        conn, cursor = _import_to_db(report, tmp_path)
+
+        cursor.execute("SELECT COUNT(*) FROM edges")
+        assert cursor.fetchone()[0] > 0
+
+        conn.close()
+
+    def test_cluster_mesh_descriptors_saved(self, tmp_path):
+        """Test that cluster and mesh descriptors are saved during import."""
+        graph = [
+            {"counter": 0, "node_type": "capture_start", "params": {}, "connections": [1]},
+            {"counter": 1, "node_type": "capture_end", "params": {}, "connections": []},
+        ]
+        report = _make_report(graph)
+        report["cluster_descriptor"] = "# Mock cluster descriptor YAML\ndevices:\n  - id: 0\n    type: wormhole\n"
+        report["mesh_coordinate_mapping"] = "# physical_chip_mesh_coordinate_mapping_1_of_1.yaml\nchips:\n  0: [0, 0]\n"
+
+        report_path = tmp_path / "report.json"
+        with open(report_path, "w") as f:
+            json.dump(report, f)
+        output_dir = tmp_path / "output"
+        graph_report.import_report(report_path, output_dir)
+
+        # Check cluster descriptor was saved
+        cluster_path = output_dir / "cluster_descriptor.yaml"
+        assert cluster_path.exists(), "cluster_descriptor.yaml should be created"
+        with open(cluster_path) as f:
+            content = f.read()
+        assert "wormhole" in content
+
+        # Check mesh coordinate mapping was saved
+        mesh_path = output_dir / "physical_chip_mesh_coordinate_mapping_1_of_1.yaml"
+        assert mesh_path.exists(), "physical_chip_mesh_coordinate_mapping_1_of_1.yaml should be created"
+        with open(mesh_path) as f:
+            content = f.read()
+        assert "chips" in content
+        assert "0: [0, 0]" in content
+
+
+class TestInputTensorResolution:
+    """Regression tests: input_tensors must resolve node counters to real tensor_ids."""
+
+    def test_input_tensor_resolves_node_counter_to_tensor_id(self, tmp_path):
+        """
+        Regression: input_tensors field contains node counter values, not tensor_ids.
+        The import must look up the node and extract tensor_id from its params.
+        """
+        mock_graph = [
+            {"counter": 0, "node_type": "capture_start", "params": {}, "connections": [1, 5]},
+            {
+                "counter": 1,
+                "node_type": "tensor",
+                "params": {"tensor_id": "77", "shape": "[1,1,32,32]"},
+                "connections": [],
+            },
+            {
+                "counter": 2,
+                "node_type": "function_start",
+                "params": {"name": "ttnn::relu", "inputs": "1"},
+                "connections": [],
+                "input_tensors": [1],
+            },
+            {
+                "counter": 3,
+                "node_type": "function_end",
+                "params": {"name": "ttnn::relu"},
+                "connections": [],
+                "duration_ns": 500,
+            },
+            {"counter": 4, "node_type": "capture_end", "params": {}, "connections": []},
+        ]
+
+        report = _make_report(mock_graph)
+        conn, cursor = _import_to_db(report, tmp_path)
+
+        cursor.execute("SELECT tensor_id FROM input_tensors")
+        rows = cursor.fetchall()
+        assert len(rows) == 1
+        assert (
+            rows[0][0] == 77
+        ), f"input_tensors should store the real tensor_id (77), not the node counter (1). Got {rows[0][0]}"
+        conn.close()
+
+    def test_input_tensor_id_exists_in_tensors_table(self, tmp_path):
+        """
+        Regression: all tensor_ids referenced in input_tensors must exist in the tensors table.
+        The old bug stored node counter values which didn't match any tensor row.
+        """
+        mock_graph = [
+            {"counter": 0, "node_type": "capture_start", "params": {}, "connections": [2, 6]},
+            {
+                "counter": 1,
+                "node_type": "tensor",
+                "params": {"tensor_id": "10", "shape": "[1024,1024]"},
+                "connections": [],
+            },
+            {
+                "counter": 2,
+                "node_type": "function_start",
+                "params": {"name": "ttnn::matmul", "inputs": "1"},
+                "connections": [],
+                "input_tensors": [1],
+            },
+            {
+                "counter": 3,
+                "node_type": "tensor",
+                "params": {"tensor_id": "20", "shape": "[1024,1024]"},
+                "connections": [],
+            },
+            {
+                "counter": 4,
+                "node_type": "function_end",
+                "params": {"name": "ttnn::matmul"},
+                "connections": [3],
+                "duration_ns": 1000,
+            },
+            {"counter": 5, "node_type": "capture_end", "params": {}, "connections": []},
+        ]
+
+        report = _make_report(mock_graph)
+        conn, cursor = _import_to_db(report, tmp_path)
+
+        cursor.execute("SELECT tensor_id FROM tensors")
+        tensor_ids = {row[0] for row in cursor.fetchall()}
+
+        cursor.execute("SELECT tensor_id FROM input_tensors")
+        for row in cursor.fetchall():
+            assert row[0] in tensor_ids or str(row[0]) in tensor_ids, (
+                f"input_tensors references tensor_id={row[0]} which doesn't exist in tensors table. "
+                f"Available: {tensor_ids}"
+            )
+        conn.close()
+
+    def test_multiple_input_tensors_all_resolved(self, tmp_path):
+        """Test that all input tensors for an operation are correctly resolved."""
+        mock_graph = [
+            {"counter": 0, "node_type": "capture_start", "params": {}, "connections": [1, 8]},
+            {
+                "counter": 1,
+                "node_type": "tensor",
+                "params": {"tensor_id": "5", "shape": "[1024,1024]"},
+                "connections": [],
+            },
+            {
+                "counter": 2,
+                "node_type": "tensor",
+                "params": {"tensor_id": "8", "shape": "[1024,1024]"},
+                "connections": [],
+            },
+            {
+                "counter": 3,
+                "node_type": "tensor",
+                "params": {"tensor_id": "11", "shape": "[1,1024]"},
+                "connections": [],
+            },
+            {
+                "counter": 4,
+                "node_type": "function_start",
+                "params": {"name": "ttnn::linear", "inputs": "3"},
+                "connections": [],
+                "input_tensors": [1, 2, 3],
+            },
+            {
+                "counter": 5,
+                "node_type": "tensor",
+                "params": {"tensor_id": "20", "shape": "[1024,1024]"},
+                "connections": [],
+            },
+            {
+                "counter": 6,
+                "node_type": "function_end",
+                "params": {"name": "ttnn::linear"},
+                "connections": [5],
+                "duration_ns": 5000,
+            },
+            {"counter": 7, "node_type": "capture_end", "params": {}, "connections": []},
+        ]
+
+        report = _make_report(mock_graph)
+        conn, cursor = _import_to_db(report, tmp_path)
+
+        cursor.execute("SELECT input_index, tensor_id FROM input_tensors ORDER BY input_index")
+        rows = cursor.fetchall()
+
+        assert len(rows) == 3, f"Expected 3 input tensors, got {len(rows)}"
+        assert rows[0] == (0, 5), f"Input 0 should be tensor_id 5 (node 1), got {rows[0]}"
+        assert rows[1] == (1, 8), f"Input 1 should be tensor_id 8 (node 2), got {rows[1]}"
+        assert rows[2] == (2, 11), f"Input 2 should be tensor_id 11 (node 3), got {rows[2]}"
+        conn.close()
+
+    def test_invalid_node_counter_skipped(self, tmp_path):
+        """Input tensor references to non-existent nodes are silently skipped."""
+        mock_graph = [
+            {"counter": 0, "node_type": "capture_start", "params": {}, "connections": [1, 4]},
+            {
+                "counter": 1,
+                "node_type": "function_start",
+                "params": {"name": "ttnn::relu", "inputs": "1"},
+                "connections": [],
+                "input_tensors": [999],
+            },
+            {
+                "counter": 2,
+                "node_type": "function_end",
+                "params": {"name": "ttnn::relu"},
+                "connections": [],
+                "duration_ns": 100,
+            },
+            {"counter": 3, "node_type": "capture_end", "params": {}, "connections": []},
+        ]
+
+        report = _make_report(mock_graph)
+        conn, cursor = _import_to_db(report, tmp_path)
+
+        cursor.execute("SELECT * FROM input_tensors")
+        assert cursor.fetchall() == [], "Invalid node counter should not produce input_tensor rows"
+        conn.close()
+
+
+class TestImportValidation:
+    """Tests for the referential integrity validation in the importer."""
+
+    def _make_db(self, tmp_path):
+        db_path = tmp_path / "test.db"
+        conn = sqlite3.connect(db_path)
+        cursor = conn.cursor()
+        graph_report.create_database_schema(cursor)
+        return conn, cursor
+
+    def test_clean_import_produces_no_warnings(self, tmp_path):
+        """A well-formed graph should produce zero integrity warnings."""
+        mock_graph = [
+            {"counter": 0, "node_type": "capture_start", "params": {}, "connections": [1, 5]},
+            {
+                "counter": 1,
+                "node_type": "tensor",
+                "params": {"tensor_id": "10", "shape": "[32,32]"},
+                "connections": [],
+            },
+            {
+                "counter": 2,
+                "node_type": "function_start",
+                "params": {"name": "ttnn::relu", "inputs": "1"},
+                "connections": [],
+                "input_tensors": [1],
+            },
+            {
+                "counter": 3,
+                "node_type": "tensor",
+                "params": {"tensor_id": "20", "shape": "[32,32]"},
+                "connections": [],
+            },
+            {
+                "counter": 4,
+                "node_type": "function_end",
+                "params": {"name": "ttnn::relu"},
+                "connections": [3],
+                "duration_ns": 100,
+            },
+            {"counter": 5, "node_type": "capture_end", "params": {}, "connections": []},
+        ]
+
+        conn, cursor = self._make_db(tmp_path)
+        stats = graph_report.import_graph(cursor, mock_graph)
+        conn.commit()
+
+        assert stats.get("warnings", []) == [], f"Clean import should have no warnings, got: {stats['warnings']}"
+        conn.close()
+
+    def test_dangling_input_tensor_produces_warning(self, tmp_path):
+        """
+        Simulate the old bug: manually insert an input_tensor row pointing to
+        a nonexistent tensor_id and verify the validator catches it.
+        """
+        mock_graph = [
+            {"counter": 0, "node_type": "capture_start", "params": {}, "connections": [1, 3]},
+            {
+                "counter": 1,
+                "node_type": "function_start",
+                "params": {"name": "ttnn::relu", "inputs": "1"},
+                "connections": [],
+                "input_tensors": [],
+            },
+            {
+                "counter": 2,
+                "node_type": "function_end",
+                "params": {"name": "ttnn::relu"},
+                "connections": [],
+                "duration_ns": 100,
+            },
+            {"counter": 3, "node_type": "capture_end", "params": {}, "connections": []},
+        ]
+
+        conn, cursor = self._make_db(tmp_path)
+        graph_report.import_graph(cursor, mock_graph)
+        conn.commit()
+
+        # Manually insert a dangling reference (simulating the old bug)
+        cursor.execute("INSERT INTO input_tensors VALUES (0, 0, 999)")
+        conn.commit()
+
+        # Run validation directly
+        warnings = graph_report._validate_graph_integrity(
+            operations_batch=[(0, "ttnn::relu", 0.0)],
+            tensors_batch=[],
+            input_tensors_batch=[(0, 0, 999)],
+            output_tensors_batch=[],
+            operation_arguments_batch=[],
+            device_tensors_batch=[],
+            buffers_batch=[],
+            devices=None,
+        )
+        assert len(warnings) >= 1
+        assert any("tensor_id=999" in w for w in warnings), f"Should warn about dangling tensor_id=999, got: {warnings}"
+        conn.close()
+
+
+class TestBufferMaxSizePerBank:
+    """Regression tests: max_size_per_bank must be per-bank, not total buffer size."""
+
+    @staticmethod
+    def _make_buffer_graph(size, page_size, buf_type="DRAM", layout="INTERLEAVED", num_cores=0):
+        return [
+            {"counter": 0, "node_type": "capture_start", "params": {}, "connections": [1, 4]},
+            {
+                "counter": 1,
+                "node_type": "function_start",
+                "params": {"name": "ttnn::to_device", "inputs": "1"},
+                "connections": [],
+                "input_tensors": [],
+            },
+            {
+                "counter": 2,
+                "node_type": "buffer_allocate",
+                "params": {
+                    "device_id": "0",
+                    "address": "1000",
+                    "size": str(size),
+                    "page_size": str(page_size),
+                    "num_cores": str(num_cores),
+                    "type": buf_type,
+                    "layout": layout,
+                },
+                "connections": [],
+            },
+            {
+                "counter": 3,
+                "node_type": "function_end",
+                "params": {"name": "ttnn::to_device"},
+                "connections": [],
+                "duration_ns": 100,
+            },
+            {"counter": 4, "node_type": "capture_end", "params": {}, "connections": []},
+        ]
+
+    def test_dram_interleaved_per_bank_size(self, tmp_path):
+        """
+        Regression: a 1024x1024 bf16 TILE tensor is 2,097,152 bytes total.
+        With 12 DRAM channels: ceil(1024 pages / 12 banks) * 2048 page_size = 176,128 per bank.
+        """
+        devices = [{"device_id": 0, "num_dram_channels": 12, "l1_num_banks": 64}]
+        graph = self._make_buffer_graph(size=2097152, page_size=2048, buf_type="DRAM")
+
+        report = _make_report(graph, devices=devices)
+        conn, cursor = _import_to_db(report, tmp_path)
+
+        cursor.execute("SELECT max_size_per_bank FROM buffers")
+        actual = cursor.fetchone()[0]
+        expected = 86 * 2048  # ceil(1024/12) * page_size = 176128
+        assert actual == expected, f"max_size_per_bank should be {expected} (per-bank), got {actual}"
+        conn.close()
+
+    def test_l1_interleaved_per_bank_size(self, tmp_path):
+        """L1 interleaved buffers should use l1_num_banks for per-bank computation."""
+        devices = [{"device_id": 0, "num_dram_channels": 12, "l1_num_banks": 64}]
+        graph = self._make_buffer_graph(size=65536, page_size=2048, buf_type="L1")
+
+        report = _make_report(graph, devices=devices)
+        conn, cursor = _import_to_db(report, tmp_path)
+
+        cursor.execute("SELECT max_size_per_bank FROM buffers")
+        actual = cursor.fetchone()[0]
+        expected = 2048  # 32 pages, ceil(32/64) = 1 page/bank, 1 * 2048
+        assert actual == expected, f"L1 per-bank should be {expected}, got {actual}"
+        conn.close()
+
+    def test_small_dram_buffer_per_bank(self, tmp_path):
+        """
+        Regression from the real bug: bias tensor buffer (26,624 bytes).
+        ceil(13 pages / 12 banks) * 2048 = 4096 per bank.
+        """
+        devices = [{"device_id": 0, "num_dram_channels": 12, "l1_num_banks": 64}]
+        graph = self._make_buffer_graph(size=26624, page_size=2048, buf_type="DRAM")
+
+        report = _make_report(graph, devices=devices)
+        conn, cursor = _import_to_db(report, tmp_path)
+
+        cursor.execute("SELECT max_size_per_bank FROM buffers")
+        actual = cursor.fetchone()[0]
+        expected = 2 * 2048  # ceil(13/12) * 2048 = 4096
+        assert actual == expected, f"Bias buffer per-bank should be {expected}, got {actual}"
+        conn.close()
+
+    def test_no_device_info_falls_back_to_total_size(self, tmp_path):
+        """Without device info, max_size_per_bank falls back to total buffer size."""
+        graph = self._make_buffer_graph(size=4096, page_size=2048, buf_type="DRAM")
+
+        report = _make_report(graph)
+        conn, cursor = _import_to_db(report, tmp_path)
+
+        cursor.execute("SELECT max_size_per_bank FROM buffers")
+        assert cursor.fetchone()[0] == 4096, "Without device info, should fall back to total size"
+        conn.close()
+
+    def test_sharded_buffer_per_core_size(self, tmp_path):
+        """Sharded buffers compute per-bank from num_cores."""
+        devices = [{"device_id": 0, "num_dram_channels": 12, "l1_num_banks": 64}]
+        graph = self._make_buffer_graph(size=32768, page_size=2048, buf_type="L1", layout="HEIGHT_SHARDED", num_cores=8)
+
+        report = _make_report(graph, devices=devices)
+        conn, cursor = _import_to_db(report, tmp_path)
+
+        cursor.execute("SELECT max_size_per_bank FROM buffers")
+        assert cursor.fetchone()[0] == 4096, f"Sharded per-core should be 4096"
+        conn.close()
+
+
+class TestLinearModelImport:
+    """
+    End-to-end regression test using the exact graph structure from the team's test_linear model:
+        a = ttnn.ones([1024, 1024], layout=ttnn.TILE_LAYOUT, device=device)
+        b = ttnn.ones([1024, 1024], layout=ttnn.TILE_LAYOUT, device=device)
+        c = ttnn.ones([1, 1024], layout=ttnn.TILE_LAYOUT, device=device)
+        d = ttnn.linear(a, b, bias=c)
+
+    Verifies the import produces output consistent with the known-good (correct) database.
+    """
+
+    MOCK_DEVICE_INFO = [
+        {
+            "device_id": 1,
+            "num_dram_channels": 12,
+            "l1_num_banks": 64,
+            "num_y_cores": 8,
+            "num_x_cores": 8,
+            "num_y_compute_cores": 8,
+            "num_x_compute_cores": 8,
+            "worker_l1_size": 1499136,
+            "l1_bank_size": 1395424,
+            "address_at_first_l1_bank": 0,
+            "address_at_first_l1_cb_buffer": 103712,
+            "num_banks_per_storage_core": 1,
+            "num_compute_cores": 64,
+            "num_storage_cores": 0,
+            "total_l1_memory": 95944704,
+            "total_l1_for_tensors": 0,
+            "total_l1_for_interleaved_buffers": 89307136,
+            "total_l1_for_sharded_buffers": 89307136,
+            "cb_limit": 1395424,
+        }
+    ]
+
+    MOCK_LINEAR_GRAPH = [
+        {"counter": 0, "node_type": "capture_start", "params": {}, "connections": [1, 7, 13, 19]},
+        # --- ttnn.ones #1 → ttnn.to_device ---
+        {
+            "counter": 1,
+            "node_type": "function_start",
+            "params": {"name": "ttnn.to_device", "inputs": "1"},
+            "connections": [3, 4, 5],
+            "input_tensors": [2],
+        },
+        {
+            "counter": 2,
+            "node_type": "tensor",
+            "params": {
+                "tensor_id": "0",
+                "shape": "Shape([1024, 1024])",
+                "dtype": "DataType::BFLOAT16",
+                "layout": "Layout::TILE",
+            },
+            "connections": [1],
+        },
+        {"counter": 3, "node_type": "buffer", "params": {}, "connections": [6, 6]},
+        {
+            "counter": 4,
+            "node_type": "buffer_allocate",
+            "params": {
+                "device_id": "1",
+                "address": "1920032",
+                "size": "2097152",
+                "page_size": "2048",
+                "num_cores": "0",
+                "type": "DRAM",
+                "layout": "INTERLEAVED",
+            },
+            "connections": [3],
+        },
+        {
+            "counter": 5,
+            "node_type": "function_end",
+            "params": {"name": "ttnn.to_device"},
+            "connections": [6, 7],
+            "duration_ns": 2784790,
+        },
+        {
+            "counter": 6,
+            "node_type": "tensor",
+            "params": {
+                "tensor_id": "1",
+                "shape": "Shape([1024, 1024])",
+                "dtype": "DataType::BFLOAT16",
+                "layout": "Layout::TILE",
+                "memory_config": "MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::DRAM,shard_spec=std::nullopt,nd_shard_spec=std::nullopt,created_with_nd_shard_spec=0)",
+                "device_id": "1",
+                "address": "1920032",
+                "buffer_type": "DRAM",
+                "device_tensors": '[{"device_id": 0, "mesh_device_id": 1, "address": 1920032}]',
+            },
+            "connections": [19],
+        },
+        # --- ttnn.ones #2 → ttnn.to_device ---
+        {
+            "counter": 7,
+            "node_type": "function_start",
+            "params": {"name": "ttnn.to_device", "inputs": "1"},
+            "connections": [9, 10, 11],
+            "input_tensors": [8],
+        },
+        {
+            "counter": 8,
+            "node_type": "tensor",
+            "params": {
+                "tensor_id": "2",
+                "shape": "Shape([1024, 1024])",
+                "dtype": "DataType::BFLOAT16",
+                "layout": "Layout::TILE",
+            },
+            "connections": [7],
+        },
+        {"counter": 9, "node_type": "buffer", "params": {}, "connections": [12, 12]},
+        {
+            "counter": 10,
+            "node_type": "buffer_allocate",
+            "params": {
+                "device_id": "1",
+                "address": "2096160",
+                "size": "2097152",
+                "page_size": "2048",
+                "num_cores": "0",
+                "type": "DRAM",
+                "layout": "INTERLEAVED",
+            },
+            "connections": [9],
+        },
+        {
+            "counter": 11,
+            "node_type": "function_end",
+            "params": {"name": "ttnn.to_device"},
+            "connections": [12, 13],
+            "duration_ns": 252479,
+        },
+        {
+            "counter": 12,
+            "node_type": "tensor",
+            "params": {
+                "tensor_id": "3",
+                "shape": "Shape([1024, 1024])",
+                "dtype": "DataType::BFLOAT16",
+                "layout": "Layout::TILE",
+                "memory_config": "MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::DRAM,shard_spec=std::nullopt,nd_shard_spec=std::nullopt,created_with_nd_shard_spec=0)",
+                "device_id": "1",
+                "address": "2096160",
+                "buffer_type": "DRAM",
+                "device_tensors": '[{"device_id": 0, "mesh_device_id": 1, "address": 2096160}]',
+            },
+            "connections": [19],
+        },
+        # --- ttnn.ones #3 → ttnn.to_device ---
+        {
+            "counter": 13,
+            "node_type": "function_start",
+            "params": {"name": "ttnn.to_device", "inputs": "1"},
+            "connections": [15, 16, 17],
+            "input_tensors": [14],
+        },
+        {
+            "counter": 14,
+            "node_type": "tensor",
+            "params": {
+                "tensor_id": "4",
+                "shape": "Shape([1, 1024])",
+                "dtype": "DataType::BFLOAT16",
+                "layout": "Layout::TILE",
+            },
+            "connections": [13],
+        },
+        {"counter": 15, "node_type": "buffer", "params": {}, "connections": [18, 18]},
+        {
+            "counter": 16,
+            "node_type": "buffer_allocate",
+            "params": {
+                "device_id": "1",
+                "address": "2272288",
+                "size": "65536",
+                "page_size": "2048",
+                "num_cores": "0",
+                "type": "DRAM",
+                "layout": "INTERLEAVED",
+            },
+            "connections": [15],
+        },
+        {
+            "counter": 17,
+            "node_type": "function_end",
+            "params": {"name": "ttnn.to_device"},
+            "connections": [18, 19],
+            "duration_ns": 31240,
+        },
+        {
+            "counter": 18,
+            "node_type": "tensor",
+            "params": {
+                "tensor_id": "5",
+                "shape": "Shape([1, 1024])",
+                "dtype": "DataType::BFLOAT16",
+                "layout": "Layout::TILE",
+                "memory_config": "MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::DRAM,shard_spec=std::nullopt,nd_shard_spec=std::nullopt,created_with_nd_shard_spec=0)",
+                "device_id": "1",
+                "address": "2272288",
+                "buffer_type": "DRAM",
+                "device_tensors": '[{"device_id": 0, "mesh_device_id": 1, "address": 2272288}]',
+            },
+            "connections": [19],
+        },
+        # --- ttnn.linear → MatmulDeviceOperation ---
+        {
+            "counter": 19,
+            "node_type": "function_start",
+            "params": {"name": "MatmulDeviceOperation", "inputs": "3"},
+            "connections": [20, 25, 26, 27, 28, 29, 30, 31, 32],
+            "input_tensors": [6, 12, 18],
+        },
+        {
+            "counter": 20,
+            "node_type": "function_start",
+            "params": {"name": "tt::tt_metal::create_device_tensor"},
+            "connections": [21, 22, 23],
+            "input_tensors": [],
+        },
+        {"counter": 21, "node_type": "buffer", "params": {}, "connections": [24, 24]},
+        {
+            "counter": 22,
+            "node_type": "buffer_allocate",
+            "params": {
+                "device_id": "1",
+                "address": "2278432",
+                "size": "2097152",
+                "page_size": "2048",
+                "num_cores": "0",
+                "type": "DRAM",
+                "layout": "INTERLEAVED",
+            },
+            "connections": [21],
+        },
+        {
+            "counter": 23,
+            "node_type": "function_end",
+            "params": {"name": "tt::tt_metal::create_device_tensor"},
+            "connections": [24],
+            "duration_ns": 14929,
+        },
+        {
+            "counter": 24,
+            "node_type": "tensor",
+            "params": {
+                "tensor_id": "7",
+                "shape": "Shape([1024, 1024])",
+                "dtype": "DataType::BFLOAT16",
+                "layout": "Layout::TILE",
+                "memory_config": "MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::DRAM,shard_spec=std::nullopt,nd_shard_spec=std::nullopt,created_with_nd_shard_spec=0)",
+                "device_id": "1",
+                "address": "2278432",
+                "buffer_type": "DRAM",
+                "device_tensors": '[{"device_id": 0, "mesh_device_id": 1, "address": 2278432}]',
+            },
+            "connections": [],
+        },
+        {"counter": 25, "node_type": "circular_buffer_deallocate_all", "params": {}, "connections": [19]},
+        {"counter": 26, "node_type": "circular_buffer_allocate", "params": {}, "connections": []},
+        {"counter": 27, "node_type": "circular_buffer_allocate", "params": {}, "connections": []},
+        {"counter": 28, "node_type": "circular_buffer_allocate", "params": {}, "connections": []},
+        {"counter": 29, "node_type": "circular_buffer_allocate", "params": {}, "connections": []},
+        {"counter": 30, "node_type": "buffer", "params": {}, "connections": []},
+        {
+            "counter": 31,
+            "node_type": "buffer_allocate",
+            "params": {
+                "device_id": "1",
+                "address": "1073737728",
+                "size": "26624",
+                "page_size": "2048",
+                "num_cores": "0",
+                "type": "DRAM",
+                "layout": "INTERLEAVED",
+            },
+            "connections": [30],
+        },
+        {
+            "counter": 32,
+            "node_type": "function_end",
+            "params": {"name": "MatmulDeviceOperation"},
+            "connections": [24, 33],
+            "duration_ns": 13232532,
+        },
+        {"counter": 33, "node_type": "capture_end", "params": {}, "connections": []},
+    ]
+
+    def _import_linear_graph(self, tmp_path):
+        report = _make_report(self.MOCK_LINEAR_GRAPH, devices=self.MOCK_DEVICE_INFO)
+        return _import_to_db(report, tmp_path)
+
+    def test_operations_count_and_names(self, tmp_path):
+        """The linear model should produce 5 operations matching the C++ trace."""
+        conn, cursor = self._import_linear_graph(tmp_path)
+
+        cursor.execute("SELECT operation_id, name FROM operations ORDER BY operation_id")
+        rows = cursor.fetchall()
+
+        assert len(rows) == 4, f"Expected 4 ops (nested child ops filtered), got {len(rows)}"
+        assert rows[0][1] == "ttnn.to_device"
+        assert rows[1][1] == "ttnn.to_device"
+        assert rows[2][1] == "ttnn.to_device"
+        assert rows[3][1] == "MatmulDeviceOperation"
+        conn.close()
+
+    def test_all_input_tensors_reference_valid_tensor_ids(self, tmp_path):
+        """
+        Regression: the old bug stored node counters (2, 8, 14, 6, 12, 18) as tensor_ids
+        in input_tensors. After the fix, they must resolve to real tensor_ids that exist
+        in the tensors table.
+        """
+        conn, cursor = self._import_linear_graph(tmp_path)
+
+        cursor.execute("SELECT tensor_id FROM tensors")
+        valid_tensor_ids = {row[0] for row in cursor.fetchall()}
+        valid_tensor_ids_int = {int(t) if isinstance(t, str) else t for t in valid_tensor_ids}
+
+        cursor.execute(
+            "SELECT operation_id, input_index, tensor_id FROM input_tensors ORDER BY operation_id, input_index"
+        )
+        input_rows = cursor.fetchall()
+
+        for op_id, idx, tid in input_rows:
+            tid_int = int(tid) if isinstance(tid, str) else tid
+            assert tid_int in valid_tensor_ids_int, (
+                f"input_tensors({op_id}, {idx}) references tensor_id={tid} which doesn't exist in tensors table. "
+                f"This is likely the old bug where node counters were stored instead of real tensor_ids. "
+                f"Valid tensor_ids: {sorted(valid_tensor_ids_int)}"
+            )
+        conn.close()
+
+    def test_matmul_input_tensors_are_device_tensors(self, tmp_path):
+        """
+        The MatmulDeviceOperation's input_tensors field has [6, 12, 18] (node counters
+        for the three device tensors). After resolution, these should become tensor_ids
+        1, 3, 5 — the device-side tensors from the three to_device operations.
+        """
+        conn, cursor = self._import_linear_graph(tmp_path)
+
+        cursor.execute("SELECT input_index, tensor_id FROM input_tensors WHERE operation_id = 4 ORDER BY input_index")
+        rows = cursor.fetchall()
+
+        assert len(rows) == 3, f"MatmulDeviceOperation should have 3 inputs, got {len(rows)}"
+        resolved_ids = [int(r[1]) if isinstance(r[1], str) else r[1] for r in rows]
+        assert resolved_ids == [1, 3, 5], (
+            f"Matmul inputs should be tensor_ids [1, 3, 5] (device tensors), "
+            f"not node counters [6, 12, 18]. Got {resolved_ids}"
+        )
+        conn.close()
+
+    def test_to_device_input_tensors_are_host_tensors(self, tmp_path):
+        """Each ttnn.to_device should take one host tensor as input."""
+        conn, cursor = self._import_linear_graph(tmp_path)
+
+        cursor.execute("SELECT operation_id, tensor_id FROM input_tensors WHERE operation_id < 4 ORDER BY operation_id")
+        rows = cursor.fetchall()
+
+        assert len(rows) == 3
+        resolved_ids = [int(r[1]) if isinstance(r[1], str) else r[1] for r in rows]
+        assert resolved_ids == [0, 2, 4], f"to_device inputs should be host tensor_ids [0, 2, 4], got {resolved_ids}"
+        conn.close()
+
+    def test_output_tensors_match_expected(self, tmp_path):
+        """Verify output tensor associations match the graph structure."""
+        conn, cursor = self._import_linear_graph(tmp_path)
+
+        cursor.execute(
+            "SELECT operation_id, output_index, tensor_id FROM output_tensors ORDER BY operation_id, output_index"
+        )
+        rows = cursor.fetchall()
+
+        output_map = {r[0]: int(r[2]) if isinstance(r[2], str) else r[2] for r in rows}
+        assert output_map[1] == 1, "to_device #1 output should be tensor 1"
+        assert output_map[2] == 3, "to_device #2 output should be tensor 3"
+        assert output_map[3] == 5, "to_device #3 output should be tensor 5"
+        assert output_map[4] == 7, "MatmulDeviceOperation output should be tensor 7"
+        conn.close()
+
+    def test_buffer_sizes_are_per_bank_not_total(self, tmp_path):
+        """
+        Regression: the correct DB has per-bank sizes (176128, 6144, 4096).
+        The old bug stored total sizes (2097152, 65536, 26624).
+        """
+        conn, cursor = self._import_linear_graph(tmp_path)
+
+        cursor.execute("SELECT address, max_size_per_bank FROM buffers ORDER BY address")
+        rows = cursor.fetchall()
+        buf_by_addr = {r[0]: r[1] for r in rows}
+
+        assert (
+            buf_by_addr[1920032] == 176128
+        ), f"1024x1024 bf16 DRAM buffer should be 176128/bank, got {buf_by_addr[1920032]}"
+        assert (
+            buf_by_addr[2096160] == 176128
+        ), f"1024x1024 bf16 DRAM buffer should be 176128/bank, got {buf_by_addr[2096160]}"
+        assert buf_by_addr[2272288] == 6144, f"1x1024 bf16 DRAM buffer should be 6144/bank, got {buf_by_addr[2272288]}"
+        assert (
+            buf_by_addr[2278432] == 176128
+        ), f"output 1024x1024 DRAM buffer should be 176128/bank, got {buf_by_addr[2278432]}"
+        assert (
+            buf_by_addr[1073737728] == 4096
+        ), f"matmul intermediate DRAM buffer should be 4096/bank, got {buf_by_addr[1073737728]}"
+        conn.close()
+
+    def test_buffers_are_cumulative_per_operation(self, tmp_path):
+        """
+        Regression: the correct DB has cumulative buffer snapshots per operation.
+        op 1: 1 buffer, op 2: 2 buffers, op 3: 3 buffers, op 4 (matmul): 5 buffers.
+        Nested create_device_tensor is filtered, its buffers still tracked.
+        """
+        conn, cursor = self._import_linear_graph(tmp_path)
+
+        cursor.execute("SELECT operation_id, COUNT(*) FROM buffers GROUP BY operation_id ORDER BY operation_id")
+        rows = cursor.fetchall()
+
+        expected_counts = {1: 1, 2: 2, 3: 3, 4: 5}
+        actual_counts = {r[0]: r[1] for r in rows}
+
+        assert actual_counts == expected_counts, (
+            f"Buffer counts should be cumulative per operation. " f"Expected {expected_counts}, got {actual_counts}"
+        )
+        conn.close()
+
+    def test_device_tensors_have_correct_addresses_and_device_ids(self, tmp_path):
+        """Device tensor addresses and device_ids should match the correct DB (mesh_device_id=1)."""
+        conn, cursor = self._import_linear_graph(tmp_path)
+
+        cursor.execute("SELECT tensor_id, device_id, address FROM device_tensors ORDER BY CAST(tensor_id AS INTEGER)")
+        rows = cursor.fetchall()
+
+        expected = [
+            (1, 0, 1920032),
+            (3, 0, 2096160),
+            (5, 0, 2272288),
+            (7, 0, 2278432),
+        ]
+        assert len(rows) == len(expected), f"Expected {len(expected)} device_tensors, got {len(rows)}"
+        for row, (exp_tid, exp_dev, exp_addr) in zip(rows, expected):
+            tid = int(row[0]) if isinstance(row[0], str) else row[0]
+            assert tid == exp_tid, f"Expected tensor_id {exp_tid}, got {tid}"
+            assert row[1] == exp_dev, f"Tensor {tid}: expected device_id {exp_dev}, got {row[1]}"
+            assert row[2] == exp_addr, f"Tensor {tid}: expected address {exp_addr}, got {row[2]}"
+        conn.close()
+
+    def test_tensor_count_and_shapes(self, tmp_path):
+        """7 unique tensors (3 host + 4 device, tensor_id 6 is skipped) with correct shapes."""
+        conn, cursor = self._import_linear_graph(tmp_path)
+
+        cursor.execute("SELECT tensor_id, shape FROM tensors ORDER BY CAST(tensor_id AS INTEGER)")
+        rows = cursor.fetchall()
+
+        assert len(rows) == 7, f"Expected 7 tensors (ids 0-5,7), got {len(rows)}"
+
+        shapes = {int(r[0]) if isinstance(r[0], str) else r[0]: r[1] for r in rows}
+        for tid in [0, 1, 2, 3, 7]:
+            assert "1024, 1024" in str(shapes[tid]), f"Tensor {tid} should be 1024x1024, got {shapes[tid]}"
+        for tid in [4, 5]:
+            assert "1, 1024" in str(shapes[tid]), f"Tensor {tid} should be 1x1024, got {shapes[tid]}"
+        conn.close()
+
+
+class TestGraphCaptureToFile:
+    """Tests for end_graph_capture_to_file API."""
+
+    def test_basic_capture_to_file(self, device, tmp_report_dir):
+        """Test basic graph capture to JSON file."""
+        report_path = tmp_report_dir / "report.json"
+
+        torch_input = torch.rand((1, 1, 32, 32), dtype=torch.bfloat16)
+        tt_input = ttnn.from_torch(torch_input, layout=ttnn.TILE_LAYOUT, device=device)
+
+        ttnn.graph.begin_graph_capture(ttnn.graph.RunMode.NORMAL)
+        _ = ttnn.relu(tt_input)
+        captured_graph = ttnn.graph.end_graph_capture_to_file(report_path)
+
+        # Verify file was created
+        assert report_path.exists(), "Report file should be created"
+
+        # Verify returned graph matches file contents
+        with open(report_path) as f:
+            report = json.load(f)
+
+        assert "graph" in report
+        assert "version" in report
+        assert report["graph"] == captured_graph
+
+    def test_report_contains_device_info(self, device, tmp_report_dir):
+        """Test that report contains device information."""
+        report_path = tmp_report_dir / "report.json"
+
+        torch_input = torch.rand((1, 1, 32, 32), dtype=torch.bfloat16)
+        tt_input = ttnn.from_torch(torch_input, layout=ttnn.TILE_LAYOUT, device=device)
+
+        ttnn.graph.begin_graph_capture(ttnn.graph.RunMode.NORMAL)
+        _ = ttnn.relu(tt_input)
+        _ = ttnn.graph.end_graph_capture_to_file(report_path)
+
+        with open(report_path) as f:
+            report = json.load(f)
+
+        assert "devices" in report
+        assert len(report["devices"]) > 0
+
+        # Check device has expected fields
+        dev = report["devices"][0]
+        assert "device_id" in dev
+        assert "arch" in dev
+
+    def test_report_contains_duration(self, device, tmp_report_dir):
+        """Test that function_end nodes contain duration."""
+        report_path = tmp_report_dir / "report.json"
+
+        torch_input = torch.rand((1, 1, 32, 32), dtype=torch.bfloat16)
+        tt_input = ttnn.from_torch(torch_input, layout=ttnn.TILE_LAYOUT, device=device)
+
+        ttnn.graph.begin_graph_capture(ttnn.graph.RunMode.NORMAL)
+        _ = ttnn.relu(tt_input)
+        captured_graph = ttnn.graph.end_graph_capture_to_file(report_path)
+
+        # Find function_end nodes
+        function_ends = [n for n in captured_graph if n.get("node_type") == "function_end"]
+        assert len(function_ends) > 0, "Should have function_end nodes"
+
+        # At least one should have duration
+        has_duration = any("duration_ns" in n for n in function_ends)
+        assert has_duration, "function_end nodes should have duration_ns"
+
+
+class TestDurationExtraction:
+    """Tests for duration extraction utilities."""
+
+    def test_extract_total_duration(self, device):
+        """Test extracting total capture duration."""
+        torch_input = torch.rand((1, 1, 32, 32), dtype=torch.bfloat16)
+        tt_input = ttnn.from_torch(torch_input, layout=ttnn.TILE_LAYOUT, device=device)
+
+        ttnn.graph.begin_graph_capture(ttnn.graph.RunMode.NORMAL)
+        _ = ttnn.relu(tt_input)
+        captured_graph = ttnn.graph.end_graph_capture()
+
+        duration = graph_report.extract_total_duration_from_graph(captured_graph)
+        assert isinstance(duration, float)
+        assert duration > 0, "relu should have a positive duration"
+
+    def test_extract_operation_durations(self, device):
+        """Test extracting per-operation durations."""
+        torch_input = torch.rand((1, 1, 32, 32), dtype=torch.bfloat16)
+        tt_input = ttnn.from_torch(torch_input, layout=ttnn.TILE_LAYOUT, device=device)
+
+        ttnn.graph.begin_graph_capture(ttnn.graph.RunMode.NORMAL)
+        _ = ttnn.relu(tt_input)
+        _ = ttnn.add(tt_input, tt_input)
+        captured_graph = ttnn.graph.end_graph_capture()
+
+        durations = graph_report.extract_operation_durations(captured_graph)
+        assert isinstance(durations, dict)
+        assert len(durations) >= 2, f"Should have at least 2 operation durations (relu, add), got {len(durations)}"
+        for name, dur in durations.items():
+            assert dur > 0, f"Duration for {name} should be positive"
+
+
+class TestGraphReportImport:
+    """Tests for the offline import functionality."""
+
+    def test_import_creates_database(self, device, tmp_report_dir):
+        """Test that import creates SQLite database."""
+        report_path = tmp_report_dir / "report.json"
+        db_dir = tmp_report_dir / "db"
+
+        torch_input = torch.rand((1, 1, 32, 32), dtype=torch.bfloat16)
+        tt_input = ttnn.from_torch(torch_input, layout=ttnn.TILE_LAYOUT, device=device)
+
+        ttnn.graph.begin_graph_capture(ttnn.graph.RunMode.NORMAL)
+        _ = ttnn.relu(tt_input)
+        _ = ttnn.graph.end_graph_capture_to_file(report_path)
+
+        db_path = graph_report.import_report(report_path, db_dir)
+
+        assert db_path.exists()
+        assert db_path.name == "db.sqlite"
+
+    def test_import_populates_tables(self, device, tmp_report_dir):
+        """Test that import populates all expected tables."""
+        report_path = tmp_report_dir / "report.json"
+        db_dir = tmp_report_dir / "db"
+
+        torch_input = torch.rand((1, 1, 32, 32), dtype=torch.bfloat16)
+        tt_input = ttnn.from_torch(torch_input, layout=ttnn.TILE_LAYOUT, device=device)
+
+        ttnn.graph.begin_graph_capture(ttnn.graph.RunMode.NORMAL)
+        _ = ttnn.relu(tt_input)
+        _ = ttnn.graph.end_graph_capture_to_file(report_path)
+
+        db_path = graph_report.import_report(report_path, db_dir)
+
+        conn = sqlite3.connect(db_path)
+        cursor = conn.cursor()
+
+        cursor.execute("SELECT COUNT(*) FROM devices")
+        assert cursor.fetchone()[0] >= 1, "devices table should have at least 1 device"
+
+        cursor.execute("SELECT COUNT(*) FROM operations")
+        op_count = cursor.fetchone()[0]
+        assert op_count >= 1, f"operations table should have at least 1 operation (relu), got {op_count}"
+
+        cursor.execute("SELECT COUNT(*) FROM captured_graph")
+        cg_count = cursor.fetchone()[0]
+        assert cg_count >= 1, f"captured_graph should have at least 1 entry, got {cg_count}"
+
+        cursor.execute("SELECT COUNT(*) FROM tensors")
+        assert cursor.fetchone()[0] >= 1, "tensors table should have at least 1 tensor"
+
+        conn.close()
+
+
+class TestReportVersion:
+    """Tests for report version handling."""
+
+    def test_version_constant_exposed(self):
+        """Test that REPORT_VERSION is exposed."""
+        assert hasattr(ttnn.graph, "REPORT_VERSION")
+        assert isinstance(ttnn.graph.REPORT_VERSION, int)
+        assert ttnn.graph.REPORT_VERSION >= 1
+
+    def test_report_has_matching_version(self, device, tmp_report_dir):
+        """Test that generated reports have correct version."""
+        report_path = tmp_report_dir / "report.json"
+
+        torch_input = torch.rand((1, 1, 32, 32), dtype=torch.bfloat16)
+        tt_input = ttnn.from_torch(torch_input, layout=ttnn.TILE_LAYOUT, device=device)
+
+        ttnn.graph.begin_graph_capture(ttnn.graph.RunMode.NORMAL)
+        _ = ttnn.relu(tt_input)
+        _ = ttnn.graph.end_graph_capture_to_file(report_path)
+
+        with open(report_path) as f:
+            report = json.load(f)
+
+        assert report["version"] == ttnn.graph.REPORT_VERSION
+
+
+class TestResNet50Patterns:
+    """
+    Tests for patterns observed in the ResNet50 reference database:
+    - Host weight tensors used as inputs to conv2d operations
+    - Deallocate operations (no output tensors)
+    - Multiple buffer types and layouts (DRAM, L1, L1_SMALL)
+    - Large number of cumulative buffers per operation
+    - Operations with multiple input/output tensors
+    """
+
+    MOCK_RESNET_GRAPH = [
+        # capture_start
+        {"counter": 0, "node_type": "capture_start", "params": {}, "connections": [1, 7, 13, 19, 25]},
+        # Op 1: ttnn.to_device (host tensor -> device tensor)
+        {
+            "counter": 1,
+            "node_type": "function_start",
+            "params": {"name": "ttnn.to_device", "inputs": "1"},
+            "connections": [],
+            "input_tensors": [2],
+        },
+        {
+            "counter": 2,
+            "node_type": "tensor",
+            "params": {
+                "tensor_id": "0",
+                "shape": "Shape([64, 16, 4, 4])",
+                "dtype": "DataType::FLOAT32",
+                "layout": "Layout::ROW_MAJOR",
+            },
+            "connections": [],
+        },
+        {
+            "counter": 3,
+            "node_type": "buffer_allocate",
+            "params": {"size": "65536", "type": "DRAM", "layout": "INTERLEAVED", "device_id": "0", "address": "1000"},
+            "connections": [],
+        },
+        {
+            "counter": 4,
+            "node_type": "tensor",
+            "params": {
+                "tensor_id": "1",
+                "shape": "Shape([64, 16, 4, 4])",
+                "dtype": "DataType::BFLOAT16",
+                "layout": "Layout::TILE",
+                "device_id": "0",
+                "address": "1000",
+                "buffer_type": "DRAM",
+                "memory_config": "MemoryConfig(DRAM)",
+            },
+            "connections": [],
+        },
+        {
+            "counter": 5,
+            "node_type": "function_end",
+            "params": {"name": "ttnn.to_device"},
+            "connections": [4],
+            "duration_ns": 100,
+        },
+        # Op 2: conv2d (host weight + device activation -> device output)
+        {
+            "counter": 6,
+            "node_type": "tensor",
+            "params": {
+                "tensor_id": "10",
+                "shape": "Shape([64, 64, 3, 3])",
+                "dtype": "DataType::FLOAT32",
+                "layout": "Layout::ROW_MAJOR",
+            },
+            "connections": [],
+        },
+        {
+            "counter": 7,
+            "node_type": "function_start",
+            "params": {"name": "ttnn::conv2d", "inputs": "3"},
+            "connections": [],
+            "input_tensors": [4, 6],
+            "arguments": ["activation_tensor", "weight_tensor", "bias_tensor"],
+        },
+        {
+            "counter": 8,
+            "node_type": "buffer_allocate",
+            "params": {"size": "176128", "type": "DRAM", "layout": "INTERLEAVED", "device_id": "0", "address": "2000"},
+            "connections": [],
+        },
+        {
+            "counter": 9,
+            "node_type": "buffer_allocate",
+            "params": {
+                "size": "4096",
+                "type": "L1",
+                "layout": "HEIGHT_SHARDED",
+                "device_id": "0",
+                "address": "5000",
+                "num_cores": "64",
+            },
+            "connections": [],
+        },
+        {
+            "counter": 10,
+            "node_type": "tensor",
+            "params": {
+                "tensor_id": "2",
+                "shape": "Shape([1, 1, 3136, 64])",
+                "dtype": "DataType::BFLOAT16",
+                "layout": "Layout::TILE",
+                "device_id": "0",
+                "address": "2000",
+                "buffer_type": "DRAM",
+                "memory_config": "MemoryConfig(DRAM)",
+            },
+            "connections": [],
+        },
+        {
+            "counter": 11,
+            "node_type": "function_end",
+            "params": {"name": "ttnn::conv2d"},
+            "connections": [10],
+            "duration_ns": 5000,
+        },
+        # Op 3: add_ (two device tensors -> device output)
+        {
+            "counter": 12,
+            "node_type": "tensor",
+            "params": {
+                "tensor_id": "3",
+                "shape": "Shape([1, 1, 3136, 64])",
+                "dtype": "DataType::BFLOAT16",
+                "layout": "Layout::TILE",
+                "device_id": "0",
+                "address": "3000",
+                "buffer_type": "L1",
+                "memory_config": "MemoryConfig(L1)",
+            },
+            "connections": [],
+        },
+        {
+            "counter": 13,
+            "node_type": "function_start",
+            "params": {"name": "ttnn::add_", "inputs": "2"},
+            "connections": [],
+            "input_tensors": [10, 12],
+        },
+        {
+            "counter": 14,
+            "node_type": "buffer_allocate",
+            "params": {"size": "8192", "type": "L1", "layout": "INTERLEAVED", "device_id": "0", "address": "4000"},
+            "connections": [],
+        },
+        {
+            "counter": 15,
+            "node_type": "tensor",
+            "params": {
+                "tensor_id": "4",
+                "shape": "Shape([1, 1, 3136, 64])",
+                "dtype": "DataType::BFLOAT16",
+                "layout": "Layout::TILE",
+                "device_id": "0",
+                "address": "4000",
+                "buffer_type": "L1",
+                "memory_config": "MemoryConfig(L1)",
+            },
+            "connections": [],
+        },
+        {
+            "counter": 16,
+            "node_type": "function_end",
+            "params": {"name": "ttnn::add_"},
+            "connections": [15],
+            "duration_ns": 200,
+        },
+        # Deallocate: C++ only emits buffer_deallocate (function tracking is not wrapped).
+        # The importer synthesizes an operation from this node.
+        # connections points to the buffer node (counter 8) which connects to tensor (counter 10).
+        {
+            "counter": 17,
+            "node_type": "buffer_deallocate",
+            "params": {"address": "2000", "size": "176128", "type": "DRAM", "device_id": "0"},
+            "connections": [8],
+        },
+        # capture_end
+        {"counter": 25, "node_type": "capture_end", "params": {}, "connections": []},
+    ]
+
+    MOCK_DEVICE_INFO = [
+        {
+            "device_id": 0,
+            "num_dram_channels": 12,
+            "l1_num_banks": 64,
+            "num_y_cores": 8,
+            "num_x_cores": 8,
+            "num_y_compute_cores": 8,
+            "num_x_compute_cores": 8,
+            "num_storage_cores": 0,
+            "worker_l1_size": 1499136,
+            "l1_bank_size": 23424,
+        }
+    ]
+
+    def _import_resnet(self, tmp_path):
+        report = _make_report(self.MOCK_RESNET_GRAPH, devices=self.MOCK_DEVICE_INFO)
+        return _import_to_db(report, tmp_path)
+
+    def test_host_weight_tensors_kept_in_compatible_mode(self, tmp_path):
+        """Host weight tensors referenced as inputs must be preserved in compatible mode."""
+        conn, cursor = self._import_resnet(tmp_path)
+
+        cursor.execute("SELECT tensor_id, device_id FROM tensors WHERE device_id IS NULL")
+        host_tensors = cursor.fetchall()
+        # tensor_id 0 (input to to_device) + tensor_id 10 (conv2d weight)
+        assert (
+            len(host_tensors) == 2
+        ), f"Expected 2 host tensors (to_device input + conv weight), got {len(host_tensors)}"
+
+        # Verify each host tensor is referenced in input_tensors
+        for tid, _ in host_tensors:
+            tid_int = int(tid) if isinstance(tid, str) else tid
+            cursor.execute("SELECT COUNT(*) FROM input_tensors WHERE tensor_id = ?", (tid_int,))
+            refs = cursor.fetchone()[0]
+            assert refs > 0, f"Host tensor {tid} should be referenced in input_tensors"
+        conn.close()
+
+    def test_deallocate_ops_have_no_output_tensors(self, tmp_path):
+        """Deallocate operations should have input tensors but no output tensors."""
+        conn, cursor = self._import_resnet(tmp_path)
+
+        cursor.execute("SELECT operation_id, name FROM operations WHERE name LIKE '%deallocate%'")
+        dealloc_ops = cursor.fetchall()
+        assert len(dealloc_ops) == 1, f"Expected 1 deallocate op, got {len(dealloc_ops)}"
+
+        op_id = dealloc_ops[0][0]
+
+        cursor.execute("SELECT COUNT(*) FROM input_tensors WHERE operation_id = ?", (op_id,))
+        input_count = cursor.fetchone()[0]
+        assert input_count == 1, f"Deallocate should have 1 input, got {input_count}"
+
+        cursor.execute("SELECT COUNT(*) FROM output_tensors WHERE operation_id = ?", (op_id,))
+        output_count = cursor.fetchone()[0]
+        assert output_count == 0, f"Deallocate should have 0 outputs, got {output_count}"
+        conn.close()
+
+    def test_conv2d_has_host_and_device_inputs(self, tmp_path):
+        """Conv2d should accept both host weight tensors and device activation tensors as inputs."""
+        conn, cursor = self._import_resnet(tmp_path)
+
+        cursor.execute("SELECT operation_id FROM operations WHERE name = 'ttnn::conv2d'")
+        conv_op = cursor.fetchone()
+        assert conv_op is not None, "Should have a conv2d operation"
+
+        cursor.execute(
+            """
+            SELECT t.tensor_id, t.device_id
+            FROM input_tensors it JOIN tensors t ON it.tensor_id = t.tensor_id
+            WHERE it.operation_id = ?
+            ORDER BY it.input_index
+        """,
+            (conv_op[0],),
+        )
+        inputs = cursor.fetchall()
+
+        device_inputs = [r for r in inputs if r[1] is not None]
+        host_inputs = [r for r in inputs if r[1] is None]
+        assert len(device_inputs) >= 1, f"Conv2d should have at least 1 device input, got {len(device_inputs)}"
+        assert len(host_inputs) >= 1, f"Conv2d should have at least 1 host weight input, got {len(host_inputs)}"
+        conn.close()
+
+    def test_multiple_buffer_types(self, tmp_path):
+        """Buffers should support DRAM and L1 buffer types."""
+        conn, cursor = self._import_resnet(tmp_path)
+
+        cursor.execute("SELECT DISTINCT buffer_type FROM buffers ORDER BY buffer_type")
+        type_values = {r[0] for r in cursor.fetchall()}
+        assert len(type_values) >= 2, f"Should have at least DRAM and L1 buffer types, got {type_values}"
+        assert 0 in type_values, "Missing buffer_type 0 (DRAM)"
+        assert 1 in type_values, "Missing buffer_type 1 (L1)"
+        conn.close()
+
+    def test_cumulative_buffers_reflect_allocations_and_deallocations(self, tmp_path):
+        """
+        Buffer counts should grow with allocations and shrink with deallocations.
+        Op 1 (to_device): 1 DRAM buffer allocated -> 1 total
+        Op 2 (conv2d): 2 more buffers (DRAM + L1) -> 3 total
+        Op 3 (add_): 1 more L1 buffer -> 4 total
+        Op 4 (deallocate): 1 DRAM buffer deallocated before op -> 3 total
+        """
+        conn, cursor = self._import_resnet(tmp_path)
+
+        cursor.execute(
+            """
+            SELECT operation_id, COUNT(*) FROM buffers
+            GROUP BY operation_id ORDER BY operation_id
+        """
+        )
+        rows = cursor.fetchall()
+        counts_by_op = {r[0]: r[1] for r in rows}
+        assert len(counts_by_op) >= 3, f"Should have at least 3 ops with buffers, got {len(counts_by_op)}"
+
+        op_ids = sorted(counts_by_op.keys())
+        assert counts_by_op[op_ids[0]] == 1, f"First op should have 1 buffer, got {counts_by_op[op_ids[0]]}"
+        assert counts_by_op[op_ids[1]] == 3, f"Second op should have 3 buffers, got {counts_by_op[op_ids[1]]}"
+        assert counts_by_op[op_ids[2]] == 4, f"Third op should have 4 buffers, got {counts_by_op[op_ids[2]]}"
+        if len(op_ids) >= 4:
+            assert (
+                counts_by_op[op_ids[3]] == 3
+            ), f"Fourth op (post-dealloc) should have 3 buffers, got {counts_by_op[op_ids[3]]}"
+        conn.close()
+
+    def test_captured_graph_per_operation(self, tmp_path):
+        """Each operation should have a captured_graph entry."""
+        conn, cursor = self._import_resnet(tmp_path)
+
+        cursor.execute("SELECT COUNT(*) FROM operations")
+        op_count = cursor.fetchone()[0]
+        cursor.execute("SELECT COUNT(*) FROM captured_graph")
+        cg_count = cursor.fetchone()[0]
+        assert cg_count == op_count, f"Expected {op_count} captured_graph rows, got {cg_count}"
+        conn.close()
+
+    def test_operation_ids_start_at_one(self, tmp_path):
+        """Operation IDs should start at 1 (1-based indexing)."""
+        conn, cursor = self._import_resnet(tmp_path)
+
+        cursor.execute("SELECT MIN(operation_id), MAX(operation_id), COUNT(*) FROM operations")
+        min_id, max_id, count = cursor.fetchone()
+        assert min_id == 1, f"First operation_id should be 1, got {min_id}"
+        conn.close()
+
+    def test_all_input_output_tensors_reference_valid_ids(self, tmp_path):
+        """All tensor references in input/output tables should exist in the tensors table."""
+        conn, cursor = self._import_resnet(tmp_path)
+
+        cursor.execute("SELECT tensor_id FROM tensors")
+        valid_ids = {int(r[0]) if isinstance(r[0], str) else r[0] for r in cursor.fetchall()}
+
+        cursor.execute("SELECT operation_id, tensor_id FROM input_tensors")
+        for op_id, tid in cursor.fetchall():
+            tid_int = int(tid) if isinstance(tid, str) else tid
+            assert tid_int in valid_ids, f"input_tensors op={op_id} references tensor {tid} not in tensors table"
+
+        cursor.execute("SELECT operation_id, tensor_id FROM output_tensors")
+        for op_id, tid in cursor.fetchall():
+            tid_int = int(tid) if isinstance(tid, str) else tid
+            assert tid_int in valid_ids, f"output_tensors op={op_id} references tensor {tid} not in tensors table"
+        conn.close()
+
+
+@pytest.mark.skipif(not is_wormhole_b0(), reason="Requires Wormhole B0")
+class TestLinearModelE2E:
+    """
+    End-to-end test: run ttnn.ones + ttnn.linear on real hardware,
+    capture graph to JSON, import to SQLite, and validate structural properties.
+    """
+
+    def test_linear_model_structural_properties(self, device, tmp_path):
+        report_path = tmp_path / "linear_report.json"
+
+        with ttnn.manage_config("enable_fast_runtime_mode", False), ttnn.manage_config(
+            "enable_logging", True
+        ), ttnn.manage_config("enable_graph_report", True):
+            ttnn.graph.begin_graph_capture(ttnn.graph.RunMode.NORMAL)
+            a = ttnn.ones([1024, 1024], layout=ttnn.TILE_LAYOUT, device=device)
+            b = ttnn.ones([1024, 1024], layout=ttnn.TILE_LAYOUT, device=device)
+            c = ttnn.ones([1, 1024], layout=ttnn.TILE_LAYOUT, device=device)
+            ttnn.linear(a, b, bias=c)
+            ttnn.graph.end_graph_capture_to_file(report_path)
+
+        assert report_path.exists(), "Report JSON should be created"
+
+        output_dir = tmp_path / "output"
+        db_path = graph_report.import_report(report_path, output_dir)
+        assert db_path.exists(), "Imported DB should be created"
+
+        conn = sqlite3.connect(db_path)
+        c = conn.cursor()
+
+        c.execute("SELECT COUNT(*) FROM operations")
+        op_count = c.fetchone()[0]
+        assert op_count >= 4, f"Expected at least 4 operations, got {op_count}"
+
+        c.execute("SELECT COUNT(*) FROM tensors WHERE device_id IS NOT NULL")
+        device_count = c.fetchone()[0]
+        assert device_count >= 4, f"Expected at least 4 device tensors, got {device_count}"
+
+        c.execute("SELECT COUNT(*) FROM input_tensors")
+        input_count = c.fetchone()[0]
+        assert input_count >= 3, f"Expected at least 3 input_tensor rows, got {input_count}"
+
+        c.execute("SELECT COUNT(*) FROM output_tensors")
+        output_count = c.fetchone()[0]
+        assert output_count >= 4, f"Expected at least 4 output_tensor rows, got {output_count}"
+
+        c.execute(
+            """
+            SELECT COUNT(*) FROM input_tensors it
+            LEFT JOIN tensors t ON it.tensor_id = t.tensor_id
+            WHERE t.tensor_id IS NULL
+        """
+        )
+        dangling = c.fetchone()[0]
+        assert dangling == 0, f"{dangling} dangling input_tensors references"
+
+        c.execute(
+            """
+            SELECT COUNT(*) FROM output_tensors ot
+            LEFT JOIN tensors t ON ot.tensor_id = t.tensor_id
+            WHERE t.tensor_id IS NULL
+        """
+        )
+        dangling = c.fetchone()[0]
+        assert dangling == 0, f"{dangling} dangling output_tensors references"
+
+        c.execute("SELECT COUNT(*) FROM buffers")
+        buf_count = c.fetchone()[0]
+        assert buf_count >= 5, f"Expected at least 5 buffer rows, got {buf_count}"
+
+        c.execute("SELECT max_size_per_bank FROM buffers")
+        for (size,) in c.fetchall():
+            assert size < 10_000_000, f"max_size_per_bank={size} looks like a total size, not per-bank"
+
+        c.execute("SELECT COUNT(*) FROM captured_graph")
+        cg_count = c.fetchone()[0]
+        assert cg_count == op_count, f"Expected {op_count} captured_graph rows, got {cg_count}"
+
+        c.execute("SELECT COUNT(*) FROM stack_traces")
+        st_count = c.fetchone()[0]
+        assert st_count > 0, f"Expected at least one stack_trace row (from Python), got {st_count}"
+
+        conn.close()
+
+
+@pytest.fixture
+def imagenet_label_dict():
+    import ast
+
+    path = Path("models/sample_data/imagenet_class_labels.txt")
+    assert path.exists(), f"ImageNet labels not found at {path}"
+    with open(path, "r") as f:
+        return ast.literal_eval(f.read())
+
+
+@pytest.mark.skipif(not is_wormhole_b0(), reason="Requires Wormhole B0")
+@pytest.mark.skipif(is_simulator(), reason="ResNet-50 uses ops unsupported by ttsim")
+@pytest.mark.timeout(600)
+@pytest.mark.parametrize("device_params", [{"l1_small_size": 24576}], indirect=True)
+@pytest.mark.parametrize(
+    "batch_size, input_loc",
+    ((16, "models/demos/vision/classification/resnet50/ttnn_resnet/demo/images/"),),
+)
+def test_resnet50_e2e_graph_capture(
+    mesh_device, batch_size, input_loc, imagenet_label_dict, model_location_generator, tmp_path
+):
+    """Run ResNet50 inference, capture graph, import to DB, and validate structural properties."""
+    import shutil
+
+    from models.demos.vision.classification.resnet50.ttnn_resnet.demo.demo import run_resnet_inference
+
+    report_path = tmp_path / "resnet50_report.json"
+
+    with ttnn.manage_config("enable_fast_runtime_mode", False):
+        ttnn.graph.begin_graph_capture(ttnn.graph.RunMode.NORMAL)
+        run_resnet_inference(batch_size, input_loc, imagenet_label_dict, mesh_device, model_location_generator)
+        ttnn.graph.end_graph_capture_to_file(report_path)
+
+    assert report_path.exists(), "Report JSON should be created"
+
+    output_dir = tmp_path / "output"
+    db_path = graph_report.import_report(report_path, output_dir)
+    assert db_path.exists(), "Imported DB should be created"
+
+    shutil.copy2(db_path, "/tmp/db.sqlite")
+
+    conn = sqlite3.connect(db_path)
+    c = conn.cursor()
+
+    c.execute("SELECT COUNT(*) FROM operations")
+    op_count = c.fetchone()[0]
+    assert op_count >= 300, f"Expected at least 300 operations, got {op_count}"
+
+    c.execute("SELECT name, COUNT(*) FROM operations GROUP BY name ORDER BY COUNT(*) DESC")
+    op_dist = dict(c.fetchall())
+    assert op_dist.get("ttnn.conv2d", 0) == 159, f"Expected 159 conv2d ops, got {op_dist.get('ttnn.conv2d', 0)}"
+    assert (
+        op_dist.get("ttnn.deallocate", 0) == 51
+    ), f"Expected 51 deallocate ops, got {op_dist.get('ttnn.deallocate', 0)}"
+    assert op_dist.get("ttnn.add_", 0) == 48, f"Expected 48 add_ ops, got {op_dist.get('ttnn.add_', 0)}"
+
+    c.execute("SELECT COUNT(*) FROM tensors WHERE device_id IS NULL")
+    host_count = c.fetchone()[0]
+    assert host_count > 0, "Expected host tensors (weights)"
+
+    c.execute("SELECT COUNT(*) FROM tensors WHERE device_id IS NOT NULL")
+    device_count = c.fetchone()[0]
+    assert device_count > 0, "Expected device tensors"
+
+    c.execute("SELECT COUNT(*) FROM input_tensors")
+    input_count = c.fetchone()[0]
+    assert input_count >= 600, f"Expected at least 600 input_tensor rows, got {input_count}"
+
+    c.execute("SELECT COUNT(*) FROM output_tensors")
+    output_count = c.fetchone()[0]
+    assert output_count >= 300, f"Expected at least 300 output_tensor rows, got {output_count}"
+
+    c.execute(
+        """
+        SELECT COUNT(*) FROM input_tensors it
+        LEFT JOIN tensors t ON it.tensor_id = t.tensor_id
+        WHERE t.tensor_id IS NULL
+    """
+    )
+    dangling = c.fetchone()[0]
+    assert dangling == 0, f"{dangling} dangling input_tensors references"
+
+    c.execute(
+        """
+        SELECT COUNT(*) FROM output_tensors ot
+        LEFT JOIN tensors t ON ot.tensor_id = t.tensor_id
+        WHERE t.tensor_id IS NULL
+    """
+    )
+    dangling = c.fetchone()[0]
+    assert dangling == 0, f"{dangling} dangling output_tensors references"
+
+    c.execute(
+        """
+        SELECT COUNT(*) FROM operations o
+        WHERE o.name = 'ttnn.deallocate'
+        AND EXISTS (SELECT 1 FROM input_tensors it WHERE it.operation_id = o.operation_id)
+        AND NOT EXISTS (SELECT 1 FROM output_tensors ot WHERE ot.operation_id = o.operation_id)
+    """
+    )
+    dealloc_correct = c.fetchone()[0]
+    assert dealloc_correct == 51, f"Expected 51 deallocate ops with input+no-output, got {dealloc_correct}"
+
+    c.execute("SELECT COUNT(*) FROM buffers")
+    buf_count = c.fetchone()[0]
+    assert buf_count > 0, "Expected non-zero buffers"
+
+    c.execute("SELECT COUNT(*) FROM captured_graph")
+    cg_count = c.fetchone()[0]
+    assert cg_count == op_count, f"Expected {op_count} captured_graph rows, got {cg_count}"
+
+    c.execute("SELECT COUNT(*) FROM stack_traces")
+    st_count = c.fetchone()[0]
+    assert st_count > 0, f"Expected at least one stack_trace row (from Python), got {st_count}"
+
+    conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for Python-level graph helpers (graph.py)
+# ---------------------------------------------------------------------------
+class TestSafeArgStr:
+    """Tests for ttnn.graph._safe_arg_str - safe argument stringification."""
+
+    def test_plain_int(self):
+        from ttnn.graph import _safe_arg_str
+
+        assert _safe_arg_str(42) == "42"
+
+    def test_plain_string(self):
+        from ttnn.graph import _safe_arg_str
+
+        assert _safe_arg_str("hello") == "hello"
+
+    def test_plain_float(self):
+        from ttnn.graph import _safe_arg_str
+
+        assert _safe_arg_str(3.14) == "3.14"
+
+    def test_none(self):
+        from ttnn.graph import _safe_arg_str
+
+        assert _safe_arg_str(None) == "None"
+
+    def test_bool(self):
+        from ttnn.graph import _safe_arg_str
+
+        assert _safe_arg_str(True) == "True"
+
+    def test_torch_tensor(self):
+        from ttnn.graph import _safe_arg_str
+
+        t = torch.randn(2, 3)
+        result = _safe_arg_str(t)
+        assert "torch.Tensor" in result
+        assert "[2, 3]" in result
+        assert "float32" in result
+
+    def test_torch_tensor_does_not_print_data(self):
+        from ttnn.graph import _safe_arg_str
+
+        t = torch.randn(100, 100)
+        result = _safe_arg_str(t)
+        assert len(result) < 200, "Should be compact, not the full tensor data"
+
+    def test_list_not_recursed(self):
+        from ttnn.graph import _safe_arg_str
+
+        result = _safe_arg_str([1, 2, 3])
+        assert result == "[1, 2, 3]"
+
+    def test_enum_value(self):
+        from ttnn.graph import _safe_arg_str
+
+        result = _safe_arg_str(ttnn.TILE_LAYOUT)
+        assert "TILE" in result
+
+
+class TestRecordPythonOperation:
+    """Tests for ttnn.graph.record_python_operation."""
+
+    def setup_method(self):
+        import ttnn.graph as g
+
+        g._python_io_data = []
+        g.enable_python_stack_traces()
+
+    def test_records_kwargs(self):
+        import ttnn.graph as g
+
+        g.record_python_operation("ttnn.relu", (), {"memory_config": "DRAM"})
+        assert len(g._python_io_data) == 1
+        entry = g._python_io_data[0]
+        assert entry["name"] == "ttnn.relu"
+        assert entry["arguments"]["memory_config"] == "DRAM"
+
+    def test_records_positional_args(self):
+        import ttnn.graph as g
+
+        g.record_python_operation("ttnn.add", (10, 20), {})
+        entry = g._python_io_data[0]
+        assert entry["arguments"]["0"] == "10"
+        assert entry["arguments"]["1"] == "20"
+
+    def test_mixed_args_and_kwargs(self):
+        import ttnn.graph as g
+
+        g.record_python_operation("ttnn.linear", ("pos0",), {"bias": "bias_val"})
+        entry = g._python_io_data[0]
+        assert entry["arguments"]["0"] == "pos0"
+        assert entry["arguments"]["bias"] == "bias_val"
+
+    def test_torch_tensor_arg_compact(self):
+        import ttnn.graph as g
+
+        t = torch.randn(4, 8)
+        g.record_python_operation("ttnn.from_torch", (t,), {})
+        entry = g._python_io_data[0]
+        val = entry["arguments"]["0"]
+        assert "torch.Tensor" in val
+        assert "[4, 8]" in val
+
+    def test_multiple_records_append(self):
+        import ttnn.graph as g
+
+        g.record_python_operation("op1", (), {})
+        g.record_python_operation("op2", (), {})
+        g.record_python_operation("op3", (), {})
+        assert len(g._python_io_data) == 3
+        assert [e["name"] for e in g._python_io_data] == ["op1", "op2", "op3"]
+
+    def test_empty_args(self):
+        import ttnn.graph as g
+
+        g.record_python_operation("ttnn.deallocate", (), {})
+        entry = g._python_io_data[0]
+        assert entry["arguments"] == {}
+
+    def test_python_stack_trace_captured_when_enabled(self):
+        import ttnn.graph as g
+
+        g.enable_python_stack_traces()
+        try:
+            g.record_python_operation("ttnn.relu", (), {"x": "val"})
+            entry = g._python_io_data[0]
+            assert "python_stack_trace" in entry
+            assert len(entry["python_stack_trace"]) > 0
+            joined = "\n".join(entry["python_stack_trace"])
+            assert "test_graph_report.py" in joined
+        finally:
+            g.disable_python_stack_traces()
+
+    def test_python_stack_trace_absent_when_disabled(self):
+        import ttnn.graph as g
+
+        g.disable_python_stack_traces()
+        g.record_python_operation("ttnn.relu", (), {})
+        entry = g._python_io_data[0]
+        assert "python_stack_trace" not in entry
+
+    def test_python_stack_trace_filters_internals(self):
+        import ttnn.graph as g
+
+        g.enable_python_stack_traces()
+        try:
+            g.record_python_operation("ttnn.add", (1,), {})
+            entry = g._python_io_data[0]
+            joined = "\n".join(entry["python_stack_trace"])
+            assert "graph.py" not in joined, "Internal graph.py frames should be filtered"
+            assert "decorators.py" not in joined, "Internal decorators.py frames should be filtered"
+        finally:
+            g.disable_python_stack_traces()
+
+    def test_enable_disable_toggle(self):
+        import ttnn.graph as g
+
+        assert g.is_python_stack_trace_enabled()
+        g.disable_python_stack_traces()
+        assert not g.is_python_stack_trace_enabled()
+        g.enable_python_stack_traces()
+        assert g.is_python_stack_trace_enabled()
+
+
+class TestStoreCapturedGraph:
+    """Tests for ttnn.graph.store_captured_graph."""
+
+    def setup_method(self):
+        import ttnn.graph as g
+
+        g._python_io_data = []
+
+    def test_attaches_to_last_entry(self):
+        import ttnn.graph as g
+
+        g._python_io_data.append({"name": "op1"})
+        g._python_io_data.append({"name": "op2"})
+        mock_cg = [{"node_type": "capture_start"}]
+        g.store_captured_graph(mock_cg)
+        assert "captured_graph" not in g._python_io_data[0]
+        assert g._python_io_data[1]["captured_graph"] == mock_cg
+
+    def test_noop_on_empty_list(self):
+        import ttnn.graph as g
+
+        g.store_captured_graph([{"node_type": "capture_start"}])
+        assert len(g._python_io_data) == 0
+
+    def test_overwrites_existing(self):
+        import ttnn.graph as g
+
+        g._python_io_data.append({"name": "op1", "captured_graph": "old"})
+        g.store_captured_graph("new")
+        assert g._python_io_data[0]["captured_graph"] == "new"
+
+
+class TestBeginGraphCaptureClearing:
+    """Tests for begin_graph_capture clearing behavior."""
+
+    def test_clears_python_io_when_not_active(self):
+        import ttnn.graph as g
+
+        g._python_io_data = [{"name": "stale"}]
+        g.begin_graph_capture(ttnn.graph.RunMode.NORMAL)
+        assert g._python_io_data == []
+        ttnn.graph.end_graph_capture()
+
+    def test_preserves_python_io_when_active(self):
+        import ttnn.graph as g
+
+        g.begin_graph_capture(ttnn.graph.RunMode.NORMAL)
+        g._python_io_data = [{"name": "keep_me"}]
+        g.begin_graph_capture(ttnn.graph.RunMode.NORMAL)
+        assert len(g._python_io_data) == 1
+        assert g._python_io_data[0]["name"] == "keep_me"
+        ttnn.graph.end_graph_capture()
+        ttnn.graph.end_graph_capture()
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for graph_report.py import_graph - new features
+# ---------------------------------------------------------------------------
+class TestPythonIOArgumentImport:
+    """Tests that python_io arguments are preferred over C++ arguments."""
+
+    def test_python_io_arguments_used_when_present(self, tmp_path):
+        """When python_io has arguments, they should be used instead of C++ ones."""
+        mock_graph = [
+            {"counter": 0, "node_type": "capture_start", "params": {}, "connections": [1, 3]},
+            {
+                "counter": 1,
+                "node_type": "function_start",
+                "params": {"name": "ttnn.relu"},
+                "connections": [],
+                "input_tensors": [],
+                "arguments": ["cpp_arg0", "cpp_arg1"],
+            },
+            {
+                "counter": 2,
+                "node_type": "function_end",
+                "params": {"name": "ttnn.relu"},
+                "connections": [],
+                "duration_ns": 100,
+            },
+            {"counter": 3, "node_type": "capture_end", "params": {}, "connections": []},
+        ]
+        python_io = [
+            {
+                "name": "ttnn.relu",
+                "arguments": {"0": "ttnn.Tensor(shape=[1,32], dtype=bfloat16)", "memory_config": "DRAM"},
+                "input_tensor_ids": [],
+            }
+        ]
+
+        report = _make_report(mock_graph, python_io=python_io)
+        conn, cursor = _import_to_db(report, tmp_path)
+
+        cursor.execute("SELECT name, value FROM operation_arguments ORDER BY name")
+        rows = cursor.fetchall()
+        values = {r[0]: r[1] for r in rows}
+
+        assert "memory_config" in values, "Named kwarg should appear"
+        assert values["memory_config"] == "DRAM"
+        assert values["0"] == "ttnn.Tensor(shape=[1,32], dtype=bfloat16)"
+        assert "cpp_arg0" not in [r[1] for r in rows], "C++ args should be overridden"
+        conn.close()
+
+    def test_cpp_arguments_fallback_when_no_python_io(self, tmp_path):
+        """When no python_io is provided, C++ arguments should be used."""
+        mock_graph = [
+            {"counter": 0, "node_type": "capture_start", "params": {}, "connections": [1, 3]},
+            {
+                "counter": 1,
+                "node_type": "function_start",
+                "params": {"name": "ttnn.relu"},
+                "connections": [],
+                "input_tensors": [],
+                "arguments": ["tensor_a", "alpha=1.0"],
+            },
+            {
+                "counter": 2,
+                "node_type": "function_end",
+                "params": {"name": "ttnn.relu"},
+                "connections": [],
+                "duration_ns": 100,
+            },
+            {"counter": 3, "node_type": "capture_end", "params": {}, "connections": []},
+        ]
+
+        report = _make_report(mock_graph)
+        conn, cursor = _import_to_db(report, tmp_path)
+
+        cursor.execute("SELECT name, value FROM operation_arguments ORDER BY name")
+        rows = cursor.fetchall()
+        assert len(rows) == 2
+        assert "tensor_a" in [r[1] for r in rows]
+        conn.close()
+
+
+class TestPerOpCapturedGraphImport:
+    """Tests that per-op captured_graph from python_io is used directly."""
+
+    def test_per_op_captured_graph_used_when_available(self, tmp_path):
+        """captured_graph from python_io should be stored as-is."""
+        per_op_graph = [
+            {"counter": 0, "node_type": "capture_start", "params": {}, "connections": [1]},
+            {
+                "counter": 1,
+                "node_type": "function_start",
+                "params": {"name": "InnerOp"},
+                "connections": [2],
+            },
+            {
+                "counter": 2,
+                "node_type": "function_end",
+                "params": {"name": "InnerOp"},
+                "connections": [3],
+            },
+            {"counter": 3, "node_type": "capture_end", "params": {}, "connections": []},
+        ]
+        mock_graph = [
+            {"counter": 0, "node_type": "capture_start", "params": {}, "connections": [1, 3]},
+            {
+                "counter": 1,
+                "node_type": "function_start",
+                "params": {"name": "ttnn.relu"},
+                "connections": [],
+                "input_tensors": [],
+            },
+            {
+                "counter": 2,
+                "node_type": "function_end",
+                "params": {"name": "ttnn.relu"},
+                "connections": [],
+                "duration_ns": 100,
+            },
+            {"counter": 3, "node_type": "capture_end", "params": {}, "connections": []},
+        ]
+        python_io = [
+            {
+                "name": "ttnn.relu",
+                "arguments": {},
+                "input_tensor_ids": [],
+                "captured_graph": per_op_graph,
+            }
+        ]
+
+        report = _make_report(mock_graph, python_io=python_io)
+        conn, cursor = _import_to_db(report, tmp_path)
+
+        cursor.execute("SELECT captured_graph FROM captured_graph")
+        rows = cursor.fetchall()
+        assert len(rows) == 1
+        stored = json.loads(rows[0][0])
+        assert stored == per_op_graph, "Per-op graph should be stored exactly as provided"
+        conn.close()
+
+    def test_fallback_extraction_when_no_per_op_graph(self, tmp_path):
+        """Without captured_graph in python_io, importer should extract from global graph."""
+        mock_graph = [
+            {"counter": 0, "node_type": "capture_start", "params": {}, "connections": [1, 3]},
+            {
+                "counter": 1,
+                "node_type": "function_start",
+                "params": {"name": "ttnn.relu"},
+                "connections": [3],
+                "input_tensors": [],
+            },
+            {
+                "counter": 2,
+                "node_type": "function_end",
+                "params": {"name": "ttnn.relu"},
+                "connections": [],
+                "duration_ns": 100,
+            },
+            {"counter": 3, "node_type": "capture_end", "params": {}, "connections": []},
+        ]
+        python_io = [{"name": "ttnn.relu", "arguments": {}, "input_tensor_ids": []}]
+
+        report = _make_report(mock_graph, python_io=python_io)
+        conn, cursor = _import_to_db(report, tmp_path)
+
+        cursor.execute("SELECT captured_graph FROM captured_graph")
+        rows = cursor.fetchall()
+        assert len(rows) == 1
+        stored = json.loads(rows[0][0])
+        assert stored[0]["node_type"] == "capture_start"
+        assert stored[-1]["node_type"] == "capture_end"
+        conn.close()
+
+
+class TestFromTorchFiltering:
+    """Tests for the smart from_torch filtering (leading block only)."""
+
+    def _make_graph(self, op_names):
+        """Helper: build a simple graph with given operation names."""
+        nodes = [{"counter": 0, "node_type": "capture_start", "params": {}, "connections": []}]
+        c = 1
+        for name in op_names:
+            nodes.append(
+                {
+                    "counter": c,
+                    "node_type": "function_start",
+                    "params": {"name": name},
+                    "connections": [],
+                    "input_tensors": [],
+                }
+            )
+            c += 1
+            nodes.append(
+                {
+                    "counter": c,
+                    "node_type": "function_end",
+                    "params": {"name": name},
+                    "connections": [],
+                    "duration_ns": 100,
+                }
+            )
+            c += 1
+        nodes.append({"counter": c, "node_type": "capture_end", "params": {}, "connections": []})
+        return nodes
+
+    def test_leading_from_torch_filtered(self, tmp_path):
+        """from_torch before any compute op should be filtered out."""
+        graph = self._make_graph(["ttnn.from_torch", "ttnn.from_torch", "ttnn.conv2d"])
+
+        report = _make_report(graph)
+        conn, cursor = _import_to_db(report, tmp_path)
+
+        cursor.execute("SELECT name FROM operations ORDER BY operation_id")
+        ops = [r[0] for r in cursor.fetchall()]
+        assert "ttnn.from_torch" not in ops, "Leading from_torch should be filtered"
+        assert "ttnn.conv2d" in ops
+        conn.close()
+
+    def test_from_torch_after_compute_kept(self, tmp_path):
+        """from_torch after a compute op should be kept."""
+        graph = self._make_graph(["ttnn.conv2d", "ttnn.from_torch"])
+
+        report = _make_report(graph)
+        conn, cursor = _import_to_db(report, tmp_path)
+
+        cursor.execute("SELECT name FROM operations ORDER BY operation_id")
+        ops = [r[0] for r in cursor.fetchall()]
+        assert ops == ["ttnn.conv2d", "ttnn.from_torch"]
+        conn.close()
+
+    def test_mixed_leading_block(self, tmp_path):
+        """from_torch interleaved with filtered ops before compute should all be filtered."""
+        graph = self._make_graph(
+            [
+                "ttnn.from_torch",
+                "Tensor::to_device",
+                "ttnn.from_torch",
+                "ttnn.conv2d",
+                "ttnn.from_torch",
+            ]
+        )
+
+        report = _make_report(graph)
+        conn, cursor = _import_to_db(report, tmp_path)
+
+        cursor.execute("SELECT name FROM operations ORDER BY operation_id")
+        ops = [r[0] for r in cursor.fetchall()]
+        assert ops == ["ttnn.conv2d", "ttnn.from_torch"]
+        conn.close()
+
+
+class TestFilteredOpPrefixes:
+    """Tests that _FILTERED_OP_PREFIXES operations are transparent."""
+
+    @staticmethod
+    def _make_flat_graph(op_names):
+        nodes = [{"counter": 0, "node_type": "capture_start", "params": {}, "connections": []}]
+        c = 1
+        for name in op_names:
+            nodes.append(
+                {
+                    "counter": c,
+                    "node_type": "function_start",
+                    "params": {"name": name},
+                    "connections": [],
+                    "input_tensors": [],
+                }
+            )
+            c += 1
+            nodes.append(
+                {
+                    "counter": c,
+                    "node_type": "function_end",
+                    "params": {"name": name},
+                    "connections": [],
+                    "duration_ns": 100,
+                }
+            )
+            c += 1
+        nodes.append({"counter": c, "node_type": "capture_end", "params": {}, "connections": []})
+        return nodes
+
+    @pytest.mark.parametrize(
+        "filtered_op",
+        [
+            "Tensor::deallocate",
+            "Tensor::to_device",
+            "Tensor::reshape",
+            "tt::tt_metal::to_dtype",
+            "ttnn::convert_python_tensor_to_tt_tensor",
+            "tt::tt_metal::detail::convert_tt_tensor_to_framework_tensor",
+        ],
+    )
+    def test_filtered_op_prefix_excluded(self, tmp_path, filtered_op):
+        """Each _FILTERED_OP_PREFIXES entry should be excluded from operations."""
+        graph = self._make_flat_graph([filtered_op, "ttnn.relu"])
+        report = _make_report(graph)
+        conn, cursor = _import_to_db(report, tmp_path)
+
+        cursor.execute("SELECT name FROM operations")
+        ops = [r[0] for r in cursor.fetchall()]
+        assert filtered_op not in ops, f"{filtered_op} should be filtered"
+        assert "ttnn.relu" in ops, "Non-filtered op should remain"
+        conn.close()
+
+
+class TestPythonIONameMatching:
+    """Tests that python_io records are matched to graph nodes by name."""
+
+    def test_multiple_ops_same_name_matched_in_order(self, tmp_path):
+        """Two ops with the same name should consume python_io records in order."""
+        mock_graph = [
+            {"counter": 0, "node_type": "capture_start", "params": {}, "connections": []},
+            {
+                "counter": 1,
+                "node_type": "function_start",
+                "params": {"name": "ttnn.relu"},
+                "connections": [],
+                "input_tensors": [],
+            },
+            {
+                "counter": 2,
+                "node_type": "function_end",
+                "params": {"name": "ttnn.relu"},
+                "connections": [],
+                "duration_ns": 100,
+            },
+            {
+                "counter": 3,
+                "node_type": "function_start",
+                "params": {"name": "ttnn.relu"},
+                "connections": [],
+                "input_tensors": [],
+            },
+            {
+                "counter": 4,
+                "node_type": "function_end",
+                "params": {"name": "ttnn.relu"},
+                "connections": [],
+                "duration_ns": 200,
+            },
+            {"counter": 5, "node_type": "capture_end", "params": {}, "connections": []},
+        ]
+        python_io = [
+            {"name": "ttnn.relu", "arguments": {"alpha": "1.0"}, "input_tensor_ids": []},
+            {"name": "ttnn.relu", "arguments": {"alpha": "2.0"}, "input_tensor_ids": []},
+        ]
+
+        report = _make_report(mock_graph, python_io=python_io)
+        conn, cursor = _import_to_db(report, tmp_path)
+
+        cursor.execute(
+            """
+            SELECT oa.value FROM operation_arguments oa
+            JOIN operations o ON oa.operation_id = o.operation_id
+            WHERE oa.name = 'alpha'
+            ORDER BY o.operation_id
+        """
+        )
+        values = [r[0] for r in cursor.fetchall()]
+        assert values == ["1.0", "2.0"], f"Expected ordered matching, got {values}"
+        conn.close()
+
+    def test_unmatched_python_io_ignored(self, tmp_path):
+        """python_io records for non-existent ops should be silently ignored."""
+        mock_graph = [
+            {"counter": 0, "node_type": "capture_start", "params": {}, "connections": []},
+            {
+                "counter": 1,
+                "node_type": "function_start",
+                "params": {"name": "ttnn.relu"},
+                "connections": [],
+                "input_tensors": [],
+            },
+            {
+                "counter": 2,
+                "node_type": "function_end",
+                "params": {"name": "ttnn.relu"},
+                "connections": [],
+                "duration_ns": 100,
+            },
+            {"counter": 3, "node_type": "capture_end", "params": {}, "connections": []},
+        ]
+        python_io = [
+            {"name": "ttnn.relu", "arguments": {"x": "tensor"}, "input_tensor_ids": []},
+            {"name": "ttnn.nonexistent", "arguments": {"y": "other"}, "input_tensor_ids": []},
+        ]
+
+        report = _make_report(mock_graph, python_io=python_io)
+        conn, cursor = _import_to_db(report, tmp_path)
+
+        cursor.execute("SELECT COUNT(*) FROM operations")
+        assert cursor.fetchone()[0] == 1
+        conn.close()
+
+
+class TestCapturedGraphFallbackExtraction:
+    """Tests for the global-graph extraction fallback (when no per-op captured_graph)."""
+
+    def test_extracted_graph_has_sequential_counters(self, tmp_path):
+        """Fallback extraction should renumber counters to be sequential."""
+        mock_graph = [
+            {"counter": 0, "node_type": "capture_start", "params": {}, "connections": [100]},
+            {
+                "counter": 100,
+                "node_type": "function_start",
+                "params": {"name": "ttnn.relu"},
+                "connections": [102],
+                "input_tensors": [],
+            },
+            {"counter": 101, "node_type": "tensor", "params": {"tensor_id": "1"}, "connections": [100]},
+            {
+                "counter": 102,
+                "node_type": "function_end",
+                "params": {"name": "ttnn.relu"},
+                "connections": [103],
+                "duration_ns": 100,
+            },
+            {"counter": 103, "node_type": "tensor", "params": {"tensor_id": "2"}, "connections": []},
+            {"counter": 999, "node_type": "capture_end", "params": {}, "connections": []},
+        ]
+
+        report = _make_report(mock_graph)
+        conn, cursor = _import_to_db(report, tmp_path)
+
+        cursor.execute("SELECT captured_graph FROM captured_graph")
+        rows = cursor.fetchall()
+        assert len(rows) == 1
+        cg = json.loads(rows[0][0])
+        counters = [n["counter"] for n in cg]
+        assert counters == list(range(len(cg))), f"Counters should be sequential: {counters}"
+        assert cg[0]["node_type"] == "capture_start"
+        assert cg[-1]["node_type"] == "capture_end"
+        conn.close()
+
+    def test_extracted_graph_connections_remapped(self, tmp_path):
+        """Connections in extracted graph should reference local counters."""
+        mock_graph = [
+            {"counter": 0, "node_type": "capture_start", "params": {}, "connections": [50]},
+            {
+                "counter": 50,
+                "node_type": "function_start",
+                "params": {"name": "ttnn.relu"},
+                "connections": [52],
+                "input_tensors": [51],
+            },
+            {"counter": 51, "node_type": "tensor", "params": {"tensor_id": "1"}, "connections": [50]},
+            {
+                "counter": 52,
+                "node_type": "function_end",
+                "params": {"name": "ttnn.relu"},
+                "connections": [],
+                "duration_ns": 100,
+            },
+            {"counter": 999, "node_type": "capture_end", "params": {}, "connections": []},
+        ]
+
+        report = _make_report(mock_graph)
+        conn, cursor = _import_to_db(report, tmp_path)
+
+        cursor.execute("SELECT captured_graph FROM captured_graph")
+        cg = json.loads(cursor.fetchone()[0])
+        max_counter = max(n["counter"] for n in cg)
+        for node in cg:
+            for conn_id in node.get("connections", []):
+                assert conn_id <= max_counter, (
+                    f"Connection {conn_id} exceeds max counter {max_counter} "
+                    f"in node {node['counter']} ({node['node_type']})"
+                )
+        conn.close()
+
+    def test_parent_wrapper_included_in_captured_graph(self, tmp_path):
+        """The parent function_start/end should appear in the extracted subgraph."""
+        mock_graph = [
+            {"counter": 0, "node_type": "capture_start", "params": {}, "connections": [1]},
+            {
+                "counter": 1,
+                "node_type": "function_start",
+                "params": {"name": "ttnn.relu"},
+                "connections": [2, 4],
+                "input_tensors": [],
+            },
+            {
+                "counter": 2,
+                "node_type": "function_start",
+                "params": {"name": "InnerOp"},
+                "connections": [3],
+                "input_tensors": [],
+            },
+            {
+                "counter": 3,
+                "node_type": "function_end",
+                "params": {"name": "InnerOp"},
+                "connections": [],
+                "duration_ns": 50,
+            },
+            {
+                "counter": 4,
+                "node_type": "function_end",
+                "params": {"name": "ttnn.relu"},
+                "connections": [],
+                "duration_ns": 100,
+            },
+            {"counter": 5, "node_type": "capture_end", "params": {}, "connections": []},
+        ]
+
+        report = _make_report(mock_graph)
+        conn, cursor = _import_to_db(report, tmp_path)
+
+        cursor.execute("SELECT captured_graph FROM captured_graph")
+        cg = json.loads(cursor.fetchone()[0])
+        fn_names = [
+            n.get("params", {}).get("name", "") for n in cg if n["node_type"] in ("function_start", "function_end")
+        ]
+        assert "ttnn.relu" in fn_names, f"Parent wrapper should be included in captured_graph, found: {fn_names}"
+        conn.close()
+
+
+@pytest.mark.skipif(is_simulator(), reason="Fast dispatch with ttnn.add crashes ttsim worker on teardown")
+class TestFastOperationGraphTracking:
+    """Tests that FastOperation emits track_function_start/end during graph capture."""
+
+    def test_python_op_names_in_graph(self, device, tmp_path):
+        """FastOperation.__call__ should produce Python-level function_start/end nodes."""
+        torch_input = torch.randn(1, 32)
+        tt_input = ttnn.from_torch(torch_input, layout=ttnn.TILE_LAYOUT, device=device)
+
+        report_path = str(tmp_path / "report.json")
+        ttnn.graph.begin_graph_capture()
+        with ttnn.manage_config("enable_fast_runtime_mode", True):
+            ttnn.add(tt_input, tt_input)
+        ttnn.graph.end_graph_capture_to_file(report_path)
+
+        with open(report_path) as f:
+            report = json.load(f)
+
+        fn_names = [
+            n["params"]["name"]
+            for n in report["graph"]
+            if n.get("node_type") == "function_start" and "name" in n.get("params", {})
+        ]
+        assert "ttnn.add" in fn_names, f"Expected 'ttnn.add' in function_start names, got: {fn_names}"
+
+    def test_python_io_records_tensor_ids(self, device, tmp_path):
+        """FastOperation should record input_tensor_ids and output_tensor_ids in python_io."""
+        report_path = str(tmp_path / "report.json")
+
+        with ttnn.manage_config("enable_fast_runtime_mode", True):
+            ttnn.graph.begin_graph_capture(ttnn.graph.RunMode.NORMAL)
+            a = ttnn.ones([1, 32], layout=ttnn.TILE_LAYOUT, device=device)
+            b = ttnn.add(a, a)
+            ttnn.graph.end_graph_capture_to_file(report_path)
+
+        report_path = Path(report_path)
+        sidecar_path = report_path.with_suffix(".python_io.json")
+        assert sidecar_path.exists(), f"python_io sidecar file not found at {sidecar_path}"
+
+        with open(sidecar_path) as f:
+            py_io = json.load(f)
+
+        names = [r["name"] for r in py_io]
+        assert "ttnn.ones" in names, f"Expected ttnn.ones in python_io, got {names}"
+        assert "ttnn.add" in names, f"Expected ttnn.add in python_io, got {names}"
+
+        add_record = next(r for r in py_io if r["name"] == "ttnn.add")
+        assert len(add_record.get("input_tensor_ids", [])) > 0, "ttnn.add should have input_tensor_ids"
+        assert len(add_record.get("output_tensor_ids", [])) > 0, "ttnn.add should have output_tensor_ids"
+
+    def test_tensor_connectivity_across_operations(self, device, tmp_path):
+        """Output tensor ID of op A should appear as input tensor ID of op B."""
+        report_path = tmp_path / "report.json"
+
+        with ttnn.manage_config("enable_fast_runtime_mode", True):
+            ttnn.graph.begin_graph_capture(ttnn.graph.RunMode.NORMAL)
+            a = ttnn.ones([1, 32], layout=ttnn.TILE_LAYOUT, device=device)
+            b = ttnn.add(a, a)
+            ttnn.graph.end_graph_capture_to_file(report_path)
+
+        db_path = graph_report.import_report(report_path, tmp_path / "output")
+        conn = sqlite3.connect(db_path)
+        c = conn.cursor()
+
+        c.execute(
+            """SELECT COUNT(DISTINCT ot.tensor_id)
+               FROM output_tensors ot
+               INNER JOIN input_tensors it ON ot.tensor_id = it.tensor_id"""
+        )
+        connected = c.fetchone()[0]
+        assert connected >= 1, f"Expected at least 1 connected tensor ID, got {connected}"
+        conn.close()
+
+
+class TestPyIdToCppTensorReconciliation:
+    """Tests that Python-assigned output tensor IDs get proper tensor entries
+    even when they don't appear in any C++ graph tensor node."""
+
+    def test_missing_pyid_created_from_cpp_tensor_node(self, tmp_path):
+        """When python_io output_tensor_ids references an ID not in the graph,
+        the import should create a tensor entry by cloning from the function_end
+        node's connected C++ tensor."""
+        graph = [
+            {
+                "counter": 0,
+                "node_type": "capture_start",
+                "params": {},
+                "connections": [1],
+                "arguments": [],
+                "input_tensors": [],
+                "stacking_level": 0,
+            },
+            {
+                "counter": 1,
+                "node_type": "function_start",
+                "params": {"name": "ttnn.relu"},
+                "connections": [2, 5],
+                "arguments": [],
+                "input_tensors": [3],
+                "stacking_level": 0,
+            },
+            {
+                "counter": 2,
+                "node_type": "function_start",
+                "params": {"name": "ReluOp"},
+                "connections": [4],
+                "arguments": [],
+                "input_tensors": [3],
+                "stacking_level": 1,
+            },
+            {
+                "counter": 3,
+                "node_type": "tensor",
+                "params": {
+                    "tensor_id": "100",
+                    "shape": "[1,32]",
+                    "dtype": "BFLOAT16",
+                    "layout": "TILE",
+                    "memory_config": "",
+                    "device_id": 0,
+                    "address": 1000,
+                },
+                "connections": [2],
+                "arguments": [],
+                "input_tensors": [],
+                "stacking_level": 0,
+            },
+            {
+                "counter": 4,
+                "node_type": "function_end",
+                "params": {"name": "ReluOp"},
+                "connections": [6],
+                "arguments": [],
+                "input_tensors": [],
+                "stacking_level": 1,
+            },
+            {
+                "counter": 5,
+                "node_type": "function_end",
+                "params": {"name": "ttnn.relu"},
+                "connections": [6],
+                "arguments": [],
+                "input_tensors": [],
+                "stacking_level": 0,
+            },
+            {
+                "counter": 6,
+                "node_type": "tensor",
+                "params": {
+                    "tensor_id": "200",
+                    "shape": "[1,32]",
+                    "dtype": "BFLOAT16",
+                    "layout": "TILE",
+                    "memory_config": "",
+                    "device_id": 0,
+                    "address": 2000,
+                },
+                "connections": [],
+                "arguments": [],
+                "input_tensors": [],
+                "stacking_level": 0,
+            },
+            {
+                "counter": 7,
+                "node_type": "capture_end",
+                "params": {},
+                "connections": [],
+                "arguments": [],
+                "input_tensors": [],
+                "stacking_level": 0,
+            },
+        ]
+        python_io = [
+            {"name": "ttnn.relu", "arguments": {}, "input_tensor_ids": [100], "output_tensor_ids": [999]},
+        ]
+        report = _make_report(graph, python_io=python_io)
+        conn, c = _import_to_db(report, tmp_path)
+
+        c.execute("SELECT tensor_id FROM output_tensors")
+        out_ids = {r[0] for r in c.fetchall()}
+        assert 999 in out_ids, f"Python-assigned output ID 999 should be in output_tensors, got {out_ids}"
+
+        c.execute("SELECT tensor_id FROM tensors WHERE tensor_id = 999")
+        row = c.fetchone()
+        assert row is not None, "Reconciliation should create a tensor entry for Python-assigned ID 999"
+        conn.close()
+
+
+class TestPythonStackTraceImport:
+    """Tests that Python stack traces from python_io are stored in the stack_traces table."""
+
+    def test_python_stack_trace_stored_alone(self, tmp_path):
+        """Python stack trace stored when no C++ stack trace exists."""
+        graph = [
+            {
+                "counter": 0,
+                "node_type": "capture_start",
+                "params": {},
+                "connections": [1],
+                "arguments": [],
+                "input_tensors": [],
+                "stacking_level": 0,
+            },
+            {
+                "counter": 1,
+                "node_type": "function_start",
+                "params": {"name": "ttnn::add", "inputs": 2},
+                "connections": [],
+                "arguments": [],
+                "input_tensors": [],
+                "stacking_level": 0,
+            },
+            {
+                "counter": 2,
+                "node_type": "function_end",
+                "params": {"name": "ttnn::add"},
+                "connections": [],
+                "arguments": [],
+                "input_tensors": [],
+                "stacking_level": 0,
+            },
+            {
+                "counter": 3,
+                "node_type": "capture_end",
+                "params": {},
+                "connections": [],
+                "arguments": [],
+                "input_tensors": [],
+                "stacking_level": 0,
+            },
+        ]
+        python_io = [
+            {
+                "name": "ttnn::add",
+                "arguments": {"a": "tensor_a", "b": "tensor_b"},
+                "input_tensor_ids": [],
+                "python_stack_trace": [
+                    '  File "my_model.py", line 42, in forward\n    out = ttnn.add(x, y)',
+                    '  File "train.py", line 10, in main\n    model.forward(batch)',
+                ],
+            }
+        ]
+        report = _make_report(graph, python_io=python_io)
+        conn, c = _import_to_db(report, tmp_path)
+        c.execute("SELECT stack_trace FROM stack_traces WHERE operation_id = 1")
+        row = c.fetchone()
+        assert row is not None, "Stack trace should be stored"
+        assert "my_model.py" in row[0]
+        assert "train.py" in row[0]
+        assert "--- C++ ---" not in row[0], "No C++ separator when only Python trace"
+        conn.close()
+
+    def test_python_stack_trace_replaces_cpp(self, tmp_path):
+        """Python stack trace is stored for Python-level ops."""
+        graph = [
+            {
+                "counter": 0,
+                "node_type": "capture_start",
+                "params": {},
+                "connections": [1],
+                "arguments": [],
+                "input_tensors": [],
+                "stacking_level": 0,
+            },
+            {
+                "counter": 1,
+                "node_type": "function_start",
+                "params": {"name": "ttnn::add", "inputs": 2},
+                "connections": [],
+                "arguments": [],
+                "input_tensors": [],
+                "stacking_level": 0,
+            },
+            {
+                "counter": 2,
+                "node_type": "function_end",
+                "params": {"name": "ttnn::add"},
+                "connections": [],
+                "arguments": [],
+                "input_tensors": [],
+                "stacking_level": 0,
+            },
+            {
+                "counter": 3,
+                "node_type": "capture_end",
+                "params": {},
+                "connections": [],
+                "arguments": [],
+                "input_tensors": [],
+                "stacking_level": 0,
+            },
+        ]
+        python_io = [
+            {
+                "name": "ttnn::add",
+                "arguments": {},
+                "input_tensor_ids": [],
+                "python_stack_trace": ['  File "model.py", line 5, in run\n    ttnn.add(a, b)'],
+            }
+        ]
+        report = _make_report(graph, python_io=python_io)
+        conn, c = _import_to_db(report, tmp_path)
+        c.execute("SELECT stack_trace FROM stack_traces WHERE operation_id = 1")
+        row = c.fetchone()
+        assert row is not None
+        trace = row[0]
+        assert "model.py" in trace, "Python trace should be stored"
+        conn.close()
+
+    def test_no_python_stack_trace_uses_cpp_only(self, tmp_path):
+        """When python_io has no stack trace, no trace is stored."""
+        graph = [
+            {
+                "counter": 0,
+                "node_type": "capture_start",
+                "params": {},
+                "connections": [1],
+                "arguments": [],
+                "input_tensors": [],
+                "stacking_level": 0,
+            },
+            {
+                "counter": 1,
+                "node_type": "function_start",
+                "params": {"name": "ttnn::add", "inputs": 2},
+                "connections": [],
+                "arguments": [],
+                "input_tensors": [],
+                "stacking_level": 0,
+            },
+            {
+                "counter": 2,
+                "node_type": "function_end",
+                "params": {"name": "ttnn::add"},
+                "connections": [],
+                "arguments": [],
+                "input_tensors": [],
+                "stacking_level": 0,
+            },
+            {
+                "counter": 3,
+                "node_type": "capture_end",
+                "params": {},
+                "connections": [],
+                "arguments": [],
+                "input_tensors": [],
+                "stacking_level": 0,
+            },
+        ]
+        python_io = [{"name": "ttnn::add", "arguments": {}, "input_tensor_ids": []}]
+        report = _make_report(graph, python_io=python_io)
+        conn, c = _import_to_db(report, tmp_path)
+        c.execute("SELECT stack_trace FROM stack_traces WHERE operation_id = 1")
+        row = c.fetchone()
+        assert row is None, "No stack trace should be stored when Python trace is absent"
+        conn.close()

--- a/tests/ttnn/unit_tests/gtests/test_graph_add.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_graph_add.cpp
@@ -79,12 +79,10 @@ TEST_P(AddOpGraphTestFixture, AddGraphTrace) {
         {
             EXPECT_EQ(graph::extract_calltrace(json_trace), params.expected_calltrace);
             EXPECT_EQ(graph::extract_peak_L1_memory_usage(json_trace), params.expected_peak_L1_memory_usage);
-            EXPECT_EQ(graph::extract_output_tensors(json_trace).size(), 1);
 
             auto [intermediate_tensors_count, output_tensors_count] =
                 graph::count_intermediate_and_output_tensors(json_trace);
             EXPECT_EQ(intermediate_tensors_count, params.expected_intermediate_tensors_count);
-            EXPECT_EQ(output_tensors_count, 1);
         }
 
         // per core buffer allocation size
@@ -102,34 +100,7 @@ TEST_P(AddOpGraphTestFixture, AddGraphTrace) {
         // Query calls
         {
             auto peak_L1_memory_usage = graph::query_peak_L1_memory_usage(call);
-            auto output_info = graph::query_output_info(call);
-
             EXPECT_EQ(peak_L1_memory_usage, params.expected_peak_L1_memory_usage);
-
-            if (output_info.size() != params.expected_output_info.size()) {
-                auto print = [](const auto& infos) {
-                    for (const auto& info : infos) {
-                        log_info(tt::LogTest, "{}", info);
-                    }
-                };
-
-                log_info(
-                    tt::LogTest,
-                    "Output info size mismatch. Expected {} but got {}",
-                    params.expected_output_info.size(),
-                    output_info.size());
-
-                log_info(tt::LogTest, "Expected output info:");
-                print(params.expected_output_info);
-
-                log_info(tt::LogTest, "Actual output info:");
-                print(output_info);
-                ASSERT_TRUE(false);
-            }
-
-            for (int i = 0; i < output_info.size(); ++i) {
-                EXPECT_EQ(output_info[i], params.expected_output_info[i]);
-            }
         }
     }
 }
@@ -144,8 +115,8 @@ INSTANTIATE_TEST_SUITE_P(
                 .a_Shape = ttnn::Shape(tt::tt_metal::Array4D{1, 3, 32, 32}),
                 .b_Shape = ttnn::Shape(tt::tt_metal::Array4D{1, 3, 32, 32}),
                 .memory_config = ttnn::L1_MEMORY_CONFIG,
-                // Note: High-level function tracing (ttnn::add) was removed, now only device operations are captured
-                .expected_calltrace = {"BinaryNgDeviceOperation", "tt::tt_metal::create_device_tensor"},
+                .expected_calltrace =
+                    {"BinaryNgDeviceOperation", "tt::tt_metal::create_device_tensor", "Tensor::deallocate"},
                 .expected_peak_L1_memory_usage = 30720,
                 .expected_intermediate_tensors_count = 0,
                 .expected_cb_peak_per_core = 3 * 4096,
@@ -159,8 +130,8 @@ INSTANTIATE_TEST_SUITE_P(
                 .a_Shape = ttnn::Shape(tt::tt_metal::Array4D{4, 3, 32, 32}),
                 .b_Shape = ttnn::Shape(tt::tt_metal::Array4D{1, 3, 32, 32}),
                 .memory_config = ttnn::L1_MEMORY_CONFIG,
-                // Note: High-level function tracing (ttnn::add) was removed, now only device operations are captured
-                .expected_calltrace = {"BinaryNgDeviceOperation", "tt::tt_metal::create_device_tensor"},
+                .expected_calltrace =
+                    {"BinaryNgDeviceOperation", "tt::tt_metal::create_device_tensor", "Tensor::deallocate"},
                 .expected_peak_L1_memory_usage = 67584,
                 .expected_intermediate_tensors_count = 0,
                 .expected_cb_peak_per_core = 3 * 4096,
@@ -182,8 +153,8 @@ INSTANTIATE_TEST_SUITE_P(
                             CoreRangeSet{std::set<CoreRange>{CoreRange{CoreCoord{0, 0}, CoreCoord{3, 3}}}},
                             {6 * 32, 32 * 32},
                             ShardOrientation::COL_MAJOR}},
-                // Note: High-level function tracing (ttnn::add) was removed, now only device operations are captured
-                .expected_calltrace = {"BinaryNgDeviceOperation", "tt::tt_metal::create_device_tensor"},
+                .expected_calltrace =
+                    {"BinaryNgDeviceOperation", "tt::tt_metal::create_device_tensor", "Tensor::deallocate"},
                 .expected_peak_L1_memory_usage = 20054016,
                 .expected_intermediate_tensors_count = 0,
                 .expected_cb_peak_per_core = 0,

--- a/tests/ttnn/unit_tests/gtests/test_graph_basic.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_graph_basic.cpp
@@ -8,6 +8,8 @@
 #include <cstddef>
 #include <cstdint>
 #include <exception>
+#include <filesystem>
+#include <fstream>
 #include <iostream>
 #include <map>
 #include <sstream>
@@ -115,11 +117,11 @@ TEST_P(BufferTestFixture, BufferTest) {
         // Check if there are two buffer nodes and they have correct sizes
         auto buffer_nodes = find_nodes_by_type(trace, kNodeBuffer);
         EXPECT_EQ(buffer_nodes.size(), 3);
-        auto size_a = std::stoi(buffer_nodes[0].at(kParams).at(kSize).get<std::string>());
+        auto size_a = buffer_nodes[0].at(kParams).at(kSize).get<int64_t>();
         EXPECT_EQ(params.shape_a.volume() * 2, size_a);
-        auto size_a2 = std::stoi(buffer_nodes[1].at(kParams).at(kSize).get<std::string>());
+        auto size_a2 = buffer_nodes[1].at(kParams).at(kSize).get<int64_t>();
         EXPECT_EQ(params.shape_a.volume() * 2, size_a2);
-        auto size_b = std::stoi(buffer_nodes[2].at(kParams).at(kSize).get<std::string>());
+        auto size_b = buffer_nodes[2].at(kParams).at(kSize).get<int64_t>();
         EXPECT_EQ(params.shape_b.volume() * 2, size_b);
 
         // Print the trace for reference
@@ -203,14 +205,14 @@ TEST_F(TestScopedGraphCapture, ScopedGraphCapture) {
         }
         auto json_trace = capture.end_graph_capture();
 
-        // Note: High-level function tracing (ttnn::softmax) was removed from decorators.hpp
-        // Now only device operations are captured
         EXPECT_EQ(
             ttnn::graph::extract_calltrace(json_trace),
             std::vector<std::string>(
                 {"tt::tt_metal::create_device_tensor",
                  "SoftmaxDeviceOperation",
-                 "tt::tt_metal::create_device_tensor"}));
+                 "tt::tt_metal::create_device_tensor",
+                 "Tensor::deallocate",
+                 "Tensor::deallocate"}));
     }
 
     // check original again to ensure it's not affected by the thrown exceptions
@@ -659,4 +661,312 @@ TEST_F(TestScopedGraphCapture, SubtractArgumentOrderWithCapturedTensorsTest) {
     // Verify that subtract(a, b) has reversed order compared to subtract(b, a)
     EXPECT_EQ(first_input_tensors[0], second_input_tensors[1]);
     EXPECT_EQ(first_input_tensors[1], second_input_tensors[0]);
+}
+
+class DurationTrackingTest : public ttnn::TTNNFixtureWithDevice,
+                             public testing::WithParamInterface<tt::tt_metal::IGraphProcessor::RunMode> {};
+
+TEST_P(DurationTrackingTest, DurationTracking) {
+    auto run_mode = GetParam();
+    tt::tt_metal::IDevice* device = device_;
+
+    nlohmann::json trace;
+    {
+        auto capture = ttnn::graph::ScopedGraphCapture(run_mode);
+
+        const auto tensor_spec = ttnn::TensorSpec(
+            ttnn::Shape(tt::tt_metal::Array4D{1, 4, 512, 512}),
+            tt::tt_metal::TensorLayout(
+                tt::tt_metal::DataType::BFLOAT16,
+                tt::tt_metal::PageConfig(tt::tt_metal::Layout::TILE),
+                ttnn::L1_MEMORY_CONFIG));
+        const auto input_tensor = tt::tt_metal::create_device_tensor(tensor_spec, device);
+        const auto output_tensor = ttnn::softmax(input_tensor, -1);
+
+        trace = capture.end_graph_capture();
+    }
+
+    // Find function_start and function_end nodes
+    bool found_function_start = false;
+    bool found_end_with_duration = false;
+    bool found_capture_end_with_duration = false;
+
+    for (const auto& node : trace) {
+        if (node.at(ttnn::graph::kNodeType) == ttnn::graph::kNodeFunctionStart) {
+            found_function_start = true;
+        }
+        if (node.at(ttnn::graph::kNodeType) == ttnn::graph::kNodeFunctionEnd) {
+            if (node.contains(ttnn::graph::kDurationNs)) {
+                auto duration = node.at(ttnn::graph::kDurationNs).get<uint64_t>();
+                EXPECT_GE(duration, 0u);
+                found_end_with_duration = true;
+            }
+        }
+        if (node.at(ttnn::graph::kNodeType) == ttnn::graph::kNodeCaptureEnd) {
+            if (node.contains(ttnn::graph::kDurationNs)) {
+                auto total_duration = node.at(ttnn::graph::kDurationNs).get<uint64_t>();
+                EXPECT_GE(total_duration, 0u);
+                found_capture_end_with_duration = true;
+            }
+        }
+    }
+
+    EXPECT_TRUE(found_function_start);
+    EXPECT_TRUE(found_end_with_duration);
+    EXPECT_TRUE(found_capture_end_with_duration);
+
+    ASSERT_FALSE(trace.empty());
+    EXPECT_EQ(trace[0].at(ttnn::graph::kNodeType), ttnn::graph::kNodeCaptureStart);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    DurationTracking,
+    DurationTrackingTest,
+    ::testing::Values(
+        tt::tt_metal::IGraphProcessor::RunMode::NO_DISPATCH, tt::tt_metal::IGraphProcessor::RunMode::NORMAL),
+    [](const testing::TestParamInfo<tt::tt_metal::IGraphProcessor::RunMode>& info) {
+        switch (info.param) {
+            case tt::tt_metal::IGraphProcessor::RunMode::NO_DISPATCH: return "NO_DISPATCH";
+            case tt::tt_metal::IGraphProcessor::RunMode::NORMAL: return "NORMAL";
+            default: return "UNKNOWN";
+        }
+    });
+
+// Test full tensor info capture (dtype, layout, memory_config, device_id, address, buffer_type)
+class TensorInfoTest : public ttnn::TTNNFixtureWithDevice,
+                       public testing::WithParamInterface<tt::tt_metal::IGraphProcessor::RunMode> {};
+
+TEST_P(TensorInfoTest, FullTensorInfoCaptured) {
+    auto run_mode = GetParam();
+    tt::tt_metal::IDevice* device = device_;
+
+    nlohmann::json trace;
+    {
+        auto capture = ttnn::graph::ScopedGraphCapture(run_mode);
+
+        const auto tensor_spec = ttnn::TensorSpec(
+            ttnn::Shape(tt::tt_metal::Array4D{1, 1, 32, 32}),
+            tt::tt_metal::TensorLayout(
+                tt::tt_metal::DataType::BFLOAT16,
+                tt::tt_metal::PageConfig(tt::tt_metal::Layout::TILE),
+                ttnn::L1_MEMORY_CONFIG));
+        const auto input_tensor = tt::tt_metal::create_device_tensor(tensor_spec, device);
+
+        trace = capture.end_graph_capture();
+    }
+
+    // Find tensor nodes and verify they have full info
+    bool found_tensor_with_full_info = false;
+    for (const auto& node : trace) {
+        if (node.at(ttnn::graph::kNodeType) == ttnn::graph::kNodeTensor) {
+            const auto& params = node.at(ttnn::graph::kParams);
+
+            // Required fields
+            ASSERT_TRUE(params.contains(ttnn::graph::kShape));
+            ASSERT_TRUE(params.contains(ttnn::graph::kTensorId));
+
+            // Check for extended tensor info
+            if (params.contains(ttnn::graph::kDtype)) {
+                found_tensor_with_full_info = true;
+
+                // dtype should be a string like "DataType::BFLOAT16"
+                EXPECT_TRUE(params.at(ttnn::graph::kDtype).is_string());
+                std::string dtype = params.at(ttnn::graph::kDtype).get<std::string>();
+                EXPECT_FALSE(dtype.empty());
+
+                // layout should be present
+                ASSERT_TRUE(params.contains(ttnn::graph::kLayout));
+                EXPECT_TRUE(params.at(ttnn::graph::kLayout).is_string());
+
+                // For device tensors, these fields should be present
+                if (params.contains(ttnn::graph::kDeviceId)) {
+                    EXPECT_TRUE(params.at(ttnn::graph::kDeviceId).is_number());
+
+                    ASSERT_TRUE(params.contains(ttnn::graph::kAddress));
+                    EXPECT_TRUE(params.at(ttnn::graph::kAddress).is_number());
+
+                    ASSERT_TRUE(params.contains(ttnn::graph::kBufferType));
+                    EXPECT_TRUE(params.at(ttnn::graph::kBufferType).is_string());
+
+                    ASSERT_TRUE(params.contains(ttnn::graph::kMemoryConfig));
+                    EXPECT_TRUE(params.at(ttnn::graph::kMemoryConfig).is_string());
+                }
+            }
+        }
+    }
+
+    EXPECT_TRUE(found_tensor_with_full_info)
+        << "Expected at least one tensor node with full info (dtype, layout, etc.)";
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    TensorInfoTest,
+    TensorInfoTest,
+    ::testing::Values(
+        tt::tt_metal::IGraphProcessor::RunMode::NO_DISPATCH, tt::tt_metal::IGraphProcessor::RunMode::NORMAL),
+    [](const testing::TestParamInfo<tt::tt_metal::IGraphProcessor::RunMode>& info) {
+        switch (info.param) {
+            case tt::tt_metal::IGraphProcessor::RunMode::NO_DISPATCH: return "NO_DISPATCH";
+            case tt::tt_metal::IGraphProcessor::RunMode::NORMAL: return "NORMAL";
+            default: return "UNKNOWN";
+        }
+    });
+
+// Test report contains cluster_descriptor when devices are present
+TEST_F(TestScopedGraphCapture, ReportContainsClusterDescriptor) {
+    tt::tt_metal::IDevice* device = device_;
+
+    auto report_path = std::filesystem::temp_directory_path() / "test_cluster_desc_report.json";
+    {
+        auto capture = ttnn::graph::ScopedGraphCapture(IGraphProcessor::RunMode::NO_DISPATCH);
+
+        const auto tensor_spec = ttnn::TensorSpec(
+            ttnn::Shape(tt::tt_metal::Array4D{1, 1, 32, 32}),
+            tt::tt_metal::TensorLayout(
+                tt::tt_metal::DataType::BFLOAT16,
+                tt::tt_metal::PageConfig(tt::tt_metal::Layout::TILE),
+                ttnn::L1_MEMORY_CONFIG));
+        const auto input_tensor = tt::tt_metal::create_device_tensor(tensor_spec, device);
+
+        capture.end_graph_capture_to_file(report_path);
+    }
+
+    std::ifstream file(report_path);
+    ASSERT_TRUE(file.is_open()) << "Failed to open report file";
+    nlohmann::json report = nlohmann::json::parse(file);
+    std::filesystem::remove(report_path);
+
+    // Check that the report has devices
+    ASSERT_TRUE(report.contains(ttnn::graph::kReportDevices));
+    const auto& devices = report.at(ttnn::graph::kReportDevices);
+    EXPECT_GT(devices.size(), 0u) << "Expected at least one device to be captured";
+
+    if (report.contains("cluster_descriptor")) {
+        EXPECT_TRUE(report.at("cluster_descriptor").is_string());
+    }
+}
+
+TEST_F(TestScopedGraphCapture, ExactBufferTypeAndMaxSizePerBankTest) {
+    tt::tt_metal::IDevice* device = device_;
+
+    nlohmann::json trace;
+    {
+        auto capture = ttnn::graph::ScopedGraphCapture(IGraphProcessor::RunMode::NO_DISPATCH);
+
+        const auto tensor_spec = ttnn::TensorSpec(
+            ttnn::Shape(tt::tt_metal::Array4D{1, 1, 32, 32}),
+            tt::tt_metal::TensorLayout(
+                tt::tt_metal::DataType::BFLOAT16,
+                tt::tt_metal::PageConfig(tt::tt_metal::Layout::TILE),
+                ttnn::L1_MEMORY_CONFIG));
+        const auto input_tensor = tt::tt_metal::create_device_tensor(tensor_spec, device);
+
+        trace = capture.end_graph_capture();
+    }
+
+    bool found_buffer_allocate = false;
+    for (const auto& node : trace) {
+        if (node.at(ttnn::graph::kNodeType) == ttnn::graph::kNodeBufferAllocate) {
+            found_buffer_allocate = true;
+            const auto& params = node.at(ttnn::graph::kParams);
+
+            ASSERT_TRUE(params.contains(ttnn::graph::kExactBufferType))
+                << "buffer_allocate should contain exact_buffer_type";
+            EXPECT_TRUE(params.at(ttnn::graph::kExactBufferType).is_string());
+            auto exact_type = params.at(ttnn::graph::kExactBufferType).get<std::string>();
+            EXPECT_FALSE(exact_type.empty());
+
+            ASSERT_TRUE(params.contains(ttnn::graph::kMaxSizePerBank))
+                << "buffer_allocate should contain max_size_per_bank";
+            auto max_size = params.at(ttnn::graph::kMaxSizePerBank).get<uint64_t>();
+            EXPECT_GT(max_size, 0u);
+        }
+    }
+    EXPECT_TRUE(found_buffer_allocate) << "Expected at least one buffer_allocate node";
+}
+
+TEST_F(TestScopedGraphCapture, PerOperationBuffersInReportTest) {
+    tt::tt_metal::IDevice* device = device_;
+
+    auto report_path = std::filesystem::temp_directory_path() / "test_per_op_buffers_report.json";
+    {
+        auto capture = ttnn::graph::ScopedGraphCapture(IGraphProcessor::RunMode::NORMAL);
+
+        const auto tensor_spec = ttnn::TensorSpec(
+            ttnn::Shape(tt::tt_metal::Array4D{1, 1, 32, 32}),
+            tt::tt_metal::TensorLayout(
+                tt::tt_metal::DataType::BFLOAT16,
+                tt::tt_metal::PageConfig(tt::tt_metal::Layout::TILE),
+                ttnn::L1_MEMORY_CONFIG));
+        const auto input_tensor = tt::tt_metal::create_device_tensor(tensor_spec, device);
+        const auto output_tensor = ttnn::softmax(input_tensor, -1);
+
+        capture.end_graph_capture_to_file(report_path);
+    }
+
+    std::ifstream file(report_path);
+    ASSERT_TRUE(file.is_open()) << "Failed to open report file";
+    nlohmann::json report = nlohmann::json::parse(file);
+    std::filesystem::remove(report_path);
+
+    ASSERT_TRUE(report.contains("per_operation_buffers"))
+        << "Report should contain per_operation_buffers in NORMAL mode";
+    const auto& per_op = report.at("per_operation_buffers");
+    EXPECT_TRUE(per_op.is_object());
+    EXPECT_GT(per_op.size(), 0u) << "Expected at least one operation's buffer snapshot";
+
+    for (const auto& [op_counter, bufs] : per_op.items()) {
+        EXPECT_TRUE(bufs.is_array());
+        for (const auto& buf : bufs) {
+            EXPECT_TRUE(buf.contains("device_id"));
+            EXPECT_TRUE(buf.contains("address"));
+            EXPECT_TRUE(buf.contains("max_size_per_bank"));
+            EXPECT_TRUE(buf.contains("buffer_type"));
+            EXPECT_TRUE(buf.contains("buffer_layout"));
+        }
+    }
+}
+
+TEST_F(TestScopedGraphCapture, DeallocateContainsExactBufferTypeTest) {
+    tt::tt_metal::IDevice* device = device_;
+
+    nlohmann::json trace;
+    {
+        auto capture = ttnn::graph::ScopedGraphCapture(IGraphProcessor::RunMode::NORMAL);
+
+        const auto tensor_spec = ttnn::TensorSpec(
+            ttnn::Shape(tt::tt_metal::Array4D{1, 1, 32, 32}),
+            tt::tt_metal::TensorLayout(
+                tt::tt_metal::DataType::BFLOAT16,
+                tt::tt_metal::PageConfig(tt::tt_metal::Layout::TILE),
+                ttnn::L1_MEMORY_CONFIG));
+        const auto input_tensor = tt::tt_metal::create_device_tensor(tensor_spec, device);
+        const auto output_tensor = ttnn::softmax(input_tensor, -1);
+
+        trace = capture.end_graph_capture();
+    }
+
+    for (const auto& node : trace) {
+        if (node.at(ttnn::graph::kNodeType) == ttnn::graph::kNodeBufferDeallocate) {
+            const auto& params = node.at(ttnn::graph::kParams);
+            EXPECT_TRUE(params.contains(ttnn::graph::kExactBufferType))
+                << "buffer_deallocate should contain exact_buffer_type";
+            if (params.contains(ttnn::graph::kExactBufferType)) {
+                EXPECT_TRUE(params.at(ttnn::graph::kExactBufferType).is_string());
+            }
+            EXPECT_TRUE(params.contains(ttnn::graph::kAddress)) << "buffer_deallocate should contain address";
+        }
+    }
+
+    // Verify buffer_allocate events also carry exact_buffer_type (stronger check)
+    bool found_alloc = false;
+    for (const auto& node : trace) {
+        if (node.at(ttnn::graph::kNodeType) == ttnn::graph::kNodeBufferAllocate) {
+            found_alloc = true;
+            const auto& params = node.at(ttnn::graph::kParams);
+            ASSERT_TRUE(params.contains(ttnn::graph::kExactBufferType));
+            ASSERT_TRUE(params.contains(ttnn::graph::kAddress));
+        }
+    }
+    EXPECT_TRUE(found_alloc) << "Expected at least one buffer_allocate node";
 }

--- a/tests/ttnn/unit_tests/gtests/test_levelized_graph.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_levelized_graph.cpp
@@ -63,95 +63,52 @@ TEST_F(TestLevelizedGraphCapture, SimpleBinaryOp) {
     }
 
     ttnn::graph::LevelizedGraph levelized_graph(ref_json_trace, 1);
-    // Note: High-level function tracing (ttnn::add) was removed from decorators.hpp
-    // Now only device operations are captured: BinaryNgDeviceOperation
-    // Includes: 1 tensor + 1 device operation
-    EXPECT_EQ(levelized_graph.size(), 2);
-    // invariants: all vertices should be at level 1 and with no internals:
+    // Includes: 1 tensor + 1 device operation + deallocate(s)
+    EXPECT_GE(levelized_graph.size(), 2);
     EXPECT_TRUE(std::ranges::all_of(
         levelized_graph.vertices(), [&](const auto& vertex) { return vertex.stacking_level == 1; }));
     EXPECT_TRUE(
         std::ranges::all_of(levelized_graph.vertices(), [&](const auto& vertex) { return vertex.internals.empty(); }));
 
-    auto vertex_0 = levelized_graph.get_vertex(0);
-    auto vertex_1 = levelized_graph.get_vertex(1);
-    EXPECT_TRUE(vertex_0.name.find("tensor") != std::string::npos);
-    // High-level function tracing removed - now we get BinaryNgDeviceOperation directly
-    EXPECT_EQ(vertex_1.name, "BinaryNgDeviceOperation");
+    auto tensor_it = std::ranges::find_if(levelized_graph.vertices(), [](const auto& v) {
+        return v.name.find("tensor") != std::string::npos && v.in_edges.empty();
+    });
+    ASSERT_NE(tensor_it, levelized_graph.vertices().end());
 
-    EXPECT_TRUE(vertex_0.in_edges.empty());
-    EXPECT_EQ(vertex_0.out_edges.size(), 1);
-    EXPECT_EQ(vertex_0.out_edges[0], vertex_1.id);
-    EXPECT_EQ(vertex_0.output_shape[0], shape_to_string(tt::tt_metal::Array2D{64, 128}));
-    EXPECT_TRUE(vertex_0.internals.empty());
+    auto binary_it = std::ranges::find_if(levelized_graph.vertices(), [](const auto& v) {
+        return v.name.find("BinaryNg") != std::string::npos || v.name.find("Binary") != std::string::npos;
+    });
+    ASSERT_NE(binary_it, levelized_graph.vertices().end());
+    auto vertex_1 = *binary_it;
 
-    EXPECT_EQ(vertex_1.in_edges.size(), 2);  // 2 in edges since we're re-using the same tensor.
-    EXPECT_EQ(vertex_1.in_edges[0], vertex_0.id);
-    EXPECT_EQ(vertex_1.in_edges[1], vertex_0.id);
+    // Tensor deduplication was removed: add(a, a) now creates two separate tensor
+    // nodes.  Both in_edges of the binary op must reference tensor vertices.
+    EXPECT_EQ(vertex_1.in_edges.size(), 2);
+    for (auto edge_id : vertex_1.in_edges) {
+        const auto& edge_vertex = levelized_graph.get_vertex(edge_id);
+        EXPECT_TRUE(edge_vertex.name.find("tensor") != std::string::npos);
+    }
     EXPECT_TRUE(vertex_1.out_edges.empty());
-    EXPECT_TRUE(vertex_1.internals.empty());
     EXPECT_FALSE(vertex_1.output_shape.empty());
     EXPECT_EQ(vertex_1.output_shape[0], shape_to_string(tt::tt_metal::Array2D{64, 128}));
 
     // Now get the same graph but up to level 2:
     auto levelized_graph_2 = ttnn::graph::LevelizedGraph(ref_json_trace, 2);
 
-    // Note: High-level function tracing (ttnn::add) was removed from decorators.hpp
-    // Now only device operations are captured, so level 2 graph structure is different
-    // The structure may have 2 or 3 vertices depending on how device operations are captured
     EXPECT_GE(levelized_graph_2.size(), 2);
     EXPECT_TRUE(std::ranges::all_of(
         levelized_graph_2.vertices(), [&](const auto& vertex) { return vertex.stacking_level <= 2; }));
-    if (levelized_graph_2.size() > 2) {
-        EXPECT_TRUE(std::ranges::all_of(
-            levelized_graph_2.get_vertices_at_level(2), [&](const auto& vertex) { return vertex.internals.empty(); }));
-    }
-    EXPECT_TRUE(std::ranges::none_of(
-        levelized_graph_2.vertices(), [&](const auto& vertex) { return vertex.output_shape.empty(); }));
 
-    vertex_0 = levelized_graph_2.get_vertex(0);
-    vertex_1 = levelized_graph_2.get_vertex(1);
-    EXPECT_TRUE(vertex_0.name.find("tensor") != std::string::npos);
-    // High-level function tracing removed - now we get BinaryNgDeviceOperation directly
-    EXPECT_EQ(vertex_1.name, "BinaryNgDeviceOperation");
+    auto binary_it_2 = std::ranges::find_if(levelized_graph_2.vertices(), [](const auto& v) {
+        return v.name.find("BinaryNg") != std::string::npos || v.name.find("Binary") != std::string::npos;
+    });
+    ASSERT_NE(binary_it_2, levelized_graph_2.vertices().end());
+    vertex_1 = *binary_it_2;
 
-    // If there's a third vertex, it should be create_device_tensor
-    if (levelized_graph_2.size() > 2) {
-        const auto& vertex_2 = levelized_graph_2.get_vertex(2);
-        EXPECT_TRUE(vertex_2.name.find("create_device_tensor") != std::string::npos);
-    }
-
-    EXPECT_EQ(vertex_0.output_shape[0], shape_to_string(tt::tt_metal::Array2D{64, 128}));
-    EXPECT_EQ(vertex_1.output_shape[0], shape_to_string(tt::tt_metal::Array2D{64, 128}));
-    // vertex_2 may not exist if high-level tracing was removed
-    if (levelized_graph_2.size() > 2) {
-        const auto& vertex_2 = levelized_graph_2.get_vertex(2);
-        EXPECT_EQ(vertex_2.output_shape[0], shape_to_string(tt::tt_metal::Array2D{64, 128}));
-    }
-
-    // Note: Structure changed due to removal of high-level function tracing
-    // The exact structure depends on how device operations are captured
-    EXPECT_TRUE(vertex_0.in_edges.empty());
-    EXPECT_GE(vertex_0.out_edges.size(), 1);
-    EXPECT_EQ(vertex_0.out_edges[0], vertex_1.id);
-    EXPECT_TRUE(vertex_0.internals.empty());
-
-    EXPECT_EQ(vertex_1.in_edges.size(), 2);  // 2 in edges since we're re-using the same tensor.
-    EXPECT_EQ(vertex_1.in_edges[0], vertex_0.id);
-    EXPECT_EQ(vertex_1.in_edges[1], vertex_0.id);
-    // Note: With high-level tracing removed, device operations may have internals even at level 1
-    // depending on how the levelized graph is constructed
-
-    // If vertex_2 exists, check its structure
-    if (levelized_graph_2.size() > 2) {
-        const auto& vertex_2 = levelized_graph_2.get_vertex(2);
-        // vertex_2 structure depends on how device operations are captured
-        // It may or may not have in_edges depending on the graph structure
-        EXPECT_TRUE(vertex_2.out_edges.empty());
-        // Internals may or may not be empty depending on the level
-        if (vertex_2.stacking_level == 2) {
-            EXPECT_TRUE(vertex_2.internals.empty());
-        }
+    EXPECT_EQ(vertex_1.in_edges.size(), 2);
+    for (auto edge_id : vertex_1.in_edges) {
+        const auto& edge_vertex = levelized_graph_2.get_vertex(edge_id);
+        EXPECT_TRUE(edge_vertex.name.find("tensor") != std::string::npos);
     }
 }
 
@@ -178,11 +135,8 @@ TEST_F(TestLevelizedGraphCapture, ReductionOp) {
         ref_json_trace = capture.end_graph_capture();
     }
 
-    // Note: High-level function tracing (ttnn::sum, ttnn::mean) was removed from decorators.hpp
-    // Now only device operations are captured. The graph structure is more complex.
     // Test level 1
     ttnn::graph::LevelizedGraph levelized_graph(ref_json_trace, 1);
-    // The graph will have more vertices since device operations are captured directly
     EXPECT_GE(levelized_graph.size(), 3);
     EXPECT_TRUE(std::ranges::all_of(
         levelized_graph.vertices(), [&](const auto& vertex) { return vertex.stacking_level == 1; }));
@@ -212,11 +166,9 @@ TEST_F(TestLevelizedGraphCapture, ReductionOp) {
                 std::ranges::all_of(level_2_vertices, [&](const auto& vertex) { return vertex.internals.empty(); }));
         }
     }
-    EXPECT_TRUE(std::ranges::none_of(
-        levelized_graph_2.vertices(), [&](const auto& vertex) { return vertex.output_shape.empty(); }));
-
-    // Note: High-level function tracing removed - structure is different now
-    // Device operations are captured directly, so the internals structure is different
+    EXPECT_TRUE(std::ranges::none_of(levelized_graph_2.vertices(), [&](const auto& vertex) {
+        return vertex.output_shape.empty() && vertex.name.find("deallocate") == std::string::npos;
+    }));
 }
 
 TEST_F(TestLevelizedGraphCapture, OutputLayoutInfo) {
@@ -242,18 +194,11 @@ TEST_F(TestLevelizedGraphCapture, OutputLayoutInfo) {
         ref_json_trace = capture.end_graph_capture();
     }
 
-    // Note: High-level function tracing (ttnn::sum, ttnn::softmax) was removed from decorators.hpp
-    // Now only device operations are captured. The graph structure is more complex.
     // Test level 1
     ttnn::graph::LevelizedGraph levelized_graph(ref_json_trace, 1);
-    // The graph will have more vertices since device operations are captured directly
     EXPECT_GE(levelized_graph.size(), 3);
     EXPECT_TRUE(std::ranges::all_of(
         levelized_graph.vertices(), [&](const auto& vertex) { return vertex.stacking_level == 1; }));
-    // With high-level tracing removed, internals may exist even at level 1
-    // EXPECT_TRUE(
-    //     std::ranges::all_of(levelized_graph.vertices(), [&](const auto& vertex) { return vertex.internals.empty();
-    //     }));
 
     // Find the input tensor vertex
     auto input_tensor_it = std::ranges::find_if(levelized_graph.vertices(), [](const auto& v) {
@@ -270,8 +215,6 @@ TEST_F(TestLevelizedGraphCapture, OutputLayoutInfo) {
     EXPECT_GE(vertex_0.out_edges.size(), 1);
     EXPECT_EQ(vertex_0.output_shape[0], shape_to_string(tt::tt_metal::Array3D{16, 32, 64}));
 
-    // With high-level tracing removed, we can't verify the exact structure
-    // but we can verify that the graph has the expected operations
     auto has_reduction = std::ranges::any_of(
         levelized_graph.vertices(), [](const auto& v) { return v.name.find("Reduce") != std::string::npos; });
     auto has_softmax = std::ranges::any_of(
@@ -289,11 +232,9 @@ TEST_F(TestLevelizedGraphCapture, OutputLayoutInfo) {
                 std::ranges::all_of(level_2_vertices, [&](const auto& vertex) { return vertex.internals.empty(); }));
         }
     }
-    EXPECT_TRUE(std::ranges::none_of(
-        levelized_graph_2.vertices(), [&](const auto& vertex) { return vertex.output_shape.empty(); }));
-
-    // Note: High-level function tracing removed - structure is different now
-    // Device operations are captured directly, so we can't verify specific internals structure
+    EXPECT_TRUE(std::ranges::none_of(levelized_graph_2.vertices(), [&](const auto& vertex) {
+        return vertex.output_shape.empty() && vertex.name.find("deallocate") == std::string::npos;
+    }));
 }
 
 TEST_F(TestLevelizedGraphCapture, MatmulWithBiasTest) {
@@ -319,18 +260,11 @@ TEST_F(TestLevelizedGraphCapture, MatmulWithBiasTest) {
         ref_json_trace = capture.end_graph_capture();
     }
 
-    // Note: High-level function tracing (ttnn::matmul, ttnn::add) was removed from decorators.hpp
-    // Now only device operations are captured. The graph structure is more complex.
     // Test level 1
     ttnn::graph::LevelizedGraph levelized_graph(ref_json_trace, 1);
-    // The graph will have more vertices since device operations are captured directly
     EXPECT_GE(levelized_graph.size(), 3);
     EXPECT_TRUE(std::ranges::all_of(
         levelized_graph.vertices(), [&](const auto& vertex) { return vertex.stacking_level == 1; }));
-    // With high-level tracing removed, internals may exist even at level 1
-    // EXPECT_TRUE(
-    //     std::ranges::all_of(levelized_graph.vertices(), [&](const auto& vertex) { return vertex.internals.empty();
-    //     }));
 
     // Find the input tensor vertex
     auto input_tensor_it = std::ranges::find_if(levelized_graph.vertices(), [](const auto& v) {
@@ -353,8 +287,6 @@ TEST_F(TestLevelizedGraphCapture, MatmulWithBiasTest) {
     EXPECT_GE(vertex_0.out_edges.size(), 1);  // feeds operations
     EXPECT_EQ(vertex_0.output_shape[0], shape_to_string(tt::tt_metal::Array2D{32, 32}));
 
-    // With high-level tracing removed, we can't verify the exact structure
-    // but we can verify that the graph has the expected operations
     EXPECT_TRUE(matmul_op_it != levelized_graph.vertices().end() || add_op_it != levelized_graph.vertices().end());
 
     // Test level 2
@@ -368,11 +300,9 @@ TEST_F(TestLevelizedGraphCapture, MatmulWithBiasTest) {
                 std::ranges::all_of(level_2_vertices, [&](const auto& vertex) { return vertex.internals.empty(); }));
         }
     }
-    EXPECT_TRUE(std::ranges::none_of(
-        levelized_graph_2.vertices(), [&](const auto& vertex) { return vertex.output_shape.empty(); }));
-
-    // Note: High-level function tracing removed - structure is different now
-    // Device operations are captured directly, so we can't verify specific internals structure
+    EXPECT_TRUE(std::ranges::none_of(levelized_graph_2.vertices(), [&](const auto& vertex) {
+        return vertex.output_shape.empty() && vertex.name.find("deallocate") == std::string::npos;
+    }));
 }
 
 TEST_F(TestLevelizedGraphCapture, CompositeOpTest) {
@@ -395,18 +325,11 @@ TEST_F(TestLevelizedGraphCapture, CompositeOpTest) {
         ref_json_trace = capture.end_graph_capture();
     }
 
-    // Note: High-level function tracing (ttnn::digamma) was removed from decorators.hpp
-    // Now only device operations are captured. The graph structure is more complex.
     // Test level 1
     ttnn::graph::LevelizedGraph levelized_graph(ref_json_trace, 1);
-    // The graph will have more vertices since device operations are captured directly
     EXPECT_GE(levelized_graph.size(), 2);
     EXPECT_TRUE(std::ranges::all_of(
         levelized_graph.vertices(), [&](const auto& vertex) { return vertex.stacking_level == 1; }));
-    // With high-level tracing removed, internals may exist even at level 1
-    // EXPECT_TRUE(
-    //     std::ranges::all_of(levelized_graph.vertices(), [&](const auto& vertex) { return vertex.internals.empty();
-    //     }));
 
     // Find the input tensor vertex
     auto input_tensor_it = std::ranges::find_if(levelized_graph.vertices(), [](const auto& v) {
@@ -427,8 +350,6 @@ TEST_F(TestLevelizedGraphCapture, CompositeOpTest) {
     EXPECT_GE(vertex_0.out_edges.size(), 1);
     EXPECT_EQ(vertex_0.output_shape[0], shape_to_string(tt::tt_metal::Array2D{12, 19}));
 
-    // With high-level tracing removed, we can't verify the exact structure
-    // but we can verify that the graph has the expected operation
     EXPECT_TRUE(digamma_op_it != levelized_graph.vertices().end());
 
     // Test level 2
@@ -442,11 +363,9 @@ TEST_F(TestLevelizedGraphCapture, CompositeOpTest) {
                 std::ranges::all_of(level_2_vertices, [&](const auto& vertex) { return vertex.internals.empty(); }));
         }
     }
-    EXPECT_TRUE(std::ranges::none_of(
-        levelized_graph_2.vertices(), [&](const auto& vertex) { return vertex.output_shape.empty(); }));
-
-    // Note: High-level function tracing removed - structure is different now
-    // Device operations are captured directly, so we can't verify specific internals structure
+    EXPECT_TRUE(std::ranges::none_of(levelized_graph_2.vertices(), [&](const auto& vertex) {
+        return vertex.output_shape.empty() && vertex.name.find("deallocate") == std::string::npos;
+    }));
 }
 
 TEST_F(TestLevelizedGraphCapture, MultiplySelfTest) {
@@ -471,17 +390,11 @@ TEST_F(TestLevelizedGraphCapture, MultiplySelfTest) {
         ref_json_trace = capture.end_graph_capture();
     }
 
-    // Note: High-level function tracing (ttnn::multiply) was removed from decorators.hpp
-    // Now only device operations are captured: BinaryNgDeviceOperation
     // Test level 1
     ttnn::graph::LevelizedGraph levelized_graph(ref_json_trace, 1);
     EXPECT_GE(levelized_graph.size(), 2);  // tensor, device operation
     EXPECT_TRUE(std::ranges::all_of(
         levelized_graph.vertices(), [&](const auto& vertex) { return vertex.stacking_level == 1; }));
-    // With high-level tracing removed, internals may exist even at level 1
-    // EXPECT_TRUE(
-    //     std::ranges::all_of(levelized_graph.vertices(), [&](const auto& vertex) { return vertex.internals.empty();
-    //     }));
 
     // Find the input tensor vertex
     auto input_tensor_it = std::ranges::find_if(levelized_graph.vertices(), [](const auto& v) {
@@ -499,16 +412,15 @@ TEST_F(TestLevelizedGraphCapture, MultiplySelfTest) {
 
     EXPECT_TRUE(vertex_0.in_edges.empty());
     EXPECT_GE(vertex_0.out_edges.size(), 1);
-    // vertex_0 should connect to vertex_1
-    EXPECT_TRUE(std::ranges::find(vertex_0.out_edges, vertex_1.id) != vertex_0.out_edges.end());
     EXPECT_EQ(vertex_0.output_shape[0], shape_to_string(tt::tt_metal::Array2D{64, 128}));
 
-    EXPECT_EQ(vertex_1.in_edges.size(), 2);  // 2 in edges since we're re-using the same tensor
-    EXPECT_EQ(vertex_1.in_edges[0], vertex_0.id);
-    EXPECT_EQ(vertex_1.in_edges[1], vertex_0.id);
+    // Tensor dedup removed: multiply(a,a) creates two separate tensor vertices.
+    EXPECT_EQ(vertex_1.in_edges.size(), 2);
+    for (auto edge_id : vertex_1.in_edges) {
+        const auto& edge_v = levelized_graph.get_vertex(edge_id);
+        EXPECT_TRUE(edge_v.name.find("tensor") != std::string::npos);
+    }
     EXPECT_TRUE(vertex_1.out_edges.empty());
-    // With high-level tracing removed, internals may exist even at level 1
-    // EXPECT_TRUE(vertex_1.internals.empty());
     EXPECT_FALSE(vertex_1.output_shape.empty());
     EXPECT_EQ(vertex_1.output_shape[0], shape_to_string(tt::tt_metal::Array2D{64, 128}));
 
@@ -524,8 +436,9 @@ TEST_F(TestLevelizedGraphCapture, MultiplySelfTest) {
                 std::ranges::all_of(level_2_vertices, [&](const auto& vertex) { return vertex.internals.empty(); }));
         }
     }
-    EXPECT_TRUE(std::ranges::none_of(
-        levelized_graph_2.vertices(), [&](const auto& vertex) { return vertex.output_shape.empty(); }));
+    EXPECT_TRUE(std::ranges::none_of(levelized_graph_2.vertices(), [&](const auto& vertex) {
+        return vertex.output_shape.empty() && vertex.name.find("deallocate") == std::string::npos;
+    }));
 
     // Find vertices by name since structure changed
     auto vertex_0_it = std::ranges::find_if(levelized_graph_2.vertices(), [](const auto& v) {
@@ -541,7 +454,6 @@ TEST_F(TestLevelizedGraphCapture, MultiplySelfTest) {
     vertex_1 = *vertex_1_it;
 
     EXPECT_TRUE(vertex_0.name.find("tensor") != std::string::npos);
-    // High-level function tracing removed - now we get BinaryNgDeviceOperation directly
     EXPECT_TRUE(
         vertex_1.name.find("BinaryNg") != std::string::npos || vertex_1.name.find("Binary") != std::string::npos);
 
@@ -552,14 +464,11 @@ TEST_F(TestLevelizedGraphCapture, MultiplySelfTest) {
     EXPECT_TRUE(vertex_0.internals.empty());
 
     EXPECT_EQ(vertex_1.in_edges.size(), 2);
-    EXPECT_EQ(vertex_1.in_edges[0], vertex_0.id);
-    EXPECT_EQ(vertex_1.in_edges[1], vertex_0.id);
+    for (auto edge_id : vertex_1.in_edges) {
+        const auto& edge_v = levelized_graph_2.get_vertex(edge_id);
+        EXPECT_TRUE(edge_v.name.find("tensor") != std::string::npos);
+    }
     EXPECT_TRUE(vertex_1.out_edges.empty());
-    // With high-level tracing removed, internals structure is different
-    // EXPECT_EQ(vertex_1.internals.size(), 1);
-
-    // Note: With high-level tracing removed, vertex_2 may not exist or may be structured differently
-    // The exact structure depends on how device operations are captured
 }
 
 TEST_F(TestLevelizedGraphCapture, ForkTest) {
@@ -585,11 +494,8 @@ TEST_F(TestLevelizedGraphCapture, ForkTest) {
         ref_json_trace = capture.end_graph_capture();
     }
 
-    // Note: High-level function tracing (ttnn::add, ttnn::subtract) was removed from decorators.hpp
-    // Now only device operations are captured. The graph structure is more complex.
     // Test level 1 - fork: one input tensor feeds multiple operations
     ttnn::graph::LevelizedGraph levelized_graph(ref_json_trace, 1);
-    // The graph will have more vertices since device operations are captured directly
     EXPECT_GE(levelized_graph.size(), 3);
     EXPECT_TRUE(std::ranges::all_of(
         levelized_graph.vertices(), [&](const auto& vertex) { return vertex.stacking_level == 1; }));
@@ -630,16 +536,19 @@ TEST_F(TestLevelizedGraphCapture, ForkTest) {
     // vertex_0 should connect to vertex_1
     EXPECT_TRUE(std::ranges::find(vertex_0.out_edges, vertex_1.id) != vertex_0.out_edges.end());
 
-    EXPECT_EQ(vertex_1.in_edges.size(), 2);  // both inputs from vertex_0
-    EXPECT_EQ(vertex_1.in_edges[0], vertex_0.id);
-    EXPECT_EQ(vertex_1.in_edges[1], vertex_0.id);
+    EXPECT_EQ(vertex_1.in_edges.size(), 2);
+    for (auto edge_id : vertex_1.in_edges) {
+        const auto& edge_vertex = levelized_graph.get_vertex(edge_id);
+        EXPECT_TRUE(edge_vertex.name.find("tensor") != std::string::npos);
+    }
     EXPECT_TRUE(vertex_1.out_edges.empty());
 
-    // If vertex_2 is different from vertex_1, check its structure
     if (vertex_2.id != vertex_1.id) {
-        EXPECT_EQ(vertex_2.in_edges.size(), 2);  // both inputs from vertex_0
-        EXPECT_EQ(vertex_2.in_edges[0], vertex_0.id);
-        EXPECT_EQ(vertex_2.in_edges[1], vertex_0.id);
+        EXPECT_EQ(vertex_2.in_edges.size(), 2);
+        for (auto edge_id : vertex_2.in_edges) {
+            const auto& edge_vertex = levelized_graph.get_vertex(edge_id);
+            EXPECT_TRUE(edge_vertex.name.find("tensor") != std::string::npos);
+        }
         EXPECT_TRUE(vertex_2.out_edges.empty());
     }
 
@@ -654,9 +563,6 @@ TEST_F(TestLevelizedGraphCapture, ForkTest) {
                 std::ranges::all_of(level_2_vertices, [&](const auto& vertex) { return vertex.internals.empty(); }));
         }
     }
-
-    // Note: High-level function tracing removed - structure is different now
-    // Device operations are captured directly, so we can't verify specific internals structure
 }
 
 TEST_F(TestLevelizedGraphCapture, JoinTest) {
@@ -688,11 +594,8 @@ TEST_F(TestLevelizedGraphCapture, JoinTest) {
         ref_json_trace = capture.end_graph_capture();
     }
 
-    // Note: High-level function tracing (ttnn::add) was removed from decorators.hpp
-    // Now only device operations are captured. The graph structure is more complex.
     // Test level 1 - join: one operation uses multiple different input tensors
     ttnn::graph::LevelizedGraph levelized_graph(ref_json_trace, 1);
-    // The graph will have more vertices since device operations are captured directly
     EXPECT_GE(levelized_graph.size(), 3);
     EXPECT_TRUE(std::ranges::all_of(
         levelized_graph.vertices(), [&](const auto& vertex) { return vertex.stacking_level == 1; }));
@@ -742,9 +645,6 @@ TEST_F(TestLevelizedGraphCapture, JoinTest) {
                 std::ranges::all_of(level_2_vertices, [&](const auto& vertex) { return vertex.internals.empty(); }));
         }
     }
-
-    // Note: High-level function tracing removed - structure is different now
-    // Device operations are captured directly, so we can't verify specific internals structure
 }
 
 TEST_F(TestLevelizedGraphCapture, OrderOfArgs) {
@@ -771,8 +671,6 @@ TEST_F(TestLevelizedGraphCapture, OrderOfArgs) {
         ref_json_trace = capture.end_graph_capture();
     }
 
-    // Note: High-level function tracing (ttnn::subtract) was removed from decorators.hpp
-    // Now only device operations are captured, but argument order is still preserved in in_edges
     // Test level 1
     ttnn::graph::LevelizedGraph levelized_graph(ref_json_trace, 1);
     EXPECT_GE(levelized_graph.size(), 4);
@@ -803,32 +701,35 @@ TEST_F(TestLevelizedGraphCapture, OrderOfArgs) {
 
     EXPECT_TRUE(tensor_a_vertex.name.find("tensor") != std::string::npos);
     EXPECT_TRUE(tensor_b_vertex.name.find("tensor") != std::string::npos);
-    // High-level function tracing removed - now we get BinaryNgDeviceOperation
     EXPECT_TRUE(
         subtract_ab.name.find("BinaryNg") != std::string::npos || subtract_ab.name.find("Binary") != std::string::npos);
     EXPECT_TRUE(
         subtract_ba.name.find("BinaryNg") != std::string::npos || subtract_ba.name.find("Binary") != std::string::npos);
 
-    // Both tensors connect to both subtract operations
     EXPECT_TRUE(tensor_a_vertex.in_edges.empty());
-    EXPECT_EQ(tensor_a_vertex.out_edges.size(), 2);
     EXPECT_TRUE(tensor_b_vertex.in_edges.empty());
-    EXPECT_EQ(tensor_b_vertex.out_edges.size(), 2);
 
-    // First subtract(a, b) should have in_edges [a, b]
+    // First subtract(a, b) should have 2 tensor inputs
     EXPECT_EQ(subtract_ab.in_edges.size(), 2);
-    EXPECT_EQ(subtract_ab.in_edges[0], tensor_a_vertex.id);
-    EXPECT_EQ(subtract_ab.in_edges[1], tensor_b_vertex.id);
+    const auto& sub_ab_in0 = levelized_graph.get_vertex(subtract_ab.in_edges[0]);
+    const auto& sub_ab_in1 = levelized_graph.get_vertex(subtract_ab.in_edges[1]);
+    EXPECT_TRUE(sub_ab_in0.name.find("tensor") != std::string::npos);
+    EXPECT_TRUE(sub_ab_in1.name.find("tensor") != std::string::npos);
+    EXPECT_NE(sub_ab_in0.name, sub_ab_in1.name);
     EXPECT_TRUE(subtract_ab.out_edges.empty());
 
-    // Second subtract(b, a) should have in_edges [b, a]
+    // Second subtract(b, a) should have 2 tensor inputs with reversed order
     EXPECT_EQ(subtract_ba.in_edges.size(), 2);
-    EXPECT_EQ(subtract_ba.in_edges[0], tensor_b_vertex.id);
-    EXPECT_EQ(subtract_ba.in_edges[1], tensor_a_vertex.id);
+    const auto& sub_ba_in0 = levelized_graph.get_vertex(subtract_ba.in_edges[0]);
+    const auto& sub_ba_in1 = levelized_graph.get_vertex(subtract_ba.in_edges[1]);
+    EXPECT_TRUE(sub_ba_in0.name.find("tensor") != std::string::npos);
+    EXPECT_TRUE(sub_ba_in1.name.find("tensor") != std::string::npos);
+    EXPECT_NE(sub_ba_in0.name, sub_ba_in1.name);
     EXPECT_TRUE(subtract_ba.out_edges.empty());
 
-    // Verify that the two subtract operations have different input orders
-    EXPECT_NE(subtract_ab.in_edges, subtract_ba.in_edges);
+    // Verify argument order is preserved: tensor names should be swapped
+    EXPECT_EQ(sub_ab_in0.name, sub_ba_in1.name);
+    EXPECT_EQ(sub_ab_in1.name, sub_ba_in0.name);
 
     // Test level 2
     auto levelized_graph_2 = ttnn::graph::LevelizedGraph(ref_json_trace, 2);
@@ -841,9 +742,6 @@ TEST_F(TestLevelizedGraphCapture, OrderOfArgs) {
                 std::ranges::all_of(level_2_vertices, [&](const auto& vertex) { return vertex.internals.empty(); }));
         }
     }
-
-    // Note: High-level function tracing removed - structure is different now
-    // Device operations are captured directly, so we can't verify specific internals structure
 }
 
 TEST_F(TestLevelizedGraphCapture, OrderOfArgsIntermediateTensorTest) {
@@ -872,8 +770,6 @@ TEST_F(TestLevelizedGraphCapture, OrderOfArgsIntermediateTensorTest) {
         ref_json_trace = capture.end_graph_capture();
     }
 
-    // Note: High-level function tracing (ttnn::add, ttnn::subtract) was removed from decorators.hpp
-    // Now only device operations are captured, but argument order is still preserved in in_edges
     // Test level 1
     ttnn::graph::LevelizedGraph levelized_graph(ref_json_trace, 1);
 
@@ -882,17 +778,6 @@ TEST_F(TestLevelizedGraphCapture, OrderOfArgsIntermediateTensorTest) {
     EXPECT_TRUE(std::ranges::all_of(
         levelized_graph.vertices(), [&](const auto& vertex) { return vertex.stacking_level == 1; }));
 
-    // Find input tensor vertices
-    auto tensor_vertices = std::vector<decltype(levelized_graph.vertices().begin())>();
-    for (auto it = levelized_graph.vertices().begin(); it != levelized_graph.vertices().end(); ++it) {
-        if (it->name.find("tensor") != std::string::npos && it->in_edges.empty()) {
-            tensor_vertices.push_back(it);
-        }
-    }
-    EXPECT_GE(tensor_vertices.size(), 2);
-    const auto& tensor_a_vertex = *tensor_vertices[0];
-    const auto& tensor_b_vertex = *tensor_vertices[1];
-
     // Find binary operations (add and subtract are both BinaryNgDeviceOperation now)
     auto binary_ops = std::vector<decltype(levelized_graph.vertices().begin())>();
     for (auto it = levelized_graph.vertices().begin(); it != levelized_graph.vertices().end(); ++it) {
@@ -900,93 +785,47 @@ TEST_F(TestLevelizedGraphCapture, OrderOfArgsIntermediateTensorTest) {
             binary_ops.push_back(it);
         }
     }
-    EXPECT_GE(binary_ops.size(), 4);  // At least 4 binary operations (2 adds, 2 subtracts)
+    // The first 2 binary ops (in graph order) are the adds, the last 2 are the subtracts.
+    ASSERT_GE(binary_ops.size(), 4);
+    const auto& add_aa = *binary_ops[0];
+    const auto& add_bb = *binary_ops[1];
+    const auto& subtract_12 = *binary_ops[2];
+    const auto& subtract_21 = *binary_ops[3];
 
-    // Find add operations: they take the same tensor twice as input
-    auto add_ops = std::vector<decltype(levelized_graph.vertices().begin())>();
-    for (auto it : binary_ops) {
-        if (it->in_edges.size() == 2 && it->in_edges[0] == it->in_edges[1]) {
-            add_ops.push_back(it);
-        }
-    }
-    EXPECT_GE(add_ops.size(), 2);
-    const auto& add_aa = *add_ops[0];  // add(a, a) - both inputs from tensor_a
-    const auto& add_bb = *add_ops[1];  // add(b, b) - both inputs from tensor_b
-
-    // Find subtract operations: they take two different intermediate tensors as input
-    auto subtract_ops = std::vector<decltype(levelized_graph.vertices().begin())>();
-    for (auto it : binary_ops) {
-        if (it->in_edges.size() == 2 && it->in_edges[0] != it->in_edges[1] && it->in_edges[0] != tensor_a_vertex.id &&
-            it->in_edges[0] != tensor_b_vertex.id && it->in_edges[1] != tensor_a_vertex.id &&
-            it->in_edges[1] != tensor_b_vertex.id) {
-            subtract_ops.push_back(it);
-        }
-    }
-    EXPECT_GE(subtract_ops.size(), 2);
-    const auto& subtract_12 = *subtract_ops[0];  // subtract(output_tensor_1, output_tensor_2)
-    const auto& subtract_21 = *subtract_ops[1];  // subtract(output_tensor_2, output_tensor_1)
-
-    // Verify tensor names
-    EXPECT_TRUE(tensor_a_vertex.name.find("tensor") != std::string::npos);
-    EXPECT_TRUE(tensor_b_vertex.name.find("tensor") != std::string::npos);
-    // High-level function tracing removed - now we get BinaryNgDeviceOperation
-    EXPECT_TRUE(add_aa.name.find("BinaryNg") != std::string::npos || add_aa.name.find("Binary") != std::string::npos);
-    EXPECT_TRUE(add_bb.name.find("BinaryNg") != std::string::npos || add_bb.name.find("Binary") != std::string::npos);
-    EXPECT_TRUE(
-        subtract_12.name.find("BinaryNg") != std::string::npos || subtract_12.name.find("Binary") != std::string::npos);
-    EXPECT_TRUE(
-        subtract_21.name.find("BinaryNg") != std::string::npos || subtract_21.name.find("Binary") != std::string::npos);
-
-    // Verify input tensors have no incoming edges (they are runtime inputs)
-    EXPECT_TRUE(tensor_a_vertex.in_edges.empty());
-    EXPECT_TRUE(tensor_b_vertex.in_edges.empty());
-
-    // Verify first add(a, a) has correct inputs
+    // Verify add operations have tensor inputs representing the same underlying tensor
     EXPECT_EQ(add_aa.in_edges.size(), 2);
-    EXPECT_EQ(add_aa.in_edges[0], tensor_a_vertex.id);
-    EXPECT_EQ(add_aa.in_edges[1], tensor_a_vertex.id);
+    const auto& add_aa_in0 = levelized_graph.get_vertex(add_aa.in_edges[0]);
+    const auto& add_aa_in1 = levelized_graph.get_vertex(add_aa.in_edges[1]);
+    EXPECT_TRUE(add_aa_in0.name.find("tensor") != std::string::npos);
+    EXPECT_TRUE(add_aa_in1.name.find("tensor") != std::string::npos);
+    EXPECT_EQ(add_aa_in0.name, add_aa_in1.name);
 
-    // Verify second add(b, b) has correct inputs
     EXPECT_EQ(add_bb.in_edges.size(), 2);
-    EXPECT_EQ(add_bb.in_edges[0], tensor_b_vertex.id);
-    EXPECT_EQ(add_bb.in_edges[1], tensor_b_vertex.id);
+    const auto& add_bb_in0 = levelized_graph.get_vertex(add_bb.in_edges[0]);
+    const auto& add_bb_in1 = levelized_graph.get_vertex(add_bb.in_edges[1]);
+    EXPECT_TRUE(add_bb_in0.name.find("tensor") != std::string::npos);
+    EXPECT_TRUE(add_bb_in1.name.find("tensor") != std::string::npos);
+    EXPECT_EQ(add_bb_in0.name, add_bb_in1.name);
 
-    // KEY TEST: Verify first subtract(output_tensor_1, output_tensor_2) has correct argument order
-    // This tests that intermediate tensors maintain their order
+    // add_aa and add_bb use different underlying tensors
+    EXPECT_NE(add_aa_in0.name, add_bb_in0.name);
+
+    // KEY TEST: subtract operations have 2 inputs each
     EXPECT_EQ(subtract_12.in_edges.size(), 2);
-    EXPECT_EQ(subtract_12.in_edges[0], add_aa.id);  // First arg: output_tensor_1 = add(a, a)
-    EXPECT_EQ(subtract_12.in_edges[1], add_bb.id);  // Second arg: output_tensor_2 = add(b, b)
-
-    // KEY TEST: Verify second subtract(output_tensor_2, output_tensor_1) has REVERSED argument order
-    // This is the critical test - argument order must be preserved for intermediate tensors
     EXPECT_EQ(subtract_21.in_edges.size(), 2);
-    EXPECT_EQ(subtract_21.in_edges[0], add_bb.id);  // First arg: output_tensor_2 = add(b, b)
-    EXPECT_EQ(subtract_21.in_edges[1], add_aa.id);  // Second arg: output_tensor_1 = add(a, a)
 
-    // Verify the two subtract operations have different input orders
-    EXPECT_NE(subtract_12.in_edges, subtract_21.in_edges);
+    // Verify the subtract operations have reversed argument order by comparing input names
+    const auto& s12_in0 = levelized_graph.get_vertex(subtract_12.in_edges[0]);
+    const auto& s12_in1 = levelized_graph.get_vertex(subtract_12.in_edges[1]);
+    const auto& s21_in0 = levelized_graph.get_vertex(subtract_21.in_edges[0]);
+    const auto& s21_in1 = levelized_graph.get_vertex(subtract_21.in_edges[1]);
 
-    // Verify that subtract(out1, out2) has reversed order compared to subtract(out2, out1)
-    EXPECT_EQ(subtract_12.in_edges[0], subtract_21.in_edges[1]);
-    EXPECT_EQ(subtract_12.in_edges[1], subtract_21.in_edges[0]);
+    EXPECT_NE(s12_in0.name, s12_in1.name);
+    EXPECT_NE(s21_in0.name, s21_in1.name);
+    EXPECT_EQ(s12_in0.name, s21_in1.name);
+    EXPECT_EQ(s12_in1.name, s21_in0.name);
 
-    // Verify output connections
-    EXPECT_EQ(tensor_a_vertex.out_edges.size(), 1);
-    EXPECT_EQ(tensor_a_vertex.out_edges[0], add_aa.id);
-
-    EXPECT_EQ(tensor_b_vertex.out_edges.size(), 1);
-    EXPECT_EQ(tensor_b_vertex.out_edges[0], add_bb.id);
-
-    // Each add operation feeds into both subtract operations
-    EXPECT_EQ(add_aa.out_edges.size(), 2);
-    EXPECT_TRUE(std::ranges::find(add_aa.out_edges, subtract_12.id) != add_aa.out_edges.end());
-    EXPECT_TRUE(std::ranges::find(add_aa.out_edges, subtract_21.id) != add_aa.out_edges.end());
-
-    EXPECT_EQ(add_bb.out_edges.size(), 2);
-    EXPECT_TRUE(std::ranges::find(add_bb.out_edges, subtract_12.id) != add_bb.out_edges.end());
-    EXPECT_TRUE(std::ranges::find(add_bb.out_edges, subtract_21.id) != add_bb.out_edges.end());
-
-    // Both subtract operations are terminal (no outgoing edges)
+    // Both subtract operations are terminal
     EXPECT_TRUE(subtract_12.out_edges.empty());
     EXPECT_TRUE(subtract_21.out_edges.empty());
 
@@ -1001,9 +840,6 @@ TEST_F(TestLevelizedGraphCapture, OrderOfArgsIntermediateTensorTest) {
                 std::ranges::all_of(level_2_vertices, [&](const auto& vertex) { return vertex.internals.empty(); }));
         }
     }
-
-    // Note: High-level function tracing removed - structure is different now
-    // Device operations are captured directly, so we can't verify specific internals structure
 }
 
 TEST_F(TestLevelizedGraphCapture, SameTensorMultipleTimes) {
@@ -1026,8 +862,6 @@ TEST_F(TestLevelizedGraphCapture, SameTensorMultipleTimes) {
         ref_json_trace = capture.end_graph_capture();
     }
 
-    // Note: High-level function tracing (ttnn::add) was removed from decorators.hpp
-    // Now only device operations are captured: BinaryNgDeviceOperation
     // Test level 1
     ttnn::graph::LevelizedGraph levelized_graph(ref_json_trace, 1);
     EXPECT_GE(levelized_graph.size(), 2);
@@ -1049,17 +883,18 @@ TEST_F(TestLevelizedGraphCapture, SameTensorMultipleTimes) {
     const auto& add_aa = *add_op_it;
 
     EXPECT_TRUE(tensor_a_vertex.name.find("tensor") != std::string::npos);
-    // High-level function tracing removed - now we get BinaryNgDeviceOperation
     EXPECT_TRUE(add_aa.name.find("BinaryNg") != std::string::npos || add_aa.name.find("Binary") != std::string::npos);
 
     EXPECT_TRUE(tensor_a_vertex.in_edges.empty());
-    EXPECT_EQ(tensor_a_vertex.out_edges.size(), 1);
+    EXPECT_GE(tensor_a_vertex.out_edges.size(), 1);
     EXPECT_EQ(tensor_a_vertex.out_edges[0], add_aa.id);
 
-    // add(a, a) should have in_edges [a, a]
+    // add(a, a) should have 2 tensor inputs (dedup removed, so different vertex IDs)
     EXPECT_EQ(add_aa.in_edges.size(), 2);
-    EXPECT_EQ(add_aa.in_edges[0], tensor_a_vertex.id);
-    EXPECT_EQ(add_aa.in_edges[1], tensor_a_vertex.id);
+    for (auto edge_id : add_aa.in_edges) {
+        const auto& edge_v = levelized_graph.get_vertex(edge_id);
+        EXPECT_TRUE(edge_v.name.find("tensor") != std::string::npos);
+    }
     EXPECT_TRUE(add_aa.out_edges.empty());
 
     // Test level 2
@@ -1073,9 +908,6 @@ TEST_F(TestLevelizedGraphCapture, SameTensorMultipleTimes) {
                 std::ranges::all_of(level_2_vertices, [&](const auto& vertex) { return vertex.internals.empty(); }));
         }
     }
-
-    // Note: High-level function tracing removed - structure is different now
-    // Device operations are captured directly, so we can't verify specific internals structure
 }
 
 TEST_F(TestLevelizedGraphCapture, TernaryOpDifferentOrder) {
@@ -1103,8 +935,6 @@ TEST_F(TestLevelizedGraphCapture, TernaryOpDifferentOrder) {
         ref_json_trace = capture.end_graph_capture();
     }
 
-    // Note: High-level function tracing (ttnn::addcmul) was removed from decorators.hpp
-    // Now only device operations are captured, but argument order is still preserved in in_edges
     // Test level 1
     ttnn::graph::LevelizedGraph levelized_graph(ref_json_trace, 1);
     EXPECT_GE(levelized_graph.size(), 5);
@@ -1138,34 +968,35 @@ TEST_F(TestLevelizedGraphCapture, TernaryOpDifferentOrder) {
     EXPECT_TRUE(tensor_a_vertex.name.find("tensor") != std::string::npos);
     EXPECT_TRUE(tensor_b_vertex.name.find("tensor") != std::string::npos);
     EXPECT_TRUE(tensor_c_vertex.name.find("tensor") != std::string::npos);
-    // High-level function tracing removed - operation names are device operations now
-    // EXPECT_EQ(addcmul_abc.name, "ttnn::addcmul");
-    // EXPECT_EQ(addcmul_cba.name, "ttnn::addcmul");
 
-    // All three tensors connect to both addcmul operations
     EXPECT_TRUE(tensor_a_vertex.in_edges.empty());
-    EXPECT_EQ(tensor_a_vertex.out_edges.size(), 2);
     EXPECT_TRUE(tensor_b_vertex.in_edges.empty());
-    EXPECT_EQ(tensor_b_vertex.out_edges.size(), 2);
     EXPECT_TRUE(tensor_c_vertex.in_edges.empty());
-    EXPECT_EQ(tensor_c_vertex.out_edges.size(), 2);
 
-    // First addcmul(a, b, c) should have in_edges [a, b, c]
+    // First addcmul(a, b, c) should have 3 tensor inputs
     EXPECT_EQ(addcmul_abc.in_edges.size(), 3);
-    EXPECT_EQ(addcmul_abc.in_edges[0], tensor_a_vertex.id);
-    EXPECT_EQ(addcmul_abc.in_edges[1], tensor_b_vertex.id);
-    EXPECT_EQ(addcmul_abc.in_edges[2], tensor_c_vertex.id);
+    const auto& abc_in0 = levelized_graph.get_vertex(addcmul_abc.in_edges[0]);
+    const auto& abc_in1 = levelized_graph.get_vertex(addcmul_abc.in_edges[1]);
+    const auto& abc_in2 = levelized_graph.get_vertex(addcmul_abc.in_edges[2]);
+    EXPECT_TRUE(abc_in0.name.find("tensor") != std::string::npos);
+    EXPECT_TRUE(abc_in1.name.find("tensor") != std::string::npos);
+    EXPECT_TRUE(abc_in2.name.find("tensor") != std::string::npos);
     EXPECT_TRUE(addcmul_abc.out_edges.empty());
 
-    // Second addcmul(c, b, a) should have in_edges [c, b, a]
+    // Second addcmul(c, b, a) should have 3 tensor inputs with reversed a,c order
     EXPECT_EQ(addcmul_cba.in_edges.size(), 3);
-    EXPECT_EQ(addcmul_cba.in_edges[0], tensor_c_vertex.id);
-    EXPECT_EQ(addcmul_cba.in_edges[1], tensor_b_vertex.id);
-    EXPECT_EQ(addcmul_cba.in_edges[2], tensor_a_vertex.id);
+    const auto& cba_in0 = levelized_graph.get_vertex(addcmul_cba.in_edges[0]);
+    const auto& cba_in1 = levelized_graph.get_vertex(addcmul_cba.in_edges[1]);
+    const auto& cba_in2 = levelized_graph.get_vertex(addcmul_cba.in_edges[2]);
+    EXPECT_TRUE(cba_in0.name.find("tensor") != std::string::npos);
+    EXPECT_TRUE(cba_in1.name.find("tensor") != std::string::npos);
+    EXPECT_TRUE(cba_in2.name.find("tensor") != std::string::npos);
     EXPECT_TRUE(addcmul_cba.out_edges.empty());
 
-    // Verify that the two addcmul operations have different input orders
-    EXPECT_NE(addcmul_abc.in_edges, addcmul_cba.in_edges);
+    // Verify argument order: addcmul(a,b,c) vs addcmul(c,b,a) - a and c swapped, b same
+    EXPECT_EQ(abc_in0.name, cba_in2.name);
+    EXPECT_EQ(abc_in1.name, cba_in1.name);
+    EXPECT_EQ(abc_in2.name, cba_in0.name);
 
     // Test level 2
     auto levelized_graph_2 = ttnn::graph::LevelizedGraph(ref_json_trace, 2);
@@ -1178,9 +1009,6 @@ TEST_F(TestLevelizedGraphCapture, TernaryOpDifferentOrder) {
                 std::ranges::all_of(level_2_vertices, [&](const auto& vertex) { return vertex.internals.empty(); }));
         }
     }
-
-    // Note: High-level function tracing removed - structure is different now
-    // Device operations are captured directly, so we can't verify specific internals structure
 }
 
 TEST_F(TestLevelizedGraphCapture, TernaryOpRepeatedTensors) {
@@ -1207,8 +1035,6 @@ TEST_F(TestLevelizedGraphCapture, TernaryOpRepeatedTensors) {
         ref_json_trace = capture.end_graph_capture();
     }
 
-    // Note: High-level function tracing (ttnn::addcmul) was removed from decorators.hpp
-    // Now only device operations are captured, but argument order is still preserved in in_edges
     // Test level 1
     ttnn::graph::LevelizedGraph levelized_graph(ref_json_trace, 1);
     EXPECT_GE(levelized_graph.size(), 4);
@@ -1240,32 +1066,38 @@ TEST_F(TestLevelizedGraphCapture, TernaryOpRepeatedTensors) {
 
     EXPECT_TRUE(tensor_a_vertex.name.find("tensor") != std::string::npos);
     EXPECT_TRUE(tensor_b_vertex.name.find("tensor") != std::string::npos);
-    // High-level function tracing removed - operation names are device operations now
-    // EXPECT_EQ(addcmul_aba.name, "ttnn::addcmul");
-    // EXPECT_EQ(addcmul_baa.name, "ttnn::addcmul");
 
-    // Both tensors connect to both addcmul operations
     EXPECT_TRUE(tensor_a_vertex.in_edges.empty());
-    EXPECT_EQ(tensor_a_vertex.out_edges.size(), 2);
     EXPECT_TRUE(tensor_b_vertex.in_edges.empty());
-    EXPECT_EQ(tensor_b_vertex.out_edges.size(), 2);
 
-    // First addcmul(a, b, a) should have in_edges [a, b, a]
+    // First addcmul(a, b, a) should have 3 tensor inputs
     EXPECT_EQ(addcmul_aba.in_edges.size(), 3);
-    EXPECT_EQ(addcmul_aba.in_edges[0], tensor_a_vertex.id);
-    EXPECT_EQ(addcmul_aba.in_edges[1], tensor_b_vertex.id);
-    EXPECT_EQ(addcmul_aba.in_edges[2], tensor_a_vertex.id);
+    const auto& aba_in0 = levelized_graph.get_vertex(addcmul_aba.in_edges[0]);
+    const auto& aba_in1 = levelized_graph.get_vertex(addcmul_aba.in_edges[1]);
+    const auto& aba_in2 = levelized_graph.get_vertex(addcmul_aba.in_edges[2]);
+    EXPECT_TRUE(aba_in0.name.find("tensor") != std::string::npos);
+    EXPECT_TRUE(aba_in1.name.find("tensor") != std::string::npos);
+    EXPECT_TRUE(aba_in2.name.find("tensor") != std::string::npos);
+    EXPECT_EQ(aba_in0.name, aba_in2.name);
+    EXPECT_NE(aba_in0.name, aba_in1.name);
     EXPECT_TRUE(addcmul_aba.out_edges.empty());
 
-    // Second addcmul(b, a, a) should have in_edges [b, a, a]
+    // Second addcmul(b, a, a) should have 3 tensor inputs
     EXPECT_EQ(addcmul_baa.in_edges.size(), 3);
-    EXPECT_EQ(addcmul_baa.in_edges[0], tensor_b_vertex.id);
-    EXPECT_EQ(addcmul_baa.in_edges[1], tensor_a_vertex.id);
-    EXPECT_EQ(addcmul_baa.in_edges[2], tensor_a_vertex.id);
+    const auto& baa_in0 = levelized_graph.get_vertex(addcmul_baa.in_edges[0]);
+    const auto& baa_in1 = levelized_graph.get_vertex(addcmul_baa.in_edges[1]);
+    const auto& baa_in2 = levelized_graph.get_vertex(addcmul_baa.in_edges[2]);
+    EXPECT_TRUE(baa_in0.name.find("tensor") != std::string::npos);
+    EXPECT_TRUE(baa_in1.name.find("tensor") != std::string::npos);
+    EXPECT_TRUE(baa_in2.name.find("tensor") != std::string::npos);
+    EXPECT_EQ(baa_in1.name, baa_in2.name);
+    EXPECT_NE(baa_in0.name, baa_in1.name);
     EXPECT_TRUE(addcmul_baa.out_edges.empty());
 
-    // Verify that the two addcmul operations have different input orders
-    EXPECT_NE(addcmul_aba.in_edges, addcmul_baa.in_edges);
+    // Verify argument order: addcmul(a,b,a) vs addcmul(b,a,a)
+    EXPECT_EQ(aba_in0.name, baa_in1.name);
+    EXPECT_EQ(aba_in1.name, baa_in0.name);
+    EXPECT_EQ(aba_in2.name, baa_in2.name);
 
     // Test level 2
     auto levelized_graph_2 = ttnn::graph::LevelizedGraph(ref_json_trace, 2);
@@ -1278,9 +1110,6 @@ TEST_F(TestLevelizedGraphCapture, TernaryOpRepeatedTensors) {
                 std::ranges::all_of(level_2_vertices, [&](const auto& vertex) { return vertex.internals.empty(); }));
         }
     }
-
-    // Note: High-level function tracing removed - structure is different now
-    // Device operations are captured directly, so we can't verify specific internals structure
 }
 
 TEST_F(TestLevelizedGraphCapture, MatmulDifferentOrders) {
@@ -1308,8 +1137,6 @@ TEST_F(TestLevelizedGraphCapture, MatmulDifferentOrders) {
         ref_json_trace = capture.end_graph_capture();
     }
 
-    // Note: High-level function tracing (ttnn::matmul) was removed from decorators.hpp
-    // Now only device operations are captured, but argument order is still preserved in in_edges
     // Test level 1
     ttnn::graph::LevelizedGraph levelized_graph(ref_json_trace, 1);
     EXPECT_GE(levelized_graph.size(), 5);
@@ -1364,39 +1191,42 @@ for (auto t : tensor_vertices) {
 
     EXPECT_TRUE(tensor_a_vertex.name.find("tensor") != std::string::npos);
     EXPECT_TRUE(tensor_b_vertex.name.find("tensor") != std::string::npos);
-    // High-level function tracing removed - operation names are device operations now
-    // EXPECT_EQ(matmul_ab.name, "ttnn::matmul");
-    // EXPECT_EQ(matmul_ba.name, "ttnn::matmul");
-    // EXPECT_EQ(matmul_aa.name, "ttnn::matmul");
 
-    // Both tensors connect to all three matmul operations
     EXPECT_TRUE(tensor_a_vertex.in_edges.empty());
-    EXPECT_EQ(tensor_a_vertex.out_edges.size(), 3);
     EXPECT_TRUE(tensor_b_vertex.in_edges.empty());
-    EXPECT_EQ(tensor_b_vertex.out_edges.size(), 2);
 
-    // First matmul(a, b) should have in_edges [a, b]
+    // First matmul(a, b) should have 2 different tensor inputs
     EXPECT_EQ(matmul_ab.in_edges.size(), 2);
-    EXPECT_EQ(matmul_ab.in_edges[0], tensor_a_vertex.id);
-    EXPECT_EQ(matmul_ab.in_edges[1], tensor_b_vertex.id);
+    const auto& mab_in0 = levelized_graph.get_vertex(matmul_ab.in_edges[0]);
+    const auto& mab_in1 = levelized_graph.get_vertex(matmul_ab.in_edges[1]);
+    EXPECT_TRUE(mab_in0.name.find("tensor") != std::string::npos);
+    EXPECT_TRUE(mab_in1.name.find("tensor") != std::string::npos);
+    EXPECT_NE(mab_in0.name, mab_in1.name);
     EXPECT_TRUE(matmul_ab.out_edges.empty());
 
-    // Second matmul(b, a) should have in_edges [b, a]
+    // Second matmul(b, a) should have 2 different tensor inputs with reversed order
     EXPECT_EQ(matmul_ba.in_edges.size(), 2);
-    EXPECT_EQ(matmul_ba.in_edges[0], tensor_b_vertex.id);
-    EXPECT_EQ(matmul_ba.in_edges[1], tensor_a_vertex.id);
+    const auto& mba_in0 = levelized_graph.get_vertex(matmul_ba.in_edges[0]);
+    const auto& mba_in1 = levelized_graph.get_vertex(matmul_ba.in_edges[1]);
+    EXPECT_TRUE(mba_in0.name.find("tensor") != std::string::npos);
+    EXPECT_TRUE(mba_in1.name.find("tensor") != std::string::npos);
+    EXPECT_NE(mba_in0.name, mba_in1.name);
     EXPECT_TRUE(matmul_ba.out_edges.empty());
 
-    // Third matmul(a, a) should have in_edges [a, a]
+    // Third matmul(a, a) should have 2 tensor inputs with same underlying tensor
     EXPECT_EQ(matmul_aa.in_edges.size(), 2);
-    EXPECT_EQ(matmul_aa.in_edges[0], tensor_a_vertex.id);
-    EXPECT_EQ(matmul_aa.in_edges[1], tensor_a_vertex.id);
+    const auto& maa_in0 = levelized_graph.get_vertex(matmul_aa.in_edges[0]);
+    const auto& maa_in1 = levelized_graph.get_vertex(matmul_aa.in_edges[1]);
+    EXPECT_TRUE(maa_in0.name.find("tensor") != std::string::npos);
+    EXPECT_TRUE(maa_in1.name.find("tensor") != std::string::npos);
+    EXPECT_EQ(maa_in0.name, maa_in1.name);
     EXPECT_TRUE(matmul_aa.out_edges.empty());
 
-    // Verify all three matmul operations have different input patterns
-    EXPECT_NE(matmul_ab.in_edges, matmul_ba.in_edges);
-    EXPECT_NE(matmul_ab.in_edges, matmul_aa.in_edges);
-    EXPECT_NE(matmul_ba.in_edges, matmul_aa.in_edges);
+    // Verify argument order: matmul(a,b) vs matmul(b,a) - should be swapped
+    EXPECT_EQ(mab_in0.name, mba_in1.name);
+    EXPECT_EQ(mab_in1.name, mba_in0.name);
+    // matmul(a,a) uses the same tensor as matmul(a,b)'s first arg
+    EXPECT_EQ(maa_in0.name, mab_in0.name);
 
     // Test level 2
     auto levelized_graph_2 = ttnn::graph::LevelizedGraph(ref_json_trace, 2);
@@ -1409,9 +1239,6 @@ for (auto t : tensor_vertices) {
                 std::ranges::all_of(level_2_vertices, [&](const auto& vertex) { return vertex.internals.empty(); }));
         }
     }
-
-    // Note: High-level function tracing removed - structure is different now
-    // Device operations are captured directly, so we can't verify specific internals structure
 }
 
 TEST_F(TestLevelizedGraphCapture, ExtractLevelizedGraphJsonTest) {
@@ -1441,9 +1268,9 @@ TEST_F(TestLevelizedGraphCapture, ExtractLevelizedGraphJsonTest) {
 
     // Verify JSON structure
     EXPECT_TRUE(levelized_graph_json.is_array());
-    EXPECT_EQ(levelized_graph_json.size(), 2);  // tensor, device operation
+    EXPECT_GE(levelized_graph_json.size(), 2);
 
-    // Verify first vertex (tensor)
+    // Verify first vertex is a tensor with expected fields
     EXPECT_TRUE(levelized_graph_json[0].is_object());
     EXPECT_TRUE(levelized_graph_json[0].contains(ttnn::graph::kCounter));
     EXPECT_TRUE(levelized_graph_json[0].contains(ttnn::graph::kStackingLevel));
@@ -1459,28 +1286,31 @@ TEST_F(TestLevelizedGraphCapture, ExtractLevelizedGraphJsonTest) {
     EXPECT_TRUE(levelized_graph_json[0][ttnn::graph::kInEdges].is_array());
     EXPECT_TRUE(levelized_graph_json[0][ttnn::graph::kInEdges].empty());
     EXPECT_TRUE(levelized_graph_json[0][ttnn::graph::kOutEdges].is_array());
-    EXPECT_EQ(levelized_graph_json[0][ttnn::graph::kOutEdges].size(), 1);
+    EXPECT_GE(levelized_graph_json[0][ttnn::graph::kOutEdges].size(), 1);
     EXPECT_TRUE(levelized_graph_json[0][ttnn::graph::kInternals].is_array());
     EXPECT_TRUE(levelized_graph_json[0][ttnn::graph::kInternals].empty());
     EXPECT_TRUE(levelized_graph_json[0][ttnn::graph::kOutputShape].is_array());
     EXPECT_FALSE(levelized_graph_json[0][ttnn::graph::kOutputShape].empty());
 
-    // Verify second vertex (device operation - BinaryNgDeviceOperation)
-    // Note: High-level function tracing (ttnn::add) was removed, now we get BinaryNgDeviceOperation
-    EXPECT_TRUE(levelized_graph_json[1].is_object());
-    EXPECT_EQ(levelized_graph_json[1][ttnn::graph::kName], "BinaryNgDeviceOperation");
-    EXPECT_EQ(levelized_graph_json[1][ttnn::graph::kStackingLevel], 1);
-    EXPECT_EQ(levelized_graph_json[1][ttnn::graph::kCounter], 1);
-    EXPECT_TRUE(levelized_graph_json[1][ttnn::graph::kInEdges].is_array());
-    EXPECT_EQ(levelized_graph_json[1][ttnn::graph::kInEdges].size(), 2);  // both inputs from vertex 0
-    EXPECT_EQ(levelized_graph_json[1][ttnn::graph::kInEdges][0], 0);
-    EXPECT_EQ(levelized_graph_json[1][ttnn::graph::kInEdges][1], 0);
-    EXPECT_TRUE(levelized_graph_json[1][ttnn::graph::kOutEdges].is_array());
-    EXPECT_TRUE(levelized_graph_json[1][ttnn::graph::kOutEdges].empty());
-    EXPECT_TRUE(levelized_graph_json[1][ttnn::graph::kInternals].is_array());
-    EXPECT_TRUE(levelized_graph_json[1][ttnn::graph::kInternals].empty());
-    EXPECT_TRUE(levelized_graph_json[1][ttnn::graph::kOutputShape].is_array());
-    EXPECT_FALSE(levelized_graph_json[1][ttnn::graph::kOutputShape].empty());
+    // Find the BinaryNgDeviceOperation vertex by name (index may vary with dedup removed)
+    auto binary_json_it = std::ranges::find_if(
+        levelized_graph_json, [](const auto& v) { return v[ttnn::graph::kName] == "BinaryNgDeviceOperation"; });
+    ASSERT_NE(binary_json_it, levelized_graph_json.end());
+    const auto& binary_json = *binary_json_it;
+
+    EXPECT_EQ(binary_json[ttnn::graph::kStackingLevel], 1);
+    EXPECT_TRUE(binary_json[ttnn::graph::kInEdges].is_array());
+    EXPECT_EQ(binary_json[ttnn::graph::kInEdges].size(), 2);
+    for (const auto& edge_id : binary_json[ttnn::graph::kInEdges]) {
+        auto& tensor_v = levelized_graph_json[edge_id.get<int>()];
+        EXPECT_TRUE(tensor_v[ttnn::graph::kName].get<std::string>().find("tensor") != std::string::npos);
+    }
+    EXPECT_TRUE(binary_json[ttnn::graph::kOutEdges].is_array());
+    EXPECT_TRUE(binary_json[ttnn::graph::kOutEdges].empty());
+    EXPECT_TRUE(binary_json[ttnn::graph::kInternals].is_array());
+    EXPECT_TRUE(binary_json[ttnn::graph::kInternals].empty());
+    EXPECT_TRUE(binary_json[ttnn::graph::kOutputShape].is_array());
+    EXPECT_FALSE(binary_json[ttnn::graph::kOutputShape].empty());
 
     // Test extract_levelized_graph API - level 2
     auto levelized_graph_json_2 = ttnn::graph::extract_levelized_graph(ref_json_trace, 2);
@@ -1490,7 +1320,6 @@ TEST_F(TestLevelizedGraphCapture, ExtractLevelizedGraphJsonTest) {
     EXPECT_GE(levelized_graph_json_2.size(), 3);  // At least 3 vertices at level 2
 
     // Verify that BinaryNgDeviceOperation vertex has internals at level 2
-    // Note: High-level function tracing (ttnn::add) was removed, now we get BinaryNgDeviceOperation
     auto add_vertex_it = std::ranges::find_if(
         levelized_graph_json_2, [](const auto& v) { return v[ttnn::graph::kName] == "BinaryNgDeviceOperation"; });
     EXPECT_NE(add_vertex_it, levelized_graph_json_2.end());
@@ -1548,61 +1377,53 @@ TEST_F(TestLevelizedGraphCapture, MultiplyAndAddTest) {
 
     // Test extract_levelized_graph API - level 1
     ttnn::graph::LevelizedGraph levelized_graph(ref_json_trace, 1);
-    EXPECT_EQ(levelized_graph.size(), 5);
+    EXPECT_GE(levelized_graph.size(), 5);
     EXPECT_TRUE(std::ranges::all_of(
         levelized_graph.vertices(), [&](const auto& vertex) { return vertex.stacking_level == 1; }));
     EXPECT_TRUE(
         std::ranges::all_of(levelized_graph.vertices(), [&](const auto& vertex) { return vertex.internals.empty(); }));
-    EXPECT_TRUE(std::ranges::none_of(
-        levelized_graph.vertices(), [&](const auto& vertex) { return vertex.output_shape.empty(); }));
+    EXPECT_TRUE(std::ranges::none_of(levelized_graph.vertices(), [&](const auto& vertex) {
+        return vertex.output_shape.empty() && vertex.name.find("deallocate") == std::string::npos;
+    }));
 
-    // Tensor 1 is the first one that is used, thus it'll have the id 0
-    const auto& v_tensor_1 = levelized_graph.get_vertex(0);
-    // Tensor 2 is the second one that is used, thus it'll have the id 1
-    const auto& v_tensor_2 = levelized_graph.get_vertex(1);
-    // Tensor 0 is the third one that is used, thus it'll have the id 2
-    const auto& v_tensor_0 = levelized_graph.get_vertex(2);
-    const auto& v_multiply = levelized_graph.get_vertex(3);
-    const auto& v_add = levelized_graph.get_vertex(4);
-    EXPECT_NE(v_tensor_0.name.find("tensor"), std::string::npos);
-    EXPECT_NE(v_tensor_1.name.find("tensor"), std::string::npos);
-    EXPECT_NE(v_tensor_2.name.find("tensor"), std::string::npos);
-    // Note: High-level function tracing (ttnn::multiply, ttnn::add) was removed, now we get BinaryNgDeviceOperation
-    EXPECT_EQ(v_multiply.name, "BinaryNgDeviceOperation");
-    EXPECT_EQ(v_add.name, "BinaryNgDeviceOperation");
+    // Find the BinaryNgDeviceOperation vertices by name (indices may vary)
+    std::vector<size_t> binary_op_ids;
+    for (size_t i = 0; i < levelized_graph.size(); ++i) {
+        const auto& v = levelized_graph.get_vertex(i);
+        if (v.name == "BinaryNgDeviceOperation") {
+            binary_op_ids.push_back(i);
+        }
+    }
+    ASSERT_EQ(binary_op_ids.size(), 2);
 
-    // Confirming that the multiply vertex has two inputs from tensors
-    // Also add should have one input from tensor and one from multiply
+    // The first binary op (in graph order) is multiply, the second is add
+    const auto& v_multiply = levelized_graph.get_vertex(binary_op_ids[0]);
+    const auto& v_add = levelized_graph.get_vertex(binary_op_ids[1]);
+
+    // Multiply should have 2 tensor inputs (b and c)
     // Motivated by this issue: https://github.com/tenstorrent/tt-mlir/issues/5929
     EXPECT_EQ(v_multiply.in_edges.size(), 2);
-    // Both inputs should be tensors
-    // Note: In the current form of trace, it's not possible to distinguish between the two tensors (order of args)
-    EXPECT_TRUE(v_multiply.in_edges[0] == v_tensor_1.id || v_multiply.in_edges[0] == v_tensor_2.id);
-    EXPECT_TRUE(v_multiply.in_edges[1] == v_tensor_1.id || v_multiply.in_edges[1] == v_tensor_2.id);
-    EXPECT_TRUE(v_multiply.in_edges[0] != v_multiply.in_edges[1]);
+    const auto& mul_in0 = levelized_graph.get_vertex(v_multiply.in_edges[0]);
+    const auto& mul_in1 = levelized_graph.get_vertex(v_multiply.in_edges[1]);
+    EXPECT_TRUE(mul_in0.name.find("tensor") != std::string::npos);
+    EXPECT_TRUE(mul_in1.name.find("tensor") != std::string::npos);
+    EXPECT_NE(mul_in0.name, mul_in1.name);
 
+    // Add should have 2 inputs: one tensor (a) and one related to multiply's output
     EXPECT_EQ(v_add.in_edges.size(), 2);
-    // One input should be a tensor, the other should be multiply
-    bool has_tensor_input = v_add.in_edges[0] == v_tensor_0.id || v_add.in_edges[1] == v_tensor_0.id;
-    bool has_multiply_input = v_add.in_edges[0] == v_multiply.id || v_add.in_edges[1] == v_multiply.id;
-    EXPECT_TRUE(has_tensor_input);
-    EXPECT_TRUE(has_multiply_input);
-    EXPECT_TRUE(v_add.in_edges[0] != v_add.in_edges[1]);
-
-    // Each tensor should have exactly one outgoing edge
-    EXPECT_EQ(v_tensor_0.out_edges.size(), 1);
-    EXPECT_EQ(v_tensor_0.out_edges[0], v_add.id);
-    EXPECT_EQ(v_tensor_1.out_edges.size(), 1);
-    EXPECT_EQ(v_tensor_1.out_edges[0], v_multiply.id);
-    EXPECT_EQ(v_tensor_2.out_edges.size(), 1);
-    EXPECT_EQ(v_tensor_2.out_edges[0], v_multiply.id);
-
-    // Multiply should output to add
-    EXPECT_EQ(v_multiply.out_edges.size(), 1);
-    EXPECT_EQ(v_multiply.out_edges[0], v_add.id);
+    bool found_tensor_a = false;
+    for (auto edge_id : v_add.in_edges) {
+        const auto& edge_v = levelized_graph.get_vertex(edge_id);
+        if (edge_v.name.find("tensor") != std::string::npos && edge_v.name != mul_in0.name &&
+            edge_v.name != mul_in1.name) {
+            found_tensor_a = true;
+        }
+    }
+    EXPECT_TRUE(found_tensor_a);
+    EXPECT_NE(v_add.in_edges[0], v_add.in_edges[1]);
 
     // Add should be the final operation
-    EXPECT_EQ(v_add.out_edges.size(), 0);
+    EXPECT_TRUE(v_add.out_edges.empty());
 }
 
 TEST_F(TestLevelizedGraphCapture, MultiplyAndAddWithCapturedTensorsTest) {
@@ -1654,14 +1475,14 @@ TEST_F(TestLevelizedGraphCapture, MultiplyAndAddWithCapturedTensorsTest) {
     // Test extract_levelized_graph API - level 1
     ttnn::graph::LevelizedGraph levelized_graph(ref_json_trace, 1);
 
-    // Should have 8 vertices: 3 create_device_tensor operations + 3 tensor nodes + multiply + add
-    EXPECT_EQ(levelized_graph.size(), 8);
+    EXPECT_GE(levelized_graph.size(), 8);
     EXPECT_TRUE(std::ranges::all_of(
         levelized_graph.vertices(), [&](const auto& vertex) { return vertex.stacking_level == 1; }));
     EXPECT_TRUE(
         std::ranges::all_of(levelized_graph.vertices(), [&](const auto& vertex) { return vertex.internals.empty(); }));
-    EXPECT_TRUE(std::ranges::none_of(
-        levelized_graph.vertices(), [&](const auto& vertex) { return vertex.output_shape.empty(); }));
+    EXPECT_TRUE(std::ranges::none_of(levelized_graph.vertices(), [&](const auto& vertex) {
+        return vertex.output_shape.empty() && vertex.name.find("deallocate") == std::string::npos;
+    }));
 
     // Categorize vertices by type
     std::vector<size_t> create_tensor_ids;
@@ -1676,139 +1497,49 @@ TEST_F(TestLevelizedGraphCapture, MultiplyAndAddWithCapturedTensorsTest) {
         } else if (v.name.find("tensor[") != std::string::npos) {
             tensor_ids.push_back(i);
         } else if (v.name == "BinaryNgDeviceOperation") {
-            // Note: High-level function tracing (ttnn::multiply, ttnn::add) was removed, now we get
             // BinaryNgDeviceOperation
             binary_op_ids.push_back(i);
         }
     }
 
-    // Verify we have the expected number of each type
-    EXPECT_EQ(create_tensor_ids.size(), 3);  // 3 create_device_tensor operations
-    EXPECT_EQ(tensor_ids.size(), 3);         // 3 tensor nodes
-    EXPECT_EQ(binary_op_ids.size(), 2);      // 2 binary operations (multiply and add)
+    EXPECT_EQ(create_tensor_ids.size(), 3);
+    EXPECT_GE(tensor_ids.size(), 3);
+    EXPECT_EQ(binary_op_ids.size(), 2);
 
-    // Identify multiply and add by their graph relationships:
-    // - multiply: has 2 tensor inputs, outputs to add
-    // - add: has 1 tensor input + 1 input from multiply, no outputs
-    bool found_multiply = false;
-    for (size_t op_id : binary_op_ids) {
-        const auto& op = levelized_graph.get_vertex(op_id);
-        // Multiply has 2 tensor inputs and outputs to another operation
-        if (op.in_edges.size() == 2 && op.out_edges.size() == 1) {
-            // Check that both inputs are tensors
-            bool both_inputs_are_tensors = true;
-            for (size_t input_id : op.in_edges) {
-                if (std::find(tensor_ids.begin(), tensor_ids.end(), input_id) == tensor_ids.end()) {
-                    both_inputs_are_tensors = false;
-                    break;
-                }
-            }
-            if (both_inputs_are_tensors && !found_multiply) {
-                multiply_id = op_id;
-                found_multiply = true;
-            }
-        }
-    }
-
-    EXPECT_TRUE(found_multiply) << "Failed to identify multiply operation";
-
-    // Now identify add: has 2 inputs (1 tensor + 1 from multiply) and no outputs
-    bool found_add = false;
-    for (size_t op_id : binary_op_ids) {
-        if (op_id == multiply_id) {
-            continue;  // Skip multiply
-        }
-        const auto& op = levelized_graph.get_vertex(op_id);
-        // Add has 2 inputs and no outputs, and one input should be from multiply
-        if (op.in_edges.size() == 2 && op.out_edges.empty()) {
-            bool has_multiply_input =
-                std::find(op.in_edges.begin(), op.in_edges.end(), multiply_id) != op.in_edges.end();
-            if (has_multiply_input) {
-                add_id = op_id;
-                found_add = true;
-                break;
-            }
-        }
-    }
-
-    EXPECT_TRUE(found_add) << "Failed to identify add operation";
-
+    // The first binary op (in graph order) is multiply, the second is add
+    multiply_id = binary_op_ids[0];
+    add_id = binary_op_ids[1];
     const auto& v_multiply = levelized_graph.get_vertex(multiply_id);
     const auto& v_add = levelized_graph.get_vertex(add_id);
 
-    // Key verification: create_device_tensor operations have no edges in the levelized graph
-    // This is expected behavior - edges connect tensor nodes to operations, not operations to tensor nodes
-    for (size_t create_id : create_tensor_ids) {
-        const auto& create_vertex = levelized_graph.get_vertex(create_id);
-        EXPECT_EQ(create_vertex.in_edges.size(), 0);   // No inputs
-        EXPECT_EQ(create_vertex.out_edges.size(), 0);  // No outgoing edges (edges go through tensor nodes)
-        EXPECT_FALSE(create_vertex.output_shape.empty());
-    }
-
-    // Key verification: Each tensor node should have exactly one incoming edge from create_device_tensor
-    // and exactly one outgoing edge to an operation
-    for (size_t tensor_id : tensor_ids) {
-        const auto& tensor_vertex = levelized_graph.get_vertex(tensor_id);
-        EXPECT_EQ(tensor_vertex.in_edges.size(), 1);   // One input from create_device_tensor
-        EXPECT_EQ(tensor_vertex.out_edges.size(), 1);  // One output to operation
-        EXPECT_FALSE(tensor_vertex.output_shape.empty());
-        EXPECT_TRUE(tensor_vertex.internals.empty());
-
-        // The input should be a create_device_tensor operation
-        size_t creator = tensor_vertex.in_edges[0];
-        EXPECT_NE(std::find(create_tensor_ids.begin(), create_tensor_ids.end(), creator), create_tensor_ids.end());
-
-        // The output should be either multiply or add
-        size_t consumer = tensor_vertex.out_edges[0];
-        EXPECT_TRUE(consumer == multiply_id || consumer == add_id);
-    }
-
-    // Verify multiply has 2 tensor inputs
+    // Multiply should have 2 tensor inputs (b and c)
     EXPECT_EQ(v_multiply.in_edges.size(), 2);
-    for (size_t input_id : v_multiply.in_edges) {
-        EXPECT_NE(std::find(tensor_ids.begin(), tensor_ids.end(), input_id), tensor_ids.end());
-    }
-    EXPECT_EQ(v_multiply.out_edges.size(), 1);
-    EXPECT_EQ(v_multiply.out_edges[0], add_id);
+    const auto& mul_in0 = levelized_graph.get_vertex(v_multiply.in_edges[0]);
+    const auto& mul_in1 = levelized_graph.get_vertex(v_multiply.in_edges[1]);
+    EXPECT_TRUE(mul_in0.name.find("tensor") != std::string::npos);
+    EXPECT_TRUE(mul_in1.name.find("tensor") != std::string::npos);
+    EXPECT_NE(mul_in0.name, mul_in1.name);
 
-    // Verify add has 2 inputs: 1 tensor + 1 multiply result
+    // Add should have 2 inputs
     EXPECT_EQ(v_add.in_edges.size(), 2);
-    int tensor_inputs = 0;
-    int multiply_inputs = 0;
-    for (size_t input_id : v_add.in_edges) {
-        if (std::find(tensor_ids.begin(), tensor_ids.end(), input_id) != tensor_ids.end()) {
-            tensor_inputs++;
-        } else if (input_id == multiply_id) {
-            multiply_inputs++;
+    bool found_tensor_a = false;
+    for (auto edge_id : v_add.in_edges) {
+        const auto& edge_v = levelized_graph.get_vertex(edge_id);
+        if (edge_v.name.find("tensor") != std::string::npos && edge_v.name != mul_in0.name &&
+            edge_v.name != mul_in1.name) {
+            found_tensor_a = true;
         }
     }
-    EXPECT_EQ(tensor_inputs, 1);           // One tensor input
-    EXPECT_EQ(multiply_inputs, 1);         // One multiply result input
-    EXPECT_EQ(v_add.out_edges.size(), 0);  // Final operation
+    EXPECT_TRUE(found_tensor_a);
 
-    // Verify the data flow: tensor nodes track their creator and consumer
-    // This demonstrates the key difference from runtime inputs:
-    // - Runtime input tensors: empty in_edges
-    // - Captured creation tensors: in_edges point to create_device_tensor
-    for (size_t tensor_id : tensor_ids) {
-        const auto& tensor_vertex = levelized_graph.get_vertex(tensor_id);
+    // Add is the final operation
+    EXPECT_TRUE(v_add.out_edges.empty());
 
-        // Verify the tensor knows its creator (create_device_tensor)
-        EXPECT_EQ(tensor_vertex.in_edges.size(), 1);
-        size_t creator_id = tensor_vertex.in_edges[0];
-        const auto& creator = levelized_graph.get_vertex(creator_id);
-        EXPECT_EQ(creator.name, "tt::tt_metal::create_device_tensor");
-
-        // Verify the tensor feeds into an operation
-        EXPECT_EQ(tensor_vertex.out_edges.size(), 1);
-        size_t operation_id = tensor_vertex.out_edges[0];
-        EXPECT_TRUE(operation_id == multiply_id || operation_id == add_id);
+    // Verify create_device_tensor operations exist
+    for (size_t create_id : create_tensor_ids) {
+        const auto& create_vertex = levelized_graph.get_vertex(create_id);
+        EXPECT_FALSE(create_vertex.output_shape.empty());
     }
-
-    // This test demonstrates that the levelized graph algorithm correctly handles both:
-    // 1. Runtime input tensors (empty in_edges) - as in MultiplyAndAddTest
-    // 2. Captured tensor creation (in_edges point to creator) - as in this test
-    // The key insight: tensor nodes always represent the data flow, regardless of where tensors were created
 }
 
 TEST_F(TestLevelizedGraphCapture, SubtractArgumentOrderWithCapturedTensorsTest) {
@@ -1845,8 +1576,7 @@ TEST_F(TestLevelizedGraphCapture, SubtractArgumentOrderWithCapturedTensorsTest) 
     // Test level 1
     ttnn::graph::LevelizedGraph levelized_graph(ref_json_trace, 1);
 
-    // Should have: 2 create_device_tensor operations + 2 tensor nodes + 2 subtract operations
-    EXPECT_EQ(levelized_graph.size(), 6);
+    EXPECT_GE(levelized_graph.size(), 6);
     EXPECT_TRUE(std::ranges::all_of(
         levelized_graph.vertices(), [&](const auto& vertex) { return vertex.stacking_level == 1; }));
 
@@ -1862,50 +1592,37 @@ TEST_F(TestLevelizedGraphCapture, SubtractArgumentOrderWithCapturedTensorsTest) 
         } else if (v.name.find("tensor[") != std::string::npos) {
             tensor_ids.push_back(i);
         } else if (v.name == "BinaryNgDeviceOperation") {
-            // Note: High-level function tracing (ttnn::subtract) was removed, now we get BinaryNgDeviceOperation
             subtract_ids.push_back(i);
         }
     }
 
-    // Verify we have the expected number of each type
-    EXPECT_EQ(create_tensor_ids.size(), 2);  // 2 create_device_tensor operations
-    EXPECT_EQ(tensor_ids.size(), 2);         // 2 tensor nodes
-    EXPECT_EQ(subtract_ids.size(), 2);       // 2 subtract operations (both are BinaryNgDeviceOperation)
+    EXPECT_EQ(create_tensor_ids.size(), 2);
+    EXPECT_GE(tensor_ids.size(), 2);
+    EXPECT_EQ(subtract_ids.size(), 2);
 
-    // Get references to the subtract operations
     const auto& subtract_1 = levelized_graph.get_vertex(subtract_ids[0]);
     const auto& subtract_2 = levelized_graph.get_vertex(subtract_ids[1]);
 
-    // Both subtract operations should have exactly 2 input edges (from tensor nodes)
     EXPECT_EQ(subtract_1.in_edges.size(), 2);
     EXPECT_EQ(subtract_2.in_edges.size(), 2);
 
-    // Get the tensor node IDs
-    size_t tensor_a_id = tensor_ids[0];
-    size_t tensor_b_id = tensor_ids[1];
+    // Verify inputs are tensor vertices and check argument order by name
+    const auto& s1_in0 = levelized_graph.get_vertex(subtract_1.in_edges[0]);
+    const auto& s1_in1 = levelized_graph.get_vertex(subtract_1.in_edges[1]);
+    EXPECT_TRUE(s1_in0.name.find("tensor") != std::string::npos);
+    EXPECT_TRUE(s1_in1.name.find("tensor") != std::string::npos);
+    EXPECT_NE(s1_in0.name, s1_in1.name);
 
-    // First subtract should be subtract(a, b), so in_edges should be [tensor_a, tensor_b]
-    EXPECT_EQ(subtract_1.in_edges[0], tensor_a_id);
-    EXPECT_EQ(subtract_1.in_edges[1], tensor_b_id);
+    const auto& s2_in0 = levelized_graph.get_vertex(subtract_2.in_edges[0]);
+    const auto& s2_in1 = levelized_graph.get_vertex(subtract_2.in_edges[1]);
+    EXPECT_TRUE(s2_in0.name.find("tensor") != std::string::npos);
+    EXPECT_TRUE(s2_in1.name.find("tensor") != std::string::npos);
+    EXPECT_NE(s2_in0.name, s2_in1.name);
 
-    // Second subtract should be subtract(b, a), so in_edges should be [tensor_b, tensor_a]
-    EXPECT_EQ(subtract_2.in_edges[0], tensor_b_id);
-    EXPECT_EQ(subtract_2.in_edges[1], tensor_a_id);
+    // Argument order is preserved: names should be swapped
+    EXPECT_EQ(s1_in0.name, s2_in1.name);
+    EXPECT_EQ(s1_in1.name, s2_in0.name);
 
-    // Verify the two subtract operations have different input patterns (argument order matters!)
-    EXPECT_NE(subtract_1.in_edges, subtract_2.in_edges);
-
-    // Verify that subtract(a, b) has reversed order compared to subtract(b, a)
-    EXPECT_EQ(subtract_1.in_edges[0], subtract_2.in_edges[1]);
-    EXPECT_EQ(subtract_1.in_edges[1], subtract_2.in_edges[0]);
-
-    // Both subtract operations should have no output edges (they are terminal operations)
     EXPECT_TRUE(subtract_1.out_edges.empty());
     EXPECT_TRUE(subtract_2.out_edges.empty());
-
-    // Verify each tensor node feeds into exactly 2 subtract operations
-    for (size_t tensor_id : tensor_ids) {
-        const auto& tensor_vertex = levelized_graph.get_vertex(tensor_id);
-        EXPECT_EQ(tensor_vertex.out_edges.size(), 2);  // Each tensor used in both subtract operations
-    }
 }

--- a/ttnn/api/ttnn/device_operation.hpp
+++ b/ttnn/api/ttnn/device_operation.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <concepts>
+#include <exception>
 #include <optional>
 #include <tt-logger/tt-logger.hpp>
 #include <tt_stl/overloaded.hpp>
@@ -434,8 +435,8 @@ typename device_operation_t::tensor_return_value_t launch(
     ttsl::reflection::visit_object_of_type<Tensor>(
         [&input_tensors](const Tensor& t) { input_tensors.push_back(std::cref(t)); }, tensor_args);
 
-    tt::tt_metal::GraphTracker::instance().track_function_start(
-        detail::get_operation_name<device_operation_t>(operation_attributes), operation_attributes, input_tensors);
+    const auto operation_name = detail::get_operation_name<device_operation_t>(operation_attributes);
+    tt::tt_metal::GraphTracker::instance().track_function_start(operation_name, operation_attributes, input_tensors);
 
     auto first_tensor = ttsl::reflection::get_first_object_of_type<Tensor>(tensor_args);
     if (first_tensor.has_value()) [[likely]] {

--- a/ttnn/api/ttnn/graph/graph_consts.hpp
+++ b/ttnn/api/ttnn/graph/graph_consts.hpp
@@ -21,11 +21,20 @@ constexpr auto kAddress = "address";
 constexpr auto kSize = "size";
 constexpr auto kLayout = "layout";
 constexpr auto kShape = "shape";
+constexpr auto kDtype = "dtype";
+constexpr auto kMemoryConfig = "memory_config";
+constexpr auto kBufferType = "buffer_type";
+constexpr auto kDeviceTensors = "device_tensors";  // Per-device buffer placement for multi-device (mesh) tensors
+constexpr auto kMeshDeviceId = "mesh_device_id";
 constexpr auto kNumCores = "num_cores";
 constexpr auto kPageSize = "page_size";
 constexpr auto kCoreRangeSet = "core_range_set";
 constexpr auto kGloballyAllocated = "globally_allocated";
 constexpr auto kDeviceId = "device_id";
+constexpr auto kDurationNs = "duration_ns";
+constexpr auto kMaxSizePerBank = "max_size_per_bank";
+constexpr auto kExactBufferType = "exact_buffer_type";
+constexpr auto kBufferTypeValue = "buffer_type_value";
 
 // node names
 constexpr auto kNodeBuffer = "buffer";
@@ -38,7 +47,6 @@ constexpr auto kNodeFunctionStart = "function_start";
 constexpr auto kNodeFunctionEnd = "function_end";
 constexpr auto kNodeCaptureStart = "capture_start";
 constexpr auto kNodeCaptureEnd = "capture_end";
-
 // levelized graph keys
 constexpr auto kInEdges = "in_edges";
 constexpr auto kOutEdges = "out_edges";
@@ -46,4 +54,34 @@ constexpr auto kInternals = "internals";
 constexpr auto kOutputInfo = "output_info";
 constexpr auto kOutputShape = "output_shape";
 constexpr auto kStackingLevel = "stacking_level";
+
+// report file keys
+constexpr auto kReportVersion = "version";
+constexpr auto kReportGraph = "graph";
+constexpr auto kReportDevices = "devices";
+constexpr auto kReportMetadata = "metadata";
+constexpr auto kReportTimestampNs = "capture_timestamp_ns";
+constexpr auto kReportTotalDurationNs = "total_duration_ns";
+
+// device info keys
+constexpr auto kDeviceNumYCores = "num_y_cores";
+constexpr auto kDeviceNumXCores = "num_x_cores";
+constexpr auto kDeviceNumYComputeCores = "num_y_compute_cores";
+constexpr auto kDeviceNumXComputeCores = "num_x_compute_cores";
+constexpr auto kDeviceWorkerL1Size = "worker_l1_size";
+constexpr auto kDeviceL1NumBanks = "l1_num_banks";
+constexpr auto kDeviceL1BankSize = "l1_bank_size";
+constexpr auto kDeviceAddressAtFirstL1Bank = "address_at_first_l1_bank";
+constexpr auto kDeviceAddressAtFirstL1CbBuffer = "address_at_first_l1_cb_buffer";
+constexpr auto kDeviceNumBanksPerStorageCore = "num_banks_per_storage_core";
+constexpr auto kDeviceNumComputeCores = "num_compute_cores";
+constexpr auto kDeviceNumStorageCores = "num_storage_cores";
+constexpr auto kDeviceTotalL1Memory = "total_l1_memory";
+constexpr auto kDeviceTotalL1ForTensors = "total_l1_for_tensors";
+constexpr auto kDeviceTotalL1ForInterleavedBuffers = "total_l1_for_interleaved_buffers";
+constexpr auto kDeviceTotalL1ForShardedBuffers = "total_l1_for_sharded_buffers";
+constexpr auto kDeviceCbLimit = "cb_limit";
+
+// current report format version
+constexpr int kCurrentReportVersion = 1;
 }  // namespace ttnn::graph

--- a/ttnn/api/ttnn/graph/graph_processor.hpp
+++ b/ttnn/api/ttnn/graph/graph_processor.hpp
@@ -7,11 +7,21 @@
 #include <tt-metalium/graph_tracking.hpp>
 #include <nlohmann/json.hpp>
 #include "ttnn/tensor/tensor.hpp"
+#include "ttnn/reports.hpp"
 
+#include <atomic>
+#include <chrono>
+#include <filesystem>
 #include <mutex>
 #include <stack>
 #include <unordered_map>
+#include <unordered_set>
 #include <any>
+
+namespace tt::tt_metal::distributed {
+class MeshDevice;
+}
+
 namespace ttnn::graph {
 
 // Node identifiers in the graph
@@ -81,7 +91,10 @@ public:
         std::vector<node_id> connections;
         std::vector<node_id> input_tensors;
         int stacking_level = 0;
+        uint64_t duration_ns = 0;  // Duration in nanoseconds (for function_end nodes)
     };
+
+    nlohmann::json get_report() const;
 
 private:
     std::shared_ptr<ProcessorHooks> hook;
@@ -90,10 +103,29 @@ private:
     RunMode run_mode = RunMode::NORMAL;
     std::stack<node_id> current_op_id;
     std::unordered_map<std::int64_t, node_id> buffer_id_to_counter;
-    std::unordered_map<std::int64_t, node_id> tensor_id_to_counter;
     node_id last_finished_op_id = -1;
     std::vector<Vertex> graph;
     std::vector<node_id> current_input_tensors;
+
+    // Duration tracking - stack of start timestamps for nested operations
+    using time_point = std::chrono::steady_clock::time_point;
+    std::stack<time_point> function_start_times;
+
+    // Capture timing
+    time_point capture_start_time;
+    uint64_t capture_start_timestamp_ns = 0;
+
+    // Device info captured at track time (keyed by device_id)
+    std::unordered_map<uint32_t, nlohmann::json> captured_device_info;
+    // Device pointers for buffer pages (only valid during capture)
+    std::vector<tt::tt_metal::distributed::MeshDevice*> captured_mesh_devices;
+    // Per-operation buffer snapshots (function_start counter -> buffers)
+    std::unordered_map<node_id, std::vector<ttnn::reports::BufferInfo>> per_op_buffers_;
+    // Buffer pages keyed by address, with versioning for re-allocations.
+    // Each address maps to a list of (allocation_counter, pages) pairs so that
+    // re-allocations at the same address with different page configs are preserved.
+    std::unordered_map<uint64_t, std::vector<std::pair<uint32_t, std::vector<ttnn::reports::BufferPageInfo>>>>
+        buffer_pages_by_address_;
 
     node_id add_tensor(const Tensor& t);
     node_id add_buffer(const tt::tt_metal::Buffer* buffer);
@@ -120,9 +152,21 @@ private:
 
     void clean_hook();
 
+    void track_device(const tt::tt_metal::IDevice* device);
+
 public:
     static void begin_graph_capture(RunMode mode);
     static nlohmann::json end_graph_capture();
+
+    static nlohmann::json end_graph_capture_to_file(const std::filesystem::path& report_path);
+
+    // Detailed buffer tracing control
+    static void enable_detailed_buffer_tracing();
+    static void disable_detailed_buffer_tracing();
+    static bool is_detailed_buffer_tracing_enabled();
+
+private:
+    static std::atomic<bool> capture_detailed_buffer_tracing_;
 };
 
 /**
@@ -138,9 +182,15 @@ public:
  */
 class ScopedGraphCapture {
 public:
-    ScopedGraphCapture(GraphProcessor::RunMode mode);
+    explicit ScopedGraphCapture(GraphProcessor::RunMode mode);
+
+    ScopedGraphCapture(GraphProcessor::RunMode mode, std::filesystem::path report_path);
+
     ~ScopedGraphCapture();
+
     nlohmann::json end_graph_capture();
+
+    nlohmann::json end_graph_capture_to_file(const std::filesystem::path& report_path);
 
     ScopedGraphCapture(const ScopedGraphCapture&) = delete;
     ScopedGraphCapture(ScopedGraphCapture&&) = delete;
@@ -149,5 +199,6 @@ public:
 
 private:
     bool is_active = false;
+    std::filesystem::path auto_report_path;
 };
 }  // namespace ttnn::graph

--- a/ttnn/core/graph/graph_nanobind.cpp
+++ b/ttnn/core/graph/graph_nanobind.cpp
@@ -6,20 +6,25 @@
 
 #include <string>
 #include <sstream>
+#include <filesystem>
 
 #include <nanobind/nanobind.h>
 #include <nanobind/stl/string.h>
 #include <nanobind/stl/vector.h>
 #include <nanobind/stl/tuple.h>
 #include <nanobind/stl/unordered_set.h>
+#include <nanobind/stl/filesystem.h>
 #include <nlohmann/json.hpp>
 
 #include "ttnn/graph/graph_processor.hpp"
 #include "ttnn/graph/graph_trace_utils.hpp"
+#include "ttnn/graph/graph_consts.hpp"
+#include <tt-metalium/graph_tracking.hpp>
 
 namespace ttnn::graph {
 
 using IGraphProcessor = tt::tt_metal::IGraphProcessor;
+using GraphTracker = tt::tt_metal::GraphTracker;
 
 void py_graph_module_types(nb::module_& m) {
     nb::enum_<IGraphProcessor::RunMode>(m, "RunMode", R"doc(
@@ -137,8 +142,12 @@ void py_graph_module(nb::module_& m) {
         nb::arg("run_mode") = IGraphProcessor::RunMode::NORMAL);
 
     const auto* doc_end =
-        R"doc(end_graph_capture() -> Union[None, bool, int, float, list, dict]
-        returns the value captured graph as a json object converted to python object
+        R"doc(end_graph_capture() -> list
+        Ends graph capture and returns the captured graph trace.
+
+        Returns:
+            List of graph nodes, where each node is a dict with keys like
+            'node_type', 'counter', 'params', 'connections', etc.
     )doc";
 
     m.def(
@@ -150,6 +159,32 @@ void py_graph_module(nb::module_& m) {
             return json_module.attr("loads")(json_object_str);
         },
         doc_end);
+
+    const auto* doc_end_to_file =
+        R"doc(end_graph_capture_to_file(report_path) -> str
+        Ends graph capture and writes a full report to a JSON file.
+
+        The report file contains: graph trace, device info, and metadata.
+        Useful for offline analysis without Python at capture time.
+
+        Args:
+            report_path: Path to write the JSON report file
+
+        Returns:
+            The captured graph trace as a JSON string
+    )doc";
+
+    m.def(
+        "end_graph_capture_to_file",
+        [](const std::filesystem::path& report_path) {
+            nlohmann::json json_object = GraphProcessor::end_graph_capture_to_file(report_path);
+            return json_object.dump();
+        },
+        doc_end_to_file,
+        nb::arg("report_path"));
+
+    // Expose report version constant
+    m.attr("REPORT_VERSION") = kCurrentReportVersion;
 
     m.def(
         "extract_calltrace",
@@ -257,6 +292,69 @@ void py_graph_module(nb::module_& m) {
         )doc",
         nb::arg("trace"),
         nb::arg("interleaved_storage_cores"));
+
+    m.def(
+        "is_graph_capture_active",
+        [] { return GraphTracker::instance().is_enabled(); },
+        R"doc(is_graph_capture_active() -> bool
+
+        Check if a graph capture session is currently active.
+
+        Returns:
+            True if begin_graph_capture() was called and capture is in progress.
+        )doc");
+
+    m.def(
+        "track_function_start",
+        [](const std::string& function_name) {
+            GraphTracker::instance().track_function_start(std::string_view(function_name));
+        },
+        R"doc(track_function_start(function_name: str) -> None
+
+        Emit a function_start node into the active graph capture.
+
+        This is used by Python-level operation decorators to wrap high-level
+        operations (e.g. ttnn.fold, ttnn.conv2d) so that the graph trace
+        correctly nests their internal C++ sub-operations.
+
+        Args:
+            function_name: The operation name (e.g. "ttnn.fold")
+        )doc",
+        nb::arg("function_name"));
+
+    m.def(
+        "track_function_end",
+        [] { GraphTracker::instance().track_function_end(); },
+        R"doc(track_function_end() -> None
+
+        Emit a function_end node into the active graph capture.
+
+        Must be paired with a prior track_function_start() call.
+        )doc");
+
+    m.def(
+        "enable_detailed_buffer_tracing",
+        &GraphProcessor::enable_detailed_buffer_tracing,
+        R"doc(enable_detailed_buffer_tracing() -> None
+
+        Enable detailed per-page buffer tracing for graph reports.
+        )doc");
+
+    m.def(
+        "disable_detailed_buffer_tracing",
+        &GraphProcessor::disable_detailed_buffer_tracing,
+        R"doc(disable_detailed_buffer_tracing() -> None
+
+        Disable detailed per-page buffer tracing.
+        )doc");
+
+    m.def(
+        "is_detailed_buffer_tracing_enabled",
+        &GraphProcessor::is_detailed_buffer_tracing_enabled,
+        R"doc(is_detailed_buffer_tracing_enabled() -> bool
+
+        Check if detailed per-page buffer tracing is currently enabled.
+        )doc");
 }
 
 }  // namespace ttnn::graph

--- a/ttnn/core/graph/graph_processor.cpp
+++ b/ttnn/core/graph/graph_processor.cpp
@@ -8,9 +8,20 @@
 #include "ttnn/types.hpp"
 #include "ttnn/core.hpp"
 #include "ttnn/tensor/tensor_utils.hpp"
+#include "ttnn/cluster.hpp"
+#include "ttnn/reports.hpp"
 #include <boost/algorithm/string/replace.hpp>
+#include <cstdlib>
+
+#include <fstream>
+#include <sstream>
+#include <enchantum/enchantum.hpp>
 #include <memory>
 #include <string>
+#include <tt-metalium/allocator.hpp>
+#include <tt-metalium/circular_buffer.hpp>
+#include <tt-metalium/hal_types.hpp>
+#include <tt-metalium/mesh_device.hpp>
 #include <tt-metalium/program.hpp>
 #include <unordered_map>
 
@@ -32,11 +43,38 @@ nlohmann::json to_json(const ttnn::graph::GraphProcessor::Vertex& data) {
     nlohmann::json j;
     j[ttnn::graph::kCounter] = data.counter;
     j[ttnn::graph::kNodeType] = data.node_type;
-    j[ttnn::graph::kParams] = data.params;
+
+    static const std::unordered_set<std::string> integer_params = {
+        ttnn::graph::kSize,
+        ttnn::graph::kAddress,
+        ttnn::graph::kTensorId,
+        ttnn::graph::kDeviceId,
+        ttnn::graph::kBufferTypeValue,
+        ttnn::graph::kPageSize,
+        ttnn::graph::kNumCores,
+        ttnn::graph::kMaxSizePerBank,
+    };
+    nlohmann::json params_json;
+    for (const auto& [key, value] : data.params) {
+        if (integer_params.contains(key)) {
+            params_json[key] = std::stoll(value);
+        } else {
+            params_json[key] = value;
+        }
+    }
+    j[ttnn::graph::kParams] = std::move(params_json);
+
     j[ttnn::graph::kArguments] = data.arguments;
     j[ttnn::graph::kConnections] = data.connections;
     j[ttnn::graph::kInputTensors] = data.input_tensors;
     j[ttnn::graph::kStackingLevel] = data.stacking_level;
+
+    // Include duration_ns for function_end and capture_end nodes
+    if ((data.node_type == ttnn::graph::kNodeFunctionEnd || data.node_type == ttnn::graph::kNodeCaptureEnd) &&
+        data.duration_ns > 0) {
+        j[ttnn::graph::kDurationNs] = data.duration_ns;
+    }
+
     return j;
 }
 
@@ -48,27 +86,180 @@ nlohmann::json to_json(const std::vector<ttnn::graph::GraphProcessor::Vertex>& d
     return j;
 }
 
+uint64_t current_time_ns() {
+    return std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::system_clock::now().time_since_epoch())
+        .count();
+}
+
+// Get cluster descriptor YAML content
+// Note: Only called during report generation (offline), not on hot path
+std::string get_cluster_descriptor_content() {
+    std::string descriptor_path = ttnn::cluster::serialize_cluster_descriptor();
+    if (descriptor_path.empty()) {
+        return "";
+    }
+    std::ifstream file(descriptor_path);
+    if (!file.is_open()) {
+        return "";
+    }
+    std::stringstream buffer;
+    buffer << file.rdbuf();
+    return buffer.str();
+}
+
+// Get mesh coordinate mapping from generated/fabric/ directory
+// This matches the old behavior of save_mesh_descriptor() which copied these YAML files
+// Note: Only called during report generation (offline), not on hot path
+std::string get_mesh_coordinate_mapping_content() {
+    const char* tt_metal_home = std::getenv("TT_METAL_HOME");
+    if (tt_metal_home == nullptr) {
+        log_warning(tt::LogAlways, "TT_METAL_HOME not set, mesh coordinate mapping will be missing from report");
+        return "";
+    }
+
+    std::filesystem::path fabric_dir = std::filesystem::path(tt_metal_home) / "generated" / "fabric";
+    if (!std::filesystem::exists(fabric_dir)) {
+        return "";
+    }
+
+    // Collect all physical_chip_mesh_coordinate_mapping*.yaml files
+    std::string combined_content;
+    for (const auto& entry : std::filesystem::directory_iterator(fabric_dir)) {
+        if (entry.is_regular_file()) {
+            std::string filename = entry.path().filename().string();
+            if (filename.find("physical_chip_mesh_coordinate_mapping") != std::string::npos &&
+                filename.find(".yaml") != std::string::npos) {
+                std::ifstream file(entry.path());
+                if (file.is_open()) {
+                    if (!combined_content.empty()) {
+                        combined_content += "\n---\n";  // YAML document separator
+                    }
+                    combined_content += "# " + filename + "\n";
+                    std::stringstream buffer;
+                    buffer << file.rdbuf();
+                    combined_content += buffer.str();
+                }
+            }
+        }
+    }
+    return combined_content;
+}
+
 }  // namespace
 
 namespace ttnn::graph {
 
+std::atomic<bool> GraphProcessor::capture_detailed_buffer_tracing_{false};
+
+void GraphProcessor::enable_detailed_buffer_tracing() { capture_detailed_buffer_tracing_ = true; }
+
+void GraphProcessor::disable_detailed_buffer_tracing() { capture_detailed_buffer_tracing_ = false; }
+
+bool GraphProcessor::is_detailed_buffer_tracing_enabled() { return capture_detailed_buffer_tracing_; }
+
 GraphProcessor::GraphProcessor(RunMode mode) : run_mode(mode) { GraphProcessor::begin_capture(mode); }
+
+void GraphProcessor::track_device(const tt::tt_metal::IDevice* device) {
+    if (device == nullptr) {
+        return;
+    }
+    auto device_id = device->id();
+    if (captured_device_info.contains(device_id)) {
+        return;  // Already captured
+    }
+
+    // Capture device info now - the device may not be available when report is generated
+    const auto& allocator = device->allocator();
+    auto compute_grid = device->compute_with_storage_grid_size();
+    auto logical_grid = device->logical_grid_size();
+
+    size_t num_x_compute_cores = compute_grid.x;
+    size_t num_y_compute_cores = compute_grid.y;
+    size_t num_compute_cores = num_x_compute_cores * num_y_compute_cores;
+    size_t num_storage_cores = device->storage_only_cores().size();
+    size_t worker_l1_size = allocator->get_worker_l1_size();
+    size_t l1_num_banks = allocator->get_num_banks(tt::tt_metal::BufferType::L1);
+    size_t l1_bank_size = allocator->get_bank_size(tt::tt_metal::BufferType::L1);
+
+    nlohmann::json info;
+    info[kDeviceId] = device_id;
+    info[kDeviceNumYCores] = logical_grid.y;
+    info[kDeviceNumXCores] = logical_grid.x;
+    info[kDeviceNumYComputeCores] = num_y_compute_cores;
+    info[kDeviceNumXComputeCores] = num_x_compute_cores;
+    info[kDeviceWorkerL1Size] = worker_l1_size;
+    info[kDeviceL1NumBanks] = l1_num_banks;
+    info[kDeviceL1BankSize] = l1_bank_size;
+    info[kDeviceAddressAtFirstL1Bank] = allocator->get_bank_offset(tt::tt_metal::BufferType::L1, 0);
+    info[kDeviceAddressAtFirstL1CbBuffer] = allocator->get_base_allocator_addr(tt::tt_metal::HalMemType::L1);
+    info[kDeviceNumBanksPerStorageCore] = l1_bank_size > 0 ? worker_l1_size / l1_bank_size : 0;
+    info[kDeviceNumComputeCores] = num_compute_cores;
+    info[kDeviceNumStorageCores] = num_storage_cores;
+    info[kDeviceTotalL1Memory] = (num_storage_cores + num_compute_cores) * worker_l1_size;
+    info[kDeviceTotalL1ForTensors] = 0;  // Not computed in original implementation
+    info[kDeviceTotalL1ForInterleavedBuffers] =
+        (num_storage_cores + num_compute_cores +
+         (l1_bank_size > 0 ? (worker_l1_size / l1_bank_size) * num_storage_cores : 0)) *
+        l1_bank_size;
+    info[kDeviceTotalL1ForShardedBuffers] = num_compute_cores * l1_bank_size;
+    info[kDeviceCbLimit] = worker_l1_size - allocator->get_base_allocator_addr(tt::tt_metal::HalMemType::L1);
+
+    // Extra useful info
+    info["arch"] = enchantum::to_string(device->arch());
+    info["num_dram_channels"] = device->num_dram_channels();
+    info["dram_size_per_channel"] = device->dram_size_per_channel();
+
+    captured_device_info[device_id] = std::move(info);
+
+    // Store device pointer for buffer page capture (MeshDevice extends IDevice)
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
+    auto* mesh_device = const_cast<tt::tt_metal::distributed::MeshDevice*>(
+        dynamic_cast<const tt::tt_metal::distributed::MeshDevice*>(device));
+    if (mesh_device != nullptr) {
+        captured_mesh_devices.push_back(mesh_device);
+    }
+}
 
 void GraphProcessor::track_allocate(const tt::tt_metal::Buffer* buffer) {
     const std::lock_guard<std::mutex> lock(mutex);
+
+    // Track the device for later device info collection
+    track_device(buffer->device());
+
     node_id buffer_node_id = add_buffer(buffer);
 
     node_id counter = graph.size();
     int stacking_level = static_cast<int>(current_op_id.size()) - 1;
 
+    // Compute max_size_per_bank: the maximum allocation footprint per bank for this
+    // buffer.  For interleaved layouts we use the real bank count from the allocator
+    // (important for L1_SMALL which has fewer banks than L1).  For sharded layouts
+    // we use the per-core page spread which matches the allocator's distribution for
+    // all standard shard specs.
+    uint32_t num_pages = buffer->num_pages();
+    uint32_t page_sz = buffer->page_size();
+    uint32_t max_size_per_bank;
+    if (tt::tt_metal::is_sharded(buffer->buffer_layout())) {
+        uint32_t nc = buffer->num_cores().value_or(1);
+        uint32_t pages_per_core = nc > 0 ? (num_pages + nc - 1) / nc : num_pages;
+        max_size_per_bank = pages_per_core * page_sz;
+    } else {
+        uint32_t num_banks = buffer->device()->allocator()->get_num_banks(buffer->buffer_type());
+        uint32_t pages_per_bank = num_banks > 0 ? (num_pages + num_banks - 1) / num_banks : num_pages;
+        max_size_per_bank = pages_per_bank * page_sz;
+    }
+
     std::unordered_map<std::string, std::string> params = {
         {kSize, std::to_string(buffer->size())},
         {kAddress, std::to_string(buffer->address())},
         {kType, buffer->is_dram() ? "DRAM" : "L1"},
+        {kExactBufferType, std::string(enchantum::to_string(buffer->buffer_type()))},
+        {kBufferTypeValue, std::to_string(static_cast<int>(buffer->buffer_type()))},
         {kLayout, tensorMemoryLayoutToString(buffer->buffer_layout())},
         {kPageSize, std::to_string(buffer->page_size())},
         {kNumCores, std::to_string(buffer->num_cores().value_or(0))},  // use 0 for interleaved
-        {kDeviceId, std::to_string(buffer->device()->id())}};
+        {kDeviceId, std::to_string(buffer->device()->id())},
+        {kMaxSizePerBank, std::to_string(max_size_per_bank)}};
     {
         graph.push_back(Vertex{
             .counter = counter,
@@ -78,16 +269,41 @@ void GraphProcessor::track_allocate(const tt::tt_metal::Buffer* buffer) {
             .stacking_level = stacking_level});
         graph[current_op_id.top()].connections.push_back(counter);
     }
+
+    // Capture buffer pages for this address on every allocation.
+    // The same address may be re-allocated with a different page configuration
+    // (e.g. fold at ps=448 then max_pool2d at ps=128).  Each allocation is
+    // recorded with its graph counter so the importer can pick the right version.
+    uint64_t addr = buffer->address();
+    if (capture_detailed_buffer_tracing_ && !captured_mesh_devices.empty()) {
+        auto all_pages = ttnn::reports::get_buffer_pages(captured_mesh_devices);
+        std::vector<ttnn::reports::BufferPageInfo> pages_for_addr;
+        for (const auto& page : all_pages) {
+            if (page.address == addr) {
+                pages_for_addr.push_back(page);
+            }
+        }
+        if (!pages_for_addr.empty()) {
+            buffer_pages_by_address_[addr].emplace_back(counter, std::move(pages_for_addr));
+        }
+    }
 }
 
 void GraphProcessor::track_deallocate(tt::tt_metal::Buffer* buffer) {
     const std::lock_guard<std::mutex> lock(mutex);
+
+    // Track the device for later device info collection
+    track_device(buffer->device());
+
     node_id buffer_node_id = add_buffer(buffer);
     node_id counter = graph.size();
     int stacking_level = static_cast<int>(current_op_id.size()) - 1;
     std::unordered_map<std::string, std::string> params = {
         {kSize, std::to_string(buffer->size())},
+        {kAddress, std::to_string(buffer->address())},
         {kType, buffer->is_dram() ? "DRAM" : "L1"},
+        {kExactBufferType, std::string(enchantum::to_string(buffer->buffer_type()))},
+        {kBufferTypeValue, std::to_string(static_cast<int>(buffer->buffer_type()))},
         {kLayout, tensorMemoryLayoutToString(buffer->buffer_layout())},
         {kPageSize, std::to_string(buffer->page_size())},
         {kNumCores, std::to_string(buffer->num_cores().value_or(0))},  // use 0 for interleaved
@@ -111,6 +327,10 @@ void GraphProcessor::track_allocate_cb(
     const tt::tt_metal::IDevice* device) {
     TT_ASSERT(device);
     const std::lock_guard<std::mutex> lock(mutex);
+
+    // Track the device for later device info collection
+    track_device(device);
+
     std::unordered_map<std::string, std::string> params = {
         {kSize, std::to_string(size)},
         {kAddress, std::to_string(addr)},
@@ -133,6 +353,10 @@ void GraphProcessor::track_allocate_cb(
 void GraphProcessor::track_deallocate_cb(const tt::tt_metal::IDevice* device) {
     TT_ASSERT(device);
     const std::lock_guard<std::mutex> lock(mutex);
+
+    // Track the device for later device info collection
+    track_device(device);
+
     node_id counter = graph.size();
     int stacking_level = static_cast<int>(current_op_id.size()) - 1;
     {
@@ -189,8 +413,14 @@ void GraphProcessor::track_function_start(
         make_process<std::optional<const Tensor>, &GraphProcessor::begin_function_process>(),
     };
 
+    // Record start time BEFORE acquiring lock to minimize overhead in timing measurement
+    auto start_time = std::chrono::steady_clock::now();
+
     const std::lock_guard<std::mutex> lock(mutex);
     log_debug(tt::LogAlways, "Begin op: {}", function_name);
+
+    // Push start time onto stack for duration calculation
+    function_start_times.push(start_time);
 
     // Clear the input tensor list for this new operation
     current_input_tensors.clear();
@@ -211,6 +441,7 @@ void GraphProcessor::track_function_start(
     node_id counter = graph.size();
     // Track stacking level: current stack depth (before pushing this operation)
     int stacking_level = static_cast<int>(current_op_id.size());
+
     {
         graph.push_back(Vertex{
             .counter = counter,
@@ -219,7 +450,8 @@ void GraphProcessor::track_function_start(
             .arguments = serialized_arguments,
             .connections = {/*current_op_id.top()*/},
             .input_tensors = {},
-            .stacking_level = stacking_level});
+            .stacking_level = stacking_level,
+            .duration_ns = 0});
         if (last_finished_op_id != -1) {
             graph[last_finished_op_id].connections.push_back(counter);
             last_finished_op_id = -1;
@@ -228,7 +460,7 @@ void GraphProcessor::track_function_start(
         current_op_id.push(counter);
     }
 
-    for (auto& tracked_arg : input_parameters) {
+    for (const auto& tracked_arg : input_parameters) {
         const auto* const it =
             std::ranges::find(begin_function_any_map, tracked_arg.value.type(), [](const auto& pair) -> const auto& {
                 return pair.first;
@@ -246,8 +478,17 @@ void GraphProcessor::track_function_start(
 }
 
 void GraphProcessor::track_function_end_impl() {
+    // Calculate duration - get end time first for accuracy
+    uint64_t duration_ns = 0;
+    if (!function_start_times.empty()) {
+        auto end_time = std::chrono::steady_clock::now();
+        auto start_time = function_start_times.top();
+        function_start_times.pop();
+        duration_ns = std::chrono::duration_cast<std::chrono::nanoseconds>(end_time - start_time).count();
+    }
+
     auto name = graph[current_op_id.top()].params[kName];
-    log_debug(tt::LogAlways, "End op: {}", name);
+    log_debug(tt::LogAlways, "End op: {} (duration: {} ns)", name, duration_ns);
 
     node_id function_start_id = current_op_id.top();
     int stacking_level = graph[function_start_id].stacking_level;
@@ -259,10 +500,16 @@ void GraphProcessor::track_function_end_impl() {
             .node_type = kNodeFunctionEnd,
             .params = {{kName, name}},
             .connections = {},
-            .stacking_level = stacking_level});
+            .stacking_level = stacking_level,
+            .duration_ns = duration_ns});
         graph[current_op_id.top()].connections.push_back(counter);
     }
     last_finished_op_id = counter;
+
+    // Snapshot live buffer state after each top-level operation completes
+    if (stacking_level == 1 && !captured_mesh_devices.empty()) {
+        per_op_buffers_[function_start_id] = ttnn::reports::get_buffers(captured_mesh_devices);
+    }
 }
 
 void GraphProcessor::track_function_end() {
@@ -297,6 +544,7 @@ void GraphProcessor::track_function_end(const std::any& output_tensors) {
 
 node_id GraphProcessor::add_tensor(const Tensor& t) {
     tt::tt_metal::Buffer* buffer = nullptr;
+    nlohmann::json device_tensors_json = nlohmann::json::array();
     if (is_device_tensor(t)) {
         const auto& storage = t.device_storage();
         if (storage.mesh_buffer) {
@@ -305,40 +553,60 @@ node_id GraphProcessor::add_tensor(const Tensor& t) {
             // To deduplicate an entry for this buffer, captured during its allocation, use the "backing"
             // buffer.
             buffer = storage.mesh_buffer->get_backing_buffer();
+
+            // For multi-device tensors, capture per-device addresses and mesh device IDs
+            if (storage.mesh_buffer->is_allocated()) {
+                for (const auto& coord : storage.coords) {
+                    auto* device_buffer = storage.mesh_buffer->get_device_buffer(coord);
+                    if (device_buffer != nullptr) {
+                        device_tensors_json.push_back(
+                            {{"device_id", device_buffer->device()->id()},
+                             {kMeshDeviceId,
+                              buffer != nullptr ? buffer->device()->id() : device_buffer->device()->id()},
+                             {"address", device_buffer->address()}});
+                    }
+                }
+            }
         } else {
             buffer = t.buffer();
         }
     }
 
-    // TODO #32045: Remove the check for INVALID_TENSOR_ID since IDs are assigned in the constructor.
-    std::uint64_t tensor_id = t.tensor_id;
-    if (tensor_id == tt::tt_metal::Tensor::INVALID_TENSOR_ID) {
-        log_debug(
-            tt::LogAlways,
-            "Tensor doesn't have tensor_id (sentinel value is INVALID_TENSOR_ID), generating new one. Ideally this "
-            "should not happen. "
-            "Please set tensor_id "
-            "for this tensor ahead of time.");
-        tensor_id = tt::tt_metal::Tensor::next_tensor_id();
-    }
-    node_id tensor_counter = tensor_id_to_counter.contains(tensor_id) ? tensor_id_to_counter[tensor_id] : graph.size();
+    node_id tensor_counter = graph.size();
     auto shape = t.logical_shape();
 
     std::unordered_map<std::string, std::string> params = {
         {kShape, fmt::format("{}", shape)},
-        {kTensorId, fmt::format("{}", tensor_id)},
+        {kTensorId, fmt::format("{}", t.tensor_id)},
+        {kDtype, fmt::format("{}", t.dtype())},
+        {kLayout, fmt::format("{}", t.layout())},
+        {kSize, std::to_string(t.logical_volume() * t.element_size())},
     };
 
-    if (!tensor_id_to_counter.contains(tensor_id)) {
-        int stacking_level = static_cast<int>(current_op_id.size()) - 1;
-        graph.push_back(Vertex{
-            .counter = tensor_counter,
-            .node_type = kNodeTensor,
-            .params = std::move(params),
-            .connections = {},
-            .stacking_level = stacking_level});
-        tensor_id_to_counter[tensor_id] = tensor_counter;
+    // Add memory config if tensor is on device
+    if (t.is_allocated() && t.storage_type() == StorageType::DEVICE) {
+        params[kMemoryConfig] = fmt::format("{}", t.memory_config());
     }
+
+    // Add buffer-related info (primary device for single-device tensors)
+    if (buffer != nullptr) {
+        params[kDeviceId] = std::to_string(buffer->device()->id());
+        params[kAddress] = std::to_string(buffer->address());
+        params[kBufferType] = fmt::format("{}", buffer->buffer_type());
+        params[kBufferTypeValue] = std::to_string(static_cast<int>(buffer->buffer_type()));
+    }
+
+    if (!device_tensors_json.empty()) {
+        params[kDeviceTensors] = device_tensors_json.dump();
+    }
+
+    int stacking_level = static_cast<int>(current_op_id.size()) - 1;
+    graph.push_back(Vertex{
+        .counter = tensor_counter,
+        .node_type = kNodeTensor,
+        .params = std::move(params),
+        .connections = {},
+        .stacking_level = stacking_level});
 
     if (buffer == nullptr) {
         log_debug(tt::LogAlways, "Tensor doesn't have buffer, but storage is {}", t.storage_type());
@@ -362,6 +630,8 @@ node_id GraphProcessor::add_buffer(const tt::tt_metal::Buffer* buffer) {
     std::unordered_map<std::string, std::string> params = {
         {kSize, std::to_string(buffer->size())},
         {kType, buffer->is_dram() ? "DRAM" : "L1"},
+        {kExactBufferType, std::string(enchantum::to_string(buffer->buffer_type()))},
+        {kBufferTypeValue, std::to_string(static_cast<int>(buffer->buffer_type()))},
         {kLayout, tensorMemoryLayoutToString(buffer->buffer_layout())},
         {kDeviceId, std::to_string(buffer->device()->id())}};
 
@@ -395,7 +665,7 @@ void GraphProcessor::begin_function_process(const std::optional<T>& tensor_opt) 
 
 template <typename T>
 void GraphProcessor::begin_function_process(const std::vector<T>& tensor_vec) {
-    for (auto& it : tensor_vec) {
+    for (const auto& it : tensor_vec) {
         begin_function_process(it);
     }
 }
@@ -414,7 +684,7 @@ void GraphProcessor::end_function_process(const std::optional<T>& tensor_opt) {
 
 template <typename T>
 void GraphProcessor::end_function_process(const std::vector<T>& tensor_vec) {
-    for (auto& it : tensor_vec) {
+    for (const auto& it : tensor_vec) {
         end_function_process(it);
     }
 }
@@ -423,7 +693,17 @@ void GraphProcessor::begin_capture(RunMode mode) {
     const std::lock_guard<std::mutex> lock(mutex);
     graph.clear();
     buffer_id_to_counter.clear();
-    tensor_id_to_counter.clear();
+    captured_device_info.clear();
+    captured_mesh_devices.clear();
+    per_op_buffers_.clear();
+    buffer_pages_by_address_.clear();
+
+    function_start_times = {};
+
+    // Record capture start time
+    capture_start_time = std::chrono::steady_clock::now();
+    capture_start_timestamp_ns = current_time_ns();
+
     graph.push_back(
         Vertex{.counter = 0, .node_type = kNodeCaptureStart, .params = {}, .connections = {}, .stacking_level = 0});
 
@@ -436,9 +716,21 @@ void GraphProcessor::begin_capture(RunMode mode) {
 }
 nlohmann::json GraphProcessor::end_capture() {
     const std::lock_guard<std::mutex> lock(mutex);
+
+    // Calculate total capture duration
+    auto capture_end_time = std::chrono::steady_clock::now();
+    uint64_t total_duration_ns =
+        std::chrono::duration_cast<std::chrono::nanoseconds>(capture_end_time - capture_start_time).count();
+
     node_id counter = graph.size();
-    graph.push_back(
-        Vertex{.counter = counter, .node_type = kNodeCaptureEnd, .params = {}, .connections = {}, .stacking_level = 0});
+    graph.push_back(Vertex{
+        .counter = counter,
+        .node_type = kNodeCaptureEnd,
+        .params = {},
+        .connections = {},
+        .stacking_level = 0,
+        .duration_ns = total_duration_ns});
+
     if (last_finished_op_id != -1) {
         graph[last_finished_op_id].connections.push_back(counter);
     } else {
@@ -451,6 +743,111 @@ nlohmann::json GraphProcessor::end_capture() {
     }
     clean_hook();
     return to_json(graph);
+}
+
+nlohmann::json GraphProcessor::get_report() const {
+    nlohmann::json report;
+
+    // Version for forward compatibility
+    report[kReportVersion] = kCurrentReportVersion;
+
+    // Graph trace
+    report[kReportGraph] = to_json(graph);
+
+    // Device info captured during trace
+    nlohmann::json devices = nlohmann::json::array();
+    for (const auto& [device_id, device_info] : captured_device_info) {
+        devices.push_back(device_info);
+    }
+    report[kReportDevices] = devices;
+
+    // Metadata
+    nlohmann::json metadata;
+    metadata[kReportTimestampNs] = capture_start_timestamp_ns;
+
+    // Calculate total duration if capture has ended (capture_end node exists)
+    if (!graph.empty() && graph.back().node_type == kNodeCaptureEnd) {
+        metadata[kReportTotalDurationNs] = graph.back().duration_ns;
+    }
+
+    report[kReportMetadata] = metadata;
+
+    // Cluster descriptor (YAML content) - always try, returns empty if unavailable
+    std::string cluster_desc = get_cluster_descriptor_content();
+    if (!cluster_desc.empty()) {
+        report["cluster_descriptor"] = cluster_desc;
+    }
+
+    // Mesh coordinate mapping (from generated/fabric/*.yaml) - matches old behavior
+    std::string mesh_mapping = get_mesh_coordinate_mapping_content();
+    if (!mesh_mapping.empty()) {
+        report["mesh_coordinate_mapping"] = mesh_mapping;
+    }
+
+    // Buffer pages (when detailed buffer report is enabled)
+    if (capture_detailed_buffer_tracing_ && !captured_mesh_devices.empty()) {
+        auto buffer_pages = ttnn::reports::get_buffer_pages(captured_mesh_devices);
+        nlohmann::json buffer_pages_json = nlohmann::json::array();
+        for (const auto& page : buffer_pages) {
+            buffer_pages_json.push_back(
+                {{"device_id", page.device_id},
+                 {"address", page.address},
+                 {"core_y", page.core_y},
+                 {"core_x", page.core_x},
+                 {"bank_id", page.bank_id},
+                 {"page_index", page.page_index},
+                 {"page_address", page.page_address},
+                 {"page_size", page.page_size},
+                 {"buffer_type", static_cast<int>(page.buffer_type)}});
+        }
+        report["buffer_pages"] = buffer_pages_json;
+    }
+
+    // Per-operation buffer snapshots from get_buffers()
+    if (!per_op_buffers_.empty()) {
+        nlohmann::json per_op_json = nlohmann::json::object();
+        for (const auto& [op_counter, buffers] : per_op_buffers_) {
+            nlohmann::json bufs_json = nlohmann::json::array();
+            for (const auto& buf : buffers) {
+                bufs_json.push_back(
+                    {{"device_id", buf.device_id},
+                     {"address", buf.address},
+                     {"max_size_per_bank", buf.max_size_per_bank},
+                     {"buffer_type", static_cast<int>(buf.buffer_type)},
+                     {"buffer_layout", static_cast<int>(buf.buffer_layout)}});
+            }
+            per_op_json[std::to_string(op_counter)] = std::move(bufs_json);
+        }
+        report["per_operation_buffers"] = std::move(per_op_json);
+    }
+
+    // Buffer pages keyed by address, versioned by allocation counter.
+    if (!buffer_pages_by_address_.empty()) {
+        nlohmann::json bp_json = nlohmann::json::object();
+        for (const auto& [addr, snapshots] : buffer_pages_by_address_) {
+            nlohmann::json snaps_json = nlohmann::json::array();
+            for (const auto& [alloc_counter, pages] : snapshots) {
+                nlohmann::json pages_json = nlohmann::json::array();
+                for (const auto& page : pages) {
+                    pages_json.push_back(
+                        {{"device_id", page.device_id},
+                         {"address", page.address},
+                         {"core_y", page.core_y},
+                         {"core_x", page.core_x},
+                         {"bank_id", page.bank_id},
+                         {"page_index", page.page_index},
+                         {"page_address", page.page_address},
+                         {"page_size", page.page_size},
+                         {"buffer_type", static_cast<int>(page.buffer_type)}});
+                }
+                snaps_json.push_back({{"alloc_counter", alloc_counter}, {"pages", std::move(pages_json)}});
+            }
+            bp_json[std::to_string(addr)] = std::move(snaps_json);
+        }
+        report["buffer_pages_by_address"] = std::move(bp_json);
+    }
+
+    return report;
 }
 
 void GraphProcessor::clean_hook() {
@@ -466,10 +863,41 @@ GraphProcessor::~GraphProcessor() { clean_hook(); }
 void GraphProcessor::begin_graph_capture(RunMode mode = RunMode::NORMAL) {
     tt::tt_metal::GraphTracker::instance().push_processor(std::make_shared<GraphProcessor>(mode));
 }
+
 nlohmann::json GraphProcessor::end_graph_capture() {
     auto res = tt::tt_metal::GraphTracker::instance().get_processors().back()->end_capture();
     tt::tt_metal::GraphTracker::instance().pop_processor();
     return res;
+}
+
+nlohmann::json GraphProcessor::end_graph_capture_to_file(const std::filesystem::path& report_path) {
+    const auto& processors = tt::tt_metal::GraphTracker::instance().get_processors();
+    TT_ASSERT(!processors.empty(), "No active graph capture to end");
+
+    auto* processor = dynamic_cast<GraphProcessor*>(processors.back().get());
+    TT_ASSERT(processor != nullptr, "Current processor is not a GraphProcessor");
+
+    // Finalize the graph, then build the report via the shared get_report() path
+    auto graph_json = processor->end_capture();
+    nlohmann::json report = processor->get_report();
+
+    // Write to file
+    if (report_path.has_parent_path()) {
+        std::filesystem::create_directories(report_path.parent_path());
+    }
+    std::ofstream file(report_path);
+    if (!file.is_open()) {
+        TT_THROW("Failed to open graph report file for writing: {}", report_path.string());
+    }
+    file << report.dump(2);
+    if (!file) {
+        TT_THROW("Failed to write graph report to file: {}", report_path.string());
+    }
+    file.close();
+    log_info(tt::LogAlways, "Graph report written to: {}", report_path.string());
+
+    tt::tt_metal::GraphTracker::instance().pop_processor();
+    return graph_json;
 }
 
 bool ProcessorHooks::hook_allocate(const tt::tt_metal::Buffer* /*buffer*/) { return do_block; }
@@ -496,14 +924,35 @@ bool ProcessorHooks::get_block() const { return do_block; }
 ScopedGraphCapture::ScopedGraphCapture(GraphProcessor::RunMode mode) : is_active(true) {
     GraphProcessor::begin_graph_capture(mode);
 }
+
+ScopedGraphCapture::ScopedGraphCapture(GraphProcessor::RunMode mode, std::filesystem::path report_path) :
+    is_active(true), auto_report_path(std::move(report_path)) {
+    GraphProcessor::begin_graph_capture(mode);
+}
+
 ScopedGraphCapture::~ScopedGraphCapture() {
-    if (is_active) {
-        GraphProcessor::end_graph_capture();
+    if (!is_active) {
+        return;
+    }
+    try {
+        if (!auto_report_path.empty()) {
+            GraphProcessor::end_graph_capture_to_file(auto_report_path);
+        } else {
+            GraphProcessor::end_graph_capture();
+        }
+    } catch (const std::exception& e) {
+        log_warning(tt::LogAlways, "Exception during graph capture teardown: {}", e.what());
     }
 }
+
 nlohmann::json ScopedGraphCapture::end_graph_capture() {
     is_active = false;
     return GraphProcessor::end_graph_capture();
+}
+
+nlohmann::json ScopedGraphCapture::end_graph_capture_to_file(const std::filesystem::path& report_path) {
+    is_active = false;
+    return GraphProcessor::end_graph_capture_to_file(report_path);
 }
 
 }  // namespace ttnn::graph

--- a/ttnn/core/graph/graph_trace_utils.cpp
+++ b/ttnn/core/graph/graph_trace_utils.cpp
@@ -18,6 +18,14 @@
 namespace ttnn::graph {
 
 namespace {
+
+int64_t json_to_int(const nlohmann::json& v) {
+    if (v.is_number()) {
+        return v.get<int64_t>();
+    }
+    return std::stoll(v.get<std::string>());
+}
+
 ttnn::Shape parse_shape(std::string_view shape_string) {
     // Extract shape values from string like "ttnn.Shape([1, 3, 32, 32])"
     auto start = shape_string.find('[') + 1;
@@ -63,7 +71,7 @@ uint32_t extract_peak_L1_memory_usage(const nlohmann::json& trace) {
                 while (++i < trace.size()) {
                     const auto& inner_v = trace[i];
                     if (inner_v[kNodeType] == "buffer" && inner_v[kParams][kType] == "L1") {
-                        total_buffer += std::stoi(inner_v[kParams][kSize].get<std::string>());
+                        total_buffer += json_to_int(inner_v[kParams][kSize]);
                     } else if (inner_v[kNodeType] == kNodeTensor) {
                         continue;
                     } else {
@@ -74,16 +82,16 @@ uint32_t extract_peak_L1_memory_usage(const nlohmann::json& trace) {
             }
             current_op.push_back(v[kParams][kName]);
         } else if (v[kNodeType] == kNodeCBAllocate) {
-            total_cb += stoi(v[kParams][kSize].get<std::string>());
+            total_cb += json_to_int(v[kParams][kSize]);
         } else if (v[kNodeType] == kNodeCBDeallocateAll) {
             total_cb = 0;
         } else if (v[kNodeType] == kNodeBufferAllocate && v[kParams][kType] == "L1") {
-            total_buffer += stoi(v[kParams][kSize].get<std::string>());
+            total_buffer += json_to_int(v[kParams][kSize]);
         } else if (v[kNodeType] == kNodeBufferDeallocate) {
             auto connection = v[kConnections][0].get<int>();
             auto buffer = trace[connection];
             if (buffer[kParams][kType] == "L1") {
-                total_buffer -= stoi(buffer[kParams][kSize].get<std::string>());
+                total_buffer -= json_to_int(buffer[kParams][kSize]);
             }
         } else if (v[kNodeType] == kNodeFunctionEnd) {
             current_op.pop_back();
@@ -97,21 +105,35 @@ uint32_t extract_peak_L1_memory_usage(const nlohmann::json& trace) {
 
 std::pair<uint32_t, uint32_t> count_intermediate_and_output_tensors(const nlohmann::json& trace) {
     bool first_begin_found = false;
-    bool last_end_found = false;
 
     std::unordered_set<int> intermediate_tensors;
     std::unordered_set<int> output_tensors;
 
+    // Walk backwards to find the last function_end whose connections include
+    // at least one tensor node.  Python wrapper and deallocate function_end
+    // nodes connect to non-tensor nodes (other functions or capture_end).
     int last_end_index = -1;
-
-    for (int i = 0; i < trace.size(); ++i) {
+    for (int i = static_cast<int>(trace.size()) - 1; i >= 0; --i) {
         const auto& v = trace[i];
+        if (v[kNodeType] != kNodeFunctionEnd) {
+            continue;
+        }
+        for (const auto& conn : v[kConnections]) {
+            auto idx = conn.get<int>();
+            if (trace[idx][kNodeType] == kNodeTensor) {
+                last_end_index = i;
+                break;
+            }
+        }
+        if (last_end_index != -1) {
+            break;
+        }
+    }
+
+    for (const auto& v : trace) {
         if (v[kNodeType] == kNodeFunctionStart && !first_begin_found) {
             first_begin_found = true;
         } else if (v[kNodeType] == kNodeFunctionEnd) {
-            last_end_found = true;
-            last_end_index = i;
-
             if (v[kParams][kName] == "create_device_tensor") {
                 auto id = v[kConnections][0].get<int>();
                 intermediate_tensors.insert(id);
@@ -120,11 +142,10 @@ std::pair<uint32_t, uint32_t> count_intermediate_and_output_tensors(const nlohma
     }
 
     TT_ASSERT(first_begin_found);
-    TT_ASSERT(last_end_found);
+    TT_ASSERT(last_end_index != -1, "No function_end node with tensor connections found");
 
     auto connections = trace[last_end_index][kConnections].get<std::unordered_set<uint32_t>>();
     for (auto index : connections) {
-        // It can be tensor or some other node like
         if (trace[index][kNodeType] == kNodeTensor) {
             output_tensors.insert(index);
         }
@@ -177,15 +198,22 @@ std::vector<OperationInfo> extract_arguments(const nlohmann::json& trace) {
 }
 
 std::unordered_set<uint32_t> extract_output_tensors(const nlohmann::json& trace) {
-    // Lambda to find the last 'function_end' node
+    // Find the last function_end node whose connections include a tensor node.
+    // Python wrapper and deallocate function_end nodes connect to non-tensor
+    // nodes (other functions or capture_end).
     auto find_function_end_node = [](const auto& trace) -> const nlohmann::json& {
         for (int i = trace.size() - 1; i >= 0; --i) {
             const auto& v = trace[i];
-            if (v[kNodeType] == kNodeFunctionEnd) {
-                return v;
+            if (v[kNodeType] != kNodeFunctionEnd) {
+                continue;
+            }
+            for (const auto& conn : v[kConnections]) {
+                if (trace[conn.template get<int>()][kNodeType] == kNodeTensor) {
+                    return v;
+                }
             }
         }
-        TT_THROW("No function_end node found in the trace");
+        TT_THROW("No function_end node with tensor connections found in the trace");
     };
 
     const auto& function_end_node = find_function_end_node(trace);
@@ -224,7 +252,7 @@ std::vector<TensorInfo> extract_output_info(const nlohmann::json& trace) {
 
             const auto type =
                 node[kParams][kType] == "L1" ? tt::tt_metal::BufferType::L1 : tt::tt_metal::BufferType::DRAM;
-            const auto size = stoi(node[kParams][kSize].get<std::string>());
+            const auto size = json_to_int(node[kParams][kSize]);
 
             const auto& tensor = trace[tensor_id];
             const std::string shape_string = tensor[kParams][kShape];
@@ -276,13 +304,13 @@ uint32_t extract_circular_buffers_peak_size_per_core(const nlohmann::json& trace
 
 // calculate the size of buffer allocated/deallocated on each core
 static uint32_t calculate_buffer_allocation_size(const nlohmann::json& node, size_t interleaved_storage_cores) {
-    uint32_t page_size = std::stoi(node.at(kParams).at(kPageSize).get<std::string>());
-    uint32_t num_of_cores = std::stoi(node.at(kParams).at(kNumCores).get<std::string>());
+    uint32_t page_size = json_to_int(node.at(kParams).at(kPageSize));
+    uint32_t num_of_cores = json_to_int(node.at(kParams).at(kNumCores));
     if (num_of_cores == 0) {
         num_of_cores = interleaved_storage_cores;
     }
 
-    uint32_t total_size = std::stoi(node.at(kParams).at(kSize).get<std::string>());
+    uint32_t total_size = json_to_int(node.at(kParams).at(kSize));
     return detail::worst_case_per_core_allocation(total_size, page_size, num_of_cores);
 }
 
@@ -307,9 +335,9 @@ PeakMemoryUsagePerCore extract_resource_usage_per_core(const nlohmann::json& tra
         }
 
         if (node.at(kNodeType) == kNodeCBAllocate) {
-            bool is_globally_allocated = std::stoi(node.at(kParams).at(kGloballyAllocated).get<std::string>()) == 1;
+            bool is_globally_allocated = json_to_int(node.at(kParams).at(kGloballyAllocated)) == 1;
             if (!is_globally_allocated) {
-                uint32_t alloc_size = std::stoi(node.at(kParams).at(kSize).get<std::string>());
+                uint32_t alloc_size = json_to_int(node.at(kParams).at(kSize));
                 current_cb += alloc_size;
                 peak_cb = std::max(peak_cb, current_cb);
                 current_total += alloc_size;
@@ -345,14 +373,14 @@ DRAMUsage extract_dram_usage(const nlohmann::json& trace) {
         const auto& v = trace[i];
 
         if (v[kNodeType] == kNodeBufferAllocate && v[kParams][kType] == "DRAM") {
-            size_t buffer_size = std::stoll(v[kParams][kSize].get<std::string>());
+            size_t buffer_size = json_to_int(v[kParams][kSize]);
             current_buffer += buffer_size;
             result.total_allocations += buffer_size;
         } else if (v[kNodeType] == kNodeBufferDeallocate) {
             auto connection = v[kConnections][0].get<int>();
             auto buffer = trace[connection];
             if (buffer[kParams][kType] == "DRAM") {
-                size_t buffer_size = std::stoll(buffer[kParams][kSize].get<std::string>());
+                size_t buffer_size = json_to_int(buffer[kParams][kSize]);
                 current_buffer -= buffer_size;
                 result.total_deallocations += buffer_size;
             }

--- a/ttnn/core/graph/levelized_graph.cpp
+++ b/ttnn/core/graph/levelized_graph.cpp
@@ -105,9 +105,10 @@ void LevelizedGraph::populate_vertices(const nlohmann::json& trace, std::size_t 
         // Extract tensor_id and shape from params
         if (node.contains(kParams)) {
             if (node[kParams].contains(kTensorId)) {
-                // override tensor name to include tensor_id:
-                vertex.name =
-                    std::string(kNodeTensor) + "[" + node[kParams][kTensorId].template get<std::string>() + "]";
+                const auto& tid = node[kParams][kTensorId];
+                std::string tid_str =
+                    tid.is_string() ? tid.template get<std::string>() : std::to_string(tid.template get<int64_t>());
+                vertex.name = std::string(kNodeTensor) + "[" + tid_str + "]";
             }
             if (node[kParams].contains(kShape)) {
                 vertex.output_shape.push_back(node[kParams][kShape].template get<std::string>());

--- a/ttnn/core/tensor/tensor.cpp
+++ b/ttnn/core/tensor/tensor.cpp
@@ -152,20 +152,25 @@ void Tensor::deallocate_impl(bool force) {
                (shared_resource.use_count() > 1 && force);
     };
 
-    // GraphTracker::instance().track_function_start("Tensor::deallocate", *this, force);
+    bool tracking = GraphTracker::instance().is_enabled();
     if (can_deallocate(tensor_attributes, force)) {
         std::visit(
             ttsl::overloaded{
                 [](HostStorage&) {},
-                [this, force, &can_deallocate](DeviceStorage& storage) {
+                [this, force, tracking, &can_deallocate](DeviceStorage& storage) {
                     if (can_deallocate(storage.get_root_mesh_buffer(), force)) {
+                        if (tracking) {
+                            GraphTracker::instance().track_function_start(std::string_view("Tensor::deallocate"));
+                        }
                         storage.deallocate_root_mesh_buffer();
+                        if (tracking) {
+                            GraphTracker::instance().track_function_end();
+                        }
                     }
                     storage.reset_root_mesh_buffer();
                 }},
             this->tensor_attributes->get_storage());
     }
-    // GraphTracker::instance().track_function_end();
 }
 
 std::uint64_t Tensor::get_tensor_id_counter() { return tensor_id_counter.load(std::memory_order_relaxed); }

--- a/ttnn/ttnn/decorators.py
+++ b/ttnn/ttnn/decorators.py
@@ -3,18 +3,13 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import dataclasses
-import glob
 import os
 
 import pathlib
-import shutil
 import sys
-import time
-import traceback
 import types
 
 from contextlib import contextmanager
-from datetime import datetime
 from functools import wraps
 from importlib.machinery import ModuleSpec
 from importlib.util import module_from_spec
@@ -215,13 +210,31 @@ def set_tensor_id(tensor, force=False):
         raise RuntimeError(f"Unsupported input to set_tensor_id: {type(tensor)}")
 
 
+def get_output_tensor_ids(output):
+    """Return the list of tensor_id ints from all tensors in *output*.
+
+    Tensor IDs must already be assigned (via ``set_tensor_id``).
+    """
+    ids = []
+    for t in get_all_tensors(output):
+        tid = getattr(t, "tensor_id", None)
+        if tid is not None:
+            ids.append(int(tid))
+    return ids
+
+
+def set_output_tensor_id_decorator(function):
+    @wraps(function)
+    def call_wrapper(*function_args, **function_kwargs):
+        output = function(*function_args, **function_kwargs)
+        output_tensors = get_all_tensors(output)
+        set_tensor_id(output_tensors, force=True)
+        return output
+
+    return call_wrapper
+
+
 OPERATION_CALL_STACK = []
-
-
-@dataclasses.dataclass
-class OutputWithDuration:
-    output: any
-    duration: float
 
 
 def default_preprocess_golden_function_inputs(function_args, function_kwargs):
@@ -446,6 +459,15 @@ class FastOperation:
         elif "cq_id" in function_kwargs:
             cq_id = function_kwargs.pop("cq_id")
 
+        tracking = ttnn.graph.is_graph_capture_active()
+        if tracking:
+            ttnn.graph.track_function_start(self.python_fully_qualified_name)
+
+            ttnn.graph.record_python_operation(self.python_fully_qualified_name, function_args, function_kwargs)
+
+            input_tensors = get_all_tensors((function_args, function_kwargs))
+            set_tensor_id(input_tensors)
+
         try:
             if cq_id is None:
                 result = self.function(*function_args, **function_kwargs)
@@ -457,6 +479,13 @@ class FastOperation:
             if enhanced_msg:
                 raise TypeError(enhanced_msg) from e
             raise
+        finally:
+            if tracking:
+                ttnn.graph.track_function_end()
+
+        if tracking:
+            set_tensor_id(get_all_tensors(result), force=True)
+            ttnn.graph.store_output_tensor_ids(get_output_tensor_ids(result))
 
         return result
 
@@ -510,28 +539,6 @@ class Operation:
             self.postprocess_golden_function_outputs or default_postprocess_golden_function_outputs
         )
 
-        def set_output_tensor_id_decorator(function):
-            @wraps(function)
-            def call_wrapper(*function_args, **function_kwargs):
-                output = function(*function_args, **function_kwargs)
-                output_tensors = get_all_tensors(output)
-                # Set new tensor id to store the outputs of in-place operations correctly
-                set_tensor_id(output_tensors, force=True)
-                return output
-
-            return call_wrapper
-
-        def duration_decorator(function):
-            @wraps(function)
-            def call_wrapper(*function_args, **function_kwargs):
-                start = time.time()
-                output = function(*function_args, **function_kwargs)
-                end = time.time()
-                duration = end - start
-                return OutputWithDuration(output, duration)
-
-            return call_wrapper
-
         def comparison_decorator(function):
             @wraps(function)
             def call_wrapper(*function_args, **function_kwargs):
@@ -561,10 +568,7 @@ class Operation:
                         [],
                     )
 
-                if isinstance(function_return_value, OutputWithDuration):
-                    output = function_return_value.output
-                else:
-                    output = function_return_value
+                output = function_return_value
 
                 logger.debug(f"{self.python_fully_qualified_name}: Comparing against CPU")
                 local_golden_function_output = self.golden_function(
@@ -618,18 +622,6 @@ class Operation:
         def runtime_decorator(function):
             @wraps(function)
             def call_wrapper(*function_args, **function_kwargs):
-                if ttnn.CONFIG.report_path is not None:
-                    # If the database already exists, get the operation_id from the latest operation
-                    latest_operation = ttnn.database.query_latest_operation(ttnn.CONFIG.report_path)
-                    if latest_operation is not None:
-                        operation_id = latest_operation.operation_id + 1
-                        ttnn._ttnn.set_python_operation_id(operation_id)
-
-                    latest_tensor = ttnn.database.query_latest_tensor(ttnn.CONFIG.report_path)
-                    if latest_tensor is not None:
-                        tensor_id = latest_tensor.tensor_id + 1
-                        ttnn._ttnn.set_tensor_id(tensor_id)
-
                 operation_id = ttnn._ttnn.get_python_operation_id()
                 is_top_level_operation = len(OPERATION_CALL_STACK) == 1
 
@@ -660,6 +652,11 @@ class Operation:
                         self.python_fully_qualified_name, decorated_function
                     )
 
+                # Record Python I/O BEFORE set_tensor_id mutates tensor IDs.
+                # This ensures input_tensor_ids match the previous op's output_tensor_ids.
+                if ttnn.graph.is_graph_capture_active():
+                    ttnn.graph.record_python_operation(self.python_fully_qualified_name, function_args, function_kwargs)
+
                 if ttnn.CONFIG.enable_logging or ttnn.CONFIG.enable_comparison_mode:
                     input_tensors = get_all_tensors((function_args, function_kwargs))
                     set_tensor_id(input_tensors)
@@ -672,35 +669,14 @@ class Operation:
 
                     logger.debug(f"Started {self.python_fully_qualified_name:50}")
 
-                    if ttnn.CONFIG.report_path is not None:
-                        cluster_descriptor_path = pathlib.Path(ttnn.CONFIG.report_path) / "cluster_descriptor.yaml"
-                        if not cluster_descriptor_path.exists():
-                            save_cluster_descriptor(str(cluster_descriptor_path))
-                        if not glob.glob(str(ttnn.CONFIG.report_path) + "/physical_chip_mesh_coordinate_mapping*.yaml"):
-                            save_mesh_descriptor(ttnn.CONFIG.report_path)
-                        ttnn.database.insert_operation(ttnn.CONFIG.report_path, operation_id, self, None)
-                        ttnn.database.insert_stack_trace(
-                            ttnn.CONFIG.report_path, operation_id, traceback.format_stack()
-                        )
-                        ttnn.database.insert_operation_arguments(
-                            ttnn.CONFIG.report_path, operation_id, function_args, function_kwargs
-                        )
-                        ttnn.database.insert_input_tensors(ttnn.CONFIG.report_path, operation_id, input_tensors)
-
-                    decorated_function = duration_decorator(decorated_function)
-
                 if ttnn.CONFIG.enable_comparison_mode:
                     decorated_function = comparison_decorator(decorated_function)
 
-                # Initialize variables that may be needed in finally block
-                output = None
-                duration = None
-                captured_graph = None
+                # Initialize variables for comparison mode
                 local_tensor_comparison_records = []
                 local_golden_function_output = []
                 global_tensor_comparison_records = []
                 global_golden_function_output = []
-                output_tensors = []
 
                 ttnn.graph.begin_graph_capture(ttnn.graph.RunMode.NORMAL)
 
@@ -711,25 +687,7 @@ class Operation:
                         with command_queue(cq_id):
                             output = decorated_function(*function_args, **function_kwargs)
 
-                except Exception as e:
-                    # Record error to database if reporting is enabled
-                    if ttnn.CONFIG.report_path is not None:
-                        operation_id = ttnn._ttnn.get_python_operation_id()
-                        error_type = type(e).__name__
-                        error_message = str(e)
-                        stack_trace = traceback.format_exc()
-                        timestamp = datetime.now().isoformat()
-                        ttnn.database.insert_error(
-                            ttnn.CONFIG.report_path,
-                            operation_id,
-                            self.python_fully_qualified_name,
-                            error_type,
-                            error_message,
-                            stack_trace,
-                            timestamp,
-                        )
-                    raise
-                else:
+                    # Success path - only runs if no exception
                     if ttnn.CONFIG.enable_comparison_mode:
                         (
                             output,
@@ -744,50 +702,31 @@ class Operation:
                     if ttnn.CONFIG.enable_logging:
                         for device in devices:
                             ttnn.synchronize_device(device)
-
-                        output, duration = output.output, output.duration
                         logger.debug(f"Finished {self.python_fully_qualified_name:50}")
 
-                        output_tensors = get_all_tensors(output)
-
-                        if ttnn.CONFIG.report_path is not None:
-                            ttnn.database.insert_output_tensors(ttnn.CONFIG.report_path, operation_id, output_tensors)
-                            ttnn.database.insert_tensor_comparison_records(
-                                ttnn.CONFIG.report_path,
-                                "local_tensor_comparison_records",
-                                local_tensor_comparison_records,
-                            )
-                            if local_golden_function_output is not None:
-                                ttnn.database.store_tensors(ttnn.CONFIG.report_path, local_golden_function_output)
-                            ttnn.database.insert_tensor_comparison_records(
-                                ttnn.CONFIG.report_path,
-                                "global_tensor_comparison_records",
-                                global_tensor_comparison_records,
-                            )
-                            if global_golden_function_output is not None:
-                                ttnn.database.store_tensors(ttnn.CONFIG.report_path, global_golden_function_output)
-
-                            if ttnn.CONFIG.enable_graph_report:
-                                ttnn.tracer.visualize(
-                                    ttnn.tracer.GRAPH_STACK[-1],
-                                    file_name=ttnn.CONFIG.report_path
-                                    / ttnn.database.GRAPHS_PATH
-                                    / f"{operation_id}.svg",
-                                )
-                                # ttnn.database.store_graph(operation_id, ttnn.tracer.GRAPH_STACK[-1])
+                    # Comparison mode: persist golden tensor comparison records (Python-specific)
+                    if ttnn.CONFIG.enable_comparison_mode and ttnn.CONFIG.report_path is not None:
+                        ttnn.database.insert_tensor_comparison_records(
+                            ttnn.CONFIG.report_path,
+                            "local_tensor_comparison_records",
+                            local_tensor_comparison_records,
+                        )
+                        if local_golden_function_output is not None:
+                            ttnn.database.store_tensors(ttnn.CONFIG.report_path, local_golden_function_output)
+                        ttnn.database.insert_tensor_comparison_records(
+                            ttnn.CONFIG.report_path,
+                            "global_tensor_comparison_records",
+                            global_tensor_comparison_records,
+                        )
+                        if global_golden_function_output is not None:
+                            ttnn.database.store_tensors(ttnn.CONFIG.report_path, global_golden_function_output)
 
                 finally:
                     captured_graph = ttnn.graph.end_graph_capture()
 
-                    if ttnn.CONFIG.enable_logging and ttnn.CONFIG.report_path is not None:
-                        ttnn.database.insert_devices(ttnn.CONFIG.report_path, devices)
-                        ttnn.database.insert_operation(ttnn.CONFIG.report_path, operation_id, self, duration)
-                        ttnn.database.insert_buffers(ttnn.CONFIG.report_path, operation_id, devices)
-                        if ttnn.CONFIG.enable_detailed_buffer_report:
-                            ttnn.database.insert_buffer_pages(ttnn.CONFIG.report_path, operation_id, devices)
-
-                        if captured_graph is not None:
-                            ttnn.database.insert_captured_graph(ttnn.CONFIG.report_path, operation_id, captured_graph)
+                if ttnn.graph.is_graph_capture_active():
+                    ttnn.graph.store_output_tensor_ids(get_output_tensor_ids(output))
+                    ttnn.graph.store_captured_graph(captured_graph)
 
                 for hook in POST_OPERATION_HOOKS:
                     hook_return_value = hook(self, function_args, function_kwargs, output)
@@ -804,6 +743,9 @@ class Operation:
         self.decorated_function = function
 
     def __call__(self, *function_args, **function_kwargs):
+        tracking = ttnn.graph.is_graph_capture_active()
+        if tracking:
+            ttnn.graph.track_function_start(self.python_fully_qualified_name)
         try:
             if not OPERATION_CALL_STACK:
                 ttnn._ttnn.fetch_and_increment_python_operation_id()
@@ -811,6 +753,8 @@ class Operation:
             output = self.decorated_function(*function_args, **function_kwargs)
         finally:
             OPERATION_CALL_STACK.pop()
+            if tracking:
+                ttnn.graph.track_function_end()
         return output
 
     __doc__ = property(lambda self: self.decorated_function.__doc__)
@@ -1051,27 +995,3 @@ def register_ttl_operation_as_ttnn_operation(python_fully_qualified_name, functi
         is_experimental=True,
     )(function)
     return function
-
-
-def save_cluster_descriptor(dest_path):
-    temp_path = ttnn._ttnn.cluster.serialize_cluster_descriptor()
-
-    if not temp_path:
-        return None
-
-    shutil.copy(temp_path, dest_path)
-
-
-def save_mesh_descriptor(dest_path):
-    if not "TT_METAL_HOME" in os.environ:
-        logger.warning("Not copying mesh descriptor - TT_METAL_HOME not set")
-        return
-
-    mesh_descriptor_paths = glob.glob(f"{os.environ['TT_METAL_HOME']}/generated/fabric/*.yaml")
-
-    if not mesh_descriptor_paths:
-        logger.warning("Mesh descriptor not found")
-        return
-
-    for path in mesh_descriptor_paths:
-        shutil.copy(path, dest_path)

--- a/ttnn/ttnn/graph.py
+++ b/ttnn/ttnn/graph.py
@@ -3,6 +3,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import contextlib
+import json
+import traceback
 from typing import Callable, Union
 from loguru import logger
 import pathlib
@@ -10,8 +12,10 @@ import graphviz
 
 from ttnn._ttnn.graph import (
     RunMode,
-    begin_graph_capture,
+    begin_graph_capture as _cpp_begin_graph_capture,
     end_graph_capture,
+    end_graph_capture_to_file as _cpp_end_graph_capture_to_file,
+    REPORT_VERSION,
     extract_calltrace,
     extract_levelized_graph,
     TensorInfo,
@@ -20,7 +24,250 @@ from ttnn._ttnn.graph import (
     extract_output_info,
     extract_output_tensors,
     extract_resource_usage_per_core,
+    enable_detailed_buffer_tracing,
+    disable_detailed_buffer_tracing,
+    is_detailed_buffer_tracing_enabled,
+    is_graph_capture_active,
+    track_function_start,
+    track_function_end,
 )
+
+from ttnn.graph_report import (
+    import_report,
+    extract_total_duration_from_graph,
+    extract_operation_durations,
+)
+
+
+# ---------------------------------------------------------------------------
+# Python-level I/O tracking
+# ---------------------------------------------------------------------------
+# The C++ graph trace does not capture Python function arguments or return
+# values.  The decorator records them here so that end_graph_capture_to_file
+# can embed them in the JSON report.  The offline importer then uses them
+# to set correct input_tensors / output_tensors associations.
+
+_python_io_data: list = []
+_python_stack_traces_enabled: bool = True
+
+# Glob patterns for frames to strip from stack traces (pathlib-style).
+# Matches ttnn internals (decorators/graph), pytest, pluggy, and the pytest entry script.
+_STACK_TRACE_INTERNAL_PATTERNS = (
+    "**/ttnn/**/decorators.py",
+    "**/ttnn/decorators.py",
+    "**/ttnn/**/graph.py",
+    "**/ttnn/graph.py",
+    "**/_pytest/**",
+    "**/_pytest/config/__init__.py",
+    "**/pluggy/**",
+    "**/bin/pytest",
+)
+
+
+def enable_python_stack_traces():
+    """Enable capturing Python call stacks in graph trace records."""
+    global _python_stack_traces_enabled
+    _python_stack_traces_enabled = True
+
+
+def disable_python_stack_traces():
+    """Disable capturing Python call stacks in graph trace records."""
+    global _python_stack_traces_enabled
+    _python_stack_traces_enabled = False
+
+
+def is_python_stack_trace_enabled() -> bool:
+    """Return whether Python stack trace capture is currently enabled."""
+    return _python_stack_traces_enabled
+
+
+def _capture_python_stack_trace() -> list[str]:
+    """Capture the current Python call stack, filtering out ttnn internals.
+
+    Returns a list of formatted frame strings (file:line in function) with
+    infrastructure frames from decorators.py and graph.py removed.
+    """
+    frames = traceback.extract_stack()
+    result = []
+    for frame in frames:
+        path = pathlib.Path(frame.filename).resolve()
+        # Match against path relative to root so globs like **/_pytest/** work on absolute paths
+        try:
+            path_for_match = path.relative_to(path.anchor)
+        except ValueError:
+            path_for_match = path
+        if any(path_for_match.match(p) for p in _STACK_TRACE_INTERNAL_PATTERNS):
+            continue
+        result.append(f'  File "{frame.filename}", line {frame.lineno}, in {frame.name}\n    {frame.line}\n')
+
+    return result[::-1]
+
+
+def _collect_tensor_ids(value) -> list:
+    """Recursively extract tensor_id ints from ttnn.Tensor and torch.Tensor objects."""
+    import ttnn
+
+    try:
+        import torch
+
+        _tensor_types = (ttnn.Tensor, torch.Tensor)
+    except ImportError:
+        _tensor_types = (ttnn.Tensor,)
+
+    ids: list[int] = []
+    if isinstance(value, _tensor_types):
+        tid = getattr(value, "tensor_id", None)
+        if tid is not None:
+            ids.append(int(tid))
+    elif isinstance(value, (list, tuple)):
+        for item in value:
+            ids.extend(_collect_tensor_ids(item))
+    return ids
+
+
+def begin_graph_capture(run_mode=None):
+    """Wrapper that clears Python I/O state before starting C++ capture."""
+    global _python_io_data
+    if not is_graph_capture_active():
+        _python_io_data = []
+        import ttnn
+
+        if ttnn.CONFIG.enable_fast_runtime_mode:
+            logger.warning(
+                "Graph capture started with enable_fast_runtime_mode=true (fast dispatch). "
+                "FastOperation records arguments, tensor IDs, and output tensor IDs, "
+                "but does not produce per-operation captured sub-graphs. "
+                "For full captured-graph detail, disable fast runtime mode via "
+                "TTNN_CONFIG_OVERRIDES or ttnn.manage_config."
+            )
+    if run_mode is None:
+        return _cpp_begin_graph_capture()
+    return _cpp_begin_graph_capture(run_mode)
+
+
+def end_graph_capture_to_file(report_path):
+    """Wrapper that appends Python I/O data to the JSON report."""
+    result_str = _cpp_end_graph_capture_to_file(report_path)
+    if _python_io_data:
+        _write_python_io_sidecar(report_path)
+    return json.loads(result_str)
+
+
+def _ttnn_tensor_summary(t) -> str:
+    """Build a rich one-line summary of a ttnn.Tensor.
+
+    All properties accessed here are always present on ttnn.Tensor and never
+    trigger device data reads:
+      - shape, dtype, layout, tensor_id: plain attributes on every tensor
+      - memory_config(): stored in TensorSpec, available for host and device tensors
+      - storage_type(), is_allocated(): always safe
+      - device(): returns None for host tensors, MeshDevice* otherwise
+      - tensor_topology(): always returns a TensorTopology reference
+    """
+    info: dict = {}
+
+    info["shape"] = t.shape
+    info["dtype"] = t.dtype
+    info["layout"] = t.layout
+    info["memory_config"] = t.memory_config()
+    info["storage_type"] = t.storage_type()
+    info["tensor_id"] = t.tensor_id
+    info["is_allocated"] = t.is_allocated()
+
+    device = t.device()
+    if device is not None:
+        info["device_id"] = device.id()
+        info["mesh_shape"] = str(device.shape)
+
+    topology = t.tensor_topology()
+    mesh_coords = topology.mesh_coords()
+    if mesh_coords:
+        info["mesh_coords"] = [str(c) for c in mesh_coords]
+    dist_shape = topology.distribution_shape()
+    if dist_shape is not None:
+        info["distribution_shape"] = str(dist_shape)
+    placements = topology.placements()
+    if placements:
+        info["placements"] = [str(p) for p in placements]
+
+    parts = [f"{k}={v}" for k, v in info.items() if v is not None]
+    return f"ttnn.Tensor({', '.join(parts)})"
+
+
+def _safe_arg_str(v):
+    """Stringify a function argument without triggering graph-tracked operations."""
+    import ttnn
+
+    if isinstance(v, ttnn.Tensor):
+        return _ttnn_tensor_summary(v)
+    try:
+        import torch
+
+        if isinstance(v, torch.Tensor):
+            return f"torch.Tensor(shape={list(v.shape)}, dtype={v.dtype})"
+    except ImportError:
+        pass
+    return str(v)
+
+
+def record_python_operation(name, function_args, function_kwargs):
+    """Record a Python-level operation's arguments and I/O tensor ids.
+
+    Called from ``FastOperation.__call__`` and ``runtime_decorator.call_wrapper``
+    to capture the Python-visible arguments (named kwargs + positional args)
+    that the C++ graph trace does not see.
+    """
+    args_dict = {}
+    for k, v in function_kwargs.items():
+        args_dict[k] = _safe_arg_str(v)
+    for idx, v in enumerate(function_args):
+        args_dict[str(idx)] = _safe_arg_str(v)
+
+    input_tensor_ids = _collect_tensor_ids((*function_args, *function_kwargs.values()))
+
+    record = {
+        "name": name,
+        "arguments": args_dict,
+        "input_tensor_ids": input_tensor_ids,
+    }
+
+    if _python_stack_traces_enabled:
+        record["python_stack_trace"] = _capture_python_stack_trace()
+
+    _python_io_data.append(record)
+
+
+def store_output_tensor_ids(output_tensor_ids):
+    """Attach output tensor IDs to the most recent _python_io_data entry.
+
+    Called from both ``FastOperation.__call__`` and ``runtime_decorator.call_wrapper``.
+    """
+    if _python_io_data:
+        _python_io_data[-1]["output_tensor_ids"] = output_tensor_ids
+
+
+def store_captured_graph(captured_graph_json):
+    """Attach a per-op captured graph to the most recent _python_io_data entry.
+
+    Called from ``runtime_decorator.call_wrapper`` (slow dispatch) right after
+    ``end_graph_capture()``.  ``[-1]`` is always the correct entry since
+    ``record_python_operation`` is called first for the same operation.
+    """
+    if _python_io_data:
+        _python_io_data[-1]["captured_graph"] = captured_graph_json
+
+
+def _write_python_io_sidecar(report_path):
+    """Write python_io data as a sidecar JSON file next to the main report.
+
+    Avoids the expensive read-modify-write cycle on potentially huge
+    (hundreds of MB) graph capture files.  The importer picks up the
+    sidecar automatically when it sits alongside the main report.
+    """
+    report_path = pathlib.Path(report_path)
+    sidecar_path = report_path.with_suffix(".python_io.json")
+    with open(sidecar_path, "w") as f:
+        json.dump(_python_io_data, f)
 
 
 class ExitStackWithPop(contextlib.ExitStack):
@@ -54,7 +301,7 @@ def pretty_format(captured_graph):
         elif node["node_type"] == "function_end":
             node_string = format_string.format("Function End:   " + node["params"]["name"])
         elif node["node_type"] == "tensor":
-            node_string = format_string.format("Add Tensor: " + node["params"]["tensor_id"])
+            node_string = format_string.format("Add Tensor: " + str(node["params"]["tensor_id"]))
         elif node["node_type"] == "circular_buffer_allocate":
             node_string = format_string.format("Allocate Circular Buffer")
         elif node["node_type"] == "circular_buffer_deallocate_all":

--- a/ttnn/ttnn/graph_report.py
+++ b/ttnn/ttnn/graph_report.py
@@ -1,0 +1,1524 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Import C++ graph capture reports into ttnn-visualizer SQLite database.
+
+This module completely decouples graph capture (C++) from visualization (SQLite).
+No database operations happen during model execution - everything is offline.
+
+Workflow:
+    1. C++ captures graph to JSON: ttnn::graph::end_graph_capture_to_file("report.json")
+    2. Later, import to SQLite: python -m ttnn.graph_report report.json ./visualizer_db/
+    3. Open ttnn-visualizer pointing to ./visualizer_db/
+
+This replaces the invasive approach where decorators.py inserted into SQLite during execution.
+
+Note: Comparison mode (golden tensor validation) is Python-specific and still writes
+directly to SQLite during execution. The importer is aware of this and uses
+CREATE TABLE IF NOT EXISTS to avoid conflicts with comparison mode data.
+"""
+
+import json
+import math
+import sqlite3
+from pathlib import Path
+from typing import Union
+
+from loguru import logger
+
+SUPPORTED_REPORT_VERSION = 1
+DATABASE_SCHEMA_VERSION = 2
+
+_BUFFER_TYPE_MAP = {"DRAM": 0, "L1": 1, "SYSTEM_MEMORY": 2, "L1_SMALL": 3, "TRACE": 4}
+
+
+def _int_param(params, key):
+    """Return an int from params[key], or None if missing."""
+    v = params.get(key)
+    if v is None:
+        return None
+    return v if isinstance(v, int) else int(v)
+
+
+def _strip_enum_prefix(value):
+    """Strip namespace prefix from enum string: 'BufferType::L1' -> 'L1'."""
+    if value is None:
+        return None
+    s = str(value)
+    return s.split("::")[-1] if "::" in s else s
+
+
+def _tid_int(tid):
+    """Coerce a tensor ID (possibly a string) to int."""
+    return int(tid) if isinstance(tid, str) else tid
+
+
+def create_database_schema(cursor: sqlite3.Cursor) -> None:
+    """Create the full ttnn-visualizer SQLite database schema."""
+
+    # Devices table
+    cursor.execute(
+        """
+        CREATE TABLE IF NOT EXISTS devices (
+            device_id int,
+            num_y_cores int,
+            num_x_cores int,
+            num_y_compute_cores int,
+            num_x_compute_cores int,
+            worker_l1_size int,
+            l1_num_banks int,
+            l1_bank_size int,
+            address_at_first_l1_bank int,
+            address_at_first_l1_cb_buffer int,
+            num_banks_per_storage_core int,
+            num_compute_cores int,
+            num_storage_cores int,
+            total_l1_memory int,
+            total_l1_for_tensors int,
+            total_l1_for_interleaved_buffers int,
+            total_l1_for_sharded_buffers int,
+            cb_limit int
+        )
+    """
+    )
+
+    # Operations table
+    cursor.execute(
+        """
+        CREATE TABLE IF NOT EXISTS operations (
+            operation_id int UNIQUE,
+            name text,
+            duration float
+        )
+    """
+    )
+
+    # Operation arguments
+    cursor.execute(
+        """
+        CREATE TABLE IF NOT EXISTS operation_arguments (
+            operation_id int,
+            name text,
+            value text
+        )
+    """
+    )
+
+    # Tensors table
+    cursor.execute(
+        """
+        CREATE TABLE IF NOT EXISTS tensors (
+            tensor_id int UNIQUE,
+            shape text,
+            dtype text,
+            layout text,
+            memory_config text,
+            device_id int,
+            address int,
+            buffer_type int
+        )
+    """
+    )
+
+    # Device tensors table (for multi-device tensor placement)
+    cursor.execute(
+        """
+        CREATE TABLE IF NOT EXISTS device_tensors (
+            tensor_id int,
+            device_id int,
+            address int
+        )
+    """
+    )
+
+    # Buffers table
+    cursor.execute(
+        """
+        CREATE TABLE IF NOT EXISTS buffers (
+            operation_id int,
+            device_id int,
+            address int,
+            max_size_per_bank int,
+            buffer_type int,
+            buffer_layout int
+        )
+    """
+    )
+
+    # Captured graph (raw JSON)
+    cursor.execute(
+        """
+        CREATE TABLE IF NOT EXISTS captured_graph (
+            operation_id int,
+            captured_graph text
+        )
+    """
+    )
+
+    # Graph nodes (extracted from captured_graph)
+    cursor.execute(
+        """
+        CREATE TABLE IF NOT EXISTS nodes (
+            operation_id int,
+            unique_id int,
+            node_operation_id int,
+            name text
+        )
+    """
+    )
+
+    # Graph edges (extracted from connections in captured_graph)
+    cursor.execute(
+        """
+        CREATE TABLE IF NOT EXISTS edges (
+            operation_id int,
+            source_unique_id int,
+            sink_unique_id int,
+            source_output_index int,
+            sink_input_index int,
+            key int
+        )
+    """
+    )
+
+    # Report metadata
+    cursor.execute(
+        """
+        CREATE TABLE IF NOT EXISTS report_metadata (
+            key text UNIQUE,
+            value text
+        )
+    """
+    )
+
+    # Errors table (populated from C++ error nodes)
+    cursor.execute(
+        """
+        CREATE TABLE IF NOT EXISTS errors (
+            operation_id int,
+            operation_name text,
+            error_type text,
+            error_message text,
+            stack_trace text,
+            timestamp text
+        )
+    """
+    )
+
+    # Stack traces table (when stack trace capture is enabled)
+    cursor.execute(
+        """
+        CREATE TABLE IF NOT EXISTS stack_traces (
+            operation_id int,
+            stack_trace text
+        )
+    """
+    )
+
+    # Input/output tensors
+    cursor.execute(
+        """
+        CREATE TABLE IF NOT EXISTS input_tensors (
+            operation_id int,
+            input_index int,
+            tensor_id int
+        )
+    """
+    )
+
+    cursor.execute(
+        """
+        CREATE TABLE IF NOT EXISTS output_tensors (
+            operation_id int,
+            output_index int,
+            tensor_id int
+        )
+    """
+    )
+
+    # Comparison mode tables (populated by Python runtime, not importer)
+    # These are created here for schema completeness but data comes from
+    # ttnn.database when comparison mode is enabled during execution
+    cursor.execute(
+        """
+        CREATE TABLE IF NOT EXISTS local_tensor_comparison_records (
+            tensor_id int,
+            golden_tensor_id int,
+            matches int,
+            desired_pcc float,
+            actual_pcc float
+        )
+    """
+    )
+
+    cursor.execute(
+        """
+        CREATE TABLE IF NOT EXISTS global_tensor_comparison_records (
+            tensor_id int,
+            golden_tensor_id int,
+            matches int,
+            desired_pcc float,
+            actual_pcc float
+        )
+    """
+    )
+
+    # Buffer pages table (when detailed buffer report is enabled)
+    cursor.execute(
+        """
+        CREATE TABLE IF NOT EXISTS buffer_pages (
+            operation_id int,
+            device_id int,
+            address int,
+            core_y int,
+            core_x int,
+            bank_id int,
+            page_index int,
+            page_address int,
+            page_size int,
+            buffer_type int
+        )
+    """
+    )
+
+
+def save_database_schema_version(cursor: sqlite3.Cursor) -> None:
+    """Save the database schema version to the database."""
+    cursor.execute(
+        "INSERT OR REPLACE INTO report_metadata (key, value) VALUES ('schema_version', ?)", (DATABASE_SCHEMA_VERSION,)
+    )
+
+
+def import_devices(cursor: sqlite3.Cursor, devices: list) -> set:
+    """Import device information using batch insert. Returns set of imported device IDs."""
+    if not devices:
+        return set()
+
+    batch = []
+    imported_ids = set()
+    for device in devices:
+        device_id = device.get("device_id", 0)
+        batch.append(
+            (
+                device_id,
+                device.get("num_y_cores", 0),
+                device.get("num_x_cores", 0),
+                device.get("num_y_compute_cores", 0),
+                device.get("num_x_compute_cores", 0),
+                device.get("worker_l1_size", 0),
+                device.get("l1_num_banks", 0),
+                device.get("l1_bank_size", 0),
+                device.get("address_at_first_l1_bank", 0),
+                device.get("address_at_first_l1_cb_buffer", 0),
+                device.get("num_banks_per_storage_core", 0),
+                device.get("num_compute_cores", 0),
+                device.get("num_storage_cores", 0),
+                device.get("total_l1_memory", 0),
+                device.get("total_l1_for_tensors", 0),
+                device.get("total_l1_for_interleaved_buffers", 0),
+                device.get("total_l1_for_sharded_buffers", 0),
+                device.get("cb_limit", 0),
+            )
+        )
+        imported_ids.add(device_id)
+
+    cursor.executemany(
+        """INSERT OR REPLACE INTO devices VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""", batch
+    )
+    return imported_ids
+
+
+def _compute_max_size_per_bank(size, page_size, buffer_type, layout, num_cores, dev_info):
+    """Compute per-bank buffer allocation from total size and device bank count."""
+    if page_size <= 0 or size <= 0:
+        return size
+
+    total_pages = size // page_size
+
+    if layout == "INTERLEAVED":
+        num_banks = dev_info.get("num_dram_channels", 0) if buffer_type == 0 else dev_info.get("l1_num_banks", 0)
+        if num_banks > 0:
+            pages_per_bank = math.ceil(total_pages / num_banks)
+            return pages_per_bank * page_size
+    elif num_cores > 0:
+        pages_per_core = math.ceil(total_pages / num_cores)
+        return pages_per_core * page_size
+
+    return size
+
+
+def _validate_graph_integrity(
+    operations_batch,
+    tensors_batch,
+    input_tensors_batch,
+    output_tensors_batch,
+    operation_arguments_batch,
+    device_tensors_batch,
+    buffers_batch,
+    devices,
+) -> list:
+    """
+    Validate referential integrity of imported graph data.
+    Returns a list of warning strings for any violations found.
+    """
+    warnings = []
+
+    operation_ids = {row[0] for row in operations_batch}
+    tensor_ids = {_tid_int(row[0]) for row in tensors_batch}
+    device_ids = {dev.get("device_id", 0) for dev in devices} if devices else set()
+
+    # input_tensors.tensor_id must reference a known tensor
+    for op_id, idx, tid in input_tensors_batch:
+        tid_int = _tid_int(tid)
+        if tid_int not in tensor_ids:
+            warnings.append(
+                f"input_tensors references tensor_id={tid} (operation_id={op_id}, input_index={idx}) "
+                f"which does not exist in tensors table. "
+                f"This may indicate node counters are being stored instead of real tensor_ids."
+            )
+
+    # output_tensors.tensor_id must reference a known tensor
+    for op_id, idx, tid in output_tensors_batch:
+        tid_int = _tid_int(tid)
+        if tid_int not in tensor_ids:
+            warnings.append(
+                f"output_tensors references tensor_id={tid} (operation_id={op_id}, output_index={idx}) "
+                f"which does not exist in tensors table."
+            )
+
+    # input/output_tensors.operation_id must reference a known operation
+    for op_id, idx, tid in input_tensors_batch:
+        if op_id not in operation_ids:
+            warnings.append(f"input_tensors references operation_id={op_id} which does not exist in operations table.")
+
+    for op_id, idx, tid in output_tensors_batch:
+        if op_id not in operation_ids:
+            warnings.append(f"output_tensors references operation_id={op_id} which does not exist in operations table.")
+
+    # operation_arguments.operation_id must reference a known operation
+    for op_id, name, val in operation_arguments_batch:
+        if op_id not in operation_ids:
+            warnings.append(
+                f"operation_arguments references operation_id={op_id} which does not exist in operations table."
+            )
+            break  # one warning is enough for args
+
+    # device_tensors.tensor_id must reference a known tensor
+    for tid, dev_id, addr in device_tensors_batch:
+        tid_int = _tid_int(tid)
+        if tid_int not in tensor_ids:
+            warnings.append(f"device_tensors references tensor_id={tid} which does not exist in tensors table.")
+
+    # buffers.device_id should reference a known device (if device info available)
+    if device_ids:
+        bad_device_ids = set()
+        for row in buffers_batch:
+            dev_id = row[1]
+            if dev_id not in device_ids:
+                bad_device_ids.add(dev_id)
+        for dev_id in bad_device_ids:
+            warnings.append(
+                f"buffers references device_id={dev_id} which does not exist in devices table. "
+                f"Known devices: {sorted(device_ids)}"
+            )
+
+    return warnings
+
+
+def import_graph(
+    cursor: sqlite3.Cursor,
+    graph: list,
+    base_operation_id: int = 0,
+    devices: list = None,
+    python_io: list = None,
+    per_operation_buffers: dict = None,
+) -> dict:
+    """
+    Import graph trace into database using batch inserts for performance.
+
+    Extracts and imports:
+    - Operations with durations
+    - Tensors
+    - Buffers
+    - Operation arguments
+    - Input/output tensor relationships
+    - Graph edges
+
+    Device tensors are deduplicated by address. Host tensors are kept only when
+    referenced in input/output relationships. Nested (child) operations are filtered.
+
+    Args:
+        devices: Raw device info dicts from the report, used to compute per-bank buffer sizes.
+        python_io: Optional list of Python-level I/O records from the decorator.
+            Each record has ``name``, ``input_tensor_ids``, and ``output_tensor_ids``.
+            When available, these override the heuristic I/O lifting.
+
+    Returns dict with stats about what was imported.
+    """
+    from collections import defaultdict, deque
+
+    # Collect data for batch inserts
+    nodes_batch = []
+    stack_traces_batch = []
+    operations_batch = []
+    operation_arguments_batch = []
+    input_tensors_batch = []
+    output_tensors_batch = []
+    tensors_batch = []
+    device_tensors_batch = []
+    buffers_batch = []
+    errors_batch = []
+    edges_batch = []
+    captured_graph_batch = []
+    pyid_to_cpp_tensor = {}
+
+    # Build device bank info for per-bank buffer size computation
+    device_bank_info = {}
+    if devices:
+        for dev in devices:
+            dev_id = dev.get("device_id", 0)
+            device_bank_info[dev_id] = {
+                "num_dram_channels": dev.get("num_dram_channels", 0),
+                "l1_num_banks": dev.get("l1_num_banks", 0),
+            }
+
+    # -------------------------------------------------------------------
+    # Build per-name queues from Python I/O records.
+    # Each function_start whose name matches consumes the next record.
+    # -------------------------------------------------------------------
+    python_io_by_name: dict[str, deque] = defaultdict(deque)
+    if python_io:
+        for rec in python_io:
+            python_io_by_name[rec["name"]].append(rec)
+
+    # Track function start nodes to pair with function end
+    function_stack = []
+    operation_counter = 1
+    tensor_ids_seen = set()
+    active_buffers = []
+    current_op_nodes = []
+    op_nesting_depth = 0
+    # Counts only non-filtered, non-nested ops so filtered wrappers are transparent
+    real_function_depth = 0
+
+    # Map C++ graph node counter -> assigned operation_id (for per-op buffer pages)
+    graph_counter_to_op_id = {}
+
+    # Accumulate input/output tensors from nested children to lift to parent.
+    nested_input_tensor_ids = []
+    nested_output_tensor_ids = []
+    nested_output_tensor_nodes = []
+    # Track ALL nested outputs at every depth for internal-output filtering.
+    # Excludes in-place outputs (where the output is also an input of the same op)
+    # so that in-place operations like add_ correctly report their output.
+    all_nested_output_ids = set()
+    # Same as above but INCLUDING in-place outputs. Used for input filtering
+    # to detect workspace tensors reused across calls (e.g., fold allocates
+    # buffers that persist and are re-consumed in subsequent calls).
+    all_scope_output_ids = set()
+    # Track ALL nested inputs at every depth so we can identify intermediate tensors
+    all_nested_input_ids = set()
+    # Arguments lifted from the first C++ child operation for argument-less Python ops
+    first_child_arguments = None
+    # Internal C++ wrapper operations to skip (transparent: children still visible).
+    _FILTERED_OP_PREFIXES = (
+        "ttnn::convert_python_tensor_to_tt_tensor",
+        "tt::tt_metal::detail::convert_tt_tensor_to_framework_tensor",
+        "Tensor::deallocate",
+        "Tensor::to_device",
+        "Tensor::reshape",
+        "tt::tt_metal::to_dtype",
+    )
+
+    # from_torch is only filtered in the leading block (model weight loading).
+    # Once any real compute op is seen, subsequent from_torch ops are kept.
+    seen_compute_op = False
+
+    # -------------------------------------------------------------------
+    # Pre-pass: build lookup tables for tensor nodes.
+    # tensor_first_counter: first graph counter where a tensor_id appears
+    # tensor_address: address of a tensor_id (for device vs host distinction)
+    # -------------------------------------------------------------------
+    tensor_first_counter = {}
+    tensor_address = {}
+    for node in graph:
+        if node.get("node_type") == "tensor":
+            params = node.get("params", {})
+            tid = params.get("tensor_id", "")
+            if tid:
+                itid = int(tid)
+                counter = node.get("counter", 0)
+                if itid not in tensor_first_counter:
+                    tensor_first_counter[itid] = counter
+                addr = params.get("address")
+                if addr and itid not in tensor_address:
+                    tensor_address[itid] = addr
+
+    # Running set of tensor_ids that have been emitted as outputs of tracked
+    # (non-nested) operations.  Used during input lifting to reject "orphaned"
+    # device tensors that were produced inside another operation's scope but
+    # never surfaced as a formal output.
+    emitted_output_tids = set()
+
+    # First pass: collect all data
+    for node in graph:
+        node_type = node.get("node_type", "")
+        counter = node.get("counter", 0)
+        params = node.get("params", {})
+
+        # Collect nodes for per-operation captured_graph subgraphs
+        if op_nesting_depth > 0:
+            current_op_nodes.append(node)
+
+        if node_type == "function_start":
+            name = params.get("name", "unknown")
+            is_prefix_filtered = name.startswith(_FILTERED_OP_PREFIXES)
+            is_leading_from_torch = name == "ttnn.from_torch" and not seen_compute_op
+            is_filtered = is_prefix_filtered or is_leading_from_torch
+            if not is_filtered and real_function_depth == 0 and name != "ttnn.from_torch":
+                seen_compute_op = True
+            is_nested = real_function_depth > 0 or is_filtered
+
+            # Consume matching Python I/O record (keep queues in sync for
+            # both nested and non-nested ops).
+            py_io_record = None
+            if name in python_io_by_name and python_io_by_name[name]:
+                py_io_record = python_io_by_name[name].popleft()
+
+            function_stack.append(
+                {
+                    "counter": counter,
+                    "name": name,
+                    "arguments": node.get("arguments", []),
+                    "input_tensors": node.get("input_tensors", []),
+                    "nested": is_nested,
+                    "python_io": py_io_record,
+                }
+            )
+
+            if not is_nested:
+                real_function_depth += 1
+                op_nesting_depth += 1
+                current_op_nodes = [node]
+                nested_input_tensor_ids = []
+                nested_output_tensor_ids = []
+                nested_output_tensor_nodes = []
+                all_nested_output_ids = set()
+                all_scope_output_ids = set()
+                all_nested_input_ids = set()
+                first_child_arguments = None
+                nodes_batch.append((base_operation_id, counter, operation_counter, name))
+
+            else:
+                op_nesting_depth += 1
+
+        elif node_type == "function_end":
+            name = params.get("name", "unknown")
+
+            start_node = function_stack.pop() if function_stack else None
+            if start_node and start_node.get("nested"):
+                op_nesting_depth -= 1
+
+                # Gather this op's own input tensor IDs so we can detect in-place ops
+                # (where the output tensor is the same as an input tensor)
+                this_op_input_ids = set()
+                for node_counter in start_node.get("input_tensors", []):
+                    if node_counter < len(graph):
+                        tensor_node = graph[node_counter]
+                        if tensor_node.get("node_type") == "tensor":
+                            tid = tensor_node.get("params", {}).get("tensor_id", "")
+                            if tid:
+                                this_op_input_ids.add(int(tid))
+
+                # Track ALL input tensors at every depth for intermediate detection
+                all_nested_input_ids.update(this_op_input_ids)
+
+                # Collect output tensors from ALL depths for internal-output filtering.
+                connections = node.get("connections", [])
+                for conn_id in connections:
+                    if conn_id < len(graph):
+                        conn_node = graph[conn_id]
+                        if conn_node.get("node_type") == "tensor":
+                            tid = conn_node.get("params", {}).get("tensor_id", "")
+                            if tid:
+                                itid = int(tid)
+                                all_scope_output_ids.add(itid)
+                                # For the output-lifting intermediate filter, skip
+                                # in-place outputs (same tensor as input to same op)
+                                if itid not in this_op_input_ids:
+                                    all_nested_output_ids.add(itid)
+
+                # Lift INPUT tensors from ALL depths (not just direct children).
+                # Filters below correctly discard internal intermediates.
+                for tid in this_op_input_ids:
+                    nested_input_tensor_ids.append(tid)
+
+                # Collect OUTPUT tensor candidates from ALL depths.
+                for conn_id in connections:
+                    if conn_id < len(graph):
+                        conn_node = graph[conn_id]
+                        if conn_node.get("node_type") == "tensor":
+                            tid = conn_node.get("params", {}).get("tensor_id", "")
+                            if tid:
+                                nested_output_tensor_ids.append(int(tid))
+                                nested_output_tensor_nodes.append(conn_node)
+
+                continue
+
+            real_function_depth -= 1
+            op_nesting_depth -= 1
+
+            duration_ns = node.get("duration_ns", 0)
+            duration_s = duration_ns / 1e9 if duration_ns else 0
+
+            operation_id = base_operation_id + operation_counter
+            operations_batch.append((operation_id, name, duration_s))
+
+            if start_node:
+                graph_counter_to_op_id[start_node["counter"]] = operation_id
+
+            # ----- Python I/O: if available, use directly -----
+            py_io = start_node.get("python_io") if start_node else None
+
+            if py_io and py_io.get("arguments"):
+                for key, val in py_io["arguments"].items():
+                    operation_arguments_batch.append((operation_id, str(key), str(val)))
+            elif start_node:
+                for idx, arg in enumerate(start_node.get("arguments", [])):
+                    operation_arguments_batch.append((operation_id, f"arg_{idx}", str(arg)))
+
+            if py_io and py_io.get("python_stack_trace"):
+                py_trace = "\n".join(py_io["python_stack_trace"])
+                stack_traces_batch.append((operation_id, py_trace))
+
+            if py_io and py_io.get("input_tensor_ids"):
+                for idx, tid in enumerate(py_io["input_tensor_ids"]):
+                    input_tensors_batch.append((operation_id, idx, int(tid)))
+            elif start_node:
+                direct_inputs = []
+                for node_counter in start_node.get("input_tensors", []):
+                    if node_counter < len(graph):
+                        tensor_node = graph[node_counter]
+                        if tensor_node.get("node_type") == "tensor":
+                            tid = tensor_node.get("params", {}).get("tensor_id", "")
+                            if tid:
+                                direct_inputs.append(int(tid))
+
+                if direct_inputs:
+                    for idx, tid in enumerate(direct_inputs):
+                        input_tensors_batch.append((operation_id, idx, tid))
+                elif nested_input_tensor_ids:
+                    seen = set()
+                    lifted_inputs = []
+                    for tid in nested_input_tensor_ids:
+                        if tid in all_nested_output_ids:
+                            continue
+                        if tid in seen:
+                            continue
+                        seen.add(tid)
+                        lifted_inputs.append(tid)
+                    for idx, tid in enumerate(lifted_inputs):
+                        input_tensors_batch.append((operation_id, idx, tid))
+
+            # ----- Outputs -----
+            output_tensor_nodes = []
+            output_idx = 0
+
+            if py_io and py_io.get("output_tensor_ids"):
+                cpp_output_nodes = []
+                for conn_id in node.get("connections", []):
+                    if conn_id < len(graph):
+                        cn = graph[conn_id]
+                        if cn.get("node_type") == "tensor":
+                            cpp_output_nodes.append(cn)
+                if not cpp_output_nodes and nested_output_tensor_nodes:
+                    cpp_output_nodes = nested_output_tensor_nodes
+
+                for i, tid in enumerate(py_io["output_tensor_ids"]):
+                    output_tensors_batch.append((operation_id, output_idx, int(tid)))
+                    emitted_output_tids.add(int(tid))
+                    output_idx += 1
+                    if i < len(cpp_output_nodes):
+                        pyid_to_cpp_tensor[int(tid)] = cpp_output_nodes[i]
+            else:
+                connections = node.get("connections", [])
+                for conn_id in connections:
+                    if conn_id < len(graph):
+                        conn_node = graph[conn_id]
+                        if conn_node.get("node_type") == "tensor":
+                            tid = conn_node.get("params", {}).get("tensor_id", "")
+                            if tid:
+                                itid = int(tid)
+                                output_tensors_batch.append((operation_id, output_idx, itid))
+                                emitted_output_tids.add(itid)
+                                output_idx += 1
+                                output_tensor_nodes.append(conn_node)
+
+                # If parent had no direct outputs, lift from nested children.
+                if output_idx == 0 and nested_output_tensor_ids:
+                    intermediate_tids = all_nested_output_ids & all_nested_input_ids
+                    seen = set()
+                    kept_nodes = []
+                    for i, tid in enumerate(nested_output_tensor_ids):
+                        if tid in intermediate_tids:
+                            continue
+                        tensor_node = nested_output_tensor_nodes[i]
+                        if tid not in seen:
+                            seen.add(tid)
+                            output_tensors_batch.append((operation_id, output_idx, tid))
+                            emitted_output_tids.add(tid)
+                            output_idx += 1
+                            kept_nodes.append(tensor_node)
+                    output_tensor_nodes = kept_nodes
+
+            # Per-operation captured_graph subgraph
+            if py_io and py_io.get("captured_graph"):
+                subgraph = py_io["captured_graph"]
+            else:
+                capture_start = {
+                    "arguments": [],
+                    "connections": [1],
+                    "counter": 0,
+                    "input_tensors": [],
+                    "node_type": "capture_start",
+                    "params": {},
+                    "stacking_level": 0,
+                }
+                capture_end = {
+                    "arguments": [],
+                    "connections": [],
+                    "counter": 0,
+                    "input_tensors": [],
+                    "node_type": "capture_end",
+                    "params": {},
+                    "stacking_level": 0,
+                }
+                raw_subgraph = [capture_start] + current_op_nodes + output_tensor_nodes + [capture_end]
+                old_to_new = {}
+                for idx, nd in enumerate(raw_subgraph):
+                    old_to_new[nd.get("counter", 0)] = idx
+                subgraph = []
+                for idx, nd in enumerate(raw_subgraph):
+                    nd_copy = dict(nd)
+                    nd_copy["counter"] = idx
+                    if "connections" in nd_copy:
+                        nd_copy["connections"] = [old_to_new.get(c, c) for c in nd_copy["connections"]]
+                    if "input_tensors" in nd_copy:
+                        nd_copy["input_tensors"] = [old_to_new.get(c, c) for c in nd_copy["input_tensors"]]
+                    subgraph.append(nd_copy)
+            captured_graph_batch.append((operation_id, json.dumps(subgraph)))
+            current_op_nodes = []
+
+            # Use real buffer snapshot from get_buffers() when available;
+            # fall back to reconstructed active_buffers for older reports.
+            start_counter = start_node["counter"] if start_node else None
+            real_bufs = (
+                per_operation_buffers.get(str(start_counter))
+                if per_operation_buffers and start_counter is not None
+                else None
+            )
+            if real_bufs is not None:
+                for buf in real_bufs:
+                    buffers_batch.append(
+                        (
+                            operation_id,
+                            buf.get("device_id", 0),
+                            buf.get("address", 0),
+                            buf.get("max_size_per_bank", 0),
+                            buf.get("buffer_type", 0),
+                            buf.get("buffer_layout", 0),
+                        )
+                    )
+            else:
+                for buf in active_buffers:
+                    buffers_batch.append((operation_id, *buf))
+
+            operation_counter += 1
+
+        elif node_type == "tensor":
+            tensor_id = params.get("tensor_id", "")
+            if tensor_id and tensor_id not in tensor_ids_seen:
+                tensor_ids_seen.add(tensor_id)
+                shape = params.get("shape", "")
+                dtype = params.get("dtype")
+                layout = params.get("layout")
+                memory_config = params.get("memory_config")
+
+                if dtype and "::" in dtype:
+                    dtype = dtype.replace("::", ".")
+                if layout and "::" in layout:
+                    layout = layout.replace("::", ".")
+                device_id = _int_param(params, "device_id")
+                address = _int_param(params, "address")
+                buffer_type = _int_param(params, "buffer_type_value")
+                if buffer_type is None:
+                    bt_name = _strip_enum_prefix(params.get("buffer_type"))
+                    buffer_type = _BUFFER_TYPE_MAP.get(bt_name, 0) if bt_name else 0
+                tensors_batch.append(
+                    (
+                        tensor_id,
+                        shape,
+                        dtype,
+                        layout,
+                        memory_config,
+                        device_id,
+                        address,
+                        buffer_type,
+                    )
+                )
+
+                device_tensors_str = params.get("device_tensors")
+                if device_tensors_str:
+                    device_tensors = json.loads(device_tensors_str)
+                    for dt in device_tensors:
+                        device_tensors_batch.append(
+                            (tensor_id, dt.get("mesh_device_id", dt.get("device_id")), dt.get("address"))
+                        )
+
+        elif node_type == "buffer_allocate":
+            device_id = _int_param(params, "device_id") or 0
+            address = _int_param(params, "address") or 0
+            size = _int_param(params, "size") or 0
+            page_size = _int_param(params, "page_size") or 0
+            num_cores = _int_param(params, "num_cores") or 0
+            buffer_type = _int_param(params, "buffer_type_value")
+            if buffer_type is None:
+                bt_name = _strip_enum_prefix(params.get("exact_buffer_type") or params.get("type", "DRAM"))
+                buffer_type = _BUFFER_TYPE_MAP.get(bt_name, 0)
+            layout = params.get("layout", "INTERLEAVED")
+            layout_int = {"INTERLEAVED": 0, "HEIGHT_SHARDED": 1, "WIDTH_SHARDED": 2, "BLOCK_SHARDED": 3}.get(layout, 0)
+
+            # Prefer pre-computed value from C++ (uses real allocator bank counts);
+            # fall back to Python approximation for older traces without it.
+            if "max_size_per_bank" in params:
+                max_size_per_bank = int(params["max_size_per_bank"])
+            else:
+                max_size_per_bank = _compute_max_size_per_bank(
+                    size,
+                    page_size,
+                    buffer_type,
+                    layout,
+                    num_cores,
+                    device_bank_info.get(device_id, {}),
+                )
+            active_buffers.append((device_id, address, max_size_per_bank, buffer_type, layout_int))
+
+        elif node_type == "buffer_deallocate":
+            # Resolve address: prefer direct param, fall back to connected buffer_allocate
+            dealloc_address = None
+            if "address" in params:
+                dealloc_address = int(params["address"])
+            else:
+                for conn_id in node.get("connections", []):
+                    if conn_id < len(graph) and graph[conn_id].get("node_type") == "buffer_allocate":
+                        dealloc_address = int(graph[conn_id].get("params", {}).get("address", 0))
+                        break
+            if dealloc_address is not None:
+                active_buffers = [b for b in active_buffers if b[1] != dealloc_address]
+
+            # Find the tensor that owns the deallocated address
+            dealloc_tensor_id = None
+            if dealloc_address is not None:
+                for t in tensors_batch:
+                    tid, _, _, _, _, _, addr, _ = t
+                    if addr == dealloc_address:
+                        dealloc_tensor_id = _tid_int(tid)
+                        break
+
+            if not function_stack:
+                # Synthesize a deallocate operation if not inside a function_start/end pair
+                operation_id = base_operation_id + operation_counter
+                op_name = "ttnn::deallocate"
+                operations_batch.append((operation_id, op_name, 0))
+                nodes_batch.append((base_operation_id, counter, operation_counter, op_name))
+
+                if dealloc_tensor_id is not None:
+                    input_tensors_batch.append((operation_id, 0, dealloc_tensor_id))
+
+                for buf in active_buffers:
+                    buffers_batch.append((operation_id, *buf))
+
+                capture_start = {
+                    "arguments": [],
+                    "connections": [1],
+                    "counter": 0,
+                    "input_tensors": [],
+                    "node_type": "capture_start",
+                    "params": {},
+                    "stacking_level": 0,
+                }
+                capture_end = {
+                    "arguments": [],
+                    "connections": [],
+                    "counter": 0,
+                    "input_tensors": [],
+                    "node_type": "capture_end",
+                    "params": {},
+                    "stacking_level": 0,
+                }
+                captured_graph_batch.append((operation_id, json.dumps([capture_start, node, capture_end])))
+
+                operation_counter += 1
+            else:
+                # Inside a function pair (e.g., Python-level ttnn.deallocate) -
+                # lift the deallocated tensor as a nested input for the parent
+                if dealloc_tensor_id is not None:
+                    nested_input_tensor_ids.append(dealloc_tensor_id)
+
+        elif node_type == "error":
+            error_type = params.get("error_type", "unknown")
+            error_message = params.get("error_message", "")
+            error_operation = params.get("error_operation", "")
+            errors_batch.append((base_operation_id, error_operation, error_type, error_message, "", ""))
+
+    # Detect orphan function_start nodes (started but never ended = operation error).
+    already_errored = {e[1] for e in errors_batch}
+    for orphan in function_stack:
+        if not orphan.get("nested"):
+            op_name = orphan.get("name", "unknown")
+            if op_name not in already_errored:
+                errors_batch.append(
+                    (
+                        base_operation_id,
+                        op_name,
+                        "incomplete_operation",
+                        f"Operation '{op_name}' started but never completed (likely crashed)",
+                        "",
+                        "",
+                    )
+                )
+
+    # Keep host tensors only when referenced in I/O; keep all device tensors as-is.
+    referenced_tids = set()
+    for _, _, tid in input_tensors_batch:
+        referenced_tids.add(_tid_int(tid))
+    for _, _, tid in output_tensors_batch:
+        referenced_tids.add(_tid_int(tid))
+
+    filtered_tensors = []
+    for t in tensors_batch:
+        tid, shape, dtype, layout, mem_cfg, dev_id, addr, bt = t
+        tid_int = _tid_int(tid)
+        if dev_id is None:
+            if tid_int in referenced_tids:
+                filtered_tensors.append(t)
+        else:
+            filtered_tensors.append(t)
+    tensors_batch = filtered_tensors
+
+    # Ensure py_io tensor IDs that don't have C++ graph entries get created.
+    # When enable_logging=True, Python's set_output_tensor_id_decorator assigns
+    # new tensor IDs after C++ records the output.  These Python-level IDs appear
+    # in py_io output_tensor_ids but have no C++ tensor node.  Create tensor
+    # entries for them by copying from the nearest tensor at the same address.
+    existing_tids = {_tid_int(t[0]) for t in tensors_batch}
+    io_tids = set()
+    for _, _, tid in input_tensors_batch:
+        io_tids.add(_tid_int(tid))
+    for _, _, tid in output_tensors_batch:
+        io_tids.add(_tid_int(tid))
+    missing_tids = io_tids - existing_tids
+    if missing_tids:
+        addr_to_tensor = {}
+        for t in tensors_batch:
+            tid_val, shape, dtype, layout, mem_cfg, dev_id, addr, bt = t
+            if addr is not None and addr not in addr_to_tensor:
+                addr_to_tensor[addr] = t
+        for mtid in missing_tids:
+            addr = tensor_address.get(mtid)
+            if addr is not None and addr in addr_to_tensor:
+                _, shape, dtype, layout, mem_cfg, dev_id, _, bt = addr_to_tensor[addr]
+                tensors_batch.append((mtid, shape, dtype, layout, mem_cfg, dev_id, addr, bt))
+            elif mtid in pyid_to_cpp_tensor:
+                cpp_node = pyid_to_cpp_tensor[mtid]
+                p = cpp_node.get("params", {})
+                btv = _int_param(p, "buffer_type_value")
+                if btv is None:
+                    bt_name = _strip_enum_prefix(p.get("buffer_type"))
+                    btv = _BUFFER_TYPE_MAP.get(bt_name, 0) if bt_name else 0
+                tensors_batch.append(
+                    (
+                        mtid,
+                        str(p.get("shape", "")),
+                        str(p.get("dtype", "")),
+                        str(p.get("layout", "")),
+                        str(p.get("memory_config", "")),
+                        _int_param(p, "device_id"),
+                        _int_param(p, "address"),
+                        btv,
+                    )
+                )
+
+    kept_tensor_ids = {_tid_int(t[0]) for t in tensors_batch}
+
+    # Deduplicate per operation (same op + same tensor = one entry)
+    seen_input = set()
+    deduped_inputs = []
+    input_idx_counter = {}
+    for op_id, idx, tid in input_tensors_batch:
+        tid_int = _tid_int(tid)
+        if tid_int in kept_tensor_ids:
+            key = (op_id, tid_int)
+            if key not in seen_input:
+                seen_input.add(key)
+                new_idx = input_idx_counter.get(op_id, 0)
+                input_idx_counter[op_id] = new_idx + 1
+                deduped_inputs.append((op_id, new_idx, tid_int))
+    input_tensors_batch = deduped_inputs
+
+    seen_output = set()
+    deduped_outputs = []
+    output_idx_counter = {}
+    for op_id, idx, tid in output_tensors_batch:
+        tid_int = _tid_int(tid)
+        if tid_int in kept_tensor_ids:
+            key = (op_id, tid_int)
+            if key not in seen_output:
+                seen_output.add(key)
+                new_idx = output_idx_counter.get(op_id, 0)
+                output_idx_counter[op_id] = new_idx + 1
+                deduped_outputs.append((op_id, new_idx, tid_int))
+    output_tensors_batch = deduped_outputs
+    device_tensors_batch = [
+        (_tid_int(tid), dev_id, addr) for tid, dev_id, addr in device_tensors_batch if _tid_int(tid) in kept_tensor_ids
+    ]
+    seen_dt = set()
+    filtered_dt = []
+    for dt in device_tensors_batch:
+        key = (dt[0], dt[2])
+        if key not in seen_dt:
+            seen_dt.add(key)
+            filtered_dt.append(dt)
+    device_tensors_batch = filtered_dt
+
+    # Batch inserts
+    if captured_graph_batch:
+        cursor.executemany("""INSERT INTO captured_graph VALUES (?, ?)""", captured_graph_batch)
+        for op_id, graph_json_str in captured_graph_batch:
+            subgraph = json.loads(graph_json_str)
+            for snode in subgraph:
+                source_id = snode.get("counter", 0)
+                for conn_idx, target_id in enumerate(snode.get("connections", [])):
+                    edges_batch.append((op_id, source_id, target_id, conn_idx, 0, conn_idx))
+    if nodes_batch:
+        cursor.executemany("""INSERT INTO nodes VALUES (?, ?, ?, ?)""", nodes_batch)
+    if edges_batch:
+        cursor.executemany("""INSERT INTO edges VALUES (?, ?, ?, ?, ?, ?)""", edges_batch)
+    if stack_traces_batch:
+        cursor.executemany("""INSERT INTO stack_traces VALUES (?, ?)""", stack_traces_batch)
+    if operations_batch:
+        cursor.executemany("""INSERT OR REPLACE INTO operations VALUES (?, ?, ?)""", operations_batch)
+    if operation_arguments_batch:
+        cursor.executemany("""INSERT INTO operation_arguments VALUES (?, ?, ?)""", operation_arguments_batch)
+    if input_tensors_batch:
+        cursor.executemany("""INSERT INTO input_tensors VALUES (?, ?, ?)""", input_tensors_batch)
+    if output_tensors_batch:
+        cursor.executemany("""INSERT INTO output_tensors VALUES (?, ?, ?)""", output_tensors_batch)
+    if tensors_batch:
+        cursor.executemany("""INSERT OR IGNORE INTO tensors VALUES (?, ?, ?, ?, ?, ?, ?, ?)""", tensors_batch)
+    if device_tensors_batch:
+        cursor.executemany("""INSERT INTO device_tensors VALUES (?, ?, ?)""", device_tensors_batch)
+    if buffers_batch:
+        cursor.executemany("""INSERT INTO buffers VALUES (?, ?, ?, ?, ?, ?)""", buffers_batch)
+    if errors_batch:
+        cursor.executemany("""INSERT INTO errors VALUES (?, ?, ?, ?, ?, ?)""", errors_batch)
+
+    # Validate referential integrity
+    warnings = _validate_graph_integrity(
+        operations_batch,
+        tensors_batch,
+        input_tensors_batch,
+        output_tensors_batch,
+        operation_arguments_batch,
+        device_tensors_batch,
+        buffers_batch,
+        devices,
+    )
+    for w in warnings:
+        logger.warning(f"[graph import] {w}")
+
+    return {
+        "operations": len(operations_batch),
+        "tensors": len(tensors_batch),
+        "device_tensors": len(device_tensors_batch),
+        "buffers": len(buffers_batch),
+        "nodes": len(nodes_batch),
+        "edges": len(edges_batch),
+        "stack_traces": len(stack_traces_batch),
+        "errors": len(errors_batch),
+        "warnings": warnings,
+        "graph_counter_to_op_id": graph_counter_to_op_id,
+    }
+
+
+def import_metadata(cursor: sqlite3.Cursor, metadata: dict) -> None:
+    """Import report metadata using batch insert."""
+    if not metadata:
+        return
+    batch = [(key, str(value)) for key, value in metadata.items()]
+    cursor.executemany("""INSERT OR REPLACE INTO report_metadata VALUES (?, ?)""", batch)
+
+
+def extract_total_duration_from_graph(graph: list) -> float:
+    """Extract total capture duration in seconds."""
+    for node in reversed(graph):
+        if node.get("node_type") == "capture_end":
+            return node.get("duration_ns", 0) / 1e9
+    return 0.0
+
+
+def extract_operation_durations(graph: list) -> dict:
+    """Extract per-operation durations as {name: seconds}."""
+    durations = {}
+    for node in graph:
+        if node.get("node_type") == "function_end":
+            name = node.get("params", {}).get("name", "unknown")
+            durations[name] = node.get("duration_ns", 0) / 1e9
+    return durations
+
+
+def generate_svg(graph: list, output_path: Union[str, Path]) -> Path:
+    """
+    Generate SVG visualization from graph data.
+
+    Args:
+        graph: Graph data (list of nodes from JSON report)
+        output_path: Path for output SVG file
+
+    Returns:
+        Path to generated SVG file
+    """
+    # Import here to avoid circular dependency and allow CLI usage without ttnn
+    try:
+        import ttnn.graph
+
+        output_path = Path(output_path)
+        ttnn.graph.visualize(graph, file_name=output_path)
+        return output_path
+    except ImportError:
+        logger.warning("ttnn.graph not available, skipping SVG generation")
+        return None
+
+
+def import_report(
+    report_path: Union[str, Path],
+    output_dir: Union[str, Path],
+    db_name: str = "db.sqlite",
+    generate_svgs: bool = False,
+) -> Path:
+    """
+    Import a C++ graph capture report into ttnn-visualizer SQLite database.
+
+    This is the main entry point for offline import.
+
+    Args:
+        report_path: Path to JSON report file (or directory containing multiple reports)
+        output_dir: Directory to create SQLite database in
+        db_name: Database filename
+        generate_svgs: If True, generate SVG visualizations for each report
+
+    Returns:
+        Path to created database
+    """
+    report_path = Path(report_path)
+    output_dir = Path(output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    db_path = output_dir / db_name
+
+    # Create graphs directory if generating SVGs
+    graphs_dir = None
+    if generate_svgs:
+        graphs_dir = output_dir / "graphs"
+        graphs_dir.mkdir(parents=True, exist_ok=True)
+
+    conn = sqlite3.connect(db_path)
+    cursor = conn.cursor()
+
+    try:
+        create_database_schema(cursor)
+        save_database_schema_version(cursor)
+
+        # Handle single file or directory of reports
+        if report_path.is_file():
+            report_files = [report_path]
+        else:
+            report_files = list(report_path.glob("*.json"))
+
+        total_stats = {
+            "files": 0,
+            "operations": 0,
+            "tensors": 0,
+            "buffers": 0,
+            "edges": 0,
+            "devices": 0,
+            "errors": 0,
+            "stack_traces": 0,
+            "svgs": 0,
+        }
+
+        for idx, rpath in enumerate(sorted(report_files)):
+            with open(rpath, "r") as f:
+                report = json.load(f)
+
+            version = report.get("version", 0)
+            if version != SUPPORTED_REPORT_VERSION:
+                logger.warning(f"{rpath} has version {version}, expected {SUPPORTED_REPORT_VERSION}")
+                continue
+
+            devices_data = report.get("devices", [])
+            # Normalize device IDs to 0-based sequential indices so the visualizer
+            # works regardless of the physical chip IDs the C++ trace emits.
+            raw_dev_ids = sorted({d.get("device_id", 0) for d in devices_data})
+            dev_id_remap = {raw: remap_idx for remap_idx, raw in enumerate(raw_dev_ids)}
+            if dev_id_remap:
+                for d in devices_data:
+                    d["device_id"] = dev_id_remap.get(d.get("device_id", 0), 0)
+                for node in report.get("graph", []):
+                    p = node.get("params") or {}
+                    if "device_id" in p:
+                        old = int(p["device_id"]) if isinstance(p["device_id"], str) else p["device_id"]
+                        p["device_id"] = dev_id_remap.get(old, old)
+                    if "device_tensors" in p:
+                        dt_list = json.loads(p["device_tensors"])
+                        for dt in dt_list:
+                            for _dk in ("device_id", "mesh_device_id"):
+                                if _dk in dt:
+                                    dt[_dk] = dev_id_remap.get(dt[_dk], dt[_dk])
+                        p["device_tensors"] = json.dumps(dt_list)
+                for bufs in report.get("per_operation_buffers", {}).values():
+                    for buf in bufs:
+                        if "device_id" in buf:
+                            buf["device_id"] = dev_id_remap.get(buf["device_id"], buf["device_id"])
+                for pages in report.get("buffer_pages_by_address", {}).values():
+                    for page in pages:
+                        if "device_id" in page:
+                            page["device_id"] = dev_id_remap.get(page["device_id"], page["device_id"])
+
+            if devices_data:
+                device_ids = import_devices(cursor, devices_data)
+                total_stats["devices"] += len(device_ids)
+
+            if "graph" in report:
+                python_io = report.get("python_io")
+                if python_io is None:
+                    sidecar_path = rpath.with_suffix(".python_io.json")
+                    if sidecar_path.exists():
+                        with open(sidecar_path, "r") as pio:
+                            python_io = json.load(pio)
+
+                stats = import_graph(
+                    cursor,
+                    report["graph"],
+                    base_operation_id=idx * 10000,
+                    devices=devices_data,
+                    python_io=python_io,
+                    per_operation_buffers=report.get("per_operation_buffers"),
+                )
+                total_stats["operations"] += stats["operations"]
+                total_stats["tensors"] += stats["tensors"]
+                total_stats["device_tensors"] = total_stats.get("device_tensors", 0) + stats.get("device_tensors", 0)
+                total_stats["buffers"] += stats["buffers"]
+                total_stats["edges"] += stats.get("edges", 0)
+                total_stats["errors"] += stats.get("errors", 0)
+                total_stats["stack_traces"] += stats.get("stack_traces", 0)
+
+                # Generate SVG if requested
+                if generate_svgs and graphs_dir:
+                    svg_path = graphs_dir / f"{rpath.stem}.svg"
+                    if generate_svg(report["graph"], svg_path):
+                        total_stats["svgs"] += 1
+
+            if "metadata" in report:
+                import_metadata(cursor, report["metadata"])
+
+            # Save cluster descriptor YAML if present
+            if "cluster_descriptor" in report and report["cluster_descriptor"]:
+                cluster_path = output_dir / "cluster_descriptor.yaml"
+                if not cluster_path.exists():  # Only write once
+                    with open(cluster_path, "w") as f:
+                        f.write(report["cluster_descriptor"])
+                    total_stats["cluster_descriptor"] = True
+
+            # Save mesh coordinate mapping if present (matches old save_mesh_descriptor behavior)
+            if "mesh_coordinate_mapping" in report and report["mesh_coordinate_mapping"]:
+                mesh_path = output_dir / "physical_chip_mesh_coordinate_mapping_1_of_1.yaml"
+                if not mesh_path.exists():  # Only write once
+                    with open(mesh_path, "w") as f:
+                        f.write(report["mesh_coordinate_mapping"])
+                    total_stats["mesh_coordinate_mapping"] = True
+
+            # Import buffer pages.
+            # Preferred: buffer_pages_by_address (compact, ~0.5 MB) combined with
+            # per_operation_buffers to reconstruct per-operation buffer_pages.
+            # Fallback: flat buffer_pages snapshot from end of capture.
+            graph_counter_to_op_id = stats.get("graph_counter_to_op_id", {}) if "graph" in report else {}
+            bp_by_addr = report.get("buffer_pages_by_address")
+            per_op_bufs = report.get("per_operation_buffers")
+
+            if bp_by_addr and per_op_bufs:
+
+                def _parse_page(p):
+                    return (
+                        p.get("device_id", 0),
+                        p.get("address", 0),
+                        p.get("core_y", 0),
+                        p.get("core_x", 0),
+                        p.get("bank_id", 0),
+                        p.get("page_index", 0),
+                        p.get("page_address", 0),
+                        p.get("page_size", 0),
+                        p.get("buffer_type", 0),
+                    )
+
+                # Build a timeline of page snapshots per address.
+                # Each address may have multiple snapshots from re-allocations.
+                # Format: {addr: [(alloc_counter, [page_tuples]), ...]} sorted by counter.
+                pages_timeline = {}
+                for addr_str, snapshots in bp_by_addr.items():
+                    addr_int = int(addr_str)
+                    if (
+                        isinstance(snapshots, list)
+                        and snapshots
+                        and isinstance(snapshots[0], dict)
+                        and "alloc_counter" in snapshots[0]
+                    ):
+                        timeline = sorted(
+                            [(s["alloc_counter"], [_parse_page(p) for p in s["pages"]]) for s in snapshots],
+                            key=lambda x: x[0],
+                        )
+                    else:
+                        timeline = [(0, [_parse_page(p) for p in snapshots])]
+                    pages_timeline[addr_int] = timeline
+
+                import bisect
+
+                def _get_pages_for_addr(addr, op_counter):
+                    """Pick the latest snapshot whose alloc_counter <= op_counter."""
+                    timeline = pages_timeline.get(addr)
+                    if not timeline:
+                        return []
+                    counters = [t[0] for t in timeline]
+                    idx = bisect.bisect_right(counters, op_counter) - 1
+                    if idx < 0:
+                        return timeline[0][1]
+                    return timeline[idx][1]
+
+                # Build function_start → function_end counter mapping.
+                # per_op_bufs keys are function_start counters but buffers
+                # are allocated DURING the operation, so we need the end
+                # counter to pick the correct page snapshot.
+                start_to_end = {}
+                if "graph" in report:
+                    end_stack = []
+                    for node in report["graph"]:
+                        nt = node.get("node_type", "")
+                        c = node.get("counter", 0)
+                        if nt == "function_start":
+                            end_stack.append(c)
+                        elif nt == "function_end" and end_stack:
+                            start_c = end_stack.pop()
+                            start_to_end[start_c] = c
+
+                buffer_pages_batch = []
+                for graph_counter_str, bufs in per_op_bufs.items():
+                    graph_counter = int(graph_counter_str)
+                    op_id = graph_counter_to_op_id.get(graph_counter)
+                    if op_id is None:
+                        continue
+                    end_counter = start_to_end.get(graph_counter, graph_counter)
+                    for buf in bufs:
+                        addr = buf.get("address", 0)
+                        for page_tuple in _get_pages_for_addr(addr, end_counter):
+                            buffer_pages_batch.append((op_id, *page_tuple))
+                if buffer_pages_batch:
+                    cursor.executemany(
+                        """INSERT INTO buffer_pages VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""", buffer_pages_batch
+                    )
+                    total_stats["buffer_pages"] = total_stats.get("buffer_pages", 0) + len(buffer_pages_batch)
+            elif "buffer_pages" in report and report["buffer_pages"]:
+                base_op_id = idx * 10000
+                buffer_pages_batch = [
+                    (
+                        base_op_id,
+                        page.get("device_id", 0),
+                        page.get("address", 0),
+                        page.get("core_y", 0),
+                        page.get("core_x", 0),
+                        page.get("bank_id", 0),
+                        page.get("page_index", 0),
+                        page.get("page_address", 0),
+                        page.get("page_size", 0),
+                        page.get("buffer_type", 0),
+                    )
+                    for page in report["buffer_pages"]
+                ]
+                cursor.executemany(
+                    """INSERT INTO buffer_pages VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""", buffer_pages_batch
+                )
+                total_stats["buffer_pages"] = total_stats.get("buffer_pages", 0) + len(buffer_pages_batch)
+
+            total_stats["files"] += 1
+
+        conn.commit()
+        summary = [f"Imported {total_stats['files']} report(s) into {db_path}"]
+        summary.append(f"  - {total_stats['devices']} devices")
+        summary.append(f"  - {total_stats['operations']} operations")
+        summary.append(f"  - {total_stats['tensors']} tensors")
+        if total_stats.get("device_tensors", 0) > 0:
+            summary.append(f"  - {total_stats['device_tensors']} device tensor entries")
+        summary.append(f"  - {total_stats['buffers']} buffers")
+        summary.append(f"  - {total_stats['edges']} edges")
+        if total_stats["errors"] > 0:
+            summary.append(f"  - {total_stats['errors']} errors captured")
+        if total_stats["stack_traces"] > 0:
+            summary.append(f"  - {total_stats['stack_traces']} stack traces captured")
+        if total_stats.get("buffer_pages", 0) > 0:
+            summary.append(f"  - {total_stats['buffer_pages']} buffer pages")
+        if total_stats.get("cluster_descriptor"):
+            summary.append("  - cluster_descriptor.yaml saved")
+        if total_stats.get("mesh_coordinate_mapping"):
+            summary.append("  - physical_chip_mesh_coordinate_mapping_1_of_1.yaml saved")
+        if generate_svgs:
+            summary.append(f"  - {total_stats['svgs']} SVG visualizations in {graphs_dir}/")
+        logger.info("\n".join(summary))
+
+    finally:
+        conn.close()
+
+    return db_path
+
+
+def main():
+    """CLI for importing reports."""
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description="Import C++ graph capture reports into ttnn-visualizer database",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+    # Import single report
+    python -m ttnn.graph_report report.json ./visualizer_db/
+
+    # Import all reports from a directory
+    python -m ttnn.graph_report ./reports/ ./visualizer_db/
+
+    # Import with SVG visualization generation
+    python -m ttnn.graph_report report.json ./visualizer_db/ --svg
+
+    # Then open ttnn-visualizer pointing to ./visualizer_db/
+        """,
+    )
+    parser.add_argument("report_path", help="JSON report file or directory containing reports")
+    parser.add_argument("output_dir", help="Directory to create SQLite database in")
+    parser.add_argument("--db-name", default="db.sqlite", help="Database filename")
+    parser.add_argument("--svg", action="store_true", help="Generate SVG visualizations")
+
+    args = parser.parse_args()
+    import_report(args.report_path, args.output_dir, args.db_name, generate_svgs=args.svg)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION

### Ticket
Link to Github Issue

### Problem description
The graph tracing infrastructure (ttnn::graph) captured low-level C++ data but lacked the Python-level context needed for practical debugging and visualization. Specifically:
Operation arguments visible in Python (kwargs, tensor metadata) were not recorded — the C++ trace only saw serialized C++ representations.
Input/output tensor relationships were heuristically inferred from the C++ graph structure, often incorrectly for operations like conv2d that have complex internal subgraphs.
Stack traces were raw C++ addresses (hex pointers), useless without debug symbols. There was no way to see which Python source file and line invoked an operation.
The offline importer (graph_report.py) did not exist — there was no path from a JSON graph capture to the SQLite database format that ttnn-visualizer expects.
Buffer page data, per-operation captured subgraphs, and device metadata were either missing or incomplete in the generated databases.

### What's changed
Python-to-SQLite importer (graph_report.py)

- Imports JSON graph captures into the ttnn-visualizer SQLite schema (operations, tensors, buffers, edges, stack traces, captured graphs, buffer pages, device info).
- Handles nested operation filtering, input/output tensor lifting, from_torch filtering, deallocate synthesis, and per-bank buffer size computation.
- Supports versioned buffer pages with re-allocation timelines.
- Runnable as python -m ttnn.graph_report <json> <output_dir>.
- 

Python I/O recording in decorators

- Both FastOperation and Operation decorators now call record_python_operation() during graph capture, recording named arguments (with rich ttnn.Tensor summaries including shape, dtype, layout, memory_config, device_id, mesh coordinates, sharding, allocation status), input tensor IDs, and output tensor IDs.
- The importer uses these python_io records for correct argument display and tensor relationship resolution, falling back to C++ data when unavailable.

Python stack trace capture

- enable_python_stack_traces() / disable_python_stack_traces() API (enabled by default).
- Each Python-level operation records a filtered Python call stack (ttnn decorator internals stripped) at invocation time.
- The importer stores Python stack traces in the stack_traces table for Python ops, replacing the raw C++ hex addresses. C++ internal ops in captured_graph keep their C++ stack traces untouched.

C++ graph processor improvements

- New graph_consts.hpp with centralized node type and parameter key constants.
- GraphProcessor now emits per-operation buffer snapshots (per_operation_buffers), versioned buffer page data (buffer_pages_by_address), and device metadata.
- end_graph_capture_to_file() writes complete reports with all data in a single call.
- Python function names (e.g. ttnn.add instead of ttnn::add) are emitted during fast dispatch via track_function_start/track_function_end.


Testing

- New test_graph_report.py with 113 tests: unit tests for every importer behavior (tensor dedup, I/O lifting, filtered ops, buffer pages, stack traces, Python I/O matching, captured graph extraction), plus device integration tests and a full ResNet-50 E2E structural validation.
- Updated C++ gtests for the new graph processor behavior.
- conftest.py fixture for automatic graph report generation during test runs.

Documentation

- Complete rewrite of graph-tracing.md: quick start, core concepts, database schema reference, all advanced features documented with examples, full test matrix.


### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=dgomeztt/visualizer)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:dgomeztt/visualizer)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=dgomeztt/visualizer)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:dgomeztt/visualizer)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=dgomeztt/visualizer)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:dgomeztt/visualizer)
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=dgomeztt/visualizer)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:dgomeztt/visualizer)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=dgomeztt/visualizer)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:dgomeztt/visualizer)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=dgomeztt/visualizer)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:dgomeztt/visualizer)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
