### PR TITLE
Exhaustive, Valid range testing : FMOD, POW, xIELU

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_pow_accuracy.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_pow_accuracy.py
@@ -1,0 +1,692 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+import os
+import csv
+import pytest
+import ttnn
+import numpy as np
+import matplotlib.pyplot as plt
+from tests.ttnn.utils_for_testing import assert_with_ulp
+
+
+def _run_exhaustive_pairwise_pow_helper(device, x_values, y_values, test_name, variant_name, max_skipped_samples=10):
+    """Helper function to run exhaustive pairwise pow test between two value sets.
+
+    Masks out invalid pow results:
+    - NaN: x < 0 with non-integer y, or other undefined cases
+    - ±Inf: overflow or 0^negative
+    These are skipped from comparison since they represent mathematically undefined or
+    implementation-sensitive cases.
+
+    Returns:
+        list: Up to max_skipped_samples skipped pairs as dicts with keys:
+              [x, y, torch_result, ttnn_result, skip_reason, category]
+    """
+    ttnn_dtype = ttnn.bfloat16
+
+    Nx = x_values.numel()
+    Ny = y_values.numel()
+    print(f"\n{'='*60}")
+    print(f"{test_name}: Testing {Nx} × {Ny} = {Nx*Ny:,} pairs")
+
+    batch_size = 512  # process 512×Ny pairs at a time
+    num_batches = (Nx + batch_size - 1) // batch_size
+
+    max_ulp_global = 0
+    total_mismatches = 0
+    total_valid_pairs = 0
+    total_skipped_pairs = 0
+
+    # Track ULP distribution
+    ulp_0_count = 0
+    ulp_1_count = 0
+    ulp_2_count = 0
+    ulp_3_to_10_count = 0
+    ulp_11_to_100_count = 0
+    ulp_above_100_count = 0
+
+    # Collect up to max_skipped_samples skipped pairs
+    skipped_samples = []
+
+    for batch_idx in range(num_batches):
+        start = batch_idx * batch_size
+        end = min(start + batch_size, Nx)
+
+        # x_batch: [batch_size, 1], y: [1, Ny] → broadcasts to [batch_size, Ny]
+        x_batch = x_values[start:end].unsqueeze(1)  # shape: [B, 1]
+        y_full = y_values.unsqueeze(0)  # shape: [1, Ny]
+
+        # Broadcast pow
+        z_torch = torch.pow(x_batch, y_full)  # shape: [B, Ny]
+
+        # Send to backend
+        x_tt = ttnn.from_torch(x_batch, dtype=ttnn_dtype, layout=ttnn.TILE_LAYOUT, device=device)
+        y_tt = ttnn.from_torch(y_full, dtype=ttnn_dtype, layout=ttnn.TILE_LAYOUT, device=device)
+        z_tt = ttnn.pow(x_tt, y_tt)
+        tt_out = ttnn.to_torch(z_tt)
+
+        # ULP check (use bf16 space)
+        z_bf16 = z_torch.to(torch.bfloat16).contiguous()
+        tt_bf16 = tt_out.to(torch.bfloat16).contiguous()
+
+        # Create validity mask: skip if torch result is NaN or ±Inf
+        # These represent mathematically undefined inputs (x<0 with non-integer y)
+        # or overflow/underflow cases (0^negative, large^large)
+        valid_mask = torch.isfinite(z_bf16)
+        skipped_mask = ~valid_mask
+        batch_skipped = skipped_mask.sum().item()
+        total_skipped_pairs += batch_skipped
+
+        # Collect skipped samples (up to max_skipped_samples)
+        if batch_skipped > 0 and len(skipped_samples) < max_skipped_samples:
+            skipped_indices = skipped_mask.nonzero(as_tuple=False)
+            for idx_pair in skipped_indices:
+                if len(skipped_samples) >= max_skipped_samples:
+                    break
+                i, j = idx_pair[0].item(), idx_pair[1].item()
+                xv = x_batch[i, 0].item()
+                yv = y_full[0, j].item()
+                torch_val = z_bf16[i, j].item()
+                ttnn_val = tt_bf16[i, j].item()
+                # Determine skip reason
+                if torch.isnan(z_bf16[i, j]):
+                    reason = "NaN"
+                elif torch.isinf(z_bf16[i, j]):
+                    reason = "+Inf" if z_bf16[i, j] > 0 else "-Inf"
+                else:
+                    reason = "Unknown"
+                skipped_samples.append(
+                    {
+                        "x": xv,
+                        "y": yv,
+                        "torch_result": torch_val,
+                        "ttnn_result": ttnn_val,
+                        "skip_reason": reason,
+                        "category": variant_name,
+                    }
+                )
+
+        # Flush subnormal bfloat16 values to zero (only for valid comparisons)
+        min_normal_threshold = torch.finfo(torch.bfloat16).tiny
+        subnormal_mask = z_bf16.abs() <= min_normal_threshold
+        z_bf16[subnormal_mask] = 0.0
+        subnormal_mask_tt = tt_bf16.abs() <= min_normal_threshold
+        tt_bf16[subnormal_mask_tt] = 0.0
+
+        # For ttnn output, also flush non-finite to 0 for comparison purposes
+        # (if torch was finite but ttnn overflowed, we want to detect that)
+        tt_nonfinite_mask = ~torch.isfinite(tt_bf16)
+        tt_bf16[tt_nonfinite_mask] = 0.0
+
+        z_bits = z_bf16.view(torch.uint16).to(torch.int32)
+        tt_bits = tt_bf16.view(torch.uint16).to(torch.int32)
+
+        sign_z = (z_bits >> 15) & 1
+        sign_tt = (tt_bits >> 15) & 1
+        z_ord = torch.where(sign_z == 0, z_bits + 0x8000, 0x8000 - z_bits)
+        tt_ord = torch.where(sign_tt == 0, tt_bits + 0x8000, 0x8000 - tt_bits)
+        ulp_dist = (z_ord - tt_ord).abs()
+
+        # Apply validity mask - set ULP to 0 for invalid pairs (they will be skipped)
+        ulp_dist_valid = torch.where(valid_mask, ulp_dist, torch.zeros_like(ulp_dist))
+
+        max_ulp_batch = ulp_dist_valid.max().item()
+        max_ulp_global = max(max_ulp_global, max_ulp_batch)
+
+        # Count ULP distribution (only for valid pairs)
+        ulp_0_count += ((ulp_dist == 0) & valid_mask).sum().item()
+        ulp_1_count += ((ulp_dist == 1) & valid_mask).sum().item()
+        ulp_2_count += ((ulp_dist == 2) & valid_mask).sum().item()
+        ulp_3_to_10_count += ((ulp_dist >= 3) & (ulp_dist <= 10) & valid_mask).sum().item()
+        ulp_11_to_100_count += ((ulp_dist >= 11) & (ulp_dist <= 100) & valid_mask).sum().item()
+        ulp_above_100_count += ((ulp_dist > 100) & valid_mask).sum().item()
+
+        # Count mismatches (only among valid pairs)
+        mismatch_mask = (ulp_dist > 1) & valid_mask
+        mismatch_count = mismatch_mask.sum().item()
+        total_mismatches += mismatch_count
+        total_valid_pairs += valid_mask.sum().item()
+
+        if (batch_idx + 1) % 10 == 0 or batch_idx == num_batches - 1:
+            print(
+                f"Batch {batch_idx+1}/{num_batches}: max_ulp={max_ulp_batch}, mismatches={mismatch_count}, skipped={batch_skipped}"
+            )
+
+    total_pairs = Nx * Ny
+    mismatch_pct = (total_mismatches / total_valid_pairs) * 100 if total_valid_pairs > 0 else 0.0
+    skipped_pct = (total_skipped_pairs / total_pairs) * 100 if total_pairs > 0 else 0.0
+
+    print(f"\n--- Summary ---")
+    print(f"Total pairs: {total_pairs:,}")
+    print(f"Valid pairs (torch finite): {total_valid_pairs:,} ({100-skipped_pct:.4f}%)")
+    print(f"Skipped pairs (torch NaN/Inf): {total_skipped_pairs:,} ({skipped_pct:.4f}%)")
+    print(f"Skipped samples collected: {len(skipped_samples)}")
+    print(f"Global max ULP: {max_ulp_global}")
+    print(f"Total mismatches (ULP > 1): {total_mismatches:,} ({mismatch_pct:.4f}% of valid)")
+
+    print(f"\nULP Distribution (valid pairs only):")
+    print(
+        f"  ULP = 0: {ulp_0_count:,} ({ulp_0_count/total_valid_pairs*100:.4f}%)"
+        if total_valid_pairs > 0
+        else "  ULP = 0: 0"
+    )
+    print(
+        f"  ULP = 1: {ulp_1_count:,} ({ulp_1_count/total_valid_pairs*100:.4f}%)"
+        if total_valid_pairs > 0
+        else "  ULP = 1: 0"
+    )
+    print(
+        f"  ULP = 2: {ulp_2_count:,} ({ulp_2_count/total_valid_pairs*100:.4f}%)"
+        if total_valid_pairs > 0
+        else "  ULP = 2: 0"
+    )
+    print(
+        f"  ULP 3-10: {ulp_3_to_10_count:,} ({ulp_3_to_10_count/total_valid_pairs*100:.4f}%)"
+        if total_valid_pairs > 0
+        else "  ULP 3-10: 0"
+    )
+    print(
+        f"  ULP 11-100: {ulp_11_to_100_count:,} ({ulp_11_to_100_count/total_valid_pairs*100:.4f}%)"
+        if total_valid_pairs > 0
+        else "  ULP 11-100: 0"
+    )
+    print(
+        f"  ULP > 100: {ulp_above_100_count:,} ({ulp_above_100_count/total_valid_pairs*100:.4f}%)"
+        if total_valid_pairs > 0
+        else "  ULP > 100: 0"
+    )
+
+    return skipped_samples
+
+
+def _run_exhaustive_pairwise_pow_helper_float32(
+    device, x_values, y_values, test_name, variant_name, max_skipped_samples=10
+):
+    """Helper function to run exhaustive pairwise pow test in float32 precision.
+
+    Takes bfloat16 bit patterns as input, converts to float32, and performs pow in float32.
+    Computes ULP distance in float32 space.
+
+    Masks out invalid pow results:
+    - NaN: x < 0 with non-integer y, or other undefined cases
+    - ±Inf: overflow or 0^negative
+    These are skipped from comparison since they represent mathematically undefined or
+    implementation-sensitive cases.
+
+    Returns:
+        list: Up to max_skipped_samples skipped pairs as dicts with keys:
+              [x, y, torch_result, ttnn_result, skip_reason, category]
+    """
+    ttnn_dtype = ttnn.float32
+
+    Nx = x_values.numel()
+    Ny = y_values.numel()
+    print(f"\n{'='*60}")
+    print(f"{test_name} (float32): Testing {Nx} × {Ny} = {Nx*Ny:,} pairs")
+
+    batch_size = 512  # process 512×Ny pairs at a time
+    num_batches = (Nx + batch_size - 1) // batch_size
+
+    max_ulp_global = 0
+    total_mismatches = 0
+    total_valid_pairs = 0
+    total_skipped_pairs = 0
+
+    # Track ULP distribution
+    ulp_0_count = 0
+    ulp_1_count = 0
+    ulp_2_count = 0
+    ulp_3_to_10_count = 0
+    ulp_11_to_100_count = 0
+    ulp_above_100_count = 0
+
+    # Collect up to max_skipped_samples skipped pairs
+    skipped_samples = []
+
+    for batch_idx in range(num_batches):
+        start = batch_idx * batch_size
+        end = min(start + batch_size, Nx)
+
+        # Convert bfloat16 values to float32 for computation
+        # x_batch: [batch_size, 1], y: [1, Ny] → broadcasts to [batch_size, Ny]
+        x_batch_f32 = x_values[start:end].to(torch.float32).unsqueeze(1)  # shape: [B, 1]
+        y_full_f32 = y_values.to(torch.float32).unsqueeze(0)  # shape: [1, Ny]
+
+        # Broadcast pow in float32
+        z_torch = torch.pow(x_batch_f32, y_full_f32)  # shape: [B, Ny]
+
+        # Send to backend using float32
+        x_tt = ttnn.from_torch(x_batch_f32, dtype=ttnn_dtype, layout=ttnn.TILE_LAYOUT, device=device)
+        y_tt = ttnn.from_torch(y_full_f32, dtype=ttnn_dtype, layout=ttnn.TILE_LAYOUT, device=device)
+        z_tt = ttnn.pow(x_tt, y_tt)
+        tt_out = ttnn.to_torch(z_tt)
+
+        # ULP check (use float32 space)
+        z_f32 = z_torch.to(torch.float32).contiguous()
+        tt_f32 = tt_out.to(torch.float32).contiguous()
+
+        # Create validity mask: skip if torch result is NaN or ±Inf
+        # These represent mathematically undefined inputs (x<0 with non-integer y)
+        # or overflow/underflow cases (0^negative, large^large)
+        valid_mask = torch.isfinite(z_f32)
+        skipped_mask = ~valid_mask
+        batch_skipped = skipped_mask.sum().item()
+        total_skipped_pairs += batch_skipped
+
+        # Collect skipped samples (up to max_skipped_samples)
+        if batch_skipped > 0 and len(skipped_samples) < max_skipped_samples:
+            skipped_indices = skipped_mask.nonzero(as_tuple=False)
+            for idx_pair in skipped_indices:
+                if len(skipped_samples) >= max_skipped_samples:
+                    break
+                i, j = idx_pair[0].item(), idx_pair[1].item()
+                xv = x_batch_f32[i, 0].item()
+                yv = y_full_f32[0, j].item()
+                torch_val = z_f32[i, j].item()
+                ttnn_val = tt_f32[i, j].item()
+                # Determine skip reason
+                if torch.isnan(z_f32[i, j]):
+                    reason = "NaN"
+                elif torch.isinf(z_f32[i, j]):
+                    reason = "+Inf" if z_f32[i, j] > 0 else "-Inf"
+                else:
+                    reason = "Unknown"
+                skipped_samples.append(
+                    {
+                        "x": xv,
+                        "y": yv,
+                        "torch_result": torch_val,
+                        "ttnn_result": ttnn_val,
+                        "skip_reason": reason,
+                        "category": variant_name,
+                    }
+                )
+
+        # Flush subnormal float32 values to zero (only for valid comparisons)
+        min_normal_threshold = torch.finfo(torch.float32).tiny
+        subnormal_mask = z_f32.abs() <= min_normal_threshold
+        z_f32[subnormal_mask] = 0.0
+        subnormal_mask_tt = tt_f32.abs() <= min_normal_threshold
+        tt_f32[subnormal_mask_tt] = 0.0
+
+        # For ttnn output, also flush non-finite to 0 for comparison purposes
+        # (if torch was finite but ttnn overflowed, we want to detect that)
+        tt_nonfinite_mask = ~torch.isfinite(tt_f32)
+        tt_f32[tt_nonfinite_mask] = 0.0
+
+        z_bits = z_f32.view(torch.int32)
+        tt_bits = tt_f32.view(torch.int32)
+
+        sign_z = (z_bits >> 31) & 1
+        sign_tt = (tt_bits >> 31) & 1
+        z_ord = torch.where(sign_z == 0, z_bits + 0x80000000, 0x80000000 - z_bits)
+        tt_ord = torch.where(sign_tt == 0, tt_bits + 0x80000000, 0x80000000 - tt_bits)
+        ulp_dist = (z_ord - tt_ord).abs()
+
+        # Apply validity mask - set ULP to 0 for invalid pairs (they will be skipped)
+        ulp_dist_valid = torch.where(valid_mask, ulp_dist, torch.zeros_like(ulp_dist))
+
+        max_ulp_batch = ulp_dist_valid.max().item()
+        max_ulp_global = max(max_ulp_global, max_ulp_batch)
+
+        # Count ULP distribution (only for valid pairs)
+        ulp_0_count += ((ulp_dist == 0) & valid_mask).sum().item()
+        ulp_1_count += ((ulp_dist == 1) & valid_mask).sum().item()
+        ulp_2_count += ((ulp_dist == 2) & valid_mask).sum().item()
+        ulp_3_to_10_count += ((ulp_dist >= 3) & (ulp_dist <= 10) & valid_mask).sum().item()
+        ulp_11_to_100_count += ((ulp_dist >= 11) & (ulp_dist <= 100) & valid_mask).sum().item()
+        ulp_above_100_count += ((ulp_dist > 100) & valid_mask).sum().item()
+
+        # Count mismatches (only among valid pairs)
+        mismatch_mask = (ulp_dist > 1) & valid_mask
+        mismatch_count = mismatch_mask.sum().item()
+        total_mismatches += mismatch_count
+        total_valid_pairs += valid_mask.sum().item()
+
+        if (batch_idx + 1) % 10 == 0 or batch_idx == num_batches - 1:
+            print(
+                f"Batch {batch_idx+1}/{num_batches}: max_ulp={max_ulp_batch}, mismatches={mismatch_count}, skipped={batch_skipped}"
+            )
+
+    total_pairs = Nx * Ny
+    mismatch_pct = (total_mismatches / total_valid_pairs) * 100 if total_valid_pairs > 0 else 0.0
+    skipped_pct = (total_skipped_pairs / total_pairs) * 100 if total_pairs > 0 else 0.0
+
+    print(f"\n--- Summary ---")
+    print(f"Total pairs: {total_pairs:,}")
+    print(f"Valid pairs (torch finite): {total_valid_pairs:,} ({100-skipped_pct:.4f}%)")
+    print(f"Skipped pairs (torch NaN/Inf): {total_skipped_pairs:,} ({skipped_pct:.4f}%)")
+    print(f"Skipped samples collected: {len(skipped_samples)}")
+    print(f"Global max ULP: {max_ulp_global}")
+    print(f"Total mismatches (ULP > 1): {total_mismatches:,} ({mismatch_pct:.4f}% of valid)")
+
+    print(f"\nULP Distribution (valid pairs only):")
+    print(
+        f"  ULP = 0: {ulp_0_count:,} ({ulp_0_count/total_valid_pairs*100:.4f}%)"
+        if total_valid_pairs > 0
+        else "  ULP = 0: 0"
+    )
+    print(
+        f"  ULP = 1: {ulp_1_count:,} ({ulp_1_count/total_valid_pairs*100:.4f}%)"
+        if total_valid_pairs > 0
+        else "  ULP = 1: 0"
+    )
+    print(
+        f"  ULP = 2: {ulp_2_count:,} ({ulp_2_count/total_valid_pairs*100:.4f}%)"
+        if total_valid_pairs > 0
+        else "  ULP = 2: 0"
+    )
+    print(
+        f"  ULP 3-10: {ulp_3_to_10_count:,} ({ulp_3_to_10_count/total_valid_pairs*100:.4f}%)"
+        if total_valid_pairs > 0
+        else "  ULP 3-10: 0"
+    )
+    print(
+        f"  ULP 11-100: {ulp_11_to_100_count:,} ({ulp_11_to_100_count/total_valid_pairs*100:.4f}%)"
+        if total_valid_pairs > 0
+        else "  ULP 11-100: 0"
+    )
+    print(
+        f"  ULP > 100: {ulp_above_100_count:,} ({ulp_above_100_count/total_valid_pairs*100:.4f}%)"
+        if total_valid_pairs > 0
+        else "  ULP > 100: 0"
+    )
+
+    return skipped_samples
+
+
+# FP32 exhaustive tests
+def test_pow_tt_FP32_exhaustive_pos_pos(device):
+    """Test positive base ^ positive exponent normal fp32 values."""
+    torch.manual_seed(0)
+
+    # Generate all possible bf16 values
+    all_bitpatterns = torch.arange(0, 2**16, dtype=torch.int32).to(torch.uint16)
+    vals = all_bitpatterns.view(torch.bfloat16)
+
+    # Keep only finite, non-zero, positive normal bf16 values
+    tiny = torch.finfo(torch.bfloat16).tiny
+    mask = torch.isfinite(vals) & (vals > 0) & (vals >= tiny)
+
+    pos_values = vals[mask]  # ~32512 positive normal values
+    return _run_exhaustive_pairwise_pow_helper_float32(device, pos_values, pos_values, "Positive ^ Positive", "pos_pos")
+
+
+def test_pow_tt_FP32_exhaustive_pos_neg(device):
+    """Test positive base ^ negative exponent normal bf16 values."""
+    torch.manual_seed(0)
+
+    # Generate all possible bf16 values
+    all_bitpatterns = torch.arange(0, 2**16, dtype=torch.int32).to(torch.uint16)
+    vals = all_bitpatterns.view(torch.bfloat16)
+
+    # Keep only finite, non-zero, normal bf16 values
+    tiny = torch.finfo(torch.bfloat16).tiny
+    pos_mask = torch.isfinite(vals) & (vals > 0) & (vals >= tiny)
+    neg_mask = torch.isfinite(vals) & (vals < 0) & (vals.abs() >= tiny)
+
+    pos_values = vals[pos_mask]  # ~32512 positive normal values
+    neg_values = vals[neg_mask]  # ~32512 negative normal values
+    return _run_exhaustive_pairwise_pow_helper_float32(device, pos_values, neg_values, "Positive ^ Negative", "pos_neg")
+
+
+def test_pow_tt_FP32_exhaustive_neg_pos(device):
+    """Test negative base ^ positive exponent normal bf16 values.
+
+    Note: This will have many NaN results since pow(negative, non-integer) is undefined.
+    The masking in the helper function will skip these invalid cases.
+    """
+    torch.manual_seed(0)
+
+    # Generate all possible bf16 values
+    all_bitpatterns = torch.arange(0, 2**16, dtype=torch.int32).to(torch.uint16)
+    vals = all_bitpatterns.view(torch.bfloat16)
+
+    # Keep only finite, non-zero, normal bf16 values
+    tiny = torch.finfo(torch.bfloat16).tiny
+    pos_mask = torch.isfinite(vals) & (vals > 0) & (vals >= tiny)
+    neg_mask = torch.isfinite(vals) & (vals < 0) & (vals.abs() >= tiny)
+
+    pos_values = vals[pos_mask]  # ~32512 positive normal values
+    neg_values = vals[neg_mask]  # ~32512 negative normal values
+    return _run_exhaustive_pairwise_pow_helper_float32(device, neg_values, pos_values, "Negative ^ Positive", "neg_pos")
+
+
+def test_pow_tt_FP32_exhaustive_neg_neg(device):
+    """Test negative base ^ negative exponent normal bf16 values.
+
+    Note: This will have many NaN results since pow(negative, non-integer) is undefined.
+    The masking in the helper function will skip these invalid cases.
+    """
+    torch.manual_seed(0)
+
+    # Generate all possible bf16 values
+    all_bitpatterns = torch.arange(0, 2**16, dtype=torch.int32).to(torch.uint16)
+    vals = all_bitpatterns.view(torch.bfloat16)
+
+    # Keep only finite, non-zero, negative normal bf16 values
+    tiny = torch.finfo(torch.bfloat16).tiny
+    mask = torch.isfinite(vals) & (vals < 0) & (vals.abs() >= tiny)
+
+    neg_values = vals[mask]  # ~32512 negative normal values
+    return _run_exhaustive_pairwise_pow_helper_float32(device, neg_values, neg_values, "Negative ^ Negative", "neg_neg")
+
+
+def test_pow_tt_FP32_exhaustive_test(device):
+    """Test pow with fp32 values - all sign combinations."""
+    import io
+    import sys
+    from datetime import datetime
+
+    # Tee class to write to both terminal and buffer
+    class Tee:
+        def __init__(self, *streams):
+            self.streams = streams
+
+        def write(self, data):
+            for s in self.streams:
+                s.write(data)
+                s.flush()
+
+        def flush(self):
+            for s in self.streams:
+                s.flush()
+
+    # Capture stdout while still printing to terminal
+    captured_output = io.StringIO()
+    original_stdout = sys.stdout
+    sys.stdout = Tee(original_stdout, captured_output)
+
+    # Collect skipped samples from all 4 categories
+    all_skipped_samples = []
+
+    try:
+        all_skipped_samples.extend(test_pow_tt_FP32_exhaustive_pos_pos(device))
+        all_skipped_samples.extend(test_pow_tt_FP32_exhaustive_pos_neg(device))
+        all_skipped_samples.extend(test_pow_tt_FP32_exhaustive_neg_pos(device))
+        all_skipped_samples.extend(test_pow_tt_FP32_exhaustive_neg_neg(device))
+    finally:
+        sys.stdout = original_stdout
+
+    # Get captured content
+    output_content = captured_output.getvalue()
+
+    # Write results to file
+    out_dir = "/home/ubuntu/Files"
+    os.makedirs(out_dir, exist_ok=True)
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    out_path = os.path.join(out_dir, f"pow_fp32_exhaustive_results_{timestamp}.txt")
+    with open(out_path, "w") as f:
+        f.write(output_content)
+
+    # Write merged skipped samples CSV (40 rows max: 10 per category)
+    skipped_csv_path = os.path.join(out_dir, f"pow_fp32_skipped_samples_{timestamp}.csv")
+    with open(skipped_csv_path, mode="w", newline="") as csv_file:
+        writer = csv.writer(csv_file)
+        writer.writerow(["category", "x", "y", "torch_result", "ttnn_result", "skip_reason"])
+        for sample in all_skipped_samples:
+            writer.writerow(
+                [
+                    sample["category"],
+                    sample["x"],
+                    sample["y"],
+                    sample["torch_result"],
+                    sample["ttnn_result"],
+                    sample["skip_reason"],
+                ]
+            )
+
+    print(f"\n{'='*60}")
+    print(f"All results saved to: {out_path}")
+    print(f"Skipped samples CSV ({len(all_skipped_samples)} rows): {skipped_csv_path}")
+    print(f"{'='*60}")
+
+
+# BF16 Exhaustive tests
+def test_pow_tt_bf16_exhaustive_pos_pos(device):
+    """Test positive base ^ positive exponent normal bf16 values."""
+    torch.manual_seed(0)
+
+    # Generate all possible bf16 values
+    all_bitpatterns = torch.arange(0, 2**16, dtype=torch.int32).to(torch.uint16)
+    vals = all_bitpatterns.view(torch.bfloat16)
+
+    # Keep only finite, non-zero, positive normal bf16 values
+    tiny = torch.finfo(torch.bfloat16).tiny
+    mask = torch.isfinite(vals) & (vals > 0) & (vals >= tiny)
+
+    pos_values = vals[mask]  # ~32512 positive normal values
+    return _run_exhaustive_pairwise_pow_helper(device, pos_values, pos_values, "Positive ^ Positive", "pos_pos")
+
+
+def test_pow_tt_bf16_exhaustive_pos_neg(device):
+    """Test positive base ^ negative exponent normal bf16 values."""
+    torch.manual_seed(0)
+
+    # Generate all possible bf16 values
+    all_bitpatterns = torch.arange(0, 2**16, dtype=torch.int32).to(torch.uint16)
+    vals = all_bitpatterns.view(torch.bfloat16)
+
+    # Keep only finite, non-zero, normal bf16 values
+    tiny = torch.finfo(torch.bfloat16).tiny
+    pos_mask = torch.isfinite(vals) & (vals > 0) & (vals >= tiny)
+    neg_mask = torch.isfinite(vals) & (vals < 0) & (vals.abs() >= tiny)
+
+    pos_values = vals[pos_mask]  # ~32512 positive normal values
+    neg_values = vals[neg_mask]  # ~32512 negative normal values
+    return _run_exhaustive_pairwise_pow_helper(device, pos_values, neg_values, "Positive ^ Negative", "pos_neg")
+
+
+def test_pow_tt_bf16_exhaustive_neg_pos(device):
+    """Test negative base ^ positive exponent normal bf16 values.
+
+    Note: This will have many NaN results since pow(negative, non-integer) is undefined.
+    The masking in the helper function will skip these invalid cases.
+    """
+    torch.manual_seed(0)
+
+    # Generate all possible bf16 values
+    all_bitpatterns = torch.arange(0, 2**16, dtype=torch.int32).to(torch.uint16)
+    vals = all_bitpatterns.view(torch.bfloat16)
+
+    # Keep only finite, non-zero, normal bf16 values
+    tiny = torch.finfo(torch.bfloat16).tiny
+    pos_mask = torch.isfinite(vals) & (vals > 0) & (vals >= tiny)
+    neg_mask = torch.isfinite(vals) & (vals < 0) & (vals.abs() >= tiny)
+
+    pos_values = vals[pos_mask]  # ~32512 positive normal values
+    neg_values = vals[neg_mask]  # ~32512 negative normal values
+    return _run_exhaustive_pairwise_pow_helper(device, neg_values, pos_values, "Negative ^ Positive", "neg_pos")
+
+
+def test_pow_tt_bf16_exhaustive_neg_neg(device):
+    """Test negative base ^ negative exponent normal bf16 values.
+
+    Note: This will have many NaN results since pow(negative, non-integer) is undefined.
+    The masking in the helper function will skip these invalid cases.
+    """
+    torch.manual_seed(0)
+
+    # Generate all possible bf16 values
+    all_bitpatterns = torch.arange(0, 2**16, dtype=torch.int32).to(torch.uint16)
+    vals = all_bitpatterns.view(torch.bfloat16)
+
+    # Keep only finite, non-zero, negative normal bf16 values
+    tiny = torch.finfo(torch.bfloat16).tiny
+    mask = torch.isfinite(vals) & (vals < 0) & (vals.abs() >= tiny)
+
+    neg_values = vals[mask]  # ~32512 negative normal values
+    return _run_exhaustive_pairwise_pow_helper(device, neg_values, neg_values, "Negative ^ Negative", "neg_neg")
+
+
+def test_pow_tt_BF16_exhaustive_test(device):
+    """Test pow with BF16 values - all sign combinations."""
+    import io
+    import sys
+    from datetime import datetime
+
+    # Tee class to write to both terminal and buffer
+    class Tee:
+        def __init__(self, *streams):
+            self.streams = streams
+
+        def write(self, data):
+            for s in self.streams:
+                s.write(data)
+                s.flush()
+
+        def flush(self):
+            for s in self.streams:
+                s.flush()
+
+    # Capture stdout while still printing to terminal
+    captured_output = io.StringIO()
+    original_stdout = sys.stdout
+    sys.stdout = Tee(original_stdout, captured_output)
+
+    # Collect skipped samples from all 4 categories
+    all_skipped_samples = []
+
+    try:
+        all_skipped_samples.extend(test_pow_tt_bf16_exhaustive_pos_pos(device))
+        all_skipped_samples.extend(test_pow_tt_bf16_exhaustive_pos_neg(device))
+        all_skipped_samples.extend(test_pow_tt_bf16_exhaustive_neg_pos(device))
+        all_skipped_samples.extend(test_pow_tt_bf16_exhaustive_neg_neg(device))
+    finally:
+        sys.stdout = original_stdout
+
+    # Get captured content
+    output_content = captured_output.getvalue()
+
+    # Write results to file
+    out_dir = "/home/ubuntu/Files"
+    os.makedirs(out_dir, exist_ok=True)
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    out_path = os.path.join(out_dir, f"pow_bf16_exhaustive_results_{timestamp}.txt")
+    with open(out_path, "w") as f:
+        f.write(output_content)
+
+    # Write merged skipped samples CSV (40 rows max: 10 per category)
+    skipped_csv_path = os.path.join(out_dir, f"pow_bf16_skipped_samples_{timestamp}.csv")
+    with open(skipped_csv_path, mode="w", newline="") as csv_file:
+        writer = csv.writer(csv_file)
+        writer.writerow(["category", "x", "y", "torch_result", "ttnn_result", "skip_reason"])
+        for sample in all_skipped_samples:
+            writer.writerow(
+                [
+                    sample["category"],
+                    sample["x"],
+                    sample["y"],
+                    sample["torch_result"],
+                    sample["ttnn_result"],
+                    sample["skip_reason"],
+                ]
+            )
+
+    print(f"\n{'='*60}")
+    print(f"All results saved to: {out_path}")
+    print(f"Skipped samples CSV ({len(all_skipped_samples)} rows): {skipped_csv_path}")
+    print(f"{'='*60}")

--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_pow_with_flushing.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_pow_with_flushing.py
@@ -12,10 +12,10 @@ import matplotlib.pyplot as plt
 from tests.ttnn.utils_for_testing import assert_with_ulp
 
 # BF16
-# pytest /home/ubuntu/tt-metal/tests/ttnn/unit_tests/operations/eltwise/test_binary_pow_accuracy.py::test_pow_tt_BF16_exhaustive_test
+# pytest /home/ubuntu/tt-metal/tests/ttnn/unit_tests/operations/eltwise/test_binary_pow_with_flushing.py::test_pow_tt_BF16_exhaustive_test
 
 # FP32
-# pytest /home/ubuntu/tt-metal/tests/ttnn/unit_tests/operations/eltwise/test_binary_pow_accuracy.py::test_pow_tt_FP32_exhaustive_test
+# pytest /home/ubuntu/tt-metal/tests/ttnn/unit_tests/operations/eltwise/test_binary_pow_with_flushing.py::test_pow_tt_FP32_exhaustive_test
 
 
 def flush_subnormal_values(tensor):

