### PR TITLE
[skip ci] set-cpu-governor VM handling

### DIFF
--- a/.github/actions/set-cpu-governor/action.yml
+++ b/.github/actions/set-cpu-governor/action.yml
@@ -15,6 +15,15 @@ runs:
         governor="${{ inputs.governor }}"
         echo "🔧 Setting CPU governor to: $governor for all cores"
 
+        # Check if scaling_governor exists (may not on VMs)
+        scaling_governors=(/sys/devices/system/cpu/cpu*/cpufreq/scaling_governor)
+        if [ ! -e "${scaling_governors[0]}" ]; then
+          echo "⚠️ No scaling_governor found under /sys/devices/system/cpu/cpu*/cpufreq/"
+          echo "⚠️ This may be running on a virtual machine where CPU frequency scaling is not available."
+          echo "⚠️ Skipping CPU governor configuration."
+          exit 0
+        fi
+
         # Set governor for all CPU cores by writing directly to sysfs
         if echo "$governor" | sudo tee /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor > /dev/null; then
           echo "✅ Successfully set $governor governor for all CPU cores"

--- a/.github/actions/set-cpu-governor/action.yml
+++ b/.github/actions/set-cpu-governor/action.yml
@@ -16,8 +16,10 @@ runs:
         echo "🔧 Setting CPU governor to: $governor for all cores"
 
         # Check if scaling_governor exists (may not on VMs)
+        shopt -s nullglob
         scaling_governors=(/sys/devices/system/cpu/cpu*/cpufreq/scaling_governor)
-        if [ ! -e "${scaling_governors[0]}" ]; then
+        shopt -u nullglob
+        if [ ${#scaling_governors[@]} -eq 0 ]; then
           echo "⚠️ No scaling_governor found under /sys/devices/system/cpu/cpu*/cpufreq/"
           echo "⚠️ This may be running on a virtual machine where CPU frequency scaling is not available."
           echo "⚠️ Skipping CPU governor configuration."


### PR DESCRIPTION
### Ticket
N/A

### Problem description
The setup action on a VM would fail if there was no cpu governor available.
https://github.com/tenstorrent/tt-metal/actions/runs/21726350969/job/62670222462#step:7:1

### What's changed
If the governor doesn't exist, assume its being run on a VM,  print a warning, and continue.

### Checklist
- [ ] t3k models-extended [run post-merge since the hook targets specifically @ main](https://github.com/tenstorrent/tt-metal/actions/runs/21739211919)