### PR TITLE
Fix segfaults on ttnn.ones, ttnn.zeros, ttnn.empty

### DIFF
--- a/ttnn/cpp/ttnn-nanobind/operations/creation.cpp
+++ b/ttnn/cpp/ttnn-nanobind/operations/creation.cpp
@@ -18,6 +18,7 @@
 #include "ttnn-nanobind/bfloat16_type_caster.hpp"  // NOLINT - for nanobind bfloat16 binding support.
 #include "ttnn-nanobind/decorators.hpp"
 #include "ttnn-nanobind/nanobind_helpers.hpp"
+#include "ttnn-nanobind/small_vector_caster.hpp"  // NOLINT - for nanobind SmallVector binding support.
 #include "ttnn-nanobind/types.hpp"
 #include "ttnn/operations/creation.hpp"
 #include "ttnn/tensor/types.hpp"
@@ -29,7 +30,7 @@ template <typename creation_operation_t, typename fill_value_t>
 auto create_nanobind_full_overload() {
     return ttnn::nanobind_overload_t{
         [](const creation_operation_t& self,
-           const std::vector<uint32_t>& shape,
+           const ttsl::SmallVector<uint32_t>& shape,
            const fill_value_t fill_value,
            const std::optional<DataType>& dtype,
            const std::optional<Layout>& layout,
@@ -209,7 +210,7 @@ void bind_full_operation_with_hard_coded_value(
         doc,
         ttnn::nanobind_overload_t{
             [](const creation_operation_t& self,
-               const std::vector<uint32_t>& shape,
+               const ttsl::SmallVector<uint32_t>& shape,
                const std::optional<DataType>& dtype,
                const std::optional<Layout>& layout,
                const std::optional<MeshDevice*> device,
@@ -393,7 +394,7 @@ void bind_empty_operation(nb::module_& mod, const creation_operation_t& operatio
         doc,
         ttnn::nanobind_overload_t{
             [](const creation_operation_t& self,
-               const std::vector<uint32_t>& shape,
+               const ttsl::SmallVector<uint32_t>& shape,
                const DataType& dtype,
                const Layout& layout,
                MeshDevice* device,


### PR DESCRIPTION
### Ticket
#37178

### Problem description
When building metal with specific arguments, creations ops can segfault (host) problem.
This is due to a typecaster issue in nanobind.  

### What's changed
This PR updates nano binding of zeros/ones/... to use SmallVector instead of std::vector and include small_vector_typecaster file.
This fixes the segfault (confirmed locally). 

### Checklist

- [x] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=nmaurice/fix-ttnn-zero-segfault)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:nmaurice/fix-ttnn-zero-segfault)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:{{branch_name}})
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nmaurice/fix-ttnn-zero-segfault)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nmaurice/fix-ttnn-zero-segfault) (fails on something else, running [test_creations.py gives good results](https://github.com/tenstorrent/tt-metal/actions/runs/21753351023))
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:{{branch_name}})
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:{{branch_name}})
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:{{branch_name}})
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