--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_pow_with_flushing.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_pow_with_flushing.py
@@ -1,0 +1,705 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+import os
+import csv
+import pytest
+import ttnn
+import numpy as np
+import matplotlib.pyplot as plt
+from tests.ttnn.utils_for_testing import assert_with_ulp
+
+# BF16
+# pytest /home/ubuntu/tt-metal/tests/ttnn/unit_tests/operations/eltwise/test_binary_pow_accuracy.py::test_pow_tt_BF16_exhaustive_test
+
+# FP32
+# pytest /home/ubuntu/tt-metal/tests/ttnn/unit_tests/operations/eltwise/test_binary_pow_accuracy.py::test_pow_tt_FP32_exhaustive_test
+
+
+def flush_subnormal_values(tensor):
+    # f32 and bf16 numbers are subnormals if exponent == 0
+    # i.e. if their value < 2**(-126)
+    SUBNORMAL_THRESHOLD = 2.0 ** (-126)
+    mask = torch.abs(tensor) < SUBNORMAL_THRESHOLD
+    tensor[mask] = 0.0
+    return tensor
+
+
+def _run_exhaustive_pairwise_pow_helper(device, x_values, y_values, test_name, variant_name, max_skipped_samples=10):
+    """Helper function to run exhaustive pairwise pow test between two value sets.
+
+    Masks out invalid pow results:
+    - NaN: x < 0 with non-integer y, or other undefined cases
+    - ±Inf: overflow or 0^negative
+    These are skipped from comparison since they represent mathematically undefined or
+    implementation-sensitive cases.
+
+    Returns:
+        list: Up to max_skipped_samples skipped pairs as dicts with keys:
+              [x, y, torch_result, ttnn_result, skip_reason, category]
+    """
+    ttnn_dtype = ttnn.bfloat16
+
+    Nx = x_values.numel()
+    Ny = y_values.numel()
+    print(f"\n{'='*60}")
+    print(f"{test_name}: Testing {Nx} × {Ny} = {Nx*Ny:,} pairs")
+
+    batch_size = 512  # process 512×Ny pairs at a time
+    num_batches = (Nx + batch_size - 1) // batch_size
+
+    max_ulp_global = 0
+    total_mismatches = 0
+    total_valid_pairs = 0
+    total_skipped_pairs = 0
+
+    # Track ULP distribution
+    ulp_0_count = 0
+    ulp_1_count = 0
+    ulp_2_count = 0
+    ulp_3_to_10_count = 0
+    ulp_11_to_100_count = 0
+    ulp_above_100_count = 0
+
+    # Collect up to max_skipped_samples skipped pairs
+    skipped_samples = []
+
+    for batch_idx in range(num_batches):
+        start = batch_idx * batch_size
+        end = min(start + batch_size, Nx)
+
+        # x_batch: [batch_size, 1], y: [1, Ny] → broadcasts to [batch_size, Ny]
+        x_batch = x_values[start:end].unsqueeze(1)  # shape: [B, 1]
+        y_full = y_values.unsqueeze(0)  # shape: [1, Ny]
+        flush_subnormal_values(x_batch)
+        flush_subnormal_values(y_full)
+
+        # Broadcast pow
+        z_torch = torch.pow(x_batch, y_full)  # shape: [B, Ny]
+
+        # Send to backend
+        x_tt = ttnn.from_torch(x_batch, dtype=ttnn_dtype, layout=ttnn.TILE_LAYOUT, device=device)
+        y_tt = ttnn.from_torch(y_full, dtype=ttnn_dtype, layout=ttnn.TILE_LAYOUT, device=device)
+        z_tt = ttnn.pow(x_tt, y_tt)
+        tt_out = ttnn.to_torch(z_tt)
+
+        # ULP check (use bf16 space)
+        z_bf16 = z_torch.to(torch.bfloat16).contiguous()
+        tt_bf16 = tt_out.to(torch.bfloat16).contiguous()
+
+        # Create validity mask: skip if torch result is NaN or ±Inf
+        # These represent mathematically undefined inputs (x<0 with non-integer y)
+        # or overflow/underflow cases (0^negative, large^large)
+        valid_mask = torch.isfinite(z_bf16)
+        skipped_mask = ~valid_mask
+        batch_skipped = skipped_mask.sum().item()
+        total_skipped_pairs += batch_skipped
+
+        # Collect skipped samples (up to max_skipped_samples)
+        if batch_skipped > 0 and len(skipped_samples) < max_skipped_samples:
+            skipped_indices = skipped_mask.nonzero(as_tuple=False)
+            for idx_pair in skipped_indices:
+                if len(skipped_samples) >= max_skipped_samples:
+                    break
+                i, j = idx_pair[0].item(), idx_pair[1].item()
+                xv = x_batch[i, 0].item()
+                yv = y_full[0, j].item()
+                torch_val = z_bf16[i, j].item()
+                ttnn_val = tt_bf16[i, j].item()
+                # Determine skip reason
+                if torch.isnan(z_bf16[i, j]):
+                    reason = "NaN"
+                elif torch.isinf(z_bf16[i, j]):
+                    reason = "+Inf" if z_bf16[i, j] > 0 else "-Inf"
+                else:
+                    reason = "Unknown"
+                skipped_samples.append(
+                    {
+                        "x": xv,
+                        "y": yv,
+                        "torch_result": torch_val,
+                        "ttnn_result": ttnn_val,
+                        "skip_reason": reason,
+                        "category": variant_name,
+                    }
+                )
+
+        # Flush subnormal output values to zero (only for valid comparisons)
+        flush_subnormal_values(z_bf16)
+        flush_subnormal_values(tt_bf16)
+
+        # For ttnn output, also flush non-finite to 0 for comparison purposes
+        # (if torch was finite but ttnn overflowed, we want to detect that)
+        tt_nonfinite_mask = ~torch.isfinite(tt_bf16)
+        tt_bf16[tt_nonfinite_mask] = 0.0
+
+        z_bits = z_bf16.view(torch.uint16).to(torch.int32)
+        tt_bits = tt_bf16.view(torch.uint16).to(torch.int32)
+
+        sign_z = (z_bits >> 15) & 1
+        sign_tt = (tt_bits >> 15) & 1
+        z_ord = torch.where(sign_z == 0, z_bits + 0x8000, 0x8000 - z_bits)
+        tt_ord = torch.where(sign_tt == 0, tt_bits + 0x8000, 0x8000 - tt_bits)
+        ulp_dist = (z_ord - tt_ord).abs()
+
+        # Apply validity mask - set ULP to 0 for invalid pairs (they will be skipped)
+        ulp_dist_valid = torch.where(valid_mask, ulp_dist, torch.zeros_like(ulp_dist))
+
+        max_ulp_batch = ulp_dist_valid.max().item()
+        max_ulp_global = max(max_ulp_global, max_ulp_batch)
+
+        # Count ULP distribution (only for valid pairs)
+        ulp_0_count += ((ulp_dist == 0) & valid_mask).sum().item()
+        ulp_1_count += ((ulp_dist == 1) & valid_mask).sum().item()
+        ulp_2_count += ((ulp_dist == 2) & valid_mask).sum().item()
+        ulp_3_to_10_count += ((ulp_dist >= 3) & (ulp_dist <= 10) & valid_mask).sum().item()
+        ulp_11_to_100_count += ((ulp_dist >= 11) & (ulp_dist <= 100) & valid_mask).sum().item()
+        ulp_above_100_count += ((ulp_dist > 100) & valid_mask).sum().item()
+
+        # Count mismatches (only among valid pairs)
+        mismatch_mask = (ulp_dist > 1) & valid_mask
+        mismatch_count = mismatch_mask.sum().item()
+        total_mismatches += mismatch_count
+        total_valid_pairs += valid_mask.sum().item()
+
+        if (batch_idx + 1) % 10 == 0 or batch_idx == num_batches - 1:
+            print(
+                f"Batch {batch_idx+1}/{num_batches}: max_ulp={max_ulp_batch}, mismatches={mismatch_count}, skipped={batch_skipped}"
+            )
+
+    total_pairs = Nx * Ny
+    mismatch_pct = (total_mismatches / total_valid_pairs) * 100 if total_valid_pairs > 0 else 0.0
+    skipped_pct = (total_skipped_pairs / total_pairs) * 100 if total_pairs > 0 else 0.0
+
+    print(f"\n--- Summary ---")
+    print(f"Total pairs: {total_pairs:,}")
+    print(f"Valid pairs (torch finite): {total_valid_pairs:,} ({100-skipped_pct:.4f}%)")
+    print(f"Skipped pairs (torch NaN/Inf): {total_skipped_pairs:,} ({skipped_pct:.4f}%)")
+    print(f"Skipped samples collected: {len(skipped_samples)}")
+    print(f"Global max ULP: {max_ulp_global}")
+    print(f"Total mismatches (ULP > 1): {total_mismatches:,} ({mismatch_pct:.4f}% of valid)")
+
+    print(f"\nULP Distribution (valid pairs only):")
+    print(
+        f"  ULP = 0: {ulp_0_count:,} ({ulp_0_count/total_valid_pairs*100:.4f}%)"
+        if total_valid_pairs > 0
+        else "  ULP = 0: 0"
+    )
+    print(
+        f"  ULP = 1: {ulp_1_count:,} ({ulp_1_count/total_valid_pairs*100:.4f}%)"
+        if total_valid_pairs > 0
+        else "  ULP = 1: 0"
+    )
+    print(
+        f"  ULP = 2: {ulp_2_count:,} ({ulp_2_count/total_valid_pairs*100:.4f}%)"
+        if total_valid_pairs > 0
+        else "  ULP = 2: 0"
+    )
+    print(
+        f"  ULP 3-10: {ulp_3_to_10_count:,} ({ulp_3_to_10_count/total_valid_pairs*100:.4f}%)"
+        if total_valid_pairs > 0
+        else "  ULP 3-10: 0"
+    )
+    print(
+        f"  ULP 11-100: {ulp_11_to_100_count:,} ({ulp_11_to_100_count/total_valid_pairs*100:.4f}%)"
+        if total_valid_pairs > 0
+        else "  ULP 11-100: 0"
+    )
+    print(
+        f"  ULP > 100: {ulp_above_100_count:,} ({ulp_above_100_count/total_valid_pairs*100:.4f}%)"
+        if total_valid_pairs > 0
+        else "  ULP > 100: 0"
+    )
+
+    return skipped_samples
+
+
+def _run_exhaustive_pairwise_pow_helper_float32(
+    device, x_values, y_values, test_name, variant_name, max_skipped_samples=10
+):
+    """Helper function to run exhaustive pairwise pow test in float32 precision.
+
+    Takes bfloat16 bit patterns as input, converts to float32, and performs pow in float32.
+    Computes ULP distance in float32 space.
+
+    Masks out invalid pow results:
+    - NaN: x < 0 with non-integer y, or other undefined cases
+    - ±Inf: overflow or 0^negative
+    These are skipped from comparison since they represent mathematically undefined or
+    implementation-sensitive cases.
+
+    Returns:
+        list: Up to max_skipped_samples skipped pairs as dicts with keys:
+              [x, y, torch_result, ttnn_result, skip_reason, category]
+    """
+    ttnn_dtype = ttnn.float32
+
+    Nx = x_values.numel()
+    Ny = y_values.numel()
+    print(f"\n{'='*60}")
+    print(f"{test_name} (float32): Testing {Nx} × {Ny} = {Nx*Ny:,} pairs")
+
+    batch_size = 512  # process 512×Ny pairs at a time
+    num_batches = (Nx + batch_size - 1) // batch_size
+
+    max_ulp_global = 0
+    total_mismatches = 0
+    total_valid_pairs = 0
+    total_skipped_pairs = 0
+
+    # Track ULP distribution
+    ulp_0_count = 0
+    ulp_1_count = 0
+    ulp_2_count = 0
+    ulp_3_to_10_count = 0
+    ulp_11_to_100_count = 0
+    ulp_above_100_count = 0
+
+    # Collect up to max_skipped_samples skipped pairs
+    skipped_samples = []
+
+    for batch_idx in range(num_batches):
+        start = batch_idx * batch_size
+        end = min(start + batch_size, Nx)
+
+        # Convert bfloat16 values to float32 for computation
+        # x_batch: [batch_size, 1], y: [1, Ny] → broadcasts to [batch_size, Ny]
+        x_batch_f32 = x_values[start:end].to(torch.float32).unsqueeze(1)  # shape: [B, 1]
+        y_full_f32 = y_values.to(torch.float32).unsqueeze(0)  # shape: [1, Ny]
+        flush_subnormal_values(x_batch_f32)
+        flush_subnormal_values(y_full_f32)
+
+        # Broadcast pow in float32
+        z_torch = torch.pow(x_batch_f32, y_full_f32)  # shape: [B, Ny]
+
+        # Send to backend using float32
+        x_tt = ttnn.from_torch(x_batch_f32, dtype=ttnn_dtype, layout=ttnn.TILE_LAYOUT, device=device)
+        y_tt = ttnn.from_torch(y_full_f32, dtype=ttnn_dtype, layout=ttnn.TILE_LAYOUT, device=device)
+        z_tt = ttnn.pow(x_tt, y_tt)
+        tt_out = ttnn.to_torch(z_tt)
+
+        # ULP check (use float32 space)
+        z_f32 = z_torch.to(torch.float32).contiguous()
+        tt_f32 = tt_out.to(torch.float32).contiguous()
+
+        # Create validity mask: skip if torch result is NaN or ±Inf
+        # These represent mathematically undefined inputs (x<0 with non-integer y)
+        # or overflow/underflow cases (0^negative, large^large)
+        valid_mask = torch.isfinite(z_f32)
+        skipped_mask = ~valid_mask
+        batch_skipped = skipped_mask.sum().item()
+        total_skipped_pairs += batch_skipped
+
+        # Collect skipped samples (up to max_skipped_samples)
+        if batch_skipped > 0 and len(skipped_samples) < max_skipped_samples:
+            skipped_indices = skipped_mask.nonzero(as_tuple=False)
+            for idx_pair in skipped_indices:
+                if len(skipped_samples) >= max_skipped_samples:
+                    break
+                i, j = idx_pair[0].item(), idx_pair[1].item()
+                xv = x_batch_f32[i, 0].item()
+                yv = y_full_f32[0, j].item()
+                torch_val = z_f32[i, j].item()
+                ttnn_val = tt_f32[i, j].item()
+                # Determine skip reason
+                if torch.isnan(z_f32[i, j]):
+                    reason = "NaN"
+                elif torch.isinf(z_f32[i, j]):
+                    reason = "+Inf" if z_f32[i, j] > 0 else "-Inf"
+                else:
+                    reason = "Unknown"
+                skipped_samples.append(
+                    {
+                        "x": xv,
+                        "y": yv,
+                        "torch_result": torch_val,
+                        "ttnn_result": ttnn_val,
+                        "skip_reason": reason,
+                        "category": variant_name,
+                    }
+                )
+
+        # Flush subnormal output values to zero (only for valid comparisons)
+        flush_subnormal_values(z_f32)
+        flush_subnormal_values(tt_f32)
+
+        # For ttnn output, also flush non-finite to 0 for comparison purposes
+        # (if torch was finite but ttnn overflowed, we want to detect that)
+        tt_nonfinite_mask = ~torch.isfinite(tt_f32)
+        tt_f32[tt_nonfinite_mask] = 0.0
+
+        z_bits = z_f32.view(torch.int32)
+        tt_bits = tt_f32.view(torch.int32)
+
+        sign_z = (z_bits >> 31) & 1
+        sign_tt = (tt_bits >> 31) & 1
+        z_ord = torch.where(sign_z == 0, z_bits + 0x80000000, 0x80000000 - z_bits)
+        tt_ord = torch.where(sign_tt == 0, tt_bits + 0x80000000, 0x80000000 - tt_bits)
+        ulp_dist = (z_ord - tt_ord).abs()
+
+        # Apply validity mask - set ULP to 0 for invalid pairs (they will be skipped)
+        ulp_dist_valid = torch.where(valid_mask, ulp_dist, torch.zeros_like(ulp_dist))
+
+        max_ulp_batch = ulp_dist_valid.max().item()
+        max_ulp_global = max(max_ulp_global, max_ulp_batch)
+
+        # Count ULP distribution (only for valid pairs)
+        ulp_0_count += ((ulp_dist == 0) & valid_mask).sum().item()
+        ulp_1_count += ((ulp_dist == 1) & valid_mask).sum().item()
+        ulp_2_count += ((ulp_dist == 2) & valid_mask).sum().item()
+        ulp_3_to_10_count += ((ulp_dist >= 3) & (ulp_dist <= 10) & valid_mask).sum().item()
+        ulp_11_to_100_count += ((ulp_dist >= 11) & (ulp_dist <= 100) & valid_mask).sum().item()
+        ulp_above_100_count += ((ulp_dist > 100) & valid_mask).sum().item()
+
+        # Count mismatches (only among valid pairs)
+        mismatch_mask = (ulp_dist > 1) & valid_mask
+        mismatch_count = mismatch_mask.sum().item()
+        total_mismatches += mismatch_count
+        total_valid_pairs += valid_mask.sum().item()
+
+        if (batch_idx + 1) % 10 == 0 or batch_idx == num_batches - 1:
+            print(
+                f"Batch {batch_idx+1}/{num_batches}: max_ulp={max_ulp_batch}, mismatches={mismatch_count}, skipped={batch_skipped}"
+            )
+
+    total_pairs = Nx * Ny
+    mismatch_pct = (total_mismatches / total_valid_pairs) * 100 if total_valid_pairs > 0 else 0.0
+    skipped_pct = (total_skipped_pairs / total_pairs) * 100 if total_pairs > 0 else 0.0
+
+    print(f"\n--- Summary ---")
+    print(f"Total pairs: {total_pairs:,}")
+    print(f"Valid pairs (torch finite): {total_valid_pairs:,} ({100-skipped_pct:.4f}%)")
+    print(f"Skipped pairs (torch NaN/Inf): {total_skipped_pairs:,} ({skipped_pct:.4f}%)")
+    print(f"Skipped samples collected: {len(skipped_samples)}")
+    print(f"Global max ULP: {max_ulp_global}")
+    print(f"Total mismatches (ULP > 1): {total_mismatches:,} ({mismatch_pct:.4f}% of valid)")
+
+    print(f"\nULP Distribution (valid pairs only):")
+    print(
+        f"  ULP = 0: {ulp_0_count:,} ({ulp_0_count/total_valid_pairs*100:.4f}%)"
+        if total_valid_pairs > 0
+        else "  ULP = 0: 0"
+    )
+    print(
+        f"  ULP = 1: {ulp_1_count:,} ({ulp_1_count/total_valid_pairs*100:.4f}%)"
+        if total_valid_pairs > 0
+        else "  ULP = 1: 0"
+    )
+    print(
+        f"  ULP = 2: {ulp_2_count:,} ({ulp_2_count/total_valid_pairs*100:.4f}%)"
+        if total_valid_pairs > 0
+        else "  ULP = 2: 0"
+    )
+    print(
+        f"  ULP 3-10: {ulp_3_to_10_count:,} ({ulp_3_to_10_count/total_valid_pairs*100:.4f}%)"
+        if total_valid_pairs > 0
+        else "  ULP 3-10: 0"
+    )
+    print(
+        f"  ULP 11-100: {ulp_11_to_100_count:,} ({ulp_11_to_100_count/total_valid_pairs*100:.4f}%)"
+        if total_valid_pairs > 0
+        else "  ULP 11-100: 0"
+    )
+    print(
+        f"  ULP > 100: {ulp_above_100_count:,} ({ulp_above_100_count/total_valid_pairs*100:.4f}%)"
+        if total_valid_pairs > 0
+        else "  ULP > 100: 0"
+    )
+
+    return skipped_samples
+
+
+# FP32 exhaustive tests
+def test_pow_tt_FP32_exhaustive_pos_pos(device):
+    """Test positive base ^ positive exponent normal fp32 values."""
+    torch.manual_seed(0)
+
+    # Generate all possible bf16 values
+    all_bitpatterns = torch.arange(0, 2**16, dtype=torch.int32).to(torch.uint16)
+    vals = all_bitpatterns.view(torch.bfloat16)
+
+    # Keep only finite, non-zero, positive normal bf16 values
+    tiny = torch.finfo(torch.bfloat16).tiny
+    mask = torch.isfinite(vals) & (vals > 0) & (vals >= tiny)
+
+    pos_values = vals[mask]  # ~32512 positive normal values
+    return _run_exhaustive_pairwise_pow_helper_float32(device, pos_values, pos_values, "Positive ^ Positive", "pos_pos")
+
+
+def test_pow_tt_FP32_exhaustive_pos_neg(device):
+    """Test positive base ^ negative exponent normal bf16 values."""
+    torch.manual_seed(0)
+
+    # Generate all possible bf16 values
+    all_bitpatterns = torch.arange(0, 2**16, dtype=torch.int32).to(torch.uint16)
+    vals = all_bitpatterns.view(torch.bfloat16)
+
+    # Keep only finite, non-zero, normal bf16 values
+    tiny = torch.finfo(torch.bfloat16).tiny
+    pos_mask = torch.isfinite(vals) & (vals > 0) & (vals >= tiny)
+    neg_mask = torch.isfinite(vals) & (vals < 0) & (vals.abs() >= tiny)
+
+    pos_values = vals[pos_mask]  # ~32512 positive normal values
+    neg_values = vals[neg_mask]  # ~32512 negative normal values
+    return _run_exhaustive_pairwise_pow_helper_float32(device, pos_values, neg_values, "Positive ^ Negative", "pos_neg")
+
+
+def test_pow_tt_FP32_exhaustive_neg_pos(device):
+    """Test negative base ^ positive exponent normal bf16 values.
+
+    Note: This will have many NaN results since pow(negative, non-integer) is undefined.
+    The masking in the helper function will skip these invalid cases.
+    """
+    torch.manual_seed(0)
+
+    # Generate all possible bf16 values
+    all_bitpatterns = torch.arange(0, 2**16, dtype=torch.int32).to(torch.uint16)
+    vals = all_bitpatterns.view(torch.bfloat16)
+
+    # Keep only finite, non-zero, normal bf16 values
+    tiny = torch.finfo(torch.bfloat16).tiny
+    pos_mask = torch.isfinite(vals) & (vals > 0) & (vals >= tiny)
+    neg_mask = torch.isfinite(vals) & (vals < 0) & (vals.abs() >= tiny)
+
+    pos_values = vals[pos_mask]  # ~32512 positive normal values
+    neg_values = vals[neg_mask]  # ~32512 negative normal values
+    return _run_exhaustive_pairwise_pow_helper_float32(device, neg_values, pos_values, "Negative ^ Positive", "neg_pos")
+
+
+def test_pow_tt_FP32_exhaustive_neg_neg(device):
+    """Test negative base ^ negative exponent normal bf16 values.
+
+    Note: This will have many NaN results since pow(negative, non-integer) is undefined.
+    The masking in the helper function will skip these invalid cases.
+    """
+    torch.manual_seed(0)
+
+    # Generate all possible bf16 values
+    all_bitpatterns = torch.arange(0, 2**16, dtype=torch.int32).to(torch.uint16)
+    vals = all_bitpatterns.view(torch.bfloat16)
+
+    # Keep only finite, non-zero, negative normal bf16 values
+    tiny = torch.finfo(torch.bfloat16).tiny
+    mask = torch.isfinite(vals) & (vals < 0) & (vals.abs() >= tiny)
+
+    neg_values = vals[mask]  # ~32512 negative normal values
+    return _run_exhaustive_pairwise_pow_helper_float32(device, neg_values, neg_values, "Negative ^ Negative", "neg_neg")
+
+
+def test_pow_tt_FP32_exhaustive_test(device):
+    """Test pow with fp32 values - all sign combinations."""
+    import io
+    import sys
+    from datetime import datetime
+
+    # Tee class to write to both terminal and buffer
+    class Tee:
+        def __init__(self, *streams):
+            self.streams = streams
+
+        def write(self, data):
+            for s in self.streams:
+                s.write(data)
+                s.flush()
+
+        def flush(self):
+            for s in self.streams:
+                s.flush()
+
+    # Capture stdout while still printing to terminal
+    captured_output = io.StringIO()
+    original_stdout = sys.stdout
+    sys.stdout = Tee(original_stdout, captured_output)
+
+    # Collect skipped samples from all 4 categories
+    all_skipped_samples = []
+
+    try:
+        all_skipped_samples.extend(test_pow_tt_FP32_exhaustive_pos_pos(device))
+        all_skipped_samples.extend(test_pow_tt_FP32_exhaustive_pos_neg(device))
+        all_skipped_samples.extend(test_pow_tt_FP32_exhaustive_neg_pos(device))
+        all_skipped_samples.extend(test_pow_tt_FP32_exhaustive_neg_neg(device))
+    finally:
+        sys.stdout = original_stdout
+
+    # Get captured content
+    output_content = captured_output.getvalue()
+
+    # Write results to file
+    out_dir = "/home/ubuntu/Files"
+    os.makedirs(out_dir, exist_ok=True)
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    out_path = os.path.join(out_dir, f"pow_fp32_exhaustive_results_{timestamp}.txt")
+    with open(out_path, "w") as f:
+        f.write(output_content)
+
+    # Write merged skipped samples CSV (40 rows max: 10 per category)
+    skipped_csv_path = os.path.join(out_dir, f"pow_fp32_skipped_samples_{timestamp}.csv")
+    with open(skipped_csv_path, mode="w", newline="") as csv_file:
+        writer = csv.writer(csv_file)
+        writer.writerow(["category", "x", "y", "torch_result", "ttnn_result", "skip_reason"])
+        for sample in all_skipped_samples:
+            writer.writerow(
+                [
+                    sample["category"],
+                    sample["x"],
+                    sample["y"],
+                    sample["torch_result"],
+                    sample["ttnn_result"],
+                    sample["skip_reason"],
+                ]
+            )
+
+    print(f"\n{'='*60}")
+    print(f"All results saved to: {out_path}")
+    print(f"Skipped samples CSV ({len(all_skipped_samples)} rows): {skipped_csv_path}")
+    print(f"{'='*60}")
+
+
+# BF16 Exhaustive tests
+def test_pow_tt_bf16_exhaustive_pos_pos(device):
+    """Test positive base ^ positive exponent normal bf16 values."""
+    torch.manual_seed(0)
+
+    # Generate all possible bf16 values
+    all_bitpatterns = torch.arange(0, 2**16, dtype=torch.int32).to(torch.uint16)
+    vals = all_bitpatterns.view(torch.bfloat16)
+
+    # Keep only finite, non-zero, positive normal bf16 values
+    tiny = torch.finfo(torch.bfloat16).tiny
+    mask = torch.isfinite(vals) & (vals > 0) & (vals >= tiny)
+
+    pos_values = vals[mask]  # ~32512 positive normal values
+    return _run_exhaustive_pairwise_pow_helper(device, pos_values, pos_values, "Positive ^ Positive", "pos_pos")
+
+
+def test_pow_tt_bf16_exhaustive_pos_neg(device):
+    """Test positive base ^ negative exponent normal bf16 values."""
+    torch.manual_seed(0)
+
+    # Generate all possible bf16 values
+    all_bitpatterns = torch.arange(0, 2**16, dtype=torch.int32).to(torch.uint16)
+    vals = all_bitpatterns.view(torch.bfloat16)
+
+    # Keep only finite, non-zero, normal bf16 values
+    tiny = torch.finfo(torch.bfloat16).tiny
+    pos_mask = torch.isfinite(vals) & (vals > 0) & (vals >= tiny)
+    neg_mask = torch.isfinite(vals) & (vals < 0) & (vals.abs() >= tiny)
+
+    pos_values = vals[pos_mask]  # ~32512 positive normal values
+    neg_values = vals[neg_mask]  # ~32512 negative normal values
+    return _run_exhaustive_pairwise_pow_helper(device, pos_values, neg_values, "Positive ^ Negative", "pos_neg")
+
+
+def test_pow_tt_bf16_exhaustive_neg_pos(device):
+    """Test negative base ^ positive exponent normal bf16 values.
+
+    Note: This will have many NaN results since pow(negative, non-integer) is undefined.
+    The masking in the helper function will skip these invalid cases.
+    """
+    torch.manual_seed(0)
+
+    # Generate all possible bf16 values
+    all_bitpatterns = torch.arange(0, 2**16, dtype=torch.int32).to(torch.uint16)
+    vals = all_bitpatterns.view(torch.bfloat16)
+
+    # Keep only finite, non-zero, normal bf16 values
+    tiny = torch.finfo(torch.bfloat16).tiny
+    pos_mask = torch.isfinite(vals) & (vals > 0) & (vals >= tiny)
+    neg_mask = torch.isfinite(vals) & (vals < 0) & (vals.abs() >= tiny)
+
+    pos_values = vals[pos_mask]  # ~32512 positive normal values
+    neg_values = vals[neg_mask]  # ~32512 negative normal values
+    return _run_exhaustive_pairwise_pow_helper(device, neg_values, pos_values, "Negative ^ Positive", "neg_pos")
+
+
+def test_pow_tt_bf16_exhaustive_neg_neg(device):
+    """Test negative base ^ negative exponent normal bf16 values.
+
+    Note: This will have many NaN results since pow(negative, non-integer) is undefined.
+    The masking in the helper function will skip these invalid cases.
+    """
+    torch.manual_seed(0)
+
+    # Generate all possible bf16 values
+    all_bitpatterns = torch.arange(0, 2**16, dtype=torch.int32).to(torch.uint16)
+    vals = all_bitpatterns.view(torch.bfloat16)
+
+    # Keep only finite, non-zero, negative normal bf16 values
+    tiny = torch.finfo(torch.bfloat16).tiny
+    mask = torch.isfinite(vals) & (vals < 0) & (vals.abs() >= tiny)
+
+    neg_values = vals[mask]  # ~32512 negative normal values
+    return _run_exhaustive_pairwise_pow_helper(device, neg_values, neg_values, "Negative ^ Negative", "neg_neg")
+
+
+def test_pow_tt_BF16_exhaustive_test(device):
+    """Test pow with BF16 values - all sign combinations."""
+    import io
+    import sys
+    from datetime import datetime
+
+    # Tee class to write to both terminal and buffer
+    class Tee:
+        def __init__(self, *streams):
+            self.streams = streams
+
+        def write(self, data):
+            for s in self.streams:
+                s.write(data)
+                s.flush()
+
+        def flush(self):
+            for s in self.streams:
+                s.flush()
+
+    # Capture stdout while still printing to terminal
+    captured_output = io.StringIO()
+    original_stdout = sys.stdout
+    sys.stdout = Tee(original_stdout, captured_output)
+
+    # Collect skipped samples from all 4 categories
+    all_skipped_samples = []
+
+    try:
+        all_skipped_samples.extend(test_pow_tt_bf16_exhaustive_pos_pos(device))
+        all_skipped_samples.extend(test_pow_tt_bf16_exhaustive_pos_neg(device))
+        all_skipped_samples.extend(test_pow_tt_bf16_exhaustive_neg_pos(device))
+        all_skipped_samples.extend(test_pow_tt_bf16_exhaustive_neg_neg(device))
+    finally:
+        sys.stdout = original_stdout
+
+    # Get captured content
+    output_content = captured_output.getvalue()
+
+    # Write results to file
+    out_dir = "/home/ubuntu/Files"
+    os.makedirs(out_dir, exist_ok=True)
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    out_path = os.path.join(out_dir, f"pow_bf16_exhaustive_results_{timestamp}.txt")
+    with open(out_path, "w") as f:
+        f.write(output_content)
+
+    # Write merged skipped samples CSV (40 rows max: 10 per category)
+    skipped_csv_path = os.path.join(out_dir, f"pow_bf16_skipped_samples_{timestamp}.csv")
+    with open(skipped_csv_path, mode="w", newline="") as csv_file:
+        writer = csv.writer(csv_file)
+        writer.writerow(["category", "x", "y", "torch_result", "ttnn_result", "skip_reason"])
+        for sample in all_skipped_samples:
+            writer.writerow(
+                [
+                    sample["category"],
+                    sample["x"],
+                    sample["y"],
+                    sample["torch_result"],
+                    sample["ttnn_result"],
+                    sample["skip_reason"],
+                ]
+            )
+
+    print(f"\n{'='*60}")
+    print(f"All results saved to: {out_path}")
+    print(f"Skipped samples CSV ({len(all_skipped_samples)} rows): {skipped_csv_path}")
+    print(f"{'='*60}")

