### PR TITLE
Fuse Post SDPA with TP All Reduce.

### DIFF
--- a/models/demos/deepseek_v3_b1/fused_ops/post_sdpa/kernels/post_sdpa_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/fused_ops/post_sdpa/kernels/post_sdpa_kernel.cpp
@@ -1,36 +1,47 @@
 // SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 // SPDX-License-Identifier: Apache-2.0
 
-// Post SDPA unified kernel
+// Post SDPA unified kernel with CCL All-Reduce
 // Single kernel file, compiles correctly for all RISC cores
 // Each RISC has its own CTArgs struct with different compile-time arg layout
 //
-// Implements: Matmul1 + Gather1 + Mcast + Matmul2 + Gather2
+// Implements: Matmul1 + Gather1 + Mcast + Matmul2 + Gather2 + CCL All-Reduce
 // - Matmul1: [1, 512] x [512, 128] -> [1, 128] on 64 cores (8x8)
 // - Gather1: Collect [1, 128] from 64 cores to [1, 8192] on gather core
 // - Mcast: Broadcast [1, 8192] to 117 cores (13x9 grid, rectangular)
 // - Matmul2: [1, 8192] x [8192, 64] -> [1, 64] on 112 active cores (rows 0-7 full 13 + row 8 cols 0-7)
 // - Gather2: Collect [1, 64] from 112 active cores to [1, 7168] on gather core
+// - CCL All-Reduce: Exchange [1, 7168] between devices, reduce (local + remote + residual)
 //
 // Note: Mcast grid (13x9=117) includes 5 inactive cores (row 8, cols 8-12) which receive
 // mcast data but skip matmul2 via is_matmul2_core=false
+//
+// CCL Core Layout:
+// - CCL Receiver = Gather core (12, 9): already has local data after Gather2
+// - CCL Sender = Adjacent core (11, 9): reads from gather core, sends via fabric
 
 #include "../../../unified_kernels/kernel_op_api.hpp"
 #include "../../../unified_kernels/kernel_utils.hpp"
 #include "../../../unified_kernels/matmul.hpp"
 #include "../../../unified_kernels/gather.hpp"
 #include "../../../unified_kernels/mcast.hpp"
