### PR TITLE
Add Support For Fused Shared-Expert Kernel

### DIFF
--- a/models/demos/deepseek_v3_b1/fused_ops/down_proj/kernels/down_proj_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/fused_ops/down_proj/kernels/down_proj_kernel.cpp
@@ -1,0 +1,300 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+// SPDX-License-Identifier: Apache-2.0
+
+// Down Projection (W_down) unified kernel
+// Single kernel file, compiles correctly for all RISC cores
+//
+// Implements: Mcast1 + Mcast2 + Matmul + ResidualAdd + Gather
+// - Mcast1: Input [1, K] on (12,9) -> broadcast to 130-core grid (13x10)
+// - Mcast2: Residual input [1, N] on (12,9) -> broadcast to 130-core grid (13x10)
+// - Matmul: [1, K] x [K, N_per_core] -> [1, N_per_core] on 112 cores
+// - Residual add: matmul_out + shard(residual) -> [1, N_per_core] on 112 cores
+// - Gather: Collect [1, N_per_core] from 112 cores to [1, N] on (12,9)
+//
+// Core roles in 13x10 = 130 core grid:
+//   M = Mcast sender + Gather receiver (12,9) — dual role
+//   R = Matmul core (112 cores)
+//   D = DRAM worker — receives mcast semaphore, skips matmul & gather (8 cores)
+//   P = Phantom — receives mcast semaphore, skips matmul & gather (9 cores, col 12 rows 0-8)
+//
+// Note: Mcast sender (12,9) IS in the mcast grid (is_part_of_receiver_grid=true)
+// but is NOT an mcast receiver (is_mcast_receiver_core=false) to avoid deadlock.
+
+#include "../../../unified_kernels/kernel_op_api.hpp"
+#include "../../../unified_kernels/kernel_utils.hpp"
+#include "../../../unified_kernels/matmul.hpp"
+#include "../../../unified_kernels/gather.hpp"
+#include "../../../unified_kernels/mcast.hpp"
+#include "../../../unified_kernels/residual_add.hpp"
+
+// Compile-time role flags for dead code elimination via if constexpr
+struct Core {
+    // Mcast sender (12,9) only
+    static constexpr bool is_mcast_sender_core = get_named_compile_time_arg_val("is_mcast_sender_core") == 1;
+    // Mcast receiver: 129 cores (full 130-core grid MINUS sender at 12,9)
+    static constexpr bool is_mcast_receiver_core = get_named_compile_time_arg_val("is_mcast_receiver_core") == 1;
+    // Active matmul cores (112 cores: excludes 8 DRAM workers + 9 phantoms + sender)
+    static constexpr bool is_matmul_core = get_named_compile_time_arg_val("is_matmul_core") == 1;
+    // Gather receiver (12,9) only
+    static constexpr bool is_gather_receiver_core = get_named_compile_time_arg_val("is_gather_receiver_core") == 1;
+    // Whether this core uses per-core sender index for scattered gather
+    static constexpr bool gather_use_per_core_sender_idx =
+        get_named_compile_time_arg_val("gather_use_per_core_sender_idx") == 1;
+};
+
+void kernel_main() {
+// ============================================================================
+// NCRISC (Reader)
+// - Matmul reader (112 cores): setup sharded weight buffers
+// - Mcast receiver (129 cores): receive mcast data
+// - Gather sender (112 cores): send matmul output to gather core
+// ============================================================================
+#if defined(COMPILE_FOR_NCRISC)
+    // Mcast1 receiver args
+    using McastCTArgs = deepseek_b1_ops::Mcast::ReceiverCTArgs;
+    deepseek_b1_ops::Mcast::ReceiverArgs mcast_args{
+        get_named_compile_time_arg_val("mcast_data_receiver_semaphore"),
+        get_named_compile_time_arg_val("mcast_dst_cb"),
+        get_named_compile_time_arg_val("mcast_dst_num_pages"),
+    };
+
+    // Mcast2 receiver args
+    using Mcast2CTArgs = deepseek_b1_ops::Mcast::ReceiverCTArgs;
+    deepseek_b1_ops::Mcast::ReceiverArgs mcast2_args{
+        get_named_compile_time_arg_val("mcast2_data_receiver_semaphore"),
+        get_named_compile_time_arg_val("mcast2_dst_cb"),
+        get_named_compile_time_arg_val("mcast2_dst_num_pages"),
+    };
+
+    // Matmul CTArgs (NCRISC is no-op for matmul compute)
+    using MatmulCTArgs = deepseek_b1_ops::Matmul::ReaderCTArgs;
+    deepseek_b1_ops::Matmul::ReaderArgs matmul_args{};
+
+    // Gather sender args
+    deepseek_b1_ops::Gather::SenderArgs gather_args{
+        get_named_compile_time_arg_val("gather_dest_noc_x"),
+        get_named_compile_time_arg_val("gather_dest_noc_y"),
+        get_named_compile_time_arg_val("gather_data_size_bytes"),
+        get_named_compile_time_arg_val("gather_receiver_semaphore_id"),
+        get_named_compile_time_arg_val("gather_src_cb"),
+        get_named_compile_time_arg_val("gather_src_num_pages"),
+        get_named_compile_time_arg_val("gather_sender_grid_start_x"),
+        get_named_compile_time_arg_val("gather_sender_grid_start_y"),
+        get_named_compile_time_arg_val("gather_sender_grid_end_x"),
+        get_named_compile_time_arg_val("gather_sender_grid_end_y"),
+        get_named_compile_time_arg_val("gather_row_major"),
+        get_named_compile_time_arg_val("gather_receiver_data_addr"),
+        get_named_compile_time_arg_val("gather_sender_idx"),
+    };
+
+// ============================================================================
+// BRISC (Writer)
+// - Mcast sender (12,9): broadcast input to 130-core grid
+// - Gather receiver (12,9): receive from 112 matmul cores
+// ============================================================================
+#elif defined(COMPILE_FOR_BRISC)
+    // Mcast1 sender args
+    using McastCTArgs = deepseek_b1_ops::Mcast::SenderCTArgs<
+        get_named_compile_time_arg_val("mcast_num_cores"),
+        get_named_compile_time_arg_val("mcast_is_part_of_receiver_grid") == 1,
+        false>;  // loopback = false (sender does not need its own mcast data)
+
+    constexpr uint32_t mcast_src_cb = get_named_compile_time_arg_val("mcast_src_cb");
+    constexpr uint32_t mcast_dst_cb = get_named_compile_time_arg_val("mcast_dst_cb");
+    deepseek_b1_ops::Mcast::SenderArgs mcast_args{
+        get_named_compile_time_arg_val("mcast_dest_noc_start_x"),
+        get_named_compile_time_arg_val("mcast_dest_noc_start_y"),
+        get_named_compile_time_arg_val("mcast_dest_noc_end_x"),
+        get_named_compile_time_arg_val("mcast_dest_noc_end_y"),
+        get_named_compile_time_arg_val("mcast_data_sender_semaphore"),
+        get_named_compile_time_arg_val("mcast_data_receiver_semaphore"),
+        get_named_compile_time_arg_val("mcast_data_size_bytes"),
+        mcast_src_cb,
+        get_named_compile_time_arg_val("mcast_src_num_pages"),
+        get_read_ptr(mcast_src_cb),
+        get_write_ptr(mcast_dst_cb),
+    };
+
+    // Mcast2 sender args (same grid, different semaphores and CBs)
+    using Mcast2CTArgs = McastCTArgs;
+
+    constexpr uint32_t mcast2_src_cb = get_named_compile_time_arg_val("mcast2_src_cb");
+    constexpr uint32_t mcast2_dst_cb = get_named_compile_time_arg_val("mcast2_dst_cb");
+    deepseek_b1_ops::Mcast::SenderArgs mcast2_args{
+        get_named_compile_time_arg_val("mcast_dest_noc_start_x"),
+        get_named_compile_time_arg_val("mcast_dest_noc_start_y"),
+        get_named_compile_time_arg_val("mcast_dest_noc_end_x"),
+        get_named_compile_time_arg_val("mcast_dest_noc_end_y"),
+        get_named_compile_time_arg_val("mcast2_data_sender_semaphore"),
+        get_named_compile_time_arg_val("mcast2_data_receiver_semaphore"),
+        get_named_compile_time_arg_val("mcast2_data_size_bytes"),
+        mcast2_src_cb,
+        get_named_compile_time_arg_val("mcast2_src_num_pages"),
+        get_read_ptr(mcast2_src_cb),
+        get_write_ptr(mcast2_dst_cb),
+    };
+
+    // Matmul CTArgs (BRISC is no-op for matmul)
+    using MatmulCTArgs = deepseek_b1_ops::Matmul::WriterCTArgs;
+    deepseek_b1_ops::Matmul::WriterArgs matmul_args{};
+
+    // Gather receiver args
+    deepseek_b1_ops::Gather::ReceiverArgs gather_args{
+        get_named_compile_time_arg_val("gather_noc0_num_senders"),
+        get_named_compile_time_arg_val("gather_noc1_num_senders"),
+        get_named_compile_time_arg_val("gather_noc0_receiver_semaphore_id"),
+        get_named_compile_time_arg_val("gather_noc1_receiver_semaphore_id"),
+        get_named_compile_time_arg_val("gather_dst_cb"),
+        get_named_compile_time_arg_val("gather_dst_num_pages"),
+    };
+
+// ============================================================================
+// TRISC (Compute)
+// - Matmul compute (112 cores)
+// ============================================================================
+#elif defined(COMPILE_FOR_TRISC)
+    // Mcast1 CTArgs (no-op for TRISC)
+    using McastCTArgs = deepseek_b1_ops::Mcast::ComputeCTArgs;
+    deepseek_b1_ops::Mcast::ComputeArgs mcast_args{};
+
+    // Mcast2 CTArgs (no-op for TRISC)
+    using Mcast2CTArgs = deepseek_b1_ops::Mcast::ComputeCTArgs;
+    deepseek_b1_ops::Mcast::ComputeArgs mcast2_args{};
+
+    // Matmul CTArgs
+    using MatmulCTArgs =
+        deepseek_b1_ops::Matmul::ComputeCTArgs<get_named_compile_time_arg_val("matmul_out_w_per_core")>;
+    deepseek_b1_ops::Matmul::ComputeArgs matmul_args{
+        get_named_compile_time_arg_val("matmul_in0"),
+        get_named_compile_time_arg_val("matmul_in1"),
+        get_named_compile_time_arg_val("matmul_out"),
+        get_named_compile_time_arg_val("matmul_k_num_tiles"),
+    };
+
+    // Gather compute args (no-op for TRISC)
+    deepseek_b1_ops::Gather::ComputeArgs gather_args{};
+#endif
+
+    // ========================================================================
+    // Setup sharded buffers (NCRISC only)
+    // ========================================================================
+#if defined(COMPILE_FOR_NCRISC)
+    // Mcast source buffer setup (sender core only)
+    if constexpr (Core::is_mcast_sender_core) {
+        constexpr uint32_t mcast_src_cb = get_named_compile_time_arg_val("mcast_src_cb");
+        constexpr uint32_t mcast_src_num_pages = get_named_compile_time_arg_val("mcast_src_num_pages");
+        unified_kernels::setup_sharded_buffer(mcast_src_cb, mcast_src_num_pages);
+
+        constexpr uint32_t mcast2_src_cb = get_named_compile_time_arg_val("mcast2_src_cb");
+        constexpr uint32_t mcast2_src_num_pages = get_named_compile_time_arg_val("mcast2_src_num_pages");
+        unified_kernels::setup_sharded_buffer(mcast2_src_cb, mcast2_src_num_pages);
+    }
+    // Matmul weight buffers (112 matmul cores)
+    if constexpr (Core::is_matmul_core) {
+        constexpr uint32_t matmul_in1 = get_named_compile_time_arg_val("matmul_in1");
+        constexpr uint32_t matmul_k_num_tiles = get_named_compile_time_arg_val("matmul_k_num_tiles");
+        constexpr uint32_t matmul_out_w_per_core = get_named_compile_time_arg_val("matmul_out_w_per_core");
+        unified_kernels::setup_sharded_buffer(matmul_in1, matmul_k_num_tiles * matmul_out_w_per_core);
+    }
+#endif
+
+    // ========================================================================
+    // Mcast1: (12,9) -> 129 receivers in 13x10 grid
+    // Broadcasts input [1, K] to all cores
+    // ========================================================================
+    deepseek_b1_ops::Mcast::Op<
+        McastCTArgs,
+        Core::is_mcast_sender_core,
+        Core::is_mcast_receiver_core,  // IsMcastGridCore (for semaphore wait on non-receiver cores)
+        Core::is_mcast_receiver_core,  // IsReceiverCore (for CB reserve/push)
+        true>                          // pop_src
+        mcast;
+#if defined(COMPILE_FOR_BRISC)
+    if constexpr (Core::is_mcast_sender_core) {
+        mcast.init(mcast_args);
+    }
+#endif
+    {
+        DeviceZoneScopedN("MCAST1");
+        mcast(mcast_args);
+    }
+#if defined(COMPILE_FOR_BRISC)
+    if constexpr (Core::is_mcast_sender_core) {
+        mcast.teardown();
+    }
+#endif
+
+    // ========================================================================
+    // Mcast2: (12,9) -> 129 receivers in 13x10 grid
+    // Broadcasts residual input [1, N] to all cores
+    // ========================================================================
+    deepseek_b1_ops::Mcast::Op<
+        Mcast2CTArgs,
+        Core::is_mcast_sender_core,
+        Core::is_mcast_receiver_core,  // IsMcastGridCore
+        Core::is_mcast_receiver_core,  // IsReceiverCore
+        true>                          // pop_src
+        mcast2;
+#if defined(COMPILE_FOR_BRISC)
+    if constexpr (Core::is_mcast_sender_core) {
+        mcast2.init(mcast2_args);
+    }
+#endif
+    {
+        DeviceZoneScopedN("MCAST2");
+        mcast2(mcast2_args);
+    }
+#if defined(COMPILE_FOR_BRISC)
+    if constexpr (Core::is_mcast_sender_core) {
+        mcast2.teardown();
+    }
+#endif
+
+    // ========================================================================
+    // Matmul: [1, K] x [K, N_per_core] -> [1, N_per_core] on 112 cores
+    // Input: mcast_dst_cb (CB 1), Weights: matmul_in1 (CB 2), Output: matmul_out (CB 3)
+    // ========================================================================
+    {
+        DeviceZoneScopedN("MATMUL");
+        // pop_in0 = true (mcast output consumed), pop_in1 = false (weights persistent)
+        deepseek_b1_ops::Matmul::Op<MatmulCTArgs, Core::is_matmul_core, true, false> matmul;
+        matmul(matmul_args);
+    }
+
+    // ========================================================================
+    // Residual add: matmul_out + shard(residual) -> residual_add_out on 112 matmul cores
+    // Each core indexes into the full [1, N] CB6 at offset core_idx * out_w_per_core
+    // ========================================================================
+    using ResidualAddCTArgs =
+        deepseek_b1_ops::ResidualAdd::ComputeCTArgs<get_named_compile_time_arg_val("residual_add_out_w")>;
+    deepseek_b1_ops::ResidualAdd::RTArgs residual_add_args{
+#if defined(COMPILE_FOR_TRISC)
+        get_named_compile_time_arg_val("residual_add_in0"),
+        get_named_compile_time_arg_val("residual_add_in1"),
+        get_named_compile_time_arg_val("residual_add_out"),
+        get_named_compile_time_arg_val("residual_add_total_in1_tiles"),
+        get_named_compile_time_arg_val("gather_sender_idx"),
+#endif
+    };
+    {
+        DeviceZoneScopedN("ADD");
+        deepseek_b1_ops::ResidualAdd::Op<ResidualAddCTArgs, Core::is_matmul_core> residual_add;
+        residual_add(residual_add_args);
+    }
+
+    // ========================================================================
+    // Gather: 112 matmul cores -> (12,9)
+    // Collects [1, N_per_core] * 112 = [1, N]
+    // Uses UsePerCoreSenderIdx=true for scattered (non-rectangular) core layout
+    // ========================================================================
+    {
+        DeviceZoneScopedN("GATHER");
+        deepseek_b1_ops::Gather::Op<
+            Core::is_matmul_core,                  // IsSenderCore
+            Core::is_gather_receiver_core,         // IsReceiverCore
+            true,                                  // pop_src
+            Core::gather_use_per_core_sender_idx>  // UsePerCoreSenderIdx
+            gather;
+        gather(gather_args);
+    }
+}

--- a/models/demos/deepseek_v3_b1/fused_ops/down_proj/op.py
+++ b/models/demos/deepseek_v3_b1/fused_ops/down_proj/op.py
@@ -1,0 +1,533 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Down Projection (W_down) fused operation.
+
+Implements Mcast1 + Mcast2 + Matmul + ResidualAdd + Gather as a fused execution on 112 cores:
+- Mcast1: Input [1, K] on (12,9) -> broadcast to 130-core grid (13x10)
+- Mcast2: Add input [1, N] on (12,9) -> broadcast to 130-core grid (13x10)
+- Matmul: [1, K] x [K, N_per_core] -> [1, N_per_core] on 112 matmul cores
+- Residual add: matmul_out + shard(residual) -> [1, N_per_core] on 112 matmul cores
+- Gather: Collect [1, N_per_core] from 112 scattered cores to [1, N] on (12,9)
+
+Core Layout (13x10 = 130-core mcast grid):
+    D = DRAM worker (8 cores) — receives mcast semaphore, skips matmul & gather
+    P = Phantom (9 cores, col 12 rows 0-8) — same as DRAM worker
+    M = Mcast sender + Gather receiver (12,9)
+    R = Matmul core (112 cores)
+
+CB Layout:
+- CB 0: mcast_src (input on (12,9), tensor-backed)
+- CB 1: mcast_dst / matmul_in0 (all 130 cores, receives mcast data)
+- CB 2: matmul_in1 (weights on 112 matmul cores, tensor-backed)
+- CB 3: matmul_out (112 matmul cores, intermediate consumed by add)
+- CB 4: gather_dst (output on (12,9), tensor-backed)
+- CB 5: residual_add_mcast_src (residual input on (12,9), tensor-backed)
+- CB 6: residual_add_mcast_dst (all 130 cores, receives mcast2 data)
+- CB 7: residual_add_out (112 matmul cores, matmul_out + shard(residual))
+"""
+
+import ttnn
+from models.demos.deepseek_v3_b1.unified_kernel_descriptor import (
+    PerCoreCompileTimeDescriptor,
+    UnifiedCompileTimeCoreDescriptor,
+    UnifiedKernelDescriptor,
+)
+
+
+class DownProj:
+    """
+    Down Projection fused operation using ttnn.generic_op.
+
+    Implements: Mcast1 -> Mcast2 -> Matmul -> ResidualAdd -> Gather on a 13x10 grid with 112 active matmul cores.
+    """
+
+    # DRAM worker positions (logical coordinates) — cores that sit on DRAM banks
+    DRAM_WORKER_POSITIONS = [(0, 0), (0, 3), (0, 7), (0, 9), (7, 1), (7, 4), (7, 6), (7, 9)]
+
+    # Full mcast grid dimensions
+    MCAST_GRID_X = 13
+    MCAST_GRID_Y = 10
+
+    # Mcast sender / Gather receiver core
+    MCAST_GATHER_CORE = ttnn.CoreCoord(12, 9)
+
+    # Number of active matmul cores
+    NUM_MATMUL_CORES = 112
+
+    @staticmethod
+    def build_matmul_core_grid():
+        """
+        Build CoreRangeSet for 112 matmul cores.
+
+        From the 13x10 = 130 core grid, exclude:
+        - 8 DRAM workers at known positions
+        - 9 phantoms at col 12, rows 0-8
+        - 1 mcast/gather core at (12, 9)
+
+        Returns contiguous row segments as CoreRanges for efficiency.
+        """
+        excluded = set(DownProj.DRAM_WORKER_POSITIONS)
+        # Add phantoms (col 12, rows 0-8) and mcast/gather core (12, 9)
+        for row in range(10):
+            excluded.add((12, row))
+
+        # Collect all non-excluded cores
+        all_matmul_cores = []
+        for row in range(DownProj.MCAST_GRID_Y):
+            for col in range(DownProj.MCAST_GRID_X):
+                if (col, row) not in excluded:
+                    all_matmul_cores.append((col, row))
+
+        assert (
+            len(all_matmul_cores) == DownProj.NUM_MATMUL_CORES
+        ), f"Expected {DownProj.NUM_MATMUL_CORES} matmul cores, got {len(all_matmul_cores)}"
+
+        # Build contiguous row segments
+        core_ranges = []
+        for row in range(DownProj.MCAST_GRID_Y):
+            row_cores = [(c, r) for c, r in all_matmul_cores if r == row]
+            if not row_cores:
+                continue
+            row_cores.sort()
+            seg_start = row_cores[0][0]
+            prev_col = seg_start
+            for i in range(1, len(row_cores)):
+                col = row_cores[i][0]
+                if col != prev_col + 1:
+                    core_ranges.append(
+                        ttnn.CoreRange(
+                            ttnn.CoreCoord(seg_start, row),
+                            ttnn.CoreCoord(prev_col, row),
+                        )
+                    )
+                    seg_start = col
+                prev_col = col
+            core_ranges.append(
+                ttnn.CoreRange(
+                    ttnn.CoreCoord(seg_start, row),
+                    ttnn.CoreCoord(prev_col, row),
+                )
+            )
+
+        return ttnn.CoreRangeSet(core_ranges)
+
+    @staticmethod
+    def build_mcast_receiver_grid():
+        """
+        Build CoreRangeSet for mcast receivers: all 130 cores minus sender (12,9).
+        """
+        mcast_gather_core = DownProj.MCAST_GATHER_CORE
+        ranges = []
+        for row in range(DownProj.MCAST_GRID_Y):
+            for col in range(DownProj.MCAST_GRID_X):
+                if col == mcast_gather_core.x and row == mcast_gather_core.y:
+                    continue
+                ranges.append(ttnn.CoreRange(ttnn.CoreCoord(col, row), ttnn.CoreCoord(col, row)))
+        return ttnn.CoreRangeSet(ranges)
+
+    @staticmethod
+    def golden(input_tensor, weights_tensor, add_input_tensor):
+        """
+        PyTorch reference implementation.
+
+        Args:
+            input_tensor: [1, K] torch.Tensor
+            weights_tensor: [K, N] torch.Tensor
+            add_input_tensor: [1, N] torch.Tensor
+
+        Returns:
+            [1, N] torch.Tensor
+        """
+        return input_tensor @ weights_tensor + add_input_tensor
+
+    @staticmethod
+    def op(input_tensor, weights_tensor, output_tensor, add_input_tensor, fp32_dest_acc_en=False):
+        """
+        Execute down projection fused operation using generic_op.
+
+        Args:
+            input_tensor: Input [1, K] HEIGHT_SHARDED on (12,9)
+            weights_tensor: Weights [K, N] WIDTH_SHARDED on 112 matmul cores
+            output_tensor: Output [1, N] HEIGHT_SHARDED on (12,9)
+            add_input_tensor: Add input [1, N] HEIGHT_SHARDED on (12,9)
+            fp32_dest_acc_en: Whether to enable FP32 accumulation
+
+        Returns:
+            Output tensor with result
+        """
+        device = input_tensor.device()
+        data_format = input_tensor.dtype
+
+        # Tile definitions
+        TILE_1x32 = ttnn.Tile((1, 32))
+        tile_1x32_size = TILE_1x32.get_tile_size(data_format)
+
+        # ====================================================================
+        # Core grid configuration
+        # ====================================================================
+        mcast_gather_core = DownProj.MCAST_GATHER_CORE
+        mcast_gather_core_grid = ttnn.CoreRangeSet([ttnn.CoreRange(mcast_gather_core, mcast_gather_core)])
+
+        # Full 13x10 mcast grid
+        mcast_grid = ttnn.CoreRange(
+            ttnn.CoreCoord(0, 0),
+            ttnn.CoreCoord(DownProj.MCAST_GRID_X - 1, DownProj.MCAST_GRID_Y - 1),
+        )
+        mcast_grid_set = ttnn.CoreRangeSet([mcast_grid])
+        num_mcast_cores = DownProj.MCAST_GRID_X * DownProj.MCAST_GRID_Y  # 130
+
+        # 112 matmul cores (excludes DRAM workers, phantoms, mcast/gather core)
+        matmul_core_grid = DownProj.build_matmul_core_grid()
+
+        # Mcast receiver grid = all 130 minus sender (12,9)
+        mcast_receiver_grid = DownProj.build_mcast_receiver_grid()
+
+        # All cores = full mcast grid (sender is already included)
+        all_cores = mcast_grid_set
+
+        # Get NOC coordinates
+        gather_dest_noc_core = device.worker_core_from_logical_core(mcast_gather_core)
+        mcast_dest_noc_start = device.worker_core_from_logical_core(mcast_grid.start)
+        mcast_dest_noc_end = device.worker_core_from_logical_core(mcast_grid.end)
+
+        # ====================================================================
+        # Dimension parameters
+        # ====================================================================
+        input_tile = input_tensor.get_tile()
+        k_num_tiles = input_tensor.shape[1] // input_tile.tile_shape[1]
+
+        weights_shard_spec = weights_tensor.memory_config().shard_spec
+        n_per_core = weights_shard_spec.shape[1]
+        out_w_per_core = n_per_core // TILE_1x32.tile_shape[1]
+
+        input_tile_size = input_tile.get_tile_size(data_format)
+
+        # ====================================================================
+        # CB indices
+        # ====================================================================
+        mcast_src_cb = 0  # Input on (12,9)
+        mcast_dst_cb = 1  # Mcast destination = matmul in0 (all 130 cores)
+        matmul_in1_cb = 2  # Matmul weights (112 matmul cores)
+        matmul_out_cb = 3  # Matmul output (112 matmul cores)
+        gather_dst_cb = 4  # Gather output (12,9)
+        residual_add_mcast_src_cb = 5  # Residual input on (12,9)
+        residual_add_mcast_dst_cb = 6  # Residual input after mcast2 (all 130 cores)
+        residual_add_out_cb = 7  # Residual add output (112 matmul cores)
+
+        # ====================================================================
+        # Mcast parameters
+        # ====================================================================
+        mcast_data_size_bytes = k_num_tiles * input_tile_size
+        mcast_is_part_of_receiver_grid = mcast_grid.contains(mcast_gather_core)  # True
+
+        # ====================================================================
+        # Mcast2 parameters (add input)
+        # ====================================================================
+        total_residual_add_tiles = DownProj.NUM_MATMUL_CORES * out_w_per_core  # = N / 32
+        residual_add_mcast_data_size_bytes = total_residual_add_tiles * tile_1x32_size
+
+        # ====================================================================
+        # Gather parameters
+        # ====================================================================
+        gather_data_size_bytes = out_w_per_core * tile_1x32_size
+        gather_src_num_pages = out_w_per_core
+        gather_dst_num_pages = DownProj.NUM_MATMUL_CORES * out_w_per_core
+        gather_noc0_num_senders = DownProj.NUM_MATMUL_CORES
+        gather_noc1_num_senders = 0
+
+        # ====================================================================
+        # Semaphore IDs
+        # ====================================================================
+        mcast_data_sender_semaphore_id = 0
+        mcast_data_receiver_semaphore_id = 1
+        gather_noc0_receiver_semaphore_id = 2
+        gather_noc1_receiver_semaphore_id = 3
+        mcast2_data_sender_semaphore_id = 4
+        mcast2_data_receiver_semaphore_id = 5
+
+        # ====================================================================
+        # Buffer addresses
+        # ====================================================================
+        gather_receiver_data_addr = output_tensor.buffer_address()
+
+        # ====================================================================
+        # Per-core gather indices for 112 scattered matmul cores
+        # ====================================================================
+        matmul_cores_list = ttnn.corerange_to_cores(matmul_core_grid)
+        per_core_gather_idx = PerCoreCompileTimeDescriptor(
+            named_compile_time_arg="gather_sender_idx",
+            core_values=[(core, idx) for idx, core in enumerate(matmul_cores_list)],
+            other_value=0,
+        )
+
+        # ====================================================================
+        # NCRISC compile-time args
+        # ====================================================================
+        ncrisc_named_compile_time_args = [
+            # Mcast1 source (for setup_sharded_buffer on sender core)
+            ("mcast_src_cb", mcast_src_cb),
+            ("mcast_src_num_pages", k_num_tiles),
+            # Mcast1 receiver
+            ("mcast_data_receiver_semaphore", mcast_data_receiver_semaphore_id),
+            ("mcast_dst_cb", mcast_dst_cb),
+            ("mcast_dst_num_pages", k_num_tiles),
+            # Mcast2 source (for setup_sharded_buffer on sender core)
+            ("mcast2_src_cb", residual_add_mcast_src_cb),
+            ("mcast2_src_num_pages", total_residual_add_tiles),
+            # Mcast2 receiver
+            ("mcast2_data_receiver_semaphore", mcast2_data_receiver_semaphore_id),
+            ("mcast2_dst_cb", residual_add_mcast_dst_cb),
+            ("mcast2_dst_num_pages", total_residual_add_tiles),
+            # Matmul
+            ("matmul_in0", mcast_dst_cb),
+            ("matmul_in1", matmul_in1_cb),
+            ("matmul_out", matmul_out_cb),
+            ("matmul_k_num_tiles", k_num_tiles),
+            ("matmul_out_w_per_core", out_w_per_core),
+            # Residual add (needed for ResidualAdd CTArgs template parameter)
+            ("residual_add_out_w", out_w_per_core),
+            # Gather sender (now reads from residual_add_out_cb instead of matmul_out_cb)
+            ("gather_dest_noc_x", gather_dest_noc_core.x),
+            ("gather_dest_noc_y", gather_dest_noc_core.y),
+            ("gather_data_size_bytes", gather_data_size_bytes),
+            ("gather_receiver_semaphore_id", gather_noc0_receiver_semaphore_id),
+            ("gather_src_cb", residual_add_out_cb),
+            ("gather_src_num_pages", gather_src_num_pages),
+            ("gather_sender_grid_start_x", 0),
+            ("gather_sender_grid_start_y", 0),
+            ("gather_sender_grid_end_x", 0),
+            ("gather_sender_grid_end_y", 0),
+            ("gather_row_major", 1),
+            ("gather_receiver_data_addr", gather_receiver_data_addr),
+        ]
+
+        # ====================================================================
+        # BRISC compile-time args
+        # ====================================================================
+        brisc_named_compile_time_args = [
+            # Mcast1 sender
+            ("mcast_dest_noc_start_x", mcast_dest_noc_start.x),
+            ("mcast_dest_noc_start_y", mcast_dest_noc_start.y),
+            ("mcast_dest_noc_end_x", mcast_dest_noc_end.x),
+            ("mcast_dest_noc_end_y", mcast_dest_noc_end.y),
+            ("mcast_num_cores", num_mcast_cores),
+            ("mcast_data_sender_semaphore", mcast_data_sender_semaphore_id),
+            ("mcast_data_receiver_semaphore", mcast_data_receiver_semaphore_id),
+            ("mcast_data_size_bytes", mcast_data_size_bytes),
+            ("mcast_src_cb", mcast_src_cb),
+            ("mcast_src_num_pages", k_num_tiles),
+            ("mcast_dst_cb", mcast_dst_cb),
+            ("mcast_is_part_of_receiver_grid", mcast_is_part_of_receiver_grid),
+            # Mcast2 sender
+            ("mcast2_data_sender_semaphore", mcast2_data_sender_semaphore_id),
+            ("mcast2_data_receiver_semaphore", mcast2_data_receiver_semaphore_id),
+            ("mcast2_data_size_bytes", residual_add_mcast_data_size_bytes),
+            ("mcast2_src_cb", residual_add_mcast_src_cb),
+            ("mcast2_src_num_pages", total_residual_add_tiles),
+            ("mcast2_dst_cb", residual_add_mcast_dst_cb),
+            # Residual add (needed for ResidualAdd CTArgs template parameter)
+            ("residual_add_out_w", out_w_per_core),
+            # Gather receiver
+            ("gather_noc0_num_senders", gather_noc0_num_senders),
+            ("gather_noc1_num_senders", gather_noc1_num_senders),
+            ("gather_noc0_receiver_semaphore_id", gather_noc0_receiver_semaphore_id),
+            ("gather_noc1_receiver_semaphore_id", gather_noc1_receiver_semaphore_id),
+            ("gather_dst_cb", gather_dst_cb),
+            ("gather_dst_num_pages", gather_dst_num_pages),
+        ]
+
+        # ====================================================================
+        # TRISC compile-time args
+        # ====================================================================
+        trisc_named_compile_time_args = [
+            ("matmul_in0", mcast_dst_cb),
+            ("matmul_in1", matmul_in1_cb),
+            ("matmul_out", matmul_out_cb),
+            ("matmul_k_num_tiles", k_num_tiles),
+            ("matmul_out_w_per_core", out_w_per_core),
+            # Residual add step
+            ("residual_add_in0", matmul_out_cb),
+            ("residual_add_in1", residual_add_mcast_dst_cb),
+            ("residual_add_out", residual_add_out_cb),
+            ("residual_add_out_w", out_w_per_core),
+            ("residual_add_total_in1_tiles", total_residual_add_tiles),
+        ]
+
+        # ====================================================================
+        # Circular buffer descriptors
+        # ====================================================================
+        # CB 0: Mcast source — input on (12,9), tensor-backed
+        mcast_src_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(mcast_src_cb, input_tensor)
+
+        # CB 1: Mcast destination — on all 130 cores (including sender for get_write_ptr)
+        mcast_dst_tile_descriptor = ttnn.TileDescriptor(TILE_1x32)
+        mcast_dst_cb_format = ttnn.CBFormatDescriptor(
+            buffer_index=mcast_dst_cb,
+            data_format=data_format,
+            page_size=input_tile_size,
+            tile=mcast_dst_tile_descriptor,
+        )
+        mcast_dst_cb_descriptor = ttnn.CBDescriptor(
+            total_size=k_num_tiles * input_tile_size,
+            core_ranges=all_cores,
+            format_descriptors=[mcast_dst_cb_format],
+        )
+
+        # CB 2: Matmul weights — tensor-backed on 112 matmul cores
+        matmul_in1_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(matmul_in1_cb, weights_tensor)
+
+        # CB 3: Matmul output — on 112 matmul cores
+        matmul_out_cb_format = ttnn.CBFormatDescriptor(
+            buffer_index=matmul_out_cb,
+            data_format=data_format,
+            page_size=tile_1x32_size,
+            tile=mcast_dst_tile_descriptor,
+        )
+        matmul_out_cb_descriptor = ttnn.CBDescriptor(
+            total_size=out_w_per_core * tile_1x32_size,
+            core_ranges=matmul_core_grid,
+            format_descriptors=[matmul_out_cb_format],
+        )
+
+        # CB 4: Gather destination — output on (12,9), tensor-backed
+        gather_dst_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(gather_dst_cb, output_tensor)
+
+        # CB 5: Mcast2 source — residual input on (12,9), tensor-backed
+        residual_add_mcast_src_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(
+            residual_add_mcast_src_cb, add_input_tensor
+        )
+
+        # CB 6: Mcast2 destination — on all 130 cores (full [1, N] residual input)
+        residual_add_mcast_dst_cb_format = ttnn.CBFormatDescriptor(
+            buffer_index=residual_add_mcast_dst_cb,
+            data_format=data_format,
+            page_size=tile_1x32_size,
+            tile=mcast_dst_tile_descriptor,
+        )
+        residual_add_mcast_dst_cb_descriptor = ttnn.CBDescriptor(
+            total_size=total_residual_add_tiles * tile_1x32_size,
+            core_ranges=all_cores,
+            format_descriptors=[residual_add_mcast_dst_cb_format],
+        )
+
+        # CB 7: Residual add output — on 112 matmul cores
+        residual_add_out_cb_format = ttnn.CBFormatDescriptor(
+            buffer_index=residual_add_out_cb,
+            data_format=data_format,
+            page_size=tile_1x32_size,
+            tile=mcast_dst_tile_descriptor,
+        )
+        residual_add_out_cb_descriptor = ttnn.CBDescriptor(
+            total_size=out_w_per_core * tile_1x32_size,
+            core_ranges=matmul_core_grid,
+            format_descriptors=[residual_add_out_cb_format],
+        )
+
+        # ====================================================================
+        # Semaphore descriptors
+        # ====================================================================
+        full_device_grid = ttnn.CoreRangeSet(
+            [
+                ttnn.CoreRange(
+                    ttnn.CoreCoord(0, 0),
+                    ttnn.CoreCoord(
+                        device.compute_with_storage_grid_size().x - 1,
+                        device.compute_with_storage_grid_size().y - 1,
+                    ),
+                )
+            ]
+        )
+
+        semaphore_descriptors = [
+            ttnn.SemaphoreDescriptor(id=mcast_data_sender_semaphore_id, core_ranges=full_device_grid, initial_value=0),
+            ttnn.SemaphoreDescriptor(
+                id=mcast_data_receiver_semaphore_id, core_ranges=full_device_grid, initial_value=0
+            ),
+            ttnn.SemaphoreDescriptor(
+                id=gather_noc0_receiver_semaphore_id, core_ranges=full_device_grid, initial_value=0
+            ),
+            ttnn.SemaphoreDescriptor(
+                id=gather_noc1_receiver_semaphore_id, core_ranges=full_device_grid, initial_value=0
+            ),
+            ttnn.SemaphoreDescriptor(id=mcast2_data_sender_semaphore_id, core_ranges=full_device_grid, initial_value=0),
+            ttnn.SemaphoreDescriptor(
+                id=mcast2_data_receiver_semaphore_id, core_ranges=full_device_grid, initial_value=0
+            ),
+        ]
+
+        # ====================================================================
+        # Kernel descriptor
+        # ====================================================================
+        unified_kernel = UnifiedKernelDescriptor(
+            kernel_source="models/demos/deepseek_v3_b1/fused_ops/down_proj/kernels/down_proj_kernel.cpp",
+            core_ranges=all_cores,
+            ncrisc_named_compile_time_args=ncrisc_named_compile_time_args,
+            brisc_named_compile_time_args=brisc_named_compile_time_args,
+            trisc_named_compile_time_args=trisc_named_compile_time_args,
+            trisc_compute_config=ttnn.ComputeConfigDescriptor(
+                math_fidelity=ttnn.MathFidelity.LoFi,
+                math_approx_mode=False,
+                fp32_dest_acc_en=fp32_dest_acc_en,
+                dst_full_sync_en=fp32_dest_acc_en,
+            ),
+            unified_compile_time_core_descriptors=[
+                UnifiedCompileTimeCoreDescriptor(
+                    named_compile_time_arg="is_mcast_sender_core",
+                    core_range=mcast_gather_core_grid,
+                    value=1,
+                    other_value=0,
+                ),
+                UnifiedCompileTimeCoreDescriptor(
+                    named_compile_time_arg="is_mcast_receiver_core",
+                    core_range=mcast_receiver_grid,
+                    value=1,
+                    other_value=0,
+                ),
+                UnifiedCompileTimeCoreDescriptor(
+                    named_compile_time_arg="is_matmul_core",
+                    core_range=matmul_core_grid,
+                    value=1,
+                    other_value=0,
+                ),
+                UnifiedCompileTimeCoreDescriptor(
+                    named_compile_time_arg="is_gather_receiver_core",
+                    core_range=mcast_gather_core_grid,
+                    value=1,
+                    other_value=0,
+                ),
+                UnifiedCompileTimeCoreDescriptor(
+                    named_compile_time_arg="gather_use_per_core_sender_idx",
+                    core_range=matmul_core_grid,
+                    value=1,
+                    other_value=0,
+                ),
+            ],
+            per_core_compile_time_descriptors=[per_core_gather_idx],
+        )
+
+        # ====================================================================
+        # Program descriptor
+        # ====================================================================
+        program_descriptor = ttnn.ProgramDescriptor(
+            kernels=unified_kernel.get_kernel_descriptors().kernels,
+            cbs=[
+                mcast_src_cb_descriptor,
+                mcast_dst_cb_descriptor,
+                matmul_in1_cb_descriptor,
+                matmul_out_cb_descriptor,
+                gather_dst_cb_descriptor,
+                residual_add_mcast_src_cb_descriptor,
+                residual_add_mcast_dst_cb_descriptor,
+                residual_add_out_cb_descriptor,
+            ],
+            semaphores=semaphore_descriptors,
+        )
+
+        # Execute generic op
+        # Order must match tensor-backed CBs in cbs list: CB0(input), CB2(weights), CB4(output), CB5(add_input)
+        io_tensors = [input_tensor, weights_tensor, output_tensor, add_input_tensor]
+        ttnn.generic_op(io_tensors, program_descriptor)
+        return output_tensor

--- a/models/demos/deepseek_v3_b1/fused_ops/face_view_utils.py
+++ b/models/demos/deepseek_v3_b1/fused_ops/face_view_utils.py
@@ -1,0 +1,42 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Face-view optimization utilities for gated reduce operations.
+
+Face-view packs multiple small tiles into a single hardware face (16x16 = 256 elements),
+allowing the reduce kernel to operate on face-sized tiles instead of iterating over
+multiple small tiles per K-position.
+"""
+
+# Hardware face dimensions
+FACE_HEIGHT = 16
+FACE_WIDTH = 16
+FACE_ELEMENTS = FACE_HEIGHT * FACE_WIDTH  # 256
+
+
+def can_use_face_view(tile_h, tile_w, tiles_per_k, k_num_tiles):
+    """
+    Check if face-view optimization can be applied for gated reduce.
+
+    Face-view requires:
+    1. Tiles smaller than a face (tile_h * tile_w < 256)
+    2. Each collection's k_num_tiles tiles exactly fill one face
+    3. tiles_per_k >= 2 (need at least 2 faces to reduce)
+    4. tiles_per_k is even (for pairwise addition)
+    """
+    elements_per_tile = tile_h * tile_w
+    if elements_per_tile >= FACE_ELEMENTS:
+        return False
+
+    if elements_per_tile * k_num_tiles != FACE_ELEMENTS:
+        return False
+
+    if tiles_per_k < 2:
+        return False
+
+    if tiles_per_k % 2 != 0:
+        return False
+
+    return True

