### PR TITLE
TT-Train: Remove TT_METAL_HOME env var dependency from CMake

### DIFF
--- a/tt-train/sources/ttml/CMakeLists.txt
+++ b/tt-train/sources/ttml/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.20)
 project(ttml)
 
 set(SOURCES

--- a/tt-train/sources/ttml/CMakeLists.txt
+++ b/tt-train/sources/ttml/CMakeLists.txt
@@ -330,19 +330,18 @@ if(NOT TARGET TT::Metalium)
     find_package(TT-NN)
 
     if(NOT TT-NN_FOUND)
-        # Try to get TT_METAL_HOME from environment, otherwise infer from directory structure
-        if(DEFINED ENV{TT_METAL_HOME})
-            set(TT_METAL_HOME "$ENV{TT_METAL_HOME}")
-            message(STATUS "Using TT_METAL_HOME from environment: ${TT_METAL_HOME}")
+        # Infer tt-metal repository layout from directory structure (tt-metal/tt-train)
+        # From the tt-train project root, go up one level to reach the tt-metal repository root
+        set(TT_METAL_HOME "${CMAKE_SOURCE_DIR}/..")
+        cmake_path(NORMAL_PATH TT_METAL_HOME)
+        if(EXISTS "${TT_METAL_HOME}/tt_metal/CMakeLists.txt")
+            message(STATUS "Inferred tt-metal location: ${TT_METAL_HOME}")
         else()
-            # Infer tt-metal repository layout from directory structure (tt-metal/tt-train)
-            # From tt-train/sources/ttml/, go up THREE levels to reach the repository root
-            set(TT_METAL_HOME "${CMAKE_CURRENT_SOURCE_DIR}/../../..")
-            if(EXISTS "${TT_METAL_HOME}/tt_metal/CMakeLists.txt")
-                message(STATUS "Inferred tt-metal location: ${TT_METAL_HOME}")
-            else()
-                message(FATAL_ERROR "Failed to infer tt-metal location from ${TT_METAL_HOME}")
-            endif()
+            message(
+                FATAL_ERROR
+                "Failed to infer tt-metal location from ${TT_METAL_HOME}. "
+                "Please build tt-metal first or install the TT-NN package."
+            )
         endif()
 
         set(METALIUM_INCLUDE_DIRS
@@ -360,9 +359,9 @@ if(NOT TARGET TT::Metalium)
             "${TT_METAL_HOME}/tt_metal/hw/inc"
             "${TT_METAL_HOME}/tt_stl"
             # TTNN
-            "$ENV{TT_METAL_HOME}/ttnn"
-            "$ENV{TT_METAL_HOME}/ttnn/api"
-            "$ENV{TT_METAL_HOME}/ttnn/cpp"
+            "${TT_METAL_HOME}/ttnn"
+            "${TT_METAL_HOME}/ttnn/api"
+            "${TT_METAL_HOME}/ttnn/cpp"
             "${reflect_SOURCE_DIR}"
         )
 


### PR DESCRIPTION
### Ticket
NA

### Problem description
Standalone builds of TT-Train were relying on the TT_METAL_HOME env var, which has been removed.  This broke the standalone TT-Train build.

### What's changed
Remove env var lookup, set TT_METAL_HOME to `../`.  Add CMake minimum version for usage of cmake_path.
TT-Train standalone builds are no longer broken due to this dependency on an old env var.

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=athompson/tt-train-cmake-remove-TT_METAL_HOME)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:athompson/tt-train-cmake-remove-TT_METAL_HOME)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=athompson/tt-train-cmake-remove-TT_METAL_HOME)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:athompson/tt-train-cmake-remove-TT_METAL_HOME)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=athompson/tt-train-cmake-remove-TT_METAL_HOME)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:athompson/tt-train-cmake-remove-TT_METAL_HOME)
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=athompson/tt-train-cmake-remove-TT_METAL_HOME)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:athompson/tt-train-cmake-remove-TT_METAL_HOME)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=athompson/tt-train-cmake-remove-TT_METAL_HOME)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:athompson/tt-train-cmake-remove-TT_METAL_HOME)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=athompson/tt-train-cmake-remove-TT_METAL_HOME)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:athompson/tt-train-cmake-remove-TT_METAL_HOME)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
