### PR TITLE
Fused lerp operation & lerp_tile LLK

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/eltwise/test_lerp.py
+++ b/tests/ttnn/nightly/unit_tests/operations/eltwise/test_lerp.py
@@ -9,10 +9,10 @@ import torch
 import ttnn
 
 from math import pi
-from tests.ttnn.utils_for_testing import assert_with_pcc
+from tests.ttnn.utils_for_testing import assert_with_ulp
 
 
-def run_lerp_test_float(device, h, w, low, high, end, weight, ttnn_function, torch_function, pcc=0.9999):
+def run_lerp_test_float(device, h, w, low, high, end, weight, ttnn_function, torch_function, ulp_threshold=1):
     torch_input_tensor_a = torch.linspace(low, high, steps=h * w, dtype=torch.bfloat16).reshape((h, w))
     torch_input_tensor_b = torch.full((h, w), end, dtype=torch.bfloat16)
 
@@ -26,7 +26,7 @@ def run_lerp_test_float(device, h, w, low, high, end, weight, ttnn_function, tor
     output_tensor = ttnn.from_device(output_tensor)
     output_tensor = ttnn.to_torch(output_tensor)
 
-    assert_with_pcc(torch_output_tensor, output_tensor, pcc)
+    assert_with_ulp(torch_output_tensor, output_tensor, ulp_threshold=ulp_threshold)
 
 
 @pytest.mark.parametrize("h", [64])
@@ -40,26 +40,52 @@ def test_lerp_float_a(device, h, w, weight):
 @pytest.mark.parametrize("w", [128])
 @pytest.mark.parametrize("weight", [0.75])
 def test_lerp_float_b(device, h, w, weight):
-    run_lerp_test_float(device, h, w, 1, 80, 99, weight, ttnn.lerp, torch.lerp, pcc=0.999)
+    run_lerp_test_float(device, h, w, 1, 80, 99, weight, ttnn.lerp, torch.lerp, ulp_threshold=2)
 
 
-def run_lerp_test_tensor(device, h, w, low, high, end, weight, ttnn_function, torch_function, pcc=0.9999):
+def run_lerp_test_tensor(
+    device,
+    h,
+    w,
+    low,
+    high,
+    end,
+    weight,
+    ttnn_function,
+    torch_function,
+    ulp_threshold=1,
+    output_dtype=None,
+):
     torch_input_tensor_a = torch.linspace(low, high, steps=h * w, dtype=torch.bfloat16).reshape((h, w))
     torch_input_tensor_b = torch.full((h, w), end, dtype=torch.bfloat16)
     torch_weight = torch.full((h, w), weight, dtype=torch.bfloat16)
-
-    torch_output_tensor = torch_function(torch_input_tensor_a, torch_input_tensor_b, torch_weight)
 
     input_tensor_a = ttnn.from_torch(torch_input_tensor_a, layout=ttnn.TILE_LAYOUT, device=device)
     input_tensor_b = ttnn.from_torch(torch_input_tensor_b, layout=ttnn.TILE_LAYOUT, device=device)
     input_weight = ttnn.from_torch(torch_weight, layout=ttnn.TILE_LAYOUT, device=device)
 
-    output_tensor = ttnn_function(input_tensor_a, input_tensor_b, input_weight)
+    if output_dtype is None:
+        # Output dtype = input dtype (default)
+        torch_output_tensor = torch_function(torch_input_tensor_a, torch_input_tensor_b, torch_weight)
+        output_tensor = ttnn_function(input_tensor_a, input_tensor_b, input_weight)
+    else:
+        # Preallocated output with given dtype; reference in same dtype
+        torch_output_dtype = getattr(torch, output_dtype)
+        ttnn_output_dtype = getattr(ttnn, output_dtype)
+
+        torch_output_tensor = torch_function(
+            torch_input_tensor_a.to(torch_output_dtype),
+            torch_input_tensor_b.to(torch_output_dtype),
+            torch_weight.to(torch_output_dtype),
+        )
+        output_tensor = ttnn.empty((h, w), dtype=ttnn_output_dtype, layout=ttnn.TILE_LAYOUT, device=device)
+        ttnn_function(input_tensor_a, input_tensor_b, input_weight, output_tensor=output_tensor)
+
     output_tensor = ttnn.to_layout(output_tensor, ttnn.ROW_MAJOR_LAYOUT)
     output_tensor = ttnn.from_device(output_tensor)
     output_tensor = ttnn.to_torch(output_tensor)
 
-    assert_with_pcc(torch_output_tensor, output_tensor, pcc)
+    assert_with_ulp(torch_output_tensor, output_tensor, ulp_threshold=ulp_threshold)
 
 
 @pytest.mark.parametrize("h", [64])
@@ -73,4 +99,15 @@ def test_lerp_tensor_a(device, h, w, weight):
 @pytest.mark.parametrize("w", [128])
 @pytest.mark.parametrize("weight", [0.75])
 def test_lerp_tensor_b(device, h, w, weight):
-    run_lerp_test_tensor(device, h, w, 1, 80, 99, weight, ttnn.lerp, torch.lerp, pcc=0.999)
+    run_lerp_test_tensor(device, h, w, 1, 80, 99, weight, ttnn.lerp, torch.lerp, ulp_threshold=2)
+
+
+@pytest.mark.parametrize("h", [64])
+@pytest.mark.parametrize("w", [128])
+@pytest.mark.parametrize("weight", [0.75])
+def test_lerp_bf16_inputs_fp32_preallocated_output(device, h, w, weight):
+    """Lerp with bfloat16 inputs (two tensors + scalar weight) and preallocated float32 output.
+    Checks that output is correct within 2 ULP for float32."""
+    run_lerp_test_tensor(
+        device, h, w, 1, 80, 99, weight, ttnn.lerp, torch.lerp, ulp_threshold=2, output_dtype="float32"
+    )

--- a/tests/ttnn/nightly/unit_tests/operations/eltwise/test_lerp.py
+++ b/tests/ttnn/nightly/unit_tests/operations/eltwise/test_lerp.py
@@ -20,7 +20,7 @@ def run_lerp_test(
     end,
     weight,
     ttnn_function,
-    scalar_weight=False,
+    use_scalar_weight=False,
     ulp_threshold=1,
     input_dtype="bfloat16",
     output_dtype=None,
@@ -32,7 +32,7 @@ def run_lerp_test(
 
     golden_function = ttnn.get_golden_function(ttnn_function)
 
-    if scalar_weight:
+    if use_scalar_weight:
         torch_weight = weight
         ttnn_weight = weight
     else:
@@ -70,7 +70,7 @@ def run_lerp_test(
 @pytest.mark.parametrize("weight", [0.5])
 @pytest.mark.parametrize("input_dtype", ["bfloat16", "float32"])
 def test_lerp_float_a(device, h, w, weight, input_dtype):
-    run_lerp_test(device, h, w, 0, 90, 100, weight, ttnn.lerp, scalar_weight=True, input_dtype=input_dtype)
+    run_lerp_test(device, h, w, 0, 90, 100, weight, ttnn.lerp, use_scalar_weight=True, input_dtype=input_dtype)
 
 
 @pytest.mark.parametrize("h", [64])
@@ -79,7 +79,7 @@ def test_lerp_float_a(device, h, w, weight, input_dtype):
 @pytest.mark.parametrize("input_dtype", ["bfloat16", "float32"])
 def test_lerp_float_b(device, h, w, weight, input_dtype):
     run_lerp_test(
-        device, h, w, 1, 80, 99, weight, ttnn.lerp, scalar_weight=True, ulp_threshold=2, input_dtype=input_dtype
+        device, h, w, 1, 80, 99, weight, ttnn.lerp, use_scalar_weight=True, ulp_threshold=2, input_dtype=input_dtype
     )
 
 
@@ -88,7 +88,7 @@ def test_lerp_float_b(device, h, w, weight, input_dtype):
 @pytest.mark.parametrize("weight", [0.5])
 @pytest.mark.parametrize("input_dtype", ["bfloat16", "float32"])
 def test_lerp_tensor_a(device, h, w, weight, input_dtype):
-    run_lerp_test(device, h, w, 0, 90, 100, weight, ttnn.lerp, scalar_weight=False, input_dtype=input_dtype)
+    run_lerp_test(device, h, w, 0, 90, 100, weight, ttnn.lerp, use_scalar_weight=False, input_dtype=input_dtype)
 
 
 @pytest.mark.parametrize("h", [64])
@@ -97,7 +97,7 @@ def test_lerp_tensor_a(device, h, w, weight, input_dtype):
 @pytest.mark.parametrize("input_dtype", ["bfloat16", "float32"])
 def test_lerp_tensor_b(device, h, w, weight, input_dtype):
     run_lerp_test(
-        device, h, w, 1, 80, 99, weight, ttnn.lerp, scalar_weight=False, ulp_threshold=2, input_dtype=input_dtype
+        device, h, w, 1, 80, 99, weight, ttnn.lerp, use_scalar_weight=False, ulp_threshold=2, input_dtype=input_dtype
     )
 
 
@@ -117,7 +117,7 @@ def test_lerp_fp32_preallocated_output(device, h, w, weight, input_dtype):
         99,
         weight,
         ttnn.lerp,
-        scalar_weight=True,
+        use_scalar_weight=True,
         ulp_threshold=1,
         output_dtype="float32",
         input_dtype=input_dtype,

--- a/tests/ttnn/nightly/unit_tests/operations/eltwise/test_lerp.py
+++ b/tests/ttnn/nightly/unit_tests/operations/eltwise/test_lerp.py
@@ -2,30 +2,41 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
-import csv
-import os
-
 import pytest
 
 import torch
 
 import ttnn
 
-from math import pi
-from models.common.utility_functions import comp_ulp
 from tests.ttnn.utils_for_testing import assert_with_ulp
 
 
-def run_lerp_test_scalar_weight(device, h, w, low, high, end, weight, ttnn_function, torch_function, ulp_threshold=1):
+def run_lerp_test_scalar_weight(
+    device, h, w, low, high, end, weight, ttnn_function, torch_function, ulp_threshold=1, output_dtype=None
+):
     torch_input_tensor_a = torch.linspace(low, high, steps=h * w, dtype=torch.bfloat16).reshape((h, w))
     torch_input_tensor_b = torch.full((h, w), end, dtype=torch.bfloat16)
-
-    torch_output_tensor = torch_function(torch_input_tensor_a, torch_input_tensor_b, weight)
 
     input_tensor_a = ttnn.from_torch(torch_input_tensor_a, layout=ttnn.TILE_LAYOUT, device=device)
     input_tensor_b = ttnn.from_torch(torch_input_tensor_b, layout=ttnn.TILE_LAYOUT, device=device)
 
-    output_tensor = ttnn_function(input_tensor_a, input_tensor_b, weight)
+    if output_dtype is None:
+        # Output dtype = input dtype (default)
+        torch_output_tensor = torch_function(torch_input_tensor_a, torch_input_tensor_b, weight)
+        output_tensor = ttnn_function(input_tensor_a, input_tensor_b, weight)
+    else:
+        # Preallocated output with given dtype; reference in same dtype
+        torch_output_dtype = getattr(torch, output_dtype)
+        ttnn_output_dtype = getattr(ttnn, output_dtype)
+
+        torch_output_tensor = torch_function(
+            torch_input_tensor_a.to(torch_output_dtype),
+            torch_input_tensor_b.to(torch_output_dtype),
+            weight,
+        )
+        output_tensor = ttnn.empty((h, w), dtype=ttnn_output_dtype, layout=ttnn.TILE_LAYOUT, device=device)
+        ttnn_function(input_tensor_a, input_tensor_b, weight, output_tensor=output_tensor)
+
     output_tensor = ttnn.to_torch(output_tensor)
 
     assert_with_ulp(torch_output_tensor, output_tensor, ulp_threshold=ulp_threshold)
@@ -107,7 +118,7 @@ def test_lerp_tensor_b(device, h, w, weight):
 @pytest.mark.parametrize("weight", [0.75])
 def test_lerp_bf16_inputs_fp32_preallocated_output(device, h, w, weight):
     """Lerp with bfloat16 inputs (two tensors + scalar weight) and preallocated float32 output.
-    Checks that output is correct within 2 ULP for float32."""
-    run_lerp_test_tensor(
+    Checks that output is correct within 1 ULP for float32."""
+    run_lerp_test_scalar_weight(
         device, h, w, 1, 80, 99, weight, ttnn.lerp, torch.lerp, ulp_threshold=1, output_dtype="float32"
     )

--- a/tests/ttnn/nightly/unit_tests/operations/eltwise/test_lerp.py
+++ b/tests/ttnn/nightly/unit_tests/operations/eltwise/test_lerp.py
@@ -12,10 +12,12 @@ from tests.ttnn.utils_for_testing import assert_with_ulp
 
 
 def run_lerp_test_scalar_weight(
-    device, h, w, low, high, end, weight, ttnn_function, ulp_threshold=1, output_dtype=None
+    device, h, w, low, high, end, weight, ttnn_function, ulp_threshold=1, input_dtype="bfloat16", output_dtype=None
 ):
-    torch_input_tensor_a = torch.linspace(low, high, steps=h * w, dtype=torch.bfloat16).reshape((h, w))
-    torch_input_tensor_b = torch.full((h, w), end, dtype=torch.bfloat16)
+    torch_input_dtype = getattr(torch, input_dtype)
+
+    torch_input_tensor_a = torch.linspace(low, high, steps=h * w, dtype=torch_input_dtype).reshape((h, w))
+    torch_input_tensor_b = torch.full((h, w), end, dtype=torch_input_dtype)
 
     golden_function = ttnn.get_golden_function(ttnn_function)
 
@@ -55,11 +57,13 @@ def run_lerp_test_tensor(
     weight,
     ttnn_function,
     ulp_threshold=1,
+    input_dtype="bfloat16",
     output_dtype=None,
 ):
-    torch_input_tensor_a = torch.linspace(low, high, steps=h * w, dtype=torch.bfloat16).reshape((h, w))
-    torch_input_tensor_b = torch.full((h, w), end, dtype=torch.bfloat16)
-    torch_weight = torch.full((h, w), weight, dtype=torch.bfloat16)
+    torch_input_dtype = getattr(torch, input_dtype)
+    torch_input_tensor_a = torch.linspace(low, high, steps=h * w, dtype=torch_input_dtype).reshape((h, w))
+    torch_input_tensor_b = torch.full((h, w), end, dtype=torch_input_dtype)
+    torch_weight = torch.full((h, w), weight, dtype=torch_input_dtype)
 
     golden_function = ttnn.get_golden_function(ttnn_function)
 
@@ -94,35 +98,42 @@ def run_lerp_test_tensor(
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
 @pytest.mark.parametrize("weight", [0.5])
-def test_lerp_float_a(device, h, w, weight):
-    run_lerp_test_scalar_weight(device, h, w, 0, 90, 100, weight, ttnn.lerp)
+@pytest.mark.parametrize("input_dtype", ["bfloat16", "float32"])
+def test_lerp_float_a(device, h, w, weight, input_dtype):
+    run_lerp_test_scalar_weight(device, h, w, 0, 90, 100, weight, ttnn.lerp, input_dtype=input_dtype)
 
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
 @pytest.mark.parametrize("weight", [0.75])
-def test_lerp_float_b(device, h, w, weight):
-    run_lerp_test_scalar_weight(device, h, w, 1, 80, 99, weight, ttnn.lerp, ulp_threshold=2)
+@pytest.mark.parametrize("input_dtype", ["bfloat16", "float32"])
+def test_lerp_float_b(device, h, w, weight, input_dtype):
+    run_lerp_test_scalar_weight(device, h, w, 1, 80, 99, weight, ttnn.lerp, ulp_threshold=2, input_dtype=input_dtype)
 
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
 @pytest.mark.parametrize("weight", [0.5])
-def test_lerp_tensor_a(device, h, w, weight):
-    run_lerp_test_tensor(device, h, w, 0, 90, 100, weight, ttnn.lerp)
+@pytest.mark.parametrize("input_dtype", ["bfloat16", "float32"])
+def test_lerp_tensor_a(device, h, w, weight, input_dtype):
+    run_lerp_test_tensor(device, h, w, 0, 90, 100, weight, ttnn.lerp, input_dtype=input_dtype)
 
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
 @pytest.mark.parametrize("weight", [0.75])
-def test_lerp_tensor_b(device, h, w, weight):
-    run_lerp_test_tensor(device, h, w, 1, 80, 99, weight, ttnn.lerp, ulp_threshold=2)
+@pytest.mark.parametrize("input_dtype", ["bfloat16", "float32"])
+def test_lerp_tensor_b(device, h, w, weight, input_dtype):
+    run_lerp_test_tensor(device, h, w, 1, 80, 99, weight, ttnn.lerp, ulp_threshold=2, input_dtype=input_dtype)
 
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [9472])
 @pytest.mark.parametrize("weight", [0.75])
-def test_lerp_bf16_inputs_fp32_preallocated_output(device, h, w, weight):
+@pytest.mark.parametrize("input_dtype", ["bfloat16", "float32"])
+def test_lerp_fp32_preallocated_output(device, h, w, weight, input_dtype):
     """Lerp with bfloat16 inputs (two tensors + scalar weight) and preallocated float32 output.
     Checks that output is correct within 1 ULP for float32."""
-    run_lerp_test_scalar_weight(device, h, w, 1, 80, 99, weight, ttnn.lerp, ulp_threshold=1, output_dtype="float32")
+    run_lerp_test_scalar_weight(
+        device, h, w, 1, 80, 99, weight, ttnn.lerp, ulp_threshold=1, output_dtype="float32", input_dtype=input_dtype
+    )

--- a/tests/ttnn/nightly/unit_tests/operations/eltwise/test_lerp.py
+++ b/tests/ttnn/nightly/unit_tests/operations/eltwise/test_lerp.py
@@ -12,48 +12,37 @@ from tests.ttnn.utils_for_testing import assert_with_ulp
 
 
 def run_lerp_test_scalar_weight(
-    device, h, w, low, high, end, weight, ttnn_function, torch_function, ulp_threshold=1, output_dtype=None
+    device, h, w, low, high, end, weight, ttnn_function, ulp_threshold=1, output_dtype=None
 ):
     torch_input_tensor_a = torch.linspace(low, high, steps=h * w, dtype=torch.bfloat16).reshape((h, w))
     torch_input_tensor_b = torch.full((h, w), end, dtype=torch.bfloat16)
 
+    golden_function = ttnn.get_golden_function(ttnn_function)
+
     input_tensor_a = ttnn.from_torch(torch_input_tensor_a, layout=ttnn.TILE_LAYOUT, device=device)
     input_tensor_b = ttnn.from_torch(torch_input_tensor_b, layout=ttnn.TILE_LAYOUT, device=device)
 
-    if output_dtype is None:
-        # Output dtype = input dtype (default)
-        torch_output_tensor = torch_function(torch_input_tensor_a, torch_input_tensor_b, weight)
-        output_tensor = ttnn_function(input_tensor_a, input_tensor_b, weight)
-    else:
-        # Preallocated output with given dtype; reference in same dtype
-        torch_output_dtype = getattr(torch, output_dtype)
+    calculated_tensor = None
+    if output_dtype is not None:
+        torch_dtype = getattr(torch, output_dtype)
         ttnn_output_dtype = getattr(ttnn, output_dtype)
+        torch_input_tensor_a = torch_input_tensor_a.to(torch_dtype)
+        torch_input_tensor_b = torch_input_tensor_b.to(torch_dtype)
+        calculated_tensor = ttnn.empty((h, w), dtype=ttnn_output_dtype, layout=ttnn.TILE_LAYOUT, device=device)
 
-        torch_output_tensor = torch_function(
-            torch_input_tensor_a.to(torch_output_dtype),
-            torch_input_tensor_b.to(torch_output_dtype),
-            weight,
-        )
-        output_tensor = ttnn.empty((h, w), dtype=ttnn_output_dtype, layout=ttnn.TILE_LAYOUT, device=device)
-        ttnn_function(input_tensor_a, input_tensor_b, weight, output_tensor=output_tensor)
+    golden_output_tensor = golden_function(
+        torch_input_tensor_a,
+        torch_input_tensor_b,
+        weight,
+    )
 
-    output_tensor = ttnn.to_torch(output_tensor)
+    calculated_tensor = ttnn_function(input_tensor_a, input_tensor_b, weight, output_tensor=calculated_tensor)
 
-    assert_with_ulp(torch_output_tensor, output_tensor, ulp_threshold=ulp_threshold)
+    if output_dtype is not None:
+        assert calculated_tensor.dtype == ttnn_output_dtype
 
-
-@pytest.mark.parametrize("h", [64])
-@pytest.mark.parametrize("w", [128])
-@pytest.mark.parametrize("weight", [0.5])
-def test_lerp_float_a(device, h, w, weight):
-    run_lerp_test_scalar_weight(device, h, w, 0, 90, 100, weight, ttnn.lerp, torch.lerp)
-
-
-@pytest.mark.parametrize("h", [64])
-@pytest.mark.parametrize("w", [128])
-@pytest.mark.parametrize("weight", [0.75])
-def test_lerp_float_b(device, h, w, weight):
-    run_lerp_test_scalar_weight(device, h, w, 1, 80, 99, weight, ttnn.lerp, torch.lerp, ulp_threshold=2)
+    calculated_tensor = ttnn.to_torch(calculated_tensor)
+    assert_with_ulp(golden_output_tensor, calculated_tensor, ulp_threshold=ulp_threshold)
 
 
 def run_lerp_test_tensor(
@@ -65,7 +54,6 @@ def run_lerp_test_tensor(
     end,
     weight,
     ttnn_function,
-    torch_function,
     ulp_threshold=1,
     output_dtype=None,
 ):
@@ -73,44 +61,62 @@ def run_lerp_test_tensor(
     torch_input_tensor_b = torch.full((h, w), end, dtype=torch.bfloat16)
     torch_weight = torch.full((h, w), weight, dtype=torch.bfloat16)
 
+    golden_function = ttnn.get_golden_function(ttnn_function)
+
     input_tensor_a = ttnn.from_torch(torch_input_tensor_a, layout=ttnn.TILE_LAYOUT, device=device)
     input_tensor_b = ttnn.from_torch(torch_input_tensor_b, layout=ttnn.TILE_LAYOUT, device=device)
     input_weight = ttnn.from_torch(torch_weight, layout=ttnn.TILE_LAYOUT, device=device)
 
-    if output_dtype is None:
-        # Output dtype = input dtype (default)
-        torch_output_tensor = torch_function(torch_input_tensor_a, torch_input_tensor_b, torch_weight)
-        output_tensor = ttnn_function(input_tensor_a, input_tensor_b, input_weight)
-    else:
-        # Preallocated output with given dtype; reference in same dtype
-        torch_output_dtype = getattr(torch, output_dtype)
+    calculated_tensor = None
+    if output_dtype is not None:
+        torch_dtype = getattr(torch, output_dtype)
         ttnn_output_dtype = getattr(ttnn, output_dtype)
+        torch_input_tensor_a = torch_input_tensor_a.to(torch_dtype)
+        torch_input_tensor_b = torch_input_tensor_b.to(torch_dtype)
+        torch_weight = torch_weight.to(torch_dtype)
+        calculated_tensor = ttnn.empty((h, w), dtype=ttnn_output_dtype, layout=ttnn.TILE_LAYOUT, device=device)
 
-        torch_output_tensor = torch_function(
-            torch_input_tensor_a.to(torch_output_dtype),
-            torch_input_tensor_b.to(torch_output_dtype),
-            torch_weight.to(torch_output_dtype),
-        )
-        output_tensor = ttnn.empty((h, w), dtype=ttnn_output_dtype, layout=ttnn.TILE_LAYOUT, device=device)
-        ttnn_function(input_tensor_a, input_tensor_b, input_weight, output_tensor=output_tensor)
+    golden_output_tensor = golden_function(
+        torch_input_tensor_a,
+        torch_input_tensor_b,
+        torch_weight,
+    )
 
-    output_tensor = ttnn.to_torch(output_tensor)
+    calculated_tensor = ttnn_function(input_tensor_a, input_tensor_b, input_weight, output_tensor=calculated_tensor)
 
-    assert_with_ulp(torch_output_tensor, output_tensor, ulp_threshold=ulp_threshold)
+    if output_dtype is not None:
+        assert calculated_tensor.dtype == ttnn_output_dtype
+
+    calculated_tensor = ttnn.to_torch(calculated_tensor)
+    assert_with_ulp(golden_output_tensor, calculated_tensor, ulp_threshold=ulp_threshold)
+
+
+@pytest.mark.parametrize("h", [64])
+@pytest.mark.parametrize("w", [128])
+@pytest.mark.parametrize("weight", [0.5])
+def test_lerp_float_a(device, h, w, weight):
+    run_lerp_test_scalar_weight(device, h, w, 0, 90, 100, weight, ttnn.lerp)
+
+
+@pytest.mark.parametrize("h", [64])
+@pytest.mark.parametrize("w", [128])
+@pytest.mark.parametrize("weight", [0.75])
+def test_lerp_float_b(device, h, w, weight):
+    run_lerp_test_scalar_weight(device, h, w, 1, 80, 99, weight, ttnn.lerp, ulp_threshold=2)
 
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
 @pytest.mark.parametrize("weight", [0.5])
 def test_lerp_tensor_a(device, h, w, weight):
-    run_lerp_test_tensor(device, h, w, 0, 90, 100, weight, ttnn.lerp, torch.lerp)
+    run_lerp_test_tensor(device, h, w, 0, 90, 100, weight, ttnn.lerp)
 
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
 @pytest.mark.parametrize("weight", [0.75])
 def test_lerp_tensor_b(device, h, w, weight):
-    run_lerp_test_tensor(device, h, w, 1, 80, 99, weight, ttnn.lerp, torch.lerp, ulp_threshold=2)
+    run_lerp_test_tensor(device, h, w, 1, 80, 99, weight, ttnn.lerp, ulp_threshold=2)
 
 
 @pytest.mark.parametrize("h", [64])
@@ -119,6 +125,4 @@ def test_lerp_tensor_b(device, h, w, weight):
 def test_lerp_bf16_inputs_fp32_preallocated_output(device, h, w, weight):
     """Lerp with bfloat16 inputs (two tensors + scalar weight) and preallocated float32 output.
     Checks that output is correct within 1 ULP for float32."""
-    run_lerp_test_scalar_weight(
-        device, h, w, 1, 80, 99, weight, ttnn.lerp, torch.lerp, ulp_threshold=1, output_dtype="float32"
-    )
+    run_lerp_test_scalar_weight(device, h, w, 1, 80, 99, weight, ttnn.lerp, ulp_threshold=1, output_dtype="float32")

--- a/tests/ttnn/unit_tests/operations/eltwise/test_ternary_composite.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_ternary_composite.py
@@ -223,8 +223,8 @@ def test_lerp_overload_ttnn(input_shapes, value, device):
     golden_fn = ttnn.get_golden_function(ttnn.lerp)
     golden_tensor = golden_fn(in_data1, in_data2, value)
 
-    comp_pass = compare_pcc([output_tensor], [golden_tensor])
-    assert comp_pass
+    output_torch = output_tensor.cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch()
+    assert_with_ulp(golden_tensor, output_torch, ulp_threshold=2)
 
 
 @pytest.mark.parametrize(
@@ -244,8 +244,8 @@ def test_lerp_ttnn(input_shapes, device):
     golden_fn = ttnn.get_golden_function(ttnn.lerp)
     golden_tensor = golden_fn(in_data1, in_data2, in_data3)
 
-    comp_pass = compare_pcc([output_tensor], [golden_tensor])
-    assert comp_pass
+    output_torch = output_tensor.cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch()
+    assert_with_ulp(golden_tensor, output_torch, ulp_threshold=2)
 
 
 @pytest.mark.parametrize(

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_lerp.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_lerp.h
@@ -1,0 +1,40 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "llk_defs.h"
+#include "sfpi.h"
+#include "ckernel_sfpu_binary.h"
+
+namespace ckernel::sfpu {
+
+template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, DataFormat data_format, int ITERATIONS>
+inline void calculate_lerp(
+    const uint dst_index_in0,  // input (start)
+    const uint dst_index_in1,  // end
+    const uint dst_index_in2,  // weight
+    const uint dst_index_out) {
+    static_assert(
+        data_format == DataFormat::Float32 || data_format == DataFormat::Float16_b,
+        "Unsupported data format for calculate_lerp(). Supported data formats are: Float32, Float16_b.");
+
+    // size of each tile in Dest is 64/SFP_DESTREG_STRIDE = 32 rows when using sfpi to load/store
+    constexpr uint dst_tile_size_sfpi = 32;
+    // lerp: out = input + weight * (end - input)
+#pragma GCC unroll 8
+    for (int d = 0; d < ITERATIONS; d++) {
+        sfpi::vFloat in0 = sfpi::dst_reg[dst_index_in0 * dst_tile_size_sfpi];
+        sfpi::vFloat in1 = sfpi::dst_reg[dst_index_in1 * dst_tile_size_sfpi];
+        sfpi::vFloat in2 = sfpi::dst_reg[dst_index_in2 * dst_tile_size_sfpi];
+        sfpi::vFloat result = in0 + in2 * (in1 - in0);
+        if constexpr (!is_fp32_dest_acc_en) {
+            result = float32_to_bf16_rne(result);
+        }
+        sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi] = result;
+        sfpi::dst_reg++;
+    }
+}
+
+}  // namespace ckernel::sfpu

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_ternary_sfpu_lerp.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_ternary_sfpu_lerp.h
@@ -1,0 +1,29 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "llk_math_eltwise_ternary_sfpu_params.h"
+#include "ckernel_sfpu_lerp.h"
+
+namespace ckernel {
+
+template <bool APPROXIMATE, bool is_fp32_dest_acc_en, DataFormat data_format, int ITERATIONS = 8>
+inline void llk_math_eltwise_ternary_sfpu_lerp(
+    uint dst_index0, uint dst_index1, uint dst_index2, uint odst, int vector_mode = (int)VectorMode::RC) {
+    _llk_math_eltwise_ternary_sfpu_params_<APPROXIMATE>(
+        sfpu::calculate_lerp<APPROXIMATE, is_fp32_dest_acc_en, data_format, ITERATIONS>,
+        dst_index0,
+        dst_index1,
+        dst_index2,
+        odst,
+        vector_mode);
+}
+
+template <bool APPROXIMATE>
+inline void llk_math_eltwise_ternary_sfpu_lerp_init() {
+    _llk_math_eltwise_ternary_sfpu_init_<SfpuType::lerp>();
+}
+
+}  // namespace ckernel

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu_types.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu_types.h
@@ -151,4 +151,5 @@ enum class SfpuType {
     unary_max_uint32,
     unary_min_uint32,
     addcdiv,
+    lerp,
 };

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_lerp.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_lerp.h
@@ -1,0 +1,40 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "llk_defs.h"
+#include "sfpi.h"
+#include "ckernel_sfpu_binary.h"
+
+namespace ckernel::sfpu {
+
+template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, DataFormat data_format, int ITERATIONS>
+inline void calculate_lerp(
+    const uint dst_index_in0,  // input (start)
+    const uint dst_index_in1,  // end
+    const uint dst_index_in2,  // weight
+    const uint dst_index_out) {
+    static_assert(
+        data_format == DataFormat::Float32 || data_format == DataFormat::Float16_b,
+        "Unsupported data format for calculate_lerp(). Supported data formats are: Float32, Float16_b.");
+
+    // size of each tile in Dest is 64/SFP_DESTREG_STRIDE = 32 rows when using sfpi to load/store
+    constexpr uint dst_tile_size_sfpi = 32;
+    // lerp: out = input + weight * (end - input)
+#pragma GCC unroll 8
+    for (int d = 0; d < ITERATIONS; d++) {
+        sfpi::vFloat in0 = sfpi::dst_reg[dst_index_in0 * dst_tile_size_sfpi];
+        sfpi::vFloat in1 = sfpi::dst_reg[dst_index_in1 * dst_tile_size_sfpi];
+        sfpi::vFloat in2 = sfpi::dst_reg[dst_index_in2 * dst_tile_size_sfpi];
+        sfpi::vFloat result = in0 + in2 * (in1 - in0);
+        if constexpr (!is_fp32_dest_acc_en) {
+            result = float32_to_bf16_rne(result);
+        }
+        sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi] = result;
+        sfpi::dst_reg++;
+    }
+}
+
+}  // namespace ckernel::sfpu

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_ternary_sfpu_lerp.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_ternary_sfpu_lerp.h
@@ -1,0 +1,29 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "llk_math_eltwise_ternary_sfpu_params.h"
+#include "ckernel_sfpu_lerp.h"
+
+namespace ckernel {
+
+template <bool APPROXIMATE, bool is_fp32_dest_acc_en, DataFormat data_format, int ITERATIONS = 8>
+inline void llk_math_eltwise_ternary_sfpu_lerp(
+    uint dst_index0, uint dst_index1, uint dst_index2, uint odst, int vector_mode = (int)VectorMode::RC) {
+    _llk_math_eltwise_ternary_sfpu_params_<APPROXIMATE>(
+        sfpu::calculate_lerp<APPROXIMATE, is_fp32_dest_acc_en, data_format, ITERATIONS>,
+        dst_index0,
+        dst_index1,
+        dst_index2,
+        odst,
+        vector_mode);
+}
+
+template <bool APPROXIMATE>
+inline void llk_math_eltwise_ternary_sfpu_lerp_init() {
+    _llk_math_eltwise_ternary_sfpu_init_<SfpuType::lerp>();
+}
+
+}  // namespace ckernel

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu_types.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu_types.h
@@ -151,4 +151,5 @@ enum class SfpuType {
     unary_max_uint32,
     unary_min_uint32,
     addcdiv,
+    lerp,
 };

--- a/tt_metal/hw/inc/api/compute/eltwise_unary/lerp.h
+++ b/tt_metal/hw/inc/api/compute/eltwise_unary/lerp.h
@@ -1,0 +1,36 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "api/compute/common_globals.h"
+#ifdef TRISC_MATH
+#include "llk_math_eltwise_ternary_sfpu_lerp.h"
+#endif
+
+namespace ckernel {
+
+// clang-format off
+/**
+ * Performs elementwise linear interpolation (lerp): out = input + weight * (end - input)
+ *
+ * | Argument | Description                                                | Type     | Valid Range                                           | Required |
+ * |----------|------------------------------------------------------------|----------|-------------------------------------------------------|----------|
+ * | idst0    | Index of the tile in DST register buffer (input/start)   | uint32_t | Must be less than the size of the DST register buffer | True     |
+ * | idst1    | Index of the tile in DST register buffer (end)           | uint32_t | Must be less than the size of the DST register buffer | True     |
+ * | idst2    | Index of the tile in DST register buffer (weight)        | uint32_t | Must be less than the size of the DST register buffer | True     |
+ * | odst     | Index of the tile in DST register buffer (output)        | uint32_t | Must be less than the size of the DST register buffer | True     |
+ */
+// clang-format on
+template <DataFormat data_format>
+ALWI void lerp_tile(uint32_t idst0, uint32_t idst1, uint32_t idst2, uint32_t odst) {
+    MATH((llk_math_eltwise_ternary_sfpu_lerp<APPROX, DST_ACCUM_MODE, data_format>(idst0, idst1, idst2, odst)));
+}
+
+/**
+ * Please refer to documentation for any_init.
+ */
+ALWI void lerp_tile_init() { MATH((llk_math_eltwise_ternary_sfpu_lerp_init<APPROX>())); }
+
+}  // namespace ckernel

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/compute/ternary_sfpu_col_scalar_bcast_tts_tst.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/compute/ternary_sfpu_col_scalar_bcast_tts_tst.cpp
@@ -6,6 +6,7 @@
 
 #include "api/compute/eltwise_unary/eltwise_unary.h"
 #include "api/compute/eltwise_unary/where.h"
+#include "api/compute/eltwise_unary/lerp.h"
 #include "api/compute/eltwise_unary/fill.h"
 #include "ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_utils_common.hpp"
 #include "ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_utils_sfpu.hpp"

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/compute/ternary_sfpu_col_scalar_bcast_ttt.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/compute/ternary_sfpu_col_scalar_bcast_ttt.cpp
@@ -6,6 +6,7 @@
 
 #include "api/compute/eltwise_unary/eltwise_unary.h"
 #include "api/compute/eltwise_unary/where.h"
+#include "api/compute/eltwise_unary/lerp.h"
 #include "ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_utils_common.hpp"
 #include "ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_utils_sfpu.hpp"
 

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/compute/ternary_sfpu_no_bcast_tts_tst.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/compute/ternary_sfpu_no_bcast_tts_tst.cpp
@@ -8,6 +8,7 @@
 #include "ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_utils_sfpu.hpp"
 #include "api/compute/eltwise_unary/eltwise_unary.h"
 #include "api/compute/eltwise_unary/where.h"
+#include "api/compute/eltwise_unary/lerp.h"
 #include "api/compute/eltwise_unary/fill.h"
 
 void kernel_main() {

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/compute/ternary_sfpu_no_bcast_ttt.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/compute/ternary_sfpu_no_bcast_ttt.cpp
@@ -8,6 +8,7 @@
 #include "ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_utils_sfpu.hpp"
 #include "api/compute/eltwise_unary/eltwise_unary.h"
 #include "api/compute/eltwise_unary/where.h"
+#include "api/compute/eltwise_unary/lerp.h"
 
 void kernel_main() {
     uint32_t num_tiles = get_arg_val<uint32_t>(0);

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/compute/ternary_sfpu_row_bcast_ttt.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/compute/ternary_sfpu_row_bcast_ttt.cpp
@@ -17,6 +17,7 @@
 #include "ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_utils_sfpu.hpp"
 #include "api/compute/eltwise_unary/eltwise_unary.h"
 #include "api/compute/eltwise_unary/where.h"
+#include "api/compute/eltwise_unary/lerp.h"
 #include "api/compute/bcast.h"
 #include "api/compute/tile_move_copy.h"
 

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/device/ternary_op_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/device/ternary_op_utils.cpp
@@ -289,9 +289,9 @@ std::map<std::string, std::string> get_compute_defines(TernaryOpType op_type, Da
             }
             break;
         case TernaryOpType::LERP:
-            // LERP will use lerp_tile_init and lerp_tile functions (to be implemented)
             defines["TERNARY_SFPU_OP_INIT"] = "lerp_tile_init";
-            defines["TERNARY_SFPU_OP_FUNC"] = "lerp_tile";
+            defines["TERNARY_SFPU_OP_FUNC"] =
+                (dtype == DataType::FLOAT32) ? "lerp_tile<DataFormat::Float32>" : "lerp_tile<DataFormat::Float16_b>";
             break;
         case TernaryOpType::ADDCMUL:
             defines["TERNARY_SFPU_OP_INIT"] = "addcmul_tile_init";

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/ternary.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/ternary.cpp
@@ -340,8 +340,6 @@ Tensor LerpOperation::invoke(
     float weight,
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<Tensor>& output) {
-    log_debug(tt::LogOp, "Lerp LLK - TTS (scalar weight)");
-
     auto broadcast_type = ttnn::operations::ternary::get_broadcast_type(input.logical_shape(), end.logical_shape());
 
     bool is_any_input_block_format = is_block_float(input.dtype()) || is_block_float(end.dtype());
@@ -351,11 +349,11 @@ Tensor LerpOperation::invoke(
     bool is_input_int32 = (input.dtype() == DataType::INT32) && (end.dtype() == DataType::INT32);
 
     if (is_invalid_bcast(broadcast_type) || (is_any_input_block_format && is_subtile_bcast) || is_input_int32) {
-        log_debug(tt::LogOp, "Lerp Fallback - TTS");
+        log_debug(tt::LogOp, "Lerp Fallback - TTS (scalar weight)");
         return _lerp_overload(input, end, weight, memory_config);
     }
 
-    log_debug(tt::LogOp, "Lerp LLK - TTS");
+    log_debug(tt::LogOp, "Lerp LLK - TTS (scalar weight)");
     return ttnn::prim::ternary(
         TernaryOpType::LERP,
         input,
@@ -373,8 +371,6 @@ Tensor LerpOperation::invoke(
     const Tensor& weight,
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<Tensor>& output) {
-    log_debug(tt::LogOp, "Lerp LLK - TTT (tensor weight)");
-
     auto broadcast_type = ttnn::operations::ternary::get_broadcast_type(
         input.logical_shape(), end.logical_shape(), weight.logical_shape());
 
@@ -387,11 +383,11 @@ Tensor LerpOperation::invoke(
         (input.dtype() == DataType::INT32) && (end.dtype() == DataType::INT32) && (weight.dtype() == DataType::INT32);
 
     if (is_invalid_bcast(broadcast_type) || (is_any_input_block_format && is_subtile_bcast) || is_input_int32) {
-        log_debug(tt::LogOp, "Lerp Fallback - TTT");
+        log_debug(tt::LogOp, "Lerp Fallback - TTT (tensor weight)");
         return _lerp(input, end, weight, memory_config);
     }
 
-    log_debug(tt::LogOp, "Lerp LLK - TTT");
+    log_debug(tt::LogOp, "Lerp LLK - TTT (tensor weight)");
     return ttnn::prim::ternary(
         TernaryOpType::LERP,
         input,

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/ternary.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/ternary.cpp
@@ -334,4 +334,73 @@ Tensor AddcdivOperation::invoke(
         std::nullopt);
 }
 
+Tensor LerpOperation::invoke(
+    const Tensor& input,
+    const Tensor& end,
+    float weight,
+    const std::optional<MemoryConfig>& memory_config,
+    const std::optional<Tensor>& output) {
+    log_debug(tt::LogOp, "Lerp LLK - TTS (scalar weight)");
+
+    auto broadcast_type = ttnn::operations::ternary::get_broadcast_type(input.logical_shape(), end.logical_shape());
+
+    bool is_any_input_block_format = is_block_float(input.dtype()) || is_block_float(end.dtype());
+    bool is_subtile_bcast = (broadcast_type == TernaryBroadcastType::ROW_BCAST) ||
+                            (broadcast_type == TernaryBroadcastType::COL_BCAST) ||
+                            (broadcast_type == TernaryBroadcastType::SCALAR_BCAST);
+    bool is_input_int32 = (input.dtype() == DataType::INT32) && (end.dtype() == DataType::INT32);
+
+    if (is_invalid_bcast(broadcast_type) || (is_any_input_block_format && is_subtile_bcast) || is_input_int32) {
+        log_debug(tt::LogOp, "Lerp Fallback - TTS");
+        return _lerp_overload(input, end, weight, memory_config);
+    }
+
+    log_debug(tt::LogOp, "Lerp LLK - TTS");
+    return ttnn::prim::ternary(
+        TernaryOpType::LERP,
+        input,
+        end,
+        weight,
+        ternary_utils::determine_output_dtype(output, input.dtype()),
+        ternary_utils::determine_memory_config(memory_config, input.memory_config()),
+        output,
+        std::nullopt);
+}
+
+Tensor LerpOperation::invoke(
+    const Tensor& input,
+    const Tensor& end,
+    const Tensor& weight,
+    const std::optional<MemoryConfig>& memory_config,
+    const std::optional<Tensor>& output) {
+    log_debug(tt::LogOp, "Lerp LLK - TTT (tensor weight)");
+
+    auto broadcast_type = ttnn::operations::ternary::get_broadcast_type(
+        input.logical_shape(), end.logical_shape(), weight.logical_shape());
+
+    bool is_any_input_block_format =
+        is_block_float(input.dtype()) || is_block_float(end.dtype()) || is_block_float(weight.dtype());
+    bool is_subtile_bcast = (broadcast_type == TernaryBroadcastType::ROW_BCAST) ||
+                            (broadcast_type == TernaryBroadcastType::COL_BCAST) ||
+                            (broadcast_type == TernaryBroadcastType::SCALAR_BCAST);
+    bool is_input_int32 =
+        (input.dtype() == DataType::INT32) && (end.dtype() == DataType::INT32) && (weight.dtype() == DataType::INT32);
+
+    if (is_invalid_bcast(broadcast_type) || (is_any_input_block_format && is_subtile_bcast) || is_input_int32) {
+        log_debug(tt::LogOp, "Lerp Fallback - TTT");
+        return _lerp(input, end, weight, memory_config);
+    }
+
+    log_debug(tt::LogOp, "Lerp LLK - TTT");
+    return ttnn::prim::ternary(
+        TernaryOpType::LERP,
+        input,
+        end,
+        weight,
+        ternary_utils::determine_output_dtype(output, input.dtype()),
+        ternary_utils::determine_memory_config(memory_config, input.memory_config()),
+        output,
+        std::nullopt);
+}
+
 }  // namespace ttnn::operations::ternary

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/ternary.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/ternary.cpp
@@ -350,7 +350,7 @@ Tensor LerpOperation::invoke(
 
     if (is_invalid_bcast(broadcast_type) || (is_any_input_block_format && is_subtile_bcast) || is_input_int32) {
         log_debug(tt::LogOp, "Lerp Fallback - TTS (scalar weight)");
-        return _lerp_overload(input, end, weight, memory_config);
+        return _lerp_overload(input, end, weight, memory_config, output);
     }
 
     log_debug(tt::LogOp, "Lerp LLK - TTS (scalar weight)");
@@ -384,7 +384,7 @@ Tensor LerpOperation::invoke(
 
     if (is_invalid_bcast(broadcast_type) || (is_any_input_block_format && is_subtile_bcast) || is_input_int32) {
         log_debug(tt::LogOp, "Lerp Fallback - TTT (tensor weight)");
-        return _lerp(input, end, weight, memory_config);
+        return _lerp(input, end, weight, memory_config, output);
     }
 
     log_debug(tt::LogOp, "Lerp LLK - TTT (tensor weight)");

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/ternary.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/ternary.hpp
@@ -57,11 +57,28 @@ struct AddcdivOperation {
         const std::optional<Tensor>& output = std::nullopt);
 };
 
+// Lerp Operation (linear interpolation: out = input + weight * (end - input))
+struct LerpOperation {
+    static Tensor invoke(
+        const Tensor& input,
+        const Tensor& end,
+        float weight,
+        const std::optional<MemoryConfig>& memory_config = std::nullopt,
+        const std::optional<Tensor>& output = std::nullopt);
+    static Tensor invoke(
+        const Tensor& input,
+        const Tensor& end,
+        const Tensor& weight,
+        const std::optional<MemoryConfig>& memory_config = std::nullopt,
+        const std::optional<Tensor>& output = std::nullopt);
+};
+
 }  // namespace operations::ternary
 
 // Register the operations
 constexpr auto where = ttnn::register_operation<"ttnn::where", operations::ternary::WhereOperation>();
 constexpr auto addcmul = ttnn::register_operation<"ttnn::addcmul", operations::ternary::AddcmulOperation>();
 constexpr auto addcdiv = ttnn::register_operation<"ttnn::addcdiv", operations::ternary::AddcdivOperation>();
+constexpr auto lerp = ttnn::register_operation<"ttnn::lerp", operations::ternary::LerpOperation>();
 
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/ternary_composite.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/ternary_composite.hpp
@@ -65,9 +65,6 @@ struct ExecuteTernaryCompositeMac {
 
 }  // namespace operations::ternary
 
-constexpr auto lerp = ttnn::register_operation<
-    "ttnn::lerp",
-    operations::ternary::ExecuteTernaryCompositeLerp<operations::ternary::TernaryCompositeOpType::LERP>>();
 constexpr auto mac = ttnn::register_operation<
     "ttnn::mac",
     operations::ternary::ExecuteTernaryCompositeMac<operations::ternary::TernaryCompositeOpType::MAC>>();

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/ternary_composite_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/ternary_composite_op.cpp
@@ -61,6 +61,7 @@ Tensor _addcdiv(
     return result;
 }
 
+// Fallback composite implementation for lerp (with scalar weight)
 // lerp(input, end, weight) = start + weight * (end - start)
 Tensor _lerp_overload(
     const Tensor& input,
@@ -101,6 +102,7 @@ Tensor _lerp_overload(
     return result;
 }
 
+// LLK implementation for lerp (with tensor weight)
 Tensor _lerp(
     const Tensor& input,
     const Tensor& end,

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/ternary_composite_op.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/ternary_composite_op.hpp
@@ -28,8 +28,10 @@ enum class TernaryCompositeOpType {
 
 Tensor _addcmul(const Tensor&, const Tensor&, const Tensor&, float, const std::optional<MemoryConfig>&);
 Tensor _addcdiv(const Tensor&, const Tensor&, const Tensor&, float, const std::optional<MemoryConfig>&);
-Tensor _lerp(const Tensor&, const Tensor&, const Tensor&, const std::optional<MemoryConfig>&);
-Tensor _lerp_overload(const Tensor&, const Tensor&, float, const std::optional<MemoryConfig>&);
+Tensor _lerp(
+    const Tensor&, const Tensor&, const Tensor&, const std::optional<MemoryConfig>&, const std::optional<Tensor>&);
+Tensor _lerp_overload(
+    const Tensor&, const Tensor&, float, const std::optional<MemoryConfig>&, const std::optional<Tensor>&);
 Tensor _mac(const Tensor&, const Tensor&, const Tensor&, const std::optional<MemoryConfig>&);
 Tensor _mac_overload(const Tensor&, float, float, const std::optional<MemoryConfig>&);
 
@@ -55,11 +57,20 @@ struct OpHandler<TernaryCompositeOpType::ADDCDIV> {
 template <>
 struct OpHandler<TernaryCompositeOpType::LERP> {
     static Tensor handle(
-        const Tensor& t1, const Tensor& t2, const Tensor& t3, const std::optional<MemoryConfig>& mem_cfg) {
-        return _lerp(t1, t2, t3, mem_cfg);
+        const Tensor& t1,
+        const Tensor& t2,
+        const Tensor& t3,
+        const std::optional<MemoryConfig>& mem_cfg,
+        const std::optional<Tensor>& output) {
+        return _lerp(t1, t2, t3, mem_cfg, output);
     }
-    static Tensor handle(const Tensor& t1, const Tensor& t2, float value, const std::optional<MemoryConfig>& mem_cfg) {
-        return _lerp_overload(t1, t2, value, mem_cfg);
+    static Tensor handle(
+        const Tensor& t1,
+        const Tensor& t2,
+        float value,
+        const std::optional<MemoryConfig>& mem_cfg,
+        const std::optional<Tensor>& output) {
+        return _lerp_overload(t1, t2, value, mem_cfg, output);
     }
 };
 

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/ternary_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/ternary_nanobind.cpp
@@ -217,6 +217,8 @@ void bind_ternary_lerp(nb::module_& mod, const ternary_operation_t& operation, c
             bfloat8_b/bfloat4_b supports only on TILE_LAYOUT
 
             end, weight tensors should have same dtype as input
+
+            output_tensor dtype must match input dtype, or be FLOAT32 when inputs are BFLOAT16, or be BFLOAT16 when inputs are FLOAT32
         )doc",
         operation.base_name(),
         operation.python_fully_qualified_name(),

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/ternary_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/ternary_nanobind.cpp
@@ -200,6 +200,7 @@ void bind_ternary_lerp(nb::module_& mod, const ternary_operation_t& operation, c
 
         Keyword Args:
             memory_config (ttnn.MemoryConfig, optional): memory configuration for the operation. Defaults to `None`.
+            output_tensor (ttnn.Tensor, optional): preallocated output tensor. Defaults to `None`.
 
 
         Note:
@@ -230,24 +231,32 @@ void bind_ternary_lerp(nb::module_& mod, const ternary_operation_t& operation, c
                const Tensor& input,
                const Tensor& end,
                const Tensor& weight,
-               const std::optional<MemoryConfig>& memory_config) { return self(input, end, weight, memory_config); },
+               const std::optional<MemoryConfig>& memory_config,
+               const std::optional<Tensor>& output_tensor) {
+                return self(input, end, weight, memory_config, output_tensor);
+            },
             nb::arg("input"),
             nb::arg("end"),
             nb::arg("weight"),
             nb::kw_only(),
-            nb::arg("memory_config") = nb::none()},
+            nb::arg("memory_config") = nb::none(),
+            nb::arg("output_tensor") = nb::none()},
 
         ttnn::nanobind_overload_t{
             [](const ternary_operation_t& self,
                const Tensor& input,
                const Tensor& end,
                float weight,
-               const std::optional<MemoryConfig>& memory_config) { return self(input, end, weight, memory_config); },
+               const std::optional<MemoryConfig>& memory_config,
+               const std::optional<Tensor>& output_tensor) {
+                return self(input, end, weight, memory_config, output_tensor);
+            },
             nb::arg("input"),
             nb::arg("end"),
             nb::arg("weight"),
             nb::kw_only(),
-            nb::arg("memory_config") = nb::none()});
+            nb::arg("memory_config") = nb::none(),
+            nb::arg("output_tensor") = nb::none()});
 }
 
 template <typename ternary_operation_t>


### PR DESCRIPTION
### Ticket
#36763

### Problem description
For Wan2.2, we want to perform the following:

```
permuted_noise_pred = permuted_noise_uncond + current_guidance_scale * (
    permuted_noise_pred - permuted_noise_uncond
)
```
This is equivalent to `lerp(permuted_noise_uncond, permuted_noise_pred, current_guidance_scale)`.
However, `ttnn.lerp` is defined as a composite and may be lossy due to `ttnn::add`, `ttnn::subtract` and `ttnn::multiply`, especially with bfloat16 data. 

Fusing the operations should also improve performance.

### What's changed
- Add fused lerp implementation
- Update `ttnn.lerp` to take `output_tensor` 
- Add `lerp_tile` LLK
- Update tests for lerp, tests now use ULP instead of PCC.
- Add shape for Wan2.2 in test.


#### Performance

Performance (Wormhole N150)

On 9472 x 64 tensor in DRAM:

dtype | Branch |  Total Duration [ms]
-- | -- | --
bfloat16 | main | 8813
bfoat16 | new | 1495
float32 | main | 15461
float32 | new | 2761


### Checklist

- [x] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=nmaurice/36763-fused-lerp)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:nmaurice/36763-fused-lerp)
- [x] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=nmaurice/36763-fused-lerp)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:nmaurice/36763-fused-lerp) (unrelated failure, also in other [branches](https://github.com/tenstorrent/tt-metal/actions/runs/21864535471/job/63102851430))
- [x] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nmaurice/36763-fused-lerp)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nmaurice/36763-fused-lerp) (executes `test_lerp.py`)
- [x] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nmaurice/36763-fused-lerp)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nmaurice/36763-fused-lerp)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nmaurice/36763-fused-lerp)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nmaurice/36763-fused-lerp)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nmaurice/36763-fused-lerp)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nmaurice/36763-fused-lerp)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
