### PR TITLE
[tt-train] Make training profiler respect TT_METAL_DEVICE_PROFILER

### DIFF
--- a/tt-train/sources/ttml/core/tt_profiler.cpp
+++ b/tt-train/sources/ttml/core/tt_profiler.cpp
@@ -4,6 +4,8 @@
 
 #include "tt_profiler.hpp"
 
+#include <cstdlib>
+
 #include "core/tt_tensor_utils.hpp"
 #include "metal/operations.hpp"
 
@@ -55,7 +57,9 @@ void TTProfiler::disable() {
 }
 
 TTProfiler::TTProfiler() : m_enabled(false) {
-    if (is_tracy_enabled) {
+    const char* env_value = std::getenv("TT_METAL_DEVICE_PROFILER");
+    bool runtime_profiler_enabled = env_value != nullptr && std::string(env_value) == "1";
+    if (is_tracy_enabled && runtime_profiler_enabled) {
         enable();
 
         tt::tt_metal::detail::ProfilerSync(tt::tt_metal::ProfilerSyncState::INIT);
@@ -63,7 +67,7 @@ TTProfiler::TTProfiler() : m_enabled(false) {
 }
 
 TTProfiler::~TTProfiler() {
-    if (is_tracy_enabled) {
+    if (is_enabled()) {
         tt::tt_metal::detail::ProfilerSync(tt::tt_metal::ProfilerSyncState::CLOSE_DEVICE);
     }
 }


### PR DESCRIPTION
### Ticket
None

### Problem description
<img width="754" height="530" alt="image" src="https://github.com/user-attachments/assets/e62f493f-e3ac-4dc5-bb82-3cbcdeb22085" />
See cache entires increasing even in release build. 
This is due to a change in debug build config when tracy is now included by default.
What matters is a runtime env flag TT_METAL_DEVICE_PROFILER. 
If it is not set, it does not make sense to add `profiler_no_op` calls.

### What's changed
Initially wanted to use `tt::tt_metal::MetalContext::instance().rtoptions().get_profiler_enabled()` but it is not accessible - `MetalContext` is a part of metal's private api. Raised this with Audrey. Keeping it raw for now.

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=ay/train_profiling_tweak)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:ay/train_profiling_tweak)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ay/train_profiling_tweak)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ay/train_profiling_tweak)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ay/train_profiling_tweak)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ay/train_profiling_tweak)
- [ ] New/Existing tests provide coverage for changes