### PR TITLE
Skipping cores in reset when dumping debug bus signals in triage

### DIFF
--- a/tools/triage/dump_risc_debug_signals.py
+++ b/tools/triage/dump_risc_debug_signals.py
@@ -48,9 +48,11 @@ def dump_risc_debug_signals(
     If it throws an exception, collect and return debug bus signals.
     """
     noc_block = location._device.get_block(location)
+    risc_debug = noc_block.get_risc_debug(risc_name)
+    if risc_debug.is_in_reset():
+        return None
 
     try:
-        risc_debug = noc_block.get_risc_debug(risc_name)
         # Try to halt the core
         with risc_debug.ensure_halted():
             pass


### PR DESCRIPTION
We ran into issue when trying to dump risc's debug bus signals in `dump_risc_debug_bus.py` script. 
https://github.com/tenstorrent/tt-metal/actions/runs/21535314587/job/62060045576#step:7:7383

The problem is we are trying to halt core that is in reset and `tt-exalens` raises an exception that is not handled. Since these cores are not broken we should just skip them.

Triage tests: https://github.com/tenstorrent/tt-metal/actions/runs/21626435321