### PR TITLE
[gpt-oss] attention decode optimizations

### DIFF
--- a/models/demos/gpt_oss/tt/attention/__init__.py
+++ b/models/demos/gpt_oss/tt/attention/__init__.py
@@ -4,7 +4,6 @@
 import ttnn
 
 from models.demos.gpt_oss.config import MeshConfig
-from models.tt_transformers.tt.common import get_rot_transformation_mat
 
 from .config import AttentionConfig, ProgramConfig
 from .decode import decode_forward
@@ -101,29 +100,6 @@ class Attention:
             config.head_dim,
         )
 
-        # Pre-create fused transformation matrix for fused QK RoPE (avoids host writes during trace)
-        self.fused_transformation_mat = None
-        if config.max_local_batch_size <= 32:
-            doubled_batch = config.max_local_batch_size * 2
-            grid_size = mesh_device.compute_with_storage_grid_size()
-            doubled_batch_grid = ttnn.num_cores_to_corerangeset(doubled_batch, grid_size, row_wise=True)
-            trans_mat_torch = get_rot_transformation_mat(dhead=ttnn.TILE_SIZE).repeat(1, 1, doubled_batch, 1)
-            trans_mat_mem_config = ttnn.create_sharded_memory_config(
-                shape=(ttnn.TILE_SIZE, ttnn.TILE_SIZE),
-                core_grid=doubled_batch_grid,
-                strategy=ttnn.ShardStrategy.HEIGHT,
-                orientation=ttnn.ShardOrientation.ROW_MAJOR,
-                use_height_and_width_as_shard_shape=True,
-            )
-            self.fused_transformation_mat = ttnn.from_torch(
-                trans_mat_torch,
-                device=mesh_device,
-                layout=ttnn.TILE_LAYOUT,
-                dtype=ttnn.bfloat16,
-                memory_config=trans_mat_mem_config,
-                mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device),
-            )
-
         # Store references for backward compatibility
         self.hidden_size = config.hidden_size
         self.num_heads = config.num_heads
@@ -173,7 +149,6 @@ class Attention:
                 mesh_device=self.mesh_device,
                 program_config=self.program_config,
                 transformation_mat=transformation_mat,
-                fused_transformation_mat=self.fused_transformation_mat,
                 kv_mem_cfg=self.kv_mem_cfg,
                 position_idx=position_idx,
                 page_table=page_table,

--- a/models/demos/gpt_oss/tt/attention/decode.py
+++ b/models/demos/gpt_oss/tt/attention/decode.py
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import ttnn
+from models.common.utility_functions import nearest_32
+from models.tt_transformers.tt.model_config import num_to_corerange
 
 from .config import AttentionConfig, ProgramConfig
 from .operations import apply_allreduce, apply_rope
