### PR TITLE
Add fused post sdpa op

### DIFF
--- a/models/demos/deepseek_v3_b1/fused_ops/post_sdpa/kernels/post_sdpa_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/fused_ops/post_sdpa/kernels/post_sdpa_kernel.cpp
@@ -1,0 +1,267 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+// SPDX-License-Identifier: Apache-2.0
+
+// Post SDPA unified kernel
+// Single kernel file, compiles correctly for all RISC cores
+// Each RISC has its own CTArgs struct with different compile-time arg layout
+//
+// Implements: Matmul1 + Gather1 + Mcast + Matmul2 + Gather2
+// - Matmul1: [1, 512] x [512, 128] -> [1, 128] on 64 cores (8x8)
+// - Gather1: Collect [1, 128] from 64 cores to [1, 8192] on gather core
+// - Mcast: Broadcast [1, 8192] to 96 cores (12x8)
+// - Matmul2: [1, 8192] x [8192, 64] -> [1, 64] on 96 cores
+// - Gather2: Collect [1, 64] from 96 cores to [1, 6144] on gather core
+
+#include "../../../unified_kernels/kernel_op_api.hpp"
+#include "../../../unified_kernels/kernel_utils.hpp"
+#include "../../../unified_kernels/matmul.hpp"
+#include "../../../unified_kernels/gather.hpp"
+#include "../../../unified_kernels/mcast.hpp"
+
+// Compile-time role flags for dead code elimination via if constexpr
+struct Core {
+    // First matmul on 8x8 grid
+    static constexpr bool is_matmul1_core = get_named_compile_time_arg_val("is_matmul1_core") == 1;
+    // Gather core (11, 9) - receives gather1, sends mcast, receives gather2
+    static constexpr bool is_gather_receiver_core = get_named_compile_time_arg_val("is_gather_receiver_core") == 1;
+    // Mcast receiver grid = matmul2 grid (12x8)
+    static constexpr bool is_matmul2_core = get_named_compile_time_arg_val("is_matmul2_core") == 1;
+};
+
+void kernel_main() {
+// ============================================================================
+// NCRISC (Reader)
+// - Matmul1 reader (8x8 grid): setup sharded buffers
+// - Gather1 sender (8x8 grid): send matmul1 output to gather core
+// - Mcast receiver (12x8 grid): receive mcast data
+// - Matmul2 reader (12x8 grid): setup weights buffer
+// - Gather2 sender (12x8 grid): send matmul2 output to gather core
+// ============================================================================
+#if defined(COMPILE_FOR_NCRISC)
+    // Matmul1 CTArgs
+    using Matmul1CTArgs = deepseek_b1_ops::Matmul::ReaderCTArgs;
+    deepseek_b1_ops::Matmul::ReaderArgs matmul1_args{};
+
+    // Gather1 sender args
+    deepseek_b1_ops::Gather::SenderArgs gather1_args{
+        get_named_compile_time_arg_val("gather1_dest_noc_x"),
+        get_named_compile_time_arg_val("gather1_dest_noc_y"),
+        get_named_compile_time_arg_val("gather1_data_size_bytes"),
+        get_named_compile_time_arg_val("gather1_receiver_semaphore_id"),
+        get_named_compile_time_arg_val("gather1_src_cb"),
+        get_named_compile_time_arg_val("gather1_src_num_pages"),
+        get_named_compile_time_arg_val("gather1_sender_grid_start_x"),
+        get_named_compile_time_arg_val("gather1_sender_grid_start_y"),
+        get_named_compile_time_arg_val("gather1_sender_grid_end_x"),
+        get_named_compile_time_arg_val("gather1_sender_grid_end_y"),
+        get_named_compile_time_arg_val("gather1_row_major"),
+        get_named_compile_time_arg_val("gather1_receiver_data_addr"),
+    };
+
+    // Mcast receiver args
+    using McastCTArgs = deepseek_b1_ops::Mcast::ReceiverCTArgs;
+    deepseek_b1_ops::Mcast::ReceiverArgs mcast_args{
+        get_named_compile_time_arg_val("mcast_data_receiver_semaphore"),
+        get_named_compile_time_arg_val("mcast_dst_cb"),
+        get_named_compile_time_arg_val("mcast_dst_num_pages"),
+    };
+
+    // Matmul2 CTArgs
+    using Matmul2CTArgs = deepseek_b1_ops::Matmul::ReaderCTArgs;
+    deepseek_b1_ops::Matmul::ReaderArgs matmul2_args{};
+
+    // Gather2 sender args
+    deepseek_b1_ops::Gather::SenderArgs gather2_args{
+        get_named_compile_time_arg_val("gather2_dest_noc_x"),
+        get_named_compile_time_arg_val("gather2_dest_noc_y"),
+        get_named_compile_time_arg_val("gather2_data_size_bytes"),
+        get_named_compile_time_arg_val("gather2_receiver_semaphore_id"),
+        get_named_compile_time_arg_val("gather2_src_cb"),
+        get_named_compile_time_arg_val("gather2_src_num_pages"),
+        get_named_compile_time_arg_val("gather2_sender_grid_start_x"),
+        get_named_compile_time_arg_val("gather2_sender_grid_start_y"),
+        get_named_compile_time_arg_val("gather2_sender_grid_end_x"),
+        get_named_compile_time_arg_val("gather2_sender_grid_end_y"),
+        get_named_compile_time_arg_val("gather2_row_major"),
+        get_named_compile_time_arg_val("gather2_receiver_data_addr"),
+    };
+
+// ============================================================================
+// BRISC (Writer)
+// - Gather1 receiver (gather core): receive from 8x8 grid
+// - Mcast sender (gather core): broadcast to 12x8 grid
+// - Gather2 receiver (gather core): receive from 12x8 grid
+// ============================================================================
+#elif defined(COMPILE_FOR_BRISC)
+    // Matmul1/2 CTArgs (BRISC is no-op for matmul)
+    using Matmul1CTArgs = deepseek_b1_ops::Matmul::WriterCTArgs;
+    using Matmul2CTArgs = deepseek_b1_ops::Matmul::WriterCTArgs;
+    deepseek_b1_ops::Matmul::WriterArgs matmul1_args{};
+    deepseek_b1_ops::Matmul::WriterArgs matmul2_args{};
+
+    // Gather1 receiver args
+    deepseek_b1_ops::Gather::ReceiverArgs gather1_args{
+        get_named_compile_time_arg_val("gather1_noc0_num_senders"),
+        get_named_compile_time_arg_val("gather1_noc1_num_senders"),
+        get_named_compile_time_arg_val("gather1_noc0_receiver_semaphore_id"),
+        get_named_compile_time_arg_val("gather1_noc1_receiver_semaphore_id"),
+        get_named_compile_time_arg_val("gather1_dst_cb"),
+        get_named_compile_time_arg_val("gather1_dst_num_pages"),
+    };
+
+    // Mcast sender args
+    using McastCTArgs = deepseek_b1_ops::Mcast::SenderCTArgs<
+        get_named_compile_time_arg_val("mcast_num_cores"),
+        get_named_compile_time_arg_val("mcast_is_part_of_receiver_grid") == 1,
+        false>;  // loopback = false (gather core not in mcast grid)
+
+    constexpr uint32_t mcast_src_cb = get_named_compile_time_arg_val("mcast_src_cb");
+    constexpr uint32_t mcast_dst_cb = get_named_compile_time_arg_val("mcast_dst_cb");
+    deepseek_b1_ops::Mcast::SenderArgs mcast_args{
+        get_named_compile_time_arg_val("mcast_dest_noc_start_x"),
+        get_named_compile_time_arg_val("mcast_dest_noc_start_y"),
+        get_named_compile_time_arg_val("mcast_dest_noc_end_x"),
+        get_named_compile_time_arg_val("mcast_dest_noc_end_y"),
+        get_named_compile_time_arg_val("mcast_data_sender_semaphore"),
+        get_named_compile_time_arg_val("mcast_data_receiver_semaphore"),
+        get_named_compile_time_arg_val("mcast_data_size_bytes"),
+        mcast_src_cb,
+        get_named_compile_time_arg_val("mcast_src_num_pages"),
+        get_read_ptr(mcast_src_cb),
+        get_write_ptr(mcast_dst_cb),  // CB 4 address (now allocated on gather core too)
+    };
+
+    // Gather2 receiver args
+    deepseek_b1_ops::Gather::ReceiverArgs gather2_args{
+        get_named_compile_time_arg_val("gather2_noc0_num_senders"),
+        get_named_compile_time_arg_val("gather2_noc1_num_senders"),
+        get_named_compile_time_arg_val("gather2_noc0_receiver_semaphore_id"),
+        get_named_compile_time_arg_val("gather2_noc1_receiver_semaphore_id"),
+        get_named_compile_time_arg_val("gather2_dst_cb"),
+        get_named_compile_time_arg_val("gather2_dst_num_pages"),
+    };
+
+// ============================================================================
+// TRISC (Compute)
+// - Matmul1 compute (8x8 grid)
+// - Matmul2 compute (12x8 grid)
+// ============================================================================
+#elif defined(COMPILE_FOR_TRISC)
+    // Matmul1 CTArgs
+    using Matmul1CTArgs =
+        deepseek_b1_ops::Matmul::ComputeCTArgs<get_named_compile_time_arg_val("matmul1_out_w_per_core")>;
+    deepseek_b1_ops::Matmul::ComputeArgs matmul1_args{
+        get_named_compile_time_arg_val("matmul1_in0"),
+        get_named_compile_time_arg_val("matmul1_in1"),
+        get_named_compile_time_arg_val("matmul1_out"),
+        get_named_compile_time_arg_val("matmul1_k_num_tiles"),
+    };
+
+    // Gather1 compute args (no-op)
+    deepseek_b1_ops::Gather::ComputeArgs gather1_args{};
+
+    // Mcast CTArgs (no-op)
+    using McastCTArgs = deepseek_b1_ops::Mcast::ComputeCTArgs;
+    deepseek_b1_ops::Mcast::ComputeArgs mcast_args{};
+
+    // Matmul2 CTArgs
+    using Matmul2CTArgs =
+        deepseek_b1_ops::Matmul::ComputeCTArgs<get_named_compile_time_arg_val("matmul2_out_w_per_core")>;
+    deepseek_b1_ops::Matmul::ComputeArgs matmul2_args{
+        get_named_compile_time_arg_val("matmul2_in0"),
+        get_named_compile_time_arg_val("matmul2_in1"),
+        get_named_compile_time_arg_val("matmul2_out"),
+        get_named_compile_time_arg_val("matmul2_k_num_tiles"),
+    };
+
+    // Gather2 compute args (no-op)
+    deepseek_b1_ops::Gather::ComputeArgs gather2_args{};
+#endif
+
+    // ========================================================================
+    // Setup sharded buffers (NCRISC only)
+    // ========================================================================
+#if defined(COMPILE_FOR_NCRISC)
+    // Matmul1 buffers (8x8 grid)
+    if constexpr (Core::is_matmul1_core) {
+        constexpr uint32_t matmul1_in0 = get_named_compile_time_arg_val("matmul1_in0");
+        constexpr uint32_t matmul1_k_num_tiles = get_named_compile_time_arg_val("matmul1_k_num_tiles");
+        unified_kernels::setup_sharded_buffer(matmul1_in0, matmul1_k_num_tiles);
+
+        constexpr uint32_t matmul1_in1 = get_named_compile_time_arg_val("matmul1_in1");
+        constexpr uint32_t matmul1_out_w_per_core = get_named_compile_time_arg_val("matmul1_out_w_per_core");
+        unified_kernels::setup_sharded_buffer(matmul1_in1, matmul1_k_num_tiles * matmul1_out_w_per_core);
+    }
+
+    // Matmul2 buffers (12x8 grid) - weights only, input comes from mcast
+    if constexpr (Core::is_matmul2_core) {
+        constexpr uint32_t matmul2_in1 = get_named_compile_time_arg_val("matmul2_in1");
+        constexpr uint32_t matmul2_k_num_tiles = get_named_compile_time_arg_val("matmul2_k_num_tiles");
+        constexpr uint32_t matmul2_out_w_per_core = get_named_compile_time_arg_val("matmul2_out_w_per_core");
+        unified_kernels::setup_sharded_buffer(matmul2_in1, matmul2_k_num_tiles * matmul2_out_w_per_core);
+    }
+#endif
+
+    // ========================================================================
+    // Matmul1: [1, 512] x [512, 128] -> [1, 128] per core (8x8 grid)
+    // ========================================================================
+    {
+        DeviceZoneScopedN("MATMUL1");
+        deepseek_b1_ops::Matmul::Op<Matmul1CTArgs, Core::is_matmul1_core, true, false> matmul1;
+        matmul1(matmul1_args);
+    }
+
+    // ========================================================================
+    // Gather1: 8x8 matmul cores -> gather core (11, 9)
+    // Collects [1, 128] * 64 = [1, 8192]
+    // ========================================================================
+    {
+        DeviceZoneScopedN("GATHER1");
+        deepseek_b1_ops::Gather::Op<Core::is_matmul1_core, Core::is_gather_receiver_core, true> gather1;
+        gather1(gather1_args);
+    }
+
+    // ========================================================================
+    // Mcast: gather core -> 12x8 matmul2 grid
+    // Broadcasts [1, 8192] to each matmul2 core
+    // Source: gather1_dst_cb (CB 3), Destination: mcast_dst_cb = matmul2_in0 (CB 4)
+    // ========================================================================
+    deepseek_b1_ops::Mcast::
+        Op<McastCTArgs, Core::is_gather_receiver_core, Core::is_matmul2_core, Core::is_matmul2_core, true>
+            mcast;
+#if defined(COMPILE_FOR_BRISC)
+    if constexpr (Core::is_gather_receiver_core) {
+        mcast.init(mcast_args);
+    }
+#endif
+    {
+        DeviceZoneScopedN("MCAST");
+        mcast(mcast_args);
+    }
+#if defined(COMPILE_FOR_BRISC)
+    if constexpr (Core::is_gather_receiver_core) {
+        mcast.teardown();
+    }
+#endif
+
+    // ========================================================================
+    // Matmul2: [1, 8192] x [8192, 64] -> [1, 64] per core (12x8 grid)
+    // Input: mcast_dst_cb (CB 4), Weights: matmul2_in1 (CB 5), Output: matmul2_out (CB 6)
+    // ========================================================================
+    {
+        DeviceZoneScopedN("MATMUL2");
+        // pop_in0 = true (mcast output consumed), pop_in1 = false (weights persistent)
+        deepseek_b1_ops::Matmul::Op<Matmul2CTArgs, Core::is_matmul2_core, true, false> matmul2;
+        matmul2(matmul2_args);
+    }
+
+    // ========================================================================
+    // Gather2: 12x8 matmul2 cores -> gather core (11, 9)
+    // Collects [1, 64] * 96 = [1, 6144]
+    // ========================================================================
+    {
+        DeviceZoneScopedN("GATHER2");
+        deepseek_b1_ops::Gather::Op<Core::is_matmul2_core, Core::is_gather_receiver_core, true> gather2;
+        gather2(gather2_args);
+    }
+}

