### PR TITLE
Fix FP32 precision loss in untilize for wide tensors

### DIFF
--- a/ttnn/cpp/ttnn/operations/data_movement/untilize/device/factories/untilize_multi_core_input_and_output_nd_shard_type_and_shard_spec_identical_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize/device/factories/untilize_multi_core_input_and_output_nd_shard_type_and_shard_spec_identical_program_factory.cpp
@@ -128,8 +128,7 @@ UntilizeMultiCoreInputAndOutputNDShardTypeAndShardSpecIdenticalProgramFactory::c
         unpack_to_dest_mode[src0_cb_index] = UnpackToDestMode::UnpackToDestFp32;
     }
     std::string compute_kernel;
-    if (!use_pack_untilize || a.dtype() == DataType::UINT16 ||
-        (a.dtype() == DataType::FLOAT32 && num_tiles_per_block > MAX_PACK_UNTILIZE_WIDTH)) {
+    if (!use_pack_untilize || a.dtype() == DataType::UINT16) {
         log_debug(tt::LogOp, "Using slow untilize.");
 
         compute_kernel = std::string(

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize/device/factories/untilize_multi_core_input_and_output_shard_type_and_shard_spec_identical_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize/device/factories/untilize_multi_core_input_and_output_shard_type_and_shard_spec_identical_program_factory.cpp
@@ -109,8 +109,7 @@ UntilizeMultiCoreInputAndOutputShardTypeAndShardSpecIdenticalProgramFactory::cre
         unpack_to_dest_mode[src0_cb_index] = UnpackToDestMode::UnpackToDestFp32;
     }
     std::string compute_kernel;
-    if (!use_pack_untilize || a.dtype() == DataType::UINT16 ||
-        (a.dtype() == DataType::FLOAT32 && num_tiles_per_block > MAX_PACK_UNTILIZE_WIDTH)) {
+    if (!use_pack_untilize || a.dtype() == DataType::UINT16) {
         log_debug(tt::LogOp, "Using slow untilize.");
         compute_kernel =
             std::string("ttnn/cpp/ttnn/operations/data_movement/untilize/device/kernels/compute/untilize.cpp");

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize/device/factories/untilize_multi_core_nd_shard_input_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize/device/factories/untilize_multi_core_nd_shard_input_program_factory.cpp
@@ -185,8 +185,7 @@ UntilizeMultiCoreNDShardInputProgramFactory::cached_program_t UntilizeMultiCoreN
 
     // Compute kernel file
     std::string compute_kernel;
-    if (!use_pack_untilize || a.dtype() == DataType::UINT16 ||
-        (a.dtype() == DataType::FLOAT32 && num_tiles_per_input_block > MAX_PACK_UNTILIZE_WIDTH)) {
+    if (!use_pack_untilize || a.dtype() == DataType::UINT16) {
         log_debug(tt::LogOp, "Using slow untilize.");
         compute_kernel = std::string(
             "ttnn/cpp/ttnn/operations/data_movement/untilize/device/kernels/compute/untilize_variable_num_blocks.cpp");

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize/device/factories/untilize_multi_core_parallelize_column_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize/device/factories/untilize_multi_core_parallelize_column_program_factory.cpp
@@ -137,8 +137,7 @@ UntilizeMultiCoreParallelizeColumnProgramFactory::create(
     }
     std::string compute_kernel(
         "ttnn/cpp/ttnn/operations/data_movement/untilize/device/kernels/compute/pack_untilize.cpp");
-    if (!use_pack_untilize || a.dtype() == DataType::UINT16 ||
-        (a.dtype() == DataType::FLOAT32 && ntiles_per_block > MAX_PACK_UNTILIZE_WIDTH)) {
+    if (!use_pack_untilize || a.dtype() == DataType::UINT16) {
         log_debug(tt::LogOp, "Using slow untilize.");
         compute_kernel =
             std::string("ttnn/cpp/ttnn/operations/data_movement/untilize/device/kernels/compute/untilize.cpp");

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize/device/factories/untilize_multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize/device/factories/untilize_multi_core_program_factory.cpp
@@ -194,8 +194,7 @@ UntilizeMultiCoreProgramFactory::cached_program_t UntilizeMultiCoreProgramFactor
 
     // Compute kernel file
     std::string compute_kernel;
-    if (!use_pack_untilize || a.dtype() == DataType::UINT16 ||
-        (a.dtype() == DataType::FLOAT32 && num_tiles_per_input_block > MAX_PACK_UNTILIZE_WIDTH)) {
+    if (!use_pack_untilize || a.dtype() == DataType::UINT16) {
         log_debug(tt::LogOp, "Using slow untilize.");
         compute_kernel = std::string(
             "ttnn/cpp/ttnn/operations/data_movement/untilize/device/kernels/compute/untilize_variable_num_blocks.cpp");

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize/device/factories/untilize_multi_core_sub_core_grids_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize/device/factories/untilize_multi_core_sub_core_grids_program_factory.cpp
@@ -122,8 +122,7 @@ UntilizeMultiCoreSubCoreGridsProgramFactory::cached_program_t UntilizeMultiCoreS
     }
     std::string compute_kernel(
         "ttnn/cpp/ttnn/operations/data_movement/untilize/device/kernels/compute/pack_untilize.cpp");
-    if (!use_pack_untilize || a.dtype() == DataType::UINT16 ||
-        (a.dtype() == DataType::FLOAT32 && ntiles_per_block > MAX_PACK_UNTILIZE_WIDTH)) {
+    if (!use_pack_untilize || a.dtype() == DataType::UINT16) {
         log_debug(tt::LogOp, "Using slow untilize.");
         compute_kernel =
             std::string("ttnn/cpp/ttnn/operations/data_movement/untilize/device/kernels/compute/untilize.cpp");

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize/device/factories/untilize_single_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize/device/factories/untilize_single_core_program_factory.cpp
@@ -148,8 +148,7 @@ UntilizeSingleCoreProgramFactory::cached_program_t UntilizeSingleCoreProgramFact
     }
     std::string compute_kernel(
         "ttnn/cpp/ttnn/operations/data_movement/untilize/device/kernels/compute/pack_untilize.cpp");
-    if (!use_pack_untilize || a.dtype() == DataType::UINT16 ||
-        (a.dtype() == DataType::FLOAT32 && num_tiles_per_block > MAX_PACK_UNTILIZE_WIDTH)) {
+    if (!use_pack_untilize || a.dtype() == DataType::UINT16) {
         log_debug(tt::LogOp, "Using slow untilize.");
         compute_kernel =
             std::string("ttnn/cpp/ttnn/operations/data_movement/untilize/device/kernels/compute/untilize.cpp");

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/factories/untilize_with_unpadding_multi_core_block_interleaved_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/factories/untilize_with_unpadding_multi_core_block_interleaved_program_factory.cpp
@@ -189,8 +189,7 @@ UntilizeWithUnpaddingMultiCoreBlockInterleavedProgramFactory::create(
         unpack_to_dest_mode[tt::CBIndex::c_0] = UnpackToDestMode::UnpackToDestFp32;
     }
     bool use_pack_kernel = true;
-    if (!use_pack_untilize || a.dtype() == DataType::UINT16 ||
-        (a.dtype() == DataType::FLOAT32 && num_tiles_per_row > MAX_PACK_UNTILIZE_WIDTH)) {
+    if (!use_pack_untilize || a.dtype() == DataType::UINT16) {
         use_pack_kernel = false;
         unpack_to_dest_mode[tt::CBIndex::c_0] =
             UnpackToDestMode::Default;  // TODO: We need SFPU untilize for FP32 (#30400, #33795)

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/factories/untilize_with_unpadding_multi_core_interleaved_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/factories/untilize_with_unpadding_multi_core_interleaved_program_factory.cpp
@@ -108,8 +108,7 @@ UntilizeWithUnpaddingMultiCoreInterleavedProgramFactory::create(
     }
     std::string compute_kernel(
         "ttnn/cpp/ttnn/operations/data_movement/untilize/device/kernels/compute/pack_untilize.cpp");
-    if (!use_pack_untilize || a.dtype() == DataType::UINT16 ||
-        (input_cb_data_format == tt::DataFormat::Float32 && num_tiles_per_row > MAX_PACK_UNTILIZE_WIDTH)) {
+    if (!use_pack_untilize || a.dtype() == DataType::UINT16) {
         compute_kernel = "ttnn/cpp/ttnn/operations/data_movement/untilize/device/kernels/compute/untilize.cpp";
         unpack_to_dest_mode[tt::CBIndex::c_0] =
             UnpackToDestMode::Default;  // TODO: We need SFPU untilize for FP32 (#30400, #33795)

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/factories/untilize_with_unpadding_multi_core_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/factories/untilize_with_unpadding_multi_core_sharded_program_factory.cpp
@@ -180,9 +180,7 @@ UntilizeWithUnpaddingMultiCoreShardedProgramFactory::create(
         // Use copy compute kernel just for a potential data type conversion.
         compute_kernel = "ttnn/cpp/ttnn/kernel/compute/eltwise_copy.cpp";
         compute_args[0] = (uint32_t)num_input_tiles;  // per_core_tile_cnt
-    } else if (
-        !use_pack_untilize || a.dtype() == DataType::UINT16 ||
-        (input_cb_data_format == tt::DataFormat::Float32 && ntiles_per_block > MAX_PACK_UNTILIZE_WIDTH)) {
+    } else if (!use_pack_untilize || a.dtype() == DataType::UINT16) {
         log_debug(tt::LogOp, "Using slow untilize.");
         compute_kernel = "ttnn/cpp/ttnn/operations/data_movement/untilize/device/kernels/compute/untilize.cpp";
         unpack_to_dest_mode[tt::CBIndex::c_0] =

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/factories/untilize_with_unpadding_single_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/factories/untilize_with_unpadding_single_core_program_factory.cpp
@@ -175,8 +175,7 @@ UntilizeWithUnpaddingSingleCoreProgramFactory::cached_program_t UntilizeWithUnpa
     }
     std::string compute_kernel(
         "ttnn/cpp/ttnn/operations/data_movement/untilize/device/kernels/compute/pack_untilize.cpp");
-    if (!use_pack_untilize || a.dtype() == DataType::UINT16 ||
-        (input_cb_data_format == tt::DataFormat::Float32 && num_tiles_per_block > MAX_PACK_UNTILIZE_WIDTH)) {
+    if (!use_pack_untilize || a.dtype() == DataType::UINT16) {
         log_debug(tt::LogOp, "Using slow untilize.");
         compute_kernel = "ttnn/cpp/ttnn/operations/data_movement/untilize/device/kernels/compute/untilize.cpp";
         unpack_to_dest_mode[src0_cb_index] =


### PR DESCRIPTION
## Summary

Fixes #33795 — FP32 precision loss during `ttnn.untilize()` and `ttnn.untilize_with_unpadding()`.

Two independent bugs were causing FP32 values to lose precision (or get corrupted) during untilize:

- **`MAX_PACK_UNTILIZE_WIDTH=8` limit across 12 factory files**: All untilize/untilize_with_unpadding factory files had a condition that forced FP32 tensors wider than 8 tiles (256 elements) onto the slow untilize path, which truncates FP32→TF32 (~4.88e-04 max error). The `pack_untilize` kernel already handles arbitrary widths correctly via chunking (`block_ct_dim=4` for FP32), so this limit was unnecessarily conservative. **Fix**: Remove the `(a.dtype() == DataType::FLOAT32 && ... > MAX_PACK_UNTILIZE_WIDTH)` condition from all 12 factories.

- **Missing FP32 config in `untilize_multi_core_block_program_factory.cpp`**: This factory (used for tensors >32 tiles wide via `select_program_factory`) was missing `DST_ACCUM_MODE` define and `unpack_to_dest_mode` in its `ComputeConfig`. Without `DST_ACCUM_MODE`, `pack_untilize_wh.cpp` uses `max_bct=8` instead of `4`, trying to fit 8 tiles into FP32 DEST (which only holds 4 tiles in half-sync mode), causing **data corruption** with errors up to ~6-7. **Fix**: Add `DST_ACCUM_MODE` define and `unpack_to_dest_mode` to all 4 `CreateKernel` calls in the block factory, matching the pattern used by the other factories.

### What this does NOT fix

The slow untilize path (`untilize.cpp` / `untilize_wh.cpp`) still lacks native FP32 support — it forces `UnpackToDestMode::Default`, which truncates FP32→TF32 through SrcA registers. This is gated behind `use_pack_untilize=False` (not the default) and remains a separate issue tracked as the SFPU untilize work in #33795 / #30400.

## Test plan

### Local validation (already run, all passing)

- [x] `pytest tests/ttnn/unit_tests/operations/data_movement/test_untilize.py` — **1012 passed**, 8 skipped, 8 xfailed
- [x] `pytest tests/ttnn/unit_tests/operations/data_movement/test_untilize_with_unpadding.py` — **40 passed**

### CI workflows to run for full validation

**Automatic (triggered on PR):**
- [x] **PR Gate** (`pr-gate.yaml`) — smoke tests, ASan build, clang-tidy
- [x] **Merge Gate** (`merge-gate.yaml`) — ttnn smoke/merge-gate tests, metalium smoke tests https://github.com/tenstorrent/tt-metal/actions/runs/21771154409

**Manual triggers (request via workflow_dispatch on this branch):**
- [x] **Data Movement Test Suite** — `tm-data-movement-wrapper.yaml` — runs `unit_tests_data_movement` C++ gtest suite on N150/N300/P150b. **This is the most directly relevant workflow.** https://github.com/tenstorrent/tt-metal/actions/runs/21769373366

- [x] **All Post-Commit** — `all-post-commit-workflows.yaml` — comprehensive suite including ttnn-unit-tests, ops-unit-tests, models-unit-tests https://github.com/tenstorrent/tt-metal/actions/runs/21769288970

### Additional targeted tests to run manually on a Wormhole machine

```bash
# Core untilize tests (already passed locally)
pytest tests/ttnn/unit_tests/operations/data_movement/test_untilize.py -v
pytest tests/ttnn/unit_tests/operations/data_movement/test_untilize_with_unpadding.py -v

# Base functionality tilize/untilize
pytest tests/ttnn/unit_tests/base_functionality/test_tilize_untilize_2D.py -v
pytest tests/ttnn/unit_tests/base_functionality/test_untilize_bfloat8_b.py -v

# Legacy eager tests
pytest tests/tt_eager/python_api_testing/unit_testing/misc/test_untilize_test.py -v
pytest tests/tt_eager/python_api_testing/sweep_tests/pytests/tt_dnn/test_untilize.py -v
pytest tests/tt_eager/python_api_testing/sweep_tests/pytests/tt_dnn/test_untilize_with_unpadding.py -v

# C++ data movement gtest (if built)
./build/test/tt_metal/unit_tests_data_movement
```

**Additional notes from claude:**

Why the width limit existed: The MAX_PACK_UNTILIZE_WIDTH=8 limit was originally a hard constraint — the compute kernel processed all tiles in a row at once without chunking, so it couldn't exceed DEST capacity (8 tiles for non-FP32, 4 for FP32). When the kernel was later refactored to chunk via compute_num_blocks_per_column(), the limit became redundant but was never cleaned up at the factory level. Similarly, the block factory's missing FP32 config was never caught because the width limit prevented FP32 tensors from ever reaching that code path.

**Additional notes from Evan:**

There's a chance this actually provides small perf benefits, since it enables faster hardware acceleration for untilize operations. The operation does seem to be memory bound though so probably not much.

🤖 Generated with [Claude Code](https://claude.com/claude-code)