### PR TITLE
Quad GLX Deepseek CI Improvements

### DIFF
--- a/.github/workflows/multi-host-physical.yaml
+++ b/.github/workflows/multi-host-physical.yaml
@@ -12,8 +12,28 @@ on:
         required: false
         default: true
         type: boolean
-      glx_4x_multihost:
-        description: 'Run Galaxy 4x multi-host job (timeshare)'
+      glx_4x_unit_tests:
+        description: 'Run Galaxy 4x unit tests'
+        required: false
+        default: false
+        type: boolean
+      glx_4x_deepseekv3_tests:
+        description: 'Run Galaxy 4x DeepSeek V3 tests'
+        required: false
+        default: false
+        type: boolean
+      glx_4x_teacher_forced:
+        description: 'Run Galaxy 4x teacher forced test'
+        required: false
+        default: false
+        type: boolean
+      glx_4x_dual_demo:
+        description: 'Run Galaxy 4x dual demo test'
+        required: false
+        default: false
+        type: boolean
+      glx_4x_dual_demo_stress:
+        description: 'Run Galaxy 4x dual demo stress test'
         required: false
         default: false
         type: boolean
@@ -170,8 +190,8 @@ jobs:
             ./tests/scripts/multihost/setup_shared_venv.sh
             ./tests/scripts/multihost/run_dual_galaxy_tests.sh
 
-  multi-host-glx-4x-unit-tests:
-    if: ${{ github.event.inputs.glx_4x_multihost == 'true' || github.event.schedule == '0 4 * * *' }}
+  multi-host-glx-4x:
+    if: ${{ github.event.inputs.glx_4x_unit_tests == 'true' || github.event.inputs.glx_4x_deepseekv3_tests == 'true' || github.event.inputs.glx_4x_teacher_forced == 'true' || github.event.inputs.glx_4x_dual_demo == 'true' || github.event.inputs.glx_4x_dual_demo_stress == 'true' || github.event.schedule == '0 4 * * *' }}
     runs-on:
       # A physical, multi-host WH Galaxy that's in service
       - multi-host-glx-4x
@@ -200,6 +220,7 @@ jobs:
         id: capture-home
         run: echo "home=${HOME}" >> $GITHUB_OUTPUT
       - name: Run quad galaxy unit tests
+        if: ${{ github.event.inputs.glx_4x_unit_tests == 'true' || github.event.schedule == '0 4 * * *' }}
         uses: ./.github/actions/docker-run
         timeout-minutes: 30
         with:
@@ -221,36 +242,8 @@ jobs:
           run_args: |
             ./tests/scripts/multihost/setup_shared_venv.sh
             ./tests/scripts/multihost/run_quad_galaxy_tests.sh unit_tests
-
-  multi-host-glx-4x-deepseekv3-tests:
-    if: ${{ github.event.inputs.glx_4x_multihost == 'true' || github.event.schedule == '0 4 * * *' }}
-    runs-on:
-      - multi-host-glx-4x
-      - arch-wormhole_b0
-      - bare-metal
-      - in-service
-    needs: build-artifact
-    steps:
-      - name: ⬇️ Checkout
-        uses: actions/checkout@v4
-        with:
-          submodules: recursive
-      - name: ⬇️ Download Build
-        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0
-        timeout-minutes: 10
-        with:
-          name: ${{ needs.build-artifact.outputs.build-artifact-name }}
-      - name: Extract files
-        run: tar --zstd -xvf ttm_any.tar.zst
-      - name: ⬇️ Download Wheel
-        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0
-        timeout-minutes: 10
-        with:
-          name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
-      - name: Capture runner's home directory
-        id: capture-home
-        run: echo "home=${HOME}" >> $GITHUB_OUTPUT
       - name: Run DeepSeek V3 unit and module tests
+        if: ${{ github.event.inputs.glx_4x_deepseekv3_tests == 'true' || github.event.schedule == '0 4 * * *' }}
         uses: ./.github/actions/docker-run
         timeout-minutes: 60
         with:
@@ -273,36 +266,8 @@ jobs:
             ./tests/scripts/multihost/setup_shared_venv.sh
             ./tests/scripts/multihost/run_quad_galaxy_tests.sh deepseekv3_unit_tests
             ./tests/scripts/multihost/run_quad_galaxy_tests.sh deepseekv3_module_tests
-
-  multi-host-glx-4x-teacher-forced:
-    if: ${{ github.event.inputs.glx_4x_multihost == 'true' || github.event.schedule == '0 4 * * *' }}
-    runs-on:
-      - multi-host-glx-4x
-      - arch-wormhole_b0
-      - bare-metal
-      - in-service
-    needs: build-artifact
-    steps:
-      - name: ⬇️ Checkout
-        uses: actions/checkout@v4
-        with:
-          submodules: recursive
-      - name: ⬇️ Download Build
-        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0
-        timeout-minutes: 10
-        with:
-          name: ${{ needs.build-artifact.outputs.build-artifact-name }}
-      - name: Extract files
-        run: tar --zstd -xvf ttm_any.tar.zst
-      - name: ⬇️ Download Wheel
-        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0
-        timeout-minutes: 10
-        with:
-          name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
-      - name: Capture runner's home directory
-        id: capture-home
-        run: echo "home=${HOME}" >> $GITHUB_OUTPUT
       - name: Run teacher forced accuracy test
+        if: ${{ github.event.inputs.glx_4x_teacher_forced == 'true' || github.event.schedule == '0 4 * * *' }}
         uses: ./.github/actions/docker-run
         timeout-minutes: 60
         with:
