### PR TITLE
Decouple ControlPlane and it's children from MetalContext

### DIFF
--- a/tests/tt_metal/distributed/test_mesh_socket.cpp
+++ b/tests/tt_metal/distributed/test_mesh_socket.cpp
@@ -1639,7 +1639,7 @@ void run_multi_sender_single_recv(FixtureT* fixture, bool split_reducer) {
                     reducer_fabric_node_id, forwarding_direction);
 
                 auto forwarding_links = get_forwarding_link_indices_in_direction(
-                    reducer_fabric_node_id, dst_fabric_node_id, forwarding_direction);
+                    control_plane, reducer_fabric_node_id, dst_fabric_node_id, forwarding_direction);
                 // Cannot use the last link which might already have a fabric router on it or used by dispatch
                 // TODO: https://github.com/tenstorrent/tt-metal/issues/24413
                 if (!forwarding_links.empty()) {

--- a/tests/tt_metal/tt_fabric/fabric_router/test_custom_routing_tables.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_router/test_custom_routing_tables.cpp
@@ -25,9 +25,13 @@ constexpr auto k_FabricConfig = tt::tt_fabric::FabricConfig::FABRIC_2D;
 constexpr auto k_ReliabilityMode = tt::tt_fabric::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE;
 
 std::unique_ptr<tt::tt_fabric::ControlPlane> make_control_plane(const std::filesystem::path& graph_desc) {
-    auto control_plane = std::make_unique<tt::tt_fabric::ControlPlane>(graph_desc.string());
-    control_plane->initialize_fabric_context(k_FabricConfig, tt::tt_fabric::FabricRouterConfig{});
-    control_plane->configure_routing_tables_for_fabric_ethernet_channels(k_FabricConfig, k_ReliabilityMode);
+    auto& cluster = tt::tt_metal::MetalContext::instance().get_cluster();
+    auto& rtoptions = tt::tt_metal::MetalContext::instance().rtoptions();
+    const auto& hal = tt::tt_metal::MetalContext::instance().hal();
+    const auto& distributed_context = tt::tt_metal::MetalContext::instance().full_world_distributed_context();
+    auto control_plane = std::make_unique<tt::tt_fabric::ControlPlane>(
+        cluster, rtoptions, hal, distributed_context, graph_desc.string(), k_FabricConfig, k_ReliabilityMode);
+    control_plane->configure_routing_tables_for_fabric_ethernet_channels();
     return control_plane;
 }
 

--- a/tests/tt_metal/tt_fabric/fabric_router/test_mesh_graph_descriptor.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_router/test_mesh_graph_descriptor.cpp
@@ -15,6 +15,8 @@
 #include <tt-metalium/experimental/fabric/mesh_graph_descriptor.hpp>
 #include <tt-metalium/experimental/fabric/mesh_graph.hpp>
 
+#include "impl/context/metal_context.hpp"
+
 using namespace tt::tt_fabric;
 
 // Helper functions for hierarchy testing
@@ -1485,9 +1487,10 @@ TEST(MeshGraphDescriptorTests, AssignZDirectionInMeshGraph) {
         file << text_proto;
     }
 
-    EXPECT_NO_THROW(tt::tt_fabric::MeshGraph mesh_graph(test_file.string()));
+    const auto& cluster = tt::tt_metal::MetalContext::instance().get_cluster();
+    EXPECT_NO_THROW(tt::tt_fabric::MeshGraph mesh_graph(cluster, test_file.string()));
 
-    tt::tt_fabric::MeshGraph mesh_graph(test_file.string());
+    tt::tt_fabric::MeshGraph mesh_graph(cluster, test_file.string());
 
     // Test should_assign_z_direction method
     tt::tt_fabric::MeshId mesh_0(0);
@@ -1548,9 +1551,10 @@ TEST(MeshGraphDescriptorTests, AssignZDirectionGraphTopologyInMeshGraph) {
         file << text_proto;
     }
 
-    EXPECT_NO_THROW(tt::tt_fabric::MeshGraph mesh_graph(test_file.string()));
+    const auto& cluster = tt::tt_metal::MetalContext::instance().get_cluster();
+    EXPECT_NO_THROW(tt::tt_fabric::MeshGraph mesh_graph(cluster, test_file.string()));
 
-    tt::tt_fabric::MeshGraph mesh_graph(test_file.string());
+    tt::tt_fabric::MeshGraph mesh_graph(cluster, test_file.string());
 
     // Test should_assign_z_direction method for all mesh pairs
     tt::tt_fabric::MeshId mesh_0(0);

--- a/tests/tt_metal/tt_fabric/fabric_router/test_mesh_graph_descriptor.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_router/test_mesh_graph_descriptor.cpp
@@ -15,6 +15,7 @@
 #include <tt-metalium/experimental/fabric/mesh_graph_descriptor.hpp>
 #include <tt-metalium/experimental/fabric/mesh_graph.hpp>
 
+#include "cluster.hpp"
 #include "impl/context/metal_context.hpp"
 
 using namespace tt::tt_fabric;
@@ -1487,10 +1488,11 @@ TEST(MeshGraphDescriptorTests, AssignZDirectionInMeshGraph) {
         file << text_proto;
     }
 
-    const auto& cluster = tt::tt_metal::MetalContext::instance().get_cluster();
-    EXPECT_NO_THROW(tt::tt_fabric::MeshGraph mesh_graph(cluster, test_file.string()));
+    // Cluster type doesn't matter
+    const tt::tt_metal::ClusterType cluster_type = tt::tt_metal::ClusterType::BLACKHOLE_GALAXY;
+    EXPECT_NO_THROW(tt::tt_fabric::MeshGraph mesh_graph(cluster_type, test_file.string()));
 
-    tt::tt_fabric::MeshGraph mesh_graph(cluster, test_file.string());
+    tt::tt_fabric::MeshGraph mesh_graph(cluster_type, test_file.string());
 
     // Test should_assign_z_direction method
     tt::tt_fabric::MeshId mesh_0(0);
@@ -1551,10 +1553,11 @@ TEST(MeshGraphDescriptorTests, AssignZDirectionGraphTopologyInMeshGraph) {
         file << text_proto;
     }
 
-    const auto& cluster = tt::tt_metal::MetalContext::instance().get_cluster();
-    EXPECT_NO_THROW(tt::tt_fabric::MeshGraph mesh_graph(cluster, test_file.string()));
+    // Cluster type doesn't matter
+    const tt::tt_metal::ClusterType cluster_type = tt::tt_metal::ClusterType::BLACKHOLE_GALAXY;
+    EXPECT_NO_THROW(tt::tt_fabric::MeshGraph mesh_graph(cluster_type, test_file.string()));
 
-    tt::tt_fabric::MeshGraph mesh_graph(cluster, test_file.string());
+    tt::tt_fabric::MeshGraph mesh_graph(cluster_type, test_file.string());
 
     // Test should_assign_z_direction method for all mesh pairs
     tt::tt_fabric::MeshId mesh_0(0);

--- a/tests/tt_metal/tt_fabric/fabric_router/test_multi_host.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_router/test_multi_host.cpp
@@ -744,7 +744,7 @@ TEST(MultiHost, TestClosetBox3PodTTSwitchControlPlaneInit) {
         "tests/tt_metal/tt_fabric/custom_mesh_descriptors/wh_closetbox_3pod_ttswitch_mgd.textproto";
     auto control_plane = make_control_plane(
         mesh_graph_desc_path.string(),
-        tt::tt_fabric::FabricConfig::FABRIC_2D_TORUS_XY,
+        tt::tt_fabric::FabricConfig::FABRIC_2D,
         tt::tt_fabric::FabricReliabilityMode::RELAXED_SYSTEM_HEALTH_SETUP_MODE);
     control_plane->configure_routing_tables_for_fabric_ethernet_channels();
     check_asic_mapping_against_golden("TestClosetBox3PodTTSwitchControlPlaneInit");
@@ -776,7 +776,7 @@ TEST(MultiHost, TestClosetBox3PodTTSwitchAPIs) {
 
     auto control_plane = make_control_plane(
         mesh_graph_desc_path.string(),
-        tt::tt_fabric::FabricConfig::FABRIC_2D_TORUS_XY,
+        tt::tt_fabric::FabricConfig::FABRIC_2D,
         tt::tt_fabric::FabricReliabilityMode::RELAXED_SYSTEM_HEALTH_SETUP_MODE);
     const auto& mesh_graph = control_plane->get_mesh_graph();
 

--- a/tests/tt_metal/tt_fabric/fabric_router/test_multi_host.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_router/test_multi_host.cpp
@@ -199,19 +199,16 @@ TEST(MultiHost, TestDual2x4Fabric2DSanity) {
         tt::tt_fabric::FabricConfig::FABRIC_2D, tt::tt_fabric::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE);
     tt::tt_metal::MetalContext::instance().initialize_fabric_config();
 
-    auto control_plane = make_control_plane(
-        std::filesystem::path(),
-        tt::tt_fabric::FabricConfig::FABRIC_2D,
-        tt::tt_fabric::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE);
-    const auto& intermesh_connections = get_all_intermesh_connections(*control_plane);
+    auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
+    const auto& intermesh_connections = get_all_intermesh_connections(control_plane);
     EXPECT_EQ(intermesh_connections.size(), 16);  // Bidirectional
     for (const auto& [src_node_id, dst_node_id] : intermesh_connections) {
-        const auto& direction = control_plane->get_forwarding_direction(src_node_id, dst_node_id);
+        const auto& direction = control_plane.get_forwarding_direction(src_node_id, dst_node_id);
         EXPECT_TRUE(direction.has_value());
         const auto& eth_chans_by_direction =
-            control_plane->get_forwarding_eth_chans_to_chip(src_node_id, dst_node_id, *direction);
+            control_plane.get_forwarding_eth_chans_to_chip(src_node_id, dst_node_id, *direction);
         EXPECT_TRUE(!eth_chans_by_direction.empty());
-        const auto& eth_chans = control_plane->get_forwarding_eth_chans_to_chip(src_node_id, dst_node_id);
+        const auto& eth_chans = control_plane.get_forwarding_eth_chans_to_chip(src_node_id, dst_node_id);
         EXPECT_TRUE(!eth_chans.empty());
     }
 }
@@ -222,19 +219,20 @@ TEST(MultiHost, TestDual2x4Fabric1DSanity) {
         GTEST_SKIP();
     }
 
-    auto control_plane = make_control_plane(
-        std::filesystem::path(),
-        tt::tt_fabric::FabricConfig::FABRIC_1D,
-        tt::tt_fabric::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE);
-    const auto& intermesh_connections = get_all_intermesh_connections(*control_plane);
+    tt::tt_metal::MetalContext::instance().set_fabric_config(
+        tt::tt_fabric::FabricConfig::FABRIC_1D, tt::tt_fabric::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE);
+    tt::tt_metal::MetalContext::instance().initialize_fabric_config();
+
+    auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
+    const auto& intermesh_connections = get_all_intermesh_connections(control_plane);
     EXPECT_EQ(intermesh_connections.size(), 16);  // Bidirectional
     for (const auto& [src_node_id, dst_node_id] : intermesh_connections) {
-        const auto& direction = control_plane->get_forwarding_direction(src_node_id, dst_node_id);
+        const auto& direction = control_plane.get_forwarding_direction(src_node_id, dst_node_id);
         EXPECT_TRUE(direction.has_value());
         const auto& eth_chans_by_direction =
-            control_plane->get_forwarding_eth_chans_to_chip(src_node_id, dst_node_id, *direction);
+            control_plane.get_forwarding_eth_chans_to_chip(src_node_id, dst_node_id, *direction);
         EXPECT_TRUE(!eth_chans_by_direction.empty());
-        const auto& eth_chans = control_plane->get_forwarding_eth_chans_to_chip(src_node_id, dst_node_id);
+        const auto& eth_chans = control_plane.get_forwarding_eth_chans_to_chip(src_node_id, dst_node_id);
         EXPECT_TRUE(!eth_chans.empty());
     }
 }
@@ -260,19 +258,20 @@ TEST(MultiHost, TestSplit2x2ControlPlaneInit) {
 }
 
 TEST(MultiHost, TestSplit2x2Fabric2DSanity) {
-    auto control_plane = make_control_plane(
-        std::filesystem::path(),
-        tt::tt_fabric::FabricConfig::FABRIC_2D,
-        tt::tt_fabric::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE);
-    const auto& intermesh_connections = get_all_intermesh_connections(*control_plane);
+    tt::tt_metal::MetalContext::instance().set_fabric_config(
+        tt::tt_fabric::FabricConfig::FABRIC_2D, tt::tt_fabric::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE);
+    tt::tt_metal::MetalContext::instance().initialize_fabric_config();
+
+    auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
+    const auto& intermesh_connections = get_all_intermesh_connections(control_plane);
     EXPECT_EQ(intermesh_connections.size(), 8);  // Bidirectional
     for (const auto& [src_node_id, dst_node_id] : intermesh_connections) {
-        const auto& direction = control_plane->get_forwarding_direction(src_node_id, dst_node_id);
+        const auto& direction = control_plane.get_forwarding_direction(src_node_id, dst_node_id);
         EXPECT_TRUE(direction.has_value());
         const auto& eth_chans_by_direction =
-            control_plane->get_forwarding_eth_chans_to_chip(src_node_id, dst_node_id, *direction);
+            control_plane.get_forwarding_eth_chans_to_chip(src_node_id, dst_node_id, *direction);
         EXPECT_TRUE(!eth_chans_by_direction.empty());
-        const auto& eth_chans = control_plane->get_forwarding_eth_chans_to_chip(src_node_id, dst_node_id);
+        const auto& eth_chans = control_plane.get_forwarding_eth_chans_to_chip(src_node_id, dst_node_id);
         EXPECT_TRUE(!eth_chans.empty());
     }
 }
@@ -284,19 +283,21 @@ TEST(MultiHost, TestSplit2x2Fabric1DSanity) {
         GTEST_SKIP();
     }
 
-    auto control_plane = make_control_plane(
-        std::filesystem::path(),
-        tt::tt_fabric::FabricConfig::FABRIC_1D,
-        tt::tt_fabric::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE);
-    const auto& intermesh_connections = get_all_intermesh_connections(*control_plane);
+    tt::tt_metal::MetalContext::instance().set_fabric_config(
+        tt::tt_fabric::FabricConfig::FABRIC_1D, tt::tt_fabric::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE);
+    tt::tt_metal::MetalContext::instance().initialize_fabric_config();
+
+    // Validate control plane apis
+    auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
+    const auto& intermesh_connections = get_all_intermesh_connections(control_plane);
     EXPECT_EQ(intermesh_connections.size(), 8);  // Bidirectional
     for (const auto& [src_node_id, dst_node_id] : intermesh_connections) {
-        const auto& direction = control_plane->get_forwarding_direction(src_node_id, dst_node_id);
+        const auto& direction = control_plane.get_forwarding_direction(src_node_id, dst_node_id);
         EXPECT_TRUE(direction.has_value());
         const auto& eth_chans_by_direction =
-            control_plane->get_forwarding_eth_chans_to_chip(src_node_id, dst_node_id, *direction);
+            control_plane.get_forwarding_eth_chans_to_chip(src_node_id, dst_node_id, *direction);
         EXPECT_TRUE(!eth_chans_by_direction.empty());
-        const auto& eth_chans = control_plane->get_forwarding_eth_chans_to_chip(src_node_id, dst_node_id);
+        const auto& eth_chans = control_plane.get_forwarding_eth_chans_to_chip(src_node_id, dst_node_id);
         EXPECT_TRUE(!eth_chans.empty());
     }
 }
@@ -328,21 +329,23 @@ TEST(MultiHost, TestBigMesh2x4Fabric2DSanity) {
         GTEST_SKIP();
     }
 
-    auto control_plane = make_control_plane(
-        std::filesystem::path(),
-        tt::tt_fabric::FabricConfig::FABRIC_2D,
-        tt::tt_fabric::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE);
-    const auto& intramesh_connections = get_all_intramesh_connections(*control_plane);
+    tt::tt_metal::MetalContext::instance().set_fabric_config(
+        tt::tt_fabric::FabricConfig::FABRIC_2D, tt::tt_fabric::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE);
+    tt::tt_metal::MetalContext::instance().initialize_fabric_config();
+
+    // Validate control plane apis
+    auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
+    const auto& intramesh_connections = get_all_intramesh_connections(control_plane);
     EXPECT_EQ(
         intramesh_connections.size(),
         40);  // 10 (connections for 2x4) * 2 (bidirectional) * 2 (connections per direction)
     for (const auto& [src_node_id, dst_node_id] : intramesh_connections) {
-        const auto& direction = control_plane->get_forwarding_direction(src_node_id, dst_node_id);
+        const auto& direction = control_plane.get_forwarding_direction(src_node_id, dst_node_id);
         EXPECT_TRUE(direction.has_value());
         const auto& eth_chans_by_direction =
-            control_plane->get_forwarding_eth_chans_to_chip(src_node_id, dst_node_id, *direction);
+            control_plane.get_forwarding_eth_chans_to_chip(src_node_id, dst_node_id, *direction);
         EXPECT_TRUE(!eth_chans_by_direction.empty());
-        const auto& eth_chans = control_plane->get_forwarding_eth_chans_to_chip(src_node_id, dst_node_id);
+        const auto& eth_chans = control_plane.get_forwarding_eth_chans_to_chip(src_node_id, dst_node_id);
         EXPECT_TRUE(!eth_chans.empty());
     }
 }
@@ -354,21 +357,23 @@ TEST(MultiHost, TestBigMesh2x4Fabric1DSanity) {
         GTEST_SKIP();
     }
 
-    auto control_plane = make_control_plane(
-        std::filesystem::path(),
-        tt::tt_fabric::FabricConfig::FABRIC_1D,
-        tt::tt_fabric::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE);
-    const auto& intramesh_connections = get_all_intramesh_connections(*control_plane);
+    tt::tt_metal::MetalContext::instance().set_fabric_config(
+        tt::tt_fabric::FabricConfig::FABRIC_1D, tt::tt_fabric::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE);
+    tt::tt_metal::MetalContext::instance().initialize_fabric_config();
+
+    // Validate control plane apis
+    auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
+    const auto& intramesh_connections = get_all_intramesh_connections(control_plane);
     EXPECT_EQ(
         intramesh_connections.size(),
         40);  // 10 (connections for 2x4) * 2 (bidirectional) * 2 (connections per direction)
     for (const auto& [src_node_id, dst_node_id] : intramesh_connections) {
-        const auto& direction = control_plane->get_forwarding_direction(src_node_id, dst_node_id);
+        const auto& direction = control_plane.get_forwarding_direction(src_node_id, dst_node_id);
         EXPECT_TRUE(direction.has_value());
         const auto& eth_chans_by_direction =
-            control_plane->get_forwarding_eth_chans_to_chip(src_node_id, dst_node_id, *direction);
+            control_plane.get_forwarding_eth_chans_to_chip(src_node_id, dst_node_id, *direction);
         EXPECT_TRUE(!eth_chans_by_direction.empty());
-        const auto& eth_chans = control_plane->get_forwarding_eth_chans_to_chip(src_node_id, dst_node_id);
+        const auto& eth_chans = control_plane.get_forwarding_eth_chans_to_chip(src_node_id, dst_node_id);
         EXPECT_TRUE(!eth_chans.empty());
     }
 }
@@ -378,6 +383,10 @@ TEST(MultiHost, Test32x4QuadGalaxyControlPlaneInit) {
         log_info(tt::LogTest, "This test is only for GALAXY");
         GTEST_SKIP();
     }
+    tt::tt_metal::MetalContext::instance().set_fabric_config(
+        tt::tt_fabric::FabricConfig::FABRIC_2D_TORUS_XY,
+        tt::tt_fabric::FabricReliabilityMode::RELAXED_SYSTEM_HEALTH_SETUP_MODE);
+    tt::tt_metal::MetalContext::instance().initialize_fabric_config();
 
     const std::filesystem::path quad_galaxy_mesh_graph_desc_path =
         std::filesystem::path(tt::tt_metal::MetalContext::instance().rtoptions().get_root_dir()) /
@@ -396,11 +405,12 @@ TEST(MultiHost, TestBHGalaxyTorusXYControlPlaneQueries) {
         log_info(tt::LogTest, "This test is only for Blackhole Galaxy");
         GTEST_SKIP();
     }
