### PR TITLE
added demo profiling script and device perf utils

### DIFF
--- a/.github/time_budget.yaml
+++ b/.github/time_budget.yaml
@@ -104,7 +104,7 @@ models:
     wh_llmbox: 422
   perf:
     wh_llmbox_perf: 685
-    wh_galaxy: 260
+    wh_galaxy: 305
   demo:
     wh_llmbox_perf: 1090
     wh_galaxy: 270

--- a/.github/time_budget.yaml
+++ b/.github/time_budget.yaml
@@ -104,7 +104,7 @@ models:
     wh_llmbox: 422
   perf:
     wh_llmbox_perf: 685
-    wh_galaxy: 305
+    wh_galaxy: 280
   demo:
     wh_llmbox_perf: 1090
     wh_galaxy: 270

--- a/.github/workflows/galaxy-perf-tests.yaml
+++ b/.github/workflows/galaxy-perf-tests.yaml
@@ -22,6 +22,7 @@ on:
           - mochi
           - qwenimage
           - gpt-oss
+          - deepseek_v3
       build-type:
         required: false
         type: choice

--- a/create_venv.sh
+++ b/create_venv.sh
@@ -334,6 +334,12 @@ else
 fi
 
 echo "Installing dev dependencies"
+# mmcv/mmcv-full use pkg_resources in setup.py but don't declare setuptools as a
+# build dependency. Pre-install them with --no-build-isolation so they pick up the
+# setuptools already installed in the venv above.
+echo "Pre-installing mmcv packages (--no-build-isolation for setuptools/pkg_resources)..."
+uv pip install --no-build-isolation --extra-index-url "$PYTORCH_INDEX" mmcv==2.2.0 mmcv-full==1.7.2 || true
+
 # Use --extra-index-url for PyTorch CPU wheels and index-strategy for transitive deps
 # no-build-isolation as a workaround for setuptools/mmcv
 uv pip install --extra-index-url "$PYTORCH_INDEX" \

--- a/create_venv.sh
+++ b/create_venv.sh
@@ -334,12 +334,6 @@ else
 fi
 
 echo "Installing dev dependencies"
-# mmcv/mmcv-full use pkg_resources in setup.py but don't declare setuptools as a
-# build dependency. Pre-install them with --no-build-isolation so they pick up the
-# setuptools already installed in the venv above.
-echo "Pre-installing mmcv packages (--no-build-isolation for setuptools/pkg_resources)..."
-uv pip install --no-build-isolation --extra-index-url "$PYTORCH_INDEX" mmcv==2.2.0 mmcv-full==1.7.2 || true
-
 # Use --extra-index-url for PyTorch CPU wheels and index-strategy for transitive deps
 # no-build-isolation as a workaround for setuptools/mmcv
 uv pip install --extra-index-url "$PYTORCH_INDEX" \

--- a/models/demos/deepseek_v3/demo/demo.py
+++ b/models/demos/deepseek_v3/demo/demo.py
@@ -137,6 +137,12 @@ def create_parser() -> argparse.ArgumentParser:
         type=int,
         help="Maximum number of tokens to prefill.",
     )
+    p.add_argument(
+        "--profile-decode",
+        action="store_true",
+        default=False,
+        help="Profile decode performance: skip prefill (use random tokens), and run only first dense layer + first MoE layer during decode.",
+    )
     return p
 
 
@@ -253,7 +259,7 @@ def run_demo(
     repeat_batches: int = 1,
     signpost: bool = False,
     prefill_max_tokens: int = None,
-    force_recalculate: bool = False,
+    profile_decode: bool = False,
 ) -> dict:
     """Programmatic entrypoint for the DeepSeek-V3 demo.
 
@@ -352,7 +358,7 @@ def run_demo(
                 enable_mem_profile=enable_mem_profile,
                 signpost=signpost,
                 prefill_max_tokens=prefill_max_tokens,
-                force_recalculate=force_recalculate,
+                profile_decode=profile_decode,
             )
         # Build the prompt list
         pre_tokenized_prompts = None
@@ -452,6 +458,7 @@ def main() -> None:
         enable_mem_profile=args.enable_mem_profile,
         signpost=args.signpost,
         prefill_max_tokens=args.prefill_max_tokens,
+        profile_decode=args.profile_decode,
     )
 
     # If prompts were loaded from a JSON file, save output to JSON file instead of printing

--- a/models/demos/deepseek_v3/demo/demo.py
+++ b/models/demos/deepseek_v3/demo/demo.py
@@ -415,6 +415,8 @@ def run_demo(
             gen.cleanup_all()
         except Exception as e:
             logger.warning(f"Failed to cleanup generator: {e}")
+        # Synchronize device before closing to flush pending ops (e.g. profiler data)
+        ttnn.synchronize_device(mesh_device)
         # Clean up mesh device(s)
         for submesh in mesh_device.get_submeshes():
             ttnn.close_mesh_device(submesh)

--- a/models/demos/deepseek_v3/demo/test_decode_demo_perf.py
+++ b/models/demos/deepseek_v3/demo/test_decode_demo_perf.py
@@ -40,7 +40,7 @@ def _assert_within_margin(metric_name: str, measured: float, expected: float, ma
 @pytest.mark.parametrize(
     "expected_kernel_duration_us, expected_op_to_op_latency_us, expected_e2e_time_us, margin",
     [
-        pytest.param(12373.07, 189.20, 12562.27, 0.03, id="decode_e2e_perf"),
+        pytest.param(10386.34, 191.52, 10577.85, 0.03, id="decode_e2e_perf"),
     ],
 )
 def test_decode_demo_perf(expected_kernel_duration_us, expected_op_to_op_latency_us, expected_e2e_time_us, margin):

--- a/models/demos/deepseek_v3/demo/test_decode_demo_perf.py
+++ b/models/demos/deepseek_v3/demo/test_decode_demo_perf.py
@@ -46,6 +46,7 @@ def _assert_within_margin(metric_name: str, measured: float, expected: float, ma
 # ---------------------------------------------------------------------------
 # Test
 # ---------------------------------------------------------------------------
+@pytest.mark.timeout(1200)
 @pytest.mark.parametrize(
     "margin",
     [pytest.param(PERF_MARGIN, id="decode_e2e_perf")],
@@ -69,7 +70,7 @@ def test_decode_demo_perf(margin):
     # ------------------------------------------------------------------
     logger.info("Step 1: Running device profiler …")
     clear_profiler_runtime_artifacts()
-    run_device_profiler(command, subdir, device_analysis_types=["device_kernel_duration"])
+    run_device_profiler(command, subdir, device_analysis_types=["device_kernel_duration"], op_support_count=5000)
 
     # ------------------------------------------------------------------
     # Step 2 – Locate the raw CSV produced by the profiler

--- a/models/demos/deepseek_v3/demo/test_decode_demo_perf.py
+++ b/models/demos/deepseek_v3/demo/test_decode_demo_perf.py
@@ -18,16 +18,6 @@ from tracy.process_model_log import get_latest_ops_log_filename, run_device_prof
 
 from models.demos.deepseek_v3.utils.device_perf_utils import compute_e2e_time, filter_profile_csv, process_profile_stats
 
-# ---------------------------------------------------------------------------
-# Expected 2-Layer Model E2E performance values (microseconds)
-# ---------------------------------------------------------------------------
-EXPECTED_TOTAL_KERNEL_DURATION_US = 12373.07
-EXPECTED_TOTAL_OP_TO_OP_LATENCY_US = 189.20
-EXPECTED_E2E_TIME_US = 12562.27
-
-# Acceptable deviation from expected values (fraction, e.g. 0.03 = 3%)
-PERF_MARGIN = 0.03
-
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -48,12 +38,15 @@ def _assert_within_margin(metric_name: str, measured: float, expected: float, ma
 # ---------------------------------------------------------------------------
 @pytest.mark.timeout(1200)
 @pytest.mark.parametrize(
-    "margin",
-    [pytest.param(PERF_MARGIN, id="decode_e2e_perf")],
+    "expected_kernel_duration_us, expected_op_to_op_latency_us, expected_e2e_time_us, margin",
+    [
+        pytest.param(12373.07, 189.20, 12562.27, 0.03, id="decode_e2e_perf"),
+    ],
 )
-def test_decode_demo_perf(margin):
+def test_decode_demo_perf(expected_kernel_duration_us, expected_op_to_op_latency_us, expected_e2e_time_us, margin):
     """
     End-to-end device-performance test for the DeepSeek V3 2-layer decode demo.