--- a/tests/ttnn/unit_tests/operations/eltwise/test_fmod_accuracy.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_fmod_accuracy.py
@@ -1,0 +1,367 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+import os
+import csv
+import pytest
+import ttnn
+import numpy as np
+import matplotlib.pyplot as plt
+from tests.ttnn.utils_for_testing import assert_with_ulp
+
+
+def _run_exhaustive_pairwise_mul_helper_float32(device, x_values, y_values, test_name, variant_name):
+    """Helper function to run exhaustive pairwise multiplication test in float32 precision.
+
+    Takes bfloat16 bit patterns as input, converts to float32, and performs multiplication in float32.
+    Computes ULP distance in float32 space.
+    """
+    ttnn_dtype = ttnn.float32
+
+    Nx = x_values.numel()
+    Ny = y_values.numel()
+    print(f"{test_name} (float32): Testing {Nx} × {Ny} = {Nx*Ny:,} pairs")
+
+    batch_size = 512  # process 512×Ny pairs at a time
+    num_batches = (Nx + batch_size - 1) // batch_size
+
+    max_ulp_global = 0
+    total_mismatches = 0
+
+    # Track ULP distribution
+    ulp_0_count = 0
+    ulp_1_count = 0
+    ulp_2_count = 0
+    ulp_3_to_10_count = 0
+    ulp_11_to_100_count = 0
+    ulp_above_100_count = 0
+
+    # # Open CSV for logging mismatches (variant-specific) - write outside repo
+    # out_dir = "/home/ubuntu/Files"
+    # os.makedirs(out_dir, exist_ok=True)
+    # out_path_mismatch = os.path.join(out_dir, f"mul_ulp_mismatch_exhaustive_{variant_name}_float32.csv")
+    # csv_file = open(out_path_mismatch, mode="w", newline="")
+    # writer = csv.writer(csv_file)
+    # writer.writerow(
+    #     [
+    #         "batch_idx",
+    #         "x_idx",
+    #         "y_idx",
+    #         "x_value",
+    #         "y_value",
+    #         "torch_out",
+    #         "tt_out",
+    #         "ulp_distance",
+    #         "x_bits_u32",
+    #         "y_bits_u32",
+    #         "torch_bits_u32",
+    #         "tt_bits_u32",
+    #     ]
+    # )
+
+    for batch_idx in range(num_batches):
+        start = batch_idx * batch_size
+        end = min(start + batch_size, Nx)
+
+        # Convert bfloat16 values to float32 for computation
+        # x_batch: [batch_size, 1], y: [1, Ny] → broadcasts to [batch_size, Ny]
+        x_batch_f32 = x_values[start:end].to(torch.float32).unsqueeze(1)  # shape: [B, 1]
+        y_full_f32 = y_values.to(torch.float32).unsqueeze(0)  # shape: [1, Ny]
+
+        # Broadcast multiply in float32
+        z_torch = torch.fmod(x_batch_f32, y_full_f32)  # shape: [B, Ny]
+
+        # Send to backend using float32
+        x_tt = ttnn.from_torch(x_batch_f32, dtype=ttnn_dtype, layout=ttnn.TILE_LAYOUT, device=device)
+        y_tt = ttnn.from_torch(y_full_f32, dtype=ttnn_dtype, layout=ttnn.TILE_LAYOUT, device=device)
+        z_tt = ttnn.pow(x_tt, y_tt)
+        tt_out = ttnn.to_torch(z_tt)
+
+        # ULP check (use float32 space)
+        z_f32 = z_torch.to(torch.float32).contiguous()
+        tt_f32 = tt_out.to(torch.float32).contiguous()
+
+        # Flush subnormal float32 values to zero
+        # For float32, min normal is ~1.175494e-38
+        min_normal_threshold = torch.finfo(torch.float32).tiny
+        subnormal_mask = z_f32.abs() <= min_normal_threshold
+        z_f32[subnormal_mask] = 0.0
+        subnormal_mask_tt = tt_f32.abs() <= min_normal_threshold
+        tt_f32[subnormal_mask_tt] = 0.0
+
+        # Flush overflow values (greater than max normal or inf) to zero
+        # For float32, max normal is ~3.389531e38
+        max_normal_threshold = torch.finfo(torch.float32).max
+        overflow_mask = (z_f32.abs() > max_normal_threshold) | ~torch.isfinite(z_f32)
+        z_f32[overflow_mask] = 0.0
+        overflow_mask_tt = (tt_f32.abs() > max_normal_threshold) | ~torch.isfinite(tt_f32)
+        tt_f32[overflow_mask_tt] = 0.0
+
+        z_bits = z_f32.view(torch.int32)
+        tt_bits = tt_f32.view(torch.int32)
+
+        sign_z = (z_bits >> 31) & 1
+        sign_tt = (tt_bits >> 31) & 1
+        z_ord = torch.where(sign_z == 0, z_bits + 0x80000000, 0x80000000 - z_bits)
+        tt_ord = torch.where(sign_tt == 0, tt_bits + 0x80000000, 0x80000000 - tt_bits)
+        ulp_dist = (z_ord - tt_ord).abs()
+
+        max_ulp_batch = ulp_dist.max().item()
+        max_ulp_global = max(max_ulp_global, max_ulp_batch)
+
+        # Count ULP distribution
+        ulp_0_count += (ulp_dist == 0).sum().item()
+        ulp_1_count += (ulp_dist == 1).sum().item()
+        ulp_2_count += (ulp_dist == 2).sum().item()
+        ulp_3_to_10_count += ((ulp_dist >= 3) & (ulp_dist <= 10)).sum().item()
+        ulp_11_to_100_count += ((ulp_dist >= 11) & (ulp_dist <= 100)).sum().item()
+        ulp_above_100_count += (ulp_dist > 100).sum().item()
+
+        # Log mismatches to CSV
+        mismatch_mask = ulp_dist > 1
+        mismatch_count = mismatch_mask.sum().item()
+        total_mismatches += mismatch_count
+
+        # if mismatch_count > 0:
+        #     # Get mismatch indices in [B, Ny] grid
+        #     mismatch_indices = mismatch_mask.nonzero(as_tuple=False)  # shape: [num_mismatches, 2]
+        #
+        #     for idx_pair in mismatch_indices:
+        #         i, j = idx_pair[0].item(), idx_pair[1].item()
+        #         x_idx = start + i
+        #         y_idx = j
+        #
+        #         xv = x_batch_f32[i, 0].item()
+        #         yv = y_full_f32[0, j].item()
+        #         zv = z_f32[i, j].item()
+        #         tv = tt_f32[i, j].item()
+        #         ulp = ulp_dist[i, j].item()
+        #
+        #         # Get bit representations as uint32
+        #         xb = z_f32.new_tensor(xv).view(torch.int32).item() & 0xFFFFFFFF
+        #         yb = z_f32.new_tensor(yv).view(torch.int32).item() & 0xFFFFFFFF
+        #         zb = z_bits[i, j].item() & 0xFFFFFFFF
+        #         tb = tt_bits[i, j].item() & 0xFFFFFFFF
+        #
+        #         writer.writerow([batch_idx, x_idx, y_idx, xv, yv, zv, tv, ulp, hex(xb), hex(yb), hex(zb), hex(tb)])
+
+        if (batch_idx + 1) % 10 == 0 or batch_idx == num_batches - 1:
+            print(f"Batch {batch_idx+1}/{num_batches}: max_ulp={max_ulp_batch}, mismatches={mismatch_count}")
+
+    # csv_file.close()
+    total_pairs = Nx * Ny
+    mismatch_pct = (total_mismatches / total_pairs) * 100 if total_pairs > 0 else 0.0
+    print(f"Global max ULP: {max_ulp_global}, total mismatches: {total_mismatches}/{total_pairs} ({mismatch_pct:.4f}%)")
+    print(f"\nULP Distribution:")
+    print(f"  ULP = 0: {ulp_0_count:,} ({ulp_0_count/total_pairs*100:.4f}%)")
+    print(f"  ULP = 1: {ulp_1_count:,} ({ulp_1_count/total_pairs*100:.4f}%)")
+    print(f"  ULP = 2: {ulp_2_count:,} ({ulp_2_count/total_pairs*100:.4f}%)")
+    print(f"  ULP 3-10: {ulp_3_to_10_count:,} ({ulp_3_to_10_count/total_pairs*100:.4f}%)")
+    print(f"  ULP 11-100: {ulp_11_to_100_count:,} ({ulp_11_to_100_count/total_pairs*100:.4f}%)")
+    print(f"  ULP > 100: {ulp_above_100_count:,} ({ulp_above_100_count/total_pairs*100:.4f}%)")
+    # print(f"Mismatch details written to: {out_path_mismatch}")
+
+    # Comment out assertion for characterization test
+    # assert max_ulp_global <= 2, f"Max ULP {max_ulp_global} exceeds threshold 2"
+
+
+def test_mul_tt_bf16_exhaustive_pos_pos(device):
+    """Test positive × positive normal fp32 values."""
+    torch.manual_seed(0)
+
+    # Generate all possible bf16 values
+    all_bitpatterns = torch.arange(0, 2**16, dtype=torch.int32).to(torch.uint16)
+    vals = all_bitpatterns.view(torch.bfloat16)
+
+    # Keep only finite, non-zero, positive normal bf16 values
+    tiny = torch.finfo(torch.bfloat16).tiny
+    # tiny = 1e-18  # Use 1e-18 as lower bound instead of bfloat16 min normal
+    mask = torch.isfinite(vals) & (vals > 0) & (vals >= tiny)
+
+    pos_values = vals[mask]  # ~32512 positive normal values
+    _run_exhaustive_pairwise_mul_helper_float32(device, pos_values, pos_values, "Positive × Positive", "pos_pos")
+
+
+def test_mul_tt_bf16_exhaustive_pos_neg(device):
+    """Test positive × negative normal bf16 values."""
+    torch.manual_seed(0)
+
+    # Generate all possible bf16 values
+    all_bitpatterns = torch.arange(0, 2**16, dtype=torch.int32).to(torch.uint16)
+    vals = all_bitpatterns.view(torch.bfloat16)
+
+    # Keep only finite, non-zero, normal bf16 values
+    tiny = torch.finfo(torch.bfloat16).tiny
+    # tiny = 1e-18  # Use 1e-18 as lower bound for absolute value
+    pos_mask = torch.isfinite(vals) & (vals > 0) & (vals >= tiny)
+    neg_mask = torch.isfinite(vals) & (vals < 0) & (vals.abs() >= tiny)
+
+    pos_values = vals[pos_mask]  # ~32512 positive normal values
+    neg_values = vals[neg_mask]  # ~32512 negative normal values
+    _run_exhaustive_pairwise_mul_helper_float32(device, pos_values, neg_values, "Positive × Negative", "pos_neg")
+
+
+def test_mul_tt_bf16_exhaustive_neg_pos(device):
+    """Test negative × positive normal bf16 values."""
+    torch.manual_seed(0)
+
+    # Generate all possible bf16 values
+    all_bitpatterns = torch.arange(0, 2**16, dtype=torch.int32).to(torch.uint16)
+    vals = all_bitpatterns.view(torch.bfloat16)
+
+    # Keep only finite, non-zero, normal bf16 values
+    tiny = torch.finfo(torch.bfloat16).tiny
+    # tiny = 1e-18  # Use 1e-18 as lower bound for absolute value
+    pos_mask = torch.isfinite(vals) & (vals > 0) & (vals >= tiny)
+    neg_mask = torch.isfinite(vals) & (vals < 0) & (vals.abs() >= tiny)
+
+    pos_values = vals[pos_mask]  # ~32512 positive normal values
+    neg_values = vals[neg_mask]  # ~32512 negative normal values
+    _run_exhaustive_pairwise_mul_helper_float32(device, neg_values, pos_values, "Negative × Positive", "neg_pos")
+
+
+def test_mul_tt_bf16_exhaustive_neg_neg(device):
+    """Test negative × negative normal bf16 values."""
+    torch.manual_seed(0)
+
+    # Generate all possible bf16 values
+    all_bitpatterns = torch.arange(0, 2**16, dtype=torch.int32).to(torch.uint16)
+    vals = all_bitpatterns.view(torch.bfloat16)
+
+    # Keep only finite, non-zero, negative normal bf16 values
+    tiny = torch.finfo(torch.bfloat16).tiny
+    # tiny = 1e-18  # Use 1e-18 as lower bound for absolute value
+    mask = torch.isfinite(vals) & (vals < 0) & (vals.abs() >= tiny)
+
+    neg_values = vals[mask]  # ~32512 negative normal values
+    _run_exhaustive_pairwise_mul_helper_float32(device, neg_values, neg_values, "Negative × Negative", "neg_neg")
+
+
+def test_binary_fp32(device, low=-1e-20, high=1e20):
+    torch.manual_seed(0)
+    torch_dtype = torch.float32
+    ttnn_dtype = ttnn.float32
+    x_torch = torch.rand([1, 12288], dtype=torch_dtype) * (high - low) + low
+    y_torch = torch.rand([1, 1], dtype=torch_dtype) * (high - low) + low
+    z_torch = torch.mul(x_torch, y_torch)
+    x_tt = ttnn.from_torch(x_torch, dtype=ttnn_dtype, layout=ttnn.TILE_LAYOUT, device=device)
+    y_tt = ttnn.from_torch(y_torch, dtype=ttnn_dtype, layout=ttnn.TILE_LAYOUT, device=device)
+    z_tt = ttnn.mul(x_tt, y_tt)
+    tt_out = ttnn.to_torch(z_tt)
+
+    # Calculate ULP distance
+    z_f32 = z_torch.to(torch.float32).contiguous()
+    tt_f32 = tt_out.to(torch.float32).contiguous()
+
+    # Check for non-finite values first
+    z_nonfinite = ~torch.isfinite(z_f32)
+    tt_nonfinite = ~torch.isfinite(tt_f32)
+    nonfinite_count = (z_nonfinite | tt_nonfinite).sum().item()
+
+    print(f"\n=== Diagnostics ===")
+    print(f"Total elements: {z_f32.numel()}")
+    print(f"Non-finite in torch output: {z_nonfinite.sum().item()}")
+    print(f"Non-finite in ttnn output: {tt_nonfinite.sum().item()}")
+    print(f"Total non-finite: {nonfinite_count}")
+
+    # Print some example values
+    print(f"\nInput x_torch range: [{x_torch.min().item():.6e}, {x_torch.max().item():.6e}]")
+    print(f"Input y_torch range: [{y_torch.min().item():.6e}, {y_torch.max().item():.6e}]")
+    print(
+        f"Output z_torch range: [{z_f32[torch.isfinite(z_f32)].min().item() if torch.isfinite(z_f32).any() else float('nan'):.6e}, {z_f32[torch.isfinite(z_f32)].max().item() if torch.isfinite(z_f32).any() else float('nan'):.6e}] (finite only)"
+    )
+    print(
+        f"Output tt_out range: [{tt_f32[torch.isfinite(tt_f32)].min().item() if torch.isfinite(tt_f32).any() else float('nan'):.6e}, {tt_f32[torch.isfinite(tt_f32)].max().item() if torch.isfinite(tt_f32).any() else float('nan'):.6e}] (finite only)"
+    )
+
+    # Print first 10 values
+    print(f"\nFirst 10 x values: {x_torch[0, :10].tolist()}")
+    print(f"First 10 y values: {y_torch[:10].tolist()}")
+    print(f"First 10 z_torch values: {z_f32[0, :10].tolist()}")
+    print(f"First 10 tt_out values: {tt_f32[0, :10].tolist()}")
+
+    z_bits = z_f32.view(torch.int32)
+    tt_bits = tt_f32.view(torch.int32)
+
+    sign_z = (z_bits >> 31) & 1
+    sign_tt = (tt_bits >> 31) & 1
+    z_ord = torch.where(sign_z == 0, z_bits + 0x80000000, 0x80000000 - z_bits)
+    tt_ord = torch.where(sign_tt == 0, tt_bits + 0x80000000, 0x80000000 - tt_bits)
+    ulp_dist = (z_ord - tt_ord).abs()
+
+    # Find mismatches (ULP > 1) - only check finite values
+    finite_mask = torch.isfinite(z_f32) & torch.isfinite(tt_f32)
+    mismatch_mask = (ulp_dist > 1) & finite_mask
+    mismatch_count = mismatch_mask.sum().item()
+
+    print(f"\nFinite values: {finite_mask.sum().item()}")
+    print(f"Mismatches (ULP > 1) in finite values: {mismatch_count}")
+
+    if mismatch_count > 0:
+        # Write mismatches to CSV
+        out_dir = os.path.dirname(__file__)
+        out_path = os.path.join(out_dir, "mul_binary_fp32_mismatchBH.csv")
+        csv_file = open(out_path, mode="w", newline="")
+        writer = csv.writer(csv_file)
+        writer.writerow(
+            [
+                "index",
+                "input_A",
+                "input_B",
+                "torch_output",
+                "ttnn_output",
+                "ulp_distance",
+                "input_A_bits_u32",
+                "input_B_bits_u32",
+                "torch_output_bits_u32",
+                "ttnn_output_bits_u32",
+            ]
+        )
+
+        # Get mismatch indices
+        mismatch_indices = mismatch_mask.nonzero(as_tuple=False)  # shape: [num_mismatches, 2]
+
+        for idx_pair in mismatch_indices:
+            i, j = idx_pair[0].item(), idx_pair[1].item()
+
+            x_val = x_torch[i, j].item()
+            y_val = y_torch[j].item()
+            z_val = z_f32[i, j].item()
+            tt_val = tt_f32[i, j].item()
+            ulp = ulp_dist[i, j].item()
+
+            # Get bit representations as uint32
+            x_bits = z_f32.new_tensor(x_val).view(torch.int32).item() & 0xFFFFFFFF
+            y_bits = z_f32.new_tensor(y_val).view(torch.int32).item() & 0xFFFFFFFF
+            z_bits_val = z_bits[i, j].item() & 0xFFFFFFFF
+            tt_bits_val = tt_bits[i, j].item() & 0xFFFFFFFF
+
+            writer.writerow(
+                [
+                    f"({i},{j})",
+                    x_val,
+                    y_val,
+                    z_val,
+                    tt_val,
+                    ulp,
+                    hex(x_bits),
+                    hex(y_bits),
+                    hex(z_bits_val),
+                    hex(tt_bits_val),
+                ]
+            )
+
+        csv_file.close()
+        print(f"Found {mismatch_count} mismatches (ULP > 1), written to {out_path}")
+    else:
+        print("No mismatches found (all ULP <= 1)")
+
+    # torch.set_printoptions(linewidth=200, threshold = 10000 , precision=15, sci_mode = False, edgeitems=17)
+    # print("z_tt", z_tt)
+    # print("tt_out", tt_out)
+    # print("z_torch", z_torch)
+
+    # Allow non-finite values if both outputs agree on them
+    assert_with_ulp(z_torch, tt_out, 1, allow_nonfinite=True)

--- a/tests/ttnn/unit_tests/operations/eltwise/test_fmod_accuracy.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_fmod_accuracy.py
@@ -12,6 +12,159 @@ import matplotlib.pyplot as plt
 from tests.ttnn.utils_for_testing import assert_with_ulp
 
 
