### PR TITLE
Adding Qwen3-VL vllm support

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -310,8 +310,8 @@ models/demos/t3000 @uaydonat @yieldthought @cglagovichTT @tenstorrent/codeowner-
 models/tt_transformers @cglagovichTT @yieldthought @mtairum @uaydonat @gwangTT @ppetrovicTT @tenstorrent/codeowner-bypass
 models/demos/llama3_70b_galaxy @johanna-rock-tt @kpaigwar @sraizada-tt @djordje-tt @mtairum @yalrawwashTT @alingTT @tenstorrent/codeowner-bypass
 models/tt_transformers/tt/generator*.py @cglagovichTT @yieldthought @mtairum @skhorasganiTT @ppetrovicTT @uaydonat @tenstorrent/codeowner-bypass
-models/demos/qwen25_vl @gwangTT @yieldthought @uaydonat @tenstorrent/codeowner-bypass
-models/demos/qwen3_vl @ssanjayTT @tenstorrent/codeowner-bypass
+models/demos/qwen25_vl @gwangTT @ssanjayTT @yieldthought @uaydonat @tenstorrent/codeowner-bypass
+models/demos/qwen3_vl @ssanjayTT @gwangTT @tenstorrent/codeowner-bypass
 models/demos/falcon7b_common @skhorasganiTT @djordje-tt @uaydonat @tenstorrent/codeowner-bypass
 models/demos/wormhole/mamba @esmalTT @uaydonat @kpaigwar @tenstorrent/codeowner-bypass
 models/demos/wormhole/falcon7b @skhorasganiTT @djordje-tt @uaydonat @tenstorrent/codeowner-bypass

--- a/.github/workflows/vllm-nightly-tests-impl.yaml
+++ b/.github/workflows/vllm-nightly-tests-impl.yaml
@@ -442,7 +442,7 @@ jobs:
       volumes:
         - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
         - /dev/hugepages-1G:/dev/hugepages-1G
-        - ${{ (matrix.test-group.runner-label == 'BH-QB-GE' && '/localdev/blackhole_demos/huggingface_data:/mnt/MLPerf/huggingface:ro') || '/mnt/MLPerf:/mnt/MLPerf:ro' }}
+        - ${{ (matrix.test-group.runner-label == 'BH-QB-GE' && '/localdev/blackhole_demos/huggingface_data:/mnt/MLPerf/huggingface:ro') || '/mnt/MLPerf:/mnt/MLPerf:rw' }}
       options: "--device /dev/tenstorrent"
     defaults:
       run:

