### PR TITLE
[tt-train] Remove unnecessary .hpp files from ttml METAL_OPS_FILES

### DIFF
--- a/tt-train/sources/ttml/CMakeLists.txt
+++ b/tt-train/sources/ttml/CMakeLists.txt
@@ -194,131 +194,65 @@ set(SOURCES
 )
 
 # Manually select only specific files from metal ops
+# Note: Only .cpp files are listed here. Headers (.hpp) are found via include directories.
 set(METAL_OPS_FILES
-    # General
-    ${CMAKE_CURRENT_SOURCE_DIR}/metal/operations.hpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/metal/ttnn_all_includes.hpp
-    # Common
-    ${CMAKE_CURRENT_SOURCE_DIR}/metal/common/dataflow_utils.hpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/metal/common/compute_utils.hpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/metal/common/program_utils.hpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/metal/common/const_utils.hpp
-    # RMSNorm
     # RMSNorm Forward
     ${CMAKE_CURRENT_SOURCE_DIR}/metal/ops/rmsnorm_fw/rmsnorm_fw.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/metal/ops/rmsnorm_fw/rmsnorm_fw.hpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/metal/ops/rmsnorm_fw/device/rmsnorm_fw_device_operation_types.hpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/metal/ops/rmsnorm_fw/device/rmsnorm_fw_device_operation.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/metal/ops/rmsnorm_fw/device/rmsnorm_fw_device_operation.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/metal/ops/rmsnorm_fw/device/rmsnorm_fw_program_factory.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/metal/ops/rmsnorm_fw/device/rmsnorm_fw_program_factory.cpp
     # RMSNorm Backward
     ${CMAKE_CURRENT_SOURCE_DIR}/metal/ops/rmsnorm_bw/rmsnorm_bw.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/metal/ops/rmsnorm_bw/rmsnorm_bw.hpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/metal/ops/rmsnorm_bw/device/rmsnorm_bw_device_operation_types.hpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/metal/ops/rmsnorm_bw/device/rmsnorm_bw_device_operation.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/metal/ops/rmsnorm_bw/device/rmsnorm_bw_device_operation.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/metal/ops/rmsnorm_bw/device/rmsnorm_bw_program_factory.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/metal/ops/rmsnorm_bw/device/rmsnorm_bw_program_factory.cpp
     # LayerNorm Backward
     ${CMAKE_CURRENT_SOURCE_DIR}/metal/ops/layernorm_bw/layernorm_bw.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/metal/ops/layernorm_bw/layernorm_bw.hpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/metal/ops/layernorm_bw/device/layernorm_bw_device_operation_types.hpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/metal/ops/layernorm_bw/device/layernorm_bw_device_operation.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/metal/ops/layernorm_bw/device/layernorm_bw_device_operation.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/metal/ops/layernorm_bw/device/layernorm_bw_program_factory.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/metal/ops/layernorm_bw/device/layernorm_bw_program_factory.cpp
     # LayerNorm Forward
     ${CMAKE_CURRENT_SOURCE_DIR}/metal/ops/layernorm_fw/layernorm_fw.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/metal/ops/layernorm_fw/layernorm_fw.hpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/metal/ops/layernorm_fw/device/layernorm_fw_device_operation_types.hpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/metal/ops/layernorm_fw/device/layernorm_fw_device_operation.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/metal/ops/layernorm_fw/device/layernorm_fw_device_operation.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/metal/ops/layernorm_fw/device/layernorm_fw_program_factory.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/metal/ops/layernorm_fw/device/layernorm_fw_program_factory.cpp
-    # CrossEntropy
+    # CrossEntropy Forward
     ${CMAKE_CURRENT_SOURCE_DIR}/metal/ops/cross_entropy_fw/cross_entropy_fw.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/metal/ops/cross_entropy_fw/cross_entropy_fw.hpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/metal/ops/cross_entropy_fw/device/cross_entropy_fw_device_operation_types.hpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/metal/ops/cross_entropy_fw/device/cross_entropy_fw_device_operation.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/metal/ops/cross_entropy_fw/device/cross_entropy_fw_device_operation.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/metal/ops/cross_entropy_fw/device/cross_entropy_fw_program_factory.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/metal/ops/cross_entropy_fw/device/cross_entropy_fw_program_factory.cpp
+    # CrossEntropy Backward
     ${CMAKE_CURRENT_SOURCE_DIR}/metal/ops/cross_entropy_bw/cross_entropy_bw.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/metal/ops/cross_entropy_bw/cross_entropy_bw.hpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/metal/ops/cross_entropy_bw/device/cross_entropy_bw_device_operation_types.hpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/metal/ops/cross_entropy_bw/device/cross_entropy_bw_device_operation.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/metal/ops/cross_entropy_bw/device/cross_entropy_bw_device_operation.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/metal/ops/cross_entropy_bw/device/cross_entropy_bw_program_factory.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/metal/ops/cross_entropy_bw/device/cross_entropy_bw_program_factory.cpp
     # Softmax
     ${CMAKE_CURRENT_SOURCE_DIR}/metal/ops/softmax/softmax.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/metal/ops/softmax/softmax.hpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/metal/ops/softmax/device/softmax_device_operation_types.hpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/metal/ops/softmax/device/softmax_device_operation.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/metal/ops/softmax/device/softmax_device_operation.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/metal/ops/softmax/device/softmax_program_factory.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/metal/ops/softmax/device/softmax_program_factory.cpp
     # ProfilerNoOp
     ${CMAKE_CURRENT_SOURCE_DIR}/metal/ops/profiler_no_op/profiler_no_op.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/metal/ops/profiler_no_op/profiler_no_op.hpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/metal/ops/profiler_no_op/device/profiler_no_op_device_operation_types.hpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/metal/ops/profiler_no_op/device/profiler_no_op_device_operation.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/metal/ops/profiler_no_op/device/profiler_no_op_device_operation.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/metal/ops/profiler_no_op/device/profiler_no_op_program_factory.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/metal/ops/profiler_no_op/device/profiler_no_op_program_factory.cpp
     # SiLU Backward
     ${CMAKE_CURRENT_SOURCE_DIR}/metal/ops/silu_bw/silu_bw.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/metal/ops/silu_bw/silu_bw.hpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/metal/ops/silu_bw/device/silu_bw_device_operation_types.hpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/metal/ops/silu_bw/device/silu_bw_device_operation.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/metal/ops/silu_bw/device/silu_bw_device_operation.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/metal/ops/silu_bw/device/silu_bw_program_factory.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/metal/ops/silu_bw/device/silu_bw_program_factory.cpp
     # SDPA Forward
     ${CMAKE_CURRENT_SOURCE_DIR}/metal/ops/sdpa_fw/sdpa_fw.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/metal/ops/sdpa_fw/sdpa_fw.hpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/metal/ops/sdpa_fw/device/sdpa_fw_device_operation_types.hpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/metal/ops/sdpa_fw/device/sdpa_fw_device_operation.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/metal/ops/sdpa_fw/device/sdpa_fw_device_operation.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/metal/ops/sdpa_fw/device/sdpa_fw_program_factory.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/metal/ops/sdpa_fw/device/sdpa_fw_program_factory.cpp
     # SDPA Backward
     ${CMAKE_CURRENT_SOURCE_DIR}/metal/ops/sdpa_bw/sdpa_bw.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/metal/ops/sdpa_bw/sdpa_bw.hpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/metal/ops/sdpa_bw/device/sdpa_bw_kv_device_operation_types.hpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/metal/ops/sdpa_bw/device/sdpa_bw_kv_device_operation.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/metal/ops/sdpa_bw/device/sdpa_bw_kv_device_operation.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/metal/ops/sdpa_bw/device/sdpa_bw_kv_program_factory.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/metal/ops/sdpa_bw/device/sdpa_bw_kv_program_factory.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/metal/ops/sdpa_bw/device/sdpa_bw_q_device_operation_types.hpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/metal/ops/sdpa_bw/device/sdpa_bw_q_device_operation.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/metal/ops/sdpa_bw/device/sdpa_bw_q_device_operation.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/metal/ops/sdpa_bw/device/sdpa_bw_q_program_factory.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/metal/ops/sdpa_bw/device/sdpa_bw_q_program_factory.cpp
     # SGD Fused Optimizer
-    ${CMAKE_CURRENT_SOURCE_DIR}/metal/optimizers/sgd_fused/sgd_fused.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/metal/optimizers/sgd_fused/sgd_fused.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/metal/optimizers/sgd_fused/device/sgd_fused_device_operation_types.hpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/metal/optimizers/sgd_fused/device/sgd_fused_device_operation.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/metal/optimizers/sgd_fused/device/sgd_fused_device_operation.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/metal/optimizers/sgd_fused/device/sgd_fused_program_factory.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/metal/optimizers/sgd_fused/device/sgd_fused_program_factory.cpp
     # SwiGLU Forward
     ${CMAKE_CURRENT_SOURCE_DIR}/metal/ops/swiglu_fw/swiglu_fw.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/metal/ops/swiglu_fw/swiglu_fw.hpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/metal/ops/swiglu_fw/device/swiglu_fw_device_operation_types.hpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/metal/ops/swiglu_fw/device/swiglu_fw_device_operation.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/metal/ops/swiglu_fw/device/swiglu_fw_device_operation.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/metal/ops/swiglu_fw/device/swiglu_fw_program_factory.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/metal/ops/swiglu_fw/device/swiglu_fw_program_factory.cpp
     # AdamW Optimizer (consolidated: supports both half and full precision)
-    ${CMAKE_CURRENT_SOURCE_DIR}/metal/optimizers/adamw/adamw.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/metal/optimizers/adamw/adamw.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/metal/optimizers/adamw/device/adamw_device_operation_types.hpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/metal/optimizers/adamw/device/adamw_device_operation.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/metal/optimizers/adamw/device/adamw_device_operation.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/metal/optimizers/adamw/device/adamw_program_factory.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/metal/optimizers/adamw/device/adamw_program_factory.cpp
 )
 

