### PR TITLE
Split initialization of various components into their own classes

### DIFF
--- a/tt_metal/distributed/dispatch_context.cpp
+++ b/tt_metal/distributed/dispatch_context.cpp
@@ -50,7 +50,7 @@ void DispatchContext::initialize_fast_dispatch(distributed::MeshDevice* mesh_dev
     }
     // Query the number of command queues requested
     populate_fd_kernels(active_devices, num_hw_cqs);
-    device_manager->configure_and_load_fast_dispatch_kernels();
+    device_manager->initialize_dispatch_firmware();
     tt::tt_metal::MetalContext::instance().rtoptions().set_fast_dispatch(fast_dispatch_enabled_);
 
     auto& mesh_device_impl = mesh_device->impl();

--- a/tt_metal/distributed/mesh_device.cpp
+++ b/tt_metal/distributed/mesh_device.cpp
@@ -349,8 +349,7 @@ std::shared_ptr<MeshDevice> MeshDeviceImpl::create(
     // Wait for all ranks to finish initializing the mesh device before proceeding.
     mesh_device->pimpl_->distributed_context_->barrier();
 
-    // The Device Profiler must be initialized before Fabric is loaded on the Cluster
-    tt_metal::MetalContext::instance().device_manager()->init_profiler();
+    tt_metal::MetalContext::instance().device_manager()->initialize_profiler();
     tt_metal::MetalContext::instance().device_manager()->initialize_fabric_and_dispatch_fw();
     return mesh_device;
 }
@@ -441,8 +440,7 @@ std::map<int, std::shared_ptr<MeshDevice>> MeshDeviceImpl::create_unit_meshes(
     // Wait for all ranks to finish initializing the mesh device before proceeding.
     mesh_device->pimpl_->distributed_context_->barrier();
 
-    // The Device Profiler must be initialized before Fabric is loaded on the Cluster
-    tt_metal::MetalContext::instance().device_manager()->init_profiler();
+    tt_metal::MetalContext::instance().device_manager()->initialize_profiler();
     tt_metal::MetalContext::instance().device_manager()->initialize_fabric_and_dispatch_fw();
     return result;
 }

