### PR TITLE
Add Multi-Threaded Test using H <-> D Sockets

### DIFF
--- a/tests/tt_metal/distributed/test_hd_sockets.cpp
+++ b/tests/tt_metal/distributed/test_hd_sockets.cpp
@@ -215,6 +215,81 @@ void test_hd_socket_loopback(
     EXPECT_EQ(src_vec, dst_vec);
 }
 
+void test_hd_socket_multithreaded_loopback(
+    const std::shared_ptr<tt::tt_metal::distributed::MeshDevice>& mesh_device,
+    std::size_t socket_fifo_size,
+    std::size_t page_size,
+    std::size_t data_size,
+    H2DMode h2d_mode,
+    uint32_t num_iterations = 10,
+    const MeshCoreCoord& socket_core = {MeshCoordinate(0, 0), CoreCoord(0, 0)}) {
+    auto input_socket = H2DSocket(mesh_device, socket_core, BufferType::L1, socket_fifo_size, h2d_mode);
+    auto output_socket = D2HSocket(mesh_device, socket_core, socket_fifo_size);
+
+    TT_FATAL(data_size % page_size == 0, "Data size must be a multiple of page size");
+
+    auto send_program = CreateProgram();
+    CreateKernel(
+        send_program,
+        "tests/tt_metal/tt_metal/test_kernels/misc/socket/pcie_socket_loopback.cpp",
+        socket_core.core_coord,
+        DataMovementConfig{
+            .processor = DataMovementProcessor::RISCV_0,
+            .noc = NOC::RISCV_0_default,
+            .compile_args = {
+                static_cast<uint32_t>(input_socket.get_config_buffer_address()),
+                static_cast<uint32_t>(output_socket.get_config_buffer_address()),
+                static_cast<uint32_t>(page_size),
+                static_cast<uint32_t>(data_size),
+                static_cast<uint32_t>(num_iterations),
+                h2d_mode == H2DMode::DEVICE_PULL,
+            }});
+
+    uint32_t num_txns = data_size / page_size;
+    std::vector<uint32_t> src_vec(data_size * num_iterations / sizeof(uint32_t));
+    std::vector<uint32_t> dst_vec(data_size * num_iterations / sizeof(uint32_t));
+    std::iota(src_vec.begin(), src_vec.end(), 0);
+
+    auto mesh_workload = MeshWorkload();
+    MeshCoordinateRange devices = MeshCoordinateRange(socket_core.device_coord);
+    mesh_workload.add_program(devices, std::move(send_program));
+
+    // Launch Loopback Kernel on device (copies data from H2D to D2H socket).
+    EnqueueMeshWorkload(mesh_device->mesh_command_queue(), mesh_workload, false);
+
+    // Set Required Page Size for Socket.
+    input_socket.set_page_size(page_size);
+    output_socket.set_page_size(page_size);
+
+    uint32_t page_size_words = page_size / sizeof(uint32_t);
+    uint32_t data_size_words = data_size / sizeof(uint32_t);
+
+    // Socket Read/Write done over different threads.
+    std::thread write_thread([&]() {
+        for (uint32_t i = 0; i < num_iterations; i++) {
+            for (uint32_t j = 0; j < num_txns; j++) {
+                input_socket.write(src_vec.data() + (i * data_size_words) + (j * page_size_words), 1);
+            }
+        }
+    });
+
+    std::thread read_thread([&]() {
+        for (uint32_t i = 0; i < num_iterations; i++) {
+            for (uint32_t j = 0; j < num_txns; j++) {
+                output_socket.read(dst_vec.data() + (i * data_size_words) + (j * page_size_words), 1);
+            }
+        }
+    });
+    // Barrier with a timeout in the main thread ensure that the read/write threads are not hung.
+    input_socket.barrier(10000);
+    output_socket.barrier(10000);
+
+    write_thread.join();
+    read_thread.join();
+
+    EXPECT_EQ(src_vec, dst_vec);
+}
+
 bool is_device_coord_mmio_mapped(
     const std::shared_ptr<tt::tt_metal::distributed::MeshDevice>& mesh_device, const MeshCoordinate& device_coord) {
     const auto& cluster = MetalContext::instance().get_cluster();
@@ -294,6 +369,34 @@ TEST_F(HDSocketFixture, H2DSocketLoopback) {
             // On most hosts, page size is 4K, so this should lead to 5 pages being allocated on the host.
             test_hd_socket_loopback(
                 mesh_device_, 16512, 1088, 156672, h2d_mode, 50, MeshCoreCoord(socket_coord, CoreCoord(0, 1)));
+        }
+    }
+}
+
+TEST_F(HDSocketFixture, H2DSocketLoopbackMultiThreadedStress) {
+    // Skip if mapping to NOC isn't supported on this system
+    if (!experimental::GetMemoryPinningParameters(*mesh_device_).can_map_to_noc) {
+        GTEST_SKIP() << "Mapping host memory to NOC is not supported on this system";
+    }
+
+    for (auto h2d_mode : {H2DMode::DEVICE_PULL, H2DMode::HOST_PUSH}) {
+        for (const auto& socket_coord : MeshCoordinateRange(mesh_device_->shape())) {
+            if (!is_device_coord_mmio_mapped(mesh_device_, socket_coord)) {
+                continue;
+            }
+            // No wrap
+            test_hd_socket_multithreaded_loopback(
+                mesh_device_, 1024, 64, 1024, h2d_mode, 100, MeshCoreCoord(socket_coord, CoreCoord(0, 0)));
+            // Even wrap
+            test_hd_socket_multithreaded_loopback(
+                mesh_device_, 1024, 64, 32768, h2d_mode, 100, MeshCoreCoord(socket_coord, CoreCoord(1, 1)));
+            // Uneven wrap
+            test_hd_socket_multithreaded_loopback(
+                mesh_device_, 4096, 1088, 78336, h2d_mode, 100, MeshCoreCoord(socket_coord, CoreCoord(0, 1)));
+            // Uneven wrap with multiple pages on host allocated.
+            // On most hosts, page size is 4K, so this should lead to 5 pages being allocated on the host.
+            test_hd_socket_multithreaded_loopback(
+                mesh_device_, 16512, 1088, 156672, h2d_mode, 100, MeshCoreCoord(socket_coord, CoreCoord(0, 1)));
         }
     }
 }


### PR DESCRIPTION
### Ticket
No Ticket.

### Problem description
- All tests/examples for `H <-> D` sockets use single threaded environments
- Applications such as inference serving will likely spawn pipeline feeder/drainer threads using sockets
- This use case should be tested

### What's changed
- Add multi-threaded loopback stress test: 1 Writer for H -> D & 1 Reader for D -> H
- Minor optimizations to loopback kernel

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=asaigal/hd_socket_multithreaded)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:asaigal/hd_socket_multithreaded)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=asaigal/hd_socket_multithreaded)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:asaigal/hd_socket_multithreaded)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=asaigal/hd_socket_multithreaded)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:asaigal/hd_socket_multithreaded)
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=asaigal/hd_socket_multithreaded)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:asaigal/hd_socket_multithreaded)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=asaigal/hd_socket_multithreaded)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:asaigal/hd_socket_multithreaded)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=asaigal/hd_socket_multithreaded)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:asaigal/hd_socket_multithreaded)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
