### PR TITLE
[TT-Transformers] Put mesh_partition instead of reduce_scatter for slicing replicated mesh tensor

### DIFF
--- a/models/tt_transformers/tt/decoder.py
+++ b/models/tt_transformers/tt/decoder.py
@@ -6,7 +6,6 @@ import ttnn
 from models.common.lightweightmodule import LightweightModule
 from models.common.rmsnorm import RMSNorm
 from models.tt_transformers.tt.attention import Attention as DefaultAttention
-from models.tt_transformers.tt.ccl import tt_all_reduce
 from models.tt_transformers.tt.distributed_norm import DistributedNorm
 from models.tt_transformers.tt.mixtral_mlp import TtMixtralMLP
 from models.tt_transformers.tt.mixtral_moe import TtMoeLayer
@@ -167,6 +166,7 @@ class TransformerBlock(LightweightModule):
                 prefetcher=self.prefetcher,
                 TG=args.is_galaxy,
             )
+            self.ff_norm.enable_all_gather = False  # all_gather after normalization is not needed if model uses pre_ff_norm because the output of ff_norm is already sharded correctly so it can be added with the residual without all_gather and mesh_partition
         else:
             # If pre_feedforward_layernorm is not in state_dict, we do not use it
             self.pre_ff_norm = None
@@ -191,6 +191,7 @@ class TransformerBlock(LightweightModule):
                 tt_ccl=self.tt_ccl,
                 prefetcher=self.prefetcher,
                 TG=args.is_galaxy,
+                enable_all_gather=False,
             )
         else:
             # If post_feedforward_layernorm is not in state_dict, we do not use it
@@ -258,20 +259,16 @@ class TransformerBlock(LightweightModule):
 
         if self.pre_ff_norm is not None:
             # The output of the ff_norm is replicated across the device
