### PR TITLE
Fix hard-coded action hash causing CI errors

### DIFF
--- a/.github/workflows/tm-fabric-tests-impl.yaml
+++ b/.github/workflows/tm-fabric-tests-impl.yaml
@@ -121,8 +121,13 @@ jobs:
         working-directory: /work
     name: Wormhole T3K UDM tests
     steps:
+      - name: 🧬 Checkout Repository
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          path: docker-job
       - name: ⬇️  Setup Job
-        uses: tenstorrent/tt-metal/.github/actions/setup-job@5b5c6ff5b54025e165d189371cda93d2b9ef6115
+        uses: ./docker-job/.github/actions/setup-job
         timeout-minutes: 10
         with:
           build-artifact-name: ${{ inputs.build-artifact-name }}
@@ -171,8 +176,13 @@ jobs:
         shell: bash
         working-directory: /work
     steps:
+      - name: 🧬 Checkout Repository
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          path: docker-job
       - name: ⬇️  Setup Job
-        uses: tenstorrent/tt-metal/.github/actions/setup-job@5b5c6ff5b54025e165d189371cda93d2b9ef6115
+        uses: ./docker-job/.github/actions/setup-job
         timeout-minutes: 10
         with:
           build-artifact-name: ${{ inputs.build-artifact-name }}
@@ -336,8 +346,13 @@ jobs:
         shell: bash
         working-directory: /work
     steps:
+      - name: 🧬 Checkout Repository
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          path: docker-job
       - name: ⬇️  Setup Job
-        uses: tenstorrent/tt-metal/.github/actions/setup-job@5b5c6ff5b54025e165d189371cda93d2b9ef6115
+        uses: ./docker-job/.github/actions/setup-job
         timeout-minutes: 10
         with:
           build-artifact-name: ${{ inputs.build-artifact-name }}

--- a/.github/workflows/tm-fabric-tests-perf-impl.yaml
+++ b/.github/workflows/tm-fabric-tests-perf-impl.yaml
@@ -90,8 +90,13 @@ jobs:
     name: ${{ matrix.test-group.name }}
     runs-on: ${{ matrix.test-group.runs-on }}
     steps:
+      - name: 🧬 Checkout Repository
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          path: docker-job
       - name: ⬇️  Setup Job
-        uses: tenstorrent/tt-metal/.github/actions/setup-job@5b5c6ff5b54025e165d189371cda93d2b9ef6115
+        uses: ./docker-job/.github/actions/setup-job
         timeout-minutes: 10
         with:
           build-artifact-name: ${{ inputs.build-artifact-name }}

--- a/ttnn/ttnn/__init__.py
+++ b/ttnn/ttnn/__init__.py
@@ -259,7 +259,6 @@ from ttnn.types import (
 )
 
 from ttnn.device import (
-    Arch,
     Device,
     DispatchCoreType,
     DispatchCoreAxis,

--- a/ttnn/ttnn/__init__.py
+++ b/ttnn/ttnn/__init__.py
@@ -259,6 +259,7 @@ from ttnn.types import (
 )
 
 from ttnn.device import (
+    Arch,
     Device,
     DispatchCoreType,
     DispatchCoreAxis,


### PR DESCRIPTION
### Ticket
Closes https://github.com/tenstorrent/tt-metal/issues/37157

### Problem description
Runtime error making CI tests fail.

### What's changed
Changed setup-job to use current action version not an old pre-uv version.

### Checklist
- [x] (TM-Fabric) Fabric Tests https://github.com/tenstorrent/tt-metal/actions/runs/21702751652/job/62586640029 Failure caused by the tagged issue is no longer present. 