### PR TITLE
Multi-host Fabric tests

### DIFF
--- a/README_MULTIHOST_TESTS.md
+++ b/README_MULTIHOST_TESTS.md
@@ -1,0 +1,71 @@
+# Multi-Host Test Scripts
+
+This directory contains scripts and configuration files for running multi-host tests on Tenstorrent Galaxy clusters.
+
+## Quick Start
+
+### Prerequisites
+- SLURM allocation with 4 nodes
+- `TT_METAL_HOME` environment variable set
+- Passwordless SSH configured between hosts
+- Rankfiles present in the current directory
+
+### Running Tests
+
+**1. Allocate SLURM resources (4 nodes required for both tests):**
+```bash
+srun --partition=wh_pod_8x16_2 -N 4 --pty /bin/bash
+```
+
+**2. Navigate to TT_METAL_HOME:**
+```bash
+cd $TT_METAL_HOME
+```
+
+**3. Run the desired test script:**
+
+For **Dual Galaxy** tests (2 hosts):
+```bash
+./run_dual_galaxy_tests_commands.sh
+```
+
+For **Quad Galaxy** tests (4 hosts):
+```bash
+./run_quad_galaxy_tests_commands.sh
+```
+
+## Files
+
+- `run_dual_galaxy_tests_commands.sh` - Script for 2-host dual galaxy tests
+- `run_quad_galaxy_tests_commands.sh` - Script for 4-host quad galaxy tests
+- `rankfile_dual_galaxy` - MPI rankfile for 2 hosts
+- `rankfile_quad_galaxy` - MPI rankfile for 4 hosts
+- `MULTIHOST_TEST_INSTRUCTIONS.md` - Detailed instructions and troubleshooting
+
+## Detailed Documentation
+
+For detailed instructions, troubleshooting, and configuration options, see:
+**[MULTIHOST_TEST_INSTRUCTIONS.md](MULTIHOST_TEST_INSTRUCTIONS.md)**
+
+## Test Coverage
+
+### Dual Galaxy Tests
+- `test_all_to_all_dispatch_8x8_dual_galaxy`
+- `test_all_to_all_combine_8x8_dual_galaxy`
+
+### Quad Galaxy Tests
+- `test_all_to_all_dispatch_8x16_quad_galaxy`
+
+## Host Configuration
+
+**Dual Galaxy (2 hosts)**:
+- wh-glx-a04u02
+- wh-glx-a05u02
+
+**Quad Galaxy (4 hosts)**:
+- wh-glx-a04u02
+- wh-glx-a05u02
+- wh-glx-a05u08
+- wh-glx-a05u14
+
+To use different hosts, edit the rankfiles and update the host variables in the scripts.

--- a/rankfile_4galaxy_16partition
+++ b/rankfile_4galaxy_16partition
@@ -1,0 +1,27 @@
+# Rankfile for 4 galaxies split into 4 partitions each (16 ranks total)
+# Format: rank <rank_number>=<hostname> slot=<slot_number>
+# Each galaxy (host) has 4 partitions (ranks)
+
+# Host 0 (wh-glx-a04u02): ranks 0-3
+rank 0=wh-glx-a04u02 slot=0
+rank 1=wh-glx-a04u02 slot=1
+rank 2=wh-glx-a04u02 slot=2
+rank 3=wh-glx-a04u02 slot=3
+
+# Host 1 (wh-glx-a05u02): ranks 4-7
+rank 4=wh-glx-a05u02 slot=0
+rank 5=wh-glx-a05u02 slot=1
+rank 6=wh-glx-a05u02 slot=2
+rank 7=wh-glx-a05u02 slot=3
+
+# Host 2 (wh-glx-a05u08): ranks 8-11
+rank 8=wh-glx-a05u08 slot=0
+rank 9=wh-glx-a05u08 slot=1
+rank 10=wh-glx-a05u08 slot=2
+rank 11=wh-glx-a05u08 slot=3
+
+# Host 3 (wh-glx-a05u14): ranks 12-15
+rank 12=wh-glx-a05u14 slot=0
+rank 13=wh-glx-a05u14 slot=1
+rank 14=wh-glx-a05u14 slot=2
+rank 15=wh-glx-a05u14 slot=3

--- a/rankfile_dual_galaxy
+++ b/rankfile_dual_galaxy
@@ -1,0 +1,6 @@
+# Rankfile for dual galaxy setup
+# Format: rank <rank_number>=<hostname> slot=<slot_number>
+# For dual galaxy, we need 2 ranks (rank 0 and rank 1)
+
+rank 0=wh-glx-a04u02 slot=0
+rank 1=wh-glx-a05u02 slot=0

