### PR TITLE
Remove assert on ARCH_NAME in data collection step in workflows

### DIFF
--- a/.github/scripts/data_analysis/create_benchmark_with_environment_json.py
+++ b/.github/scripts/data_analysis/create_benchmark_with_environment_json.py
@@ -1,10 +1,13 @@
+import sys
+
 from infra.data_collection.github.utils import (
     get_github_partial_benchmark_data_filenames,
     create_json_with_github_benchmark_environment,
 )
 
 if __name__ == "__main__":
+    sku_from_test = sys.argv[1] if len(sys.argv) > 1 else None
     github_partial_benchmark_data_filenames = get_github_partial_benchmark_data_filenames()
 
     for benchmark_data_filename in github_partial_benchmark_data_filenames:
-        create_json_with_github_benchmark_environment(benchmark_data_filename)
+        create_json_with_github_benchmark_environment(benchmark_data_filename, sku_from_test=sku_from_test)

--- a/.github/workflows/galaxy-demo-tests-impl.yaml
+++ b/.github/workflows/galaxy-demo-tests-impl.yaml
@@ -130,7 +130,7 @@ jobs:
         run: |
           if [ -d "generated/benchmark_data" ]; then
             echo "has_benchmark_data=true" >> $GITHUB_OUTPUT
-            python3 .github/scripts/data_analysis/create_benchmark_with_environment_json.py
+            python3 .github/scripts/data_analysis/create_benchmark_with_environment_json.py "${{ matrix.test-group.sku }}"
           else
             echo "::warning::Benchmark data directory 'generated/benchmark_data' does not exist"
             echo "has_benchmark_data=false" >> $GITHUB_OUTPUT

