### PR TITLE
don't use cache write around when not needed

### DIFF
--- a/tests/tt_metal/tt_metal/test_dm_loopback.cpp
+++ b/tests/tt_metal/tt_metal/test_dm_loopback.cpp
@@ -40,8 +40,8 @@ TEST_F(MeshDeviceSingleCardFixture, DmLoopback) {
     constexpr CoreCoord core = {0, 0};
 
     // These addresses have been randomly chosen
-    uint32_t signal_address = MEM_L1_UNCACHED_BASE + (999 * 1024);
-    uint32_t l1_address = MEM_L1_UNCACHED_BASE + (1000 * 1024);
+    uint32_t signal_address = 999 * 1024;
+    uint32_t l1_address = 1000 * 1024;
     uint32_t dram_address = 30000 * 1024;
     std::vector<uint32_t> value = {0x12345678};
 
@@ -77,12 +77,18 @@ TEST_F(MeshDeviceSingleCardFixture, DmLoopback) {
 
     for (uint32_t i = 0; i < 4; i++) {
         SetRuntimeArgs(
-            program, dm_dram_to_l1_kernels[i], core, {dram_address, l1_address, signal_address, 4, 0, signal[0]});
+            program,
+            dm_dram_to_l1_kernels[i],
+            core,
+            {dram_address, l1_address, MEM_L1_UNCACHED_BASE + signal_address, 4, 0, signal[0]});
         signal[0]++;
         dram_address += 1024;
 
         SetRuntimeArgs(
-            program, dm_l1_to_dram_kernels[i], core, {dram_address, l1_address, signal_address, 4, 0, signal[0]});
+            program,
+            dm_l1_to_dram_kernels[i],
+            core,
+            {dram_address, l1_address, MEM_L1_UNCACHED_BASE + signal_address, 4, 0, signal[0]});
         signal[0]++;
         l1_address += sizeof(uint32_t);
     }


### PR DESCRIPTION
### Ticket
N/A

### Problem description
DM loopback test was using cache bypass addresses when writing from host or using NOC.

### What's changed
Removed the offset to use cache bypass anywhere in the test beside access to the `signal` memory which is used in L1 and read from different cores

### Checklist
- [x] Verified current Quasar tests manually on Emulation and TT-Sim