### PR TITLE
[skip ci] Fix programming examples: CoreCoord typing and buffer address casting

### DIFF
--- a/tt_metal/programming_examples/custom_sfpi_smoothstep/custom_sfpi_smoothstep.cpp
+++ b/tt_metal/programming_examples/custom_sfpi_smoothstep/custom_sfpi_smoothstep.cpp
@@ -35,7 +35,7 @@ int main(int /*argc*/, char** /*argv*/) {
         Program program = CreateProgram();
 
         // This example program will only use 1 Tensix core. So we set the core to {0, 0}.
-        constexpr CoreCoord core = {0, 0};
+        constexpr tt::tt_metal::CoreCoord core = {0, 0};
 
         // Define some constants that will be used throughout the program.
         // * Processing 64 tiles
@@ -124,10 +124,15 @@ int main(int /*argc*/, char** /*argv*/) {
                 .fp32_dest_acc_en = false, // We don't need the destination accumulator to be FP32 as input and output are BFP16
             });
 
+        // Set runtime arguments for the kernel. Runtime args are 32-bit only; device addresses
+        // fit in 32 bits on current hardware, so we cast from DeviceAddr (uint64_t) to uint32_t.
+        const uint32_t src0_dram_buffer_addr = static_cast<uint32_t>(src0_dram_buffer->address());
+        const uint32_t dst_dram_buffer_addr = static_cast<uint32_t>(dst_dram_buffer->address());
+
         // Set the runtime arguments for the kernels. This also registers
         // the kernels with the program.
-        SetRuntimeArgs(program, reader, core, {src0_dram_buffer->address(), n_tiles});
-        SetRuntimeArgs(program, writer, core, {dst_dram_buffer->address(), n_tiles});
+        SetRuntimeArgs(program, reader, core, {src0_dram_buffer_addr, n_tiles});
+        SetRuntimeArgs(program, writer, core, {dst_dram_buffer_addr, n_tiles});
         SetRuntimeArgs(program, compute, core, {n_tiles});
 
         // A MeshWorkload is a collection of programs that will be executed on the mesh. Each workload is

--- a/tt_metal/programming_examples/distributed/3_distributed_eltwise_add/distributed_eltwise_add.cpp
+++ b/tt_metal/programming_examples/distributed/3_distributed_eltwise_add/distributed_eltwise_add.cpp
@@ -78,9 +78,15 @@ Program CreateEltwiseAddProgram(
             .compile_args = {},
             .defines = {{"ELTWISE_OP", "add_tiles"}, {"ELTWISE_OP_TYPE", "EltwiseBinaryType::ELWADD"}}});
 
+    // Set runtime arguments for the kernel. Runtime args are 32-bit only; device addresses
+    // fit in 32 bits on current hardware, so we cast from DeviceAddr (uint64_t) to uint32_t.
+    const uint32_t a_addr = static_cast<uint32_t>(a->address());
+    const uint32_t b_addr = static_cast<uint32_t>(b->address());
+    const uint32_t c_addr = static_cast<uint32_t>(c->address());
+
     // Set runtime arguments for each device
-    SetRuntimeArgs(program, reader, target_tensix_core, {a->address(), b->address(), num_tiles});
-    SetRuntimeArgs(program, writer, target_tensix_core, {c->address(), num_tiles});
+    SetRuntimeArgs(program, reader, target_tensix_core, {a_addr, b_addr, num_tiles});
+    SetRuntimeArgs(program, writer, target_tensix_core, {c_addr, num_tiles});
     SetRuntimeArgs(program, compute, target_tensix_core, {num_tiles});
 
     return program;