+#include "../../../unified_kernels/all_reduce_sender.hpp"
+#include "../../../unified_kernels/all_reduce_receiver.hpp"
 
 // Compile-time role flags for dead code elimination via if constexpr
 struct Core {
     // First matmul on 8x8 grid
     static constexpr bool is_matmul1_core = get_named_compile_time_arg_val("is_matmul1_core") == 1;
-    // Gather core (11, 9) - receives gather1, sends mcast, receives gather2
+    // Gather core (12, 9) - receives gather1, sends mcast, receives gather2, CCL receiver
     static constexpr bool is_gather_receiver_core = get_named_compile_time_arg_val("is_gather_receiver_core") == 1;
     // Mcast receiver grid (13x9 = 117 cores) - receives mcast data
     static constexpr bool is_mcast_receiver_core = get_named_compile_time_arg_val("is_mcast_receiver_core") == 1;
     // Active matmul2 cores (112 cores: rows 0-7 full 13 + row 8 cols 0-7)
     static constexpr bool is_matmul2_core = get_named_compile_time_arg_val("is_matmul2_core") == 1;
+    // CCL sender core (11, 9) - reads from gather core, sends via fabric
+    static constexpr bool is_ccl_sender_core = get_named_compile_time_arg_val("is_ccl_sender_core") == 1;
+    // CCL receiver core = gather core (12, 9) - receives remote data, performs reduction
+    static constexpr bool is_ccl_receiver_core = get_named_compile_time_arg_val("is_ccl_receiver_core") == 1;
 };
 
 void kernel_main() {
@@ -41,6 +52,8 @@ void kernel_main() {
 // - Mcast receiver (13x9 grid = 117 cores): receive mcast data
 // - Matmul2 reader (112 active cores): setup weights buffer
 // - Gather2 sender (112 active cores): send matmul2 output to gather core
+// - CCL sender (11, 9): read gather2 output from gather core
+// - CCL receiver (12, 9): wait for remote data, push to compute
 // ============================================================================
 #if defined(COMPILE_FOR_NCRISC)
     // Matmul1 CTArgs
@@ -90,12 +103,34 @@ void kernel_main() {
         get_named_compile_time_arg_val("gather2_row_major"),
         get_named_compile_time_arg_val("gather2_receiver_data_addr"),
     };
+    // CCL Sender NCRISC CTArgs (reads from gather core)
+    using CCLSenderReaderCTArgs = deepseek_b1_ops::AllReduceSender::ReaderCTArgs<
+        get_named_compile_time_arg_val("ccl_sender_cb0_id"),
+        get_named_compile_time_arg_val("ccl_sender_num_tiles"),
+        get_named_compile_time_arg_val("ccl_sender_tensor_page_size"),
+        get_named_compile_time_arg_val("ccl_sender_data_noc_x"),
+        get_named_compile_time_arg_val("ccl_sender_data_noc_y")>;
 
+    // CCL Receiver NCRISC CTArgs (waits for remote data)
+    // Note: skip_local_push=1 because gather2 already pushed to CB7 (gather2_dst_cb)
+    using CCLReceiverReaderCTArgs = deepseek_b1_ops::AllReduceReceiver::ReaderCTArgs<
+        get_named_compile_time_arg_val("ccl_receiver_packet_header_cb_id"),
+        get_named_compile_time_arg_val("ccl_receiver_cb_in1"),
+        get_named_compile_time_arg_val("ccl_receiver_l1_alignment"),
+        get_named_compile_time_arg_val("ccl_receiver_cb_in2"),
+        get_named_compile_time_arg_val("ccl_receiver_remote_sender_noc_x"),
+        get_named_compile_time_arg_val("ccl_receiver_remote_sender_noc_y"),
+        get_named_compile_time_arg_val("ccl_receiver_num_standard_tiles"),
+        get_named_compile_time_arg_val("ccl_receiver_cb_residual"),
+        get_named_compile_time_arg_val("ccl_receiver_has_residual"),
+        get_named_compile_time_arg_val("ccl_receiver_using_persistent_buffer"),
+        get_named_compile_time_arg_val("ccl_receiver_skip_local_push")>;
 // ============================================================================
 // BRISC (Writer)
 // - Gather1 receiver (gather core): receive from 8x8 grid
 // - Mcast sender (gather core): broadcast to 13x9 grid (117 cores)
 // - Gather2 receiver (gather core): receive from 112 active matmul2 cores
+// - CCL sender (11, 9): send gather2 output via fabric
 // ============================================================================
 #elif defined(COMPILE_FOR_BRISC)
     // Matmul1/2 CTArgs (BRISC is no-op for matmul)
@@ -146,10 +181,26 @@ void kernel_main() {
         get_named_compile_time_arg_val("gather2_dst_num_pages"),
     };
 
+    // CCL Sender BRISC CTArgs (sends via fabric)
+    using CCLSenderWriterCTArgs = deepseek_b1_ops::AllReduceSender::WriterCTArgs<
+        get_named_compile_time_arg_val("ccl_sender_packet_header_cb_id"),
+        get_named_compile_time_arg_val("ccl_sender_packet_cb_id"),
+        get_named_compile_time_arg_val("ccl_sender_l1_alignment"),
+        get_named_compile_time_arg_val("ccl_sender_input_num_tiles"),
+        get_named_compile_time_arg_val("ccl_sender_page_size_bytes"),
+        get_named_compile_time_arg_val("ccl_sender_payload_size_bytes"),
+        get_named_compile_time_arg_val("ccl_sender_data_noc_x"),
+        get_named_compile_time_arg_val("ccl_sender_data_noc_y"),
+        get_named_compile_time_arg_val("ccl_sender_remote_receiver_noc_x"),
+        get_named_compile_time_arg_val("ccl_sender_remote_receiver_noc_y"),
+        get_named_compile_time_arg_val("ccl_sender_dst_num_hops"),
+        get_named_compile_time_arg_val("ccl_sender_num_connections"),
+        get_named_compile_time_arg_val("ccl_sender_using_persistent_buffer")>;
 // ============================================================================
 // TRISC (Compute)
 // - Matmul1 compute (8x8 grid)
 // - Matmul2 compute (112 active cores)
+// - CCL receiver compute (gather core): reduction (local + remote + residual)
 // ============================================================================
 #elif defined(COMPILE_FOR_TRISC)
     // Matmul1 CTArgs
@@ -181,6 +232,16 @@ void kernel_main() {
 
     // Gather2 compute args (no-op)
     deepseek_b1_ops::Gather::ComputeArgs gather2_args{};
+
+    // CCL Receiver compute CTArgs (reduction)
+    using CCLReceiverComputeCTArgs = deepseek_b1_ops::AllReduceReceiver::ComputeCTArgs<
+        get_named_compile_time_arg_val("ccl_receiver_cb_in0"),
+        get_named_compile_time_arg_val("ccl_receiver_cb_in1"),
+        get_named_compile_time_arg_val("ccl_receiver_cb_out0"),
+        get_named_compile_time_arg_val("ccl_receiver_cb_residual"),
+        get_named_compile_time_arg_val("ccl_receiver_cb_temp"),
+        get_named_compile_time_arg_val("ccl_receiver_has_residual"),
+        get_named_compile_time_arg_val("ccl_receiver_num_tiles")>;
 #endif
 
     // ========================================================================
@@ -217,7 +278,7 @@ void kernel_main() {
     }
 
     // ========================================================================
-    // Gather1: 8x8 matmul cores -> gather core (11, 9)
+    // Gather1: 8x8 matmul cores -> gather core (12, 9)
     // Collects [1, 128] * 64 = [1, 8192]
     // ========================================================================
     {
@@ -263,7 +324,7 @@ void kernel_main() {
     }
 
     // ========================================================================
-    // Gather2: 112 active matmul2 cores -> gather core (11, 9)
+    // Gather2: 112 active matmul2 cores -> gather core (12, 9)
     // Collects [1, 64] * 112 = [1, 7168]
     // ========================================================================
     {
@@ -271,4 +332,93 @@ void kernel_main() {
         deepseek_b1_ops::Gather::Op<Core::is_matmul2_core, Core::is_gather_receiver_core, true> gather2;
         gather2(gather2_args);
     }
+
+#if defined(COMPILE_FOR_BRISC)
+    // Signal CCL sender that gather2 is complete (gather receiver only)
+    if constexpr (Core::is_gather_receiver_core) {
+        constexpr uint32_t gather2_completion_semaphore_id =
+            get_named_compile_time_arg_val("gather2_completion_semaphore_id");
+        constexpr uint32_t ccl_sender_noc_x = get_named_compile_time_arg_val("ccl_sender_noc_x");
+        constexpr uint32_t ccl_sender_noc_y = get_named_compile_time_arg_val("ccl_sender_noc_y");
+        uint64_t ccl_sender_semaphore_addr =
+            get_noc_addr(ccl_sender_noc_x, ccl_sender_noc_y, get_semaphore(gather2_completion_semaphore_id));
+        noc_semaphore_inc(ccl_sender_semaphore_addr, 1);
+    }
+#endif
+
+    // ========================================================================
+    // CCL All-Reduce: Exchange [1, 7168] between devices
+    // - CCL Sender (11, 9): Reads gather2 output from gather core, sends via fabric
+    // - CCL Receiver (12, 9): Receives remote data, performs reduction
+    //
+    // Note: skip_local_push=1 is set for CCLReceiverReaderCTArgs because
+    // gather2 already pushed to CB7 (gather2_dst_cb). The receiver just
+    // needs to wait for remote data and perform the reduction.
+    // ========================================================================
+#if defined(COMPILE_FOR_NCRISC)
+    if constexpr (Core::is_ccl_sender_core) {
+        DeviceZoneScopedN("CCL_SENDER_READ");
+
+        // Wait for gather2 to complete before reading from gather core
+        constexpr uint32_t gather2_completion_semaphore_id =
+            get_named_compile_time_arg_val("ccl_sender_gather2_completion_semaphore_id");
+        volatile tt_l1_ptr uint32_t* gather2_completion_semaphore_addr =
+            reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_semaphore(gather2_completion_semaphore_id));
+        noc_semaphore_wait(gather2_completion_semaphore_addr, 1);
+        noc_semaphore_set(gather2_completion_semaphore_addr, 0);
+
+        // Dummy WriterCTArgs - not used by NCRISC but needed for Op template
+        using DummyWriterCTArgs = deepseek_b1_ops::AllReduceSender::WriterCTArgs<0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0>;
+
+        deepseek_b1_ops::AllReduceSender::RTArgs ccl_sender_args{};
+        ccl_sender_args.tensor_address = get_arg_val<uint32_t>(0);
+        size_t fabric_arg_idx = 1;
+
+        deepseek_b1_ops::AllReduceSender::Op<CCLSenderReaderCTArgs, DummyWriterCTArgs> ccl_sender_reader;
+        ccl_sender_reader(ccl_sender_args, fabric_arg_idx);
+    }
+
+    if constexpr (Core::is_ccl_receiver_core) {
+        DeviceZoneScopedN("CCL_RECEIVER_WAIT");
+        // Dummy ComputeCTArgs - not used by NCRISC but needed for Op template
+        using DummyComputeCTArgs = deepseek_b1_ops::AllReduceReceiver::ComputeCTArgs<0, 0, 0, 0, 0, 0, 0>;
+
+        deepseek_b1_ops::AllReduceReceiver::RTArgs ccl_receiver_args{};
+        ccl_receiver_args.sender_semaphore_addr = get_arg_val<uint32_t>(0);
+        size_t fabric_arg_idx = 1;
+
+        deepseek_b1_ops::AllReduceReceiver::Op<CCLReceiverReaderCTArgs, DummyComputeCTArgs> ccl_receiver_reader;
+        ccl_receiver_reader(ccl_receiver_args, fabric_arg_idx);
+    }
+
+#elif defined(COMPILE_FOR_BRISC)
+    if constexpr (Core::is_ccl_sender_core) {
+        DeviceZoneScopedN("CCL_SENDER_SEND");
+        // Dummy ReaderCTArgs - not used by BRISC but needed for Op template
+        using DummyReaderCTArgs = deepseek_b1_ops::AllReduceSender::ReaderCTArgs<0, 0, 0, 0, 0>;
+
+        deepseek_b1_ops::AllReduceSender::RTArgs ccl_sender_args{};
+        ccl_sender_args.receiver_base_address = get_arg_val<uint32_t>(0);
+        ccl_sender_args.receive_semaphore_addr = get_arg_val<uint32_t>(1);
+        size_t fabric_arg_idx = 2;
+
+        deepseek_b1_ops::AllReduceSender::Op<DummyReaderCTArgs, CCLSenderWriterCTArgs> ccl_sender_writer;
+        ccl_sender_writer(ccl_sender_args, fabric_arg_idx);
+    }
+    // CCL Receiver BRISC is no-op
+
+#elif defined(COMPILE_FOR_TRISC)
+    if constexpr (Core::is_ccl_receiver_core) {
+        DeviceZoneScopedN("CCL_RECEIVER_COMPUTE");
+        // Dummy ReaderCTArgs - not used by TRISC but needed for Op template
+        using DummyReaderCTArgs = deepseek_b1_ops::AllReduceReceiver::ReaderCTArgs<0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0>;
+
+        deepseek_b1_ops::AllReduceReceiver::RTArgs ccl_receiver_args{};
+        size_t fabric_arg_idx = 0;
+
+        deepseek_b1_ops::AllReduceReceiver::Op<DummyReaderCTArgs, CCLReceiverComputeCTArgs> ccl_receiver_compute;
+        ccl_receiver_compute(ccl_receiver_args, fabric_arg_idx);
+    }
+    // CCL Sender TRISC is no-op
+#endif
 }

--- a/models/demos/deepseek_v3_b1/fused_ops/post_sdpa/kernels/post_sdpa_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/fused_ops/post_sdpa/kernels/post_sdpa_kernel.cpp
@@ -371,8 +371,8 @@ void kernel_main() {
         using DummyWriterCTArgs = deepseek_b1_ops::AllReduceSender::WriterCTArgs<0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0>;
 
         deepseek_b1_ops::AllReduceSender::RTArgs ccl_sender_args{};
-        ccl_sender_args.tensor_address = get_arg_val<uint32_t>(0);
-        size_t fabric_arg_idx = 1;
+        ccl_sender_args.tensor_address = get_common_arg_val<uint32_t>(0);
+        size_t fabric_arg_idx = 0;
 
         deepseek_b1_ops::AllReduceSender::Op<CCLSenderReaderCTArgs, DummyWriterCTArgs> ccl_sender_reader;
         ccl_sender_reader(ccl_sender_args, fabric_arg_idx);
@@ -384,8 +384,8 @@ void kernel_main() {
         using DummyComputeCTArgs = deepseek_b1_ops::AllReduceReceiver::ComputeCTArgs<0, 0, 0, 0, 0, 0, 0>;
 
         deepseek_b1_ops::AllReduceReceiver::RTArgs ccl_receiver_args{};
-        ccl_receiver_args.sender_semaphore_addr = get_arg_val<uint32_t>(0);
-        size_t fabric_arg_idx = 1;
+        ccl_receiver_args.sender_semaphore_addr = get_common_arg_val<uint32_t>(0);
+        size_t fabric_arg_idx = 0;
 
         deepseek_b1_ops::AllReduceReceiver::Op<CCLReceiverReaderCTArgs, DummyComputeCTArgs> ccl_receiver_reader;
         ccl_receiver_reader(ccl_receiver_args, fabric_arg_idx);
@@ -398,9 +398,9 @@ void kernel_main() {
         using DummyReaderCTArgs = deepseek_b1_ops::AllReduceSender::ReaderCTArgs<0, 0, 0, 0, 0>;
 
         deepseek_b1_ops::AllReduceSender::RTArgs ccl_sender_args{};
-        ccl_sender_args.receiver_base_address = get_arg_val<uint32_t>(0);
-        ccl_sender_args.receive_semaphore_addr = get_arg_val<uint32_t>(1);
-        size_t fabric_arg_idx = 2;
+        ccl_sender_args.receiver_base_address = get_common_arg_val<uint32_t>(0);
+        ccl_sender_args.receive_semaphore_addr = get_common_arg_val<uint32_t>(1);
+        size_t fabric_arg_idx = 0;
 
         deepseek_b1_ops::AllReduceSender::Op<DummyReaderCTArgs, CCLSenderWriterCTArgs> ccl_sender_writer;
         ccl_sender_writer(ccl_sender_args, fabric_arg_idx);

--- a/models/demos/deepseek_v3_b1/fused_ops/post_sdpa/op.py
+++ b/models/demos/deepseek_v3_b1/fused_ops/post_sdpa/op.py
@@ -3,17 +3,22 @@
 # SPDX-License-Identifier: Apache-2.0
 
 """
-Post SDPA fused operation.
+Post SDPA fused operation with CCL All-Reduce.
 
-This implements Matmul1 + Gather1 + Mcast + Matmul2 + Gather2 as a fused execution:
+This implements Matmul1 + Gather1 + Mcast + Matmul2 + Gather2 + CCL All-Reduce as a fused execution:
 - Matmul1: [1, 512] x [512, 128] -> [1, 128] distributed across 64 cores (8x8 grid)
 - Gather1: Collect results from all 64 cores to [1, 8192] on gather core (12, 9)
 - Mcast: Broadcast [1, 8192] to 117 cores (13x9 grid, rectangular for efficient mcast)
 - Matmul2: [1, 8192] x [8192, 64] -> [1, 64] on 112 active cores (rows 0-7 full 13 + row 8 cols 0-7)
 - Gather2: Collect results from all 112 active cores to [1, 7168] on gather core (12, 9)
+- CCL All-Reduce: Exchange [1, 7168] between devices and reduce (local + remote + residual)
 
 The 13x9 mcast grid contains 117 cores, but only 112 are active for matmul2.
 The 5 inactive cores (row 8, cols 8-12) receive mcast data but skip matmul via is_matmul2_core=false.
+
+CCL All-Reduce uses:
+- CCL Receiver core = Gather core (12, 9) - already has local data after Gather2
+- CCL Sender core = Adjacent core (11, 9) - reads from gather core, sends via fabric
 
 CB Layout:
 - CB 0: matmul1_in0 (8x8 grid)
@@ -23,8 +28,16 @@ CB Layout:
 - CB 4: mcast_dst = matmul2_in0 (13x9 grid)
 - CB 5: matmul2_in1 (112 active matmul2 cores)
 - CB 6: matmul2_out (112 active matmul2 cores)
-- CB 7: gather2_dst (gather core)
+- CB 7: gather2_dst = ccl_local_data (gather core)
+- CB 8: ccl_sender_in (ccl sender core)
+- CB 9: ccl_remote_data (gather/receiver core - intermediate tensor)
+- CB 10: ccl_residual (gather/receiver core - optional)
+- CB 11: ccl_temp (gather/receiver core - for compute)
+- CB 12: ccl_output (gather/receiver core - final output)
+- CB 13: ccl_packet_header (sender + receiver cores)
 """
+
+import torch
 
 import ttnn
 from models.demos.deepseek_v3_b1.unified_kernel_descriptor import (
@@ -37,54 +50,96 @@ class PostSDPA:
     """
     Post SDPA fused operation implementation using ttnn.generic_op.
 
-    Implements the full post_sdpa fusion:
-    - Matmul1 + Gather1 + Mcast + Matmul2 + Gather2
+    Implements the full post_sdpa fusion with CCL all-reduce:
+    - Matmul1 + Gather1 + Mcast + Matmul2 + Gather2 + CCL All-Reduce
     """
 
     @staticmethod
-    def golden(input_tensor, weights1_tensor, weights2_tensor):
+    def golden(input_tensors, weights1_tensor, weights2_tensor, residual_tensor=None):
         """
         PyTorch reference implementation for validation.
 
         Args:
-            input_tensor: Input tensor (torch.Tensor) [1, 512]
+            input_tensors: List of input tensors (torch.Tensor) [1, 512], one per device
             weights1_tensor: First weights tensor (torch.Tensor) [512, 8192]
             weights2_tensor: Second weights tensor (torch.Tensor) [8192, 7168]
+            residual_tensor: Optional residual tensor to add after reduction [1, 7168]
 
         Returns:
-            Output tensor [1, 7168]
+            Output tensor [1, 7168] - result of all-reduce across devices
         """
-        intermediate = input_tensor @ weights1_tensor  # [1, 8192]
-        return intermediate @ weights2_tensor  # [1, 6144]
+        # Compute matmul chain for each device
+        device_results = []
+        for input_tensor in input_tensors:
+            intermediate = input_tensor @ weights1_tensor  # [1, 8192]
+            result = intermediate @ weights2_tensor  # [1, 7168]
+            device_results.append(result)
+
+        # All-reduce: sum across all devices
+        reduced = torch.sum(torch.stack(device_results), dim=0)
+
+        # Add residual if provided
+        if residual_tensor is not None:
+            reduced = reduced + residual_tensor
+
+        return reduced
 
     @staticmethod
     def op(
-        input_tensor,
+        input_tensor_mesh,
         weights1_tensor,
         weights2_tensor,
         gather1_output_tensor,
+        gather2_output_tensor,
+        intermediate_tensor,
         output_tensor,
+        semaphores,
+        cluster_axis=0,
+        residual_tensor_mesh=None,
         fp32_dest_acc_en=False,
     ):
         """
-        Execute post_sdpa fused operation using generic_op.
+        Execute post_sdpa fused operation with CCL all-reduce using generic_op.
 
         Args:
-            input_tensor: Input tensor [1, 512] (height-sharded across 8x8 matmul1 cores)
+            input_tensor_mesh: Input tensor mesh [1, 512] (height-sharded across 8x8 matmul1 cores)
             weights1_tensor: First weights tensor [512, 8192] (width-sharded across 8x8)
-            weights2_tensor: Second weights tensor [8192, 7168] (width-sharded across 14x8)
+            weights2_tensor: Second weights tensor [8192, 7168] (width-sharded across 112 cores)
             gather1_output_tensor: Intermediate tensor [1, 8192] for gather1/mcast (on gather core)
-            output_tensor: Final output tensor [1, 7168] (on gather core)
+            gather2_output_tensor: Intermediate tensor mesh [1, 7168] for gather2/CCL (on gather core per device)
+            intermediate_tensor: CCL intermediate tensor mesh for receiving remote data (32x32 tiles)
+            output_tensor: Final output tensor mesh [1, 7168]
+            semaphores: List of two global semaphores for CCL synchronization
+            cluster_axis: Axis for all-reduce (default 0)
+            residual_tensor_mesh: Optional tensor mesh for residuals [1, 7168]
             fp32_dest_acc_en: Whether to enable FP32 accumulation in compute kernel
 
         Returns:
-            Output tensor with full fused result
+            Output tensor mesh with full fused result including all-reduce
         """
-        # Get device
-        device = input_tensor.device()
+        mesh_device = input_tensor_mesh.device()
+        mesh_shape = mesh_device.shape
+        mesh_rows = mesh_shape[0]
+        mesh_cols = mesh_shape[1]
 
-        # Get tensor properties
-        data_format = input_tensor.dtype
+        # Get per-device tensors
+        input_tensors_per_device = ttnn.get_device_tensors(input_tensor_mesh)
+        gather2_output_tensors_per_device = ttnn.get_device_tensors(gather2_output_tensor)
+        intermediate_tensors_per_device = ttnn.get_device_tensors(intermediate_tensor)
+        output_tensors_per_device = ttnn.get_device_tensors(output_tensor)
+        if residual_tensor_mesh is not None:
+            residual_tensors_per_device = ttnn.get_device_tensors(residual_tensor_mesh)
+
+        # CCL semaphores
+        ccl_semaphore1 = semaphores[0]
+        ccl_semaphore2 = semaphores[1]
+        ccl_semaphore1_addr = ttnn.get_global_semaphore_address(ccl_semaphore1)
+        ccl_semaphore2_addr = ttnn.get_global_semaphore_address(ccl_semaphore2)
+
+        # Get tensor properties from first device
+        input_tensor_sample = input_tensors_per_device[0]
+        data_format = input_tensor_sample.dtype
+        element_size = 2  # bfloat16
 
         # Tile definitions
         TILE_1x32 = ttnn.Tile((1, 32))
@@ -92,8 +147,14 @@ class PostSDPA:
         tile_1x32_size = TILE_1x32.get_tile_size(data_format)
         tile_32x32_size = TILE_32x32.get_tile_size(data_format)
 
+        # CCL intermediate tensor info (32x32 tiles)
+        intermediate_tensor_sample = intermediate_tensors_per_device[0]
+        intermediate_tile = intermediate_tensor_sample.tile
+        intermediate_tile_height, intermediate_tile_width = intermediate_tile.tile_shape
+        standard_tile_size_bytes = intermediate_tile_height * intermediate_tile_width * element_size
+
         # ========================================================================
-        # Core grid configuration
+        # Core grid configuration (same for all devices)
         # ========================================================================
         # Matmul1 grid: 8x8 = 64 cores
         MATMUL1_GRID_START_X = 0
@@ -107,9 +168,13 @@ class PostSDPA:
         matmul1_core_grid = ttnn.CoreRangeSet([matmul1_grid])
         num_matmul1_cores = matmul1_grid.grid_size().x * matmul1_grid.grid_size().y  # 64
 
-        # Gather receiver core: (12, 9)
+        # Gather/CCL receiver core: (12, 9)
         gather_core = ttnn.CoreCoord(12, 9)
         gather_core_grid = ttnn.CoreRangeSet([ttnn.CoreRange(gather_core, gather_core)])
+
+        # CCL sender core: (11, 9) - adjacent to gather core
+        ccl_sender_core = ttnn.CoreCoord(11, 9)
+        ccl_sender_core_grid = ttnn.CoreRangeSet([ttnn.CoreRange(ccl_sender_core, ccl_sender_core)])
 
         # Mcast grid: 13x9 = 117 cores (full rectangular for efficient mcast)
         MCAST_GRID_START_X = 0
@@ -124,9 +189,6 @@ class PostSDPA:
         num_mcast_cores = mcast_grid.grid_size().x * mcast_grid.grid_size().y  # 117
 
         # Active Matmul2 cores: 112 cores (rows 0-7 full 13 cols + row 8 cols 0-7)
-        # This is a non-rectangular grid defined as two CoreRanges:
-        # - Rows 0-7: all 13 columns = 104 cores
-        # - Row 8: columns 0-7 = 8 cores
         matmul2_grid_main = ttnn.CoreRange(
             ttnn.CoreCoord(0, 0),
             ttnn.CoreCoord(12, 7),  # 13 columns x 8 rows = 104 cores
@@ -145,12 +207,7 @@ class PostSDPA:
         MATMUL2_GRID_END_Y = 8
 
         # Full grid (union of all cores for semaphore allocation)
-        full_grid = matmul1_core_grid.merge(gather_core_grid).merge(mcast_core_grid)
-
-        # Get NOC coordinates
-        gather_dest_noc_core = device.worker_core_from_logical_core(gather_core)
-        mcast_dest_noc_start_core = device.worker_core_from_logical_core(mcast_grid.start)
-        mcast_dest_noc_end_core = device.worker_core_from_logical_core(mcast_grid.end)
+        full_grid = matmul1_core_grid.merge(gather_core_grid).merge(mcast_core_grid).merge(ccl_sender_core_grid)
 
         # ========================================================================
         # Matmul1 parameters: [1, 512] x [512, 128] -> [1, 128]
@@ -174,7 +231,13 @@ class PostSDPA:
         matmul2_in0_cb = 4  # Mcast dst = Matmul2 input (13x9 mcast grid)
         matmul2_in1_cb = 5  # Matmul2 weights (112 active cores)
         matmul2_out_cb = 6  # Matmul2 output (112 active cores)
-        gather2_dst_cb = 7  # Gather2 output = final output (gather core)
+        gather2_dst_cb = 7  # Gather2 output = CCL local data (gather core)
+        ccl_sender_in_cb = 8  # CCL sender reads gather2 output (sender core)
+        ccl_remote_data_cb = 9  # CCL received remote data (receiver core)
+        ccl_residual_cb = 10  # CCL residual (receiver core)
+        ccl_temp_cb = 11  # CCL temp for compute (receiver core)
+        ccl_output_cb = 12  # CCL output (receiver core)
+        ccl_packet_header_cb = 13  # CCL packet headers (sender + receiver cores)
 
         # ========================================================================
         # Gather1 parameters: 64 cores -> [1, 8192]
@@ -191,7 +254,6 @@ class PostSDPA:
         mcast_data_size_bytes = gather1_dst_num_pages * tile_1x32_size  # 256 * 64 = 16384 bytes
         mcast_src_num_pages = gather1_dst_num_pages  # 256 pages
         mcast_dst_num_pages = gather1_dst_num_pages  # 256 pages per receiver
-        mcast_is_part_of_receiver_grid = mcast_grid.contains(gather_core)
 
         # ========================================================================
         # Gather2 parameters: 112 cores -> [1, 7168]
@@ -203,6 +265,21 @@ class PostSDPA:
         gather2_noc1_num_senders = 0
 
         # ========================================================================
+        # CCL parameters: [1, 7168] all-reduce
+        # ========================================================================
+        # Using 1x32 tiles to match gather2 output format (for tile-compatible reduction)
+        # 7168 elements = 224 tiles of 1x32 (32 elements each)
+        ccl_num_tiles = gather2_dst_num_pages  # 224 tiles of 1x32
+        ccl_page_size_bytes = tile_1x32_size  # 1x32 tile size
+        ccl_num_pages = gather2_dst_num_pages  # 224 pages of 1x32
+        ccl_payload_size_bytes = ccl_num_pages * ccl_page_size_bytes  # 224 * 64 = 14336 bytes
+        ccl_packet_header_size_bytes = 32
+        l1_alignment = 16
+
+        has_residual = 1 if residual_tensor_mesh is not None else 0
+        using_persistent_buffers = 1  # Use persistent buffers for CCL
+
+        # ========================================================================
         # Semaphore IDs
         # ========================================================================
         gather1_noc0_receiver_semaphore_id = 0
@@ -211,280 +288,549 @@ class PostSDPA:
         mcast_data_receiver_semaphore_id = 3
         gather2_noc0_receiver_semaphore_id = 4
         gather2_noc1_receiver_semaphore_id = 5
+        gather2_completion_semaphore_id = 6  # Gather2 signals, CCL sender waits
+        # CCL uses global semaphores (passed via runtime args)
 
-        # ========================================================================
-        # Buffer addresses
-        # ========================================================================
-        gather1_receiver_data_addr = gather1_output_tensor.buffer_address()
-        mcast_receiver_data_addr = weights2_tensor.buffer_address()  # Actually mcast writes to matmul2_in0
-        gather2_receiver_data_addr = output_tensor.buffer_address()
+        # Create mesh program descriptor
+        mesh_program_descriptor = ttnn.MeshProgramDescriptor()
 
-        # ========================================================================
-        # NCRISC compile-time args
-        # ========================================================================
-        ncrisc_named_compile_time_args = [
-            # Matmul1
-            ("matmul1_in0", matmul1_in0_cb),
-            ("matmul1_in1", matmul1_in1_cb),
-            ("matmul1_out", matmul1_out_cb),
-            ("matmul1_k_num_tiles", matmul1_k_num_tiles),
-            ("matmul1_out_w_per_core", matmul1_out_w_per_core),
-            # Gather1 sender
-            ("gather1_dest_noc_x", gather_dest_noc_core.x),
-            ("gather1_dest_noc_y", gather_dest_noc_core.y),
-            ("gather1_data_size_bytes", gather1_data_size_bytes),
-            ("gather1_receiver_semaphore_id", gather1_noc0_receiver_semaphore_id),
-            ("gather1_src_cb", matmul1_out_cb),
-            ("gather1_src_num_pages", gather1_src_num_pages),
-            ("gather1_sender_grid_start_x", MATMUL1_GRID_START_X),
-            ("gather1_sender_grid_start_y", MATMUL1_GRID_START_Y),
-            ("gather1_sender_grid_end_x", MATMUL1_GRID_END_X),
-            ("gather1_sender_grid_end_y", MATMUL1_GRID_END_Y),
-            ("gather1_row_major", 1),
-            ("gather1_receiver_data_addr", gather1_receiver_data_addr),
-            # Mcast receiver
-            ("mcast_data_receiver_semaphore", mcast_data_receiver_semaphore_id),
-            ("mcast_dst_cb", matmul2_in0_cb),
-            ("mcast_dst_num_pages", mcast_dst_num_pages),
-            # Matmul2
-            ("matmul2_in0", matmul2_in0_cb),
-            ("matmul2_in1", matmul2_in1_cb),
-            ("matmul2_out", matmul2_out_cb),
-            ("matmul2_k_num_tiles", matmul2_k_num_tiles),
-            ("matmul2_out_w_per_core", matmul2_out_w_per_core),
-            # Gather2 sender
-            ("gather2_dest_noc_x", gather_dest_noc_core.x),
-            ("gather2_dest_noc_y", gather_dest_noc_core.y),
-            ("gather2_data_size_bytes", gather2_data_size_bytes),
-            ("gather2_receiver_semaphore_id", gather2_noc0_receiver_semaphore_id),
-            ("gather2_src_cb", matmul2_out_cb),
-            ("gather2_src_num_pages", gather2_src_num_pages),
-            ("gather2_sender_grid_start_x", MATMUL2_GRID_START_X),
-            ("gather2_sender_grid_start_y", MATMUL2_GRID_START_Y),
-            ("gather2_sender_grid_end_x", MATMUL2_GRID_END_X),
-            ("gather2_sender_grid_end_y", MATMUL2_GRID_END_Y),
-            ("gather2_row_major", 1),
-            ("gather2_receiver_data_addr", gather2_receiver_data_addr),
+        # For each device in the mesh, create appropriate program
+        for row in range(mesh_rows):
+            for col in range(mesh_cols):
+                coord = ttnn.MeshCoordinate(row, col)
+                device_idx = row * mesh_cols + col
+
+                # Ring index along the cluster axis
+                ring_index = row if cluster_axis == 0 else col
+                is_first_chip = ring_index == 0
+
+                # Get the device's tensors
+                input_tensor_device = input_tensors_per_device[device_idx]
+                gather2_output_tensor_device = gather2_output_tensors_per_device[device_idx]
+                output_tensor_device = output_tensors_per_device[device_idx]
+                intermediate_tensor_device = intermediate_tensors_per_device[device_idx]
+
+                device = input_tensor_device.device()
+
+                # Get NOC coordinates for this device
+                gather_dest_noc_core = device.worker_core_from_logical_core(gather_core)
+                mcast_dest_noc_start_core = device.worker_core_from_logical_core(mcast_grid.start)
+                mcast_dest_noc_end_core = device.worker_core_from_logical_core(mcast_grid.end)
+                ccl_sender_noc_core = device.worker_core_from_logical_core(ccl_sender_core)
+                ccl_receiver_noc_core = gather_dest_noc_core  # Same as gather core
+
+                # Determine CCL neighbor and semaphores based on position
+                ccl_sender_link = 0 if is_first_chip else 1
+                ccl_receiver_link = 1 if is_first_chip else 0
+                ccl_sender_semaphore_addr = ccl_semaphore1_addr if is_first_chip else ccl_semaphore2_addr
+                ccl_receiver_semaphore_addr = ccl_semaphore2_addr if is_first_chip else ccl_semaphore1_addr
+
+                # Calculate neighbor coordinate
+                if is_first_chip:
+                    neighbor_row = row + 1 if cluster_axis == 0 else row
+                    neighbor_col = col if cluster_axis == 0 else col + 1
+                else:
+                    neighbor_row = row - 1 if cluster_axis == 0 else row
+                    neighbor_col = col if cluster_axis == 0 else col - 1
+
+                # Buffer addresses
+                gather1_receiver_data_addr = gather1_output_tensor.buffer_address()
+                # Gather2 writes to gather2_output_tensor, CCL reads from there and writes to output_tensor
+                gather2_receiver_data_addr = gather2_output_tensor_device.buffer_address()
+
+                mcast_is_part_of_receiver_grid = mcast_grid.contains(gather_core)
+
+                # ========================================================================
+                # NCRISC compile-time args
+                # ========================================================================
+                ncrisc_named_compile_time_args = [
+                    # Matmul1
+                    ("matmul1_in0", matmul1_in0_cb),
+                    ("matmul1_in1", matmul1_in1_cb),
+                    ("matmul1_out", matmul1_out_cb),
+                    ("matmul1_k_num_tiles", matmul1_k_num_tiles),
+                    ("matmul1_out_w_per_core", matmul1_out_w_per_core),
+                    # Gather1 sender
+                    ("gather1_dest_noc_x", gather_dest_noc_core.x),
+                    ("gather1_dest_noc_y", gather_dest_noc_core.y),
+                    ("gather1_data_size_bytes", gather1_data_size_bytes),
+                    ("gather1_receiver_semaphore_id", gather1_noc0_receiver_semaphore_id),
+                    ("gather1_src_cb", matmul1_out_cb),
+                    ("gather1_src_num_pages", gather1_src_num_pages),
+                    ("gather1_sender_grid_start_x", MATMUL1_GRID_START_X),
+                    ("gather1_sender_grid_start_y", MATMUL1_GRID_START_Y),
+                    ("gather1_sender_grid_end_x", MATMUL1_GRID_END_X),
+                    ("gather1_sender_grid_end_y", MATMUL1_GRID_END_Y),
+                    ("gather1_row_major", 1),
+                    ("gather1_receiver_data_addr", gather1_receiver_data_addr),
+                    # Mcast receiver
+                    ("mcast_data_receiver_semaphore", mcast_data_receiver_semaphore_id),
+                    ("mcast_dst_cb", matmul2_in0_cb),
+                    ("mcast_dst_num_pages", mcast_dst_num_pages),
+                    # Matmul2
+                    ("matmul2_in0", matmul2_in0_cb),
+                    ("matmul2_in1", matmul2_in1_cb),
+                    ("matmul2_out", matmul2_out_cb),
+                    ("matmul2_k_num_tiles", matmul2_k_num_tiles),
+                    ("matmul2_out_w_per_core", matmul2_out_w_per_core),
+                    # Gather2 sender
+                    ("gather2_dest_noc_x", gather_dest_noc_core.x),
+                    ("gather2_dest_noc_y", gather_dest_noc_core.y),
+                    ("gather2_data_size_bytes", gather2_data_size_bytes),
+                    ("gather2_receiver_semaphore_id", gather2_noc0_receiver_semaphore_id),
+                    ("gather2_src_cb", matmul2_out_cb),
+                    ("gather2_src_num_pages", gather2_src_num_pages),
+                    ("gather2_sender_grid_start_x", MATMUL2_GRID_START_X),
+                    ("gather2_sender_grid_start_y", MATMUL2_GRID_START_Y),
+                    ("gather2_sender_grid_end_x", MATMUL2_GRID_END_X),
+                    ("gather2_sender_grid_end_y", MATMUL2_GRID_END_Y),
+                    ("gather2_row_major", 1),
+                    ("gather2_receiver_data_addr", gather2_receiver_data_addr),
+                    # CCL sender (NCRISC reads from gather core)
+                    ("ccl_sender_cb0_id", ccl_sender_in_cb),
+                    ("ccl_sender_num_tiles", ccl_num_pages),
+                    ("ccl_sender_tensor_page_size", ccl_page_size_bytes),
+                    ("ccl_sender_data_noc_x", ccl_receiver_noc_core.x),
+                    ("ccl_sender_data_noc_y", ccl_receiver_noc_core.y),
+                    ("ccl_sender_gather2_completion_semaphore_id", gather2_completion_semaphore_id),
+                    # CCL receiver (NCRISC waits for remote data)
+                    ("ccl_receiver_packet_header_cb_id", ccl_packet_header_cb),
+                    ("ccl_receiver_cb_in1", ccl_remote_data_cb),
+                    ("ccl_receiver_l1_alignment", l1_alignment),
+                    ("ccl_receiver_cb_in2", gather2_dst_cb),  # Local data from gather2
+                    ("ccl_receiver_remote_sender_noc_x", ccl_sender_noc_core.x),
+                    ("ccl_receiver_remote_sender_noc_y", ccl_sender_noc_core.y),
+                    ("ccl_receiver_num_standard_tiles", ccl_num_tiles),
+                    ("ccl_receiver_cb_residual", ccl_residual_cb),
+                    ("ccl_receiver_has_residual", has_residual),
+                    ("ccl_receiver_using_persistent_buffer", using_persistent_buffers),
+                    ("ccl_receiver_skip_local_push", 1),  # Skip local push since gather2 already pushed to CB7
+                ]
+
+                # ========================================================================
+                # BRISC compile-time args
+                # ========================================================================
+                brisc_named_compile_time_args = [
+                    # Matmul1/2 (no-op)
+                    ("matmul1_out", matmul1_out_cb),
+                    ("matmul2_out", matmul2_out_cb),
+                    # Gather1 receiver
+                    ("gather1_noc0_num_senders", gather1_noc0_num_senders),
+                    ("gather1_noc1_num_senders", gather1_noc1_num_senders),
+                    ("gather1_noc0_receiver_semaphore_id", gather1_noc0_receiver_semaphore_id),
+                    ("gather1_noc1_receiver_semaphore_id", gather1_noc1_receiver_semaphore_id),
+                    ("gather1_dst_cb", gather1_dst_cb),
+                    ("gather1_dst_num_pages", gather1_dst_num_pages),
+                    # Mcast sender
+                    ("mcast_dest_noc_start_x", mcast_dest_noc_start_core.x),
+                    ("mcast_dest_noc_start_y", mcast_dest_noc_start_core.y),
+                    ("mcast_dest_noc_end_x", mcast_dest_noc_end_core.x),
+                    ("mcast_dest_noc_end_y", mcast_dest_noc_end_core.y),
+                    ("mcast_num_cores", num_mcast_cores),
+                    ("mcast_data_sender_semaphore", mcast_data_sender_semaphore_id),
+                    ("mcast_data_receiver_semaphore", mcast_data_receiver_semaphore_id),
+                    ("mcast_data_size_bytes", mcast_data_size_bytes),
+                    ("mcast_src_cb", gather1_dst_cb),
+                    ("mcast_src_num_pages", mcast_src_num_pages),
+                    ("mcast_dst_cb", matmul2_in0_cb),
+                    ("mcast_is_part_of_receiver_grid", mcast_is_part_of_receiver_grid),
+                    # Gather2 receiver
+                    ("gather2_noc0_num_senders", gather2_noc0_num_senders),
+                    ("gather2_noc1_num_senders", gather2_noc1_num_senders),
+                    ("gather2_noc0_receiver_semaphore_id", gather2_noc0_receiver_semaphore_id),
+                    ("gather2_noc1_receiver_semaphore_id", gather2_noc1_receiver_semaphore_id),
+                    ("gather2_dst_cb", gather2_dst_cb),
+                    ("gather2_dst_num_pages", gather2_dst_num_pages),
+                    # Gather2 completion signal for CCL sender synchronization
+                    ("gather2_completion_semaphore_id", gather2_completion_semaphore_id),
+                    ("ccl_sender_noc_x", ccl_sender_noc_core.x),
+                    ("ccl_sender_noc_y", ccl_sender_noc_core.y),
+                    # CCL sender (BRISC sends via fabric)
+                    ("ccl_sender_packet_header_cb_id", ccl_packet_header_cb),
+                    ("ccl_sender_packet_cb_id", ccl_sender_in_cb),
+                    ("ccl_sender_l1_alignment", l1_alignment),
+                    ("ccl_sender_input_num_tiles", ccl_num_pages),
+                    ("ccl_sender_page_size_bytes", ccl_page_size_bytes),
+                    ("ccl_sender_payload_size_bytes", ccl_payload_size_bytes),
+                    ("ccl_sender_data_noc_x", ccl_receiver_noc_core.x),
+                    ("ccl_sender_data_noc_y", ccl_receiver_noc_core.y),
+                    ("ccl_sender_remote_receiver_noc_x", ccl_receiver_noc_core.x),
+                    ("ccl_sender_remote_receiver_noc_y", ccl_receiver_noc_core.y),
+                    ("ccl_sender_dst_num_hops", 1),
+                    ("ccl_sender_num_connections", 1),
+                    ("ccl_sender_using_persistent_buffer", using_persistent_buffers),
+                ]
+
+                # ========================================================================
+                # TRISC compile-time args
+                # ========================================================================
+                trisc_named_compile_time_args = [
+                    # Matmul1
+                    ("matmul1_in0", matmul1_in0_cb),
+                    ("matmul1_in1", matmul1_in1_cb),
+                    ("matmul1_out", matmul1_out_cb),
+                    ("matmul1_k_num_tiles", matmul1_k_num_tiles),
+                    ("matmul1_out_w_per_core", matmul1_out_w_per_core),
+                    # Matmul2
+                    ("matmul2_in0", matmul2_in0_cb),
+                    ("matmul2_in1", matmul2_in1_cb),
+                    ("matmul2_out", matmul2_out_cb),
+                    ("matmul2_k_num_tiles", matmul2_k_num_tiles),
+                    ("matmul2_out_w_per_core", matmul2_out_w_per_core),
+                    # CCL receiver compute (reduction)
+                    ("ccl_receiver_cb_in0", ccl_remote_data_cb),
+                    ("ccl_receiver_cb_in1", gather2_dst_cb),  # Local data
+                    ("ccl_receiver_cb_out0", ccl_output_cb),
+                    ("ccl_receiver_cb_residual", ccl_residual_cb),
+                    ("ccl_receiver_cb_temp", ccl_temp_cb),
+                    ("ccl_receiver_has_residual", has_residual),
+                    ("ccl_receiver_num_tiles", ccl_num_tiles),
+                ]
+
+                # ========================================================================
+                # Circular buffer descriptors
+                # ========================================================================
+                # CB 0: Matmul1 input (from sharded tensor, 8x8 grid)
+                matmul1_in0_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(matmul1_in0_cb, input_tensor_device)
+
+                # CB 1: Matmul1 weights (from sharded tensor, 8x8 grid)
+                matmul1_in1_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(matmul1_in1_cb, weights1_tensor)
+
+                # CB 2: Matmul1 output (4 tiles of 1x32 per core, 8x8 grid)
+                matmul1_out_tile_descriptor = ttnn.TileDescriptor(TILE_1x32)
+                matmul1_out_cb_format = ttnn.CBFormatDescriptor(
+                    buffer_index=matmul1_out_cb,
+                    data_format=data_format,
+                    page_size=tile_1x32_size,
+                    tile=matmul1_out_tile_descriptor,
+                )
+                matmul1_out_cb_descriptor = ttnn.CBDescriptor(
+                    total_size=matmul1_out_w_per_core * tile_1x32_size,
+                    core_ranges=matmul1_core_grid,
+                    format_descriptors=[matmul1_out_cb_format],
+                )
+
+                # CB 3: Gather1 output = Mcast source (from sharded tensor, gather core)
+                gather1_dst_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(
+                    gather1_dst_cb, gather1_output_tensor
+                )
+
+                # CB 4: Mcast destination = Matmul2 input (256 tiles of 1x32 per core)
+                matmul2_in0_cb_format = ttnn.CBFormatDescriptor(
+                    buffer_index=matmul2_in0_cb,
+                    data_format=data_format,
+                    page_size=tile_1x32_size,
+                    tile=matmul1_out_tile_descriptor,
+                )
+                matmul2_in0_cb_grid = mcast_core_grid.merge(gather_core_grid)
+                matmul2_in0_cb_descriptor = ttnn.CBDescriptor(
+                    total_size=mcast_dst_num_pages * tile_1x32_size,
+                    core_ranges=matmul2_in0_cb_grid,
+                    format_descriptors=[matmul2_in0_cb_format],
+                )
+
+                # CB 5: Matmul2 weights (from sharded tensor, 112 active matmul2 cores)
+                matmul2_in1_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(matmul2_in1_cb, weights2_tensor)
+
+                # CB 6: Matmul2 output (2 tiles of 1x32 per core, 112 active matmul2 cores)
+                matmul2_out_cb_format = ttnn.CBFormatDescriptor(
+                    buffer_index=matmul2_out_cb,
+                    data_format=data_format,
+                    page_size=tile_1x32_size,
+                    tile=matmul1_out_tile_descriptor,
+                )
+                matmul2_out_cb_descriptor = ttnn.CBDescriptor(
+                    total_size=matmul2_out_w_per_core * tile_1x32_size,
+                    core_ranges=matmul2_active_core_grid,
+                    format_descriptors=[matmul2_out_cb_format],
+                )
+
+                # CB 7: Gather2 output = CCL local data (backed by tensor on gather core)
+                # CCL sender reads from this tensor via NOC, not from local CB
+                gather2_dst_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(
+                    gather2_dst_cb, gather2_output_tensor_device
+                )
+
+                # CB 8: CCL sender input (reads from gather2 output via NOC)
+                ccl_sender_in_cb_format = ttnn.CBFormatDescriptor(
+                    buffer_index=ccl_sender_in_cb,
+                    data_format=data_format,
+                    page_size=tile_1x32_size,
+                    tile=matmul1_out_tile_descriptor,
+                )
+                ccl_sender_in_cb_descriptor = ttnn.CBDescriptor(
+                    total_size=ccl_num_pages * tile_1x32_size,
+                    core_ranges=ccl_sender_core_grid,
+                    format_descriptors=[ccl_sender_in_cb_format],
+                )
+
+                # CB 9: CCL remote data (backed by intermediate tensor with 1x32 tiles)
+                # The intermediate tensor is where the CCL sender writes remote data
+                ccl_remote_data_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(
+                    ccl_remote_data_cb, intermediate_tensor_device
+                )
+                ccl_remote_data_cb_descriptor.core_ranges = gather_core_grid
+
+                # CB 10: CCL residual (optional, from sharded tensor)
+                cb_list = [
+                    matmul1_in0_cb_descriptor,
+                    matmul1_in1_cb_descriptor,
+                    matmul1_out_cb_descriptor,
+                    gather1_dst_cb_descriptor,
+                    matmul2_in0_cb_descriptor,
+                    matmul2_in1_cb_descriptor,
+                    matmul2_out_cb_descriptor,
+                    gather2_dst_cb_descriptor,
+                    ccl_sender_in_cb_descriptor,
+                    ccl_remote_data_cb_descriptor,
+                ]
+
+                if residual_tensor_mesh is not None:
+                    ccl_residual_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(
+                        ccl_residual_cb, residual_tensors_per_device[device_idx]
+                    )
+                    ccl_residual_cb_descriptor.core_ranges = gather_core_grid
+                    ccl_residual_cb_descriptor.total_size = ccl_num_tiles * tile_1x32_size
+                    ccl_residual_cb_descriptor.format_descriptors = [
+                        ttnn.CBFormatDescriptor(
+                            buffer_index=ccl_residual_cb,
+                            data_format=data_format,
+                            page_size=tile_1x32_size,
+                            tile=matmul1_out_tile_descriptor,  # 1x32 tiles to match gather2
+                        )
+                    ]
+                    cb_list.append(ccl_residual_cb_descriptor)
+
+                    # CB 11: CCL temp scratch buffer (not backed by tensor)
+                    ccl_temp_cb_descriptor = ttnn.CBDescriptor(
+                        total_size=ccl_num_tiles * tile_1x32_size,
+                        core_ranges=gather_core_grid,
+                        format_descriptors=[
+                            ttnn.CBFormatDescriptor(
+                                buffer_index=ccl_temp_cb,
+                                data_format=data_format,
+                                page_size=tile_1x32_size,
+                                tile=matmul1_out_tile_descriptor,  # 1x32 tiles to match gather2
+                            )
+                        ],
+                    )
+                    cb_list.append(ccl_temp_cb_descriptor)
+
+                # CB 12: CCL output (from sharded tensor)
+                ccl_output_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(ccl_output_cb, output_tensor_device)
+                ccl_output_cb_descriptor.core_ranges = gather_core_grid
+                cb_list.append(ccl_output_cb_descriptor)
+
+                # CB 13: CCL packet headers
+                ccl_packet_header_cb_format = ttnn.CBFormatDescriptor(
+                    buffer_index=ccl_packet_header_cb,
+                    data_format=ttnn.uint32,
+                    page_size=ccl_packet_header_size_bytes,
+                )
+                ccl_packet_header_cb_descriptor = ttnn.CBDescriptor(
+                    total_size=2 * ccl_packet_header_size_bytes,
+                    core_ranges=gather_core_grid.merge(ccl_sender_core_grid),
+                    format_descriptors=[ccl_packet_header_cb_format],
+                )
+                cb_list.append(ccl_packet_header_cb_descriptor)
+
+                # ========================================================================
+                # Semaphore descriptors
+                # ========================================================================
+                gather1_noc0_semaphore_descriptor = ttnn.SemaphoreDescriptor(
+                    id=gather1_noc0_receiver_semaphore_id,
+                    core_ranges=full_grid,
+                    initial_value=0,
+                )
+                gather1_noc1_semaphore_descriptor = ttnn.SemaphoreDescriptor(
+                    id=gather1_noc1_receiver_semaphore_id,
+                    core_ranges=full_grid,
+                    initial_value=0,
+                )
+                mcast_sender_semaphore_descriptor = ttnn.SemaphoreDescriptor(
+                    id=mcast_data_sender_semaphore_id,
+                    core_ranges=full_grid,
+                    initial_value=0,
+                )
+                mcast_receiver_semaphore_descriptor = ttnn.SemaphoreDescriptor(
+                    id=mcast_data_receiver_semaphore_id,
+                    core_ranges=full_grid,
+                    initial_value=0,
+                )
+                gather2_noc0_semaphore_descriptor = ttnn.SemaphoreDescriptor(
+                    id=gather2_noc0_receiver_semaphore_id,
+                    core_ranges=full_grid,
+                    initial_value=0,
+                )
+                gather2_noc1_semaphore_descriptor = ttnn.SemaphoreDescriptor(
+                    id=gather2_noc1_receiver_semaphore_id,
+                    core_ranges=full_grid,
+                    initial_value=0,
+                )
+                gather2_completion_semaphore_descriptor = ttnn.SemaphoreDescriptor(
+                    id=gather2_completion_semaphore_id,
+                    core_ranges=full_grid,
+                    initial_value=0,
+                )
+
+                # ========================================================================
+                # Kernel descriptor
+                # ========================================================================
+                unified_kernel = UnifiedKernelDescriptor(
+                    kernel_source="models/demos/deepseek_v3_b1/fused_ops/post_sdpa/kernels/post_sdpa_kernel.cpp",
+                    core_ranges=full_grid,
+                    ncrisc_named_compile_time_args=ncrisc_named_compile_time_args,
+                    brisc_named_compile_time_args=brisc_named_compile_time_args,
+                    trisc_named_compile_time_args=trisc_named_compile_time_args,
+                    trisc_compute_config=ttnn.ComputeConfigDescriptor(
+                        math_fidelity=ttnn.MathFidelity.HiFi4,
+                        math_approx_mode=False,
+                        fp32_dest_acc_en=fp32_dest_acc_en,
+                        dst_full_sync_en=fp32_dest_acc_en,
+                    ),
+                    unified_compile_time_core_descriptors=[
+                        UnifiedCompileTimeCoreDescriptor(
+                            named_compile_time_arg="is_matmul1_core",
+                            core_range=matmul1_core_grid,
+                            value=1,
+                            other_value=0,
+                        ),
+                        UnifiedCompileTimeCoreDescriptor(
+                            named_compile_time_arg="is_gather_receiver_core",
+                            core_range=gather_core_grid,
+                            value=1,
+                            other_value=0,
+                        ),
+                        UnifiedCompileTimeCoreDescriptor(
+                            named_compile_time_arg="is_matmul2_core",
+                            core_range=matmul2_active_core_grid,
+                            value=1,
+                            other_value=0,
+                        ),
+                        UnifiedCompileTimeCoreDescriptor(
+                            named_compile_time_arg="is_mcast_receiver_core",
+                            core_range=mcast_core_grid,
+                            value=1,
+                            other_value=0,
+                        ),
+                        UnifiedCompileTimeCoreDescriptor(
+                            named_compile_time_arg="is_ccl_sender_core",
+                            core_range=ccl_sender_core_grid,
+                            value=1,
+                            other_value=0,
+                        ),
+                        UnifiedCompileTimeCoreDescriptor(
+                            named_compile_time_arg="is_ccl_receiver_core",
+                            core_range=gather_core_grid,  # CCL receiver = gather core
+                            value=1,
+                            other_value=0,
+                        ),
+                    ],
+                )
+
+                # Get kernel descriptors
+                kernel_result = unified_kernel.get_kernel_descriptors()
+
+                # Get kernel indices for runtime args
+                ccl_sender_group = kernel_result.get_group_by_arg("is_ccl_sender_core", 1)
+                ccl_receiver_group = kernel_result.get_group_by_arg("is_ccl_receiver_core", 1)
+
+                # ========================================================================
+                # Program descriptor
+                # ========================================================================
+                program = ttnn.ProgramDescriptor(
+                    kernels=kernel_result.kernels,
+                    cbs=cb_list,
+                    semaphores=[
+                        gather1_noc0_semaphore_descriptor,
+                        gather1_noc1_semaphore_descriptor,
+                        mcast_sender_semaphore_descriptor,
+                        mcast_receiver_semaphore_descriptor,
+                        gather2_noc0_semaphore_descriptor,
+                        gather2_noc1_semaphore_descriptor,
+                        gather2_completion_semaphore_descriptor,
+                    ],
+                )
+
+                # ========================================================================
+                # Runtime args for CCL
+                # ========================================================================
+                # CCL Sender NCRISC runtime args: tensor_address (gather2 output address)
+                ccl_sender_ncrisc_rt_args = ttnn.RuntimeArgs()
+                ccl_sender_ncrisc_rt_args[ccl_sender_core.x][ccl_sender_core.y] = [
+                    gather2_receiver_data_addr,  # Address of gather2 output on gather core
+                ]
+
+                # CCL Sender BRISC runtime args: receiver_base_address, receive_semaphore_addr
+                ccl_sender_brisc_rt_args = ttnn.RuntimeArgs()
+                ccl_sender_brisc_rt_args[ccl_sender_core.x][ccl_sender_core.y] = [
+                    intermediate_tensor_device.buffer_address(),  # Remote intermediate tensor
+                    ccl_sender_semaphore_addr,
+                ]
+
+                # CCL Receiver NCRISC runtime args: sender_semaphore_addr
+                ccl_receiver_ncrisc_rt_args = ttnn.RuntimeArgs()
+                ccl_receiver_ncrisc_rt_args[gather_core.x][gather_core.y] = [
+                    ccl_receiver_semaphore_addr,
+                ]
+
+                # Set runtime args for CCL kernels
+                program.kernels[ccl_sender_group.ncrisc_kernel_index].runtime_args = ccl_sender_ncrisc_rt_args
+                program.kernels[ccl_sender_group.brisc_kernel_index].runtime_args = ccl_sender_brisc_rt_args
+                program.kernels[ccl_receiver_group.ncrisc_kernel_index].runtime_args = ccl_receiver_ncrisc_rt_args
+
+                # ========================================================================
+                # Fabric connection setup
+                # ========================================================================
+                fabric_node_id = mesh_device.get_fabric_node_id(coord)
+                neighbor_coord = ttnn.MeshCoordinate(neighbor_row, neighbor_col)
+                neighbor_fabric_node_id = mesh_device.get_fabric_node_id(neighbor_coord)
+
+                # Setup sender fabric connection
+                sender_brisc_kernel_idx = ccl_sender_group.brisc_kernel_index
+                sender_brisc_rt_args_ref = program.kernels[sender_brisc_kernel_idx].runtime_args[ccl_sender_core.x][
+                    ccl_sender_core.y
+                ]
+                sender_fabric_args = ttnn.setup_routing_plane_connection(
+                    fabric_node_id,
+                    [neighbor_fabric_node_id],
+                    [ccl_sender_link],
+                    program,
+                    sender_brisc_kernel_idx,
+                    ccl_sender_core,
+                )
+                sender_brisc_rt_args_ref.extend(sender_fabric_args)
+
+                # Setup receiver fabric connection
+                receiver_ncrisc_kernel_idx = ccl_receiver_group.ncrisc_kernel_index
+                receiver_ncrisc_rt_args_ref = program.kernels[receiver_ncrisc_kernel_idx].runtime_args[gather_core.x][
+                    gather_core.y
+                ]
+                receiver_fabric_args = ttnn.setup_routing_plane_connection(
+                    fabric_node_id,
+                    [neighbor_fabric_node_id],
+                    [ccl_receiver_link],
+                    program,
+                    receiver_ncrisc_kernel_idx,
+                    gather_core,
+                )
+                receiver_ncrisc_rt_args_ref.extend(receiver_fabric_args)
+
+                mesh_program_descriptor[ttnn.MeshCoordinateRange(coord, coord)] = program
+
+        # Execute generic_op
+        io_tensors = [
+            input_tensor_mesh,
+            weights1_tensor,
+            weights2_tensor,
+            gather1_output_tensor,
+            gather2_output_tensor,
+            intermediate_tensor,
+            output_tensor,
         ]
+        if residual_tensor_mesh is not None:
+            io_tensors.append(residual_tensor_mesh)
 
-        # ========================================================================
-        # BRISC compile-time args
-        # ========================================================================
-        brisc_named_compile_time_args = [
-            # Matmul1/2 (no-op)
-            ("matmul1_out", matmul1_out_cb),
-            ("matmul2_out", matmul2_out_cb),
-            # Gather1 receiver
-            ("gather1_noc0_num_senders", gather1_noc0_num_senders),
-            ("gather1_noc1_num_senders", gather1_noc1_num_senders),
-            ("gather1_noc0_receiver_semaphore_id", gather1_noc0_receiver_semaphore_id),
-            ("gather1_noc1_receiver_semaphore_id", gather1_noc1_receiver_semaphore_id),
-            ("gather1_dst_cb", gather1_dst_cb),
-            ("gather1_dst_num_pages", gather1_dst_num_pages),
-            # Mcast sender
-            ("mcast_dest_noc_start_x", mcast_dest_noc_start_core.x),
-            ("mcast_dest_noc_start_y", mcast_dest_noc_start_core.y),
-            ("mcast_dest_noc_end_x", mcast_dest_noc_end_core.x),
-            ("mcast_dest_noc_end_y", mcast_dest_noc_end_core.y),
-            ("mcast_num_cores", num_mcast_cores),  # 117 cores in mcast grid
-            ("mcast_data_sender_semaphore", mcast_data_sender_semaphore_id),
-            ("mcast_data_receiver_semaphore", mcast_data_receiver_semaphore_id),
-            ("mcast_data_size_bytes", mcast_data_size_bytes),
-            ("mcast_src_cb", gather1_dst_cb),
-            ("mcast_src_num_pages", mcast_src_num_pages),
-            ("mcast_dst_cb", matmul2_in0_cb),  # For get_write_ptr on sender
-            ("mcast_is_part_of_receiver_grid", mcast_is_part_of_receiver_grid),
-            # Gather2 receiver
-            ("gather2_noc0_num_senders", gather2_noc0_num_senders),
-            ("gather2_noc1_num_senders", gather2_noc1_num_senders),
-            ("gather2_noc0_receiver_semaphore_id", gather2_noc0_receiver_semaphore_id),
-            ("gather2_noc1_receiver_semaphore_id", gather2_noc1_receiver_semaphore_id),
-            ("gather2_dst_cb", gather2_dst_cb),
-            ("gather2_dst_num_pages", gather2_dst_num_pages),
-        ]
+        ttnn.generic_op(io_tensors, mesh_program_descriptor)
 
-        # ========================================================================
-        # TRISC compile-time args
-        # ========================================================================
-        trisc_named_compile_time_args = [
-            # Matmul1
-            ("matmul1_in0", matmul1_in0_cb),
-            ("matmul1_in1", matmul1_in1_cb),
-            ("matmul1_out", matmul1_out_cb),
-            ("matmul1_k_num_tiles", matmul1_k_num_tiles),
-            ("matmul1_out_w_per_core", matmul1_out_w_per_core),
-            # Matmul2
-            ("matmul2_in0", matmul2_in0_cb),
-            ("matmul2_in1", matmul2_in1_cb),
-            ("matmul2_out", matmul2_out_cb),
-            ("matmul2_k_num_tiles", matmul2_k_num_tiles),
-            ("matmul2_out_w_per_core", matmul2_out_w_per_core),
-        ]
-
-        # ========================================================================
-        # Circular buffer descriptors
-        # ========================================================================
-        # CB 0: Matmul1 input (from sharded tensor, 8x8 grid)
-        matmul1_in0_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(matmul1_in0_cb, input_tensor)
-
-        # CB 1: Matmul1 weights (from sharded tensor, 8x8 grid)
-        matmul1_in1_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(matmul1_in1_cb, weights1_tensor)
-
-        # CB 2: Matmul1 output (4 tiles of 1x32 per core, 8x8 grid)
-        matmul1_out_tile_descriptor = ttnn.TileDescriptor(TILE_1x32)
-        matmul1_out_cb_format = ttnn.CBFormatDescriptor(
-            buffer_index=matmul1_out_cb,
-            data_format=data_format,
-            page_size=tile_1x32_size,
-            tile=matmul1_out_tile_descriptor,
-        )
-        matmul1_out_cb_descriptor = ttnn.CBDescriptor(
-            total_size=matmul1_out_w_per_core * tile_1x32_size,
-            core_ranges=matmul1_core_grid,
-            format_descriptors=[matmul1_out_cb_format],
-        )
-
-        # CB 3: Gather1 output = Mcast source (from sharded tensor, gather core)
-        gather1_dst_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(gather1_dst_cb, gather1_output_tensor)
-
-        # CB 4: Mcast destination = Matmul2 input (256 tiles of 1x32 per core)
-        # Allocated on full mcast grid (13x9) AND gather core (so sender can use get_write_ptr)
-        matmul2_in0_cb_format = ttnn.CBFormatDescriptor(
-            buffer_index=matmul2_in0_cb,
-            data_format=data_format,
-            page_size=tile_1x32_size,
-            tile=matmul1_out_tile_descriptor,
-        )
-        matmul2_in0_cb_grid = mcast_core_grid.merge(gather_core_grid)
-        matmul2_in0_cb_descriptor = ttnn.CBDescriptor(
-            total_size=mcast_dst_num_pages * tile_1x32_size,
-            core_ranges=matmul2_in0_cb_grid,
-            format_descriptors=[matmul2_in0_cb_format],
-        )
-
-        # CB 5: Matmul2 weights (from sharded tensor, 112 active matmul2 cores)
-        matmul2_in1_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(matmul2_in1_cb, weights2_tensor)
-
-        # CB 6: Matmul2 output (2 tiles of 1x32 per core, 112 active matmul2 cores)
-        matmul2_out_cb_format = ttnn.CBFormatDescriptor(
-            buffer_index=matmul2_out_cb,
-            data_format=data_format,
-            page_size=tile_1x32_size,
-            tile=matmul1_out_tile_descriptor,
-        )
-        matmul2_out_cb_descriptor = ttnn.CBDescriptor(
-            total_size=matmul2_out_w_per_core * tile_1x32_size,
-            core_ranges=matmul2_active_core_grid,
-            format_descriptors=[matmul2_out_cb_format],
-        )
-
-        # CB 7: Gather2 output = final output (from sharded tensor, gather core)
-        gather2_dst_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(gather2_dst_cb, output_tensor)
-
-        # ========================================================================
-        # Semaphore descriptors
-        # ========================================================================
-        gather1_noc0_semaphore_descriptor = ttnn.SemaphoreDescriptor(
-            id=gather1_noc0_receiver_semaphore_id,
-            core_ranges=full_grid,
-            initial_value=0,
-        )
-        gather1_noc1_semaphore_descriptor = ttnn.SemaphoreDescriptor(
-            id=gather1_noc1_receiver_semaphore_id,
-            core_ranges=full_grid,
-            initial_value=0,
-        )
-        mcast_sender_semaphore_descriptor = ttnn.SemaphoreDescriptor(
-            id=mcast_data_sender_semaphore_id,
-            core_ranges=full_grid,
-            initial_value=0,
-        )
-        mcast_receiver_semaphore_descriptor = ttnn.SemaphoreDescriptor(
-            id=mcast_data_receiver_semaphore_id,
-            core_ranges=full_grid,
-            initial_value=0,
-        )
-        gather2_noc0_semaphore_descriptor = ttnn.SemaphoreDescriptor(
-            id=gather2_noc0_receiver_semaphore_id,
-            core_ranges=full_grid,
-            initial_value=0,
-        )
-        gather2_noc1_semaphore_descriptor = ttnn.SemaphoreDescriptor(
-            id=gather2_noc1_receiver_semaphore_id,
-            core_ranges=full_grid,
-            initial_value=0,
-        )
-
-        # ========================================================================
-        # Kernel descriptor
-        # ========================================================================
-        unified_kernel = UnifiedKernelDescriptor(
-            kernel_source="models/demos/deepseek_v3_b1/fused_ops/post_sdpa/kernels/post_sdpa_kernel.cpp",
-            core_ranges=full_grid,
-            ncrisc_named_compile_time_args=ncrisc_named_compile_time_args,
-            brisc_named_compile_time_args=brisc_named_compile_time_args,
-            trisc_named_compile_time_args=trisc_named_compile_time_args,
-            trisc_compute_config=ttnn.ComputeConfigDescriptor(
-                math_fidelity=ttnn.MathFidelity.LoFi,
-                math_approx_mode=False,
-                fp32_dest_acc_en=fp32_dest_acc_en,
-                dst_full_sync_en=fp32_dest_acc_en,
-            ),
-            unified_compile_time_core_descriptors=[
-                UnifiedCompileTimeCoreDescriptor(
-                    named_compile_time_arg="is_matmul1_core",
-                    core_range=matmul1_core_grid,
-                    value=1,
-                    other_value=0,
-                ),
-                UnifiedCompileTimeCoreDescriptor(
-                    named_compile_time_arg="is_gather_receiver_core",
-                    core_range=gather_core_grid,
-                    value=1,
-                    other_value=0,
-                ),
-                UnifiedCompileTimeCoreDescriptor(
-                    named_compile_time_arg="is_matmul2_core",
-                    core_range=matmul2_active_core_grid,  # Only 112 active cores
-                    value=1,
-                    other_value=0,
-                ),
-                UnifiedCompileTimeCoreDescriptor(
-                    named_compile_time_arg="is_mcast_receiver_core",
-                    core_range=mcast_core_grid,  # All 117 cores in mcast grid
-                    value=1,
-                    other_value=0,
-                ),
-            ],
-        )
-
-        # ========================================================================
-        # Program descriptor
-        # ========================================================================
-        program_descriptor = ttnn.ProgramDescriptor(
-            kernels=unified_kernel.get_kernel_descriptors().kernels,
-            cbs=[
-                matmul1_in0_cb_descriptor,
-                matmul1_in1_cb_descriptor,
-                matmul1_out_cb_descriptor,
-                gather1_dst_cb_descriptor,
-                matmul2_in0_cb_descriptor,
-                matmul2_in1_cb_descriptor,
-                matmul2_out_cb_descriptor,
-                gather2_dst_cb_descriptor,
-            ],
-            semaphores=[
-                gather1_noc0_semaphore_descriptor,
-                gather1_noc1_semaphore_descriptor,
-                mcast_sender_semaphore_descriptor,
-                mcast_receiver_semaphore_descriptor,
-                gather2_noc0_semaphore_descriptor,
-                gather2_noc1_semaphore_descriptor,
-            ],
-        )
-
-        # Execute generic op
-        io_tensors = [input_tensor, weights1_tensor, weights2_tensor, gather1_output_tensor, output_tensor]
-        output = ttnn.generic_op(io_tensors, program_descriptor)
-
-        return output
+        return output_tensor

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_post_sdpa.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_post_sdpa.py
@@ -3,19 +3,25 @@
 # SPDX-License-Identifier: Apache-2.0
 
 """
-TTNN Post SDPA Fused Op Test
+TTNN Post SDPA Fused Op Test with CCL All-Reduce
 
-Tests the full post_sdpa fused operation which implements:
+Tests the full post_sdpa fused operation with CCL all-reduce which implements:
 - Matmul1: [1, 512] x [512, 128] -> [1, 128] per core on 64 cores (8x8)
 - Gather1: Collect to [1, 8192] on gather core (12, 9)
 - Mcast: Broadcast [1, 8192] to 117 cores (13x9 rectangular grid)
 - Matmul2: [1, 8192] x [8192, 64] -> [1, 64] per core on 112 active cores
 - Gather2: Collect to [1, 7168] on gather core (12, 9)
+- CCL All-Reduce: Exchange [1, 7168] between devices, reduce (local + remote + residual)
 
 The mcast grid (13x9=117 cores) includes 5 inactive cores (row 8, cols 8-12)
 that receive mcast data but skip matmul2 via is_matmul2_core=false.
 
-Full operation: [1, 512] @ [512, 8192] @ [8192, 7168] -> [1, 7168]
+CCL All-Reduce uses:
+- CCL Receiver = Gather core (12, 9): already has local data after Gather2
+- CCL Sender = Adjacent core (11, 9): reads from gather core, sends via fabric
+
+Full operation: [1, 512] @ [512, 8192] @ [8192, 7168] -> [1, 7168] per device,
+then all-reduce across devices with optional residual add.
 """
 
 import pytest
@@ -27,15 +33,65 @@ from models.common.utility_functions import comp_pcc
 from models.demos.deepseek_v3_b1.fused_ops.post_sdpa.op import PostSDPA
 
 
+def create_fabric_router_config(max_payload_size):
+    """Helper to create FabricRouterConfig with custom max payload size."""
+    config = ttnn._ttnn.fabric.FabricRouterConfig()
+    config.max_packet_payload_size_bytes = max_payload_size
+    return config
+
+
 @pytest.mark.parametrize(
-    "M, K1, intermediate, K2, output_size, in0_dtype, in1_dtype",
+    "num_devices, M, K1, intermediate, K2, output_size, in0_dtype, in1_dtype",
     [
-        # Main target shape: [1,512] @ [512,8192] @ [8192,7168] -> [1,7168]
-        (1, 512, 8192, 8192, 7168, ttnn.bfloat16, ttnn.bfloat8_b),
+        (2, 1, 512, 8192, 8192, 7168, ttnn.bfloat16, ttnn.bfloat8_b),
     ],
 )
-def test_post_sdpa(device, M, K1, intermediate, K2, output_size, in0_dtype, in1_dtype):
-    """Test full post_sdpa fused operation"""
+@pytest.mark.parametrize("cluster_axis", [0])
+@pytest.mark.parametrize("mesh_device", [(2, 2)], indirect=True)  # Open full mesh, create submesh
+@pytest.mark.parametrize(
+    "device_params",
+    [
+        {
+            "fabric_config": ttnn.FabricConfig.FABRIC_2D,
+            "fabric_router_config": create_fabric_router_config(15232),
+        }
+    ],
+    indirect=True,
+)
+@pytest.mark.parametrize("fuse_residual_add", [False, True])
+def test_post_sdpa(
+    mesh_device,
+    num_devices,
+    M,
+    K1,
+    intermediate,
+    K2,
+    output_size,
+    in0_dtype,
+    in1_dtype,
+    cluster_axis,
+    fuse_residual_add,
+):
+    """Test full post_sdpa fused operation with CCL all-reduce"""
+
+    # Validate mesh size
+    if mesh_device.shape[0] * mesh_device.shape[1] < num_devices:
+        pytest.skip("Test requires more devices than are available on this platform")
+
+    # Create submesh - fabric requires opening full system mesh first
+    submesh = mesh_device.create_submesh(ttnn.MeshShape((num_devices, 1)))
+
+    # Set up sub-device
+    compute_grid_size = submesh.compute_with_storage_grid_size()
+    ccl_sub_device_crs = ttnn.CoreRangeSet(
+        {ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(compute_grid_size.x - 1, compute_grid_size.y - 1))}
+    )
+    worker_sub_device = ttnn.SubDevice([ccl_sub_device_crs])
+    worker_sub_device_id = ttnn.SubDeviceId(0)
+    sub_device_stall_group = [worker_sub_device_id]
+    sub_device_manager = submesh.create_sub_device_manager([worker_sub_device], 0)
+    submesh.load_sub_device_manager(sub_device_manager)
+    submesh.set_sub_device_stall_group(sub_device_stall_group)
 
     # Tile dimensions
     a_tile = ttnn.Tile([M, 32])  # 1x32 tiles for input/activation
@@ -62,11 +118,12 @@ def test_post_sdpa(device, M, K1, intermediate, K2, output_size, in0_dtype, in1_
     n1_per_core = intermediate // num_matmul1_cores  # 8192 / 64 = 128
     n2_per_core = output_size // num_matmul2_cores  # 7168 / 112 = 64
 
-    logger.info(f"Testing full post_sdpa fused op:")
+    logger.info(f"Testing full post_sdpa fused op with CCL all-reduce:")
     logger.info(f"  Matmul1: [{M}, {K1}] x [{K1}, {intermediate}] on {num_matmul1_cores} cores")
     logger.info(f"  Mcast: [{M}, {intermediate}] to {num_mcast_cores} cores (13x9 grid)")
     logger.info(f"  Matmul2: [{M}, {K2}] x [{K2}, {output_size}] on {num_matmul2_cores} active cores")
-    logger.info(f"  Output: [{M}, {output_size}]")
+    logger.info(f"  CCL All-Reduce: [{M}, {output_size}] across {num_devices} devices")
+    logger.info(f"  Output: [{M}, {output_size}] (fuse_residual_add={fuse_residual_add})")
 
     # Create core grids
     matmul1_grid = ttnn.CoreRangeSet(
@@ -85,27 +142,48 @@ def test_post_sdpa(device, M, K1, intermediate, K2, output_size, in0_dtype, in1_
     gather_core_grid = ttnn.CoreRangeSet([ttnn.CoreRange(gather_core, gather_core)])
 
     # ========================================================================
-    # Create PyTorch tensors
+    # Create PyTorch tensors (per-device)
     # ========================================================================
     torch.manual_seed(0)
 
-    # Input: [1, 512] - replicated to 64 matmul1 cores
-    torch_input_single = torch.randn((M, K1), dtype=torch.bfloat16)
-    torch_input = torch_input_single.repeat(num_matmul1_cores, 1)  # [64, 512]
-
+    # Weights are shared across all devices (replicated)
     # Weights1: [512, 8192]
     torch_weights1 = torch.randn((K1, intermediate), dtype=torch.bfloat16)
 
     # Weights2: [8192, 7168]
     torch_weights2 = torch.randn((K2, output_size), dtype=torch.bfloat16)
 
+    # Input per device: [1, 512]
+    device_inputs = []
+    device_input_replicated = []  # For sharding
+    for device_idx in range(num_devices):
+        torch_input_single = torch.randn((M, K1), dtype=torch.bfloat16)
+        device_inputs.append(torch_input_single)
+        # Replicate for matmul1 cores
+        torch_input = torch_input_single.repeat(num_matmul1_cores, 1)  # [64, 512]
+        device_input_replicated.append(torch_input)
+
+    # Residual tensor (optional, shared across devices)
+    if fuse_residual_add:
+        torch_residual = torch.randn((M, output_size), dtype=torch.bfloat16)
+    else:
+        torch_residual = None
+
     # ========================================================================
-    # Compute golden reference: input @ weights1 @ weights2
+    # Compute golden reference (full CCL all-reduce)
     # ========================================================================
     torch_expected = PostSDPA.golden(
-        torch_input_single.float(), torch_weights1.float(), torch_weights2.float()
+        [inp.float() for inp in device_inputs],
+        torch_weights1.float(),
+        torch_weights2.float(),
+        torch_residual.float() if torch_residual is not None else None,
     ).bfloat16()
     logger.info(f"Golden output shape: {torch_expected.shape}")
+
+    # ========================================================================
+    # Create mesh mapper
+    # ========================================================================
+    mesh_mapper_config = ttnn.MeshMapperConfig([ttnn.PlacementShard(0), ttnn.PlacementReplicate()], submesh.shape)
 
     # ========================================================================
     # Create input tensor (height-sharded across matmul1 cores)
@@ -119,18 +197,21 @@ def test_post_sdpa(device, M, K1, intermediate, K2, output_size, in0_dtype, in1_
     )
     input_mem_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, input_shard_spec)
 
+    # Concatenate per-device inputs for mesh tensor
+    mesh_input_torch = torch.cat(device_input_replicated, dim=0)  # [num_devices * 64, 512]
     ttnn_input = ttnn.from_torch(
-        torch_input,
+        mesh_input_torch,
+        device=submesh,
         dtype=in0_dtype,
         layout=ttnn.TILE_LAYOUT,
-        device=device,
         memory_config=input_mem_config,
         tile=a_tile,
+        mesh_mapper=ttnn.create_mesh_mapper(submesh, mesh_mapper_config),
     )
-    logger.info(f"Created input tensor: shard {input_shard_shape} on {num_matmul1_cores} cores")
+    logger.info(f"Created input tensor: shard {input_shard_shape} on {num_matmul1_cores} cores per device")
 
     # ========================================================================
-    # Create weights1 tensor (width-sharded across matmul1 cores)
+    # Create weights1 tensor (width-sharded across matmul1 cores, replicated)
     # Each core gets [512, 128]
     # ========================================================================
     weights1_shard_shape = (K1, n1_per_core)  # [512, 128] per core
@@ -143,18 +224,20 @@ def test_post_sdpa(device, M, K1, intermediate, K2, output_size, in0_dtype, in1_
         ttnn.TensorMemoryLayout.WIDTH_SHARDED, ttnn.BufferType.L1, weights1_shard_spec
     )
 
+    # Get single device for weights (they're replicated, so we just need one)
+    single_device = ttnn.get_device_tensors(ttnn_input)[0].device()
     ttnn_weights1 = ttnn.from_torch(
         torch_weights1,
         dtype=in1_dtype,
         layout=ttnn.TILE_LAYOUT,
-        device=device,
+        device=single_device,
         memory_config=weights1_mem_config,
         tile=b_tile,
     )
     logger.info(f"Created weights1 tensor: shard {weights1_shard_shape} on {num_matmul1_cores} cores")
 
     # ========================================================================
-    # Create weights2 tensor (width-sharded across 112 active matmul2 cores)
+    # Create weights2 tensor (width-sharded across 112 active matmul2 cores, replicated)
     # Each core gets [8192, 64]
     # ========================================================================
     weights2_shard_shape = (K2, n2_per_core)  # [8192, 64] per core
@@ -171,14 +254,14 @@ def test_post_sdpa(device, M, K1, intermediate, K2, output_size, in0_dtype, in1_
         torch_weights2,
         dtype=in1_dtype,
         layout=ttnn.TILE_LAYOUT,
-        device=device,
+        device=single_device,
         memory_config=weights2_mem_config,
         tile=b_tile,
     )
     logger.info(f"Created weights2 tensor: shard {weights2_shard_shape} on {num_matmul2_cores} active cores")
 
     # ========================================================================
-    # Create gather1 output tensor (intermediate [1, 8192] on gather core)
+    # Create gather1 output tensor (intermediate [1, 8192] on gather core, replicated)
     # ========================================================================
     gather1_output_shard_shape = (M, intermediate)  # [1, 8192]
     gather1_output_shard_spec = ttnn.ShardSpec(
@@ -195,11 +278,66 @@ def test_post_sdpa(device, M, K1, intermediate, K2, output_size, in0_dtype, in1_
         torch_gather1_zeros,
         dtype=ttnn.bfloat16,
         layout=ttnn.TILE_LAYOUT,
-        device=device,
+        device=single_device,
         memory_config=gather1_output_mem_config,
         tile=a_tile,
     )
     logger.info(f"Created gather1 output tensor: {gather1_output_shard_shape} on gather core")
+
+    # ========================================================================
+    # Create gather2 output tensor (intermediate [1, 7168] on gather core, per device)
+    # This tensor backs CB7 and holds gather2 output for CCL to read
+    # ========================================================================
+    gather2_output_shard_shape = (M, output_size)  # [1, 7168]
+    gather2_output_shard_spec = ttnn.ShardSpec(
+        gather_core_grid,
+        gather2_output_shard_shape,
+        ttnn.ShardOrientation.ROW_MAJOR,
+    )
+    gather2_output_mem_config = ttnn.MemoryConfig(
+        ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, gather2_output_shard_spec
+    )
+
+    torch_gather2_zeros = torch.zeros((M, output_size), dtype=torch.bfloat16)
+    mesh_gather2_torch = torch.cat([torch_gather2_zeros] * num_devices, dim=0)
+    ttnn_gather2_output = ttnn.from_torch(
+        mesh_gather2_torch,
+        device=submesh,
+        layout=ttnn.TILE_LAYOUT,
+        tile=a_tile,
+        dtype=ttnn.bfloat16,
+        memory_config=gather2_output_mem_config,
+        mesh_mapper=ttnn.create_mesh_mapper(submesh, mesh_mapper_config),
+    )
+    logger.info(f"Created gather2 output tensor: {gather2_output_shard_shape} on gather core per device")
+
+    # ========================================================================
+    # Create CCL intermediate tensor (1x32 tiles to match gather2 output format)
+    # Shape: [1, 7168] = 224 tiles of 1x32
+    # ========================================================================
+    ccl_intermediate_shape = [M, output_size]  # [1, 7168]
+    ccl_intermediate_shard_shape = tuple(ccl_intermediate_shape)
+    ccl_intermediate_shard_spec = ttnn.ShardSpec(
+        gather_core_grid,
+        ccl_intermediate_shard_shape,
+        ttnn.ShardOrientation.ROW_MAJOR,
+    )
+    ccl_intermediate_mem_config = ttnn.MemoryConfig(
+        ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, ccl_intermediate_shard_spec
+    )
+
+    torch_ccl_intermediate = torch.zeros(ccl_intermediate_shape, dtype=torch.bfloat16)
+    mesh_ccl_intermediate_torch = torch.cat([torch_ccl_intermediate] * num_devices, dim=0)
+    ttnn_ccl_intermediate = ttnn.from_torch(
+        mesh_ccl_intermediate_torch,
+        device=submesh,
+        layout=ttnn.TILE_LAYOUT,
+        tile=a_tile,  # 1x32 tiles to match gather2 output
+        dtype=ttnn.bfloat16,
+        memory_config=ccl_intermediate_mem_config,
+        mesh_mapper=ttnn.create_mesh_mapper(submesh, mesh_mapper_config),
+    )
+    logger.info(f"Created CCL intermediate tensor: {ccl_intermediate_shape} on gather core per device")
 
     # ========================================================================
     # Create final output tensor ([1, 7168] on gather core)
@@ -213,43 +351,99 @@ def test_post_sdpa(device, M, K1, intermediate, K2, output_size, in0_dtype, in1_
     output_mem_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, output_shard_spec)
 
     torch_output_zeros = torch.zeros((M, output_size), dtype=torch.bfloat16)
+    mesh_output_torch = torch.cat([torch_output_zeros] * num_devices, dim=0)
     ttnn_output = ttnn.from_torch(
-        torch_output_zeros,
-        dtype=ttnn.bfloat16,
+        mesh_output_torch,
+        device=submesh,
         layout=ttnn.TILE_LAYOUT,
-        device=device,
-        memory_config=output_mem_config,
         tile=a_tile,
+        dtype=ttnn.bfloat16,
+        memory_config=output_mem_config,
+        mesh_mapper=ttnn.create_mesh_mapper(submesh, mesh_mapper_config),
     )
-    logger.info(f"Created output tensor: {output_shard_shape} on gather core")
+    logger.info(f"Created output tensor: {output_shard_shape} on gather core per device")
+
+    # ========================================================================
+    # Create residual tensor (optional)
+    # ========================================================================
+    if fuse_residual_add:
+        mesh_residual_torch = torch.cat([torch_residual] * num_devices, dim=0)
+        ttnn_residual = ttnn.from_torch(
+            mesh_residual_torch,
+            device=submesh,
+            layout=ttnn.TILE_LAYOUT,
+            tile=a_tile,
+            dtype=ttnn.bfloat16,
+            memory_config=output_mem_config,
+            mesh_mapper=ttnn.create_mesh_mapper(submesh, mesh_mapper_config),
+        )
+        logger.info(f"Created residual tensor: {output_shard_shape} on gather core per device")
+    else:
+        ttnn_residual = None
+
+    # ========================================================================
+    # Create global semaphores for CCL
+    # ========================================================================
+    num_cores = compute_grid_size.x * compute_grid_size.y
+    available_cores = ttnn.num_cores_to_corerangeset(num_cores, compute_grid_size, row_wise=True)
+    semaphore1 = ttnn.create_global_semaphore(submesh, available_cores, 0)
+    semaphore2 = ttnn.create_global_semaphore(submesh, available_cores, 0)
+    semaphores = [semaphore1, semaphore2]
+    logger.info("Created global semaphores for CCL synchronization")
 
     # ========================================================================
     # Run fused operation
     # ========================================================================
-    logger.info("Running full post_sdpa fused operation...")
+    logger.info("Running full post_sdpa fused operation with CCL all-reduce...")
     ttnn_result = PostSDPA.op(
         ttnn_input,
         ttnn_weights1,
         ttnn_weights2,
         ttnn_gather1_output,
+        ttnn_gather2_output,
+        ttnn_ccl_intermediate,
         ttnn_output,
+        semaphores,
+        cluster_axis=cluster_axis,
+        residual_tensor_mesh=ttnn_residual,
         fp32_dest_acc_en=False,
     )
+    ttnn.synchronize_device(submesh)
 
     # Convert back to torch for comparison
-    output_torch = ttnn.to_torch(ttnn_result)
+    output_torch = ttnn.to_torch(
+        ttnn_result,
+        mesh_composer=ttnn.ConcatMeshToTensor(submesh, dim=0),
+    )
     logger.info(f"Output shape: {output_torch.shape}")
 
     # ========================================================================
-    # Verify results
+    # Verify results using PCC (Pearson Correlation Coefficient)
+    # All devices should have the same all-reduced result
     # ========================================================================
-    # Output should be [1, 7168] on gather core
-    expected_shape = (M, output_size)
-    assert output_torch.shape == expected_shape, f"Expected shape {expected_shape}, got {output_torch.shape}"
+    all_passed = True
+    pcc_threshold = 0.99  # Require 99% correlation
+    for device_idx in range(num_devices):
+        received = output_torch[device_idx : device_idx + 1, :]
 
-    # Compare with golden reference
-    passing, pcc_message = comp_pcc(torch_expected, output_torch, 0.99)
-    logger.info(f"PCC comparison: {pcc_message}")
+        # Output should be [1, 7168]
+        expected_shape = (M, output_size)
+        assert received.shape == expected_shape, f"Expected shape {expected_shape}, got {received.shape}"
 
-    assert passing, f"PCC check failed: {pcc_message}"
-    logger.info("✓ Post SDPA full fused op test passed!")
+        # Compare with all-reduced golden reference using PCC
+        # All devices should have the same result after all-reduce
+        passing, pcc_message = comp_pcc(torch_expected, received, pcc_threshold)
+        if not passing:
+            logger.error(f"Device {device_idx}: PCC check FAILED - {pcc_message}")
+            logger.error(f"Expected: {torch_expected[:, :5]}")
+            logger.error(f"Received: {received[:, :5]}")
+            all_passed = False
+        else:
+            logger.info(f"Device {device_idx}: PASSED - {pcc_message}")
+
+    # Cleanup
+    submesh.reset_sub_device_stall_group()
+    submesh.clear_loaded_sub_device_manager()
+
+    assert all_passed, "Not all devices have the correct output"
+    logger.info("✓ Post SDPA full fused op with CCL all-reduce test passed!")

--- a/models/demos/deepseek_v3_b1/unified_kernels/all_reduce_receiver.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/all_reduce_receiver.hpp
@@ -50,7 +50,8 @@ struct AllReduceReceiver {
         uint32_t numStandardTiles,
         uint32_t cbResidual,
         uint32_t hasResidual,
-        uint32_t usingPersistentBuffer>
+        uint32_t usingPersistentBuffer,
+        uint32_t skipLocalPush = 0>  // Skip cb_reserve/push on cb_in2 when fused with gather
     struct ReaderCTArgs {
         static constexpr uint32_t packet_header_cb_id = packetHeaderCbId;
         static constexpr uint32_t cb_in1 = cbIn1;
@@ -62,6 +63,7 @@ struct AllReduceReceiver {
         static constexpr uint32_t cb_residual = cbResidual;
         static constexpr bool has_residual = hasResidual;
         static constexpr bool using_persistent_buffer = usingPersistentBuffer;
+        static constexpr bool skip_local_push = skipLocalPush;
     };
 
     // Compute CTArgs (TRISC)
@@ -151,8 +153,11 @@ struct AllReduceReceiver {
             }
 
             // Push local and residual tiles to compute immediately (they're ready)
-            cb_reserve_back(ReaderCT::cb_in2, ReaderCT::num_standard_tiles);
-            cb_push_back(ReaderCT::cb_in2, ReaderCT::num_standard_tiles);
+            // Skip local push if data is already in CB (e.g., from preceding gather operation)
+            if constexpr (!ReaderCT::skip_local_push) {
+                cb_reserve_back(ReaderCT::cb_in2, ReaderCT::num_standard_tiles);
+                cb_push_back(ReaderCT::cb_in2, ReaderCT::num_standard_tiles);
+            }
 
             if constexpr (ReaderCT::has_residual) {
                 cb_reserve_back(ReaderCT::cb_residual, ReaderCT::num_standard_tiles);


### PR DESCRIPTION
Fuse post sdpa op with downstream TP all reduce op.

### Ticket
(https://github.com/tenstorrent/tt-metal/issues/35541)

### Problem description
Provide context for the problem.

### What's changed
Describe the approach used to solve the problem.
Summarize the changes made and its impact.

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=ucheema/deepseek-b1-post-sdpa-ar)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:ucheema/deepseek-b1-post-sdpa-ar)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ucheema/deepseek-b1-post-sdpa-ar)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ucheema/deepseek-b1-post-sdpa-ar)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ucheema/deepseek-b1-post-sdpa-ar)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ucheema/deepseek-b1-post-sdpa-ar)
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ucheema/deepseek-b1-post-sdpa-ar)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ucheema/deepseek-b1-post-sdpa-ar)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ucheema/deepseek-b1-post-sdpa-ar)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ucheema/deepseek-b1-post-sdpa-ar)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ucheema/deepseek-b1-post-sdpa-ar)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ucheema/deepseek-b1-post-sdpa-ar)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