--- a/rankfile_quad_galaxy
+++ b/rankfile_quad_galaxy
@@ -1,0 +1,8 @@
+# Rankfile for quad galaxy setup
+# Format: rank <rank_number>=<hostname> slot=<slot_number>
+# For quad galaxy, we need 4 ranks (rank 0, 1, 2, 3)
+
+rank 0=wh-glx-a04u02 slot=0
+rank 1=wh-glx-a05u02 slot=0
+rank 2=wh-glx-a05u08 slot=0
+rank 3=wh-glx-a05u14 slot=0

--- a/run_4galaxy_16partition_physical_discovery.sh
+++ b/run_4galaxy_16partition_physical_discovery.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# Command to run physical discovery test with 4 galaxies split into 16 partitions
+
+# Set up variables
+RANK_BINDING="tests/tt_metal/distributed/config/4galaxy_16partition_rank_bindings.yaml"
+RANKFILE="$(pwd)/rankfile_4galaxy_16partition"
+HOSTS="wh-glx-a04u02,wh-glx-a05u02,wh-glx-a05u08,wh-glx-a05u14"
+
+# MPI arguments for multi-host communication
+MPI_ARGS="--host $HOSTS --rankfile $RANKFILE --oversubscribe --mca btl self,tcp --mca btl_tcp_if_exclude docker0,lo,tailscale0 --bind-to none --tag-output"
+
+# Ensure we're in TT_METAL_HOME
+if [[ -z "$TT_METAL_HOME" ]]; then
+    echo "Error: TT_METAL_HOME is not set. Please set it to the root of your tt-metal repository."
+    exit 1
+fi
+
+cd "$TT_METAL_HOME"
+
+echo "=========================================="
+echo "Running physical discovery test"
+echo "Configuration: 4 galaxies, 16 partitions (4 partitions per galaxy)"
+echo "=========================================="
+echo ""
+
+# Run physical discovery test
+tt-run --rank-binding "$RANK_BINDING" --mpi-args "$MPI_ARGS" ./build/test/tt_metal/tt_fabric/test_physical_discovery --gtest_filter="PhysicalDiscovery.*"

