### PR TITLE
Add functionality to force regenerate deepseek v3 cache

### DIFF
--- a/models/demos/deepseek_v3/demo/demo.py
+++ b/models/demos/deepseek_v3/demo/demo.py
@@ -127,6 +127,12 @@ def create_parser() -> argparse.ArgumentParser:
         type=int,
         help="Maximum number of tokens to prefill.",
     )
+    p.add_argument(
+        "--force-recalculate-cache",
+        action="store_true",
+        default=False,
+        help="Force regeneration of the weight cache even if it already exists.",
+    )
     return p
 
 
@@ -242,6 +248,7 @@ def run_demo(
     repeat_batches: int = 1,
     signpost: bool = False,
     prefill_max_tokens: int = None,
+    force_recalculate_cache: bool = False,
 ) -> dict:
     """Programmatic entrypoint for the DeepSeek-V3 demo.
 
@@ -340,6 +347,7 @@ def run_demo(
                 enable_trace=enable_trace,
                 signpost=signpost,
                 prefill_max_tokens=prefill_max_tokens,
+                force_recalculate_cache=force_recalculate_cache,
             )
         # Build the prompt list
         pre_tokenized_prompts = None
@@ -438,6 +446,7 @@ def main() -> None:
         enable_trace=args.enable_trace,
         signpost=args.signpost,
         prefill_max_tokens=args.prefill_max_tokens,
+        force_recalculate_cache=bool(args.force_recalculate_cache),
     )
 
     # If prompts were loaded from a JSON file, save output to JSON file instead of printing

--- a/models/demos/deepseek_v3/demo/test_demo.py
+++ b/models/demos/deepseek_v3/demo/test_demo.py
@@ -12,11 +12,11 @@ MODEL_PATH = Path(os.getenv("DEEPSEEK_V3_HF_MODEL", "/mnt/MLPerf/tt_dnn-models/d
 CACHE_DIR = Path(os.getenv("DEEPSEEK_V3_CACHE", "/mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528-Cache/CI"))
 
 
-@pytest.mark.parametrize("repeat_batches", [2])
-def test_demo(repeat_batches):
+def test_demo():
     """
     Stress test the DeepSeek v3 demo with prompts loaded from JSON file, 2x runs.
     Uses only 5 layers (override_num_layers=5) for faster CI execution.
+    Regenerates cache if outdated.
     """
     # Path to the external JSON file containing prompts
     json_path = "models/demos/deepseek_v3/demo/test_prompts.json"
@@ -25,6 +25,7 @@ def test_demo(repeat_batches):
     prompts = load_prompts_from_json(json_path, max_prompts=56)
 
     # Run demo with only 5 layers for faster CI execution
+    # force_recalculate_cache=True will regenerate the cache if outdated
     results = run_demo(
         prompts=prompts,
         model_path=MODEL_PATH,
@@ -32,8 +33,12 @@ def test_demo(repeat_batches):
         random_weights=False,
         max_new_tokens=128,
         override_num_layers=5,
-        repeat_batches=repeat_batches,
+        repeat_batches=2,
+        force_recalculate_cache=True,
     )
 
     # Check output
     assert len(results["generations"][0]["tokens"]) == 128
+
+if __name__ == "__main__":
+    test_demo()

--- a/models/demos/deepseek_v3/demo/test_demo.py
+++ b/models/demos/deepseek_v3/demo/test_demo.py
@@ -12,11 +12,11 @@ MODEL_PATH = Path(os.getenv("DEEPSEEK_V3_HF_MODEL", "/mnt/MLPerf/tt_dnn-models/d
 CACHE_DIR = Path(os.getenv("DEEPSEEK_V3_CACHE", "/mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528-Cache/CI"))
 
 
-def test_demo():
+@pytest.mark.parametrize("repeat_batches", [2])
+def test_demo(repeat_batches):
     """
     Stress test the DeepSeek v3 demo with prompts loaded from JSON file, 2x runs.
     Uses only 5 layers (override_num_layers=5) for faster CI execution.
-    Regenerates cache if outdated.
     """
     # Path to the external JSON file containing prompts
     json_path = "models/demos/deepseek_v3/demo/test_prompts.json"
@@ -25,7 +25,6 @@ def test_demo():
     prompts = load_prompts_from_json(json_path, max_prompts=56)
 
     # Run demo with only 5 layers for faster CI execution
-    # force_recalculate_cache=True will regenerate the cache if outdated
     results = run_demo(
         prompts=prompts,
         model_path=MODEL_PATH,
@@ -33,12 +32,8 @@ def test_demo():
         random_weights=False,
         max_new_tokens=128,
         override_num_layers=5,
-        repeat_batches=2,
-        force_recalculate_cache=True,
+        repeat_batches=repeat_batches,
     )
 
     # Check output
     assert len(results["generations"][0]["tokens"]) == 128
-
-if __name__ == "__main__":
-    test_demo()

--- a/models/demos/deepseek_v3/tt/generator.py
+++ b/models/demos/deepseek_v3/tt/generator.py
@@ -85,6 +85,7 @@ class DeepseekGenerator:
         enable_trace: bool = False,
         signpost: bool = False,
         prefill_max_tokens: int | None = None,
+        force_recalculate_cache: bool = False,
     ) -> None:
         self.mesh_device = mesh_device
         self.model_path = str(model_path)
@@ -150,6 +151,7 @@ class DeepseekGenerator:
         self.enable_trace = enable_trace
         self.signpost = signpost
         self.prefill_max_tokens = prefill_max_tokens
+        self.force_recalculate_cache = force_recalculate_cache
         logger.info(f"Enable trace: {self.enable_trace}")
 
         # Initialize rope_setup once
@@ -186,7 +188,7 @@ class DeepseekGenerator:
             hf_config=self.hf_config,
             weight_cache_path=weight_cache_path,
             mesh_device=self.mesh_device,
-            force_recalculate=False,
+            force_recalculate=self.force_recalculate_cache,
             random_weights=self.random_weights,
             model_path=self.model_path,
             single_layer=self.single_layer,


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Currently, if the cache is outdated, you would need to delete the cache and then regenerate it, or else model errors out.

### What's changed
Now, there's added functionality to pass a parameter into model demo, that would force cache. regeneration. Super useful, if cache is outdated, ie. changing model ops / configs. Works for 5 & 61 layer demo.

### Checklist

- [ ] [![(Galaxy) DeepSeek tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-deepseek-tests.yaml/badge.svg?branch=fix/regenerate-deepseek-v3-cache)](https://github.com/tenstorrent/tt-metal/actions/runs/21673719085)
