### PR TITLE
Fix conv2d reader kernel runtime arg mismatch for height-sharded conv

### DIFF
--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_sharded_program_factory.cpp
@@ -1177,16 +1177,15 @@ Conv2dShardedProgramFactory::cached_program_t Conv2dShardedProgramFactory::creat
         uint32_t core_index = 0;
         for (const CoreRange& core_range : input_cores.ranges()) {
             for (const CoreCoord& core : core_range) {
-                std::vector<uint32_t> reader_rt_args{core_index};
+                uint32_t reader_remaining_tiles_to_push = 0;
                 if (enable_activation_reuse) {
-                    uint32_t reader_remaining_tiles_to_push = 0;
                     if (activation_reuse_config.has_partial_core && core == activation_reuse_config.partial_work_core) {
                         reader_remaining_tiles_to_push = activation_reuse_config.partial_core_reader_tiles_to_push;
                     } else if (activation_reuse_config.cores_with_non_meaningful_work.contains(core)) {
                         reader_remaining_tiles_to_push = act_block_h_nsubblocks_split;
                     }
-                    reader_rt_args.push_back(reader_remaining_tiles_to_push);
                 }
+                std::vector<uint32_t> reader_rt_args{core_index, reader_remaining_tiles_to_push};
                 SetRuntimeArgs(program, reader_id, core, reader_rt_args);
                 core_index++;
             }


### PR DESCRIPTION
### Ticket
#29531

### Problem description
The reader kernel (reader_conv_activations_padded_with_halo_3x3_weights_v2) always reads remaining_tiles_to_push as a runtime argument, but the host code only provided this argument when enable_activation_reuse was true. This caused a runtime arg out-of-bounds access detected by the watcher.

This was a regression from a commit that cleaned up ifdefs from kernels: https://github.com/tenstorrent/tt-metal/commit/ae5830b9ae50fa3b1c4fc173f6056fdb2077e954

### What's changed
Always pass remaining_tiles_to_push (defaulting to 0 when activation reuse is disabled) to match the kernel's expectations.


### CI

APC: https://github.com/tenstorrent/tt-metal/actions/runs/21674877248 ✅ 
Nightly L2: https://github.com/tenstorrent/tt-metal/actions/runs/21674858284 ✅ 
