### PR TITLE
Disabling dumping debug bus signals in CI

### DIFF
--- a/.github/actions/setup-job/action.yml
+++ b/.github/actions/setup-job/action.yml
@@ -112,5 +112,4 @@ runs:
         echo "Enabling detection of timeout on fast dispatch and automatically call tt-triage"
         echo "TT_METAL_DISPATCH_TIMEOUT_COMMAND_TO_EXECUTE=/opt/venv/bin/python3 $(pwd)/tools/tt-triage.py --disable-progress 1>&2" >> $GITHUB_ENV
         echo "TT_METAL_OPERATION_TIMEOUT_SECONDS=${{ inputs.hang-detection-timeout }}" >> $GITHUB_ENV
-        echo "TT_RUN_DISABLED_TRIAGE_SCRIPTS_IN_CI=1" >> $GITHUB_ENV
       shell: bash


### PR DESCRIPTION
Disabling dumping debug bus signals in CI for now since for some workflows it is possible to overflow output with these therefore no other scripts output is shown.
We are in progress of refactoring this `dump_risc_debug_bus.py` to print its output to a file which later can be processed to give something similar to what we have now, but until this is done this script will remain disabled in CI. 

Issue tracking this: https://github.com/tenstorrent/tt-exalens/issues/885