### PR TITLE
Add program configs for Matmul ops in Embedding block to run across 40 cores in the SDXL Refiner

### DIFF
--- a/models/experimental/stable_diffusion_xl_base/refiner/tests/pcc/test_module_tt_embedding.py
+++ b/models/experimental/stable_diffusion_xl_base/refiner/tests/pcc/test_module_tt_embedding.py
@@ -7,6 +7,7 @@ import torch
 import pytest
 import ttnn
 from models.experimental.stable_diffusion_xl_base.tt.tt_embedding import TtTimestepEmbedding
+from models.experimental.stable_diffusion_xl_base.refiner.tt.model_configs import RefinerModelOptimisations
 from diffusers import UNet2DConditionModel
 from tests.ttnn.utils_for_testing import assert_with_pcc
 from models.common.utility_functions import torch_random
@@ -28,7 +29,10 @@ def test_embedding(device, input_shape, module_path, is_ci_env, reset_seeds, lin
     torch_embedding = eval("unet." + module_path)
     assert torch_embedding is not None, f"{module_path} is not a valid UNet module"
 
-    tt_embedding = TtTimestepEmbedding(device, state_dict, module_path, linear_weights_dtype=linear_weights_dtype)
+    model_config = RefinerModelOptimisations()
+    tt_embedding = TtTimestepEmbedding(
+        device, state_dict, module_path, model_config, linear_weights_dtype=linear_weights_dtype
+    )
 
     torch_input_tensor = torch_random(input_shape, -0.1, 0.1, dtype=torch.float32)
     torch_output_tensor = torch_embedding(torch_input_tensor)

--- a/models/experimental/stable_diffusion_xl_base/refiner/tt/model_configs.py
+++ b/models/experimental/stable_diffusion_xl_base/refiner/tt/model_configs.py
@@ -604,12 +604,12 @@ class RefinerModelOptimisations(ModelOptimisations):
                     fused_activation=None,
                 ),
                 "1D_RESNET_LINEAR_1536": ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
-                    compute_with_storage_grid_size=(6, 8),
-                    in0_block_w=12,
+                    compute_with_storage_grid_size=(3, 8),
+                    in0_block_w=6,
                     out_subblock_h=1,
-                    out_subblock_w=1,
+                    out_subblock_w=2,
                     per_core_M=1,
-                    per_core_N=1,
+                    per_core_N=2,
                     mcast_in0=True,
                     fuse_batch=False,
                     fused_activation=None,
@@ -704,6 +704,50 @@ class RefinerModelOptimisations(ModelOptimisations):
                     out_subblock_h=1,
                     out_subblock_w=6,
                     mcast_in0=False,
+                    fuse_batch=False,
+                    fused_activation=None,
+                ),
+                "1D_TIME_EMBEDDING_LINEAR_1": ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
+                    compute_with_storage_grid_size=(3, 8),
+                    in0_block_w=4,
+                    out_subblock_h=1,
+                    out_subblock_w=1,
+                    per_core_M=1,
+                    per_core_N=2,
+                    mcast_in0=True,
+                    fuse_batch=False,
+                    fused_activation=ttnn.UnaryOpType.SILU,
+                ),
+                "1D_TIME_EMBEDDING_LINEAR_2": ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
+                    compute_with_storage_grid_size=(3, 8),
+                    in0_block_w=6,
+                    out_subblock_h=1,
+                    out_subblock_w=2,
+                    per_core_M=1,
+                    per_core_N=2,
+                    mcast_in0=True,
+                    fuse_batch=False,
+                    fused_activation=None,
+                ),
+                "1D_ADD_EMBEDDING_LINEAR_1": ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
+                    compute_with_storage_grid_size=(3, 8),
+                    in0_block_w=8,
+                    out_subblock_h=1,
+                    out_subblock_w=1,
+                    per_core_M=1,
+                    per_core_N=2,
+                    mcast_in0=True,
+                    fuse_batch=False,
+                    fused_activation=ttnn.UnaryOpType.SILU,
+                ),
+                "1D_ADD_EMBEDDING_LINEAR_2": ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
+                    compute_with_storage_grid_size=(3, 8),
+                    in0_block_w=6,
+                    out_subblock_h=1,
+                    out_subblock_w=2,
+                    per_core_M=1,
+                    per_core_N=2,
+                    mcast_in0=True,
                     fuse_batch=False,
                     fused_activation=None,
                 ),