--- a/run_dual_galaxy_tests_commands.sh
+++ b/run_dual_galaxy_tests_commands.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+# Commands to run dual galaxy tests using tt-run
+# Based on .github/workflows/multi-host-physical.yaml and tests/scripts/multihost/run_dual_galaxy_tests.sh
+
+# Set up variables
+RANK_BINDING="tests/tt_metal/distributed/config/dual_galaxy_rank_bindings.yaml"
+RANKFILE="$(pwd)/rankfile_dual_galaxy"
+# For SLURM sessions with mpirun, try using --rankfile with --host
+# --host is needed for TCP BTL to establish connections between hosts
+# --bind-to none is important for multi-host communication
+# Using exclude instead of include - cnx1 interface doesn't exist on these hosts
+MPI_ARGS_BASE="--host wh-glx-a04u02,wh-glx-a05u02 --rankfile $RANKFILE --mca btl self,tcp --mca btl_tcp_if_exclude docker0,lo,tailscale0 --bind-to none --tag-output"
+MPI_ARGS_REVERSED="--host wh-glx-a05u02,wh-glx-a04u02 --rankfile $RANKFILE --mca btl self,tcp --mca btl_tcp_if_exclude docker0,lo,tailscale0 --bind-to none --tag-output"
+
+# Ensure we're in TT_METAL_HOME
+if [[ -z "$TT_METAL_HOME" ]]; then
+    echo "Error: TT_METAL_HOME is not set. Please set it to the root of your tt-metal repository."
+    exit 1
+fi
+
+cd "$TT_METAL_HOME"
+
+# Set up host list for MPI commands
+HOSTS="wh-glx-a04u02,wh-glx-a05u02"
+
+# Step 1: Reset hardware using MPI
+echo "=========================================="
+echo "Step 1: Running tt-smi -glx_reset on all hosts..."
+echo "=========================================="
+mpirun --host $HOSTS --mca btl_tcp_if_exclude docker0,lo,tailscale0 tt-smi -glx_reset
+if [[ $? -ne 0 ]]; then
+    echo "Error: Hardware reset failed"
+    exit 1
+fi
+sleep 5
+echo ""
+
+# Step 2: Run physical discovery test
+echo "=========================================="
+echo "Step 2: Running physical discovery test..."
+echo "=========================================="
+tt-run --rank-binding "$RANK_BINDING" --mpi-args "$MPI_ARGS_REVERSED" ./build/test/tt_metal/tt_fabric/test_physical_discovery --gtest_filter="PhysicalDiscovery.*"
+if [[ $? -ne 0 ]]; then
+    echo "Error: Physical discovery test failed"
+    exit 1
+fi
+echo ""
+
+# Test 1: test_all_to_all_dispatch_8x8_dual_galaxy
+# To run all parametrized variants:
+echo "Running test_all_to_all_dispatch_8x8_dual_galaxy (all variants)..."
+tt-run --rank-binding "$RANK_BINDING" --mpi-args "$MPI_ARGS_REVERSED" bash -c "source ./python_env/bin/activate && pytest -svv tests/nightly/tg/ccl/test_all_to_all_dispatch_6U.py::test_all_to_all_dispatch_8x8_dual_galaxy"
+
+# Or to run specific parametrized variants (matching the workflow):
+# echo "Running test_all_to_all_dispatch_8x8_dual_galaxy (fabric_2d variant)..."
+# tt-run --rank-binding "$RANK_BINDING" --mpi-args "$MPI_ARGS_REVERSED" bash -c "source ./python_env/bin/activate && pytest -svv \"tests/nightly/tg/ccl/test_all_to_all_dispatch_6U.py::test_all_to_all_dispatch_8x8_dual_galaxy[wormhole_b0-dram-dram-DataType.BFLOAT16-None-1-s2-7168-8-256-32-1-8x8_grid-False-fabric_2d]\""
+
+# echo "Running test_all_to_all_dispatch_8x8_dual_galaxy (fabric_1d_line variant)..."
+# tt-run --rank-binding "$RANK_BINDING" --mpi-args "$MPI_ARGS_REVERSED" bash -c "source ./python_env/bin/activate && pytest -svv \"tests/nightly/tg/ccl/test_all_to_all_dispatch_6U.py::test_all_to_all_dispatch_8x8_dual_galaxy[wormhole_b0-dram-dram-DataType.BFLOAT16-None-1-s2-7168-8-256-32-1-8x8_grid-False-fabric_1d_line]\""
+
+# Test 2: test_all_to_all_combine_8x8_dual_galaxy
+# To run all parametrized variants:
+echo "Running test_all_to_all_combine_8x8_dual_galaxy (all variants)..."
+tt-run --rank-binding "$RANK_BINDING" --mpi-args "$MPI_ARGS_REVERSED" bash -c "source ./python_env/bin/activate && pytest -svv tests/nightly/tg/ccl/test_all_to_all_combine_6U.py::test_all_to_all_combine_8x8_dual_galaxy"
+
+# Or to run specific parametrized variant (matching the workflow):
+# echo "Running test_all_to_all_combine_8x8_dual_galaxy (fabric_1d_line variant)..."
+# tt-run --rank-binding "$RANK_BINDING" --mpi-args "$MPI_ARGS_REVERSED" bash -c "source ./python_env/bin/activate && pytest -svv \"tests/nightly/tg/ccl/test_all_to_all_combine_6U.py::test_all_to_all_combine_8x8_dual_galaxy[wormhole_b0-dram-dram-DataType.BFLOAT16-None-num_links_1-2-sparse-s2-7168-8-256-32-axis_1-8x8_grid-False-fabric_1d_line]\""

