### PR TITLE
[skip ci] Disable auto-triage workflow dispatch (temporary)

### DIFF
--- a/.github/actions/trigger-auto-triage-for-regressions/index.js
+++ b/.github/actions/trigger-auto-triage-for-regressions/index.js
@@ -124,20 +124,21 @@ async function run() {
         core.info(`Triggering auto-triage for workflow: ${workflowFileName}, job: ${jobName}`);
 
         try {
-          await octokit.rest.actions.createWorkflowDispatch({
-            owner: github.context.repo.owner,
-            repo: github.context.repo.repo,
-            workflow_id: 'auto-triage.yml',
-            ref: dispatchRef,
-            inputs: {
-              workflow_name: workflowFileName,
-              job_name: jobName,
-              slack_ts: slackTs,
-              'send-slack-message': sendSlackMessageFlag,
-              slack_channel_id: slackChannelId
-            }
-          });
-          core.info(`✓ Successfully triggered auto-triage for ${workflowFileName} / ${jobName}`);
+          // await octokit.rest.actions.createWorkflowDispatch({
+          //   owner: github.context.repo.owner,
+          //   repo: github.context.repo.repo,
+          //   workflow_id: 'auto-triage.yml',
+          //   ref: dispatchRef,
+          //   inputs: {
+          //     workflow_name: workflowFileName,
+          //     job_name: jobName,
+          //     slack_ts: slackTs,
+          //     'send-slack-message': sendSlackMessageFlag,
+          //     slack_channel_id: slackChannelId
+          //   }
+          // });
+          // core.info(`✓ Successfully triggered auto-triage for ${workflowFileName} / ${jobName}`);
+          core.info(`Skipping auto-triage for ${workflowFileName} / ${jobName}`);
 
           // Add a small delay to avoid rate limiting
           await new Promise(resolve => setTimeout(resolve, 1000));


### PR DESCRIPTION
### Ticket
Link to Github Issue (if any)

### Problem description
Auto-triage workflow dispatch was triggering on ND/regression failures. This temporarily disables that behavior so we can run CI without triggering auto-triage until it's ready.

### What's changed
- In `.github/actions/trigger-auto-triage-for-regressions/index.js`, the `createWorkflowDispatch` call that triggers the `auto-triage.yml` workflow is commented out.
- The action now logs "Skipping auto-triage for {workflow}/{job}" instead of triggering the workflow.
- No other behavior is changed; the action still runs and logs, but does not dispatch the auto-triage workflow.

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=ebanerjee/disable-auto-triage-for-now)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:ebanerjee/disable-auto-triage-for-now)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ebanerjee/disable-auto-triage-for-now)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ebanerjee/disable-auto-triage-for-now)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ebanerjee/disable-auto-triage-for-now)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ebanerjee/disable-auto-triage-for-now)
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ebanerjee/disable-auto-triage-for-now)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ebanerjee/disable-auto-triage-for-now)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ebanerjee/disable-auto-triage-for-now)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ebanerjee/disable-auto-triage-for-now)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ebanerjee/disable-auto-triage-for-now)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ebanerjee/disable-auto-triage-for-now)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
