### PR TITLE
[skip ci] Comment out reset_tensix call in teardown

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1044,7 +1044,7 @@ def pytest_runtest_teardown(item, nextitem):
             pci_ids = getattr(item.parent, "pci_ids", None)
         if pci_ids is not None:
             logger.info(f"In custom teardown, open device ids: {set(pci_ids)}")
-            reset_tensix(set(pci_ids))
+            # reset_tensix(set(pci_ids))
 
 
 def reset_tensix(tt_open_devices=None):


### PR DESCRIPTION
Comment out the call to reset_tensix in the custom teardown.

Hot fix.

@Aswinmcw reported that calling tt-smi -r after a failed test, in a single process environment can trigger:

```
terminate called after throwing an instance of 'std::runtime_error'
  what():  TT_THROW @ /home/ubuntu/tt-metal/tt_metal/third_party/umd/device/pcie/tlb_handle.cpp:49: tt::exception
info:
tt_tlb_map failed with error code -19 for TLB size 2097152.
```

Disabling the reset for now. No special handling for failed tests.

Will investigate deeper in the morning.