+def _run_exhaustive_pairwise_mul_helper(device, x_values, y_values, test_name, variant_name):
+    """Helper function to run exhaustive pairwise multiplication test between two value sets."""
+    ttnn_dtype = ttnn.bfloat16
+
+    Nx = x_values.numel()
+    Ny = y_values.numel()
+    print(f"{test_name}: Testing {Nx} × {Ny} = {Nx*Ny:,} pairs")
+
+    batch_size = 512  # process 512×Ny pairs at a time
+    num_batches = (Nx + batch_size - 1) // batch_size
+
+    max_ulp_global = 0
+    total_mismatches = 0
+
+    # Track ULP distribution
+    ulp_0_count = 0
+    ulp_1_count = 0
+    ulp_2_count = 0
+    ulp_3_to_10_count = 0
+    ulp_11_to_100_count = 0
+    ulp_above_100_count = 0
+
+    # # Open CSV for logging mismatches (variant-specific) - write outside repo
+    # out_dir = "/home/ubuntu/Files"
+    # os.makedirs(out_dir, exist_ok=True)
+    # out_path_mismatch = os.path.join(out_dir, f"mul_ulp_mismatch_exhaustive_{variant_name}_BH.csv")
+    # csv_file = open(out_path_mismatch, mode="w", newline="")
+    # writer = csv.writer(csv_file)
+    # writer.writerow(
+    #     [
+    #         "batch_idx",
+    #         "x_idx",
+    #         "y_idx",
+    #         "x_value",
+    #         "y_value",
+    #         "torch_out",
+    #         "tt_out",
+    #         "ulp_distance",
+    #         "x_bits_u16",
+    #         "y_bits_u16",
+    #         "torch_bits_u16",
+    #         "tt_bits_u16",
+    #     ]
+    # )
+
+    for batch_idx in range(num_batches):
+        start = batch_idx * batch_size
+        end = min(start + batch_size, Nx)
+
+        # x_batch: [batch_size, 1], y: [1, Ny] → broadcasts to [batch_size, Ny]
+        x_batch = x_values[start:end].unsqueeze(1)  # shape: [B, 1]
+        y_full = y_values.unsqueeze(0)  # shape: [1, Ny]
+
+        # Broadcast multiply
+        z_torch = torch.fmod(x_batch, y_full)  # shape: [B, Ny]
+
+        # Send to backend
+        x_tt = ttnn.from_torch(x_batch, dtype=ttnn_dtype, layout=ttnn.TILE_LAYOUT, device=device)
+        y_tt = ttnn.from_torch(y_full, dtype=ttnn_dtype, layout=ttnn.TILE_LAYOUT, device=device)
+        z_tt = ttnn.pow(x_tt, y_tt)
+        tt_out = ttnn.to_torch(z_tt)
+
+        # ULP check (use bf16 space)
+        z_bf16 = z_torch.to(torch.bfloat16).contiguous()
+        tt_bf16 = tt_out.to(torch.bfloat16).contiguous()
+
+        # Flush subnormal bfloat16 values to zero
+        # For bfloat16, min normal is ~1.175494e-38 (same exponent range as float32)
+        min_normal_threshold = torch.finfo(torch.bfloat16).tiny
+        subnormal_mask = z_bf16.abs() <= min_normal_threshold
+        z_bf16[subnormal_mask] = 0.0
+        subnormal_mask_tt = tt_bf16.abs() <= min_normal_threshold
+        tt_bf16[subnormal_mask_tt] = 0.0
+
+        # Flush overflow values (greater than max normal or inf) to zero
+        # For bfloat16, max normal is ~3.389531e38 (same exponent range as float32)
+        max_normal_threshold = torch.finfo(torch.bfloat16).max
+        overflow_mask = (z_bf16.abs() > max_normal_threshold) | ~torch.isfinite(z_bf16)
+        z_bf16[overflow_mask] = 0.0
+        overflow_mask_tt = (tt_bf16.abs() > max_normal_threshold) | ~torch.isfinite(tt_bf16)
+        tt_bf16[overflow_mask_tt] = 0.0
+
+        z_bits = z_bf16.view(torch.uint16).to(torch.int32)
+        tt_bits = tt_bf16.view(torch.uint16).to(torch.int32)
+
+        sign_z = (z_bits >> 15) & 1
+        sign_tt = (tt_bits >> 15) & 1
+        z_ord = torch.where(sign_z == 0, z_bits + 0x8000, 0x8000 - z_bits)
+        tt_ord = torch.where(sign_tt == 0, tt_bits + 0x8000, 0x8000 - tt_bits)
+        ulp_dist = (z_ord - tt_ord).abs()
+
+        max_ulp_batch = ulp_dist.max().item()
+        max_ulp_global = max(max_ulp_global, max_ulp_batch)
+
+        # Count ULP distribution
+        ulp_0_count += (ulp_dist == 0).sum().item()
+        ulp_1_count += (ulp_dist == 1).sum().item()
+        ulp_2_count += (ulp_dist == 2).sum().item()
+        ulp_3_to_10_count += ((ulp_dist >= 3) & (ulp_dist <= 10)).sum().item()
+        ulp_11_to_100_count += ((ulp_dist >= 11) & (ulp_dist <= 100)).sum().item()
+        ulp_above_100_count += (ulp_dist > 100).sum().item()
+
+        # # Log mismatches to CSV
+        # mismatch_mask = ulp_dist > 1
+        # mismatch_count = mismatch_mask.sum().item()
+        # total_mismatches += mismatch_count
+        #
+        # if mismatch_count > 0:
+        #     # Get mismatch indices in [B, Ny] grid
+        #     mismatch_indices = mismatch_mask.nonzero(as_tuple=False)  # shape: [num_mismatches, 2]
+        #
+        #     for idx_pair in mismatch_indices:
+        #         i, j = idx_pair[0].item(), idx_pair[1].item()
+        #         x_idx = start + i
+        #         y_idx = j
+        #
+        #         xv = x_batch[i, 0].item()
+        #         yv = y_full[0, j].item()
+        #         zv = z_bf16[i, j].item()
+        #         tv = tt_bf16[i, j].item()
+        #         ulp = ulp_dist[i, j].item()
+        #
+        #         xb = z_bf16.new_tensor(xv).view(torch.uint16).item()
+        #         yb = z_bf16.new_tensor(yv).view(torch.uint16).item()
+        #         zb = z_bits[i, j].item() & 0xFFFF
+        #         tb = tt_bits[i, j].item() & 0xFFFF
+        #
+        #         writer.writerow([batch_idx, x_idx, y_idx, xv, yv, zv, tv, ulp, xb, yb, zb, tb])
+
+        mismatch_mask = ulp_dist > 1
+        mismatch_count = mismatch_mask.sum().item()
+        total_mismatches += mismatch_count
+
+        if (batch_idx + 1) % 10 == 0 or batch_idx == num_batches - 1:
+            print(f"Batch {batch_idx+1}/{num_batches}: max_ulp={max_ulp_batch}, mismatches={mismatch_count}")
+
+    # csv_file.close()
+    total_pairs = Nx * Ny
+    mismatch_pct = (total_mismatches / total_pairs) * 100 if total_pairs > 0 else 0.0
+    print(f"Global max ULP: {max_ulp_global}, total mismatches: {total_mismatches}/{total_pairs} ({mismatch_pct:.4f}%)")
+    print(f"\nULP Distribution:")
+    print(f"  ULP = 0: {ulp_0_count:,} ({ulp_0_count/total_pairs*100:.4f}%)")
+    print(f"  ULP = 1: {ulp_1_count:,} ({ulp_1_count/total_pairs*100:.4f}%)")
+    print(f"  ULP = 2: {ulp_2_count:,} ({ulp_2_count/total_pairs*100:.4f}%)")
+    print(f"  ULP 3-10: {ulp_3_to_10_count:,} ({ulp_3_to_10_count/total_pairs*100:.4f}%)")
+    print(f"  ULP 11-100: {ulp_11_to_100_count:,} ({ulp_11_to_100_count/total_pairs*100:.4f}%)")
+    print(f"  ULP > 100: {ulp_above_100_count:,} ({ulp_above_100_count/total_pairs*100:.4f}%)")
+    # print(f"Mismatch details written to: {out_path_mismatch}")
+
+    # Comment out assertion for characterization test
+    # assert max_ulp_global <= 2, f"Max ULP {max_ulp_global} exceeds threshold 2"
+
+
 def _run_exhaustive_pairwise_mul_helper_float32(device, x_values, y_values, test_name, variant_name):
     """Helper function to run exhaustive pairwise multiplication test in float32 precision.
 
@@ -22,6 +175,7 @@ def _run_exhaustive_pairwise_mul_helper_float32(device, x_values, y_values, test
 
     Nx = x_values.numel()
     Ny = y_values.numel()
+    print(f"\n{'='*60}")
     print(f"{test_name} (float32): Testing {Nx} × {Ny} = {Nx*Ny:,} pairs")
 
     batch_size = 512  # process 512×Ny pairs at a time
@@ -167,7 +321,8 @@ def _run_exhaustive_pairwise_mul_helper_float32(device, x_values, y_values, test
     # assert max_ulp_global <= 2, f"Max ULP {max_ulp_global} exceeds threshold 2"
 
 
-def test_mul_tt_bf16_exhaustive_pos_pos(device):
+# FP32 exhaustive tests
+def test_mul_tt_FP32_exhaustive_pos_pos(device):
     """Test positive × positive normal fp32 values."""
     torch.manual_seed(0)
 
@@ -184,7 +339,7 @@ def test_mul_tt_bf16_exhaustive_pos_pos(device):
     _run_exhaustive_pairwise_mul_helper_float32(device, pos_values, pos_values, "Positive × Positive", "pos_pos")
 
 
-def test_mul_tt_bf16_exhaustive_pos_neg(device):
+def test_mul_tt_FP32_exhaustive_pos_neg(device):
     """Test positive × negative normal bf16 values."""
     torch.manual_seed(0)
 
@@ -203,7 +358,7 @@ def test_mul_tt_bf16_exhaustive_pos_neg(device):
     _run_exhaustive_pairwise_mul_helper_float32(device, pos_values, neg_values, "Positive × Negative", "pos_neg")
 
 
-def test_mul_tt_bf16_exhaustive_neg_pos(device):
+def test_mul_tt_FP32_exhaustive_neg_pos(device):
     """Test negative × positive normal bf16 values."""
     torch.manual_seed(0)
 
@@ -222,7 +377,7 @@ def test_mul_tt_bf16_exhaustive_neg_pos(device):
     _run_exhaustive_pairwise_mul_helper_float32(device, neg_values, pos_values, "Negative × Positive", "neg_pos")
 
 
-def test_mul_tt_bf16_exhaustive_neg_neg(device):
+def test_mul_tt_FP32_exhaustive_neg_neg(device):
     """Test negative × negative normal bf16 values."""
     torch.manual_seed(0)
 
@@ -237,6 +392,177 @@ def test_mul_tt_bf16_exhaustive_neg_neg(device):
 
     neg_values = vals[mask]  # ~32512 negative normal values
     _run_exhaustive_pairwise_mul_helper_float32(device, neg_values, neg_values, "Negative × Negative", "neg_neg")
+
+
+def test_fmod_tt_FP32_exhaustive_test(device):
+    """Test fp32 values."""
+    import io
+    import sys
+    from datetime import datetime
+
+    # Tee class to write to both terminal and buffer
+    class Tee:
+        def __init__(self, *streams):
+            self.streams = streams
+
+        def write(self, data):
+            for s in self.streams:
+                s.write(data)
+                s.flush()
+
+        def flush(self):
+            for s in self.streams:
+                s.flush()
+
+    # Capture stdout while still printing to terminal
+    captured_output = io.StringIO()
+    original_stdout = sys.stdout
+    sys.stdout = Tee(original_stdout, captured_output)
+
+    try:
+        test_mul_tt_FP32_exhaustive_pos_pos(device)
+        test_mul_tt_FP32_exhaustive_pos_neg(device)
+        test_mul_tt_FP32_exhaustive_neg_pos(device)
+        test_mul_tt_FP32_exhaustive_neg_neg(device)
+    finally:
+        sys.stdout = original_stdout
+
+    # Get captured content
+    output_content = captured_output.getvalue()
+
+    # Write to file
+    out_dir = "/home/ubuntu/Files"
+    os.makedirs(out_dir, exist_ok=True)
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    out_path = os.path.join(out_dir, f"pow_fp32_exhaustive_results_{timestamp}.txt")
+    with open(out_path, "w") as f:
+        f.write(output_content)
+
+    print(f"\n{'='*60}")
+    print(f"All results saved to: {out_path}")
+    print(f"{'='*60}")
+
+
+# BF16 Exhaustive tests
+def test_fmod_tt_bf16_exhaustive_pos_pos(device):
+    """Test positive × positive normal fp32 values."""
+    torch.manual_seed(0)
+
+    # Generate all possible bf16 values
+    all_bitpatterns = torch.arange(0, 2**16, dtype=torch.int32).to(torch.uint16)
+    vals = all_bitpatterns.view(torch.bfloat16)
+
+    # Keep only finite, non-zero, positive normal bf16 values
+    tiny = torch.finfo(torch.bfloat16).tiny
+    # tiny = 1e-18  # Use 1e-18 as lower bound instead of bfloat16 min normal
+    mask = torch.isfinite(vals) & (vals > 0) & (vals >= tiny)
+
+    pos_values = vals[mask]  # ~32512 positive normal values
+    _run_exhaustive_pairwise_mul_helper(device, pos_values, pos_values, "Positive × Positive", "pos_pos")
+
+
+def test_fmod_tt_bf16_exhaustive_pos_neg(device):
+    """Test positive × negative normal bf16 values."""
+    torch.manual_seed(0)
+
+    # Generate all possible bf16 values
+    all_bitpatterns = torch.arange(0, 2**16, dtype=torch.int32).to(torch.uint16)
+    vals = all_bitpatterns.view(torch.bfloat16)
+
+    # Keep only finite, non-zero, normal bf16 values
+    tiny = torch.finfo(torch.bfloat16).tiny
+    # tiny = 1e-18  # Use 1e-18 as lower bound for absolute value
+    pos_mask = torch.isfinite(vals) & (vals > 0) & (vals >= tiny)
+    neg_mask = torch.isfinite(vals) & (vals < 0) & (vals.abs() >= tiny)
+
+    pos_values = vals[pos_mask]  # ~32512 positive normal values
+    neg_values = vals[neg_mask]  # ~32512 negative normal values
+    _run_exhaustive_pairwise_mul_helper(device, pos_values, neg_values, "Positive × Negative", "pos_neg")
+
+
+def test_fmod_tt_bf16_exhaustive_neg_pos(device):
+    """Test negative × positive normal bf16 values."""
+    torch.manual_seed(0)
+
+    # Generate all possible bf16 values
+    all_bitpatterns = torch.arange(0, 2**16, dtype=torch.int32).to(torch.uint16)
+    vals = all_bitpatterns.view(torch.bfloat16)
+
+    # Keep only finite, non-zero, normal bf16 values
+    tiny = torch.finfo(torch.bfloat16).tiny
+    # tiny = 1e-18  # Use 1e-18 as lower bound for absolute value
+    pos_mask = torch.isfinite(vals) & (vals > 0) & (vals >= tiny)
+    neg_mask = torch.isfinite(vals) & (vals < 0) & (vals.abs() >= tiny)
+
+    pos_values = vals[pos_mask]  # ~32512 positive normal values
+    neg_values = vals[neg_mask]  # ~32512 negative normal values
+    _run_exhaustive_pairwise_mul_helper(device, neg_values, pos_values, "Negative × Positive", "neg_pos")
+
+
+def test_fmod_tt_bf16_exhaustive_neg_neg(device):
+    """Test negative × negative normal bf16 values."""
+    torch.manual_seed(0)
+
+    # Generate all possible bf16 values
+    all_bitpatterns = torch.arange(0, 2**16, dtype=torch.int32).to(torch.uint16)
+    vals = all_bitpatterns.view(torch.bfloat16)
+
+    # Keep only finite, non-zero, negative normal bf16 values
+    tiny = torch.finfo(torch.bfloat16).tiny
+    # tiny = 1e-18  # Use 1e-18 as lower bound for absolute value
+    mask = torch.isfinite(vals) & (vals < 0) & (vals.abs() >= tiny)
+
+    neg_values = vals[mask]  # ~32512 negative normal values
+    _run_exhaustive_pairwise_mul_helper(device, neg_values, neg_values, "Negative × Negative", "neg_neg")
+
+
+def test_fmod_tt_BF16_exhaustive_test(device):
+    """Test BF16 values."""
+    import io
+    import sys
+    from datetime import datetime
+
+    # Tee class to write to both terminal and buffer
+    class Tee:
+        def __init__(self, *streams):
+            self.streams = streams
+
+        def write(self, data):
+            for s in self.streams:
+                s.write(data)
+                s.flush()
+
+        def flush(self):
+            for s in self.streams:
+                s.flush()
+
+    # Capture stdout while still printing to terminal
+    captured_output = io.StringIO()
+    original_stdout = sys.stdout
+    sys.stdout = Tee(original_stdout, captured_output)
+
+    try:
+        test_fmod_tt_bf16_exhaustive_pos_pos(device)
+        test_fmod_tt_bf16_exhaustive_pos_neg(device)
+        test_fmod_tt_bf16_exhaustive_neg_pos(device)
+        test_fmod_tt_bf16_exhaustive_neg_neg(device)
+    finally:
+        sys.stdout = original_stdout
+
+    # Get captured content
+    output_content = captured_output.getvalue()
+
+    # Write to file
+    out_dir = "/home/ubuntu/Files"
+    os.makedirs(out_dir, exist_ok=True)
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    out_path = os.path.join(out_dir, f"pow_bf16_exhaustive_results_{timestamp}.txt")
+    with open(out_path, "w") as f:
+        f.write(output_content)
+
+    print(f"\n{'='*60}")
+    print(f"All results saved to: {out_path}")
+    print(f"{'='*60}")
 
 
 def test_binary_fp32(device, low=-1e-20, high=1e20):

--- a/tests/ttnn/unit_tests/operations/eltwise/test_fmod_fp32_exhaustive.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_fmod_fp32_exhaustive.py
@@ -1,0 +1,729 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Exhaustive FP32 fmod test using all BF16 values converted to FP32.
+
+This test:
+1. Generates all possible BF16 values (~65536 values)
+2. Converts them to FP32 as input 'a'
+3. Sets input 'b' = a + 1.542
+4. Calls ttnn.pow (which internally uses _sfpu_binary_power_61f_ that implements fmod)
+5. Compares results using ULP (Units in Last Place)
+6. Reports mismatches and stores them in a CSV file
+
+Formula: fmod(a, b) = a - trunc(a/b) * b
+"""
+
+import pytest
+import torch
+import ttnn
+import struct
+import csv
+import os
+import math
+from datetime import datetime
+
+
+def bf16_to_float32(bf16_bits: int) -> float:
+    """Convert BF16 bit pattern to FP32 value."""
+    # BF16 is essentially FP32 with lower 16 mantissa bits truncated
+    # So we just shift left by 16 to get the FP32 bit pattern
+    fp32_bits = bf16_bits << 16
+    return struct.unpack("f", struct.pack("I", fp32_bits))[0]
+
+
+def float32_to_bits(f: float) -> int:
+    """Convert FP32 value to its bit representation."""
+    return struct.unpack("I", struct.pack("f", f))[0]
+
+
+def compute_ulp_diff(a: float, b: float) -> int:
+    """
+    Compute the ULP (Units in Last Place) difference between two floats.
+
+    ULP is the number of representable floating-point numbers between a and b.
+    """
+    # Handle special cases
+    if math.isnan(a) or math.isnan(b):
+        return float("inf") if (math.isnan(a) != math.isnan(b)) else 0
+
+    if math.isinf(a) or math.isinf(b):
+        if a == b:
+            return 0
+        return float("inf")
+
+    if a == b:
+        return 0
+
+    # Get bit representations
+    bits_a = float32_to_bits(a)
+    bits_b = float32_to_bits(b)
+
+    # Handle sign differences
+    sign_a = (bits_a >> 31) & 1
+    sign_b = (bits_b >> 31) & 1
+
+    if sign_a != sign_b:
+        # Different signs - compute distance through zero
+        if sign_a:
+            bits_a = 0x80000000 - bits_a
+        if sign_b:
+            bits_b = 0x80000000 - bits_b
+        return bits_a + bits_b
+
+    # Same sign - simple difference
+    if sign_a:
+        bits_a = 0x80000000 - bits_a
+        bits_b = 0x80000000 - bits_b
+
+    return abs(bits_a - bits_b)
+
+
+def generate_all_bf16_as_fp32():
+    """
+    Generate all possible BF16 values as FP32.
+
+    BF16 has 16 bits: 1 sign + 8 exponent + 7 mantissa
+    Total: 2^16 = 65536 values
+    """
+    values = []
+
+    for bf16_bits in range(65536):
+        exponent = (bf16_bits >> 7) & 0xFF
+        mantissa = bf16_bits & 0x7F
+
+        # Skip special values
+        if exponent == 0xFF:  # Inf or NaN
+            continue
+        if exponent == 0 and mantissa != 0:  # Denormals
+            continue
+
+        fp32_val = bf16_to_float32(bf16_bits)
+
+        if math.isnan(fp32_val) or math.isinf(fp32_val):
+            continue
+
+        values.append(fp32_val)
+
+    return values
+
+
+def write_mismatches_to_file(mismatches: list, output_path: str):
+    """Write mismatch details to a CSV file."""
+    with open(output_path, "w", newline="") as csvfile:
+        fieldnames = ["index", "input_a", "input_b", "expected_torch", "ttnn_result", "ulp_diff", "abs_diff"]
+        writer = csv.DictWriter(csvfile, fieldnames=fieldnames)
+        writer.writeheader()
+
+        for mismatch in mismatches:
+            writer.writerow(mismatch)
+
+    print(f"Mismatches written to: {output_path}")
+
+
+def pad_to_tile(values: list, tile_size: int = 32) -> list:
+    """Pad values list to be a multiple of tile_size."""
+    remainder = len(values) % tile_size
+    if remainder != 0:
+        padding_needed = tile_size - remainder
+        # Pad with zeros (or first value to avoid div by zero issues)
+        values = values + [1.0] * padding_needed
+    return values
+
+
+@pytest.mark.parametrize("device_params", [{"l1_small_size": 32768}], indirect=True)
+def test_fmod_fp32_small_batch(device):
+    """
+    Small batch test of fmod operation to verify basic functionality.
+    Uses a subset of BF16 values for quick testing.
+    """
+
+    # Configuration
+    ULP_TOLERANCE = 10
+    OFFSET_B = 1.542
+    BATCH_SIZE = 32 * 32  # 1024 values = one 32x32 tile
+
+    print("\nGenerating test values...")
+    all_bf16_fp32 = generate_all_bf16_as_fp32()
+
+    # Take a subset and filter
+    filtered_values = []
+    for val in all_bf16_fp32[: BATCH_SIZE * 2]:
+        b_val = val + OFFSET_B
+        if abs(val) >= 0.01 and abs(b_val) >= 0.01:
+            filtered_values.append(val)
+        if len(filtered_values) >= BATCH_SIZE:
+            break
+
+    # Pad to tile-aligned size (32x32 = 1024)
+    while len(filtered_values) < 32 * 32:
+        filtered_values.append(1.0)
+
+    num_values = len(filtered_values)
+
+    print(f"Testing with {num_values} values (tile-aligned 32x32)")
+
+    # Create input tensors with proper tile-aligned shape (32x32)
+    input_a = torch.tensor(filtered_values, dtype=torch.float32).reshape(1, 1, 32, 32)
+    input_b = input_a + OFFSET_B
+
+    # Compute expected result using PyTorch
+    print("Computing expected results with PyTorch fmod...")
+    expected = torch.fmod(input_a, input_b)
+
+    # Create TTNN tensors
+    print("Creating TTNN tensors...")
+    ttnn_a = ttnn.from_torch(input_a, dtype=ttnn.float32, device=device, layout=ttnn.TILE_LAYOUT)
+    ttnn_b = ttnn.from_torch(input_b, dtype=ttnn.float32, device=device, layout=ttnn.TILE_LAYOUT)
+
+    # Run fmod via ttnn.pow
+    print("Running TTNN pow (fmod implementation)...")
+    ttnn_result = ttnn.pow(ttnn_a, ttnn_b)
+
+    # Convert back to PyTorch
+    result = ttnn.to_torch(ttnn_result)
+
+    # Flatten for comparison
+    expected_flat = expected.flatten()
+    result_flat = result.flatten()
+    input_a_flat = input_a.flatten()
+
+    # Compare results
+    print("Comparing results...")
+    mismatches = []
+    max_ulp = 0
+    total_ulp = 0
+    valid_comparisons = 0
+
+    for i in range(len(filtered_values)):
+        a_val = input_a_flat[i].item()
+        b_val = a_val + OFFSET_B
+        exp_val = expected_flat[i].item()
+        res_val = result_flat[i].item()
+
+        ulp_diff = compute_ulp_diff(exp_val, res_val)
+
+        if ulp_diff == float("inf"):
+            mismatches.append(
+                {
+                    "index": i,
+                    "input_a": a_val,
+                    "input_b": b_val,
+                    "expected_torch": exp_val,
+                    "ttnn_result": res_val,
+                    "ulp_diff": "inf",
+                    "abs_diff": "NaN",
+                }
+            )
+            continue
+
+        valid_comparisons += 1
+        total_ulp += ulp_diff
+        max_ulp = max(max_ulp, ulp_diff)
+
+        if ulp_diff > ULP_TOLERANCE:
+            mismatches.append(
+                {
+                    "index": i,
+                    "input_a": a_val,
+                    "input_b": b_val,
+                    "expected_torch": exp_val,
+                    "ttnn_result": res_val,
+                    "ulp_diff": ulp_diff,
+                    "abs_diff": abs(exp_val - res_val),
+                }
+            )
+
+    # Print summary
+    print("\n" + "=" * 80)
+    print("FMOD FP32 TEST RESULTS")
+    print("=" * 80)
+    print(f"Total values tested: {len(filtered_values)}")
+    print(f"Valid comparisons: {valid_comparisons}")
+    print(f"Number of mismatches (ULP > {ULP_TOLERANCE}): {len(mismatches)}")
+    print(f"Max ULP difference: {max_ulp}")
+    if valid_comparisons > 0:
+        print(f"Average ULP difference: {total_ulp / valid_comparisons:.2f}")
+    print("=" * 80)
+
+    # Write mismatches to file
+    if mismatches:
+        timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+        output_dir = "/home/ubuntu/tt-metal/test_outputs"
+        os.makedirs(output_dir, exist_ok=True)
+        output_path = os.path.join(output_dir, f"fmod_mismatches_{timestamp}.csv")
+        write_mismatches_to_file(mismatches, output_path)
+
+        print("\nFirst 10 mismatches:")
+        print("-" * 100)
+        print(f"{'Index':<8} {'Input A':<15} {'Input B':<15} {'Expected':<15} {'TTNN':<15} {'ULP':<10}")
+        print("-" * 100)
+        for m in mismatches[:10]:
+            exp_str = (
+                f"{m['expected_torch']:.6f}" if isinstance(m["expected_torch"], float) else str(m["expected_torch"])
+            )
+            res_str = f"{m['ttnn_result']:.6f}" if isinstance(m["ttnn_result"], float) else str(m["ttnn_result"])
+            print(
+                f"{m['index']:<8} {m['input_a']:<15.6f} {m['input_b']:<15.6f} {exp_str:<15} {res_str:<15} {m['ulp_diff']:<10}"
+            )
+
+    print(f"\nTest completed: {len(mismatches)} mismatches found")
+
+
+@pytest.mark.parametrize("device_params", [{"l1_small_size": 32768}], indirect=True)
+def test_fmod_fp32_exhaustive(device):
+    """
+    Exhaustive test of fmod operation using all BF16 values converted to FP32.
+    Processes in batches to avoid memory issues.
+    """
+
+    # Configuration
+    ULP_TOLERANCE = 10
+    OFFSET_B = 1.542
+    BATCH_SIZE = 32 * 32  # 1024 values per batch (one 32x32 tile)
+
+    print("\nGenerating all BF16 values as FP32...")
+    all_bf16_fp32 = generate_all_bf16_as_fp32()
+    print(f"Generated {len(all_bf16_fp32)} valid values")
+
+    # Filter values
+    filtered_values = []
+    for val in all_bf16_fp32:
+        b_val = val + OFFSET_B
+        if abs(val) >= 0.01 and abs(b_val) >= 0.01:
+            filtered_values.append(val)
+
+    print(f"After filtering: {len(filtered_values)} values")
+
+    # Process in batches
+    all_mismatches = []
+    all_results = []  # Store ALL results for ULP distribution analysis
+    max_ulp_global = 0
+    total_ulp_global = 0
+    valid_comparisons_global = 0
+
+    # ULP distribution tracking
+    ulp_distribution = {
+        "ulp_0": 0,  # Exact match
+        "ulp_1": 0,  # ULP = 1
+        "ulp_2": 0,  # ULP = 2
+        "ulp_3": 0,  # ULP = 3
+        "ulp_4_10": 0,  # ULP 4-10
+        "ulp_11_100": 0,  # ULP 11-100
+        "ulp_101_1000": 0,  # ULP 101-1000
+        "ulp_gt_1000": 0,  # ULP > 1000
+        "ulp_inf": 0,  # Inf/NaN cases
+    }
+
+    num_batches = (len(filtered_values) + BATCH_SIZE - 1) // BATCH_SIZE
+    print(f"Processing in {num_batches} batches...")
+
+    for batch_idx in range(num_batches):
+        start_idx = batch_idx * BATCH_SIZE
+        end_idx = min(start_idx + BATCH_SIZE, len(filtered_values))
+        batch_values = filtered_values[start_idx:end_idx]
+
+        # Pad batch to 32x32 tile size
+        while len(batch_values) < 32 * 32:
+            batch_values.append(1.0)
+
+        # Shape for tile layout (32x32)
+        input_a = torch.tensor(batch_values, dtype=torch.float32).reshape(1, 1, 32, 32)
+        input_b = input_a + OFFSET_B
+
+        # Expected result
+        expected = torch.fmod(input_a, input_b)
+
+        # TTNN computation
+        ttnn_a = ttnn.from_torch(input_a, dtype=ttnn.float32, device=device, layout=ttnn.TILE_LAYOUT)
+        ttnn_b = ttnn.from_torch(input_b, dtype=ttnn.float32, device=device, layout=ttnn.TILE_LAYOUT)
+
+        ttnn_result = ttnn.pow(ttnn_a, ttnn_b)
+        result = ttnn.to_torch(ttnn_result)
+
+        # Compare
+        expected_flat = expected.flatten()
+        result_flat = result.flatten()
+        input_a_flat = input_a.flatten()
+
+        actual_batch_size = end_idx - start_idx
+        for i in range(actual_batch_size):
+            a_val = input_a_flat[i].item()
+            b_val = a_val + OFFSET_B
+            exp_val = expected_flat[i].item()
+            res_val = result_flat[i].item()
+
+            ulp_diff = compute_ulp_diff(exp_val, res_val)
+
+            # Track ULP distribution
+            if ulp_diff == float("inf"):
+                ulp_distribution["ulp_inf"] += 1
+                all_mismatches.append(
+                    {
+                        "index": start_idx + i,
+                        "input_a": a_val,
+                        "input_b": b_val,
+                        "expected_torch": exp_val,
+                        "ttnn_result": res_val,
+                        "ulp_diff": "inf",
+                        "abs_diff": "NaN",
+                    }
+                )
+                continue
+
+            # Categorize ULP
+            if ulp_diff == 0:
+                ulp_distribution["ulp_0"] += 1
+            elif ulp_diff == 1:
+                ulp_distribution["ulp_1"] += 1
+            elif ulp_diff == 2:
+                ulp_distribution["ulp_2"] += 1
+            elif ulp_diff == 3:
+                ulp_distribution["ulp_3"] += 1
+            elif ulp_diff <= 10:
+                ulp_distribution["ulp_4_10"] += 1
+            elif ulp_diff <= 100:
+                ulp_distribution["ulp_11_100"] += 1
+            elif ulp_diff <= 1000:
+                ulp_distribution["ulp_101_1000"] += 1
+            else:
+                ulp_distribution["ulp_gt_1000"] += 1
+
+            valid_comparisons_global += 1
+            total_ulp_global += ulp_diff
+            max_ulp_global = max(max_ulp_global, ulp_diff)
+
+            # Store ALL results for analysis
+            all_results.append(
+                {
+                    "index": start_idx + i,
+                    "input_a": a_val,
+                    "input_b": b_val,
+                    "expected_torch": exp_val,
+                    "ttnn_result": res_val,
+                    "ulp_diff": ulp_diff,
+                    "abs_diff": abs(exp_val - res_val),
+                }
+            )
+
+            if ulp_diff > ULP_TOLERANCE:
+                all_mismatches.append(
+                    {
+                        "index": start_idx + i,
+                        "input_a": a_val,
+                        "input_b": b_val,
+                        "expected_torch": exp_val,
+                        "ttnn_result": res_val,
+                        "ulp_diff": ulp_diff,
+                        "abs_diff": abs(exp_val - res_val),
+                    }
+                )
+
+        # Deallocate tensors
+        ttnn_a.deallocate()
+        ttnn_b.deallocate()
+        ttnn_result.deallocate()
+
+        if (batch_idx + 1) % 10 == 0:
+            print(f"  Processed batch {batch_idx + 1}/{num_batches}")
+
+    # Print summary
+    print("\n" + "=" * 80)
+    print("FMOD FP32 EXHAUSTIVE TEST RESULTS")
+    print("=" * 80)
+    print(f"Total values tested: {len(filtered_values)}")
+    print(f"Valid comparisons: {valid_comparisons_global}")
+    print(f"Number of mismatches (ULP > {ULP_TOLERANCE}): {len(all_mismatches)}")
+    print(f"Max ULP difference: {max_ulp_global}")
+    if valid_comparisons_global > 0:
+        print(f"Average ULP difference: {total_ulp_global / valid_comparisons_global:.2f}")
+    print("=" * 80)
+
+    # Build dynamic ULP distribution from actual data
+    # Count ULP values in fine-grained buckets first
+    ulp_counts = {}  # ulp_value -> count
+    for r in all_results:
+        ulp = r["ulp_diff"]
+        if ulp not in ulp_counts:
+            ulp_counts[ulp] = 0
+        ulp_counts[ulp] += 1
+
+    # Define range boundaries for detailed breakdown
+    def get_ulp_range_counts():
+        """Dynamically compute ULP ranges based on actual data distribution."""
+        ranges = []
+
+        # Always show ULP = 0 separately
+        ulp_0_count = ulp_counts.get(0, 0)
+        if ulp_0_count > 0:
+            ranges.append(("ULP = 0 (exact)", 0, 0, ulp_0_count))
+
+        # Define potential range boundaries
+        boundaries = [
+            1,
+            2,
+            3,
+            4,
+            5,
+            10,
+            50,
+            100,
+            500,
+            1000,
+            5000,
+            10000,
+            50000,
+            100000,
+            500000,
+            1000000,
+            10000000,
+            100000000,
+            1000000000,
+            float("inf"),
+        ]
+
+        # Count values in each potential range
+        range_data = []
+        for i in range(len(boundaries) - 1):
+            low = boundaries[i]
+            high = boundaries[i + 1]
+            count = sum(c for ulp, c in ulp_counts.items() if low <= ulp < high)
+            range_data.append((low, high, count))
+
+        # Combine adjacent zero ranges
+        combined_ranges = []
+        i = 0
+        while i < len(range_data):
+            low, high, count = range_data[i]
+
+            if count == 0:
+                # Start combining zero ranges
+                combined_low = low
+                combined_high = high
+                while i + 1 < len(range_data) and range_data[i + 1][2] == 0:
+                    i += 1
+                    combined_high = range_data[i][1]
+                combined_ranges.append((combined_low, combined_high, 0))
+            else:
+                # Non-zero range - check if we need to split it further
+                if count > 100:  # If significant count, try to split
+                    # Find actual ULP values in this range
+                    ulps_in_range = [(ulp, c) for ulp, c in ulp_counts.items() if low <= ulp < high]
+                    ulps_in_range.sort()
+
+                    if len(ulps_in_range) > 1:
+                        # Find natural groupings based on gaps
+                        sub_ranges = []
+                        sub_low = ulps_in_range[0][0]
+                        sub_count = ulps_in_range[0][1]
+                        prev_ulp = ulps_in_range[0][0]
+
+                        for ulp, c in ulps_in_range[1:]:
+                            # If big gap or enough values, start new sub-range
+                            if ulp > prev_ulp * 2 or sub_count >= count // 3:
+                                sub_ranges.append((sub_low, prev_ulp, sub_count))
+                                sub_low = ulp
+                                sub_count = c
+                            else:
+                                sub_count += c
+                            prev_ulp = ulp
+
+                        sub_ranges.append((sub_low, prev_ulp, sub_count))
+
+                        for sr in sub_ranges:
+                            combined_ranges.append(sr)
+                    else:
+                        combined_ranges.append((low, high, count))
+                else:
+                    combined_ranges.append((low, high, count))
+            i += 1
+
+        # Format range names
+        final_ranges = []
+        if ulp_0_count > 0:
+            final_ranges.append(("ULP = 0 (exact)", ulp_0_count))
+
+        for low, high, count in combined_ranges:
+            if count > 0 or (low == 1):  # Show at least one zero range for context
+                if low == high or (isinstance(high, float) and high == float("inf")):
+                    if high == float("inf"):
+                        name = f"ULP >= {low:,}"
+                    else:
+                        name = f"ULP = {low:,}"
+                elif high == float("inf"):
+                    name = f"ULP >= {low:,}"
+                else:
+                    name = f"ULP {low:,} - {high:,}"
+                final_ranges.append((name, count))
+
+        # Add inf/NaN if present
+        if ulp_distribution["ulp_inf"] > 0:
+            final_ranges.append(("ULP = inf (NaN)", ulp_distribution["ulp_inf"]))
+
+        return final_ranges
+
+    # Print ULP Distribution Table
+    print("\n" + "=" * 90)
+    print("ULP DISTRIBUTION TABLE (Dynamic Ranges)")
+    print("=" * 90)
+    print(f"{'ULP Range':<45} {'Count':>15} {'Percentage':>15}")
+    print("-" * 90)
+
+    total_for_pct = valid_comparisons_global + ulp_distribution["ulp_inf"]
+    dynamic_ranges = get_ulp_range_counts()
+
+    for range_name, count in dynamic_ranges:
+        pct = (count / total_for_pct * 100) if total_for_pct > 0 else 0
+        if count > 0 or "ULP = 0" in range_name or "1 -" in range_name:
+            print(f"{range_name:<45} {count:>15,} {pct:>14.2f}%")
+
+    print("-" * 90)
+    print(f"{'TOTAL':<45} {total_for_pct:>15,}")
+    print("=" * 90)
+
+    # Analyze high ULP cases
+    print("\n" + "=" * 80)
+    print("HIGH ULP ANALYSIS (ULP > 3)")
+    print("=" * 80)
+
+    # Find examples from different ULP ranges
+    high_ulp_examples = []
+    for r in all_results:
+        if r["ulp_diff"] > 3 and len(high_ulp_examples) < 5:
+            high_ulp_examples.append(r)
+
+    if high_ulp_examples:
+        print(f"\n{'Index':<8} {'Input A':<18} {'Input B':<18} {'Expected':<18} {'TTNN':<18} {'ULP':<12}")
+        print("-" * 100)
+        for ex in high_ulp_examples:
+            print(
+                f"{ex['index']:<8} {ex['input_a']:<18.6g} {ex['input_b']:<18.6g} "
+                f"{ex['expected_torch']:<18.6g} {ex['ttnn_result']:<18.6g} {ex['ulp_diff']:<12}"
+            )
+
+        # Provide analysis
+        print("\n" + "-" * 80)
+        print("REASON ANALYSIS:")
+        print("-" * 80)
+
+        # Categorize reasons
+        large_value_count = sum(1 for r in all_results if r["ulp_diff"] > 3 and abs(r["input_a"]) > 1e6)
+        equal_ab_count = sum(1 for r in all_results if r["ulp_diff"] > 3 and abs(r["input_a"] - r["input_b"]) < 1e-5)
+        near_integer_count = sum(
+            1
+            for r in all_results
+            if r["ulp_diff"] > 3 and abs(r["input_a"] / r["input_b"] - round(r["input_a"] / r["input_b"])) < 0.001
+        )
+
+        print(f"1. Large values (|a| > 1e6):        {large_value_count} cases")
+        print(f"   Reason: FP32 precision limits - adding 1.542 to large numbers may not change the value")
+        print(f"           When a ≈ b, fmod(a,a) should be 0, but reciprocal error causes wrong trunc")
+        print(f"")
+        print(f"2. Near-equal a,b (|a-b| < 1e-5):   {equal_ab_count} cases")
+        print(f"   Reason: When a ≈ b, a/b ≈ 1.0. Small reciprocal errors cause trunc(0.999...) = 0")
+        print(f"           instead of trunc(1.0) = 1, giving fmod = a instead of 0")
+        print(f"")
+        print(f"3. Near-integer quotient:           {near_integer_count} cases")
+        print(f"   Reason: When a/b is very close to an integer, truncation can go wrong direction")
+        print("=" * 80)
+
+    # Write results to files (always save to CSV, not terminal)
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    output_dir = "/home/ubuntu/tt-metal/test_outputs"
+    os.makedirs(output_dir, exist_ok=True)
+
+    # Write mismatches (ULP > tolerance)
+    mismatch_path = os.path.join(output_dir, f"fmod_mismatches_{timestamp}.csv")
+    if all_mismatches:
+        write_mismatches_to_file(all_mismatches, mismatch_path)
+    else:
+        print(f"No mismatches (ULP > {ULP_TOLERANCE}) found!")
+
+    # Write ALL results for detailed ULP analysis
+    all_results_path = os.path.join(output_dir, f"fmod_all_results_{timestamp}.csv")
+    with open(all_results_path, "w", newline="") as csvfile:
+        fieldnames = ["index", "input_a", "input_b", "expected_torch", "ttnn_result", "ulp_diff", "abs_diff"]
+        writer = csv.DictWriter(csvfile, fieldnames=fieldnames)
+        writer.writeheader()
+        for r in all_results:
+            writer.writerow(r)
+    print(f"All results written to: {all_results_path}")
+
+    # Assert
+    mismatch_threshold = len(filtered_values) * 0.01  # Allow 1% mismatches
+    if len(all_mismatches) <= mismatch_threshold:
+        print(f"\nTest PASSED: {len(all_mismatches)} mismatches within tolerance ({mismatch_threshold:.0f} allowed)")
+    else:
+        print(f"\nTest FAILED: {len(all_mismatches)} mismatches exceeds tolerance ({mismatch_threshold:.0f} allowed)")
+        print(f"See detailed mismatches in: {mismatch_path}")
+        print(f"See all results in: {all_results_path}")
+        assert False, f"Too many mismatches: {len(all_mismatches)} > {mismatch_threshold}"
+
+
+@pytest.mark.parametrize("device_params", [{"l1_small_size": 32768}], indirect=True)
+def test_fmod_fp32_simple(device):
+    """
+    Simple test with known values to verify fmod implementation.
+    Uses proper tile-aligned tensor shapes (32x32 minimum).
+    """
+    # Test cases: (a, b)
+    test_cases = [
+        (7.2, 3.1),
+        (10.0, 3.0),
+        (-10.0, 3.0),
+        (10.0, -3.0),
+        (-10.0, -3.0),
+        (5.5, 2.5),
+        (100.0, 7.0),
+        (1.5, 0.7),
+    ]
+
+    num_test_cases = len(test_cases)
+
+    # Pad to 32x32 = 1024 values for tile alignment (minimum tile size)
+    while len(test_cases) < 32 * 32:
+        test_cases.append((1.0, 1.0))
+
+    a_values = [tc[0] for tc in test_cases]
+    b_values = [tc[1] for tc in test_cases]
+
+    # Create tile-aligned tensors (1, 1, 32, 32) - minimum tile size
+    input_a = torch.tensor(a_values, dtype=torch.float32).reshape(1, 1, 32, 32)
+    input_b = torch.tensor(b_values, dtype=torch.float32).reshape(1, 1, 32, 32)
+
+    # Expected from PyTorch
+    expected = torch.fmod(input_a, input_b)
+
+    # TTNN
+    ttnn_a = ttnn.from_torch(input_a, dtype=ttnn.float32, device=device, layout=ttnn.TILE_LAYOUT)
+    ttnn_b = ttnn.from_torch(input_b, dtype=ttnn.float32, device=device, layout=ttnn.TILE_LAYOUT)
+
+    result = ttnn.pow(ttnn_a, ttnn_b)
+    result_torch = ttnn.to_torch(result)
+
+    print("\nSimple fmod test results:")
+    print("-" * 80)
+    print(f"{'A':<10} {'B':<10} {'Expected':<15} {'TTNN':<15} {'ULP':<10}")
+    print("-" * 80)
+
+    for i in range(num_test_cases):  # Only print actual test cases
+        a = a_values[i]
+        b = b_values[i]
+        exp = expected.flatten()[i].item()
+        res = result_torch.flatten()[i].item()
+        ulp = compute_ulp_diff(exp, res)
+
+        print(f"{a:<10.2f} {b:<10.2f} {exp:<15.6f} {res:<15.6f} {ulp:<10}")
+
+        # Check ULP tolerance
+        assert ulp <= 100 or ulp == float("inf"), f"fmod({a}, {b}) ULP too high: {ulp}"
+
+    print("\nSimple test completed!")
+
+
+if __name__ == "__main__":
+    import sys
+
+    pytest.main([__file__, "-v", "-s", "-k", "simple"] + sys.argv[1:])

--- a/tests/ttnn/unit_tests/operations/eltwise/test_fmod_fp32_exhaustive.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_fmod_fp32_exhaustive.py
@@ -807,12 +807,12 @@ def test_fmod_fp32_multi_offset(device):
             else:  # operation == "sub"
                 b_val = val - offset_value
 
-            # Filter: avoid div by zero, very small values, and inf/nan
-            if abs(val) >= 0.01 and abs(b_val) >= 0.01:
-                if not math.isnan(b_val) and not math.isinf(b_val):
-                    if not math.isnan(val) and not math.isinf(val):
-                        filtered_values.append(val)
-                        filtered_b_values.append(b_val)
+            # Filter: only avoid div by zero (b=0) and inf/nan
+            # No magnitude filter - test all ~65k BF16 values
+            if b_val != 0.0 and not math.isnan(b_val) and not math.isinf(b_val):
+                if not math.isnan(val) and not math.isinf(val):
+                    filtered_values.append(val)
+                    filtered_b_values.append(b_val)
 
         print(f"After filtering: {len(filtered_values)} values")
 

--- a/tests/ttnn/unit_tests/operations/eltwise/test_fmod_inf_nan.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_fmod_inf_nan.py
@@ -1,0 +1,148 @@
+# SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+import pytest
+import ttnn
+import csv
+import math
+import itertools
+from datetime import datetime
+
+
+# Special values to test
+SPECIAL_VALUES = [
+    float("inf"),
+    float("nan"),
+    float("-inf"),
+    -0.0,
+    1.0,
+    -1.0,
+    0.0,
+]
+
+
+def get_value_name(val):
+    """Get readable name for a special value."""
+    if math.isnan(val):
+        return "nan"
+    elif math.isinf(val):
+        return "inf" if val > 0 else "-inf"
+    elif val == 0.0:
+        # Check for negative zero using copysign
+        # Note: -0.0 == 0.0 is True in Python, so we need copysign to distinguish
+        if math.copysign(1.0, val) < 0:
+            return "minus 0.0"
+        return "0.0"
+    elif val == 1.0:
+        return "1.0"
+    return str(val)
+
+
+def format_result(val):
+    """Format result value for CSV output."""
+    if isinstance(val, torch.Tensor):
+        val = val.item()
+    if math.isnan(val):
+        return "nan"
+    elif math.isinf(val):
+        return "inf" if val > 0 else "-inf"
+    elif val == 0.0:
+        # Check for negative zero
+        if math.copysign(1.0, val) < 0:
+            return "minus 0.0"
+        return "0.0"
+    return str(val)
+
+
+def test_fmod_special_values(device):
+    """
+    Test fmod with all combinations of special values.
+    Compares torch.fmod vs ttnn.fmod for bf16 and fp32.
+
+    Output CSV columns:
+    - case: test configuration (e.g., bf16, fp32)
+    - input_a: input A value (dividend)
+    - input_b: input B value (divisor)
+    - ttnn_result: TTNN computed result
+    - golden_result: Torch golden reference result
+    - error: exception message if operation failed
+    """
+    csv_file_path = "fmod_special_values.csv"
+
+    # Generate all combinations of special values for A and B
+    combinations = list(itertools.product(SPECIAL_VALUES, SPECIAL_VALUES))
+
+    print(f"Testing fmod with {len(combinations)} special value combinations...")
+    print(f"Special values: {[get_value_name(v) for v in SPECIAL_VALUES]}")
+
+    # Test configurations: (name, ttnn_dtype, torch_dtype)
+    test_configs = [
+        ("bf16", ttnn.bfloat16, torch.bfloat16),
+        ("fp32", ttnn.float32, torch.float32),
+    ]
+
+    with open(csv_file_path, "w", newline="") as csvfile:
+        fieldnames = ["case", "input_a", "input_b", "ttnn_result", "golden_result", "error"]
+        writer = csv.DictWriter(csvfile, fieldnames=fieldnames)
+        writer.writeheader()
+
+        total_cases = 0
+        for case_name, ttnn_dtype, torch_dtype in test_configs:
+            print(f"Testing case: {case_name}")
+
+            for a_val, b_val in combinations:
+                a_name = get_value_name(a_val)
+                b_name = get_value_name(b_val)
+
+                # Create tensors with single value (tile-sized for TTNN)
+                tensor_a = torch.full((1, 1, 32, 32), a_val, dtype=torch_dtype)
+                tensor_b = torch.full((1, 1, 32, 32), b_val, dtype=torch_dtype)
+
+                # Calculate golden result using torch.fmod
+                golden = torch.fmod(tensor_a, tensor_b)
+                golden_val = golden[0, 0, 0, 0].item()
+
+                try:
+                    # Convert to TTNN tensors
+                    tt_a = ttnn.from_torch(
+                        tensor_a,
+                        dtype=ttnn_dtype,
+                        device=device,
+                        layout=ttnn.TILE_LAYOUT,
+                        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+                    )
+                    tt_b = ttnn.from_torch(
+                        tensor_b,
+                        dtype=ttnn_dtype,
+                        device=device,
+                        layout=ttnn.TILE_LAYOUT,
+                        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+                    )
+
+                    # Compute fmod using TTNN
+                    tt_result = ttnn.pow(tt_a, tt_b)
+
+                    result = ttnn.to_torch(tt_result)
+                    ttnn_val = result[0, 0, 0, 0].item()
+                    error_msg = ""
+
+                except Exception as e:
+                    ttnn_val = "ERROR"
+                    error_msg = str(e)
+
+                writer.writerow(
+                    {
+                        "case": case_name,
+                        "input_a": a_name,
+                        "input_b": b_name,
+                        "ttnn_result": format_result(ttnn_val) if ttnn_val != "ERROR" else "ERROR",
+                        "golden_result": format_result(golden_val),
+                        "error": error_msg,
+                    }
+                )
+                total_cases += 1
+
+    print(f"\nResults saved to {csv_file_path}")
+    print(f"Total test cases: {total_cases}")

