### PR TITLE
Fix #32306: Add clear error for BLOCK_SHARDED on 1D grid with batched…

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/matmul/test_matmul_block_sharded_1d_grid.py
+++ b/tests/ttnn/nightly/unit_tests/operations/matmul/test_matmul_block_sharded_1d_grid.py
@@ -1,0 +1,498 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Tests for GitHub issue #32306: matmul with BLOCK_SHARDED output on 1D grid.
+
+This test suite validates the fix for issue #32306, which caused matmul to hang
+when BLOCK_SHARDED output memory config was requested with a 1D core grid
+(single row or column of cores).
+
+The fix:
+1. For unbatched B tensor: Routes to 1D multicast program with proper per_core values
+2. For batched B tensor: Throws a clear error message explaining the limitation
+
+Test cases:
+- test_matmul_block_sharded_1d_column_grid_batched_b: Error case (batched B on 1D column)
+- test_matmul_block_sharded_1d_row_grid_batched_b: Error case (batched B on 1D row)
+- test_matmul_block_sharded_1d_column_grid_unbatched_b: Success case (unbatched B on 1D column)
+- test_matmul_block_sharded_1d_row_grid_unbatched_b: Success case (unbatched B on 1D row)
+- test_matmul_block_sharded_2d_grid: Success case (2D grid)
+- test_matmul_no_sharding_sanity: Sanity check
+"""
+
+import pytest
+import torch
+import ttnn
+
+from tests.ttnn.utils_for_testing import assert_with_pcc
+
+
+class TestMatmulBlockSharded1DGrid:
+    """Tests for BLOCK_SHARDED output with 1D core grids (issue #32306)."""
+
+    @pytest.mark.parametrize(
+        "batch_a, batch_b, M, K, N, grid_start, grid_end",
+        [
+            # Original issue case: [5, 400, 32] @ [5, 32, 400] on 1x5 column grid
+            (5, 5, 416, 32, 416, (0, 0), (0, 4)),
+            # Smaller batched case on 1D column grid
+            (2, 2, 64, 64, 64, (0, 0), (0, 1)),
+        ],
+    )
+    def test_matmul_block_sharded_1d_column_grid_batched_b(
+        self, device, batch_a, batch_b, M, K, N, grid_start, grid_end
+    ):
+        """
+        Test that BLOCK_SHARDED on 1D column grid with batched B tensor raises an error.
+
+        This configuration is unsupported because the 2D multicast program doesn't handle
+        degenerate 1D grids correctly. The fix should raise TT_FATAL with a clear message.
+        """
+        torch.manual_seed(0)
+
+        # Create batched input tensors
+        torch_a = torch.randn((batch_a, M, K), dtype=torch.bfloat16)
+        torch_b = torch.randn((batch_b, K, N), dtype=torch.bfloat16)
+
+        tt_a = ttnn.from_torch(torch_a, layout=ttnn.TILE_LAYOUT, device=device, dtype=ttnn.bfloat16)
+        tt_b = ttnn.from_torch(torch_b, layout=ttnn.TILE_LAYOUT, device=device, dtype=ttnn.bfloat16)
+
+        # BLOCK_SHARDED memory config with 1D column grid (single column of cores)
+        num_cores_y = grid_end[1] - grid_start[1] + 1
+        shard_height = (batch_a * M + num_cores_y - 1) // num_cores_y
+        # Round up to tile size
+        shard_height = ((shard_height + 31) // 32) * 32
+        shard_width = N
+
+        memory_config = ttnn.MemoryConfig(
+            memory_layout=ttnn.TensorMemoryLayout.BLOCK_SHARDED,
+            buffer_type=ttnn.BufferType.L1,
+            shard_spec=ttnn.ShardSpec(
+                ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(*grid_start), ttnn.CoreCoord(*grid_end))}),
+                (shard_height, shard_width),
+                ttnn.ShardOrientation.ROW_MAJOR,
+            ),
+        )
+
+        # Should raise RuntimeError with message about BLOCK_SHARDED on 1D grid
+        with pytest.raises(RuntimeError) as excinfo:
+            _ = ttnn.matmul(tt_a, tt_b, memory_config=memory_config)
+
+        assert "BLOCK_SHARDED" in str(excinfo.value)
+        assert "1D grid" in str(excinfo.value) or "single row or column" in str(excinfo.value)
+
+    @pytest.mark.parametrize(
+        "batch_a, batch_b, M, K, N, grid_start, grid_end",
+        [
+            # 1D row grid (5x1) with batched tensors
+            (5, 5, 416, 32, 416, (0, 0), (4, 0)),
+            # Smaller batched case on 1D row grid
+            (2, 2, 64, 64, 64, (0, 0), (1, 0)),
+        ],
+    )
+    def test_matmul_block_sharded_1d_row_grid_batched_b(self, device, batch_a, batch_b, M, K, N, grid_start, grid_end):
+        """
+        Test that BLOCK_SHARDED on 1D row grid with batched B tensor raises an error.
+
+        Similar to column grid case, this configuration is unsupported with batched tensors.
+        """
+        torch.manual_seed(0)
+
+        # Create batched input tensors
+        torch_a = torch.randn((batch_a, M, K), dtype=torch.bfloat16)
+        torch_b = torch.randn((batch_b, K, N), dtype=torch.bfloat16)
+
+        tt_a = ttnn.from_torch(torch_a, layout=ttnn.TILE_LAYOUT, device=device, dtype=ttnn.bfloat16)
+        tt_b = ttnn.from_torch(torch_b, layout=ttnn.TILE_LAYOUT, device=device, dtype=ttnn.bfloat16)
+
+        # BLOCK_SHARDED memory config with 1D row grid (single row of cores)
+        num_cores_x = grid_end[0] - grid_start[0] + 1
+        shard_height = batch_a * M
+        shard_width = (N + num_cores_x - 1) // num_cores_x
+        # Round up to tile size
+        shard_width = ((shard_width + 31) // 32) * 32
+
+        memory_config = ttnn.MemoryConfig(
+            memory_layout=ttnn.TensorMemoryLayout.BLOCK_SHARDED,
+            buffer_type=ttnn.BufferType.L1,
+            shard_spec=ttnn.ShardSpec(
+                ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(*grid_start), ttnn.CoreCoord(*grid_end))}),
+                (shard_height, shard_width),
+                ttnn.ShardOrientation.ROW_MAJOR,
+            ),
+        )
+
+        # Should raise RuntimeError with message about BLOCK_SHARDED on 1D grid
+        with pytest.raises(RuntimeError) as excinfo:
+            _ = ttnn.matmul(tt_a, tt_b, memory_config=memory_config)
+
+        assert "BLOCK_SHARDED" in str(excinfo.value)
+        assert "1D grid" in str(excinfo.value) or "single row or column" in str(excinfo.value)
+
+    @pytest.mark.parametrize(
+        "M, K, N, num_cores_y",
+        [
+            # Various sizes with unbatched B on 1D column grid
+            # Use sizes that work well with the 1D mcast program constraints
+            (128, 128, 128, 4),
+            (256, 128, 128, 4),
+        ],
+    )
+    def test_matmul_block_sharded_1d_column_grid_unbatched_b(self, device, M, K, N, num_cores_y):
+        """
+        Test that BLOCK_SHARDED on 1D column grid works correctly with unbatched B tensor.
+
+        When B is unbatched (batch_size=1), the fix routes this to the 1D multicast program
+        with HEIGHT_SHARDED-like behavior. This should complete without hanging.
+        """
+        torch.manual_seed(0)
+
+        # Use 4D tensors: [1, 1, M, K] @ [1, 1, K, N] = [1, 1, M, N]
+        torch_a = torch.randn((1, 1, M, K), dtype=torch.bfloat16)
+        torch_b = torch.randn((1, 1, K, N), dtype=torch.bfloat16)
+        torch_expected = torch.matmul(torch_a, torch_b)
+
+        tt_a = ttnn.from_torch(torch_a, layout=ttnn.TILE_LAYOUT, device=device, dtype=ttnn.bfloat16)
+        tt_b = ttnn.from_torch(torch_b, layout=ttnn.TILE_LAYOUT, device=device, dtype=ttnn.bfloat16)
+
+        # BLOCK_SHARDED memory config with 1D column grid
+        shard_height = M // num_cores_y
+        shard_width = N
+
+        memory_config = ttnn.MemoryConfig(
+            memory_layout=ttnn.TensorMemoryLayout.BLOCK_SHARDED,
+            buffer_type=ttnn.BufferType.L1,
+            shard_spec=ttnn.ShardSpec(
+                ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(0, num_cores_y - 1))}),
+                (shard_height, shard_width),
+                ttnn.ShardOrientation.ROW_MAJOR,
+            ),
+        )
+
+        # Should complete without hanging
+        output = ttnn.matmul(tt_a, tt_b, memory_config=memory_config)
+        ttnn.synchronize_device(device)
+
+        output_torch = ttnn.to_torch(output)
+        assert_with_pcc(torch_expected, output_torch, pcc=0.99)
+
+    @pytest.mark.parametrize(
+        "M, K, N, num_cores_x",
+        [
+            # Various sizes with unbatched B on 1D row grid
+            # Use sizes that work well with the 1D mcast program constraints
+            (128, 128, 128, 4),
+            (128, 128, 256, 4),
+        ],
+    )
+    def test_matmul_block_sharded_1d_row_grid_unbatched_b(self, device, M, K, N, num_cores_x):
+        """
+        Test that BLOCK_SHARDED on 1D row grid works correctly with unbatched B tensor.
+
+        When B is unbatched (batch_size=1), the fix routes this to the 1D multicast program
+        with WIDTH_SHARDED-like behavior. This should complete without hanging.
+        """
+        torch.manual_seed(0)
+
+        # Use 4D tensors: [1, 1, M, K] @ [1, 1, K, N] = [1, 1, M, N]
+        torch_a = torch.randn((1, 1, M, K), dtype=torch.bfloat16)
+        torch_b = torch.randn((1, 1, K, N), dtype=torch.bfloat16)
+        torch_expected = torch.matmul(torch_a, torch_b)
+
+        tt_a = ttnn.from_torch(torch_a, layout=ttnn.TILE_LAYOUT, device=device, dtype=ttnn.bfloat16)
+        tt_b = ttnn.from_torch(torch_b, layout=ttnn.TILE_LAYOUT, device=device, dtype=ttnn.bfloat16)
+
+        # BLOCK_SHARDED memory config with 1D row grid
+        shard_height = M
+        shard_width = N // num_cores_x
+
+        memory_config = ttnn.MemoryConfig(
+            memory_layout=ttnn.TensorMemoryLayout.BLOCK_SHARDED,
+            buffer_type=ttnn.BufferType.L1,
+            shard_spec=ttnn.ShardSpec(
+                ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(num_cores_x - 1, 0))}),
+                (shard_height, shard_width),
+                ttnn.ShardOrientation.ROW_MAJOR,
+            ),
+        )
+
+        # Should complete without hanging
+        output = ttnn.matmul(tt_a, tt_b, memory_config=memory_config)
+        ttnn.synchronize_device(device)
+
+        output_torch = ttnn.to_torch(output)
+        assert_with_pcc(torch_expected, output_torch, pcc=0.99)
+
+    @pytest.mark.parametrize(
+        "batch, M, K, N, grid_x, grid_y",
+        [
+            # 2D grid cases (should work normally)
+            (1, 128, 64, 128, 2, 2),
+            (1, 256, 128, 256, 4, 2),
+        ],
+    )
+    def test_matmul_block_sharded_2d_grid(self, device, batch, M, K, N, grid_x, grid_y):
+        """
+        Test that BLOCK_SHARDED on 2D grid continues to work correctly.
+
+        This is a regression test to ensure the fix doesn't break the normal 2D grid case.
+        """
+        torch.manual_seed(0)
+
+        torch_a = torch.randn((batch, M, K), dtype=torch.bfloat16)
+        torch_b = torch.randn((batch, K, N), dtype=torch.bfloat16)
+        torch_expected = torch.bmm(torch_a, torch_b)
+
+        tt_a = ttnn.from_torch(torch_a, layout=ttnn.TILE_LAYOUT, device=device, dtype=ttnn.bfloat16)
+        tt_b = ttnn.from_torch(torch_b, layout=ttnn.TILE_LAYOUT, device=device, dtype=ttnn.bfloat16)
+
+        # BLOCK_SHARDED memory config with 2D grid
+        shard_height = (batch * M) // grid_y
+        shard_width = N // grid_x
+        # Round up to tile size
+        shard_height = ((shard_height + 31) // 32) * 32
+        shard_width = ((shard_width + 31) // 32) * 32
+
+        memory_config = ttnn.MemoryConfig(
+            memory_layout=ttnn.TensorMemoryLayout.BLOCK_SHARDED,
+            buffer_type=ttnn.BufferType.L1,
+            shard_spec=ttnn.ShardSpec(
+                ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(grid_x - 1, grid_y - 1))}),
+                (shard_height, shard_width),
+                ttnn.ShardOrientation.ROW_MAJOR,
+            ),
+        )
+
+        output = ttnn.matmul(tt_a, tt_b, memory_config=memory_config)
+        ttnn.synchronize_device(device)
+
+        output_torch = ttnn.to_torch(output)
+        assert_with_pcc(torch_expected, output_torch, pcc=0.99)
+
+    def test_matmul_no_sharding_sanity(self, device):
+        """
+        Sanity test: basic matmul without sharding should work.
+
+        This verifies the device and basic matmul functionality are working.
+        """
+        torch.manual_seed(0)
+
+        # Use the exact shapes from the original issue
+        torch_a = torch.randn((5, 400, 32), dtype=torch.bfloat16)
+        torch_b = torch.randn((5, 32, 400), dtype=torch.bfloat16)
+        torch_expected = torch.bmm(torch_a, torch_b)
+
+        tt_a = ttnn.from_torch(torch_a, layout=ttnn.TILE_LAYOUT, device=device, dtype=ttnn.bfloat16)
+        tt_b = ttnn.from_torch(torch_b, layout=ttnn.TILE_LAYOUT, device=device, dtype=ttnn.bfloat16)
+
+        # matmul without memory_config should work
+        output = ttnn.matmul(tt_a, tt_b)
+        ttnn.synchronize_device(device)
+
+        output_torch = ttnn.to_torch(output)
+        assert_with_pcc(torch_expected, output_torch, pcc=0.99)
+
+
+class TestMatmulBlockSharded1DGridOriginalIssue:
+    """Tests that specifically reproduce the original issue #32306 scenario."""
+
+    def test_original_issue_exact_shapes(self, device):
+        """
+        Reproduce the EXACT scenario from GitHub issue #32306.
+
+        Original shapes: [5, 400, 32] @ [5, 32, 400] = [5, 400, 400]
+        With BLOCK_SHARDED output on a 1x5 column grid, shard shape (416, 416).
+
+        This should now raise a clear error instead of hanging.
+        """
+        # Create tensors with exact shapes from the issue
+        v2 = ttnn.ones(
+            shape=ttnn.Shape([5, 400, 32]),
+            dtype=ttnn.DataType.BFLOAT16,
+            layout=ttnn.Layout.TILE,
+            device=device,
+        )
+        v3 = ttnn.ones(
+            shape=ttnn.Shape([5, 32, 400]),
+            dtype=ttnn.DataType.BFLOAT16,
+            layout=ttnn.Layout.TILE,
+            device=device,
+        )
+
+        # Exact memory config from the original issue
+        memory_config = ttnn.MemoryConfig(
+            memory_layout=ttnn.TensorMemoryLayout.BLOCK_SHARDED,
+            buffer_type=ttnn.BufferType.L1,
+            shard_spec=ttnn.ShardSpec(
+                ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(0, 4))}),
+                (416, 416),
+                ttnn.ShardOrientation.ROW_MAJOR,
+            ),
+        )
+
+        # With the fix, this should raise RuntimeError instead of hanging
+        with pytest.raises(RuntimeError) as excinfo:
+            _ = ttnn.matmul(v2, v3, memory_config=memory_config)
+
+        error_msg = str(excinfo.value)
+        # Verify the error message is helpful
+        assert "BLOCK_SHARDED" in error_msg
+        # Should suggest workarounds
+        assert "HEIGHT_SHARDED" in error_msg or "WIDTH_SHARDED" in error_msg or "2D" in error_msg
+
+    def test_original_issue_shapes_batched_error(self, device):
+        """
+        Reproduce the exact scenario from GitHub issue #32306 using torch tensors.
+
+        Original shapes: [5, 400, 32] @ [5, 32, 400] = [5, 400, 400]
+        With BLOCK_SHARDED output on a 1x5 column grid.
+
+        This should now raise a clear error instead of hanging.
+        """
+        torch.manual_seed(0)
+
+        # Exact shapes from the issue (padded to tile alignment)
+        torch_a = torch.randn((5, 416, 32), dtype=torch.bfloat16)
+        torch_b = torch.randn((5, 32, 416), dtype=torch.bfloat16)
+
+        tt_a = ttnn.from_torch(torch_a, layout=ttnn.TILE_LAYOUT, device=device, dtype=ttnn.bfloat16)
+        tt_b = ttnn.from_torch(torch_b, layout=ttnn.TILE_LAYOUT, device=device, dtype=ttnn.bfloat16)
+
+        # Memory config from the original issue: 1x5 column grid
+        memory_config = ttnn.MemoryConfig(
+            memory_layout=ttnn.TensorMemoryLayout.BLOCK_SHARDED,
+            buffer_type=ttnn.BufferType.L1,
+            shard_spec=ttnn.ShardSpec(
+                ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(0, 4))}),
+                (416, 416),
+                ttnn.ShardOrientation.ROW_MAJOR,
+            ),
+        )
+
+        # With the fix, this should raise RuntimeError instead of hanging
+        with pytest.raises(RuntimeError) as excinfo:
+            _ = ttnn.matmul(tt_a, tt_b, memory_config=memory_config)
+
+        error_msg = str(excinfo.value)
+        # Verify the error message is helpful
+        assert "BLOCK_SHARDED" in error_msg
+        # Should suggest workarounds
+        assert "HEIGHT_SHARDED" in error_msg or "WIDTH_SHARDED" in error_msg or "2D" in error_msg
+
+
+class TestMatmulBlockSharded1DGridEdgeCases:
+    """Edge cases and boundary conditions for the fix."""
+
+    def test_single_core_grid(self, device):
+        """
+        Test BLOCK_SHARDED on a single core (1x1 grid).
+
+        A single core is technically both a "1D column" and "1D row" grid.
+        This should work when B is unbatched.
+        """
+        torch.manual_seed(0)
+
+        M, K, N = 64, 64, 64
+
+        # Use 4D tensors with batch=1
+        torch_a = torch.randn((1, 1, M, K), dtype=torch.bfloat16)
+        torch_b = torch.randn((1, 1, K, N), dtype=torch.bfloat16)
+        torch_expected = torch.matmul(torch_a, torch_b)
+
+        tt_a = ttnn.from_torch(torch_a, layout=ttnn.TILE_LAYOUT, device=device, dtype=ttnn.bfloat16)
+        tt_b = ttnn.from_torch(torch_b, layout=ttnn.TILE_LAYOUT, device=device, dtype=ttnn.bfloat16)
+
+        # Single core grid
+        memory_config = ttnn.MemoryConfig(
+            memory_layout=ttnn.TensorMemoryLayout.BLOCK_SHARDED,
+            buffer_type=ttnn.BufferType.L1,
+            shard_spec=ttnn.ShardSpec(
+                ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(0, 0))}),
+                (M, N),
+                ttnn.ShardOrientation.ROW_MAJOR,
+            ),
+        )
+
+        output = ttnn.matmul(tt_a, tt_b, memory_config=memory_config)
+        ttnn.synchronize_device(device)
+
+        output_torch = ttnn.to_torch(output)
+        assert_with_pcc(torch_expected, output_torch, pcc=0.99)
+
+    def test_workaround_height_sharded_explicit(self, device):
+        """
+        Test the workaround: use HEIGHT_SHARDED explicitly instead of BLOCK_SHARDED on 1D column.
+
+        This demonstrates the recommended workaround for users hitting issue #32306.
+        """
+        torch.manual_seed(0)
+
+        # Use simpler shapes that divide evenly
+        M, K, N = 256, 128, 128
+        num_cores = 4
+
+        torch_a = torch.randn((1, 1, M, K), dtype=torch.bfloat16)
+        torch_b = torch.randn((1, 1, K, N), dtype=torch.bfloat16)
+        torch_expected = torch.matmul(torch_a, torch_b)
+
+        tt_a = ttnn.from_torch(torch_a, layout=ttnn.TILE_LAYOUT, device=device, dtype=ttnn.bfloat16)
+        tt_b = ttnn.from_torch(torch_b, layout=ttnn.TILE_LAYOUT, device=device, dtype=ttnn.bfloat16)
+
+        # Workaround: use HEIGHT_SHARDED explicitly on a 1D column grid
+        shard_height = M // num_cores
+
+        memory_config = ttnn.MemoryConfig(
+            memory_layout=ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+            buffer_type=ttnn.BufferType.L1,
+            shard_spec=ttnn.ShardSpec(
+                ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(0, num_cores - 1))}),
+                (shard_height, N),
+                ttnn.ShardOrientation.ROW_MAJOR,
+            ),
+        )
+
+        output = ttnn.matmul(tt_a, tt_b, memory_config=memory_config)
+        ttnn.synchronize_device(device)
+
+        output_torch = ttnn.to_torch(output)
+        assert_with_pcc(torch_expected, output_torch, pcc=0.99)
+
+    def test_workaround_width_sharded_explicit(self, device):
+        """
+        Test the workaround: use WIDTH_SHARDED explicitly instead of BLOCK_SHARDED on 1D row.
+
+        This demonstrates another recommended workaround for users hitting issue #32306.
+        """
+        torch.manual_seed(0)
+
+        # Use simpler shapes that divide evenly
+        M, K, N = 128, 128, 256
+        num_cores = 4
+
+        torch_a = torch.randn((1, 1, M, K), dtype=torch.bfloat16)
+        torch_b = torch.randn((1, 1, K, N), dtype=torch.bfloat16)
+        torch_expected = torch.matmul(torch_a, torch_b)
+
+        tt_a = ttnn.from_torch(torch_a, layout=ttnn.TILE_LAYOUT, device=device, dtype=ttnn.bfloat16)
+        tt_b = ttnn.from_torch(torch_b, layout=ttnn.TILE_LAYOUT, device=device, dtype=ttnn.bfloat16)
+
+        # Workaround: use WIDTH_SHARDED explicitly on a 1D row grid
+        shard_width = N // num_cores
+
+        memory_config = ttnn.MemoryConfig(
+            memory_layout=ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+            buffer_type=ttnn.BufferType.L1,
+            shard_spec=ttnn.ShardSpec(
+                ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(num_cores - 1, 0))}),
+                (M, shard_width),
+                ttnn.ShardOrientation.ROW_MAJOR,
+            ),
+        )
+
+        output = ttnn.matmul(tt_a, tt_b, memory_config=memory_config)
+        ttnn.synchronize_device(device)
+
+        output_torch = ttnn.to_torch(output)
+        assert_with_pcc(torch_expected, output_torch, pcc=0.99)