--- a/run_quad_galaxy_tests_commands.sh
+++ b/run_quad_galaxy_tests_commands.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+# Commands to run quad galaxy tests using tt-run
+# Based on .github/workflows/multi-host-physical.yaml and tests/scripts/multihost/run_quad_galaxy_tests.sh
+
+# Set up variables for quad galaxy
+QUAD_RANK_BINDING="tests/tt_metal/distributed/config/quad_galaxy_rank_bindings.yaml"
+QUAD_RANKFILE="$(pwd)/rankfile_quad_galaxy"
+QUAD_HOSTS="wh-glx-a04u02,wh-glx-a05u02,wh-glx-a05u08,wh-glx-a05u14"
+# For SLURM sessions with mpirun, using --rankfile with --host
+# --host is needed for TCP BTL to establish connections between hosts
+# --bind-to none is important for multi-host communication
+# Using exclude instead of include - cnx1 interface doesn't exist on these hosts
+QUAD_MPI_ARGS="--host $QUAD_HOSTS --rankfile $QUAD_RANKFILE --mca btl self,tcp --mca btl_tcp_if_exclude docker0,lo,tailscale0 --bind-to none --tag-output"
+
+# Ensure we're in TT_METAL_HOME
+if [[ -z "$TT_METAL_HOME" ]]; then
+    echo "Error: TT_METAL_HOME is not set. Please set it to the root of your tt-metal repository."
+    exit 1
+fi
+
+cd "$TT_METAL_HOME"
+
+# Step 1: Reset hardware for quad galaxy (all 4 hosts)
+echo "=========================================="
+echo "Step 1: Running tt-smi -glx_reset on all 4 hosts..."
+echo "=========================================="
+mpirun --host $QUAD_HOSTS --mca btl_tcp_if_exclude docker0,lo,tailscale0 tt-smi -glx_reset
+if [[ $? -ne 0 ]]; then
+    echo "Error: Hardware reset failed for quad galaxy"
+    exit 1
+fi
+sleep 5
+echo ""
+
+# Step 2: Run physical discovery test (optional - uncomment if needed)
+# echo "=========================================="
+# echo "Step 2: Running physical discovery test..."
+# echo "=========================================="
+# tt-run --rank-binding "$QUAD_RANK_BINDING" --mpi-args "$QUAD_MPI_ARGS" ./build/test/tt_metal/tt_fabric/test_physical_discovery --gtest_filter="PhysicalDiscovery.*"
+# if [[ $? -ne 0 ]]; then
+#     echo "Error: Physical discovery test failed"
+#     exit 1
+# fi
+# echo ""
+
+# Test: test_all_to_all_dispatch_8x16_quad_galaxy
+echo "=========================================="
+echo "Running test_all_to_all_dispatch_8x16_quad_galaxy (all variants)..."
+echo "=========================================="
+tt-run --rank-binding "$QUAD_RANK_BINDING" --mpi-args "$QUAD_MPI_ARGS" bash -c "source ./python_env/bin/activate && pytest -svv tests/nightly/tg/ccl/test_all_to_all_dispatch_6U.py::test_all_to_all_dispatch_8x16_quad_galaxy"

--- a/run_quad_galaxy_tests_commands.sh
+++ b/run_quad_galaxy_tests_commands.sh
@@ -33,15 +33,15 @@ sleep 5
 echo ""
 
 # Step 2: Run physical discovery test (optional - uncomment if needed)
-# echo "=========================================="
-# echo "Step 2: Running physical discovery test..."
-# echo "=========================================="
-# tt-run --rank-binding "$QUAD_RANK_BINDING" --mpi-args "$QUAD_MPI_ARGS" ./build/test/tt_metal/tt_fabric/test_physical_discovery --gtest_filter="PhysicalDiscovery.*"
-# if [[ $? -ne 0 ]]; then
-#     echo "Error: Physical discovery test failed"
-#     exit 1
-# fi
-# echo ""
+echo "=========================================="
+echo "Step 2: Running physical discovery test..."
+echo "=========================================="
+tt-run --rank-binding "$QUAD_RANK_BINDING" --mpi-args "$QUAD_MPI_ARGS" ./build/test/tt_metal/tt_fabric/test_physical_discovery --gtest_filter="PhysicalDiscovery.*"
+if [[ $? -ne 0 ]]; then
+    echo "Error: Physical discovery test failed"
+    exit 1
+fi
+echo ""
 
 # Test: test_all_to_all_dispatch_8x16_quad_galaxy
 echo "=========================================="