--- a/tests/ttnn/unit_tests/operations/eltwise/test_fmod_valid_range.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_fmod_valid_range.py
@@ -1,0 +1,806 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+import os
+import csv
+import pytest
+import ttnn
+import numpy as np
+import matplotlib.pyplot as plt
+from tests.ttnn.utils_for_testing import assert_with_ulp
+
+
+def _run_exhaustive_pairwise_mul_helper(device, x_values, y_values, test_name, variant_name):
+    """Helper function to run exhaustive pairwise multiplication test between two value sets."""
+    ttnn_dtype = ttnn.bfloat16
+
+    Nx = x_values.numel()
+    Ny = y_values.numel()
+    print()
+    print(f"{test_name}")
+
+    batch_size = 512  # process 512×Ny pairs at a time
+    num_batches = (Nx + batch_size - 1) // batch_size
+
+    max_ulp_global = 0
+    total_mismatches = 0
+    total_valid_pairs = 0  # Track total valid pairs after filtering
+    total_filtered_pairs = 0  # Track filtered out pairs
+
+    # Track ULP distribution
+    ulp_0_count = 0
+    ulp_1_count = 0
+    ulp_2_count = 0
+    ulp_3_to_10_count = 0
+    ulp_11_to_100_count = 0
+    ulp_above_100_count = 0
+
+    # # Open CSV for logging mismatches (variant-specific) - write outside repo
+    # out_dir = "/home/ubuntu/Files"
+    # os.makedirs(out_dir, exist_ok=True)
+    # out_path_mismatch = os.path.join(out_dir, f"mul_ulp_mismatch_exhaustive_{variant_name}_BH.csv")
+    # csv_file = open(out_path_mismatch, mode="w", newline="")
+    # writer = csv.writer(csv_file)
+    # writer.writerow(
+    #     [
+    #         "batch_idx",
+    #         "x_idx",
+    #         "y_idx",
+    #         "x_value",
+    #         "y_value",
+    #         "torch_out",
+    #         "tt_out",
+    #         "ulp_distance",
+    #         "x_bits_u16",
+    #         "y_bits_u16",
+    #         "torch_bits_u16",
+    #         "tt_bits_u16",
+    #     ]
+    # )
+
+    for batch_idx in range(num_batches):
+        start = batch_idx * batch_size
+        end = min(start + batch_size, Nx)
+
+        # x_batch: [batch_size, 1], y: [1, Ny] → broadcasts to [batch_size, Ny]
+        x_batch = x_values[start:end].unsqueeze(1)  # shape: [B, 1]
+        y_full = y_values.unsqueeze(0)  # shape: [1, Ny]
+
+        # Filter valid range: |x/y| < 2^7 for BF16 precision
+        # This ensures the quotient can be represented accurately
+        quotient_threshold = 2**7  # 128 for BF16
+        total_batch_pairs = x_batch.shape[0] * y_full.shape[1]
+
+        with torch.no_grad():
+            # Compute |x/y| safely (avoid division by zero)
+            y_safe = torch.where(y_full == 0, torch.ones_like(y_full), y_full)
+            quotient_abs = (x_batch / y_safe).abs()
+            # Create valid mask (quotient within range and y is not zero)
+            valid_mask = (quotient_abs < quotient_threshold) & (y_full != 0)
+
+        valid_count = valid_mask.sum().item()
+
+        # Track valid/filtered pairs
+        total_valid_pairs += valid_count
+        total_filtered_pairs += total_batch_pairs - valid_count
+
+        # Compute fmod on full tensor (faster than extracting valid pairs)
+        z_torch = torch.fmod(x_batch, y_full)  # shape: [B, Ny]
+
+        # Send to backend
+        x_tt = ttnn.from_torch(x_batch, dtype=ttnn_dtype, layout=ttnn.TILE_LAYOUT, device=device)
+        y_tt = ttnn.from_torch(y_full, dtype=ttnn_dtype, layout=ttnn.TILE_LAYOUT, device=device)
+        z_tt = ttnn.pow(x_tt, y_tt)
+        tt_out = ttnn.to_torch(z_tt)
+
+        # ULP check (use bf16 space)
+        z_bf16 = z_torch.to(torch.bfloat16).contiguous()
+        tt_bf16 = tt_out.to(torch.bfloat16).contiguous()
+
+        # Flush subnormal bfloat16 values to zero
+        # For bfloat16, min normal is ~1.175494e-38 (same exponent range as float32)
+        min_normal_threshold = torch.finfo(torch.bfloat16).tiny
+        subnormal_mask = z_bf16.abs() <= min_normal_threshold
+        z_bf16[subnormal_mask] = 0.0
+        subnormal_mask_tt = tt_bf16.abs() <= min_normal_threshold
+        tt_bf16[subnormal_mask_tt] = 0.0
+
+        # Flush overflow values (greater than max normal or inf) to zero
+        # For bfloat16, max normal is ~3.389531e38 (same exponent range as float32)
+        max_normal_threshold = torch.finfo(torch.bfloat16).max
+        overflow_mask = (z_bf16.abs() > max_normal_threshold) | ~torch.isfinite(z_bf16)
+        z_bf16[overflow_mask] = 0.0
+        overflow_mask_tt = (tt_bf16.abs() > max_normal_threshold) | ~torch.isfinite(tt_bf16)
+        tt_bf16[overflow_mask_tt] = 0.0
+
+        z_bits = z_bf16.view(torch.uint16).to(torch.int32)
+        tt_bits = tt_bf16.view(torch.uint16).to(torch.int32)
+
+        sign_z = (z_bits >> 15) & 1
+        sign_tt = (tt_bits >> 15) & 1
+        z_ord = torch.where(sign_z == 0, z_bits + 0x8000, 0x8000 - z_bits)
+        tt_ord = torch.where(sign_tt == 0, tt_bits + 0x8000, 0x8000 - tt_bits)
+        ulp_dist = (z_ord - tt_ord).abs()
+
+        # Only consider valid pairs for ULP statistics (masking approach - faster)
+        max_ulp_batch = ulp_dist[valid_mask].max().item() if valid_count > 0 else 0
+        max_ulp_global = max(max_ulp_global, max_ulp_batch)
+
+        # Count ULP distribution (only for valid pairs)
+        ulp_0_count += ((ulp_dist == 0) & valid_mask).sum().item()
+        ulp_1_count += ((ulp_dist == 1) & valid_mask).sum().item()
+        ulp_2_count += ((ulp_dist == 2) & valid_mask).sum().item()
+        ulp_3_to_10_count += ((ulp_dist >= 3) & (ulp_dist <= 10) & valid_mask).sum().item()
+        ulp_11_to_100_count += ((ulp_dist >= 11) & (ulp_dist <= 100) & valid_mask).sum().item()
+        ulp_above_100_count += ((ulp_dist > 100) & valid_mask).sum().item()
+
+        # # Log mismatches to CSV
+        # mismatch_mask = ulp_dist > 1
+        # mismatch_count = mismatch_mask.sum().item()
+        # total_mismatches += mismatch_count
+        #
+        # if mismatch_count > 0:
+        #     # Get mismatch indices in [B, Ny] grid
+        #     mismatch_indices = mismatch_mask.nonzero(as_tuple=False)  # shape: [num_mismatches, 2]
+        #
+        #     for idx_pair in mismatch_indices:
+        #         i, j = idx_pair[0].item(), idx_pair[1].item()
+        #         x_idx = start + i
+        #         y_idx = j
+        #
+        #         xv = x_batch[i, 0].item()
+        #         yv = y_full[0, j].item()
+        #         zv = z_bf16[i, j].item()
+        #         tv = tt_bf16[i, j].item()
+        #         ulp = ulp_dist[i, j].item()
+        #
+        #         xb = z_bf16.new_tensor(xv).view(torch.uint16).item()
+        #         yb = z_bf16.new_tensor(yv).view(torch.uint16).item()
+        #         zb = z_bits[i, j].item() & 0xFFFF
+        #         tb = tt_bits[i, j].item() & 0xFFFF
+        #
+        #         writer.writerow([batch_idx, x_idx, y_idx, xv, yv, zv, tv, ulp, xb, yb, zb, tb])
+
+        mismatch_mask = (ulp_dist > 1) & valid_mask
+        mismatch_count = mismatch_mask.sum().item()
+        total_mismatches += mismatch_count
+
+        if (batch_idx + 1) % 10 == 0 or batch_idx == num_batches - 1:
+            print(
+                f"Batch {batch_idx+1}/{num_batches}: max_ulp={max_ulp_batch}, mismatches={mismatch_count}, tested={valid_count}/{total_batch_pairs}"
+            )
+
+    # csv_file.close()
+    total_pairs = Nx * Ny
+    mismatch_pct = (total_mismatches / total_valid_pairs) * 100 if total_valid_pairs > 0 else 0.0
+    print(f"\n{'='*60}")
+    print(f"Valid Range Filter: |x/y| < 2^7 (128) for BF16")
+    print(f"Total input pairs: {total_pairs:,}")
+    print(f"Valid input pairs (|x/y| < 2^7): {total_valid_pairs:,} ({total_valid_pairs/total_pairs*100:.4f}%)")
+    print(f"Input pairs removed (|x/y| >= 2^7): {total_filtered_pairs:,} ({total_filtered_pairs/total_pairs*100:.4f}%)")
+    print(f"{'='*60}")
+    print(
+        f"Global max ULP: {max_ulp_global}, total mismatches: {total_mismatches}/{total_valid_pairs} ({mismatch_pct:.4f}%)"
+    )
+    print(f"\nULP Distribution (valid pairs only):")
+    print(
+        f"  ULP = 0: {ulp_0_count:,} ({ulp_0_count/total_valid_pairs*100:.4f}%)"
+        if total_valid_pairs > 0
+        else "  ULP = 0: 0 (N/A)"
+    )
+    print(
+        f"  ULP = 1: {ulp_1_count:,} ({ulp_1_count/total_valid_pairs*100:.4f}%)"
+        if total_valid_pairs > 0
+        else "  ULP = 1: 0 (N/A)"
+    )
+    print(
+        f"  ULP = 2: {ulp_2_count:,} ({ulp_2_count/total_valid_pairs*100:.4f}%)"
+        if total_valid_pairs > 0
+        else "  ULP = 2: 0 (N/A)"
+    )
+    print(
+        f"  ULP 3-10: {ulp_3_to_10_count:,} ({ulp_3_to_10_count/total_valid_pairs*100:.4f}%)"
+        if total_valid_pairs > 0
+        else "  ULP 3-10: 0 (N/A)"
+    )
+    print(
+        f"  ULP 11-100: {ulp_11_to_100_count:,} ({ulp_11_to_100_count/total_valid_pairs*100:.4f}%)"
+        if total_valid_pairs > 0
+        else "  ULP 11-100: 0 (N/A)"
+    )
+    print(
+        f"  ULP > 100: {ulp_above_100_count:,} ({ulp_above_100_count/total_valid_pairs*100:.4f}%)"
+        if total_valid_pairs > 0
+        else "  ULP > 100: 0 (N/A)"
+    )
+    # print(f"Mismatch details written to: {out_path_mismatch}")
+
+    # Comment out assertion for characterization test
+    # assert max_ulp_global <= 2, f"Max ULP {max_ulp_global} exceeds threshold 2"
+
+
+def _run_exhaustive_pairwise_mul_helper_float32(device, x_values, y_values, test_name, variant_name):
+    """Helper function to run exhaustive pairwise multiplication test in float32 precision.
+
+    Takes bfloat16 bit patterns as input, converts to float32, and performs multiplication in float32.
+    Computes ULP distance in float32 space.
+    """
+    ttnn_dtype = ttnn.float32
+
+    Nx = x_values.numel()
+    Ny = y_values.numel()
+    print(f"\n{'='*60}")
+    print(f"{test_name} (float32): Testing {Nx} × {Ny} = {Nx*Ny:,} pairs")
+
+    batch_size = 512  # process 512×Ny pairs at a time
+    num_batches = (Nx + batch_size - 1) // batch_size
+
+    max_ulp_global = 0
+    total_mismatches = 0
+    total_valid_pairs = 0  # Track total valid pairs after filtering
+    total_filtered_pairs = 0  # Track filtered out pairs
+
+    # Track ULP distribution
+    ulp_0_count = 0
+    ulp_1_count = 0
+    ulp_2_count = 0
+    ulp_3_to_10_count = 0
+    ulp_11_to_100_count = 0
+    ulp_above_100_count = 0
+
+    # # Open CSV for logging mismatches (variant-specific) - write outside repo
+    # out_dir = "/home/ubuntu/Files"
+    # os.makedirs(out_dir, exist_ok=True)
+    # out_path_mismatch = os.path.join(out_dir, f"mul_ulp_mismatch_exhaustive_{variant_name}_float32.csv")
+    # csv_file = open(out_path_mismatch, mode="w", newline="")
+    # writer = csv.writer(csv_file)
+    # writer.writerow(
+    #     [
+    #         "batch_idx",
+    #         "x_idx",
+    #         "y_idx",
+    #         "x_value",
+    #         "y_value",
+    #         "torch_out",
+    #         "tt_out",
+    #         "ulp_distance",
+    #         "x_bits_u32",
+    #         "y_bits_u32",
+    #         "torch_bits_u32",
+    #         "tt_bits_u32",
+    #     ]
+    # )
+
+    for batch_idx in range(num_batches):
+        start = batch_idx * batch_size
+        end = min(start + batch_size, Nx)
+
+        # Convert bfloat16 values to float32 for computation
+        # x_batch: [batch_size, 1], y: [1, Ny] → broadcasts to [batch_size, Ny]
+        x_batch_f32 = x_values[start:end].to(torch.float32).unsqueeze(1)  # shape: [B, 1]
+        y_full_f32 = y_values.to(torch.float32).unsqueeze(0)  # shape: [1, Ny]
+
+        # Filter valid range: |x/y| < 2^23 for FP32 precision
+        # This ensures the quotient can be represented accurately
+        quotient_threshold = 2**23  # 8,388,608 for FP32
+        total_batch_pairs = x_batch_f32.shape[0] * y_full_f32.shape[1]
+
+        with torch.no_grad():
+            # Compute |x/y| safely (avoid division by zero)
+            y_safe = torch.where(y_full_f32 == 0, torch.ones_like(y_full_f32), y_full_f32)
+            quotient_abs = (x_batch_f32 / y_safe).abs()
+            # Create valid mask (quotient within range and y is not zero)
+            valid_mask = (quotient_abs < quotient_threshold) & (y_full_f32 != 0)
+
+        valid_count = valid_mask.sum().item()
+
+        # Track valid/filtered pairs
+        total_valid_pairs += valid_count
+        total_filtered_pairs += total_batch_pairs - valid_count
+
+        # Compute fmod on full tensor (faster than extracting valid pairs)
+        z_torch = torch.fmod(x_batch_f32, y_full_f32)  # shape: [B, Ny]
+
+        # Send to backend using float32
+        x_tt = ttnn.from_torch(x_batch_f32, dtype=ttnn_dtype, layout=ttnn.TILE_LAYOUT, device=device)
+        y_tt = ttnn.from_torch(y_full_f32, dtype=ttnn_dtype, layout=ttnn.TILE_LAYOUT, device=device)
+        z_tt = ttnn.pow(x_tt, y_tt)
+        tt_out = ttnn.to_torch(z_tt)
+
+        # ULP check (use float32 space)
+        z_f32 = z_torch.to(torch.float32).contiguous()
+        tt_f32 = tt_out.to(torch.float32).contiguous()
+
+        # Flush subnormal float32 values to zero
+        # For float32, min normal is ~1.175494e-38
+        min_normal_threshold = torch.finfo(torch.float32).tiny
+        subnormal_mask = z_f32.abs() <= min_normal_threshold
+        z_f32[subnormal_mask] = 0.0
+        subnormal_mask_tt = tt_f32.abs() <= min_normal_threshold
+        tt_f32[subnormal_mask_tt] = 0.0
+
+        # Flush overflow values (greater than max normal or inf) to zero
+        # For float32, max normal is ~3.389531e38
+        max_normal_threshold = torch.finfo(torch.float32).max
+        overflow_mask = (z_f32.abs() > max_normal_threshold) | ~torch.isfinite(z_f32)
+        z_f32[overflow_mask] = 0.0
+        overflow_mask_tt = (tt_f32.abs() > max_normal_threshold) | ~torch.isfinite(tt_f32)
+        tt_f32[overflow_mask_tt] = 0.0
+
+        z_bits = z_f32.view(torch.int32)
+        tt_bits = tt_f32.view(torch.int32)
+
+        sign_z = (z_bits >> 31) & 1
+        sign_tt = (tt_bits >> 31) & 1
+        z_ord = torch.where(sign_z == 0, z_bits + 0x80000000, 0x80000000 - z_bits)
+        tt_ord = torch.where(sign_tt == 0, tt_bits + 0x80000000, 0x80000000 - tt_bits)
+        ulp_dist = (z_ord - tt_ord).abs()
+
+        # Only consider valid pairs for ULP statistics (masking approach - faster)
+        max_ulp_batch = ulp_dist[valid_mask].max().item() if valid_count > 0 else 0
+        max_ulp_global = max(max_ulp_global, max_ulp_batch)
+
+        # Count ULP distribution (only for valid pairs)
+        ulp_0_count += ((ulp_dist == 0) & valid_mask).sum().item()
+        ulp_1_count += ((ulp_dist == 1) & valid_mask).sum().item()
+        ulp_2_count += ((ulp_dist == 2) & valid_mask).sum().item()
+        ulp_3_to_10_count += ((ulp_dist >= 3) & (ulp_dist <= 10) & valid_mask).sum().item()
+        ulp_11_to_100_count += ((ulp_dist >= 11) & (ulp_dist <= 100) & valid_mask).sum().item()
+        ulp_above_100_count += ((ulp_dist > 100) & valid_mask).sum().item()
+
+        # Log mismatches (only for valid pairs)
+        mismatch_mask = (ulp_dist > 1) & valid_mask
+        mismatch_count = mismatch_mask.sum().item()
+        total_mismatches += mismatch_count
+
+        # if mismatch_count > 0:
+        #     # Get mismatch indices in [B, Ny] grid
+        #     mismatch_indices = mismatch_mask.nonzero(as_tuple=False)  # shape: [num_mismatches, 2]
+        #
+        #     for idx_pair in mismatch_indices:
+        #         i, j = idx_pair[0].item(), idx_pair[1].item()
+        #         x_idx = start + i
+        #         y_idx = j
+        #
+        #         xv = x_batch_f32[i, 0].item()
+        #         yv = y_full_f32[0, j].item()
+        #         zv = z_f32[i, j].item()
+        #         tv = tt_f32[i, j].item()
+        #         ulp = ulp_dist[i, j].item()
+        #
+        #         # Get bit representations as uint32
+        #         xb = z_f32.new_tensor(xv).view(torch.int32).item() & 0xFFFFFFFF
+        #         yb = z_f32.new_tensor(yv).view(torch.int32).item() & 0xFFFFFFFF
+        #         zb = z_bits[i, j].item() & 0xFFFFFFFF
+        #         tb = tt_bits[i, j].item() & 0xFFFFFFFF
+        #
+        #         writer.writerow([batch_idx, x_idx, y_idx, xv, yv, zv, tv, ulp, hex(xb), hex(yb), hex(zb), hex(tb)])
+
+        if (batch_idx + 1) % 10 == 0 or batch_idx == num_batches - 1:
+            print(
+                f"Batch {batch_idx+1}/{num_batches}: max_ulp={max_ulp_batch}, mismatches={mismatch_count}, tested={valid_count}/{total_batch_pairs}"
+            )
+
+    # csv_file.close()
+    total_pairs = Nx * Ny
+    mismatch_pct = (total_mismatches / total_valid_pairs) * 100 if total_valid_pairs > 0 else 0.0
+    print(f"\n{'='*60}")
+    print(f"Valid Range Filter: |x/y| < 2^23 (8,388,608) for FP32")
+    print(f"Total input pairs: {total_pairs:,}")
+    print(f"Valid input pairs (|x/y| < 2^23): {total_valid_pairs:,} ({total_valid_pairs/total_pairs*100:.4f}%)")
+    print(
+        f"Input pairs removed (|x/y| >= 2^23): {total_filtered_pairs:,} ({total_filtered_pairs/total_pairs*100:.4f}%)"
+    )
+    print(f"{'='*60}")
+    print(
+        f"Global max ULP: {max_ulp_global}, total mismatches: {total_mismatches}/{total_valid_pairs} ({mismatch_pct:.4f}%)"
+    )
+    print(f"\nULP Distribution (valid pairs only):")
+    print(
+        f"  ULP = 0: {ulp_0_count:,} ({ulp_0_count/total_valid_pairs*100:.4f}%)"
+        if total_valid_pairs > 0
+        else "  ULP = 0: 0 (N/A)"
+    )
+    print(
+        f"  ULP = 1: {ulp_1_count:,} ({ulp_1_count/total_valid_pairs*100:.4f}%)"
+        if total_valid_pairs > 0
+        else "  ULP = 1: 0 (N/A)"
+    )
+    print(
+        f"  ULP = 2: {ulp_2_count:,} ({ulp_2_count/total_valid_pairs*100:.4f}%)"
+        if total_valid_pairs > 0
+        else "  ULP = 2: 0 (N/A)"
+    )
+    print(
+        f"  ULP 3-10: {ulp_3_to_10_count:,} ({ulp_3_to_10_count/total_valid_pairs*100:.4f}%)"
+        if total_valid_pairs > 0
+        else "  ULP 3-10: 0 (N/A)"
+    )
+    print(
+        f"  ULP 11-100: {ulp_11_to_100_count:,} ({ulp_11_to_100_count/total_valid_pairs*100:.4f}%)"
+        if total_valid_pairs > 0
+        else "  ULP 11-100: 0 (N/A)"
+    )
+    print(
+        f"  ULP > 100: {ulp_above_100_count:,} ({ulp_above_100_count/total_valid_pairs*100:.4f}%)"
+        if total_valid_pairs > 0
+        else "  ULP > 100: 0 (N/A)"
+    )
+    # print(f"Mismatch details written to: {out_path_mismatch}")
+
+    # Comment out assertion for characterization test
+    # assert max_ulp_global <= 2, f"Max ULP {max_ulp_global} exceeds threshold 2"
+
+
+# FP32 exhaustive tests
+def test_mul_tt_FP32_exhaustive_pos_pos(device):
+    """Test positive × positive normal fp32 values."""
+    torch.manual_seed(0)
+
+    # Generate all possible bf16 values
+    all_bitpatterns = torch.arange(0, 2**16, dtype=torch.int32).to(torch.uint16)
+    vals = all_bitpatterns.view(torch.bfloat16)
+
+    # Keep only finite, non-zero, positive normal bf16 values
+    tiny = torch.finfo(torch.bfloat16).tiny
+    # tiny = 1e-18  # Use 1e-18 as lower bound instead of bfloat16 min normal
+    mask = torch.isfinite(vals) & (vals > 0) & (vals >= tiny)
+
+    pos_values = vals[mask]  # ~32512 positive normal values
+    _run_exhaustive_pairwise_mul_helper_float32(device, pos_values, pos_values, "Positive × Positive", "pos_pos")
+
+
+def test_mul_tt_FP32_exhaustive_pos_neg(device):
+    """Test positive × negative normal bf16 values."""
+    torch.manual_seed(0)
+
+    # Generate all possible bf16 values
+    all_bitpatterns = torch.arange(0, 2**16, dtype=torch.int32).to(torch.uint16)
+    vals = all_bitpatterns.view(torch.bfloat16)
+
+    # Keep only finite, non-zero, normal bf16 values
+    tiny = torch.finfo(torch.bfloat16).tiny
+    # tiny = 1e-18  # Use 1e-18 as lower bound for absolute value
+    pos_mask = torch.isfinite(vals) & (vals > 0) & (vals >= tiny)
+    neg_mask = torch.isfinite(vals) & (vals < 0) & (vals.abs() >= tiny)
+
+    pos_values = vals[pos_mask]  # ~32512 positive normal values
+    neg_values = vals[neg_mask]  # ~32512 negative normal values
+    _run_exhaustive_pairwise_mul_helper_float32(device, pos_values, neg_values, "Positive × Negative", "pos_neg")
+
+
+def test_mul_tt_FP32_exhaustive_neg_pos(device):
+    """Test negative × positive normal bf16 values."""
+    torch.manual_seed(0)
+
+    # Generate all possible bf16 values
+    all_bitpatterns = torch.arange(0, 2**16, dtype=torch.int32).to(torch.uint16)
+    vals = all_bitpatterns.view(torch.bfloat16)
+
+    # Keep only finite, non-zero, normal bf16 values
+    tiny = torch.finfo(torch.bfloat16).tiny
+    # tiny = 1e-18  # Use 1e-18 as lower bound for absolute value
+    pos_mask = torch.isfinite(vals) & (vals > 0) & (vals >= tiny)
+    neg_mask = torch.isfinite(vals) & (vals < 0) & (vals.abs() >= tiny)
+
+    pos_values = vals[pos_mask]  # ~32512 positive normal values
+    neg_values = vals[neg_mask]  # ~32512 negative normal values
+    _run_exhaustive_pairwise_mul_helper_float32(device, neg_values, pos_values, "Negative × Positive", "neg_pos")
+
+
+def test_mul_tt_FP32_exhaustive_neg_neg(device):
+    """Test negative × negative normal bf16 values."""
+    torch.manual_seed(0)
+
+    # Generate all possible bf16 values
+    all_bitpatterns = torch.arange(0, 2**16, dtype=torch.int32).to(torch.uint16)
+    vals = all_bitpatterns.view(torch.bfloat16)
+
+    # Keep only finite, non-zero, negative normal bf16 values
+    tiny = torch.finfo(torch.bfloat16).tiny
+    # tiny = 1e-18  # Use 1e-18 as lower bound for absolute value
+    mask = torch.isfinite(vals) & (vals < 0) & (vals.abs() >= tiny)
+
+    neg_values = vals[mask]  # ~32512 negative normal values
+    _run_exhaustive_pairwise_mul_helper_float32(device, neg_values, neg_values, "Negative × Negative", "neg_neg")
+
+
+def test_fmod_tt_FP32_exhaustive_test(device):
+    """Test fp32 values."""
+    import io
+    import sys
+    from datetime import datetime
+
+    # Tee class to write to both terminal and buffer
+    class Tee:
+        def __init__(self, *streams):
+            self.streams = streams
+
+        def write(self, data):
+            for s in self.streams:
+                s.write(data)
+                s.flush()
+
+        def flush(self):
+            for s in self.streams:
+                s.flush()
+
+    # Capture stdout while still printing to terminal
+    captured_output = io.StringIO()
+    original_stdout = sys.stdout
+    sys.stdout = Tee(original_stdout, captured_output)
+
+    try:
+        test_mul_tt_FP32_exhaustive_pos_pos(device)
+        test_mul_tt_FP32_exhaustive_pos_neg(device)
+        test_mul_tt_FP32_exhaustive_neg_pos(device)
+        test_mul_tt_FP32_exhaustive_neg_neg(device)
+    finally:
+        sys.stdout = original_stdout
+
+    # Get captured content
+    output_content = captured_output.getvalue()
+
+    # Write to file
+    out_dir = "/home/ubuntu/Files"
+    os.makedirs(out_dir, exist_ok=True)
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    out_path = os.path.join(out_dir, f"pow_fp32_exhaustive_results_{timestamp}.txt")
+    with open(out_path, "w") as f:
+        f.write(output_content)
+
+    print(f"\n{'='*60}")
+    print(f"All results saved to: {out_path}")
+    print(f"{'='*60}")
+
+
+# BF16 Exhaustive tests
+def test_fmod_tt_bf16_exhaustive_pos_pos(device):
+    """Test positive × positive normal fp32 values."""
+    torch.manual_seed(0)
+
+    # Generate all possible bf16 values
+    all_bitpatterns = torch.arange(0, 2**16, dtype=torch.int32).to(torch.uint16)
+    vals = all_bitpatterns.view(torch.bfloat16)
+
+    # Keep only finite, non-zero, positive normal bf16 values
+    tiny = torch.finfo(torch.bfloat16).tiny
+    # tiny = 1e-18  # Use 1e-18 as lower bound instead of bfloat16 min normal
+    mask = torch.isfinite(vals) & (vals > 0) & (vals >= tiny)
+
+    pos_values = vals[mask]  # ~32512 positive normal values
+    _run_exhaustive_pairwise_mul_helper(device, pos_values, pos_values, "Positive × Positive", "pos_pos")
+
+
+def test_fmod_tt_bf16_exhaustive_pos_neg(device):
+    """Test positive × negative normal bf16 values."""
+    torch.manual_seed(0)
+
+    # Generate all possible bf16 values
+    all_bitpatterns = torch.arange(0, 2**16, dtype=torch.int32).to(torch.uint16)
+    vals = all_bitpatterns.view(torch.bfloat16)
+
+    # Keep only finite, non-zero, normal bf16 values
+    tiny = torch.finfo(torch.bfloat16).tiny
+    # tiny = 1e-18  # Use 1e-18 as lower bound for absolute value
+    pos_mask = torch.isfinite(vals) & (vals > 0) & (vals >= tiny)
+    neg_mask = torch.isfinite(vals) & (vals < 0) & (vals.abs() >= tiny)
+
+    pos_values = vals[pos_mask]  # ~32512 positive normal values
+    neg_values = vals[neg_mask]  # ~32512 negative normal values
+    _run_exhaustive_pairwise_mul_helper(device, pos_values, neg_values, "Positive × Negative", "pos_neg")
+
+
+def test_fmod_tt_bf16_exhaustive_neg_pos(device):
+    """Test negative × positive normal bf16 values."""
+    torch.manual_seed(0)
+
+    # Generate all possible bf16 values
+    all_bitpatterns = torch.arange(0, 2**16, dtype=torch.int32).to(torch.uint16)
+    vals = all_bitpatterns.view(torch.bfloat16)
+
+    # Keep only finite, non-zero, normal bf16 values
+    tiny = torch.finfo(torch.bfloat16).tiny
+    # tiny = 1e-18  # Use 1e-18 as lower bound for absolute value
+    pos_mask = torch.isfinite(vals) & (vals > 0) & (vals >= tiny)
+    neg_mask = torch.isfinite(vals) & (vals < 0) & (vals.abs() >= tiny)
+
+    pos_values = vals[pos_mask]  # ~32512 positive normal values
+    neg_values = vals[neg_mask]  # ~32512 negative normal values
+    _run_exhaustive_pairwise_mul_helper(device, neg_values, pos_values, "Negative × Positive", "neg_pos")
+
+
+def test_fmod_tt_bf16_exhaustive_neg_neg(device):
+    """Test negative × negative normal bf16 values."""
+    torch.manual_seed(0)
+
+    # Generate all possible bf16 values
+    all_bitpatterns = torch.arange(0, 2**16, dtype=torch.int32).to(torch.uint16)
+    vals = all_bitpatterns.view(torch.bfloat16)
+
+    # Keep only finite, non-zero, negative normal bf16 values
+    tiny = torch.finfo(torch.bfloat16).tiny
+    # tiny = 1e-18  # Use 1e-18 as lower bound for absolute value
+    mask = torch.isfinite(vals) & (vals < 0) & (vals.abs() >= tiny)
+
+    neg_values = vals[mask]  # ~32512 negative normal values
+    _run_exhaustive_pairwise_mul_helper(device, neg_values, neg_values, "Negative × Negative", "neg_neg")
+
+
+def test_fmod_tt_BF16_exhaustive_test(device):
+    """Test BF16 values."""
+    import io
+    import sys
+    from datetime import datetime
+
+    # Tee class to write to both terminal and buffer
+    class Tee:
+        def __init__(self, *streams):
+            self.streams = streams
+
+        def write(self, data):
+            for s in self.streams:
+                s.write(data)
+                s.flush()
+
+        def flush(self):
+            for s in self.streams:
+                s.flush()
+
+    # Capture stdout while still printing to terminal
+    captured_output = io.StringIO()
+    original_stdout = sys.stdout
+    sys.stdout = Tee(original_stdout, captured_output)
+
+    try:
+        test_fmod_tt_bf16_exhaustive_pos_pos(device)
+        test_fmod_tt_bf16_exhaustive_pos_neg(device)
+        test_fmod_tt_bf16_exhaustive_neg_pos(device)
+        test_fmod_tt_bf16_exhaustive_neg_neg(device)
+    finally:
+        sys.stdout = original_stdout
+
+    # Get captured content
+    output_content = captured_output.getvalue()
+
+    # Write to file
+    out_dir = "/home/ubuntu/Files"
+    os.makedirs(out_dir, exist_ok=True)
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    out_path = os.path.join(out_dir, f"pow_bf16_exhaustive_results_{timestamp}.txt")
+    with open(out_path, "w") as f:
+        f.write(output_content)
+
+    print(f"\n{'='*60}")
+    print(f"All results saved to: {out_path}")
+    print(f"{'='*60}")
+
+
+def test_binary_fp32(device, low=-1e-20, high=1e20):
+    torch.manual_seed(0)
+    torch_dtype = torch.float32
+    ttnn_dtype = ttnn.float32
+    x_torch = torch.rand([1, 12288], dtype=torch_dtype) * (high - low) + low
+    y_torch = torch.rand([1, 1], dtype=torch_dtype) * (high - low) + low
+    z_torch = torch.mul(x_torch, y_torch)
+    x_tt = ttnn.from_torch(x_torch, dtype=ttnn_dtype, layout=ttnn.TILE_LAYOUT, device=device)
+    y_tt = ttnn.from_torch(y_torch, dtype=ttnn_dtype, layout=ttnn.TILE_LAYOUT, device=device)
+    z_tt = ttnn.mul(x_tt, y_tt)
+    tt_out = ttnn.to_torch(z_tt)
+
+    # Calculate ULP distance
+    z_f32 = z_torch.to(torch.float32).contiguous()
+    tt_f32 = tt_out.to(torch.float32).contiguous()
+
+    # Check for non-finite values first
+    z_nonfinite = ~torch.isfinite(z_f32)
+    tt_nonfinite = ~torch.isfinite(tt_f32)
+    nonfinite_count = (z_nonfinite | tt_nonfinite).sum().item()
+
+    print(f"\n=== Diagnostics ===")
+    print(f"Total elements: {z_f32.numel()}")
+    print(f"Non-finite in torch output: {z_nonfinite.sum().item()}")
+    print(f"Non-finite in ttnn output: {tt_nonfinite.sum().item()}")
+    print(f"Total non-finite: {nonfinite_count}")
+
+    # Print some example values
+    print(f"\nInput x_torch range: [{x_torch.min().item():.6e}, {x_torch.max().item():.6e}]")
+    print(f"Input y_torch range: [{y_torch.min().item():.6e}, {y_torch.max().item():.6e}]")
+    print(
+        f"Output z_torch range: [{z_f32[torch.isfinite(z_f32)].min().item() if torch.isfinite(z_f32).any() else float('nan'):.6e}, {z_f32[torch.isfinite(z_f32)].max().item() if torch.isfinite(z_f32).any() else float('nan'):.6e}] (finite only)"
+    )
+    print(
+        f"Output tt_out range: [{tt_f32[torch.isfinite(tt_f32)].min().item() if torch.isfinite(tt_f32).any() else float('nan'):.6e}, {tt_f32[torch.isfinite(tt_f32)].max().item() if torch.isfinite(tt_f32).any() else float('nan'):.6e}] (finite only)"
+    )
+
+    # Print first 10 values
+    print(f"\nFirst 10 x values: {x_torch[0, :10].tolist()}")
+    print(f"First 10 y values: {y_torch[:10].tolist()}")
+    print(f"First 10 z_torch values: {z_f32[0, :10].tolist()}")
+    print(f"First 10 tt_out values: {tt_f32[0, :10].tolist()}")
+
+    z_bits = z_f32.view(torch.int32)
+    tt_bits = tt_f32.view(torch.int32)
+
+    sign_z = (z_bits >> 31) & 1
+    sign_tt = (tt_bits >> 31) & 1
+    z_ord = torch.where(sign_z == 0, z_bits + 0x80000000, 0x80000000 - z_bits)
+    tt_ord = torch.where(sign_tt == 0, tt_bits + 0x80000000, 0x80000000 - tt_bits)
+    ulp_dist = (z_ord - tt_ord).abs()
+
+    # Find mismatches (ULP > 1) - only check finite values
+    finite_mask = torch.isfinite(z_f32) & torch.isfinite(tt_f32)
+    mismatch_mask = (ulp_dist > 1) & finite_mask
+    mismatch_count = mismatch_mask.sum().item()
+
+    print(f"\nFinite values: {finite_mask.sum().item()}")
+    print(f"Mismatches (ULP > 1) in finite values: {mismatch_count}")
+
+    if mismatch_count > 0:
+        # Write mismatches to CSV
+        out_dir = os.path.dirname(__file__)
+        out_path = os.path.join(out_dir, "mul_binary_fp32_mismatchBH.csv")
+        csv_file = open(out_path, mode="w", newline="")
+        writer = csv.writer(csv_file)
+        writer.writerow(
+            [
+                "index",
+                "input_A",
+                "input_B",
+                "torch_output",
+                "ttnn_output",
+                "ulp_distance",
+                "input_A_bits_u32",
+                "input_B_bits_u32",
+                "torch_output_bits_u32",
+                "ttnn_output_bits_u32",
+            ]
+        )
+
+        # Get mismatch indices
+        mismatch_indices = mismatch_mask.nonzero(as_tuple=False)  # shape: [num_mismatches, 2]
+
+        for idx_pair in mismatch_indices:
+            i, j = idx_pair[0].item(), idx_pair[1].item()
+
+            x_val = x_torch[i, j].item()
+            y_val = y_torch[j].item()
+            z_val = z_f32[i, j].item()
+            tt_val = tt_f32[i, j].item()
+            ulp = ulp_dist[i, j].item()
+
+            # Get bit representations as uint32
+            x_bits = z_f32.new_tensor(x_val).view(torch.int32).item() & 0xFFFFFFFF
+            y_bits = z_f32.new_tensor(y_val).view(torch.int32).item() & 0xFFFFFFFF
+            z_bits_val = z_bits[i, j].item() & 0xFFFFFFFF
+            tt_bits_val = tt_bits[i, j].item() & 0xFFFFFFFF
+
+            writer.writerow(
+                [
+                    f"({i},{j})",
+                    x_val,
+                    y_val,
+                    z_val,
+                    tt_val,
+                    ulp,
+                    hex(x_bits),
+                    hex(y_bits),
+                    hex(z_bits_val),
+                    hex(tt_bits_val),
+                ]
+            )
+
+        csv_file.close()
+        print(f"Found {mismatch_count} mismatches (ULP > 1), written to {out_path}")
+    else:
+        print("No mismatches found (all ULP <= 1)")
+
+    # torch.set_printoptions(linewidth=200, threshold = 10000 , precision=15, sci_mode = False, edgeitems=17)
+    # print("z_tt", z_tt)
+    # print("tt_out", tt_out)
+    # print("z_torch", z_torch)
+
+    # Allow non-finite values if both outputs agree on them
+    assert_with_ulp(z_torch, tt_out, 1, allow_nonfinite=True)

