### PR TITLE
Move decode warmup from vLLM to metal side

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -295,7 +295,7 @@ tests/ttnn/distributed/ @tenstorrent/metalium-developers-ttnn-core @tenstorrent/
 /**/functional_*/ @uaydonat @esmalTT @tenstorrent/codeowner-bypass
 models/common @yieldthought @mtairum @uaydonat @gwangTT @tenstorrent/codeowner-bypass
 models/common/sampling/ @sraizada-tt @djordje-tt @rdraskicTT @tchedaTT @tenstorrent/codeowner-bypass
-models/common/warmup/ @nostojicTT @skhorasganiTT @sraizada-tt @djordje-tt @rdraskicTT @tchedaTT
+models/common/warmup/ @nostojicTT @skhorasganiTT @sraizada-tt @djordje-tt @rdraskicTT @tchedaTT @tenstorrent/codeowner-bypass
 models/datasets/llm_dataset_utils.py @skhorasganiTT @uaydonat @tenstorrent/codeowner-bypass
 models/demos @uaydonat @yieldthought @cglagovichTT @tenstorrent/codeowner-bypass
 models/demos/deepseek_v3 @uaydonat @yieldthought @kpaigwar @pprajapatiTT @esmalTT @johanna-rock-tt @tenstorrent/codeowner-bypass

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -295,6 +295,7 @@ tests/ttnn/distributed/ @tenstorrent/metalium-developers-ttnn-core @tenstorrent/
 /**/functional_*/ @uaydonat @esmalTT @tenstorrent/codeowner-bypass
 models/common @yieldthought @mtairum @uaydonat @gwangTT @tenstorrent/codeowner-bypass
 models/common/sampling/ @sraizada-tt @djordje-tt @rdraskicTT @tchedaTT @tenstorrent/codeowner-bypass
+models/common/warmup/ @nostojicTT @skhorasganiTT @sraizada-tt @djordje-tt @rdraskicTT @tchedaTT
 models/datasets/llm_dataset_utils.py @skhorasganiTT @uaydonat @tenstorrent/codeowner-bypass
 models/demos @uaydonat @yieldthought @cglagovichTT @tenstorrent/codeowner-bypass
 models/demos/deepseek_v3 @uaydonat @yieldthought @kpaigwar @pprajapatiTT @esmalTT @johanna-rock-tt @tenstorrent/codeowner-bypass

--- a/.github/time_budget.yaml
+++ b/.github/time_budget.yaml
@@ -107,4 +107,4 @@ models:
     wh_galaxy: 280
   demo:
     wh_llmbox_perf: 1090
-    wh_galaxy: 270
+    wh_galaxy: 287

