### PR TITLE
Eliminate redundant map lookups in hot paths

### DIFF
--- a/tt_metal/impl/allocator/allocator.cpp
+++ b/tt_metal/impl/allocator/allocator.cpp
@@ -241,10 +241,12 @@ const std::vector<uint32_t>& AllocatorImpl::get_bank_ids_from_dram_channel(uint3
 const std::vector<uint32_t>& AllocatorImpl::get_bank_ids_from_logical_core(
     BufferType buffer_type, const CoreCoord& logical_core) const {
     std::lock_guard<std::mutex> lock(mutex_);
-    if (!logical_core_to_bank_ids_.at(buffer_type).contains(logical_core)) {
+    const auto& core_to_bank_ids = logical_core_to_bank_ids_.at(buffer_type);
+    auto it = core_to_bank_ids.find(logical_core);
+    if (it == core_to_bank_ids.end()) {
         TT_THROW("No {} bank exists for core {}", enchantum::to_string(buffer_type), logical_core.str());
     }
-    return logical_core_to_bank_ids_.at(buffer_type).at(logical_core);
+    return it->second;
 }
 
 const AllocatorConfig& AllocatorImpl::get_config() const { return *config_; }

--- a/tt_metal/impl/device/device_manager.cpp
+++ b/tt_metal/impl/device/device_manager.cpp
@@ -541,11 +541,11 @@ void DeviceManager::activate_device(ChipId id) {
     if (!device) {
         log_debug(tt::LogMetal, "DeviceManager new device {}", id);
         // For mock devices, these maps may not be populated, use defaults
-        int worker_core_thread_core =
-            this->worker_thread_to_cpu_core_map_.contains(id) ? this->worker_thread_to_cpu_core_map_.at(id) : -1;
-        int completion_queue_reader_core = this->completion_queue_reader_to_cpu_core_map_.contains(id)
-                                               ? this->completion_queue_reader_to_cpu_core_map_.at(id)
-                                               : -1;
+        auto worker_it = this->worker_thread_to_cpu_core_map_.find(id);
+        int worker_core_thread_core = worker_it != this->worker_thread_to_cpu_core_map_.end() ? worker_it->second : -1;
+        auto cq_it = this->completion_queue_reader_to_cpu_core_map_.find(id);
+        int completion_queue_reader_core =
+            cq_it != this->completion_queue_reader_to_cpu_core_map_.end() ? cq_it->second : -1;
         device = new Device(
             id,
             this->num_hw_cqs_,

--- a/tt_metal/impl/dispatch/dispatch_core_manager.cpp
+++ b/tt_metal/impl/dispatch/dispatch_core_manager.cpp
@@ -246,17 +246,19 @@ void dispatch_core_manager::reset_dispatch_core_manager(
 }
 
 CoreCoord dispatch_core_manager::get_next_available_dispatch_core(ChipId device_id) {
-    if (!this->available_dispatch_cores_by_device.contains(device_id)) {
+    auto it = this->available_dispatch_cores_by_device.find(device_id);
+    if (it == this->available_dispatch_cores_by_device.end()) {
         TT_THROW("Invalid device ID to assign dispatch cores {}", device_id);
     }
-    if (this->available_dispatch_cores_by_device.at(device_id).empty()) {
+    auto& cores = it->second;
+    if (cores.empty()) {
         TT_THROW(
             "No more available dispatch cores on device {} to assign. Expand dispatch cores specified in core "
             "descriptor YAML",
             device_id);
     }
-    CoreCoord avail_dispatch_core = this->available_dispatch_cores_by_device.at(device_id).front();
-    this->available_dispatch_cores_by_device.at(device_id).pop_front();
+    CoreCoord avail_dispatch_core = cores.front();
+    cores.pop_front();
     return avail_dispatch_core;
 }
 

--- a/tt_metal/impl/dispatch/topology.cpp
+++ b/tt_metal/impl/dispatch/topology.cpp
@@ -593,6 +593,7 @@ void populate_fd_kernels(const std::vector<DispatchKernelNode>& nodes) {
 
     // Connect the graph with upstream/downstream kernels
     for (const auto& node : nodes) {
+        auto& current_kernel = node_id_to_kernel.at(node.id);
         for (int idx = 0; idx < node.upstream_ids.size(); idx++) {
             if (node.upstream_ids[idx] >= 0) {
                 TT_ASSERT(
@@ -600,7 +601,7 @@ void populate_fd_kernels(const std::vector<DispatchKernelNode>& nodes) {
                     "Upstream kernel id {} out of bounds (max = {})",
                     node.upstream_ids[idx],
                     node_id_to_kernel.size());
-                node_id_to_kernel.at(node.id)->AddUpstreamKernel(node_id_to_kernel.at(node.upstream_ids[idx]));
+                current_kernel->AddUpstreamKernel(node_id_to_kernel.at(node.upstream_ids[idx]));
             }
         }
         for (int idx = 0; idx < node.downstream_ids.size(); idx++) {
@@ -610,7 +611,7 @@ void populate_fd_kernels(const std::vector<DispatchKernelNode>& nodes) {
                     "Downstream kernel id {} out of bounds (max = {})",
                     node.downstream_ids[idx],
                     node_id_to_kernel.size());
-                node_id_to_kernel.at(node.id)->AddDownstreamKernel(node_id_to_kernel.at(node.downstream_ids[idx]));
+                current_kernel->AddDownstreamKernel(node_id_to_kernel.at(node.downstream_ids[idx]));
             }
         }
     }
@@ -806,10 +807,8 @@ const std::unordered_set<CoreCoord>& get_virtual_dispatch_routing_cores(ChipId d
 }
 
 const std::unordered_set<TerminationInfo>& get_registered_termination_cores(ChipId dev_id) {
-    if (!termination_info.contains(dev_id)) {
-        termination_info[dev_id] = {};
-    }
-    return termination_info.at(dev_id);
+    // operator[] will default-construct entry if not present, avoiding multiple lookups
+    return termination_info[dev_id];
 }
 
 void reset_topology_state() {

--- a/tt_metal/impl/profiler/profiler.cpp
+++ b/tt_metal/impl/profiler/profiler.cpp
@@ -2646,8 +2646,9 @@ void DeviceProfiler::pollDebugDumpResults(
 
         std::map<CoreCoord, std::set<tracy::RiscType>> cores_with_data_in_current_buffer;
         for (const auto& [virtual_core, risc_types] : stalled_cores_with_data) {
+            const auto& risc_to_buffer = this->active_dram_buffer_per_core_risc_map.at(virtual_core);
             for (const auto& risc_type : risc_types) {
-                if (this->active_dram_buffer_per_core_risc_map.at(virtual_core).at(risc_type) == buffer_index) {
+                if (risc_to_buffer.at(risc_type) == buffer_index) {
                     cores_with_data_in_current_buffer[virtual_core].insert(risc_type);
                 }
             }


### PR DESCRIPTION
## Summary
- Optimize map lookups across several files by using `find()` + iterator instead of `contains()` + `at()` patterns
- Cache map references in loops to avoid repeated lookups
- Use `operator[]` for default-construction where appropriate

Files changed:
- `tt_metal/impl/dispatch/dispatch_core_manager.cpp` - 4 lookups → 1 lookup
- `tt_metal/impl/device/device_manager.cpp` - 2 instances of `contains()` + `at()` → `find()` + iterator
- `tt_metal/impl/allocator/allocator.cpp` - 3 lookups → 1 lookup with cached reference
- `tt_metal/impl/dispatch/topology.cpp` - Cache loop variable, use `operator[]` for default-construction
- `tt_metal/impl/profiler/profiler.cpp` - Cache inner map reference in nested loop

## Test plan
- [x] Build completes successfully
- [ ] Existing unit tests pass (no new tests needed - this is a pure refactor)

🤖 Generated with [Claude Code](https://claude.com/claude-code)