--- a/tests/ttnn/unit_tests/operations/eltwise/test_unary_pow_accuracy.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_unary_pow_accuracy.py
@@ -1,0 +1,595 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+import os
+import csv
+import pytest
+import ttnn
+import numpy as np
+import matplotlib.pyplot as plt
+from tests.ttnn.utils_for_testing import assert_with_ulp, flush_subnormal_values_to_zero
+
+# BF16
+# pytest /home/ubuntu/tt-metal/tests/ttnn/unit_tests/operations/eltwise/test_unary_pow_accuracy.py::test_pow_tt_BF16_exhaustive_test
+
+# FP32
+# pytest /home/ubuntu/tt-metal/tests/ttnn/unit_tests/operations/eltwise/test_unary_pow_accuracy.py::test_pow_tt_FP32_exhaustive_test
+
+
+def _run_exhaustive_unary_pow_helper_exhaustive_exponents(
+    device,
+    base_values,
+    exponent_values,
+    test_name,
+    variant_name,
+    max_skipped_samples=10,
+    progress_every=10,
+):
+    """Exhaustive unary pow: sweep over all base_values and all exponent_values.
+
+    Uses binary ttnn.pow(base_tensor, exponent_tensor) with shapes [B, 1] and [1, N_exp]
+    so each device launch covers B×N_exp pairs (same batching strategy as fmod test).
+    Pairs where the torch (reference) result is NaN or Inf are SKIPPED from accuracy
+    comparison.
+    """
+    ttnn_dtype = ttnn.bfloat16
+    N_base = base_values.numel()
+    N_exp = exponent_values.numel()
+    total_pairs = N_base * N_exp
+    print(f"\n{'='*60}")
+    print(f"{test_name}: Testing {N_base:,} bases × {N_exp:,} exponents = {total_pairs:,} pairs")
+
+    batch_size = 512
+    num_batches = (N_base + batch_size - 1) // batch_size
+
+    max_ulp_global = 0
+    total_mismatches = 0
+    total_valid_pairs = 0
+    total_skipped_pairs = 0
+    ulp_0_count = 0
+    ulp_1_count = 0
+    ulp_2_count = 0
+    ulp_3_to_10_count = 0
+    ulp_11_to_100_count = 0
+    ulp_above_100_count = 0
+    skipped_samples = []
+
+    # Broadcast: base [B, 1], exponent [1, N_exp] -> one kernel per base batch
+    exp_full = exponent_values.unsqueeze(0).clone()  # [1, N_exp]
+    # Flush input exponents: subnormal and non-finite to zero (once, reused for all batches)
+    flush_subnormal_values_to_zero(exp_full)
+    exp_full[~torch.isfinite(exp_full)] = 0.0
+
+    for batch_idx in range(num_batches):
+        start = batch_idx * batch_size
+        end = min(start + batch_size, N_base)
+        x_batch = base_values[start:end].unsqueeze(1).clone()  # [B, 1]
+        # Flush input bases: subnormal and non-finite to zero
+        flush_subnormal_values_to_zero(x_batch)
+        x_batch[~torch.isfinite(x_batch)] = 0.0
+        z_torch = torch.pow(x_batch, exp_full)  # [B, N_exp]
+
+        x_tt = ttnn.from_torch(x_batch, dtype=ttnn_dtype, layout=ttnn.TILE_LAYOUT, device=device)
+        exp_tt = ttnn.from_torch(exp_full, dtype=ttnn_dtype, layout=ttnn.TILE_LAYOUT, device=device)
+        z_tt = ttnn.pow(x_tt, exp_tt)
+        tt_out = ttnn.to_torch(z_tt)
+
+        z_bf16 = z_torch.to(torch.bfloat16).contiguous()
+        tt_bf16 = tt_out.to(torch.bfloat16).contiguous()
+        valid_mask = torch.isfinite(z_bf16)
+        skipped_mask = ~valid_mask
+        total_skipped_pairs += skipped_mask.sum().item()
+
+        if skipped_mask.any() and len(skipped_samples) < max_skipped_samples:
+            skipped_indices = skipped_mask.nonzero(as_tuple=False)
+            for idx_pair in skipped_indices:
+                if len(skipped_samples) >= max_skipped_samples:
+                    break
+                i, j = idx_pair[0].item(), idx_pair[1].item()
+                reason = "NaN" if torch.isnan(z_bf16[i, j]) else ("+Inf" if z_bf16[i, j] > 0 else "-Inf")
+                skipped_samples.append(
+                    {
+                        "base": x_batch[i, 0].item(),
+                        "exponent": exp_full[0, j].item(),
+                        "torch_result": z_bf16[i, j].item(),
+                        "ttnn_result": tt_bf16[i, j].item(),
+                        "skip_reason": reason,
+                        "category": variant_name,
+                    }
+                )
+
+        # Flush subnormal and non-finite (outputs) to zero
+        flush_subnormal_values_to_zero(z_bf16)
+        flush_subnormal_values_to_zero(tt_bf16)
+        z_bf16[~torch.isfinite(z_bf16)] = 0.0
+        tt_bf16[~torch.isfinite(tt_bf16)] = 0.0
+
+        z_bits = z_bf16.view(torch.uint16).to(torch.int32)
+        tt_bits = tt_bf16.view(torch.uint16).to(torch.int32)
+        sign_z = (z_bits >> 15) & 1
+        sign_tt = (tt_bits >> 15) & 1
+        z_ord = torch.where(sign_z == 0, z_bits + 0x8000, 0x8000 - z_bits)
+        tt_ord = torch.where(sign_tt == 0, tt_bits + 0x8000, 0x8000 - tt_bits)
+        ulp_dist = (z_ord - tt_ord).abs()
+        valid_count = valid_mask.sum().item()
+        max_ulp_batch = ulp_dist[valid_mask].max().item() if valid_count > 0 else 0
+        max_ulp_global = max(max_ulp_global, max_ulp_batch)
+        ulp_0_count += ((ulp_dist == 0) & valid_mask).sum().item()
+        ulp_1_count += ((ulp_dist == 1) & valid_mask).sum().item()
+        ulp_2_count += ((ulp_dist == 2) & valid_mask).sum().item()
+        ulp_3_to_10_count += ((ulp_dist >= 3) & (ulp_dist <= 10) & valid_mask).sum().item()
+        ulp_11_to_100_count += ((ulp_dist >= 11) & (ulp_dist <= 100) & valid_mask).sum().item()
+        ulp_above_100_count += ((ulp_dist > 100) & valid_mask).sum().item()
+        mismatch_count = ((ulp_dist > 1) & valid_mask).sum().item()
+        total_mismatches += mismatch_count
+        total_valid_pairs += valid_count
+        total_batch_pairs = x_batch.shape[0] * exp_full.shape[1]
+
+        if progress_every and ((batch_idx + 1) % progress_every == 0 or batch_idx == num_batches - 1):
+            print(
+                f"  Batch {batch_idx+1}/{num_batches}: max_ulp={max_ulp_batch}, mismatches={mismatch_count}, tested={valid_count}/{total_batch_pairs}"
+            )
+
+    mismatch_pct = (total_mismatches / total_valid_pairs) * 100 if total_valid_pairs > 0 else 0.0
+    skipped_pct = (total_skipped_pairs / total_pairs) * 100 if total_pairs > 0 else 0.0
+    print(f"\n{'='*60}")
+    # print(f"Valid (torch finite): pairs used for ULP; skipped (torch NaN/Inf) excluded")
+    print(f"Total input pairs: {total_pairs:,}")
+    print(f"Valid pairs (torch finite): {total_valid_pairs:,} ({total_valid_pairs/total_pairs*100:.4f}%)")
+    print(f"Skipped pairs (torch NaN/Inf): {total_skipped_pairs:,} ({skipped_pct:.4f}%)")
+    print(f"{'='*60}")
+    print(
+        f"Global max ULP: {max_ulp_global}, total mismatches: {total_mismatches}/{total_valid_pairs} ({mismatch_pct:.4f}%)"
+    )
+    print(f"\nULP Distribution (valid pairs only):")
+    print(
+        f"  ULP = 0: {ulp_0_count:,} ({ulp_0_count/total_valid_pairs*100:.4f}%)"
+        if total_valid_pairs > 0
+        else "  ULP = 0: 0 (N/A)"
+    )
+    print(
+        f"  ULP = 1: {ulp_1_count:,} ({ulp_1_count/total_valid_pairs*100:.4f}%)"
+        if total_valid_pairs > 0
+        else "  ULP = 1: 0 (N/A)"
+    )
+    print(
+        f"  ULP = 2: {ulp_2_count:,} ({ulp_2_count/total_valid_pairs*100:.4f}%)"
+        if total_valid_pairs > 0
+        else "  ULP = 2: 0 (N/A)"
+    )
+    print(
+        f"  ULP 3-10: {ulp_3_to_10_count:,} ({ulp_3_to_10_count/total_valid_pairs*100:.4f}%)"
+        if total_valid_pairs > 0
+        else "  ULP 3-10: 0 (N/A)"
+    )
+    print(
+        f"  ULP 11-100: {ulp_11_to_100_count:,} ({ulp_11_to_100_count/total_valid_pairs*100:.4f}%)"
+        if total_valid_pairs > 0
+        else "  ULP 11-100: 0 (N/A)"
+    )
+    print(
+        f"  ULP > 100: {ulp_above_100_count:,} ({ulp_above_100_count/total_valid_pairs*100:.4f}%)"
+        if total_valid_pairs > 0
+        else "  ULP > 100: 0 (N/A)"
+    )
+    print(f"Skipped samples collected: {len(skipped_samples)}")
+    return skipped_samples
+
+
+def _run_exhaustive_unary_pow_helper_float32_exhaustive_exponents(
+    device,
+    base_values,
+    exponent_values,
+    test_name,
+    variant_name,
+    max_skipped_samples=10,
+    progress_every=10,
+):
+    """Exhaustive unary pow in float32: all base_values × all exponent_values.
+
+    Uses binary ttnn.pow(base_tensor, exponent_tensor) with shapes [B, 1] and [1, N_exp]
+    so each device launch covers B×N_exp pairs (same batching as fmod test).
+    Pairs where the torch (reference) result is NaN or Inf are SKIPPED from accuracy
+    comparison.
+    """
+    ttnn_dtype = ttnn.float32
+    N_base = base_values.numel()
+    N_exp = exponent_values.numel()
+    total_pairs = N_base * N_exp
+    print(f"\n{'='*60}")
+    print(f"{test_name} (float32): Testing {N_base:,} bases × {N_exp:,} exponents = {total_pairs:,} pairs ")
+
+    batch_size = 512
+    num_batches = (N_base + batch_size - 1) // batch_size
+
+    max_ulp_global = 0
+    total_mismatches = 0
+    total_valid_pairs = 0
+    total_skipped_pairs = 0
+    ulp_0_count = 0
+    ulp_1_count = 0
+    ulp_2_count = 0
+    ulp_3_to_10_count = 0
+    ulp_11_to_100_count = 0
+    ulp_above_100_count = 0
+    skipped_samples = []
+
+    exp_full = exponent_values.to(torch.float32).unsqueeze(0).clone()  # [1, N_exp]
+    # Flush input exponents: subnormal and non-finite to zero (once, reused for all batches)
+    flush_subnormal_values_to_zero(exp_full)
+    exp_full[~torch.isfinite(exp_full)] = 0.0
+
+    for batch_idx in range(num_batches):
+        start = batch_idx * batch_size
+        end = min(start + batch_size, N_base)
+        x_batch_f32 = base_values[start:end].to(torch.float32).unsqueeze(1).clone()  # [B, 1]
+        # Flush input bases: subnormal and non-finite to zero
+        flush_subnormal_values_to_zero(x_batch_f32)
+        x_batch_f32[~torch.isfinite(x_batch_f32)] = 0.0
+        z_torch = torch.pow(x_batch_f32, exp_full)  # [B, N_exp]
+
+        x_tt = ttnn.from_torch(x_batch_f32, dtype=ttnn_dtype, layout=ttnn.TILE_LAYOUT, device=device)
+        exp_tt = ttnn.from_torch(exp_full, dtype=ttnn_dtype, layout=ttnn.TILE_LAYOUT, device=device)
+        z_tt = ttnn.pow(x_tt, exp_tt)
+        tt_out = ttnn.to_torch(z_tt)
+
+        z_f32 = z_torch.to(torch.float32).contiguous()
+        tt_f32 = tt_out.to(torch.float32).contiguous()
+        valid_mask = torch.isfinite(z_f32)
+        skipped_mask = ~valid_mask
+        total_skipped_pairs += skipped_mask.sum().item()
+
+        if skipped_mask.any() and len(skipped_samples) < max_skipped_samples:
+            skipped_indices = skipped_mask.nonzero(as_tuple=False)
+            for idx_pair in skipped_indices:
+                if len(skipped_samples) >= max_skipped_samples:
+                    break
+                i, j = idx_pair[0].item(), idx_pair[1].item()
+                reason = "NaN" if torch.isnan(z_f32[i, j]) else ("+Inf" if z_f32[i, j] > 0 else "-Inf")
+                skipped_samples.append(
+                    {
+                        "base": x_batch_f32[i, 0].item(),
+                        "exponent": exp_full[0, j].item(),
+                        "torch_result": z_f32[i, j].item(),
+                        "ttnn_result": tt_f32[i, j].item(),
+                        "skip_reason": reason,
+                        "category": variant_name,
+                    }
+                )
+
+        # Flush subnormal and non-finite (outputs) to zero
+        flush_subnormal_values_to_zero(z_f32)
+        flush_subnormal_values_to_zero(tt_f32)
+        z_f32[~torch.isfinite(z_f32)] = 0.0
+        tt_f32[~torch.isfinite(tt_f32)] = 0.0
+
+        z_bits = z_f32.view(torch.int32)
+        tt_bits = tt_f32.view(torch.int32)
+        sign_z = (z_bits >> 31) & 1
+        sign_tt = (tt_bits >> 31) & 1
+        z_ord = torch.where(sign_z == 0, z_bits + 0x80000000, 0x80000000 - z_bits)
+        tt_ord = torch.where(sign_tt == 0, tt_bits + 0x80000000, 0x80000000 - tt_bits)
+        ulp_dist = (z_ord - tt_ord).abs()
+        valid_count = valid_mask.sum().item()
+        max_ulp_batch = ulp_dist[valid_mask].max().item() if valid_count > 0 else 0
+        max_ulp_global = max(max_ulp_global, max_ulp_batch)
+        ulp_0_count += ((ulp_dist == 0) & valid_mask).sum().item()
+        ulp_1_count += ((ulp_dist == 1) & valid_mask).sum().item()
+        ulp_2_count += ((ulp_dist == 2) & valid_mask).sum().item()
+        ulp_3_to_10_count += ((ulp_dist >= 3) & (ulp_dist <= 10) & valid_mask).sum().item()
+        ulp_11_to_100_count += ((ulp_dist >= 11) & (ulp_dist <= 100) & valid_mask).sum().item()
+        ulp_above_100_count += ((ulp_dist > 100) & valid_mask).sum().item()
+        mismatch_count = ((ulp_dist > 1) & valid_mask).sum().item()
+        total_mismatches += mismatch_count
+        total_valid_pairs += valid_count
+        total_batch_pairs = x_batch_f32.shape[0] * exp_full.shape[1]
+
+        if progress_every and ((batch_idx + 1) % progress_every == 0 or batch_idx == num_batches - 1):
+            print(
+                f"  Batch {batch_idx+1}/{num_batches}: max_ulp={max_ulp_batch}, mismatches={mismatch_count}, tested={valid_count}/{total_batch_pairs}"
+            )
+
+    mismatch_pct = (total_mismatches / total_valid_pairs) * 100 if total_valid_pairs > 0 else 0.0
+    skipped_pct = (total_skipped_pairs / total_pairs) * 100 if total_pairs > 0 else 0.0
+    print(f"\n{'='*60}")
+    # print(f"Valid (torch finite): pairs used for ULP; skipped (torch NaN/Inf) excluded")
+    print(f"Total input pairs: {total_pairs:,}")
+    print(f"Valid pairs (torch finite): {total_valid_pairs:,} ({total_valid_pairs/total_pairs*100:.4f}%)")
+    print(f"Skipped pairs (torch NaN/Inf): {total_skipped_pairs:,} ({skipped_pct:.4f}%)")
+    print(f"{'='*60}")
+    print(
+        f"Global max ULP: {max_ulp_global}, total mismatches: {total_mismatches}/{total_valid_pairs} ({mismatch_pct:.4f}%)"
+    )
+    print(f"\nULP Distribution (valid pairs only):")
+    print(
+        f"  ULP = 0: {ulp_0_count:,} ({ulp_0_count/total_valid_pairs*100:.4f}%)"
+        if total_valid_pairs > 0
+        else "  ULP = 0: 0 (N/A)"
+    )
+    print(
+        f"  ULP = 1: {ulp_1_count:,} ({ulp_1_count/total_valid_pairs*100:.4f}%)"
+        if total_valid_pairs > 0
+        else "  ULP = 1: 0 (N/A)"
+    )
+    print(
+        f"  ULP = 2: {ulp_2_count:,} ({ulp_2_count/total_valid_pairs*100:.4f}%)"
+        if total_valid_pairs > 0
+        else "  ULP = 2: 0 (N/A)"
+    )
+    print(
+        f"  ULP 3-10: {ulp_3_to_10_count:,} ({ulp_3_to_10_count/total_valid_pairs*100:.4f}%)"
+        if total_valid_pairs > 0
+        else "  ULP 3-10: 0 (N/A)"
+    )
+    print(
+        f"  ULP 11-100: {ulp_11_to_100_count:,} ({ulp_11_to_100_count/total_valid_pairs*100:.4f}%)"
+        if total_valid_pairs > 0
+        else "  ULP 11-100: 0 (N/A)"
+    )
+    print(
+        f"  ULP > 100: {ulp_above_100_count:,} ({ulp_above_100_count/total_valid_pairs*100:.4f}%)"
+        if total_valid_pairs > 0
+        else "  ULP > 100: 0 (N/A)"
+    )
+    print(f"Skipped samples collected: {len(skipped_samples)}")
+    return skipped_samples
+
+
+def _generate_normal_finite_nonzero_bf16_values():
+    """All normal finite non-zero bf16 values, split into positive and negative."""
+    all_bitpatterns = torch.arange(0, 2**16, dtype=torch.int32).to(torch.uint16)
+    vals = all_bitpatterns.view(torch.bfloat16)
+    tiny = torch.finfo(torch.bfloat16).tiny
+    pos_mask = torch.isfinite(vals) & (vals > 0) & (vals >= tiny)
+    neg_mask = torch.isfinite(vals) & (vals < 0) & (vals.abs() >= tiny)
+    return vals[pos_mask], vals[neg_mask]
+
+
+# FP32 exhaustive tests (unary pow: all bases × all exponents, same normal finite non-zero set)
+def test_pow_tt_FP32_exhaustive_pos_pos(device):
+    """Exhaustive: positive base ^ positive exponent (all normal finite non-zero)."""
+    torch.manual_seed(0)
+    pos_values, neg_values = _generate_normal_finite_nonzero_bf16_values()
+    return _run_exhaustive_unary_pow_helper_float32_exhaustive_exponents(
+        device,
+        pos_values,
+        pos_values,
+        "Positive base ^ Positive exponent (exhaustive)",
+        "pos_pos",
+    )
+
+
+def test_pow_tt_FP32_exhaustive_pos_neg(device):
+    """Exhaustive: positive base ^ negative exponent (all normal finite non-zero)."""
+    torch.manual_seed(0)
+    pos_values, neg_values = _generate_normal_finite_nonzero_bf16_values()
+    return _run_exhaustive_unary_pow_helper_float32_exhaustive_exponents(
+        device,
+        pos_values,
+        neg_values,
+        "Positive base ^ Negative exponent (exhaustive)",
+        "pos_neg",
+    )
+
+
+def test_pow_tt_FP32_exhaustive_neg_pos(device):
+    """Exhaustive: negative base ^ positive exponent. Many NaN (non-integer exp); helper skips."""
+    torch.manual_seed(0)
+    pos_values, neg_values = _generate_normal_finite_nonzero_bf16_values()
+    return _run_exhaustive_unary_pow_helper_float32_exhaustive_exponents(
+        device,
+        neg_values,
+        pos_values,
+        "Negative base ^ Positive exponent (exhaustive)",
+        "neg_pos",
+    )
+
+
+def test_pow_tt_FP32_exhaustive_neg_neg(device):
+    """Exhaustive: negative base ^ negative exponent. Many NaN; helper skips."""
+    torch.manual_seed(0)
+    pos_values, neg_values = _generate_normal_finite_nonzero_bf16_values()
+    return _run_exhaustive_unary_pow_helper_float32_exhaustive_exponents(
+        device,
+        neg_values,
+        neg_values,
+        "Negative base ^ Negative exponent (exhaustive)",
+        "neg_neg",
+    )
+
+
+@pytest.mark.timeout(1800)
+def test_pow_tt_FP32_exhaustive_test(device):
+    """Unary pow (base**exponent) with fp32 - all sign combinations, one exponent per variant."""
+    import io
+    import sys
+    from datetime import datetime
+
+    # Tee class to write to both terminal and buffer
+    class Tee:
+        def __init__(self, *streams):
+            self.streams = streams
+
+        def write(self, data):
+            for s in self.streams:
+                s.write(data)
+                s.flush()
+
+        def flush(self):
+            for s in self.streams:
+                s.flush()
+
+    # Capture stdout while still printing to terminal
+    captured_output = io.StringIO()
+    original_stdout = sys.stdout
+    sys.stdout = Tee(original_stdout, captured_output)
+
+    # Collect skipped samples from all 4 categories
+    all_skipped_samples = []
+
+    try:
+        all_skipped_samples.extend(test_pow_tt_FP32_exhaustive_pos_pos(device))
+        all_skipped_samples.extend(test_pow_tt_FP32_exhaustive_pos_neg(device))
+        all_skipped_samples.extend(test_pow_tt_FP32_exhaustive_neg_pos(device))
+        all_skipped_samples.extend(test_pow_tt_FP32_exhaustive_neg_neg(device))
+    finally:
+        sys.stdout = original_stdout
+
+    # Get captured content
+    output_content = captured_output.getvalue()
+
+    # Write results to file
+    out_dir = "/home/ubuntu/Files"
+    os.makedirs(out_dir, exist_ok=True)
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    out_path = os.path.join(out_dir, f"pow_fp32_exhaustive_results_{timestamp}.txt")
+    with open(out_path, "w") as f:
+        f.write(output_content)
+
+    # Write merged skipped samples CSV (40 rows max: 10 per category)
+    skipped_csv_path = os.path.join(out_dir, f"pow_fp32_skipped_samples_{timestamp}.csv")
+    with open(skipped_csv_path, mode="w", newline="") as csv_file:
+        writer = csv.writer(csv_file)
+        writer.writerow(["category", "base", "exponent", "torch_result", "ttnn_result", "skip_reason"])
+        for sample in all_skipped_samples:
+            writer.writerow(
+                [
+                    sample["category"],
+                    sample["base"],
+                    sample["exponent"],
+                    sample["torch_result"],
+                    sample["ttnn_result"],
+                    sample["skip_reason"],
+                ]
+            )
+
+    print(f"\n{'='*60}")
+    print(f"All results saved to: {out_path}")
+    print(f"Skipped samples CSV ({len(all_skipped_samples)} rows): {skipped_csv_path}")
+    print(f"{'='*60}")
+
+
+# BF16 Exhaustive tests (unary pow: all bases × all exponents, same normal finite non-zero set)
+def test_pow_tt_bf16_exhaustive_pos_pos(device):
+    """Exhaustive: positive base ^ positive exponent (all normal finite non-zero)."""
+    torch.manual_seed(0)
+    pos_values, neg_values = _generate_normal_finite_nonzero_bf16_values()
+    return _run_exhaustive_unary_pow_helper_exhaustive_exponents(
+        device,
+        pos_values,
+        pos_values,
+        "Positive base ^ Positive exponent (exhaustive)",
+        "pos_pos",
+    )
+
+
+def test_pow_tt_bf16_exhaustive_pos_neg(device):
+    """Exhaustive: positive base ^ negative exponent (all normal finite non-zero)."""
+    torch.manual_seed(0)
+    pos_values, neg_values = _generate_normal_finite_nonzero_bf16_values()
+    return _run_exhaustive_unary_pow_helper_exhaustive_exponents(
+        device,
+        pos_values,
+        neg_values,
+        "Positive base ^ Negative exponent (exhaustive)",
+        "pos_neg",
+    )
+
+
+def test_pow_tt_bf16_exhaustive_neg_pos(device):
+    """Exhaustive: negative base ^ positive exponent. Many NaN; helper skips."""
+    torch.manual_seed(0)
+    pos_values, neg_values = _generate_normal_finite_nonzero_bf16_values()
+    return _run_exhaustive_unary_pow_helper_exhaustive_exponents(
+        device,
+        neg_values,
+        pos_values,
+        "Negative base ^ Positive exponent (exhaustive)",
+        "neg_pos",
+    )
+
+
+def test_pow_tt_bf16_exhaustive_neg_neg(device):
+    """Exhaustive: negative base ^ negative exponent. Many NaN; helper skips."""
+    torch.manual_seed(0)
+    pos_values, neg_values = _generate_normal_finite_nonzero_bf16_values()
+    return _run_exhaustive_unary_pow_helper_exhaustive_exponents(
+        device,
+        neg_values,
+        neg_values,
+        "Negative base ^ Negative exponent (exhaustive)",
+        "neg_neg",
+    )
+
+
+@pytest.mark.timeout(1800)
+def test_pow_tt_BF16_exhaustive_test(device):
+    """Unary pow (base**exponent) with BF16 - all sign combinations, one exponent per variant."""
+    import io
+    import sys
+    from datetime import datetime
+
+    # Tee class to write to both terminal and buffer
+    class Tee:
+        def __init__(self, *streams):
+            self.streams = streams
+
+        def write(self, data):
+            for s in self.streams:
+                s.write(data)
+                s.flush()
+
+        def flush(self):
+            for s in self.streams:
+                s.flush()
+
+    # Capture stdout while still printing to terminal
+    captured_output = io.StringIO()
+    original_stdout = sys.stdout
+    sys.stdout = Tee(original_stdout, captured_output)
+
+    # Collect skipped samples from all 4 categories
+    all_skipped_samples = []
+
+    try:
+        all_skipped_samples.extend(test_pow_tt_bf16_exhaustive_pos_pos(device))
+        all_skipped_samples.extend(test_pow_tt_bf16_exhaustive_pos_neg(device))
+        all_skipped_samples.extend(test_pow_tt_bf16_exhaustive_neg_pos(device))
+        all_skipped_samples.extend(test_pow_tt_bf16_exhaustive_neg_neg(device))
+    finally:
+        sys.stdout = original_stdout
+
+    # Get captured content
+    output_content = captured_output.getvalue()
+
+    # Write results to file
+    out_dir = "/home/ubuntu/Files"
+    os.makedirs(out_dir, exist_ok=True)
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    out_path = os.path.join(out_dir, f"pow_bf16_exhaustive_results_{timestamp}.txt")
+    with open(out_path, "w") as f:
+        f.write(output_content)
+
+    # Write merged skipped samples CSV (40 rows max: 10 per category)
+    skipped_csv_path = os.path.join(out_dir, f"pow_bf16_skipped_samples_{timestamp}.csv")
+    with open(skipped_csv_path, mode="w", newline="") as csv_file:
+        writer = csv.writer(csv_file)
+        writer.writerow(["category", "base", "exponent", "torch_result", "ttnn_result", "skip_reason"])
+        for sample in all_skipped_samples:
+            writer.writerow(
+                [
+                    sample["category"],
+                    sample["base"],
+                    sample["exponent"],
+                    sample["torch_result"],
+                    sample["ttnn_result"],
+                    sample["skip_reason"],
+                ]
+            )
+
+    print(f"\n{'='*60}")
+    print(f"All results saved to: {out_path}")
+    print(f"Skipped samples CSV ({len(all_skipped_samples)} rows): {skipped_csv_path}")
+    print(f"{'='*60}")

--- a/tests/ttnn/unit_tests/operations/eltwise/test_unary_pow_exhaustive_with_flushing.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_unary_pow_exhaustive_with_flushing.py
@@ -29,8 +29,7 @@ def _run_exhaustive_unary_pow_helper_exhaustive_exponents(
 ):
     """Exhaustive unary pow: sweep over all base_values and all exponent_values.
 
-    Uses binary ttnn.pow(base_tensor, exponent_tensor) with shapes [B, 1] and [1, N_exp]
-    so each device launch covers B×N_exp pairs (same batching strategy as fmod test).
+    Uses unary ttnn.pow(base_tensor, exponent_scalar): one device launch per (batch, exponent).
     Pairs where the torch (reference) result is NaN or Inf are SKIPPED from accuracy
     comparison.
     """
