### PR TITLE
Update module tests with tracing, 100 iterations, random weight option

### DIFF
--- a/models/demos/deepseek_v3/tests/test_decoder_block.py
+++ b/models/demos/deepseek_v3/tests/test_decoder_block.py
@@ -220,6 +220,9 @@ def run_test_forward_pass_decoder1d(
         check_outputs(tt_output)
         ttnn.deallocate(tt_output)
 
+        # Reset CCL semaphore counters before trace capture
+        ccl.reset_sem_counters()
+
         trace_id = ttnn.begin_trace_capture(mesh_device, cq_id=0)
         trace_output = run_forward()
         ttnn.end_trace_capture(mesh_device, trace_id, cq_id=0)
@@ -367,6 +370,9 @@ def run_test_forward_pass_decoder2d(
         ttnn.synchronize_device(mesh_device)
         check_outputs(tt_output)
         ttnn.deallocate(tt_output)
+
+        # Reset CCL semaphore counters before trace capture
+        ccl.reset_sem_counters()
 
         trace_id = ttnn.begin_trace_capture(mesh_device, cq_id=0)
         trace_output = run_forward()

--- a/models/demos/deepseek_v3/tests/test_decoder_block.py
+++ b/models/demos/deepseek_v3/tests/test_decoder_block.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 
+import os
 from pathlib import Path
 
 import pytest
@@ -35,8 +36,16 @@ from models.demos.deepseek_v3.utils.test_utils import (
     torch_cache_from_transformers_single_layer,
 )
 
+TEST_CHECK_ITERS = 100
+CI_ACTIVE = os.getenv("CI") == "true"
+_CI_SKIP_MARK = pytest.mark.skipif(
+    CI_ACTIVE,
+    reason="CI runs traced coverage only.",
+)
+
 
 def generate_reference_io(
+    use_real_weights: bool,
     model_path: Path,
     module_path: str | None,
     hf_config: PretrainedConfig,
@@ -48,7 +57,7 @@ def generate_reference_io(
     decode_position_id: int | None = None,
 ):
     reference_model = DeepseekV3DecoderLayer(hf_config, layer_idx=layer_idx).eval().to(torch.bfloat16)
-    if module_path is not None:
+    if use_real_weights and module_path is not None:
         state_dict = sub_state_dict(state_dict, module_path + ".")
         reference_model.load_state_dict(dequantize_state_dict(state_dict, hf_config))
     else:
@@ -87,13 +96,14 @@ def generate_reference_io(
     return state_dict, position_ids, torch_input, reference_output, input_cache, output_cache
 
 
-def run_test_forward_pass_decoder2d(
-    DecoderBlockClass: type[DecoderBlock2DBase],
+def run_test_forward_pass_decoder1d(
+    DecoderBlockClass: type[DecoderBlock1DBase],
     module_path,
     reference_layer_idx,
     mode,
     seq_len,
-    batch_size_per_row,
+    batch_size,
+    trace_mode,
     hf_config_short,
     cache_path,
     mesh_device,
@@ -101,6 +111,159 @@ def run_test_forward_pass_decoder2d(
     ccl,
     force_recalculate_weight_config,
     state_dict,
+    use_real_weights,
+    decode_position_ids: int | None = None,
+):
+    # Check params
+    if mode == "prefill":
+        assert batch_size == 1, "Prefill only supports a batch size of 1"
+    else:
+        assert mode == "decode" and seq_len == 1, "Decode only supports a sequence length of 1"
+
+    state_dict, position_ids, torch_input, reference_output, input_cache, _ = generate_reference_io(
+        use_real_weights,
+        model_path,
+        module_path,
+        hf_config_short,
+        reference_layer_idx,
+        seq_len,
+        batch_size,
+        mode,
+        state_dict,
+        decode_position_ids,
+    )
+
+    # Set up page config
+    logger.info("Setting up model configs")
+    user_id = None if mode == "decode" else torch.randint(0, USERS_PER_ROW, ()).item()
+    paged_config = MLA1D.get_valid_paged_config(hf_config_short.max_seq_len, USERS_PER_ROW, mesh_device.shape[1])
+    paged_input_cache, torch_page_table = paged_cache_from_torch(
+        input_cache, (1, mesh_device.shape[1]), paged_config, user_id
+    )
+
+    # Set up model config
+    weight_cache_root = cache_path if use_real_weights else cache_path / "random_weights"
+    weight_config = get_test_weight_config(
+        DecoderBlockClass,
+        hf_config_short,
+        (state_dict,) * mesh_device.shape[0],
+        weight_cache_root,
+        mesh_device,
+        force_recalculate_weight_config or not use_real_weights,
+    )
+    model_config = get_model_config(DecoderBlockClass, mode, hf_config_short, mesh_device)
+    model_state = DecoderBlockClass.create_state(
+        hf_config_short,
+        paged_config,
+        mesh_device,
+        ccl,
+        is_padding_layer=(False,) * mesh_device.shape[0],
+        mla_caches=(paged_input_cache,) * mesh_device.shape[0],
+    )
+    model_shared_state = DecoderBlockClass.create_shared_state(hf_config_short, mesh_device)
+    run_config = create_run_config(model_config, weight_config, model_state, model_shared_state)
+
+    # Set up ttnn inputs
+    logger.info("Setting up model inputs")
+    tt_input = ttnn.from_torch(
+        torch_input.unsqueeze(0),
+        device=mesh_device,
+        mesh_mapper=ttnn.ShardTensor2dMesh(mesh_device, dims=(None, -1), mesh_shape=mesh_device.shape),
+        dtype=ttnn.bfloat16,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        layout=ttnn.TILE_LAYOUT,
+    )
+
+    position_ids_tensor = (
+        ttnn.from_torch(
+            position_ids,
+            device=mesh_device,
+            mesh_mapper=ttnn.ShardTensor2dMesh(mesh_device, dims=(None, 0), mesh_shape=mesh_device.shape),
+            dtype=ttnn.int32,
+        )
+        if mode == "decode"
+        else None
+    )
+
+    tt_page_table = MLA1D.create_page_table(
+        page_table=torch_page_table, paged_config=paged_config, mesh_device=mesh_device
+    )
+    rope_tensors = get_rope_tensors(hf_config_short, batch_size, seq_len, position_ids, mesh_device)
+    paged_config = MLA1D.get_valid_paged_config(hf_config_short.max_seq_len, USERS_PER_ROW, mesh_device.shape[1])
+
+    # Forward pass
+    logger.info("Running TTNN forward pass")
+    cur_row_idx = torch.randint(0, mesh_device.shape[0], ()).item()
+
+    def run_forward() -> ttnn.Tensor:
+        if mode == "prefill":
+            return DecoderBlockClass.forward_prefill(
+                tt_input, user_id, cur_row_idx, run_config, rope_tensors, tt_page_table
+            )
+        return DecoderBlockClass.forward_decode(
+            tt_input, position_ids_tensor, cur_row_idx, run_config, rope_tensors, tt_page_table
+        )
+
+    def check_outputs(tt_output: ttnn.Tensor) -> None:
+        tt_output_torch = ttnn.to_torch(
+            tt_output,
+            mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_device, dims=(0, -1), mesh_shape=mesh_device.shape),
+        )[cur_row_idx]
+        assert_hidden_dim_pcc(tt_output_torch, reference_output, pcc_required=0.9899)
+
+    if trace_mode:
+        # Iteration 0: eager compile run (not traced)
+        tt_output = run_forward()
+        ttnn.synchronize_device(mesh_device)
+        check_outputs(tt_output)
+        ttnn.deallocate(tt_output)
+
+        trace_id = ttnn.begin_trace_capture(mesh_device, cq_id=0)
+        trace_output = run_forward()
+        ttnn.end_trace_capture(mesh_device, trace_id, cq_id=0)
+        ttnn.synchronize_device(mesh_device)
+
+        for _ in range(TEST_CHECK_ITERS - 1):
+            ttnn.execute_trace(mesh_device, trace_id, blocking=True)
+        ttnn.synchronize_device(mesh_device)
+
+        check_outputs(trace_output)
+        ttnn.release_trace(mesh_device, trace_id)
+        ttnn.deallocate(trace_output)
+    else:
+        for iter_idx in range(TEST_CHECK_ITERS):
+            tt_output = run_forward()
+            ttnn.synchronize_device(mesh_device)
+            if iter_idx in (0, TEST_CHECK_ITERS - 1):
+                check_outputs(tt_output)
+            ttnn.deallocate(tt_output)
+
+    ttnn.deallocate(tt_input)
+    if position_ids_tensor is not None:
+        ttnn.deallocate(position_ids_tensor)
+    ttnn.deallocate(tt_page_table)
+    rope_values = rope_tensors.values() if isinstance(rope_tensors, dict) else rope_tensors
+    for rope_tensor in rope_values:
+        if isinstance(rope_tensor, ttnn.Tensor):
+            ttnn.deallocate(rope_tensor)
+
+
+def run_test_forward_pass_decoder2d(
+    DecoderBlockClass: type[DecoderBlock2DBase],
+    module_path,
+    reference_layer_idx,
+    mode,
+    seq_len,
+    batch_size_per_row,
+    trace_mode,
+    hf_config_short,
+    cache_path,
+    mesh_device,
+    model_path,
+    ccl,
+    force_recalculate_weight_config,
+    state_dict,
+    use_real_weights,
     decode_position_ids: int | None = None,
 ):
     # Check params
@@ -112,6 +275,7 @@ def run_test_forward_pass_decoder2d(
         batch_size = batch_size_per_row * mesh_device.shape[0]
 
     state_dict, position_ids, torch_input, reference_output, input_cache, _ = generate_reference_io(
+        use_real_weights,
         model_path,
         module_path,
         hf_config_short,
@@ -132,13 +296,14 @@ def run_test_forward_pass_decoder2d(
     )
 
     # Set up model config
+    weight_cache_root = cache_path if use_real_weights else cache_path / "random_weights"
     weight_config = get_test_weight_config(
         DecoderBlockClass,
         hf_config_short,
         (state_dict,),
-        cache_path,
+        weight_cache_root,
         mesh_device,
-        force_recalculate_weight_config,
+        force_recalculate_weight_config or not use_real_weights,
     )
     model_config = get_model_config(DecoderBlockClass, mode, hf_config_short, mesh_device)
     model_state = DecoderBlockClass.create_state(
@@ -182,19 +347,53 @@ def run_test_forward_pass_decoder2d(
     # Forward pass
     logger.info("Running TTNN forward pass")
 
-    if mode == "prefill":
-        tt_output = DecoderBlockClass.forward_prefill(tt_input, user_id, run_config, rope_tensors, tt_page_table)
-    else:
-        tt_output = DecoderBlockClass.forward_decode(
-            tt_input, position_ids_tensor, run_config, rope_tensors, tt_page_table
+    def run_forward() -> ttnn.Tensor:
+        if mode == "prefill":
+            return DecoderBlockClass.forward_prefill(tt_input, user_id, run_config, rope_tensors, tt_page_table)
+        return DecoderBlockClass.forward_decode(tt_input, position_ids_tensor, run_config, rope_tensors, tt_page_table)
+
+    def check_outputs(tt_output: ttnn.Tensor) -> None:
+        tt_output_torch = ttnn.to_torch(
+            tt_output,
+            mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_device, dims=(-2, -1), mesh_shape=mesh_device.shape),
         )
+        assert_hidden_dim_pcc(tt_output_torch, reference_output, pcc_required=0.9899)
 
-    tt_output_torch = ttnn.to_torch(
-        tt_output, mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_device, dims=(-2, -1), mesh_shape=mesh_device.shape)
-    )
+    if trace_mode:
+        # Iteration 0: eager compile run (not traced)
+        tt_output = run_forward()
+        ttnn.synchronize_device(mesh_device)
+        check_outputs(tt_output)
+        ttnn.deallocate(tt_output)
 
-    # Check output PCC
-    assert_hidden_dim_pcc(tt_output_torch, reference_output, pcc_required=0.9899)
+        trace_id = ttnn.begin_trace_capture(mesh_device, cq_id=0)
+        trace_output = run_forward()
+        ttnn.end_trace_capture(mesh_device, trace_id, cq_id=0)
+        ttnn.synchronize_device(mesh_device)
+
+        for _ in range(TEST_CHECK_ITERS - 1):
+            ttnn.execute_trace(mesh_device, trace_id, blocking=True)
+        ttnn.synchronize_device(mesh_device)
+
+        check_outputs(trace_output)
+        ttnn.release_trace(mesh_device, trace_id)
+        ttnn.deallocate(trace_output)
+    else:
+        for iter_idx in range(TEST_CHECK_ITERS):
+            tt_output = run_forward()
+            ttnn.synchronize_device(mesh_device)
+            if iter_idx in (0, TEST_CHECK_ITERS - 1):
+                check_outputs(tt_output)
+            ttnn.deallocate(tt_output)
+
+    ttnn.deallocate(tt_input)
+    if position_ids_tensor is not None:
+        ttnn.deallocate(position_ids_tensor)
+    ttnn.deallocate(tt_page_table)
+    rope_values = rope_tensors.values() if isinstance(rope_tensors, dict) else rope_tensors
+    for rope_tensor in rope_values:
+        if isinstance(rope_tensor, ttnn.Tensor):
+            ttnn.deallocate(rope_tensor)
 
 
 # Base test cases - ranges will be expanded into individual test cases
@@ -210,8 +409,11 @@ BASE_TEST_CASES = [
         seq_len,
         1,
         None,
-        marks=pytest.mark.skip(
-            f"Skipping prefilling with seq_len={seq_len} since this would cause us to exceed our available CI workload time"
+        marks=pytest.mark.skipif(
+            CI_ACTIVE,
+            reason=(
+                f"Skipping prefilling with seq_len={seq_len} since this would cause us to exceed our available CI workload time"
+            ),
         ),
     )
     for seq_len in PREFILL_SEQ_LENS
@@ -223,9 +425,23 @@ EXPANDED_TEST_IDS = build_expanded_test_ids(EXPANDED_TEST_CASES)
 @pytest.mark.parametrize(
     "device_params",
     [
-        {"fabric_config": ttnn.FabricConfig.FABRIC_1D},
+        {"fabric_config": ttnn.FabricConfig.FABRIC_1D, "trace_region_size": 10485760},
     ],
     indirect=True,
+)
+@pytest.mark.parametrize(
+    "trace_mode",
+    [
+        pytest.param(False, marks=_CI_SKIP_MARK, id="eager"),
+        pytest.param(True, id="tracing"),
+    ],
+)
+@pytest.mark.parametrize(
+    "use_real_weights",
+    [
+        pytest.param(True, id="real_weights"),
+        pytest.param(False, marks=_CI_SKIP_MARK, id="random_weights"),
+    ],
 )
 @pytest.mark.parametrize(
     "DecoderBlockClass, module_path, reference_layer_idx, test_closure",
@@ -267,6 +483,8 @@ EXPANDED_TEST_IDS = build_expanded_test_ids(EXPANDED_TEST_CASES)
 )
 def test_forward_pass(
     DecoderBlockClass: type[DecoderBlock2DBase],
+    trace_mode,
+    use_real_weights,
     module_path,
     reference_layer_idx,
     mode,
@@ -283,6 +501,15 @@ def test_forward_pass(
     set_deterministic_env,
     state_dict,
 ):
+    if getattr(hf_config_short, "_attn_implementation", None) is None:
+        hf_config_short._attn_implementation = "eager"
+    if CI_ACTIVE and not (DecoderBlockClass in (DecoderBlock2D, MoEDecoderBlock2D) and module_path is not None):
+        pytest.skip("CI runs only DecoderBlock2D/MoEDecoderBlock2D with module_path set.")
+    if trace_mode and mode != "decode":
+        pytest.skip("Tracing is only supported for decode mode.")
+    if use_real_weights and module_path is None:
+        pytest.skip("Real weights require module_path to be set.")
+
     if mode != "decode":
         decode_position_ids = None
 
@@ -293,6 +520,7 @@ def test_forward_pass(
         mode,
         seq_len,
         batch_size_per_row,
+        trace_mode,
         hf_config_short,
         cache_path,
         mesh_device,
@@ -300,6 +528,7 @@ def test_forward_pass(
         ccl,
         force_recalculate_weight_config,
         state_dict,
+        use_real_weights,
         decode_position_ids,
     )
 

--- a/models/demos/deepseek_v3/tests/test_decoder_block.py
+++ b/models/demos/deepseek_v3/tests/test_decoder_block.py
@@ -19,6 +19,7 @@ from models.demos.deepseek_v3.tests.pytest_utils import (
 )
 from models.demos.deepseek_v3.tt.decoder_block.decoder_block_2d import DecoderBlock2D
 from models.demos.deepseek_v3.tt.decoder_block.decoder_block_2d_base import DecoderBlock2DBase
+from models.demos.deepseek_v3.tt.decoder_block.decoder_block_base import DecoderBlockBase
 from models.demos.deepseek_v3.tt.decoder_block.moe_decoder_block_2d import MoEDecoderBlock2D
 from models.demos.deepseek_v3.tt.mla.mla1d import MLA1D
 from models.demos.deepseek_v3.tt.mla.mla2d import MLA2D
@@ -42,6 +43,7 @@ _CI_SKIP_MARK = pytest.mark.skipif(
     CI_ACTIVE,
     reason="CI runs traced coverage only.",
 )
+pytestmark = pytest.mark.timeout(1200)
 
 
 def generate_reference_io(
@@ -97,7 +99,7 @@ def generate_reference_io(
 
 
 def run_test_forward_pass_decoder1d(
-    DecoderBlockClass: type[DecoderBlock1DBase],
+    DecoderBlockClass: type[DecoderBlockBase],
     module_path,
     reference_layer_idx,
     mode,

--- a/models/demos/deepseek_v3/tests/test_embedding.py
+++ b/models/demos/deepseek_v3/tests/test_embedding.py
@@ -208,6 +208,9 @@ def test_embedding_forward_pass(
         assert_hidden_dim_pcc(tt_output_torch, reference_output, pcc_required=0.98)
         ttnn.deallocate(tt_output)
 
+        # Reset CCL semaphore counters before trace capture
+        ccl.reset_sem_counters()
+
         trace_id = ttnn.begin_trace_capture(mesh_device, cq_id=0)
         trace_output = run_module_forward(EmbeddingClass, mode, tt_input_ids, run_config)
         ttnn.end_trace_capture(mesh_device, trace_id, cq_id=0)

--- a/models/demos/deepseek_v3/tests/test_embedding.py
+++ b/models/demos/deepseek_v3/tests/test_embedding.py
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 
+import os
+
 import pytest
 import torch
 from loguru import logger
@@ -23,11 +25,18 @@ from models.demos.deepseek_v3.utils.test_utils import (
     run_module_forward,
 )
 
+TEST_CHECK_ITERS = 100
+CI_ACTIVE = os.getenv("CI") == "true"
+_CI_SKIP_MARK = pytest.mark.skipif(
+    CI_ACTIVE,
+    reason="CI runs traced coverage only.",
+)
+
 
 @pytest.mark.parametrize(
     "device_params",
     [
-        {"fabric_config": ttnn.FabricConfig.FABRIC_1D},
+        {"fabric_config": ttnn.FabricConfig.FABRIC_1D, "trace_region_size": 10485760},
     ],
     indirect=True,
 )
@@ -46,8 +55,11 @@ from models.demos.deepseek_v3.utils.test_utils import (
             seq_len,
             marks=[
                 pytest.mark.requires_device(["TG"]),
-                pytest.mark.skip(
-                    f"Skipping prefilling with seq_len={seq_len} since this would cause us to exceed our available CI workload time"
+                pytest.mark.skipif(
+                    CI_ACTIVE,
+                    reason=(
+                        f"Skipping prefilling with seq_len={seq_len} since this would cause us to exceed our available CI workload time"
+                    ),
                 ),
             ],
         )
@@ -62,12 +74,29 @@ from models.demos.deepseek_v3.utils.test_utils import (
             seq_len,
             marks=[
                 pytest.mark.requires_device(["TG", "DUAL", "QUAD"]),
-                pytest.mark.skip(
-                    f"Skipping prefilling with seq_len={seq_len} since this would cause us to exceed our available CI workload time"
+                pytest.mark.skipif(
+                    CI_ACTIVE,
+                    reason=(
+                        f"Skipping prefilling with seq_len={seq_len} since this would cause us to exceed our available CI workload time"
+                    ),
                 ),
             ],
         )
         for seq_len in PREFILL_SEQ_LENS
+    ],
+)
+@pytest.mark.parametrize(
+    "trace_mode",
+    [
+        pytest.param(False, marks=_CI_SKIP_MARK, id="eager"),
+        pytest.param(True, id="tracing"),
+    ],
+)
+@pytest.mark.parametrize(
+    "use_real_weights",
+    [
+        pytest.param(True, id="real_weights"),
+        pytest.param(False, marks=_CI_SKIP_MARK, id="random_weights"),
     ],
 )
 @pytest.mark.parametrize(
@@ -79,6 +108,8 @@ def test_embedding_forward_pass(
     hf_config,
     mode,
     batch_size_or_seq_len,
+    trace_mode,
+    use_real_weights,
     generate_reference_io,
     mesh_device,
     ccl,
@@ -88,8 +119,14 @@ def test_embedding_forward_pass(
     set_deterministic_env,
     state_dict,
 ):
+    if trace_mode and mode != "decode":
+        pytest.skip("Tracing is only supported for decode mode.")
+
     logger.info("Setting up reference IO")
     module_path = "model.embed_tokens"
+
+    if not use_real_weights:
+        generate_reference_io = True
 
     if generate_reference_io:
         reference_model = EmbeddingReference(
@@ -97,21 +134,40 @@ def test_embedding_forward_pass(
             hf_config.hidden_size,
             hf_config.pad_token_id,
         ).eval()
-        state_dict = reference_model.state_dict()
+        if use_real_weights:
+            state_dict = reference_model.state_dict()
+        else:
+            random_state_dict = {}
+            for name, tensor in reference_model.state_dict().items():
+                if torch.is_floating_point(tensor):
+                    random_state_dict[name] = torch.randn_like(tensor) * 0.02
+                else:
+                    random_state_dict[name] = torch.zeros_like(tensor)
+            reference_model.load_state_dict(random_state_dict)
+            state_dict = random_state_dict
 
         torch_input = torch.randint(0, hf_config.vocab_size, (1, 1, batch_size_or_seq_len))
         reference_output = reference_model(torch_input)
 
     else:
         state_dict = sub_state_dict(state_dict, module_path + ".")
-        torch_input, reference_output = load_reference_io_tensors_for_module(
-            mode, module_path, batch_size_or_seq_len, 1
-        )
+        try:
+            torch_input, reference_output = load_reference_io_tensors_for_module(
+                mode, module_path, batch_size_or_seq_len, 1
+            )
+        except FileNotFoundError as exc:
+            pytest.skip(str(exc))
 
     # Generate module configs and state
     logger.info("Setting up TTNN configs")
+    weight_cache_root = cache_path if use_real_weights else cache_path / "random_weights"
     weight_config = get_test_weight_config(
-        EmbeddingClass, hf_config, (state_dict,), cache_path, mesh_device, force_recalculate_weight_config
+        EmbeddingClass,
+        hf_config,
+        (state_dict,),
+        weight_cache_root,
+        mesh_device,
+        force_recalculate_weight_config or not use_real_weights,
     )
     model_config = get_model_config(EmbeddingClass, mode, hf_config, mesh_device)
     model_state = EmbeddingClass.create_state(hf_config, mesh_device, ccl)
@@ -128,31 +184,54 @@ def test_embedding_forward_pass(
         layout=ttnn.ROW_MAJOR_LAYOUT,
     )
 
+    def to_torch_output(tt_output: ttnn.Tensor) -> torch.Tensor:
+        tt_output_torch = ttnn.to_torch(
+            tt_output,
+            mesh_composer=ttnn.ConcatMesh2dToTensor(
+                mesh_device,
+                dims=(0, -1),
+                mesh_shape=tuple(mesh_device.shape),
+            ),
+        )
+        if EmbeddingClass is Embedding1D:
+            tt_output_torch = tt_output_torch[:1]
+        else:
+            tt_output_torch = tt_output_torch.reshape(1, batch_size_or_seq_len, hf_config.hidden_size)
+        return tt_output_torch
+
     # TTNN forward pass
     logger.info("Running TTNN forward pass")
-    tt_output = run_module_forward(EmbeddingClass, mode, tt_input_ids, run_config)
+    if trace_mode:
+        tt_output = run_module_forward(EmbeddingClass, mode, tt_input_ids, run_config)
+        ttnn.synchronize_device(mesh_device)
+        tt_output_torch = to_torch_output(tt_output)
+        assert_hidden_dim_pcc(tt_output_torch, reference_output, pcc_required=0.98)
+        ttnn.deallocate(tt_output)
 
-    # Convert output back to torch
-    logger.info("Validating output")
-    tt_output_torch = ttnn.to_torch(
-        tt_output,
-        mesh_composer=ttnn.ConcatMesh2dToTensor(
-            mesh_device,
-            dims=(0, -1),
-            mesh_shape=tuple(mesh_device.shape),
-        ),
-    )
-    if EmbeddingClass is Embedding1D:
-        tt_output_torch = tt_output_torch[:1]
+        trace_id = ttnn.begin_trace_capture(mesh_device, cq_id=0)
+        trace_output = run_module_forward(EmbeddingClass, mode, tt_input_ids, run_config)
+        ttnn.end_trace_capture(mesh_device, trace_id, cq_id=0)
+        ttnn.synchronize_device(mesh_device)
+
+        for _ in range(TEST_CHECK_ITERS - 1):
+            ttnn.execute_trace(mesh_device, trace_id, blocking=True)
+        ttnn.synchronize_device(mesh_device)
+
+        tt_output_torch = to_torch_output(trace_output)
+        assert_hidden_dim_pcc(tt_output_torch, reference_output, pcc_required=0.98)
+        ttnn.release_trace(mesh_device, trace_id)
+        ttnn.deallocate(trace_output)
     else:
-        tt_output_torch = tt_output_torch.reshape(1, batch_size_or_seq_len, hf_config.hidden_size)
+        for iter_idx in range(TEST_CHECK_ITERS):
+            tt_output = run_module_forward(EmbeddingClass, mode, tt_input_ids, run_config)
+            ttnn.synchronize_device(mesh_device)
+            if iter_idx in (0, TEST_CHECK_ITERS - 1):
+                tt_output_torch = to_torch_output(tt_output)
+                assert_hidden_dim_pcc(tt_output_torch, reference_output, pcc_required=0.98)
+            ttnn.deallocate(tt_output)
 
     # Cleanup
     ttnn.deallocate(tt_input_ids)
-    ttnn.deallocate(tt_output)
-
-    # Check PCC
-    assert_hidden_dim_pcc(tt_output_torch, reference_output, pcc_required=0.98)
 
 
 if __name__ == "__main__":

--- a/models/demos/deepseek_v3/tests/test_lm_head1d.py
+++ b/models/demos/deepseek_v3/tests/test_lm_head1d.py
@@ -217,6 +217,9 @@ def test_forward_pass(
         assert_hidden_dim_pcc(tt_output_torch, reference_output, pcc_required=0.98)
         ttnn.deallocate(warmup_base)
 
+        # Reset CCL semaphore counters before trace capture
+        ccl.reset_sem_counters()
+
         trace_input_base, trace_input = make_tt_input()
         trace_id = ttnn.begin_trace_capture(mesh_device, cq_id=0)
         trace_output = run_module_forward(LMHead1D, mode, trace_input, run_config)

--- a/models/demos/deepseek_v3/tests/test_lm_head1d.py
+++ b/models/demos/deepseek_v3/tests/test_lm_head1d.py
@@ -3,6 +3,7 @@
 
 
 import gc
+import os
 from pathlib import Path
 from typing import Any
 
@@ -23,6 +24,13 @@ from models.demos.deepseek_v3.utils.test_utils import (
     run_module_forward,
 )
 
+TEST_CHECK_ITERS = 100
+CI_ACTIVE = os.getenv("CI") == "true"
+_CI_SKIP_MARK = pytest.mark.skipif(
+    CI_ACTIVE,
+    reason="CI runs traced coverage only.",
+)
+
 
 class DeepseekV3LMHead(nn.Module):
     """
@@ -41,7 +49,7 @@ class DeepseekV3LMHead(nn.Module):
 @pytest.mark.parametrize(
     "device_params",
     [
-        {"fabric_config": ttnn.FabricConfig.FABRIC_1D},
+        {"fabric_config": ttnn.FabricConfig.FABRIC_1D, "trace_region_size": 10485760},
     ],
     indirect=True,
 )
@@ -52,119 +60,187 @@ class DeepseekV3LMHead(nn.Module):
         ("prefill", 1024),
     ],
 )
+@pytest.mark.parametrize(
+    "trace_mode",
+    [
+        pytest.param(False, marks=_CI_SKIP_MARK, id="eager"),
+        pytest.param(True, id="tracing"),
+    ],
+)
+@pytest.mark.parametrize(
+    "use_real_weights",
+    [
+        pytest.param(True, id="real_weights"),
+        pytest.param(False, marks=_CI_SKIP_MARK, id="random_weights"),
+    ],
+)
 @pytest.mark.requires_device(["TG", "DUAL", "QUAD"])
 def test_forward_pass(
     mode: str,
     batch_size_per_row: int,
+    trace_mode: bool,
+    use_real_weights: bool,
     hf_config: Any,
     mesh_device: ttnn.Device,
     ccl: CCL,
     cache_path: Path,
+    force_recalculate_weight_config: bool,
     set_deterministic_env: Any,
 ):
+    if trace_mode and mode != "decode":
+        pytest.skip("Tracing is only supported for decode mode.")
+
     reference_model = DeepseekV3LMHead(hf_config).eval()
-    state_dict = sub_state_dict(reference_model.state_dict(), "lm_head.")
+    if use_real_weights:
+        state_dict = sub_state_dict(reference_model.state_dict(), "lm_head.")
+    else:
+        random_state_dict = {}
+        for name, tensor in reference_model.state_dict().items():
+            if torch.is_floating_point(tensor):
+                random_state_dict[name] = torch.randn_like(tensor) * 0.02
+            else:
+                random_state_dict[name] = torch.zeros_like(tensor)
+        reference_model.load_state_dict(random_state_dict)
+        state_dict = sub_state_dict(random_state_dict, "lm_head.")
     batch_size = batch_size_per_row * mesh_device.shape[0]
     torch_input = torch.randn(1, 1, batch_size, hf_config.hidden_size)
     reference_output = reference_model(torch_input)
 
+    weight_cache_root = cache_path if use_real_weights else cache_path / "random_weights"
     weight_config = get_test_weight_config(
-        LMHead1D, hf_config, (state_dict,), cache_path, mesh_device, force_recalculate=False
+        LMHead1D,
+        hf_config,
+        (state_dict,),
+        weight_cache_root,
+        mesh_device,
+        force_recalculate_weight_config or not use_real_weights,
     )
     model_config = get_model_config(LMHead1D, mode, mesh_device)
     model_state = LMHead1D.create_state(mesh_device, ccl)
     run_config = create_run_config(model_config, weight_config, model_state)
 
-    # Convert input to TTNN
-    tt_input = ttnn.from_torch(
-        torch_input,
-        device=mesh_device,
-        mesh_mapper=ttnn.ShardTensor2dMesh(mesh_device, dims=(-2, None), mesh_shape=mesh_device.shape),
-        dtype=ttnn.bfloat16,
-        memory_config=run_config["input_memory_config"],
-        layout=ttnn.TILE_LAYOUT,
-    )
+    def make_tt_input() -> tuple[ttnn.Tensor, ttnn.Tensor]:
+        tt_base = ttnn.from_torch(
+            torch_input,
+            device=mesh_device,
+            mesh_mapper=ttnn.ShardTensor2dMesh(mesh_device, dims=(-2, None), mesh_shape=mesh_device.shape),
+            dtype=ttnn.bfloat16,
+            memory_config=run_config["input_memory_config"],
+            layout=ttnn.TILE_LAYOUT,
+        )
+        tt_base = ttnn.to_memory_config(tt_base, run_config["input_memory_config"])
+        # LMHead1D deallocates input internally; keep a base view alive to preserve the buffer.
+        tt_view = ttnn.view(tt_base, tt_base.shape)
+        return tt_base, tt_view
 
-    # TTNN forward pass
-    tt_input = ttnn.to_memory_config(tt_input, run_config["input_memory_config"])
-    tt_output = run_module_forward(LMHead1D, mode, tt_input, run_config)
+    def to_torch_output(tt_output: ttnn.Tensor) -> torch.Tensor:
+        expected_output_memory_config = run_config["output_memory_config"]
+        actual_output_memory_config = tt_output.memory_config()
+        assert (
+            actual_output_memory_config == expected_output_memory_config
+        ), f"Output memory config mismatch: expected {expected_output_memory_config}, got {actual_output_memory_config}"
 
-    # Deallocate input tensor as it's no longer needed
-    # Synchronize device to ensure all operations complete before deallocation
-    ttnn.synchronize_device(mesh_device)
-    ttnn.deallocate(tt_input)
-    del tt_input
-    gc.collect()
+        tt_output_shape = tt_output.shape
+        logger.info(f"tt_output shape: {tt_output_shape}")
 
-    expected_output_memory_config = run_config["output_memory_config"]
+        # Get seq_len from dimension 2
+        seq_len = tt_output_shape[2]
 
-    # Verify output memory config matches expected
-    actual_output_memory_config = tt_output.memory_config()
-    assert (
-        actual_output_memory_config == expected_output_memory_config
-    ), f"Output memory config mismatch: expected {expected_output_memory_config}, got {actual_output_memory_config}"
+        if seq_len > 16384:  # Only apply chunking if seq_len > 16k tokens
+            logger.info("running ttnn.to_torch with chunking")
+            # Introduce chunking because to_torch isn't compatible for large tensors >4GB
+            actual_batch_dim = tt_output_shape[2]
+            chunk_size = 16384
+            chunks = []
 
-    tt_output_shape = tt_output.shape
-    logger.info(f"tt_output shape: {tt_output_shape}")
+            for start_idx in range(0, actual_batch_dim, chunk_size):
+                end_idx = min(start_idx + chunk_size, actual_batch_dim)
+                logger.info(f"Processing chunk {start_idx}:{end_idx} of {actual_batch_dim}")
 
-    # Get seq_len from dimension 2
-    seq_len = tt_output_shape[2]
+                # Slice the tensor along the batch dimension
+                tt_chunk = ttnn.slice(
+                    tt_output,
+                    [0, 0, start_idx, 0],
+                    [tt_output_shape[0], tt_output_shape[1], end_idx, tt_output_shape[3]],
+                )
 
-    if seq_len > 16384:  # Only apply chunking if seq_len > 16k tokens
-        logger.info("running ttnn.to_torch with chunking")
-        # Introduce chunking because to_torch isn't compatible for large tensors >4GB
-        actual_batch_dim = tt_output_shape[2]
-        chunk_size = 16384
-        chunks = []
+                # Convert chunk to torch
+                chunk_torch = ttnn.to_torch(
+                    tt_chunk,
+                    mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_device, dims=(-2, -1), mesh_shape=mesh_device.shape),
+                )
 
-        for start_idx in range(0, actual_batch_dim, chunk_size):
-            end_idx = min(start_idx + chunk_size, actual_batch_dim)
-            logger.info(f"Processing chunk {start_idx}:{end_idx} of {actual_batch_dim}")
+                # Deallocate the TTNN chunk tensor immediately after conversion
+                ttnn.deallocate(tt_chunk)
+                del tt_chunk
 
-            # Slice the tensor along the batch dimension
-            tt_chunk = ttnn.slice(
-                tt_output, [0, 0, start_idx, 0], [tt_output_shape[0], tt_output_shape[1], end_idx, tt_output_shape[3]]
-            )
+                chunks.append(chunk_torch)
 
-            # Convert chunk to torch
-            chunk_torch = ttnn.to_torch(
-                tt_chunk,
+                # Periodic garbage collection to help free memory
+                if (start_idx // chunk_size) % 2 == 1:
+                    gc.collect()
+
+            # Deallocate the original output tensor as all chunks have been processed
+            ttnn.deallocate(tt_output)
+            del tt_output
+            gc.collect()
+
+            # Concatenate all chunks along the batch dimension
+            tt_output_torch = torch.cat(chunks, dim=-2)
+
+            # Clear the chunks list to free memory
+            del chunks
+            gc.collect()
+
+            logger.info("finished ttnn.to_torch with chunking")
+        else:
+            # For seq_len <= 16k, use regular to_torch without chunking
+            logger.info("running ttnn.to_torch without chunking (seq_len <= 16k)")
+            tt_output_torch = ttnn.to_torch(
+                tt_output,
                 mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_device, dims=(-2, -1), mesh_shape=mesh_device.shape),
             )
+            # Deallocate the TTNN output tensor after conversion
+            ttnn.deallocate(tt_output)
+            del tt_output
+            gc.collect()
 
-            # Deallocate the TTNN chunk tensor immediately after conversion
-            ttnn.deallocate(tt_chunk)
-            del tt_chunk
+        logger.info(f"tt_output_torch shape: {tt_output_torch.shape}")
+        return tt_output_torch
 
-            chunks.append(chunk_torch)
+    if trace_mode:
+        # Iteration 0: eager compile run (not traced)
+        warmup_base, warmup_input = make_tt_input()
+        tt_output = run_module_forward(LMHead1D, mode, warmup_input, run_config)
+        ttnn.synchronize_device(mesh_device)
+        tt_output_torch = to_torch_output(tt_output)
+        assert_hidden_dim_pcc(tt_output_torch, reference_output, pcc_required=0.98)
+        ttnn.deallocate(warmup_base)
 
-            # Periodic garbage collection to help free memory
-            if (start_idx // chunk_size) % 2 == 1:
-                gc.collect()
+        trace_input_base, trace_input = make_tt_input()
+        trace_id = ttnn.begin_trace_capture(mesh_device, cq_id=0)
+        trace_output = run_module_forward(LMHead1D, mode, trace_input, run_config)
+        ttnn.end_trace_capture(mesh_device, trace_id, cq_id=0)
+        ttnn.synchronize_device(mesh_device)
 
-        # Deallocate the original output tensor as all chunks have been processed
-        ttnn.deallocate(tt_output)
-        del tt_output
-        gc.collect()
+        for _ in range(TEST_CHECK_ITERS - 1):
+            ttnn.execute_trace(mesh_device, trace_id, blocking=True)
+        ttnn.synchronize_device(mesh_device)
 
-        # Concatenate all chunks along the batch dimension
-        tt_output_torch = torch.cat(chunks, dim=-2)
-
-        # Clear the chunks list to free memory
-        del chunks
-        gc.collect()
-
-        logger.info("finished ttnn.to_torch with chunking")
+        tt_output_torch = to_torch_output(trace_output)
+        assert_hidden_dim_pcc(tt_output_torch, reference_output, pcc_required=0.98)
+        ttnn.release_trace(mesh_device, trace_id)
+        ttnn.deallocate(trace_input_base)
     else:
-        # For seq_len <= 16k, use regular to_torch without chunking
-        logger.info("running ttnn.to_torch without chunking (seq_len <= 16k)")
-        tt_output_torch = ttnn.to_torch(
-            tt_output, mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_device, dims=(-2, -1), mesh_shape=mesh_device.shape)
-        )
-        # Deallocate the TTNN output tensor after conversion
-        ttnn.deallocate(tt_output)
-        del tt_output
-        gc.collect()
+        for iter_idx in range(TEST_CHECK_ITERS):
+            tt_base, tt_input = make_tt_input()
+            tt_output = run_module_forward(LMHead1D, mode, tt_input, run_config)
+            ttnn.synchronize_device(mesh_device)
+            if iter_idx in (0, TEST_CHECK_ITERS - 1):
+                tt_output_torch = to_torch_output(tt_output)
+                assert_hidden_dim_pcc(tt_output_torch, reference_output, pcc_required=0.98)
+            else:
+                ttnn.deallocate(tt_output)
+            ttnn.deallocate(tt_base)
 
-    logger.info(f"tt_output_torch shape: {tt_output_torch.shape}")
-    assert_hidden_dim_pcc(tt_output_torch, reference_output, pcc_required=0.98)
+    gc.collect()

--- a/models/demos/deepseek_v3/tests/test_mla.py
+++ b/models/demos/deepseek_v3/tests/test_mla.py
@@ -372,6 +372,9 @@ def run_test_forward_pass_mla1d(
         check_outputs(tt_output)
         ttnn.deallocate(tt_output)
 
+        # Reset CCL semaphore counters before trace capture
+        ccl.reset_sem_counters()
+
         trace_id = ttnn.begin_trace_capture(mesh_device, cq_id=0)
         trace_output = run_forward()
         ttnn.end_trace_capture(mesh_device, trace_id, cq_id=0)
@@ -530,6 +533,9 @@ def run_test_forward_pass_mla2d(
         ttnn.synchronize_device(mesh_device)
         check_outputs(tt_output)
         ttnn.deallocate(tt_output)
+
+        # Reset CCL semaphore counters before trace capture
+        ccl.reset_sem_counters()
 
         trace_id = ttnn.begin_trace_capture(mesh_device, cq_id=0)
         trace_output = run_forward()

--- a/models/demos/deepseek_v3/tests/test_mla.py
+++ b/models/demos/deepseek_v3/tests/test_mla.py
@@ -2,6 +2,7 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
+import os
 from pathlib import Path
 
 import pytest
@@ -34,6 +35,12 @@ from models.demos.deepseek_v3.utils.test_utils import (
 
 PCC_REQUIRED = 0.99
 PCC_REQUIRED_KVPE = 0.999
+TEST_CHECK_ITERS = 100
+CI_ACTIVE = os.getenv("CI") == "true"
+_CI_SKIP_MARK = pytest.mark.skipif(
+    CI_ACTIVE,
+    reason="CI runs traced coverage only.",
+)
 
 
 def get_cache_on_host(tt_cache: ttnn.Tensor, mesh_device: ttnn.MeshDevice) -> torch.Tensor:
@@ -63,6 +70,7 @@ def generate_reference_io(
     mode: str,
     state_dict: dict[str, torch.Tensor],
     decode_position_id: int | None = None,
+    use_real_weights: bool = True,
 ) -> tuple[dict[str, torch.Tensor], torch.Tensor | None, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
     """
     Generate reference input/output for testing.
@@ -72,15 +80,46 @@ def generate_reference_io(
             - None: Generate random position_ids in range [0, max_seq_len - 1)
             - int: Use this specific position for all batches
     """
-    if module_path is None:
-        reference_model = DeepseekV3Attention(hf_config, layer_idx=layer_idx).eval().to(torch.bfloat16)
+    reference_model = DeepseekV3Attention(hf_config, layer_idx=layer_idx).eval().to(torch.bfloat16)
+    if use_real_weights:
+        if module_path is None:
+            state_dict = add_inv_scale_to_state_dict(
+                reference_model.state_dict(),
+                block_shape=hf_config.quantization_config["weight_block_size"],
+            )
+        else:
+            state_dict = sub_state_dict(state_dict, module_path + ".")
+            dequantized_state_dict = dequantize_state_dict(state_dict, hf_config)
+            reference_model.load_state_dict(dequantized_state_dict)
+    else:
+        random_state_dict = {}
+        for name, tensor in reference_model.state_dict().items():
+            if torch.is_floating_point(tensor):
+                # Keep weights small to reduce quantization error for random-weight tests.
+                random_state_dict[name] = torch.randn_like(tensor) * 0.02
+            else:
+                random_state_dict[name] = torch.zeros_like(tensor)
         state_dict = add_inv_scale_to_state_dict(
-            reference_model.state_dict(),
+            random_state_dict,
             block_shape=hf_config.quantization_config["weight_block_size"],
         )
-    else:
-        reference_model = DeepseekV3Attention(hf_config, layer_idx=layer_idx).eval().to(torch.bfloat16)
-        state_dict = sub_state_dict(state_dict, module_path + ".")
+        # Ensure no NaNs/Infs to satisfy MLA2D weight replication checks
+        float8_dtypes = tuple(
+            dt
+            for dt in (
+                getattr(torch, "float8_e4m3fn", None),
+                getattr(torch, "float8_e5m2", None),
+                getattr(torch, "float8_e5m2fnuz", None),
+            )
+            if dt is not None
+        )
+        for name, tensor in state_dict.items():
+            if torch.is_floating_point(tensor):
+                if float8_dtypes and tensor.dtype in float8_dtypes:
+                    cleaned = torch.nan_to_num(tensor.float(), nan=0.0, posinf=0.0, neginf=0.0)
+                    state_dict[name] = cleaned.to(tensor.dtype)
+                else:
+                    state_dict[name] = torch.nan_to_num(tensor, nan=0.0, posinf=0.0, neginf=0.0)
         dequantized_state_dict = dequantize_state_dict(state_dict, hf_config)
         reference_model.load_state_dict(dequantized_state_dict)
 
@@ -183,6 +222,177 @@ def check_cache_unchanged(tt_cache, exclusion_area: tuple[slice, slice, slice, s
     return all_zeros
 
 
+def run_test_forward_pass_mla1d(
+    layer_idx,
+    mode,
+    seq_len,
+    batch_size,
+    hf_config_short,
+    cache_path,
+    mesh_device,
+    ccl,
+    model_path,
+    module_path,
+    force_recalculate_weight_config,
+    state_dict,
+    decode_position_ids: int | None = None,
+    trace_mode: bool = False,
+    use_real_weights: bool = True,
+):
+    # Check params
+    if mode == "prefill":
+        assert batch_size == 1, "Prefill only supports a batch size of 1"
+    else:
+        assert mode == "decode" and seq_len == 1, "Decode only supports a sequence length of 1"
+
+    # Get reference IO
+    logger.info("Setting up reference IO")
+    state_dict, position_ids, torch_input, reference_output, input_cache, output_cache = generate_reference_io(
+        model_path,
+        module_path,
+        hf_config_short,
+        layer_idx,
+        seq_len,
+        batch_size,
+        mode,
+        state_dict,
+        decode_position_ids,
+        use_real_weights,
+    )
+
+    # Set up page config
+    logger.info("Setting up model configs")
+    user_id = None if mode == "decode" else torch.randint(0, USERS_PER_ROW, ()).item()
+    paged_config = MLA1D.get_valid_paged_config(hf_config_short.max_seq_len, USERS_PER_ROW, mesh_device.shape[1])
+    paged_input_cache, torch_page_table = paged_cache_from_torch(
+        input_cache, (1, mesh_device.shape[1]), paged_config, user_id
+    )
+
+    # Set up model config
+    weight_cache_root = cache_path if use_real_weights else cache_path / "random_weights"
+    weight_config = get_test_weight_config(
+        MLA1D,
+        hf_config_short,
+        (state_dict,) * mesh_device.shape[0],
+        weight_cache_root,
+        mesh_device,
+        force_recalculate_weight_config or not use_real_weights,
+    )
+    model_config = get_model_config(MLA1D, mode, hf_config_short, mesh_device)
+    model_state = MLA1D.create_state(
+        hf_config_short, paged_config, mesh_device, ccl, (paged_input_cache,) * mesh_device.shape[0]
+    )
+    run_config = create_run_config(model_config, weight_config, model_state)
+
+    # Set up ttnn inputs
+    logger.info("Setting up model inputs")
+
+    tt_input = ttnn.from_torch(
+        torch_input.unsqueeze(0),
+        device=mesh_device,
+        mesh_mapper=ttnn.ShardTensor2dMesh(mesh_device, dims=(None, -1), mesh_shape=mesh_device.shape),
+        dtype=ttnn.bfloat16,
+        memory_config=run_config["input_memory_config"],
+        layout=ttnn.TILE_LAYOUT,
+    )
+
+    position_ids_tensor = (
+        ttnn.from_torch(
+            position_ids,
+            device=mesh_device,
+            mesh_mapper=ttnn.ShardTensor2dMesh(mesh_device, dims=(None, 0), mesh_shape=mesh_device.shape),
+            dtype=ttnn.int32,
+        )
+        if mode == "decode"
+        else None
+    )
+
+    tt_page_table = MLA1D.create_page_table(
+        page_table=torch_page_table, paged_config=paged_config, mesh_device=mesh_device
+    )
+    tt_rope_tensors = get_rope_tensors(hf_config_short, batch_size, seq_len, position_ids, mesh_device)
+
+    # Forward pass
+    logger.info("Running TTNN forward pass")
+
+    cur_row_idx = 0 if trace_mode else torch.randint(0, mesh_device.shape[0], ()).item()
+
+    def run_forward() -> ttnn.Tensor:
+        if mode == "prefill":
+            return MLA1D.forward_prefill(tt_input, user_id, cur_row_idx, run_config, tt_rope_tensors, tt_page_table)
+        return MLA1D.forward_decode(
+            tt_input, position_ids_tensor, cur_row_idx, run_config, tt_rope_tensors, tt_page_table
+        )
+
+    def check_outputs(tt_output: ttnn.Tensor) -> None:
+        tt_output_torch = ttnn.to_torch(
+            tt_output, mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_device, dims=(0, -1), mesh_shape=mesh_device.shape)
+        )[cur_row_idx]
+
+        tt_cache = torch_cache_from_paged(
+            get_cache_on_host(run_config["kvpe_cache"], mesh_device), torch_page_table, mesh_device.get_num_devices()
+        )
+        if mode == "prefill":
+            batch_id = user_id + cur_row_idx * USERS_PER_ROW
+            assert (
+                check_output_matches(tt_output_torch, reference_output, pcc_required=PCC_REQUIRED)
+                and check_cache_matches(
+                    tt_cache[batch_id : batch_id + 1, :, :seq_len],
+                    output_cache,
+                    hf_config_short.kv_lora_rank,
+                    pcc_required=PCC_REQUIRED_KVPE,
+                )
+                and check_cache_unchanged(
+                    tt_cache, (slice(batch_id, batch_id + 1), slice(None), slice(None, seq_len), slice(None))
+                )
+            ), f"MLA output for prefill {seq_len=} {user_id=} {cur_row_idx=} does not meet PCC requirement {PCC_REQUIRED} or KVPE Cache PCC requirement {PCC_REQUIRED_KVPE} or has been modified outside user area"
+        else:
+            assert (
+                check_output_matches(tt_output_torch, reference_output, pcc_required=PCC_REQUIRED)
+                and check_cache_matches(
+                    tt_cache[torch.arange(batch_size) + cur_row_idx * USERS_PER_ROW, :, position_ids, :].unsqueeze(2),
+                    output_cache[:, :, -1:, :],
+                    hf_config_short.kv_lora_rank,
+                    pcc_required=PCC_REQUIRED_KVPE,
+                )
+                and check_cache_unchanged(
+                    tt_cache,
+                    (
+                        slice(cur_row_idx * USERS_PER_ROW, (cur_row_idx + 1) * USERS_PER_ROW),
+                        slice(None),
+                        slice(None),
+                        slice(None),
+                    ),
+                )
+            ), f"MLA output for decode {batch_size=} {position_ids=} does not meet PCC requirement {PCC_REQUIRED} or KVPE Cache PCC requirement {PCC_REQUIRED_KVPE} or has been modified outside user area"
+
+    if trace_mode:
+        tt_output = run_forward()
+        ttnn.synchronize_device(mesh_device)
+        check_outputs(tt_output)
+        ttnn.deallocate(tt_output)
+
+        trace_id = ttnn.begin_trace_capture(mesh_device, cq_id=0)
+        trace_output = run_forward()
+        ttnn.end_trace_capture(mesh_device, trace_id, cq_id=0)
+        ttnn.synchronize_device(mesh_device)
+
+        for _ in range(TEST_CHECK_ITERS - 1):
+            ttnn.execute_trace(mesh_device, trace_id, blocking=True)
+        ttnn.synchronize_device(mesh_device)
+
+        check_outputs(trace_output)
+        ttnn.release_trace(mesh_device, trace_id)
+        ttnn.deallocate(trace_output)
+    else:
+        for iter_idx in range(TEST_CHECK_ITERS):
+            tt_output = run_forward()
+            ttnn.synchronize_device(mesh_device)
+            if iter_idx in (0, TEST_CHECK_ITERS - 1):
+                check_outputs(tt_output)
+            ttnn.deallocate(tt_output)
+
+
 def run_test_forward_pass_mla2d(
     layer_idx,
     mode,
@@ -197,6 +407,8 @@ def run_test_forward_pass_mla2d(
     force_recalculate_weight_config,
     state_dict,
     decode_position_ids: int | None = None,
+    trace_mode: bool = False,
+    use_real_weights: bool = True,
 ):
     # Check params
     if mode == "prefill":
@@ -218,6 +430,7 @@ def run_test_forward_pass_mla2d(
         mode,
         state_dict,
         decode_position_ids,
+        use_real_weights,
     )
 
     # Set up page config
@@ -229,13 +442,14 @@ def run_test_forward_pass_mla2d(
     )
 
     # Set up model config
+    weight_cache_root = cache_path if use_real_weights else cache_path / "random_weights"
     weight_config = get_test_weight_config(
         MLA2D,
         hf_config_short,
         (state_dict,),
-        cache_path,
+        weight_cache_root,
         mesh_device,
-        force_recalculate_weight_config,
+        force_recalculate_weight_config or not use_real_weights,
     )
     model_config = get_model_config(MLA2D, mode, hf_config_short, mesh_device)
     model_state = MLA2D.create_state(hf_config_short, paged_config, mesh_device, ccl, paged_input_cache)
@@ -271,45 +485,71 @@ def run_test_forward_pass_mla2d(
     # Forward pass
     logger.info("Running TTNN forward pass")
 
-    if mode == "prefill":
-        tt_output = MLA2D.forward_prefill(tt_input, user_id, run_config, tt_rope_tensors, tt_page_table)
-    else:
-        tt_output = MLA2D.forward_decode(tt_input, position_ids_tensor, run_config, tt_rope_tensors, tt_page_table)
+    def run_forward() -> ttnn.Tensor:
+        if mode == "prefill":
+            return MLA2D.forward_prefill(tt_input, user_id, run_config, tt_rope_tensors, tt_page_table)
+        return MLA2D.forward_decode(tt_input, position_ids_tensor, run_config, tt_rope_tensors, tt_page_table)
 
-    tt_output_torch = ttnn.to_torch(
-        tt_output, mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_device, dims=(0, -1), mesh_shape=mesh_device.shape)
-    ).reshape(
-        -1, seq_len, hf_config_short.hidden_size
-    )  # Concatenate all batches together
+    def check_outputs(tt_output: ttnn.Tensor) -> None:
+        tt_output_torch = ttnn.to_torch(
+            tt_output, mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_device, dims=(0, -1), mesh_shape=mesh_device.shape)
+        ).reshape(
+            -1, seq_len, hf_config_short.hidden_size
+        )  # Concatenate all batches together
 
-    # Check PCC
-    tt_cache = torch_cache_from_paged(
-        get_cache_on_host(run_config["mla1d"]["kvpe_cache"], mesh_device),
-        torch_page_table,
-        mesh_device.get_num_devices(),
-    )
-    if mode == "prefill":
-        assert (
-            check_output_matches(tt_output_torch, reference_output, pcc_required=PCC_REQUIRED)
-            and check_cache_matches(
-                tt_cache[user_id : user_id + 1, :, :seq_len],
-                output_cache,
+        tt_cache = torch_cache_from_paged(
+            get_cache_on_host(run_config["mla1d"]["kvpe_cache"], mesh_device),
+            torch_page_table,
+            mesh_device.get_num_devices(),
+        )
+        if mode == "prefill":
+            assert (
+                check_output_matches(tt_output_torch, reference_output, pcc_required=PCC_REQUIRED)
+                and check_cache_matches(
+                    tt_cache[user_id : user_id + 1, :, :seq_len],
+                    output_cache,
+                    hf_config_short.kv_lora_rank,
+                    pcc_required=PCC_REQUIRED_KVPE,
+                )
+                and check_cache_unchanged(
+                    tt_cache, (slice(user_id, user_id + 1), slice(None), slice(None, seq_len), slice(None))
+                )
+            ), f"MLA output for prefill {seq_len=} {user_id=} does not meet PCC requirement {PCC_REQUIRED} or KVPE Cache PCC requirement {PCC_REQUIRED_KVPE} or has been modified outside user area"
+        else:
+            assert check_output_matches(
+                tt_output_torch, reference_output, pcc_required=PCC_REQUIRED
+            ) and check_cache_matches(
+                tt_cache[torch.arange(batch_size), :, position_ids, :].unsqueeze(2),
+                output_cache[:, :, -1:, :],
                 hf_config_short.kv_lora_rank,
                 pcc_required=PCC_REQUIRED_KVPE,
-            )
-            and check_cache_unchanged(
-                tt_cache, (slice(user_id, user_id + 1), slice(None), slice(None, seq_len), slice(None))
-            )
-        ), f"MLA output for prefill {seq_len=} {user_id=} does not meet PCC requirement {PCC_REQUIRED} or KVPE Cache PCC requirement {PCC_REQUIRED_KVPE} or has been modified outside user area"
+            ), f"MLA output for decode {batch_size=} {position_ids=} does not meet PCC requirement {PCC_REQUIRED} or KVPE Cache PCC requirement {PCC_REQUIRED_KVPE} or has been modified outside user area"
+
+    if trace_mode:
+        tt_output = run_forward()
+        ttnn.synchronize_device(mesh_device)
+        check_outputs(tt_output)
+        ttnn.deallocate(tt_output)
+
+        trace_id = ttnn.begin_trace_capture(mesh_device, cq_id=0)
+        trace_output = run_forward()
+        ttnn.end_trace_capture(mesh_device, trace_id, cq_id=0)
+        ttnn.synchronize_device(mesh_device)
+
+        for _ in range(TEST_CHECK_ITERS - 1):
+            ttnn.execute_trace(mesh_device, trace_id, blocking=True)
+        ttnn.synchronize_device(mesh_device)
+
+        check_outputs(trace_output)
+        ttnn.release_trace(mesh_device, trace_id)
+        ttnn.deallocate(trace_output)
     else:
-        assert check_output_matches(
-            tt_output_torch, reference_output, pcc_required=PCC_REQUIRED
-        ) and check_cache_matches(
-            tt_cache[torch.arange(batch_size), :, position_ids, :].unsqueeze(2),
-            output_cache[:, :, -1:, :],
-            hf_config_short.kv_lora_rank,
-            pcc_required=PCC_REQUIRED_KVPE,
-        ), f"MLA output for decode {batch_size=} {position_ids=} does not meet PCC requirement {PCC_REQUIRED} or KVPE Cache PCC requirement {PCC_REQUIRED_KVPE} or has been modified outside user area"
+        for iter_idx in range(TEST_CHECK_ITERS):
+            tt_output = run_forward()
+            ttnn.synchronize_device(mesh_device)
+            if iter_idx in (0, TEST_CHECK_ITERS - 1):
+                check_outputs(tt_output)
+            ttnn.deallocate(tt_output)
 
 
 # Base test cases - ranges will be expanded into individual test cases
@@ -326,8 +566,11 @@ BASE_TEST_CASES = [
         seq_len,
         1,
         None,
-        marks=pytest.mark.skip(
-            f"Skipping prefilling with seq_len={seq_len} since this would cause us to exceed our available CI workload time"
+        marks=pytest.mark.skipif(
+            CI_ACTIVE,
+            reason=(
+                f"Skipping prefilling with seq_len={seq_len} since this would cause us to exceed our available CI workload time"
+            ),
         ),
     )
     for seq_len in PREFILL_SEQ_LENS
@@ -348,9 +591,24 @@ EXPANDED_TEST_IDS = build_expanded_test_ids(EXPANDED_TEST_CASES)
     [
         {
             "fabric_config": ttnn.FabricConfig.FABRIC_1D,
+            "trace_region_size": 10485760,
         }
     ],
     indirect=True,
+)
+@pytest.mark.parametrize(
+    "trace_mode",
+    [
+        pytest.param(False, marks=_CI_SKIP_MARK, id="eager"),
+        pytest.param(True, id="tracing"),
+    ],
+)
+@pytest.mark.parametrize(
+    "use_real_weights",
+    [
+        pytest.param(True, id="real_weights"),
+        pytest.param(False, marks=_CI_SKIP_MARK, id="random_weights"),
+    ],
 )
 @pytest.mark.parametrize(
     "module_path",
@@ -367,6 +625,8 @@ def test_forward_pass(
     seq_len,
     batch_size_per_row,
     decode_position_ids,
+    trace_mode,
+    use_real_weights,
     hf_config_short,
     cache_path,
     mesh_device,
@@ -384,6 +644,8 @@ def test_forward_pass(
     # Only use decode_position_ids for decode mode
     if mode != "decode":
         decode_position_ids = None
+    if trace_mode and mode != "decode":
+        pytest.skip("Tracing is only supported for decode mode.")
 
     test_closure(
         layer_idx,
@@ -399,6 +661,8 @@ def test_forward_pass(
         force_recalculate_weight_config,
         state_dict,
         decode_position_ids,
+        trace_mode,
+        use_real_weights,
     )
 
 

--- a/models/demos/deepseek_v3/tests/test_mlp.py
+++ b/models/demos/deepseek_v3/tests/test_mlp.py
@@ -282,6 +282,9 @@ def test_forward_pass(
         check_outputs(tt_output)
         ttnn.deallocate(tt_output)
 
+        # Reset CCL semaphore counters before trace capture
+        ccl.reset_sem_counters()
+
         trace_id = ttnn.begin_trace_capture(mesh_device, cq_id=0)
         trace_output = run_module_forward(MLPClass, mode, tt_input, run_config)
         ttnn.end_trace_capture(mesh_device, trace_id, cq_id=0)

--- a/models/demos/deepseek_v3/tests/test_mlp.py
+++ b/models/demos/deepseek_v3/tests/test_mlp.py
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 
+import os
+
 import pytest
 import torch
 from loguru import logger
@@ -22,6 +24,13 @@ from models.demos.deepseek_v3.utils.test_utils import (
     get_test_weight_config,
     load_reference_io_tensors_for_module,
     run_module_forward,
+)
+
+TEST_CHECK_ITERS = 100
+CI_ACTIVE = os.getenv("CI") == "true"
+_CI_SKIP_MARK = pytest.mark.skipif(
+    CI_ACTIVE,
+    reason="CI runs traced coverage only.",
 )
 
 
@@ -128,7 +137,11 @@ def run_weight_conversion_test(MLPClass, hf_config, state_dict, tmp_path, refere
     ttnn.deallocate(w1_ttnn)
 
 
-@pytest.mark.parametrize("device_params", [{"fabric_config": ttnn.FabricConfig.FABRIC_1D}], indirect=True)
+@pytest.mark.parametrize(
+    "device_params",
+    [{"fabric_config": ttnn.FabricConfig.FABRIC_1D, "trace_region_size": 10485760}],
+    indirect=True,
+)
 @pytest.mark.parametrize(
     "MLPClass,module_path",
     [
@@ -148,11 +161,28 @@ def run_weight_conversion_test(MLPClass, hf_config, state_dict, tmp_path, refere
         else pytest.param(
             "prefill",
             seq_len,
-            marks=pytest.mark.skip(
-                f"Skipping prefilling with seq_len={seq_len} since this would cause us to exceed our available CI workload time"
+            marks=pytest.mark.skipif(
+                CI_ACTIVE,
+                reason=(
+                    f"Skipping prefilling with seq_len={seq_len} since this would cause us to exceed our available CI workload time"
+                ),
             ),
         )
         for seq_len in PREFILL_SEQ_LENS
+    ],
+)
+@pytest.mark.parametrize(
+    "trace_mode",
+    [
+        pytest.param(False, marks=_CI_SKIP_MARK, id="eager"),
+        pytest.param(True, id="tracing"),
+    ],
+)
+@pytest.mark.parametrize(
+    "use_real_weights",
+    [
+        pytest.param(True, id="real_weights"),
+        pytest.param(False, marks=_CI_SKIP_MARK, id="random_weights"),
     ],
 )
 def test_forward_pass(
@@ -160,6 +190,8 @@ def test_forward_pass(
     module_path,
     mode,
     seq_len,
+    trace_mode,
+    use_real_weights,
     hf_config,
     mesh_device,
     ccl,
@@ -170,25 +202,52 @@ def test_forward_pass(
     set_deterministic_env,
     state_dict,
 ):
+    if trace_mode and mode != "decode":
+        pytest.skip("Tracing is only supported for decode mode.")
+
     num_module_layers, _ = mesh_device.shape
 
     # Get the reference IO
-    if not issubclass(MLPClass, MLPDequant):
-        reference_model = DeepseekV3MLP(hf_config).eval()
-        state_dict = reference_model.to(torch.bfloat16).state_dict()
-        torch_input = torch.randn(num_module_layers, 1, seq_len, hf_config.hidden_size)
+    if use_real_weights:
+        if not issubclass(MLPClass, MLPDequant):
+            reference_model = DeepseekV3MLP(hf_config).eval()
+            state_dict = reference_model.to(torch.bfloat16).state_dict()
+            torch_input = torch.randn(num_module_layers, 1, seq_len, hf_config.hidden_size)
 
+            reference_model = reference_model.to(torch.float32)
+            reference_output = reference_model(torch_input)
+        else:
+            state_dict = sub_state_dict(state_dict, module_path + ".")
+            torch_input, reference_output = load_reference_io_tensors_for_module(
+                mode, module_path, seq_len, num_module_layers
+            )
+    else:
+        reference_model = DeepseekV3MLP(hf_config).eval()
+        torch_input = torch.randn(num_module_layers, 1, seq_len, hf_config.hidden_size)
+        random_state_dict = {k: torch.randn_like(v) for k, v in reference_model.state_dict().items()}
+        if issubclass(MLPClass, MLPDequant):
+            from models.demos.deepseek_v3.utils.test_utils import add_inv_scale_to_state_dict, dequantize_state_dict
+
+            state_dict = add_inv_scale_to_state_dict(
+                random_state_dict,
+                block_shape=hf_config.quantization_config["weight_block_size"],
+            )
+            reference_model.load_state_dict(dequantize_state_dict(state_dict, hf_config, dtype=torch.float32))
+        else:
+            state_dict = {k: v.to(torch.bfloat16) for k, v in random_state_dict.items()}
+            reference_model.load_state_dict({k: v.to(torch.float32) for k, v in random_state_dict.items()})
         reference_model = reference_model.to(torch.float32)
         reference_output = reference_model(torch_input)
-    else:
-        state_dict = sub_state_dict(state_dict, module_path + ".")
-        torch_input, reference_output = load_reference_io_tensors_for_module(
-            mode, module_path, seq_len, num_module_layers
-        )
 
     # Generate module configs and state
+    weight_cache_root = cache_path if use_real_weights else cache_path / "random_weights"
     weight_config = get_test_weight_config(
-        MLPClass, hf_config, (state_dict,) * num_module_layers, cache_path, mesh_device, force_recalculate_weight_config
+        MLPClass,
+        hf_config,
+        (state_dict,) * num_module_layers,
+        weight_cache_root,
+        mesh_device,
+        force_recalculate_weight_config or not use_real_weights,
     )
     model_config = get_model_config(MLPClass, mode, hf_config, mesh_device)
     model_state = MLPClass.create_state(hf_config, mesh_device, ccl)
@@ -204,28 +263,46 @@ def test_forward_pass(
         layout=ttnn.TILE_LAYOUT,
     )
 
-    # TTNN forward pass
-    tt_output = run_module_forward(MLPClass, mode, tt_input, run_config)
+    def check_outputs(tt_output: ttnn.Tensor) -> None:
+        expected_output_memory_config = run_config["output_memory_config"]
+        actual_output_memory_config = tt_output.memory_config()
+        assert (
+            actual_output_memory_config == expected_output_memory_config
+        ), f"Output memory config mismatch: expected {expected_output_memory_config}, got {actual_output_memory_config}"
 
-    # Verify output memory config matches expected
-    expected_output_memory_config = run_config["output_memory_config"]
-    actual_output_memory_config = tt_output.memory_config()
-    assert (
-        actual_output_memory_config == expected_output_memory_config
-    ), f"Output memory config mismatch: expected {expected_output_memory_config}, got {actual_output_memory_config}"
+        tt_output_torch = ttnn.to_torch(
+            tt_output,
+            mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_device, dims=(0, -1), mesh_shape=mesh_device.shape),
+        )
+        assert_hidden_dim_pcc(tt_output_torch, reference_output, pcc_required=0.975)
 
-    # Convert output back to torch
-    tt_output_torch = ttnn.to_torch(
-        tt_output,
-        mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_device, dims=(0, -1), mesh_shape=mesh_device.shape),
-    )
+    if trace_mode:
+        tt_output = run_module_forward(MLPClass, mode, tt_input, run_config)
+        ttnn.synchronize_device(mesh_device)
+        check_outputs(tt_output)
+        ttnn.deallocate(tt_output)
 
-    # Cleanup
+        trace_id = ttnn.begin_trace_capture(mesh_device, cq_id=0)
+        trace_output = run_module_forward(MLPClass, mode, tt_input, run_config)
+        ttnn.end_trace_capture(mesh_device, trace_id, cq_id=0)
+        ttnn.synchronize_device(mesh_device)
+
+        for _ in range(TEST_CHECK_ITERS - 1):
+            ttnn.execute_trace(mesh_device, trace_id, blocking=True)
+        ttnn.synchronize_device(mesh_device)
+
+        check_outputs(trace_output)
+        ttnn.release_trace(mesh_device, trace_id)
+        ttnn.deallocate(trace_output)
+    else:
+        for iter_idx in range(TEST_CHECK_ITERS):
+            tt_output = run_module_forward(MLPClass, mode, tt_input, run_config)
+            ttnn.synchronize_device(mesh_device)
+            if iter_idx in (0, TEST_CHECK_ITERS - 1):
+                check_outputs(tt_output)
+            ttnn.deallocate(tt_output)
+
     ttnn.deallocate(tt_input)
-    ttnn.deallocate(tt_output)
-
-    # Check PCC
-    assert_hidden_dim_pcc(tt_output_torch, reference_output, pcc_required=0.975)
 
 
 if __name__ == "__main__":

--- a/models/demos/deepseek_v3/tests/test_model.py
+++ b/models/demos/deepseek_v3/tests/test_model.py
@@ -248,6 +248,9 @@ def run_test_forward_pass_dpmodel(
         check_outputs(tt_output)
         ttnn.deallocate(tt_output)
 
+        # Reset CCL semaphore counters before trace capture
+        ccl.reset_sem_counters()
+
         trace_id = ttnn.begin_trace_capture(mesh_device, cq_id=0)
         trace_output = run_forward()
         ttnn.end_trace_capture(mesh_device, trace_id, cq_id=0)

--- a/models/demos/deepseek_v3/tests/test_model.py
+++ b/models/demos/deepseek_v3/tests/test_model.py
@@ -38,6 +38,7 @@ _CI_SKIP_MARK = pytest.mark.skipif(
     CI_ACTIVE,
     reason="CI runs traced coverage only.",
 )
+pytestmark = pytest.mark.timeout(1200)
 
 
 def generate_reference_io(

--- a/models/demos/deepseek_v3/tests/test_model.py
+++ b/models/demos/deepseek_v3/tests/test_model.py
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 
+import os
+
 import pytest
 import torch
 from loguru import logger
@@ -28,6 +30,13 @@ from models.demos.deepseek_v3.utils.test_utils import (
     paged_caches_from_torch,
     run_reference_with_attention,
     torch_cache_from_transformers,
+)
+
+TEST_CHECK_ITERS = 100
+CI_ACTIVE = os.getenv("CI") == "true"
+_CI_SKIP_MARK = pytest.mark.skipif(
+    CI_ACTIVE,
+    reason="CI runs traced coverage only.",
 )
 
 
@@ -64,10 +73,34 @@ def generate_reference_io(
     else:
         logger.info("Creating reference model with random weights")
         reference_model = DeepseekV3ForCausalLM(hf_config).eval().to(torch.bfloat16)
+        random_state_dict: dict[str, torch.Tensor] = {}
+        for name, tensor in reference_model.state_dict().items():
+            if torch.is_floating_point(tensor):
+                random_state_dict[name] = torch.randn_like(tensor) * 0.02
+            else:
+                random_state_dict[name] = tensor
         state_dict = add_inv_scale_to_state_dict(
-            reference_model.to(torch.bfloat16).state_dict(),
+            random_state_dict,
             block_shape=hf_config.quantization_config["weight_block_size"],
         )
+        float8_dtypes = tuple(
+            dt
+            for dt in (
+                getattr(torch, "float8_e4m3fn", None),
+                getattr(torch, "float8_e5m2", None),
+                getattr(torch, "float8_e5m2fnuz", None),
+            )
+            if dt is not None
+        )
+        for name, tensor in state_dict.items():
+            if torch.is_floating_point(tensor):
+                if float8_dtypes and tensor.dtype in float8_dtypes:
+                    cleaned = torch.nan_to_num(tensor.float(), nan=0.0, posinf=0.0, neginf=0.0)
+                    state_dict[name] = cleaned.to(tensor.dtype)
+                else:
+                    state_dict[name] = torch.nan_to_num(tensor, nan=0.0, posinf=0.0, neginf=0.0)
+        dequantized_state_dict = dequantize_state_dict(state_dict, hf_config)
+        reference_model.load_state_dict(dequantized_state_dict)
 
     torch_input = torch.randint(0, hf_config.vocab_size - 1, (batch_size, seq_len), dtype=torch.long)
     position_ids = None
@@ -105,6 +138,7 @@ def generate_reference_io(
 
 def run_test_forward_pass_dpmodel(
     use_real_weights,
+    trace_mode,
     mode,
     seq_len,
     batch_size_per_row,
@@ -117,6 +151,9 @@ def run_test_forward_pass_dpmodel(
     state_dict,
     decode_position_ids: int | None = None,
 ):
+    if trace_mode and mode != "decode":
+        pytest.skip("Tracing is only supported for decode mode.")
+
     # Check params
     if mode == "prefill":
         assert batch_size_per_row == 1, "Prefill only supports a batch size of 1"
@@ -141,8 +178,14 @@ def run_test_forward_pass_dpmodel(
     )
 
     # Set up model config
+    weight_cache_root = cache_path if use_real_weights else cache_path / "random_weights"
     weight_config = get_test_weight_config(
-        RowBatchedModel, hf_config_short, (state_dict,), cache_path, mesh_device, force_recalculate_weight_config
+        RowBatchedModel,
+        hf_config_short,
+        (state_dict,),
+        weight_cache_root,
+        mesh_device,
+        force_recalculate_weight_config or not use_real_weights,
     )
     model_config = get_model_config(RowBatchedModel, mode, hf_config_short, mesh_device)
     model_state = RowBatchedModel.create_state(hf_config_short, paged_config, mesh_device, ccl, paged_input_caches)
@@ -179,26 +222,58 @@ def run_test_forward_pass_dpmodel(
     rope_tensors = get_rope_tensors(hf_config_short, batch_size_per_row, seq_len, position_ids, mesh_device)
     paged_config = MLA2D.get_valid_paged_config(hf_config_short.max_seq_len, USERS_PER_ROW, mesh_device.shape[1])
 
+    def run_forward() -> ttnn.Tensor:
+        if mode == "prefill":
+            return RowBatchedModel.forward_prefill(tt_input, user_id, run_config, rope_tensors, tt_page_tables)
+        return RowBatchedModel.forward_decode(tt_input, position_ids_tensor, run_config, rope_tensors, tt_page_tables)
+
+    def check_outputs(tt_output: ttnn.Tensor) -> None:
+        tt_output_torch = ttnn.to_torch(
+            tt_output,
+            mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_device, dims=(-2, -1), mesh_shape=mesh_device.shape),
+        )
+        assert (
+            tt_output_torch.shape[-1] == hf_config_short.vocab_size
+        ), f"Output shape mismatch: {tt_output_torch.shape} vs {hf_config_short.vocab_size}"
+
+        assert_hidden_dim_pcc(tt_output_torch, reference_output, pcc_required=0.97)
+
     # Forward pass
     logger.info("Running TTNN forward pass")
-    if mode == "prefill":
-        tt_output = RowBatchedModel.forward_prefill(tt_input, user_id, run_config, rope_tensors, tt_page_tables)
+    if trace_mode:
+        # Iteration 0: eager compile run (not traced)
+        tt_output = run_forward()
+        ttnn.synchronize_device(mesh_device)
+        check_outputs(tt_output)
+        ttnn.deallocate(tt_output)
+
+        trace_id = ttnn.begin_trace_capture(mesh_device, cq_id=0)
+        trace_output = run_forward()
+        ttnn.end_trace_capture(mesh_device, trace_id, cq_id=0)
+        ttnn.synchronize_device(mesh_device)
+
+        for _ in range(TEST_CHECK_ITERS - 1):
+            ttnn.execute_trace(mesh_device, trace_id, blocking=True)
+        ttnn.synchronize_device(mesh_device)
+
+        check_outputs(trace_output)
+        ttnn.release_trace(mesh_device, trace_id)
+        ttnn.deallocate(trace_output)
     else:
-        tt_output = RowBatchedModel.forward_decode(
-            tt_input, position_ids_tensor, run_config, rope_tensors, tt_page_tables
-        )
+        for iter_idx in range(TEST_CHECK_ITERS):
+            tt_output = run_forward()
+            ttnn.synchronize_device(mesh_device)
+            if iter_idx in (0, TEST_CHECK_ITERS - 1):
+                check_outputs(tt_output)
+            ttnn.deallocate(tt_output)
 
-    ttnn.synchronize_device(mesh_device)
-
-    tt_output_torch = ttnn.to_torch(
-        tt_output, mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_device, dims=(-2, -1), mesh_shape=mesh_device.shape)
-    )
-    assert (
-        tt_output_torch.shape[-1] == hf_config_short.vocab_size
-    ), f"Output shape mismatch: {tt_output_torch.shape} vs {hf_config_short.vocab_size}"
-
-    # Check output PCC
-    assert_hidden_dim_pcc(tt_output_torch, reference_output, pcc_required=0.97)
+    ttnn.deallocate(tt_input)
+    if position_ids_tensor is not None:
+        ttnn.deallocate(position_ids_tensor)
+    for tt_page_table in tt_page_tables:
+        ttnn.deallocate(tt_page_table)
+    for rope_tensor in rope_tensors.values():
+        ttnn.deallocate(rope_tensor)
 
 
 # Base test cases - ranges will be expanded into individual test cases
@@ -215,8 +290,11 @@ BASE_TEST_CASES = [
         seq_len,
         1,
         None,
-        marks=pytest.mark.skip(
-            f"Skipping prefilling with seq_len={seq_len} since this would cause us to exceed our available CI workload time"
+        marks=pytest.mark.skipif(
+            CI_ACTIVE,
+            reason=(
+                f"Skipping prefilling with seq_len={seq_len} since this would cause us to exceed our available CI workload time"
+            ),
         ),
     )
     for seq_len in PREFILL_SEQ_LENS
@@ -228,13 +306,23 @@ EXPANDED_TEST_IDS = build_expanded_test_ids(EXPANDED_TEST_CASES)
 @pytest.mark.parametrize(
     "device_params",
     [
-        {"fabric_config": ttnn.FabricConfig.FABRIC_1D},
+        {"fabric_config": ttnn.FabricConfig.FABRIC_1D, "trace_region_size": 10485760},
     ],
     indirect=True,
 )
 @pytest.mark.parametrize(
     "use_real_weights",
-    [True],  # Test only with real weights for now
+    [
+        pytest.param(True, id="real_weights"),
+        pytest.param(False, marks=_CI_SKIP_MARK, id="random_weights"),
+    ],
+)
+@pytest.mark.parametrize(
+    "trace_mode",
+    [
+        pytest.param(False, marks=_CI_SKIP_MARK, id="eager"),
+        pytest.param(True, id="tracing"),
+    ],
 )
 @pytest.mark.parametrize(
     "mode, seq_len, batch_size_per_row, decode_position_ids",
@@ -243,6 +331,7 @@ EXPANDED_TEST_IDS = build_expanded_test_ids(EXPANDED_TEST_CASES)
 )
 def test_forward_pass(
     use_real_weights,
+    trace_mode,
     mode,
     seq_len,
     batch_size_per_row,
@@ -265,6 +354,7 @@ def test_forward_pass(
 
     run_test_forward_pass_dpmodel(
         use_real_weights,
+        trace_mode,
         mode,
         seq_len,
         batch_size_per_row,

--- a/models/demos/deepseek_v3/tests/test_moe.py
+++ b/models/demos/deepseek_v3/tests/test_moe.py
@@ -180,6 +180,9 @@ def test_forward_pass(
         assert_hidden_dim_pcc(tt_output_torch, reference_output.unsqueeze(0), pcc_required=0.98)
         ttnn.deallocate(tt_output)
 
+        # Reset CCL semaphore counters before trace capture
+        ccl.reset_sem_counters()
+
         trace_id = ttnn.begin_trace_capture(mesh_device, cq_id=0)
         trace_output = run_module_forward(MoE, mode, tt_input, run_config)
         ttnn.end_trace_capture(mesh_device, trace_id, cq_id=0)

--- a/models/demos/deepseek_v3/tests/test_moe.py
+++ b/models/demos/deepseek_v3/tests/test_moe.py
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 
+import os
+
 import pytest
 import torch
 from loguru import logger
@@ -21,6 +23,13 @@ from models.demos.deepseek_v3.utils.test_utils import (
     run_module_forward,
 )
 
+TEST_CHECK_ITERS = 100
+CI_ACTIVE = os.getenv("CI") == "true"
+_CI_SKIP_MARK = pytest.mark.skipif(
+    CI_ACTIVE,
+    reason="CI runs traced coverage only.",
+)
+
 
 @pytest.fixture
 def reference_model(hf_config):
@@ -34,7 +43,7 @@ def reference_model(hf_config):
 @pytest.mark.parametrize(
     "device_params",
     [
-        {"fabric_config": ttnn.FabricConfig.FABRIC_1D},
+        {"fabric_config": ttnn.FabricConfig.FABRIC_1D, "trace_region_size": 10485760},
     ],
     indirect=True,
 )
@@ -55,16 +64,35 @@ def reference_model(hf_config):
         else pytest.param(
             "prefill",
             seq_len,
-            marks=pytest.mark.skip(
-                f"Skipping prefilling with seq_len={seq_len} since this would cause us to exceed our available CI workload time"
+            marks=pytest.mark.skipif(
+                CI_ACTIVE,
+                reason=(
+                    f"Skipping prefilling with seq_len={seq_len} since this would cause us to exceed our available CI workload time"
+                ),
             ),
         )
         for seq_len in PREFILL_SEQ_LENS
     ],
 )
+@pytest.mark.parametrize(
+    "trace_mode",
+    [
+        pytest.param(False, id="eager"),
+        pytest.param(True, id="tracing"),
+    ],
+)
+@pytest.mark.parametrize(
+    "use_real_weights",
+    [
+        pytest.param(True, id="real_weights"),
+        pytest.param(False, id="random_weights"),
+    ],
+)
 def test_forward_pass(
     mode,
     num_tokens,
+    trace_mode,
+    use_real_weights,
     set_deterministic_env,
     reference_model,
     hf_config,
@@ -74,10 +102,19 @@ def test_forward_pass(
     topk_fallback,
 ):
     """Test forward pass against reference model."""
+    if trace_mode and mode != "decode":
+        pytest.skip("Tracing is only supported for decode mode.")
+    if trace_mode and topk_fallback:
+        pytest.skip("Tracing not supported with topk_fallback.")
 
-    # Get state dict from actual model - pass directly to convert_weights
+    if use_real_weights:
+        model_for_reference = reference_model
+    else:
+        model_for_reference = DeepseekV3MoE(hf_config).eval()
+
+    # Get state dict from model - pass directly to convert_weights
     state_dict = add_inv_scale_to_state_dict(
-        reference_model.state_dict(),
+        model_for_reference.state_dict(),
         block_shape=hf_config.quantization_config["weight_block_size"],
     )
 
@@ -85,13 +122,18 @@ def test_forward_pass(
     torch_input = torch.randn(1, num_tokens, hf_config.hidden_size, dtype=torch.bfloat16)
 
     # Reference forward pass
-    reference_model.eval()
-    reference_model.to(torch.bfloat16)
+    model_for_reference.eval()
+    model_for_reference.to(torch.bfloat16)
     with torch.no_grad():
-        reference_output = reference_model(torch_input)
+        reference_output = model_for_reference(torch_input)
 
     weight_config = get_test_weight_config(
-        MoE, hf_config, (state_dict,), cache_path, mesh_device, force_recalculate=False
+        MoE,
+        hf_config,
+        (state_dict,),
+        cache_path,
+        mesh_device,
+        force_recalculate=not use_real_weights,
     )
 
     # Generate appropriate config using utility function
@@ -116,30 +158,51 @@ def test_forward_pass(
         layout=ttnn.TILE_LAYOUT,
     )
 
-    # TTNN forward pass using utility function
     tt_input = ttnn.to_memory_config(tt_input, run_config["input_memory_config"])
-    tt_output = run_module_forward(MoE, mode, tt_input, run_config)
 
-    # Verify output memory config matches expected
-    expected_output_memory_config = run_config["output_memory_config"]
-    actual_output_memory_config = tt_output.memory_config()
-    assert (
-        actual_output_memory_config == expected_output_memory_config
-    ), f"MoE output memory config mismatch: expected {expected_output_memory_config}, got {actual_output_memory_config}"
+    def to_torch_output(tt_output: ttnn.Tensor) -> torch.Tensor:
+        expected_output_memory_config = run_config["output_memory_config"]
+        actual_output_memory_config = tt_output.memory_config()
+        assert (
+            actual_output_memory_config == expected_output_memory_config
+        ), f"MoE output memory config mismatch: expected {expected_output_memory_config}, got {actual_output_memory_config}"
+        return ttnn.to_torch(
+            tt_output,
+            mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_device, dims=(-2, -1), mesh_shape=tuple(mesh_device.shape)),
+        )
 
-    # Convert output back to torch
-    tt_output_torch = ttnn.to_torch(
-        tt_output,
-        mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_device, dims=(-2, -1), mesh_shape=tuple(mesh_device.shape)),
-    )
-
-    # Cleanup
-    ttnn.deallocate(tt_input)
-    ttnn.deallocate(tt_output)
-
-    # Compare outputs using utility function
     logger.info(f"Mode: {mode}, Num tokens: {num_tokens}")
-    assert_hidden_dim_pcc(tt_output_torch, reference_output.unsqueeze(0), pcc_required=0.98)
+    if trace_mode:
+        # Iteration 0: eager compile run (not traced)
+        tt_output = run_module_forward(MoE, mode, tt_input, run_config)
+        ttnn.synchronize_device(mesh_device)
+        tt_output_torch = to_torch_output(tt_output)
+        assert_hidden_dim_pcc(tt_output_torch, reference_output.unsqueeze(0), pcc_required=0.98)
+        ttnn.deallocate(tt_output)
+
+        trace_id = ttnn.begin_trace_capture(mesh_device, cq_id=0)
+        trace_output = run_module_forward(MoE, mode, tt_input, run_config)
+        ttnn.end_trace_capture(mesh_device, trace_id, cq_id=0)
+        ttnn.synchronize_device(mesh_device)
+
+        for _ in range(TEST_CHECK_ITERS - 1):
+            ttnn.execute_trace(mesh_device, trace_id, blocking=True)
+        ttnn.synchronize_device(mesh_device)
+
+        tt_output_torch = to_torch_output(trace_output)
+        assert_hidden_dim_pcc(tt_output_torch, reference_output.unsqueeze(0), pcc_required=0.98)
+        ttnn.release_trace(mesh_device, trace_id)
+        ttnn.deallocate(trace_output)
+    else:
+        for iter_idx in range(TEST_CHECK_ITERS):
+            tt_output = run_module_forward(MoE, mode, tt_input, run_config)
+            ttnn.synchronize_device(mesh_device)
+            if iter_idx in (0, TEST_CHECK_ITERS - 1):
+                tt_output_torch = to_torch_output(tt_output)
+                assert_hidden_dim_pcc(tt_output_torch, reference_output.unsqueeze(0), pcc_required=0.98)
+            ttnn.deallocate(tt_output)
+
+    ttnn.deallocate(tt_input)
 
 
 if __name__ == "__main__":

--- a/models/demos/deepseek_v3/tests/test_moe_experts.py
+++ b/models/demos/deepseek_v3/tests/test_moe_experts.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 
+import os
 from pathlib import Path
 from typing import Any
 
@@ -23,6 +24,13 @@ from models.demos.deepseek_v3.utils.test_utils import (
     get_model_config,
     get_test_weight_config,
     run_module_forward,
+)
+
+TEST_CHECK_ITERS = 100
+CI_ACTIVE = os.getenv("CI") == "true"
+_CI_SKIP_MARK = pytest.mark.skipif(
+    CI_ACTIVE,
+    reason="CI runs traced coverage only.",
 )
 
 
@@ -80,16 +88,36 @@ def create_combined_state_dict(module_path: str, model_path: Path, state_dict: d
         else pytest.param(
             "prefill",
             seq_len,
-            marks=pytest.mark.skip(
-                f"Skipping prefilling with seq_len={seq_len} since this would cause us to exceed our available CI workload time"
+            marks=pytest.mark.skipif(
+                CI_ACTIVE,
+                reason=(
+                    f"Skipping prefilling with seq_len={seq_len} since this would cause us to exceed our available CI workload time"
+                ),
             ),
         )
         for seq_len in PREFILL_SEQ_LENS
     ],
 )
 @pytest.mark.parametrize(
-    "weight_type",
-    ["random", "real"],
+    "trace_mode",
+    [
+        pytest.param(False, marks=_CI_SKIP_MARK, id="eager"),
+        pytest.param(True, id="tracing"),
+    ],
+)
+@pytest.mark.parametrize(
+    "use_real_weights",
+    [
+        pytest.param(True, id="real_weights"),
+        pytest.param(False, marks=_CI_SKIP_MARK, id="random_weights"),
+    ],
+)
+@pytest.mark.parametrize(
+    "device_params",
+    [
+        {"fabric_config": ttnn.FabricConfig.FABRIC_1D, "trace_region_size": 10485760},
+    ],
+    indirect=True,
 )
 @pytest.mark.parametrize(
     "module_path",
@@ -98,33 +126,42 @@ def create_combined_state_dict(module_path: str, model_path: Path, state_dict: d
 def test_forward_pass(
     mode: str,
     seq_len: int,
+    trace_mode: bool,
+    use_real_weights: bool,
     hf_config: Any,
     cache_path: Path,
     mesh_device: Any,
-    weight_type: str,
     module_path: str,
     model_path: Path,
     force_recalculate_weight_config,
     set_deterministic_env,
     state_dict: dict[str, torch.Tensor],
 ):
+    if trace_mode and mode != "decode":
+        pytest.skip("Tracing is only supported for decode mode.")
+
     batch_size = 1
     num_experts_per_device = even_int_div(hf_config.n_routed_experts, mesh_device.get_num_devices())
 
     reference_model = DeepseekV3MoEExperts(hf_config).eval()
     torch_input = torch.randn(batch_size, 1, seq_len, hf_config.hidden_size)
 
-    if weight_type == "random":
+    if not use_real_weights:
         state_dict = add_inv_scale_to_state_dict(
             reference_model.state_dict(), block_shape=hf_config.quantization_config["weight_block_size"]
         )
     else:
-        assert weight_type == "real"
         state_dict = create_combined_state_dict(module_path, model_path, state_dict)
         reference_model.load_state_dict(dequantize_state_dict(state_dict, hf_config))
 
+    weight_cache_root = cache_path if use_real_weights else cache_path / "random_weights"
     weight_config = get_test_weight_config(
-        TTExperts, hf_config, (state_dict,), cache_path, mesh_device, force_recalculate_weight_config
+        TTExperts,
+        hf_config,
+        (state_dict,),
+        weight_cache_root,
+        mesh_device,
+        force_recalculate_weight_config or not use_real_weights,
     )
     model_config = get_model_config(TTExperts, mode, hf_config, mesh_device)
     model_state = TTExperts.create_state(hf_config, mesh_device)
@@ -140,63 +177,91 @@ def test_forward_pass(
     )
 
     tt_input = ttnn.to_memory_config(tt_input, run_config["input_memory_config"])
-    tt_output = run_module_forward(TTExperts, mode, tt_input, run_config)
-    expected_output_memory_config = run_config["output_memory_config"]
 
-    actual_output_memory_config = tt_output.memory_config()
-    assert (
-        actual_output_memory_config == expected_output_memory_config
-    ), f"Output memory config mismatch: expected {expected_output_memory_config}, got {actual_output_memory_config}"
+    def check_outputs(tt_output: ttnn.Tensor) -> None:
+        expected_output_memory_config = run_config["output_memory_config"]
+        actual_output_memory_config = tt_output.memory_config()
+        assert (
+            actual_output_memory_config == expected_output_memory_config
+        ), f"Output memory config mismatch: expected {expected_output_memory_config}, got {actual_output_memory_config}"
 
-    TARGET_CHUNK_SIZE = 2048
-    num_chunks = (seq_len + TARGET_CHUNK_SIZE - 1) // TARGET_CHUNK_SIZE
+        TARGET_CHUNK_SIZE = 2048
+        CHUNK_SIZE_SEQ = ((TARGET_CHUNK_SIZE + SPARSITY_BLOCK_SIZE - 1) // SPARSITY_BLOCK_SIZE) * SPARSITY_BLOCK_SIZE
+        num_chunks = (seq_len + CHUNK_SIZE_SEQ - 1) // CHUNK_SIZE_SEQ
 
-    from models.common.utility_functions import comp_pcc
+        from models.common.utility_functions import comp_pcc
 
-    min_pcc = 0.98
-    passed = True
+        min_pcc = 0.98
+        passed = True
 
-    for chunk_idx in range(num_chunks):
-        start_seq = chunk_idx * TARGET_CHUNK_SIZE
-        end_seq = min(start_seq + TARGET_CHUNK_SIZE, seq_len)
-        chunk_seq_len = end_seq - start_seq
+        for chunk_idx in range(num_chunks):
+            start_seq = chunk_idx * CHUNK_SIZE_SEQ
+            end_seq = min(start_seq + CHUNK_SIZE_SEQ, seq_len)
+            chunk_seq_len = end_seq - start_seq
 
-        chunk_input = torch_input[:, :, start_seq:end_seq, :]
-        chunk_ref_output = reference_model(chunk_input)
+            chunk_input = torch_input[:, :, start_seq:end_seq, :]
+            chunk_ref_output = reference_model(chunk_input)
 
-        tt_output_chunk = ttnn.slice(
-            tt_output,
-            [0, 0, start_seq, 0],
-            [1, num_experts_per_device, end_seq, hf_config.hidden_size],
-        )
+            tt_output_chunk = ttnn.slice(
+                tt_output,
+                [0, 0, start_seq, 0],
+                [1, num_experts_per_device, end_seq, hf_config.hidden_size],
+            )
 
-        tt_output_chunk_torch = ttnn.to_torch(
-            tt_output_chunk,
-            mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_device, dims=(0, 1), mesh_shape=tuple(mesh_device.shape)),
-        )
+            tt_output_chunk_torch = ttnn.to_torch(
+                tt_output_chunk,
+                mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_device, dims=(0, 1), mesh_shape=tuple(mesh_device.shape)),
+            )
 
-        ttnn.deallocate(tt_output_chunk)
+            ttnn.deallocate(tt_output_chunk)
 
-        tt_output_chunk_torch = tt_output_chunk_torch.reshape(1, -1, chunk_seq_len, hf_config.hidden_size)
-        tt_output_chunk_torch = tt_output_chunk_torch[0].unsqueeze(1)
+            tt_output_chunk_torch = tt_output_chunk_torch.reshape(1, -1, chunk_seq_len, hf_config.hidden_size)
+            tt_output_chunk_torch = tt_output_chunk_torch[0].unsqueeze(1)
 
-        if chunk_ref_output.shape != tt_output_chunk_torch.shape:
-            chunk_ref_output = chunk_ref_output.unsqueeze(0)
+            if chunk_ref_output.shape != tt_output_chunk_torch.shape:
+                chunk_ref_output = chunk_ref_output.unsqueeze(0)
 
-        chunk_passed, chunk_pcc = comp_pcc(tt_output_chunk_torch, chunk_ref_output, pcc=0.98)
+            chunk_passed, chunk_pcc = comp_pcc(tt_output_chunk_torch, chunk_ref_output, pcc=0.98)
 
-        min_pcc = min(min_pcc, chunk_pcc)
-        if not chunk_passed:
-            passed = False
+            min_pcc = min(min_pcc, chunk_pcc)
+            if not chunk_passed:
+                passed = False
 
-        del chunk_ref_output
-        del tt_output_chunk_torch
-        del chunk_input
+            del chunk_ref_output
+            del tt_output_chunk_torch
+            del chunk_input
+
+        assert passed, f"PCC check failed! Min PCC: {min_pcc:.6f} < 0.98"
+
+    if trace_mode:
+        # Iteration 0: eager compile run (not traced)
+        tt_output = run_module_forward(TTExperts, mode, tt_input, tt_sparsity, run_config)
+        ttnn.synchronize_device(mesh_device)
+        check_outputs(tt_output)
+        ttnn.deallocate(tt_output)
+
+        trace_id = ttnn.begin_trace_capture(mesh_device, cq_id=0)
+        trace_output = run_module_forward(TTExperts, mode, tt_input, tt_sparsity, run_config)
+        ttnn.end_trace_capture(mesh_device, trace_id, cq_id=0)
+        ttnn.synchronize_device(mesh_device)
+
+        for _ in range(TEST_CHECK_ITERS - 1):
+            ttnn.execute_trace(mesh_device, trace_id, blocking=True)
+        ttnn.synchronize_device(mesh_device)
+
+        check_outputs(trace_output)
+        ttnn.release_trace(mesh_device, trace_id)
+        ttnn.deallocate(trace_output)
+    else:
+        for iter_idx in range(TEST_CHECK_ITERS):
+            tt_output = run_module_forward(TTExperts, mode, tt_input, tt_sparsity, run_config)
+            ttnn.synchronize_device(mesh_device)
+            if iter_idx in (0, TEST_CHECK_ITERS - 1):
+                check_outputs(tt_output)
+            ttnn.deallocate(tt_output)
 
     ttnn.deallocate(tt_input)
-    ttnn.deallocate(tt_output)
-
-    assert passed, f"PCC check failed! Min PCC: {min_pcc:.6f} < 0.98"
+    ttnn.deallocate(tt_sparsity)
 
 
 if __name__ == "__main__":

--- a/models/demos/deepseek_v3/tests/test_moe_gate.py
+++ b/models/demos/deepseek_v3/tests/test_moe_gate.py
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 
+import os
+
 import pytest
 import torch
 from loguru import logger
@@ -16,6 +18,13 @@ from models.demos.deepseek_v3.utils.run_config import create_run_config
 from models.demos.deepseek_v3.utils.test_utils import get_model_config, get_test_weight_config, run_module_forward
 from tests.ttnn.utils_for_testing import comp_pcc
 
+TEST_CHECK_ITERS = 100
+CI_ACTIVE = os.getenv("CI") == "true"
+_CI_SKIP_MARK = pytest.mark.skipif(
+    CI_ACTIVE,
+    reason="CI runs traced coverage only.",
+)
+
 
 @pytest.mark.parametrize(
     "mode,seq_len",
@@ -28,45 +37,88 @@ from tests.ttnn.utils_for_testing import comp_pcc
         else pytest.param(
             "prefill",
             seq_len,
-            marks=pytest.mark.skip(
-                f"Skipping prefilling with seq_len={seq_len} since this would cause us to exceed our available CI workload time"
+            marks=pytest.mark.skipif(
+                CI_ACTIVE,
+                reason=(
+                    f"Skipping prefilling with seq_len={seq_len} since this would cause us to exceed our available CI workload time"
+                ),
             ),
         )
         for seq_len in PREFILL_SEQ_LENS
     ],
 )
 @pytest.mark.parametrize(
+    "trace_mode",
+    [
+        pytest.param(False, id="eager"),
+        pytest.param(True, id="tracing"),
+    ],
+)
+@pytest.mark.parametrize(
+    "use_real_weights",
+    [
+        pytest.param(True, id="real_weights"),
+        pytest.param(False, marks=_CI_SKIP_MARK, id="random_weights"),
+    ],
+)
+@pytest.mark.parametrize(
+    "device_params",
+    [
+        {"fabric_config": ttnn.FabricConfig.FABRIC_1D, "trace_region_size": 10485760},
+    ],
+    indirect=True,
+)
+@pytest.mark.parametrize(
     "topk_fallback,use_bitonic_sort",
     [
-        (True, True),
+        pytest.param(True, True, id="topk_fallback_true"),
     ],
 )
 def test_forward_pass(
     mode,
     seq_len,
+    trace_mode,
+    use_real_weights,
     hf_config,
     topk_fallback,
     use_bitonic_sort,
     cache_path,
     mesh_device,
+    force_recalculate_weight_config,
     set_deterministic_env,
 ):
     """Test forward pass against reference model."""
+    if trace_mode and mode != "decode":
+        pytest.skip("Tracing is only supported for decode mode.")
+    if trace_mode and topk_fallback:
+        pytest.skip("Tracing not supported with topk_fallback.")
 
     batch_size = 1
+    effective_topk_fallback = topk_fallback and not trace_mode
 
     # Get state dict from actual model - pass directly to convert_weights
     torch.use_deterministic_algorithms(True)
     reference_model = ReferenceMoEGate(hf_config, use_bitonic_sort).eval()
     hf_state_dict = reference_model.state_dict()
 
+    weight_cache_root = cache_path if use_real_weights else cache_path / "random_weights"
     weight_config = get_test_weight_config(
-        MoEGate, hf_config, (hf_state_dict,), cache_path, mesh_device, force_recalculate=False
+        MoEGate,
+        hf_config,
+        (hf_state_dict,),
+        weight_cache_root,
+        mesh_device,
+        force_recalculate=force_recalculate_weight_config or not use_real_weights,
     )
 
     # Generate appropriate config using utility function
     model_config = get_model_config(
-        MoEGate, mode, hf_config, mesh_device, topk_fallback=topk_fallback, use_bitonic_sort=use_bitonic_sort
+        MoEGate,
+        mode,
+        hf_config,
+        mesh_device,
+        topk_fallback=effective_topk_fallback,
+        use_bitonic_sort=use_bitonic_sort,
     )
 
     # Create a new model state
@@ -82,6 +134,10 @@ def test_forward_pass(
     reference_model.eval()
     reference_model.to(torch.bfloat16)
     reference_topk_indices, reference_topk_weights = reference_model(torch_input)
+    reference_topk_indices_short = reference_topk_indices.to(torch.short)
+    reference_sort_idx = torch.argsort(reference_topk_indices_short, dim=-1, stable=True)
+    reference_topk_indices_sorted = torch.gather(reference_topk_indices_short, -1, reference_sort_idx)
+    reference_topk_weights_sorted = torch.gather(reference_topk_weights, -1, reference_sort_idx)
 
     # Convert input to TTNN
     tt_input = ttnn.from_torch(
@@ -93,53 +149,78 @@ def test_forward_pass(
         layout=ttnn.TILE_LAYOUT,
     )
 
-    # TTNN forward pass using utility function
     tt_input = ttnn.to_memory_config(tt_input, run_config["input_memory_config"])
-    tt_topk_weights, tt_topk_indices = run_module_forward(MoEGate, mode, tt_input, run_config)
 
-    # Verify output memory config matches expected
-    expected_output_memory_config = run_config["output_memory_config"]
-    actual_topk_weights_memory_config = tt_topk_weights.memory_config()
-    assert (
-        actual_topk_weights_memory_config == expected_output_memory_config
-    ), f"TopK experts weights memory config mismatch: expected {expected_output_memory_config}, got {actual_topk_weights_memory_config}"
+    def check_outputs(tt_topk_weights, tt_topk_indices) -> None:
+        expected_output_memory_config = run_config["output_memory_config"]
+        actual_topk_weights_memory_config = tt_topk_weights.memory_config()
+        assert (
+            actual_topk_weights_memory_config == expected_output_memory_config
+        ), f"TopK experts weights memory config mismatch: expected {expected_output_memory_config}, got {actual_topk_weights_memory_config}"
 
-    actual_topk_indices_memory_config = tt_topk_indices.memory_config()
-    assert (
-        actual_topk_indices_memory_config == expected_output_memory_config
-    ), f"TopK experts indices memory config mismatch: expected {expected_output_memory_config}, got {actual_topk_indices_memory_config}"
+        actual_topk_indices_memory_config = tt_topk_indices.memory_config()
+        assert (
+            actual_topk_indices_memory_config == expected_output_memory_config
+        ), f"TopK experts indices memory config mismatch: expected {expected_output_memory_config}, got {actual_topk_indices_memory_config}"
 
-    # Convert output back to torch
-    tt_topk_weights_torch = ttnn.to_torch(
-        tt_topk_weights,
-        mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_device, dims=(-2, 0), mesh_shape=tuple(mesh_device.shape)),
-    )[0].squeeze(0)
-    tt_topk_indices_torch = ttnn.to_torch(
-        tt_topk_indices,
-        mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_device, dims=(-2, 0), mesh_shape=tuple(mesh_device.shape)),
-    )[0].squeeze(0)
+        tt_topk_weights_torch = ttnn.to_torch(
+            tt_topk_weights,
+            mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_device, dims=(-2, 0), mesh_shape=tuple(mesh_device.shape)),
+        )[0].squeeze(0)
+        tt_topk_indices_torch = ttnn.to_torch(
+            tt_topk_indices,
+            mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_device, dims=(-2, 0), mesh_shape=tuple(mesh_device.shape)),
+        )[0].squeeze(0)
 
-    # Cleanup
-    ttnn.deallocate(tt_input)
-    ttnn.deallocate(tt_topk_weights)
-    ttnn.deallocate(tt_topk_indices)
+        tt_topk_indices_short = tt_topk_indices_torch.to(torch.short)
+        tt_sort_idx = torch.argsort(tt_topk_indices_short, dim=-1, stable=True)
+        tt_topk_indices_sorted = torch.gather(tt_topk_indices_short, -1, tt_sort_idx)
+        tt_topk_weights_sorted = torch.gather(tt_topk_weights_torch, -1, tt_sort_idx)
 
-    # Compare outputs
+        topk_weights_pcc_required = 0.99
+        passing, pcc_message = comp_pcc(
+            reference_topk_weights_sorted, tt_topk_weights_sorted, topk_weights_pcc_required
+        )
+        logger.info(f"TopK experts weights PCC: {pcc_message}")
+        assert (
+            passing
+        ), f"TopK experts weights output does not meet PCC requirement {topk_weights_pcc_required}: {pcc_message}"
+
+        assert torch.allclose(
+            reference_topk_indices_sorted, tt_topk_indices_sorted
+        ), "TopK experts indices output does not match"
+
     logger.info(f"Mode: {mode}, Seq len: {seq_len}")
+    if trace_mode:
+        tt_topk_weights, tt_topk_indices = run_module_forward(MoEGate, mode, tt_input, run_config)
+        ttnn.synchronize_device(mesh_device)
+        check_outputs(tt_topk_weights, tt_topk_indices)
+        ttnn.deallocate(tt_topk_weights)
+        ttnn.deallocate(tt_topk_indices)
 
-    topk_weights_pcc_required = 0.99
-    passing, pcc_message = comp_pcc(reference_topk_weights, tt_topk_weights_torch, topk_weights_pcc_required)
+        trace_id = ttnn.begin_trace_capture(mesh_device, cq_id=0)
+        trace_topk_weights, trace_topk_indices = run_module_forward(MoEGate, mode, tt_input, run_config)
+        ttnn.end_trace_capture(mesh_device, trace_id, cq_id=0)
+        ttnn.synchronize_device(mesh_device)
 
-    logger.info(f"TopK experts weights PCC: {pcc_message}")
-    assert (
-        passing
-    ), f"TopK experts weights output does not meet PCC requirement {topk_weights_pcc_required}: {pcc_message}"
+        for _ in range(TEST_CHECK_ITERS - 1):
+            ttnn.execute_trace(mesh_device, trace_id, blocking=True)
+        ttnn.synchronize_device(mesh_device)
 
-    topk_indices_pcc_required = 1.0
-    # stable sort both reference and ttnn indices to avoid random tie breaking for better comparison
-    reference_topk_indices = torch.sort(reference_topk_indices.to(torch.short), dim=-1, stable=True)[0]
-    tt_topk_indices_torch = torch.sort(tt_topk_indices_torch, dim=-1, stable=True)[0]
-    assert torch.allclose(reference_topk_indices, tt_topk_indices_torch), f"TopK experts indices output does not match"
+        check_outputs(trace_topk_weights, trace_topk_indices)
+        ttnn.release_trace(mesh_device, trace_id)
+        ttnn.deallocate(trace_topk_weights)
+        ttnn.deallocate(trace_topk_indices)
+    else:
+        for iter_idx in range(TEST_CHECK_ITERS):
+            tt_topk_weights, tt_topk_indices = run_module_forward(MoEGate, mode, tt_input, run_config)
+            ttnn.synchronize_device(mesh_device)
+            if iter_idx in (0, TEST_CHECK_ITERS - 1):
+                check_outputs(tt_topk_weights, tt_topk_indices)
+            ttnn.deallocate(tt_topk_weights)
+            ttnn.deallocate(tt_topk_indices)
+
+    ttnn.deallocate(tt_input)
 
 
 if __name__ == "__main__":

--- a/models/demos/deepseek_v3/tests/test_rms_norm.py
+++ b/models/demos/deepseek_v3/tests/test_rms_norm.py
@@ -176,6 +176,9 @@ def test_forward_pass(
         assert_hidden_dim_pcc(tt_output_torch, reference_output, pcc_required=0.98)
         ttnn.deallocate(tt_output)
 
+        # Reset CCL semaphore counters before trace capture
+        ccl.reset_sem_counters()
+
         trace_id = ttnn.begin_trace_capture(mesh_device, cq_id=0)
         trace_output = run_module_forward(RMSNormClass, mode, tt_input, run_config)
         ttnn.end_trace_capture(mesh_device, trace_id, cq_id=0)

--- a/models/demos/deepseek_v3/tests/test_rms_norm.py
+++ b/models/demos/deepseek_v3/tests/test_rms_norm.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC.
 # SPDX-License-Identifier: Apache-2.0
 
+import os
 
 import pytest
 import torch
@@ -19,10 +20,23 @@ from models.demos.deepseek_v3.utils.test_utils import (
     run_module_forward,
 )
 
+TEST_CHECK_ITERS = 100
+CI_ACTIVE = os.getenv("CI") == "true"
+_CI_SKIP_MARK = pytest.mark.skipif(
+    CI_ACTIVE,
+    reason="CI runs traced coverage only.",
+)
+
 
 @pytest.mark.parametrize(
     "device_params",
-    [{"dispatch_core_axis": ttnn.DispatchCoreAxis.COL, "fabric_config": ttnn.FabricConfig.FABRIC_1D}],
+    [
+        {
+            "dispatch_core_axis": ttnn.DispatchCoreAxis.COL,
+            "fabric_config": ttnn.FabricConfig.FABRIC_1D,
+            "trace_region_size": 10485760,
+        }
+    ],
     indirect=True,
 )
 @pytest.mark.parametrize(
@@ -36,21 +50,33 @@ from models.demos.deepseek_v3.utils.test_utils import (
         else pytest.param(
             "prefill",
             seq_len,
-            marks=pytest.mark.skip(
-                f"Skipping prefilling with seq_len={seq_len} since this would cause us to exceed our available CI workload time"
+            marks=pytest.mark.skipif(
+                CI_ACTIVE,
+                reason=(
+                    f"Skipping prefilling with seq_len={seq_len} since this would cause us to exceed our available CI workload time"
+                ),
             ),
         )
         for seq_len in PREFILL_SEQ_LENS
     ],
 )
 @pytest.mark.parametrize(
+    "trace_mode",
+    [
+        pytest.param(False, marks=_CI_SKIP_MARK, id="eager"),
+        pytest.param(True, id="tracing"),
+    ],
+)
+@pytest.mark.parametrize(
     "reference_layernorm_path, RMSNormClass, hf_config_size_attr",
     [
-        (None, DistributedRMSNorm, "hidden_size"),
+        pytest.param(None, DistributedRMSNorm, "hidden_size", marks=_CI_SKIP_MARK),
         ("model.layers.0.input_layernorm", DistributedRMSNorm, "hidden_size"),
         ("model.layers.0.post_attention_layernorm", DistributedRMSNorm, "hidden_size"),
-        (None, RMSNorm, "kv_lora_rank"),  # TODO: not properly tested here, needs fixing
-        (None, RMSNorm, "q_lora_rank"),  # TODO: not properly tested here, needs fixing
+        pytest.param(
+            None, RMSNorm, "kv_lora_rank", marks=_CI_SKIP_MARK
+        ),  # TODO: not properly tested here, needs fixing
+        pytest.param(None, RMSNorm, "q_lora_rank", marks=_CI_SKIP_MARK),  # TODO: not properly tested here, needs fixing
         (
             "model.layers.0.self_attn.kv_a_layernorm",
             RMSNorm,
@@ -68,6 +94,7 @@ def test_forward_pass(
     hf_config_size_attr,
     mode,
     seq_len,
+    trace_mode,
     reference_layernorm_path,
     model_path,
     hf_config,
@@ -132,23 +159,46 @@ def test_forward_pass(
         layout=ttnn.TILE_LAYOUT,
     )
 
-    # Run TTNN forward pass
-    tt_output = run_module_forward(RMSNormClass, mode, tt_input, run_config)
+    def to_torch_output(tt_output: ttnn.Tensor) -> torch.Tensor:
+        tt_output_torch = ttnn.to_torch(
+            tt_output,
+            mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_device, mesh_device.shape, dims=(0, -1)),
+        )
+        if RMSNormClass is RMSNorm:
+            tt_output_torch = tt_output_torch[..., :hidden_size]
+        return tt_output_torch
 
-    # Convert output back to torch
-    tt_output_torch = ttnn.to_torch(
-        tt_output,
-        mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_device, mesh_device.shape, dims=(0, -1)),
-    )
-    if RMSNormClass is RMSNorm:
-        tt_output_torch = tt_output_torch[..., :hidden_size]
+    if trace_mode:
+        # Iteration 0: eager compile run (not traced)
+        tt_output = run_module_forward(RMSNormClass, mode, tt_input, run_config)
+        ttnn.synchronize_device(mesh_device)
+        tt_output_torch = to_torch_output(tt_output)
+        assert_hidden_dim_pcc(tt_output_torch, reference_output, pcc_required=0.98)
+        ttnn.deallocate(tt_output)
 
-    # Cleanup
+        trace_id = ttnn.begin_trace_capture(mesh_device, cq_id=0)
+        trace_output = run_module_forward(RMSNormClass, mode, tt_input, run_config)
+        ttnn.end_trace_capture(mesh_device, trace_id, cq_id=0)
+        ttnn.synchronize_device(mesh_device)
+
+        for _ in range(TEST_CHECK_ITERS - 1):
+            ttnn.execute_trace(mesh_device, trace_id, blocking=True)
+        ttnn.synchronize_device(mesh_device)
+
+        tt_output_torch = to_torch_output(trace_output)
+        assert_hidden_dim_pcc(tt_output_torch, reference_output, pcc_required=0.98)
+        ttnn.release_trace(mesh_device, trace_id)
+        ttnn.deallocate(trace_output)
+    else:
+        for iter_idx in range(TEST_CHECK_ITERS):
+            tt_output = run_module_forward(RMSNormClass, mode, tt_input, run_config)
+            ttnn.synchronize_device(mesh_device)
+            if iter_idx in (0, TEST_CHECK_ITERS - 1):
+                tt_output_torch = to_torch_output(tt_output)
+                assert_hidden_dim_pcc(tt_output_torch, reference_output, pcc_required=0.98)
+            ttnn.deallocate(tt_output)
+
     ttnn.deallocate(tt_input)
-    ttnn.deallocate(tt_output)
-
-    # Check PCC
-    assert_hidden_dim_pcc(tt_output_torch, reference_output, pcc_required=0.98)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/36973)

### Problem description
Current module tests don't have tracing, and only run 1 iteration.

### What's changed
- Added tracing/eager option
- Added real weights/random weights option
- Runs 100 iterations now for pcc/atol checks
- CI skips everything except for decode/prefill-128 + tracing + real weights
- Changes made to:
    - [x] Rms norm
    - [x] Moe: note: tracing skipped, using eager in CI tests for now; reason is topk fallback
    - [x] Moe gate: tracing skipped, using eager in CI tests for now; reason is topk fallback
    - [x] Moe experts
    - [x] Model
    - [x] Mlp
    - [x] Mla
    - [x] Lmhead1d
    - [x] Embedding
    - [x] Decoder block

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:{{branch_name}})
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:{{branch_name}})
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:{{branch_name}})
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:{{branch_name}})
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:{{branch_name}})
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:{{branch_name}})
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-deepseek-tests.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:{{branch_name}})
