### PR TITLE
Extend CB tests

### DIFF
--- a/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_dataflow_cb.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_dataflow_cb.cpp
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "common/device_fixture.hpp"
+#include "mesh_dispatch_fixture.hpp"
 
 #include <chrono>
 #include <cstdint>

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_dataflow_cb.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_dataflow_cb.cpp
@@ -17,6 +17,8 @@
 using namespace tt;
 using namespace tt::tt_metal;
 
+// Tests dataflow through CBs at indices 0, 8, 16, ... and topmost CB
+// Validates data integrity: DRAM -> Reader -> CB -> Writer -> DRAM (src == dst)
 TEST_F(MeshDispatchFixture, DataflowCb) {
     auto mesh_device = devices_[0];
     IDevice* dev = mesh_device->get_devices()[0];
@@ -24,9 +26,26 @@ TEST_F(MeshDispatchFixture, DataflowCb) {
 
     CoreCoord core = {0, 0};
 
-    uint32_t single_tile_size = 2 * 1024;
-    uint32_t num_tiles = 1800;
-    uint32_t dram_buffer_size = single_tile_size * num_tiles;
+    // Tile configuration
+    constexpr uint32_t single_tile_size = 2 * 1024;
+    constexpr uint32_t cb_capacity_tiles = 8;
+    constexpr uint32_t tiles_to_transfer_per_cb = 200;
+    constexpr uint32_t reader_ublock_size = 2;
+    constexpr uint32_t writer_ublock_size = 4;
+
+    static_assert(
+        tiles_to_transfer_per_cb % writer_ublock_size == 0,
+        "tiles_to_transfer_per_cb must be divisible by writer_ublock_size");
+
+    // CB index configuration
+    constexpr uint32_t start_cb = 0;
+    constexpr uint32_t stride = 8;
+    const uint32_t strided_cb_count = max_cbs_ / stride;  // CBs at 0, 8, 16, ...
+    const uint32_t topmost_cb = max_cbs_ - 1;
+    const uint32_t total_cbs = strided_cb_count + 1;  // Strided + topmost
+
+    const uint32_t num_tiles = tiles_to_transfer_per_cb * total_cbs;
+    const uint32_t dram_buffer_size = single_tile_size * num_tiles;
 
     InterleavedBufferConfig dram_config{
         .device = dev, .size = dram_buffer_size, .page_size = dram_buffer_size, .buffer_type = BufferType::DRAM};
@@ -36,32 +55,22 @@ TEST_F(MeshDispatchFixture, DataflowCb) {
     auto dst_dram_buffer = CreateBuffer(dram_config);
     uint32_t dram_buffer_dst_addr = dst_dram_buffer->address();
 
-    const uint32_t start_cb = 0;
-    const uint32_t stride = 8;
-    const uint32_t num_cbs_stride = (max_cbs_ / stride);
-    const uint32_t topmost_cb = max_cbs_ - 1;
-
-    const uint32_t total_cbs = num_cbs_stride + 1;
-    ASSERT_EQ(num_tiles % total_cbs, 0) << "num_tiles must be divisible by total CBs";
-    uint32_t num_tiles_per_cb = num_tiles / total_cbs;
-    uint32_t num_cb_tiles = 8;
-
     auto create_cb = [&](uint32_t cb_index) {
         CircularBufferConfig cb_config =
-            CircularBufferConfig(num_cb_tiles * single_tile_size, {{cb_index, tt::DataFormat::Float16_b}})
+            CircularBufferConfig(cb_capacity_tiles * single_tile_size, {{cb_index, tt::DataFormat::Float16_b}})
                 .set_page_size(cb_index, single_tile_size);
         CreateCircularBuffer(program, core, cb_config);
     };
 
     // Create CBs at 0, 8, 16, ...
-    for (uint32_t cb_idx = 0; cb_idx < max_cbs_; cb_idx += 8) {
+    for (uint32_t cb_idx = 0; cb_idx < max_cbs_; cb_idx += stride) {
         create_cb(cb_idx);
     }
     // Also test topmost
     create_cb(topmost_cb);
 
-    std::vector<uint32_t> reader_cb_kernel_args = {start_cb, num_cbs_stride, stride, topmost_cb, 2};
-    std::vector<uint32_t> writer_cb_kernel_args = {start_cb, num_cbs_stride, stride, topmost_cb, 4};
+    std::vector<uint32_t> reader_cb_compile_args = {start_cb, strided_cb_count, stride, topmost_cb, reader_ublock_size};
+    std::vector<uint32_t> writer_cb_compile_args = {start_cb, strided_cb_count, stride, topmost_cb, writer_ublock_size};
 
     auto reader_cb_kernel = CreateKernel(
         program,
@@ -70,7 +79,7 @@ TEST_F(MeshDispatchFixture, DataflowCb) {
         DataMovementConfig{
             .processor = DataMovementProcessor::RISCV_1,
             .noc = NOC::RISCV_1_default,
-            .compile_args = reader_cb_kernel_args});
+            .compile_args = reader_cb_compile_args});
 
     auto writer_cb_kernel = CreateKernel(
         program,
@@ -79,15 +88,14 @@ TEST_F(MeshDispatchFixture, DataflowCb) {
         DataMovementConfig{
             .processor = DataMovementProcessor::RISCV_0,
             .noc = NOC::RISCV_0_default,
-            .compile_args = writer_cb_kernel_args});
+            .compile_args = writer_cb_compile_args});
 
-    // Execute
     std::vector<uint32_t> src_vec = create_random_vector_of_bfloat16(
         dram_buffer_size, 100, std::chrono::system_clock::now().time_since_epoch().count());
     detail::WriteToBuffer(src_dram_buffer, src_vec);
 
-    SetRuntimeArgs(program, reader_cb_kernel, core, {dram_buffer_src_addr, 0, (uint32_t)num_tiles_per_cb});
-    SetRuntimeArgs(program, writer_cb_kernel, core, {dram_buffer_dst_addr, 0, (uint32_t)num_tiles_per_cb});
+    SetRuntimeArgs(program, reader_cb_kernel, core, {dram_buffer_src_addr, 0, tiles_to_transfer_per_cb});
+    SetRuntimeArgs(program, writer_cb_kernel, core, {dram_buffer_dst_addr, 0, tiles_to_transfer_per_cb});
 
     // Execute
     distributed::MeshWorkload workload;

--- a/tests/tt_metal/tt_metal/dispatch/sources.cmake
+++ b/tests/tt_metal/tt_metal/dispatch/sources.cmake
@@ -16,6 +16,7 @@ set(UNIT_TESTS_DISPATCH_BASIC_SOURCES
     dispatch_buffer/test_sub_device.cpp
     dispatch_buffer/test_BufferCorePageMapping_Iterator.cpp
     dispatch_program/test_dispatch.cpp
+    dispatch_program/test_dataflow_cb.cpp
     dispatch_program/test_global_circular_buffers.cpp
     dispatch_trace/test_sub_device.cpp
     dispatch_util/test_ringbuffer_cache.cpp

--- a/tests/tt_metal/tt_metal/sources.cmake
+++ b/tests/tt_metal/tt_metal/sources.cmake
@@ -12,7 +12,6 @@ set(UNIT_TESTS_LEGACY_SRC
     test_datacopy.cpp
     test_datacopy_bfp8b.cpp
     test_datacopy_output_in_l1.cpp
-    test_dataflow_cb.cpp
     test_dm_loopback.cpp
     test_dram_copy_sticks_multi_core.cpp
     test_dram_loopback_single_core.cpp

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/writer_cb_test.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/writer_cb_test.cpp
@@ -36,11 +36,22 @@ void kernel_main() {
     std::uint32_t bank_id               = get_arg_val<uint32_t>(1);
     std::uint32_t num_tiles_per_cb      = get_arg_val<uint32_t>(2);
 
-    constexpr uint32_t cb_id = get_compile_time_arg_val(0);
-    constexpr uint32_t ublock_size_tiles = get_compile_time_arg_val(1);
+    constexpr uint32_t start_cb = get_compile_time_arg_val(0);
+    constexpr uint32_t num_cbs_stride = get_compile_time_arg_val(1);
+    constexpr uint32_t stride = get_compile_time_arg_val(2);
+    constexpr uint32_t topmost_cb = get_compile_time_arg_val(3);
+    constexpr uint32_t ublock_size_tiles = get_compile_time_arg_val(4);
 
-    experimental::CircularBuffer cb(cb_id);
+    // Process strided CBs: 0, 8, 16, ...
+    for (uint32_t i = 0; i < num_cbs_stride; i++) {
+        uint32_t cb_id = start_cb + i * stride;
+        experimental::CircularBuffer cb(cb_id);
+        uint32_t ublock_size_bytes = cb.get_tile_size() * ublock_size_tiles;
+        pop_from_cb_and_write(
+            cb, num_tiles_per_cb, ublock_size_tiles, ublock_size_bytes, bank_id, dram_buffer_dst_addr);
+    }
+    // Process topmost CB
+    experimental::CircularBuffer cb(topmost_cb);
     uint32_t ublock_size_bytes = cb.get_tile_size() * ublock_size_tiles;
-
     pop_from_cb_and_write(cb, num_tiles_per_cb, ublock_size_tiles, ublock_size_bytes, bank_id, dram_buffer_dst_addr);
 }


### PR DESCRIPTION
### Ticket
NA

### Problem description
The CB dataflow test (`test_dataflow_cb.cpp`) was hardcoded to only test 4 CBs at indices 0, 8, 16, 24. Blackhole supports 64 CBs, and this extended range wasn't being tested.


### What's changed
- Extended Tests CBs to use CB indices at stride of 8 (0, 8, 16, ...) plus topmost CB
- Updated reader/writer kernels to loop through multiple CBs
- Moved test from `unit_tests_legacy` to `unit_tests_dispatch`
- Switched fixture to `MeshDispatchFixture` for fast/slow dispatch support

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=snadkarni/extend_dataflow_to_max_cbs)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:snadkarni/extend_dataflow_to_max_cbs)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=snadkarni/extend_dataflow_to_max_cbs)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:snadkarni/extend_dataflow_to_max_cbs)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=snadkarni/extend_dataflow_to_max_cbs)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:snadkarni/extend_dataflow_to_max_cbs)
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=snadkarni/extend_dataflow_to_max_cbs)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:snadkarni/extend_dataflow_to_max_cbs)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=snadkarni/extend_dataflow_to_max_cbs)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:snadkarni/extend_dataflow_to_max_cbs)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=snadkarni/extend_dataflow_to_max_cbs)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:snadkarni/extend_dataflow_to_max_cbs)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
