### PR TITLE
[skip ci] Remove unnecessary TT_METAL_HOME export instructions from programming examples

### DIFF
--- a/tt_metal/programming_examples/add_2_integers_in_compute/add_2_integers_in_compute.md
+++ b/tt_metal/programming_examples/add_2_integers_in_compute/add_2_integers_in_compute.md
@@ -7,7 +7,6 @@ This program can be found in
 
 To build and execute, you may use the following commands:
 ```bash
-    export TT_METAL_HOME=$(pwd)
     ./build_metal.sh --build-programming-examples
     ./build/programming_examples/metal_example_add_2_integers_in_compute
 ```

--- a/tt_metal/programming_examples/add_2_integers_in_riscv/add_2_integers_in_riscv.md
+++ b/tt_metal/programming_examples/add_2_integers_in_riscv/add_2_integers_in_riscv.md
@@ -8,7 +8,6 @@ so you can follow along.
 
 To build and execute, you may use the following commands:
 ```bash
-    export TT_METAL_HOME=$(pwd)
     ./build_metal.sh --build-programming-examples
     ./build/programming_examples/metal_example_add_2_integers_in_riscv
 ```

--- a/tt_metal/programming_examples/eltwise_binary/eltwise_binary.md
+++ b/tt_metal/programming_examples/eltwise_binary/eltwise_binary.md
@@ -7,7 +7,6 @@ We'll go through any new code section by section. This builds on top of previous
 
 To build and execute, you may use the following commands:
 ```bash
-    export TT_METAL_HOME=$(pwd)
     ./build_metal.sh --build-programming-examples
     ./build/programming_examples/metal_example_eltwise_binary
 ```

--- a/tt_metal/programming_examples/eltwise_sfpu/eltwise_sfpu.md
+++ b/tt_metal/programming_examples/eltwise_sfpu/eltwise_sfpu.md
@@ -6,7 +6,6 @@ We'll go through any new code section by section. This builds on top of previous
 
 To build and execute, you may use the following commands:
 ```bash
-export TT_METAL_HOME=$(pwd)
 ./build_metal.sh --build-programming-examples
 ./build/programming_examples/metal_example_eltwise_sfpu
 ```

--- a/tt_metal/programming_examples/hello_world_compute_kernel/hello_world_compute.md
+++ b/tt_metal/programming_examples/hello_world_compute_kernel/hello_world_compute.md
@@ -6,7 +6,6 @@ We'll go through this code section by section. The full example program is at [h
 
 To build and execute, you may use the following commands:
 ```bash
-    export TT_METAL_HOME=$(pwd)
     ./build_metal.sh --build-programming-examples
     ./build/programming_examples/metal_example_hello_world_compute_kernel
 ```

--- a/tt_metal/programming_examples/hello_world_datamovement_kernel/hello_world_data_movement.md
+++ b/tt_metal/programming_examples/hello_world_datamovement_kernel/hello_world_data_movement.md
@@ -9,7 +9,6 @@ so you can follow along.
 To build and execute, you may use the following commands:
 Then run the following:
 ```bash
-    export TT_METAL_HOME=$(pwd)
     ./build_metal.sh --build-programming-examples
     ./build/programming_examples/metal_example_hello_world_datamovement_kernel
 ```

--- a/tt_metal/programming_examples/loopback/dram_loopback.md
+++ b/tt_metal/programming_examples/loopback/dram_loopback.md
@@ -8,7 +8,6 @@ We\'ll go through this code section by section. Note that we have this exact, fu
 
 To build and execute, you may use the following commands:
 ```bash
-    export TT_METAL_HOME=$(pwd)
     ./build_metal.sh --build-programming-examples
     ./build/programming_examples/loopback
 ```

--- a/tt_metal/programming_examples/matmul/matmul_multi_core/matmul_multi_core.md
+++ b/tt_metal/programming_examples/matmul/matmul_multi_core/matmul_multi_core.md
@@ -14,7 +14,6 @@ The full example program is in [matmul_multi_core.cpp](../../../tt_metal/program
 To build and execute, you may use the following commands:
 Then run the following:
 ```bash
-    export TT_METAL_HOME=$(pwd)
     ./build_metal.sh --build-programming-examples
     ./build/programming_examples/metal_example_matmul_multi_core
 ```

--- a/tt_metal/programming_examples/matmul/matmul_single_core/matmul_single_core.md
+++ b/tt_metal/programming_examples/matmul/matmul_single_core/matmul_single_core.md
@@ -8,7 +8,6 @@ The full example program is in
 To build and execute, you may use the following commands:
 Then run the following:
 ```bash
-    export TT_METAL_HOME=$(pwd)
     ./build_metal.sh --build-programming-examples
     ./build/programming_examples/metal_example_matmul_single_core
 ```


### PR DESCRIPTION
### Ticket
N/A

### Problem description
The `TT_METAL_HOME` environment variable is no longer needed for the programming examples build process. The documentation was instructing users to export this variable unnecessarily.

### What's changed
Removed the `export TT_METAL_HOME=$(pwd)` line from all markdown documentation files in `tt_metal/programming_examples/`:
- add_2_integers_in_riscv.md
- add_2_integers_in_compute.md
- eltwise_binary.md
- eltwise_sfpu.md
- hello_world_compute_kernel.md
- hello_world_datamovement_kernel.md
- loopback/dram_loopback.md
- matmul/matmul_multi_core.md
- matmul/matmul_single_core.md

The build commands now only require:
```bash
./build_metal.sh --build-programming-examples
./build/programming_examples/[example_name]
```

### Checklist

- [x] New/Existing tests provide coverage for changes (documentation only)