### PR TITLE
Allow dynamic allocation of trace buffers when no trace region is set.

### DIFF
--- a/tests/tt_metal/distributed/test_mesh_trace.cpp
+++ b/tests/tt_metal/distributed/test_mesh_trace.cpp
@@ -915,7 +915,7 @@ TEST_F(MeshTraceDynamicAllocationTestSuite, TraceOverlapDetection) {
         }
     }
     ASSERT_TRUE(overlap_detected) << "Overlap detected - trace buffer conflicted with allocations made during trace";
-    #if 0
+#if 0
     if (overlap_detected) {
         SUCCEED() << "Successfully detected trace buffer overlap";
     } else {
@@ -926,7 +926,7 @@ TEST_F(MeshTraceDynamicAllocationTestSuite, TraceOverlapDetection) {
             tt::LogTest, "No overlap detected with {} bytes allocated - trace fit in remaining space", total_allocated);
         SUCCEED() << "No overlap detected (trace fit in available space)";
     }
-    #endif
+#endif
 }
 
 TEST_F(MeshTraceDynamicAllocationTestSuite, TraceWithTopDownAllocationsDetectsOverlap) {
@@ -952,14 +952,14 @@ TEST_F(MeshTraceDynamicAllocationTestSuite, TraceWithTopDownAllocationsDetectsOv
     // Allocate a large top-down DRAM buffer during trace capture
     // This will be tracked in the high water mark
     constexpr size_t buffer_size = 512 * 1024 * 1024;  // 512MB - large enough to likely cause overlap
-    
+
     ReplicatedBufferConfig global_buffer_config{.size = buffer_size};
     DeviceLocalBufferConfig top_down_config{
         .page_size = buffer_size,
         .buffer_type = BufferType::DRAM,
         .bottom_up = false  // Top-down allocation
     };
-    
+
     std::shared_ptr<MeshBuffer> top_down_buffer;
     try {
         top_down_buffer = MeshBuffer::create(global_buffer_config, top_down_config, mesh_device_.get());
@@ -992,7 +992,7 @@ TEST_F(MeshTraceDynamicAllocationTestSuite, TraceWithTopDownAllocationsDetectsOv
     }
     ASSERT_TRUE(overlap_detected) << "Overlap detected - trace buffer conflicted with top-down allocation";
 
-    #if 0
+#if 0
     if (overlap_detected) {
         SUCCEED() << "Successfully detected trace buffer overlap with top-down allocation";
     } else {
@@ -1001,7 +1001,7 @@ TEST_F(MeshTraceDynamicAllocationTestSuite, TraceWithTopDownAllocationsDetectsOv
         log_info(tt::LogTest, "No overlap detected - trace buffer did not conflict with top-down allocation");
         SUCCEED() << "No overlap detected (trace fit in available space)";
     }
-    #endif
+#endif
 }
 
 TEST_F(MeshTraceDynamicAllocationTestSuite, TraceOverlapDetectionWithAllocationsBeforeAndDuring) {
@@ -1055,7 +1055,7 @@ TEST_F(MeshTraceDynamicAllocationTestSuite, TraceOverlapDetectionWithAllocations
     // Begin trace capture - this starts tracking at 0
     auto trace_id = BeginTraceCapture(mesh_device_.get(), 0);
 
-    #if 0
+#if 0
     // Allocate more buffers DURING trace capture to increase the high water mark
     std::vector<std::shared_ptr<MeshBuffer>> during_trace_buffers;
     size_t during_trace_allocated = 0;
@@ -1081,7 +1081,7 @@ TEST_F(MeshTraceDynamicAllocationTestSuite, TraceOverlapDetectionWithAllocations
         "Allocated {} bytes DURING trace capture (pre-existing: {} bytes)",
         during_trace_allocated,
         total_allocated);
-    #endif
+#endif
 
     // Record many command iterations to make the trace buffer larger
     for (uint32_t i = 0; i < 1000; i++) {
@@ -1091,9 +1091,9 @@ TEST_F(MeshTraceDynamicAllocationTestSuite, TraceOverlapDetectionWithAllocations
     // Deallocate all buffers (both pre-existing and during-trace) BEFORE ending trace
     // The high water mark should remember the during-trace allocations
     pre_existing_buffers.clear();
-    #if 0
+#if 0
     during_trace_buffers.clear();
-    #endif
+#endif
 
     log_info(tt::LogTest, "Deallocated all buffers before ending trace");
 
@@ -1113,7 +1113,7 @@ TEST_F(MeshTraceDynamicAllocationTestSuite, TraceOverlapDetectionWithAllocations
         }
     }
     ASSERT_TRUE(overlap_detected) << "Overlap detected - trace buffer conflicted with allocations made during trace";
-    #if 0
+#if 0
     if (overlap_detected) {
         SUCCEED() << "Successfully detected trace buffer overlap with allocations made during trace";
     } else {
@@ -1126,7 +1126,7 @@ TEST_F(MeshTraceDynamicAllocationTestSuite, TraceOverlapDetectionWithAllocations
             during_trace_allocated);
         SUCCEED() << "No overlap detected (trace fit in available space)";
     }
-    #endif
+#endif
 }
 
 }  // namespace

--- a/tests/tt_metal/distributed/test_mesh_trace.cpp
+++ b/tests/tt_metal/distributed/test_mesh_trace.cpp
@@ -773,7 +773,7 @@ TEST_F(MeshTraceDynamicAllocationTestSuite, BasicTraceWithZeroTraceRegion) {
 
     MeshCoordinateRange all_devices(mesh_device_->shape());
     std::vector<std::shared_ptr<MeshWorkload>> mesh_workloads = {};
-    
+
     // Create workloads before trace capture
     for (uint32_t i = 0; i < num_workloads; i++) {
         auto workload = std::make_shared<MeshWorkload>();
@@ -860,7 +860,7 @@ TEST_F(MeshTraceDynamicAllocationTestSuite, TraceOverlapDetection) {
     // Allocate as many buffers as possible DURING trace capture (bottom-up, like tensor allocations)
     // This increases the high water mark, which should cause overlap with the trace buffer
     std::vector<std::shared_ptr<MeshBuffer>> blocking_buffers;
-    constexpr size_t min_buffer_size = 4 * 1024;       // 4KB minimum
+    constexpr size_t min_buffer_size = 4 * 1024;            // 4KB minimum
     constexpr size_t max_buffer_size = 1024 * 1024 * 1024;  // 1GB max per buffer
     size_t current_buffer_size = max_buffer_size;
     size_t total_allocated = 0;
@@ -907,8 +907,7 @@ TEST_F(MeshTraceDynamicAllocationTestSuite, TraceOverlapDetection) {
         // If we get here, no overlap was detected
     } catch (const std::runtime_error& e) {
         std::string error_msg = e.what();
-        if (error_msg.find("overlap") != std::string::npos ||
-            error_msg.find("high water mark") != std::string::npos) {
+        if (error_msg.find("overlap") != std::string::npos || error_msg.find("high water mark") != std::string::npos) {
             overlap_detected = true;
         } else {
             // Re-throw unexpected errors
@@ -923,9 +922,7 @@ TEST_F(MeshTraceDynamicAllocationTestSuite, TraceOverlapDetection) {
         // This is still valid, release the trace and log it
         mesh_device_->release_mesh_trace(trace_id);
         log_info(
-            tt::LogTest,
-            "No overlap detected with {} bytes allocated - trace fit in remaining space",
-            total_allocated);
+            tt::LogTest, "No overlap detected with {} bytes allocated - trace fit in remaining space", total_allocated);
         SUCCEED() << "No overlap detected (trace fit in available space)";
     }
 }

--- a/tt_metal/distributed/mesh_device.cpp
+++ b/tt_metal/distributed/mesh_device.cpp
@@ -1058,13 +1058,13 @@ void MeshDeviceImpl::begin_mesh_trace(uint8_t cq_id, const MeshTraceId& trace_id
         (uint32_t)cq_id,
         *trace_id);
     this->mark_allocations_safe();
-    
+
     // Start tracking DRAM high water mark if trace_region_size is 0 (dynamic allocation mode)
     auto trace_region_size = this->allocator_impl()->get_config().trace_region_size;
     if (trace_region_size == 0) {
         this->allocator_impl()->begin_dram_high_water_mark_tracking();
     }
-    
+
     // Create an empty trace buffer here. This will get initialized in end_trace
     auto* active_sub_device_manager = sub_device_manager_tracker_->get_active_sub_device_manager();
     TT_FATAL(

--- a/tt_metal/distributed/mesh_device.cpp
+++ b/tt_metal/distributed/mesh_device.cpp
@@ -1096,12 +1096,16 @@ void MeshDeviceImpl::end_mesh_trace(uint8_t cq_id, const MeshTraceId& trace_id) 
 
     // End DRAM high water mark tracking if trace_region_size is 0 (dynamic allocation mode)
     auto trace_region_size = this->allocator_impl()->get_config().trace_region_size;
-    DeviceAddr dram_high_water_mark = 0;
+    DeviceAddr dram_allocation_high_water_mark = 0;
+    DeviceAddr dram_deletion_high_water_mark = 0;
     if (trace_region_size == 0) {
-        dram_high_water_mark = this->allocator_impl()->end_dram_high_water_mark_tracking();
+        this->allocator_impl()->end_dram_high_water_mark_tracking();
+        dram_allocation_high_water_mark = this->allocator_impl()->get_dram_allocation_high_water_mark();
+        dram_deletion_high_water_mark = this->allocator_impl()->get_dram_deletion_high_water_mark();
     }
 
-    MeshTrace::populate_mesh_buffer(*(mesh_command_queues_[cq_id]), trace_buffer, dram_high_water_mark);
+    MeshTrace::populate_mesh_buffer(
+        *(mesh_command_queues_[cq_id]), trace_buffer, dram_allocation_high_water_mark, dram_deletion_high_water_mark);
     this->mark_allocations_unsafe();
 }
 

--- a/tt_metal/distributed/mesh_device.cpp
+++ b/tt_metal/distributed/mesh_device.cpp
@@ -1058,6 +1058,13 @@ void MeshDeviceImpl::begin_mesh_trace(uint8_t cq_id, const MeshTraceId& trace_id
         (uint32_t)cq_id,
         *trace_id);
     this->mark_allocations_safe();
+    
+    // Start tracking DRAM high water mark if trace_region_size is 0 (dynamic allocation mode)
+    auto trace_region_size = this->allocator_impl()->get_config().trace_region_size;
+    if (trace_region_size == 0) {
+        this->allocator_impl()->begin_dram_high_water_mark_tracking();
+    }
+    
     // Create an empty trace buffer here. This will get initialized in end_trace
     auto* active_sub_device_manager = sub_device_manager_tracker_->get_active_sub_device_manager();
     TT_FATAL(
@@ -1087,7 +1094,14 @@ void MeshDeviceImpl::end_mesh_trace(uint8_t cq_id, const MeshTraceId& trace_id) 
         active_sub_device_manager->id());
     this->mesh_command_queues_[cq_id]->record_end();
 
-    MeshTrace::populate_mesh_buffer(*(mesh_command_queues_[cq_id]), trace_buffer);
+    // End DRAM high water mark tracking if trace_region_size is 0 (dynamic allocation mode)
+    auto trace_region_size = this->allocator_impl()->get_config().trace_region_size;
+    DeviceAddr dram_high_water_mark = 0;
+    if (trace_region_size == 0) {
+        dram_high_water_mark = this->allocator_impl()->end_dram_high_water_mark_tracking();
+    }
+
+    MeshTrace::populate_mesh_buffer(*(mesh_command_queues_[cq_id]), trace_buffer, dram_high_water_mark);
     this->mark_allocations_unsafe();
 }
 

--- a/tt_metal/distributed/mesh_trace.cpp
+++ b/tt_metal/distributed/mesh_trace.cpp
@@ -151,7 +151,8 @@ std::shared_ptr<MeshTraceBuffer> MeshTrace::create_empty_mesh_trace_buffer() {
     return std::make_shared<MeshTraceBuffer>(std::make_shared<MeshTraceDescriptor>(), nullptr);
 }
 
-void MeshTrace::populate_mesh_buffer(MeshCommandQueue& mesh_cq, std::shared_ptr<MeshTraceBuffer>& trace_buffer) {
+void MeshTrace::populate_mesh_buffer(
+    MeshCommandQueue& mesh_cq, std::shared_ptr<MeshTraceBuffer>& trace_buffer, DeviceAddr dram_high_water_mark) {
     uint64_t unpadded_size = trace_buffer->desc->total_trace_size;
     size_t page_size = trace_dispatch::compute_interleaved_trace_buf_page_size(
         unpadded_size, mesh_cq.device()->allocator()->get_num_banks(BufferType::DRAM));
@@ -160,16 +161,29 @@ void MeshTrace::populate_mesh_buffer(MeshCommandQueue& mesh_cq, std::shared_ptr<
     const auto current_trace_buffers_size = mesh_cq.device()->get_trace_buffers_size();
     mesh_cq.device()->set_trace_buffers_size(current_trace_buffers_size + padded_size);
     auto trace_region_size = mesh_cq.device()->allocator_impl()->get_config().trace_region_size;
-    TT_FATAL(
-        mesh_cq.device()->get_trace_buffers_size() <= trace_region_size,
-        "Creating trace buffers of size {}B on MeshDevice {}, but only {}B is allocated for trace region.",
-        mesh_cq.device()->get_trace_buffers_size(),
-        mesh_cq.device()->id(),
-        trace_region_size);
+    
+    // When trace_region_size is 0, use dynamic allocation mode (allocate in DRAM, top-down)
+    BufferType buffer_type = BufferType::TRACE;
+    std::optional<bool> bottom_up = std::nullopt;
+    
+    if (trace_region_size == 0) {
+        // Dynamic allocation mode: allocate trace buffer in DRAM (top-down)
+        buffer_type = BufferType::DRAM;
+        bottom_up = false;  // Top-down allocation
+    } else {
+        // Traditional mode: use dedicated trace region
+        TT_FATAL(
+            mesh_cq.device()->get_trace_buffers_size() <= trace_region_size,
+            "Creating trace buffers of size {}B on MeshDevice {}, but only {}B is allocated for trace region.",
+            mesh_cq.device()->get_trace_buffers_size(),
+            mesh_cq.device()->id(),
+            trace_region_size);
+    }
 
     DeviceLocalBufferConfig device_local_trace_buf_config = {
         .page_size = page_size,
-        .buffer_type = BufferType::TRACE,
+        .buffer_type = buffer_type,
+        .bottom_up = bottom_up,
     };
 
     ReplicatedBufferConfig global_trace_buf_config = {
@@ -178,6 +192,18 @@ void MeshTrace::populate_mesh_buffer(MeshCommandQueue& mesh_cq, std::shared_ptr<
 
     trace_buffer->mesh_buffer =
         MeshBuffer::create(global_trace_buf_config, device_local_trace_buf_config, mesh_cq.device());
+    
+    // In dynamic allocation mode, validate that trace buffer doesn't overlap with allocations during trace
+    if (trace_region_size == 0 && dram_high_water_mark > 0) {
+        // Get the address of the trace buffer (it's allocated top-down, so we check the start address)
+        DeviceAddr trace_buffer_address = trace_buffer->mesh_buffer->address();
+        TT_FATAL(
+            trace_buffer_address >= dram_high_water_mark,
+            "Trace buffer at address {} overlaps with allocations made during trace (high water mark: {}). "
+            "Reduce allocations during trace capture or set a non-zero trace_region_size.",
+            trace_buffer_address,
+            dram_high_water_mark);
+    }
 
     std::unordered_map<MeshCoordinateRange, uint32_t> write_offset_per_device_range = {};
     for (auto& mesh_trace_data : trace_buffer->desc->ordered_trace_data) {

--- a/tt_metal/distributed/mesh_trace.cpp
+++ b/tt_metal/distributed/mesh_trace.cpp
@@ -161,11 +161,11 @@ void MeshTrace::populate_mesh_buffer(
     const auto current_trace_buffers_size = mesh_cq.device()->get_trace_buffers_size();
     mesh_cq.device()->set_trace_buffers_size(current_trace_buffers_size + padded_size);
     auto trace_region_size = mesh_cq.device()->allocator_impl()->get_config().trace_region_size;
-    
+
     // When trace_region_size is 0, use dynamic allocation mode (allocate in DRAM, top-down)
     BufferType buffer_type = BufferType::TRACE;
     std::optional<bool> bottom_up = std::nullopt;
-    
+
     if (trace_region_size == 0) {
         // Dynamic allocation mode: allocate trace buffer in DRAM (top-down)
         buffer_type = BufferType::DRAM;
@@ -192,7 +192,7 @@ void MeshTrace::populate_mesh_buffer(
 
     trace_buffer->mesh_buffer =
         MeshBuffer::create(global_trace_buf_config, device_local_trace_buf_config, mesh_cq.device());
-    
+
     // In dynamic allocation mode, validate that trace buffer doesn't overlap with allocations during trace
     if (trace_region_size == 0 && dram_high_water_mark > 0) {
         // Get the address of the trace buffer (it's allocated top-down, so we check the start address)

--- a/tt_metal/distributed/mesh_trace.cpp
+++ b/tt_metal/distributed/mesh_trace.cpp
@@ -203,11 +203,11 @@ void MeshTrace::populate_mesh_buffer(
         DeviceAddr trace_buffer_address = trace_buffer->mesh_buffer->address();
         if (trace_buffer_address < dram_high_water_mark) {
             // Determine which high water mark caused the overlap for a more specific error message
-            bool allocation_overlap = dram_allocation_high_water_mark > 0 && 
-                                      trace_buffer_address < dram_allocation_high_water_mark;
-            bool deletion_overlap = dram_deletion_high_water_mark > 0 && 
-                                    trace_buffer_address < dram_deletion_high_water_mark;
-            
+            bool allocation_overlap =
+                dram_allocation_high_water_mark > 0 && trace_buffer_address < dram_allocation_high_water_mark;
+            bool deletion_overlap =
+                dram_deletion_high_water_mark > 0 && trace_buffer_address < dram_deletion_high_water_mark;
+
             if (allocation_overlap && deletion_overlap) {
                 TT_FATAL(
                     false,

--- a/tt_metal/distributed/mesh_trace.cpp
+++ b/tt_metal/distributed/mesh_trace.cpp
@@ -199,7 +199,6 @@ void MeshTrace::populate_mesh_buffer(
     // In dynamic allocation mode, validate that trace buffer doesn't overlap with allocations during trace
     DeviceAddr dram_high_water_mark = std::max(dram_allocation_high_water_mark, dram_deletion_high_water_mark);
     if (trace_region_size == 0 && dram_high_water_mark > 0) {
-        // Get the address of the trace buffer (it's allocated top-down, so we check the start address)
         DeviceAddr trace_buffer_address = trace_buffer->mesh_buffer->address();
         if (trace_buffer_address < dram_high_water_mark) {
             // Determine which high water mark caused the overlap for a more specific error message

--- a/tt_metal/distributed/mesh_trace.hpp
+++ b/tt_metal/distributed/mesh_trace.hpp
@@ -80,7 +80,11 @@ public:
     // Once the Trace Data per logical device has been captured in the
     // MeshTraceDescriptor corresponding to this MeshTraceBuffer,
     // it can be binarized to a MeshDevice through a Command Queue.
-    static void populate_mesh_buffer(MeshCommandQueue& mesh_cq, std::shared_ptr<MeshTraceBuffer>& trace_buffer);
+    // dram_high_water_mark is used when trace_region_size is 0 to validate no overlap
+    static void populate_mesh_buffer(
+        MeshCommandQueue& mesh_cq,
+        std::shared_ptr<MeshTraceBuffer>& trace_buffer,
+        DeviceAddr dram_high_water_mark = 0);
 };
 
 }  // namespace tt::tt_metal::distributed

--- a/tt_metal/distributed/mesh_trace.hpp
+++ b/tt_metal/distributed/mesh_trace.hpp
@@ -80,9 +80,12 @@ public:
     // Once the Trace Data per logical device has been captured in the
     // MeshTraceDescriptor corresponding to this MeshTraceBuffer,
     // it can be binarized to a MeshDevice through a Command Queue.
-    // dram_high_water_mark is used when trace_region_size is 0 to validate no overlap
+    // High water marks are used when trace_region_size is 0 to validate no overlap
     static void populate_mesh_buffer(
-        MeshCommandQueue& mesh_cq, std::shared_ptr<MeshTraceBuffer>& trace_buffer, DeviceAddr dram_high_water_mark = 0);
+        MeshCommandQueue& mesh_cq,
+        std::shared_ptr<MeshTraceBuffer>& trace_buffer,
+        DeviceAddr dram_allocation_high_water_mark = 0,
+        DeviceAddr dram_deletion_high_water_mark = 0);
 };
 
 }  // namespace tt::tt_metal::distributed

--- a/tt_metal/distributed/mesh_trace.hpp
+++ b/tt_metal/distributed/mesh_trace.hpp
@@ -82,9 +82,7 @@ public:
     // it can be binarized to a MeshDevice through a Command Queue.
     // dram_high_water_mark is used when trace_region_size is 0 to validate no overlap
     static void populate_mesh_buffer(
-        MeshCommandQueue& mesh_cq,
-        std::shared_ptr<MeshTraceBuffer>& trace_buffer,
-        DeviceAddr dram_high_water_mark = 0);
+        MeshCommandQueue& mesh_cq, std::shared_ptr<MeshTraceBuffer>& trace_buffer, DeviceAddr dram_high_water_mark = 0);
 };
 
 }  // namespace tt::tt_metal::distributed

--- a/tt_metal/impl/allocator/algorithms/allocator_algorithm.hpp
+++ b/tt_metal/impl/allocator/algorithms/allocator_algorithm.hpp
@@ -51,6 +51,9 @@ public:
     // Returns all allocated address ranges as (start_address, end_address) pairs; start address is not sorted
     virtual std::vector<std::pair<DeviceAddr, DeviceAddr>> allocated_addresses() const = 0;
 
+    // Returns the size of the allocation at the given absolute address, or nullopt if not found
+    virtual std::optional<DeviceAddr> get_allocation_size(DeviceAddr absolute_address) const = 0;
+
     // bottom_up=true indicates that allocation grows from address 0
     // Address limit is only used as a final check to see if selected address is > address limit
     // - Effectively, this means that address limit should only be used with top-down allocation

--- a/tt_metal/impl/allocator/algorithms/free_list_opt.hpp
+++ b/tt_metal/impl/allocator/algorithms/free_list_opt.hpp
@@ -43,6 +43,9 @@ public:
     // Returns start and end addresses of allocated blocks; addresses are absolute addresses with offset added
     std::vector<std::pair<DeviceAddr, DeviceAddr>> allocated_addresses() const override;
 
+    // Returns the size of the allocation at the given absolute address, or nullopt if not found
+    std::optional<DeviceAddr> get_allocation_size(DeviceAddr absolute_address) const override;
+
     // Address limit is used as a final check to see if selected address is > address limit.
     // The selected address is first converted to absolute address by adding offset_bytes_.
     // Based on usage, it seems like offset_bytes_ is used to offset by address limit so that
@@ -128,6 +131,7 @@ private:
     static size_t hash_device_address(DeviceAddr address);
     void insert_block_to_alloc_table(DeviceAddr address, size_t block_index);
     bool is_address_in_alloc_table(DeviceAddr address) const;
+    std::optional<size_t> get_block_index_from_alloc_table(DeviceAddr address) const;
     std::optional<size_t> get_and_remove_from_alloc_table(DeviceAddr address);
 
     void update_lowest_occupied_address(DeviceAddr address);

--- a/tt_metal/impl/allocator/allocator.cpp
+++ b/tt_metal/impl/allocator/allocator.cpp
@@ -359,7 +359,18 @@ void AllocatorImpl::mark_allocations_safe() {
 
 void AllocatorImpl::begin_dram_high_water_mark_tracking() {
     std::lock_guard<std::mutex> lock(mutex_);
-    dram_manager_->begin_high_water_mark_tracking();
+
+    // Calculate the initial high water mark from existing bottom-up DRAM buffers
+    DeviceAddr initial_high_water_mark = 0;
+    for (const auto* buffer : allocated_buffers_) {
+        if (buffer->buffer_type() == BufferType::DRAM && buffer->bottom_up()) {
+            // Calculate end address: address + size_per_bank
+            DeviceAddr end_address = buffer->address() + buffer->aligned_size_per_bank();
+            initial_high_water_mark = std::max(initial_high_water_mark, end_address);
+        }
+    }
+
+    dram_manager_->begin_high_water_mark_tracking(initial_high_water_mark);
 }
 
 DeviceAddr AllocatorImpl::end_dram_high_water_mark_tracking() {

--- a/tt_metal/impl/allocator/allocator.cpp
+++ b/tt_metal/impl/allocator/allocator.cpp
@@ -372,6 +372,16 @@ DeviceAddr AllocatorImpl::get_dram_high_water_mark() const {
     return dram_manager_->get_high_water_mark();
 }
 
+DeviceAddr AllocatorImpl::get_dram_allocation_high_water_mark() const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return dram_manager_->get_allocation_high_water_mark();
+}
+
+DeviceAddr AllocatorImpl::get_dram_deletion_high_water_mark() const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return dram_manager_->get_deletion_high_water_mark();
+}
+
 void AllocatorImpl::clear() {
     std::lock_guard<std::mutex> lock(mutex_);
     dram_manager_->clear();

--- a/tt_metal/impl/allocator/allocator.cpp
+++ b/tt_metal/impl/allocator/allocator.cpp
@@ -357,6 +357,21 @@ void AllocatorImpl::mark_allocations_safe() {
     allocations_unsafe_ = false;
 }
 
+void AllocatorImpl::begin_dram_high_water_mark_tracking() {
+    std::lock_guard<std::mutex> lock(mutex_);
+    dram_manager_->begin_high_water_mark_tracking();
+}
+
+DeviceAddr AllocatorImpl::end_dram_high_water_mark_tracking() {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return dram_manager_->end_high_water_mark_tracking();
+}
+
+DeviceAddr AllocatorImpl::get_dram_high_water_mark() const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return dram_manager_->get_high_water_mark();
+}
+
 void AllocatorImpl::clear() {
     std::lock_guard<std::mutex> lock(mutex_);
     dram_manager_->clear();

--- a/tt_metal/impl/allocator/allocator.cpp
+++ b/tt_metal/impl/allocator/allocator.cpp
@@ -178,7 +178,7 @@ size_t AllocatorImpl::get_num_allocated_buffers() const {
 }
 
 uint32_t AllocatorImpl::get_num_banks(const BufferType& buffer_type) const {
-    std::lock_guard<std::mutex> lock(mutex_);
+    // Don't lock mutex_ because the number of banks is a constant and does not change.
     switch (buffer_type) {
         case BufferType::DRAM: return dram_manager_->num_banks();
         case BufferType::L1: return l1_manager_->num_banks();

--- a/tt_metal/impl/allocator/allocator.cpp
+++ b/tt_metal/impl/allocator/allocator.cpp
@@ -359,18 +359,7 @@ void AllocatorImpl::mark_allocations_safe() {
 
 void AllocatorImpl::begin_dram_high_water_mark_tracking() {
     std::lock_guard<std::mutex> lock(mutex_);
-
-    // Calculate the initial high water mark from existing bottom-up DRAM buffers
-    DeviceAddr initial_high_water_mark = 0;
-    for (const auto* buffer : allocated_buffers_) {
-        if (buffer->buffer_type() == BufferType::DRAM && buffer->bottom_up()) {
-            // Calculate end address: address + size_per_bank
-            DeviceAddr end_address = buffer->address() + buffer->aligned_size_per_bank();
-            initial_high_water_mark = std::max(initial_high_water_mark, end_address);
-        }
-    }
-
-    dram_manager_->begin_high_water_mark_tracking(initial_high_water_mark);
+    dram_manager_->begin_high_water_mark_tracking();
 }
 
 DeviceAddr AllocatorImpl::end_dram_high_water_mark_tracking() {

--- a/tt_metal/impl/allocator/allocator.hpp
+++ b/tt_metal/impl/allocator/allocator.hpp
@@ -110,7 +110,7 @@ private:
     // Set to true if allocating a buffer is unsafe. This happens when a live trace on device can corrupt
     // memory allocated by the user (memory used by trace is not tracked in the allocator once the trace is captured).
     bool allocations_unsafe_ = false;
-    
+
     std::unique_ptr<BankManager> dram_manager_;
     std::unique_ptr<BankManager> l1_manager_;
     std::unique_ptr<BankManager> l1_small_manager_;

--- a/tt_metal/impl/allocator/allocator.hpp
+++ b/tt_metal/impl/allocator/allocator.hpp
@@ -74,6 +74,12 @@ public:
     void mark_allocations_unsafe();
     void mark_allocations_safe();
 
+    // High water mark tracking for DRAM allocations during trace capture
+    // Delegates to BankManager to account for banking properly
+    void begin_dram_high_water_mark_tracking();
+    DeviceAddr end_dram_high_water_mark_tracking();
+    DeviceAddr get_dram_high_water_mark() const;
+
     // what does clear even mean on an allocator???
     void clear();
 
@@ -104,6 +110,7 @@ private:
     // Set to true if allocating a buffer is unsafe. This happens when a live trace on device can corrupt
     // memory allocated by the user (memory used by trace is not tracked in the allocator once the trace is captured).
     bool allocations_unsafe_ = false;
+    
     std::unique_ptr<BankManager> dram_manager_;
     std::unique_ptr<BankManager> l1_manager_;
     std::unique_ptr<BankManager> l1_small_manager_;

--- a/tt_metal/impl/allocator/allocator.hpp
+++ b/tt_metal/impl/allocator/allocator.hpp
@@ -112,7 +112,6 @@ private:
     // Set to true if allocating a buffer is unsafe. This happens when a live trace on device can corrupt
     // memory allocated by the user (memory used by trace is not tracked in the allocator once the trace is captured).
     bool allocations_unsafe_ = false;
-
     std::unique_ptr<BankManager> dram_manager_;
     std::unique_ptr<BankManager> l1_manager_;
     std::unique_ptr<BankManager> l1_small_manager_;

--- a/tt_metal/impl/allocator/allocator.hpp
+++ b/tt_metal/impl/allocator/allocator.hpp
@@ -79,6 +79,8 @@ public:
     void begin_dram_high_water_mark_tracking();
     DeviceAddr end_dram_high_water_mark_tracking();
     DeviceAddr get_dram_high_water_mark() const;
+    DeviceAddr get_dram_allocation_high_water_mark() const;
+    DeviceAddr get_dram_deletion_high_water_mark() const;
 
     // what does clear even mean on an allocator???
     void clear();

--- a/tt_metal/impl/allocator/bank_manager.cpp
+++ b/tt_metal/impl/allocator/bank_manager.cpp
@@ -434,7 +434,7 @@ uint64_t BankManager::allocate_buffer(
                 mem_stats.largest_free_block_bytes);
         }
         allocated_buffers_[allocator_id.get()].insert(address.value());
-        
+
         // Track high water mark for bottom-up allocations
         if (tracking_high_water_mark_ && bottom_up) {
             // Calculate end address in interleaved space: address + size_per_bank
@@ -443,7 +443,7 @@ uint64_t BankManager::allocate_buffer(
             DeviceAddr end_address = address.value() + size_per_bank;
             high_water_mark_ = std::max(high_water_mark_, end_address);
         }
-        
+
         // No neighbors, nothing to invalidate
         return address.value();
     }
@@ -499,7 +499,7 @@ uint64_t BankManager::allocate_buffer(
     auto address = alloc->allocate_at_address(chosen.value(), size_per_bank);
     TT_FATAL(address.has_value(), "Allocator failed to place at chosen address {}", chosen.value());
     allocated_buffers_[allocator_id.get()].insert(address.value());
-    
+
     // Track high water mark for bottom-up allocations
     if (tracking_high_water_mark_ && bottom_up) {
         // Calculate end address in interleaved space: address + size_per_bank
@@ -508,7 +508,7 @@ uint64_t BankManager::allocate_buffer(
         DeviceAddr end_address = address.value() + size_per_bank;
         high_water_mark_ = std::max(high_water_mark_, end_address);
     }
-    
+
     // Allocation in this allocator invalidates caches in allocators that depend on this allocator
     this->invalidate_allocated_ranges_cache_for_dependent_allocators(allocator_id);
     return address.value();
@@ -586,9 +586,7 @@ DeviceAddr BankManager::end_high_water_mark_tracking() {
     return high_water_mark_;
 }
 
-DeviceAddr BankManager::get_high_water_mark() const {
-    return high_water_mark_;
-}
+DeviceAddr BankManager::get_high_water_mark() const { return high_water_mark_; }
 
 void BankManager::dump_blocks(std::ostream& out, BankManager::AllocatorDependencies::AllocatorID allocator_id) const {
     const auto* alloc = this->get_allocator_from_id(allocator_id);

--- a/tt_metal/impl/allocator/bank_manager.cpp
+++ b/tt_metal/impl/allocator/bank_manager.cpp
@@ -435,12 +435,13 @@ uint64_t BankManager::allocate_buffer(
         }
         allocated_buffers_[allocator_id.get()].insert(address.value());
 
+        // Track allocation high water mark
         if (tracking_high_water_mark_) {
             // Calculate end address in interleaved space: address + size_per_bank
             // Bank offsets don't need to be accounted for here since overlap comparisons
             // are done in interleaved space where both allocations have the same bank offset applied
             DeviceAddr end_address = address.value() + size_per_bank;
-            high_water_mark_ = std::max(high_water_mark_, end_address);
+            allocation_high_water_mark_ = std::max(allocation_high_water_mark_, end_address);
         }
 
         // No neighbors, nothing to invalidate
@@ -499,13 +500,13 @@ uint64_t BankManager::allocate_buffer(
     TT_FATAL(address.has_value(), "Allocator failed to place at chosen address {}", chosen.value());
     allocated_buffers_[allocator_id.get()].insert(address.value());
 
-    // Track high water mark for all allocations (both bottom-up and top-down)
+    // Track allocation high water mark
     if (tracking_high_water_mark_) {
         // Calculate end address in interleaved space: address + size_per_bank
         // Bank offsets don't need to be accounted for here since overlap comparisons
         // are done in interleaved space where both allocations have the same bank offset applied
         DeviceAddr end_address = address.value() + size_per_bank;
-        high_water_mark_ = std::max(high_water_mark_, end_address);
+        allocation_high_water_mark_ = std::max(allocation_high_water_mark_, end_address);
     }
 
     // Allocation in this allocator invalidates caches in allocators that depend on this allocator
@@ -517,13 +518,13 @@ void BankManager::deallocate_buffer(DeviceAddr address, BankManager::AllocatorDe
     auto* alloc = this->get_allocator_from_id(allocator_id);
     TT_FATAL(alloc, "Allocator not initialized!");
     
-    // Track high water mark for deallocations - remember the extent of buffers being freed
+    // Track deletion high water mark - remember the extent of buffers being freed
     if (tracking_high_water_mark_) {
         auto size_opt = alloc->get_allocation_size(address);
         if (size_opt.has_value()) {
-            // Update high water mark with the end address of the buffer being deallocated
+            // Update deletion high water mark with the end address of the buffer being deallocated
             DeviceAddr end_address = address + size_opt.value();
-            high_water_mark_ = std::max(high_water_mark_, end_address);
+            deletion_high_water_mark_ = std::max(deletion_high_water_mark_, end_address);
         }
     }
     
@@ -588,15 +589,22 @@ Statistics BankManager::get_statistics(BankManager::AllocatorDependencies::Alloc
 
 void BankManager::begin_high_water_mark_tracking() {
     tracking_high_water_mark_ = true;
-    high_water_mark_ = 0;
+    allocation_high_water_mark_ = 0;
+    deletion_high_water_mark_ = 0;
 }
 
 DeviceAddr BankManager::end_high_water_mark_tracking() {
     tracking_high_water_mark_ = false;
-    return high_water_mark_;
+    return std::max(allocation_high_water_mark_, deletion_high_water_mark_);
 }
 
-DeviceAddr BankManager::get_high_water_mark() const { return high_water_mark_; }
+DeviceAddr BankManager::get_high_water_mark() const {
+    return std::max(allocation_high_water_mark_, deletion_high_water_mark_);
+}
+
+DeviceAddr BankManager::get_allocation_high_water_mark() const { return allocation_high_water_mark_; }
+
+DeviceAddr BankManager::get_deletion_high_water_mark() const { return deletion_high_water_mark_; }
 
 void BankManager::dump_blocks(std::ostream& out, BankManager::AllocatorDependencies::AllocatorID allocator_id) const {
     const auto* alloc = this->get_allocator_from_id(allocator_id);

--- a/tt_metal/impl/allocator/bank_manager.cpp
+++ b/tt_metal/impl/allocator/bank_manager.cpp
@@ -576,9 +576,9 @@ Statistics BankManager::get_statistics(BankManager::AllocatorDependencies::Alloc
     return alloc ? alloc->get_statistics() : Statistics();
 }
 
-void BankManager::begin_high_water_mark_tracking() {
+void BankManager::begin_high_water_mark_tracking(DeviceAddr initial_high_water_mark) {
     tracking_high_water_mark_ = true;
-    high_water_mark_ = 0;
+    high_water_mark_ = initial_high_water_mark;
 }
 
 DeviceAddr BankManager::end_high_water_mark_tracking() {

--- a/tt_metal/impl/allocator/bank_manager.cpp
+++ b/tt_metal/impl/allocator/bank_manager.cpp
@@ -517,7 +517,7 @@ uint64_t BankManager::allocate_buffer(
 void BankManager::deallocate_buffer(DeviceAddr address, BankManager::AllocatorDependencies::AllocatorID allocator_id) {
     auto* alloc = this->get_allocator_from_id(allocator_id);
     TT_FATAL(alloc, "Allocator not initialized!");
-    
+
     // Track deletion high water mark - remember the extent of buffers being freed
     if (tracking_high_water_mark_) {
         auto size_opt = alloc->get_allocation_size(address);
@@ -527,7 +527,7 @@ void BankManager::deallocate_buffer(DeviceAddr address, BankManager::AllocatorDe
             deletion_high_water_mark_ = std::max(deletion_high_water_mark_, end_address);
         }
     }
-    
+
     alloc->deallocate(address);
     allocated_buffers_[allocator_id.get()].erase(address);
     // Deallocation in this allocator invalidates caches in allocators that depend on this allocator

--- a/tt_metal/impl/allocator/bank_manager.hpp
+++ b/tt_metal/impl/allocator/bank_manager.hpp
@@ -124,6 +124,11 @@ public:
         AllocatorDependencies::AllocatorID allocator_id = AllocatorDependencies::AllocatorID{0});
     void reset_size(AllocatorDependencies::AllocatorID allocator_id = AllocatorDependencies::AllocatorID{0});
 
+    // High water mark tracking for bottom-up allocations
+    void begin_high_water_mark_tracking();
+    DeviceAddr end_high_water_mark_tracking();
+    DeviceAddr get_high_water_mark() const;
+
     // AllocatorState Methods
     // Extracts the state of the given allocator.
     AllocatorState::BufferTypeState extract_state(
@@ -166,6 +171,10 @@ private:
 
     // Per-allocator cache of: merged allocated ranges of all other dependent allocators
     ttsl::SmallVector<std::optional<std::vector<std::pair<DeviceAddr, DeviceAddr>>>> allocated_ranges_cache_{};
+
+    // High water mark tracking for bottom-up allocations
+    bool tracking_high_water_mark_ = false;
+    DeviceAddr high_water_mark_ = 0;
 
     /*********************************
      * Allocator-independent methods *

--- a/tt_metal/impl/allocator/bank_manager.hpp
+++ b/tt_metal/impl/allocator/bank_manager.hpp
@@ -125,7 +125,7 @@ public:
     void reset_size(AllocatorDependencies::AllocatorID allocator_id = AllocatorDependencies::AllocatorID{0});
 
     // High water mark tracking for bottom-up allocations
-    void begin_high_water_mark_tracking();
+    void begin_high_water_mark_tracking(DeviceAddr initial_high_water_mark = 0);
     DeviceAddr end_high_water_mark_tracking();
     DeviceAddr get_high_water_mark() const;
 

--- a/tt_metal/impl/allocator/bank_manager.hpp
+++ b/tt_metal/impl/allocator/bank_manager.hpp
@@ -129,6 +129,8 @@ public:
     void begin_high_water_mark_tracking();
     DeviceAddr end_high_water_mark_tracking();
     DeviceAddr get_high_water_mark() const;
+    DeviceAddr get_allocation_high_water_mark() const;
+    DeviceAddr get_deletion_high_water_mark() const;
 
     // AllocatorState Methods
     // Extracts the state of the given allocator.
@@ -173,9 +175,10 @@ private:
     // Per-allocator cache of: merged allocated ranges of all other dependent allocators
     ttsl::SmallVector<std::optional<std::vector<std::pair<DeviceAddr, DeviceAddr>>>> allocated_ranges_cache_{};
 
-    // High water mark tracking for bottom-up allocations
+    // High water mark tracking for allocations and deallocations
     bool tracking_high_water_mark_ = false;
-    DeviceAddr high_water_mark_ = 0;
+    DeviceAddr allocation_high_water_mark_ = 0;
+    DeviceAddr deletion_high_water_mark_ = 0;
 
     /*********************************
      * Allocator-independent methods *

--- a/tt_metal/impl/allocator/bank_manager.hpp
+++ b/tt_metal/impl/allocator/bank_manager.hpp
@@ -124,8 +124,9 @@ public:
         AllocatorDependencies::AllocatorID allocator_id = AllocatorDependencies::AllocatorID{0});
     void reset_size(AllocatorDependencies::AllocatorID allocator_id = AllocatorDependencies::AllocatorID{0});
 
-    // High water mark tracking for bottom-up allocations
-    void begin_high_water_mark_tracking(DeviceAddr initial_high_water_mark = 0);
+    // High water mark tracking for all allocations (both bottom-up and top-down)
+    // Tracks the maximum address extent reached during the tracking period, including deallocated buffers
+    void begin_high_water_mark_tracking();
     DeviceAddr end_high_water_mark_tracking();
     DeviceAddr get_high_water_mark() const;
 


### PR DESCRIPTION
### Problem description
Creating traces requires a specific size of trace region is set before, which can be annoying when developing a model.

### What's changed
When the trace region size is 0, allocate trace buffers top down just like program binaries.

This has the potential problem that the trace buffer may overlap with a buffer used inside the trace that's deleted by the end of a trace, causing problems. To detect this potential problem, track a high water mark of DRAM allocations created or deleted during the trace. If the trace buffer overlaps anything from the high water mark or below, throw a fatal error.

### Checklist

- [x] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=jbauman/traceregionflexiblesize)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:jbauman/traceregionflexiblesize)
- [x] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=jbauman/traceregionflexiblesize)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:jbauman/traceregionflexiblesize)
- [x] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=jbauman/traceregionflexiblesize)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jbauman/traceregionflexiblesize)
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=jbauman/traceregionflexiblesize)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:jbauman/traceregionflexiblesize)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=jbauman/traceregionflexiblesize)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:jbauman/traceregionflexiblesize)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=jbauman/traceregionflexiblesize)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:jbauman/traceregionflexiblesize)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