@@ -325,7 +290,7 @@ jobs:
             ./tests/scripts/multihost/setup_shared_venv.sh
             ./tests/scripts/multihost/run_quad_galaxy_tests.sh teacher_forced
       - name: Upload teacher forced accuracy artifacts
-        if: always()
+        if: ${{ always() && (github.event.inputs.glx_4x_teacher_forced == 'true' || github.event.schedule == '0 4 * * *') }}
         uses: actions/upload-artifact@v4
         with:
           name: teacher-forced-accuracy-${{ github.run_id }}
@@ -333,36 +298,8 @@ jobs:
             generated/artifacts/teacher_forced_accuracy.txt
             generated/artifacts/teacher_forced_output.log
           if-no-files-found: warn
-
-  multi-host-glx-4x-dual-demo:
-    if: ${{ github.event.inputs.glx_4x_multihost == 'true' || github.event.schedule == '0 4 * * *' }}
-    runs-on:
-      - multi-host-glx-4x
-      - arch-wormhole_b0
-      - bare-metal
-      - in-service
-    needs: build-artifact
-    steps:
-      - name: ⬇️ Checkout
-        uses: actions/checkout@v4
-        with:
-          submodules: recursive
-      - name: ⬇️ Download Build
-        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0
-        timeout-minutes: 10
-        with:
-          name: ${{ needs.build-artifact.outputs.build-artifact-name }}
-      - name: Extract files
-        run: tar --zstd -xvf ttm_any.tar.zst
-      - name: ⬇️ Download Wheel
-        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0
-        timeout-minutes: 10
-        with:
-          name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
-      - name: Capture runner's home directory
-        id: capture-home
-        run: echo "home=${HOME}" >> $GITHUB_OUTPUT
       - name: Run dual demo test (256 prompts, 1 batch)
+        if: ${{ github.event.inputs.glx_4x_dual_demo == 'true' || github.event.schedule == '0 4 * * *' }}
         uses: ./.github/actions/docker-run
         timeout-minutes: 40
         with:
@@ -385,7 +322,7 @@ jobs:
             ./tests/scripts/multihost/setup_shared_venv.sh
             ./tests/scripts/multihost/run_quad_galaxy_tests.sh dual_demo
       - name: Upload dual demo output artifacts
-        if: always()
+        if: ${{ always() && (github.event.inputs.glx_4x_dual_demo == 'true' || github.event.schedule == '0 4 * * *') }}
         uses: actions/upload-artifact@v4
         with:
           name: dual-demo-output-${{ github.run_id }}
@@ -393,36 +330,8 @@ jobs:
             generated/artifacts/dual_demo_output.log
             generated/artifacts/dual_demo_full_results.json
           if-no-files-found: warn
-
-  multi-host-glx-4x-dual-demo-stress:
-    if: ${{ github.event.inputs.glx_4x_multihost == 'true' || github.event.schedule == '0 4 * * *' }}
-    runs-on:
-      - multi-host-glx-4x
-      - arch-wormhole_b0
-      - bare-metal
-      - in-service
-    needs: build-artifact
-    steps:
-      - name: ⬇️ Checkout
-        uses: actions/checkout@v4
-        with:
-          submodules: recursive
-      - name: ⬇️ Download Build
-        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0
-        timeout-minutes: 10
-        with:
-          name: ${{ needs.build-artifact.outputs.build-artifact-name }}
-      - name: Extract files
-        run: tar --zstd -xvf ttm_any.tar.zst
-      - name: ⬇️ Download Wheel
-        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0
-        timeout-minutes: 10
-        with:
-          name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
-      - name: Capture runner's home directory
-        id: capture-home
-        run: echo "home=${HOME}" >> $GITHUB_OUTPUT
       - name: Run stress dual demo test (56 prompts, 20 batches)
+        if: ${{ github.event.inputs.glx_4x_dual_demo_stress == 'true' || github.event.schedule == '0 4 * * *' }}
         uses: ./.github/actions/docker-run
         timeout-minutes: 90
         with:
@@ -445,7 +354,7 @@ jobs:
             ./tests/scripts/multihost/setup_shared_venv.sh
             ./tests/scripts/multihost/run_quad_galaxy_tests.sh dual_demo_stress
       - name: Upload stress demo output artifacts
-        if: always()
+        if: ${{ always() && (github.event.inputs.glx_4x_dual_demo_stress == 'true' || github.event.schedule == '0 4 * * *') }}
         uses: actions/upload-artifact@v4
         with:
           name: dual-demo-stress-output-${{ github.run_id }}

--- a/.github/workflows/multi-host-physical.yaml
+++ b/.github/workflows/multi-host-physical.yaml
@@ -170,7 +170,7 @@ jobs:
             ./tests/scripts/multihost/setup_shared_venv.sh
             ./tests/scripts/multihost/run_dual_galaxy_tests.sh
 
-  multi-host-glx-4x:
+  multi-host-glx-4x-unit-tests:
     if: ${{ github.event.inputs.glx_4x_multihost == 'true' || github.event.schedule == '0 4 * * *' }}
     runs-on:
       # A physical, multi-host WH Galaxy that's in service
@@ -199,9 +199,9 @@ jobs:
       - name: Capture runner's home directory
         id: capture-home
         run: echo "home=${HOME}" >> $GITHUB_OUTPUT
-      - name: Run tests on multiple hosts
+      - name: Run quad galaxy unit tests
         uses: ./.github/actions/docker-run
-        timeout-minutes: 160
+        timeout-minutes: 30
         with:
           docker_image: ${{ needs.build-artifact.outputs.dev-docker-image }}
           docker_password: ${{ secrets.GITHUB_TOKEN }}
@@ -219,6 +219,237 @@ jobs:
             --hostname=mpirun-host
           install_wheel: true
           run_args: |
