### PR TITLE
[Watcher] In order to get tt-train-cpp-unit group of tests green there was a need to skip some tests with watcher

### DIFF
--- a/tt-train/sources/ttml/core/system_utils.hpp
+++ b/tt-train/sources/ttml/core/system_utils.hpp
@@ -4,8 +4,22 @@
 
 #pragma once
 
+#include <cstdlib>
 #include <string>
 
 namespace ttml::core {
 std::string demangle(const char* name);
+
+inline bool is_watcher_enabled() {
+    const char* watcher = std::getenv("TT_METAL_WATCHER");
+    const char* asserts = std::getenv("TT_METAL_LIGHTWEIGHT_KERNEL_ASSERTS");
+    return (watcher != nullptr && watcher[0] != '\0') || (asserts != nullptr && std::string(asserts) == "1");
 }
+}  // namespace ttml::core
+
+#define SKIP_FOR_WATCHER()                                        \
+    do {                                                          \
+        if (ttml::core::is_watcher_enabled()) {                   \
+            GTEST_SKIP() << "Skipping test with watcher enabled"; \
+        }                                                         \
+    } while (0)

--- a/tt-train/tests/core/clip_grad_norm_test.cpp
+++ b/tt-train/tests/core/clip_grad_norm_test.cpp
@@ -12,6 +12,7 @@
 
 #include "autograd/auto_context.hpp"
 #include "autograd/tensor.hpp"
