### PR TITLE
Increase hang detection timeout for data movement tests

### DIFF
--- a/.github/workflows/tt-metal-l2-nightly-impl.yaml
+++ b/.github/workflows/tt-metal-l2-nightly-impl.yaml
@@ -770,6 +770,7 @@ jobs:
         with:
           build-artifact-name: ${{ inputs.build-artifact-name }}
           wheel-artifact-name: ${{ inputs.wheel-artifact-name }}
+          hang-detection-timeout: 10.0
       - name: ttnn nightly data_movement tests
         timeout-minutes: ${{ inputs.timeout }}
         run: pytest tests/ttnn/nightly/unit_tests/operations/data_movement -xv -m "not disable_fast_runtime_mode" --timeout=${{ env.TEST_BUDGET_SECONDS }}


### PR DESCRIPTION
### Ticket
N/A

### Problem description
The data movement tests in the nightly L2 test suite were failing due to timeout issues. The default hang detection timeout of 5.0 seconds was too aggressive for these tests, causing false positives where tests were incorrectly identified as hung.

**Failure on main:**
- [Failed run on main](https://github.com/tenstorrent/tt-metal/actions/runs/21701088256/job/62601203526) - Shows the test failure before this fix

### What's changed
Increased the `hang-detection-timeout` parameter from the default 5.0 seconds to 10.0 seconds specifically for the data movement tests in the nightly L2 workflow. This gives the tests more time to make progress before being flagged as hung, preventing false timeout detections.

The change modifies `.github/workflows/tt-metal-l2-nightly-impl.yaml` to explicitly set `hang-detection-timeout: 10.0` for the setup-job action used by the data movement tests.

**Proof of fix:**
- [Successful run with fix](https://github.com/tenstorrent/tt-metal/actions/runs/21720864416/job/62651965491) - Shows the tests passing after this change

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=ebanerjee/increasing-hang-detection-timeout-for-datamovement)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:ebanerjee/increasing-hang-detection-timeout-for-datamovement)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ebanerjee/increasing-hang-detection-timeout-for-datamovement)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ebanerjee/increasing-hang-detection-timeout-for-datamovement)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ebanerjee/increasing-hang-detection-timeout-for-datamovement)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ebanerjee/increasing-hang-detection-timeout-for-datamovement)
- [x] New/Existing tests provide coverage for changes