### PR TITLE
Fix various problems seen in test_prefetcher and test_dispatcher

### DIFF
--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_dispatcher.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_dispatcher.cpp
@@ -462,8 +462,8 @@ public:
         // the payload + header + sub-commands must fit within the dispatch buffer page size
         while (remaining_bytes > payload_unit) {
             // Generate random transfer size
-            uint32_t xfer_size_bytes =
-                payload_generator_->get_random_size(dispatch_buffer_page_size_ / payload_unit, payload_unit, remaining_bytes);
+            uint32_t xfer_size_bytes = payload_generator_->get_random_size(
+                dispatch_buffer_page_size_ / payload_unit, payload_unit, remaining_bytes);
 
             // Random no_stride flag
             bool no_stride = payload_generator_->get_rand_bool();
@@ -472,7 +472,12 @@ public:
             if (no_stride) {
                 const uint32_t max_allowed = dispatch_buffer_page_size_ - sizeof(CQDispatchCmd) - sub_cmds_bytes;
                 if (xfer_size_bytes > max_allowed) {
-                    log_warning(tt::LogTest, "Clamping packed_write cmd w/ no_stride to fit dispatch page, max allowed: {}, xfer_size_bytes: {}", max_allowed, xfer_size_bytes);
+                    log_warning(
+                        tt::LogTest,
+                        "Clamping packed_write cmd w/ no_stride to fit dispatch page, max allowed: {}, "
+                        "xfer_size_bytes: {}",
+                        max_allowed,
+                        xfer_size_bytes);
                     xfer_size_bytes = max_allowed;
                 }
             }
@@ -488,7 +493,11 @@ public:
 
             // Generate payload
             std::vector<uint32_t> payload = payload_generator_->generate_payload_with_core(fw, xfer_size_bytes);
-            TT_FATAL(payload.size() > 0, "Generated payload size is 0, xfer_size_bytes: {}, prev_xfer_size_bytes: {}", xfer_size_bytes, prev_xfer_size_bytes);
+            TT_FATAL(
+                payload.size() > 0,
+                "Generated payload size is 0, xfer_size_bytes: {}, prev_xfer_size_bytes: {}",
+                xfer_size_bytes,
+                prev_xfer_size_bytes);
 
             // Update expected device_data for all cores
             Common::DeviceDataUpdater::update_packed_write(payload, device_data, worker_cores, l1_alignment);

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_dispatcher.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_dispatcher.cpp
@@ -494,7 +494,7 @@ public:
             // Generate payload
             std::vector<uint32_t> payload = payload_generator_->generate_payload_with_core(fw, xfer_size_bytes);
             TT_FATAL(
-                payload.size() > 0,
+                !payload.empty(),
                 "Generated payload size is 0, xfer_size_bytes: {}, prev_xfer_size_bytes: {}",
                 xfer_size_bytes,
                 prev_xfer_size_bytes);

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_dispatcher.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_dispatcher.cpp
@@ -453,16 +453,17 @@ public:
 
         // Relevel once before generating commands
         device_data.relevel(tt::CoreType::WORKER);
+        constexpr uint32_t payload_unit = sizeof(uint32_t);
 
         // Generate random-sized packed write commands until transfer_size_bytes_ is consumed
         // Each command is constrained by:
         // 1. Command entry size <= max_fetch_bytes_ : the whole packet must within prefetcher buffer limits
         // 2. Payload <= dispatch_cb_page_size_bytes : when 'no_stride' mode is used (data replication),
         // the payload + header + sub-commands must fit within the dispatch buffer page size
-        while (remaining_bytes > 0) {
+        while (remaining_bytes > payload_unit) {
             // Generate random transfer size
             uint32_t xfer_size_bytes =
-                payload_generator_->get_random_size(dispatch_buffer_page_size_, 1, remaining_bytes);
+                payload_generator_->get_random_size(dispatch_buffer_page_size_ / payload_unit, payload_unit, remaining_bytes);
 
             // Random no_stride flag
             bool no_stride = payload_generator_->get_rand_bool();
@@ -471,10 +472,11 @@ public:
             if (no_stride) {
                 const uint32_t max_allowed = dispatch_buffer_page_size_ - sizeof(CQDispatchCmd) - sub_cmds_bytes;
                 if (xfer_size_bytes > max_allowed) {
-                    log_warning(tt::LogTest, "Clamping packed_write cmd w/ no_stride to fit dispatch page");
+                    log_warning(tt::LogTest, "Clamping packed_write cmd w/ no_stride to fit dispatch page, max allowed: {}, xfer_size_bytes: {}", max_allowed, xfer_size_bytes);
                     xfer_size_bytes = max_allowed;
                 }
             }
+            uint32_t prev_xfer_size_bytes = xfer_size_bytes;
 
             // Clamp to fit within max_fetch_bytes_
             xfer_size_bytes = clamp_to_max_fetch(
@@ -486,6 +488,7 @@ public:
 
             // Generate payload
             std::vector<uint32_t> payload = payload_generator_->generate_payload_with_core(fw, xfer_size_bytes);
+            TT_FATAL(payload.size() > 0, "Generated payload size is 0, xfer_size_bytes: {}, prev_xfer_size_bytes: {}", xfer_size_bytes, prev_xfer_size_bytes);
 
             // Update expected device_data for all cores
             Common::DeviceDataUpdater::update_packed_write(payload, device_data, worker_cores, l1_alignment);

--- a/tt_metal/impl/debug/watcher_device_reader.cpp
+++ b/tt_metal/impl/debug/watcher_device_reader.cpp
@@ -809,6 +809,7 @@ void WatcherDeviceReader::Core::DumpAssertStatus() const {
     DumpWaypoints(true);
     DumpRingBuffer(true);
     LogRunningKernels();
+    sleep(10000);
     MetalContext::instance().watcher_server()->set_exception_message(error_msg);
     TT_THROW("Watcher detected tripped assert and stopped device.");
 }

--- a/tt_metal/impl/debug/watcher_device_reader.cpp
+++ b/tt_metal/impl/debug/watcher_device_reader.cpp
@@ -809,7 +809,6 @@ void WatcherDeviceReader::Core::DumpAssertStatus() const {
     DumpWaypoints(true);
     DumpRingBuffer(true);
     LogRunningKernels();
-    sleep(10000);
     MetalContext::instance().watcher_server()->set_exception_message(error_msg);
     TT_THROW("Watcher detected tripped assert and stopped device.");
 }

--- a/tt_metal/impl/dispatch/kernels/cq_common.hpp
+++ b/tt_metal/impl/dispatch/kernels/cq_common.hpp
@@ -299,13 +299,8 @@ public:
         n &= 0x7fffffff;
 
         WAYPOINT("TAPW");
-        uint32_t count = 0;
         do {
             invalidate_l1_cache();
-            count++;
-            if (count == 1000000) {
-                DPRINT << "wait all pages hung: n " << n << " additional_count " << additional_count << " sem_addr " << *sem_addr << " check value " << ((additional_count + *sem_addr) & 0x7fffffff) << ENDL();
-            }
         } while (((additional_count + *sem_addr) & 0x7fffffff) != n);  // mask off terminate bit
         WAYPOINT("TAPD");
     }
@@ -404,13 +399,6 @@ public:
     // Return available space (in bytes) after data_ptr. This data will always be contiguous in memory and will never
     // wrap around.
     uint32_t available_bytes(uint32_t data_ptr) const { return cb_fence_ - data_ptr; }
-
-    uint32_t acquired_count() {
-        volatile tt_l1_ptr uint32_t* sem_addr =
-            reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_semaphore<fd_core_type>(my_sem_id));
-        return *sem_addr;
-
-    }
 
 protected:
     FORCE_INLINE void init() {

--- a/tt_metal/impl/dispatch/kernels/cq_common.hpp
+++ b/tt_metal/impl/dispatch/kernels/cq_common.hpp
@@ -299,8 +299,13 @@ public:
         n &= 0x7fffffff;
 
         WAYPOINT("TAPW");
+        uint32_t count = 0;
         do {
             invalidate_l1_cache();
+            count++;
+            if (count == 1000000) {
+                DPRINT << "wait all pages hung: n " << n << " additional_count " << additional_count << " sem_addr " << *sem_addr << " check value " << ((additional_count + *sem_addr) & 0x7fffffff) << ENDL();
+            }
         } while (((additional_count + *sem_addr) & 0x7fffffff) != n);  // mask off terminate bit
         WAYPOINT("TAPD");
     }
@@ -399,6 +404,13 @@ public:
     // Return available space (in bytes) after data_ptr. This data will always be contiguous in memory and will never
     // wrap around.
     uint32_t available_bytes(uint32_t data_ptr) const { return cb_fence_ - data_ptr; }
+
+    uint32_t acquired_count() {
+        volatile tt_l1_ptr uint32_t* sem_addr =
+            reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_semaphore<fd_core_type>(my_sem_id));
+        return *sem_addr;
+
+    }
 
 protected:
     FORCE_INLINE void init() {

--- a/tt_metal/impl/dispatch/kernels/cq_common.hpp
+++ b/tt_metal/impl/dispatch/kernels/cq_common.hpp
@@ -321,9 +321,25 @@ public:
                     if (expected > buffer_end) {
                         expected -= buffer_size;
                     }
+
+                    // Allow writer to be one page ahead if round_to_page_size is true (writer has advanced
+                    // into the next page but we round down to the page boundary). This can happen when we do
+                    // write_pages_to_dispatcher<1, true> and the final write fills a page. The later check at the end
+                    // of the command with round_to_page_size=false will check that all the data is eventually written
+                    // out.
+                    bool one_page_ahead = false;
+                    if (round_to_page_size) {
+                        uint32_t expected_plus_page = expected + buffer_page_size;
+                        if (expected_plus_page > buffer_end) {
+                            expected_plus_page -= buffer_size;
+                        }
+                        one_page_ahead = (adjusted_writer_ptr == expected_plus_page) ||
+                                        ((expected_plus_page == buffer_end) && (adjusted_writer_ptr == buffer_base));
+                    }
+
                     // It's possible the writer_ptr wrapped and the expected pointer is at the very end of the buffer so
                     // it hasn't wrapped yet.
-                    ASSERT((adjusted_writer_ptr == expected) || ((expected == buffer_end) && (adjusted_writer_ptr == buffer_base)));
+                    ASSERT((adjusted_writer_ptr == expected) || ((expected == buffer_end) && (adjusted_writer_ptr == buffer_base)) || one_page_ahead);
                     watch_released_ptr_ = expected;
                 }
             }

