### PR TITLE
SDXL disable timeout

### DIFF
--- a/models/experimental/stable_diffusion_xl_base/conftest.py
+++ b/models/experimental/stable_diffusion_xl_base/conftest.py
@@ -5,6 +5,11 @@ import pytest
 from conftest import is_galaxy
 
 
+def pytest_configure(config):
+    """Override global timeout setting for SDXL tests"""
+    config.option.timeout = 0
+
+
 def pytest_addoption(parser):
     parser.addoption(
         "--start-from",


### PR DESCRIPTION
### Problem description
- Metal Ci and Shield CI errors due to global timeout of 5 minutes

### What's changed
For sdxl folder local `conftest.py` overrides global timeout

### Checklist
- [x] [device perf](https://github.com/tenstorrent/tt-metal/actions/runs/21709165725) passes
- [ ] [demo](https://github.com/tenstorrent/tt-metal/actions/runs/21708047180) progress
- [ ] [Shield Ci accuracy](https://github.com/tenstorrent/tt-shield/actions/runs/21707048325) progress
