### PR TITLE
Add support for more scenarios when reading from pinned memory

### DIFF
--- a/tests/tt_metal/distributed/test_mesh_buffer.cpp
+++ b/tests/tt_metal/distributed/test_mesh_buffer.cpp
@@ -890,6 +890,8 @@ TEST_F(MeshBufferTestSuite, EnqueueWriteShardsWithPinnedMemoryFullRange) {
                                  .region(BufferRegion(0, bytes_per_device));
         mesh_device_->mesh_command_queue().enqueue_read_shards({read_transfer}, mesh_buffer, /*blocking=*/true);
         EXPECT_EQ(*src, dst);
+        // Pinned memory should have been used, so locking may block.
+        EXPECT_TRUE(pinned_shared->lock_may_block());
     }
 }
 
@@ -948,6 +950,8 @@ TEST_F(MeshBufferTestSuite, EnqueueWriteShardsWithPinnedMemoryFullRangeLargePage
                                  .region(BufferRegion(0, bytes_per_device));
         mesh_device_->mesh_command_queue().enqueue_read_shards({read_transfer}, mesh_buffer, /*blocking=*/true);
         EXPECT_EQ(*src, dst);
+        // Pinned memory should have been used, so locking may block.
+        EXPECT_TRUE(pinned_shared->lock_may_block());
     }
 }
 