--- a/tests/tt_metal/distributed/config/4galaxy_16partition_rank_bindings.yaml
+++ b/tests/tt_metal/distributed/config/4galaxy_16partition_rank_bindings.yaml
@@ -1,0 +1,117 @@
+rank_bindings:
+  # Host 0 (wh-glx-a04u02) - Partition 0: devices 0-7
+  - rank: 0
+    mesh_id: 0
+    mesh_host_rank: 0
+    env_overrides:
+      TT_VISIBLE_DEVICES: "0,1,2,3,4,5,6,7"
+
+  # Host 0 (wh-glx-a04u02) - Partition 1: devices 8-15
+  - rank: 1
+    mesh_id: 1
+    mesh_host_rank: 0
+    env_overrides:
+      TT_VISIBLE_DEVICES: "8,9,10,11,12,13,14,15"
+
+  # Host 0 (wh-glx-a04u02) - Partition 2: devices 16-23
+  - rank: 2
+    mesh_id: 2
+    mesh_host_rank: 0
+    env_overrides:
+      TT_VISIBLE_DEVICES: "16,17,18,19,20,21,22,23"
+
+  # Host 0 (wh-glx-a04u02) - Partition 3: devices 24-31
+  - rank: 3
+    mesh_id: 3
+    mesh_host_rank: 0
+    env_overrides:
+      TT_VISIBLE_DEVICES: "24,25,26,27,28,29,30,31"
+
+  # Host 1 (wh-glx-a05u02) - Partition 0: devices 0-7
+  - rank: 4
+    mesh_id: 4
+    mesh_host_rank: 0
+    env_overrides:
+      TT_VISIBLE_DEVICES: "0,1,2,3,4,5,6,7"
+
+  # Host 1 (wh-glx-a05u02) - Partition 1: devices 8-15
+  - rank: 5
+    mesh_id: 5
+    mesh_host_rank: 0
+    env_overrides:
+      TT_VISIBLE_DEVICES: "8,9,10,11,12,13,14,15"
+
+  # Host 1 (wh-glx-a05u02) - Partition 2: devices 16-23
+  - rank: 6
+    mesh_id: 6
+    mesh_host_rank: 0
+    env_overrides:
+      TT_VISIBLE_DEVICES: "16,17,18,19,20,21,22,23"
+
+  # Host 1 (wh-glx-a05u02) - Partition 3: devices 24-31
+  - rank: 7
+    mesh_id: 7
+    mesh_host_rank: 0
+    env_overrides:
+      TT_VISIBLE_DEVICES: "24,25,26,27,28,29,30,31"
+
+  # Host 2 (wh-glx-a05u08) - Partition 0: devices 0-7
+  - rank: 8
+    mesh_id: 8
+    mesh_host_rank: 0
+    env_overrides:
+      TT_VISIBLE_DEVICES: "0,1,2,3,4,5,6,7"
+
+  # Host 2 (wh-glx-a05u08) - Partition 1: devices 8-15
+  - rank: 9
+    mesh_id: 9
+    mesh_host_rank: 0
+    env_overrides:
+      TT_VISIBLE_DEVICES: "8,9,10,11,12,13,14,15"
+
+  # Host 2 (wh-glx-a05u08) - Partition 2: devices 16-23
+  - rank: 10
+    mesh_id: 10
+    mesh_host_rank: 0
+    env_overrides:
+      TT_VISIBLE_DEVICES: "16,17,18,19,20,21,22,23"
+
+  # Host 2 (wh-glx-a05u08) - Partition 3: devices 24-31
+  - rank: 11
+    mesh_id: 11
+    mesh_host_rank: 0
+    env_overrides:
+      TT_VISIBLE_DEVICES: "24,25,26,27,28,29,30,31"
+
+  # Host 3 (wh-glx-a05u14) - Partition 0: devices 0-7
+  - rank: 12
+    mesh_id: 12
+    mesh_host_rank: 0
+    env_overrides:
+      TT_VISIBLE_DEVICES: "0,1,2,3,4,5,6,7"
+
+  # Host 3 (wh-glx-a05u14) - Partition 1: devices 8-15
+  - rank: 13
+    mesh_id: 13
+    mesh_host_rank: 0
+    env_overrides:
+      TT_VISIBLE_DEVICES: "8,9,10,11,12,13,14,15"
+
+  # Host 3 (wh-glx-a05u14) - Partition 2: devices 16-23
+  - rank: 14
+    mesh_id: 14
+    mesh_host_rank: 0
+    env_overrides:
+      TT_VISIBLE_DEVICES: "16,17,18,19,20,21,22,23"
+
+  # Host 3 (wh-glx-a05u14) - Partition 3: devices 24-31
+  - rank: 15
+    mesh_id: 15
+    mesh_host_rank: 0
+    env_overrides:
+      TT_VISIBLE_DEVICES: "24,25,26,27,28,29,30,31"
+
+# Note: You may need to create a mesh graph descriptor for 16 independent meshes
+# For physical discovery, this path may not be critical, but for actual workloads you'll need
+# a proper multi-mesh descriptor that defines all 16 meshes
+mesh_graph_desc_path: "tt_metal/fabric/mesh_graph_descriptors/dual_galaxy_mesh_graph_descriptor.textproto"


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Provide context for the problem.

### What's changed
Describe the approach used to solve the problem.
Summarize the changes made and its impact.

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=ridvan/dual-quad-galaxy-exabox-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:ridvan/dual-quad-galaxy-exabox-tests)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ridvan/dual-quad-galaxy-exabox-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ridvan/dual-quad-galaxy-exabox-tests)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ridvan/dual-quad-galaxy-exabox-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ridvan/dual-quad-galaxy-exabox-tests)
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ridvan/dual-quad-galaxy-exabox-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ridvan/dual-quad-galaxy-exabox-tests)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ridvan/dual-quad-galaxy-exabox-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ridvan/dual-quad-galaxy-exabox-tests)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ridvan/dual-quad-galaxy-exabox-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ridvan/dual-quad-galaxy-exabox-tests)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
