### PR TITLE
#36030: Re-enable BH QB2 in post-commit and release

### DIFF
--- a/.github/workflows/blackhole-post-commit.yaml
+++ b/.github/workflows/blackhole-post-commit.yaml
@@ -301,7 +301,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        test-group: [ "BH-LLMBox", "BH-LoudBox", "P300-viommu" ]
+        test-group: [ "BH-LLMBox", "BH-LoudBox", "P300-viommu", "BH-QB-GE" ]
     with:
       arch: blackhole
       runner-label: ${{ matrix.test-group }}

--- a/.github/workflows/release-build-test-publish.yaml
+++ b/.github/workflows/release-build-test-publish.yaml
@@ -141,10 +141,10 @@ jobs:
             runner-label: P300-viommu
             extra-tag: pipeline-yyz2-lfc
             num_devices: 2
-          # - name: QuietBox Global Edition tests
-          #   runner-label: BH-QB-GE
-          #   extra-tag: pipeline-perf
-          #   num_devices: 4
+          - name: QuietBox Global Edition tests
+            runner-label: BH-QB-GE
+            extra-tag: pipeline-perf
+            num_devices: 4
     with:
       runner-label: ${{ matrix.test-group.runner-label }}
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}


### PR DESCRIPTION
### Ticket
Closes #36030

### What's changed
Revert pipeline disables now that QB2 is back with BMC


### Checklist

- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=williamly/bhpc-qb2)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:williamly/bhpc-qb2)
