### PR TITLE
#0: add models timeout for bh

### DIFF
--- a/tests/scripts/run_python_model_tests.sh
+++ b/tests/scripts/run_python_model_tests.sh
@@ -73,19 +73,19 @@ run_python_model_tests_slow_runtime_mode_wormhole_b0() {
 }
 
 run_python_model_tests_blackhole() {
-    SD_HF_DOWNLOAD_OVERRIDE=1 pytest models/demos/vision/generative/stable_diffusion/blackhole/tests --ignore=models/demos/vision/generative/stable_diffusion/blackhole/tests/test_perf.py
+    SD_HF_DOWNLOAD_OVERRIDE=1 pytest models/demos/vision/generative/stable_diffusion/blackhole/tests --timeout 420 --ignore=models/demos/vision/generative/stable_diffusion/blackhole/tests/test_perf.py
 
     # Llama3.1-8B
     llama8b=meta-llama/Llama-3.1-8B-Instruct
     # Run all Llama3 tests for 8B - dummy weights with tight PCC check
     for hf_model in "$llama8b"; do
         tt_cache=$TT_CACHE_HOME/$hf_model
-        HF_MODEL=$hf_model TT_CACHE_PATH=$tt_cache pytest models/tt_transformers/tests/test_model.py -k "quick" ; fail+=$?
+        HF_MODEL=$hf_model TT_CACHE_PATH=$tt_cache pytest models/tt_transformers/tests/test_model.py -k "quick" --timeout 360 ; fail+=$?
         echo "LOG_METAL: Llama3 tests for $hf_model completed"
     done
 
-    pytest models/demos/vision/classification/resnet50/wormhole/tests/test_resnet50_functional.py
-    pytest models/experimental/functional_unet/tests/test_unet_model.py
+    pytest models/demos/vision/classification/resnet50/wormhole/tests/test_resnet50_functional.py --timeout 300
+    pytest models/experimental/functional_unet/tests/test_unet_model.py --timeout 90
 }
 
 run_python_model_tests_slow_runtime_mode_blackhole() {
@@ -96,5 +96,5 @@ run_python_model_tests_slow_runtime_mode_blackhole() {
         "comparison_mode_should_raise_exception": true,
         "comparison_mode_pcc": 0.998
     }'
-    pytest -svv models/experimental/functional_unet/tests/test_unet_model.py
+    pytest -svv models/experimental/functional_unet/tests/test_unet_model.py --timeout 90
 }


### PR DESCRIPTION
https://productionresultssa2.blob.core.windows.net/actions-results/c1038eb7-a9ff-47c7-9a19-5889f2065874/workflow-job-run-1ceda5b1-6a34-5d5c-9ea5-51d6ad65c95d/logs/job/job-logs.txt?rsct=text%2Fplain&se=2026-02-06T00%3A39%3A31Z&sig=5StYdDSj2SRVW%2FqgBRoZ5%2FahYa3A5ggUx0GiGQVJoRw%3D&ske=2026-02-06T03%3A00%3A36Z&skoid=ca7593d4-ee42-46cd-af88-8b886a2f84eb&sks=b&skt=2026-02-05T23%3A00%3A36Z&sktid=398a6654-997b-47e9-b12b-9515b896b4de&skv=2025-11-05&sp=r&spr=https&sr=b&st=2026-02-06T00%3A29%3A26Z&sv=2025-11-05 

https://github.com/tenstorrent/tt-metal/actions/runs/21508922460/job/61971799929

Numbers generated from this raw log

### Ticket
Link to Github Issue

# Add Blackhole model test timeouts

## Summary

Add explicit pytest timeouts to Blackhole model tests in `run_python_model_tests.sh` so long-running or stuck jobs are bounded and CI fails fast instead of hanging.

## Changes

| Test / suite | Timeout | Notes |
|--------------|---------|--------|
| Stable Diffusion (BH) | 420s (7 min) | Full suite, excluding `test_perf.py` |
| Llama3.1-8B (BH) | 360s (6 min) | `test_model.py -k "quick"` |
| ResNet50 functional (BH) | 300s (5 min) | `test_resnet50_functional.py` |
| UNet model (BH) | 90s | `test_unet_model.py` (fast and slow-runtime) |

## File changed

- **`tests/scripts/run_python_model_tests.sh`**
  - `run_python_model_tests_blackhole()`: added `--timeout` to all pytest invocations above.
  - `run_python_model_tests_slow_runtime_mode_blackhole()`: added `--timeout 90` to UNet pytest call.

## Rationale

- Aligns Blackhole model test timeouts with expected runtimes and avoids indefinite CI runs.
- Uses pytest-timeout (already in use via `pytest.ini` default `timeout = 300`); these overrides set suite-specific limits for BH.