-            # Setup shared venv for multi-host access (handles race conditions)
             ./tests/scripts/multihost/setup_shared_venv.sh
-            ./tests/scripts/multihost/run_quad_galaxy_tests.sh
+            ./tests/scripts/multihost/run_quad_galaxy_tests.sh unit_tests
+
+  multi-host-glx-4x-deepseekv3-tests:
+    if: ${{ github.event.inputs.glx_4x_multihost == 'true' || github.event.schedule == '0 4 * * *' }}
+    runs-on:
+      - multi-host-glx-4x
+      - arch-wormhole_b0
+      - bare-metal
+      - in-service
+    needs: build-artifact
+    steps:
+      - name: ⬇️ Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - name: ⬇️ Download Build
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0
+        timeout-minutes: 10
+        with:
+          name: ${{ needs.build-artifact.outputs.build-artifact-name }}
+      - name: Extract files
+        run: tar --zstd -xvf ttm_any.tar.zst
+      - name: ⬇️ Download Wheel
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0
+        timeout-minutes: 10
+        with:
+          name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
+      - name: Capture runner's home directory
+        id: capture-home
+        run: echo "home=${HOME}" >> $GITHUB_OUTPUT
+      - name: Run DeepSeek V3 unit and module tests
+        uses: ./.github/actions/docker-run
+        timeout-minutes: 60
+        with:
+          docker_image: ${{ needs.build-artifact.outputs.dev-docker-image }}
+          docker_password: ${{ secrets.GITHUB_TOKEN }}
+          docker_opts: |
+            -e LD_LIBRARY_PATH=${{ github.workspace }}/build/lib
+            -e PYTHONPATH=${{ github.workspace }}
+            -e TT_METAL_HOME=${{ github.workspace }}
+            -e ARCH_NAME=wormhole_b0
+            -e TT_METAL_ENABLE_ERISC_IRAM="1"
+            -e GTEST_OUTPUT="xml:${{ github.workspace }}/generated/test_reports/"
+            -v /etc/mpirun:/etc/mpirun:ro
+            -v ${{ steps.capture-home.outputs.home }}/.ssh:${{ steps.capture-home.outputs.home }}/.ssh:ro
+            --device /dev/tenstorrent
+            --pid=host
+            --hostname=mpirun-host
+          install_wheel: true
+          run_args: |
+            ./tests/scripts/multihost/setup_shared_venv.sh
+            ./tests/scripts/multihost/run_quad_galaxy_tests.sh deepseekv3_unit_tests
+            ./tests/scripts/multihost/run_quad_galaxy_tests.sh deepseekv3_module_tests
+
+  multi-host-glx-4x-teacher-forced:
+    if: ${{ github.event.inputs.glx_4x_multihost == 'true' || github.event.schedule == '0 4 * * *' }}
+    runs-on:
+      - multi-host-glx-4x
+      - arch-wormhole_b0
+      - bare-metal
+      - in-service
+    needs: build-artifact
+    steps:
+      - name: ⬇️ Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - name: ⬇️ Download Build
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0
+        timeout-minutes: 10
+        with:
+          name: ${{ needs.build-artifact.outputs.build-artifact-name }}
+      - name: Extract files
+        run: tar --zstd -xvf ttm_any.tar.zst
+      - name: ⬇️ Download Wheel
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0
+        timeout-minutes: 10
+        with:
+          name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
+      - name: Capture runner's home directory
+        id: capture-home
+        run: echo "home=${HOME}" >> $GITHUB_OUTPUT
+      - name: Run teacher forced accuracy test
+        uses: ./.github/actions/docker-run
+        timeout-minutes: 60
+        with:
+          docker_image: ${{ needs.build-artifact.outputs.dev-docker-image }}
+          docker_password: ${{ secrets.GITHUB_TOKEN }}
+          docker_opts: |
+            -e LD_LIBRARY_PATH=${{ github.workspace }}/build/lib
+            -e PYTHONPATH=${{ github.workspace }}
+            -e TT_METAL_HOME=${{ github.workspace }}
+            -e ARCH_NAME=wormhole_b0
+            -e TT_METAL_ENABLE_ERISC_IRAM="1"
+            -e GTEST_OUTPUT="xml:${{ github.workspace }}/generated/test_reports/"
+            -v /etc/mpirun:/etc/mpirun:ro
+            -v ${{ steps.capture-home.outputs.home }}/.ssh:${{ steps.capture-home.outputs.home }}/.ssh:ro
+            --device /dev/tenstorrent
+            --pid=host
+            --hostname=mpirun-host
+          install_wheel: true
+          run_args: |
+            ./tests/scripts/multihost/setup_shared_venv.sh
+            ./tests/scripts/multihost/run_quad_galaxy_tests.sh teacher_forced
+      - name: Upload teacher forced accuracy artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: teacher-forced-accuracy-${{ github.run_id }}
+          path: |
+            generated/artifacts/teacher_forced_accuracy.txt
+            generated/artifacts/teacher_forced_output.log
+          if-no-files-found: warn
+
+  multi-host-glx-4x-dual-demo:
+    if: ${{ github.event.inputs.glx_4x_multihost == 'true' || github.event.schedule == '0 4 * * *' }}
+    runs-on:
+      - multi-host-glx-4x
+      - arch-wormhole_b0
+      - bare-metal
+      - in-service
+    needs: build-artifact
+    steps:
+      - name: ⬇️ Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - name: ⬇️ Download Build
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0
+        timeout-minutes: 10
+        with:
+          name: ${{ needs.build-artifact.outputs.build-artifact-name }}
+      - name: Extract files
+        run: tar --zstd -xvf ttm_any.tar.zst
+      - name: ⬇️ Download Wheel
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0
+        timeout-minutes: 10
+        with:
+          name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
+      - name: Capture runner's home directory
+        id: capture-home
+        run: echo "home=${HOME}" >> $GITHUB_OUTPUT
+      - name: Run dual demo test (256 prompts, 1 batch)
+        uses: ./.github/actions/docker-run
+        timeout-minutes: 40
+        with:
+          docker_image: ${{ needs.build-artifact.outputs.dev-docker-image }}
+          docker_password: ${{ secrets.GITHUB_TOKEN }}
+          docker_opts: |
+            -e LD_LIBRARY_PATH=${{ github.workspace }}/build/lib
+            -e PYTHONPATH=${{ github.workspace }}
+            -e TT_METAL_HOME=${{ github.workspace }}
+            -e ARCH_NAME=wormhole_b0
+            -e TT_METAL_ENABLE_ERISC_IRAM="1"
+            -e GTEST_OUTPUT="xml:${{ github.workspace }}/generated/test_reports/"
+            -v /etc/mpirun:/etc/mpirun:ro
+            -v ${{ steps.capture-home.outputs.home }}/.ssh:${{ steps.capture-home.outputs.home }}/.ssh:ro
+            --device /dev/tenstorrent
+            --pid=host
+            --hostname=mpirun-host
+          install_wheel: true
+          run_args: |
+            ./tests/scripts/multihost/setup_shared_venv.sh
+            ./tests/scripts/multihost/run_quad_galaxy_tests.sh dual_demo
+      - name: Upload dual demo output artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: dual-demo-output-${{ github.run_id }}
+          path: |
+            generated/artifacts/dual_demo_output.log
+            generated/artifacts/dual_demo_full_results.json
+          if-no-files-found: warn
+
+  multi-host-glx-4x-dual-demo-stress:
+    if: ${{ github.event.inputs.glx_4x_multihost == 'true' || github.event.schedule == '0 4 * * *' }}
+    runs-on:
+      - multi-host-glx-4x
+      - arch-wormhole_b0
+      - bare-metal
+      - in-service
+    needs: build-artifact
+    steps:
+      - name: ⬇️ Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - name: ⬇️ Download Build
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0
+        timeout-minutes: 10
+        with:
+          name: ${{ needs.build-artifact.outputs.build-artifact-name }}
+      - name: Extract files
+        run: tar --zstd -xvf ttm_any.tar.zst
+      - name: ⬇️ Download Wheel
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0
+        timeout-minutes: 10
+        with:
+          name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
+      - name: Capture runner's home directory
+        id: capture-home
+        run: echo "home=${HOME}" >> $GITHUB_OUTPUT
+      - name: Run stress dual demo test (56 prompts, 20 batches)
+        uses: ./.github/actions/docker-run
+        timeout-minutes: 90
+        with:
+          docker_image: ${{ needs.build-artifact.outputs.dev-docker-image }}
+          docker_password: ${{ secrets.GITHUB_TOKEN }}
+          docker_opts: |
+            -e LD_LIBRARY_PATH=${{ github.workspace }}/build/lib
+            -e PYTHONPATH=${{ github.workspace }}
+            -e TT_METAL_HOME=${{ github.workspace }}
+            -e ARCH_NAME=wormhole_b0
+            -e TT_METAL_ENABLE_ERISC_IRAM="1"
+            -e GTEST_OUTPUT="xml:${{ github.workspace }}/generated/test_reports/"
+            -v /etc/mpirun:/etc/mpirun:ro
+            -v ${{ steps.capture-home.outputs.home }}/.ssh:${{ steps.capture-home.outputs.home }}/.ssh:ro
+            --device /dev/tenstorrent
+            --pid=host
+            --hostname=mpirun-host
+          install_wheel: true
+          run_args: |
+            ./tests/scripts/multihost/setup_shared_venv.sh
+            ./tests/scripts/multihost/run_quad_galaxy_tests.sh dual_demo_stress
+      - name: Upload stress demo output artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: dual-demo-stress-output-${{ github.run_id }}
+          path: |
+            generated/artifacts/dual_demo_stress_output.log
+            generated/artifacts/dual_demo_stress_results.json
+          if-no-files-found: warn

