### PR TITLE
Update SDXL VAE device perf targets after SDPA KV chain forwarding optimization

### DIFF
--- a/models/experimental/stable_diffusion_xl_base/tests/test_sdxl_perf.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/test_sdxl_perf.py
@@ -113,7 +113,7 @@ def test_refiner_unet(
         ),
         (
             "pytest models/experimental/stable_diffusion_xl_base/vae/tests/pcc/test_module_tt_autoencoder_kl.py::test_vae -k 'test_decode'",
-            691_445_943,
+            663_083_865,
             "sdxl_vae",
             "sdxl_vae_decode",
             VAE_DEVICE_TEST_TOTAL_ITERATIONS,
@@ -123,7 +123,7 @@ def test_refiner_unet(
         ),
         (
             "pytest models/experimental/stable_diffusion_xl_base/vae/tests/pcc/test_module_tt_autoencoder_kl.py::test_vae -k 'test_encode'",
-            348_815_743,
+            324_271_938,
             "sdxl_vae",
             "sdxl_vae_encode",
             VAE_DEVICE_TEST_TOTAL_ITERATIONS,


### PR DESCRIPTION
The KV store-and-forward chain optimization for non-causal SDPA (#37285) improved SDPA kernel performance, which flows through to the SDXL VAE pipeline. Update device perf targets to reflect the measured improvements:

- vae_decode: 691_445_943 -> 663_083_865 ns (~4.1% faster)
- vae_encode: 348_815_743 -> 324_271_938 ns (~7.0% faster)