### PR TITLE
Make perf test timeout explicit for DiT models

### DIFF
--- a/.github/workflows/blackhole-multi-card-demo-tests-impl.yaml
+++ b/.github/workflows/blackhole-multi-card-demo-tests-impl.yaml
@@ -344,7 +344,7 @@ jobs:
               "model": "flux.1-dev",
               "arch": "blackhole",
               "runner-label": "P300-viommu",
-              "cmd": "HF_HUB_CACHE=/localdev/blackhole_demos/huggingface_data/black-forest-labs pytest models/experimental/tt_dit/tests/models/flux1/test_performance_flux1.py -k \"1x2sp0tp1\"",
+              "cmd": "HF_HUB_CACHE=/localdev/blackhole_demos/huggingface_data/black-forest-labs pytest models/experimental/tt_dit/tests/models/flux1/test_performance_flux1.py -k \"1x2sp0tp1\" --timeout=600",
               "owner_id": "U08TED0JM9D",
               "owner_name": "Samuel Adesoye"
             },
@@ -353,7 +353,7 @@ jobs:
               "model": "flux.1-dev",
               "arch": "blackhole",
               "runner-label": "BH-QB-GE",
-              "cmd": "HF_HUB_CACHE=/localdev/blackhole_demos/huggingface_data/black-forest-labs pytest models/experimental/tt_dit/tests/models/flux1/test_performance_flux1.py -k \"2x2sp0tp1\"",
+              "cmd": "HF_HUB_CACHE=/localdev/blackhole_demos/huggingface_data/black-forest-labs pytest models/experimental/tt_dit/tests/models/flux1/test_performance_flux1.py -k \"2x2sp0tp1\" --timeout=600",
               "owner_id": "U08TED0JM9D",
               "owner_name": "Samuel Adesoye"
             },
@@ -362,7 +362,7 @@ jobs:
               "model": "flux.1-dev",
               "arch": "blackhole",
               "runner-label": "BH-LoudBox",
-              "cmd": "HF_HUB_CACHE=/localdev/blackhole_demos/huggingface_data/black-forest-labs pytest models/experimental/tt_dit/tests/models/flux1/test_performance_flux1.py -k \"bh_2x4sp0tp1\"",
+              "cmd": "HF_HUB_CACHE=/localdev/blackhole_demos/huggingface_data/black-forest-labs pytest models/experimental/tt_dit/tests/models/flux1/test_performance_flux1.py -k \"bh_2x4sp0tp1\" --timeout=600",
               "owner_id": "U09ELB03XRU",
               "owner_name": "Stephen Osborne"
             },
@@ -371,7 +371,7 @@ jobs:
               "model": "wan2.2-t2v-a14b",
               "arch": "blackhole",
               "runner-label": "BH-QB-GE",
-              "cmd": "HF_HUB_CACHE=/localdev/blackhole_demos/huggingface_data/Wan-AI TT_DIT_CACHE_DIR=\"/tmp/TT_DIT_CACHE\" pytest models/experimental/tt_dit/tests/models/wan2_2/test_performance_wan.py -k \"2x2sp0tp1 and resolution_480p and t2v\"",
+              "cmd": "HF_HUB_CACHE=/localdev/blackhole_demos/huggingface_data/Wan-AI TT_DIT_CACHE_DIR=\"/tmp/TT_DIT_CACHE\" pytest models/experimental/tt_dit/tests/models/wan2_2/test_performance_wan.py -k \"2x2sp0tp1 and resolution_480p and t2v\" --timeout=1200",
               "owner_id": "U08TED0JM9D",
               "owner_name": "Samuel Adesoye"
             },
@@ -380,7 +380,7 @@ jobs:
               "model": "wan2.2-t2v-a14b",
               "arch": "blackhole",
               "runner-label": "BH-LoudBox",
-              "cmd": "HF_HUB_CACHE=/localdev/blackhole_demos/huggingface_data/Wan-AI TT_DIT_CACHE_DIR=\"/tmp/TT_DIT_CACHE\" pytest models/experimental/tt_dit/tests/models/wan2_2/test_performance_wan.py -k \"1x8sp0tp1 and resolution_480p and t2v\"",
+              "cmd": "HF_HUB_CACHE=/localdev/blackhole_demos/huggingface_data/Wan-AI TT_DIT_CACHE_DIR=\"/tmp/TT_DIT_CACHE\" pytest models/experimental/tt_dit/tests/models/wan2_2/test_performance_wan.py -k \"1x8sp0tp1 and resolution_480p and t2v\" --timeout=1200",
               "owner_id": "U09ELB03XRU",
               "owner_name": "Stephen Osborne"
             }