--- a/.github/workflows/multi-host-physical.yaml
+++ b/.github/workflows/multi-host-physical.yaml
@@ -18,12 +18,12 @@ on:
         default: false
         type: boolean
       glx_4x_deepseekv3_tests:
-        description: 'Run Galaxy 4x DeepSeek V3 tests'
+        description: 'Run Galaxy 4x DeepSeekV3 tests'
         required: false
         default: false
         type: boolean
       glx_4x_teacher_forced:
-        description: 'Run Galaxy 4x teacher forced test'
+        description: 'Run Galaxy 4x DeepSeekV3 accuracy test'
         required: false
         default: false
         type: boolean

--- a/.github/workflows/multi-host-physical.yaml
+++ b/.github/workflows/multi-host-physical.yaml
@@ -273,7 +273,7 @@ jobs:
       - name: Run DeepSeek V3 module tests
         if: ${{ github.event.inputs.glx_4x_deepseekv3_module_tests == 'true' || github.event.schedule == '0 4 * * *' }}
         uses: ./.github/actions/docker-run
-        timeout-minutes: 80
+        timeout-minutes: 150
         with:
           docker_image: ${{ needs.build-artifact.outputs.dev-docker-image }}
           docker_password: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/multi-host-physical.yaml
+++ b/.github/workflows/multi-host-physical.yaml
@@ -17,8 +17,13 @@ on:
         required: false
         default: false
         type: boolean
