### PR TITLE
Exclude graph_argument_serializer.cpp from unity builds to reduce build time

### DIFF
--- a/ttnn/CMakeLists.txt
+++ b/ttnn/CMakeLists.txt
@@ -159,6 +159,17 @@ target_sources(
         core/tensor/to_string.cpp
         core/tensor/py_to_tt_tensor.cpp
 )
+
+# graph_argument_serializer.cpp takes ~142s to compile due to combinatorial template
+# explosion (~48 types × ~60 specializations each). Exclude it from unity builds so it
+# compiles as its own TU in parallel, rather than blocking the entire unity batch.
+set_source_files_properties(
+    core/graph/graph_argument_serializer.cpp
+    PROPERTIES
+        SKIP_UNITY_BUILD_INCLUSION
+            ON
+)
+
 target_include_directories(
     ttnn_core
     PUBLIC


### PR DESCRIPTION
## Problem

Clean build wall time is bottlenecked by a single unity compilation unit (`unity_2_cxx.cxx.o`) that takes **263 seconds** — it finishes last, leaving most cores idle while waiting.

The culprit is `ttnn/core/graph/graph_argument_serializer.cpp`, which takes **~142 seconds** to compile within that unity batch. Its `initialize()` function registers conversion functions for **48 types**, each instantiating ~60 template specializations (`std::any_cast`, `std::reference_wrapper`, `std::optional`, `std::array`, `ttsl::SmallVector`, `std::vector`), creating a combinatorial template explosion.

## Solution

Exclude `graph_argument_serializer.cpp` from unity builds via `SKIP_UNITY_BUILD_INCLUSION`. This lets it compile as its own translation unit **in parallel** with the rest of the unity batch, rather than serializing the entire batch behind it.