--- a/.github/workflows/galaxy-model-perf-tests-impl.yaml
+++ b/.github/workflows/galaxy-model-perf-tests-impl.yaml
@@ -95,7 +95,7 @@ jobs:
               "arch": "wormhole_b0",
               "save-perf-data": true,
               "timeout": 50,
-              "cmd": "pytest models/experimental/tt_dit/tests/models/sd35/test_performance_sd35.py -k \"4x8cfg1sp0tp1\"",
+              "cmd": "pytest models/experimental/tt_dit/tests/models/sd35/test_performance_sd35.py -k \"4x8cfg1sp0tp1\" --timeout=480",
               "owner_id": "U03FJB5TM5Y"
             }, # Colman Glagovich
             {
@@ -105,7 +105,7 @@ jobs:
               "arch": "wormhole_b0",
               "save-perf-data": true,
               "timeout": 50,
-              "cmd": "HF_HUB_CACHE=/mnt/MLPerf/huggingface/hub pytest models/experimental/tt_dit/tests/models/flux1/test_performance_flux1.py -k \"wh_4x8sp0tp1\"",
+              "cmd": "HF_HUB_CACHE=/mnt/MLPerf/huggingface/hub pytest models/experimental/tt_dit/tests/models/flux1/test_performance_flux1.py -k \"wh_4x8sp0tp1\" --timeout=500",
               "owner_id": "U08TED0JM9D"
             }, # Samuel Adesoye
             {
@@ -115,7 +115,7 @@ jobs:
               "arch": "wormhole_b0",
               "save-perf-data": true,
               "timeout": 15,
-              "cmd": "HF_HUB_CACHE=/mnt/MLPerf/huggingface/hub pytest models/experimental/tt_dit/tests/models/motif/test_performance_motif.py -k \"4x8cfg1sp0tp1\"",
+              "cmd": "HF_HUB_CACHE=/mnt/MLPerf/huggingface/hub pytest models/experimental/tt_dit/tests/models/motif/test_performance_motif.py -k \"4x8cfg1sp0tp1\" --timeout=1000",
               "owner_id": "U08TED0JM9D"
             }, # Samuel Adesoye
             {
@@ -125,7 +125,7 @@ jobs:
               "arch": "wormhole_b0",
               "save-perf-data": true,
               "timeout": 35,
-              "cmd": "export TT_DIT_CACHE_DIR=\"/tmp/TT_DIT_CACHE\" && pytest models/experimental/tt_dit/tests/models/wan2_2/test_performance_wan.py -k \"wh_4x8sp1tp0 and resolution_720p and t2v\"",
+              "cmd": "export TT_DIT_CACHE_DIR=\"/tmp/TT_DIT_CACHE\" && pytest models/experimental/tt_dit/tests/models/wan2_2/test_performance_wan.py -k \"wh_4x8sp1tp0 and resolution_720p and t2v\" --timeout=1200",
               "owner_id": "U03FJB5TM5Y"
             }, # Colman Glagovich
             {
@@ -135,7 +135,7 @@ jobs:
               "arch": "wormhole_b0",
               "save-perf-data": true,
               "timeout": 50,
-              "cmd": "export TT_DIT_CACHE_DIR=\"/tmp/TT_DIT_CACHE\" && export NO_PROMPT=1 && pytest models/experimental/tt_dit/tests/models/mochi/test_performance_mochi.py -k \"4x8sp1tp0 \"",
+              "cmd": "export TT_DIT_CACHE_DIR=\"/tmp/TT_DIT_CACHE\" && export NO_PROMPT=1 && pytest models/experimental/tt_dit/tests/models/mochi/test_performance_mochi.py -k \"4x8sp1tp0 \" --timeout=1000",
               "owner_id": "U09ELB03XRU"
             }, # Stephen Osborne
             {
@@ -145,7 +145,7 @@ jobs:
               "arch": "wormhole_b0",
               "save-perf-data": true,
               "timeout": 20,
-              "cmd": "export TT_DIT_CACHE_DIR=\"/tmp/TT_DIT_CACHE\" && pytest models/experimental/tt_dit/tests/models/qwenimage/test_performance_qwenimage.py -k \"4x8\"",
+              "cmd": "export TT_DIT_CACHE_DIR=\"/tmp/TT_DIT_CACHE\" && pytest models/experimental/tt_dit/tests/models/qwenimage/test_performance_qwenimage.py -k \"4x8\" --timeout=1000",
               "owner_id": "U08TED0JM9D"
             } # Samuel Adesoye
           ]' --compact-output)