@@ -889,6 +933,18 @@ class RefinerModelOptimisations(ModelOptimisations):
                 or "up_blocks.1.resnets" in matmul_path
             ):
                 return self.matmul_configs.get("1D_RESNET_LINEAR_1536")
+
+        if "time_embedding" in matmul_path:
+            if "linear_1" in matmul_path:
+                return self.matmul_configs.get("1D_TIME_EMBEDDING_LINEAR_1")
+            elif "linear_2" in matmul_path:
+                return self.matmul_configs.get("1D_TIME_EMBEDDING_LINEAR_2")
+
+        if "add_embedding" in matmul_path:
+            if "linear_1" in matmul_path:
+                return self.matmul_configs.get("1D_ADD_EMBEDDING_LINEAR_1")
+            elif "linear_2" in matmul_path:
+                return self.matmul_configs.get("1D_ADD_EMBEDDING_LINEAR_2")
 
         return None
 

--- a/models/experimental/stable_diffusion_xl_base/refiner/tt/model_configs.py
+++ b/models/experimental/stable_diffusion_xl_base/refiner/tt/model_configs.py
@@ -603,6 +603,7 @@ class RefinerModelOptimisations(ModelOptimisations):
                     fuse_batch=False,
                     fused_activation=None,
                 ),
+                # If stress test with 48 cores passes, change config to use 48 cores to avoid perf impact
                 "1D_RESNET_LINEAR_1536": ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
                     compute_with_storage_grid_size=(3, 8),
                     in0_block_w=6,

--- a/models/experimental/stable_diffusion_xl_base/tests/pcc/test_module_tt_embedding.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/pcc/test_module_tt_embedding.py
@@ -7,6 +7,7 @@ import torch
 import pytest
 import ttnn
 from models.experimental.stable_diffusion_xl_base.tt.tt_embedding import TtTimestepEmbedding
+from models.experimental.stable_diffusion_xl_base.tt.model_configs import ModelOptimisations
 from diffusers import UNet2DConditionModel
 from tests.ttnn.utils_for_testing import assert_with_pcc
 from models.common.utility_functions import torch_random
