### PR TITLE
#36881: add validation check for sharded softmax

### DIFF
--- a/ttnn/cpp/ttnn/operations/normalization/softmax/device/softmax_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/softmax/device/softmax_device_operation.cpp
@@ -239,6 +239,7 @@ void SoftmaxDeviceOperation::validate_on_program_cache_miss(
                             program_config.block_w * tensors_args.input_tensor.tensor_spec().tile().get_width() ==
                                 shape[3],
                             "shard width must equal to input tensor shape[3]!");
+
                         TT_FATAL(attributes.inplace, "Operation must be inplace for sharded multi-core program config");
                         if (!attributes.is_scale_causal_mask_hw_dims_softmax) {
                             // grid
@@ -288,6 +289,42 @@ void SoftmaxDeviceOperation::validate_on_program_cache_miss(
     } else {
         TT_FATAL(not attributes.scale.has_value(), "Scale value must not be set when mask is not present");
     }
+
+    // Validate SoftmaxShardedMultiCoreProgramConfig parameters regardless of mask presence
+    std::visit(
+        [&](const auto& program_config) {
+            using ProgramConfigType = std::decay_t<decltype(program_config)>;
+            if constexpr (std::is_same_v<ProgramConfigType, SoftmaxShardedMultiCoreProgramConfig>) {
+                // Validate block_h and block_w match the actual shard dimensions in tiles
+                TT_FATAL(
+                    attributes.output_mem_config.shard_spec().has_value(),
+                    "output_mem_config must have a shard_spec when using SoftmaxShardedMultiCoreProgramConfig");
+                const auto& shard_shape = attributes.output_mem_config.shard_spec().value().shape;
+                uint32_t shard_height_in_tiles =
+                    shard_shape[0] / tensors_args.input_tensor.tensor_spec().tile().get_height();
+                uint32_t shard_width_in_tiles =
+                    shard_shape[1] / tensors_args.input_tensor.tensor_spec().tile().get_width();
+                TT_FATAL(
+                    program_config.block_h == shard_height_in_tiles,
+                    "block_h ({}) must match the shard height in tiles ({}). Shard shape is [{}, {}] with tile "
+                    "height {}.",
+                    program_config.block_h,
+                    shard_height_in_tiles,
+                    shard_shape[0],
+                    shard_shape[1],
+                    tensors_args.input_tensor.tensor_spec().tile().get_height());
+                TT_FATAL(
+                    program_config.block_w == shard_width_in_tiles,
+                    "block_w ({}) must match the shard width in tiles ({}). Shard shape is [{}, {}] with tile "
+                    "width {}.",
+                    program_config.block_w,
+                    shard_width_in_tiles,
+                    shard_shape[0],
+                    shard_shape[1],
+                    tensors_args.input_tensor.tensor_spec().tile().get_width());
+            }
+        },
+        attributes.program_config);
 }
 
 SoftmaxDeviceOperation::spec_return_value_t SoftmaxDeviceOperation::compute_output_specs(


### PR DESCRIPTION
### Ticket
Link to Github Issue #36881

### Problem description
Someone did computation over a single tile instead of the entire shard and got results that did not line up with performing computation over the entire shard. There was no validation to catch this. 

### What's changed
Add validation.

Tested locally that the error is caught.

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=bbradel-36881_sm_shard)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:bbradel-36881_sm_shard)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=bbradel-36881_sm_shard)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:bbradel-36881_sm_shard)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=bbradel-36881_sm_shard)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:bbradel-36881_sm_shard)
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=bbradel-36881_sm_shard)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:bbradel-36881_sm_shard)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=bbradel-36881_sm_shard)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:bbradel-36881_sm_shard)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=bbradel-36881_sm_shard)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:bbradel-36881_sm_shard)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
