### PR TITLE
Update blitz mcast/gather micro ops

### DIFF
--- a/.github/workflows/ops-post-commit.yaml
+++ b/.github/workflows/ops-post-commit.yaml
@@ -76,7 +76,7 @@ jobs:
         default-ops-tests:
           [[
             { name: "wormhole_b0 sdxl op tests", cmd: "pytest --timeout 300 models/experimental/stable_diffusion_xl_base/tests/test_sdxl_op_unit_test_perf.py -k \"_performance\" -xv --tb=short", merge_gate: false, arch: "wormhole_b0", timeout: 5 },
-            { name: "blackhole deepseek blitz op tests", cmd: "pytest --timeout 600 -m \"not slow\" models/demos/deepseek_v3_b1/tests/unit_tests/", merge_gate: false, arch: "blackhole", timeout: 20 }
+            { name: "blackhole deepseek blitz op tests", cmd: "pytest --timeout 600 -m \"not skip_post_commit\" models/demos/deepseek_v3_b1/tests/unit_tests/", merge_gate: false, arch: "blackhole", timeout: 20 }
           ]]
     steps:
       - name: Compute tests

--- a/.github/workflows/ops-post-commit.yaml
+++ b/.github/workflows/ops-post-commit.yaml
@@ -76,7 +76,7 @@ jobs:
         default-ops-tests:
           [[
             { name: "wormhole_b0 sdxl op tests", cmd: "pytest --timeout 300 models/experimental/stable_diffusion_xl_base/tests/test_sdxl_op_unit_test_perf.py -k \"_performance\" -xv --tb=short", merge_gate: false, arch: "wormhole_b0", timeout: 5 },
-            { name: "blackhole deepseek blitz op tests", cmd: "pytest --timeout 600 -m \"not slow\" models/demos/deepseek_v3_b1/tests/unit_tests/", merge_gate: false, auto-triage: false, arch: "blackhole", timeout: 20 }
+            { name: "blackhole deepseek blitz op tests", cmd: "pytest --timeout 600 -m \"not slow\" models/demos/deepseek_v3_b1/tests/unit_tests/", merge_gate: false, arch: "blackhole", timeout: 20 }
           ]]
     steps:
       - name: Compute tests

--- a/.github/workflows/ops-post-commit.yaml
+++ b/.github/workflows/ops-post-commit.yaml
@@ -76,7 +76,7 @@ jobs:
         default-ops-tests:
           [[
             { name: "wormhole_b0 sdxl op tests", cmd: "pytest --timeout 300 models/experimental/stable_diffusion_xl_base/tests/test_sdxl_op_unit_test_perf.py -k \"_performance\" -xv --tb=short", merge_gate: false, arch: "wormhole_b0", timeout: 5 },
-            { name: "blackhole deepseek blitz op tests", cmd: "pytest models/demos/deepseek_v3_b1/tests/unit_tests/", merge_gate: false, arch: "blackhole", timeout: 20 }
+            { name: "blackhole deepseek blitz op tests", cmd: "pytest --timeout 600 -m \"not slow\" models/demos/deepseek_v3_b1/tests/unit_tests/", merge_gate: false, arch: "blackhole", timeout: 20 }
           ]]
     steps:
       - name: Compute tests

--- a/.github/workflows/ops-post-commit.yaml
+++ b/.github/workflows/ops-post-commit.yaml
@@ -76,7 +76,7 @@ jobs:
         default-ops-tests:
           [[
             { name: "wormhole_b0 sdxl op tests", cmd: "pytest --timeout 300 models/experimental/stable_diffusion_xl_base/tests/test_sdxl_op_unit_test_perf.py -k \"_performance\" -xv --tb=short", merge_gate: false, arch: "wormhole_b0", timeout: 5 },
-            { name: "blackhole deepseek blitz op tests", cmd: "pytest --timeout 600 -m \"not slow\" models/demos/deepseek_v3_b1/tests/unit_tests/", merge_gate: false, arch: "blackhole", timeout: 20 }
+            { name: "blackhole deepseek blitz op tests", cmd: "pytest --timeout 600 -m \"not slow\" models/demos/deepseek_v3_b1/tests/unit_tests/", merge_gate: false, auto-triage: false, arch: "blackhole", timeout: 20 }
           ]]
     steps:
       - name: Compute tests

