### PR TITLE
Add scattered core support for gather operation

### DIFF
--- a/models/demos/deepseek_v3_b1/micro_ops/gather/kernels/gather_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/micro_ops/gather/kernels/gather_kernel.cpp
@@ -13,6 +13,15 @@
 struct Core {
     static constexpr bool is_sender_core = get_named_compile_time_arg_val("is_sender_core") == 1;
     static constexpr bool is_receiver_core = get_named_compile_time_arg_val("is_receiver_core") == 1;
+#if defined(COMPILE_FOR_NCRISC)
+    // Use per-core sender index (scattered mode) vs grid-based computation
+    // Only relevant for sender (NCRISC) - receiver/compute don't need this
+    static constexpr bool use_per_core_sender_idx =
+        get_named_compile_time_arg_val("gather_use_per_core_sender_idx") == 1;
+#else
+    // For BRISC/TRISC, default to false (not used anyway)
+    static constexpr bool use_per_core_sender_idx = false;
+#endif
 };
 
 void kernel_main() {
@@ -50,6 +59,7 @@ void kernel_main() {
         get_named_compile_time_arg_val("gather_sender_grid_end_y"),
         get_named_compile_time_arg_val("gather_row_major"),
         receiver_data_addr,  // receiver_data_addr from runtime arg (output tensor buffer address)
+        get_named_compile_time_arg_val("gather_sender_idx"),
     };
 
 // ============================================================================
@@ -78,6 +88,7 @@ void kernel_main() {
 
     // Execute gather operation
     // pop_src = true (input is consumed after gather)
-    Gather::Op<Core::is_sender_core, Core::is_receiver_core, true> gather;
-    gather(gather_args);
+    // UsePerCoreSenderIdx = Core::use_per_core_sender_idx (compile-time scattered vs grid mode)
+    Gather::Op<Core::is_sender_core, Core::is_receiver_core, true, Core::use_per_core_sender_idx> gather_op;
+    gather_op(gather_args);
 }

--- a/models/demos/deepseek_v3_b1/micro_ops/gather/op.py
+++ b/models/demos/deepseek_v3_b1/micro_ops/gather/op.py
@@ -4,6 +4,40 @@
 
 
 import ttnn
+from models.demos.deepseek_v3_b1.unified_kernel_descriptor import PerCoreCompileTimeDescriptor
+
+# Dtype to element size mapping (in bytes)
+_DTYPE_SIZES = {
+    ttnn.bfloat16: 2,
+    ttnn.bfloat8_b: 1,
+    ttnn.bfloat4_b: 0.5,
+    ttnn.float32: 4,
+    ttnn.uint16: 2,
+    ttnn.uint32: 4,
+}
+
+
+def _get_element_size(dtype):
+    """Get element size in bytes for a given dtype."""
+    if dtype not in _DTYPE_SIZES:
+        raise ValueError(f"Unsupported dtype: {dtype}. Supported: {list(_DTYPE_SIZES.keys())}")
+    return _DTYPE_SIZES[dtype]
+
+
+def _validate_gather_inputs(input_tensor, output_tensor, sender_cores=None):
+    """Validate gather operation inputs."""
+    # Validate output has single core
+    output_grid = output_tensor.memory_config().shard_spec.grid
+    if output_grid.num_cores() != 1:
+        raise ValueError(f"Output tensor must be sharded on exactly one core, got {output_grid.num_cores()}")
+
+    # Validate sender cores are within device bounds
+    if sender_cores:
+        device = input_tensor.device()
+        grid_size = device.compute_with_storage_grid_size()
+        for core in sender_cores:
+            if core.x >= grid_size.x or core.y >= grid_size.y:
+                raise ValueError(f"Core ({core.x}, {core.y}) is outside device grid ({grid_size.x}, {grid_size.y})")
 
 
 class GatherSingleCore:
@@ -28,92 +62,83 @@ class GatherSingleCore:
         return input_tensor
 
     @staticmethod
-    def op(input_tensor, output_tensor, noc=None):
+    def _split_cores_by_noc(device, sender_cores, gather_core, noc):
         """
-        Execute gather operation using generic_op.
+        Split sender cores into NOC0 and NOC1 groups.
 
         Args:
-            input_tensor: Input tensor (must be sharded across multiple cores)
-            output_tensor: Pre-allocated output tensor (must be sharded on single core)
-            noc: NOC to use for gather (ttnn.NOC.NOC_0 or ttnn.NOC.NOC_1). If None,
-                 automatically optimizes NOC routing based on hop distance for each sender core.
+            device: TT device
+            sender_cores: List of CoreCoord
+            gather_core: Destination CoreCoord
+            noc: Forced NOC (ttnn.NOC.NOC_0/NOC_1) or None for auto-optimization
 
         Returns:
-            Output tensor with input data gathered from all cores to gather_core
+            Tuple of (noc0_cores, noc1_cores)
         """
-        # Get device
-        device = input_tensor.device()
+        if noc is not None:
+            if noc == ttnn.NOC.NOC_0:
+                return list(sender_cores), []
+            else:
+                return [], list(sender_cores)
 
-        # Get core grids from tensor memory configs
-        input_memory_config = input_tensor.memory_config()
-        output_memory_config = output_tensor.memory_config()
-        input_core_grid = input_memory_config.shard_spec.grid
-        output_core_grid = output_memory_config.shard_spec.grid
-
-        # Gather core (first core from output grid)
-        gather_core = output_core_grid.ranges()[0].start
-
-        # Get NOC coordinates for gather destination
-        gather_dest_noc_core = device.worker_core_from_logical_core(gather_core)
-
-        # Calculate data size from shard shape and element size
-        shard_spec = input_memory_config.shard_spec
-        shard_shape = shard_spec.shape
-        shard_height = shard_shape[0]
-        shard_width = shard_shape[1]
-
-        # Get element size in bytes based on dtype
-        dtype = input_tensor.dtype
-        total_elements = shard_height * shard_width
-
-        # Calculate total size in bytes based on dtype
-        if dtype == ttnn.bfloat16:
-            element_size_bytes = 2
-        else:
-            raise ValueError(f"Unsupported dtype: {dtype}")
-
-        total_size = total_elements * element_size_bytes
-
-        # All cores (input + output) for semaphore allocation
-        all_cores = input_core_grid.merge(output_core_grid)
-
-        # Split cores into NOC0 and NOC1 groups based on hop distance optimization
+        # Optimize NOC routing based on hop distance
         noc0_cores = []
         noc1_cores = []
-
-        # Convert CoreRangeSet to list of cores
-        input_cores_list = ttnn.corerange_to_cores(input_core_grid, row_wise=True)
-
-        # Assign cores to NOC based on noc parameter or hop distance optimization
-        if noc is not None:
-            # User specified NOC, use it for all cores
-            if noc == ttnn.NOC.NOC_0:
-                noc0_cores = input_cores_list
+        for core in sender_cores:
+            noc0_hop = device.get_worker_noc_hop_distance(core, gather_core, ttnn.NOC.NOC_0)
+            noc1_hop = device.get_worker_noc_hop_distance(core, gather_core, ttnn.NOC.NOC_1)
+            if noc0_hop <= noc1_hop:
+                noc0_cores.append(core)
             else:
-                noc1_cores = input_cores_list
-        else:
-            # Optimize NOC routing based on hop distance
-            for core in input_cores_list:
-                noc0_hop = device.get_worker_noc_hop_distance(core, gather_core, ttnn.NOC.NOC_0)
-                noc1_hop = device.get_worker_noc_hop_distance(core, gather_core, ttnn.NOC.NOC_1)
-                if noc0_hop <= noc1_hop:
-                    noc0_cores.append(core)
-                else:
-                    noc1_cores.append(core)
+                noc1_cores.append(core)
+        return noc0_cores, noc1_cores
 
-        # Create CoreRangeSets for NOC0 and NOC1 cores
+    @staticmethod
+    def _build_gather_program(
+        input_tensor,
+        output_tensor,
+        sender_cores,
+        noc0_cores,
+        noc1_cores,
+        gather_core,
+        gather_dest_noc_core,
+        use_per_core_sender_idx,
+        sender_grid_bounds=None,
+    ):
+        """
+        Build the gather program descriptor.
+
+        Args:
+            input_tensor: Input tensor
+            output_tensor: Output tensor
+            sender_cores: List of all sender CoreCoords
+            noc0_cores: List of cores using NOC0
+            noc1_cores: List of cores using NOC1
+            gather_core: Destination core
+            gather_dest_noc_core: NOC coordinates of destination
+            use_per_core_sender_idx: If True, use per-core sender indices (scattered mode)
+            sender_grid_bounds: Tuple of (start_x, start_y, end_x, end_y) for grid-based indexing
+
+        Returns:
+            ProgramDescriptor
+        """
+        input_memory_config = input_tensor.memory_config()
+        output_memory_config = output_tensor.memory_config()
+        output_core_grid = output_memory_config.shard_spec.grid
+
+        # Calculate data size
+        shard_spec = input_memory_config.shard_spec
+        shard_shape = shard_spec.shape
+        total_elements = shard_shape[0] * shard_shape[1]
+        element_size = _get_element_size(input_tensor.dtype)
+        total_size = int(total_elements * element_size)
+
+        # Create CoreRangeSets
+        input_core_grid = ttnn.CoreRangeSet([ttnn.CoreRange(core, core) for core in sender_cores])
+        all_cores = input_core_grid.merge(output_core_grid)
         noc0_core_range_set = ttnn.CoreRangeSet([ttnn.CoreRange(core, core) for core in noc0_cores])
-        noc1_core_range_set = ttnn.CoreRangeSet([ttnn.CoreRange(core, core) for core in noc1_cores])
 
-        # Get sender grid dimensions for computing per-core offset in kernel
-        input_core_ranges = list(input_core_grid.ranges())
-        sender_grid_range = input_core_ranges[0]
-        sender_grid_start_x = sender_grid_range.start.x
-        sender_grid_start_y = sender_grid_range.start.y
-        sender_grid_end_x = sender_grid_range.end.x
-        sender_grid_end_y = sender_grid_range.end.y
-
-        # Semaphore IDs
+        # Semaphore setup
         noc0_receiver_semaphore_id = 0
         noc1_receiver_semaphore_id = 1
 
@@ -135,7 +160,7 @@ class GatherSingleCore:
         dst_cb = 1  # Output CB (from sharded output tensor)
 
         # Number of pages
-        num_senders = len(input_cores_list)
+        num_senders = len(sender_cores)
         src_num_pages = 1  # Each sender has one page
         dst_num_pages = num_senders  # Receiver gets one page per sender
 
@@ -148,56 +173,105 @@ class GatherSingleCore:
         # The dst CB doesn't exist on sender cores, so we pass the buffer address as runtime arg
         receiver_data_addr = output_tensor.buffer_address()
 
+        # Grid bounds (used only when use_per_core_sender_idx=False)
+        if sender_grid_bounds:
+            start_x, start_y, end_x, end_y = sender_grid_bounds
+        else:
+            start_x = start_y = end_x = end_y = 0
+
+        # Build per-core sender index mapping for scattered mode
+        core_to_idx = (
+            {(core.x, core.y): idx for idx, core in enumerate(sender_cores)} if use_per_core_sender_idx else {}
+        )
+
         # ========================================================================
         # Sender kernels (NCRISC) - separate for NOC0 and NOC1
         # ========================================================================
-        def create_sender_named_compile_time_args(receiver_semaphore_id):
-            return [
-                ("gather_dest_noc_x", gather_dest_noc_core.x),
-                ("gather_dest_noc_y", gather_dest_noc_core.y),
-                ("gather_data_size_bytes", total_size),
-                ("gather_receiver_semaphore_id", receiver_semaphore_id),
-                ("gather_src_cb", src_cb),
-                ("gather_src_num_pages", src_num_pages),
-                ("gather_sender_grid_start_x", sender_grid_start_x),
-                ("gather_sender_grid_start_y", sender_grid_start_y),
-                ("gather_sender_grid_end_x", sender_grid_end_x),
-                ("gather_sender_grid_end_y", sender_grid_end_y),
-                ("gather_row_major", 1),  # 1 = row-major linearization
-                # Role flags
-                ("is_sender_core", 1),
-                ("is_receiver_core", 0),
-            ]
+        def create_sender_kernel(cores, semaphore_id, noc_type):
+            if not cores:
+                return []
 
-        # NOC0 sender kernel
-        if not noc0_core_range_set.empty():
-            noc0_sender_kernel_descriptor = ttnn.KernelDescriptor(
-                kernel_source=kernel_path,
-                source_type=ttnn.KernelDescriptor.SourceType.FILE_PATH,
-                core_ranges=noc0_core_range_set,
-                named_compile_time_args=create_sender_named_compile_time_args(noc0_receiver_semaphore_id),
-                common_runtime_args=[receiver_data_addr],  # receiver_data_addr passed as runtime arg
-                config=ttnn.DataMovementConfigDescriptor(
-                    processor=ttnn.DataMovementProcessor.RISCV_1,
-                    noc=ttnn.NOC.NOC_0,
-                ),
-            )
-            kernels.append(noc0_sender_kernel_descriptor)
+            if use_per_core_sender_idx:
+                # Scattered mode: use PerCoreCompileTimeDescriptor for per-core sender_idx
+                per_core_desc = PerCoreCompileTimeDescriptor(
+                    named_compile_time_arg="gather_sender_idx",
+                    core_values=[(core, core_to_idx[(core.x, core.y)]) for core in cores],
+                    other_value=0,
+                )
 
-        # NOC1 sender kernel
-        if not noc1_core_range_set.empty():
-            noc1_sender_kernel_descriptor = ttnn.KernelDescriptor(
-                kernel_source=kernel_path,
-                source_type=ttnn.KernelDescriptor.SourceType.FILE_PATH,
-                core_ranges=noc1_core_range_set,
-                named_compile_time_args=create_sender_named_compile_time_args(noc1_receiver_semaphore_id),
-                common_runtime_args=[receiver_data_addr],  # receiver_data_addr passed as runtime arg
-                config=ttnn.DataMovementConfigDescriptor(
-                    processor=ttnn.DataMovementProcessor.RISCV_1,
-                    noc=ttnn.NOC.NOC_1,
-                ),
-            )
-            kernels.append(noc1_sender_kernel_descriptor)
+                shared_named_args = [
+                    ("gather_dest_noc_x", gather_dest_noc_core.x),
+                    ("gather_dest_noc_y", gather_dest_noc_core.y),
+                    ("gather_data_size_bytes", total_size),
+                    ("gather_receiver_semaphore_id", semaphore_id),
+                    ("gather_src_cb", src_cb),
+                    ("gather_src_num_pages", src_num_pages),
+                    ("gather_sender_grid_start_x", 0),
+                    ("gather_sender_grid_start_y", 0),
+                    ("gather_sender_grid_end_x", 0),
+                    ("gather_sender_grid_end_y", 0),
+                    ("gather_row_major", 1),
+                    ("gather_use_per_core_sender_idx", 1),
+                    ("is_sender_core", 1),
+                    ("is_receiver_core", 0),
+                ]
+
+                kernel_list = []
+                for core, sender_idx in per_core_desc.core_values:
+                    core_range_set = ttnn.CoreRangeSet([ttnn.CoreRange(core, core)])
+                    named_args = shared_named_args + [
+                        (per_core_desc.named_compile_time_arg, sender_idx),
+                    ]
+                    kernel_list.append(
+                        ttnn.KernelDescriptor(
+                            kernel_source=kernel_path,
+                            source_type=ttnn.KernelDescriptor.SourceType.FILE_PATH,
+                            core_ranges=core_range_set,
+                            named_compile_time_args=named_args,
+                            common_runtime_args=[receiver_data_addr],
+                            config=ttnn.DataMovementConfigDescriptor(
+                                processor=ttnn.DataMovementProcessor.RISCV_1,
+                                noc=noc_type,
+                            ),
+                        )
+                    )
+                return kernel_list
+            else:
+                # Grid mode: single kernel for all cores
+                core_range_set = ttnn.CoreRangeSet([ttnn.CoreRange(core, core) for core in cores])
+                named_args = [
+                    ("gather_dest_noc_x", gather_dest_noc_core.x),
+                    ("gather_dest_noc_y", gather_dest_noc_core.y),
+                    ("gather_data_size_bytes", total_size),
+                    ("gather_receiver_semaphore_id", semaphore_id),
+                    ("gather_src_cb", src_cb),
+                    ("gather_src_num_pages", src_num_pages),
+                    ("gather_sender_grid_start_x", start_x),
+                    ("gather_sender_grid_start_y", start_y),
+                    ("gather_sender_grid_end_x", end_x),
+                    ("gather_sender_grid_end_y", end_y),
+                    ("gather_row_major", 1),
+                    ("gather_use_per_core_sender_idx", 0),
+                    ("gather_sender_idx", 0),
+                    ("is_sender_core", 1),
+                    ("is_receiver_core", 0),
+                ]
+                return [
+                    ttnn.KernelDescriptor(
+                        kernel_source=kernel_path,
+                        source_type=ttnn.KernelDescriptor.SourceType.FILE_PATH,
+                        core_ranges=core_range_set,
+                        named_compile_time_args=named_args,
+                        common_runtime_args=[receiver_data_addr],
+                        config=ttnn.DataMovementConfigDescriptor(
+                            processor=ttnn.DataMovementProcessor.RISCV_1,
+                            noc=noc_type,
+                        ),
+                    )
+                ]
+
+        kernels.extend(create_sender_kernel(noc0_cores, noc0_receiver_semaphore_id, ttnn.NOC.NOC_0))
+        kernels.extend(create_sender_kernel(noc1_cores, noc1_receiver_semaphore_id, ttnn.NOC.NOC_1))
 
         # ========================================================================
         # Receiver kernel (BRISC)
@@ -268,15 +342,103 @@ class GatherSingleCore:
         src_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(src_cb, input_tensor)
         dst_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(dst_cb, output_tensor)
 
-        # Create program descriptor
-        program_descriptor = ttnn.ProgramDescriptor(
+        return ttnn.ProgramDescriptor(
             kernels=kernels,
             cbs=[src_cb_descriptor, dst_cb_descriptor],
             semaphores=semaphores,
         )
 
-        # Execute generic op
-        io_tensors = [input_tensor, output_tensor]
-        output = ttnn.generic_op(io_tensors, program_descriptor)
+    @staticmethod
+    def op(input_tensor, output_tensor, noc=None):
+        """
+        Execute gather operation using generic_op.
 
-        return output
+        Args:
+            input_tensor: Input tensor (must be sharded across a rectangular grid)
+            output_tensor: Pre-allocated output tensor (must be sharded on single core)
+            noc: NOC to use for gather (ttnn.NOC.NOC_0 or ttnn.NOC.NOC_1). If None,
+                 automatically optimizes NOC routing based on hop distance for each sender core.
+
+        Returns:
+            Output tensor with input data gathered from all cores to gather_core
+        """
+        _validate_gather_inputs(input_tensor, output_tensor)
+
+        device = input_tensor.device()
+        input_memory_config = input_tensor.memory_config()
+        output_memory_config = output_tensor.memory_config()
+        input_core_grid = input_memory_config.shard_spec.grid
+        output_core_grid = output_memory_config.shard_spec.grid
+
+        gather_core = output_core_grid.ranges()[0].start
+        gather_dest_noc_core = device.worker_core_from_logical_core(gather_core)
+
+        # Get sender grid dimensions
+        input_core_ranges = list(input_core_grid.ranges())
+        sender_grid_range = input_core_ranges[0]
+        sender_grid_bounds = (
+            sender_grid_range.start.x,
+            sender_grid_range.start.y,
+            sender_grid_range.end.x,
+            sender_grid_range.end.y,
+        )
+
+        sender_cores = ttnn.corerange_to_cores(input_core_grid, row_wise=True)
+        noc0_cores, noc1_cores = GatherSingleCore._split_cores_by_noc(device, sender_cores, gather_core, noc)
+
+        program_descriptor = GatherSingleCore._build_gather_program(
+            input_tensor=input_tensor,
+            output_tensor=output_tensor,
+            sender_cores=sender_cores,
+            noc0_cores=noc0_cores,
+            noc1_cores=noc1_cores,
+            gather_core=gather_core,
+            gather_dest_noc_core=gather_dest_noc_core,
+            use_per_core_sender_idx=False,
+            sender_grid_bounds=sender_grid_bounds,
+        )
+
+        return ttnn.generic_op([input_tensor, output_tensor], program_descriptor)
+
+    @staticmethod
+    def op_scattered(input_tensor, output_tensor, sender_cores, noc=None):
+        """
+        Execute gather operation from scattered (non-rectangular) cores using generic_op.
+
+        This variant uses per-core compile-time args to specify unique sender indices,
+        enabling gather from non-contiguous cores that don't form a rectangular grid.
+
+        Args:
+            input_tensor: Input tensor (must be sharded across the specified scattered cores)
+            output_tensor: Pre-allocated output tensor (must be sharded on single core)
+            sender_cores: List of CoreCoord specifying which cores participate in gather
+            noc: NOC to use for gather (ttnn.NOC.NOC_0 or ttnn.NOC.NOC_1). If None,
+                 automatically optimizes NOC routing based on hop distance for each sender core.
+
+        Returns:
+            Output tensor with input data gathered from all specified cores to gather_core
+        """
+        _validate_gather_inputs(input_tensor, output_tensor, sender_cores)
+
+        device = input_tensor.device()
+        output_memory_config = output_tensor.memory_config()
+        output_core_grid = output_memory_config.shard_spec.grid
+
+        gather_core = output_core_grid.ranges()[0].start
+        gather_dest_noc_core = device.worker_core_from_logical_core(gather_core)
+
+        noc0_cores, noc1_cores = GatherSingleCore._split_cores_by_noc(device, sender_cores, gather_core, noc)
+
+        program_descriptor = GatherSingleCore._build_gather_program(
+            input_tensor=input_tensor,
+            output_tensor=output_tensor,
+            sender_cores=list(sender_cores),
+            noc0_cores=noc0_cores,
+            noc1_cores=noc1_cores,
+            gather_core=gather_core,
+            gather_dest_noc_core=gather_dest_noc_core,
+            use_per_core_sender_idx=True,
+            sender_grid_bounds=None,
+        )
+
+        return ttnn.generic_op([input_tensor, output_tensor], program_descriptor)

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_gather.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_gather.py
@@ -16,6 +16,74 @@ from loguru import logger
 import ttnn
 from models.demos.deepseek_v3_b1.micro_ops.gather.op import GatherSingleCore
 
+# =============================================================================
+# Helper functions
+# =============================================================================
+
+
+def create_input_tensor(device, torch_input, gather_grid, shard_shape, tile):
+    """Create a sharded input tensor."""
+    input_shard_spec = ttnn.ShardSpec(
+        ttnn.CoreRangeSet({gather_grid}),
+        shard_shape,
+        ttnn.ShardOrientation.ROW_MAJOR,
+    )
+    input_mem_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.WIDTH_SHARDED, ttnn.BufferType.L1, input_shard_spec)
+
+    return ttnn.from_torch(
+        torch_input,
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        memory_config=input_mem_config,
+        tile=tile,
+    )
+
+
+def create_output_tensor(device, output_shape, gather_core, tile):
+    """Create a sharded output tensor on the gather core."""
+    output_shard_spec = ttnn.ShardSpec(
+        ttnn.CoreRangeSet({ttnn.CoreRange(gather_core, gather_core)}),
+        output_shape,
+        ttnn.ShardOrientation.ROW_MAJOR,
+    )
+    output_mem_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, output_shard_spec)
+
+    torch_output = torch.zeros(output_shape, dtype=torch.bfloat16)
+    return ttnn.from_torch(
+        torch_output,
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        memory_config=output_mem_config,
+        tile=tile,
+    )
+
+
+def create_scattered_input_tensor(device, torch_input, sender_cores, shard_shape, tile):
+    """Create a sharded input tensor on scattered (non-rectangular) cores."""
+    core_range_set = ttnn.CoreRangeSet([ttnn.CoreRange(core, core) for core in sender_cores])
+    input_shard_spec = ttnn.ShardSpec(
+        core_range_set,
+        shard_shape,
+        ttnn.ShardOrientation.ROW_MAJOR,
+    )
+    input_mem_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.WIDTH_SHARDED, ttnn.BufferType.L1, input_shard_spec)
+
+    return ttnn.from_torch(
+        torch_input,
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        memory_config=input_mem_config,
+        tile=tile,
+    )
+
+
+# =============================================================================
+# Basic gather test (rectangular grid)
+# =============================================================================
+
 
 @pytest.mark.parametrize(
     "width_per_core, gather_core, gather_grid, noc",
@@ -93,47 +161,13 @@ def test_gather(device, width_per_core, gather_core, gather_grid, noc):
     # Compute expected output using PyTorch reference
     torch_expected = GatherSingleCore.golden(torch_input)
 
-    # Input: sharded across multiple cores (gather_grid)
-    input_shard_spec = ttnn.ShardSpec(
-        ttnn.CoreRangeSet({gather_grid}),
-        shard_shape,
-        ttnn.ShardOrientation.ROW_MAJOR,
-    )
-    input_mem_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.WIDTH_SHARDED, ttnn.BufferType.L1, input_shard_spec)
-
-    # Create input tensor sharded across gather_grid cores
-    ttnn_input = ttnn.from_torch(
-        torch_input,
-        dtype=ttnn.bfloat16,
-        layout=ttnn.TILE_LAYOUT,
-        device=device,
-        memory_config=input_mem_config,
-        tile=tile,
-    )
-
+    # Create input and output tensors
+    ttnn_input = create_input_tensor(device, torch_input, gather_grid, shard_shape, tile)
     logger.info(f"Created input tensor sharded across {num_input_cores} cores with shard shape {shard_shape}")
 