+#include "core/system_utils.hpp"
 #include "core/tt_tensor_utils.hpp"
 
 class ClipGradNormTest : public ::testing::Test {
@@ -26,6 +27,8 @@ protected:
 };
 
 TEST_F(ClipGradNormTest, ClipGradNorm_GENEROUS_TOLERANCE) {
+    // Skip with watcher enabled due to moreh_clip_grad_norm_step2_kernel assert failure (#37040)
+    SKIP_FOR_WATCHER();
     using namespace ttml;
 
     auto* device = &autograd::ctx().get_device();

--- a/tt-train/tests/core/clip_grad_norm_test.cpp
+++ b/tt-train/tests/core/clip_grad_norm_test.cpp
@@ -27,7 +27,7 @@ protected:
 };
 
 TEST_F(ClipGradNormTest, ClipGradNorm_GENEROUS_TOLERANCE) {
-    // Skip with watcher enabled due to moreh_clip_grad_norm_step2_kernel assert failure (#37040)
+    // Skip with watcher enabled due to assert failure github issue #37040
     SKIP_FOR_WATCHER();
     using namespace ttml;
 

--- a/tt-train/tests/core/n300_utils_test.cpp
+++ b/tt-train/tests/core/n300_utils_test.cpp
@@ -12,8 +12,8 @@
 #include "autograd/auto_context.hpp"
 #include "core/compute_kernel_config.hpp"
 #include "core/random.hpp"
+#include "core/system_utils.hpp"
 #include "core/tt_tensor_utils.hpp"
-#include "test_utils/env_utils.hpp"
 #include "ttnn_fixed/distributed/tt_metal.hpp"
 #include "ttnn_fixed/distributed/ttnn_ops.hpp"
 

--- a/tt-train/tests/core/n300_utils_test.cpp
+++ b/tt-train/tests/core/n300_utils_test.cpp
@@ -262,6 +262,8 @@ TEST_F(N300UtilsTest, DropoutDifferentSeed) {
 }
 
 TEST_F(N300UtilsTest, MorehClipGradNorm) {
+    // Skip with watcher enabled github issue #37040
+    SKIP_FOR_WATCHER();
     auto* device = &ttml::autograd::ctx().get_device();
     auto mesh_shape = device->shape();
     xt::xarray<float> xtensor = xt::ones<float>({4, 1, 20, 5});

--- a/tt-train/tests/core/n300_utils_test.cpp
+++ b/tt-train/tests/core/n300_utils_test.cpp
@@ -13,6 +13,7 @@
 #include "core/compute_kernel_config.hpp"
 #include "core/random.hpp"
 #include "core/tt_tensor_utils.hpp"
+#include "test_utils/env_utils.hpp"
 #include "ttnn_fixed/distributed/tt_metal.hpp"
 #include "ttnn_fixed/distributed/ttnn_ops.hpp"
 
@@ -118,6 +119,9 @@ TEST_F(N300UtilsTest, TestXTensorShardAxis2) {
 }
 
 TEST_F(N300UtilsTest, TestXTensorReplicateAllReduce) {
+    // Test failing with watcher enabled, github issue #30521
+    SKIP_FOR_WATCHER();
+
     auto* device = &ttml::autograd::ctx().get_device();
     auto mesh_shape = device->shape();
 
@@ -146,6 +150,9 @@ TEST_F(N300UtilsTest, TestXTensorReplicateAllReduce) {
 }
 
 TEST_F(N300UtilsTest, TestXTensorReplicateAllReduceBadTiles) {
+    // Test failing with watcher enabled, github issue #30521
+    SKIP_FOR_WATCHER();
+
     auto* device = &ttml::autograd::ctx().get_device();
     auto mesh_shape = device->shape();
 

--- a/tt-train/tests/model/linear_regression_ddp_test.cpp
+++ b/tt-train/tests/model/linear_regression_ddp_test.cpp
@@ -10,6 +10,7 @@
 
 #include "autograd/auto_context.hpp"
 #include "autograd/tensor.hpp"
+#include "core/system_utils.hpp"
 #include "core/tt_tensor_utils.hpp"
 #include "core/xtensor_utils.hpp"
 #include "datasets/dataloader.hpp"
@@ -54,6 +55,8 @@ using DataLoader = ttml::datasets::DataLoader<
     BatchType>;
 
 TEST_F(LinearRegressionDDPTest, Full) {
+    // Skip with watcher enabled github issue #37193
+    SKIP_FOR_WATCHER();
     const size_t training_samples_count = 1000;
     const size_t num_features = 64;
     const size_t num_targets = 32;

--- a/tt-train/tests/model/linear_regression_full_test.cpp
+++ b/tt-train/tests/model/linear_regression_full_test.cpp
@@ -8,6 +8,7 @@
 #include <core/ttnn_all_includes.hpp>
 
 #include "autograd/auto_context.hpp"
+#include "core/system_utils.hpp"
 #include "core/tt_tensor_utils.hpp"
 #include "modules/linear_module.hpp"
 #include "ops/losses.hpp"
@@ -26,6 +27,8 @@ protected:
 };
 
 TEST_F(LinearRegressionFullTest, TestLinearRegressionFull) {
+    // Skip with watcher enabled github issue #37193
+    SKIP_FOR_WATCHER();
     using namespace ttml::ops;
     auto* device = &ttml::autograd::ctx().get_device();
     const size_t batch_size = 128;

--- a/tt-train/tests/model/weight_tying_test.cpp
+++ b/tt-train/tests/model/weight_tying_test.cpp
@@ -7,6 +7,7 @@
 #include <memory>
 
 #include "autograd/auto_context.hpp"
+#include "core/system_utils.hpp"
 #include "core/tt_tensor_utils.hpp"
 #include "modules/embedding_module.hpp"
 #include "modules/linear_module.hpp"
@@ -74,6 +75,8 @@ protected:
 };
 
 TEST_F(WeightTyingTest, ModelFC) {
+    // Skip with watcher enabled (#xxx)
+    SKIP_FOR_WATCHER();
     auto model = ModelFC();
     auto params = model.parameters();
     assert(params.size() == 3U);

--- a/tt-train/tests/model/weight_tying_test.cpp
+++ b/tt-train/tests/model/weight_tying_test.cpp
@@ -75,7 +75,7 @@ protected:
 };
 
 TEST_F(WeightTyingTest, ModelFC) {
-    // Skip with watcher enabled (#xxx)
+    // Skip with watcher enabled due to failure, see github issue #37193
     SKIP_FOR_WATCHER();
     auto model = ModelFC();
     auto params = model.parameters();

--- a/tt-train/tests/modules/distributed/linear_test.cpp
+++ b/tt-train/tests/modules/distributed/linear_test.cpp
@@ -15,6 +15,7 @@
 #include "core/random.hpp"
 #include "core/tt_tensor_utils.hpp"
 #include "modules/linear_module.hpp"
+#include "test_utils/env_utils.hpp"
 #include "ttnn_fixed/distributed/tt_metal.hpp"
 
 namespace {
@@ -52,6 +53,9 @@ protected:
 };
 
 TEST_F(N300TensorParallelLinearTest, RowParallelLinearHasBiasNotInputParallel) {
+    // Test failing with watcher enabled, github issue #30521
+    SKIP_FOR_WATCHER();
+
     uint32_t in_features = 64U;
     uint32_t out_features = 64U;
     bool has_bias = true;
@@ -102,6 +106,9 @@ TEST_F(N300TensorParallelLinearTest, RowParallelLinearHasBiasNotInputParallel) {
 };
 
 TEST_F(N300TensorParallelLinearTest, RowParallelLinearNoBiasNotInputParallel) {
+    // Test failing with watcher enabled, github issue #30521
+    SKIP_FOR_WATCHER();
+
     uint32_t in_features = 64U;
     uint32_t out_features = 64U;
     bool has_bias = false;
@@ -146,6 +153,9 @@ TEST_F(N300TensorParallelLinearTest, RowParallelLinearNoBiasNotInputParallel) {
 };
 
 TEST_F(N300TensorParallelLinearTest, RowParallelLinearHasBiasInputParallel) {
+    // Test failing with watcher enabled, github issue #30521
+    SKIP_FOR_WATCHER();
+
     uint32_t in_features = 64U;
     uint32_t out_features = 64U;
     bool has_bias = true;
@@ -192,6 +202,9 @@ TEST_F(N300TensorParallelLinearTest, RowParallelLinearHasBiasInputParallel) {
 };
 
 TEST_F(N300TensorParallelLinearTest, RowParallelLinearNoBiasInputParallel) {
+    // Test failing with watcher enabled, github issue #30521
+    SKIP_FOR_WATCHER();
+
     uint32_t in_features = 64U;
     uint32_t out_features = 64U;
     bool has_bias = false;
@@ -430,6 +443,9 @@ TEST_F(N300TensorParallelLinearTest, ColumnParallelLinearNoBiasNoAllGather) {
 };
 
 TEST_F(N300TensorParallelLinearTest, RowParallelLinearHasBiasNanoGPT) {
+    // Test failing with watcher enabled, github issue #30521
+    SKIP_FOR_WATCHER();
+
     uint32_t batch_size = 64;
     uint32_t sequence_length = 256;
     uint32_t in_features = 384U;
@@ -514,6 +530,9 @@ TEST_F(N300TensorParallelLinearTest, RowParallelLinearHasBiasNanoGPT) {
 };
 
 TEST_F(N300TensorParallelLinearTest, ColumnParallelLinearHasBiasNanoGPT) {
+    // Test failing with watcher enabled, github issue #30521
+    SKIP_FOR_WATCHER();
+
     uint32_t batch_size = 64;
     uint32_t sequence_length = 256;
     uint32_t in_features = 384U;
@@ -593,6 +612,9 @@ TEST_F(N300TensorParallelLinearTest, ColumnParallelLinearHasBiasNanoGPT) {
 };
 
 TEST_F(N300TensorParallelLinearTest, ColumnParallelLinearNoBiasNanoGPT) {
+    // Test failing with watcher enabled, github issue #30521
+    SKIP_FOR_WATCHER();
+
     uint32_t batch_size = 64;
     uint32_t sequence_length = 256;
     uint32_t in_features = 384U;

--- a/tt-train/tests/modules/distributed/linear_test.cpp
+++ b/tt-train/tests/modules/distributed/linear_test.cpp
@@ -13,9 +13,9 @@
 
 #include "autograd/auto_context.hpp"
 #include "core/random.hpp"
+#include "core/system_utils.hpp"
 #include "core/tt_tensor_utils.hpp"
 #include "modules/linear_module.hpp"
-#include "test_utils/env_utils.hpp"
 #include "ttnn_fixed/distributed/tt_metal.hpp"
 
 namespace {

--- a/tt-train/tests/ops/cross_entropy_bw_op_test.cpp
+++ b/tt-train/tests/ops/cross_entropy_bw_op_test.cpp
@@ -273,7 +273,7 @@ TEST_F(CrossEntropyBackwardTest, NIGHTLY_CrossEntropyBackward_Huge_Backward) {
 }
 
 TEST_F(CrossEntropyBackwardTest, CrossEntropyForwardBackward_ReduceMeanVsNone) {
-    // Skip with watcher enabled (#xxx)
+    // Skip with watcher enabled due to failure github issue #37193
     SKIP_FOR_WATCHER();
     using namespace ttml;
 

--- a/tt-train/tests/ops/cross_entropy_bw_op_test.cpp
+++ b/tt-train/tests/ops/cross_entropy_bw_op_test.cpp
@@ -16,6 +16,7 @@
 
 #include "autograd/auto_context.hpp"
 #include "core/random.hpp"
+#include "core/system_utils.hpp"
 #include "core/tt_tensor_utils.hpp"
 #include "metal/operations.hpp"
 #include "ops/losses.hpp"
@@ -272,6 +273,8 @@ TEST_F(CrossEntropyBackwardTest, NIGHTLY_CrossEntropyBackward_Huge_Backward) {
 }
 
 TEST_F(CrossEntropyBackwardTest, CrossEntropyForwardBackward_ReduceMeanVsNone) {
+    // Skip with watcher enabled (#xxx)
+    SKIP_FOR_WATCHER();
     using namespace ttml;
 
     const uint32_t N = 5U, C = 1U, H = 91U, W = 187U;

--- a/tt-train/tests/ops/distributed/comm_ops_test.cpp
+++ b/tt-train/tests/ops/distributed/comm_ops_test.cpp
@@ -13,6 +13,7 @@
 #include "autograd/auto_context.hpp"
 #include "core/random.hpp"
 #include "core/tt_tensor_utils.hpp"
+#include "test_utils/env_utils.hpp"
 #include "ttnn_fixed/distributed/tt_metal.hpp"
 
 namespace {
@@ -40,6 +41,9 @@ protected:
 };
 
 TEST_F(N300CommOpsTest, TestAllReduceNotFullyTiled) {
+    // Test failing with watcher enabled, github issue #30521
+    SKIP_FOR_WATCHER();
+
     auto* device = &ttml::autograd::ctx().get_device();
     auto mesh_shape = device->shape();
 
@@ -97,6 +101,9 @@ TEST_F(N300CommOpsTest, TestAllReduceNotFullyTiled) {
 }
 
 TEST_F(N300CommOpsTest, TestAllReduceNanoGPT) {
+    // Test failing with watcher enabled, github issue #30521
+    SKIP_FOR_WATCHER();
+
     auto* device = &ttml::autograd::ctx().get_device();
     auto mesh_shape = device->shape();
 
@@ -159,6 +166,9 @@ TEST_F(N300CommOpsTest, TestAllReduceNanoGPT) {
 }
 
 TEST_F(N300CommOpsTest, TestAllReduceFullyTiled) {
+    // Test failing with watcher enabled, github issue #30521
+    SKIP_FOR_WATCHER();
+
     auto* device = &ttml::autograd::ctx().get_device();
     auto mesh_shape = device->shape();
 

--- a/tt-train/tests/ops/distributed/comm_ops_test.cpp
+++ b/tt-train/tests/ops/distributed/comm_ops_test.cpp
@@ -12,8 +12,8 @@
 
 #include "autograd/auto_context.hpp"
 #include "core/random.hpp"
+#include "core/system_utils.hpp"
 #include "core/tt_tensor_utils.hpp"
-#include "test_utils/env_utils.hpp"
 #include "ttnn_fixed/distributed/tt_metal.hpp"
 
 namespace {

--- a/tt-train/tests/ops/embedding_op_test.cpp
+++ b/tt-train/tests/ops/embedding_op_test.cpp
@@ -10,6 +10,7 @@
 
 #include "autograd/auto_context.hpp"
 #include "autograd/tensor.hpp"
+#include "core/system_utils.hpp"
 #include "core/tt_tensor_utils.hpp"
 #include "ops/losses.hpp"
 
@@ -25,6 +26,8 @@ protected:
 };
 
 TEST_F(EmbeddingOpTest, EmbeddingForwardBackward) {
+    // Skip with watcher enabled github issue #37193
+    SKIP_FOR_WATCHER();
     using namespace ttml;
 
     auto* device = &autograd::ctx().get_device();

--- a/tt-train/tests/ops/layer_norm_composite_test.cpp
+++ b/tt-train/tests/ops/layer_norm_composite_test.cpp
@@ -9,6 +9,7 @@
 
 #include "autograd/auto_context.hpp"
 #include "autograd/tensor.hpp"
+#include "core/system_utils.hpp"
 #include "core/tt_tensor_utils.hpp"
 #include "ops/layernorm_op.hpp"
 #include "ops/losses.hpp"
@@ -76,6 +77,8 @@ TEST_F(LayerNormOpTest, CompositeLayerNormOp_0) {
 }
 
 TEST_F(LayerNormOpTest, CompositeLayerNormOp_backward) {
+    // Skip with watcher enabled github issue #37193
+    SKIP_FOR_WATCHER();
     using namespace ttml;
 
     uint32_t batch_size = 1;

--- a/tt-train/tests/ops/rmsnorm_op_test.cpp
+++ b/tt-train/tests/ops/rmsnorm_op_test.cpp
@@ -14,6 +14,7 @@
 #include "autograd/auto_context.hpp"
 #include "autograd/tensor.hpp"
 #include "core/random.hpp"
+#include "core/system_utils.hpp"
 #include "core/tt_tensor_utils.hpp"
 #include "ops/losses.hpp"
 
@@ -42,6 +43,8 @@ protected:
 // 4. Compare TTML kernel results with PyTorch reference results
 // ============================================================================
 TEST_F(RMSNormOpTest, RMSNorm_Small_Forward) {
+    // Skip with watcher enabled github issue #37193
+    SKIP_FOR_WATCHER();
     using namespace ttml;
 
     [[maybe_unused]] uint32_t N = 1, C = 1, H = 1, W = 8;
@@ -57,6 +60,8 @@ TEST_F(RMSNormOpTest, RMSNorm_Small_Forward) {
 }
 
 TEST_F(RMSNormOpTest, RMSNorm_Small_Backward) {
+    // Skip with watcher enabled github issue #37193
+    SKIP_FOR_WATCHER();
     using namespace ttml;
 
     [[maybe_unused]] uint32_t N = 1, C = 1, H = 1, W = 8;
@@ -90,6 +95,8 @@ TEST_F(RMSNormOpTest, RMSNorm_Small_Backward) {
 }
 
 TEST_F(RMSNormOpTest, NIGHTLY_RMSNorm_Forward_Batch) {
+    // Skip with watcher enabled github issue #37193
+    SKIP_FOR_WATCHER();
     auto board = tt::umd::Cluster::create_cluster_descriptor()->get_board_type(0);
     if (board == tt::BoardType::P100 || board == tt::BoardType::P150) {
         GTEST_SKIP() << "Skipping on P100/P150 boards";
@@ -132,6 +139,8 @@ TEST_F(RMSNormOpTest, NIGHTLY_RMSNorm_Forward_Batch) {
 }
 
 TEST_F(RMSNormOpTest, NIGHTLY_RMSNorm_Backward_Batch) {
+    // Skip with watcher enabled github issue #37193
+    SKIP_FOR_WATCHER();
     auto board = tt::umd::Cluster::create_cluster_descriptor()->get_board_type(0);
     if (board == tt::BoardType::P100 || board == tt::BoardType::P150) {
         GTEST_SKIP() << "Skipping on P100/P150 boards";
@@ -173,6 +182,8 @@ TEST_F(RMSNormOpTest, NIGHTLY_RMSNorm_Backward_Batch) {
 // Same test methodology as Section 1, but using rmsnorm_composite() instead.
 // ============================================================================
 TEST_F(RMSNormOpTest, NIGHTLY_CompositeRMSNorm_Small_Forward) {
+    // Skip with watcher enabled github issue #37193
+    SKIP_FOR_WATCHER();
     using namespace ttml;
 
     [[maybe_unused]] uint32_t N = 1, C = 1, H = 1, W = 8;
@@ -188,6 +199,8 @@ TEST_F(RMSNormOpTest, NIGHTLY_CompositeRMSNorm_Small_Forward) {
 }
 
 TEST_F(RMSNormOpTest, NIGHTLY_CompositeRMSNorm_Small_Backward) {
+    // Skip with watcher enabled github issue #37193
+    SKIP_FOR_WATCHER();
     using namespace ttml;
 
     [[maybe_unused]] uint32_t N = 1, C = 1, H = 1, W = 8;
@@ -221,6 +234,8 @@ TEST_F(RMSNormOpTest, NIGHTLY_CompositeRMSNorm_Small_Backward) {
 }
 
 TEST_F(RMSNormOpTest, NIGHTLY_CompositeRMSNorm_Forward_Batch) {
+    // Skip with watcher enabled github issue #37193
+    SKIP_FOR_WATCHER();
     using namespace ttml;
 
     // 2 batches, 1 sequence, 20 tokens, 5-dim'l embedding space.
@@ -259,6 +274,8 @@ TEST_F(RMSNormOpTest, NIGHTLY_CompositeRMSNorm_Forward_Batch) {
 }
 
 TEST_F(RMSNormOpTest, NIGHTLY_CompositeRMSNorm_Backward_Batch) {
+    // Skip with watcher enabled github issue #37193
+    SKIP_FOR_WATCHER();
     using namespace ttml;
 
     // 2 batches, 1 sequence, 20 tokens, 5-dim'l embedding space.
@@ -401,11 +418,15 @@ static void CompareKernelVsComposite(const std::vector<uint32_t>& shape) {
 // ============================================================================
 
 TEST_F(RMSNormOpTest, RMSNorm_Compare_Basic_Small) {
+    // Skip with watcher enabled github issue #37193
+    SKIP_FOR_WATCHER();
     CompareKernelVsComposite({1U, 1U, 2U, 32U});
 }
 
 // Test aligned dimensions (C % 32 == 0) that fit in L1 cache
 TEST_F(RMSNormOpTest, RMSNorm_Compare_Aligned_FitsInL1) {
+    // Skip with watcher enabled github issue #37193
+    SKIP_FOR_WATCHER();
     // C = 1024 (32 * 32), fits in L1 cache
     CompareKernelVsComposite({1U, 1U, 1U, 1024U});
 
@@ -415,24 +436,32 @@ TEST_F(RMSNormOpTest, RMSNorm_Compare_Aligned_FitsInL1) {
 
 // Test aligned dimensions (C % 32 == 0) that fit in L1 except for gamma
 TEST_F(RMSNormOpTest, RMSNorm_Compare_Aligned_L1ExceptGamma) {
+    // Skip with watcher enabled github issue #37193
+    SKIP_FOR_WATCHER();
     // C = 8192 (1 << 13), fits in L1 except gamma parameter
     CompareKernelVsComposite({1U, 1U, 1U, 8192U});
 }
 
 // Test aligned dimensions (C % 32 == 0) that don't fit in L1 cache
 TEST_F(RMSNormOpTest, RMSNorm_Compare_Aligned_DoesNotFitInL1) {
+    // Skip with watcher enabled github issue #37193
+    SKIP_FOR_WATCHER();
     // C = 16384 (1 << 14), does not fit in L1 cache
     CompareKernelVsComposite({1U, 1U, 1U, 16384U});
 }
 
 // Test aligned dimensions (C % 32 == 0) with very large C
 TEST_F(RMSNormOpTest, RMSNorm_Compare_Aligned_VeryLargeC) {
+    // Skip with watcher enabled github issue #37193
+    SKIP_FOR_WATCHER();
     // C = 1048576 (1 << 20), very large C dimension (1M elements)
     CompareKernelVsComposite({1U, 1U, 1U, 1048576U});
 }
 
 // Test unaligned dimensions (C % 32 != 0) that fit in L1 cache
 TEST_F(RMSNormOpTest, RMSNorm_Compare_Unaligned_FitsInL1) {
+    // Skip with watcher enabled github issue #37193
+    SKIP_FOR_WATCHER();
     // C = 1023 (32 * 31 + 31), requires masking, fits in L1
     CompareKernelVsComposite({1U, 1U, 1U, 1023U});
 
@@ -442,12 +471,16 @@ TEST_F(RMSNormOpTest, RMSNorm_Compare_Unaligned_FitsInL1) {
 
 // Test unaligned dimensions (C % 32 != 0) that don't fit in L1 cache
 TEST_F(RMSNormOpTest, RMSNorm_Compare_Unaligned_DoesNotFitInL1) {
+    // Skip with watcher enabled github issue #37193
+    SKIP_FOR_WATCHER();
     // C = 16383 (1 << 14 - 1), requires masking, does not fit in L1
     CompareKernelVsComposite({1U, 1U, 1U, 16383U});
 }
 
 // Test unaligned dimensions (C % 32 != 0) with very large C
 TEST_F(RMSNormOpTest, RMSNorm_Compare_Unaligned_VeryLargeC) {
+    // Skip with watcher enabled github issue #37193
+    SKIP_FOR_WATCHER();
     // C = 1048575 (1 << 20 - 1), very large C with masking
     CompareKernelVsComposite({1U, 1U, 1U, 1048575U});
 
@@ -457,29 +490,39 @@ TEST_F(RMSNormOpTest, RMSNorm_Compare_Unaligned_VeryLargeC) {
 
 // Test block_size = 1 (C is odd)
 TEST_F(RMSNormOpTest, RMSNorm_Compare_BlockSize1_OddC) {
+    // Skip with watcher enabled github issue #37193
+    SKIP_FOR_WATCHER();
     CompareKernelVsComposite({1U, 1U, 1U, 33U});   // C = 33 (odd)
     CompareKernelVsComposite({1U, 1U, 1U, 127U});  // C = 127 (odd)
 }
 
 // Test block_size = 2 (C is even)
 TEST_F(RMSNormOpTest, RMSNorm_Compare_BlockSize2_EvenC) {
+    // Skip with watcher enabled github issue #37193
+    SKIP_FOR_WATCHER();
     CompareKernelVsComposite({1U, 1U, 1U, 34U});   // C = 34 (even)
     CompareKernelVsComposite({1U, 1U, 1U, 126U});  // C = 126 (even)
 }
 
 // Test training-like shapes with NanoLlama dimensions
 TEST_F(RMSNormOpTest, RMSNorm_Compare_TrainingShapes_NanoLlama) {
+    // Skip with watcher enabled github issue #37193
+    SKIP_FOR_WATCHER();
     // NanoLlama training shape: batch=64, seq_len=256, hidden_dim=384
     CompareKernelVsComposite({64U, 1U, 256U, 384U});
 }
 
 // Test training-like shapes with LLaMA 7B dimensions
 TEST_F(RMSNormOpTest, RMSNorm_Compare_TrainingShapes_NanoGPT) {
+    // Skip with watcher enabled github issue #37193
+    SKIP_FOR_WATCHER();
     CompareKernelVsComposite({1U, 1U, 512U, 4096U});
 }
 
 // Test small batch and sequence dimensions (non-1 values)
 TEST_F(RMSNormOpTest, NIGHTLY_RMSNorm_Compare_SmallBatch_NonUnit) {
+    // Skip with watcher enabled github issue #37193
+    SKIP_FOR_WATCHER();
     auto board = tt::umd::Cluster::create_cluster_descriptor()->get_board_type(0);
     if (board == tt::BoardType::P100 || board == tt::BoardType::P150) {
         GTEST_SKIP() << "Skipping on P100/P150 boards";
@@ -490,6 +533,8 @@ TEST_F(RMSNormOpTest, NIGHTLY_RMSNorm_Compare_SmallBatch_NonUnit) {
 
 // Test different masking patterns with larger batches
 TEST_F(RMSNormOpTest, NIGHTLY_RMSNorm_Compare_Masking_Patterns) {
+    // Skip with watcher enabled github issue #37193
+    SKIP_FOR_WATCHER();
     auto board = tt::umd::Cluster::create_cluster_descriptor()->get_board_type(0);
     if (board == tt::BoardType::P100 || board == tt::BoardType::P150) {
         GTEST_SKIP() << "Skipping on P100/P150 boards";

--- a/tt-train/tests/ops/rope_test.cpp
+++ b/tt-train/tests/ops/rope_test.cpp
@@ -6,6 +6,7 @@
 #include <core/ttnn_all_includes.hpp>
 
 #include "autograd/tensor.hpp"
+#include "core/system_utils.hpp"
 #include "core/tt_tensor_utils.hpp"
 #include "core/xtensor_utils.hpp"
 #include "modules/positional_embeddings.hpp"
@@ -466,6 +467,8 @@ TEST_F(RoPETest, ForwardTest) {
 }
 
 TEST_F(RoPETest, BackwardTest) {
+    // Skip with watcher enabled github issue #37193
+    SKIP_FOR_WATCHER();
     // Head dim must be a multiple of TILE_WIDTH
     // Head dim must be <= 256
     // Input query tensor

--- a/tt-train/tests/ops/silu_op_test.cpp
+++ b/tt-train/tests/ops/silu_op_test.cpp
@@ -11,6 +11,7 @@
 #include "autograd/auto_context.hpp"
 #include "autograd/tensor.hpp"
 #include "core/random.hpp"
+#include "core/system_utils.hpp"
 #include "core/tt_tensor_utils.hpp"
 #include "ops/losses.hpp"
 #include "ops/unary_ops.hpp"
@@ -175,6 +176,8 @@ static void CompareKernelVsReferenceWithShape(const std::vector<uint32_t>& shape
 
 // Test small tensor - basic functionality
 TEST_F(SiLUOpTest, SiLU_Compare_Small) {
+    // Skip with watcher enabled github issue #37193
+    SKIP_FOR_WATCHER();
     // C=8, Wt=1, Wt%4=1
     CompareKernelVsReferenceWithShape({1, 1, 1, 8});
 }
@@ -182,30 +185,40 @@ TEST_F(SiLUOpTest, SiLU_Compare_Small) {
 // Test block_size alignment patterns
 // Wt % block_size = 0 (perfectly aligned)
 TEST_F(SiLUOpTest, SiLU_Compare_BlockSize_Remainder0) {
+    // Skip with watcher enabled github issue #37193
+    SKIP_FOR_WATCHER();
     // C=128, Wt=4, Wt%4=0
     CompareKernelVsReferenceWithShape({1, 1, 1, 128});
 }
 
 // Wt % block_size = 1
 TEST_F(SiLUOpTest, SiLU_Compare_BlockSize_Remainder1) {
+    // Skip with watcher enabled github issue #37193
+    SKIP_FOR_WATCHER();
     // C=160, Wt=5, Wt%4=1
     CompareKernelVsReferenceWithShape({1, 1, 1, 160});
 }
 
 // Wt % block_size = 2
 TEST_F(SiLUOpTest, SiLU_Compare_BlockSize_Remainder2) {
+    // Skip with watcher enabled github issue #37193
+    SKIP_FOR_WATCHER();
     // C=192, Wt=6, Wt%4=2
     CompareKernelVsReferenceWithShape({1, 1, 1, 192});
 }
 
 // Wt % block_size = 3
 TEST_F(SiLUOpTest, SiLU_Compare_BlockSize_Remainder3) {
+    // Skip with watcher enabled github issue #37193
+    SKIP_FOR_WATCHER();
     // C=224, Wt=7, Wt%4=3
     CompareKernelVsReferenceWithShape({1, 1, 1, 224});
 }
 
 // Test large tensor - memory stress test
 TEST_F(SiLUOpTest, SiLU_Compare_Large) {
+    // Skip with watcher enabled github issue #37193
+    SKIP_FOR_WATCHER();
     // Large C dimension to test memory handling
     // C=32768, Wt=1024, Wt%4=0
     CompareKernelVsReferenceWithShape({1, 1, 1, 32768});
@@ -213,6 +226,8 @@ TEST_F(SiLUOpTest, SiLU_Compare_Large) {
 
 // Test very large tensor - extreme memory test
 TEST_F(SiLUOpTest, SiLU_Compare_VeryLarge) {
+    // Skip with watcher enabled github issue #37193
+    SKIP_FOR_WATCHER();
     // Very large C dimension ~1M elements
     // C=1048576, Wt=32768, Wt%4=0
     CompareKernelVsReferenceWithShape({1, 1, 1, 1048576});
@@ -220,6 +235,8 @@ TEST_F(SiLUOpTest, SiLU_Compare_VeryLarge) {
 
 // Test NanoLlama-like shape - realistic transformer model
 TEST_F(SiLUOpTest, SiLU_Compare_NanoLlama_Shape) {
+    // Skip with watcher enabled github issue #37193
+    SKIP_FOR_WATCHER();
     // Typical NanoLlama dimensions: multiple batches and sequences
     // B=2, N=1, S=64, C=512 (hidden dimension)
     // C=512, Wt=16, Wt%4=0
@@ -228,6 +245,8 @@ TEST_F(SiLUOpTest, SiLU_Compare_NanoLlama_Shape) {
 
 // Test batch processing with different sequence lengths
 TEST_F(SiLUOpTest, SiLU_Compare_MultiBatch_MultiSeq) {
+    // Skip with watcher enabled github issue #37193
+    SKIP_FOR_WATCHER();
     // Multiple batches with longer sequences
     // B=4, N=1, S=128, C=768
     // C=768, Wt=24, Wt%4=0
@@ -236,6 +255,8 @@ TEST_F(SiLUOpTest, SiLU_Compare_MultiBatch_MultiSeq) {
 
 // Test smaller model dimensions with unaligned C
 TEST_F(SiLUOpTest, SiLU_Compare_SmallModel_Unaligned) {
+    // Skip with watcher enabled github issue #37193
+    SKIP_FOR_WATCHER();
     // Smaller model with unaligned channel dimension
     // B=2, N=1, S=32, C=100
     // C=100, Wt=4, Wt%4=0 (but C is not multiple of 32)
@@ -251,6 +272,8 @@ TEST_F(SiLUOpTest, SiLU_Compare_SmallModel_Unaligned) {
 // ============================================================================
 
 TEST_F(SiLUOpTest, SiLU_Precision_Comparison) {
+    // Skip with watcher enabled github issue #37193
+    SKIP_FOR_WATCHER();
     using namespace ttml;
 
     // Single test shape: nanollama-like

--- a/tt-train/tests/ops/unary_ops_test.cpp
+++ b/tt-train/tests/ops/unary_ops_test.cpp
@@ -19,6 +19,7 @@
 #include "autograd/auto_context.hpp"
 #include "autograd/tensor.hpp"
 #include "core/random.hpp"
+#include "core/system_utils.hpp"
 #include "core/tt_tensor_utils.hpp"
 #include "ops/losses.hpp"
 
@@ -76,6 +77,8 @@ protected:
 };
 
 TEST_F(UnaryOpsTest, GlobalMean) {
+    // Skip with watcher enabled github issue #37193
+    SKIP_FOR_WATCHER();
     std::vector<float> test_data = {1.F, 2.F, 3.F, 4.F, 1.F, 2.F, 3.F, 4.F};
 
     auto shape = ttnn::Shape({2, 1, 1, 4});
@@ -121,6 +124,8 @@ TEST_F(UnaryOpsTest, LogSoftmax) {
 }
 
 TEST_F(UnaryOpsTest, Silu) {
+    // Skip with watcher enabled github issue #37193
+    SKIP_FOR_WATCHER();
     auto N = 4;
     auto C = 1;
     auto H = 20;

--- a/tt-train/tests/optimizers/adamw_test.cpp
+++ b/tt-train/tests/optimizers/adamw_test.cpp
@@ -10,6 +10,7 @@
 #include <core/ttnn_all_includes.hpp>
 
 #include "autograd/auto_context.hpp"
+#include "core/system_utils.hpp"
 #include "core/tt_tensor_utils.hpp"
 #include "fmt/base.h"
 #include "modules/linear_module.hpp"
@@ -28,6 +29,8 @@ protected:
 };
 
 TEST_F(AdamWFullTest, AdamWTest) {
+    // Skip with watcher enabled github issue #37193
+    SKIP_FOR_WATCHER();
     using namespace ttml::ops;
     ttml::autograd::ctx().set_seed(42);
     auto* device = &ttml::autograd::ctx().get_device();

--- a/tt-train/tests/optimizers/sgd_fused_test.cpp
+++ b/tt-train/tests/optimizers/sgd_fused_test.cpp
@@ -12,9 +12,9 @@
 
 #include "autograd/auto_context.hpp"
 #include "core/random.hpp"
+#include "core/system_utils.hpp"
 #include "core/tt_tensor_utils.hpp"
 #include "optimizers/sgd.hpp"
-#include "test_utils/env_utils.hpp"
 #include "xtensor/core/xtensor_forward.hpp"
 
 struct ParityCase {

--- a/tt-train/tests/optimizers/sgd_fused_test.cpp
+++ b/tt-train/tests/optimizers/sgd_fused_test.cpp
@@ -203,7 +203,7 @@ TEST_P(SGDFusedParityTest, UpdateParity) {
     // Skip specific Nesterov test case with watcher enabled
     if (pc.nesterov && pc.name == "Nesterov" && pc.shape[0] == 1 && pc.shape[1] == 2 && pc.shape[2] == 32 &&
         pc.shape[3] == 64) {
-        SKIP_FOR_WATCHER("Test is not passing with watcher enabled");
+        SKIP_FOR_WATCHER();
     }
 
     // Run 2 steps if momentum is enabled, 1 step otherwise

--- a/tt-train/tests/optimizers/sgd_fused_test.cpp
+++ b/tt-train/tests/optimizers/sgd_fused_test.cpp
@@ -200,12 +200,6 @@ static std::string CaseName(const ::testing::TestParamInfo<ParityCase>& info) {
 TEST_P(SGDFusedParityTest, UpdateParity) {
     const auto& pc = GetParam();
 
-    // Skip specific Nesterov test case with watcher enabled
-    if (pc.nesterov && pc.name == "Nesterov" && pc.shape[0] == 1 && pc.shape[1] == 2 && pc.shape[2] == 32 &&
-        pc.shape[3] == 64) {
-        SKIP_FOR_WATCHER();
-    }
-
     // Run 2 steps if momentum is enabled, 1 step otherwise
     const uint32_t steps = (pc.momentum != 0.0f) ? 2 : 1;
     run_steps_and_compare(pc, steps);

--- a/tt-train/tests/optimizers/sgd_fused_test.cpp
+++ b/tt-train/tests/optimizers/sgd_fused_test.cpp
@@ -201,9 +201,9 @@ TEST_P(SGDFusedParityTest, UpdateParity) {
     const auto& pc = GetParam();
 
     // Skip specific Nesterov test case with watcher enabled
-    if (ttml::test_utils::is_watcher_enabled() && pc.nesterov && pc.name == "Nesterov" && pc.shape[0] == 1 &&
-        pc.shape[1] == 2 && pc.shape[2] == 32 && pc.shape[3] == 64) {
-        GTEST_SKIP() << "Test is not passing with watcher enabled";
+    if (pc.nesterov && pc.name == "Nesterov" && pc.shape[0] == 1 && pc.shape[1] == 2 && pc.shape[2] == 32 &&
+        pc.shape[3] == 64) {
+        SKIP_FOR_WATCHER("Test is not passing with watcher enabled");
     }
 
     // Run 2 steps if momentum is enabled, 1 step otherwise

--- a/tt-train/tests/optimizers/sgd_fused_test.cpp
+++ b/tt-train/tests/optimizers/sgd_fused_test.cpp
@@ -12,7 +12,6 @@
 
 #include "autograd/auto_context.hpp"
 #include "core/random.hpp"
-#include "core/system_utils.hpp"
 #include "core/tt_tensor_utils.hpp"
 #include "optimizers/sgd.hpp"
 #include "xtensor/core/xtensor_forward.hpp"
@@ -199,7 +198,6 @@ static std::string CaseName(const ::testing::TestParamInfo<ParityCase>& info) {
 
 TEST_P(SGDFusedParityTest, UpdateParity) {
     const auto& pc = GetParam();
-
     // Run 2 steps if momentum is enabled, 1 step otherwise
     const uint32_t steps = (pc.momentum != 0.0f) ? 2 : 1;
     run_steps_and_compare(pc, steps);

--- a/tt-train/tests/optimizers/sgd_fused_test.cpp
+++ b/tt-train/tests/optimizers/sgd_fused_test.cpp
@@ -14,6 +14,7 @@
 #include "core/random.hpp"
 #include "core/tt_tensor_utils.hpp"
 #include "optimizers/sgd.hpp"
+#include "test_utils/env_utils.hpp"
 #include "xtensor/core/xtensor_forward.hpp"
 
 struct ParityCase {
@@ -198,6 +199,13 @@ static std::string CaseName(const ::testing::TestParamInfo<ParityCase>& info) {
 
 TEST_P(SGDFusedParityTest, UpdateParity) {
     const auto& pc = GetParam();
+
+    // Skip specific Nesterov test case with watcher enabled
+    if (ttml::test_utils::is_watcher_enabled() && pc.nesterov && pc.name == "Nesterov" && pc.shape[0] == 1 &&
+        pc.shape[1] == 2 && pc.shape[2] == 32 && pc.shape[3] == 64) {
+        GTEST_SKIP() << "Test is not passing with watcher enabled";
+    }
+
     // Run 2 steps if momentum is enabled, 1 step otherwise
     const uint32_t steps = (pc.momentum != 0.0f) ? 2 : 1;
     run_steps_and_compare(pc, steps);

--- a/tt-train/tests/ttnn_fixed/distributed/distributed_ttnn_ops_test.cpp
+++ b/tt-train/tests/ttnn_fixed/distributed/distributed_ttnn_ops_test.cpp
@@ -12,8 +12,8 @@
 #include "autograd/auto_context.hpp"
 #include "core/compute_kernel_config.hpp"
 #include "core/device.hpp"
+#include "core/system_utils.hpp"
 #include "core/tt_tensor_utils.hpp"
-#include "test_utils/env_utils.hpp"
 #include "ttnn_fixed/distributed/tt_metal.hpp"
 #include "ttnn_fixed/distributed/ttnn_ops.hpp"
 

--- a/tt-train/tests/ttnn_fixed/distributed/distributed_ttnn_ops_test.cpp
+++ b/tt-train/tests/ttnn_fixed/distributed/distributed_ttnn_ops_test.cpp
@@ -13,6 +13,7 @@
 #include "core/compute_kernel_config.hpp"
 #include "core/device.hpp"
 #include "core/tt_tensor_utils.hpp"
+#include "test_utils/env_utils.hpp"
 #include "ttnn_fixed/distributed/tt_metal.hpp"
 #include "ttnn_fixed/distributed/ttnn_ops.hpp"
 
@@ -40,6 +41,9 @@ protected:
 }  // namespace
 
 TEST_F(TrivialTnnFixedDistributedTest, TestCustomScatterDim0) {
+    // Test failing with watcher enabled, github issue #29556
+    SKIP_FOR_WATCHER();
+
     auto* device = &ttml::autograd::ctx().get_device();
 
     uint32_t size = 64U;
@@ -66,6 +70,9 @@ TEST_F(TrivialTnnFixedDistributedTest, TestCustomScatterDim0) {
 }
 
 TEST_F(TrivialTnnFixedDistributedTest, TestCustomScatterDim1) {
+    // Test failing with watcher enabled, github issue #29556
+    SKIP_FOR_WATCHER();
+
     auto* device = &ttml::autograd::ctx().get_device();
 
     uint32_t size = 64U;
@@ -92,6 +99,9 @@ TEST_F(TrivialTnnFixedDistributedTest, TestCustomScatterDim1) {
 }
 
 TEST_F(TrivialTnnFixedDistributedTest, TestCustomScatterDim2) {
+    // Test failing with watcher enabled, github issue #29556
+    SKIP_FOR_WATCHER();
+
     auto* device = &ttml::autograd::ctx().get_device();
 
     uint32_t size = 64U;

--- a/tt-train/tests/ttnn_fixed/reduce_ops_test.cpp
+++ b/tt-train/tests/ttnn_fixed/reduce_ops_test.cpp
@@ -14,6 +14,7 @@
 #include "core/compute_kernel_config.hpp"
 #include "core/device.hpp"
 #include "core/random.hpp"
+#include "core/system_utils.hpp"
 #include "core/tt_tensor_utils.hpp"
 #include "ttnn_fixed/trivial_ttnn_ops.hpp"
 
@@ -30,6 +31,8 @@ protected:
 };
 
 TEST_F(ReduceOpTest, TestMeanDim0) {
+    // Skip with watcher enabled github issue #37193
+    SKIP_FOR_WATCHER();
     ttml::autograd::ctx().set_seed(42);
     auto* device = &ttml::autograd::ctx().get_device();
     xt::xarray<float> xtensor_a = xt::empty<float>({128 * 64});

--- a/tt-train/tests/utils/memory_utils_test.cpp
+++ b/tt-train/tests/utils/memory_utils_test.cpp
@@ -31,6 +31,9 @@ size_t compute_tensor_size(const ttnn::Tensor& tensor) {
 }
 
 TEST_F(MemoryUtilsTest, DRAMUsageMatmulInScope) {
+    // Test is skipped with watcher due to the nature of the test.
+    // Test checks whether the calculated memory equals the amount actually used, this will always fail with watcher
+    // since watcher adds code overhead and uses memory to store its assert messages
     SKIP_FOR_WATCHER();
     auto* device = &ttml::autograd::ctx().get_device();
 
@@ -101,6 +104,9 @@ TEST_F(MemoryUtilsTest, DRAMUsageMatmulInScope) {
 }
 
 TEST_F(MemoryUtilsTest, DRAMUsageMultipleOperations) {
+    // Test is skipped with watcher due to the nature of the test.
+    // Test checks whether the calculated memory equals the amount actually used, this will always fail with watcher
+    // since watcher adds code overhead and uses memory to store its assert messages
     SKIP_FOR_WATCHER();
     auto* device = &ttml::autograd::ctx().get_device();
 
@@ -182,6 +188,9 @@ TEST_F(MemoryUtilsTest, DRAMUsageMultipleOperations) {
 }
 
 TEST_F(MemoryUtilsTest, L1Usage) {
+    // Test is skipped with watcher due to the nature of the test.
+    // Test checks whether the calculated memory equals the amount actually used, this will always fail with watcher
+    // since watcher adds code overhead and uses memory to store its assert messages
     SKIP_FOR_WATCHER();
     auto* device = &ttml::autograd::ctx().get_device();
 
@@ -278,6 +287,9 @@ TEST_F(MemoryUtilsTest, L1Usage) {
 }
 
 TEST_F(MemoryUtilsTest, SnapshotFeature) {
+    // Test is skipped with watcher due to the nature of the test.
+    // Test checks whether the calculated memory equals the amount actually used, this will always fail with watcher
+    // since watcher adds code overhead and uses memory to store its assert messages
     SKIP_FOR_WATCHER();
     auto* device = &ttml::autograd::ctx().get_device();
     device->disable_and_clear_program_cache();

--- a/tt-train/tests/utils/memory_utils_test.cpp
+++ b/tt-train/tests/utils/memory_utils_test.cpp
@@ -9,9 +9,9 @@
 #include <core/ttnn_all_includes.hpp>
 
 #include "autograd/auto_context.hpp"
+#include "core/system_utils.hpp"
 #include "core/tt_tensor_utils.hpp"
 #include "ops/scaled_dot_product_attention.hpp"
-#include "test_utils/env_utils.hpp"
 #include "ttnn/types.hpp"
 
 class MemoryUtilsTest : public ::testing::Test {

--- a/tt-train/tests/utils/memory_utils_test.cpp
+++ b/tt-train/tests/utils/memory_utils_test.cpp
@@ -11,6 +11,7 @@
 #include "autograd/auto_context.hpp"
 #include "core/tt_tensor_utils.hpp"
 #include "ops/scaled_dot_product_attention.hpp"
+#include "test_utils/env_utils.hpp"
 #include "ttnn/types.hpp"
 
 class MemoryUtilsTest : public ::testing::Test {
@@ -30,6 +31,7 @@ size_t compute_tensor_size(const ttnn::Tensor& tensor) {
 }
 
 TEST_F(MemoryUtilsTest, DRAMUsageMatmulInScope) {
+    SKIP_FOR_WATCHER();
     auto* device = &ttml::autograd::ctx().get_device();
 
     std::vector<float> data1(64 * 128, 1.0F);
@@ -99,6 +101,7 @@ TEST_F(MemoryUtilsTest, DRAMUsageMatmulInScope) {
 }
 
 TEST_F(MemoryUtilsTest, DRAMUsageMultipleOperations) {
+    SKIP_FOR_WATCHER();
     auto* device = &ttml::autograd::ctx().get_device();
 
     // Create multiple tensors of various sizes
@@ -179,6 +182,7 @@ TEST_F(MemoryUtilsTest, DRAMUsageMultipleOperations) {
 }
 
 TEST_F(MemoryUtilsTest, L1Usage) {
+    SKIP_FOR_WATCHER();
     auto* device = &ttml::autograd::ctx().get_device();
 
     // First capture: two 256x256 tensors added
@@ -274,6 +278,7 @@ TEST_F(MemoryUtilsTest, L1Usage) {
 }
 
 TEST_F(MemoryUtilsTest, SnapshotFeature) {
+    SKIP_FOR_WATCHER();
     auto* device = &ttml::autograd::ctx().get_device();
     device->disable_and_clear_program_cache();
 


### PR DESCRIPTION
### Ticket
[#27840](https://github.com/tenstorrent/tt-metal/issues/27840) 

### Problem description
Skipping the tests that have issues with watcher enabled

### What's changed
The tests having issues with watcher enabled are filed, described and skipped for CI run being run with watcher.

### Checklist

- [x] [APC Select](https://github.com/tenstorrent/tt-metal/actions/runs/21745897135?query=branch:dstoiljkovic/apc_select_watcher_7)