### PR TITLE
APC-test-count check to PR gate

### DIFF
--- a/.github/workflows/pr-gate.yaml
+++ b/.github/workflows/pr-gate.yaml
@@ -522,6 +522,7 @@ jobs:
       - clang-tidy-light
       - model-charts-sync
       - build-docs
+      - APC-test-count-check
     runs-on: ubuntu-latest
     steps:
       - name: Check if all jobs passed

--- a/.github/workflows/pr-gate.yaml
+++ b/.github/workflows/pr-gate.yaml
@@ -522,7 +522,6 @@ jobs:
       - clang-tidy-light
       - model-charts-sync
       - build-docs
-      - APC-test-count-check
     runs-on: ubuntu-latest
     steps:
       - name: Check if all jobs passed

--- a/.github/workflows/pr-gate.yaml
+++ b/.github/workflows/pr-gate.yaml
@@ -343,6 +343,9 @@ jobs:
       runner: ${{ matrix.platform }}
       product: tt-nn
 
+  APC-test-count-check:
+    uses: ./.github/workflows/validate-test-count.yaml
+
   ttsim-integration-tests:
     needs: [ build ]
     if: >-
@@ -527,6 +530,7 @@ jobs:
           required-jobs: "asan-build, build, build-tt-train"
           optional-jobs: >-
             metalium-smoke-tests, ttnn-smoke-tests, metalium-examples,
-            ttsim-integration-tests, model-charts-sync, build-docs
+            ttsim-integration-tests, model-charts-sync, build-docs,
+            APC-test-count-check
         env:
           NEEDS_CONTEXT: '${{ toJSON(needs) }}'

--- a/.github/workflows/validate-test-count.yaml
+++ b/.github/workflows/validate-test-count.yaml
@@ -86,7 +86,7 @@ jobs:
             echo "" >> $GITHUB_STEP_SUMMARY
             echo "These test directories have a locked test count to maintain stable APC runtime." >> $GITHUB_STEP_SUMMARY
             echo "Please look into removing existing lower priority tests to add new tests." >> $GITHUB_STEP_SUMMARY
-            exit 0
+            exit 1
           fi
 
           echo "" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/validate-test-count.yaml
+++ b/.github/workflows/validate-test-count.yaml
@@ -1,0 +1,94 @@
+name: "Validate Test Count"
+
+on:
+  workflow_call:
+
+jobs:
+  check-test-count:
+    runs-on: ubuntu-latest
+    name: "Check Test Count"
+    steps:
+      - name: Checkout PR branch
+        uses: actions/checkout@v4
+
+      - name: Count and compare tests
+        run: |
+          # Define directory paths to check test counts
+          declare -A DIRS=(
+            ["eltwise"]="tests/ttnn/unit_tests/operations/eltwise"
+            ["conv"]="tests/ttnn/unit_tests/operations/conv"
+            ["matmul"]="tests/ttnn/unit_tests/operations/matmul"
+            ["pool"]="tests/ttnn/unit_tests/operations/pool"
+            ["fused"]="tests/ttnn/unit_tests/operations/fused"
+            ["transformers"]="tests/ttnn/unit_tests/operations/transformers"
+            ["reduce"]="tests/ttnn/unit_tests/operations/reduce"
+            ["tensor"]="tests/ttnn/unit_tests/tensor"
+            ["debug"]="tests/ttnn/unit_tests/operations/debug"
+            ["base_functionality"]="tests/ttnn/unit_tests/base_functionality"
+            ["benchmarks"]="tests/ttnn/unit_tests/benchmarks"
+          )
+
+          # Function to count test functions including parametrize expansions
+          count_tests() {
+            local dir=$1
+            python3 .github/scripts/utils/count_pytests.py "$dir"
+          }
+
+          # Count tests in PR branch
+          echo "=== PR branch test counts ==="
+          declare -A pr_counts
+          for name in "${!DIRS[@]}"; do
+            path="${DIRS[$name]}"
+            count=$(count_tests "$path")
+            pr_counts[$name]=$count
+            echo "  $name: $count"
+          done
+
+          # Checkout base branch
+          git fetch --depth=1 origin main
+          git checkout origin/main
+
+          # Count tests in base branch
+          echo "=== Base branch test counts ==="
+          declare -A base_counts
+          for name in "${!DIRS[@]}"; do
+            path="${DIRS[$name]}"
+            count=$(count_tests "$path")
+            base_counts[$name]=$count
+            echo "  $name: $count"
+          done
+
+          # Compare and generate report
+          FAILED=0
+
+          echo "## Test Count Validation Results" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "| Directory | Base | PR | Status |" >> $GITHUB_STEP_SUMMARY
+          echo "|-----------|------|-------|--------|" >> $GITHUB_STEP_SUMMARY
+
+          for name in "${!DIRS[@]}"; do
+            path="${DIRS[$name]}"
+            pr_count=${pr_counts[$name]}
+            base_count=${base_counts[$name]}
+
+            if [ "$pr_count" -gt "$base_count" ]; then
+              echo "| $path | $base_count | $pr_count | ❌ New tests added (+$((pr_count - base_count))) |" >> $GITHUB_STEP_SUMMARY
+              echo "::notice::New tests detected in $path/ ($base_count → $pr_count)"
+              FAILED=1
+            else
+              echo "| $path | $base_count | $pr_count | ✅ No new tests |" >> $GITHUB_STEP_SUMMARY
+            fi
+          done
+
+          if [ "$FAILED" -eq 1 ]; then
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "❌ **This PR adds new tests to ttnn in APC.**" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "These test directories have a locked test count to maintain stable APC runtime." >> $GITHUB_STEP_SUMMARY
+            echo "Please look into removing existing lower priority tests to add new tests." >> $GITHUB_STEP_SUMMARY
+            exit 0
+          fi
+
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "✅ **No new tests added - validation passed**" >> $GITHUB_STEP_SUMMARY
+          exit 0