-            # but the residual is fractured across the devices
-            if self.num_devices > 1:
-                hidden_states = tt_all_reduce(
+            # but the residual is fractured across the devices.
+            # If ff_norm uses distributed norm, then the output is already sharded correctly across devices, so no need to all_gather and mesh_partition, otherwise we need to mesh_partition the output of ff_norm to match the sharding of the residual for the addition
+            if self.num_devices > 1 and not self.args.is_distributed_norm(mode):
+                hidden_states = ttnn.mesh_partition(
                     hidden_states,
-                    self.mesh_device,
-                    tt_ccl=self.tt_ccl,
-                    cluster_axis=0,
+                    memory_config=hidden_states.memory_config(),
                     dim=3,
-                    topology=ttnn.Topology.Ring,
-                    memory_config=ttnn.DRAM_MEMORY_CONFIG,
-                    dtype=self.args.ccl_dtype,
+                    cluster_axis=1,
                 )
 
-                hidden_states = ttnn.div(hidden_states, self.num_devices)
             hidden_states = ttnn.add(
                 residual, hidden_states, memory_config=skip_mem_cfg, dtype=ttnn.bfloat16 if TG else None
             )
@@ -294,19 +291,13 @@ class TransformerBlock(LightweightModule):
         if self.post_ff_norm is not None:
             post_ff_norm_config = self.args.get_norm_config("ff", mode, self.prefetcher)
             hidden_states = self.post_ff_norm(hidden_states, mode, norm_config=post_ff_norm_config)  # Gathered
-            if self.num_devices > 1:
-                hidden_states = tt_all_reduce(
+            if self.num_devices > 1 and not self.args.is_distributed_norm(mode):
+                hidden_states = ttnn.mesh_partition(
                     hidden_states,
-                    self.mesh_device,
-                    tt_ccl=self.tt_ccl,
-                    cluster_axis=0,
+                    memory_config=hidden_states.memory_config(),
                     dim=3,
-                    topology=ttnn.Topology.Ring,
-                    memory_config=ttnn.DRAM_MEMORY_CONFIG,
-                    dtype=self.args.ccl_dtype,
+                    cluster_axis=1,
                 )
-
-                hidden_states = ttnn.div(hidden_states, self.num_devices)
 
         out = ttnn.add(
             residual,

--- a/models/tt_transformers/tt/distributed_norm.py
+++ b/models/tt_transformers/tt/distributed_norm.py
@@ -16,7 +16,7 @@ class DistributedNorm(LightweightModule):
         self.prefetcher = prefetcher
         self.ag_config_key = ag_config_key
 
-        # This flag is to enable or disable the all_gather after the distributed norm, but if model uses pre_ff or post_ff normalization then all_gather+mesh_partition is not needed as the output of distributed norm is already sharded
+        # Flag to control whether all_gather is performed after distributed norm (can be disabled when output should remain sharded)
         self.enable_all_gather = enable_all_gather
 
         if TG:

--- a/models/tt_transformers/tt/distributed_norm.py
+++ b/models/tt_transformers/tt/distributed_norm.py
@@ -9,12 +9,15 @@ from models.tt_transformers.tt.common import Mode
 
 
 class DistributedNorm(LightweightModule):
-    def __init__(self, norm, args, tt_ccl, prefetcher=None, TG=False, ag_config_key=None):
+    def __init__(self, norm, args, tt_ccl, prefetcher=None, TG=False, ag_config_key=None, enable_all_gather=True):
         self.norm = norm
         self.args = args
         self.tt_ccl = tt_ccl
         self.prefetcher = prefetcher
         self.ag_config_key = ag_config_key
+
+        # This flag is to enable or disable the all_gather after the distributed norm, but if model uses pre_ff or post_ff normalization then all_gather+mesh_partition is not needed as the output of distributed norm is already sharded
+        self.enable_all_gather = enable_all_gather
 
         if TG:
             core_grid_ln = (
@@ -107,7 +110,7 @@ class DistributedNorm(LightweightModule):
         )
 
         # Distributed norm requires a gather
-        if self.args.is_distributed_norm(mode):
+        if self.args.is_distributed_norm(mode) and self.enable_all_gather:
             x = ttnn.experimental.all_gather_async(
                 x,
                 persistent_output_buffer=None,


### PR DESCRIPTION
### Ticket
(https://github.com/tenstorrent/tt-metal/issues/37107)

### Problem description
`tt_all_reduce` takes too long to slice replicated `mesh tensor `on multiple devices it should be changed.

### What's changed
Put `mesh_partition` for slicing replicated `mesh tensor` on multiple devices for better performance.
All changes are measured `without tracy` enabled.

Decode performance of 1 layer before changes with `tt_all_reduce` for `gemma-3-27b`.
<img width="2558" height="1924" alt="image" src="https://github.com/user-attachments/assets/f61634ce-f99e-4a38-9654-c2b7a1b02a8f" />

Prefill performance of 1 layer before changes with `4096 max_seq_len` for `gemma-3-27b`.
<img width="3090" height="1742" alt="image" src="https://github.com/user-attachments/assets/9e2057d8-7bcd-44aa-8ea4-23a18ecbd252" />


Decode performance of 1 layer with `mesh_partition` used  for `gemma-3-27b`.
<img width="3490" height="2234" alt="image" src="https://github.com/user-attachments/assets/cec69038-6e13-41a4-8e7a-e1737b4cb059" />

Prefill performance of 1 layer with changes for `4096 max_seq_len` for `gemma-3-27b`.
<img width="3038" height="1484" alt="image" src="https://github.com/user-attachments/assets/07779cf8-554b-4a79-9b7b-69623f0259fa" />




### Checklist

- [x] [All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/runs/21756668963)
- [x] [vLLM-nightly](https://github.com/tenstorrent/tt-metal/actions/runs/21756709205)
- [x] [Single-card demo](https://github.com/tenstorrent/tt-metal/actions/runs/21756672975)
- [x] [Single-card unit tests](https://github.com/tenstorrent/tt-metal/actions/runs/21756682546)
- [x] [Models CI](https://github.com/tenstorrent/tt-shield/actions/runs/21756646687/job/62773138169)