--- a/.github/workflows/vllm-nightly-tests-impl.yaml
+++ b/.github/workflows/vllm-nightly-tests-impl.yaml
@@ -72,7 +72,7 @@ jobs:
               "co-owner-1-id": "U07RY6B5FLJ"
             },
             {
-              "name": "[BH-LB] Llama-3.1-8B-Instruct v0 fallback structured-output",
+              "name": "[BH-LB] Llama-3.1-8B-Instruct v0 single-step with sampling-tests",
               "model": "meta-llama/Llama-3.1-8B-Instruct",
               "server-timeout": 35,
               "benchmark-timeout": 10,
@@ -261,7 +261,7 @@ jobs:
               "co-owner-1-id": "U08H31YMN4Q"
             },
             {
-              "name": "[BH-DB][v1] Llama-3.1-8B-Instruct",
+              "name": "[BH-DB][v1] Llama-3.1-8B-Instruct with sampling-tests",
               "model": "meta-llama/Llama-3.1-8B-Instruct",
               "server-timeout": 10,
               "benchmark-timeout": 5,

--- a/.github/workflows/vllm-nightly-tests-impl.yaml
+++ b/.github/workflows/vllm-nightly-tests-impl.yaml
@@ -429,7 +429,7 @@ jobs:
       volumes:
         - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
         - /dev/hugepages-1G:/dev/hugepages-1G
-        - ${{ (matrix.test-group.runner-label == 'BH-QB-GE' && '/localdev/blackhole_demos/huggingface_data:/mnt/MLPerf/huggingface:ro') || '/mnt/MLPerf:/mnt/MLPerf:rw' }}
+        - ${{ (matrix.test-group.runner-label == 'BH-QB-GE' && '/localdev/blackhole_demos/huggingface_data:/mnt/MLPerf/huggingface:ro') || '/mnt/MLPerf:/mnt/MLPerf:ro' }}
       options: "--device /dev/tenstorrent"
     defaults:
       run:

--- a/.github/workflows/vllm-nightly-tests-impl.yaml
+++ b/.github/workflows/vllm-nightly-tests-impl.yaml
@@ -34,7 +34,8 @@ jobs:
         run: |
           # Owner mapping:
           # Pavle Petrovic (U08E1JCDVNX), Salar Hosseini Khorasgani (U08CEGF78ET) - Llama models
-          # Gongyu Wang (U07RY6B5FLJ) - Qwen models
+          # Gongyu Wang (U07RY6B5FLJ) - Qwen 2.5 VL models
+          # Sarva Sanjay (U08H31YMN4Q) - Qwen 3 VL models
           # Ambrose Ling (U08GELBB1AP) - BH tests
           # Tomasz Cheda (U091SNDA4TS) - Structured output tests
           # Radoica Draskic (U08BH66EXAL) - DP tests
@@ -71,7 +72,20 @@ jobs:
               "co-owner-1-id": "U07RY6B5FLJ"
             },
             {
-              "name": "[BH-LB] Llama-3.1-8B-Instruct v0 single-step with sampling-tests",
+              "name": "[WH-T3K] Qwen3-VL-32B-Instruct",
+              "model": "Qwen/Qwen3-VL-32B-Instruct",
+              "server-timeout": 10,
+              "benchmark-timeout": 10,
+              "runner-label": "config-t3000",
+              "arch": "arch-wormhole_b0",
+              "mesh-device": "T3K",
+              "tt-llama-text-ver": "tt_transformers",
+              "override-tt-config": "{\"fabric_config\": \"FABRIC_1D\", \"trace_region_size\": 28467200}",
+              "multimodal": true,
+              "co-owner-1-id": "U08H31YMN4Q"
+            },
+            {
+              "name": "[BH-LB] Llama-3.1-8B-Instruct v0 fallback structured-output",
               "model": "meta-llama/Llama-3.1-8B-Instruct",
               "server-timeout": 35,
               "benchmark-timeout": 10,
@@ -245,7 +259,22 @@ jobs:
               "co-owner-1-id": "U07RY6B5FLJ"
             },
             {
-              "name": "[BH-DB][v1] Llama-3.1-8B-Instruct with sampling-tests",
+              "name": "[WH-T3K][v1] Qwen3-VL-32B-Instruct",
+              "model": "Qwen/Qwen3-VL-32B-Instruct",
+              "server-timeout": 10,
+              "benchmark-timeout": 10,
+              "runner-label": "config-t3000",
+              "arch": "arch-wormhole_b0",
+              "mesh-device": "T3K",
+              "tt-llama-text-ver": "tt_transformers",
+              "override-tt-config": "{\"fabric_config\": \"FABRIC_1D\", \"trace_region_size\": 28467200}",
+              "use-vllm-v1": true,
+              "structured-output": true,
+              "multimodal": true,
+              "co-owner-1-id": "U08H31YMN4Q"
+            },
+            {
+              "name": "[BH-DB][v1] Llama-3.1-8B-Instruct",
               "model": "meta-llama/Llama-3.1-8B-Instruct",
               "server-timeout": 10,
               "benchmark-timeout": 5,

--- a/.github/workflows/vllm-nightly-tests-impl.yaml
+++ b/.github/workflows/vllm-nightly-tests-impl.yaml
@@ -72,19 +72,6 @@ jobs:
               "co-owner-1-id": "U07RY6B5FLJ"
             },
             {
-              "name": "[WH-T3K] Qwen3-VL-32B-Instruct",
-              "model": "Qwen/Qwen3-VL-32B-Instruct",
-              "server-timeout": 10,
-              "benchmark-timeout": 10,
-              "runner-label": "config-t3000",
-              "arch": "arch-wormhole_b0",
-              "mesh-device": "T3K",
-              "tt-llama-text-ver": "tt_transformers",
-              "override-tt-config": "{\"fabric_config\": \"FABRIC_1D\", \"trace_region_size\": 28467200}",
-              "multimodal": true,
-              "co-owner-1-id": "U08H31YMN4Q"
-            },
-            {
               "name": "[BH-LB] Llama-3.1-8B-Instruct v0 fallback structured-output",
               "model": "meta-llama/Llama-3.1-8B-Instruct",
               "server-timeout": 35,

--- a/.github/workflows/vllm-nightly-tests.yaml
+++ b/.github/workflows/vllm-nightly-tests.yaml
@@ -17,6 +17,7 @@ on:
           - meta-llama/Llama-3.1-8B-Instruct
           - meta-llama/Llama-3.3-70B-Instruct
           - Qwen/Qwen2.5-VL-72B-Instruct
+          - Qwen/Qwen3-VL-32B-Instruct
           - google/gemma-3-27b-it
           - openai/gpt-oss-120b
           - models/vllm_test_utils/t3000_multiproc_test

--- a/models/demos/qwen3_vl/tt/generator.py
+++ b/models/demos/qwen3_vl/tt/generator.py
@@ -88,6 +88,10 @@ class Generator:
 
         return output_logits
 
+    def warmup_model_prefill(self, kv_cache, enable_trace, sampling_params=None):
+        logger.warning("Warmup model prefill not implemented for Qwen3_VL Generator")
+        logger.warning("Tracing in prefill mode is not supported for Qwen3_VL")
+
     def update_cos_sin(self, cos_matrix_pt=None, sin_matrix_pt=None):
         self.model.rope_setup.update_cos_sin(cos_matrix_pt=cos_matrix_pt, sin_matrix_pt=sin_matrix_pt)
 

--- a/models/demos/qwen3_vl/tt/generator_vllm.py
+++ b/models/demos/qwen3_vl/tt/generator_vllm.py
@@ -180,7 +180,8 @@ class Qwen3VLForConditionalGeneration(QwenVLGenerator, SupportsMultiModal):
             x == 0 for x in start_pos
         ), f"Prefix caching is not supported for Qwen3VL, got start_pos: {start_pos}"
         # Must add this so that vLLM can call without errors
