### PR TITLE
Decouple init from MetalContext

### DIFF
--- a/tt_metal/api/tt-metalium/experimental/fabric/control_plane.hpp
+++ b/tt_metal/api/tt-metalium/experimental/fabric/control_plane.hpp
@@ -31,8 +31,14 @@ class Cluster;
 
 }  // namespace tt::umd
 
+namespace tt::tt_metal {
+class dispatch_core_manager;
+class DeviceManager;
+}  // namespace tt::tt_metal
+
 namespace tt::tt_fabric {
 
+struct FabricTensixInitContext;
 class TopologyMapper;
 
 // TODO: remove this once UMD provides API for UBB ID and bus ID
@@ -193,7 +199,7 @@ public:
     void clear_fabric_context();
 
     // Initialize fabric tensix config (call after routing tables are configured)
-    void initialize_fabric_tensix_datamover_config();
+    void initialize_fabric_tensix_datamover_config(const FabricTensixInitContext& ctx);
 
     // Check if the provided chip and channel is a cross-host eth link
     bool is_cross_host_eth_link(ChipId chip_id, chan_id_t chan_id) const;

--- a/tt_metal/distributed/dispatch_context.cpp
+++ b/tt_metal/distributed/dispatch_context.cpp
@@ -16,6 +16,7 @@
 #include "llrt/hal/generated/dev_msgs.hpp"
 #include "llrt/rtoptions.hpp"
 #include "llrt/llrt.hpp"
+#include "tt_cluster.hpp"
 
 namespace tt::tt_metal::experimental {
 
@@ -49,7 +50,11 @@ void DispatchContext::initialize_fast_dispatch(distributed::MeshDevice* mesh_dev
         dev->init_command_queue_host();
     }
     // Query the number of command queues requested
-    populate_fd_kernels(active_devices, num_hw_cqs);
+    populate_fd_kernels(
+        active_devices,
+        num_hw_cqs,
+        MetalContext::instance().get_cluster(),
+        MetalContext::instance().get_dispatch_core_manager());
     device_manager->configure_and_load_fast_dispatch_kernels();
     tt::tt_metal::MetalContext::instance().rtoptions().set_fast_dispatch(fast_dispatch_enabled_);
 

--- a/tt_metal/distributed/fd_mesh_command_queue.cpp
+++ b/tt_metal/distributed/fd_mesh_command_queue.cpp
@@ -23,6 +23,7 @@
 #include "buffer.hpp"
 #include "buffer_types.hpp"
 #include "device.hpp"
+#include "dispatch/dispatch_core_manager.hpp"
 #include "impl/context/metal_context.hpp"
 #include "impl/dispatch/dispatch_core_common.hpp"
 #include "dispatch/dispatch_settings.hpp"
@@ -38,6 +39,7 @@
 #include <tt_stl/strong_type.hpp>
 #include "dispatch/system_memory_manager.hpp"
 #include "trace/trace_buffer.hpp"
+#include "tt_cluster.hpp"
 #include "tt_metal/common/thread_pool.hpp"
 #include "tt_metal/common/multi_producer_single_consumer_queue.hpp"
 #include "tt_metal/distributed/mesh_workload_utils.hpp"

--- a/tt_metal/fabric/compute_mesh_router_builder.cpp
+++ b/tt_metal/fabric/compute_mesh_router_builder.cpp
@@ -166,6 +166,9 @@ std::unique_ptr<ComputeMeshRouterBuilder> ComputeMeshRouterBuilder::build(
     // Create tensix builder if needed
     std::optional<FabricTensixDatamoverBuilder> tensix_builder_opt;
     if (will_create_tensix_builder) {
+        // Note: control_plane is non-const reference but we need it for the builder
+        auto& control_plane_ref =
+            const_cast<tt::tt_fabric::ControlPlane&>(tt::tt_metal::MetalContext::instance().get_control_plane());
         tensix_builder_opt = FabricTensixDatamoverBuilder::build(
             device,
             program,
@@ -173,7 +176,9 @@ std::unique_ptr<ComputeMeshRouterBuilder> ComputeMeshRouterBuilder::build(
             location.remote_node,
             location.eth_chan,
             eth_direction,
-            std::move(tensix_injection_flags));
+            std::move(tensix_injection_flags),
+            control_plane_ref,
+            fabric_tensix_config);
     }
 
     // Use unique_ptr constructor directly since ComputeMeshRouterBuilder constructor is private

--- a/tt_metal/fabric/control_plane.cpp
+++ b/tt_metal/fabric/control_plane.cpp
@@ -31,6 +31,7 @@
 #include <tt-metalium/experimental/fabric/control_plane.hpp>
 #include "core_coord.hpp"
 #include "compressed_direction_table.hpp"
+#include "fabric_tensix_builder.hpp"
 #include "compressed_routing_path.hpp"
 #include "tools/scaleout/factory_system_descriptor/utils.hpp"
 #include "hostdevcommon/fabric_common.h"
@@ -2035,9 +2036,9 @@ void ControlPlane::clear_fabric_context() {
     asic_id_to_fabric_node_cache_.clear();
 }
 
-void ControlPlane::initialize_fabric_tensix_datamover_config() {
+void ControlPlane::initialize_fabric_tensix_datamover_config(const FabricTensixInitContext& ctx) {
     TT_FATAL(this->fabric_context_ != nullptr, "Fabric context must be initialized first");
-    this->fabric_context_->get_builder_context().initialize_tensix_config();
+    this->fabric_context_->get_builder_context().initialize_tensix_config(ctx);
 }
 
 bool ControlPlane::is_cross_host_eth_link(ChipId chip_id, chan_id_t chan_id) const {

--- a/tt_metal/fabric/fabric_builder.hpp
+++ b/tt_metal/fabric/fabric_builder.hpp
@@ -12,6 +12,11 @@
 #include "tt_metal/fabric/fabric_router_builder.hpp"
 #include "hostdevcommon/fabric_common.h"
 #include <tt-metalium/experimental/fabric/mesh_graph.hpp>
+#include <tt-metalium/experimental/fabric/fabric_types.hpp>
+
+namespace tt {
+class Cluster;
+}  // namespace tt
 
 namespace tt::tt_metal {
 class IDevice;
@@ -20,6 +25,7 @@ class Program;
 
 namespace tt::tt_fabric {
 
+class ControlPlane;
 class FabricContext;
 class FabricBuilderContext;
 
@@ -37,7 +43,13 @@ class FabricBuilderContext;
  */
 class FabricBuilder {
 public:
-    FabricBuilder(tt::tt_metal::IDevice* device, tt::tt_metal::Program& program, FabricContext& fabric_context);
+    FabricBuilder(
+        tt::tt_metal::IDevice* device,
+        tt::tt_metal::Program& program,
+        FabricContext& fabric_context,
+        ControlPlane& control_plane,
+        const tt::Cluster& cluster,
+        FabricTensixConfig fabric_tensix_config);
 
     /**
      * Discover active ethernet channels and neighbors for this device.
@@ -121,6 +133,9 @@ private:
     tt::tt_metal::Program& program_;
     FabricContext& fabric_context_;
     FabricBuilderContext& builder_context_;
+    ControlPlane& control_plane_;
+    const tt::Cluster& cluster_;
+    FabricTensixConfig fabric_tensix_config_;
 
     // Fabric node ID for this device (derived from device_->id())
     FabricNodeId local_node_;

--- a/tt_metal/fabric/fabric_builder_context.cpp
+++ b/tt_metal/fabric/fabric_builder_context.cpp
@@ -177,14 +177,13 @@ FabricTensixDatamoverConfig& FabricBuilderContext::get_tensix_config() const {
     return *tensix_config_;
 }
 
-void FabricBuilderContext::initialize_tensix_config() {
+void FabricBuilderContext::initialize_tensix_config(const FabricTensixInitContext& ctx) {
     TT_FATAL(tensix_config_ == nullptr, "Trying to re-initialize fabric tensix config");
 
-    auto fabric_tensix_config = tt::tt_metal::MetalContext::instance().get_fabric_tensix_config();
-    if (fabric_tensix_config != FabricTensixConfig::DISABLED) {
+    if (ctx.fabric_tensix_config != FabricTensixConfig::DISABLED) {
         // Now it's safe to call get_active_fabric_eth_channels() because
         // configure_routing_tables_for_fabric_ethernet_channels() has already run
-        tensix_config_ = std::make_unique<FabricTensixDatamoverConfig>();
+        tensix_config_ = std::make_unique<FabricTensixDatamoverConfig>(ctx);
     }
 }
 

--- a/tt_metal/fabric/fabric_builder_context.hpp
+++ b/tt_metal/fabric/fabric_builder_context.hpp
@@ -137,7 +137,7 @@ public:
     }
 
     // ============ Tensix Config ============
-    void initialize_tensix_config();
+    void initialize_tensix_config(const FabricTensixInitContext& ctx);
     FabricTensixDatamoverConfig& get_tensix_config() const;
     bool has_tensix_config() const { return tensix_config_ != nullptr; }
 

--- a/tt_metal/fabric/fabric_init.hpp
+++ b/tt_metal/fabric/fabric_init.hpp
@@ -6,13 +6,26 @@
 
 #include "device.hpp"
 #include "tt_metal.hpp"
+#include <experimental/fabric/fabric_types.hpp>
+
+namespace tt {
+class Cluster;
+}  // namespace tt
 
 namespace tt::tt_fabric {
 
+class ControlPlane;
+
 // Compile fabric kernels needed to support scaleout systems.
-std::unique_ptr<tt::tt_metal::Program> create_and_compile_fabric_program(tt::tt_metal::IDevice* device);
+std::unique_ptr<tt::tt_metal::Program> create_and_compile_fabric_program(
+    tt::tt_metal::IDevice* device,
+    FabricConfig fabric_config,
+    ControlPlane& control_plane,
+    const tt::Cluster& cluster,
+    FabricTensixConfig fabric_tensix_config,
+    bool fast_dispatch);
 
 // Perform additional configuration (writing to specific L1 addresses, etc.) for fabric kernels on this device.
-void configure_fabric_cores(tt::tt_metal::IDevice* device);
+void configure_fabric_cores(tt::tt_metal::IDevice* device, const tt::Cluster& cluster, ControlPlane& control_plane);
 
 }  // namespace tt::tt_fabric

--- a/tt_metal/impl/buffers/dispatch.cpp
+++ b/tt_metal/impl/buffers/dispatch.cpp
@@ -14,6 +14,7 @@
 #include <tt_stl/assert.hpp>
 #include "buffer_types.hpp"
 #include "dispatch.hpp"
+#include "dispatch/dispatch_core_manager.hpp"
 #include "impl/context/metal_context.hpp"
 #include "dispatch/kernels/cq_commands.hpp"
 #include "dispatch/dispatch_settings.hpp"
@@ -23,6 +24,7 @@
 #include <tt_stl/strong_type.hpp>
 #include "sub_device_types.hpp"
 #include "tt_align.hpp"
+#include "tt_cluster.hpp"
 #include "tt_metal/impl/dispatch/device_command.hpp"
 #include "tt_metal/impl/dispatch/device_command_calculator.hpp"
 #include "tt_metal/impl/dispatch/topology.hpp"

--- a/tt_metal/impl/context/metal_context.cpp
+++ b/tt_metal/impl/context/metal_context.cpp
@@ -37,6 +37,7 @@
 #include <experimental/fabric/control_plane.hpp>
 #include <experimental/mock_device.hpp>
 #include "device/device_manager.hpp"
+#include "fabric/fabric_tensix_builder.hpp"
 #include <distributed_context.hpp>
 #include <experimental/fabric/fabric.hpp>
 
@@ -869,7 +870,17 @@ void MetalContext::initialize_fabric_tensix_datamover_config() {
     // Initialize fabric tensix config after routing tables are configured and devices are available
     if (tt::tt_fabric::is_tt_fabric_config(this->fabric_config_)) {
         auto& control_plane = this->get_control_plane();
-        control_plane.initialize_fabric_tensix_datamover_config();
+
+        // Create the context with all required dependencies
+        tt_fabric::FabricTensixInitContext ctx{
+            .cluster = *cluster_,
+            .control_plane = control_plane,
+            .hal = hal(),
+            .dispatch_core_mgr = this->get_dispatch_core_manager(),
+            .device_manager = *device_manager_,
+            .fabric_tensix_config = this->get_fabric_tensix_config()};
+
+        control_plane.initialize_fabric_tensix_datamover_config(ctx);
     }
 }
 

--- a/tt_metal/impl/device/dispatch.cpp
+++ b/tt_metal/impl/device/dispatch.cpp
@@ -6,7 +6,9 @@
 #include <cstdint>
 #include "dispatch/device_command.hpp"
 #include "dispatch/device_command_calculator.hpp"
+#include "dispatch/dispatch_core_manager.hpp"
 #include "dispatch/system_memory_manager.hpp"
+#include "tt_cluster.hpp"
 #include <tt-metalium/math.hpp>
 #include <impl/dispatch/dispatch_mem_map.hpp>
 

--- a/tt_metal/impl/dispatch/kernel_config/dispatch.hpp
+++ b/tt_metal/impl/dispatch/kernel_config/dispatch.hpp
@@ -12,7 +12,6 @@
 #include "dispatch/kernel_config/relay_mux.hpp"
 #include "fd_kernel.hpp"
 #include <tt-metalium/experimental/fabric/mesh_graph.hpp>
-#include "impl/context/metal_context.hpp"
 #include "tt_metal/impl/dispatch/topology.hpp"
 #include <umd/device/types/xy_pair.hpp>
 
@@ -117,6 +116,8 @@ public:
     const dispatch_static_config_t& GetStaticConfig() { return static_config_; }
 
 private:
+    void SetLogicalCore();
+
     dispatch_static_config_t static_config_;
     dispatch_dependent_config_t dependent_config_;
     FDKernelEdmConnectionAttributes edm_connection_attributes_;

--- a/tt_metal/impl/dispatch/kernel_config/dispatch_s.hpp
+++ b/tt_metal/impl/dispatch/kernel_config/dispatch_s.hpp
@@ -6,7 +6,6 @@
 #include <optional>
 
 #include "fd_kernel.hpp"
-#include "impl/context/metal_context.hpp"
 #include <umd/device/types/xy_pair.hpp>
 
 namespace tt::tt_metal {
@@ -44,6 +43,8 @@ public:
     const dispatch_s_static_config_t& GetStaticConfig() { return static_config_; }
 
 private:
+    void SetLogicalCore();
+
     dispatch_s_static_config_t static_config_;
     dispatch_s_dependent_config_t dependent_config_;
 };

--- a/tt_metal/impl/dispatch/kernel_config/prefetch.hpp
+++ b/tt_metal/impl/dispatch/kernel_config/prefetch.hpp
@@ -10,7 +10,6 @@
 #include "core_coord.hpp"
 #include "fd_kernel.hpp"
 #include <tt-metalium/experimental/fabric/mesh_graph.hpp>
-#include "impl/context/metal_context.hpp"
 #include <umd/device/types/xy_pair.hpp>
 #include <umd/device/types/cluster_descriptor_types.hpp>
 #include "dispatch/kernel_config/relay_mux.hpp"
@@ -112,6 +111,8 @@ public:
     const prefetch_static_config_t& GetStaticConfig() { return static_config_; }
 
 private:
+    void SetLogicalCore();
+
     prefetch_static_config_t static_config_;
     prefetch_dependent_config_t dependent_config_;
     FDKernelEdmConnectionAttributes edm_connection_attributes_;

--- a/tt_metal/impl/dispatch/kernel_config/relay_mux.hpp
+++ b/tt_metal/impl/dispatch/kernel_config/relay_mux.hpp
@@ -105,7 +105,9 @@ public:
     static uint32_t get_dispatch_link_index(
         tt::tt_fabric::FabricNodeId src_fabric_node_id,
         tt::tt_fabric::FabricNodeId dst_fabric_node_id,
-        IDevice* device);
+        IDevice* device,
+        const tt::Cluster& cluster,
+        const tt::tt_fabric::ControlPlane& control_plane);
 };
 
 // Helper function to assemble the dispatch_fabric_mux_client_config args
@@ -117,12 +119,15 @@ void assemble_fabric_mux_client_config_args(
 
 // Helper function to calculate number of hops from a mmio device to downstream device
 // The two devices must be along the same tunnel.
-int get_num_hops(ChipId mmio_dev_id, ChipId downstream_dev_id);
+int get_num_hops(ChipId mmio_dev_id, ChipId downstream_dev_id, const tt::Cluster& cluster);
 
 // Helper function to assemble args specific to the 2D fabric header
 template <typename Configuration>
-void assemble_2d_fabric_packet_header_args(Configuration& config, int my_device_id, int destination_device_id) {
-    const auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
+void assemble_2d_fabric_packet_header_args(
+    Configuration& config,
+    int my_device_id,
+    int destination_device_id,
+    const tt::tt_fabric::ControlPlane& control_plane) {
     const auto& src_fabric_node_id = control_plane.get_fabric_node_id_from_physical_chip_id(my_device_id);
     const auto& dst_fabric_node_id = control_plane.get_fabric_node_id_from_physical_chip_id(destination_device_id);
     const auto& forwarding_direction = control_plane.get_forwarding_direction(src_fabric_node_id, dst_fabric_node_id);

--- a/tt_metal/impl/dispatch/topology.hpp
+++ b/tt_metal/impl/dispatch/topology.hpp
@@ -15,9 +15,16 @@
 #include "tt_metal/impl/dispatch/kernel_config/fd_kernel.hpp"
 #include "tt_metal/impl/dispatch/dispatch_core_common.hpp"
 
+namespace tt {
+class Cluster;
+}  // namespace tt
+
 namespace tt::tt_metal {
 
 class IDevice;
+class dispatch_core_manager;
+class DispatchMemMap;
+class DeviceManager;
 enum DispatchWorkerType : uint32_t;
 
 // NOC ID used by dispatch kernels to communicate with downstream cores. This parameter
@@ -39,17 +46,25 @@ struct DispatchKernelNode {
 // Create FD kernels for all given device ids. Creates all objects, but need to call create_and_compile_cq_program() use
 // a created Device to fill out the settings. First version automatically generates the topology based on devices, num
 // cqs, and detected board. Second version uses the topology passed in.
-void populate_fd_kernels(const std::vector<IDevice*>& devices, uint32_t num_hw_cqs);
-void populate_fd_kernels(const std::set<ChipId>& device_ids, uint32_t num_hw_cqs);
-void populate_fd_kernels(const std::vector<DispatchKernelNode>& nodes);
+void populate_fd_kernels(
+    const std::vector<IDevice*>& devices,
+    uint32_t num_hw_cqs,
+    const tt::Cluster& cluster,
+    dispatch_core_manager& dispatch_core_mgr);
+void populate_fd_kernels(
+    const std::set<ChipId>& device_ids,
+    uint32_t num_hw_cqs,
+    const tt::Cluster& cluster,
+    dispatch_core_manager& dispatch_core_mgr);
+void populate_fd_kernels(const std::vector<DispatchKernelNode>& nodes, const tt::Cluster& cluster);
 
 // Populate the static arguments for a device.
 // Prerequisites: Must call populate_fd_kernels
-void populate_cq_static_args(IDevice* device);
+void populate_cq_static_args(IDevice* device, DispatchInitContext& ctx);
 
 // Fill out all settings for FD kernels on the given device, and add them to a Program and return it.
 // Prerequisites: Must call populate_cq_static_args
-void create_cq_program(tt::tt_metal::IDevice* device);
+void create_cq_program(tt::tt_metal::IDevice* device, DispatchInitContext& ctx);
 
 // Compile all command queue programs created by create_and_compile_cq_program()
 void compile_cq_programs();
@@ -58,7 +73,12 @@ void compile_cq_programs();
 std::unique_ptr<tt::tt_metal::Program> get_compiled_cq_program(tt::tt_metal::IDevice* device);
 
 // Perform additional configuration (writing to specific L1 addresses, etc.) for FD kernels on this device.
-void configure_dispatch_cores(tt::tt_metal::IDevice* device);
+void configure_dispatch_cores(
+    tt::tt_metal::IDevice* device,
+    const tt::Cluster& cluster,
+    dispatch_core_manager& dispatch_core_mgr,
+    const DispatchMemMap& dispatch_mem_map,
+    DeviceManager& device_manager);
 
 // Return the virtual dispatch cores running on a given device
 const std::unordered_set<CoreCoord>& get_virtual_dispatch_cores(ChipId dev_id);

--- a/tt_metal/impl/event/dispatch.cpp
+++ b/tt_metal/impl/event/dispatch.cpp
@@ -21,6 +21,7 @@
 #include <tt-logger/tt-logger.hpp>
 #include <tt_stl/strong_type.hpp>
 #include "sub_device_types.hpp"
+#include "tt_cluster.hpp"
 #include "tt_metal/impl/dispatch/device_command.hpp"
 #include "tt_metal/impl/dispatch/device_command_calculator.hpp"
 #include "tt_metal/impl/dispatch/topology.hpp"


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/37247

### Problem description
These objects need the Cluster, HAL, and RtOptions. They should not be calling MetalContext after init when their dependecies are known

### What's changed
- Decouple init from MetalContext by removing the MetalContext::instance().hal/cluster/rtoptions calls and pass in the Cluster/HAL/RtOptions parameters explicitly.

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=nhuang/decouple-init)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:nhuang/decouple-init)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=nhuang/decouple-init)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:nhuang/decouple-init)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nhuang/decouple-init)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nhuang/decouple-init)
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nhuang/decouple-init)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nhuang/decouple-init)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nhuang/decouple-init)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nhuang/decouple-init)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nhuang/decouple-init)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nhuang/decouple-init)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
