### PR TITLE
Add 4 chunks scatter_write and extra ring optimization to all_to_all_async_generic

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_async_generic/device/kernels/all_to_all_sender_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_async_generic/device/kernels/all_to_all_sender_reader.cpp
@@ -18,15 +18,20 @@ constexpr uint32_t num_devices = get_compile_time_arg_val(3);
 constexpr uint32_t split_dim_size = get_compile_time_arg_val(4);
 constexpr uint32_t inner_dims_size = get_compile_time_arg_val(5);
 constexpr uint32_t last_dim_size = get_compile_time_arg_val(6);
-constexpr uint32_t number_pages_per_packet = get_compile_time_arg_val(7);
-constexpr uint32_t has_reader_tail = get_compile_time_arg_val(8);
-constexpr uint32_t has_writer_tail = get_compile_time_arg_val(9);
-constexpr uint32_t num_devices_per_core = get_compile_time_arg_val(10);
-constexpr uint32_t num_blocks_per_core = get_compile_time_arg_val(11);
+constexpr uint32_t has_reader_tail = get_compile_time_arg_val(7);
+constexpr uint32_t has_writer_tail = get_compile_time_arg_val(8);
+constexpr uint32_t concat_num_tiles = get_compile_time_arg_val(9);
+constexpr uint32_t dst_inner_dims_size = get_compile_time_arg_val(10);
 
 template <typename AddrGenType>
 void read_data(
-    uint32_t device_id, uint32_t tile_id, uint32_t l1_write_addr, AddrGenType input_addrgen, uint32_t i, bool last) {
+    uint32_t device_id,
+    uint32_t tile_id,
+    uint32_t& l1_write_addr,
+    AddrGenType input_addrgen,
+    uint32_t c,
+    bool last,
+    uint32_t payload_size) {
     // half tile output case: add padding to the last tile
     bool pad_last_half_tile = has_reader_tail && last;
     if (pad_last_half_tile) {
@@ -36,6 +41,7 @@ void read_data(
             input_page_size / 2);
         uint64_t zeros_noc_addr = get_noc_addr(MEM_ZEROS_BASE);
         noc_async_read(zeros_noc_addr, l1_write_addr + input_page_size / 2, input_page_size / 2);
+        l1_write_addr += input_page_size;
         return;
     }
 
@@ -47,11 +53,12 @@ void read_data(
             input_addrgen.get_noc_addr(tile_id + inner_dims_size, 0),
             l1_write_addr + input_page_size / 2,
             input_page_size / 2);
+        l1_write_addr += input_page_size;
         return;
     }
 
     // half tile input case: odd devices need to read with half tile offset starting from the second tile in block