-        assert enable_trace is False, "Tracing in prefill mode is not supported for Qwen3VL"
+        enable_trace = False
+        logger.warning("Tracing in prefill mode is not supported for Qwen3VL")
 
         # [INFO] tokens are padded to the same length by appending 0s; change the padding to use pad_token_id
         pad_token_id = self.tokenizer.pad_token_id

--- a/models/demos/qwen3_vl/tt/generator_vllm.py
+++ b/models/demos/qwen3_vl/tt/generator_vllm.py
@@ -12,7 +12,7 @@ from transformers.models.qwen3_vl.modeling_qwen3_vl import (
     Qwen3VLForConditionalGeneration as Ref_Qwen3VLForConditionalGeneration,
 )
 from vllm.model_executor.models.interfaces import SupportsMultiModal
-from vllm.model_executor.models.qwen2_5_vl import Qwen2_5_VLProcessingInfo
+from vllm.model_executor.models.qwen3_vl import Qwen3VLProcessingInfo
 from vllm.multimodal import MULTIMODAL_REGISTRY
 
 import ttnn
@@ -90,14 +90,14 @@ class CustomNamespace(SimpleNamespace):
         return key in self.__dict__
 
 
-class TT_Qwen2_5_VLProcessingInfo(Qwen2_5_VLProcessingInfo):
+class TT_Qwen3VLProcessingInfo(Qwen3VLProcessingInfo):
     def get_supported_mm_limits(self) -> Mapping[str, Optional[int]]:
         return {"image": 1, "video": 0}  # [INFO] videos are not supported yet, only supporting 1 image for now
 
 
 # TODO: Eventually replace MultiModalProcessor with vllm.model_executor.models.qwen2_5_vl::Qwen2_5_VLMultiModalProcessor
 @MULTIMODAL_REGISTRY.register_processor(
-    MultiModalProcessor, info=TT_Qwen2_5_VLProcessingInfo, dummy_inputs=DummyInputsBuilder
+    MultiModalProcessor, info=TT_Qwen3VLProcessingInfo, dummy_inputs=DummyInputsBuilder
 )
 class Qwen3VLForConditionalGeneration(QwenVLGenerator, SupportsMultiModal):
     def __init__(self, *args, **kwargs):
