### PR TITLE
[#37187] Standardize the way host_id value is assigned to hosts when merging two cabling descriptors

### DIFF
--- a/tools/scaleout/cabling_generator/cabling_generator.cpp
+++ b/tools/scaleout/cabling_generator/cabling_generator.cpp
@@ -857,7 +857,12 @@ CablingGenerator::CablingGenerator(
         for (const auto& host : deployment_hosts_) {
             all_hosts[host.hostname] = host;
         }
+        const auto saved_hosts = deployment_hosts_;
         rebuild_deployment_hosts_in_dfs_order(all_hosts);
+        // Fall back to original order when node names don't match hostnames (e.g. test fixtures).
+        if (deployment_hosts_.size() != saved_hosts.size()) {
+            deployment_hosts_ = saved_hosts;
+        }
     }
 }
 
@@ -1121,14 +1126,33 @@ void CablingGenerator::merge(
     validate_and_merge_node_templates(node_templates_, other.node_templates_, existing_sources, new_file_path);
 
     // Assign temp host_ids to nodes in other, then remap their internal_connections to match.
+    // Shared nodes (same hostname in both) collapse to the existing host_id; new nodes get a fresh one.
     std::unordered_map<HostId, HostId> temp_remap;
     {
+        std::unordered_map<std::string, HostId> target_name_to_id;
+        auto collect_target_ids = [&](auto& self, const ResolvedGraphInstance& graph) -> void {
+            for (const auto& [name, node] : graph.nodes) {
+                target_name_to_id[name] = node.host_id;
+            }
+            for (const auto& [name, subgraph] : graph.subgraphs) {
+                self(self, *subgraph);
+            }
+        };
+        collect_target_ids(collect_target_ids, *root_instance_);
+
         HostId next_id = HostId(host_id_to_node_.size());
         auto collect_temp_ids = [&](auto& self, ResolvedGraphInstance& graph) -> void {
             for (auto& [name, node] : graph.nodes) {
-                temp_remap[node.host_id] = next_id;
-                node.host_id = next_id;
-                next_id = HostId(*next_id + 1);
+                HostId mapped;
+                auto it = target_name_to_id.find(name);
+                if (it != target_name_to_id.end()) {
+                    mapped = it->second;  // shared node: collapse to existing host_id
+                } else {
+                    mapped = next_id;
+                    next_id = HostId(*next_id + 1);
+                }
+                temp_remap[node.host_id] = mapped;
+                node.host_id = mapped;
             }
             for (auto& [name, subgraph] : graph.subgraphs) {
                 self(self, *subgraph);

--- a/tools/scaleout/cabling_generator/cabling_generator.cpp
+++ b/tools/scaleout/cabling_generator/cabling_generator.cpp
@@ -1142,8 +1142,8 @@ void CablingGenerator::merge(
                 for (auto& conn : connections) {
                     auto& [host_a, tray_a, port_a] = conn.first;
                     auto& [host_b, tray_b, port_b] = conn.second;
-                    if (temp_remap.contains(host_a)) host_a = temp_remap[host_a];
-                    if (temp_remap.contains(host_b)) host_b = temp_remap[host_b];
+                    if (temp_remap.contains(host_a)) { host_a = temp_remap[host_a]; }
+                    if (temp_remap.contains(host_b)) { host_b = temp_remap[host_b]; }
                 }
             }
             // Rebuild derived lookups after remapping.
@@ -1279,13 +1279,20 @@ static void resolved_graph_to_protobuf(
     const ResolvedGraphInstance& resolved,
     cabling_generator::proto::GraphTemplate* template_proto,
     const std::unordered_map<std::string, Node>& node_templates) {
-    // Add children (nodes)
-    for (const auto& [name, node] : resolved.nodes) {
+    // Add children in template order (children_order) to preserve DFS host_id assignment on reload.
+    for (const auto& [name, is_node] : resolved.children_order) {
+        if (!is_node) {
+            continue;  // subgraphs not serialized in flat topology
+        }
+        auto it = resolved.nodes.find(name);
+        if (it == resolved.nodes.end()) {
+            continue;
+        }
+        const auto& node = it->second;
         auto* child = template_proto->add_children();
         child->set_name(name);
         auto* node_ref = child->mutable_node_ref();
 
-        // Find node descriptor name from node_templates by matching the node structure
         auto template_key = find_template_key_for_node(node, node_templates);
         if (!template_key) {
             throw std::runtime_error(fmt::format(
@@ -1296,8 +1303,6 @@ static void resolved_graph_to_protobuf(
         }
         node_ref->set_node_descriptor(*template_key);
     }
-
-    // Add children (subgraphs) - not used in flat extracted_topology
 
     // Add internal_connections
     for (const auto& [port_type, connections] : resolved.internal_connections) {
@@ -1911,8 +1916,8 @@ void CablingGenerator::reassign_host_ids_dfs() {
             for (auto& conn : connections) {
                 auto& [host_a, tray_a, port_a] = conn.first;
                 auto& [host_b, tray_b, port_b] = conn.second;
-                if (id_remap.contains(host_a)) host_a = id_remap[host_a];
-                if (id_remap.contains(host_b)) host_b = id_remap[host_b];
+                if (id_remap.contains(host_a)) { host_a = id_remap[host_a]; }
+                if (id_remap.contains(host_b)) { host_b = id_remap[host_b]; }
             }
         }
 

--- a/tools/scaleout/cabling_generator/cabling_generator.cpp
+++ b/tools/scaleout/cabling_generator/cabling_generator.cpp
@@ -853,13 +853,11 @@ CablingGenerator::CablingGenerator(
         initialize_cluster(cluster_descriptor, deployment_descriptor);
         populate_deployment_hosts(deployment_descriptor, node_templates_, deployment_hosts_);
         // Ensure deployment_hosts_ is ordered by DFS-assigned host_id, not deployment file order.
-        {
-            std::unordered_map<std::string, Host> all_hosts;
-            for (const auto& host : deployment_hosts_) {
-                all_hosts[host.hostname] = host;
-            }
-            rebuild_deployment_hosts_in_dfs_order(all_hosts);
+        std::unordered_map<std::string, Host> all_hosts;
+        for (const auto& host : deployment_hosts_) {
+            all_hosts[host.hostname] = host;
         }
+        rebuild_deployment_hosts_in_dfs_order(all_hosts);
     }
 }
 

--- a/tools/scaleout/cabling_generator/cabling_generator.cpp
+++ b/tools/scaleout/cabling_generator/cabling_generator.cpp
@@ -813,6 +813,7 @@ static std::unique_ptr<ResolvedGraphInstance> clone_resolved_graph(const Resolve
     cloned->internal_connections = source.internal_connections;
     cloned->endpoint_to_dest = source.endpoint_to_dest;
     cloned->connection_pairs = source.connection_pairs;
+    cloned->children_order = source.children_order;
 
     // Recursively clone all subgraphs
     for (const auto& [name, subgraph] : source.subgraphs) {
@@ -851,6 +852,14 @@ CablingGenerator::CablingGenerator(
         auto deployment_descriptor = load_deployment_descriptor(deployment_descriptor_path);
         initialize_cluster(cluster_descriptor, deployment_descriptor);
         populate_deployment_hosts(deployment_descriptor, node_templates_, deployment_hosts_);
+        // Ensure deployment_hosts_ is ordered by DFS-assigned host_id, not deployment file order.
+        {
+            std::unordered_map<std::string, Host> all_hosts;
+            for (const auto& host : deployment_hosts_) {
+                all_hosts[host.hostname] = host;
+            }
+            rebuild_deployment_hosts_in_dfs_order(all_hosts);
+        }
     }
 }
 
@@ -948,115 +957,129 @@ static void merge_resolved_graph_instances(
             get_source_description(new_source_file)));
     }
 
-    // Merge nodes - if same name exists, host_id already matches (same hostname -> same host_id)
-    for (const auto& [name, source_node] : source.nodes) {
-        if (target.nodes.contains(name)) {
-            // Same hostname -> same host; host_id was collapsed in merge() so they match
-            if (target.nodes[name].host_id != source_node.host_id) {
-                throw std::runtime_error(fmt::format(
-                    "Node '{}' has conflicting host_id: {} vs {} from {} (same hostname must map to same host)",
-                    name,
-                    target.nodes[name].host_id.get(),
-                    source_node.host_id.get(),
-                    get_source_description(new_source_file)));
+    // Walk source in template order to preserve mixed node/subgraph sequences in children_order.
+    for (const auto& [name, is_node] : source.children_order) {
+        if (is_node) {
+            auto it = source.nodes.find(name);
+            if (it == source.nodes.end()) {
+                continue;
             }
-            // Validate inter_board_connections match or are torus-compatible
-            // For torus-compatible nodes, we merge the connections
-            // For non-torus nodes, we only merge internal_connections, not inter_board_connections
+            const Node& source_node = it->second;
 
-            // Check if this is a torus-compatible merge scenario
-            auto target_template_key = find_template_key_for_node(target.nodes[name], node_templates);
-            auto source_template_key = find_template_key_for_node(source_node, node_templates);
-
-            bool is_torus_merge =
-                (target_template_key && source_template_key &&
-                 are_torus_compatible_for_merge(*target_template_key, *source_template_key));
-
-            if (is_torus_merge) {
-                // Torus-compatible merge: combine inter_board_connections
-                if (existing_source_file.empty() && new_source_file.empty()) {
-                    throw std::runtime_error("At least one source file name must be provided for merge error messages");
+            if (target.nodes.contains(name)) {
+                // Same hostname -> same host; host_id was collapsed in merge() so they match
+                if (target.nodes[name].host_id != source_node.host_id) {
+                    throw std::runtime_error(fmt::format(
+                        "Node '{}' has conflicting host_id: {} vs {} from {} (same hostname must map to same host)",
+                        name,
+                        target.nodes[name].host_id.get(),
+                        source_node.host_id.get(),
+                        get_source_description(new_source_file)));
                 }
+                // Validate inter_board_connections match or are torus-compatible
+                // For torus-compatible nodes, we merge the connections
+                // For non-torus nodes, we only merge internal_connections, not inter_board_connections
+
+                // Check if this is a torus-compatible merge scenario
+                auto target_template_key = find_template_key_for_node(target.nodes[name], node_templates);
+                auto source_template_key = find_template_key_for_node(source_node, node_templates);
+
+                bool is_torus_merge =
+                    (target_template_key && source_template_key &&
+                     are_torus_compatible_for_merge(*target_template_key, *source_template_key));
+
+                if (is_torus_merge) {
+                    // Torus-compatible merge: combine inter_board_connections
+                    if (existing_source_file.empty() && new_source_file.empty()) {
+                        throw std::runtime_error(
+                            "At least one source file name must be provided for merge error messages");
+                    }
+                    log_info(
+                        tt::LogDistributed,
+                        "Merging torus-compatible node '{}' inter_board_connections from {} and {}",
+                        name,
+                        get_source_description(existing_source_file),
+                        get_source_description(new_source_file));
+
+                    // Merge connections from both nodes using helper function
+                    merge_inter_board_connections(target.nodes[name], source_node);
+                } else {
+                    // Non-torus: validate inter_board_connections match exactly
+                    // Build normalized sets for comparison (build once per node, not per port type)
+                    std::map<PortType, std::set<Node::BoardConnection>> target_sets, source_sets;
+
+                    // Pre-build all sets for both target and source
+                    for (const auto& [port_type, connections] : target.nodes[name].inter_board_connections) {
+                        target_sets[port_type] = build_normalized_board_connection_set(connections);
+                    }
+                    for (const auto& [port_type, connections] : source_node.inter_board_connections) {
+                        source_sets[port_type] = build_normalized_board_connection_set(connections);
+                    }
+
+                    // Now compare the sets
+                    for (const auto& [port_type, target_set] : target_sets) {
+                        if (!source_sets.contains(port_type)) {
+                            throw std::runtime_error(fmt::format(
+                                "Node '{}' has port type {} in {} but not in {} - inconsistent "
+                                "inter_board_connections usage",
+                                name,
+                                enchantum::to_string(port_type),
+                                get_source_description(existing_source_file),
+                                get_source_description(new_source_file)));
+                        }
+
+                        if (target_set != source_sets[port_type]) {
+                            throw std::runtime_error(fmt::format(
+                                "Node '{}' has conflicting inter_board_connections: {} and {} have different "
+                                "inter-board connections (we only merge inter-node connections, not "
+                                "inter_board_connections)",
+                                name,
+                                get_source_description(existing_source_file),
+                                get_source_description(new_source_file)));
+                        }
+                    }
+                    // Also check for port types in source that don't exist in target
+                    for (const auto& [port_type, connections] : source_node.inter_board_connections) {
+                        if (!target.nodes[name].inter_board_connections.contains(port_type)) {
+                            throw std::runtime_error(fmt::format(
+                                "Node '{}' has inter_board_connections for port type {} in {} but not in {}",
+                                name,
+                                enchantum::to_string(port_type),
+                                get_source_description(new_source_file),
+                                get_source_description(existing_source_file)));
+                        }
+                    }
+                }
+            } else {
+                // Node exists in source but not in target - add it to target
                 log_info(
                     tt::LogDistributed,
-                    "Merging torus-compatible node '{}' inter_board_connections from {} and {}",
+                    "Adding node '{}' from {} to merged topology",
                     name,
-                    get_source_description(existing_source_file),
                     get_source_description(new_source_file));
-
-                // Merge connections from both nodes using helper function
-                merge_inter_board_connections(target.nodes[name], source_node);
-            } else {
-                // Non-torus: validate inter_board_connections match exactly
-                // Build normalized sets for comparison (build once per node, not per port type)
-                std::map<PortType, std::set<Node::BoardConnection>> target_sets, source_sets;
-
-                // Pre-build all sets for both target and source
-                for (const auto& [port_type, connections] : target.nodes[name].inter_board_connections) {
-                    target_sets[port_type] = build_normalized_board_connection_set(connections);
-                }
-                for (const auto& [port_type, connections] : source_node.inter_board_connections) {
-                    source_sets[port_type] = build_normalized_board_connection_set(connections);
-                }
-
-                // Now compare the sets
-                for (const auto& [port_type, target_set] : target_sets) {
-                    if (!source_sets.contains(port_type)) {
-                        throw std::runtime_error(fmt::format(
-                            "Node '{}' has port type {} in {} but not in {} - inconsistent inter_board_connections "
-                            "usage",
-                            name,
-                            enchantum::to_string(port_type),
-                            get_source_description(existing_source_file),
-                            get_source_description(new_source_file)));
-                    }
-
-                    if (target_set != source_sets[port_type]) {
-                        throw std::runtime_error(fmt::format(
-                            "Node '{}' has conflicting inter_board_connections: {} and {} have different "
-                            "inter-board connections (we only merge inter-node connections, not "
-                            "inter_board_connections)",
-                            name,
-                            get_source_description(existing_source_file),
-                            get_source_description(new_source_file)));
-                    }
-                }
-                // Also check for port types in source that don't exist in target
-                for (const auto& [port_type, connections] : source_node.inter_board_connections) {
-                    if (!target.nodes[name].inter_board_connections.contains(port_type)) {
-                        throw std::runtime_error(fmt::format(
-                            "Node '{}' has inter_board_connections for port type {} in {} but not in {}",
-                            name,
-                            enchantum::to_string(port_type),
-                            get_source_description(new_source_file),
-                            get_source_description(existing_source_file)));
-                    }
-                }
+                target.nodes[name] = source_node;
+                target.children_order.emplace_back(name, true);
             }
         } else {
-            // Node exists in source but not in target - add it to target
-            log_info(
-                tt::LogDistributed,
-                "Adding node '{}' from {} to merged topology",
-                name,
-                get_source_description(new_source_file));
-            target.nodes[name] = source_node;
-        }
-    }
+            auto it = source.subgraphs.find(name);
+            if (it == source.subgraphs.end()) {
+                continue;
+            }
+            const ResolvedGraphInstance& source_subgraph = *it->second;
 
-    // Merge subgraphs recursively
-    for (const auto& [name, source_subgraph] : source.subgraphs) {
-        if (target.subgraphs.contains(name)) {
-            merge_resolved_graph_instances(
-                *target.subgraphs[name], *source_subgraph, existing_source_file, new_source_file, node_templates);
-        } else {
-            // Subgraph exists in source but not in target - add it to target
-            log_info(
-                tt::LogDistributed,
-                "Adding subgraph '{}' from {} to merged topology",
-                name,
-                get_source_description(new_source_file));
-            target.subgraphs[name] = clone_resolved_graph(*source_subgraph);
+            if (target.subgraphs.contains(name)) {
+                merge_resolved_graph_instances(
+                    *target.subgraphs[name], source_subgraph, existing_source_file, new_source_file, node_templates);
+            } else {
+                // Subgraph exists in source but not in target - add it to target
+                log_info(
+                    tt::LogDistributed,
+                    "Adding subgraph '{}' from {} to merged topology",
+                    name,
+                    get_source_description(new_source_file));
+                target.subgraphs[name] = clone_resolved_graph(source_subgraph);
+                target.children_order.emplace_back(name, false);
+            }
         }
     }
 
@@ -1099,18 +1122,48 @@ void CablingGenerator::merge(
     }
     validate_and_merge_node_templates(node_templates_, other.node_templates_, existing_sources, new_file_path);
 
-    // Assign temp host_ids to avoid conflicts during merge
-    HostId next_id = HostId(host_id_to_node_.size());
-    auto assign_temp_ids = [&](auto& self, ResolvedGraphInstance& graph) -> void {
-        for (auto& [name, node] : graph.nodes) {
-            node.host_id = next_id;
-            next_id = HostId(*next_id + 1);
-        }
-        for (auto& [name, subgraph] : graph.subgraphs) {
-            self(self, *subgraph);
-        }
-    };
-    assign_temp_ids(assign_temp_ids, *other.root_instance_);
+    // Assign temp host_ids to nodes in other, then remap their internal_connections to match.
+    std::unordered_map<HostId, HostId> temp_remap;
+    {
+        HostId next_id = HostId(host_id_to_node_.size());
+        auto collect_temp_ids = [&](auto& self, ResolvedGraphInstance& graph) -> void {
+            for (auto& [name, node] : graph.nodes) {
+                temp_remap[node.host_id] = next_id;
+                node.host_id = next_id;
+                next_id = HostId(*next_id + 1);
+            }
+            for (auto& [name, subgraph] : graph.subgraphs) {
+                self(self, *subgraph);
+            }
+        };
+        collect_temp_ids(collect_temp_ids, *other.root_instance_);
+    }
+    if (!temp_remap.empty()) {
+        auto remap_other_connections = [&](auto& self, ResolvedGraphInstance& graph) -> void {
+            for (auto& [port_type, connections] : graph.internal_connections) {
+                for (auto& conn : connections) {
+                    auto& [host_a, tray_a, port_a] = conn.first;
+                    auto& [host_b, tray_b, port_b] = conn.second;
+                    if (temp_remap.contains(host_a)) host_a = temp_remap[host_a];
+                    if (temp_remap.contains(host_b)) host_b = temp_remap[host_b];
+                }
+            }
+            // Rebuild derived lookups after remapping.
+            graph.endpoint_to_dest.clear();
+            graph.connection_pairs.clear();
+            for (const auto& [port_type, conns] : graph.internal_connections) {
+                for (const auto& conn : conns) {
+                    graph.endpoint_to_dest[conn.first] = conn.second;
+                    graph.endpoint_to_dest[conn.second] = conn.first;
+                    graph.connection_pairs.insert(normalize_graph_connection(conn));
+                }
+            }
+            for (auto& [name, subgraph] : graph.subgraphs) {
+                self(self, *subgraph);
+            }
+        };
+        remap_other_connections(remap_other_connections, *other.root_instance_);
+    }
 
     merge_resolved_graph_instances(
         *root_instance_, *other.root_instance_, existing_sources, new_file_path, node_templates_);
@@ -1125,20 +1178,7 @@ void CablingGenerator::merge(
 
     recreate_nodes_from_templates(*root_instance_);
     reassign_host_ids_dfs();
-
-    deployment_hosts_.clear();
-    auto collect_hosts = [&](auto& self, const ResolvedGraphInstance& graph) -> void {
-        for (const auto& [name, is_node] : graph.children_order) {
-            if (is_node && all_hosts.contains(name)) {
-                deployment_hosts_.push_back(all_hosts[name]);
-            } else if (!is_node) {
-                if (auto it = graph.subgraphs.find(name); it != graph.subgraphs.end()) {
-                    self(self, *it->second);
-                }
-            }
-        }
-    };
-    collect_hosts(collect_hosts, *root_instance_);
+    rebuild_deployment_hosts_in_dfs_order(all_hosts);
 
     generate_logical_chip_connections();
 }
@@ -1867,7 +1907,7 @@ void CablingGenerator::reassign_host_ids_dfs() {
     };
     assign_ids(assign_ids, *root_instance_);
 
-    // Remap host_ids in connections
+    // Remap host_ids in connections; recurse in children_order to match assign_ids traversal.
     auto remap_connections = [&](auto& self, ResolvedGraphInstance& graph) -> void {
         for (auto& [port_type, connections] : graph.internal_connections) {
             for (auto& conn : connections) {
@@ -1888,13 +1928,40 @@ void CablingGenerator::reassign_host_ids_dfs() {
             }
         }
 
-        for (auto& [name, subgraph] : graph.subgraphs) {
-            self(self, *subgraph);
+        for (const auto& [name, is_node] : graph.children_order) {
+            if (!is_node) {
+                if (auto it = graph.subgraphs.find(name); it != graph.subgraphs.end()) {
+                    self(self, *it->second);
+                }
+            }
         }
     };
     remap_connections(remap_connections, *root_instance_);
 
     populate_host_id_to_node();
+}
+
+void CablingGenerator::rebuild_deployment_hosts_in_dfs_order(
+    const std::unordered_map<std::string, Host>& all_hosts) {
+    if (!root_instance_) {
+        return;
+    }
+    deployment_hosts_.clear();
+    auto collect = [&](auto& self, const ResolvedGraphInstance& graph) -> void {
+        for (const auto& [name, is_node] : graph.children_order) {
+            if (is_node) {
+                auto it = all_hosts.find(name);
+                if (it != all_hosts.end()) {
+                    deployment_hosts_.push_back(it->second);
+                }
+            } else {
+                if (auto it = graph.subgraphs.find(name); it != graph.subgraphs.end()) {
+                    self(self, *it->second);
+                }
+            }
+        }
+    };
+    collect(collect, *root_instance_);
 }
 
 void CablingGenerator::get_all_connections_of_type(

--- a/tools/scaleout/cabling_generator/cabling_generator.hpp
+++ b/tools/scaleout/cabling_generator/cabling_generator.hpp
@@ -114,6 +114,8 @@ struct ResolvedGraphInstance {
     std::string template_name;  // Graph template name (e.g., "n300_t3k_superpod")
     std::string instance_name;  // Instance name (e.g., "superpod1", "pod2")
 
+    std::vector<std::pair<std::string, bool>> children_order;  // (name, is_node) in template order
+
     // Direct child nodes at this level (not nested)
     std::map<std::string, Node> nodes;
 
@@ -222,6 +224,8 @@ private:
 
     // Recreate all nodes from templates to reset port availability for graph-level connections
     void recreate_nodes_from_templates(ResolvedGraphInstance& graph);
+
+    void reassign_host_ids_dfs();
 
     void get_all_connections_of_type(
         const std::vector<PortType>& port_types, std::vector<PortConnection>& conn_list) const;

--- a/tools/scaleout/cabling_generator/cabling_generator.hpp
+++ b/tools/scaleout/cabling_generator/cabling_generator.hpp
@@ -227,6 +227,10 @@ private:
 
     void reassign_host_ids_dfs();
 
+    // Rebuild deployment_hosts_ in DFS (template children) order.
+    // all_hosts maps every hostname that could appear in the graph to its Host metadata.
+    void rebuild_deployment_hosts_in_dfs_order(const std::unordered_map<std::string, Host>& all_hosts);
+
     void get_all_connections_of_type(
         const std::vector<PortType>& port_types, std::vector<PortConnection>& conn_list) const;
 

--- a/tools/tests/scaleout/CMakeLists.txt
+++ b/tools/tests/scaleout/CMakeLists.txt
@@ -124,3 +124,27 @@ target_link_libraries(
 add_dependencies(test_cabling_descriptor_mgd_generation scaleout_generated_protos)
 add_dependencies(test_cabling_descriptor_mgd_generation fabric_generated_protos)
 add_dependencies(test_cabling_descriptor_mgd_generation tt_metal)
+
+# Test for host_id assignment in DFS order (matching Python tt-CableGen behavior)
+add_executable(test_host_id_assignment test_host_id_assignment.cpp)
+
+set_target_properties(
+    test_host_id_assignment
+    PROPERTIES
+        RUNTIME_OUTPUT_DIRECTORY
+            ${PROJECT_BINARY_DIR}/test/tools/scaleout
+)
+
+target_include_directories(test_host_id_assignment SYSTEM PRIVATE ${CMAKE_BINARY_DIR}/tools/scaleout)
+
+target_link_libraries(
+    test_host_id_assignment
+    PRIVATE
+        TT::ScaleoutTools
+        gmock_main
+        enchantum::enchantum
+        protobuf::libprotobuf
+)
+
+# Make sure protobuf files are generated before compiling host_id assignment tests
+add_dependencies(test_host_id_assignment scaleout_generated_protos)

--- a/tools/tests/scaleout/CMakeLists.txt
+++ b/tools/tests/scaleout/CMakeLists.txt
@@ -148,4 +148,3 @@ target_link_libraries(
 
 # Make sure protobuf files are generated before compiling host_id assignment tests
 add_dependencies(test_host_id_assignment scaleout_generated_protos)
-

--- a/tools/tests/scaleout/CMakeLists.txt
+++ b/tools/tests/scaleout/CMakeLists.txt
@@ -148,3 +148,4 @@ target_link_libraries(
 
 # Make sure protobuf files are generated before compiling host_id assignment tests
 add_dependencies(test_host_id_assignment scaleout_generated_protos)
+

--- a/tools/tests/scaleout/CMakeLists.txt
+++ b/tools/tests/scaleout/CMakeLists.txt
@@ -135,7 +135,7 @@ set_target_properties(
             ${PROJECT_BINARY_DIR}/test/tools/scaleout
 )
 
-target_include_directories(test_host_id_assignment SYSTEM PRIVATE ${CMAKE_BINARY_DIR}/tools/scaleout)
+target_include_directories(test_host_id_assignment SYSTEM PRIVATE ${Metalium_BINARY_DIR}/tools/scaleout)
 
 target_link_libraries(
     test_host_id_assignment

--- a/tools/tests/scaleout/test_host_id_assignment.cpp
+++ b/tools/tests/scaleout/test_host_id_assignment.cpp
@@ -1,0 +1,273 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <gtest/gtest.h>
+#include <filesystem>
+#include <fstream>
+#include <google/protobuf/text_format.h>
+
+#include <cabling_generator/cabling_generator.hpp>
+#include "protobuf/cluster_config.pb.h"
+#include "protobuf/factory_system_descriptor.pb.h"
+
+namespace tt::scaleout_tools {
+
+class HostIdAssignmentTest : public ::testing::Test {
+protected:
+    static std::string create_test_dir(const std::string& name) {
+        std::string dir = "generated/tests/host_id_" + name + "/";
+        if (std::filesystem::exists(dir)) {
+            std::filesystem::remove_all(dir);
+        }
+        std::filesystem::create_directories(dir);
+        return dir;
+    }
+
+    static std::vector<std::string> hostnames(int count) {
+        std::vector<std::string> result;
+        for (int i = 0; i < count; ++i) {
+            result.push_back("host" + std::to_string(i));
+        }
+        return result;
+    }
+
+    static void write_textproto(const std::string& path, const std::string& content) {
+        std::ofstream(path) << content;
+    }
+
+    static void create_descriptor(
+        const std::string& path,
+        const std::string& tmpl,
+        const std::vector<std::string>& children,
+        const std::vector<uint32_t>& ids) {
+        std::string s = "graph_templates {\n  key: \"" + tmpl + "\"\n  value {\n";
+        for (const auto& c : children) {
+            s += "    children { name: \"" + c + "\" node_ref { node_descriptor: \"WH_GALAXY\" } }\n";
+        }
+        s += "  }\n}\nroot_instance {\n  template_name: \"" + tmpl + "\"\n";
+        for (size_t i = 0; i < children.size(); ++i) {
+            s += "  child_mappings { key: \"" + children[i] + "\" value { host_id: " + std::to_string(ids[i]) + " } }\n";
+        }
+        s += "}\n";
+        write_textproto(path, s);
+    }
+
+    static void create_nested_descriptor(
+        const std::string& path,
+        const std::vector<std::string>& root_children,
+        const std::vector<bool>& is_subgraph,
+        const std::vector<std::string>& sub_children,
+        const std::vector<uint32_t>& ids) {
+        std::string s;
+        s += "graph_templates { key: \"sub\" value {\n";
+        for (const auto& c : sub_children) {
+            s += "  children { name: \"" + c + "\" node_ref { node_descriptor: \"WH_GALAXY\" } }\n";
+        }
+        s += "}}\n";
+        s += "graph_templates { key: \"root\" value {\n";
+        for (size_t i = 0; i < root_children.size(); ++i) {
+            if (is_subgraph[i]) {
+                s += "  children { name: \"" + root_children[i] + "\" graph_ref { graph_template: \"sub\" } }\n";
+            } else {
+                s += "  children { name: \"" + root_children[i] + "\" node_ref { node_descriptor: \"WH_GALAXY\" } }\n";
+            }
+        }
+        s += "}}\n";
+        s += "root_instance { template_name: \"root\"\n";
+        size_t idx = 0;
+        for (size_t i = 0; i < root_children.size(); ++i) {
+            if (is_subgraph[i]) {
+                s += "  child_mappings { key: \"" + root_children[i] + "\" value { sub_instance {\n";
+                s += "    template_name: \"sub\"\n";
+                for (const auto& c : sub_children) {
+                    s += "    child_mappings { key: \"" + c + "\" value { host_id: " + std::to_string(ids[idx++]) + " } }\n";
+                }
+                s += "  }}}\n";
+            } else {
+                s += "  child_mappings { key: \"" + root_children[i] + "\" value { host_id: " + std::to_string(ids[idx++]) + " } }\n";
+            }
+        }
+        s += "}\n";
+        write_textproto(path, s);
+    }
+};
+
+TEST_F(HostIdAssignmentTest, FollowsTemplateOrder) {
+    auto dir = create_test_dir("template_order");
+    create_descriptor(dir + "test.textproto", "cluster", {"node_a", "node_b", "node_c"}, {5, 3, 7});
+    CablingGenerator gen(dir + "test.textproto", hostnames(3));
+
+    const auto& hosts = gen.get_deployment_hosts();
+    ASSERT_EQ(hosts.size(), 3);
+    EXPECT_EQ(hosts[0].hostname, "host0");
+    EXPECT_EQ(hosts[1].hostname, "host1");
+    EXPECT_EQ(hosts[2].hostname, "host2");
+}
+
+TEST_F(HostIdAssignmentTest, TemplateOrderNotAlphabetical) {
+    // Template: zebra, yak, apple (not alphabetical)
+    auto dir = create_test_dir("not_alphabetical");
+    create_descriptor(dir + "test.textproto", "cluster", {"zebra", "yak", "apple"}, {0, 1, 2});
+    CablingGenerator gen(dir + "test.textproto", hostnames(3));
+
+    const auto& hosts = gen.get_deployment_hosts();
+    ASSERT_EQ(hosts.size(), 3);
+}
+
+TEST_F(HostIdAssignmentTest, NestedGraphDFS) {
+    // Structure: node1 -> subgraph(sub1, sub2) -> node2
+    // DFS order: node1=0, sub1=1, sub2=2, node2=3
+    auto dir = create_test_dir("nested");
+    create_nested_descriptor(
+        dir + "test.textproto",
+        {"node1", "subgraph1", "node2"},
+        {false, true, false},
+        {"sub1", "sub2"},
+        {10, 20, 30, 40}  // arbitrary, will be reassigned
+    );
+    CablingGenerator gen(dir + "test.textproto", hostnames(4));
+
+    const auto& hosts = gen.get_deployment_hosts();
+    ASSERT_EQ(hosts.size(), 4);
+}
+
+TEST_F(HostIdAssignmentTest, SubgraphFirst) {
+    // subgraph comes before node
+    auto dir = create_test_dir("subgraph_first");
+    create_nested_descriptor(
+        dir + "test.textproto",
+        {"subgraph1", "node1"},
+        {true, false},
+        {"sub1", "sub2"},
+        {5, 6, 7}
+    );
+    CablingGenerator gen(dir + "test.textproto", hostnames(3));
+    EXPECT_EQ(gen.get_deployment_hosts().size(), 3);
+}
+
+TEST_F(HostIdAssignmentTest, MergeProducesConsistentOrder) {
+    auto dir = create_test_dir("merge");
+    create_descriptor(dir + "a.textproto", "cluster", {"n1", "n2", "n3"}, {0, 1, 2});
+    create_descriptor(dir + "b.textproto", "cluster", {"n1", "n2", "n3"}, {0, 1, 2});
+    CablingGenerator gen(dir, hostnames(3));
+
+    const auto& hosts = gen.get_deployment_hosts();
+    ASSERT_EQ(hosts.size(), 3);
+}
+
+TEST_F(HostIdAssignmentTest, ReloadIdentical) {
+    auto dir = create_test_dir("reload");
+    create_descriptor(dir + "test.textproto", "cluster", {"x", "m", "a"}, {0, 1, 2});
+
+    CablingGenerator gen1(dir + "test.textproto", hostnames(3));
+    CablingGenerator gen2(dir + "test.textproto", hostnames(3));
+    EXPECT_EQ(gen1, gen2);
+}
+
+TEST_F(HostIdAssignmentTest, FileOrderDoesNotMatter) {
+    auto dir1 = create_test_dir("order1");
+    auto dir2 = create_test_dir("order2");
+
+    std::string content = R"(
+graph_templates { key: "t" value {
+  children { name: "n1" node_ref { node_descriptor: "WH_GALAXY" } }
+  children { name: "n2" node_ref { node_descriptor: "WH_GALAXY" } }
+}}
+root_instance { template_name: "t"
+  child_mappings { key: "n1" value { host_id: 0 } }
+  child_mappings { key: "n2" value { host_id: 1 } }
+}
+)";
+    write_textproto(dir1 + "a.textproto", content);
+    write_textproto(dir1 + "z.textproto", content);
+    write_textproto(dir2 + "z.textproto", content);
+    write_textproto(dir2 + "a.textproto", content);
+
+    CablingGenerator gen1(dir1, hostnames(2));
+    CablingGenerator gen2(dir2, hostnames(2));
+    EXPECT_EQ(gen1, gen2);
+}
+
+TEST_F(HostIdAssignmentTest, ExportedHostIdsAreSequential) {
+    auto dir = create_test_dir("export");
+    write_textproto(dir + "input.textproto", R"(
+graph_templates { key: "t" value {
+  children { name: "first" node_ref { node_descriptor: "WH_GALAXY" } }
+  children { name: "second" node_ref { node_descriptor: "WH_GALAXY" } }
+  children { name: "third" node_ref { node_descriptor: "WH_GALAXY" } }
+}}
+root_instance { template_name: "t"
+  child_mappings { key: "first" value { host_id: 100 } }
+  child_mappings { key: "second" value { host_id: 50 } }
+  child_mappings { key: "third" value { host_id: 200 } }
+}
+)");
+
+    CablingGenerator gen(dir + "input.textproto", hostnames(3));
+    gen.emit_cabling_descriptor(dir + "output.textproto");
+
+    std::ifstream f(dir + "output.textproto");
+    std::string content((std::istreambuf_iterator<char>(f)), std::istreambuf_iterator<char>());
+
+    cabling_generator::proto::ClusterDescriptor desc;
+    ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(content, &desc));
+
+    const auto& mappings = desc.root_instance().child_mappings();
+    EXPECT_EQ(mappings.at("first").host_id(), 0);
+    EXPECT_EQ(mappings.at("second").host_id(), 1);
+    EXPECT_EQ(mappings.at("third").host_id(), 2);
+}
+
+TEST_F(HostIdAssignmentTest, TemplateOrderTakesPrecedence) {
+    auto dir = create_test_dir("precedence");
+    write_textproto(dir + "input.textproto", R"(
+graph_templates { key: "t" value {
+  children { name: "charlie" node_ref { node_descriptor: "WH_GALAXY" } }
+  children { name: "alpha" node_ref { node_descriptor: "WH_GALAXY" } }
+  children { name: "bravo" node_ref { node_descriptor: "WH_GALAXY" } }
+}}
+root_instance { template_name: "t"
+  child_mappings { key: "charlie" value { host_id: 99 } }
+  child_mappings { key: "alpha" value { host_id: 98 } }
+  child_mappings { key: "bravo" value { host_id: 97 } }
+}
+)");
+
+    CablingGenerator gen(dir + "input.textproto", hostnames(3));
+    gen.emit_cabling_descriptor(dir + "output.textproto");
+
+    std::ifstream f(dir + "output.textproto");
+    std::string content((std::istreambuf_iterator<char>(f)), std::istreambuf_iterator<char>());
+
+    cabling_generator::proto::ClusterDescriptor desc;
+    ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(content, &desc));
+
+    const auto& mappings = desc.root_instance().child_mappings();
+    // Template order: charlie, alpha, bravo -> host_ids: 0, 1, 2
+    EXPECT_EQ(mappings.at("charlie").host_id(), 0);
+    EXPECT_EQ(mappings.at("alpha").host_id(), 1);
+    EXPECT_EQ(mappings.at("bravo").host_id(), 2);
+}
+
+TEST_F(HostIdAssignmentTest, SingleNode) {
+    auto dir = create_test_dir("single");
+    create_descriptor(dir + "test.textproto", "t", {"only"}, {42});
+    CablingGenerator gen(dir + "test.textproto", hostnames(1));
+    EXPECT_EQ(gen.get_deployment_hosts().size(), 1);
+}
+
+TEST_F(HostIdAssignmentTest, ManyNodes) {
+    auto dir = create_test_dir("many");
+    std::vector<std::string> names;
+    std::vector<uint32_t> ids;
+    for (int i = 0; i < 50; ++i) {
+        names.push_back("n" + std::to_string(i));
+        ids.push_back(49 - i);  // reverse order
+    }
+    create_descriptor(dir + "test.textproto", "t", names, ids);
+    CablingGenerator gen(dir + "test.textproto", hostnames(50));
+    EXPECT_EQ(gen.get_deployment_hosts().size(), 50);
+}
+
+}  // namespace tt::scaleout_tools

--- a/tools/tests/scaleout/test_host_id_assignment.cpp
+++ b/tools/tests/scaleout/test_host_id_assignment.cpp
@@ -40,8 +40,9 @@ static void write(const std::string& path, const std::string& content) {
 static void write_deploy(const std::string& path, const std::vector<std::string>& hosts,
                          const std::string& node_type = "WH_GALAXY_Y_TORUS") {
     std::string s;
-    for (const auto& h : hosts)
+    for (const auto& h : hosts) {
         s += "hosts { host: \"" + h + "\" node_type: \"" + node_type + "\" }\n";
+    }
     write(path, s);
 }
 
@@ -52,7 +53,7 @@ static std::string read_file(const std::string& path) {
 
 static void replace_first(std::string& s, const std::string& from, const std::string& to) {
     auto pos = s.find(from);
-    if (pos != std::string::npos) s.replace(pos, from.size(), to);
+    if (pos != std::string::npos) { s.replace(pos, from.size(), to); }
 }
 
 // ---- Single-file tests ----
@@ -229,10 +230,10 @@ root_instance { template_name: "root"
     CablingGenerator gen(cdir, dir + "dep.textproto");
     bool stale = false, n2_n3 = false;
     for (const auto& [ep_a, ep_b] : gen.get_chip_connections()) {
-        if (*ep_a.host_id == *ep_b.host_id) continue;
+        if (*ep_a.host_id == *ep_b.host_id) { continue; }
         auto a = *ep_a.host_id, b = *ep_b.host_id;
-        if (a == 0u || b == 0u) stale = true;
-        if ((a == 1u && b == 2u) || (a == 2u && b == 1u)) n2_n3 = true;
+        if (a == 0u || b == 0u) { stale = true; }
+        if ((a == 1u && b == 2u) || (a == 2u && b == 1u)) { n2_n3 = true; }
     }
     EXPECT_FALSE(stale) << "n1 (id=0) must not appear in inter-node connections";
     EXPECT_TRUE(n2_n3) << "n2 (id=1) and n3 (id=2) must be connected after remap";

--- a/tools/tests/scaleout/test_host_id_assignment.cpp
+++ b/tools/tests/scaleout/test_host_id_assignment.cpp
@@ -3,9 +3,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <gtest/gtest.h>
+#include <algorithm>
 #include <atomic>
 #include <filesystem>
 #include <fstream>
+#include <set>
 #include <google/protobuf/text_format.h>
 
 #include <cabling_generator/cabling_generator.hpp>

--- a/tools/tests/scaleout/test_host_id_assignment.cpp
+++ b/tools/tests/scaleout/test_host_id_assignment.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <gtest/gtest.h>
+#include <atomic>
 #include <filesystem>
 #include <fstream>
 #include <google/protobuf/text_format.h>
@@ -13,261 +14,696 @@
 
 namespace tt::scaleout_tools {
 
+// All tests use the deployment-descriptor constructor so FSD hosts[i].hostname()
+// directly reflects which node received host_id=i after DFS reassignment.
 class HostIdAssignmentTest : public ::testing::Test {
 protected:
-    static std::string create_test_dir(const std::string& name) {
-        std::string dir = "generated/tests/host_id_" + name + "/";
-        if (std::filesystem::exists(dir)) {
-            std::filesystem::remove_all(dir);
-        }
+    std::string create_test_dir(const std::string& name) {
+        static std::atomic<int> seq{0};
+        auto dir = std::filesystem::temp_directory_path() /
+                   ("host_id_" + name + "_test_" + std::to_string(seq++));
+        std::filesystem::remove_all(dir);
         std::filesystem::create_directories(dir);
-        return dir;
+        dirs_.push_back(dir.string());
+        return dir.string() + "/";
     }
 
-    static std::vector<std::string> hostnames(int count) {
-        std::vector<std::string> result;
-        for (int i = 0; i < count; ++i) {
-            result.push_back("host" + std::to_string(i));
+    void TearDown() override {
+        for (const auto& d : dirs_) {
+            std::filesystem::remove_all(d);
         }
-        return result;
+        dirs_.clear();
     }
+
+    std::vector<std::string> dirs_;
+
+    static void write(const std::string& path, const std::string& content) {
+        std::ofstream(path) << content;
+    }
+
+    // Flat cabling descriptor: root template -> direct WH_GALAXY nodes.
+    static void flat(
+        const std::string& path,
+        const std::vector<std::string>& names,
+        const std::vector<uint32_t>& ids) {
+        std::string s = "graph_templates { key: \"root\" value {\n";
+        for (const auto& n : names) {
+            s += "  children { name: \"" + n + "\" node_ref { node_descriptor: \"WH_GALAXY\" } }\n";
+        }
+        s += "}}\nroot_instance { template_name: \"root\"\n";
+        for (size_t i = 0; i < names.size(); ++i) {
+            s += "  child_mappings { key: \"" + names[i] + "\" value { host_id: " +
+                 std::to_string(ids[i]) + " } }\n";
+        }
+        s += "}\n";
+        write(path, s);
+    }
+
+    // Deployment descriptor with one WH_GALAXY entry per hostname.
+    static void deployment(const std::string& path, const std::vector<std::string>& hosts) {
+        std::string s;
+        for (const auto& h : hosts) {
+            s += "hosts { host: \"" + h + "\" node_type: \"WH_GALAXY\" }\n";
+        }
+        write(path, s);
+    }
+
+    // Read back FSD and return hosts vector for easy indexed access.
+    static auto fsd_hosts(const CablingGenerator& gen) {
+        return gen.generate_factory_system_descriptor().hosts();
+    }
+};
+
+// Template order determines host_id assignment, not initial child_mapping values.
+// node_a is first in the template -> must get host_id 0 after DFS reassignment.
+TEST_F(HostIdAssignmentTest, TemplateOrderDeterminesAssignment) {
+    auto dir = create_test_dir("template_order");
+    flat(dir + "c.textproto", {"node_a", "node_b", "node_c"}, {2, 0, 1});  // scrambled
+    deployment(dir + "d.textproto", {"node_a", "node_b", "node_c"});
+
+    CablingGenerator gen(dir + "c.textproto", dir + "d.textproto");
+    const auto hosts = fsd_hosts(gen);
+
+    ASSERT_EQ(hosts.size(), 3);
+    EXPECT_EQ(hosts[0].hostname(), "node_a");
+    EXPECT_EQ(hosts[1].hostname(), "node_b");
+    EXPECT_EQ(hosts[2].hostname(), "node_c");
+}
+
+// Template order must be respected even when names are non-alphabetical.
+// Template: zebra, yak, apple -> host_ids 0, 1, 2 respectively.
+TEST_F(HostIdAssignmentTest, TemplateOrderNotAlphabetical) {
+    auto dir = create_test_dir("not_alphabetical");
+    flat(dir + "c.textproto", {"zebra", "yak", "apple"}, {0, 1, 2});
+    deployment(dir + "d.textproto", {"zebra", "yak", "apple"});
+
+    CablingGenerator gen(dir + "c.textproto", dir + "d.textproto");
+    const auto hosts = fsd_hosts(gen);
+
+    ASSERT_EQ(hosts.size(), 3);
+    EXPECT_EQ(hosts[0].hostname(), "zebra");
+    EXPECT_EQ(hosts[1].hostname(), "yak");
+    EXPECT_EQ(hosts[2].hostname(), "apple");
+}
+
+// DFS enters a subgraph before visiting siblings that come after it in the template.
+// Template: node1, subgraph1(sub1,sub2), node2 -> DFS order: node1, sub1, sub2, node2.
+TEST_F(HostIdAssignmentTest, SubgraphChildrenVisitedBeforeSiblings) {
+    auto dir = create_test_dir("nested_dfs");
+    write(dir + "c.textproto", R"(
+graph_templates { key: "sub" value {
+  children { name: "sub1" node_ref { node_descriptor: "WH_GALAXY" } }
+  children { name: "sub2" node_ref { node_descriptor: "WH_GALAXY" } }
+}}
+graph_templates { key: "root" value {
+  children { name: "node1"     node_ref  { node_descriptor: "WH_GALAXY" } }
+  children { name: "subgraph1" graph_ref { graph_template: "sub" } }
+  children { name: "node2"     node_ref  { node_descriptor: "WH_GALAXY" } }
+}}
+root_instance { template_name: "root"
+  child_mappings { key: "node1" value { host_id: 3 } }
+  child_mappings { key: "subgraph1" value { sub_instance {
+    template_name: "sub"
+    child_mappings { key: "sub1" value { host_id: 0 } }
+    child_mappings { key: "sub2" value { host_id: 2 } }
+  }}}
+  child_mappings { key: "node2" value { host_id: 1 } }
+}
+)");
+    deployment(dir + "d.textproto", {"node1", "sub1", "sub2", "node2"});
+
+    CablingGenerator gen(dir + "c.textproto", dir + "d.textproto");
+    const auto hosts = fsd_hosts(gen);
+
+    ASSERT_EQ(hosts.size(), 4);
+    EXPECT_EQ(hosts[0].hostname(), "node1");
+    EXPECT_EQ(hosts[1].hostname(), "sub1");
+    EXPECT_EQ(hosts[2].hostname(), "sub2");
+    EXPECT_EQ(hosts[3].hostname(), "node2");
+}
+
+// When a subgraph appears first in the template, all its children are
+// assigned lower host_ids than any node listed after it.
+TEST_F(HostIdAssignmentTest, SubgraphFirstInTemplate_GetsLowerIds) {
+    auto dir = create_test_dir("subgraph_first");
+    write(dir + "c.textproto", R"(
+graph_templates { key: "sub" value {
+  children { name: "sub1" node_ref { node_descriptor: "WH_GALAXY" } }
+  children { name: "sub2" node_ref { node_descriptor: "WH_GALAXY" } }
+}}
+graph_templates { key: "root" value {
+  children { name: "subgraph1" graph_ref { graph_template: "sub" } }
+  children { name: "node1"     node_ref  { node_descriptor: "WH_GALAXY" } }
+}}
+root_instance { template_name: "root"
+  child_mappings { key: "subgraph1" value { sub_instance {
+    template_name: "sub"
+    child_mappings { key: "sub1" value { host_id: 2 } }
+    child_mappings { key: "sub2" value { host_id: 0 } }
+  }}}
+  child_mappings { key: "node1" value { host_id: 1 } }
+}
+)");
+    deployment(dir + "d.textproto", {"sub1", "sub2", "node1"});
+
+    CablingGenerator gen(dir + "c.textproto", dir + "d.textproto");
+    const auto hosts = fsd_hosts(gen);
+
+    ASSERT_EQ(hosts.size(), 3);
+    EXPECT_EQ(hosts[0].hostname(), "sub1");
+    EXPECT_EQ(hosts[1].hostname(), "sub2");
+    EXPECT_EQ(hosts[2].hostname(), "node1");
+}
+
+// Template order is [third, first, second] with scrambled initial ids - exported ids must match template position.
+TEST_F(HostIdAssignmentTest, ScrambledInitialIdsReassignedSequentially) {
+    auto dir = create_test_dir("scrambled");
+    write(dir + "c.textproto", R"(
+graph_templates { key: "t" value {
+  children { name: "third"  node_ref { node_descriptor: "WH_GALAXY" } }
+  children { name: "first"  node_ref { node_descriptor: "WH_GALAXY" } }
+  children { name: "second" node_ref { node_descriptor: "WH_GALAXY" } }
+}}
+root_instance { template_name: "t"
+  child_mappings { key: "third"  value { host_id: 1 } }
+  child_mappings { key: "first"  value { host_id: 2 } }
+  child_mappings { key: "second" value { host_id: 0 } }
+}
+)");
+    deployment(dir + "d.textproto", {"third", "first", "second"});
+
+    CablingGenerator gen(dir + "c.textproto", dir + "d.textproto");
+    gen.emit_cabling_descriptor(dir + "out.textproto");
+
+    std::ifstream f(dir + "out.textproto");
+    std::string content((std::istreambuf_iterator<char>(f)), std::istreambuf_iterator<char>());
+    cabling_generator::proto::ClusterDescriptor desc;
+    ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(content, &desc));
+
+    const auto& m = desc.root_instance().child_mappings();
+    EXPECT_EQ(m.at("third").host_id(), 0);
+    EXPECT_EQ(m.at("first").host_id(), 1);
+    EXPECT_EQ(m.at("second").host_id(), 2);
+}
+
+// Template order wins over alphabetical order.
+// Template: charlie, alpha, bravo -> must get host_ids 0, 1, 2 respectively.
+TEST_F(HostIdAssignmentTest, TemplateOrderNotAlphabetical_ExportedIds) {
+    auto dir = create_test_dir("non_alpha_export");
+    write(dir + "c.textproto", R"(
+graph_templates { key: "t" value {
+  children { name: "charlie" node_ref { node_descriptor: "WH_GALAXY" } }
+  children { name: "alpha"   node_ref { node_descriptor: "WH_GALAXY" } }
+  children { name: "bravo"   node_ref { node_descriptor: "WH_GALAXY" } }
+}}
+root_instance { template_name: "t"
+  child_mappings { key: "charlie" value { host_id: 2 } }
+  child_mappings { key: "alpha"   value { host_id: 0 } }
+  child_mappings { key: "bravo"   value { host_id: 1 } }
+}
+)");
+    deployment(dir + "d.textproto", {"charlie", "alpha", "bravo"});
+
+    CablingGenerator gen(dir + "c.textproto", dir + "d.textproto");
+    const auto hosts = fsd_hosts(gen);
+
+    ASSERT_EQ(hosts.size(), 3);
+    EXPECT_EQ(hosts[0].hostname(), "charlie");
+    EXPECT_EQ(hosts[1].hostname(), "alpha");
+    EXPECT_EQ(hosts[2].hostname(), "bravo");
+}
+
+class MergeChildrenOrderTest : public ::testing::Test {
+protected:
+    std::string create_test_dir(const std::string& name) {
+        static std::atomic<int> seq{0};
+        auto dir = std::filesystem::temp_directory_path() /
+                   ("merge_children_order_" + name + "_test_" + std::to_string(seq++));
+        std::filesystem::remove_all(dir);
+        std::filesystem::create_directories(dir);
+        dirs_.push_back(dir.string());
+        return dir.string() + "/";
+    }
+
+    void TearDown() override {
+        for (const auto& d : dirs_) {
+            std::filesystem::remove_all(d);
+        }
+        dirs_.clear();
+    }
+
+    std::vector<std::string> dirs_;
 
     static void write_textproto(const std::string& path, const std::string& content) {
         std::ofstream(path) << content;
     }
 
-    static void create_descriptor(
-        const std::string& path,
-        const std::string& tmpl,
-        const std::vector<std::string>& children,
-        const std::vector<uint32_t>& ids) {
-        std::string s = "graph_templates {\n  key: \"" + tmpl + "\"\n  value {\n";
-        for (const auto& c : children) {
-            s += "    children { name: \"" + c + "\" node_ref { node_descriptor: \"WH_GALAXY\" } }\n";
+    static void write_deployment(const std::string& path, const std::vector<std::string>& host_names) {
+        std::string s;
+        for (const auto& h : host_names) {
+            s += "hosts { host: \"" + h + "\" node_type: \"WH_GALAXY\" }\n";
         }
-        s += "  }\n}\nroot_instance {\n  template_name: \"" + tmpl + "\"\n";
-        for (size_t i = 0; i < children.size(); ++i) {
-            s += "  child_mappings { key: \"" + children[i] + "\" value { host_id: " + std::to_string(ids[i]) + " } }\n";
+        write_textproto(path, s);
+    }
+
+    static void write_flat_descriptor(
+        const std::string& path,
+        const std::string& root_tmpl,
+        const std::vector<std::string>& node_names,
+        const std::vector<uint32_t>& host_ids) {
+        std::string s;
+        s += "graph_templates { key: \"" + root_tmpl + "\" value {\n";
+        for (const auto& n : node_names) {
+            s += "  children { name: \"" + n + "\" node_ref { node_descriptor: \"WH_GALAXY\" } }\n";
+        }
+        s += "}}\n";
+        s += "root_instance { template_name: \"" + root_tmpl + "\"\n";
+        for (size_t i = 0; i < node_names.size(); ++i) {
+            s += "  child_mappings { key: \"" + node_names[i] + "\" value { host_id: " +
+                 std::to_string(host_ids[i]) + " } }\n";
         }
         s += "}\n";
         write_textproto(path, s);
     }
 
-    static void create_nested_descriptor(
+    static void write_subgraph_descriptor(
         const std::string& path,
-        const std::vector<std::string>& root_children,
-        const std::vector<bool>& is_subgraph,
-        const std::vector<std::string>& sub_children,
-        const std::vector<uint32_t>& ids) {
+        const std::string& root_tmpl,
+        const std::string& group_name,
+        const std::string& sub_tmpl,
+        const std::vector<std::string>& node_names,
+        const std::vector<uint32_t>& host_ids) {
         std::string s;
-        s += "graph_templates { key: \"sub\" value {\n";
-        for (const auto& c : sub_children) {
-            s += "  children { name: \"" + c + "\" node_ref { node_descriptor: \"WH_GALAXY\" } }\n";
+        s += "graph_templates { key: \"" + sub_tmpl + "\" value {\n";
+        for (const auto& n : node_names) {
+            s += "  children { name: \"" + n + "\" node_ref { node_descriptor: \"WH_GALAXY\" } }\n";
         }
         s += "}}\n";
-        s += "graph_templates { key: \"root\" value {\n";
-        for (size_t i = 0; i < root_children.size(); ++i) {
-            if (is_subgraph[i]) {
-                s += "  children { name: \"" + root_children[i] + "\" graph_ref { graph_template: \"sub\" } }\n";
-            } else {
-                s += "  children { name: \"" + root_children[i] + "\" node_ref { node_descriptor: \"WH_GALAXY\" } }\n";
-            }
-        }
+        s += "graph_templates { key: \"" + root_tmpl + "\" value {\n";
+        s += "  children { name: \"" + group_name +
+             "\" graph_ref { graph_template: \"" + sub_tmpl + "\" } }\n";
         s += "}}\n";
-        s += "root_instance { template_name: \"root\"\n";
-        size_t idx = 0;
-        for (size_t i = 0; i < root_children.size(); ++i) {
-            if (is_subgraph[i]) {
-                s += "  child_mappings { key: \"" + root_children[i] + "\" value { sub_instance {\n";
-                s += "    template_name: \"sub\"\n";
-                for (const auto& c : sub_children) {
-                    s += "    child_mappings { key: \"" + c + "\" value { host_id: " + std::to_string(ids[idx++]) + " } }\n";
-                }
-                s += "  }}}\n";
-            } else {
-                s += "  child_mappings { key: \"" + root_children[i] + "\" value { host_id: " + std::to_string(ids[idx++]) + " } }\n";
-            }
+        s += "root_instance { template_name: \"" + root_tmpl + "\"\n";
+        s += "  child_mappings { key: \"" + group_name + "\" value { sub_instance {\n";
+        s += "    template_name: \"" + sub_tmpl + "\"\n";
+        for (size_t i = 0; i < node_names.size(); ++i) {
+            s += "    child_mappings { key: \"" + node_names[i] + "\" value { host_id: " +
+                 std::to_string(host_ids[i]) + " } }\n";
         }
-        s += "}\n";
+        s += "  }}}\n}\n";
         write_textproto(path, s);
     }
 };
 
-TEST_F(HostIdAssignmentTest, FollowsTemplateOrder) {
-    auto dir = create_test_dir("template_order");
-    create_descriptor(dir + "test.textproto", "cluster", {"node_a", "node_b", "node_c"}, {5, 3, 7});
-    CablingGenerator gen(dir + "test.textproto", hostnames(3));
+// Two files each contributing a disjoint direct node - both must appear in the merged FSD.
+TEST_F(MergeChildrenOrderTest, NewDirectNodeFromMergeGetsHostId) {
+    auto base = create_test_dir("new_direct_node");
+    std::string cluster_dir = base + "cluster/";
+    std::filesystem::create_directories(cluster_dir);
+    std::string deployment_path = base + "deployment.textproto";
+
+    write_deployment(deployment_path, {"h1", "h2"});
+    write_flat_descriptor(cluster_dir + "a.textproto", "root", {"h1"}, {0});
+    write_flat_descriptor(cluster_dir + "b.textproto", "root", {"h2"}, {1});
+
+    CablingGenerator gen(cluster_dir, deployment_path);
 
     const auto& hosts = gen.get_deployment_hosts();
-    ASSERT_EQ(hosts.size(), 3);
-    EXPECT_EQ(hosts[0].hostname, "host0");
-    EXPECT_EQ(hosts[1].hostname, "host1");
-    EXPECT_EQ(hosts[2].hostname, "host2");
+    ASSERT_EQ(hosts.size(), 2u);
+    EXPECT_EQ(hosts[0].hostname, "h1");
+    EXPECT_EQ(hosts[1].hostname, "h2");
 }
 
-TEST_F(HostIdAssignmentTest, TemplateOrderNotAlphabetical) {
-    // Template: zebra, yak, apple (not alphabetical)
-    auto dir = create_test_dir("not_alphabetical");
-    create_descriptor(dir + "test.textproto", "cluster", {"zebra", "yak", "apple"}, {0, 1, 2});
-    CablingGenerator gen(dir + "test.textproto", hostnames(3));
+// Two files each contributing a disjoint subgraph - all nodes must appear in the merged FSD.
+TEST_F(MergeChildrenOrderTest, NewSubgraphFromMergeGetsHostIds) {
+    auto base = create_test_dir("new_subgraph");
+    std::string cluster_dir = base + "cluster/";
+    std::filesystem::create_directories(cluster_dir);
+    std::string deployment_path = base + "deployment.textproto";
+
+    write_deployment(deployment_path, {"h1", "h2", "h3", "h4"});
+    write_subgraph_descriptor(cluster_dir + "a.textproto", "root", "group_a", "sub", {"h1", "h2"}, {0, 1});
+    write_subgraph_descriptor(cluster_dir + "b.textproto", "root", "group_b", "sub", {"h3", "h4"}, {2, 3});
+
+    CablingGenerator gen(cluster_dir, deployment_path);
 
     const auto& hosts = gen.get_deployment_hosts();
-    ASSERT_EQ(hosts.size(), 3);
+    ASSERT_EQ(hosts.size(), 4u);
+    EXPECT_EQ(hosts[0].hostname, "h1");
+    EXPECT_EQ(hosts[1].hostname, "h2");
+    EXPECT_EQ(hosts[2].hostname, "h3");
+    EXPECT_EQ(hosts[3].hostname, "h4");
 }
 
-TEST_F(HostIdAssignmentTest, NestedGraphDFS) {
-    // Structure: node1 -> subgraph(sub1, sub2) -> node2
-    // DFS order: node1=0, sub1=1, sub2=2, node2=3
-    auto dir = create_test_dir("nested");
-    create_nested_descriptor(
-        dir + "test.textproto",
-        {"node1", "subgraph1", "node2"},
-        {false, true, false},
-        {"sub1", "sub2"},
-        {10, 20, 30, 40}  // arbitrary, will be reassigned
-    );
-    CablingGenerator gen(dir + "test.textproto", hostnames(4));
+// Per-file host_ids are irrelevant - the FSD must reflect DFS order after merge.
+TEST_F(MergeChildrenOrderTest, MergedSubgraphHostIdsAreSequentialAfterExport) {
+    auto base = create_test_dir("subgraph_sequential_export");
+    std::string cluster_dir = base + "cluster/";
+    std::filesystem::create_directories(cluster_dir);
+    std::string deployment_path = base + "deployment.textproto";
 
-    const auto& hosts = gen.get_deployment_hosts();
-    ASSERT_EQ(hosts.size(), 4);
+    write_deployment(deployment_path, {"h1", "h2", "h3", "h4"});
+    write_subgraph_descriptor(cluster_dir + "a.textproto", "root", "group_a", "sub", {"h1", "h2"}, {2, 3});
+    write_subgraph_descriptor(cluster_dir + "b.textproto", "root", "group_b", "sub", {"h3", "h4"}, {0, 1});
+
+    CablingGenerator gen(cluster_dir, deployment_path);
+    const auto fsd = gen.generate_factory_system_descriptor();
+
+    ASSERT_EQ(fsd.hosts().size(), 4);
+    EXPECT_EQ(fsd.hosts()[0].hostname(), "h1");
+    EXPECT_EQ(fsd.hosts()[1].hostname(), "h2");
+    EXPECT_EQ(fsd.hosts()[2].hostname(), "h3");
+    EXPECT_EQ(fsd.hosts()[3].hostname(), "h4");
 }
 
-TEST_F(HostIdAssignmentTest, SubgraphFirst) {
-    // subgraph comes before node
-    auto dir = create_test_dir("subgraph_first");
-    create_nested_descriptor(
-        dir + "test.textproto",
-        {"subgraph1", "node1"},
-        {true, false},
-        {"sub1", "sub2"},
-        {5, 6, 7}
-    );
-    CablingGenerator gen(dir + "test.textproto", hostnames(3));
-    EXPECT_EQ(gen.get_deployment_hosts().size(), 3);
+// Template order in file B is [rack_b(subgraph), n2(node)] - subgraph first.
+// DFS must visit rack_b's children before n2, so the merged order is n1, n3, n4, n2.
+TEST_F(MergeChildrenOrderTest, MergePreservesTemplateOrderForMixedNewChildren) {
+    auto base = create_test_dir("template_order_mixed");
+    std::string cluster_dir = base + "cluster/";
+    std::filesystem::create_directories(cluster_dir);
+    std::string deployment_path = base + "deployment.textproto";
+
+    write_deployment(deployment_path, {"n1", "n3", "n4", "n2"});
+    write_flat_descriptor(cluster_dir + "a.textproto", "root", {"n1"}, {0});
+    write_textproto(
+        cluster_dir + "b.textproto",
+        R"(graph_templates { key: "sub" value {
+  children { name: "n3" node_ref { node_descriptor: "WH_GALAXY" } }
+  children { name: "n4" node_ref { node_descriptor: "WH_GALAXY" } }
+}}
+graph_templates { key: "root" value {
+  children { name: "rack_b" graph_ref { graph_template: "sub" } }
+  children { name: "n2" node_ref { node_descriptor: "WH_GALAXY" } }
+}}
+root_instance { template_name: "root"
+  child_mappings { key: "rack_b" value { sub_instance {
+    template_name: "sub"
+    child_mappings { key: "n3" value { host_id: 1 } }
+    child_mappings { key: "n4" value { host_id: 2 } }
+  }}}
+  child_mappings { key: "n2" value { host_id: 3 } }
+}
+)");
+
+    CablingGenerator gen(cluster_dir, deployment_path);
+    const auto fsd = gen.generate_factory_system_descriptor();
+
+    ASSERT_EQ(fsd.hosts().size(), 4);
+    EXPECT_EQ(fsd.hosts()[0].hostname(), "n1");
+    EXPECT_EQ(fsd.hosts()[1].hostname(), "n3");
+    EXPECT_EQ(fsd.hosts()[2].hostname(), "n4");
+    EXPECT_EQ(fsd.hosts()[3].hostname(), "n2");
 }
 
-TEST_F(HostIdAssignmentTest, MergeProducesConsistentOrder) {
-    auto dir = create_test_dir("merge");
-    create_descriptor(dir + "a.textproto", "cluster", {"n1", "n2", "n3"}, {0, 1, 2});
-    create_descriptor(dir + "b.textproto", "cluster", {"n1", "n2", "n3"}, {0, 1, 2});
-    CablingGenerator gen(dir, hostnames(3));
+// Merged direct nodes must be reassigned sequential host_ids in the emitted descriptor.
+TEST_F(MergeChildrenOrderTest, MergedDirectNodeHostIdsAreSequentialAfterExport) {
+    auto base = create_test_dir("direct_node_sequential_export");
+    std::string cluster_dir = base + "cluster/";
+    std::filesystem::create_directories(cluster_dir);
+    std::string deployment_path = base + "deployment.textproto";
 
-    const auto& hosts = gen.get_deployment_hosts();
-    ASSERT_EQ(hosts.size(), 3);
+    write_deployment(deployment_path, {"h1", "h2"});
+    write_flat_descriptor(cluster_dir + "a.textproto", "root", {"h1"}, {1});
+    write_flat_descriptor(cluster_dir + "b.textproto", "root", {"h2"}, {0});
+
+    CablingGenerator gen(cluster_dir, deployment_path);
+    gen.emit_cabling_descriptor(base + "output.textproto");
+
+    std::ifstream f(base + "output.textproto");
+    std::string content((std::istreambuf_iterator<char>(f)), std::istreambuf_iterator<char>());
+
+    cabling_generator::proto::ClusterDescriptor desc;
+    ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(content, &desc));
+
+    const auto& mappings = desc.root_instance().child_mappings();
+    EXPECT_EQ(mappings.at("h1").host_id(), 0);
+    EXPECT_EQ(mappings.at("h2").host_id(), 1);
 }
 
-TEST_F(HostIdAssignmentTest, ReloadIdentical) {
-    auto dir = create_test_dir("reload");
-    create_descriptor(dir + "test.textproto", "cluster", {"x", "m", "a"}, {0, 1, 2});
+// Three-file merge with mixed node/subgraph contributions - DFS order must be n1, n2, n3, n4.
+TEST_F(MergeChildrenOrderTest, ThreeFileMergeAllGetSequentialHostIds) {
+    auto base = create_test_dir("three_file_merge");
+    std::string cluster_dir = base + "cluster/";
+    std::filesystem::create_directories(cluster_dir);
+    std::string deployment_path = base + "deployment.textproto";
 
-    CablingGenerator gen1(dir + "test.textproto", hostnames(3));
-    CablingGenerator gen2(dir + "test.textproto", hostnames(3));
-    EXPECT_EQ(gen1, gen2);
+    write_deployment(deployment_path, {"n1", "n2", "n3", "n4"});
+    write_flat_descriptor(cluster_dir + "a.textproto", "root", {"n1"}, {0});
+    write_subgraph_descriptor(cluster_dir + "b.textproto", "root", "group_b", "sub", {"n2", "n3"}, {1, 2});
+    write_flat_descriptor(cluster_dir + "c.textproto", "root", {"n4"}, {3});
+
+    CablingGenerator gen(cluster_dir, deployment_path);
+    const auto fsd = gen.generate_factory_system_descriptor();
+
+    ASSERT_EQ(fsd.hosts().size(), 4);
+    EXPECT_EQ(fsd.hosts()[0].hostname(), "n1");
+    EXPECT_EQ(fsd.hosts()[1].hostname(), "n2");
+    EXPECT_EQ(fsd.hosts()[2].hostname(), "n3");
+    EXPECT_EQ(fsd.hosts()[3].hostname(), "n4");
 }
 
-TEST_F(HostIdAssignmentTest, FileOrderDoesNotMatter) {
-    auto dir1 = create_test_dir("order1");
-    auto dir2 = create_test_dir("order2");
+// Two files share a subgraph name - new nodes are appended in file B's template order.
+TEST_F(MergeChildrenOrderTest, NewNodesAddedToExistingSubgraphGetSequentialHostIds) {
+    auto base = create_test_dir("new_nodes_existing_subgraph");
+    std::string cluster_dir = base + "cluster/";
+    std::filesystem::create_directories(cluster_dir);
+    std::string deployment_path = base + "deployment.textproto";
 
-    std::string content = R"(
-graph_templates { key: "t" value {
+    write_deployment(deployment_path, {"n1", "n2", "n3", "n4"});
+    write_subgraph_descriptor(cluster_dir + "a.textproto", "root", "group_a", "sub", {"n1", "n2"}, {0, 1});
+    write_subgraph_descriptor(cluster_dir + "b.textproto", "root", "group_a", "sub", {"n3", "n4"}, {2, 3});
+
+    CablingGenerator gen(cluster_dir, deployment_path);
+    const auto fsd = gen.generate_factory_system_descriptor();
+
+    ASSERT_EQ(fsd.hosts().size(), 4);
+    EXPECT_EQ(fsd.hosts()[0].hostname(), "n1");
+    EXPECT_EQ(fsd.hosts()[1].hostname(), "n2");
+    EXPECT_EQ(fsd.hosts()[2].hostname(), "n3");
+    EXPECT_EQ(fsd.hosts()[3].hostname(), "n4");
+}
+
+// Two-level nesting in file A (root->outer->inner->{n1,n2}); file B adds n3 at root level.
+// DFS must fully descend before visiting n3.
+TEST_F(MergeChildrenOrderTest, DeepNestingThroughMergeGetsCorrectDFSOrder) {
+    auto base = create_test_dir("deep_nesting_merge");
+    std::string cluster_dir = base + "cluster/";
+    std::filesystem::create_directories(cluster_dir);
+    std::string deployment_path = base + "deployment.textproto";
+
+    write_deployment(deployment_path, {"n1", "n2", "n3"});
+    write_textproto(
+        cluster_dir + "a.textproto",
+        R"(graph_templates { key: "inner_tmpl" value {
   children { name: "n1" node_ref { node_descriptor: "WH_GALAXY" } }
   children { name: "n2" node_ref { node_descriptor: "WH_GALAXY" } }
 }}
-root_instance { template_name: "t"
-  child_mappings { key: "n1" value { host_id: 0 } }
-  child_mappings { key: "n2" value { host_id: 1 } }
-}
-)";
-    write_textproto(dir1 + "a.textproto", content);
-    write_textproto(dir1 + "z.textproto", content);
-    write_textproto(dir2 + "z.textproto", content);
-    write_textproto(dir2 + "a.textproto", content);
-
-    CablingGenerator gen1(dir1, hostnames(2));
-    CablingGenerator gen2(dir2, hostnames(2));
-    EXPECT_EQ(gen1, gen2);
-}
-
-TEST_F(HostIdAssignmentTest, ExportedHostIdsAreSequential) {
-    auto dir = create_test_dir("export");
-    write_textproto(dir + "input.textproto", R"(
-graph_templates { key: "t" value {
-  children { name: "first" node_ref { node_descriptor: "WH_GALAXY" } }
-  children { name: "second" node_ref { node_descriptor: "WH_GALAXY" } }
-  children { name: "third" node_ref { node_descriptor: "WH_GALAXY" } }
+graph_templates { key: "outer_tmpl" value {
+  children { name: "inner_group" graph_ref { graph_template: "inner_tmpl" } }
 }}
-root_instance { template_name: "t"
-  child_mappings { key: "first" value { host_id: 100 } }
-  child_mappings { key: "second" value { host_id: 50 } }
-  child_mappings { key: "third" value { host_id: 200 } }
+graph_templates { key: "root" value {
+  children { name: "outer_group" graph_ref { graph_template: "outer_tmpl" } }
+}}
+root_instance { template_name: "root"
+  child_mappings { key: "outer_group" value { sub_instance {
+    template_name: "outer_tmpl"
+    child_mappings { key: "inner_group" value { sub_instance {
+      template_name: "inner_tmpl"
+      child_mappings { key: "n1" value { host_id: 0 } }
+      child_mappings { key: "n2" value { host_id: 1 } }
+    }}}
+  }}}
 }
 )");
+    write_flat_descriptor(cluster_dir + "b.textproto", "root", {"n3"}, {2});
 
-    CablingGenerator gen(dir + "input.textproto", hostnames(3));
-    gen.emit_cabling_descriptor(dir + "output.textproto");
+    CablingGenerator gen(cluster_dir, deployment_path);
+    const auto fsd = gen.generate_factory_system_descriptor();
 
-    std::ifstream f(dir + "output.textproto");
-    std::string content((std::istreambuf_iterator<char>(f)), std::istreambuf_iterator<char>());
-
-    cabling_generator::proto::ClusterDescriptor desc;
-    ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(content, &desc));
-
-    const auto& mappings = desc.root_instance().child_mappings();
-    EXPECT_EQ(mappings.at("first").host_id(), 0);
-    EXPECT_EQ(mappings.at("second").host_id(), 1);
-    EXPECT_EQ(mappings.at("third").host_id(), 2);
+    ASSERT_EQ(fsd.hosts().size(), 3);
+    EXPECT_EQ(fsd.hosts()[0].hostname(), "n1");
+    EXPECT_EQ(fsd.hosts()[1].hostname(), "n2");
+    EXPECT_EQ(fsd.hosts()[2].hostname(), "n3");
 }
 
-TEST_F(HostIdAssignmentTest, TemplateOrderTakesPrecedence) {
-    auto dir = create_test_dir("precedence");
-    write_textproto(dir + "input.textproto", R"(
-graph_templates { key: "t" value {
-  children { name: "charlie" node_ref { node_descriptor: "WH_GALAXY" } }
-  children { name: "alpha" node_ref { node_descriptor: "WH_GALAXY" } }
-  children { name: "bravo" node_ref { node_descriptor: "WH_GALAXY" } }
-}}
-root_instance { template_name: "t"
-  child_mappings { key: "charlie" value { host_id: 99 } }
-  child_mappings { key: "alpha" value { host_id: 98 } }
-  child_mappings { key: "bravo" value { host_id: 97 } }
-}
-)");
+// File B's local host_ids (n2=0, n3=1) must be remapped to post-merge ids (n2=1, n3=2).
+// n1 (id=0) is standalone and must not appear in any inter-node connection.
+TEST_F(MergeChildrenOrderTest, ConnectionHostIdsCorrectlyRemappedAfterMerge) {
+    auto base = create_test_dir("connection_remap");
+    std::string cluster_dir = base + "cluster/";
+    std::filesystem::create_directories(cluster_dir);
+    std::string deployment_path = base + "deployment.textproto";
 
-    CablingGenerator gen(dir + "input.textproto", hostnames(3));
-    gen.emit_cabling_descriptor(dir + "output.textproto");
-
-    std::ifstream f(dir + "output.textproto");
-    std::string content((std::istreambuf_iterator<char>(f)), std::istreambuf_iterator<char>());
-
-    cabling_generator::proto::ClusterDescriptor desc;
-    ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(content, &desc));
-
-    const auto& mappings = desc.root_instance().child_mappings();
-    // Template order: charlie, alpha, bravo -> host_ids: 0, 1, 2
-    EXPECT_EQ(mappings.at("charlie").host_id(), 0);
-    EXPECT_EQ(mappings.at("alpha").host_id(), 1);
-    EXPECT_EQ(mappings.at("bravo").host_id(), 2);
-}
-
-TEST_F(HostIdAssignmentTest, SingleNode) {
-    auto dir = create_test_dir("single");
-    create_descriptor(dir + "test.textproto", "t", {"only"}, {42});
-    CablingGenerator gen(dir + "test.textproto", hostnames(1));
-    EXPECT_EQ(gen.get_deployment_hosts().size(), 1);
-}
-
-TEST_F(HostIdAssignmentTest, ManyNodes) {
-    auto dir = create_test_dir("many");
-    std::vector<std::string> names;
-    std::vector<uint32_t> ids;
-    for (int i = 0; i < 50; ++i) {
-        names.push_back("n" + std::to_string(i));
-        ids.push_back(49 - i);  // reverse order
+    write_deployment(deployment_path, {"n1", "n2", "n3"});
+    write_flat_descriptor(cluster_dir + "a.textproto", "root", {"n1"}, {0});
+    write_textproto(
+        cluster_dir + "b.textproto",
+        R"(graph_templates { key: "root" value {
+  children { name: "n2" node_ref { node_descriptor: "WH_GALAXY" } }
+  children { name: "n3" node_ref { node_descriptor: "WH_GALAXY" } }
+  internal_connections {
+    key: "QSFP_DD"
+    value {
+      connections {
+        port_a { path: ["n2"] tray_id: 1 port_id: 1 }
+        port_b { path: ["n3"] tray_id: 1 port_id: 1 }
+      }
     }
-    create_descriptor(dir + "test.textproto", "t", names, ids);
-    CablingGenerator gen(dir + "test.textproto", hostnames(50));
-    EXPECT_EQ(gen.get_deployment_hosts().size(), 50);
+  }
+}}
+root_instance { template_name: "root"
+  child_mappings { key: "n2" value { host_id: 0 } }
+  child_mappings { key: "n3" value { host_id: 1 } }
+}
+)");
+
+    CablingGenerator gen(cluster_dir, deployment_path);
+    const auto& connections = gen.get_chip_connections();
+
+    bool stale_connection_found = false;
+    bool n2_n3_connected = false;
+    for (const auto& [ep_a, ep_b] : connections) {
+        if (*ep_a.host_id == *ep_b.host_id) {
+            continue;  // intra-node connection, skip
+        }
+        auto a = *ep_a.host_id, b = *ep_b.host_id;
+        if (a == 0u || b == 0u) {
+            stale_connection_found = true;
+        }
+        if ((a == 1u && b == 2u) || (a == 2u && b == 1u)) {
+            n2_n3_connected = true;
+        }
+    }
+    EXPECT_FALSE(stale_connection_found) << "n1 (host_id=0) must not appear in any inter-node connection";
+    EXPECT_TRUE(n2_n3_connected) << "n2 (host_id=1) and n3 (host_id=2) must be connected";
+}
+
+// Deployment file order is irrelevant - FSD hosts[i] must reflect DFS template order.
+TEST_F(MergeChildrenOrderTest, DeploymentOutOfOrder_SingleFile_FsdReflectsDfsOrder) {
+    auto base = create_test_dir("dep_ooo_single");
+    write_deployment(base + "dep.textproto", {"h3", "h2", "h1"});
+    write_flat_descriptor(base + "cabling.textproto", "root", {"h1", "h2", "h3"}, {2, 1, 0});
+
+    CablingGenerator gen(base + "cabling.textproto", base + "dep.textproto");
+    const auto fsd = gen.generate_factory_system_descriptor();
+
+    ASSERT_EQ(fsd.hosts().size(), 3);
+    EXPECT_EQ(fsd.hosts()[0].hostname(), "h1");
+    EXPECT_EQ(fsd.hosts()[1].hostname(), "h2");
+    EXPECT_EQ(fsd.hosts()[2].hostname(), "h3");
+}
+
+// Same as above but across a two-file merge with fully reversed deployment order.
+TEST_F(MergeChildrenOrderTest, DeploymentOutOfOrder_MergedFiles_FsdReflectsDfsOrder) {
+    auto base = create_test_dir("dep_ooo_merge");
+    std::string cdir = base + "c/";
+    std::filesystem::create_directories(cdir);
+    write_deployment(base + "dep.textproto", {"h4", "h3", "h2", "h1"});
+    write_flat_descriptor(cdir + "a.textproto", "root", {"h1", "h2"}, {3, 2});
+    write_flat_descriptor(cdir + "b.textproto", "root", {"h3", "h4"}, {1, 0});
+
+    CablingGenerator gen(cdir, base + "dep.textproto");
+    const auto fsd = gen.generate_factory_system_descriptor();
+
+    ASSERT_EQ(fsd.hosts().size(), 4);
+    EXPECT_EQ(fsd.hosts()[0].hostname(), "h1");
+    EXPECT_EQ(fsd.hosts()[1].hostname(), "h2");
+    EXPECT_EQ(fsd.hosts()[2].hostname(), "h3");
+    EXPECT_EQ(fsd.hosts()[3].hostname(), "h4");
+}
+
+// Both files declare connections; file B's local ids (0<->1) must become (2<->3) after merge.
+TEST_F(MergeChildrenOrderTest, BothFilesHaveConnections_PostMergeIdsCorrect) {
+    auto base = create_test_dir("both_connected");
+    std::string cdir = base + "c/";
+    std::filesystem::create_directories(cdir);
+    write_deployment(base + "dep.textproto", {"h1", "h2", "h3", "h4"});
+    write_textproto(cdir + "a.textproto", R"(
+graph_templates { key: "root" value {
+  children { name: "h1" node_ref { node_descriptor: "WH_GALAXY" } }
+  children { name: "h2" node_ref { node_descriptor: "WH_GALAXY" } }
+  internal_connections { key: "QSFP_DD" value {
+    connections {
+      port_a { path: ["h1"] tray_id: 1 port_id: 1 }
+      port_b { path: ["h2"] tray_id: 1 port_id: 1 }
+    }
+  }}
+}}
+root_instance { template_name: "root"
+  child_mappings { key: "h1" value { host_id: 0 } }
+  child_mappings { key: "h2" value { host_id: 1 } }
+}
+)");
+    write_textproto(cdir + "b.textproto", R"(
+graph_templates { key: "root" value {
+  children { name: "h3" node_ref { node_descriptor: "WH_GALAXY" } }
+  children { name: "h4" node_ref { node_descriptor: "WH_GALAXY" } }
+  internal_connections { key: "QSFP_DD" value {
+    connections {
+      port_a { path: ["h3"] tray_id: 1 port_id: 1 }
+      port_b { path: ["h4"] tray_id: 1 port_id: 1 }
+    }
+  }}
+}}
+root_instance { template_name: "root"
+  child_mappings { key: "h3" value { host_id: 0 } }
+  child_mappings { key: "h4" value { host_id: 1 } }
+}
+)");
+
+    CablingGenerator gen(cdir, base + "dep.textproto");
+    std::set<std::pair<uint32_t, uint32_t>> pairs;
+    for (const auto& [ep_a, ep_b] : gen.get_chip_connections()) {
+        if (*ep_a.host_id != *ep_b.host_id) {
+            pairs.insert({std::min(*ep_a.host_id, *ep_b.host_id), std::max(*ep_a.host_id, *ep_b.host_id)});
+        }
+    }
+    EXPECT_EQ(pairs, (std::set<std::pair<uint32_t, uint32_t>>{{0u, 1u}, {2u, 3u}}));
+}
+
+// File B's fan-out (h3->h4, h3->h5) must use post-merge ids after remapping.
+TEST_F(MergeChildrenOrderTest, FanOut_SecondFile_AllConnectionsRemapped) {
+    auto base = create_test_dir("fanout_second_file");
+    std::string cdir = base + "c/";
+    std::filesystem::create_directories(cdir);
+    write_deployment(base + "dep.textproto", {"h1", "h2", "h3", "h4", "h5"});
+    write_flat_descriptor(cdir + "a.textproto", "root", {"h1", "h2"}, {0, 1});
+    write_textproto(cdir + "b.textproto", R"(
+graph_templates { key: "root" value {
+  children { name: "h3" node_ref { node_descriptor: "WH_GALAXY" } }
+  children { name: "h4" node_ref { node_descriptor: "WH_GALAXY" } }
+  children { name: "h5" node_ref { node_descriptor: "WH_GALAXY" } }
+  internal_connections { key: "QSFP_DD" value {
+    connections {
+      port_a { path: ["h3"] tray_id: 1 port_id: 1 }
+      port_b { path: ["h4"] tray_id: 1 port_id: 1 }
+    }
+    connections {
+      port_a { path: ["h3"] tray_id: 1 port_id: 2 }
+      port_b { path: ["h5"] tray_id: 1 port_id: 1 }
+    }
+  }}
+}}
+root_instance { template_name: "root"
+  child_mappings { key: "h3" value { host_id: 0 } }
+  child_mappings { key: "h4" value { host_id: 1 } }
+  child_mappings { key: "h5" value { host_id: 2 } }
+}
+)");
+
+    CablingGenerator gen(cdir, base + "dep.textproto");
+    const auto fsd = gen.generate_factory_system_descriptor();
+    ASSERT_EQ(fsd.hosts().size(), 5);
+    EXPECT_EQ(fsd.hosts()[2].hostname(), "h3");
+
+    std::set<std::pair<uint32_t, uint32_t>> pairs;
+    for (const auto& [ep_a, ep_b] : gen.get_chip_connections()) {
+        if (*ep_a.host_id != *ep_b.host_id) {
+            pairs.insert({std::min(*ep_a.host_id, *ep_b.host_id), std::max(*ep_a.host_id, *ep_b.host_id)});
+        }
+    }
+    EXPECT_EQ(pairs, (std::set<std::pair<uint32_t, uint32_t>>{{2u, 3u}, {2u, 4u}}));
 }
 
 }  // namespace tt::scaleout_tools

--- a/tools/tests/scaleout/test_host_id_assignment.cpp
+++ b/tools/tests/scaleout/test_host_id_assignment.cpp
@@ -16,696 +16,228 @@
 
 namespace tt::scaleout_tools {
 
-// All tests use the deployment-descriptor constructor so FSD hosts[i].hostname()
-// directly reflects which node received host_id=i after DFS reassignment.
-class HostIdAssignmentTest : public ::testing::Test {
-protected:
-    std::string create_test_dir(const std::string& name) {
-        static std::atomic<int> seq{0};
-        auto dir = std::filesystem::temp_directory_path() /
-                   ("host_id_" + name + "_test_" + std::to_string(seq++));
-        std::filesystem::remove_all(dir);
-        std::filesystem::create_directories(dir);
-        dirs_.push_back(dir.string());
-        return dir.string() + "/";
-    }
+static constexpr std::string_view k5NodeCabling =
+    "tools/tests/scaleout/cabling_descriptors/5_wh_galaxy_y_torus_superpod.textproto";
+static constexpr std::string_view k16NodeCabling =
+    "tools/tests/scaleout/cabling_descriptors/16_n300_lb_cluster.textproto";
+static constexpr std::string_view k16NodeDeploy =
+    "tools/tests/scaleout/deployment_descriptors/16_lb_deployment.textproto";
 
-    void TearDown() override {
-        for (const auto& d : dirs_) {
-            std::filesystem::remove_all(d);
-        }
-        dirs_.clear();
-    }
+// ---- Helpers ----
 
-    std::vector<std::string> dirs_;
-
-    static void write(const std::string& path, const std::string& content) {
-        std::ofstream(path) << content;
-    }
-
-    // Flat cabling descriptor: root template -> direct WH_GALAXY nodes.
-    static void flat(
-        const std::string& path,
-        const std::vector<std::string>& names,
-        const std::vector<uint32_t>& ids) {
-        std::string s = "graph_templates { key: \"root\" value {\n";
-        for (const auto& n : names) {
-            s += "  children { name: \"" + n + "\" node_ref { node_descriptor: \"WH_GALAXY\" } }\n";
-        }
-        s += "}}\nroot_instance { template_name: \"root\"\n";
-        for (size_t i = 0; i < names.size(); ++i) {
-            s += "  child_mappings { key: \"" + names[i] + "\" value { host_id: " +
-                 std::to_string(ids[i]) + " } }\n";
-        }
-        s += "}\n";
-        write(path, s);
-    }
-
-    // Deployment descriptor with one WH_GALAXY entry per hostname.
-    static void deployment(const std::string& path, const std::vector<std::string>& hosts) {
-        std::string s;
-        for (const auto& h : hosts) {
-            s += "hosts { host: \"" + h + "\" node_type: \"WH_GALAXY\" }\n";
-        }
-        write(path, s);
-    }
-
-    // Read back FSD and return hosts vector for easy indexed access.
-    static auto fsd_hosts(const CablingGenerator& gen) {
-        return gen.generate_factory_system_descriptor().hosts();
-    }
-};
-
-// Template order determines host_id assignment, not initial child_mapping values.
-// node_a is first in the template -> must get host_id 0 after DFS reassignment.
-TEST_F(HostIdAssignmentTest, TemplateOrderDeterminesAssignment) {
-    auto dir = create_test_dir("template_order");
-    flat(dir + "c.textproto", {"node_a", "node_b", "node_c"}, {2, 0, 1});  // scrambled
-    deployment(dir + "d.textproto", {"node_a", "node_b", "node_c"});
-
-    CablingGenerator gen(dir + "c.textproto", dir + "d.textproto");
-    const auto hosts = fsd_hosts(gen);
-
-    ASSERT_EQ(hosts.size(), 3);
-    EXPECT_EQ(hosts[0].hostname(), "node_a");
-    EXPECT_EQ(hosts[1].hostname(), "node_b");
-    EXPECT_EQ(hosts[2].hostname(), "node_c");
+static std::string tmp_dir(const std::string& name) {
+    static std::atomic<int> seq{0};
+    auto p = std::filesystem::temp_directory_path() / ("host_id_" + name + "_" + std::to_string(seq++));
+    std::filesystem::remove_all(p);
+    std::filesystem::create_directories(p);
+    return p.string() + "/";
 }
 
-// Template order must be respected even when names are non-alphabetical.
-// Template: zebra, yak, apple -> host_ids 0, 1, 2 respectively.
-TEST_F(HostIdAssignmentTest, TemplateOrderNotAlphabetical) {
-    auto dir = create_test_dir("not_alphabetical");
-    flat(dir + "c.textproto", {"zebra", "yak", "apple"}, {0, 1, 2});
-    deployment(dir + "d.textproto", {"zebra", "yak", "apple"});
-
-    CablingGenerator gen(dir + "c.textproto", dir + "d.textproto");
-    const auto hosts = fsd_hosts(gen);
-
-    ASSERT_EQ(hosts.size(), 3);
-    EXPECT_EQ(hosts[0].hostname(), "zebra");
-    EXPECT_EQ(hosts[1].hostname(), "yak");
-    EXPECT_EQ(hosts[2].hostname(), "apple");
+static void write(const std::string& path, const std::string& content) {
+    std::ofstream(path) << content;
 }
 
-// DFS enters a subgraph before visiting siblings that come after it in the template.
-// Template: node1, subgraph1(sub1,sub2), node2 -> DFS order: node1, sub1, sub2, node2.
-TEST_F(HostIdAssignmentTest, SubgraphChildrenVisitedBeforeSiblings) {
-    auto dir = create_test_dir("nested_dfs");
-    write(dir + "c.textproto", R"(
-graph_templates { key: "sub" value {
-  children { name: "sub1" node_ref { node_descriptor: "WH_GALAXY" } }
-  children { name: "sub2" node_ref { node_descriptor: "WH_GALAXY" } }
-}}
-graph_templates { key: "root" value {
-  children { name: "node1"     node_ref  { node_descriptor: "WH_GALAXY" } }
-  children { name: "subgraph1" graph_ref { graph_template: "sub" } }
-  children { name: "node2"     node_ref  { node_descriptor: "WH_GALAXY" } }
-}}
-root_instance { template_name: "root"
-  child_mappings { key: "node1" value { host_id: 3 } }
-  child_mappings { key: "subgraph1" value { sub_instance {
-    template_name: "sub"
-    child_mappings { key: "sub1" value { host_id: 0 } }
-    child_mappings { key: "sub2" value { host_id: 2 } }
-  }}}
-  child_mappings { key: "node2" value { host_id: 1 } }
+static void write_deploy(const std::string& path, const std::vector<std::string>& hosts,
+                         const std::string& node_type = "WH_GALAXY_Y_TORUS") {
+    std::string s;
+    for (const auto& h : hosts)
+        s += "hosts { host: \"" + h + "\" node_type: \"" + node_type + "\" }\n";
+    write(path, s);
 }
-)");
-    deployment(dir + "d.textproto", {"node1", "sub1", "sub2", "node2"});
 
-    CablingGenerator gen(dir + "c.textproto", dir + "d.textproto");
-    const auto hosts = fsd_hosts(gen);
+static std::string read_file(const std::string& path) {
+    std::ifstream f(path);
+    return {std::istreambuf_iterator<char>(f), {}};
+}
 
-    ASSERT_EQ(hosts.size(), 4);
+static void replace_first(std::string& s, const std::string& from, const std::string& to) {
+    auto pos = s.find(from);
+    if (pos != std::string::npos) s.replace(pos, from.size(), to);
+}
+
+// ---- Single-file tests ----
+
+// Real 5-node cabling with node1<->node5 and node2<->node4 host_ids swapped.
+// DFS must restore template order (node1..5) regardless of scrambled initial IDs.
+// Also checks the emitted cabling carries the DFS-corrected IDs, not the originals.
+TEST(HostIdAssignmentTest, ScrambledHostIds_TemplateOrderRestored) {
+    auto dir = tmp_dir("scrambled");
+
+    auto cabling = read_file(std::string(k5NodeCabling));
+    for (const auto& [key, from, to] : std::vector<std::tuple<std::string, int, int>>{
+             {"node1", 0, 4}, {"node2", 1, 3}, {"node4", 3, 1}, {"node5", 4, 0}}) {
+        replace_first(cabling,
+            "\"" + key + "\"\n    value { host_id: " + std::to_string(from) + " }",
+            "\"" + key + "\"\n    value { host_id: " + std::to_string(to) + " }");
+    }
+    write(dir + "c.textproto", cabling);
+    write_deploy(dir + "dep.textproto", {"node1", "node2", "node3", "node4", "node5"});
+
+    CablingGenerator gen(dir + "c.textproto", dir + "dep.textproto");
+    const auto hosts = gen.generate_factory_system_descriptor().hosts();
+
+    ASSERT_EQ(hosts.size(), 5u);
     EXPECT_EQ(hosts[0].hostname(), "node1");
-    EXPECT_EQ(hosts[1].hostname(), "sub1");
-    EXPECT_EQ(hosts[2].hostname(), "sub2");
-    EXPECT_EQ(hosts[3].hostname(), "node2");
-}
+    EXPECT_EQ(hosts[1].hostname(), "node2");
+    EXPECT_EQ(hosts[2].hostname(), "node3");
+    EXPECT_EQ(hosts[3].hostname(), "node4");
+    EXPECT_EQ(hosts[4].hostname(), "node5");
 
-// When a subgraph appears first in the template, all its children are
-// assigned lower host_ids than any node listed after it.
-TEST_F(HostIdAssignmentTest, SubgraphFirstInTemplate_GetsLowerIds) {
-    auto dir = create_test_dir("subgraph_first");
-    write(dir + "c.textproto", R"(
-graph_templates { key: "sub" value {
-  children { name: "sub1" node_ref { node_descriptor: "WH_GALAXY" } }
-  children { name: "sub2" node_ref { node_descriptor: "WH_GALAXY" } }
-}}
-graph_templates { key: "root" value {
-  children { name: "subgraph1" graph_ref { graph_template: "sub" } }
-  children { name: "node1"     node_ref  { node_descriptor: "WH_GALAXY" } }
-}}
-root_instance { template_name: "root"
-  child_mappings { key: "subgraph1" value { sub_instance {
-    template_name: "sub"
-    child_mappings { key: "sub1" value { host_id: 2 } }
-    child_mappings { key: "sub2" value { host_id: 0 } }
-  }}}
-  child_mappings { key: "node1" value { host_id: 1 } }
-}
-)");
-    deployment(dir + "d.textproto", {"sub1", "sub2", "node1"});
-
-    CablingGenerator gen(dir + "c.textproto", dir + "d.textproto");
-    const auto hosts = fsd_hosts(gen);
-
-    ASSERT_EQ(hosts.size(), 3);
-    EXPECT_EQ(hosts[0].hostname(), "sub1");
-    EXPECT_EQ(hosts[1].hostname(), "sub2");
-    EXPECT_EQ(hosts[2].hostname(), "node1");
-}
-
-// Template order is [third, first, second] with scrambled initial ids - exported ids must match template position.
-TEST_F(HostIdAssignmentTest, ScrambledInitialIdsReassignedSequentially) {
-    auto dir = create_test_dir("scrambled");
-    write(dir + "c.textproto", R"(
-graph_templates { key: "t" value {
-  children { name: "third"  node_ref { node_descriptor: "WH_GALAXY" } }
-  children { name: "first"  node_ref { node_descriptor: "WH_GALAXY" } }
-  children { name: "second" node_ref { node_descriptor: "WH_GALAXY" } }
-}}
-root_instance { template_name: "t"
-  child_mappings { key: "third"  value { host_id: 1 } }
-  child_mappings { key: "first"  value { host_id: 2 } }
-  child_mappings { key: "second" value { host_id: 0 } }
-}
-)");
-    deployment(dir + "d.textproto", {"third", "first", "second"});
-
-    CablingGenerator gen(dir + "c.textproto", dir + "d.textproto");
     gen.emit_cabling_descriptor(dir + "out.textproto");
-
-    std::ifstream f(dir + "out.textproto");
-    std::string content((std::istreambuf_iterator<char>(f)), std::istreambuf_iterator<char>());
+    std::ifstream ef(dir + "out.textproto");
+    std::string emitted((std::istreambuf_iterator<char>(ef)), {});
     cabling_generator::proto::ClusterDescriptor desc;
-    ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(content, &desc));
-
+    ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(emitted, &desc));
     const auto& m = desc.root_instance().child_mappings();
-    EXPECT_EQ(m.at("third").host_id(), 0);
-    EXPECT_EQ(m.at("first").host_id(), 1);
-    EXPECT_EQ(m.at("second").host_id(), 2);
+    EXPECT_EQ(m.at("node1").host_id(), 0u);
+    EXPECT_EQ(m.at("node5").host_id(), 4u);
+
+    std::filesystem::remove_all(dir);
 }
 
-// Template order wins over alphabetical order.
-// Template: charlie, alpha, bravo -> must get host_ids 0, 1, 2 respectively.
-TEST_F(HostIdAssignmentTest, TemplateOrderNotAlphabetical_ExportedIds) {
-    auto dir = create_test_dir("non_alpha_export");
-    write(dir + "c.textproto", R"(
-graph_templates { key: "t" value {
-  children { name: "charlie" node_ref { node_descriptor: "WH_GALAXY" } }
-  children { name: "alpha"   node_ref { node_descriptor: "WH_GALAXY" } }
-  children { name: "bravo"   node_ref { node_descriptor: "WH_GALAXY" } }
-}}
-root_instance { template_name: "t"
-  child_mappings { key: "charlie" value { host_id: 2 } }
-  child_mappings { key: "alpha"   value { host_id: 0 } }
-  child_mappings { key: "bravo"   value { host_id: 1 } }
-}
-)");
-    deployment(dir + "d.textproto", {"charlie", "alpha", "bravo"});
+// Real 5-node cabling + deployment with hosts listed in reverse template order.
+// DFS must reorder deployment_hosts_ to match template traversal regardless of file order.
+TEST(HostIdAssignmentTest, ReversedDeployment_TemplateOrderRestored) {
+    auto dir = tmp_dir("reversed_deploy");
+    write_deploy(dir + "dep.textproto", {"node5", "node4", "node3", "node2", "node1"});
 
-    CablingGenerator gen(dir + "c.textproto", dir + "d.textproto");
-    const auto hosts = fsd_hosts(gen);
+    CablingGenerator gen(std::string(k5NodeCabling), dir + "dep.textproto");
+    const auto hosts = gen.generate_factory_system_descriptor().hosts();
 
-    ASSERT_EQ(hosts.size(), 3);
-    EXPECT_EQ(hosts[0].hostname(), "charlie");
-    EXPECT_EQ(hosts[1].hostname(), "alpha");
-    EXPECT_EQ(hosts[2].hostname(), "bravo");
+    ASSERT_EQ(hosts.size(), 5u);
+    EXPECT_EQ(hosts[0].hostname(), "node1");
+    EXPECT_EQ(hosts[4].hostname(), "node5");
+
+    std::filesystem::remove_all(dir);
 }
 
-class MergeChildrenOrderTest : public ::testing::Test {
-protected:
-    std::string create_test_dir(const std::string& name) {
-        static std::atomic<int> seq{0};
-        auto dir = std::filesystem::temp_directory_path() /
-                   ("merge_children_order_" + name + "_test_" + std::to_string(seq++));
-        std::filesystem::remove_all(dir);
-        std::filesystem::create_directories(dir);
-        dirs_.push_back(dir.string());
-        return dir.string() + "/";
-    }
-
-    void TearDown() override {
-        for (const auto& d : dirs_) {
-            std::filesystem::remove_all(d);
-        }
-        dirs_.clear();
-    }
-
-    std::vector<std::string> dirs_;
-
-    static void write_textproto(const std::string& path, const std::string& content) {
-        std::ofstream(path) << content;
-    }
-
-    static void write_deployment(const std::string& path, const std::vector<std::string>& host_names) {
-        std::string s;
-        for (const auto& h : host_names) {
-            s += "hosts { host: \"" + h + "\" node_type: \"WH_GALAXY\" }\n";
-        }
-        write_textproto(path, s);
-    }
-
-    static void write_flat_descriptor(
-        const std::string& path,
-        const std::string& root_tmpl,
-        const std::vector<std::string>& node_names,
-        const std::vector<uint32_t>& host_ids) {
-        std::string s;
-        s += "graph_templates { key: \"" + root_tmpl + "\" value {\n";
-        for (const auto& n : node_names) {
-            s += "  children { name: \"" + n + "\" node_ref { node_descriptor: \"WH_GALAXY\" } }\n";
-        }
-        s += "}}\n";
-        s += "root_instance { template_name: \"" + root_tmpl + "\"\n";
-        for (size_t i = 0; i < node_names.size(); ++i) {
-            s += "  child_mappings { key: \"" + node_names[i] + "\" value { host_id: " +
-                 std::to_string(host_ids[i]) + " } }\n";
-        }
-        s += "}\n";
-        write_textproto(path, s);
-    }
-
-    static void write_subgraph_descriptor(
-        const std::string& path,
-        const std::string& root_tmpl,
-        const std::string& group_name,
-        const std::string& sub_tmpl,
-        const std::vector<std::string>& node_names,
-        const std::vector<uint32_t>& host_ids) {
-        std::string s;
-        s += "graph_templates { key: \"" + sub_tmpl + "\" value {\n";
-        for (const auto& n : node_names) {
-            s += "  children { name: \"" + n + "\" node_ref { node_descriptor: \"WH_GALAXY\" } }\n";
-        }
-        s += "}}\n";
-        s += "graph_templates { key: \"" + root_tmpl + "\" value {\n";
-        s += "  children { name: \"" + group_name +
-             "\" graph_ref { graph_template: \"" + sub_tmpl + "\" } }\n";
-        s += "}}\n";
-        s += "root_instance { template_name: \"" + root_tmpl + "\"\n";
-        s += "  child_mappings { key: \"" + group_name + "\" value { sub_instance {\n";
-        s += "    template_name: \"" + sub_tmpl + "\"\n";
-        for (size_t i = 0; i < node_names.size(); ++i) {
-            s += "    child_mappings { key: \"" + node_names[i] + "\" value { host_id: " +
-                 std::to_string(host_ids[i]) + " } }\n";
-        }
-        s += "  }}}\n}\n";
-        write_textproto(path, s);
-    }
-};
-
-// Two files each contributing a disjoint direct node - both must appear in the merged FSD.
-TEST_F(MergeChildrenOrderTest, NewDirectNodeFromMergeGetsHostId) {
-    auto base = create_test_dir("new_direct_node");
-    std::string cluster_dir = base + "cluster/";
-    std::filesystem::create_directories(cluster_dir);
-    std::string deployment_path = base + "deployment.textproto";
-
-    write_deployment(deployment_path, {"h1", "h2"});
-    write_flat_descriptor(cluster_dir + "a.textproto", "root", {"h1"}, {0});
-    write_flat_descriptor(cluster_dir + "b.textproto", "root", {"h2"}, {1});
-
-    CablingGenerator gen(cluster_dir, deployment_path);
-
-    const auto& hosts = gen.get_deployment_hosts();
-    ASSERT_EQ(hosts.size(), 2u);
-    EXPECT_EQ(hosts[0].hostname, "h1");
-    EXPECT_EQ(hosts[1].hostname, "h2");
-}
-
-// Two files each contributing a disjoint subgraph - all nodes must appear in the merged FSD.
-TEST_F(MergeChildrenOrderTest, NewSubgraphFromMergeGetsHostIds) {
-    auto base = create_test_dir("new_subgraph");
-    std::string cluster_dir = base + "cluster/";
-    std::filesystem::create_directories(cluster_dir);
-    std::string deployment_path = base + "deployment.textproto";
-
-    write_deployment(deployment_path, {"h1", "h2", "h3", "h4"});
-    write_subgraph_descriptor(cluster_dir + "a.textproto", "root", "group_a", "sub", {"h1", "h2"}, {0, 1});
-    write_subgraph_descriptor(cluster_dir + "b.textproto", "root", "group_b", "sub", {"h3", "h4"}, {2, 3});
-
-    CablingGenerator gen(cluster_dir, deployment_path);
-
-    const auto& hosts = gen.get_deployment_hosts();
-    ASSERT_EQ(hosts.size(), 4u);
-    EXPECT_EQ(hosts[0].hostname, "h1");
-    EXPECT_EQ(hosts[1].hostname, "h2");
-    EXPECT_EQ(hosts[2].hostname, "h3");
-    EXPECT_EQ(hosts[3].hostname, "h4");
-}
-
-// Per-file host_ids are irrelevant - the FSD must reflect DFS order after merge.
-TEST_F(MergeChildrenOrderTest, MergedSubgraphHostIdsAreSequentialAfterExport) {
-    auto base = create_test_dir("subgraph_sequential_export");
-    std::string cluster_dir = base + "cluster/";
-    std::filesystem::create_directories(cluster_dir);
-    std::string deployment_path = base + "deployment.textproto";
-
-    write_deployment(deployment_path, {"h1", "h2", "h3", "h4"});
-    write_subgraph_descriptor(cluster_dir + "a.textproto", "root", "group_a", "sub", {"h1", "h2"}, {2, 3});
-    write_subgraph_descriptor(cluster_dir + "b.textproto", "root", "group_b", "sub", {"h3", "h4"}, {0, 1});
-
-    CablingGenerator gen(cluster_dir, deployment_path);
+// Real 16-node cabling (4 superpods of 4 nodes each) with its real deployment.
+// All FSD connection endpoints must use host_ids in [0..15], confirming DFS traversed
+// the full nested hierarchy correctly.
+TEST(HostIdAssignmentTest, ComplexHierarchy_AllConnectionsUseValidHostIds) {
+    CablingGenerator gen{std::string(k16NodeCabling), std::string(k16NodeDeploy)};
     const auto fsd = gen.generate_factory_system_descriptor();
 
-    ASSERT_EQ(fsd.hosts().size(), 4);
-    EXPECT_EQ(fsd.hosts()[0].hostname(), "h1");
-    EXPECT_EQ(fsd.hosts()[1].hostname(), "h2");
-    EXPECT_EQ(fsd.hosts()[2].hostname(), "h3");
-    EXPECT_EQ(fsd.hosts()[3].hostname(), "h4");
+    ASSERT_EQ(fsd.hosts().size(), 16u);
+    for (const auto& conn : fsd.eth_connections().connection()) {
+        EXPECT_LT(conn.endpoint_a().host_id(), 16u);
+        EXPECT_LT(conn.endpoint_b().host_id(), 16u);
+    }
+    EXPECT_GT(fsd.eth_connections().connection().size(), 0u);
 }
 
-// Template order in file B is [rack_b(subgraph), n2(node)] - subgraph first.
-// DFS must visit rack_b's children before n2, so the merged order is n1, n3, n4, n2.
-TEST_F(MergeChildrenOrderTest, MergePreservesTemplateOrderForMixedNewChildren) {
-    auto base = create_test_dir("template_order_mixed");
-    std::string cluster_dir = base + "cluster/";
-    std::filesystem::create_directories(cluster_dir);
-    std::string deployment_path = base + "deployment.textproto";
+// ---- Merge tests ----
 
-    write_deployment(deployment_path, {"n1", "n3", "n4", "n2"});
-    write_flat_descriptor(cluster_dir + "a.textproto", "root", {"n1"}, {0});
-    write_textproto(
-        cluster_dir + "b.textproto",
-        R"(graph_templates { key: "sub" value {
-  children { name: "n3" node_ref { node_descriptor: "WH_GALAXY" } }
-  children { name: "n4" node_ref { node_descriptor: "WH_GALAXY" } }
+// Real 5-node cabling as file A; file B adds node6+node7 to the same template.
+// After merge + DFS, all 7 nodes must be sequential and in template order.
+TEST(MergeTest, RealBaseWithExtension_AllNodesSequential) {
+    auto dir = tmp_dir("merge_extend");
+    std::string cdir = dir + "c/";
+    std::filesystem::create_directories(cdir);
+    std::filesystem::copy(k5NodeCabling, cdir + "a.textproto");
+    write(cdir + "b.textproto", R"(
+graph_templates { key: "5_wh_galaxy_y_torus_superpod" value {
+  children { name: "node6" node_ref { node_descriptor: "WH_GALAXY_Y_TORUS" } }
+  children { name: "node7" node_ref { node_descriptor: "WH_GALAXY_Y_TORUS" } }
 }}
+root_instance { template_name: "5_wh_galaxy_y_torus_superpod"
+  child_mappings { key: "node6" value { host_id: 0 } }
+  child_mappings { key: "node7" value { host_id: 1 } }
+}
+)");
+    write_deploy(dir + "dep.textproto", {"node1", "node2", "node3", "node4", "node5", "node6", "node7"});
+
+    CablingGenerator gen(cdir, dir + "dep.textproto");
+    const auto fsd = gen.generate_factory_system_descriptor();
+
+    ASSERT_EQ(fsd.hosts().size(), 7u);
+    EXPECT_EQ(fsd.hosts()[0].hostname(), "node1");
+    EXPECT_EQ(fsd.hosts()[5].hostname(), "node6");
+    EXPECT_EQ(fsd.hosts()[6].hostname(), "node7");
+
+    std::filesystem::remove_all(dir);
+}
+
+// Real 5-node cabling as file A; file B re-declares node1..5 (shared) and adds node6.
+// Shared nodes collapse to a single entry: 6 unique hosts, not 11.
+TEST(MergeTest, SharedNodesCollapse_NoDuplication) {
+    auto dir = tmp_dir("merge_shared");
+    std::string cdir = dir + "c/";
+    std::filesystem::create_directories(cdir);
+    std::filesystem::copy(k5NodeCabling, cdir + "a.textproto");
+    write(cdir + "b.textproto", R"(
+graph_templates { key: "5_wh_galaxy_y_torus_superpod" value {
+  children { name: "node1" node_ref { node_descriptor: "WH_GALAXY_Y_TORUS" } }
+  children { name: "node2" node_ref { node_descriptor: "WH_GALAXY_Y_TORUS" } }
+  children { name: "node3" node_ref { node_descriptor: "WH_GALAXY_Y_TORUS" } }
+  children { name: "node4" node_ref { node_descriptor: "WH_GALAXY_Y_TORUS" } }
+  children { name: "node5" node_ref { node_descriptor: "WH_GALAXY_Y_TORUS" } }
+  children { name: "node6" node_ref { node_descriptor: "WH_GALAXY_Y_TORUS" } }
+}}
+root_instance { template_name: "5_wh_galaxy_y_torus_superpod"
+  child_mappings { key: "node1" value { host_id: 0 } }
+  child_mappings { key: "node2" value { host_id: 1 } }
+  child_mappings { key: "node3" value { host_id: 2 } }
+  child_mappings { key: "node4" value { host_id: 3 } }
+  child_mappings { key: "node5" value { host_id: 4 } }
+  child_mappings { key: "node6" value { host_id: 5 } }
+}
+)");
+    write_deploy(dir + "dep.textproto", {"node1", "node2", "node3", "node4", "node5", "node6"});
+
+    CablingGenerator gen(cdir, dir + "dep.textproto");
+    const auto fsd = gen.generate_factory_system_descriptor();
+
+    ASSERT_EQ(fsd.hosts().size(), 6u);
+    EXPECT_EQ(fsd.hosts()[5].hostname(), "node6");
+
+    std::filesystem::remove_all(dir);
+}
+
+// File B declares n2+n3 with local ids 0,1 and a connection between them.
+// After merge, n2 and n3 get post-merge ids 1,2; connection endpoints must reflect that.
+TEST(MergeTest, ConnectionHostIdsRemappedAfterMerge) {
+    auto dir = tmp_dir("merge_conns");
+    std::string cdir = dir + "c/";
+    std::filesystem::create_directories(cdir);
+    write(cdir + "a.textproto", R"(
 graph_templates { key: "root" value {
-  children { name: "rack_b" graph_ref { graph_template: "sub" } }
-  children { name: "n2" node_ref { node_descriptor: "WH_GALAXY" } }
-}}
-root_instance { template_name: "root"
-  child_mappings { key: "rack_b" value { sub_instance {
-    template_name: "sub"
-    child_mappings { key: "n3" value { host_id: 1 } }
-    child_mappings { key: "n4" value { host_id: 2 } }
-  }}}
-  child_mappings { key: "n2" value { host_id: 3 } }
-}
-)");
-
-    CablingGenerator gen(cluster_dir, deployment_path);
-    const auto fsd = gen.generate_factory_system_descriptor();
-
-    ASSERT_EQ(fsd.hosts().size(), 4);
-    EXPECT_EQ(fsd.hosts()[0].hostname(), "n1");
-    EXPECT_EQ(fsd.hosts()[1].hostname(), "n3");
-    EXPECT_EQ(fsd.hosts()[2].hostname(), "n4");
-    EXPECT_EQ(fsd.hosts()[3].hostname(), "n2");
-}
-
-// Merged direct nodes must be reassigned sequential host_ids in the emitted descriptor.
-TEST_F(MergeChildrenOrderTest, MergedDirectNodeHostIdsAreSequentialAfterExport) {
-    auto base = create_test_dir("direct_node_sequential_export");
-    std::string cluster_dir = base + "cluster/";
-    std::filesystem::create_directories(cluster_dir);
-    std::string deployment_path = base + "deployment.textproto";
-
-    write_deployment(deployment_path, {"h1", "h2"});
-    write_flat_descriptor(cluster_dir + "a.textproto", "root", {"h1"}, {1});
-    write_flat_descriptor(cluster_dir + "b.textproto", "root", {"h2"}, {0});
-
-    CablingGenerator gen(cluster_dir, deployment_path);
-    gen.emit_cabling_descriptor(base + "output.textproto");
-
-    std::ifstream f(base + "output.textproto");
-    std::string content((std::istreambuf_iterator<char>(f)), std::istreambuf_iterator<char>());
-
-    cabling_generator::proto::ClusterDescriptor desc;
-    ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(content, &desc));
-
-    const auto& mappings = desc.root_instance().child_mappings();
-    EXPECT_EQ(mappings.at("h1").host_id(), 0);
-    EXPECT_EQ(mappings.at("h2").host_id(), 1);
-}
-
-// Three-file merge with mixed node/subgraph contributions - DFS order must be n1, n2, n3, n4.
-TEST_F(MergeChildrenOrderTest, ThreeFileMergeAllGetSequentialHostIds) {
-    auto base = create_test_dir("three_file_merge");
-    std::string cluster_dir = base + "cluster/";
-    std::filesystem::create_directories(cluster_dir);
-    std::string deployment_path = base + "deployment.textproto";
-
-    write_deployment(deployment_path, {"n1", "n2", "n3", "n4"});
-    write_flat_descriptor(cluster_dir + "a.textproto", "root", {"n1"}, {0});
-    write_subgraph_descriptor(cluster_dir + "b.textproto", "root", "group_b", "sub", {"n2", "n3"}, {1, 2});
-    write_flat_descriptor(cluster_dir + "c.textproto", "root", {"n4"}, {3});
-
-    CablingGenerator gen(cluster_dir, deployment_path);
-    const auto fsd = gen.generate_factory_system_descriptor();
-
-    ASSERT_EQ(fsd.hosts().size(), 4);
-    EXPECT_EQ(fsd.hosts()[0].hostname(), "n1");
-    EXPECT_EQ(fsd.hosts()[1].hostname(), "n2");
-    EXPECT_EQ(fsd.hosts()[2].hostname(), "n3");
-    EXPECT_EQ(fsd.hosts()[3].hostname(), "n4");
-}
-
-// Two files share a subgraph name - new nodes are appended in file B's template order.
-TEST_F(MergeChildrenOrderTest, NewNodesAddedToExistingSubgraphGetSequentialHostIds) {
-    auto base = create_test_dir("new_nodes_existing_subgraph");
-    std::string cluster_dir = base + "cluster/";
-    std::filesystem::create_directories(cluster_dir);
-    std::string deployment_path = base + "deployment.textproto";
-
-    write_deployment(deployment_path, {"n1", "n2", "n3", "n4"});
-    write_subgraph_descriptor(cluster_dir + "a.textproto", "root", "group_a", "sub", {"n1", "n2"}, {0, 1});
-    write_subgraph_descriptor(cluster_dir + "b.textproto", "root", "group_a", "sub", {"n3", "n4"}, {2, 3});
-
-    CablingGenerator gen(cluster_dir, deployment_path);
-    const auto fsd = gen.generate_factory_system_descriptor();
-
-    ASSERT_EQ(fsd.hosts().size(), 4);
-    EXPECT_EQ(fsd.hosts()[0].hostname(), "n1");
-    EXPECT_EQ(fsd.hosts()[1].hostname(), "n2");
-    EXPECT_EQ(fsd.hosts()[2].hostname(), "n3");
-    EXPECT_EQ(fsd.hosts()[3].hostname(), "n4");
-}
-
-// Two-level nesting in file A (root->outer->inner->{n1,n2}); file B adds n3 at root level.
-// DFS must fully descend before visiting n3.
-TEST_F(MergeChildrenOrderTest, DeepNestingThroughMergeGetsCorrectDFSOrder) {
-    auto base = create_test_dir("deep_nesting_merge");
-    std::string cluster_dir = base + "cluster/";
-    std::filesystem::create_directories(cluster_dir);
-    std::string deployment_path = base + "deployment.textproto";
-
-    write_deployment(deployment_path, {"n1", "n2", "n3"});
-    write_textproto(
-        cluster_dir + "a.textproto",
-        R"(graph_templates { key: "inner_tmpl" value {
   children { name: "n1" node_ref { node_descriptor: "WH_GALAXY" } }
-  children { name: "n2" node_ref { node_descriptor: "WH_GALAXY" } }
-}}
-graph_templates { key: "outer_tmpl" value {
-  children { name: "inner_group" graph_ref { graph_template: "inner_tmpl" } }
-}}
-graph_templates { key: "root" value {
-  children { name: "outer_group" graph_ref { graph_template: "outer_tmpl" } }
 }}
 root_instance { template_name: "root"
-  child_mappings { key: "outer_group" value { sub_instance {
-    template_name: "outer_tmpl"
-    child_mappings { key: "inner_group" value { sub_instance {
-      template_name: "inner_tmpl"
-      child_mappings { key: "n1" value { host_id: 0 } }
-      child_mappings { key: "n2" value { host_id: 1 } }
-    }}}
-  }}}
+  child_mappings { key: "n1" value { host_id: 0 } }
 }
 )");
-    write_flat_descriptor(cluster_dir + "b.textproto", "root", {"n3"}, {2});
-
-    CablingGenerator gen(cluster_dir, deployment_path);
-    const auto fsd = gen.generate_factory_system_descriptor();
-
-    ASSERT_EQ(fsd.hosts().size(), 3);
-    EXPECT_EQ(fsd.hosts()[0].hostname(), "n1");
-    EXPECT_EQ(fsd.hosts()[1].hostname(), "n2");
-    EXPECT_EQ(fsd.hosts()[2].hostname(), "n3");
-}
-
-// File B's local host_ids (n2=0, n3=1) must be remapped to post-merge ids (n2=1, n3=2).
-// n1 (id=0) is standalone and must not appear in any inter-node connection.
-TEST_F(MergeChildrenOrderTest, ConnectionHostIdsCorrectlyRemappedAfterMerge) {
-    auto base = create_test_dir("connection_remap");
-    std::string cluster_dir = base + "cluster/";
-    std::filesystem::create_directories(cluster_dir);
-    std::string deployment_path = base + "deployment.textproto";
-
-    write_deployment(deployment_path, {"n1", "n2", "n3"});
-    write_flat_descriptor(cluster_dir + "a.textproto", "root", {"n1"}, {0});
-    write_textproto(
-        cluster_dir + "b.textproto",
-        R"(graph_templates { key: "root" value {
+    write(cdir + "b.textproto", R"(
+graph_templates { key: "root" value {
   children { name: "n2" node_ref { node_descriptor: "WH_GALAXY" } }
   children { name: "n3" node_ref { node_descriptor: "WH_GALAXY" } }
-  internal_connections {
-    key: "QSFP_DD"
-    value {
-      connections {
-        port_a { path: ["n2"] tray_id: 1 port_id: 1 }
-        port_b { path: ["n3"] tray_id: 1 port_id: 1 }
-      }
+  internal_connections { key: "QSFP_DD" value {
+    connections {
+      port_a { path: ["n2"] tray_id: 1 port_id: 1 }
+      port_b { path: ["n3"] tray_id: 1 port_id: 1 }
     }
-  }
+  }}
 }}
 root_instance { template_name: "root"
   child_mappings { key: "n2" value { host_id: 0 } }
   child_mappings { key: "n3" value { host_id: 1 } }
 }
 )");
+    write(dir + "dep.textproto", "hosts{host:\"n1\" node_type:\"WH_GALAXY\"}\nhosts{host:\"n2\" node_type:\"WH_GALAXY\"}\nhosts{host:\"n3\" node_type:\"WH_GALAXY\"}\n");
 
-    CablingGenerator gen(cluster_dir, deployment_path);
-    const auto& connections = gen.get_chip_connections();
-
-    bool stale_connection_found = false;
-    bool n2_n3_connected = false;
-    for (const auto& [ep_a, ep_b] : connections) {
-        if (*ep_a.host_id == *ep_b.host_id) {
-            continue;  // intra-node connection, skip
-        }
+    CablingGenerator gen(cdir, dir + "dep.textproto");
+    bool stale = false, n2_n3 = false;
+    for (const auto& [ep_a, ep_b] : gen.get_chip_connections()) {
+        if (*ep_a.host_id == *ep_b.host_id) continue;
         auto a = *ep_a.host_id, b = *ep_b.host_id;
-        if (a == 0u || b == 0u) {
-            stale_connection_found = true;
-        }
-        if ((a == 1u && b == 2u) || (a == 2u && b == 1u)) {
-            n2_n3_connected = true;
-        }
+        if (a == 0u || b == 0u) stale = true;
+        if ((a == 1u && b == 2u) || (a == 2u && b == 1u)) n2_n3 = true;
     }
-    EXPECT_FALSE(stale_connection_found) << "n1 (host_id=0) must not appear in any inter-node connection";
-    EXPECT_TRUE(n2_n3_connected) << "n2 (host_id=1) and n3 (host_id=2) must be connected";
-}
+    EXPECT_FALSE(stale) << "n1 (id=0) must not appear in inter-node connections";
+    EXPECT_TRUE(n2_n3) << "n2 (id=1) and n3 (id=2) must be connected after remap";
 
-// Deployment file order is irrelevant - FSD hosts[i] must reflect DFS template order.
-TEST_F(MergeChildrenOrderTest, DeploymentOutOfOrder_SingleFile_FsdReflectsDfsOrder) {
-    auto base = create_test_dir("dep_ooo_single");
-    write_deployment(base + "dep.textproto", {"h3", "h2", "h1"});
-    write_flat_descriptor(base + "cabling.textproto", "root", {"h1", "h2", "h3"}, {2, 1, 0});
-
-    CablingGenerator gen(base + "cabling.textproto", base + "dep.textproto");
-    const auto fsd = gen.generate_factory_system_descriptor();
-
-    ASSERT_EQ(fsd.hosts().size(), 3);
-    EXPECT_EQ(fsd.hosts()[0].hostname(), "h1");
-    EXPECT_EQ(fsd.hosts()[1].hostname(), "h2");
-    EXPECT_EQ(fsd.hosts()[2].hostname(), "h3");
-}
-
-// Same as above but across a two-file merge with fully reversed deployment order.
-TEST_F(MergeChildrenOrderTest, DeploymentOutOfOrder_MergedFiles_FsdReflectsDfsOrder) {
-    auto base = create_test_dir("dep_ooo_merge");
-    std::string cdir = base + "c/";
-    std::filesystem::create_directories(cdir);
-    write_deployment(base + "dep.textproto", {"h4", "h3", "h2", "h1"});
-    write_flat_descriptor(cdir + "a.textproto", "root", {"h1", "h2"}, {3, 2});
-    write_flat_descriptor(cdir + "b.textproto", "root", {"h3", "h4"}, {1, 0});
-
-    CablingGenerator gen(cdir, base + "dep.textproto");
-    const auto fsd = gen.generate_factory_system_descriptor();
-
-    ASSERT_EQ(fsd.hosts().size(), 4);
-    EXPECT_EQ(fsd.hosts()[0].hostname(), "h1");
-    EXPECT_EQ(fsd.hosts()[1].hostname(), "h2");
-    EXPECT_EQ(fsd.hosts()[2].hostname(), "h3");
-    EXPECT_EQ(fsd.hosts()[3].hostname(), "h4");
-}
-
-// Both files declare connections; file B's local ids (0<->1) must become (2<->3) after merge.
-TEST_F(MergeChildrenOrderTest, BothFilesHaveConnections_PostMergeIdsCorrect) {
-    auto base = create_test_dir("both_connected");
-    std::string cdir = base + "c/";
-    std::filesystem::create_directories(cdir);
-    write_deployment(base + "dep.textproto", {"h1", "h2", "h3", "h4"});
-    write_textproto(cdir + "a.textproto", R"(
-graph_templates { key: "root" value {
-  children { name: "h1" node_ref { node_descriptor: "WH_GALAXY" } }
-  children { name: "h2" node_ref { node_descriptor: "WH_GALAXY" } }
-  internal_connections { key: "QSFP_DD" value {
-    connections {
-      port_a { path: ["h1"] tray_id: 1 port_id: 1 }
-      port_b { path: ["h2"] tray_id: 1 port_id: 1 }
-    }
-  }}
-}}
-root_instance { template_name: "root"
-  child_mappings { key: "h1" value { host_id: 0 } }
-  child_mappings { key: "h2" value { host_id: 1 } }
-}
-)");
-    write_textproto(cdir + "b.textproto", R"(
-graph_templates { key: "root" value {
-  children { name: "h3" node_ref { node_descriptor: "WH_GALAXY" } }
-  children { name: "h4" node_ref { node_descriptor: "WH_GALAXY" } }
-  internal_connections { key: "QSFP_DD" value {
-    connections {
-      port_a { path: ["h3"] tray_id: 1 port_id: 1 }
-      port_b { path: ["h4"] tray_id: 1 port_id: 1 }
-    }
-  }}
-}}
-root_instance { template_name: "root"
-  child_mappings { key: "h3" value { host_id: 0 } }
-  child_mappings { key: "h4" value { host_id: 1 } }
-}
-)");
-
-    CablingGenerator gen(cdir, base + "dep.textproto");
-    std::set<std::pair<uint32_t, uint32_t>> pairs;
-    for (const auto& [ep_a, ep_b] : gen.get_chip_connections()) {
-        if (*ep_a.host_id != *ep_b.host_id) {
-            pairs.insert({std::min(*ep_a.host_id, *ep_b.host_id), std::max(*ep_a.host_id, *ep_b.host_id)});
-        }
-    }
-    EXPECT_EQ(pairs, (std::set<std::pair<uint32_t, uint32_t>>{{0u, 1u}, {2u, 3u}}));
-}
-
-// File B's fan-out (h3->h4, h3->h5) must use post-merge ids after remapping.
-TEST_F(MergeChildrenOrderTest, FanOut_SecondFile_AllConnectionsRemapped) {
-    auto base = create_test_dir("fanout_second_file");
-    std::string cdir = base + "c/";
-    std::filesystem::create_directories(cdir);
-    write_deployment(base + "dep.textproto", {"h1", "h2", "h3", "h4", "h5"});
-    write_flat_descriptor(cdir + "a.textproto", "root", {"h1", "h2"}, {0, 1});
-    write_textproto(cdir + "b.textproto", R"(
-graph_templates { key: "root" value {
-  children { name: "h3" node_ref { node_descriptor: "WH_GALAXY" } }
-  children { name: "h4" node_ref { node_descriptor: "WH_GALAXY" } }
-  children { name: "h5" node_ref { node_descriptor: "WH_GALAXY" } }
-  internal_connections { key: "QSFP_DD" value {
-    connections {
-      port_a { path: ["h3"] tray_id: 1 port_id: 1 }
-      port_b { path: ["h4"] tray_id: 1 port_id: 1 }
-    }
-    connections {
-      port_a { path: ["h3"] tray_id: 1 port_id: 2 }
-      port_b { path: ["h5"] tray_id: 1 port_id: 1 }
-    }
-  }}
-}}
-root_instance { template_name: "root"
-  child_mappings { key: "h3" value { host_id: 0 } }
-  child_mappings { key: "h4" value { host_id: 1 } }
-  child_mappings { key: "h5" value { host_id: 2 } }
-}
-)");
-
-    CablingGenerator gen(cdir, base + "dep.textproto");
-    const auto fsd = gen.generate_factory_system_descriptor();
-    ASSERT_EQ(fsd.hosts().size(), 5);
-    EXPECT_EQ(fsd.hosts()[2].hostname(), "h3");
-
-    std::set<std::pair<uint32_t, uint32_t>> pairs;
-    for (const auto& [ep_a, ep_b] : gen.get_chip_connections()) {
-        if (*ep_a.host_id != *ep_b.host_id) {
-            pairs.insert({std::min(*ep_a.host_id, *ep_b.host_id), std::max(*ep_a.host_id, *ep_b.host_id)});
-        }
-    }
-    EXPECT_EQ(pairs, (std::set<std::pair<uint32_t, uint32_t>>{{2u, 3u}, {2u, 4u}}));
+    std::filesystem::remove_all(dir);
 }
 
 }  // namespace tt::scaleout_tools


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/37187

### Problem description
- When merging two cabling descriptors, nodes from the second file could be assigned incorrect host IDs or skipped entirely if `children_order` was not propagated during cloning and merge
- Internal connections stored as host ID tuples were not updated when temporary IDs were assigned during merge, silently linking the wrong nodes after reassignment
- Deployment descriptor file order incorrectly influenced the final host ID assignment instead of the template-defined DFS traversal order which is used by tt-cablegen tool and our approach ended up split-headed

### What's changed
- `merge_resolved_graph_instances` now iterates `source.children_order` in a single pass so mixed node/subgraph sequences are appended to `target.children_order` in template order; `clone_resolved_graph` also copies `children_order`
- `assign_temp_ids` in `merge()` is now two-pass: first remaps every node's host ID and records the mapping, then applies it to all `internal_connections` in the merged graph
- `rebuild_deployment_hosts_in_dfs_order` is introduced and called after both single-file load and multi-file merge, ensuring `deployment_hosts_[i]` always matches the DFS-assigned host ID regardless of deployment file line order

### Checklist

- [ ] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=jpanasiuk/host-id-reordering)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:jpanasiuk/host-id-reordering)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=jpanasiuk/host-id-reordering)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:jpanasiuk/host-id-reordering)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=jpanasiuk/host-id-reordering)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jpanasiuk/host-id-reordering)
- [ ] New/Existing tests provide coverage for changes
- [ ] (Optional) Ran [clang-tidy code analysis](https://github.com/tenstorrent/tt-metal/actions/workflows/code-analysis.yaml) on the PR branch to catch linting errors early