### PR TITLE
Fix DeepSeek V3 config loading when model path is a symlink

### DIFF
--- a/models/demos/deepseek_v3/conftest.py
+++ b/models/demos/deepseek_v3/conftest.py
@@ -145,12 +145,16 @@ def mesh_device(request, device_params):
 
 @pytest.fixture(scope="session")
 def model_path():
-    return Path(os.getenv("DEEPSEEK_V3_HF_MODEL", "models/demos/deepseek_v3/reference"))
+    """Get model path and resolve symlinks to ensure all operations can find files."""
+    path = Path(os.getenv("DEEPSEEK_V3_HF_MODEL", "models/demos/deepseek_v3/reference"))
+    # Resolve symlinks to ensure AutoConfig and other operations can find config.json and other files
+    return path.resolve()
 
 
 @pytest.fixture(scope="session")
 def hf_config(model_path):
     """Load DeepSeek config for testing"""
+    # model_path is already resolved in the fixture
     config = AutoConfig.from_pretrained(model_path, trust_remote_code=True)
     return config
 


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
OSError: Can't load the configuration when DEEPSEEK_V3_HF_MODEL points to a symlink (e.g., /mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528).

### What's changed
Resolve symlinks in model_path fixture to ensure AutoConfig.from_pretrained() can find config.json when the model path points to a symlinked directory.

### Checklist
- [x] [![(Galaxy) DeepSeek tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-deepseek-tests.yaml/badge.svg?branch=fix/deepseek-v3-symlink-config-loading)](https://github.com/tenstorrent/tt-metal/actions/runs/21757749517)