### PR TITLE
Set medgemma's max_prefill_chunk_size the same as gemma-3

### DIFF
--- a/models/tt_transformers/tt/model_config.py
+++ b/models/tt_transformers/tt/model_config.py
@@ -571,7 +571,9 @@ class ModelArgs:
                 },  # Conservative: Allow on all devices
                 "gemma-3-1b": {"N150": 32, "N300": 32, "T3K": 32, "TG": 32, "P150x4": 32},
                 "gemma-3-4b": {"N150": 128, "N300": 128, "T3K": 128, "TG": 128, "P150x4": 128},
+                "medgemma-4b": {"N150": 128, "N300": 128, "T3K": 128, "TG": 128, "P150x4": 128},
                 "gemma-3-27b": {"N150": 128, "N300": 128, "T3K": 128, "TG": 128, "P150x4": 128},
+                "medgemma-27b": {"N150": 128, "N300": 128, "T3K": 128, "TG": 128, "P150x4": 128},
             }
             try:
                 max_prefill_chunk_size_div1024 = MAX_PREFILL_CHUNK_SIZES_DIV1024[self.base_model_name][self.device_name]


### PR DESCRIPTION
### Ticket
<!-- Link to Github Issue if applicable -->

### Problem description
MedGemma-27b-it was failing with `NotImplementedError: Sliding window not supported for chunked prefill SDPA` when processing requests with prefill sequence lengths exceeding 4096 tokens. 

The root cause was that `medgemma-27b-it` was not recognized in the `MAX_PREFILL_CHUNK_SIZES_DIV1024` lookup table. When `get_base_model_name("medgemma-27b-it")` returns `"medgemma-27b"`, this key was missing from the dictionary, causing a fallback to the default `max_prefill_chunk_size` of 4 * 1024 = 4096 tokens.

When requests exceeded 4096 tokens (e.g., 4364 tokens from a 4096-token text prompt + 260 vision tokens), chunked prefill was triggered. However, Gemma3 models use sliding window attention, and the chunked prefill SDPA implementation does not support sliding window attention, resulting in the `NotImplementedError`.

In contrast, `gemma-3-27b-it` worked correctly because it was recognized in the lookup table and had `max_prefill_chunk_size` set to 128 * 1024 = 131072 tokens, allowing prefills up to that length without triggering chunking.

### What's changed
Added `"medgemma-27b"` to the `MAX_PREFILL_CHUNK_SIZES_DIV1024` dictionary in `model_config.py` with the same values as `"gemma-3-27b"` (128 for all device types: N150, N300, T3K, TG, P150x4). This sets `max_prefill_chunk_size` to 131072 tokens for MedGemma-27b-it, matching the configuration used for Gemma-3-27b-it.

With this change, MedGemma-27b-it can now handle prefills up to 131072 tokens without triggering chunked prefill, avoiding the sliding window + chunked prefill incompatibility error. This aligns MedGemma's behavior with Gemma-3, which is appropriate since both models share the same architecture (`Gemma3ForConditionalGeneration`) and sliding window attention configuration.

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=adam/medgemma)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:adam/medgemma)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=adam/medgemma)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:adam/medgemma)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=adam/medgemma)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:adam/medgemma)
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=adam/medgemma)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:adam/medgemma)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
