### PR TITLE
[gpt-oss] add on device sampling

### DIFF
--- a/models/common/sampling/generator.py
+++ b/models/common/sampling/generator.py
@@ -294,7 +294,8 @@ def format_sampling_params(sampling_params, max_batch_size):
         "seed": random.randint(0, 1000000),  # set to random seed to have variability while using tensor manual_seed
     }
     target_len = max_batch_size
-    assert target_len == 32, "Sampling only support batch_size=32"
+    assert target_len % 32 == 0, f"Sampling batch size must be a multiple of 32, got {target_len}"
+
     for name, tensor in zip(
         ("temp", "p", "k"), (sampling_params.temperature, sampling_params.top_p, sampling_params.top_k)
     ):

--- a/models/common/utils.py
+++ b/models/common/utils.py
@@ -87,8 +87,12 @@ class LogProbsCalculator:
         mask_tensor = torch.arange(num_devices_for_sharding).unsqueeze(1).expand(num_devices_for_sharding, batch_size)
 
         if self.mesh_device.get_num_devices() == 32:
-            mesh_mapper = ttnn.ShardTensor2dMesh(self.mesh_device, dims=(0, None), mesh_shape=self.cluster_shape)
-            assert self.cluster_shape == [8, 4], "Cluster shape must be (8, 4) for 32 devices"
+            if self.cluster_shape == [8, 4]:
+                mesh_mapper = ttnn.ShardTensor2dMesh(self.mesh_device, dims=(0, None), mesh_shape=self.cluster_shape)
+            elif self.cluster_shape == [4, 8]:
+                mesh_mapper = ttnn.ShardTensor2dMesh(self.mesh_device, dims=(None, 0), mesh_shape=self.cluster_shape)
+            else:
+                raise ValueError(f"Unsupported cluster shape {self.cluster_shape} for 32 devices")
         elif self.mesh_device.get_num_devices() == 8:
             mesh_mapper = ttnn.ShardTensorToMesh(self.mesh_device, dim=0)
         else:

--- a/models/common/utils.py
+++ b/models/common/utils.py
@@ -81,6 +81,17 @@ class LogProbsCalculator:
         # TODO: Test this for 6U Galaxy
         # Enforce working on 8 devices instead of all 32 since logits are sharded across 8 devices
         num_devices_for_sharding = 8 if num_devices == 32 else num_devices
+        self.num_devices_for_sharding = num_devices_for_sharding
+
+        # Determine the cluster_axis for all-gather: gather across the TP dimension (8 devices)
+        if num_devices == 32:
+            # For 2D meshes, find the axis with 8 devices (TP dimension)
+            if self.cluster_shape[0] == num_devices_for_sharding:
+                self._all_gather_cluster_axis = 0
+            else:
+                self._all_gather_cluster_axis = 1
+        else:
+            self._all_gather_cluster_axis = None
 
         # Create mask tensor with shape (num_devices, batch_size)
         # Each row will have device_id starting from 0 to num_devices - 1
@@ -131,7 +142,7 @@ class LogProbsCalculator:
                 dim=dim,
                 num_links=num_links,
                 memory_config=tensor.memory_config(),
-                cluster_axis=0,
+                cluster_axis=self._all_gather_cluster_axis,
                 buffer_key=buffer_key,
             )
         else:
@@ -140,7 +151,7 @@ class LogProbsCalculator:
                 dim=dim,
                 num_links=num_links,
                 memory_config=tensor.memory_config(),
-                cluster_axis=None,
+                cluster_axis=self._all_gather_cluster_axis,
                 topology=ttnn.Topology.Linear,
             )
 
@@ -177,13 +188,15 @@ class LogProbsCalculator:
         )
         # TODO: Convert to ROW_MAJOR_LAYOUT due to memory clobbering which affects all ttnn.reshape ops with TILE_LAYOUT
         gathered_max_tensors = ttnn.to_layout(gathered_max_tensors, ttnn.ROW_MAJOR_LAYOUT, **self.common_args)