--- a/.github/workflows/vllm-nightly-tests-impl.yaml
+++ b/.github/workflows/vllm-nightly-tests-impl.yaml
@@ -343,7 +343,7 @@ jobs:
             {
               "name": "[WH-GLX][v1] Llama-8B DP=4",
               "model": "meta-llama/Llama-3.1-8B-Instruct",
-              "server-timeout": 15,
+              "server-timeout": 20,
               "benchmark-timeout": 5,
               "runner-label": "topology-6u",
               "arch": "arch-wormhole_b0",

--- a/models/common/demos/llama31_8B_demo.py
+++ b/models/common/demos/llama31_8B_demo.py
@@ -652,7 +652,7 @@ def test_mlp1d_llama_demo(
             out_tok[0] = token_acc.collect_predicted_tokens(out_tok[0].item())
 
         # Decode forward
-        logits, _ = generator.decode_forward_text(
+        logits, _ = generator.decode_forward(
             out_tok,
             current_pos,
             enable_trace=not measure_accuracy,  # Disable trace for accuracy (teacher forcing)

--- a/models/common/sampling/__init__.py
+++ b/models/common/sampling/__init__.py
@@ -5,6 +5,7 @@
 from .tt_sampling import TTSampling
 from .tt_penalties import TTPenalties, apply_penalties
 from .generator import SamplingGenerator, format_sampling_params
+from .sampling_params import SamplingParams
 
 __all__ = [
     "TTSampling",
@@ -12,4 +13,5 @@ __all__ = [
     "TTPenalties",
     "apply_penalties",
     "SamplingGenerator",
+    "SamplingParams",
 ]

--- a/models/common/sampling/sampling_params.py
+++ b/models/common/sampling/sampling_params.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/models/common/sampling/sampling_params.py
+++ b/models/common/sampling/sampling_params.py
@@ -10,7 +10,7 @@ from dataclasses import dataclass
 class SamplingParams:
     """
     Used in Generator decode forward functions for greedy decoding / sampling on device.
-    The same data class exists in vLLM at vllm/worker/tt_model_runner.py.
+    The same data class exists in vLLM at vllm/v1/worker/tt_model_runner.py.
     """
 
     temperature: float | list[float]

--- a/models/common/sampling/sampling_params.py
+++ b/models/common/sampling/sampling_params.py
@@ -1,0 +1,23 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class SamplingParams:
+    """
+    Used in Generator decode forward functions for greedy decoding / sampling on device.
+    The same data class exists in vLLM at vllm/worker/tt_model_runner.py.
+    """
+
+    temperature: float | list[float]
+    top_k: int | list[int]
+    top_p: float | list[float]
+    presence_penalty: float | list[float] = 0.0
+    frequency_penalty: float | list[float] = 0.0
+    repetition_penalty: float | list[float] = 1.0
+    seed: int | list[int] | None = None
+    enable_log_probs: bool | list[bool] = False

--- a/models/common/warmup/__init__.py
+++ b/models/common/warmup/__init__.py
@@ -1,0 +1,7 @@
+# SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+from .decode_warmup import DecodeWarmupMixin
+
+__all__ = ["DecodeWarmupMixin"]

--- a/models/common/warmup/__init__.py
+++ b/models/common/warmup/__init__.py
@@ -1,7 +1,7 @@
-# SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 
 # SPDX-License-Identifier: Apache-2.0
 
-from .decode_warmup import DecodeWarmupMixin
+from .warmup_utils import WarmupForwardMixin
 
-__all__ = ["DecodeWarmupMixin"]
+__all__ = ["WarmupForwardMixin"]

--- a/models/common/warmup/decode_warmup.py
+++ b/models/common/warmup/decode_warmup.py
@@ -1,0 +1,93 @@
+# SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+from itertools import product
+
+import torch
+from loguru import logger
+
+from models.tt_transformers.tt.common import SamplingParams
+
+
+class DecodeWarmupMixin:
+    """
+    Mixin class that provides decode warmup functionality for generator classes.
+
+    This class should be inherited by any generator class that needs to warm up
+    the decode forward pass. It requires the following to be defined in the
+    inheriting class:
+    - self.decode_forward_text(): method to perform decode forward pass
+    """
+
+    def _create_sampling_params(self, sample_on_device_mode, non_greedy_decoding_on_device, max_batch_size):
+        if not sample_on_device_mode:
+            return [None]
+
+        sampling_configs = []
+
+        if non_greedy_decoding_on_device:
+            for penalties, log_probs in product([True, False], repeat=2):
+                presence_penalty = [1.2] * max_batch_size if penalties else None
+                frequency_penalty = [1.2] * max_batch_size if penalties else None
+                repetition_penalty = [1.5] * max_batch_size if penalties else None
+                enable_log_probs = [log_probs] * max_batch_size
+
+                sampling_configs.append(
+                    SamplingParams(
+                        temperature=[1.0] * max_batch_size,
+                        top_k=[10] * max_batch_size,
+                        top_p=[0.9] * max_batch_size,
+                        presence_penalty=presence_penalty,
+                        frequency_penalty=frequency_penalty,
+                        repetition_penalty=repetition_penalty,
+                        enable_log_probs=enable_log_probs,
+                    )
+                )
+
+        sampling_configs.append(SamplingParams(temperature=0.0, top_k=1, top_p=1.0))
+
+        sampling_configs.append(None)
+
+        return sampling_configs
+
+    def _create_decode_warmup_inputs(self, max_batch_size, num_gpu_blocks):
+        tokens = torch.zeros(max_batch_size, 1, dtype=torch.int32)
+        start_pos = torch.zeros(max_batch_size, dtype=torch.int32)
+        page_table = torch.zeros(max_batch_size, num_gpu_blocks, dtype=torch.int32)
+        return tokens, start_pos, page_table
+
+    def warmup_model_decode(
+        self,
+        kv_cache,
+        enable_trace,
+        max_batch_size,
+        num_gpu_blocks,
+        sample_on_device_mode=None,
+        non_greedy_decoding_on_device=False,
+        sampling_params=None,
+    ):
+        sampling_params = self._create_sampling_params(
+            sample_on_device_mode, non_greedy_decoding_on_device, max_batch_size
+        )
+
+        tokens, start_pos, page_table = self._create_decode_warmup_inputs(max_batch_size, num_gpu_blocks)
+
+        logger.info("Starting decode warmup")
+        logger.info(f"Tokens shape: {tokens.shape}")
+        logger.info(f"Start pos shape: {start_pos.shape}")
+        logger.info(f"Page table shape: {page_table.shape}")
+
+        for param in sampling_params:
+            logger.info(f"Warming up decode for sampling params: {param}")
+            self.decode_forward_text(
+                tokens=tokens,
+                start_pos=start_pos,
+                page_table=page_table,
+                kv_cache=kv_cache,
+                enable_trace=enable_trace,
+                read_from_device=True,
+                sampling_params=param,
+            )
+
+        logger.info("Decode warmup completed")

--- a/models/common/warmup/decode_warmup.py
+++ b/models/common/warmup/decode_warmup.py
@@ -98,7 +98,7 @@ class DecodeWarmupMixin:
 
         for param in sampling_params:
             logger.info(f"Warming up decode for sampling params: {param}")
-            self.decode_forward_text(
+            self.decode_forward(
                 tokens=tokens,
                 start_pos=start_pos,
                 page_table=page_table,

--- a/models/common/warmup/decode_warmup.py
+++ b/models/common/warmup/decode_warmup.py
@@ -65,7 +65,6 @@ class DecodeWarmupMixin:
         num_gpu_blocks,
         sample_on_device_mode=None,
         non_greedy_decoding_on_device=False,
-        sampling_params=None,
     ):
         sampling_params = self._create_sampling_params(
             sample_on_device_mode, non_greedy_decoding_on_device, max_batch_size

--- a/models/common/warmup/decode_warmup.py
+++ b/models/common/warmup/decode_warmup.py
@@ -7,7 +7,7 @@ from itertools import product
 import torch
 from loguru import logger
 
-from models.tt_transformers.tt.common import SamplingParams
+from models.common.sampling.sampling_params import SamplingParams
 
 
 class DecodeWarmupMixin:

--- a/models/common/warmup/warmup_utils.py
+++ b/models/common/warmup/warmup_utils.py
@@ -72,10 +72,10 @@ class WarmupForwardMixin:
 
         return sampling_configs
 
-    def _create_decode_warmup_inputs(self, max_batch_size, num_gpu_blocks):
+    def _create_decode_warmup_inputs(self, max_batch_size, num_blocks):
         tokens = torch.zeros(max_batch_size, 1, dtype=torch.int32)
         start_pos = torch.zeros(max_batch_size, dtype=torch.int32)
-        page_table = torch.zeros(max_batch_size, num_gpu_blocks, dtype=torch.int32)
+        page_table = torch.zeros(max_batch_size, num_blocks, dtype=torch.int32)
         return tokens, start_pos, page_table
 
     def warmup_model_decode(
@@ -83,7 +83,7 @@ class WarmupForwardMixin:
         kv_cache,
         enable_trace,
         max_batch_size,
-        num_gpu_blocks,
+        num_blocks,
         can_sample_on_device,
         non_greedy_decoding_on_device,
     ):
@@ -94,7 +94,7 @@ class WarmupForwardMixin:
             can_sample_on_device, non_greedy_decoding_on_device, max_batch_size, mode="decode"
         )
 
-        tokens, start_pos, page_table = self._create_decode_warmup_inputs(max_batch_size, num_gpu_blocks)
+        tokens, start_pos, page_table = self._create_decode_warmup_inputs(max_batch_size, num_blocks)
 
         logger.info("Starting decode warmup")
         logger.info(f"Tokens shape: {tokens.shape}")

--- a/models/common/warmup/warmup_utils.py
+++ b/models/common/warmup/warmup_utils.py
@@ -103,7 +103,7 @@ class WarmupForwardMixin:
 
         for param in sampling_params:
             logger.info(f"Warming up decode for sampling params: {param}")
-            self.decode_forward_text(
+            self.decode_forward(
                 tokens=tokens,
                 start_pos=start_pos,
                 page_table=page_table,

--- a/models/common/warmup/warmup_utils.py
+++ b/models/common/warmup/warmup_utils.py
@@ -19,7 +19,7 @@ class WarmupForwardMixin:
     This class should be inherited by any generator class that needs to warm up
     the decode forward pass. It requires the following to be defined in the
     inheriting class:
-    - self.decode_forward(): method to perform decode forward pass
+    - self.decode_forward_text(): method to perform decode forward pass
     """
 
     def _create_sampling_params(self, can_sample_on_device, non_greedy_decoding_on_device, max_batch_size, mode):

--- a/models/common/warmup/warmup_utils.py
+++ b/models/common/warmup/warmup_utils.py
@@ -103,7 +103,7 @@ class WarmupForwardMixin:
 
         for param in sampling_params:
             logger.info(f"Warming up decode for sampling params: {param}")
-            self.decode_forward(
+            self.decode_forward_text(
                 tokens=tokens,
                 start_pos=start_pos,
                 page_table=page_table,

--- a/models/common/warmup/warmup_utils.py
+++ b/models/common/warmup/warmup_utils.py
@@ -19,7 +19,7 @@ class WarmupForwardMixin:
     This class should be inherited by any generator class that needs to warm up
     the decode forward pass. It requires the following to be defined in the
     inheriting class:
-    - self.decode_forward_text(): method to perform decode forward pass
+    - self.decode_forward(): method to perform decode forward pass
     """
 
     def _create_sampling_params(self, can_sample_on_device, non_greedy_decoding_on_device, max_batch_size, mode):
@@ -103,7 +103,7 @@ class WarmupForwardMixin:
 
         for param in sampling_params:
             logger.info(f"Warming up decode for sampling params: {param}")
-            self.decode_forward_text(
+            self.decode_forward(
                 tokens=tokens,
                 start_pos=start_pos,
                 page_table=page_table,

--- a/models/demos/deepseek_v3/tt/generator.py
+++ b/models/demos/deepseek_v3/tt/generator.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Iterable, List, Tuple
 
@@ -12,8 +13,6 @@ from tracy import signpost
 from transformers import AutoConfig
 
 import ttnn
-from models.common.sampling.sampling_params import SamplingParams
-from models.common.warmup import WarmupForwardMixin
 from models.demos.deepseek_v3.tt.ccl import CCL
 from models.demos.deepseek_v3.tt.mla.mla2d import MLA2D
 from models.demos.deepseek_v3.tt.model.row_batched_model import RowBatchedModel
@@ -26,6 +25,13 @@ from models.demos.deepseek_v3.utils.weight_config import get_weight_config
 from models.perf.benchmarking_utils import BenchmarkProfiler
 
 MAX_SEQ_LEN = 2048
+
+@dataclass(frozen=True)
+class SamplingParams:
+    temperature: float = 0.0
+    top_k: int = 0
+    top_p: float = 0.0
+
 
 def _strip_model_prefix(state_dict: dict[str, torch.Tensor]) -> dict[str, torch.Tensor]:
     """Return a copy of the HF state_dict with leading 'model.' stripped.
@@ -42,7 +48,7 @@ def _strip_model_prefix(state_dict: dict[str, torch.Tensor]) -> dict[str, torch.
     return out
 
 
-class DeepseekGenerator(WarmupForwardMixin):
+class DeepseekGenerator:
     """
     Simple generator that wires RowBatchedModel + LMHead for decode-only inference.
 
@@ -958,24 +964,22 @@ class DeepseekGenerator(WarmupForwardMixin):
     def decode_forward(
         self,
         tokens: torch.Tensor,
-        start_pos: torch.Tensor,
+        positions: torch.Tensor,
         batch_size_per_row: int,
         gen_idx: int = 0,
         profiler: BenchmarkProfiler | None = None,
         enable_trace: bool = False,
-        page_table: torch.Tensor | None = None,
-        read_from_device: bool = False,
-        sampling_params: SamplingParams | None = None,
+        page_tables: torch.Tensor | None = None,
     ) -> torch.Tensor:
         # vLLM does not pass enable_trace param while initializing the model.
         # vLLM sets it in decode/prefill calls only, so we need to set it here too.
         self.enable_trace = enable_trace
         if not enable_trace:
-            return self._decode_step(tokens, start_pos, batch_size_per_row, page_table).squeeze(0).squeeze(0)
+            return self._decode_step(tokens, positions, batch_size_per_row, page_tables).squeeze(0).squeeze(0)
         else:
             # Capture trace and return trace output
             if self._trace_id is None:
-                self._capture_decode_trace(tokens, start_pos, batch_size_per_row, page_table)
+                self._capture_decode_trace(tokens, positions, batch_size_per_row, page_tables)
                 # First call: return the captured run's output
                 assert self._trace_output is not None
                 logits = ttnn.to_torch(
@@ -1011,7 +1015,7 @@ class DeepseekGenerator(WarmupForwardMixin):
             ttnn.copy_host_to_device_tensor(host_tokens, self._trace_tokens)
 
             host_positions = ttnn.from_torch(
-                start_pos,
+                positions,
                 device=None,
                 mesh_mapper=ttnn.ShardTensorToMesh(self.mesh_device, dim=0),
                 dtype=ttnn.int32,
@@ -1019,11 +1023,11 @@ class DeepseekGenerator(WarmupForwardMixin):
 
             ttnn.copy_host_to_device_tensor(host_positions, self._trace_positions)
 
-            host_rot_idxs = self.rope_setup.get_rot_idxs(start_pos, on_host=True)
+            host_rot_idxs = self.rope_setup.get_rot_idxs(positions, on_host=True)
             ttnn.copy_host_to_device_tensor(host_rot_idxs, self._trace_rot_idxs)
 
-            if page_table is not None:
-                page_tables_to_use = self._convert_vllm_page_table_for_batch(page_table, device=None)
+            if page_tables is not None:
+                page_tables_to_use = self._convert_vllm_page_table_for_batch(page_tables, device=None)
                 for i, page_table in enumerate(page_tables_to_use):
                     ttnn.copy_host_to_device_tensor(page_table, self._trace_page_tables_to_use[i])
 

--- a/models/demos/deepseek_v3/tt/generator.py
+++ b/models/demos/deepseek_v3/tt/generator.py
@@ -713,7 +713,7 @@ class DeepseekGenerator(WarmupForwardMixin):
                 for gen_idx in range(decode_steps):
                     logger.info(f"Decoding step {gen_idx} for {num_of_prompts} user(s)...")
                     profiler.start(f"decode_time_{gen_idx}")
-                    logits = self.decode_forward_text(
+                    logits = self.decode_forward(
                         tokens=next_tokens,
                         positions=positions,
                         batch_size_per_row=self.batch_size_per_row,
@@ -955,7 +955,7 @@ class DeepseekGenerator(WarmupForwardMixin):
         logger.info("Decode trace capture complete.")
         self._trace_id = trace_id
 
-    def decode_forward_text(
+    def decode_forward(
         self,
         tokens: torch.Tensor,
         start_pos: torch.Tensor,

--- a/models/demos/deepseek_v3/tt/generator.py
+++ b/models/demos/deepseek_v3/tt/generator.py
@@ -3,7 +3,6 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
 from pathlib import Path
 from typing import Iterable, List, Tuple
 
@@ -13,6 +12,8 @@ from tracy import signpost
 from transformers import AutoConfig
 
 import ttnn
+from models.common.sampling.sampling_params import SamplingParams
+from models.common.warmup import WarmupForwardMixin
 from models.demos.deepseek_v3.tt.ccl import CCL
 from models.demos.deepseek_v3.tt.mla.mla2d import MLA2D
 from models.demos.deepseek_v3.tt.model.row_batched_model import RowBatchedModel
@@ -25,13 +26,6 @@ from models.demos.deepseek_v3.utils.weight_config import get_weight_config
 from models.perf.benchmarking_utils import BenchmarkProfiler
 
 MAX_SEQ_LEN = 2048
-
-@dataclass(frozen=True)
-class SamplingParams:
-    temperature: float = 0.0
-    top_k: int = 0
-    top_p: float = 0.0
-
 
 def _strip_model_prefix(state_dict: dict[str, torch.Tensor]) -> dict[str, torch.Tensor]:
     """Return a copy of the HF state_dict with leading 'model.' stripped.
@@ -48,7 +42,7 @@ def _strip_model_prefix(state_dict: dict[str, torch.Tensor]) -> dict[str, torch.
     return out
 
 
-class DeepseekGenerator:
+class DeepseekGenerator(WarmupForwardMixin):
     """
     Simple generator that wires RowBatchedModel + LMHead for decode-only inference.
 

--- a/models/demos/deepseek_v3/tt/generator.py
+++ b/models/demos/deepseek_v3/tt/generator.py
@@ -1101,6 +1101,17 @@ class DeepseekGenerator(DecodeWarmupMixin):
                 f"set_kv_cache: More kv_cache entries provided ({len(kv_cache_list)}) than decoder blocks ({cache_idx})"
             )
 
+    def warmup_model_decode(
+        self,
+        kv_cache,
+        enable_trace,
+        max_batch_size,
+        num_gpu_blocks,
+        sample_on_device_mode=None,
+        non_greedy_decoding_on_device=False,
+    ):
+        logger.warning("decode_forward_text is not implemented for DeepseekGenerator")
+
     def _convert_vllm_page_table_for_user(
         self, page_table: torch.Tensor, user_id: int, local_user_id: int | None = None
     ) -> tuple[ttnn.Tensor, ...]:

--- a/models/demos/deepseek_v3/tt/generator.py
+++ b/models/demos/deepseek_v3/tt/generator.py
@@ -27,6 +27,7 @@ from models.perf.benchmarking_utils import BenchmarkProfiler
 
 MAX_SEQ_LEN = 2048
 
+
 def _strip_model_prefix(state_dict: dict[str, torch.Tensor]) -> dict[str, torch.Tensor]:
     """Return a copy of the HF state_dict with leading 'model.' stripped.
 

--- a/models/demos/deepseek_v3/tt/generator.py
+++ b/models/demos/deepseek_v3/tt/generator.py
@@ -1048,7 +1048,9 @@ class DeepseekGenerator(DecodeWarmupMixin):
                 ttnn.ReadDeviceProfiler(self.mesh_device)
             return logits.squeeze(0).squeeze(0)
 
-    def warmup_model_prefill(self, kv_cache, enable_trace, sampling_params) -> None:
+    def warmup_model_prefill(
+        self, kv_cache, enable_trace, sample_on_device_mode, non_greedy_decoding_on_device, max_batch_size
+    ) -> None:
         logger.warning("Warmup model prefill not implemented for DeepseekGenerator")
         logger.warning("Tracing in prefill mode is not supported for DeepseekGenerator")
 

--- a/models/demos/deepseek_v3/tt/generator.py
+++ b/models/demos/deepseek_v3/tt/generator.py
@@ -715,7 +715,7 @@ class DeepseekGenerator(WarmupForwardMixin):
                     profiler.start(f"decode_time_{gen_idx}")
                     logits = self.decode_forward(
                         tokens=next_tokens,
-                        positions=positions,
+                        start_pos=positions,
                         batch_size_per_row=self.batch_size_per_row,
                         profiler=profiler,
                         gen_idx=gen_idx,

--- a/models/demos/deepseek_v3/tt/generator.py
+++ b/models/demos/deepseek_v3/tt/generator.py
@@ -1102,17 +1102,6 @@ class DeepseekGenerator(WarmupForwardMixin):
                 f"set_kv_cache: More kv_cache entries provided ({len(kv_cache_list)}) than decoder blocks ({cache_idx})"
             )
 
-    def warmup_model_decode(
-        self,
-        kv_cache,
-        enable_trace,
-        max_batch_size,
-        num_gpu_blocks,
-        can_sample_on_device,
-        non_greedy_decoding_on_device,
-    ):
-        logger.warning("decode_forward_text is not implemented for DeepseekGenerator")
-
     def _convert_vllm_page_table_for_user(
         self, page_table: torch.Tensor, user_id: int, local_user_id: int | None = None
     ) -> tuple[ttnn.Tensor, ...]:

--- a/models/demos/deepseek_v3/tt/generator.py
+++ b/models/demos/deepseek_v3/tt/generator.py
@@ -13,7 +13,7 @@ from transformers import AutoConfig
 
 import ttnn
 from models.common.sampling.sampling_params import SamplingParams
-from models.common.warmup import DecodeWarmupMixin
+from models.common.warmup import WarmupForwardMixin
 from models.demos.deepseek_v3.tt.ccl import CCL
 from models.demos.deepseek_v3.tt.mla.mla2d import MLA2D
 from models.demos.deepseek_v3.tt.model.row_batched_model import RowBatchedModel
@@ -42,7 +42,7 @@ def _strip_model_prefix(state_dict: dict[str, torch.Tensor]) -> dict[str, torch.
     return out
 
 
-class DeepseekGenerator(DecodeWarmupMixin):
+class DeepseekGenerator(WarmupForwardMixin):
     """
     Simple generator that wires RowBatchedModel + LMHead for decode-only inference.
 
@@ -713,7 +713,7 @@ class DeepseekGenerator(DecodeWarmupMixin):
                 for gen_idx in range(decode_steps):
                     logger.info(f"Decoding step {gen_idx} for {num_of_prompts} user(s)...")
                     profiler.start(f"decode_time_{gen_idx}")
-                    logits = self.decode_forward(
+                    logits = self.decode_forward_text(
                         tokens=next_tokens,
                         positions=positions,
                         batch_size_per_row=self.batch_size_per_row,
@@ -955,25 +955,27 @@ class DeepseekGenerator(DecodeWarmupMixin):
         logger.info("Decode trace capture complete.")
         self._trace_id = trace_id
 
-    def decode_forward(
+    def decode_forward_text(
         self,
         tokens: torch.Tensor,
-        positions: torch.Tensor,
+        start_pos: torch.Tensor,
         batch_size_per_row: int,
         gen_idx: int = 0,
         profiler: BenchmarkProfiler | None = None,
         enable_trace: bool = False,
-        page_tables: torch.Tensor | None = None,
+        page_table: torch.Tensor | None = None,
+        read_from_device: bool = False,
+        sampling_params: SamplingParams | None = None,
     ) -> torch.Tensor:
         # vLLM does not pass enable_trace param while initializing the model.
         # vLLM sets it in decode/prefill calls only, so we need to set it here too.
         self.enable_trace = enable_trace
         if not enable_trace:
-            return self._decode_step(tokens, positions, batch_size_per_row, page_tables).squeeze(0).squeeze(0)
+            return self._decode_step(tokens, start_pos, batch_size_per_row, page_table).squeeze(0).squeeze(0)
         else:
             # Capture trace and return trace output
             if self._trace_id is None:
-                self._capture_decode_trace(tokens, positions, batch_size_per_row, page_tables)
+                self._capture_decode_trace(tokens, start_pos, batch_size_per_row, page_table)
                 # First call: return the captured run's output
                 assert self._trace_output is not None
                 logits = ttnn.to_torch(
@@ -1009,7 +1011,7 @@ class DeepseekGenerator(DecodeWarmupMixin):
             ttnn.copy_host_to_device_tensor(host_tokens, self._trace_tokens)
 
             host_positions = ttnn.from_torch(
-                positions,
+                start_pos,
                 device=None,
                 mesh_mapper=ttnn.ShardTensorToMesh(self.mesh_device, dim=0),
                 dtype=ttnn.int32,
@@ -1017,11 +1019,11 @@ class DeepseekGenerator(DecodeWarmupMixin):
 
             ttnn.copy_host_to_device_tensor(host_positions, self._trace_positions)
 
-            host_rot_idxs = self.rope_setup.get_rot_idxs(positions, on_host=True)
+            host_rot_idxs = self.rope_setup.get_rot_idxs(start_pos, on_host=True)
             ttnn.copy_host_to_device_tensor(host_rot_idxs, self._trace_rot_idxs)
 
-            if page_tables is not None:
-                page_tables_to_use = self._convert_vllm_page_table_for_batch(page_tables, device=None)
+            if page_table is not None:
+                page_tables_to_use = self._convert_vllm_page_table_for_batch(page_table, device=None)
                 for i, page_table in enumerate(page_tables_to_use):
                     ttnn.copy_host_to_device_tensor(page_table, self._trace_page_tables_to_use[i])
 
@@ -1048,9 +1050,7 @@ class DeepseekGenerator(DecodeWarmupMixin):
                 ttnn.ReadDeviceProfiler(self.mesh_device)
             return logits.squeeze(0).squeeze(0)
 
-    def warmup_model_prefill(
-        self, kv_cache, enable_trace, sample_on_device_mode, non_greedy_decoding_on_device, max_batch_size
-    ) -> None:
+    def warmup_model_prefill(self, kv_cache, enable_trace, can_sample_on_device, non_greedy_decoding_on_device) -> None:
         logger.warning("Warmup model prefill not implemented for DeepseekGenerator")
         logger.warning("Tracing in prefill mode is not supported for DeepseekGenerator")
 
@@ -1107,8 +1107,8 @@ class DeepseekGenerator(DecodeWarmupMixin):
         enable_trace,
         max_batch_size,
         num_gpu_blocks,
-        sample_on_device_mode=None,
-        non_greedy_decoding_on_device=False,
+        can_sample_on_device,
+        non_greedy_decoding_on_device,
     ):
         logger.warning("decode_forward_text is not implemented for DeepseekGenerator")
 

--- a/models/demos/deepseek_v3/tt/generator.py
+++ b/models/demos/deepseek_v3/tt/generator.py
@@ -3,7 +3,6 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
 from pathlib import Path
 from typing import Iterable, List, Tuple
 
@@ -13,6 +12,7 @@ from tracy import signpost
 from transformers import AutoConfig
 
 import ttnn
+from models.common.warmup import DecodeWarmupMixin
 from models.demos.deepseek_v3.tt.ccl import CCL
 from models.demos.deepseek_v3.tt.mla.mla2d import MLA2D
 from models.demos.deepseek_v3.tt.model.row_batched_model import RowBatchedModel
@@ -23,16 +23,9 @@ from models.demos.deepseek_v3.utils.debug_utils import dump_ttnn_meminfo
 from models.demos.deepseek_v3.utils.run_config import create_run_config
 from models.demos.deepseek_v3.utils.weight_config import get_weight_config
 from models.perf.benchmarking_utils import BenchmarkProfiler
+from models.tt_transformers.tt.common import SamplingParams
 
 MAX_SEQ_LEN = 2048
-
-
-@dataclass(frozen=True)
-class SamplingParams:
-    temperature: float = 0.0
-    top_k: int = 0
-    top_p: float = 0.0
-
 
 def _strip_model_prefix(state_dict: dict[str, torch.Tensor]) -> dict[str, torch.Tensor]:
     """Return a copy of the HF state_dict with leading 'model.' stripped.
@@ -49,7 +42,7 @@ def _strip_model_prefix(state_dict: dict[str, torch.Tensor]) -> dict[str, torch.
     return out
 
 
-class DeepseekGenerator:
+class DeepseekGenerator(DecodeWarmupMixin):
     """
     Simple generator that wires RowBatchedModel + LMHead for decode-only inference.
 

--- a/models/demos/deepseek_v3/tt/generator.py
+++ b/models/demos/deepseek_v3/tt/generator.py
@@ -958,22 +958,25 @@ class DeepseekGenerator(WarmupForwardMixin):
     def decode_forward(
         self,
         tokens: torch.Tensor,
-        positions: torch.Tensor,
-        batch_size_per_row: int,
+        start_pos: torch.Tensor,
+        batch_size_per_row: int = USERS_PER_ROW,
         gen_idx: int = 0,
         profiler: BenchmarkProfiler | None = None,
         enable_trace: bool = False,
-        page_tables: torch.Tensor | None = None,
+        page_table: torch.Tensor | None = None,
+        kv_cache: None = None,
+        read_from_device: bool = None,
+        sampling_params: SamplingParams = None,
     ) -> torch.Tensor:
         # vLLM does not pass enable_trace param while initializing the model.
         # vLLM sets it in decode/prefill calls only, so we need to set it here too.
         self.enable_trace = enable_trace
         if not enable_trace:
-            return self._decode_step(tokens, positions, batch_size_per_row, page_tables).squeeze(0).squeeze(0)
+            return self._decode_step(tokens, start_pos, batch_size_per_row, page_table).squeeze(0).squeeze(0)
         else:
             # Capture trace and return trace output
             if self._trace_id is None:
-                self._capture_decode_trace(tokens, positions, batch_size_per_row, page_tables)
+                self._capture_decode_trace(tokens, start_pos, batch_size_per_row, page_table)
                 # First call: return the captured run's output
                 assert self._trace_output is not None
                 logits = ttnn.to_torch(
@@ -1009,7 +1012,7 @@ class DeepseekGenerator(WarmupForwardMixin):
             ttnn.copy_host_to_device_tensor(host_tokens, self._trace_tokens)
 
             host_positions = ttnn.from_torch(
-                positions,
+                start_pos,
                 device=None,
                 mesh_mapper=ttnn.ShardTensorToMesh(self.mesh_device, dim=0),
                 dtype=ttnn.int32,
@@ -1017,11 +1020,11 @@ class DeepseekGenerator(WarmupForwardMixin):
 
             ttnn.copy_host_to_device_tensor(host_positions, self._trace_positions)
 
-            host_rot_idxs = self.rope_setup.get_rot_idxs(positions, on_host=True)
+            host_rot_idxs = self.rope_setup.get_rot_idxs(start_pos, on_host=True)
             ttnn.copy_host_to_device_tensor(host_rot_idxs, self._trace_rot_idxs)
 
-            if page_tables is not None:
-                page_tables_to_use = self._convert_vllm_page_table_for_batch(page_tables, device=None)
+            if page_table is not None:
+                page_tables_to_use = self._convert_vllm_page_table_for_batch(page_table, device=None)
                 for i, page_table in enumerate(page_tables_to_use):
                     ttnn.copy_host_to_device_tensor(page_table, self._trace_page_tables_to_use[i])
 

--- a/models/demos/deepseek_v3/tt/generator.py
+++ b/models/demos/deepseek_v3/tt/generator.py
@@ -12,6 +12,7 @@ from tracy import signpost
 from transformers import AutoConfig
 
 import ttnn
+from models.common.sampling.sampling_params import SamplingParams
 from models.common.warmup import DecodeWarmupMixin
 from models.demos.deepseek_v3.tt.ccl import CCL
 from models.demos.deepseek_v3.tt.mla.mla2d import MLA2D
@@ -23,7 +24,6 @@ from models.demos.deepseek_v3.utils.debug_utils import dump_ttnn_meminfo
 from models.demos.deepseek_v3.utils.run_config import create_run_config
 from models.demos.deepseek_v3.utils.weight_config import get_weight_config
 from models.perf.benchmarking_utils import BenchmarkProfiler
-from models.tt_transformers.tt.common import SamplingParams
 
 MAX_SEQ_LEN = 2048
 

--- a/models/demos/deepseek_v3/tt/generator_vllm.py
+++ b/models/demos/deepseek_v3/tt/generator_vllm.py
@@ -145,10 +145,10 @@ class DeepseekV3ForCausalLM(DeepseekGenerator):
             super()
             .decode_forward(
                 tokens=tokens_step,
-                positions=kwargs["start_pos"],
+                start_pos=kwargs["start_pos"],
                 batch_size_per_row=USERS_PER_ROW,
                 enable_trace=enable_trace,
-                page_tables=page_tables,
+                page_table=page_tables,
             )
             .unsqueeze(1)
         )  # [B, V] -> [B, 1, V]

--- a/models/demos/deepseek_v3/tt/generator_vllm.py
+++ b/models/demos/deepseek_v3/tt/generator_vllm.py
@@ -143,7 +143,7 @@ class DeepseekV3ForCausalLM(DeepseekGenerator):
 
         return_value = (
             super()
-            .decode_forward_text(
+            .decode_forward(
                 tokens=tokens_step,
                 start_pos=kwargs["start_pos"],
                 batch_size_per_row=USERS_PER_ROW,

--- a/models/demos/deepseek_v3/tt/generator_vllm.py
+++ b/models/demos/deepseek_v3/tt/generator_vllm.py
@@ -145,10 +145,10 @@ class DeepseekV3ForCausalLM(DeepseekGenerator):
             super()
             .decode_forward(
                 tokens=tokens_step,
-                start_pos=kwargs["start_pos"],
+                positions=kwargs["start_pos"],
                 batch_size_per_row=USERS_PER_ROW,
                 enable_trace=enable_trace,
-                page_table=page_tables,
+                page_tables=page_tables,
             )
             .unsqueeze(1)
         )  # [B, V] -> [B, 1, V]

--- a/models/demos/deepseek_v3/tt/generator_vllm.py
+++ b/models/demos/deepseek_v3/tt/generator_vllm.py
@@ -143,12 +143,12 @@ class DeepseekV3ForCausalLM(DeepseekGenerator):
 
         return_value = (
             super()
-            .decode_forward(
+            .decode_forward_text(
                 tokens=tokens_step,
-                positions=kwargs["start_pos"],
+                start_pos=kwargs["start_pos"],
                 batch_size_per_row=USERS_PER_ROW,
                 enable_trace=enable_trace,
-                page_tables=page_tables,
+                page_table=page_tables,
             )
             .unsqueeze(1)
         )  # [B, V] -> [B, 1, V]

--- a/models/demos/gpt_oss/demo/text_demo.py
+++ b/models/demos/gpt_oss/demo/text_demo.py
@@ -954,7 +954,7 @@ def test_gpt_oss_demo(
                 profiler.start(f"inference_decode_time_{iteration}", iteration=batch_idx)
 
             # Decode forward (matching tt_transformers call)
-            logits, _ = generator.decode_forward_text(
+            logits, _ = generator.decode_forward(
                 out_tok,
                 current_pos,
                 enable_trace=enable_decode_trace,

--- a/models/demos/gpt_oss/tests/accuracy/test_model.py
+++ b/models/demos/gpt_oss/tests/accuracy/test_model.py
@@ -105,7 +105,7 @@ def run_accuracy(
     for i in range(1, len(reference_tokens)):
         # Use decode for subsequent tokens with teacher forcing (use reference tokens)
         with torch.no_grad():
-            logits, _ = generator.decode_forward_text(
+            logits, _ = generator.decode_forward(
                 out_tok,  # out_tok (current token)
                 current_pos,  # current_pos
                 enable_trace=False,  # enable_trace

--- a/models/demos/llama3_70b_galaxy/demo/text_demo.py
+++ b/models/demos/llama3_70b_galaxy/demo/text_demo.py
@@ -983,7 +983,7 @@ def test_demo_text(
             try:
                 # Save logits only for PCC check when tracing is disabled
                 tt_out_logits_saved = torch.zeros(vocab_size) if (pcc_check and not is_enable_trace) else None
-                tt_out_tok, read_event = generator.decode_forward_text(
+                tt_out_tok, read_event = generator.decode_forward(
                     out_tok,
                     current_pos,
                     enable_trace=is_enable_trace,

--- a/models/demos/llama3_70b_galaxy/demo/text_qwen_demo.py
+++ b/models/demos/llama3_70b_galaxy/demo/text_qwen_demo.py
@@ -794,7 +794,7 @@ def test_qwen_demo_text(
             try:
                 # Save logits only for PCC check when tracing is disabled
                 tt_out_logits_saved = torch.zeros(vocab_size) if (pcc_check and not is_enable_trace) else None
-                tt_out_tok, read_event = generator.decode_forward_text(
+                tt_out_tok, read_event = generator.decode_forward(
                     out_tok,
                     current_pos,
                     enable_trace=is_enable_trace,

--- a/models/demos/llama3_70b_galaxy/demo/text_qwen_demo.py
+++ b/models/demos/llama3_70b_galaxy/demo/text_qwen_demo.py
@@ -794,7 +794,7 @@ def test_qwen_demo_text(
             try:
                 # Save logits only for PCC check when tracing is disabled
                 tt_out_logits_saved = torch.zeros(vocab_size) if (pcc_check and not is_enable_trace) else None
-                tt_out_tok, read_event = generator.decode_forward(
+                tt_out_tok, read_event = generator.decode_forward_text(
                     out_tok,
                     current_pos,
                     enable_trace=is_enable_trace,

--- a/models/demos/llama3_70b_galaxy/tt/generator.py
+++ b/models/demos/llama3_70b_galaxy/tt/generator.py
@@ -856,7 +856,9 @@ class Generator(DecodeWarmupMixin):
             padded_page_table[user_id, :] = page_table[0, :]
         return padded_page_table
 
-    def warmup_model_prefill(self, kv_cache, enable_trace, sampling_params) -> None:
+    def warmup_model_prefill(
+        self, kv_cache, enable_trace, sample_on_device_mode, non_greedy_decoding_on_device, max_batch_size
+    ) -> None:
         # page_table gets padded properly in prefill_forward_text
         # be sure to pad correctly for non traced sequences in future warmup calls
         page_table = torch.zeros(1, 1, dtype=torch.int32)

--- a/models/demos/llama3_70b_galaxy/tt/generator.py
+++ b/models/demos/llama3_70b_galaxy/tt/generator.py
@@ -24,7 +24,7 @@ from models.common.llama_models import (
 )
 
 from models.common.sampling.generator import format_sampling_params
-from models.tt_transformers.tt.common import SamplingParams
+from models.common.sampling.sampling_params import SamplingParams
 from models.common.warmup import DecodeWarmupMixin
 
 

--- a/models/demos/llama3_70b_galaxy/tt/generator.py
+++ b/models/demos/llama3_70b_galaxy/tt/generator.py
@@ -24,7 +24,8 @@ from models.common.llama_models import (
 )
 
 from models.common.sampling.generator import format_sampling_params
-from models.tt_transformers.tt.generator import SamplingParams
+from models.tt_transformers.tt.common import SamplingParams
+from models.common.warmup import DecodeWarmupMixin
 
 
 def get_padded_prefill_len(seq_len: int) -> int:
@@ -41,7 +42,7 @@ def get_padded_prefill_len(seq_len: int) -> int:
         return 2 ** (seq_len - 1).bit_length()
 
 
-class Generator:
+class Generator(DecodeWarmupMixin):
     def __init__(self, model, model_args, mesh_device, tokenizer=None, formatter=None):
         """
         Creating a LlamaVision wrapper requires only a mesh_device and model_args.

--- a/models/demos/llama3_70b_galaxy/tt/generator.py
+++ b/models/demos/llama3_70b_galaxy/tt/generator.py
@@ -502,7 +502,7 @@ class Generator(WarmupForwardMixin):
 
         return tt_out_trace
 
-    def decode_forward_text(
+    def decode_forward(
         self,
         tokens,
         start_pos,

--- a/models/demos/llama3_70b_galaxy/tt/generator.py
+++ b/models/demos/llama3_70b_galaxy/tt/generator.py
@@ -860,20 +860,16 @@ class Generator(WarmupForwardMixin):
         # page_table gets padded properly in prefill_forward_text
         # be sure to pad correctly for non traced sequences in future warmup calls
         page_table = torch.zeros(1, 1, dtype=torch.int32)
-        sampling_params = self._create_sampling_params(
-            can_sample_on_device, non_greedy_decoding_on_device, None, mode="prefill"
+        self.warmup_prefill_traces(
+            tokens=None,
+            page_table=page_table,
+            kv_cache=kv_cache,
+            prompt_lens=None,
+            enable_trace=enable_trace,
+            sampling_params=None,
+            empty_slots=None,
+            tt_out_logits_all_users=None,
         )
-        for sampling_param in sampling_params:
-            self.warmup_prefill_traces(
-                tokens=None,
-                page_table=page_table,
-                kv_cache=kv_cache,
-                prompt_lens=None,
-                enable_trace=enable_trace,
-                sampling_params=sampling_param,
-                empty_slots=None,
-                tt_out_logits_all_users=None,
-            )
 
     ## Destructor (used to delete ttnn trace if exists)
 

--- a/models/demos/llama3_70b_galaxy/tt/generator.py
+++ b/models/demos/llama3_70b_galaxy/tt/generator.py
@@ -502,7 +502,7 @@ class Generator(WarmupForwardMixin):
 
         return tt_out_trace
 
-    def decode_forward(
+    def decode_forward_text(
         self,
         tokens,
         start_pos,

--- a/models/demos/llama3_70b_galaxy/tt/generator_vllm.py
+++ b/models/demos/llama3_70b_galaxy/tt/generator_vllm.py
@@ -207,7 +207,7 @@ class LlamaForCausalLM(Generator):
         return super().prefill_forward_text(*args, **kwargs)
 
     def decode_forward(self, *args, **kwargs):
-        return super().decode_forward_text(*args, **kwargs)
+        return super().decode_forward(*args, **kwargs)
 
     def allocate_kv_cache(self, *args, **kwargs):
         return allocate_vllm_kv_cache(*args, **kwargs, model=self.model, tt_cache_path=self.cache_path)
@@ -252,7 +252,7 @@ class QwenForCausalLM(Generator):
         return super().prefill_forward_text(*args, **kwargs)
 
     def decode_forward(self, *args, **kwargs):
-        return super().decode_forward_text(*args, **kwargs)
+        return super().decode_forward(*args, **kwargs)
 
     def allocate_kv_cache(self, *args, **kwargs):
         return allocate_vllm_kv_cache(*args, **kwargs, model=self.model, tt_cache_path=self.cache_path)

--- a/models/demos/llama3_70b_galaxy/tt/generator_vllm.py
+++ b/models/demos/llama3_70b_galaxy/tt/generator_vllm.py
@@ -207,7 +207,7 @@ class LlamaForCausalLM(Generator):
         return super().prefill_forward_text(*args, **kwargs)
 
     def decode_forward(self, *args, **kwargs):
-        return super().decode_forward(*args, **kwargs)
+        return super().decode_forward_text(*args, **kwargs)
 
     def allocate_kv_cache(self, *args, **kwargs):
         return allocate_vllm_kv_cache(*args, **kwargs, model=self.model, tt_cache_path=self.cache_path)
@@ -252,7 +252,7 @@ class QwenForCausalLM(Generator):
         return super().prefill_forward_text(*args, **kwargs)
 
     def decode_forward(self, *args, **kwargs):
-        return super().decode_forward(*args, **kwargs)
+        return super().decode_forward_text(*args, **kwargs)
 
     def allocate_kv_cache(self, *args, **kwargs):
         return allocate_vllm_kv_cache(*args, **kwargs, model=self.model, tt_cache_path=self.cache_path)

--- a/models/demos/multimodal/gemma3/demo/text_demo.py
+++ b/models/demos/multimodal/gemma3/demo/text_demo.py
@@ -951,7 +951,7 @@ def test_demo_text(
                 out_tok[0] = token_acc.collect_predicted_tokens(out_tok[0].item())
 
             # Run decode forward
-            logits, _ = generator.decode_forward_text(
+            logits, _ = generator.decode_forward(
                 out_tok,
                 current_pos,
                 enable_trace=enable_trace,

--- a/models/demos/multimodal/gemma3/demo/vision_demo.py
+++ b/models/demos/multimodal/gemma3/demo/vision_demo.py
@@ -435,7 +435,7 @@ def test_multimodal_demo_text(
                     position_id = prefill_lens + gen_idx
                     next_token_tensor = next_tokens.reshape(max_batch_size, 1)
 
-                    logits = generator.decode_forward(
+                    logits = generator.decode_forward_llama_vision(
                         position_id,
                         next_token_tensor,
                         prefill_batch_xattn_masks,

--- a/models/demos/multimodal/gemma3/demo/vision_demo.py
+++ b/models/demos/multimodal/gemma3/demo/vision_demo.py
@@ -446,6 +446,9 @@ def test_multimodal_demo_text(
                         enable_trace=enable_trace,
                     )
 
+                    if isinstance(logits, tuple):
+                        logits = logits[0]
+
                     next_tokens, next_texts = sampler(logits)
                     # Update next token
                     tokens[torch.arange(max_batch_size), position_id + 1] = next_tokens

--- a/models/demos/qwen25_vl/demo/demo.py
+++ b/models/demos/qwen25_vl/demo/demo.py
@@ -13,6 +13,7 @@ from transformers import AutoProcessor
 from transformers.models.qwen2_5_vl.modeling_qwen2_5_vl import Qwen2_5_VLForConditionalGeneration
 
 import ttnn
+from models.common.sampling.sampling_params import SamplingParams
 from models.demos.qwen25_vl.tt.common import (
     PagedAttentionConfig,
     merge_vision_tokens,
@@ -25,7 +26,6 @@ from models.demos.qwen25_vl.tt.model import DropInVisionTransformer, Transformer
 from models.demos.qwen25_vl.tt.model_config import VisionModelArgs
 from models.demos.utils.llm_demo_utils import create_benchmark_data
 from models.perf.benchmarking_utils import BenchmarkProfiler
-from models.tt_transformers.tt.generator import SamplingParams
 from models.tt_transformers.tt.model_config import DecodersPrecision, ModelArgs, parse_decoder_json
 
 

--- a/models/demos/qwen25_vl/demo/demo.py
+++ b/models/demos/qwen25_vl/demo/demo.py
@@ -520,7 +520,7 @@ def test_demo(
                 profiler.start(f"inference_decode_time_{iteration}", iteration=batch_idx)
 
             # Run decode forward
-            logits, _ = generator.decode_forward(
+            logits, _ = generator.decode_forward_text(
                 out_tok,
                 current_pos,
                 enable_trace=enable_trace,

--- a/models/demos/qwen25_vl/demo/demo.py
+++ b/models/demos/qwen25_vl/demo/demo.py
@@ -520,7 +520,7 @@ def test_demo(
                 profiler.start(f"inference_decode_time_{iteration}", iteration=batch_idx)
 
             # Run decode forward
-            logits, _ = generator.decode_forward_text(
+            logits, _ = generator.decode_forward(
                 out_tok,
                 current_pos,
                 enable_trace=enable_trace,

--- a/models/demos/qwen25_vl/tt/generator.py
+++ b/models/demos/qwen25_vl/tt/generator.py
@@ -216,7 +216,9 @@ class Generator:
     def process_decode_output_host(self, tt_out, is_tokens=False):
         return self._ttt_generator.process_decode_output_host(tt_out, is_tokens=is_tokens)
 
-    def warmup_model_prefill(self, kv_cache, enable_trace, sampling_params) -> None:
+    def warmup_model_prefill(
+        self, kv_cache, enable_trace, sample_on_device_mode, non_greedy_decoding_on_device, max_batch_size
+    ) -> None:
         logger.warning("Warmup model prefill not implemented for Qwen2_5_VL Generator")
         logger.warning("Tracing in prefill mode is not supported for Qwen2_5_VL")
 

--- a/models/demos/qwen25_vl/tt/generator.py
+++ b/models/demos/qwen25_vl/tt/generator.py
@@ -103,7 +103,7 @@ class Generator(WarmupForwardMixin):
         read_from_device=True,
         sampling_params=None,
     ):
-        return self._ttt_generator.decode_forward_text(
+        return self._ttt_generator.decode_forward(
             tokens=tokens,
             start_pos=start_pos,
             page_table=page_table,

--- a/models/demos/qwen25_vl/tt/generator.py
+++ b/models/demos/qwen25_vl/tt/generator.py
@@ -6,7 +6,7 @@ import torch
 from loguru import logger
 
 import ttnn
-from models.common.warmup.decode_warmup import DecodeWarmupMixin
+from models.common.warmup import DecodeWarmupMixin
 from models.demos.qwen25_vl.tt.common import get_block_size, get_max_prefill_chunk_size, num_blocks_in_seq
 from models.tt_transformers.tt.generator import Generator as TTTGenerator
 

--- a/models/demos/qwen25_vl/tt/generator.py
+++ b/models/demos/qwen25_vl/tt/generator.py
@@ -93,7 +93,7 @@ class Generator(WarmupForwardMixin):
         # convert to torch tensor
         self.model.rope_setup.rope_deltas = torch.tensor(rope_deltas_list)
 
-    def decode_forward(
+    def decode_forward_text(
         self,
         tokens,
         start_pos,

--- a/models/demos/qwen25_vl/tt/generator.py
+++ b/models/demos/qwen25_vl/tt/generator.py
@@ -6,12 +6,12 @@ import torch
 from loguru import logger
 
 import ttnn
-from models.common.warmup import DecodeWarmupMixin
+from models.common.warmup import WarmupForwardMixin
 from models.demos.qwen25_vl.tt.common import get_block_size, get_max_prefill_chunk_size, num_blocks_in_seq
 from models.tt_transformers.tt.generator import Generator as TTTGenerator
 
 
-class Generator(DecodeWarmupMixin):
+class Generator(WarmupForwardMixin):
     def __init__(self, model, model_args, mesh_device, processor=None, tokenizer=None):
         """
         Creating a Qwen2_5_Vision wrapper requires only a mesh_device and model_args.
@@ -209,24 +209,6 @@ class Generator(DecodeWarmupMixin):
 
             return logits
 
-    def warmup_model_decode(
-        self,
-        kv_cache,
-        enable_trace,
-        max_batch_size,
-        num_gpu_blocks,
-        sample_on_device_mode=None,
-        non_greedy_decoding_on_device=False,
-    ):
-        return super().warmup_model_decode(
-            kv_cache=kv_cache,
-            enable_trace=enable_trace,
-            max_batch_size=max_batch_size,
-            num_gpu_blocks=num_gpu_blocks,
-            sample_on_device_mode=sample_on_device_mode,
-            non_greedy_decoding_on_device=non_greedy_decoding_on_device,
-        )
-
     # [INFO] this is called by vLLM
     def read_decode_output(self, tt_out, async_read=False):
         return self._ttt_generator.read_decode_output(tt_out, async_read=async_read)
@@ -235,9 +217,7 @@ class Generator(DecodeWarmupMixin):
     def process_decode_output_host(self, tt_out, is_tokens=False):
         return self._ttt_generator.process_decode_output_host(tt_out, is_tokens=is_tokens)
 
-    def warmup_model_prefill(
-        self, kv_cache, enable_trace, sample_on_device_mode, non_greedy_decoding_on_device, max_batch_size
-    ) -> None:
+    def warmup_model_prefill(self, kv_cache, enable_trace, can_sample_on_device, non_greedy_decoding_on_device) -> None:
         logger.warning("Warmup model prefill not implemented for Qwen2_5_VL Generator")
         logger.warning("Tracing in prefill mode is not supported for Qwen2_5_VL")
 

--- a/models/demos/qwen25_vl/tt/generator.py
+++ b/models/demos/qwen25_vl/tt/generator.py
@@ -93,7 +93,7 @@ class Generator(WarmupForwardMixin):
         # convert to torch tensor
         self.model.rope_setup.rope_deltas = torch.tensor(rope_deltas_list)
 
-    def decode_forward_text(
+    def decode_forward(
         self,
         tokens,
         start_pos,

--- a/models/demos/qwen25_vl/tt/generator.py
+++ b/models/demos/qwen25_vl/tt/generator.py
@@ -218,7 +218,7 @@ class Generator(DecodeWarmupMixin):
         sample_on_device_mode=None,
         non_greedy_decoding_on_device=False,
     ):
-        return self._ttt_generator.warmup_model_decode(
+        return super().warmup_model_decode(
             kv_cache=kv_cache,
             enable_trace=enable_trace,
             max_batch_size=max_batch_size,

--- a/models/demos/qwen25_vl/tt/generator_vllm.py
+++ b/models/demos/qwen25_vl/tt/generator_vllm.py
@@ -306,4 +306,4 @@ class Qwen2_5_VLForConditionalGeneration(QwenVLGenerator, SupportsMultiModal):
         if rope_deltas_list is not None:
             super().update_rope_deltas(rope_deltas_list)
 
-        return super().decode_forward_text(*args, **kwargs)
+        return super().decode_forward(*args, **kwargs)

--- a/models/demos/qwen25_vl/tt/generator_vllm.py
+++ b/models/demos/qwen25_vl/tt/generator_vllm.py
@@ -306,4 +306,4 @@ class Qwen2_5_VLForConditionalGeneration(QwenVLGenerator, SupportsMultiModal):
         if rope_deltas_list is not None:
             super().update_rope_deltas(rope_deltas_list)
 
-        return super().decode_forward(*args, **kwargs)
+        return super().decode_forward_text(*args, **kwargs)

--- a/models/demos/qwen3_vl/demo/demo.py
+++ b/models/demos/qwen3_vl/demo/demo.py
@@ -531,7 +531,7 @@ def test_demo(
                 profiler.start(f"inference_decode_time_{iteration}", iteration=batch_idx)
 
             # Run decode forward
-            logits, log_probs = generator.decode_forward(
+            logits, log_probs = generator.decode_forward_text(
                 out_tok,
                 current_pos,
                 enable_trace=enable_trace,

--- a/models/demos/qwen3_vl/demo/demo.py
+++ b/models/demos/qwen3_vl/demo/demo.py
@@ -13,6 +13,7 @@ from transformers import AutoProcessor
 from transformers.models.qwen3_vl.modeling_qwen3_vl import Qwen3VLForConditionalGeneration
 
 import ttnn
+from models.common.sampling.sampling_params import SamplingParams
 from models.demos.qwen3_vl.tt.common import (
     PagedAttentionConfig,
     merge_vision_tokens,
@@ -25,7 +26,6 @@ from models.demos.qwen3_vl.tt.model import DropInVisionTransformer, Transformer
 from models.demos.qwen3_vl.tt.model_config import VisionModelArgs
 from models.demos.utils.llm_demo_utils import create_benchmark_data
 from models.perf.benchmarking_utils import BenchmarkProfiler
-from models.tt_transformers.tt.generator import SamplingParams
 from models.tt_transformers.tt.model_config import DecodersPrecision, ModelArgs, parse_decoder_json
 
 

--- a/models/demos/qwen3_vl/demo/demo.py
+++ b/models/demos/qwen3_vl/demo/demo.py
@@ -531,7 +531,7 @@ def test_demo(
                 profiler.start(f"inference_decode_time_{iteration}", iteration=batch_idx)
 
             # Run decode forward
-            logits, log_probs = generator.decode_forward_text(
+            logits, log_probs = generator.decode_forward(
                 out_tok,
                 current_pos,
                 enable_trace=enable_trace,

--- a/models/demos/qwen3_vl/tt/generator.py
+++ b/models/demos/qwen3_vl/tt/generator.py
@@ -243,6 +243,10 @@ class Generator:
 
             return logits
 
+    def warmup_model_prefill(self, kv_cache, enable_trace, sampling_params):
+        logger.warning("Warmup model prefill not implemented for Qwen3_VL Generator")
+        logger.warning("Tracing in prefill mode is not supported for Qwen3_VL")
+
     # [INFO] this is called by vLLM
     def read_decode_output(self, tt_out, async_read=False):
         return self._ttt_generator.read_decode_output(tt_out, async_read=async_read)

--- a/models/demos/qwen3_vl/tt/generator.py
+++ b/models/demos/qwen3_vl/tt/generator.py
@@ -104,7 +104,7 @@ class Generator(WarmupForwardMixin):
         # convert to torch tensor
         self.model.rope_setup.rope_deltas = torch.tensor(rope_deltas_list)
 
-    def decode_forward_text(
+    def decode_forward(
         self,
         tokens,
         start_pos,

--- a/models/demos/qwen3_vl/tt/generator.py
+++ b/models/demos/qwen3_vl/tt/generator.py
@@ -104,7 +104,7 @@ class Generator(WarmupForwardMixin):
         # convert to torch tensor
         self.model.rope_setup.rope_deltas = torch.tensor(rope_deltas_list)
 
-    def decode_forward(
+    def decode_forward_text(
         self,
         tokens,
         start_pos,

--- a/models/demos/qwen3_vl/tt/generator.py
+++ b/models/demos/qwen3_vl/tt/generator.py
@@ -243,7 +243,9 @@ class Generator:
 
             return logits
 
-    def warmup_model_prefill(self, kv_cache, enable_trace, sampling_params):
+    def warmup_model_prefill(
+        self, kv_cache, enable_trace, sample_on_device_mode, non_greedy_decoding_on_device, max_batch_size
+    ) -> None:
         logger.warning("Warmup model prefill not implemented for Qwen3_VL Generator")
         logger.warning("Tracing in prefill mode is not supported for Qwen3_VL")
 

--- a/models/demos/qwen3_vl/tt/generator.py
+++ b/models/demos/qwen3_vl/tt/generator.py
@@ -114,7 +114,7 @@ class Generator(WarmupForwardMixin):
         read_from_device=True,
         sampling_params=None,
     ):
-        return self._ttt_generator.decode_forward_text(
+        return self._ttt_generator.decode_forward(
             tokens=tokens,
             start_pos=start_pos,
             page_table=page_table,

--- a/models/demos/qwen3_vl/tt/generator.py
+++ b/models/demos/qwen3_vl/tt/generator.py
@@ -259,7 +259,7 @@ class Generator(DecodeWarmupMixin):
         sample_on_device_mode=None,
         non_greedy_decoding_on_device=False,
     ):
-        return self._ttt_generator.warmup_model_decode(
+        return super().warmup_model_decode(
             kv_cache=kv_cache,
             enable_trace=enable_trace,
             max_batch_size=max_batch_size,

--- a/models/demos/qwen3_vl/tt/generator.py
+++ b/models/demos/qwen3_vl/tt/generator.py
@@ -6,6 +6,7 @@ import torch
 from loguru import logger
 
 import ttnn
+from models.common.warmup.decode_warmup import DecodeWarmupMixin
 from models.demos.qwen3_vl.tt.common import get_block_size, get_max_prefill_chunk_size, num_blocks_in_seq
 from models.tt_transformers.tt.generator import Generator as TTTGenerator
 

--- a/models/demos/qwen3_vl/tt/generator.py
+++ b/models/demos/qwen3_vl/tt/generator.py
@@ -10,7 +10,7 @@ from models.demos.qwen3_vl.tt.common import get_block_size, get_max_prefill_chun
 from models.tt_transformers.tt.generator import Generator as TTTGenerator
 
 
-class Generator:
+class Generator(DecodeWarmupMixin):
     def __init__(self, model, model_args, mesh_device, processor=None, tokenizer=None):
         """
         Creating a Qwen2_5_Vision wrapper requires only a mesh_device and model_args.
@@ -248,6 +248,24 @@ class Generator:
     ) -> None:
         logger.warning("Warmup model prefill not implemented for Qwen3_VL Generator")
         logger.warning("Tracing in prefill mode is not supported for Qwen3_VL")
+
+    def warmup_model_decode(
+        self,
+        kv_cache,
+        enable_trace,
+        max_batch_size,
+        num_gpu_blocks,
+        sample_on_device_mode=None,
+        non_greedy_decoding_on_device=False,
+    ):
+        return self._ttt_generator.warmup_model_decode(
+            kv_cache=kv_cache,
+            enable_trace=enable_trace,
+            max_batch_size=max_batch_size,
+            num_gpu_blocks=num_gpu_blocks,
+            sample_on_device_mode=sample_on_device_mode,
+            non_greedy_decoding_on_device=non_greedy_decoding_on_device,
+        )
 
     # [INFO] this is called by vLLM
     def read_decode_output(self, tt_out, async_read=False):

--- a/models/demos/qwen3_vl/tt/generator_vllm.py
+++ b/models/demos/qwen3_vl/tt/generator_vllm.py
@@ -310,4 +310,4 @@ class Qwen3VLForConditionalGeneration(QwenVLGenerator, SupportsMultiModal):
         if rope_deltas_list is not None:
             super().update_rope_deltas(rope_deltas_list)
 
-        return super().decode_forward_text(*args, **kwargs)
+        return super().decode_forward(*args, **kwargs)

--- a/models/demos/qwen3_vl/tt/generator_vllm.py
+++ b/models/demos/qwen3_vl/tt/generator_vllm.py
@@ -310,4 +310,4 @@ class Qwen3VLForConditionalGeneration(QwenVLGenerator, SupportsMultiModal):
         if rope_deltas_list is not None:
             super().update_rope_deltas(rope_deltas_list)
 
-        return super().decode_forward(*args, **kwargs)
+        return super().decode_forward_text(*args, **kwargs)

--- a/models/experimental/gemma3_4b/tests/vision_tests/test_end2end.py
+++ b/models/experimental/gemma3_4b/tests/vision_tests/test_end2end.py
@@ -203,7 +203,7 @@ def generate(model, processed_inputs, model_args, page_table=None, paged_attenti
         logger.info(f"[Text] Decoding token {iteration}, current_pos: {current_pos.item()}")
 
         # Run decode (exactly like test_end2end.py)
-        logits = generator.decode_forward_text(
+        logits = generator.decode_forward(
             out_tok,
             current_pos,
             enable_trace=False,

--- a/models/experimental/mistral_24b/tests/pipeline_tests/test_end2end.py
+++ b/models/experimental/mistral_24b/tests/pipeline_tests/test_end2end.py
@@ -303,7 +303,7 @@ def run_generation_exactly_like_test_end2end(
     for iteration in range(generation_length):
         logger.info(f"[Text] Decoding token {iteration}, current_pos: {current_pos.item()}")
 
-        decode_output = generator.decode_forward_text(
+        decode_output = generator.decode_forward(
             out_tok,
             current_pos,
             enable_trace=False,

--- a/models/experimental/mistral_24b/tests/pipeline_tests/test_end2end.py
+++ b/models/experimental/mistral_24b/tests/pipeline_tests/test_end2end.py
@@ -311,7 +311,7 @@ def run_generation_exactly_like_test_end2end(
             kv_cache=tt_kv_cache,
         )
 
-        # decode_forward_text returns (logits, log_probs) tuple when read_from_device=True
+        # decode_forward returns (logits, log_probs) tuple when read_from_device=True
         if isinstance(decode_output, tuple):
             logits, _ = decode_output
         else:

--- a/models/experimental/openvla/tt/open_vla.py
+++ b/models/experimental/openvla/tt/open_vla.py
@@ -529,14 +529,14 @@ class OpenVLALanguageModel(GenerationMixin):
         out_tok = prefilled_token
         while user_decoding:
             # Run decode forward
-            decode_output = self.generator.decode_forward_text(
+            decode_output = self.generator.decode_forward(
                 out_tok,
                 current_pos,
                 page_table=self.page_table,
                 kv_cache=self.tt_kv_cache,
                 sampling_params=device_sampling_params,
             )
-            # decode_forward_text returns (logits, log_probs) tuple
+            # decode_forward returns (logits, log_probs) tuple
             logits = decode_output[0] if isinstance(decode_output, tuple) else decode_output
 
             # Get the next token
@@ -695,7 +695,7 @@ class OpenVLALanguageModel(GenerationMixin):
             # Prefill: model[0].forward(..., kv_cache=self.tt_kv_cache[0], ...)
             # Decode must read from the SAME KV cache object
             CHECKPOINTS.checkpoint("start_LLM_DECODE")
-            decode_output = self.generator.decode_forward_text(
+            decode_output = self.generator.decode_forward(
                 out_tok,
                 current_pos,
                 page_table=page_table_user,
@@ -703,7 +703,7 @@ class OpenVLALanguageModel(GenerationMixin):
                 sampling_params=None,
                 enable_trace=False,
             )
-            # decode_forward_text returns (logits, log_probs) tuple
+            # decode_forward returns (logits, log_probs) tuple
             logits = decode_output[0] if isinstance(decode_output, tuple) else decode_output
             CHECKPOINTS.checkpoint("end_LLM_DECODE")
 

--- a/models/tt_transformers/demo/simple_text_demo.py
+++ b/models/tt_transformers/demo/simple_text_demo.py
@@ -1126,7 +1126,7 @@ def test_demo_text(
                 out_tok[0] = token_acc.collect_predicted_tokens(out_tok[0].item())
 
             # Run decode forward
-            logits, log_probs = generator.decode_forward_text(
+            logits, log_probs = generator.decode_forward(
                 out_tok,
                 current_pos,
                 enable_trace=enable_trace,

--- a/models/tt_transformers/demo/simple_vision_demo.py
+++ b/models/tt_transformers/demo/simple_vision_demo.py
@@ -435,7 +435,7 @@ def test_multimodal_demo_text(
                     position_id = prefill_lens + gen_idx
                     next_token_tensor = next_tokens.reshape(max_batch_size, 1)
 
-                    logits = generator.decode_forward(
+                    logits = generator.decode_forward_llama_vision(
                         position_id,
                         next_token_tensor,
                         prefill_batch_xattn_masks,

--- a/models/tt_transformers/demo/simple_vision_demo.py
+++ b/models/tt_transformers/demo/simple_vision_demo.py
@@ -435,7 +435,7 @@ def test_multimodal_demo_text(
                     position_id = prefill_lens + gen_idx
                     next_token_tensor = next_tokens.reshape(max_batch_size, 1)
 
-                    logits, logprobs = generator.decode_forward_llama_vision(
+                    logits = generator.decode_forward_llama_vision(
                         position_id,
                         next_token_tensor,
                         prefill_batch_xattn_masks,
@@ -445,6 +445,9 @@ def test_multimodal_demo_text(
                         xattn_caches,
                         enable_trace=enable_trace,
                     )
+
+                    if isinstance(logits, tuple):
+                        logits = logits[0]
 
                     next_tokens, next_texts = sampler(logits)
                     # Update next token

--- a/models/tt_transformers/demo/simple_vision_demo.py
+++ b/models/tt_transformers/demo/simple_vision_demo.py
@@ -446,6 +446,9 @@ def test_multimodal_demo_text(
                         enable_trace=enable_trace,
                     )
 
+                    if isinstance(logits, tuple):
+                        logits = logits[0]
+
                     next_tokens, next_texts = sampler(logits)
                     # Update next token
                     tokens[torch.arange(max_batch_size), position_id + 1] = next_tokens

--- a/models/tt_transformers/demo/simple_vision_demo.py
+++ b/models/tt_transformers/demo/simple_vision_demo.py
@@ -435,7 +435,7 @@ def test_multimodal_demo_text(
                     position_id = prefill_lens + gen_idx
                     next_token_tensor = next_tokens.reshape(max_batch_size, 1)
 
-                    logits = generator.decode_forward_llama_vision(
+                    logits, logprobs = generator.decode_forward_llama_vision(
                         position_id,
                         next_token_tensor,
                         prefill_batch_xattn_masks,
@@ -445,9 +445,6 @@ def test_multimodal_demo_text(
                         xattn_caches,
                         enable_trace=enable_trace,
                     )
-
-                    if isinstance(logits, tuple):
-                        logits = logits[0]
 
                     next_tokens, next_texts = sampler(logits)
                     # Update next token

--- a/models/tt_transformers/tt/common.py
+++ b/models/tt_transformers/tt/common.py
@@ -5,7 +5,6 @@
 import math
 import os
 import re
-from dataclasses import dataclass
 from enum import Enum
 from types import SimpleNamespace
 from typing import List, Optional, Union
@@ -52,8 +51,6 @@ InterleavedTextMedia = Union[
 class Mode(Enum):
     DECODE = "decode"
     PREFILL = "prefill"
-
-
 
 class HostEmbedding(torch.nn.Module):
     def __init__(self, model_args):

--- a/models/tt_transformers/tt/common.py
+++ b/models/tt_transformers/tt/common.py
@@ -5,6 +5,7 @@
 import math
 import os
 import re
+from dataclasses import dataclass
 from enum import Enum
 from types import SimpleNamespace
 from typing import List, Optional, Union
@@ -15,6 +16,7 @@ from PIL import Image as PIL_Image
 from pydantic import AliasChoices, BaseModel, Field
 
 import ttnn
+
 
 
 class URL(BaseModel):
@@ -50,6 +52,7 @@ InterleavedTextMedia = Union[
 class Mode(Enum):
     DECODE = "decode"
     PREFILL = "prefill"
+
 
 
 class HostEmbedding(torch.nn.Module):

--- a/models/tt_transformers/tt/common.py
+++ b/models/tt_transformers/tt/common.py
@@ -18,6 +18,7 @@ import ttnn
 
 
 
+
 class URL(BaseModel):
     uri: str
 
@@ -48,9 +49,11 @@ InterleavedTextMedia = Union[
 ]
 
 
+
 class Mode(Enum):
     DECODE = "decode"
     PREFILL = "prefill"
+
 
 class HostEmbedding(torch.nn.Module):
     def __init__(self, model_args):

--- a/models/tt_transformers/tt/common.py
+++ b/models/tt_transformers/tt/common.py
@@ -17,8 +17,6 @@ from pydantic import AliasChoices, BaseModel, Field
 import ttnn
 
 
-
-
 class URL(BaseModel):
     uri: str
 
@@ -47,7 +45,6 @@ InterleavedTextMedia = Union[
     ImageMedia,
     List[Union[str, ImageMedia]],
 ]
-
 
 
 class Mode(Enum):

--- a/models/tt_transformers/tt/generator.py
+++ b/models/tt_transformers/tt/generator.py
@@ -1805,7 +1805,7 @@ class Generator(WarmupForwardMixin):
             position_id = torch.tensor([prefill_len + gen_idx])
             next_token_tensor = next_token.reshape(1, 1)  # B, S
 
-            logits = self.decode_forward_llama_vision(
+            logits, logprobs = self.decode_forward_llama_vision(
                 position_id,
                 next_token_tensor,
                 prefill_output_xattn_masks,

--- a/models/tt_transformers/tt/generator.py
+++ b/models/tt_transformers/tt/generator.py
@@ -20,6 +20,7 @@ from models.common.llama_models import (
     sample_top_p,
 )
 from models.common.sampling.generator import format_sampling_params
+from models.common.sampling.sampling_params import SamplingParams
 from models.common.warmup import DecodeWarmupMixin
 from models.tt_transformers.tt.common import (
     Mode,

--- a/models/tt_transformers/tt/generator.py
+++ b/models/tt_transformers/tt/generator.py
@@ -21,7 +21,7 @@ from models.common.llama_models import (
 )
 from models.common.sampling.generator import format_sampling_params
 from models.common.sampling.sampling_params import SamplingParams
-from models.common.warmup import DecodeWarmupMixin
+from models.common.warmup import WarmupForwardMixin
 from models.tt_transformers.tt.common import (
     Mode,
     copy_host_to_device,
@@ -90,7 +90,7 @@ def max_prefill_chunk_size_cutoff(sequence_length, max_prefill_chunk_size):
     return sequence_length > max_prefill_chunk_size
 
 
-class Generator(DecodeWarmupMixin):
+class Generator(WarmupForwardMixin):
     def __init__(self, model, model_args, mesh_device, processor=None, tokenizer=None):
         """
         Creating a LlamaVision wrapper requires only a mesh_device and model_args.

--- a/models/tt_transformers/tt/generator.py
+++ b/models/tt_transformers/tt/generator.py
@@ -1805,7 +1805,7 @@ class Generator(WarmupForwardMixin):
             position_id = torch.tensor([prefill_len + gen_idx])
             next_token_tensor = next_token.reshape(1, 1)  # B, S
 
-            logits = self.decode_forward(
+            logits = self.decode_forward_llama_vision(
                 position_id,
                 next_token_tensor,
                 prefill_output_xattn_masks,
@@ -1815,6 +1815,10 @@ class Generator(WarmupForwardMixin):
                 [xattn_caches],
                 enable_trace=False,
             )
+
+            if isinstance(logits, tuple):
+                logits = logits[0]
+
             next_token, text = sample(logits)
             yield TokenResult(
                 token=next_token[0].item(),

--- a/models/tt_transformers/tt/generator.py
+++ b/models/tt_transformers/tt/generator.py
@@ -153,6 +153,7 @@ class Generator(DecodeWarmupMixin):
             sample_on_device_mode,
             non_greedy_decoding_on_device,
             max_batch_size,
+            mode="prefill",
         )
 
         sequence_lengths_to_warmup = self.model_args[0].get_warmup_prefill_supported_seq_lens()

--- a/models/tt_transformers/tt/generator.py
+++ b/models/tt_transformers/tt/generator.py
@@ -125,15 +125,6 @@ class Generator(DecodeWarmupMixin):
         "supports_prefix_caching": True,
     }
 
-    @property
-    def supports_non_greedy_decoding_on_device(self):
-        if not hasattr(self, "model") or not self.model:
-            return False
-
-        model_instance = self.model[0] if isinstance(self.model, list) else self.model
-        sampling_module = getattr(model_instance, "sampling", None)
-        return sampling_module is not None
-
     def _chunk_sampling_param(self, values):
         if isinstance(values, List):
             return split_list(values, self.data_parallel)
@@ -197,6 +188,9 @@ class Generator(DecodeWarmupMixin):
                     )
                     break
                 for param in sampling_params:
+                    logger.info(
+                        f"Warming up prefill for sequence length: {supported_length} with sampling params: {param}"
+                    )
                     self.prefill_forward_text(
                         warmup_tokens,
                         page_table_warmup,

--- a/models/tt_transformers/tt/generator.py
+++ b/models/tt_transformers/tt/generator.py
@@ -1228,18 +1228,12 @@ class Generator(WarmupForwardMixin):
         else:
             tt_logits = self._decode_forward_no_trace(**decode_kwargs)
 
-        output = None
         if read_from_device:
             to_host = self.read_decode_output(tt_logits)
-            output = self.process_decode_output_host(to_host)
+            # skip log_probs
+            return self.process_decode_output_host(to_host)[0]
         else:
-            output = tt_logits
-
-        # skip returning log-probs
-        if isinstance(output, tuple):
-            return output[0]
-        else:
-            return output
+            return tt_logits
 
     # Note: This function is called by vLLM
     def read_decode_output(self, tt_out, async_read=False):

--- a/models/tt_transformers/tt/generator.py
+++ b/models/tt_transformers/tt/generator.py
@@ -137,22 +137,15 @@ class Generator(DecodeWarmupMixin):
             if sampling_module is not None:
                 sampling_module.enable_internal_trace = enabled
 
-    def warmup_model_prefill(
-        self,
-        kv_cache,
-        enable_trace,
-        sample_on_device_mode=None,
-        non_greedy_decoding_on_device=False,
-        max_batch_size=1,
-    ):
+    def warmup_model_prefill(self, kv_cache, enable_trace, can_sample_on_device, non_greedy_decoding_on_device):
         if self.already_warmed_up_prefill:
             return
         self.already_warmed_up_prefill = True
 
         sampling_params = self._create_sampling_params(
-            sample_on_device_mode,
+            can_sample_on_device,
             non_greedy_decoding_on_device,
-            max_batch_size,
+            None,
             mode="prefill",
         )
 

--- a/models/tt_transformers/tt/generator.py
+++ b/models/tt_transformers/tt/generator.py
@@ -319,7 +319,7 @@ class Generator(WarmupForwardMixin):
 
         # we need this here becuase of tt-metal tests
         if warmup_prefill:
-            self.warmup_model_prefill(kv_cache, enable_trace)
+            self.warmup_model_prefill(kv_cache, enable_trace, False, False)
 
         batch_size, batch_seq_len = tokens.shape
         max_batch_size_per_model = self.model_args[0].max_batch_size

--- a/models/tt_transformers/tt/generator.py
+++ b/models/tt_transformers/tt/generator.py
@@ -319,7 +319,11 @@ class Generator(WarmupForwardMixin):
 
         # we need this here becuase of tt-metal tests
         if warmup_prefill:
-            self.warmup_model_prefill(kv_cache, enable_trace, False, False)
+            sampling_on_device_enabled = (
+                getattr(self.model[0], "_supports_on_device_sampling", False)
+                and getattr(self.model[0], "sampling", None) is not None
+            )
+            self.warmup_model_prefill(kv_cache, enable_trace, sampling_on_device_enabled, sampling_on_device_enabled)
 
         batch_size, batch_seq_len = tokens.shape
         max_batch_size_per_model = self.model_args[0].max_batch_size

--- a/models/tt_transformers/tt/generator.py
+++ b/models/tt_transformers/tt/generator.py
@@ -1230,8 +1230,7 @@ class Generator(WarmupForwardMixin):
 
         if read_from_device:
             to_host = self.read_decode_output(tt_logits)
-            # skip log_probs
-            return self.process_decode_output_host(to_host)[0]
+            return self.process_decode_output_host(to_host)
         else:
             return tt_logits
 

--- a/models/tt_transformers/tt/generator.py
+++ b/models/tt_transformers/tt/generator.py
@@ -1805,7 +1805,7 @@ class Generator(WarmupForwardMixin):
             position_id = torch.tensor([prefill_len + gen_idx])
             next_token_tensor = next_token.reshape(1, 1)  # B, S
 
-            logits, logprobs = self.decode_forward_llama_vision(
+            logits = self.decode_forward_llama_vision(
                 position_id,
                 next_token_tensor,
                 prefill_output_xattn_masks,

--- a/models/tt_transformers/tt/generator_vllm.py
+++ b/models/tt_transformers/tt/generator_vllm.py
@@ -355,6 +355,9 @@ class MllamaForConditionalGeneration(Generator, SupportsMultiModal, SupportsV0On
             cross_page_table=cross_page_table,
         )
 
+    def decode_forward(self, *args, **kwargs):
+        return super().decode_forward_llama_vision(*args, **kwargs)
+
     def allocate_kv_cache(self, *args, **kwargs):
         return allocate_vllm_kv_cache(*args, **kwargs, dp_model=self.model, tt_cache_path=self.cache_path)
 
@@ -414,7 +417,7 @@ class LlamaForCausalLM(Generator):
         return super().prefill_forward_text(*args, **kwargs)
 
     def decode_forward(self, *args, **kwargs):
-        return super().decode_forward_text(*args, **kwargs)
+        return super().decode_forward(*args, **kwargs)
 
     def allocate_kv_cache(self, *args, **kwargs):
         return allocate_vllm_kv_cache(*args, **kwargs, dp_model=self.model, tt_cache_path=self.cache_path)
@@ -462,7 +465,7 @@ class QwenForCausalLM(Generator):
         return super().prefill_forward_text(*args, **kwargs)
 
     def decode_forward(self, *args, **kwargs):
-        return super().decode_forward_text(*args, **kwargs)
+        return super().decode_forward(*args, **kwargs)
 
     def allocate_kv_cache(self, *args, **kwargs):
         return allocate_vllm_kv_cache(*args, **kwargs, dp_model=self.model, tt_cache_path=self.cache_path)
@@ -510,7 +513,7 @@ class MistralForCausalLM(Generator):
         return super().prefill_forward_text(*args, **kwargs)
 
     def decode_forward(self, *args, **kwargs):
-        return super().decode_forward_text(*args, **kwargs)
+        return super().decode_forward(*args, **kwargs)
 
     def allocate_kv_cache(self, *args, **kwargs):
         return allocate_vllm_kv_cache(*args, **kwargs, dp_model=self.model, tt_cache_path=self.cache_path)
@@ -648,7 +651,7 @@ class Gemma3ForConditionalGeneration(Generator, SupportsMultiModal):
         return allocate_vllm_kv_cache(*args, **kwargs, dp_model=self.model, tt_cache_path=self.cache_path)
 
     def decode_forward(self, *args, **kwargs):
-        return super().decode_forward_text(*args, **kwargs)
+        return super().decode_forward(*args, **kwargs)
 
 
 class GptOssForCausalLM(Generator):
@@ -717,7 +720,7 @@ class GptOssForCausalLM(Generator):
         return super().prefill_forward_text(*args, **kwargs)
 
     def decode_forward(self, *args, **kwargs):
-        return super().decode_forward_text(*args, **kwargs)
+        return super().decode_forward(*args, **kwargs)
 
     def allocate_kv_cache(self, *args, **kwargs):
         return allocate_vllm_kv_cache(*args, **kwargs, dp_model=self.model, tt_cache_path=self.cache_path)

--- a/models/tt_transformers/tt/generator_vllm.py
+++ b/models/tt_transformers/tt/generator_vllm.py
@@ -356,7 +356,11 @@ class MllamaForConditionalGeneration(Generator, SupportsMultiModal, SupportsV0On
         )
 
     def decode_forward(self, *args, **kwargs):
-        return super().decode_forward_llama_vision(*args, **kwargs)
+        logits = super().decode_forward_llama_vision(*args, **kwargs)
+        if isinstance(logits, tuple):
+            return logits[0]
+        else:
+            return logits
 
     def allocate_kv_cache(self, *args, **kwargs):
         return allocate_vllm_kv_cache(*args, **kwargs, dp_model=self.model, tt_cache_path=self.cache_path)

--- a/models/vllm_test_utils/no_op_test/test_model.py
+++ b/models/vllm_test_utils/no_op_test/test_model.py
@@ -38,3 +38,6 @@ class DummyNoOpModel:
 
     def warmup_model_prefill(self, *args, **kwargs):
         pass
+
+    def warmup_model_decode(self, *args, **kwargs):
+        pass

--- a/models/vllm_test_utils/t3000_multiproc_test/test_model.py
+++ b/models/vllm_test_utils/t3000_multiproc_test/test_model.py
@@ -72,3 +72,6 @@ class DummyT3000MultiProcessModel:
 
     def warmup_model_prefill(self, *args, **kwargs):
         pass
+
+    def warmup_model_decode(self, *args, **kwargs):
+        pass

--- a/tests/pipeline_reorg/galaxy_demo_tests.yaml
+++ b/tests/pipeline_reorg/galaxy_demo_tests.yaml
@@ -21,7 +21,7 @@
   model: llama3
   skus:
     wh_galaxy:
-      timeout: 20
+      timeout: 27
   owner_id: U053W15B6JF # Djordje Ivanovic
   team: models
 
@@ -32,7 +32,7 @@
   model: llama3_8b_dp
   skus:
     wh_galaxy:
-      timeout: 20
+      timeout: 27
   owner_id: U08BH66EXAL # Radoica Draskic
   team: models
 

--- a/tests/pipeline_reorg/galaxy_demo_tests.yaml
+++ b/tests/pipeline_reorg/galaxy_demo_tests.yaml
@@ -21,7 +21,7 @@
   model: llama3
   skus:
     wh_galaxy:
-      timeout: 27
+      timeout: 22
   owner_id: U053W15B6JF # Djordje Ivanovic
   team: models
 

--- a/tests/pipeline_reorg/t3k_demo_tests.yaml
+++ b/tests/pipeline_reorg/t3k_demo_tests.yaml
@@ -31,7 +31,7 @@
   cmd: run_t3000_llama3_tests
   skus:
     wh_llmbox_perf:
-      timeout: 60
+      timeout: 70
   owner_id: U03PUAKE719 # Miguel Tairum Cruz
   team: models
   model-name: llama3


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/vllm/issues/311)

### Problem description
Currently the parameters for decode warmup are being created at vLLM side. Because of this, we can't run metal demo and e2e tests, so we need to move the parameter creation inside metal.

vllm changes - https://github.com/tenstorrent/vllm/pull/316

#### Model tests

vllm nightly - https://github.com/tenstorrent/tt-metal/actions/runs/22135023070
t3k demo tests - https://github.com/tenstorrent/tt-metal/actions/runs/22135035672
single card demo tests - https://github.com/tenstorrent/tt-metal/actions/runs/22135047665
galaxy demo tests - https://github.com/tenstorrent/tt-metal/actions/runs/22135921831