--- a/models/demos/deepseek_v3_b1/fused_ops/post_sdpa/op.py
+++ b/models/demos/deepseek_v3_b1/fused_ops/post_sdpa/op.py
@@ -462,7 +462,7 @@ class PostSDPA:
         # Program descriptor
         # ========================================================================
         program_descriptor = ttnn.ProgramDescriptor(
-            kernels=unified_kernel.get_kernel_descriptors(),
+            kernels=unified_kernel.get_kernel_descriptors().kernels,
             cbs=[
                 matmul1_in0_cb_descriptor,
                 matmul1_in1_cb_descriptor,

--- a/models/demos/deepseek_v3_b1/fused_ops/post_sdpa/op.py
+++ b/models/demos/deepseek_v3_b1/fused_ops/post_sdpa/op.py
@@ -1,0 +1,460 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Post SDPA fused operation.
+
+This implements Matmul1 + Gather1 + Mcast + Matmul2 + Gather2 as a fused execution:
+- Matmul1: [1, 512] x [512, 128] -> [1, 128] distributed across 64 cores (8x8 grid)
+- Gather1: Collect results from all 64 cores to [1, 8192] on gather core (11, 9)
+- Mcast: Broadcast [1, 8192] to 96 cores (12x8 grid)
+- Matmul2: [1, 8192] x [8192, 64] -> [1, 64] distributed across 96 cores (12x8 grid)
+- Gather2: Collect results from all 96 cores to [1, 6144] on gather core (11, 9)
+
+CB Layout:
+- CB 0: matmul1_in0 (8x8 grid)
+- CB 1: matmul1_in1 (8x8 grid)
+- CB 2: matmul1_out (8x8 grid)
+- CB 3: gather1_dst = mcast_src (gather core)
+- CB 4: mcast_dst = matmul2_in0 (12x8 grid)
+- CB 5: matmul2_in1 (12x8 grid)
+- CB 6: matmul2_out (12x8 grid)
+- CB 7: gather2_dst (gather core)
+"""
+
+import ttnn
+from models.demos.deepseek_v3_b1.unified_kernel_descriptor import (
+    UnifiedCompileTimeCoreDescriptor,
+    UnifiedKernelDescriptor,
+)
+
+
+class PostSDPA:
+    """
+    Post SDPA fused operation implementation using ttnn.generic_op.
+
+    Implements the full post_sdpa fusion:
+    - Matmul1 + Gather1 + Mcast + Matmul2 + Gather2
+    """
+
+    @staticmethod
+    def golden(input_tensor, weights1_tensor, weights2_tensor):
+        """
+        PyTorch reference implementation for validation.
+
+        Args:
+            input_tensor: Input tensor (torch.Tensor) [1, 512]
+            weights1_tensor: First weights tensor (torch.Tensor) [512, 8192]
+            weights2_tensor: Second weights tensor (torch.Tensor) [8192, 6144]
+
+        Returns:
+            Output tensor [1, 6144]
+        """
+        intermediate = input_tensor @ weights1_tensor  # [1, 8192]
+        return intermediate @ weights2_tensor  # [1, 6144]
+
+    @staticmethod
+    def op(
+        input_tensor,
+        weights1_tensor,
+        weights2_tensor,
+        gather1_output_tensor,
+        output_tensor,
+        fp32_dest_acc_en=False,
+    ):
+        """
+        Execute post_sdpa fused operation using generic_op.
+
+        Args:
+            input_tensor: Input tensor [1, 512] (height-sharded across 8x8 matmul1 cores)
+            weights1_tensor: First weights tensor [512, 8192] (width-sharded across 8x8)
+            weights2_tensor: Second weights tensor [8192, 6144] (width-sharded across 12x8)
+            gather1_output_tensor: Intermediate tensor [1, 8192] for gather1/mcast (on gather core)
+            output_tensor: Final output tensor [1, 6144] (on gather core)
+            fp32_dest_acc_en: Whether to enable FP32 accumulation in compute kernel
+
+        Returns:
+            Output tensor with full fused result
+        """
+        # Get device
+        device = input_tensor.device()
+
+        # Get tensor properties
+        data_format = input_tensor.dtype
+
+        # Tile definitions
+        TILE_1x32 = ttnn.Tile((1, 32))
+        TILE_32x32 = ttnn.Tile((32, 32))
+        tile_1x32_size = TILE_1x32.get_tile_size(data_format)
+        tile_32x32_size = TILE_32x32.get_tile_size(data_format)
+
+        # ========================================================================
+        # Core grid configuration
+        # ========================================================================
+        # Matmul1 grid: 8x8 = 64 cores
+        MATMUL1_GRID_START_X = 0
+        MATMUL1_GRID_START_Y = 0
+        MATMUL1_GRID_END_X = 7  # 8 columns (0-7)
+        MATMUL1_GRID_END_Y = 7  # 8 rows (0-7)
+        matmul1_grid = ttnn.CoreRange(
+            ttnn.CoreCoord(MATMUL1_GRID_START_X, MATMUL1_GRID_START_Y),
+            ttnn.CoreCoord(MATMUL1_GRID_END_X, MATMUL1_GRID_END_Y),
+        )
+        matmul1_core_grid = ttnn.CoreRangeSet([matmul1_grid])
+        num_matmul1_cores = matmul1_grid.grid_size().x * matmul1_grid.grid_size().y  # 64
+
+        # Gather receiver core: (11, 9)
+        gather_core = ttnn.CoreCoord(11, 9)
+        gather_core_grid = ttnn.CoreRangeSet([ttnn.CoreRange(gather_core, gather_core)])
+
+        # Matmul2/Mcast grid: 12x8 = 96 cores
+        MATMUL2_GRID_START_X = 0
+        MATMUL2_GRID_START_Y = 0
+        MATMUL2_GRID_END_X = 11  # 12 columns (0-11)
+        MATMUL2_GRID_END_Y = 7  # 8 rows (0-7)
+        matmul2_grid = ttnn.CoreRange(
+            ttnn.CoreCoord(MATMUL2_GRID_START_X, MATMUL2_GRID_START_Y),
+            ttnn.CoreCoord(MATMUL2_GRID_END_X, MATMUL2_GRID_END_Y),
+        )
+        matmul2_core_grid = ttnn.CoreRangeSet([matmul2_grid])
+        num_matmul2_cores = matmul2_grid.grid_size().x * matmul2_grid.grid_size().y  # 96
+
+        # Full grid (union of all cores for semaphore allocation)
+        full_grid = matmul1_core_grid.merge(gather_core_grid).merge(matmul2_core_grid)
+
+        # Get NOC coordinates
+        gather_dest_noc_core = device.worker_core_from_logical_core(gather_core)
+        mcast_dest_noc_start_core = device.worker_core_from_logical_core(matmul2_grid.start)
+        mcast_dest_noc_end_core = device.worker_core_from_logical_core(matmul2_grid.end)
+
+        # ========================================================================
+        # Matmul1 parameters: [1, 512] x [512, 128] -> [1, 128]
+        # ========================================================================
+        matmul1_k_num_tiles = 16  # 512 / 32 = 16 tiles
+        matmul1_out_w_per_core = 4  # 128 / 32 = 4 tiles per core
+
+        # ========================================================================
+        # Matmul2 parameters: [1, 8192] x [8192, 64] -> [1, 64]
+        # ========================================================================
+        matmul2_k_num_tiles = 256  # 8192 / 32 = 256 tiles
+        matmul2_out_w_per_core = 2  # 64 / 32 = 2 tiles per core
+
+        # ========================================================================
+        # CB indices
+        # ========================================================================
+        matmul1_in0_cb = 0  # Matmul1 input (8x8)
+        matmul1_in1_cb = 1  # Matmul1 weights (8x8)
+        matmul1_out_cb = 2  # Matmul1 output (8x8)
+        gather1_dst_cb = 3  # Gather1 output = Mcast source (gather core)
+        matmul2_in0_cb = 4  # Mcast dst = Matmul2 input (12x8)
+        matmul2_in1_cb = 5  # Matmul2 weights (12x8)
+        matmul2_out_cb = 6  # Matmul2 output (12x8)
+        gather2_dst_cb = 7  # Gather2 output = final output (gather core)
+
+        # ========================================================================
+        # Gather1 parameters: 64 cores -> [1, 8192]
+        # ========================================================================
+        gather1_data_size_bytes = matmul1_out_w_per_core * tile_1x32_size
+        gather1_src_num_pages = matmul1_out_w_per_core  # 4 pages per sender
+        gather1_dst_num_pages = num_matmul1_cores * matmul1_out_w_per_core  # 64 * 4 = 256 pages
+        gather1_noc0_num_senders = num_matmul1_cores
+        gather1_noc1_num_senders = 0
+
+        # ========================================================================
+        # Mcast parameters: [1, 8192] to 96 cores
+        # ========================================================================
+        mcast_data_size_bytes = gather1_dst_num_pages * tile_1x32_size  # 256 * 64 = 16384 bytes
+        mcast_src_num_pages = gather1_dst_num_pages  # 256 pages
+        mcast_dst_num_pages = gather1_dst_num_pages  # 256 pages per receiver
+        mcast_is_part_of_receiver_grid = matmul2_grid.contains(gather_core)
+
+        # ========================================================================
+        # Gather2 parameters: 96 cores -> [1, 6144]
+        # ========================================================================
+        gather2_data_size_bytes = matmul2_out_w_per_core * tile_1x32_size
+        gather2_src_num_pages = matmul2_out_w_per_core  # 2 pages per sender
+        gather2_dst_num_pages = num_matmul2_cores * matmul2_out_w_per_core  # 96 * 2 = 192 pages
+        gather2_noc0_num_senders = num_matmul2_cores
+        gather2_noc1_num_senders = 0
+
+        # ========================================================================
+        # Semaphore IDs
+        # ========================================================================
+        gather1_noc0_receiver_semaphore_id = 0
+        gather1_noc1_receiver_semaphore_id = 1
+        mcast_data_sender_semaphore_id = 2
+        mcast_data_receiver_semaphore_id = 3
+        gather2_noc0_receiver_semaphore_id = 4
+        gather2_noc1_receiver_semaphore_id = 5
+
+        # ========================================================================
+        # Buffer addresses
+        # ========================================================================
+        gather1_receiver_data_addr = gather1_output_tensor.buffer_address()
+        mcast_receiver_data_addr = weights2_tensor.buffer_address()  # Actually mcast writes to matmul2_in0
+        gather2_receiver_data_addr = output_tensor.buffer_address()
+
+        # ========================================================================
+        # NCRISC compile-time args
+        # ========================================================================
+        ncrisc_named_compile_time_args = [
+            # Matmul1
+            ("matmul1_in0", matmul1_in0_cb),
+            ("matmul1_in1", matmul1_in1_cb),
+            ("matmul1_out", matmul1_out_cb),
+            ("matmul1_k_num_tiles", matmul1_k_num_tiles),
+            ("matmul1_out_w_per_core", matmul1_out_w_per_core),
+            # Gather1 sender
+            ("gather1_dest_noc_x", gather_dest_noc_core.x),
+            ("gather1_dest_noc_y", gather_dest_noc_core.y),
+            ("gather1_data_size_bytes", gather1_data_size_bytes),
+            ("gather1_receiver_semaphore_id", gather1_noc0_receiver_semaphore_id),
+            ("gather1_src_cb", matmul1_out_cb),
+            ("gather1_src_num_pages", gather1_src_num_pages),
+            ("gather1_sender_grid_start_x", MATMUL1_GRID_START_X),
+            ("gather1_sender_grid_start_y", MATMUL1_GRID_START_Y),
+            ("gather1_sender_grid_end_x", MATMUL1_GRID_END_X),
+            ("gather1_sender_grid_end_y", MATMUL1_GRID_END_Y),
+            ("gather1_row_major", 1),
+            ("gather1_receiver_data_addr", gather1_receiver_data_addr),
+            # Mcast receiver
+            ("mcast_data_receiver_semaphore", mcast_data_receiver_semaphore_id),
+            ("mcast_dst_cb", matmul2_in0_cb),
+            ("mcast_dst_num_pages", mcast_dst_num_pages),
+            # Matmul2
+            ("matmul2_in0", matmul2_in0_cb),
+            ("matmul2_in1", matmul2_in1_cb),
+            ("matmul2_out", matmul2_out_cb),
+            ("matmul2_k_num_tiles", matmul2_k_num_tiles),
+            ("matmul2_out_w_per_core", matmul2_out_w_per_core),
+            # Gather2 sender
+            ("gather2_dest_noc_x", gather_dest_noc_core.x),
+            ("gather2_dest_noc_y", gather_dest_noc_core.y),
+            ("gather2_data_size_bytes", gather2_data_size_bytes),
+            ("gather2_receiver_semaphore_id", gather2_noc0_receiver_semaphore_id),
+            ("gather2_src_cb", matmul2_out_cb),
+            ("gather2_src_num_pages", gather2_src_num_pages),
+            ("gather2_sender_grid_start_x", MATMUL2_GRID_START_X),
+            ("gather2_sender_grid_start_y", MATMUL2_GRID_START_Y),
+            ("gather2_sender_grid_end_x", MATMUL2_GRID_END_X),
+            ("gather2_sender_grid_end_y", MATMUL2_GRID_END_Y),
+            ("gather2_row_major", 1),
+            ("gather2_receiver_data_addr", gather2_receiver_data_addr),
+        ]
+
+        # ========================================================================
+        # BRISC compile-time args
+        # ========================================================================
+        brisc_named_compile_time_args = [
+            # Matmul1/2 (no-op)
+            ("matmul1_out", matmul1_out_cb),
+            ("matmul2_out", matmul2_out_cb),
+            # Gather1 receiver
+            ("gather1_noc0_num_senders", gather1_noc0_num_senders),
+            ("gather1_noc1_num_senders", gather1_noc1_num_senders),
+            ("gather1_noc0_receiver_semaphore_id", gather1_noc0_receiver_semaphore_id),
+            ("gather1_noc1_receiver_semaphore_id", gather1_noc1_receiver_semaphore_id),
+            ("gather1_dst_cb", gather1_dst_cb),
+            ("gather1_dst_num_pages", gather1_dst_num_pages),
+            # Mcast sender
+            ("mcast_dest_noc_start_x", mcast_dest_noc_start_core.x),
+            ("mcast_dest_noc_start_y", mcast_dest_noc_start_core.y),
+            ("mcast_dest_noc_end_x", mcast_dest_noc_end_core.x),
+            ("mcast_dest_noc_end_y", mcast_dest_noc_end_core.y),
+            ("mcast_num_cores", num_matmul2_cores),
+            ("mcast_data_sender_semaphore", mcast_data_sender_semaphore_id),
+            ("mcast_data_receiver_semaphore", mcast_data_receiver_semaphore_id),
+            ("mcast_data_size_bytes", mcast_data_size_bytes),
+            ("mcast_src_cb", gather1_dst_cb),
+            ("mcast_src_num_pages", mcast_src_num_pages),
+            ("mcast_dst_cb", matmul2_in0_cb),  # For get_write_ptr on sender
+            ("mcast_is_part_of_receiver_grid", mcast_is_part_of_receiver_grid),
+            # Gather2 receiver
+            ("gather2_noc0_num_senders", gather2_noc0_num_senders),
+            ("gather2_noc1_num_senders", gather2_noc1_num_senders),
+            ("gather2_noc0_receiver_semaphore_id", gather2_noc0_receiver_semaphore_id),
+            ("gather2_noc1_receiver_semaphore_id", gather2_noc1_receiver_semaphore_id),
+            ("gather2_dst_cb", gather2_dst_cb),
+            ("gather2_dst_num_pages", gather2_dst_num_pages),
+        ]
+
+        # ========================================================================
+        # TRISC compile-time args
+        # ========================================================================
+        trisc_named_compile_time_args = [
+            # Matmul1
+            ("matmul1_in0", matmul1_in0_cb),
+            ("matmul1_in1", matmul1_in1_cb),
+            ("matmul1_out", matmul1_out_cb),
+            ("matmul1_k_num_tiles", matmul1_k_num_tiles),
+            ("matmul1_out_w_per_core", matmul1_out_w_per_core),
+            # Matmul2
+            ("matmul2_in0", matmul2_in0_cb),
+            ("matmul2_in1", matmul2_in1_cb),
+            ("matmul2_out", matmul2_out_cb),
+            ("matmul2_k_num_tiles", matmul2_k_num_tiles),
+            ("matmul2_out_w_per_core", matmul2_out_w_per_core),
+        ]
+
+        # ========================================================================
+        # Circular buffer descriptors
+        # ========================================================================
+        # CB 0: Matmul1 input (from sharded tensor, 8x8 grid)
+        matmul1_in0_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(matmul1_in0_cb, input_tensor)
+
+        # CB 1: Matmul1 weights (from sharded tensor, 8x8 grid)
+        matmul1_in1_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(matmul1_in1_cb, weights1_tensor)
+
+        # CB 2: Matmul1 output (4 tiles of 1x32 per core, 8x8 grid)
+        matmul1_out_tile_descriptor = ttnn.TileDescriptor(TILE_1x32)
+        matmul1_out_cb_format = ttnn.CBFormatDescriptor(
+            buffer_index=matmul1_out_cb,
+            data_format=data_format,
+            page_size=tile_1x32_size,
+            tile=matmul1_out_tile_descriptor,
+        )
+        matmul1_out_cb_descriptor = ttnn.CBDescriptor(
+            total_size=matmul1_out_w_per_core * tile_1x32_size,
+            core_ranges=matmul1_core_grid,
+            format_descriptors=[matmul1_out_cb_format],
+        )
+
+        # CB 3: Gather1 output = Mcast source (from sharded tensor, gather core)
+        gather1_dst_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(gather1_dst_cb, gather1_output_tensor)
+
+        # CB 4: Mcast destination = Matmul2 input (256 tiles of 1x32 per core)
+        # Allocated on matmul2 grid AND gather core (so sender can use get_write_ptr)
+        matmul2_in0_cb_format = ttnn.CBFormatDescriptor(
+            buffer_index=matmul2_in0_cb,
+            data_format=data_format,
+            page_size=tile_1x32_size,
+            tile=matmul1_out_tile_descriptor,
+        )
+        matmul2_in0_cb_grid = matmul2_core_grid.merge(gather_core_grid)
+        matmul2_in0_cb_descriptor = ttnn.CBDescriptor(
+            total_size=mcast_dst_num_pages * tile_1x32_size,
+            core_ranges=matmul2_in0_cb_grid,
+            format_descriptors=[matmul2_in0_cb_format],
+        )
+
+        # CB 5: Matmul2 weights (from sharded tensor, 12x8 grid)
+        matmul2_in1_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(matmul2_in1_cb, weights2_tensor)
+
+        # CB 6: Matmul2 output (2 tiles of 1x32 per core, 12x8 grid)
+        matmul2_out_cb_format = ttnn.CBFormatDescriptor(
+            buffer_index=matmul2_out_cb,
+            data_format=data_format,
+            page_size=tile_1x32_size,
+            tile=matmul1_out_tile_descriptor,
+        )
+        matmul2_out_cb_descriptor = ttnn.CBDescriptor(
+            total_size=matmul2_out_w_per_core * tile_1x32_size,
+            core_ranges=matmul2_core_grid,
+            format_descriptors=[matmul2_out_cb_format],
+        )
+
+        # CB 7: Gather2 output = final output (from sharded tensor, gather core)
+        gather2_dst_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(gather2_dst_cb, output_tensor)
+
+        # ========================================================================
+        # Semaphore descriptors
+        # ========================================================================
+        gather1_noc0_semaphore_descriptor = ttnn.SemaphoreDescriptor(
+            id=gather1_noc0_receiver_semaphore_id,
+            core_ranges=full_grid,
+            initial_value=0,
+        )
+        gather1_noc1_semaphore_descriptor = ttnn.SemaphoreDescriptor(
+            id=gather1_noc1_receiver_semaphore_id,
+            core_ranges=full_grid,
+            initial_value=0,
+        )
+        mcast_sender_semaphore_descriptor = ttnn.SemaphoreDescriptor(
+            id=mcast_data_sender_semaphore_id,
+            core_ranges=full_grid,
+            initial_value=0,
+        )
+        mcast_receiver_semaphore_descriptor = ttnn.SemaphoreDescriptor(
+            id=mcast_data_receiver_semaphore_id,
+            core_ranges=full_grid,
+            initial_value=0,
+        )
+        gather2_noc0_semaphore_descriptor = ttnn.SemaphoreDescriptor(
+            id=gather2_noc0_receiver_semaphore_id,
+            core_ranges=full_grid,
+            initial_value=0,
+        )
+        gather2_noc1_semaphore_descriptor = ttnn.SemaphoreDescriptor(
+            id=gather2_noc1_receiver_semaphore_id,
+            core_ranges=full_grid,
+            initial_value=0,
+        )
+
+        # ========================================================================
+        # Kernel descriptor
+        # ========================================================================
+        unified_kernel = UnifiedKernelDescriptor(
+            kernel_source="models/demos/deepseek_v3_b1/fused_ops/post_sdpa/kernels/post_sdpa_kernel.cpp",
+            core_ranges=full_grid,
+            ncrisc_named_compile_time_args=ncrisc_named_compile_time_args,
+            brisc_named_compile_time_args=brisc_named_compile_time_args,
+            trisc_named_compile_time_args=trisc_named_compile_time_args,
+            trisc_compute_config=ttnn.ComputeConfigDescriptor(
+                math_fidelity=ttnn.MathFidelity.LoFi,
+                math_approx_mode=False,
+                fp32_dest_acc_en=fp32_dest_acc_en,
+                dst_full_sync_en=fp32_dest_acc_en,
+            ),
+            unified_compile_time_core_descriptors=[
+                UnifiedCompileTimeCoreDescriptor(
+                    named_compile_time_arg="is_matmul1_core",
+                    core_range=matmul1_core_grid,
+                    value=1,
+                    other_value=0,
+                ),
+                UnifiedCompileTimeCoreDescriptor(
+                    named_compile_time_arg="is_gather_receiver_core",
+                    core_range=gather_core_grid,
+                    value=1,
+                    other_value=0,
+                ),
+                UnifiedCompileTimeCoreDescriptor(
+                    named_compile_time_arg="is_matmul2_core",
+                    core_range=matmul2_core_grid,
+                    value=1,
+                    other_value=0,
+                ),
+            ],
+        )
+
+        # ========================================================================
+        # Program descriptor
+        # ========================================================================
+        program_descriptor = ttnn.ProgramDescriptor(
+            kernels=unified_kernel.get_kernel_descriptors(),
+            cbs=[
+                matmul1_in0_cb_descriptor,
+                matmul1_in1_cb_descriptor,
+                matmul1_out_cb_descriptor,
+                gather1_dst_cb_descriptor,
+                matmul2_in0_cb_descriptor,
+                matmul2_in1_cb_descriptor,
+                matmul2_out_cb_descriptor,
+                gather2_dst_cb_descriptor,
+            ],
+            semaphores=[
+                gather1_noc0_semaphore_descriptor,
+                gather1_noc1_semaphore_descriptor,
+                mcast_sender_semaphore_descriptor,
+                mcast_receiver_semaphore_descriptor,
+                gather2_noc0_semaphore_descriptor,
+                gather2_noc1_semaphore_descriptor,
+            ],
+        )
+
+        # Execute generic op
+        io_tensors = [input_tensor, weights1_tensor, weights2_tensor, gather1_output_tensor, output_tensor]
+        output = ttnn.generic_op(io_tensors, program_descriptor)
+
+        return output

--- a/models/demos/deepseek_v3_b1/fused_ops/post_sdpa/op.py
+++ b/models/demos/deepseek_v3_b1/fused_ops/post_sdpa/op.py
@@ -7,10 +7,10 @@ Post SDPA fused operation.
 
 This implements Matmul1 + Gather1 + Mcast + Matmul2 + Gather2 as a fused execution:
 - Matmul1: [1, 512] x [512, 128] -> [1, 128] distributed across 64 cores (8x8 grid)
-- Gather1: Collect results from all 64 cores to [1, 8192] on gather core (11, 9)
+- Gather1: Collect results from all 64 cores to [1, 8192] on gather core (12, 9)
 - Mcast: Broadcast [1, 8192] to 117 cores (13x9 grid, rectangular for efficient mcast)
 - Matmul2: [1, 8192] x [8192, 64] -> [1, 64] on 112 active cores (rows 0-7 full 13 + row 8 cols 0-7)
-- Gather2: Collect results from all 112 active cores to [1, 7168] on gather core (11, 9)
+- Gather2: Collect results from all 112 active cores to [1, 7168] on gather core (12, 9)
 
 The 13x9 mcast grid contains 117 cores, but only 112 are active for matmul2.
 The 5 inactive cores (row 8, cols 8-12) receive mcast data but skip matmul via is_matmul2_core=false.
@@ -107,8 +107,8 @@ class PostSDPA:
         matmul1_core_grid = ttnn.CoreRangeSet([matmul1_grid])
         num_matmul1_cores = matmul1_grid.grid_size().x * matmul1_grid.grid_size().y  # 64
 
-        # Gather receiver core: (11, 9)
-        gather_core = ttnn.CoreCoord(11, 9)
+        # Gather receiver core: (12, 9)
+        gather_core = ttnn.CoreCoord(12, 9)
         gather_core_grid = ttnn.CoreRangeSet([ttnn.CoreRange(gather_core, gather_core)])
 
         # Mcast grid: 13x9 = 117 cores (full rectangular for efficient mcast)

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_post_sdpa.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_post_sdpa.py
@@ -7,10 +7,10 @@ TTNN Post SDPA Fused Op Test
 
 Tests the full post_sdpa fused operation which implements:
 - Matmul1: [1, 512] x [512, 128] -> [1, 128] per core on 64 cores (8x8)
-- Gather1: Collect to [1, 8192] on gather core (11, 9)
+- Gather1: Collect to [1, 8192] on gather core (12, 9)
 - Mcast: Broadcast [1, 8192] to 117 cores (13x9 rectangular grid)
 - Matmul2: [1, 8192] x [8192, 64] -> [1, 64] per core on 112 active cores
-- Gather2: Collect to [1, 7168] on gather core (11, 9)
+- Gather2: Collect to [1, 7168] on gather core (12, 9)
 
 The mcast grid (13x9=117 cores) includes 5 inactive cores (row 8, cols 8-12)
 that receive mcast data but skip matmul2 via is_matmul2_core=false.
@@ -81,7 +81,7 @@ def test_post_sdpa(device, M, K1, intermediate, K2, output_size, in0_dtype, in1_
             ttnn.CoreRange(ttnn.CoreCoord(0, 8), ttnn.CoreCoord(7, 8)),  # 8x1 = 8 cores
         ]
     )
-    gather_core = ttnn.CoreCoord(11, 9)
+    gather_core = ttnn.CoreCoord(12, 9)
     gather_core_grid = ttnn.CoreRangeSet([ttnn.CoreRange(gather_core, gather_core)])
 
     # ========================================================================

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_post_sdpa.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_post_sdpa.py
@@ -1,0 +1,242 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+TTNN Post SDPA Fused Op Test
+
+Tests the full post_sdpa fused operation which implements:
+- Matmul1: [1, 512] x [512, 128] -> [1, 128] per core on 64 cores (8x8)
+- Gather1: Collect to [1, 8192] on gather core (11, 9)
+- Mcast: Broadcast [1, 8192] to 96 cores (12x8)
+- Matmul2: [1, 8192] x [8192, 64] -> [1, 64] per core on 96 cores
+- Gather2: Collect to [1, 6144] on gather core (11, 9)
+
+Full operation: [1, 512] @ [512, 8192] @ [8192, 6144] -> [1, 6144]
+"""
+
+import pytest
+import torch
+from loguru import logger
+
+import ttnn
+from models.common.utility_functions import comp_pcc
+from models.demos.deepseek_v3_b1.fused_ops.post_sdpa.op import PostSDPA
+
+
+@pytest.mark.parametrize(
+    "M, K1, intermediate, K2, output_size, in0_dtype, in1_dtype",
+    [
+        # Main target shape: [1,512] @ [512,8192] @ [8192,6144] -> [1,6144]
+        (1, 512, 8192, 8192, 6144, ttnn.bfloat16, ttnn.bfloat8_b),
+    ],
+)
+def test_post_sdpa(device, M, K1, intermediate, K2, output_size, in0_dtype, in1_dtype):
+    """Test full post_sdpa fused operation"""
+
+    # Tile dimensions
+    a_tile = ttnn.Tile([M, 32])  # 1x32 tiles for input/activation
+    b_tile = ttnn.Tile([32, 32])  # 32x32 tiles for weights
+
+    # ========================================================================
+    # Grid configuration
+    # ========================================================================
+    # Matmul1 grid: 8x8 = 64 cores
+    MATMUL1_GRID_X = 8
+    MATMUL1_GRID_Y = 8
+    num_matmul1_cores = MATMUL1_GRID_X * MATMUL1_GRID_Y  # 64
+
+    # Matmul2/Mcast grid: 12x8 = 96 cores
+    MATMUL2_GRID_X = 12
+    MATMUL2_GRID_Y = 8
+    num_matmul2_cores = MATMUL2_GRID_X * MATMUL2_GRID_Y  # 96
+
+    # Per-core dimensions
+    n1_per_core = intermediate // num_matmul1_cores  # 8192 / 64 = 128
+    n2_per_core = output_size // num_matmul2_cores  # 6144 / 96 = 64
+
+    logger.info(f"Testing full post_sdpa fused op:")
+    logger.info(f"  Matmul1: [{M}, {K1}] x [{K1}, {intermediate}] on {num_matmul1_cores} cores")
+    logger.info(f"  Mcast: [{M}, {intermediate}] to {num_matmul2_cores} cores")
+    logger.info(f"  Matmul2: [{M}, {K2}] x [{K2}, {output_size}] on {num_matmul2_cores} cores")
+    logger.info(f"  Output: [{M}, {output_size}]")
+
+    # Create core grids
+    matmul1_grid = ttnn.CoreRangeSet(
+        [ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(MATMUL1_GRID_X - 1, MATMUL1_GRID_Y - 1))]
+    )
+    matmul2_grid = ttnn.CoreRangeSet(
+        [ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(MATMUL2_GRID_X - 1, MATMUL2_GRID_Y - 1))]
+    )
+    gather_core = ttnn.CoreCoord(11, 9)
+    gather_core_grid = ttnn.CoreRangeSet([ttnn.CoreRange(gather_core, gather_core)])
+
+    # ========================================================================
+    # Create PyTorch tensors
+    # ========================================================================
+    torch.manual_seed(0)
+
+    # Input: [1, 512] - replicated to 64 matmul1 cores
+    torch_input_single = torch.randn((M, K1), dtype=torch.bfloat16)
+    torch_input = torch_input_single.repeat(num_matmul1_cores, 1)  # [64, 512]
+
+    # Weights1: [512, 8192]
+    torch_weights1 = torch.randn((K1, intermediate), dtype=torch.bfloat16)
+
+    # Weights2: [8192, 6144]
+    torch_weights2 = torch.randn((K2, output_size), dtype=torch.bfloat16)
+
+    # ========================================================================
+    # Compute golden reference: input @ weights1 @ weights2
+    # ========================================================================
+    torch_expected = PostSDPA.golden(
+        torch_input_single.float(), torch_weights1.float(), torch_weights2.float()
+    ).bfloat16()
+    logger.info(f"Golden output shape: {torch_expected.shape}")
+
+    # ========================================================================
+    # Create input tensor (height-sharded across matmul1 cores)
+    # Each core gets [1, 512]
+    # ========================================================================
+    input_shard_shape = (M, K1)  # [1, 512] per core
+    input_shard_spec = ttnn.ShardSpec(
+        matmul1_grid,
+        input_shard_shape,
+        ttnn.ShardOrientation.ROW_MAJOR,
+    )
+    input_mem_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, input_shard_spec)
+
+    ttnn_input = ttnn.from_torch(
+        torch_input,
+        dtype=in0_dtype,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        memory_config=input_mem_config,
+        tile=a_tile,
+    )
+    logger.info(f"Created input tensor: shard {input_shard_shape} on {num_matmul1_cores} cores")
+
+    # ========================================================================
+    # Create weights1 tensor (width-sharded across matmul1 cores)
+    # Each core gets [512, 128]
+    # ========================================================================
+    weights1_shard_shape = (K1, n1_per_core)  # [512, 128] per core
+    weights1_shard_spec = ttnn.ShardSpec(
+        matmul1_grid,
+        weights1_shard_shape,
+        ttnn.ShardOrientation.ROW_MAJOR,
+    )
+    weights1_mem_config = ttnn.MemoryConfig(
+        ttnn.TensorMemoryLayout.WIDTH_SHARDED, ttnn.BufferType.L1, weights1_shard_spec
+    )
+
+    ttnn_weights1 = ttnn.from_torch(
+        torch_weights1,
+        dtype=in1_dtype,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        memory_config=weights1_mem_config,
+        tile=b_tile,
+    )
+    logger.info(f"Created weights1 tensor: shard {weights1_shard_shape} on {num_matmul1_cores} cores")
+
+    # ========================================================================
+    # Create weights2 tensor (width-sharded across matmul2 cores)
+    # Each core gets [8192, 64]
+    # ========================================================================
+    weights2_shard_shape = (K2, n2_per_core)  # [8192, 64] per core
+    weights2_shard_spec = ttnn.ShardSpec(
+        matmul2_grid,
+        weights2_shard_shape,
+        ttnn.ShardOrientation.ROW_MAJOR,
+    )
+    weights2_mem_config = ttnn.MemoryConfig(
+        ttnn.TensorMemoryLayout.WIDTH_SHARDED, ttnn.BufferType.L1, weights2_shard_spec
+    )
+
+    ttnn_weights2 = ttnn.from_torch(
+        torch_weights2,
+        dtype=in1_dtype,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        memory_config=weights2_mem_config,
+        tile=b_tile,
+    )
+    logger.info(f"Created weights2 tensor: shard {weights2_shard_shape} on {num_matmul2_cores} cores")
+
+    # ========================================================================
+    # Create gather1 output tensor (intermediate [1, 8192] on gather core)
+    # ========================================================================
+    gather1_output_shard_shape = (M, intermediate)  # [1, 8192]
+    gather1_output_shard_spec = ttnn.ShardSpec(
+        gather_core_grid,
+        gather1_output_shard_shape,
+        ttnn.ShardOrientation.ROW_MAJOR,
+    )
+    gather1_output_mem_config = ttnn.MemoryConfig(
+        ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, gather1_output_shard_spec
+    )
+
+    torch_gather1_zeros = torch.zeros((M, intermediate), dtype=torch.bfloat16)
+    ttnn_gather1_output = ttnn.from_torch(
+        torch_gather1_zeros,
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        memory_config=gather1_output_mem_config,
+        tile=a_tile,
+    )
+    logger.info(f"Created gather1 output tensor: {gather1_output_shard_shape} on gather core")
+
+    # ========================================================================
+    # Create final output tensor ([1, 6144] on gather core)
+    # ========================================================================
+    output_shard_shape = (M, output_size)  # [1, 6144]
+    output_shard_spec = ttnn.ShardSpec(
+        gather_core_grid,
+        output_shard_shape,
+        ttnn.ShardOrientation.ROW_MAJOR,
+    )
+    output_mem_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, output_shard_spec)
+
+    torch_output_zeros = torch.zeros((M, output_size), dtype=torch.bfloat16)
+    ttnn_output = ttnn.from_torch(
+        torch_output_zeros,
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        memory_config=output_mem_config,
+        tile=a_tile,
+    )
+    logger.info(f"Created output tensor: {output_shard_shape} on gather core")
+
+    # ========================================================================
+    # Run fused operation
+    # ========================================================================
+    logger.info("Running full post_sdpa fused operation...")
+    ttnn_result = PostSDPA.op(
+        ttnn_input,
+        ttnn_weights1,
+        ttnn_weights2,
+        ttnn_gather1_output,
+        ttnn_output,
+        fp32_dest_acc_en=False,
+    )
+
+    # Convert back to torch for comparison
+    output_torch = ttnn.to_torch(ttnn_result)
+    logger.info(f"Output shape: {output_torch.shape}")
+
+    # ========================================================================
+    # Verify results
+    # ========================================================================
+    # Output should be [1, 6144] on gather core
+    expected_shape = (M, output_size)
+    assert output_torch.shape == expected_shape, f"Expected shape {expected_shape}, got {output_torch.shape}"
+
+    # Compare with golden reference
+    passing, pcc_message = comp_pcc(torch_expected, output_torch, 0.99)
+    logger.info(f"PCC comparison: {pcc_message}")
+
+    assert passing, f"PCC check failed: {pcc_message}"
+    logger.info("✓ Post SDPA full fused op test passed!")


### PR DESCRIPTION
Add single fuse op that does post sdpa computations:
matmul + gather + mcast + matmul + gather

### Ticket
https://github.com/tenstorrent/tt-metal/issues/35542

### Problem description
Provide context for the problem.

### What's changed
Describe the approach used to solve the problem.
Summarize the changes made and its impact.

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=ucheema/deepseek-b1-post-sdpa)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:ucheema/deepseek-b1-post-sdpa)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ucheema/deepseek-b1-post-sdpa)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ucheema/deepseek-b1-post-sdpa)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ucheema/deepseek-b1-post-sdpa)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ucheema/deepseek-b1-post-sdpa)
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ucheema/deepseek-b1-post-sdpa)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ucheema/deepseek-b1-post-sdpa)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ucheema/deepseek-b1-post-sdpa)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ucheema/deepseek-b1-post-sdpa)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ucheema/deepseek-b1-post-sdpa)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ucheema/deepseek-b1-post-sdpa)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
