### PR TITLE
[skip ci] bring back BH GLX tests in CI

### DIFF
--- a/.github/workflows/galaxy-quick-impl.yaml
+++ b/.github/workflows/galaxy-quick-impl.yaml
@@ -202,6 +202,7 @@ jobs:
         if: ${{ failure() }}
       - uses: tenstorrent/tt-metal/.github/actions/cleanup@main
         if: always()
+        
   quick-bh-glx-health:
     if: ${{ inputs.blackhole == true || inputs.scheduled == true }}
     runs-on:

--- a/.github/workflows/galaxy-quick-impl.yaml
+++ b/.github/workflows/galaxy-quick-impl.yaml
@@ -202,7 +202,6 @@ jobs:
         if: ${{ failure() }}
       - uses: tenstorrent/tt-metal/.github/actions/cleanup@main
         if: always()
-        
   quick-bh-glx-health:
     if: ${{ inputs.blackhole == true || inputs.scheduled == true }}
     runs-on:

--- a/.github/workflows/galaxy-quick.yaml
+++ b/.github/workflows/galaxy-quick.yaml
@@ -8,7 +8,7 @@ on:
         type: choice
         options:
           - wormhole_b0
-          # - blackhole
+          - blackhole
         default: wormhole_b0
       platform:
         required: false

--- a/tests/pipeline_reorg/galaxy_e2e_tests.yaml
+++ b/tests/pipeline_reorg/galaxy_e2e_tests.yaml
@@ -46,7 +46,7 @@
   team: fabric
   timeout: 15
 
-# Blackhole Galaxy e2e tests 
+# Blackhole Galaxy e2e tests
 - name: BH Galaxy CCL tests
   cmd: pytest tests/ttnn/unit_tests/operations/ccl/blackhole_CI/galaxy/galaxy_nightly
   sku: bh_galaxy

--- a/tests/pipeline_reorg/galaxy_e2e_tests.yaml
+++ b/tests/pipeline_reorg/galaxy_e2e_tests.yaml
@@ -46,24 +46,24 @@
   team: fabric
   timeout: 15
 
-# Blackhole Galaxy e2e tests #issue #36869 for all BH GLX tests
-# - name: BH Galaxy CCL tests
-#   cmd: pytest tests/ttnn/unit_tests/operations/ccl/blackhole_CI/galaxy/galaxy_nightly
-#   sku: bh_galaxy
-#   owner_id: U05ACKAJTHS # Naif Tarafdar, Camilo Vega
-#   team: ttnn
-#   timeout: 40
+# Blackhole Galaxy e2e tests 
+- name: BH Galaxy CCL tests
+  cmd: pytest tests/ttnn/unit_tests/operations/ccl/blackhole_CI/galaxy/galaxy_nightly
+  sku: bh_galaxy
+  owner_id: U05ACKAJTHS # Naif Tarafdar, Camilo Vega
+  team: ttnn
+  timeout: 40
 
-# - name: BH Galaxy Fabric unit tests
-#   cmd: build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="NightlyFabric*Fixture.*"
-#   sku: bh_galaxy
-#   owner_id: U08UBDUKH6Z # Neel Nyamagoudar
-#   team: fabric
-#   timeout: 30
+- name: BH Galaxy Fabric unit tests
+  cmd: build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="NightlyFabric*Fixture.*"
+  sku: bh_galaxy
+  owner_id: U08UBDUKH6Z # Neel Nyamagoudar
+  team: fabric
+  timeout: 30
 
-# - name: BH Galaxy Fabric Torus Stability Tests
-#   cmd: ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric --test_config tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_bh_glx_2d_torus_stability.yaml
-#   sku: bh_galaxy
-#   owner_id: U08UBDUKH6Z # Neel Nyamagoudar
-#   team: fabric
-#   timeout: 20
+- name: BH Galaxy Fabric Torus Stability Tests
+  cmd: ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric --test_config tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_bh_glx_2d_torus_stability.yaml
+  sku: bh_galaxy
+  owner_id: U08UBDUKH6Z # Neel Nyamagoudar
+  team: fabric
+  timeout: 20


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/36869

Galaxy was OOS, its in a better state, putting it back into CI and therefore uncommenting out the BH GLX tests. The health test was accidentally uncommented out in #36822 so its been in queue.