### PR TITLE
SDXL Relax encoder2 perf targets

### DIFF
--- a/models/experimental/stable_diffusion_xl_base/tests/test_sdxl_perf.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/test_sdxl_perf.py
@@ -143,7 +143,7 @@ def test_refiner_unet(
         ),
         (
             "pytest models/experimental/stable_diffusion_xl_base/tests/pcc/test_sdxl_clip_encoders.py::test_clip_encoder -k 'encoder_2'",
-            63_023_709,  # Note: this is an average value of 5 test runs due to high variability
+            63_591_763,  # Note: this is an average value of 30 test runs due to high variability
             "sdxl_clip_encoder_2",
             "sdxl_clip_encoder_2",
             CLIP_ENCODER_DEVICE_TEST_TOTAL_ITERATIONS,


### PR DESCRIPTION
### Problem description
**SDXL (Single-card) Device perf regressions**: failed in Metal CI due to CLIP Encoder2:
- [Feb 6 run, link](https://github.com/tenstorrent/tt-metal/actions/runs/21753828786/job/62759302569)

### What's changed
Clip Encoders Average Device Kernel Analysis [link](https://docs.google.com/spreadsheets/d/1mumhAkT0QmXm0RPbBhTg3SBHT5DAxFARcFxWltydF3w/edit?gid=0#gid=0)

New Expected value is fixed for Encoder2
From `63023709ns` to `63591763ns`,  (where `63591763ns` is average from 30 runs in period Feb 9 - Feb 5)


### Checklist
- [ ] [SDXL (Single-card) Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/runs/21822893767) **in progress**

