### PR TITLE
Deepseek: Optimized OP for MoE Gate

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/experimental/test_moe_mm.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/test_moe_mm.py
@@ -1,0 +1,498 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+import itertools
+import math
+import pytest
+import torch
+import ttnn
+from loguru import logger
+
+from models.common.utility_functions import comp_pcc, comp_allclose
+
+from tracy.process_model_log import (
+    get_latest_ops_log_filename,
+    run_device_profiler,
+)
+
+PCC_THRESHOLD = 0.97
+
+"""
+We have a total of 12 cores adjacent to 12 DRAM banks. Out of these, 8 cores process 2/3rd of the K
+tiles for just one N tile. The remaining 4 cores process 1/3rd of the K tiles for 2 N tiles.
+Since the 4 cores send their partial to the other 8 cores for final value, we identify these 4 cores
+as the SEND_CORES and the remaining 4 cores as the RECV_CORES.
+"""
+SEND_CORES = (0, 3, 6, 9)
+RECV_CORES = (1, 2, 4, 5, 7, 8, 10, 11)
+
+
+def create_torch_input(L, in0_num_cores, M, K):
+    """
+    Create torch input tensor with random values per layer.
+
+    Args:
+        L: Number of layers
+        in0_num_cores: Number of input cores the tensor is replicated across
+        M: Number of tokens
+        K: Hidden dimension
+
+    Returns:
+        torch_input: Tensor of shape (L, in0_num_cores, M, K)
+    """
+    torch_input = torch.rand((L, 1, M, K), dtype=torch.bfloat16) - 0.5
+    torch_input = torch_input.repeat(1, in0_num_cores, 1, 1)
+    return torch_input
+
+
+def create_torch_w(L, K, N):
+    """
+    Create torch weight tensor with random values.
+
+    Args:
+        L: Number of layers
+        K: Hidden dimension
+        N: Output dimension
+
+    Returns:
+        torch_w: Tensor of shape (L, K, N)
+    """
+    torch_w = torch.rand((L, K, N), dtype=torch.bfloat16) - 0.5
+    return torch_w
+
+
+def create_torch_bias(L, N):
+    """
+    Create torch bias tensor with random values.
+
+    Args:
+        L: Number of layers
+        N: Output dimension
+
+    Returns:
+        torch_bias: Tensor of shape (L, N)
+    """
+    torch_bias = torch.rand((L, N), dtype=torch.bfloat16)
+    return torch_bias
+
+
+def prepare_w_tensor(torch_w, torch_bias, L, K, N, ring2cores):
+    """
+    Prepare the w tensor and bias tensor by padding and reordering tiles.
+
+    Args:
+        torch_w: Weight tensor of shape (L, K, N)
+        torch_bias: Bias tensor of shape (L, N)
+        L: Number of layers
+        K: Input dimension
+        N: Output dimension
+        ring2cores: Dictionary mapping ring position to (core_coord, dram_bank_id, send_flag)
+
+    Returns:
+        torch_w: Tensor of shape (L, K, N)
+    """
+    Kt, Nt = math.ceil(K / ttnn.TILE_SIZE), math.ceil(N / ttnn.TILE_SIZE)
+    # 8 cores get 2/3rd of K tiles and 1 N tile -> Type 1 (send flag is 0)
+    # 4 cores get 1/3rd of K tiles and 2 N tiles -> Type 2 (send flag is 1)
+    # Every third core is of type 2.
+    w_tile_view = torch_w.view(L, Kt, ttnn.TILE_SIZE, Nt, ttnn.TILE_SIZE)
+
+    # For the 8 cores, we append values from the bias tensor at the end, so it can be read in the
+    # same DRAM transaction, optimally without any additional overhead.
+    bias_tile_view = torch_bias.view(L, Nt, ttnn.TILE_SIZE)
+
+    each_shard = []
+
+    current_N_tile = 0
+    for ring_pos in range(len(ring2cores)):
+        _, _, send_flag = ring2cores[ring_pos]
+
+        if send_flag:
+            # Type 2: Last 72 K tiles for 2 N tiles
+            first_chunk = w_tile_view[:, -72:, :, current_N_tile, :]
+            second_chunk = w_tile_view[:, -72:, :, current_N_tile + 1, :]
+
+            # Interleave the two chunks, one tile each on width dimension.
+            interleaved = torch.stack([first_chunk, second_chunk], dim=3)
+
+            # Reshape to interleave: (L, E, K, Nt * 2 * ttnn.TILE_SIZE) = (L, E, K, 4096)
+            # The order will be: w0_chunk_0, w1_chunk_0, w0_chunk_1, w1_chunk_1, ...
+            interleaved_chunks = interleaved.view(L, 72, ttnn.TILE_SIZE, 2 * ttnn.TILE_SIZE)
+
+            # Since we want the shard height to be same on all 12 cores, we add some padding here.
+            padding = torch.zeros(L, 5, ttnn.TILE_SIZE, 2 * ttnn.TILE_SIZE, dtype=torch_w.dtype)
+            torch_w_with_padding = torch.cat([interleaved_chunks, padding], dim=1)
+            each_shard.append(torch_w_with_padding)
+        else:
+            # Type 1: First 2 * 76 K tiles for 1 N tile
+            all_tiles = w_tile_view[:, : 2 * 76, :, current_N_tile, :]
+
+            # Separate the even and odd tiles.
+            even_tiles = all_tiles[:, ::2, :, :]
+            odd_tiles = all_tiles[:, 1::2, :, :]
+            interleaved = torch.cat([even_tiles, odd_tiles], dim=-1)
+
+            # Put one each of even and odd tiles in width dimension.
+            all_tiles = interleaved.reshape(L, 76, ttnn.TILE_SIZE, 2 * ttnn.TILE_SIZE)
+
+            # Create the bias tile with zero padding.
+            bias_tile = torch.zeros((L, 1, ttnn.TILE_SIZE, 2 * ttnn.TILE_SIZE), dtype=torch_bias.dtype)
+
+            # Add data from bias tensor to the bias tile.
+            bias_tile[:, 0, 0, : ttnn.TILE_SIZE] = bias_tile_view[:, current_N_tile, :]
+
+            # Append the bias tensor to the end of the all tiles.
+            w_bias_tile = torch.cat([all_tiles, bias_tile], dim=1)
+            each_shard.append(w_bias_tile)
+            current_N_tile += 1
+
+    torch_w_all_banks = torch.stack(each_shard, dim=0)
+    return torch_w_all_banks
+
+
+def prepare_output_tensor(tt_output, ring2cores):
+    """
+    Prepare the output tensor by picking the appropriate tiles from the cores that have the final data.
+
+    Args:
+        tt_output: Tensor of shape (M, in0_num_cores * ttnn.TILE_SIZE)
+        ring2cores: Dictionary mapping ring position to (core_coord, dram_bank_id, send_flag)
+
+    Returns:
+        tt_values: Tensor of shape (M, 8)
+    """
+
+    each_shard = []
+    current_column = 0
+    for ring_pos in range(len(ring2cores)):
+        _, _, send_flag = ring2cores[ring_pos]
+        if not send_flag:
+            each_shard.append(tt_output[:, current_column : current_column + ttnn.TILE_SIZE])
+        current_column += ttnn.TILE_SIZE
+
+    # --------------------------------------------------------------------------
+    # The following snippet is to be used if we want to return just the matmul
+    # output, without the final selection of top 8 experts.
+    # So we retain it for reference, but not used in the test.
+    # --------------------------------------------------------------------------
+    # output = torch.cat(each_shard, dim=1)
+
+    # # Get the 32 scores values from each tile.
+    # f1_scores = output.view(output.shape[0], -1, ttnn.TILE_SIZE)[3, :, :16]
+    # f2_scores = output.view(output.shape[0], -1, ttnn.TILE_SIZE)[4, :, :16]
+
+    # group_scores = torch.cat([f1_scores, f2_scores], dim=-1)
+    # return group_scores.transpose(0, 1)
+    # --------------------------------------------------------------------------
+
+    # Only the last core has the values in the first 8 rows of the first 2 faces of the tile
+    tt_values = each_shard[-1][:8, :].transpose(0, 1)
+    tt_as_bf16_indices = each_shard[-1][8:16, :].transpose(0, 1).view(torch.uint16)
+
+    # Initialize an empty array of shape tt_indices
+    tt_indices = torch.empty(tt_as_bf16_indices.shape, dtype=torch.uint16)
+    for m, k in itertools.product(range(tt_as_bf16_indices.shape[0]), range(tt_as_bf16_indices.shape[1])):
+        tt_indices[m, k] = tt_as_bf16_indices[m, k].item() >> 7
+
+    return tt_values, tt_indices
+
+
+def get_accuracy_metrics(torch_output, tt_output):
+    _pcc_passed, pcc_val = comp_pcc(torch_output, tt_output)
+    std = torch_output.std().item()
+    relative_rmse_val = (torch.nn.functional.mse_loss(torch_output, tt_output).sqrt().item() / std) if std != 0 else 0.0
+    allclose_passed, allclose_val = comp_allclose(torch_output, tt_output, rtol=2e-2, atol=1e-1)
+    return {
+        "pcc": pcc_val,
+        "relative_rmse": relative_rmse_val,
+        "allclose": allclose_passed,
+        "allclose_val": allclose_val,
+    }
+
+
+def run_test_moe_mm(device, M, K, N, L, C, check_accuracy, dump_outputs):
+    torch.manual_seed(0)
+
+    logger.info(
+        f"Running test_moe_mm with M={M}, K={K}, N={N}, L={L}, C={C}, check_accuracy={check_accuracy}, dump_outputs={dump_outputs}"
+    )
+
+    # --------------------------------------------------------------------------
+    # Shard grid
+    # --------------------------------------------------------------------------
+    in0_core_coords = device.get_optimal_dram_bank_to_logical_worker_assignment(ttnn.NOC.NOC_0)
+
+    core2dram = {}
+    for dram_bank_id, core_coords in enumerate(in0_core_coords):
+        core2dram[core_coords] = dram_bank_id
+
+    in0_num_cores = len(in0_core_coords)
+
+    # Make a new list of core coords that are sorted in decreasing order by y coordinate and then x coordinate.
+    in0_core_coords_sorted = sorted(in0_core_coords, key=lambda x: (x.y, x.x), reverse=True)
+
+    ring2cores = {}
+    for ring_pos, core_coord in enumerate(in0_core_coords_sorted):
+        # key: ring_pos, value: (core_coord, dram_bank_id, send_flag)
+        ring2cores[ring_pos] = (core_coord, core2dram[core_coord], 1 if ring_pos in SEND_CORES else 0)
+
+    in0_core_range = [ttnn.CoreRange(in0_core_coord, in0_core_coord) for in0_core_coord in in0_core_coords_sorted]
+    in0_core_range_set = ttnn.CoreRangeSet(in0_core_range)
+
+    # --------------------------------------------------------------------------
+    # Constants
+    # --------------------------------------------------------------------------
+    in0_dtype = ttnn.bfloat16
+    w_dtype = ttnn.bfloat16
+    num_dram_banks = len(in0_core_coords)
+
+    dram_core_coords = [ttnn.CoreCoord(core2dram[in0_core_coord], 0) for in0_core_coord in in0_core_coords_sorted]
+    dram_core_range = [ttnn.CoreRange(dram_core_coord, dram_core_coord) for dram_core_coord in dram_core_coords]
+    dram_core_range_set = ttnn.CoreRangeSet(dram_core_range)
+
+    # --------------------------------------------------------------------------
+    # Tensor shapes and memory configurations
+    # --------------------------------------------------------------------------
+    # Define tensor shapes - same for both accuracy and performance testing
+    input_shape = (in0_num_cores, M, K)
+
+    in0_shard_spec = ttnn.ShardSpec(
+        grid=in0_core_range_set,
+        shard_shape=(M, K),
+        shard_orientation=ttnn.ShardOrientation.ROW_MAJOR,
+    )
+
+    # Each core gets a copy of the original (M, K) input
+    input_sharded_mem_config = ttnn.MemoryConfig(
+        ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, in0_shard_spec
+    )
+
+    # ------------------------------------------------------------------------
+    # Create DRAM shard spec for w
+    # Tensor shape: (L, K, N) -> Sharded across N cores
+    # ------------------------------------------------------------------------
+    w_shard_height = L * (76 + 1) * ttnn.TILE_SIZE
+    w_shard_width = 2 * ttnn.TILE_SIZE
+
+    w_shard_spec = ttnn.ShardSpec(dram_core_range_set, (w_shard_height, w_shard_width), ttnn.ShardOrientation.ROW_MAJOR)
+
+    w_mem_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.DRAM, w_shard_spec)
+
+    # ------------------------------------------------------------------------
+    # Create DRAM shard spec for output
+    # Tensor shape: (M, N) -> Sharded across 8 cores
+    # ------------------------------------------------------------------------
+    output_shard_height = M
+    output_shard_width = ttnn.TILE_SIZE
+    output_shard_spec = ttnn.ShardSpec(
+        in0_core_range_set, (output_shard_height, output_shard_width), ttnn.ShardOrientation.ROW_MAJOR
+    )
+    output_mem_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.WIDTH_SHARDED, ttnn.BufferType.L1, output_shard_spec)
+    tt_output = ttnn.empty(
+        (M, in0_num_cores * ttnn.TILE_SIZE),
+        dtype=in0_dtype,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=output_mem_config,
+    )
+
+    # ------------------------------------------------------------------------
+    # Prepare the tensors
+    # --------------------------------------------------------------------------
+    if check_accuracy:
+        torch_input = create_torch_input(L, in0_num_cores, M, K)
+        torch_w = create_torch_w(L, K, N)
+        torch_bias = create_torch_bias(L, N)
+
+        # ------------------------------------------------------------------------
+        # Prepare w tensor (padded, and reordered)
+        torch_w_reordered = prepare_w_tensor(torch_w, torch_bias, L, K, N, ring2cores)
+        # Create tt_w tensor with DRAM sharding
+        tt_w = ttnn.from_torch(
+            torch_w_reordered,
+            dtype=w_dtype,
+            device=device,
+            layout=ttnn.TILE_LAYOUT,
+            memory_config=w_mem_config,
+        )
+    else:
+        tt_input = ttnn.empty(
+            input_shape,
+            dtype=in0_dtype,
+            device=device,
+            layout=ttnn.TILE_LAYOUT,
+            memory_config=input_sharded_mem_config,
+        )
+        tt_w = ttnn.empty(
+            (num_dram_banks, L, w_shard_height, w_shard_width),
+            dtype=w_dtype,
+            device=device,
+            layout=ttnn.TILE_LAYOUT,
+            memory_config=w_mem_config,
+        )
+
+    # --------------------------------------------------------------------------
+    # Run the operation
+    # --------------------------------------------------------------------------
+    # Collect accuracy metrics for all layers and experts
+    all_outputs = []
+    all_accuracy_metrics = {}
+
+    for layer_id, column_id in itertools.product(range(L), range(C)):
+        if check_accuracy:
+            tt_input = ttnn.from_torch(
+                torch_input[layer_id],
+                dtype=in0_dtype,
+                device=device,
+                layout=ttnn.TILE_LAYOUT,
+                memory_config=input_sharded_mem_config,
+            )
+
+        ttnn.experimental.deepseek.moe.moe_gate_mm(
+            tt_input,
+            w_tensor=tt_w,
+            output_tensor=tt_output,
+            layer_id=layer_id,
+            column_id=column_id,
+        )
+
+        tt_to_torch_output = ttnn.to_torch(tt_output)
+        all_outputs.append(tt_to_torch_output)
+
+    tt_to_torch_outputs = torch.stack(all_outputs)
+
+    if check_accuracy:
+        with torch.no_grad():
+            # Reference calculation to match TT output shape (2*M, N) = (E*M, N)
+            # Use first 2*M rows of input (one copy of the original replicated input)
+            torch_input_ref = torch_input[:, 0, ...]
+
+            # 1. Linear projection: scores = x @ weight
+            # (L, M, K) @ (L, K, N) -> (L, M, N)
+            torch_mm_out = torch_input_ref @ torch_w
+
+            # 2. Sigmoid activation: scores = sigmoid(scores)
+            torch_sigmoid_out = torch.nn.functional.sigmoid(torch_mm_out)
+
+            # 3. Store original scores: original_scores = scores
+            torch_original_scores = torch_sigmoid_out.clone()
+
+            # 4. Add bias: scores = scores + bias
+            torch_bias_out = torch_sigmoid_out + torch_bias[:, None, :]
+
+            # 5. Reshape to groups of 8
+            num_groups = 8
+            torch_bias_out = torch_bias_out.reshape(L, M, num_groups, -1)
+
+            # 6. Compute group scores: sum of top-2 scores for each group
+            torch_topk_out = torch.topk(torch_bias_out, k=2, dim=-1)[0].sum(dim=-1)
+
+            # 7. Select top groups: 4 group indices for each token
+            torch_top4_groups = torch.topk(torch_topk_out, k=4, dim=-1)[1]
+
+            # 7a. Get bitmask for each token, of 8 bits, 1 for each group
+            torch_group_bitmask = (
+                (1 << torch_top4_groups[:, :, 0])
+                + (1 << torch_top4_groups[:, :, 1])
+                + (1 << torch_top4_groups[:, :, 2])
+                + (1 << torch_top4_groups[:, :, 3])
+            )
+
+            # 8. Create group mask: mask = scatter(ones, indices)
+            torch_group_mask = torch.zeros((L, M, num_groups), dtype=torch.bool)
+            torch_group_mask.scatter_(2, torch_top4_groups, 1)
+
+            # 9. Mask and flatten scores
+            torch_masked_scores = (torch_bias_out * torch_group_mask.unsqueeze(-1)).flatten(2)
+
+            # 10. Select top 8 experts
+            torch_top8_values, torch_top8_indices = torch.topk(torch_masked_scores, k=8, dim=-1)
+
+            # 11. Gather original scores: weights = original_scores.gather(1, indices)
+            torch_weights = torch_original_scores.gather(-1, torch_top8_indices)
+
+            # 12. Normalize weights: weights = weights / weights.sum(dim=-1, keepdim=True)
+            torch_weights_scaled = 2.5 * (torch_weights / torch_weights.sum(dim=-1, keepdim=True))
+
+            # 13. Create a token -> experts bitmask for each column
+            group_idx, bit_idx = torch_top8_indices // ttnn.TILE_SIZE, torch_top8_indices % ttnn.TILE_SIZE
+            bit_values = (1 << bit_idx).to(torch.int32)
+
+            torch_bitmask = torch.zeros(L, M, 8, dtype=torch.int32)
+
+            for i in range(8):
+                mask = group_idx == i
+                masked_bits = torch.where(mask, bit_values, 0)
+                # OR reduction along N dimension
+                torch_bitmask[:, :, i] = masked_bits.sum(dim=2)
+
+        # Calculate accuracy metrics for each layer
+        for layer_id, column_id in itertools.product(range(L), range(C)):
+            torch_layer_values = torch_top8_values[layer_id, :, :]
+            torch_layer_indices = torch_top8_indices[layer_id, :, :]
+            tt_layer_output = tt_to_torch_outputs[C * layer_id + column_id, :, :]
+            tt_values, tt_indices = prepare_output_tensor(tt_layer_output, ring2cores)
+            layer_metrics = get_accuracy_metrics(torch_layer_values, tt_values)
+            all_accuracy_metrics[layer_id] = layer_metrics
+
+    if dump_outputs:
+        torch.set_printoptions(profile="full")
+        var2filename = {
+            tt_to_torch_outputs: "tt_w_output_act.txt",
+        }
+        if check_accuracy:
+            var2filename[torch_top8_values] = "torch_w_output_ref.txt"
+
+        for var, filename in var2filename.items():
+            with open(filename, "w") as f:
+                f.write(str(var))
+
+    return all_accuracy_metrics
+
+
+SHAPE2TIME = {
+    (32, 7168, 256, 1, 1): 27,
+}
+
+
+@pytest.mark.parametrize(
+    "device_params",
+    [
+        pytest.param(
+            {
+                "dispatch_core_axis": ttnn.DispatchCoreAxis.ROW,
+            },
+            id="dispatch_row",
+        )
+    ],
+    indirect=True,
+)
+@pytest.mark.parametrize(
+    "M, K, N, L, C",
+    SHAPE2TIME.keys(),
+)
+@pytest.mark.parametrize("check_accuracy", [True], ids=["check_accuracy_True"])
+@pytest.mark.parametrize("dump_outputs", [False], ids=["dump_outputs_False"])
+def test_moe_mm(device, M, K, N, L, C, check_accuracy, dump_outputs):
+    accuracy_metrics = run_test_moe_mm(
+        device,
+        M,
+        K,
+        N,
+        L,
+        C,
+        check_accuracy,
+        dump_outputs,
+    )
+
+    passing = True
+    # Print the layers that did not pass the PCC check
+    for layer_id, metrics in accuracy_metrics.items():
+        if metrics["pcc"] < PCC_THRESHOLD:
+            passing = False
+            logger.warning(f"Layer {layer_id}: PCC={metrics['pcc']:.6f}")
+        else:
+            logger.info(f"Layer {layer_id}: PCC={metrics['pcc']:.6f} (Passed)")
+
+    assert passing, f"Some layers did not pass the PCC/Allclose check"

--- a/tests/ttnn/nightly/unit_tests/operations/experimental/test_moe_mm.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/test_moe_mm.py
@@ -11,11 +11,6 @@ from loguru import logger
 
 from models.common.utility_functions import comp_pcc, comp_allclose
 