--- a/infra/data_collection/github/utils.py
+++ b/infra/data_collection/github/utils.py
@@ -415,9 +415,9 @@ def _get_device_type_from_runner_environment(sku_from_test: Optional[str] = None
                 for label in runs_on:
                     label_lower = label.lower()
                     # Only checks CIv1 style labels in sku_config for now
-                    if "arch-blackhole" in label_lower:
+                    if "blackhole" in label_lower:
                         return "blackhole"
-                    if "arch-wormhole" in label_lower:
+                    if "wormhole" in label_lower:
                         return "wormhole_b0"
 
     # Failed to parse from CIv2 runner name and failed to parse from sku_config:

--- a/infra/data_collection/github/utils.py
+++ b/infra/data_collection/github/utils.py
@@ -392,7 +392,7 @@ def _get_device_type_from_runner_environment() -> str:
     # This assumes all CIv2 runner names start with tt-ubuntu
     if runner_name.startswith("tt-ubuntu"):
         r = runner_name.lower()
-        if "blackhole" in r or "bh-" in r or "p150" in r:
+        if "blackhole" in r or "bh-" in r or "p100" in r or "p150" in r:
             return "blackhole"
         if "n150" in r or "n300" in r or "wormhole" in r:
             return "wormhole_b0"

--- a/infra/data_collection/github/utils.py
+++ b/infra/data_collection/github/utils.py
@@ -248,16 +248,14 @@ def get_job_row_from_github_job(github_job, github_job_id_to_annotations, workfl
         logger.info("Seems to have no config- label, so assuming no special config requested")
         detected_config = None
 
-    if labels_have_overlap(["E150", "grayskull", "arch-grayskull"], labels):
-        detected_arch = "grayskull"
-    elif labels_have_overlap(["N150", "N300", "wormhole_b0", "arch-wormhole_b0", "config-t3000"], labels):
+    if labels_have_overlap(["N150", "N300", "wormhole_b0", "arch-wormhole_b0", "config-t3000"], labels):
         detected_arch = "wormhole_b0"
     elif labels_have_overlap(["BH", "arch-blackhole"], labels):
         detected_arch = "blackhole"
     else:
         detected_arch = None
 
-    single_cards_list = ("E150", "N150", "N300", "BH")
+    single_cards_list = ("N150", "N300", "BH")
     single_cards_overlap = get_overlap(single_cards_list, labels)
 
     # In order of preference

--- a/infra/data_collection/github/utils.py
+++ b/infra/data_collection/github/utils.py
@@ -411,7 +411,7 @@ def _get_device_type_from_runner_environment(sku_from_test: Optional[str] = None
 
             if sku_from_test in skus:
                 # Use sku_from_test from workflow: get runs_on labels for this SKU
-                runs_on = skus[sku_from_test].get("runs_on") or []
+                runs_on = skus.get(sku_from_test, {}).get("runs_on") or []
                 for label in runs_on:
                     label_lower = label.lower()
                     # Only checks CIv1 style labels in sku_config for now

--- a/infra/data_collection/github/utils.py
+++ b/infra/data_collection/github/utils.py
@@ -402,21 +402,23 @@ def _get_device_type_from_runner_environment(sku_from_test: Optional[str] = None
         return "unknown"
 
     # Not tt-ubuntu: check .github/sku_config.yaml for arch from runs_on labels matching runner
-    sku_config_path = _get_repo_root() / ".github" / "sku_config.yaml"
-    if sku_config_path.exists():
-        with open(sku_config_path) as f:
-            config = yaml.safe_load(f)
-        skus = config.get("skus") or {}
+    if sku_from_test:
+        sku_config_path = _get_repo_root() / ".github" / "sku_config.yaml"
+        if sku_config_path.exists():
+            with open(sku_config_path) as f:
+                config = yaml.safe_load(f)
+            skus = config.get("skus") or {}
 
-        if sku_from_test and sku_from_test in skus:
-            # Use sku_from_test from workflow: get runs_on labels for this SKU
-            runs_on = skus[sku_from_test].get("runs_on") or []
-            for label in runs_on:
-                label_lower = label.lower()
-                if "blackhole" in label_lower:
-                    return "blackhole"
-                if "wormhole" in label_lower:
-                    return "wormhole_b0"
+            if sku_from_test in skus:
+                # Use sku_from_test from workflow: get runs_on labels for this SKU
+                runs_on = skus[sku_from_test].get("runs_on") or []
+                for label in runs_on:
+                    label_lower = label.lower()
+                    # Only checks CIv1 style labels in sku_config for now
+                    if "arch-blackhole" in label_lower:
+                        return "blackhole"
+                    if "arch-wormhole" in label_lower:
+                        return "wormhole_b0"
 
     # Failed to parse from CIv2 runner name and failed to parse from sku_config:
     # Fallback to using ARCH_NAME env var

--- a/infra/data_collection/github/utils.py
+++ b/infra/data_collection/github/utils.py
@@ -381,24 +381,22 @@ def get_github_runner_environment():
 
 def _get_device_type_from_runner_environment() -> str:
     """
-    Infer device/card type (grayskull, wormhole_b0, blackhole) from runner environment.
+    Infer device/card type (wormhole_b0, blackhole) from runner environment.
     RUNNER_NAME is a GitHub Actions env var that must be set.
     """
     assert "RUNNER_NAME" in os.environ, "RUNNER_NAME must be set (GitHub Actions env var)"
     runner_name = os.environ["RUNNER_NAME"]
 
+    # This assumes all CIv2 runner names start with tt-ubuntu
     if runner_name.startswith("tt-ubuntu"):
-        # CIv2: parse arch from runner name (e.g. n150, n300, p150, blackhole_loudbox)
         r = runner_name.lower()
         if "blackhole" in r or "bh-" in r or "p150" in r:
             return "blackhole"
         if "n150" in r or "n300" in r or "wormhole" in r:
             return "wormhole_b0"
-        if "grayskull" in r or "e150" in r or "p100" in r:
-            return "grayskull"
         return "unknown"
 
-    # Not tt-ubuntu: check sku_config.yaml for arch from runs_on labels matching runner
+    # Not tt-ubuntu: check .github/sku_config.yaml for arch from runs_on labels matching runner
     repo_root = pathlib.Path(__file__).parent.parent.parent.parent
     sku_config_path = repo_root / ".github" / "sku_config.yaml"
     if sku_config_path.exists():
@@ -414,18 +412,15 @@ def _get_device_type_from_runner_environment() -> str:
                 if "arch-blackhole" in label_lower or "blackhole" in label_lower:
                     if label in runner_name or "blackhole" in runner_name.lower():
                         return "blackhole"
-                if "arch-grayskull" in label_lower or "grayskull" in label_lower:
-                    if label in runner_name or "grayskull" in runner_name.lower():
-                        return "grayskull"
 
     if "ARCH_NAME" in os.environ:
         arch = os.environ["ARCH_NAME"]
-        if arch in ("grayskull", "wormhole_b0", "blackhole"):
+        if arch in ("wormhole_b0", "blackhole"):
             return arch
 
     logger.warning(
         f"Could not infer device type from RUNNER_NAME={runner_name!r}. "
-        "Set ARCH_NAME env var (grayskull, wormhole_b0, blackhole) for accurate benchmark data."
+        "Set ARCH_NAME env var (wormhole_b0, blackhole) for accurate benchmark data."
     )
     return "unknown"
 

--- a/infra/requirements-infra.txt
+++ b/infra/requirements-infra.txt
@@ -6,4 +6,4 @@ pydantic
 toolz
 defusedxml
 pytest
-yaml
+PyYAML

--- a/infra/requirements-infra.txt
+++ b/infra/requirements-infra.txt
@@ -6,3 +6,4 @@ pydantic
 toolz
 defusedxml
 pytest
+yaml


### PR DESCRIPTION
We would like to gradually remove reliance on `ARCH_NAME` env var.

Recently `ARCH_NAME` was removed from Galaxy demo pipelines. No tests need the env var set, but the data collection step in the workflow still has an assert on `ARCH_NAME`. 

This PR removes the hard assert on `ARCH_NAME` in the data collection script and tries to infer from the runner name for CIv2 or the SKU config for CIv1.

Testing:

- [x] Galaxy demo https://github.com/tenstorrent/tt-metal/actions/runs/21768966673