### PR TITLE
add per core compile args

### DIFF
--- a/models/demos/deepseek_v3_b1/unified_kernel_descriptor.py
+++ b/models/demos/deepseek_v3_b1/unified_kernel_descriptor.py
@@ -53,6 +53,28 @@ class UnifiedKernelResult:
 
 
 @dataclass
+class PerCoreCompileTimeDescriptor:
+    """
+    Descriptor for a compile-time arg with unique values per core.
+
+    Unlike UnifiedCompileTimeCoreDescriptor which uses a single value for all cores
+    in a range, this allows specifying different values for each individual core.
+
+    Use case: When each core needs a unique compile-time value (e.g., bank_id, vc)
+    that cannot be computed from grid position (e.g., scattered non-rectangular grids).
+
+    Args:
+        named_compile_time_arg: Name of the compile-time arg (string)
+        core_values: List of (CoreCoord, value) tuples specifying the value for each core
+        other_value: Value for any cores NOT in the core_values list
+    """
+
+    named_compile_time_arg: str
+    core_values: list  # List of (CoreCoord, value) tuples
+    other_value: int
+
+
+@dataclass
 class UnifiedCompileTimeCoreDescriptor:
     """
     Descriptor for a compile-time arg that varies across core ranges.
@@ -104,6 +126,7 @@ class UnifiedKernelDescriptor:
         trisc_common_runtime_args: Common runtime args for compute (shared across all cores)
         trisc_compute_config: Optional compute configuration (math fidelity, fp32 acc, etc.)
         unified_compile_time_core_descriptors: List of per-core-range compile-time arg overrides
+        per_core_compile_time_descriptors: List of PerCoreCompileTimeDescriptor for individual core values
         defines: Preprocessor definitions as list of (name, value) tuples, e.g. [("SKIP_CCL", "1")]
     """
 
@@ -120,6 +143,7 @@ class UnifiedKernelDescriptor:
     trisc_common_runtime_args: list = field(default_factory=list)
     trisc_compute_config: Optional[ttnn.ComputeConfigDescriptor] = None
     unified_compile_time_core_descriptors: list = field(default_factory=list)
+    per_core_compile_time_descriptors: list = field(default_factory=list)  # List of PerCoreCompileTimeDescriptor
     defines: list = field(default_factory=list)  # List of (name, value) tuples
 
     def _get_core_range_set(
@@ -136,19 +160,18 @@ class UnifiedKernelDescriptor:
         """
         Generate kernel descriptors for all RISC processors.
 
-        If unified_compile_time_core_descriptors is empty, returns 3 descriptors
-        (one each for NCRISC, BRISC, TRISC).
+        If both unified_compile_time_core_descriptors and per_core_compile_time_descriptors
+        are empty, returns 3 descriptors (one each for NCRISC, BRISC, TRISC).
 
-        If unified_compile_time_core_descriptors is specified, returns multiple
-        kernel descriptors per processor to handle different compile-time args
-        for different core ranges.
+        If either is specified, returns multiple kernel descriptors per processor
+        to handle different compile-time args for different core ranges.
 
         Returns:
             UnifiedKernelResult containing:
             - kernels: List of KernelDescriptor objects
             - groups: List of KernelGroup objects for identifying kernels by role
         """
-        if not self.unified_compile_time_core_descriptors:
+        if not self.unified_compile_time_core_descriptors and not self.per_core_compile_time_descriptors:
             # Simple case: no per-core compile-time arg overrides
             return self._get_simple_kernel_descriptors()
 
@@ -221,20 +244,38 @@ class UnifiedKernelDescriptor:
         # Step 1: Enumerate all cores
         all_cores = ttnn.corerange_to_cores(self.core_ranges)
 
-        # Preconvert desc.core_range to CoreRangeSets for all descriptors
+        # Preconvert desc.core_range to CoreRangeSets for all unified descriptors
         desc_core_range_sets = [
             self._get_core_range_set(desc.core_range) for desc in self.unified_compile_time_core_descriptors
         ]
+
+        # Preprocess per-core descriptors into lookup dicts for fast access
+        per_core_lookup = {}  # {arg_name: {(x, y): value, ...}}
+        for desc in self.per_core_compile_time_descriptors:
+            arg_lookup = {}
+            for core_coord, value in desc.core_values:
+                arg_lookup[(core_coord.x, core_coord.y)] = value
+            per_core_lookup[desc.named_compile_time_arg] = (arg_lookup, desc.other_value)
 
         # Step 2: For each core, compute its complete named compile-time args
         core_to_args = {}
         for core_coord in all_cores:
             args = {}
+            # Process unified compile-time core descriptors (range-based)
             for desc, desc_core_range in zip(self.unified_compile_time_core_descriptors, desc_core_range_sets):
                 if desc_core_range.contains(core_coord):
                     args[desc.named_compile_time_arg] = desc.value
                 else:
                     args[desc.named_compile_time_arg] = desc.other_value
+
+            # Process per-core compile-time descriptors (individual core values)
+            core_key = (core_coord.x, core_coord.y)
+            for arg_name, (arg_lookup, other_value) in per_core_lookup.items():
+                if core_key in arg_lookup:
+                    args[arg_name] = arg_lookup[core_key]
+                else:
+                    args[arg_name] = other_value
+
             # Convert to frozen (hashable) form, use (x, y) tuple as key
             core_to_args[(core_coord.x, core_coord.y)] = tuple(sorted(args.items()))
 


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Add per core compile arg to generic op infra

### What's changed
Describe the approach used to solve the problem.
Summarize the changes made and its impact.

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=yugao/unified-kernel-descriptor-update)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:yugao/unified-kernel-descriptor-update)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=yugao/unified-kernel-descriptor-update)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:yugao/unified-kernel-descriptor-update)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=yugao/unified-kernel-descriptor-update)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:yugao/unified-kernel-descriptor-update)
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=yugao/unified-kernel-descriptor-update)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:yugao/unified-kernel-descriptor-update)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=yugao/unified-kernel-descriptor-update)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:yugao/unified-kernel-descriptor-update)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=yugao/unified-kernel-descriptor-update)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:yugao/unified-kernel-descriptor-update)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