-        gathered_max_tensors = ttnn.reshape(gathered_max_tensors, (1, 1, 8, 32), **self.common_args)
+        D = self.num_devices_for_sharding
+        B = gathered_max_tensors.shape[2]
+        gathered_max_tensors = ttnn.reshape(gathered_max_tensors, (1, 1, D, B), **self.common_args)
         gathered_max_tensors = ttnn.to_layout(gathered_max_tensors, ttnn.TILE_LAYOUT, **self.common_args)
 
         self.global_max = ttnn.max(gathered_max_tensors, dim=2, keepdim=True, **self.common_args)
 
         global_max_to_subtract = ttnn.to_layout(self.global_max, ttnn.ROW_MAJOR_LAYOUT, **self.common_args)
-        global_max_to_subtract = ttnn.reshape(global_max_to_subtract, (1, 1, 32, 1), **self.common_args)
+        global_max_to_subtract = ttnn.reshape(global_max_to_subtract, (1, 1, B, 1), **self.common_args)
         global_max_to_subtract = ttnn.to_layout(global_max_to_subtract, ttnn.TILE_LAYOUT, **self.common_args)
 
         # Calculate stable local sum-exp using subtract of global-max from each local logit
@@ -198,7 +211,8 @@ class LogProbsCalculator:
             buffer_key="LOGPROBS_SUM_EXP_REDUCTION",
         )
         gathered_sum_exp_tensors = ttnn.to_layout(gathered_sum_exp_tensors, ttnn.ROW_MAJOR_LAYOUT, **self.common_args)
-        gathered_sum_exp_tensors = ttnn.reshape(gathered_sum_exp_tensors, (1, 1, 8, 32), **self.common_args)
+        B_sum = gathered_sum_exp_tensors.shape[2]
+        gathered_sum_exp_tensors = ttnn.reshape(gathered_sum_exp_tensors, (1, 1, D, B_sum), **self.common_args)
         gathered_sum_exp_tensors = ttnn.to_layout(gathered_sum_exp_tensors, ttnn.TILE_LAYOUT, **self.common_args)
 
         self.global_exp_sum = ttnn.sum(gathered_sum_exp_tensors, dim=2, keepdim=True, **self.common_args)
@@ -236,7 +250,8 @@ class LogProbsCalculator:
         remainder_tensor = ttnn.typecast(remainder_tensor, ttnn.uint32, **self.common_args)
         # convert to ROW_MAJOR_LAYOUT due to memory clobbering which affects all ttnn.reshape ops with TILE_LAYOUT
         remainder_tensor = ttnn.to_layout(remainder_tensor, ttnn.ROW_MAJOR_LAYOUT, **self.common_args)
-        remainder_tensor = ttnn.reshape(remainder_tensor, (1, 1, 32, 1), **self.common_args)
+        batch_vol = remainder_tensor.shape[2] * remainder_tensor.shape[3]
+        remainder_tensor = ttnn.reshape(remainder_tensor, (1, 1, batch_vol, 1), **self.common_args)
         remainder_tensor = ttnn.to_layout(remainder_tensor, ttnn.TILE_LAYOUT, **self.common_args)
 
         # Get logits for each user on each chip based on local index
@@ -244,7 +259,8 @@ class LogProbsCalculator:
 
         # convert to ROW_MAJOR_LAYOUT due to memory clobbering which affects all ttnn.reshape ops with TILE_LAYOUT
         selected_logits_tensor = ttnn.to_layout(selected_logits_tensor, ttnn.ROW_MAJOR_LAYOUT, **self.common_args)
-        selected_logits_tensor = ttnn.reshape(selected_logits_tensor, (1, 1, 1, 32), **self.common_args)
+        batch_vol_s = selected_logits_tensor.shape[2] * selected_logits_tensor.shape[3]
+        selected_logits_tensor = ttnn.reshape(selected_logits_tensor, (1, 1, 1, batch_vol_s), **self.common_args)
         selected_logits_tensor = ttnn.to_layout(selected_logits_tensor, ttnn.TILE_LAYOUT, **self.common_args)
         # Compare mask to chip_ids tensor and select correct positions for each user on all chips inplace
         ttnn.eq_(chip_ids_tensor, self.mask, **self.common_args)
@@ -261,7 +277,9 @@ class LogProbsCalculator:
         )
 
         selected_logits_tensor = ttnn.to_layout(selected_logits_tensor, ttnn.ROW_MAJOR_LAYOUT, **self.common_args)