--- a/models/demos/deepseek_v3_b1/fused_ops/gated_local_reduce/__init__.py
+++ b/models/demos/deepseek_v3_b1/fused_ops/gated_local_reduce/__init__.py
@@ -1,0 +1,7 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+from .op import GatedLocalReduceOp
+
+__all__ = ["GatedLocalReduceOp"]

--- a/models/demos/deepseek_v3_b1/fused_ops/gated_local_reduce/kernels/gated_local_reduce_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/fused_ops/gated_local_reduce/kernels/gated_local_reduce_kernel.cpp
@@ -46,30 +46,20 @@ void kernel_main() {
         constexpr uint32_t group1_num_tiles = get_named_compile_time_arg_val("gated_local_reduce_group1_num_tiles");
         constexpr uint32_t group2_num_tiles = get_named_compile_time_arg_val("gated_local_reduce_group2_num_tiles");
 
-        using LocalReduceCTArgs = deepseek_b1_ops::LocalReduce::ComputeCTArgs;
-
         // ================================================================
         // Phase 1: reduce(group1) + SiLU -> intermed[0]  (ADD with SiLU)
         // ================================================================
-        deepseek_b1_ops::LocalReduce::ComputeArgs group1_args{
-            .in_cb = in0_cb,
-            .out_cb = intermed_cb,
-            .num_tiles = group1_num_tiles,
-            .apply_silu = true,
-        };
-        deepseek_b1_ops::LocalReduce::Op<LocalReduceCTArgs, true> group1_reduce;
+        using Group1CTArgs = deepseek_b1_ops::LocalReduce::ComputeCTArgs<group1_num_tiles, true>;
+        deepseek_b1_ops::LocalReduce::ComputeArgs group1_args{in0_cb, intermed_cb};
+        deepseek_b1_ops::LocalReduce::Op<Group1CTArgs, true> group1_reduce;
         group1_reduce(group1_args);
 
         // ================================================================
         // Phase 2: reduce(group2) -> intermed[1]  (ADD)
         // ================================================================
-        deepseek_b1_ops::LocalReduce::ComputeArgs group2_args{
-            .in_cb = in1_cb,
-            .out_cb = intermed_cb,
-            .num_tiles = group2_num_tiles,
-            .apply_silu = false,
-        };
-        deepseek_b1_ops::LocalReduce::Op<LocalReduceCTArgs, true> group2_reduce;
+        using Group2CTArgs = deepseek_b1_ops::LocalReduce::ComputeCTArgs<group2_num_tiles, false>;
+        deepseek_b1_ops::LocalReduce::ComputeArgs group2_args{in1_cb, intermed_cb};
+        deepseek_b1_ops::LocalReduce::Op<Group2CTArgs, true> group2_reduce;
         group2_reduce(group2_args);
 
         // ================================================================

--- a/models/demos/deepseek_v3_b1/fused_ops/gated_local_reduce/kernels/gated_local_reduce_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/fused_ops/gated_local_reduce/kernels/gated_local_reduce_kernel.cpp
@@ -1,0 +1,103 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+// SPDX-License-Identifier: Apache-2.0
+
+// Gated Local Reduce fused kernel
+//
+// Composes two LocalReduce ADD operations plus a final multiplication:
+//   Phase 1: reduce(group1) + SiLU -> intermed[0]  (ADD with SiLU)
+//   Phase 2: reduce(group2)        -> intermed[1]  (ADD)
+//   Phase 3: intermed[0] * intermed[1] -> out      (single mul_tiles)
+//
+// NCRISC: Signals sharded CBs are ready
+// BRISC: No-op
+// TRISC: Performs gated local reduce via composed LocalReduce ops + mul_tiles
+
+#include "../../../unified_kernels/kernel_op_api.hpp"
+#include "../../../unified_kernels/kernel_utils.hpp"
+#include "../../../unified_kernels/local_reduce.hpp"
+
+struct Core {
+    static constexpr bool is_active_core = get_named_compile_time_arg_val("is_active_core") == 1;
+};
+
+void kernel_main() {
+#if defined(COMPILE_FOR_NCRISC)
+    constexpr uint32_t in0_cb = get_named_compile_time_arg_val("gated_local_reduce_in0_cb");
+    constexpr uint32_t in1_cb = get_named_compile_time_arg_val("gated_local_reduce_in1_cb");
+    constexpr uint32_t group1_num_tiles = get_named_compile_time_arg_val("gated_local_reduce_group1_num_tiles");
+    constexpr uint32_t group2_num_tiles = get_named_compile_time_arg_val("gated_local_reduce_group2_num_tiles");
+
+    // Setup sharded buffers for both input groups
+    if constexpr (Core::is_active_core) {
+        unified_kernels::setup_sharded_buffer(in0_cb, group1_num_tiles);
+        unified_kernels::setup_sharded_buffer(in1_cb, group2_num_tiles);
+    }
+
+#elif defined(COMPILE_FOR_BRISC)
+    // No-op for BRISC
+
+#elif defined(COMPILE_FOR_TRISC)
+    if constexpr (Core::is_active_core) {
+        // Get compile-time args
+        constexpr uint32_t in0_cb = get_named_compile_time_arg_val("gated_local_reduce_in0_cb");
+        constexpr uint32_t in1_cb = get_named_compile_time_arg_val("gated_local_reduce_in1_cb");
+        constexpr uint32_t intermed_cb = get_named_compile_time_arg_val("gated_local_reduce_intermed_cb");
+        constexpr uint32_t out_cb = get_named_compile_time_arg_val("gated_local_reduce_out_cb");
+        constexpr uint32_t group1_num_tiles = get_named_compile_time_arg_val("gated_local_reduce_group1_num_tiles");
+        constexpr uint32_t group2_num_tiles = get_named_compile_time_arg_val("gated_local_reduce_group2_num_tiles");
+
+        using LocalReduceCTArgs = deepseek_b1_ops::LocalReduce::ComputeCTArgs;
+
+        // ================================================================
+        // Phase 1: reduce(group1) + SiLU -> intermed[0]  (ADD with SiLU)
+        // ================================================================
+        deepseek_b1_ops::LocalReduce::ComputeArgs group1_args{
+            .in_cb = in0_cb,
+            .out_cb = intermed_cb,
+            .num_tiles = group1_num_tiles,
+            .apply_silu = true,
+        };
+        deepseek_b1_ops::LocalReduce::Op<LocalReduceCTArgs, true> group1_reduce;
+        group1_reduce(group1_args);
+
+        // ================================================================
+        // Phase 2: reduce(group2) -> intermed[1]  (ADD)
+        // ================================================================
+        deepseek_b1_ops::LocalReduce::ComputeArgs group2_args{
+            .in_cb = in1_cb,
+            .out_cb = intermed_cb,
+            .num_tiles = group2_num_tiles,
+            .apply_silu = false,
+        };
+        deepseek_b1_ops::LocalReduce::Op<LocalReduceCTArgs, true> group2_reduce;
+        group2_reduce(group2_args);
+
+        // ================================================================
+        // Phase 3: intermed[0] * intermed[1] -> out  (single mul_tiles)
+        // ================================================================
+        // Wait for both intermediate tiles
+        cb_wait_front(intermed_cb, 2);
+
+        // Reserve output
+        cb_reserve_back(out_cb, 1);
+
+        // Initialize and perform multiplication
+        binary_op_init_common(intermed_cb, intermed_cb, out_cb);
+        tile_regs_acquire();
+        mul_tiles_init(intermed_cb, intermed_cb);
+        mul_tiles(intermed_cb, intermed_cb, 0, 1, 0);
+
+        // Commit and wait
+        tile_regs_commit();
+        tile_regs_wait();
+
+        // Pack result
+        pack_tile(0, out_cb);
+        tile_regs_release();
+
+        // Pop intermediates and push output
+        cb_pop_front(intermed_cb, 2);
+        cb_push_back(out_cb, 1);
+    }
+#endif
+}

--- a/models/demos/deepseek_v3_b1/fused_ops/gated_local_reduce/op.py
+++ b/models/demos/deepseek_v3_b1/fused_ops/gated_local_reduce/op.py
@@ -1,0 +1,170 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Gated Local Reduce fused operation.
+
+Composes three LocalReduceSilu operations:
+    Phase 1: reduce(group1) + SiLU -> intermed[0]  (ADD)
+    Phase 2: reduce(group2)        -> intermed[1]  (ADD)
+    Phase 3: intermed[0] * intermed[1] -> out      (MUL)
+
+This is useful for gated MLP patterns where:
+  - Group 1 is the "gate" path (with SiLU activation)
+  - Group 2 is the "up" path (no activation)
+  - Final result is element-wise product (gate * up)
+"""
+
+import torch
+
+import ttnn
+from models.demos.deepseek_v3_b1.unified_kernel_descriptor import (
+    UnifiedCompileTimeCoreDescriptor,
+    UnifiedKernelDescriptor,
+)
+
+
+class GatedLocalReduceOp:
+    """
+    Two reductions (group1 with SiLU, group2 without), then multiply.
+
+    Computes: SiLU(reduce(group1)) * reduce(group2)
+    """
+
+    @staticmethod
+    def golden(group1_inputs, group2_inputs):
+        """
+        PyTorch reference implementation.
+
+        Args:
+            group1_inputs: List of tensors for group 1 (SiLU applied)
+            group2_inputs: List of tensors for group 2 (no SiLU)
+
+        Returns:
+            SiLU(reduce(group1)) * reduce(group2)
+        """
+        # Sum group 1 and apply SiLU
+        group1_sum = group1_inputs[0]
+        for inp in group1_inputs[1:]:
+            group1_sum = group1_sum + inp
+        group1_sum = torch.nn.functional.silu(group1_sum)
+
+        # Sum group 2 (no SiLU)
+        group2_sum = group2_inputs[0]
+        for inp in group2_inputs[1:]:
+            group2_sum = group2_sum + inp
+
+        # Combine with element-wise multiply
+        return group1_sum * group2_sum
+
+    @staticmethod
+    def op(
+        input_tensor_group1,
+        input_tensor_group2,
+        output_tensor,
+        group1_num_tiles,
+        group2_num_tiles,
+    ):
+        """
+        Execute gated local reduce: SiLU on group1, no SiLU on group2, then multiply.
+
+        Args:
+            input_tensor_group1: Input tensor for group 1 (shape [N*tile_h, tile_w])
+            input_tensor_group2: Input tensor for group 2 (shape [M*tile_h, tile_w])
+            output_tensor: Pre-allocated output tensor (shape [tile_h, tile_w])
+            group1_num_tiles: Number of tiles in group 1
+            group2_num_tiles: Number of tiles in group 2
+
+        Returns:
+            Output tensor with SiLU(reduce(group1)) * reduce(group2)
+        """
+        all_cores = input_tensor_group1.memory_config().shard_spec.grid
+        assert all_cores.num_cores() == 1, "Only single core is supported"
+        assert group1_num_tiles >= 2, "Need at least 2 tiles in group 1"
+        assert group1_num_tiles % 2 == 0, "Group 1 tile count must be even"
+        assert group2_num_tiles >= 2, "Need at least 2 tiles in group 2"
+        assert group2_num_tiles % 2 == 0, "Group 2 tile count must be even"
+
+        # CB indices (4 CBs total)
+        in0_cb = 0  # Group 1 input
+        in1_cb = 1  # Group 2 input
+        intermed_cb = 2  # Intermediate: holds 2 tiles (group1 result + group2 result)
+        out_cb = 3  # Final output
+
+        # Get tile info from output tensor for intermediate buffer
+        output_tile = output_tensor.tile
+        tile_h, tile_w = output_tile.tile_shape
+        data_format = ttnn.DataType.BFLOAT16
+        tile_size = output_tile.get_tile_size(data_format)
+        tile_descriptor = ttnn.TileDescriptor(tile_h, tile_w, False)
+
+        # CB descriptors for inputs (backed by tensors)
+        in0_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(in0_cb, input_tensor_group1)
+        in1_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(in1_cb, input_tensor_group2)
+
+        # Intermediate CB: 2 tiles (group1 result + group2 result)
+        intermed_format = ttnn.CBFormatDescriptor(
+            buffer_index=intermed_cb,
+            data_format=data_format,
+            page_size=tile_size,
+            tile=tile_descriptor,
+        )
+        intermed_cb_descriptor = ttnn.CBDescriptor(
+            total_size=2 * tile_size,  # 2 tiles
+            core_ranges=all_cores,
+            format_descriptors=[intermed_format],
+        )
+
+        # Output CB (backed by output tensor)
+        out_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(out_cb, output_tensor)
+
+        # Named compile-time args for NCRISC
+        ncrisc_named_compile_time_args = [
+            ("gated_local_reduce_in0_cb", in0_cb),
+            ("gated_local_reduce_in1_cb", in1_cb),
+            ("gated_local_reduce_group1_num_tiles", group1_num_tiles),
+            ("gated_local_reduce_group2_num_tiles", group2_num_tiles),
+        ]
+
+        # Named compile-time args for TRISC
+        trisc_named_compile_time_args = [
+            ("gated_local_reduce_in0_cb", in0_cb),
+            ("gated_local_reduce_in1_cb", in1_cb),
+            ("gated_local_reduce_intermed_cb", intermed_cb),
+            ("gated_local_reduce_out_cb", out_cb),
+            ("gated_local_reduce_group1_num_tiles", group1_num_tiles),
+            ("gated_local_reduce_group2_num_tiles", group2_num_tiles),
+        ]
+
+        unified_kernel = UnifiedKernelDescriptor(
+            kernel_source="models/demos/deepseek_v3_b1/fused_ops/gated_local_reduce/kernels/gated_local_reduce_kernel.cpp",
+            core_ranges=all_cores,
+            ncrisc_named_compile_time_args=ncrisc_named_compile_time_args,
+            brisc_named_compile_time_args=[],
+            trisc_named_compile_time_args=trisc_named_compile_time_args,
+            trisc_compute_config=ttnn.ComputeConfigDescriptor(
+                math_fidelity=ttnn.MathFidelity.HiFi4,
+                math_approx_mode=True,  # SiLU uses approximation
+                fp32_dest_acc_en=False,
+                dst_full_sync_en=False,
+            ),
+            unified_compile_time_core_descriptors=[
+                UnifiedCompileTimeCoreDescriptor(
+                    named_compile_time_arg="is_active_core",
+                    core_range=all_cores,
+                    value=1,
+                    other_value=0,
+                ),
+            ],
+        )
+
+        program_descriptor = ttnn.ProgramDescriptor(
+            kernels=unified_kernel.get_kernel_descriptors().kernels,
+            cbs=[in0_cb_descriptor, in1_cb_descriptor, intermed_cb_descriptor, out_cb_descriptor],
+        )
+
+        io_tensors = [input_tensor_group1, input_tensor_group2, output_tensor]
+        output = ttnn.generic_op(io_tensors, program_descriptor)
+
+        return output

--- a/models/demos/deepseek_v3_b1/fused_ops/gated_local_reduce/op.py
+++ b/models/demos/deepseek_v3_b1/fused_ops/gated_local_reduce/op.py
@@ -92,6 +92,12 @@ class GatedLocalReduceOp:
         intermed_cb = 2  # Intermediate: holds 2 tiles (group1 result + group2 result)
         out_cb = 3  # Final output
 
+        # GatedReduce requires all CBs to share the same data format (binary_op_init_common called once)
+        assert input_tensor_group1.dtype == input_tensor_group2.dtype == output_tensor.dtype, (
+            f"GatedReduce requires matching dtypes: group1={input_tensor_group1.dtype}, "
+            f"group2={input_tensor_group2.dtype}, output={output_tensor.dtype}"
+        )
+
         # Get tile info from output tensor for intermediate buffer
         output_tile = output_tensor.tile
         tile_h, tile_w = output_tile.tile_shape

--- a/models/demos/deepseek_v3_b1/fused_ops/gated_local_reduce/op.py
+++ b/models/demos/deepseek_v3_b1/fused_ops/gated_local_reduce/op.py
@@ -95,7 +95,7 @@ class GatedLocalReduceOp:
         # Get tile info from output tensor for intermediate buffer
         output_tile = output_tensor.tile
         tile_h, tile_w = output_tile.tile_shape
-        data_format = ttnn.DataType.BFLOAT16
+        data_format = output_tensor.dtype
         tile_size = output_tile.get_tile_size(data_format)
         tile_descriptor = ttnn.TileDescriptor(tile_h, tile_w, False)
 

--- a/models/demos/deepseek_v3_b1/fused_ops/gated_local_reduce_down_proj/__init__.py
+++ b/models/demos/deepseek_v3_b1/fused_ops/gated_local_reduce_down_proj/__init__.py
@@ -1,0 +1,7 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+from .op import GatedLocalReduceDownProjOp
+
+__all__ = ["GatedLocalReduceDownProjOp"]

--- a/models/demos/deepseek_v3_b1/fused_ops/gated_local_reduce_down_proj/kernels/gated_local_reduce_down_proj_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/fused_ops/gated_local_reduce_down_proj/kernels/gated_local_reduce_down_proj_kernel.cpp
@@ -1,0 +1,421 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+// SPDX-License-Identifier: Apache-2.0
+
+// Gated Local Reduce + Down Projection unified kernel
+//
+// Fuses: Input Gather + GatedLocalReduce + Mcast1 + Mcast2 + Matmul + ResidualAdd + Output Gather
+//
+// Sender core (12,9):
+//   BRISC:  input_gather_g1 receive, input_gather_g2 receive,
+//           mcast1(mcast_src) → 130-core grid,
+//           mcast2(residual) → 130-core grid,
+//           output gather_receive
+//   TRISC:  gated reduce → mcast_src
+//   NCRISC: idle (for gated reduce); setup_sharded_buffer for mcast1/mcast2 sources
+//
+// Matmul cores (112):
+//   NCRISC: setup_sharded_buffer(input_src, weights), input_gather send,
+//           mcast1 receive, mcast2 receive, output gather send
+//   TRISC:  matmul + residual add
+//
+// CB Layout:
+//   CB 0:  group1 gather dest / reduce input (sender core, tensor-backed)
+//   CB 1:  group2 gather dest / reduce input (sender core, tensor-backed)
+//   CB 2:  intermediate (sender core, 2 tiles, manual)
+//   CB 3:  mcast1 source (sender core, manual, TRISC-filled)
+//   CB 4:  mcast1 destination / matmul in0 (all 130 cores, manual)
+//   CB 5:  matmul weights (112 matmul cores, tensor-backed)
+//   CB 6:  matmul output (112 matmul cores, manual)
+//   CB 7:  output gather destination (sender core, tensor-backed)
+//   CB 8:  input source group1 (g1 source cores, tensor-backed)
+//   CB 9:  input source group2 (g2 source cores, tensor-backed)
+//   CB 10: mcast2 source / residual input (sender core, tensor-backed)
+//   CB 11: mcast2 destination (all 130 cores, manual)
+//   CB 12: residual add output (112 matmul cores, manual)
+
+#include "../../../unified_kernels/kernel_op_api.hpp"
+#include "../../../unified_kernels/kernel_utils.hpp"
+#include "../../../unified_kernels/gated_reduce.hpp"
+#include "../../../unified_kernels/mcast.hpp"
+#include "../../../unified_kernels/matmul.hpp"
+#include "../../../unified_kernels/gather.hpp"
+#include "../../../unified_kernels/residual_add.hpp"
+
+struct Core {
+    static constexpr bool is_input_gather_sender_g1 = get_named_compile_time_arg_val("is_input_gather_sender_g1") == 1;
+    static constexpr bool is_input_gather_sender_g2 = get_named_compile_time_arg_val("is_input_gather_sender_g2") == 1;
+    static constexpr bool is_gated_reduce_core = get_named_compile_time_arg_val("is_gated_reduce_core") == 1;
+    static constexpr bool is_mcast_sender_core = get_named_compile_time_arg_val("is_mcast_sender_core") == 1;
+    static constexpr bool is_mcast_receiver_core = get_named_compile_time_arg_val("is_mcast_receiver_core") == 1;
+    static constexpr bool is_matmul_core = get_named_compile_time_arg_val("is_matmul_core") == 1;
+    static constexpr bool is_gather_receiver_core = get_named_compile_time_arg_val("is_gather_receiver_core") == 1;
+    static constexpr bool gather_use_per_core_sender_idx =
+        get_named_compile_time_arg_val("gather_use_per_core_sender_idx") == 1;
+};
+
+void kernel_main() {
+// ============================================================================
+// NCRISC (Reader)
+// ============================================================================
+#if defined(COMPILE_FOR_NCRISC)
+    // Input gather g1 sender args
+    deepseek_b1_ops::Gather::SenderArgs ig_g1_args{
+        get_named_compile_time_arg_val("ig_g1_dest_noc_x"),
+        get_named_compile_time_arg_val("ig_g1_dest_noc_y"),
+        get_named_compile_time_arg_val("ig_g1_data_size_bytes"),
+        get_named_compile_time_arg_val("ig_g1_receiver_semaphore_id"),
+        get_named_compile_time_arg_val("ig_g1_src_cb"),
+        get_named_compile_time_arg_val("ig_g1_src_num_pages"),
+        0,
+        0,
+        0,
+        0,
+        1,
+        get_named_compile_time_arg_val("ig_g1_receiver_data_addr"),
+        get_named_compile_time_arg_val("ig_g1_sender_idx"),
+    };
+
+    // Input gather g2 sender args
+    deepseek_b1_ops::Gather::SenderArgs ig_g2_args{
+        get_named_compile_time_arg_val("ig_g2_dest_noc_x"),
+        get_named_compile_time_arg_val("ig_g2_dest_noc_y"),
+        get_named_compile_time_arg_val("ig_g2_data_size_bytes"),
+        get_named_compile_time_arg_val("ig_g2_receiver_semaphore_id"),
+        get_named_compile_time_arg_val("ig_g2_src_cb"),
+        get_named_compile_time_arg_val("ig_g2_src_num_pages"),
+        0,
+        0,
+        0,
+        0,
+        1,
+        get_named_compile_time_arg_val("ig_g2_receiver_data_addr"),
+        get_named_compile_time_arg_val("ig_g2_sender_idx"),
+    };
+
+    // Gated reduce reader args (NCRISC no-op)
+    using GatedReduceCTArgs = deepseek_b1_ops::GatedReduce::ReaderCTArgs;
+    deepseek_b1_ops::GatedReduce::ReaderArgs gated_reduce_args{};
+
+    // Mcast1 receiver args
+    using McastCTArgs = deepseek_b1_ops::Mcast::ReceiverCTArgs;
+    deepseek_b1_ops::Mcast::ReceiverArgs mcast_args{
+        get_named_compile_time_arg_val("mcast_data_receiver_semaphore"),
+        get_named_compile_time_arg_val("mcast_dst_cb"),
+        get_named_compile_time_arg_val("mcast_dst_num_pages"),
+    };
+
+    // Mcast2 receiver args
+    using Mcast2CTArgs = deepseek_b1_ops::Mcast::ReceiverCTArgs;
+    deepseek_b1_ops::Mcast::ReceiverArgs mcast2_args{
+        get_named_compile_time_arg_val("mcast2_data_receiver_semaphore"),
+        get_named_compile_time_arg_val("mcast2_dst_cb"),
+        get_named_compile_time_arg_val("mcast2_dst_num_pages"),
+    };
+
+    // Matmul CTArgs (NCRISC is no-op for matmul compute)
+    using MatmulCTArgs = deepseek_b1_ops::Matmul::ReaderCTArgs;
+    deepseek_b1_ops::Matmul::ReaderArgs matmul_args{};
+
+    // Output gather sender args
+    deepseek_b1_ops::Gather::SenderArgs og_args{
+        get_named_compile_time_arg_val("gather_dest_noc_x"),
+        get_named_compile_time_arg_val("gather_dest_noc_y"),
+        get_named_compile_time_arg_val("gather_data_size_bytes"),
+        get_named_compile_time_arg_val("gather_receiver_semaphore_id"),
+        get_named_compile_time_arg_val("gather_src_cb"),
+        get_named_compile_time_arg_val("gather_src_num_pages"),
+        get_named_compile_time_arg_val("gather_sender_grid_start_x"),
+        get_named_compile_time_arg_val("gather_sender_grid_start_y"),
+        get_named_compile_time_arg_val("gather_sender_grid_end_x"),
+        get_named_compile_time_arg_val("gather_sender_grid_end_y"),
+        get_named_compile_time_arg_val("gather_row_major"),
+        get_named_compile_time_arg_val("gather_receiver_data_addr"),
+        get_named_compile_time_arg_val("gather_sender_idx"),
+    };
+
+// ============================================================================
+// BRISC (Writer)
+// ============================================================================
+#elif defined(COMPILE_FOR_BRISC)
+    // Input gather g1 receiver args
+    deepseek_b1_ops::Gather::ReceiverArgs ig_g1_args{
+        get_named_compile_time_arg_val("ig_g1_noc0_num_senders"),
+        0,
+        get_named_compile_time_arg_val("ig_g1_noc0_receiver_semaphore_id"),
+        get_named_compile_time_arg_val("ig_g1_noc1_receiver_semaphore_id"),
+        get_named_compile_time_arg_val("ig_g1_dst_cb"),
+        get_named_compile_time_arg_val("ig_g1_dst_num_pages"),
+    };
+
+    // Input gather g2 receiver args
+    deepseek_b1_ops::Gather::ReceiverArgs ig_g2_args{
+        get_named_compile_time_arg_val("ig_g2_noc0_num_senders"),
+        0,
+        get_named_compile_time_arg_val("ig_g2_noc0_receiver_semaphore_id"),
+        get_named_compile_time_arg_val("ig_g2_noc1_receiver_semaphore_id"),
+        get_named_compile_time_arg_val("ig_g2_dst_cb"),
+        get_named_compile_time_arg_val("ig_g2_dst_num_pages"),
+    };
+
+    // Gated reduce writer args (BRISC no-op)
+    using GatedReduceCTArgs = deepseek_b1_ops::GatedReduce::WriterCTArgs;
+    deepseek_b1_ops::GatedReduce::WriterArgs gated_reduce_args{};
+
+    // Mcast1 sender args
+    using McastCTArgs = deepseek_b1_ops::Mcast::SenderCTArgs<
+        get_named_compile_time_arg_val("mcast_num_cores"),
+        get_named_compile_time_arg_val("mcast_is_part_of_receiver_grid") == 1,
+        /*Loopback=*/false>;
+
+    constexpr uint32_t mcast_src_cb = get_named_compile_time_arg_val("mcast_src_cb");
+    constexpr uint32_t mcast_dst_cb = get_named_compile_time_arg_val("mcast_dst_cb");
+    deepseek_b1_ops::Mcast::SenderArgs mcast_args{
+        get_named_compile_time_arg_val("mcast_dest_noc_start_x"),
+        get_named_compile_time_arg_val("mcast_dest_noc_start_y"),
+        get_named_compile_time_arg_val("mcast_dest_noc_end_x"),
+        get_named_compile_time_arg_val("mcast_dest_noc_end_y"),
+        get_named_compile_time_arg_val("mcast_data_sender_semaphore"),
+        get_named_compile_time_arg_val("mcast_data_receiver_semaphore"),
+        get_named_compile_time_arg_val("mcast_data_size_bytes"),
+        mcast_src_cb,
+        get_named_compile_time_arg_val("mcast_src_num_pages"),
+        get_read_ptr(mcast_src_cb),
+        get_write_ptr(mcast_dst_cb),
+    };
+
+    // Mcast2 sender args (same grid, different semaphores and CBs)
+    using Mcast2CTArgs = McastCTArgs;
+
+    constexpr uint32_t mcast2_src_cb = get_named_compile_time_arg_val("mcast2_src_cb");
+    constexpr uint32_t mcast2_dst_cb = get_named_compile_time_arg_val("mcast2_dst_cb");
+    deepseek_b1_ops::Mcast::SenderArgs mcast2_args{
+        get_named_compile_time_arg_val("mcast_dest_noc_start_x"),
+        get_named_compile_time_arg_val("mcast_dest_noc_start_y"),
+        get_named_compile_time_arg_val("mcast_dest_noc_end_x"),
+        get_named_compile_time_arg_val("mcast_dest_noc_end_y"),
+        get_named_compile_time_arg_val("mcast2_data_sender_semaphore"),
+        get_named_compile_time_arg_val("mcast2_data_receiver_semaphore"),
+        get_named_compile_time_arg_val("mcast2_data_size_bytes"),
+        mcast2_src_cb,
+        get_named_compile_time_arg_val("mcast2_src_num_pages"),
+        get_read_ptr(mcast2_src_cb),
+        get_write_ptr(mcast2_dst_cb),
+    };
+
+    // Matmul CTArgs (BRISC is no-op for matmul)
+    using MatmulCTArgs = deepseek_b1_ops::Matmul::WriterCTArgs;
+    deepseek_b1_ops::Matmul::WriterArgs matmul_args{};
+
+    // Output gather receiver args
+    deepseek_b1_ops::Gather::ReceiverArgs og_args{
+        get_named_compile_time_arg_val("gather_noc0_num_senders"),
+        get_named_compile_time_arg_val("gather_noc1_num_senders"),
+        get_named_compile_time_arg_val("gather_noc0_receiver_semaphore_id"),
+        get_named_compile_time_arg_val("gather_noc1_receiver_semaphore_id"),
+        get_named_compile_time_arg_val("gather_dst_cb"),
+        get_named_compile_time_arg_val("gather_dst_num_pages"),
+    };
+
+// ============================================================================
+// TRISC (Compute)
+// ============================================================================
+#elif defined(COMPILE_FOR_TRISC)
+    // Input gather compute args (no-op)
+    deepseek_b1_ops::Gather::ComputeArgs ig_g1_args{};
+    deepseek_b1_ops::Gather::ComputeArgs ig_g2_args{};
+
+    // Mcast1 CTArgs (no-op for TRISC)
+    using McastCTArgs = deepseek_b1_ops::Mcast::ComputeCTArgs;
+    deepseek_b1_ops::Mcast::ComputeArgs mcast_args{};
+
+    // Mcast2 CTArgs (no-op for TRISC)
+    using Mcast2CTArgs = deepseek_b1_ops::Mcast::ComputeCTArgs;
+    deepseek_b1_ops::Mcast::ComputeArgs mcast2_args{};
+
+    // Gated reduce compute args
+    using GatedReduceCTArgs = deepseek_b1_ops::GatedReduce::ComputeCTArgs<
+        get_named_compile_time_arg_val("gated_reduce_tiles_per_k"),
+        get_named_compile_time_arg_val("gated_reduce_k_num_tiles")>;
+    deepseek_b1_ops::GatedReduce::ComputeArgs gated_reduce_args{
+        get_named_compile_time_arg_val("gated_reduce_group1_cb"),
+        get_named_compile_time_arg_val("gated_reduce_group2_cb"),
+        get_named_compile_time_arg_val("gated_reduce_intermed_cb"),
+        get_named_compile_time_arg_val("gated_reduce_mcast_src_cb"),
+    };
+
+    // Matmul CTArgs
+    using MatmulCTArgs =
+        deepseek_b1_ops::Matmul::ComputeCTArgs<get_named_compile_time_arg_val("matmul_out_w_per_core")>;
+    deepseek_b1_ops::Matmul::ComputeArgs matmul_args{
+        get_named_compile_time_arg_val("matmul_in0"),
+        get_named_compile_time_arg_val("matmul_in1"),
+        get_named_compile_time_arg_val("matmul_out"),
+        get_named_compile_time_arg_val("matmul_k_num_tiles"),
+    };
+
+    // Output gather compute args (no-op)
+    deepseek_b1_ops::Gather::ComputeArgs og_args{};
+#endif
+
+    // ========================================================================
+    // Setup sharded buffers (NCRISC only)
+    // ========================================================================
+#if defined(COMPILE_FOR_NCRISC)
+    // Input source buffers on source cores
+    if constexpr (Core::is_input_gather_sender_g1) {
+        constexpr uint32_t ig_g1_src_cb = get_named_compile_time_arg_val("ig_g1_src_cb");
+        unified_kernels::setup_sharded_buffer(ig_g1_src_cb, 1);
+    }
+    if constexpr (Core::is_input_gather_sender_g2) {
+        constexpr uint32_t ig_g2_src_cb = get_named_compile_time_arg_val("ig_g2_src_cb");
+        unified_kernels::setup_sharded_buffer(ig_g2_src_cb, 1);
+    }
+    // Mcast2 source (residual input on sender core)
+    if constexpr (Core::is_mcast_sender_core) {
+        constexpr uint32_t m2_src_cb = get_named_compile_time_arg_val("mcast2_src_cb");
+        constexpr uint32_t m2_src_pages = get_named_compile_time_arg_val("mcast2_src_num_pages");
+        unified_kernels::setup_sharded_buffer(m2_src_cb, m2_src_pages);
+    }
+    // Matmul weight buffers (112 matmul cores)
+    if constexpr (Core::is_matmul_core) {
+        constexpr uint32_t matmul_in1 = get_named_compile_time_arg_val("matmul_in1");
+        constexpr uint32_t matmul_k_num_tiles = get_named_compile_time_arg_val("matmul_k_num_tiles");
+        constexpr uint32_t matmul_out_w_per_core = get_named_compile_time_arg_val("matmul_out_w_per_core");
+        unified_kernels::setup_sharded_buffer(matmul_in1, matmul_k_num_tiles * matmul_out_w_per_core);
+    }
+#endif
+
+    // ========================================================================
+    // Input Gather Group1: source cores -> (12,9) group1_cb
+    // ========================================================================
+    {
+        DeviceZoneScopedN("INPUT_GATHER_G1");
+        deepseek_b1_ops::Gather::Op<
+            Core::is_input_gather_sender_g1,
+            Core::is_gated_reduce_core,
+            /*pop_src=*/true,
+            Core::is_input_gather_sender_g1>
+            input_gather_g1;
+        input_gather_g1(ig_g1_args);
+    }
+
+    // ========================================================================
+    // Input Gather Group2: source cores -> (12,9) group2_cb
+    // ========================================================================
+    {
+        DeviceZoneScopedN("INPUT_GATHER_G2");
+        deepseek_b1_ops::Gather::Op<
+            Core::is_input_gather_sender_g2,
+            Core::is_gated_reduce_core,
+            /*pop_src=*/true,
+            Core::is_input_gather_sender_g2>
+            input_gather_g2;
+        input_gather_g2(ig_g2_args);
+    }
+
+    // ========================================================================
+    // Gated Local Reduce (TRISC on sender core)
+    // ========================================================================
+    {
+        DeviceZoneScopedN("GATED_REDUCE");
+        deepseek_b1_ops::GatedReduce::Op<GatedReduceCTArgs, Core::is_gated_reduce_core> gated_reduce;
+        gated_reduce(gated_reduce_args);
+    }
+
+    // ========================================================================
+    // Mcast1: sender (12,9) -> 129 receivers in 13x10 grid
+    // Broadcasts hidden state [1, K] to all cores
+    // ========================================================================
+    deepseek_b1_ops::Mcast::Op<
+        McastCTArgs,
+        Core::is_mcast_sender_core,
+        Core::is_mcast_receiver_core,
+        Core::is_mcast_receiver_core,
+        /*pop_src=*/true>
+        mcast;
+#if defined(COMPILE_FOR_BRISC)
+    if constexpr (Core::is_mcast_sender_core) {
+        mcast.init(mcast_args);
+    }
+#endif
+    {
+        DeviceZoneScopedN("MCAST1");
+        mcast(mcast_args);
+    }
+#if defined(COMPILE_FOR_BRISC)
+    if constexpr (Core::is_mcast_sender_core) {
+        mcast.teardown();
+    }
+#endif
+
+    // ========================================================================
+    // Mcast2: sender (12,9) -> 129 receivers in 13x10 grid
+    // Broadcasts residual input [1, N] to all cores
+    // ========================================================================
+    deepseek_b1_ops::Mcast::Op<
+        Mcast2CTArgs,
+        Core::is_mcast_sender_core,
+        Core::is_mcast_receiver_core,
+        Core::is_mcast_receiver_core,
+        /*pop_src=*/true>
+        mcast2;
+#if defined(COMPILE_FOR_BRISC)
+    if constexpr (Core::is_mcast_sender_core) {
+        mcast2.init(mcast2_args);
+    }
+#endif
+    {
+        DeviceZoneScopedN("MCAST2");
+        mcast2(mcast2_args);
+    }
+#if defined(COMPILE_FOR_BRISC)
+    if constexpr (Core::is_mcast_sender_core) {
+        mcast2.teardown();
+    }
+#endif
+
+    // ========================================================================
+    // Matmul: [1, K] x [K, N_per_core] -> [1, N_per_core] on 112 cores
+    // ========================================================================
+    {
+        DeviceZoneScopedN("MATMUL");
+        deepseek_b1_ops::Matmul::Op<MatmulCTArgs, Core::is_matmul_core, /*pop_in0=*/true, /*pop_in1=*/false> matmul;
+        matmul(matmul_args);
+    }
+
+    // ========================================================================
+    // Residual add: matmul_out + shard(residual) -> residual_add_out on 112 matmul cores
+    // Each core indexes into the full [1, N] CB11 at offset core_idx * out_w_per_core
+    // ========================================================================
+    using ResidualAddCTArgs =
+        deepseek_b1_ops::ResidualAdd::ComputeCTArgs<get_named_compile_time_arg_val("residual_add_out_w")>;
+    deepseek_b1_ops::ResidualAdd::RTArgs residual_add_args{
+#if defined(COMPILE_FOR_TRISC)
+        get_named_compile_time_arg_val("residual_add_in0"),
+        get_named_compile_time_arg_val("residual_add_in1"),
+        get_named_compile_time_arg_val("residual_add_out"),
+        get_named_compile_time_arg_val("residual_add_total_in1_tiles"),
+        get_named_compile_time_arg_val("gather_sender_idx"),
+#endif
+    };
+    {
+        DeviceZoneScopedN("ADD");
+        deepseek_b1_ops::ResidualAdd::Op<ResidualAddCTArgs, Core::is_matmul_core> residual_add;
+        residual_add(residual_add_args);
+    }
+
+    // ========================================================================
+    // Output Gather: 112 matmul cores -> (12,9)
+    // Reads from residual_add_out_cb (CB 12)
+    // ========================================================================
+    {
+        DeviceZoneScopedN("OUTPUT_GATHER");
+        deepseek_b1_ops::Gather::Op<
+            Core::is_matmul_core,
+            Core::is_gather_receiver_core,
+            /*pop_src=*/true,
+            Core::gather_use_per_core_sender_idx>
+            output_gather;
+        output_gather(og_args);
+    }
+}

--- a/models/demos/deepseek_v3_b1/fused_ops/gated_local_reduce_down_proj/op.py
+++ b/models/demos/deepseek_v3_b1/fused_ops/gated_local_reduce_down_proj/op.py
@@ -1,0 +1,830 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Gated Local Reduce + Down Projection fused operation.
+
+Fuses Input Gather + GatedLocalReduce + Mcast1 + Mcast2 + Matmul + ResidualAdd + Output Gather:
+  1. Input gather: pull [1,32] tiles from 32 source cores (16 per group) to (12,9)
+  2. Gated reduce on sender core (12,9):
+     For each K-tile position:
+       SiLU(reduce(group1[k])) * reduce(group2[k]) → mcast_src[k]
+  3. Mcast1: broadcast [1, K] from (12,9) to 130-core grid
+  4. Mcast2: broadcast add input [1, N] from (12,9) to 130-core grid
+  5. Matmul: [1, K] x [K, N_per_core] on 112 matmul cores
+  6. Residual add: matmul_out + shard(residual) on 112 matmul cores
+  7. Output gather: collect [1, N_per_core] from 112 cores to [1, N] on (12,9)
+
+CB Layout:
+  CB 0:  group1 gather dest / reduce input (sender, tensor-backed)
+  CB 1:  group2 gather dest / reduce input (sender, tensor-backed)
+  CB 2:  intermediate (sender, 2 tiles, manual)
+  CB 3:  mcast1 source (sender, k_num_tiles tiles, manual, TRISC-filled)
+  CB 4:  mcast1 destination / matmul in0 (all 130 cores, manual)
+  CB 5:  matmul weights (112 matmul cores, tensor-backed)
+  CB 6:  matmul output (112 matmul cores, manual)
+  CB 7:  output gather destination (sender, tensor-backed)
+  CB 8:  input source group1 (g1 source cores, tensor-backed)
+  CB 9:  input source group2 (g2 source cores, tensor-backed)
+  CB 10: mcast2 source / add input (sender core, tensor-backed)
+  CB 11: mcast2 destination (all 130 cores, manual)
+  CB 12: residual add output (112 matmul cores, manual)
+"""
+
+from dataclasses import dataclass
+from typing import Any
+
+import torch.nn.functional as F
+
+import ttnn
+from models.demos.deepseek_v3_b1.fused_ops.down_proj.op import DownProj
+from models.demos.deepseek_v3_b1.fused_ops.face_view_utils import FACE_HEIGHT, FACE_WIDTH, can_use_face_view
+from models.demos.deepseek_v3_b1.unified_kernel_descriptor import (
+    PerCoreCompileTimeDescriptor,
+    UnifiedCompileTimeCoreDescriptor,
+    UnifiedKernelDescriptor,
+)
+
+
+@dataclass
+class _GatedReduceDownProjContext:
+    """Holds all computed values needed by GatedLocalReduceDownProjOp helper methods."""
+
+    # Device & format
+    device: Any
+    data_format: Any
+    input_tile: Any
+    input_tile_size: int
+    tile_1x32_size: int
+    tile_1x32_descriptor: Any
+
+    # Grids
+    mcast_gather_core: Any
+    mcast_gather_core_grid: Any
+    mcast_grid: Any
+    all_cores: Any
+    matmul_core_grid: Any
+    mcast_receiver_grid: Any
+    g1_source_grid: Any
+    g2_source_grid: Any
+    g1_source_cores: list
+    g2_source_cores: list
+    num_g1_sources: int
+    num_g2_sources: int
+    num_mcast_cores: int
+
+    # Dimensions
+    out_w_per_core: int
+    tiles_per_k: int
+    k_num_tiles: int
+
+    # Face-view
+    use_face_view: bool
+    face_tile_desc: Any
+    face_tile_size: Any
+    kernel_tiles_per_k: int
+    kernel_k_num_tiles: int
+    mcast_src_num_pages: int
+    reduce_tile_size: int
+
+    # CB indices
+    group1_cb: int
+    group2_cb: int
+    intermed_cb: int
+    mcast_src_cb: int
+    mcast_dst_cb: int
+    matmul_in1_cb: int
+    matmul_out_cb: int
+    gather_dst_cb: int
+    input_src_g1_cb: int
+    input_src_g2_cb: int
+    residual_add_mcast_src_cb: int
+    residual_add_mcast_dst_cb: int
+    residual_add_out_cb: int
+
+    # Derived sizes
+    mcast_data_size_bytes: int
+    mcast_is_part_of_receiver_grid: bool
+    total_residual_add_tiles: int
+    residual_add_mcast_data_size_bytes: int
+    gather_data_size_bytes: int
+    gather_src_num_pages: int
+    gather_dst_num_pages: int
+    gather_noc0_num_senders: int
+    gather_noc1_num_senders: int
+    ig_data_size_bytes: int
+    total_input_tiles: int
+
+    # Semaphore IDs
+    mcast_data_sender_semaphore_id: int
+    mcast_data_receiver_semaphore_id: int
+    gather_noc0_receiver_semaphore_id: int
+    gather_noc1_receiver_semaphore_id: int
+    ig_g1_receiver_semaphore_id: int
+    ig_g2_receiver_semaphore_id: int
+    ig_g1_noc1_receiver_semaphore_id: int
+    ig_g2_noc1_receiver_semaphore_id: int
+    mcast2_data_sender_semaphore_id: int
+    mcast2_data_receiver_semaphore_id: int
+
+    # Addresses
+    gather_receiver_data_addr: int
+    ig_g1_receiver_data_addr: int
+    ig_g2_receiver_data_addr: int
+
+    # NOC coordinates
+    gather_dest_noc_core: Any
+    mcast_dest_noc_start: Any
+    mcast_dest_noc_end: Any
+
+    # Input tensors (needed for CB descriptors)
+    group1_src_tensor: Any
+    group2_src_tensor: Any
+    group1_dst_tensor: Any
+    group2_dst_tensor: Any
+    weights_tensor: Any
+    add_input_tensor: Any
+    output_tensor: Any
+
+
+class GatedLocalReduceDownProjOp:
+    """
+    Fused Input Gather + GatedLocalReduce + DownProj operation.
+
+    Computes: SiLU(sum(group1)) * sum(group2) @ weights
+    where group1/group2 inputs are gathered from remote source cores.
+    """
+
+    @staticmethod
+    def golden(group1_inputs, group2_inputs, weights, add_input):
+        """
+        PyTorch reference implementation.
+
+        Args:
+            group1_inputs: List of E tensors, each [1, K]
+            group2_inputs: List of E tensors, each [1, K]
+            weights: [K, N] tensor
+            add_input: [1, N] tensor (bias)
+
+        Returns:
+            [1, N] tensor
+        """
+        g1_sum = group1_inputs[0]
+        for inp in group1_inputs[1:]:
+            g1_sum = g1_sum + inp
+        g1_silu = F.silu(g1_sum)
+
+        g2_sum = group2_inputs[0]
+        for inp in group2_inputs[1:]:
+            g2_sum = g2_sum + inp
+
+        hidden = g1_silu * g2_sum
+        return hidden @ weights + add_input
+
+    @staticmethod
+    def _setup_dimensions(
+        group1_src_tensor,
+        group2_src_tensor,
+        group1_dst_tensor,
+        group2_dst_tensor,
+        weights_tensor,
+        add_input_tensor,
+        output_tensor,
+        tiles_per_k,
+        k_num_tiles,
+        use_face_view,
+    ):
+        """Compute all dimensions, grids, face-view params, CB indices, semaphores, and addresses."""
+        device = group1_src_tensor.device()
+        data_format = group1_src_tensor.dtype
+
+        # Tile definitions
+        TILE_1x32 = ttnn.Tile((1, 32))
+        tile_1x32_size = TILE_1x32.get_tile_size(data_format)
+        tile_1x32_descriptor = ttnn.TileDescriptor(TILE_1x32)
+
+        # Core grid configuration
+        mcast_gather_core = DownProj.MCAST_GATHER_CORE
+        mcast_gather_core_grid = ttnn.CoreRangeSet([ttnn.CoreRange(mcast_gather_core, mcast_gather_core)])
+
+        mcast_grid = ttnn.CoreRange(
+            ttnn.CoreCoord(0, 0),
+            ttnn.CoreCoord(DownProj.MCAST_GRID_X - 1, DownProj.MCAST_GRID_Y - 1),
+        )
+        mcast_grid_set = ttnn.CoreRangeSet([mcast_grid])
+        num_mcast_cores = DownProj.MCAST_GRID_X * DownProj.MCAST_GRID_Y  # 130
+
+        matmul_core_grid = DownProj.build_matmul_core_grid()
+        mcast_receiver_grid = DownProj.build_mcast_receiver_grid()
+        all_cores = mcast_grid_set
+
+        # NOC coordinates
+        gather_dest_noc_core = device.worker_core_from_logical_core(mcast_gather_core)
+        mcast_dest_noc_start = device.worker_core_from_logical_core(mcast_grid.start)
+        mcast_dest_noc_end = device.worker_core_from_logical_core(mcast_grid.end)
+
+        # Input gather source core grids
+        g1_source_grid = group1_src_tensor.memory_config().shard_spec.grid
+        g2_source_grid = group2_src_tensor.memory_config().shard_spec.grid
+        g1_source_cores = ttnn.corerange_to_cores(g1_source_grid)
+        g2_source_cores = ttnn.corerange_to_cores(g2_source_grid)
+        num_g1_sources = len(g1_source_cores)
+        num_g2_sources = len(g2_source_cores)
+
+        # Dimension parameters
+        input_tile = group1_src_tensor.get_tile()
+        tile_h, tile_w = input_tile.tile_shape
+        input_tile_size = input_tile.get_tile_size(data_format)
+
+        weights_shard_spec = weights_tensor.memory_config().shard_spec
+        n_per_core = weights_shard_spec.shape[1]
+        out_w_per_core = n_per_core // TILE_1x32.tile_shape[1]
+
+        # Face-view optimization
+        if use_face_view is None:
+            use_face_view = can_use_face_view(tile_h, tile_w, tiles_per_k, k_num_tiles)
+
+        if use_face_view:
+            face_tile = ttnn.Tile([FACE_HEIGHT, FACE_WIDTH])
+            face_tile_desc = ttnn.TileDescriptor(FACE_HEIGHT, FACE_WIDTH, False)
+            face_tile_size = face_tile.get_tile_size(data_format)
+            kernel_tiles_per_k = tiles_per_k
+            kernel_k_num_tiles = 1
+            mcast_src_num_pages = 1
+            reduce_tile_size = face_tile_size
+        else:
+            face_tile_desc = None
+            face_tile_size = None
+            kernel_tiles_per_k = tiles_per_k
+            kernel_k_num_tiles = k_num_tiles
+            mcast_src_num_pages = k_num_tiles
+            reduce_tile_size = input_tile_size
+
+        # CB indices
+        group1_cb = 0
+        group2_cb = 1
+        intermed_cb = 2
+        mcast_src_cb = 3
+        mcast_dst_cb = 4
+        matmul_in1_cb = 5
+        matmul_out_cb = 6
+        gather_dst_cb = 7
+        input_src_g1_cb = 8
+        input_src_g2_cb = 9
+        residual_add_mcast_src_cb = 10
+        residual_add_mcast_dst_cb = 11
+        residual_add_out_cb = 12
+
+        # Derived sizes
+        mcast_data_size_bytes = k_num_tiles * input_tile_size
+        mcast_is_part_of_receiver_grid = mcast_grid.contains(mcast_gather_core)
+        total_residual_add_tiles = DownProj.NUM_MATMUL_CORES * out_w_per_core
+        residual_add_mcast_data_size_bytes = total_residual_add_tiles * tile_1x32_size
+        gather_data_size_bytes = out_w_per_core * tile_1x32_size
+        gather_src_num_pages = out_w_per_core
+        gather_dst_num_pages = DownProj.NUM_MATMUL_CORES * out_w_per_core
+        gather_noc0_num_senders = DownProj.NUM_MATMUL_CORES
+        gather_noc1_num_senders = 0
+        ig_data_size_bytes = input_tile_size
+        total_input_tiles = tiles_per_k * k_num_tiles
+
+        # Semaphore IDs
+        mcast_data_sender_semaphore_id = 0
+        mcast_data_receiver_semaphore_id = 1
+        gather_noc0_receiver_semaphore_id = 2
+        gather_noc1_receiver_semaphore_id = 3
+        ig_g1_receiver_semaphore_id = 4
+        ig_g2_receiver_semaphore_id = 5
+        ig_g1_noc1_receiver_semaphore_id = 6
+        ig_g2_noc1_receiver_semaphore_id = 7
+        mcast2_data_sender_semaphore_id = 8
+        mcast2_data_receiver_semaphore_id = 9
+
+        # Buffer addresses
+        gather_receiver_data_addr = output_tensor.buffer_address()
+        ig_g1_receiver_data_addr = group1_dst_tensor.buffer_address()
+        ig_g2_receiver_data_addr = group2_dst_tensor.buffer_address()
+
+        return _GatedReduceDownProjContext(
+            device=device,
+            data_format=data_format,
+            input_tile=input_tile,
+            input_tile_size=input_tile_size,
+            tile_1x32_size=tile_1x32_size,
+            tile_1x32_descriptor=tile_1x32_descriptor,
+            mcast_gather_core=mcast_gather_core,
+            mcast_gather_core_grid=mcast_gather_core_grid,
+            mcast_grid=mcast_grid,
+            all_cores=all_cores,
+            matmul_core_grid=matmul_core_grid,
+            mcast_receiver_grid=mcast_receiver_grid,
+            g1_source_grid=g1_source_grid,
+            g2_source_grid=g2_source_grid,
+            g1_source_cores=g1_source_cores,
+            g2_source_cores=g2_source_cores,
+            num_g1_sources=num_g1_sources,
+            num_g2_sources=num_g2_sources,
+            num_mcast_cores=num_mcast_cores,
+            out_w_per_core=out_w_per_core,
+            tiles_per_k=tiles_per_k,
+            k_num_tiles=k_num_tiles,
+            use_face_view=use_face_view,
+            face_tile_desc=face_tile_desc,
+            face_tile_size=face_tile_size,
+            kernel_tiles_per_k=kernel_tiles_per_k,
+            kernel_k_num_tiles=kernel_k_num_tiles,
+            mcast_src_num_pages=mcast_src_num_pages,
+            reduce_tile_size=reduce_tile_size,
+            group1_cb=group1_cb,
+            group2_cb=group2_cb,
+            intermed_cb=intermed_cb,
+            mcast_src_cb=mcast_src_cb,
+            mcast_dst_cb=mcast_dst_cb,
+            matmul_in1_cb=matmul_in1_cb,
+            matmul_out_cb=matmul_out_cb,
+            gather_dst_cb=gather_dst_cb,
+            input_src_g1_cb=input_src_g1_cb,
+            input_src_g2_cb=input_src_g2_cb,
+            residual_add_mcast_src_cb=residual_add_mcast_src_cb,
+            residual_add_mcast_dst_cb=residual_add_mcast_dst_cb,
+            residual_add_out_cb=residual_add_out_cb,
+            mcast_data_size_bytes=mcast_data_size_bytes,
+            mcast_is_part_of_receiver_grid=mcast_is_part_of_receiver_grid,
+            total_residual_add_tiles=total_residual_add_tiles,
+            residual_add_mcast_data_size_bytes=residual_add_mcast_data_size_bytes,
+            gather_data_size_bytes=gather_data_size_bytes,
+            gather_src_num_pages=gather_src_num_pages,
+            gather_dst_num_pages=gather_dst_num_pages,
+            gather_noc0_num_senders=gather_noc0_num_senders,
+            gather_noc1_num_senders=gather_noc1_num_senders,
+            ig_data_size_bytes=ig_data_size_bytes,
+            total_input_tiles=total_input_tiles,
+            mcast_data_sender_semaphore_id=mcast_data_sender_semaphore_id,
+            mcast_data_receiver_semaphore_id=mcast_data_receiver_semaphore_id,
+            gather_noc0_receiver_semaphore_id=gather_noc0_receiver_semaphore_id,
+            gather_noc1_receiver_semaphore_id=gather_noc1_receiver_semaphore_id,
+            ig_g1_receiver_semaphore_id=ig_g1_receiver_semaphore_id,
+            ig_g2_receiver_semaphore_id=ig_g2_receiver_semaphore_id,
+            ig_g1_noc1_receiver_semaphore_id=ig_g1_noc1_receiver_semaphore_id,
+            ig_g2_noc1_receiver_semaphore_id=ig_g2_noc1_receiver_semaphore_id,
+            mcast2_data_sender_semaphore_id=mcast2_data_sender_semaphore_id,
+            mcast2_data_receiver_semaphore_id=mcast2_data_receiver_semaphore_id,
+            gather_receiver_data_addr=gather_receiver_data_addr,
+            ig_g1_receiver_data_addr=ig_g1_receiver_data_addr,
+            ig_g2_receiver_data_addr=ig_g2_receiver_data_addr,
+            gather_dest_noc_core=gather_dest_noc_core,
+            mcast_dest_noc_start=mcast_dest_noc_start,
+            mcast_dest_noc_end=mcast_dest_noc_end,
+            group1_src_tensor=group1_src_tensor,
+            group2_src_tensor=group2_src_tensor,
+            group1_dst_tensor=group1_dst_tensor,
+            group2_dst_tensor=group2_dst_tensor,
+            weights_tensor=weights_tensor,
+            add_input_tensor=add_input_tensor,
+            output_tensor=output_tensor,
+        )
+
+    @staticmethod
+    def _build_compile_time_args(ctx):
+        """Build NCRISC, BRISC, and TRISC compile-time arg lists."""
+        ncrisc_named_compile_time_args = [
+            # Input gather g1 sender
+            ("ig_g1_dest_noc_x", ctx.gather_dest_noc_core.x),
+            ("ig_g1_dest_noc_y", ctx.gather_dest_noc_core.y),
+            ("ig_g1_data_size_bytes", ctx.ig_data_size_bytes),
+            ("ig_g1_receiver_semaphore_id", ctx.ig_g1_receiver_semaphore_id),
+            ("ig_g1_src_cb", ctx.input_src_g1_cb),
+            ("ig_g1_src_num_pages", 1),
+            ("ig_g1_receiver_data_addr", ctx.ig_g1_receiver_data_addr),
+            # Input gather g2 sender
+            ("ig_g2_dest_noc_x", ctx.gather_dest_noc_core.x),
+            ("ig_g2_dest_noc_y", ctx.gather_dest_noc_core.y),
+            ("ig_g2_data_size_bytes", ctx.ig_data_size_bytes),
+            ("ig_g2_receiver_semaphore_id", ctx.ig_g2_receiver_semaphore_id),
+            ("ig_g2_src_cb", ctx.input_src_g2_cb),
+            ("ig_g2_src_num_pages", 1),
+            ("ig_g2_receiver_data_addr", ctx.ig_g2_receiver_data_addr),
+            # Mcast1 receiver
+            ("mcast_data_receiver_semaphore", ctx.mcast_data_receiver_semaphore_id),
+            ("mcast_dst_cb", ctx.mcast_dst_cb),
+            ("mcast_dst_num_pages", ctx.k_num_tiles),
+            # Mcast2 source (for setup_sharded_buffer on sender core)
+            ("mcast2_src_cb", ctx.residual_add_mcast_src_cb),
+            ("mcast2_src_num_pages", ctx.total_residual_add_tiles),
+            # Mcast2 receiver
+            ("mcast2_data_receiver_semaphore", ctx.mcast2_data_receiver_semaphore_id),
+            ("mcast2_dst_cb", ctx.residual_add_mcast_dst_cb),
+            ("mcast2_dst_num_pages", ctx.total_residual_add_tiles),
+            # Matmul
+            ("matmul_in0", ctx.mcast_dst_cb),
+            ("matmul_in1", ctx.matmul_in1_cb),
+            ("matmul_out", ctx.matmul_out_cb),
+            ("matmul_k_num_tiles", ctx.k_num_tiles),
+            ("matmul_out_w_per_core", ctx.out_w_per_core),
+            # Residual add (needed for ResidualAdd CTArgs template parameter)
+            ("residual_add_out_w", ctx.out_w_per_core),
+            # Output gather sender
+            ("gather_dest_noc_x", ctx.gather_dest_noc_core.x),
+            ("gather_dest_noc_y", ctx.gather_dest_noc_core.y),
+            ("gather_data_size_bytes", ctx.gather_data_size_bytes),
+            ("gather_receiver_semaphore_id", ctx.gather_noc0_receiver_semaphore_id),
+            ("gather_src_cb", ctx.residual_add_out_cb),
+            ("gather_src_num_pages", ctx.gather_src_num_pages),
+            ("gather_sender_grid_start_x", 0),
+            ("gather_sender_grid_start_y", 0),
+            ("gather_sender_grid_end_x", 0),
+            ("gather_sender_grid_end_y", 0),
+            ("gather_row_major", 1),
+            ("gather_receiver_data_addr", ctx.gather_receiver_data_addr),
+        ]
+
+        brisc_named_compile_time_args = [
+            # Input gather g1 receiver
+            ("ig_g1_noc0_num_senders", ctx.num_g1_sources),
+            ("ig_g1_noc0_receiver_semaphore_id", ctx.ig_g1_receiver_semaphore_id),
+            ("ig_g1_noc1_receiver_semaphore_id", ctx.ig_g1_noc1_receiver_semaphore_id),
+            ("ig_g1_dst_cb", ctx.group1_cb),
+            ("ig_g1_dst_num_pages", ctx.kernel_tiles_per_k if ctx.use_face_view else ctx.total_input_tiles),
+            # Input gather g2 receiver
+            ("ig_g2_noc0_num_senders", ctx.num_g2_sources),
+            ("ig_g2_noc0_receiver_semaphore_id", ctx.ig_g2_receiver_semaphore_id),
+            ("ig_g2_noc1_receiver_semaphore_id", ctx.ig_g2_noc1_receiver_semaphore_id),
+            ("ig_g2_dst_cb", ctx.group2_cb),
+            ("ig_g2_dst_num_pages", ctx.kernel_tiles_per_k if ctx.use_face_view else ctx.total_input_tiles),
+            # Mcast sender
+            ("mcast_dest_noc_start_x", ctx.mcast_dest_noc_start.x),
+            ("mcast_dest_noc_start_y", ctx.mcast_dest_noc_start.y),
+            ("mcast_dest_noc_end_x", ctx.mcast_dest_noc_end.x),
+            ("mcast_dest_noc_end_y", ctx.mcast_dest_noc_end.y),
+            ("mcast_num_cores", ctx.num_mcast_cores),
+            ("mcast_data_sender_semaphore", ctx.mcast_data_sender_semaphore_id),
+            ("mcast_data_receiver_semaphore", ctx.mcast_data_receiver_semaphore_id),
+            ("mcast_data_size_bytes", ctx.mcast_data_size_bytes),
+            ("mcast_src_cb", ctx.mcast_src_cb),
+            ("mcast_src_num_pages", ctx.mcast_src_num_pages),
+            ("mcast_dst_cb", ctx.mcast_dst_cb),
+            ("mcast_is_part_of_receiver_grid", ctx.mcast_is_part_of_receiver_grid),
+            # Mcast2 sender
+            ("mcast2_data_sender_semaphore", ctx.mcast2_data_sender_semaphore_id),
+            ("mcast2_data_receiver_semaphore", ctx.mcast2_data_receiver_semaphore_id),
+            ("mcast2_data_size_bytes", ctx.residual_add_mcast_data_size_bytes),
+            ("mcast2_src_cb", ctx.residual_add_mcast_src_cb),
+            ("mcast2_src_num_pages", ctx.total_residual_add_tiles),
+            ("mcast2_dst_cb", ctx.residual_add_mcast_dst_cb),
+            # Residual add (needed for ResidualAdd CTArgs template parameter)
+            ("residual_add_out_w", ctx.out_w_per_core),
+            # Output gather receiver
+            ("gather_noc0_num_senders", ctx.gather_noc0_num_senders),
+            ("gather_noc1_num_senders", ctx.gather_noc1_num_senders),
+            ("gather_noc0_receiver_semaphore_id", ctx.gather_noc0_receiver_semaphore_id),
+            ("gather_noc1_receiver_semaphore_id", ctx.gather_noc1_receiver_semaphore_id),
+            ("gather_dst_cb", ctx.gather_dst_cb),
+            ("gather_dst_num_pages", ctx.gather_dst_num_pages),
+        ]
+
+        trisc_named_compile_time_args = [
+            # Gated reduce
+            ("gated_reduce_group1_cb", ctx.group1_cb),
+            ("gated_reduce_group2_cb", ctx.group2_cb),
+            ("gated_reduce_intermed_cb", ctx.intermed_cb),
+            ("gated_reduce_mcast_src_cb", ctx.mcast_src_cb),
+            ("gated_reduce_tiles_per_k", ctx.kernel_tiles_per_k),
+            ("gated_reduce_k_num_tiles", ctx.kernel_k_num_tiles),
+            # Matmul
+            ("matmul_in0", ctx.mcast_dst_cb),
+            ("matmul_in1", ctx.matmul_in1_cb),
+            ("matmul_out", ctx.matmul_out_cb),
+            ("matmul_k_num_tiles", ctx.k_num_tiles),
+            ("matmul_out_w_per_core", ctx.out_w_per_core),
+            # Residual add step
+            ("residual_add_in0", ctx.matmul_out_cb),
+            ("residual_add_in1", ctx.residual_add_mcast_dst_cb),
+            ("residual_add_out", ctx.residual_add_out_cb),
+            ("residual_add_out_w", ctx.out_w_per_core),
+            ("residual_add_total_in1_tiles", ctx.total_residual_add_tiles),
+        ]
+
+        return ncrisc_named_compile_time_args, brisc_named_compile_time_args, trisc_named_compile_time_args
+
+    @staticmethod
+    def _build_cb_descriptors(ctx):
+        """Build all 13 circular buffer descriptors."""
+        # CB 0: Group 1 gather dest — tensor-backed on sender core
+        group1_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(ctx.group1_cb, ctx.group1_dst_tensor)
+
+        # CB 1: Group 2 gather dest — tensor-backed on sender core
+        group2_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(ctx.group2_cb, ctx.group2_dst_tensor)
+
+        # Face-view: override CB 0, 1 tile descriptors to [16,16] face tiles
+        if ctx.use_face_view:
+            group1_cb_descriptor.format_descriptors[0].tile = ctx.face_tile_desc
+            group1_cb_descriptor.format_descriptors[0].page_size = ctx.face_tile_size
+            group2_cb_descriptor.format_descriptors[0].tile = ctx.face_tile_desc
+            group2_cb_descriptor.format_descriptors[0].page_size = ctx.face_tile_size
+
+        tile_desc = ctx.face_tile_desc if ctx.use_face_view else ttnn.TileDescriptor(ctx.input_tile)
+
+        # CB 2: Intermediate — 2 tiles on sender core, manual
+        intermed_format = ttnn.CBFormatDescriptor(
+            buffer_index=ctx.intermed_cb,
+            data_format=ctx.data_format,
+            page_size=ctx.reduce_tile_size,
+            tile=tile_desc,
+        )
+        intermed_cb_descriptor = ttnn.CBDescriptor(
+            total_size=2 * ctx.reduce_tile_size,
+            core_ranges=ctx.mcast_gather_core_grid,
+            format_descriptors=[intermed_format],
+        )
+
+        # CB 3: Mcast source — on sender core, manual
+        mcast_src_format = ttnn.CBFormatDescriptor(
+            buffer_index=ctx.mcast_src_cb,
+            data_format=ctx.data_format,
+            page_size=ctx.reduce_tile_size,
+            tile=tile_desc,
+        )
+        mcast_src_cb_descriptor = ttnn.CBDescriptor(
+            total_size=ctx.mcast_src_num_pages * ctx.reduce_tile_size,
+            core_ranges=ctx.mcast_gather_core_grid,
+            format_descriptors=[mcast_src_format],
+        )
+
+        input_tile_desc = ttnn.TileDescriptor(ctx.input_tile)
+
+        # CB 4: Mcast destination / matmul in0 — all 130 cores
+        mcast_dst_format = ttnn.CBFormatDescriptor(
+            buffer_index=ctx.mcast_dst_cb,
+            data_format=ctx.data_format,
+            page_size=ctx.input_tile_size,
+            tile=input_tile_desc,
+        )
+        mcast_dst_cb_descriptor = ttnn.CBDescriptor(
+            total_size=ctx.k_num_tiles * ctx.input_tile_size,
+            core_ranges=ctx.all_cores,
+            format_descriptors=[mcast_dst_format],
+        )
+
+        # CB 5: Matmul weights — tensor-backed on 112 matmul cores
+        matmul_in1_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(ctx.matmul_in1_cb, ctx.weights_tensor)
+
+        # CB 6: Matmul output — on 112 matmul cores
+        matmul_out_format = ttnn.CBFormatDescriptor(
+            buffer_index=ctx.matmul_out_cb,
+            data_format=ctx.data_format,
+            page_size=ctx.tile_1x32_size,
+            tile=ctx.tile_1x32_descriptor,
+        )
+        matmul_out_cb_descriptor = ttnn.CBDescriptor(
+            total_size=ctx.out_w_per_core * ctx.tile_1x32_size,
+            core_ranges=ctx.matmul_core_grid,
+            format_descriptors=[matmul_out_format],
+        )
+
+        # CB 7: Output gather destination — tensor-backed on sender core
+        gather_dst_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(ctx.gather_dst_cb, ctx.output_tensor)
+
+        # CB 8: Input source group1 — tensor-backed on g1 source cores
+        input_src_g1_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(ctx.input_src_g1_cb, ctx.group1_src_tensor)
+
+        # CB 9: Input source group2 — tensor-backed on g2 source cores
+        input_src_g2_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(ctx.input_src_g2_cb, ctx.group2_src_tensor)
+
+        # CB 10: Mcast2 source — residual input on (12,9), tensor-backed
+        residual_add_mcast_src_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(
+            ctx.residual_add_mcast_src_cb, ctx.add_input_tensor
+        )
+
+        # CB 11: Mcast2 destination — on all 130 cores
+        residual_add_mcast_dst_format = ttnn.CBFormatDescriptor(
+            buffer_index=ctx.residual_add_mcast_dst_cb,
+            data_format=ctx.data_format,
+            page_size=ctx.tile_1x32_size,
+            tile=ctx.tile_1x32_descriptor,
+        )
+        residual_add_mcast_dst_cb_descriptor = ttnn.CBDescriptor(
+            total_size=ctx.total_residual_add_tiles * ctx.tile_1x32_size,
+            core_ranges=ctx.all_cores,
+            format_descriptors=[residual_add_mcast_dst_format],
+        )
+
+        # CB 12: Residual add output — on 112 matmul cores
+        residual_add_out_format = ttnn.CBFormatDescriptor(
+            buffer_index=ctx.residual_add_out_cb,
+            data_format=ctx.data_format,
+            page_size=ctx.tile_1x32_size,
+            tile=ctx.tile_1x32_descriptor,
+        )
+        residual_add_out_cb_descriptor = ttnn.CBDescriptor(
+            total_size=ctx.out_w_per_core * ctx.tile_1x32_size,
+            core_ranges=ctx.matmul_core_grid,
+            format_descriptors=[residual_add_out_format],
+        )
+
+        return [
+            group1_cb_descriptor,
+            group2_cb_descriptor,
+            intermed_cb_descriptor,
+            mcast_src_cb_descriptor,
+            mcast_dst_cb_descriptor,
+            matmul_in1_cb_descriptor,
+            matmul_out_cb_descriptor,
+            gather_dst_cb_descriptor,
+            input_src_g1_cb_descriptor,
+            input_src_g2_cb_descriptor,
+            residual_add_mcast_src_cb_descriptor,
+            residual_add_mcast_dst_cb_descriptor,
+            residual_add_out_cb_descriptor,
+        ]
+
+    @staticmethod
+    def _build_core_descriptors(ctx):
+        """Build per-core and unified compile-time core descriptors."""
+        # Per-core: output gather sender index
+        matmul_cores_list = ttnn.corerange_to_cores(ctx.matmul_core_grid)
+        per_core_gather_idx = PerCoreCompileTimeDescriptor(
+            named_compile_time_arg="gather_sender_idx",
+            core_values=[(core, idx) for idx, core in enumerate(matmul_cores_list)],
+            other_value=0,
+        )
+
+        # Per-core: input gather sender indices
+        def compute_sender_indices(source_cores):
+            indices = []
+            for i, core in enumerate(source_cores):
+                collection = i // ctx.k_num_tiles
+                k = i % ctx.k_num_tiles
+                if ctx.use_face_view:
+                    sender_idx = collection * ctx.k_num_tiles + k
+                else:
+                    sender_idx = k * ctx.tiles_per_k + collection
+                indices.append((core, sender_idx))
+            return indices
+
+        per_core_ig_g1_idx = PerCoreCompileTimeDescriptor(
+            named_compile_time_arg="ig_g1_sender_idx",
+            core_values=compute_sender_indices(ctx.g1_source_cores),
+            other_value=0,
+        )
+        per_core_ig_g2_idx = PerCoreCompileTimeDescriptor(
+            named_compile_time_arg="ig_g2_sender_idx",
+            core_values=compute_sender_indices(ctx.g2_source_cores),
+            other_value=0,
+        )
+
+        # Unified core descriptors (role flags)
+        core_descs = [
+            UnifiedCompileTimeCoreDescriptor(
+                named_compile_time_arg="is_input_gather_sender_g1",
+                core_range=ctx.g1_source_grid,
+                value=1,
+                other_value=0,
+            ),
+            UnifiedCompileTimeCoreDescriptor(
+                named_compile_time_arg="is_input_gather_sender_g2",
+                core_range=ctx.g2_source_grid,
+                value=1,
+                other_value=0,
+            ),
+            UnifiedCompileTimeCoreDescriptor(
+                named_compile_time_arg="is_gated_reduce_core",
+                core_range=ctx.mcast_gather_core_grid,
+                value=1,
+                other_value=0,
+            ),
+            UnifiedCompileTimeCoreDescriptor(
+                named_compile_time_arg="is_mcast_sender_core",
+                core_range=ctx.mcast_gather_core_grid,
+                value=1,
+                other_value=0,
+            ),
+            UnifiedCompileTimeCoreDescriptor(
+                named_compile_time_arg="is_mcast_receiver_core",
+                core_range=ctx.mcast_receiver_grid,
+                value=1,
+                other_value=0,
+            ),
+            UnifiedCompileTimeCoreDescriptor(
+                named_compile_time_arg="is_matmul_core",
+                core_range=ctx.matmul_core_grid,
+                value=1,
+                other_value=0,
+            ),
+            UnifiedCompileTimeCoreDescriptor(
+                named_compile_time_arg="is_gather_receiver_core",
+                core_range=ctx.mcast_gather_core_grid,
+                value=1,
+                other_value=0,
+            ),
+            UnifiedCompileTimeCoreDescriptor(
+                named_compile_time_arg="gather_use_per_core_sender_idx",
+                core_range=ctx.matmul_core_grid,
+                value=1,
+                other_value=0,
+            ),
+        ]
+
+        per_core_descs = [per_core_gather_idx, per_core_ig_g1_idx, per_core_ig_g2_idx]
+
+        return core_descs, per_core_descs
+
+    @staticmethod
+    def op(
+        group1_src_tensor,
+        group2_src_tensor,
+        group1_dst_tensor,
+        group2_dst_tensor,
+        weights_tensor,
+        add_input_tensor,
+        output_tensor,
+        tiles_per_k,
+        k_num_tiles,
+        use_face_view=None,
+    ):
+        """
+        Execute fused input gather + gated local reduce + down projection.
+
+        Args:
+            group1_src_tensor: Source data for group1, HEIGHT_SHARDED on g1 source cores,
+                               1 tile [1,32] per core
+            group2_src_tensor: Source data for group2, same layout on g2 source cores
+            group1_dst_tensor: Gather destination for group1, HEIGHT_SHARDED on (12,9),
+                               pre-allocated (filled by input gather)
+            group2_dst_tensor: Gather destination for group2, same layout on (12,9)
+            weights_tensor: Weights [K, N] WIDTH_SHARDED on 112 matmul cores
+            output_tensor: Output [1, N] HEIGHT_SHARDED on (12,9)
+            tiles_per_k: Number of collections to reduce per K-position
+            k_num_tiles: Number of K-tile positions (K / 32)
+
+        Returns:
+            Output tensor with result
+        """
+        ctx = GatedLocalReduceDownProjOp._setup_dimensions(
+            group1_src_tensor,
+            group2_src_tensor,
+            group1_dst_tensor,
+            group2_dst_tensor,
+            weights_tensor,
+            add_input_tensor,
+            output_tensor,
+            tiles_per_k,
+            k_num_tiles,
+            use_face_view,
+        )
+
+        ncrisc_args, brisc_args, trisc_args = GatedLocalReduceDownProjOp._build_compile_time_args(ctx)
+        cb_descriptors = GatedLocalReduceDownProjOp._build_cb_descriptors(ctx)
+        core_descs, per_core_descs = GatedLocalReduceDownProjOp._build_core_descriptors(ctx)
+
+        # Semaphore descriptors
+        full_device_grid = ttnn.CoreRangeSet(
+            [
+                ttnn.CoreRange(
+                    ttnn.CoreCoord(0, 0),
+                    ttnn.CoreCoord(
+                        ctx.device.compute_with_storage_grid_size().x - 1,
+                        ctx.device.compute_with_storage_grid_size().y - 1,
+                    ),
+                )
+            ]
+        )
+        semaphore_descriptors = [
+            ttnn.SemaphoreDescriptor(id=i, core_ranges=full_device_grid, initial_value=0) for i in range(10)
+        ]
+
+        # Kernel descriptor
+        unified_kernel = UnifiedKernelDescriptor(
+            kernel_source="models/demos/deepseek_v3_b1/fused_ops/gated_local_reduce_down_proj/kernels/gated_local_reduce_down_proj_kernel.cpp",
+            core_ranges=ctx.all_cores,
+            ncrisc_named_compile_time_args=ncrisc_args,
+            brisc_named_compile_time_args=brisc_args,
+            trisc_named_compile_time_args=trisc_args,
+            trisc_compute_config=ttnn.ComputeConfigDescriptor(
+                math_fidelity=ttnn.MathFidelity.LoFi,
+                math_approx_mode=True,
+                fp32_dest_acc_en=False,
+                dst_full_sync_en=False,
+            ),
+            unified_compile_time_core_descriptors=core_descs,
+            per_core_compile_time_descriptors=per_core_descs,
+        )
+
+        # Program descriptor
+        program_descriptor = ttnn.ProgramDescriptor(
+            kernels=unified_kernel.get_kernel_descriptors().kernels,
+            cbs=cb_descriptors,
+            semaphores=semaphore_descriptors,
+        )
+
+        # Execute generic op
+        io_tensors = [
+            group1_src_tensor,
+            group2_src_tensor,
+            group1_dst_tensor,
+            group2_dst_tensor,
+            weights_tensor,
+            add_input_tensor,
+            output_tensor,
+        ]
+        return ttnn.generic_op(io_tensors, program_descriptor)

--- a/models/demos/deepseek_v3_b1/fused_ops/shared_expert/__init__.py
+++ b/models/demos/deepseek_v3_b1/fused_ops/shared_expert/__init__.py
@@ -1,0 +1,7 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+from .op import SharedExpertOp
+
+__all__ = ["SharedExpertOp"]

--- a/models/demos/deepseek_v3_b1/fused_ops/shared_expert/kernels/shared_expert_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/fused_ops/shared_expert/kernels/shared_expert_kernel.cpp
@@ -1,0 +1,492 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+// SPDX-License-Identifier: Apache-2.0
+
+// Shared expert unified kernel
+//
+// Fuses: Activation Mcast + Gate/Up Matmul + Gather + GatedLocalReduce
+//        + Mcast1 + Mcast2 + Down Proj Matmul + ResidualAdd + Output Gather
+//
+// Sender core (12,9):
+//   BRISC:  act_mcast send → 130-core grid,
+//           A_gather receive, B_gather receive,
+//           mcast1(mcast_src) → 130-core grid,
+//           mcast2(residual) → 130-core grid,
+//           output gather receive
+//   TRISC:  gated reduce → mcast_src
+//   NCRISC: setup_sharded_buffer(act_mcast_src), act_mcast recv (grid only),
+//           setup_sharded_buffer(down_weights), mcast1 recv, mcast2 recv,
+//           output gather send
+//
+// Gate compute cores (64 A cores):
+//   NCRISC: setup_sharded_buffer(gate_up_weights), act_mcast recv,
+//           gate_gather send, mcast1 recv, mcast2 recv, output gather send (if matmul)
+//   TRISC:  gate matmul [1, k_per_core] x [k_per_core, 1] → 1 tile,
+//           down proj matmul (if matmul core), residual add (if matmul core)
+//
+// Up compute cores (64 B cores):
+//   NCRISC: setup_sharded_buffer(gate_up_weights), act_mcast recv,
+//           up_gather send, mcast1 recv, mcast2 recv, output gather send (if matmul)
+//   TRISC:  up matmul [1, k_per_core] x [k_per_core, 1] → 1 tile,
+//           down proj matmul (if matmul core), residual add (if matmul core)
+//
+// Idle core (12,8):
+//   NCRISC: act_mcast recv (grid only), mcast1 recv (grid only), mcast2 recv (grid only)
+//
+// CB Layout:
+//   CB 0:  A_gather_dst / reduce_g1 (sender, 64 face tiles, manual, face-view)
+//   CB 1:  B_gather_dst / reduce_g2 (sender, 64 face tiles, manual, face-view)
+//   CB 2:  intermediate (sender, 2 face tiles, manual)
+//   CB 3:  mcast1 source (sender, 1 face tile, manual, TRISC-filled)
+//   CB 4:  mcast1 dest / down_matmul_in0 (all 130 cores, manual)
+//   CB 5:  down_weights (112 matmul cores, tensor-backed)
+//   CB 6:  down_matmul_out (112 matmul cores, manual)
+//   CB 7:  output_gather_dst (sender, tensor-backed)
+//   CB 8:  act_mcast_src (sender, tensor-backed)
+//   CB 9:  act_mcast_recv (all 130 cores, manual)
+//   CB 10: residual_mcast_src (sender, tensor-backed)
+//   CB 11: residual_mcast_dst (all 130 cores, manual)
+//   CB 12: residual_add_out (112 matmul cores, manual)
+//   CB 13: gate_up_weights (128 compute cores, tensor-backed)
+//   CB 14: gate_up_matmul_out (128 compute cores, 1 tile, manual)
+
+#include "../../../unified_kernels/kernel_op_api.hpp"
+#include "../../../unified_kernels/kernel_utils.hpp"
+#include "../../../unified_kernels/gated_reduce.hpp"
+#include "../../../unified_kernels/mcast.hpp"
+#include "../../../unified_kernels/matmul.hpp"
+#include "../../../unified_kernels/kn_sliced_matmul.hpp"
+#include "../../../unified_kernels/gather.hpp"
+#include "../../../unified_kernels/residual_add.hpp"
+
+struct Core {
+    static constexpr bool is_gate_compute_core = get_named_compile_time_arg_val("is_gate_compute_core") == 1;
+    static constexpr bool is_up_compute_core = get_named_compile_time_arg_val("is_up_compute_core") == 1;
+    static constexpr bool is_compute_core = is_gate_compute_core || is_up_compute_core;
+    static constexpr bool is_gated_reduce_core = get_named_compile_time_arg_val("is_gated_reduce_core") == 1;
+    static constexpr bool is_mcast_sender_core = get_named_compile_time_arg_val("is_mcast_sender_core") == 1;
+    static constexpr bool is_mcast_receiver_core = get_named_compile_time_arg_val("is_mcast_receiver_core") == 1;
+    static constexpr bool is_matmul_core = get_named_compile_time_arg_val("is_matmul_core") == 1;
+    static constexpr bool is_gather_receiver_core = get_named_compile_time_arg_val("is_gather_receiver_core") == 1;
+    static constexpr bool gather_use_per_core_sender_idx =
+        get_named_compile_time_arg_val("gather_use_per_core_sender_idx") == 1;
+};
+
+void kernel_main() {
+// ============================================================================
+// NCRISC (Reader)
+// ============================================================================
+#if defined(COMPILE_FOR_NCRISC)
+    // Activation mcast receiver args
+    using ActMcastCTArgs = deepseek_b1_ops::Mcast::ReceiverCTArgs;
+    deepseek_b1_ops::Mcast::ReceiverArgs act_mcast_args{
+        get_named_compile_time_arg_val("act_mcast_data_receiver_semaphore"),
+        get_named_compile_time_arg_val("act_mcast_dst_cb"),
+        get_named_compile_time_arg_val("act_mcast_dst_num_pages"),
+    };
+
+    // Gated reduce reader args (NCRISC no-op)
+    using GatedReduceCTArgs = deepseek_b1_ops::GatedReduce::ReaderCTArgs;
+    deepseek_b1_ops::GatedReduce::ReaderArgs gated_reduce_args{};
+
+    // Gate gather (A) sender args
+    deepseek_b1_ops::Gather::SenderArgs ag_args{
+        get_named_compile_time_arg_val("ag_dest_noc_x"),
+        get_named_compile_time_arg_val("ag_dest_noc_y"),
+        get_named_compile_time_arg_val("ag_data_size_bytes"),
+        get_named_compile_time_arg_val("ag_receiver_semaphore_id"),
+        get_named_compile_time_arg_val("ag_src_cb"),
+        get_named_compile_time_arg_val("ag_src_num_pages"),
+        0,  // sender_grid_start_x (unused, per-core idx)
+        0,  // sender_grid_start_y
+        0,  // sender_grid_end_x
+        0,  // sender_grid_end_y
+        1,  // row_major
+        get_named_compile_time_arg_val("ag_receiver_data_addr"),
+        get_named_compile_time_arg_val("ag_sender_idx"),
+    };
+
+    // Up gather (B) sender args
+    deepseek_b1_ops::Gather::SenderArgs bg_args{
+        get_named_compile_time_arg_val("bg_dest_noc_x"),
+        get_named_compile_time_arg_val("bg_dest_noc_y"),
+        get_named_compile_time_arg_val("bg_data_size_bytes"),
+        get_named_compile_time_arg_val("bg_receiver_semaphore_id"),
+        get_named_compile_time_arg_val("bg_src_cb"),
+        get_named_compile_time_arg_val("bg_src_num_pages"),
+        0,  // sender_grid_start_x (unused, per-core idx)
+        0,  // sender_grid_start_y
+        0,  // sender_grid_end_x
+        0,  // sender_grid_end_y
+        1,  // row_major
+        get_named_compile_time_arg_val("bg_receiver_data_addr"),
+        get_named_compile_time_arg_val("bg_sender_idx"),
+    };
+
+    // Mcast1 receiver args (down proj activation)
+    using McastCTArgs = deepseek_b1_ops::Mcast::ReceiverCTArgs;
+    deepseek_b1_ops::Mcast::ReceiverArgs mcast_args{
+        get_named_compile_time_arg_val("mcast_data_receiver_semaphore"),
+        get_named_compile_time_arg_val("mcast_dst_cb"),
+        get_named_compile_time_arg_val("mcast_dst_num_pages"),
+    };
+
+    // Mcast2 receiver args (residual, shares init/teardown with mcast1)
+    deepseek_b1_ops::Mcast::ReceiverArgs mcast2_args{
+        get_named_compile_time_arg_val("mcast2_data_receiver_semaphore"),
+        get_named_compile_time_arg_val("mcast2_dst_cb"),
+        get_named_compile_time_arg_val("mcast2_dst_num_pages"),
+    };
+
+    // Gate/Up sliced matmul reader args (NCRISC no-op)
+    using KNSlicedMatmulCTArgs = deepseek_b1_ops::KNSlicedMatmul::ReaderCTArgs;
+    deepseek_b1_ops::KNSlicedMatmul::ReaderArgs gu_matmul_args{};
+
+    // Down proj matmul reader args (NCRISC no-op)
+    using MatmulCTArgs = deepseek_b1_ops::Matmul::ReaderCTArgs;
+    deepseek_b1_ops::Matmul::ReaderArgs matmul_args{};
+
+    // Output gather sender args
+    deepseek_b1_ops::Gather::SenderArgs og_args{
+        get_named_compile_time_arg_val("gather_dest_noc_x"),
+        get_named_compile_time_arg_val("gather_dest_noc_y"),
+        get_named_compile_time_arg_val("gather_data_size_bytes"),
+        get_named_compile_time_arg_val("gather_receiver_semaphore_id"),
+        get_named_compile_time_arg_val("gather_src_cb"),
+        get_named_compile_time_arg_val("gather_src_num_pages"),
+        get_named_compile_time_arg_val("gather_sender_grid_start_x"),
+        get_named_compile_time_arg_val("gather_sender_grid_start_y"),
+        get_named_compile_time_arg_val("gather_sender_grid_end_x"),
+        get_named_compile_time_arg_val("gather_sender_grid_end_y"),
+        get_named_compile_time_arg_val("gather_row_major"),
+        get_named_compile_time_arg_val("gather_receiver_data_addr"),
+        get_named_compile_time_arg_val("gather_sender_idx"),
+    };
+
+// ============================================================================
+// BRISC (Writer)
+// ============================================================================
+#elif defined(COMPILE_FOR_BRISC)
+    // Activation mcast sender args
+    using ActMcastCTArgs = deepseek_b1_ops::Mcast::SenderCTArgs<
+        get_named_compile_time_arg_val("act_mcast_num_cores"),
+        get_named_compile_time_arg_val("act_mcast_is_part_of_receiver_grid") == 1,
+        /*Loopback=*/false>;
+
+    constexpr uint32_t act_mcast_src_cb = get_named_compile_time_arg_val("act_mcast_src_cb");
+    constexpr uint32_t act_mcast_dst_cb = get_named_compile_time_arg_val("act_mcast_dst_cb");
+    deepseek_b1_ops::Mcast::SenderArgs act_mcast_args{
+        get_named_compile_time_arg_val("act_mcast_dest_noc_start_x"),
+        get_named_compile_time_arg_val("act_mcast_dest_noc_start_y"),
+        get_named_compile_time_arg_val("act_mcast_dest_noc_end_x"),
+        get_named_compile_time_arg_val("act_mcast_dest_noc_end_y"),
+        get_named_compile_time_arg_val("act_mcast_data_sender_semaphore"),
+        get_named_compile_time_arg_val("act_mcast_data_receiver_semaphore"),
+        get_named_compile_time_arg_val("act_mcast_data_size_bytes"),
+        act_mcast_src_cb,
+        get_named_compile_time_arg_val("act_mcast_src_num_pages"),
+        get_read_ptr(act_mcast_src_cb),
+        get_write_ptr(act_mcast_dst_cb),
+    };
+
+    // Gated reduce writer args (BRISC no-op)
+    using GatedReduceCTArgs = deepseek_b1_ops::GatedReduce::WriterCTArgs;
+    deepseek_b1_ops::GatedReduce::WriterArgs gated_reduce_args{};
+
+    // Gate gather (A) receiver args
+    deepseek_b1_ops::Gather::ReceiverArgs ag_args{
+        get_named_compile_time_arg_val("ag_noc0_num_senders"),
+        0,
+        get_named_compile_time_arg_val("ag_noc0_receiver_semaphore_id"),
+        get_named_compile_time_arg_val("ag_noc1_receiver_semaphore_id"),
+        get_named_compile_time_arg_val("ag_dst_cb"),
+        get_named_compile_time_arg_val("ag_dst_num_pages"),
+    };
+
+    // Up gather (B) receiver args
+    deepseek_b1_ops::Gather::ReceiverArgs bg_args{
+        get_named_compile_time_arg_val("bg_noc0_num_senders"),
+        0,
+        get_named_compile_time_arg_val("bg_noc0_receiver_semaphore_id"),
+        get_named_compile_time_arg_val("bg_noc1_receiver_semaphore_id"),
+        get_named_compile_time_arg_val("bg_dst_cb"),
+        get_named_compile_time_arg_val("bg_dst_num_pages"),
+    };
+
+    // Mcast1 sender args (down proj activation)
+    using McastCTArgs = deepseek_b1_ops::Mcast::SenderCTArgs<
+        get_named_compile_time_arg_val("mcast_num_cores"),
+        get_named_compile_time_arg_val("mcast_is_part_of_receiver_grid") == 1,
+        /*Loopback=*/false>;
+
+    constexpr uint32_t mcast_src_cb = get_named_compile_time_arg_val("mcast_src_cb");
+    constexpr uint32_t mcast_dst_cb = get_named_compile_time_arg_val("mcast_dst_cb");
+    deepseek_b1_ops::Mcast::SenderArgs mcast_args{
+        get_named_compile_time_arg_val("mcast_dest_noc_start_x"),
+        get_named_compile_time_arg_val("mcast_dest_noc_start_y"),
+        get_named_compile_time_arg_val("mcast_dest_noc_end_x"),
+        get_named_compile_time_arg_val("mcast_dest_noc_end_y"),
+        get_named_compile_time_arg_val("mcast_data_sender_semaphore"),
+        get_named_compile_time_arg_val("mcast_data_receiver_semaphore"),
+        get_named_compile_time_arg_val("mcast_data_size_bytes"),
+        mcast_src_cb,
+        get_named_compile_time_arg_val("mcast_src_num_pages"),
+        get_read_ptr(mcast_src_cb),
+        get_write_ptr(mcast_dst_cb),
+    };
+
+    // Mcast2 sender args (residual, shares init/teardown with mcast1)
+    constexpr uint32_t mcast2_src_cb = get_named_compile_time_arg_val("mcast2_src_cb");
+    constexpr uint32_t mcast2_dst_cb = get_named_compile_time_arg_val("mcast2_dst_cb");
+    deepseek_b1_ops::Mcast::SenderArgs mcast2_args{
+        get_named_compile_time_arg_val("mcast_dest_noc_start_x"),
+        get_named_compile_time_arg_val("mcast_dest_noc_start_y"),
+        get_named_compile_time_arg_val("mcast_dest_noc_end_x"),
+        get_named_compile_time_arg_val("mcast_dest_noc_end_y"),
+        get_named_compile_time_arg_val("mcast2_data_sender_semaphore"),
+        get_named_compile_time_arg_val("mcast2_data_receiver_semaphore"),
+        get_named_compile_time_arg_val("mcast2_data_size_bytes"),
+        mcast2_src_cb,
+        get_named_compile_time_arg_val("mcast2_src_num_pages"),
+        get_read_ptr(mcast2_src_cb),
+        get_write_ptr(mcast2_dst_cb),
+    };
+
+    // Gate/Up sliced matmul writer args (BRISC no-op)
+    using KNSlicedMatmulCTArgs = deepseek_b1_ops::KNSlicedMatmul::WriterCTArgs;
+    deepseek_b1_ops::KNSlicedMatmul::WriterArgs gu_matmul_args{};
+
+    // Down proj matmul writer args (BRISC no-op)
+    using MatmulCTArgs = deepseek_b1_ops::Matmul::WriterCTArgs;
+    deepseek_b1_ops::Matmul::WriterArgs matmul_args{};
+
+    // Output gather receiver args
+    deepseek_b1_ops::Gather::ReceiverArgs og_args{
+        get_named_compile_time_arg_val("gather_noc0_num_senders"),
+        get_named_compile_time_arg_val("gather_noc1_num_senders"),
+        get_named_compile_time_arg_val("gather_noc0_receiver_semaphore_id"),
+        get_named_compile_time_arg_val("gather_noc1_receiver_semaphore_id"),
+        get_named_compile_time_arg_val("gather_dst_cb"),
+        get_named_compile_time_arg_val("gather_dst_num_pages"),
+    };
+
+// ============================================================================
+// TRISC (Compute)
+// ============================================================================
+#elif defined(COMPILE_FOR_TRISC)
+    // Activation mcast (no-op for TRISC)
+    using ActMcastCTArgs = deepseek_b1_ops::Mcast::ComputeCTArgs;
+    deepseek_b1_ops::Mcast::ComputeArgs act_mcast_args{};
+
+    // Gate/Up gather compute args (no-op)
+    deepseek_b1_ops::Gather::ComputeArgs ag_args{};
+    deepseek_b1_ops::Gather::ComputeArgs bg_args{};
+
+    // Mcast1 CTArgs (no-op for TRISC)
+    using McastCTArgs = deepseek_b1_ops::Mcast::ComputeCTArgs;
+    deepseek_b1_ops::Mcast::ComputeArgs mcast_args{};
+
+    // Mcast2 (no-op for TRISC, shares init/teardown with mcast1, residual)
+    deepseek_b1_ops::Mcast::ComputeArgs mcast2_args{};
+
+    // Gated reduce compute args
+    using GatedReduceCTArgs = deepseek_b1_ops::GatedReduce::ComputeCTArgs<
+        get_named_compile_time_arg_val("gated_reduce_tiles_per_k"),
+        get_named_compile_time_arg_val("gated_reduce_k_num_tiles")>;
+    deepseek_b1_ops::GatedReduce::ComputeArgs gated_reduce_args{
+        get_named_compile_time_arg_val("gated_reduce_group1_cb"),
+        get_named_compile_time_arg_val("gated_reduce_group2_cb"),
+        get_named_compile_time_arg_val("gated_reduce_intermed_cb"),
+        get_named_compile_time_arg_val("gated_reduce_mcast_src_cb"),
+    };
+
+    // Gate/Up sliced matmul CTArgs
+    using KNSlicedMatmulCTArgs = deepseek_b1_ops::KNSlicedMatmul::ComputeCTArgs;
+    deepseek_b1_ops::KNSlicedMatmul::ComputeArgs gu_matmul_args{
+        get_named_compile_time_arg_val("gu_act_cb"),
+        get_named_compile_time_arg_val("gu_weights_cb"),
+        get_named_compile_time_arg_val("gu_out_cb"),
+        get_named_compile_time_arg_val("gu_k_offset"),
+        get_named_compile_time_arg_val("gu_k_per_core"),
+        get_named_compile_time_arg_val("gu_act_total_tiles"),
+    };
+
+    // Down proj matmul CTArgs
+    using MatmulCTArgs =
+        deepseek_b1_ops::Matmul::ComputeCTArgs<get_named_compile_time_arg_val("matmul_out_w_per_core")>;
+    deepseek_b1_ops::Matmul::ComputeArgs matmul_args{
+        get_named_compile_time_arg_val("matmul_in0"),
+        get_named_compile_time_arg_val("matmul_in1"),
+        get_named_compile_time_arg_val("matmul_out"),
+        get_named_compile_time_arg_val("matmul_k_num_tiles"),
+    };
+
+    // Output gather compute args (no-op)
+    deepseek_b1_ops::Gather::ComputeArgs og_args{};
+#endif
+
+    // ========================================================================
+    // Setup sharded buffers (NCRISC only)
+    // ========================================================================
+#if defined(COMPILE_FOR_NCRISC)
+    // Activation mcast source on sender core
+    if constexpr (Core::is_mcast_sender_core) {
+        constexpr uint32_t act_src_cb = get_named_compile_time_arg_val("act_mcast_src_cb");
+        constexpr uint32_t act_src_pages = get_named_compile_time_arg_val("act_mcast_src_num_pages");
+        unified_kernels::setup_sharded_buffer(act_src_cb, act_src_pages);
+    }
+    // Gate/Up weights on 128 compute cores
+    if constexpr (Core::is_compute_core) {
+        constexpr uint32_t gu_weights_cb = get_named_compile_time_arg_val("gu_weights_cb");
+        constexpr uint32_t gu_weights_num_pages = get_named_compile_time_arg_val("gu_weights_num_pages");
+        unified_kernels::setup_sharded_buffer(gu_weights_cb, gu_weights_num_pages);
+    }
+#endif
+
+    // ========================================================================
+    // Phase 1: Activation Mcast — sender (12,9) → all 130 cores
+    // Broadcasts [1, 7168] activation to all cores
+    // ========================================================================
+    deepseek_b1_ops::Mcast::Op<
+        ActMcastCTArgs,
+        Core::is_mcast_sender_core,
+        Core::is_mcast_receiver_core,
+        Core::is_mcast_receiver_core,
+        /*pop_src=*/true>
+        act_mcast;
+    act_mcast.init(act_mcast_args);
+    {
+        DeviceZoneScopedN("ACT_MCAST");
+        act_mcast(act_mcast_args);
+    }
+    act_mcast.teardown();
+
+    // ========================================================================
+    // Phase 2: Gate/Up Matmul on 128 compute cores
+    // A cores: activation[k_offset..k_offset+k_per_core] @ gate_weights → 1 tile
+    // B cores: activation[k_offset..k_offset+k_per_core] @ up_weights → 1 tile
+    // ========================================================================
+    {
+        DeviceZoneScopedN("GATE_UP_MATMUL");
+        deepseek_b1_ops::KNSlicedMatmul::
+            Op<KNSlicedMatmulCTArgs, Core::is_compute_core, /*pop_act=*/true, /*pop_weights=*/false>
+                gu_matmul;
+        gu_matmul(gu_matmul_args);
+    }
+
+    // ========================================================================
+    // Phase 3: Gate Gather (A) — 64 A cores → CB0 on (12,9)
+    // ========================================================================
+    {
+        DeviceZoneScopedN("GATE_GATHER");
+        deepseek_b1_ops::Gather::
+            Op<Core::is_gate_compute_core, Core::is_gated_reduce_core, /*pop_src=*/true, Core::is_gate_compute_core>
+                gate_gather;
+        gate_gather(ag_args);
+    }
+
+    // ========================================================================
+    // Phase 3b: Up Gather (B) — 64 B cores → CB1 on (12,9)
+    // ========================================================================
+    {
+        DeviceZoneScopedN("UP_GATHER");
+        deepseek_b1_ops::Gather::
+            Op<Core::is_up_compute_core, Core::is_gated_reduce_core, /*pop_src=*/true, Core::is_up_compute_core>
+                up_gather;
+        up_gather(bg_args);
+    }
+
+    // ========================================================================
+    // Phase 4: Gated Local Reduce (TRISC on sender core)
+    // SiLU(sum(gate_partials)) * sum(up_partials) → [1, 256]
+    // ========================================================================
+    {
+        DeviceZoneScopedN("GATED_REDUCE");
+        deepseek_b1_ops::GatedReduce::Op<GatedReduceCTArgs, Core::is_gated_reduce_core> gated_reduce;
+        gated_reduce(gated_reduce_args);
+    }
+
+    // ========================================================================
+    // Phases 5-6: Mcast1 + Mcast2 — sender (12,9) → 129 receivers in 13x10 grid
+    // Shared init/teardown: same grid, same semaphores, sequential sends
+    // Mcast1: gated reduce output [1, K_down], Mcast2: residual [1, N]
+    // ========================================================================
+    deepseek_b1_ops::Mcast::Op<
+        McastCTArgs,
+        Core::is_mcast_sender_core,
+        Core::is_mcast_receiver_core,
+        Core::is_mcast_receiver_core,
+        /*pop_src=*/true>
+        mcast;
+    mcast.init(mcast_args);
+    {
+        DeviceZoneScopedN("MCAST1");
+        mcast(mcast_args);
+    }
+
+    // ========================================================================
+    // Setup down proj weights (NCRISC, after mcast1 since we need buffer space)
+    // ========================================================================
+#if defined(COMPILE_FOR_NCRISC)
+    if constexpr (Core::is_matmul_core) {
+        constexpr uint32_t matmul_in1 = get_named_compile_time_arg_val("matmul_in1");
+        constexpr uint32_t matmul_k_num_tiles = get_named_compile_time_arg_val("matmul_k_num_tiles");
+        constexpr uint32_t matmul_out_w_per_core = get_named_compile_time_arg_val("matmul_out_w_per_core");
+        unified_kernels::setup_sharded_buffer(matmul_in1, matmul_k_num_tiles * matmul_out_w_per_core);
+    }
+    // Mcast2 source (residual on sender core)
+    if constexpr (Core::is_mcast_sender_core) {
+        constexpr uint32_t m2_src_cb = get_named_compile_time_arg_val("mcast2_src_cb");
+        constexpr uint32_t m2_src_pages = get_named_compile_time_arg_val("mcast2_src_num_pages");
+        unified_kernels::setup_sharded_buffer(m2_src_cb, m2_src_pages);
+    }
+#endif
+
+    {
+        DeviceZoneScopedN("MCAST2");
+        mcast(mcast2_args);
+    }
+    mcast.teardown();
+
+    // ========================================================================
+    // Phase 7: Down Proj Matmul — [1, K_down] x [K_down, N_per_core] on 112 cores
+    // ========================================================================
+    {
+        DeviceZoneScopedN("DOWN_MATMUL");
+        deepseek_b1_ops::Matmul::Op<MatmulCTArgs, Core::is_matmul_core, /*pop_in0=*/true, /*pop_in1=*/false> matmul;
+        matmul(matmul_args);
+    }
+
+    // ========================================================================
+    // Phase 8: Residual add — matmul_out + shard(residual) → residual_add_out on 112 cores
+    // ========================================================================
+    using ResidualAddCTArgs =
+        deepseek_b1_ops::ResidualAdd::ComputeCTArgs<get_named_compile_time_arg_val("residual_add_out_w")>;
+    deepseek_b1_ops::ResidualAdd::RTArgs residual_add_args{
+#if defined(COMPILE_FOR_TRISC)
+        get_named_compile_time_arg_val("residual_add_in0"),
+        get_named_compile_time_arg_val("residual_add_in1"),
+        get_named_compile_time_arg_val("residual_add_out"),
+        get_named_compile_time_arg_val("residual_add_total_in1_tiles"),
+        get_named_compile_time_arg_val("gather_sender_idx"),
+#endif
+    };
+    {
+        DeviceZoneScopedN("ADD");
+        deepseek_b1_ops::ResidualAdd::Op<ResidualAddCTArgs, Core::is_matmul_core> residual_add;
+        residual_add(residual_add_args);
+    }
+
+    // ========================================================================
+    // Phase 9: Output Gather — 112 matmul cores → (12,9)
+    // ========================================================================
+    {
+        DeviceZoneScopedN("OUTPUT_GATHER");
+        deepseek_b1_ops::Gather::Op<
+            Core::is_matmul_core,
+            Core::is_gather_receiver_core,
+            /*pop_src=*/true,
+            Core::gather_use_per_core_sender_idx>
+            output_gather;
+        output_gather(og_args);
+    }
+}

--- a/models/demos/deepseek_v3_b1/fused_ops/shared_expert/kernels/shared_expert_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/fused_ops/shared_expert/kernels/shared_expert_kernel.cpp
@@ -300,7 +300,7 @@ void kernel_main() {
     };
 
     // Gate/Up sliced matmul CTArgs
-    using KNSlicedMatmulCTArgs = deepseek_b1_ops::KNSlicedMatmul::ComputeCTArgs;
+    using KNSlicedMatmulCTArgs = deepseek_b1_ops::KNSlicedMatmul::ComputeCTArgs<>;
     deepseek_b1_ops::KNSlicedMatmul::ComputeArgs gu_matmul_args{
         get_named_compile_time_arg_val("gu_act_cb"),
         get_named_compile_time_arg_val("gu_weights_cb"),

--- a/models/demos/deepseek_v3_b1/fused_ops/shared_expert/op.py
+++ b/models/demos/deepseek_v3_b1/fused_ops/shared_expert/op.py
@@ -1,0 +1,975 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Shared expert operation.
+
+Fuses: Activation Mcast + Gate/Up Matmul + Gather + GatedLocalReduce
+       + Mcast1 + Mcast2 + Down Proj Matmul + ResidualAdd + Output Gather
+
+Pipeline:
+  1. Activation mcast: [1, K_gate] from (12,9) → all 130 cores
+  2. Gate matmul on 64 A cores, Up matmul on 64 B cores
+  3. Gather A→CB0, B→CB1 on (12,9)
+  4. Gated reduce: SiLU(sum(A)) * sum(B) → [1, K_down]
+  5. Mcast1: [1, K_down] from (12,9) → all 130 cores
+  6. Mcast2: bias [1, N] from (12,9) → all 130 cores
+  7. Down proj matmul on 112 cores
+  8. Residual add on 112 cores
+  9. Output gather → (12,9)
+
+CB Layout (15 CBs: 0-14):
+  CB 0:  A_gather_dst / reduce_g1 (sender, manual, face-view)
+  CB 1:  B_gather_dst / reduce_g2 (sender, manual, face-view)
+  CB 2:  intermediate (sender, 2 tiles, manual)
+  CB 3:  mcast1 source (sender, manual, TRISC-filled)
+  CB 4:  mcast1 dest / down_matmul_in0 (all 130 cores, manual)
+  CB 5:  down_weights (112 matmul cores, tensor-backed)
+  CB 6:  down_matmul_out (112 matmul cores, manual)
+  CB 7:  output_gather_dst (sender, tensor-backed)
+  CB 8:  act_mcast_src (sender, tensor-backed)
+  CB 9:  act_mcast_recv (all 130 cores, manual)
+  CB 10: residual_mcast_src (sender, tensor-backed)
+  CB 11: residual_mcast_dst (all 130 cores, manual)
+  CB 12: residual_add_out (112 matmul cores, manual)
+  CB 13: gate_up_weights (128 compute cores, tensor-backed)
+  CB 14: gate_up_matmul_out (128 compute cores, 1 tile, manual)
+"""
+
+from dataclasses import dataclass
+from typing import Any
+
+import torch
+import torch.nn.functional as F
+
+import ttnn
+from models.demos.deepseek_v3_b1.fused_ops.down_proj.op import DownProj
+from models.demos.deepseek_v3_b1.fused_ops.face_view_utils import FACE_HEIGHT, FACE_WIDTH, can_use_face_view
+from models.demos.deepseek_v3_b1.unified_kernel_descriptor import (
+    PerCoreCompileTimeDescriptor,
+    UnifiedCompileTimeCoreDescriptor,
+    UnifiedKernelDescriptor,
+)
+
+
+@dataclass
+class _SharedExpertContext:
+    """Holds all computed values needed by SharedExpertOp helper methods."""
+
+    # Device & format
+    device: Any
+    data_format: Any
+    input_tile: Any
+    input_tile_size: int
+    tile_1x32_size: int
+    tile_1x32_descriptor: Any
+
+    # Grids
+    mcast_gather_core: Any
+    mcast_gather_core_grid: Any
+    mcast_grid: Any
+    all_cores: Any
+    matmul_core_grid: Any
+    mcast_receiver_grid: Any
+    a_cores_list: list
+    b_cores_list: list
+    compute_cores_list: list
+    a_compute_grid: Any
+    b_compute_grid: Any
+    num_mcast_cores: int
+
+    # Dimensions
+    K_gate_tiles: int
+    k_per_core: int
+    K_down_tiles: int
+    out_w_per_core: int
+    tiles_per_k: int
+    k_num_tiles: int
+    n_parallel: int
+    k_parallel: int
+    num_compute_cores: int
+
+    # Face-view
+    use_face_view: bool
+    face_tile_desc: Any
+    face_tile_size: Any
+    kernel_tiles_per_k: int
+    kernel_k_num_tiles: int
+    mcast_src_num_pages: int
+    reduce_tile_size: int
+
+    # CB indices
+    group1_cb: int
+    group2_cb: int
+    intermed_cb: int
+    mcast_src_cb: int
+    mcast_dst_cb: int
+    matmul_in1_cb: int
+    matmul_out_cb: int
+    gather_dst_cb: int
+    act_mcast_src_cb: int
+    act_mcast_dst_cb: int
+    residual_mcast_src_cb: int
+    residual_mcast_dst_cb: int
+    residual_add_out_cb: int
+    gu_weights_cb: int
+    gu_out_cb: int
+
+    # Derived sizes
+    act_mcast_data_size_bytes: int
+    act_mcast_is_part_of_receiver_grid: bool
+    mcast_data_size_bytes: int
+    mcast_is_part_of_receiver_grid: bool
+    total_residual_add_tiles: int
+    residual_mcast_data_size_bytes: int
+    gather_data_size_bytes: int
+    gather_src_num_pages: int
+    gather_dst_num_pages: int
+    gather_noc0_num_senders: int
+    gather_noc1_num_senders: int
+    gu_gather_data_size_bytes: int
+    total_gather_tiles: int
+
+    # Semaphore IDs
+    mcast_data_sender_semaphore_id: int
+    mcast_data_receiver_semaphore_id: int
+    gather_noc0_receiver_semaphore_id: int
+    gather_noc1_receiver_semaphore_id: int
+    ag_receiver_semaphore_id: int
+    bg_receiver_semaphore_id: int
+    ag_noc1_receiver_semaphore_id: int
+    bg_noc1_receiver_semaphore_id: int
+    act_mcast_sender_semaphore_id: int
+    act_mcast_receiver_semaphore_id: int
+
+    # Addresses & tensors
+    gather_receiver_data_addr: int
+    ag_dummy_tensor: Any
+    bg_dummy_tensor: Any
+    ag_receiver_data_addr: int
+    bg_receiver_data_addr: int
+
+    # NOC coordinates
+    gather_dest_noc_core: Any
+    mcast_dest_noc_start: Any
+    mcast_dest_noc_end: Any
+
+    # Input tensors (needed for CB descriptors)
+    activation_tensor: Any
+    down_weights_tensor: Any
+    bias_tensor: Any
+    output_tensor: Any
+    gate_up_weights_tensor: Any
+
+
+class SharedExpertOp:
+    """
+    Shared expert operation.
+
+    Computes: (SiLU(activation @ gate_weights) * (activation @ up_weights)) @ down_weights + bias
+    """
+
+    @staticmethod
+    def build_ab_grids():
+        """
+        Build A (gate) / B (up) compute core grids for 64+64 dual matmul layout.
+
+        Layout on 13x10 grid:
+            Rows 0-3: A=cols{0-3,7-9}, B=cols{4-6,10-12}
+            Rows 4-7: A=cols{0-2,7-9}, B=cols{3-6,10-12}
+            Row 8:    A=cols{0-2,7-9}, B=cols{3-6,10-11}  (col 12 = idle phantom)
+            Row 9:    A=cols{0-2,7-9}, B=cols{3-6,10-11}  (col 12 = sender M)
+
+        Returns:
+            (a_cores, b_cores): Lists of ttnn.CoreCoord, 64 each
+        """
+        a_cores = []
+        b_cores = []
+        for row in range(10):
+            for col in range(13):
+                if col == 12 and row == 9:  # sender core (12,9)
+                    continue
+                if col == 12 and row == 8:  # idle phantom
+                    continue
+                if row < 4:
+                    is_a = col in {0, 1, 2, 3, 7, 8, 9}
+                else:
+                    is_a = col in {0, 1, 2, 7, 8, 9}
+                if is_a:
+                    a_cores.append(ttnn.CoreCoord(col, row))
+                else:
+                    b_cores.append(ttnn.CoreCoord(col, row))
+        assert len(a_cores) == 64, f"Expected 64 A cores, got {len(a_cores)}"
+        assert len(b_cores) == 64, f"Expected 64 B cores, got {len(b_cores)}"
+        return a_cores, b_cores
+
+    @staticmethod
+    def golden(activation, gate_weights, up_weights, down_weights, bias):
+        """
+        PyTorch reference implementation.
+
+        Args:
+            activation: [1, K_gate] tensor
+            gate_weights: [K_gate, K_down] tensor
+            up_weights: [K_gate, K_down] tensor
+            down_weights: [K_down, N] tensor
+            bias: [1, N] tensor
+
+        Returns:
+            [1, N] tensor
+        """
+        gate_out = F.silu(activation @ gate_weights)
+        up_out = activation @ up_weights
+        hidden = gate_out * up_out
+        return hidden @ down_weights + bias
+
+    @staticmethod
+    def _setup_dimensions(
+        activation_tensor,
+        gate_up_weights_tensor,
+        down_weights_tensor,
+        bias_tensor,
+        output_tensor,
+        k_parallel,
+        n_parallel,
+    ):
+        """Compute all dimensions, grids, face-view params, CB indices, semaphores, and addresses."""
+        device = activation_tensor.device()
+        data_format = activation_tensor.dtype
+
+        # Tile definitions
+        TILE_1x32 = ttnn.Tile((1, 32))
+        tile_1x32_size = TILE_1x32.get_tile_size(data_format)
+        tile_1x32_descriptor = ttnn.TileDescriptor(TILE_1x32)
+
+        # Core grid configuration
+        mcast_gather_core = DownProj.MCAST_GATHER_CORE
+        mcast_gather_core_grid = ttnn.CoreRangeSet([ttnn.CoreRange(mcast_gather_core, mcast_gather_core)])
+
+        mcast_grid = ttnn.CoreRange(
+            ttnn.CoreCoord(0, 0),
+            ttnn.CoreCoord(DownProj.MCAST_GRID_X - 1, DownProj.MCAST_GRID_Y - 1),
+        )
+        mcast_grid_set = ttnn.CoreRangeSet([mcast_grid])
+        num_mcast_cores = DownProj.MCAST_GRID_X * DownProj.MCAST_GRID_Y  # 130
+
+        matmul_core_grid = DownProj.build_matmul_core_grid()
+
+        # A/B compute grids
+        a_cores_list, b_cores_list = SharedExpertOp.build_ab_grids()
+        a_compute_grid = ttnn.CoreRangeSet([ttnn.CoreRange(c, c) for c in a_cores_list])
+        b_compute_grid = ttnn.CoreRangeSet([ttnn.CoreRange(c, c) for c in b_cores_list])
+        compute_cores_list = a_cores_list + b_cores_list  # 128 cores
+
+        mcast_receiver_grid = DownProj.build_mcast_receiver_grid()
+        all_cores = mcast_grid_set
+
+        # NOC coordinates
+        gather_dest_noc_core = device.worker_core_from_logical_core(mcast_gather_core)
+        mcast_dest_noc_start = device.worker_core_from_logical_core(mcast_grid.start)
+        mcast_dest_noc_end = device.worker_core_from_logical_core(mcast_grid.end)
+
+        # Dimension parameters
+        input_tile = activation_tensor.get_tile()
+        tile_h, tile_w = input_tile.tile_shape
+        input_tile_size = input_tile.get_tile_size(data_format)
+
+        K_gate = activation_tensor.shape[1]
+        K_gate_tiles = K_gate // tile_w
+
+        num_compute_cores = 64
+        k_per_core = K_gate_tiles // k_parallel
+        K_down_tiles = n_parallel
+
+        # Down proj dimensions
+        down_weights_shard_spec = down_weights_tensor.memory_config().shard_spec
+        n_per_core = down_weights_shard_spec.shape[1]
+        out_w_per_core = n_per_core // TILE_1x32.tile_shape[1]
+
+        # Face-view parameters
+        tiles_per_k = k_parallel
+        k_num_tiles = n_parallel
+
+        use_face_view = can_use_face_view(tile_h, tile_w, tiles_per_k, k_num_tiles)
+
+        if use_face_view:
+            face_tile = ttnn.Tile([FACE_HEIGHT, FACE_WIDTH])
+            face_tile_desc = ttnn.TileDescriptor(FACE_HEIGHT, FACE_WIDTH, False)
+            face_tile_size = face_tile.get_tile_size(data_format)
+            kernel_tiles_per_k = tiles_per_k
+            kernel_k_num_tiles = 1
+            mcast_src_num_pages = 1
+            reduce_tile_size = face_tile_size
+        else:
+            face_tile_desc = None
+            face_tile_size = None
+            kernel_tiles_per_k = tiles_per_k
+            kernel_k_num_tiles = k_num_tiles
+            mcast_src_num_pages = k_num_tiles
+            reduce_tile_size = input_tile_size
+
+        # CB indices
+        group1_cb = 0
+        group2_cb = 1
+        intermed_cb = 2
+        mcast_src_cb = 3
+        mcast_dst_cb = 4
+        matmul_in1_cb = 5
+        matmul_out_cb = 6
+        gather_dst_cb = 7
+        act_mcast_src_cb = 8
+        act_mcast_dst_cb = 9
+        residual_mcast_src_cb = 10
+        residual_mcast_dst_cb = 11
+        residual_add_out_cb = 12
+        gu_weights_cb = 13
+        gu_out_cb = 14
+
+        # Derived sizes
+        act_mcast_data_size_bytes = K_gate_tiles * input_tile_size
+        act_mcast_is_part_of_receiver_grid = mcast_grid.contains(mcast_gather_core)
+        mcast_data_size_bytes = K_down_tiles * input_tile_size
+        mcast_is_part_of_receiver_grid = mcast_grid.contains(mcast_gather_core)
+        total_residual_add_tiles = DownProj.NUM_MATMUL_CORES * out_w_per_core
+        residual_mcast_data_size_bytes = total_residual_add_tiles * tile_1x32_size
+        gather_data_size_bytes = out_w_per_core * tile_1x32_size
+        gather_src_num_pages = out_w_per_core
+        gather_dst_num_pages = DownProj.NUM_MATMUL_CORES * out_w_per_core
+        gather_noc0_num_senders = DownProj.NUM_MATMUL_CORES
+        gather_noc1_num_senders = 0
+        gu_gather_data_size_bytes = input_tile_size
+        total_gather_tiles = num_compute_cores
+
+        # Semaphore IDs
+        mcast_data_sender_semaphore_id = 0
+        mcast_data_receiver_semaphore_id = 1
+        gather_noc0_receiver_semaphore_id = 2
+        gather_noc1_receiver_semaphore_id = 3
+        ag_receiver_semaphore_id = 4
+        bg_receiver_semaphore_id = 5
+        ag_noc1_receiver_semaphore_id = 6
+        bg_noc1_receiver_semaphore_id = 7
+        act_mcast_sender_semaphore_id = 8
+        act_mcast_receiver_semaphore_id = 9
+
+        # Buffer addresses
+        gather_receiver_data_addr = output_tensor.buffer_address()
+
+        ag_dummy_shape = (total_gather_tiles, 32)
+        ag_dummy_shard_spec = ttnn.ShardSpec(mcast_gather_core_grid, ag_dummy_shape, ttnn.ShardOrientation.ROW_MAJOR)
+        ag_dummy_mem = ttnn.MemoryConfig(
+            ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, ag_dummy_shard_spec
+        )
+
+        ag_dummy_tensor = ttnn.from_torch(
+            torch.zeros(total_gather_tiles, 32, dtype=torch.bfloat16),
+            dtype=ttnn.bfloat16,
+            layout=ttnn.TILE_LAYOUT,
+            device=device,
+            memory_config=ag_dummy_mem,
+            tile=input_tile,
+        )
+        bg_dummy_tensor = ttnn.from_torch(
+            torch.zeros(total_gather_tiles, 32, dtype=torch.bfloat16),
+            dtype=ttnn.bfloat16,
+            layout=ttnn.TILE_LAYOUT,
+            device=device,
+            memory_config=ag_dummy_mem,
+            tile=input_tile,
+        )
+
+        ag_receiver_data_addr = ag_dummy_tensor.buffer_address()
+        bg_receiver_data_addr = bg_dummy_tensor.buffer_address()
+
+        return _SharedExpertContext(
+            device=device,
+            data_format=data_format,
+            input_tile=input_tile,
+            input_tile_size=input_tile_size,
+            tile_1x32_size=tile_1x32_size,
+            tile_1x32_descriptor=tile_1x32_descriptor,
+            mcast_gather_core=mcast_gather_core,
+            mcast_gather_core_grid=mcast_gather_core_grid,
+            mcast_grid=mcast_grid,
+            all_cores=all_cores,
+            matmul_core_grid=matmul_core_grid,
+            mcast_receiver_grid=mcast_receiver_grid,
+            a_cores_list=a_cores_list,
+            b_cores_list=b_cores_list,
+            compute_cores_list=compute_cores_list,
+            a_compute_grid=a_compute_grid,
+            b_compute_grid=b_compute_grid,
+            num_mcast_cores=num_mcast_cores,
+            K_gate_tiles=K_gate_tiles,
+            k_per_core=k_per_core,
+            K_down_tiles=K_down_tiles,
+            out_w_per_core=out_w_per_core,
+            tiles_per_k=tiles_per_k,
+            k_num_tiles=k_num_tiles,
+            n_parallel=n_parallel,
+            k_parallel=k_parallel,
+            num_compute_cores=num_compute_cores,
+            use_face_view=use_face_view,
+            face_tile_desc=face_tile_desc,
+            face_tile_size=face_tile_size,
+            kernel_tiles_per_k=kernel_tiles_per_k,
+            kernel_k_num_tiles=kernel_k_num_tiles,
+            mcast_src_num_pages=mcast_src_num_pages,
+            reduce_tile_size=reduce_tile_size,
+            group1_cb=group1_cb,
+            group2_cb=group2_cb,
+            intermed_cb=intermed_cb,
+            mcast_src_cb=mcast_src_cb,
+            mcast_dst_cb=mcast_dst_cb,
+            matmul_in1_cb=matmul_in1_cb,
+            matmul_out_cb=matmul_out_cb,
+            gather_dst_cb=gather_dst_cb,
+            act_mcast_src_cb=act_mcast_src_cb,
+            act_mcast_dst_cb=act_mcast_dst_cb,
+            residual_mcast_src_cb=residual_mcast_src_cb,
+            residual_mcast_dst_cb=residual_mcast_dst_cb,
+            residual_add_out_cb=residual_add_out_cb,
+            gu_weights_cb=gu_weights_cb,
+            gu_out_cb=gu_out_cb,
+            act_mcast_data_size_bytes=act_mcast_data_size_bytes,
+            act_mcast_is_part_of_receiver_grid=act_mcast_is_part_of_receiver_grid,
+            mcast_data_size_bytes=mcast_data_size_bytes,
+            mcast_is_part_of_receiver_grid=mcast_is_part_of_receiver_grid,
+            total_residual_add_tiles=total_residual_add_tiles,
+            residual_mcast_data_size_bytes=residual_mcast_data_size_bytes,
+            gather_data_size_bytes=gather_data_size_bytes,
+            gather_src_num_pages=gather_src_num_pages,
+            gather_dst_num_pages=gather_dst_num_pages,
+            gather_noc0_num_senders=gather_noc0_num_senders,
+            gather_noc1_num_senders=gather_noc1_num_senders,
+            gu_gather_data_size_bytes=gu_gather_data_size_bytes,
+            total_gather_tiles=total_gather_tiles,
+            mcast_data_sender_semaphore_id=mcast_data_sender_semaphore_id,
+            mcast_data_receiver_semaphore_id=mcast_data_receiver_semaphore_id,
+            gather_noc0_receiver_semaphore_id=gather_noc0_receiver_semaphore_id,
+            gather_noc1_receiver_semaphore_id=gather_noc1_receiver_semaphore_id,
+            ag_receiver_semaphore_id=ag_receiver_semaphore_id,
+            bg_receiver_semaphore_id=bg_receiver_semaphore_id,
+            ag_noc1_receiver_semaphore_id=ag_noc1_receiver_semaphore_id,
+            bg_noc1_receiver_semaphore_id=bg_noc1_receiver_semaphore_id,
+            act_mcast_sender_semaphore_id=act_mcast_sender_semaphore_id,
+            act_mcast_receiver_semaphore_id=act_mcast_receiver_semaphore_id,
+            gather_receiver_data_addr=gather_receiver_data_addr,
+            ag_dummy_tensor=ag_dummy_tensor,
+            bg_dummy_tensor=bg_dummy_tensor,
+            ag_receiver_data_addr=ag_receiver_data_addr,
+            bg_receiver_data_addr=bg_receiver_data_addr,
+            gather_dest_noc_core=gather_dest_noc_core,
+            mcast_dest_noc_start=mcast_dest_noc_start,
+            mcast_dest_noc_end=mcast_dest_noc_end,
+            activation_tensor=activation_tensor,
+            down_weights_tensor=down_weights_tensor,
+            bias_tensor=bias_tensor,
+            output_tensor=output_tensor,
+            gate_up_weights_tensor=gate_up_weights_tensor,
+        )
+
+    @staticmethod
+    def _build_compile_time_args(ctx):
+        """Build NCRISC, BRISC, and TRISC compile-time arg lists."""
+        ncrisc_named_compile_time_args = [
+            # Activation mcast source (setup_sharded_buffer on sender)
+            ("act_mcast_src_cb", ctx.act_mcast_src_cb),
+            ("act_mcast_src_num_pages", ctx.K_gate_tiles),
+            # Activation mcast receiver
+            ("act_mcast_data_receiver_semaphore", ctx.act_mcast_receiver_semaphore_id),
+            ("act_mcast_dst_cb", ctx.act_mcast_dst_cb),
+            ("act_mcast_dst_num_pages", ctx.K_gate_tiles),
+            # Gate/Up weights (setup_sharded_buffer on compute cores)
+            ("gu_weights_cb", ctx.gu_weights_cb),
+            ("gu_weights_num_pages", ctx.k_per_core),
+            # Gate gather (A) sender
+            ("ag_dest_noc_x", ctx.gather_dest_noc_core.x),
+            ("ag_dest_noc_y", ctx.gather_dest_noc_core.y),
+            ("ag_data_size_bytes", ctx.gu_gather_data_size_bytes),
+            ("ag_receiver_semaphore_id", ctx.ag_receiver_semaphore_id),
+            ("ag_src_cb", ctx.gu_out_cb),
+            ("ag_src_num_pages", 1),
+            ("ag_receiver_data_addr", ctx.ag_receiver_data_addr),
+            # Up gather (B) sender
+            ("bg_dest_noc_x", ctx.gather_dest_noc_core.x),
+            ("bg_dest_noc_y", ctx.gather_dest_noc_core.y),
+            ("bg_data_size_bytes", ctx.gu_gather_data_size_bytes),
+            ("bg_receiver_semaphore_id", ctx.bg_receiver_semaphore_id),
+            ("bg_src_cb", ctx.gu_out_cb),
+            ("bg_src_num_pages", 1),
+            ("bg_receiver_data_addr", ctx.bg_receiver_data_addr),
+            # Mcast1 receiver (down proj activation)
+            ("mcast_data_receiver_semaphore", ctx.mcast_data_receiver_semaphore_id),
+            ("mcast_dst_cb", ctx.mcast_dst_cb),
+            ("mcast_dst_num_pages", ctx.K_down_tiles),
+            # Down proj weights (setup_sharded_buffer on matmul cores)
+            ("matmul_in1", ctx.matmul_in1_cb),
+            ("matmul_k_num_tiles", ctx.K_down_tiles),
+            ("matmul_out_w_per_core", ctx.out_w_per_core),
+            # Mcast2 source (residual on sender)
+            ("mcast2_src_cb", ctx.residual_mcast_src_cb),
+            ("mcast2_src_num_pages", ctx.total_residual_add_tiles),
+            # Mcast2 receiver (residual, shares semaphores with mcast1)
+            ("mcast2_data_receiver_semaphore", ctx.mcast_data_receiver_semaphore_id),
+            ("mcast2_dst_cb", ctx.residual_mcast_dst_cb),
+            ("mcast2_dst_num_pages", ctx.total_residual_add_tiles),
+            # Down proj matmul (NCRISC no-op, but args needed for split kernel)
+            ("matmul_in0", ctx.mcast_dst_cb),
+            ("matmul_out", ctx.matmul_out_cb),
+            # Residual add (needed for ResidualAdd CTArgs template parameter)
+            ("residual_add_out_w", ctx.out_w_per_core),
+            # Output gather sender
+            ("gather_dest_noc_x", ctx.gather_dest_noc_core.x),
+            ("gather_dest_noc_y", ctx.gather_dest_noc_core.y),
+            ("gather_data_size_bytes", ctx.gather_data_size_bytes),
+            ("gather_receiver_semaphore_id", ctx.gather_noc0_receiver_semaphore_id),
+            ("gather_src_cb", ctx.residual_add_out_cb),
+            ("gather_src_num_pages", ctx.gather_src_num_pages),
+            ("gather_sender_grid_start_x", 0),
+            ("gather_sender_grid_start_y", 0),
+            ("gather_sender_grid_end_x", 0),
+            ("gather_sender_grid_end_y", 0),
+            ("gather_row_major", 1),
+            ("gather_receiver_data_addr", ctx.gather_receiver_data_addr),
+        ]
+
+        brisc_named_compile_time_args = [
+            # Activation mcast sender
+            ("act_mcast_dest_noc_start_x", ctx.mcast_dest_noc_start.x),
+            ("act_mcast_dest_noc_start_y", ctx.mcast_dest_noc_start.y),
+            ("act_mcast_dest_noc_end_x", ctx.mcast_dest_noc_end.x),
+            ("act_mcast_dest_noc_end_y", ctx.mcast_dest_noc_end.y),
+            ("act_mcast_num_cores", ctx.num_mcast_cores),
+            ("act_mcast_data_sender_semaphore", ctx.act_mcast_sender_semaphore_id),
+            ("act_mcast_data_receiver_semaphore", ctx.act_mcast_receiver_semaphore_id),
+            ("act_mcast_data_size_bytes", ctx.act_mcast_data_size_bytes),
+            ("act_mcast_src_cb", ctx.act_mcast_src_cb),
+            ("act_mcast_src_num_pages", ctx.K_gate_tiles),
+            ("act_mcast_dst_cb", ctx.act_mcast_dst_cb),
+            ("act_mcast_is_part_of_receiver_grid", ctx.act_mcast_is_part_of_receiver_grid),
+            # Gate gather (A) receiver
+            ("ag_noc0_num_senders", ctx.num_compute_cores),
+            ("ag_noc0_receiver_semaphore_id", ctx.ag_receiver_semaphore_id),
+            ("ag_noc1_receiver_semaphore_id", ctx.ag_noc1_receiver_semaphore_id),
+            ("ag_dst_cb", ctx.group1_cb),
+            ("ag_dst_num_pages", ctx.kernel_tiles_per_k if ctx.use_face_view else ctx.total_gather_tiles),
+            # Up gather (B) receiver
+            ("bg_noc0_num_senders", ctx.num_compute_cores),
+            ("bg_noc0_receiver_semaphore_id", ctx.bg_receiver_semaphore_id),
+            ("bg_noc1_receiver_semaphore_id", ctx.bg_noc1_receiver_semaphore_id),
+            ("bg_dst_cb", ctx.group2_cb),
+            ("bg_dst_num_pages", ctx.kernel_tiles_per_k if ctx.use_face_view else ctx.total_gather_tiles),
+            # Mcast1 sender (down proj activation)
+            ("mcast_dest_noc_start_x", ctx.mcast_dest_noc_start.x),
+            ("mcast_dest_noc_start_y", ctx.mcast_dest_noc_start.y),
+            ("mcast_dest_noc_end_x", ctx.mcast_dest_noc_end.x),
+            ("mcast_dest_noc_end_y", ctx.mcast_dest_noc_end.y),
+            ("mcast_num_cores", ctx.num_mcast_cores),
+            ("mcast_data_sender_semaphore", ctx.mcast_data_sender_semaphore_id),
+            ("mcast_data_receiver_semaphore", ctx.mcast_data_receiver_semaphore_id),
+            ("mcast_data_size_bytes", ctx.mcast_data_size_bytes),
+            ("mcast_src_cb", ctx.mcast_src_cb),
+            ("mcast_src_num_pages", ctx.mcast_src_num_pages),
+            ("mcast_dst_cb", ctx.mcast_dst_cb),
+            ("mcast_is_part_of_receiver_grid", ctx.mcast_is_part_of_receiver_grid),
+            # Mcast2 sender (bias, shares semaphores with mcast1)
+            ("mcast2_data_sender_semaphore", ctx.mcast_data_sender_semaphore_id),
+            ("mcast2_data_receiver_semaphore", ctx.mcast_data_receiver_semaphore_id),
+            ("mcast2_data_size_bytes", ctx.residual_mcast_data_size_bytes),
+            ("mcast2_src_cb", ctx.residual_mcast_src_cb),
+            ("mcast2_src_num_pages", ctx.total_residual_add_tiles),
+            ("mcast2_dst_cb", ctx.residual_mcast_dst_cb),
+            # Residual add (needed for ResidualAdd CTArgs template parameter)
+            ("residual_add_out_w", ctx.out_w_per_core),
+            # Output gather receiver
+            ("gather_noc0_num_senders", ctx.gather_noc0_num_senders),
+            ("gather_noc1_num_senders", ctx.gather_noc1_num_senders),
+            ("gather_noc0_receiver_semaphore_id", ctx.gather_noc0_receiver_semaphore_id),
+            ("gather_noc1_receiver_semaphore_id", ctx.gather_noc1_receiver_semaphore_id),
+            ("gather_dst_cb", ctx.gather_dst_cb),
+            ("gather_dst_num_pages", ctx.gather_dst_num_pages),
+        ]
+
+        trisc_named_compile_time_args = [
+            # Gate/Up matmul
+            ("gu_act_cb", ctx.act_mcast_dst_cb),
+            ("gu_weights_cb", ctx.gu_weights_cb),
+            ("gu_out_cb", ctx.gu_out_cb),
+            ("gu_k_per_core", ctx.k_per_core),
+            ("gu_act_total_tiles", ctx.K_gate_tiles),
+            # Gated reduce
+            ("gated_reduce_group1_cb", ctx.group1_cb),
+            ("gated_reduce_group2_cb", ctx.group2_cb),
+            ("gated_reduce_intermed_cb", ctx.intermed_cb),
+            ("gated_reduce_mcast_src_cb", ctx.mcast_src_cb),
+            ("gated_reduce_tiles_per_k", ctx.kernel_tiles_per_k),
+            ("gated_reduce_k_num_tiles", ctx.kernel_k_num_tiles),
+            # Down proj matmul
+            ("matmul_in0", ctx.mcast_dst_cb),
+            ("matmul_in1", ctx.matmul_in1_cb),
+            ("matmul_out", ctx.matmul_out_cb),
+            ("matmul_k_num_tiles", ctx.K_down_tiles),
+            ("matmul_out_w_per_core", ctx.out_w_per_core),
+            # Residual add step
+            ("residual_add_in0", ctx.matmul_out_cb),
+            ("residual_add_in1", ctx.residual_mcast_dst_cb),
+            ("residual_add_out", ctx.residual_add_out_cb),
+            ("residual_add_out_w", ctx.out_w_per_core),
+            ("residual_add_total_in1_tiles", ctx.total_residual_add_tiles),
+        ]
+
+        return ncrisc_named_compile_time_args, brisc_named_compile_time_args, trisc_named_compile_time_args
+
+    @staticmethod
+    def _build_cb_descriptors(ctx):
+        """Build all 15 circular buffer descriptors."""
+        # CB 0: A_gather_dst — tensor-backed on sender (backed by dummy tensor)
+        group1_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(ctx.group1_cb, ctx.ag_dummy_tensor)
+        if ctx.use_face_view:
+            group1_cb_descriptor.format_descriptors[0].tile = ctx.face_tile_desc
+            group1_cb_descriptor.format_descriptors[0].page_size = ctx.face_tile_size
+
+        # CB 1: B_gather_dst — tensor-backed on sender (backed by dummy tensor)
+        group2_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(ctx.group2_cb, ctx.bg_dummy_tensor)
+        if ctx.use_face_view:
+            group2_cb_descriptor.format_descriptors[0].tile = ctx.face_tile_desc
+            group2_cb_descriptor.format_descriptors[0].page_size = ctx.face_tile_size
+
+        tile_desc = ctx.face_tile_desc if ctx.use_face_view else ttnn.TileDescriptor(ctx.input_tile)
+
+        # CB 2: Intermediate — 2 tiles on sender core, manual
+        intermed_format = ttnn.CBFormatDescriptor(
+            buffer_index=ctx.intermed_cb,
+            data_format=ctx.data_format,
+            page_size=ctx.reduce_tile_size,
+            tile=tile_desc,
+        )
+        intermed_cb_descriptor = ttnn.CBDescriptor(
+            total_size=2 * ctx.reduce_tile_size,
+            core_ranges=ctx.mcast_gather_core_grid,
+            format_descriptors=[intermed_format],
+        )
+
+        # CB 3: Mcast1 source — on sender core, manual, TRISC-filled
+        mcast_src_format = ttnn.CBFormatDescriptor(
+            buffer_index=ctx.mcast_src_cb,
+            data_format=ctx.data_format,
+            page_size=ctx.reduce_tile_size,
+            tile=tile_desc,
+        )
+        mcast_src_cb_descriptor = ttnn.CBDescriptor(
+            total_size=ctx.mcast_src_num_pages * ctx.reduce_tile_size,
+            core_ranges=ctx.mcast_gather_core_grid,
+            format_descriptors=[mcast_src_format],
+        )
+
+        input_tile_desc = ttnn.TileDescriptor(ctx.input_tile)
+
+        # CB 4: Mcast1 dest / down_matmul_in0 — all 130 cores
+        mcast_dst_format = ttnn.CBFormatDescriptor(
+            buffer_index=ctx.mcast_dst_cb,
+            data_format=ctx.data_format,
+            page_size=ctx.input_tile_size,
+            tile=input_tile_desc,
+        )
+        mcast_dst_cb_descriptor = ttnn.CBDescriptor(
+            total_size=ctx.K_down_tiles * ctx.input_tile_size,
+            core_ranges=ctx.all_cores,
+            format_descriptors=[mcast_dst_format],
+        )
+
+        # CB 5: Down weights — tensor-backed on 112 matmul cores
+        matmul_in1_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(ctx.matmul_in1_cb, ctx.down_weights_tensor)
+
+        # CB 6: Down matmul output — on 112 matmul cores
+        matmul_out_format = ttnn.CBFormatDescriptor(
+            buffer_index=ctx.matmul_out_cb,
+            data_format=ctx.data_format,
+            page_size=ctx.tile_1x32_size,
+            tile=ctx.tile_1x32_descriptor,
+        )
+        matmul_out_cb_descriptor = ttnn.CBDescriptor(
+            total_size=ctx.out_w_per_core * ctx.tile_1x32_size,
+            core_ranges=ctx.matmul_core_grid,
+            format_descriptors=[matmul_out_format],
+        )
+
+        # CB 7: Output gather destination — tensor-backed on sender
+        gather_dst_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(ctx.gather_dst_cb, ctx.output_tensor)
+
+        # CB 8: Activation mcast source — tensor-backed on sender
+        act_mcast_src_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(
+            ctx.act_mcast_src_cb, ctx.activation_tensor
+        )
+
+        # CB 9: Activation mcast recv — manual on all 130 cores
+        act_mcast_dst_format = ttnn.CBFormatDescriptor(
+            buffer_index=ctx.act_mcast_dst_cb,
+            data_format=ctx.data_format,
+            page_size=ctx.input_tile_size,
+            tile=input_tile_desc,
+        )
+        act_mcast_dst_cb_descriptor = ttnn.CBDescriptor(
+            total_size=ctx.K_gate_tiles * ctx.input_tile_size,
+            core_ranges=ctx.all_cores,
+            format_descriptors=[act_mcast_dst_format],
+        )
+
+        # CB 10: Residual mcast source — tensor-backed on sender
+        residual_mcast_src_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(
+            ctx.residual_mcast_src_cb, ctx.bias_tensor
+        )
+
+        # CB 11: Residual mcast dest — all 130 cores, manual
+        residual_mcast_dst_format = ttnn.CBFormatDescriptor(
+            buffer_index=ctx.residual_mcast_dst_cb,
+            data_format=ctx.data_format,
+            page_size=ctx.tile_1x32_size,
+            tile=ctx.tile_1x32_descriptor,
+        )
+        residual_mcast_dst_cb_descriptor = ttnn.CBDescriptor(
+            total_size=ctx.total_residual_add_tiles * ctx.tile_1x32_size,
+            core_ranges=ctx.all_cores,
+            format_descriptors=[residual_mcast_dst_format],
+        )
+
+        # CB 12: Residual add output — on 112 matmul cores
+        residual_add_out_format = ttnn.CBFormatDescriptor(
+            buffer_index=ctx.residual_add_out_cb,
+            data_format=ctx.data_format,
+            page_size=ctx.tile_1x32_size,
+            tile=ctx.tile_1x32_descriptor,
+        )
+        residual_add_out_cb_descriptor = ttnn.CBDescriptor(
+            total_size=ctx.out_w_per_core * ctx.tile_1x32_size,
+            core_ranges=ctx.matmul_core_grid,
+            format_descriptors=[residual_add_out_format],
+        )
+
+        # CB 13: Gate/Up weights — tensor-backed on 128 compute cores
+        gu_weights_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(ctx.gu_weights_cb, ctx.gate_up_weights_tensor)
+
+        # CB 14: Gate/Up matmul output — 1 tile on 128 compute cores, manual
+        compute_core_grid = ttnn.CoreRangeSet([ttnn.CoreRange(c, c) for c in ctx.compute_cores_list])
+        gu_out_format = ttnn.CBFormatDescriptor(
+            buffer_index=ctx.gu_out_cb,
+            data_format=ctx.data_format,
+            page_size=ctx.input_tile_size,
+            tile=input_tile_desc,
+        )
+        gu_out_cb_descriptor = ttnn.CBDescriptor(
+            total_size=ctx.input_tile_size,
+            core_ranges=compute_core_grid,
+            format_descriptors=[gu_out_format],
+        )
+
+        return [
+            group1_cb_descriptor,
+            group2_cb_descriptor,
+            intermed_cb_descriptor,
+            mcast_src_cb_descriptor,
+            mcast_dst_cb_descriptor,
+            matmul_in1_cb_descriptor,
+            matmul_out_cb_descriptor,
+            gather_dst_cb_descriptor,
+            act_mcast_src_cb_descriptor,
+            act_mcast_dst_cb_descriptor,
+            residual_mcast_src_cb_descriptor,
+            residual_mcast_dst_cb_descriptor,
+            residual_add_out_cb_descriptor,
+            gu_weights_cb_descriptor,
+            gu_out_cb_descriptor,
+        ]
+
+    @staticmethod
+    def _build_core_descriptors(ctx):
+        """Build per-core and unified compile-time core descriptors."""
+        # Per-core: output gather sender index
+        matmul_cores_list = ttnn.corerange_to_cores(ctx.matmul_core_grid)
+        per_core_gather_idx = PerCoreCompileTimeDescriptor(
+            named_compile_time_arg="gather_sender_idx",
+            core_values=[(core, idx) for idx, core in enumerate(matmul_cores_list)],
+            other_value=0,
+        )
+
+        # Per-core: gate/up gather sender indices
+        def compute_gu_sender_indices(cores_list):
+            indices = []
+            for linear_id, core in enumerate(cores_list):
+                k_idx = linear_id // ctx.n_parallel
+                n_idx = linear_id % ctx.n_parallel
+                if ctx.use_face_view:
+                    sender_idx = k_idx * ctx.n_parallel + n_idx
+                else:
+                    sender_idx = n_idx * ctx.tiles_per_k + k_idx
+                indices.append((core, sender_idx))
+            return indices
+
+        per_core_ag_idx = PerCoreCompileTimeDescriptor(
+            named_compile_time_arg="ag_sender_idx",
+            core_values=compute_gu_sender_indices(ctx.a_cores_list),
+            other_value=0,
+        )
+        per_core_bg_idx = PerCoreCompileTimeDescriptor(
+            named_compile_time_arg="bg_sender_idx",
+            core_values=compute_gu_sender_indices(ctx.b_cores_list),
+            other_value=0,
+        )
+
+        # Per-core: gate/up matmul K-offset
+        per_core_gu_k_offset = PerCoreCompileTimeDescriptor(
+            named_compile_time_arg="gu_k_offset",
+            core_values=[(core, (i // ctx.n_parallel) * ctx.k_per_core) for i, core in enumerate(ctx.a_cores_list)]
+            + [(core, (i // ctx.n_parallel) * ctx.k_per_core) for i, core in enumerate(ctx.b_cores_list)],
+            other_value=0,
+        )
+
+        # Unified core descriptors (role flags)
+        core_descs = [
+            UnifiedCompileTimeCoreDescriptor(
+                named_compile_time_arg="is_gate_compute_core",
+                core_range=ctx.a_compute_grid,
+                value=1,
+                other_value=0,
+            ),
+            UnifiedCompileTimeCoreDescriptor(
+                named_compile_time_arg="is_up_compute_core",
+                core_range=ctx.b_compute_grid,
+                value=1,
+                other_value=0,
+            ),
+            UnifiedCompileTimeCoreDescriptor(
+                named_compile_time_arg="is_gated_reduce_core",
+                core_range=ctx.mcast_gather_core_grid,
+                value=1,
+                other_value=0,
+            ),
+            UnifiedCompileTimeCoreDescriptor(
+                named_compile_time_arg="is_mcast_sender_core",
+                core_range=ctx.mcast_gather_core_grid,
+                value=1,
+                other_value=0,
+            ),
+            UnifiedCompileTimeCoreDescriptor(
+                named_compile_time_arg="is_mcast_receiver_core",
+                core_range=ctx.mcast_receiver_grid,
+                value=1,
+                other_value=0,
+            ),
+            UnifiedCompileTimeCoreDescriptor(
+                named_compile_time_arg="is_matmul_core",
+                core_range=ctx.matmul_core_grid,
+                value=1,
+                other_value=0,
+            ),
+            UnifiedCompileTimeCoreDescriptor(
+                named_compile_time_arg="is_gather_receiver_core",
+                core_range=ctx.mcast_gather_core_grid,
+                value=1,
+                other_value=0,
+            ),
+            UnifiedCompileTimeCoreDescriptor(
+                named_compile_time_arg="gather_use_per_core_sender_idx",
+                core_range=ctx.matmul_core_grid,
+                value=1,
+                other_value=0,
+            ),
+        ]
+
+        per_core_descs = [per_core_gather_idx, per_core_ag_idx, per_core_bg_idx, per_core_gu_k_offset]
+
+        return core_descs, per_core_descs
+
+    @staticmethod
+    def op(
+        activation_tensor,
+        gate_up_weights_tensor,
+        down_weights_tensor,
+        bias_tensor,
+        output_tensor,
+        k_parallel,
+        n_parallel,
+    ):
+        """
+        Execute shared expert operation.
+
+        Args:
+            activation_tensor: [1, K_gate] HEIGHT_SHARDED on (12,9)
+            gate_up_weights_tensor: [128*k_per_core, 32] HEIGHT_SHARDED on 128 compute cores (row_wise)
+            down_weights_tensor: [K_down, N_per_core] WIDTH_SHARDED on 112 matmul cores
+            bias_tensor: [1, N] HEIGHT_SHARDED on (12,9)
+            output_tensor: [1, N] HEIGHT_SHARDED on (12,9)
+            k_parallel: Number of K-parallel partitions per branch (e.g., 8)
+            n_parallel: Number of N-parallel partitions per branch (e.g., 8)
+
+        Returns:
+            Output tensor with result
+        """
+        ctx = SharedExpertOp._setup_dimensions(
+            activation_tensor,
+            gate_up_weights_tensor,
+            down_weights_tensor,
+            bias_tensor,
+            output_tensor,
+            k_parallel,
+            n_parallel,
+        )
+
+        ncrisc_args, brisc_args, trisc_args = SharedExpertOp._build_compile_time_args(ctx)
+        cb_descriptors = SharedExpertOp._build_cb_descriptors(ctx)
+        core_descs, per_core_descs = SharedExpertOp._build_core_descriptors(ctx)
+
+        # Semaphore descriptors
+        full_device_grid = ttnn.CoreRangeSet(
+            [
+                ttnn.CoreRange(
+                    ttnn.CoreCoord(0, 0),
+                    ttnn.CoreCoord(
+                        ctx.device.compute_with_storage_grid_size().x - 1,
+                        ctx.device.compute_with_storage_grid_size().y - 1,
+                    ),
+                )
+            ]
+        )
+        semaphore_descriptors = [
+            ttnn.SemaphoreDescriptor(id=i, core_ranges=full_device_grid, initial_value=0) for i in range(10)
+        ]
+
+        # Kernel descriptor
+        unified_kernel = UnifiedKernelDescriptor(
+            kernel_source="models/demos/deepseek_v3_b1/fused_ops/shared_expert/kernels/shared_expert_kernel.cpp",
+            core_ranges=ctx.all_cores,
+            ncrisc_named_compile_time_args=ncrisc_args,
+            brisc_named_compile_time_args=brisc_args,
+            trisc_named_compile_time_args=trisc_args,
+            trisc_compute_config=ttnn.ComputeConfigDescriptor(
+                math_fidelity=ttnn.MathFidelity.LoFi,
+                math_approx_mode=True,
+                fp32_dest_acc_en=False,
+                dst_full_sync_en=False,
+            ),
+            unified_compile_time_core_descriptors=core_descs,
+            per_core_compile_time_descriptors=per_core_descs,
+        )
+
+        # Program descriptor
+        program_descriptor = ttnn.ProgramDescriptor(
+            kernels=unified_kernel.get_kernel_descriptors().kernels,
+            cbs=cb_descriptors,
+            semaphores=semaphore_descriptors,
+        )
+
+        # Execute generic op
+        io_tensors = [
+            ctx.ag_dummy_tensor,
+            ctx.bg_dummy_tensor,
+            down_weights_tensor,
+            output_tensor,
+            activation_tensor,
+            bias_tensor,
+            gate_up_weights_tensor,
+        ]
+        ttnn.generic_op(io_tensors, program_descriptor)
+        return output_tensor

--- a/models/demos/deepseek_v3_b1/fused_ops/shared_expert/op.py
+++ b/models/demos/deepseek_v3_b1/fused_ops/shared_expert/op.py
@@ -279,6 +279,10 @@ class SharedExpertOp:
         K_gate_tiles = K_gate // tile_w
 
         num_compute_cores = 64
+        assert (
+            K_gate_tiles % k_parallel == 0
+        ), f"K_gate_tiles ({K_gate_tiles}) must be divisible by k_parallel ({k_parallel})"
+        assert k_parallel * n_parallel == num_compute_cores, f"k_parallel * n_parallel must equal {num_compute_cores}"
         k_per_core = K_gate_tiles // k_parallel
         K_down_tiles = n_parallel
 
@@ -364,7 +368,7 @@ class SharedExpertOp:
 
         ag_dummy_tensor = ttnn.from_torch(
             torch.zeros(total_gather_tiles, 32, dtype=torch.bfloat16),
-            dtype=ttnn.bfloat16,
+            dtype=data_format,
             layout=ttnn.TILE_LAYOUT,
             device=device,
             memory_config=ag_dummy_mem,
@@ -372,7 +376,7 @@ class SharedExpertOp:
         )
         bg_dummy_tensor = ttnn.from_torch(
             torch.zeros(total_gather_tiles, 32, dtype=torch.bfloat16),
-            dtype=ttnn.bfloat16,
+            dtype=data_format,
             layout=ttnn.TILE_LAYOUT,
             device=device,
             memory_config=ag_dummy_mem,

--- a/models/demos/deepseek_v3_b1/micro_ops/kn_sliced_matmul/kernels/kn_sliced_matmul_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/micro_ops/kn_sliced_matmul/kernels/kn_sliced_matmul_kernel.cpp
@@ -1,0 +1,51 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+// SPDX-License-Identifier: Apache-2.0
+
+// KNSlicedMatmul standalone kernel
+//
+// Computes: output[1, out_w] = act[k_offset..k_offset+k_per_core] @ weights[k_per_core, out_w]
+//
+// NCRISC: setup_sharded_buffer for activation and weight CBs
+// BRISC: No-op
+// TRISC: KNSlicedMatmul compute
+
+#include "../../../unified_kernels/kernel_op_api.hpp"
+#include "../../../unified_kernels/kernel_utils.hpp"
+#include "../../../unified_kernels/kn_sliced_matmul.hpp"
+
+void kernel_main() {
+#if defined(COMPILE_FOR_NCRISC)
+    constexpr uint32_t act_cb = get_named_compile_time_arg_val("act_cb");
+    constexpr uint32_t act_num_pages = get_named_compile_time_arg_val("act_num_pages");
+    constexpr uint32_t weights_cb = get_named_compile_time_arg_val("weights_cb");
+    constexpr uint32_t weights_num_pages = get_named_compile_time_arg_val("weights_num_pages");
+
+    unified_kernels::setup_sharded_buffer(act_cb, act_num_pages);
+    unified_kernels::setup_sharded_buffer(weights_cb, weights_num_pages);
+
+    using KNSlicedMatmulCTArgs = deepseek_b1_ops::KNSlicedMatmul::ReaderCTArgs;
+    deepseek_b1_ops::KNSlicedMatmul::ReaderArgs matmul_args{};
+    deepseek_b1_ops::KNSlicedMatmul::Op<KNSlicedMatmulCTArgs, true> matmul;
+    matmul(matmul_args);
+
+#elif defined(COMPILE_FOR_BRISC)
+    using KNSlicedMatmulCTArgs = deepseek_b1_ops::KNSlicedMatmul::WriterCTArgs;
+    deepseek_b1_ops::KNSlicedMatmul::WriterArgs matmul_args{};
+    deepseek_b1_ops::KNSlicedMatmul::Op<KNSlicedMatmulCTArgs, true> matmul;
+    matmul(matmul_args);
+
+#elif defined(COMPILE_FOR_TRISC)
+    using KNSlicedMatmulCTArgs =
+        deepseek_b1_ops::KNSlicedMatmul::ComputeCTArgs<get_named_compile_time_arg_val("out_w")>;
+    deepseek_b1_ops::KNSlicedMatmul::ComputeArgs matmul_args{
+        get_named_compile_time_arg_val("act_cb"),
+        get_named_compile_time_arg_val("weights_cb"),
+        get_named_compile_time_arg_val("out_cb"),
+        get_named_compile_time_arg_val("k_offset"),
+        get_named_compile_time_arg_val("k_per_core"),
+        get_named_compile_time_arg_val("act_total_tiles"),
+    };
+    deepseek_b1_ops::KNSlicedMatmul::Op<KNSlicedMatmulCTArgs, true, /*pop_act=*/true, /*pop_weights=*/false> matmul;
+    matmul(matmul_args);
+#endif
+}

--- a/models/demos/deepseek_v3_b1/micro_ops/kn_sliced_matmul/op.py
+++ b/models/demos/deepseek_v3_b1/micro_ops/kn_sliced_matmul/op.py
@@ -1,0 +1,116 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+KNSlicedMatmul standalone micro-op.
+
+Computes: output[1, out_w] = act[k_offset..k_offset+k_per_core] @ weights[k_per_core, out_w]
+
+Each core takes a K-slice of the shared activation buffer (via k_offset) and
+multiplies it against its local weight shard, producing out_w output tiles.
+"""
+
+import ttnn
+from models.demos.deepseek_v3_b1.unified_kernel_descriptor import PerCoreCompileTimeDescriptor, UnifiedKernelDescriptor
+
+
+class KNSlicedMatmulOp:
+    """
+    KN-sliced matmul micro-op.
+
+    Each core computes: act[k_offset..k_offset+k_per_core] @ weights[k_per_core, out_w]
+    """
+
+    KERNEL_SOURCE = "models/demos/deepseek_v3_b1/micro_ops/kn_sliced_matmul/kernels/kn_sliced_matmul_kernel.cpp"
+
+    @staticmethod
+    def op(
+        activation_tensor,
+        weights_tensor,
+        output_tensor,
+        k_per_core,
+        out_w,
+        core_k_offsets=None,
+    ):
+        """
+        Execute KNSlicedMatmul.
+
+        Args:
+            activation_tensor: [M, K] HEIGHT_SHARDED (full K on each core)
+            weights_tensor: [k_per_core*32, out_w*32] HEIGHT_SHARDED or WIDTH_SHARDED per core
+            output_tensor: [M, out_w*32] HEIGHT_SHARDED per core
+            k_per_core: Number of K tiles each core processes
+            out_w: Number of output tiles per core
+            core_k_offsets: List of (CoreCoord, k_offset) tuples for per-core offsets.
+                            If None, all cores use k_offset=0.
+
+        Returns:
+            Output tensor with results
+        """
+        act_shard_spec = activation_tensor.memory_config().shard_spec
+        act_total_tiles = act_shard_spec.shape[1] // activation_tensor.get_tile().tile_shape[1]
+
+        # CB indices
+        act_cb = 0
+        weights_cb = 1
+        out_cb = 2
+
+        core_grid = output_tensor.memory_config().shard_spec.grid
+
+        # Compile-time args
+        ncrisc_args = [
+            ("act_cb", act_cb),
+            ("act_num_pages", act_total_tiles),
+            ("weights_cb", weights_cb),
+            ("weights_num_pages", k_per_core * out_w),
+        ]
+        brisc_args = []
+        trisc_args = [
+            ("act_cb", act_cb),
+            ("weights_cb", weights_cb),
+            ("out_cb", out_cb),
+            ("k_per_core", k_per_core),
+            ("act_total_tiles", act_total_tiles),
+            ("out_w", out_w),
+        ]
+
+        per_core_descs = []
+        if core_k_offsets is not None:
+            per_core_descs.append(
+                PerCoreCompileTimeDescriptor(
+                    named_compile_time_arg="k_offset",
+                    core_values=core_k_offsets,
+                    other_value=0,
+                )
+            )
+        else:
+            trisc_args.append(("k_offset", 0))
+
+        unified_kernel = UnifiedKernelDescriptor(
+            kernel_source=KNSlicedMatmulOp.KERNEL_SOURCE,
+            core_ranges=core_grid,
+            ncrisc_named_compile_time_args=ncrisc_args,
+            brisc_named_compile_time_args=brisc_args,
+            trisc_named_compile_time_args=trisc_args,
+            trisc_compute_config=ttnn.ComputeConfigDescriptor(
+                math_fidelity=ttnn.MathFidelity.LoFi,
+                math_approx_mode=False,
+                fp32_dest_acc_en=False,
+                dst_full_sync_en=False,
+            ),
+            per_core_compile_time_descriptors=per_core_descs,
+        )
+
+        program_descriptor = ttnn.ProgramDescriptor(
+            kernels=unified_kernel.get_kernel_descriptors().kernels,
+            cbs=[
+                ttnn.cb_descriptor_from_sharded_tensor(act_cb, activation_tensor),
+                ttnn.cb_descriptor_from_sharded_tensor(weights_cb, weights_tensor),
+                ttnn.cb_descriptor_from_sharded_tensor(out_cb, output_tensor),
+            ],
+            semaphores=[],
+        )
+
+        ttnn.generic_op([activation_tensor, weights_tensor, output_tensor], program_descriptor)
+        return output_tensor

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_gated_local_reduce.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_gated_local_reduce.py
@@ -1,0 +1,249 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Tests for gated local reduce with SiLU activation.
+
+Two parallel reductions:
+    group1_result = SiLU(group1[0] + group1[1] + ... + group1[n-1])
+    group2_result = group2[0] + group2[1] + ... + group2[m-1]
+    output = group1_result + group2_result
+
+This pattern is used in gated MLP where:
+  - Group 1 is the "gate" path (with SiLU)
+  - Group 2 is the "up" path (no SiLU)
+"""
+
+import pytest
+import torch
+from loguru import logger
+
+import ttnn
+from models.common.utility_functions import comp_pcc
+from models.demos.deepseek_v3_b1.fused_ops.gated_local_reduce.op import GatedLocalReduceOp
+
+
+@pytest.mark.parametrize(
+    "tile_h, tile_w, group1_num_tiles, group2_num_tiles",
+    [
+        (32, 32, 2, 2),  # Minimal case: 2 tiles each
+        (32, 32, 4, 2),  # More group1 tiles
+        (32, 32, 2, 4),  # More group2 tiles
+        (32, 32, 4, 4),  # Equal larger groups
+        (16, 16, 4, 4),  # Smaller tiles
+        (32, 32, 8, 8),  # Larger groups (simulates MoE expert accumulation)
+    ],
+)
+def test_gated_local_reduce(device, tile_h, tile_w, group1_num_tiles, group2_num_tiles):
+    """Test gated local reduce with SiLU on group1."""
+    tile = ttnn.Tile([tile_h, tile_w])
+
+    core = ttnn.CoreCoord(0, 0)
+    core_grid = ttnn.CoreRangeSet({ttnn.CoreRange(core, core)})
+
+    logger.info(
+        f"Testing gated local reduce: tile=[{tile_h}, {tile_w}], "
+        f"group1={group1_num_tiles} tiles, group2={group2_num_tiles} tiles"
+    )
+
+    # Create input tensors for both groups
+    torch.manual_seed(42)
+    group1_inputs = [torch.randn((tile_h, tile_w), dtype=torch.bfloat16) for _ in range(group1_num_tiles)]
+    group2_inputs = [torch.randn((tile_h, tile_w), dtype=torch.bfloat16) for _ in range(group2_num_tiles)]
+
+    # Golden reference
+    torch_expected = GatedLocalReduceOp.golden(
+        [t.float() for t in group1_inputs], [t.float() for t in group2_inputs]
+    ).bfloat16()
+
+    # Stack inputs into tensors
+    torch_group1_stacked = torch.cat(group1_inputs, dim=0)  # [N*tile_h, tile_w]
+    torch_group2_stacked = torch.cat(group2_inputs, dim=0)  # [M*tile_h, tile_w]
+
+    # Create sharded memory config for group1 input
+    group1_shard_shape = (group1_num_tiles * tile_h, tile_w)
+    group1_shard_spec = ttnn.ShardSpec(
+        core_grid,
+        group1_shard_shape,
+        ttnn.ShardOrientation.ROW_MAJOR,
+    )
+    group1_mem_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, group1_shard_spec)
+
+    ttnn_group1 = ttnn.from_torch(
+        torch_group1_stacked,
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        memory_config=group1_mem_config,
+        tile=tile,
+    )
+
+    # Create sharded memory config for group2 input
+    group2_shard_shape = (group2_num_tiles * tile_h, tile_w)
+    group2_shard_spec = ttnn.ShardSpec(
+        core_grid,
+        group2_shard_shape,
+        ttnn.ShardOrientation.ROW_MAJOR,
+    )
+    group2_mem_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, group2_shard_spec)
+
+    ttnn_group2 = ttnn.from_torch(
+        torch_group2_stacked,
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        memory_config=group2_mem_config,
+        tile=tile,
+    )
+
+    # Create output tensor
+    output_shard_shape = (tile_h, tile_w)
+    output_shard_spec = ttnn.ShardSpec(
+        core_grid,
+        output_shard_shape,
+        ttnn.ShardOrientation.ROW_MAJOR,
+    )
+    output_mem_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, output_shard_spec)
+
+    ttnn_output = ttnn.from_torch(
+        torch.zeros((tile_h, tile_w), dtype=torch.bfloat16),
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        memory_config=output_mem_config,
+        tile=tile,
+    )
+
+    logger.info(f"Running gated local reduce: group1={group1_num_tiles} + SiLU, group2={group2_num_tiles}...")
+    ttnn_result = GatedLocalReduceOp.op(
+        ttnn_group1,
+        ttnn_group2,
+        ttnn_output,
+        group1_num_tiles,
+        group2_num_tiles,
+    )
+
+    # Convert back to torch and verify
+    output_torch = ttnn.to_torch(ttnn_result)
+    assert output_torch.shape == (tile_h, tile_w), f"Expected shape ({tile_h}, {tile_w}), got {output_torch.shape}"
+
+    # SiLU uses approximation, so we use a slightly lower PCC threshold
+    pcc_threshold = 0.998
+    passing, pcc_message = comp_pcc(torch_expected, output_torch, pcc_threshold)
+    logger.info(pcc_message)
+
+    assert passing, pcc_message
+
+    logger.info(f"Test passed! (tile=[{tile_h}, {tile_w}], group1={group1_num_tiles}, group2={group2_num_tiles})")
+
+
+@pytest.mark.parametrize(
+    "group1_num_tiles, group2_num_tiles",
+    [
+        (2, 2),  # Minimal MoE case
+        (4, 4),  # Small MoE case
+        (8, 8),  # Medium MoE case
+    ],
+)
+def test_gated_local_reduce_moe_pattern(device, group1_num_tiles, group2_num_tiles):
+    """
+    Test pattern matching MoE gated MLP computation.
+
+    In MoE, we often compute:
+        gate_output = SiLU(sum of gate projections)
+        up_output = sum of up projections
+        final = gate_output * up_output  (element-wise, but here we test addition)
+
+    This test verifies the gated local reduce pattern works for MoE-like workloads.
+    """
+    tile_h, tile_w = 32, 32
+    tile = ttnn.Tile([tile_h, tile_w])
+
+    core = ttnn.CoreCoord(0, 0)
+    core_grid = ttnn.CoreRangeSet({ttnn.CoreRange(core, core)})
+
+    logger.info(f"Testing MoE pattern: group1={group1_num_tiles} (gate+SiLU), group2={group2_num_tiles} (up)")
+
+    # Simulate MoE expert outputs (each expert contributes one tile)
+    torch.manual_seed(123)
+    gate_tiles = [torch.randn((tile_h, tile_w), dtype=torch.bfloat16) for _ in range(group1_num_tiles)]
+    up_tiles = [torch.randn((tile_h, tile_w), dtype=torch.bfloat16) for _ in range(group2_num_tiles)]
+
+    # Golden: SiLU(sum(gate)) + sum(up)
+    torch_expected = GatedLocalReduceOp.golden(
+        [t.float() for t in gate_tiles], [t.float() for t in up_tiles]
+    ).bfloat16()
+
+    # Stack inputs
+    torch_gate_stacked = torch.cat(gate_tiles, dim=0)
+    torch_up_stacked = torch.cat(up_tiles, dim=0)
+
+    # Create tensors on device
+    gate_shard_spec = ttnn.ShardSpec(
+        core_grid,
+        (group1_num_tiles * tile_h, tile_w),
+        ttnn.ShardOrientation.ROW_MAJOR,
+    )
+    gate_mem_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, gate_shard_spec)
+
+    up_shard_spec = ttnn.ShardSpec(
+        core_grid,
+        (group2_num_tiles * tile_h, tile_w),
+        ttnn.ShardOrientation.ROW_MAJOR,
+    )
+    up_mem_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, up_shard_spec)
+
+    output_shard_spec = ttnn.ShardSpec(
+        core_grid,
+        (tile_h, tile_w),
+        ttnn.ShardOrientation.ROW_MAJOR,
+    )
+    output_mem_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, output_shard_spec)
+
+    ttnn_gate = ttnn.from_torch(
+        torch_gate_stacked,
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        memory_config=gate_mem_config,
+        tile=tile,
+    )
+
+    ttnn_up = ttnn.from_torch(
+        torch_up_stacked,
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        memory_config=up_mem_config,
+        tile=tile,
+    )
+
+    ttnn_output = ttnn.from_torch(
+        torch.zeros((tile_h, tile_w), dtype=torch.bfloat16),
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        memory_config=output_mem_config,
+        tile=tile,
+    )
+
+    # Run operation
+    logger.info("Running gated local reduce for MoE pattern...")
+    ttnn_result = GatedLocalReduceOp.op(
+        ttnn_gate,
+        ttnn_up,
+        ttnn_output,
+        group1_num_tiles,
+        group2_num_tiles,
+    )
+
+    # Verify
+    output_torch = ttnn.to_torch(ttnn_result)
+
+    pcc_threshold = 0.998
+    passing, pcc_message = comp_pcc(torch_expected, output_torch, pcc_threshold)
+    logger.info(pcc_message)
+
+    assert passing, pcc_message
+    logger.info(f"MoE pattern test passed! (group1={group1_num_tiles}, group2={group2_num_tiles})")

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_gated_local_reduce.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_gated_local_reduce.py
@@ -8,7 +8,7 @@ Tests for gated local reduce with SiLU activation.
 Two parallel reductions:
     group1_result = SiLU(group1[0] + group1[1] + ... + group1[n-1])
     group2_result = group2[0] + group2[1] + ... + group2[m-1]
-    output = group1_result + group2_result
+    output = group1_result * group2_result
 
 This pattern is used in gated MLP where:
   - Group 1 is the "gate" path (with SiLU)
@@ -153,7 +153,7 @@ def test_gated_local_reduce_moe_pattern(device, group1_num_tiles, group2_num_til
     In MoE, we often compute:
         gate_output = SiLU(sum of gate projections)
         up_output = sum of up projections
-        final = gate_output * up_output  (element-wise, but here we test addition)
+        final = gate_output * up_output  (element-wise multiplication)
 
     This test verifies the gated local reduce pattern works for MoE-like workloads.
     """

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_gated_local_reduce_down_proj.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_gated_local_reduce_down_proj.py
@@ -1,0 +1,271 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Tests for fused Input Gather + Gated Local Reduce + Down Projection.
+
+Fuses:
+  1. Input gather: pull [1,32] tiles from source cores to (12,9)
+  2. Gated reduce: SiLU(sum(group1)) * sum(group2) → [1, K]
+  3. Mcast: broadcast [1, K] to 130-core grid
+  4. Matmul: [1, K] x [K, N_per_core] on 112 cores
+  5. Output gather: collect to [1, N] on sender core
+
+Run:
+    pytest models/demos/deepseek_v3_b1/tests/unit_tests/test_gated_local_reduce_down_proj.py -v -s
+"""
+
+import pytest
+import torch
+from loguru import logger
+
+import ttnn
+from models.common.utility_functions import comp_pcc
+from models.demos.deepseek_v3_b1.fused_ops.down_proj.op import DownProj
+from models.demos.deepseek_v3_b1.fused_ops.face_view_utils import can_use_face_view
+from models.demos.deepseek_v3_b1.fused_ops.gated_local_reduce_down_proj.op import GatedLocalReduceDownProjOp
+from models.demos.deepseek_v3_b1.fused_ops.shared_expert.op import SharedExpertOp
+
+
+@pytest.mark.parametrize(
+    "tiles_per_k, K, N_per_core, weights_dtype",
+    [
+        (2, 256, 32, ttnn.bfloat8_b),  # 2 collections of 8, K=256, N=3584
+        (2, 128, 32, ttnn.bfloat8_b),  # 2 collections of 4, K=128
+        (4, 256, 32, ttnn.bfloat8_b),  # 4 collections of 8, K=256
+        (2, 256, 64, ttnn.bfloat8_b),  # 2 collections, larger output N=7168
+        (2, 256, 64, ttnn.bfloat4_b),  # bfloat4 weights
+        (8, 256, 64, ttnn.bfloat8_b),  # 8 collections, 64+64 A/B grid, N=7168
+    ],
+)
+def test_gated_local_reduce_down_proj(device, tiles_per_k, K, N_per_core, weights_dtype):
+    """Test fused input gather + gated local reduce + down projection."""
+
+    device_grid = device.compute_with_storage_grid_size()
+    if device_grid.x < 13 or device_grid.y < 10:
+        pytest.skip(f"Device grid {device_grid.x}x{device_grid.y} too small for 13x10")
+
+    N = N_per_core * DownProj.NUM_MATMUL_CORES  # 112 cores
+    k_num_tiles = K // 32
+    M = 1
+    num_sources_per_group = tiles_per_k * k_num_tiles
+
+    face_view = can_use_face_view(1, 32, tiles_per_k, k_num_tiles)
+
+    # Use A/B grid when we need 64 sources per group (includes DRAM/phantom cores)
+    use_ab_grid = num_sources_per_group == 64
+
+    logger.info("=" * 70)
+    logger.info("Testing Fused InputGather+GatedLocalReduce+DownProj:")
+    logger.info(f"  tiles_per_k={tiles_per_k}, K={K}, N={N}, N_per_core={N_per_core}")
+    logger.info(f"  k_num_tiles={k_num_tiles}, sources_per_group={num_sources_per_group}")
+    logger.info(f"  weights_dtype={weights_dtype}, face_view={face_view}")
+    logger.info(f"  use_ab_grid={use_ab_grid}")
+    logger.info("=" * 70)
+
+    # Tile definitions
+    a_tile = ttnn.Tile([M, 32])
+    b_tile = ttnn.Tile([32, 32])
+    out_tile = ttnn.Tile([M, 32])
+
+    # ========================================================================
+    # Select source cores
+    # ========================================================================
+    matmul_core_grid = DownProj.build_matmul_core_grid()
+    matmul_cores_list = ttnn.corerange_to_cores(matmul_core_grid)
+
+    if use_ab_grid:
+        # 64+64 layout using DRAM workers, phantoms, and matmul cores
+        g1_source_cores, g2_source_cores = SharedExpertOp.build_ab_grids()
+        logger.info(f"Using A/B grid: {len(g1_source_cores)} A + {len(g2_source_cores)} B source cores")
+    else:
+        # Small cases: pick source cores from matmul cores only
+        total_sources = 2 * num_sources_per_group
+        assert total_sources <= len(
+            matmul_cores_list
+        ), f"Need {total_sources} source cores but only {len(matmul_cores_list)} matmul cores"
+
+        g1_source_cores = matmul_cores_list[:num_sources_per_group]
+        g2_source_cores = matmul_cores_list[num_sources_per_group:total_sources]
+
+    g1_source_grid = ttnn.CoreRangeSet([ttnn.CoreRange(c, c) for c in g1_source_cores])
+    g2_source_grid = ttnn.CoreRangeSet([ttnn.CoreRange(c, c) for c in g2_source_cores])
+
+    # ========================================================================
+    # Create source data: each source core gets one [1, 32] tile
+    # Layout: tiles_per_k collections of k_num_tiles tiles each
+    # Source tensor rows 0..k_num_tiles-1 → collection 0
+    # Source tensor rows k_num_tiles..2*k_num_tiles-1 → collection 1, etc.
+    # ========================================================================
+    torch.manual_seed(42)
+
+    # Generate collection vectors [tiles_per_k, 1, K] for golden
+    g1_collections = [torch.randn((M, K), dtype=torch.bfloat16) for _ in range(tiles_per_k)]
+    g2_collections = [torch.randn((M, K), dtype=torch.bfloat16) for _ in range(tiles_per_k)]
+
+    # Build source tensors: [num_sources_per_group, 32]
+    # Collection c, K-position k → source row c * k_num_tiles + k
+    g1_src_rows = []
+    for c in range(tiles_per_k):
+        for k in range(k_num_tiles):
+            g1_src_rows.append(g1_collections[c][:, k * 32 : (k + 1) * 32])
+    torch_g1_src = torch.cat(g1_src_rows, dim=0)  # [num_sources, 32]
+
+    g2_src_rows = []
+    for c in range(tiles_per_k):
+        for k in range(k_num_tiles):
+            g2_src_rows.append(g2_collections[c][:, k * 32 : (k + 1) * 32])
+    torch_g2_src = torch.cat(g2_src_rows, dim=0)  # [num_sources, 32]
+
+    torch_weights = torch.randn((K, N), dtype=torch.bfloat16)
+    torch_add_input = torch.randn((M, N), dtype=torch.bfloat16)
+
+    # Golden reference
+    torch_expected = GatedLocalReduceDownProjOp.golden(
+        [t.float() for t in g1_collections],
+        [t.float() for t in g2_collections],
+        torch_weights.float(),
+        torch_add_input.float(),
+    ).bfloat16()
+    logger.info(f"Golden output shape: {torch_expected.shape}")
+
+    # ========================================================================
+    # Source tensors: HEIGHT_SHARDED, 1 tile per core
+    # ========================================================================
+    mcast_gather_core = DownProj.MCAST_GATHER_CORE
+    sender_core_grid = ttnn.CoreRangeSet([ttnn.CoreRange(mcast_gather_core, mcast_gather_core)])
+
+    g1_src_shard_spec = ttnn.ShardSpec(g1_source_grid, (M, 32), ttnn.ShardOrientation.ROW_MAJOR)
+    g1_src_mem = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, g1_src_shard_spec)
+
+    ttnn_g1_src = ttnn.from_torch(
+        torch_g1_src,
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        memory_config=g1_src_mem,
+        tile=a_tile,
+    )
+
+    g2_src_shard_spec = ttnn.ShardSpec(g2_source_grid, (M, 32), ttnn.ShardOrientation.ROW_MAJOR)
+    g2_src_mem = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, g2_src_shard_spec)
+
+    ttnn_g2_src = ttnn.from_torch(
+        torch_g2_src,
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        memory_config=g2_src_mem,
+        tile=a_tile,
+    )
+    logger.info(f"Created source tensors: {num_sources_per_group} cores per group")
+
+    # ========================================================================
+    # Gather destination tensors on sender core (pre-allocated, filled by gather)
+    # ========================================================================
+    dst_shard_shape = (num_sources_per_group * M, 32)
+    dst_shard_spec = ttnn.ShardSpec(sender_core_grid, dst_shard_shape, ttnn.ShardOrientation.ROW_MAJOR)
+    dst_mem = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, dst_shard_spec)
+
+    ttnn_g1_dst = ttnn.from_torch(
+        torch.zeros(num_sources_per_group * M, 32, dtype=torch.bfloat16),
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        memory_config=dst_mem,
+        tile=a_tile,
+    )
+    ttnn_g2_dst = ttnn.from_torch(
+        torch.zeros(num_sources_per_group * M, 32, dtype=torch.bfloat16),
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        memory_config=dst_mem,
+        tile=a_tile,
+    )
+    logger.info(
+        f"Created gather dest tensors: shard {dst_shard_shape} on ({mcast_gather_core.x},{mcast_gather_core.y})"
+    )
+
+    # ========================================================================
+    # Weights: WIDTH_SHARDED across 112 matmul cores
+    # ========================================================================
+    weights_shard_spec = ttnn.ShardSpec(matmul_core_grid, (K, N_per_core), ttnn.ShardOrientation.ROW_MAJOR)
+    weights_mem = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.WIDTH_SHARDED, ttnn.BufferType.L1, weights_shard_spec)
+
+    ttnn_weights = ttnn.from_torch(
+        torch_weights,
+        dtype=weights_dtype,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        memory_config=weights_mem,
+        tile=b_tile,
+    )
+    logger.info(f"Created weights tensor: shard ({K}, {N_per_core}) on {DownProj.NUM_MATMUL_CORES} cores")
+
+    # ========================================================================
+    # Output: HEIGHT_SHARDED on sender core
+    # ========================================================================
+    output_shard_spec = ttnn.ShardSpec(sender_core_grid, (M, N), ttnn.ShardOrientation.ROW_MAJOR)
+    output_mem = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, output_shard_spec)
+
+    ttnn_output = ttnn.from_torch(
+        torch.zeros((M, N), dtype=torch.bfloat16),
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        memory_config=output_mem,
+        tile=out_tile,
+    )
+
+    # ========================================================================
+    # Add input (bias): HEIGHT_SHARDED on sender core
+    # ========================================================================
+    add_input_shard_spec = ttnn.ShardSpec(sender_core_grid, (M, N), ttnn.ShardOrientation.ROW_MAJOR)
+    add_input_mem = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, add_input_shard_spec)
+
+    ttnn_add_input = ttnn.from_torch(
+        torch_add_input,
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        memory_config=add_input_mem,
+        tile=out_tile,
+    )
+
+    # ========================================================================
+    # Run fused operation
+    # ========================================================================
+    logger.info("-" * 70)
+    logger.info("Running fused input gather + gated local reduce + down projection ...")
+
+    ttnn_result = GatedLocalReduceDownProjOp.op(
+        ttnn_g1_src,
+        ttnn_g2_src,
+        ttnn_g1_dst,
+        ttnn_g2_dst,
+        ttnn_weights,
+        ttnn_add_input,
+        ttnn_output,
+        tiles_per_k,
+        k_num_tiles,
+    )
+
+    output_torch = ttnn.to_torch(ttnn_result)
+    logger.info(f"Output shape: {output_torch.shape}")
+
+    expected_shape = (M, N)
+    assert output_torch.shape == expected_shape, f"Expected {expected_shape}, got {output_torch.shape}"
+
+    pcc_threshold = 0.97
+    passing, pcc_message = comp_pcc(torch_expected, output_torch, pcc_threshold)
+    logger.info(f"PCC comparison: {pcc_message}")
+
+    assert passing, f"PCC check failed: {pcc_message}"
+    logger.info("=" * 70)
+    logger.info("Fused InputGather+GatedLocalReduce+DownProj test PASSED!")
+    logger.info("=" * 70)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v", "-s"])

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_kn_sliced_matmul.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_kn_sliced_matmul.py
@@ -1,0 +1,185 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Tests for KNSlicedMatmul micro-op.
+
+Verifies: act[k_offset..k_offset+k_per_core] @ weights[k_per_core, out_w] -> output[1, out_w]
+
+Tests both single-core (out_w > 1) and multi-core (k_offset > 0) configurations.
+
+Run:
+    pytest models/demos/deepseek_v3_b1/tests/unit_tests/test_kn_sliced_matmul.py -v -s
+"""
+
+import pytest
+import torch
+from loguru import logger
+
+import ttnn
+from models.common.utility_functions import comp_pcc
+from models.demos.deepseek_v3_b1.micro_ops.kn_sliced_matmul.op import KNSlicedMatmulOp
+
+
+@pytest.mark.parametrize(
+    "k_per_core, out_w",
+    [
+        (4, 1),  # Original: single output tile
+        (4, 2),  # Two output tiles
+        (8, 2),  # Larger K, two output tiles
+        (4, 4),  # Four output tiles
+    ],
+)
+def test_kn_sliced_matmul_single_core(device, k_per_core, out_w):
+    """Test KNSlicedMatmul on a single core with configurable out_w."""
+
+    M = 1
+    act_tile = ttnn.Tile([M, 32])
+    weight_tile = ttnn.Tile([32, 32])
+    out_tile = ttnn.Tile([M, 32])
+
+    K = k_per_core * 32
+    N = out_w * 32
+
+    logger.info(f"Testing KNSlicedMatmul: [{M}, {K}] x [{K}, {N}] -> [{M}, {N}], out_w={out_w}")
+
+    core = ttnn.CoreCoord(0, 0)
+    core_grid = ttnn.CoreRangeSet({ttnn.CoreRange(core, core)})
+
+    torch.manual_seed(42)
+    torch_act = torch.randn((M, K), dtype=torch.bfloat16)
+    torch_weights = torch.randn((K, N), dtype=torch.bfloat16)
+    torch_expected = (torch_act.float() @ torch_weights.float()).bfloat16()
+
+    act_shard = ttnn.ShardSpec(core_grid, (M, K), ttnn.ShardOrientation.ROW_MAJOR)
+    act_mem = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, act_shard)
+    ttnn_act = ttnn.from_torch(
+        torch_act, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device, memory_config=act_mem, tile=act_tile
+    )
+
+    weights_shard = ttnn.ShardSpec(core_grid, (K, N), ttnn.ShardOrientation.ROW_MAJOR)
+    weights_mem = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.WIDTH_SHARDED, ttnn.BufferType.L1, weights_shard)
+    ttnn_weights = ttnn.from_torch(
+        torch_weights,
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        memory_config=weights_mem,
+        tile=weight_tile,
+    )
+
+    out_shard = ttnn.ShardSpec(core_grid, (M, N), ttnn.ShardOrientation.ROW_MAJOR)
+    out_mem = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, out_shard)
+    ttnn_output = ttnn.from_torch(
+        torch.zeros((M, N), dtype=torch.bfloat16),
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        memory_config=out_mem,
+        tile=out_tile,
+    )
+
+    KNSlicedMatmulOp.op(ttnn_act, ttnn_weights, ttnn_output, k_per_core, out_w)
+
+    output_torch = ttnn.to_torch(ttnn_output)
+    assert output_torch.shape == (M, N)
+
+    passing, pcc_message = comp_pcc(torch_expected, output_torch, 0.99)
+    logger.info(f"PCC: {pcc_message}")
+    assert passing, f"PCC check failed: {pcc_message}"
+
+
+@pytest.mark.parametrize(
+    "num_cores, k_per_core, out_w",
+    [
+        (2, 4, 1),  # 2 cores, K-parallel, out_w=1
+        (4, 2, 1),  # 4 cores, K-parallel, out_w=1
+        (2, 4, 2),  # 2 cores, K-parallel, out_w=2
+    ],
+)
+def test_kn_sliced_matmul_k_offset(device, num_cores, k_per_core, out_w):
+    """Test KNSlicedMatmul with k_offset > 0 across multiple cores.
+
+    Each core computes a K-slice partial: act[k_offset..k_offset+k_per_core] @ weights.
+    Verifies each core's output independently against the golden partial.
+    """
+
+    M = 1
+    act_tile = ttnn.Tile([M, 32])
+    weight_tile = ttnn.Tile([32, 32])
+    out_tile = ttnn.Tile([M, 32])
+
+    K_total = num_cores * k_per_core * 32
+    N = out_w * 32
+
+    logger.info(
+        f"Testing KNSlicedMatmul k_offset: {num_cores} cores, "
+        f"K_total={K_total}, k_per_core={k_per_core * 32}, out_w={out_w}"
+    )
+
+    cores = [ttnn.CoreCoord(i, 0) for i in range(num_cores)]
+    core_grid = ttnn.CoreRangeSet([ttnn.CoreRange(c, c) for c in cores])
+
+    torch.manual_seed(42)
+    torch_act = torch.randn((M, K_total), dtype=torch.bfloat16)
+    torch_weights_per_core = [torch.randn((k_per_core * 32, N), dtype=torch.bfloat16) for _ in range(num_cores)]
+
+    # Golden: each core's partial result
+    torch_partials = []
+    for i in range(num_cores):
+        k_start = i * k_per_core * 32
+        k_end = k_start + k_per_core * 32
+        partial = (torch_act[:, k_start:k_end].float() @ torch_weights_per_core[i].float()).bfloat16()
+        torch_partials.append(partial)
+
+    # Activation: replicated on each core via HEIGHT_SHARDED with full [1, K_total] shard.
+    # Each core uses k_offset to index into its slice of the shared activation buffer.
+    act_shard = ttnn.ShardSpec(core_grid, (M, K_total), ttnn.ShardOrientation.ROW_MAJOR)
+    act_mem = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, act_shard)
+    ttnn_act = ttnn.from_torch(
+        torch_act.repeat(num_cores, 1),
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        memory_config=act_mem,
+        tile=act_tile,
+    )
+
+    # Weights: HEIGHT_SHARDED, each core gets [k_per_core * 32, N]
+    torch_weights_stacked = torch.cat(torch_weights_per_core, dim=0)
+    weights_shard = ttnn.ShardSpec(core_grid, (k_per_core * 32, N), ttnn.ShardOrientation.ROW_MAJOR)
+    weights_mem = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, weights_shard)
+    ttnn_weights = ttnn.from_torch(
+        torch_weights_stacked,
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        memory_config=weights_mem,
+        tile=weight_tile,
+    )
+
+    # Output: HEIGHT_SHARDED, each core produces [M, N]
+    out_shard = ttnn.ShardSpec(core_grid, (M, N), ttnn.ShardOrientation.ROW_MAJOR)
+    out_mem = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, out_shard)
+    ttnn_output = ttnn.from_torch(
+        torch.zeros((num_cores * M, N), dtype=torch.bfloat16),
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        memory_config=out_mem,
+        tile=out_tile,
+    )
+
+    core_k_offsets = [(cores[i], i * k_per_core) for i in range(num_cores)]
+    KNSlicedMatmulOp.op(ttnn_act, ttnn_weights, ttnn_output, k_per_core, out_w, core_k_offsets)
+
+    output_torch = ttnn.to_torch(ttnn_output)
+    assert output_torch.shape == (num_cores * M, N)
+
+    for i in range(num_cores):
+        core_output = output_torch[i * M : (i + 1) * M, :]
+        passing, pcc_message = comp_pcc(torch_partials[i], core_output, 0.99)
+        logger.info(f"Core {i} (k_offset={i * k_per_core}): PCC={pcc_message}")
+        assert passing, f"Core {i} PCC check failed: {pcc_message}"
+
+    logger.info(f"PASSED: {num_cores} cores, k_per_core={k_per_core}, out_w={out_w}")

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_mcast_112_core_down.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_mcast_112_core_down.py
@@ -1,0 +1,209 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+TTNN Down Projection (W_down) 112-Core Unit Test
+
+Tests the W_down [1, K] x [K, N] + add_input -> [1, N] fused operation using:
+  {mcast1} -> {mcast2} -> {matmul} -> {add} -> {gather}
+
+on 112 matmul cores within a 13x10 = 130 core mcast grid.
+
+Core Layout:
+    D = DRAM worker (8 cores) — receives mcast semaphore, skips matmul & gather
+    P = Phantom (9 cores, col 12 rows 0-8) — same as DRAM worker
+    M = Mcast sender + Gather receiver at (12, 9)
+    R = Matmul core (112 cores)
+
+Run:
+    pytest models/demos/deepseek_v3_b1/tests/unit_tests/test_mcast_112_core_down.py -v -s
+"""
+
+import pytest
+import torch
+from loguru import logger
+
+import ttnn
+from models.common.utility_functions import comp_pcc
+from models.demos.deepseek_v3_b1.fused_ops.down_proj.op import DownProj
+
+
+@pytest.mark.parametrize(
+    "M, K, N_per_core, weights_dtype",
+    [
+        # (1, 256, 32, ttnn.bfloat8_b),  # Small: 112 * 32 = 3584
+        (1, 256, 64, ttnn.bfloat8_b),  # Target: 112 * 64 = 7168
+        (1, 256, 64, ttnn.bfloat4_b),  # Target with bfloat4 weights
+        # (1, 7168, 64, ttnn.bfloat8_b),  # Full K dimension
+        # (1, 7168, 64, ttnn.bfloat4_b),  # bfloat4 weights
+    ],
+)
+def test_down_proj_112_core(device, M, K, N_per_core, weights_dtype):
+    """Test down projection with mcast1 -> mcast2 -> matmul -> add -> gather on 112 scattered cores"""
+
+    device_grid = device.compute_with_storage_grid_size()
+    logger.info(f"Device grid: {device_grid.x}x{device_grid.y}")
+
+    if device_grid.x < 13 or device_grid.y < 10:
+        pytest.skip(f"Device grid {device_grid.x}x{device_grid.y} too small for 13x10")
+
+    N = N_per_core * DownProj.NUM_MATMUL_CORES  # 112 cores
+
+    logger.info("=" * 70)
+    logger.info(f"Testing Down Projection: [{M}, {K}] x [{K}, {N}] -> [{M}, {N}]")
+    logger.info(f"Matmul cores: {DownProj.NUM_MATMUL_CORES} (scattered)")
+    logger.info(f"Per-core output: {N_per_core} columns")
+    logger.info(f"Weights dtype: {weights_dtype}")
+    logger.info("=" * 70)
+
+    # Tile dimensions
+    a_tile = ttnn.Tile([M, 32])
+    b_tile = ttnn.Tile([32, 32])
+    out_tile = ttnn.Tile([M, 32])
+
+    # Create test data
+    torch.manual_seed(42)
+    torch_input = torch.randn((M, K), dtype=torch.bfloat16)
+    torch_weights = torch.randn((K, N), dtype=torch.bfloat16)
+    torch_add_input = torch.randn((M, N), dtype=torch.bfloat16)
+
+    # Compute golden reference
+    torch_expected = DownProj.golden(torch_input.float(), torch_weights.float(), torch_add_input.float()).bfloat16()
+    logger.info(f"Golden output shape: {torch_expected.shape}")
+
+    # ========================================================================
+    # Input tensor: HEIGHT_SHARDED on mcast/gather core (12, 9)
+    # ========================================================================
+    mcast_gather_core = DownProj.MCAST_GATHER_CORE
+    sender_core_grid = ttnn.CoreRangeSet([ttnn.CoreRange(mcast_gather_core, mcast_gather_core)])
+
+    input_shard_shape = (M, K)
+    input_shard_spec = ttnn.ShardSpec(
+        sender_core_grid,
+        input_shard_shape,
+        ttnn.ShardOrientation.ROW_MAJOR,
+    )
+    input_mem_config = ttnn.MemoryConfig(
+        ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+        ttnn.BufferType.L1,
+        input_shard_spec,
+    )
+
+    ttnn_input = ttnn.from_torch(
+        torch_input,
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        memory_config=input_mem_config,
+        tile=a_tile,
+    )
+    logger.info(f"Created input tensor: shard {input_shard_shape} on ({mcast_gather_core.x},{mcast_gather_core.y})")
+
+    # ========================================================================
+    # Weights: WIDTH_SHARDED across 112 scattered matmul cores
+    # ========================================================================
+    matmul_core_grid = DownProj.build_matmul_core_grid()
+
+    weights_shard_shape = (K, N_per_core)
+    weights_shard_spec = ttnn.ShardSpec(
+        matmul_core_grid,
+        weights_shard_shape,
+        ttnn.ShardOrientation.ROW_MAJOR,
+    )
+    weights_mem_config = ttnn.MemoryConfig(
+        ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+        ttnn.BufferType.L1,
+        weights_shard_spec,
+    )
+
+    ttnn_weights = ttnn.from_torch(
+        torch_weights,
+        dtype=weights_dtype,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        memory_config=weights_mem_config,
+        tile=b_tile,
+    )
+    logger.info(f"Created weights tensor: shard {weights_shard_shape} on {DownProj.NUM_MATMUL_CORES} cores")
+
+    # ========================================================================
+    # Output: HEIGHT_SHARDED on gather core (12, 9)
+    # ========================================================================
+    output_shard_shape = (M, N)
+    output_shard_spec = ttnn.ShardSpec(
+        sender_core_grid,
+        output_shard_shape,
+        ttnn.ShardOrientation.ROW_MAJOR,
+    )
+    output_mem_config = ttnn.MemoryConfig(
+        ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+        ttnn.BufferType.L1,
+        output_shard_spec,
+    )
+
+    torch_output_zeros = torch.zeros((M, N), dtype=torch.bfloat16)
+    ttnn_output = ttnn.from_torch(
+        torch_output_zeros,
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        memory_config=output_mem_config,
+        tile=out_tile,
+    )
+    logger.info(f"Created output tensor: shard {output_shard_shape} on ({mcast_gather_core.x},{mcast_gather_core.y})")
+
+    # ========================================================================
+    # Add input: HEIGHT_SHARDED on mcast/gather core (12, 9)
+    # ========================================================================
+    add_input_shard_shape = (M, N)
+    add_input_shard_spec = ttnn.ShardSpec(
+        sender_core_grid,
+        add_input_shard_shape,
+        ttnn.ShardOrientation.ROW_MAJOR,
+    )
+    add_input_mem_config = ttnn.MemoryConfig(
+        ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+        ttnn.BufferType.L1,
+        add_input_shard_spec,
+    )
+
+    ttnn_add_input = ttnn.from_torch(
+        torch_add_input,
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        memory_config=add_input_mem_config,
+        tile=out_tile,
+    )
+    logger.info(
+        f"Created add_input tensor: shard {add_input_shard_shape} on ({mcast_gather_core.x},{mcast_gather_core.y})"
+    )
+
+    # ========================================================================
+    # Run fused operation
+    # ========================================================================
+    logger.info("-" * 70)
+    logger.info("Running down projection: mcast1 -> mcast2 -> matmul -> add -> gather ...")
+
+    ttnn_result = DownProj.op(ttnn_input, ttnn_weights, ttnn_output, ttnn_add_input)
+
+    # Convert back to torch for comparison
+    output_torch = ttnn.to_torch(ttnn_result)
+    logger.info(f"Output shape: {output_torch.shape}")
+
+    # Verify output shape
+    expected_shape = (M, N)
+    assert output_torch.shape == expected_shape, f"Expected shape {expected_shape}, got {output_torch.shape}"
+
+    # Compare with golden reference
+    passing, pcc_message = comp_pcc(torch_expected, output_torch, 0.97)
+    logger.info(f"PCC comparison: {pcc_message}")
+
+    assert passing, f"PCC check failed: {pcc_message}"
+    logger.info("=" * 70)
+    logger.info("Down projection test PASSED!")
+    logger.info("=" * 70)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v", "-s"])

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_shared_expert.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_shared_expert.py
@@ -1,0 +1,231 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Tests for shared expert operation.
+
+Fuses: Activation Mcast + Gate/Up Matmul + Gather + GatedLocalReduce
+       + Mcast1 + Mcast2 + Down Proj Matmul + Add + Output Gather
+
+Run:
+    pytest models/demos/deepseek_v3_b1/tests/unit_tests/test_shared_expert.py -v -s
+"""
+
+import pytest
+import torch
+from loguru import logger
+
+import ttnn
+from models.common.utility_functions import comp_pcc
+from models.demos.deepseek_v3_b1.fused_ops.down_proj.op import DownProj
+from models.demos.deepseek_v3_b1.fused_ops.shared_expert.op import SharedExpertOp
+
+
+@pytest.mark.parametrize(
+    "K_gate, N_per_core, weights_dtype",
+    [
+        (7168, 64, ttnn.bfloat8_b),  # Full MLP: K_gate=7168, K_down=256, N=7168
+        (2048, 64, ttnn.bfloat8_b),  # Mid: K_gate=2048, K_down=256, N=7168
+        (1024, 32, ttnn.bfloat8_b),  # Small: K_gate=1024, K_down=256, N=3584
+        (7168, 64, ttnn.bfloat4_b),  # bfloat4 weights
+    ],
+)
+def test_shared_expert(device, K_gate, N_per_core, weights_dtype):
+    """Test shared expert: activation → gate/up matmul → gated reduce → down proj + bias."""
+
+    device_grid = device.compute_with_storage_grid_size()
+    if device_grid.x < 13 or device_grid.y < 10:
+        pytest.skip(f"Device grid {device_grid.x}x{device_grid.y} too small for 13x10")
+
+    # Dimensions
+    k_parallel = 8
+    n_parallel = 8
+    K_down = n_parallel * 32  # = 256 (64 partials per branch, 8 N-positions)
+    N = N_per_core * DownProj.NUM_MATMUL_CORES  # e.g. 7168
+    M = 1
+    k_per_core = (K_gate // 32) // k_parallel  # tiles per core along K dimension
+    assert k_per_core * k_parallel * 32 == K_gate, "K_gate must be divisible by 32 * k_parallel"
+
+    logger.info("=" * 70)
+    logger.info("Testing Shared Expert:")
+    logger.info(f"  K_gate={K_gate}, K_down={K_down}, N={N}, N_per_core={N_per_core}")
+    logger.info(f"  k_parallel={k_parallel}, n_parallel={n_parallel}, k_per_core={k_per_core}")
+    logger.info(f"  weights_dtype={weights_dtype}")
+    logger.info("=" * 70)
+
+    # Tile definitions
+    a_tile = ttnn.Tile([M, 32])
+    b_tile = ttnn.Tile([32, 32])
+    out_tile = ttnn.Tile([M, 32])
+
+    # ========================================================================
+    # Core grids
+    # ========================================================================
+    a_cores_list, b_cores_list = SharedExpertOp.build_ab_grids()
+    compute_cores_list = a_cores_list + b_cores_list  # 128 compute cores
+
+    mcast_gather_core = DownProj.MCAST_GATHER_CORE
+    sender_core_grid = ttnn.CoreRangeSet([ttnn.CoreRange(mcast_gather_core, mcast_gather_core)])
+
+    matmul_core_grid = DownProj.build_matmul_core_grid()
+
+    # ========================================================================
+    # Create test data
+    # ========================================================================
+    torch.manual_seed(42)
+
+    torch_activation = torch.randn((M, K_gate), dtype=torch.bfloat16)
+    torch_gate_weights = torch.randn((K_gate, K_down), dtype=torch.bfloat16)
+    torch_up_weights = torch.randn((K_gate, K_down), dtype=torch.bfloat16)
+    torch_down_weights = torch.randn((K_down, N), dtype=torch.bfloat16)
+    torch_bias = torch.randn((M, N), dtype=torch.bfloat16)
+
+    # Golden reference
+    torch_expected = SharedExpertOp.golden(
+        torch_activation.float(),
+        torch_gate_weights.float(),
+        torch_up_weights.float(),
+        torch_down_weights.float(),
+        torch_bias.float(),
+    ).bfloat16()
+    logger.info(f"Golden output shape: {torch_expected.shape}")
+
+    # ========================================================================
+    # Activation tensor: [1, K_gate] HEIGHT_SHARDED on sender (12,9)
+    # ========================================================================
+    act_shard_spec = ttnn.ShardSpec(sender_core_grid, (M, K_gate), ttnn.ShardOrientation.ROW_MAJOR)
+    act_mem = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, act_shard_spec)
+
+    ttnn_activation = ttnn.from_torch(
+        torch_activation,
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        memory_config=act_mem,
+        tile=a_tile,
+    )
+
+    # ========================================================================
+    # Gate/Up weights: stacked, HEIGHT_SHARDED on 128 compute cores
+    # Each core gets [k_per_core, 32] weight shard
+    # A cores get gate weight shards, B cores get up weight shards
+    # Row order must match compute_cores_list = a_cores + b_cores
+    # ========================================================================
+    # Build weight tensor with shards ordered by compute core list
+    weight_shards = []
+    for i, core in enumerate(a_cores_list):
+        # A core i: k_idx = i // n_parallel, n_idx = i % n_parallel
+        k_idx = i // n_parallel
+        n_idx = i % n_parallel
+        k_start = k_idx * k_per_core * 32
+        k_end = k_start + k_per_core * 32
+        n_start = n_idx * 32
+        n_end = n_start + 32
+        weight_shards.append(torch_gate_weights[k_start:k_end, n_start:n_end])
+
+    for i, core in enumerate(b_cores_list):
+        k_idx = i // n_parallel
+        n_idx = i % n_parallel
+        k_start = k_idx * k_per_core * 32
+        k_end = k_start + k_per_core * 32
+        n_start = n_idx * 32
+        n_end = n_start + 32
+        weight_shards.append(torch_up_weights[k_start:k_end, n_start:n_end])
+
+    # Stack all shards: [128 * k_per_core, 32]
+    torch_gate_up_stacked = torch.cat(weight_shards, dim=0)
+    logger.info(f"Gate/Up weights stacked shape: {torch_gate_up_stacked.shape}")
+
+    compute_core_grid = ttnn.CoreRangeSet([ttnn.CoreRange(c, c) for c in compute_cores_list])
+    gu_shard_spec = ttnn.ShardSpec(compute_core_grid, (k_per_core * 32, 32), ttnn.ShardOrientation.ROW_MAJOR)
+    gu_mem = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, gu_shard_spec)
+
+    ttnn_gate_up_weights = ttnn.from_torch(
+        torch_gate_up_stacked,
+        dtype=weights_dtype,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        memory_config=gu_mem,
+        tile=b_tile,
+    )
+
+    # ========================================================================
+    # Down proj weights: [K_down, N] WIDTH_SHARDED on 112 matmul cores
+    # ========================================================================
+    down_shard_spec = ttnn.ShardSpec(matmul_core_grid, (K_down, N_per_core), ttnn.ShardOrientation.ROW_MAJOR)
+    down_mem = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.WIDTH_SHARDED, ttnn.BufferType.L1, down_shard_spec)
+
+    ttnn_down_weights = ttnn.from_torch(
+        torch_down_weights,
+        dtype=weights_dtype,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        memory_config=down_mem,
+        tile=b_tile,
+    )
+    logger.info(f"Down weights: shard ({K_down}, {N_per_core}) on {DownProj.NUM_MATMUL_CORES} cores")
+
+    # ========================================================================
+    # Bias: [1, N] HEIGHT_SHARDED on sender (12,9)
+    # ========================================================================
+    bias_shard_spec = ttnn.ShardSpec(sender_core_grid, (M, N), ttnn.ShardOrientation.ROW_MAJOR)
+    bias_mem = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, bias_shard_spec)
+
+    ttnn_bias = ttnn.from_torch(
+        torch_bias,
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        memory_config=bias_mem,
+        tile=out_tile,
+    )
+
+    # ========================================================================
+    # Output: [1, N] HEIGHT_SHARDED on sender (12,9)
+    # ========================================================================
+    output_shard_spec = ttnn.ShardSpec(sender_core_grid, (M, N), ttnn.ShardOrientation.ROW_MAJOR)
+    output_mem = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, output_shard_spec)
+
+    ttnn_output = ttnn.from_torch(
+        torch.zeros((M, N), dtype=torch.bfloat16),
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        memory_config=output_mem,
+        tile=out_tile,
+    )
+
+    # ========================================================================
+    # Run shared expert
+    # ========================================================================
+    logger.info("-" * 70)
+    logger.info("Running shared expert ...")
+
+    ttnn_result = SharedExpertOp.op(
+        ttnn_activation,
+        ttnn_gate_up_weights,
+        ttnn_down_weights,
+        ttnn_bias,
+        ttnn_output,
+        k_parallel,
+        n_parallel,
+    )
+
+    output_torch = ttnn.to_torch(ttnn_result)
+    logger.info(f"Output shape: {output_torch.shape}")
+
+    expected_shape = (M, N)
+    assert output_torch.shape == expected_shape, f"Expected {expected_shape}, got {output_torch.shape}"
+
+    pcc_threshold = 0.97
+    passing, pcc_message = comp_pcc(torch_expected, output_torch, pcc_threshold)
+    logger.info(f"PCC comparison: {pcc_message}")
+
+    assert passing, f"PCC check failed: {pcc_message}"
+    logger.info("=" * 70)
+    logger.info("Shared expert test PASSED!")
+    logger.info("=" * 70)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v", "-s"])

