### PR TITLE
Support for local tile reduce using DST accum

### DIFF
--- a/models/demos/deepseek_v3_b1/micro_ops/local_reduce/__init__.py
+++ b/models/demos/deepseek_v3_b1/micro_ops/local_reduce/__init__.py
@@ -1,0 +1,7 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+from .op import LocalReduceOp
+
+__all__ = ["LocalReduceOp"]

--- a/models/demos/deepseek_v3_b1/micro_ops/local_reduce/kernels/local_reduce_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/micro_ops/local_reduce/kernels/local_reduce_kernel.cpp
@@ -37,18 +37,16 @@ void kernel_main() {
     deepseek_b1_ops::LocalReduce::WriterArgs local_reduce_args{};
 
 #elif defined(COMPILE_FOR_TRISC)
-    using LocalReduceCTArgs = deepseek_b1_ops::LocalReduce::ComputeCTArgs;
-
     constexpr uint32_t in_cb = get_named_compile_time_arg_val("local_reduce_in_cb");
     constexpr uint32_t out_cb = get_named_compile_time_arg_val("local_reduce_out_cb");
-    constexpr uint32_t num_tiles = get_named_compile_time_arg_val("local_reduce_num_tiles");
-    constexpr uint32_t apply_silu = get_named_compile_time_arg_val("local_reduce_apply_silu");
+
+    using LocalReduceCTArgs = deepseek_b1_ops::LocalReduce::ComputeCTArgs<
+        get_named_compile_time_arg_val("local_reduce_num_tiles"),
+        get_named_compile_time_arg_val("local_reduce_apply_silu") == 1>;
 
     deepseek_b1_ops::LocalReduce::ComputeArgs local_reduce_args{
         .in_cb = in_cb,
         .out_cb = out_cb,
-        .num_tiles = num_tiles,
-        .apply_silu = apply_silu == 1,
     };
 #endif
 

--- a/models/demos/deepseek_v3_b1/micro_ops/local_reduce/kernels/local_reduce_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/micro_ops/local_reduce/kernels/local_reduce_kernel.cpp
@@ -1,0 +1,57 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+// SPDX-License-Identifier: Apache-2.0
+
+// Local Reduce unified kernel
+// Element-wise sum reduction: output = in_cb[0] + in_cb[1] + ... + in_cb[n-1]
+// Optionally applies SiLU activation: output = SiLU(sum)
+//
+// NCRISC: Signals sharded CB is ready
+// BRISC: No-op
+// TRISC: Performs reduction via LocalReduce::Op
+
+#include "../../../unified_kernels/kernel_op_api.hpp"
+#include "../../../unified_kernels/kernel_utils.hpp"
+#include "../../../unified_kernels/local_reduce.hpp"
+
+struct Core {
+    static constexpr bool is_active_core = get_named_compile_time_arg_val("is_active_core") == 1;
+};
+
+void kernel_main() {
+#if defined(COMPILE_FOR_NCRISC)
+    using LocalReduceCTArgs = deepseek_b1_ops::LocalReduce::ReaderCTArgs;
+
+    constexpr uint32_t in_cb = get_named_compile_time_arg_val("local_reduce_in_cb");
+    constexpr uint32_t num_tiles = get_named_compile_time_arg_val("local_reduce_num_tiles");
+
+    // Setup sharded buffer
+    if constexpr (Core::is_active_core) {
+        unified_kernels::setup_sharded_buffer(in_cb, num_tiles);
+    }
+
+    deepseek_b1_ops::LocalReduce::ReaderArgs local_reduce_args{};
+
+#elif defined(COMPILE_FOR_BRISC)
+    using LocalReduceCTArgs = deepseek_b1_ops::LocalReduce::WriterCTArgs;
+
+    deepseek_b1_ops::LocalReduce::WriterArgs local_reduce_args{};
+
+#elif defined(COMPILE_FOR_TRISC)
+    using LocalReduceCTArgs = deepseek_b1_ops::LocalReduce::ComputeCTArgs;
+
+    constexpr uint32_t in_cb = get_named_compile_time_arg_val("local_reduce_in_cb");
+    constexpr uint32_t out_cb = get_named_compile_time_arg_val("local_reduce_out_cb");
+    constexpr uint32_t num_tiles = get_named_compile_time_arg_val("local_reduce_num_tiles");
+    constexpr uint32_t apply_silu = get_named_compile_time_arg_val("local_reduce_apply_silu");
+
+    deepseek_b1_ops::LocalReduce::ComputeArgs local_reduce_args{
+        .in_cb = in_cb,
+        .out_cb = out_cb,
+        .num_tiles = num_tiles,
+        .apply_silu = apply_silu == 1,
+    };
+#endif
+
+    deepseek_b1_ops::LocalReduce::Op<LocalReduceCTArgs, Core::is_active_core> local_reduce;
+    local_reduce(local_reduce_args);
+}

--- a/models/demos/deepseek_v3_b1/micro_ops/local_reduce/op.py
+++ b/models/demos/deepseek_v3_b1/micro_ops/local_reduce/op.py
@@ -1,0 +1,192 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Local Reduce micro-op.
+
+Element-wise reduction of N tiles from single CB with optional SiLU activation:
+    output = SiLU(in[0] + in[1] + ... + in[n-1])  if apply_silu=True
+    output = in[0] + in[1] + ... + in[n-1]        if apply_silu=False
+
+All input tiles come from the same circular buffer.
+
+Face-view optimization: When tile dimensions allow (e.g., 16 [1,32] tiles = 2 [16,16] faces),
+the kernel can process fewer, larger tiles for better efficiency.
+"""
+
+import torch
+
+import ttnn
+from models.demos.deepseek_v3_b1.unified_kernel_descriptor import (
+    UnifiedCompileTimeCoreDescriptor,
+    UnifiedKernelDescriptor,
+)
+
+# Face dimensions (hardware constant)
+FACE_HEIGHT = 16
+FACE_WIDTH = 16
+FACE_ELEMENTS = FACE_HEIGHT * FACE_WIDTH  # 256
+
+
+class LocalReduceOp:
+    """
+    Element-wise reduction of N tiles with optional SiLU activation.
+
+    Computes: output = in[0] + in[1] + ... + in[n-1] (all from same CB)
+              or with SiLU: output = SiLU(in[0] + in[1] + ... + in[n-1])
+
+    Supports face-view optimization for small tiles (e.g., [1,32]) that can
+    be grouped into [16,16] faces for more efficient processing.
+    """
+
+    @staticmethod
+    def golden(*inputs, apply_silu=False):
+        """PyTorch reference: sum of all inputs with optional SiLU"""
+        result = inputs[0]
+        for inp in inputs[1:]:
+            result = result + inp
+        if apply_silu:
+            result = torch.nn.functional.silu(result)
+        return result
+
+    @staticmethod
+    def can_use_face_view(tile_h, tile_w, num_tiles):
+        """
+        Check if face-view optimization can be applied.
+
+        Face-view optimization requires:
+        1. Tiles SMALLER than a face (i.e., not already [16,16])
+        2. Small tiles that evenly divide into faces (256 elements)
+        3. Total elements form an even number of faces (2, 4, 6, ...)
+        """
+        elements_per_tile = tile_h * tile_w
+        total_elements = elements_per_tile * num_tiles
+
+        # Don't apply optimization if tiles are already face-sized or larger
+        if elements_per_tile >= FACE_ELEMENTS:
+            return False
+
+        # Check if tiles divide evenly into faces
+        if FACE_ELEMENTS % elements_per_tile != 0:
+            return False
+
+        # Check if total elements form complete faces
+        if total_elements % FACE_ELEMENTS != 0:
+            return False
+
+        # Check if we have an even number of faces (for pairwise addition)
+        num_faces = total_elements // FACE_ELEMENTS
+        if num_faces < 2 or num_faces % 2 != 0:
+            return False
+
+        return True
+
+    @staticmethod
+    def op(input_tensor, output_tensor, num_tiles, apply_silu=False, use_face_view=None):
+        """
+        Execute element-wise reduction with optional SiLU using dest register with acc_to_dest.
+
+        Uses single input CB - DST is zeroed at kernel startup, enabling
+        direct accumulation with acc_to_dest mode.
+
+        Args:
+            input_tensor: Input tensor containing N tiles stacked (shape [N*tile_h, tile_w])
+            output_tensor: Pre-allocated output tensor (shape [tile_h, tile_w])
+            num_tiles: Number of tiles to accumulate
+            apply_silu: Whether to apply SiLU activation after accumulation
+            use_face_view: Override auto-detection of face-view optimization.
+                           If None, auto-detect based on tile dimensions.
+
+        Returns:
+            Output tensor with in[0] + in[1] + ... + in[n-1] (optionally with SiLU)
+        """
+        all_cores = input_tensor.memory_config().shard_spec.grid
+        assert all_cores.num_cores() == 1, "Only single core is supported"
+        assert num_tiles >= 2, "Need at least 2 tiles to accumulate"
+        assert num_tiles % 2 == 0, "Number of tiles must be even"
+
+        # Get tile dimensions from input tensor
+        input_tile = input_tensor.tile
+        tile_h, tile_w = input_tile.tile_shape
+
+        # Determine if face-view optimization applies
+        if use_face_view is None:
+            use_face_view = LocalReduceOp.can_use_face_view(tile_h, tile_w, num_tiles)
+
+        # CB indices
+        in_cb = 0  # Input (N tiles)
+        out_cb = 1  # Output (1 tile)
+
+        if use_face_view:
+            # Face-view mode: treat input as N [16,16] faces
+            elements_per_tile = tile_h * tile_w
+            total_elements = elements_per_tile * num_tiles
+            kernel_num_tiles = total_elements // FACE_ELEMENTS  # Number of faces
+        else:
+            # Normal mode: use original tile dimensions
+            kernel_num_tiles = num_tiles
+
+        # CB descriptors
+        in_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(in_cb, input_tensor)
+        out_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(out_cb, output_tensor)
+
+        # For face-view mode, override the tile descriptor and page_size
+        if use_face_view:
+            # Create face tile and get its size
+            face_tile = ttnn.Tile([FACE_HEIGHT, FACE_WIDTH])
+            face_tile_desc = ttnn.TileDescriptor(FACE_HEIGHT, FACE_WIDTH, False)
+            face_tile_size = face_tile.get_tile_size(input_tensor.dtype)
+
+            # Update input CB with face tile configuration
+            in_cb_descriptor.format_descriptors[0].tile = face_tile_desc
+            in_cb_descriptor.format_descriptors[0].page_size = face_tile_size
+
+            # Update output CB with face tile configuration
+            out_cb_descriptor.format_descriptors[0].tile = face_tile_desc
+            out_cb_descriptor.format_descriptors[0].page_size = face_tile_size
+
+        # Named compile-time args
+        ncrisc_named_compile_time_args = [
+            ("local_reduce_in_cb", in_cb),
+            ("local_reduce_num_tiles", kernel_num_tiles),
+        ]
+
+        trisc_named_compile_time_args = [
+            ("local_reduce_in_cb", in_cb),
+            ("local_reduce_out_cb", out_cb),
+            ("local_reduce_num_tiles", kernel_num_tiles),
+            ("local_reduce_apply_silu", 1 if apply_silu else 0),
+        ]
+
+        unified_kernel = UnifiedKernelDescriptor(
+            kernel_source="models/demos/deepseek_v3_b1/micro_ops/local_reduce/kernels/local_reduce_kernel.cpp",
+            core_ranges=all_cores,
+            ncrisc_named_compile_time_args=ncrisc_named_compile_time_args,
+            brisc_named_compile_time_args=[],
+            trisc_named_compile_time_args=trisc_named_compile_time_args,
+            trisc_compute_config=ttnn.ComputeConfigDescriptor(
+                math_fidelity=ttnn.MathFidelity.HiFi4,
+                math_approx_mode=apply_silu,  # SiLU uses approximation
+                fp32_dest_acc_en=False,
+                dst_full_sync_en=False,
+            ),
+            unified_compile_time_core_descriptors=[
+                UnifiedCompileTimeCoreDescriptor(
+                    named_compile_time_arg="is_active_core",
+                    core_range=all_cores,
+                    value=1,
+                    other_value=0,
+                ),
+            ],
+        )
+
+        program_descriptor = ttnn.ProgramDescriptor(
+            kernels=unified_kernel.get_kernel_descriptors().kernels,
+            cbs=[in_cb_descriptor, out_cb_descriptor],
+        )
+
+        io_tensors = [input_tensor, output_tensor]
+        output = ttnn.generic_op(io_tensors, program_descriptor)
+
+        return output

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_local_reduce.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_local_reduce.py
@@ -1,0 +1,238 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Tests element-wise reduction of N tiles with optional SiLU activation.
+
+output = SiLU(in[0] + in[1] + ... + in[n-1])  if apply_silu=True
+output = in[0] + in[1] + ... + in[n-1]        if apply_silu=False
+
+All input tiles come from the same circular buffer. We use the local reduce operation
+to perform the reduction.
+
+This is used in MOE-shared expert / Dense MLP when we shard matmul on inner-dim
+across multiple cores. We accumulate results and optionally apply activation.
+"""
+
+import pytest
+import torch
+from loguru import logger
+
+import ttnn
+from models.common.utility_functions import comp_pcc
+from models.demos.deepseek_v3_b1.micro_ops.local_reduce.op import LocalReduceOp
+
+
+@pytest.mark.parametrize(
+    "tile_h, tile_w, num_tiles, apply_silu",
+    [
+        # Without SiLU
+        (32, 32, 2, False),  # Standard tiles, 2 inputs
+        (32, 32, 4, False),  # Standard tiles, 4 inputs
+        (32, 32, 8, False),  # Standard tiles, 8 inputs
+        (16, 16, 4, False),  # Small tiles, 4 inputs
+        (1, 32, 6, False),  # Tiny tiles, 6 inputs
+        # With SiLU
+        (32, 32, 2, True),  # Standard tiles, with SiLU
+        (32, 32, 4, True),  # Standard tiles, 4 inputs, with SiLU
+        (16, 16, 4, True),  # Small tiles, with SiLU
+        (1, 32, 6, True),  # Tiny tiles, with SiLU
+    ],
+)
+def test_local_reduce(device, tile_h, tile_w, num_tiles, apply_silu):
+    tile = ttnn.Tile([tile_h, tile_w])
+
+    core = ttnn.CoreCoord(0, 0)
+    core_grid = ttnn.CoreRangeSet({ttnn.CoreRange(core, core)})
+
+    silu_str = "with SiLU" if apply_silu else "no SiLU"
+    logger.info(f"Testing local reduce: tile=[{tile_h}, {tile_w}], num_tiles={num_tiles}, {silu_str}")
+
+    # Create N input tensors
+    torch.manual_seed(42)
+    torch_inputs = [torch.randn((tile_h, tile_w), dtype=torch.bfloat16) for _ in range(num_tiles)]
+
+    # Golden reference: sum of all inputs with optional SiLU
+    torch_expected = LocalReduceOp.golden(*[t.float() for t in torch_inputs], apply_silu=apply_silu).bfloat16()
+
+    # Stack inputs into single tensor: [N*tile_h, tile_w] (N tiles)
+    torch_input_stacked = torch.cat(torch_inputs, dim=0)
+
+    logger.info(f"Input (stacked) shape: {torch_input_stacked.shape}")
+    logger.info(f"Output shape: {torch_expected.shape}")
+
+    # Create sharded memory config for input (N tiles)
+    input_shard_shape = (num_tiles * tile_h, tile_w)
+    input_shard_spec = ttnn.ShardSpec(
+        core_grid,
+        input_shard_shape,
+        ttnn.ShardOrientation.ROW_MAJOR,
+    )
+    input_mem_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, input_shard_spec)
+
+    ttnn_input = ttnn.from_torch(
+        torch_input_stacked,
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        memory_config=input_mem_config,
+        tile=tile,
+    )
+
+    output_shard_shape = (tile_h, tile_w)
+    output_shard_spec = ttnn.ShardSpec(
+        core_grid,
+        output_shard_shape,
+        ttnn.ShardOrientation.ROW_MAJOR,
+    )
+    output_mem_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, output_shard_spec)
+
+    ttnn_output = ttnn.from_torch(
+        torch.zeros((tile_h, tile_w), dtype=torch.bfloat16),
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        memory_config=output_mem_config,
+        tile=tile,
+    )
+
+    logger.info(f"Running local reduce {'+ SiLU ' if apply_silu else ''}operation...")
+    ttnn_result = LocalReduceOp.op(ttnn_input, ttnn_output, num_tiles, apply_silu=apply_silu)
+
+    # Convert back to torch and verify
+    output_torch = ttnn.to_torch(ttnn_result)
+    assert output_torch.shape == (tile_h, tile_w), f"Expected shape ({tile_h}, {tile_w}), got {output_torch.shape}"
+
+    # SiLU uses approximation, so we use a slightly lower PCC threshold
+    pcc_threshold = 0.998 if apply_silu else 0.999
+    passing, pcc_message = comp_pcc(torch_expected, output_torch, pcc_threshold)
+    logger.info(pcc_message)
+
+    assert passing, pcc_message
+
+    logger.info(f"Test passed! (tile=[{tile_h}, {tile_w}], num_tiles={num_tiles}, {silu_str})")
+
+
+@pytest.mark.parametrize("num_faces", [2, 4, 6, 8])
+@pytest.mark.parametrize("apply_silu", [False, True])
+def test_local_reduce_face_view(device, num_faces, apply_silu):
+    """
+    Test automatic face-view optimization at the op/kernel level.
+
+    Input: N*8 tiles of [1,32] = N*256 elements = N faces
+    The op detects this can be viewed as N [16,16] faces and:
+    1. Configures CB with [16,16] tile descriptor
+    2. Passes num_tiles=N to kernel
+    3. N/2 add_tiles calls instead of N*4
+
+    Memory layout: Elements are grouped into faces of 256 elements each.
+    Output: sum of all faces element-wise, with optional SiLU activation.
+    """
+    # Original view: N*8 tiles of [1,32] (8 tiles per face)
+    orig_tile_h, orig_tile_w = 1, 32
+    tiles_per_face = 256 // (orig_tile_h * orig_tile_w)  # 8 tiles per face
+    orig_num_tiles = num_faces * tiles_per_face
+    orig_tile = ttnn.Tile([orig_tile_h, orig_tile_w])
+
+    # Output will be a [16,16] face
+    output_tile_h, output_tile_w = 16, 16
+    output_tile = ttnn.Tile([output_tile_h, output_tile_w])
+
+    core = ttnn.CoreCoord(0, 0)
+    core_grid = ttnn.CoreRangeSet({ttnn.CoreRange(core, core)})
+
+    silu_str = "with SiLU" if apply_silu else "no SiLU"
+    logger.info(
+        f"Testing face-view: {orig_num_tiles}x[{orig_tile_h},{orig_tile_w}] -> {num_faces}x[16,16] faces, {silu_str}"
+    )
+
+    # Create input data
+    torch.manual_seed(42)
+    torch_inputs = [torch.randn((orig_tile_h, orig_tile_w), dtype=torch.bfloat16) for _ in range(orig_num_tiles)]
+
+    # Stack inputs
+    torch_input_stacked = torch.cat(torch_inputs, dim=0)
+    total_elements = orig_num_tiles * orig_tile_h * orig_tile_w
+    assert torch_input_stacked.numel() == total_elements
+
+    # Golden: element-wise sum of all faces, then optional SiLU
+    input_flat = torch_input_stacked.flatten().float()
+    faces = [input_flat[i * 256 : (i + 1) * 256] for i in range(num_faces)]
+    sum_result = sum(faces)
+    if apply_silu:
+        torch_expected = torch.nn.functional.silu(sum_result).view(output_tile_h, output_tile_w).bfloat16()
+    else:
+        torch_expected = sum_result.view(output_tile_h, output_tile_w).bfloat16()
+
+    logger.info(f"Input: {orig_num_tiles} tiles, {total_elements} elements, {num_faces} faces")
+    logger.info(f"Output shape: {torch_expected.shape}")
+
+    # Create sharded memory config
+    input_shard_shape = (orig_num_tiles * orig_tile_h, orig_tile_w)
+    input_shard_spec = ttnn.ShardSpec(
+        core_grid,
+        input_shard_shape,
+        ttnn.ShardOrientation.ROW_MAJOR,
+    )
+    input_mem_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, input_shard_spec)
+
+    ttnn_input = ttnn.from_torch(
+        torch_input_stacked,
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        memory_config=input_mem_config,
+        tile=orig_tile,
+    )
+
+    # Create output tensor - [16,16] face
+    output_shard_shape = (output_tile_h, output_tile_w)
+    output_shard_spec = ttnn.ShardSpec(
+        core_grid,
+        output_shard_shape,
+        ttnn.ShardOrientation.ROW_MAJOR,
+    )
+    output_mem_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, output_shard_spec)
+
+    ttnn_output = ttnn.from_torch(
+        torch.zeros((output_tile_h, output_tile_w), dtype=torch.bfloat16),
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        memory_config=output_mem_config,
+        tile=output_tile,
+    )
+
+    # Verify face-view optimization will be applied
+    assert LocalReduceOp.can_use_face_view(
+        orig_tile_h, orig_tile_w, orig_num_tiles
+    ), f"Face-view optimization should be applicable for {orig_num_tiles} [1,32] tiles"
+
+    # Log the optimization benefit
+    original_add_calls = orig_num_tiles // 2
+    optimized_add_calls = num_faces // 2
+    logger.info(
+        f"Optimization: {original_add_calls} add_tiles -> {optimized_add_calls} add_tiles "
+        f"({original_add_calls - optimized_add_calls} fewer calls)"
+    )
+
+    # Run operation with face-view optimization
+    logger.info(f"Running local reduce {'+ SiLU ' if apply_silu else ''}with {num_faces} faces...")
+    ttnn_result = LocalReduceOp.op(ttnn_input, ttnn_output, orig_num_tiles, apply_silu=apply_silu, use_face_view=True)
+
+    # Convert back to torch and verify
+    output_torch = ttnn.to_torch(ttnn_result)
+    assert output_torch.shape == (
+        output_tile_h,
+        output_tile_w,
+    ), f"Expected shape ({output_tile_h}, {output_tile_w}), got {output_torch.shape}"
+
+    # SiLU uses approximation, so we use a slightly lower PCC threshold
+    pcc_threshold = 0.998 if apply_silu else 0.999
+    passing, pcc_message = comp_pcc(torch_expected, output_torch, pcc_threshold)
+    logger.info(pcc_message)
+
+    assert passing, pcc_message
+
+    logger.info(f"Face-view test passed! ({num_faces} faces, {silu_str})")

