### PR TITLE
move possibly unused var inside useage scope

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads/device/kernels/dataflow/reader_tm_tile_layout_nlp_create_qkv_heads.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads/device/kernels/dataflow/reader_tm_tile_layout_nlp_create_qkv_heads.cpp
@@ -18,7 +18,6 @@ void kernel_main() {
     constexpr uint32_t q_num_tiles = get_compile_time_arg_val(0);
     constexpr uint32_t kv_num_tiles = get_compile_time_arg_val(1);
     constexpr auto in0_args = TensorAccessorArgs<2>();
-    constexpr auto in1_args = TensorAccessorArgs<in0_args.next_compile_time_args_offset()>();
 
     constexpr uint32_t cb_id_qv = 1;  // cb for Q, V heads
 #ifdef TRANSPOSE_K_HEADS
@@ -32,6 +31,7 @@ void kernel_main() {
     const auto s0 = TensorAccessor(in0_args, in0_tensor_addr, single_tile_size_bytes);
 
 #ifdef READ_FROM_INPUT_TENSOR_KV
+    constexpr auto in1_args = TensorAccessorArgs<in0_args.next_compile_time_args_offset()>();
     const auto s1 = TensorAccessor(in1_args, in1_tensor_addr, single_tile_size_bytes);
 #endif
 


### PR DESCRIPTION
Moves declaration of possibly unused var `in1_args` inside #ifdef scope in which it might be used to prevent JIT compiler warnings about possible unused var.

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=handrews/nlp-concat-compile-warning)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:handrews/nlp-concat-compile-warning)