-    # Output: sharded on single core (gather_core)
-    output_shard_spec = ttnn.ShardSpec(
-        ttnn.CoreRangeSet({ttnn.CoreRange(gather_core, gather_core)}),
-        output_shape,
-        ttnn.ShardOrientation.ROW_MAJOR,
-    )
-    output_mem_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, output_shard_spec)
+    ttnn_output = create_output_tensor(device, output_shape, gather_core, tile)
 
-    # Create output tensor with the sharded memory config
-    # We need to create an empty tensor with the right shape and memory config
-    torch_output = torch.zeros(output_shape, dtype=torch.bfloat16)
-    ttnn_output = ttnn.from_torch(
-        torch_output,
-        dtype=ttnn.bfloat16,
-        layout=ttnn.TILE_LAYOUT,
-        device=device,
-        memory_config=output_mem_config,
-        tile=tile,
-    )
-
-    # Run gather operation using generic implementation
+    # Run gather operation
     logger.info("Running gather operation...")
     ttnn_result = GatherSingleCore.op(ttnn_input, ttnn_output, noc)
 
@@ -146,4 +180,282 @@ def test_gather(device, width_per_core, gather_core, gather_grid, noc):
     # Verify that the output matches the expected
     logger.info("Verifying gather results...")
     assert torch.equal(output_torch, torch_expected), "Output tensor does not match expected tensor"