--- a/tt_metal/impl/dispatch/kernels/cq_common.hpp
+++ b/tt_metal/impl/dispatch/kernels/cq_common.hpp
@@ -334,12 +334,14 @@ public:
                             expected_plus_page -= buffer_size;
                         }
                         one_page_ahead = (adjusted_writer_ptr == expected_plus_page) ||
-                                        ((expected_plus_page == buffer_end) && (adjusted_writer_ptr == buffer_base));
+                                         ((expected_plus_page == buffer_end) && (adjusted_writer_ptr == buffer_base));
                     }
 
                     // It's possible the writer_ptr wrapped and the expected pointer is at the very end of the buffer so
                     // it hasn't wrapped yet.
-                    ASSERT((adjusted_writer_ptr == expected) || ((expected == buffer_end) && (adjusted_writer_ptr == buffer_base)) || one_page_ahead);
+                    ASSERT(
+                        (adjusted_writer_ptr == expected) ||
+                        ((expected == buffer_end) && (adjusted_writer_ptr == buffer_base)) || one_page_ahead);
                     watch_released_ptr_ = expected;
                 }
             }

--- a/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
@@ -1992,7 +1992,7 @@ CBReaderWithManualRelease<
 // Used in prefetch_d downstream of a CQ_PREFETCH_CMD_RELAY_LINEAR_H command.
 inline void relay_raw_data_to_downstream(uint32_t& data_ptr, uint64_t wlength, uint32_t& local_downstream_data_ptr) {
     // In initial return, we return the header bytes as well
-    uint32_t initial_data_to_clear = sizeof(CQPrefetchHToPrefetchDHeader);
+    uint32_t initial_data_to_return = sizeof(CQPrefetchHToPrefetchDHeader);
     data_ptr += sizeof(CQPrefetchHToPrefetchDHeader);
     wlength -= sizeof(CQPrefetchHToPrefetchDHeader);
     // Stream data to downstream as it arrives. Acquire upstream pages incrementally.
@@ -2028,8 +2028,8 @@ inline void relay_raw_data_to_downstream(uint32_t& data_ptr, uint64_t wlength, u
         // data race.
         noc_async_writes_flushed();
         // wait_for_available_data always returns up to a page boundary, so the rounding only matters on the final chunk and lets us return the final bytes in the page early.
-        uint32_t pages_to_free = (can_read_now + initial_data_to_clear + cmddat_q_page_size - 1) >> cmddat_q_log_page_size;
-        initial_data_to_clear = 0;
+        uint32_t pages_to_free = (can_read_now + initial_data_to_return + cmddat_q_page_size - 1) >> cmddat_q_log_page_size;
+        initial_data_to_return = 0;
         uint32_t watcher_data_ptr = data_ptr;
 #if ASSERT_ENABLED
         if (wlength == 0) {

--- a/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
@@ -2027,13 +2027,16 @@ inline void relay_raw_data_to_downstream(uint32_t& data_ptr, uint64_t wlength, u
         // Release upstream pages so prefetch_h can make more available. Ensure to flush the writes just made to prevent
         // data race.
         noc_async_writes_flushed();
-        // wait_for_available_data always returns up to a page boundary, so the rounding only matters on the final chunk and lets us return the final bytes in the page early.
-        uint32_t pages_to_free = (can_read_now + initial_data_to_return + cmddat_q_page_size - 1) >> cmddat_q_log_page_size;
+        // wait_for_available_data always returns up to a page boundary, so the rounding only matters on the final chunk
+        // and lets us return the final bytes in the page early.
+        uint32_t pages_to_free =
+            (can_read_now + initial_data_to_return + cmddat_q_page_size - 1) >> cmddat_q_log_page_size;
         initial_data_to_return = 0;
         uint32_t watcher_data_ptr = data_ptr;
 #if ASSERT_ENABLED
         if (wlength == 0) {
-            // This normally happens after the end of the loop, but do it early here so we don't hit assertions. Data until the end of the page isn't used.
+            // This normally happens after the end of the loop, but do it early here so we don't hit assertions. Data
+            // until the end of the page isn't used.
             watcher_data_ptr = round_up_pow2(watcher_data_ptr, cmddat_q_page_size);
         }
 #endif
@@ -2156,7 +2159,6 @@ void kernel_main_d() {
     bool done = false;
     uint32_t heartbeat = 0;
     uint32_t l1_cache[l1_cache_elements_rounded];
-
 
     // Cmdbuf allocation is not defined yet for fabric so we can't use stateful APIs on Dispatch D
 #if defined(FABRIC_RELAY)

--- a/tt_metal/impl/dispatch/kernels/cq_relay.hpp
+++ b/tt_metal/impl/dispatch/kernels/cq_relay.hpp
@@ -28,7 +28,6 @@ private:
     constexpr static ProgrammableCoreType fd_core_type = static_cast<ProgrammableCoreType>(FD_CORE_TYPE);
 
     tt::tt_fabric::WorkerToFabricMuxSender<mux_num_buffers_per_channel> edm;
-    uint32_t released_pages_;
 
 #if ASSERT_ENABLED
     // Pointer to the end of the last released page. Used for assertions to catch cmd_ptr/released_pages desync.
@@ -37,10 +36,6 @@ private:
 
 public:
     CQRelayClient() = default;
-
-    uint32_t released_pages() {
-        return released_pages_;
-    }
 
     // Initialize cmd_ptr tracking for release_pages assertions.
     // Call this after init() and before any release_pages() calls that use cmd_ptr tracking.
@@ -73,7 +68,6 @@ public:
     FORCE_INLINE void init(
         uint64_t downstream_noc_addr, uint32_t my_dev_id, uint32_t to_dev_id, uint32_t router_direction) {
         WAYPOINT("FMCW");
-        released_pages_ = 0;
 #if defined(FABRIC_RELAY)
         edm.template init<fd_core_type>(
             true /*connected_to_persistent_fabric*/,
@@ -231,13 +225,10 @@ public:
 #else
         noc_semaphore_inc(get_noc_addr_helper(dest_noc_xy, get_semaphore<fd_core_type>(dest_sem_id)), n, noc_idx);
 #endif
-
-        released_pages_ += n;
     }
 
     // Version of release_pages with cmd_ptr tracking for synchronization assertions.
     // Template parameters specify the buffer geometry for validation.
-    // If round_to_page_size is true, cmd_ptr may be up to one page ahead of expected (for mid-command releases).
     template <
         uint8_t noc_idx,
         uint32_t dest_noc_xy,
@@ -245,7 +236,7 @@ public:
         uint32_t buffer_base,
         uint32_t buffer_end,
         uint32_t buffer_page_size>
-    FORCE_INLINE void release_pages(uint32_t n, uint32_t cmd_ptr, bool round_to_page_size = false) {
+    FORCE_INLINE void release_pages(uint32_t n, uint32_t cmd_ptr) {
         release_pages<noc_idx, dest_noc_xy, dest_sem_id>(n);
 
 #if ASSERT_ENABLED
@@ -255,43 +246,16 @@ public:
                 if (n != 0) {
                     // In the middle of processing, cmd_ptr may not be aligned to page size, but
                     // must always be past the number of pages released.
-                    uint32_t adjusted_cmd_ptr =
-                        round_to_page_size ? (cmd_ptr - (cmd_ptr - buffer_base) % buffer_page_size) : cmd_ptr;
                     uint64_t bytes = n * buffer_page_size;
                     uint32_t expected = watch_released_ptr_ + bytes;
                     if (expected > buffer_end) {
                         expected -= buffer_size;
                     }
 
-                    // Allow cmd_ptr to be one page ahead if round_to_page_size is true (cmd_ptr has advanced
-                    // into the next page but we round down to the page boundary). This can happen when releasing
-                    // pages mid-stream. The later check at the end with round_to_page_size=false will verify
-                    // that all data is eventually accounted for.
-                    bool one_page_ahead = false;
-                    if (round_to_page_size) {
-                        uint32_t expected_plus_page = expected + buffer_page_size;
-                        if (expected_plus_page > buffer_end) {
-                            expected_plus_page -= buffer_size;
-                        }
-                        one_page_ahead = (adjusted_cmd_ptr == expected_plus_page) ||
-                                         ((expected_plus_page == buffer_end) && (adjusted_cmd_ptr == buffer_base));
-                    }
-                    #if 1
-                    if (!(
-                        (adjusted_cmd_ptr == expected) ||
-                        ((expected == buffer_end) && (adjusted_cmd_ptr == buffer_base)) || one_page_ahead)) {
-                            WATCHER_RING_BUFFER_PUSH(adjusted_cmd_ptr);
-                            WATCHER_RING_BUFFER_PUSH(expected);
-                            WATCHER_RING_BUFFER_PUSH(cmd_ptr);
-                            WATCHER_RING_BUFFER_PUSH(n);
-                            WATCHER_RING_BUFFER_PUSH(round_to_page_size);
-                        }
-
                     // It's possible the cmd_ptr wrapped and the expected pointer is at the very end of the buffer
                     ASSERT(
-                        (adjusted_cmd_ptr == expected) ||
-                        ((expected == buffer_end) && (adjusted_cmd_ptr == buffer_base)) || one_page_ahead);
-                    #endif
+                        (cmd_ptr == expected) ||
+                        ((expected == buffer_end) && (cmd_ptr == buffer_base)));
                     watch_released_ptr_ = expected;
                 }
             }

--- a/tt_metal/impl/dispatch/kernels/cq_relay.hpp
+++ b/tt_metal/impl/dispatch/kernels/cq_relay.hpp
@@ -276,7 +276,7 @@ public:
                         one_page_ahead = (adjusted_cmd_ptr == expected_plus_page) ||
                                          ((expected_plus_page == buffer_end) && (adjusted_cmd_ptr == buffer_base));
                     }
-                    #if 0
+                    #if 1
                     if (!(
                         (adjusted_cmd_ptr == expected) ||
                         ((expected == buffer_end) && (adjusted_cmd_ptr == buffer_base)) || one_page_ahead)) {

--- a/tt_metal/impl/dispatch/kernels/cq_relay.hpp
+++ b/tt_metal/impl/dispatch/kernels/cq_relay.hpp
@@ -253,9 +253,7 @@ public:
                     }
 
                     // It's possible the cmd_ptr wrapped and the expected pointer is at the very end of the buffer
-                    ASSERT(
-                        (cmd_ptr == expected) ||
-                        ((expected == buffer_end) && (cmd_ptr == buffer_base)));
+                    ASSERT((cmd_ptr == expected) || ((expected == buffer_end) && (cmd_ptr == buffer_base)));
                     watch_released_ptr_ = expected;
                 }
             }

--- a/tt_metal/impl/dispatch/kernels/cq_relay.hpp
+++ b/tt_metal/impl/dispatch/kernels/cq_relay.hpp
@@ -276,6 +276,7 @@ public:
                         one_page_ahead = (adjusted_cmd_ptr == expected_plus_page) ||
                                          ((expected_plus_page == buffer_end) && (adjusted_cmd_ptr == buffer_base));
                     }
+                    #if 0
                     if (!(
                         (adjusted_cmd_ptr == expected) ||
                         ((expected == buffer_end) && (adjusted_cmd_ptr == buffer_base)) || one_page_ahead)) {
@@ -290,6 +291,7 @@ public:
                     ASSERT(
                         (adjusted_cmd_ptr == expected) ||
                         ((expected == buffer_end) && (adjusted_cmd_ptr == buffer_base)) || one_page_ahead);
+                    #endif
                     watch_released_ptr_ = expected;
                 }
             }


### PR DESCRIPTION
### Ticket
#36555
#36459

### Problem description
We're seeing some watcher asserts/NoC sanitization errors in test_prefetcher and test_dispatcher, as well as an occasionally hang in RelayLinearH in test_prefetcher.

### What's changed
* To fix the test_dispatcher NoC sanitization error, make sure the payload to packed_write is always a multiple of 4 bytes, because we round the size down when creating the vector<uint32_t>, and that was causing us to have 0-byte payloads, giving 0-length NoC transactions.
* To fix the test_prefetcher assert, allow in very specific cases for us to have an entire page of data outstanding and not yet sent to the reader. As an optimization to reduce cycle counts in some scenarios, we sometime leave a page of data outstanding until the end of the command.
* To fix the hang, ensure prefetch_d returns the data corresponding to CQPrefetchHToPrefetchDHeader to prefetch_d. Depending on the exact size of commands, we could sometimes return 1 too few pages, which was causing prefetch_h to hang because it didn't receive all the pages back that it sent. To enable us to avoid errors like this in the future, ad logic in CQRelayClient to validate the data_ptr against how many pages are released.

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=jbauman/fixpackedwrite)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:jbauman/fixpackedwrite)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=jbauman/fixpackedwrite)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:jbauman/fixpackedwrite)
- [x] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=jbauman/fixpackedwrite)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jbauman/fixpackedwrite)
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=jbauman/fixpackedwrite)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:jbauman/fixpackedwrite)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=jbauman/fixpackedwrite)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:jbauman/fixpackedwrite)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=jbauman/fixpackedwrite)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:jbauman/fixpackedwrite)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
