### PR TITLE
Fixes for binary_ng and unary caching issues 

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_ng_cache.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_ng_cache.py
@@ -1,0 +1,261 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Program cache validation tests for binary_ng operations.
+
+Tests verify that the program cache correctly handles:
+1. Different worker_grid values (Bug #1 fix)
+2. Scalar presence/absence (Bug #2 fix)
+3. Different tensor shapes and broadcast patterns (Bug #3 fix)
+"""
+
+import pytest
+import torch
+import ttnn
+from loguru import logger
+
+pytestmark = pytest.mark.use_module_device
+
+
+def run_binary_ng(device, shape_a, shape_b=None, scalar=None, sub_core_grids=None, op=ttnn.add):
+    """Helper to run binary_ng operation with various configurations."""
+    torch.manual_seed(0)
+
+    # Create input tensors
+    input_a = torch.randn(shape_a, dtype=torch.bfloat16)
+    tt_input_a = ttnn.from_torch(input_a, layout=ttnn.TILE_LAYOUT, device=device, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+
+    if scalar is not None:
+        # Scalar operation
+        result = op(tt_input_a, scalar, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+    elif shape_b is not None:
+        # Tensor-tensor operation
+        input_b = torch.randn(shape_b, dtype=torch.bfloat16)
+        tt_input_b = ttnn.from_torch(input_b, layout=ttnn.TILE_LAYOUT, device=device, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+        if sub_core_grids is not None:
+            result = ttnn.experimental.operations.primary.binary_ng(
+                tt_input_a, tt_input_b, ttnn.BinaryOpType.ADD, sub_core_grids=sub_core_grids
+            )
+        else:
+            result = op(tt_input_a, tt_input_b, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+    else:
+        raise ValueError("Must provide either shape_b or scalar")
+
+    return result.cpu()
+
+
+@pytest.mark.parametrize(
+    "shape_a,shape_b",
+    [
+        ([1, 1, 32, 32], [1, 1, 32, 32]),  # No broadcast
+        ([1, 1, 64, 64], [1, 1, 64, 64]),  # Larger shape, no broadcast
+    ],
+)
+def test_binary_ng_cache_hit_identical_params(device, shape_a, shape_b):
+    """Test that identical operations produce cache hits."""
+    num_cache_entries = []
+
+    for iteration in range(2):
+        run_binary_ng(device, shape_a, shape_b)
+        # Dummy tensor to prevent address reuse
+        _ = ttnn.empty([1, 1, 32, 32], ttnn.bfloat16, ttnn.TILE_LAYOUT, device)
+        num_cache_entries.append(device.num_program_cache_entries())
+        logger.info(f"Iteration {iteration}: cache entries = {num_cache_entries[-1]}")
+
+    # Verify cache hit: entries shouldn't increase on second run
+    assert num_cache_entries[0] > 0, "Cache should have entries after first run"
+    assert num_cache_entries[0] == num_cache_entries[1], \
+        f"Cache hit expected: entries increased from {num_cache_entries[0]} to {num_cache_entries[1]}"
+
+
+@pytest.mark.parametrize(
+    "sub_core_grids_list",
+    [
+        # Different sub_core_grids should produce different cache entries
+        [
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(3, 3))}),
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(7, 7))}),
+        ],
+    ],
+)
+def test_binary_ng_cache_miss_different_worker_grids(device, sub_core_grids_list):
+    """
+    Bug #1 Fix Verification: Different worker_grid values should produce different cache entries.
+
+    Before fix: Different worker grids would hash to same value, causing incorrect core distribution.
+    After fix: worker_grid is included in hash, ensuring different programs for different grids.
+    """
+    shape_a = [1, 1, 64, 64]
+    shape_b = [1, 1, 64, 64]
+
+    cache_entries_before = device.num_program_cache_entries()
+
+    # Run with first sub_core_grid
+    run_binary_ng(device, shape_a, shape_b, sub_core_grids=sub_core_grids_list[0])
+    cache_entries_after_first = device.num_program_cache_entries()
+
+    # Run with second sub_core_grid
+    run_binary_ng(device, shape_a, shape_b, sub_core_grids=sub_core_grids_list[1])
+    cache_entries_after_second = device.num_program_cache_entries()
+
+    logger.info(f"Cache entries: before={cache_entries_before}, "
+                f"after_first={cache_entries_after_first}, "
+                f"after_second={cache_entries_after_second}")
+
+    # Different worker grids should create different cache entries
+    assert cache_entries_after_first > cache_entries_before, \
+        "First operation should create cache entry"
+    assert cache_entries_after_second > cache_entries_after_first, \
+        "Different worker_grid should create new cache entry (Bug #1 fix)"
+
+
+@pytest.mark.parametrize(
+    "shape",
+    [
+        [1, 1, 32, 32],
+        [1, 1, 64, 64],
+    ],
+)
+def test_binary_ng_cache_miss_scalar_vs_tensor(device, shape):
+    """
+    Bug #2 Fix Verification: Operations with scalar vs tensor should have different cache entries.
+
+    Before fix: scalar.has_value() was not hashed, could cause collisions.
+    After fix: scalar.has_value() is included in hash.
+    """
+    cache_entries_before = device.num_program_cache_entries()
+
+    # Run tensor-tensor operation
+    run_binary_ng(device, shape, shape_b=shape)
+    cache_entries_after_tensor = device.num_program_cache_entries()
+
+    # Run tensor-scalar operation
+    run_binary_ng(device, shape, scalar=2.5)
+    cache_entries_after_scalar = device.num_program_cache_entries()
+
+    logger.info(f"Cache entries: before={cache_entries_before}, "
+                f"after_tensor={cache_entries_after_tensor}, "
+                f"after_scalar={cache_entries_after_scalar}")
+
+    # Scalar vs tensor should create different cache entries
+    assert cache_entries_after_tensor > cache_entries_before, \
+        "Tensor operation should create cache entry"
+    assert cache_entries_after_scalar > cache_entries_after_tensor, \
+        "Scalar operation should create different cache entry (Bug #2 fix)"
+
+
+@pytest.mark.parametrize(
+    "shape_pairs",
+    [
+        # Different broadcast patterns with same output shape
+        [
+            ([1, 1, 32, 32], [1, 1, 32, 32]),  # No broadcast
+            ([1, 1, 32, 32], [1, 1, 1, 32]),   # Row broadcast
+            ([1, 1, 32, 32], [1, 1, 32, 1]),   # Column broadcast
+            ([1, 1, 32, 32], [1, 1, 1, 1]),    # Scalar broadcast
+        ],
+    ],
+)
+def test_binary_ng_cache_miss_different_broadcast_patterns(device, shape_pairs):
+    """
+    Bug #3 Fix Verification: Different broadcast patterns should produce different cache entries.
+
+    Before fix: Only shard_volumes was hashed, not tensor shapes, causing collisions
+                for different broadcast patterns.
+    After fix: logical_shape and padded_shape are explicitly hashed for both inputs.
+    """
+    initial_cache_entries = device.num_program_cache_entries()
+    cache_entries = [initial_cache_entries]
+
+    for i, (shape_a, shape_b) in enumerate(shape_pairs):
+        run_binary_ng(device, shape_a, shape_b)
+        current_entries = device.num_program_cache_entries()
+        cache_entries.append(current_entries)
+        logger.info(f"Shape pair {i} {shape_a} + {shape_b}: cache entries = {current_entries}")
+
+    # Each different broadcast pattern should create a new cache entry
+    for i in range(1, len(cache_entries)):
+        assert cache_entries[i] > cache_entries[i-1], \
+            f"Shape pair {i-1} should create new cache entry (Bug #3 fix): " \
+            f"{cache_entries[i-1]} -> {cache_entries[i]}"
+
+
+@pytest.mark.parametrize(
+    "shapes_and_layouts",
+    [
+        # Same shape, different layouts
+        [
+            ([1, 1, 64, 64], ttnn.TILE_LAYOUT),
+            ([1, 1, 64, 64], ttnn.ROW_MAJOR_LAYOUT),
+        ],
+    ],
+)
+def test_binary_ng_cache_miss_different_layouts(device, shapes_and_layouts):
+    """
+    Bug #3 Extended: Different layouts should produce different cache entries.
+
+    After fix: layout() is explicitly hashed for both inputs.
+    """
+    cache_entries_before = device.num_program_cache_entries()
+
+    # Run with first layout
+    shape, layout1 = shapes_and_layouts[0]
+    input_a = torch.randn(shape, dtype=torch.bfloat16)
+    tt_input_a = ttnn.from_torch(input_a, layout=layout1, device=device, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+    input_b = torch.randn(shape, dtype=torch.bfloat16)
+    tt_input_b = ttnn.from_torch(input_b, layout=layout1, device=device, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+    _ = ttnn.add(tt_input_a, tt_input_b, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+    cache_entries_after_first = device.num_program_cache_entries()
+
+    # Run with second layout
+    shape, layout2 = shapes_and_layouts[1]
+    input_a = torch.randn(shape, dtype=torch.bfloat16)
+    tt_input_a = ttnn.from_torch(input_a, layout=layout2, device=device, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+    input_b = torch.randn(shape, dtype=torch.bfloat16)
+    tt_input_b = ttnn.from_torch(input_b, layout=layout2, device=device, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+    _ = ttnn.add(tt_input_a, tt_input_b, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+    cache_entries_after_second = device.num_program_cache_entries()
+
+    logger.info(f"Cache entries: before={cache_entries_before}, "
+                f"after_layout1={cache_entries_after_first}, "
+                f"after_layout2={cache_entries_after_second}")
+
+    # Different layouts should create different cache entries
+    assert cache_entries_after_first > cache_entries_before, \
+        "First layout should create cache entry"
+    assert cache_entries_after_second > cache_entries_after_first, \
+        "Different layout should create new cache entry (Bug #3 fix - layout hashing)"
+
+
+@pytest.mark.parametrize(
+    "shapes_with_same_volume",
+    [
+        # Different shapes with same volume (512 elements)
+        [
+            [1, 1, 32, 64],
+            [1, 1, 64, 32],
+            [1, 1, 128, 16],
+        ],
+    ],
+)
+def test_binary_ng_cache_miss_different_shapes_same_volume(device, shapes_with_same_volume):
+    """
+    Bug #3 Extended: Different shapes with same volume should produce different cache entries.
+
+    This verifies that we hash actual shapes, not just volumes.
+    """
+    initial_cache_entries = device.num_program_cache_entries()
+    cache_entries = [initial_cache_entries]
+
+    for i, shape in enumerate(shapes_with_same_volume):
+        run_binary_ng(device, shape, shape_b=shape)
+        current_entries = device.num_program_cache_entries()
+        cache_entries.append(current_entries)
+        logger.info(f"Shape {i} {shape}: cache entries = {current_entries}")
+
+    # Each different shape should create a new cache entry, even with same volume
+    for i in range(1, len(cache_entries)):
+        assert cache_entries[i] > cache_entries[i-1], \
+            f"Shape {i-1} should create new cache entry: " \
+            f"{shapes_with_same_volume[i-1]} -> {shapes_with_same_volume[i]}"

--- a/tests/ttnn/unit_tests/operations/eltwise/test_unary_cache.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_unary_cache.py
@@ -1,0 +1,302 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Program cache validation tests for unary operations.
+
+Tests verify that the program cache correctly handles:
+1. Different shapes with same volume (Bug fix)
+2. Different logical vs padded shapes (Bug fix)
+3. Different layouts
+"""
+
+import pytest
+import torch
+import ttnn
+from loguru import logger
+
+pytestmark = pytest.mark.use_module_device
+
+
+def run_unary_op(device, shape, layout=ttnn.TILE_LAYOUT, op=ttnn.relu, sub_core_grids=None):
+    """Helper to run unary operation with various configurations."""
+    torch.manual_seed(0)
+
+    # Create input tensor
+    input_tensor = torch.randn(shape, dtype=torch.bfloat16)
+    tt_input = ttnn.from_torch(
+        input_tensor,
+        layout=layout,
+        device=device,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG
+    )
+
+    if sub_core_grids is not None:
+        # Use the lower-level API with sub_core_grids
+        result = ttnn.experimental.operations.primary.unary(
+            tt_input,
+            op_chain=[ttnn.UnaryWithParam(ttnn.UnaryOpType.RELU)],
+            sub_core_grids=sub_core_grids
+        )
+    else:
+        result = op(tt_input, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+
+    return result.cpu()
+
+
+@pytest.mark.parametrize(
+    "shape",
+    [
+        [1, 1, 32, 32],
+        [1, 1, 64, 64],
+    ],
+)
+def test_unary_cache_hit_identical_params(device, shape):
+    """Test that identical operations produce cache hits."""
+    num_cache_entries = []
+
+    for iteration in range(2):
+        run_unary_op(device, shape)
+        # Dummy tensor to prevent address reuse
+        _ = ttnn.empty([1, 1, 32, 32], ttnn.bfloat16, ttnn.TILE_LAYOUT, device)
+        num_cache_entries.append(device.num_program_cache_entries())
+        logger.info(f"Iteration {iteration}: cache entries = {num_cache_entries[-1]}")
+
+    # Verify cache hit: entries shouldn't increase on second run
+    assert num_cache_entries[0] > 0, "Cache should have entries after first run"
+    assert num_cache_entries[0] == num_cache_entries[1], \
+        f"Cache hit expected: entries increased from {num_cache_entries[0]} to {num_cache_entries[1]}"
+
+
+@pytest.mark.parametrize(
+    "shapes_with_same_volume",
+    [
+        # Different shapes with same volume (2048 elements for TILE layout)
+        [
+            [1, 1, 32, 64],
+            [1, 1, 64, 32],
+        ],
+    ],
+)
+def test_unary_cache_miss_different_shapes_same_volume(device, shapes_with_same_volume):
+    """
+    Bug Fix Verification: Different shapes with same volume should produce different cache entries.
+
+    Before fix: For TILE layout, only volume was hashed, causing collisions for different
+                shapes with same volume.
+    After fix: Full shape (logical_shape and padded_shape) is hashed for all layouts.
+    """
+    initial_cache_entries = device.num_program_cache_entries()
+    cache_entries = [initial_cache_entries]
+
+    for i, shape in enumerate(shapes_with_same_volume):
+        run_unary_op(device, shape)
+        current_entries = device.num_program_cache_entries()
+        cache_entries.append(current_entries)
+        logger.info(f"Shape {i} {shape}: cache entries = {current_entries}, "
+                   f"volume = {shape[-2] * shape[-1]}")
+
+    # Each different shape should create a new cache entry, even with same volume
+    for i in range(1, len(cache_entries)):
+        assert cache_entries[i] > cache_entries[i-1], \
+            f"Shape {i-1} should create new cache entry (Bug fix): " \
+            f"{shapes_with_same_volume[i-1]} (volume={shapes_with_same_volume[i-1][-2]*shapes_with_same_volume[i-1][-1]}) -> " \
+            f"{shapes_with_same_volume[i]} (volume={shapes_with_same_volume[i][-2]*shapes_with_same_volume[i][-1]})"
+
+
+@pytest.mark.parametrize(
+    "layout_pairs",
+    [
+        [ttnn.TILE_LAYOUT, ttnn.ROW_MAJOR_LAYOUT],
+    ],
+)
+def test_unary_cache_miss_different_layouts(device, layout_pairs):
+    """
+    Bug Fix Verification: Different layouts should produce different cache entries.
+
+    After fix: layout is explicitly hashed for input tensor.
+    """
+    shape = [1, 1, 64, 64]
+    cache_entries_before = device.num_program_cache_entries()
+
+    # Run with first layout
+    run_unary_op(device, shape, layout=layout_pairs[0])
+    cache_entries_after_first = device.num_program_cache_entries()
+
+    # Run with second layout
+    run_unary_op(device, shape, layout=layout_pairs[1])
+    cache_entries_after_second = device.num_program_cache_entries()
+
+    logger.info(f"Cache entries: before={cache_entries_before}, "
+                f"after_layout1={cache_entries_after_first}, "
+                f"after_layout2={cache_entries_after_second}")
+
+    # Different layouts should create different cache entries
+    assert cache_entries_after_first > cache_entries_before, \
+        "First layout should create cache entry"
+    assert cache_entries_after_second > cache_entries_after_first, \
+        "Different layout should create new cache entry (Bug fix - layout hashing)"
+
+
+@pytest.mark.parametrize(
+    "sub_core_grids_list",
+    [
+        # Different sub_core_grids should produce different cache entries
+        [
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(3, 3))}),
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(7, 7))}),
+        ],
+    ],
+)
+def test_unary_cache_miss_different_subcore_grids(device, sub_core_grids_list):
+    """
+    Verify that different sub_core_grids values produce different cache entries.
+
+    This validates that sub_core_grids is properly hashed (it already was before our fix).
+    """
+    shape = [1, 1, 64, 64]
+
+    cache_entries_before = device.num_program_cache_entries()
+
+    # Run with first sub_core_grid
+    run_unary_op(device, shape, sub_core_grids=sub_core_grids_list[0])
+    cache_entries_after_first = device.num_program_cache_entries()
+
+    # Run with second sub_core_grid
+    run_unary_op(device, shape, sub_core_grids=sub_core_grids_list[1])
+    cache_entries_after_second = device.num_program_cache_entries()
+
+    logger.info(f"Cache entries: before={cache_entries_before}, "
+                f"after_first={cache_entries_after_first}, "
+                f"after_second={cache_entries_after_second}")
+
+    # Different sub_core_grids should create different cache entries
+    assert cache_entries_after_first > cache_entries_before, \
+        "First operation should create cache entry"
+    assert cache_entries_after_second > cache_entries_after_first, \
+        "Different sub_core_grids should create new cache entry"
+
+
+@pytest.mark.parametrize(
+    "op_list",
+    [
+        [ttnn.relu, ttnn.gelu, ttnn.sigmoid, ttnn.abs],
+    ],
+)
+def test_unary_cache_miss_different_operations(device, op_list):
+    """
+    Verify that different unary operations produce different cache entries.
+
+    This is a sanity check that operation type is properly distinguished.
+    """
+    shape = [1, 1, 32, 32]
+    initial_cache_entries = device.num_program_cache_entries()
+    cache_entries = [initial_cache_entries]
+
+    for i, op in enumerate(op_list):
+        run_unary_op(device, shape, op=op)
+        current_entries = device.num_program_cache_entries()
+        cache_entries.append(current_entries)
+        logger.info(f"Operation {i} {op.__name__}: cache entries = {current_entries}")
+
+    # Each different operation should create a new cache entry
+    for i in range(1, len(cache_entries)):
+        assert cache_entries[i] > cache_entries[i-1], \
+            f"Operation {i-1} should create new cache entry: " \
+            f"{op_list[i-1].__name__} -> {op_list[i].__name__}"
+
+
+@pytest.mark.parametrize(
+    "shape_and_dtype_pairs",
+    [
+        # Same shape, different dtypes
+        [
+            ([1, 1, 32, 32], ttnn.bfloat16),
+            ([1, 1, 32, 32], ttnn.float32),
+        ],
+    ],
+)
+def test_unary_cache_miss_different_dtypes(device, shape_and_dtype_pairs):
+    """
+    Verify that different dtypes produce different cache entries.
+
+    This validates that dtype is properly hashed.
+    """
+    cache_entries_before = device.num_program_cache_entries()
+
+    # Run with first dtype
+    shape, dtype1 = shape_and_dtype_pairs[0]
+    input_tensor = torch.randn(shape, dtype=torch.float32)
+    tt_input = ttnn.from_torch(
+        input_tensor,
+        dtype=dtype1,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG
+    )
+    _ = ttnn.relu(tt_input, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+    cache_entries_after_first = device.num_program_cache_entries()
+
+    # Run with second dtype
+    shape, dtype2 = shape_and_dtype_pairs[1]
+    input_tensor = torch.randn(shape, dtype=torch.float32)
+    tt_input = ttnn.from_torch(
+        input_tensor,
+        dtype=dtype2,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG
+    )
+    _ = ttnn.relu(tt_input, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+    cache_entries_after_second = device.num_program_cache_entries()
+
+    logger.info(f"Cache entries: before={cache_entries_before}, "
+                f"after_dtype1={cache_entries_after_first}, "
+                f"after_dtype2={cache_entries_after_second}")
+
+    # Different dtypes should create different cache entries
+    assert cache_entries_after_first > cache_entries_before, \
+        "First dtype should create cache entry"
+    assert cache_entries_after_second > cache_entries_after_first, \
+        "Different dtype should create new cache entry"
+
+
+@pytest.mark.parametrize(
+    "shapes",
+    [
+        # Test multiple different shapes to ensure proper hashing
+        [
+            [1, 1, 32, 32],
+            [1, 1, 32, 64],
+            [1, 1, 64, 32],
+            [1, 1, 64, 64],
+            [1, 1, 128, 32],
+        ],
+    ],
+)
+def test_unary_cache_comprehensive_shape_coverage(device, shapes):
+    """
+    Comprehensive test: Multiple different shapes should each create new cache entries.
+
+    This validates that both logical_shape and padded_shape are properly hashed
+    across a variety of shape combinations.
+    """
+    initial_cache_entries = device.num_program_cache_entries()
+    cache_entries = [initial_cache_entries]
+
+    for i, shape in enumerate(shapes):
+        run_unary_op(device, shape)
+        current_entries = device.num_program_cache_entries()
+        cache_entries.append(current_entries)
+        logger.info(f"Shape {i} {shape}: cache entries = {current_entries}")
+
+    # Each different shape should create a new cache entry
+    for i in range(1, len(cache_entries)):
+        assert cache_entries[i] > cache_entries[i-1], \
+            f"Shape {i-1} should create new cache entry: " \
+            f"{shapes[i-1]} -> {shapes[i]}"
+
+    # Verify total increase matches number of unique shapes
+    total_new_entries = cache_entries[-1] - cache_entries[0]
+    assert total_new_entries >= len(shapes), \
+        f"Expected at least {len(shapes)} new cache entries, got {total_new_entries}"

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_device_operation.cpp
@@ -158,30 +158,24 @@ Tensor UnaryDeviceOperation::create_output_tensors(
 tt::stl::hash::hash_t UnaryDeviceOperation::compute_program_hash(
     const operation_attributes_t& args, const tensor_args_t& tensor_args) {
     const auto& input_tensor = tensor_args.input;
-    const auto& input_shape = input_tensor.padded_shape();
+    const auto& input_padded_shape = input_tensor.padded_shape();
+    const auto& input_logical_shape = input_tensor.logical_shape();
 
     auto program_factory = select_program_factory(args, tensor_args);
     operation::Hash hash;
 
-    if (input_tensor.layout() == Layout::TILE) {
-        hash = operation::hash_operation<UnaryDeviceOperation>(
-            args,
-            args.sub_core_grids,
-            program_factory.index(),
-            input_tensor.dtype(),
-            input_tensor.memory_config(),
-            input_shape.volume(),
-            input_tensor.layout());
-    } else {
-        hash = operation::hash_operation<UnaryDeviceOperation>(
-            args,
-            args.sub_core_grids,
-            program_factory.index(),
-            input_tensor.dtype(),
-            input_tensor.memory_config(),
-            input_shape,
-            input_tensor.layout());
-    }
+    // Hash both logical and padded shapes for all layouts
+    // - logical_shape affects computation correctness
+    // - padded_shape affects L1 buffer allocation
+    hash = operation::hash_operation<UnaryDeviceOperation>(
+        args,
+        args.sub_core_grids,
+        program_factory.index(),
+        input_tensor.dtype(),
+        input_tensor.memory_config(),
+        input_logical_shape,   // [HASH] Affects computation correctness
+        input_padded_shape,    // [HASH] Affects L1 buffer allocation
+        input_tensor.layout());
 
     return hash;
 }


### PR DESCRIPTION
### Ticket
#35229

### Problem description
Multiple caching issues exist in binary_ng and unary operations.
In particular:
- worker_grid values were not considered
- scalar vs. tensor 2nd input was not considered
- different tensor shapes and broadcasting patterns were not considered

### What's changed
Now handles properly earlier missed op caching parameters, in particular hash computations now considers such parameters.
In addition set of unit tests exploring those incorrect cases was added.

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=35229_caching_fixis)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:35229_caching_fixis)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=35229_caching_fixis)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:35229_caching_fixis)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=35229_caching_fixis)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:35229_caching_fixis)
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=35229_caching_fixis)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:35229_caching_fixis)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=35229_caching_fixis)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:35229_caching_fixis)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=35229_caching_fixis)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:35229_caching_fixis)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
