### PR TITLE
#36993: restore compiler selection for tt-train standalone builds

### DIFF
--- a/tt-train/CMakeLists.txt
+++ b/tt-train/CMakeLists.txt
@@ -1,4 +1,18 @@
 cmake_minimum_required(VERSION 3.18...4.2)
+include(cmake/compilers.cmake)
+
+# When building as a standalone top-level project, inherit the compiler from
+# tt-metal's CMakeCache.txt for ABI compatibility. This is necessary because
+# build systems like scikit-build-core (used by "pip install -e") set CC/CXX
+# to generic values that don't match tt-metal's compiler.
+#
+# To use a different compiler, disable inheritance:
+#   cmake -DTT_TRAIN_INHERIT_COMPILER=OFF -DCMAKE_C_COMPILER=gcc-12 ...
+option(TT_TRAIN_INHERIT_COMPILER "Inherit compiler from tt-metal's CMakeCache.txt" ON)
+
+if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR AND TT_TRAIN_INHERIT_COMPILER)
+    inherit_compiler_from_tt_metal()
+endif()
 
 project(
     ml-framework-cpp
@@ -6,6 +20,7 @@ project(
         C
         CXX
 )
+CHECK_COMPILERS()
 
 message(STATUS "Build type: ${CMAKE_BUILD_TYPE}")
 set(CMAKE_CXX_FLAGS_RELEASE "-O3")

--- a/tt-train/cmake/compilers.cmake
+++ b/tt-train/cmake/compilers.cmake
@@ -1,0 +1,88 @@
+# Compiler selection and validation for tt-train.
+#
+# When building standalone (not as a tt-metal subproject), tt-train needs
+# a compiler compatible with the one used to build tt-metal, since it links
+# against tt-metal libraries (libtt_metal.so, _ttnncpp.so).
+#
+# Compiler selection (standalone top-level builds):
+#   - By default, the compiler is inherited from tt-metal's CMakeCache.txt
+#     to ensure ABI compatibility (TT_TRAIN_INHERIT_COMPILER=ON).
+#   - To use a different compiler, disable inheritance and set explicitly:
+#     cmake -DTT_TRAIN_INHERIT_COMPILER=OFF -DCMAKE_C_COMPILER=gcc-12 ...
+#   - If no CMakeCache.txt is found, falls back to CMake default detection.
+#   - CHECK_COMPILERS() validates the result (Clang 17+ or GCC 12+).
+#
+# When building as a tt-metal subproject (add_subdirectory), the parent
+# project's compiler is used and inheritance is skipped.
+#
+# Restored after deletion in a7618b9282 ("TT-Train: bump clang version
+# from 17 to 20 #36568").
+#
+# See: https://github.com/tenstorrent/tt-metal/issues/36993
+
+# Read the compiler used by tt-metal from its CMakeCache.txt and set it
+# as CMAKE_C_COMPILER/CMAKE_CXX_COMPILER so tt-train uses the same one.
+function(INHERIT_COMPILER_FROM_TT_METAL)
+    # Determine TT_METAL_HOME
+    if(DEFINED ENV{TT_METAL_HOME})
+        set(_tt_metal_home "$ENV{TT_METAL_HOME}")
+    else()
+        # Infer from directory structure: tt-metal/tt-train/ -> tt-metal/
+        set(_tt_metal_home "${CMAKE_CURRENT_SOURCE_DIR}/..")
+        if(NOT EXISTS "${_tt_metal_home}/tt_metal/CMakeLists.txt")
+            message(STATUS "Cannot infer tt-metal location; using CMake default compiler")
+            return()
+        endif()
+    endif()
+
+    # Search for CMakeCache.txt in known build directories
+    set(_cache_file "")
+    foreach(_build_dir "build" "build_Debug" "build_Release")
+        if(EXISTS "${_tt_metal_home}/${_build_dir}/CMakeCache.txt")
+            set(_cache_file "${_tt_metal_home}/${_build_dir}/CMakeCache.txt")
+            break()
+        endif()
+    endforeach()
+
+    if(NOT _cache_file)
+        message(STATUS "No tt-metal build found; using CMake default compiler")
+        return()
+    endif()
+
+    # Parse CMAKE_C_COMPILER and CMAKE_CXX_COMPILER from CMakeCache.txt
+    file(STRINGS "${_cache_file}" _c_compiler_line REGEX "^CMAKE_C_COMPILER:.*=")
+    file(STRINGS "${_cache_file}" _cxx_compiler_line REGEX "^CMAKE_CXX_COMPILER:.*=")
+
+    if(_c_compiler_line AND _cxx_compiler_line)
+        string(REGEX REPLACE "^CMAKE_C_COMPILER:[^=]*=(.*)" "\\1" _c_compiler "${_c_compiler_line}")
+        string(REGEX REPLACE "^CMAKE_CXX_COMPILER:[^=]*=(.*)" "\\1" _cxx_compiler "${_cxx_compiler_line}")
+
+        if(EXISTS "${_c_compiler}" AND EXISTS "${_cxx_compiler}")
+            message(STATUS "Inheriting compiler from tt-metal build (${_cache_file}):")
+            message(STATUS "  C compiler:   ${_c_compiler}")
+            message(STATUS "  C++ compiler: ${_cxx_compiler}")
+            set(CMAKE_C_COMPILER "${_c_compiler}" PARENT_SCOPE)
+            set(CMAKE_CXX_COMPILER "${_cxx_compiler}" PARENT_SCOPE)
+        else()
+            message(STATUS "Compiler paths from tt-metal CMakeCache not found on disk; using CMake default")
+        endif()
+    else()
+        message(STATUS "Could not parse compiler from ${_cache_file}; using CMake default")
+    endif()
+endfunction()
+
+function(CHECK_COMPILERS)
+    message(STATUS "Checking compilers: ${CMAKE_CXX_COMPILER_ID} ${CMAKE_CXX_COMPILER_VERSION}")
+
+    if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+        if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS "17.0.0")
+            message(FATAL_ERROR "Clang-17 or higher is required")
+        endif()
+    elseif(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+        if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS "12.0.0")
+            message(FATAL_ERROR "GCC-12 or higher is required")
+        endif()
+    else()
+        message(WARNING "Unsupported compiler: ${CMAKE_CXX_COMPILER_ID} ! Only Clang and GCC are supported")
+    endif()
+endfunction()


