### PR TITLE
Update binary operation handling in OpConfig for non-INT32 types

### DIFF
--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.cpp
@@ -159,6 +159,7 @@ OpConfig::OpConfig(BinaryOpType binary_op_type, std::in_place_type_t<EnumT>, std
             break;
         case BinaryOpType::LT:
             if (dtype != DataType::INT32) {
+                binary_op = EnumT::SUB;
                 postprocess = unary::UnaryOpType::LTZ;
             } else {
                 binary_op = SfpuBinaryOp::LT;
@@ -166,6 +167,7 @@ OpConfig::OpConfig(BinaryOpType binary_op_type, std::in_place_type_t<EnumT>, std
             break;
         case BinaryOpType::GT:
             if (dtype != DataType::INT32) {
+                binary_op = EnumT::SUB;
                 postprocess = unary::UnaryOpType::GTZ;
             } else {
                 binary_op = SfpuBinaryOp::GT;
@@ -173,6 +175,7 @@ OpConfig::OpConfig(BinaryOpType binary_op_type, std::in_place_type_t<EnumT>, std
             break;
         case BinaryOpType::GE:
             if (dtype != DataType::INT32) {
+                binary_op = EnumT::SUB;
                 postprocess = unary::UnaryOpType::GEZ;
             } else {
                 binary_op = SfpuBinaryOp::GE;
@@ -180,15 +183,23 @@ OpConfig::OpConfig(BinaryOpType binary_op_type, std::in_place_type_t<EnumT>, std
             break;
         case BinaryOpType::LE:
             if (dtype != DataType::INT32) {
+                binary_op = EnumT::SUB;
                 postprocess = unary::UnaryOpType::LEZ;
             } else {
                 binary_op = SfpuBinaryOp::LE;
             }
             break;
         case BinaryOpType::EQ:
-            if (dtype == DataType::FLOAT32) {
-                binary_op = SfpuBinaryOp::EQ;
+            if constexpr (std::is_same_v<EnumT, SfpuBinaryOp>) {
+                if (dtype == DataType::FLOAT32) {
+                    binary_op = SfpuBinaryOp::EQ;
+                } else {
+                    binary_op = EnumT::SUB;
+                    postprocess = unary::UnaryOpType::EQZ;
+                }
             } else {
+                // FPU context: always use SUB + EQZ
+                binary_op = EnumT::SUB;
                 postprocess = unary::UnaryOpType::EQZ;
             }
             break;


### PR DESCRIPTION
### What's changed
- Added handling for binary operations (LT, GT, GE, LE, EQ) to use EnumT::SUB and set appropriate postprocess types when dtype is not INT32.
- Refactored EQ case to ensure consistent behavior across different data types, specifically for FLOAT32 and non-FLOAT32 scenarios.

This change enhances the flexibility of binary operations in the OpConfig class, ensuring correct behavior across various data types.

### Ticket
Link to Github Issue

### Problem description
Provide context for the problem.

### What's changed
Describe the approach used to solve the problem.
Summarize the changes made and its impact.

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=Aswinmcw/fix_t3k_pipe)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:Aswinmcw/fix_t3k_pipe)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=Aswinmcw/fix_t3k_pipe)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:Aswinmcw/fix_t3k_pipe)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=Aswinmcw/fix_t3k_pipe)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:Aswinmcw/fix_t3k_pipe)
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=Aswinmcw/fix_t3k_pipe)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:Aswinmcw/fix_t3k_pipe)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=Aswinmcw/fix_t3k_pipe)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:Aswinmcw/fix_t3k_pipe)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=Aswinmcw/fix_t3k_pipe)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:Aswinmcw/fix_t3k_pipe)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