-      glx_4x_deepseekv3_tests:
-        description: 'Run Galaxy 4x DeepSeekV3 tests'
+      glx_4x_deepseekv3_unit_tests:
+        description: 'Run Galaxy 4x DeepSeek V3 unit tests'
+        required: false
+        default: false
+        type: boolean
+      glx_4x_deepseekv3_module_tests:
+        description: 'Run Galaxy 4x DeepSeek V3 module tests'
         required: false
         default: false
         type: boolean
@@ -191,7 +196,7 @@ jobs:
             ./tests/scripts/multihost/run_dual_galaxy_tests.sh
 
   multi-host-glx-4x:
-    if: ${{ github.event.inputs.glx_4x_unit_tests == 'true' || github.event.inputs.glx_4x_deepseekv3_tests == 'true' || github.event.inputs.glx_4x_teacher_forced == 'true' || github.event.inputs.glx_4x_dual_demo == 'true' || github.event.inputs.glx_4x_dual_demo_stress == 'true' || github.event.schedule == '0 4 * * *' }}
+    if: ${{ github.event.inputs.glx_4x_unit_tests == 'true' || github.event.inputs.glx_4x_deepseekv3_unit_tests == 'true' || github.event.inputs.glx_4x_deepseekv3_module_tests == 'true' || github.event.inputs.glx_4x_teacher_forced == 'true' || github.event.inputs.glx_4x_dual_demo == 'true' || github.event.inputs.glx_4x_dual_demo_stress == 'true' || github.event.schedule == '0 4 * * *' }}
     runs-on:
       # A physical, multi-host WH Galaxy that's in service
       - multi-host-glx-4x
@@ -242,8 +247,8 @@ jobs:
           run_args: |
             ./tests/scripts/multihost/setup_shared_venv.sh
             ./tests/scripts/multihost/run_quad_galaxy_tests.sh unit_tests
-      - name: Run DeepSeek V3 unit and module tests
-        if: ${{ github.event.inputs.glx_4x_deepseekv3_tests == 'true' || github.event.schedule == '0 4 * * *' }}
+      - name: Run DeepSeek V3 unit tests
+        if: ${{ github.event.inputs.glx_4x_deepseekv3_unit_tests == 'true' || github.event.schedule == '0 4 * * *' }}
         uses: ./.github/actions/docker-run
         timeout-minutes: 60
         with:
@@ -265,6 +270,28 @@ jobs:
           run_args: |
             ./tests/scripts/multihost/setup_shared_venv.sh
             ./tests/scripts/multihost/run_quad_galaxy_tests.sh deepseekv3_unit_tests
+      - name: Run DeepSeek V3 module tests
+        if: ${{ github.event.inputs.glx_4x_deepseekv3_module_tests == 'true' || github.event.schedule == '0 4 * * *' }}
+        uses: ./.github/actions/docker-run
+        timeout-minutes: 80
+        with:
+          docker_image: ${{ needs.build-artifact.outputs.dev-docker-image }}
+          docker_password: ${{ secrets.GITHUB_TOKEN }}
+          docker_opts: |
+            -e LD_LIBRARY_PATH=${{ github.workspace }}/build/lib
+            -e PYTHONPATH=${{ github.workspace }}
+            -e TT_METAL_HOME=${{ github.workspace }}
+            -e ARCH_NAME=wormhole_b0
+            -e TT_METAL_ENABLE_ERISC_IRAM="1"
+            -e GTEST_OUTPUT="xml:${{ github.workspace }}/generated/test_reports/"
+            -v /etc/mpirun:/etc/mpirun:ro
+            -v ${{ steps.capture-home.outputs.home }}/.ssh:${{ steps.capture-home.outputs.home }}/.ssh:ro
+            --device /dev/tenstorrent
+            --pid=host
+            --hostname=mpirun-host
+          install_wheel: true
+          run_args: |
+            ./tests/scripts/multihost/setup_shared_venv.sh
             ./tests/scripts/multihost/run_quad_galaxy_tests.sh deepseekv3_module_tests
       - name: Run teacher forced accuracy test
         if: ${{ github.event.inputs.glx_4x_teacher_forced == 'true' || github.event.schedule == '0 4 * * *' }}

