### PR TITLE
Relax graph capture conv memory targets

### DIFF
--- a/tests/ttnn/unit_tests/gtests/test_graph_query_op_constraints.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_graph_query_op_constraints.cpp
@@ -876,9 +876,9 @@ TEST_P(Conv2dOpIfTest, Conv2d) {
         EXPECT_EQ(query.status, ttnn::graph::ExecutionStatus::Success);
         // Ensure some real usage is reported
         EXPECT_GT(query.resource_usage.cb_peak_size_per_core, 10000);
-        const uint32_t l1_peak_threshold = (conv2d_config == std::nullopt) ? 200000 : 150000;
+        const uint32_t l1_peak_threshold = (conv2d_config == std::nullopt) ? 150000 : 120000;
         EXPECT_GT(query.resource_usage.l1_buffers_peak_per_core, l1_peak_threshold);
-        const uint32_t total_peak_threshold = (conv2d_config == std::nullopt) ? 400000 : 350000;
+        const uint32_t total_peak_threshold = (conv2d_config == std::nullopt) ? 250000 : 220000;
         EXPECT_GT(query.resource_usage.peak_memory_usage_per_core, total_peak_threshold);
         ASSERT_TRUE(query.output_tensor_specs.has_value());
         EXPECT_EQ(query.output_tensor_specs.value().size(), 1);


### PR DESCRIPTION
### Problem description
Conv2d graph capture tests fail on BH due to memory targets being written for WH. 

### What's changed
Relax targets as we are not interested in how much memory was used exactly.

### Checklist
APC:  https://github.com/tenstorrent/tt-metal/actions/runs/21832083904 ✅ 