-        selected_logits_tensor = ttnn.reshape(selected_logits_tensor, (1, 1, 8, 32), **self.common_args)
+        D_s = self.num_devices_for_sharding
+        B_g = selected_logits_tensor.shape[3]
+        selected_logits_tensor = ttnn.reshape(selected_logits_tensor, (1, 1, D_s, B_g), **self.common_args)
         selected_logits_tensor = ttnn.to_layout(selected_logits_tensor, ttnn.TILE_LAYOUT, **self.common_args)
 
         # Apply sum over device dimension to get logits for each user on all chips

--- a/models/demos/gpt_oss/tt/model.py
+++ b/models/demos/gpt_oss/tt/model.py
@@ -3,8 +3,10 @@
 
 
 import torch
+from loguru import logger
 
 import ttnn
+from models.common.sampling.generator import SamplingGenerator
 from models.common.utility_functions import nearest_32
 from models.demos.gpt_oss.config import MeshConfig, Mode, ModeConfig
 from models.demos.gpt_oss.utils.general_utils import get_cache_file_name
@@ -181,6 +183,55 @@ class Model:
             mesh_mapper=self.mesh_config.column_parallel(mesh_device),
         )
 
+        # Initialize on-device sampling (supported when per-device vocab fits in 64K)
+        sampling_splits = mesh_device.shape[1]
+        self._supports_on_device_sampling = self.vocab_size // sampling_splits <= 64 * 1024
+        self._prefill_sampling_active = False
+        if self._supports_on_device_sampling:
+            # tt_ccl=None makes TTSampling fall back to ttnn.all_gather() which works on [4,8] meshes
+            self.sampling = SamplingGenerator(
+                args=self.args if hasattr(self, "args") else self._make_sampling_args(hf_config, mesh_device),
+                mesh_device=mesh_device,
+                tt_ccl=None,
+                enable_internal_trace=False,
+            )
+            # Hook reset_sampling_params to set prefill flag — Generator calls this
+            # before prefill forward; tells _forward_layers_and_head to skip TP all-gather
+            _orig_reset = self.sampling.reset_sampling_params
+
+            def _reset_with_flag(params, _orig=_orig_reset):
+                _orig(params)
+                self._prefill_sampling_active = True
+
+            self.sampling.reset_sampling_params = _reset_with_flag
+            logger.info(f"On-device sampling initialized (vocab_size={self.vocab_size}, splits={sampling_splits})")
+        else:
+            self.sampling = None
+
+    def _make_sampling_args(self, hf_config, mesh_device):
+        """Create a minimal args object for SamplingGenerator/TTSampling."""
+
+        class _SamplingArgs:
+            pass
+
+        args = _SamplingArgs()
+        args.vocab_size = hf_config.vocab_size
+        num_tp = mesh_device.shape[1]
+        # padded_vocab_size must match lm_head column-parallel output per device exactly
+        per_device_vocab = (args.vocab_size + num_tp - 1) // num_tp
+        args.padded_vocab_size = per_device_vocab * num_tp
+        args.cluster_shape = tuple(mesh_device.shape)
+        args.sampling_all_gather_axis = 1
+        args.num_devices = mesh_device.get_num_devices()
+        args.is_galaxy = mesh_device.shape[0] > 1
+        args.model_config = {}  # No SAMPLING_AG_CONFIG → regular sampling path always used
+        return args
+
+    def _increment_decode_positions_device(self, current_pos, rot_mat_idxs):
+        """On-device position increment for traced decode loops with sampling."""
+        ttnn.plus_one(current_pos, skip_negative_entries=True)
+        ttnn.plus_one(rot_mat_idxs)
+
     @classmethod
     def create_transformer_compatible(
         cls,
@@ -230,7 +281,16 @@ class Model:
         return instance
 
     def _forward_layers_and_head(
-        self, hidden_states, rope_mats, current_pos, page_table, kv_cache, get_last_token=-1, is_decode=True, user_id=0
+        self,
+        hidden_states,
+        rope_mats,
+        current_pos,
+        page_table,
+        kv_cache,
+        get_last_token=-1,
+        is_decode=True,
+        user_id=0,
+        sampling_on_device=False,
     ):
         """
         Shared forward pass through decoder layers and final projection.
@@ -276,9 +336,11 @@ class Model:
         hidden_states = self.norm(hidden_states)
         logits = ttnn.matmul(hidden_states, self.lm_head_weight, dtype=ttnn.bfloat8_b)
         hidden_states.deallocate(True)
-        # TP all-gather if using tensor parallelism
+        # Skip TP all-gather when sampling is active — TTSampling handles its own all-gather
+        skip_gather = sampling_on_device or self._prefill_sampling_active
+        self._prefill_sampling_active = False
         config = self.mesh_config.get_config(mode)
-        if config.tp > 1:
+        if config.tp > 1 and not skip_gather:
             logits_gathered = self.mesh_config.allgather(
                 logits, self.ccl_manager, axis=self.mesh_config.tp_axis, dim=-1
             )
@@ -301,8 +363,15 @@ class Model:
         Decode forward pass - processes single tokens.
         Matches tt-transformers interface where rot_mat_idxs are used for on-device RoPE lookup.
         """
-        # Embed tokens
-        input_embeds = ttnn.embedding(tokens, self.embedding_weight, layout=ttnn.TILE_LAYOUT, dtype=ttnn.bfloat8_b)
+        # For non-row-sharded b<32, token buffer is padded to 32 — only embed real tokens
+        actual_batch = current_pos.shape[-1]
+        if not self.users_row_sharded and tokens.shape[-1] > actual_batch:
+            tokens_for_embed = tokens[:, :, :, :actual_batch]
+        else:
+            tokens_for_embed = tokens
+        input_embeds = ttnn.embedding(
+            tokens_for_embed, self.embedding_weight, layout=ttnn.TILE_LAYOUT, dtype=ttnn.bfloat8_b
+        )
         input_embeds = ttnn.unsqueeze(input_embeds, 0)
         # Get RoPE embeddings via on-device embedding lookup (matches tt-transformers)
         rope_mats = self.rope_setup.get_rot_mats(self.get_tt_pos_idx(rot_mat_idxs))
@@ -315,9 +384,20 @@ class Model:
             page_table=page_table,
             kv_cache=kv_cache,
             is_decode=True,
+            sampling_on_device=sampling_on_device,
         )
