### PR TITLE
Propagating new unpack LLK for reduce ops

### DIFF
--- a/tests/tt_metal/tt_metal/test_kernels/compute/reduce_h.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/reduce_h.cpp
@@ -7,12 +7,20 @@
 #include "api/compute/reduce.h"
 #include "experimental/circular_buffer.h"
 
+#if (MATH_ONLY == 1) && (defined(TRISC_UNPACK))
+#include "llk_unpack_AB_api.h"
+#endif
+
 void kernel_main() {
     constexpr uint32_t Ht = get_compile_time_arg_val(0);
     constexpr uint32_t Wt = get_compile_time_arg_val(1);
     constexpr uint32_t NC = get_compile_time_arg_val(2);
     compute_kernel_hw_startup(tt::CBIndex::c_0, tt::CBIndex::c_2, tt::CBIndex::c_16);
     reduce_init(tt::CBIndex::c_0, tt::CBIndex::c_2, tt::CBIndex::c_16);
+
+#if (MATH_ONLY == 1)
+    UNPACK((llk_unpack_AB_reduce_init<REDUCE_DIM, BroadcastType::NONE, false>(tt::CBIndex::c_0, tt::CBIndex::c_2)));
+#endif
 
     experimental::CircularBuffer cb0(tt::CBIndex::c_0);
     experimental::CircularBuffer cb2(tt::CBIndex::c_2);
@@ -30,7 +38,7 @@ void kernel_main() {
             for (uint32_t ht = 0; ht < Ht; ++ht) {
                 cb0.wait_front(onetile);
 #if (MATH_ONLY == 1)
-                UNPACK((llk_unpack_AB_reduce(tt::CBIndex::c_0, tt::CBIndex::c_2, 0, 0)));
+                UNPACK((llk_unpack_AB(tt::CBIndex::c_0, tt::CBIndex::c_2, 0, 0)));
                 // REDUCE_OP is expected to come from add_define
                 reduce_tile_math(reduce_dst_idx);
 #elif (MATH_ONLY == 0)

--- a/tests/tt_metal/tt_metal/test_kernels/compute/reduce_h.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/reduce_h.cpp
@@ -7,20 +7,12 @@
 #include "api/compute/reduce.h"
 #include "experimental/circular_buffer.h"
 
-#if (MATH_ONLY == 1) && (defined(TRISC_UNPACK))
-#include "llk_unpack_AB_api.h"
-#endif
-
 void kernel_main() {
     constexpr uint32_t Ht = get_compile_time_arg_val(0);
     constexpr uint32_t Wt = get_compile_time_arg_val(1);
     constexpr uint32_t NC = get_compile_time_arg_val(2);
     compute_kernel_hw_startup(tt::CBIndex::c_0, tt::CBIndex::c_2, tt::CBIndex::c_16);
     reduce_init(tt::CBIndex::c_0, tt::CBIndex::c_2, tt::CBIndex::c_16);
-
-#if (MATH_ONLY == 1)
-    UNPACK((llk_unpack_AB_reduce_init<REDUCE_DIM, BroadcastType::NONE, false>(tt::CBIndex::c_0, tt::CBIndex::c_2)));
-#endif
 
     experimental::CircularBuffer cb0(tt::CBIndex::c_0);
     experimental::CircularBuffer cb2(tt::CBIndex::c_2);
@@ -38,7 +30,7 @@ void kernel_main() {
             for (uint32_t ht = 0; ht < Ht; ++ht) {
                 cb0.wait_front(onetile);
 #if (MATH_ONLY == 1)
-                UNPACK((llk_unpack_AB(tt::CBIndex::c_0, tt::CBIndex::c_2, 0, 0)));
+                UNPACK((llk_unpack_AB_reduce(tt::CBIndex::c_0, tt::CBIndex::c_2, 0, 0)));
                 // REDUCE_OP is expected to come from add_define
                 reduce_tile_math(reduce_dst_idx);
 #elif (MATH_ONLY == 0)

--- a/tests/tt_metal/tt_metal/test_kernels/compute/reduce_h.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/reduce_h.cpp
@@ -30,7 +30,7 @@ void kernel_main() {
             for (uint32_t ht = 0; ht < Ht; ++ht) {
                 cb0.wait_front(onetile);
 #if (MATH_ONLY == 1)
-                UNPACK((llk_unpack_AB(tt::CBIndex::c_0, tt::CBIndex::c_2, 0, 0)));
+                UNPACK((llk_unpack_AB_reduce(tt::CBIndex::c_0, tt::CBIndex::c_2, 0, 0)));
                 // REDUCE_OP is expected to come from add_define
                 reduce_tile_math(reduce_dst_idx);
 #elif (MATH_ONLY == 0)

--- a/tests/tt_metal/tt_metal/test_kernels/compute/reduce_hw.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/reduce_hw.cpp
@@ -7,20 +7,12 @@
 #include "api/compute/reduce.h"
 #include "experimental/circular_buffer.h"
 
-#if (MATH_ONLY == 1) && (defined(TRISC_UNPACK))
-#include "llk_unpack_AB_api.h"
-#endif
-
 void kernel_main() {
     constexpr uint32_t Ht = get_compile_time_arg_val(0);
     constexpr uint32_t Wt = get_compile_time_arg_val(1);
     constexpr uint32_t NC = get_compile_time_arg_val(2);
     compute_kernel_hw_startup(tt::CBIndex::c_0, tt::CBIndex::c_2, tt::CBIndex::c_16);
     reduce_init(tt::CBIndex::c_0, tt::CBIndex::c_2, tt::CBIndex::c_16);
-
-#if (MATH_ONLY == 1)
-    UNPACK((llk_unpack_AB_reduce_init<REDUCE_DIM, BroadcastType::NONE, false>(tt::CBIndex::c_0, tt::CBIndex::c_2)));
-#endif
 
     experimental::CircularBuffer cb0(tt::CBIndex::c_0);
     experimental::CircularBuffer cb2(tt::CBIndex::c_2);
@@ -38,7 +30,7 @@ void kernel_main() {
             for (uint32_t wt = 0; wt < Wt; ++wt) {
                 cb0.wait_front(onetile);
 #if (MATH_ONLY == 1)
-                UNPACK((llk_unpack_AB(tt::CBIndex::c_0, tt::CBIndex::c_2, 0, 0)));
+                UNPACK((llk_unpack_AB_reduce(tt::CBIndex::c_0, tt::CBIndex::c_2, 0, 0)));
                 // REDUCE_OP is expected to come from add_define
                 reduce_tile_math(reduce_dst_idx);
 #elif (MATH_ONLY == 0)

--- a/tests/tt_metal/tt_metal/test_kernels/compute/reduce_hw.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/reduce_hw.cpp
@@ -30,7 +30,7 @@ void kernel_main() {
             for (uint32_t wt = 0; wt < Wt; ++wt) {
                 cb0.wait_front(onetile);
 #if (MATH_ONLY == 1)
-                UNPACK((llk_unpack_AB(tt::CBIndex::c_0, tt::CBIndex::c_2, 0, 0)));
+                UNPACK((llk_unpack_AB_reduce(tt::CBIndex::c_0, tt::CBIndex::c_2, 0, 0)));
                 // REDUCE_OP is expected to come from add_define
                 reduce_tile_math(reduce_dst_idx);
 #elif (MATH_ONLY == 0)

--- a/tests/tt_metal/tt_metal/test_kernels/compute/reduce_hw.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/reduce_hw.cpp
@@ -7,12 +7,20 @@
 #include "api/compute/reduce.h"
 #include "experimental/circular_buffer.h"
 
+#if (MATH_ONLY == 1) && (defined(TRISC_UNPACK))
+#include "llk_unpack_AB_api.h"
+#endif
+
 void kernel_main() {
     constexpr uint32_t Ht = get_compile_time_arg_val(0);
     constexpr uint32_t Wt = get_compile_time_arg_val(1);
     constexpr uint32_t NC = get_compile_time_arg_val(2);
     compute_kernel_hw_startup(tt::CBIndex::c_0, tt::CBIndex::c_2, tt::CBIndex::c_16);
     reduce_init(tt::CBIndex::c_0, tt::CBIndex::c_2, tt::CBIndex::c_16);
+
+#if (MATH_ONLY == 1)
+    UNPACK((llk_unpack_AB_reduce_init<REDUCE_DIM, BroadcastType::NONE, false>(tt::CBIndex::c_0, tt::CBIndex::c_2)));
+#endif
 
     experimental::CircularBuffer cb0(tt::CBIndex::c_0);
     experimental::CircularBuffer cb2(tt::CBIndex::c_2);
@@ -30,7 +38,7 @@ void kernel_main() {
             for (uint32_t wt = 0; wt < Wt; ++wt) {
                 cb0.wait_front(onetile);
 #if (MATH_ONLY == 1)
-                UNPACK((llk_unpack_AB_reduce(tt::CBIndex::c_0, tt::CBIndex::c_2, 0, 0)));
+                UNPACK((llk_unpack_AB(tt::CBIndex::c_0, tt::CBIndex::c_2, 0, 0)));
                 // REDUCE_OP is expected to come from add_define
                 reduce_tile_math(reduce_dst_idx);
 #elif (MATH_ONLY == 0)

--- a/tests/tt_metal/tt_metal/test_kernels/compute/reduce_w.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/reduce_w.cpp
@@ -7,20 +7,12 @@
 #include "api/compute/reduce.h"
 #include "experimental/circular_buffer.h"
 
-#if (MATH_ONLY == 1) && (defined(TRISC_UNPACK))
-#include "llk_unpack_AB_api.h"
-#endif
-
 void kernel_main() {
     constexpr uint32_t Ht = get_compile_time_arg_val(0);
     constexpr uint32_t Wt = get_compile_time_arg_val(1);
     constexpr uint32_t NC = get_compile_time_arg_val(2);
     compute_kernel_hw_startup(tt::CBIndex::c_0, tt::CBIndex::c_2, tt::CBIndex::c_16);
     reduce_init(tt::CBIndex::c_0, tt::CBIndex::c_2, tt::CBIndex::c_16);
-
-#if (MATH_ONLY == 1)
-    UNPACK((llk_unpack_AB_reduce_init<REDUCE_DIM, BroadcastType::NONE, false>(tt::CBIndex::c_0, tt::CBIndex::c_2)));
-#endif
 
     experimental::CircularBuffer cb0(tt::CBIndex::c_0);
     experimental::CircularBuffer cb2(tt::CBIndex::c_2);
@@ -38,7 +30,7 @@ void kernel_main() {
             for (uint32_t wt = 0; wt < Wt; ++wt) {
                 cb0.wait_front(onetile);
 #if (MATH_ONLY == 1)
-                UNPACK((llk_unpack_AB(tt::CBIndex::c_0, tt::CBIndex::c_2, 0, 0)));
+                UNPACK((llk_unpack_AB_reduce(tt::CBIndex::c_0, tt::CBIndex::c_2, 0, 0)));
                 // REDUCE_OP is expected to come from add_define
                 reduce_tile_math(reduce_dst_idx);
 #elif (MATH_ONLY == 0)

--- a/tests/tt_metal/tt_metal/test_kernels/compute/reduce_w.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/reduce_w.cpp
@@ -30,7 +30,7 @@ void kernel_main() {
             for (uint32_t wt = 0; wt < Wt; ++wt) {
                 cb0.wait_front(onetile);
 #if (MATH_ONLY == 1)
-                UNPACK((llk_unpack_AB(tt::CBIndex::c_0, tt::CBIndex::c_2, 0, 0)));
+                UNPACK((llk_unpack_AB_reduce(tt::CBIndex::c_0, tt::CBIndex::c_2, 0, 0)));
                 // REDUCE_OP is expected to come from add_define
                 reduce_tile_math(reduce_dst_idx);
 #elif (MATH_ONLY == 0)

--- a/tests/tt_metal/tt_metal/test_kernels/compute/reduce_w.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/reduce_w.cpp
@@ -7,12 +7,20 @@
 #include "api/compute/reduce.h"
 #include "experimental/circular_buffer.h"
 
+#if (MATH_ONLY == 1) && (defined(TRISC_UNPACK))
+#include "llk_unpack_AB_api.h"
+#endif
+
 void kernel_main() {
     constexpr uint32_t Ht = get_compile_time_arg_val(0);
     constexpr uint32_t Wt = get_compile_time_arg_val(1);
     constexpr uint32_t NC = get_compile_time_arg_val(2);
     compute_kernel_hw_startup(tt::CBIndex::c_0, tt::CBIndex::c_2, tt::CBIndex::c_16);
     reduce_init(tt::CBIndex::c_0, tt::CBIndex::c_2, tt::CBIndex::c_16);
+
+#if (MATH_ONLY == 1)
+    UNPACK((llk_unpack_AB_reduce_init<REDUCE_DIM, BroadcastType::NONE, false>(tt::CBIndex::c_0, tt::CBIndex::c_2)));
+#endif
 
     experimental::CircularBuffer cb0(tt::CBIndex::c_0);
     experimental::CircularBuffer cb2(tt::CBIndex::c_2);
@@ -30,7 +38,7 @@ void kernel_main() {
             for (uint32_t wt = 0; wt < Wt; ++wt) {
                 cb0.wait_front(onetile);
 #if (MATH_ONLY == 1)
-                UNPACK((llk_unpack_AB_reduce(tt::CBIndex::c_0, tt::CBIndex::c_2, 0, 0)));
+                UNPACK((llk_unpack_AB(tt::CBIndex::c_0, tt::CBIndex::c_2, 0, 0)));
                 // REDUCE_OP is expected to come from add_define
                 reduce_tile_math(reduce_dst_idx);
 #elif (MATH_ONLY == 0)

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_math_reduce_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_math_reduce_api.h
@@ -16,8 +16,7 @@ template <
     bool is_fp32_dest_acc_en,
     MathFidelity math_fidelity,
     bool is_int_fpu_en = false,
-    bool enforce_fp32_accumulation = false,
-    bool tilize_AB_support_en = true>
+    bool enforce_fp32_accumulation = false>
 inline void llk_math_reduce(const uint dst_index, const uint num_faces = 4) {
     _llk_math_reduce_<type, dim, is_fp32_dest_acc_en, math_fidelity, is_int_fpu_en, enforce_fp32_accumulation>(
         dst_index, false, num_faces);
@@ -29,8 +28,7 @@ template <
     bool is_fp32_dest_acc_en,
     MathFidelity math_fidelity,
     bool is_int_fpu_en = false,
-    bool enforce_fp32_accumulation = false,
-    bool tilize_AB_support_en = true>
+    bool enforce_fp32_accumulation = false>
 inline void llk_math_reduce(const std::uint32_t operandA, const std::uint32_t operandB, const std::uint32_t dst_index) {
     const std::uint32_t operand_id = get_operand_id(operandA);
     const std::uint32_t num_faces = get_operand_num_faces(operand_id);

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_math_reduce_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_math_reduce_api.h
@@ -16,7 +16,8 @@ template <
     bool is_fp32_dest_acc_en,
     MathFidelity math_fidelity,
     bool is_int_fpu_en = false,
-    bool enforce_fp32_accumulation = false>
+    bool enforce_fp32_accumulation = false,
+    bool tilize_AB_support_en = true>
 inline void llk_math_reduce(const uint dst_index, const uint num_faces = 4) {
     _llk_math_reduce_<type, dim, is_fp32_dest_acc_en, math_fidelity, is_int_fpu_en, enforce_fp32_accumulation>(
         dst_index, false, num_faces);
@@ -28,7 +29,8 @@ template <
     bool is_fp32_dest_acc_en,
     MathFidelity math_fidelity,
     bool is_int_fpu_en = false,
-    bool enforce_fp32_accumulation = false>
+    bool enforce_fp32_accumulation = false,
+    bool tilize_AB_support_en = true>
 inline void llk_math_reduce(const std::uint32_t operandA, const std::uint32_t operandB, const std::uint32_t dst_index) {
     const std::uint32_t operand_id = get_operand_id(operandA);
     const std::uint32_t num_faces = get_operand_num_faces(operand_id);

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_AB_reduce_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_AB_reduce_api.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2026 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_AB_reduce_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_AB_reduce_api.h
@@ -1,0 +1,52 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+#include "llk_unpack_AB_reduce.h"
+#include "llk_unpack_common_api.h"
+
+/*************************************************************************
+ * LLK UNPACK AB REDUCE
+ *************************************************************************/
+
+template <PoolType pool_type, ReduceDim reduce_dim>
+inline void llk_unpack_AB_reduce_mop_config(const std::uint32_t operand_id = 0) {
+    const std::uint32_t face_r_dim = get_operand_face_r_dim(operand_id);
+    const std::uint32_t num_faces = get_operand_num_faces(operand_id);
+    _llk_unpack_AB_reduce_mop_config_<pool_type, reduce_dim>(face_r_dim, num_faces);
+}
+
+template <PoolType pool_type, ReduceDim reduce_dim, bool enforce_fp32_accumulation = false>
+inline void llk_unpack_AB_reduce_init(const std::uint32_t operandA, const std::uint32_t operandB) {
+    const std::uint32_t operandA_id = get_operand_id(operandA);
+    const std::uint32_t face_r_dim = get_operand_face_r_dim(operandA_id);  // face_r_d for srcA
+    const std::uint32_t num_faces = get_operand_num_faces(operandA_id);
+
+    if constexpr (enforce_fp32_accumulation) {
+        // Set necessary config regs for MOVB2D hi16/lo16 to work
+        _llk_unpack_dbg_feature_disable_();
+        cfg_reg_rmw_tensix<ALU_ACC_CTRL_Zero_Flag_disabled_src_RMW>(1);
+    }
+    _llk_unpack_AB_reduce_init_<pool_type, reduce_dim>(face_r_dim, num_faces);
+}
+
+template <PoolType pool_type = REDUCE_OP, ReduceDim reduce_dim = REDUCE_DIM>
+inline void llk_unpack_AB_reduce(
+    const std::uint32_t operandA,
+    const std::uint32_t operandB,
+    const std::uint32_t tile_index_a,
+    const std::uint32_t tile_index_b) {
+    std::uint32_t operandA_id = get_operand_id(operandA);
+    std::uint32_t operandB_id = get_operand_id(operandB);
+    std::uint32_t base_address_a = get_local_cb_interface(operandA_id).fifo_rd_ptr - 1;
+    std::uint32_t offset_address_a = get_local_cb_interface(operandA_id).fifo_page_size * tile_index_a;
+    std::uint32_t address_a = base_address_a + offset_address_a;
+    std::uint32_t base_address_b = get_local_cb_interface(operandB_id).fifo_rd_ptr - 1;
+    std::uint32_t offset_address_b = get_local_cb_interface(operandB_id).fifo_page_size * tile_index_b;
+    std::uint32_t address_b = base_address_b + offset_address_b;
+
+    WAYPOINT("UABW");
+    _llk_unpack_AB_reduce_<pool_type, reduce_dim>(address_a, address_b);
+    WAYPOINT("UABD");
+}

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_AB_reduce_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_AB_reduce_api.h
@@ -20,15 +20,15 @@ inline void llk_unpack_AB_reduce_mop_config(const std::uint32_t operand_id = 0) 
 template <PoolType pool_type, ReduceDim reduce_dim, bool enforce_fp32_accumulation = false>
 inline void llk_unpack_AB_reduce_init(const std::uint32_t operandA, const std::uint32_t operandB) {
     const std::uint32_t operandA_id = get_operand_id(operandA);
-    const std::uint32_t face_r_dim = get_operand_face_r_dim(operandA_id);  // face_r_d for srcA
+    const std::uint32_t face_r_dim = get_operand_face_r_dim(operandA_id);
     const std::uint32_t num_faces = get_operand_num_faces(operandA_id);
 
     if constexpr (enforce_fp32_accumulation) {
         // Set necessary config regs for MOVB2D hi16/lo16 to work
         _llk_unpack_dbg_feature_disable_();
-        cfg_reg_rmw_tensix<ALU_ACC_CTRL_Zero_Flag_disabled_src_RMW>(1);
     }
-    _llk_unpack_AB_reduce_init_<pool_type, reduce_dim>(face_r_dim, num_faces);
+
+    _llk_unpack_AB_reduce_init_<pool_type, reduce_dim, enforce_fp32_accumulation>(face_r_dim, num_faces);
 }
 
 template <PoolType pool_type = REDUCE_OP, ReduceDim reduce_dim = REDUCE_DIM>

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_math_reduce_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_math_reduce_api.h
@@ -16,8 +16,7 @@ template <
     bool is_fp32_dest_acc_en,
     MathFidelity math_fidelity,
     bool is_int_fpu_en = false,
-    bool enforce_fp32_accumulation = false,
-    bool tilize_AB_support_en = true>
+    bool enforce_fp32_accumulation = false>
 inline void llk_math_reduce(const uint dst_index, const uint num_faces = 4) {
     _llk_math_reduce_<type, dim, is_fp32_dest_acc_en, math_fidelity, is_int_fpu_en, enforce_fp32_accumulation>(
         dst_index, false, num_faces);
@@ -29,8 +28,7 @@ template <
     bool is_fp32_dest_acc_en,
     MathFidelity math_fidelity,
     bool is_int_fpu_en = false,
-    bool enforce_fp32_accumulation = false,
-    bool tilize_AB_support_en = true>
+    bool enforce_fp32_accumulation = false>
 inline void llk_math_reduce(const std::uint32_t operandA, const std::uint32_t operandB, const std::uint32_t dst_index) {
     const std::uint32_t operand_id = get_operand_id(operandA);  // both operands must have same number of faces
     const std::uint32_t num_faces = get_operand_num_faces(operand_id);

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_math_reduce_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_math_reduce_api.h
@@ -16,7 +16,8 @@ template <
     bool is_fp32_dest_acc_en,
     MathFidelity math_fidelity,
     bool is_int_fpu_en = false,
-    bool enforce_fp32_accumulation = false>
+    bool enforce_fp32_accumulation = false,
+    bool tilize_AB_support_en = true>
 inline void llk_math_reduce(const uint dst_index, const uint num_faces = 4) {
     _llk_math_reduce_<type, dim, is_fp32_dest_acc_en, math_fidelity, is_int_fpu_en, enforce_fp32_accumulation>(
         dst_index, false, num_faces);
@@ -28,7 +29,8 @@ template <
     bool is_fp32_dest_acc_en,
     MathFidelity math_fidelity,
     bool is_int_fpu_en = false,
-    bool enforce_fp32_accumulation = false>
+    bool enforce_fp32_accumulation = false,
+    bool tilize_AB_support_en = true>
 inline void llk_math_reduce(const std::uint32_t operandA, const std::uint32_t operandB, const std::uint32_t dst_index) {
     const std::uint32_t operand_id = get_operand_id(operandA);  // both operands must have same number of faces
     const std::uint32_t num_faces = get_operand_num_faces(operand_id);

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_AB_reduce_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_AB_reduce_api.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2026 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_AB_reduce_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_AB_reduce_api.h
@@ -1,0 +1,52 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+#include "llk_unpack_AB_reduce.h"
+#include "llk_unpack_common_api.h"
+
+/*************************************************************************
+ * LLK UNPACK AB REDUCE
+ *************************************************************************/
+
+template <PoolType pool_type, ReduceDim reduce_dim>
+inline void llk_unpack_AB_reduce_mop_config(const std::uint32_t operand_id = 0) {
+    const std::uint32_t face_r_dim = get_operand_face_r_dim(operand_id);
+    const std::uint32_t num_faces = get_operand_num_faces(operand_id);
+    _llk_unpack_AB_reduce_mop_config_<pool_type, reduce_dim>(face_r_dim, num_faces);
+}
+
+template <PoolType pool_type, ReduceDim reduce_dim, bool enforce_fp32_accumulation = false>
+inline void llk_unpack_AB_reduce_init(const std::uint32_t operandA, const std::uint32_t operandB) {
+    const std::uint32_t operandA_id = get_operand_id(operandA);
+    const std::uint32_t face_r_dim = get_operand_face_r_dim(operandA_id);  // face_r_d for srcA
+    const std::uint32_t num_faces = get_operand_num_faces(operandA_id);
+
+    if constexpr (enforce_fp32_accumulation) {
+        // Set necessary config regs for MOVB2D hi16/lo16 to work
+        _llk_unpack_dbg_feature_disable_();
+        cfg_reg_rmw_tensix<ALU_ACC_CTRL_Zero_Flag_disabled_src_RMW>(1);
+    }
+    _llk_unpack_AB_reduce_init_<pool_type, reduce_dim>(face_r_dim, num_faces);
+}
+
+template <PoolType pool_type = REDUCE_OP, ReduceDim reduce_dim = REDUCE_DIM>
+inline void llk_unpack_AB_reduce(
+    const std::uint32_t operandA,
+    const std::uint32_t operandB,
+    const std::uint32_t tile_index_a,
+    const std::uint32_t tile_index_b) {
+    std::uint32_t operandA_id = get_operand_id(operandA);
+    std::uint32_t operandB_id = get_operand_id(operandB);
+    std::uint32_t base_address_a = get_local_cb_interface(operandA_id).fifo_rd_ptr - 1;
+    std::uint32_t offset_address_a = get_local_cb_interface(operandA_id).fifo_page_size * tile_index_a;
+    std::uint32_t address_a = base_address_a + offset_address_a;
+    std::uint32_t base_address_b = get_local_cb_interface(operandB_id).fifo_rd_ptr - 1;
+    std::uint32_t offset_address_b = get_local_cb_interface(operandB_id).fifo_page_size * tile_index_b;
+    std::uint32_t address_b = base_address_b + offset_address_b;
+
+    WAYPOINT("UABW");
+    _llk_unpack_AB_reduce_<pool_type, reduce_dim>(address_a, address_b);
+    WAYPOINT("UABD");
+}

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_AB_reduce_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_AB_reduce_api.h
@@ -20,15 +20,15 @@ inline void llk_unpack_AB_reduce_mop_config(const std::uint32_t operand_id = 0) 
 template <PoolType pool_type, ReduceDim reduce_dim, bool enforce_fp32_accumulation = false>
 inline void llk_unpack_AB_reduce_init(const std::uint32_t operandA, const std::uint32_t operandB) {
     const std::uint32_t operandA_id = get_operand_id(operandA);
-    const std::uint32_t face_r_dim = get_operand_face_r_dim(operandA_id);  // face_r_d for srcA
+    const std::uint32_t face_r_dim = get_operand_face_r_dim(operandA_id);
     const std::uint32_t num_faces = get_operand_num_faces(operandA_id);
 
     if constexpr (enforce_fp32_accumulation) {
         // Set necessary config regs for MOVB2D hi16/lo16 to work
         _llk_unpack_dbg_feature_disable_();
-        cfg_reg_rmw_tensix<ALU_ACC_CTRL_Zero_Flag_disabled_src_RMW>(1);
     }
-    _llk_unpack_AB_reduce_init_<pool_type, reduce_dim>(face_r_dim, num_faces);
+
+    _llk_unpack_AB_reduce_init_<pool_type, reduce_dim, enforce_fp32_accumulation>(face_r_dim, num_faces);
 }
 
 template <PoolType pool_type = REDUCE_OP, ReduceDim reduce_dim = REDUCE_DIM>

--- a/tt_metal/hw/inc/api/compute/reduce.h
+++ b/tt_metal/hw/inc/api/compute/reduce.h
@@ -120,14 +120,8 @@ ALWI void reduce_uninit(uint32_t icb = 0) {
 // clang-format on
 template <PoolType reduce_type = REDUCE_OP, ReduceDim reduce_dim = REDUCE_DIM, bool enforce_fp32_accumulation = false>
 ALWI void reduce_tile(uint32_t icb, uint32_t icb_scaler, uint32_t itile, uint32_t itile_scaler, uint32_t idst) {
-    MATH((llk_math_reduce<
-          reduce_type,
-          reduce_dim,
-          DST_ACCUM_MODE,
-          MATH_FIDELITY,
-          false,
-          enforce_fp32_accumulation,
-          false /* tilize_AB_support_en */>(icb, icb_scaler, idst)));
+    MATH((llk_math_reduce<reduce_type, reduce_dim, DST_ACCUM_MODE, MATH_FIDELITY, false, enforce_fp32_accumulation>(
+        icb, icb_scaler, idst)));
     UNPACK((llk_unpack_AB_reduce<reduce_type, reduce_dim>(icb, icb_scaler, itile, itile_scaler)));
 }
 
@@ -146,13 +140,7 @@ ALWI void reduce_tile(uint32_t icb, uint32_t icb_scaler, uint32_t itile, uint32_
 // clang-format on
 template <PoolType reduce_type = REDUCE_OP, ReduceDim reduce_dim = REDUCE_DIM, bool enforce_fp32_accumulation = false>
 ALWI void reduce_tile_math(uint32_t idst, uint32_t num_faces = 4) {
-    MATH((llk_math_reduce<
-          reduce_type,
-          reduce_dim,
-          DST_ACCUM_MODE,
-          MATH_FIDELITY,
-          false,
-          enforce_fp32_accumulation,
-          true /* tilize_AB_support_en */>(idst, num_faces)));
+    MATH((llk_math_reduce<reduce_type, reduce_dim, DST_ACCUM_MODE, MATH_FIDELITY, false, enforce_fp32_accumulation>(
+        idst, num_faces)));
 }
 }  // namespace ckernel

--- a/tt_metal/hw/inc/api/compute/reduce.h
+++ b/tt_metal/hw/inc/api/compute/reduce.h
@@ -120,8 +120,14 @@ ALWI void reduce_uninit(uint32_t icb = 0) {
 // clang-format on
 template <PoolType reduce_type = REDUCE_OP, ReduceDim reduce_dim = REDUCE_DIM, bool enforce_fp32_accumulation = false>
 ALWI void reduce_tile(uint32_t icb, uint32_t icb_scaler, uint32_t itile, uint32_t itile_scaler, uint32_t idst) {
-    MATH((llk_math_reduce<reduce_type, reduce_dim, DST_ACCUM_MODE, MATH_FIDELITY, false, enforce_fp32_accumulation>(
-        icb, icb_scaler, idst)));
+    MATH((llk_math_reduce<
+          reduce_type,
+          reduce_dim,
+          DST_ACCUM_MODE,
+          MATH_FIDELITY,
+          false,
+          enforce_fp32_accumulation,
+          false /* tilize_AB_support_en */>(icb, icb_scaler, idst)));
     UNPACK((llk_unpack_AB_reduce<reduce_type, reduce_dim>(icb, icb_scaler, itile, itile_scaler)));
 }
 
@@ -140,7 +146,13 @@ ALWI void reduce_tile(uint32_t icb, uint32_t icb_scaler, uint32_t itile, uint32_
 // clang-format on
 template <PoolType reduce_type = REDUCE_OP, ReduceDim reduce_dim = REDUCE_DIM, bool enforce_fp32_accumulation = false>
 ALWI void reduce_tile_math(uint32_t idst, uint32_t num_faces = 4) {
-    MATH((llk_math_reduce<reduce_type, reduce_dim, DST_ACCUM_MODE, MATH_FIDELITY, false, enforce_fp32_accumulation>(
-        idst, num_faces)));
+    MATH((llk_math_reduce<
+          reduce_type,
+          reduce_dim,
+          DST_ACCUM_MODE,
+          MATH_FIDELITY,
+          false,
+          enforce_fp32_accumulation,
+          true /* tilize_AB_support_en */>(idst, num_faces)));
 }
 }  // namespace ckernel

--- a/tt_metal/hw/inc/api/compute/reduce.h
+++ b/tt_metal/hw/inc/api/compute/reduce.h
@@ -11,7 +11,7 @@
 #endif
 
 #ifdef TRISC_UNPACK
-#include "llk_unpack_AB_api.h"
+#include "llk_unpack_AB_reduce_api.h"
 #endif
 
 namespace ckernel {
@@ -49,7 +49,7 @@ namespace ckernel {
 template <PoolType reduce_type = REDUCE_OP, ReduceDim reduce_dim = REDUCE_DIM, bool enforce_fp32_accumulation = false>
 ALWI void reduce_init(uint32_t icb, uint32_t icb_scaler, uint32_t ocb, uint32_t call_line = __builtin_LINE()) {
     state_configure(icb, icb_scaler, ocb, call_line);
-    UNPACK((llk_unpack_AB_reduce_init<reduce_dim, BroadcastType::NONE, enforce_fp32_accumulation>(icb, icb_scaler)));
+    UNPACK((llk_unpack_AB_reduce_init<reduce_type, reduce_dim, enforce_fp32_accumulation>(icb, icb_scaler)));
     MATH((llk_math_reduce_init<reduce_type, reduce_dim, DST_ACCUM_MODE, MATH_FIDELITY, enforce_fp32_accumulation>()));
     PACK((llk_pack_reduce_mask_config<false /*untilize*/, reduce_dim>()));
 }
@@ -122,7 +122,7 @@ template <PoolType reduce_type = REDUCE_OP, ReduceDim reduce_dim = REDUCE_DIM, b
 ALWI void reduce_tile(uint32_t icb, uint32_t icb_scaler, uint32_t itile, uint32_t itile_scaler, uint32_t idst) {
     MATH((llk_math_reduce<reduce_type, reduce_dim, DST_ACCUM_MODE, MATH_FIDELITY, false, enforce_fp32_accumulation>(
         icb, icb_scaler, idst)));
-    UNPACK((llk_unpack_AB(icb, icb_scaler, itile, itile_scaler)));
+    UNPACK((llk_unpack_AB_reduce<reduce_type, reduce_dim>(icb, icb_scaler, itile, itile_scaler)));
 }
 
 // clang-format off


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-llk/issues/1096
https://github.com/tenstorrent/tt-metal/issues/35356

Accompanying TT-LLK PR: https://github.com/tenstorrent/tt-llk/pull/1240

### Problem description
llk_math_reduce.h used llk_unpack_AB.h for unpacking data for reduce operations. This unpack kernel can be optimized for reduce operations because only 1 vector is needed to be unpacked for SrcB. The unpacker also needs to be updated to support tiny-tiles and padding values depending on the pool operations.

### What's changed
For tt-metal, everything should be almost exactly the same except only 1x16 vector is needed to be populated for SrcB matrix when using reduce_(init/tile).
- Updated function calls (unpack_AB -> unpack_AB_reduce) in reduce.h and all test_reduce tests
- Added unpack_AB_reduce_api.h for WH/BH

### Checklist

- [x] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=gdsingh/new-unpack-for-reduce-llk-1096)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:gdsingh/new-unpack-for-reduce-llk-1096)
- [x] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=gdsingh/new-unpack-for-reduce-llk-1096)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:gdsingh/new-unpack-for-reduce-llk-1096)
- [x] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=gdsingh/new-unpack-for-reduce-llk-1096)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:gdsingh/new-unpack-for-reduce-llk-1096)
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=gdsingh/new-unpack-for-reduce-llk-1096)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:gdsingh/new-unpack-for-reduce-llk-1096)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=gdsingh/new-unpack-for-reduce-llk-1096)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:gdsingh/new-unpack-for-reduce-llk-1096)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=gdsingh/new-unpack-for-reduce-llk-1096)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:gdsingh/new-unpack-for-reduce-llk-1096)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
