### PR TITLE
issue 36707 - concat of ND sharded tensors

### DIFF
--- a/tests/ttnn/unit_tests/operations/data_movement/test_concat.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_concat.py
@@ -430,22 +430,22 @@ def test_nd_sharded_concat(device, num_tensors, tensor_shape, shard_shape, conca
     # Compute output shard shape (adjust for concat dimension): same grid and layout as inputs,
     # output shard shape = sum of input shard shapes along concat_dim (mirrors device op logic).
     # TODO:Z ? should we calculate output_shard_shape in the python - or should force it in C++ code?
-    input_mem_config = ttnn_tensors[0].memory_config()
-    input_nd_spec = input_mem_config.nd_shard_spec
-    output_shard_shape = list(input_nd_spec.shard_shape)
-    output_shard_shape[concat_dim] = 0
-    for tt_t in ttnn_tensors:
-        output_shard_shape[concat_dim] += tt_t.memory_config().nd_shard_spec.shard_shape[concat_dim]
-    output_nd_shard_spec = ttnn.NdShardSpec(
-        output_shard_shape,
-        input_nd_spec.grid,
-        orientation=input_nd_spec.orientation,
-        shard_distribution_strategy=input_nd_spec.shard_distribution_strategy,
-    )
-    output_memory_config = ttnn.MemoryConfig(input_mem_config.buffer_type, output_nd_shard_spec)
+    # input_mem_config = ttnn_tensors[0].memory_config()
+    # input_nd_spec = input_mem_config.nd_shard_spec
+    # output_shard_shape = list(input_nd_spec.shard_shape)
+    # output_shard_shape[concat_dim] = 0
+    # for tt_t in ttnn_tensors:
+    #     output_shard_shape[concat_dim] += tt_t.memory_config().nd_shard_spec.shard_shape[concat_dim]
+    # output_nd_shard_spec = ttnn.NdShardSpec(
+    #     output_shard_shape,
+    #     input_nd_spec.grid,
+    #     orientation=input_nd_spec.orientation,
+    #     shard_distribution_strategy=input_nd_spec.shard_distribution_strategy,
+    # )
+    # output_memory_config = ttnn.MemoryConfig(input_mem_config.buffer_type, output_nd_shard_spec)
 
     print("\nright before concat\n")
-    ttnn_output = ttnn.concat(ttnn_tensors, dim=concat_dim, memory_config=output_memory_config)
+    ttnn_output = ttnn.concat(ttnn_tensors, dim=concat_dim)  # , memory_config=output_memory_config)
 
     # Convert back to torch and compare
     actual_output = ttnn.to_torch(ttnn_output)

--- a/tests/ttnn/unit_tests/operations/data_movement/test_concat.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_concat.py
@@ -388,19 +388,16 @@ def test_nd_sharded_concat(device, num_tensors, tensor_shape, shard_shape, conca
     for 2, 3, and 4 input tensors across different concat dimensions.
     """
     torch.manual_seed(0)
-    print("\n\nodin\n\n")
 
     # Skip incompatible configurations
     if dtype == ttnn.bfloat8_b and layout == ttnn.ROW_MAJOR_LAYOUT:
         pytest.skip("bfloat8_b is only valid for TILE_LAYOUT")
-    print("\n\ndwa\n\n")
 
     # Setup grid
     grid_size = device.compute_with_storage_grid_size()
     core_range = ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(grid_size.x - 1, grid_size.y - 1))
     grid = ttnn.CoreRangeSet([core_range])  # TODOZ: to discuss/test partial core range set
 
-    print("\n\ntri\n\n")
     # Create ND shard spec for input tensors
     input_nd_shard_spec = ttnn.NdShardSpec(shard_shape, grid)
     input_memory_config = ttnn.MemoryConfig(ttnn.BufferType.L1, input_nd_shard_spec)
@@ -438,8 +435,8 @@ def test_nd_sharded_concat(device, num_tensors, tensor_shape, shard_shape, conca
     # For concat dim, the output shard shape might need adjustment based on memory layout
     # For simplicity, keep same shard shape and let output be interleaved
 
-    # Perform concat - output to DRAM (interleaved) since ND sharded output may not be supported yet
-    output_memory_config = ttnn.DRAM_MEMORY_CONFIG
+    # usage of ND sharded tensors supposes only L1_BLOCK_SHARDED_MEMORY_CONFIG memory config
+    output_memory_config = ttnn.L1_BLOCK_SHARDED_MEMORY_CONFIG
 
     ttnn_output = ttnn.concat(ttnn_tensors, dim=concat_dim, memory_config=output_memory_config)
 

--- a/tests/ttnn/unit_tests/operations/data_movement/test_concat.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_concat.py
@@ -368,12 +368,12 @@ def test_concat_1d(device, layout, dim, input_shapes):
         #        (2, [3, 4, 5], [1, 1, 5], 0, ttnn.ROW_MAJOR_LAYOUT),   # RM concat on batch
         #        (2, [3, 4, 5], [3, 1, 5], 1, ttnn.ROW_MAJOR_LAYOUT),   # RM concat on height
         # 3 tensors - ND sharding concat
-        (3, [2, 64, 64], [1, 32, 32], 0, ttnn.TILE_LAYOUT),  # concat 3 tensors on batch
+        #        (3, [2, 64, 64], [1, 32, 32], 0, ttnn.TILE_LAYOUT),  # concat 3 tensors on batch
         #        (3, [2, 64, 64], [2, 32, 32], 1, ttnn.TILE_LAYOUT),    # concat 3 tensors on height
         #        (3, [2, 64, 64], [2, 64, 32], 2, ttnn.TILE_LAYOUT),    # concat 3 tensors on width
         #        (3, [2, 4, 8], [1, 4, 8], 0, ttnn.ROW_MAJOR_LAYOUT),   # RM concat 3 tensors
         # 4 tensors - ND sharding concat
-        (4, [1, 64, 64], [1, 32, 32], 1, ttnn.TILE_LAYOUT),  # concat 4 tensors on height
+        #        (4, [1, 64, 64], [1, 32, 32], 1, ttnn.TILE_LAYOUT),  # concat 4 tensors on height
         #        (4, [1, 64, 64], [1, 64, 32], 2, ttnn.TILE_LAYOUT),    # concat 4 tensors on width
         #        (4, [2, 32, 32], [1, 32, 32], 0, ttnn.TILE_LAYOUT),    # concat 4 tensors on batch
         #        (4, [2, 4, 8], [2, 4, 8], 0, ttnn.ROW_MAJOR_LAYOUT),   # RM concat 4 tensors on batch
@@ -402,11 +402,9 @@ def test_nd_sharded_concat(device, num_tensors, tensor_shape, shard_shape, conca
     input_nd_shard_spec = ttnn.NdShardSpec(shard_shape, grid)
     input_memory_config = ttnn.MemoryConfig(ttnn.BufferType.L1, input_nd_shard_spec)
 
-    print("\n\n4etire\n\n")
     # Generate input tensors
     torch_tensors = [torch.rand(tensor_shape, dtype=torch.bfloat16) for _ in range(num_tensors)]
 
-    print("\n\npat\n\n")
     # Expected output from PyTorch
     torch_output = torch.concat(torch_tensors, dim=concat_dim)
 
@@ -438,6 +436,7 @@ def test_nd_sharded_concat(device, num_tensors, tensor_shape, shard_shape, conca
     # usage of ND sharded tensors supposes only L1_BLOCK_SHARDED_MEMORY_CONFIG memory config
     output_memory_config = ttnn.L1_BLOCK_SHARDED_MEMORY_CONFIG
 
+    print("\n\nright before concat\n\n")
     ttnn_output = ttnn.concat(ttnn_tensors, dim=concat_dim, memory_config=output_memory_config)
 
     # Convert back to torch and compare

--- a/tests/ttnn/unit_tests/operations/data_movement/test_concat.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_concat.py
@@ -352,3 +352,131 @@ def test_concat_1d(device, layout, dim, input_shapes):
     output = ttnn.to_torch(output)
 
     assert_equal(torch_output_tensor, output)
+
+
+# DN sharded
+@pytest.mark.parametrize(
+    "num_tensors, tensor_shape, shard_shape, concat_dim, layout",
+    [
+        # 2 tensors - basic ND sharding concat
+        (2, [3, 128, 160], [1, 32, 32], 0, ttnn.TILE_LAYOUT),  # concat on batch dim
+        #        (2, [3, 128, 160], [3, 32, 32], 1, ttnn.TILE_LAYOUT),  # concat on height dim
+        #        (2, [3, 128, 160], [3, 128, 32], 2, ttnn.TILE_LAYOUT),  # concat on width dim
+        #        (2, [3, 4, 5], [1, 1, 5], 0, ttnn.ROW_MAJOR_LAYOUT),   # RM concat on batch
+        #        (2, [3, 4, 5], [3, 1, 5], 1, ttnn.ROW_MAJOR_LAYOUT),   # RM concat on height
+        # 3 tensors - ND sharding concat
+        (3, [2, 64, 64], [1, 32, 32], 0, ttnn.TILE_LAYOUT),  # concat 3 tensors on batch
+        #        (3, [2, 64, 64], [2, 32, 32], 1, ttnn.TILE_LAYOUT),    # concat 3 tensors on height
+        #        (3, [2, 64, 64], [2, 64, 32], 2, ttnn.TILE_LAYOUT),    # concat 3 tensors on width
+        #        (3, [2, 4, 8], [1, 4, 8], 0, ttnn.ROW_MAJOR_LAYOUT),   # RM concat 3 tensors
+        # 4 tensors - ND sharding concat
+        (4, [1, 64, 64], [1, 32, 32], 1, ttnn.TILE_LAYOUT),  # concat 4 tensors on height
+        #        (4, [1, 64, 64], [1, 64, 32], 2, ttnn.TILE_LAYOUT),    # concat 4 tensors on width
+        #        (4, [2, 32, 32], [1, 32, 32], 0, ttnn.TILE_LAYOUT),    # concat 4 tensors on batch
+        #        (4, [2, 4, 8], [2, 4, 8], 0, ttnn.ROW_MAJOR_LAYOUT),   # RM concat 4 tensors on batch
+    ],
+)
+@pytest.mark.parametrize("dtype", [ttnn.bfloat16, ttnn.float32])
+def test_nd_sharded_concat(device, num_tensors, tensor_shape, shard_shape, concat_dim, layout, dtype):
+    """
+    Test concat operation with ND sharded tensors.
+
+    This test verifies that concat works correctly with N-dimensional sharding
+    for 2, 3, and 4 input tensors across different concat dimensions.
+    """
+    torch.manual_seed(0)
+    print("\n\nodin\n\n")
+
+    # Skip incompatible configurations
+    if dtype == ttnn.bfloat8_b and layout == ttnn.ROW_MAJOR_LAYOUT:
+        pytest.skip("bfloat8_b is only valid for TILE_LAYOUT")
+    print("\n\ndwa\n\n")
+
+    # Setup grid
+    grid_size = device.compute_with_storage_grid_size()
+    core_range = ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(grid_size.x - 1, grid_size.y - 1))
+    grid = ttnn.CoreRangeSet([core_range])  # TODOZ: to discuss/test partial core range set
+
+    print("\n\ntri\n\n")
+    # Create ND shard spec for input tensors
+    input_nd_shard_spec = ttnn.NdShardSpec(shard_shape, grid)
+    input_memory_config = ttnn.MemoryConfig(ttnn.BufferType.L1, input_nd_shard_spec)
+
+    print("\n\n4etire\n\n")
+    # Generate input tensors
+    torch_tensors = [torch.rand(tensor_shape, dtype=torch.bfloat16) for _ in range(num_tensors)]
+
+    print("\n\npat\n\n")
+    # Expected output from PyTorch
+    torch_output = torch.concat(torch_tensors, dim=concat_dim)
+
+    # Create TTNN tensors with ND sharding
+    ttnn_tensors = [
+        ttnn.from_torch(t, dtype=dtype, device=device, layout=layout, memory_config=input_memory_config)
+        for t in torch_tensors
+    ]
+    print("\n\ntensors have been created\n\n")
+
+    # Verify tensors have ND sharding
+    for tt_tensor in ttnn_tensors:
+        assert tt_tensor.memory_config().is_sharded(), "Input tensor should be sharded"
+
+    # Compute output shard shape (adjust for concat dimension)
+    output_shape = list(tensor_shape)
+    output_shape[concat_dim] *= num_tensors
+    output_shard_shape = list(shard_shape)
+    # For concat dim, the output shard shape might need adjustment based on memory layout
+    # For simplicity, keep same shard shape and let output be interleaved
+
+    # Perform concat - output to DRAM (interleaved) since ND sharded output may not be supported yet
+    output_memory_config = ttnn.DRAM_MEMORY_CONFIG
+
+    ttnn_output = ttnn.concat(ttnn_tensors, dim=concat_dim, memory_config=output_memory_config)
+
+    # Convert back to torch and compare
+    actual_output = ttnn.to_torch(ttnn_output)
+
+    assert_with_pcc(torch_output, actual_output, 0.999)
+
+
+# @pytest.mark.parametrize(
+#     "tensor_shapes, shard_shapes, concat_dim",
+#     [
+#         # Different sized tensors (same shard shape where applicable)
+#         ([(2, 64, 64), (3, 64, 64)], [(1, 32, 32), (1, 32, 32)], 0),  # Different batch sizes
+#         ([(2, 64, 64), (2, 96, 64)], [(2, 32, 32), (2, 32, 32)], 1),  # Different heights
+#         ([(2, 64, 64), (2, 64, 96)], [(2, 64, 32), (2, 64, 32)], 2),  # Different widths
+#     ],
+# )
+# @pytest.mark.parametrize("dtype", [ttnn.bfloat16])
+# def test_nd_sharded_concat_different_sizes(device, tensor_shapes, shard_shapes, concat_dim, dtype):
+#     """
+#     Test concat with ND sharded tensors of different sizes along concat dimension.
+#     """
+#     torch.manual_seed(0)
+
+#     # Setup grid
+#     grid_size = device.compute_with_storage_grid_size()
+#     core_range = ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(grid_size.x - 1, grid_size.y - 1))
+#     grid = ttnn.CoreRangeSet([core_range])
+
+#     # Generate input tensors with different shapes
+#     torch_tensors = [torch.rand(shape, dtype=torch.bfloat16) for shape in tensor_shapes]
+#     torch_output = torch.concat(torch_tensors, dim=concat_dim)
+
+#     # Create TTNN tensors with ND sharding
+#     ttnn_tensors = []
+#     for torch_tensor, shard_shape in zip(torch_tensors, shard_shapes):
+#         nd_shard_spec = ttnn.NdShardSpec(shard_shape, grid)
+#         memory_config = ttnn.MemoryConfig(ttnn.BufferType.L1, nd_shard_spec)
+#         tt_tensor = ttnn.from_torch(
+#             torch_tensor, dtype=dtype, device=device,
+#             layout=ttnn.TILE_LAYOUT, memory_config=memory_config
+#         )
+#         ttnn_tensors.append(tt_tensor)
+
+#     # Concat with interleaved output
+#     ttnn_output = ttnn.concat(ttnn_tensors, dim=concat_dim, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+#     actual_output = ttnn.to_torch(ttnn_output)
+
+#     assert_with_pcc(torch_output, actual_output, 0.999)

--- a/ttnn/api/ttnn/device_operation.hpp
+++ b/ttnn/api/ttnn/device_operation.hpp
@@ -283,9 +283,12 @@ void create_and_cache_mesh_workload(
     ttnn::MeshDevice* mesh_device,
     tt::tt_metal::program_cache::detail::ProgramCache& program_cache,
     tt::stl::hash::hash_t program_hash) {
+    std::cout << "create_and_cache_mesh_workload 01\n";
     mesh_device_operation_t::validate_on_program_cache_miss(operation_attributes, tensor_args);
+    std::cout << "create_and_cache_mesh_workload 02\n";
 
     auto program_factory = mesh_device_operation_t::select_program_factory(operation_attributes, tensor_args);
+    std::cout << "create_and_cache_mesh_workload 03\n";
     auto program_factory_index = program_factory.index();
     auto log_msg_func = [] {
         log_warning(
@@ -364,9 +367,11 @@ void launch_operation_with_adapter(
     tt::stl::reflection::visit_object_of_type<Tensor>(CheckDeviceBufferIsAllocated{}, tensor_args);
 
     if (program_cache_hit) {
+        std::cout << "launch_operation_with_adapter 05\n";
         handle_mesh_adapter_cache_hit<mesh_device_operation_t>(
             operation_attributes, tensor_args, tensor_return_value, mesh_device, program_cache, program_hash);
     } else {
+        std::cout << "launch_operation_with_adapter 06\n";
         create_and_cache_mesh_workload<mesh_device_operation_t>(
             operation_attributes, tensor_args, tensor_return_value, mesh_device, program_cache, program_hash);
     }
@@ -527,7 +532,6 @@ typename device_operation_t::tensor_return_value_t launch(
     std::vector<std::reference_wrapper<const Tensor>> input_tensors;
     tt::stl::reflection::visit_object_of_type<Tensor>(
         [&input_tensors](const Tensor& t) { input_tensors.push_back(std::cref(t)); }, tensor_args);
-
     tt::tt_metal::GraphTracker::instance().track_function_start(
         detail::get_operation_name<device_operation_t>(operation_attributes), operation_attributes, input_tensors);
 
@@ -586,10 +590,12 @@ typename device_operation_t::tensor_return_value_t launch(
         }
     }
 
+    std::cout << "lavanch 08\n";
     detail::launch_operation_with_adapter<MeshDeviceOperationAdapter<device_operation_t>>(
         operation_attributes, tensor_args, tensor_return_value, mesh_device);
 
     tt::tt_metal::GraphTracker::instance().track_function_end(tensor_return_value);
+    std::cout << "lavanch 09\n";
     return tensor_return_value;
 }
 

--- a/ttnn/cpp/ttnn/operations/data_movement/CMakeLists.txt
+++ b/ttnn/cpp/ttnn/operations/data_movement/CMakeLists.txt
@@ -118,6 +118,7 @@ target_sources(
         concat/device/concat_s2s_rm_program_factory.cpp
         concat/device/concat_s2s_multi_program_factory.cpp
         concat/device/concat_s2i_program_factory.cpp
+        concat/device/concat_nd_sharded_program_factory.cpp
         copy/copy.cpp
         copy/device/copy_device_operation.cpp
         copy/device/copy_program_factory.cpp

--- a/ttnn/cpp/ttnn/operations/data_movement/concat/concat.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/concat/concat.cpp
@@ -333,9 +333,8 @@ ttnn::Tensor ConcatOperation::invoke(
         untilize_rm_retilize_concat.sequence(unsqueeze_squeeze_1D_concat.sequence(non_aligned_last_dim_concat));
 
     const std::vector<ttnn::Tensor>& itensors(input_tensors);
-    std::cout << "ConcatOperation::invoke: I have got here 6\n";
     auto res = massaged_concat(itensors, dim, groups);
-    std::cout << "ConcatOperation::invoke: I have got here 7\n";
+    std::cout << "ConcatOperation::invoke: leaving - Yau\n";
     return res;
 }
 

--- a/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_device_operation.cpp
@@ -235,6 +235,15 @@ TensorSpec ConcatDeviceOperation::compute_output_specs(
             first_spec.orientation,
             first_spec.shard_distribution_strategy);
         const MemoryConfig output_mem_config(ref_in_tensor.memory_config().buffer_type(), std::move(output_nd_spec));
+
+        // ensure correct memory config
+        // TODO: - to clarify: by overwriting const object (to sort out - where args.output_mem_config could be
+        // established correctly?)
+        if (args.output_mem_config == ttnn::DRAM_MEMORY_CONFIG ||   // default if it came empty
+            !args.output_mem_config.nd_shard_spec().has_value()) {  // output for nd sharding should be the same
+            std::cout << "ensure correct memory config\n";
+            const_cast<MemoryConfig&>(args.output_mem_config) = output_mem_config;
+        }
         return TensorSpec(
             shape_out, TensorLayout(ref_in_tensor.dtype(), PageConfig(ref_in_tensor.layout()), output_mem_config));
     }

--- a/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_device_operation.cpp
@@ -5,6 +5,7 @@
 #include "concat_device_operation.hpp"
 #include "ttnn/device_operation.hpp"
 #include "concat_program_factory.hpp"
+#include "concat_nd_sharded_program_factory.hpp"
 
 #include "ttnn/tensor/tensor.hpp"
 #include "ttnn/operations/data_movement/clone/clone.hpp"
@@ -37,9 +38,8 @@ ConcatDeviceOperation::program_factory_t ConcatDeviceOperation::select_program_f
 
     if (output_is_sharded) {
         if (const auto& first_nd_shard_spec = input_tensors[0].nd_shard_spec(); first_nd_shard_spec.has_value()) {
-            std::cout << "~~~~~~~~~~~~~~~~~~~~~~~~~~\n";
-            TT_FATAL(!first_nd_shard_spec.has_value(), "expected string");
-            return ConcatS2IProgramFactory{};
+            std::cout << "ConcatNDShardedProgramFactory\n~~~~~~~~~~~~~~~~~~~~~~~~~~\n";
+            return ConcatNDShardedProgramFactory{};
         } else
             // Sharded-to-sharded (s2s) cases
             if (input_tensors.size() == 2) {

--- a/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_device_operation.cpp
@@ -239,10 +239,11 @@ TensorSpec ConcatDeviceOperation::compute_output_specs(
         // ensure correct memory config
         // TODO: - to clarify: by overwriting const object (to sort out - where args.output_mem_config could be
         // established correctly?)
+        // TODO: as a guess some constness need to be reworked
         if (args.output_mem_config == ttnn::DRAM_MEMORY_CONFIG ||   // default if it came empty
             !args.output_mem_config.nd_shard_spec().has_value()) {  // output for nd sharding should be the same
             std::cout << "ensure correct memory config\n";
-            const_cast<MemoryConfig&>(args.output_mem_config) = output_mem_config;
+            const_cast<decltype(args.output_mem_config)&>(args.output_mem_config) = output_mem_config;
         }
         return TensorSpec(
             shape_out, TensorLayout(ref_in_tensor.dtype(), PageConfig(ref_in_tensor.layout()), output_mem_config));

--- a/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_device_operation.cpp
@@ -100,6 +100,9 @@ void ConcatDeviceOperation::validate_on_program_cache_miss(
                 TT_FATAL(
                     in_ref.nd_shard_spec().value().grid == first_nd_shard_spec.value().grid,
                     "ND Sharded tensors must have the same grid.");
+                TT_FATAL(
+                    in_ref.memory_config().memory_layout() == TensorMemoryLayout::BLOCK_SHARDED,
+                    "Block sharded inputs necessary for ND sharded tensors");
 
                 // Verify that shard shapes differ only in the concat dimension
                 const auto& first_shard_shape = first_nd_shard_spec.value().shard_shape;
@@ -134,7 +137,11 @@ void ConcatDeviceOperation::validate_on_program_cache_miss(
                 TT_FATAL(
                     in_ref.shard_spec().value().grid == first_input.shard_spec().value().grid,
                     "Sharded tensors must have the same grid.");
+                TT_FATAL(
+                    in_ref.memory_config().memory_layout() != TensorMemoryLayout::BLOCK_SHARDED,
+                    "Block sharded inputs are not supported");
             }
+
             TT_FATAL(
                 in_ref.memory_config().memory_layout() == first_input.memory_config().memory_layout(),
                 "Sharded tensors must have the same memory layout.");
@@ -142,10 +149,6 @@ void ConcatDeviceOperation::validate_on_program_cache_miss(
             TT_FATAL(
                 input_tensors.size() > 2 || in_ref.memory_config().memory_layout() != TensorMemoryLayout::WIDTH_SHARDED,
                 "Width sharded inputs are not supported for two tensors concat yet");
-            // TODO:Z Next TT_FATAL - to bypass
-            TT_FATAL(
-                in_ref.memory_config().memory_layout() != TensorMemoryLayout::BLOCK_SHARDED,
-                "Block sharded inputs are not supported");
         }
     }
     if (warn_about_alignment) {

--- a/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_device_operation.cpp
@@ -93,10 +93,20 @@ void ConcatDeviceOperation::validate_on_program_cache_miss(
         TT_FATAL(curr_shape == shape_first, "concat tensors differ in shape across non-concat dimensions.");
         TT_FATAL(in_ref.is_sharded() == shard_first, "All tensors must be sharded or all must be interleaved");
         if (shard_first) {
-            TT_FATAL(in_ref.shard_spec().has_value(), "Sharded tensors must have a shard spec.");
-            TT_FATAL(
-                in_ref.shard_spec().value().grid == first_input.shard_spec().value().grid,
-                "Sharded tensors must have the same grid.");
+            if (first_input.nd_shard_spec().has_value()) {
+                TT_FATAL(in_ref.nd_shard_spec().has_value(), "ND Sharded tensors must have a shard spec.");
+
+                // TODO:Z add nd sharding verification possibility here
+                //  need to be different at the same dimention
+                TT_FATAL(
+                    in_ref.nd_shard_spec().value().grid == first_input.nd_shard_spec().value().grid,
+                    "ND Sharded tensors must have the same grid.");
+            } else {
+                TT_FATAL(in_ref.shard_spec().has_value(), "Sharded tensors must have a shard spec.");
+                TT_FATAL(
+                    in_ref.shard_spec().value().grid == first_input.shard_spec().value().grid,
+                    "Sharded tensors must have the same grid.");
+            }
             TT_FATAL(
                 in_ref.memory_config().memory_layout() == first_input.memory_config().memory_layout(),
                 "Sharded tensors must have the same memory layout.");

--- a/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_device_operation.hpp
@@ -12,6 +12,7 @@
 #include "concat_s2s_rm_program_factory.hpp"
 #include "concat_s2s_multi_program_factory.hpp"
 #include "concat_s2i_program_factory.hpp"
+#include "concat_nd_sharded_program_factory.hpp"
 
 #include "ttnn/decorators.hpp"
 
@@ -29,7 +30,8 @@ struct ConcatDeviceOperation {
         ConcatS2STiledProgramFactory,
         ConcatS2SRMProgramFactory,
         ConcatS2SMultiProgramFactory,
-        ConcatS2IProgramFactory>;
+        ConcatS2IProgramFactory,
+        ConcatNDShardedProgramFactory>;
 
     static program_factory_t select_program_factory(const operation_attributes_t&, const tensor_args_t&);
 

--- a/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_nd_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_nd_sharded_program_factory.cpp
@@ -1,0 +1,178 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "concat_nd_sharded_program_factory.hpp"
+
+#include <algorithm>
+#include <numeric>
+
+#include "ttnn/tensor/tensor.hpp"
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/constants.hpp>
+#include <tt-metalium/buffer_distribution_spec.hpp>
+
+namespace ttnn::prim {
+
+namespace {
+
+// Returns the index of `core` in `cores` vector, or cores.size() if not found.
+size_t find_core_index(const CoreCoord& core, const std::vector<CoreCoord>& cores) {
+    auto it = std::find(cores.begin(), cores.end(), core);
+    return static_cast<size_t>(it - cores.begin());
+}
+
+}  // namespace
+
+// Creates the device program for ND sharded concat: one program with reader and writer kernels
+// that copy each core's input shards (in concat order) into the output shard. Reader and writer
+// split the input range so both RISC-V processors can run in parallel.
+ConcatNDShardedProgramFactory::cached_program_t ConcatNDShardedProgramFactory::create(
+    const ConcatParams& /*operation_attributes*/, const ConcatInputs& tensor_args, Tensor& tensor_return_value) {
+    using namespace tt::constants;
+    using namespace tt::tt_metal;
+
+    const auto& input_tensors = tensor_args.input_tensors;
+    Tensor& output = tensor_return_value;
+    const uint32_t num_input_tensors = static_cast<uint32_t>(input_tensors.size());
+
+    TT_FATAL(!input_tensors.empty(), "ND sharded concat requires at least one input");
+    TT_FATAL(input_tensors[0].nd_shard_spec().has_value(), "First input must be ND sharded");
+    TT_FATAL(output.nd_shard_spec().has_value(), "Output must be ND sharded");
+
+    const auto& first_nd_spec = input_tensors[0].nd_shard_spec().value();
+    const CoreRangeSet all_cores = first_nd_spec.grid;
+    const ShardOrientation orientation = first_nd_spec.orientation;
+    const bool is_row_major = (orientation == ShardOrientation::ROW_MAJOR);
+
+    // Core list order must match the order used by each buffer's distribution spec for correct core_idx.
+    std::vector<CoreCoord> cores = corerange_to_cores(all_cores, std::nullopt, is_row_major);
+
+    Program program = CreateProgram();
+
+    // All inputs and output share the same grid; use first input's buffer for alignment/page size.
+    const uint32_t page_size = input_tensors[0].buffer()->aligned_page_size();
+    const tt::DataFormat cb_data_format = datatype_to_dataformat_converter(output.dtype());
+    const uint32_t cb_dst_id = 16;
+    TT_FATAL(num_input_tensors <= cb_dst_id, "ND sharded concat supports at most {} inputs", cb_dst_id);
+
+    // Distribution specs from buffers (already set when tensors are allocated with ND sharding).
+    std::vector<const BufferDistributionSpec*> input_dist_specs(num_input_tensors);
+    for (uint32_t i = 0; i < num_input_tensors; ++i) {
+        TT_FATAL(
+            input_tensors[i].buffer()->buffer_distribution_spec().has_value(),
+            "ND sharded input {} must have buffer distribution spec",
+            i);
+        input_dist_specs[i] = &input_tensors[i].buffer()->buffer_distribution_spec().value();
+    }
+    TT_FATAL(
+        output.buffer()->buffer_distribution_spec().has_value(),
+        "ND sharded output must have buffer distribution spec");
+    const BufferDistributionSpec& output_dist_spec = output.buffer()->buffer_distribution_spec().value();
+
+    // Input CBs: each backed by the corresponding input buffer so each core sees only its shard.
+    std::vector<CBHandle> cb_inputs(num_input_tensors);
+    for (uint32_t input_id = 0; input_id < num_input_tensors; ++input_id) {
+        const BufferDistributionSpec& spec = *input_dist_specs[input_id];
+        uint32_t max_pages = static_cast<uint32_t>(spec.max_num_dev_pages_per_core());
+        const CircularBufferConfig input_cb_config =
+            CircularBufferConfig(page_size * max_pages, {{input_id, cb_data_format}})
+                .set_page_size(input_id, page_size)
+                .set_globally_allocated_address(*input_tensors[input_id].buffer());
+        cb_inputs[input_id] = CreateCircularBuffer(program, all_cores, input_cb_config);
+    }
+
+    // Output CB: backed by output buffer; each core writes its output shard.
+    uint32_t output_max_pages = static_cast<uint32_t>(output_dist_spec.max_num_dev_pages_per_core());
+    const CircularBufferConfig output_cb_config =
+        CircularBufferConfig(page_size * output_max_pages, {{cb_dst_id, cb_data_format}})
+            .set_page_size(cb_dst_id, page_size)
+            .set_globally_allocated_address(*output.buffer());
+    CBHandle cb_output = CreateCircularBuffer(program, all_cores, output_cb_config);
+
+    // Compile-time args for reader/writer: output CB id, page size, number of inputs.
+    std::vector<uint32_t> compile_time_args = {cb_dst_id, page_size, num_input_tensors};
+
+    // Reader: reads from input CBs (in concat order) and writes into output CB.
+    // Writer: same kernel, different runtime args to split work (first half of inputs vs second half).
+    KernelHandle reader_kernel_id = CreateKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/data_movement/concat/device/kernels/dataflow/reader_concat_nd_sharded.cpp",
+        all_cores,
+        ReaderDataMovementConfig(compile_time_args));
+
+    KernelHandle writer_kernel_id = CreateKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/data_movement/concat/device/kernels/dataflow/writer_concat_nd_sharded.cpp",
+        all_cores,
+        WriterDataMovementConfig(compile_time_args));
+
+    // Per-core runtime args: [start_input_id, end_input_id, (num_pages, write_offset_in_pages) for each input in
+    // [start,end)). Reader handles inputs [0, mid), writer handles [mid, num_input_tensors).
+    const uint32_t mid = (num_input_tensors + 1) / 2;
+
+    for (const CoreCoord& core : cores) {
+        const size_t core_idx = find_core_index(core, output_dist_spec.cores());
+        if (core_idx >= output_dist_spec.num_cores()) {
+            continue;
+        }
+
+        uint32_t output_write_offset_pages = 0;
+        std::vector<uint32_t> input_num_pages(num_input_tensors);
+        std::vector<uint32_t> input_write_offsets_pages(num_input_tensors);
+
+        for (uint32_t input_id = 0; input_id < num_input_tensors; ++input_id) {
+            const BufferDistributionSpec& in_spec = *input_dist_specs[input_id];
+            const size_t in_core_idx = find_core_index(core, in_spec.cores());
+            const uint32_t num_pages = (in_core_idx < in_spec.num_cores())
+                                           ? static_cast<uint32_t>(in_spec.num_dev_pages_per_core(in_core_idx))
+                                           : 0;
+            input_num_pages[input_id] = num_pages;
+            input_write_offsets_pages[input_id] = output_write_offset_pages;
+            output_write_offset_pages += num_pages;
+        }
+
+        std::vector<uint32_t> reader_runtime_args = {0u, mid};
+        for (uint32_t input_id = 0; input_id < mid; ++input_id) {
+            reader_runtime_args.push_back(input_num_pages[input_id]);
+            reader_runtime_args.push_back(input_write_offsets_pages[input_id]);
+        }
+        std::vector<uint32_t> writer_runtime_args = {mid, num_input_tensors};
+        for (uint32_t input_id = mid; input_id < num_input_tensors; ++input_id) {
+            writer_runtime_args.push_back(input_num_pages[input_id]);
+            writer_runtime_args.push_back(input_write_offsets_pages[input_id]);
+        }
+
+        SetRuntimeArgs(program, reader_kernel_id, core, reader_runtime_args);
+        SetRuntimeArgs(program, writer_kernel_id, core, writer_runtime_args);
+    }
+
+    return {
+        std::move(program),
+        {.num_input_tensors = num_input_tensors,
+         .cb_inputs = cb_inputs,
+         .cb_output = cb_output,
+         .reader_kernel_id = reader_kernel_id,
+         .writer_kernel_id = writer_kernel_id,
+         .all_cores = all_cores,
+         .cores = cores}};
+}
+
+// Updates buffer addresses in the cached program when the same program is reused with
+// different tensor pointers (e.g. program cache hit with new tensor allocations).
+void ConcatNDShardedProgramFactory::override_runtime_arguments(
+    cached_program_t& cached_program,
+    const ConcatParams& /*operation_attributes*/,
+    const ConcatInputs& tensor_args,
+    Tensor& tensor_return_value) {
+    auto& program = cached_program.program;
+    const auto& shared_vars = cached_program.shared_variables;
+
+    for (uint32_t input_id = 0; input_id < shared_vars.num_input_tensors; ++input_id) {
+        UpdateDynamicCircularBufferAddress(
+            program, shared_vars.cb_inputs[input_id], *tensor_args.input_tensors[input_id].buffer());
+    }
+    UpdateDynamicCircularBufferAddress(program, shared_vars.cb_output, *tensor_return_value.buffer());
+}
+
+}  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_nd_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_nd_sharded_program_factory.cpp
@@ -127,11 +127,15 @@ ConcatNDShardedProgramFactory::cached_program_t ConcatNDShardedProgramFactory::c
     // [start,end)). Reader handles inputs [0, mid), writer handles [mid, num_input_tensors).
     const uint32_t mid = (num_input_tensors + 1) / 2;
 
+    std::cout << "cores amount " << cores.size() << " output cores amount " << output_dist_spec.cores().size() << "\n";
+
+    uint32_t cn = 0;
     for (const CoreCoord& core : cores) {
         const size_t core_idx = find_core_index(core, output_dist_spec.cores());
         if (core_idx >= output_dist_spec.num_cores()) {
             continue;
         }
+        std::cout << "core x :" << ++cn << "\n";
 
         uint32_t output_write_offset_pages = 0;
         std::vector<uint32_t> input_num_pages(num_input_tensors);
@@ -161,7 +165,7 @@ ConcatNDShardedProgramFactory::cached_program_t ConcatNDShardedProgramFactory::c
 
         SetRuntimeArgs(program, reader_kernel_id, core, reader_runtime_args);
         SetRuntimeArgs(program, writer_kernel_id, core, writer_runtime_args);
-    }
+    }  // for cores
 
     return {
         std::move(program),

--- a/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_nd_sharded_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_nd_sharded_program_factory.hpp
@@ -1,0 +1,41 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "concat_device_operation_types.hpp"
+#include "ttnn/device_operation.hpp"
+
+namespace ttnn::prim {
+
+// Shared variables for ND sharded concat (inputs and output are block-sharded with NdShardSpec).
+// Used to update buffer addresses when the same program is reused with different tensor pointers.
+struct ConcatNDShardedSharedVariables {
+    uint32_t num_input_tensors = 0;
+    std::vector<tt::tt_metal::CBHandle> cb_inputs;
+    tt::tt_metal::CBHandle cb_output = 0;
+    tt::tt_metal::KernelHandle reader_kernel_id = 0;
+    tt::tt_metal::KernelHandle writer_kernel_id = 0;
+    CoreRangeSet all_cores;
+    std::vector<CoreCoord> cores;
+};
+
+// Program factory for concat when all input tensors and the output tensor are ND sharded
+// (same grid, block-sharded; shard shapes may differ only along the concat dimension).
+// Each core holds its shard of each input and writes its shard of the output by
+// reading input shards in concat order into a circular buffer, then writing to output.
+struct ConcatNDShardedProgramFactory {
+    using shared_variables_t = ConcatNDShardedSharedVariables;
+    using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
+
+    static cached_program_t create(
+        const ConcatParams& operation_attributes, const ConcatInputs& tensor_args, Tensor& tensor_return_value);
+    static void override_runtime_arguments(
+        cached_program_t& cached_program,
+        const ConcatParams& operation_attributes,
+        const ConcatInputs& tensor_args,
+        Tensor& tensor_return_value);
+};
+
+}  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/concat/device/kernels/dataflow/reader_concat_nd_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/concat/device/kernels/dataflow/reader_concat_nd_sharded.cpp
@@ -32,7 +32,7 @@ void kernel_main() {
     const uint32_t base_l1_write_addr = get_write_ptr(output_cb);
     uint32_t arg_idx = 2;
 
-    for (uint32_t input_id = start_input_id; input_id < end_input_id; input_id++) {
+    for (uint32_t input_id = start_input_id; input_id < end_input_id; ++input_id) {
         const uint32_t num_pages = get_arg_val<uint32_t>(arg_idx++);
         const uint32_t write_offset_pages = get_arg_val<uint32_t>(arg_idx++);
 
@@ -49,7 +49,7 @@ void kernel_main() {
 
         // Copy this input's shard (num_pages pages) into the output region.
         noc_async_read_one_packet_set_state(noc_addr_src, page_size);
-        for (uint32_t page = 0; page < num_pages; page++) {
+        for (uint32_t page = 0; page < num_pages; ++page) {
             noc_async_read_one_packet_with_state<true>(l1_read_addr, l1_write_addr + page * page_size);
             l1_read_addr += page_size;
         }

--- a/ttnn/cpp/ttnn/operations/data_movement/concat/device/kernels/dataflow/reader_concat_nd_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/concat/device/kernels/dataflow/reader_concat_nd_sharded.cpp
@@ -1,0 +1,58 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Reader kernel for ND sharded concat.
+ *
+ * Each core holds a shard of every input and a shard of the output (same grid for all).
+ * This kernel reads from a subset of input CBs in concat order and writes into the output CB.
+ * The host splits work between reader and writer: reader handles inputs [start_input_id, end_input_id)
+ * so that two RISC-V processors can run in parallel (reader on one, writer on the other).
+ *
+ * Compile-time args: [output_cb_id, page_size, num_input_tensors]
+ * Runtime args: [start_input_id, end_input_id, (num_pages, write_offset_pages) for each input in [start, end)]
+ *
+ * Input CBs 0..num_input_tensors-1 are backed by the input buffers (each core sees its shard).
+ * Output data is written to output_cb at byte offset (write_offset_pages * page_size).
+ */
+
+#include <stdint.h>
+
+void kernel_main() {
+    // --- Compile-time: output CB, page size, total number of input tensors ---
+    constexpr uint32_t output_cb = get_compile_time_arg_val(0);
+    constexpr uint32_t page_size = get_compile_time_arg_val(1);
+    constexpr uint32_t num_input_tensors = get_compile_time_arg_val(2);
+
+    // --- Runtime: which input range this kernel instance processes ---
+    const uint32_t start_input_id = get_arg_val<uint32_t>(0);
+    const uint32_t end_input_id = get_arg_val<uint32_t>(1);
+
+    const uint32_t base_l1_write_addr = get_write_ptr(output_cb);
+    uint32_t arg_idx = 2;
+
+    for (uint32_t input_id = start_input_id; input_id < end_input_id; input_id++) {
+        const uint32_t num_pages = get_arg_val<uint32_t>(arg_idx++);
+        const uint32_t write_offset_pages = get_arg_val<uint32_t>(arg_idx++);
+
+        if (num_pages == 0) {
+            continue;
+        }
+
+        // Source: this core's shard of input_id (CB is backed by the input buffer).
+        uint32_t l1_read_addr = get_read_ptr(input_id);
+        const uint64_t noc_addr_src = get_noc_addr(l1_read_addr);
+
+        // Destination: output CB at the offset for this input in concat order.
+        const uint32_t l1_write_addr = base_l1_write_addr + (write_offset_pages * page_size);
+
+        // Copy this input's shard (num_pages pages) into the output region.
+        noc_async_read_one_packet_set_state(noc_addr_src, page_size);
+        for (uint32_t page = 0; page < num_pages; page++) {
+            noc_async_read_one_packet_with_state<true>(l1_read_addr, l1_write_addr + page * page_size);
+            l1_read_addr += page_size;
+        }
+        noc_async_read_barrier();
+    }
+}

--- a/ttnn/cpp/ttnn/operations/data_movement/concat/device/kernels/dataflow/writer_concat_nd_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/concat/device/kernels/dataflow/writer_concat_nd_sharded.cpp
@@ -1,0 +1,53 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Writer kernel for ND sharded concat.
+ *
+ * Same algorithm as reader_concat_nd_sharded: reads from a subset of input CBs in concat order
+ * and writes into the output CB. The host assigns the reader to inputs [0, mid) and the writer
+ * to inputs [mid, num_input_tensors), so both RISC-V processors run in parallel and the
+ * output CB (backed by the output buffer) is filled with the concatenated shard.
+ *
+ * Compile-time args: [output_cb_id, page_size, num_input_tensors]
+ * Runtime args: [start_input_id, end_input_id, (num_pages, write_offset_pages) for each input in [start, end)]
+ *
+ * No separate "read from CB and write to buffer" step: the output CB is the output buffer
+ * (set_globally_allocated_address), so writing to the CB is writing to the final output.
+ */
+
+#include <stdint.h>
+
+void kernel_main() {
+    constexpr uint32_t output_cb = get_compile_time_arg_val(0);
+    constexpr uint32_t page_size = get_compile_time_arg_val(1);
+    constexpr uint32_t num_input_tensors = get_compile_time_arg_val(2);
+
+    const uint32_t start_input_id = get_arg_val<uint32_t>(0);
+    const uint32_t end_input_id = get_arg_val<uint32_t>(1);
+
+    const uint32_t base_l1_write_addr = get_write_ptr(output_cb);
+    uint32_t arg_idx = 2;
+
+    for (uint32_t input_id = start_input_id; input_id < end_input_id; input_id++) {
+        const uint32_t num_pages = get_arg_val<uint32_t>(arg_idx++);
+        const uint32_t write_offset_pages = get_arg_val<uint32_t>(arg_idx++);
+
+        if (num_pages == 0) {
+            continue;
+        }
+
+        uint32_t l1_read_addr = get_read_ptr(input_id);
+        const uint64_t noc_addr_src = get_noc_addr(l1_read_addr);
+
+        const uint32_t l1_write_addr = base_l1_write_addr + (write_offset_pages * page_size);
+
+        noc_async_read_one_packet_set_state(noc_addr_src, page_size);
+        for (uint32_t page = 0; page < num_pages; page++) {
+            noc_async_read_one_packet_with_state<true>(l1_read_addr, l1_write_addr + page * page_size);
+            l1_read_addr += page_size;
+        }
+        noc_async_read_barrier();
+    }
+}

--- a/ttnn/cpp/ttnn/operations/data_movement/concat/device/kernels/dataflow/writer_concat_nd_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/concat/device/kernels/dataflow/writer_concat_nd_sharded.cpp
@@ -30,7 +30,7 @@ void kernel_main() {
     const uint32_t base_l1_write_addr = get_write_ptr(output_cb);
     uint32_t arg_idx = 2;
 
-    for (uint32_t input_id = start_input_id; input_id < end_input_id; input_id++) {
+    for (uint32_t input_id = start_input_id; input_id < end_input_id; ++input_id) {
         const uint32_t num_pages = get_arg_val<uint32_t>(arg_idx++);
         const uint32_t write_offset_pages = get_arg_val<uint32_t>(arg_idx++);
 
@@ -44,7 +44,7 @@ void kernel_main() {
         const uint32_t l1_write_addr = base_l1_write_addr + (write_offset_pages * page_size);
 
         noc_async_read_one_packet_set_state(noc_addr_src, page_size);
-        for (uint32_t page = 0; page < num_pages; page++) {
+        for (uint32_t page = 0; page < num_pages; ++page) {
             noc_async_read_one_packet_with_state<true>(l1_read_addr, l1_write_addr + page * page_size);
             l1_read_addr += page_size;
         }


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/36707

### Problem description
Implement ND sharding support for operation: ttnn::concat

### What's changed
Describe the approach used to solve the problem.
Summarize the changes made and its impact.

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=AlexeyZaytsev-epam/issue/36707/concat_nd_sharding)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:AlexeyZaytsev-epam/issue/36707/concat_nd_sharding)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=AlexeyZaytsev-epam/issue/36707/concat_nd_sharding)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:AlexeyZaytsev-epam/issue/36707/concat_nd_sharding)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=AlexeyZaytsev-epam/issue/36707/concat_nd_sharding)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:AlexeyZaytsev-epam/issue/36707/concat_nd_sharding)
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=AlexeyZaytsev-epam/issue/36707/concat_nd_sharding)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:AlexeyZaytsev-epam/issue/36707/concat_nd_sharding)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=AlexeyZaytsev-epam/issue/36707/concat_nd_sharding)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:AlexeyZaytsev-epam/issue/36707/concat_nd_sharding)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=AlexeyZaytsev-epam/issue/36707/concat_nd_sharding)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:AlexeyZaytsev-epam/issue/36707/concat_nd_sharding)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