--- a/models/demos/deepseek_v3_b1/unified_kernels/gated_reduce.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/gated_reduce.hpp
@@ -1,0 +1,146 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "kernel_op_api.hpp"
+
+#if defined(COMPILE_FOR_BRISC)
+#include "api/dataflow/dataflow_api.h"
+#elif defined(COMPILE_FOR_NCRISC)
+#include "api/dataflow/dataflow_api.h"
+#elif defined(COMPILE_FOR_TRISC)
+#include "compute_kernel_api.h"
+#include "compute_kernel_api/eltwise_binary.h"
+#include "compute_kernel_api/eltwise_unary/sfpu_split_includes.h"
+#include "compute_kernel_api/tile_move_copy.h"
+#endif
+
+namespace deepseek_b1_ops {
+
+// ============================================================================
+// GatedReduce micro-op: SiLU(sum(group1)) * sum(group2)
+//
+// Performs gated local reduction over two groups of input tiles:
+//   1. Reduces group1 tiles with pairwise add, applies SiLU
+//   2. Reduces group2 tiles with pairwise add (no activation)
+//   3. Multiplies the two results
+//
+// Produces k_num_tiles output tiles (one per K iteration).
+// Each iteration consumes tiles_per_k tiles from each group CB.
+//
+// CB Layout:
+//   group1_cb:   Gate partials (tiles_per_k tiles consumed per iteration)
+//   group2_cb:   Up partials (tiles_per_k tiles consumed per iteration)
+//   intermed_cb: Intermediate buffer (2 tiles, reused each iteration)
+//   out_cb:      Output (1 tile produced per iteration)
+// ============================================================================
+struct GatedReduce {
+    struct ReaderCTArgs {};
+    struct WriterCTArgs {};
+
+    template <uint32_t TilesPerK, uint32_t KNumTiles>
+    struct ComputeCTArgs {
+        static constexpr uint32_t tiles_per_k = TilesPerK;
+        static constexpr uint32_t k_num_tiles = KNumTiles;
+    };
+
+    struct ReaderArgs {};
+    struct WriterArgs {};
+
+    struct ComputeArgs {
+        uint32_t group1_cb;    // gate partials CB
+        uint32_t group2_cb;    // up partials CB
+        uint32_t intermed_cb;  // intermediate CB (2 tiles, reused)
+        uint32_t out_cb;       // output CB (1 tile per iteration)
+    };
+
+    using RTArgs = unified_kernels::SelectByRISCV<ReaderArgs, WriterArgs, ComputeArgs>;
+
+    template <typename CTArgs, bool IsActiveCore>
+    class Op {
+    public:
+        void operator()(const RTArgs& args) {
+            if constexpr (IsActiveCore) {
+                impl(args);
+            }
+        }
+
+    private:
+        void impl(const RTArgs& args) {
+#if defined(COMPILE_FOR_TRISC)
+            constexpr uint32_t tiles_per_k = CTArgs::tiles_per_k;
+            constexpr uint32_t k_num_tiles = CTArgs::k_num_tiles;
+
+            // Init add + silu for group1 once before the loop
+            binary_op_init_common(args.group1_cb, args.group1_cb, args.intermed_cb);
+            add_tiles_init(args.group1_cb, args.group1_cb, true /* acc_to_dest */);
+            silu_tile_init();
+
+            for (uint32_t k = 0; k < k_num_tiles; k++) {
+                // Group 1: reduce + SiLU (add already initialized)
+                cb_wait_front(args.group1_cb, tiles_per_k);
+                cb_reserve_back(args.intermed_cb, 1);
+
+                tile_regs_acquire();
+                for (uint32_t i = 0; i < tiles_per_k; i += 2) {
+                    add_tiles(args.group1_cb, args.group1_cb, i, i + 1, 0);
+                }
+                silu_tile(0);
+                tile_regs_commit();
+                tile_regs_wait();
+                pack_tile(0, args.intermed_cb);
+                tile_regs_release();
+
+                cb_pop_front(args.group1_cb, tiles_per_k);
+                cb_push_back(args.intermed_cb, 1);
+
+                // Group 2: reduce (re-init add for different CB)
+                binary_op_init_common(args.group2_cb, args.group2_cb, args.intermed_cb);
+                add_tiles_init(args.group2_cb, args.group2_cb, true /* acc_to_dest */);
+
+                cb_wait_front(args.group2_cb, tiles_per_k);
+                cb_reserve_back(args.intermed_cb, 1);
+
+                tile_regs_acquire();
+                for (uint32_t i = 0; i < tiles_per_k; i += 2) {
+                    add_tiles(args.group2_cb, args.group2_cb, i, i + 1, 0);
+                }
+                tile_regs_commit();
+                tile_regs_wait();
+                pack_tile(0, args.intermed_cb);
+                tile_regs_release();
+
+                cb_pop_front(args.group2_cb, tiles_per_k);
+                cb_push_back(args.intermed_cb, 1);
+
+                // Multiply: SiLU(g1) * g2
+                cb_wait_front(args.intermed_cb, 2);
+                cb_reserve_back(args.out_cb, 1);
+
+                binary_op_init_common(args.intermed_cb, args.intermed_cb, args.out_cb);
+                mul_tiles_init(args.intermed_cb, args.intermed_cb);
+
+                tile_regs_acquire();
+                mul_tiles(args.intermed_cb, args.intermed_cb, 0, 1, 0);
+                tile_regs_commit();
+                tile_regs_wait();
+                pack_tile(0, args.out_cb);
+                tile_regs_release();
+
+                cb_pop_front(args.intermed_cb, 2);
+                cb_push_back(args.out_cb, 1);
+
+                // Re-init add for group1 in next iteration
+                if constexpr (k_num_tiles > 1) {
+                    binary_op_init_common(args.group1_cb, args.group1_cb, args.intermed_cb);
+                    add_tiles_init(args.group1_cb, args.group1_cb, true /* acc_to_dest */);
+                    silu_tile_init();
+                }
+            }
+#endif
+        }
+    };
+};
+
+}  // namespace deepseek_b1_ops

