### PR TITLE
Expose Parameters in all gather

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/all_gather_async.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/all_gather_async.cpp
@@ -24,7 +24,9 @@ ttnn::Tensor ExecuteAllGatherAsync::invoke(
     bool use_optimal_ccl_for_llama,
     const std::optional<GlobalSemaphore>& barrier_semaphore,
     bool reverse_order,
-    const std::optional<CoreRangeSet>& sub_core_grid) {
+    const std::optional<CoreRangeSet>& sub_core_grid,
+    std::optional<uint32_t> num_workers_per_link,
+    std::optional<uint32_t> num_buffers_per_channel) {
     tt::tt_fabric::Topology usable_topology = ::ttnn::ccl::get_usable_topology(input_tensor, topology, std::nullopt);
     bool composite_all_gather_case = composite_common::use_composite_all_gather(input_tensor, dim, memory_config);
     bool all_gather_async_llama_sharded_case = composite_common::use_all_gather_async_llama_sharded(
@@ -55,8 +57,8 @@ ttnn::Tensor ExecuteAllGatherAsync::invoke(
         all_gather_async_llama_sharded_case,
         barrier_semaphore,
         /*chunks_per_sync*/ std::nullopt,
-        /*num_workers_per_link*/ std::nullopt,
-        /*num_buffers_per_channel*/ std::nullopt,
+        num_workers_per_link,
+        num_buffers_per_channel,
         reverse_order,
         sub_core_grid,
         /*mesh_device*/ nullptr);
@@ -184,7 +186,9 @@ ttnn::Tensor ExecuteAllGatherAsync::invoke(
     bool use_optimal_ccl_for_llama,
     const std::optional<GlobalSemaphore>& barrier_semaphore,
     bool reverse_order,
-    const std::optional<CoreRangeSet>& sub_core_grid) {
+    const std::optional<CoreRangeSet>& sub_core_grid,
+    std::optional<uint32_t> num_workers_per_link,
+    std::optional<uint32_t> num_buffers_per_channel) {
     tt::tt_fabric::Topology usable_topology = ::ttnn::ccl::get_usable_topology(input_tensor, topology, cluster_axis);
     bool composite_all_gather_case = composite_common::use_composite_all_gather(input_tensor, dim, memory_config);
     bool all_gather_async_llama_sharded_case = composite_common::use_all_gather_async_llama_sharded(
@@ -210,8 +214,8 @@ ttnn::Tensor ExecuteAllGatherAsync::invoke(
         all_gather_async_llama_sharded_case,
         barrier_semaphore,
         /*chunks_per_sync*/ std::nullopt,
-        /*num_workers_per_link*/ std::nullopt,
-        /*num_buffers_per_channel*/ std::nullopt,
+        /*num_workers_per_link*/ num_workers_per_link,
+        /*num_buffers_per_channel*/ num_buffers_per_channel,
         reverse_order,
         sub_core_grid,
         &mesh_device);
@@ -228,7 +232,9 @@ ttnn::Tensor ExecuteAllGatherAsyncReversed::invoke(
     bool use_optimal_ccl_for_llama,
     const std::optional<GlobalSemaphore>& barrier_semaphore,
     bool /*reverse_order*/,
-    const std::optional<CoreRangeSet>& sub_core_grid) {
+    const std::optional<CoreRangeSet>& sub_core_grid,
+    std::optional<uint32_t> num_workers_per_link,
+    std::optional<uint32_t> num_buffers_per_channel) {
     // NOTE: reverse_order parameter is ignored, always use true for reversed API
     tt::tt_fabric::Topology usable_topology = ::ttnn::ccl::get_usable_topology(input_tensor, topology, std::nullopt);
     bool composite_all_gather_case = composite_common::use_composite_all_gather(input_tensor, dim, memory_config);
@@ -260,8 +266,8 @@ ttnn::Tensor ExecuteAllGatherAsyncReversed::invoke(
         all_gather_async_llama_sharded_case,
         barrier_semaphore,
         /*chunks_per_sync*/ std::nullopt,
-        /*num_workers_per_link*/ std::nullopt,
-        /*num_buffers_per_channel*/ std::nullopt,
+        /*num_workers_per_link*/ num_workers_per_link,
+        /*num_buffers_per_channel*/ num_buffers_per_channel,
         /*reverse_order*/ true,
         sub_core_grid,
         /*mesh_device*/ nullptr);  // reverse_order=true for reversed API
@@ -330,7 +336,9 @@ ttnn::Tensor ExecuteAllGatherAsyncReversed::invoke(
     bool use_optimal_ccl_for_llama,
     const std::optional<GlobalSemaphore>& barrier_semaphore,
     bool /*reverse_order*/,
-    const std::optional<CoreRangeSet>& sub_core_grid) {
+    const std::optional<CoreRangeSet>& sub_core_grid,
+    std::optional<uint32_t> num_workers_per_link,
+    std::optional<uint32_t> num_buffers_per_channel) {
     tt::tt_fabric::Topology usable_topology = ::ttnn::ccl::get_usable_topology(input_tensor, topology, cluster_axis);
     bool composite_all_gather_case = composite_common::use_composite_all_gather(input_tensor, dim, memory_config);
     bool all_gather_async_llama_sharded_case = composite_common::use_all_gather_async_llama_sharded(
@@ -356,8 +364,8 @@ ttnn::Tensor ExecuteAllGatherAsyncReversed::invoke(
         all_gather_async_llama_sharded_case,
         barrier_semaphore,
         /*chunks_per_sync*/ std::nullopt,
-        /*num_workers_per_link*/ std::nullopt,
-        /*num_buffers_per_channel*/ std::nullopt,
+        num_workers_per_link,
+        num_buffers_per_channel,
         /*reverse_order*/ true,
         sub_core_grid,
         &mesh_device);  // reverse_order=true for reversed API

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/all_gather_async.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/all_gather_async.hpp
@@ -24,7 +24,9 @@ struct ExecuteAllGatherAsync {
         bool use_optimal_ccl_for_llama = false,
         const std::optional<GlobalSemaphore>& barrier_semaphore = std::nullopt,
         bool reverse_order = false,
-        const std::optional<CoreRangeSet>& sub_core_grid = std::nullopt);
+        const std::optional<CoreRangeSet>& sub_core_grid = std::nullopt,
+        std::optional<uint32_t> num_workers_per_link = std::nullopt,
+        std::optional<uint32_t> num_buffers_per_channel = std::nullopt);
 
     static ttnn::Tensor invoke(
         const ttnn::Tensor& input_tensor,
@@ -76,7 +78,9 @@ struct ExecuteAllGatherAsync {
         bool use_optimal_ccl_for_llama = false,
         const std::optional<GlobalSemaphore>& barrier_semaphore = std::nullopt,
         bool reverse_order = false,
-        const std::optional<CoreRangeSet>& sub_core_grid = std::nullopt);
+        const std::optional<CoreRangeSet>& sub_core_grid = std::nullopt,
+        std::optional<uint32_t> num_workers_per_link = std::nullopt,
+        std::optional<uint32_t> num_buffers_per_channel = std::nullopt);
 };
 
 struct ExecuteAllGatherAsyncReversed {
@@ -91,7 +95,9 @@ struct ExecuteAllGatherAsyncReversed {
         bool use_optimal_ccl_for_llama = false,
         const std::optional<GlobalSemaphore>& barrier_semaphore = std::nullopt,
         bool reverse_order = false,
-        const std::optional<CoreRangeSet>& sub_core_grid = std::nullopt);
+        const std::optional<CoreRangeSet>& sub_core_grid = std::nullopt,
+        std::optional<uint32_t> num_workers_per_link = std::nullopt,
+        std::optional<uint32_t> num_buffers_per_channel = std::nullopt);
 
     static ttnn::Tensor invoke(
         const ttnn::Tensor& input_tensor,
@@ -125,7 +131,9 @@ struct ExecuteAllGatherAsyncReversed {
         bool use_optimal_ccl_for_llama = false,
         const std::optional<GlobalSemaphore>& barrier_semaphore = std::nullopt,
         bool reverse_order = false,
-        const std::optional<CoreRangeSet>& sub_core_grid = std::nullopt);
+        const std::optional<CoreRangeSet>& sub_core_grid = std::nullopt,
+        std::optional<uint32_t> num_workers_per_link = std::nullopt,
+        std::optional<uint32_t> num_buffers_per_channel = std::nullopt);
 };
 
 }  // namespace operations::experimental::ccl

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/all_gather_async_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/all_gather_async_nanobind.cpp
@@ -50,7 +50,9 @@ void bind_all_gather_async(nb::module_& mod, const ccl_operation_t& operation, c
                std::optional<tt::tt_metal::SubDeviceId> subdevice_id,
                bool use_optimal_ccl_for_llama,
                const std::optional<GlobalSemaphore>& barrier_semaphore,
-               const std::optional<CoreRangeSet>& sub_core_grids) -> ttnn::Tensor {
+               const std::optional<CoreRangeSet>& sub_core_grids,
+               std::optional<uint32_t> num_workers_per_link,
+               std::optional<uint32_t> num_buffers_per_channel) -> ttnn::Tensor {
                 return self(
                     input_tensor,
                     dim,
@@ -62,7 +64,9 @@ void bind_all_gather_async(nb::module_& mod, const ccl_operation_t& operation, c
                     use_optimal_ccl_for_llama,
                     barrier_semaphore,
                     false,
-                    sub_core_grids);
+                    sub_core_grids,
+                    num_workers_per_link,
+                    num_buffers_per_channel);
             },
             nb::arg("input_tensor"),
             nb::arg("dim"),
@@ -74,8 +78,9 @@ void bind_all_gather_async(nb::module_& mod, const ccl_operation_t& operation, c
             nb::arg("subdevice_id") = nb::none(),
             nb::arg("use_optimal_ccl_for_llama") = false,
             nb::arg("barrier_semaphore") = nb::none(),
-            nb::arg("sub_core_grids") = nb::none()},
-
+            nb::arg("sub_core_grids") = nb::none(),
+            nb::arg("num_workers_per_link") = nb::none(),
+            nb::arg("num_buffers_per_channel") = nb::none()},
         // ring
         ttnn::nanobind_overload_t{
             [](const ccl_operation_t& self,
@@ -144,7 +149,9 @@ void bind_all_gather_async(nb::module_& mod, const ccl_operation_t& operation, c
                std::optional<tt::tt_metal::SubDeviceId> subdevice_id,
                bool use_optimal_ccl_for_llama,
                const std::optional<GlobalSemaphore>& barrier_semaphore,
-               const std::optional<CoreRangeSet>& sub_core_grids) -> ttnn::Tensor {
+               const std::optional<CoreRangeSet>& sub_core_grids,
+               std::optional<uint32_t> num_workers_per_link,
+               std::optional<uint32_t> num_buffers_per_channel) -> ttnn::Tensor {
                 return self(
                     input_tensor,
                     dim,
@@ -159,7 +166,9 @@ void bind_all_gather_async(nb::module_& mod, const ccl_operation_t& operation, c
                     use_optimal_ccl_for_llama,
                     barrier_semaphore,
                     false,
-                    sub_core_grids);
+                    sub_core_grids,
+                    num_workers_per_link,
+                    num_buffers_per_channel);
             },
             nb::arg("input_tensor"),
             nb::arg("dim"),
@@ -174,7 +183,9 @@ void bind_all_gather_async(nb::module_& mod, const ccl_operation_t& operation, c
             nb::arg("subdevice_id") = nb::none(),
             nb::arg("use_optimal_ccl_for_llama") = false,
             nb::arg("barrier_semaphore") = nb::none(),
-            nb::arg("sub_core_grids") = nb::none()});
+            nb::arg("sub_core_grids") = nb::none(),
+            nb::arg("num_workers_per_link") = nb::none(),
+            nb::arg("num_buffers_per_channel") = nb::none()});
 }
 
 }  // namespace


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
I am exposing a couple parameters in all gather that will let me optimize deepseek, so far seen 1.5uS difference in mlc

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=jvega/expose_ag_params)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:jvega/expose_ag_params)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=jvega/expose_ag_params)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:jvega/expose_ag_params)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=jvega/expose_ag_params)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jvega/expose_ag_params)
- [ ] New/Existing tests provide coverage for changes