### PR DESCRIPTION

### Ticket

Fixes #36993

### Problem description

Commit `a7618b9282` ("TT-Train: bump clang version from 17 to 20 #36568") deleted all compiler selection logic from tt-train:
- Deleted `tt-train/cmake/compilers.cmake` (63 lines: `FIND_AND_SET_CLANG20()`, `CHECK_COMPILERS()`, `ADJUST_COMPILER_WARNINGS()`)
- Removed 15 lines from `tt-train/CMakeLists.txt` (env var override, clang-20 default, compiler validation)
- Replaced with CI workflow `env: CC/CXX` variables and README documentation

This broke standalone builds via `pip install -e tt-train/` (and `uv pip install -e tt-train/`) because scikit-build-core creates an isolated CMake invocation where `CC`/`CXX` env vars are overridden with generic values (e.g., `cc -pthread`), causing CMake to fall back to system GCC. GCC 11 fails on the `reflect` library's `constexpr` lambda function pointers.

When tt-train is built as a tt-metal subproject (via `add_subdirectory(tt-train)` in tt-metal's `CMakeLists.txt`), it inherits the parent's compiler and works fine — so this only affects standalone builds.

### What's changed

Restore `tt-train/cmake/compilers.cmake` with a new approach: inherit the compiler from tt-metal's `CMakeCache.txt` for ABI compatibility.

**Files changed:** 2 files, 103 lines added
- `tt-train/cmake/compilers.cmake` (88 lines, new)
- `tt-train/CMakeLists.txt` (+15 lines)

The restored file has two functions:
- `INHERIT_COMPILER_FROM_TT_METAL()` — reads `CMAKE_C_COMPILER`/`CMAKE_CXX_COMPILER` from tt-metal's `CMakeCache.txt` (`build/`, `build_Debug/`, or `build_Release/`). Falls back to CMake default detection if no tt-metal build is found.
- `CHECK_COMPILERS()` — validates Clang 17+ or GCC 12+, matching tt-metal's own `cmake/compilers.cmake`.

The `CMakeLists.txt` changes (before `project()`):
1. `include(cmake/compilers.cmake)`
2. `option(TT_TRAIN_INHERIT_COMPILER)` — ON by default, can be disabled for explicit compiler selection
3. Guard: only inherit when building as a standalone top-level project (not as a tt-metal subproject)
4. After `project()`, call `CHECK_COMPILERS()` to validate

#### Compiler selection priority (standalone builds)

1. `cmake -DTT_TRAIN_INHERIT_COMPILER=OFF -DCMAKE_C_COMPILER=gcc-12 ...` (explicit override)
2. CMakeCache.txt inheritance from tt-metal (default, ensures ABI compatibility)
3. CMake default detection (fallback if no tt-metal build found)

#### Why CMakeCache.txt inheritance?

Build systems like scikit-build-core (used by `pip install -e`) set `CC`/`CXX` to generic values via an initial cache file (`-C CMakeInit.txt`), defeating env var checks. Reading the compiler from tt-metal's existing build guarantees ABI compatibility without relying on environment variables.

#### Verification

Built and tested in a clean Docker container (Ubuntu 22.04, clang-20.1.8). All 1711 tt-metal targets and tt-train standalone targets compile successfully without `CC`/`CXX` env vars set.

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=ivoitovych/issue-36993-fix-gcc-constexpr-lambda)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:ivoitovych/issue-36993-fix-gcc-constexpr-lambda)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ivoitovych/issue-36993-fix-gcc-constexpr-lambda)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ivoitovych/issue-36993-fix-gcc-constexpr-lambda)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ivoitovych/issue-36993-fix-gcc-constexpr-lambda)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ivoitovych/issue-36993-fix-gcc-constexpr-lambda)
- [x] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ivoitovych/issue-36993-fix-gcc-constexpr-lambda)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ivoitovych/issue-36993-fix-gcc-constexpr-lambda)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ivoitovych/issue-36993-fix-gcc-constexpr-lambda)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ivoitovych/issue-36993-fix-gcc-constexpr-lambda)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ivoitovych/issue-36993-fix-gcc-constexpr-lambda)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ivoitovych/issue-36993-fix-gcc-constexpr-lambda)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