--- a/tt-train/sources/ttml/CMakeLists.txt
+++ b/tt-train/sources/ttml/CMakeLists.txt
@@ -2,199 +2,95 @@ project(ttml)
 
 set(SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/autograd/auto_context.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/autograd/auto_context.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/autograd/autocast_tensor.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/autograd/autocast_tensor.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/autograd/graph.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/autograd/graph.hpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/autograd/graph_utils.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/autograd/tensor.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/autograd/tensor.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/core/clip_grad_norm.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/core/clip_grad_norm.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/core/compute_kernel_config.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/core/compute_kernel_config.hpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/core/debug.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/core/device.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/core/device.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/core/distributed/distributed.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/core/distributed/distributed.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/core/distributed/ccl_resources.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/core/distributed/ccl_resources.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/core/distributed/socket_manager.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/core/distributed/socket_manager.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/core/mesh_device.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/core/mesh_device.hpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/core/not_null.hpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/core/random.hpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/core/random_sse.hpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/core/scoped.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/core/system_utils.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/core/system_utils.hpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/core/template_utils.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/core/tt_profiler.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/core/tt_profiler.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/core/tt_tensor_utils.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/core/tt_tensor_utils.hpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/core/ttnn_all_includes.hpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/core/xtensor_utils.hpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/datasets/dataloader.hpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/datasets/dataset_base.hpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/datasets/dataset_subset.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/datasets/generators.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/datasets/generators.hpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/datasets/in_memory_dataset.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/datasets/in_memory_token_dataset.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/datasets/in_memory_token_dataset.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/datasets/utils.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/datasets/utils.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/init/cpu_initializers.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/init/cpu_initializers.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/init/tensor_initializers.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/init/tensor_initializers.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/models/common/transformer_common.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/models/common/transformer_common.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/models/distributed/gpt2.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/models/distributed/gpt2.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/models/distributed/llama.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/models/distributed/llama.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/models/distributed/pipeline_parallel_llama.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/models/distributed/pipeline_parallel_llama.hpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/models/base_transformer.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/models/gpt2.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/models/gpt2.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/models/linear_regression.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/models/linear_regression.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/models/llama.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/models/llama.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/models/mlp.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/models/mlp.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/modules/distributed/gpt_block.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/modules/distributed/gpt_block.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/modules/distributed/grouped_query_attention.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/modules/distributed/grouped_query_attention.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/modules/distributed/linear.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/modules/distributed/linear.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/modules/distributed/llama_block.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/modules/distributed/llama_block.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/modules/distributed/multi_head_attention.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/modules/distributed/multi_head_attention.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/modules/dropout_module.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/modules/dropout_module.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/modules/embedding_module.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/modules/embedding_module.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/modules/gpt_block.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/modules/gpt_block.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/modules/grouped_query_attention.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/modules/grouped_query_attention.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/modules/layer_norm_module.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/modules/layer_norm_module.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/modules/linear_module.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/modules/linear_module.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/modules/llama_block.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/modules/llama_block.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/modules/lora_linear_module.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/modules/lora_linear_module.hpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/modules/module_base.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/modules/module_base.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/modules/multi_head_attention.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/modules/multi_head_attention.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/modules/multi_layer_perceptron.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/modules/multi_layer_perceptron.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/modules/positional_embeddings.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/modules/positional_embeddings.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/modules/rms_norm_module.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/modules/rms_norm_module.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/modules/rotary_embedding.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/modules/rotary_embedding.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/modules/single_head_attention.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/modules/single_head_attention.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/ops/binary_ops.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/ops/binary_ops.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/ops/distributed/comm_ops.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/ops/distributed/comm_ops.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/ops/distributed/pipeline_parallel_comm_ops.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/ops/distributed/pipeline_parallel_comm_ops.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/ops/dropout_op.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/ops/dropout_op.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/ops/embedding_op.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/ops/embedding_op.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/ops/layernorm_op.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/ops/layernorm_op.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/ops/linear_op.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/ops/linear_op.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/ops/losses.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/ops/losses.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/ops/matmul_op.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/ops/matmul_op.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/ops/multi_head_utils.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/ops/multi_head_utils.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/ops/reshape_op.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/ops/reshape_op.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/ops/rmsnorm_op.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/ops/rmsnorm_op.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/ops/rope_op.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/ops/rope_op.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/ops/scaled_dot_product_attention.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/ops/scaled_dot_product_attention.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/ops/swiglu_op.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/ops/swiglu_op.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/ops/unary_ops.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/ops/unary_ops.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/ops/sampling_op.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/ops/sampling_op.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/optimizers/adamw.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/optimizers/adamw.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/optimizers/optimizer_base.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/optimizers/optimizer_base.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/optimizers/remote_optimizer.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/optimizers/remote_optimizer.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/optimizers/sgd.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/optimizers/sgd.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/optimizers/adamw_fused.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/optimizers/adamw_fused.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/optimizers/adamw_full_precision.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/optimizers/adamw_full_precision.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/optimizers/no_op.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/optimizers/no_op.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/optimizers/sgd_fused.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/optimizers/sgd_fused.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/schedulers/lambda_scheduler.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/schedulers/lambda_scheduler.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/schedulers/linear_scheduler.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/schedulers/linear_scheduler.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/schedulers/scheduler_base.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/schedulers/scheduler_base.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/schedulers/sequential_scheduler.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/schedulers/sequential_scheduler.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/schedulers/step_scheduler.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/schedulers/step_scheduler.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/serialization/flatbuffer_file.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/serialization/flatbuffer_file.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/serialization/safetensors.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/serialization/safetensors.hpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/serialization/serializable.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/serialization/serialization.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/serialization/serialization.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/tokenizers/char_tokenizer.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/tokenizers/char_tokenizer.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/tokenizers/char_tokenizer_trainer.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/tokenizers/char_tokenizer_trainer.hpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/tokenizers/tokenizer_base.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/ttnn_fixed/distributed/ttnn_ops.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/ttnn_fixed/distributed/ttnn_ops.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/ttnn_fixed/distributed/tt_metal.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/ttnn_fixed/distributed/tt_metal.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/ttnn_fixed/matmuls.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/ttnn_fixed/matmuls.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/ttnn_fixed/trivial_ttnn_ops.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/ttnn_fixed/trivial_ttnn_ops.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/utils/memory_utils.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/utils/memory_utils.hpp
 )
 
 # Manually select only specific files from metal ops