--- a/tt_metal/impl/CMakeLists.txt
+++ b/tt_metal/impl/CMakeLists.txt
@@ -3,6 +3,11 @@ set(IMPL_SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/sub_device/sub_device_manager_tracker.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/sub_device/sub_device_manager.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/context/metal_context.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/device/firmware/firmware_initializer.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/device/firmware/fabric_firmware_initializer.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/device/firmware/dispatch_kernel_initializer.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/device/firmware/command_queue_initializer.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/device/firmware/profiler_initializer.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/device/experimental/device.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/device/device.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/device/mock_device.cpp

--- a/tt_metal/impl/context/context_descriptor.hpp
+++ b/tt_metal/impl/context/context_descriptor.hpp
@@ -1,0 +1,104 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <optional>
+#include <cstdint>
+#include <string_view>
+
+#include <tt-metalium/dispatch_core_common.hpp>
+#include <experimental/fabric/fabric_types.hpp>
+
+namespace tt {
+class Cluster;
+}  // namespace tt
+
+namespace tt::llrt {
+class RunTimeOptions;
+}  // namespace tt::llrt
+
+namespace tt::tt_metal {
+
+class Context;
+class Hal;
+
+class ContextDescriptor {
+public:
+    ContextDescriptor(
+        const Hal& hal,
+        Cluster& cluster,
+        const llrt::RunTimeOptions& rtoptions,
+        std::string_view mock_cluster_desc_path,
+        tt::tt_fabric::FabricConfig fabric_config,
+        tt::tt_fabric::FabricTensixConfig fabric_tensix_config,
+        tt::tt_fabric::FabricManagerMode fabric_manager,
+        int num_cqs = 1,
+        int l1_small_size = 0,
+        int trace_region_size = 0,
+        int worker_l1_size = 0) :
+        hal_(&hal),
+        cluster_(&cluster),
+        rtoptions_(&rtoptions),
+        num_cqs_(num_cqs),
+        l1_small_size_(l1_small_size),
+        trace_region_size_(trace_region_size),
+        worker_l1_size_(worker_l1_size),
+        mock_cluster_desc_path_(mock_cluster_desc_path),
+        fabric_config_(fabric_config),
+        fabric_tensix_config_(fabric_tensix_config),
+        fabric_manager_(fabric_manager) {}
+
+    ContextDescriptor() = default;
+
+    // Service accessors
+    const Hal& hal() const { return *hal_; }
+    Cluster& cluster() const { return *cluster_; }
+    const llrt::RunTimeOptions& rtoptions() const { return *rtoptions_; }
+
+    int num_cqs() const { return num_cqs_; }
+    int l1_small_size() const { return l1_small_size_; }
+    int trace_region_size() const { return trace_region_size_; }
+    int worker_l1_size() const { return worker_l1_size_; }
+    const DispatchCoreConfig& dispatch_core_config() const { return dispatch_core_config_; }
+    bool is_mock_device() const { return !mock_cluster_desc_path_.empty(); }
+    std::string_view mock_cluster_desc_path() const { return mock_cluster_desc_path_; }
+
+    tt::tt_fabric::FabricConfig fabric_config() const { return fabric_config_; }
+    tt::tt_fabric::FabricReliabilityMode reliability_mode() const { return reliability_mode_; }
+    std::optional<uint8_t> num_routing_planes() const { return num_routing_planes_; }
+    tt::tt_fabric::FabricTensixConfig fabric_tensix_config() const { return fabric_tensix_config_; }
+    tt::tt_fabric::FabricUDMMode fabric_udm_mode() const { return fabric_udm_mode_; }
+    tt::tt_fabric::FabricManagerMode fabric_manager() const { return fabric_manager_; }
+    const tt::tt_fabric::FabricRouterConfig& router_config() const { return router_config_; }
+
+private:
+    friend class Context;
+
+    // Dependencies
+    const Hal* hal_ = nullptr;
+    Cluster* cluster_ = nullptr;
+    const llrt::RunTimeOptions* rtoptions_ = nullptr;
+
+    // Dispatch
+    int num_cqs_ = 1;
+    int l1_small_size_ = 0;
+    int trace_region_size_ = 0;
+    int worker_l1_size_ = 0;
+    DispatchCoreConfig dispatch_core_config_;
+    bool is_mock_device_ = false;
+    std::string_view mock_cluster_desc_path_;
+
+    // Fabric
+    tt::tt_fabric::FabricConfig fabric_config_ = tt::tt_fabric::FabricConfig::DISABLED;
+    tt::tt_fabric::FabricReliabilityMode reliability_mode_ =
+        tt::tt_fabric::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE;
+    std::optional<uint8_t> num_routing_planes_;
+    tt::tt_fabric::FabricTensixConfig fabric_tensix_config_ = tt::tt_fabric::FabricTensixConfig::DISABLED;
+    tt::tt_fabric::FabricUDMMode fabric_udm_mode_ = tt::tt_fabric::FabricUDMMode::DISABLED;
+    tt::tt_fabric::FabricManagerMode fabric_manager_ = tt::tt_fabric::FabricManagerMode::DEFAULT;
+    tt::tt_fabric::FabricRouterConfig router_config_;
+};
+
+}  // namespace tt::tt_metal

--- a/tt_metal/impl/context/metal_context.cpp
+++ b/tt_metal/impl/context/metal_context.cpp
@@ -139,7 +139,6 @@ void MetalContext::initialize_device_manager(
     initialize(dispatch_core_config, num_hw_cqs, {l1_bank_remap.begin(), l1_bank_remap.end()}, worker_l1_size);
     device_manager_->initialize(
         device_ids,
-        l1_bank_remap,
         init_profiler,
         initialize_fabric_and_dispatch_fw,
         create_context_descriptor(num_hw_cqs, l1_small_size, trace_region_size, worker_l1_size));
@@ -905,14 +904,19 @@ std::shared_ptr<ContextDescriptor> MetalContext::create_context_descriptor(
         *hal_,
         *cluster_,
         rtoptions_,
-        rtoptions_.get_mock_cluster_desc_path(),
         fabric_config_,
+        fabric_reliability_mode_,
         fabric_tensix_config_,
+        fabric_udm_mode_,
         fabric_manager_,
+        fabric_router_config_,
         num_hw_cqs,
         l1_small_size,
         trace_region_size,
-        worker_l1_size);
+        worker_l1_size,
+        dispatch_core_config_,
+        l1_bank_remap_,
+        rtoptions_.get_mock_cluster_desc_path());
 }
 
 void MetalContext::construct_control_plane(const std::filesystem::path& mesh_graph_desc_path) {

--- a/tt_metal/impl/context/metal_context.hpp
+++ b/tt_metal/impl/context/metal_context.hpp
@@ -30,6 +30,7 @@ namespace inspector {
 class Data;
 }
 
+class ContextDescriptor;
 class DataCollector;
 class DeviceManager;
 class Hal;
@@ -71,6 +72,9 @@ public:
     std::unique_ptr<DataCollector>& data_collector() { return data_collector_; }
     std::unique_ptr<DeviceManager>& device_manager() { return device_manager_; }
     bool is_device_manager_initialized() const { return device_manager_ != nullptr; }
+
+    std::shared_ptr<ContextDescriptor> create_context_descriptor(
+        int num_hw_cqs, size_t l1_small_size, size_t trace_region_size, size_t worker_l1_size) const;
 
     std::unique_ptr<NOCDebugState>& noc_debug_state() { return noc_debug_state_; }
 
@@ -156,6 +160,7 @@ private:
     void initialize_control_plane_impl();  // Private implementation without mutex
     void teardown_fabric_config();
     void teardown_base_objects();
+    void teardown_dispatch_state();
     void initialize_base_objects();
 
     void reset_cores(ChipId device_id);

--- a/tt_metal/impl/device/device_manager.cpp
+++ b/tt_metal/impl/device/device_manager.cpp
@@ -441,11 +441,11 @@ void DeviceManager::add_devices_to_pool(const std::vector<ChipId>& device_ids) {
 void DeviceManager::initialize_profiler() {
     auto& ctx = tt::tt_metal::MetalContext::instance();
     auto active_devices = this->get_all_active_devices_impl();
-    initializers_[ProfilerInitializer::key()] =
+    initializers_[ProfilerInitializer::key] =
         std::make_unique<ProfilerInitializer>(descriptor_, skip_remote_devices_, ctx.profiler_state_manager().get());
-    initializers_[ProfilerInitializer::key()]->init(active_devices, init_done_);
-    init_done_.insert(ProfilerInitializer::key());
-    initializers_[ProfilerInitializer::key()]->configure();
+    initializers_[ProfilerInitializer::key]->init(active_devices, init_done_);
+    init_done_.insert(ProfilerInitializer::key);
+    initializers_[ProfilerInitializer::key]->configure();
 }
 
 void DeviceManager::initialize_fabric_and_dispatch_fw() {
@@ -458,17 +458,17 @@ void DeviceManager::initialize_fabric_and_dispatch_fw() {
 
     auto active_devices = this->get_all_active_devices_impl();
 
-    initializers_[FabricFirmwareInitializer::key()] =
+    initializers_[FabricFirmwareInitializer::key] =
         std::make_unique<FabricFirmwareInitializer>(descriptor_, ctx.get_control_plane());
-    initializers_[FabricFirmwareInitializer::key()]->init(active_devices, init_done_);
-    init_done_.insert(FabricFirmwareInitializer::key());
+    initializers_[FabricFirmwareInitializer::key]->init(active_devices, init_done_);
+    init_done_.insert(FabricFirmwareInitializer::key);
 
-    initializers_[DispatchKernelInitializer::key()] = std::make_unique<DispatchKernelInitializer>(descriptor_);
-    initializers_[DispatchKernelInitializer::key()]->init(active_devices, init_done_);
-    init_done_.insert(DispatchKernelInitializer::key());
-    initializers_[DispatchKernelInitializer::key()]->configure();
+    initializers_[DispatchKernelInitializer::key] = std::make_unique<DispatchKernelInitializer>(descriptor_);
+    initializers_[DispatchKernelInitializer::key]->init(active_devices, init_done_);
+    init_done_.insert(DispatchKernelInitializer::key);
 
-    initializers_[FabricFirmwareInitializer::key()]->configure();
+    initializers_[DispatchKernelInitializer::key]->configure();
+    initializers_[FabricFirmwareInitializer::key]->configure();
 
     log_trace(tt::LogMetal, "Fabric and Dispatch Firmware initialized");
 }
@@ -478,19 +478,20 @@ void DeviceManager::initialize_dispatch_firmware() {
     // It will re initialize the dispatch firmware on the active devices as they were manually
     // disabled
     auto active_devices = this->get_all_active_devices_impl();
-    initializers_[DispatchKernelInitializer::key()] = std::make_unique<DispatchKernelInitializer>(descriptor_);
-    initializers_[DispatchKernelInitializer::key()]->init(active_devices, init_done_);
-    initializers_[DispatchKernelInitializer::key()]->configure();
-    init_done_.insert(DispatchKernelInitializer::key());
+    init_done_.erase(DispatchKernelInitializer::key);
+    initializers_[DispatchKernelInitializer::key] = std::make_unique<DispatchKernelInitializer>(descriptor_);
+    initializers_[DispatchKernelInitializer::key]->init(active_devices, init_done_);
+    initializers_[DispatchKernelInitializer::key]->configure();
+    init_done_.insert(DispatchKernelInitializer::key);
 }
 
 void DeviceManager::init_firmware_on_active_devices() {
     auto active_devices = this->get_all_active_devices_impl();
 
-    initializers_[CommandQueueInitializer::key()] =
+    initializers_[CommandQueueInitializer::key] =
         std::make_unique<CommandQueueInitializer>(descriptor_, skip_remote_devices_);
-    initializers_[CommandQueueInitializer::key()]->init(active_devices, init_done_);
-    init_done_.insert(CommandQueueInitializer::key());
+    initializers_[CommandQueueInitializer::key]->init(active_devices, init_done_);
+    init_done_.insert(CommandQueueInitializer::key);
 
     if (init_profiler_) {
         this->initialize_profiler();
@@ -570,7 +571,7 @@ std::unordered_map<ChipId, std::vector<uint32_t>> DeviceManager::get_all_command
 }
 
 bool DeviceManager::is_dispatch_firmware_active() const {
-    auto it = initializers_.find(DispatchKernelInitializer::key());
+    auto it = initializers_.find(DispatchKernelInitializer::key);
     return it != initializers_.end() && it->second->is_initialized();
 }
 
@@ -623,15 +624,15 @@ bool DeviceManager::close_devices(const std::vector<IDevice*>& devices, bool /*s
     }
 
     // Order matters
-    initializers_[DispatchKernelInitializer::key()]->teardown();
-    initializers_[FabricFirmwareInitializer::key()]->teardown();
-    initializers_[ProfilerInitializer::key()]->teardown();
-    initializers_[CommandQueueInitializer::key()]->teardown();
+    initializers_[DispatchKernelInitializer::key]->teardown();
+    initializers_[FabricFirmwareInitializer::key]->teardown();
+    initializers_[ProfilerInitializer::key]->teardown();
+    initializers_[CommandQueueInitializer::key]->teardown();
 
-    initializers_[DispatchKernelInitializer::key()]->post_teardown();
-    initializers_[FabricFirmwareInitializer::key()]->post_teardown();
-    initializers_[ProfilerInitializer::key()]->post_teardown();
-    initializers_[CommandQueueInitializer::key()]->post_teardown();
+    initializers_[DispatchKernelInitializer::key]->post_teardown();
+    initializers_[FabricFirmwareInitializer::key]->post_teardown();
+    initializers_[ProfilerInitializer::key]->post_teardown();
+    initializers_[CommandQueueInitializer::key]->post_teardown();
 
     init_done_.clear();
     initializers_.clear();

--- a/tt_metal/impl/device/device_manager.cpp
+++ b/tt_metal/impl/device/device_manager.cpp
@@ -179,7 +179,6 @@ namespace tt_metal {
 
 void DeviceManager::initialize(
     const std::vector<ChipId>& device_ids,
-    tt::stl::Span<const std::uint32_t> l1_bank_remap,
     bool init_profiler,
     bool initialize_fabric_and_dispatch_fw,
     std::shared_ptr<ContextDescriptor> descriptor) {
@@ -198,7 +197,7 @@ void DeviceManager::initialize(
     worker_thread_to_cpu_core_map_ =
         device_cpu_allocator::get_device_id_to_core_map(num_hw_cqs_, completion_queue_reader_to_cpu_core_map_);
 
-    l1_bank_remap_.assign(l1_bank_remap.begin(), l1_bank_remap.end());
+    l1_bank_remap_.assign(descriptor->l1_bank_remap().begin(), descriptor->l1_bank_remap().end());
 
     open_devices(device_ids);
     is_initialized_ = true;

--- a/tt_metal/impl/device/device_manager.cpp
+++ b/tt_metal/impl/device/device_manager.cpp
@@ -181,11 +181,11 @@ void DeviceManager::initialize(
     const std::vector<ChipId>& device_ids,
     bool init_profiler,
     bool initialize_fabric_and_dispatch_fw,
-    std::shared_ptr<ContextDescriptor> descriptor) {
+    const std::shared_ptr<ContextDescriptor>& descriptor) {
     ZoneScoped;
     log_debug(tt::LogMetal, "DeviceManager initialize");
 
-    descriptor_ = std::move(descriptor);
+    descriptor_ = descriptor;
     num_hw_cqs_ = descriptor_->num_cqs();
     l1_small_size_ = descriptor_->l1_small_size();
     trace_region_size_ = descriptor_->trace_region_size();
@@ -197,7 +197,7 @@ void DeviceManager::initialize(
     worker_thread_to_cpu_core_map_ =
         device_cpu_allocator::get_device_id_to_core_map(num_hw_cqs_, completion_queue_reader_to_cpu_core_map_);
 
-    l1_bank_remap_.assign(descriptor->l1_bank_remap().begin(), descriptor->l1_bank_remap().end());
+    l1_bank_remap_.assign(descriptor_->l1_bank_remap().begin(), descriptor_->l1_bank_remap().end());
 
     open_devices(device_ids);
     is_initialized_ = true;

--- a/tt_metal/impl/device/device_manager.hpp
+++ b/tt_metal/impl/device/device_manager.hpp
@@ -35,7 +35,7 @@ public:
         const std::vector<ChipId>& device_ids,
         bool init_profiler,
         bool initialize_fabric_and_dispatch_fw,
-        std::shared_ptr<ContextDescriptor> descriptor);
+        const std::shared_ptr<ContextDescriptor>& descriptor);
 
     IDevice* get_active_device(ChipId device_id) const;
     std::vector<IDevice*> get_all_active_devices() const;

--- a/tt_metal/impl/device/device_manager.hpp
+++ b/tt_metal/impl/device/device_manager.hpp
@@ -33,7 +33,6 @@ public:
 
     void initialize(
         const std::vector<ChipId>& device_ids,
-        tt::stl::Span<const std::uint32_t> l1_bank_remap,
         bool init_profiler,
         bool initialize_fabric_and_dispatch_fw,
         std::shared_ptr<ContextDescriptor> descriptor);

--- a/tt_metal/impl/device/firmware/command_queue_initializer.cpp
+++ b/tt_metal/impl/device/firmware/command_queue_initializer.cpp
@@ -1,0 +1,85 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "command_queue_initializer.hpp"
+
+#include <tt_stl/assert.hpp>
+#include <tt-logger/tt-logger.hpp>
+#include <llrt/tt_cluster.hpp>
+#include <tt_metal.hpp>
+#include "impl/context/context_descriptor.hpp"
+#include "device/device_impl.hpp"
+
+#include <tt_metal_profiler.hpp>
+
+namespace tt::tt_metal {
+
+CommandQueueInitializer::CommandQueueInitializer(
+    std::shared_ptr<const ContextDescriptor> descriptor, bool skip_remote_devices) :
+    FirmwareInitializer(std::move(descriptor)), skip_remote_devices_(skip_remote_devices) {}
+
+void CommandQueueInitializer::init(
+    const std::vector<Device*>& devices, [[maybe_unused]] const std::unordered_set<InitializerKey>& init_done) {
+    devices_ = devices;
+
+    if (descriptor_->is_mock_device()) {
+        log_info(tt::LogMetal, "Skipping host-side CQ initialization for mock devices");
+        initialized_ = true;
+        return;
+    }
+
+    // Initialize host-side state for each MMIO device and its tunnel devices
+    for (auto* dev : devices_) {
+        // Only process MMIO devices at this level; tunnel devices are handled inside the loop
+        if (cluster_.get_associated_mmio_device(dev->id()) != dev->id()) {
+            continue;
+        }
+        auto tunnels_from_mmio = cluster_.get_tunnels_from_mmio_device(dev->id());
+        initialize_host(dev);
+        if (!skip_remote_devices_) {
+            for (uint32_t t = 0; t < tunnels_from_mmio.size(); t++) {
+                // Process tunnel devices from farthest to closest
+                for (uint32_t ts = tunnels_from_mmio[t].size() - 1; ts > 0; ts--) {
+                    uint32_t mmio_controlled_device_id = tunnels_from_mmio[t][ts];
+                    log_debug(tt::LogMetal, "Tunnel {} Device {} Tunnel Stop: {}", t, mmio_controlled_device_id, ts);
+                    auto it = std::find_if(devices_.begin(), devices_.end(), [&](Device* d) {
+                        return d->id() == mmio_controlled_device_id;
+                    });
+                    if (it != devices_.end()) {
+                        initialize_host(*it);
+                    }
+                }
+            }
+        }
+    }
+
+    initialized_ = true;
+}
+
+void CommandQueueInitializer::configure() {}
+
+void CommandQueueInitializer::teardown() {
+    devices_.clear();
+    initialized_ = false;
+}
+
+bool CommandQueueInitializer::is_initialized() const { return initialized_; }
+
+void CommandQueueInitializer::initialize_host(Device* dev) const {
+    detail::ClearProfilerControlBuffer(dev);
+
+    // Create system memory writer for this device to have an associated interface to hardware command
+    // queue (i.e. hugepage). Need to do this before FW init so we know what dispatch cores to reset.
+    if (using_fast_dispatch()) {
+        detail::DispatchStateCheck(true);
+        dev->init_command_queue_host();
+    } else {
+        detail::DispatchStateCheck(false);
+        TT_ASSERT(dev->num_hw_cqs() == 1, "num_hw_cqs must be 1 in slow dispatch");
+    }
+}
+
+bool CommandQueueInitializer::using_fast_dispatch() const { return rtoptions_.get_fast_dispatch(); }
+
+}  // namespace tt::tt_metal

--- a/tt_metal/impl/device/firmware/command_queue_initializer.hpp
+++ b/tt_metal/impl/device/firmware/command_queue_initializer.hpp
@@ -1,0 +1,32 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "firmware_initializer.hpp"
+
+namespace tt::tt_metal {
+
+class CommandQueueInitializer final : public FirmwareInitializer {
+public:
+    static constexpr InitializerKey key() { return InitializerKey::CommandQueue; }
+
+    CommandQueueInitializer(std::shared_ptr<const ContextDescriptor> descriptor, bool skip_remote_devices);
+
+    void init(const std::vector<Device*>& devices, const std::unordered_set<InitializerKey>& init_done) override;
+    void configure() override;
+    void teardown() override;
+    bool is_initialized() const override;
+
+private:
+    void initialize_host(Device* dev) const;
+
+    bool using_fast_dispatch() const;
+
+    bool skip_remote_devices_;
+    std::vector<Device*> devices_;
+    bool initialized_ = false;
+};
+
+}  // namespace tt::tt_metal

--- a/tt_metal/impl/device/firmware/command_queue_initializer.hpp
+++ b/tt_metal/impl/device/firmware/command_queue_initializer.hpp
@@ -10,7 +10,7 @@ namespace tt::tt_metal {
 
 class CommandQueueInitializer final : public FirmwareInitializer {
 public:
-    static constexpr InitializerKey key() { return InitializerKey::CommandQueue; }
+    static constexpr InitializerKey key = InitializerKey::CommandQueue;
 
     CommandQueueInitializer(std::shared_ptr<const ContextDescriptor> descriptor, bool skip_remote_devices);
 

--- a/tt_metal/impl/device/firmware/dispatch_kernel_initializer.cpp
+++ b/tt_metal/impl/device/firmware/dispatch_kernel_initializer.cpp
@@ -39,7 +39,7 @@ void DispatchKernelInitializer::init(
     }
 
     TT_ASSERT(
-        init_done.contains(FabricFirmwareInitializer::key()),
+        init_done.contains(FabricFirmwareInitializer::key),
         "Fabric firmware must be initialized before dispatch firmware");
 
     // Compile dispatch kernels if using fast dispatch.

--- a/tt_metal/impl/device/firmware/dispatch_kernel_initializer.cpp
+++ b/tt_metal/impl/device/firmware/dispatch_kernel_initializer.cpp
@@ -1,0 +1,218 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "dispatch_kernel_initializer.hpp"
+
+#include <tt_stl/assert.hpp>
+#include <tt-logger/tt-logger.hpp>
+#include <llrt/tt_cluster.hpp>
+#include <tt_metal.hpp>
+#include "common/executor.hpp"
+#include "device/firmware/fabric_firmware_initializer.hpp"
+#include "impl/context/context_descriptor.hpp"
+#include "device/device_impl.hpp"
+
+#include "dispatch/topology.hpp"
+
+#include "llrt/hal/generated/dev_msgs.hpp"
+
+namespace tt::llrt::internal_ {
+void wait_until_cores_done(
+    ChipId device_id, int run_state, std::unordered_set<CoreCoord>& not_done_phys_cores, int timeout_ms);
+}  // namespace tt::llrt::internal_
+
+namespace tt::tt_metal {
+
+void DispatchKernelInitializer::init(
+    const std::vector<Device*>& devices, [[maybe_unused]] const std::unordered_set<InitializerKey>& init_done) {
+    if (!using_fast_dispatch()) {
+        return;
+    }
+
+    devices_ = devices;
+
+    // Skip firmware initialization for mock devices
+    if (descriptor_->is_mock_device()) {
+        log_info(tt::LogMetal, "Skipping dispatch firmware initialization for mock devices");
+        return;
+    }
+
+    TT_ASSERT(
+        init_done.contains(FabricFirmwareInitializer::key()),
+        "Fabric firmware must be initialized before dispatch firmware");
+
+    // Compile dispatch kernels if using fast dispatch.
+    // Note: Host-side init (profiler buffer clear, CQ host init) is a prerequisite
+    // that must be performed by the caller before this point.
+    if (using_fast_dispatch()) {
+        compile_dispatch_kernels();
+    }
+}
+
+void DispatchKernelInitializer::configure() {
+    if (!using_fast_dispatch()) {
+        return;
+    }
+
+    init_device_command_queues();
+    initialized_ = true;
+}
+
+void DispatchKernelInitializer::teardown() {
+    if (!using_fast_dispatch()) {
+        return;
+    }
+
+    // Mock devices don't have sysmem_manager, skip FD teardown
+    if (descriptor_->is_mock_device()) {
+        return;
+    }
+
+    terminate_command_queues();
+    wait_for_dispatch_cores();
+
+    process_termination_signals();
+
+    devices_.clear();
+    initialized_ = false;
+}
+
+bool DispatchKernelInitializer::is_initialized() const { return initialized_; }
+
+void DispatchKernelInitializer::compile_dispatch_kernels() {
+    // Compile dispatch firmware: populate static args, create CQ programs, compile.
+
+    if (descriptor_->is_mock_device()) {
+        return;
+    }
+
+    // Generate static args
+    for (auto* dev : devices_) {
+        if (cluster_.get_associated_mmio_device(dev->id()) != dev->id()) {
+            continue;
+        }
+
+        auto tunnels_from_mmio = cluster_.get_tunnels_from_mmio_device(dev->id());
+        populate_cq_static_args(dev);
+        for (const auto& tunnel : tunnels_from_mmio) {
+            for (uint32_t ts = tunnel.size() - 1; ts > 0; ts--) {
+                uint32_t mmio_controlled_device_id = tunnel[ts];
+                auto it = std::find_if(
+                    devices_.begin(), devices_.end(), [&](IDevice* d) { return d->id() == mmio_controlled_device_id; });
+                if (it != devices_.end()) {
+                    populate_cq_static_args(*it);
+                }
+            }
+        }
+    }
+
+    // Create command queue programs
+    for (auto* dev : devices_) {
+        if (cluster_.get_associated_mmio_device(dev->id()) != dev->id()) {
+            continue;
+        }
+
+        create_cq_program(dev);
+        auto tunnels_from_mmio = cluster_.get_tunnels_from_mmio_device(dev->id());
+        for (const auto& tunnel : tunnels_from_mmio) {
+            for (uint32_t ts = tunnel.size() - 1; ts > 0; ts--) {
+                uint32_t mmio_controlled_device_id = tunnel[ts];
+                auto it = std::find_if(
+                    devices_.begin(), devices_.end(), [&](IDevice* d) { return d->id() == mmio_controlled_device_id; });
+                if (it != devices_.end()) {
+                    create_cq_program(*it);
+                }
+            }
+        }
+    }
+
+    // Compile all programs
+    compile_cq_programs();
+}
+
+void DispatchKernelInitializer::init_device_command_queues() {
+    // Initialize device-side command queues (parallelized per MMIO device).
+
+    if (descriptor_->is_mock_device()) {
+        return;
+    }
+
+    std::vector<std::shared_future<void>> events;
+    for (auto* dev : devices_) {
+        if (cluster_.get_associated_mmio_device(dev->id()) != dev->id()) {
+            continue;
+        }
+        ChipId mmio_device_id = dev->id();
+        events.emplace_back(detail::async([this, dev, mmio_device_id]() {
+            auto tunnels_from_mmio = cluster_.get_tunnels_from_mmio_device(mmio_device_id);
+            dev->init_command_queue_device();
+            log_debug(tt::LogMetal, "Command Queue initialized on Device {}", dev->id());
+            for (const auto& tunnel : tunnels_from_mmio) {
+                for (uint32_t ts = tunnel.size() - 1; ts > 0; ts--) {
+                    uint32_t mmio_controlled_device_id = tunnel[ts];
+                    auto it = std::find_if(devices_.begin(), devices_.end(), [&](IDevice* d) {
+                        return d->id() == mmio_controlled_device_id;
+                    });
+                    if (it != devices_.end()) {
+                        (*it)->init_command_queue_device();
+                        log_info(tt::LogMetal, "Command Queue initialized on Device {}", (*it)->id());
+                    }
+                }
+            }
+        }));
+    }
+    for (const auto& event : events) {
+        event.get();
+    }
+}
+
+void DispatchKernelInitializer::terminate_command_queues() {
+    for (auto* dev : devices_) {
+        auto* device = dynamic_cast<Device*>(dev);
+        TT_ASSERT(device != nullptr, "Expected concrete Device but got different IDevice subclass");
+        for (int cq_id = 0; cq_id < device->num_hw_cqs(); cq_id++) {
+            auto& cq = device->command_queue(cq_id);
+            cq.terminate();
+        }
+    }
+}
+
+void DispatchKernelInitializer::wait_for_dispatch_cores() const {
+    for (auto* dev : devices_) {
+        if (!dev->is_mmio_capable()) {
+            continue;
+        }
+
+        auto dispatch_cores = get_virtual_dispatch_cores(dev->id());
+        // Wrap in try-catch so that device close continues even if dispatch cores fail or timeout.
+        // This allows the device handles to be properly released, enabling subsequent
+        // device opens and tt-smi resets to succeed.
+        try {
+            tt::llrt::internal_::wait_until_cores_done(dev->id(), dev_msgs::RUN_MSG_GO, dispatch_cores, 0);
+        } catch (const std::exception& e) {
+            log_warning(
+                LogMetal,
+                "Device {}: Exception waiting for dispatch cores to finish during teardown. "
+                "Continuing with cleanup. Error: {}",
+                dev->id(),
+                e.what());
+        }
+    }
+}
+
+void DispatchKernelInitializer::process_termination_signals() const {
+    for (auto* dev : devices_) {
+        const auto& info = get_registered_termination_cores(dev->id());
+        for (const auto& core_to_terminate : info) {
+            std::vector<uint32_t> val{core_to_terminate.val};
+            detail::WriteToDeviceL1(
+                dev, core_to_terminate.logical_core, core_to_terminate.address, val, core_to_terminate.core_type);
+        }
+        cluster_.l1_barrier(dev->id());
+    }
+}
+
+bool DispatchKernelInitializer::using_fast_dispatch() const { return rtoptions_.get_fast_dispatch(); }
+
+}  // namespace tt::tt_metal

--- a/tt_metal/impl/device/firmware/dispatch_kernel_initializer.hpp
+++ b/tt_metal/impl/device/firmware/dispatch_kernel_initializer.hpp
@@ -10,7 +10,7 @@ namespace tt::tt_metal {
 
 class DispatchKernelInitializer final : public FirmwareInitializer {
 public:
-    static constexpr InitializerKey key() { return InitializerKey::Dispatch; }
+    static constexpr InitializerKey key = InitializerKey::Dispatch;
 
     using FirmwareInitializer::FirmwareInitializer;
 

--- a/tt_metal/impl/device/firmware/dispatch_kernel_initializer.hpp
+++ b/tt_metal/impl/device/firmware/dispatch_kernel_initializer.hpp
@@ -1,0 +1,40 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "firmware_initializer.hpp"
+
+namespace tt::tt_metal {
+
+class DispatchKernelInitializer final : public FirmwareInitializer {
+public:
+    static constexpr InitializerKey key() { return InitializerKey::Dispatch; }
+
+    using FirmwareInitializer::FirmwareInitializer;
+
+    void init(const std::vector<Device*>& devices, const std::unordered_set<InitializerKey>& init_done) override;
+    void configure() override;
+    void teardown() override;
+    // Returns true if fast dispatch is enabled and has been configured
+    bool is_initialized() const override;
+
+private:
+    void compile_dispatch_kernels();
+
+    void init_device_command_queues();
+
+    void terminate_command_queues();
+
+    void wait_for_dispatch_cores() const;
+
+    void process_termination_signals() const;
+
+    bool using_fast_dispatch() const;
+
+    std::vector<Device*> devices_;
+    bool initialized_ = false;
+};
+
+}  // namespace tt::tt_metal

--- a/tt_metal/impl/device/firmware/fabric_firmware_initializer.cpp
+++ b/tt_metal/impl/device/firmware/fabric_firmware_initializer.cpp
@@ -1,0 +1,247 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "fabric_firmware_initializer.hpp"
+
+#include <chrono>
+
+#include <tt_stl/assert.hpp>
+#include <tt-logger/tt-logger.hpp>
+#include <llrt/tt_cluster.hpp>
+#include <tt_metal.hpp>
+#include "device/device_impl.hpp"
+#include "common/executor.hpp"
+#include "impl/context/context_descriptor.hpp"
+
+#include <experimental/fabric/control_plane.hpp>
+#include <experimental/fabric/fabric_types.hpp>
+#include "fabric/fabric_host_utils.hpp"
+#include "fabric/fabric_context.hpp"
+#include "fabric/fabric_builder_context.hpp"
+
+namespace tt::tt_metal {
+
+FabricFirmwareInitializer::FabricFirmwareInitializer(
+    std::shared_ptr<const ContextDescriptor> descriptor, tt::tt_fabric::ControlPlane& control_plane) :
+    FirmwareInitializer(std::move(descriptor)), control_plane_(control_plane) {}
+
+void FabricFirmwareInitializer::init(
+    const std::vector<Device*>& devices, const std::unordered_set<InitializerKey>& /*init_done*/) {
+    devices_ = devices;
+
+    tt_fabric::FabricConfig fabric_config = descriptor_->fabric_config();
+    if (!tt_fabric::is_tt_fabric_config(fabric_config)) {
+        return;
+    }
+
+    if (descriptor_->is_mock_device()) {
+        log_info(tt::LogMetal, "Skipping fabric initialization for mock devices");
+        return;
+    }
+
+    if (has_flag(descriptor_->fabric_manager(), tt_fabric::FabricManagerMode::INIT_FABRIC)) {
+        log_info(tt::LogMetal, "Initializing Fabric");
+        control_plane_.write_routing_tables_to_all_chips();
+        compile_and_configure_fabric();
+        log_info(tt::LogMetal, "Fabric Initialized with config {}", fabric_config);
+    } else if (has_flag(descriptor_->fabric_manager(), tt_fabric::FabricManagerMode::TERMINATE_FABRIC)) {
+        log_info(tt::LogMetal, "Compiling fabric to setup fabric context for fabric termination");
+        for (auto* dev : devices_) {
+            dev->compile_fabric();
+        }
+    } else {
+        log_info(tt::LogMetal, "Fabric initialized through Fabric Manager");
+    }
+}
+
+void FabricFirmwareInitializer::configure() {
+    if (has_flag(descriptor_->fabric_manager(), tt_fabric::FabricManagerMode::INIT_FABRIC)) {
+        wait_for_fabric_router_sync(get_fabric_router_sync_timeout_ms());
+    }
+    initialized_ = true;
+}
+
+void FabricFirmwareInitializer::teardown() {
+    if (!has_flag(descriptor_->fabric_manager(), tt_fabric::FabricManagerMode::TERMINATE_FABRIC)) {
+        devices_.clear();
+        initialized_ = false;
+        return;
+    }
+
+    tt_fabric::FabricConfig fabric_config = descriptor_->fabric_config();
+    if (!tt_fabric::is_tt_fabric_config(fabric_config)) {
+        devices_.clear();
+        initialized_ = false;
+        return;
+    }
+
+    const auto& fabric_context = control_plane_.get_fabric_context();
+    const auto& builder_ctx = fabric_context.get_builder_context();
+    auto [termination_signal_address, signal] = builder_ctx.get_fabric_router_termination_address_and_signal();
+    std::vector<uint32_t> termination_signal(1, signal);
+
+    // Terminate fabric tensix mux cores if enabled
+    // TODO: issue #26855, move the termination process to device
+    if (descriptor_->fabric_tensix_config() != tt::tt_fabric::FabricTensixConfig::DISABLED) {
+        const auto& tensix_config = builder_ctx.get_tensix_config();
+
+        for (auto* dev : devices_) {
+            if (builder_ctx.get_num_fabric_initialized_routers(dev->id()) == 0) {
+                continue;
+            }
+
+            const auto fabric_node_id = control_plane_.get_fabric_node_id_from_physical_chip_id(dev->id());
+            const auto& active_fabric_eth_channels = control_plane_.get_active_fabric_eth_channels(fabric_node_id);
+
+            for (const auto& [eth_chan_id, direction] : active_fabric_eth_channels) {
+                auto core_id = tensix_config.get_core_id_for_channel(dev->id(), eth_chan_id);
+                auto [tensix_termination_address, tensix_signal] =
+                    tensix_config.get_termination_address_and_signal(core_id);
+                std::vector<uint32_t> tensix_termination_signal(1, tensix_signal);
+                auto mux_core = tensix_config.get_core_for_channel(dev->id(), eth_chan_id);
+
+                detail::WriteToDeviceL1(
+                    dev, mux_core, tensix_termination_address, tensix_termination_signal, CoreType::WORKER);
+            }
+
+            cluster_.l1_barrier(dev->id());
+        }
+    }
+
+    // Terminate fabric routers via master router on each device
+    for (auto* dev : devices_) {
+        if (builder_ctx.get_num_fabric_initialized_routers(dev->id()) == 0) {
+            continue;
+        }
+
+        auto master_router_logical_core = cluster_.get_soc_desc(dev->id()).get_eth_core_for_channel(
+            builder_ctx.get_fabric_master_router_chan(dev->id()), CoordSystem::LOGICAL);
+        detail::WriteToDeviceL1(
+            dev, master_router_logical_core, termination_signal_address, termination_signal, CoreType::ETH);
+    }
+
+    devices_.clear();
+    initialized_ = false;
+}
+
+void FabricFirmwareInitializer::post_teardown() {
+    // Reset fabric config
+    tt::tt_fabric::SetFabricConfig(tt::tt_fabric::FabricConfig::DISABLED);
+}
+
+bool FabricFirmwareInitializer::is_initialized() const { return initialized_; }
+
+void FabricFirmwareInitializer::compile_and_configure_fabric() {
+    std::vector<std::shared_future<Device*>> events;
+    events.reserve(devices_.size());
+    for (auto* dev : devices_) {
+        events.emplace_back(detail::async([dev]() {
+            if (dev->compile_fabric()) {
+                return dev;
+            }
+            // Compile failure mostly comes from Nebula (TG)
+            log_trace(tt::LogMetal, "Did not build fabric on Device {}", dev->id());
+            return static_cast<Device*>(nullptr);
+        }));
+    }
+
+    if (!has_flag(descriptor_->fabric_manager(), tt_fabric::FabricManagerMode::INIT_FABRIC)) {
+        return;
+    }
+
+    for (const auto& event : events) {
+        auto* dev = event.get();
+        if (dev) {
+            dev->configure_fabric();
+        }
+    }
+}
+
+void FabricFirmwareInitializer::wait_for_fabric_router_sync(uint32_t timeout_ms) const {
+    tt_fabric::FabricConfig fabric_config = descriptor_->fabric_config();
+    if (!tt_fabric::is_tt_fabric_config(fabric_config)) {
+        return;
+    }
+
+    const auto& fabric_context = control_plane_.get_fabric_context();
+    const auto& builder_context = fabric_context.get_builder_context();
+
+    auto wait_for_handshake = [&](Device* dev) {
+        if (!dev) {
+            TT_THROW("Fabric router sync on null device. All devices must be opened for Fabric.");
+        }
+        if (builder_context.get_num_fabric_initialized_routers(dev->id()) == 0) {
+            return;
+        }
+
+        const auto master_router_chan = builder_context.get_fabric_master_router_chan(dev->id());
+        const auto master_router_logical_core =
+            cluster_.get_soc_desc(dev->id()).get_eth_core_for_channel(master_router_chan, CoordSystem::LOGICAL);
+
+        const auto [router_sync_address, expected_status] = builder_context.get_fabric_router_sync_address_and_status();
+        std::vector<std::uint32_t> master_router_status{0};
+        auto start_time = std::chrono::steady_clock::now();
+        while (master_router_status[0] != expected_status) {
+            detail::ReadFromDeviceL1(
+                dev, master_router_logical_core, router_sync_address, 4, master_router_status, CoreType::ETH);
+            if (master_router_status[0] == expected_status) {
+                break;
+            }
+            auto current_time = std::chrono::steady_clock::now();
+            auto elapsed_ms = std::chrono::duration_cast<std::chrono::milliseconds>(current_time - start_time).count();
+            if (elapsed_ms > timeout_ms) {
+                log_info(
+                    tt::LogMetal,
+                    "Fabric Router Sync: master chan={}, logical core={}, sync address=0x{:08x}",
+                    master_router_chan,
+                    master_router_logical_core.str(),
+                    router_sync_address);
+                TT_THROW(
+                    "Fabric Router Sync: Timeout after {} ms. Device {}: Expected status 0x{:08x}, got 0x{:08x}",
+                    timeout_ms,
+                    dev->id(),
+                    expected_status,
+                    master_router_status[0]);
+            }
+        }
+
+        auto ready_address_and_signal = builder_context.get_fabric_router_ready_address_and_signal();
+        if (ready_address_and_signal) {
+            std::vector<uint32_t> ready_signal(1, ready_address_and_signal->second);
+            detail::WriteToDeviceL1(
+                dev, master_router_logical_core, ready_address_and_signal->first, ready_signal, CoreType::ETH);
+        }
+    };
+
+    // Poll devices in tunnel order: farthest-to-closest, then MMIO device itself
+    for (auto* dev : devices_) {
+        if (cluster_.get_associated_mmio_device(dev->id()) != dev->id()) {
+            continue;
+        }
+
+        auto tunnels_from_mmio = cluster_.get_tunnels_from_mmio_device(dev->id());
+        for (const auto& tunnel : tunnels_from_mmio) {
+            for (auto j = tunnel.size() - 1; j > 0; j--) {
+                // Find the device in our device list by chip ID
+                auto it =
+                    std::find_if(devices_.begin(), devices_.end(), [&](Device* d) { return d->id() == tunnel[j]; });
+                if (it != devices_.end()) {
+                    wait_for_handshake(*it);
+                }
+            }
+        }
+
+        wait_for_handshake(dev);
+    }
+}
+
+uint32_t FabricFirmwareInitializer::get_fabric_router_sync_timeout_ms() const {
+    if (rtoptions_.get_simulator_enabled()) {
+        return 15000;
+    }
+    auto timeout = rtoptions_.get_fabric_router_sync_timeout_ms();
+    return timeout.value_or(10000);
+}
+
+}  // namespace tt::tt_metal

--- a/tt_metal/impl/device/firmware/fabric_firmware_initializer.hpp
+++ b/tt_metal/impl/device/firmware/fabric_firmware_initializer.hpp
@@ -15,7 +15,7 @@ namespace tt::tt_metal {
 
 class FabricFirmwareInitializer final : public FirmwareInitializer {
 public:
-    static constexpr InitializerKey key() { return InitializerKey::Fabric; }
+    static constexpr InitializerKey key = InitializerKey::Fabric;
 
     FabricFirmwareInitializer(
         std::shared_ptr<const ContextDescriptor> descriptor, tt::tt_fabric::ControlPlane& control_plane);

--- a/tt_metal/impl/device/firmware/fabric_firmware_initializer.hpp
+++ b/tt_metal/impl/device/firmware/fabric_firmware_initializer.hpp
@@ -1,0 +1,46 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "device/device_impl.hpp"
+#include "firmware_initializer.hpp"
+
+namespace tt::tt_fabric {
+class ControlPlane;
+}  // namespace tt::tt_fabric
+
+namespace tt::tt_metal {
+
+class FabricFirmwareInitializer final : public FirmwareInitializer {
+public:
+    static constexpr InitializerKey key() { return InitializerKey::Fabric; }
+
+    FabricFirmwareInitializer(
+        std::shared_ptr<const ContextDescriptor> descriptor, tt::tt_fabric::ControlPlane& control_plane);
+
+    void init(const std::vector<Device*>& devices, [[maybe_unused]] const std::unordered_set<InitializerKey>& init_done)
+        override;
+    void configure() override;
+    void teardown() override;
+    void post_teardown() override;
+    bool is_initialized() const override;
+
+private:
+    // Compile fabric on all devices, parallelized via async.
+    // Configure fabric sequentially (Galaxy hangs if parallelized).
+    void compile_and_configure_fabric();
+
+    // Wait for fabric router handshake on all devices.
+    void wait_for_fabric_router_sync(uint32_t timeout_ms) const;
+
+    // Compute the fabric router sync timeout from runtime options.
+    uint32_t get_fabric_router_sync_timeout_ms() const;
+
+    tt::tt_fabric::ControlPlane& control_plane_;
+    std::vector<Device*> devices_;
+    bool initialized_ = false;
+};
+
+}  // namespace tt::tt_metal

--- a/tt_metal/impl/device/firmware/firmware_initializer.cpp
+++ b/tt_metal/impl/device/firmware/firmware_initializer.cpp
@@ -1,0 +1,19 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "firmware_initializer.hpp"
+
+#include "impl/context/context_descriptor.hpp"
+
+namespace tt::tt_metal {
+
+FirmwareInitializer::FirmwareInitializer(std::shared_ptr<const ContextDescriptor> descriptor) :
+    hal_(descriptor->hal()),
+    cluster_(descriptor->cluster()),
+    rtoptions_(descriptor->rtoptions()),
+    descriptor_(std::move(descriptor)) {}
+
+void FirmwareInitializer::post_teardown() {}
+
+}  // namespace tt::tt_metal

--- a/tt_metal/impl/device/firmware/firmware_initializer.hpp
+++ b/tt_metal/impl/device/firmware/firmware_initializer.hpp
@@ -1,0 +1,57 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <memory>
+#include <vector>
+
+#include <llrt/rtoptions.hpp>
+
+#include "tt_metal/llrt/tt_cluster.hpp"
+#include "tt_metal/llrt/hal.hpp"
+
+namespace tt::tt_metal {
+
+class ContextDescriptor;
+class Device;
+
+enum class InitializerKey {
+    Profiler,
+    CommandQueue,
+    Fabric,
+    Dispatch,
+};
+
+class FirmwareInitializer {
+public:
+    explicit FirmwareInitializer(std::shared_ptr<const ContextDescriptor> descriptor);
+
+    virtual ~FirmwareInitializer() = default;
+
+    FirmwareInitializer(const FirmwareInitializer&) = delete;
+    FirmwareInitializer& operator=(const FirmwareInitializer&) = delete;
+    FirmwareInitializer(FirmwareInitializer&&) = delete;
+    FirmwareInitializer& operator=(FirmwareInitializer&&) = delete;
+
+    virtual void init(const std::vector<Device*>& devices, const std::unordered_set<InitializerKey>& init_done) = 0;
+
+    // This is called after all init calls have completed
+    virtual void configure() = 0;
+
+    virtual void teardown() = 0;
+
+    // This is called after all teardown calls have completed and devices have been closed
+    virtual void post_teardown();
+
+    virtual bool is_initialized() const = 0;
+
+protected:
+    const Hal& hal_;
+    Cluster& cluster_;
+    const llrt::RunTimeOptions& rtoptions_;
+    std::shared_ptr<const ContextDescriptor> descriptor_;
+};
+
+}  // namespace tt::tt_metal

--- a/tt_metal/impl/device/firmware/profiler_initializer.cpp
+++ b/tt_metal/impl/device/firmware/profiler_initializer.cpp
@@ -25,7 +25,8 @@ ProfilerInitializer::ProfilerInitializer(
     profiler_state_manager_(profiler_state_manager) {}
 
 void ProfilerInitializer::init(
-    const std::vector<Device*>& devices, [[maybe_unused]] const std::unordered_set<InitializerKey>& init_done) {
+    [[maybe_unused]] const std::vector<Device*>& devices,
+    [[maybe_unused]] const std::unordered_set<InitializerKey>& init_done) {
 #if defined(TRACY_ENABLE)
     devices_ = devices;
 

--- a/tt_metal/impl/device/firmware/profiler_initializer.cpp
+++ b/tt_metal/impl/device/firmware/profiler_initializer.cpp
@@ -1,0 +1,95 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "profiler_initializer.hpp"
+
+#include <tt-logger/tt-logger.hpp>
+#include <llrt/tt_cluster.hpp>
+#include <device.hpp>
+#include "device/device_impl.hpp"
+#include "impl/context/context_descriptor.hpp"
+
+#include <tt_metal_profiler.hpp>
+#include "profiler/profiler_state.hpp"
+#include "profiler/profiler_state_manager.hpp"
+
+namespace tt::tt_metal {
+
+ProfilerInitializer::ProfilerInitializer(
+    std::shared_ptr<const ContextDescriptor> descriptor,
+    bool skip_remote_devices,
+    ProfilerStateManager* profiler_state_manager) :
+    FirmwareInitializer(std::move(descriptor)),
+    skip_remote_devices_(skip_remote_devices),
+    profiler_state_manager_(profiler_state_manager) {}
+
+void ProfilerInitializer::init(
+    const std::vector<Device*>& devices, [[maybe_unused]] const std::unordered_set<InitializerKey>& init_done) {
+#if defined(TRACY_ENABLE)
+    devices_ = devices;
+
+    if (!getDeviceProfilerState()) {
+        return;
+    }
+
+    for (auto* dev : devices_) {
+        // For Galaxy init, we only need to loop over mmio devices
+        if (cluster_.get_associated_mmio_device(dev->id()) != dev->id()) {
+            continue;
+        }
+        auto tunnels_from_mmio = cluster_.get_tunnels_from_mmio_device(dev->id());
+        detail::InitDeviceProfiler(dev);
+        log_info(tt::LogMetal, "Profiler started on device {}", dev->id());
+        if (!skip_remote_devices_) {
+            for (const auto& tunnel : tunnels_from_mmio) {
+                // Need to create devices from farthest to the closest.
+                for (uint32_t ts = tunnel.size() - 1; ts > 0; ts--) {
+                    uint32_t mmio_controlled_device_id = tunnel[ts];
+                    auto it = std::find_if(devices_.begin(), devices_.end(), [&](Device* d) {
+                        return d->id() == mmio_controlled_device_id;
+                    });
+                    if (it != devices_.end()) {
+                        detail::InitDeviceProfiler(*it);
+                        log_info(tt::LogMetal, "Profiler started on remote device {}", (*it)->id());
+                    }
+                }
+            }
+        }
+    }
+    detail::ProfilerSync(ProfilerSyncState::INIT);
+
+    if (profiler_state_manager_ && rtoptions_.get_experimental_noc_debug_dump_enabled()) {
+        tt::tt_metal::LaunchIntervalBasedProfilerReadThread(std::vector<IDevice*>(devices_.begin(), devices_.end()));
+    }
+#endif
+
+    initialized_ = true;
+}
+
+void ProfilerInitializer::configure() {}
+
+void ProfilerInitializer::teardown() {
+    // Read profiler results from dispatch cores
+    for (auto* dev : devices_) {
+        detail::ReadDeviceProfilerResults(static_cast<IDevice*>(dev), ProfilerReadState::ONLY_DISPATCH_CORES);
+    }
+    detail::ProfilerSync(ProfilerSyncState::CLOSE_DEVICE);
+
+    devices_.clear();
+    initialized_ = false;
+}
+
+void ProfilerInitializer::post_teardown() {
+    if (getDeviceProfilerState()) {
+        // Device profiling data is dumped here instead of MetalContext::teardown() because MetalContext::teardown() is
+        // called as a std::atexit() function, and ProfilerStateManager::cleanup_device_profilers() cannot be safely
+        // called from a std::atexit() function because it creates new threads, which is unsafe during program
+        // termination.
+        profiler_state_manager_->cleanup_device_profilers();
+    }
+}
+
+bool ProfilerInitializer::is_initialized() const { return initialized_; }
+
+}  // namespace tt::tt_metal

--- a/tt_metal/impl/device/firmware/profiler_initializer.hpp
+++ b/tt_metal/impl/device/firmware/profiler_initializer.hpp
@@ -1,0 +1,35 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "firmware_initializer.hpp"
+
+namespace tt::tt_metal {
+
+struct ProfilerStateManager;
+
+class ProfilerInitializer final : public FirmwareInitializer {
+public:
+    static constexpr InitializerKey key() { return InitializerKey::Profiler; }
+
+    ProfilerInitializer(
+        std::shared_ptr<const ContextDescriptor> descriptor,
+        bool skip_remote_devices,
+        ProfilerStateManager* profiler_state_manager);
+
+    void init(const std::vector<Device*>& devices, const std::unordered_set<InitializerKey>& init_done) override;
+    void configure() override;
+    void teardown() override;
+    void post_teardown() override;
+    bool is_initialized() const override;
+
+private:
+    [[maybe_unused]] bool skip_remote_devices_;
+    [[maybe_unused]] ProfilerStateManager* profiler_state_manager_;
+    [[maybe_unused]] std::vector<Device*> devices_;
+    bool initialized_ = false;
+};
+
+}  // namespace tt::tt_metal

--- a/tt_metal/impl/device/firmware/profiler_initializer.hpp
+++ b/tt_metal/impl/device/firmware/profiler_initializer.hpp
@@ -12,7 +12,7 @@ struct ProfilerStateManager;
 
 class ProfilerInitializer final : public FirmwareInitializer {
 public:
-    static constexpr InitializerKey key() { return InitializerKey::Profiler; }
+    static constexpr InitializerKey key = InitializerKey::Profiler;
 
     ProfilerInitializer(
         std::shared_ptr<const ContextDescriptor> descriptor,


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/37247
https://github.com/tenstorrent/tt-metal/issues/37246

### Problem description
- Reduce the dependency on MetalContext
- Convoluted initialization logic spread across MetalContext and Device Manager

### What's changed
- Create a `ContextDescriptor` which includes all the relevant settings for the cluster such as num CQs, fabric mode
- Create an initialization interface `FirmwareInitializer` which has common init / teardown methods. It accepts a `ContextDescriptor` and Cluster/HAL/RuntimeOptions references in the constructor.
  - Transfer code from MetalContext/DeviceManager into `CommandQueueInitializer`, `DispatchFirmwareInitializer`, `FabricFirmwareInitializer`, `ProfilerInitializer`. 


### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=nhuang/split-init)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:nhuang/split-init)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=nhuang/split-init)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:nhuang/split-init)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nhuang/split-init)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nhuang/split-init)
- [ ] New/Existing tests provide coverage for changes

Multihost
https://github.com/tenstorrent/tt-metal/actions/runs/21922825008

Profiler
https://github.com/tenstorrent/tt-metal/actions/runs/21980271636

Merge Gate
https://github.com/tenstorrent/tt-metal/actions/runs/21980258094

#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:{{branch_name}})
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:{{branch_name}})
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:{{branch_name}})
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