@@ -28,7 +29,10 @@ def test_embedding(device, input_shape, module_path, is_ci_env, reset_seeds, lin
     torch_embedding = eval("unet." + module_path)
     assert torch_embedding is not None, f"{module_path} is not a valid UNet module"
 
-    tt_embedding = TtTimestepEmbedding(device, state_dict, module_path, linear_weights_dtype=linear_weights_dtype)
+    model_config = ModelOptimisations()
+    tt_embedding = TtTimestepEmbedding(
+        device, state_dict, module_path, model_config, linear_weights_dtype=linear_weights_dtype
+    )
 
     torch_input_tensor = torch_random(input_shape, -0.1, 0.1, dtype=torch.float32)
     torch_output_tensor = torch_embedding(torch_input_tensor)

--- a/models/experimental/stable_diffusion_xl_base/tt/tt_embedding.py
+++ b/models/experimental/stable_diffusion_xl_base/tt/tt_embedding.py
@@ -24,8 +24,6 @@ class TtTimestepEmbedding(LightweightModule):
 
         self.linear_1_program_config = model_config.get_matmul_config(f"{module_path}.linear_1")
         self.linear_2_program_config = model_config.get_matmul_config(f"{module_path}.linear_2")
-        assert self.linear_1_program_config is not None
-        assert self.linear_2_program_config is not None
 
     def forward(self, sample):
         sample = ttnn.linear(

--- a/models/experimental/stable_diffusion_xl_base/tt/tt_embedding.py
+++ b/models/experimental/stable_diffusion_xl_base/tt/tt_embedding.py
@@ -38,6 +38,5 @@ class TtTimestepEmbedding(LightweightModule):
             self.tt_weights_2,
             bias=self.tt_bias_2,
             program_config=self.linear_2_program_config if self.linear_2_program_config else None,
-            activation="silu" if not self.linear_2_program_config else None,
         )
         return sample

--- a/models/experimental/stable_diffusion_xl_base/tt/tt_embedding.py
+++ b/models/experimental/stable_diffusion_xl_base/tt/tt_embedding.py
@@ -9,7 +9,7 @@ from models.experimental.stable_diffusion_xl_base.tt.sdxl_utility import prepare
 
 
 class TtTimestepEmbedding(LightweightModule):
-    def __init__(self, device, state_dict, module_path, linear_weights_dtype=ttnn.bfloat16):
+    def __init__(self, device, state_dict, module_path, model_config, linear_weights_dtype=ttnn.bfloat16):
         super().__init__()
 
         self.device = device
@@ -22,11 +22,24 @@ class TtTimestepEmbedding(LightweightModule):
         self.tt_weights_1, self.tt_bias_1 = prepare_linear_params(device, weights_1, bias_1, linear_weights_dtype)
         self.tt_weights_2, self.tt_bias_2 = prepare_linear_params(device, weights_2, bias_2, linear_weights_dtype)
 
+        self.linear_1_program_config = model_config.get_matmul_config(f"{module_path}.linear_1")
+        self.linear_2_program_config = model_config.get_matmul_config(f"{module_path}.linear_2")
+        assert self.linear_1_program_config is not None
+        assert self.linear_2_program_config is not None
+
     def forward(self, sample):
-        sample = ttnn.linear(sample, self.tt_weights_1, bias=self.tt_bias_1, activation="silu")
+        sample = ttnn.linear(
+            sample,
+            self.tt_weights_1,
+            bias=self.tt_bias_1,
+            program_config=self.linear_1_program_config if self.linear_1_program_config else None,
+            activation="silu" if not self.linear_1_program_config else None,
+        )
         sample = ttnn.linear(
             sample,
             self.tt_weights_2,
             bias=self.tt_bias_2,
+            program_config=self.linear_2_program_config if self.linear_2_program_config else None,
+            activation="silu" if not self.linear_2_program_config else None,
         )
         return sample

--- a/models/experimental/stable_diffusion_xl_base/tt/tt_unet.py
+++ b/models/experimental/stable_diffusion_xl_base/tt/tt_unet.py
@@ -49,10 +49,14 @@ class TtUNet2DConditionModel(LightweightModule):
 
         # Initialze embeddings with attention_weights_dtype for the time being.
         self.time_embedding = TtTimestepEmbedding(
-            device, state_dict, "time_embedding", linear_weights_dtype=model_config.attention_weights_dtype
+            device,
+            state_dict,
+            "time_embedding",
+            model_config,
+            linear_weights_dtype=model_config.attention_weights_dtype,
         )
         self.add_embedding = TtTimestepEmbedding(
-            device, state_dict, "add_embedding", linear_weights_dtype=model_config.attention_weights_dtype
+            device, state_dict, "add_embedding", model_config, linear_weights_dtype=model_config.attention_weights_dtype
         )
 
         self.down_blocks = []


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/37262

### Problem description
SDXL Refiner currently doesn't have program configs that run Embedding block Matmul ops across at most 40 cores. Also `1D_RESNET_LINEAR_1536` currently uses 48 cores. Change config so this Resnet Linear op runs across at most 40 cores.

### What's changed
Added missing program configs for Embedding block for the Refiner and changed `1D_RESNET_LINEAR_1536` config so all Matmul/Linear ops in the SDXL Refiner run across at most 40 cores.
Embedding block now receives model_config, so the `__init__` method is changed. Changed all tests to pass model_config to the Embedding block.

Sheet with all Matmul/Linear ops in the SDXL Refiner is available [here](https://docs.google.com/spreadsheets/d/1sxeUqdDLLSZJ3WWP2X_OhcqSZ09bFVZhtEAMfBg_Z14/edit?usp=sharing).

### Checklist

- [x] [All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/runs/21744897306) CI passes
- [x] [(Single-card) Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/runs/21744917423) CI passes
- [x] [(Single-card) Demo tests (perf runs)](https://github.com/tenstorrent/tt-metal/actions/runs/21744929505) CI passes
- [x] [Nightly tt-metal L2 tests](https://github.com/tenstorrent/tt-metal/actions/runs/21744947225) CI passes
- [x] [(Single-card) Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/runs/21745193663) CI passes