### PR TITLE
Add 32x4 quad BH rankbindings file

### DIFF
--- a/tests/tt_metal/distributed/config/32x4_quad_bh_galaxy_rank_bindings.yaml
+++ b/tests/tt_metal/distributed/config/32x4_quad_bh_galaxy_rank_bindings.yaml
@@ -1,0 +1,18 @@
+rank_bindings:
+  - rank: 0
+    mesh_id: 0
+    mesh_host_rank: 0
+
+  - rank: 1
+    mesh_id: 0
+    mesh_host_rank: 1
+
+  - rank: 2
+    mesh_id: 0
+    mesh_host_rank: 2
+
+  - rank: 3
+    mesh_id: 0
+    mesh_host_rank: 3
+
+mesh_graph_desc_path: "tt_metal/fabric/mesh_graph_descriptors/32x4_quad_bh_galaxy_torus_xy_graph_descriptor.textproto"


### PR DESCRIPTION
### Problem description
There was no 4x32 quad BH rankbindings file.