--- a/.github/workflows/validate-test-count.yaml
+++ b/.github/workflows/validate-test-count.yaml
@@ -13,6 +13,8 @@ jobs:
 
       - name: Count and compare tests
         run: |
+          set -euo pipefail
+
           # Define directory paths to check test counts
           declare -A DIRS=(
             ["eltwise"]="tests/ttnn/unit_tests/operations/eltwise"

--- a/tests/ttnn/unit_tests/operations/conv/test_conv1d.py
+++ b/tests/ttnn/unit_tests/operations/conv/test_conv1d.py
@@ -444,25 +444,3 @@ def test_with_prepare_weights(
     passing, pcc_msg = check_with_pcc_without_tensor_printout(torch_output_tensor, torch_out_golden_tensor, pcc=0.995)
     print(pcc_msg)
     assert passing
-
-@pytest.mark.parametrize("device_params", [{"l1_small_size": 16384}], indirect=True)
-@pytest.mark.parametrize("batch_size", [1, 2])
-@pytest.mark.parametrize("output_channels", [32, 64])
-def test_conv1d_workflow_validation_new(device, use_program_cache, batch_size, output_channels):
-    """Test added to verify validate-test-count workflow catches new tests"""
-    run_conv(
-        device=device,
-        math_fidelity=ttnn.MathFidelity.LoFi,
-        activations_dtype=ttnn.bfloat16,
-        weights_dtype=ttnn.bfloat16,
-        output_dtype=ttnn.bfloat16,
-        batch_size=batch_size,
-        output_channels=output_channels,
-        input_channels=64,
-        input_length=128,
-        kernel_size=3,
-        stride=1,
-        padding=1,
-        use_1d_systolic_array=True,
-        config_override=None,
-    )

--- a/tests/ttnn/unit_tests/operations/conv/test_conv1d.py
+++ b/tests/ttnn/unit_tests/operations/conv/test_conv1d.py
@@ -444,3 +444,25 @@ def test_with_prepare_weights(
     passing, pcc_msg = check_with_pcc_without_tensor_printout(torch_output_tensor, torch_out_golden_tensor, pcc=0.995)
     print(pcc_msg)
     assert passing
+
+@pytest.mark.parametrize("device_params", [{"l1_small_size": 16384}], indirect=True)
+@pytest.mark.parametrize("batch_size", [1, 2])
+@pytest.mark.parametrize("output_channels", [32, 64])
+def test_conv1d_workflow_validation_new(device, use_program_cache, batch_size, output_channels):
+    """Test added to verify validate-test-count workflow catches new tests"""
+    run_conv(
+        device=device,
+        math_fidelity=ttnn.MathFidelity.LoFi,
+        activations_dtype=ttnn.bfloat16,
+        weights_dtype=ttnn.bfloat16,
+        output_dtype=ttnn.bfloat16,
+        batch_size=batch_size,
+        output_channels=output_channels,
+        input_channels=64,
+        input_length=128,
+        kernel_size=3,
+        stride=1,
+        padding=1,
+        use_1d_systolic_array=True,
+        config_override=None,
+    )


### PR DESCRIPTION
### What's changed
Add validation-test-count workflow to check APC test count for ttnn-unit-test job in PR gate

PR-gate CI run passes with running test-count check: https://github.com/tenstorrent/tt-metal/actions/runs/21842615535/attempts/1#summary-63030593236

Adding a new test to ttnn-unit-test job in APC causes the check to fail in this run: https://github.com/tenstorrent/tt-metal/actions/runs/21842835668/attempts/1#summary-63031368113

Once the newly added test is removed, it passes all checks because the counts match between the PR and main branch: https://github.com/tenstorrent/tt-metal/actions/runs/21842877667