--- a/models/demos/deepseek_v3_b1/unified_kernels/gated_reduce.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/gated_reduce.hpp
@@ -71,6 +71,7 @@ struct GatedReduce {
 #if defined(COMPILE_FOR_TRISC)
             constexpr uint32_t tiles_per_k = CTArgs::tiles_per_k;
             constexpr uint32_t k_num_tiles = CTArgs::k_num_tiles;
+            static_assert(tiles_per_k >= 2 && tiles_per_k % 2 == 0, "tiles_per_k must be even and >= 2");
 
             // Init add + silu for group1 once before the loop
             binary_op_init_common(args.group1_cb, args.group1_cb, args.intermed_cb);

--- a/models/demos/deepseek_v3_b1/unified_kernels/kn_sliced_matmul.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/kn_sliced_matmul.hpp
@@ -1,0 +1,139 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "kernel_op_api.hpp"
+
+#if defined(COMPILE_FOR_BRISC)
+#include "api/dataflow/dataflow_api.h"
+#elif defined(COMPILE_FOR_NCRISC)
+#include "api/dataflow/dataflow_api.h"
+#elif defined(COMPILE_FOR_TRISC)
+#include "compute_kernel_api.h"
+#include "compute_kernel_api/matmul.h"
+#include "../kernel_includes/tt_metal/include/compute_kernel_api/custom_mm.h"
+#include "compute_kernel_api/tile_move_copy.h"
+#endif
+
+namespace deepseek_b1_ops {
+
+// ============================================================================
+// KNSlicedMatmul micro-op: KN-parallel partial matmul with offset into activation buffer
+//
+// Computes: output[1,1] = act[k_offset..k_offset+k_per_core] @ weights[k_per_core,1]
+//
+// Each core takes a slice of the shared activation buffer (via k_offset) and
+// multiplies it against its local weight shard, producing a single output tile.
+// Fixed properties: out_w=1, transpose=false, split_acc=true, dense_packing=true.
+//
+// CB States:
+//   NCRISC: No-op (weights setup done externally via setup_sharded_buffer)
+//   BRISC: No-op
+//   TRISC (Compute):
+//     - Waits: act_cb (act_total_tiles), weights_cb (k_per_core)
+//     - Reserves: out_cb (1 tile)
+//     - Pushes: out_cb (1 tile)
+//     - Pops: act_cb (act_total_tiles) if pop_act=true,
+//             weights_cb (k_per_core) if pop_weights=true
+// ============================================================================
+struct KNSlicedMatmul {
+    // ========================================================================
+    // Compile-time args structs - different layout per RISC
+    // ========================================================================
+
+    // Reader CTArgs (NCRISC): none
+    struct ReaderCTArgs {};
+
+    // Writer CTArgs (BRISC): none
+    struct WriterCTArgs {};
+
+    // Compute CTArgs (TRISC): none (out_w=1, split_acc=true are fixed)
+    struct ComputeCTArgs {};
+
+    // ========================================================================
+    // Runtime args structs - different layout per RISC
+    // ========================================================================
+
+    // Reader args (NCRISC): none
+    struct ReaderArgs {};
+
+    // Writer args (BRISC): none
+    struct WriterArgs {};
+
+    // Compute args (TRISC)
+    struct ComputeArgs {
+        uint32_t act_cb;           // activation CB (full shared buffer)
+        uint32_t weights_cb;       // weights CB (per-core K-slice)
+        uint32_t out_cb;           // output CB (1 tile)
+        uint32_t k_offset;         // tile offset into act_cb
+        uint32_t k_per_core;       // K tiles this core processes
+        uint32_t act_total_tiles;  // total tiles in act_cb (for wait/pop)
+    };
+
+    using RTArgs = unified_kernels::SelectByRISCV<ReaderArgs, WriterArgs, ComputeArgs>;
+
+    // ========================================================================
+    // Op - the actual operation, templated on CTArgs and IsActiveCore
+    // Template args:
+    //   CTArgs - compile-time args struct (ReaderCTArgs, WriterCTArgs, or ComputeCTArgs)
+    //   IsActiveCore - whether this core runs the matmul
+    //   pop_act - whether to pop act_cb after compute (default true)
+    //   pop_weights - whether to pop weights_cb after compute (default false)
+    // ========================================================================
+    template <typename CTArgs, bool IsActiveCore, bool pop_act = true, bool pop_weights = false>
+    class Op {
+    public:
+        void operator()(const RTArgs& args) {
+            if constexpr (IsActiveCore) {
+                impl(args);
+            }
+        }
+
+    private:
+        void impl(const RTArgs& args) {
+#if defined(COMPILE_FOR_TRISC)
+            // ================================================================
+            // TRISC (Compute)
+            // ================================================================
+            constexpr bool transpose = false;
+            constexpr bool split_acc = true;
+            constexpr bool dense_packing = true;
+            constexpr bool finalize = true;
+            constexpr uint32_t out_w = 1;
+
+            // Wait for all activation tiles and weight tiles
+            cb_wait_front(args.act_cb, args.act_total_tiles);
+            cb_wait_front(args.weights_cb, args.k_per_core);
+
+            // Reserve output tile
+            cb_reserve_back(args.out_cb, 1);
+
+            custom_mm_block_init<transpose, split_acc, dense_packing>(args.act_cb, args.weights_cb, args.out_cb, out_w);
+
+            tile_regs_acquire();
+            custom_mm_block<finalize, false>(args.act_cb, args.weights_cb, args.k_offset, 0, 0, args.k_per_core, out_w);
+            tile_regs_commit();
+
+            tile_regs_wait();
+            pack_tile(0, args.out_cb, 0);
+            tile_regs_release();
+
+            custom_mm_block_uninit<dense_packing>();
+
+            // Pop inputs
+            if constexpr (pop_act) {
+                cb_pop_front(args.act_cb, args.act_total_tiles);
+            }
+            if constexpr (pop_weights) {
+                cb_pop_front(args.weights_cb, args.k_per_core);
+            }
+
+            cb_push_back(args.out_cb, 1);
+#endif
+        }
+    };  // class Op
+
+};  // struct KNSlicedMatmul
+
+}  // namespace deepseek_b1_ops

--- a/models/demos/deepseek_v3_b1/unified_kernels/residual_add.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/residual_add.hpp
@@ -1,0 +1,88 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "kernel_op_api.hpp"
+
+#if defined(COMPILE_FOR_TRISC)
+#include "compute_kernel_api/eltwise_binary.h"
+#endif
+
+namespace deepseek_b1_ops {
+
+// ============================================================================
+// ResidualAdd micro-op: matmul_out + shard(residual) → add_out
+//
+// Each matmul core adds its local matmul output tiles with the corresponding
+// shard of a broadcast residual CB. The residual CB contains the full [1, N]
+// residual (all total_in1_tiles tiles); each core indexes at offset
+// core_idx * out_w.
+//
+// CB Layout:
+//   in0_cb:  matmul output (out_w tiles, consumed)
+//   in1_cb:  full residual (total_in1_tiles tiles, consumed after add)
+//   out_cb:  add output (out_w tiles, produced)
+// ============================================================================
+struct ResidualAdd {
+    struct ReaderCTArgs {};
+    struct WriterCTArgs {};
+
+    template <uint32_t OutW>
+    struct ComputeCTArgs {
+        static constexpr uint32_t out_w = OutW;
+    };
+
+    struct ReaderArgs {};
+    struct WriterArgs {};
+
+    struct ComputeArgs {
+        uint32_t in0_cb;           // matmul output
+        uint32_t in1_cb;           // full residual CB (all N tiles)
+        uint32_t out_cb;           // add output
+        uint32_t total_in1_tiles;  // total tiles in residual CB
+        uint32_t core_idx;         // index into residual CB (= core_idx * out_w)
+    };
+
+    using RTArgs = unified_kernels::SelectByRISCV<ReaderArgs, WriterArgs, ComputeArgs>;
+
+    template <typename CTArgs, bool IsActiveCore>
+    class Op {
+    public:
+        void operator()(const RTArgs& args) {
+            if constexpr (IsActiveCore) {
+                impl(args);
+            }
+        }
+
+    private:
+        void impl(const RTArgs& args) {
+#if defined(COMPILE_FOR_TRISC)
+            constexpr uint32_t out_w = CTArgs::out_w;
+
+            cb_wait_front(args.in0_cb, out_w);
+            cb_wait_front(args.in1_cb, args.total_in1_tiles);
+            cb_reserve_back(args.out_cb, out_w);
+
+            binary_op_init_common(args.in0_cb, args.in1_cb, args.out_cb);
+            add_tiles_init(args.in0_cb, args.in1_cb);
+            tile_regs_acquire();
+            for (uint32_t j = 0; j < out_w; j++) {
+                add_tiles(args.in0_cb, args.in1_cb, j, args.core_idx * out_w + j, j);
+            }
+            tile_regs_commit();
+            tile_regs_wait();
+            for (uint32_t j = 0; j < out_w; j++) {
+                pack_tile(j, args.out_cb, j);
+            }
+            tile_regs_release();
+
+            cb_pop_front(args.in0_cb, out_w);
+            cb_pop_front(args.in1_cb, args.total_in1_tiles);
+            cb_push_back(args.out_cb, out_w);
+#endif
+        }
+    };
+};
+
+}  // namespace deepseek_b1_ops

--- a/models/demos/deepseek_v3_b1/unified_kernels/residual_add.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/residual_add.hpp
@@ -60,12 +60,12 @@ struct ResidualAdd {
 #if defined(COMPILE_FOR_TRISC)
             constexpr uint32_t out_w = CTArgs::out_w;
 
+            binary_op_init_common(args.in0_cb, args.in1_cb, args.out_cb);
+            add_tiles_init(args.in0_cb, args.in1_cb);
+
             cb_wait_front(args.in0_cb, out_w);
             cb_wait_front(args.in1_cb, args.total_in1_tiles);
             cb_reserve_back(args.out_cb, out_w);
-
-            binary_op_init_common(args.in0_cb, args.in1_cb, args.out_cb);
-            add_tiles_init(args.in0_cb, args.in1_cb);
             tile_regs_acquire();
             for (uint32_t j = 0; j < out_w; j++) {
                 add_tiles(args.in0_cb, args.in1_cb, j, args.core_idx * out_w + j, j);


### PR DESCRIPTION
### Ticket
N/A

### Problem description
We need a fused kernel for the entire shared-expert block used in MoE and MLP layers.

### What's changed
This parallelization scheme runs MM with weights out of SRAM. It minimizes SRAM overhead of weights by parallelizing also on inner-dim within the device.

Single fused kernel capturing the following operations:

1. Activation mcast: [1, K_gate] from sender → all 130 cores
2. Gate/Up KN-sliced matmul: 128 cores (64 gate + 64 up), K×N parallel
3. Gate/Up gather: 128 cores → sender
4. Gated reduce: SiLU(sum(gate)) * sum(up) → [1, K_down] on sender
5. Mcast1: [1, K_down] from sender → all 130 cores
6. Mcast2: [1, N] residual from sender → all 130 cores
7. Down proj matmul: [1, K_down] × [K_down, N/112] on 112 cores
8. Residual add: matmul_out + shard(residual) on 112 cores
9. Output gather: 112 cores → sender [1, N]

New reusable micro-ops in `unified_kernels/`:

| Micro-op | Description |
|---|---|
| `KNSlicedMatmul` | K+N parallel partial matmul with `k_offset` into shared activation buffer |
| `ResidualAdd` | Per-core element-wise add with indexed shard of broadcast CB |
| `GatedReduce` | Fused SiLU-gated reduction of gathered partials |

### CI Runs
- [x] [All post commit CI](https://github.com/tenstorrent/tt-metal/actions/runs/21775090645) passes
- [x] New/Existing tests provide coverage for changes