+    1st layer is dense decoder block and 2nd layer is MoE Decoder Block.
 
     Steps
     -----
@@ -117,8 +110,8 @@ def test_decode_demo_perf(margin):
     # ------------------------------------------------------------------
     logger.info("Step 6: Asserting performance thresholds …")
 
-    _assert_within_margin("E2E Time", e2e_time_us, EXPECTED_E2E_TIME_US, margin)
-    _assert_within_margin("Total Kernel Duration", total_kernel_us, EXPECTED_TOTAL_KERNEL_DURATION_US, margin)
-    _assert_within_margin("Total Op-to-Op Latency", total_latency_us, EXPECTED_TOTAL_OP_TO_OP_LATENCY_US, margin)
+    _assert_within_margin("E2E Time", e2e_time_us, expected_e2e_time_us, margin)
+    _assert_within_margin("Total Kernel Duration", total_kernel_us, expected_kernel_duration_us, margin)
+    _assert_within_margin("Total Op-to-Op Latency", total_latency_us, expected_op_to_op_latency_us, margin)
 
     logger.info("All performance assertions passed!")

--- a/models/demos/deepseek_v3/demo/test_decode_demo_perf.py
+++ b/models/demos/deepseek_v3/demo/test_decode_demo_perf.py
@@ -1,0 +1,123 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+DeepSeek V3 decode demo device performance test.
+
+Runs the profile_decode test case under the device profiler, filters and
+processes the resulting CSV to compute 2-Layer Model E2E Time, then asserts
+against known-good performance thresholds.
+"""
+
+from pathlib import Path
+
+import pytest
+from loguru import logger
+from tracy.common import clear_profiler_runtime_artifacts
+from tracy.process_model_log import get_latest_ops_log_filename, run_device_profiler
+
+from models.demos.deepseek_v3.utils.device_perf_utils import compute_e2e_time, filter_profile_csv, process_profile_stats
+
+# ---------------------------------------------------------------------------
+# Expected 2-Layer Model E2E performance values (microseconds)
+# ---------------------------------------------------------------------------
+EXPECTED_TOTAL_KERNEL_DURATION_US = 12373.07
+EXPECTED_TOTAL_OP_TO_OP_LATENCY_US = 189.20
+EXPECTED_E2E_TIME_US = 12562.27
+
+# Acceptable deviation from expected values (fraction, e.g. 0.03 = 3%)
+PERF_MARGIN = 0.03
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+def _assert_within_margin(metric_name: str, measured: float, expected: float, margin: float):
+    """Assert that *measured* falls within *expected* ± *margin* (fraction)."""
+    lower = expected * (1 - margin)
+    upper = expected * (1 + margin)
+    logger.info(f"{metric_name}: measured={measured:.2f} us, expected=[{lower:.2f}, {upper:.2f}] us")
+    assert lower <= measured <= upper, (
+        f"{metric_name} {measured:.2f} us is outside the expected range "
+        f"[{lower:.2f}, {upper:.2f}] us (expected {expected:.2f} us ± {margin*100:.1f}%)"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize(
+    "margin",
+    [pytest.param(PERF_MARGIN, id="decode_e2e_perf")],
+)
+def test_decode_demo_perf(margin):
+    """
+    End-to-end device-performance test for the DeepSeek V3 2-layer decode demo.
+
+    Steps
+    -----
+    1. Run the ``profile_decode`` test case under the device profiler.
+    2. Filter the raw ops CSV.
+    3. Compute per-op statistics and derive 2-Layer Model E2E Time.
+    4. Assert against thresholds.
+    """
+    subdir = "deepseek_v3_decode_perf"
+    command = "pytest models/demos/deepseek_v3/demo/test_demo.py -k profile_decode"
+
+    # ------------------------------------------------------------------
+    # Step 1 – Run the device profiler
+    # ------------------------------------------------------------------
+    logger.info("Step 1: Running device profiler …")
+    clear_profiler_runtime_artifacts()
+    run_device_profiler(command, subdir, device_analysis_types=["device_kernel_duration"])
+
+    # ------------------------------------------------------------------
+    # Step 2 – Locate the raw CSV produced by the profiler
+    # ------------------------------------------------------------------
+    raw_csv_path = Path(get_latest_ops_log_filename(subdir))
+    logger.info(f"Step 2: Raw profiler CSV → {raw_csv_path}")
+    assert raw_csv_path.exists(), f"Raw CSV not found: {raw_csv_path}"
+
+    # ------------------------------------------------------------------
+    # Step 3 – Filter the CSV
+    # ------------------------------------------------------------------
+    logger.info("Step 3: Filtering CSV …")
+    filtered_csv_path = raw_csv_path.parent / "decode_demo_profile_filtered.csv"
+    filter_profile_csv(raw_csv_path, filtered_csv_path)
+
+    # ------------------------------------------------------------------
+    # Step 4 – Process stats & write merged CSV
+    # ------------------------------------------------------------------
+    logger.info("Step 4: Processing stats …")
+    merged_csv_path = raw_csv_path.parent / "decode_demo_profile_merged.csv"
+    results = process_profile_stats(filtered_csv_path, merged_csv_path)
+
+    # ------------------------------------------------------------------
+    # Step 5 – Compute & log 2-Layer Model E2E Time
+    # ------------------------------------------------------------------
+    e2e = compute_e2e_time(results)
+
+    total_kernel_us = e2e["total_kernel_duration_us"]
+    total_latency_us = e2e["total_op_to_op_latency_us"]
+    e2e_time_us = e2e["e2e_time_us"]
+
+    logger.info(
+        f"\n{'=' * 50}"
+        f"\n2-Layer Model E2E Time"
+        f"\n{'=' * 50}"
+        f"\n  Total Kernel Duration : {total_kernel_us:.2f} us ({total_kernel_us / 1000:.3f} ms)"
+        f"\n  Total Op-to-Op Latency: {total_latency_us:.2f} us ({total_latency_us / 1000:.3f} ms)"
+        f"\n  E2E Time              : {e2e_time_us:.2f} us ({e2e_time_us / 1000:.3f} ms)"
+        f"\n{'=' * 50}"
+    )
+
+    # ------------------------------------------------------------------
+    # Step 6 – Assert against expected thresholds
+    # ------------------------------------------------------------------
+    logger.info("Step 6: Asserting performance thresholds …")
+
+    _assert_within_margin("E2E Time", e2e_time_us, EXPECTED_E2E_TIME_US, margin)
+    _assert_within_margin("Total Kernel Duration", total_kernel_us, EXPECTED_TOTAL_KERNEL_DURATION_US, margin)
+    _assert_within_margin("Total Op-to-Op Latency", total_latency_us, EXPECTED_TOTAL_OP_TO_OP_LATENCY_US, margin)
+
+    logger.info("All performance assertions passed!")

--- a/models/demos/deepseek_v3/demo/test_decode_demo_perf.py
+++ b/models/demos/deepseek_v3/demo/test_decode_demo_perf.py
@@ -43,6 +43,7 @@ def _assert_within_margin(metric_name: str, measured: float, expected: float, ma
         pytest.param(10386.34, 191.52, 10577.85, 0.03, id="decode_e2e_perf"),
     ],
 )
+@pytest.mark.models_device_performance_bare_metal
 def test_decode_demo_perf(expected_kernel_duration_us, expected_op_to_op_latency_us, expected_e2e_time_us, margin):
     """
     End-to-end device-performance test for the DeepSeek V3 2-layer decode demo.