--- a/models/demos/deepseek_v3/demo/test_demo_dual.py
+++ b/models/demos/deepseek_v3/demo/test_demo_dual.py
@@ -12,7 +12,7 @@ MODEL_PATH = Path(os.getenv("DEEPSEEK_V3_HF_MODEL", "/mnt/MLPerf/tt_dnn-models/d
 CACHE_DIR = Path(os.getenv("DEEPSEEK_V3_CACHE", "/mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528-Cache/CI"))
 
 
-@pytest.mark.parametrize("repeat_batches", [10])
+@pytest.mark.parametrize("repeat_batches", [20])
 def test_demo_dual(repeat_batches):
     """
     Demo test the DeepSeek v3 demo with prompts loaded from JSON file, 10x runs.

--- a/models/demos/deepseek_v3/demo/test_demo_dual.py
+++ b/models/demos/deepseek_v3/demo/test_demo_dual.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC.
 # SPDX-License-Identifier: Apache-2.0
 
+import json
 import os
 from pathlib import Path
 
@@ -12,16 +13,26 @@ MODEL_PATH = Path(os.getenv("DEEPSEEK_V3_HF_MODEL", "/mnt/MLPerf/tt_dnn-models/d
 CACHE_DIR = Path(os.getenv("DEEPSEEK_V3_CACHE", "/mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528-Cache/CI"))
 
 
-@pytest.mark.parametrize("repeat_batches", [20])
-def test_demo_dual(repeat_batches):
+@pytest.mark.parametrize(
+    "max_prompts,repeat_batches,artifact_name",
+    [
+        pytest.param(256, 1, "dual_demo_full_results", id="full_demo"),
+        pytest.param(56, 20, "dual_demo_stress_results", id="stress_demo"),
+    ],
+)
+def test_demo_dual(max_prompts: int, repeat_batches: int, artifact_name: str):
     """
-    Demo test the DeepSeek v3 demo with prompts loaded from JSON file, 10x runs.
+    DeepSeek v3 dual demo test with prompts loaded from JSON file.
+
+    Test variants:
+    - full_demo: 256 prompts, 1 batch - tests full prompt capacity
+    - stress_demo: 56 prompts, 20 batches - tests stability under repeated execution
     """
     # Path to the external JSON file containing prompts
     json_path = "models/demos/deepseek_v3/demo/test_prompts.json"
 
     # Load prompts from JSON file
-    prompts = load_prompts_from_json(json_path, max_prompts=56)
+    prompts = load_prompts_from_json(json_path, max_prompts=max_prompts)
 
     # Run demo
     results = run_demo(
@@ -29,10 +40,38 @@ def test_demo_dual(repeat_batches):
         model_path=MODEL_PATH,
         cache_dir=CACHE_DIR,
         random_weights=False,
-        max_new_tokens=128,
+        max_new_tokens=129,
         repeat_batches=repeat_batches,
         enable_trace=True,
     )
 
     # Check output
-    assert len(results["generations"][0]["tokens"]) == 128
+    assert len(results["generations"][0]["tokens"]) == 129
+
+    # Save results to JSON for artifact upload
+    artifact_dir = Path("generated/artifacts")
+    artifact_dir.mkdir(parents=True, exist_ok=True)
+    output_file = artifact_dir / f"{artifact_name}.json"
+
+    # Prepare output data structure matching demo.py format
+    output_data = {
+        "prompts": prompts,
+        "generations": [],
+        "statistics": results.get("statistics", {}),
+    }
+
+    # Add generation results
+    for i, gen_result in enumerate(results["generations"]):
+        prompt_text = prompts[i] if i < len(prompts) else "[empty prompt]"
+        output_data["generations"].append(
+            {
+                "index": i + 1,
+                "prompt": prompt_text,
+                "text": gen_result.get("text"),
+            }
+        )
+
+    with open(output_file, "w", encoding="utf-8") as f:
+        json.dump(output_data, f, indent=2, ensure_ascii=False)
+
+    print(f"\nDemo results saved to: {output_file}")

--- a/models/demos/deepseek_v3/demo/test_demo_dual.py
+++ b/models/demos/deepseek_v3/demo/test_demo_dual.py
@@ -31,6 +31,7 @@ def test_demo_dual(repeat_batches):
         random_weights=False,
         max_new_tokens=128,
         repeat_batches=repeat_batches,
+        enable_trace=True,
     )
 
     # Check output

--- a/models/demos/deepseek_v3/demo/test_demo_teacher_forced.py
+++ b/models/demos/deepseek_v3/demo/test_demo_teacher_forced.py
@@ -128,6 +128,7 @@ def test_demo_teacher_forcing_accuracy(reference_file: Path):
         token_accuracy=True,
         reference_file=REFERENCE_FILE,
         tf_prompt_len=tf_prompt_len,
+        enable_trace=True,
     )
 
     # Check results

--- a/tests/scripts/multihost/run_quad_galaxy_tests.sh
+++ b/tests/scripts/multihost/run_quad_galaxy_tests.sh
@@ -160,7 +160,6 @@ run_quad_galaxy_tests() {
   run_dual_galaxy_deepseekv3_tests_on_quad_galaxy
 }
 
-fail=0
 main() {
   # For CI pipeline - source func commands but don't execute tests if not invoked directly
   if [[ "${BASH_SOURCE[0]}" != "${0}" ]]; then
@@ -216,10 +215,6 @@ main() {
       exit 1
       ;;
   esac
-
-  if [[ $fail -ne 0 ]]; then
-    exit 1
-  fi
 }
 
 main "$@"

--- a/tests/scripts/multihost/run_quad_galaxy_tests.sh
+++ b/tests/scripts/multihost/run_quad_galaxy_tests.sh
@@ -32,14 +32,13 @@ run_quad_galaxy_unit_tests() {
   fi
 }
 
-run_dual_galaxy_deepseekv3_tests_on_quad_galaxy() {
-    fail=0
-
-    # Run dual galaxy tests on quad galaxy since this is the only available machine
-    local RANK_BINDING_YAML="tests/tt_metal/distributed/config/dual_galaxy_rank_bindings.yaml"
-    local HOSTS="g05glx01,g05glx02"
-    local RANKFILE=/etc/mpirun/rankfile_g05glx01_g05glx02
+# Common setup for dual galaxy tests on quad galaxy
+setup_dual_galaxy_env() {
+    export RANK_BINDING_YAML="tests/tt_metal/distributed/config/dual_galaxy_rank_bindings.yaml"
+    export HOSTS="g05glx01,g05glx02"
+    export RANKFILE=/etc/mpirun/rankfile_g05glx01_g05glx02
     mkdir -p logs
+    mkdir -p generated/artifacts
 
     if ! test -f "$RANKFILE"; then
         echo "File '$RANKFILE' does not exist."
@@ -50,31 +49,88 @@ run_dual_galaxy_deepseekv3_tests_on_quad_galaxy() {
         exit 1
     fi
 
-    local DEEPSEEK_V3_HF_MODEL="/mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528"
-    local DEEPSEEK_V3_CACHE="/mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528-Cache/CI"
-    local MESH_DEVICE="DUAL"
+    export DEEPSEEK_V3_HF_MODEL="/mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528"
+    export DEEPSEEK_V3_CACHE="/mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528-Cache/CI"
+    export MESH_DEVICE="DUAL"
+}
+
+# Run deepseek v3 module tests (models/demos/deepseek_v3/tests)
+run_quad_galaxy_deepseekv3_module_tests() {
+    fail=0
+    setup_dual_galaxy_env
 
     local TEST_CASE="source ./python_env/bin/activate && pytest -svvv models/demos/deepseek_v3/tests"
-    local TEST_TEACHER_FORCED="source ./python_env/bin/activate && pytest -svvv models/demos/deepseek_v3/demo/test_demo_teacher_forced.py::test_demo_teacher_forcing_accuracy"
 
     tt-run --rank-binding "$RANK_BINDING_YAML" \
         --mpi-args "--host $HOSTS --map-by rankfile:file=$RANKFILE --mca btl self,tcp --mca btl_tcp_if_include cnx1 --bind-to none --output-filename logs/mpi_job --tag-output" \
         bash -c "export DEEPSEEK_V3_HF_MODEL=$DEEPSEEK_V3_HF_MODEL && export DEEPSEEK_V3_CACHE=$DEEPSEEK_V3_CACHE && export MESH_DEVICE=$MESH_DEVICE && $TEST_CASE" ; fail+=$?
 
-    # Run test_demo_dual test on DUAL galaxy setup
-    local TEST_DEMO_DUAL="source ./python_env/bin/activate && pytest -svvv models/demos/deepseek_v3/demo/test_demo_dual.py::test_demo_dual"
+    if [[ $fail -ne 0 ]]; then
+        exit 1
+    fi
+}
+
+# Run teacher forced accuracy test and save metrics to artifacts
+run_quad_galaxy_teacher_forced_test() {
+    fail=0
+    setup_dual_galaxy_env
+
+    local TEST_TEACHER_FORCED="source ./python_env/bin/activate && pytest -svvv models/demos/deepseek_v3/demo/test_demo_teacher_forced.py::test_demo_teacher_forcing_accuracy 2>&1 | tee generated/artifacts/teacher_forced_output.log"
 
     tt-run --rank-binding "$RANK_BINDING_YAML" \
         --mpi-args "--host $HOSTS --map-by rankfile:file=$RANKFILE --mca btl self,tcp --mca btl_tcp_if_include cnx1 --bind-to none --output-filename logs/mpi_job --tag-output" \
-        bash -c "export DEEPSEEK_V3_HF_MODEL=$DEEPSEEK_V3_HF_MODEL && export DEEPSEEK_V3_CACHE=$DEEPSEEK_V3_CACHE && export MESH_DEVICE=$MESH_DEVICE && $TEST_DEMO_DUAL" ; fail+=$?
+        bash -c "export DEEPSEEK_V3_HF_MODEL=$DEEPSEEK_V3_HF_MODEL && export DEEPSEEK_V3_CACHE=$DEEPSEEK_V3_CACHE && export MESH_DEVICE=$MESH_DEVICE && $TEST_TEACHER_FORCED" ; fail+=$?
 
-    tt-run --rank-binding "$RANK_BINDING_YAML" \
-        --mpi-args "--host $HOSTS --map-by rankfile:file=$RANKFILE --mca btl self,tcp --mca btl_tcp_if_include cnx1 --bind-to none --output-filename logs/mpi_job --tag-output" \
-        bash -c "source ./python_env/bin/activate && export DEEPSEEK_V3_HF_MODEL=$DEEPSEEK_V3_HF_MODEL && export DEEPSEEK_V3_CACHE=$DEEPSEEK_V3_CACHE && export MESH_DEVICE=$MESH_DEVICE && $TEST_TEACHER_FORCED" ; fail+=$?
+    # Extract accuracy metrics from logs and save to artifact file
+    if [[ -f generated/artifacts/teacher_forced_output.log ]]; then
+        echo "Extracting accuracy metrics from test output..."
+        grep -E "Top-1 accuracy:|Top-5 accuracy:" generated/artifacts/teacher_forced_output.log > generated/artifacts/teacher_forced_accuracy.txt || true
+        echo "Accuracy metrics saved to generated/artifacts/teacher_forced_accuracy.txt"
+    fi
 
     if [[ $fail -ne 0 ]]; then
         exit 1
     fi
+}
+
+# Run dual demo test (256 prompts, 1 batch) - full_demo variant
+run_quad_galaxy_dual_demo_test() {
+    fail=0
+    setup_dual_galaxy_env
+
+    local TEST_DEMO="source ./python_env/bin/activate && pytest -svvv 'models/demos/deepseek_v3/demo/test_demo_dual.py::test_demo_dual[full_demo]' 2>&1 | tee generated/artifacts/dual_demo_output.log"
+
+    tt-run --rank-binding "$RANK_BINDING_YAML" \
+        --mpi-args "--host $HOSTS --map-by rankfile:file=$RANKFILE --mca btl self,tcp --mca btl_tcp_if_include cnx1 --bind-to none --output-filename logs/mpi_job --tag-output" \
+        bash -c "export DEEPSEEK_V3_HF_MODEL=$DEEPSEEK_V3_HF_MODEL && export DEEPSEEK_V3_CACHE=$DEEPSEEK_V3_CACHE && export MESH_DEVICE=$MESH_DEVICE && $TEST_DEMO" ; fail+=$?
+
+    if [[ $fail -ne 0 ]]; then
+        exit 1
+    fi
+}
+
+# Run stress dual demo test (56 prompts, 20 batches) - stress_demo variant
+run_quad_galaxy_dual_demo_stress_test() {
+    fail=0
+    setup_dual_galaxy_env
+
+    local TEST_DEMO_STRESS="source ./python_env/bin/activate && pytest -svvv 'models/demos/deepseek_v3/demo/test_demo_dual.py::test_demo_dual[stress_demo]' 2>&1 | tee generated/artifacts/dual_demo_stress_output.log"
+
+    tt-run --rank-binding "$RANK_BINDING_YAML" \
+        --mpi-args "--host $HOSTS --map-by rankfile:file=$RANKFILE --mca btl self,tcp --mca btl_tcp_if_include cnx1 --bind-to none --output-filename logs/mpi_job --tag-output" \
+        bash -c "export DEEPSEEK_V3_HF_MODEL=$DEEPSEEK_V3_HF_MODEL && export DEEPSEEK_V3_CACHE=$DEEPSEEK_V3_CACHE && export MESH_DEVICE=$MESH_DEVICE && $TEST_DEMO_STRESS" ; fail+=$?
+
+    if [[ $fail -ne 0 ]]; then
+        exit 1
+    fi
+}
+
+# Legacy function that runs all dual galaxy tests on quad galaxy
+run_dual_galaxy_deepseekv3_tests_on_quad_galaxy() {
+    run_quad_galaxy_deepseekv3_module_tests
+    run_quad_galaxy_teacher_forced_test
+    run_quad_galaxy_dual_demo_test
+    run_quad_galaxy_dual_demo_stress_test
 }
 
 run_quad_galaxy_deepseekv3_unit_tests() {
@@ -122,11 +178,41 @@ main() {
     exit 1
   fi
 
-  # Run all tests
+  # Run tests
   cd $TT_METAL_HOME
   export PYTHONPATH=$TT_METAL_HOME
 
-  run_quad_galaxy_tests
+  # Support running specific test function via argument
+  local test_function="${1:-all}"
+
+  case "$test_function" in
+    "unit_tests")
+      run_quad_galaxy_unit_tests
+      ;;
+    "deepseekv3_unit_tests")
+      run_quad_galaxy_deepseekv3_unit_tests
+      ;;
+    "deepseekv3_module_tests")
+      run_quad_galaxy_deepseekv3_module_tests
+      ;;
+    "teacher_forced")
+      run_quad_galaxy_teacher_forced_test
+      ;;
+    "dual_demo")
+      run_quad_galaxy_dual_demo_test
+      ;;
+    "dual_demo_stress")
+      run_quad_galaxy_dual_demo_stress_test
+      ;;
+    "all")
+      run_quad_galaxy_tests
+      ;;
+    *)
+      echo "Unknown test function: $test_function" 1>&2
+      echo "Available options: unit_tests, deepseekv3_unit_tests, deepseekv3_module_tests, teacher_forced, dual_demo, dual_demo_stress, all" 1>&2
+      exit 1
+      ;;
+  esac
 
   if [[ $fail -ne 0 ]]; then
     exit 1

--- a/tests/scripts/multihost/run_quad_galaxy_tests.sh
+++ b/tests/scripts/multihost/run_quad_galaxy_tests.sh
@@ -204,12 +204,15 @@ main() {
     "dual_demo_stress")
       run_quad_galaxy_dual_demo_stress_test
       ;;
+    "deepseekv3_integration_tests")
+      run_dual_galaxy_deepseekv3_tests_on_quad_galaxy
+      ;;
     "all")
       run_quad_galaxy_tests
       ;;
     *)
       echo "Unknown test function: $test_function" 1>&2
-      echo "Available options: unit_tests, deepseekv3_unit_tests, deepseekv3_module_tests, teacher_forced, dual_demo, dual_demo_stress, all" 1>&2
+      echo "Available options: unit_tests, deepseekv3_unit_tests, deepseekv3_module_tests, teacher_forced, dual_demo, dual_demo_stress, deepseekv3_integration_tests, all" 1>&2
       exit 1
       ;;
   esac


### PR DESCRIPTION
## Pull request overview

This PR refactors the quad galaxy CI test infrastructure to enable granular test execution and adds trace functionality to DeepSeek V3 demo tests. The changes split a monolithic test execution flow into independent, selectable test steps and add artifact collection for test outputs and accuracy metrics.

**Changes:**
- Enables trace mode (`enable_trace=True`) in DeepSeek V3 demo tests for performance profiling
- Refactors bash test runner to support executing individual test suites via command-line arguments
- Adds GitHub Actions workflow inputs to trigger specific test categories independently
- Implements artifact collection for demo outputs and accuracy metrics

### Reviewed changes

Copilot reviewed 4 out of 4 changed files in this pull request and generated 4 comments.

| File | Description |
| ---- | ----------- |
| tests/scripts/multihost/run_quad_galaxy_tests.sh | Refactored to extract setup logic into `setup_dual_galaxy_env()`, split test execution into granular functions, and added CLI argument handling for selective test execution |
| models/demos/deepseek_v3/demo/test_demo_teacher_forced.py | Added `enable_trace=True` parameter to enable performance tracing |
| models/demos/deepseek_v3/demo/test_demo_dual.py | Added test parametrization for full/stress variants, enabled trace mode, changed max_new_tokens from 128 to 129, and added JSON artifact generation |
| .github/workflows/multi-host-physical.yaml | Replaced single `glx_4x_multihost` input with six granular inputs, split monolithic test step into independent steps with conditional execution, and added artifact upload steps for test outputs |



### CI Job Run
https://github.com/tenstorrent/tt-metal/actions/runs/21653646094/job/62424950581