### PR TITLE
[Watcher] Models-unit-tests turned red after recent commit, keeping it green with additional skips

### DIFF
--- a/models/demos/deepseek_v3/tests/unit/test_matmul.py
+++ b/models/demos/deepseek_v3/tests/unit/test_matmul.py
@@ -272,6 +272,8 @@ def test_matmul_dram_sharded_mesh_device(
     """
     Mesh device test for matmul with DRAM sharded weights.
     """
+    if is_watcher_enabled() and (M, K, N) == (32, 7168, 256):
+        pytest.skip("Fails with watcher enabled. See issue #36314")
     # Get device grid info from mesh_device
     grid = mesh_device.compute_with_storage_grid_size()
     max_num_cores = grid.x * grid.y

--- a/models/demos/deepseek_v3/tests/unit/test_matmul.py
+++ b/models/demos/deepseek_v3/tests/unit/test_matmul.py
@@ -7,6 +7,7 @@ import torch
 from loguru import logger
 
 import ttnn
+from models.common.utility_functions import is_watcher_enabled
 from models.demos.deepseek_v3.tests.unit.utils import run_test
 from models.demos.deepseek_v3.utils.config_helpers import (
     COMPUTE_KERNEL_CONFIG_HIFI2,
@@ -210,6 +211,8 @@ def test_matmul_dram_sharded_single_device(
     in1_dtype,
     out_dtype,
 ):
+    if is_watcher_enabled() and (M, K, N) == (32, 7168, 256):
+        pytest.skip("Fails with watcher enabled. See issue #36314")
     run_test_matmul_dram_sharded(
         device,
         M,

--- a/models/demos/deepseek_v3/tests/unit/test_reshape.py
+++ b/models/demos/deepseek_v3/tests/unit/test_reshape.py
@@ -5,6 +5,7 @@
 import pytest
 
 import ttnn
+from models.common.utility_functions import is_watcher_enabled
 from models.demos.deepseek_v3.tests.unit.utils import random_torch_tensor, run_test
 from tests.ttnn.utils_for_testing import assert_with_pcc
 
@@ -33,6 +34,8 @@ from tests.ttnn.utils_for_testing import assert_with_pcc
     "device_params", [{"trace_region_size": 10000, "fabric_config": ttnn.FabricConfig.FABRIC_1D}], indirect=True
 )
 def test_reshape(mesh_device, in_shape, out_shape, layout, mem_config, dtype, enable_trace):
+    if is_watcher_enabled():
+        pytest.skip("Test fails with watcher enabled. See issue #37096")
     torch_input = random_torch_tensor(dtype, in_shape)
     torch_output = torch_input.reshape(out_shape)
 

--- a/models/demos/vision/classification/mobilenetv2/tests/pcc/test_mobilenetv2.py
+++ b/models/demos/vision/classification/mobilenetv2/tests/pcc/test_mobilenetv2.py
@@ -6,6 +6,7 @@
 import pytest
 
 import ttnn
+from models.common.utility_functions import skip_with_watcher
 from models.demos.vision.classification.mobilenetv2.common import (
     MOBILENETV2_BATCH_SIZE,
     MOBILENETV2_L1_SMALL_SIZE,
@@ -36,6 +37,7 @@ from tests.ttnn.utils_for_testing import assert_with_pcc
         MOBILENETV2_BATCH_SIZE,
     ],
 )
+@skip_with_watcher("Skipping test with watcher enabled. See github issue #37097")
 def test_mobilenetv2(device, use_pretrained_weight, batch_size, reset_seeds, model_location_generator):
     if use_pretrained_weight:
         torch_model = Mobilenetv2()

--- a/models/demos/vision/classification/resnet50/wormhole/tests/test_resnet50_functional.py
+++ b/models/demos/vision/classification/resnet50/wormhole/tests/test_resnet50_functional.py
@@ -72,7 +72,16 @@ def test_resnet_50(
     math_fidelity,
     use_pretrained_weight,
     model_location_generator,
+    is_watcher_enabled,
 ):
+    if (
+        is_watcher_enabled
+        and not use_pretrained_weight
+        and batch_size == 16
+        and math_fidelity == ttnn.MathFidelity.HiFi2
+    ):
+        pytest.skip("Skipping test with watcher enabled. See github issue #37097")
+
     run_resnet_50(
         device,
         batch_size,

--- a/models/demos/vision/classification/resnet50/wormhole/tests/test_resnet50_functional.py
+++ b/models/demos/vision/classification/resnet50/wormhole/tests/test_resnet50_functional.py
@@ -5,7 +5,7 @@
 import pytest
 
 import ttnn
-from models.common.utility_functions import is_blackhole
+from models.common.utility_functions import is_blackhole, skip_with_watcher
 from models.demos.vision.classification.resnet50.ttnn_resnet.tests.common.resnet50_test_infra import create_test_infra
 
 
@@ -64,6 +64,7 @@ def run_resnet_50(
         "pretrained_weight_false",
     ],
 )
+@skip_with_watcher("Skipping test with watcher enabled. See github issue #37097")
 def test_resnet_50(
     device,
     batch_size,
@@ -72,16 +73,7 @@ def test_resnet_50(
     math_fidelity,
     use_pretrained_weight,
     model_location_generator,
-    is_watcher_enabled,
 ):
-    if (
-        is_watcher_enabled
-        and not use_pretrained_weight
-        and batch_size == 16
-        and math_fidelity == ttnn.MathFidelity.HiFi2
-    ):
-        pytest.skip("Skipping test with watcher enabled. See github issue #37097")
-
     run_resnet_50(
         device,
         batch_size,

--- a/models/experimental/functional_unet/tests/test_unet_model.py
+++ b/models/experimental/functional_unet/tests/test_unet_model.py
@@ -7,6 +7,7 @@ import ttnn
 
 from ttnn.device import is_wormhole_b0
 
+from models.common.utility_functions import skip_with_watcher
 from models.experimental.functional_unet.tt.model_preprocessing import (
     create_unet_input_tensors,
     create_unet_model_parameters,
@@ -64,6 +65,7 @@ def run_unet_model(batch, groups, device, iterations=1):
 @pytest.mark.parametrize("batch", [1])
 @pytest.mark.parametrize("groups", [4])
 @pytest.mark.parametrize("device_params", [{"l1_small_size": UNET_L1_SMALL_REGION_SIZE}], indirect=True)
+@skip_with_watcher("Skipping test with watcher enabled. See github issue #37097")
 def test_unet_model(batch, groups, device, reset_seeds):
     if not is_wormhole_b0(device) and (
         device.compute_with_storage_grid_size().x * device.compute_with_storage_grid_size().y != 110


### PR DESCRIPTION
### Ticket
[#27840](https://github.com/tenstorrent/tt-metal/issues/27840)

### Problem description
Recent commit concerning pools and matmul got a couple of models failing with watcher enabled.

### What's changed
Skipped the mentioned models with watcher enabled and linked the skip reason to github issue describing the problem.

### Checklist

- [x] [APC Select](https://github.com/tenstorrent/tt-metal/actions/runs/21862155991)