### PR TITLE
Add mLSTM autograd op

### DIFF
--- a/tt-train/sources/ttml/ttml/__init__.py
+++ b/tt-train/sources/ttml/ttml/__init__.py
@@ -17,3 +17,6 @@ from ._recursive_import import _recursive_import_from_ttml
 # Recursively import all _ttml symbols into this module
 # Python implementations in subpackages will take precedence
 _recursive_import_from_ttml(_ttml, sys.modules[__name__])
+
+# Import Python subpackages
+from . import ops

--- a/tt-train/sources/ttml/ttml/ops/__init__.py
+++ b/tt-train/sources/ttml/ttml/ops/__init__.py
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""TTML Operations package.
+
+This package provides custom operations implemented using the TTML autograd system.
+"""
+
+from .mlstm import mlstm_parallel, MLSTMParallel
+
+__all__ = [
+    "mlstm_parallel",
+    "MLSTMParallel",
+]

--- a/tt-train/sources/ttml/ttml/ops/__init__.py
+++ b/tt-train/sources/ttml/ttml/ops/__init__.py
@@ -5,11 +5,56 @@
 """TTML Operations package.
 
 This package provides custom operations implemented using the TTML autograd system.
+
+mLSTM Components:
+    - mlstm_parallel: Core mLSTM parallel computation with autograd
+    - mLSTMCell: mLSTM cell with gates and normalization
+    - mLSTMLayer: Full mLSTM layer with projections and convolution
+    - mLSTMBlock: Pre-normed block with residual connection
+    - xLSTMStack: Stack of mLSTM blocks for building models
+
+Helper Components:
+    - CausalConv1d: Causal 1D depthwise convolution
+    - LayerNorm: Layer normalization
+    - MultiHeadLayerNorm: Multi-head layer normalization
+    - LinearHeadwiseExpand: Headwise linear projection
 """
 
+# Core mLSTM operation
 from .mlstm import mlstm_parallel, MLSTMParallel
 
+# mLSTM modules
+from .mlstm_cell import mLSTMCell, mLSTMCellConfig
+from .mlstm_layer import mLSTMLayer, mLSTMLayerConfig
+from .mlstm_block import mLSTMBlock, mLSTMBlockConfig, xLSTMStack
+
+# Component layers
+from .components import (
+    CausalConv1d,
+    CausalConv1dConfig,
+    LayerNorm,
+    MultiHeadLayerNorm,
+    LinearHeadwiseExpand,
+    LinearHeadwiseExpandConfig,
+)
+
 __all__ = [
+    # Core mLSTM
     "mlstm_parallel",
     "MLSTMParallel",
+    # mLSTM modules
+    "mLSTMCell",
+    "mLSTMCellConfig",
+    "mLSTMLayer",
+    "mLSTMLayerConfig",
+    "mLSTMBlock",
+    "mLSTMBlockConfig",
+    "xLSTMStack",
+    # Components
+    "CausalConv1d",
+    "CausalConv1dConfig",
+    "LayerNorm",
+    "MultiHeadLayerNorm",
+    "LinearHeadwiseExpand",
+    "LinearHeadwiseExpandConfig",
 ]

--- a/tt-train/sources/ttml/ttml/ops/components.py
+++ b/tt-train/sources/ttml/ttml/ops/components.py
@@ -1,0 +1,395 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Building block components for mLSTM and other architectures.
+
+This module provides reusable components including:
+- CausalConv1d: Causal 1D convolution for temporal sequences
+- MultiHeadLayerNorm: Layer normalization for multi-head tensors
+- LinearHeadwiseExpand: Headwise linear projection layer
+"""
+
+from dataclasses import dataclass
+from math import sqrt
+from typing import Optional, Tuple
+
+import numpy as np
+import ttnn
+
+import ttml
+from ttml.modules import AbstractModuleBase, Parameter
+
+
+@dataclass
+class CausalConv1dConfig:
+    """Configuration for CausalConv1d."""
+
+    feature_dim: int
+    kernel_size: int = 4
+    bias: bool = True
+
+
+class CausalConv1d(AbstractModuleBase):
+    """Causal 1D depthwise convolution.
+
+    Implements causal depthwise convolution of a time series tensor.
+    Input: Tensor of shape (B, S, D), i.e. (batch, sequence, features)
+    Output: Tensor of shape (B, S, D)
+
+    Args:
+        config: CausalConv1dConfig with feature_dim, kernel_size, bias
+    """
+
+    def __init__(self, config: CausalConv1dConfig) -> None:
+        super().__init__()
+        self.config = config
+
+        if config.kernel_size == 0:
+            self.weight = None
+            self.bias_param = None
+        else:
+            # Weight shape: (kernel_size, feature_dim) for depthwise conv
+            # Initialize with uniform distribution
+            k = config.kernel_size
+            d = config.feature_dim
+            bound = 1.0 / sqrt(k)
+
+            weight_data = np.random.uniform(-bound, bound, (k, d)).astype(np.float32)
+            self.weight = Parameter(ttml.autograd.Tensor.from_numpy(weight_data))
+
+            if config.bias:
+                bias_data = np.zeros((d,), dtype=np.float32)
+                self.bias_param = Parameter(ttml.autograd.Tensor.from_numpy(bias_data))
+            else:
+                self.bias_param = None
+
+    def forward(self, x: ttml.autograd.Tensor) -> ttml.autograd.Tensor:
+        """Forward pass of causal conv1d.
+
+        Args:
+            x: Input tensor of shape (B, S, D)
+
+        Returns:
+            Output tensor of shape (B, S, D)
+        """
+        if self.config.kernel_size == 0:
+            return x
+
+        # Simple implementation using manual convolution
+        # For a full implementation, would use ttnn.conv1d with proper padding
+        B, S, D = x.get_value().shape
+
+        # Pad on the left (causal padding)
+        pad_size = self.config.kernel_size - 1
+
+        # Create padded tensor
+        x_val = x.get_value()
+
+        # Transpose to (B, D, S) for conv
+        x_transposed = ttnn.transpose(x_val, 1, 2)  # (B, D, S)
+
+        # Pad left with zeros
+        if pad_size > 0:
+            device = ttml.autograd.AutoContext.get_instance().get_device()
+            zeros_shape = (B, D, pad_size)
+            zeros = ttml.core.zeros(zeros_shape, device)
+            x_padded = ttnn.concat([zeros, x_transposed], dim=2)  # (B, D, S+pad)
+        else:
+            x_padded = x_transposed
+
+        # Apply depthwise conv manually
+        # weight: (K, D)
+        weight_val = self.weight.tensor.get_value()
+
+        # Compute conv output
+        outputs = []
+        for t in range(S):
+            # Window: [t, t+K)
+            window = x_padded[:, :, t : t + self.config.kernel_size]  # (B, D, K)
+            window_t = ttnn.transpose(window, 1, 2)  # (B, K, D)
+
+            # Element-wise multiply and sum over kernel dimension
+            weighted = ttnn.multiply(window_t, weight_val)  # (B, K, D)
+            summed = ttnn.sum(weighted, dim=1, keepdim=True)  # (B, 1, D)
+            outputs.append(summed)
+
+        # Stack outputs
+        out = ttnn.concat(outputs, dim=1)  # (B, S, D)
+
+        # Add bias
+        if self.bias_param is not None:
+            bias_val = self.bias_param.tensor.get_value()
+            out = ttnn.add(out, bias_val)
+
+        return ttml.autograd.create_tensor(out, requires_grad=True)
+
+
+@dataclass
+class LinearHeadwiseExpandConfig:
+    """Configuration for LinearHeadwiseExpand."""
+
+    in_features: int
+    num_heads: int
+    expand_factor: float = 1.0
+    bias: bool = True
+
+    def __post_init__(self):
+        assert self.num_heads > 0, "num_heads must be > 0"
+        assert (
+            self.in_features % self.num_heads == 0
+        ), "in_features must be divisible by num_heads"
+
+
+class LinearHeadwiseExpand(AbstractModuleBase):
+    """Headwise linear projection layer.
+
+    Projects input features where each head is projected independently.
+    This is useful for Q/K/V projections in attention mechanisms.
+
+    Args:
+        config: LinearHeadwiseExpandConfig
+    """
+
+    def __init__(self, config: LinearHeadwiseExpandConfig) -> None:
+        super().__init__()
+        self.config = config
+
+        in_features = config.in_features
+        num_heads = config.num_heads
+        out_features = round(config.expand_factor * in_features)
+        out_per_head = out_features // num_heads
+        in_per_head = in_features // num_heads
+
+        # Weight shape: (num_heads, out_per_head, in_per_head)
+        # Small init: normal with std = sqrt(2/5/in_per_head)
+        std = sqrt(2.0 / 5.0 / in_per_head)
+        weight_data = np.random.normal(
+            0, std, (num_heads, out_per_head, in_per_head)
+        ).astype(np.float32)
+        self.weight = Parameter(ttml.autograd.Tensor.from_numpy(weight_data))
+
+        self.out_features = out_features
+        self.num_heads = num_heads
+        self.in_per_head = in_per_head
+        self.out_per_head = out_per_head
+
+        if config.bias:
+            bias_data = np.zeros((out_features,), dtype=np.float32)
+            self.bias_param = Parameter(ttml.autograd.Tensor.from_numpy(bias_data))
+        else:
+            self.bias_param = None
+
+    def forward(self, x: ttml.autograd.Tensor) -> ttml.autograd.Tensor:
+        """Forward pass of headwise linear projection.
+
+        Args:
+            x: Input tensor of shape (..., in_features)
+
+        Returns:
+            Output tensor of shape (..., out_features)
+        """
+        x_val = x.get_value()
+        shape = x_val.shape  # (..., in_features)
+
+        # Reshape to (..., num_heads, in_per_head)
+        new_shape = list(shape[:-1]) + [self.num_heads, self.in_per_head]
+        x_heads = ttnn.reshape(x_val, new_shape)
+
+        # Apply einsum: ...hd,hod->...ho
+        # Manual implementation since ttnn may not have einsum
+        weight_val = self.weight.tensor.get_value()  # (NH, out_per_head, in_per_head)
+
+        # For simplicity, use matmul with proper reshaping
+        # x_heads: (..., NH, in_per_head) -> (..., NH, 1, in_per_head)
+        # weight: (NH, out_per_head, in_per_head) -> needs transpose to (NH, in_per_head, out_per_head)
+        weight_t = ttnn.transpose(weight_val, -2, -1)  # (NH, in_per_head, out_per_head)
+
+        # Expand dims for matmul
+        x_expanded = ttnn.reshape(
+            x_heads, list(shape[:-1]) + [self.num_heads, 1, self.in_per_head]
+        )
+
+        # Batched matmul
+        # This is tricky with varying batch dims - simplified version
+        # For now, flatten batch dims
+        batch_shape = shape[:-1]
+        batch_size = 1
+        for s in batch_shape:
+            batch_size *= s
+
+        x_flat = ttnn.reshape(x_heads, (batch_size, self.num_heads, self.in_per_head))
+        # x_flat: (B, NH, in_per_head) @ weight_t: (NH, in_per_head, out_per_head)
+        # Need batched matmul per head
+
+        # Transpose to (B, NH, 1, in_per_head) @ (NH, in_per_head, out_per_head) broadcast
+        x_for_mm = ttnn.reshape(
+            x_flat, (batch_size, self.num_heads, 1, self.in_per_head)
+        )
+
+        # Broadcast weight across batch: need to tile it
+        # For now, do a simple loop (can be optimized)
+        # Actually, use the fact that weight is (NH, in_per_head, out_per_head)
+        # and we need (1, NH, in_per_head, out_per_head) for broadcasting
+        weight_broadcast = ttnn.reshape(
+            weight_t, (1, self.num_heads, self.in_per_head, self.out_per_head)
+        )
+
+        # matmul: (B, NH, 1, in_per_head) @ (1, NH, in_per_head, out_per_head) -> (B, NH, 1, out_per_head)
+        out = ttnn.matmul(x_for_mm, weight_broadcast)
+
+        # Reshape back to (..., num_heads, out_per_head) -> (..., out_features)
+        out = ttnn.reshape(out, (batch_size, self.num_heads, self.out_per_head))
+        out = ttnn.reshape(out, list(batch_shape) + [self.out_features])
+
+        # Add bias
+        if self.bias_param is not None:
+            bias_val = self.bias_param.tensor.get_value()
+            out = ttnn.add(out, bias_val)
+
+        return ttml.autograd.create_tensor(out, requires_grad=True)
+
+
+class LayerNorm(AbstractModuleBase):
+    """Layer normalization with optional bias.
+
+    Args:
+        ndim: Normalized dimension
+        weight: Whether to use learnable weight
+        bias: Whether to use learnable bias
+        eps: Epsilon for numerical stability
+    """
+
+    def __init__(
+        self,
+        ndim: int,
+        weight: bool = True,
+        bias: bool = False,
+        eps: float = 1e-5,
+    ) -> None:
+        super().__init__()
+        self.ndim = ndim
+        self.eps = eps
+        self.has_weight = weight
+        self.has_bias = bias
+
+        if weight:
+            # Initialize to ones (via 1 + zeros pattern)
+            weight_data = np.ones((ndim,), dtype=np.float32)
+            self.weight = Parameter(ttml.autograd.Tensor.from_numpy(weight_data))
+        else:
+            self.weight = None
+
+        if bias:
+            bias_data = np.zeros((ndim,), dtype=np.float32)
+            self.bias_param = Parameter(ttml.autograd.Tensor.from_numpy(bias_data))
+        else:
+            self.bias_param = None
+
+    def forward(self, x: ttml.autograd.Tensor) -> ttml.autograd.Tensor:
+        """Forward pass of layer norm.
+
+        Args:
+            x: Input tensor of shape (..., ndim)
+
+        Returns:
+            Normalized output tensor
+        """
+        x_val = x.get_value()
+
+        # Compute mean and variance over last dimension
+        mean = ttnn.mean(x_val, dim=-1, keepdim=True)
+        x_centered = ttnn.subtract(x_val, mean)
+        var = ttnn.mean(ttnn.multiply(x_centered, x_centered), dim=-1, keepdim=True)
+
+        # Normalize
+        inv_std = ttnn.rsqrt(ttnn.add(var, self.eps))
+        out = ttnn.multiply(x_centered, inv_std)
+
+        # Apply weight and bias
+        if self.weight is not None:
+            weight_val = self.weight.tensor.get_value()
+            out = ttnn.multiply(out, weight_val)
+
+        if self.bias_param is not None:
+            bias_val = self.bias_param.tensor.get_value()
+            out = ttnn.add(out, bias_val)
+
+        return ttml.autograd.create_tensor(out, requires_grad=True)
+
+
+class MultiHeadLayerNorm(AbstractModuleBase):
+    """Multi-head layer normalization using group norm.
+
+    Applies layer normalization per head using group normalization.
+    Input shape: (B, NH, S, DH)
+    Output shape: (B, NH, S, DH)
+
+    Args:
+        ndim: Total embedding dimension (NH * DH)
+        num_heads: Number of heads
+        weight: Whether to use learnable weight
+        bias: Whether to use learnable bias
+        eps: Epsilon for numerical stability
+    """
+
+    def __init__(
+        self,
+        ndim: int,
+        num_heads: int,
+        weight: bool = True,
+        bias: bool = False,
+        eps: float = 1e-5,
+    ) -> None:
+        super().__init__()
+        self.ndim = ndim
+        self.num_heads = num_heads
+        self.eps = eps
+
+        if weight:
+            weight_data = np.ones((ndim,), dtype=np.float32)
+            self.weight = Parameter(ttml.autograd.Tensor.from_numpy(weight_data))
+        else:
+            self.weight = None
+
+        if bias:
+            bias_data = np.zeros((ndim,), dtype=np.float32)
+            self.bias_param = Parameter(ttml.autograd.Tensor.from_numpy(bias_data))
+        else:
+            self.bias_param = None
+
+    def forward(self, x: ttml.autograd.Tensor) -> ttml.autograd.Tensor:
+        """Forward pass of multi-head layer norm.
+
+        Args:
+            x: Input tensor of shape (B, NH, S, DH)
+
+        Returns:
+            Normalized output tensor of shape (B, NH, S, DH)
+        """
+        x_val = x.get_value()
+        assert len(x_val.shape) == 4, "Input must be 4D tensor (B, NH, S, DH)"
+        B, NH, S, DH = x_val.shape
+
+        # Per-head normalization over DH dimension
+        mean = ttnn.mean(x_val, dim=-1, keepdim=True)
+        x_centered = ttnn.subtract(x_val, mean)
+        var = ttnn.mean(ttnn.multiply(x_centered, x_centered), dim=-1, keepdim=True)
+
+        # Normalize
+        inv_std = ttnn.rsqrt(ttnn.add(var, self.eps))
+        out = ttnn.multiply(x_centered, inv_std)
+
+        # Apply weight and bias (reshape for broadcasting)
+        if self.weight is not None:
+            weight_val = self.weight.tensor.get_value()
+            # Reshape weight to (1, NH, 1, DH)
+            weight_reshaped = ttnn.reshape(weight_val, (1, NH, 1, DH))
+            out = ttnn.multiply(out, weight_reshaped)
+
+        if self.bias_param is not None:
+            bias_val = self.bias_param.tensor.get_value()
+            bias_reshaped = ttnn.reshape(bias_val, (1, NH, 1, DH))
+            out = ttnn.add(out, bias_reshaped)
+
+        return ttml.autograd.create_tensor(out, requires_grad=True)

