### PR TITLE
Generate Welford reciprocals in Python and pass into distributed layernorm ops

### DIFF
--- a/models/tt_dit/layers/normalization.py
+++ b/models/tt_dit/layers/normalization.py
@@ -228,6 +228,10 @@ class DistributedLayerNorm(Module):
     Implements LayerNorm on an activation sharded on the reduction dimension.
     """
 
+    # Shared dictionary to store reciprocal tensors
+    # Key: width_per_device, Value: recip_tensor
+    _recip_tensors = {}
+
     def __init__(
         self,
         embedding_dim,
@@ -274,14 +278,21 @@ class DistributedLayerNorm(Module):
             else None
         )
 
-        # Create reciprocal tensor for Welford algorithm used in dit_layernorm_pre_allgather
+        # Create or reuse reciprocal tensor for Welford algorithm used in dit_layernorm_pre_allgather
         # Width per device is embedding_dim / mesh_width
         width_per_device = embedding_dim // self.mesh_width
-        grid = mesh_device.compute_with_storage_grid_size()
-        core_range_set = ttnn.CoreRangeSet(
-            {ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(grid.x - 1, grid.y - 1))}
-        )
-        self.recip_tensor = ttnn.create_layer_norm_reciprocals(mesh_device, core_range_set, width_per_device)
+
+        # Check if we already have a recip_tensor for this width_per_device
+        if width_per_device not in self._recip_tensors:
+            grid = mesh_device.compute_with_storage_grid_size()
+            core_range_set = ttnn.CoreRangeSet(
+                {ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(grid.x - 1, grid.y - 1))}
+            )
+            self._recip_tensors[width_per_device] = ttnn.create_layer_norm_reciprocals(
+                mesh_device, core_range_set, width_per_device
+            )
+
+        self.recip_tensor = self._recip_tensors[width_per_device]
 
     def _prepare_torch_state(self, state: dict[str, torch.Tensor]) -> None:
         weight = state.pop("weight", None)

--- a/models/tt_dit/layers/normalization.py
+++ b/models/tt_dit/layers/normalization.py
@@ -274,6 +274,15 @@ class DistributedLayerNorm(Module):
             else None
         )
 
+        # Create reciprocal tensor for Welford algorithm used in dit_layernorm_pre_allgather
+        # Width per device is embedding_dim / mesh_width
+        width_per_device = embedding_dim // self.mesh_width
+        grid = mesh_device.compute_with_storage_grid_size()
+        core_range_set = ttnn.CoreRangeSet(
+            {ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(grid.x - 1, grid.y - 1))}
+        )
+        self.recip_tensor = ttnn.create_layer_norm_reciprocals(mesh_device, core_range_set, width_per_device)
+
     def _prepare_torch_state(self, state: dict[str, torch.Tensor]) -> None:
         weight = state.pop("weight", None)
         bias = state.pop("bias", None)
@@ -313,6 +322,7 @@ class DistributedLayerNorm(Module):
 
         stats = ttnn.experimental.dit_layernorm_pre_allgather(
             x,
+            self.recip_tensor,
             compute_kernel_config=compute_kernel_config or self.compute_kernel_config,
         )
 

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/dit_layernorm_pre_all_gather/device/dit_layernorm_pre_all_gather_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/dit_layernorm_pre_all_gather/device/dit_layernorm_pre_all_gather_device_operation.hpp
@@ -16,7 +16,7 @@ namespace ttnn::experimental::prim {
 
 struct PreAllGatherDeviceOperation {
     using operation_attributes_t = DitLayernormPreAllGatherParams;
-    using tensor_args_t = Tensor;
+    using tensor_args_t = DitLayernormPreAllGatherInputs;
     using spec_return_value_t = TensorSpec;
     using tensor_return_value_t = Tensor;
     using program_factory_t = std::variant<PreAllGatherWelfordProgramFactory>;
@@ -36,6 +36,7 @@ namespace ttnn::prim {
 
 Tensor dit_layernorm_pre_all_gather(
     const Tensor& input,
+    const Tensor& recip_tensor,
     const std::optional<tt::tt_metal::DataType>& dtype,
     const DeviceComputeKernelConfig& compute_kernel_config,
     const tt::tt_metal::MemoryConfig& memory_config);

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/dit_layernorm_pre_all_gather/device/dit_layernorm_pre_all_gather_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/dit_layernorm_pre_all_gather/device/dit_layernorm_pre_all_gather_device_operation_types.hpp
@@ -17,4 +17,9 @@ struct DitLayernormPreAllGatherParams {
     tt::tt_metal::MemoryConfig memory_config;
 };
 
+struct DitLayernormPreAllGatherInputs {
+    Tensor input;
+    Tensor recip_tensor;
+};
+
 }  // namespace ttnn::experimental::prim

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/dit_layernorm_pre_all_gather/device/dit_layernorm_pre_all_gather_welford_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/dit_layernorm_pre_all_gather/device/dit_layernorm_pre_all_gather_welford_program_factory.hpp
@@ -21,12 +21,14 @@ struct PreAllGatherWelfordProgramFactory {
     using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
 
     static cached_program_t create(
-        const DitLayernormPreAllGatherParams& operation_attributes, const Tensor& tensor_args, Tensor& output);
+        const DitLayernormPreAllGatherParams& operation_attributes,
+        const DitLayernormPreAllGatherInputs& tensor_args,
+        Tensor& output);
 
     static void override_runtime_arguments(
         cached_program_t& cached_program,
         const DitLayernormPreAllGatherParams& operation_attributes,
-        const Tensor& tensor_args,
+        const DitLayernormPreAllGatherInputs& tensor_args,
         Tensor& output);
 };
 

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/dit_layernorm_pre_all_gather/dit_layernorm_pre_all_gather.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/dit_layernorm_pre_all_gather/dit_layernorm_pre_all_gather.cpp
@@ -10,6 +10,7 @@ namespace ttnn::operations::experimental::transformer {
 
 ttnn::Tensor ExecuteDitLayerNormPreAllGather::invoke(
     const ttnn::Tensor& input_tensor,
+    const ttnn::Tensor& recip_tensor,
     const DataType dtype,
     const std::optional<const DeviceComputeKernelConfig> compute_kernel_config,
     const std::optional<MemoryConfig>& memory_config) {
@@ -18,7 +19,7 @@ ttnn::Tensor ExecuteDitLayerNormPreAllGather::invoke(
         init_device_compute_kernel_config(arch, compute_kernel_config, MathFidelity::HiFi4, true, false, false);
 
     return ttnn::prim::dit_layernorm_pre_all_gather(
-        input_tensor, dtype, kernel_config_val, memory_config.value_or(input_tensor.memory_config()));
+        input_tensor, recip_tensor, dtype, kernel_config_val, memory_config.value_or(input_tensor.memory_config()));
 }
 
 }  // namespace ttnn::operations::experimental::transformer

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/dit_layernorm_pre_all_gather/dit_layernorm_pre_all_gather.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/dit_layernorm_pre_all_gather/dit_layernorm_pre_all_gather.hpp
@@ -17,6 +17,7 @@ struct ExecuteDitLayerNormPreAllGather {
     // Computes Welford stats (sum and sumsq) over the last dim for LayerNorm.
     static ttnn::Tensor invoke(
         const ttnn::Tensor& input_tensor,
+        const ttnn::Tensor& recip_tensor,
         DataType dtype = DataType::BFLOAT16,
         std::optional<const DeviceComputeKernelConfig> compute_kernel_config = std::nullopt,
         const std::optional<MemoryConfig>& memory_config = std::nullopt);

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/dit_layernorm_pre_all_gather/dit_layernorm_pre_all_gather_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/dit_layernorm_pre_all_gather/dit_layernorm_pre_all_gather_nanobind.cpp
@@ -22,6 +22,15 @@ void bind_dit_layernorm_pre_all_gather(nb::module_& mod) {
             producing a 2-tile-wide tensor with sum(x) and sum(x**2) per row (tile columns 0 and 1).
             Intended to be followed by an all-gather across devices, then ``dit_layernorm_post_allgather``.
 
+            Args:
+              input_tensor (ttnn.Tensor): the input tensor.
+              recip_tensor (ttnn.Tensor): the reciprocals tensor for Welford algorithm.
+
+            Keyword args:
+              dtype (ttnn.DataType, optional): the data type of the output tensor. Defaults to BFLOAT16.
+              compute_kernel_config (ttnn.DeviceComputeKernelConfig, optional): the compute kernel configuration.
+              memory_config (ttnn.MemoryConfig, optional): the memory configuration.
+
             Limitations:
               - Input must be TILE layout, on device, non-sharded.
               - Supported dtypes: BF16, BF8_B, FP32 for input; output stats are BF16.
@@ -29,6 +38,7 @@ void bind_dit_layernorm_pre_all_gather(nb::module_& mod) {
             )doc",
         ttnn::nanobind_arguments_t{
             nb::arg("input_tensor"),
+            nb::arg("recip_tensor"),
             nb::kw_only(),
             nb::arg("dtype") = nb::cast(DataType::BFLOAT16),
             nb::arg("compute_kernel_config") = nb::none(),

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/layernorm_common.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/layernorm_common.cpp
@@ -6,7 +6,6 @@
 #include "ttnn/operations/normalization/layernorm/device/layernorm_types.hpp"
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/constants.hpp>
-#include "ttnn/tensor/tensor.hpp"
 
 namespace ttnn::prim {
 
@@ -24,43 +23,6 @@ LayerNormProgramConfig create_layernorm_program_config(const std::optional<tt::t
         .block_w = spec.shape[1] / tt::constants::TILE_WIDTH,
         .inplace = false,
     };
-}
-
-std::pair<std::optional<tt::tt_metal::Tensor>, uint32_t> create_reciprocal_tensor_if_needed(
-    tt::tt_metal::IDevice* device, uint32_t W, const tt::tt_metal::CoreRangeSet& cores, const bool use_welford) {
-    const auto num_cores = cores.num_cores();
-    std::optional<tt::tt_metal::Tensor> recip_tensor = std::nullopt;
-    uint32_t reciprocal_CB_size_bytes = 0;
-    if (use_welford) {
-        const auto recip_dtype = tt::tt_metal::DataType::FLOAT32;
-        const tt::tt_metal::ShardSpec shard_spec(cores, {1, W}, tt::tt_metal::ShardOrientation::ROW_MAJOR);
-        const tt::tt_metal::MemoryConfig mem_config = tt::tt_metal::MemoryConfig{
-            tt::tt_metal::TensorMemoryLayout::HEIGHT_SHARDED, tt::tt_metal::BufferType::L1, shard_spec};
-        const tt::tt_metal::TensorLayout tensor_layout(
-            tt::tt_metal::TensorLayout(recip_dtype, tt::tt_metal::Layout::ROW_MAJOR, mem_config));
-        const tt::tt_metal::Shape tensor_shape{num_cores, W};
-        const tt::tt_metal::TensorSpec tensor_spec(tensor_shape, tensor_layout);
-        // Compute the reciprocals of an ascending sequence of integers
-        std::vector<float> reciprocals(num_cores * W);
-        for (uint32_t i = 0; i < W; i++) {
-            // Compute for first row
-            reciprocals[i] = 1.0f / (i + 1);
-        }
-        for (uint32_t i = 1; i < num_cores; i++) {
-            // Copy to other rows
-            std::copy(reciprocals.begin(), reciprocals.begin() + W, reciprocals.begin() + i * W);
-        }
-
-        if (auto* p_mesh_device = dynamic_cast<tt::tt_metal::distributed::MeshDevice*>(device)) {
-            recip_tensor = tt::tt_metal::Tensor::from_vector(std::move(reciprocals), tensor_spec, p_mesh_device);
-        } else {
-            TT_THROW("Cannot cast to MeshDevice");
-        }
-
-        reciprocal_CB_size_bytes = recip_tensor->buffer()->aligned_size_per_bank();
-    }
-
-    return std::make_pair(recip_tensor, reciprocal_CB_size_bytes);
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/layernorm_common.hpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/layernorm_common.hpp
@@ -13,9 +13,6 @@
 
 namespace ttnn::prim {
 
-std::pair<std::optional<tt::tt_metal::Tensor>, uint32_t> create_reciprocal_tensor_if_needed(
-    tt::tt_metal::IDevice* device, uint32_t W, const tt::tt_metal::CoreRangeSet& cores, bool use_welford);
-
 // Creates a program config from shard spec.
 // - If shard_spec has value, creates a sharded config derived from it
 // - Otherwise, returns a default interleaved config

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/layernorm_pre_all_gather_2d_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/layernorm_pre_all_gather_2d_program_factory.cpp
@@ -46,10 +46,12 @@ inline uint32_t pack_two_bfloat16_into_uint32(std::pair<uint16_t, uint16_t> two_
 
 // 2D Program Factory Implementation
 LayerNormPreAllGather2DProgramFactory::cached_program_t LayerNormPreAllGather2DProgramFactory::create(
-    const LayerNormPreAllGatherParams& operation_attributes, const Tensor& tensor_args, Tensor& output) {
+    const LayerNormPreAllGatherParams& operation_attributes,
+    const LayerNormPreAllGatherInputs& tensor_args,
+    Tensor& output) {
     using namespace CMAKE_UNIQUE_NAMESPACE;
 
-    const auto& a = tensor_args;
+    const auto& a = tensor_args.input;
     const bool is_rmsnorm = operation_attributes.norm_type == LayerNormDistributedType::RMSNORM;
     const auto& shape = a.padded_shape();
     const uint32_t W = shape[-1], H = shape[-2];

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/layernorm_pre_all_gather_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/layernorm_pre_all_gather_device_operation.cpp
@@ -35,24 +35,28 @@ LayerNormPreAllGatherDeviceOperation::program_factory_t LayerNormPreAllGatherDev
 
 void LayerNormPreAllGatherDeviceOperation::validate_on_program_cache_miss(
     const operation_attributes_t& args, const tensor_args_t& tensor_args) {
-    const auto& tensor = tensor_args;
+    const auto& input = tensor_args.input;
 
-    TT_FATAL(tensor.layout() == Layout::TILE, "Only tilized inputs supported.");
+    TT_FATAL(input.layout() == Layout::TILE, "Only tilized inputs supported.");
     TT_FATAL(
-        tensor.memory_config().memory_layout() == TensorMemoryLayout::INTERLEAVED,
-        "Only interleaved inputs supported.");
+        input.memory_config().memory_layout() == TensorMemoryLayout::INTERLEAVED, "Only interleaved inputs supported.");
     TT_FATAL(
-        tensor.dtype() == DataType::BFLOAT16 || tensor.dtype() == DataType::BFLOAT8_B ||
-            tensor.dtype() == DataType::FLOAT32,
+        input.dtype() == DataType::BFLOAT16 || input.dtype() == DataType::BFLOAT8_B ||
+            input.dtype() == DataType::FLOAT32,
         "Input data format not supported.");
-    TT_FATAL(tensor.storage_type() == StorageType::DEVICE, "Operands to layernorm need to be on device!");
-    TT_FATAL(tensor.buffer() != nullptr, "Operands to layernorm need to be allocated in buffers on device!");
+    TT_FATAL(input.storage_type() == StorageType::DEVICE, "Operands to layernorm need to be on device!");
+    TT_FATAL(input.buffer() != nullptr, "Operands to layernorm need to be allocated in buffers on device!");
 
-    // Additional validation for Welford - it doesn't support rmsnorm
+    // Additional validation for Welford - requires recip_tensor
     if (std::holds_alternative<LayerNormDefaultProgramConfig>(args.program_config)) {
         const auto& program_config = std::get<LayerNormDefaultProgramConfig>(args.program_config);
-        if (program_config.use_welford && args.norm_type == LayerNormDistributedType::RMSNORM) {
-            TT_FATAL(false, "RMS norm is not compatible with Welford algorithm. Please disable use_welford flag.");
+        if (program_config.use_welford) {
+            TT_FATAL(
+                args.norm_type != LayerNormDistributedType::RMSNORM,
+                "RMSNorm with Welford's algorithm not supported in pre_all_gather");
+            TT_FATAL(
+                tensor_args.recip_tensor.has_value(),
+                "Welford algorithm requires recip_tensor. Use ttnn.create_layer_norm_reciprocals() to create it.");
         }
     }
 
@@ -69,7 +73,7 @@ void LayerNormPreAllGatherDeviceOperation::validate_on_program_cache_miss(
 
 LayerNormPreAllGatherDeviceOperation::spec_return_value_t LayerNormPreAllGatherDeviceOperation::compute_output_specs(
     const operation_attributes_t& args, const tensor_args_t& tensor_args) {
-    const auto& input_tensor = tensor_args;
+    const auto& input_tensor = tensor_args.input;
 
     auto output_shape = input_tensor.logical_shape();
     uint32_t num_tiles_w = 1;
@@ -84,7 +88,7 @@ LayerNormPreAllGatherDeviceOperation::spec_return_value_t LayerNormPreAllGatherD
 
 LayerNormPreAllGatherDeviceOperation::tensor_return_value_t LayerNormPreAllGatherDeviceOperation::create_output_tensors(
     const operation_attributes_t& args, const tensor_args_t& tensor_args) {
-    return create_device_tensor(compute_output_specs(args, tensor_args), tensor_args.device());
+    return create_device_tensor(compute_output_specs(args, tensor_args), tensor_args.input.device());
 }
 
 }  // namespace ttnn::prim
@@ -93,6 +97,7 @@ namespace ttnn::prim {
 
 Tensor layer_norm_pre_all_gather(
     const Tensor& input,
+    const std::optional<Tensor>& recip_tensor,
     LayerNormDistributedType norm_type,
     const std::optional<tt::tt_metal::DataType>& dtype,
     const DeviceComputeKernelConfig& compute_kernel_config,
@@ -107,7 +112,10 @@ Tensor layer_norm_pre_all_gather(
             .program_config = program_config,
             .use_2d_core_grid = use_2d_core_grid,
         },
-        input);
+        OperationType::tensor_args_t{
+            .input = input,
+            .recip_tensor = recip_tensor,
+        });
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/layernorm_pre_all_gather_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/layernorm_pre_all_gather_device_operation.hpp
@@ -16,7 +16,7 @@ namespace ttnn::prim {
 
 struct LayerNormPreAllGatherDeviceOperation {
     using operation_attributes_t = LayerNormPreAllGatherParams;
-    using tensor_args_t = Tensor;
+    using tensor_args_t = LayerNormPreAllGatherInputs;
     using spec_return_value_t = TensorSpec;
     using tensor_return_value_t = Tensor;
     using program_factory_t = std::variant<
@@ -39,6 +39,7 @@ namespace ttnn::prim {
 
 Tensor layer_norm_pre_all_gather(
     const Tensor& input,
+    const std::optional<Tensor>& recip_tensor,
     LayerNormDistributedType norm_type,
     const std::optional<tt::tt_metal::DataType>& dtype,
     const DeviceComputeKernelConfig& compute_kernel_config,

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/layernorm_pre_all_gather_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/layernorm_pre_all_gather_device_operation_types.hpp
@@ -19,4 +19,9 @@ struct LayerNormPreAllGatherParams {
     std::optional<bool> use_2d_core_grid;
 };
 
+struct LayerNormPreAllGatherInputs {
+    Tensor input;
+    std::optional<Tensor> recip_tensor;
+};
+
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/layernorm_pre_all_gather_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/layernorm_pre_all_gather_program_factory.cpp
@@ -52,10 +52,12 @@ inline uint32_t pack_two_bfloat16_into_uint32(std::pair<uint16_t, uint16_t> two_
 // =============================================================================
 
 LayerNormPreAllGatherProgramFactory::cached_program_t LayerNormPreAllGatherProgramFactory::create(
-    const LayerNormPreAllGatherParams& operation_attributes, const Tensor& tensor_args, Tensor& output) {
+    const LayerNormPreAllGatherParams& operation_attributes,
+    const LayerNormPreAllGatherInputs& tensor_args,
+    Tensor& output) {
     using namespace CMAKE_UNIQUE_NAMESPACE;
 
-    const auto& a = tensor_args;
+    const auto& a = tensor_args.input;
     const bool is_rmsnorm = operation_attributes.norm_type == LayerNormDistributedType::RMSNORM;
     const auto& shape = a.padded_shape();
     const uint32_t W = shape[-1], H = shape[-2];
@@ -259,12 +261,12 @@ LayerNormPreAllGatherProgramFactory::cached_program_t LayerNormPreAllGatherProgr
 void LayerNormPreAllGatherProgramFactory::override_runtime_arguments(
     cached_program_t& cached_program,
     const LayerNormPreAllGatherParams& /*operation_attributes*/,
-    const Tensor& tensor_args,
+    const LayerNormPreAllGatherInputs& tensor_args,
     Tensor& output) {
     auto& shared_vars = cached_program.shared_variables;
     auto& program = cached_program.program;
 
-    const auto input_addr = tensor_args.buffer()->address();
+    const auto input_addr = tensor_args.input.buffer()->address();
     const auto output_addr = output.buffer()->address();
 
     auto& reader_runtime_args_by_core = tt::tt_metal::GetRuntimeArgs(program, shared_vars.reader_kernel_id);
@@ -290,10 +292,12 @@ void LayerNormPreAllGatherProgramFactory::override_runtime_arguments(
 // =============================================================================
 
 LayerNormPreAllGather2DProgramFactory::cached_program_t LayerNormPreAllGather2DProgramFactory::create(
-    const LayerNormPreAllGatherParams& operation_attributes, const Tensor& tensor_args, Tensor& output) {
+    const LayerNormPreAllGatherParams& operation_attributes,
+    const LayerNormPreAllGatherInputs& tensor_args,
+    Tensor& output) {
     using namespace CMAKE_UNIQUE_NAMESPACE;
 
-    const auto& a = tensor_args;
+    const auto& a = tensor_args.input;
     const auto& shape = a.padded_shape();
     const uint32_t W = shape[-1], H = shape[-2];
     const uint32_t HW = H * W;
@@ -504,12 +508,12 @@ LayerNormPreAllGather2DProgramFactory::cached_program_t LayerNormPreAllGather2DP
 void LayerNormPreAllGather2DProgramFactory::override_runtime_arguments(
     cached_program_t& cached_program,
     const LayerNormPreAllGatherParams& /*operation_attributes*/,
-    const Tensor& tensor_args,
+    const LayerNormPreAllGatherInputs& tensor_args,
     Tensor& output) {
     auto& shared_vars = cached_program.shared_variables;
     auto& program = cached_program.program;
 
-    const auto input_addr = tensor_args.buffer()->address();
+    const auto input_addr = tensor_args.input.buffer()->address();
     const auto output_addr = output.buffer()->address();
 
     auto& reader_runtime_args_by_core = tt::tt_metal::GetRuntimeArgs(program, shared_vars.reader_kernel_id);

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/layernorm_pre_all_gather_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/layernorm_pre_all_gather_program_factory.hpp
@@ -31,12 +31,14 @@ struct LayerNormPreAllGatherProgramFactory {
     using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
 
     static cached_program_t create(
-        const LayerNormPreAllGatherParams& operation_attributes, const Tensor& tensor_args, Tensor& output);
+        const LayerNormPreAllGatherParams& operation_attributes,
+        const LayerNormPreAllGatherInputs& tensor_args,
+        Tensor& output);
 
     static void override_runtime_arguments(
         cached_program_t& cached_program,
         const LayerNormPreAllGatherParams& operation_attributes,
-        const Tensor& tensor_args,
+        const LayerNormPreAllGatherInputs& tensor_args,
         Tensor& output);
 };
 
@@ -46,12 +48,14 @@ struct LayerNormPreAllGather2DProgramFactory {
     using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
 
     static cached_program_t create(
-        const LayerNormPreAllGatherParams& operation_attributes, const Tensor& tensor_args, Tensor& output);
+        const LayerNormPreAllGatherParams& operation_attributes,
+        const LayerNormPreAllGatherInputs& tensor_args,
+        Tensor& output);
 
     static void override_runtime_arguments(
         cached_program_t& cached_program,
         const LayerNormPreAllGatherParams& operation_attributes,
-        const Tensor& tensor_args,
+        const LayerNormPreAllGatherInputs& tensor_args,
         Tensor& output);
 };
 

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/layernorm_pre_all_gather_welford_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/layernorm_pre_all_gather_welford_program_factory.hpp
@@ -23,12 +23,14 @@ struct LayerNormPreAllGatherWelfordProgramFactory {
     using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
 
     static cached_program_t create(
-        const LayerNormPreAllGatherParams& operation_attributes, const Tensor& tensor_args, Tensor& output);
+        const LayerNormPreAllGatherParams& operation_attributes,
+        const LayerNormPreAllGatherInputs& tensor_args,
+        Tensor& output);
 
     static void override_runtime_arguments(
         cached_program_t& cached_program,
         const LayerNormPreAllGatherParams& operation_attributes,
-        const Tensor& tensor_args,
+        const LayerNormPreAllGatherInputs& tensor_args,
         Tensor& output);
 };
 

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/layernorm_distributed_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/layernorm_distributed_nanobind.cpp
@@ -45,6 +45,7 @@ void bind_normalization_layernorm_pre_all_gather_operation(nb::module_& mod) {
                 compute_kernel_config (ttnn.DeviceComputeKernelConfig, optional): the compute kernel configuration. Defaults to None.
                 program_config (ttnn.ProgramConfig, optional): the program configuration. Defaults to None.
                 memory_config (ttnn.MemoryConfig, optional): the memory configuration. Defaults to None.
+                recip_tensor (ttnn.Tensor, optional): the reciprocals tensor for Welford algorithm. Required when using Welford (use_welford=True in program_config). Create using :func:`ttnn.create_layer_norm_reciprocals`. Defaults to None.
 
               Returns:
                 ttnn.Tensor: the output tensor.
@@ -75,6 +76,7 @@ void bind_normalization_layernorm_pre_all_gather_operation(nb::module_& mod) {
                 - Unsharded runs: :attr:`input_tensor` must be interleaved.
                 - Sharded runs: inputs cannot be height-sharded, padded height must equal TILE_HEIGHT (32).
                 - When using :attr:`residual_input_tensor` with sharding, it must match the :attr:`input_tensor` padded shape and sharding.
+                - When using Welford algorithm (use_welford=True), :attr:`recip_tensor` must be provided.
         )doc",
         ttnn::nanobind_arguments_t{
             nb::arg("input_tensor"),
@@ -83,7 +85,8 @@ void bind_normalization_layernorm_pre_all_gather_operation(nb::module_& mod) {
             nb::arg("residual_input_tensor") = nb::none(),
             nb::arg("compute_kernel_config") = nb::none(),
             nb::arg("program_config") = nb::none(),
-            nb::arg("memory_config") = nb::none()});
+            nb::arg("memory_config") = nb::none(),
+            nb::arg("recip_tensor") = nb::none()});
 }
 
 void bind_normalization_layernorm_post_all_gather_operation(nb::module_& mod) {

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/layernorm_pre_all_gather.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/layernorm_pre_all_gather.cpp
@@ -16,7 +16,8 @@ ttnn::Tensor ExecuteLayerNormPreAllGather::invoke(
     const std::optional<const ttnn::Tensor>& residual_input_tensor,
     const std::optional<const DeviceComputeKernelConfig> compute_kernel_config,
     const std::optional<const ttnn::prim::LayerNormProgramConfig>& program_config,
-    const std::optional<MemoryConfig>& memory_config) {
+    const std::optional<MemoryConfig>& memory_config,
+    const std::optional<const ttnn::Tensor>& recip_tensor) {
     auto arch = input_tensor.storage_type() == StorageType::DEVICE ? input_tensor.device()->arch()
                                                                    : ttnn::GetDefaultDevice()->arch();
     auto kernel_config_val =
@@ -37,6 +38,7 @@ ttnn::Tensor ExecuteLayerNormPreAllGather::invoke(
     }
     return ttnn::prim::layer_norm_pre_all_gather(
         input_tensor,
+        recip_tensor,
         ttnn::prim::LayerNormDistributedType::LAYERNORM,
         dtype,
         kernel_config_val,

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/layernorm_pre_all_gather.hpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/layernorm_pre_all_gather.hpp
@@ -6,6 +6,7 @@
 
 #include "ttnn/decorators.hpp"
 #include "device/layernorm_distributed_types.hpp"
+#include "device/layernorm_pre_all_gather_device_operation_types.hpp"
 #include "ttnn/operations/normalization/layernorm/device/layernorm_types.hpp"
 #include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
 
@@ -19,7 +20,8 @@ struct ExecuteLayerNormPreAllGather {
         const std::optional<const ttnn::Tensor>& residual_input_tensor = std::nullopt,
         std::optional<const DeviceComputeKernelConfig> compute_kernel_config = std::nullopt,
         const std::optional<const ttnn::prim::LayerNormProgramConfig>& program_config = std::nullopt,
-        const std::optional<MemoryConfig>& memory_config = std::nullopt);
+        const std::optional<MemoryConfig>& memory_config = std::nullopt,
+        const std::optional<const ttnn::Tensor>& recip_tensor = std::nullopt);
 };
 
 }  // namespace operations::normalization

--- a/ttnn/cpp/ttnn/operations/normalization/rmsnorm_distributed/rmsnorm_pre_all_gather.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/rmsnorm_distributed/rmsnorm_pre_all_gather.cpp
@@ -38,6 +38,7 @@ ttnn::Tensor ExecuteRMSNormPreAllGather::invoke(
     }
     return ttnn::prim::layer_norm_pre_all_gather(
         input_tensor,
+        std::nullopt,  // recip_tensor not needed for rmsnorm (second argument)
         ttnn::prim::LayerNormDistributedType::RMSNORM,
         dtype,
         kernel_config_val,


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/37047

### Problem description
Welford layernorm kernels require a sharded tensor of reciprocals (well, not technically, but it's over 5x faster if you provide it). Previously, this tensor was being generated in the program factories. However, this is unsafe, as the tensor goes out of scope at the end of the factory, and data could potentially be dangling.

The non-distributed paths were addressed in https://github.com/tenstorrent/tt-metal/pull/36732. This is to fix the distributed paths, namely:
- ttnn.layer_norm_pre_all_gather
- ttnn.experimental.dit_layernorm_pre_allgather

### What's changed
Just a bunch of plumbing to take in and use the reciprocals, and changed the call sites to generate and pass in the reciprocals

### Checklist

- [x] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:{{branch_name}})
- [x] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:{{branch_name}})
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:{{branch_name}})
- [x] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:{{branch_name}})
  - [x] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:{{branch_name}})
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:{{branch_name}})
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