-# Note: Only .cpp files are listed here. Headers (.hpp) are found via include directories.
 set(METAL_OPS_FILES
     # RMSNorm Forward
     ${CMAKE_CURRENT_SOURCE_DIR}/metal/ops/rmsnorm_fw/rmsnorm_fw.cpp


### PR DESCRIPTION
### Ticket
N/A (Code cleanup)

### Problem description
The `SOURCES` and `METAL_OPS_FILES` lists in `tt-train/sources/ttml/CMakeLists.txt` included both `.cpp` and `.hpp` files. Header files don't need to be listed in CMake source lists - they are discovered automatically through `#include` directives and the configured `target_include_directories`. This added unnecessary maintenance burden when adding new source files, as developers had to remember to list both the source and header files.

### What's changed
Removed all `.hpp` files from both the `SOURCES` and `METAL_OPS_FILES` lists in `CMakeLists.txt`, keeping only `.cpp` files that require compilation. Added comments clarifying this convention for future contributors.

**Changes:**
- **SOURCES section**: Reduced from ~194 entries to ~81 entries (removed 103 `.hpp` files)
- **METAL_OPS_FILES section**: Reduced from ~131 entries to ~65 entries (removed 66 `.hpp` files)  

This significantly reduces the maintenance burden - when adding new source files, developers now only need to add the `.cpp` files to the appropriate lists.

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=mdragula/remove-commons-from-cmake)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:mdragula/remove-commons-from-cmake)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=mdragula/remove-commons-from-cmake)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:mdragula/remove-commons-from-cmake)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mdragula/remove-commons-from-cmake)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mdragula/remove-commons-from-cmake)
- [ ] New/Existing tests provide coverage for changes