-    logger.info("✓ Gather test passed!")
+    logger.info("Gather test passed!")
+
+
+# =============================================================================
+# Scattered cores test (non-rectangular grid)
+# =============================================================================
+
+
+@pytest.mark.parametrize(
+    "sender_cores, gather_core, width_per_core, description",
+    [
+        (
+            # Diagonal pattern - non-contiguous cores
+            [ttnn.CoreCoord(0, 0), ttnn.CoreCoord(1, 1), ttnn.CoreCoord(2, 2), ttnn.CoreCoord(3, 3)],
+            ttnn.CoreCoord(7, 5),
+            32,
+            "Diagonal scattered cores (4 cores)",
+        ),
+        (
+            # L-shaped pattern
+            [
+                ttnn.CoreCoord(0, 0),
+                ttnn.CoreCoord(0, 1),
+                ttnn.CoreCoord(0, 2),
+                ttnn.CoreCoord(1, 0),
+                ttnn.CoreCoord(2, 0),
+            ],
+            ttnn.CoreCoord(7, 5),
+            32,
+            "L-shaped scattered cores (5 cores)",
+        ),
+        (
+            # Sparse checkerboard pattern
+            [ttnn.CoreCoord(0, 0), ttnn.CoreCoord(2, 0), ttnn.CoreCoord(0, 2), ttnn.CoreCoord(2, 2)],
+            ttnn.CoreCoord(5, 5),
+            64,
+            "Checkerboard scattered cores (4 cores)",
+        ),
+        (
+            # Single scattered core
+            [ttnn.CoreCoord(3, 4)],
+            ttnn.CoreCoord(7, 7),
+            128,
+            "Single scattered core",
+        ),
+    ],
+)
+def test_gather_scattered_cores(device, sender_cores, gather_core, width_per_core, description):
+    """
+    Test gather from scattered (non-rectangular) cores using per-core compile-time args.
+
+    This test uses the PerCoreCompileTimeDescriptor feature to specify per-core
+    sender indices, enabling gather from arbitrary non-contiguous core patterns.
+    """
+    # Truncate cores for device grid size
+    device_grid_x = device.compute_with_storage_grid_size().x
+    device_grid_y = device.compute_with_storage_grid_size().y
+
+    # Filter out cores that don't fit on the device
+    valid_sender_cores = [core for core in sender_cores if core.x < device_grid_x and core.y < device_grid_y]
+
+    if len(valid_sender_cores) < len(sender_cores):
+        logger.warning(
+            f"Reduced sender cores from {len(sender_cores)} to {len(valid_sender_cores)} due to device grid size"
+        )
+
+    if len(valid_sender_cores) == 0:
+        pytest.skip("No valid sender cores for this device grid size")
+
+    # Truncate gather_core if needed
+    if gather_core.x >= device_grid_x or gather_core.y >= device_grid_y:
+        gather_core = ttnn.CoreCoord(min(gather_core.x, device_grid_x - 1), min(gather_core.y, device_grid_y - 1))
+        logger.warning(f"Truncated gather_core to {gather_core}")
+
+    tile = ttnn.Tile([1, 32])
+    num_senders = len(valid_sender_cores)
+    full_width = width_per_core * num_senders
+
+    shard_shape = (1, width_per_core)
+    output_shape = (1, full_width)
+
+    logger.info(f"Testing {description}: {num_senders} scattered cores, shard={shard_shape}, output={output_shape}")
+    logger.info(f"Sender cores: {[(c.x, c.y) for c in valid_sender_cores]}")
+
+    # Create random input
+    torch.manual_seed(42)
+    torch_input = torch.randn(output_shape, dtype=torch.bfloat16)
+    torch_expected = GatherSingleCore.golden(torch_input)
+
+    # Create input tensor on scattered cores
+    ttnn_input = create_scattered_input_tensor(device, torch_input, valid_sender_cores, shard_shape, tile)
+    logger.info(f"Created input tensor sharded across {num_senders} scattered cores")
+
+    # Create output tensor on gather core
+    ttnn_output = create_output_tensor(device, output_shape, gather_core, tile)
+
+    # Run gather operation using the scattered cores variant
+    logger.info("Running gather operation on scattered cores...")
+    ttnn_result = GatherSingleCore.op_scattered(ttnn_input, ttnn_output, valid_sender_cores, noc=None)
+
+    # Convert back to torch for verification
+    output_torch = ttnn.to_torch(ttnn_result)
+
+    # Verify output shape
+    assert output_torch.shape == output_shape, f"Expected shape {output_shape}, got {output_torch.shape}"
+
+    # Verify that the output matches the expected
+    logger.info("Verifying gather results...")
+    assert torch.equal(output_torch, torch_expected), f"{description}: Output mismatch"
+    logger.info(f"{description} passed!")
+
+
+# =============================================================================
+# Gate/Up parallel gather test (A/B split pattern from DeepSeek MoE)
+# =============================================================================
+
+
+def get_gate_up_core_assignment():
+    """
+    Returns the A (Gate) and B (Up) core assignments for the 128-core split pattern.
+
+        Col:  0   1   2   3   4   5   6   7   8   9  10  11  12
+    Row 0:  | A | A | A | A | B | B | B | A | A | A | B | B | B |
+    Row 1:  | A | A | A | A | B | B | B | A | A | A | B | B | B |
+    Row 2:  | A | A | A | A | B | B | B | A | A | A | B | B | B |
+    Row 3:  | A | A | A | A | B | B | B | A | A | A | B | B | B |
+    Row 4:  | A | A | A | B | B | B | B | A | A | A | B | B | B |
+    Row 5:  | A | A | A | B | B | B | B | A | A | A | B | B | B |
+    Row 6:  | A | A | A | B | B | B | B | A | A | A | B | B | B |
+    Row 7:  | A | A | A | B | B | B | B | A | A | A | B | B | B |
+    Row 8:  | A | A | A | B | B | B | B | A | A | A | B | B |   |
+    Row 9:  | A | A | A | B | B | B | B | A | A | A | B | B | M |
+
+    A = Gate matmul (64 cores)
+    B = Up matmul (64 cores)
+    M = Mcast/Reduce core (12, 9)
+    """
+    a_cores = []  # Gate cores
+    b_cores = []  # Up cores
+
+    for row in range(10):
+        for col in range(13):
+            # Skip the M core at (12, 9)
+            if col == 12 and row == 9:
+                continue
+            # Skip (12, 8) - empty in diagram
+            if col == 12 and row == 8:
+                continue
+
+            # Determine if A or B based on the pattern
+            if row <= 3:
+                # Rows 0-3: cols 0-3 and 7-9 are A, cols 4-6 and 10-12 are B
+                if col <= 3 or (7 <= col <= 9):
+                    a_cores.append(ttnn.CoreCoord(col, row))
+                else:
+                    b_cores.append(ttnn.CoreCoord(col, row))
+            else:
+                # Rows 4-9: cols 0-2 and 7-9 are A, cols 3-6 and 10-12 are B
+                if col <= 2 or (7 <= col <= 9):
+                    a_cores.append(ttnn.CoreCoord(col, row))
+                else:
+                    b_cores.append(ttnn.CoreCoord(col, row))
+
+    return a_cores, b_cores
+
+
+def test_gather_gate_up_parallel_pattern(device):
+    """
+    Test two parallel gathers from the Gate/Up A/B split pattern.
+
+    This simulates the DeepSeek MoE scenario where:
+    - Gate matmul runs on 64 "A" cores (scattered pattern)
+    - Up matmul runs on 64 "B" cores (scattered pattern)
+    - Both gather to the M core at (12, 9)
+    - The gathers happen in sequence (could be parallel with different semaphores)
+
+    This test verifies that the per-core compile args correctly handle
+    the complex scattered pattern where A and B cores are interleaved.
+    """
+    device_grid_x = device.compute_with_storage_grid_size().x
+    device_grid_y = device.compute_with_storage_grid_size().y
+
+    # Need at least 13x10 grid for full pattern
+    if device_grid_x < 13 or device_grid_y < 10:
+        pytest.skip(f"Device grid too small (need 13x10, got {device_grid_x}x{device_grid_y})")
+
+    # Get core assignments
+    a_cores, b_cores = get_gate_up_core_assignment()
+    m_core = ttnn.CoreCoord(12, 9)  # Mcast/Reduce core
+
+    logger.info("=" * 70)
+    logger.info("Test: Gate/Up Parallel Gather (A/B Split Pattern)")
+    logger.info("=" * 70)
+    logger.info(f"A (Gate) cores: {len(a_cores)}")
+    logger.info(f"B (Up) cores: {len(b_cores)}")
+    logger.info(f"M (Gather) core: ({m_core.x}, {m_core.y})")
+
+    # Verify we have 64 cores each
+    assert len(a_cores) == 64, f"Expected 64 A cores, got {len(a_cores)}"
+    assert len(b_cores) == 64, f"Expected 64 B cores, got {len(b_cores)}"
+
+    # Configuration
+    width_per_core = 32
+    tile = ttnn.Tile([1, 32])
+
+    # Gate (A) tensor: 64 cores x 32 width = 2048 total width
+    a_total_width = width_per_core * len(a_cores)
+    a_shard_shape = (1, width_per_core)
+    a_output_shape = (1, a_total_width)
+
+    # Up (B) tensor: 64 cores x 32 width = 2048 total width
+    b_total_width = width_per_core * len(b_cores)
+    b_shard_shape = (1, width_per_core)
+    b_output_shape = (1, b_total_width)
+
+    logger.info(f"Gate shard: {a_shard_shape}, total: {a_output_shape}")
+    logger.info(f"Up shard: {b_shard_shape}, total: {b_output_shape}")
+
+    # ========================================================================
+    # Create Gate (A) input data
+    # ========================================================================
+    torch.manual_seed(42)
+    torch_a_input = torch.randn(a_output_shape, dtype=torch.bfloat16)
+    torch_a_expected = torch_a_input.clone()
+
+    # ========================================================================
+    # Create Up (B) input data
+    # ========================================================================
+    torch.manual_seed(123)
+    torch_b_input = torch.randn(b_output_shape, dtype=torch.bfloat16)
+    torch_b_expected = torch_b_input.clone()
+
+    # ========================================================================
+    # Create sharded tensors on A and B cores
+    # ========================================================================
+    ttnn_a_input = create_scattered_input_tensor(device, torch_a_input, a_cores, a_shard_shape, tile)
+    ttnn_b_input = create_scattered_input_tensor(device, torch_b_input, b_cores, b_shard_shape, tile)
+
+    logger.info(f"Created Gate input sharded across {len(a_cores)} A cores")
+    logger.info(f"Created Up input sharded across {len(b_cores)} B cores")
+
+    # ========================================================================
+    # Create output tensors (both gather to M core)
+    # ========================================================================
+    ttnn_a_output = create_output_tensor(device, a_output_shape, m_core, tile)
+    ttnn_b_output = create_output_tensor(device, b_output_shape, m_core, tile)
+
+    # ========================================================================
+    # Run Gate (A) gather
+    # ========================================================================
+    logger.info("-" * 70)
+    logger.info("Running Gate (A) gather from 64 scattered cores...")
+    ttnn_a_result = GatherSingleCore.op_scattered(ttnn_a_input, ttnn_a_output, a_cores, noc=None)
+    output_a_torch = ttnn.to_torch(ttnn_a_result)
+
+    # Verify Gate gather
+    assert torch.equal(output_a_torch, torch_a_expected), "Gate (A) gather failed"
+    logger.info("Gate (A) gather: PASSED")
+
+    # ========================================================================
+    # Run Up (B) gather
+    # ========================================================================
+    logger.info("-" * 70)
+    logger.info("Running Up (B) gather from 64 scattered cores...")
+    ttnn_b_result = GatherSingleCore.op_scattered(ttnn_b_input, ttnn_b_output, b_cores, noc=None)
+    output_b_torch = ttnn.to_torch(ttnn_b_result)
+
+    # Verify Up gather
+    assert torch.equal(output_b_torch, torch_b_expected), "Up (B) gather failed"
+    logger.info("Up (B) gather: PASSED")
+
+    # ========================================================================
+    # Summary
+    # ========================================================================
+    logger.info("=" * 70)
+    logger.info("SUCCESS: Both Gate and Up gathers completed correctly!")
+    logger.info(f"  Gate (A): Gathered {a_total_width} elements from {len(a_cores)} scattered cores")
+    logger.info(f"  Up (B):   Gathered {b_total_width} elements from {len(b_cores)} scattered cores")
+    logger.info("=" * 70)

