### PR TITLE
Update ResNet50 batch_size=32 performance target for Blackhole

### DIFF
--- a/models/demos/vision/classification/resnet50/blackhole/tests/test_perf_device_resnet50.py
+++ b/models/demos/vision/classification/resnet50/blackhole/tests/test_perf_device_resnet50.py
@@ -14,7 +14,7 @@ from models.demos.vision.classification.resnet50.ttnn_resnet.tests.common.perf_d
     "batch_size, test, expected_perf",
     [
         [16, "True-DataType.BFLOAT8_B-DataType.BFLOAT8_B-MathFidelity.LoFi-16-device_params0", 10610.0],
-        [32, "True-DataType.BFLOAT8_B-DataType.BFLOAT8_B-MathFidelity.LoFi-32-device_params0", 14815.0],
+        [32, "True-DataType.BFLOAT8_B-DataType.BFLOAT8_B-MathFidelity.LoFi-32-device_params0", 15480.0],
     ],
 )
 def test_perf_device(batch_size, test, expected_perf):


### PR DESCRIPTION
The model performance improved by ~4.5% (from 14,815 to ~15,480 samples/s) due to https://github.com/tenstorrent/tt-metal/pull/37194

Updated expected_perf from 14815.0 to 15480.0 samples/s to reflect the improved performance and prevent CI failures.

Measured performance: 15,480.9 samples/s
Previous threshold: 15,259.45 samples/s (14815 * 1.03)
New threshold: 15,944.4 samples/s (15480 * 1.03)

Resnet50 device perf
https://github.com/tenstorrent/tt-metal/actions/runs/21818151042