--- a/models/demos/deepseek_v3_b1/fused_ops/down_proj/kernels/down_proj_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/fused_ops/down_proj/kernels/down_proj_kernel.cpp
@@ -209,20 +209,11 @@ void kernel_main() {
         Core::is_mcast_receiver_core,  // IsReceiverCore (for CB reserve/push)
         true>                          // pop_src
         mcast;
-#if defined(COMPILE_FOR_BRISC)
-    if constexpr (Core::is_mcast_sender_core) {
-        mcast.init(mcast_args);
-    }
-#endif
+    mcast.init(mcast_args);
     {
         DeviceZoneScopedN("MCAST1");
         mcast(mcast_args);
     }
-#if defined(COMPILE_FOR_BRISC)
-    if constexpr (Core::is_mcast_sender_core) {
-        mcast.teardown();
-    }
-#endif
 
     // ========================================================================
     // Mcast2: (12,9) -> 129 receivers in 13x10 grid
@@ -235,20 +226,11 @@ void kernel_main() {
         Core::is_mcast_receiver_core,  // IsReceiverCore
         true>                          // pop_src
         mcast2;
-#if defined(COMPILE_FOR_BRISC)
-    if constexpr (Core::is_mcast_sender_core) {
-        mcast2.init(mcast2_args);
-    }
-#endif
     {
         DeviceZoneScopedN("MCAST2");
         mcast2(mcast2_args);
     }
-#if defined(COMPILE_FOR_BRISC)
-    if constexpr (Core::is_mcast_sender_core) {
-        mcast2.teardown();
-    }
-#endif
+    mcast.teardown();
 
     // ========================================================================
     // Matmul: [1, K] x [K, N_per_core] -> [1, N_per_core] on 112 cores

--- a/models/demos/deepseek_v3_b1/fused_ops/down_proj/op.py
+++ b/models/demos/deepseek_v3_b1/fused_ops/down_proj/op.py
@@ -245,8 +245,7 @@ class DownProj:
         mcast_data_receiver_semaphore_id = 1
         gather_noc0_receiver_semaphore_id = 2
         gather_noc1_receiver_semaphore_id = 3
-        mcast2_data_sender_semaphore_id = 4
-        mcast2_data_receiver_semaphore_id = 5
+        mcast2_data_receiver_semaphore_id = 4
 
         # ====================================================================
         # Buffer addresses
@@ -322,7 +321,7 @@ class DownProj:
             ("mcast_dst_cb", mcast_dst_cb),
             ("mcast_is_part_of_receiver_grid", mcast_is_part_of_receiver_grid),
             # Mcast2 sender
-            ("mcast2_data_sender_semaphore", mcast2_data_sender_semaphore_id),
+            ("mcast2_data_sender_semaphore", mcast_data_sender_semaphore_id),
             ("mcast2_data_receiver_semaphore", mcast2_data_receiver_semaphore_id),
             ("mcast2_data_size_bytes", residual_add_mcast_data_size_bytes),
             ("mcast2_src_cb", residual_add_mcast_src_cb),
@@ -452,7 +451,6 @@ class DownProj:
             ttnn.SemaphoreDescriptor(
                 id=gather_noc1_receiver_semaphore_id, core_ranges=full_device_grid, initial_value=0
             ),
-            ttnn.SemaphoreDescriptor(id=mcast2_data_sender_semaphore_id, core_ranges=full_device_grid, initial_value=0),
             ttnn.SemaphoreDescriptor(
                 id=mcast2_data_receiver_semaphore_id, core_ranges=full_device_grid, initial_value=0
             ),

--- a/models/demos/deepseek_v3_b1/fused_ops/gated_local_reduce_down_proj/kernels/gated_local_reduce_down_proj_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/fused_ops/gated_local_reduce_down_proj/kernels/gated_local_reduce_down_proj_kernel.cpp
@@ -333,20 +333,11 @@ void kernel_main() {
         Core::is_mcast_receiver_core,
         /*pop_src=*/true>
         mcast;
-#if defined(COMPILE_FOR_BRISC)
-    if constexpr (Core::is_mcast_sender_core) {
-        mcast.init(mcast_args);
-    }
-#endif
+    mcast.init(mcast_args);
     {
         DeviceZoneScopedN("MCAST1");
         mcast(mcast_args);
     }
-#if defined(COMPILE_FOR_BRISC)
-    if constexpr (Core::is_mcast_sender_core) {
-        mcast.teardown();
-    }
-#endif
 
     // ========================================================================
     // Mcast2: sender (12,9) -> 129 receivers in 13x10 grid
@@ -359,20 +350,11 @@ void kernel_main() {
         Core::is_mcast_receiver_core,
         /*pop_src=*/true>
         mcast2;
-#if defined(COMPILE_FOR_BRISC)
-    if constexpr (Core::is_mcast_sender_core) {
-        mcast2.init(mcast2_args);
-    }
-#endif
     {
         DeviceZoneScopedN("MCAST2");
         mcast2(mcast2_args);
     }
-#if defined(COMPILE_FOR_BRISC)
-    if constexpr (Core::is_mcast_sender_core) {
-        mcast2.teardown();
-    }
-#endif
+    mcast.teardown();
 
     // ========================================================================
     // Matmul: [1, K] x [K, N_per_core] -> [1, N_per_core] on 112 cores

--- a/models/demos/deepseek_v3_b1/fused_ops/gated_local_reduce_down_proj/op.py
+++ b/models/demos/deepseek_v3_b1/fused_ops/gated_local_reduce_down_proj/op.py
@@ -127,6 +127,7 @@ class _GatedReduceDownProjContext:
     ig_g2_noc1_receiver_semaphore_id: int
     mcast2_data_sender_semaphore_id: int
     mcast2_data_receiver_semaphore_id: int
+    num_semaphores: int
 
     # Addresses
     gather_receiver_data_addr: int
@@ -298,8 +299,8 @@ class GatedLocalReduceDownProjOp:
         ig_g2_receiver_semaphore_id = 5
         ig_g1_noc1_receiver_semaphore_id = 6
         ig_g2_noc1_receiver_semaphore_id = 7
-        mcast2_data_sender_semaphore_id = 8
-        mcast2_data_receiver_semaphore_id = 9
+        mcast2_data_receiver_semaphore_id = 8
+        num_semaphores = 9
 
         # Buffer addresses
         gather_receiver_data_addr = output_tensor.buffer_address()
@@ -381,8 +382,9 @@ class GatedLocalReduceDownProjOp:
             ig_g2_receiver_semaphore_id=ig_g2_receiver_semaphore_id,
             ig_g1_noc1_receiver_semaphore_id=ig_g1_noc1_receiver_semaphore_id,
             ig_g2_noc1_receiver_semaphore_id=ig_g2_noc1_receiver_semaphore_id,
-            mcast2_data_sender_semaphore_id=mcast2_data_sender_semaphore_id,
+            mcast2_data_sender_semaphore_id=mcast_data_sender_semaphore_id,
             mcast2_data_receiver_semaphore_id=mcast2_data_receiver_semaphore_id,
+            num_semaphores=num_semaphores,
             gather_receiver_data_addr=gather_receiver_data_addr,
             ig_g1_receiver_data_addr=ig_g1_receiver_data_addr,
             ig_g2_receiver_data_addr=ig_g2_receiver_data_addr,
@@ -792,7 +794,8 @@ class GatedLocalReduceDownProjOp:
 
         # Semaphore descriptors
         semaphore_descriptors = [
-            ttnn.SemaphoreDescriptor(id=i, core_ranges=ctx.full_device_grid, initial_value=0) for i in range(10)
+            ttnn.SemaphoreDescriptor(id=i, core_ranges=ctx.full_device_grid, initial_value=0)
+            for i in range(ctx.num_semaphores)
         ]
 
         # Kernel descriptor

--- a/models/demos/deepseek_v3_b1/fused_ops/moe_routed_expert/op.py
+++ b/models/demos/deepseek_v3_b1/fused_ops/moe_routed_expert/op.py
@@ -991,7 +991,6 @@ class MoeRoutedExpert:
         expert_scale_tile_size = expert_scale_tile.get_tile_size(expert_scale_dtype)
 
         # Expert scale mcast parameters (different semaphores to avoid race condition with back-to-back mcasts)
-        # Using UpdateSemaphoreAddr=true in kernel allows using different semaphore addresses
         expert_scale_mcast_sender_semaphore_id = 4  # Different from index_mcast
         expert_scale_mcast_receiver_semaphore_id = 5  # Different from index_mcast
         expert_scale_mcast_num_pages = 1
@@ -1387,8 +1386,7 @@ class MoeRoutedExpert:
             initial_value=0,
         )
 
-        # Expert scale mcast uses separate semaphores (IDs 4 and 5) to avoid race condition
-        # with back-to-back mcasts. Kernel uses UpdateSemaphoreAddr=true to update addresses.
+        # Expert scale mcast uses separate semaphores (IDs 4 and 5) to avoid race condition with back-to-back mcasts.
         expert_scale_mcast_sender_semaphore_descriptor = ttnn.SemaphoreDescriptor(
             id=expert_scale_mcast_sender_semaphore_id,
             core_ranges=full_device_grid,

--- a/models/demos/deepseek_v3_b1/fused_ops/moe_routed_expert/op.py
+++ b/models/demos/deepseek_v3_b1/fused_ops/moe_routed_expert/op.py
@@ -991,8 +991,8 @@ class MoeRoutedExpert:
         expert_scale_tile_size = expert_scale_tile.get_tile_size(expert_scale_dtype)
 
         # Expert scale mcast parameters (different semaphores to avoid race condition with back-to-back mcasts)
-        expert_scale_mcast_sender_semaphore_id = 4  # Different from index_mcast
-        expert_scale_mcast_receiver_semaphore_id = 5  # Different from index_mcast
+        expert_scale_mcast_sender_semaphore_id = mcast_data_sender_semaphore_id
+        expert_scale_mcast_receiver_semaphore_id = 4  # Different from index_mcast
         expert_scale_mcast_num_pages = 1
         expert_scale_mcast_data_size_bytes = expert_scale_tile_size
 
@@ -1386,13 +1386,6 @@ class MoeRoutedExpert:
             initial_value=0,
         )
 
-        # Expert scale mcast uses separate semaphores (IDs 4 and 5) to avoid race condition with back-to-back mcasts.
-        expert_scale_mcast_sender_semaphore_descriptor = ttnn.SemaphoreDescriptor(
-            id=expert_scale_mcast_sender_semaphore_id,
-            core_ranges=full_device_grid,
-            initial_value=1,  # Sender semaphore starts as VALID (1)
-        )
-
         expert_scale_mcast_receiver_semaphore_descriptor = ttnn.SemaphoreDescriptor(
             id=expert_scale_mcast_receiver_semaphore_id,
             core_ranges=full_device_grid,
@@ -1534,7 +1527,6 @@ class MoeRoutedExpert:
             mcast_receiver_semaphore_descriptor,
             gather_noc0_semaphore_descriptor,
             gather_noc1_semaphore_descriptor,
-            expert_scale_mcast_sender_semaphore_descriptor,
             expert_scale_mcast_receiver_semaphore_descriptor,
         ]
 

--- a/models/demos/deepseek_v3_b1/fused_ops/shared_expert/kernels/shared_expert_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/fused_ops/shared_expert/kernels/shared_expert_kernel.cpp
@@ -358,7 +358,6 @@ void kernel_main() {
         DeviceZoneScopedN("ACT_MCAST");
         act_mcast(act_mcast_args);
     }
-    act_mcast.teardown();
 
     // ========================================================================
     // Phase 2: Gate/Up Matmul on 128 compute cores
@@ -417,7 +416,6 @@ void kernel_main() {
         Core::is_mcast_receiver_core,
         /*pop_src=*/true>
         mcast;
-    mcast.init(mcast_args);
     {
         DeviceZoneScopedN("MCAST1");
         mcast(mcast_args);
@@ -445,7 +443,7 @@ void kernel_main() {
         DeviceZoneScopedN("MCAST2");
         mcast(mcast2_args);
     }
-    mcast.teardown();
+    act_mcast.teardown();
 
     // ========================================================================
     // Phase 7: Down Proj Matmul — [1, K_down] x [K_down, N_per_core] on 112 cores

--- a/models/demos/deepseek_v3_b1/fused_ops/shared_expert/op.py
+++ b/models/demos/deepseek_v3_b1/fused_ops/shared_expert/op.py
@@ -142,6 +142,7 @@ class _SharedExpertContext:
     bg_noc1_receiver_semaphore_id: int
     act_mcast_sender_semaphore_id: int
     act_mcast_receiver_semaphore_id: int
+    num_semaphores: int
 
     # Addresses & tensors
     gather_receiver_data_addr: int
@@ -347,8 +348,8 @@ class SharedExpertOp:
         bg_receiver_semaphore_id = 5
         ag_noc1_receiver_semaphore_id = 6
         bg_noc1_receiver_semaphore_id = 7
-        act_mcast_sender_semaphore_id = 8
-        act_mcast_receiver_semaphore_id = 9
+        act_mcast_receiver_semaphore_id = 8
+        num_semaphores = 9
 
         # Buffer addresses
         gather_receiver_data_addr = output_tensor.buffer_address()
@@ -463,8 +464,9 @@ class SharedExpertOp:
             bg_receiver_semaphore_id=bg_receiver_semaphore_id,
             ag_noc1_receiver_semaphore_id=ag_noc1_receiver_semaphore_id,
             bg_noc1_receiver_semaphore_id=bg_noc1_receiver_semaphore_id,
-            act_mcast_sender_semaphore_id=act_mcast_sender_semaphore_id,
+            act_mcast_sender_semaphore_id=mcast_data_sender_semaphore_id,
             act_mcast_receiver_semaphore_id=act_mcast_receiver_semaphore_id,
+            num_semaphores=num_semaphores,
             gather_receiver_data_addr=gather_receiver_data_addr,
             ag_dummy_tensor=ag_dummy_tensor,
             bg_dummy_tensor=bg_dummy_tensor,
@@ -930,7 +932,8 @@ class SharedExpertOp:
 
         # Semaphore descriptors
         semaphore_descriptors = [
-            ttnn.SemaphoreDescriptor(id=i, core_ranges=ctx.full_device_grid, initial_value=0) for i in range(10)
+            ttnn.SemaphoreDescriptor(id=i, core_ranges=ctx.full_device_grid, initial_value=0)
+            for i in range(ctx.num_semaphores)
         ]
 
         # Kernel descriptor

--- a/models/demos/deepseek_v3_b1/kernel_includes/tt_llk/tt_llk_blackhole/llk_lib/llk_math_rmsnorm_bcast_scalar_dest_reuse.h
+++ b/models/demos/deepseek_v3_b1/kernel_includes/tt_llk/tt_llk_blackhole/llk_lib/llk_math_rmsnorm_bcast_scalar_dest_reuse.h
@@ -33,6 +33,7 @@ inline void rmsnorm_bcast_scalar_dest_reuse_configure_mop(
             TT_OP_ELWADD(0, acc_to_dest, broadcast_type, ADDR_MOD_0, 0),
             TT_OP_ELWADD(p_setrwc::CLR_A, acc_to_dest, broadcast_type, ADDR_MOD_2, 0));
         tmp.set_last_inner_loop_instr(TT_OP_ELWADD(p_setrwc::CLR_A, acc_to_dest, broadcast_type, ADDR_MOD_3, 0));
+        tmp.set_last_outer_loop_instr(TT_OP_ELWADD(p_setrwc::CLR_A, acc_to_dest, broadcast_type, ADDR_MOD_3, 0));
         tmp.program();
     } else if constexpr (eltwise_binary_type == ELWSUB) {
         ckernel_template tmp(
@@ -41,6 +42,7 @@ inline void rmsnorm_bcast_scalar_dest_reuse_configure_mop(
             TT_OP_ELWSUB(0, acc_to_dest, broadcast_type, ADDR_MOD_0, 0),
             TT_OP_ELWSUB(p_setrwc::CLR_A, acc_to_dest, broadcast_type, ADDR_MOD_2, 0));
         tmp.set_last_inner_loop_instr(TT_OP_ELWSUB(p_setrwc::CLR_A, acc_to_dest, broadcast_type, ADDR_MOD_3, 0));
+        tmp.set_last_outer_loop_instr(TT_OP_ELWSUB(p_setrwc::CLR_A, acc_to_dest, broadcast_type, ADDR_MOD_3, 0));
         tmp.program();
     } else if constexpr (eltwise_binary_type == ELWMUL) {
         if constexpr (high_fidelity) {
@@ -59,6 +61,7 @@ inline void rmsnorm_bcast_scalar_dest_reuse_configure_mop(
                 TT_OP_ELWMUL(0, 0, broadcast_type, ADDR_MOD_0, 0),
                 TT_OP_ELWMUL(p_setrwc::CLR_A, 0, broadcast_type, ADDR_MOD_2, 0));
             tmp.set_last_inner_loop_instr(TT_OP_ELWMUL(p_setrwc::CLR_A, 0, broadcast_type, ADDR_MOD_3, 0));
+            tmp.set_last_outer_loop_instr(TT_OP_ELWMUL(p_setrwc::CLR_A, 0, broadcast_type, ADDR_MOD_3, 0));
             tmp.program();
         }
     }
@@ -100,7 +103,6 @@ inline void _llk_math_rmsnorm_bcast_scalar_dest_reuse_(uint src_index, uint dst_
     } else if constexpr (eltwise_binary_type == ELWMUL) {
         // Row and no broadcasted behaves similarly
         if constexpr (high_fidelity) {
-#pragma GCC unroll 0
             for (std::uint32_t tile_num = 0; tile_num < num_tiles; tile_num++) {
                 ckernel_template::run();
             }
@@ -110,8 +112,6 @@ inline void _llk_math_rmsnorm_bcast_scalar_dest_reuse_(uint src_index, uint dst_
     }
     // Manually clear B once mop is done for scaler bcast
     TTI_SETRWC(p_setrwc::CLR_B, 0, 0, 0, 0, p_setrwc::SET_D);
-
-    math::clear_dst_reg_addr();
 }
 
 template <EltwiseBinaryType eltwise_binary_type, int NUM_FIDELITY_PHASES, std::uint32_t FIDELITY_INCREMENT>

--- a/models/demos/deepseek_v3_b1/kernel_includes/tt_llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_deepseek_moe_gate_topk_single_face.h
+++ b/models/demos/deepseek_v3_b1/kernel_includes/tt_llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_deepseek_moe_gate_topk_single_face.h
@@ -333,7 +333,7 @@ inline void _deepseek_moe_gate_sum_top2() {
     constexpr int phase_replay_offset = store_replay_offset + load_store_replay_count;
 
     TTI_SETRWC(p_setrwc::CLR_NONE, 0, 0, 0, 0, p_setrwc::SET_D);
-    _sfpu_load_config32_(0xF, 0x0, 0x4);
+    TTI_SFPCONFIG(0x4, 0xF, 1);
 
     // Phase 0-3 Even Columns
     bitonic_topk_load16_concat_indices_single_face<is_fp32_dest_acc_en, 0>();
@@ -423,13 +423,12 @@ inline void _deepseek_moe_gate_top8(uint32_t eps, uint32_t scale) {
     TTI_SFPSHFT2(0, p_sfpu::LREG0, p_sfpu::LREG3, sfpi::SFPSHFT2_MOD1_SUBVEC_SHFLROR1);
     TTI_SFPSHFT2(0, p_sfpu::LREG1, p_sfpu::LREG2, sfpi::SFPSHFT2_MOD1_SUBVEC_SHFLROR1);
     // There is a hardware bug that affects operations on LREG4-7 while this is enabled
-    // Note this overwrites LREG0
-    _sfpu_load_config32_(0xF, 0x0, 0x0);
+    TTI_SFPCONFIG(0, 0xF, 1);
     TTI_SFPSHFT2(0, p_sfpu::LREG4, p_sfpu::LREG7, sfpi::SFPSHFT2_MOD1_SUBVEC_SHFLROR1);
     TTI_SFPSHFT2(0, p_sfpu::LREG5, p_sfpu::LREG6, sfpi::SFPSHFT2_MOD1_SUBVEC_SHFLROR1);
 
     // Re-enable index tracking
-    _sfpu_load_config32_(0xF, 0x0, 0x4);
+    TTI_SFPCONFIG(0x4, 0xF, 1);
     reverse_sort_order();
     bitonic_topk_load8_even_cols_concatted_indices_single_face<is_fp32_dest_acc_en>();
 
@@ -455,13 +454,9 @@ inline void _deepseek_moe_gate_top8(uint32_t eps, uint32_t scale) {
     TTI_SFPNOP;
 
     // Calculate 1 / (sum + eps) * scale
-    // Store the value in lreg0 and reload later since the following instructions overwrite it
-    TTI_SFPSTORE(p_sfpu::LREG0, 0, ADDR_MOD_3, interm_offset + 0);
+    TTI_SFPCONFIG(0, 0xF, 1);
     // Technically we only need to reprogram a single constant here, instead of all 3 used by reciprocal init
     sfpu_reciprocal_init<APPROXIMATION_MODE>();
-    _sfpu_load_config32_(0xF, 0x0, 0x0);
-    TTI_SFPLOAD(p_sfpu::LREG0, 0, ADDR_MOD_3, interm_offset + 0);
-
     sfpi::vFloat l0 = sfpi::l_reg[sfpi::LRegs::LReg0];
     sfpi::vFloat eps_value = Converter::as_float(eps);
     l0 = l0 + eps_value;

--- a/models/demos/deepseek_v3_b1/micro_ops/gather_heads/kernels/gather_heads_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/micro_ops/gather_heads/kernels/gather_heads_kernel.cpp
@@ -58,7 +58,7 @@ void kernel_main() {
 
     if constexpr (is_ncrisc_sender) {
         // NOC0 sender on NCRISC
-        uint32_t receiver_data_addr = get_arg_val<uint32_t>(0);
+        uint32_t receiver_data_addr = get_common_arg_val<uint32_t>(0);
         deepseek_b1_ops::GatherHeads::SenderArgs gather_heads_args{
             get_named_compile_time_arg_val("sender_grid_start_x"),
             get_named_compile_time_arg_val("sender_grid_start_y"),
@@ -135,7 +135,7 @@ void kernel_main() {
 
     if constexpr (is_brisc_sender) {
         // NOC1 sender on BRISC
-        uint32_t receiver_data_addr = get_arg_val<uint32_t>(0);
+        uint32_t receiver_data_addr = get_common_arg_val<uint32_t>(0);
         deepseek_b1_ops::GatherHeads::SenderArgs gather_heads_args{
             get_named_compile_time_arg_val("sender_grid_start_x"),
             get_named_compile_time_arg_val("sender_grid_start_y"),

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_dram_streaming_matmul.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_dram_streaming_matmul.py
@@ -258,6 +258,7 @@ def test_dram_streaming_matmul(device, k, n, m, fused_activation):
 @pytest.mark.parametrize("m", [1])
 @pytest.mark.parametrize("num_experts", [256])
 @pytest.mark.parametrize("fused_activation", ["silu"])
+@pytest.mark.slow
 def test_dram_streaming_matmul_indexed(device, k, n, m, num_experts, fused_activation):
     """Test DRAM streaming matmul with expert indexing.
 

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_dram_streaming_matmul.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_dram_streaming_matmul.py
@@ -258,7 +258,7 @@ def test_dram_streaming_matmul(device, k, n, m, fused_activation):
 @pytest.mark.parametrize("m", [1])
 @pytest.mark.parametrize("num_experts", [256])
 @pytest.mark.parametrize("fused_activation", ["silu"])
-@pytest.mark.slow
+@pytest.mark.skip_post_commit
 def test_dram_streaming_matmul_indexed(device, k, n, m, num_experts, fused_activation):
     """Test DRAM streaming matmul with expert indexing.
 

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_gated_local_reduce_down_proj.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_gated_local_reduce_down_proj.py
@@ -30,9 +30,11 @@ from models.demos.deepseek_v3_b1.fused_ops.shared_expert.op import SharedExpertO
 @pytest.mark.parametrize(
     "tiles_per_k, K, N_per_core, weights_dtype",
     [
-        (2, 256, 32, ttnn.bfloat8_b),  # 2 collections of 8, K=256, N=3584
-        (2, 128, 32, ttnn.bfloat8_b),  # 2 collections of 4, K=128
-        (4, 256, 32, ttnn.bfloat8_b),  # 4 collections of 8, K=256
+        pytest.param(
+            2, 256, 32, ttnn.bfloat8_b, marks=pytest.mark.skip_post_commit
+        ),  # 2 collections of 8, K=256, N=3584
+        pytest.param(2, 128, 32, ttnn.bfloat8_b, marks=pytest.mark.skip_post_commit),  # 2 collections of 4, K=128
+        pytest.param(4, 256, 32, ttnn.bfloat8_b, marks=pytest.mark.skip_post_commit),  # 4 collections of 8, K=256
         (2, 256, 64, ttnn.bfloat8_b),  # 2 collections, larger output N=7168
         (2, 256, 64, ttnn.bfloat4_b),  # bfloat4 weights
         (8, 256, 64, ttnn.bfloat8_b),  # 8 collections, 64+64 A/B grid, N=7168

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_gather.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_gather.py
@@ -91,7 +91,7 @@ def create_scattered_input_tensor(device, torch_input, sender_cores, shard_shape
     [
         (
             32,
-            ttnn.CoreCoord(11, 9),
+            ttnn.CoreCoord(12, 9),
             ttnn.CoreRange(
                 ttnn.CoreCoord(0, 4),
                 ttnn.CoreCoord(11, 7),
@@ -100,7 +100,7 @@ def create_scattered_input_tensor(device, torch_input, sender_cores, shard_shape
         ),  # q_a_proj output, if on 48 cores (could also do 6x8 instead of 12x4 grid)
         (
             32,
-            ttnn.CoreCoord(11, 9),
+            ttnn.CoreCoord(12, 9),
             ttnn.CoreRange(
                 ttnn.CoreCoord(0, 0),
                 ttnn.CoreCoord(11, 7),
@@ -118,7 +118,7 @@ def create_scattered_input_tensor(device, torch_input, sender_cores, shard_shape
         ),  # kv_a_proj output, 16 cores (Gather only a subset for kv_a_layernorm)
         (
             128,
-            ttnn.CoreCoord(11, 9),
+            ttnn.CoreCoord(12, 9),
             ttnn.CoreRange(
                 ttnn.CoreCoord(4, 0),
                 ttnn.CoreCoord(11, 7),

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_mcast.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_mcast.py
@@ -22,7 +22,7 @@ from models.demos.deepseek_v3_b1.micro_ops.mcast.op import McastSingleCore
     [
         (
             7168,
-            ttnn.CoreCoord(11, 9),
+            ttnn.CoreCoord(12, 9),
             ttnn.CoreRangeSet(
                 {
                     ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(11, 7)),
@@ -31,23 +31,23 @@ from models.demos.deepseek_v3_b1.micro_ops.mcast.op import McastSingleCore
             ),
             ttnn.CoreRange(
                 ttnn.CoreCoord(0, 0),
-                ttnn.CoreCoord(11, 9),
+                ttnn.CoreCoord(12, 9),
             ),
             ttnn.NOC.NOC_1,
         ),  # q_a_proj input + kv_a_proj input, 96 cores + 18 cores (120 cores total)
         (
             1536,
-            ttnn.CoreCoord(11, 9),
+            ttnn.CoreCoord(12, 9),
             ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(11, 7))}),
             ttnn.CoreRange(
                 ttnn.CoreCoord(0, 0),
-                ttnn.CoreCoord(11, 9),
+                ttnn.CoreCoord(12, 9),
             ),
             ttnn.NOC.NOC_1,
         ),  # q_b_proj input, 96 cores (120 cores total)
         (
             8192,
-            ttnn.CoreCoord(11, 9),
+            ttnn.CoreCoord(12, 9),
             ttnn.CoreRangeSet(
                 {
                     ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(11, 7)),
@@ -56,17 +56,17 @@ from models.demos.deepseek_v3_b1.micro_ops.mcast.op import McastSingleCore
             ),
             ttnn.CoreRange(
                 ttnn.CoreCoord(0, 0),
-                ttnn.CoreCoord(11, 9),
+                ttnn.CoreCoord(12, 9),
             ),
             ttnn.NOC.NOC_1,
         ),  # o_proj input (TP 2), 112 cores (120 cores total)
         (
             1536,
-            ttnn.CoreCoord(11, 9),
-            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(11, 9))}),
+            ttnn.CoreCoord(12, 9),
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(12, 9))}),
             ttnn.CoreRange(
                 ttnn.CoreCoord(0, 0),
-                ttnn.CoreCoord(11, 9),
+                ttnn.CoreCoord(12, 9),
             ),
             ttnn.NOC.NOC_1,
         ),  # loopback test for testing, not used in model

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_moe_routed_expert.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_moe_routed_expert.py
@@ -136,7 +136,7 @@ def create_expert_matmul_tensors(
     return weights_tensor, output_tensor, expert_weights_for_validation, expert_tensors
 
 
-@pytest.mark.parametrize("use_hardcoded_expert_index", [True, False])
+@pytest.mark.parametrize("use_hardcoded_expert_index", [True, pytest.param(False, marks=pytest.mark.slow)])
 def test_moe_routed_expert(device, use_hardcoded_expert_index):
     """Test MoE routed expert fused operation"""
 

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_moe_routed_expert.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_moe_routed_expert.py
@@ -136,7 +136,7 @@ def create_expert_matmul_tensors(
     return weights_tensor, output_tensor, expert_weights_for_validation, expert_tensors
 
 
-@pytest.mark.parametrize("use_hardcoded_expert_index", [True, pytest.param(False, marks=pytest.mark.slow)])
+@pytest.mark.parametrize("use_hardcoded_expert_index", [True, pytest.param(False, marks=pytest.mark.skip_post_commit)])
 def test_moe_routed_expert(device, use_hardcoded_expert_index):
     """Test MoE routed expert fused operation"""
 

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_shared_expert.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_shared_expert.py
@@ -25,8 +25,12 @@ from models.demos.deepseek_v3_b1.fused_ops.shared_expert.op import SharedExpertO
     "K_gate, N_per_core, weights_dtype",
     [
         (7168, 64, ttnn.bfloat8_b),  # Full MLP: K_gate=7168, K_down=256, N=7168
-        (2048, 64, ttnn.bfloat8_b),  # Mid: K_gate=2048, K_down=256, N=7168
-        (1024, 32, ttnn.bfloat8_b),  # Small: K_gate=1024, K_down=256, N=3584
+        pytest.param(
+            2048, 64, ttnn.bfloat8_b, marks=pytest.mark.skip_post_commit
+        ),  # Mid: K_gate=2048, K_down=256, N=7168
+        pytest.param(
+            1024, 32, ttnn.bfloat8_b, marks=pytest.mark.skip_post_commit
+        ),  # Small: K_gate=1024, K_down=256, N=3584
         (7168, 64, ttnn.bfloat4_b),  # bfloat4 weights
     ],
 )

--- a/models/demos/deepseek_v3_b1/unified_kernels/mcast.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/mcast.hpp
@@ -125,14 +125,14 @@ FORCE_INLINE void mcast_send_with_state(uint32_t src_local_addr, uint32_t dst_lo
     }
 }
 
-template <uint32_t mcast_num_cores, bool loopback, bool is_part_of_receiver_grid>
+template <uint32_t mcast_num_cores, bool loopback, bool is_part_of_receiver_grid, bool linked, bool posted>
 FORCE_INLINE void init_persistent_mcast_sender(uint64_t mcast_flag_noc_addr, uint32_t data_sender_semaphore_addr) {
     mcast_send_set_state<
         mcast_num_cores,
         loopback,
         is_part_of_receiver_grid,
-        true,
-        true,
+        linked,
+        posted,
         true,
         false,
         false,
@@ -141,21 +141,21 @@ FORCE_INLINE void init_persistent_mcast_sender(uint64_t mcast_flag_noc_addr, uin
         mcast_num_cores,
         loopback,
         is_part_of_receiver_grid,
+        linked,
+        posted,
         true,
         true,
         true,
-        false,
-        true,
-        write_reg_cmd_buf>(0, mcast_flag_noc_addr, 4);
+        write_reg_cmd_buf>(data_sender_semaphore_addr, mcast_flag_noc_addr, 4);
     mcast_send_with_state<
         mcast_num_cores,
         loopback,
         is_part_of_receiver_grid,
-        true,
-        true,
+        linked,
+        posted,
         false,
         false,
-        write_reg_cmd_buf>(data_sender_semaphore_addr, mcast_flag_noc_addr, 0);
+        write_reg_cmd_buf>(0, 0, 0);
     noc_async_posted_writes_flushed();
 }
 
@@ -305,7 +305,9 @@ struct Mcast {
                     init_persistent_mcast_sender<
                         CTArgsT::mcast_num_cores,
                         CTArgsT::loopback,
-                        CTArgsT::is_part_of_receiver_grid>(mcast_flag_noc_addr, data_sender_semaphore_addr);
+                        CTArgsT::is_part_of_receiver_grid,
+                        linked,
+                        posted>(mcast_flag_noc_addr, data_sender_semaphore_addr);
                 }
                 noc_semaphore_set(data_sender_semaphore_addr_ptr, VALID);
             }
@@ -351,8 +353,8 @@ struct Mcast {
                     CTArgsT::mcast_num_cores,
                     CTArgsT::loopback,
                     CTArgsT::is_part_of_receiver_grid,
-                    true,
-                    true,
+                    linked,
+                    posted,
                     true,
                     true,
                     write_cmd_buf>(args.input_data_addr, args.mcast_receiver_data_addr, args.data_size_bytes);
@@ -360,8 +362,8 @@ struct Mcast {
                     CTArgsT::mcast_num_cores,
                     CTArgsT::loopback,
                     CTArgsT::is_part_of_receiver_grid,
-                    true,
-                    true,
+                    linked,
+                    posted,
                     true,
                     false,
                     write_reg_cmd_buf>(data_sender_semaphore_addr, data_receiver_semaphore_addr, 0);
@@ -393,6 +395,10 @@ struct Mcast {
             }
 #endif
         }
+
+        static constexpr bool linked = true;
+        static constexpr bool posted = true;
+
     };  // class Op
 
 };  // struct Mcast


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Mcast assumed we always used the same sem addr, which isn't always the case. One workaround applied in some of the kernels was to teardown and reinit the persistent mcaster, which is not ideal.

### What's changed
Update mcast to always reprogram the sem addrs.

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=aho/blitz2)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:aho/blitz2)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=aho/blitz2)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:aho/blitz2)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=aho/blitz2)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:aho/blitz2)
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=aho/blitz2)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:aho/blitz2)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=aho/blitz2)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:aho/blitz2)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=aho/blitz2)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:aho/blitz2)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
