### PR TITLE
WIP: Add watcher ring buffer support for Quasar architecture

### DIFF
--- a/tests/tt_metal/tt_metal/test_kernels/misc/watcher_ringbuf.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/misc/watcher_ringbuf.cpp
@@ -8,7 +8,7 @@
 /*
  * A test for the watcher waypointing feature.
 */
-#if defined(COMPILE_FOR_BRISC) || defined(COMPILE_FOR_NCRISC) || defined(COMPILE_FOR_ERISC) || defined(COMPILE_FOR_IDLE_ERISC)
+#if defined(COMPILE_FOR_DM) || defined(COMPILE_FOR_BRISC) || defined(COMPILE_FOR_NCRISC) || defined(COMPILE_FOR_ERISC) || defined(COMPILE_FOR_IDLE_ERISC)
 void kernel_main() {
 #else
 #include "compute_kernel_api/common.h"
@@ -20,13 +20,13 @@ void MAIN {
 #if (defined(UCK_CHLKC_UNPACK) and defined(TRISC0)) or \
     (defined(UCK_CHLKC_MATH) and defined(TRISC1)) or \
     (defined(UCK_CHLKC_PACK) and defined(TRISC2)) or \
-    (defined(COMPILE_FOR_BRISC) || defined(COMPILE_FOR_NCRISC) || defined(COMPILE_FOR_ERISC) || defined(COMPILE_FOR_IDLE_ERISC))
+    (defined(COMPILE_FOR_DM) || defined(COMPILE_FOR_BRISC) || defined(COMPILE_FOR_NCRISC) || defined(COMPILE_FOR_ERISC) || defined(COMPILE_FOR_IDLE_ERISC))
     for (uint32_t idx = 0; idx < 40; idx++) {
         WATCHER_RING_BUFFER_PUSH((idx + 1) + (idx << 16));
     }
 #endif
 
-#if defined(COMPILE_FOR_BRISC) || defined(COMPILE_FOR_NCRISC) || defined(COMPILE_FOR_ERISC) || defined(COMPILE_FOR_IDLE_ERISC)
+#if defined(COMPILE_FOR_DM) || defined(COMPILE_FOR_BRISC) || defined(COMPILE_FOR_NCRISC) || defined(COMPILE_FOR_ERISC) || defined(COMPILE_FOR_IDLE_ERISC)
 }
 #else
 }

--- a/tt_metal/hw/inc/internal/tt-2xx/quasar/core_config.h
+++ b/tt_metal/hw/inc/internal/tt-2xx/quasar/core_config.h
@@ -72,7 +72,6 @@ union subordinate_map_t {
 
 constexpr uint8_t MaxProcessorsPerCoreType = 24;
 constexpr uint8_t MaxDMProcessorsPerCoreType = 8;
-constexpr uint8_t NumTensixDispatchClasses = 3;
 constexpr uint8_t NumEthDispatchClasses = 2;
 constexpr uint8_t NumDramDispatchClasses = 1;
 constexpr uint8_t noc_size_x = 8;

--- a/tt_metal/impl/kernels/kernel.hpp
+++ b/tt_metal/impl/kernels/kernel.hpp
@@ -218,7 +218,8 @@ public:
             config.defines,
             config.named_compile_args),
         config_(config) {
-        this->dispatch_class_ = DISPATCH_CLASS_TENSIX_DM0 + enchantum::to_underlying(config.processor);
+        // Use HAL to map DM processor type to architecture-specific dispatch class
+        this->dispatch_class_ = DISPATCH_CLASS_TENSIX_DM0 + MetalContext::instance().hal().get_dm_dispatch_class(enchantum::to_underlying(config.processor));
     }
 
     ~DataMovementKernel() override = default;
@@ -298,9 +299,8 @@ public:
             config.defines,
             config.named_compile_args),
         config_(config) {
-        // Note: it's wrong to use HalProcessorClassType here, because DM == 0 and COMPUTE == 1,
-        // but DISPATCH_CLASS_TENSIX_COMPUTE == 2.
-        this->dispatch_class_ = DISPATCH_CLASS_TENSIX_COMPUTE;
+        // Use HAL to get the architecture-specific dispatch class for COMPUTE processors
+        this->dispatch_class_ = MetalContext::instance().hal().get_compute_dispatch_class();
     }
 
     ~ComputeKernel() override = default;

--- a/tt_metal/impl/program/dispatch.hpp
+++ b/tt_metal/impl/program/dispatch.hpp
@@ -11,6 +11,7 @@
 #include <vector_aligned.hpp>
 #include <array>
 #include <memory>
+#include <span>
 #include <unordered_map>
 #include <utility>
 #include <vector>