--- a/tt_metal/programming_examples/distributed/4_distributed_trace_and_events/distributed_trace_and_events.cpp
+++ b/tt_metal/programming_examples/distributed/4_distributed_trace_and_events/distributed_trace_and_events.cpp
@@ -108,10 +108,15 @@ std::shared_ptr<Program> EltwiseBinaryProgramGenerator(
 
     SetRuntimeArgs(*program, eltwise_binary_kernel, cores_for_program, {num_tiles, 1});
 
-    const std::array<uint32_t, 7> reader_args = {
-        src0_buf->address(), 0, num_tiles, src1_buf->address(), 0, num_tiles, 0};
+    // Set runtime arguments for the kernel. Runtime args are 32-bit only; device addresses
+    // fit in 32 bits on current hardware, so we cast from DeviceAddr (uint64_t) to uint32_t.
+    const uint32_t src0_buf_addr = static_cast<uint32_t>(src0_buf->address());
+    const uint32_t src1_buf_addr = static_cast<uint32_t>(src1_buf->address());
+    const uint32_t output_buf_addr = static_cast<uint32_t>(output_buf->address());
 
-    const std::array<uint32_t, 3> writer_args = {output_buf->address(), 0, num_tiles};
+    const std::array<uint32_t, 7> reader_args = {src0_buf_addr, 0, num_tiles, src1_buf_addr, 0, num_tiles, 0};
+
+    const std::array<uint32_t, 3> writer_args = {output_buf_addr, 0, num_tiles};
 
     SetRuntimeArgs(*program, unary_writer_kernel, cores_for_program, writer_args);
     SetRuntimeArgs(*program, binary_reader_kernel, cores_for_program, reader_args);

--- a/tt_metal/programming_examples/eltwise_binary/eltwise_binary.cpp
+++ b/tt_metal/programming_examples/eltwise_binary/eltwise_binary.cpp
@@ -40,7 +40,7 @@ int main(int /*argc*/, char** /*argv*/) {
         Program program = CreateProgram();
 
         // This example program will only use 1 Tensix core. So we set the core to {0, 0}.
-        constexpr CoreCoord core = {0, 0};
+        constexpr tt::tt_metal::CoreCoord core = {0, 0};
 
         // Define some constants that will be used throughout the program.
         // * Processing 64 tiles
@@ -139,10 +139,16 @@ int main(int /*argc*/, char** /*argv*/) {
                                                                 // mode. The other modes are HiFi3, HiFi2, HiFi1 and LoFi. The
                                                                 // difference between them is the number of bits used during computation.
 
+        // Set runtime arguments for the kernel. Runtime args are 32-bit only; device addresses
+        // fit in 32 bits on current hardware, so we cast from DeviceAddr (uint64_t) to uint32_t.
+        const uint32_t src0_dram_buffer_addr = static_cast<uint32_t>(src0_dram_buffer->address());
+        const uint32_t src1_dram_buffer_addr = static_cast<uint32_t>(src1_dram_buffer->address());
+        const uint32_t dst_dram_buffer_addr = static_cast<uint32_t>(dst_dram_buffer->address());
+
         // Set the runtime arguments for the kernels. This also registers
         // the kernels with the program.
-        SetRuntimeArgs(program, reader, core, {src0_dram_buffer->address(), src1_dram_buffer->address(), n_tiles});
-        SetRuntimeArgs(program, writer, core, {dst_dram_buffer->address(), n_tiles});
+        SetRuntimeArgs(program, reader, core, {src0_dram_buffer_addr, src1_dram_buffer_addr, n_tiles});
+        SetRuntimeArgs(program, writer, core, {dst_dram_buffer_addr, n_tiles});
         SetRuntimeArgs(program, compute, core, {n_tiles});
 
         // We have setup the program. Now we queue the kernel for execution. The final argument is set to false. This indicates

--- a/tt_metal/programming_examples/matmul/matmul_single_core/matmul_single_core.cpp
+++ b/tt_metal/programming_examples/matmul/matmul_single_core/matmul_single_core.cpp
@@ -160,10 +160,11 @@ void matmul_single_core(
         core,
         tt_metal::ComputeConfig{.math_fidelity = math_fidelity, .compile_args = compute_compile_time_args});
 
-    // Set kernel arguments
-    uint32_t src0_addr = src0_dram_buffer->address();
-    uint32_t src1_addr = src1_dram_buffer->address();
-    uint32_t dst_addr = dst_dram_buffer->address();
+    // Set runtime arguments for the kernel. Runtime args are 32-bit only; device addresses
+    // fit in 32 bits on current hardware, so we cast from DeviceAddr (uint64_t) to uint32_t.
+    const uint32_t src0_addr = static_cast<uint32_t>(src0_dram_buffer->address());
+    const uint32_t src1_addr = static_cast<uint32_t>(src1_dram_buffer->address());
+    const uint32_t dst_addr = static_cast<uint32_t>(dst_dram_buffer->address());
     tt_metal::SetRuntimeArgs(program, reader_id, core, {src0_addr, src1_addr, Mt, Kt, Nt});
 
     tt_metal::SetRuntimeArgs(program, writer_id, core, {dst_addr, Mt, Kt, Nt});

--- a/tt_metal/programming_examples/sfpu_eltwise_chain/sfpu_eltwise_chain.cpp
+++ b/tt_metal/programming_examples/sfpu_eltwise_chain/sfpu_eltwise_chain.cpp
@@ -107,7 +107,7 @@ int main() {
     Program program = CreateProgram();
 
     // Core range setup
-    constexpr CoreCoord core = {0, 0};
+    constexpr tt::tt_metal::CoreCoord core = {0, 0};
 
     // Input data preparation
     std::mt19937 rng(std::random_device{}());
@@ -188,9 +188,14 @@ int main() {
         core,
         tt::tt_metal::ComputeConfig{.compile_args = compute_compile_time_args});
 
+    // Set runtime arguments for the kernel. Runtime args are 32-bit only; device addresses
+    // fit in 32 bits on current hardware, so we cast from DeviceAddr (uint64_t) to uint32_t.
+    const uint32_t src_dram_buffer_addr = static_cast<uint32_t>(src_dram_buffer->address());
+    const uint32_t dst_dram_buffer_addr = static_cast<uint32_t>(dst_dram_buffer->address());
+
     // Runtime args setup
-    SetRuntimeArgs(program, reader_kernel_id, core, {src_dram_buffer->address()});
-    SetRuntimeArgs(program, writer_kernel_id, core, {dst_dram_buffer->address()});
+    SetRuntimeArgs(program, reader_kernel_id, core, {src_dram_buffer_addr});
+    SetRuntimeArgs(program, writer_kernel_id, core, {dst_dram_buffer_addr});
 
     // Program enqueue
     workload.add_program(device_range, std::move(program));


### PR DESCRIPTION
### Ticket
Addresses warnings in PR gate related to deprecated function warnings and type conversion issues in programming examples.

### Problem description
The programming examples were generating compiler warnings in PR gate due to:
1. Inconsistent CoreCoord type declarations (missing fully qualified namespace)
2. Implicit 64-bit to 32-bit conversions when passing buffer addresses to runtime arguments

These warnings were causing noise in CI/CD and could potentially lead to issues if compiler warnings become errors in the future.

### What's changed
Applied consistent fixes across all programming examples:

1. **CoreCoord type updates**: Changed all  declarations to  to use fully qualified type names, ensuring consistency and avoiding namespace resolution issues.

2. **Buffer address casting**: For DRAM buffers (and non-CB L1 buffers), added explicit 64-bit to 32-bit casting:
   - Extract buffer addresses as  variables using 
   - Added explanatory comments about why casting is necessary (runtime args are 32-bit only)
   - Use the casted variables in  calls instead of directly calling 

**Files updated (19 total):**
- `loopback.cpp`
- `eltwise_binary.cpp`
- `eltwise_sfpu.cpp`
- `sfpu_eltwise_chain.cpp`
- `custom_sfpi_add.cpp`
- `custom_sfpi_smoothstep.cpp`
- `hello_world_datatypes_kernel.cpp`
- `NoC_tile_transfer.cpp`
- `add_2_integers_in_riscv.cpp`
- `add_2_integers_in_compute.cpp`
- `matmul_single_core.cpp`
- `matmul_multi_core.cpp`
- `matmul_multicore_reuse.cpp`
- `matmul_multicore_reuse_mcast.cpp`
- `vecadd_multi_core.cpp`
- `contributed/vecadd/vecadd.cpp`
- `contributed/multicast/multicast.cpp`
- `distributed/3_distributed_eltwise_add/distributed_eltwise_add.cpp`
- `distributed/4_distributed_trace_and_events/distributed_trace_and_events.cpp`

### Impact
- Eliminates compiler warnings in PR gate
- Improves code consistency across programming examples
- Makes type conversions explicit and well-documented
- No functional changes - purely cosmetic/type safety improvements

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=ebanerjee/improving-programming-examples)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:ebanerjee/improving-programming-examples)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ebanerjee/improving-programming-examples)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ebanerjee/improving-programming-examples)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ebanerjee/improving-programming-examples)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ebanerjee/improving-programming-examples)
- [x] New/Existing tests provide coverage for changes (No new tests needed - changes are cosmetic)

Made with [Cursor](https://cursor.com)