### PR TITLE
[skip ci] Expand Exabox troubleshooting guide with new operational issues

### DIFF
--- a/tools/scaleout/exabox/README.md
+++ b/tools/scaleout/exabox/README.md
@@ -170,24 +170,7 @@ The script parses the test log and provides:
 
 **Important: Host Ordering Matters for 4x32 Clusters**
 
-For 4x32 topology, you **must** specify hosts in physical connectivity order. The 4 Galaxies are connected in a ring (`1 <-> 2 <-> 3 <-> 4 <-> 1`), and MPI rank assignment depends on the order you pass hosts.
-
-If you see this error:
-```
-TT_FATAL: Graph specified in MGD could not fit in the discovered physical topology
-```
-
-This can mean one of two things:
-
-1. **Physical validation reported missing connections** - Run physical validation first to check cluster health
-2. **Hosts passed in wrong order** - Only if physical validation passed, fix by:
-   - Identifying which host is "Host 1" in your pod
-   - Logging onto that host
-   - Passing hosts in ring order: `host1,host2,host3,host4`
-
-See [Fabric Test Fails with "Graph could not fit in physical topology"](./TROUBLESHOOTING.md#fabric-test-fails-with-graph-could-not-fit-in-physical-topology) for details.
-
-**Note:** These topology-specific scripts will eventually be replaced with a unified cluster-level descriptor approach that handles host ordering automatically.
+For 4x32 topology, you **must** specify hosts in physical connectivity order. The 4 Galaxies are connected in a ring (`1 <-> 2 <-> 3 <-> 4 <-> 1`). If you see `TT_FATAL: Graph specified in MGD could not fit in the discovered physical topology`, see [Fabric Test Fails with "Graph could not fit in physical topology"](./TROUBLESHOOTING.md#fabric-test-fails-with-graph-could-not-fit-in-physical-topology) for diagnosis and resolution.
 
 If these tests fail, raise the issue in the `#exabox-infra` Slack channel and tag the syseng and scaleout teams.
 
@@ -223,9 +206,7 @@ source python_env/bin/activate
 ./tools/scaleout/exabox/recover_4x32.sh <hosts>
 ```
 
-Look for `All Detected Links are healthy` in the output.
-
-**If you see "could not access or execute an executable"**: You haven't built tt-metal. Either build it (see above) or use the Docker-based `run_validation.sh` script instead (run with `--help` for usage), which doesn't require a build.
+Look for `All Detected Links are healthy` in the output. If you see `could not access or execute an executable`, see [Recovery Script Fails](./TROUBLESHOOTING.md#recovery-script-fails-with-could-not-access-or-execute-an-executable).
 
 ## Troubleshooting
 

--- a/tools/scaleout/exabox/README.md
+++ b/tools/scaleout/exabox/README.md
@@ -177,10 +177,13 @@ If you see this error:
 TT_FATAL: Graph specified in MGD could not fit in the discovered physical topology
 ```
 
-It means hosts were passed in the wrong order. Fix by:
-1. Identifying which host is "Host 1" in your pod
-2. Logging onto that host
-3. Passing hosts in ring order: `host1,host2,host3,host4`
+This can mean one of two things:
+
+1. **Physical validation reported missing connections** - Run physical validation first to check cluster health
+2. **Hosts passed in wrong order** - Only if physical validation passed, fix by:
+   - Identifying which host is "Host 1" in your pod
+   - Logging onto that host
+   - Passing hosts in ring order: `host1,host2,host3,host4`
 
 See [Fabric Test Fails with "Graph could not fit in physical topology"](./TROUBLESHOOTING.md#fabric-test-fails-with-graph-could-not-fit-in-physical-topology) for details.
 

--- a/tools/scaleout/exabox/README.md
+++ b/tools/scaleout/exabox/README.md
@@ -201,13 +201,13 @@ For day-to-day use when you just need to verify a cluster is working.
 
 **Important: These scripts require a local build!**
 
-Unlike the Docker-based qualification scripts above (`run_validation_*.sh`, `run_fabric_tests_*.sh`), the recovery scripts run binaries directly on the host and require you to build tt-metal first.
+Unlike the Docker-based qualification scripts above (`run_validation.sh`, `run_fabric_tests.sh`), the recovery scripts run binaries directly on the host and require you to build tt-metal first.
 
 | Script Type | Requires Build? | Uses Docker? |
 |-------------|----------------|--------------|
 | `recover_*.sh` | **Yes** | No |
-| `run_validation_*.sh` | No | Yes |
-| `run_fabric_tests_*.sh` | No | Yes |
+| `run_validation.sh` | No | Yes |
+| `run_fabric_tests.sh` | No | Yes |
 
 **Build first:**
 ```bash
@@ -225,7 +225,7 @@ source python_env/bin/activate
 
 Look for `All Detected Links are healthy` in the output.
 
-**If you see "could not access or execute an executable"**: You haven't built tt-metal. Either build it (see above) or use the Docker-based `run_validation_*.sh` scripts instead, which don't require a build.
+**If you see "could not access or execute an executable"**: You haven't built tt-metal. Either build it (see above) or use the Docker-based `run_validation.sh` script instead (run with `--help` for usage), which doesn't require a build.
 
 ## Troubleshooting
 

--- a/tools/scaleout/exabox/TROUBLESHOOTING.md
+++ b/tools/scaleout/exabox/TROUBLESHOOTING.md
@@ -231,32 +231,9 @@ while attempting to start process rank 0.
 
 **Cause**: The `recover_*.sh` scripts run binaries directly on the host (not via Docker) and require a local build of tt-metal. Unlike the Docker-based scripts (`run_validation.sh`, `run_fabric_tests.sh`), they don't use containers.
 
-**Key distinction**:
-| Script Type | Requires Build? | Uses Docker? |
-|-------------|----------------|--------------|
-| `recover_*.sh` | **Yes** | No |
-| `run_validation.sh` | No | Yes |
-| `run_fabric_tests.sh` | No | Yes |
-| `run_dispatch_tests.sh` | No | Yes |
-
-**Solution**: Build tt-metal before running recovery scripts:
-
-```bash
-# From your tt-metal repo directory
-./create_venv.sh
-source python_env/bin/activate
-./build_metal.sh --build-metal-tests
-
-# Now the recovery script will work
-./tools/scaleout/exabox/recover_4x32.sh <hosts>
-```
-
-**Alternative - Use Docker-based validation instead**: If you don't need a local build, use the Docker-based validation script which doesn't require building:
-
-```bash
-# This doesn't require a build - it uses Docker
-./tools/scaleout/exabox/run_validation.sh --hosts <hosts> --image <docker-image>
-```
+**Solution**: 
+- **Build tt-metal first** - See [Quick Health Check](./README.md#quick-health-check-for-developers) for build instructions
+- **Or use Docker-based validation** - Run `./run_validation.sh --hosts <hosts> --image <docker-image>` which doesn't require a build
 
 **Common confusion**: People often confuse the `recover_*.sh` scripts (developer tools, require build) with the `run_validation.sh` script (operator tool, uses Docker). For hardware qualification, use the Docker-based scripts.
 

--- a/tools/scaleout/exabox/TROUBLESHOOTING.md
+++ b/tools/scaleout/exabox/TROUBLESHOOTING.md
@@ -231,7 +231,7 @@ while attempting to start process rank 0.
 
 **Cause**: The `recover_*.sh` scripts run binaries directly on the host (not via Docker) and require a local build of tt-metal. Unlike the Docker-based scripts (`run_validation.sh`, `run_fabric_tests.sh`), they don't use containers.
 
-**Solution**: 
+**Solution**:
 - **Build tt-metal first** - See [Quick Health Check](./README.md#quick-health-check-for-developers) for build instructions
 - **Or use Docker-based validation** - Run `./run_validation.sh --hosts <hosts> --image <docker-image>` which doesn't require a build
 

--- a/tools/scaleout/exabox/TROUBLESHOOTING.md
+++ b/tools/scaleout/exabox/TROUBLESHOOTING.md
@@ -751,24 +751,13 @@ The error originates from `tt_metal/impl/device/device_manager.cpp` during `Devi
 
 **Solution**:
 
-1. **Increase reset sleep time**: 30 seconds may not be enough. Try 60 seconds or more:
-   ```bash
-   mpirun --host <hosts> tt-smi -r
-   sleep 60  # Increased from 30
-   ```
-
-2. **Increase sync timeout**: Set `TT_METAL_FABRIC_ROUTER_SYNC_TIMEOUT_MS` to a higher value (e.g., 60000 for 1 minute):
-   ```bash
-   export TT_METAL_FABRIC_ROUTER_SYNC_TIMEOUT_MS=60000
-   ```
-
-3. **Run physical validation first**: This catches unhealthy links before attempting fabric tests:
+1. **Run physical validation first**: This catches unhealthy links before attempting fabric tests:
    ```bash
    ./run_validation.sh --hosts <hosts> --image <docker-image>
    ```
    If validation shows missing connections or unhealthy links, fix those issues before running fabric tests.
 
-4. **For automated pipelines**: Add physical validation as a pre-check and implement retry logic:
+2. **For automated pipelines**: Add physical validation as a pre-check and implement retry logic:
    ```bash
    # Reset and wait
    mpirun --host <hosts> tt-smi -r

--- a/tools/scaleout/exabox/TROUBLESHOOTING.md
+++ b/tools/scaleout/exabox/TROUBLESHOOTING.md
@@ -508,12 +508,12 @@ This error typically appears across multiple MPI ranks with the same hostname me
      - `/data/scaleout_configs/4xBH_4x32_intrapod_updated/` - updated 4x32 configs
 
 3. **Update the script or use a custom command**:
-   
+
    Option A - Modify the recovery script temporarily:
    ```bash
    # Edit recover_4x32.sh and change the --factory-descriptor-path to the correct FSD
    ```
-   
+
    Option B - Run the validation command directly with the correct FSD:
    ```bash
    mpirun --host <hosts> tt-smi -r
@@ -730,10 +730,10 @@ The error originates from `tt_metal/impl/context/metal_context.cpp` during `Meta
    # Reset all hosts
    mpirun --host <hosts> tt-smi -r
    sleep 30
-   
+
    # Validate cluster health
    ./run_validation_4x32.sh <hosts> <docker-image>
-   
+
    # Only proceed if validation passes
    ./run_fabric_tests_4x32.sh <hosts> <docker-image>
    ```
@@ -782,10 +782,10 @@ The error originates from `tt_metal/impl/device/device_manager.cpp` during `Devi
    # Reset and wait
    mpirun --host <hosts> tt-smi -r
    sleep 60
-   
+
    # Validate - exit early if cluster is unhealthy
    ./run_validation_4x32.sh <hosts> <docker-image> || exit 1
-   
+
    # Run fabric tests
    ./run_fabric_tests_4x32.sh <hosts> <docker-image>
    ```

--- a/tools/scaleout/exabox/TROUBLESHOOTING.md
+++ b/tools/scaleout/exabox/TROUBLESHOOTING.md
@@ -658,7 +658,21 @@ Either relax pinnings or modify the MGD.
 
 The error originates from `tt_metal/fabric/topology_mapper.cpp` during `TopologyMapper::build_mapping()`.
 
-**Cause**: Host ordering mismatch between MPI ranks and physical connectivity.
+**Cause**: This error can have two root causes:
+
+1. **Missing physical connections** - Physical validation reported missing connections, meaning the cluster doesn't have all expected links. This is the most common cause.
+
+2. **Host ordering mismatch** - If physical validation passed but fabric tests fail with this error, hosts were passed in the wrong order to MPI.
+
+**Diagnosing the cause**:
+```bash
+# Run physical validation first
+./run_validation_4x32.sh <hosts> <docker-image>
+```
+- If validation shows missing connections → Fix the hardware/cabling issue first
+- If validation passes (all links healthy) → It's a host ordering issue, continue below
+
+**Host Ordering Explanation (Cause #2)**:
 
 In a 4x32 pod, the 4 Galaxies are connected in a ring: `1 <-> 2 <-> 3 <-> 4 <-> 1`. Hosts 1 & 3 are **not** directly connected, and neither are hosts 2 & 4.
 


### PR DESCRIPTION
### Ticket
No issue

### Problem description

- New operational issues surfaced during Exabox cluster validation and fabric testing (topology mapping failures, FW initialization timeouts, router sync errors, FSD mismatches) that were causing confusion and delays for operators
- Existing documentation didn't clearly distinguish between scripts requiring local builds vs Docker containers, and lacked guidance on FSD path configuration for different clusters

### What's changed

- Added 5 new troubleshooting entries covering: fabric topology mapping failures (with dual-cause diagnosis), FW initialization timeouts, fabric router sync timeouts, recovery script build requirements, and FSD hostname mismatches with hardcoded path guidance
- Enhanced README and recovery scripts with clearer warnings about build requirements, host ordering for 4x32 clusters, and notes about hardcoded FSD paths that may need cluster-specific updates