@@ -170,6 +170,7 @@ class Qwen3VLForConditionalGeneration(QwenVLGenerator, SupportsMultiModal):
         page_table,
         kv_cache,
         prompt_lens,  # [INFO] prompt_lens is pre-padding number of tokens after text-image processing
+        enable_trace=False,
     ):
         # [INFO] tokens are padded to the same length by appending 0s; change the padding to use pad_token_id
         pad_token_id = self.tokenizer.pad_token_id

--- a/models/demos/qwen3_vl/tt/generator_vllm.py
+++ b/models/demos/qwen3_vl/tt/generator_vllm.py
@@ -7,11 +7,11 @@ from types import SimpleNamespace
 from typing import Mapping, Optional
 
 import torch
+import vllm.envs as envs
 from loguru import logger
 from transformers.models.qwen3_vl.modeling_qwen3_vl import (
     Qwen3VLForConditionalGeneration as Ref_Qwen3VLForConditionalGeneration,
 )
-from vllm.env import envs
 from vllm.model_executor.models.interfaces import SupportsMultiModal
 from vllm.model_executor.models.qwen3_vl import Qwen3VLProcessingInfo
 from vllm.multimodal import MULTIMODAL_REGISTRY

--- a/models/demos/qwen3_vl/tt/generator_vllm.py
+++ b/models/demos/qwen3_vl/tt/generator_vllm.py
@@ -99,7 +99,6 @@ class TT_Qwen3VLProcessingInfo(Qwen3VLProcessingInfo):
         return {"image": 1, "video": 0}  # [INFO] videos are not supported yet, only supporting 1 image for now
 
 
-# TODO: Eventually replace MultiModalProcessor with vllm.model_executor.models.qwen2_5_vl::Qwen2_5_VLMultiModalProcessor
 @MULTIMODAL_REGISTRY.register_processor(
     Qwen3VLMultiModalProcessor, info=TT_Qwen3VLProcessingInfo, dummy_inputs=Qwen3VLDummyInputsBuilder
 )
@@ -181,8 +180,7 @@ class Qwen3VLForConditionalGeneration(QwenVLGenerator, SupportsMultiModal):
             x == 0 for x in start_pos
         ), f"Prefix caching is not supported for Qwen3VL, got start_pos: {start_pos}"
         # Must add this so that vLLM can call without errors
-        enable_trace = False
-        logger.warning("Tracing in prefill mode is not supported for Qwen3VL")
+        assert enable_trace is False, "Tracing in prefill mode is not supported for Qwen3VL"
 
         # [INFO] tokens are padded to the same length by appending 0s; change the padding to use pad_token_id
         pad_token_id = self.tokenizer.pad_token_id

--- a/models/demos/qwen3_vl/tt/generator_vllm.py
+++ b/models/demos/qwen3_vl/tt/generator_vllm.py
@@ -167,7 +167,6 @@ class Qwen3VLForConditionalGeneration(QwenVLGenerator, SupportsMultiModal):
     def prefill_forward(
         self,
         tokens,
-        images,
         page_table,
         kv_cache,
         prompt_lens,  # [INFO] prompt_lens is pre-padding number of tokens after text-image processing

--- a/models/demos/qwen3_vl/tt/generator_vllm.py
+++ b/models/demos/qwen3_vl/tt/generator_vllm.py
@@ -11,6 +11,7 @@ from loguru import logger
 from transformers.models.qwen3_vl.modeling_qwen3_vl import (
     Qwen3VLForConditionalGeneration as Ref_Qwen3VLForConditionalGeneration,
 )
+from vllm.env import envs
 from vllm.model_executor.models.interfaces import SupportsMultiModal
 from vllm.model_executor.models.qwen3_vl import Qwen3VLProcessingInfo
 from vllm.multimodal import MULTIMODAL_REGISTRY
@@ -170,38 +171,103 @@ class Qwen3VLForConditionalGeneration(QwenVLGenerator, SupportsMultiModal):
         page_table,
         kv_cache,
         prompt_lens,  # [INFO] prompt_lens is pre-padding number of tokens after text-image processing
-        enable_trace=False,
+        enable_trace,
+        **kwargs,  # images for V0, pixel_values and image_grid_thw for V1,
     ):