-        # Return logits and None for log-probs for compatibility with generator interface
-        # TODO: Add log-probs return value once sampling_on_device is supported
+
+        if sampling_on_device and self.sampling is not None:
+            # Pad logits batch to 32 (TTSampling requirement) before split-trace or sampling
+            batch_dim = out.shape[-2]
+            if batch_dim < 32:
+                out = ttnn.pad(out, padding=[(0, 0), (0, 0), (0, 32 - batch_dim), (0, 0)], value=0.0)
+            self._increment_decode_positions_device(current_pos, rot_mat_idxs)
+            if capture_sampling_trace:
+                return out
+            tt_toks, tt_log_probs = self.sampling.sample(out, tt_out_tok=tokens, enable_trace=False)
+            return tt_toks, tt_log_probs
+
         return out, None
 
     def ttnn_prefill_forward(
@@ -422,7 +502,9 @@ class Model:
             current_pos = current_pos.unsqueeze(0)
         assert current_pos.shape[0] == B, "Batch size mismatch"
 
-        # Convert tokens to TTNN format
+        # Pad token buffer to 32 for non-row-sharded b<32 (TTSampling requirement)
+        if not self.users_row_sharded and tokens.view(-1).shape[-1] < 32:
+            tokens = torch.nn.functional.pad(tokens.view(-1), (0, 32 - len(tokens.view(-1))), "constant", 0)
         if self.users_row_sharded:
             mesh_mapper = ttnn.ShardTensor2dMesh(self.mesh_device, dims=(0, None), mesh_shape=self.mesh_device.shape)
         else:
@@ -474,9 +556,7 @@ class Model:
         global_user_id=None,
     ):
         """Prepare inputs for prefill mode"""
