### PR TITLE
Calculating arc heartbeats per seconds with more precision

### DIFF
--- a/tools/triage/check_arc.py
+++ b/tools/triage/check_arc.py
@@ -32,6 +32,12 @@ script_config = ScriptConfig(
 
 
 @dataclass
+class HeartbeatSample:
+    heartbeat: int
+    timestamp: float
+
+
+@dataclass
 class ArcCheckData:
     location: OnChipCoordinate = triage_field("Loc")
     postcode: int = triage_field("Postcode", hex_serializer)
@@ -40,39 +46,43 @@ class ArcCheckData:
     heartbeats_per_second: float = triage_field("Heartbeats/s")
 
 
-def check_arc_block(arc: NocBlock, postcode: int) -> ArcCheckData:
+def check_arc_block(arc: NocBlock, postcode: int, heartbeat_sample: HeartbeatSample) -> ArcCheckData:
     device = arc.location.device
     device_id = arc.location.device_id
     # Heartbeat must be increasing
-    heartbeat_0 = read_arc_telemetry_entry(device_id, "TIMER_HEARTBEAT")
-    delay_seconds = 0.2
-    time.sleep(delay_seconds)
-    heartbeat_1 = read_arc_telemetry_entry(device_id, "TIMER_HEARTBEAT")
-    log_check_device(device, heartbeat_1 > heartbeat_0, f"ARC heartbeat not increasing: [error]{heartbeat_1}[/].")
+    current_heartbeat_sample = HeartbeatSample(
+        heartbeat=read_arc_telemetry_entry(device_id, "TIMER_HEARTBEAT"), timestamp=time.time()
+    )
     arcclk_mhz = read_arc_telemetry_entry(device_id, "ARCCLK")
-    heartbeats_per_second = (heartbeat_1 - heartbeat_0) / delay_seconds
+    heartbeats_per_second = (current_heartbeat_sample.heartbeat - heartbeat_sample.heartbeat) / (
+        current_heartbeat_sample.timestamp - heartbeat_sample.timestamp
+    )
 
     # We do this in order to support all firmware versions
     # This way we do not support uptime longer than around 8 years, but that is unrealistic
-    heartbeat_offset = 0xA5A5A5A5 if heartbeat_1 >= 0xA5A5A5A5 else 0
+    heartbeat_offset = 0xA5A5A5A5 if current_heartbeat_sample.heartbeat >= 0xA5A5A5A5 else 0
     log_check_device(
         device,
-        heartbeat_1 > heartbeat_offset,
-        f"ARC heartbeat lower than default value: [error]{heartbeat_1}[/]. Expected at least [info]{heartbeat_offset}[/]",
+        current_heartbeat_sample.heartbeat > heartbeat_offset,
+        f"ARC heartbeat lower than default value: [error]{current_heartbeat_sample.heartbeat}[/]. Expected at least [info]{heartbeat_offset}[/]",
     )
+
+    # Heartbeat must be between 9 and 11
+    heartbeats_per_second_lower_bound = 9
+    heartbeats_per_second_upper_bound = 11
+    log_check_device(
+        device,
+        heartbeats_per_second >= heartbeats_per_second_lower_bound,
+        f"ARC heartbeat is too low: [error]{heartbeats_per_second}[/]hb/s. Expected at least [info]{heartbeats_per_second_lower_bound}[/]hb/s",
+    )
+    log_check_device(
+        device,
+        heartbeats_per_second <= heartbeats_per_second_upper_bound,
+        f"ARC heartbeat is too high: [error]{heartbeats_per_second}[/]hb/s. Expected at most [info]{heartbeats_per_second_upper_bound}[/]hb/s",
+    )
+
     heartbeat_interval = 0.1  # seconds
-    uptime_seconds = (heartbeat_1 - heartbeat_offset) * heartbeat_interval
-    # Heartbeat must be between 5 and 15
-    log_check_device(
-        device,
-        heartbeats_per_second >= 5,
-        f"ARC heartbeat is too low: [error]{heartbeats_per_second}[/]hb/s. Expected at least [info]5[/]hb/s",
-    )
-    log_check_device(
-        device,
-        heartbeats_per_second <= 15,
-        f"ARC heartbeat is too high: [error]{heartbeats_per_second}[/]hb/s. Expected at most [info]15[/]hb/s",
-    )
+    uptime_seconds = (current_heartbeat_sample.heartbeat - heartbeat_offset) * heartbeat_interval
 
     return ArcCheckData(
         location=arc.location,
@@ -83,7 +93,14 @@ def check_arc_block(arc: NocBlock, postcode: int) -> ArcCheckData:
     )
 
 
-def check_arc(device: Device):
+def get_heartbeat_sample(device: Device) -> HeartbeatSample:
+    return HeartbeatSample(
+        heartbeat=read_arc_telemetry_entry(device.arc_block.location.device_id, "TIMER_HEARTBEAT"),
+        timestamp=time.time(),
+    )
+
+
+def check_arc(device: Device, heartbeat_sample: HeartbeatSample):
     arc = device.arc_block
     postcode = arc.get_register_store().read_register("ARC_RESET_SCRATCH0")
     log_check_device(
@@ -92,14 +109,20 @@ def check_arc(device: Device):
         f"ARC postcode: [error]0x{postcode:08x}[/]. Expected [info]0xc0de____[/]",
     )
     if device.is_wormhole() or device.is_blackhole():
-        return check_arc_block(arc, postcode)
+        return check_arc_block(arc, postcode, heartbeat_sample)
     else:
         utils.DEBUG(f"Unsupported architecture for check_arc: {device._arch}")
 
 
 def run(args, context: Context):
     run_checks = get_run_checks(args, context)
-    return run_checks.run_per_device_check(lambda device: check_arc(device))
+
+    heartbeat_samples = {
+        sample.device_description.device: sample.result
+        for sample in run_checks.run_per_device_check(lambda device: get_heartbeat_sample(device))
+    }
+    time.sleep(2)
+    return run_checks.run_per_device_check(lambda device: check_arc(device, heartbeat_samples[device]))
 
 
 if __name__ == "__main__":

--- a/tools/triage/check_arc.py
+++ b/tools/triage/check_arc.py
@@ -51,7 +51,7 @@ def check_arc_block(arc: NocBlock, postcode: int, heartbeat_sample: HeartbeatSam
     device_id = arc.location.device_id
     # Heartbeat must be increasing
     current_heartbeat_sample = HeartbeatSample(
-        heartbeat=read_arc_telemetry_entry(device_id, "TIMER_HEARTBEAT"), timestamp=time.time()
+        heartbeat=read_arc_telemetry_entry(device_id, "TIMER_HEARTBEAT"), timestamp=time.monotonic()
     )
     arcclk_mhz = read_arc_telemetry_entry(device_id, "ARCCLK")
     heartbeats_per_second = (current_heartbeat_sample.heartbeat - heartbeat_sample.heartbeat) / (
@@ -96,7 +96,7 @@ def check_arc_block(arc: NocBlock, postcode: int, heartbeat_sample: HeartbeatSam
 def get_heartbeat_sample(device: Device) -> HeartbeatSample:
     return HeartbeatSample(
         heartbeat=read_arc_telemetry_entry(device.arc_block.location.device_id, "TIMER_HEARTBEAT"),
-        timestamp=time.time(),
+        timestamp=time.monotonic(),
     )
 
 


### PR DESCRIPTION
Issue: https://github.com/tenstorrent/tt-exalens/issues/891

Refactored `check_arc.py` to collect heartbeat value for all devices then sleep only once and go through devices once again  using previous heartbeat values to calculate heartbeats per seconds. We now sleep for 2 seconds instead of 0.2 seconds leading to much more precise heartbeat frequency estimation.

Once we implement script priority we could further improve this by extracting first part to separate script have it execute at the start of triage and other script at the end.

Triage tests: https://github.com/tenstorrent/tt-metal/actions/runs/21784982815