### PR TITLE
PDL: PCC drop on instance embedding fix 

### DIFF
--- a/models/experimental/panoptic_deeplab/demo/demo.py
+++ b/models/experimental/panoptic_deeplab/demo/demo.py
@@ -472,6 +472,7 @@ def run_panoptic_deeplab_demo(
     return None
 
 
+@pytest.mark.timeout(900)
 @pytest.mark.parametrize(
     "device_params",
     [{"l1_small_size": PDL_L1_SMALL_SIZE, "trace_region_size": 4000000}],

--- a/models/experimental/panoptic_deeplab/tests/pcc/test_tt_model.py
+++ b/models/experimental/panoptic_deeplab/tests/pcc/test_tt_model.py
@@ -31,7 +31,7 @@ from models.experimental.panoptic_deeplab.tests.pcc.common import (
             PANOPTIC_DEEPLAB,
             {
                 "semantic": {"pcc": 0.986, "abs_err": 1.3, "rel_err": 0.4},
-                "center": {"pcc": 0.804, "abs_err": 0.1, "rel_err": 2.1},
+                "center": {"pcc": 0.95, "abs_err": 0.1, "rel_err": 2.1},
                 "offset": {"pcc": 0.990, "abs_err": 10.4, "rel_err": 0.6},
             },
             skip_if_not_blackhole_20_cores,
@@ -39,9 +39,9 @@ from models.experimental.panoptic_deeplab.tests.pcc.common import (
         (
             PANOPTIC_DEEPLAB,
             {
-                "semantic": {"pcc": 0.981, "abs_err": 1.8, "rel_err": 0.4},
-                "center": {"pcc": 0.803, "abs_err": 0.1, "rel_err": 2.1},
-                "offset": {"pcc": 0.991, "abs_err": 9.5, "rel_err": 0.6},
+                "semantic": {"pcc": 0.983, "abs_err": 1.7, "rel_err": 0.4},
+                "center": {"pcc": 0.95, "abs_err": 0.1, "rel_err": 2.1},
+                "offset": {"pcc": 0.992, "abs_err": 8.5, "rel_err": 0.5},
             },
             skip_if_not_blackhole_110_cores,
         ),
@@ -55,7 +55,7 @@ from models.experimental.panoptic_deeplab.tests.pcc.common import (
         (
             DEEPLAB_V3_PLUS,
             {
-                "semantic": {"pcc": 0.981, "abs_err": 1.8, "rel_err": 0.4},
+                "semantic": {"pcc": 0.983, "abs_err": 1.7, "rel_err": 0.4},
             },
             skip_if_not_blackhole_110_cores,
         ),

--- a/models/experimental/panoptic_deeplab/tests/pcc/test_tt_model.py
+++ b/models/experimental/panoptic_deeplab/tests/pcc/test_tt_model.py
@@ -24,6 +24,7 @@ from models.experimental.panoptic_deeplab.tests.pcc.common import (
 )
 
 
+@pytest.mark.timeout(600)
 @pytest.mark.parametrize(
     "model_category, pcc_values, skip_check",
     [

--- a/models/experimental/panoptic_deeplab/tests/pcc/test_tt_upsample.py
+++ b/models/experimental/panoptic_deeplab/tests/pcc/test_tt_upsample.py
@@ -48,7 +48,7 @@ def test_bilinear_upsample_matmul_vs_torch(b, h, w, c, scale, input_channels_fir
     out_torch = upsampler.forward(img_torch)
 
     # Torch bilinear upsampling (always works with channels-first)
-    out_t = torch.nn.functional.interpolate(img_nchw, scale_factor=scale, mode="bilinear", align_corners=True)
+    out_t = torch.nn.functional.interpolate(img_nchw, scale_factor=scale, mode="bilinear", align_corners=False)
 
     if output_channels_first:
         # Keep channels-first format
@@ -145,9 +145,9 @@ def test_bilinear_upsample_ttnn_matmul_vs_ttnn_upsample(
     output_matmul = upsampler(ttnn_input_tensor)
     output_matmul_torch = ttnn.to_torch(output_matmul)
 
-    # Method 2: PyTorch reference with align_corners=True
+    # Method 2: PyTorch reference with align_corners=False
     torch_result_nchw = torch.nn.functional.interpolate(
-        img_torch_nchw, scale_factor=scale, mode="bilinear", align_corners=True
+        img_torch_nchw, scale_factor=scale, mode="bilinear", align_corners=False
     )
 
     if output_channels_first:
@@ -240,9 +240,9 @@ def test_bilinear_upsample_l1_ttnn_matmul_vs_ttnn_upsample(
     output_matmul = upsampler(ttnn_input_tensor)
     output_matmul_torch = ttnn.to_torch(output_matmul)
 
-    # Method 2: PyTorch reference with align_corners=True
+    # Method 2: PyTorch reference with align_corners=False
     torch_result_nchw = torch.nn.functional.interpolate(
-        img_torch_nchw, scale_factor=scale, mode="bilinear", align_corners=True
+        img_torch_nchw, scale_factor=scale, mode="bilinear", align_corners=False
     )
 
     if output_channels_first:


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/31697)

### Problem description
After fusing of ImageNet norm into the `stem.conv1` the PCC of instance center fell from 0.955 to 0.803.

### What's changed
The fundamental difference between pytorch reference implementation and our ttnn implementation is the upsample in the heads. Pytorch uses `align_corners=False` while our `tt_upsample.py` was implemented with `align_corners=True` behavior. Center logits are way smaller (values close to 0) than semantic and offset so they are much more affected by introduced bias and larger activations. ImageNet fusion increased the signal in center logits, making the half-pixel misalignment visible in PCC check, whereas before the logits were so small/noisy that PCC didn’t notice.

- [tt_upsample.py](https://github.com/tenstorrent/tt-metal/blob/main/models/experimental/panoptic_deeplab/tt/tt_upsample.py) is updated to upsample with `align_corners=False`, [test_tt_upsample.py](https://github.com/tenstorrent/tt-metal/blob/main/models/experimental/panoptic_deeplab/tests/pcc/test_tt_upsample.py) as well. 
- PCCs are updated in [test_tt_model.py](https://github.com/tenstorrent/tt-metal/blob/main/models/experimental/panoptic_deeplab/tests/pcc/test_tt_model.py) and also pytest timeout since full model tests and [demo.py](https://github.com/tenstorrent/tt-metal/blob/main/models/experimental/panoptic_deeplab/demo/demo.py) can take more than the default 300s to execute. 

<img width="463" height="116" alt="image" src="https://github.com/user-attachments/assets/d6875814-4fe6-4b45-a83c-deaf8c6d300f" />

### Checklist

- [x] [![(Single-card) Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml/badge.svg?branch=nmilicevic/pdl-pcc-drop)](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml?query=branch:nmilicevic/pdl-pcc-drop)
- [x] [![(Blackhole) Blackhole nightly tests](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-nightly-tests.yaml/badge.svg?branch=nmilicevic/pdl-pcc-drop)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-nightly-tests.yaml?query=branch:nmilicevic/pdl-pcc-drop) PDL PASSES
- [x] [![(Blackhole) Demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-demo-tests.yaml/badge.svg?branch=nmilicevic/pdl-pcc-drop)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-demo-tests.yaml?query=branch:nmilicevic/pdl-pcc-drop)
- [x] New/Existing tests provide coverage for changes