@@ -18,6 +20,7 @@ def decode_forward(
     mesh_device,
     program_config: ProgramConfig,
     transformation_mat,
+    fused_transformation_mat,
     kv_mem_cfg,
     position_idx,
     page_table,
@@ -25,29 +28,9 @@ def decode_forward(
 ):
     """
     Decode forward pass - optimized for single token (seq_len=1).
-
-    Args:
-        hidden_states: Input tensor [batch, 1, hidden_size]
-        rope_mats: Tuple of (cos, sin) matrices for RoPE
-        weights: Attention weights
-        kv_cache: KV cache [k_cache, v_cache]
-        config: Attention configuration
-        mesh_config: Mesh parallelization config
-        mesh_device: TTNN mesh device
-        program_config: Model-specific program configs
-        transformation_mat: Transformation matrix for RoPE
-        kv_mem_cfg: Memory config for KV tensors
-        position_idx: Current position index
-        page_table: Page table for paged attention (optional)
-        ccl_manager: Communication manager
-
-    Returns:
-        Attention output [batch, 1, hidden_size]
     """
-    # batch_size, seq_len, hidden_size = hidden_states.shape
     _, seq_len, batch_size, hidden_size = hidden_states.shape
 
-    # Validate decode mode
     if seq_len != 1:
         raise ValueError(f"Decode mode requires seq_len=1, got {seq_len}")
 
@@ -68,55 +51,99 @@ def decode_forward(
         num_kv_heads=num_local_kv_heads,
         memory_config=ttnn.L1_HEIGHT_SHARDED_MEMORY_CONFIG,
     )
-
     xqkv_fused.deallocate(True)
 
-    # Apply RoPE
-    tt_q_orig = tt_q
-    tt_k_orig = tt_k
-    tt_q = apply_rope(tt_q, rope_mats, transformation_mat, is_decode_mode=True)
-    tt_k = apply_rope(tt_k, rope_mats, transformation_mat, is_decode_mode=True)
-    tt_q_orig.deallocate(True)
-    tt_k_orig.deallocate(True)
+    # Apply RoPE - use fused QK op when batch allows (requires 2*batch cores, max 32 on 8x8 grid)
+    use_fused_qk = fused_transformation_mat is not None and batch_size <= 32
 
-    # DEBUG: Check for NaN/Inf in Q/K after rope (enable with DEBUG_ATTENTION=1)
-    # Disabled by default to avoid performance impact
+    if use_fused_qk:
+        # Prepare doubled rope_mats for fused RoPE
+        cos, sin = rope_mats
+        cos_interleaved = ttnn.to_memory_config(cos, ttnn.DRAM_MEMORY_CONFIG)
+        sin_interleaved = ttnn.to_memory_config(sin, ttnn.DRAM_MEMORY_CONFIG)
+        doubled_cos = ttnn.repeat(cos_interleaved, ttnn.Shape([1, 2, 1, 1]))
+        doubled_sin = ttnn.repeat(sin_interleaved, ttnn.Shape([1, 2, 1, 1]))
+        cos_interleaved.deallocate(True)
+        sin_interleaved.deallocate(True)
 
-    # Update KV cache
-    k_cache, v_cache = kv_cache
-    tt_k = ttnn.to_memory_config(tt_k, kv_mem_cfg)
-    tt_v = ttnn.to_memory_config(tt_v, kv_mem_cfg)
+        grid_size = mesh_device.compute_with_storage_grid_size()
+        doubled_batch_grid = ttnn.num_cores_to_corerangeset(batch_size * 2, grid_size, row_wise=True)
+        doubled_mem_config = ttnn.create_sharded_memory_config(
+            shape=(ttnn.TILE_SIZE, head_dim),
+            core_grid=doubled_batch_grid,
+            strategy=ttnn.ShardStrategy.HEIGHT,
+            orientation=ttnn.ShardOrientation.ROW_MAJOR,
+            use_height_and_width_as_shard_shape=True,
+        )
+        doubled_cos = ttnn.to_memory_config(doubled_cos, doubled_mem_config)
+        doubled_sin = ttnn.to_memory_config(doubled_sin, doubled_mem_config)
 
-    ttnn.experimental.paged_update_cache(
-        k_cache,
-        tt_k,
-        update_idxs_tensor=position_idx,
-        page_table=page_table,
-    )
-    ttnn.experimental.paged_update_cache(
-        v_cache,
-        tt_v,
-        update_idxs_tensor=position_idx,
-        page_table=page_table,
-    )
+        # Move Q and K to disjoint core regions for fused RoPE
+        row_size = 8
+        k_start_core = ttnn.CoreCoord(batch_size % row_size, batch_size // row_size)
+        q_core_grid = ttnn.CoreRangeSet({num_to_corerange(batch_size)})
+        k_core_grid = ttnn.CoreRangeSet({num_to_corerange(batch_size, start_core=k_start_core)})
+
+        q_mem_config = ttnn.create_sharded_memory_config(
+            shape=(nearest_32(num_local_heads), head_dim),
+            core_grid=q_core_grid,
+            strategy=ttnn.ShardStrategy.HEIGHT,
+            orientation=ttnn.ShardOrientation.ROW_MAJOR,
+            use_height_and_width_as_shard_shape=True,
+        )
+        k_mem_config = ttnn.create_sharded_memory_config(
+            shape=(nearest_32(num_local_kv_heads), head_dim),
+            core_grid=k_core_grid,
+            strategy=ttnn.ShardStrategy.HEIGHT,
+            orientation=ttnn.ShardOrientation.ROW_MAJOR,
+            use_height_and_width_as_shard_shape=True,
+        )
+        tt_q = ttnn.to_memory_config(tt_q, q_mem_config)
+        tt_k = ttnn.to_memory_config(tt_k, k_mem_config)
+
+        # Fused RoPE applies rotation to both Q and K in a single kernel
+        tt_q, tt_k = ttnn.experimental.rotary_embedding_llama_fused_qk(
+            tt_q, tt_k, doubled_cos, doubled_sin, fused_transformation_mat
+        )
+        doubled_cos.deallocate(True)
+        doubled_sin.deallocate(True)
+
+        # Fused KV cache update (K and V already on disjoint cores)
+        k_cache, v_cache = kv_cache
+        ttnn.experimental.paged_fused_update_cache(
+            k_cache, tt_k, v_cache, tt_v, update_idxs_tensor=position_idx, page_table=page_table
+        )
+    else:
+        # Fallback to separate RoPE calls
+        tt_q_orig, tt_k_orig = tt_q, tt_k
+        tt_q = apply_rope(tt_q, rope_mats, transformation_mat, is_decode_mode=True)
+        tt_k = apply_rope(tt_k, rope_mats, transformation_mat, is_decode_mode=True)
+        tt_q_orig.deallocate(True)
+        tt_k_orig.deallocate(True)
+
+        # Separate KV cache updates
+        k_cache, v_cache = kv_cache
+        tt_k = ttnn.to_memory_config(tt_k, kv_mem_cfg)
+        tt_v = ttnn.to_memory_config(tt_v, kv_mem_cfg)
+        ttnn.experimental.paged_update_cache(k_cache, tt_k, update_idxs_tensor=position_idx, page_table=page_table)
+        ttnn.experimental.paged_update_cache(v_cache, tt_v, update_idxs_tensor=position_idx, page_table=page_table)
 
     tt_k.deallocate(True)
     tt_v.deallocate(True)
+
+    # Scaled dot-product attention
     grid_size = mesh_device.compute_with_storage_grid_size()
     batch_grid = ttnn.num_cores_to_corerangeset(batch_size, grid_size, row_wise=True)
-
-    # Calculate padded heads (must be tile-aligned, e.g., 32)
-    # Use local heads per device, not global heads
     padded_heads = ((num_local_heads + 31) // 32) * 32
 
     height_sharded_mem_config = ttnn.create_sharded_memory_config(
-        shape=(padded_heads, head_dim),  # Shape per shard (tile-aligned)
+        shape=(padded_heads, head_dim),
         core_grid=batch_grid,
         strategy=ttnn.ShardStrategy.HEIGHT,
         orientation=ttnn.ShardOrientation.ROW_MAJOR,
         use_height_and_width_as_shard_shape=True,
     )
-    # Scaled dot-product attention
+
     if page_table is not None:
         tt_sdpa_tensor = ttnn.transformer.paged_scaled_dot_product_attention_decode(
             tt_q,
@@ -129,7 +156,6 @@ def decode_forward(
             scale=config.scaling,
             program_config=program_config.get_decode_sdpa_config(mesh_device),
             compute_kernel_config=program_config.get_compute_kernel_config(),
-            # memory_config=height_sharded_mem_config,
             memory_config=ttnn.DRAM_MEMORY_CONFIG,
         )
         tt_sdpa_tensor = ttnn.to_memory_config(tt_sdpa_tensor, height_sharded_mem_config)
@@ -149,33 +175,25 @@ def decode_forward(
     tt_q.deallocate(True)
 
     # Concat heads and apply output projection
-
     tt_sdpa_out = ttnn.experimental.nlp_concat_heads_decode(tt_sdpa_tensor, num_heads=num_local_heads)
     tt_sdpa_tensor.deallocate(True)
 
     tt_out = ttnn.linear(
         tt_sdpa_out, weights.o_proj, dtype=ttnn.bfloat16, memory_config=ttnn.L1_WIDTH_SHARDED_MEMORY_CONFIG
     )
-
     tt_sdpa_out.deallocate(True)
+
     tt_out = ttnn.add(tt_out, weights.o_proj_bias, memory_config=ttnn.L1_MEMORY_CONFIG)
     tt_out = ttnn.typecast(tt_out, ttnn.bfloat8_b)
 
-    # Calculate padded hidden size for tile-aligned CCL operations.
-    # o_proj weights may be padded so local_hidden becomes tile-aligned.
+    # Reshape for CCL
     local_hidden = hidden_size // mesh_config.tp
     padded_local_hidden = ((local_hidden + 31) // 32) * 32
     padded_hidden = padded_local_hidden * mesh_config.tp if mesh_config.tp > 1 else hidden_size
 
-    tt_out = ttnn.reshape(
-        tt_out,
-        (1, 1, batch_size, padded_hidden),
-        (1, 1, 32, padded_hidden),
-    )
-    # tt_out = ttnn.unsqueeze(tt_out, 0)
+    tt_out = ttnn.reshape(tt_out, (1, 1, batch_size, padded_hidden), (1, 1, 32, padded_hidden))
 
     # Tensor parallel allreduce
-    # TODO: This will need to be a reduce scatter so outputs are [1, 1, global_batch//num_rows, hidden_size//num_columns
     tt_out = apply_allreduce(tt_out, mesh_config, ccl_manager, batch_size, seq_len, hidden_size)
 
     return tt_out

--- a/models/demos/gpt_oss/tt/attention/decode.py
+++ b/models/demos/gpt_oss/tt/attention/decode.py
@@ -2,8 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import ttnn
-from models.common.utility_functions import nearest_32
-from models.tt_transformers.tt.model_config import num_to_corerange
 
 from .config import AttentionConfig, ProgramConfig
 from .operations import apply_allreduce, apply_rope
@@ -20,7 +18,6 @@ def decode_forward(
     mesh_device,
     program_config: ProgramConfig,
     transformation_mat,
-    fused_transformation_mat,
     kv_mem_cfg,
     position_idx,
     page_table,
@@ -28,9 +25,29 @@ def decode_forward(
 ):
     """
     Decode forward pass - optimized for single token (seq_len=1).
+
+    Args:
+        hidden_states: Input tensor [batch, 1, hidden_size]
+        rope_mats: Tuple of (cos, sin) matrices for RoPE
+        weights: Attention weights
+        kv_cache: KV cache [k_cache, v_cache]
+        config: Attention configuration
+        mesh_config: Mesh parallelization config
+        mesh_device: TTNN mesh device
+        program_config: Model-specific program configs
+        transformation_mat: Transformation matrix for RoPE
+        kv_mem_cfg: Memory config for KV tensors
+        position_idx: Current position index
+        page_table: Page table for paged attention (optional)
+        ccl_manager: Communication manager
+
+    Returns:
+        Attention output [batch, 1, hidden_size]
     """
+    # batch_size, seq_len, hidden_size = hidden_states.shape
     _, seq_len, batch_size, hidden_size = hidden_states.shape
 
+    # Validate decode mode
     if seq_len != 1:
         raise ValueError(f"Decode mode requires seq_len=1, got {seq_len}")
 
@@ -51,99 +68,55 @@ def decode_forward(
         num_kv_heads=num_local_kv_heads,
         memory_config=ttnn.L1_HEIGHT_SHARDED_MEMORY_CONFIG,
     )
+
     xqkv_fused.deallocate(True)
 
-    # Apply RoPE - use fused QK op when batch allows (requires 2*batch cores, max 32 on 8x8 grid)
-    use_fused_qk = fused_transformation_mat is not None and batch_size <= 32
+    # Apply RoPE
+    tt_q_orig = tt_q
+    tt_k_orig = tt_k
+    tt_q = apply_rope(tt_q, rope_mats, transformation_mat, is_decode_mode=True)
+    tt_k = apply_rope(tt_k, rope_mats, transformation_mat, is_decode_mode=True)
+    tt_q_orig.deallocate(True)
+    tt_k_orig.deallocate(True)
 
-    if use_fused_qk:
-        # Prepare doubled rope_mats for fused RoPE
-        cos, sin = rope_mats
-        cos_interleaved = ttnn.to_memory_config(cos, ttnn.DRAM_MEMORY_CONFIG)
-        sin_interleaved = ttnn.to_memory_config(sin, ttnn.DRAM_MEMORY_CONFIG)
-        doubled_cos = ttnn.repeat(cos_interleaved, ttnn.Shape([1, 2, 1, 1]))
-        doubled_sin = ttnn.repeat(sin_interleaved, ttnn.Shape([1, 2, 1, 1]))
-        cos_interleaved.deallocate(True)
-        sin_interleaved.deallocate(True)
+    # DEBUG: Check for NaN/Inf in Q/K after rope (enable with DEBUG_ATTENTION=1)
+    # Disabled by default to avoid performance impact
 
-        grid_size = mesh_device.compute_with_storage_grid_size()
-        doubled_batch_grid = ttnn.num_cores_to_corerangeset(batch_size * 2, grid_size, row_wise=True)
-        doubled_mem_config = ttnn.create_sharded_memory_config(
-            shape=(ttnn.TILE_SIZE, head_dim),
-            core_grid=doubled_batch_grid,
-            strategy=ttnn.ShardStrategy.HEIGHT,
-            orientation=ttnn.ShardOrientation.ROW_MAJOR,
-            use_height_and_width_as_shard_shape=True,
-        )
-        doubled_cos = ttnn.to_memory_config(doubled_cos, doubled_mem_config)
-        doubled_sin = ttnn.to_memory_config(doubled_sin, doubled_mem_config)
+    # Update KV cache
+    k_cache, v_cache = kv_cache
+    tt_k = ttnn.to_memory_config(tt_k, kv_mem_cfg)
+    tt_v = ttnn.to_memory_config(tt_v, kv_mem_cfg)
 
-        # Move Q and K to disjoint core regions for fused RoPE
-        row_size = 8
-        k_start_core = ttnn.CoreCoord(batch_size % row_size, batch_size // row_size)
-        q_core_grid = ttnn.CoreRangeSet({num_to_corerange(batch_size)})
-        k_core_grid = ttnn.CoreRangeSet({num_to_corerange(batch_size, start_core=k_start_core)})
-
-        q_mem_config = ttnn.create_sharded_memory_config(
-            shape=(nearest_32(num_local_heads), head_dim),
-            core_grid=q_core_grid,
-            strategy=ttnn.ShardStrategy.HEIGHT,
-            orientation=ttnn.ShardOrientation.ROW_MAJOR,
-            use_height_and_width_as_shard_shape=True,
-        )
-        k_mem_config = ttnn.create_sharded_memory_config(
-            shape=(nearest_32(num_local_kv_heads), head_dim),
-            core_grid=k_core_grid,
-            strategy=ttnn.ShardStrategy.HEIGHT,
-            orientation=ttnn.ShardOrientation.ROW_MAJOR,
-            use_height_and_width_as_shard_shape=True,
-        )
-        tt_q = ttnn.to_memory_config(tt_q, q_mem_config)
-        tt_k = ttnn.to_memory_config(tt_k, k_mem_config)
-
-        # Fused RoPE applies rotation to both Q and K in a single kernel
-        tt_q, tt_k = ttnn.experimental.rotary_embedding_llama_fused_qk(
-            tt_q, tt_k, doubled_cos, doubled_sin, fused_transformation_mat
-        )
-        doubled_cos.deallocate(True)
-        doubled_sin.deallocate(True)
-
-        # Fused KV cache update (K and V already on disjoint cores)
-        k_cache, v_cache = kv_cache
-        ttnn.experimental.paged_fused_update_cache(
-            k_cache, tt_k, v_cache, tt_v, update_idxs_tensor=position_idx, page_table=page_table
-        )
-    else:
-        # Fallback to separate RoPE calls
-        tt_q_orig, tt_k_orig = tt_q, tt_k
-        tt_q = apply_rope(tt_q, rope_mats, transformation_mat, is_decode_mode=True)
-        tt_k = apply_rope(tt_k, rope_mats, transformation_mat, is_decode_mode=True)
-        tt_q_orig.deallocate(True)
-        tt_k_orig.deallocate(True)
-
-        # Separate KV cache updates
-        k_cache, v_cache = kv_cache
-        tt_k = ttnn.to_memory_config(tt_k, kv_mem_cfg)
-        tt_v = ttnn.to_memory_config(tt_v, kv_mem_cfg)
-        ttnn.experimental.paged_update_cache(k_cache, tt_k, update_idxs_tensor=position_idx, page_table=page_table)
-        ttnn.experimental.paged_update_cache(v_cache, tt_v, update_idxs_tensor=position_idx, page_table=page_table)
+    ttnn.experimental.paged_update_cache(
+        k_cache,
+        tt_k,
+        update_idxs_tensor=position_idx,
+        page_table=page_table,
+    )
+    ttnn.experimental.paged_update_cache(
+        v_cache,
+        tt_v,
+        update_idxs_tensor=position_idx,
+        page_table=page_table,
+    )
 
     tt_k.deallocate(True)
     tt_v.deallocate(True)
-
-    # Scaled dot-product attention
     grid_size = mesh_device.compute_with_storage_grid_size()
     batch_grid = ttnn.num_cores_to_corerangeset(batch_size, grid_size, row_wise=True)
+
+    # Calculate padded heads (must be tile-aligned, e.g., 32)
+    # Use local heads per device, not global heads
     padded_heads = ((num_local_heads + 31) // 32) * 32
 
     height_sharded_mem_config = ttnn.create_sharded_memory_config(
-        shape=(padded_heads, head_dim),
+        shape=(padded_heads, head_dim),  # Shape per shard (tile-aligned)
         core_grid=batch_grid,
         strategy=ttnn.ShardStrategy.HEIGHT,
         orientation=ttnn.ShardOrientation.ROW_MAJOR,
         use_height_and_width_as_shard_shape=True,
     )
-
+    # Scaled dot-product attention
     if page_table is not None:
         tt_sdpa_tensor = ttnn.transformer.paged_scaled_dot_product_attention_decode(
             tt_q,
@@ -156,6 +129,7 @@ def decode_forward(
             scale=config.scaling,
             program_config=program_config.get_decode_sdpa_config(mesh_device),
             compute_kernel_config=program_config.get_compute_kernel_config(),
+            # memory_config=height_sharded_mem_config,
             memory_config=ttnn.DRAM_MEMORY_CONFIG,
         )
         tt_sdpa_tensor = ttnn.to_memory_config(tt_sdpa_tensor, height_sharded_mem_config)
@@ -175,25 +149,33 @@ def decode_forward(
     tt_q.deallocate(True)
 
     # Concat heads and apply output projection
+
     tt_sdpa_out = ttnn.experimental.nlp_concat_heads_decode(tt_sdpa_tensor, num_heads=num_local_heads)
     tt_sdpa_tensor.deallocate(True)
 
     tt_out = ttnn.linear(
         tt_sdpa_out, weights.o_proj, dtype=ttnn.bfloat16, memory_config=ttnn.L1_WIDTH_SHARDED_MEMORY_CONFIG
     )
-    tt_sdpa_out.deallocate(True)
 
+    tt_sdpa_out.deallocate(True)
     tt_out = ttnn.add(tt_out, weights.o_proj_bias, memory_config=ttnn.L1_MEMORY_CONFIG)
     tt_out = ttnn.typecast(tt_out, ttnn.bfloat8_b)
 
-    # Reshape for CCL
+    # Calculate padded hidden size for tile-aligned CCL operations.
+    # o_proj weights may be padded so local_hidden becomes tile-aligned.
     local_hidden = hidden_size // mesh_config.tp
     padded_local_hidden = ((local_hidden + 31) // 32) * 32
     padded_hidden = padded_local_hidden * mesh_config.tp if mesh_config.tp > 1 else hidden_size
 
-    tt_out = ttnn.reshape(tt_out, (1, 1, batch_size, padded_hidden), (1, 1, 32, padded_hidden))
+    tt_out = ttnn.reshape(
+        tt_out,
+        (1, 1, batch_size, padded_hidden),
+        (1, 1, 32, padded_hidden),
+    )
+    # tt_out = ttnn.unsqueeze(tt_out, 0)
 
     # Tensor parallel allreduce
+    # TODO: This will need to be a reduce scatter so outputs are [1, 1, global_batch//num_rows, hidden_size//num_columns
     tt_out = apply_allreduce(tt_out, mesh_config, ccl_manager, batch_size, seq_len, hidden_size)
 
     return tt_out

--- a/models/demos/gpt_oss/tt/attention/operations.py
+++ b/models/demos/gpt_oss/tt/attention/operations.py
@@ -132,9 +132,22 @@ def apply_allreduce(tensor, mesh_config, ccl_manager, batch_size: int, seq_len: 
         Tensor after allreduce (if TP > 1) or original tensor
     """
     if mesh_config.tp > 1:
-        # tensor = ttnn.unsqueeze(tensor, 0)
         tensor = mesh_config.allreduce(tensor, ccl_manager, pad_size=0, axis=mesh_config.tp_axis)
-        # tensor = ttnn.reshape(tensor, (batch_size, seq_len, hidden_size))
+
+        # Remove padding added in weights.py for tile-aligned CCL operations.
+        # If local_hidden was padded (e.g., 360 -> 384), we need to slice back to original hidden_size.
+        local_hidden = hidden_size // mesh_config.tp
+        padded_local_hidden = ((local_hidden + 31) // 32) * 32
+        if padded_local_hidden != local_hidden:
+            # Slice from padded_hidden back to hidden_size on the last dimension.
+            # Works for both decode [1, 1, batch, padded_hidden] and prefill [1, batch, seq_len, padded_hidden].
+            shape = tensor.shape
+            tensor = ttnn.slice(
+                tensor,
+                starts=[0, 0, 0, 0],
+                ends=[shape[0], shape[1], shape[2], hidden_size],
+                steps=[1, 1, 1, 1],
+            )
     return tensor
 
 

--- a/models/demos/gpt_oss/tt/attention/weights.py
+++ b/models/demos/gpt_oss/tt/attention/weights.py
@@ -132,16 +132,34 @@ def load_attention_weights(
     decode_sinks /= config.scaling
 
     # Output projection
+    # Pad o_proj output dimension for tile alignment in CCL operations.
+    # Without padding, local_hidden = hidden_size / TP may not be tile-aligned (e.g., 2880/8 = 360),
+    # causing CCL to do expensive Untilize->Pad->Tilize cycles internally.
+    hidden_size = config.hidden_size
+    local_hidden = hidden_size // mesh_config.tp
+    padded_local_hidden = ((local_hidden + 31) // 32) * 32  # Round up to tile boundary
+    o_proj_pad_size = padded_local_hidden - local_hidden
+
+    if o_proj_pad_size > 0 and mesh_config.tp > 1:
+        # Pad the output dimension of o_proj weight: [input_dim, hidden_size] -> [input_dim, padded_hidden]
+        # Each TP device's output goes from local_hidden to padded_local_hidden
+        padded_hidden = padded_local_hidden * mesh_config.tp
+        o_proj = torch.nn.functional.pad(o_proj, (0, padded_hidden - hidden_size), "constant", value=0.0)
+        # Pad bias similarly
+        o_proj_bias = torch.nn.functional.pad(o_proj_bias, (0, padded_hidden - hidden_size), "constant", value=0.0)
+
     if mesh_config.tp > 1:
         o_proj_bias = torch.cat([o_proj_bias] + [torch.zeros_like(o_proj_bias)] * (mesh_config.tp - 1), dim=-1)
 
+    # Use unique cache key when padding is applied
+    o_proj_cache_suffix = f"_padded{padded_local_hidden}" if o_proj_pad_size > 0 and mesh_config.tp > 1 else ""
     o_proj_tt = ttnn.as_tensor(
         o_proj,
         device=mesh_device,
         layout=ttnn.TILE_LAYOUT,
         dtype=weight_dtype,
         mesh_mapper=row_mesh_mapper,
-        cache_file_name=get_cache_file_name(tensor_cache_path, "o_proj"),
+        cache_file_name=get_cache_file_name(tensor_cache_path, f"o_proj{o_proj_cache_suffix}"),
         memory_config=ttnn.DRAM_MEMORY_CONFIG,
     )
 
@@ -151,7 +169,7 @@ def load_attention_weights(
         layout=ttnn.TILE_LAYOUT,
         dtype=bias_dtype,
         mesh_mapper=col_mesh_mapper,
-        cache_file_name=get_cache_file_name(tensor_cache_path, "o_proj_bias"),
+        cache_file_name=get_cache_file_name(tensor_cache_path, f"o_proj_bias{o_proj_cache_suffix}"),
         memory_config=ttnn.DRAM_MEMORY_CONFIG,
     )
 


### PR DESCRIPTION
Added padding to o_proj weights and bias to ensure tile-aligned dimensions in CCL operations, avoiding expensive untilize-pad-tilize cycles

https://github.com/tenstorrent/tt-metal/actions/runs/21719380426