### PR TITLE
# Fix moreh kernel runtime arg bounds issues (#37193, #37040)

### DIFF
--- a/tt-train/tests/core/clip_grad_norm_test.cpp
+++ b/tt-train/tests/core/clip_grad_norm_test.cpp
@@ -27,8 +27,6 @@ protected:
 };
 
 TEST_F(ClipGradNormTest, ClipGradNorm_GENEROUS_TOLERANCE) {
-    // Skip with watcher enabled due to assert failure github issue #37040
-    SKIP_FOR_WATCHER();
     using namespace ttml;
 
     auto* device = &autograd::ctx().get_device();

--- a/tt-train/tests/core/n300_utils_test.cpp
+++ b/tt-train/tests/core/n300_utils_test.cpp
@@ -262,7 +262,7 @@ TEST_F(N300UtilsTest, DropoutDifferentSeed) {
 }
 
 TEST_F(N300UtilsTest, MorehClipGradNorm) {
-    // Skip with watcher enabled github issue #37040
+    // Test failing with watcher enabled, github issue #30521
     SKIP_FOR_WATCHER();
     auto* device = &ttml::autograd::ctx().get_device();
     auto mesh_shape = device->shape();

--- a/tt-train/tests/model/linear_regression_full_test.cpp
+++ b/tt-train/tests/model/linear_regression_full_test.cpp
@@ -27,8 +27,6 @@ protected:
 };
 
 TEST_F(LinearRegressionFullTest, TestLinearRegressionFull) {
-    // Skip with watcher enabled github issue #37193
-    SKIP_FOR_WATCHER();
     using namespace ttml::ops;
     auto* device = &ttml::autograd::ctx().get_device();
     const size_t batch_size = 128;

--- a/tt-train/tests/model/weight_tying_test.cpp
+++ b/tt-train/tests/model/weight_tying_test.cpp
@@ -75,8 +75,6 @@ protected:
 };
 
 TEST_F(WeightTyingTest, ModelFC) {
-    // Skip with watcher enabled due to failure, see github issue #37193
-    SKIP_FOR_WATCHER();
     auto model = ModelFC();
     auto params = model.parameters();
     assert(params.size() == 3U);

--- a/tt-train/tests/ops/cross_entropy_bw_op_test.cpp
+++ b/tt-train/tests/ops/cross_entropy_bw_op_test.cpp
@@ -273,8 +273,6 @@ TEST_F(CrossEntropyBackwardTest, NIGHTLY_CrossEntropyBackward_Huge_Backward) {
 }
 
 TEST_F(CrossEntropyBackwardTest, CrossEntropyForwardBackward_ReduceMeanVsNone) {
-    // Skip with watcher enabled due to failure github issue #37193
-    SKIP_FOR_WATCHER();
     using namespace ttml;
 
     const uint32_t N = 5U, C = 1U, H = 91U, W = 187U;

--- a/tt-train/tests/ops/embedding_op_test.cpp
+++ b/tt-train/tests/ops/embedding_op_test.cpp
@@ -26,8 +26,6 @@ protected:
 };
 
 TEST_F(EmbeddingOpTest, EmbeddingForwardBackward) {
-    // Skip with watcher enabled github issue #37193
-    SKIP_FOR_WATCHER();
     using namespace ttml;
 
     auto* device = &autograd::ctx().get_device();

--- a/tt-train/tests/ops/layer_norm_composite_test.cpp
+++ b/tt-train/tests/ops/layer_norm_composite_test.cpp
@@ -77,8 +77,6 @@ TEST_F(LayerNormOpTest, CompositeLayerNormOp_0) {
 }
 
 TEST_F(LayerNormOpTest, CompositeLayerNormOp_backward) {
-    // Skip with watcher enabled github issue #37193
-    SKIP_FOR_WATCHER();
     using namespace ttml;
 
     uint32_t batch_size = 1;

--- a/tt-train/tests/ops/rmsnorm_op_test.cpp
+++ b/tt-train/tests/ops/rmsnorm_op_test.cpp
@@ -43,8 +43,6 @@ protected:
 // 4. Compare TTML kernel results with PyTorch reference results
 // ============================================================================
 TEST_F(RMSNormOpTest, RMSNorm_Small_Forward) {
-    // Skip with watcher enabled github issue #37193
-    SKIP_FOR_WATCHER();
     using namespace ttml;
 
     [[maybe_unused]] uint32_t N = 1, C = 1, H = 1, W = 8;
@@ -60,8 +58,6 @@ TEST_F(RMSNormOpTest, RMSNorm_Small_Forward) {
 }
 
 TEST_F(RMSNormOpTest, RMSNorm_Small_Backward) {
-    // Skip with watcher enabled github issue #37193
-    SKIP_FOR_WATCHER();
     using namespace ttml;
 
     [[maybe_unused]] uint32_t N = 1, C = 1, H = 1, W = 8;
@@ -95,8 +91,6 @@ TEST_F(RMSNormOpTest, RMSNorm_Small_Backward) {
 }
 
 TEST_F(RMSNormOpTest, NIGHTLY_RMSNorm_Forward_Batch) {
-    // Skip with watcher enabled github issue #37193
-    SKIP_FOR_WATCHER();
     auto board = tt::umd::Cluster::create_cluster_descriptor()->get_board_type(0);
     if (board == tt::BoardType::P100 || board == tt::BoardType::P150) {
         GTEST_SKIP() << "Skipping on P100/P150 boards";
@@ -139,8 +133,6 @@ TEST_F(RMSNormOpTest, NIGHTLY_RMSNorm_Forward_Batch) {
 }
 
 TEST_F(RMSNormOpTest, NIGHTLY_RMSNorm_Backward_Batch) {
-    // Skip with watcher enabled github issue #37193
-    SKIP_FOR_WATCHER();
     auto board = tt::umd::Cluster::create_cluster_descriptor()->get_board_type(0);
     if (board == tt::BoardType::P100 || board == tt::BoardType::P150) {
         GTEST_SKIP() << "Skipping on P100/P150 boards";
@@ -182,8 +174,6 @@ TEST_F(RMSNormOpTest, NIGHTLY_RMSNorm_Backward_Batch) {
 // Same test methodology as Section 1, but using rmsnorm_composite() instead.
 // ============================================================================
 TEST_F(RMSNormOpTest, NIGHTLY_CompositeRMSNorm_Small_Forward) {
-    // Skip with watcher enabled github issue #37193
-    SKIP_FOR_WATCHER();
     using namespace ttml;
 
     [[maybe_unused]] uint32_t N = 1, C = 1, H = 1, W = 8;
@@ -199,8 +189,6 @@ TEST_F(RMSNormOpTest, NIGHTLY_CompositeRMSNorm_Small_Forward) {
 }
 
 TEST_F(RMSNormOpTest, NIGHTLY_CompositeRMSNorm_Small_Backward) {
-    // Skip with watcher enabled github issue #37193
-    SKIP_FOR_WATCHER();
     using namespace ttml;
 
     [[maybe_unused]] uint32_t N = 1, C = 1, H = 1, W = 8;
@@ -234,8 +222,6 @@ TEST_F(RMSNormOpTest, NIGHTLY_CompositeRMSNorm_Small_Backward) {
 }
 
 TEST_F(RMSNormOpTest, NIGHTLY_CompositeRMSNorm_Forward_Batch) {
-    // Skip with watcher enabled github issue #37193
-    SKIP_FOR_WATCHER();
     using namespace ttml;
 
     // 2 batches, 1 sequence, 20 tokens, 5-dim'l embedding space.
@@ -274,8 +260,6 @@ TEST_F(RMSNormOpTest, NIGHTLY_CompositeRMSNorm_Forward_Batch) {
 }
 
 TEST_F(RMSNormOpTest, NIGHTLY_CompositeRMSNorm_Backward_Batch) {
-    // Skip with watcher enabled github issue #37193
-    SKIP_FOR_WATCHER();
     using namespace ttml;
 
     // 2 batches, 1 sequence, 20 tokens, 5-dim'l embedding space.
@@ -418,15 +402,11 @@ static void CompareKernelVsComposite(const std::vector<uint32_t>& shape) {
 // ============================================================================
 
 TEST_F(RMSNormOpTest, RMSNorm_Compare_Basic_Small) {
-    // Skip with watcher enabled github issue #37193
-    SKIP_FOR_WATCHER();
     CompareKernelVsComposite({1U, 1U, 2U, 32U});
 }
 
 // Test aligned dimensions (C % 32 == 0) that fit in L1 cache
 TEST_F(RMSNormOpTest, RMSNorm_Compare_Aligned_FitsInL1) {
-    // Skip with watcher enabled github issue #37193
-    SKIP_FOR_WATCHER();
     // C = 1024 (32 * 32), fits in L1 cache
     CompareKernelVsComposite({1U, 1U, 1U, 1024U});
 
@@ -436,32 +416,24 @@ TEST_F(RMSNormOpTest, RMSNorm_Compare_Aligned_FitsInL1) {
 
 // Test aligned dimensions (C % 32 == 0) that fit in L1 except for gamma
 TEST_F(RMSNormOpTest, RMSNorm_Compare_Aligned_L1ExceptGamma) {
-    // Skip with watcher enabled github issue #37193
-    SKIP_FOR_WATCHER();
     // C = 8192 (1 << 13), fits in L1 except gamma parameter
     CompareKernelVsComposite({1U, 1U, 1U, 8192U});
 }
 
 // Test aligned dimensions (C % 32 == 0) that don't fit in L1 cache
 TEST_F(RMSNormOpTest, RMSNorm_Compare_Aligned_DoesNotFitInL1) {
-    // Skip with watcher enabled github issue #37193
-    SKIP_FOR_WATCHER();
     // C = 16384 (1 << 14), does not fit in L1 cache
     CompareKernelVsComposite({1U, 1U, 1U, 16384U});
 }
 
 // Test aligned dimensions (C % 32 == 0) with very large C
 TEST_F(RMSNormOpTest, RMSNorm_Compare_Aligned_VeryLargeC) {
-    // Skip with watcher enabled github issue #37193
-    SKIP_FOR_WATCHER();
     // C = 1048576 (1 << 20), very large C dimension (1M elements)
     CompareKernelVsComposite({1U, 1U, 1U, 1048576U});
 }
 
 // Test unaligned dimensions (C % 32 != 0) that fit in L1 cache
 TEST_F(RMSNormOpTest, RMSNorm_Compare_Unaligned_FitsInL1) {
-    // Skip with watcher enabled github issue #37193
-    SKIP_FOR_WATCHER();
     // C = 1023 (32 * 31 + 31), requires masking, fits in L1
     CompareKernelVsComposite({1U, 1U, 1U, 1023U});
 
@@ -471,16 +443,12 @@ TEST_F(RMSNormOpTest, RMSNorm_Compare_Unaligned_FitsInL1) {
 
 // Test unaligned dimensions (C % 32 != 0) that don't fit in L1 cache
 TEST_F(RMSNormOpTest, RMSNorm_Compare_Unaligned_DoesNotFitInL1) {
-    // Skip with watcher enabled github issue #37193
-    SKIP_FOR_WATCHER();
     // C = 16383 (1 << 14 - 1), requires masking, does not fit in L1
     CompareKernelVsComposite({1U, 1U, 1U, 16383U});
 }
 
 // Test unaligned dimensions (C % 32 != 0) with very large C
 TEST_F(RMSNormOpTest, RMSNorm_Compare_Unaligned_VeryLargeC) {
-    // Skip with watcher enabled github issue #37193
-    SKIP_FOR_WATCHER();
     // C = 1048575 (1 << 20 - 1), very large C with masking
     CompareKernelVsComposite({1U, 1U, 1U, 1048575U});
 
@@ -490,39 +458,29 @@ TEST_F(RMSNormOpTest, RMSNorm_Compare_Unaligned_VeryLargeC) {
 
 // Test block_size = 1 (C is odd)
 TEST_F(RMSNormOpTest, RMSNorm_Compare_BlockSize1_OddC) {
-    // Skip with watcher enabled github issue #37193
-    SKIP_FOR_WATCHER();
     CompareKernelVsComposite({1U, 1U, 1U, 33U});   // C = 33 (odd)
     CompareKernelVsComposite({1U, 1U, 1U, 127U});  // C = 127 (odd)
 }
 
 // Test block_size = 2 (C is even)
 TEST_F(RMSNormOpTest, RMSNorm_Compare_BlockSize2_EvenC) {
-    // Skip with watcher enabled github issue #37193
-    SKIP_FOR_WATCHER();
     CompareKernelVsComposite({1U, 1U, 1U, 34U});   // C = 34 (even)
     CompareKernelVsComposite({1U, 1U, 1U, 126U});  // C = 126 (even)
 }
 
 // Test training-like shapes with NanoLlama dimensions
 TEST_F(RMSNormOpTest, RMSNorm_Compare_TrainingShapes_NanoLlama) {
-    // Skip with watcher enabled github issue #37193
-    SKIP_FOR_WATCHER();
     // NanoLlama training shape: batch=64, seq_len=256, hidden_dim=384
     CompareKernelVsComposite({64U, 1U, 256U, 384U});
 }
 
 // Test training-like shapes with LLaMA 7B dimensions
 TEST_F(RMSNormOpTest, RMSNorm_Compare_TrainingShapes_NanoGPT) {
-    // Skip with watcher enabled github issue #37193
-    SKIP_FOR_WATCHER();
     CompareKernelVsComposite({1U, 1U, 512U, 4096U});
 }
 
 // Test small batch and sequence dimensions (non-1 values)
 TEST_F(RMSNormOpTest, NIGHTLY_RMSNorm_Compare_SmallBatch_NonUnit) {
-    // Skip with watcher enabled github issue #37193
-    SKIP_FOR_WATCHER();
     auto board = tt::umd::Cluster::create_cluster_descriptor()->get_board_type(0);
     if (board == tt::BoardType::P100 || board == tt::BoardType::P150) {
         GTEST_SKIP() << "Skipping on P100/P150 boards";
@@ -533,8 +491,6 @@ TEST_F(RMSNormOpTest, NIGHTLY_RMSNorm_Compare_SmallBatch_NonUnit) {
 
 // Test different masking patterns with larger batches
 TEST_F(RMSNormOpTest, NIGHTLY_RMSNorm_Compare_Masking_Patterns) {
-    // Skip with watcher enabled github issue #37193
-    SKIP_FOR_WATCHER();
     auto board = tt::umd::Cluster::create_cluster_descriptor()->get_board_type(0);
     if (board == tt::BoardType::P100 || board == tt::BoardType::P150) {
         GTEST_SKIP() << "Skipping on P100/P150 boards";

--- a/tt-train/tests/ops/rope_test.cpp
+++ b/tt-train/tests/ops/rope_test.cpp
@@ -467,8 +467,6 @@ TEST_F(RoPETest, ForwardTest) {
 }
 
 TEST_F(RoPETest, BackwardTest) {
-    // Skip with watcher enabled github issue #37193
-    SKIP_FOR_WATCHER();
     // Head dim must be a multiple of TILE_WIDTH
     // Head dim must be <= 256
     // Input query tensor

--- a/tt-train/tests/ops/silu_op_test.cpp
+++ b/tt-train/tests/ops/silu_op_test.cpp
@@ -176,8 +176,6 @@ static void CompareKernelVsReferenceWithShape(const std::vector<uint32_t>& shape
 
 // Test small tensor - basic functionality
 TEST_F(SiLUOpTest, SiLU_Compare_Small) {
-    // Skip with watcher enabled github issue #37193
-    SKIP_FOR_WATCHER();
     // C=8, Wt=1, Wt%4=1
     CompareKernelVsReferenceWithShape({1, 1, 1, 8});
 }
@@ -185,40 +183,30 @@ TEST_F(SiLUOpTest, SiLU_Compare_Small) {
 // Test block_size alignment patterns
 // Wt % block_size = 0 (perfectly aligned)
 TEST_F(SiLUOpTest, SiLU_Compare_BlockSize_Remainder0) {
-    // Skip with watcher enabled github issue #37193
-    SKIP_FOR_WATCHER();
     // C=128, Wt=4, Wt%4=0
     CompareKernelVsReferenceWithShape({1, 1, 1, 128});
 }
 
 // Wt % block_size = 1
 TEST_F(SiLUOpTest, SiLU_Compare_BlockSize_Remainder1) {
-    // Skip with watcher enabled github issue #37193
-    SKIP_FOR_WATCHER();
     // C=160, Wt=5, Wt%4=1
     CompareKernelVsReferenceWithShape({1, 1, 1, 160});
 }
 
 // Wt % block_size = 2
 TEST_F(SiLUOpTest, SiLU_Compare_BlockSize_Remainder2) {
-    // Skip with watcher enabled github issue #37193
-    SKIP_FOR_WATCHER();
     // C=192, Wt=6, Wt%4=2
     CompareKernelVsReferenceWithShape({1, 1, 1, 192});
 }
 
 // Wt % block_size = 3
 TEST_F(SiLUOpTest, SiLU_Compare_BlockSize_Remainder3) {
-    // Skip with watcher enabled github issue #37193
-    SKIP_FOR_WATCHER();
     // C=224, Wt=7, Wt%4=3
     CompareKernelVsReferenceWithShape({1, 1, 1, 224});
 }
 
 // Test large tensor - memory stress test
 TEST_F(SiLUOpTest, SiLU_Compare_Large) {
-    // Skip with watcher enabled github issue #37193
-    SKIP_FOR_WATCHER();
     // Large C dimension to test memory handling
     // C=32768, Wt=1024, Wt%4=0
     CompareKernelVsReferenceWithShape({1, 1, 1, 32768});
@@ -226,8 +214,6 @@ TEST_F(SiLUOpTest, SiLU_Compare_Large) {
 
 // Test very large tensor - extreme memory test
 TEST_F(SiLUOpTest, SiLU_Compare_VeryLarge) {
-    // Skip with watcher enabled github issue #37193
-    SKIP_FOR_WATCHER();
     // Very large C dimension ~1M elements
     // C=1048576, Wt=32768, Wt%4=0
     CompareKernelVsReferenceWithShape({1, 1, 1, 1048576});
@@ -235,8 +221,6 @@ TEST_F(SiLUOpTest, SiLU_Compare_VeryLarge) {
 
 // Test NanoLlama-like shape - realistic transformer model
 TEST_F(SiLUOpTest, SiLU_Compare_NanoLlama_Shape) {
-    // Skip with watcher enabled github issue #37193
-    SKIP_FOR_WATCHER();
     // Typical NanoLlama dimensions: multiple batches and sequences
     // B=2, N=1, S=64, C=512 (hidden dimension)
     // C=512, Wt=16, Wt%4=0
@@ -245,8 +229,6 @@ TEST_F(SiLUOpTest, SiLU_Compare_NanoLlama_Shape) {
 
 // Test batch processing with different sequence lengths
 TEST_F(SiLUOpTest, SiLU_Compare_MultiBatch_MultiSeq) {
-    // Skip with watcher enabled github issue #37193
-    SKIP_FOR_WATCHER();
     // Multiple batches with longer sequences
     // B=4, N=1, S=128, C=768
     // C=768, Wt=24, Wt%4=0
@@ -255,8 +237,6 @@ TEST_F(SiLUOpTest, SiLU_Compare_MultiBatch_MultiSeq) {
 
 // Test smaller model dimensions with unaligned C
 TEST_F(SiLUOpTest, SiLU_Compare_SmallModel_Unaligned) {
-    // Skip with watcher enabled github issue #37193
-    SKIP_FOR_WATCHER();
     // Smaller model with unaligned channel dimension
     // B=2, N=1, S=32, C=100
     // C=100, Wt=4, Wt%4=0 (but C is not multiple of 32)
@@ -272,8 +252,6 @@ TEST_F(SiLUOpTest, SiLU_Compare_SmallModel_Unaligned) {
 // ============================================================================
 
 TEST_F(SiLUOpTest, SiLU_Precision_Comparison) {
-    // Skip with watcher enabled github issue #37193
-    SKIP_FOR_WATCHER();
     using namespace ttml;
 
     // Single test shape: nanollama-like

--- a/tt-train/tests/ops/unary_ops_test.cpp
+++ b/tt-train/tests/ops/unary_ops_test.cpp
@@ -77,8 +77,6 @@ protected:
 };
 
 TEST_F(UnaryOpsTest, GlobalMean) {
-    // Skip with watcher enabled github issue #37193
-    SKIP_FOR_WATCHER();
     std::vector<float> test_data = {1.F, 2.F, 3.F, 4.F, 1.F, 2.F, 3.F, 4.F};
 
     auto shape = ttnn::Shape({2, 1, 1, 4});
@@ -124,8 +122,6 @@ TEST_F(UnaryOpsTest, LogSoftmax) {
 }
 
 TEST_F(UnaryOpsTest, Silu) {
-    // Skip with watcher enabled github issue #37193
-    SKIP_FOR_WATCHER();
     auto N = 4;
     auto C = 1;
     auto H = 20;

--- a/tt-train/tests/optimizers/adamw_test.cpp
+++ b/tt-train/tests/optimizers/adamw_test.cpp
@@ -29,8 +29,6 @@ protected:
 };
 
 TEST_F(AdamWFullTest, AdamWTest) {
-    // Skip with watcher enabled github issue #37193
-    SKIP_FOR_WATCHER();
     using namespace ttml::ops;
     ttml::autograd::ctx().set_seed(42);
     auto* device = &ttml::autograd::ctx().get_device();

--- a/tt-train/tests/ttnn_fixed/reduce_ops_test.cpp
+++ b/tt-train/tests/ttnn_fixed/reduce_ops_test.cpp
@@ -31,8 +31,6 @@ protected:
 };
 
 TEST_F(ReduceOpTest, TestMeanDim0) {
-    // Skip with watcher enabled github issue #37193
-    SKIP_FOR_WATCHER();
     ttml::autograd::ctx().set_seed(42);
     auto* device = &ttml::autograd::ctx().get_device();
     xt::xarray<float> xtensor_a = xt::empty<float>({128 * 64});

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_clip_grad_norm/moreh_clip_grad_norm_step2/device/kernels/moreh_clip_grad_norm_step2_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_clip_grad_norm/moreh_clip_grad_norm_step2/device/kernels/moreh_clip_grad_norm_step2_kernel.cpp
@@ -9,7 +9,6 @@ void kernel_main() {
     const auto num_tiles = get_arg_val<uint32_t>(i++);
     const auto p = get_arg_val<uint32_t>(i++);
     const bool p_is_negative = get_arg_val<uint32_t>(i++) == 1;
-    const auto norm_type = get_arg_val<uint32_t>(i++);
 
     std::uint8_t input_id{0};
     const auto cb_input = input_id++;    // input(==tmp_pow_sum)

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_mean/device/kernels/writer_moreh_mean_nc.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_mean/device/kernels/writer_moreh_mean_nc.cpp
@@ -10,7 +10,6 @@ void kernel_main() {
     const auto output_addr = get_arg_val<uint32_t>(0);
     const auto num_tiles = get_arg_val<uint32_t>(1);
     const auto start_id = get_arg_val<uint32_t>(2);
-    const auto output_is_dram = (get_arg_val<uint32_t>(3) == 1);
 
     constexpr uint32_t cb_id_out = 16;
     constexpr uint32_t onetile = 1;


### PR DESCRIPTION
## Kernel fixes:
- writer_moreh_mean_nc.cpp: Remove unused output_is_dram runtime arg read
- moreh_clip_grad_norm_step2_kernel.cpp: Remove unused norm_type runtime arg read

## Test updates:
- Remove SKIP_FOR_WATCHER from single-device tests that now pass:
  - ClipGradNormTest
  - EmbeddingOpTest
  - RMSNormOpTest
  - SiLUOpTest
  - UnaryOpsTest
  - RoPETest
  - LayerNormCompositeTest
  - CrossEntropyBwOpTest
  - AdamWTest
  - ReduceOpsTest
  - LinearRegressionFullTest
  - WeightTyingTest

### Ticket
Closes #37193
Closes #37040

### Problem description
When running tt-train tests with `TT_METAL_WATCHER=1`, several tests were skipped via `SKIP_FOR_WATCHER()` due to kernel assertion failures. The watcher detected runtime argument bounds violations in moreh kernels where code was reading more runtime args than were actually set.

### What's changed
Fixed two moreh kernels that had dead code reading unused runtime arguments:
1. `writer_moreh_mean_nc.cpp` - removed unused `output_is_dram` arg read (arg was never set by host)
2. `moreh_clip_grad_norm_step2_kernel.cpp` - removed unused `norm_type` arg read (arg was never set by host)

With these kernel fixes, single-device tests now pass with watcher enabled. Removed `SKIP_FOR_WATCHER()` from 14 test files covering ClipGradNormTest, EmbeddingOpTest, RMSNormOpTest, SiLUOpTest, and other single-device operations.

The `moreh_clip_grad_norm_step2_kernel.cpp` fix also resolves #37040 -- the single-device `ClipGradNormTest` now passes with watcher. The N300 `MorehClipGradNorm` test retains its `SKIP_FOR_WATCHER()` because it hits the unrelated Ethernet fabric contention issue (#30521), not the original assert failure. Updated its comment accordingly.

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=mdragula/fix-tests-with-enabled-watcher)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:mdragula/fix-tests-with-enabled-watcher)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=mdragula/fix-tests-with-enabled-watcher)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:mdragula/fix-tests-with-enabled-watcher)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mdragula/fix-tests-with-enabled-watcher)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mdragula/fix-tests-with-enabled-watcher)
- [x] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mdragula/fix-tests-with-enabled-watcher)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mdragula/fix-tests-with-enabled-watcher)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mdragula/fix-tests-with-enabled-watcher)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mdragula/fix-tests-with-enabled-watcher)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mdragula/fix-tests-with-enabled-watcher)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mdragula/fix-tests-with-enabled-watcher)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