-    auto control_plane = make_control_plane(
-        std::filesystem::path(),
+    tt::tt_metal::MetalContext::instance().set_fabric_config(
         tt::tt_fabric::FabricConfig::FABRIC_2D_TORUS_XY,
         tt::tt_fabric::FabricReliabilityMode::RELAXED_SYSTEM_HEALTH_SETUP_MODE);
-    const auto& intramesh_connections = get_all_intramesh_connections(*control_plane);
+    tt::tt_metal::MetalContext::instance().initialize_fabric_config();
+    const auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
+    const auto& intramesh_connections = get_all_intramesh_connections(control_plane);
     // 64 devices * 4 edges per device * 2 links per edge
     EXPECT_EQ(intramesh_connections.size(), 64 * 4 * 2);
     FabricNodeId src_node_id(MeshId{0}, 0);
@@ -410,33 +420,33 @@ TEST(MultiHost, TestBHGalaxyTorusXYControlPlaneQueries) {
     FabricNodeId dst_node_id_2(MeshId{0}, 56);
     MeshCoordinate dst_mesh_coord_2(7, 0);
     // Validate XY Torus connectivity
-    auto host_local_coord_range = control_plane->get_coord_range(MeshId{0}, MeshScope::LOCAL);
+    auto host_local_coord_range = control_plane.get_coord_range(MeshId{0}, MeshScope::LOCAL);
     if (host_local_coord_range.contains(src_mesh_coord)) {
-        const auto& direction = control_plane->get_forwarding_direction(src_node_id, dst_node_id);
+        const auto& direction = control_plane.get_forwarding_direction(src_node_id, dst_node_id);
         TT_FATAL(direction.has_value(), "No direction found");
         EXPECT_EQ(*direction, RoutingDirection::W);
-        const auto& direction_2 = control_plane->get_forwarding_direction(src_node_id, dst_node_id_2);
+        const auto& direction_2 = control_plane.get_forwarding_direction(src_node_id, dst_node_id_2);
         TT_FATAL(direction_2.has_value(), "No direction found");
         EXPECT_EQ(*direction_2, RoutingDirection::N);
-        const auto& reverse_direction_2 = control_plane->get_forwarding_direction(dst_node_id_2, src_node_id);
+        const auto& reverse_direction_2 = control_plane.get_forwarding_direction(dst_node_id_2, src_node_id);
         TT_FATAL(reverse_direction_2.has_value(), "No reverse direction found");
         EXPECT_EQ(*reverse_direction_2, RoutingDirection::S);
         const auto& eth_chans_by_direction =
-            control_plane->get_forwarding_eth_chans_to_chip(src_node_id, dst_node_id, *direction);
+            control_plane.get_forwarding_eth_chans_to_chip(src_node_id, dst_node_id, *direction);
         EXPECT_TRUE(!eth_chans_by_direction.empty());
         const auto& eth_chans_by_direction_2 =
-            control_plane->get_forwarding_eth_chans_to_chip(src_node_id, dst_node_id_2, *direction_2);
+            control_plane.get_forwarding_eth_chans_to_chip(src_node_id, dst_node_id_2, *direction_2);
         EXPECT_TRUE(!eth_chans_by_direction_2.empty());
         const auto& reverse_eth_chans_by_direction_2 =
-            control_plane->get_forwarding_eth_chans_to_chip(dst_node_id_2, src_node_id, *reverse_direction_2);
+            control_plane.get_forwarding_eth_chans_to_chip(dst_node_id_2, src_node_id, *reverse_direction_2);
         EXPECT_TRUE(!reverse_eth_chans_by_direction_2.empty());
     } else {
         TT_FATAL(host_local_coord_range.contains(dst_mesh_coord), "Dst mesh coord not in local range");
-        const auto& reverse_direction = control_plane->get_forwarding_direction(dst_node_id, src_node_id);
+        const auto& reverse_direction = control_plane.get_forwarding_direction(dst_node_id, src_node_id);
         TT_FATAL(reverse_direction.has_value(), "No reverse direction found");
         EXPECT_EQ(*reverse_direction, RoutingDirection::E);
         const auto& eth_chans_by_direction =
-            control_plane->get_forwarding_eth_chans_to_chip(dst_node_id, src_node_id, *reverse_direction);
+            control_plane.get_forwarding_eth_chans_to_chip(dst_node_id, src_node_id, *reverse_direction);
         EXPECT_TRUE(!eth_chans_by_direction.empty());
     }
 }
@@ -446,12 +456,14 @@ TEST(MultiHost, Test32x4QuadGalaxyFabric2DSanity) {
         log_info(tt::LogTest, "This test is only for GALAXY");
         GTEST_SKIP();
     }
-    auto control_plane = make_control_plane(
-        std::filesystem::path(),
+    tt::tt_metal::MetalContext::instance().set_fabric_config(
         tt::tt_fabric::FabricConfig::FABRIC_2D_TORUS_XY,
         tt::tt_fabric::FabricReliabilityMode::RELAXED_SYSTEM_HEALTH_SETUP_MODE);
-    const bool is_ubb_galaxy = tt::tt_metal::MetalContext::instance().get_cluster().is_ubb_galaxy();
-    const auto fabric_type = get_fabric_type(tt::tt_fabric::FabricConfig::FABRIC_2D_TORUS_XY, is_ubb_galaxy);
+    tt::tt_metal::MetalContext::instance().initialize_fabric_config();
+
+    // Validate control plane apis
+    auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
+    const auto fabric_type = get_fabric_type(tt::tt_fabric::FabricConfig::FABRIC_2D_TORUS_XY, true);
 
     FabricNodeId src_node_id(MeshId{0}, 3);  // On host rank 0
     MeshCoordinate src_mesh_coord(0, 3);
@@ -468,26 +480,26 @@ TEST(MultiHost, Test32x4QuadGalaxyFabric2DSanity) {
         expected_reverse_direction = RoutingDirection::N;
     }
 
-    auto host_local_coord_range = control_plane->get_coord_range(MeshId{0}, MeshScope::LOCAL);
+    auto host_local_coord_range = control_plane.get_coord_range(MeshId{0}, MeshScope::LOCAL);
     if (host_local_coord_range.contains(src_mesh_coord)) {
-        const auto& direction = control_plane->get_forwarding_direction(src_node_id, dst_node_id);
+        const auto& direction = control_plane.get_forwarding_direction(src_node_id, dst_node_id);
         EXPECT_EQ(direction, expected_direction);
 
         const auto& eth_chans_by_direction =
-            control_plane->get_forwarding_eth_chans_to_chip(src_node_id, dst_node_id, expected_direction);
+            control_plane.get_forwarding_eth_chans_to_chip(src_node_id, dst_node_id, expected_direction);
         EXPECT_TRUE(!eth_chans_by_direction.empty());
-        const auto& eth_chans = control_plane->get_forwarding_eth_chans_to_chip(src_node_id, dst_node_id);
+        const auto& eth_chans = control_plane.get_forwarding_eth_chans_to_chip(src_node_id, dst_node_id);
         EXPECT_TRUE(!eth_chans.empty());
     }
 
     if (host_local_coord_range.contains(dst_mesh_coord)) {
-        const auto& reverse_direction = control_plane->get_forwarding_direction(dst_node_id, src_node_id);
+        const auto& reverse_direction = control_plane.get_forwarding_direction(dst_node_id, src_node_id);
         EXPECT_EQ(reverse_direction, expected_reverse_direction);
 
-        const auto& eth_chans = control_plane->get_forwarding_eth_chans_to_chip(dst_node_id, src_node_id);
+        const auto& eth_chans = control_plane.get_forwarding_eth_chans_to_chip(dst_node_id, src_node_id);
         EXPECT_TRUE(!eth_chans.empty());
         const auto& eth_chans_by_direction =
-            control_plane->get_forwarding_eth_chans_to_chip(dst_node_id, src_node_id, expected_reverse_direction);
+            control_plane.get_forwarding_eth_chans_to_chip(dst_node_id, src_node_id, expected_reverse_direction);
         EXPECT_TRUE(!eth_chans_by_direction.empty());
     }
 }
@@ -497,35 +509,38 @@ TEST(MultiHost, Test32x4QuadGalaxyFabric1DSanity) {
         log_info(tt::LogTest, "This test is only for GALAXY");
         GTEST_SKIP();
     }
-    auto control_plane = make_control_plane(
-        std::filesystem::path(),
+    tt::tt_metal::MetalContext::instance().set_fabric_config(
         tt::tt_fabric::FabricConfig::FABRIC_1D_RING,
         tt::tt_fabric::FabricReliabilityMode::RELAXED_SYSTEM_HEALTH_SETUP_MODE);
+    tt::tt_metal::MetalContext::instance().initialize_fabric_config();
+
+    // Validate control plane apis
+    auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
     FabricNodeId src_node_id(MeshId{0}, 3);  // On host rank 0
     MeshCoordinate src_mesh_coord(0, 3);
     FabricNodeId dst_node_id(MeshId{0}, 96);  // On host rank 3
     MeshCoordinate dst_mesh_coord(0, 96);
 
-    auto host_local_coord_range = control_plane->get_coord_range(MeshId{0}, MeshScope::LOCAL);
+    auto host_local_coord_range = control_plane.get_coord_range(MeshId{0}, MeshScope::LOCAL);
     if (host_local_coord_range.contains(src_mesh_coord)) {
-        const auto& direction = control_plane->get_forwarding_direction(src_node_id, dst_node_id);
+        const auto& direction = control_plane.get_forwarding_direction(src_node_id, dst_node_id);
         EXPECT_EQ(direction, RoutingDirection::N);
 
         const auto& eth_chans_by_direction =
-            control_plane->get_forwarding_eth_chans_to_chip(src_node_id, dst_node_id, RoutingDirection::N);
+            control_plane.get_forwarding_eth_chans_to_chip(src_node_id, dst_node_id, RoutingDirection::N);
         EXPECT_TRUE(!eth_chans_by_direction.empty());
-        const auto& eth_chans = control_plane->get_forwarding_eth_chans_to_chip(src_node_id, dst_node_id);
+        const auto& eth_chans = control_plane.get_forwarding_eth_chans_to_chip(src_node_id, dst_node_id);
         EXPECT_TRUE(!eth_chans.empty());
     }
 
     if (host_local_coord_range.contains(dst_mesh_coord)) {
-        const auto& reverse_direction = control_plane->get_forwarding_direction(dst_node_id, src_node_id);
+        const auto& reverse_direction = control_plane.get_forwarding_direction(dst_node_id, src_node_id);
         EXPECT_EQ(reverse_direction, RoutingDirection::S);
 
-        const auto& eth_chans = control_plane->get_forwarding_eth_chans_to_chip(dst_node_id, src_node_id);
+        const auto& eth_chans = control_plane.get_forwarding_eth_chans_to_chip(dst_node_id, src_node_id);
         EXPECT_TRUE(!eth_chans.empty());
         const auto& eth_chans_by_direction =
-            control_plane->get_forwarding_eth_chans_to_chip(dst_node_id, src_node_id, RoutingDirection::S);
+            control_plane.get_forwarding_eth_chans_to_chip(dst_node_id, src_node_id, RoutingDirection::S);
         EXPECT_TRUE(!eth_chans_by_direction.empty());
     }
 }
@@ -553,12 +568,14 @@ TEST(MultiHost, TestQuadGalaxyFabric2DSanity) {
         log_info(tt::LogTest, "This test is only for GALAXY");
         GTEST_SKIP();
     }
-    auto control_plane = make_control_plane(
-        std::filesystem::path(),
+    tt::tt_metal::MetalContext::instance().set_fabric_config(
         tt::tt_fabric::FabricConfig::FABRIC_2D_TORUS_XY,
         tt::tt_fabric::FabricReliabilityMode::RELAXED_SYSTEM_HEALTH_SETUP_MODE);
-    const bool is_ubb_galaxy = tt::tt_metal::MetalContext::instance().get_cluster().is_ubb_galaxy();
-    const auto fabric_type = get_fabric_type(tt::tt_fabric::FabricConfig::FABRIC_2D_TORUS_XY, is_ubb_galaxy);
+    tt::tt_metal::MetalContext::instance().initialize_fabric_config();
+
+    // Validate control plane apis
+    auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
+    const auto fabric_type = get_fabric_type(tt::tt_fabric::FabricConfig::FABRIC_2D_TORUS_XY, true);
 
     FabricNodeId src_node_id(MeshId{0}, 3);  // On host rank 0
     MeshCoordinate src_mesh_coord(0, 3);
@@ -575,26 +592,26 @@ TEST(MultiHost, TestQuadGalaxyFabric2DSanity) {
         expected_reverse_direction = RoutingDirection::W;
     }
 
-    auto host_local_coord_range = control_plane->get_coord_range(MeshId{0}, MeshScope::LOCAL);
+    auto host_local_coord_range = control_plane.get_coord_range(MeshId{0}, MeshScope::LOCAL);
     if (host_local_coord_range.contains(src_mesh_coord)) {
-        const auto& direction = control_plane->get_forwarding_direction(src_node_id, dst_node_id);
+        const auto& direction = control_plane.get_forwarding_direction(src_node_id, dst_node_id);
         EXPECT_EQ(direction, expected_direction);
 
         const auto& eth_chans_by_direction =
-            control_plane->get_forwarding_eth_chans_to_chip(src_node_id, dst_node_id, expected_direction);
+            control_plane.get_forwarding_eth_chans_to_chip(src_node_id, dst_node_id, expected_direction);
         EXPECT_TRUE(!eth_chans_by_direction.empty());
-        const auto& eth_chans = control_plane->get_forwarding_eth_chans_to_chip(src_node_id, dst_node_id);
+        const auto& eth_chans = control_plane.get_forwarding_eth_chans_to_chip(src_node_id, dst_node_id);
         EXPECT_TRUE(!eth_chans.empty());
     }
 
     if (host_local_coord_range.contains(dst_mesh_coord)) {
-        const auto& reverse_direction = control_plane->get_forwarding_direction(dst_node_id, src_node_id);
+        const auto& reverse_direction = control_plane.get_forwarding_direction(dst_node_id, src_node_id);
         EXPECT_EQ(reverse_direction, expected_reverse_direction);
 
-        const auto& eth_chans = control_plane->get_forwarding_eth_chans_to_chip(dst_node_id, src_node_id);
+        const auto& eth_chans = control_plane.get_forwarding_eth_chans_to_chip(dst_node_id, src_node_id);
         EXPECT_TRUE(!eth_chans.empty());
         const auto& eth_chans_by_direction =
-            control_plane->get_forwarding_eth_chans_to_chip(dst_node_id, src_node_id, expected_reverse_direction);
+            control_plane.get_forwarding_eth_chans_to_chip(dst_node_id, src_node_id, expected_reverse_direction);
         EXPECT_TRUE(!eth_chans_by_direction.empty());
     }
 }
@@ -604,35 +621,38 @@ TEST(MultiHost, TestQuadGalaxyFabric1DSanity) {
         log_info(tt::LogTest, "This test is only for GALAXY");
         GTEST_SKIP();
     }
-    auto control_plane = make_control_plane(
-        std::filesystem::path(),
+    tt::tt_metal::MetalContext::instance().set_fabric_config(
         tt::tt_fabric::FabricConfig::FABRIC_1D_RING,
         tt::tt_fabric::FabricReliabilityMode::RELAXED_SYSTEM_HEALTH_SETUP_MODE);
+    tt::tt_metal::MetalContext::instance().initialize_fabric_config();
+
+    // Validate control plane apis
+    auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
     FabricNodeId src_node_id(MeshId{0}, 3);  // On host rank 0
     MeshCoordinate src_mesh_coord(0, 3);
     FabricNodeId dst_node_id(MeshId{0}, 12);  // On host rank 3
     MeshCoordinate dst_mesh_coord(0, 12);
 
-    auto host_local_coord_range = control_plane->get_coord_range(MeshId{0}, MeshScope::LOCAL);
+    auto host_local_coord_range = control_plane.get_coord_range(MeshId{0}, MeshScope::LOCAL);
     if (host_local_coord_range.contains(src_mesh_coord)) {
-        const auto& direction = control_plane->get_forwarding_direction(src_node_id, dst_node_id);
+        const auto& direction = control_plane.get_forwarding_direction(src_node_id, dst_node_id);
         EXPECT_EQ(direction, RoutingDirection::W);
 
         const auto& eth_chans_by_direction =
-            control_plane->get_forwarding_eth_chans_to_chip(src_node_id, dst_node_id, RoutingDirection::W);
+            control_plane.get_forwarding_eth_chans_to_chip(src_node_id, dst_node_id, RoutingDirection::W);
         EXPECT_TRUE(!eth_chans_by_direction.empty());
-        const auto& eth_chans = control_plane->get_forwarding_eth_chans_to_chip(src_node_id, dst_node_id);
+        const auto& eth_chans = control_plane.get_forwarding_eth_chans_to_chip(src_node_id, dst_node_id);
         EXPECT_TRUE(!eth_chans.empty());
     }
 
     if (host_local_coord_range.contains(dst_mesh_coord)) {
-        const auto& reverse_direction = control_plane->get_forwarding_direction(dst_node_id, src_node_id);
+        const auto& reverse_direction = control_plane.get_forwarding_direction(dst_node_id, src_node_id);
         EXPECT_EQ(reverse_direction, RoutingDirection::E);
 
-        const auto& eth_chans = control_plane->get_forwarding_eth_chans_to_chip(dst_node_id, src_node_id);
+        const auto& eth_chans = control_plane.get_forwarding_eth_chans_to_chip(dst_node_id, src_node_id);
         EXPECT_TRUE(!eth_chans.empty());
         const auto& eth_chans_by_direction =
-            control_plane->get_forwarding_eth_chans_to_chip(dst_node_id, src_node_id, RoutingDirection::E);
+            control_plane.get_forwarding_eth_chans_to_chip(dst_node_id, src_node_id, RoutingDirection::E);
         EXPECT_TRUE(!eth_chans_by_direction.empty());
     }
 }
@@ -663,25 +683,27 @@ TEST(MultiHost, TestBHQB4x4Fabric2DSanity) {
         GTEST_SKIP();
     }
 
-    auto control_plane = make_control_plane(
-        std::filesystem::path(),
+    tt::tt_metal::MetalContext::instance().set_fabric_config(
         tt::tt_fabric::FabricConfig::FABRIC_2D_TORUS_XY,
         tt::tt_fabric::FabricReliabilityMode::RELAXED_SYSTEM_HEALTH_SETUP_MODE);
+    tt::tt_metal::MetalContext::instance().initialize_fabric_config();
+
+    auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
 
     // 4x4 torus has 32 unique undirected adjacencies: (horizontal 16 + vertical 16)
     // With bidirectional and 2 ethernet channels per direction -> 32 * 2 * 2 = 128
-    const auto& intramesh_connections = get_all_intramesh_connections(*control_plane);
+    const auto& intramesh_connections = get_all_intramesh_connections(control_plane);
     EXPECT_EQ(intramesh_connections.size(), 128);
 
     for (const auto& [src_node_id, dst_node_id] : intramesh_connections) {
-        const auto& direction = control_plane->get_forwarding_direction(src_node_id, dst_node_id);
+        const auto& direction = control_plane.get_forwarding_direction(src_node_id, dst_node_id);
         EXPECT_TRUE(direction.has_value());
 
         const auto& eth_chans_by_direction =
-            control_plane->get_forwarding_eth_chans_to_chip(src_node_id, dst_node_id, *direction);
+            control_plane.get_forwarding_eth_chans_to_chip(src_node_id, dst_node_id, *direction);
         EXPECT_TRUE(!eth_chans_by_direction.empty());
 
-        const auto& eth_chans = control_plane->get_forwarding_eth_chans_to_chip(src_node_id, dst_node_id);
+        const auto& eth_chans = control_plane.get_forwarding_eth_chans_to_chip(src_node_id, dst_node_id);
         EXPECT_TRUE(!eth_chans.empty());
     }
 }
@@ -692,24 +714,26 @@ TEST(MultiHost, TestBHQB4x4Fabric1DSanity) {
         GTEST_SKIP();
     }
 
-    auto control_plane = make_control_plane(
-        std::filesystem::path(),
+    tt::tt_metal::MetalContext::instance().set_fabric_config(
         tt::tt_fabric::FabricConfig::FABRIC_1D_RING,
         tt::tt_fabric::FabricReliabilityMode::RELAXED_SYSTEM_HEALTH_SETUP_MODE);
+    tt::tt_metal::MetalContext::instance().initialize_fabric_config();
+
+    auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
 
     // Intra-mesh adjacency count is determined by the MGD, independent of fabric config
-    const auto& intramesh_connections = get_all_intramesh_connections(*control_plane);
+    const auto& intramesh_connections = get_all_intramesh_connections(control_plane);
     EXPECT_EQ(intramesh_connections.size(), 96);  // MESH. Convert to 128 for TORUS_XY
 
     for (const auto& [src_node_id, dst_node_id] : intramesh_connections) {
-        const auto& direction = control_plane->get_forwarding_direction(src_node_id, dst_node_id);
+        const auto& direction = control_plane.get_forwarding_direction(src_node_id, dst_node_id);
         EXPECT_TRUE(direction.has_value());
 
         const auto& eth_chans_by_direction =
-            control_plane->get_forwarding_eth_chans_to_chip(src_node_id, dst_node_id, *direction);
+            control_plane.get_forwarding_eth_chans_to_chip(src_node_id, dst_node_id, *direction);
         EXPECT_TRUE(!eth_chans_by_direction.empty());
 
-        const auto& eth_chans = control_plane->get_forwarding_eth_chans_to_chip(src_node_id, dst_node_id);
+        const auto& eth_chans = control_plane.get_forwarding_eth_chans_to_chip(src_node_id, dst_node_id);
         EXPECT_TRUE(!eth_chans.empty());
     }
 }
@@ -867,45 +891,46 @@ TEST(MultiHost, BHDualGalaxyFabric2DSanity) {
         GTEST_SKIP();
     }
 
-    auto control_plane = make_control_plane(
-        std::filesystem::path(),
-        tt::tt_fabric::FabricConfig::FABRIC_2D,
-        tt::tt_fabric::FabricReliabilityMode::RELAXED_SYSTEM_HEALTH_SETUP_MODE);
+    tt::tt_metal::MetalContext::instance().set_fabric_config(
+        tt::tt_fabric::FabricConfig::FABRIC_2D, tt::tt_fabric::FabricReliabilityMode::RELAXED_SYSTEM_HEALTH_SETUP_MODE);
+    tt::tt_metal::MetalContext::instance().initialize_fabric_config();
 
-    control_plane->print_routing_tables();
+    auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
+
+    control_plane.print_routing_tables();
 
     // Test Z direction functionality
     // routing_direction_to_eth_direction always returns Z for RoutingDirection::Z (regardless of assign_z_direction)
     EXPECT_EQ(
-        control_plane->routing_direction_to_eth_direction(RoutingDirection::Z),
+        control_plane.routing_direction_to_eth_direction(RoutingDirection::Z),
         static_cast<eth_chan_directions>(eth_chan_directions::Z));
 
     // Verify get_forwarding_eth_chans_to_chip can handle Z direction
     // (This will return empty if no Z connections exist, but should not crash)
-    const auto& intramesh_connections = get_all_intramesh_connections(*control_plane);
+    const auto& intramesh_connections = get_all_intramesh_connections(control_plane);
     for (const auto& [src_node_id, dst_node_id] : intramesh_connections) {
         const auto& z_chans =
-            control_plane->get_forwarding_eth_chans_to_chip(src_node_id, dst_node_id, RoutingDirection::Z);
+            control_plane.get_forwarding_eth_chans_to_chip(src_node_id, dst_node_id, RoutingDirection::Z);
         // Z direction channels may be empty if no Z connections exist, which is expected
         // The important thing is that the API doesn't crash
     }
 
     // Verify channels 8 and 9 are associated with Z direction when appropriate
     // Check if any fabric node has channels 8 or 9 assigned to Z direction
-    const auto& mesh_ids = control_plane->get_mesh_graph().get_mesh_ids();
+    const auto& mesh_ids = control_plane.get_mesh_graph().get_mesh_ids();
     size_t z_channel_count = 0;
     for (const auto& mesh_id : mesh_ids) {
-        const auto& chip_ids = control_plane->get_mesh_graph().get_chip_ids(mesh_id);
+        const auto& chip_ids = control_plane.get_mesh_graph().get_chip_ids(mesh_id);
         for (const auto& [_, chip_id] : chip_ids) {
             auto fabric_node_id = FabricNodeId(mesh_id, static_cast<std::uint32_t>(chip_id));
             const auto& z_direction_chans =
-                control_plane->get_active_fabric_eth_channels_in_direction(fabric_node_id, RoutingDirection::Z);
+                control_plane.get_active_fabric_eth_channels_in_direction(fabric_node_id, RoutingDirection::Z);
             for (const auto& chan : z_direction_chans) {
                 if (chan == 8 || chan == 9) {
                     z_channel_count++;
                     // Verify that get_eth_chan_direction returns Z for Z channels
                     EXPECT_EQ(
-                        control_plane->get_eth_chan_direction(fabric_node_id, chan),
+                        control_plane.get_eth_chan_direction(fabric_node_id, chan),
                         static_cast<eth_chan_directions>(eth_chan_directions::Z));
                 }
             }
@@ -929,33 +954,34 @@ TEST(MultiHost, T3K2x2AssignZDirectionControlPlaneInit) {
 }
 
 TEST(MultiHost, T3K2x2AssignZDirectionFabric2DSanity) {
-    auto control_plane = make_control_plane(
-        std::filesystem::path(),
-        tt::tt_fabric::FabricConfig::FABRIC_2D,
-        tt::tt_fabric::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE);
+    tt::tt_metal::MetalContext::instance().set_fabric_config(
+        tt::tt_fabric::FabricConfig::FABRIC_2D, tt::tt_fabric::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE);
+    tt::tt_metal::MetalContext::instance().initialize_fabric_config();
+
+    auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
 
     // Verify that MeshGraph correctly identifies mesh pairs that should use Z direction
-    const auto& mesh_graph = control_plane->get_mesh_graph();
+    const auto& mesh_graph = control_plane.get_mesh_graph();
     EXPECT_TRUE(mesh_graph.should_assign_z_direction(MeshId{0}, MeshId{1}))
         << "Mesh 0 <-> Mesh 1 should use Z direction";
     EXPECT_TRUE(mesh_graph.should_assign_z_direction(MeshId{1}, MeshId{0}))
         << "Mesh 1 <-> Mesh 0 should use Z direction (bidirectional)";
 
-    control_plane->print_routing_tables();
+    control_plane.print_routing_tables();
 
     // Test Z direction functionality
     // When assign_z_direction is set, routing_direction_to_eth_direction should return Z (not INVALID_DIRECTION)
     EXPECT_EQ(
-        control_plane->routing_direction_to_eth_direction(RoutingDirection::Z),
+        control_plane.routing_direction_to_eth_direction(RoutingDirection::Z),
         static_cast<eth_chan_directions>(eth_chan_directions::Z));
 
     // Verify get_forwarding_eth_chans_to_chip can handle Z direction for intermesh connections
-    const auto& intermesh_connections = get_all_intermesh_connections(*control_plane);
+    const auto& intermesh_connections = get_all_intermesh_connections(control_plane);
     EXPECT_EQ(intermesh_connections.size(), 8);  // 2x2 mesh, 4 chips per mesh, bidirectional = 8 total
 
     size_t z_direction_intermesh_count = 0;
     for (const auto& [src_node_id, dst_node_id] : intermesh_connections) {
-        const auto& direction = control_plane->get_forwarding_direction(src_node_id, dst_node_id);
+        const auto& direction = control_plane.get_forwarding_direction(src_node_id, dst_node_id);
         EXPECT_TRUE(direction.has_value());
 
         // Verify that intermesh connections use Z direction when assign_z_direction is set
@@ -964,15 +990,15 @@ TEST(MultiHost, T3K2x2AssignZDirectionFabric2DSanity) {
         }
 
         const auto& eth_chans_by_direction =
-            control_plane->get_forwarding_eth_chans_to_chip(src_node_id, dst_node_id, *direction);
+            control_plane.get_forwarding_eth_chans_to_chip(src_node_id, dst_node_id, *direction);
         EXPECT_TRUE(!eth_chans_by_direction.empty());
 
-        const auto& eth_chans = control_plane->get_forwarding_eth_chans_to_chip(src_node_id, dst_node_id);
+        const auto& eth_chans = control_plane.get_forwarding_eth_chans_to_chip(src_node_id, dst_node_id);
         EXPECT_TRUE(!eth_chans.empty());
 
         // Verify Z direction channels can be retrieved
         const auto& z_chans =
-            control_plane->get_forwarding_eth_chans_to_chip(src_node_id, dst_node_id, RoutingDirection::Z);
+            control_plane.get_forwarding_eth_chans_to_chip(src_node_id, dst_node_id, RoutingDirection::Z);
         // For intermesh connections with assign_z_direction, Z channels should exist
         if (direction == RoutingDirection::Z) {
             EXPECT_TRUE(!z_chans.empty())
@@ -990,14 +1016,14 @@ TEST(MultiHost, T3K2x2AssignZDirectionFabric2DSanity) {
 
     // Verify Z direction channels are properly assigned for intermesh connections
     // Check if any fabric node has Z direction channels assigned for intermesh connections
-    const auto& mesh_ids = control_plane->get_mesh_graph().get_mesh_ids();
+    const auto& mesh_ids = control_plane.get_mesh_graph().get_mesh_ids();
     size_t z_channel_count = 0;
     for (const auto& mesh_id : mesh_ids) {
-        const auto& chip_ids = control_plane->get_mesh_graph().get_chip_ids(mesh_id);
+        const auto& chip_ids = control_plane.get_mesh_graph().get_chip_ids(mesh_id);
         for (const auto& [_, chip_id] : chip_ids) {
             auto fabric_node_id = FabricNodeId(mesh_id, static_cast<std::uint32_t>(chip_id));
             const auto& z_direction_chans =
-                control_plane->get_active_fabric_eth_channels_in_direction(fabric_node_id, RoutingDirection::Z);
+                control_plane.get_active_fabric_eth_channels_in_direction(fabric_node_id, RoutingDirection::Z);
             z_channel_count += z_direction_chans.size();
 
             // Verify that get_eth_chan_direction returns INVALID_DIRECTION for Z channels
@@ -1005,7 +1031,7 @@ TEST(MultiHost, T3K2x2AssignZDirectionFabric2DSanity) {
                 bool is_valid_chan = (chan == 0 || chan == 1 || chan == 6 || chan == 7);
                 EXPECT_TRUE(is_valid_chan) << "Unexpected Z direction channel: " << chan;
                 EXPECT_EQ(
-                    control_plane->get_eth_chan_direction(fabric_node_id, chan),
+                    control_plane.get_eth_chan_direction(fabric_node_id, chan),
                     static_cast<eth_chan_directions>(eth_chan_directions::Z));
             }
         }
@@ -1030,41 +1056,41 @@ TEST(MultiHost, TestBHBlitzPipelineControlPlaneInit) {
 }
 
 TEST(MultiHost, TestBHBlitzPipelineFabric2DSanity) {
-    auto control_plane = make_control_plane(
-        std::filesystem::path(),
-        tt::tt_fabric::FabricConfig::FABRIC_2D,
-        tt::tt_fabric::FabricReliabilityMode::RELAXED_SYSTEM_HEALTH_SETUP_MODE);
+    tt::tt_metal::MetalContext::instance().set_fabric_config(
+        tt::tt_fabric::FabricConfig::FABRIC_2D, tt::tt_fabric::FabricReliabilityMode::RELAXED_SYSTEM_HEALTH_SETUP_MODE);
+    tt::tt_metal::MetalContext::instance().initialize_fabric_config();
 
     // Validate control plane apis
-    const auto& intermesh_connections = get_all_intermesh_connections(*control_plane);
+    auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
+    const auto& intermesh_connections = get_all_intermesh_connections(control_plane);
     EXPECT_GT(intermesh_connections.size(), 0);
     for (const auto& [src_node_id, dst_node_id] : intermesh_connections) {
-        const auto& direction = control_plane->get_forwarding_direction(src_node_id, dst_node_id);
+        const auto& direction = control_plane.get_forwarding_direction(src_node_id, dst_node_id);
         EXPECT_TRUE(direction.has_value());
         const auto& eth_chans_by_direction =
-            control_plane->get_forwarding_eth_chans_to_chip(src_node_id, dst_node_id, *direction);
+            control_plane.get_forwarding_eth_chans_to_chip(src_node_id, dst_node_id, *direction);
         EXPECT_TRUE(!eth_chans_by_direction.empty());
-        const auto& eth_chans = control_plane->get_forwarding_eth_chans_to_chip(src_node_id, dst_node_id);
+        const auto& eth_chans = control_plane.get_forwarding_eth_chans_to_chip(src_node_id, dst_node_id);
         EXPECT_TRUE(!eth_chans.empty());
     }
 }
 
 TEST(MultiHost, TestBHBlitzPipelineFabric1DSanity) {
-    auto control_plane = make_control_plane(
-        std::filesystem::path(),
-        tt::tt_fabric::FabricConfig::FABRIC_1D,
-        tt::tt_fabric::FabricReliabilityMode::RELAXED_SYSTEM_HEALTH_SETUP_MODE);
+    tt::tt_metal::MetalContext::instance().set_fabric_config(
+        tt::tt_fabric::FabricConfig::FABRIC_1D, tt::tt_fabric::FabricReliabilityMode::RELAXED_SYSTEM_HEALTH_SETUP_MODE);
+    tt::tt_metal::MetalContext::instance().initialize_fabric_config();
 
     // Validate control plane apis
-    const auto& intermesh_connections = get_all_intermesh_connections(*control_plane);
+    auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
+    const auto& intermesh_connections = get_all_intermesh_connections(control_plane);
     EXPECT_GT(intermesh_connections.size(), 0);
     for (const auto& [src_node_id, dst_node_id] : intermesh_connections) {
-        const auto& direction = control_plane->get_forwarding_direction(src_node_id, dst_node_id);
+        const auto& direction = control_plane.get_forwarding_direction(src_node_id, dst_node_id);
         EXPECT_TRUE(direction.has_value());
         const auto& eth_chans_by_direction =
-            control_plane->get_forwarding_eth_chans_to_chip(src_node_id, dst_node_id, *direction);
+            control_plane.get_forwarding_eth_chans_to_chip(src_node_id, dst_node_id, *direction);
         EXPECT_TRUE(!eth_chans_by_direction.empty());
-        const auto& eth_chans = control_plane->get_forwarding_eth_chans_to_chip(src_node_id, dst_node_id);
+        const auto& eth_chans = control_plane.get_forwarding_eth_chans_to_chip(src_node_id, dst_node_id);
         EXPECT_TRUE(!eth_chans.empty());
     }
 }
@@ -1083,41 +1109,43 @@ TEST(MultiHost, TestTriplePod16x8QuadBHGalaxyControlPlaneInit) {
 }
 
 TEST(MultiHost, TestTriplePod16x8QuadBHGalaxyFabric2DSanity) {
-    auto control_plane = make_control_plane(
-        std::filesystem::path(),
+    tt::tt_metal::MetalContext::instance().set_fabric_config(
         tt::tt_fabric::FabricConfig::FABRIC_2D_TORUS_XY,
         tt::tt_fabric::FabricReliabilityMode::RELAXED_SYSTEM_HEALTH_SETUP_MODE);
+    tt::tt_metal::MetalContext::instance().initialize_fabric_config();
 
     // Validate control plane apis
-    const auto& intermesh_connections = get_all_intermesh_connections(*control_plane);
+    auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
+    const auto& intermesh_connections = get_all_intermesh_connections(control_plane);
     EXPECT_GT(intermesh_connections.size(), 0);
     for (const auto& [src_node_id, dst_node_id] : intermesh_connections) {
-        const auto& direction = control_plane->get_forwarding_direction(src_node_id, dst_node_id);
+        const auto& direction = control_plane.get_forwarding_direction(src_node_id, dst_node_id);
         EXPECT_TRUE(direction.has_value());
         const auto& eth_chans_by_direction =
-            control_plane->get_forwarding_eth_chans_to_chip(src_node_id, dst_node_id, *direction);
+            control_plane.get_forwarding_eth_chans_to_chip(src_node_id, dst_node_id, *direction);
         EXPECT_TRUE(!eth_chans_by_direction.empty());
-        const auto& eth_chans = control_plane->get_forwarding_eth_chans_to_chip(src_node_id, dst_node_id);
+        const auto& eth_chans = control_plane.get_forwarding_eth_chans_to_chip(src_node_id, dst_node_id);
         EXPECT_TRUE(!eth_chans.empty());
     }
 }
 
 TEST(MultiHost, TestTriplePod16x8QuadBHGalaxyFabric1DSanity) {
-    auto control_plane = make_control_plane(
-        std::filesystem::path(),
+    tt::tt_metal::MetalContext::instance().set_fabric_config(
         tt::tt_fabric::FabricConfig::FABRIC_1D_RING,
         tt::tt_fabric::FabricReliabilityMode::RELAXED_SYSTEM_HEALTH_SETUP_MODE);
+    tt::tt_metal::MetalContext::instance().initialize_fabric_config();
 
     // Validate control plane apis
-    const auto& intermesh_connections = get_all_intermesh_connections(*control_plane);
+    auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
+    const auto& intermesh_connections = get_all_intermesh_connections(control_plane);
     EXPECT_GT(intermesh_connections.size(), 0);
     for (const auto& [src_node_id, dst_node_id] : intermesh_connections) {
-        const auto& direction = control_plane->get_forwarding_direction(src_node_id, dst_node_id);
+        const auto& direction = control_plane.get_forwarding_direction(src_node_id, dst_node_id);
         EXPECT_TRUE(direction.has_value());
         const auto& eth_chans_by_direction =
-            control_plane->get_forwarding_eth_chans_to_chip(src_node_id, dst_node_id, *direction);
+            control_plane.get_forwarding_eth_chans_to_chip(src_node_id, dst_node_id, *direction);
         EXPECT_TRUE(!eth_chans_by_direction.empty());
-        const auto& eth_chans = control_plane->get_forwarding_eth_chans_to_chip(src_node_id, dst_node_id);
+        const auto& eth_chans = control_plane.get_forwarding_eth_chans_to_chip(src_node_id, dst_node_id);
         EXPECT_TRUE(!eth_chans.empty());
     }
 }

--- a/tests/tt_metal/tt_fabric/fabric_router/test_routing_tables.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_router/test_routing_tables.cpp
@@ -62,7 +62,16 @@ std::unique_ptr<tt::tt_fabric::ControlPlane> make_control_plane(
     return control_plane;
 }
 
-constexpr auto kFabricConfig1D = tt::tt_fabric::FabricConfig::FABRIC_1D_RING;
+tt::tt_fabric::MeshGraph make_mesh_graph(const std::filesystem::path& mesh_graph_desc_file) {
+    const tt::Cluster& cluster = tt::tt_metal::MetalContext::instance().get_cluster();
+    return tt::tt_fabric::MeshGraph(cluster, mesh_graph_desc_file.string());
+}
+
+tt::tt_fabric::MeshGraph make_mesh_graph(
+    const std::filesystem::path& mesh_graph_desc_file, tt::tt_fabric::FabricConfig fabric_config) {
+    const tt::Cluster& cluster = tt::tt_metal::MetalContext::instance().get_cluster();
+    return tt::tt_fabric::MeshGraph(cluster, mesh_graph_desc_file.string(), fabric_config);
+}
 
 // Helper struct to keep dependencies alive for RoutingTableGenerator tests
 struct RoutingTableGeneratorTestHelper {
@@ -72,8 +81,8 @@ struct RoutingTableGeneratorTestHelper {
     std::unique_ptr<tt::tt_fabric::RoutingTableGenerator> routing_table_generator;
 
     RoutingTableGeneratorTestHelper(const std::string& mesh_graph_desc_file) {
-        mesh_graph = std::make_unique<tt::tt_fabric::MeshGraph>(mesh_graph_desc_file);
-        const auto& cluster = tt::tt_metal::MetalContext::instance().get_cluster();
+        const tt::Cluster& cluster = tt::tt_metal::MetalContext::instance().get_cluster();
+        mesh_graph = std::make_unique<tt::tt_fabric::MeshGraph>(cluster, mesh_graph_desc_file);
         const auto& driver = cluster.get_driver();
         const auto& distributed_context = tt::tt_metal::distributed::multihost::DistributedContext::get_current_world();
         const auto& rtoptions = tt::tt_metal::MetalContext::instance().rtoptions();
@@ -96,7 +105,21 @@ std::unique_ptr<RoutingTableGeneratorTestHelper> make_routing_table_generator(co
     return std::make_unique<RoutingTableGeneratorTestHelper>(mesh_graph_desc_file);
 }
 
+std::unique_ptr<tt::tt_fabric::ControlPlane> make_control_plane_1d_ring(const std::filesystem::path& graph_desc) {
+    constexpr auto kFabricConfig1D = tt::tt_fabric::FabricConfig::FABRIC_1D_RING;
+    auto& cluster = tt::tt_metal::MetalContext::instance().get_cluster();
+    auto& rtoptions = tt::tt_metal::MetalContext::instance().rtoptions();
+    const auto& hal = tt::tt_metal::MetalContext::instance().hal();
+    const auto& distributed_context = tt::tt_metal::MetalContext::instance().full_world_distributed_context();
+    auto control_plane = std::make_unique<tt::tt_fabric::ControlPlane>(
+        cluster, rtoptions, hal, distributed_context, graph_desc.string(), kFabricConfig1D, kReliabilityMode);
+    control_plane->configure_routing_tables_for_fabric_ethernet_channels();
+
+    return control_plane;
+}
+
 std::unique_ptr<tt::tt_fabric::ControlPlane> make_control_plane_1d(const std::filesystem::path& graph_desc) {
+    constexpr auto kFabricConfig1D = tt::tt_fabric::FabricConfig::FABRIC_1D;
     auto& cluster = tt::tt_metal::MetalContext::instance().get_cluster();
     auto& rtoptions = tt::tt_metal::MetalContext::instance().rtoptions();
     const auto& hal = tt::tt_metal::MetalContext::instance().hal();
@@ -123,7 +146,7 @@ TEST(MeshGraphValidation, TestMGDConnections) {
     const std::filesystem::path test_desc_path =
         std::filesystem::path(tt::tt_metal::MetalContext::instance().rtoptions().get_root_dir()) /
         "tests/tt_metal/tt_fabric/custom_mesh_descriptors/mgd_test_connections.textproto";
-    MeshGraph mesh_graph(test_desc_path.string());
+    auto mesh_graph = make_mesh_graph(test_desc_path);
 
     auto connections = mesh_graph.get_requested_intermesh_connections();
     EXPECT_EQ(connections[0][1], 5); // 2 (relaxed) + 3 (mixed, treated as relaxed)
@@ -190,7 +213,7 @@ TEST(MeshGraphValidation, TestT3kMeshGraphInit) {
     const std::filesystem::path t3k_mesh_graph_desc_path =
         std::filesystem::path(tt::tt_metal::MetalContext::instance().rtoptions().get_root_dir()) /
         "tt_metal/fabric/mesh_graph_descriptors/t3k_mesh_graph_descriptor.textproto";
-    MeshGraph mesh_graph_desc(t3k_mesh_graph_desc_path.string());
+    auto mesh_graph_desc = make_mesh_graph(t3k_mesh_graph_desc_path);
     EXPECT_EQ(
         mesh_graph_desc.get_coord_range(MeshId{0}, MeshHostRankId(0)),
         MeshCoordinateRange(MeshCoordinate(0, 0), MeshCoordinate(1, 3)));
@@ -246,7 +269,7 @@ TEST_F(ControlPlaneFixture, TestT3k1x8FabricRoutes) {
     const std::filesystem::path t3k_mesh_graph_desc_path =
         std::filesystem::path(tt::tt_metal::MetalContext::instance().rtoptions().get_root_dir()) /
         "tests/tt_metal/tt_fabric/custom_mesh_descriptors/t3k_1x8_mesh_graph_descriptor.textproto";
-    auto control_plane = make_control_plane_1d(t3k_mesh_graph_desc_path);
+    auto control_plane = make_control_plane_1d_ring(t3k_mesh_graph_desc_path);
 
     auto valid_chans = control_plane->get_valid_eth_chans_on_routing_plane(FabricNodeId(MeshId{0}, 0), 0);
     EXPECT_GT(valid_chans.size(), 0);
@@ -276,7 +299,7 @@ TEST_F(ControlPlaneFixture, TestSingleGalaxy1x32ControlPlaneInit) {
         "tests/tt_metal/tt_fabric/custom_mesh_descriptors/galaxy_1x32_mesh_graph_descriptor.textproto";
     auto control_plane = make_control_plane_1d(galaxy_6u_mesh_graph_desc_path);
 
-    check_asic_mapping_against_golden("TestSingleGalaxy1x32ControlPlaneInit", "ControlPlaneFixture_SingleGalaxy");
+    check_asic_mapping_against_golden("TestSingleGalaxy1x32ControlPlaneInit", "ControlPlaneFixture_SingleGalaxy_1x32");
 }
 
 TEST_F(ControlPlaneFixture, TestSingleGalaxy1x32FabricRoutes) {
@@ -361,7 +384,7 @@ TEST_P(T3kCustomMeshGraphControlPlaneFixture, TestT3kMeshGraphInit) {
     auto [mesh_graph_desc_path, _] = GetParam();
     const std::filesystem::path t3k_mesh_graph_desc_path =
         std::filesystem::path(tt::tt_metal::MetalContext::instance().rtoptions().get_root_dir()) / mesh_graph_desc_path;
-    MeshGraph mesh_graph_desc(t3k_mesh_graph_desc_path.string());
+    auto mesh_graph_desc = make_mesh_graph(t3k_mesh_graph_desc_path);
 }
 
 TEST_P(T3kCustomMeshGraphControlPlaneFixture, TestT3kControlPlaneInit) {
@@ -567,7 +590,7 @@ TEST(MeshGraphValidation, TestT3kDualHostMeshGraph) {
     const std::filesystem::path t3k_dual_host_mesh_graph_desc_path =
         std::filesystem::path(tt::tt_metal::MetalContext::instance().rtoptions().get_root_dir()) /
         "tests/tt_metal/tt_fabric/custom_mesh_descriptors/t3k_dual_host_mesh_graph_descriptor.textproto";
-    tt_fabric::MeshGraph mesh_graph(t3k_dual_host_mesh_graph_desc_path.string());
+    auto mesh_graph = make_mesh_graph(t3k_dual_host_mesh_graph_desc_path);
 
     EXPECT_THAT(mesh_graph.get_mesh_ids(), ElementsAre(MeshId{0}));
 
@@ -604,7 +627,7 @@ TEST(MeshGraphValidation, TestT3k2x2MeshGraph) {
     const std::filesystem::path t3k_2x2_mesh_graph_desc_path =
         std::filesystem::path(tt::tt_metal::MetalContext::instance().rtoptions().get_root_dir()) /
         "tests/tt_metal/tt_fabric/custom_mesh_descriptors/t3k_2x2_mesh_graph_descriptor.textproto";
-    tt_fabric::MeshGraph mesh_graph(t3k_2x2_mesh_graph_desc_path.string());
+    auto mesh_graph = make_mesh_graph(t3k_2x2_mesh_graph_desc_path);
 
     // This configuration has two meshes (id 0 and id 1)
     EXPECT_THAT(mesh_graph.get_mesh_ids(), ElementsAre(MeshId{0}, MeshId{1}));
@@ -661,7 +684,7 @@ TEST(MeshGraphValidation, TestGetHostRankForChip) {
     const std::filesystem::path t3k_dual_host_mesh_graph_desc_path =
         std::filesystem::path(tt::tt_metal::MetalContext::instance().rtoptions().get_root_dir()) /
         "tests/tt_metal/tt_fabric/custom_mesh_descriptors/t3k_dual_host_mesh_graph_descriptor.textproto";
-    tt_fabric::MeshGraph mesh_graph(t3k_dual_host_mesh_graph_desc_path.string());
+    auto mesh_graph = make_mesh_graph(t3k_dual_host_mesh_graph_desc_path);
 
     // Test valid chips for mesh 0
     // Based on the dual host configuration:
@@ -688,7 +711,7 @@ TEST(MeshGraphValidation, TestGetHostRankForChip) {
     const std::filesystem::path t3k_mesh_graph_desc_path =
         std::filesystem::path(tt::tt_metal::MetalContext::instance().rtoptions().get_root_dir()) /
         "tt_metal/fabric/mesh_graph_descriptors/t3k_mesh_graph_descriptor.textproto";
-    tt_fabric::MeshGraph mesh_graph_single_host(t3k_mesh_graph_desc_path.string());
+    auto mesh_graph_single_host = make_mesh_graph(t3k_mesh_graph_desc_path);
 
     // In single host configuration, all chips should belong to host rank 0
     for (ChipId chip_id = 0; chip_id < 8; chip_id++) {
@@ -699,7 +722,7 @@ TEST(MeshGraphValidation, TestGetHostRankForChip) {
     const std::filesystem::path t3k_2x2_mesh_graph_desc_path =
         std::filesystem::path(tt::tt_metal::MetalContext::instance().rtoptions().get_root_dir()) /
         "tests/tt_metal/tt_fabric/custom_mesh_descriptors/t3k_2x2_mesh_graph_descriptor.textproto";
-    tt_fabric::MeshGraph mesh_graph_2x2(t3k_2x2_mesh_graph_desc_path.string());
+    auto mesh_graph_2x2 = make_mesh_graph(t3k_2x2_mesh_graph_desc_path);
 
     // Each mesh has only one host rank (0)
     for (ChipId chip_id = 0; chip_id < 4; chip_id++) {
@@ -719,7 +742,7 @@ TEST(MeshGraphValidation, TestExplicitShapeValidationNegative) {
         "tests/tt_metal/tt_fabric/custom_mesh_descriptors/t3k_invalid_shape_mesh_graph_descriptor.textproto";
 
     // This should throw an exception due to incompatible shape
-    EXPECT_THROW(tt_fabric::MeshGraph(invalid_shape_mesh_graph_desc_path.string()), std::exception);
+    EXPECT_THROW(make_mesh_graph(invalid_shape_mesh_graph_desc_path), std::exception);
 }
 
 namespace single_galaxy_constants {
@@ -737,7 +760,7 @@ TEST(MeshGraphValidation, TestSingleGalaxyMesh) {
     const std::filesystem::path mesh_graph_desc_path =
         std::filesystem::path(tt::tt_metal::MetalContext::instance().rtoptions().get_root_dir()) /
         "tt_metal/fabric/mesh_graph_descriptors/single_galaxy_mesh_graph_descriptor.textproto";
-    MeshGraph mesh_graph(mesh_graph_desc_path.string());
+    auto mesh_graph = make_mesh_graph(mesh_graph_desc_path);
     const auto& intra_mesh_connectivity = mesh_graph.get_intra_mesh_connectivity();
 
     EXPECT_EQ(intra_mesh_connectivity.size(), 1);
@@ -833,7 +856,7 @@ TEST(MeshGraphValidation, TestSingleGalaxyTorusXY) {
     const std::filesystem::path mesh_graph_desc_path =
         std::filesystem::path(tt::tt_metal::MetalContext::instance().rtoptions().get_root_dir()) /
         "tt_metal/fabric/mesh_graph_descriptors/single_galaxy_torus_xy_graph_descriptor.textproto";
-    MeshGraph mesh_graph(mesh_graph_desc_path.string());
+    auto mesh_graph = make_mesh_graph(mesh_graph_desc_path);
     const auto& intra_mesh_connectivity = mesh_graph.get_intra_mesh_connectivity();
 
     EXPECT_EQ(intra_mesh_connectivity.size(), 1);
@@ -907,7 +930,7 @@ TEST(MeshGraphValidation, TestSingleGalaxyTorusX) {
     const std::filesystem::path mesh_graph_desc_path =
         std::filesystem::path(tt::tt_metal::MetalContext::instance().rtoptions().get_root_dir()) /
         "tt_metal/fabric/mesh_graph_descriptors/single_galaxy_torus_x_graph_descriptor.textproto";
-    MeshGraph mesh_graph(mesh_graph_desc_path.string());
+    auto mesh_graph = make_mesh_graph(mesh_graph_desc_path);
     const auto& intra_mesh_connectivity = mesh_graph.get_intra_mesh_connectivity();
 
     EXPECT_EQ(intra_mesh_connectivity.size(), 1);
@@ -993,7 +1016,7 @@ TEST(MeshGraphValidation, TestSingleGalaxyTorusY) {
     const std::filesystem::path mesh_graph_desc_path =
         std::filesystem::path(tt::tt_metal::MetalContext::instance().rtoptions().get_root_dir()) /
         "tt_metal/fabric/mesh_graph_descriptors/single_galaxy_torus_y_graph_descriptor.textproto";
-    MeshGraph mesh_graph(mesh_graph_desc_path.string());
+    auto mesh_graph = make_mesh_graph(mesh_graph_desc_path);
     const auto& intra_mesh_connectivity = mesh_graph.get_intra_mesh_connectivity();
 
     EXPECT_EQ(intra_mesh_connectivity.size(), 1);
@@ -1079,7 +1102,7 @@ TEST(MeshGraphValidation, TestDualGalaxyMeshGraph) {
     const std::filesystem::path mesh_graph_desc_path =
         std::filesystem::path(tt::tt_metal::MetalContext::instance().rtoptions().get_root_dir()) /
         "tt_metal/fabric/mesh_graph_descriptors/dual_galaxy_mesh_graph_descriptor.textproto";
-    MeshGraph mesh_graph_desc(mesh_graph_desc_path.string());
+    auto mesh_graph_desc = make_mesh_graph(mesh_graph_desc_path);
     EXPECT_EQ(
         mesh_graph_desc.get_coord_range(MeshId{0}, MeshHostRankId(0)),
         MeshCoordinateRange(MeshCoordinate(0, 0), MeshCoordinate(7, 3)));
@@ -1092,7 +1115,7 @@ TEST(MeshGraphValidation, TestSingleGalaxy1x32MeshGraph) {
     const std::filesystem::path galaxy_6u_mesh_graph_desc_path =
         std::filesystem::path(tt::tt_metal::MetalContext::instance().rtoptions().get_root_dir()) /
         "tests/tt_metal/tt_fabric/custom_mesh_descriptors/galaxy_1x32_mesh_graph_descriptor.textproto";
-    MeshGraph mesh_graph_desc(galaxy_6u_mesh_graph_desc_path.string());
+    auto mesh_graph_desc = make_mesh_graph(galaxy_6u_mesh_graph_desc_path);
 
     // Verify the mesh has correct topology for 1x32 Galaxy configuration
     EXPECT_EQ(
@@ -1112,7 +1135,7 @@ TEST(MeshGraphValidation, TestP150BlackHoleMeshGraph) {
     const std::filesystem::path p150_mesh_graph_desc_path =
         std::filesystem::path(tt::tt_metal::MetalContext::instance().rtoptions().get_root_dir()) /
         "tt_metal/fabric/mesh_graph_descriptors/p150_mesh_graph_descriptor.textproto";
-    MeshGraph mesh_graph(p150_mesh_graph_desc_path.string());
+    auto mesh_graph = make_mesh_graph(p150_mesh_graph_desc_path);
 
     EXPECT_THAT(mesh_graph.get_mesh_ids(), ElementsAre(MeshId{0}));
     EXPECT_EQ(mesh_graph.get_mesh_shape(MeshId{0}), MeshShape(1, 1));
@@ -1133,7 +1156,7 @@ TEST(MeshGraphValidation, TestP100BlackHoleMeshGraph) {
     const std::filesystem::path p100_mesh_graph_desc_path =
         std::filesystem::path(tt::tt_metal::MetalContext::instance().rtoptions().get_root_dir()) /
         "tt_metal/fabric/mesh_graph_descriptors/p100_mesh_graph_descriptor.textproto";
-    MeshGraph mesh_graph(p100_mesh_graph_desc_path.string());
+    auto mesh_graph = make_mesh_graph(p100_mesh_graph_desc_path);
 
     EXPECT_THAT(mesh_graph.get_mesh_ids(), ElementsAre(MeshId{0}));
     EXPECT_EQ(mesh_graph.get_mesh_shape(MeshId{0}), MeshShape(1, 1));
@@ -1154,7 +1177,7 @@ TEST(MeshGraphValidation, TestP150X8BlackHoleMeshGraph) {
     const std::filesystem::path p150_x8_mesh_graph_desc_path =
         std::filesystem::path(tt::tt_metal::MetalContext::instance().rtoptions().get_root_dir()) /
         "tt_metal/fabric/mesh_graph_descriptors/p150_x8_mesh_graph_descriptor.textproto";
-    MeshGraph mesh_graph(p150_x8_mesh_graph_desc_path.string());
+    auto mesh_graph = make_mesh_graph(p150_x8_mesh_graph_desc_path);
 
     EXPECT_THAT(mesh_graph.get_mesh_ids(), ElementsAre(MeshId{0}));
     EXPECT_EQ(mesh_graph.get_mesh_shape(MeshId{0}), MeshShape(2, 4));
@@ -1198,7 +1221,7 @@ TEST(MeshGraphValidation, TestFabricConfigOverrideTorusToMesh) {
 
     // Test 1: Without FabricConfig - should respect dim_types (RING = torus with wrap-around)
     {
-        MeshGraph mesh_graph_no_override(torus_mgd_path.string());
+        auto mesh_graph_no_override = make_mesh_graph(torus_mgd_path);
         const auto& connectivity = mesh_graph_no_override.get_intra_mesh_connectivity();
 
         // In torus, NW corner (chip 0) should have wrap-around connections
@@ -1211,7 +1234,7 @@ TEST(MeshGraphValidation, TestFabricConfigOverrideTorusToMesh) {
 
     // Test 2: With FabricConfig=FABRIC_2D - should restrict to mesh (ignore wrap-around links)
     {
-        MeshGraph mesh_graph_override(torus_mgd_path.string(), tt::tt_fabric::FabricConfig::FABRIC_2D);
+        auto mesh_graph_override = make_mesh_graph(torus_mgd_path, tt::tt_fabric::FabricConfig::FABRIC_2D);
         const auto& connectivity = mesh_graph_override.get_intra_mesh_connectivity();
 
         // In mesh mode, NW corner should only have E and S connections (ignore wrap-around)
@@ -1231,7 +1254,7 @@ TEST(MeshGraphValidation, TestFabricConfigInvalidMeshToTorus) {
 
     // Attempting to override mesh to torus should throw - cannot create connections that don't exist
     EXPECT_THROW(
-        { MeshGraph mesh_graph_invalid(mesh_mgd_path.string(), tt::tt_fabric::FabricConfig::FABRIC_2D_TORUS_XY); },
+        { auto mesh_graph_invalid = make_mesh_graph(mesh_mgd_path, tt::tt_fabric::FabricConfig::FABRIC_2D_TORUS_XY); },
         std::runtime_error);
 }
 

--- a/tests/tt_metal/tt_fabric/fabric_router/test_topology_mapper.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_router/test_topology_mapper.cpp
@@ -52,7 +52,7 @@ TEST_F(TopologyMapperTest, T3kMeshGraphTest) {
         std::filesystem::path(tt::tt_metal::MetalContext::instance().rtoptions().get_root_dir()) /
         "tt_metal/fabric/mesh_graph_descriptors/t3k_mesh_graph_descriptor.textproto";
 
-    auto mesh_graph = MeshGraph(get_cluster(), t3k_mesh_graph_desc_path.string());
+    auto mesh_graph = MeshGraph(tt::tt_metal::ClusterType::T3K, t3k_mesh_graph_desc_path.string());
 
     // Create a local mesh binding for testing
     LocalMeshBinding local_mesh_binding;
@@ -107,7 +107,7 @@ TEST_F(TopologyMapperTest, DualGalaxyBigMeshTest) {
         std::filesystem::path(tt::tt_metal::MetalContext::instance().rtoptions().get_root_dir()) /
         "tt_metal/fabric/mesh_graph_descriptors/dual_galaxy_mesh_graph_descriptor.textproto";
 
-    auto mesh_graph = MeshGraph(get_cluster(), dual_galaxy_big_mesh_graph_desc_path.string());
+    auto mesh_graph = MeshGraph(tt::tt_metal::ClusterType::GALAXY, dual_galaxy_big_mesh_graph_desc_path.string());
 
     // Create a local mesh binding for testing
     LocalMeshBinding local_mesh_binding;
@@ -170,7 +170,7 @@ TEST_F(TopologyMapperTest, N300MeshGraphTest) {
         std::filesystem::path(tt::tt_metal::MetalContext::instance().rtoptions().get_root_dir()) /
         "tt_metal/fabric/mesh_graph_descriptors/n300_mesh_graph_descriptor.textproto";
 
-    auto mesh_graph = MeshGraph(get_cluster(), n300_mesh_graph_desc_path.string());
+    auto mesh_graph = MeshGraph(tt::tt_metal::ClusterType::N300, n300_mesh_graph_desc_path.string());
 
     // Create a local mesh binding for testing
     LocalMeshBinding local_mesh_binding;
@@ -211,7 +211,7 @@ TEST_F(TopologyMapperTest, P100MeshGraphTest) {
         std::filesystem::path(tt::tt_metal::MetalContext::instance().rtoptions().get_root_dir()) /
         "tt_metal/fabric/mesh_graph_descriptors/p100_mesh_graph_descriptor.textproto";
 
-    auto mesh_graph = MeshGraph(get_cluster(), p100_mesh_graph_desc_path.string());
+    auto mesh_graph = MeshGraph(tt::tt_metal::ClusterType::P100, p100_mesh_graph_desc_path.string());
 
     // Create a local mesh binding for testing
     LocalMeshBinding local_mesh_binding;
@@ -256,7 +256,7 @@ TEST_F(TopologyMapperTest, BHQB4x4MeshGraphTest) {
         std::filesystem::path(tt::tt_metal::MetalContext::instance().rtoptions().get_root_dir()) /
         "tt_metal/fabric/mesh_graph_descriptors/bh_qb_4x4_mesh_graph_descriptor.textproto";
 
-    auto mesh_graph = MeshGraph(get_cluster(), bh_qb_4x4_mesh_graph_desc_path.string());
+    auto mesh_graph = MeshGraph(tt::tt_metal::ClusterType::BLACKHOLE_GALAXY, bh_qb_4x4_mesh_graph_desc_path.string());
 
     // Create a local mesh binding for testing
     LocalMeshBinding local_mesh_binding;
@@ -343,7 +343,8 @@ TEST_F(TopologyMapperTest, BHQB4x4StrictReducedMeshGraphTest) {
         std::filesystem::path(tt::tt_metal::MetalContext::instance().rtoptions().get_root_dir()) /
         "tests/tt_metal/tt_fabric/custom_mesh_descriptors/bh_qb_4x4_strict_reduced_mesh_graph_descriptor.textproto";
 
-    auto mesh_graph = MeshGraph(get_cluster(), bh_qb_4x4_strict_mesh_graph_desc_path.string());
+    auto mesh_graph =
+        MeshGraph(tt::tt_metal::ClusterType::BLACKHOLE_GALAXY, bh_qb_4x4_strict_mesh_graph_desc_path.string());
 
     // Create a local mesh binding for testing
     LocalMeshBinding local_mesh_binding;
@@ -406,7 +407,8 @@ TEST_F(TopologyMapperTest, BHQB4x4RelaxedMeshGraphTest) {
         std::filesystem::path(tt::tt_metal::MetalContext::instance().rtoptions().get_root_dir()) /
         "tests/tt_metal/tt_fabric/custom_mesh_descriptors/bh_qb_4x4_relaxed_mesh_graph_descriptor.textproto";
 
-    auto mesh_graph = MeshGraph(get_cluster(), bh_qb_4x4_relaxed_mesh_graph_desc_path.string());
+    auto mesh_graph =
+        MeshGraph(tt::tt_metal::ClusterType::BLACKHOLE_GALAXY, bh_qb_4x4_relaxed_mesh_graph_desc_path.string());
 
     // Create a local mesh binding for testing
     LocalMeshBinding local_mesh_binding;
@@ -469,7 +471,8 @@ TEST_F(TopologyMapperTest, BHQB4x4StrictInvalidMeshGraphTest) {
         std::filesystem::path(tt::tt_metal::MetalContext::instance().rtoptions().get_root_dir()) /
         "tests/tt_metal/tt_fabric/custom_mesh_descriptors/bh_qb_4x4_strict_invalid_mesh_graph_descriptor.textproto";
 
-    auto mesh_graph = MeshGraph(get_cluster(), bh_qb_4x4_strict_invalid_mesh_graph_desc_path.string());
+    auto mesh_graph =
+        MeshGraph(tt::tt_metal::ClusterType::BLACKHOLE_GALAXY, bh_qb_4x4_strict_invalid_mesh_graph_desc_path.string());
 
     // Create a local mesh binding for testing
     LocalMeshBinding local_mesh_binding;
@@ -517,7 +520,7 @@ TEST_F(TopologyMapperTest, ClosetBox3PodTTSwitchHostnameAPIs) {
         std::filesystem::path(tt::tt_metal::MetalContext::instance().rtoptions().get_root_dir()) /
         "tests/tt_metal/tt_fabric/custom_mesh_descriptors/wh_closetbox_3pod_ttswitch_mgd.textproto";
 
-    auto mesh_graph = MeshGraph(get_cluster(), mesh_graph_desc_path.string());
+    auto mesh_graph = MeshGraph(tt::tt_metal::ClusterType::GALAXY, mesh_graph_desc_path.string());
 
     // Create local mesh binding (for testing, bind all meshes including switch)
     LocalMeshBinding local_mesh_binding;
@@ -646,7 +649,7 @@ TEST_F(TopologyMapperTest, PinningHonorsFixedAsicPositionOnDualGalaxyMesh_1pin) 
         std::filesystem::path(tt::tt_metal::MetalContext::instance().rtoptions().get_root_dir()) /
         "tt_metal/fabric/mesh_graph_descriptors/dual_galaxy_mesh_graph_descriptor.textproto";
 
-    auto mesh_graph = MeshGraph(get_cluster(), galaxy_mesh_graph_desc_path.string());
+    auto mesh_graph = MeshGraph(tt::tt_metal::ClusterType::GALAXY, galaxy_mesh_graph_desc_path.string());
 
     // Local mesh binding for single-host
     LocalMeshBinding local_mesh_binding;
@@ -777,7 +780,7 @@ TEST_P(T3kTopologyMapperWithCustomMappingFixture, T3kMeshGraphWithCustomMapping)
     const std::filesystem::path t3k_mesh_graph_desc_path =
         std::filesystem::path(tt::tt_metal::MetalContext::instance().rtoptions().get_root_dir()) / mesh_graph_desc_path;
 
-    auto mesh_graph = MeshGraph(get_cluster(), t3k_mesh_graph_desc_path.string());
+    auto mesh_graph = MeshGraph(tt::tt_metal::ClusterType::T3K, t3k_mesh_graph_desc_path.string());
 
     // Create logical to physical chip mapping from eth_coords
     auto logical_mesh_chip_id_to_physical_chip_id_mapping =

--- a/tests/tt_metal/tt_fabric/fabric_router/test_topology_mapper.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_router/test_topology_mapper.cpp
@@ -35,6 +35,12 @@ protected:
     void TearDown() override { physical_system_descriptor_.reset(); }
 
     std::unique_ptr<tt::tt_metal::PhysicalSystemDescriptor> physical_system_descriptor_;
+
+    const tt::Cluster& get_cluster() const { return tt::tt_metal::MetalContext::instance().get_cluster(); }
+
+    const tt::tt_metal::distributed::multihost::DistributedContext& get_distributed_context() const {
+        return tt::tt_metal::MetalContext::instance().global_distributed_context();
+    }
 };
 
 bool contains(const std::vector<tt::tt_metal::AsicID>& asic_ids, const tt::tt_metal::AsicID& asic_id) {
@@ -46,7 +52,7 @@ TEST_F(TopologyMapperTest, T3kMeshGraphTest) {
         std::filesystem::path(tt::tt_metal::MetalContext::instance().rtoptions().get_root_dir()) /
         "tt_metal/fabric/mesh_graph_descriptors/t3k_mesh_graph_descriptor.textproto";
 
-    auto mesh_graph = MeshGraph(t3k_mesh_graph_desc_path.string());
+    auto mesh_graph = MeshGraph(get_cluster(), t3k_mesh_graph_desc_path.string());
 
     // Create a local mesh binding for testing
     LocalMeshBinding local_mesh_binding;
@@ -55,7 +61,8 @@ TEST_F(TopologyMapperTest, T3kMeshGraphTest) {
 
     // Test that TopologyMapper can be constructed with valid parameters
     // This is a basic smoke test
-    auto topology_mapper = TopologyMapper(mesh_graph, *physical_system_descriptor_, local_mesh_binding);
+    auto topology_mapper = TopologyMapper(
+        get_cluster(), get_distributed_context(), mesh_graph, *physical_system_descriptor_, local_mesh_binding);
 
     // Fabric Node ID layout:
     // 0 1 2 3
@@ -100,11 +107,11 @@ TEST_F(TopologyMapperTest, DualGalaxyBigMeshTest) {
         std::filesystem::path(tt::tt_metal::MetalContext::instance().rtoptions().get_root_dir()) /
         "tt_metal/fabric/mesh_graph_descriptors/dual_galaxy_mesh_graph_descriptor.textproto";
 
-    auto mesh_graph = MeshGraph(dual_galaxy_big_mesh_graph_desc_path.string());
+    auto mesh_graph = MeshGraph(get_cluster(), dual_galaxy_big_mesh_graph_desc_path.string());
 
     // Create a local mesh binding for testing
     LocalMeshBinding local_mesh_binding;
-    if (*tt::tt_metal::MetalContext::instance().global_distributed_context().rank() == 0) {
+    if (*get_distributed_context().rank() == 0) {
         local_mesh_binding.mesh_ids = {MeshId{0}};
         local_mesh_binding.host_rank = MeshHostRankId{0};
     } else {
@@ -112,7 +119,8 @@ TEST_F(TopologyMapperTest, DualGalaxyBigMeshTest) {
         local_mesh_binding.host_rank = MeshHostRankId{1};
     }
 
-    auto topology_mapper = TopologyMapper(mesh_graph, *physical_system_descriptor_, local_mesh_binding);
+    auto topology_mapper = TopologyMapper(
+        get_cluster(), get_distributed_context(), mesh_graph, *physical_system_descriptor_, local_mesh_binding);
 
     // Physical System Descriptor: 8x8
     //  0  1  2  3  4  5  6  7
@@ -162,14 +170,15 @@ TEST_F(TopologyMapperTest, N300MeshGraphTest) {
         std::filesystem::path(tt::tt_metal::MetalContext::instance().rtoptions().get_root_dir()) /
         "tt_metal/fabric/mesh_graph_descriptors/n300_mesh_graph_descriptor.textproto";
 
-    auto mesh_graph = MeshGraph(n300_mesh_graph_desc_path.string());
+    auto mesh_graph = MeshGraph(get_cluster(), n300_mesh_graph_desc_path.string());
 
     // Create a local mesh binding for testing
     LocalMeshBinding local_mesh_binding;
     local_mesh_binding.mesh_ids = {MeshId{0}};
     local_mesh_binding.host_rank = MeshHostRankId{0};
 
-    auto topology_mapper = TopologyMapper(mesh_graph, *physical_system_descriptor_, local_mesh_binding);
+    auto topology_mapper = TopologyMapper(
+        get_cluster(), get_distributed_context(), mesh_graph, *physical_system_descriptor_, local_mesh_binding);
 
     // Physical System Descriptor: 1x2
     // 0 1
@@ -202,14 +211,15 @@ TEST_F(TopologyMapperTest, P100MeshGraphTest) {
         std::filesystem::path(tt::tt_metal::MetalContext::instance().rtoptions().get_root_dir()) /
         "tt_metal/fabric/mesh_graph_descriptors/p100_mesh_graph_descriptor.textproto";
 
-    auto mesh_graph = MeshGraph(p100_mesh_graph_desc_path.string());
+    auto mesh_graph = MeshGraph(get_cluster(), p100_mesh_graph_desc_path.string());
 
     // Create a local mesh binding for testing
     LocalMeshBinding local_mesh_binding;
     local_mesh_binding.mesh_ids = {MeshId{0}};
     local_mesh_binding.host_rank = MeshHostRankId{0};
 
-    auto topology_mapper = TopologyMapper(mesh_graph, *physical_system_descriptor_, local_mesh_binding);
+    auto topology_mapper = TopologyMapper(
+        get_cluster(), get_distributed_context(), mesh_graph, *physical_system_descriptor_, local_mesh_binding);
 
     // Single-chip mesh: 1x1 with chip id 0
     const MeshId mesh_id{0};
@@ -246,26 +256,26 @@ TEST_F(TopologyMapperTest, BHQB4x4MeshGraphTest) {
         std::filesystem::path(tt::tt_metal::MetalContext::instance().rtoptions().get_root_dir()) /
         "tt_metal/fabric/mesh_graph_descriptors/bh_qb_4x4_mesh_graph_descriptor.textproto";
 
-    auto mesh_graph = MeshGraph(bh_qb_4x4_mesh_graph_desc_path.string());
+    auto mesh_graph = MeshGraph(get_cluster(), bh_qb_4x4_mesh_graph_desc_path.string());
 
     // Create a local mesh binding for testing
     LocalMeshBinding local_mesh_binding;
-    if (*tt::tt_metal::MetalContext::instance().global_distributed_context().rank() == 0) {
+    if (*get_distributed_context().rank() == 0) {
         local_mesh_binding.mesh_ids = {MeshId{0}};
         local_mesh_binding.host_rank = MeshHostRankId{0};
-    } else if (*tt::tt_metal::MetalContext::instance().global_distributed_context().rank() == 1) {
+    } else if (*get_distributed_context().rank() == 1) {
         local_mesh_binding.mesh_ids = {MeshId{0}};
         local_mesh_binding.host_rank = MeshHostRankId{1};
-    } else if (*tt::tt_metal::MetalContext::instance().global_distributed_context().rank() == 2) {
+    } else if (*get_distributed_context().rank() == 2) {
         local_mesh_binding.mesh_ids = {MeshId{0}};
         local_mesh_binding.host_rank = MeshHostRankId{2};
-    } else if (*tt::tt_metal::MetalContext::instance().global_distributed_context().rank() == 3) {
+    } else if (*get_distributed_context().rank() == 3) {
         local_mesh_binding.mesh_ids = {MeshId{0}};
         local_mesh_binding.host_rank = MeshHostRankId{3};
     }
 
-
-    auto topology_mapper = TopologyMapper(mesh_graph, *physical_system_descriptor_, local_mesh_binding);
+    auto topology_mapper = TopologyMapper(
+        get_cluster(), get_distributed_context(), mesh_graph, *physical_system_descriptor_, local_mesh_binding);
 
     // Physical System Descriptor: 4x4 Blackhole mesh
     // 0  1  | 2  3
@@ -333,25 +343,26 @@ TEST_F(TopologyMapperTest, BHQB4x4StrictReducedMeshGraphTest) {
         std::filesystem::path(tt::tt_metal::MetalContext::instance().rtoptions().get_root_dir()) /
         "tests/tt_metal/tt_fabric/custom_mesh_descriptors/bh_qb_4x4_strict_reduced_mesh_graph_descriptor.textproto";
 
-    auto mesh_graph = MeshGraph(bh_qb_4x4_strict_mesh_graph_desc_path.string());
+    auto mesh_graph = MeshGraph(get_cluster(), bh_qb_4x4_strict_mesh_graph_desc_path.string());
 
     // Create a local mesh binding for testing
     LocalMeshBinding local_mesh_binding;
-    if (*tt::tt_metal::MetalContext::instance().global_distributed_context().rank() == 0) {
+    if (*get_distributed_context().rank() == 0) {
         local_mesh_binding.mesh_ids = {MeshId{0}};
         local_mesh_binding.host_rank = MeshHostRankId{0};
-    } else if (*tt::tt_metal::MetalContext::instance().global_distributed_context().rank() == 1) {
+    } else if (*get_distributed_context().rank() == 1) {
         local_mesh_binding.mesh_ids = {MeshId{0}};
         local_mesh_binding.host_rank = MeshHostRankId{1};
-    } else if (*tt::tt_metal::MetalContext::instance().global_distributed_context().rank() == 2) {
+    } else if (*get_distributed_context().rank() == 2) {
         local_mesh_binding.mesh_ids = {MeshId{0}};
         local_mesh_binding.host_rank = MeshHostRankId{2};
-    } else if (*tt::tt_metal::MetalContext::instance().global_distributed_context().rank() == 3) {
+    } else if (*get_distributed_context().rank() == 3) {
         local_mesh_binding.mesh_ids = {MeshId{0}};
         local_mesh_binding.host_rank = MeshHostRankId{3};
     }
 
-    auto topology_mapper = TopologyMapper(mesh_graph, *physical_system_descriptor_, local_mesh_binding);
+    auto topology_mapper = TopologyMapper(
+        get_cluster(), get_distributed_context(), mesh_graph, *physical_system_descriptor_, local_mesh_binding);
 
     // Physical System Descriptor: 4x4 Blackhole mesh
     // 0  1  | 2  3
@@ -395,25 +406,26 @@ TEST_F(TopologyMapperTest, BHQB4x4RelaxedMeshGraphTest) {
         std::filesystem::path(tt::tt_metal::MetalContext::instance().rtoptions().get_root_dir()) /
         "tests/tt_metal/tt_fabric/custom_mesh_descriptors/bh_qb_4x4_relaxed_mesh_graph_descriptor.textproto";
 
-    auto mesh_graph = MeshGraph(bh_qb_4x4_relaxed_mesh_graph_desc_path.string());
+    auto mesh_graph = MeshGraph(get_cluster(), bh_qb_4x4_relaxed_mesh_graph_desc_path.string());
 
     // Create a local mesh binding for testing
     LocalMeshBinding local_mesh_binding;
-    if (*tt::tt_metal::MetalContext::instance().global_distributed_context().rank() == 0) {
+    if (*get_distributed_context().rank() == 0) {
         local_mesh_binding.mesh_ids = {MeshId{0}};
         local_mesh_binding.host_rank = MeshHostRankId{0};
-    } else if (*tt::tt_metal::MetalContext::instance().global_distributed_context().rank() == 1) {
+    } else if (*get_distributed_context().rank() == 1) {
         local_mesh_binding.mesh_ids = {MeshId{0}};
         local_mesh_binding.host_rank = MeshHostRankId{1};
-    } else if (*tt::tt_metal::MetalContext::instance().global_distributed_context().rank() == 2) {
+    } else if (*get_distributed_context().rank() == 2) {
         local_mesh_binding.mesh_ids = {MeshId{0}};
         local_mesh_binding.host_rank = MeshHostRankId{2};
-    } else if (*tt::tt_metal::MetalContext::instance().global_distributed_context().rank() == 3) {
+    } else if (*get_distributed_context().rank() == 3) {
         local_mesh_binding.mesh_ids = {MeshId{0}};
         local_mesh_binding.host_rank = MeshHostRankId{3};
     }
 
-    auto topology_mapper = TopologyMapper(mesh_graph, *physical_system_descriptor_, local_mesh_binding);
+    auto topology_mapper = TopologyMapper(
+        get_cluster(), get_distributed_context(), mesh_graph, *physical_system_descriptor_, local_mesh_binding);
 
     // Physical System Descriptor: 4x4 Blackhole mesh
     // 0  1  | 2  3
@@ -457,25 +469,28 @@ TEST_F(TopologyMapperTest, BHQB4x4StrictInvalidMeshGraphTest) {
         std::filesystem::path(tt::tt_metal::MetalContext::instance().rtoptions().get_root_dir()) /
         "tests/tt_metal/tt_fabric/custom_mesh_descriptors/bh_qb_4x4_strict_invalid_mesh_graph_descriptor.textproto";
 
-    auto mesh_graph = MeshGraph(bh_qb_4x4_strict_invalid_mesh_graph_desc_path.string());
+    auto mesh_graph = MeshGraph(get_cluster(), bh_qb_4x4_strict_invalid_mesh_graph_desc_path.string());
 
     // Create a local mesh binding for testing
     LocalMeshBinding local_mesh_binding;
-    if (*tt::tt_metal::MetalContext::instance().global_distributed_context().rank() == 0) {
+    if (*get_distributed_context().rank() == 0) {
         local_mesh_binding.mesh_ids = {MeshId{0}};
         local_mesh_binding.host_rank = MeshHostRankId{0};
-    } else if (*tt::tt_metal::MetalContext::instance().global_distributed_context().rank() == 1) {
+    } else if (*get_distributed_context().rank() == 1) {
         local_mesh_binding.mesh_ids = {MeshId{0}};
         local_mesh_binding.host_rank = MeshHostRankId{1};
-    } else if (*tt::tt_metal::MetalContext::instance().global_distributed_context().rank() == 2) {
+    } else if (*get_distributed_context().rank() == 2) {
         local_mesh_binding.mesh_ids = {MeshId{0}};
         local_mesh_binding.host_rank = MeshHostRankId{2};
-    } else if (*tt::tt_metal::MetalContext::instance().global_distributed_context().rank() == 3) {
+    } else if (*get_distributed_context().rank() == 3) {
         local_mesh_binding.mesh_ids = {MeshId{0}};
         local_mesh_binding.host_rank = MeshHostRankId{3};
     }
 
-    EXPECT_THROW(TopologyMapper(mesh_graph, *physical_system_descriptor_, local_mesh_binding), std::exception);
+    EXPECT_THROW(
+        TopologyMapper(
+            get_cluster(), get_distributed_context(), mesh_graph, *physical_system_descriptor_, local_mesh_binding),
+        std::exception);
 }
 
 TEST_F(TopologyMapperTest, T3kMultiMeshTest) {
@@ -486,14 +501,15 @@ TEST_F(TopologyMapperTest, T3kMultiMeshTest) {
         std::filesystem::path(tt::tt_metal::MetalContext::instance().rtoptions().get_root_dir()) /
         "tests/tt_metal/tt_fabric/custom_mesh_descriptors/t3k_2x2_1x2_1x1_mesh_graph_descriptor.textproto";
 
-    auto mesh_graph = MeshGraph(t3k_multimesh_graph_desc_path.string());
+    auto mesh_graph = MeshGraph(get_cluster(), t3k_multimesh_graph_desc_path.string());
 
     // Create a local mesh binding for testing
     LocalMeshBinding local_mesh_binding;
     local_mesh_binding.mesh_ids = {MeshId{0}, MeshId{1}, MeshId{2}};
     local_mesh_binding.host_rank = MeshHostRankId{0};
 
-    auto topology_mapper = TopologyMapper(mesh_graph, *physical_system_descriptor_, local_mesh_binding);
+    auto topology_mapper = TopologyMapper(
+        get_cluster(), get_distributed_context(), mesh_graph, *physical_system_descriptor_, local_mesh_binding);
 }
 
 TEST_F(TopologyMapperTest, ClosetBox3PodTTSwitchHostnameAPIs) {
@@ -501,21 +517,22 @@ TEST_F(TopologyMapperTest, ClosetBox3PodTTSwitchHostnameAPIs) {
         std::filesystem::path(tt::tt_metal::MetalContext::instance().rtoptions().get_root_dir()) /
         "tests/tt_metal/tt_fabric/custom_mesh_descriptors/wh_closetbox_3pod_ttswitch_mgd.textproto";
 
-    auto mesh_graph = MeshGraph(mesh_graph_desc_path.string());
+    auto mesh_graph = MeshGraph(get_cluster(), mesh_graph_desc_path.string());
 
     // Create local mesh binding (for testing, bind all meshes including switch)
     LocalMeshBinding local_mesh_binding;
-    if (*tt::tt_metal::MetalContext::instance().global_distributed_context().rank() == 0) {
+    if (*get_distributed_context().rank() == 0) {
         local_mesh_binding.mesh_ids = {MeshId{0}};
-    } else if (*tt::tt_metal::MetalContext::instance().global_distributed_context().rank() == 1) {
+    } else if (*get_distributed_context().rank() == 1) {
         local_mesh_binding.mesh_ids = {MeshId{1}};
-    } else if (*tt::tt_metal::MetalContext::instance().global_distributed_context().rank() == 2) {
+    } else if (*get_distributed_context().rank() == 2) {
         local_mesh_binding.mesh_ids = {MeshId{2}};
-    } else if (*tt::tt_metal::MetalContext::instance().global_distributed_context().rank() == 3) {
+    } else if (*get_distributed_context().rank() == 3) {
         local_mesh_binding.mesh_ids = {MeshId{3}};
     }
 
-    auto topology_mapper = TopologyMapper(mesh_graph, *physical_system_descriptor_, local_mesh_binding);
+    auto topology_mapper = TopologyMapper(
+        get_cluster(), get_distributed_context(), mesh_graph, *physical_system_descriptor_, local_mesh_binding);
 
     // Get the current hostname from the physical system descriptor
     const auto& current_hostname = physical_system_descriptor_->my_host_name();
@@ -629,11 +646,11 @@ TEST_F(TopologyMapperTest, PinningHonorsFixedAsicPositionOnDualGalaxyMesh_1pin) 
         std::filesystem::path(tt::tt_metal::MetalContext::instance().rtoptions().get_root_dir()) /
         "tt_metal/fabric/mesh_graph_descriptors/dual_galaxy_mesh_graph_descriptor.textproto";
 
-    auto mesh_graph = MeshGraph(galaxy_mesh_graph_desc_path.string());
+    auto mesh_graph = MeshGraph(get_cluster(), galaxy_mesh_graph_desc_path.string());
 
     // Local mesh binding for single-host
     LocalMeshBinding local_mesh_binding;
-    if (*tt::tt_metal::MetalContext::instance().global_distributed_context().rank() == 0) {
+    if (*get_distributed_context().rank() == 0) {
         local_mesh_binding.mesh_ids = {MeshId{0}};
         local_mesh_binding.host_rank = MeshHostRankId{0};
     } else {
@@ -649,7 +666,8 @@ TEST_F(TopologyMapperTest, PinningHonorsFixedAsicPositionOnDualGalaxyMesh_1pin) 
         {pinned_asic, FabricNodeId(MeshId{0}, 0)},
     };
 
-    TopologyMapper topology_mapper_with_pins(mesh_graph, *physical_system_descriptor_, local_mesh_binding, pins);
+    TopologyMapper topology_mapper_with_pins(
+        get_cluster(), get_distributed_context(), mesh_graph, *physical_system_descriptor_, local_mesh_binding, pins);
 
     tt::tt_metal::AsicID mapped_asic;
     for (const auto& asics : physical_system_descriptor_->get_asics_connected_to_host(my_host)) {
@@ -671,11 +689,11 @@ TEST_F(TopologyMapperTest, PinningHonorsFixedAsicPositionOnDualGalaxyMesh_2pins)
         std::filesystem::path(tt::tt_metal::MetalContext::instance().rtoptions().get_root_dir()) /
         "tt_metal/fabric/mesh_graph_descriptors/dual_galaxy_mesh_graph_descriptor.textproto";
 
-    auto mesh_graph = MeshGraph(galaxy_mesh_graph_desc_path.string());
+    auto mesh_graph = MeshGraph(get_cluster(), galaxy_mesh_graph_desc_path.string());
 
     // Local mesh binding for single-host
     LocalMeshBinding local_mesh_binding;
-    if (*tt::tt_metal::MetalContext::instance().global_distributed_context().rank() == 0) {
+    if (*get_distributed_context().rank() == 0) {
         local_mesh_binding.mesh_ids = {MeshId{0}};
         local_mesh_binding.host_rank = MeshHostRankId{0};
     } else {
@@ -692,7 +710,8 @@ TEST_F(TopologyMapperTest, PinningHonorsFixedAsicPositionOnDualGalaxyMesh_2pins)
         {pinned_asic2, FabricNodeId(MeshId{0}, 1)},
     };
 
-    TopologyMapper topology_mapper_with_pins(mesh_graph, *physical_system_descriptor_, local_mesh_binding, pins);
+    TopologyMapper topology_mapper_with_pins(
+        get_cluster(), get_distributed_context(), mesh_graph, *physical_system_descriptor_, local_mesh_binding, pins);
 
     // Check that the potential mapped ASICs are correctly for the pinned ASICs
     std::vector<tt::tt_metal::AsicID> potential_mapped_asics;
@@ -720,10 +739,10 @@ TEST_F(TopologyMapperTest, PinningThrowsOnBadAsicPositionGalaxyMesh) {
         std::filesystem::path(tt::tt_metal::MetalContext::instance().rtoptions().get_root_dir()) /
         "tt_metal/fabric/mesh_graph_descriptors/dual_galaxy_mesh_graph_descriptor.textproto";
 
-    auto mesh_graph = MeshGraph(galaxy_mesh_graph_desc_path.string());
+    auto mesh_graph = MeshGraph(get_cluster(), galaxy_mesh_graph_desc_path.string());
 
     LocalMeshBinding local_mesh_binding;
-    if (*tt::tt_metal::MetalContext::instance().global_distributed_context().rank() == 0) {
+    if (*get_distributed_context().rank() == 0) {
         local_mesh_binding.mesh_ids = {MeshId{0}};
         local_mesh_binding.host_rank = MeshHostRankId{0};
     } else {
@@ -738,7 +757,14 @@ TEST_F(TopologyMapperTest, PinningThrowsOnBadAsicPositionGalaxyMesh) {
 
     // Expect a throw due to missing ASIC position in the local mesh physical topology
     EXPECT_THROW(
-        TopologyMapper(mesh_graph, *physical_system_descriptor_, local_mesh_binding, pins_missing), std::exception);
+        TopologyMapper(
+            get_cluster(),
+            get_distributed_context(),
+            mesh_graph,
+            *physical_system_descriptor_,
+            local_mesh_binding,
+            pins_missing),
+        std::exception);
 }
 
 // Parameterized test fixture for testing TopologyMapper with custom mappings
@@ -751,7 +777,7 @@ TEST_P(T3kTopologyMapperWithCustomMappingFixture, T3kMeshGraphWithCustomMapping)
     const std::filesystem::path t3k_mesh_graph_desc_path =
         std::filesystem::path(tt::tt_metal::MetalContext::instance().rtoptions().get_root_dir()) / mesh_graph_desc_path;
 
-    auto mesh_graph = MeshGraph(t3k_mesh_graph_desc_path.string());
+    auto mesh_graph = MeshGraph(get_cluster(), t3k_mesh_graph_desc_path.string());
 
     // Create logical to physical chip mapping from eth_coords
     auto logical_mesh_chip_id_to_physical_chip_id_mapping =
@@ -775,7 +801,12 @@ TEST_P(T3kTopologyMapperWithCustomMappingFixture, T3kMeshGraphWithCustomMapping)
 
     // Create TopologyMapper using the new constructor that skips discovery
     auto topology_mapper_with_mapping = TopologyMapper(
-        mesh_graph, *physical_system_descriptor_, local_mesh_binding, logical_mesh_chip_id_to_physical_chip_id_mapping);
+        get_cluster(),
+        get_distributed_context(),
+        mesh_graph,
+        *physical_system_descriptor_,
+        local_mesh_binding,
+        logical_mesh_chip_id_to_physical_chip_id_mapping);
 
     // Verify that the mapper correctly uses the provided mapping for each mesh
     for (const auto& mesh_id : mesh_ids_in_mapping) {
@@ -864,8 +895,9 @@ TEST_F(TopologyMapperTest, T3kMeshGraphTestFromPhysicalSystemDescriptor) {
 
     // Generate mesh graph from physical system descriptor
     // This should internally use map_mesh_to_physical to find a valid mapping
+    const auto& cluster = tt::tt_metal::MetalContext::instance().get_cluster();
     MeshGraph mesh_graph = TopologyMapper::generate_mesh_graph_from_physical_system_descriptor(
-        *physical_system_descriptor_, fabric_config);
+        cluster, *physical_system_descriptor_, fabric_config, FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE);
 
     // Verify that the mesh graph was generated successfully
     const MeshId mesh_id{0};
@@ -895,7 +927,8 @@ TEST_F(TopologyMapperTest, T3kMeshGraphTestFromPhysicalSystemDescriptor) {
     // This should work without throwing since the mesh graph was generated
     // to match the physical topology
     EXPECT_NO_THROW({
-        TopologyMapper topology_mapper(mesh_graph, *physical_system_descriptor_, local_mesh_binding);
+        TopologyMapper topology_mapper(
+            get_cluster(), get_distributed_context(), mesh_graph, *physical_system_descriptor_, local_mesh_binding);
         // Verify that mappings exist
         for (const auto& chip_id : chip_ids.values()) {
             FabricNodeId fabric_node_id(mesh_id, chip_id);

--- a/tests/tt_metal/tt_fabric/fabric_router/test_topology_solver.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_router/test_topology_solver.cpp
@@ -13,11 +13,15 @@
 #include "impl/context/metal_context.hpp"
 #include "tt_metal/fabric/physical_system_descriptor.hpp"
 #include "tt_metal/fabric/serialization/physical_system_descriptor_serialization.hpp"
+#include <tt-metalium/experimental/mock_device.hpp>
 
 namespace tt::tt_fabric {
 
 class TopologySolverTest : public ::testing::Test {
 protected:
+    // Cluster type doesn't matter as this test suite is CPU only
+    const tt::tt_metal::ClusterType cluster_type = tt::tt_metal::ClusterType::BLACKHOLE_GALAXY;
+
     void SetUp() override { setenv("TT_METAL_OPERATION_TIMEOUT_SECONDS", "10", 1); }
 
     void TearDown() override {}
@@ -32,8 +36,7 @@ TEST_F(TopologySolverTest, BuildAdjacencyMapLogical) {
         "tests/tt_metal/tt_fabric/custom_mesh_descriptors/t3k_2x2_mesh_graph_descriptor.textproto";
 
     // Create mesh graph from descriptor
-    const tt::Cluster& cluster = tt::tt_metal::MetalContext::instance().get_cluster();
-    auto mesh_graph = MeshGraph(cluster, mesh_graph_desc_path.string());
+    auto mesh_graph = MeshGraph(cluster_type, mesh_graph_desc_path.string());
 
     // Build adjacency map logical
     auto adjacency_map = build_adjacency_map_logical(mesh_graph);
@@ -85,9 +88,7 @@ TEST_F(TopologySolverTest, BuildAdjacencyMapPhysical) {
     asic_id_to_mesh_rank[MeshId{1}][tt::tt_metal::AsicID{103}] = MeshHostRankId{0};
 
     // Build adjacency map physical
-    const auto& cluster = tt::tt_metal::MetalContext::instance().get_cluster();
-    auto adjacency_map =
-        build_adjacency_map_physical(cluster.get_cluster_type(), physical_system_descriptor, asic_id_to_mesh_rank);
+    auto adjacency_map = build_adjacency_map_physical(cluster_type, physical_system_descriptor, asic_id_to_mesh_rank);
 
     // Verify that we have adjacency graphs for each mesh
     EXPECT_EQ(adjacency_map.size(), 2u) << "Should have 2 meshes";
@@ -2119,8 +2120,7 @@ TEST_F(TopologySolverTest, BuildAdjacencyMapLogical_WithSwitchMeshes) {
         "tests/tt_metal/tt_fabric/custom_mesh_descriptors/t3k_2x2_ttswitch_mgd.textproto";
 
     // Create mesh graph from descriptor
-    const tt::Cluster& cluster = tt::tt_metal::MetalContext::instance().get_cluster();
-    auto mesh_graph = MeshGraph(cluster, mesh_graph_desc_path.string());
+    auto mesh_graph = MeshGraph(cluster_type, mesh_graph_desc_path.string());
 
     // Build adjacency map logical - this should include both regular meshes and switch meshes
     auto adjacency_map = build_adjacency_map_logical(mesh_graph);

--- a/tests/tt_metal/tt_fabric/fabric_router/test_topology_solver.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_router/test_topology_solver.cpp
@@ -8,6 +8,7 @@
 #include <tt-metalium/experimental/fabric/mesh_graph.hpp>
 #include <tt-metalium/experimental/fabric/topology_solver.hpp>
 #include <tt-metalium/experimental/fabric/fabric_types.hpp>
+#include "tt_cluster.hpp"
 #include "tt_metal/fabric/topology_solver_internal.hpp"
 #include "impl/context/metal_context.hpp"
 #include "tt_metal/fabric/physical_system_descriptor.hpp"
@@ -31,7 +32,8 @@ TEST_F(TopologySolverTest, BuildAdjacencyMapLogical) {
         "tests/tt_metal/tt_fabric/custom_mesh_descriptors/t3k_2x2_mesh_graph_descriptor.textproto";
 
     // Create mesh graph from descriptor
-    auto mesh_graph = MeshGraph(mesh_graph_desc_path.string());
+    const tt::Cluster& cluster = tt::tt_metal::MetalContext::instance().get_cluster();
+    auto mesh_graph = MeshGraph(cluster, mesh_graph_desc_path.string());
 
     // Build adjacency map logical
     auto adjacency_map = build_adjacency_map_logical(mesh_graph);
@@ -83,7 +85,9 @@ TEST_F(TopologySolverTest, BuildAdjacencyMapPhysical) {
     asic_id_to_mesh_rank[MeshId{1}][tt::tt_metal::AsicID{103}] = MeshHostRankId{0};
 
     // Build adjacency map physical
-    auto adjacency_map = build_adjacency_map_physical(physical_system_descriptor, asic_id_to_mesh_rank);
+    const auto& cluster = tt::tt_metal::MetalContext::instance().get_cluster();
+    auto adjacency_map =
+        build_adjacency_map_physical(cluster.get_cluster_type(), physical_system_descriptor, asic_id_to_mesh_rank);
 
     // Verify that we have adjacency graphs for each mesh
     EXPECT_EQ(adjacency_map.size(), 2u) << "Should have 2 meshes";
@@ -2115,7 +2119,8 @@ TEST_F(TopologySolverTest, BuildAdjacencyMapLogical_WithSwitchMeshes) {
         "tests/tt_metal/tt_fabric/custom_mesh_descriptors/t3k_2x2_ttswitch_mgd.textproto";
 
     // Create mesh graph from descriptor
-    auto mesh_graph = MeshGraph(mesh_graph_desc_path.string());
+    const tt::Cluster& cluster = tt::tt_metal::MetalContext::instance().get_cluster();
+    auto mesh_graph = MeshGraph(cluster, mesh_graph_desc_path.string());
 
     // Build adjacency map logical - this should include both regular meshes and switch meshes
     auto adjacency_map = build_adjacency_map_logical(mesh_graph);

--- a/tests/tt_metal/tt_fabric/golden_mapping_files/ControlPlaneFixture_SingleGalaxy_1x32.yaml
+++ b/tests/tt_metal/tt_fabric/golden_mapping_files/ControlPlaneFixture_SingleGalaxy_1x32.yaml
@@ -1,0 +1,262 @@
+asic_to_fabric_node_mapping:
+  hostnames:
+    - hostname: aus-wh-05-special-nhuang-for-reservation-62550
+      mesh:
+        - mesh: 0
+        - chips:
+            - umd_chip_id: 0
+              asic_position:
+                tray_id: 1
+                asic_location: 1
+              fabric_node_id:
+                mesh_id: 0
+                chip_id: 0
+              asic_id: 87028768508489796
+            - umd_chip_id: 1
+              asic_position:
+                tray_id: 4
+                asic_location: 1
+              fabric_node_id:
+                mesh_id: 0
+                chip_id: 2
+              asic_id: 87028777098424391
+            - umd_chip_id: 2
+              asic_position:
+                tray_id: 3
+                asic_location: 1
+              fabric_node_id:
+                mesh_id: 0
+                chip_id: 1
+              asic_id: 87028789983326512
+            - umd_chip_id: 3
+              asic_position:
+                tray_id: 2
+                asic_location: 1
+              fabric_node_id:
+                mesh_id: 0
+                chip_id: 3
+              asic_id: 87028789983326540
+            - umd_chip_id: 4
+              asic_position:
+                tray_id: 1
+                asic_location: 2
+              fabric_node_id:
+                mesh_id: 0
+                chip_id: 5
+              asic_id: 159086362546417732
+            - umd_chip_id: 5
+              asic_position:
+                tray_id: 4
+                asic_location: 2
+              fabric_node_id:
+                mesh_id: 0
+                chip_id: 13
+              asic_id: 159086371136352327
+            - umd_chip_id: 6
+              asic_position:
+                tray_id: 3
+                asic_location: 2
+              fabric_node_id:
+                mesh_id: 0
+                chip_id: 12
+              asic_id: 159086384021254448
+            - umd_chip_id: 7
+              asic_position:
+                tray_id: 2
+                asic_location: 2
+              fabric_node_id:
+                mesh_id: 0
+                chip_id: 4
+              asic_id: 159086384021254476
+            - umd_chip_id: 8
+              asic_position:
+                tray_id: 1
+                asic_location: 3
+              fabric_node_id:
+                mesh_id: 0
+                chip_id: 6
+              asic_id: 231143956584345668
+            - umd_chip_id: 9
+              asic_position:
+                tray_id: 4
+                asic_location: 3
+              fabric_node_id:
+                mesh_id: 0
+                chip_id: 14
+              asic_id: 231143965174280263
+            - umd_chip_id: 10
+              asic_position:
+                tray_id: 3
+                asic_location: 3
+              fabric_node_id:
+                mesh_id: 0
+                chip_id: 11
+              asic_id: 231143978059182384
+            - umd_chip_id: 11
+              asic_position:
+                tray_id: 2
+                asic_location: 3
+              fabric_node_id:
+                mesh_id: 0
+                chip_id: 7
+              asic_id: 231143978059182412
+            - umd_chip_id: 12
+              asic_position:
+                tray_id: 1
+                asic_location: 4
+              fabric_node_id:
+                mesh_id: 0
+                chip_id: 9
+              asic_id: 303201550622273604
+            - umd_chip_id: 13
+              asic_position:
+                tray_id: 4
+                asic_location: 4
+              fabric_node_id:
+                mesh_id: 0
+                chip_id: 15
+              asic_id: 303201559212208199
+            - umd_chip_id: 14
+              asic_position:
+                tray_id: 3
+                asic_location: 4
+              fabric_node_id:
+                mesh_id: 0
+                chip_id: 10
+              asic_id: 303201572097110320
+            - umd_chip_id: 15
+              asic_position:
+                tray_id: 2
+                asic_location: 4
+              fabric_node_id:
+                mesh_id: 0
+                chip_id: 8
+              asic_id: 303201572097110348
+            - umd_chip_id: 16
+              asic_position:
+                tray_id: 1
+                asic_location: 5
+              fabric_node_id:
+                mesh_id: 0
+                chip_id: 21
+              asic_id: 375259144660201540
+            - umd_chip_id: 17
+              asic_position:
+                tray_id: 4
+                asic_location: 5
+              fabric_node_id:
+                mesh_id: 0
+                chip_id: 19
+              asic_id: 375259153250136135
+            - umd_chip_id: 18
+              asic_position:
+                tray_id: 3
+                asic_location: 5
+              fabric_node_id:
+                mesh_id: 0
+                chip_id: 20
+              asic_id: 375259166135038256
+            - umd_chip_id: 19
+              asic_position:
+                tray_id: 2
+                asic_location: 5
+              fabric_node_id:
+                mesh_id: 0
+                chip_id: 22
+              asic_id: 375259166135038284
+            - umd_chip_id: 20
+              asic_position:
+                tray_id: 1
+                asic_location: 6
+              fabric_node_id:
+                mesh_id: 0
+                chip_id: 24
+              asic_id: 447316738698129476
+            - umd_chip_id: 21
+              asic_position:
+                tray_id: 4
+                asic_location: 6
+              fabric_node_id:
+                mesh_id: 0
+                chip_id: 18
+              asic_id: 447316747288064071
+            - umd_chip_id: 22
+              asic_position:
+                tray_id: 3
+                asic_location: 6
+              fabric_node_id:
+                mesh_id: 0
+                chip_id: 31
+              asic_id: 447316760172966192
+            - umd_chip_id: 23
+              asic_position:
+                tray_id: 2
+                asic_location: 6
+              fabric_node_id:
+                mesh_id: 0
+                chip_id: 23
+              asic_id: 447316760172966220
+            - umd_chip_id: 24
+              asic_position:
+                tray_id: 1
+                asic_location: 7
+              fabric_node_id:
+                mesh_id: 0
+                chip_id: 25
+              asic_id: 519374332736057412
+            - umd_chip_id: 25
+              asic_position:
+                tray_id: 4
+                asic_location: 7
+              fabric_node_id:
+                mesh_id: 0
+                chip_id: 17
+              asic_id: 519374341325992007
+            - umd_chip_id: 26
+              asic_position:
+                tray_id: 3
+                asic_location: 7
+              fabric_node_id:
+                mesh_id: 0
+                chip_id: 30
+              asic_id: 519374354210894128
+            - umd_chip_id: 27
+              asic_position:
+                tray_id: 2
+                asic_location: 7
+              fabric_node_id:
+                mesh_id: 0
+                chip_id: 26
+              asic_id: 519374354210894156
+            - umd_chip_id: 28
+              asic_position:
+                tray_id: 1
+                asic_location: 8
+              fabric_node_id:
+                mesh_id: 0
+                chip_id: 28
+              asic_id: 591431926773985348
+            - umd_chip_id: 29
+              asic_position:
+                tray_id: 4
+                asic_location: 8
+              fabric_node_id:
+                mesh_id: 0
+                chip_id: 16
+              asic_id: 591431935363919943
+            - umd_chip_id: 30
+              asic_position:
+                tray_id: 3
+                asic_location: 8
+              fabric_node_id:
+                mesh_id: 0
+                chip_id: 29
+              asic_id: 591431948248822064
+            - umd_chip_id: 31
+              asic_position:
+                tray_id: 2
+                asic_location: 8
+              fabric_node_id:
+                mesh_id: 0
+                chip_id: 27
+              asic_id: 591431948248822092

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_common.hpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_common.hpp
@@ -1220,7 +1220,8 @@ public:
         const FabricNodeId& src_node_id,
         const FabricNodeId& dst_node_id,
         const RoutingDirection& direction) const override {
-        return tt::tt_fabric::get_forwarding_link_indices_in_direction(src_node_id, dst_node_id, direction);
+        return tt::tt_fabric::get_forwarding_link_indices_in_direction(
+            tt::tt_metal::MetalContext::instance().get_control_plane(), src_node_id, dst_node_id, direction);
     }
 
     std::optional<FabricNodeId> get_neighbor_node_id_or_nullopt(

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_common.hpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_common.hpp
@@ -330,6 +330,10 @@ public:
         return tt::tt_metal::MetalContext::instance().get_control_plane().get_fabric_context().is_2D_routing_enabled();
     }
 
+    bool is_ubb_galaxy() const noexcept {
+        return tt::tt_metal::MetalContext::instance().get_control_plane().get_fabric_context().is_ubb_galaxy();
+    }
+
     uint32_t get_device_frequency_mhz(const FabricNodeId& device_id) const override {
         auto cached = device_frequency_cache_.find(device_id);
         if (cached != device_frequency_cache_.end()) {
@@ -769,7 +773,7 @@ public:
         }
 
         const auto src_coord = get_device_coord(src_node_id);
-        auto fabric_type = tt::tt_fabric::get_fabric_type(current_fabric_config_);
+        auto fabric_type = tt::tt_fabric::get_fabric_type(current_fabric_config_, is_ubb_galaxy());
 
         if (has_flag(fabric_type, FabricType::TORUS_X)) {
             // EW dimension: need to cover (mesh_shape_[EW_DIM] - 1) total hops
@@ -1877,7 +1881,7 @@ private:
 
         // If toroidal wraparound connections have been enabled, we need to check whether going in an opposite direction
         // over the wraparound link is faster
-        auto fabric_type = tt::tt_fabric::get_fabric_type(current_fabric_config_);
+        auto fabric_type = tt::tt_fabric::get_fabric_type(current_fabric_config_, is_ubb_galaxy());
         // If the physical topology is a mesh, no wraparound links are present, so we can return the hops as is
         if (fabric_type == tt::tt_fabric::FabricType::MESH) {
             return hops;
@@ -2122,7 +2126,7 @@ private:
 
     MeshCoordinate::BoundaryMode get_boundary_mode_for_dimension(int32_t dim) const {
         if (topology_ == Topology::NeighborExchange || topology_ == Topology::Ring || topology_ == Topology::Torus) {
-            auto fabric_type = tt::tt_fabric::get_fabric_type(current_fabric_config_);
+            auto fabric_type = tt::tt_fabric::get_fabric_type(current_fabric_config_, is_ubb_galaxy());
             switch (fabric_type) {
                 case tt::tt_fabric::FabricType::TORUS_X:
                     return (dim == EW_DIM) ? MeshCoordinate::BoundaryMode::WRAP : MeshCoordinate::BoundaryMode::NONE;

--- a/tt_metal/api/tt-metalium/experimental/fabric/TOPOLOGY_SOLVER.md
+++ b/tt_metal/api/tt-metalium/experimental/fabric/TOPOLOGY_SOLVER.md
@@ -223,7 +223,7 @@ std::map<MeshId, AdjacencyGraph<FabricNodeId>> logical_graphs =
 
 // Build physical graphs from PhysicalSystemDescriptor
 std::map<MeshId, AdjacencyGraph<AsicID>> physical_graphs =
-    build_adjacency_map_physical(psd, asic_id_to_mesh_rank);
+    build_adjacency_map_physical(cluster_type, psd, asic_id_to_mesh_rank);
 ```
 
 ## Architecture

--- a/tt_metal/api/tt-metalium/experimental/fabric/control_plane.hpp
+++ b/tt_metal/api/tt-metalium/experimental/fabric/control_plane.hpp
@@ -19,7 +19,19 @@
 #include <memory>
 #include <vector>
 
+namespace tt {
+
+class Cluster;
+
+namespace llrt {
+class RunTimeOptions;
+}
+
+}  // namespace tt
+
 namespace tt::tt_metal {
+
+class Hal;
 
 class PhysicalSystemDescriptor;
 
@@ -75,11 +87,47 @@ using PortDescriptorTable = std::unordered_map<MeshId, std::unordered_map<MeshId
 
 class ControlPlane {
 public:
-    ControlPlane();
-    explicit ControlPlane(const std::string& mesh_graph_desc_file);
+    // Create control plane with auto-discovery
     explicit ControlPlane(
+        const ::tt::Cluster& cluster,
+        const ::tt::llrt::RunTimeOptions& rtoptions,
+        const ::tt::tt_metal::Hal& hal,
+        const tt_metal::distributed::multihost::DistributedContext& distributed_context,
+        FabricConfig fabric_config = FabricConfig::DISABLED,
+        FabricReliabilityMode fabric_reliability_mode = FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE,
+        FabricTensixConfig fabric_tensix_config = FabricTensixConfig::DISABLED,
+        FabricUDMMode fabric_udm_mode = FabricUDMMode::DISABLED,
+        FabricRouterConfig fabric_router_config = FabricRouterConfig{},
+        FabricManagerMode fabric_manager = FabricManagerMode::DEFAULT);
+
+    // Create control plane with custom mesh graph descriptor
+    explicit ControlPlane(
+        const ::tt::Cluster& cluster,
+        const ::tt::llrt::RunTimeOptions& rtoptions,
+        const ::tt::tt_metal::Hal& hal,
+        const tt_metal::distributed::multihost::DistributedContext& distributed_context,
         const std::string& mesh_graph_desc_file,
-        const std::map<FabricNodeId, ChipId>& logical_mesh_chip_id_to_physical_chip_id_mapping);
+        FabricConfig fabric_config = FabricConfig::DISABLED,
+        FabricReliabilityMode fabric_reliability_mode = FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE,
+        FabricTensixConfig fabric_tensix_config = FabricTensixConfig::DISABLED,
+        FabricUDMMode fabric_udm_mode = FabricUDMMode::DISABLED,
+        FabricRouterConfig fabric_router_config = FabricRouterConfig{},
+        FabricManagerMode fabric_manager = FabricManagerMode::DEFAULT);
+
+    // Create control plane with custom mesh graph descriptor and logical mesh chip id to physical chip id mapping
+    explicit ControlPlane(
+        const ::tt::Cluster& cluster,
+        const ::tt::llrt::RunTimeOptions& rtoptions,
+        const ::tt::tt_metal::Hal& hal,
+        const tt_metal::distributed::multihost::DistributedContext& distributed_context,
+        const std::string& mesh_graph_desc_file,
+        const std::map<FabricNodeId, ChipId>& logical_mesh_chip_id_to_physical_chip_id_mapping,
+        FabricConfig fabric_config = FabricConfig::DISABLED,
+        FabricReliabilityMode fabric_reliability_mode = FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE,
+        FabricTensixConfig fabric_tensix_config = FabricTensixConfig::DISABLED,
+        FabricUDMMode fabric_udm_mode = FabricUDMMode::DISABLED,
+        FabricRouterConfig fabric_router_config = FabricRouterConfig{},
+        FabricManagerMode fabric_manager = FabricManagerMode::DEFAULT);
 
     ~ControlPlane();
 
@@ -90,8 +138,7 @@ public:
     void print_all_ethernet_connections() const;
 
     // Converts chip level routing tables to per ethernet channel
-    void configure_routing_tables_for_fabric_ethernet_channels(
-        tt::tt_fabric::FabricConfig fabric_config, tt_fabric::FabricReliabilityMode reliability_mode);
+    void configure_routing_tables_for_fabric_ethernet_channels();
     void write_routing_tables_to_all_chips() const;
     void write_fabric_telemetry_to_all_chips(const FabricNodeId& fabric_node_id) const;
 
@@ -183,8 +230,6 @@ public:
     // Return ethernet channels on a chip that face other chips within the same mesh (intra-mesh)
     std::vector<chan_id_t> get_intramesh_facing_eth_chans(FabricNodeId fabric_node_id) const;
 
-    void initialize_fabric_context(tt_fabric::FabricConfig fabric_config, const FabricRouterConfig& router_config);
-
     FabricContext& get_fabric_context() const;
 
     // Get all fabric defines for kernel compilation (used by tt_metal.cpp)
@@ -229,6 +274,14 @@ public:
 
     tt::tt_metal::AsicID get_asic_id_from_fabric_node_id(const FabricNodeId& fabric_node_id) const;
 
+    // Getters
+    FabricConfig get_fabric_config() const { return fabric_config_; }
+    FabricReliabilityMode get_fabric_reliability_mode() const { return fabric_reliability_mode_; }
+    FabricTensixConfig get_fabric_tensix_config() const { return fabric_tensix_config_; }
+    FabricUDMMode get_fabric_udm_mode() const { return fabric_udm_mode_; }
+    FabricRouterConfig get_fabric_router_config() const { return fabric_router_config_; }
+    FabricManagerMode get_fabric_manager_mode() const { return fabric_manager_; }
+
 private:
     // Check if the provided mesh is local to this host
     bool is_local_mesh(MeshId mesh_id) const;
@@ -239,6 +292,30 @@ private:
             logical_mesh_chip_id_to_physical_chip_id_mapping = std::nullopt);
 
     void init_control_plane_auto_discovery();
+
+    // Initialize fabric context if fabric is enabled
+    void initialize_fabric_context();
+
+    // Dependencies
+    std::reference_wrapper<const ::tt::Cluster> cluster_;
+    std::reference_wrapper<const ::tt::llrt::RunTimeOptions> rtoptions_;
+    std::reference_wrapper<const ::tt::tt_metal::Hal> hal_;
+    std::reference_wrapper<const tt_metal::distributed::multihost::DistributedContext> distributed_context_;
+
+    // Fabric Settings
+    tt_fabric::FabricConfig fabric_config_ = tt_fabric::FabricConfig::DISABLED;
+
+    // Strict system health mode requires (expects) all links/devices to be live. When enabled, it
+    // is expected that any downed devices/links will result in some sort of error condition being
+    // reported. When set to false, the control plane is free to instantiate fewer routing planes
+    // according to which links are available.
+    tt_fabric::FabricReliabilityMode fabric_reliability_mode_ =
+        tt_fabric::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE;
+
+    tt_fabric::FabricTensixConfig fabric_tensix_config_ = tt_fabric::FabricTensixConfig::DISABLED;
+    tt_fabric::FabricUDMMode fabric_udm_mode_ = tt_fabric::FabricUDMMode::DISABLED;
+    tt_fabric::FabricRouterConfig fabric_router_config_ = tt_fabric::FabricRouterConfig{};
+    tt_fabric::FabricManagerMode fabric_manager_ = tt_fabric::FabricManagerMode::DEFAULT;
 
     // TODO: remove this from local node control plane. Can get it from the global control plane
     std::unique_ptr<tt::tt_metal::PhysicalSystemDescriptor> physical_system_descriptor_;

--- a/tt_metal/api/tt-metalium/experimental/fabric/mesh_graph.hpp
+++ b/tt_metal/api/tt-metalium/experimental/fabric/mesh_graph.hpp
@@ -160,7 +160,6 @@ public:
 
     // Generate a mesh graph of a specific shape (used by topology mapper)
     static MeshGraph generate_mesh_graph_of_shape(
-        const tt::Cluster& cluster,
         MeshShape mesh_shape,
         tt::tt_fabric::FabricType fabric_type,
         tt::tt_fabric::FabricReliabilityMode reliability_mode,
@@ -196,7 +195,7 @@ public:
     std::optional<std::filesystem::path> get_mesh_graph_descriptor_path() const { return mesh_graph_desc_file_path_; }
 
 private:
-    MeshGraph(const tt::Cluster& cluster) : cluster_(cluster) {}
+    MeshGraph() = default;
 
     void validate_mesh_id(MeshId mesh_id) const;
     std::unordered_map<ChipId, RouterEdge> get_valid_connections(

--- a/tt_metal/api/tt-metalium/experimental/fabric/mesh_graph.hpp
+++ b/tt_metal/api/tt-metalium/experimental/fabric/mesh_graph.hpp
@@ -23,6 +23,9 @@
 #include <memory>
 #include <vector>
 
+namespace tt {
+class Cluster;
+}  // namespace tt
 namespace tt::tt_metal {
 enum class ClusterType : std::uint8_t;
 class PhysicalSystemDescriptor;
@@ -101,7 +104,9 @@ using RequestedIntermeshPorts =
 class MeshGraph {
 public:
     explicit MeshGraph(
-        const std::string& mesh_graph_desc_file_path, std::optional<FabricConfig> fabric_config = std::nullopt);
+        const tt::Cluster& cluster,
+        const std::string& mesh_graph_desc_file_path,
+        std::optional<FabricConfig> fabric_config = std::nullopt);
     ~MeshGraph() = default;
 
     void print_connectivity() const;
@@ -155,7 +160,12 @@ public:
 
     // Generate a mesh graph of a specific shape (used by topology mapper)
     static MeshGraph generate_mesh_graph_of_shape(
-        MeshShape mesh_shape, tt::tt_fabric::FabricType fabric_type, std::uint32_t num_connections_per_direction);
+        const tt::Cluster& cluster,
+        MeshShape mesh_shape,
+        tt::tt_fabric::FabricType fabric_type,
+        tt::tt_fabric::FabricReliabilityMode reliability_mode,
+        tt::ARCH arch,
+        std::uint32_t num_connections_per_direction);
 
     // Get the number of active channels the user has requested between meshes
     const RequestedIntermeshConnections& get_requested_intermesh_connections() const;
@@ -186,15 +196,15 @@ public:
     std::optional<std::filesystem::path> get_mesh_graph_descriptor_path() const { return mesh_graph_desc_file_path_; }
 
 private:
-    // Private constructor for static factory functions
-    MeshGraph() = default;
+    MeshGraph(const tt::Cluster& cluster) : cluster_(cluster) {}
 
     void validate_mesh_id(MeshId mesh_id) const;
     std::unordered_map<ChipId, RouterEdge> get_valid_connections(
         const MeshCoordinate& src_mesh_coord,
         const MeshCoordinateRange& mesh_coord_range,
         FabricType fabric_type) const;
-    void initialize_from_mgd(const MeshGraphDescriptor& mgd, std::optional<FabricConfig> fabric_config);
+    void initialize_from_mgd(
+        const MeshGraphDescriptor& mgd, std::optional<FabricConfig> fabric_config, bool is_ubb_galaxy);
 
     void add_to_connectivity(
         MeshId src_mesh_id,

--- a/tt_metal/api/tt-metalium/experimental/fabric/mesh_graph.hpp
+++ b/tt_metal/api/tt-metalium/experimental/fabric/mesh_graph.hpp
@@ -104,6 +104,11 @@ using RequestedIntermeshPorts =
 class MeshGraph {
 public:
     explicit MeshGraph(
+        tt::tt_metal::ClusterType cluster_type,
+        const std::string& mesh_graph_desc_file_path,
+        std::optional<FabricConfig> fabric_config = std::nullopt);
+
+    explicit MeshGraph(
         const tt::Cluster& cluster,
         const std::string& mesh_graph_desc_file_path,
         std::optional<FabricConfig> fabric_config = std::nullopt);

--- a/tt_metal/api/tt-metalium/experimental/fabric/topology_mapper.hpp
+++ b/tt_metal/api/tt-metalium/experimental/fabric/topology_mapper.hpp
@@ -324,7 +324,7 @@ private:
      * based on the mesh IDs and fabric chip IDs from the mesh_container, mapping them
      * to the ASIC IDs of the physical descriptor.
      */
-    void build_mapping();
+    void build_mapping(const Cluster& cluster);
 
     /**
      * @brief Initialize chip_topology_mapping_ map with all ASICs from physical system descriptor
@@ -454,7 +454,7 @@ private:
      * - Verifies tray IDs and ASIC locations match the Physical System Descriptor
      * - Ensures physical chip IDs map correctly to ASIC IDs via cluster API for local chips
      */
-    void verify_topology_mapping() const;
+    void verify_topology_mapping(const Cluster& cluster) const;
 
     void print_logical_adjacency_map(const std::map<MeshId, LogicalAdjacencyMap>& adj_map) const;
     void print_physical_adjacency_map(const std::map<MeshId, PhysicalAdjacencyMap>& adj_map) const;

--- a/tt_metal/api/tt-metalium/experimental/fabric/topology_mapper_utils.hpp
+++ b/tt_metal/api/tt-metalium/experimental/fabric/topology_mapper_utils.hpp
@@ -149,11 +149,13 @@ std::map<MeshId, LogicalAdjacencyMap> build_adjacency_map_logical(const ::tt::tt
  * neighbors from the physical system descriptor and filters them to only include neighbors that are also part of
  * the same mesh. The resulting map contains ASIC IDs mapped to their vectors of adjacent ASIC IDs within the mesh.
  *
+ * @param cluster_type The type of the cluster
  * @param physical_system_descriptor Reference to the physical system descriptor containing ASIC topology
  * @param asic_id_to_mesh_rank Mapping of mesh IDs to ASIC IDs to mesh host ranks
  * @return std::map<MeshId, PhysicalAdjacencyMap> Map from mesh ID to physical adjacency map
  */
 std::map<MeshId, PhysicalAdjacencyMap> build_adjacency_map_physical(
+    tt::tt_metal::ClusterType cluster_type,
     const tt::tt_metal::PhysicalSystemDescriptor& physical_system_descriptor,
     const std::map<MeshId, std::map<tt::tt_metal::AsicID, MeshHostRankId>>& asic_id_to_mesh_rank);
 

--- a/tt_metal/api/tt-metalium/experimental/fabric/topology_solver.hpp
+++ b/tt_metal/api/tt-metalium/experimental/fabric/topology_solver.hpp
@@ -213,6 +213,7 @@ private:
 std::map<MeshId, AdjacencyGraph<FabricNodeId>> build_adjacency_map_logical(const MeshGraph& mesh_graph);
 
 std::map<MeshId, AdjacencyGraph<tt::tt_metal::AsicID>> build_adjacency_map_physical(
+    tt::tt_metal::ClusterType cluster_type,
     const tt::tt_metal::PhysicalSystemDescriptor& physical_system_descriptor,
     const std::map<MeshId, std::map<tt::tt_metal::AsicID, MeshHostRankId>>& asic_id_to_mesh_rank);
 

--- a/tt_metal/fabric/compute_mesh_router_builder.cpp
+++ b/tt_metal/fabric/compute_mesh_router_builder.cpp
@@ -70,7 +70,7 @@ std::unique_ptr<ComputeMeshRouterBuilder> ComputeMeshRouterBuilder::build(
     const auto& edm_config = builder_context.get_fabric_router_config(tensix_config_for_lookup, eth_direction);
 
     // Determine the router variant
-    bool has_z_router = fabric_context.has_z_router_on_device(local_node);
+    bool has_z_router = fabric_context.has_z_router_on_device(control_plane, local_node);
     RouterVariant variant = (location.direction == RoutingDirection::Z) ? RouterVariant::Z_ROUTER : RouterVariant::MESH;
 
     // Create channel mapping EARLY (needed for computing injection flags)

--- a/tt_metal/fabric/control_plane.cpp
+++ b/tt_metal/fabric/control_plane.cpp
@@ -41,7 +41,6 @@
 #include <tt-metalium/experimental/fabric/fabric_types.hpp>
 #include "hal_types.hpp"
 #include "host_api.hpp"
-#include "impl/context/metal_context.hpp"
 #include "tt_metal/common/env_lib.hpp"
 #include <tt-logger/tt-logger.hpp>
 #include "mesh_coord.hpp"
@@ -67,11 +66,6 @@
 namespace tt::tt_fabric {
 
 namespace {
-
-// Get the physical chip ids for a mesh
-std::unordered_map<ChipId, std::vector<CoreCoord>> get_ethernet_cores_grouped_by_connected_chips(ChipId chip_id) {
-    return tt::tt_metal::MetalContext::instance().get_cluster().get_ethernet_cores_grouped_by_connected_chips(chip_id);
-}
 
 // Generate fixed ASIC position pinnings for Galaxy topology to ensure QSFP links align with fabric mesh corner nodes.
 // This is a performance optimization to ensure that MGD mapping does not bisect a device.
@@ -211,7 +205,7 @@ void ControlPlane::initialize_dynamic_routing_plane_counts(
         }
     };
 
-    const auto& distributed_context = tt::tt_metal::MetalContext::instance().full_world_distributed_context();
+    const auto& distributed_context = this->distributed_context_.get();
     // For each mesh in the system
     for (auto mesh_id : user_meshes) {
         const auto& mesh_shape = this->get_physical_mesh_shape(MeshId{mesh_id});
@@ -295,7 +289,7 @@ LocalMeshBinding ControlPlane::initialize_local_mesh_binding() {
     // the MeshGraphDescriptor. Single Host Multi-Mesh is only used for testing purposes.
     const char* mesh_id_str = std::getenv("TT_MESH_ID");
     if (mesh_id_str == nullptr) {
-        const auto& ctx = tt::tt_metal::MetalContext::instance().full_world_distributed_context();
+        const auto& ctx = this->distributed_context_.get();
         TT_FATAL(
             *ctx.size() == 1 && *ctx.rank() == 0,
             "Not specifying both TT_MESH_ID and TT_MESH_HOST_RANK is only supported for single host systems.");
@@ -408,7 +402,7 @@ FabricNodeId ControlPlane::get_fabric_node_id_from_asic_id(uint64_t asic_id) con
         return cache_it->second;
     }
 
-    const auto& cluster = tt::tt_metal::MetalContext::instance().get_cluster();
+    const auto& cluster = this->cluster_.get();
     const auto& chip_unique_ids = cluster.get_unique_chip_ids();
 
     for (const auto& [physical_chip_id, unique_id] : chip_unique_ids) {
@@ -434,26 +428,34 @@ void ControlPlane::init_control_plane(
     const std::string& mesh_graph_desc_file,
     std::optional<std::reference_wrapper<const std::map<FabricNodeId, ChipId>>>
         logical_mesh_chip_id_to_physical_chip_id_mapping) {
-    const auto& cluster = tt::tt_metal::MetalContext::instance().get_cluster();
+    const auto& cluster = this->cluster_.get();
     const auto& driver = cluster.get_driver();
     const auto& distributed_context = tt_metal::distributed::multihost::DistributedContext::get_current_world();
-    const auto& rtoptions = tt::tt_metal::MetalContext::instance().rtoptions();
-    auto fabric_config = tt::tt_metal::MetalContext::instance().get_fabric_config();
+    const auto& rtoptions = this->rtoptions_.get();
+    auto fabric_config = this->get_fabric_config();
 
     // Create mesh_graph first
-    this->mesh_graph_ = std::make_unique<MeshGraph>(mesh_graph_desc_file, fabric_config);
+    this->mesh_graph_ = std::make_unique<MeshGraph>(this->cluster_, mesh_graph_desc_file, fabric_config);
 
     this->physical_system_descriptor_ = std::make_unique<tt::tt_metal::PhysicalSystemDescriptor>(
-        driver, distributed_context, &tt::tt_metal::MetalContext::instance().hal(), rtoptions);
+        driver, distributed_context, &this->hal_.get(), rtoptions);
     this->local_mesh_binding_ = this->initialize_local_mesh_binding();
+
+    auto topology_mapping_timeout = rtoptions.get_timeout_duration_for_operations();
+    if (topology_mapping_timeout.count() <= 0.0f) {
+        topology_mapping_timeout = std::chrono::duration<float>(60.0f);
+    }
 
     if (logical_mesh_chip_id_to_physical_chip_id_mapping.has_value()) {
         // Initialize topology mapper with provided mapping, skipping discovery
         this->topology_mapper_ = std::make_unique<tt::tt_fabric::TopologyMapper>(
+            this->cluster_.get(),
+            this->distributed_context_.get(),
             *this->mesh_graph_,
             *this->physical_system_descriptor_,
             this->local_mesh_binding_,
-            logical_mesh_chip_id_to_physical_chip_id_mapping->get());
+            logical_mesh_chip_id_to_physical_chip_id_mapping->get(),
+            topology_mapping_timeout);
         this->load_physical_chip_mapping(logical_mesh_chip_id_to_physical_chip_id_mapping->get());
     } else {
         std::vector<std::pair<AsicPosition, FabricNodeId>> fixed_asic_position_pinnings;
@@ -481,10 +483,13 @@ void ControlPlane::init_control_plane(
         }
 
         this->topology_mapper_ = std::make_unique<tt::tt_fabric::TopologyMapper>(
+            this->cluster_.get(),
+            this->distributed_context_.get(),
             *this->mesh_graph_,
             *this->physical_system_descriptor_,
             this->local_mesh_binding_,
-            fixed_asic_position_pinnings);
+            fixed_asic_position_pinnings,
+            topology_mapping_timeout);
         this->load_physical_chip_mapping(
             topology_mapper_->get_local_logical_mesh_chip_id_to_physical_chip_id_mapping());
     }
@@ -524,11 +529,10 @@ void ControlPlane::init_control_plane(
 }
 
 void ControlPlane::init_control_plane_auto_discovery() {
-    auto& cluster = tt::tt_metal::MetalContext::instance().get_cluster();
+    const auto& cluster = this->cluster_.get();
     const auto& driver = cluster.get_driver();
     const auto& distributed_context = tt_metal::distributed::multihost::DistributedContext::get_current_world();
-    const auto& rtoptions = tt::tt_metal::MetalContext::instance().rtoptions();
-    auto fabric_config = tt::tt_metal::MetalContext::instance().get_fabric_config();
+    const auto& rtoptions = this->rtoptions_.get();
 
     // NOTE: This algorithm is only supported for single host systems for now
     TT_FATAL(
@@ -539,18 +543,24 @@ void ControlPlane::init_control_plane_auto_discovery() {
 
     // Initialize physical system descriptor
     this->physical_system_descriptor_ = std::make_unique<tt::tt_metal::PhysicalSystemDescriptor>(
-        driver, distributed_context, &tt::tt_metal::MetalContext::instance().hal(), rtoptions);
+        driver, distributed_context, &this->hal_.get(), rtoptions);
 
     // Generate Mesh graph based on physical system descriptor
     // Reliability mode is obtained from MetalContext inside the function
     this->mesh_graph_ = std::make_unique<tt::tt_fabric::MeshGraph>(
         tt::tt_fabric::TopologyMapper::generate_mesh_graph_from_physical_system_descriptor(
-            *this->physical_system_descriptor_, fabric_config));
+            this->cluster_.get(),
+            *this->physical_system_descriptor_,
+            this->fabric_config_,
+            this->fabric_reliability_mode_));
 
     this->local_mesh_binding_ = this->initialize_local_mesh_binding();
 
     std::vector<std::pair<AsicPosition, FabricNodeId>> fixed_asic_position_pinnings;
-
+    auto topology_mapping_timeout = rtoptions.get_timeout_duration_for_operations();
+    if (topology_mapping_timeout.count() <= 0.0f) {
+        topology_mapping_timeout = std::chrono::duration<float>(60.0f);
+    }
     // Pin the start of the mesh to match the Galaxy Topology, ensuring that external QSFP links align with the
     // corner node IDs of the fabric mesh. This is a performance optimization to ensure that MGD mapping does not
     // bisect a device.
@@ -566,10 +576,13 @@ void ControlPlane::init_control_plane_auto_discovery() {
         fixed_asic_position_pinnings = get_galaxy_fixed_asic_position_pinnings(board_size);
     }
     this->topology_mapper_ = std::make_unique<tt::tt_fabric::TopologyMapper>(
+        this->cluster_.get(),
+        this->distributed_context_.get(),
         *this->mesh_graph_,
         *this->physical_system_descriptor_,
         this->local_mesh_binding_,
-        fixed_asic_position_pinnings);
+        fixed_asic_position_pinnings,
+        topology_mapping_timeout);
     this->load_physical_chip_mapping(topology_mapper_->get_local_logical_mesh_chip_id_to_physical_chip_id_mapping());
 
     // Automatically export physical chip mesh coordinate mapping to generated/fabric directory after topology mapper is
@@ -606,16 +619,89 @@ void ControlPlane::init_control_plane_auto_discovery() {
     this->mesh_graph_->print_connectivity();
 }
 
-ControlPlane::ControlPlane() { init_control_plane_auto_discovery(); }
-
-ControlPlane::ControlPlane(const std::string& mesh_graph_desc_file) {
-    init_control_plane(mesh_graph_desc_file, std::nullopt);
+ControlPlane::ControlPlane(
+    const ::tt::Cluster& cluster,
+    const ::tt::llrt::RunTimeOptions& rtoptions,
+    const ::tt::tt_metal::Hal& hal,
+    const tt_metal::distributed::multihost::DistributedContext& distributed_context,
+    FabricConfig fabric_config,
+    FabricReliabilityMode fabric_reliability_mode,
+    FabricTensixConfig fabric_tensix_config,
+    FabricUDMMode fabric_udm_mode,
+    FabricRouterConfig fabric_router_config,
+    FabricManagerMode fabric_manager) :
+    cluster_(cluster),
+    rtoptions_(rtoptions),
+    hal_(hal),
+    distributed_context_(distributed_context),
+    fabric_config_(fabric_config),
+    fabric_reliability_mode_(fabric_reliability_mode),
+    fabric_tensix_config_(fabric_tensix_config),
+    fabric_udm_mode_(fabric_udm_mode),
+    fabric_router_config_(fabric_router_config),
+    fabric_manager_(fabric_manager) {
+    init_control_plane_auto_discovery();
+    initialize_fabric_context();
 }
 
 ControlPlane::ControlPlane(
+    const ::tt::Cluster& cluster,
+    const ::tt::llrt::RunTimeOptions& rtoptions,
+    const ::tt::tt_metal::Hal& hal,
+    const tt_metal::distributed::multihost::DistributedContext& distributed_context,
     const std::string& mesh_graph_desc_file,
-    const std::map<FabricNodeId, ChipId>& logical_mesh_chip_id_to_physical_chip_id_mapping) {
+    FabricConfig fabric_config,
+    FabricReliabilityMode fabric_reliability_mode,
+    FabricTensixConfig fabric_tensix_config,
+    FabricUDMMode fabric_udm_mode,
+    FabricRouterConfig fabric_router_config,
+    FabricManagerMode fabric_manager) :
+    cluster_(cluster),
+    rtoptions_(rtoptions),
+    hal_(hal),
+    distributed_context_(distributed_context),
+    fabric_config_(fabric_config),
+    fabric_reliability_mode_(fabric_reliability_mode),
+    fabric_tensix_config_(fabric_tensix_config),
+    fabric_udm_mode_(fabric_udm_mode),
+    fabric_router_config_(fabric_router_config),
+    fabric_manager_(fabric_manager) {
+    init_control_plane(mesh_graph_desc_file, std::nullopt);
+    initialize_fabric_context();
+}
+
+ControlPlane::ControlPlane(
+    const ::tt::Cluster& cluster,
+    const ::tt::llrt::RunTimeOptions& rtoptions,
+    const ::tt::tt_metal::Hal& hal,
+    const tt_metal::distributed::multihost::DistributedContext& distributed_context,
+    const std::string& mesh_graph_desc_file,
+    const std::map<FabricNodeId, ChipId>& logical_mesh_chip_id_to_physical_chip_id_mapping,
+    FabricConfig fabric_config,
+    FabricReliabilityMode fabric_reliability_mode,
+    FabricTensixConfig fabric_tensix_config,
+    FabricUDMMode fabric_udm_mode,
+    FabricRouterConfig fabric_router_config,
+    FabricManagerMode fabric_manager) :
+    cluster_(cluster),
+    rtoptions_(rtoptions),
+    hal_(hal),
+    distributed_context_(distributed_context),
+    fabric_config_(fabric_config),
+    fabric_reliability_mode_(fabric_reliability_mode),
+    fabric_tensix_config_(fabric_tensix_config),
+    fabric_udm_mode_(fabric_udm_mode),
+    fabric_router_config_(fabric_router_config),
+    fabric_manager_(fabric_manager) {
     init_control_plane(mesh_graph_desc_file, logical_mesh_chip_id_to_physical_chip_id_mapping);
+    initialize_fabric_context();
+}
+
+void ControlPlane::initialize_fabric_context() {
+    if (tt::tt_fabric::is_tt_fabric_config(fabric_config_)) {
+        this->fabric_context_ = std::make_unique<FabricContext>(
+            *this, hal_, cluster_.get().arch(), cluster_.get().is_ubb_galaxy(), fabric_config_, fabric_router_config_);
+    }
 }
 
 void ControlPlane::load_physical_chip_mapping(
@@ -633,7 +719,7 @@ void ControlPlane::validate_mesh_connections(MeshId mesh_id) const {
     auto validate_chip_connections = [&](const MeshCoordinate& mesh_coord, const MeshCoordinate& other_mesh_coord) {
         ChipId physical_chip_id = get_physical_chip_id(mesh_coord);
         ChipId physical_chip_id_other = get_physical_chip_id(other_mesh_coord);
-        auto eth_links = get_ethernet_cores_grouped_by_connected_chips(physical_chip_id);
+        auto eth_links = this->cluster_.get().get_ethernet_cores_grouped_by_connected_chips(physical_chip_id);
         auto eth_links_to_other = eth_links.find(physical_chip_id_other);
         TT_FATAL(
             eth_links_to_other != eth_links.end(),
@@ -713,7 +799,7 @@ chan_id_t ControlPlane::get_downstream_eth_chan_id(
     // If no match found, return a channel from candidate_target_chans
     // Enabled for TG Dispatch on Fabric
     // TODO: https://github.com/tenstorrent/tt-metal/issues/24413
-    if (tt::tt_metal::MetalContext::instance().get_cluster().get_cluster_type() == tt::tt_metal::ClusterType::TG) {
+    if (this->cluster_.get().get_cluster_type() == tt::tt_metal::ClusterType::TG) {
         while (src_routing_plane_id >= candidate_target_chans.size()) {
             src_routing_plane_id = src_routing_plane_id % candidate_target_chans.size();
         }
@@ -740,11 +826,8 @@ void ControlPlane::convert_fabric_routing_table_to_chip_routing_table() {
             for (const auto& [_, src_fabric_chip_id] : local_mesh_chip_id_container) {
                 const auto src_fabric_node_id = FabricNodeId(mesh_id, src_fabric_chip_id);
                 auto physical_chip_id = get_physical_chip_id_from_fabric_node_id(src_fabric_node_id);
-                num_ports_per_chip = tt::tt_metal::MetalContext::instance()
-                                         .get_cluster()
-                                         .get_soc_desc(physical_chip_id)
-                                         .get_cores(CoreType::ETH)
-                                         .size();
+                num_ports_per_chip =
+                    this->cluster_.get().get_soc_desc(physical_chip_id).get_cores(CoreType::ETH).size();
                 break;
             }
         }
@@ -865,8 +948,7 @@ void ControlPlane::convert_fabric_routing_table_to_chip_routing_table() {
 void ControlPlane::order_ethernet_channels() {
     for (auto& [fabric_node_id, eth_chans_by_dir] : this->router_port_directions_to_physical_eth_chan_map_) {
         auto phys_chip_id = this->get_physical_chip_id_from_fabric_node_id(fabric_node_id);
-        const auto src_asic_id = tt::tt_metal::AsicID{
-            tt::tt_metal::MetalContext::instance().get_cluster().get_unique_chip_ids().at(phys_chip_id)};
+        const auto src_asic_id = tt::tt_metal::AsicID{this->cluster_.get().get_unique_chip_ids().at(phys_chip_id)};
         const auto& asic_neighbors = physical_system_descriptor_->get_asic_neighbors(src_asic_id);
         for (auto& [direction, eth_chans] : eth_chans_by_dir) {
             std::optional<tt::tt_metal::AsicID> neighbor_asic_id;
@@ -884,7 +966,7 @@ void ControlPlane::order_ethernet_channels() {
                     break;
                 }
             }
-            const auto& soc_desc = tt::tt_metal::MetalContext::instance().get_cluster().get_soc_desc(phys_chip_id);
+            const auto& soc_desc = this->cluster_.get().get_soc_desc(phys_chip_id);
             if (neighbor_asic_id.has_value() && src_asic_id > neighbor_asic_id.value()) {
                 std::sort(eth_chans.begin(), eth_chans.end(), [&soc_desc](const auto& a, const auto& b) {
                     auto translated_coords_a = soc_desc.get_eth_core_for_channel(a, CoordSystem::TRANSLATED);
@@ -894,8 +976,7 @@ void ControlPlane::order_ethernet_channels() {
             } else if (neighbor_asic_id.has_value()) {
                 // Find the physical chip ID for the neighbor AsicID
                 ChipId neighbor_phys_chip_id = 0;
-                const auto& chip_unique_ids =
-                    tt::tt_metal::MetalContext::instance().get_cluster().get_unique_chip_ids();
+                const auto& chip_unique_ids = this->cluster_.get().get_unique_chip_ids();
                 for (const auto& [physical_chip_id, unique_id] : chip_unique_ids) {
                     if (tt::tt_metal::AsicID{unique_id} == neighbor_asic_id.value()) {
                         neighbor_phys_chip_id = physical_chip_id;
@@ -903,8 +984,7 @@ void ControlPlane::order_ethernet_channels() {
                     }
                 }
                 // Get the soc_desc for the neighbor chip
-                const auto& neighbor_soc_desc =
-                    tt::tt_metal::MetalContext::instance().get_cluster().get_soc_desc(neighbor_phys_chip_id);
+                const auto& neighbor_soc_desc = this->cluster_.get().get_soc_desc(neighbor_phys_chip_id);
                 std::sort(
                     eth_connections.begin(), eth_connections.end(), [&neighbor_soc_desc](const auto& a, const auto& b) {
                         auto translated_coords_a =
@@ -924,7 +1004,7 @@ void ControlPlane::order_ethernet_channels() {
 void ControlPlane::trim_ethernet_channels_not_mapped_to_live_routing_planes() {
     auto user_mesh_ids = this->get_user_physical_mesh_ids();
     std::unordered_set<MeshId> user_mesh_ids_set(user_mesh_ids.begin(), user_mesh_ids.end());
-    if (tt::tt_metal::MetalContext::instance().get_fabric_config() != tt_fabric::FabricConfig::CUSTOM) {
+    if (this->get_fabric_config() != tt_fabric::FabricConfig::CUSTOM) {
         for (auto& [fabric_node_id, directional_eth_chans] : this->router_port_directions_to_physical_eth_chan_map_) {
             if (!user_mesh_ids_set.contains(fabric_node_id.mesh_id)) {
                 continue;
@@ -981,8 +1061,7 @@ size_t ControlPlane::get_num_live_routing_planes(
 
 // Only builds the routing table representation, does not actually populate the routing tables in memory of the
 // fabric routers on device
-void ControlPlane::configure_routing_tables_for_fabric_ethernet_channels(
-    tt::tt_fabric::FabricConfig fabric_config, tt_fabric::FabricReliabilityMode reliability_mode) {
+void ControlPlane::configure_routing_tables_for_fabric_ethernet_channels() {
     this->intra_mesh_routing_tables_.clear();
     this->inter_mesh_routing_tables_.clear();
     this->router_port_directions_to_physical_eth_chan_map_.clear();
@@ -1030,16 +1109,14 @@ void ControlPlane::configure_routing_tables_for_fabric_ethernet_channels(
                         FabricNodeId(mesh_id, logical_connected_chip_id));
 
                     const auto& connected_chips_and_eth_cores =
-                        tt::tt_metal::MetalContext::instance()
-                            .get_cluster()
-                            .get_ethernet_cores_grouped_by_connected_chips(physical_chip_id);
+                        this->cluster_.get().get_ethernet_cores_grouped_by_connected_chips(physical_chip_id);
 
                     // If connected_chips_and_eth_cores contains physical_connected_chip_id then atleast one connection
                     // exists to physical_connected_chip_id
                     bool connections_exist = connected_chips_and_eth_cores.contains(physical_connected_chip_id);
                     TT_FATAL(
-                        connections_exist ||
-                            reliability_mode != tt::tt_fabric::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE,
+                        connections_exist || fabric_reliability_mode_ !=
+                                                 tt::tt_fabric::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE,
                         "Expected connections to exist for M{}D{} to D{}",
                         mesh_id,
                         fabric_chip_id,
@@ -1049,7 +1126,8 @@ void ControlPlane::configure_routing_tables_for_fabric_ethernet_channels(
                     }
 
                     const auto& connected_eth_cores = connected_chips_and_eth_cores.at(physical_connected_chip_id);
-                    if (reliability_mode == tt::tt_fabric::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE) {
+                    if (fabric_reliability_mode_ ==
+                        tt::tt_fabric::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE) {
                         TT_FATAL(
                             connected_eth_cores.size() >= edge.connected_chip_ids.size(),
                             "Expected {} eth links from physical chip {} to physical chip {}",
@@ -1109,7 +1187,8 @@ void ControlPlane::configure_routing_tables_for_fabric_ethernet_channels(
         }
     }
 
-    this->initialize_dynamic_routing_plane_counts(intra_mesh_connectivity, fabric_config, reliability_mode);
+    this->initialize_dynamic_routing_plane_counts(
+        intra_mesh_connectivity, this->fabric_config_, this->fabric_reliability_mode_);
 
     // Order the ethernet channels so that when we use them for deciding connections, indexing into ports per direction
     // is consistent for each each neighbouring chip.
@@ -1136,7 +1215,7 @@ FabricNodeId ControlPlane::get_fabric_node_id_from_physical_chip_id(ChipId physi
 
     // Stub: For mock devices, return a synthetic FabricNodeId for any unmapped chip
     // Required for large mock clusters (32+ chips) where fabric config may not be fully populated
-    if (tt::tt_metal::MetalContext::instance().get_cluster().get_target_device_type() == tt::TargetDevice::Mock) {
+    if (this->cluster_.get().get_target_device_type() == tt::TargetDevice::Mock) {
         return FabricNodeId(MeshId{0}, physical_chip_id);
     }
 
@@ -1481,6 +1560,9 @@ std::vector<chan_id_t> ControlPlane::get_active_fabric_eth_channels_in_direction
 }
 
 void write_to_worker_or_fabric_tensix_cores(
+    const ControlPlane& control_plane,
+    const ::tt::Cluster& cluster,
+    const ::tt::tt_metal::Hal& hal,
     const void* worker_data,
     const void* dispatcher_data,
     const void* tensix_extension_data,
@@ -1488,25 +1570,24 @@ void write_to_worker_or_fabric_tensix_cores(
     tt::tt_metal::HalL1MemAddrType addr_type,
     ChipId physical_chip_id) {
     TT_FATAL(
-        size ==
-            tt_metal::MetalContext::instance().hal().get_dev_size(tt_metal::HalProgrammableCoreType::TENSIX, addr_type),
+        size == hal.get_dev_size(tt_metal::HalProgrammableCoreType::TENSIX, addr_type),
         "ControlPlane: Tensix core data size mismatch expected {} but got {}",
         size,
-        tt_metal::MetalContext::instance().hal().get_dev_size(tt_metal::HalProgrammableCoreType::TENSIX, addr_type));
+        hal.get_dev_size(tt_metal::HalProgrammableCoreType::TENSIX, addr_type));
 
-    const auto& soc_desc = tt::tt_metal::MetalContext::instance().get_cluster().get_soc_desc(physical_chip_id);
+    const auto& soc_desc = cluster.get_soc_desc(physical_chip_id);
     const std::vector<tt::umd::CoreCoord>& all_tensix_cores =
         soc_desc.get_cores(CoreType::TENSIX, CoordSystem::TRANSLATED);
 
     // Check if tensix config is enabled
-    bool tensix_config_enabled = tt::tt_metal::MetalContext::instance().get_fabric_tensix_config() !=
-                                 tt::tt_fabric::FabricTensixConfig::DISABLED;
+    bool tensix_config_enabled =
+        control_plane.get_fabric_tensix_config() != tt::tt_fabric::FabricTensixConfig::DISABLED;
 
     // Get pre-computed translated fabric mux cores from tensix config
     std::unordered_set<CoreCoord> fabric_mux_cores_translated;
     std::unordered_set<CoreCoord> dispatch_mux_cores_translated;
     if (tensix_config_enabled) {
-        const auto& fabric_context = tt::tt_metal::MetalContext::instance().get_control_plane().get_fabric_context();
+        const auto& fabric_context = control_plane.get_fabric_context();
         const auto& tensix_config = fabric_context.get_builder_context().get_tensix_config();
         fabric_mux_cores_translated = tensix_config.get_translated_fabric_mux_cores();
         dispatch_mux_cores_translated = tensix_config.get_translated_dispatch_mux_cores();
@@ -1542,23 +1623,23 @@ void write_to_worker_or_fabric_tensix_cores(
         CoreType core_type = get_core_type(core_coord);
         const void* data_to_write = select_data(core_type);
 
-        tt::tt_metal::MetalContext::instance().get_cluster().write_core(
+        cluster.write_core(
             data_to_write,
             size,
             tt_cxy_pair(physical_chip_id, core_coord),
-            tt_metal::MetalContext::instance().hal().get_dev_addr(
-                tt_metal::HalProgrammableCoreType::TENSIX, addr_type));
+            hal.get_dev_addr(tt_metal::HalProgrammableCoreType::TENSIX, addr_type));
     }
 }
 
 static void write_to_all_cores(
+    const ControlPlane& control_plane,
+    const ::tt::Cluster& cluster,
+    const ::tt::tt_metal::Hal& hal,
     const void* data,
     size_t size,
     tt::tt_metal::HalL1MemAddrType addr_type,
     ChipId physical_chip_id,
     tt::tt_metal::HalProgrammableCoreType core_type) {
-    const auto& cluster = tt::tt_metal::MetalContext::instance().get_cluster();
-
     const char* type_label = "Unknown";
     switch (core_type) {
         case tt::tt_metal::HalProgrammableCoreType::TENSIX: type_label = "Tensix"; break;
@@ -1568,10 +1649,10 @@ static void write_to_all_cores(
     }
 
     TT_FATAL(
-        size == tt::tt_metal::MetalContext::instance().hal().get_dev_size(core_type, addr_type),
+        size == hal.get_dev_size(core_type, addr_type),
         "ControlPlane: {} core data size mismatch expected {} but got {}",
         type_label,
-        tt::tt_metal::MetalContext::instance().hal().get_dev_size(core_type, addr_type),
+        hal.get_dev_size(core_type, addr_type),
         size);
 
     switch (core_type) {
@@ -1580,11 +1661,11 @@ static void write_to_all_cores(
             const std::vector<tt::umd::CoreCoord>& tensix_cores =
                 soc_desc.get_cores(CoreType::TENSIX, CoordSystem::TRANSLATED);
             for (const auto& tensix_core : tensix_cores) {
-                tt::tt_metal::MetalContext::instance().get_cluster().write_core(
+                cluster.write_core(
                     data,
                     size,
                     tt_cxy_pair(physical_chip_id, CoreCoord(tensix_core.x, tensix_core.y)),
-                    tt::tt_metal::MetalContext::instance().hal().get_dev_addr(core_type, addr_type));
+                    hal.get_dev_addr(core_type, addr_type));
             }
             break;
         }
@@ -1592,18 +1673,16 @@ static void write_to_all_cores(
         case tt::tt_metal::HalProgrammableCoreType::ACTIVE_ETH: {
             std::unordered_set<CoreCoord> logical_eth_cores =
                 (core_type == tt::tt_metal::HalProgrammableCoreType::IDLE_ETH)
-                    ? tt::tt_metal::MetalContext::instance().get_control_plane().get_inactive_ethernet_cores(
-                          physical_chip_id)
-                    : tt::tt_metal::MetalContext::instance().get_control_plane().get_active_ethernet_cores(
-                          physical_chip_id);
+                    ? control_plane.get_inactive_ethernet_cores(physical_chip_id)
+                    : control_plane.get_active_ethernet_cores(physical_chip_id);
             for (const CoreCoord& logical_eth_core : logical_eth_cores) {
                 CoreCoord virtual_eth_core = cluster.get_virtual_coordinate_from_logical_coordinates(
                     physical_chip_id, logical_eth_core, CoreType::ETH);
-                tt::tt_metal::MetalContext::instance().get_cluster().write_core(
+                cluster.write_core(
                     data,
                     size,
                     tt_cxy_pair(physical_chip_id, CoreCoord(virtual_eth_core.x, virtual_eth_core.y)),
-                    tt::tt_metal::MetalContext::instance().hal().get_dev_addr(core_type, addr_type));
+                    hal.get_dev_addr(core_type, addr_type));
             }
             break;
         }
@@ -1750,24 +1829,33 @@ void ControlPlane::write_routing_info_to_devices(MeshId mesh_id, ChipId chip_id)
 
     // Finally, write the full routing info to all Tensix cores and mirror to IDLE_ETH routing table
     write_to_all_cores(
+        *this,
+        this->cluster_,
+        this->hal_,
         &routing_info,
         sizeof(routing_info),
         tt::tt_metal::HalL1MemAddrType::ROUTING_TABLE,
         physical_chip_id,
         tt::tt_metal::HalProgrammableCoreType::TENSIX);
     write_to_all_cores(
+        *this,
+        this->cluster_,
+        this->hal_,
         &routing_info,
         sizeof(routing_info),
         tt::tt_metal::HalL1MemAddrType::ROUTING_TABLE,
         physical_chip_id,
         tt::tt_metal::HalProgrammableCoreType::IDLE_ETH);
     write_to_all_cores(
+        *this,
+        this->cluster_,
+        this->hal_,
         &routing_info,
         sizeof(routing_info),
         tt::tt_metal::HalL1MemAddrType::ROUTING_TABLE,
         physical_chip_id,
         tt::tt_metal::HalProgrammableCoreType::ACTIVE_ETH);
-    tt::tt_metal::MetalContext::instance().get_cluster().l1_barrier(physical_chip_id);
+    this->cluster_.get().l1_barrier(physical_chip_id);
 }
 
 // Write connection info to Tensix cores' L1 on a specific chip
@@ -1788,7 +1876,7 @@ void ControlPlane::write_fabric_connections_to_tensix_cores(MeshId mesh_id, Chip
     tt::tt_fabric::tensix_fabric_connections_l1_info_t fabric_tensix_connections = {};
 
     // Get all physically connected ethernet channels directly from the cluster
-    const auto& cluster = tt::tt_metal::MetalContext::instance().get_cluster();
+    const auto& cluster = this->cluster_.get();
     const auto& connected_chips_and_eth_cores = cluster.get_ethernet_cores_grouped_by_connected_chips(physical_chip_id);
 
     size_t num_eth_endpoint = 0;
@@ -1834,7 +1922,7 @@ void ControlPlane::write_fabric_connections_to_tensix_cores(MeshId mesh_id, Chip
         }
     }
 
-    const auto& fabric_tensix_config = tt::tt_metal::MetalContext::instance().get_fabric_tensix_config();
+    const auto& fabric_tensix_config = this->get_fabric_tensix_config();
     if (fabric_tensix_config == tt::tt_fabric::FabricTensixConfig::UDM) {
         // UDM mode: use per-worker connections
         this->write_udm_fabric_connections_to_tensix_cores(
@@ -1842,6 +1930,9 @@ void ControlPlane::write_fabric_connections_to_tensix_cores(MeshId mesh_id, Chip
     } else {
         // Non UDM mode: same connection info for all workers
         write_to_worker_or_fabric_tensix_cores(
+            *this,
+            this->cluster_,
+            this->hal_,
             &fabric_worker_connections,      // worker_data - goes to mux cores
             &fabric_dispatcher_connections,  // dispatcher_data - goes to dispatcher cores
             &fabric_tensix_connections,      // tensix_extension_data - goes to worker cores
@@ -1885,8 +1976,8 @@ void ControlPlane::write_fabric_telemetry_to_all_chips(const FabricNodeId& fabri
     auto physical_chip_id = this->logical_mesh_chip_id_to_physical_chip_id_mapping_.at(fabric_node_id);
     auto active_ethernet_cores = this->get_active_ethernet_cores(physical_chip_id);
 
-    const auto& hal = tt::tt_metal::MetalContext::instance().hal();
-    const auto& factory = hal.get_fabric_telemetry_factory(tt::tt_metal::HalProgrammableCoreType::ACTIVE_ETH);
+    const auto& factory =
+        this->hal_.get().get_fabric_telemetry_factory(tt::tt_metal::HalProgrammableCoreType::ACTIVE_ETH);
 
     auto telemetry = factory.create<::tt::tt_fabric::fabric_telemetry::FabricTelemetryStaticOnly>();
     auto telemetry_view = telemetry.view();
@@ -1894,30 +1985,25 @@ void ControlPlane::write_fabric_telemetry_to_all_chips(const FabricNodeId& fabri
     static_view.mesh_id() = static_cast<std::uint16_t>(*fabric_node_id.mesh_id);
     static_view.device_id() = static_cast<std::uint8_t>(fabric_node_id.chip_id);
     static_view.direction() = 0;  // TODO: populate from routing direction when available.
-    static_view.fabric_config() =
-        static_cast<std::uint32_t>(tt::tt_metal::MetalContext::instance().get_fabric_config());
+    static_view.fabric_config() = static_cast<std::uint32_t>(this->get_fabric_config());
     static_view.supported_stats() = ::tt::tt_fabric::fabric_telemetry::DynamicStatistics::NONE;
 
     for (const auto& active_ethernet_core : active_ethernet_cores) {
-        auto chan_id = tt::tt_metal::MetalContext::instance()
-                           .get_cluster()
-                           .get_soc_desc(physical_chip_id)
-                           .logical_eth_core_to_chan_map.at(active_ethernet_core);
+        auto chan_id =
+            this->cluster_.get().get_soc_desc(physical_chip_id).logical_eth_core_to_chan_map.at(active_ethernet_core);
 
         // auto routing_direction = get_eth_chan_direction(fabric_node_id, chan_id);
         // static_view.direction() = static_cast<std::uint8_t>(routing_direction);
 
-        CoreCoord virtual_eth_core =
-            tt::tt_metal::MetalContext::instance().get_cluster().get_virtual_eth_core_from_channel(
-                physical_chip_id, chan_id);
-        tt::tt_metal::MetalContext::instance().get_cluster().write_core(
+        CoreCoord virtual_eth_core = this->cluster_.get().get_virtual_eth_core_from_channel(physical_chip_id, chan_id);
+        this->cluster_.get().write_core(
             telemetry.data(),
             telemetry.size(),
             tt_cxy_pair(physical_chip_id, virtual_eth_core),
-            hal.get_dev_addr(
+            hal_.get().get_dev_addr(
                 tt::tt_metal::HalProgrammableCoreType::ACTIVE_ETH, tt::tt_metal::HalL1MemAddrType::FABRIC_TELEMETRY));
     }
-    tt::tt_metal::MetalContext::instance().get_cluster().l1_barrier(physical_chip_id);
+    this->cluster_.get().l1_barrier(physical_chip_id);
 }
 
 void ControlPlane::write_routing_tables_to_all_chips() const {
@@ -1944,7 +2030,7 @@ void ControlPlane::write_routing_tables_to_all_chips() const {
 // TODO: remove this after TG is deprecated
 std::vector<MeshId> ControlPlane::get_user_physical_mesh_ids() const {
     std::vector<MeshId> physical_mesh_ids;
-    const auto user_chips = tt::tt_metal::MetalContext::instance().get_cluster().user_exposed_chip_ids();
+    const auto user_chips = this->cluster_.get().user_exposed_chip_ids();
     for (const auto& [fabric_node_id, physical_chip_id] : this->logical_mesh_chip_id_to_physical_chip_id_mapping_) {
         if (user_chips.contains(physical_chip_id) and
             std::find(physical_mesh_ids.begin(), physical_mesh_ids.end(), fabric_node_id.mesh_id) ==
@@ -2011,12 +2097,6 @@ void ControlPlane::print_ethernet_channels() const {
     log_debug(tt::LogFabric, "{}", ss.str());
 }
 
-void ControlPlane::initialize_fabric_context(
-    tt_fabric::FabricConfig fabric_config, const FabricRouterConfig& router_config) {
-    TT_FATAL(this->fabric_context_ == nullptr, "Trying to re-initialize fabric context");
-    this->fabric_context_ = std::make_unique<FabricContext>(fabric_config, router_config);
-}
-
 FabricContext& ControlPlane::get_fabric_context() const {
     TT_FATAL(this->fabric_context_ != nullptr, "Trying to get un-initialized fabric context");
     return *this->fabric_context_;
@@ -2027,7 +2107,7 @@ std::map<std::string, std::string> ControlPlane::get_fabric_kernel_defines() con
         return {};
     }
 
-    return this->fabric_context_->get_fabric_kernel_defines();
+    return this->fabric_context_->get_fabric_kernel_defines(*this);
 }
 
 void ControlPlane::clear_fabric_context() {
@@ -2041,12 +2121,12 @@ void ControlPlane::initialize_fabric_tensix_datamover_config() {
 }
 
 bool ControlPlane::is_cross_host_eth_link(ChipId chip_id, chan_id_t chan_id) const {
-    auto asic_id = tt::tt_metal::MetalContext::instance().get_cluster().get_unique_chip_ids().at(chip_id);
+    auto asic_id = this->cluster_.get().get_unique_chip_ids().at(chip_id);
     return this->physical_system_descriptor_->is_cross_host_eth_link(tt::tt_metal::AsicID{asic_id}, chan_id);
 }
 
 std::unordered_set<CoreCoord> ControlPlane::get_active_ethernet_cores(ChipId chip_id, bool skip_reserved_cores) const {
-    const auto& cluster = tt::tt_metal::MetalContext::instance().get_cluster();
+    const auto& cluster = this->cluster_.get();
 
     std::unordered_set<CoreCoord> active_ethernet_cores;
     const auto& cluster_desc = cluster.get_cluster_desc();
@@ -2107,7 +2187,7 @@ std::unordered_set<CoreCoord> ControlPlane::get_active_ethernet_cores(ChipId chi
 }
 
 std::unordered_set<CoreCoord> ControlPlane::get_inactive_ethernet_cores(ChipId chip_id) const {
-    const auto& cluster = tt::tt_metal::MetalContext::instance().get_cluster();
+    const auto& cluster = this->cluster_.get();
     std::unordered_set<CoreCoord> active_ethernet_cores = this->get_active_ethernet_cores(chip_id);
     std::unordered_set<CoreCoord> inactive_ethernet_cores;
 
@@ -2123,8 +2203,7 @@ void ControlPlane::assign_direction_to_fabric_eth_chan(
     const FabricNodeId& fabric_node_id, chan_id_t chan_id, RoutingDirection direction) {
     auto physical_chip_id = this->logical_mesh_chip_id_to_physical_chip_id_mapping_.at(fabric_node_id);
     // TODO: get_fabric_ethernet_channels accounts for down links, but we should manage down links in control plane
-    auto fabric_router_channels_on_chip =
-        tt::tt_metal::MetalContext::instance().get_cluster().get_fabric_ethernet_channels(*this, physical_chip_id);
+    auto fabric_router_channels_on_chip = this->cluster_.get().get_fabric_ethernet_channels(*this, physical_chip_id);
 
     // TODO: add logic here to disable unsed routers, e.g. Mesh on Torus system
     if (fabric_router_channels_on_chip.contains(chan_id)) {
@@ -2142,10 +2221,7 @@ void ControlPlane::assign_direction_to_fabric_eth_chan(
 void ControlPlane::assign_direction_to_fabric_eth_core(
     const FabricNodeId& fabric_node_id, const CoreCoord& eth_core, RoutingDirection direction) {
     auto physical_chip_id = this->logical_mesh_chip_id_to_physical_chip_id_mapping_.at(fabric_node_id);
-    auto chan_id = tt::tt_metal::MetalContext::instance()
-                       .get_cluster()
-                       .get_soc_desc(physical_chip_id)
-                       .logical_eth_core_to_chan_map.at(eth_core);
+    auto chan_id = this->cluster_.get().get_soc_desc(physical_chip_id).logical_eth_core_to_chan_map.at(eth_core);
     this->assign_direction_to_fabric_eth_chan(fabric_node_id, chan_id, direction);
 }
 
@@ -2253,13 +2329,13 @@ void ControlPlane::populate_fabric_connection_info(
     chan_id_t eth_channel_id) const {
     constexpr uint16_t WORKER_FREE_SLOTS_STREAM_ID =
         tt::tt_fabric::connection_interface::sender_channel_0_free_slots_stream_id;
-    const auto& cluster = tt::tt_metal::MetalContext::instance().get_cluster();
+    const auto& cluster = this->cluster_.get();
     const auto& fabric_context = this->get_fabric_context();
     const auto& builder_context = fabric_context.get_builder_context();
     // Sender channel 0 is always for local worker in the new design
     const auto sender_channel = 0;
 
-    const auto& fabric_tensix_config = tt::tt_metal::MetalContext::instance().get_fabric_tensix_config();
+    const auto& fabric_tensix_config = this->get_fabric_tensix_config();
     // Always populate fabric router config for normal workers
     const auto& edm_config = builder_context.get_fabric_router_config(
         fabric_tensix_config, static_cast<eth_chan_directions>(sender_channel));
@@ -2301,7 +2377,7 @@ void ControlPlane::write_udm_fabric_connections_to_tensix_cores(
     ChipId physical_chip_id,
     const tt::tt_fabric::tensix_fabric_connections_l1_info_t& fabric_mux_connections,
     const tt::tt_fabric::tensix_fabric_connections_l1_info_t& fabric_dispatcher_connections) const {
-    const auto& cluster = tt::tt_metal::MetalContext::instance().get_cluster();
+    const auto& cluster = this->cluster_.get();
     const auto& fabric_context = this->get_fabric_context();
     const auto& tensix_config = fabric_context.get_builder_context().get_tensix_config();
 
@@ -2350,7 +2426,7 @@ void ControlPlane::write_udm_fabric_connections_to_tensix_cores(
             data_to_write,
             sizeof(tt::tt_fabric::tensix_fabric_connections_l1_info_t),
             tt_cxy_pair(physical_chip_id, core_coord),
-            tt_metal::MetalContext::instance().hal().get_dev_addr(
+            this->hal_.get().get_dev_addr(
                 tt_metal::HalProgrammableCoreType::TENSIX, tt::tt_metal::HalL1MemAddrType::TENSIX_FABRIC_CONNECTIONS));
 
         // Initialize fabric connection sync region (lock=0, initialized=0, connection_storage zeroed)
@@ -2359,13 +2435,13 @@ void ControlPlane::write_udm_fabric_connections_to_tensix_cores(
             &sync_init,
             sizeof(sync_init),
             tt_cxy_pair(physical_chip_id, core_coord),
-            tt_metal::MetalContext::instance().hal().get_dev_addr(
+            this->hal_.get().get_dev_addr(
                 tt_metal::HalProgrammableCoreType::TENSIX, tt::tt_metal::HalL1MemAddrType::FABRIC_CONNECTION_LOCK));
     }
 }
 
 void ControlPlane::collect_and_merge_router_port_directions_from_all_hosts() {
-    const auto& distributed_context = tt::tt_metal::MetalContext::instance().full_world_distributed_context();
+    const auto& distributed_context = this->distributed_context_.get();
     if (*distributed_context.size() == 1) {
         // No need to collect from other hosts when running a single process
         return;
@@ -2460,8 +2536,7 @@ void ControlPlane::generate_intermesh_connectivity() {
                                                         : requested_intermesh_ports.size();
     };
 
-    if (!generate_mapping_locally_ &&
-        *(tt_metal::MetalContext::instance().full_world_distributed_context().size()) > 1) {
+    if (!generate_mapping_locally_ && *(this->distributed_context_.get().size()) > 1) {
         // Intermesh Connectivity generation for the multi-host case
         auto exit_node_port_descriptors = this->generate_port_descriptors_for_exit_nodes();
         intermesh_connections = this->convert_port_desciptors_to_intermesh_connections(exit_node_port_descriptors);
@@ -2661,7 +2736,7 @@ void ControlPlane::forward_descriptors_to_controller(
     PortDescriptorTable& port_descriptors, uint32_t my_rank, const std::string& my_host) {
     using namespace tt::tt_metal::distributed::multihost;
     constexpr uint32_t CONTROLLER_RANK = 0;
-    const auto& distributed_context = tt::tt_metal::MetalContext::instance().full_world_distributed_context();
+    const auto& distributed_context = this->distributed_context_.get();
     const auto& physical_system_descriptor = this->physical_system_descriptor_;
     std::size_t serialized_table_size = 0;
     std::vector<uint8_t> serialized_table;
@@ -2728,7 +2803,7 @@ void ControlPlane::forward_descriptors_to_controller(
 
 void ControlPlane::forward_intermesh_connections_from_controller(AnnotatedIntermeshConnections& intermesh_connections) {
     using namespace tt::tt_metal::distributed::multihost;
-    const auto& distributed_context = tt::tt_metal::MetalContext::instance().full_world_distributed_context();
+    const auto& distributed_context = this->distributed_context_.get();
     constexpr uint32_t CONTROLLER_RANK = 0;
     const auto& my_host = physical_system_descriptor_->my_host_name();
     auto my_rank = physical_system_descriptor_->get_rank_for_hostname(my_host);
@@ -2921,8 +2996,7 @@ AnnotatedIntermeshConnections ControlPlane::generate_intermesh_connections_on_lo
         // Pair the exit nodes from the current mesh with the exit nodes from the neighboring meshes
         for (const auto& node : exit_nodes) {
             auto physical_chip_id = logical_mesh_chip_id_to_physical_chip_id_mapping_.at(node);
-            auto asic_id =
-                tt::tt_metal::MetalContext::instance().get_cluster().get_unique_chip_ids().at(physical_chip_id);
+            auto asic_id = this->cluster_.get().get_unique_chip_ids().at(physical_chip_id);
             const auto& asic_neighbors = physical_system_descriptor->get_asic_neighbors(tt::tt_metal::AsicID{asic_id});
 
             for (const auto& asic_neighbor : asic_neighbors) {
@@ -3082,7 +3156,7 @@ void ControlPlane::validate_torus_setup(tt::tt_fabric::FabricConfig fabric_confi
 }
 
 std::string ControlPlane::get_galaxy_cabling_descriptor_path(tt::tt_fabric::FabricConfig fabric_config) const {
-    auto cluster_type = tt::tt_metal::MetalContext::instance().get_cluster().get_cluster_type();
+    auto cluster_type = this->cluster_.get().get_cluster_type();
     TT_FATAL(
         cluster_type == tt::tt_metal::ClusterType::GALAXY,
         "get_galaxy_cabling_descriptor_path is only supported on Galaxy systems, but cluster type is {}",
@@ -3094,7 +3168,7 @@ std::string ControlPlane::get_galaxy_cabling_descriptor_path(tt::tt_fabric::Fabr
         "tt_metal/fabric/cabling_descriptors/wh_galaxy_xy_torus.textproto";
 
     // Get fabric type from config and map to cabling descriptor paths
-    FabricType fabric_type = get_fabric_type(fabric_config);
+    FabricType fabric_type = get_fabric_type(fabric_config, this->cluster_.get().is_ubb_galaxy());
 
     static constexpr std::array<std::pair<FabricType, std::string_view>, 3> cabling_map = {
         {{FabricType::TORUS_X, X_TORUS_PATH},
@@ -3105,7 +3179,7 @@ std::string ControlPlane::get_galaxy_cabling_descriptor_path(tt::tt_fabric::Fabr
         cabling_map.begin(), cabling_map.end(), [fabric_type](const auto& pair) { return pair.first == fabric_type; });
     TT_FATAL(it != cabling_map.end(), "Unknown torus configuration: {}", enchantum::to_string(fabric_config));
 
-    const auto& root_dir = tt::tt_metal::MetalContext::instance().rtoptions().get_root_dir();
+    const auto& root_dir = this->rtoptions_.get().get_root_dir();
     return root_dir + std::string(it->second);
 }
 

--- a/tt_metal/fabric/control_plane.cpp
+++ b/tt_metal/fabric/control_plane.cpp
@@ -435,7 +435,7 @@ void ControlPlane::init_control_plane(
     auto fabric_config = this->get_fabric_config();
 
     // Create mesh_graph first
-    this->mesh_graph_ = std::make_unique<MeshGraph>(this->cluster_, mesh_graph_desc_file, fabric_config);
+    this->mesh_graph_ = std::make_unique<MeshGraph>(cluster.get_cluster_type(), mesh_graph_desc_file, fabric_config);
 
     this->physical_system_descriptor_ = std::make_unique<tt::tt_metal::PhysicalSystemDescriptor>(
         driver, distributed_context, &this->hal_.get(), rtoptions);

--- a/tt_metal/fabric/erisc_datamover_builder.cpp
+++ b/tt_metal/fabric/erisc_datamover_builder.cpp
@@ -1002,7 +1002,7 @@ std::vector<uint32_t> FabricEriscDatamoverBuilder::get_compile_time_args(uint32_
     // unsure which one we should prefer at the moment
     // bool z_routers_enabled = fabric_context.get_builder_context().get_intermesh_vc_config().router_type ==
     // IntermeshRouterType::Z_INTERMESH;
-    bool z_router_enabled = fabric_context.has_z_router_on_device(local_fabric_node_id);
+    bool z_router_enabled = fabric_context.has_z_router_on_device(control_plane, local_fabric_node_id);
 
     log_debug(
         LogFabric,

--- a/tt_metal/fabric/fabric.cpp
+++ b/tt_metal/fabric/fabric.cpp
@@ -161,8 +161,8 @@ void append_fabric_connection_rt_args(
         src_fabric_node_id,
         dst_fabric_node_id);
 
-    const auto forwarding_links =
-        get_forwarding_link_indices_in_direction(src_fabric_node_id, dst_fabric_node_id, forwarding_direction.value());
+    const auto forwarding_links = get_forwarding_link_indices_in_direction(
+        control_plane, src_fabric_node_id, dst_fabric_node_id, forwarding_direction.value());
     TT_FATAL(
         std::find(forwarding_links.begin(), forwarding_links.end(), link_idx) != forwarding_links.end(),
         "Requested link index {} cannot be used for forwarding b/w src {} and dst {}. Valid forwarding links are {}",
@@ -435,7 +435,7 @@ std::vector<uint32_t> get_forwarding_link_indices(
     }
 
     return get_forwarding_link_indices_in_direction(
-        src_fabric_node_id, dst_fabric_node_id, forwarding_direction.value());
+        control_plane, src_fabric_node_id, dst_fabric_node_id, forwarding_direction.value());
 }
 
 tt::tt_fabric::Topology get_fabric_topology() {

--- a/tt_metal/fabric/fabric_context.hpp
+++ b/tt_metal/fabric/fabric_context.hpp
@@ -37,8 +37,14 @@ public:
     static constexpr auto routing_directions = {
         RoutingDirection::N, RoutingDirection::S, RoutingDirection::E, RoutingDirection::W, RoutingDirection::Z};
 
+    // control_plane and hal references are not held
     explicit FabricContext(
-        tt::tt_fabric::FabricConfig fabric_config, const FabricRouterConfig& router_config = FabricRouterConfig{});
+        const ControlPlane& control_plane,
+        const tt_metal::Hal& hal,
+        tt::ARCH arch,
+        bool is_ubb_galaxy,
+        tt::tt_fabric::FabricConfig fabric_config,
+        const FabricRouterConfig& router_config = FabricRouterConfig{});
     ~FabricContext();
 
     // Non-copyable, non-movable
@@ -53,6 +59,7 @@ public:
     bool is_2D_routing_enabled() const { return is_2D_routing_enabled_; }
     bool is_bubble_flow_control_enabled() const { return bubble_flow_control_enabled_; }
     bool need_deadlock_avoidance_support(eth_chan_directions direction) const;
+    bool is_ubb_galaxy() const { return is_ubb_galaxy_; }
 
     // ============ Mesh Type Queries ============
     // Stub: returns false for now (all meshes are compute meshes)
@@ -62,7 +69,7 @@ public:
     // ============ Z Router Queries ============
     // Check if a fabric node has Z router channels
     // Queries control plane to see if any ethernet channels are assigned Z direction
-    bool has_z_router_on_device(const FabricNodeId& fabric_node_id) const;
+    bool has_z_router_on_device(const ControlPlane& control_plane, const FabricNodeId& fabric_node_id) const;
 
     // ============ Tensix Config Query ============
     // Returns true if tensix is enabled (MUX or UDM mode)
@@ -85,7 +92,7 @@ public:
     }
 
     // Returns empty map if routing mode is undefined
-    std::map<std::string, std::string> get_fabric_kernel_defines() const;
+    std::map<std::string, std::string> get_fabric_kernel_defines(const ControlPlane& control_plane) const;
 
     // ============ Builder Context Access ============
     // For build-time operations (config selection, per-device state, router addresses)
@@ -135,20 +142,20 @@ private:
     };
 
     // ============ Private Implementation ============
-    std::unordered_map<MeshId, bool> check_for_wrap_around_mesh() const;
-    size_t compute_packet_header_size_bytes() const;
-    size_t compute_max_payload_size_bytes() const;
-    size_t validate_and_apply_packet_size(size_t requested_size) const;
+    std::unordered_map<MeshId, bool> check_for_wrap_around_mesh(const ControlPlane& control_plane) const;
+    size_t compute_packet_header_size_bytes(const ControlPlane& control_plane) const;
+    size_t compute_max_payload_size_bytes(const tt_metal::Hal& hal, tt::ARCH arch) const;
+    size_t validate_and_apply_packet_size(const tt_metal::Hal& hal, tt::ARCH arch, size_t requested_size) const;
 
     // Compute and validate routing mode from topology
     void compute_routing_mode();
 
     // Topology-based sizing
-    uint32_t get_max_1d_hops_from_topology() const;
-    uint32_t get_max_2d_hops_from_topology() const;
+    uint32_t get_max_1d_hops_from_topology(const ControlPlane& control_plane) const;
+    uint32_t get_max_2d_hops_from_topology(const ControlPlane& control_plane) const;
     uint32_t compute_1d_pkt_hdr_extension_words(uint32_t max_hops) const;
     uint32_t compute_2d_pkt_hdr_route_buffer_size(uint32_t max_hops) const;
-    void compute_packet_specifications();
+    void compute_packet_specifications(const ControlPlane& control_plane, const tt_metal::Hal& hal, tt::ARCH arch);
 
     // Header size helpers (use explicit template instantiation for type safety)
     size_t get_1d_header_size(uint32_t extension_words) const;
@@ -162,6 +169,7 @@ private:
     bool is_2D_routing_enabled_ = false;
     bool bubble_flow_control_enabled_ = false;
     bool tensix_enabled_ = false;
+    bool is_ubb_galaxy_ = false;
 
     std::unordered_map<MeshId, bool> wrap_around_mesh_;
 

--- a/tt_metal/fabric/fabric_host_utils.cpp
+++ b/tt_metal/fabric/fabric_host_utils.cpp
@@ -125,9 +125,10 @@ uint32_t compute_max_2d_hops(const std::vector<MeshShape>& mesh_shapes) {
 }
 
 std::vector<uint32_t> get_forwarding_link_indices_in_direction(
-    const FabricNodeId& src_fabric_node_id, const FabricNodeId& dst_fabric_node_id, RoutingDirection direction) {
-    const auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
-
+    const ControlPlane& control_plane,
+    const FabricNodeId& src_fabric_node_id,
+    const FabricNodeId& dst_fabric_node_id,
+    RoutingDirection direction) {
     const std::vector<chan_id_t>& fabric_channels =
         control_plane.get_active_fabric_eth_channels_in_direction(src_fabric_node_id, direction);
 

--- a/tt_metal/fabric/fabric_host_utils.cpp
+++ b/tt_metal/fabric/fabric_host_utils.cpp
@@ -25,6 +25,7 @@
 #include <fstream>
 #include <yaml-cpp/yaml.h>
 #include <tt-logger/tt-logger.hpp>
+#include <llrt/tt_cluster.hpp>
 
 namespace tt::tt_fabric {
 
@@ -32,14 +33,14 @@ bool is_tt_fabric_config(tt::tt_fabric::FabricConfig fabric_config) {
     return is_1d_fabric_config(fabric_config) || is_2d_fabric_config(fabric_config);
 }
 
-FabricType get_fabric_type(tt::tt_fabric::FabricConfig fabric_config) {
+FabricType get_fabric_type(tt::tt_fabric::FabricConfig fabric_config, bool is_ubb_galaxy) {
     switch (fabric_config) {
         // Issue: 32146, Special case for T3k WH devices to use Mesh fabric type instead of Torus_XY
         // WH T3K currently do not support Torus_XY fabric type, because they do not have wrapping connections.
         // If you want to use 1D Ring on t3k please use 1x8 MGD.
         case tt::tt_fabric::FabricConfig::FABRIC_1D_NEIGHBOR_EXCHANGE:
         case tt::tt_fabric::FabricConfig::FABRIC_1D_RING: {
-            if (tt::tt_metal::MetalContext::instance().get_cluster().is_ubb_galaxy()) {
+            if (is_ubb_galaxy) {
                 return FabricType::TORUS_XY;
             }
             return FabricType::MESH;

--- a/tt_metal/fabric/fabric_host_utils.hpp
+++ b/tt_metal/fabric/fabric_host_utils.hpp
@@ -45,7 +45,10 @@ uint32_t compute_max_1d_hops(const std::vector<MeshShape>& mesh_shapes);
 uint32_t compute_max_2d_hops(const std::vector<MeshShape>& mesh_shapes);
 
 std::vector<uint32_t> get_forwarding_link_indices_in_direction(
-    const FabricNodeId& src_fabric_node_id, const FabricNodeId& dst_fabric_node_id, RoutingDirection direction);
+    const ControlPlane& control_plane,
+    const FabricNodeId& src_fabric_node_id,
+    const FabricNodeId& dst_fabric_node_id,
+    RoutingDirection direction);
 
 // Helper: Build adjacency map and discover corners/edges using BFS
 using AdjacencyMap = std::unordered_map<ChipId, std::vector<ChipId>>;

--- a/tt_metal/fabric/fabric_host_utils.hpp
+++ b/tt_metal/fabric/fabric_host_utils.hpp
@@ -27,7 +27,7 @@ class TopologyMapper;
 class FabricNodeId;
 bool is_tt_fabric_config(tt::tt_fabric::FabricConfig fabric_config);
 
-FabricType get_fabric_type(tt::tt_fabric::FabricConfig fabric_config);
+FabricType get_fabric_type(tt::tt_fabric::FabricConfig fabric_config, bool is_ubb_galaxy);
 
 // Helper to validate that requested FabricType doesn't require more connectivity than available FabricType provides
 // Returns true if requested_type requires more connections than available_type provides

--- a/tt_metal/fabric/mesh_graph.cpp
+++ b/tt_metal/fabric/mesh_graph.cpp
@@ -101,7 +101,7 @@ const tt::stl::Indestructible<FabricToClusterDescriptorMap>& cluster_type_to_mes
              {tt::tt_metal::ClusterType::BLACKHOLE_GALAXY, "single_bh_galaxy_torus_xy_graph_descriptor.textproto"}}}});
 
 MeshGraph::MeshGraph(
-    const tt::Cluster& cluster,
+    tt::tt_metal::ClusterType cluster_type,
     const std::string& mesh_graph_desc_file_path,
     std::optional<FabricConfig> fabric_config) {
     log_debug(tt::LogFabric, "mesh_graph_desc_file_path: {}", mesh_graph_desc_file_path);
@@ -109,7 +109,8 @@ MeshGraph::MeshGraph(
         auto filepath = std::filesystem::path(mesh_graph_desc_file_path);
         mesh_graph_desc_file_path_ = filepath;
         mesh_graph_descriptor_.emplace(filepath, true);
-        this->initialize_from_mgd(mesh_graph_descriptor_.value(), fabric_config, cluster.is_ubb_galaxy());
+        this->initialize_from_mgd(
+            mesh_graph_descriptor_.value(), fabric_config, tt::Cluster::is_ubb_galaxy(cluster_type));
     } else {
         TT_THROW(
             "Mesh graph descriptor file must use the .textproto format. "
@@ -124,6 +125,12 @@ MeshGraph::MeshGraph(
             mesh_graph_desc_file_path);
     }
 }
+
+MeshGraph::MeshGraph(
+    const tt::Cluster& cluster,
+    const std::string& mesh_graph_desc_file_path,
+    std::optional<FabricConfig> fabric_config) :
+    MeshGraph(cluster.get_cluster_type(), mesh_graph_desc_file_path, fabric_config) {}
 
 void MeshGraph::add_to_connectivity(
     MeshId src_mesh_id, ChipId src_chip_id, MeshId dest_mesh_id, ChipId dest_chip_id, RoutingDirection port_direction) {

--- a/tt_metal/fabric/mesh_graph.cpp
+++ b/tt_metal/fabric/mesh_graph.cpp
@@ -869,13 +869,12 @@ bool MeshGraph::is_intra_mesh_policy_relaxed(MeshId mesh_id) const {
  */
 
 MeshGraph MeshGraph::generate_mesh_graph_of_shape(
-    const tt::Cluster& cluster,
     MeshShape mesh_shape,
     tt::tt_fabric::FabricType fabric_type,
     tt::tt_fabric::FabricReliabilityMode reliability_mode,
     tt::ARCH arch,
     std::uint32_t num_connections_per_direction) {
-    MeshGraph mesh_graph(cluster);
+    MeshGraph mesh_graph;
 
     // Use the provided num_connections_per_direction
     std::uint32_t num_eth_ports_per_direction = num_connections_per_direction;

--- a/tt_metal/fabric/mesh_graph.cpp
+++ b/tt_metal/fabric/mesh_graph.cpp
@@ -18,6 +18,7 @@
 #include <tt_stl/assert.hpp>
 #include <tt-logger/tt-logger.hpp>
 #include <llrt/tt_cluster.hpp>
+#include <umd/device/types/arch.hpp>
 #include <umd/device/types/cluster_descriptor_types.hpp>
 #include <tt_stl/indestructible.hpp>
 #include <tt_stl/caseless_comparison.hpp>
@@ -25,7 +26,6 @@
 #include <tt-metalium/experimental/fabric/mesh_graph_descriptor.hpp>
 #include "physical_system_descriptor.hpp"
 #include "protobuf/mesh_graph_descriptor.pb.h"
-#include "impl/context/metal_context.hpp"
 #include <numeric>
 #include <set>
 #include <cmath>
@@ -100,13 +100,16 @@ const tt::stl::Indestructible<FabricToClusterDescriptorMap>& cluster_type_to_mes
              {tt::tt_metal::ClusterType::GALAXY, "single_galaxy_torus_xy_graph_descriptor.textproto"},
              {tt::tt_metal::ClusterType::BLACKHOLE_GALAXY, "single_bh_galaxy_torus_xy_graph_descriptor.textproto"}}}});
 
-MeshGraph::MeshGraph(const std::string& mesh_graph_desc_file_path, std::optional<FabricConfig> fabric_config) {
+MeshGraph::MeshGraph(
+    const tt::Cluster& cluster,
+    const std::string& mesh_graph_desc_file_path,
+    std::optional<FabricConfig> fabric_config) {
     log_debug(tt::LogFabric, "mesh_graph_desc_file_path: {}", mesh_graph_desc_file_path);
     if (mesh_graph_desc_file_path.ends_with(".textproto")) {
         auto filepath = std::filesystem::path(mesh_graph_desc_file_path);
         mesh_graph_desc_file_path_ = filepath;
         mesh_graph_descriptor_.emplace(filepath, true);
-        this->initialize_from_mgd(mesh_graph_descriptor_.value(), fabric_config);
+        this->initialize_from_mgd(mesh_graph_descriptor_.value(), fabric_config, cluster.is_ubb_galaxy());
     } else {
         TT_THROW(
             "Mesh graph descriptor file must use the .textproto format. "
@@ -216,7 +219,8 @@ std::unordered_map<ChipId, RouterEdge> MeshGraph::get_valid_connections(
     return valid_connections;
 }
 
-void MeshGraph::initialize_from_mgd(const MeshGraphDescriptor& mgd, std::optional<FabricConfig> fabric_config) {
+void MeshGraph::initialize_from_mgd(
+    const MeshGraphDescriptor& mgd, std::optional<FabricConfig> fabric_config, bool is_ubb_galaxy) {
     static const std::unordered_map<const proto::Architecture, tt::ARCH> proto_arch_to_arch = {
         {proto::Architecture::WORMHOLE_B0, tt::ARCH::WORMHOLE_B0},
         {proto::Architecture::BLACKHOLE, tt::ARCH::BLACKHOLE},
@@ -366,12 +370,13 @@ void MeshGraph::initialize_from_mgd(const MeshGraphDescriptor& mgd, std::optiona
         FabricType effective_fabric_type;
 
         if (fabric_config.has_value()) {
-            FabricType requested_fabric_type = get_fabric_type(*fabric_config);
+            FabricType requested_fabric_type = get_fabric_type(*fabric_config, is_ubb_galaxy);
             // Validate that FabricConfig doesn't try to create connections that don't exist
             if (requires_more_connectivity(requested_fabric_type, mgd_fabric_type, mesh_shape)) {
                 TT_THROW(
-                    "FabricConfig requests topology {} which requires more connectivity than MGD provides {}. "
+                    "FabricConfig {} requests topology {} which requires more connectivity than MGD provides {}. "
                     "FabricConfig can only restrict topology (e.g., torus→mesh), not create new connections.",
+                    enchantum::to_string(*fabric_config),
                     enchantum::to_string(requested_fabric_type),
                     enchantum::to_string(mgd_fabric_type));
             }
@@ -509,7 +514,7 @@ void MeshGraph::initialize_from_mgd(const MeshGraphDescriptor& mgd, std::optiona
         FabricType effective_fabric_type;
 
         if (fabric_config.has_value()) {
-            FabricType requested_fabric_type = get_fabric_type(*fabric_config);
+            FabricType requested_fabric_type = get_fabric_type(*fabric_config, is_ubb_galaxy);
             // Validate that FabricConfig doesn't try to create connections that don't exist
             if (requires_more_connectivity(requested_fabric_type, mgd_fabric_type, switch_shape)) {
                 TT_THROW(
@@ -864,16 +869,13 @@ bool MeshGraph::is_intra_mesh_policy_relaxed(MeshId mesh_id) const {
  */
 
 MeshGraph MeshGraph::generate_mesh_graph_of_shape(
-    MeshShape mesh_shape, tt::tt_fabric::FabricType fabric_type, std::uint32_t num_connections_per_direction) {
-    MeshGraph mesh_graph;
-
-    // Get chip spec from MetalContext
-    const auto& metal_context = tt::tt_metal::MetalContext::instance();
-    const auto& cluster = metal_context.get_cluster();
-    tt::ARCH arch = cluster.get_cluster_desc()->get_arch();
-
-    // Get reliability mode from fabric config (stored in MetalContext)
-    tt::tt_fabric::FabricReliabilityMode reliability_mode = metal_context.get_fabric_reliability_mode();
+    const tt::Cluster& cluster,
+    MeshShape mesh_shape,
+    tt::tt_fabric::FabricType fabric_type,
+    tt::tt_fabric::FabricReliabilityMode reliability_mode,
+    tt::ARCH arch,
+    std::uint32_t num_connections_per_direction) {
+    MeshGraph mesh_graph(cluster);
 
     // Use the provided num_connections_per_direction
     std::uint32_t num_eth_ports_per_direction = num_connections_per_direction;

--- a/tt_metal/fabric/topology_mapper.cpp
+++ b/tt_metal/fabric/topology_mapper.cpp
@@ -18,7 +18,6 @@
 #include <tt-metalium/experimental/fabric/control_plane.hpp>
 #include <tt-metalium/experimental/fabric/fabric_types.hpp>
 #include <tt-metalium/experimental/fabric/topology_mapper_utils.hpp>
-#include "tt_metal/impl/context/metal_context.hpp"
 #include <tt-metalium/distributed_context.hpp>
 #include <tt-metalium/experimental/fabric/mesh_graph.hpp>
 #include "tt_metal/fabric/fabric_host_utils.hpp"
@@ -60,19 +59,13 @@ FabricNodeId decode_fabric_node_id(std::uint64_t encoded_value) {
         static_cast<std::uint32_t>(encoded_value & 0xFFFFFFFF));
 }
 
-// Helper function to get timeout duration for topology mapping operations
-std::chrono::duration<float> get_topology_mapping_timeout() {
-    auto timeout = tt::tt_metal::MetalContext::instance().rtoptions().get_timeout_duration_for_operations();
-    if (timeout.count() <= 0.0f) {
-        timeout = std::chrono::duration<float>(60.0f);
-    }
-    return timeout;
-}
-
 // Generic timeout mechanism that can handle different types of operations
 template <typename OperationType, typename... Args>
-void execute_with_timeout(OperationType&& operation, const std::string& operation_description, Args&&... args) {
-    auto timeout = get_topology_mapping_timeout();
+void execute_with_timeout(
+    OperationType&& operation,
+    const std::string& operation_description,
+    std::chrono::duration<float> timeout,
+    Args&&... args) {
     std::atomic<bool> operation_completed{false};
     std::atomic<bool> operation_failed{false};
     std::exception_ptr exception_ptr{nullptr};
@@ -117,9 +110,9 @@ void execute_with_timeout(OperationType&& operation, const std::string& operatio
 }
 
 // Specialized wrapper for request-based operations (like irecv)
-template<typename RequestType>
-void wait_for_request_with_timeout(RequestType& req, const std::string& operation_description, int rank) {
-    auto timeout = get_topology_mapping_timeout();
+template <typename RequestType>
+void wait_for_request_with_timeout(
+    RequestType& req, const std::string& operation_description, int rank, std::chrono::duration<float> timeout) {
     auto start = std::chrono::steady_clock::now();
 
     while (!req->test()) {
@@ -140,16 +133,17 @@ void wait_for_request_with_timeout(RequestType& req, const std::string& operatio
 
 // Wrapper for all_gather operations
 void all_gather_with_timeout(
-    const std::shared_ptr<tt::tt_metal::distributed::multihost::DistributedContext>& context,
+    const tt::tt_metal::distributed::multihost::DistributedContext& context,
     tt::stl::Span<std::byte> send_buf,
     tt::stl::Span<std::byte> recv_buf,
-    const std::string& operation_description) {
+    const std::string& operation_description,
+    std::chrono::duration<float> topology_mapping_timeout) {
     execute_with_timeout(
-        [&context](tt::stl::Span<std::byte> send, tt::stl::Span<std::byte> recv) {
-            context->all_gather(send, recv);
-        },
+        [&context](tt::stl::Span<std::byte> send, tt::stl::Span<std::byte> recv) { context.all_gather(send, recv); },
         operation_description,
-        send_buf, recv_buf);
+        topology_mapping_timeout,
+        send_buf,
+        recv_buf);
 }
 }  // namespace
 
@@ -180,13 +174,19 @@ tt::tt_metal::AsicID TopologyMapper::get_asic_id_from_fabric_node_id(const Fabri
 }
 
 TopologyMapper::TopologyMapper(
+    const tt::Cluster& cluster,
+    const tt_metal::distributed::multihost::DistributedContext& distributed_context,
     const MeshGraph& mesh_graph,
     const tt::tt_metal::PhysicalSystemDescriptor& physical_system_descriptor,
-    const LocalMeshBinding& local_mesh_binding) :
+    const LocalMeshBinding& local_mesh_binding,
+    std::chrono::duration<float> topology_mapping_timeout) :
+    cluster_(cluster),
+    distributed_context_(distributed_context),
     mesh_graph_(mesh_graph),
     physical_system_descriptor_(physical_system_descriptor),
     local_mesh_binding_(local_mesh_binding),
-    fixed_asic_position_pinnings_({}) {
+    fixed_asic_position_pinnings_({}),
+    topology_mapping_timeout_(topology_mapping_timeout) {
     // Initialize containers; population will occur during build_mapping
     mesh_host_ranks_.clear();
     mesh_host_rank_coord_ranges_.clear();
@@ -197,14 +197,20 @@ TopologyMapper::TopologyMapper(
 
 // Removed bus-id pinning constructor
 TopologyMapper::TopologyMapper(
+    const tt::Cluster& cluster,
+    const tt_metal::distributed::multihost::DistributedContext& distributed_context,
     const MeshGraph& mesh_graph,
     const tt::tt_metal::PhysicalSystemDescriptor& physical_system_descriptor,
     const LocalMeshBinding& local_mesh_binding,
-    const std::vector<std::pair<AsicPosition, FabricNodeId>>& fixed_asic_position_pinnings) :
+    const std::vector<std::pair<AsicPosition, FabricNodeId>>& fixed_asic_position_pinnings,
+    std::chrono::duration<float> topology_mapping_timeout) :
+    cluster_(cluster),
+    distributed_context_(distributed_context),
     mesh_graph_(mesh_graph),
     physical_system_descriptor_(physical_system_descriptor),
     local_mesh_binding_(local_mesh_binding),
-    fixed_asic_position_pinnings_(fixed_asic_position_pinnings) {
+    fixed_asic_position_pinnings_(fixed_asic_position_pinnings),
+    topology_mapping_timeout_(topology_mapping_timeout) {
     mesh_host_ranks_.clear();
     mesh_host_rank_coord_ranges_.clear();
     mesh_host_rank_to_mpi_rank_.clear();
@@ -214,14 +220,20 @@ TopologyMapper::TopologyMapper(
 
 // Constructor that skips discovery and builds mapping directly from provided logical to physical chip mapping
 TopologyMapper::TopologyMapper(
+    const tt::Cluster& cluster,
+    const tt_metal::distributed::multihost::DistributedContext& distributed_context,
     const MeshGraph& mesh_graph,
     const tt::tt_metal::PhysicalSystemDescriptor& physical_system_descriptor,
     const LocalMeshBinding& local_mesh_binding,
-    const std::map<FabricNodeId, ChipId>& logical_mesh_chip_id_to_physical_chip_id_mapping) :
+    const std::map<FabricNodeId, ChipId>& logical_mesh_chip_id_to_physical_chip_id_mapping,
+    std::chrono::duration<float> topology_mapping_timeout) :
+    cluster_(cluster),
+    distributed_context_(distributed_context),
     mesh_graph_(mesh_graph),
     physical_system_descriptor_(physical_system_descriptor),
     local_mesh_binding_(local_mesh_binding),
-    fixed_asic_position_pinnings_({}) {
+    fixed_asic_position_pinnings_({}),
+    topology_mapping_timeout_(topology_mapping_timeout) {
     log_debug(
         tt::LogFabric,
         "TopologyMapper: Building mapping directly from provided logical to physical chip mapping (skipping "
@@ -236,13 +248,12 @@ TopologyMapper::TopologyMapper(
 
     // Build fabric node id to asic id mapping directly from the provided logical to physical chip mapping
     // Update chip_topology_mapping_ entries with the mapping information
-    auto& cluster = tt::tt_metal::MetalContext::instance().get_cluster();
     for (const auto& [fabric_node_id, physical_chip_id] : logical_mesh_chip_id_to_physical_chip_id_mapping) {
         // Convert physical chip id to asic id
         // First try to find it in the local cluster (for local chips)
         tt::tt_metal::AsicID asic_id{0};
         bool found_asic_id = false;
-        for (const auto& [chip_id, unique_id] : cluster.get_unique_chip_ids()) {
+        for (const auto& [chip_id, unique_id] : cluster_.get().get_unique_chip_ids()) {
             if (chip_id == physical_chip_id) {
                 asic_id = tt::tt_metal::AsicID{unique_id};
                 found_asic_id = true;
@@ -334,8 +345,8 @@ TopologyMapper::TopologyMapper(
 
     // For custom fabric topology, we also need to gather mesh bindings from all ranks to populate
     // mesh_host_rank_to_mpi_rank_ for meshes this rank doesn't participate in
-    auto global_context = tt::tt_metal::MetalContext::instance().get_distributed_context_ptr();
-    const std::size_t world_size = *global_context->size();
+    const auto& global_context = this->distributed_context_.get();
+    const std::size_t world_size = *global_context.size();
     if (world_size > 1) {
         // Gather mesh_id and host_rank from all ranks
         const std::uint32_t local_count = static_cast<std::uint32_t>(local_mesh_binding_.mesh_ids.size());
@@ -345,12 +356,13 @@ TopologyMapper::TopologyMapper(
             ttsl::Span<std::byte>(
                 reinterpret_cast<std::byte*>(const_cast<std::uint32_t*>(&local_count)), sizeof(std::uint32_t)),
             ttsl::as_writable_bytes(ttsl::Span<std::uint32_t>(counts.data(), counts.size())),
-            "mesh count all_gather");
+            "mesh count all_gather",
+            topology_mapping_timeout_);
 
         const std::uint32_t max_count = counts.empty() ? 0 : *std::max_element(counts.begin(), counts.end());
         const std::uint64_t sentinel = std::numeric_limits<std::uint64_t>::max();
         std::vector<std::uint64_t> send_values(max_count, sentinel);
-        auto my_mpi_rank = static_cast<int>(*global_context->rank());
+        auto my_mpi_rank = static_cast<int>(*global_context.rank());
         for (std::uint32_t i = 0; i < local_count; ++i) {
             send_values[i] = encode_mpi_rank_mesh_id_and_rank(
                 my_mpi_rank, local_mesh_binding_.mesh_ids[i], local_mesh_binding_.host_rank);
@@ -363,7 +375,8 @@ TopologyMapper::TopologyMapper(
                 ttsl::Span<std::byte>(
                     reinterpret_cast<std::byte*>(send_values.data()), send_values.size() * sizeof(std::uint64_t)),
                 ttsl::as_writable_bytes(ttsl::Span<std::uint64_t>(gathered.data(), gathered.size())),
-                "mesh binding all_gather");
+                "mesh binding all_gather",
+                topology_mapping_timeout_);
         }
 
         // Decode and populate mesh_host_rank_to_mpi_rank_ from gathered data
@@ -392,7 +405,6 @@ void TopologyMapper::initialize_chip_topology_mapping_map() {
     const auto& asic_descriptors = physical_system_descriptor_.get_asic_descriptors();
 
     // Get local cluster for physical_chip_id lookup
-    auto& cluster = tt::tt_metal::MetalContext::instance().get_cluster();
     const auto& my_host = physical_system_descriptor_.my_host_name();
 
     // Create MappedChipInfo entry for each ASIC
@@ -408,7 +420,7 @@ void TopologyMapper::initialize_chip_topology_mapping_map() {
         // Fill in physical_chip_id if this ASIC is on the local host
         if (asic_descriptor.host_name == my_host) {
             // Look up physical_chip_id from cluster
-            for (const auto& [physical_chip_id, unique_id] : cluster.get_unique_chip_ids()) {
+            for (const auto& [physical_chip_id, unique_id] : this->cluster_.get().get_unique_chip_ids()) {
                 if (unique_id == *asic_id) {
                     info.physical_chip_id = physical_chip_id;
                     break;
@@ -446,10 +458,9 @@ void TopologyMapper::build_mapping() {
 
     // Only 1 host builds the mapping the rest will wait and use the mapping from the 1st host
     using namespace tt::tt_metal::distributed::multihost;
-    const auto& distributed_context = tt::tt_metal::MetalContext::instance().full_world_distributed_context();
-    const std::size_t world_size = *distributed_context.size();
+    const std::size_t world_size = *this->distributed_context_.get().size();
     constexpr std::size_t control_host_rank = 0;
-    auto my_rank = *distributed_context.rank();
+    auto my_rank = *this->distributed_context_.get().rank();
 
     if (!generate_mapping_locally_) {
         broadcast_chip_info_to_hosts({static_cast<std::size_t>(my_rank)}, control_host_rank);
@@ -466,7 +477,7 @@ void TopologyMapper::build_mapping() {
         // Build logical and physical adjacency maps
         auto adjacency_map_logical = tt::tt_metal::experimental::tt_fabric::build_adjacency_map_logical(mesh_graph_);
         auto adjacency_map_physical = tt::tt_metal::experimental::tt_fabric::build_adjacency_map_physical(
-            physical_system_descriptor_, asic_id_to_mesh_rank);
+            cluster_.get().get_cluster_type(), physical_system_descriptor_, asic_id_to_mesh_rank);
 
         print_logical_adjacency_map(adjacency_map_logical);
         print_physical_adjacency_map(adjacency_map_physical);
@@ -523,8 +534,8 @@ std::map<MeshId, std::map<FabricNodeId, MeshHostRankId>> TopologyMapper::build_f
 
 std::map<MeshId, std::map<tt::tt_metal::AsicID, MeshHostRankId>> TopologyMapper::build_asic_id_to_mesh_rank_mapping() {
     std::map<MeshId, std::map<tt::tt_metal::AsicID, MeshHostRankId>> mapping;
-    auto global_context = tt::tt_metal::MetalContext::instance().get_distributed_context_ptr();
-    const std::size_t world_size = *global_context->size();
+    const auto& global_context = this->distributed_context_.get();
+    const std::size_t world_size = *global_context.size();
 
     if (generate_mapping_locally_ || world_size <= 1) {
         auto host_rank = local_mesh_binding_.host_rank;
@@ -557,13 +568,14 @@ std::map<MeshId, std::map<tt::tt_metal::AsicID, MeshHostRankId>> TopologyMapper:
         ttsl::Span<std::byte>(
             reinterpret_cast<std::byte*>(const_cast<std::uint32_t*>(&local_count)), sizeof(std::uint32_t)),
         ttsl::as_writable_bytes(ttsl::Span<std::uint32_t>(counts.data(), counts.size())),
-        "mesh count all_gather");
+        "mesh count all_gather",
+        topology_mapping_timeout_);
 
     const std::uint32_t max_count = counts.empty() ? 0 : *std::max_element(counts.begin(), counts.end());
 
     const std::uint64_t sentinel = std::numeric_limits<std::uint64_t>::max();
     std::vector<std::uint64_t> send_values(max_count, sentinel);
-    auto my_mpi_rank = static_cast<int>(*global_context->rank());
+    auto my_mpi_rank = static_cast<int>(*global_context.rank());
     for (std::uint32_t i = 0; i < local_count; ++i) {
         // Encode MPI rank along with mesh_id and host_rank so we can map correctly
         send_values[i] = encode_mpi_rank_mesh_id_and_rank(
@@ -577,7 +589,8 @@ std::map<MeshId, std::map<tt::tt_metal::AsicID, MeshHostRankId>> TopologyMapper:
             ttsl::Span<std::byte>(
                 reinterpret_cast<std::byte*>(send_values.data()), send_values.size() * sizeof(std::uint64_t)),
             ttsl::as_writable_bytes(ttsl::Span<std::uint64_t>(gathered.data(), gathered.size())),
-            "mesh binding all_gather");
+            "mesh binding all_gather",
+            topology_mapping_timeout_);
     }
 
     // Step 3: Use the gathered mesh bindings directly to build the mapping
@@ -700,7 +713,7 @@ void TopologyMapper::populate_fabric_node_id_to_asic_id_mappings(
 
 void TopologyMapper::broadcast_chip_info_to_hosts(const std::vector<std::size_t>& host_ranks, int target_rank) {
     using namespace tt::tt_metal::distributed::multihost;
-    const auto& distributed_context = tt::tt_metal::MetalContext::instance().full_world_distributed_context();
+    const auto& distributed_context = this->distributed_context_.get();
 
     const std::size_t world_size = *distributed_context.size();
     if (world_size <= 1) {
@@ -844,7 +857,7 @@ void TopologyMapper::broadcast_chip_info_to_hosts(const std::vector<std::size_t>
 
 void TopologyMapper::receive_chip_info_from_host(std::size_t source_rank) {
     using namespace tt::tt_metal::distributed::multihost;
-    const auto& distributed_context = tt::tt_metal::MetalContext::instance().full_world_distributed_context();
+    const auto& distributed_context = this->distributed_context_.get();
 
     // If not in distributed context, nothing to receive
     if (*distributed_context.size() <= 1) {
@@ -861,6 +874,7 @@ void TopologyMapper::receive_chip_info_from_host(std::size_t source_rank) {
     constexpr int tag_size = 3;
 
     // Receive count, then 'count' variable-size records
+
     std::uint32_t count = 0;
     {
         auto req = distributed_context.irecv(
@@ -868,7 +882,7 @@ void TopologyMapper::receive_chip_info_from_host(std::size_t source_rank) {
             Rank{static_cast<int>(source_rank)},
             Tag{tag_base});
 
-        wait_for_request_with_timeout(req, "chip info header", source_rank);
+        wait_for_request_with_timeout(req, "chip info header", source_rank, topology_mapping_timeout_);
     }
 
     // Don't clear chip_topology_mapping_ - we want to keep initialized entries and update them
@@ -902,7 +916,10 @@ void TopologyMapper::receive_chip_info_from_host(std::size_t source_rank) {
                 Tag{tag_size});  // Use tag_size for size messages
 
             wait_for_request_with_timeout(
-                req, "chip info record size " + std::to_string(i + 1) + " of " + std::to_string(count), source_rank);
+                req,
+                "chip info record size " + std::to_string(i + 1) + " of " + std::to_string(count),
+                source_rank,
+                topology_mapping_timeout_);
         }
 
         TT_FATAL(
@@ -920,7 +937,10 @@ void TopologyMapper::receive_chip_info_from_host(std::size_t source_rank) {
             Tag{tag_base});  // Use tag_base for data messages
 
         wait_for_request_with_timeout(
-            req, "chip info record " + std::to_string(i + 1) + " of " + std::to_string(count), source_rank);
+            req,
+            "chip info record " + std::to_string(i + 1) + " of " + std::to_string(count),
+            source_rank,
+            topology_mapping_timeout_);
 
         std::size_t idx = 0;
 
@@ -1006,12 +1026,11 @@ void TopologyMapper::receive_chip_info_from_host(std::size_t source_rank) {
 
     // Fill in physical_chip_id for ASICs that belong to this host
     // (The controller may have set it to 0 for ASICs on other hosts)
-    auto& cluster = tt::tt_metal::MetalContext::instance().get_cluster();
     const auto& my_host = physical_system_descriptor_.my_host_name();
     for (auto& info : chip_topology_mapping_) {
         if (info.physical_chip_id == 0 && !info.hostname.empty() && info.hostname == my_host) {
             // This ASIC belongs to this host, look up its physical chip ID
-            for (const auto& [physical_chip_id, unique_id] : cluster.get_unique_chip_ids()) {
+            for (const auto& [physical_chip_id, unique_id] : cluster_.get().get_unique_chip_ids()) {
                 if (unique_id == *info.asic_id) {
                     info.physical_chip_id = physical_chip_id;
                     break;
@@ -1483,10 +1502,10 @@ namespace {
  * @param psd The PhysicalSystemDescriptor representing the system's ASICs and their interconnections.
  * @return The maximum number of local Ethernet connections per direction between any two ASICs.
  */
-std::uint32_t get_num_connections_per_direction(const tt::tt_metal::PhysicalSystemDescriptor& psd) {
+std::uint32_t get_num_connections_per_direction(
+    const tt::Cluster& cluster, const tt::tt_metal::PhysicalSystemDescriptor& psd) {
     // Check the number of connections per direction for each asic
     std::uint32_t num_connections_per_direction = 1;  // Default to 1 connection per direction
-    const auto& cluster = tt::tt_metal::MetalContext::instance().get_cluster();
     for (const auto& [asic_id, asic_descriptor] : psd.get_asic_descriptors()) {
         auto neighbors = psd.get_asic_neighbors(asic_id);
         for (const auto& neighbor : neighbors) {
@@ -1579,12 +1598,15 @@ std::vector<MeshShape> generate_possible_cluster_shapes(std::uint32_t total_numb
 }  // namespace
 
 MeshGraph TopologyMapper::generate_mesh_graph_from_physical_system_descriptor(
-    const tt::tt_metal::PhysicalSystemDescriptor& physical_system_descriptor, FabricConfig fabric_config) {
+    const tt::Cluster& cluster,
+    const tt::tt_metal::PhysicalSystemDescriptor& physical_system_descriptor,
+    tt::tt_fabric::FabricConfig fabric_config,
+    tt::tt_fabric::FabricReliabilityMode reliability_mode) {
     // Come up with the biggest mesh that can be formed by the physical system descriptor based on number of chips
-    FabricType fabric_type = get_fabric_type(fabric_config);
+    FabricType fabric_type = get_fabric_type(fabric_config, cluster.is_ubb_galaxy());
 
     // Detect the number of connections per direction using the psd
-    const auto number_of_connections = get_num_connections_per_direction(physical_system_descriptor);
+    const auto number_of_connections = get_num_connections_per_direction(cluster, physical_system_descriptor);
 
     // Get the total number of chips in the physical system descriptor
     const auto total_number_of_chips = physical_system_descriptor.get_asic_descriptors().size();
@@ -1601,8 +1623,9 @@ MeshGraph TopologyMapper::generate_mesh_graph_from_physical_system_descriptor(
     for (const auto& asic_id : all_asic_ids) {
         asic_id_to_mesh_rank[MeshId{0}][asic_id] = MeshHostRankId{0};
     }
+
     auto physical_adjacency_matrix = tt::tt_metal::experimental::tt_fabric::build_adjacency_map_physical(
-        physical_system_descriptor, asic_id_to_mesh_rank);
+        cluster.get_cluster_type(), physical_system_descriptor, asic_id_to_mesh_rank);
 
     // Generate possible mesh shapes
     std::vector<MeshShape> mesh_shapes_to_try = generate_possible_cluster_shapes(total_number_of_chips);
@@ -1610,7 +1633,8 @@ MeshGraph TopologyMapper::generate_mesh_graph_from_physical_system_descriptor(
     // Try all possible mesh shapes
     const MeshId mesh_id{0};
     for (const auto& mesh_shape : mesh_shapes_to_try) {
-        auto mesh_graph = MeshGraph::generate_mesh_graph_of_shape(mesh_shape, fabric_type, number_of_connections);
+        auto mesh_graph = MeshGraph::generate_mesh_graph_of_shape(
+            cluster, mesh_shape, fabric_type, reliability_mode, cluster.arch(), number_of_connections);
         auto logical_adjacency_matrix = tt::tt_metal::experimental::tt_fabric::build_adjacency_map_logical(mesh_graph);
 
         // Extract adjacency maps for this mesh_id

--- a/tt_metal/fabric/topology_mapper_utils.cpp
+++ b/tt_metal/fabric/topology_mapper_utils.cpp
@@ -13,6 +13,7 @@
 #include <tt-logger/tt-logger.hpp>
 #include <fmt/format.h>
 #include <tt-metalium/experimental/fabric/mesh_graph.hpp>
+#include "cluster.hpp"
 #include "tt_metal/fabric/physical_system_descriptor.hpp"
 #include "tt_metal/impl/context/metal_context.hpp"
 #include <llrt/tt_cluster.hpp>
@@ -960,6 +961,7 @@ std::map<MeshId, LogicalAdjacencyMap> build_adjacency_map_logical(const ::tt::tt
 }
 
 std::map<MeshId, PhysicalAdjacencyMap> build_adjacency_map_physical(
+    tt::tt_metal::ClusterType cluster_type,
     const tt::tt_metal::PhysicalSystemDescriptor& physical_system_descriptor,
     const std::map<MeshId, std::map<tt::tt_metal::AsicID, MeshHostRankId>>& asic_id_to_mesh_rank) {
     std::map<MeshId, PhysicalAdjacencyMap> adjacency_map;
@@ -974,7 +976,6 @@ std::map<MeshId, PhysicalAdjacencyMap> build_adjacency_map_physical(
 
     for (const auto& [mesh_id, mesh_asics] : mesh_asic_ids) {
         auto z_channels = std::unordered_set<uint8_t>{8, 9};
-        auto cluster_type = tt::tt_metal::MetalContext::instance().get_cluster().get_cluster_type();
 
         auto get_local_adjacents = [&](tt::tt_metal::AsicID asic_id,
                                        const std::unordered_set<tt::tt_metal::AsicID>& mesh_asics) {

--- a/tt_metal/fabric/topology_solver.cpp
+++ b/tt_metal/fabric/topology_solver.cpp
@@ -7,7 +7,6 @@
 #include <tt-metalium/experimental/fabric/topology_solver.hpp>
 #include <tt-metalium/experimental/fabric/fabric_types.hpp>
 #include "tt_metal/fabric/physical_system_descriptor.hpp"
-#include "tt_metal/impl/context/metal_context.hpp"
 #include <llrt/tt_cluster.hpp>
 
 namespace tt::tt_fabric {
@@ -45,6 +44,7 @@ std::map<MeshId, AdjacencyGraph<FabricNodeId>> build_adjacency_map_logical(const
 }
 
 std::map<MeshId, AdjacencyGraph<tt::tt_metal::AsicID>> build_adjacency_map_physical(
+    tt::tt_metal::ClusterType /*cluster_type*/,
     const tt::tt_metal::PhysicalSystemDescriptor& physical_system_descriptor,
     const std::map<MeshId, std::map<tt::tt_metal::AsicID, MeshHostRankId>>& asic_id_to_mesh_rank) {
     std::map<MeshId, AdjacencyGraph<tt::tt_metal::AsicID>> adjacency_map;

--- a/tt_metal/impl/context/metal_context.cpp
+++ b/tt_metal/impl/context/metal_context.cpp
@@ -501,6 +501,7 @@ void MetalContext::reinitialize_for_real_hardware() {
 
 void MetalContext::teardown_base_objects() {
     // Teardown in backward order of dependencies to avoid dereferencing uninitialized objects
+    control_plane_.reset();
     distributed_context_.reset();
     // Destroy inspector before cluster to prevent RPC handlers from accessing destroyed cluster
     inspector_data_.reset();
@@ -840,6 +841,16 @@ void MetalContext::set_fabric_config(
     this->fabric_udm_mode_ = fabric_udm_mode;
     this->fabric_manager_ = fabric_manager;
     this->fabric_router_config_ = router_config;
+
+    // Reinitialize control plane with updated fabric settings
+    if (control_plane_ != nullptr) {
+        log_info(
+            tt::LogMetal,
+            "Fabric config changed from {} to {}, reinitializing control plane",
+            this->get_control_plane().get_fabric_config(),
+            this->fabric_config_);
+        this->initialize_control_plane_impl();
+    }
 }
 
 void MetalContext::initialize_fabric_config() {
@@ -850,11 +861,7 @@ void MetalContext::initialize_fabric_config() {
     this->cluster_->configure_ethernet_cores_for_fabric_routers(
         this->fabric_config_, this->num_fabric_active_routing_planes_);
     auto& control_plane = this->get_control_plane();
-    if (tt::tt_fabric::is_tt_fabric_config(this->fabric_config_)) {
-        control_plane.initialize_fabric_context(this->fabric_config_, this->fabric_router_config_);
-    }
-    control_plane.configure_routing_tables_for_fabric_ethernet_channels(
-        this->fabric_config_, this->fabric_reliability_mode_);
+    control_plane.configure_routing_tables_for_fabric_ethernet_channels();
 }
 
 void MetalContext::initialize_fabric_tensix_datamover_config() {
@@ -893,9 +900,31 @@ void MetalContext::construct_control_plane(const std::filesystem::path& mesh_gra
     if (!logical_mesh_chip_id_to_physical_chip_id_mapping_.empty()) {
         log_info(tt::LogDistributed, "Using custom Fabric Node Id to physical chip mapping.");
         control_plane_ = std::make_unique<tt::tt_fabric::ControlPlane>(
-            mesh_graph_desc_path.string(), logical_mesh_chip_id_to_physical_chip_id_mapping_);
+            *this->cluster_,
+            this->rtoptions_,
+            *hal_,
+            *distributed_context_,
+            mesh_graph_desc_path.string(),
+            logical_mesh_chip_id_to_physical_chip_id_mapping_,
+            this->fabric_config_,
+            this->fabric_reliability_mode_,
+            this->fabric_tensix_config_,
+            this->fabric_udm_mode_,
+            this->fabric_router_config_,
+            this->fabric_manager_);
     } else {
-        control_plane_ = std::make_unique<tt::tt_fabric::ControlPlane>(mesh_graph_desc_path.string());
+        control_plane_ = std::make_unique<tt::tt_fabric::ControlPlane>(
+            *this->cluster_,
+            this->rtoptions_,
+            *hal_,
+            *distributed_context_,
+            mesh_graph_desc_path.string(),
+            this->fabric_config_,
+            this->fabric_reliability_mode_,
+            this->fabric_tensix_config_,
+            this->fabric_udm_mode_,
+            this->fabric_router_config_,
+            this->fabric_manager_);
     }
 }
 
@@ -911,7 +940,17 @@ void MetalContext::construct_control_plane() {
             "physical mapping.");
     }
     log_info(tt::LogDistributed, "Constructing control plane using auto-discovery (no mesh graph descriptor).");
-    control_plane_ = std::make_unique<tt::tt_fabric::ControlPlane>();
+    control_plane_ = std::make_unique<tt::tt_fabric::ControlPlane>(
+        *this->cluster_,
+        this->rtoptions_,
+        *hal_,
+        *distributed_context_,
+        this->fabric_config_,
+        this->fabric_reliability_mode_,
+        this->fabric_tensix_config_,
+        this->fabric_udm_mode_,
+        this->fabric_router_config_,
+        this->fabric_manager_);
 }
 
 void MetalContext::initialize_control_plane() {
@@ -939,7 +978,7 @@ void MetalContext::initialize_control_plane_impl() {
         this->construct_control_plane();
     } else {
         auto cluster_type = cluster_->get_cluster_type();
-        auto fabric_type = tt::tt_fabric::get_fabric_type(this->fabric_config_);
+        auto fabric_type = tt::tt_fabric::get_fabric_type(this->fabric_config_, cluster_->is_ubb_galaxy());
         std::filesystem::path mesh_graph_desc_path =
             tt::tt_fabric::MeshGraph::get_mesh_graph_descriptor_path_for_cluster_type(
                 cluster_type, rtoptions_.get_root_dir(), fabric_type);

--- a/tt_metal/llrt/tt_cluster.cpp
+++ b/tt_metal/llrt/tt_cluster.cpp
@@ -261,10 +261,7 @@ void Cluster::detect_arch_and_target() {
 // TODO: remove this when we deprecate TG
 bool Cluster::is_galaxy_cluster() const { return this->cluster_type_ == tt::tt_metal::ClusterType::TG; }
 
-bool Cluster::is_ubb_galaxy() const {
-    return this->cluster_type_ == tt::tt_metal::ClusterType::BLACKHOLE_GALAXY ||
-           this->cluster_type_ == tt::tt_metal::ClusterType::GALAXY;
-}
+bool Cluster::is_ubb_galaxy() const { return Cluster::is_ubb_galaxy(this->cluster_type_); }
 
 tt::tt_metal::ClusterType Cluster::get_cluster_type() const { return this->cluster_type_; }
 

--- a/tt_metal/llrt/tt_cluster.hpp
+++ b/tt_metal/llrt/tt_cluster.hpp
@@ -318,9 +318,6 @@ public:
     void configure_ethernet_cores_for_fabric_routers(
         tt_fabric::FabricConfig fabric_config, std::optional<uint8_t> num_routing_planes = std::nullopt);
 
-    void initialize_fabric_config(
-        tt_fabric::FabricConfig fabric_config, tt_fabric::FabricReliabilityMode reliability_mode);
-
     // Returns whether we are running on Legacy Galaxy.
     bool is_galaxy_cluster() const;
 

--- a/tt_metal/llrt/tt_cluster.hpp
+++ b/tt_metal/llrt/tt_cluster.hpp
@@ -321,8 +321,13 @@ public:
     // Returns whether we are running on Legacy Galaxy.
     bool is_galaxy_cluster() const;
 
-    // Returns whether we are running on UBB Galaxy.
+    // Returns whether the Cluster instance is running on UBB Galaxy.
     bool is_ubb_galaxy() const;
+
+    static bool is_ubb_galaxy(tt::tt_metal::ClusterType cluster_type) {
+        return cluster_type == tt::tt_metal::ClusterType::BLACKHOLE_GALAXY ||
+               cluster_type == tt::tt_metal::ClusterType::GALAXY;
+    }
 
     // Returns Wormhole chip board type.
     BoardType get_board_type(ChipId chip_id) const;


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/37008

### Problem description
- Need to reduce the amount of dependencies on MetalContext as this class will become deprecated in the future.
- There are lots of circular dependencies around MetalContext, ControlPlane, and classes which are owned by control plane which makes MetalContext init difficult.

### What's changed
- Remove all MetalContext::instance() calls from ControlPlane and it's owned classes. ControlPlane depends on Cluster, HAL, RuntimeOptions, and DistributedContext.
- Change public function `initialize_fabric_context()` to private and always call it in the ControlPlane constructor
- set_fabric_config in tt_Cluster.hpp has no implementation. Remove it.

### Checklist

Results are same as main

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=nhuang/reduce-control-plane)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:nhuang/reduce-control-plane)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=nhuang/reduce-control-plane)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:nhuang/reduce-control-plane)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nhuang/reduce-control-plane)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nhuang/reduce-control-plane)
- [ ] New/Existing tests provide coverage for changes

T3K Unit
https://github.com/tenstorrent/tt-metal/actions/runs/21835279890

T3K Fast
https://github.com/tenstorrent/tt-metal/actions/runs/21835278038

Multihost Deployment
https://github.com/tenstorrent/tt-metal/actions/runs/21835262780

#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nhuang/reduce-control-plane)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nhuang/reduce-control-plane)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nhuang/reduce-control-plane)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nhuang/reduce-control-plane)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nhuang/reduce-control-plane)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nhuang/reduce-control-plane)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
