### PR TITLE
TT-Train: CMakeLists.txt: TT_METAL_HOME determination fix, env usage removal

### DIFF
--- a/tt-train/sources/ttml/CMakeLists.txt
+++ b/tt-train/sources/ttml/CMakeLists.txt
@@ -336,8 +336,8 @@ if(NOT TARGET TT::Metalium)
             message(STATUS "Using TT_METAL_HOME from environment: ${TT_METAL_HOME}")
         else()
             # Infer tt-metal repository layout from directory structure (tt-metal/tt-train)
-            # From tt-train/sources/ttml/, go up THREE levels to reach the repository root
-            set(TT_METAL_HOME "${CMAKE_CURRENT_SOURCE_DIR}/../../..")
+            # From tt-train/, go up ONE level to reach the repository root
+            set(TT_METAL_HOME "${CMAKE_SOURCE_DIR}/..")
             if(EXISTS "${TT_METAL_HOME}/tt_metal/CMakeLists.txt")
                 message(STATUS "Inferred tt-metal location: ${TT_METAL_HOME}")
             else()
@@ -360,9 +360,9 @@ if(NOT TARGET TT::Metalium)
             "${TT_METAL_HOME}/tt_metal/hw/inc"
             "${TT_METAL_HOME}/tt_stl"
             # TTNN
-            "$ENV{TT_METAL_HOME}/ttnn"
-            "$ENV{TT_METAL_HOME}/ttnn/api"
-            "$ENV{TT_METAL_HOME}/ttnn/cpp"
+            "${TT_METAL_HOME}/ttnn"
+            "${TT_METAL_HOME}/ttnn/api"
+            "${TT_METAL_HOME}/ttnn/cpp"
             "${reflect_SOURCE_DIR}"
         )
 


### PR DESCRIPTION
### Ticket
NA

### Problem description
TTML/TT-Train builds were breaking in certain scenarios.  These changes should fix the build in these scenarios (standalone, pip install).

### What's changed
Update CMakeLists to not use $ENV for TT_METAL_HOME in source list.
Use CMAKE_SOURCE_DIR/.. instead of CMAKE_CURRENT_SOURCE_DIR/../../.. to determine parent dir of tt-train.

This should fix standalone and uv pip installations of tt-train.

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=athompson/ttml_cmake_touchup)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:athompson/ttml_cmake_touchup)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=athompson/ttml_cmake_touchup)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:athompson/ttml_cmake_touchup)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=athompson/ttml_cmake_touchup)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:athompson/ttml_cmake_touchup)
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=athompson/ttml_cmake_touchup)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:athompson/ttml_cmake_touchup)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=athompson/ttml_cmake_touchup)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:athompson/ttml_cmake_touchup)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=athompson/ttml_cmake_touchup)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:athompson/ttml_cmake_touchup)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