-        # Default global_user_id to 0 if not provided
-        if global_user_id is None:
-            global_user_id = 0
+        assert global_user_id is not None, "global_user_id is required for row-sharded prefill"
         # Embed the tokens
         if tokens.dim() == 2:
             tokens = tokens.reshape(1, 1, 1, -1)
@@ -559,11 +639,12 @@ class Model:
             tt_chunk_page_table,
         )
 
-    def process_output_decode(self, tt_out, B, S=1, is_tokens=False):
+    def process_output_decode(self, tt_out, B, S=1, is_tokens=False, is_log_probs=False):
         """Process decode output and convert to torch tensors"""
         concat_out = self.concat_device_output(tt_out)
-        if is_tokens:
-            return concat_out[:B, 0]  # [batch_size]
+        if is_tokens or is_log_probs:
+            # Token IDs or log probs: shape [1, 1, B] or [1, 1, 1, B] -> [B]
+            return concat_out.reshape(-1)[:B]
 
         torch_out = concat_out[:, 0, :, :]  # [1, 1, B, vocab_size]
         # TODO: this view is dangerous, forces bad tensor shapes to work but we get garbage outputs if they're wrong

--- a/models/tt_transformers/tt/generator.py
+++ b/models/tt_transformers/tt/generator.py
@@ -49,12 +49,13 @@ class SamplingParams:
 SAMPLING_PARAM_FIELDS = tuple(f.name for f in fields(SamplingParams))
 
 
-def _broadcast_formatted_sampling_params(formatted_sampling_params: SamplingParams, idx: int) -> SamplingParams:
+def _broadcast_formatted_sampling_params(
+    formatted_sampling_params: SamplingParams, idx: int, slot_len: int = 32
+) -> SamplingParams:
     """
-    Create a new SamplingParams where each list field is broadcast to a full (length-32) list,
-    taking the value from `idx`. Does not mutate the input.
+    Create a new SamplingParams where each list field is broadcast to a full list of length
+    `slot_len`, taking the value from `idx`. Does not mutate the input.
     """
-    slot_len = 32  # sampling only supports batch_size=32
     kwargs = {}
     for f in fields(SamplingParams):
         value = getattr(formatted_sampling_params, f.name)
@@ -417,14 +418,16 @@ class Generator:
 
             if sampling_enabled:
                 sampling_executed = True
+                sampling_dp = getattr(self.model[model_id], "sampling_dp", 1)
+                total_batch = 32 * sampling_dp
                 per_request_params = format_sampling_params(
-                    _broadcast_formatted_sampling_params(sampling_params, idx), 32
+                    _broadcast_formatted_sampling_params(sampling_params, idx, slot_len=total_batch), total_batch
                 )
                 assert per_request_params is not None, "Sampling was executed but missing per-request sampling params"
                 _apply_prefill_sampling_state(
                     self.model[model_id],
                     sampling_params=per_request_params,
-                    prompt_tokens=prefill_ids[:, :seq_len].repeat(32, 1),
+                    prompt_tokens=prefill_ids[:, :seq_len].repeat(total_batch, 1),
                     empty_slots=[user_id % 32],
                 )
 
@@ -704,6 +707,14 @@ class Generator:
         page_table = torch.chunk(page_table, self.data_parallel, 0) if page_table is not None else None
         sampling_params_list = None
         if sampling_params is not None:
+            # sampling_dp may differ from data_parallel for models that internally
+            # shard users across mesh rows (users_row_sharded) — each row samples
+            # 32 users independently, so sampling params must be chunked by the
+            # number of rows even though data_parallel=1 for the forward pass.
+            sampling_dp = max(
+                self.data_parallel, *(getattr(self.model[i], "sampling_dp", 1) for i in range(self.data_parallel))
+            )
+
             # Fall back to dataclass defaults when optional fields are omitted
             chunked_fields = {}
             for field in SAMPLING_PARAM_FIELDS:
@@ -714,33 +725,66 @@ class Generator:
                         val = getattr(SamplingParams, field)
                     else:
                         raise