--- a/models/demos/deepseek_v3_b1/unified_kernels/gather.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/gather.hpp
@@ -53,7 +53,8 @@ struct Gather {
 
     // Sender args (NCRISC): [dest_noc_x, dest_noc_y, data_size_bytes, receiver_semaphore_id,
     //                        src_cb, src_num_pages, sender_grid_start_x, sender_grid_start_y,
-    //                        sender_grid_end_x, sender_grid_end_y, row_major, receiver_data_addr]
+    //                        sender_grid_end_x, sender_grid_end_y, row_major, receiver_data_addr,
+    //                        sender_idx]
     struct SenderArgs {
         uint32_t dest_noc_x;
         uint32_t dest_noc_y;
@@ -67,6 +68,7 @@ struct Gather {
         uint32_t sender_grid_end_y;
         uint32_t row_major;
         uint32_t receiver_data_addr;
+        uint32_t sender_idx;  // Per-core sender index (only used if UsePerCoreSenderIdx=true)
     };
 
     // Compute args (TRISC) - not used for gather (dataflow only)
@@ -81,8 +83,9 @@ struct Gather {
     // IsSenderCore: compile-time flag to distinguish sender vs receiver cores
     // IsReceiverCore: compile-time flag for receiver cores
     // pop_src: whether to pop the source CB after sending
+    // UsePerCoreSenderIdx: compile-time flag for scattered vs grid-based indexing
     // ========================================================================
-    template <bool IsSenderCore, bool IsReceiverCore, bool pop_src>
+    template <bool IsSenderCore, bool IsReceiverCore, bool pop_src, bool UsePerCoreSenderIdx = false>
     class Op {
     public:
         void operator()(const RTArgs& args) { impl(args); }
@@ -100,10 +103,20 @@ struct Gather {
                 // Get source address from CB
                 uint32_t input_data_addr = get_read_ptr(args.src_cb);
 
-                // Compute per-core offset based on logical core coordinates
-                // Note: my_logical_x_/y_ are global variables set by firmware
-                uint32_t core_index = unified_kernels::linear_id_in_grid<true>(
-                    args.sender_grid_start_x, args.sender_grid_start_y, args.sender_grid_end_x, args.sender_grid_end_y);
+                // Compute per-core offset using compile-time branching
+                // For scattered cores (UsePerCoreSenderIdx=true), use the provided sender_idx
+                // For rectangular grids (UsePerCoreSenderIdx=false), compute from grid position
+                uint32_t core_index;
+                if constexpr (UsePerCoreSenderIdx) {
+                    core_index = args.sender_idx;
+                } else {
+                    // Note: my_logical_x_/y_ are global variables set by firmware
+                    core_index = unified_kernels::linear_id_in_grid<true>(
+                        args.sender_grid_start_x,
+                        args.sender_grid_start_y,
+                        args.sender_grid_end_x,
+                        args.sender_grid_end_y);
+                }
                 uint32_t offset = core_index * args.data_size_bytes;
 
                 uint32_t receiver_semaphore_addr = get_semaphore(args.receiver_semaphore_id);


### PR DESCRIPTION
### Ticket
N/A

### Problem description
The gather operation only supports collecting data from cores that form a contiguous rectangular grid, limiting its use for non-contiguous core patterns like MLP shared experts. 

The use-case is for issuing a gather on op A or op B separately:

        Col:  0   1   2   3   4   5   6   7   8   9  10  11  12
    Row 0:  | A | A | A | A | B | B | B | A | A | A | B | B | B |
    Row 1:  | A | A | A | A | B | B | B | A | A | A | B | B | B |
    Row 2:  | A | A | A | A | B | B | B | A | A | A | B | B | B |
    Row 3:  | A | A | A | A | B | B | B | A | A | A | B | B | B |
    Row 4:  | A | A | A | B | B | B | B | A | A | A | B | B | B |
    Row 5:  | A | A | A | B | B | B | B | A | A | A | B | B | B |
    Row 6:  | A | A | A | B | B | B | B | A | A | A | B | B | B |
    Row 7:  | A | A | A | B | B | B | B | A | A | A | B | B | B |
    Row 8:  | A | A | A | B | B | B | B | A | A | A | B | B |   |
    Row 9:  | A | A | A | B | B | B | B | A | A | A | B | B | M |




### What's changed
- Add `op_scattered()` method to `GatherSingleCore` that enables gathering data from non-contiguous cores using per-core sender indices
- Add `use_per_core_sender_idx` and `sender_idx` compile-time args to the gather kernel with `if constexpr` branching for scattered vs grid mode
- Refactor `op()` and `op_scattered()` to share common helper methods (`_split_cores_by_noc`, `_build_gather_program`)
- Add input validation for output tensor single-core requirement
- Support additional dtypes (`bfloat8_b`, `bfloat4_b`, `float32`, `uint16`, `uint32`)
- Add tests for scattered gather functionality including the MLP shared expert pattern


### CI Runs
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/21690615931) CI passes
- [x] New/Existing tests provide coverage for changes