@@ -966,29 +970,33 @@ TEST_F(MeshBufferTestSuite, EnqueueWriteShardsWithPinnedMemoryFullRangeUnaligned
     const uint32_t tiles_per_device = 128;
     const uint32_t bytes_per_device = tiles_per_device * single_tile_size;
 
-    ReplicatedBufferConfig global_buffer_config{.size = bytes_per_device};
-    auto mesh_buffer = MeshBuffer::create(global_buffer_config, per_device_buffer_config, mesh_device_.get());
+    for (const size_t aligned_byte_shift : {4, 16}) {
+        log_info(tt::LogTest, "Testing writing from pinned memory to shard with aligned byte shift {}", aligned_byte_shift);
 
-    const auto& hal = tt::tt_metal::MetalContext::instance().hal();
-    constexpr int device_read_align{64};
-    ASSERT_TRUE(device_read_align % hal.get_read_alignment(HalMemType::HOST) == 0)
-        << "Source vector alignment must be equal to PCIE read alignment: " << hal.get_read_alignment(HalMemType::HOST)
-        << std::endl;
-    // How many words to shift the source buffer by to get it to start an unaligned word
-    constexpr size_t unaligned_word_shift = 1;
-    const size_t num_words = (bytes_per_device / sizeof(uint32_t));
-    // Prepare write source buffer and pin the entire destination range for the target shard
-    auto src = std::make_shared<std::vector<uint32_t, tt::stl::aligned_allocator<uint32_t, device_read_align>>>(
-        num_words + unaligned_word_shift, 0);
+        ReplicatedBufferConfig global_buffer_config{.size = bytes_per_device};
+        auto mesh_buffer = MeshBuffer::create(global_buffer_config, per_device_buffer_config, mesh_device_.get());
 
-    uint32_t* src_unaligned = src->data() + unaligned_word_shift;
-    std::iota(src_unaligned, src_unaligned + num_words, 0);
+        const auto& hal = tt::tt_metal::MetalContext::instance().hal();
+        constexpr int device_read_align{64};
+        ASSERT_TRUE(device_read_align % hal.get_read_alignment(HalMemType::HOST) == 0)
+            << "Source vector alignment must be equal to PCIE read alignment: " << hal.get_read_alignment(HalMemType::HOST)
+            << std::endl;
+        // How many words to shift the source buffer by to get it to start an unaligned word
+        ASSERT_EQ(aligned_byte_shift % sizeof(uint32_t), 0u);
+        const size_t unaligned_word_shift = aligned_byte_shift / sizeof(uint32_t);
+        const size_t num_words = (bytes_per_device / sizeof(uint32_t));
+        // Prepare write source buffer and pin the entire destination range for the target shard
+        auto src = std::make_shared<std::vector<uint32_t, tt::stl::aligned_allocator<uint32_t, device_read_align>>>(
+            num_words + unaligned_word_shift, 0);
 
-    // Create a copy of the source vector to make it easy to verify with the destination vector.
-    std::vector<uint32_t> src_vector(src_unaligned, src_unaligned + num_words);
-    // Create HostBuffer on top of src
-    HostBuffer host_buffer(tt::stl::Span<uint32_t>(src_unaligned, num_words), MemoryPin(src));
-    std::vector<uint32_t> dst(num_words, 0);
+        uint32_t* src_unaligned = src->data() + unaligned_word_shift;
+        std::iota(src_unaligned, src_unaligned + num_words, 0);
+
+        // Create a copy of the source vector to make it easy to verify with the destination vector.
+        std::vector<uint32_t> src_vector(src_unaligned, src_unaligned + num_words);
+        // Create HostBuffer on top of src
+        HostBuffer host_buffer(tt::stl::Span<uint32_t>(src_unaligned, num_words), MemoryPin(src));
+        std::vector<uint32_t> dst(num_words, 0);
 
     distributed::MeshCoordinateRange coord_range(mesh_device_->shape());
     auto pinned_shared = tt_metal::experimental::PinnedMemory::Create(
@@ -1003,13 +1011,18 @@ TEST_F(MeshBufferTestSuite, EnqueueWriteShardsWithPinnedMemoryFullRangeUnaligned
         distributed_host_buffer.emplace_shard(coord, [&host_buffer]() { return host_buffer; });
         mesh_device_->mesh_command_queue().enqueue_write(mesh_buffer, distributed_host_buffer, /*blocking=*/true);
 
-        // Read back via hugepage
-        std::fill(dst.begin(), dst.end(), 0);
-        auto read_transfer = distributed::ShardDataTransfer{coord}
-                                 .host_data(static_cast<void*>(dst.data()))
-                                 .region(BufferRegion(0, bytes_per_device));
-        mesh_device_->mesh_command_queue().enqueue_read_shards({read_transfer}, mesh_buffer, /*blocking=*/true);
-        EXPECT_EQ(src_vector, dst);
+            // Read back via hugepage
+            std::fill(dst.begin(), dst.end(), 0);
+            auto read_transfer = distributed::ShardDataTransfer{coord}
+                                    .host_data(static_cast<void*>(dst.data()))
+                                    .region(BufferRegion(0, bytes_per_device));
+            mesh_device_->mesh_command_queue().enqueue_read_shards({read_transfer}, mesh_buffer, /*blocking=*/true);
+            EXPECT_EQ(src_vector, dst);
+            if (unaligned_word_shift % 16 == 0) {
+                // Pinned memory should have been used, so locking may block.
+                EXPECT_TRUE(pinned_shared->lock_may_block());
+            }
+        }
     }
 }
 

--- a/tests/tt_metal/distributed/test_mesh_buffer.cpp
+++ b/tests/tt_metal/distributed/test_mesh_buffer.cpp
@@ -881,7 +881,7 @@ TEST_F(MeshBufferTestSuite, EnqueueWriteShardsWithPinnedMemoryFullRange) {
         log_info(tt::LogTest, "Testing writing from pinned memory to shard at coord {}", coord);
         auto distributed_host_buffer = DistributedHostBuffer::create(mesh_device_->shape());
         distributed_host_buffer.emplace_shard(coord, [&host_buffer]() { return host_buffer; });
-        mesh_device_->mesh_command_queue().enqueue_write(mesh_buffer, distributed_host_buffer, /*blocking=*/true);
+        mesh_device_->mesh_command_queue().enqueue_write(mesh_buffer, distributed_host_buffer, /*blocking=*/false);
 
         // Read back via hugepage
         std::fill(dst.begin(), dst.end(), 0);
@@ -941,7 +941,7 @@ TEST_F(MeshBufferTestSuite, EnqueueWriteShardsWithPinnedMemoryFullRangeLargePage
         auto distributed_host_buffer = DistributedHostBuffer::create(mesh_device_->shape());
         distributed_host_buffer.emplace_shard(coord, [&host_buffer]() { return host_buffer; });
 
-        mesh_device_->mesh_command_queue().enqueue_write(mesh_buffer, distributed_host_buffer, /*blocking=*/true);
+        mesh_device_->mesh_command_queue().enqueue_write(mesh_buffer, distributed_host_buffer, /*blocking=*/false);
 
         // Read back via hugepage
         std::fill(dst.begin(), dst.end(), 0);

--- a/tests/tt_metal/distributed/test_mesh_buffer.cpp
+++ b/tests/tt_metal/distributed/test_mesh_buffer.cpp
@@ -881,7 +881,7 @@ TEST_F(MeshBufferTestSuite, EnqueueWriteShardsWithPinnedMemoryFullRange) {
         log_info(tt::LogTest, "Testing writing from pinned memory to shard at coord {}", coord);
         auto distributed_host_buffer = DistributedHostBuffer::create(mesh_device_->shape());
         distributed_host_buffer.emplace_shard(coord, [&host_buffer]() { return host_buffer; });
-        mesh_device_->mesh_command_queue().enqueue_write(mesh_buffer, distributed_host_buffer, /*blocking=*/true);
+        mesh_device_->mesh_command_queue().enqueue_write(mesh_buffer, distributed_host_buffer, /*blocking=*/false);
 
         // Read back via hugepage
         std::fill(dst.begin(), dst.end(), 0);
@@ -941,7 +941,7 @@ TEST_F(MeshBufferTestSuite, EnqueueWriteShardsWithPinnedMemoryFullRangeLargePage
         auto distributed_host_buffer = DistributedHostBuffer::create(mesh_device_->shape());
         distributed_host_buffer.emplace_shard(coord, [&host_buffer]() { return host_buffer; });
 
-        mesh_device_->mesh_command_queue().enqueue_write(mesh_buffer, distributed_host_buffer, /*blocking=*/true);
+        mesh_device_->mesh_command_queue().enqueue_write(mesh_buffer, distributed_host_buffer, /*blocking=*/false);
 
         // Read back via hugepage
         std::fill(dst.begin(), dst.end(), 0);
@@ -1010,7 +1010,7 @@ TEST_F(MeshBufferTestSuite, EnqueueWriteShardsWithPinnedMemoryFullRangeUnaligned
             log_info(tt::LogTest, "Testing writing from pinned memory to shard at coord {}", coord);
             auto distributed_host_buffer = DistributedHostBuffer::create(mesh_device_->shape());
             distributed_host_buffer.emplace_shard(coord, [&host_buffer]() { return host_buffer; });
-            mesh_device_->mesh_command_queue().enqueue_write(mesh_buffer, distributed_host_buffer, /*blocking=*/true);
+            mesh_device_->mesh_command_queue().enqueue_write(mesh_buffer, distributed_host_buffer, /*blocking=*/false);
 
             // Read back via hugepage
             std::fill(dst.begin(), dst.end(), 0);
@@ -1019,7 +1019,7 @@ TEST_F(MeshBufferTestSuite, EnqueueWriteShardsWithPinnedMemoryFullRangeUnaligned
                                      .region(BufferRegion(0, bytes_per_device));
             mesh_device_->mesh_command_queue().enqueue_read_shards({read_transfer}, mesh_buffer, /*blocking=*/true);
             EXPECT_EQ(src_vector, dst);
-            if (unaligned_word_shift % 16 == 0) {
+            if (unaligned_byte_shift % 16 == 0) {
                 // Pinned memory should have been used, so locking may block.
                 EXPECT_TRUE(pinned_shared->lock_may_block());
             }

--- a/tests/tt_metal/distributed/test_mesh_buffer.cpp
+++ b/tests/tt_metal/distributed/test_mesh_buffer.cpp
@@ -881,7 +881,7 @@ TEST_F(MeshBufferTestSuite, EnqueueWriteShardsWithPinnedMemoryFullRange) {
         log_info(tt::LogTest, "Testing writing from pinned memory to shard at coord {}", coord);
         auto distributed_host_buffer = DistributedHostBuffer::create(mesh_device_->shape());
         distributed_host_buffer.emplace_shard(coord, [&host_buffer]() { return host_buffer; });
-        mesh_device_->mesh_command_queue().enqueue_write(mesh_buffer, distributed_host_buffer, /*blocking=*/false);
+        mesh_device_->mesh_command_queue().enqueue_write(mesh_buffer, distributed_host_buffer, /*blocking=*/true);
 
         // Read back via hugepage
         std::fill(dst.begin(), dst.end(), 0);
@@ -941,7 +941,7 @@ TEST_F(MeshBufferTestSuite, EnqueueWriteShardsWithPinnedMemoryFullRangeLargePage
         auto distributed_host_buffer = DistributedHostBuffer::create(mesh_device_->shape());
         distributed_host_buffer.emplace_shard(coord, [&host_buffer]() { return host_buffer; });
 
-        mesh_device_->mesh_command_queue().enqueue_write(mesh_buffer, distributed_host_buffer, /*blocking=*/false);
+        mesh_device_->mesh_command_queue().enqueue_write(mesh_buffer, distributed_host_buffer, /*blocking=*/true);
 
         // Read back via hugepage
         std::fill(dst.begin(), dst.end(), 0);
@@ -1019,7 +1019,7 @@ TEST_F(MeshBufferTestSuite, EnqueueWriteShardsWithPinnedMemoryFullRangeUnaligned
                                      .region(BufferRegion(0, bytes_per_device));
             mesh_device_->mesh_command_queue().enqueue_read_shards({read_transfer}, mesh_buffer, /*blocking=*/true);
             EXPECT_EQ(src_vector, dst);
-            if (unaligned_byte_shift % 16 == 0) {
+            if (aligned_byte_shift % 16 == 0) {
                 // Pinned memory should have been used, so locking may block.
                 EXPECT_TRUE(pinned_shared->lock_may_block());
             }

--- a/tt_metal/api/tt-metalium/experimental/pinned_memory.hpp
+++ b/tt_metal/api/tt-metalium/experimental/pinned_memory.hpp
@@ -134,6 +134,12 @@ public:
     void add_barrier_event(const distributed::MeshEvent& event);
 
     /**
+     * @brief Check if locking the pinned memory may block
+     * @return True if the lock may block, false otherwise
+     */
+    bool lock_may_block() const;
+
+    /**
      * @brief Lock the pinned memory for host access
      * @return Pointer to the host memory that can be safely accessed
      *

--- a/tt_metal/distributed/fd_mesh_command_queue.cpp
+++ b/tt_metal/distributed/fd_mesh_command_queue.cpp
@@ -570,7 +570,7 @@ void FDMeshCommandQueue::finish(tt::stl::Span<const SubDeviceId> sub_device_ids)
     distributed_context->barrier();
 }
 
-void FDMeshCommandQueue::write_shard_to_device(
+bool FDMeshCommandQueue::write_shard_to_device(
     const MeshBuffer& buffer,
     const MeshCoordinate& device_coord,
     const void* src,
@@ -578,14 +578,14 @@ void FDMeshCommandQueue::write_shard_to_device(
     tt::stl::Span<const SubDeviceId> sub_device_ids,
     std::shared_ptr<experimental::PinnedMemory> pinned_memory) {
     if (tt::tt_metal::MetalContext::instance().get_cluster().get_target_device_type() == tt::TargetDevice::Mock) {
-        return;
+        return false;
     }
     if (!mesh_device_->impl().is_local(device_coord)) {
-        return;
+        return false;
     }
 
     if (tt::tt_metal::GraphTracker::instance().hook_write_to_device(&buffer)) {
-        return;
+        return false;
     }
 
     in_use_ = true;
@@ -595,7 +595,7 @@ void FDMeshCommandQueue::write_shard_to_device(
     auto shard_view = device_buffer->view(region.value_or(BufferRegion(0, device_buffer->size())));
 
     sub_device_ids = buffer_dispatch::select_sub_device_ids(mesh_device_, sub_device_ids);
-    buffer_dispatch::write_to_device_buffer(
+    return buffer_dispatch::write_to_device_buffer(
         src,
         *shard_view,
         id_,

--- a/tt_metal/distributed/fd_mesh_command_queue.hpp
+++ b/tt_metal/distributed/fd_mesh_command_queue.hpp
@@ -199,7 +199,7 @@ private:
     std::atomic<bool> thread_exception_state_ = false;
 
 protected:
-    void write_shard_to_device(
+    bool write_shard_to_device(
         const MeshBuffer& buffer,
         const MeshCoordinate& device_coord,
         const void* src,

--- a/tt_metal/distributed/mesh_command_queue_base.cpp
+++ b/tt_metal/distributed/mesh_command_queue_base.cpp
@@ -226,10 +226,10 @@ void MeshCommandQueueBase::enqueue_write_shards_nolock(
     bool blocking) {
     // TODO: #17215 - this API is used by TTNN, as it currently implements rich ND sharding API for multi-devices.
     // In the long run, the multi-device sharding API in Metal will change, and this will most likely be replaced.
-    
+
     // Track if any transfer actually used pinned memory
     std::atomic<bool> any_pinned_used = false;
-    
+
     auto dispatch_lambda = [&shard_data_transfers, &buffer, &any_pinned_used, this](uint32_t shard_idx) {
         const auto& shard_data_transfer = shard_data_transfers[shard_idx];
         bool pinned_used = this->write_shard_to_device(

--- a/tt_metal/distributed/mesh_command_queue_base.cpp
+++ b/tt_metal/distributed/mesh_command_queue_base.cpp
@@ -226,21 +226,25 @@ void MeshCommandQueueBase::enqueue_write_shards_nolock(
     bool blocking) {
     // TODO: #17215 - this API is used by TTNN, as it currently implements rich ND sharding API for multi-devices.
     // In the long run, the multi-device sharding API in Metal will change, and this will most likely be replaced.
-    auto dispatch_lambda = [&shard_data_transfers, &buffer, this](uint32_t shard_idx) {
+    
+    // Track if any transfer actually used pinned memory
+    std::atomic<bool> any_pinned_used = false;
+    
+    auto dispatch_lambda = [&shard_data_transfers, &buffer, &any_pinned_used, this](uint32_t shard_idx) {
         const auto& shard_data_transfer = shard_data_transfers[shard_idx];
-        this->write_shard_to_device(
+        bool pinned_used = this->write_shard_to_device(
             *buffer,
             shard_data_transfer.shard_coord(),
             shard_data_transfer.host_data(),
             shard_data_transfer.region(),
             {},
             experimental::ShardDataTransferGetPinnedMemory(shard_data_transfer));
+        if (pinned_used) {
+            any_pinned_used.store(true, std::memory_order_relaxed);
+        }
     };
 
-    bool has_pinned_memory = false;
     for (std::size_t shard_idx = 0; shard_idx < shard_data_transfers.size(); shard_idx++) {
-        has_pinned_memory =
-            has_pinned_memory || experimental::ShardDataTransferGetPinnedMemory(shard_data_transfers[shard_idx]);
         auto shard_coord = shard_data_transfers[shard_idx].shard_coord();
         if (mesh_device_->impl().is_local(shard_coord)) {
             dispatch_thread_pool_->enqueue(
@@ -252,7 +256,8 @@ void MeshCommandQueueBase::enqueue_write_shards_nolock(
 
     if (blocking) {
         this->finish_nolock();
-    } else if (has_pinned_memory) {
+    } else if (any_pinned_used.load(std::memory_order_relaxed)) {
+        // If any transfer used pinned memory, add barrier event to all pinned memory objects
         auto event = this->enqueue_record_event_to_host_nolock();
         for (const auto& shard_data_transfer : shard_data_transfers) {
             if (mesh_device_->is_local(shard_data_transfer.shard_coord())) {

--- a/tt_metal/distributed/mesh_command_queue_base.hpp
+++ b/tt_metal/distributed/mesh_command_queue_base.hpp
@@ -20,7 +20,8 @@ protected:
     std::function<std::lock_guard<std::mutex>()> lock_api_function_;
 
     // Helper functions for reading and writing individual shards
-    virtual void write_shard_to_device(
+    // Returns true if pinned memory was used for the transfer
+    virtual bool write_shard_to_device(
         const MeshBuffer& buffer,
         const MeshCoordinate& device_coord,
         const void* src,

--- a/tt_metal/distributed/pinned_memory.cpp
+++ b/tt_metal/distributed/pinned_memory.cpp
@@ -264,6 +264,8 @@ void PinnedMemoryImpl::add_barrier_event(const distributed::MeshEvent& event) {
     }
 }
 
+bool PinnedMemoryImpl::lock_may_block() const { return !barrier_events_.empty(); }
+
 void* PinnedMemoryImpl::lock() {
     while (!barrier_events_.empty()) {
         auto& event = barrier_events_.front();
@@ -308,6 +310,8 @@ bool PinnedMemory::has_device(ChipId device_id) const { return pImpl->has_device
 bool PinnedMemory::usable_from_noc(ChipId device_id) const { return pImpl->usable_from_noc(device_id); }
 
 void PinnedMemory::add_barrier_event(const distributed::MeshEvent& event) { pImpl->add_barrier_event(event); }
+
+bool PinnedMemory::lock_may_block() const { return pImpl->lock_may_block(); }
 
 void* PinnedMemory::lock() { return pImpl->lock(); }
 

--- a/tt_metal/distributed/pinned_memory_impl.hpp
+++ b/tt_metal/distributed/pinned_memory_impl.hpp
@@ -76,6 +76,7 @@ public:
 
     void add_barrier_event(const distributed::MeshEvent& event);
 
+    bool lock_may_block() const;
     void* lock();
 
     void unlock();

--- a/tt_metal/distributed/sd_mesh_command_queue.hpp
+++ b/tt_metal/distributed/sd_mesh_command_queue.hpp
@@ -10,7 +10,7 @@ namespace tt::tt_metal::distributed {
 
 class SDMeshCommandQueue final : public MeshCommandQueueBase {
 protected:
-    void write_shard_to_device(
+    bool write_shard_to_device(
         const MeshBuffer& buffer,
         const MeshCoordinate& device_coord,
         const void* src,

--- a/tt_metal/impl/buffers/dispatch.cpp
+++ b/tt_metal/impl/buffers/dispatch.cpp
@@ -744,7 +744,10 @@ void issue_buffer_dispatch_command_sequence(
         uint64_t relay_src_addr = dispatch_params.pinned_src_addr;
         uint64_t relay_data_size = (uint64_t)dispatch_params.total_pages_to_write * dispatch_params.page_size_to_write;
         if constexpr (std::is_same_v<T, InterleavedBufferWriteDispatchParams>) {
-            TT_ASSERT(dispatch_params.alignment_prefix_bytes % MetalContext::instance().hal().get_alignment(HalMemType::L1) == 0, "Alignment prefix is not aligned to L1");
+            TT_ASSERT(
+                dispatch_params.alignment_prefix_bytes % MetalContext::instance().hal().get_alignment(HalMemType::L1) ==
+                    0,
+                "Alignment prefix is not aligned to L1");
             relay_src_addr += dispatch_params.alignment_prefix_bytes;
             relay_data_size -= dispatch_params.alignment_prefix_bytes;
         }

--- a/tt_metal/impl/buffers/dispatch.cpp
+++ b/tt_metal/impl/buffers/dispatch.cpp
@@ -65,8 +65,12 @@ struct BufferWriteDispatchParams {
     bool remote_chip = false;
 
     BufferWriteDispatchParams() = default;
-    BufferWriteDispatchParams(uint32_t src_noc_xy, uint64_t src_addr, bool src_pinned = false, bool remote_chip = false) :
-        pinned_src_noc_xy{src_noc_xy}, pinned_src_addr{src_addr}, use_pinned_transfer{src_pinned}, remote_chip{remote_chip} {}
+    BufferWriteDispatchParams(
+        uint32_t src_noc_xy, uint64_t src_addr, bool src_pinned = false, bool remote_chip = false) :
+        pinned_src_noc_xy{src_noc_xy},
+        pinned_src_addr{src_addr},
+        use_pinned_transfer{src_pinned},
+        remote_chip{remote_chip} {}
 
     void calculate_issue_wait() {
         this->issue_wait = this->total_pages_written == 0;  // only stall for the first write of the buffer

--- a/tt_metal/impl/buffers/dispatch.cpp
+++ b/tt_metal/impl/buffers/dispatch.cpp
@@ -115,6 +115,11 @@ public:
 
     virtual ~InterleavedBufferWriteDispatchParams() = default;
 
+    InterleavedBufferWriteDispatchParams(const InterleavedBufferWriteDispatchParams& other) = default;
+    InterleavedBufferWriteDispatchParams& operator=(const InterleavedBufferWriteDispatchParams& other) = default;
+    InterleavedBufferWriteDispatchParams(InterleavedBufferWriteDispatchParams&& other) = default;
+    InterleavedBufferWriteDispatchParams& operator=(InterleavedBufferWriteDispatchParams&& other) = default;
+
     virtual void calculate_num_pages_for_write_transaction(uint32_t num_pages_available_in_cq) {
         this->pages_per_txn = std::min(this->total_pages_to_write, num_pages_available_in_cq);
     }

--- a/tt_metal/impl/buffers/dispatch.cpp
+++ b/tt_metal/impl/buffers/dispatch.cpp
@@ -868,7 +868,7 @@ void write_sharded_buffer_to_core(
 }
 
 // Main API to write buffer data
-void write_to_device_buffer(
+bool write_to_device_buffer(
     const void* src,
     Buffer& buffer,
     uint32_t cq_id,
@@ -880,7 +880,7 @@ void write_to_device_buffer(
     const auto& hal = tt::tt_metal::MetalContext::instance().hal();
 
     if (tt::tt_metal::GraphTracker::instance().hook_write_to_device(&buffer)) {
-        return;
+        return false;
     }
 
     const BufferDispatchConstants buf_dispatch_constants =
@@ -984,7 +984,9 @@ void write_to_device_buffer(
 
         write_interleaved_buffer_to_device(
             src, *dispatch_params, *root_buffer, buf_dispatch_constants, sub_device_ids, dispatch_core_type);
+        return use_pinned_transfer;
     }
+    return use_pinned_transfer;
 }
 
 // ====== Utility Functions for Reads ======

--- a/tt_metal/impl/buffers/dispatch.cpp
+++ b/tt_metal/impl/buffers/dispatch.cpp
@@ -884,6 +884,7 @@ bool write_to_device_buffer(
         return false;
     }
 
+    fmt::println(stderr, "write_to_device_buffer");
     const BufferDispatchConstants buf_dispatch_constants =
         generate_buffer_dispatch_constants(sysmem_manager, dispatch_core_type, cq_id);
 
@@ -899,6 +900,7 @@ bool write_to_device_buffer(
         auto device_id = buffer.device()->id();
         auto noc_addr_pair_opt = pinned_memory->get_noc_addr(device_id);
         if (noc_addr_pair_opt.has_value()) {
+            fmt::println(stderr, "noc_addr_pair_opt has value");
             remote_chip = noc_addr_pair_opt->device_id != device_id;
             const uint64_t pinned_noc_base = noc_addr_pair_opt->addr;
             const uint8_t* pinned_host_base = static_cast<const uint8_t*>(pinned_memory->get_host_ptr());
@@ -928,8 +930,13 @@ bool write_to_device_buffer(
                 pinned_src_addr = pinned_noc_base + src_offset_base;
                 pinned_src_noc_xy = noc_addr_pair_opt->pcie_xy_enc;
                 use_pinned_transfer = true;
+                fmt::println(stderr, "Using pinned transfer");
             }
+        } else {
+            fmt::println(stderr, "noc_addr_pair_opt does not have value");
         }
+    } else {
+        fmt::println(stderr, "Has pinned inputs {} is_unpadded {} is_sharded {}", has_pinned_inputs, is_unpadded, is_sharded(buffer.buffer_layout()));
     }
     if (is_sharded(buffer.buffer_layout())) {
         ShardedBufferWriteDispatchParams dispatch_params(

--- a/tt_metal/impl/buffers/dispatch.cpp
+++ b/tt_metal/impl/buffers/dispatch.cpp
@@ -761,7 +761,7 @@ void issue_buffer_dispatch_command_sequence(
 
         if (dispatch_params.remote_chip) {
             command_sequence.add_prefetch_relay_linear_h(
-                dispatch_params.pinned_src_noc_xy, data_size_bytes, dispatch_params.pinned_src_addr);
+                dispatch_params.pinned_src_noc_xy, relay_data_size, relay_src_addr);
         } else {
             command_sequence.add_prefetch_relay_linear(
                 dispatch_params.pinned_src_noc_xy, relay_data_size, relay_src_addr);

--- a/tt_metal/impl/buffers/dispatch.cpp
+++ b/tt_metal/impl/buffers/dispatch.cpp
@@ -884,7 +884,6 @@ bool write_to_device_buffer(
         return false;
     }
 
-    fmt::println(stderr, "write_to_device_buffer");
     const BufferDispatchConstants buf_dispatch_constants =
         generate_buffer_dispatch_constants(sysmem_manager, dispatch_core_type, cq_id);
 
@@ -900,7 +899,6 @@ bool write_to_device_buffer(
         auto device_id = buffer.device()->id();
         auto noc_addr_pair_opt = pinned_memory->get_noc_addr(device_id);
         if (noc_addr_pair_opt.has_value()) {
-            fmt::println(stderr, "noc_addr_pair_opt has value");
             remote_chip = noc_addr_pair_opt->device_id != device_id;
             const uint64_t pinned_noc_base = noc_addr_pair_opt->addr;
             const uint8_t* pinned_host_base = static_cast<const uint8_t*>(pinned_memory->get_host_ptr());
@@ -930,13 +928,8 @@ bool write_to_device_buffer(
                 pinned_src_addr = pinned_noc_base + src_offset_base;
                 pinned_src_noc_xy = noc_addr_pair_opt->pcie_xy_enc;
                 use_pinned_transfer = true;
-                fmt::println(stderr, "Using pinned transfer");
             }
-        } else {
-            fmt::println(stderr, "noc_addr_pair_opt does not have value");
         }
-    } else {
-        fmt::println(stderr, "Has pinned inputs {} is_unpadded {} is_sharded {}", has_pinned_inputs, is_unpadded, is_sharded(buffer.buffer_layout()));
     }
     if (is_sharded(buffer.buffer_layout())) {
         ShardedBufferWriteDispatchParams dispatch_params(

--- a/tt_metal/impl/buffers/dispatch.cpp
+++ b/tt_metal/impl/buffers/dispatch.cpp
@@ -531,7 +531,7 @@ void populate_interleaved_buffer_write_dispatch_cmds(
         const uint64_t alignment_prefix_bytes = relay_alignment - alignment_offset;
         TT_ASSERT(alignment_prefix_bytes < buffer.page_size(), "Alignment prefix exceeds page size");
         
-        command_sequence.add_dispatch_write_paged_with_custom_inline_size<true>(
+        command_sequence.add_dispatch_write_paged_with_custom_inline_size(
             flush_prefetch,
             is_dram,
             start_page,
@@ -691,7 +691,7 @@ void issue_buffer_dispatch_command_sequence(
     } else {
         if (needs_alignment_prefix) {
             // Use custom inline size variant to account for alignment prefix bytes
-            calculator.add_dispatch_write_paged_with_custom_inline_size<true>(0, 0, alignment_prefix_bytes);
+            calculator.add_dispatch_write_paged_with_custom_inline_size(0, 0, alignment_prefix_bytes);
         } else {
             calculator.add_dispatch_write_paged<false>(0, 0);  // arguments are don't care for <false>
         }

--- a/tt_metal/impl/buffers/dispatch.hpp
+++ b/tt_metal/impl/buffers/dispatch.hpp
@@ -108,6 +108,7 @@ struct ShardedBufferReadDispatchParams : BufferReadDispatchParams {
     CoreCoord core;
 };
 
+// Returns true if pinned memory was used for the transfer
 bool write_to_device_buffer(
     const void* src,
     Buffer& buffer,

--- a/tt_metal/impl/buffers/dispatch.hpp
+++ b/tt_metal/impl/buffers/dispatch.hpp
@@ -108,7 +108,7 @@ struct ShardedBufferReadDispatchParams : BufferReadDispatchParams {
     CoreCoord core;
 };
 
-void write_to_device_buffer(
+bool write_to_device_buffer(
     const void* src,
     Buffer& buffer,
     uint32_t cq_id,

--- a/tt_metal/impl/dispatch/device_command.cpp
+++ b/tt_metal/impl/dispatch/device_command.cpp
@@ -538,7 +538,8 @@ void DeviceCommand<hugepage_write>::add_dispatch_write_paged_with_custom_inline_
     uint32_t pages,
     uint32_t inline_data_sizeB,
     const void* data) {
-    uint32_t payload_sizeB = sizeof(CQDispatchCmd) + (flush_prefetch ? inline_data_sizeB : 0);
+    // When using custom inline size, always account for inline data in payload (e.g., alignment prefix bytes)
+    uint32_t payload_sizeB = sizeof(CQDispatchCmd) + inline_data_sizeB;
     this->add_prefetch_relay_inline(flush_prefetch, payload_sizeB);
 
     auto initialize_write_cmd = [&](CQDispatchCmd* write_cmd) {

--- a/tt_metal/impl/dispatch/device_command.cpp
+++ b/tt_metal/impl/dispatch/device_command.cpp
@@ -528,7 +528,6 @@ void DeviceCommand<hugepage_write>::add_dispatch_write_paged(
 }
 
 template <bool hugepage_write>
-template <bool inline_data>
 void DeviceCommand<hugepage_write>::add_dispatch_write_paged_with_custom_inline_size(
     bool flush_prefetch,
     uint8_t is_dram,
@@ -560,13 +559,11 @@ void DeviceCommand<hugepage_write>::add_dispatch_write_paged_with_custom_inline_
         initialize_write_cmd(write_cmd_dst);
     }
 
-    if (inline_data) {
-        TT_ASSERT(data != nullptr);  // compiled out?
-        this->add_data(data, inline_data_sizeB, inline_data_sizeB);
-        // Increment wr offset to aligned address only if data is inline. Out-of-line data will
-        // follow right after the command, so defer alignment to after it.
-        this->cmd_write_offsetB = tt::align(this->cmd_write_offsetB, this->pcie_alignment);
-    }
+    TT_ASSERT(data != nullptr);
+    this->add_data(data, inline_data_sizeB, inline_data_sizeB);
+    // Increment wr offset to aligned address only if data is inline. Out-of-line data will
+    // follow right after the command, so defer alignment to after it.
+    this->cmd_write_offsetB = tt::align(this->cmd_write_offsetB, this->pcie_alignment);
 }
 
 template <bool hugepage_write>
@@ -1146,11 +1143,6 @@ template void DeviceCommand<true>::add_dispatch_write_paged<false>(bool, uint8_t
 template void DeviceCommand<true>::add_dispatch_write_paged<true>(bool, uint8_t, uint16_t, uint32_t, uint32_t, uint32_t, const void*);
 template void DeviceCommand<false>::add_dispatch_write_paged<false>(bool, uint8_t, uint16_t, uint32_t, uint32_t, uint32_t, const void*);
 template void DeviceCommand<false>::add_dispatch_write_paged<true>(bool, uint8_t, uint16_t, uint32_t, uint32_t, uint32_t, const void*);
-
-template void DeviceCommand<true>::add_dispatch_write_paged_with_custom_inline_size<false>(bool, uint8_t, uint16_t, uint32_t, uint32_t, uint32_t, uint32_t, const void*);
-template void DeviceCommand<true>::add_dispatch_write_paged_with_custom_inline_size<true>(bool, uint8_t, uint16_t, uint32_t, uint32_t, uint32_t, uint32_t, const void*);
-template void DeviceCommand<false>::add_dispatch_write_paged_with_custom_inline_size<false>(bool, uint8_t, uint16_t, uint32_t, uint32_t, uint32_t, uint32_t, const void*);
-template void DeviceCommand<false>::add_dispatch_write_paged_with_custom_inline_size<true>(bool, uint8_t, uint16_t, uint32_t, uint32_t, uint32_t, uint32_t, const void*);
 
 template void DeviceCommand<true>::add_dispatch_write_linear<true, false>(uint8_t, uint32_t, DeviceAddr, DeviceAddr, const void*, uint32_t);
 template void DeviceCommand<true>::add_dispatch_write_linear<true, true>(uint8_t, uint32_t, DeviceAddr, DeviceAddr, const void*, uint32_t);

--- a/tt_metal/impl/dispatch/device_command.hpp
+++ b/tt_metal/impl/dispatch/device_command.hpp
@@ -121,6 +121,19 @@ public:
         uint32_t pages,
         const void* data = nullptr);
 
+    // Variant that allows specifying a different inline data size than write_paged pages * page_size
+    // Used when we need to pass through alignment prefix bytes directly via relay_inline
+    template <bool inline_data = false>
+    void add_dispatch_write_paged_with_custom_inline_size(
+        bool flush_prefetch,
+        uint8_t is_dram,
+        uint16_t start_page,
+        uint32_t base_addr,
+        uint32_t page_size,
+        uint32_t pages,
+        uint32_t inline_data_sizeB,
+        const void* data = nullptr);
+
     template <bool inline_data = false>
     void add_dispatch_write_host(
         bool flush_prefetch, uint64_t data_sizeB, bool is_event, uint16_t pad1, const void* data = nullptr);

--- a/tt_metal/impl/dispatch/device_command.hpp
+++ b/tt_metal/impl/dispatch/device_command.hpp
@@ -123,7 +123,7 @@ public:
 
     // Variant that allows specifying a different inline data size than write_paged pages * page_size
     // Used when we need to pass through alignment prefix bytes directly via relay_inline
-    template <bool inline_data = false>
+    // Always inlines the data (no template parameter needed)
     void add_dispatch_write_paged_with_custom_inline_size(
         bool flush_prefetch,
         uint8_t is_dram,
@@ -132,7 +132,7 @@ public:
         uint32_t page_size,
         uint32_t pages,
         uint32_t inline_data_sizeB,
-        const void* data = nullptr);
+        const void* data);
 
     template <bool inline_data = false>
     void add_dispatch_write_host(

--- a/tt_metal/impl/dispatch/device_command_calculator.hpp
+++ b/tt_metal/impl/dispatch/device_command_calculator.hpp
@@ -153,14 +153,12 @@ public:
     }
 
     // Variant that allows specifying a different inline data size than pages * page_size
-    template <bool inline_data = false>
-    void add_dispatch_write_paged_with_custom_inline_size(uint32_t page_size, uint32_t pages, uint32_t inline_data_sizeB) {
+    // Always accounts for inline data (no template parameter needed)
+    void add_dispatch_write_paged_with_custom_inline_size(uint32_t /*page_size*/, uint32_t /*pages*/, uint32_t inline_data_sizeB) {
         this->add_prefetch_relay_inline();
         this->cmd_write_offsetB += sizeof(CQDispatchCmd);
-        if constexpr (inline_data) {
-            this->add_data(inline_data_sizeB);
-            this->cmd_write_offsetB = tt::align(this->cmd_write_offsetB, this->pcie_alignment);
-        }
+        this->add_data(inline_data_sizeB);
+        this->cmd_write_offsetB = tt::align(this->cmd_write_offsetB, this->pcie_alignment);
     }
 
     void add_prefetch_relay_paged() {

--- a/tt_metal/impl/dispatch/device_command_calculator.hpp
+++ b/tt_metal/impl/dispatch/device_command_calculator.hpp
@@ -152,6 +152,17 @@ public:
         }
     }
 
+    // Variant that allows specifying a different inline data size than pages * page_size
+    template <bool inline_data = false>
+    void add_dispatch_write_paged_with_custom_inline_size(uint32_t page_size, uint32_t pages, uint32_t inline_data_sizeB) {
+        this->add_prefetch_relay_inline();
+        this->cmd_write_offsetB += sizeof(CQDispatchCmd);
+        if constexpr (inline_data) {
+            this->add_data(inline_data_sizeB);
+            this->cmd_write_offsetB = tt::align(this->cmd_write_offsetB, this->pcie_alignment);
+        }
+    }
+
     void add_prefetch_relay_paged() {
         this->cmd_write_offsetB += tt::align(sizeof(CQPrefetchCmd), this->pcie_alignment);
     }

--- a/tt_metal/impl/dispatch/device_command_calculator.hpp
+++ b/tt_metal/impl/dispatch/device_command_calculator.hpp
@@ -154,7 +154,8 @@ public:
 
     // Variant that allows specifying a different inline data size than pages * page_size
     // Always accounts for inline data (no template parameter needed)
-    void add_dispatch_write_paged_with_custom_inline_size(uint32_t /*page_size*/, uint32_t /*pages*/, uint32_t inline_data_sizeB) {
+    void add_dispatch_write_paged_with_custom_inline_size(
+        uint32_t /*page_size*/, uint32_t /*pages*/, uint32_t inline_data_sizeB) {
         this->add_prefetch_relay_inline();
         this->cmd_write_offsetB += sizeof(CQDispatchCmd);
         this->add_data(inline_data_sizeB);

--- a/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
@@ -955,7 +955,8 @@ uint32_t process_relay_paged_packed_cmd(uint32_t cmd_ptr, uint32_t& downstream__
 }
 
 template <bool set_src_noc_addr = false, bool set_trid = false>
-void noc_read_64bit_any_len(uint32_t src_noc_addr, uint64_t src_addr, uint32_t dst_addr, uint32_t size, uint32_t trid = 0) {
+void noc_read_64bit_any_len(
+    uint32_t src_noc_addr, uint64_t src_addr, uint32_t dst_addr, uint32_t size, uint32_t trid = 0) {
     // noc_read_state_init is unnecessary.
     if constexpr (set_src_noc_addr) {
         noc_read_with_state<DM_DEDICATED_NOC, read_cmd_buf, CQ_NOC_sNdL, CQ_NOC_send, CQ_NOC_WAIT>(
@@ -999,7 +1000,9 @@ uint32_t process_relay_linear_cmd(uint32_t cmd_ptr, uint32_t& downstream_data_pt
 
     uint32_t current_trid = TRID_SCRATCH_DB_READ_1;
 
-    static_assert(scratch_db_half_size / NOC_MAX_BURST_SIZE < NOC_MAX_TRANSACTION_ID_COUNT, "Full buffer size must not have more transactions than fit in one NOC transaction counter");
+    static_assert(
+        scratch_db_half_size / NOC_MAX_BURST_SIZE < NOC_MAX_TRANSACTION_ID_COUNT,
+        "Full buffer size must not have more transactions than fit in one NOC transaction counter");
     noc_async_read_barrier_with_trid(current_trid);
     // First step - read into DB0
     uint32_t scratch_read_addr = scratch_db_top[0];


### PR DESCRIPTION
### Ticket
#25673 

### Problem description
When the dispatcher attempts to read from pinned memory to write to the device, there are several unsupported scenarios:
1. Writing to a remote device that's not connected to MMIO
2. When the source data isn't PCIe-aligned (32 bytes on wormhole, 64 bytes on blackhole)

### What's changed
For writing to a remote device, use prefetch_relay_linear_h instead of prefetch_relay_linear. That command reads the data on the local device and relays it to the remote device.

If the source data isn't PCIe-aligned, but is L1-aligned (16 bytes), we can take the start of the data and relay it inline with the dispatch command. The remainder of the data will have correct alignment and will follow in a prefetch_relay_linear(_h) command.

Also add a lock_may_block() method to PinnedMemory, which both helps clients determine whether locking may block in some circumstances, and gives feedback to the tests about whether the pinned memory was actually used.

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:{{branch_name}})
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:{{branch_name}})
- [x] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:{{branch_name}})
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:{{branch_name}})
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:{{branch_name}})
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:{{branch_name}})
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