--- a/ttnn/cpp/ttnn/operations/matmul/device/config/matmul_program_config.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/config/matmul_program_config.cpp
@@ -325,10 +325,30 @@ MatmulMultiCoreReuseMultiCast1DProgramConfig get_mcast_1d_config(
     // If user provided a shard spec (BLOCK_SHARDED on 1D grid), derive per_core values from it
     if (user_shard_spec.has_value()) {
         const auto& shard_shape = user_shard_spec->shape;
+        // Validate tile alignment
+        TT_FATAL(
+            shard_shape[0] % in0_tile.get_height() == 0,
+            "Shard height {} must be divisible by tile height {} for BLOCK_SHARDED on 1D grid",
+            shard_shape[0],
+            in0_tile.get_height());
+        TT_FATAL(
+            shard_shape[1] % in1_tile.get_width() == 0,
+            "Shard width {} must be divisible by tile width {} for BLOCK_SHARDED on 1D grid",
+            shard_shape[1],
+            in1_tile.get_width());
         per_core_M = shard_shape[0] / in0_tile.get_height();
         per_core_N = shard_shape[1] / in1_tile.get_width();
         // Also use the user's grid size for compute
         auto grid_bbox = user_shard_spec->grid.bounding_box();
+        uint32_t bbox_num_cores = (grid_bbox.end_coord.x - grid_bbox.start_coord.x + 1) *
+                                  (grid_bbox.end_coord.y - grid_bbox.start_coord.y + 1);
+        // Validate that grid is contiguous (no gaps)
+        TT_FATAL(
+            bbox_num_cores == user_shard_spec->grid.num_cores(),
+            "BLOCK_SHARDED on 1D grid requires a contiguous core grid without gaps. "
+            "Bounding box has {} cores but grid has {} cores.",
+            bbox_num_cores,
+            user_shard_spec->grid.num_cores());
         grid_size = CoreCoord{
             grid_bbox.end_coord.x - grid_bbox.start_coord.x + 1, grid_bbox.end_coord.y - grid_bbox.start_coord.y + 1};
     } else if (mcast_in0) {

--- a/ttnn/cpp/ttnn/operations/matmul/device/config/matmul_program_config.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/config/matmul_program_config.cpp
@@ -306,7 +306,8 @@ MatmulMultiCoreReuseMultiCast1DProgramConfig get_mcast_1d_config(
     const std::optional<const CoreCoord> compute_with_storage_grid_size,
     const std::optional<const ttnn::DeviceComputeKernelConfig> compute_kernel_config,
     const tt::tt_metal::DataType output_dtype,
-    const bool /*all_dram_interleaved*/) {
+    const bool /*all_dram_interleaved*/,
+    const std::optional<tt::tt_metal::ShardSpec>& user_shard_spec = std::nullopt) {
     using namespace tt;
     auto* device = input_tensor_a.device();
     auto grid_size = compute_with_storage_grid_size.value_or(device->compute_with_storage_grid_size());
@@ -320,7 +321,17 @@ MatmulMultiCoreReuseMultiCast1DProgramConfig get_mcast_1d_config(
     const auto K = utilities::get_K_dim(a_shape_padded, /*tile=*/std::nullopt);
     const auto N = utilities::get_N_dim(b_shape_padded, /*tile=*/std::nullopt);
     uint32_t per_core_M, per_core_N;
-    if (mcast_in0) {
+
+    // If user provided a shard spec (BLOCK_SHARDED on 1D grid), derive per_core values from it
+    if (user_shard_spec.has_value()) {
+        const auto& shard_shape = user_shard_spec->shape;
+        per_core_M = shard_shape[0] / in0_tile.get_height();
+        per_core_N = shard_shape[1] / in1_tile.get_width();
+        // Also use the user's grid size for compute
+        auto grid_bbox = user_shard_spec->grid.bounding_box();
+        grid_size = CoreCoord{
+            grid_bbox.end_coord.x - grid_bbox.start_coord.x + 1, grid_bbox.end_coord.y - grid_bbox.start_coord.y + 1};
+    } else if (mcast_in0) {
         per_core_M = M / in0_tile.get_height();
         per_core_N = div_up(div_up(N, grid_size.x * grid_size.y), in1_tile.get_width());
     } else {
@@ -1104,44 +1115,99 @@ MatmulProgramConfig create_simple_matmul_program_config(
 
     if (all_dram_interleaved or (num_blocks_x * num_blocks_y <= num_cores_x * num_cores_y and Kt % in0_block_w == 0)) {
         CoreCoord core_range = get_core_range(num_blocks_y, num_blocks_x, num_cores_y, num_cores_x);
-        bool use_mcast_1d_in0_config = is_wide or (core_range.y == 0 and mem_config.is_sharded() and
-                                                   mem_config.memory_layout() == TensorMemoryLayout::WIDTH_SHARDED);
-        bool use_mcast_1d_in1_config = is_tall or (core_range.y == 0 and mem_config.is_sharded() and
-                                                   mem_config.memory_layout() == TensorMemoryLayout::HEIGHT_SHARDED);
+        // Check if BLOCK_SHARDED is on a 1D grid (equivalent to HEIGHT_SHARDED or WIDTH_SHARDED)
+        // Note: 1x1 grids (single core) are NOT treated as 1D grids - they work fine with the 2D mcast path
+        bool block_sharded_on_1d_column_grid = false;
+        bool block_sharded_on_1d_row_grid = false;
+        if (mem_config.is_sharded() && mem_config.memory_layout() == TensorMemoryLayout::BLOCK_SHARDED &&
+            mem_config.shard_spec().has_value()) {
+            auto grid_bbox = mem_config.shard_spec()->grid.bounding_box();
+            bool is_single_core = (grid_bbox.end_coord.x == grid_bbox.start_coord.x) &&
+                                  (grid_bbox.end_coord.y == grid_bbox.start_coord.y);
+            // 1-column grid (e.g., 1x5): end_coord.x == start_coord.x means only 1 column
+            // Exclude single-core grids which work fine with 2D mcast
+            block_sharded_on_1d_column_grid = !is_single_core && (grid_bbox.end_coord.x == grid_bbox.start_coord.x);
+            // 1-row grid (e.g., 5x1): end_coord.y == start_coord.y means only 1 row
+            // Exclude single-core grids which work fine with 2D mcast
+            block_sharded_on_1d_row_grid = !is_single_core && (grid_bbox.end_coord.y == grid_bbox.start_coord.y);
+
+            // Check for unsupported configuration: BLOCK_SHARDED on 1D grid with both tensors batched
+            // This configuration requires the 2D mcast program which doesn't handle 1D grids correctly
+            const auto& b_shape = utilities::get_matmul_tensor_padded_shape(input_tensor_b, transpose_b);
+            bool b_is_batched = (get_batch_size(b_shape) > 1);
+            if ((block_sharded_on_1d_column_grid || block_sharded_on_1d_row_grid) && b_is_batched) {
+                TT_FATAL(
+                    false,
+                    "BLOCK_SHARDED output on a 1D grid (single row or column of cores) is not supported when both "
+                    "input tensors are batched. Either use HEIGHT_SHARDED/WIDTH_SHARDED explicitly, use a 2D core "
+                    "grid for BLOCK_SHARDED, or ensure the second input tensor (B) has batch size 1. "
+                    "See GitHub issue #32306 for details.");
+            }
+        }
+
+        bool use_mcast_1d_in0_config =
+            is_wide or
+            (core_range.y == 0 and mem_config.is_sharded() and
+             (mem_config.memory_layout() == TensorMemoryLayout::WIDTH_SHARDED or block_sharded_on_1d_row_grid));
+        bool use_mcast_1d_in1_config =
+            is_tall or
+            (core_range.y == 0 and mem_config.is_sharded() and
+             (mem_config.memory_layout() == TensorMemoryLayout::HEIGHT_SHARDED or block_sharded_on_1d_column_grid));
         bool use_mcast_2d_config =
             all_dram_interleaved or (core_range.y == 0 and mem_config.is_sharded() and
-                                     mem_config.memory_layout() == TensorMemoryLayout::BLOCK_SHARDED);
+                                     mem_config.memory_layout() == TensorMemoryLayout::BLOCK_SHARDED and
+                                     not block_sharded_on_1d_column_grid and not block_sharded_on_1d_row_grid);
         if (core_range.y == 1 or use_mcast_1d_in0_config) {
+            // Pass user's shard_spec when BLOCK_SHARDED on 1D row grid
+            std::optional<tt::tt_metal::ShardSpec> user_shard_spec =
+                (block_sharded_on_1d_row_grid && mem_config.shard_spec().has_value())
+                    ? std::make_optional(mem_config.shard_spec().value())
+                    : std::nullopt;
+            // fuse_batch can only be true when B has batch size 1
+            const auto& b_shape = utilities::get_matmul_tensor_padded_shape(input_tensor_b, transpose_b);
+            bool b_is_unbatched = (get_batch_size(b_shape) == 1);
+            bool fuse_batch_for_sharding = user_shard_spec.has_value() && b_is_unbatched;
             return get_mcast_1d_config(
                 input_tensor_a,
                 input_tensor_b,
                 transpose_a,
                 transpose_b,
                 bias_single_tile_size,
-                false /* fuse_batch */,
+                fuse_batch_for_sharding /* fuse_batch */,
                 std::nullopt /* fused_activation */,
                 true /* mcast_in0 */,
                 false /* out_sharded */,
                 std::nullopt /* compute_with_storage_grid_size */,
                 compute_kernel_config,
                 output_dtype,
-                all_dram_interleaved);
+                all_dram_interleaved,
+                user_shard_spec);
         }
         if (core_range.x == 1 or use_mcast_1d_in1_config) {
+            // Pass user's shard_spec when BLOCK_SHARDED on 1D column grid
+            std::optional<tt::tt_metal::ShardSpec> user_shard_spec =
+                (block_sharded_on_1d_column_grid && mem_config.shard_spec().has_value())
+                    ? std::make_optional(mem_config.shard_spec().value())
+                    : std::nullopt;
+            // fuse_batch can only be true when B has batch size 1
+            const auto& b_shape = utilities::get_matmul_tensor_padded_shape(input_tensor_b, transpose_b);
+            bool b_is_unbatched = (get_batch_size(b_shape) == 1);
+            bool fuse_batch_for_sharding = user_shard_spec.has_value() && b_is_unbatched;
             return get_mcast_1d_config(
                 input_tensor_a,
                 input_tensor_b,
                 transpose_a,
                 transpose_b,
                 bias_single_tile_size,
-                false /* fuse_batch */,
+                fuse_batch_for_sharding /* fuse_batch */,
                 std::nullopt /* fused_activation */,
                 false /* mcast_in0 */,
                 false /* out_sharded */,
                 std::nullopt /* compute_with_storage_grid_size */,
                 compute_kernel_config,
                 output_dtype,
-                all_dram_interleaved);
+                all_dram_interleaved,
+                user_shard_spec);
         }
         if ((core_range.y > 0 and num_blocks_x <= num_cores_x and num_blocks_y <= num_cores_y) or use_mcast_2d_config) {
             bool transpose_mcast =

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_device_operation.cpp
@@ -181,8 +181,21 @@ void MatmulDeviceOperation::validate_on_program_cache_miss(
             "Mismatch between computed {} and provided {} mem config buffer type",
             output_tensor_spec.memory_config().buffer_type(),
             attributes.output_mem_config.buffer_type());
+        // Don't warn when BLOCK_SHARDED on 1D grid is intentionally converted to HEIGHT/WIDTH_SHARDED
+        bool is_intentional_1d_conversion = false;
+        if (attributes.output_mem_config.memory_layout() == TensorMemoryLayout::BLOCK_SHARDED &&
+            attributes.output_mem_config.shard_spec().has_value()) {
+            auto grid_bbox = attributes.output_mem_config.shard_spec()->grid.bounding_box();
+            bool is_1d_column = (grid_bbox.end_coord.x == grid_bbox.start_coord.x);
+            bool is_1d_row = (grid_bbox.end_coord.y == grid_bbox.start_coord.y);
+            bool is_single_core = is_1d_column && is_1d_row;
+            // Only 1D grids (not single-core) trigger intentional conversion
+            if (!is_single_core && (is_1d_column || is_1d_row)) {
+                is_intentional_1d_conversion = true;
+            }
+        }
         if (attributes.output_mem_config.shard_spec().has_value() &&
-            output_tensor_spec.memory_config() != attributes.output_mem_config) {
+            output_tensor_spec.memory_config() != attributes.output_mem_config && !is_intentional_1d_conversion) {
             log_warning(
                 tt::LogOp,
                 "Mismatch between computed {} and provided {} mem config. Using computed config.",

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_device_operation.cpp
@@ -163,11 +163,10 @@ void MatmulDeviceOperation::validate_on_program_cache_miss(
             auto grid_bbox = attributes.output_mem_config.shard_spec()->grid.bounding_box();
             bool is_1d_column = (grid_bbox.end_coord.x == grid_bbox.start_coord.x);
             bool is_1d_row = (grid_bbox.end_coord.y == grid_bbox.start_coord.y);
-            if (is_1d_column &&
-                output_tensor_spec.memory_config().memory_layout() == TensorMemoryLayout::HEIGHT_SHARDED) {
-                memory_layout_compatible = true;
-            } else if (
-                is_1d_row && output_tensor_spec.memory_config().memory_layout() == TensorMemoryLayout::WIDTH_SHARDED) {
+            if ((is_1d_column &&
+                 output_tensor_spec.memory_config().memory_layout() == TensorMemoryLayout::HEIGHT_SHARDED) ||
+                (is_1d_row &&
+                 output_tensor_spec.memory_config().memory_layout() == TensorMemoryLayout::WIDTH_SHARDED)) {
                 memory_layout_compatible = true;
             }
         }

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_device_operation.cpp
@@ -154,8 +154,25 @@ void MatmulDeviceOperation::validate_on_program_cache_miss(
             optional_output_tensor_c->memory_config(),
             attributes.output_mem_config);
     } else {
+        // Allow BLOCK_SHARDED on 1D grids to be converted to HEIGHT_SHARDED or WIDTH_SHARDED
+        bool memory_layout_compatible =
+            output_tensor_spec.memory_config().memory_layout() == attributes.output_mem_config.memory_layout();
+        if (!memory_layout_compatible &&
+            attributes.output_mem_config.memory_layout() == TensorMemoryLayout::BLOCK_SHARDED &&
+            attributes.output_mem_config.shard_spec().has_value()) {
+            auto grid_bbox = attributes.output_mem_config.shard_spec()->grid.bounding_box();
+            bool is_1d_column = (grid_bbox.end_coord.x == grid_bbox.start_coord.x);
+            bool is_1d_row = (grid_bbox.end_coord.y == grid_bbox.start_coord.y);
+            if (is_1d_column &&
+                output_tensor_spec.memory_config().memory_layout() == TensorMemoryLayout::HEIGHT_SHARDED) {
+                memory_layout_compatible = true;
+            } else if (
+                is_1d_row && output_tensor_spec.memory_config().memory_layout() == TensorMemoryLayout::WIDTH_SHARDED) {
+                memory_layout_compatible = true;
+            }
+        }
         TT_FATAL(
-            output_tensor_spec.memory_config().memory_layout() == attributes.output_mem_config.memory_layout(),
+            memory_layout_compatible,
             "Mismatch between computed {} and provided {} mem config memory layout",
             output_tensor_spec.memory_config().memory_layout(),
             attributes.output_mem_config.memory_layout());
@@ -460,9 +477,19 @@ void MatmulDeviceOperation::validate_on_program_cache_miss(
                         }
                     }
                     if (attributes.output_mem_config.is_sharded()) {
+                        // Allow BLOCK_SHARDED on 1-row grids (equivalent to WIDTH_SHARDED)
+                        bool is_width_sharded =
+                            attributes.output_mem_config.memory_layout() == TensorMemoryLayout::WIDTH_SHARDED;
+                        bool is_block_sharded_1d_row = false;
+                        if (attributes.output_mem_config.memory_layout() == TensorMemoryLayout::BLOCK_SHARDED &&
+                            attributes.output_mem_config.shard_spec().has_value()) {
+                            auto grid_bbox = attributes.output_mem_config.shard_spec()->grid.bounding_box();
+                            is_block_sharded_1d_row = (grid_bbox.end_coord.y == grid_bbox.start_coord.y);
+                        }
                         TT_FATAL(
-                            attributes.output_mem_config.memory_layout() == TensorMemoryLayout::WIDTH_SHARDED,
-                            "Error: Output memory layout must be WIDTH_SHARDED. Provided tensor memory layout: {}",
+                            is_width_sharded || is_block_sharded_1d_row,
+                            "Error: Output memory layout must be WIDTH_SHARDED or BLOCK_SHARDED on a 1-row grid. "
+                            "Provided tensor memory layout: {}",
                             attributes.output_mem_config.memory_layout());
                         const auto M = operations::matmul::utilities::get_M_dim(
                             a_shape_padded, in0_tile, program_config.fuse_batch);
@@ -532,9 +559,18 @@ void MatmulDeviceOperation::validate_on_program_cache_miss(
                             "Error: K must be equal to shard_shape[1] / in0_tile.get_width().");
                     }
                     if (attributes.output_mem_config.is_sharded()) {
+                        // Allow BLOCK_SHARDED on 1-column grids (equivalent to HEIGHT_SHARDED)
+                        bool is_height_sharded =
+                            attributes.output_mem_config.memory_layout() == TensorMemoryLayout::HEIGHT_SHARDED;
+                        bool is_block_sharded_1d_column = false;
+                        if (attributes.output_mem_config.memory_layout() == TensorMemoryLayout::BLOCK_SHARDED &&
+                            attributes.output_mem_config.shard_spec().has_value()) {
+                            auto grid_bbox = attributes.output_mem_config.shard_spec()->grid.bounding_box();
+                            is_block_sharded_1d_column = (grid_bbox.end_coord.x == grid_bbox.start_coord.x);
+                        }
                         TT_FATAL(
-                            attributes.output_mem_config.memory_layout() == TensorMemoryLayout::HEIGHT_SHARDED,
-                            "Error: Output memory layout must be HEIGHT_SHARDED.");
+                            is_height_sharded || is_block_sharded_1d_column,
+                            "Error: Output memory layout must be HEIGHT_SHARDED or BLOCK_SHARDED on a 1-column grid.");
                         const auto N = operations::matmul::utilities::get_N_dim(b_shape_padded, in1_tile);
                         uint32_t per_core_N = program_config.per_core_N;
 
@@ -1094,16 +1130,38 @@ MatmulDeviceOperation::spec_return_value_t MatmulDeviceOperation::compute_output
                         "per_core_N must be divisible by override output tile width");
                     auto mem_config = attributes.output_mem_config;
                     if (!program_config.gather_in0) {
-                        uint32_t num_blocks_y = ((M - 1) / per_core_M) + 1;
-                        uint32_t num_blocks_x = ((N - 1) / per_core_N) + 1;
-                        uint32_t num_cores = num_blocks_x * num_blocks_y;
-                        CoreRangeSet all_cores =
-                            num_cores_to_corerangeset(num_cores, program_config.compute_with_storage_grid_size, true);
-                        tt::tt_metal::ShardSpec shard_spec = tt::tt_metal::ShardSpec{
-                            all_cores,
-                            {per_core_M * in0_tile.get_height(), per_core_N * in1_tile.get_width()},
-                            ShardOrientation::ROW_MAJOR};
-                        mem_config = mem_config.with_shard_spec(shard_spec);
+                        // Check if BLOCK_SHARDED on 1D grid - if so, use user's shard spec with converted memory layout
+                        auto memory_layout = mem_config.memory_layout();
+                        bool is_block_sharded_1d = false;
+                        if (memory_layout == TensorMemoryLayout::BLOCK_SHARDED && mem_config.shard_spec().has_value()) {
+                            auto grid_bbox = mem_config.shard_spec()->grid.bounding_box();
+                            bool is_1d_column = (grid_bbox.end_coord.x == grid_bbox.start_coord.x);
+                            bool is_1d_row = (grid_bbox.end_coord.y == grid_bbox.start_coord.y);
+                            is_block_sharded_1d = is_1d_column || is_1d_row;
+                        }
+
+                        if (is_block_sharded_1d) {
+                            // Use user's shard spec with converted memory layout
+                            auto user_shard_spec = mem_config.shard_spec().value();
+                            auto grid_bbox = user_shard_spec.grid.bounding_box();
+                            bool is_1d_column = (grid_bbox.end_coord.x == grid_bbox.start_coord.x);
+                            memory_layout =
+                                is_1d_column ? TensorMemoryLayout::HEIGHT_SHARDED : TensorMemoryLayout::WIDTH_SHARDED;
+                            mem_config =
+                                tt::tt_metal::MemoryConfig{memory_layout, mem_config.buffer_type(), user_shard_spec};
+                        } else {
+                            // Compute shard spec from per_core values
+                            uint32_t num_blocks_y = ((M - 1) / per_core_M) + 1;
+                            uint32_t num_blocks_x = ((N - 1) / per_core_N) + 1;
+                            uint32_t num_cores = num_blocks_x * num_blocks_y;
+                            CoreRangeSet all_cores = num_cores_to_corerangeset(
+                                num_cores, program_config.compute_with_storage_grid_size, true);
+                            tt::tt_metal::ShardSpec shard_spec = tt::tt_metal::ShardSpec{
+                                all_cores,
+                                {per_core_M * in0_tile.get_height(), per_core_N * in1_tile.get_width()},
+                                ShardOrientation::ROW_MAJOR};
+                            mem_config = mem_config.with_shard_spec(shard_spec);
+                        }
                     }
                     // support for multi-tensor output
                     const ttnn::TensorSpec tensor_spec(


### PR DESCRIPTION
### Ticket
Fixes #32306

### Problem description
Previously, matmul with BLOCK_SHARDED output on a 1D core grid (single row or column of cores) and batched inputs would hang indefinitely. This was caused by the 2D multicast program being incorrectly selected for this configuration, but the program's multicast address calculation doesn't handle degenerate 1D grids correctly.

### What's changed
This change:
1. Detects BLOCK_SHARDED on 1D grid configurations early in config selection
2. For unbatched B tensor: Routes to 1D multicast program with proper per_core values derived from the user's shard spec
3. For batched B tensor: Throws a clear error message explaining the limitation and suggesting workarounds

The error message now clearly states:
- BLOCK_SHARDED on 1D grid is not supported with batched matmul
- Users can use HEIGHT_SHARDED/WIDTH_SHARDED explicitly
- Users can use a 2D core grid for BLOCK_SHARDED
- Users can ensure B tensor has batch size 1

This is a partial fix - full support for this configuration would require fixing the 2D multicast program to handle 1D grids correctly.

### Checklist
- [x] Verified that the unsupported configuration now throws a clear error instead of hanging
- [x] Run existing matmul tests to ensure no regression
- [x] Test BLOCK_SHARDED on 1D grid with unbatched B tensor (should work)

- [x] [![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:{{branch_name}}) https://github.com/tenstorrent/tt-metal/actions/runs/23510890371
- [x] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:{{branch_name}}) https://github.com/tenstorrent/tt-metal/actions/runs/23510903094
- [x] [![Nightly - Matmul](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:{{branch_name}}) https://github.com/tenstorrent/tt-metal/actions/runs/23510924515
- [x] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:{{branch_name}})
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:{{branch_name}})
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:{{branch_name}})
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