-from tracy.process_model_log import (
-    run_device_profiler,
-)
-
-
 PCC_THRESHOLD = 0.97
 
 """

--- a/tests/ttnn/nightly/unit_tests/operations/experimental/test_moe_mm.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/test_moe_mm.py
@@ -12,9 +12,9 @@ from loguru import logger
 from models.common.utility_functions import comp_pcc, comp_allclose
 
 from tracy.process_model_log import (
-    get_latest_ops_log_filename,
     run_device_profiler,
 )
+
 
 PCC_THRESHOLD = 0.97
 

--- a/tests/ttnn/nightly/unit_tests/operations/experimental/test_moe_mm_perf.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/test_moe_mm_perf.py
@@ -1,0 +1,58 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+import math
+import pandas as pd
+import pytest
+import ttnn
+from loguru import logger
+
+from tracy.process_model_log import (
+    get_latest_ops_log_filename,
+    run_device_profiler,
+)
+
+from tests.ttnn.nightly.unit_tests.operations.experimental.test_moe_mm import SHAPE2TIME
+
+
+@pytest.mark.parametrize(
+    "M, K, N, L, C",
+    SHAPE2TIME.keys(),
+)
+@pytest.mark.parametrize("check_accuracy", [True], ids=["check_accuracy_True"])
+@pytest.mark.parametrize("dump_outputs", [False], ids=["dump_outputs_False"])
+def test_moe_mm_performance(M, K, N, L, C, check_accuracy, dump_outputs):
+    command = f"pytest tests/ttnn/nightly/unit_tests/operations/experimental/test_moe_mm.py::test_moe_mm[dump_outputs_{dump_outputs}-check_accuracy_{check_accuracy}-M={M}-K={K}-N={N}-L={L}-C={C}-dispatch_row]"
+    run_device_profiler(command, "ttnn_moe_mm_performance", device_analysis_types=["device_kernel_duration"])
+
+    r = post_process_ops_log("ttnn_moe_mm_performance", float_columns=["DEVICE KERNEL DURATION [ns]"])
+    duration_us = r["DEVICE KERNEL DURATION [ns]"].sum() / 1000.0
+    logger.info(f"Duration per layer: {duration_us / L} us")
+    logger.warning(f"Total Duration: {duration_us} us")
+
+    bytes_per_tile = 2048  # bfloat16
+    num_cores = 12
+
+    Kt, Nt = math.ceil(K / ttnn.TILE_SIZE), math.ceil(N / ttnn.TILE_SIZE)
+    w_tiles_per_core = 2 * 76
+
+    total_bytes_transferred = L * num_cores * w_tiles_per_core * bytes_per_tile
+    realized_bandwidth = int(total_bytes_transferred / (duration_us * 1000))
+    logger.warning(f"Realized Bandwidth: {realized_bandwidth} GB/s")
+
+    total_tiles = Kt * Nt
+    total_bytes_used = L * total_tiles * bytes_per_tile
+    bandwidth = int(total_bytes_used / (duration_us * 1000))
+    logger.warning(f"Useful Bandwidth: {bandwidth} GB/s")
+
+    assert (
+        duration_us < SHAPE2TIME[(M, K, N, L, C)]
+    ), f"Performance {duration_us} us is greater than expected {SHAPE2TIME[(M, K, N, L, C)]} us"
+
+
+def post_process_ops_log(output_logs_subdir: str, float_columns: list[str]) -> dict[str, float]:
+    filename = get_latest_ops_log_filename(output_logs_subdir)
+
+    df = pd.read_csv(filename)
+    return {col: df[col].astype(float).to_numpy() for col in float_columns}

--- a/tests/ttnn/nightly/unit_tests/operations/experimental/test_moe_mm_perf.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/test_moe_mm_perf.py
@@ -51,7 +51,7 @@ def test_moe_mm_performance(M, K, N, L, C, check_accuracy, dump_outputs):
     ), f"Performance {duration_us} us is greater than expected {SHAPE2TIME[(M, K, N, L, C)]} us"
 
 
-def post_process_ops_log(output_logs_subdir: str, float_columns: list[str]) -> dict[str, float]:
+def post_process_ops_log(output_logs_subdir: str, float_columns: list[str]):
     filename = get_latest_ops_log_filename(output_logs_subdir)
 
     df = pd.read_csv(filename)

--- a/ttnn/CMakeLists.txt
+++ b/ttnn/CMakeLists.txt
@@ -278,6 +278,7 @@ set(TTNN_SRC_PYBIND
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/experimental/conv3d/conv3d_nanobind.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/experimental/minimal_matmul/minimal_matmul_nanobind.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/experimental/minimal_matmul/minimal_matmul_split_nanobind.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/experimental/deepseek/moe/moe_gate_mm/moe_gate_mm_nanobind.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/experimental/copy/typecast/typecast_nanobind.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/experimental/dropout/dropout_nanobind.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/experimental/isin/isin_nanobind.cpp
@@ -676,6 +677,7 @@ target_link_libraries(
         TTNN::Ops::Experimental::Matmul
         TTNN::Ops::Experimental::PaddedSlice
         TTNN::Ops::Experimental::MinimalMatmul
+        TTNN::Ops::Experimental::DeepSeek::MoE::MoEGateMM
         TTNN::Ops::Experimental::PagedCache
         TTNN::Ops::Experimental::PlusOne
         TTNN::Ops::Experimental::Reduction
@@ -916,6 +918,7 @@ add_subdirectory(cpp/ttnn/operations/experimental/dropout)
 add_subdirectory(cpp/ttnn/operations/experimental/isin)
 add_subdirectory(cpp/ttnn/operations/experimental/matmul)
 add_subdirectory(cpp/ttnn/operations/experimental/minimal_matmul)
+add_subdirectory(cpp/ttnn/operations/experimental/deepseek/moe/moe_gate_mm)
 add_subdirectory(cpp/ttnn/operations/experimental/padded_slice)
 add_subdirectory(cpp/ttnn/operations/experimental/paged_cache)
 add_subdirectory(cpp/ttnn/operations/experimental/plusone)

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek/moe/moe_gate_mm/CMakeLists.txt
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek/moe/moe_gate_mm/CMakeLists.txt
@@ -1,0 +1,22 @@
+add_library(ttnn_op_experimental_deepseek_moe_moe_gate_mm ${LIB_TYPE})
+add_library(TTNN::Ops::Experimental::DeepSeek::MoE::MoEGateMM ALIAS ttnn_op_experimental_deepseek_moe_moe_gate_mm)
+
+target_precompile_headers(ttnn_op_experimental_deepseek_moe_moe_gate_mm REUSE_FROM TT::CommonPCH)
+TT_ENABLE_UNITY_BUILD(ttnn_op_experimental_deepseek_moe_moe_gate_mm)
+
+target_sources(
+    ttnn_op_experimental_deepseek_moe_moe_gate_mm
+    PRIVATE
+        device/moe_gate_mm_device_operation.cpp
+        device/moe_gate_mm_program_factory.cpp
+)
+
+target_include_directories(ttnn_op_experimental_deepseek_moe_moe_gate_mm PRIVATE ${FixmeOpIncDirs})
+target_link_libraries(
+    ttnn_op_experimental_deepseek_moe_moe_gate_mm
+    PRIVATE
+        TT::Metalium
+        TTNN::Core
+)
+
+install(TARGETS ttnn_op_experimental_deepseek_moe_moe_gate_mm LIBRARY COMPONENT tar)

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek/moe/moe_gate_mm/device/kernels/bias_bcast_sfpu.h
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek/moe/moe_gate_mm/device/kernels/bias_bcast_sfpu.h
@@ -1,0 +1,155 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+#include "api/compute/common_globals.h"
+
+/**
+ * @brief Broadcasts a 1-row bias and adds it element-wise to all 32 rows of a tile.
+ *
+ * Loads 4 FP16B bias values from the bias tile (DST offset 128, i.e. tile 2, face 0
+ * rows 0-3) into LREG4-7. These 4 values, after transpose, represent a single bias
+ * value broadcast across all 32 lanes. Then iterates over all 8 groups of 4 rows in
+ * the input tile (4 groups in the upper faces, 4 in the lower faces), loading each
+ * group, transposing, performing SFPMAD (input * 1.0 + bias), transposing back, and
+ * storing in-place. The first group's instruction sequence is recorded into the replay
+ * buffer and replayed for the remaining 3 groups per half-tile.
+ *
+ * Input:  32 FP16B values per lane from the DST tile at `input_index` (all 4 faces,
+ *         32 rows total). 4 FP16B bias values from the DST tile at offset 128 (tile 2).
+ * Output: 32 FP16B values per lane, written back in-place to the same DST tile at
+ *         `input_index`. Each value is incremented by the broadcast bias.
+ */
+
+namespace ckernel {
+
+#ifdef TRISC_MATH
+#include "llk_math_eltwise_unary_sfpu_init.h"
+#include "llk_math_eltwise_unary_sfpu_params.h"
+#include "ckernel.h"
+#include "ckernel_addrmod.h"
+#include "lltt.h"
+#include "sfpi.h"
+
+namespace sfpu {
+
+inline void _add_bias_configure_addrmod_() {
+    // SFPU configuration shifts to use ADDRMOD4-7.
+    constexpr uint32_t ADDRMOD_OFFSET = 4;
+
+    addr_mod_t{
+        .dest = {.incr = -18, .clr = 0, .cr = 0, .c_to_cr = 0},
+    }
+        .set(ADDRMOD_OFFSET + ADDR_MOD_0);
+
+    addr_mod_t{
+        .dest = {.incr = 2, .clr = 0, .cr = 0, .c_to_cr = 0},
+    }
+        .set(ADDRMOD_OFFSET + ADDR_MOD_1);
+
+    addr_mod_t{
+        .dest = {.incr = 14, .clr = 0, .cr = 0, .c_to_cr = 0},
+    }
+        .set(ADDRMOD_OFFSET + ADDR_MOD_2);
+
+    addr_mod_t{
+        .dest = {.incr = -14, .clr = 0, .cr = 0, .c_to_cr = 0},
+    }
+        .set(ADDRMOD_OFFSET + ADDR_MOD_3);
+}
+
+inline void _add_bias_(uint32_t bias_index) {
+    TTI_SETRWC(p_setrwc::CLR_NONE, 0, 0, 0, 0, p_setrwc::SET_D);
+
+    // Let us load in the bias values
+    TTI_SFPLOAD(p_sfpu::LREG4, InstrModLoadStore::FP16B, ADDR_MOD_1, 128);
+    TTI_SFPLOAD(p_sfpu::LREG5, InstrModLoadStore::FP16B, ADDR_MOD_2, 128);
+    TTI_SFPLOAD(p_sfpu::LREG6, InstrModLoadStore::FP16B, ADDR_MOD_1, 128);
+    TTI_SFPLOAD(p_sfpu::LREG7, InstrModLoadStore::FP16B, ADDR_MOD_0, 128);
+
+    lltt::record<lltt::Exec>(0, 4 + 1 + 5 + 1 + 4);
+    // Now load in the input, 4 rows at a time
+    TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::FP16B, ADDR_MOD_1, 0);
+    TTI_SFPLOAD(p_sfpu::LREG1, InstrModLoadStore::FP16B, ADDR_MOD_2, 0);
+    TTI_SFPLOAD(p_sfpu::LREG2, InstrModLoadStore::FP16B, ADDR_MOD_1, 0);
+    TTI_SFPLOAD(p_sfpu::LREG3, InstrModLoadStore::FP16B, ADDR_MOD_0, 0);
+
+    TTI_SFPTRANSP(0, 0, 0, 0);
+
+    // Now add the bias values to the input
+    TTI_SFPMAD(p_sfpu::LREG0, p_sfpu::LCONST_1, p_sfpu::LREG4, p_sfpu::LREG0, 0);
+    TTI_SFPMAD(p_sfpu::LREG1, p_sfpu::LCONST_1, p_sfpu::LREG4, p_sfpu::LREG1, 0);
+    TTI_SFPMAD(p_sfpu::LREG2, p_sfpu::LCONST_1, p_sfpu::LREG4, p_sfpu::LREG2, 0);
+    TTI_SFPMAD(p_sfpu::LREG3, p_sfpu::LCONST_1, p_sfpu::LREG4, p_sfpu::LREG3, 0);
+    TTI_SFPNOP;
+
+    TTI_SFPTRANSP(0, 0, 0, 0);
+
+    // Now store the output
+    TTI_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::FP16B, ADDR_MOD_1, 0);
+    TTI_SFPSTORE(p_sfpu::LREG1, InstrModLoadStore::FP16B, ADDR_MOD_2, 0);
+    TTI_SFPSTORE(p_sfpu::LREG2, InstrModLoadStore::FP16B, ADDR_MOD_1, 0);
+    TTI_SFPSTORE(p_sfpu::LREG3, InstrModLoadStore::FP16B, ADDR_MOD_3, 0);
+
+    // Now do this 3 more times, to complete first two faces (16 rows)
+    for (uint32_t i = 0; i < 3; ++i) {
+        lltt::replay(0, 15);
+    }
+
+    TTI_SETRWC(p_setrwc::CLR_NONE, 0, 0, 0, 0, p_setrwc::SET_D);
+
+    lltt::record<lltt::Exec>(15, 4 + 1 + 5 + 1 + 4);
+    // Now load in the input, 4 rows at a time
+    TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::FP16B, ADDR_MOD_1, 32 + 0);
+    TTI_SFPLOAD(p_sfpu::LREG1, InstrModLoadStore::FP16B, ADDR_MOD_2, 32 + 0);
+    TTI_SFPLOAD(p_sfpu::LREG2, InstrModLoadStore::FP16B, ADDR_MOD_1, 32 + 0);
+    TTI_SFPLOAD(p_sfpu::LREG3, InstrModLoadStore::FP16B, ADDR_MOD_0, 32 + 0);
+
+    TTI_SFPTRANSP(0, 0, 0, 0);
+
+    // Now add the bias values to the input
+    TTI_SFPMAD(p_sfpu::LREG0, p_sfpu::LCONST_1, p_sfpu::LREG4, p_sfpu::LREG0, 0);
+    TTI_SFPMAD(p_sfpu::LREG1, p_sfpu::LCONST_1, p_sfpu::LREG4, p_sfpu::LREG1, 0);
+    TTI_SFPMAD(p_sfpu::LREG2, p_sfpu::LCONST_1, p_sfpu::LREG4, p_sfpu::LREG2, 0);
+    TTI_SFPMAD(p_sfpu::LREG3, p_sfpu::LCONST_1, p_sfpu::LREG4, p_sfpu::LREG3, 0);
+    TTI_NOP;
+
+    TTI_SFPTRANSP(0, 0, 0, 0);
+
+    // Now store the output
+    TTI_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::FP16B, ADDR_MOD_1, 32 + 0);
+    TTI_SFPSTORE(p_sfpu::LREG1, InstrModLoadStore::FP16B, ADDR_MOD_2, 32 + 0);
+    TTI_SFPSTORE(p_sfpu::LREG2, InstrModLoadStore::FP16B, ADDR_MOD_1, 32 + 0);
+    TTI_SFPSTORE(p_sfpu::LREG3, InstrModLoadStore::FP16B, ADDR_MOD_3, 32 + 0);
+
+    // Now do this 3 more times, to complete lower two faces (16 rows)
+    for (uint32_t i = 0; i < 3; ++i) {
+        lltt::replay(15, 15);
+    }
+}
+
+}  // namespace sfpu
+
+inline void _llk_math_add_bias_init_() {
+    llk_math_eltwise_unary_sfpu_init<SfpuType::unused, /*APPROXIMATE=*/true>(
+        ckernel::sfpu::_add_bias_configure_addrmod_);
+}
+
+inline void _llk_math_add_bias_(uint32_t input_index, uint32_t bias_index) {
+    _llk_math_eltwise_unary_sfpu_params_</*APPROXIMATE=*/true>(
+        ckernel::sfpu::_add_bias_, input_index, VectorMode::RC_custom, bias_index);
+}
+
+#endif
+
+/**
+ * @brief Initializes the bias-broadcast-add SFPU operation.
+ */
+inline void add_bias_init() { MATH((_llk_math_add_bias_init_())); }
+
+ALWI void add_bias(uint32_t input_index, uint32_t bias_index) { MATH((_llk_math_add_bias_(input_index, bias_index))); }
+
+}  // namespace ckernel

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek/moe/moe_gate_mm/device/kernels/bias_bcast_sfpu.h
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek/moe/moe_gate_mm/device/kernels/bias_bcast_sfpu.h
@@ -61,7 +61,7 @@ inline void _add_bias_configure_addrmod_() {
         .set(ADDRMOD_OFFSET + ADDR_MOD_3);
 }
 
-inline void _add_bias_(uint32_t bias_index) {
+inline void _add_bias_() {
     TTI_SETRWC(p_setrwc::CLR_NONE, 0, 0, 0, 0, p_setrwc::SET_D);
 
     // Let us load in the bias values
@@ -138,9 +138,9 @@ inline void _llk_math_add_bias_init_() {
         ckernel::sfpu::_add_bias_configure_addrmod_);
 }
 
-inline void _llk_math_add_bias_(uint32_t input_index, uint32_t bias_index) {
+inline void _llk_math_add_bias_(uint32_t input_index) {
     _llk_math_eltwise_unary_sfpu_params_</*APPROXIMATE=*/true>(
-        ckernel::sfpu::_add_bias_, input_index, VectorMode::RC_custom, bias_index);
+        ckernel::sfpu::_add_bias_, input_index, VectorMode::RC_custom);
 }
 
 #endif
@@ -150,6 +150,6 @@ inline void _llk_math_add_bias_(uint32_t input_index, uint32_t bias_index) {
  */
 inline void add_bias_init() { MATH((_llk_math_add_bias_init_())); }
 
-ALWI void add_bias(uint32_t input_index, uint32_t bias_index) { MATH((_llk_math_add_bias_(input_index, bias_index))); }
+ALWI void add_bias(uint32_t input_index) { MATH((_llk_math_add_bias_(input_index))); }
 
 }  // namespace ckernel

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek/moe/moe_gate_mm/device/kernels/compute.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek/moe/moe_gate_mm/device/kernels/compute.cpp
@@ -1,0 +1,377 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "api/compute/compute_kernel_api.h"
+#include "api/compute/common.h"
+#include "api/compute/bcast.h"
+#include "api/compute/copy_dest_values.h"
+#include "api/compute/eltwise_binary.h"
+#include "api/compute/matmul.h"
+#include "api/compute/tile_move_copy.h"
+#include "api/compute/transpose_wh.h"
+
+#include "bias_bcast_sfpu.h"
+#include "top2_sum_sfpu.h"
+#include "top4_sfpu.h"
+#include "top8_sfpu.h"
+#include "top8_merge_sfpu.h"
+
+void kernel_main() {
+    constexpr uint32_t layer_id = get_named_compile_time_arg_val("layer_id");
+    constexpr uint32_t num_cores = get_named_compile_time_arg_val("num_cores");
+    constexpr uint32_t collector_physical_x = get_named_compile_time_arg_val("collector_physical_x");
+    constexpr uint32_t collector_physical_y = get_named_compile_time_arg_val("collector_physical_y");
+    constexpr uint32_t first_physical_x = get_named_compile_time_arg_val("first_physical_x");
+    constexpr uint32_t first_physical_y = get_named_compile_time_arg_val("first_physical_y");
+    constexpr uint32_t column_id = get_named_compile_time_arg_val("column_id");
+
+    // Run-time arguments
+    uint32_t argidx = 0;
+    const auto dram_bank_id = get_arg_val<uint32_t>(argidx++);
+    const auto vchannel = get_arg_val<uint32_t>(argidx++);
+    const auto in_addr = get_arg_val<uint32_t>(argidx++);
+    const auto w_addr = get_arg_val<uint32_t>(argidx++);
+    const auto out_addr = get_arg_val<uint32_t>(argidx++);
+    const auto partial_semaphore = get_arg_val<uint32_t>(argidx++);
+    const auto is_send_core = get_arg_val<uint32_t>(argidx++);
+    const auto neighbor1_physical_x = get_arg_val<uint32_t>(argidx++);
+    const auto neighbor1_physical_y = get_arg_val<uint32_t>(argidx++);
+    const auto neighbor2_physical_x = get_arg_val<uint32_t>(argidx++);
+    const auto neighbor2_physical_y = get_arg_val<uint32_t>(argidx++);
+    const auto core_id = get_arg_val<uint32_t>(argidx++);
+    const auto raw_scores_semaphore = get_arg_val<uint32_t>(argidx++);
+
+    // CBs
+    constexpr auto cb_r2c_w = tt::CBIndex::c_0;
+    constexpr auto cb_s2c_in = tt::CBIndex::c_1;
+    constexpr auto cb_c2w_rdy = tt::CBIndex::c_2;
+    constexpr auto cb_w2c_in2 = tt::CBIndex::c_3;
+    constexpr auto cb_s2c_out = tt::CBIndex::c_4;
+    constexpr auto cb_w2c_in3 = tt::CBIndex::c_5;
+    constexpr auto cb_w2c_in4 = tt::CBIndex::c_6;
+    constexpr auto cb_w2c_in5 = tt::CBIndex::c_7;
+    constexpr auto cb_w2c_in6 = tt::CBIndex::c_8;
+    constexpr auto cb_w2c_in7 = tt::CBIndex::c_9;
+
+    // Aliases
+    constexpr auto cb_w2c_in8 = tt::CBIndex::c_6;
+
+    // NOC Packet size
+    constexpr uint32_t noc_packet_size = 8192;
+
+    // Constants for MoE Gate MM
+    const uint32_t num_w_tiles_h = is_send_core ? (2 * 72) : (2 * 76 + 1);
+    constexpr uint32_t num_w_tiles_w = 1;
+
+    //-------------------------------------------------------------------------
+    // W reading constants
+    //-------------------------------------------------------------------------
+    constexpr uint32_t w_txns_per_block = 8;
+    constexpr uint32_t w_tiles_per_txn = noc_packet_size / 2048;
+    constexpr uint32_t w_tiles_per_block = w_tiles_per_txn * w_txns_per_block;
+    const uint32_t w_num_blocks = num_w_tiles_h * num_w_tiles_w / w_tiles_per_block;
+    const uint32_t w_remaining_tiles = (num_w_tiles_h * num_w_tiles_w) % w_tiles_per_block;
+    const uint32_t w_last_block_txns = (w_remaining_tiles + w_tiles_per_txn - 1) / w_tiles_per_txn;  // Ceiling division
+    const uint32_t w_tiles_per_block_last = w_remaining_tiles - 1;
+    const uint32_t bias_tile_index = w_tiles_per_block_last;  // Bias is the last tile in the last block
+
+    //-------------------------------------------------------------------------
+    // Collector core
+    //-------------------------------------------------------------------------
+    constexpr uint32_t COLLECTOR_CORE_ID = 7;
+
+    //-------------------------------------------------------------------------
+    // Compute configuration
+    //-------------------------------------------------------------------------
+    // Pack is configured to Float16_b
+    pack_reconfig_data_format(cb_s2c_out);
+
+    // Unpacker B is for input/activation, so Float16_b
+    reconfig_data_format_srcb(cb_s2c_in);
+
+    // Unpacker A is for weight, so Float16_b
+    reconfig_data_format_srca(cb_r2c_w);
+
+    if (is_send_core) {
+        // Initialize matmul: input @ weight -> output
+        mm_block_init(cb_s2c_in, cb_r2c_w, cb_s2c_out, /*transpose=*/false, /*ct_dim=*/2, /*rt_dim=*/1, /*kt_dim=*/1);
+
+        //-------------------------------------------------------------------------
+        // Compute: input @ 2 weights -> 2 outputss
+        //-------------------------------------------------------------------------
+        tile_regs_acquire();
+
+        uint32_t tile_index = 2 * 76;
+        for (uint32_t block_id = 0; block_id < w_num_blocks; ++block_id) {
+            cb_wait_front(cb_r2c_w, w_tiles_per_block);
+
+            for (uint32_t tile_id = 0; tile_id < w_tiles_per_block; tile_id += 2) {
+                // Perform matmul: 1 input tile @ 2 weight tiles
+                matmul_block(
+                    cb_s2c_in,
+                    cb_r2c_w,
+                    /*in0_index=*/tile_index++,
+                    /*in1_index=*/tile_id,
+                    /*idst=*/0,
+                    /*transpose=*/false,
+                    /*ct_dim=*/2,
+                    /*rt_dim=*/1,
+                    /*kt_dim=*/1);
+            }
+            cb_pop_front(cb_r2c_w, w_tiles_per_block);
+        }
+
+        // Last block
+        cb_wait_front(cb_r2c_w, w_tiles_per_block);
+        for (uint32_t tile_id = 0; tile_id < w_tiles_per_block_last; tile_id += 2) {
+            matmul_block(
+                cb_s2c_in,
+                cb_r2c_w,
+                /*in0_index=*/tile_index++,
+                /*in1_index=*/tile_id,
+                /*idst=*/0,
+                /*transpose=*/false,
+                /*ct_dim=*/2,
+                /*rt_dim=*/1,
+                /*kt_dim=*/1);
+        }
+        cb_pop_front(cb_r2c_w, w_tiles_per_block);
+
+        tile_regs_commit();
+
+        tile_regs_wait();
+
+        cb_reserve_back(cb_c2w_rdy, 1);
+        // Since neighbor1 is farther, we send it first (dst 1)
+        pack_tile</*out_of_order_output=*/true>(1, cb_s2c_out, /*output_tile_index=*/0);
+        cb_push_back(cb_c2w_rdy, 1);
+
+        cb_reserve_back(cb_c2w_rdy, 1);
+        pack_tile</*out_of_order_output=*/true>(0, cb_s2c_out, /*output_tile_index=*/0);
+        cb_push_back(cb_c2w_rdy, 1);
+
+        tile_regs_release();
+
+        return;
+    }
+
+    // -------------------------------------------------------------------------
+    // Rest of the 8 cores do more
+    // -------------------------------------------------------------------------
+
+    // Initialize matmul: input @ weight -> output
+    mm_block_init(cb_s2c_in, cb_r2c_w, cb_s2c_out, /*transpose=*/false, /*ct_dim=*/1, /*rt_dim=*/1, /*kt_dim=*/1);
+
+    //-------------------------------------------------------------------------
+    // Compute: input @ weight -> output
+    //-------------------------------------------------------------------------
+    tile_regs_acquire();
+
+    uint32_t tile_index = 0;
+    for (uint32_t block_id = 0; block_id < w_num_blocks; ++block_id) {
+        cb_wait_front(cb_r2c_w, w_tiles_per_block);
+
+        for (uint32_t tile_id = 0; tile_id < w_tiles_per_block; ++tile_id) {
+            // Perform matmul: 1 input tile @ 1 weight tile
+            matmul_block(
+                cb_s2c_in,
+                cb_r2c_w,
+                /*in0_index=*/tile_index++,
+                /*in1_index=*/tile_id,
+                /*idst=*/0,
+                /*transpose=*/false,
+                /*ct_dim=*/1,
+                /*rt_dim=*/1,
+                /*kt_dim=*/1);
+        }
+        cb_pop_front(cb_r2c_w, w_tiles_per_block);
+    }
+
+    // Last block
+    cb_wait_front(cb_r2c_w, w_tiles_per_block);
+    for (uint32_t tile_id = 0; tile_id < w_tiles_per_block_last; ++tile_id) {
+        matmul_block(
+            cb_s2c_in,
+            cb_r2c_w,
+            /*in0_index=*/tile_index++,
+            /*in1_index=*/tile_id,
+            /*idst=*/0,
+            /*transpose=*/false,
+            /*ct_dim=*/1,
+            /*rt_dim=*/1,
+            /*kt_dim=*/1);
+    }
+
+    binary_dest_reuse_tiles_init<ELWADD, EltwiseBinaryReuseDestType::DEST_TO_SRCA>(cb_w2c_in2);
+
+    // Wait for the partial to come, add it
+    cb_wait_front(cb_w2c_in2, 1);
+    binary_dest_reuse_tiles<ELWADD, EltwiseBinaryReuseDestType::DEST_TO_SRCA>(cb_w2c_in2, 0, 0);
+    cb_pop_front(cb_w2c_in2, 1);
+
+    //-------------------------------------------------------------------------
+    // Sigmoid
+    //-------------------------------------------------------------------------
+
+    // Sigmoid the output
+    sigmoid_tile_init();
+    sigmoid_tile(0);
+
+    //-------------------------------------------------------------------------
+    // Retain a copy
+    //-------------------------------------------------------------------------
+    // Retain this copy for final scores (raw scores)
+    copy_dest_values_init();
+    copy_dest_values(0, 1);
+
+    //-------------------------------------------------------------------------
+    // Add bias
+    //-------------------------------------------------------------------------
+    copy_tile_init(cb_r2c_w);
+    copy_tile(cb_r2c_w, bias_tile_index, 2);
+    add_bias_init();
+    add_bias(0, 2);
+
+    //-------------------------------------------------------------------------
+    // Sum of top2 scores for this group
+    //-------------------------------------------------------------------------
+    // First, pack the output and bring it back as transposed
+    tile_regs_commit();
+    tile_regs_wait();
+
+    // Store the bias adjusted scores for transpose
+    cb_reserve_back(cb_s2c_out, 1);
+    pack_tile</*out_of_order_output=*/true>(0, cb_s2c_out, /*output_tile_index=*/0);
+    cb_push_back(cb_s2c_out, 1);
+
+    // Store the raw scores for transpose
+    cb_reserve_back(cb_w2c_in3, 1);
+    pack_tile(1, cb_w2c_in3);
+    cb_push_back(cb_w2c_in3, 1);
+
+    tile_regs_release();
+
+    tile_regs_acquire();
+
+    // Transpose
+    cb_wait_front(cb_s2c_out, 1);
+    transpose_wh_init_short(cb_s2c_out);
+    transpose_wh_tile(cb_s2c_out, 0, 0);
+
+    // Sum the top-2 of the output
+    sum_top2_tile_init();
+    sum_top2_tile(0);
+
+    tile_regs_commit();
+
+    cb_reserve_back(cb_c2w_rdy, 1);
+
+    tile_regs_wait();
+    // Pack output tile
+    pack_tile(0, cb_c2w_rdy);
+    tile_regs_release();
+    cb_push_back(cb_c2w_rdy, 1);
+
+    cb_pop_front(cb_r2c_w, w_tiles_per_block);
+
+    //-------------------------------------------------------------------------
+    // Non-collector cores
+    //-------------------------------------------------------------------------
+    if (core_id != COLLECTOR_CORE_ID) {
+        // Wait for the group masks
+        cb_wait_front(cb_w2c_in5, 1);
+
+        tile_regs_acquire();
+
+        // Get the adjusted scores
+        transpose_wh_init_short(cb_s2c_out);
+        transpose_wh_tile(cb_s2c_out, 0, 0);
+        cb_pop_front(cb_s2c_out, 1);
+
+        // Get the group masks
+        copy_tile_init(cb_w2c_in5);
+        copy_tile(cb_w2c_in5, 0, 2);
+
+        // Get top 8 from adjusted scores, and mask them
+        top8_tile_init();
+        top8_tile(/*tile_index=*/core_id, /*dst_index=*/0);
+
+        cb_pop_front(cb_w2c_in5, 1);
+        cb_reserve_back(cb_w2c_in8, 1);
+
+        tile_regs_commit();
+        tile_regs_wait();
+        pack_tile(0, cb_w2c_in8);
+        tile_regs_release();
+        cb_push_back(cb_w2c_in8, 1);
+    }
+
+    //-------------------------------------------------------------------------
+    // Collector core
+    //-------------------------------------------------------------------------
+    if (core_id == COLLECTOR_CORE_ID) {
+        // I am collecting, let us wait for everyone else to finish sending their data to me
+        cb_wait_front(cb_w2c_in4, 1);
+
+        tile_regs_acquire();
+        copy_tile_to_dst_init_short(cb_w2c_in4);
+
+        // Copy the group scores
+        copy_tile(cb_w2c_in4, 0, 0);
+
+        //-------------------------------------------------------------------------
+        // Top 4 groups for each token
+        //-------------------------------------------------------------------------
+        top4_tile_init();
+        top4_tile(0);
+
+        // Pack this out for other cores to get the group masks
+        tile_regs_commit();
+        tile_regs_wait();
+        cb_reserve_back(cb_w2c_in5, 1);
+        pack_tile</*out_of_order_output=*/true>(0, cb_w2c_in5, /*output_tile_index=*/0);
+        tile_regs_release();
+        cb_push_back(cb_w2c_in5, 1);
+
+        // Get top 8 from adjusted scores, and mask them
+        tile_regs_acquire();
+        transpose_wh_init_short(cb_s2c_out);
+        transpose_wh_tile(cb_s2c_out, 0, 0);
+        cb_pop_front(cb_s2c_out, 1);
+
+        copy_tile_init(cb_w2c_in5);
+        copy_tile(cb_w2c_in5, 0, 2);
+
+        top8_tile_init();
+        top8_tile(/*tile_index=*/core_id, /*dst_index=*/0);
+
+        cb_pop_front(cb_w2c_in4, 1);
+
+        // Wait for sorted top-8 from all other cores
+        cb_wait_front(cb_w2c_in6, 4);
+
+        copy_tile_init(cb_w2c_in6);
+        // Tile ID 0 has my own data, so we copy to 1-4
+        copy_tile(cb_w2c_in6, 0, 1);
+        copy_tile(cb_w2c_in6, 1, 2);
+        copy_tile(cb_w2c_in6, 2, 3);
+        copy_tile(cb_w2c_in6, 3, 4);
+
+        top8_merge_init();
+        top8_merge<column_id>();
+
+        cb_pop_front(cb_w2c_in6, 4);
+        tile_regs_commit();
+
+        tile_regs_wait();
+        cb_reserve_back(cb_s2c_out, 1);
+        pack_tile</*out_of_order_output=*/true>(0, cb_s2c_out, /*output_tile_index=*/0);
+        cb_push_back(cb_s2c_out, 1);
+        tile_regs_release();
+
+        // Let DM1 know that we are done
+        cb_reserve_back(cb_c2w_rdy, 1);
+        cb_push_back(cb_c2w_rdy, 1);
+    }
+}

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek/moe/moe_gate_mm/device/kernels/compute.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek/moe/moe_gate_mm/device/kernels/compute.cpp
@@ -98,7 +98,7 @@ void kernel_main() {
         mm_block_init(cb_s2c_in, cb_r2c_w, cb_s2c_out, /*transpose=*/false, /*ct_dim=*/2, /*rt_dim=*/1, /*kt_dim=*/1);
 
         //-------------------------------------------------------------------------
-        // Compute: input @ 2 weights -> 2 outputss
+        // Compute: input @ 2 weights -> 2 outputs
         //-------------------------------------------------------------------------
         tile_regs_acquire();
 

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek/moe/moe_gate_mm/device/kernels/compute.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek/moe/moe_gate_mm/device/kernels/compute.cpp
@@ -231,7 +231,7 @@ void kernel_main() {
     copy_tile_init(cb_r2c_w);
     copy_tile(cb_r2c_w, bias_tile_index, 2);
     add_bias_init();
-    add_bias(0, 2);
+    add_bias(0);
 
     //-------------------------------------------------------------------------
     // Sum of top2 scores for this group

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek/moe/moe_gate_mm/device/kernels/dm0.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek/moe/moe_gate_mm/device/kernels/dm0.cpp
@@ -1,0 +1,182 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+#include "api/dataflow/dataflow_api.h"
+
+// Triple buffering constants
+#define NUM_SLOTS 3  // 3 slots in CB
+
+// Helper macros for counter advancement (avoids modulo on RISC-V)
+#define ADVANCE_SLOT(s)       \
+    do {                      \
+        (s)++;                \
+        if ((s) >= NUM_SLOTS) \
+            (s) = 0;          \
+    } while (0)
+#define ADVANCE_TRID(t)      \
+    do {                     \
+        (t)++;               \
+        if ((t) > NUM_SLOTS) \
+            (t) = 1;         \
+    } while (0)
+
+void kernel_main() {
+    // Compile time arguments
+    constexpr uint32_t layer_id = get_named_compile_time_arg_val("layer_id");
+    constexpr uint32_t num_cores = get_named_compile_time_arg_val("num_cores");
+    constexpr uint32_t collector_physical_x = get_named_compile_time_arg_val("collector_physical_x");
+    constexpr uint32_t collector_physical_y = get_named_compile_time_arg_val("collector_physical_y");
+    constexpr uint32_t first_physical_x = get_named_compile_time_arg_val("first_physical_x");
+    constexpr uint32_t first_physical_y = get_named_compile_time_arg_val("first_physical_y");
+
+    constexpr auto in_args = TensorAccessorArgs<0>();
+    constexpr auto w_args = TensorAccessorArgs<in_args.next_compile_time_args_offset()>();
+    constexpr auto out_args = TensorAccessorArgs<w_args.next_compile_time_args_offset()>();
+
+    // Run-time arguments
+    uint32_t argidx = 0;
+    const auto dram_bank_id = get_arg_val<uint32_t>(argidx++);
+    const auto vchannel = get_arg_val<uint32_t>(argidx++);
+    const auto in_addr = get_arg_val<uint32_t>(argidx++);
+    const auto w_addr = get_arg_val<uint32_t>(argidx++);
+    const auto out_addr = get_arg_val<uint32_t>(argidx++);
+    const auto partial_semaphore = get_arg_val<uint32_t>(argidx++);
+    const auto is_send_core = get_arg_val<uint32_t>(argidx++);
+    const auto neighbor1_physical_x = get_arg_val<uint32_t>(argidx++);
+    const auto neighbor1_physical_y = get_arg_val<uint32_t>(argidx++);
+    const auto neighbor2_physical_x = get_arg_val<uint32_t>(argidx++);
+    const auto neighbor2_physical_y = get_arg_val<uint32_t>(argidx++);
+    const auto core_id = get_arg_val<uint32_t>(argidx++);
+    const auto raw_scores_semaphore = get_arg_val<uint32_t>(argidx++);
+
+    // CBs
+    constexpr auto cb_r2c_w = tt::CBIndex::c_0;
+    constexpr auto cb_s2c_in = tt::CBIndex::c_1;
+    constexpr auto cb_c2w_rdy = tt::CBIndex::c_2;
+    constexpr auto cb_w2c_in2 = tt::CBIndex::c_3;
+    constexpr auto cb_s2c_out = tt::CBIndex::c_4;
+    constexpr auto cb_w2c_in3 = tt::CBIndex::c_5;
+    constexpr auto cb_w2c_in4 = tt::CBIndex::c_6;
+    constexpr auto cb_w2c_in5 = tt::CBIndex::c_7;
+    constexpr auto cb_w2c_in6 = tt::CBIndex::c_8;
+    constexpr auto cb_w2c_in7 = tt::CBIndex::c_9;
+
+    // Tile sizes
+    constexpr uint32_t in_tile_size = get_tile_size(cb_s2c_in);
+    constexpr uint32_t w_tile_size = get_tile_size(cb_r2c_w);
+    constexpr uint32_t out_tile_size = get_tile_size(cb_s2c_out);
+
+    // NOC Packet size
+    constexpr uint32_t noc_packet_size = 8192;
+
+    // Constants for MoE Gate MM
+    const uint32_t num_w_tiles_h = is_send_core ? (2 * 72) : (2 * 76 + 1);
+    constexpr uint32_t num_w_tiles_w = 1;
+
+    //-------------------------------------------------------------------------
+    // W reading constants
+    //-------------------------------------------------------------------------
+    constexpr uint32_t w_txns_per_block = 8;
+    constexpr uint32_t w_tiles_per_txn = noc_packet_size / 2048;
+    constexpr uint32_t w_tiles_per_block = w_tiles_per_txn * w_txns_per_block;
+    const uint32_t w_num_blocks = num_w_tiles_h * num_w_tiles_w / w_tiles_per_block;
+    const uint32_t w_remaining_tiles = (num_w_tiles_h * num_w_tiles_w) % w_tiles_per_block;
+    const uint32_t w_last_block_txns = (w_remaining_tiles + w_tiles_per_txn - 1) / w_tiles_per_txn;  // Ceiling division
+
+    //-------------------------------------------------------------------------
+    // DRAM Reading constants
+    //-------------------------------------------------------------------------
+    constexpr uint32_t w_bytes_per_block = w_tiles_per_block * w_tile_size;
+    constexpr uint32_t w_bytes_per_txn = w_tiles_per_txn * w_tile_size;
+
+    // DRAM bank's base NOC address
+    const uint64_t dram_noc_addr =
+        get_noc_addr_from_bank_id</*DRAM=*/true>(dram_bank_id, /*bank_address_offset=*/w_addr);
+
+    //-------------------------------------------------------------------------
+    // CB addresses
+    //-------------------------------------------------------------------------
+    const uint32_t w_cb_base_addr = get_write_ptr(cb_r2c_w);
+
+    // Precompute slot addresses (avoid multiply in hot loop)
+    // Each slot holds txns_per_block tiles
+    uint32_t slot_addr[NUM_SLOTS][w_txns_per_block];
+
+    uint32_t slot_addr_offset = 0;
+    for (uint32_t i = 0; i < NUM_SLOTS; ++i) {
+        for (uint32_t j = 0; j < w_txns_per_block; ++j) {
+            slot_addr[i][j] = w_cb_base_addr + slot_addr_offset;
+            slot_addr_offset += w_bytes_per_txn;
+        }
+    }
+
+    //-------------------------------------------------------------------------
+    // Expert loop
+    //-------------------------------------------------------------------------
+    // Set w0_w1 state once before loop (will be reused for all experts)
+    noc_async_read_one_packet_set_state<true>(dram_noc_addr, w_bytes_per_txn, vchannel);
+
+    //-------------------------------------------------------------------------
+    // Variables to track pipeline state
+    //-------------------------------------------------------------------------
+    uint32_t trid_to_issue = 1, trid_to_wait = 1, slot_to_issue = 0;
+    bool txns_in_flight = false;
+
+    // We reserve one to kick start the pipeline, and then it is steady state
+    cb_reserve_back(cb_r2c_w, w_tiles_per_block);
+
+    //-------------------------------------------------------------------------
+    // Pipelined reading of W0/W1
+    //-------------------------------------------------------------------------
+    uint32_t w_dram_read_offset = 0;
+
+    for (uint32_t block_id = 0; block_id < w_num_blocks; ++block_id) {
+        // Issue reads with current trid
+        noc_async_read_set_trid(trid_to_issue);
+        for (uint32_t txn_id = 0; txn_id < w_txns_per_block; ++txn_id) {
+            noc_async_read_one_packet_with_state_with_trid</*skip_ptr_update=*/false, /*skip_cmdbuf_chk=*/true>(
+                dram_noc_addr, w_dram_read_offset, slot_addr[slot_to_issue][txn_id], trid_to_issue);
+            w_dram_read_offset += w_bytes_per_txn;
+        }
+
+        ADVANCE_SLOT(slot_to_issue);
+        ADVANCE_TRID(trid_to_issue);
+
+        // Only when we first start the pipeline, we don't have any txns in flight
+        if (txns_in_flight) {
+            noc_async_read_barrier_with_trid(trid_to_wait);
+            cb_push_back(cb_r2c_w, w_tiles_per_block);
+
+            ADVANCE_TRID(trid_to_wait);
+
+            // Reserve for next block
+            // Reserve back is not incremental, so to reserve one more, we need to reserve 2
+            // This accounts for the one we already have reserved (for in-flight read)
+            cb_reserve_back(cb_r2c_w, w_tiles_per_block * 2);
+        }
+        txns_in_flight = true;
+    }
+
+    // Issue txns for the last block
+    noc_async_read_set_trid(trid_to_issue);
+    for (uint32_t txn_id = 0; txn_id < w_last_block_txns; ++txn_id) {
+        noc_async_read_one_packet_with_state_with_trid</*skip_ptr_update=*/false, /*skip_cmdbuf_chk=*/true>(
+            dram_noc_addr, w_dram_read_offset, slot_addr[slot_to_issue][txn_id], trid_to_issue);
+        w_dram_read_offset += w_bytes_per_txn;
+    }
+
+    noc_async_read_barrier_with_trid(trid_to_wait);
+    cb_push_back(cb_r2c_w, w_tiles_per_block);
+
+    ADVANCE_TRID(trid_to_wait);
+
+    // Drain the pipeline - the last txn in flight
+    noc_async_read_barrier_with_trid(trid_to_wait);
+    cb_push_back(cb_r2c_w, w_tiles_per_block);
+}
+
+#undef ADVANCE_TRID
+#undef ADVANCE_SLOT
+#undef NUM_SLOTS

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek/moe/moe_gate_mm/device/kernels/dm1.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek/moe/moe_gate_mm/device/kernels/dm1.cpp
@@ -226,7 +226,7 @@ void kernel_main() {
         // Send the data to the neighbor1
         noc_async_write_one_packet_with_state</*posted=*/true>(local_src_addr, neighbor_dst_addr2);
 
-        // Signal neighbor1 that data is ready (increment their semaphore)
+        // Signal neighbor2 that data is ready (increment their semaphore)
         noc_inline_dw_write_set_state</*posted=*/true, /*set_val=*/true>(
             partial_semaphore_noc_addr2, /*val=*/1, /*be=*/0xF, /*cmd_buf=*/write_at_cmd_buf, /*noc=*/1, vchannel);
         noc_inline_dw_write_with_state<
@@ -246,10 +246,10 @@ void kernel_main() {
         // Wait for the data2 to be ready
         cb_wait_front(cb_c2w_rdy, 1);
 
-        // Send the data to the neighbor2
+        // Send the data to the neighbor1
         noc_async_write_one_packet_with_state</*posted=*/true>(local_src_addr, neighbor_dst_addr1);
 
-        // Signal neighbor2 that data is ready (increment their semaphore)
+        // Signal neighbor1 that data is ready (increment their semaphore)
         noc_inline_dw_write_set_state</*posted=*/true, /*set_val=*/true>(
             partial_semaphore_noc_addr1, /*val=*/1, /*be=*/0xF, /*cmd_buf=*/write_at_cmd_buf, /*noc=*/1, vchannel);
         noc_inline_dw_write_with_state<

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek/moe/moe_gate_mm/device/kernels/dm1.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek/moe/moe_gate_mm/device/kernels/dm1.cpp
@@ -1,0 +1,387 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+#include "api/dataflow/dataflow_api.h"
+#include "ckernel_defs.h"
+#include "tt-metalium/constants.hpp"
+#include "api/debug/dprint_pages.h"
+
+/**
+ * @brief Gather the raw scores based on the top8 indices
+ * @param local_top8_partials_src_addr The address of the top8 partials
+ * @param local_raw_scores_src_addr The address of the raw scores
+ * @param local_gathered_scores_src_addr The address of the gathered scores
+ */
+void gather_raw_scores(
+    uint32_t local_top8_partials_src_addr,
+    uint32_t local_raw_scores_src_addr,
+    uint32_t local_gathered_scores_src_addr) {
+    // Gather the raw scores based on the top8 indices
+    // Strategy: Process 2 adjacent tokens per iteration using 32-bit ops to halve stores
+    auto p_adj_scores = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(local_top8_partials_src_addr);
+    auto p_raw_scores = reinterpret_cast<volatile tt_l1_ptr uint16_t*>(local_raw_scores_src_addr);
+    auto p_gathered_scores = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(local_gathered_scores_src_addr);
+
+    // Process both faces (face 0: tokens 0-15, face 1: tokens 16-31)
+    for (uint32_t face = 0; face < 2; face++) {
+        const uint32_t face_off32 = face << 7;  // uint32 offset per face (128 elements)
+        const uint32_t tok_base = face << 4;    // Token base: 0 or 16
+
+        // Process all 8 ranks (8 top indices per token)
+        for (uint32_t rank = 0; rank < 8; rank++) {
+            const uint32_t idx_base32 = face_off32 + ((8 + rank) << 3);  // indices in rows 8-15
+            const uint32_t val_base32 = face_off32 + (rank << 3);        // values in rows 0-7
+
+            // Process 8 token pairs (16 tokens total per face)
+            for (uint32_t tp = 0; tp < 8; tp++) {
+                // ---- 1 × 32-bit L1 load: read 2 indices (2 adjacent token columns) ----
+                const uint32_t idx_pair = p_adj_scores[idx_base32 + tp];
+                const uint32_t idx0 = idx_pair & 0xFFFF;  // Expert index [0-31] for first token
+                const uint32_t idx1 = idx_pair >> 16;     // Expert index [0-31] for second token
+
+                const uint32_t tok = tok_base | (tp << 1);  // Token number (0-31)
+
+                // ---- Decode index 0: find score at [tok, idx0] in raw scores (single tile) ----
+                // Row-major faces: face = (expert[4] << 1) | token[4]
+                // Offset = (face << 8) | (row << 4) | col
+                //        = ((expert[4] << 1) | token[4]) << 8 | (token[3:0] << 4) | expert[3:0]
+                //        = (expert[4] << 9) | (token[4] << 8) | (token[3:0] << 4) | expert[3:0]
+                const uint32_t off0 = ((idx0 & 0x10) << 5) | ((tok & 0x10) << 4) | ((tok & 0xF) << 4) | (idx0 & 0xF);
+
+                // ---- Decode index 1: find score at [tok+1, idx1] in raw scores (single tile) ----
+                const uint32_t tok1 = tok + 1;
+                const uint32_t off1 = ((idx1 & 0x10) << 5) | ((tok1 & 0x10) << 4) | ((tok1 & 0xF) << 4) | (idx1 & 0xF);
+
+                // ---- 2 × 16-bit L1 loads: read 2 scores (random access, can't batch) ----
+                const uint32_t score0 = p_raw_scores[off0];
+                const uint32_t score1 = p_raw_scores[off1];
+
+                // ---- 1 × 32-bit L1 store: write 2 scores packed ----
+                p_gathered_scores[val_base32 + tp] = score0 | (score1 << 16);
+            }
+        }
+    }
+}
+
+void kernel_main() {
+    // Compile time arguments
+    constexpr uint32_t layer_id = get_named_compile_time_arg_val("layer_id");
+    constexpr uint32_t num_cores = get_named_compile_time_arg_val("num_cores");
+    constexpr uint32_t collector_physical_x = get_named_compile_time_arg_val("collector_physical_x");
+    constexpr uint32_t collector_physical_y = get_named_compile_time_arg_val("collector_physical_y");
+    constexpr uint32_t first_physical_x = get_named_compile_time_arg_val("first_physical_x");
+    constexpr uint32_t first_physical_y = get_named_compile_time_arg_val("first_physical_y");
+
+    constexpr auto in_args = TensorAccessorArgs<0>();
+    constexpr auto w_args = TensorAccessorArgs<in_args.next_compile_time_args_offset()>();
+    constexpr auto out_args = TensorAccessorArgs<w_args.next_compile_time_args_offset()>();
+
+    // Run-time arguments
+    uint32_t argidx = 0;
+    const auto dram_bank_id = get_arg_val<uint32_t>(argidx++);
+    const auto vchannel = get_arg_val<uint32_t>(argidx++);
+    const auto in_addr = get_arg_val<uint32_t>(argidx++);
+    const auto w_addr = get_arg_val<uint32_t>(argidx++);
+    const auto out_addr = get_arg_val<uint32_t>(argidx++);
+    const auto partial_semaphore = get_arg_val<uint32_t>(argidx++);
+    const auto is_send_core = get_arg_val<uint32_t>(argidx++);
+    const auto neighbor1_physical_x = get_arg_val<uint32_t>(argidx++);
+    const auto neighbor1_physical_y = get_arg_val<uint32_t>(argidx++);
+    const auto neighbor2_physical_x = get_arg_val<uint32_t>(argidx++);
+    const auto neighbor2_physical_y = get_arg_val<uint32_t>(argidx++);
+    const auto core_id = get_arg_val<uint32_t>(argidx++);
+    const auto raw_scores_semaphore = get_arg_val<uint32_t>(argidx++);
+
+    // CBs
+    constexpr auto cb_r2c_w = tt::CBIndex::c_0;
+    constexpr auto cb_s2c_in = tt::CBIndex::c_1;
+    constexpr auto cb_c2w_rdy = tt::CBIndex::c_2;
+    constexpr auto cb_w2c_in2 = tt::CBIndex::c_3;
+    constexpr auto cb_s2c_out = tt::CBIndex::c_4;
+    constexpr auto cb_w2c_in3 = tt::CBIndex::c_5;
+    constexpr auto cb_w2c_in4 = tt::CBIndex::c_6;
+    constexpr auto cb_w2c_in5 = tt::CBIndex::c_7;
+    constexpr auto cb_w2c_in6 = tt::CBIndex::c_8;
+    constexpr auto cb_w2c_in7 = tt::CBIndex::c_9;
+
+    // Aliases
+    constexpr auto cb_w2c_in8 = tt::CBIndex::c_6;
+
+    // Tile sizes
+    constexpr uint32_t in_tile_size = get_tile_size(cb_s2c_in);
+    constexpr uint32_t w_tile_size = get_tile_size(cb_r2c_w);
+    constexpr uint32_t out_tile_size = get_tile_size(cb_s2c_out);
+
+    // NOC Packet size
+    constexpr uint32_t noc_packet_size = 8192;
+
+    // Constants for MoE Gate MM
+    const uint32_t num_w_tiles_h = is_send_core ? 2 * 72 : 2 * 76;
+    constexpr uint32_t num_w_tiles_w = 1;
+
+    //-------------------------------------------------------------------------
+    // Reduction transactions
+    //-------------------------------------------------------------------------
+    uint32_t semaphore_addr = get_semaphore(partial_semaphore);
+    volatile tt_l1_ptr uint32_t* my_semaphore_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(semaphore_addr);
+
+    const uint64_t partial_semaphore_noc_addr1 =
+        get_noc_addr(neighbor1_physical_x, neighbor1_physical_y, semaphore_addr);
+
+    const uint64_t partial_semaphore_noc_addr2 =
+        get_noc_addr(neighbor2_physical_x, neighbor2_physical_y, semaphore_addr);
+
+    const uint32_t local_src_addr = get_write_ptr(cb_s2c_out);
+    const uint32_t local_dst_addr = get_write_ptr(cb_w2c_in2);
+    const uint64_t neighbor_dst_addr1 = get_noc_addr(neighbor1_physical_x, neighbor1_physical_y, local_dst_addr);
+    const uint64_t neighbor_dst_addr2 = get_noc_addr(neighbor2_physical_x, neighbor2_physical_y, local_dst_addr);
+
+    // Use semaphore_inc<posted=true> with 1 transaction ID and flush barrier for trids
+    constexpr uint32_t semaphore_trid = 0x4;
+
+    //-------------------------------------------------------------------------
+    // Collector core
+    //-------------------------------------------------------------------------
+    constexpr uint32_t COLLECTOR_CORE_ID = 7;
+
+    const uint32_t local_collector_addr = 1024 + get_write_ptr(cb_w2c_in4);
+    const uint64_t collector_dst_base_addr =
+        get_noc_addr(collector_physical_x, collector_physical_y, local_collector_addr);
+    const uint32_t collector_offset = core_id * out_tile_size;
+
+    constexpr uint32_t group_score_size = tt::constants::FACE_WIDTH * sizeof(uint16_t);
+
+    //-------------------------------------------------------------------------
+    // Group scores (7 cores -> 1 collector core)
+    //-------------------------------------------------------------------------
+
+    // Group scores: data exists in 1st and 4th row of the first face of the bfloat16 tile
+    constexpr uint32_t group_score_offset1 = 0;
+    constexpr uint32_t group_score_offset2 = 4 * group_score_size;
+    const uint32_t local_group_score_base_addr = get_write_ptr(cb_c2w_rdy);
+    const uint32_t local_group_score_src_addr1 = local_group_score_base_addr + group_score_offset1;
+    const uint32_t local_group_score_src_addr2 = local_group_score_base_addr + group_score_offset2;
+
+    const uint32_t local_group_scores_dst_addr1 = local_collector_addr + core_id * group_score_size;
+    const uint32_t local_group_scores_dst_addr2 = local_group_scores_dst_addr1 + 8 * group_score_size;
+
+    const uint64_t collector_semaphore_noc_addr =
+        get_noc_addr(collector_physical_x, collector_physical_y, semaphore_addr);
+
+    //-------------------------------------------------------------------------
+    // Group masks (1 collector core -> 7 cores)
+    //-------------------------------------------------------------------------
+    const uint32_t local_group_masks_addr = get_write_ptr(cb_w2c_in5);
+    const uint64_t group_masks_noc_addr = get_noc_multicast_addr(
+        first_physical_x, first_physical_y, collector_physical_x, collector_physical_y, local_group_masks_addr);
+    const uint64_t group_semaphore_noc_addr = get_noc_multicast_addr(
+        first_physical_x, first_physical_y, collector_physical_x, collector_physical_y, semaphore_addr);
+
+    //-------------------------------------------------------------------------
+    // Top8 partials (7 cores -> 1 collector core)
+    //-------------------------------------------------------------------------
+    constexpr uint32_t partials_size = 2 * tt::constants::FACE_HW * sizeof(uint16_t);  // values and indices
+
+    // Top8 partials: data exists in first 16 rows
+    const uint32_t local_top8_partials_src_addr = get_write_ptr(cb_w2c_in8);
+
+    const uint32_t local_top8_dst_base_addr = get_write_ptr(cb_w2c_in6);
+    const uint32_t local_top8_dst_addr = local_top8_dst_base_addr + core_id * partials_size;
+
+    //-------------------------------------------------------------------------
+    // Raw scores (7 cores -> 1 collector core)
+    //-------------------------------------------------------------------------
+    constexpr uint32_t raw_scores_size = tt::constants::FACE_HW * sizeof(uint16_t);
+
+    uint32_t raw_scores_semaphore_addr = get_semaphore(raw_scores_semaphore);
+    volatile tt_l1_ptr uint32_t* my_raw_scores_semaphore_ptr =
+        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(raw_scores_semaphore_addr);
+    *my_raw_scores_semaphore_ptr = 0;
+
+    // Top8 partials: after gathering, data is in the 16-31 rows
+    const uint32_t local_raw_scores_src_addr = get_write_ptr(cb_w2c_in3);
+    const uint32_t local_gathered_scores_src_addr = local_raw_scores_src_addr + raw_scores_size;
+
+    const uint32_t local_raw_scores_dst_base_addr = get_write_ptr(cb_w2c_in7);
+    const uint32_t local_raw_scores_dst_addr = local_raw_scores_dst_base_addr + core_id * raw_scores_size;
+
+    const uint64_t raw_scores_semaphore_noc_addr =
+        get_noc_addr(collector_physical_x, collector_physical_y, raw_scores_semaphore_addr);
+    const uint64_t raw_scores_noc_addr = get_noc_multicast_addr(
+        first_physical_x, first_physical_y, collector_physical_x, collector_physical_y, local_raw_scores_dst_base_addr);
+
+    //-------------------------------------------------------------------------
+    *my_semaphore_ptr = 0;
+
+    if (is_send_core) {
+        // Since neighbor2 is farther, we send it first.
+        // Set state for the writes
+        noc_async_write_one_packet_set_state</*posted=*/true>(neighbor_dst_addr2, out_tile_size, /*noc=*/1, vchannel);
+
+        // Wait for the data1 to be ready
+        cb_wait_front(cb_c2w_rdy, 1);
+
+        // Send the data to the neighbor1
+        noc_async_write_one_packet_with_state</*posted=*/true>(local_src_addr, neighbor_dst_addr2);
+
+        // Signal neighbor1 that data is ready (increment their semaphore)
+        noc_inline_dw_write_set_state</*posted=*/true, /*set_val=*/true>(
+            partial_semaphore_noc_addr2, /*val=*/1, /*be=*/0xF, /*cmd_buf=*/write_at_cmd_buf, /*noc=*/1, vchannel);
+        noc_inline_dw_write_with_state<
+            /*update_addr_lo=*/false,
+            /*update_counter=*/true,
+            /*posted=*/true,
+            /*update_addr_hi=*/false,
+            /*update_val=*/false>(/*val=*/1);
+
+        // Ensure write and semaphore have left the core before continuing
+        noc_async_posted_writes_flushed();
+
+        cb_pop_front(cb_c2w_rdy, 1);
+
+        noc_async_write_one_packet_set_state</*posted=*/true>(neighbor_dst_addr1, out_tile_size, /*noc=*/1, vchannel);
+
+        // Wait for the data2 to be ready
+        cb_wait_front(cb_c2w_rdy, 1);
+
+        // Send the data to the neighbor2
+        noc_async_write_one_packet_with_state</*posted=*/true>(local_src_addr, neighbor_dst_addr1);
+
+        // Signal neighbor2 that data is ready (increment their semaphore)
+        noc_inline_dw_write_set_state</*posted=*/true, /*set_val=*/true>(
+            partial_semaphore_noc_addr1, /*val=*/1, /*be=*/0xF, /*cmd_buf=*/write_at_cmd_buf, /*noc=*/1, vchannel);
+        noc_inline_dw_write_with_state<
+            /*update_addr_lo=*/false,
+            /*update_counter=*/true,
+            /*posted=*/true,
+            /*update_addr_hi=*/false,
+            /*update_val=*/false>(/*val=*/1);
+
+        // Ensure write and semaphore have left the core before continuing
+        noc_async_posted_writes_flushed();
+
+        cb_pop_front(cb_c2w_rdy, 1);
+
+        return;
+    }
+
+    // -------------------------------------------------------------------------
+    // Rest of the 8 cores do more
+    // -------------------------------------------------------------------------
+    cb_reserve_back(cb_w2c_in2, 1);
+
+    // Wait for the data from sender cores to be ready
+    noc_semaphore_wait_min(my_semaphore_ptr, 1);
+    *my_semaphore_ptr = 0;
+    cb_push_back(cb_w2c_in2, 1);
+
+    // Wait for group scores to be ready from compute
+    cb_wait_front(cb_c2w_rdy, 1);
+
+    //-------------------------------------------------------------------------
+    // Cores sending data to the collector core
+    //-------------------------------------------------------------------------
+    if (core_id != COLLECTOR_CORE_ID) {
+        noc_async_write_one_packet_set_state</*posted=*/true>(
+            collector_dst_base_addr, group_score_size, /*noc=*/1, vchannel);
+
+        // Send them over to the collector core
+        noc_async_write_one_packet_with_state</*posted=*/true>(
+            local_group_score_src_addr1, local_group_scores_dst_addr1);
+        noc_async_write_one_packet_with_state</*posted=*/true>(
+            local_group_score_src_addr2, local_group_scores_dst_addr2);
+
+        // Signal the collector core that data is ready (increment their semaphore)
+        noc_async_write_set_trid(semaphore_trid, /*noc=*/1);
+        noc_semaphore_inc</*posted=*/true>(collector_semaphore_noc_addr, /*incr=*/1, /*noc_id=*/1, /*vc=*/vchannel);
+        noc_async_write_flushed_with_trid(semaphore_trid, /*noc=*/1);
+
+        // We are done with the group scores
+        cb_pop_front(cb_c2w_rdy, 1);
+
+        cb_reserve_back(cb_w2c_in5, 1);
+
+        // Wait for the group mask to be ready in the collector core
+        noc_semaphore_wait_min(my_semaphore_ptr, 1);
+        *my_semaphore_ptr = 0;
+
+        // Let compute know we got the group masks
+        cb_push_back(cb_w2c_in5, 1);
+
+        // Wait for compute to send the top-8 values and indices
+        cb_wait_front(cb_w2c_in8, 1);
+
+        noc_async_write_one_packet_set_state</*posted=*/true>(
+            collector_dst_base_addr, partials_size, /*noc=*/1, vchannel);
+
+        // Send them over to the collector core
+        noc_async_write_one_packet_with_state</*posted=*/true>(local_top8_partials_src_addr, local_top8_dst_addr);
+
+        // Signal the collector core that data is ready (increment their semaphore)
+        noc_async_write_set_trid(semaphore_trid, /*noc=*/1);
+        noc_semaphore_inc</*posted=*/true>(collector_semaphore_noc_addr, /*incr=*/1, /*noc_id=*/1, /*vc=*/vchannel);
+        noc_async_write_flushed_with_trid(semaphore_trid, /*noc=*/1);
+
+        cb_pop_front(cb_w2c_in8, 1);
+    }
+
+    //-------------------------------------------------------------------------
+    // Collector core
+    //-------------------------------------------------------------------------
+    if (core_id == COLLECTOR_CORE_ID) {
+        // Rejig the group scores to be in the correct location -> where everyone else also puts it
+        auto src_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(local_group_score_src_addr1);
+        auto dst_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(local_group_scores_dst_addr1);
+        for (uint32_t i = 0; i < 8; i++) {
+            dst_ptr[i] = src_ptr[i];
+        }
+
+        // Same, but for the second row of the group scores
+        src_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(local_group_score_src_addr2);
+        dst_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(local_group_scores_dst_addr2);
+        for (uint32_t i = 0; i < 8; i++) {
+            dst_ptr[i] = src_ptr[i];
+        }
+
+        // We are done with the group scores
+        cb_pop_front(cb_c2w_rdy, 1);
+
+        cb_reserve_back(cb_w2c_in4, 1);
+
+        // I am collecting, let us wait for everyone else to finish sending their data to me
+        noc_semaphore_wait_min(my_semaphore_ptr, 7);
+        *my_semaphore_ptr = 0;
+
+        // Let compute know that we got the group scores
+        cb_push_back(cb_w2c_in4, 1);
+
+        //-----------------------------------------------------------------
+        // Get the group masks
+        //-----------------------------------------------------------------
+        cb_wait_front(cb_w2c_in5, 1);
+        // Multicast this data to all the cores
+        noc_async_write_multicast_one_packet(
+            local_group_masks_addr, group_masks_noc_addr, /*size=*/2048, /*num_dests=*/7);
+
+        // Set the semaphore to let the clients know they got the data
+        *my_semaphore_ptr = 1;
+        noc_semaphore_set_multicast(
+            semaphore_addr, group_semaphore_noc_addr, /*num_dests=*/7, /*linked=*/false, /*noc=*/1);
+
+        cb_pop_front(cb_w2c_in5, 1);
+
+        cb_reserve_back(cb_w2c_in6, 4);
+
+        // Wait for the top8 partials to arrive
+        noc_semaphore_wait_min(my_semaphore_ptr, 1 + 7);
+
+        // Let compute know that we got the top8 partials
+        cb_push_back(cb_w2c_in6, 4);
+
+        // Wait for final top8 to be ready from compute
+        cb_wait_front(cb_c2w_rdy, 1);
+        cb_pop_front(cb_c2w_rdy, 1);
+    }
+}

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek/moe/moe_gate_mm/device/kernels/top2_sum_sfpu.h
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek/moe/moe_gate_mm/device/kernels/top2_sum_sfpu.h
@@ -1,0 +1,172 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+#include "api/compute/common_globals.h"
+
+/**
+ * @brief Computes the sum of the two largest values in a tile (per lane).
+ *
+ * Reads all 32 FP16B values (8 groups of 4 rows) from the destination tile at
+ * `dst_index` and finds the top-2 maximum values using a tournament-style
+ * compare-and-swap network. Each group of 4 values is reduced to a local top-2
+ * via 5 SFPSWAP operations, then merged with the running top-2 via 3 SFPSWAPs.
+ * After processing all 8 groups, the two winners are summed (LREG0 += LREG1).
+ *
+ * Input:  32 FP16B values per lane, read in-place from the DST tile (8 groups x 4 rows,
+ *         upper and lower faces).
+ * Output: A single FP16B sum-of-top-2 value per lane, written to the first 4 rows
+ *         (rows 0, 2, 4, 6) of face 0 of the same DST tile. All 4 rows contain the
+ *         same replicated result.
+ */
+
+namespace ckernel {
+
+#ifdef TRISC_MATH
+#include "llk_math_eltwise_unary_sfpu_init.h"
+#include "llk_math_eltwise_unary_sfpu_params.h"
+#include "ckernel.h"
+#include "ckernel_addrmod.h"
+#include "lltt.h"
+#include "sfpi.h"
+
+namespace sfpu {
+
+inline void _top2_configure_addrmod_() {
+    // SFPU configuration shifts to use ADDRMOD4-7.
+    constexpr uint32_t ADDRMOD_OFFSET = 4;
+
+    addr_mod_t{
+        .dest = {.incr = 0, .clr = 0, .cr = 0, .c_to_cr = 0},
+    }
+        .set(ADDRMOD_OFFSET + ADDR_MOD_0);
+
+    addr_mod_t{
+        .dest = {.incr = 2, .clr = 0, .cr = 0, .c_to_cr = 0},
+    }
+        .set(ADDRMOD_OFFSET + ADDR_MOD_1);
+
+    addr_mod_t{
+        .dest = {.incr = 14, .clr = 0, .cr = 0, .c_to_cr = 0},
+    }
+        .set(ADDRMOD_OFFSET + ADDR_MOD_2);
+
+    addr_mod_t{
+        .dest = {.incr = -14, .clr = 0, .cr = 0, .c_to_cr = 0},
+    }
+        .set(ADDRMOD_OFFSET + ADDR_MOD_3);
+}
+
+inline void _top2_calculate_top2_() {
+    constexpr uint16_t NEG_INF_BF16 = 0xFF80;
+
+    // Reset Dst RWC to 0
+    TTI_SETRWC(p_setrwc::CLR_NONE, 0, 0, 0, 0, p_setrwc::SET_D);
+
+    // Initialize LREG0/1 with -infinity
+    TTI_SFPLOADI(ckernel::p_sfpu::LREG0, sfpi::SFPLOADI_MOD0_FLOATB, NEG_INF_BF16);
+    TTI_SFPLOADI(ckernel::p_sfpu::LREG1, sfpi::SFPLOADI_MOD0_FLOATB, NEG_INF_BF16);
+
+    //-------------------------------------------------------------------------
+    // Group 0
+    lltt::record<lltt::Exec>(0, 14);
+
+    TTI_SFPTRANSP(0, 0, 0, 0);
+    // Load 4 tile rows into LREG4-7
+    TTI_SFPLOAD(p_sfpu::LREG4, InstrModLoadStore::FP16B, ADDR_MOD_1, 0);
+    TTI_SFPLOAD(p_sfpu::LREG5, InstrModLoadStore::FP16B, ADDR_MOD_2, 0);
+    TTI_SFPLOAD(p_sfpu::LREG6, InstrModLoadStore::FP16B, ADDR_MOD_1, 0);
+    TTI_SFPLOAD(p_sfpu::LREG7, InstrModLoadStore::FP16B, ADDR_MOD_3, 0);
+    TTI_SFPTRANSP(0, 0, 0, 0);
+
+    // Tournament on LREG4-7 to find top-2 of this batch
+    // After: LREG4 = max, LREG5 = 2nd max
+    TTI_SFPSWAP(0, p_sfpu::LREG4, p_sfpu::LREG5, p_sfpswap::ALL_ROWS_MAX);
+    TTI_SFPSWAP(0, p_sfpu::LREG6, p_sfpu::LREG7, p_sfpswap::ALL_ROWS_MAX);
+    TTI_SFPSWAP(0, p_sfpu::LREG4, p_sfpu::LREG6, p_sfpswap::ALL_ROWS_MAX);
+    TTI_SFPSWAP(0, p_sfpu::LREG5, p_sfpu::LREG7, p_sfpswap::ALL_ROWS_MAX);
+    TTI_SFPSWAP(0, p_sfpu::LREG5, p_sfpu::LREG6, p_sfpswap::ALL_ROWS_MAX);
+
+    // Merge batch top-2 (LREG4/5) with running top-2 (LREG0/1)
+    // After: LREG0 = max, LREG1 = 2nd max
+    TTI_SFPSWAP(0, p_sfpu::LREG0, p_sfpu::LREG4, p_sfpswap::ALL_ROWS_MAX);
+    TTI_SFPSWAP(0, p_sfpu::LREG1, p_sfpu::LREG5, p_sfpswap::ALL_ROWS_MAX);
+    TTI_SFPSWAP(0, p_sfpu::LREG1, p_sfpu::LREG4, p_sfpswap::ALL_ROWS_MAX);
+
+    //-------------------------------------------------------------------------
+    lltt::replay(0, 14);  // Group 1
+    lltt::replay(0, 14);  // Group 2
+    lltt::replay(0, 14);  // Group 3
+    //-------------------------------------------------------------------------
+    // We are now reading in bottom two faces
+    TTI_SETRWC(p_setrwc::CLR_NONE, 0, 0, 0, 0, p_setrwc::SET_D);
+    TTI_STALLWAIT(p_stall::STALL_MATH, p_stall::WAIT_SFPU);
+
+    lltt::record<lltt::Exec>(14, 6);
+
+    // Group 4
+    TTI_SFPTRANSP(0, 0, 0, 0);
+    // Load 4 tile rows into LREG4-7
+    TTI_SFPLOAD(p_sfpu::LREG4, InstrModLoadStore::FP16B, ADDR_MOD_1, 32);
+    TTI_SFPLOAD(p_sfpu::LREG5, InstrModLoadStore::FP16B, ADDR_MOD_2, 32);
+    TTI_SFPLOAD(p_sfpu::LREG6, InstrModLoadStore::FP16B, ADDR_MOD_1, 32);
+    TTI_SFPLOAD(p_sfpu::LREG7, InstrModLoadStore::FP16B, ADDR_MOD_3, 32);
+    TTI_SFPTRANSP(0, 0, 0, 0);
+
+    lltt::replay(6, 8);
+
+    // Group 5
+    lltt::replay(14, 6);
+    lltt::replay(6, 8);
+
+    // Group 6
+    lltt::replay(14, 6);
+    lltt::replay(6, 8);
+
+    // Group 7
+    lltt::replay(14, 6);
+    lltt::replay(6, 8);
+
+    // Store Results
+    // Sum of top-2: LREG0 = LREG0 + LREG1
+    TTI_SFPADD(p_sfpu::LREG0, p_sfpu::LCONST_1, p_sfpu::LREG1, p_sfpu::LREG0, 0);
+    TTI_SFPNOP;
+
+    // Prepare LREG0-3 for transpose-back (all with sum values)
+    TTI_SFPMOV(0, p_sfpu::LREG0, p_sfpu::LREG1, 0);
+    TTI_SFPMOV(0, p_sfpu::LREG0, p_sfpu::LREG2, 0);
+    TTI_SFPMOV(0, p_sfpu::LREG0, p_sfpu::LREG3, 0);
+    TTI_SFPTRANSP(0, 0, 0, 0);
+
+    TTI_SETRWC(p_setrwc::CLR_NONE, 0, 0, 0, 0, p_setrwc::SET_D);
+
+    TTI_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::FP16B, ADDR_MOD_0, 0);
+    TTI_SFPSTORE(p_sfpu::LREG1, InstrModLoadStore::FP16B, ADDR_MOD_0, 2);
+    TTI_SFPSTORE(p_sfpu::LREG2, InstrModLoadStore::FP16B, ADDR_MOD_0, 4);
+    TTI_SFPSTORE(p_sfpu::LREG3, InstrModLoadStore::FP16B, ADDR_MOD_0, 6);
+}
+
+}  // namespace sfpu
+
+inline void _llk_math_sum_top2_tile_init_() {
+    llk_math_eltwise_unary_sfpu_init<SfpuType::unused, /*APPROXIMATE=*/true>(ckernel::sfpu::_top2_configure_addrmod_);
+}
+
+inline void _llk_math_sum_top2_tile_(uint32_t dst_index) {
+    _llk_math_eltwise_unary_sfpu_params_</*APPROXIMATE=*/true>(
+        ckernel::sfpu::_top2_calculate_top2_, dst_index, VectorMode::RC_custom);
+}
+
+#endif
+
+/**
+ * @brief Initializes the sum-of-top-2 SFPU operation.
+ */
+inline void sum_top2_tile_init() { MATH((_llk_math_sum_top2_tile_init_())); }
+
+ALWI void sum_top2_tile(uint32_t dst_index) { MATH((_llk_math_sum_top2_tile_(dst_index))); }
+
+}  // namespace ckernel

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek/moe/moe_gate_mm/device/kernels/top4_sfpu.h
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek/moe/moe_gate_mm/device/kernels/top4_sfpu.h
@@ -1,0 +1,185 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+#include "api/compute/common_globals.h"
+
+/**
+ * @brief Selects the top-4 values from 8 inputs and produces a bitmask of their indices.
+ *
+ * Loads 8 FP16B values (from the lower face of the DST tile at `dst_index`) into
+ * LREG0-7, transposes so each LREG holds one core's data across 32 lanes, then
+ * fuses a 3-bit core index (0-7) into the lower 16 bits of each register.
+ * Uses a **bubble sort** network (4 passes of 7, 6, 5, 4 adjacent SFPSWAPs) to
+ * move the 4 largest values into LREG0-3. The core indices of the top-4 winners
+ * are extracted and OR'd into a single 8-bit bitmask per lane via shift-and-OR.
+ *
+ * Input:  8 FP16B values per lane, read from the lower face (rows 0-7) of the DST
+ *         tile at offset 32 (face 1).
+ * Output: One uint16 bitmask per lane (bits 0-7, one per core), written to row 0
+ *         of face 0 of the same DST tile (LO16 mode).
+ */
+
+namespace ckernel {
+
+#ifdef TRISC_MATH
+#include "llk_math_eltwise_unary_sfpu_init.h"
+#include "llk_math_eltwise_unary_sfpu_params.h"
+#include "ckernel.h"
+#include "ckernel_addrmod.h"
+#include "lltt.h"
+#include "sfpi.h"
+
+namespace sfpu {
+
+inline void _top4_configure_addrmod_() {
+    // SFPU configuration shifts to use ADDRMOD4-7.
+    constexpr uint32_t ADDRMOD_OFFSET = 4;
+
+    addr_mod_t{
+        .dest = {.incr = 0, .clr = 0, .cr = 0, .c_to_cr = 0},
+    }
+        .set(ADDRMOD_OFFSET + ADDR_MOD_0);
+
+    addr_mod_t{
+        .dest = {.incr = 2, .clr = 0, .cr = 0, .c_to_cr = 0},
+    }
+        .set(ADDRMOD_OFFSET + ADDR_MOD_1);
+
+    addr_mod_t{
+        .dest = {.incr = 6, .clr = 0, .cr = 0, .c_to_cr = 0},
+    }
+        .set(ADDRMOD_OFFSET + ADDR_MOD_2);
+
+    addr_mod_t{
+        .dest = {.incr = -6, .clr = 0, .cr = 0, .c_to_cr = 0},
+    }
+        .set(ADDRMOD_OFFSET + ADDR_MOD_3);
+}
+
+inline void _calculate_top4_() {
+    // Reset Dst RWC to 0
+    TTI_SETRWC(p_setrwc::CLR_NONE, 0, 0, 0, 0, p_setrwc::SET_D);
+
+    //-------------------------------------------------------------------------
+    // Step 1: Load BF16 values to HI 16 bits from offsets 0, 2, 8, 10 -> 4-3
+    //-------------------------------------------------------------------------
+    TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::FP16B, ADDR_MOD_1, 32);  // offset 0
+    TTI_SFPLOAD(p_sfpu::LREG1, InstrModLoadStore::FP16B, ADDR_MOD_2, 32);  // offset 2
+    TTI_SFPLOAD(p_sfpu::LREG2, InstrModLoadStore::FP16B, ADDR_MOD_1, 32);  // offset 8
+    TTI_SFPLOAD(p_sfpu::LREG3, InstrModLoadStore::FP16B, ADDR_MOD_3, 32);  // offset 10
+
+    //-------------------------------------------------------------------------
+    // Step 2: Load BF16 values to HI 16 bits from offsets 4, 6, 12, 14 -> LREG4-7
+    //-------------------------------------------------------------------------
+    TTI_SFPLOAD(p_sfpu::LREG4, InstrModLoadStore::FP16B, ADDR_MOD_1, 32);  // offset 4
+    TTI_SFPLOAD(p_sfpu::LREG5, InstrModLoadStore::FP16B, ADDR_MOD_2, 32);  // offset 6
+    TTI_SFPLOAD(p_sfpu::LREG6, InstrModLoadStore::FP16B, ADDR_MOD_1, 32);  // offset 12
+    TTI_SFPLOAD(p_sfpu::LREG7, InstrModLoadStore::FP16B, ADDR_MOD_3, 32);  // offset 14
+
+    //-------------------------------------------------------------------------
+    // Step 3: Transpose
+    // After transpose: each LREG has 32 lanes with data from 32 different tokens
+    // Now all lanes in LREG0 are from core 0, LREG1 from core 1, etc.
+    //-------------------------------------------------------------------------
+    TTI_SFPTRANSP(0, 0, 0, 0);
+
+    //-------------------------------------------------------------------------
+    // Step 4: Fuse core indices (0-7) into LO 16 bits of each LREG
+    //-------------------------------------------------------------------------
+    TTI_SFPLOADI(ckernel::p_sfpu::LREG0, sfpi::SFPLOADI_MOD0_LOWER, 0);  // core index 0
+    TTI_SFPLOADI(ckernel::p_sfpu::LREG1, sfpi::SFPLOADI_MOD0_LOWER, 1);  // core index 1
+    TTI_SFPLOADI(ckernel::p_sfpu::LREG2, sfpi::SFPLOADI_MOD0_LOWER, 2);  // core index 2
+    TTI_SFPLOADI(ckernel::p_sfpu::LREG3, sfpi::SFPLOADI_MOD0_LOWER, 3);  // core index 3
+    TTI_SFPLOADI(ckernel::p_sfpu::LREG4, sfpi::SFPLOADI_MOD0_LOWER, 4);  // core index 4
+    TTI_SFPLOADI(ckernel::p_sfpu::LREG5, sfpi::SFPLOADI_MOD0_LOWER, 5);  // core index 5
+    TTI_SFPLOADI(ckernel::p_sfpu::LREG6, sfpi::SFPLOADI_MOD0_LOWER, 6);  // core index 6
+    TTI_SFPLOADI(ckernel::p_sfpu::LREG7, sfpi::SFPLOADI_MOD0_LOWER, 7);  // core index 7
+
+    //-------------------------------------------------------------------------
+    // Step 5: Bubble sort to extract top 4 values into LREG0-3
+    // Using ALL_ROWS_MAX SWAP to keep max values in first register
+    // Bubble from right to left to move maximum values towards LREG0
+    // After sorting: LREG0 = max, LREG1 = 2nd, LREG2 = 3rd, LREG3 = 4th
+    //-------------------------------------------------------------------------
+
+    // Pass 1: Bubble maximum value to LREG0 (7 comparisons, right to left)
+    lltt::record<lltt::Exec>(0, 7);
+    TTI_SFPSWAP(0, p_sfpu::LREG6, p_sfpu::LREG7, p_sfpswap::ALL_ROWS_MAX);
+    TTI_SFPSWAP(0, p_sfpu::LREG5, p_sfpu::LREG6, p_sfpswap::ALL_ROWS_MAX);
+    TTI_SFPSWAP(0, p_sfpu::LREG4, p_sfpu::LREG5, p_sfpswap::ALL_ROWS_MAX);
+    TTI_SFPSWAP(0, p_sfpu::LREG3, p_sfpu::LREG4, p_sfpswap::ALL_ROWS_MAX);
+    TTI_SFPSWAP(0, p_sfpu::LREG2, p_sfpu::LREG3, p_sfpswap::ALL_ROWS_MAX);
+    TTI_SFPSWAP(0, p_sfpu::LREG1, p_sfpu::LREG2, p_sfpswap::ALL_ROWS_MAX);
+    TTI_SFPSWAP(0, p_sfpu::LREG0, p_sfpu::LREG1, p_sfpswap::ALL_ROWS_MAX);
+
+    // Pass 2: Bubble 2nd maximum to LREG1 (6 comparisons, right to left)
+    lltt::replay(0, 6);
+
+    // Pass 3: Bubble 3rd maximum to LREG2 (5 comparisons, right to left)
+    lltt::replay(0, 5);
+
+    // Pass 4: Bubble 4th maximum to LREG3 (4 comparisons, right to left)
+    lltt::replay(0, 4);
+
+    // Result: LREG0-3 contain the top 4 values (with their indices in LO 16 bits)
+    //-------------------------------------------------------------------------
+    // Step 8: Generate a bitmask vector with the top 4 indices
+    //-------------------------------------------------------------------------
+    // Initialize accumulator LREG4 to 0
+    TTI_SFPLOADI(p_sfpu::LREG4, sfpi::SFPLOADI_MOD0_USHORT, 0);
+
+    for (int i = 0; i < 4; i++) {
+        // Load mask 0xFF to extract LO 8 bits (only the indices)
+        TTI_SFPLOADI(p_sfpu::LREG7, sfpi::SFPLOADI_MOD0_USHORT, 0xFF);
+
+        // Extract LO 16 bits (the indices) from LREG[i]
+        TTI_SFPAND(0, p_sfpu::LREG0 + i, p_sfpu::LREG7, 0);
+        TTI_SFPNOP;
+
+        // Load value 1 into LREG5 (for bitmask generation)
+        TTI_SFPLOADI(p_sfpu::LREG5, sfpi::SFPLOADI_MOD0_USHORT, 1);
+        TTI_SFPNOP;
+
+        // Shift left by the value in LREG[i]: LREG6 = (1 << LREG[i])
+        // This creates a bitmask where bit LREG[i] is set
+        // SFPSHFT2 mode 5 = SFPSHFT2_MOD1_SHFT_LREG (variable shift by LREG)
+        TTI_SFPSHFT2(p_sfpu::LREG5, p_sfpu::LREG7, p_sfpu::LREG6, SFPSHFT2_MOD1_SHFT_LREG);
+        TTI_SFPNOP;
+
+        // OR into accumulator: LREG4 |= LREG6
+        TTI_SFPOR(0, p_sfpu::LREG6, p_sfpu::LREG4, 0);
+    }
+
+    //-------------------------------------------------------------------------
+    // Step 9: Write back the 4 indices as raw uint16 values
+    // Using LO16 mode to write the lower 16 bits (the indices)
+    //-------------------------------------------------------------------------
+    TTI_SETRWC(p_setrwc::CLR_NONE, 0, 0, 0, 0, p_setrwc::SET_D);
+    TTI_SFPSTORE(p_sfpu::LREG4, InstrModLoadStore::LO16_ONLY, ADDR_MOD_0, 0);  // Write 1st index
+}
+
+}  // namespace sfpu
+
+inline void _llk_math_top4_tile_init_() {
+    llk_math_eltwise_unary_sfpu_init<SfpuType::unused, /*APPROXIMATE=*/true>(ckernel::sfpu::_top4_configure_addrmod_);
+}
+
+inline void _llk_math_top4_tile_(uint32_t dst_index) {
+    _llk_math_eltwise_unary_sfpu_params_</*APPROXIMATE=*/true>(
+        ckernel::sfpu::_calculate_top4_, dst_index, VectorMode::RC_custom);
+}
+
+#endif
+
+/**
+ * @brief Initializes the top-4 selection SFPU operation.
+ */
+inline void top4_tile_init() { MATH((_llk_math_top4_tile_init_())); }
+
+ALWI void top4_tile(uint32_t dst_index) { MATH((_llk_math_top4_tile_(dst_index))); }
+
+}  // namespace ckernel

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek/moe/moe_gate_mm/device/kernels/top8_merge_sfpu.h
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek/moe/moe_gate_mm/device/kernels/top8_merge_sfpu.h
@@ -1,0 +1,456 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+#include "api/compute/common_globals.h"
+
+/**
+ * @brief Merges per-core top-8 results across 8 cores into a global top-8, then
+ *        produces a per-expert selection bitmask.
+ *
+ * Takes 8 pre-sorted top-8 sequences (one per core, each with FP16B values in the
+ * upper 16 bits and 8-bit expert indices in the lower 16 bits) spread across DST
+ * tiles 0-4 (2 cores per tile, one per face). Sequentially merges core 0's top-8
+ * with cores 1-7 using a **bitonic merge** network: for each merge, computes
+ * max(A[i], B[7-i]) to form a bitonic sequence, then applies a 12-swap bitonic
+ * merge (distance-4, distance-2, distance-1 stages). The first merge records
+ * load/store patterns into the replay buffer; subsequent merges replay them.
+ *
+ * After merging, the final top-8 expert indices (top 4 used) are decoded into a
+ * per-expert bitmask: for each of the 8 index slots, if the expert index falls
+ * within the range [column_idx*32, column_idx*32+31], a bit is set at the
+ * corresponding position. Two 16-bit bitmasks are produced (lower 16 and upper 16
+ * experts within the column's 32-expert range).
+ *
+ * Input:  8 sorted top-8 sequences across DST tiles 0-4 (8 FP16B values + 8 indices
+ *         per core per lane). Each tile holds 2 cores (face 0 and face 1).
+ * Output: Two uint16 bitmasks per lane written to face 1 of tile 0 (rows 0-3 at
+ *         offset 32, LO16 mode), indicating which of 32 experts in the column are
+ *         selected. The merged top-8 values+indices remain in tile 0, face 0.
+ */
+
+namespace ckernel {
+
+#ifdef TRISC_MATH
+#include "llk_math_eltwise_unary_sfpu_init.h"
+#include "llk_math_eltwise_unary_sfpu_params.h"
+#include "ckernel.h"
+#include "ckernel_addrmod.h"
+#include "lltt.h"
+#include "sfpi.h"
+
+namespace sfpu {
+
+inline void _top8_merge_configure_addrmod_() {
+    // SFPU configuration shifts to use ADDRMOD4-7.
+    constexpr uint32_t ADDRMOD_OFFSET = 4;
+
+    addr_mod_t{
+        .dest = {.incr = 32, .clr = 0, .cr = 0, .c_to_cr = 0},
+    }
+        .set(ADDRMOD_OFFSET + ADDR_MOD_0);
+
+    addr_mod_t{
+        .dest = {.incr = 2, .clr = 0, .cr = 0, .c_to_cr = 0},
+    }
+        .set(ADDRMOD_OFFSET + ADDR_MOD_1);
+
+    addr_mod_t{
+        .dest = {.incr = 14, .clr = 0, .cr = 0, .c_to_cr = 0},
+    }
+        .set(ADDRMOD_OFFSET + ADDR_MOD_2);
+
+    addr_mod_t{
+        .dest = {.incr = -18, .clr = 0, .cr = 0, .c_to_cr = 0},
+    }
+        .set(ADDRMOD_OFFSET + ADDR_MOD_3);
+}
+
+template <uint32_t tile_index, uint32_t face_offset, uint32_t row_offset>
+inline void _top8_merge_set_d_rwc_() {
+    constexpr uint32_t total_offset = tile_index * 64 + face_offset * 32 + row_offset;
+
+    // Set base position to 0
+    TTI_SETRWC(p_setrwc::CLR_NONE, 0, row_offset, 0, 0, p_setrwc::SET_D);
+
+    // Increment by 32 using SFPLOAD with ADDR_MOD_0
+    constexpr uint32_t num_increments = tile_index * 2 + face_offset;
+
+    // This loads to a read-only register, acting as a NOP while applying the address increment
+    for (uint32_t i = 0; i < num_increments; ++i) {
+        TTI_SFPLOAD(p_sfpu::LCONST_0, InstrModLoadStore::FP16B, ADDR_MOD_0, 0);
+    }
+}
+
+// Load sorted group from tile layout
+template <uint32_t tile_index, uint32_t face_offset, bool replay>
+inline void _top8_merge_load_rows_0_3_() {
+    _top8_merge_set_d_rwc_<tile_index, face_offset, /*row_offset*/ 0>();
+
+    if constexpr (replay) {
+        lltt::replay(0, 8);
+        return;
+    }
+
+    lltt::record<lltt::Exec>(0, 8);
+    TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::FP16B, ADDR_MOD_1, 0);  // offset 0
+    TTI_SFPLOAD(p_sfpu::LREG1, InstrModLoadStore::FP16B, ADDR_MOD_2, 0);  // offset 2
+    TTI_SFPLOAD(p_sfpu::LREG2, InstrModLoadStore::FP16B, ADDR_MOD_1, 0);  // offset 16
+    TTI_SFPLOAD(p_sfpu::LREG3, InstrModLoadStore::FP16B, ADDR_MOD_3, 0);  // offset 18
+
+    TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::LO16_ONLY, ADDR_MOD_1, 8);  // offset 0
+    TTI_SFPLOAD(p_sfpu::LREG1, InstrModLoadStore::LO16_ONLY, ADDR_MOD_2, 8);  // offset 2
+    TTI_SFPLOAD(p_sfpu::LREG2, InstrModLoadStore::LO16_ONLY, ADDR_MOD_1, 8);  // offset 16
+    TTI_SFPLOAD(p_sfpu::LREG3, InstrModLoadStore::LO16_ONLY, ADDR_MOD_3, 8);  // offset 18
+}
+
+template <uint32_t tile_index, uint32_t face_offset, bool replay>
+inline void _top8_merge_load_rows_4_7_() {
+    _top8_merge_set_d_rwc_<tile_index, face_offset, /*row_offset*/ 4>();
+
+    if constexpr (replay) {
+        lltt::replay(8, 8);
+        return;
+    }
+
+    lltt::record<lltt::Exec>(8, 8);
+    TTI_SFPLOAD(p_sfpu::LREG4, InstrModLoadStore::FP16B, ADDR_MOD_1, 0);  // offset 4
+    TTI_SFPLOAD(p_sfpu::LREG5, InstrModLoadStore::FP16B, ADDR_MOD_2, 0);  // offset 6
+    TTI_SFPLOAD(p_sfpu::LREG6, InstrModLoadStore::FP16B, ADDR_MOD_1, 0);  // offset 20
+    TTI_SFPLOAD(p_sfpu::LREG7, InstrModLoadStore::FP16B, ADDR_MOD_3, 0);  // offset 22
+
+    TTI_SFPLOAD(p_sfpu::LREG4, InstrModLoadStore::LO16_ONLY, ADDR_MOD_1, 8);  // offset 4
+    TTI_SFPLOAD(p_sfpu::LREG5, InstrModLoadStore::LO16_ONLY, ADDR_MOD_2, 8);  // offset 6
+    TTI_SFPLOAD(p_sfpu::LREG6, InstrModLoadStore::LO16_ONLY, ADDR_MOD_1, 8);  // offset 20
+    TTI_SFPLOAD(p_sfpu::LREG7, InstrModLoadStore::LO16_ONLY, ADDR_MOD_3, 8);  // offset 22
+}
+
+template <uint32_t tile_index, uint32_t face_offset, bool replay>
+inline void _top8_merge_store_rows_0_3_() {
+    _top8_merge_set_d_rwc_<tile_index, face_offset, /*row_offset*/ 0>();
+
+    if constexpr (replay) {
+        lltt::replay(16, 8);
+        return;
+    }
+
+    lltt::record<lltt::Exec>(16, 8);
+    TTI_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::FP16B, ADDR_MOD_1, 0);  // offset 0
+    TTI_SFPSTORE(p_sfpu::LREG1, InstrModLoadStore::FP16B, ADDR_MOD_2, 0);  // offset 2
+    TTI_SFPSTORE(p_sfpu::LREG2, InstrModLoadStore::FP16B, ADDR_MOD_1, 0);  // offset 16
+    TTI_SFPSTORE(p_sfpu::LREG3, InstrModLoadStore::FP16B, ADDR_MOD_3, 0);  // offset 18
+
+    TTI_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::LO16_ONLY, ADDR_MOD_1, 8);  // offset 0
+    TTI_SFPSTORE(p_sfpu::LREG1, InstrModLoadStore::LO16_ONLY, ADDR_MOD_2, 8);  // offset 2
+    TTI_SFPSTORE(p_sfpu::LREG2, InstrModLoadStore::LO16_ONLY, ADDR_MOD_1, 8);  // offset 16
+    TTI_SFPSTORE(p_sfpu::LREG3, InstrModLoadStore::LO16_ONLY, ADDR_MOD_3, 8);  // offset 18
+}
+
+template <uint32_t tile_index, uint32_t face_offset, bool replay>
+inline void _top8_merge_store_rows_4_7_() {
+    _top8_merge_set_d_rwc_<tile_index, face_offset, /*row_offset*/ 4>();
+
+    if constexpr (replay) {
+        lltt::replay(24, 8);
+        return;
+    }
+
+    lltt::record<lltt::Exec>(24, 8);
+    TTI_SFPSTORE(p_sfpu::LREG4, InstrModLoadStore::FP16B, ADDR_MOD_1, 0);  // offset 4
+    TTI_SFPSTORE(p_sfpu::LREG5, InstrModLoadStore::FP16B, ADDR_MOD_2, 0);  // offset 6
+    TTI_SFPSTORE(p_sfpu::LREG6, InstrModLoadStore::FP16B, ADDR_MOD_1, 0);  // offset 20
+    TTI_SFPSTORE(p_sfpu::LREG7, InstrModLoadStore::FP16B, ADDR_MOD_3, 0);  // offset 22
+
+    TTI_SFPSTORE(p_sfpu::LREG4, InstrModLoadStore::LO16_ONLY, ADDR_MOD_1, 8);  // offset 4
+    TTI_SFPSTORE(p_sfpu::LREG5, InstrModLoadStore::LO16_ONLY, ADDR_MOD_2, 8);  // offset 6
+    TTI_SFPSTORE(p_sfpu::LREG6, InstrModLoadStore::LO16_ONLY, ADDR_MOD_1, 8);  // offset 20
+    TTI_SFPSTORE(p_sfpu::LREG7, InstrModLoadStore::LO16_ONLY, ADDR_MOD_3, 8);  // offset 22
+}
+
+inline void _top8_merge_bitonic_merge_8_rows_() {
+    // Stage 1: Compare distance 4 (4 swaps)
+    TTI_SFPSWAP(0, p_sfpu::LREG0, p_sfpu::LREG4, p_sfpswap::ALL_ROWS_MAX);
+    TTI_SFPSWAP(0, p_sfpu::LREG1, p_sfpu::LREG5, p_sfpswap::ALL_ROWS_MAX);
+    TTI_SFPSWAP(0, p_sfpu::LREG2, p_sfpu::LREG6, p_sfpswap::ALL_ROWS_MAX);
+    TTI_SFPSWAP(0, p_sfpu::LREG3, p_sfpu::LREG7, p_sfpswap::ALL_ROWS_MAX);
+
+    // Stage 2: Compare distance 2 (4 swaps)
+    TTI_SFPSWAP(0, p_sfpu::LREG0, p_sfpu::LREG2, p_sfpswap::ALL_ROWS_MAX);
+    TTI_SFPSWAP(0, p_sfpu::LREG1, p_sfpu::LREG3, p_sfpswap::ALL_ROWS_MAX);
+    TTI_SFPSWAP(0, p_sfpu::LREG4, p_sfpu::LREG6, p_sfpswap::ALL_ROWS_MAX);
+    TTI_SFPSWAP(0, p_sfpu::LREG5, p_sfpu::LREG7, p_sfpswap::ALL_ROWS_MAX);
+
+    // Stage 3: Compare distance 1 (4 swaps)
+    TTI_SFPSWAP(0, p_sfpu::LREG0, p_sfpu::LREG1, p_sfpswap::ALL_ROWS_MAX);
+    TTI_SFPSWAP(0, p_sfpu::LREG2, p_sfpu::LREG3, p_sfpswap::ALL_ROWS_MAX);
+    TTI_SFPSWAP(0, p_sfpu::LREG4, p_sfpu::LREG5, p_sfpswap::ALL_ROWS_MAX);
+    TTI_SFPSWAP(0, p_sfpu::LREG6, p_sfpu::LREG7, p_sfpswap::ALL_ROWS_MAX);
+}
+
+// Merge two sorted-8 sequences into top-8
+// Assumes LREG0-7 contains sorted sequence A (descending, untransposed)
+// Loads sequence B from specified location and merges
+// Result is left in LREG0-7 (untransposed, sorted descending)
+template <uint32_t tile_index, uint32_t face_offset, bool replay>
+inline void _top8_merge_two_sorted_8_() {
+    //-------------------------------------------------------------------------
+    // PHASE 1: Compare and store each halves
+    //-------------------------------------------------------------------------
+
+    // First comparison half: A[0-3] vs B[7,6,5,4]
+    // Load A[0-3] to LREG0-3 (positioning + replay load pattern)
+    _top8_merge_load_rows_0_3_</*tile_index*/ 0, /*face_offset*/ 0, replay>();
+
+    // Load B[4-7] to LREG4-7 (positioning + replay load pattern)
+    _top8_merge_load_rows_4_7_<tile_index, face_offset, replay>();
+
+    // Transpose for comparison
+    TTI_SFPTRANSP(0, 0, 0, 0);
+
+    // Perform max(A[0-3], B[7,6,5,4]) - result in LREG0-3
+    TTI_SFPSWAP(0, p_sfpu::LREG0, p_sfpu::LREG7, p_sfpswap::ALL_ROWS_MAX);
+    TTI_SFPSWAP(0, p_sfpu::LREG1, p_sfpu::LREG6, p_sfpswap::ALL_ROWS_MAX);
+    TTI_SFPSWAP(0, p_sfpu::LREG2, p_sfpu::LREG5, p_sfpswap::ALL_ROWS_MAX);
+    TTI_SFPSWAP(0, p_sfpu::LREG3, p_sfpu::LREG4, p_sfpswap::ALL_ROWS_MAX);
+
+    // Transpose back for store
+    TTI_SFPTRANSP(0, 0, 0, 0);
+
+    // Store first 4 winners to temp (positioning + replay store pattern)
+    _top8_merge_store_rows_0_3_</*tile_index*/ 0, /*face_offset*/ 0, replay>();
+
+    // Second comparison half: A[4-7] vs B[3,2,1,0]
+    // Load A[4-7] from temp storage (positioning + replay load pattern)
+    _top8_merge_load_rows_4_7_</*tile_index*/ 0, /*face_offset*/ 0, replay>();
+
+    // Load B[0-3] to LREG0-3 (positioning + replay load pattern)
+    _top8_merge_load_rows_0_3_<tile_index, face_offset, replay>();
+
+    // Transpose for comparison
+    TTI_SFPTRANSP(0, 0, 0, 0);
+
+    // Perform max(A[4-7], B[3,2,1,0]) - result in LREG4-7
+    TTI_SFPSWAP(0, p_sfpu::LREG4, p_sfpu::LREG3, p_sfpswap::ALL_ROWS_MAX);
+    TTI_SFPSWAP(0, p_sfpu::LREG5, p_sfpu::LREG2, p_sfpswap::ALL_ROWS_MAX);
+    TTI_SFPSWAP(0, p_sfpu::LREG6, p_sfpu::LREG1, p_sfpswap::ALL_ROWS_MAX);
+    TTI_SFPSWAP(0, p_sfpu::LREG7, p_sfpu::LREG0, p_sfpswap::ALL_ROWS_MAX);
+
+    // Transpose back for store
+    TTI_SFPTRANSP(0, 0, 0, 0);
+
+    // Store second 4 winners to temp (positioning + replay store pattern)
+    _top8_merge_store_rows_4_7_</*tile_index*/ 0, /*face_offset*/ 0, replay>();
+
+    //-------------------------------------------------------------------------
+    // PHASE 2: Bitonic merge
+    //-------------------------------------------------------------------------
+
+    // Load all 8 winners (positioning + replay load patterns)
+    _top8_merge_load_rows_0_3_</*tile_index*/ 0, /*face_offset*/ 0, replay>();
+    _top8_merge_load_rows_4_7_</*tile_index*/ 0, /*face_offset*/ 0, replay>();
+
+    // Transpose for bitonic merge
+    TTI_SFPTRANSP(0, 0, 0, 0);
+
+    // Perform bitonic merge (12 swaps) - data is transposed
+    _top8_merge_bitonic_merge_8_rows_();
+
+    // Transpose back - data is now untransposed and sorted descending
+    TTI_SFPTRANSP(0, 0, 0, 0);
+
+    // Store the result (positioning + replay store patterns)
+    _top8_merge_store_rows_0_3_</*tile_index*/ 0, /*face_offset*/ 0, replay>();
+    _top8_merge_store_rows_4_7_</*tile_index*/ 0, /*face_offset*/ 0, replay>();
+}
+
+// Main entry point for cross-core merge
+template <uint32_t column_idx>
+inline void _top8_merge_() {
+    TTI_SETRWC(p_setrwc::CLR_NONE, 0, 0, 0, 0, p_setrwc::SET_D);
+
+    // Sequentially merge core 0 data with that in cores 1-7
+    // First call records instructions into replay buffer (replay=false)
+    // Subsequent calls replay recorded instructions (replay=true)
+
+    // Core 1: tile 1 - Record instructions
+    _top8_merge_two_sorted_8_<1, 0, /*replay=*/false>();
+
+    // Core 2: tile 1 - Replay instructions
+    _top8_merge_two_sorted_8_<1, 1, /*replay=*/true>();
+
+    // Core 3: tile 2 - Replay instructions
+    _top8_merge_two_sorted_8_<2, 0, /*replay=*/true>();
+
+    // Core 4: tile 2 - Replay instructions
+    _top8_merge_two_sorted_8_<2, 1, /*replay=*/true>();
+
+    // Core 5: tile 3 - Replay instructions
+    _top8_merge_two_sorted_8_<3, 0, /*replay=*/true>();
+
+    // Core 6: tile 3 - Replay instructions
+    _top8_merge_two_sorted_8_<3, 1, /*replay=*/true>();
+
+    // Core 7: tile 4 - Replay instructions
+    _top8_merge_two_sorted_8_<4, 0, /*replay=*/true>();
+
+    //-------------------------------------------------------------------------
+    // Create a 32-bit value for each token (lane) for each expert in the column
+    //-------------------------------------------------------------------------
+    TTI_SETRWC(p_setrwc::CLR_NONE, 0, 0, 0, 0, p_setrwc::SET_D);
+
+    // Load just the top 4 indices
+    TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::LO16, ADDR_MOD_1, 8);  // offset 0
+    TTI_SFPLOAD(p_sfpu::LREG1, InstrModLoadStore::LO16, ADDR_MOD_2, 8);  // offset 2
+    TTI_SFPLOAD(p_sfpu::LREG2, InstrModLoadStore::LO16, ADDR_MOD_1, 8);  // offset 16
+    TTI_SFPLOAD(p_sfpu::LREG3, InstrModLoadStore::LO16, ADDR_MOD_3, 8);  // offset 18
+
+    TTI_SFPTRANSP(0, 0, 0, 0);
+
+    TTI_SFPMOV(0, p_sfpu::LCONST_0, p_sfpu::LREG4, 0);  // Initialize accumulator to 0 (Lower 16 experts)
+    TTI_SFPMOV(0, p_sfpu::LCONST_0, p_sfpu::LREG5, 0);  // Initialize accumulator to 0 (Higher 16 experts)
+
+    // Main loop: 4 iterations, one per index slot
+    for (uint32_t lreg = 0; lreg < 4; lreg++) {
+        TTI_SFPMOV(0, p_sfpu::LCONST_0, p_sfpu::LREG6, 0);
+        // If value is less than "column_idx" in any lane, disable that lane
+        TTI_SFPIADD((-int(column_idx << 5)) & 0xfff, lreg, lreg, SFPIADD_MOD1_ARG_IMM | SFPIADD_MOD1_CC_GTE0);
+
+        // If value is greater than column_idx + 15 in any lane, disable that lane also
+        TTI_SFPIADD((-int(16)) & 0xfff, lreg, p_sfpu::LREG7, SFPIADD_MOD1_ARG_IMM | SFPIADD_MOD1_CC_LT0);
+
+        // Add 1 if lane is enabled
+        TTI_SFPIADD(0x1, p_sfpu::LREG6, p_sfpu::LREG6, SFPIADD_MOD1_ARG_IMM | SFPIADD_MOD1_CC_NONE);
+
+        // Shift left by the value in LREG[i]: LREG7 = (1 << LREG[i])
+        // This creates a bitmask where bit LREG[i] is set
+        TTI_SFPSHFT2(p_sfpu::LREG6, lreg, p_sfpu::LREG7, SFPSHFT2_MOD1_SHFT_LREG);
+
+        // Now add this to the accumulator
+        TTI_SFPOR(0, p_sfpu::LREG7, p_sfpu::LREG4, 0);
+
+        // Clear condition codes (re-enable all lanes)
+        TTI_SFPENCC(0, 0, 0, 0);
+    }
+
+    // Main loop: 4 iterations, one per index slot
+
+    for (uint32_t lreg = 0; lreg < 4; lreg++) {
+        TTI_SFPMOV(0, p_sfpu::LCONST_0, p_sfpu::LREG6, 0);
+        // If value is less than "column_idx + 16" in any lane, disable that lane
+        TTI_SFPIADD((-int(16)) & 0xfff, lreg, lreg, SFPIADD_MOD1_ARG_IMM | SFPIADD_MOD1_CC_GTE0);
+
+        // If value is greater than column_idx + 15 in any lane, disable that lane also
+        TTI_SFPIADD((-int(16)) & 0xfff, lreg, p_sfpu::LREG7, SFPIADD_MOD1_ARG_IMM | SFPIADD_MOD1_CC_LT0);
+
+        // Add 1 if lane is enabled
+        TTI_SFPIADD(0x1, p_sfpu::LREG6, p_sfpu::LREG6, SFPIADD_MOD1_ARG_IMM | SFPIADD_MOD1_CC_NONE);
+
+        // Shift left by the value in LREG[i]: LREG7 = (1 << LREG[i])
+        // This creates a bitmask where bit LREG[i] is set
+        TTI_SFPSHFT2(p_sfpu::LREG6, lreg, p_sfpu::LREG7, SFPSHFT2_MOD1_SHFT_LREG);
+
+        // Now add this to the accumulator
+        TTI_SFPOR(0, p_sfpu::LREG7, p_sfpu::LREG5, 0);
+
+        // Clear condition codes (re-enable all lanes)
+        TTI_SFPENCC(0, 0, 0, 0);
+    }
+
+    TTI_SFPTRANSP(0, 0, 0, 0);
+
+    // Load next 4 indices (rows 4-7). DST is at 0 after previous group, need 4.
+    TTI_SETRWC(p_setrwc::CLR_NONE, 0, 4, 0, 0, p_setrwc::SET_D);
+    TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::LO16, ADDR_MOD_1, 8);  // row 12
+    TTI_SFPLOAD(p_sfpu::LREG1, InstrModLoadStore::LO16, ADDR_MOD_2, 8);  // row 14
+    TTI_SFPLOAD(p_sfpu::LREG2, InstrModLoadStore::LO16, ADDR_MOD_1, 8);  // row 28
+    TTI_SFPLOAD(p_sfpu::LREG3, InstrModLoadStore::LO16, ADDR_MOD_3, 8);  // row 30
+
+    TTI_SFPTRANSP(0, 0, 0, 0);
+
+    // Main loop: 4 iterations, one per index slot
+    for (uint32_t lreg = 0; lreg < 4; lreg++) {
+        TTI_SFPMOV(0, p_sfpu::LCONST_0, p_sfpu::LREG6, 0);
+        // If value is less than "column_idx" in any lane, disable that lane
+        TTI_SFPIADD((-int(column_idx << 5)) & 0xfff, lreg, lreg, SFPIADD_MOD1_ARG_IMM | SFPIADD_MOD1_CC_GTE0);
+
+        // If value is greater than column_idx + 15 in any lane, disable that lane also
+        TTI_SFPIADD((-int(16)) & 0xfff, lreg, p_sfpu::LREG7, SFPIADD_MOD1_ARG_IMM | SFPIADD_MOD1_CC_LT0);
+
+        // Add 1 if lane is enabled
+        TTI_SFPIADD(0x1, p_sfpu::LREG6, p_sfpu::LREG6, SFPIADD_MOD1_ARG_IMM | SFPIADD_MOD1_CC_NONE);
+
+        // Shift left by the value in LREG[i]: LREG7 = (1 << LREG[i])
+        // This creates a bitmask where bit LREG[i] is set
+        TTI_SFPSHFT2(p_sfpu::LREG6, lreg, p_sfpu::LREG7, SFPSHFT2_MOD1_SHFT_LREG);
+
+        // Now add this to the accumulator
+        TTI_SFPOR(0, p_sfpu::LREG7, p_sfpu::LREG4, 0);
+
+        // Clear condition codes (re-enable all lanes)
+        TTI_SFPENCC(0, 0, 0, 0);
+    }
+
+    // Main loop: 4 iterations, one per index slot
+
+    for (uint32_t lreg = 0; lreg < 4; lreg++) {
+        TTI_SFPMOV(0, p_sfpu::LCONST_0, p_sfpu::LREG6, 0);
+        // If value is less than "column_idx + 16" in any lane, disable that lane
+        TTI_SFPIADD((-int(16)) & 0xfff, lreg, lreg, SFPIADD_MOD1_ARG_IMM | SFPIADD_MOD1_CC_GTE0);
+
+        // If value is greater than column_idx + 15 in any lane, disable that lane also
+        TTI_SFPIADD((-int(16)) & 0xfff, lreg, p_sfpu::LREG7, SFPIADD_MOD1_ARG_IMM | SFPIADD_MOD1_CC_LT0);
+
+        // Add 1 if lane is enabled
+        TTI_SFPIADD(0x1, p_sfpu::LREG6, p_sfpu::LREG6, SFPIADD_MOD1_ARG_IMM | SFPIADD_MOD1_CC_NONE);
+
+        // Shift left by the value in LREG[i]: LREG7 = (1 << LREG[i])
+        // This creates a bitmask where bit LREG[i] is set
+        TTI_SFPSHFT2(p_sfpu::LREG6, lreg, p_sfpu::LREG7, SFPSHFT2_MOD1_SHFT_LREG);
+
+        // Now add this to the accumulator
+        TTI_SFPOR(0, p_sfpu::LREG7, p_sfpu::LREG5, 0);
+
+        // Clear condition codes (re-enable all lanes)
+        TTI_SFPENCC(0, 0, 0, 0);
+    }
+
+    TTI_SFPTRANSP(0, 0, 0, 0);
+
+    // Store result
+    TTI_SETRWC(p_setrwc::CLR_NONE, 0, 0, 0, 0, p_setrwc::SET_D);
+
+    TTI_SFPSTORE(p_sfpu::LREG4, InstrModLoadStore::LO16, ADDR_MOD_1, 32);
+    TTI_SFPSTORE(p_sfpu::LREG5, InstrModLoadStore::LO16, ADDR_MOD_2, 32);
+    TTI_SFPSTORE(p_sfpu::LREG6, InstrModLoadStore::LO16, ADDR_MOD_1, 32);
+    TTI_SFPSTORE(p_sfpu::LREG7, InstrModLoadStore::LO16, ADDR_MOD_3, 32);
+}
+
+}  // namespace sfpu
+
+inline void _llk_math_top8_merge_init_() {
+    llk_math_eltwise_unary_sfpu_init<SfpuType::unused, /*APPROXIMATE=*/true>(
+        ckernel::sfpu::_top8_merge_configure_addrmod_);
+}
+
+template <uint32_t column_idx>
+inline void _llk_math_top8_merge_() {
+    _llk_math_eltwise_unary_sfpu_params_</*APPROXIMATE=*/true>(
+        ckernel::sfpu::_top8_merge_<column_idx>, 0, VectorMode::RC_custom);
+}
+
+#endif
+
+/**
+ * @brief Initializes the cross-core top-8 merge SFPU operation.
+ */
+inline void top8_merge_init() { MATH((_llk_math_top8_merge_init_())); }
+
+template <uint32_t column_idx>
+ALWI void top8_merge() {
+    MATH((_llk_math_top8_merge_<column_idx>()));
+}
+
+}  // namespace ckernel

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek/moe/moe_gate_mm/device/kernels/top8_sfpu.h
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek/moe/moe_gate_mm/device/kernels/top8_sfpu.h
@@ -1,0 +1,630 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+#include "api/compute/common_globals.h"
+
+/**
+ * @brief Selects the top-8 values (with expert indices) from 32 inputs within a single core.
+ *
+ * Operates on one DST tile containing 32 FP16B gate values arranged in 4 groups of
+ * 8 rows. Each value represents a different expert's score for the tokens in that lane.
+ *
+ * Phase 1 - Sort: Each of the 4 groups (8 values) is sorted in descending order using
+ *   a full **bitonic sort** network (24 SFPSWAPs: 4 stage-1 + 8 stage-2 + 12 stage-3).
+ *   A 3-bit intra-group index (0-7) is fused into the lower 16 bits of each value before
+ *   sorting, so indices travel with their values through swaps.
+ * Phase 2 - Index encoding: A 2-bit group offset (0-3) is added to bits [4:3] of each
+ *   index, extending the expert index to 5 bits (0-31).
+ * Phase 3 - Merge: The 4 sorted-8 sequences are merged pairwise into a single top-8
+ *   using an optimized bitonic merge (max(A[i], B[7-i]) followed by 12-swap merge),
+ *   requiring only 3 sequential merge passes.
+ * Phase 4 - Masking: A per-lane mask (from tile 2) is checked; if the bit for
+ *   `tile_index` is unset, that lane's values are replaced with -infinity. A 3-bit
+ *   core ID (`tile_index`) is encoded into bits [7:5] of each index.
+ *
+ * Input:  32 FP16B values per lane from the DST tile at `dst_index` (all 4 faces).
+ *         A mask tile at DST offset 128 (tile 2).
+ * Output: 8 FP16B values (top-8 descending) in face 0 rows 0-7, and 8 corresponding
+ *         8-bit expert indices in face 0 rows 8-15 (LO16 mode), of the same DST tile.
+ *         Index encoding: bits [7:5]=core_id, bits [4:3]=group, bits [2:0]=intra-group.
+ */
+
+namespace ckernel {
+
+#ifdef TRISC_MATH
+#include "llk_math_eltwise_unary_sfpu_init.h"
+#include "llk_math_eltwise_unary_sfpu_params.h"
+#include "ckernel.h"
+#include "ckernel_addrmod.h"
+#include "lltt.h"
+#include "sfpi.h"
+
+namespace sfpu {
+
+//-----------------------------------------------------------------------------
+// Bitonic Sort for 8 Values
+//-----------------------------------------------------------------------------
+//
+// Bitonic sort for LREG0-7, result is DESCENDING (LREG0 = max, LREG7 = min)
+// SFPSWAP(0, A, B, ALL_ROWS_MAX): Puts max(A,B) in A, min(A,B) in B
+//
+// Stage 1: Build alternating direction pairs (4 swaps)
+// Stage 2: Merge pairs into sorted-4 sequences (10 swaps: 4 left + 4 right + 2 to complete right)
+// Stage 3: Final bitonic merge of 8 to sorted descending (12 swaps)
+//
+// Total: 24 swaps (fits in 32-slot replay buffer)
+//-----------------------------------------------------------------------------
+
+inline void _top8_configure_addrmod_() {
+    // SFPU configuration shifts to use ADDRMOD4-7.
+    constexpr uint32_t ADDRMOD_OFFSET = 4;
+
+    addr_mod_t{
+        .dest = {.incr = -22, .clr = 0, .cr = 0, .c_to_cr = 0},
+    }
+        .set(ADDRMOD_OFFSET + ADDR_MOD_0);
+
+    addr_mod_t{
+        .dest = {.incr = 2, .clr = 0, .cr = 0, .c_to_cr = 0},
+    }
+        .set(ADDRMOD_OFFSET + ADDR_MOD_1);
+
+    addr_mod_t{
+        .dest = {.incr = 14, .clr = 0, .cr = 0, .c_to_cr = 0},
+    }
+        .set(ADDRMOD_OFFSET + ADDR_MOD_2);
+
+    addr_mod_t{
+        .dest = {.incr = -14, .clr = 0, .cr = 0, .c_to_cr = 0},
+    }
+        .set(ADDRMOD_OFFSET + ADDR_MOD_3);
+}
+
+// Load input data (FP16B) from tile layout and fuse with expert indices
+inline void _load_input_group_() {
+    TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::FP16B, ADDR_MOD_1, 0);  // offset 0
+    TTI_SFPLOAD(p_sfpu::LREG1, InstrModLoadStore::FP16B, ADDR_MOD_2, 0);  // offset 2
+    TTI_SFPLOAD(p_sfpu::LREG2, InstrModLoadStore::FP16B, ADDR_MOD_1, 0);  // offset 16
+    TTI_SFPLOAD(p_sfpu::LREG3, InstrModLoadStore::FP16B, ADDR_MOD_3, 0);  // offset 18
+    TTI_SFPLOAD(p_sfpu::LREG4, InstrModLoadStore::FP16B, ADDR_MOD_1, 0);  // offset 4
+    TTI_SFPLOAD(p_sfpu::LREG5, InstrModLoadStore::FP16B, ADDR_MOD_2, 0);  // offset 6
+    TTI_SFPLOAD(p_sfpu::LREG6, InstrModLoadStore::FP16B, ADDR_MOD_1, 0);  // offset 20
+    TTI_SFPLOAD(p_sfpu::LREG7, InstrModLoadStore::FP16B, ADDR_MOD_0, 0);  // offset 22
+}
+
+inline void _add_row_indices_() {
+    // Fuse expert indices into LO16 bits
+    TTI_SFPLOADI(p_sfpu::LREG0, sfpi::SFPLOADI_MOD0_LOWER, 0);
+    TTI_SFPLOADI(p_sfpu::LREG1, sfpi::SFPLOADI_MOD0_LOWER, 1);
+    TTI_SFPLOADI(p_sfpu::LREG2, sfpi::SFPLOADI_MOD0_LOWER, 2);
+    TTI_SFPLOADI(p_sfpu::LREG3, sfpi::SFPLOADI_MOD0_LOWER, 3);
+    TTI_SFPLOADI(p_sfpu::LREG4, sfpi::SFPLOADI_MOD0_LOWER, 4);
+    TTI_SFPLOADI(p_sfpu::LREG5, sfpi::SFPLOADI_MOD0_LOWER, 5);
+    TTI_SFPLOADI(p_sfpu::LREG6, sfpi::SFPLOADI_MOD0_LOWER, 6);
+    TTI_SFPLOADI(p_sfpu::LREG7, sfpi::SFPLOADI_MOD0_LOWER, 7);
+}
+
+// Store sorted group back to tile layout
+inline void _store_sorted_group_() {
+    TTI_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::FP16B, ADDR_MOD_1, 0);  // offset 0
+    TTI_SFPSTORE(p_sfpu::LREG1, InstrModLoadStore::FP16B, ADDR_MOD_2, 0);  // offset 2
+    TTI_SFPSTORE(p_sfpu::LREG2, InstrModLoadStore::FP16B, ADDR_MOD_1, 0);  // offset 16
+    TTI_SFPSTORE(p_sfpu::LREG3, InstrModLoadStore::FP16B, ADDR_MOD_3, 0);  // offset 18
+    TTI_SFPSTORE(p_sfpu::LREG4, InstrModLoadStore::FP16B, ADDR_MOD_1, 0);  // offset 4
+    TTI_SFPSTORE(p_sfpu::LREG5, InstrModLoadStore::FP16B, ADDR_MOD_2, 0);  // offset 6
+    TTI_SFPSTORE(p_sfpu::LREG6, InstrModLoadStore::FP16B, ADDR_MOD_1, 0);  // offset 20
+    TTI_SFPSTORE(p_sfpu::LREG7, InstrModLoadStore::FP16B, ADDR_MOD_0, 0);  // offset 22
+
+    TTI_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::LO16_ONLY, ADDR_MOD_1, 64);  // offset 0
+    TTI_SFPSTORE(p_sfpu::LREG1, InstrModLoadStore::LO16_ONLY, ADDR_MOD_2, 64);  // offset 2
+    TTI_SFPSTORE(p_sfpu::LREG2, InstrModLoadStore::LO16_ONLY, ADDR_MOD_1, 64);  // offset 16
+    TTI_SFPSTORE(p_sfpu::LREG3, InstrModLoadStore::LO16_ONLY, ADDR_MOD_3, 64);  // offset 18
+    TTI_SFPSTORE(p_sfpu::LREG4, InstrModLoadStore::LO16_ONLY, ADDR_MOD_1, 64);  // offset 4
+    TTI_SFPSTORE(p_sfpu::LREG5, InstrModLoadStore::LO16_ONLY, ADDR_MOD_2, 64);  // offset 6
+    TTI_SFPSTORE(p_sfpu::LREG6, InstrModLoadStore::LO16_ONLY, ADDR_MOD_1, 64);  // offset 20
+    TTI_SFPSTORE(p_sfpu::LREG7, InstrModLoadStore::LO16_ONLY, ADDR_MOD_0, 64);  // offset 22
+}
+
+// Load sorted group from tile layout
+inline void _load_sorted_group_() {
+    TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::FP16B, ADDR_MOD_1, 0);  // offset 0
+    TTI_SFPLOAD(p_sfpu::LREG1, InstrModLoadStore::FP16B, ADDR_MOD_2, 0);  // offset 2
+    TTI_SFPLOAD(p_sfpu::LREG2, InstrModLoadStore::FP16B, ADDR_MOD_1, 0);  // offset 16
+    TTI_SFPLOAD(p_sfpu::LREG3, InstrModLoadStore::FP16B, ADDR_MOD_3, 0);  // offset 18
+    TTI_SFPLOAD(p_sfpu::LREG4, InstrModLoadStore::FP16B, ADDR_MOD_1, 0);  // offset 4
+    TTI_SFPLOAD(p_sfpu::LREG5, InstrModLoadStore::FP16B, ADDR_MOD_2, 0);  // offset 6
+    TTI_SFPLOAD(p_sfpu::LREG6, InstrModLoadStore::FP16B, ADDR_MOD_1, 0);  // offset 20
+    TTI_SFPLOAD(p_sfpu::LREG7, InstrModLoadStore::FP16B, ADDR_MOD_0, 0);  // offset 22
+
+    TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::LO16_ONLY, ADDR_MOD_1, 64);  // offset 0
+    TTI_SFPLOAD(p_sfpu::LREG1, InstrModLoadStore::LO16_ONLY, ADDR_MOD_2, 64);  // offset 2
+    TTI_SFPLOAD(p_sfpu::LREG2, InstrModLoadStore::LO16_ONLY, ADDR_MOD_1, 64);  // offset 16
+    TTI_SFPLOAD(p_sfpu::LREG3, InstrModLoadStore::LO16_ONLY, ADDR_MOD_3, 64);  // offset 18
+    TTI_SFPLOAD(p_sfpu::LREG4, InstrModLoadStore::LO16_ONLY, ADDR_MOD_1, 64);  // offset 4
+    TTI_SFPLOAD(p_sfpu::LREG5, InstrModLoadStore::LO16_ONLY, ADDR_MOD_2, 64);  // offset 6
+    TTI_SFPLOAD(p_sfpu::LREG6, InstrModLoadStore::LO16_ONLY, ADDR_MOD_1, 64);  // offset 20
+    TTI_SFPLOAD(p_sfpu::LREG7, InstrModLoadStore::LO16_ONLY, ADDR_MOD_0, 64);  // offset 22
+}
+
+template <uint32_t face_offset, uint32_t group_offset, uint32_t row_offset>
+inline void _top8_set_d_rwc_() {
+    constexpr uint32_t total_offset = face_offset * 32 + group_offset + row_offset;
+
+    if constexpr (total_offset < 16) {
+        TTI_SETRWC(p_setrwc::CLR_NONE, 0, total_offset, 0, 0, p_setrwc::SET_D);
+        return;
+    }
+
+    constexpr uint32_t num_incr = (total_offset / 8) - 1;
+
+    TTI_SETRWC(p_setrwc::CLR_NONE, 0, 8 + row_offset, 0, 0, p_setrwc::SET_D);
+
+    for (uint32_t i = 0; i < num_incr; ++i) {
+        TTI_INCRWC(p_setrwc::CR_D, 8, 0, 0);
+    }
+}
+
+// Load sorted group from tile layout
+template <uint32_t face_offset, uint32_t group_offset>
+inline void _top8_load_rows_0_3_() {
+    _top8_set_d_rwc_<face_offset, group_offset, /*row_offset*/ 0>();
+
+    TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::FP16B, ADDR_MOD_1, 0);  // offset 0
+    TTI_SFPLOAD(p_sfpu::LREG1, InstrModLoadStore::FP16B, ADDR_MOD_2, 0);  // offset 2
+    TTI_SFPLOAD(p_sfpu::LREG2, InstrModLoadStore::FP16B, ADDR_MOD_1, 0);  // offset 16
+    TTI_SFPLOAD(p_sfpu::LREG3, InstrModLoadStore::FP16B, ADDR_MOD_3, 0);  // offset 18
+
+    _top8_set_d_rwc_<face_offset, group_offset, /*row_offset*/ 0>();
+
+    TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::LO16_ONLY, ADDR_MOD_1, 64);  // offset 0
+    TTI_SFPLOAD(p_sfpu::LREG1, InstrModLoadStore::LO16_ONLY, ADDR_MOD_2, 64);  // offset 2
+    TTI_SFPLOAD(p_sfpu::LREG2, InstrModLoadStore::LO16_ONLY, ADDR_MOD_1, 64);  // offset 16
+    TTI_SFPLOAD(p_sfpu::LREG3, InstrModLoadStore::LO16_ONLY, ADDR_MOD_3, 64);  // offset 18
+}
+
+template <uint32_t face_offset, uint32_t group_offset>
+inline void _top8_load_rows_4_7_() {
+    _top8_set_d_rwc_<face_offset, group_offset, /*row_offset*/ 4>();
+
+    TTI_SFPLOAD(p_sfpu::LREG4, InstrModLoadStore::FP16B, ADDR_MOD_1, 0);  // offset 4
+    TTI_SFPLOAD(p_sfpu::LREG5, InstrModLoadStore::FP16B, ADDR_MOD_2, 0);  // offset 6
+    TTI_SFPLOAD(p_sfpu::LREG6, InstrModLoadStore::FP16B, ADDR_MOD_1, 0);  // offset 20
+    TTI_SFPLOAD(p_sfpu::LREG7, InstrModLoadStore::FP16B, ADDR_MOD_3, 0);  // offset 22
+
+    _top8_set_d_rwc_<face_offset, group_offset, /*row_offset*/ 4>();
+
+    TTI_SFPLOAD(p_sfpu::LREG4, InstrModLoadStore::LO16_ONLY, ADDR_MOD_1, 64);  // offset 4
+    TTI_SFPLOAD(p_sfpu::LREG5, InstrModLoadStore::LO16_ONLY, ADDR_MOD_2, 64);  // offset 6
+    TTI_SFPLOAD(p_sfpu::LREG6, InstrModLoadStore::LO16_ONLY, ADDR_MOD_1, 64);  // offset 20
+    TTI_SFPLOAD(p_sfpu::LREG7, InstrModLoadStore::LO16_ONLY, ADDR_MOD_3, 64);  // offset 22
+}
+
+template <uint32_t face_offset, uint32_t group_offset>
+inline void _top8_store_rows_0_3_() {
+    _top8_set_d_rwc_<face_offset, group_offset, /*row_offset*/ 0>();
+    TTI_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::FP16B, ADDR_MOD_1, 0);  // offset 0
+    TTI_SFPSTORE(p_sfpu::LREG1, InstrModLoadStore::FP16B, ADDR_MOD_2, 0);  // offset 2
+    TTI_SFPSTORE(p_sfpu::LREG2, InstrModLoadStore::FP16B, ADDR_MOD_1, 0);  // offset 16
+    TTI_SFPSTORE(p_sfpu::LREG3, InstrModLoadStore::FP16B, ADDR_MOD_3, 0);  // offset 18
+
+    _top8_set_d_rwc_<face_offset, group_offset, /*row_offset*/ 0>();
+    TTI_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::LO16_ONLY, ADDR_MOD_1, 64);  // offset 0
+    TTI_SFPSTORE(p_sfpu::LREG1, InstrModLoadStore::LO16_ONLY, ADDR_MOD_2, 64);  // offset 2
+    TTI_SFPSTORE(p_sfpu::LREG2, InstrModLoadStore::LO16_ONLY, ADDR_MOD_1, 64);  // offset 16
+    TTI_SFPSTORE(p_sfpu::LREG3, InstrModLoadStore::LO16_ONLY, ADDR_MOD_3, 64);  // offset 18
+}
+
+template <uint32_t face_offset, uint32_t group_offset>
+inline void _top8_store_rows_4_7_() {
+    _top8_set_d_rwc_<face_offset, group_offset, /*row_offset*/ 4>();
+    TTI_SFPSTORE(p_sfpu::LREG4, InstrModLoadStore::FP16B, ADDR_MOD_1, 0);  // offset 4
+    TTI_SFPSTORE(p_sfpu::LREG5, InstrModLoadStore::FP16B, ADDR_MOD_2, 0);  // offset 6
+    TTI_SFPSTORE(p_sfpu::LREG6, InstrModLoadStore::FP16B, ADDR_MOD_1, 0);  // offset 20
+    TTI_SFPSTORE(p_sfpu::LREG7, InstrModLoadStore::FP16B, ADDR_MOD_3, 0);  // offset 22
+
+    _top8_set_d_rwc_<face_offset, group_offset, /*row_offset*/ 4>();
+    TTI_SFPSTORE(p_sfpu::LREG4, InstrModLoadStore::LO16_ONLY, ADDR_MOD_1, 64);  // offset 4
+    TTI_SFPSTORE(p_sfpu::LREG5, InstrModLoadStore::LO16_ONLY, ADDR_MOD_2, 64);  // offset 6
+    TTI_SFPSTORE(p_sfpu::LREG6, InstrModLoadStore::LO16_ONLY, ADDR_MOD_1, 64);  // offset 20
+    TTI_SFPSTORE(p_sfpu::LREG7, InstrModLoadStore::LO16_ONLY, ADDR_MOD_3, 64);  // offset 22
+}
+
+inline void _top8_load_indices_() {
+    TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::LO16_ONLY, ADDR_MOD_1, 64);  // offset 0
+    TTI_SFPLOAD(p_sfpu::LREG1, InstrModLoadStore::LO16_ONLY, ADDR_MOD_2, 64);  // offset 2
+    TTI_SFPLOAD(p_sfpu::LREG2, InstrModLoadStore::LO16_ONLY, ADDR_MOD_1, 64);  // offset 16
+    TTI_SFPLOAD(p_sfpu::LREG3, InstrModLoadStore::LO16_ONLY, ADDR_MOD_3, 64);  // offset 18
+    TTI_SFPLOAD(p_sfpu::LREG4, InstrModLoadStore::LO16_ONLY, ADDR_MOD_1, 64);  // offset 4
+    TTI_SFPLOAD(p_sfpu::LREG5, InstrModLoadStore::LO16_ONLY, ADDR_MOD_2, 64);  // offset 6
+    TTI_SFPLOAD(p_sfpu::LREG6, InstrModLoadStore::LO16_ONLY, ADDR_MOD_1, 64);  // offset 20
+    TTI_SFPLOAD(p_sfpu::LREG7, InstrModLoadStore::LO16_ONLY, ADDR_MOD_0, 64);  // offset 22
+}
+
+inline void _top8_store_indices_() {
+    TTI_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::LO16_ONLY, ADDR_MOD_1, 64);  // offset 0
+    TTI_SFPSTORE(p_sfpu::LREG1, InstrModLoadStore::LO16_ONLY, ADDR_MOD_2, 64);  // offset 2
+    TTI_SFPSTORE(p_sfpu::LREG2, InstrModLoadStore::LO16_ONLY, ADDR_MOD_1, 64);  // offset 16
+    TTI_SFPSTORE(p_sfpu::LREG3, InstrModLoadStore::LO16_ONLY, ADDR_MOD_3, 64);  // offset 18
+    TTI_SFPSTORE(p_sfpu::LREG4, InstrModLoadStore::LO16_ONLY, ADDR_MOD_1, 64);  // offset 4
+    TTI_SFPSTORE(p_sfpu::LREG5, InstrModLoadStore::LO16_ONLY, ADDR_MOD_2, 64);  // offset 6
+    TTI_SFPSTORE(p_sfpu::LREG6, InstrModLoadStore::LO16_ONLY, ADDR_MOD_1, 64);  // offset 20
+    TTI_SFPSTORE(p_sfpu::LREG7, InstrModLoadStore::LO16_ONLY, ADDR_MOD_0, 64);  // offset 22
+}
+
+template <uint32_t group_offset>
+inline void _top8_add_group_offset_to_indices_() {
+    // Add the group offset to LREG0 to LREG7, in bits 3 and 4 from the lower 16 bits
+    TTI_SFPIADD(
+        group_offset << 3, p_sfpu::LREG0, p_sfpu::LREG0, sfpi::SFPIADD_MOD1_ARG_IMM | sfpi::SFPIADD_MOD1_CC_NONE);
+    TTI_SFPIADD(
+        group_offset << 3, p_sfpu::LREG1, p_sfpu::LREG1, sfpi::SFPIADD_MOD1_ARG_IMM | sfpi::SFPIADD_MOD1_CC_NONE);
+    TTI_SFPIADD(
+        group_offset << 3, p_sfpu::LREG2, p_sfpu::LREG2, sfpi::SFPIADD_MOD1_ARG_IMM | sfpi::SFPIADD_MOD1_CC_NONE);
+    TTI_SFPIADD(
+        group_offset << 3, p_sfpu::LREG3, p_sfpu::LREG3, sfpi::SFPIADD_MOD1_ARG_IMM | sfpi::SFPIADD_MOD1_CC_NONE);
+    TTI_SFPIADD(
+        group_offset << 3, p_sfpu::LREG4, p_sfpu::LREG4, sfpi::SFPIADD_MOD1_ARG_IMM | sfpi::SFPIADD_MOD1_CC_NONE);
+    TTI_SFPIADD(
+        group_offset << 3, p_sfpu::LREG5, p_sfpu::LREG5, sfpi::SFPIADD_MOD1_ARG_IMM | sfpi::SFPIADD_MOD1_CC_NONE);
+    TTI_SFPIADD(
+        group_offset << 3, p_sfpu::LREG6, p_sfpu::LREG6, sfpi::SFPIADD_MOD1_ARG_IMM | sfpi::SFPIADD_MOD1_CC_NONE);
+    TTI_SFPIADD(
+        group_offset << 3, p_sfpu::LREG7, p_sfpu::LREG7, sfpi::SFPIADD_MOD1_ARG_IMM | sfpi::SFPIADD_MOD1_CC_NONE);
+}
+
+inline void _top8_add_core_offset_to_indices_0_3_(uint32_t core_offset) {
+    // Add the core offset to LREG0 to LREG3, in bits 7-5 from the lower 16 bits
+    TT_SFPIADD(core_offset << 5, p_sfpu::LREG0, p_sfpu::LREG0, sfpi::SFPIADD_MOD1_ARG_IMM | sfpi::SFPIADD_MOD1_CC_NONE);
+    TT_SFPIADD(core_offset << 5, p_sfpu::LREG1, p_sfpu::LREG1, sfpi::SFPIADD_MOD1_ARG_IMM | sfpi::SFPIADD_MOD1_CC_NONE);
+    TT_SFPIADD(core_offset << 5, p_sfpu::LREG2, p_sfpu::LREG2, sfpi::SFPIADD_MOD1_ARG_IMM | sfpi::SFPIADD_MOD1_CC_NONE);
+    TT_SFPIADD(core_offset << 5, p_sfpu::LREG3, p_sfpu::LREG3, sfpi::SFPIADD_MOD1_ARG_IMM | sfpi::SFPIADD_MOD1_CC_NONE);
+}
+
+inline void _top8_add_core_offset_to_indices_4_7_(uint32_t core_offset) {
+    // Add the core offset to LREG0 to LREG3, in bits 7-5 from the lower 16 bits
+    TT_SFPIADD(core_offset << 5, p_sfpu::LREG4, p_sfpu::LREG4, sfpi::SFPIADD_MOD1_ARG_IMM | sfpi::SFPIADD_MOD1_CC_NONE);
+    TT_SFPIADD(core_offset << 5, p_sfpu::LREG5, p_sfpu::LREG5, sfpi::SFPIADD_MOD1_ARG_IMM | sfpi::SFPIADD_MOD1_CC_NONE);
+    TT_SFPIADD(core_offset << 5, p_sfpu::LREG6, p_sfpu::LREG6, sfpi::SFPIADD_MOD1_ARG_IMM | sfpi::SFPIADD_MOD1_CC_NONE);
+    TT_SFPIADD(core_offset << 5, p_sfpu::LREG7, p_sfpu::LREG7, sfpi::SFPIADD_MOD1_ARG_IMM | sfpi::SFPIADD_MOD1_CC_NONE);
+}
+
+inline void _top8_store_rows_0_3_final_() {
+    _top8_set_d_rwc_<0, 0, /*row_offset*/ 0>();
+    TTI_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::FP16B, ADDR_MOD_1, 0);  // offset 0
+    TTI_SFPSTORE(p_sfpu::LREG1, InstrModLoadStore::FP16B, ADDR_MOD_2, 0);  // offset 2
+    TTI_SFPSTORE(p_sfpu::LREG2, InstrModLoadStore::FP16B, ADDR_MOD_1, 0);  // offset 16
+    TTI_SFPSTORE(p_sfpu::LREG3, InstrModLoadStore::FP16B, ADDR_MOD_3, 0);  // offset 18
+
+    _top8_set_d_rwc_<0, 8, /*row_offset*/ 0>();
+    TTI_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::LO16_ONLY, ADDR_MOD_1, 0);  // offset 0
+    TTI_SFPSTORE(p_sfpu::LREG1, InstrModLoadStore::LO16_ONLY, ADDR_MOD_2, 0);  // offset 2
+    TTI_SFPSTORE(p_sfpu::LREG2, InstrModLoadStore::LO16_ONLY, ADDR_MOD_1, 0);  // offset 16
+    TTI_SFPSTORE(p_sfpu::LREG3, InstrModLoadStore::LO16_ONLY, ADDR_MOD_3, 0);  // offset 18
+}
+
+inline void _top8_store_rows_4_7_final_() {
+    _top8_set_d_rwc_<0, 0, /*row_offset*/ 4>();
+    TTI_SFPSTORE(p_sfpu::LREG4, InstrModLoadStore::FP16B, ADDR_MOD_1, 0);  // offset 4
+    TTI_SFPSTORE(p_sfpu::LREG5, InstrModLoadStore::FP16B, ADDR_MOD_2, 0);  // offset 6
+    TTI_SFPSTORE(p_sfpu::LREG6, InstrModLoadStore::FP16B, ADDR_MOD_1, 0);  // offset 20
+    TTI_SFPSTORE(p_sfpu::LREG7, InstrModLoadStore::FP16B, ADDR_MOD_3, 0);  // offset 22
+
+    _top8_set_d_rwc_<0, 8, /*row_offset*/ 4>();
+    TTI_SFPSTORE(p_sfpu::LREG4, InstrModLoadStore::LO16_ONLY, ADDR_MOD_1, 0);  // offset 4
+    TTI_SFPSTORE(p_sfpu::LREG5, InstrModLoadStore::LO16_ONLY, ADDR_MOD_2, 0);  // offset 6
+    TTI_SFPSTORE(p_sfpu::LREG6, InstrModLoadStore::LO16_ONLY, ADDR_MOD_1, 0);  // offset 20
+    TTI_SFPSTORE(p_sfpu::LREG7, InstrModLoadStore::LO16_ONLY, ADDR_MOD_3, 0);  // offset 22
+}
+
+//-----------------------------------------------------------------------------
+// Bitonic Merge for Already-Bitonic Sequence (12 swaps)
+//-----------------------------------------------------------------------------
+//
+// Given 8 values in LREG0-7 that form a bitonic sequence (e.g., valley-shaped
+// from the merge operation max(A[i], B[7-i])), sort them into descending order.
+// This requires only 12 swaps vs 24 for full bitonic sort.
+//
+//-----------------------------------------------------------------------------
+inline void _top8_bitonic_merge_8_rows_() {
+    // Stage 1: Compare distance 4 (4 swaps)
+    TTI_SFPSWAP(0, p_sfpu::LREG0, p_sfpu::LREG4, p_sfpswap::ALL_ROWS_MAX);
+    TTI_SFPSWAP(0, p_sfpu::LREG1, p_sfpu::LREG5, p_sfpswap::ALL_ROWS_MAX);
+    TTI_SFPSWAP(0, p_sfpu::LREG2, p_sfpu::LREG6, p_sfpswap::ALL_ROWS_MAX);
+    TTI_SFPSWAP(0, p_sfpu::LREG3, p_sfpu::LREG7, p_sfpswap::ALL_ROWS_MAX);
+
+    // Stage 2: Compare distance 2 (4 swaps)
+    TTI_SFPSWAP(0, p_sfpu::LREG0, p_sfpu::LREG2, p_sfpswap::ALL_ROWS_MAX);
+    TTI_SFPSWAP(0, p_sfpu::LREG1, p_sfpu::LREG3, p_sfpswap::ALL_ROWS_MAX);
+    TTI_SFPSWAP(0, p_sfpu::LREG4, p_sfpu::LREG6, p_sfpswap::ALL_ROWS_MAX);
+    TTI_SFPSWAP(0, p_sfpu::LREG5, p_sfpu::LREG7, p_sfpswap::ALL_ROWS_MAX);
+
+    // Stage 3: Compare distance 1 (4 swaps)
+    TTI_SFPSWAP(0, p_sfpu::LREG0, p_sfpu::LREG1, p_sfpswap::ALL_ROWS_MAX);
+    TTI_SFPSWAP(0, p_sfpu::LREG2, p_sfpu::LREG3, p_sfpswap::ALL_ROWS_MAX);
+    TTI_SFPSWAP(0, p_sfpu::LREG4, p_sfpu::LREG5, p_sfpswap::ALL_ROWS_MAX);
+    TTI_SFPSWAP(0, p_sfpu::LREG6, p_sfpu::LREG7, p_sfpswap::ALL_ROWS_MAX);
+}
+
+inline void _top8_bitonic_sort_8_rows_() {
+    // Stage 1: Build alternating pairs (4 swaps)
+    TTI_SFPSWAP(0, p_sfpu::LREG0, p_sfpu::LREG1, p_sfpswap::ALL_ROWS_MAX);  // 0>1 desc
+    TTI_SFPSWAP(0, p_sfpu::LREG3, p_sfpu::LREG2, p_sfpswap::ALL_ROWS_MAX);  // 2<3 asc
+    TTI_SFPSWAP(0, p_sfpu::LREG4, p_sfpu::LREG5, p_sfpswap::ALL_ROWS_MAX);  // 4>5 desc
+    TTI_SFPSWAP(0, p_sfpu::LREG7, p_sfpu::LREG6, p_sfpswap::ALL_ROWS_MAX);  // 6<7 asc
+
+    // Stage 2: Merge into sorted-4 sequences (8 swaps)
+    TTI_SFPSWAP(0, p_sfpu::LREG0, p_sfpu::LREG2, p_sfpswap::ALL_ROWS_MAX);
+    TTI_SFPSWAP(0, p_sfpu::LREG1, p_sfpu::LREG3, p_sfpswap::ALL_ROWS_MAX);
+    TTI_SFPSWAP(0, p_sfpu::LREG0, p_sfpu::LREG1, p_sfpswap::ALL_ROWS_MAX);
+    TTI_SFPSWAP(0, p_sfpu::LREG2, p_sfpu::LREG3, p_sfpswap::ALL_ROWS_MAX);
+    TTI_SFPSWAP(0, p_sfpu::LREG6, p_sfpu::LREG4, p_sfpswap::ALL_ROWS_MAX);
+    TTI_SFPSWAP(0, p_sfpu::LREG7, p_sfpu::LREG5, p_sfpswap::ALL_ROWS_MAX);
+    TTI_SFPSWAP(0, p_sfpu::LREG5, p_sfpu::LREG4, p_sfpswap::ALL_ROWS_MAX);
+    TTI_SFPSWAP(0, p_sfpu::LREG7, p_sfpu::LREG6, p_sfpswap::ALL_ROWS_MAX);
+
+    // Stage 3: Final bitonic merge (12 swaps)
+    _top8_bitonic_merge_8_rows_();
+}
+
+//-----------------------------------------------------------------------------
+// BITONIC MERGE: Two sorted-8 → Top-8
+//-----------------------------------------------------------------------------
+//
+// Given A[0-7] sorted desc in LREG, B[0-7] sorted desc at b_row (tile layout):
+//   top-8 candidates = max(A[i], B[7-i]) for i=0..7
+//   Then bitonic sort those 8 for final order.
+//
+// Tile layout index mapping for B[i]:
+//   B[0]=+0, B[1]=+2, B[2]=+16, B[3]=+18, B[4]=+4, B[5]=+6, B[6]=+20, B[7]=+22
+//
+// So B[7-i] reversed mapping:
+//   i=0: B[7]=+22, i=1: B[6]=+20, i=2: B[5]=+6, i=3: B[4]=+4
+//   i=4: B[3]=+18, i=5: B[2]=+16, i=6: B[1]=+2, i=7: B[0]=+0
+//
+//-----------------------------------------------------------------------------
+
+template <uint32_t face_offset, uint32_t grp_offset, bool replay>
+inline void _top8_merge_sorted_8_() {
+    // First 4 comparisons: A[0-3] vs B[7,6,5,4]
+    // A[0-3] at tile offsets: 0, 2, 16, 18
+    // B[7,6,5,4] at tile offsets: 22, 20, 6, 4
+
+    // Load A[0-3] to LREG0-3
+    _top8_load_rows_0_3_</*face_offset*/ 0, /*group_offset*/ 0>();
+
+    // Load B[4-7] to LREG4-7 (LREG4=B[4], LREG5=B[5], LREG6=B[6], LREG7=B[7])
+    _top8_load_rows_4_7_<face_offset, grp_offset>();
+
+    TTI_SFPTRANSP(0, 0, 0, 0);
+
+    // Compare reversed: A[0] vs B[7], A[1] vs B[6], A[2] vs B[5], A[3] vs B[4]
+    // max goes to LREG0-3
+    TTI_SFPSWAP(0, p_sfpu::LREG0, p_sfpu::LREG7, p_sfpswap::ALL_ROWS_MAX);
+    TTI_SFPSWAP(0, p_sfpu::LREG1, p_sfpu::LREG6, p_sfpswap::ALL_ROWS_MAX);
+    TTI_SFPSWAP(0, p_sfpu::LREG2, p_sfpu::LREG5, p_sfpswap::ALL_ROWS_MAX);
+    TTI_SFPSWAP(0, p_sfpu::LREG3, p_sfpu::LREG4, p_sfpswap::ALL_ROWS_MAX);
+
+    TTI_SFPTRANSP(0, 0, 0, 0);
+
+    // Store first 4 winners
+    _top8_store_rows_0_3_</*face_offset*/ 0, /*group_offset*/ 0>();
+
+    // Second 4 comparisons: A[4-7] vs B[3,2,1,0]
+    // A[4-7] at tile offsets: 4, 6, 20, 22
+    // B[3,2,1,0] at tile offsets: 18, 16, 2, 0
+
+    // Load A[4-7] to LREG4-7 (LREG4=A[4], LREG5=A[5], LREG6=A[6], LREG7=A[7])
+    _top8_load_rows_4_7_</*face_offset*/ 0, /*group_offset*/ 0>();
+
+    // Load B[0-3] to LREG0-3 (LREG0=B[0], LREG1=B[1], LREG2=B[2], LREG3=B[3])
+    _top8_load_rows_0_3_<face_offset, grp_offset>();
+
+    TTI_SFPTRANSP(0, 0, 0, 0);
+
+    // Compare reversed: A[4] vs B[3], A[5] vs B[2], A[6] vs B[1], A[7] vs B[0]
+    // max goes to LREG4-7
+    TTI_SFPSWAP(0, p_sfpu::LREG4, p_sfpu::LREG3, p_sfpswap::ALL_ROWS_MAX);
+    TTI_SFPSWAP(0, p_sfpu::LREG5, p_sfpu::LREG2, p_sfpswap::ALL_ROWS_MAX);
+    TTI_SFPSWAP(0, p_sfpu::LREG6, p_sfpu::LREG1, p_sfpswap::ALL_ROWS_MAX);
+    TTI_SFPSWAP(0, p_sfpu::LREG7, p_sfpu::LREG0, p_sfpswap::ALL_ROWS_MAX);
+
+    TTI_SFPTRANSP(0, 0, 0, 0);
+
+    // Store second 4 winners
+    _top8_store_rows_4_7_</*face_offset*/ 0, /*group_offset*/ 0>();
+
+    // Load all 8 winners and bitonic merge (only 12 swaps needed for bitonic sequence)
+    TTI_SETRWC(p_setrwc::CLR_NONE, 0, 0, 0, 0, p_setrwc::SET_D);
+
+    if constexpr (replay) {
+        lltt::replay(0, 16);
+        TTI_SFPTRANSP(0, 0, 0, 0);
+        _top8_bitonic_merge_8_rows_();
+        TTI_SFPTRANSP(0, 0, 0, 0);
+        lltt::replay(16, 16);
+    } else {
+        lltt::record<lltt::Exec>(0, 16);
+        _load_sorted_group_();
+        TTI_SFPTRANSP(0, 0, 0, 0);
+        _top8_bitonic_merge_8_rows_();
+        TTI_SFPTRANSP(0, 0, 0, 0);
+        lltt::record<lltt::Exec>(16, 16);
+        _store_sorted_group_();
+    }
+}
+
+inline void _calculate_top8_tile_(uint32_t tile_index) {
+    TTI_SETRWC(p_setrwc::CLR_NONE, 0, 0, 0, 0, p_setrwc::SET_D);
+
+    //-------------------------------------------------------------------------
+    // PHASE 1: Sort all 4 groups using replay buffer
+    //-------------------------------------------------------------------------
+    lltt::record<lltt::Exec>(0, 8);
+    _load_input_group_();
+    TTI_SFPTRANSP(0, 0, 0, 0);
+    _add_row_indices_();
+    lltt::record<lltt::Exec>(8, 24);
+    _top8_bitonic_sort_8_rows_();
+    TTI_SFPTRANSP(0, 0, 0, 0);
+    _store_sorted_group_();
+
+    TTI_INCRWC(p_setrwc::CR_D, 8, 0, 0);
+
+    lltt::replay(0, 8);
+    TTI_SFPTRANSP(0, 0, 0, 0);
+    _add_row_indices_();
+    lltt::replay(8, 24);
+    TTI_SFPTRANSP(0, 0, 0, 0);
+    _store_sorted_group_();
+
+    // Need to increment the dst index by 16 for group 2
+    // Have to increment twice because the increment field is only 4 bit wide :(
+    TTI_INCRWC(p_setrwc::CR_D, 8, 0, 0);
+    TTI_INCRWC(p_setrwc::CR_D, 8, 0, 0);
+    TTI_INCRWC(p_setrwc::CR_D, 8, 0, 0);
+
+    lltt::replay(0, 8);
+    TTI_SFPTRANSP(0, 0, 0, 0);
+    _add_row_indices_();
+    lltt::replay(8, 24);
+    TTI_SFPTRANSP(0, 0, 0, 0);
+    _store_sorted_group_();
+
+    TTI_INCRWC(p_setrwc::CR_D, 8, 0, 0);
+
+    lltt::replay(0, 8);
+    TTI_SFPTRANSP(0, 0, 0, 0);
+    _add_row_indices_();
+    lltt::replay(8, 24);
+    TTI_SFPTRANSP(0, 0, 0, 0);
+    _store_sorted_group_();
+
+    //-------------------------------------------------------------------------
+    // Phase 2: Add group offset to the indices
+    //-------------------------------------------------------------------------
+    // No need to touch group 0 has it already has 0 as the group offset
+
+    // Group 1
+    TTI_SETRWC(p_setrwc::CLR_NONE, 0, 8, 0, 0, p_setrwc::SET_D);
+    lltt::record<lltt::Exec>(0, 9);
+    _top8_load_indices_();
+    TTI_SFPTRANSP(0, 0, 0, 0);
+    _top8_add_group_offset_to_indices_<1>();
+    lltt::record<lltt::Exec>(9, 9);
+    TTI_SFPTRANSP(0, 0, 0, 0);
+    _top8_store_indices_();
+
+    // Move to lower half
+    // Need to increment twice because the increment field is only 4 bit wide :(
+    TTI_INCRWC(p_setrwc::CR_D, 8, 0, 0);
+    TTI_INCRWC(p_setrwc::CR_D, 8, 0, 0);
+
+    // Group 2
+    TTI_INCRWC(p_setrwc::CR_D, 8, 0, 0);
+    lltt::replay(0, 9);
+    _top8_add_group_offset_to_indices_<2>();
+    lltt::replay(9, 9);
+
+    // Group 3
+    TTI_INCRWC(p_setrwc::CR_D, 8, 0, 0);
+    lltt::replay(0, 9);
+    _top8_add_group_offset_to_indices_<3>();
+    lltt::replay(9, 9);
+
+    //-------------------------------------------------------------------------
+    // PHASE 3: Sequential merge all 4 groups into final top-8
+    //-------------------------------------------------------------------------
+    // Group 0 is already sorted in place from Phase 1, merge with groups 1-3
+    _top8_merge_sorted_8_</*face_offset*/ 0, /*group_offset*/ 8, /*replay=*/false>();
+    _top8_merge_sorted_8_</*face_offset*/ 1, /*group_offset*/ 0, /*replay=*/true>();
+    _top8_merge_sorted_8_</*face_offset*/ 1, /*group_offset*/ 8, /*replay=*/true>();
+
+    //-------------------------------------------------------------------------
+    // PHASE 4: Flush some lanes if this group is not selected
+    //-------------------------------------------------------------------------
+    TTI_SETRWC(p_setrwc::CLR_NONE, 0, 0, 0, 0, p_setrwc::SET_D);
+
+    TTI_SFPTRANSP(0, 0, 0, 0);
+
+    // For these 4 indices, put the core_id in the LO 16 bits (bits 7-5)
+    _top8_add_core_offset_to_indices_0_3_(tile_index);
+
+    // Mask is available in tile 2
+    TTI_SFPLOAD(p_sfpu::LREG4, InstrModLoadStore::LO16_ONLY, ADDR_MOD_1, 128);
+
+    // Now, let us bitshift by tile_index to get the mask for this tile
+    // Mask to get only bit at tile_index
+    TT_SFPLOADI(p_sfpu::LREG5, sfpi::SFPLOADI_MOD0_USHORT, 1 << tile_index);
+    TTI_SFPAND(0, p_sfpu::LREG5, p_sfpu::LREG4, 0);  // LREG4 now has zero or (1<<tile_index)
+
+    // Enable lanes if LREG4 is 0
+    TTI_SFPSETCC(0, p_sfpu::LREG4, 0, sfpi::SFPSETCC_MOD1_LREG_EQ0);
+
+    // Load negative infinity constant (BF16 format)
+    constexpr uint16_t NEG_INF_BF16 = 0xFF80;
+
+    // Conditionally load -inf into LREG0-3 (only affects lanes where condition is true)
+    TTI_SFPLOADI(p_sfpu::LREG0, sfpi::SFPLOADI_MOD0_FLOATB, NEG_INF_BF16);
+    TTI_SFPLOADI(p_sfpu::LREG1, sfpi::SFPLOADI_MOD0_FLOATB, NEG_INF_BF16);
+    TTI_SFPLOADI(p_sfpu::LREG2, sfpi::SFPLOADI_MOD0_FLOATB, NEG_INF_BF16);
+    TTI_SFPLOADI(p_sfpu::LREG3, sfpi::SFPLOADI_MOD0_FLOATB, NEG_INF_BF16);
+
+    // Clear condition codes (re-enable all lanes)
+    TTI_SFPENCC(0, 0, 0, 0);
+
+    // Store the result
+    TTI_SFPTRANSP(0, 0, 0, 0);
+    _top8_store_rows_0_3_final_();
+
+    TTI_SFPTRANSP(0, 0, 0, 0);
+    TTI_SFPMOV(0, p_sfpu::LREG4, p_sfpu::LREG0, 0);
+    TTI_SFPTRANSP(0, 0, 0, 0);
+
+    _top8_load_rows_4_7_</*face_offset*/ 0, /*group_offset*/ 0>();
+
+    TTI_SFPTRANSP(0, 0, 0, 0);
+
+    _top8_add_core_offset_to_indices_4_7_(tile_index);
+
+    // Set condition code to 0 if LREG0 is 0
+    TTI_SFPSETCC(0, p_sfpu::LREG0, 0, sfpi::SFPSETCC_MOD1_LREG_EQ0);
+
+    // Conditionally load -inf into LREG4-7 (only affects lanes where condition is true)
+    TTI_SFPLOADI(p_sfpu::LREG4, sfpi::SFPLOADI_MOD0_FLOATB, NEG_INF_BF16);
+    TTI_SFPLOADI(p_sfpu::LREG5, sfpi::SFPLOADI_MOD0_FLOATB, NEG_INF_BF16);
+    TTI_SFPLOADI(p_sfpu::LREG6, sfpi::SFPLOADI_MOD0_FLOATB, NEG_INF_BF16);
+    TTI_SFPLOADI(p_sfpu::LREG7, sfpi::SFPLOADI_MOD0_FLOATB, NEG_INF_BF16);
+
+    // Clear condition codes (re-enable all lanes)
+    TTI_SFPENCC(0, 0, 0, 0);
+
+    // Store the result
+    TTI_SFPTRANSP(0, 0, 0, 0);
+    _top8_store_rows_4_7_final_();
+}
+
+}  // namespace sfpu
+
+inline void _llk_math_top8_tile_init_() {
+    llk_math_eltwise_unary_sfpu_init<SfpuType::unused, /*APPROXIMATE=*/true>(ckernel::sfpu::_top8_configure_addrmod_);
+}
+
+inline void _llk_math_top8_tile_(uint32_t tile_index, uint32_t dst_index) {
+    _llk_math_eltwise_unary_sfpu_params_</*APPROXIMATE=*/true>(
+        ckernel::sfpu::_calculate_top8_tile_, dst_index, VectorMode::RC_custom, tile_index);
+}
+
+#endif
+
+/**
+ * @brief Initializes the per-core top-8 selection SFPU operation.
+ */
+inline void top8_tile_init() { MATH((_llk_math_top8_tile_init_())); }
+
+ALWI void top8_tile(uint32_t tile_index, uint32_t dst_index) { MATH((_llk_math_top8_tile_(tile_index, dst_index))); }
+
+}  // namespace ckernel

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek/moe/moe_gate_mm/device/kernels/top8_sfpu.h
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek/moe/moe_gate_mm/device/kernels/top8_sfpu.h
@@ -285,7 +285,7 @@ inline void _top8_add_core_offset_to_indices_0_3_(uint32_t core_offset) {
 }
 
 inline void _top8_add_core_offset_to_indices_4_7_(uint32_t core_offset) {
-    // Add the core offset to LREG0 to LREG3, in bits 7-5 from the lower 16 bits
+    // Add the core offset to LREG4 to LREG7, in bits 7-5 from the lower 16 bits
     TT_SFPIADD(core_offset << 5, p_sfpu::LREG4, p_sfpu::LREG4, sfpi::SFPIADD_MOD1_ARG_IMM | sfpi::SFPIADD_MOD1_CC_NONE);
     TT_SFPIADD(core_offset << 5, p_sfpu::LREG5, p_sfpu::LREG5, sfpi::SFPIADD_MOD1_ARG_IMM | sfpi::SFPIADD_MOD1_CC_NONE);
     TT_SFPIADD(core_offset << 5, p_sfpu::LREG6, p_sfpu::LREG6, sfpi::SFPIADD_MOD1_ARG_IMM | sfpi::SFPIADD_MOD1_CC_NONE);

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek/moe/moe_gate_mm/device/moe_gate_mm_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek/moe/moe_gate_mm/device/moe_gate_mm_device_operation.cpp
@@ -16,14 +16,7 @@ void MoEGateMMDeviceOperation::validate_on_program_cache_hit(
     validate_on_program_cache_miss(args, tensor_args);
 }
 
-void MoEGateMMDeviceOperation::validate_on_program_cache_miss(
-    const operation_attributes_t& args, const tensor_args_t& tensor_args) {
-    TT_FATAL(
-        tensor_args.input_tensor.logical_shape().rank() >= 2,
-        "Input tensor must be at least rank 2, got {}",
-        tensor_args.input_tensor.logical_shape().rank());
-    TT_FATAL(args.layer_id >= 0, "Layer ID must be non-negative, got {}", args.layer_id);
-}
+void MoEGateMMDeviceOperation::validate_on_program_cache_miss(const operation_attributes_t&, const tensor_args_t&) {}
 
 MoEGateMMDeviceOperation::spec_return_value_t MoEGateMMDeviceOperation::compute_output_specs(
     const operation_attributes_t&, const tensor_args_t& tensor_args) {

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek/moe/moe_gate_mm/device/moe_gate_mm_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek/moe/moe_gate_mm/device/moe_gate_mm_device_operation.cpp
@@ -1,0 +1,53 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "moe_gate_mm_device_operation.hpp"
+
+namespace ttnn::operations::experimental::deepseek::moe::moe_gate_mm {
+
+MoEGateMMDeviceOperation::program_factory_t MoEGateMMDeviceOperation::select_program_factory(
+    const operation_attributes_t&, const tensor_args_t&) {
+    return program::MoEGateMMProgramFactory{};
+}
+
+void MoEGateMMDeviceOperation::validate_on_program_cache_hit(
+    const operation_attributes_t& args, const tensor_args_t& tensor_args) {
+    validate_on_program_cache_miss(args, tensor_args);
+}
+
+void MoEGateMMDeviceOperation::validate_on_program_cache_miss(
+    const operation_attributes_t& args, const tensor_args_t& tensor_args) {
+    TT_FATAL(
+        tensor_args.input_tensor.logical_shape().rank() >= 2,
+        "Input tensor must be at least rank 2, got {}",
+        tensor_args.input_tensor.logical_shape().rank());
+    TT_FATAL(args.layer_id >= 0, "Layer ID must be non-negative, got {}", args.layer_id);
+}
+
+MoEGateMMDeviceOperation::spec_return_value_t MoEGateMMDeviceOperation::compute_output_specs(
+    const operation_attributes_t&, const tensor_args_t& tensor_args) {
+    // Use the output tensor's spec since it's passed in with the correct sharded memory config
+    const auto& output_tensor = tensor_args.output_tensor;
+    return output_tensor.tensor_spec();
+}
+
+MoEGateMMDeviceOperation::tensor_return_value_t MoEGateMMDeviceOperation::create_output_tensors(
+    const operation_attributes_t&, const tensor_args_t& tensor_args) {
+    // Return the preallocated output tensor (already sharded with correct memory config)
+    return tensor_args.output_tensor;
+}
+
+std::tuple<MoEGateMMDeviceOperation::operation_attributes_t, MoEGateMMDeviceOperation::tensor_args_t>
+MoEGateMMDeviceOperation::invoke(
+    const Tensor& input_tensor,
+    const Tensor& w_tensor,
+    const Tensor& output_tensor,
+    const uint32_t layer_id,
+    const uint32_t column_id) {
+    return {
+        operation_attributes_t{.layer_id = layer_id, .column_id = column_id},
+        tensor_args_t{.input_tensor = input_tensor, .w_tensor = w_tensor, .output_tensor = output_tensor}};
+}
+
+}  // namespace ttnn::operations::experimental::deepseek::moe::moe_gate_mm

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek/moe/moe_gate_mm/device/moe_gate_mm_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek/moe/moe_gate_mm/device/moe_gate_mm_device_operation.hpp
@@ -1,0 +1,47 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <optional>
+#include <variant>
+
+#include "ttnn/tensor/tensor.hpp"
+#include "ttnn/device_operation.hpp"
+#include "ttnn/decorators.hpp"
+#include "moe_gate_mm_device_operation_types.hpp"
+#include "moe_gate_mm_program_factory.hpp"
+
+namespace ttnn::operations::experimental::deepseek::moe::moe_gate_mm {
+
+struct MoEGateMMDeviceOperation {
+    using operation_attributes_t = moe_gate_mm::operation_attributes_t;
+    using tensor_args_t = moe_gate_mm::tensor_args_t;
+    using spec_return_value_t = moe_gate_mm::spec_return_value_t;
+    using tensor_return_value_t = moe_gate_mm::tensor_return_value_t;
+    using program_factory_t = std::variant<program::MoEGateMMProgramFactory>;
+
+    static program_factory_t select_program_factory(const operation_attributes_t&, const tensor_args_t&);
+
+    static void validate_on_program_cache_hit(const operation_attributes_t&, const tensor_args_t&);
+    static void validate_on_program_cache_miss(const operation_attributes_t&, const tensor_args_t&);
+    static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
+    static tensor_return_value_t create_output_tensors(
+        const operation_attributes_t& operation_attributes, const tensor_args_t&);
+
+    static std::tuple<operation_attributes_t, tensor_args_t> invoke(
+        const Tensor& input_tensor,
+        const Tensor& w_tensor,
+        const Tensor& output_tensor,
+        const uint32_t layer_id,
+        const uint32_t column_id);
+};
+
+}  // namespace ttnn::operations::experimental::deepseek::moe::moe_gate_mm
+
+namespace ttnn::experimental::deepseek::moe {
+constexpr auto moe_gate_mm = ttnn::register_operation<
+    "ttnn::experimental::deepseek::moe::moe_gate_mm",
+    ttnn::operations::experimental::deepseek::moe::moe_gate_mm::MoEGateMMDeviceOperation>();
+}  // namespace ttnn::experimental::deepseek::moe

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek/moe/moe_gate_mm/device/moe_gate_mm_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek/moe/moe_gate_mm/device/moe_gate_mm_device_operation.hpp
@@ -34,8 +34,8 @@ struct MoEGateMMDeviceOperation {
         const Tensor& input_tensor,
         const Tensor& w_tensor,
         const Tensor& output_tensor,
-        const uint32_t layer_id,
-        const uint32_t column_id);
+        uint32_t layer_id,
+        uint32_t column_id);
 };
 
 }  // namespace ttnn::operations::experimental::deepseek::moe::moe_gate_mm

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek/moe/moe_gate_mm/device/moe_gate_mm_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek/moe/moe_gate_mm/device/moe_gate_mm_device_operation_types.hpp
@@ -1,0 +1,27 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ttnn/tensor/tensor.hpp"
+#include <tt-metalium/base_types.hpp>
+
+namespace ttnn::operations::experimental::deepseek::moe::moe_gate_mm {
+
+struct operation_attributes_t {
+    uint32_t layer_id{};
+    uint32_t column_id{};
+};
+
+struct tensor_args_t {
+    const Tensor& input_tensor;
+    const Tensor& w_tensor;
+    const Tensor& output_tensor;
+};
+
+using tensor_return_value_t = Tensor;
+
+using spec_return_value_t = TensorSpec;
+
+}  // namespace ttnn::operations::experimental::deepseek::moe::moe_gate_mm

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek/moe/moe_gate_mm/device/moe_gate_mm_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek/moe/moe_gate_mm/device/moe_gate_mm_program_factory.cpp
@@ -99,7 +99,7 @@ MoEGateMMProgramFactory::cached_program_t MoEGateMMProgramFactory::create(
     // Sort cores by (descending y, descending x) to create a ring that flows naturally
     std::vector<uint32_t> ring_pos2bank_id(num_cores);
     std::iota(ring_pos2bank_id.begin(), ring_pos2bank_id.end(), 0);
-    auto device = tensor_args.input_tensor.device();
+    auto *device = tensor_args.input_tensor.device();
 
     std::sort(
         ring_pos2bank_id.begin(),

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek/moe/moe_gate_mm/device/moe_gate_mm_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek/moe/moe_gate_mm/device/moe_gate_mm_program_factory.cpp
@@ -1,0 +1,291 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "moe_gate_mm_program_factory.hpp"
+#include "moe_gate_mm_device_operation_types.hpp"
+
+#include <tt-metalium/math.hpp>
+#include <tt-metalium/constants.hpp>
+#include "ttnn/operations/cb_utils.hpp"
+#include <tt-metalium/tensor_accessor_args.hpp>
+#include <algorithm>
+#include <numeric>
+#include <tuple>
+#include <utility>
+#include <vector>
+
+namespace ttnn::operations::experimental::deepseek::moe::moe_gate_mm::program {
+
+MoEGateMMProgramFactory::cached_program_t MoEGateMMProgramFactory::create(
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args, tensor_return_value_t&) {
+    tt::tt_metal::Program program = tt::tt_metal::CreateProgram();
+
+    // Get the cores for the program
+    const auto dram_bank2core_coords =
+        tensor_args.input_tensor.device()->get_optimal_dram_bank_to_logical_worker_assignment(
+            tt::tt_metal::NOC::RISCV_0_default);
+
+    const uint32_t num_cores = dram_bank2core_coords.size();
+    auto all_cores = tt::tt_metal::CoreRangeSet(dram_bank2core_coords);
+
+    // CBs used in the MoE Gate MM operation
+    /*
+        ------------------------------------------------------------------------------------
+        |     Name       |   CB Index    |   Dtype    | Tile? | Tiles/CB |  Total size (B) |
+        ------------------------------------------------------------------------------------
+        | cb_r2c_w       | CBIndex::c_0  | Float16_b  | true  |    32*3  |      196608     |
+        | cb_s2c_in(sh)  | CBIndex::c_1  | Float16_b  | true  |    224   |      458752     |
+        | cb_c2w_rdy     | CBIndex::c_2  | Float32    | false |    1     |      4          |
+        | cb_w2c_in2     | CBIndex::c_3  | Float32    | true  |    1     |      2048       |
+        | cb_s2c_out(sh) | CBIndex::c_4  | Float16_b  | true  |    1     |      2048       |
+        | cb_w2c_in3     | CBIndex::c_5  | Float16_b  | true  |    1     |      2048       |
+        | cb_w2c_in4     | CBIndex::c_6  | Float16_b  | true  |    1     |      2048       |
+        | cb_w2c_in5     | CBIndex::c_7  | Float16_b  | true  |    1     |      2048       |
+        | cb_w2c_in6     | CBIndex::c_8  | Float16_b  | true  |    4     |      8192       |
+        | cb_w2c_in7     | CBIndex::c_9  | Float16_b  | true  |    4     |      8192      |
+        ------------------------------------------------------------------------------------
+    */
+
+    // Define the CB configuration as a tuple: name, CBIndex, DataFormat, tiles_per_cb
+    const std::vector<std::tuple<std::string, tt::CBIndex, tt::DataFormat, bool, uint32_t>> cb_specs0 = {
+        {"cb_r2c_w", tt::CBIndex::c_0, tt::DataFormat::Float16_b, true, 32 * 3},
+        {"cb_c2w_rdy", tt::CBIndex::c_2, tt::DataFormat::Float32, false, 1},
+        {"cb_w2c_in2", tt::CBIndex::c_3, tt::DataFormat::Float32, true, 1},
+        {"cb_w2c_in3", tt::CBIndex::c_5, tt::DataFormat::Float16_b, true, 1},
+        {"cb_w2c_in4", tt::CBIndex::c_6, tt::DataFormat::Float16_b, true, 1},
+        {"cb_w2c_in5", tt::CBIndex::c_7, tt::DataFormat::Float16_b, true, 1},
+        {"cb_w2c_in6", tt::CBIndex::c_8, tt::DataFormat::Float16_b, true, 4},
+        {"cb_w2c_in7", tt::CBIndex::c_9, tt::DataFormat::Float16_b, true, 4},
+    };
+
+    [[maybe_unused]] std::map<std::string, tt::tt_metal::CBHandle> cb_handles, cb_handles_sharded;
+
+    // Create CBs
+    for (const auto& [name, index, data_format, is_tile, tiles_per_cb] : cb_specs0) {
+        const uint32_t bytes_per_tile = is_tile ? tt::tile_size(data_format) : tt::datum_size(data_format);
+        const auto cb_config = tt::tt_metal::CircularBufferConfig(tiles_per_cb * bytes_per_tile, {{index, data_format}})
+                                   .set_page_size(index, bytes_per_tile);
+
+        cb_handles[name] = tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_config);
+    }
+
+    // Create sharded CBs
+    // Define the CB configuration as a tuple: name, CBIndex, DataFormat, tiles_per_cb, Buffer*
+    const std::vector<std::tuple<std::string, tt::CBIndex, tt::DataFormat, bool, uint32_t, tt::tt_metal::Buffer*>>
+        sharded_cb_specs = {
+            {"cb_s2c_in", tt::CBIndex::c_1, tt::DataFormat::Float16_b, true, 224, tensor_args.input_tensor.buffer()},
+            {"cb_s2c_out", tt::CBIndex::c_4, tt::DataFormat::Float16_b, true, 1, tensor_args.output_tensor.buffer()}};
+
+    for (const auto& [name, index, data_format, is_tile, tiles_per_cb, p_buffer] : sharded_cb_specs) {
+        const uint32_t bytes_per_tile = is_tile ? tt::tile_size(data_format) : tt::datum_size(data_format);
+        const auto cb_config = tt::tt_metal::CircularBufferConfig(tiles_per_cb * bytes_per_tile, {{index, data_format}})
+                                   .set_page_size(index, bytes_per_tile)
+                                   .set_globally_allocated_address(*p_buffer);
+        cb_handles_sharded[name] = tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_config);
+    }
+
+    // Create compile args for the program
+    const auto tensors =
+        std::vector<const Tensor*>{&tensor_args.input_tensor, &tensor_args.w_tensor, &tensor_args.output_tensor};
+
+    std::vector<uint32_t> compile_args;
+    for (const auto& tensor : tensors) {
+        tt::tt_metal::TensorAccessorArgs(*tensor->buffer()).append_to(compile_args);
+    }
+
+    // Create optimal ring ordering for NOC1 to minimize traffic conflicts
+    // NOC1 routes: decreasing y (top) first, then decreasing x (left)
+    // Sort cores by (descending y, descending x) to create a ring that flows naturally
+    std::vector<uint32_t> ring_pos2bank_id(num_cores);
+    std::iota(ring_pos2bank_id.begin(), ring_pos2bank_id.end(), 0);
+    auto device = tensor_args.input_tensor.device();
+
+    std::sort(
+        ring_pos2bank_id.begin(),
+        ring_pos2bank_id.end(),
+        [device, &dram_bank2core_coords](uint32_t bank_id_a, uint32_t bank_id_b) {
+            const auto& pa = device->worker_core_from_logical_core(dram_bank2core_coords[bank_id_a]);
+            const auto& pb = device->worker_core_from_logical_core(dram_bank2core_coords[bank_id_b]);
+            if (pa.y != pb.y) {
+                return pa.y > pb.y;  // Descending y
+            }
+            return pa.x > pb.x;  // Descending x
+        });
+
+    // For every third core, figure out the physical coords of the two cores after it.
+    std::unordered_map<uint32_t, std::array<uint32_t, 5>> dram_bank2neighbors;
+    for (uint32_t ring_pos = 0; ring_pos < num_cores; ring_pos += 3) {
+        auto bank_id = ring_pos2bank_id[ring_pos];
+        auto bank_id_next1 = ring_pos2bank_id[ring_pos + 1];
+        auto bank_id_next2 = ring_pos2bank_id[ring_pos + 2];
+
+        const auto& core_next1 = device->worker_core_from_logical_core(dram_bank2core_coords[bank_id_next1]);
+        const auto& core_next2 = device->worker_core_from_logical_core(dram_bank2core_coords[bank_id_next2]);
+
+        dram_bank2neighbors[bank_id] = {1, core_next1.x, core_next1.y, core_next2.x, core_next2.y};
+    }
+
+    // We also need the reverse mapping for bank_id to N tile_id
+    std::unordered_map<uint32_t, uint32_t> bank2tile_id;
+    uint32_t tile_id = 0;
+    for (uint32_t core_id = 0; core_id < num_cores; core_id++) {
+        if ((core_id % 3) == 0) {
+            continue;
+        }
+        bank2tile_id[ring_pos2bank_id[core_id]] = tile_id++;
+    }
+
+    const auto& collector_core = device->worker_core_from_logical_core(dram_bank2core_coords[ring_pos2bank_id[11]]);
+    const auto& first_core = device->worker_core_from_logical_core(dram_bank2core_coords[ring_pos2bank_id[0]]);
+
+    std::unordered_map<std::string, uint32_t> named_compile_time_args = {
+        {"layer_id", operation_attributes.layer_id},
+        {"num_cores", static_cast<uint32_t>(num_cores)},
+        {"collector_physical_x", collector_core.x},
+        {"collector_physical_y", collector_core.y},
+        {"first_physical_x", first_core.x},
+        {"first_physical_y", first_core.y},
+        {"column_id", operation_attributes.column_id},
+    };
+
+    // Create kernels for the program
+    auto dm0_kernel_handle = tt::tt_metal::CreateKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/experimental/deepseek/moe/moe_gate_mm/device/kernels/dm0.cpp",
+        all_cores,
+        tt::tt_metal::DataMovementConfig{
+            .processor = tt::tt_metal::DataMovementProcessor::RISCV_1,
+            .noc = tt::tt_metal::NOC::NOC_0,
+            .compile_args = compile_args,
+            .named_compile_args = named_compile_time_args});
+
+    auto dm1_kernel_handle = tt::tt_metal::CreateKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/experimental/deepseek/moe/moe_gate_mm/device/kernels/dm1.cpp",
+        all_cores,
+        tt::tt_metal::DataMovementConfig{
+            .processor = tt::tt_metal::DataMovementProcessor::RISCV_0,
+            .noc = tt::tt_metal::NOC::NOC_1,
+            .compile_args = compile_args,
+            .named_compile_args = named_compile_time_args});
+
+    auto compute_kernel_handle = tt::tt_metal::CreateKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/experimental/deepseek/moe/moe_gate_mm/device/kernels/compute.cpp",
+        all_cores,
+        tt::tt_metal::ComputeConfig{
+            .math_fidelity = MathFidelity::LoFi,
+            .fp32_dest_acc_en = false,
+            .dst_full_sync_en = false,
+            .bfp8_pack_precise = false,
+            .math_approx_mode = true,
+            .compile_args = compile_args,
+            .named_compile_args = named_compile_time_args});
+
+    // Create semaphores to wait for the partial to arrive from the other core
+    // There will be 8 cores, each waiting for partial to come from 4 other cores.
+    // The 4 cores will send partial to two cores each.
+    const uint32_t partial_semaphore_id = tt::tt_metal::CreateSemaphore(program, all_cores, 0);
+    const uint32_t raw_scores_semaphore_id = tt::tt_metal::CreateSemaphore(program, all_cores, 0);
+
+    // Set the runtime arguments for the kernels
+    std::vector<uint32_t> runtime_args;
+    runtime_args.push_back(0);  // DRAM Bank ID placeholder
+    runtime_args.push_back(0);  // VChannel placeholder
+
+    for (const auto& tensor : tensors) {
+        runtime_args.push_back(tensor->buffer()->address());
+    }
+
+    // Add placeholders for neighbor physical coords and semaphore
+    runtime_args.push_back(partial_semaphore_id);
+    runtime_args.push_back(0);  // If this is a sender core
+    runtime_args.push_back(0);  // Neighbor1 physical x
+    runtime_args.push_back(0);  // Neighbor1 physical y
+    runtime_args.push_back(0);  // Neighbor2 physical x
+    runtime_args.push_back(0);  // Neighbor2 physical y
+    runtime_args.push_back(0);  // Core ID
+    runtime_args.push_back(raw_scores_semaphore_id);
+
+    std::vector<uint32_t> vchannels;
+    uint32_t dram_bank = 0;
+    for (auto core : dram_bank2core_coords) {
+        uint32_t vchannel = dram_bank & 0x3;
+
+        // Check if there is any core with the same row
+        auto it = std::find_if(
+            dram_bank2core_coords.begin(), dram_bank2core_coords.begin() + dram_bank, [&](const auto& core_prev) {
+                return core_prev.y == core.y;
+            });
+
+        // If there is any core with the same row, make sure the VChannel is different
+        if (it != dram_bank2core_coords.begin() + dram_bank) {
+            size_t j = std::distance(dram_bank2core_coords.begin(), it);
+            if (vchannel == vchannels[j]) {
+                vchannel = (vchannel + 1) & 0x3;
+            }
+        }
+        vchannels.push_back(vchannel);
+
+        runtime_args[0] = dram_bank;
+        runtime_args[1] = vchannel;
+        // runtime_args[2-4] are already set to tensor addresses
+        // runtime_args[5] is already set to reduce_semaphore
+        // Do this only if the key exists in the map.
+        if (dram_bank2neighbors.contains(dram_bank)) {
+            runtime_args[6] = dram_bank2neighbors[dram_bank][0];
+            runtime_args[7] = dram_bank2neighbors[dram_bank][1];
+            runtime_args[8] = dram_bank2neighbors[dram_bank][2];
+            runtime_args[9] = dram_bank2neighbors[dram_bank][3];
+            runtime_args[10] = dram_bank2neighbors[dram_bank][4];
+            runtime_args[11] = 0;
+        } else {
+            runtime_args[6] = 0;
+            runtime_args[7] = 0;
+            runtime_args[8] = 0;
+            runtime_args[9] = 0;
+            runtime_args[10] = 0;
+            runtime_args[11] = bank2tile_id[dram_bank];
+        }
+
+        tt::tt_metal::SetRuntimeArgs(program, dm0_kernel_handle, core, runtime_args);
+        tt::tt_metal::SetRuntimeArgs(program, dm1_kernel_handle, core, runtime_args);
+        tt::tt_metal::SetRuntimeArgs(program, compute_kernel_handle, core, runtime_args);
+
+        dram_bank++;
+    }
+
+    return cached_program_t{
+        std::move(program),
+        MoEGateMMSharedVariables{
+            .cb_handles_sharded = cb_handles_sharded,
+            .kernel_handles = {dm0_kernel_handle, dm1_kernel_handle, compute_kernel_handle},
+            .worker_cores = dram_bank2core_coords}};
+}
+
+void MoEGateMMProgramFactory::override_runtime_arguments(
+    cached_program_t& cached_program,
+    const operation_attributes_t&,
+    const tensor_args_t& tensor_args,
+    tensor_return_value_t&) {
+    auto& program = cached_program.program;
+    auto& shared_variables = cached_program.shared_variables;
+
+    // Update sharded circular buffer addresses
+    tt::tt_metal::UpdateDynamicCircularBufferAddress(
+        program, shared_variables.cb_handles_sharded["cb_s2c_in"], *tensor_args.input_tensor.buffer());
+    tt::tt_metal::UpdateDynamicCircularBufferAddress(
+        program, shared_variables.cb_handles_sharded["cb_s2c_out"], *tensor_args.output_tensor.buffer());
+
+    // Update runtime args for all kernels with new tensor addresses
+    // Runtime args layout: [2] = input_tensor address, [3] = w_tensor address, [4] = output_tensor address
+    for (const auto& core : shared_variables.worker_cores) {
+        for (const auto& kernel_handle : shared_variables.kernel_handles) {
+            auto& runtime_args = tt::tt_metal::GetRuntimeArgs(program, kernel_handle, core);
+            runtime_args[3] = tensor_args.w_tensor.buffer()->address();
+        }
+    }
+}
+
+}  // namespace ttnn::operations::experimental::deepseek::moe::moe_gate_mm::program

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek/moe/moe_gate_mm/device/moe_gate_mm_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek/moe/moe_gate_mm/device/moe_gate_mm_program_factory.hpp
@@ -1,0 +1,39 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "moe_gate_mm_device_operation_types.hpp"
+#include "ttnn/device_operation.hpp"
+
+namespace ttnn::operations::experimental::deepseek::moe::moe_gate_mm::program {
+
+struct MoEGateMMSharedVariables {
+    // CB handles for sharded circular buffers
+    std::map<std::string, tt::tt_metal::CBHandle> cb_handles_sharded;
+
+    // Kernel handles
+    std::vector<tt::tt_metal::KernelHandle> kernel_handles;
+
+    // Cores active
+    std::vector<CoreCoord> worker_cores;
+};
+
+struct MoEGateMMProgramFactory {
+    using shared_variables_t = MoEGateMMSharedVariables;
+    using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
+
+    static cached_program_t create(
+        const operation_attributes_t& operation_attributes,
+        const tensor_args_t& tensor_args,
+        tensor_return_value_t& tensor_return_value);
+
+    static void override_runtime_arguments(
+        cached_program_t& cached_program,
+        const operation_attributes_t& operation_attributes,
+        const tensor_args_t& tensor_args,
+        tensor_return_value_t& tensor_return_value);
+};
+
+}  // namespace ttnn::operations::experimental::deepseek::moe::moe_gate_mm::program

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek/moe/moe_gate_mm/moe_gate_mm.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek/moe/moe_gate_mm/moe_gate_mm.hpp
@@ -1,0 +1,7 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "device/moe_gate_mm_device_operation.hpp"

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek/moe/moe_gate_mm/moe_gate_mm_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek/moe/moe_gate_mm/moe_gate_mm_nanobind.cpp
@@ -1,0 +1,42 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "moe_gate_mm_nanobind.hpp"
+
+#include "ttnn-nanobind/decorators.hpp"
+#include "moe_gate_mm.hpp"
+
+namespace ttnn::operations::experimental::deepseek::moe::moe_gate_mm::detail {
+
+void bind_moe_gate_mm(nb::module_& mod) {
+    bind_registered_operation(
+        mod,
+        ttnn::experimental::deepseek::moe::moe_gate_mm,
+        R"doc(
+        Experimental, high-performance MoE Gate MM operation for DeepSeek.
+
+        Args:
+            input_tensor: Input tensor (sharded)
+            w_tensor: Weight tensor
+            output_tensor: Output tensor (sharded)
+            layer_id: The layer for which the MoE Gate MM operation is being performed
+            column_id: The column in the 16x8 grid in which this MoE gate is being performed
+        )doc",
+        ttnn::nanobind_arguments_t{
+            nb::arg("input_tensor"),
+            nb::kw_only(),
+            nb::arg("w_tensor"),
+            nb::arg("output_tensor"),
+            nb::arg("layer_id"),
+            nb::arg("column_id"),
+        });
+}
+
+}  // namespace ttnn::operations::experimental::deepseek::moe::moe_gate_mm::detail
+
+namespace ttnn::operations::experimental::deepseek::moe::detail {
+
+void bind_moe_gate_mm(::nanobind::module_& mod) { moe_gate_mm::detail::bind_moe_gate_mm(mod); }
+
+}  // namespace ttnn::operations::experimental::deepseek::moe::detail

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek/moe/moe_gate_mm/moe_gate_mm_nanobind.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek/moe/moe_gate_mm/moe_gate_mm_nanobind.hpp
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ttnn-nanobind/nanobind_fwd.hpp"
+
+namespace ttnn::operations::experimental::deepseek::moe::moe_gate_mm::detail {
+namespace nb = nanobind;
+void bind_moe_gate_mm(nb::module_& mod);
+
+}  // namespace ttnn::operations::experimental::deepseek::moe::moe_gate_mm::detail
+
+namespace ttnn::operations::experimental::deepseek::moe::detail {
+void bind_moe_gate_mm(::nanobind::module_& mod);
+}  // namespace ttnn::operations::experimental::deepseek::moe::detail

--- a/ttnn/cpp/ttnn/operations/experimental/experimental_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/experimental_nanobind.cpp
@@ -57,6 +57,7 @@
 #include "ttnn/operations/experimental/minimal_matmul/minimal_matmul_nanobind.hpp"
 #include "ttnn/operations/experimental/isin/isin_nanobind.hpp"
 #include "ttnn/operations/experimental/minimal_matmul/minimal_matmul_split_nanobind.hpp"
+#include "ttnn/operations/experimental/deepseek/moe/moe_gate_mm/moe_gate_mm_nanobind.hpp"
 
 namespace ttnn::operations::experimental {
 
@@ -133,6 +134,7 @@ void py_module(nb::module_& mod) {
     minimal_matmul::detail::bind_minimal_matmul_split(mod);
 
     isin::detail::bind_isin_operation(mod);
+    deepseek::moe::detail::bind_moe_gate_mm(mod);
 }
 
 }  // namespace ttnn::operations::experimental


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/36590

## Overview

`moe_gate_mm` is a fused TTNN operation for DeepSeek's Mixture-of-Experts (MoE) gate. It projects each token with 7168 hidden dimension on to a 256 dimension space. Further, it applies sigmoid, and selects the top-8 activated experts per token—all in one kernel. For typical dimensions (M=32, K=7168, N=256), it achieves ~17 µs for matmul+sigmoid, or ~26 µs when including post-processing (top-8 selection, sparse multicast metadata for the dispatch op).

##### Input and Output
- bfloat16 input in L1 (M×K)
- DRAM sharded weight in bfloat16 (K×N)
- bias in bfloat16 (N)  
**Outputs:**
- Bfloat16 outputs (M×N)
- top8 indices for each expert
---

## Functionality
The following table describes the sequence of steps performed by the kernel.

| Step | Reference (PyTorch) | Fused Kernel |
|------|--------------------|--------------|
| 1 | `scores = x @ W` | `matmul_block` (partial on each core) |
| 2 | `scores = sigmoid(scores)` | `sigmoid` |
| 3 | `scores = scores + bias` | `add_bias` |
| 4 | Top-2 sum per group | `sum_top2_tile` |
| 5 | Top-4 groups | `top4_tile` |
| 6 | Top-8 experts | `top8_tile` + `top8_merge` |

### Performance

| Component | Time |
|-----------|------|
| Gate Matmul | 15.0 µs |
| Sigmoid | 1.5 µs |
| Indices + metadata | 9.0 µs |
| **Total** | ~26 µs |
---

## Core mapping

Wormhole has 12 DRAM banks. Since the matmul is DRAM bound, we pick 12 Tensix cores that are next to the DRAM banks. These cores are arranged such that transactions on NoC1 from any core to its neighboring core do not intersect. The weight matrix (K×N) is split as follows:

**8 cores (RECV):** 2/3 of K tiles (152 tiles), 1 N tile each.  
**4 cores (SEND):** 1/3 of K tiles (72 tiles), 2 N tiles each.

For K=7168, N=256: Kt=224, Nt=8. SEND cores compute partials for their 2 N tiles and send them to two RECV neighbors via NOC; RECV cores reduce and complete the matmul.

```
                    WEIGHT SPLIT (K × N)

     N tiles:  0    1    2    3    4    5    6    7
              ┌────┬────┬────┬────┬────┬────┬────┬────┐
    K tiles   │    │    │    │    │    │    │    │    │
    0–151     │ C1 │ C2 │ C4 │ C5 │ C7 │ C8 │ C10│ C11│  8 RECV cores
    (2/3)     │    │    │    │    │    │    │    │    │  (1 N tile each)
              ├────┼────┼────┼────┼────┼────┼────┼────┤
    K tiles   │   C0    │    C3   │    C6   │   C9    │  4 SEND cores
    152–223   │   0,1   │   2,3   │   4,5   │   6,7   │  (2 N tiles each)
    (1/3)     └────┴────┴────┴────┴────┴────┴────┴────┘
```

### Movement of Partials

```
         Selected Tensix cores

    ┌───┐   ┌───┐   ┌───┐   ┌───┐
    │ 0 │   │ 1 │   │ 2 │   │ 3 │   ...
    │SND│   │RCV│   │RCV│   │SND│
    └─┬─┘   └───┘   └───┘   └─┬─┘
      │      ▲        ▲       │
      │      │        │       │
      └────────────────       └─────... 
```

---

## 4. Kernels

- **DM0 (RISCV_1, NOC_0):** Fast DRAM→L1 weight fetching, using transaction IDs to parallelize
- **DM1 (RISCV_0, NOC_1):** Partial reduction, multicast, gather, output write  
- **Compute:** Matmul, sigmoid, bias, top-2, top-4, top-8, merge



### Checklist

- [x] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=nsorabaTT/moe_gate_mm)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:nsorabaTT/moe_gate_mm)
- [x] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=nsorabaTT/moe_gate_mm)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:nsorabaTT/moe_gate_mm)
- [x] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nsorabaTT/moe_gate_mm)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nsorabaTT/moe_gate_mm)
- [x] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nsorabaTT/moe_gate_mm)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nsorabaTT/moe_gate_mm)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nsorabaTT/moe_gate_mm)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nsorabaTT/moe_gate_mm)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nsorabaTT/moe_gate_mm)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nsorabaTT/moe_gate_mm)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