--- a/models/demos/deepseek_v3_b1/unified_kernels/local_reduce.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/local_reduce.hpp
@@ -35,19 +35,18 @@ namespace deepseek_b1_ops {
 struct LocalReduce {
     struct ReaderCTArgs {};
     struct WriterCTArgs {};
+    template <uint32_t NumTiles, bool ApplySilu>
     struct ComputeCTArgs {
-        uint32_t num_tiles;  // Number of tiles to reduce
-        bool apply_silu;     // Whether to apply SiLU after reduction
+        static constexpr uint32_t num_tiles = NumTiles;
+        static constexpr bool apply_silu = ApplySilu;
     };
 
     struct ReaderArgs {};
     struct WriterArgs {};
 
     struct ComputeArgs {
-        uint32_t in_cb;      // Input CB with N tiles
-        uint32_t out_cb;     // Output CB
-        uint32_t num_tiles;  // Number of tiles to reduce
-        bool apply_silu;     // Whether to apply SiLU after reduction
+        uint32_t in_cb;   // Input CB with N tiles
+        uint32_t out_cb;  // Output CB
     };
 
     using RTArgs = unified_kernels::SelectByRISCV<ReaderArgs, WriterArgs, ComputeArgs>;
@@ -64,8 +63,15 @@ struct LocalReduce {
     private:
         void impl(const RTArgs& args) {
 #if defined(COMPILE_FOR_TRISC)
-            const uint32_t num_tiles = args.num_tiles;
-            const bool apply_silu = args.apply_silu;
+            constexpr uint32_t num_tiles = CTArgs::num_tiles;
+            constexpr bool apply_silu = CTArgs::apply_silu;
+
+            // Initialize operations before waiting for data
+            binary_op_init_common(args.in_cb, args.in_cb, args.out_cb);
+            add_tiles_init(args.in_cb, args.in_cb, true /* acc_to_dest */);
+            if constexpr (apply_silu) {
+                silu_tile_init();
+            }
 
             // Wait for all input tiles
             cb_wait_front(args.in_cb, num_tiles);
@@ -73,23 +79,18 @@ struct LocalReduce {
             // Reserve output
             cb_reserve_back(args.out_cb, 1);
 
-            // Initialize binary operation
-            binary_op_init_common(args.in_cb, args.in_cb, args.out_cb);
-
             // Acquire dest register
             tile_regs_acquire();
 
             // Sum all tiles using acc_to_dest mode
             // acc_to_dest=true means: DST[0] = A + B + DST[0]
             // DST accumulator starts at zero for each tile position
-            add_tiles_init(args.in_cb, args.in_cb, true /* acc_to_dest */);
             for (uint32_t i = 0; i < num_tiles; i += 2) {
                 add_tiles(args.in_cb, args.in_cb, i, i + 1, 0);
             }
 
             // Optionally apply SiLU activation
-            if (apply_silu) {
-                silu_tile_init();
+            if constexpr (apply_silu) {
                 silu_tile(0);
             }
 

--- a/models/demos/deepseek_v3_b1/unified_kernels/local_reduce.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/local_reduce.hpp
@@ -1,0 +1,114 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "kernel_op_api.hpp"
+
+#if defined(COMPILE_FOR_BRISC)
+#include "api/dataflow/dataflow_api.h"
+#elif defined(COMPILE_FOR_NCRISC)
+#include "api/dataflow/dataflow_api.h"
+#elif defined(COMPILE_FOR_TRISC)
+#include "compute_kernel_api.h"
+#include "compute_kernel_api/eltwise_binary.h"
+#include "compute_kernel_api/eltwise_unary/sfpu_split_includes.h"
+#include "compute_kernel_api/tile_move_copy.h"
+#endif
+
+namespace deepseek_b1_ops {
+
+// ============================================================================
+// LocalReduce micro-op: Element-wise sum reduction of N tiles with optional SiLU
+//
+// Computes: output = in_cb[0] + in_cb[1] + ... + in_cb[n-1]
+//
+// With optional SiLU: output = SiLU(result)
+//
+// All input tiles come from the same circular buffer.
+// Uses acc_to_dest mode for efficient pairwise accumulation.
+//
+// CB Layout:
+//   CB0 (in):  Contains N tiles to reduce
+//   CB1 (out): Output (1 tile)
+// ============================================================================
+struct LocalReduce {
+    struct ReaderCTArgs {};
+    struct WriterCTArgs {};
+    struct ComputeCTArgs {
+        uint32_t num_tiles;  // Number of tiles to reduce
+        bool apply_silu;     // Whether to apply SiLU after reduction
+    };
+
+    struct ReaderArgs {};
+    struct WriterArgs {};
+
+    struct ComputeArgs {
+        uint32_t in_cb;      // Input CB with N tiles
+        uint32_t out_cb;     // Output CB
+        uint32_t num_tiles;  // Number of tiles to reduce
+        bool apply_silu;     // Whether to apply SiLU after reduction
+    };
+
+    using RTArgs = unified_kernels::SelectByRISCV<ReaderArgs, WriterArgs, ComputeArgs>;
+
+    template <typename CTArgs, bool IsActiveCore>
+    class Op {
+    public:
+        void operator()(const RTArgs& args) {
+            if constexpr (IsActiveCore) {
+                impl(args);
+            }
+        }
+
+    private:
+        void impl(const RTArgs& args) {
+#if defined(COMPILE_FOR_TRISC)
+            const uint32_t num_tiles = args.num_tiles;
+            const bool apply_silu = args.apply_silu;
+
+            // Wait for all input tiles
+            cb_wait_front(args.in_cb, num_tiles);
+
+            // Reserve output
+            cb_reserve_back(args.out_cb, 1);
+
+            // Initialize binary operation
+            binary_op_init_common(args.in_cb, args.in_cb, args.out_cb);
+
+            // Acquire dest register
+            tile_regs_acquire();
+
+            // Sum all tiles using acc_to_dest mode
+            // acc_to_dest=true means: DST[0] = A + B + DST[0]
+            // DST accumulator starts at zero for each tile position
+            add_tiles_init(args.in_cb, args.in_cb, true /* acc_to_dest */);
+            for (uint32_t i = 0; i < num_tiles; i += 2) {
+                add_tiles(args.in_cb, args.in_cb, i, i + 1, 0);
+            }
+
+            // Optionally apply SiLU activation
+            if (apply_silu) {
+                silu_tile_init();
+                silu_tile(0);
+            }
+
+            // Commit and wait for compute
+            tile_regs_commit();
+            tile_regs_wait();
+
+            // Pack result
+            pack_tile(0, args.out_cb);
+
+            // Release dest register
+            tile_regs_release();
+
+            // Pop inputs and push output
+            cb_pop_front(args.in_cb, num_tiles);
+            cb_push_back(args.out_cb, 1);
+#endif
+        }
+    };
+};
+
+}  // namespace deepseek_b1_ops


### PR DESCRIPTION
### Ticket
N/A

### Problem description
Need a unified micro-op for element-wise tile reduction with optional SiLU activation for DeepSeek v3 model operations.

### What's changed
- Add `LocalReduceOp` that accumulates N tiles from a single circular buffer: `output = in[0] + in[1] + ... + in[n-1]`
- Support optional SiLU activation via `apply_silu` parameter
- Use `acc_to_dest` mode with DST zero-initialization
- Implement face-view optimization for small tiles (e.g., 16x [1,32] tiles → 2x [16,16] faces)
- Include 17 unit tests covering standard tiles, small tiles, SiLU activation, and face-view optimization

### CI Runs
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/21694792050) CI passes
- [x] New/Existing tests provide coverage for changes