--- a/tt-train/sources/ttml/ttml/ops/mlstm.py
+++ b/tt-train/sources/ttml/ttml/ops/mlstm.py
@@ -1,0 +1,389 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""mLSTM (Matrix LSTM) parallel implementation.
+
+This module implements the mLSTM cell from the xLSTM paper (Beck et al., 2024).
+The mLSTM uses a matrix memory with covariance update rule, enabling
+fully parallelizable computation.
+
+Reference:
+    - Paper: "xLSTM: Extended Long Short-Term Memory" (https://arxiv.org/abs/2405.04517)
+    - JAX reference: https://github.com/NX-AI/mlstm_kernels
+"""
+
+import math
+from typing import Tuple
+
+import ttnn
+
+from ..autograd import Function, FunctionContext
+from .. import _ttml as cpp
+
+
+def _create_causal_mask(seq_len: int, device) -> ttnn.Tensor:
+    """Create a lower triangular mask of ones.
+
+    Args:
+        seq_len: Sequence length S
+        device: Device to create tensor on
+
+    Returns:
+        Tensor of shape (1, 1, S, S) with lower triangular ones
+    """
+    shape = (1, 1, seq_len, seq_len)
+    ones = cpp.core.ones(shape, device)
+    return ttnn.tril(ones, 0)
+
+
+def mlstm_parallel_forward(
+    matQ: ttnn.Tensor,
+    matK: ttnn.Tensor,
+    matV: ttnn.Tensor,
+    vecI: ttnn.Tensor,
+    vecF: ttnn.Tensor,
+    eps: float = 1e-6,
+) -> Tuple[ttnn.Tensor, ttnn.Tensor, ttnn.Tensor]:
+    """mLSTM parallel forward pass.
+
+    Implements the mLSTM forward computation from the xLSTM paper.
+
+    Args:
+        matQ: Query tensor of shape (B, NH, S, DHQK)
+        matK: Key tensor of shape (B, NH, S, DHQK)
+        matV: Value tensor of shape (B, NH, S, DHV)
+        vecI: Input gate pre-activation tensor of shape (B, NH, S)
+        vecF: Forget gate pre-activation tensor of shape (B, NH, S)
+        eps: Epsilon for numerical stability
+
+    Returns:
+        Tuple of (matH, vecN, vecM):
+            - matH: Output tensor of shape (B, NH, S, DHV)
+            - vecN: Normalizer state of shape (B, NH, S)
+            - vecM: Max state for stabilization of shape (B, NH, S)
+    """
+    # Get dimensions from shapes
+    shape_q = matQ.shape
+    B, NH, S, DHQK = shape_q[0], shape_q[1], shape_q[2], shape_q[3]
+
+    # Step 1: log_sigmoid of forget gate
+    # vecLogSigF = log_sigmoid(vecF)  shape: (B, NH, S)
+    vecLogSigF = ttnn.log_sigmoid(vecF)
+
+    # Step 2: Cumulative sum along sequence dimension (dim 2 for 3D tensor)
+    vecLogSigF_cumsum = ttnn.cumsum(vecLogSigF, dim=2)
+
+    # Step 3: Compute the log forget gate matrix
+    # matLogSigF = vecLogSigF_cumsum[:,:,:,None] - vecLogSigF_cumsum[:,:,None,:]
+    # Reshape for broadcasting: (B, NH, S, 1) - (B, NH, 1, S) -> (B, NH, S, S)
+    cumsum_col = ttnn.reshape(vecLogSigF_cumsum, (B, NH, S, 1))
+    cumsum_row = ttnn.reshape(vecLogSigF_cumsum, (B, NH, 1, S))
+    matLogSigF = ttnn.subtract(cumsum_col, cumsum_row)
+
+    # Step 4: Apply lower triangular mask (causal mask)
+    # matLogSigF_mask = where(ltr, matLogSigF, -inf)
+    device = cpp.autograd.AutoContext.get_instance().get_device()
+    causal_mask = _create_causal_mask(S, device)
+    NEG_INF = -1e9  # Use large negative value for numerical stability
+    matLogSigF_masked = ttnn.where(causal_mask, matLogSigF, NEG_INF)
+
+    # Step 5: Add input gate to create log D matrix
+    # matLogD = matLogSigF_mask + vecI[:,:,None,:]
+    vecI_expanded = ttnn.reshape(vecI, (B, NH, 1, S))
+    matLogD = ttnn.add(matLogSigF_masked, vecI_expanded)
+
+    # Step 6: Stabilization - compute row-wise max
+    # vecM = max(matLogD, dim=-1, keepdim=True)  shape: (B, NH, S, 1)
+    vecM = ttnn.max(matLogD, dim=3, keepdim=True)
+
+    # Step 7: Stabilized D matrix
+    # matD = exp(matLogD - vecM)  shape: (B, NH, S, S)
+    matLogD_stabilized = ttnn.subtract(matLogD, vecM)
+    matD = ttnn.exp(matLogD_stabilized)
+
+    # Step 8: Compute scaled dot product
+    # matS = (Q @ K^T) / sqrt(d)  shape: (B, NH, S, S)
+    scale = 1.0 / math.sqrt(float(DHQK))
+    matS = ttnn.matmul(matQ, ttnn.transpose(matK, -2, -1))
+    matS = ttnn.multiply(matS, scale)
+
+    # Step 9: Gated attention
+    # matCtilde = matS * matD  shape: (B, NH, S, S)
+    matCtilde = ttnn.multiply(matS, matD)
+
+    # Step 10: Compute normalizer
+    # vecN = max(|sum(matCtilde, dim=-1)|, exp(-vecM))  shape: (B, NH, S, 1)
+    sumCtilde = ttnn.sum(matCtilde, dim=3, keepdim=True)
+    absSumCtilde = ttnn.abs(sumCtilde)
+    expNegM = ttnn.exp(ttnn.neg(vecM))
+    vecN = ttnn.maximum(absSumCtilde, expNegM)
+
+    # Step 11: Normalize
+    # matC = matCtilde / (vecN + eps)  shape: (B, NH, S, S)
+    vecN_eps = ttnn.add(vecN, eps)
+    matC = ttnn.divide(matCtilde, vecN_eps)
+
+    # Step 12: Compute output
+    # matH = matC @ V  shape: (B, NH, S, DHV)
+    matH = ttnn.matmul(matC, matV)
+
+    # Squeeze vecN and vecM for return (B, NH, S)
+    vecN_squeezed = ttnn.reshape(vecN, (B, NH, S))
+    vecM_squeezed = ttnn.reshape(vecM, (B, NH, S))
+
+    return matH, vecN_squeezed, vecM_squeezed
+
+
+def mlstm_parallel_backward(
+    matDeltaHtilde: ttnn.Tensor,
+    matQ: ttnn.Tensor,
+    matK: ttnn.Tensor,
+    matV: ttnn.Tensor,
+    vecI: ttnn.Tensor,
+    vecF: ttnn.Tensor,
+    vecN: ttnn.Tensor,
+    vecM: ttnn.Tensor,
+    eps: float = 1e-6,
+) -> Tuple[ttnn.Tensor, ttnn.Tensor, ttnn.Tensor, ttnn.Tensor, ttnn.Tensor]:
+    """mLSTM parallel backward pass.
+
+    Computes gradients for the mLSTM operation.
+
+    Args:
+        matDeltaHtilde: Gradient of output, shape (B, NH, S, DHV)
+        matQ: Query tensor of shape (B, NH, S, DHQK)
+        matK: Key tensor of shape (B, NH, S, DHQK)
+        matV: Value tensor of shape (B, NH, S, DHV)
+        vecI: Input gate pre-activation tensor of shape (B, NH, S)
+        vecF: Forget gate pre-activation tensor of shape (B, NH, S)
+        vecN: Normalizer state of shape (B, NH, S)
+        vecM: Max state of shape (B, NH, S)
+        eps: Epsilon for numerical stability
+
+    Returns:
+        Tuple of gradients (matDeltaQ, matDeltaK, matDeltaV, vecDeltaI, vecDeltaF)
+    """
+    # Get dimensions
+    shape_q = matQ.shape
+    B, NH, S, DHQK = shape_q[0], shape_q[1], shape_q[2], shape_q[3]
+
+    # Recompute forward intermediates
+    vecLogSigF = ttnn.log_sigmoid(vecF)
+    vecLogSigF_cumsum = ttnn.cumsum(vecLogSigF, dim=2)
+
+    cumsum_col = ttnn.reshape(vecLogSigF_cumsum, (B, NH, S, 1))
+    cumsum_row = ttnn.reshape(vecLogSigF_cumsum, (B, NH, 1, S))
+    matLogSigF = ttnn.subtract(cumsum_col, cumsum_row)
+
+    device = cpp.autograd.AutoContext.get_instance().get_device()
+    causal_mask = _create_causal_mask(S, device)
+    NEG_INF = -1e9
+    matLogSigF_masked = ttnn.where(causal_mask, matLogSigF, NEG_INF)
+
+    vecI_expanded = ttnn.reshape(vecI, (B, NH, 1, S))
+    matLogD = ttnn.add(matLogSigF_masked, vecI_expanded)
+
+    vecM_expanded = ttnn.reshape(vecM, (B, NH, S, 1))
+    matLogD_stabilized = ttnn.subtract(matLogD, vecM_expanded)
+    matD = ttnn.exp(matLogD_stabilized)
+
+    scale = 1.0 / math.sqrt(float(DHQK))
+    matS = ttnn.matmul(matQ, ttnn.transpose(matK, -2, -1))
+    matS = ttnn.multiply(matS, scale)
+
+    # Intermediate delta-errors
+    vecN_expanded = ttnn.reshape(vecN, (B, NH, S, 1))
+    vecN_eps = ttnn.add(vecN_expanded, eps)
+    matDeltaC = ttnn.divide(
+        ttnn.matmul(matDeltaHtilde, ttnn.transpose(matV, -2, -1)), vecN_eps
+    )
+
+    matDeltaDtilde = ttnn.multiply(ttnn.multiply(matDeltaC, matD), matS)
+
+    # vecDeltaI = sum(matDeltaDtilde, dim=-2)
+    vecDeltaI = ttnn.sum(matDeltaDtilde, dim=2)
+    vecDeltaI = ttnn.reshape(vecDeltaI, (B, NH, S))
+
+    # Output delta-errors / gradients
+    matP = ttnn.multiply(matDeltaC, matD)
+
+    matDeltaQ = ttnn.multiply(ttnn.matmul(matP, matK), scale)
+    matDeltaK = ttnn.multiply(ttnn.matmul(ttnn.transpose(matP, -2, -1), matQ), scale)
+
+    matCtilde = ttnn.multiply(matS, matD)
+    matDeltaV = ttnn.matmul(
+        ttnn.transpose(matCtilde, -2, -1), ttnn.divide(matDeltaHtilde, vecN_eps)
+    )
+
+    # Compute vecDeltaF using the formula from the paper:
+    # vecDeltaFbar = rev_cumsum((q*dq - k*dk).sum(-1))
+    # vecDeltaF = vecDeltaFbar * sigmoid(-vecF)
+    q_times_dq = ttnn.multiply(matQ, matDeltaQ)
+    k_times_dk = ttnn.multiply(matK, matDeltaK)
+    diff = ttnn.subtract(q_times_dq, k_times_dk)
+
+    # Sum over embedding dimension (dim 3)
+    vecDeltaFbar_acc = ttnn.sum(diff, dim=3)
+    vecDeltaFbar_acc = ttnn.reshape(vecDeltaFbar_acc, (B, NH, S))
+
+    # Reverse cumsum using cumsum with reverse_order=True
+    vecDeltaFbar = ttnn.cumsum(vecDeltaFbar_acc, dim=2, reverse_order=True)
+
+    # vecDeltaF = vecDeltaFbar * sigmoid(-vecF)
+    neg_vecF = ttnn.neg(vecF)
+    sig_neg_vecF = ttnn.sigmoid(neg_vecF)
+    vecDeltaF = ttnn.multiply(vecDeltaFbar, sig_neg_vecF)
+
+    return matDeltaQ, matDeltaK, matDeltaV, vecDeltaI, vecDeltaF
+
+
+class MLSTMParallel(Function):
+    """mLSTM (Matrix LSTM) parallel operation with autograd support.
+
+    This implements the mLSTM cell from the xLSTM paper using the parallel
+    formulation that enables efficient GPU computation.
+
+    Example:
+        >>> import ttml
+        >>> import numpy as np
+        >>>
+        >>> # Create inputs
+        >>> B, NH, S, D = 1, 2, 32, 64
+        >>> q = ttml.autograd.Tensor.from_numpy(np.random.randn(B, NH, S, D).astype(np.float32))
+        >>> k = ttml.autograd.Tensor.from_numpy(np.random.randn(B, NH, S, D).astype(np.float32))
+        >>> v = ttml.autograd.Tensor.from_numpy(np.random.randn(B, NH, S, D).astype(np.float32))
+        >>> i = ttml.autograd.Tensor.from_numpy(np.random.randn(B, NH, S).astype(np.float32))
+        >>> f = ttml.autograd.Tensor.from_numpy(np.random.randn(B, NH, S).astype(np.float32))
+        >>>
+        >>> # Forward pass
+        >>> output = MLSTMParallel.apply(q, k, v, i, f)
+        >>>
+        >>> # Backward pass
+        >>> output.backward()
+    """
+
+    @staticmethod
+    def forward(
+        ctx: FunctionContext,
+        query,
+        key,
+        value,
+        input_gate,
+        forget_gate,
+        eps: float = 1e-6,
+    ):
+        """Forward pass of mLSTM.
+
+        Args:
+            ctx: Context for saving tensors for backward
+            query: Query tensor of shape (B, NH, S, DHQK)
+            key: Key tensor of shape (B, NH, S, DHQK)
+            value: Value tensor of shape (B, NH, S, DHV)
+            input_gate: Input gate pre-activation of shape (B, NH, S)
+            forget_gate: Forget gate pre-activation of shape (B, NH, S)
+            eps: Epsilon for numerical stability
+
+        Returns:
+            Output tensor of shape (B, NH, S, DHV)
+        """
+        # Get raw ttnn tensors
+        matQ = query.get_value()
+        matK = key.get_value()
+        matV = value.get_value()
+        vecI = input_gate.get_value()
+        vecF = forget_gate.get_value()
+
+        # Run forward pass
+        matH, vecN, vecM = mlstm_parallel_forward(matQ, matK, matV, vecI, vecF, eps)
+
+        # Save tensors for backward
+        ctx.save_for_backward(query, key, value, input_gate, forget_gate)
+        ctx.vecN = vecN
+        ctx.vecM = vecM
+        ctx.eps = eps
+
+        return matH
+
+    @staticmethod
+    def backward(ctx: FunctionContext, grad_output):
+        """Backward pass of mLSTM.
+
+        Args:
+            ctx: Context with saved tensors
+            grad_output: Gradient of output tensor (B, NH, S, DHV)
+
+        Returns:
+            Tuple of gradients for (query, key, value, input_gate, forget_gate)
+        """
+        # Retrieve saved tensors
+        query, key, value, input_gate, forget_gate = ctx.saved_tensors
+        vecN = ctx.vecN
+        vecM = ctx.vecM
+        eps = ctx.eps
+
+        # Get raw ttnn tensors
+        matQ = query.get_value()
+        matK = key.get_value()
+        matV = value.get_value()
+        vecI = input_gate.get_value()
+        vecF = forget_gate.get_value()
+
+        # Run backward pass
+        matDeltaQ, matDeltaK, matDeltaV, vecDeltaI, vecDeltaF = mlstm_parallel_backward(
+            grad_output, matQ, matK, matV, vecI, vecF, vecN, vecM, eps
+        )
+
+        return matDeltaQ, matDeltaK, matDeltaV, vecDeltaI, vecDeltaF
+
+
+def mlstm_parallel(
+    query,
+    key,
+    value,
+    input_gate,
+    forget_gate,
+    eps: float = 1e-6,
+):
+    """mLSTM (Matrix LSTM) parallel forward pass with autograd support.
+
+    This is the main entry point for the mLSTM operation.
+
+    Args:
+        query: Query tensor of shape (B, NH, S, DHQK)
+        key: Key tensor of shape (B, NH, S, DHQK)
+        value: Value tensor of shape (B, NH, S, DHV)
+        input_gate: Input gate pre-activation of shape (B, NH, S)
+        forget_gate: Forget gate pre-activation of shape (B, NH, S)
+        eps: Epsilon for numerical stability (default: 1e-6)
+
+    Returns:
+        Output tensor of shape (B, NH, S, DHV)
+
+    Example:
+        >>> import ttml
+        >>> from ttml.ops import mlstm_parallel
+        >>> import numpy as np
+        >>>
+        >>> # Initialize
+        >>> auto_ctx = ttml.autograd.AutoContext.get_instance()
+        >>> auto_ctx.open_device()
+        >>>
+        >>> # Create inputs
+        >>> B, NH, S, D = 1, 2, 32, 64
+        >>> q = ttml.autograd.Tensor.from_numpy(np.random.randn(B, NH, S, D).astype(np.float32))
+        >>> k = ttml.autograd.Tensor.from_numpy(np.random.randn(B, NH, S, D).astype(np.float32))
+        >>> v = ttml.autograd.Tensor.from_numpy(np.random.randn(B, NH, S, D).astype(np.float32))
+        >>> i = ttml.autograd.Tensor.from_numpy(np.random.randn(B, NH, S).astype(np.float32))
+        >>> f = ttml.autograd.Tensor.from_numpy(np.random.randn(B, NH, S).astype(np.float32))
+        >>>
+        >>> # Forward + backward
+        >>> output = mlstm_parallel(q, k, v, i, f)
+        >>> output.backward()
+        >>>
+        >>> # Check gradients
+        >>> print("q gradient initialized:", q.is_grad_initialized())
+        >>>
+        >>> auto_ctx.close_device()
+    """
+    return MLSTMParallel.apply(query, key, value, input_gate, forget_gate, eps)

--- a/tt-train/sources/ttml/ttml/ops/mlstm_block.py
+++ b/tt-train/sources/ttml/ttml/ops/mlstm_block.py
@@ -1,0 +1,188 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""mLSTM Block implementation.
+
+The mLSTM block wraps the mLSTM layer with pre-normalization
+and residual (skip) connections, following the standard
+Transformer-style block pattern.
+
+Reference:
+    - Paper: "xLSTM: Extended Long Short-Term Memory" (https://arxiv.org/abs/2405.04517)
+"""
+
+from dataclasses import dataclass, field
+from typing import Optional
+
+import ttnn
+
+import ttml
+from ttml.modules import AbstractModuleBase
+from .components import LayerNorm
+from .mlstm_layer import mLSTMLayer, mLSTMLayerConfig
+
+
+@dataclass
+class mLSTMBlockConfig:
+    """Configuration for mLSTMBlock."""
+
+    mlstm: mLSTMLayerConfig = field(default_factory=mLSTMLayerConfig)
+
+    # Block tracking
+    _num_blocks: int = 1
+    _block_idx: int = 0
+
+    def __post_init__(self):
+        self.mlstm._num_blocks = self._num_blocks
+        self.mlstm.__post_init__()
+
+
+class mLSTMBlock(AbstractModuleBase):
+    """mLSTM Block with pre-normalization and skip connection.
+
+    The block follows the Pre-LN Transformer pattern:
+        output = x + mLSTMLayer(LayerNorm(x))
+
+    This design provides:
+    - Better training stability (pre-normalization)
+    - Easy gradient flow (residual connection)
+    - Modular composition for stacking
+
+    Args:
+        config: mLSTMBlockConfig containing the mLSTM layer configuration
+
+    Example:
+        >>> config = mLSTMBlockConfig(
+        ...     mlstm=mLSTMLayerConfig(
+        ...         embedding_dim=512,
+        ...         num_heads=8,
+        ...         proj_factor=2.0,
+        ...         context_length=1024,
+        ...     )
+        ... )
+        >>> block = mLSTMBlock(config)
+        >>> x = ttml.autograd.Tensor.from_numpy(np.random.randn(2, 128, 512).astype(np.float32))
+        >>> output = block(x)  # (2, 128, 512)
+    """
+
+    def __init__(self, config: mLSTMBlockConfig) -> None:
+        super().__init__()
+        self.config = config
+
+        embedding_dim = config.mlstm.embedding_dim
+
+        # Pre-normalization layer
+        self.xlstm_norm = LayerNorm(
+            ndim=embedding_dim,
+            weight=True,
+            bias=False,
+        )
+
+        # mLSTM layer
+        self.xlstm = mLSTMLayer(config.mlstm)
+
+    def forward(self, x: ttml.autograd.Tensor) -> ttml.autograd.Tensor:
+        """Forward pass of mLSTM block.
+
+        Args:
+            x: Input tensor of shape (B, S, embedding_dim)
+
+        Returns:
+            Output tensor of shape (B, S, embedding_dim)
+        """
+        # Pre-norm + mLSTM layer
+        x_norm = self.xlstm_norm(x)
+        x_mlstm = self.xlstm(x_norm)
+
+        # Residual connection
+        x_val = x.get_value()
+        x_mlstm_val = x_mlstm.get_value()
+        output_val = ttnn.add(x_val, x_mlstm_val)
+
+        return ttml.autograd.create_tensor(output_val, requires_grad=True)
+
+
+class xLSTMStack(AbstractModuleBase):
+    """Stack of mLSTM blocks for building full xLSTM models.
+
+    Creates a sequential stack of mLSTM blocks that can be used
+    as the core of a language model or other sequence model.
+
+    Args:
+        embedding_dim: Dimension of token embeddings
+        num_blocks: Number of mLSTM blocks to stack
+        num_heads: Number of attention heads per block
+        proj_factor: Up-projection factor for inner dimension
+        context_length: Maximum sequence length
+        conv1d_kernel_size: Kernel size for causal convolution
+        dropout: Dropout probability
+
+    Example:
+        >>> stack = xLSTMStack(
+        ...     embedding_dim=512,
+        ...     num_blocks=12,
+        ...     num_heads=8,
+        ...     context_length=2048,
+        ... )
+        >>> x = ttml.autograd.Tensor.from_numpy(np.random.randn(2, 128, 512).astype(np.float32))
+        >>> output = stack(x)  # (2, 128, 512)
+    """
+
+    def __init__(
+        self,
+        embedding_dim: int,
+        num_blocks: int,
+        num_heads: int = 4,
+        proj_factor: float = 2.0,
+        context_length: int = 2048,
+        conv1d_kernel_size: int = 4,
+        qkv_proj_blocksize: int = 4,
+        dropout: float = 0.0,
+    ) -> None:
+        super().__init__()
+
+        self.embedding_dim = embedding_dim
+        self.num_blocks = num_blocks
+
+        # Create blocks
+        self.blocks = ttml.modules.ModuleList()
+        for block_idx in range(num_blocks):
+            layer_config = mLSTMLayerConfig(
+                embedding_dim=embedding_dim,
+                num_heads=num_heads,
+                proj_factor=proj_factor,
+                conv1d_kernel_size=conv1d_kernel_size,
+                qkv_proj_blocksize=qkv_proj_blocksize,
+                context_length=context_length,
+                dropout=dropout,
+                _num_blocks=num_blocks,
+            )
+            block_config = mLSTMBlockConfig(
+                mlstm=layer_config,
+                _num_blocks=num_blocks,
+                _block_idx=block_idx,
+            )
+            self.blocks.append(mLSTMBlock(block_config))
+
+        # Final layer norm
+        self.final_norm = LayerNorm(
+            ndim=embedding_dim,
+            weight=True,
+            bias=False,
+        )
+
+    def forward(self, x: ttml.autograd.Tensor) -> ttml.autograd.Tensor:
+        """Forward pass through all blocks.
+
+        Args:
+            x: Input tensor of shape (B, S, embedding_dim)
+
+        Returns:
+            Output tensor of shape (B, S, embedding_dim)
+        """
+        for block in self.blocks:
+            x = block(x)
+
+        x = self.final_norm(x)
+        return x

--- a/tt-train/sources/ttml/ttml/ops/mlstm_cell.py
+++ b/tt-train/sources/ttml/ttml/ops/mlstm_cell.py
@@ -1,0 +1,154 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""mLSTM Cell implementation.
+
+The mLSTM cell is the core computational unit of the mLSTM layer.
+It computes input and forget gates based on Q, K, V inputs and
+applies the parallel mLSTM computation with stabilization.
+
+Reference:
+    - Paper: "xLSTM: Extended Long Short-Term Memory" (https://arxiv.org/abs/2405.04517)
+    - JAX reference: https://github.com/NX-AI/mlstm_kernels
+"""
+
+from dataclasses import dataclass
+from typing import Tuple
+
+import numpy as np
+import ttnn
+
+import ttml
+from ttml.modules import AbstractModuleBase, Parameter, LinearLayer
+from .components import MultiHeadLayerNorm
+from .mlstm import mlstm_parallel
+
+
+@dataclass
+class mLSTMCellConfig:
+    """Configuration for mLSTMCell."""
+
+    context_length: int
+    embedding_dim: int
+    num_heads: int
+
+
+class mLSTMCell(AbstractModuleBase):
+    """mLSTM Cell with input/forget gates and layer normalization.
+
+    The cell takes Q, K, V tensors, computes input and forget gate
+    pre-activations, applies the parallel mLSTM computation, and
+    normalizes the output.
+
+    Args:
+        config: mLSTMCellConfig with context_length, embedding_dim, num_heads
+    """
+
+    def __init__(self, config: mLSTMCellConfig) -> None:
+        super().__init__()
+        self.config = config
+
+        # Gate linear layers
+        # Input: concat(q, k, v) of shape (B, S, 3*embedding_dim)
+        # Output: (B, S, num_heads)
+        gate_input_dim = 3 * config.embedding_dim
+
+        self.igate = LinearLayer(gate_input_dim, config.num_heads, bias=True)
+        self.fgate = LinearLayer(gate_input_dim, config.num_heads, bias=True)
+
+        # Output normalization (per head)
+        self.outnorm = MultiHeadLayerNorm(
+            ndim=config.embedding_dim,
+            num_heads=config.num_heads,
+            weight=True,
+            bias=False,
+        )
+
+        # Initialize gate biases
+        self._init_gate_biases()
+
+    def _init_gate_biases(self) -> None:
+        """Initialize gate biases according to xLSTM paper.
+
+        Forget gate: linspace from 3.0 to 6.0
+        Input gate: normal(0, 0.1)
+        """
+        num_heads = self.config.num_heads
+
+        # Forget gate: linspace init from 3.0 to 6.0
+        fgate_bias = np.linspace(3.0, 6.0, num_heads).astype(np.float32)
+        # Update the bias parameter
+        # Note: LinearLayer parameters are accessible via the layer
+        # For now, we'll rely on the default initialization
+
+        # Input gate: normal init
+        igate_bias = np.random.normal(0.0, 0.1, num_heads).astype(np.float32)
+
+    def forward(
+        self,
+        q: ttml.autograd.Tensor,
+        k: ttml.autograd.Tensor,
+        v: ttml.autograd.Tensor,
+    ) -> ttml.autograd.Tensor:
+        """Forward pass of mLSTM cell.
+
+        Args:
+            q: Query tensor of shape (B, S, H) where H = embedding_dim
+            k: Key tensor of shape (B, S, H)
+            v: Value tensor of shape (B, S, H)
+
+        Returns:
+            Output tensor of shape (B, S, H)
+        """
+        B = q.get_value().shape[0]
+        S = q.get_value().shape[1]
+        H = self.config.embedding_dim
+        NH = self.config.num_heads
+        DH = H // NH
+
+        # Concatenate q, k, v for gate input
+        q_val = q.get_value()
+        k_val = k.get_value()
+        v_val = v.get_value()
+        if_gate_input = ttnn.concat([q_val, k_val, v_val], dim=-1)
+        if_gate_input_tensor = ttml.autograd.create_tensor(
+            if_gate_input, requires_grad=True
+        )
+
+        # Reshape q, k, v to (B, S, NH, DH) then transpose to (B, NH, S, DH)
+        q_heads = ttnn.reshape(q_val, (B, S, NH, DH))
+        q_heads = ttnn.transpose(q_heads, 1, 2)  # (B, NH, S, DH)
+
+        k_heads = ttnn.reshape(k_val, (B, S, NH, DH))
+        k_heads = ttnn.transpose(k_heads, 1, 2)  # (B, NH, S, DH)
+
+        v_heads = ttnn.reshape(v_val, (B, S, NH, DH))
+        v_heads = ttnn.transpose(v_heads, 1, 2)  # (B, NH, S, DH)
+
+        # Compute gate pre-activations
+        igate_preact = self.igate(if_gate_input_tensor)  # (B, S, NH)
+        fgate_preact = self.fgate(if_gate_input_tensor)  # (B, S, NH)
+
+        # Transpose gate activations to (B, NH, S)
+        igate_val = ttnn.transpose(igate_preact.get_value(), 1, 2)  # (B, NH, S)
+        fgate_val = ttnn.transpose(fgate_preact.get_value(), 1, 2)  # (B, NH, S)
+
+        # Create autograd tensors for mLSTM
+        q_tensor = ttml.autograd.create_tensor(q_heads, requires_grad=True)
+        k_tensor = ttml.autograd.create_tensor(k_heads, requires_grad=True)
+        v_tensor = ttml.autograd.create_tensor(v_heads, requires_grad=True)
+        i_tensor = ttml.autograd.create_tensor(igate_val, requires_grad=True)
+        f_tensor = ttml.autograd.create_tensor(fgate_val, requires_grad=True)
+
+        # Apply parallel mLSTM
+        h_state = mlstm_parallel(q_tensor, k_tensor, v_tensor, i_tensor, f_tensor)
+
+        # Apply output normalization
+        h_state_norm = self.outnorm(h_state)  # (B, NH, S, DH)
+
+        # Reshape back to (B, S, H)
+        h_out = ttnn.transpose(h_state_norm.get_value(), 1, 2)  # (B, S, NH, DH)
+        h_out = ttnn.reshape(h_out, (B, S, H))  # (B, S, H)
+
+        return ttml.autograd.create_tensor(h_out, requires_grad=True)

--- a/tt-train/sources/ttml/ttml/ops/mlstm_layer.py
+++ b/tt-train/sources/ttml/ttml/ops/mlstm_layer.py
@@ -1,0 +1,182 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""mLSTM Layer implementation.
+
+The mLSTM layer is a complete processing unit that includes:
+- Up-projection to inner dimension
+- Causal convolution
+- Q/K/V projections
+- mLSTM cell computation
+- Down-projection back to embedding dimension
+
+Reference:
+    - Paper: "xLSTM: Extended Long Short-Term Memory" (https://arxiv.org/abs/2405.04517)
+"""
+
+from dataclasses import dataclass
+from math import sqrt
+from typing import Optional
+
+import numpy as np
+import ttnn
+
+import ttml
+from ttml.modules import AbstractModuleBase, Parameter, LinearLayer, RunMode
+from .components import (
+    CausalConv1d,
+    CausalConv1dConfig,
+    LinearHeadwiseExpand,
+    LinearHeadwiseExpandConfig,
+)
+from .mlstm_cell import mLSTMCell, mLSTMCellConfig
+
+
+@dataclass
+class mLSTMLayerConfig:
+    """Configuration for mLSTMLayer."""
+
+    embedding_dim: int
+    num_heads: int = 4
+    proj_factor: float = 2.0
+    conv1d_kernel_size: int = 4
+    qkv_proj_blocksize: int = 4
+    bias: bool = False
+    dropout: float = 0.0
+    context_length: int = -1
+
+    # Internal
+    _num_blocks: int = 1
+    _inner_embedding_dim: int = None
+
+    def __post_init__(self):
+        if self._inner_embedding_dim is None:
+            self._inner_embedding_dim = round(self.proj_factor * self.embedding_dim)
+
+
+class mLSTMLayer(AbstractModuleBase):
+    """mLSTM Layer with projections, convolution, and mLSTM cell.
+
+    This layer implements the full mLSTM processing pipeline:
+    1. Up-projection: embedding_dim -> 2 * inner_dim
+    2. Split into x_mlstm and z (output gate)
+    3. Causal convolution + SiLU on x_mlstm
+    4. Q/K/V projections
+    5. mLSTM cell computation
+    6. Skip connection with learnable scaling
+    7. Output gating with z
+    8. Down-projection: inner_dim -> embedding_dim
+
+    Args:
+        config: mLSTMLayerConfig
+    """
+
+    def __init__(self, config: mLSTMLayerConfig) -> None:
+        super().__init__()
+        self.config = config
+        inner_dim = config._inner_embedding_dim
+
+        # Up-projection: embedding_dim -> 2 * inner_dim
+        self.proj_up = LinearLayer(
+            config.embedding_dim, 2 * inner_dim, bias=config.bias
+        )
+
+        # Q/K/V projections (headwise)
+        num_proj_heads = round(inner_dim / config.qkv_proj_blocksize)
+        qkv_config = LinearHeadwiseExpandConfig(
+            in_features=inner_dim,
+            num_heads=num_proj_heads,
+            expand_factor=1.0,
+            bias=config.bias,
+        )
+        self.q_proj = LinearHeadwiseExpand(qkv_config)
+        self.k_proj = LinearHeadwiseExpand(qkv_config)
+        self.v_proj = LinearHeadwiseExpand(qkv_config)
+
+        # Causal conv1d
+        self.conv1d = CausalConv1d(
+            CausalConv1dConfig(
+                feature_dim=inner_dim,
+                kernel_size=config.conv1d_kernel_size,
+                bias=True,
+            )
+        )
+
+        # mLSTM cell
+        self.mlstm_cell = mLSTMCell(
+            mLSTMCellConfig(
+                context_length=config.context_length,
+                embedding_dim=inner_dim,
+                num_heads=config.num_heads,
+            )
+        )
+
+        # Learnable skip connection scale
+        skip_data = np.ones((inner_dim,), dtype=np.float32)
+        self.learnable_skip = Parameter(ttml.autograd.Tensor.from_numpy(skip_data))
+
+        # Down-projection: inner_dim -> embedding_dim
+        self.proj_down = LinearLayer(inner_dim, config.embedding_dim, bias=config.bias)
+
+        self.dropout_prob = config.dropout
+        self.inner_dim = inner_dim
+
+    def forward(self, x: ttml.autograd.Tensor) -> ttml.autograd.Tensor:
+        """Forward pass of mLSTM layer.
+
+        Args:
+            x: Input tensor of shape (B, S, embedding_dim)
+
+        Returns:
+            Output tensor of shape (B, S, embedding_dim)
+        """
+        B = x.get_value().shape[0]
+        S = x.get_value().shape[1]
+
+        # Up-projection
+        x_inner = self.proj_up(x)  # (B, S, 2 * inner_dim)
+
+        # Split into x_mlstm and z
+        x_inner_val = x_inner.get_value()
+        x_mlstm_val = x_inner_val[:, :, : self.inner_dim]
+        z_val = x_inner_val[:, :, self.inner_dim :]
+
+        x_mlstm = ttml.autograd.create_tensor(x_mlstm_val, requires_grad=True)
+        z = ttml.autograd.create_tensor(z_val, requires_grad=True)
+
+        # Causal convolution + SiLU activation
+        x_mlstm_conv = self.conv1d(x_mlstm)
+
+        # Apply SiLU using ttml ops
+        x_mlstm_conv_act = ttml.ops.unary.silu(x_mlstm_conv)
+
+        # Q/K/V projections
+        q = self.q_proj(x_mlstm_conv_act)  # (B, S, inner_dim)
+        k = self.k_proj(x_mlstm_conv_act)  # (B, S, inner_dim)
+        v = self.v_proj(
+            x_mlstm
+        )  # (B, S, inner_dim) - note: v uses x_mlstm, not conv output
+
+        # mLSTM cell computation
+        h_tilde_state = self.mlstm_cell(q, k, v)  # (B, S, inner_dim)
+
+        # Skip connection with learnable scaling
+        skip_val = self.learnable_skip.tensor.get_value()
+        x_mlstm_conv_act_val = x_mlstm_conv_act.get_value()
+        scaled_skip = ttnn.multiply(x_mlstm_conv_act_val, skip_val)
+        h_tilde_state_skip_val = ttnn.add(h_tilde_state.get_value(), scaled_skip)
+
+        # Output gating with SiLU(z)
+        z_silu_val = ttnn.silu(z_val)
+        h_state_val = ttnn.multiply(h_tilde_state_skip_val, z_silu_val)
+
+        # Down-projection
+        h_state = ttml.autograd.create_tensor(h_state_val, requires_grad=True)
+        y = self.proj_down(h_state)  # (B, S, embedding_dim)
+
+        # Apply dropout if training
+        if self.get_run_mode() == RunMode.TRAIN and self.dropout_prob > 0.0:
+            y = ttml.ops.dropout.dropout(y, self.dropout_prob)
+
+        return y


### PR DESCRIPTION
### Ticket
None

### Problem description
Playing with xLSTM 
https://github.com/NX-AI/xlstm

### What's changed
Adding mLSTM operation example

The implementation follows the xLSTM paper (Beck et al., 2024) and the JAX reference implementation from mlstm_kernels. Key features:
* Exponential gating with log-sigmoid for numerical stability
* Causal masking for autoregressive computation
* Stabilization using max subtraction to prevent overflow
* Full backward pass computing gradients for Q, K, V, input gate, and forget gate

This PR is open to sample the TTML programming.
It should enable 
```py
import ttml
from ttml.ops import xLSTMStack, mLSTMBlock, mLSTMBlockConfig, mLSTMLayerConfig
import numpy as np

# Initialize device
auto_ctx = ttml.autograd.AutoContext.get_instance()
auto_ctx.open_device()

# Option 1: Use the full stack
stack = xLSTMStack(
    embedding_dim=512,
    num_blocks=12,
    num_heads=8,
    proj_factor=2.0,
    context_length=2048,
)

# Option 2: Use individual blocks
layer_config = mLSTMLayerConfig(
    embedding_dim=512,
    num_heads=8,
    proj_factor=2.0,
    context_length=2048,
)
block = mLSTMBlock(mLSTMBlockConfig(mlstm=layer_config))

# Forward pass
x = ttml.autograd.Tensor.from_numpy(
    np.random.randn(2, 128, 512).astype(np.float32)
)
output = stack(x)  # or block(x)

# Backward pass
output.backward()

auto_ctx.close_device()
```

### Checklist
todo: add mlst test in this PR
