### PR TITLE
[skip ci] Remove Fabric Sanity Benchmark from BH post-commit tests

### DIFF
--- a/.github/workflows/blackhole-multi-card-post-commit-tests-impl.yaml
+++ b/.github/workflows/blackhole-multi-card-post-commit-tests-impl.yaml
@@ -35,8 +35,6 @@ jobs:
             cmd: pytest tests/ttnn/unit_tests/operations/ccl/blackhole_CI/box/all_post_commit
           - name: Socket tests
             cmd: ./build/test/tt_metal/distributed/distributed_unit_tests --gtest_filter="*HDSocketFixture*"
-          - name: Fabric Sanity Benchmark
-            cmd: ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric --test_config ${TT_METAL_HOME}/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_ubench_at_least_2x2_mesh.yaml
     name: ${{ inputs.arch }} ${{ inputs.runner-label }} ${{ matrix.test-group.name }}
     runs-on:
       - in-service


### PR DESCRIPTION
### Ticket
None

### Problem description
Test was already moved to BH nightly with https://github.com/tenstorrent/tt-metal/commit/b26dc3b04bb735c58d1c834f7df37f8adb66e00a but was added back (likely due to merge conflict resolution) in https://github.com/tenstorrent/tt-metal/commit/ea3d8d93c6981af904a3ffe399831cab90e6584f

### What's changed
Remove test that's been moved to BH nightly