+        start_pos = kwargs.get("start_pos", None)
+        assert (start_pos is None) or all(
+            x == 0 for x in start_pos
+        ), f"Prefix caching is not supported for Qwen3VL, got start_pos: {start_pos}"
+        # Must add this so that vLLM can call without errors
+        enable_trace = False
+        logger.warning("Tracing in prefill mode is not supported for Qwen3VL")
+
         # [INFO] tokens are padded to the same length by appending 0s; change the padding to use pad_token_id
         pad_token_id = self.tokenizer.pad_token_id
         padded_seq_len = tokens.shape[-1]
         for i in range(tokens.shape[0]):  # for each user, fix their padding
             tokens[i][prompt_lens[i] :] = pad_token_id
 
-        # reconstruct the inputs that Qwen2.5-VL expects
+        # reconstruct the inputs that Qwen3VL expects
         inputs = CustomNamespace()
-        inputs.input_ids = tokens.to(images[0].attention_mask.dtype) if images[0] is not None else tokens
-        inputs.attention_mask = torch.concat(
-            [
-                torch.nn.functional.pad(im.attention_mask, (0, padded_seq_len - im.attention_mask.shape[-1]), value=0)
-                if im is not None
-                else torch.ones_like(tokens[i : i + 1], dtype=tokens.dtype)
-                for i, im in enumerate(images)
-            ],
-            dim=0,
-        )
-        if images[0] is not None and "pixel_values" in images[0]:
-            # we currently do not support mixed inputs of text-only users and text-image users; hence checking images[0] is enough
-            inputs.pixel_values = torch.concat([im.pixel_values for im in images], dim=0)
-            inputs.image_grid_thw = torch.concat([im.image_grid_thw for im in images], dim=0)
-            # Vision prefill
-            image_embeds, deepstack_visual_embeds = self.visual_model(
-                inputs.pixel_values, grid_thw=inputs.image_grid_thw
+        if envs.VLLM_USE_V1:
+            inputs.input_ids = tokens.to(torch.int64)  # TODO: Derive dtype, like V0 does (see below)?
+            # Construct inputs.attention_mask with shape [batch_size, padded_seq_len] like tokens,
+            # where each row has ones in the first prompt_lens[i] positions and zeros elsewhere
+            inputs.attention_mask = torch.zeros(
+                (tokens.shape[0], padded_seq_len), dtype=inputs.input_ids.dtype, device=tokens.device
             )
-        else:
-            # text-only users
-            image_embeds = torch.tensor([], dtype=torch.bfloat16)
-            deepstack_visual_embeds = None
+            for i, plen in enumerate(prompt_lens):
+                inputs.attention_mask[i, :plen] = 1
+
+            if (
+                "pixel_values" in kwargs
+                and len(kwargs["pixel_values"]) > 0
+                and kwargs["pixel_values"][0] is not None
+                # kwargs["pixel_values"] is a list,
+                # each element is a list of images for one user
+                # We only check if the first user's pixel_values is not None
+                # as we currently do not support mixed inputs of text-only
+                # users and text-image users
+            ):
+                inputs.pixel_values = torch.concat(
+                    [im for user_pixel_values in kwargs["pixel_values"] for im in user_pixel_values], dim=0
+                )
+                inputs.image_grid_thw = torch.concat(
+                    [im for user_image_grid_thw in kwargs["image_grid_thw"] for im in user_image_grid_thw], dim=0
+                )
+                # Vision prefill
+                image_embeds, deepstack_visual_embeds = self.visual_model(
+                    inputs.pixel_values, grid_thw=inputs.image_grid_thw
+                )
+            else:
+                # text-only users
+                image_embeds, deepstack_visual_embeds = (
+                    torch.tensor([], dtype=torch.bfloat16, device=tokens.device),
+                    None,
+                )
+        else:  # V0
+            if (
+                "images" in kwargs
+                and isinstance(kwargs["images"], list)
+                and len(kwargs["images"]) > 0
+                and kwargs["images"][0] is not None
+                and "attention_mask" in kwargs["images"][0]
+            ):
+                inputs.input_ids = tokens.to(kwargs["images"][0].attention_mask.dtype)
+            else:
+                inputs.input_ids = tokens
+
+            inputs.attention_mask = torch.concat(
+                [
+                    torch.nn.functional.pad(
+                        im.attention_mask, (0, padded_seq_len - im.attention_mask.shape[-1]), value=0
+                    )
+                    if im is not None
+                    else torch.ones_like(tokens[i : i + 1], dtype=tokens.dtype)
+                    for i, im in enumerate(kwargs["images"])
+                ],
+                dim=0,
+            )
+            if (
+                "images" in kwargs
+                and len(kwargs["images"]) > 0
+                and kwargs["images"][0] is not None
+                and "pixel_values" in kwargs["images"][0]
+            ):
+                # we currently do not support mixed inputs of text-only users and text-image users; hence checking images[0] is enough
+                inputs.pixel_values = torch.concat([im.pixel_values for im in kwargs["images"]], dim=0)
+                inputs.image_grid_thw = torch.concat([im.image_grid_thw for im in kwargs["images"]], dim=0)
+
+                image_embeds, deepstack_visual_embeds = self.visual_model(
+                    inputs.pixel_values, grid_thw=inputs.image_grid_thw
+                )
+            else:
+                # text-only users
+                image_embeds, deepstack_visual_embeds = (
+                    torch.tensor([], dtype=torch.bfloat16, device=tokens.device),
+                    None,
+                )
 
         # Prepare text + vision inputs for decoder model
         text_embeds = self.reference_model.model.language_model.embed_tokens(inputs.input_ids)

--- a/models/demos/qwen3_vl/tt/generator_vllm.py
+++ b/models/demos/qwen3_vl/tt/generator_vllm.py
@@ -13,7 +13,11 @@ from transformers.models.qwen3_vl.modeling_qwen3_vl import (
     Qwen3VLForConditionalGeneration as Ref_Qwen3VLForConditionalGeneration,
 )
 from vllm.model_executor.models.interfaces import SupportsMultiModal
-from vllm.model_executor.models.qwen3_vl import Qwen3VLProcessingInfo
+from vllm.model_executor.models.qwen3_vl import (
+    Qwen3VLDummyInputsBuilder,
+    Qwen3VLMultiModalProcessor,
+    Qwen3VLProcessingInfo,
+)
 from vllm.multimodal import MULTIMODAL_REGISTRY
 
 import ttnn
@@ -21,7 +25,6 @@ from models.demos.qwen3_vl.tt.common import merge_vision_tokens, multimodal_rope
 from models.demos.qwen3_vl.tt.generator import Generator as QwenVLGenerator
 from models.demos.qwen3_vl.tt.model import DropInVisionTransformer, Transformer
 from models.demos.qwen3_vl.tt.model_config import VisionModelArgs
-from models.tt_transformers.tt.generator_vllm import DummyInputsBuilder, MultiModalProcessor
 from models.tt_transformers.tt.model_config import DecodersPrecision, ModelArgs
 
 
@@ -98,7 +101,7 @@ class TT_Qwen3VLProcessingInfo(Qwen3VLProcessingInfo):
 
 # TODO: Eventually replace MultiModalProcessor with vllm.model_executor.models.qwen2_5_vl::Qwen2_5_VLMultiModalProcessor
 @MULTIMODAL_REGISTRY.register_processor(
-    MultiModalProcessor, info=TT_Qwen3VLProcessingInfo, dummy_inputs=DummyInputsBuilder
+    Qwen3VLMultiModalProcessor, info=TT_Qwen3VLProcessingInfo, dummy_inputs=Qwen3VLDummyInputsBuilder
 )
 class Qwen3VLForConditionalGeneration(QwenVLGenerator, SupportsMultiModal):
     def __init__(self, *args, **kwargs):


### PR DESCRIPTION
### Ticket
#33066 #33068 
### Problem description
Adding vllm support to Qwen3-VL models

### What's changed
- Modified generators to support standard vllm functions.
- Added Qwen3-VL-32B-Instruct to the vllm nightly runs

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=ssanjay/qwen3-vl-vllm)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:ssanjay/qwen3-vl-vllm)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ssanjay/qwen3-vl-vllm)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ssanjay/qwen3-vl-vllm)
- [ ] New/Existing tests provide coverage for changes