-                chunked_fields[field] = self._chunk_sampling_param(val)
+                if isinstance(val, list):
+                    chunked_fields[field] = split_list(val, sampling_dp)
+                else:
+                    chunked_fields[field] = [val] * sampling_dp
 
             prompt_chunks = (
-                torch.chunk(prompt_tokens, self.data_parallel, 0)
-                if prompt_tokens is not None
-                else [None] * self.data_parallel
+                torch.chunk(prompt_tokens, sampling_dp, 0) if prompt_tokens is not None else [None] * sampling_dp
             )
             output_chunks = (
-                torch.chunk(output_tokens, self.data_parallel, 0)
-                if output_tokens is not None
-                else [None] * self.data_parallel
+                torch.chunk(output_tokens, sampling_dp, 0) if output_tokens is not None else [None] * sampling_dp
             )
             sampling_params_list = [
                 SamplingParams(**{field: chunked_fields[field][i] for field in SAMPLING_PARAM_FIELDS})
-                for i in range(self.data_parallel)
+                for i in range(sampling_dp)
             ]
             for i in range(self.data_parallel):
-                formatted_params = format_sampling_params(
-                    sampling_params_list[i], 32
-                )  # Sampling needs params padded to 32 regardless of batch_size
                 sampling_module = getattr(self.model[i], "sampling", None)
                 assert sampling_module is not None, "Sampling module not found in model for sampling on device."
-                sampling_module.reset_sampling_params(formatted_params)
+                # Number of sampling chunks handled by this model instance
+                chunks_per_model = sampling_dp // self.data_parallel
+                model_params = sampling_params_list[i * chunks_per_model : (i + 1) * chunks_per_model]
+                if chunks_per_model == 1:
+                    # Standard case: one set of 32 params per model
+                    formatted_params = format_sampling_params(model_params[0], 32)
+                    sampling_module.reset_sampling_params(formatted_params)
+                else:
+                    # Row-sharded case: concatenate all chunks then let TTSampling
+                    # shard them across mesh rows via dims=(0, None)
+                    def _merge_field(params, field):
+                        vals = []
+                        all_none = True
+                        for p in params:
+                            v = getattr(p, field)
+                            if v is None:
+                                continue
+                            all_none = False
+                            vals.extend(v if isinstance(v, list) else [v])
+                        return None if all_none else vals
+
+                    merged = SamplingParams(
+                        **{field: _merge_field(model_params, field) for field in SAMPLING_PARAM_FIELDS}
+                    )
+                    formatted_params = format_sampling_params(merged, 32 * chunks_per_model)
+                    sampling_module.reset_sampling_params(formatted_params)
                 sampling_module.seed_manager.get_new_values()
                 if reset_batch:
-                    sampling_module.reset_prompt_tokens(prompt_chunks[i])
-                    sampling_module.reset_output_state(output_chunks[i])
+                    start_chunk = i * chunks_per_model
+                    end_chunk = start_chunk + chunks_per_model
+                    model_prompt = (
+                        torch.cat([c for c in prompt_chunks[start_chunk:end_chunk] if c is not None], 0)
+                        if prompt_tokens is not None
+                        else None
+                    )
+                    model_output = (
+                        torch.cat([c for c in output_chunks[start_chunk:end_chunk] if c is not None], 0)
+                        if output_tokens is not None
+                        else None
+                    )
+                    sampling_module.reset_prompt_tokens(model_prompt)
+                    sampling_module.reset_output_state(model_output)
 
         decode_kwargs = {
             "current_pos": start_pos,

--- a/models/tt_transformers/tt/generator.py
+++ b/models/tt_transformers/tt/generator.py
@@ -369,6 +369,7 @@ class Generator:
                 seq_len - num_cached_tokens
             )  # Without the cached tokens, then padded
             local_kwargs = kwargs.copy()  # Avoid modifying original kwargs
+            local_kwargs["global_user_id"] = user_id
             sampling_enabled = (
                 sampling_on_device_requested
                 and getattr(self.model[model_id], "_supports_on_device_sampling", False)


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Provide context for the problem.

### What's changed
Describe the approach used to solve the problem.
Summarize the changes made and its impact.

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=gpt-sampling)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:gpt-sampling)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=gpt-sampling)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:gpt-sampling)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=gpt-sampling)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:gpt-sampling)
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=gpt-sampling)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:gpt-sampling)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=gpt-sampling)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:gpt-sampling)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=gpt-sampling)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:gpt-sampling)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