-    bool read_with_half_offset_for_writer = has_writer_tail && current_device_id % 2 == 1 && i / last_dim_size > 0;
+    bool read_with_half_offset_for_writer = has_writer_tail && current_device_id % 2 == 1 && c > 0;
     if (read_with_half_offset_for_writer) {
         noc_async_read(
             input_addrgen.get_noc_addr(tile_id - last_dim_size, input_page_size / 2),
@@ -59,10 +66,12 @@ void read_data(
             input_page_size / 2);
         noc_async_read(
             input_addrgen.get_noc_addr(tile_id, 0), l1_write_addr + input_page_size / 2, input_page_size / 2);
+        l1_write_addr += input_page_size;
         return;
     }
 
-    noc_async_read_tile(tile_id, input_addrgen, l1_write_addr);
+    noc_async_read(input_addrgen.get_noc_addr(tile_id), l1_write_addr, payload_size);
+    l1_write_addr += payload_size;
 }
 
 void kernel_main() {
@@ -71,16 +80,16 @@ void kernel_main() {
     ///////////////////////////////////////////////////
     size_t arg_idx = 0;
     address_t input_address = get_arg_val<address_t>(arg_idx++);
-    address_t block_start_id = get_arg_val<address_t>(arg_idx++);
-
-    constexpr auto input_tensor_args = TensorAccessorArgs<12>();
+    uint32_t local_num_devices = get_arg_val<uint32_t>(arg_idx++);
+    constexpr auto input_tensor_args = TensorAccessorArgs<11>();
     auto input_addrgen = TensorAccessor(input_tensor_args, input_address, input_page_size);
     constexpr uint32_t split_num_half_tiles = split_dim_size * 2 / num_devices;
     constexpr uint32_t split_num_tiles = (split_num_half_tiles + 1) / 2;
+    constexpr bool has_pre_half_tile = has_writer_tail && current_device_id % 2 == 1;
+    constexpr bool has_post_half_tile = has_writer_tail && current_device_id % 2 == 0;
 
-    for (uint32_t did = 0; did < num_devices_per_core; ++did) {
+    for (uint32_t did = 0; did < local_num_devices; ++did) {
         int32_t device_offset = get_arg_val<int32_t>(arg_idx++);
-        int32_t distance = abs(device_offset);
         uint32_t device_id = (current_device_id + device_offset + num_devices) % num_devices;
 
         const uint32_t device_read_offset = (split_num_half_tiles * device_id) / 2;
@@ -88,31 +97,54 @@ void kernel_main() {
         auto calculate_tile = [&](int b) {
             const uint32_t o = b / (split_num_tiles * inner_dims_size);
             const uint32_t s = (b / inner_dims_size) % split_num_tiles;
+            const uint32_t c = (b / dst_inner_dims_size) % concat_num_tiles;
             const uint32_t i = b % inner_dims_size;
             const uint32_t tile_id =
                 o * inner_dims_size * split_dim_size + device_read_offset * inner_dims_size + s * inner_dims_size + i;
-            return std::tuple{s, i, tile_id};
+            uint32_t payload_size = ((has_pre_half_tile && c == 0) || (has_post_half_tile && c == concat_num_tiles - 1))
+                                        ? input_page_size / 2
+                                        : input_page_size;
+            return std::tuple{s, i, c, tile_id, payload_size};
         };
 
-        uint64_t block_end_id = block_start_id + num_blocks_per_core;
-        for (uint64_t block_idx = block_start_id; block_idx < block_end_id; block_idx += number_pages_per_packet) {
-            uint32_t tiles_this_iteration = std::min(number_pages_per_packet, uint32_t(block_end_id - block_idx));
+        uint32_t block_idx = get_arg_val<uint32_t>(arg_idx++);
+        uint32_t block_end_id = get_arg_val<uint32_t>(arg_idx++);
+        cb_reserve_back(cb0_id, 1);
+        address_t l1_write_addr = get_write_ptr(cb0_id);
+        uint32_t current_package_payload = 0;
+        uint32_t current_tile = 0;
 
-            cb_reserve_back(cb0_id, number_pages_per_packet);
-            address_t l1_write_addr = get_write_ptr(cb0_id);
-            for (uint32_t t = 0; t < tiles_this_iteration; ++t) {
-                auto [split_idx, inner_idx, tile_id] = calculate_tile(block_idx + t);
-                read_data(
-                    device_id,
-                    tile_id,
-                    l1_write_addr + t * input_page_size,
-                    input_addrgen,
-                    inner_idx,
-                    split_idx == split_num_tiles - 1);
+        while (block_idx < block_end_id) {
+            auto [split_idx, inner_idx, concat_idx, tile_id, payload_size] = calculate_tile(block_idx);
+
+            // If package is full, flush and start new package
+            if (current_tile == 4 || current_package_payload + payload_size > 2 * input_page_size) {
+                noc_async_read_barrier();
+                cb_push_back(cb0_id, 1);
+                cb_reserve_back(cb0_id, 1);
+                l1_write_addr = get_write_ptr(cb0_id);
+                current_package_payload = 0;
+                current_tile = 0;
             }
 
-            noc_async_read_barrier();
-            cb_push_back(cb0_id, number_pages_per_packet);
+            read_data(
+                device_id,
+                tile_id,
+                l1_write_addr,
+                input_addrgen,
+                concat_idx,
+                split_idx == split_num_tiles - 1,
+                payload_size);
+
+            current_package_payload += payload_size;
+            current_tile++;
+            block_idx++;
         }
+
+        // Flush remaining tiles in the last package
+        if (current_tile > 0) {
+            noc_async_read_barrier();
+        }
+        cb_push_back(cb0_id, 1);
     }
 }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_async_generic/device/kernels/all_to_all_sender_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_async_generic/device/kernels/all_to_all_sender_writer.cpp
@@ -19,13 +19,12 @@ constexpr uint32_t current_device_id = get_compile_time_arg_val(1);
 constexpr uint32_t num_devices = get_compile_time_arg_val(2);
 constexpr uint32_t concat_dim_size = get_compile_time_arg_val(3);
 constexpr uint32_t inner_dims_size = get_compile_time_arg_val(4);
-constexpr uint32_t number_pages_per_packet = get_compile_time_arg_val(5);
-constexpr uint32_t has_half_tile = get_compile_time_arg_val(6);
-constexpr uint32_t output_page_size = get_compile_time_arg_val(7);
-constexpr uint32_t reserved_packet_header_cb_id = get_compile_time_arg_val(8);
-constexpr uint32_t num_devices_per_core = get_compile_time_arg_val(9);
-constexpr uint32_t num_blocks_per_core = get_compile_time_arg_val(10);
-constexpr uint32_t num_cores_per_blocks = get_compile_time_arg_val(11);
+constexpr uint32_t has_half_tile = get_compile_time_arg_val(5);
+constexpr uint32_t output_page_size = get_compile_time_arg_val(6);
+constexpr uint32_t reserved_packet_header_cb_id = get_compile_time_arg_val(7);
+constexpr uint32_t semaphore_expected_value = get_compile_time_arg_val(8);
+constexpr uint32_t concat_num_tiles = get_compile_time_arg_val(9);
+constexpr uint32_t full_block_offset = get_compile_time_arg_val(10);
 
 inline tt::tt_fabric::WorkerToFabricEdmSender& select_connection(
     FabricConnectionManager& fabric_connection, int device_offset) {
@@ -33,115 +32,67 @@ inline tt::tt_fabric::WorkerToFabricEdmSender& select_connection(
                                : fabric_connection.get_backward_connection();
 }
 
-template <typename AddrGenType>
 void write_data(
-    bool last,
-    uint32_t dest_id,
-    AddrGenType addrgen,
+    uint64_t dest_addrs[4],
+    uint16_t payload_sizes[4],
+    uint32_t parts_count,
     volatile PACKET_HEADER_TYPE* pkt_hdr,
     FabricConnectionManager& fabric_connection,
     size_t l1_read_addr,
-    uint32_t payload_size_bytes,
-    uint32_t offset,
     uint64_t output_semaphore_noc_addr_in_pkt,
-    int device_offset) {
+    int device_offset,
+    bool last) {
     bool local = device_offset == 0;
-    if (last) {
-        uint32_t device_id = (current_device_id + device_offset + num_devices) % num_devices;
-        if (local) {
+    if (local) {
+        if (last) {
             noc_semaphore_inc(output_semaphore_noc_addr_in_pkt, 1);
-            noc_async_write(l1_read_addr, addrgen.get_noc_addr(dest_id, offset), payload_size_bytes);
-            noc_async_write_barrier();
-        } else {
-            perform_atomic_fabric_write(
-                pkt_hdr,
-                dest_id,
-                addrgen,
+        }
+        for (uint32_t part = 0; part < parts_count; ++part) {
+            noc_async_write(l1_read_addr, dest_addrs[part], payload_sizes[part]);
+            l1_read_addr += payload_sizes[part];
+        }
+        noc_async_write_barrier();
+    } else {
+        if (last) {
+            // TODO: reduce number of packages when atomic fused with scatter will be introduced
+            if (parts_count > 1) {
+                if (parts_count > 2) {
+                    uint32_t scatter_payload = 0;
+                    for (uint32_t part = 0; part < parts_count - 1; ++part) {
+                        scatter_payload += payload_sizes[part];
+                    }
+                    pkt_hdr->to_noc_unicast_scatter_write(
+                        NocUnicastScatterCommandHeader(dest_addrs, payload_sizes, parts_count - 1), scatter_payload);
+                    perform_payload_send(
+                        select_connection(fabric_connection, device_offset), l1_read_addr, scatter_payload, pkt_hdr);
+                    l1_read_addr += scatter_payload;
+                } else {
+                    pkt_hdr->to_noc_unicast_write(NocUnicastCommandHeader({dest_addrs[0]}), payload_sizes[0]);
+                    perform_payload_send(
+                        select_connection(fabric_connection, device_offset), l1_read_addr, payload_sizes[0], pkt_hdr);
+                    l1_read_addr += payload_sizes[0];
+                }
+                noc_async_writes_flushed();
+            }
+
+            pkt_hdr->to_noc_fused_unicast_write_atomic_inc(
+                NocUnicastAtomicIncFusedCommandHeader(
+                    {dest_addrs[parts_count - 1], output_semaphore_noc_addr_in_pkt, 1, false}),
+                payload_sizes[parts_count - 1]);
+            perform_payload_send(
                 select_connection(fabric_connection, device_offset),
                 l1_read_addr,
-                payload_size_bytes,
-                output_semaphore_noc_addr_in_pkt,
-                1,
-                false,
-                offset);
-        }
-    } else {
-        if (local) {
-            noc_async_write(l1_read_addr, addrgen.get_noc_addr(dest_id, offset), payload_size_bytes);
+                payload_sizes[parts_count - 1],
+                pkt_hdr);
         } else {
-            tt::tt_fabric::linear::to_noc_unicast_write(payload_size_bytes, pkt_hdr, dest_id, addrgen, offset);
-            perform_payload_send(
-                select_connection(fabric_connection, device_offset), l1_read_addr, payload_size_bytes, pkt_hdr);
-        }
-    }
-    noc_async_writes_flushed();
-}
-
-template <typename AddrGenType>
-void write_data(
-    bool last,
-    uint32_t dest_id0,
-    uint32_t dest_id1,
-    AddrGenType addrgen,
-    volatile PACKET_HEADER_TYPE* pkt_hdr,
-    FabricConnectionManager& fabric_connection,
-    size_t l1_read_addr,
-    uint32_t payload_size_bytes0,
-    uint32_t payload_size_bytes1,
-    uint32_t offset0,
-    uint32_t offset1,
-    uint64_t output_semaphore_noc_addr_in_pkt,
-    int device_offset) {
-    bool local = device_offset == 0;
-    if (last) {
-        uint32_t device_id = (current_device_id + device_offset + num_devices) % num_devices;
-        if (local) {
-            noc_semaphore_inc(output_semaphore_noc_addr_in_pkt, 1);
-            noc_async_write(l1_read_addr, addrgen.get_noc_addr(dest_id0, offset0), payload_size_bytes0);
-            noc_async_write(
-                l1_read_addr + output_page_size, addrgen.get_noc_addr(dest_id1, offset1), payload_size_bytes1);
-            noc_async_write_barrier();
-        } else {
-            tt::tt_fabric::linear::to_noc_unicast_write(payload_size_bytes0, pkt_hdr, dest_id0, addrgen, offset0);
-            perform_payload_send(
-                select_connection(fabric_connection, device_offset), l1_read_addr, payload_size_bytes0, pkt_hdr);
-            size_t l1_read_addr_plus_payload = l1_read_addr + output_page_size;
-            noc_async_writes_flushed();
-            perform_atomic_fabric_write(
-                pkt_hdr,
-                dest_id1,
-                addrgen,
-                select_connection(fabric_connection, device_offset),
-                l1_read_addr_plus_payload,
-                payload_size_bytes1,
-                output_semaphore_noc_addr_in_pkt,
-                1,
-                false,
-                offset1);
-        }
-    } else {
-        if (local) {
-            noc_async_write(l1_read_addr, addrgen.get_noc_addr(dest_id0, offset0), payload_size_bytes0);
-            noc_async_write(
-                l1_read_addr + output_page_size, addrgen.get_noc_addr(dest_id1, offset1), payload_size_bytes1);
-        } else {
-            constexpr uint32_t half_output_page_size = output_page_size / 2;
-            if (payload_size_bytes0 == half_output_page_size) {
-                tt::data_movement::common::tt_memmove<true, false, false, half_output_page_size>(
-                    l1_read_addr + half_output_page_size, l1_read_addr, half_output_page_size);
-                l1_read_addr = l1_read_addr + half_output_page_size;
+            uint32_t scatter_payload = 0;
+            for (uint32_t part = 0; part < parts_count; ++part) {
+                scatter_payload += payload_sizes[part];
             }
-            auto payload_size = payload_size_bytes0 + payload_size_bytes1;
-
-            auto noc_address0 = tt::tt_fabric::linear::addrgen_detail::get_noc_address(addrgen, dest_id0, offset0);
-            auto noc_address1 = tt::tt_fabric::linear::addrgen_detail::get_noc_address(addrgen, dest_id1, offset1);
-
             pkt_hdr->to_noc_unicast_scatter_write(
-                NocUnicastScatterCommandHeader(
-                    {noc_address0, noc_address1}, {static_cast<uint16_t>(payload_size_bytes0)}),
-                payload_size);
+                NocUnicastScatterCommandHeader(dest_addrs, payload_sizes, parts_count), scatter_payload);
             perform_payload_send(
-                select_connection(fabric_connection, device_offset), l1_read_addr, payload_size, pkt_hdr);
+                select_connection(fabric_connection, device_offset), l1_read_addr, scatter_payload, pkt_hdr);
         }
     }
     noc_async_writes_flushed();
@@ -156,9 +107,8 @@ void kernel_main() {
     uint32_t global_init_semaphore_addr = get_arg_val<uint32_t>(arg_idx++);
     uint32_t global_semaphore_addr = get_arg_val<uint32_t>(arg_idx++);
 
-    uint32_t device_start_id = get_arg_val<uint32_t>(arg_idx++);
-    uint32_t block_start_id = get_arg_val<uint32_t>(arg_idx++);
-
+    uint32_t core_id = get_arg_val<uint32_t>(arg_idx++);
+    uint32_t link_id = get_arg_val<uint32_t>(arg_idx++);
     const uint32_t mcast_dest_noc_start_x = get_arg_val<uint32_t>(arg_idx++);
     const uint32_t mcast_dest_noc_start_y = get_arg_val<uint32_t>(arg_idx++);
 
@@ -168,11 +118,11 @@ void kernel_main() {
     const uint32_t mcast_size = get_arg_val<uint32_t>(arg_idx++);
     uint32_t sender_core_x = get_arg_val<uint32_t>(arg_idx++);
     uint32_t sender_core_y = get_arg_val<uint32_t>(arg_idx++);
-
-    constexpr auto output_args = TensorAccessorArgs<12>();
+    uint32_t local_num_devices = get_arg_val<uint32_t>(arg_idx++);
+    constexpr auto output_args = TensorAccessorArgs<11>();
     auto output_addrgen = TensorAccessor(output_args, output_address, output_page_size);
     size_t device_offsets_idx = arg_idx;
-    arg_idx += num_devices_per_core;
+    arg_idx += local_num_devices * 3;
 
     // Build fabric connection
     auto fabric_connection =
@@ -216,10 +166,7 @@ void kernel_main() {
     constexpr bool has_pre_half_tile = has_half_tile && current_device_id % 2 == 1;
     constexpr bool has_post_half_tile = has_half_tile && current_device_id % 2 == 0;
 
-    constexpr uint32_t concat_num_half_tiles = concat_dim_size * 2 / num_devices;
-    constexpr uint32_t concat_num_tiles = (concat_num_half_tiles + 1) / 2;
-    constexpr uint32_t full_block_offset = (concat_num_half_tiles * current_device_id) / 2;
-    if (device_start_id == 0 && block_start_id == 0) {
+    if (link_id == 0) {
 #define LINEAR 1
 #define RING 2
 #if TOPOLOGY == LINEAR
@@ -248,13 +195,24 @@ void kernel_main() {
                 init_semaphore_noc_addr_in_pkt, static_cast<uint32_t>(1)});  // increment 1
             fabric_connection.get_forward_connection().wait_for_empty_write_slot();
             pkt_hdr_forward->to_chip_multicast(
-                tt::tt_fabric::MulticastRoutingCommandHeader{1, static_cast<uint8_t>(num_devices - 1)});
+                tt::tt_fabric::MulticastRoutingCommandHeader{1, static_cast<uint8_t>(num_devices / 2)});
             fabric_connection.get_forward_connection().send_payload_flush_blocking_from_address(
                 packet_header_buffer_addr_forward, sizeof(PACKET_HEADER_TYPE));
+        }
+        if (fabric_connection.has_backward_connection()) {
+            pkt_hdr_backward->to_noc_unicast_atomic_inc(tt::tt_fabric::NocUnicastAtomicIncCommandHeader{
+                init_semaphore_noc_addr_in_pkt, static_cast<uint32_t>(1)});  // increment 1
+            fabric_connection.get_backward_connection().wait_for_empty_write_slot();
+            pkt_hdr_backward->to_chip_multicast(tt::tt_fabric::MulticastRoutingCommandHeader{
+                1, static_cast<uint8_t>(num_devices - num_devices / 2 - 1)});
+            fabric_connection.get_backward_connection().send_payload_flush_blocking_from_address(
+                packet_header_buffer_addr_backward, sizeof(PACKET_HEADER_TYPE));
         }
 #else
 #error "Unsupported Topology Type"
 #endif
+    }
+    if (core_id == 0 && link_id == 0) {
         const uint64_t local_set_semaphore_noc_addr = get_noc_multicast_addr(
             mcast_dest_noc_start_x,
             mcast_dest_noc_start_y,
@@ -274,7 +232,7 @@ void kernel_main() {
     noc_semaphore_wait(global_init_semaphore_addr_ptr, num_devices - 1);
     noc_semaphore_set(global_init_semaphore_addr_ptr, 0);
 
-    for (uint32_t did = 0; did < num_devices_per_core; ++did) {
+    for (uint32_t did = 0; did < local_num_devices; ++did) {
         int32_t device_offset = get_arg_val<int32_t>(device_offsets_idx++);
         int32_t distance = abs(device_offset);
         uint32_t device_id = (current_device_id + device_offset + num_devices) % num_devices;
@@ -295,63 +253,73 @@ void kernel_main() {
             const uint32_t i = b % inner_dims_size;
             const uint32_t dest_tile_id =
                 o * inner_dims_size * concat_dim_size + (c + full_block_offset) * inner_dims_size + i;
-            uint32_t payload_size = ((has_pre_half_tile && c == 0) || (has_post_half_tile && c == concat_num_tiles - 1))
+            uint16_t payload_size = ((has_pre_half_tile && c == 0) || (has_post_half_tile && c == concat_num_tiles - 1))
                                         ? output_page_size / 2
                                         : output_page_size;
             uint32_t offset = (has_pre_half_tile && c == 0) ? (current_device_id % 2) * output_page_size / 2 : 0;
-            return std::tuple{dest_tile_id, payload_size, offset};
+            uint64_t dst_addr =
+                (current_device_id == device_id)
+                    ? output_addrgen.get_noc_addr(dest_tile_id, offset)
+                    : tt::tt_fabric::linear::addrgen_detail::get_noc_address(output_addrgen, dest_tile_id, offset);
+            return std::tuple{dst_addr, payload_size};
         };
 
-        uint64_t block_end_id = block_start_id + num_blocks_per_core;
-        for (uint64_t b = block_start_id; b < block_end_id; b += number_pages_per_packet) {
-            uint32_t tiles_this_iteration = std::min(number_pages_per_packet, uint32_t(block_end_id - b));
+        uint32_t block_idx = get_arg_val<uint32_t>(device_offsets_idx++);
+        uint32_t block_end_id = get_arg_val<uint32_t>(device_offsets_idx++);
 
-            cb_wait_front(cb0_id, number_pages_per_packet);
-            size_t l1_read_addr = get_read_ptr(cb0_id);
-
-            if (tiles_this_iteration == 2) {
-                auto [dest_tile_id0, payload_size0, offset0] = calculate_params(b);
-                auto [dest_tile_id1, payload_size1, offset1] = calculate_params(b + 1);
-                bool last = b == (block_end_id - 2);
+        cb_wait_front(cb0_id, 1);
+        size_t l1_read_addr = get_read_ptr(cb0_id);
+        uint32_t current_package_payload = 0;
+        uint32_t current_tile = 0;
+        uint64_t dst_addrs[4] = {0};
+        uint16_t payload_sizes[4] = {0};
+        while (block_idx < block_end_id) {
+            auto [dst_addr, payload_size] = calculate_params(block_idx);
+            // If package is full, flush and start new package
+            if (current_tile == 4 || current_package_payload + payload_size > 2 * output_page_size) {
                 write_data(
-                    last,
-                    dest_tile_id0,
-                    dest_tile_id1,
-                    output_addrgen,
+                    dst_addrs,
+                    payload_sizes,
+                    current_tile,
                     pkt_hdr,
                     fabric_connection,
                     l1_read_addr,
-                    payload_size0,
-                    payload_size1,
-                    offset0,
-                    offset1,
                     output_semaphore_noc_addr_in_pkt,
-                    device_offset);
-            } else {
-                auto [dest_tile_id, payload_size, offset] = calculate_params(b);
-                bool last = b == (block_end_id - 1);
-                write_data(
-                    last,
-                    dest_tile_id,
-                    output_addrgen,
-                    pkt_hdr,
-                    fabric_connection,
-                    l1_read_addr,
-                    payload_size,
-                    offset,
-                    output_semaphore_noc_addr_in_pkt,
-                    device_offset);
+                    device_offset,
+                    false);
+                cb_pop_front(cb0_id, 1);
+                cb_wait_front(cb0_id, 1);
+                l1_read_addr = get_read_ptr(cb0_id);
+                current_package_payload = 0;
+                current_tile = 0;
             }
-
-            cb_pop_front(cb0_id, number_pages_per_packet);
+            current_package_payload += payload_size;
+            payload_sizes[current_tile] = payload_size;
+            dst_addrs[current_tile] = dst_addr;
+            current_tile++;
+            block_idx++;
         }
+
+        // Flush remaining tiles in the last package
+        if (current_tile > 0) {
+            write_data(
+                dst_addrs,
+                payload_sizes,
+                current_tile,
+                pkt_hdr,
+                fabric_connection,
+                l1_read_addr,
+                output_semaphore_noc_addr_in_pkt,
+                device_offset,
+                true);
+        }
+        cb_pop_front(cb0_id, 1);
     }
 
     noc_async_write_barrier();
     fabric_connection.close();
-
-    if (device_start_id == 0 && block_start_id == 0) {
-        noc_semaphore_wait(global_semaphore_addr_ptr, num_devices * num_cores_per_blocks);
+    if (core_id == 0 && link_id == 0) {
+        noc_semaphore_wait(global_semaphore_addr_ptr, semaphore_expected_value);
         noc_semaphore_set(global_semaphore_addr_ptr, 0);
     }
 }


### PR DESCRIPTION
### What's changed
Changed process of packages preparation, added scatter_write with up to 4 chunks.
Changed initial semaphore inc for Ring.
Now block start and end ids for each device is provided though runtime variables.
For Ring topology now block is split between two senders for the farthest device.

### Checklist

- [x] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=itaraban/all-to-all-face-send)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:itaraban/all-to-all-face-send)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=itaraban/all-to-all-face-send)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:itaraban/all-to-all-face-send)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=itaraban/all-to-all-face-send)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:itaraban/all-to-all-face-send)
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=itaraban/all-to-all-face-send)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:itaraban/all-to-all-face-send)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=itaraban/all-to-all-face-send)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:itaraban/all-to-all-face-send)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=itaraban/all-to-all-face-send)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:itaraban/all-to-all-face-send)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
