### PR TITLE
[skip ci] Increase timeout for blackhole deepseek blitz tests

### DIFF
--- a/.github/workflows/ops-post-commit.yaml
+++ b/.github/workflows/ops-post-commit.yaml
@@ -76,7 +76,7 @@ jobs:
         default-ops-tests:
           [[
             { name: "wormhole_b0 sdxl op tests", cmd: "pytest --timeout 300 models/experimental/stable_diffusion_xl_base/tests/test_sdxl_op_unit_test_perf.py -k \"_performance\" -xv --tb=short", merge_gate: false, arch: "wormhole_b0", timeout: 5 },
-            { name: "blackhole deepseek blitz op tests", cmd: "pytest models/demos/deepseek_v3_b1/tests/unit_tests/", merge_gate: false, arch: "blackhole", timeout: 2 }
+            { name: "blackhole deepseek blitz op tests", cmd: "pytest models/demos/deepseek_v3_b1/tests/unit_tests/", merge_gate: false, arch: "blackhole", timeout: 5 }
           ]]
     steps:
       - name: Compute tests


### PR DESCRIPTION
### Ticket
None

### What's changed
Timeout increase from 2m -> 5m

- BHPC: https://github.com/tenstorrent/tt-metal/actions/runs/21768696821