--- a/models/demos/deepseek_v3/demo/test_demo.py
+++ b/models/demos/deepseek_v3/demo/test_demo.py
@@ -74,7 +74,7 @@ CACHE_DIR = Path(os.getenv("DEEPSEEK_V3_CACHE", "/mnt/MLPerf/tt_dnn-models/deeps
         pytest.param(
             1,
             1,
-            10,
+            13,
             5,
             True,
             None,

--- a/models/demos/deepseek_v3/demo/test_demo.py
+++ b/models/demos/deepseek_v3/demo/test_demo.py
@@ -80,6 +80,7 @@ CACHE_DIR = Path(os.getenv("DEEPSEEK_V3_CACHE", "/mnt/MLPerf/tt_dnn-models/deeps
             None,
             True,
             id="profile_decode",
+            marks=pytest.mark.timeout(1800),
         ),
     ],
 )

--- a/models/demos/deepseek_v3/demo/test_demo.py
+++ b/models/demos/deepseek_v3/demo/test_demo.py
@@ -14,7 +14,7 @@ CACHE_DIR = Path(os.getenv("DEEPSEEK_V3_CACHE", "/mnt/MLPerf/tt_dnn-models/deeps
 
 
 @pytest.mark.parametrize(
-    "max_prompts,repeat_batches,max_new_tokens,override_num_layers,enable_trace,artifact_name",
+    "max_prompts,repeat_batches,max_new_tokens,override_num_layers,enable_trace,artifact_name,profile_decode",
     [
         pytest.param(
             56,
@@ -23,6 +23,7 @@ CACHE_DIR = Path(os.getenv("DEEPSEEK_V3_CACHE", "/mnt/MLPerf/tt_dnn-models/deeps
             5,
             False,
             None,
+            False,
             id="tg_stress",
             marks=pytest.mark.requires_device(["TG"]),
         ),
@@ -33,6 +34,7 @@ CACHE_DIR = Path(os.getenv("DEEPSEEK_V3_CACHE", "/mnt/MLPerf/tt_dnn-models/deeps
             None,
             True,
             "dual_demo_full_results",
+            False,
             id="dual_full_demo",
             marks=pytest.mark.requires_device(["DUAL"]),
         ),
@@ -43,6 +45,7 @@ CACHE_DIR = Path(os.getenv("DEEPSEEK_V3_CACHE", "/mnt/MLPerf/tt_dnn-models/deeps
             None,
             True,
             "dual_demo_stress_results",
+            False,
             id="dual_stress_demo",
             marks=pytest.mark.requires_device(["DUAL"]),
         ),
@@ -53,6 +56,7 @@ CACHE_DIR = Path(os.getenv("DEEPSEEK_V3_CACHE", "/mnt/MLPerf/tt_dnn-models/deeps
             None,
             True,
             "quad_demo_full_results",
+            False,
             id="quad_full_demo",
             marks=pytest.mark.requires_device(["QUAD"]),
         ),
@@ -63,8 +67,19 @@ CACHE_DIR = Path(os.getenv("DEEPSEEK_V3_CACHE", "/mnt/MLPerf/tt_dnn-models/deeps
             None,
             True,
             "quad_demo_stress_results",
+            False,
             id="quad_stress_demo",
             marks=pytest.mark.requires_device(["QUAD"]),
+        ),
+        pytest.param(
+            1,
+            1,
+            10,
+            5,
+            True,
+            None,
+            True,
+            id="profile_decode",
         ),
     ],
 )
@@ -75,6 +90,7 @@ def test_demo(
     override_num_layers: int,
     enable_trace: bool,
     artifact_name: str,
+    profile_decode: bool,
 ):
     """
     DeepSeek v3 demo test with prompts loaded from JSON file.
@@ -85,6 +101,7 @@ def test_demo(
     - dual_stress_demo (DUAL): 56 prompts, 20 batches - tests stability under repeated execution
     - quad_full_demo (QUAD): 512 prompts, 1 batch - tests full prompt capacity
     - quad_stress_demo (QUAD): 56 prompts, 20 batches - tests stability under repeated execution
+    - profile_decode: Profile decode for non-moe and moe layers
     """
     # Path to the external JSON file containing prompts
     json_path = "models/demos/deepseek_v3/demo/test_prompts.json"
@@ -100,6 +117,8 @@ def test_demo(
         random_weights=False,
         max_new_tokens=max_new_tokens,
         repeat_batches=repeat_batches,
+        profile_decode=profile_decode,
+        signpost=True,
     )
     if override_num_layers is not None:
         run_kwargs["override_num_layers"] = override_num_layers

--- a/models/demos/deepseek_v3/tt/generator.py
+++ b/models/demos/deepseek_v3/tt/generator.py
@@ -91,6 +91,7 @@ class DeepseekGenerator:
         signpost: bool = False,
         prefill_max_tokens: int | None = None,
         force_recalculate: bool = False,
+        profile_decode: bool = False,
     ) -> None:
         self.mesh_device = mesh_device
         self.model_path = str(model_path)
@@ -161,7 +162,10 @@ class DeepseekGenerator:
         self.signpost = signpost
         self.prefill_max_tokens = prefill_max_tokens
         self.force_recalculate = force_recalculate
+        self.profile_decode = profile_decode  # Profile decode: skip prefill, run only 1st dense + 1st MoE layer
         logger.info(f"Enable trace: {self.enable_trace}")
+        if self.profile_decode:
+            logger.info("profile_decode=True: Prefill skipped, decode runs only 1st dense layer + 1st MoE layer")
 
         # Initialize rope_setup once
         self.rope_setup = RotarySetup(
@@ -516,6 +520,7 @@ class DeepseekGenerator:
             self.model_run_config_decode,
             rope_tensors,
             page_tables=page_tables_to_use,
+            profile_decode=self.profile_decode,
         )
         # Gather to host
         logits = ttnn.to_torch(
@@ -626,42 +631,56 @@ class DeepseekGenerator:
             if teacher_forcing is not None:
                 teacher_forcing.reset()
 
-            # Prefill
-            if self.signpost:
-                signpost(header="prefill")
-            profiler.start("inference_prefill")
+            # Prefill (can be skipped for decode-only profiling)
             num_of_users = tokens_batched.shape[0]
-            last_logits = []
-            for user_id in range(num_of_users):
-                if lengths[user_id] == 0:
-                    logger.info(f"Skipping prefill for user_id: {user_id} as prompt length is 0")
-                    last_logits.append(torch.zeros(self.hf_config.vocab_size))
-                    continue
-                logger.info(f"Running prefill for user_id: {user_id}")
-                prompt_len = int(lengths[user_id].item())
-                logger.info(
-                    "Input to the prefill: "
-                    + (
-                        self.tokenizer.decode(
-                            tokens_batched[user_id][:prompt_len].tolist(),
-                            skip_special_tokens=True,
+            if self.profile_decode:
+                logger.info("Skipping prefill (profile_decode=True) - using random tokens for decode profiling")
+                profiler.start("inference_prefill")
+                # Generate random initial tokens for decode
+                vocab_size = int(getattr(self.hf_config, "vocab_size", 32768))
+                last_logits = torch.randn(num_of_users, vocab_size)
+                # Set lengths to 0 so positions start at 0
+                lengths = torch.zeros((num_of_users,), dtype=torch.int32)
+                profiler.end("inference_prefill")
+            else:
+                if self.signpost:
+                    signpost(header="prefill")
+                profiler.start("inference_prefill")
+                last_logits = []
+                for user_id in range(num_of_users):
+                    if lengths[user_id] == 0:
+                        logger.info(f"Skipping prefill for user_id: {user_id} as prompt length is 0")
+                        last_logits.append(torch.zeros(self.hf_config.vocab_size))
+                        continue
+                    logger.info(f"Running prefill for user_id: {user_id}")
+                    prompt_len = int(lengths[user_id].item())
+                    logger.info(
+                        "Input to the prefill: "
+                        + (
+                            self.tokenizer.decode(
+                                tokens_batched[user_id][:prompt_len].tolist(),
+                                skip_special_tokens=True,
+                            )
+                            if self.tokenizer is not None
+                            else str(tokens_batched[user_id][:prompt_len].tolist())
                         )
-                        if self.tokenizer is not None
-                        else str(tokens_batched[user_id][:prompt_len].tolist())
                     )
-                )
-                user_out = self._prefill(tokens_batched[user_id], user_id=user_id)
-                # Use logits at the *actual* last prompt token (not the padded tail).
-                last_logits.append(user_out[0, 0, prompt_len - 1, :])
-                self.ccl.reset_sem_counters()
-            last_logits = torch.stack(last_logits)
-            profiler.end("inference_prefill")
-            if self.signpost:
-                signpost(header="prefill")
+                    user_out = self._prefill(tokens_batched[user_id], user_id=user_id)
+                    # Use logits at the *actual* last prompt token (not the padded tail).
+                    last_logits.append(user_out[0, 0, prompt_len - 1, :])
+                    self.ccl.reset_sem_counters()
+                last_logits = torch.stack(last_logits)
+                profiler.end("inference_prefill")
+                if self.signpost:
+                    signpost(header="prefill")
 
             assert len(last_logits) == num_of_users
 
-            logger.info(f"Finished prefill for all users...")
+            logger.info(
+                f"Finished prefill for all users..."
+                if not self.profile_decode
+                else "Skipped prefill, starting decode..."
+            )
 
             generations: List[List[int]] = [[] for _ in range(num_of_prompts)]
             if max_new_tokens <= 0:
@@ -890,8 +909,12 @@ class DeepseekGenerator:
 
         # 1) Warm-up compile run (no trace) to keep compilation out of capture
         logger.info("Running warm-up decode step (no trace)...")
+        if self.signpost:
+            signpost(header="decode_warmup")
         _ = self._decode_step(init_tokens, positions, batch_size_per_row=batch_size_per_row, page_tables=page_tables)
         ttnn.synchronize_device(self.mesh_device)
+        if self.signpost:
+            signpost(header="decode_warmup")
 
         # 2) Allocate persistent device inputs
         self._trace_tokens = self._tt_from_tokens_step(init_tokens)
@@ -915,6 +938,8 @@ class DeepseekGenerator:
         # 3) Capture decode graph
         self.ccl.reset_sem_counters()
         logger.info("Begin capturing decode trace...")
+        if self.signpost:
+            signpost(header="decode_trace_capture")
         trace_id = ttnn.begin_trace_capture(self.mesh_device, cq_id=0)
 
         # Only capture the rot_mats generation from rot_idxs (all ttnn ops, no from_torch)
@@ -925,8 +950,11 @@ class DeepseekGenerator:
             cfg=self.model_run_config_decode,
             rope_tensors=rope_tensors,
             page_tables=self._trace_page_tables_to_use,
+            profile_decode=self.profile_decode,
         )
         ttnn.end_trace_capture(self.mesh_device, trace_id, cq_id=0)
+        if self.signpost:
+            signpost(header="decode_trace_capture")
         logger.info("Decode trace capture complete.")
         self._trace_id = trace_id
 
@@ -1018,6 +1046,9 @@ class DeepseekGenerator:
             )
             if self.signpost:
                 signpost(header="decode_execute_trace")
+            if self.profile_decode:
+                # trigger the profiler to read the device side data each iteration to not miss any data
+                ttnn.ReadDeviceProfiler(self.mesh_device)
             return logits.squeeze(0).squeeze(0)
 
     def warmup_model_prefill(self, kv_cache, enable_trace, sampling_params) -> None:

--- a/models/demos/deepseek_v3/tt/generator.py
+++ b/models/demos/deepseek_v3/tt/generator.py
@@ -635,13 +635,12 @@ class DeepseekGenerator:
             num_of_users = tokens_batched.shape[0]
             if self.profile_decode:
                 logger.info("Skipping prefill (profile_decode=True) - using random tokens for decode profiling")
-                profiler.start("inference_prefill")
-                # Generate random initial tokens for decode
+                # Generate random starting token IDs directly instead of
+                # allocating a full [num_users, vocab_size] logits tensor.
                 vocab_size = int(getattr(self.hf_config, "vocab_size", 32768))
-                last_logits = torch.randn(num_of_users, vocab_size)
+                next_tokens_override = torch.randint(0, vocab_size, (num_of_users,))
                 # Set lengths to 0 so positions start at 0
                 lengths = torch.zeros((num_of_users,), dtype=torch.int32)
-                profiler.end("inference_prefill")
             else:
                 if self.signpost:
                     signpost(header="prefill")
@@ -674,7 +673,8 @@ class DeepseekGenerator:
                 if self.signpost:
                     signpost(header="prefill")
 
-            assert len(last_logits) == num_of_users
+            if not self.profile_decode:
+                assert len(last_logits) == num_of_users
 
             logger.info(
                 f"Finished prefill for all users..."
@@ -690,8 +690,12 @@ class DeepseekGenerator:
                 if early_print_first_user:
                     logger.info("===== Generation for first user =====")
 
-                # First generated token comes from prefill's last-position logits
-                next_tokens = self._sample_greedy(last_logits)
+                # First generated token comes from prefill's last-position logits,
+                # or from random IDs when profiling decode only.
+                if self.profile_decode:
+                    next_tokens = next_tokens_override
+                else:
+                    next_tokens = self._sample_greedy(last_logits)
                 if teacher_forcing is not None:
                     # Record user-0 prediction for accuracy, but force teacher token for alignment.
                     forced0 = teacher_forcing.collect_predicted_tokens(int(next_tokens[0].item()))
@@ -750,7 +754,7 @@ class DeepseekGenerator:
 
         profiler.end("run")
         # Calculate statistics
-        prefill_time = profiler.get_duration("inference_prefill")
+        prefill_time = profiler.get_duration("inference_prefill") if not self.profile_decode else 0
         decode_steps = max(max_new_tokens - 1, 0)
         decode_times = [profiler.get_duration(f"decode_time_{i}") for i in range(decode_steps)]
 

--- a/models/demos/deepseek_v3/utils/device_perf_utils.py
+++ b/models/demos/deepseek_v3/utils/device_perf_utils.py
@@ -1,0 +1,520 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Device-performance post-processing helpers for the DeepSeek V3 decode demo.
+
+This module consolidates the CSV filtering logic (originally in
+``generated/profiler/process_decode_demo_profile.py``) and the statistics
+merging logic (originally in ``generated/profiler/merge_profile_stats.py``)
+so that both the standalone scripts and the pytest perf test can share the
+same code.
+"""
+
+import csv
+from collections import defaultdict
+
+from loguru import logger
+
+# ============================================================================
+# CSV filtering helpers  (from process_decode_demo_profile.py)
+# ============================================================================
+
+
+def _parse_signposts(rows):
+    """
+    Parse the CSV rows to identify signpost regions.
+
+    Returns a dict with signpost info:
+    - warmup_range: (start_idx, end_idx) of warmup ops (excluding signposts)
+    - trace_capture_range: (start_idx, end_idx) of trace capture ops (to delete)
+    - trace_execution_ranges: list of (start_idx, end_idx) for each trace execution
+    - warmup_structure: dict with embedding, dense, moe, tail ranges within warmup
+    """
+    signpost_info = {
+        "warmup_range": None,
+        "trace_capture_range": None,
+        "trace_execution_ranges": [],
+        "warmup_structure": {
+            "embedding": None,
+            "dense": None,
+            "moe": None,
+            "tail": None,
+        },
+    }
+
+    # Find all signpost positions
+    signpost_positions = []
+    for idx, row in enumerate(rows):
+        if row[1] == "signpost":  # OP TYPE column
+            signpost_positions.append((idx, row[0]))  # (index, signpost_name)
+
+    # Parse the signpost structure
+    warmup_open = None
+    warmup_close = None
+    trace_capture_open = None
+    trace_capture_close = None
+    first_dense_layer_warmup_open = None
+    first_dense_layer_warmup_close = None
+    first_moe_layer_warmup_open = None
+    first_moe_layer_warmup_close = None
+    trace_exec_opens = []
+    trace_exec_closes = []
+
+    in_warmup = False
+
+    for idx, name in signpost_positions:
+        if name == "decode_warmup":
+            if warmup_open is None:
+                warmup_open = idx
+                in_warmup = True
+            else:
+                warmup_close = idx
+                in_warmup = False
+        elif name == "decode_trace_capture":
+            if trace_capture_open is None:
+                trace_capture_open = idx
+            else:
+                trace_capture_close = idx
+        elif name == "decode_execute_trace":
+            if len(trace_exec_opens) == len(trace_exec_closes):
+                trace_exec_opens.append(idx)
+            else:
+                trace_exec_closes.append(idx)
+        elif name == "first_dense_layer" and in_warmup:
+            if first_dense_layer_warmup_open is None:
+                first_dense_layer_warmup_open = idx
+            else:
+                first_dense_layer_warmup_close = idx
+        elif name == "first_moe_layer" and in_warmup:
+            if first_moe_layer_warmup_open is None:
+                first_moe_layer_warmup_open = idx
+            else:
+                first_moe_layer_warmup_close = idx
+
+    # Set ranges (excluding signpost rows themselves)
+    if warmup_open is not None and warmup_close is not None:
+        signpost_info["warmup_range"] = (warmup_open + 1, warmup_close - 1)
+
+        if first_dense_layer_warmup_open is not None:
+            signpost_info["warmup_structure"]["embedding"] = (warmup_open + 1, first_dense_layer_warmup_open - 1)
+
+        if first_dense_layer_warmup_open is not None and first_dense_layer_warmup_close is not None:
+            signpost_info["warmup_structure"]["dense"] = (
+                first_dense_layer_warmup_open + 1,
+                first_dense_layer_warmup_close - 1,
+            )
+
+        if first_moe_layer_warmup_open is not None and first_moe_layer_warmup_close is not None:
+            signpost_info["warmup_structure"]["moe"] = (
+                first_moe_layer_warmup_open + 1,
+                first_moe_layer_warmup_close - 1,
+            )
+
+        if first_moe_layer_warmup_close is not None:
+            signpost_info["warmup_structure"]["tail"] = (first_moe_layer_warmup_close + 1, warmup_close - 1)
+
+    if trace_capture_open is not None and trace_capture_close is not None:
+        signpost_info["trace_capture_range"] = (trace_capture_open, trace_capture_close)
+
+    for i in range(len(trace_exec_closes)):
+        signpost_info["trace_execution_ranges"].append((trace_exec_opens[i] + 1, trace_exec_closes[i] - 1))
+
+    return signpost_info
+
+
+def _get_op_level_for_warmup(idx, warmup_structure):
+    """Determine OP LEVEL for a warmup op based on its index."""
+    if warmup_structure["embedding"] and warmup_structure["embedding"][0] <= idx <= warmup_structure["embedding"][1]:
+        return "Embedding"
+    elif warmup_structure["dense"] and warmup_structure["dense"][0] <= idx <= warmup_structure["dense"][1]:
+        return "Dense Decoder"
+    elif warmup_structure["moe"] and warmup_structure["moe"][0] <= idx <= warmup_structure["moe"][1]:
+        return "MoE Decoder"
+    elif warmup_structure["tail"] and warmup_structure["tail"][0] <= idx <= warmup_structure["tail"][1]:
+        return "Tail"
+    return "Unknown"
+
+
+def _get_op_level_for_trace_exec(local_idx, warmup_structure):
+    """
+    Determine OP LEVEL for a trace execution op based on its local index
+    within the trace.  Uses the same op counts as warmup to determine
+    boundaries.
+    """
+    embedding_count = (
+        warmup_structure["embedding"][1] - warmup_structure["embedding"][0] + 1 if warmup_structure["embedding"] else 0
+    )
+    dense_count = warmup_structure["dense"][1] - warmup_structure["dense"][0] + 1 if warmup_structure["dense"] else 0
+    moe_count = warmup_structure["moe"][1] - warmup_structure["moe"][0] + 1 if warmup_structure["moe"] else 0
+
+    if local_idx < embedding_count:
+        return "Embedding"
+    elif local_idx < embedding_count + dense_count:
+        return "Dense Decoder"
+    elif local_idx < embedding_count + dense_count + moe_count:
+        return "MoE Decoder"
+    else:
+        return "Tail"
+
+
+def _is_ccl_op(attributes):
+    """Check if the op is a CCL op (has 'cluster_axis' in ATTRIBUTES)."""
+    return "cluster_axis" in attributes
+
+
+def _convert_ns_to_us(ns_value):
+    """Convert nanoseconds to microseconds."""
+    if ns_value == "" or ns_value is None:
+        return ""
+    try:
+        return float(ns_value) / 1_000
+    except (ValueError, TypeError):
+        return ""
+
+
+def filter_profile_csv(input_path, output_path):
+    """
+    Filter the raw profiler CSV and write a cleaned-up version.
+
+    The output CSV contains:
+    OP CODE, DEVICE ID, RUN TYPE, OP TYPE, OP LEVEL,
+    OP TO OP LATENCY [us], DEVICE KERNEL DURATION [us]
+
+    Trace-capture rows are removed; ns values are converted to us.
+    """
+    with open(input_path, "r", newline="", encoding="utf-8") as f:
+        reader = csv.reader(f)
+        header = next(reader)
+        rows = list(reader)
+
+    op_code_idx = header.index("OP CODE")
+    op_type_idx = header.index("OP TYPE")
+    device_id_idx = header.index("DEVICE ID")
+    attributes_idx = header.index("ATTRIBUTES")
+    op_to_op_latency_idx = header.index("OP TO OP LATENCY [ns]")
+    device_kernel_duration_idx = header.index("DEVICE KERNEL DURATION [ns]")
+
+    signpost_info = _parse_signposts(rows)
+
+    logger.info(f"Warmup range: {signpost_info['warmup_range']}")
+    logger.info(
+        f"Warmup structure: embedding={signpost_info['warmup_structure']['embedding']}, "
+        f"dense={signpost_info['warmup_structure']['dense']}, "
+        f"moe={signpost_info['warmup_structure']['moe']}, "
+        f"tail={signpost_info['warmup_structure']['tail']}"
+    )
+    logger.info(f"Trace capture range (to delete): {signpost_info['trace_capture_range']}")
+    logger.info(f"Number of trace executions: {len(signpost_info['trace_execution_ranges'])}")
+
+    # Op counts
+    ws = signpost_info["warmup_structure"]
+    embedding_count = ws["embedding"][1] - ws["embedding"][0] + 1 if ws["embedding"] else 0
+    dense_count = ws["dense"][1] - ws["dense"][0] + 1 if ws["dense"] else 0
+    moe_count = ws["moe"][1] - ws["moe"][0] + 1 if ws["moe"] else 0
+    tail_count = ws["tail"][1] - ws["tail"][0] + 1 if ws["tail"] else 0
+
+    logger.info(
+        f"Op counts per run: Embedding={embedding_count}, Dense={dense_count}, "
+        f"MoE={moe_count}, Tail={tail_count}, Total={embedding_count + dense_count + moe_count + tail_count}"
+    )
+
+    output_rows = []
+    output_header = [
+        "OP CODE",
+        "DEVICE ID",
+        "RUN TYPE",
+        "OP TYPE",
+        "OP LEVEL",
+        "OP TO OP LATENCY [us]",
+        "DEVICE KERNEL DURATION [us]",
+    ]
+
+    # Indices to skip (signposts + trace capture)
+    skip_indices = set()
+    for idx, row in enumerate(rows):
+        if row[op_type_idx] == "signpost":
+            skip_indices.add(idx)
+    if signpost_info["trace_capture_range"]:
+        tc_start, tc_end = signpost_info["trace_capture_range"]
+        for idx in range(tc_start, tc_end + 1):
+            skip_indices.add(idx)
+
+    # Warmup ops
+    if signpost_info["warmup_range"]:
+        warmup_start, warmup_end = signpost_info["warmup_range"]
+        for idx in range(warmup_start, warmup_end + 1):
+            if idx in skip_indices:
+                continue
+            row = rows[idx]
+            output_rows.append(
+                [
+                    row[op_code_idx],
+                    row[device_id_idx],
+                    "warmup",
+                    "CCL" if _is_ccl_op(row[attributes_idx]) else "Non CCL",
+                    _get_op_level_for_warmup(idx, signpost_info["warmup_structure"]),
+                    _convert_ns_to_us(row[op_to_op_latency_idx]),
+                    _convert_ns_to_us(row[device_kernel_duration_idx]),
+                ]
+            )
+
+    # Trace execution ops
+    for trace_idx, (trace_start, trace_end) in enumerate(signpost_info["trace_execution_ranges"]):
+        local_idx = 0
+        for idx in range(trace_start, trace_end + 1):
+            if idx in skip_indices:
+                continue
+            row = rows[idx]
+            output_rows.append(
+                [
+                    row[op_code_idx],
+                    row[device_id_idx],
+                    f"trace_execution_{trace_idx}",
+                    "CCL" if _is_ccl_op(row[attributes_idx]) else "Non CCL",
+                    _get_op_level_for_trace_exec(local_idx, signpost_info["warmup_structure"]),
+                    _convert_ns_to_us(row[op_to_op_latency_idx]),
+                    _convert_ns_to_us(row[device_kernel_duration_idx]),
+                ]
+            )
+            local_idx += 1
+
+    with open(output_path, "w", newline="", encoding="utf-8") as f:
+        writer = csv.writer(f)
+        writer.writerow(output_header)
+        writer.writerows(output_rows)
+
+    logger.info(f"Filtered CSV written to: {output_path}  ({len(output_rows)} rows)")
+
+
+# ============================================================================
+# Statistics merging helpers  (from merge_profile_stats.py)
+# ============================================================================
+
+
+def _read_filtered_csv(input_path):
+    """Read the filtered CSV and return rows as list of dicts."""
+    with open(input_path, "r", newline="", encoding="utf-8") as f:
+        reader = csv.DictReader(f)
+        return list(reader)
+
+
+def _group_rows_by_run_and_device(rows):
+    """Group rows by (run_type, device_id) → list of rows (in order)."""
+    groups = defaultdict(list)
+    for row in rows:
+        key = (row["RUN TYPE"], row["DEVICE ID"])
+        groups[key].append(row)
+    return groups
+
+
+def _get_warmup_reference(rows):
+    """
+    Get the reference op sequence from warmup device 0.
+    Returns list of dicts with op_code, op_level, op_type.
+    """
+    reference = []
+    for row in rows:
+        if row["RUN TYPE"] == "warmup" and row["DEVICE ID"] == "0":
+            reference.append(
+                {
+                    "op_code": row["OP CODE"],
+                    "op_level": row["OP LEVEL"],
+                    "op_type": row["OP TYPE"],
+                }
+            )
+    return reference
+
+
+def _get_num_trace_executions(rows):
+    """Return the count of unique ``trace_execution_N`` run types."""
+    trace_indices = set()
+    for row in rows:
+        run_type = row["RUN TYPE"]
+        if run_type.startswith("trace_execution_"):
+            try:
+                trace_indices.add(int(run_type.split("_")[-1]))
+            except ValueError:
+                pass
+    return len(trace_indices)
+
+
+def _calculate_stats(rows, reference, skip_traces=1):
+    """
+    Calculate per-op kernel duration and op-to-op latency.
+
+    Rules
+    -----
+    Kernel Duration:
+      - Non-CCL ops → warmup only, max across all devices.
+      - CCL ops → trace executions (skip first *skip_traces*), average across
+        devices then average across iterations.
+
+    Op-to-Op Latency:
+      - trace executions only (skip first *skip_traces*), device 0, average
+        across iterations.
+    """
+    grouped = _group_rows_by_run_and_device(rows)
+
+    device_ids = sorted(
+        {row["DEVICE ID"] for row in rows if row["DEVICE ID"]},
+        key=lambda x: int(x) if x.isdigit() else 0,
+    )
+    num_trace_executions = _get_num_trace_executions(rows)
+    num_ops = len(reference)
+
+    logger.info(
+        f"Stats: {num_ops} ops, {len(device_ids)} devices, "
+        f"{num_trace_executions} trace executions (skipping first {skip_traces})"
+    )
+
+    for key, group_rows in grouped.items():
+        if len(group_rows) != num_ops:
+            logger.warning(f"{key} has {len(group_rows)} ops, expected {num_ops}")
+
+    results = []
+    for op_idx, op_info in enumerate(reference):
+        op_code = op_info["op_code"]
+        op_level = op_info["op_level"]
+        op_type = op_info["op_type"]
+
+        # --- kernel duration ---
+        kernel_duration = None
+        if op_type == "Non CCL":
+            durations = []
+            for device_id in device_ids:
+                key = ("warmup", device_id)
+                if key in grouped and op_idx < len(grouped[key]):
+                    dur = grouped[key][op_idx]["DEVICE KERNEL DURATION [us]"]
+                    if dur != "":
+                        try:
+                            durations.append(float(dur))
+                        except ValueError:
+                            pass
+            if durations:
+                kernel_duration = max(durations)
+        else:  # CCL
+            iteration_averages = []
+            for trace_idx in range(skip_traces, num_trace_executions):
+                run_type = f"trace_execution_{trace_idx}"
+                durations = []
+                for device_id in device_ids:
+                    key = (run_type, device_id)
+                    if key in grouped and op_idx < len(grouped[key]):
+                        dur = grouped[key][op_idx]["DEVICE KERNEL DURATION [us]"]
+                        if dur != "":
+                            try:
+                                durations.append(float(dur))
+                            except ValueError:
+                                pass
+                if durations:
+                    iteration_averages.append(sum(durations) / len(durations))
+            if iteration_averages:
+                kernel_duration = sum(iteration_averages) / len(iteration_averages)
+
+        # --- op-to-op latency (device 0 only) ---
+        latencies = []
+        for trace_idx in range(skip_traces, num_trace_executions):
+            run_type = f"trace_execution_{trace_idx}"
+            key = (run_type, "0")
+            if key in grouped and op_idx < len(grouped[key]):
+                lat = grouped[key][op_idx]["OP TO OP LATENCY [us]"]
+                if lat != "":
+                    try:
+                        latencies.append(float(lat))
+                    except ValueError:
+                        pass
+        op_to_op_latency = (sum(latencies) / len(latencies)) if latencies else None
+
+        results.append(
+            {
+                "OP_CODE": op_code,
+                "OP_LEVEL": op_level,
+                "OP_TYPE": op_type,
+                "AVG KERNEL DURATION (us)": kernel_duration if kernel_duration is not None else "",
+                "AVG Op-to-Op LATENCY (us)": op_to_op_latency if op_to_op_latency is not None else "",
+            }
+        )
+
+    return results
+
+
+def _reorder_by_level(results):
+    """Reorder results: Embedding → Dense Decoder → MoE Decoder → Tail."""
+    level_order = ["Embedding", "Dense Decoder", "MoE Decoder", "Tail"]
+    by_level = defaultdict(list)
+    for r in results:
+        by_level[r["OP_LEVEL"]].append(r)
+    ordered = []
+    for level in level_order:
+        ordered.extend(by_level[level])
+    return ordered
+
+
+def process_profile_stats(filtered_csv_path, merged_csv_path):
+    """
+    Read the *filtered* CSV, compute per-op statistics, write the merged CSV,
+    and return the ordered per-op results list.
+
+    The returned list can be passed to :func:`compute_e2e_time`.
+    """
+    rows = _read_filtered_csv(filtered_csv_path)
+    reference = _get_warmup_reference(rows)
+
+    level_counts = defaultdict(int)
+    for op_info in reference:
+        level_counts[op_info["op_level"]] += 1
+    logger.info(
+        "Ops per level (warmup): "
+        + ", ".join(f"{lvl}={level_counts[lvl]}" for lvl in ["Embedding", "Dense Decoder", "MoE Decoder", "Tail"])
+    )
+
+    results = _calculate_stats(rows, reference)
+    results = _reorder_by_level(results)
+
+    # Write merged CSV
+    output_header = ["OP_CODE", "OP_LEVEL", "OP_TYPE", "AVG KERNEL DURATION (us)", "AVG Op-to-Op LATENCY (us)"]
+    with open(merged_csv_path, "w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(f, fieldnames=output_header)
+        writer.writeheader()
+        writer.writerows(results)
+    logger.info(f"Merged stats CSV written to: {merged_csv_path}  ({len(results)} rows)")
+
+    return results
+
+
+# ============================================================================
+# E2E time computation
+# ============================================================================
+
+
+def compute_e2e_time(results):
+    """
+    Compute 2-Layer Model E2E Time from the per-op statistics list.
+
+    Parameters
+    ----------
+    results : list[dict]
+        Output of :func:`process_profile_stats`.
+
+    Returns
+    -------
+    dict
+        Keys: ``total_kernel_duration_us``, ``total_op_to_op_latency_us``,
+        ``e2e_time_us``.
+    """
+    total_kernel_duration = 0.0
+    total_op_to_op_latency = 0.0
+
+    for i, r in enumerate(results):
+        if r["AVG KERNEL DURATION (us)"] != "":
+            total_kernel_duration += float(r["AVG KERNEL DURATION (us)"])
+        # Skip the first op's latency (meaningless)
+        if i > 0 and r["AVG Op-to-Op LATENCY (us)"] != "":
+            total_op_to_op_latency += float(r["AVG Op-to-Op LATENCY (us)"])
+
+    return {
+        "total_kernel_duration_us": total_kernel_duration,
+        "total_op_to_op_latency_us": total_op_to_op_latency,
+        "e2e_time_us": total_kernel_duration + total_op_to_op_latency,
+    }

--- a/models/demos/deepseek_v3/utils/device_perf_utils.py
+++ b/models/demos/deepseek_v3/utils/device_perf_utils.py
@@ -21,9 +21,18 @@ from loguru import logger
 # ============================================================================
 
 
-def _parse_signposts(rows):
+def _parse_signposts(rows, *, op_code_idx=0, op_type_idx=1):
     """
     Parse the CSV rows to identify signpost regions.
+
+    Parameters
+    ----------
+    rows : list[list[str]]
+        CSV data rows (without the header).
+    op_code_idx : int
+        Column index for the OP CODE field (signpost name).
+    op_type_idx : int
+        Column index for the OP TYPE field (checked for ``"signpost"``).
 
     Returns a dict with signpost info:
     - warmup_range: (start_idx, end_idx) of warmup ops (excluding signposts)
@@ -46,8 +55,8 @@ def _parse_signposts(rows):
     # Find all signpost positions
     signpost_positions = []
     for idx, row in enumerate(rows):
-        if row[1] == "signpost":  # OP TYPE column
-            signpost_positions.append((idx, row[0]))  # (index, signpost_name)
+        if row[op_type_idx] == "signpost":
+            signpost_positions.append((idx, row[op_code_idx]))
 
     # Parse the signpost structure
     warmup_open = None
@@ -195,7 +204,7 @@ def filter_profile_csv(input_path, output_path):
     op_to_op_latency_idx = header.index("OP TO OP LATENCY [ns]")
     device_kernel_duration_idx = header.index("DEVICE KERNEL DURATION [ns]")
 
-    signpost_info = _parse_signposts(rows)
+    signpost_info = _parse_signposts(rows, op_code_idx=op_code_idx, op_type_idx=op_type_idx)
 
     logger.info(f"Warmup range: {signpost_info['warmup_range']}")
     logger.info(
@@ -335,7 +344,8 @@ def _get_num_trace_executions(rows):
             try:
                 trace_indices.add(int(run_type.split("_")[-1]))
             except ValueError:
-                pass
+                # Ignore malformed trace_execution labels but log for diagnostics.
+                logger.debug("Ignoring malformed RUN TYPE for trace execution: {!r}", run_type)
     return len(trace_indices)
 
 
@@ -390,7 +400,10 @@ def _calculate_stats(rows, reference, skip_traces=1):
                         try:
                             durations.append(float(dur))
                         except ValueError:
-                            pass
+                            logger.warning(
+                                f"Non-numeric kernel duration '{dur}' for op_idx={op_idx}, "
+                                f"device_id={device_id} in warmup; skipping this value."
+                            )
             if durations:
                 kernel_duration = max(durations)
         else:  # CCL
@@ -406,7 +419,10 @@ def _calculate_stats(rows, reference, skip_traces=1):
                             try:
                                 durations.append(float(dur))
                             except ValueError:
-                                pass
+                                logger.warning(
+                                    f"Non-numeric kernel duration '{dur}' for op_idx={op_idx}, "
+                                    f"device_id={device_id}, run_type={run_type}; skipping this value."
+                                )
                 if durations:
                     iteration_averages.append(sum(durations) / len(durations))
             if iteration_averages:
@@ -423,7 +439,10 @@ def _calculate_stats(rows, reference, skip_traces=1):
                     try:
                         latencies.append(float(lat))
                     except ValueError:
-                        pass
+                        logger.warning(
+                            f"Non-numeric op-to-op latency '{lat}' for op_idx={op_idx}, "
+                            f"run_type={run_type}; skipping this value."
+                        )
         op_to_op_latency = (sum(latencies) / len(latencies)) if latencies else None
 
         results.append(
@@ -440,14 +459,21 @@ def _calculate_stats(rows, reference, skip_traces=1):
 
 
 def _reorder_by_level(results):
-    """Reorder results: Embedding → Dense Decoder → MoE Decoder → Tail."""
+    """Reorder results: Embedding → Dense Decoder → MoE Decoder → Tail.
+
+    Any rows whose OP_LEVEL is not one of the known levels are preserved and
+    appended after the known levels, in their original relative order.
+    """
     level_order = ["Embedding", "Dense Decoder", "MoE Decoder", "Tail"]
     by_level = defaultdict(list)
     for r in results:
         by_level[r["OP_LEVEL"]].append(r)
     ordered = []
     for level in level_order:
-        ordered.extend(by_level[level])
+        ordered.extend(by_level.pop(level, []))
+    # Append any remaining levels (e.g., "Unknown") in insertion order.
+    for remaining_level in by_level:
+        ordered.extend(by_level[remaining_level])
     return ordered
 
 

--- a/tests/pipeline_reorg/galaxy_perf_tests.yaml
+++ b/tests/pipeline_reorg/galaxy_perf_tests.yaml
@@ -91,6 +91,17 @@
   save-perf-data: true
   model-type: QwenImage
 
+- name: Galaxy DeepSeek V3 decode perf tests
+  cmd: export MESH_DEVICE=TG && uv pip install -r models/demos/deepseek_v3/reference/deepseek/requirements.txt && pytest models/demos/deepseek_v3/demo/test_decode_demo_perf.py --timeout=1200
+  model: deepseek_v3
+  sku: wh_galaxy
+  owner_id: U03HY7MK4BT
+  team: models
+  timeout: 45
+  arch: wormhole_b0
+  save-perf-data: true
+  model-type: deepseek_v3
+
 - name: Galaxy Sentence Bert tests
   cmd: |
     pytest --timeout 600 models/demos/tg/sentence_bert/tests/device_perf_test.py

--- a/tests/pipeline_reorg/galaxy_perf_tests.yaml
+++ b/tests/pipeline_reorg/galaxy_perf_tests.yaml
@@ -97,7 +97,7 @@
   sku: wh_galaxy
   owner_id: U03HY7MK4BT
   team: models
-  timeout: 45
+  timeout: 20
   arch: wormhole_b0
   save-perf-data: true
   model-type: deepseek_v3


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/36977)

### Problem description
Provide context for the problem.

### What's changed
Describe the approach used to solve the problem.
Summarize the changes made and its impact.

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=kp/add_decode_demo_profiler)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:kp/add_decode_demo_profiler)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=kp/add_decode_demo_profiler)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:kp/add_decode_demo_profiler)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=kp/add_decode_demo_profiler)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:kp/add_decode_demo_profiler)
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=kp/add_decode_demo_profiler)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:kp/add_decode_demo_profiler)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=kp/add_decode_demo_profiler)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:kp/add_decode_demo_profiler)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=kp/add_decode_demo_profiler)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:kp/add_decode_demo_profiler)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