--- a/tests/scripts/t3000/run_t3000_perf_tests.sh
+++ b/tests/scripts/t3000/run_t3000_perf_tests.sh
@@ -176,19 +176,19 @@ run_t3000_mochi_tests() {
 }
 
 run_t3000_stable_diffusion_35_large_tests() {
-  run_t3000_dit_tests "models/experimental/tt_dit/tests/models/sd35/test_performance_sd35.py -k 2x4cfg1sp0tp1" --timeout 600
+  run_t3000_dit_tests "models/experimental/tt_dit/tests/models/sd35/test_performance_sd35.py -k 2x4cfg1sp0tp1 --timeout 600"
 }
 
 run_t3000_flux1_tests() {
-  run_t3000_dit_tests "models/experimental/tt_dit/tests/models/flux1/test_performance_flux1.py -k wh_2x4sp0tp1" --timeout 600
+  run_t3000_dit_tests "models/experimental/tt_dit/tests/models/flux1/test_performance_flux1.py -k wh_2x4sp0tp1 --timeout 600"
 }
 
 run_t3000_motif_tests() {
-  run_t3000_dit_tests "models/experimental/tt_dit/tests/models/motif/test_performance_motif.py" --timeout 600
+  run_t3000_dit_tests "models/experimental/tt_dit/tests/models/motif/test_performance_motif.py --timeout 600"
 }
 
 run_t3000_qwenimage_tests() {
-  run_t3000_dit_tests "models/experimental/tt_dit/tests/models/qwenimage/test_performance_qwenimage.py -k 2x4" --timeout 720
+  run_t3000_dit_tests "models/experimental/tt_dit/tests/models/qwenimage/test_performance_qwenimage.py -k 2x4 --timeout 720"
 }
 
 run_t3000_model_perf_tests() {

--- a/tests/scripts/t3000/run_t3000_perf_tests.sh
+++ b/tests/scripts/t3000/run_t3000_perf_tests.sh
@@ -145,7 +145,7 @@ run_t3000_wan22_tests() {
   echo "LOG_METAL: Running run_t3000_wan22_tests"
 
   export TT_DIT_CACHE_DIR="/tmp/TT_DIT_CACHE"
-  pytest models/experimental/tt_dit/tests/models/wan2_2/test_performance_wan.py -k "2x4sp0tp1 and resolution_480p and t2v"; fail+=$?
+  pytest models/experimental/tt_dit/tests/models/wan2_2/test_performance_wan.py -k "2x4sp0tp1 and resolution_480p and t2v" --timeout 1500; fail+=$?
 
   # Record the end time
   end_time=$(date +%s)
@@ -176,19 +176,19 @@ run_t3000_mochi_tests() {
 }
 
 run_t3000_stable_diffusion_35_large_tests() {
-  run_t3000_dit_tests "models/experimental/tt_dit/tests/models/sd35/test_performance_sd35.py -k 2x4cfg1sp0tp1"
+  run_t3000_dit_tests "models/experimental/tt_dit/tests/models/sd35/test_performance_sd35.py -k 2x4cfg1sp0tp1" --timeout 600
 }
 
 run_t3000_flux1_tests() {
-  run_t3000_dit_tests "models/experimental/tt_dit/tests/models/flux1/test_performance_flux1.py -k wh_2x4sp0tp1"
+  run_t3000_dit_tests "models/experimental/tt_dit/tests/models/flux1/test_performance_flux1.py -k wh_2x4sp0tp1" --timeout 600
 }
 
 run_t3000_motif_tests() {
-  run_t3000_dit_tests "models/experimental/tt_dit/tests/models/motif/test_performance_motif.py"
+  run_t3000_dit_tests "models/experimental/tt_dit/tests/models/motif/test_performance_motif.py" --timeout 600
 }
 
 run_t3000_qwenimage_tests() {
-  run_t3000_dit_tests "models/experimental/tt_dit/tests/models/qwenimage/test_performance_qwenimage.py -k 2x4"
+  run_t3000_dit_tests "models/experimental/tt_dit/tests/models/qwenimage/test_performance_qwenimage.py -k 2x4" --timeout 720
 }
 
 run_t3000_model_perf_tests() {


### PR DESCRIPTION
### Ticket
N/A

### Problem description
DiT Perf tests are failing on main because of timeouts.

### What's changed
Make timeout explicit for each DiT test.

### Checklist

- [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=sadesoye/t3k_dit_timeout)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:sadesoye/t3k_dit_timeout)
- [![T3K Model Perf test](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-perf-tests.yaml/badge.svg?branch=sadesoye/t3k_dit_timeout)](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-perf-tests.yaml?query=branch:sadesoye/t3k_dit_timeout). Different failures from regression that may have been missed during the timeout failures. That'll be addressed separately. 