### PR TITLE
Re-enable saving T3K perf data

### DIFF
--- a/models/experimental/tt_dit/pipelines/wan/pipeline_wan.py
+++ b/models/experimental/tt_dit/pipelines/wan/pipeline_wan.py
@@ -227,14 +227,6 @@ class WanPipeline(DiffusionPipeline, WanLoraLoaderMixin):
                 "topology": ttnn.Topology.Linear,
                 "is_fsdp": False,
             }
-            device_configs[(2, 2)] = {
-                "sp_axis": 0,
-                "tp_axis": 1,
-                "num_links": 2,
-                "dynamic_load": False,
-                "topology": ttnn.Topology.Linear,
-                "is_fsdp": False,
-            }
             device_configs[(4, 8)] = {
                 "sp_axis": 1,
                 "tp_axis": 0,

--- a/models/experimental/tt_dit/pipelines/wan/pipeline_wan.py
+++ b/models/experimental/tt_dit/pipelines/wan/pipeline_wan.py
@@ -227,6 +227,14 @@ class WanPipeline(DiffusionPipeline, WanLoraLoaderMixin):
                 "topology": ttnn.Topology.Linear,
                 "is_fsdp": False,
             }
+            device_configs[(2, 2)] = {
+                "sp_axis": 0,
+                "tp_axis": 1,
+                "num_links": 2,
+                "dynamic_load": False,
+                "topology": ttnn.Topology.Linear,
+                "is_fsdp": False,
+            }
             device_configs[(4, 8)] = {
                 "sp_axis": 1,
                 "tp_axis": 0,

--- a/tests/pipeline_reorg/t3k_perf_tests.yaml
+++ b/tests/pipeline_reorg/t3k_perf_tests.yaml
@@ -56,6 +56,7 @@
   timeout: 75
   model-name: stable_diffusion_35_large
   model-type: DiT
+  save-perf-data: true
 
 - name: t3k_DiT_Mochi_model_perf_tests
   cmd: run_t3000_mochi_tests
@@ -65,6 +66,7 @@
   timeout: 75
   model-name: mochi
   model-type: DiT
+  save-perf-data: true
 
 - name: t3k_DiT_Wan2.2_model_perf_tests
   cmd: run_t3000_wan22_tests
@@ -74,6 +76,7 @@
   timeout: 45
   model-name: wan22
   model-type: DiT
+  save-perf-data: true
 
 - name: t3k_DiT_Flux.1-dev_model_perf_tests
   cmd: run_t3000_flux1_tests
@@ -83,6 +86,7 @@
   timeout: 50
   model-name: flux1-dev
   model-type: DiT
+  save-perf-data: true
 
 - name: t3k_DiT_Motif_model_perf_tests
   cmd: run_t3000_motif_tests
@@ -92,6 +96,7 @@
   timeout: 15
   model-name: motif
   model-type: DiT
+  save-perf-data: true
 
 - name: t3k_DiT_QwenImage_model_perf_tests
   cmd: run_t3000_qwenimage_tests
@@ -101,6 +106,7 @@
   timeout: 25
   model-name: qwenimage
   model-type: DiT
+  save-perf-data: true
 
 - name: t3k_ViT_Gemma3_perf_tests
   cmd: run_t3000_gemma3_tests


### PR DESCRIPTION
### Problem description
- An earlier PR (maybe [35551](https://github.com/tenstorrent/tt-metal/pull/35551)) disabled saving perf data for T3K.

### What's changed
This PR re-enables saving perf data for the DiT models running on T3K.

### Checklist

- [x] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=sosborne/reenable-t3k-ci-perf)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:sosborne/reenable-t3k-ci-perf)

#### Model tests

  - [x] Data from [Wan pipeline](https://github.com/tenstorrent/tt-metal/actions/runs/21611974568/job/62284427373) now uploaded