@@ -74,8 +75,8 @@ uint32_t configure_crta_offsets_for_kernel_groups(
     std::unordered_map<KernelHandle, std::shared_ptr<Kernel>>& kernels,
     std::vector<std::shared_ptr<KernelGroup>>& kernel_groups,
     uint32_t crta_base_offset,
-    std::array<uint32_t, DISPATCH_CLASS_MAX>& crta_offsets,
-    std::array<uint32_t, DISPATCH_CLASS_MAX>& crta_sizes);
+    std::span<uint32_t> crta_offsets,
+    std::span<uint32_t> crta_sizes);
 
 uint32_t finalize_rt_args(
     std::unordered_map<KernelHandle, std::shared_ptr<Kernel>>& kernels,
@@ -83,8 +84,8 @@ uint32_t finalize_rt_args(
     uint32_t base_offset,
     uint32_t programmable_core_type_index,
     uint32_t& rta_offset,
-    std::array<uint32_t, DISPATCH_CLASS_MAX>& crta_offsets,
-    std::array<uint32_t, DISPATCH_CLASS_MAX>& crta_sizes);
+    std::span<uint32_t> crta_offsets,
+    std::span<uint32_t> crta_sizes);
 
 uint32_t finalize_sems(
     uint32_t programmable_core_type_index,

--- a/tt_metal/impl/program/program.cpp
+++ b/tt_metal/impl/program/program.cpp
@@ -429,6 +429,7 @@ KernelGroup::KernelGroup(
     // Slow dispatch uses fixed addresses for the kernel config, configured here statically
     // Fast dispatch kernel config mangement happens under the CQ and will re-program the base
     const auto& hal = MetalContext::instance().hal();
+    this->rta_sizes.resize(hal.get_dispatch_class_count());
     for (uint32_t index = 0; index < hal.get_programmable_core_type_count(); index++) {
         kernel_config.kernel_config_base()[index] =
             hal.get_dev_addr(hal.get_programmable_core_type(index), HalL1MemAddrType::KERNEL_CONFIG);
@@ -1740,9 +1741,12 @@ uint32_t detail::ProgramImpl::finalize_program_offsets(
     const SemaphoresGetter& semaphores_getter,
     const DataflowBuffersGetter& dataflow_buffers_getter,
     tt::stl::Span<ProgramImpl*> programs) {
-    ProgramOffsetsState state;
-
     const auto& hal = MetalContext::instance().hal();
+    const uint32_t dispatch_class_count = hal.get_dispatch_class_count();
+
+    ProgramOffsetsState state;
+    state.crta_offsets.resize(dispatch_class_count);
+    state.crta_sizes.resize(dispatch_class_count);
 
     for (uint32_t index = 0; index < hal.get_programmable_core_type_count(); index++) {
         HalProgrammableCoreType programmable_core_type = hal.get_programmable_core_type(index);

--- a/tt_metal/impl/program/program_impl.hpp
+++ b/tt_metal/impl/program/program_impl.hpp
@@ -54,15 +54,16 @@ class MeshWorkloadImpl;
 
 enum dispatch_core_processor_classes {
     // Tensix processor classes
+    // On Quasar, all DMs share DISPATCH_CLASS_TENSIX_DM0 (class 0)
+    // On WH/BH, DM0 and DM1 have separate classes (0 and 1)
+    // See hal.get_dm_dispatch_class() and hal.get_compute_dispatch_class()
+    // for architecture-specific dispatch class assignment
     DISPATCH_CLASS_TENSIX_DM0 = 0,
     DISPATCH_CLASS_TENSIX_DM1 = 1,
-    DISPATCH_CLASS_TENSIX_COMPUTE = 2,
 
     // Ethernet processor classes
     DISPATCH_CLASS_ETH_DM0 = 0,
     DISPATCH_CLASS_ETH_DM1 = 1,
-
-    DISPATCH_CLASS_MAX = 3,
 };
 
 namespace experimental {
@@ -84,7 +85,7 @@ struct KernelGroup {
     CoreRangeSet core_ranges;
     // kernel_ids are ordered by dispatch class
     std::vector<KernelHandle> kernel_ids;
-    uint32_t rta_sizes[DISPATCH_CLASS_MAX]{};
+    std::vector<uint32_t> rta_sizes;
     uint32_t total_rta_size{};
     // kernel_text_offsets is indexed by processor index within core.
     std::vector<uint32_t> kernel_text_offsets;
@@ -106,8 +107,8 @@ struct KernelGroup {
 // Contains the program's worker memory map
 struct ProgramConfig {
     uint32_t rta_offset;
-    std::array<uint32_t, DISPATCH_CLASS_MAX> crta_offsets;
-    std::array<uint32_t, DISPATCH_CLASS_MAX> crta_sizes;
+    std::vector<uint32_t> crta_offsets;
+    std::vector<uint32_t> crta_sizes;
     uint32_t sem_offset;
     uint32_t sem_size;
     uint32_t cb_offset;
@@ -136,9 +137,8 @@ struct ProgramOffsetsState {
     uint32_t offset = 0;
     // Unique RTA offset.
     uint32_t rta_offset = 0;
-    // Common RTA offsets and sizes.
-    std::array<uint32_t, DISPATCH_CLASS_MAX> crta_offsets{};
-    std::array<uint32_t, DISPATCH_CLASS_MAX> crta_sizes{};
+    std::vector<uint32_t> crta_offsets;
+    std::vector<uint32_t> crta_sizes;
     // Semaphore offsets and sizes.
     uint32_t sem_offset = 0;
     uint32_t sem_size = 0;

--- a/tt_metal/llrt/hal.hpp
+++ b/tt_metal/llrt/hal.hpp
@@ -487,6 +487,26 @@ public:
     uint32_t get_total_num_risc_processors() const;
     uint32_t get_max_processors_per_core() const { return max_processors_per_core_; }
 
+    // Returns the dispatch class for a DM processor
+    // On Quasar, all DMs share DISPATCH_CLASS_TENSIX_DM0 (class 0)
+    // On WH/BH, DM0 and DM1 have separate classes (0 and 1)
+    uint32_t get_dm_dispatch_class(uint32_t processor_type) const {
+        return (arch_ == tt::ARCH::QUASAR) ? 0 : processor_type;
+    }
+
+    // Returns the number of dispatch classes for the current architecture
+    // Quasar: DM shared, COMPUTE
+    // WH/BH: DM0, DM1, COMPUTE
+    uint32_t get_dispatch_class_count() const {
+        return (arch_ == tt::ARCH::QUASAR) ? 2 : 3;
+    }
+
+    // Returns the dispatch class for COMPUTE processors.
+    // COMPUTE is always the last dispatch class.
+    uint32_t get_compute_dispatch_class() const {
+        return get_dispatch_class_count() - 1;
+    }
+
     const HalJitBuildConfig& get_jit_build_config(
         uint32_t programmable_core_type_index, uint32_t processor_class_idx, uint32_t processor_type_idx) const;
 

--- a/tt_metal/llrt/hal/tt-2xx/quasar/qa_hal_tensix.cpp
+++ b/tt_metal/llrt/hal/tt-2xx/quasar/qa_hal_tensix.cpp
@@ -119,7 +119,7 @@ HalCoreInfoType create_tensix_mem_map() {
              .fw_launch_addr_value = generate_risc_startup_addr(MEM_DM_FIRMWARE_BASE),
              .memory_load = ll_api::memory::Loading::CONTIGUOUS_XIP},
             {.fw_base_addr = MEM_DM_FIRMWARE_BASE,
-             .local_init_addr = MEM_DM0_INIT_LOCAL_L1_BASE_SCRATCH,
+             .local_init_addr = UINT32_MAX, // not used
              .fw_launch_addr = 0x0,
              .fw_launch_addr_value = generate_risc_startup_addr(MEM_DM_FIRMWARE_BASE),
              .memory_load = ll_api::memory::Loading::CONTIGUOUS_XIP},

--- a/tt_metal/tt_metal.cpp
+++ b/tt_metal/tt_metal.cpp
@@ -1102,9 +1102,19 @@ KernelHandle CreateDataMovementKernel(
         "cores because both NOCs are in use!",
         kernel_name);
 
+    // Get the number of DM processors for TENSIX cores
+    const auto& hal = tt::tt_metal::MetalContext::instance().hal();
+    uint32_t num_dm_processors = hal.get_processor_types_count(
+        hal.get_programmable_core_type_index(HalProgrammableCoreType::TENSIX),
+        static_cast<uint32_t>(HalProcessorClassType::DM));
+
+    // Validate the processor type
     TT_FATAL(
-        config.processor == DataMovementProcessor::RISCV_0 || config.processor == DataMovementProcessor::RISCV_1,
-        "DataMovementKernel creation failure: Data movement kernels can only be created on DM0 or DM1 processors.");
+        enchantum::to_underlying(config.processor) < num_dm_processors,
+        "DataMovementKernel creation failure: Invalid DM processor {}. Valid range is DM0-DM{}.",
+        enchantum::to_underlying(config.processor),
+        num_dm_processors - 1
+    );
 
     std::shared_ptr<Kernel> kernel = std::make_shared<DataMovementKernel>(kernel_src, core_range_set, config);
 


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Provide context for the problem.

### What's changed
Describe the approach used to solve the problem.
Summarize the changes made and its impact.

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:{{branch_name}})
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:{{branch_name}})
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:{{branch_name}})
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:{{branch_name}})
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:{{branch_name}})
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:{{branch_name}})
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