@@ -39,7 +38,7 @@ def _run_exhaustive_unary_pow_helper_exhaustive_exponents(
     N_exp = exponent_values.numel()
     total_pairs = N_base * N_exp
     print(f"\n{'='*60}")
-    print(f"{test_name}: Testing {N_base:,} bases × {N_exp:,} exponents = {total_pairs:,} pairs")
+    print(f"{test_name}: Testing {N_base:,} bases × {N_exp:,} exponents = {total_pairs:,} pairs (unary pow)")
 
     batch_size = 512
     num_batches = (N_base + batch_size - 1) // batch_size
@@ -56,80 +55,84 @@ def _run_exhaustive_unary_pow_helper_exhaustive_exponents(
     ulp_above_100_count = 0
     skipped_samples = []
 
-    # Broadcast: base [B, 1], exponent [1, N_exp] -> one kernel per base batch
-    exp_full = exponent_values.unsqueeze(0).clone()  # [1, N_exp]
-    # Flush input exponents: subnormal and non-finite to zero (once, reused for all batches)
-    flush_subnormal_values_to_zero(exp_full)
-    exp_full[~torch.isfinite(exp_full)] = 0.0
+    # Flush exponents to scalars (subnormal/non-finite -> 0.0)
+    exp_flushed = exponent_values.clone()
+    flush_subnormal_values_to_zero(exp_flushed)
+    exp_flushed[~torch.isfinite(exp_flushed)] = 0.0
+    exp_scalars = [exp_flushed[i].item() for i in range(N_exp)]
 
     for batch_idx in range(num_batches):
         start = batch_idx * batch_size
         end = min(start + batch_size, N_base)
         x_batch = base_values[start:end].unsqueeze(1).clone()  # [B, 1]
-        # Flush input bases: subnormal and non-finite to zero
         flush_subnormal_values_to_zero(x_batch)
         x_batch[~torch.isfinite(x_batch)] = 0.0
-        z_torch = torch.pow(x_batch, exp_full)  # [B, N_exp]
 
         x_tt = ttnn.from_torch(x_batch, dtype=ttnn_dtype, layout=ttnn.TILE_LAYOUT, device=device)
-        exp_tt = ttnn.from_torch(exp_full, dtype=ttnn_dtype, layout=ttnn.TILE_LAYOUT, device=device)
-        z_tt = ttnn.pow(x_tt, exp_tt)
-        tt_out = ttnn.to_torch(z_tt)
+        max_ulp_batch = 0
+        mismatch_count_batch = 0
+        valid_count_batch = 0
+        total_batch_pairs = 0
 
-        z_bf16 = z_torch.to(torch.bfloat16).contiguous()
-        tt_bf16 = tt_out.to(torch.bfloat16).contiguous()
-        valid_mask = torch.isfinite(z_bf16)
-        skipped_mask = ~valid_mask
-        total_skipped_pairs += skipped_mask.sum().item()
+        for exp_idx, exp_scalar in enumerate(exp_scalars):
+            z_torch = torch.pow(x_batch, exp_scalar)  # [B, 1]
+            z_tt = ttnn.pow(x_tt, exp_scalar)
+            tt_out = ttnn.to_torch(z_tt)
 
-        if skipped_mask.any() and len(skipped_samples) < max_skipped_samples:
-            skipped_indices = skipped_mask.nonzero(as_tuple=False)
-            for idx_pair in skipped_indices:
-                if len(skipped_samples) >= max_skipped_samples:
-                    break
-                i, j = idx_pair[0].item(), idx_pair[1].item()
-                reason = "NaN" if torch.isnan(z_bf16[i, j]) else ("+Inf" if z_bf16[i, j] > 0 else "-Inf")
-                skipped_samples.append(
-                    {
-                        "base": x_batch[i, 0].item(),
-                        "exponent": exp_full[0, j].item(),
-                        "torch_result": z_bf16[i, j].item(),
-                        "ttnn_result": tt_bf16[i, j].item(),
-                        "skip_reason": reason,
-                        "category": variant_name,
-                    }
-                )
+            z_bf16 = z_torch.to(torch.bfloat16).contiguous()
+            tt_bf16 = tt_out.to(torch.bfloat16).contiguous()
+            valid_mask = torch.isfinite(z_bf16)
+            skipped_mask = ~valid_mask
+            total_skipped_pairs += skipped_mask.sum().item()
 
-        # Flush subnormal and non-finite (outputs) to zero
-        flush_subnormal_values_to_zero(z_bf16)
-        flush_subnormal_values_to_zero(tt_bf16)
-        z_bf16[~torch.isfinite(z_bf16)] = 0.0
-        tt_bf16[~torch.isfinite(tt_bf16)] = 0.0
+            if skipped_mask.any() and len(skipped_samples) < max_skipped_samples:
+                skipped_indices = skipped_mask.nonzero(as_tuple=False)
+                for idx_row in skipped_indices:
+                    if len(skipped_samples) >= max_skipped_samples:
+                        break
+                    i = idx_row[0].item()
+                    reason = "NaN" if torch.isnan(z_bf16[i, 0]) else ("+Inf" if z_bf16[i, 0] > 0 else "-Inf")
+                    skipped_samples.append(
+                        {
+                            "base": x_batch[i, 0].item(),
+                            "exponent": exp_scalar,
+                            "torch_result": z_bf16[i, 0].item(),
+                            "ttnn_result": tt_bf16[i, 0].item(),
+                            "skip_reason": reason,
+                            "category": variant_name,
+                        }
+                    )
 
-        z_bits = z_bf16.view(torch.uint16).to(torch.int32)
-        tt_bits = tt_bf16.view(torch.uint16).to(torch.int32)
-        sign_z = (z_bits >> 15) & 1
-        sign_tt = (tt_bits >> 15) & 1
-        z_ord = torch.where(sign_z == 0, z_bits + 0x8000, 0x8000 - z_bits)
-        tt_ord = torch.where(sign_tt == 0, tt_bits + 0x8000, 0x8000 - tt_bits)
-        ulp_dist = (z_ord - tt_ord).abs()
-        valid_count = valid_mask.sum().item()
-        max_ulp_batch = ulp_dist[valid_mask].max().item() if valid_count > 0 else 0
-        max_ulp_global = max(max_ulp_global, max_ulp_batch)
-        ulp_0_count += ((ulp_dist == 0) & valid_mask).sum().item()
-        ulp_1_count += ((ulp_dist == 1) & valid_mask).sum().item()
-        ulp_2_count += ((ulp_dist == 2) & valid_mask).sum().item()
-        ulp_3_to_10_count += ((ulp_dist >= 3) & (ulp_dist <= 10) & valid_mask).sum().item()
-        ulp_11_to_100_count += ((ulp_dist >= 11) & (ulp_dist <= 100) & valid_mask).sum().item()
-        ulp_above_100_count += ((ulp_dist > 100) & valid_mask).sum().item()
-        mismatch_count = ((ulp_dist > 1) & valid_mask).sum().item()
-        total_mismatches += mismatch_count
-        total_valid_pairs += valid_count
-        total_batch_pairs = x_batch.shape[0] * exp_full.shape[1]
+            flush_subnormal_values_to_zero(z_bf16)
+            flush_subnormal_values_to_zero(tt_bf16)
+            z_bf16[~torch.isfinite(z_bf16)] = 0.0
+            tt_bf16[~torch.isfinite(tt_bf16)] = 0.0
+
+            z_bits = z_bf16.view(torch.uint16).to(torch.int32)
+            tt_bits = tt_bf16.view(torch.uint16).to(torch.int32)
+            sign_z = (z_bits >> 15) & 1
+            sign_tt = (tt_bits >> 15) & 1
+            z_ord = torch.where(sign_z == 0, z_bits + 0x8000, 0x8000 - z_bits)
+            tt_ord = torch.where(sign_tt == 0, tt_bits + 0x8000, 0x8000 - tt_bits)
+            ulp_dist = (z_ord - tt_ord).abs()
+            valid_count = valid_mask.sum().item()
+            total_batch_pairs += x_batch.shape[0]
+            max_ulp_batch = max(max_ulp_batch, ulp_dist[valid_mask].max().item() if valid_count > 0 else 0)
+            max_ulp_global = max(max_ulp_global, max_ulp_batch)
+            ulp_0_count += ((ulp_dist == 0) & valid_mask).sum().item()
+            ulp_1_count += ((ulp_dist == 1) & valid_mask).sum().item()
+            ulp_2_count += ((ulp_dist == 2) & valid_mask).sum().item()
+            ulp_3_to_10_count += ((ulp_dist >= 3) & (ulp_dist <= 10) & valid_mask).sum().item()
+            ulp_11_to_100_count += ((ulp_dist >= 11) & (ulp_dist <= 100) & valid_mask).sum().item()
+            ulp_above_100_count += ((ulp_dist > 100) & valid_mask).sum().item()
+            mismatch_count_batch += ((ulp_dist > 1) & valid_mask).sum().item()
+            total_mismatches += ((ulp_dist > 1) & valid_mask).sum().item()
+            total_valid_pairs += valid_count
+            valid_count_batch += valid_count
 
         if progress_every and ((batch_idx + 1) % progress_every == 0 or batch_idx == num_batches - 1):
             print(
-                f"  Batch {batch_idx+1}/{num_batches}: max_ulp={max_ulp_batch}, mismatches={mismatch_count}, tested={valid_count}/{total_batch_pairs}"
+                f"  Batch {batch_idx+1}/{num_batches}: max_ulp={max_ulp_batch}, mismatches={mismatch_count_batch}, tested={valid_count_batch}/{total_batch_pairs}"
             )
 
     mismatch_pct = (total_mismatches / total_valid_pairs) * 100 if total_valid_pairs > 0 else 0.0
@@ -189,8 +192,7 @@ def _run_exhaustive_unary_pow_helper_float32_exhaustive_exponents(
 ):
     """Exhaustive unary pow in float32: all base_values × all exponent_values.
 
-    Uses binary ttnn.pow(base_tensor, exponent_tensor) with shapes [B, 1] and [1, N_exp]
-    so each device launch covers B×N_exp pairs (same batching as fmod test).
+    Uses unary ttnn.pow(base_tensor, exponent_scalar): one device launch per (batch, exponent).
     Pairs where the torch (reference) result is NaN or Inf are SKIPPED from accuracy
     comparison.
     """
@@ -199,7 +201,7 @@ def _run_exhaustive_unary_pow_helper_float32_exhaustive_exponents(
     N_exp = exponent_values.numel()
     total_pairs = N_base * N_exp
     print(f"\n{'='*60}")
-    print(f"{test_name} (float32): Testing {N_base:,} bases × {N_exp:,} exponents = {total_pairs:,} pairs ")
+    print(f"{test_name} (float32): Testing {N_base:,} bases × {N_exp:,} exponents = {total_pairs:,} pairs (unary pow)")
 
     batch_size = 512
     num_batches = (N_base + batch_size - 1) // batch_size
@@ -216,79 +218,84 @@ def _run_exhaustive_unary_pow_helper_float32_exhaustive_exponents(
     ulp_above_100_count = 0
     skipped_samples = []
 
-    exp_full = exponent_values.to(torch.float32).unsqueeze(0).clone()  # [1, N_exp]
-    # Flush input exponents: subnormal and non-finite to zero (once, reused for all batches)
-    flush_subnormal_values_to_zero(exp_full)
-    exp_full[~torch.isfinite(exp_full)] = 0.0
+    # Flush exponents to scalars (subnormal/non-finite -> 0.0)
+    exp_flushed = exponent_values.to(torch.float32).clone()
+    flush_subnormal_values_to_zero(exp_flushed)
+    exp_flushed[~torch.isfinite(exp_flushed)] = 0.0
+    exp_scalars = [exp_flushed[i].item() for i in range(N_exp)]
 
     for batch_idx in range(num_batches):
         start = batch_idx * batch_size
         end = min(start + batch_size, N_base)
         x_batch_f32 = base_values[start:end].to(torch.float32).unsqueeze(1).clone()  # [B, 1]
-        # Flush input bases: subnormal and non-finite to zero
         flush_subnormal_values_to_zero(x_batch_f32)
         x_batch_f32[~torch.isfinite(x_batch_f32)] = 0.0
-        z_torch = torch.pow(x_batch_f32, exp_full)  # [B, N_exp]
 
         x_tt = ttnn.from_torch(x_batch_f32, dtype=ttnn_dtype, layout=ttnn.TILE_LAYOUT, device=device)
-        exp_tt = ttnn.from_torch(exp_full, dtype=ttnn_dtype, layout=ttnn.TILE_LAYOUT, device=device)
-        z_tt = ttnn.pow(x_tt, exp_tt)
-        tt_out = ttnn.to_torch(z_tt)
+        max_ulp_batch = 0
+        mismatch_count_batch = 0
+        valid_count_batch = 0
+        total_batch_pairs = 0
 
-        z_f32 = z_torch.to(torch.float32).contiguous()
-        tt_f32 = tt_out.to(torch.float32).contiguous()
-        valid_mask = torch.isfinite(z_f32)
-        skipped_mask = ~valid_mask
-        total_skipped_pairs += skipped_mask.sum().item()
+        for exp_idx, exp_scalar in enumerate(exp_scalars):
+            z_torch = torch.pow(x_batch_f32, exp_scalar)  # [B, 1]
+            z_tt = ttnn.pow(x_tt, exp_scalar)
+            tt_out = ttnn.to_torch(z_tt)
 
-        if skipped_mask.any() and len(skipped_samples) < max_skipped_samples:
-            skipped_indices = skipped_mask.nonzero(as_tuple=False)
-            for idx_pair in skipped_indices:
-                if len(skipped_samples) >= max_skipped_samples:
-                    break
-                i, j = idx_pair[0].item(), idx_pair[1].item()
-                reason = "NaN" if torch.isnan(z_f32[i, j]) else ("+Inf" if z_f32[i, j] > 0 else "-Inf")
-                skipped_samples.append(
-                    {
-                        "base": x_batch_f32[i, 0].item(),
-                        "exponent": exp_full[0, j].item(),
-                        "torch_result": z_f32[i, j].item(),
-                        "ttnn_result": tt_f32[i, j].item(),
-                        "skip_reason": reason,
-                        "category": variant_name,
-                    }
-                )
+            z_f32 = z_torch.to(torch.float32).contiguous()
+            tt_f32 = tt_out.to(torch.float32).contiguous()
+            valid_mask = torch.isfinite(z_f32)
+            skipped_mask = ~valid_mask
+            total_skipped_pairs += skipped_mask.sum().item()
 
-        # Flush subnormal and non-finite (outputs) to zero
-        flush_subnormal_values_to_zero(z_f32)
-        flush_subnormal_values_to_zero(tt_f32)
-        z_f32[~torch.isfinite(z_f32)] = 0.0
-        tt_f32[~torch.isfinite(tt_f32)] = 0.0
+            if skipped_mask.any() and len(skipped_samples) < max_skipped_samples:
+                skipped_indices = skipped_mask.nonzero(as_tuple=False)
+                for idx_row in skipped_indices:
+                    if len(skipped_samples) >= max_skipped_samples:
+                        break
+                    i = idx_row[0].item()
+                    reason = "NaN" if torch.isnan(z_f32[i, 0]) else ("+Inf" if z_f32[i, 0] > 0 else "-Inf")
+                    skipped_samples.append(
+                        {
+                            "base": x_batch_f32[i, 0].item(),
+                            "exponent": exp_scalar,
+                            "torch_result": z_f32[i, 0].item(),
+                            "ttnn_result": tt_f32[i, 0].item(),
+                            "skip_reason": reason,
+                            "category": variant_name,
+                        }
+                    )
 
-        z_bits = z_f32.view(torch.int32)
-        tt_bits = tt_f32.view(torch.int32)
-        sign_z = (z_bits >> 31) & 1
-        sign_tt = (tt_bits >> 31) & 1
-        z_ord = torch.where(sign_z == 0, z_bits + 0x80000000, 0x80000000 - z_bits)
-        tt_ord = torch.where(sign_tt == 0, tt_bits + 0x80000000, 0x80000000 - tt_bits)
-        ulp_dist = (z_ord - tt_ord).abs()
-        valid_count = valid_mask.sum().item()
-        max_ulp_batch = ulp_dist[valid_mask].max().item() if valid_count > 0 else 0
-        max_ulp_global = max(max_ulp_global, max_ulp_batch)
-        ulp_0_count += ((ulp_dist == 0) & valid_mask).sum().item()
-        ulp_1_count += ((ulp_dist == 1) & valid_mask).sum().item()
-        ulp_2_count += ((ulp_dist == 2) & valid_mask).sum().item()
-        ulp_3_to_10_count += ((ulp_dist >= 3) & (ulp_dist <= 10) & valid_mask).sum().item()
-        ulp_11_to_100_count += ((ulp_dist >= 11) & (ulp_dist <= 100) & valid_mask).sum().item()
-        ulp_above_100_count += ((ulp_dist > 100) & valid_mask).sum().item()
-        mismatch_count = ((ulp_dist > 1) & valid_mask).sum().item()
-        total_mismatches += mismatch_count
-        total_valid_pairs += valid_count
-        total_batch_pairs = x_batch_f32.shape[0] * exp_full.shape[1]
+            flush_subnormal_values_to_zero(z_f32)
+            flush_subnormal_values_to_zero(tt_f32)
+            z_f32[~torch.isfinite(z_f32)] = 0.0
+            tt_f32[~torch.isfinite(tt_f32)] = 0.0
+
+            z_bits = z_f32.view(torch.int32)
+            tt_bits = tt_f32.view(torch.int32)
+            sign_z = (z_bits >> 31) & 1
+            sign_tt = (tt_bits >> 31) & 1
+            z_ord = torch.where(sign_z == 0, z_bits + 0x80000000, 0x80000000 - z_bits)
+            tt_ord = torch.where(sign_tt == 0, tt_bits + 0x80000000, 0x80000000 - tt_bits)
+            ulp_dist = (z_ord - tt_ord).abs()
+            valid_count = valid_mask.sum().item()
+            total_batch_pairs += x_batch_f32.shape[0]
+            max_ulp_batch = max(max_ulp_batch, ulp_dist[valid_mask].max().item() if valid_count > 0 else 0)
+            max_ulp_global = max(max_ulp_global, max_ulp_batch)
+            ulp_0_count += ((ulp_dist == 0) & valid_mask).sum().item()
+            ulp_1_count += ((ulp_dist == 1) & valid_mask).sum().item()
+            ulp_2_count += ((ulp_dist == 2) & valid_mask).sum().item()
+            ulp_3_to_10_count += ((ulp_dist >= 3) & (ulp_dist <= 10) & valid_mask).sum().item()
+            ulp_11_to_100_count += ((ulp_dist >= 11) & (ulp_dist <= 100) & valid_mask).sum().item()
+            ulp_above_100_count += ((ulp_dist > 100) & valid_mask).sum().item()
+            mismatch_count_batch += ((ulp_dist > 1) & valid_mask).sum().item()
+            total_mismatches += ((ulp_dist > 1) & valid_mask).sum().item()
+            total_valid_pairs += valid_count
+            valid_count_batch += valid_count
 
         if progress_every and ((batch_idx + 1) % progress_every == 0 or batch_idx == num_batches - 1):
             print(
-                f"  Batch {batch_idx+1}/{num_batches}: max_ulp={max_ulp_batch}, mismatches={mismatch_count}, tested={valid_count}/{total_batch_pairs}"
+                f"  Batch {batch_idx+1}/{num_batches}: max_ulp={max_ulp_batch}, mismatches={mismatch_count_batch}, tested={valid_count_batch}/{total_batch_pairs}"
             )
 
     mismatch_pct = (total_mismatches / total_valid_pairs) * 100 if total_valid_pairs > 0 else 0.0
@@ -347,62 +354,85 @@ def _generate_normal_finite_nonzero_bf16_values():
     return vals[pos_mask], vals[neg_mask]
 
 
-# FP32 exhaustive tests (unary pow: all bases × all exponents, same normal finite non-zero set)
-def test_pow_tt_FP32_exhaustive_pos_pos(device):
-    """Exhaustive: positive base ^ positive exponent (all normal finite non-zero)."""
+# Specific exponent lists (same as test_fill.py): used for positive_base and negative_base categories.
+EXPONENT_FP32 = [
+    -3.0,
+    -2.0,
+    -1.0,
+    0.0,
+    1.0,
+    2.0,
+    3.0,
+    -7.25,
+    -15.875,
+    -0.75,
+    -0.3125,
+    0.125,
+    0.6000000238418579,
+    1.2999999523162842,
+    5.75,
+    12.399999618530273,
+    1.2345000505447388,
+    2.718280076980591,
+    3.141590118408203,
+    10.123000144958496,
+]
+EXPONENT_BF16 = [
+    -3.0,
+    -2.0,
+    -1.0,
+    0.0,
+    1.0,
+    2.0,
+    3.0,
+    -7.25,
+    -15.875,
+    -0.75,
+    -0.3125,
+    0.125,
+    0.59765625,
+    1.296875,
+    5.75,
+    12.375,
+    1.234375,
+    2.703125,
+    3.140625,
+    10.0625,
+]
+
+
+# FP32 exhaustive tests: two categories (positive base, negative base), each with EXPONENT_FP32.
+def test_pow_tt_FP32_exhaustive_positive_base(device):
+    """FP32: positive base ^ exponents (EXPONENT_FP32)."""
     torch.manual_seed(0)
     pos_values, neg_values = _generate_normal_finite_nonzero_bf16_values()
+    exponent_values = torch.tensor(EXPONENT_FP32, dtype=torch.float32)
     return _run_exhaustive_unary_pow_helper_float32_exhaustive_exponents(
         device,
         pos_values,
-        pos_values,
-        "Positive base ^ Positive exponent (exhaustive)",
-        "pos_pos",
+        exponent_values,
+        "Positive base ^ exponent (FP32 exponents)",
+        "positive_base",
     )
 
 
-def test_pow_tt_FP32_exhaustive_pos_neg(device):
-    """Exhaustive: positive base ^ negative exponent (all normal finite non-zero)."""
+def test_pow_tt_FP32_exhaustive_negative_base(device):
+    """FP32: negative base ^ exponents (EXPONENT_FP32)."""
     torch.manual_seed(0)
     pos_values, neg_values = _generate_normal_finite_nonzero_bf16_values()
-    return _run_exhaustive_unary_pow_helper_float32_exhaustive_exponents(
-        device,
-        pos_values,
-        neg_values,
-        "Positive base ^ Negative exponent (exhaustive)",
-        "pos_neg",
-    )
-
-
-def test_pow_tt_FP32_exhaustive_neg_pos(device):
-    """Exhaustive: negative base ^ positive exponent. Many NaN (non-integer exp); helper skips."""
-    torch.manual_seed(0)
-    pos_values, neg_values = _generate_normal_finite_nonzero_bf16_values()
+    exponent_values = torch.tensor(EXPONENT_FP32, dtype=torch.float32)
     return _run_exhaustive_unary_pow_helper_float32_exhaustive_exponents(
         device,
         neg_values,
-        pos_values,
-        "Negative base ^ Positive exponent (exhaustive)",
-        "neg_pos",
-    )
-
-
-def test_pow_tt_FP32_exhaustive_neg_neg(device):
-    """Exhaustive: negative base ^ negative exponent. Many NaN; helper skips."""
-    torch.manual_seed(0)
-    pos_values, neg_values = _generate_normal_finite_nonzero_bf16_values()
-    return _run_exhaustive_unary_pow_helper_float32_exhaustive_exponents(
-        device,
-        neg_values,
-        neg_values,
-        "Negative base ^ Negative exponent (exhaustive)",
-        "neg_neg",
+        exponent_values,
+        "Negative base ^ exponent (FP32 exponents)",
+        "negative_base",
     )
 
 
 @pytest.mark.timeout(1800)
 def test_pow_tt_FP32_exhaustive_test(device):
-    """Unary pow (base**exponent) with fp32 - all sign combinations, one exponent per variant."""
+    """Unary pow (base**exponent) with fp32 - positive_base and negative_base categories, EXPONENT_FP32."""
     import io
     import sys
     from datetime import datetime
@@ -426,14 +456,12 @@ def test_pow_tt_FP32_exhaustive_test(device):
     original_stdout = sys.stdout
     sys.stdout = Tee(original_stdout, captured_output)
 
-    # Collect skipped samples from all 4 categories
+    # Collect skipped samples from both categories (positive_base, negative_base)
     all_skipped_samples = []
 
     try:
-        all_skipped_samples.extend(test_pow_tt_FP32_exhaustive_pos_pos(device))
-        all_skipped_samples.extend(test_pow_tt_FP32_exhaustive_pos_neg(device))
-        all_skipped_samples.extend(test_pow_tt_FP32_exhaustive_neg_pos(device))
-        all_skipped_samples.extend(test_pow_tt_FP32_exhaustive_neg_neg(device))
+        all_skipped_samples.extend(test_pow_tt_FP32_exhaustive_positive_base(device))
+        all_skipped_samples.extend(test_pow_tt_FP32_exhaustive_negative_base(device))
     finally:
         sys.stdout = original_stdout
 
@@ -471,62 +499,38 @@ def test_pow_tt_FP32_exhaustive_test(device):
     print(f"{'='*60}")
 
 
-# BF16 Exhaustive tests (unary pow: all bases × all exponents, same normal finite non-zero set)
-def test_pow_tt_bf16_exhaustive_pos_pos(device):
-    """Exhaustive: positive base ^ positive exponent (all normal finite non-zero)."""
+# BF16 Exhaustive tests: two categories (positive base, negative base), each with EXPONENT_BF16.
+def test_pow_tt_bf16_exhaustive_positive_base(device):
+    """BF16: positive base ^ exponents (EXPONENT_BF16)."""
     torch.manual_seed(0)
     pos_values, neg_values = _generate_normal_finite_nonzero_bf16_values()
+    exponent_values = torch.tensor(EXPONENT_BF16, dtype=torch.bfloat16)
     return _run_exhaustive_unary_pow_helper_exhaustive_exponents(
         device,
         pos_values,
-        pos_values,
-        "Positive base ^ Positive exponent (exhaustive)",
-        "pos_pos",
+        exponent_values,
+        "Positive base ^ exponent (BF16 exponents)",
+        "positive_base",
     )
 
 
-def test_pow_tt_bf16_exhaustive_pos_neg(device):
-    """Exhaustive: positive base ^ negative exponent (all normal finite non-zero)."""
+def test_pow_tt_bf16_exhaustive_negative_base(device):
+    """BF16: negative base ^ exponents (EXPONENT_BF16)."""
     torch.manual_seed(0)
     pos_values, neg_values = _generate_normal_finite_nonzero_bf16_values()
-    return _run_exhaustive_unary_pow_helper_exhaustive_exponents(
-        device,
-        pos_values,
-        neg_values,
-        "Positive base ^ Negative exponent (exhaustive)",
-        "pos_neg",
-    )
-
-
-def test_pow_tt_bf16_exhaustive_neg_pos(device):
-    """Exhaustive: negative base ^ positive exponent. Many NaN; helper skips."""
-    torch.manual_seed(0)
-    pos_values, neg_values = _generate_normal_finite_nonzero_bf16_values()
+    exponent_values = torch.tensor(EXPONENT_BF16, dtype=torch.bfloat16)
     return _run_exhaustive_unary_pow_helper_exhaustive_exponents(
         device,
         neg_values,
-        pos_values,
-        "Negative base ^ Positive exponent (exhaustive)",
-        "neg_pos",
-    )
-
-
-def test_pow_tt_bf16_exhaustive_neg_neg(device):
-    """Exhaustive: negative base ^ negative exponent. Many NaN; helper skips."""
-    torch.manual_seed(0)
-    pos_values, neg_values = _generate_normal_finite_nonzero_bf16_values()
-    return _run_exhaustive_unary_pow_helper_exhaustive_exponents(
-        device,
-        neg_values,
-        neg_values,
-        "Negative base ^ Negative exponent (exhaustive)",
-        "neg_neg",
+        exponent_values,
+        "Negative base ^ exponent (BF16 exponents)",
+        "negative_base",
     )
 
 
 @pytest.mark.timeout(1800)
 def test_pow_tt_BF16_exhaustive_test(device):
-    """Unary pow (base**exponent) with BF16 - all sign combinations, one exponent per variant."""
+    """Unary pow (base**exponent) with BF16 - positive_base and negative_base categories, EXPONENT_BF16."""
     import io
     import sys
     from datetime import datetime
@@ -550,14 +554,12 @@ def test_pow_tt_BF16_exhaustive_test(device):
     original_stdout = sys.stdout
     sys.stdout = Tee(original_stdout, captured_output)
 
-    # Collect skipped samples from all 4 categories
+    # Collect skipped samples from both categories (positive_base, negative_base)
     all_skipped_samples = []
 
     try:
-        all_skipped_samples.extend(test_pow_tt_bf16_exhaustive_pos_pos(device))
-        all_skipped_samples.extend(test_pow_tt_bf16_exhaustive_pos_neg(device))
-        all_skipped_samples.extend(test_pow_tt_bf16_exhaustive_neg_pos(device))
-        all_skipped_samples.extend(test_pow_tt_bf16_exhaustive_neg_neg(device))
+        all_skipped_samples.extend(test_pow_tt_bf16_exhaustive_positive_base(device))
+        all_skipped_samples.extend(test_pow_tt_bf16_exhaustive_negative_base(device))
     finally:
         sys.stdout = original_stdout
 

--- a/tests/ttnn/unit_tests/operations/eltwise/test_xielu_accuracy.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_xielu_accuracy.py
@@ -1,0 +1,413 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+import os
+import csv
+import pytest
+import ttnn
+from tests.ttnn.utils_for_testing import assert_with_ulp
+
+# BF16 exhaustive: pytest /home/ubuntu/tt-metal/tests/ttnn/unit_tests/operations/eltwise/test_xielu_accuracy.py::test_xielu_tt_BF16_exhaustive_test
+# FP32 exhaustive: pytest /home/ubuntu/tt-metal/tests/ttnn/unit_tests/operations/eltwise/test_xielu_accuracy.py::test_xielu_tt_FP32_exhaustive_test
+
+pytestmark = pytest.mark.use_module_device
+
+ALPHA_P = 0.8
+ALPHA_N = 0.8
+
+
+def flush_subnormal_values(tensor):
+    SUBNORMAL_THRESHOLD = 2.0 ** (-126)
+    mask = torch.abs(tensor) < SUBNORMAL_THRESHOLD
+    tensor[mask] = 0.0
+    return tensor
+
+
+def _run_exhaustive_xielu_helper(device, input_values, test_name, variant_name, max_skipped_samples=10):
+    """Run exhaustive xielu test (BF16). Single input tensor; alpha_p=0.8, alpha_n=0.8.
+    Skips pairs where torch reference is NaN/Inf. Returns skipped samples."""
+    golden_fn = ttnn.get_golden_function(ttnn.xielu)
+    ttnn_dtype = ttnn.bfloat16
+
+    N = input_values.numel()
+    print(f"\n{'='*60}")
+    print(f"{test_name} (bfloat16): Testing {N:,} inputs (alpha_p={ALPHA_P}, alpha_n={ALPHA_N})")
+
+    batch_size = 512
+    num_batches = (N + batch_size - 1) // batch_size
+
+    max_ulp_global = 0
+    total_mismatches = 0
+    total_valid_pairs = 0
+    total_skipped_pairs = 0
+    ulp_0_count = 0
+    ulp_1_count = 0
+    ulp_2_count = 0
+    ulp_3_to_10_count = 0
+    ulp_11_to_100_count = 0
+    ulp_above_100_count = 0
+    skipped_samples = []
+
+    for batch_idx in range(num_batches):
+        start = batch_idx * batch_size
+        end = min(start + batch_size, N)
+        x_batch = input_values[start:end].clone()
+        flush_subnormal_values(x_batch)
+        x_batch[~torch.isfinite(x_batch)] = 0.0
+
+        z_torch = golden_fn(x_batch, alpha_p=ALPHA_P, alpha_n=ALPHA_N)
+        x_2d = x_batch.unsqueeze(0) if x_batch.dim() == 1 else x_batch
+        x_tt = ttnn.from_torch(x_2d, dtype=ttnn_dtype, layout=ttnn.TILE_LAYOUT, device=device)
+        z_tt = ttnn.xielu(x_tt, alpha_p=ALPHA_P, alpha_n=ALPHA_N)
+        tt_out = ttnn.to_torch(z_tt)
+        if tt_out.dim() > 1:
+            tt_out = tt_out.squeeze(0)
+
+        z_bf16 = z_torch.to(torch.bfloat16).contiguous().flatten()
+        tt_bf16 = tt_out.to(torch.bfloat16).contiguous().flatten()
+
+        valid_mask = torch.isfinite(z_bf16)
+        skipped_mask = ~valid_mask
+        batch_skipped = skipped_mask.sum().item()
+        total_skipped_pairs += batch_skipped
+
+        if batch_skipped > 0 and len(skipped_samples) < max_skipped_samples:
+            for i in range(z_bf16.numel()):
+                if len(skipped_samples) >= max_skipped_samples:
+                    break
+                if not valid_mask[i]:
+                    reason = "NaN" if torch.isnan(z_bf16[i]) else ("+Inf" if z_bf16[i] > 0 else "-Inf")
+                    skipped_samples.append(
+                        {
+                            "input": x_batch.flatten()[i].item(),
+                            "torch_result": z_bf16[i].item(),
+                            "ttnn_result": tt_bf16[i].item(),
+                            "skip_reason": reason,
+                            "category": variant_name,
+                        }
+                    )
+
+        flush_subnormal_values(z_bf16)
+        flush_subnormal_values(tt_bf16)
+        tt_bf16[~torch.isfinite(tt_bf16)] = 0.0
+
+        z_bits = z_bf16.view(torch.uint16).to(torch.int32)
+        tt_bits = tt_bf16.view(torch.uint16).to(torch.int32)
+        sign_z = (z_bits >> 15) & 1
+        sign_tt = (tt_bits >> 15) & 1
+        z_ord = torch.where(sign_z == 0, z_bits + 0x8000, 0x8000 - z_bits)
+        tt_ord = torch.where(sign_tt == 0, tt_bits + 0x8000, 0x8000 - tt_bits)
+        ulp_dist = (z_ord - tt_ord).abs()
+        ulp_dist_valid = torch.where(valid_mask, ulp_dist, torch.zeros_like(ulp_dist))
+
+        max_ulp_batch = ulp_dist_valid.max().item()
+        max_ulp_global = max(max_ulp_global, max_ulp_batch)
+
+        ulp_0_count += ((ulp_dist == 0) & valid_mask).sum().item()
+        ulp_1_count += ((ulp_dist == 1) & valid_mask).sum().item()
+        ulp_2_count += ((ulp_dist == 2) & valid_mask).sum().item()
+        ulp_3_to_10_count += ((ulp_dist >= 3) & (ulp_dist <= 10) & valid_mask).sum().item()
+        ulp_11_to_100_count += ((ulp_dist >= 11) & (ulp_dist <= 100) & valid_mask).sum().item()
+        ulp_above_100_count += ((ulp_dist > 100) & valid_mask).sum().item()
+        mismatch_count = ((ulp_dist > 1) & valid_mask).sum().item()
+        total_mismatches += mismatch_count
+        total_valid_pairs += valid_mask.sum().item()
+
+        if (batch_idx + 1) % 10 == 0 or batch_idx == num_batches - 1:
+            print(
+                f"Batch {batch_idx+1}/{num_batches}: max_ulp={max_ulp_batch}, mismatches={mismatch_count}, skipped={batch_skipped}"
+            )
+
+    mismatch_pct = (total_mismatches / total_valid_pairs) * 100 if total_valid_pairs > 0 else 0.0
+    skipped_pct = (total_skipped_pairs / N) * 100 if N > 0 else 0.0
+
+    print(f"\n--- Summary ---")
+    print(f"Total inputs: {N:,}")
+    print(f"Valid (torch finite): {total_valid_pairs:,} ({100 - skipped_pct:.4f}%)")
+    print(f"Skipped (torch NaN/Inf): {total_skipped_pairs:,} ({skipped_pct:.4f}%)")
+    print(f"Skipped samples collected: {len(skipped_samples)}")
+    print(f"Global max ULP: {max_ulp_global}")
+    print(f"Total mismatches (ULP > 1): {total_mismatches:,} ({mismatch_pct:.4f}% of valid)")
+    print(f"\nULP Distribution (valid only):")
+    if total_valid_pairs > 0:
+        print(f"  ULP = 0: {ulp_0_count:,} ({ulp_0_count/total_valid_pairs*100:.4f}%)")
+        print(f"  ULP = 1: {ulp_1_count:,} ({ulp_1_count/total_valid_pairs*100:.4f}%)")
+        print(f"  ULP = 2: {ulp_2_count:,} ({ulp_2_count/total_valid_pairs*100:.4f}%)")
+        print(f"  ULP 3-10: {ulp_3_to_10_count:,} ({ulp_3_to_10_count/total_valid_pairs*100:.4f}%)")
+        print(f"  ULP 11-100: {ulp_11_to_100_count:,} ({ulp_11_to_100_count/total_valid_pairs*100:.4f}%)")
+        print(f"  ULP > 100: {ulp_above_100_count:,} ({ulp_above_100_count/total_valid_pairs*100:.4f}%)")
+    return skipped_samples
+
+
+def _run_exhaustive_xielu_helper_float32(device, input_values, test_name, variant_name, max_skipped_samples=10):
+    """Run exhaustive xielu test (float32). Single input tensor; alpha_p=0.8, alpha_n=0.8."""
+    golden_fn = ttnn.get_golden_function(ttnn.xielu)
+    ttnn_dtype = ttnn.float32
+
+    N = input_values.numel()
+    print(f"\n{'='*60}")
+    print(f"{test_name} (float32): Testing {N:,} inputs (alpha_p={ALPHA_P}, alpha_n={ALPHA_N})")
+
+    batch_size = 512
+    num_batches = (N + batch_size - 1) // batch_size
+
+    max_ulp_global = 0
+    total_mismatches = 0
+    total_valid_pairs = 0
+    total_skipped_pairs = 0
+    ulp_0_count = 0
+    ulp_1_count = 0
+    ulp_2_count = 0
+    ulp_3_to_10_count = 0
+    ulp_11_to_100_count = 0
+    ulp_above_100_count = 0
+    skipped_samples = []
+
+    for batch_idx in range(num_batches):
+        start = batch_idx * batch_size
+        end = min(start + batch_size, N)
+        x_batch = input_values[start:end].to(torch.float32).clone()
+        flush_subnormal_values(x_batch)
+        x_batch[~torch.isfinite(x_batch)] = 0.0
+
+        z_torch = golden_fn(x_batch, alpha_p=ALPHA_P, alpha_n=ALPHA_N)
+        x_2d = x_batch.unsqueeze(0) if x_batch.dim() == 1 else x_batch
+        x_tt = ttnn.from_torch(x_2d, dtype=ttnn_dtype, layout=ttnn.TILE_LAYOUT, device=device)
+        z_tt = ttnn.xielu(x_tt, alpha_p=ALPHA_P, alpha_n=ALPHA_N)
+        tt_out = ttnn.to_torch(z_tt)
+        if tt_out.dim() > 1:
+            tt_out = tt_out.squeeze(0)
+
+        z_f32 = z_torch.to(torch.float32).contiguous().flatten()
+        tt_f32 = tt_out.to(torch.float32).contiguous().flatten()
+
+        valid_mask = torch.isfinite(z_f32)
+        skipped_mask = ~valid_mask
+        batch_skipped = skipped_mask.sum().item()
+        total_skipped_pairs += batch_skipped
+
+        if batch_skipped > 0 and len(skipped_samples) < max_skipped_samples:
+            for i in range(z_f32.numel()):
+                if len(skipped_samples) >= max_skipped_samples:
+                    break
+                if not valid_mask[i]:
+                    reason = "NaN" if torch.isnan(z_f32[i]) else ("+Inf" if z_f32[i] > 0 else "-Inf")
+                    skipped_samples.append(
+                        {
+                            "input": x_batch.flatten()[i].item(),
+                            "torch_result": z_f32[i].item(),
+                            "ttnn_result": tt_f32[i].item(),
+                            "skip_reason": reason,
+                            "category": variant_name,
+                        }
+                    )
+
+        flush_subnormal_values(z_f32)
+        flush_subnormal_values(tt_f32)
+        tt_f32[~torch.isfinite(tt_f32)] = 0.0
+
+        z_bits = z_f32.view(torch.int32)
+        tt_bits = tt_f32.view(torch.int32)
+        sign_z = (z_bits >> 31) & 1
+        sign_tt = (tt_bits >> 31) & 1
+        z_ord = torch.where(sign_z == 0, z_bits + 0x80000000, 0x80000000 - z_bits)
+        tt_ord = torch.where(sign_tt == 0, tt_bits + 0x80000000, 0x80000000 - tt_bits)
+        ulp_dist = (z_ord - tt_ord).abs()
+        ulp_dist_valid = torch.where(valid_mask, ulp_dist, torch.zeros_like(ulp_dist))
+
+        max_ulp_batch = ulp_dist_valid.max().item()
+        max_ulp_global = max(max_ulp_global, max_ulp_batch)
+
+        ulp_0_count += ((ulp_dist == 0) & valid_mask).sum().item()
+        ulp_1_count += ((ulp_dist == 1) & valid_mask).sum().item()
+        ulp_2_count += ((ulp_dist == 2) & valid_mask).sum().item()
+        ulp_3_to_10_count += ((ulp_dist >= 3) & (ulp_dist <= 10) & valid_mask).sum().item()
+        ulp_11_to_100_count += ((ulp_dist >= 11) & (ulp_dist <= 100) & valid_mask).sum().item()
+        ulp_above_100_count += ((ulp_dist > 100) & valid_mask).sum().item()
+        mismatch_count = ((ulp_dist > 1) & valid_mask).sum().item()
+        total_mismatches += mismatch_count
+        total_valid_pairs += valid_mask.sum().item()
+
+        if (batch_idx + 1) % 10 == 0 or batch_idx == num_batches - 1:
+            print(
+                f"Batch {batch_idx+1}/{num_batches}: max_ulp={max_ulp_batch}, mismatches={mismatch_count}, skipped={batch_skipped}"
+            )
+
+    mismatch_pct = (total_mismatches / total_valid_pairs) * 100 if total_valid_pairs > 0 else 0.0
+    skipped_pct = (total_skipped_pairs / N) * 100 if N > 0 else 0.0
+
+    print(f"\n--- Summary ---")
+    print(f"Total inputs: {N:,}")
+    print(f"Valid (torch finite): {total_valid_pairs:,} ({100 - skipped_pct:.4f}%)")
+    print(f"Skipped (torch NaN/Inf): {total_skipped_pairs:,} ({skipped_pct:.4f}%)")
+    print(f"Skipped samples collected: {len(skipped_samples)}")
+    print(f"Global max ULP: {max_ulp_global}")
+    print(f"Total mismatches (ULP > 1): {total_mismatches:,} ({mismatch_pct:.4f}% of valid)")
+    print(f"\nULP Distribution (valid only):")
+    if total_valid_pairs > 0:
+        print(f"  ULP = 0: {ulp_0_count:,} ({ulp_0_count/total_valid_pairs*100:.4f}%)")
+        print(f"  ULP = 1: {ulp_1_count:,} ({ulp_1_count/total_valid_pairs*100:.4f}%)")
+        print(f"  ULP = 2: {ulp_2_count:,} ({ulp_2_count/total_valid_pairs*100:.4f}%)")
+        print(f"  ULP 3-10: {ulp_3_to_10_count:,} ({ulp_3_to_10_count/total_valid_pairs*100:.4f}%)")
+        print(f"  ULP 11-100: {ulp_11_to_100_count:,} ({ulp_11_to_100_count/total_valid_pairs*100:.4f}%)")
+        print(f"  ULP > 100: {ulp_above_100_count:,} ({ulp_above_100_count/total_valid_pairs*100:.4f}%)")
+    return skipped_samples
+
+
+def _get_pos_neg_bf16_values():
+    """All normal finite non-zero bf16 values, split into positive and negative."""
+    all_bitpatterns = torch.arange(0, 2**16, dtype=torch.int32).to(torch.uint16)
+    vals = all_bitpatterns.view(torch.bfloat16)
+    tiny = torch.finfo(torch.bfloat16).tiny
+    pos_mask = torch.isfinite(vals) & (vals > 0) & (vals >= tiny)
+    neg_mask = torch.isfinite(vals) & (vals < 0) & (vals.abs() >= tiny)
+    return vals[pos_mask], vals[neg_mask]
+
+
+# --- FP32 exhaustive ---
+def test_xielu_tt_FP32_exhaustive_pos_input(device):
+    """xielu FP32: positive inputs only, alpha_p=0.8, alpha_n=0.8."""
+    torch.manual_seed(0)
+    pos_values, neg_values = _get_pos_neg_bf16_values()
+    return _run_exhaustive_xielu_helper_float32(
+        device,
+        pos_values.to(torch.float32),
+        "xielu positive input",
+        "pos_input",
+    )
+
+
+def test_xielu_tt_FP32_exhaustive_neg_input(device):
+    """xielu FP32: negative inputs only, alpha_p=0.8, alpha_n=0.8."""
+    torch.manual_seed(0)
+    pos_values, neg_values = _get_pos_neg_bf16_values()
+    return _run_exhaustive_xielu_helper_float32(
+        device,
+        neg_values.to(torch.float32),
+        "xielu negative input",
+        "neg_input",
+    )
+
+
+@pytest.mark.timeout(1800)
+def test_xielu_tt_FP32_exhaustive_test(device):
+    """xielu FP32 exhaustive: positive and negative; writes results to ~/Files/."""
+    import io
+    import sys
+    from datetime import datetime
+
+    class Tee:
+        def __init__(self, *streams):
+            self.streams = streams
+
+        def write(self, data):
+            for s in self.streams:
+                s.write(data)
+                s.flush()
+
+        def flush(self):
+            for s in self.streams:
+                s.flush()
+
+    captured_output = io.StringIO()
+    original_stdout = sys.stdout
+    sys.stdout = Tee(original_stdout, captured_output)
+    all_skipped = []
+    try:
+        all_skipped.extend(test_xielu_tt_FP32_exhaustive_pos_input(device))
+        all_skipped.extend(test_xielu_tt_FP32_exhaustive_neg_input(device))
+    finally:
+        sys.stdout = original_stdout
+
+    out_dir = os.path.join(os.path.expanduser("~"), "Files")
+    os.makedirs(out_dir, exist_ok=True)
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    out_path = os.path.join(out_dir, f"xielu_fp32_exhaustive_results_{timestamp}.txt")
+    with open(out_path, "w") as f:
+        f.write(captured_output.getvalue())
+
+    skipped_csv_path = os.path.join(out_dir, f"xielu_fp32_skipped_samples_{timestamp}.csv")
+    with open(skipped_csv_path, "w", newline="") as f:
+        w = csv.DictWriter(f, fieldnames=["category", "input", "torch_result", "ttnn_result", "skip_reason"])
+        w.writeheader()
+        w.writerows(all_skipped)
+
+    print(f"\n{'='*60}")
+    print(f"Results saved to: {out_path}")
+    print(f"Skipped samples CSV: {skipped_csv_path}")
+    print(f"{'='*60}")
+
+
+# --- BF16 exhaustive ---
+def test_xielu_tt_BF16_exhaustive_pos_input(device):
+    """xielu BF16: positive inputs only, alpha_p=0.8, alpha_n=0.8."""
+    torch.manual_seed(0)
+    pos_values, neg_values = _get_pos_neg_bf16_values()
+    return _run_exhaustive_xielu_helper(
+        device,
+        pos_values,
+        "xielu positive input",
+        "pos_input",
+    )
+
+
+def test_xielu_tt_BF16_exhaustive_neg_input(device):
+    """xielu BF16: negative inputs only, alpha_p=0.8, alpha_n=0.8."""
+    torch.manual_seed(0)
+    pos_values, neg_values = _get_pos_neg_bf16_values()
+    return _run_exhaustive_xielu_helper(
+        device,
+        neg_values,
+        "xielu negative input",
+        "neg_input",
+    )
+
+
+@pytest.mark.timeout(1800)
+def test_xielu_tt_BF16_exhaustive_test(device):
+    """xielu BF16 exhaustive: positive and negative; writes results to ~/Files/."""
+    import io
+    import sys
+    from datetime import datetime
+
+    class Tee:
+        def __init__(self, *streams):
+            self.streams = streams
+
+        def write(self, data):
+            for s in self.streams:
+                s.write(data)
+                s.flush()
+
+        def flush(self):
+            for s in self.streams:
+                s.flush()
+
+    captured_output = io.StringIO()
+    original_stdout = sys.stdout
+    sys.stdout = Tee(original_stdout, captured_output)
+    all_skipped = []
+    try:
+        all_skipped.extend(test_xielu_tt_BF16_exhaustive_pos_input(device))
+        all_skipped.extend(test_xielu_tt_BF16_exhaustive_neg_input(device))
+    finally:
+        sys.stdout = original_stdout
+
+    out_dir = os.path.join(os.path.expanduser("~"), "Files")
+    os.makedirs(out_dir, exist_ok=True)
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    out_path = os.path.join(out_dir, f"xielu_bf16_exhaustive_results_{timestamp}.txt")
+    with open(out_path, "w") as f:
+        f.write(captured_output.getvalue())
+
+    skipped_csv_path = os.path.join(out_dir, f"xielu_bf16_skipped_samples_{timestamp}.csv")
+    with open(skipped_csv_path, "w", newline="") as f:
+        w = csv.DictWriter(f, fieldnames=["category", "input", "torch_result", "ttnn_result", "skip_reason"])
+        w.writeheader()
+        w.writerows(all_skipped)
+
+    print(f"\n{'='*60}")
+    print(f"Results saved to: {out_path}")
+    print(f"Skipped samples CSV: {skipped_csv_path}")
+    print(f"{'='*60}")

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_binary_pow.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_binary_pow.h
@@ -217,6 +217,26 @@ sfpi_inline sfpi::vFloat _sfpu_binary_power_61f_(sfpi::vFloat in0, sfpi::vFloat 
     v_if(a_minus_b == sfpi::vFloat(0.0f)) { result = sfpi::vFloat(0.0f); }
     v_endif;
 
+    // FIX 4: Sign correction - fmod result must have same sign as 'a' (or be zero)
+    // If a > 0 and result < 0, the truncation was 1 too high, need to add b
+    // If a < 0 and result > 0, the truncation was 1 too low, need to subtract b
+    // This fixes cases where a/b ≈ 0.9999999 but rounds to 1 due to reciprocal error
+    v_if(a >= sfpi::vFloat(0.0f)) {
+        // a is positive, result should be >= 0
+        v_if(result < sfpi::vFloat(0.0f)) {
+            result = result + b_abs;  // Correct: we over-truncated
+        }
+        v_endif;
+    }
+    v_else {
+        // a is negative, result should be <= 0
+        v_if(result > sfpi::vFloat(0.0f)) {
+            result = result - b_abs;  // Correct: we under-truncated
+        }
+        v_endif;
+    }
+    v_endif;
+
     return result;
 }
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_binary_pow.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_binary_pow.h
@@ -218,51 +218,6 @@ sfpi_inline sfpi::vFloat _sfpu_binary_power_61f_(sfpi::vFloat in0, sfpi::vFloat 
     v_endif;
 
     return result;
-
-    // cursor code
-    // // fmod(a, b) = a - trunc(a/b) * b
-    // sfpi::vFloat a = in0;
-    // sfpi::vFloat b = in1;
-
-    // // Step 1: Compute 1/b using polynomial + Newton-Raphson
-    // sfpi::vFloat b_abs = sfpi::abs(b);
-    // sfpi::vFloat x = sfpi::setexp(b_abs, 127);  // x in [1,2)
-    // sfpi::vFloat recip = x * (x * 0.3232f - 1.4545f) + 2.1315f;
-    // sfpi::vInt b_exp = sfpi::exexp(b);
-    // recip = sfpi::setexp(recip, 126 - b_exp);
-    // recip = sfpi::setsgn(recip, b);
-    // recip = recip * (sfpi::vFloat(2.0f) - b * recip);
-    // recip = recip * (sfpi::vFloat(2.0f) - b * recip);
-
-    // // Step 2: Compute quot = a/b
-    // sfpi::vFloat quot = a * recip;
-
-    // // Step 3: Compute trunc(quot) without using _trunc_body_
-    // // Use mantissa alignment trick, but correct for FP rounding errors
-
-    // sfpi::vFloat quot_abs = sfpi::abs(quot);
-    // sfpi::vFloat big = sfpi::vFloat(8388608.0f);  // 2^23
-
-    // // The mantissa alignment trick can round up due to FP rounding
-    // // e.g., 0.9999996 + 2^23 might round to 2^23 + 1, giving trunc = 1 instead of 0
-    // sfpi::vFloat aligned = quot_abs + big;
-    // sfpi::vFloat trunc_abs = aligned - big;
-
-    // // Correct for rounding errors: if trunc_abs > quot_abs, subtract 1
-    // // This ensures we truncate towards zero, not away from zero
-    // v_if(trunc_abs > quot_abs) {
-    //     trunc_abs = trunc_abs - sfpi::vFloat(1.0f);
-    // }
-    // v_endif;
-
-    // // Handle the sign: trunc(-1.5) = -1, not -2
-    // sfpi::vFloat trunc_quot = sfpi::setsgn(trunc_abs, quot);
-
-    // // Step 4: Compute fmod = a - trunc(a/b) * b
-    // sfpi::vFloat qb = trunc_quot * b;
-    // sfpi::vFloat result = a - qb;
-
-    // return result;
 }
 
 template <bool is_fp32_dest_acc_en>

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_binary_pow.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_binary_pow.h
@@ -14,138 +14,111 @@ using namespace sfpi;
 namespace ckernel {
 namespace sfpu {
 
-/**
- * @brief Computes base raised to the power of pow (base**pow)
- *
- * This function implements binary exponentiation using a polynomial approximation algorithm
- * based on "Simple Multiple Precision Algorithms for Exponential Functions [Tips & Tricks]"
- * by Moroz et al. 2022 (https://doi.org/10.1109/MSP.2022.3157460).
- * More specifically, it is the implementation of the `exp_21f` algorithm described in Section 5
- *
- * @param base The base value (sfpi::vFloat vector), can be any floating point number
- * @param pow The exponent/power value (sfpi::vFloat vector), can be any floating point number
- *
- * @return sfpi::vFloat Result of base**pow
- *
- * Special Cases:
- * - base = 0, pow < 0: Returns NaN (undefined)
- * - base < 0, pow = integer: Returns proper signed result (negative if odd power)
- * - base < 0, pow = non-integer: Returns NaN (complex result)
- * - Overflow/underflow: Clamped to appropriate limits
- *
- * @note This function assumes that the programmable constants are set to the following values:
- * - vConstFloatPrgm0 = 1.4426950408889634f;
- * - vConstFloatPrgm1 = -127.0f;
- * - vConstFloatPrgm2 = std::numeric_limits<float>::quiet_NaN();
- *
- * @see Moroz et al. 2022 - "Simple Multiple Precision Algorithms for Exponential Functions"
- *      ( https://doi.org/10.1109/MSP.2022.3157460 )
- */
+// Convert float32 to bfloat16 using IEEE 754 Round-to-Nearest-Even (RNE)
+// This implements the "add 0x7fff + LSB" algorithm for correct tie-breaking
+sfpi_inline sfpi::vFloat float32_to_bf16_rne(sfpi::vFloat in) {
+    // Get the float32 bits as unsigned integer
+    sfpi::vUInt bits = sfpi::reinterpret<sfpi::vUInt>(in);
+
+    // Extract the LSB of what will become the bf16 mantissa (bit 16 of float32)
+    // This is needed for the tie-breaker: round to even
+    sfpi::vUInt lsb = (bits >> 16) & 1;
+
+    // Add 0x7fff + lsb to implement RNE:
+    // - If lower 16 bits > 0x8000: overflow → rounds up
+    // - If lower 16 bits < 0x8000: no overflow → rounds down
+    // - If lower 16 bits = 0x8000 (tie) and lsb=0: 0x7fff+0=0xffff, no overflow → stays even
+    // - If lower 16 bits = 0x8000 (tie) and lsb=1: 0x7fff+1=0x8000, overflow → rounds up to even
+    bits = bits + 0x7fffU + lsb;
+
+    // Clear the lower 16 bits to get bf16 in upper 16 bits (bf16 format in float32)
+    bits = bits & 0xFFFF0000U;
+
+    // Reinterpret back as float
+    return sfpi::reinterpret<sfpi::vFloat>(bits);
+}
+
 template <bool is_fp32_dest_acc_en = false>
-sfpi_inline sfpi::vFloat _sfpu_binary_power_21f_(sfpi::vFloat base, sfpi::vFloat pow) {
-    // The algorithm works in two steps:
-    // 1) Compute log2(base)
-    // 2) Compute base**pow = 2**(pow * log2(base))
+sfpi_inline sfpi::vFloat _sfpu_binary_power_21f_(sfpi::vFloat in0, sfpi::vFloat in1) {
+    // fmod(a, b) = a - trunc(a/b) * b
+    //
+    // Key insight: fmod result must satisfy: |result| < |b|
+    // If this is violated, we need to correct the truncation.
 
-    // Step 1: Compute log2(base)
-    // Normalize base to calculation range
-    sfpi::vFloat absbase = setsgn(base, 0);       // set base as positive
-    sfpi::vFloat x = sfpi::setexp(absbase, 127);  // set exp to exp bias (put base in range of 1-2)
+    sfpi::vFloat a = in0;
+    sfpi::vFloat b = in1;
+    sfpi::vFloat b_abs = sfpi::abs(b);
 
-    // 3rd order polynomial approx - determined using rminimax over [1,2]
-    sfpi::vFloat series_result = x * (x * (x * 0x2.44734p-4f - 0xd.e712ap-4f) + 0x2.4f5388p+0f) - 0x1.952992p+0f;
+    // FIX 1: Handle a == b case (common for large values where a + offset = a)
+    // When a == b, fmod(a, b) = 0
+    // Use bit comparison: if a and b have same bits, result is 0
+    sfpi::vFloat a_minus_b = a - b;
 
-    // Convert exponent to float
-    sfpi::vInt exp = sfpi::exexp(base);
-    v_if(exp < 0) { exp = sfpi::setsgn(~exp + 1, 1); }
-    v_endif;
-    sfpi::vFloat exp_f32 = sfpi::int32_to_float(exp, 0);
+    // Step 1: Compute high-precision reciprocal 1/b
+    sfpi::vFloat recip = ckernel::sfpu::_sfpu_reciprocal_<2>(b);
 
-    // De-normalize to original range
-    const sfpi::vFloat vConst1Ln2 = sfpi::vConstFloatPrgm0;           // vConst1Ln2 = 1.4426950408889634f;
-    sfpi::vFloat log2_result = exp_f32 + series_result * vConst1Ln2;  // exp correction: ln(1+x) + exp*ln(2)
+    // Step 2: Compute a/b = a * (1/b)
+    sfpi::vFloat div_result = a * recip;
 
-    // Step 2: Compute base**pow = 2**(pow * log2(base))
-    // If (base, exponent) => (0, +inf) or (base, exponent) => (N, -inf) then output should be 0
-    // However, intermediary values can overflow, which leads to output increasing again instead of
-    // staying at 0.
-    // This overflow happens when z_f32 < -127. Therefore, we clamp z_f32 to -127.
-    sfpi::vFloat z_f32 = pow * log2_result;
-    const sfpi::vFloat low_threshold = sfpi::vConstFloatPrgm1;
-    v_if(z_f32 < low_threshold) { z_f32 = low_threshold; }
-    v_endif;
+    // Step 3: Compute trunc(a/b) using hand-optimised trunc implementation
+    sfpi::l_reg[sfpi::LRegs::LReg0] = div_result;
+    _trunc_body_();
+    sfpi::vFloat trunc_div = sfpi::l_reg[sfpi::LRegs::LReg1];
+    sfpi::vFloat tmp2 = sfpi::l_reg[sfpi::LRegs::LReg2];
+    sfpi::vFloat tmp3 = sfpi::l_reg[sfpi::LRegs::LReg3];
 
-    // The paper relies on the following formula (c.f. Sections 1 and 5):
-    // z = (bias + x * log2(a)) * N_m; where:
-    // N_m = 2**23
-    // bias = 0x3f800000
+    // Step 4: Compute fmod = a - trunc(a/b) * b
+    sfpi::vFloat result = a - trunc_div * b;
 
-    // In this case, we transform the formula to:
-    // z = (bias) * N_m + (x * log2(a)) * N_m
-    // where (bias + N_m) = 0x3f800000
-    // and (x * log2(a)) * N_m = addexp(z_f32, 23)
+    // FIX 2: Post-correction - fmod result must satisfy |result| < |b|
+    // If |result| >= |b|, the truncation was wrong by 1
+    sfpi::vFloat result_abs = sfpi::abs(result);
 
-    // Notes:
-    // - N_m being a power of 2 ensures equivalent results
-    // - addexp(z_f32, 23) is used because it translates to a single-cycle SFPDIVP2
-    //   instruction with immediate operand (i.e. no extra register used).
-    //   (vs. 1 cycle SFPLOADI + 2 cycles MAD)
-
-    z_f32 = addexp(z_f32, 23);  // equal to multiplying by 2**23
-    const sfpi::vFloat bias = sfpi::vFloat(0x3f800000);
-    sfpi::vInt z = _float_to_int32_positive_(z_f32 + bias);
-
-    sfpi::vInt zii = exexp(sfpi::reinterpret<sfpi::vFloat>(z));         // Note: z & 0x7f800000 in paper
-    sfpi::vInt zif = sfpi::exman9(sfpi::reinterpret<sfpi::vFloat>(z));  // Note: z & 0x007fffff in paper
-
-    // Compute formula in Horner form
-    sfpi::vFloat d1 = sfpi::vFloat(0.40196114e-7);
-    sfpi::vFloat d2 = sfpi::int32_to_float(sfpi::vInt(0xf94ee7) + zif, 0);
-    sfpi::vFloat d3 = sfpi::int32_to_float(sfpi::vInt(0x560e) + zif, 0);
-
-    d2 = d1 * d2;
-    zif = _float_to_int32_positive_(d2 * d3);
-
-    // Restore exponent
-    zii = sfpi::reinterpret<sfpi::vInt>(sfpi::setexp(sfpi::reinterpret<sfpi::vFloat>(zif), 127U + zii));
-
-    sfpi::vFloat y = sfpi::reinterpret<sfpi::vFloat>(zii);
-
-    // Post-processing: ensure that special values (e.g. 0**0, -1**0.5, ...) are handled correctly
-    // Check valid base range
-    sfpi::vInt pow_int =
-        sfpi::float_to_int16(pow, 0);  // int16 should be plenty, since large powers will approach 0/Inf
-    sfpi::vFloat pow_rounded = sfpi::int32_to_float(pow_int, 0);
-
-    // Division by 0 when base is 0 and pow is negative => set to NaN
-    v_if((absbase == 0.f) && pow < 0.f) {
-        y = sfpi::vConstFloatPrgm2;  // negative powers of 0 are NaN, e.g. pow(0, -1.5)
-    }
-    v_endif;
-
-    v_if(base < 0.0f) {  // negative base
-        // If pow is odd integer then result is negative
-        // If power is even, then result is positive
-        // To get the sign bit of result, we can shift last bit of pow_int to the 1st bit
-        y = setsgn(y, pow_int << 31);
-
-        // Check for integer power, if it is not then overwrite result with NaN
-        v_if(pow_rounded != pow) {  // negative base and non-integer power => set to NaN
-            y = sfpi::vConstFloatPrgm2;
+    // If result >= b, we truncated too low, add/subtract b to correct
+    v_if(result_abs >= b_abs) {
+        // Determine correction direction based on sign of result
+        v_if(result >= sfpi::vFloat(0.0f)) {
+            result = result - b_abs;  // result was positive and too big
+        }
+        v_else {
+            result = result + b_abs;  // result was negative and too big (magnitude)
         }
         v_endif;
     }
     v_endif;
 
-    if constexpr (!is_fp32_dest_acc_en) {
-        // LRegs work on float32 data. If DST is bfloat16 then SFPSTORE will truncate it.
-        // This can reduce accuracy: for instance, 9**2 = 80.8 gets round to 80.5
-        // rather than 81 (which would have been correct).
-        // To avoid this issue, we explicitly convert to bfloat16 using round-to-nearest-even.
-        y = reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(y, 0));
-    }
+    // FIX 3: If a == b (within FP precision), result should be exactly 0
+    // This handles edge case where a + small_offset = a due to FP precision
+    v_if(a_minus_b == sfpi::vFloat(0.0f)) { result = sfpi::vFloat(0.0f); }
+    v_endif;
 
-    return y;
+    // FIX 4: Sign correction - fmod result must have same sign as 'a' (or be zero)
+    // If a > 0 and result < 0, the truncation was 1 too high, need to add b
+    // If a < 0 and result > 0, the truncation was 1 too low, need to subtract b
+    // This fixes cases where a/b ≈ 0.9999999 but rounds to 1 due to reciprocal error
+    v_if(a >= sfpi::vFloat(0.0f)) {
+        // a is positive, result should be >= 0
+        v_if(result < sfpi::vFloat(0.0f)) {
+            result = result + b_abs;  // Correct: we over-truncated
+        }
+        v_endif;
+    }
+    v_else {
+        // a is negative, result should be <= 0
+        v_if(result > sfpi::vFloat(0.0f)) {
+            result = result - b_abs;  // Correct: we under-truncated
+        }
+        v_endif;
+    }
+    v_endif;
+
+    // // Normal rounding
+    // result = sfpi::reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(result, 0));
+
+    // Kalai's rounding
+    // result = float32_to_bf16_rne(result);
+
+    return result;
 }
 
 /**


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Provide context for the problem.

### What's changed
test file : 

- tests/ttnn/unit_tests/operations/eltwise/test_fmod_accuracy.py::test_fmod_tt_BF16_exhaustive_test
- tests/ttnn/unit_tests/operations/eltwise/test_fmod_accuracy.py::test_fmod_tt_FP32_exhaustive_test
- tests/ttnn/unit_tests/operations/eltwise/test_fmod_valid_range.py::test_fmod_tt_BF16_exhaustive_test
- tests/ttnn/unit_tests/operations/eltwise/test_fmod_valid_range.py::test_fmod_tt_FP32_exhaustive_test

**fmod Validation Range**

- fmod(x, y) is defined as x − trunc(x / y) * y. For BF16 and FP32, when |x / y| exceeds the integer precision of the dtype, x / y cannot be represented accurately, causing trunc(x / y) to be incorrect and leading to large remainder errors. This behavior is IEEE-754 and C++ standards compliant.
- SAMPLE DATA (FP32)
```
x_value,y_value,torch_out,tt_out,ulp_distance
16240345088.0,0.003662109375,0.001953125,-2047.99267578125,60
24293408768.0,0.0054931640625,0.001953125,-2047.989013671875,90
25635586048.0,0.00579833984375,0.001953125,-2047.98828125,96
```
- PyTorch handle this by internally promoting to higher dtype(fp64 when input is fp32) or applying argument-reduction(scaling by powers of two).
- To ensure meaningful accuracy validation:
  - BF16: |x / y| < 2⁷
  - FP32: |x / y| < 2²³
    - Inputs outside these ranges are not tested, not validation failures.

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=virdhatchani/fmod_LLK)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:virdhatchani/fmod_LLK)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=virdhatchani/fmod_LLK)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:virdhatchani/fmod_LLK)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=virdhatchani/fmod_LLK)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:virdhatchani/fmod_LLK)
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=virdhatchani/fmod_LLK)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:virdhatchani/fmod_LLK)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=virdhatchani/fmod_LLK)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:virdhatchani/fmod_LLK)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=virdhatchani/fmod_LLK)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:virdhatchani/fmod_LLK)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
