### PR TITLE
Add utility to generate Blitz Decode Scaleout Configs

### DIFF
--- a/models/demos/deepseek_v3_b1/scaleout_configs/blitz_decode_mesh_graph_descriptor.textproto
+++ b/models/demos/deepseek_v3_b1/scaleout_configs/blitz_decode_mesh_graph_descriptor.textproto
@@ -1,0 +1,112 @@
+# --- Meshes ---------------------------------------------------------------
+
+mesh_descriptors {
+  name: "M0"
+  arch: BLACKHOLE
+  device_topology { dims: [ 4, 2 ] }
+  host_topology   { dims: [ 1, 1 ] }
+  channels {
+    count: 2
+    policy: RELAXED
+  }
+}
+graph_descriptors {
+  name: "G0"
+  type: "FABRIC"
+  # Instances: mesh ids 0..1 (all 2x4)
+  instances { mesh { mesh_descriptor: "M0" mesh_id: 0 } }
+  instances { mesh { mesh_descriptor: "M0" mesh_id: 1 } }
+  instances { mesh { mesh_descriptor: "M0" mesh_id: 2 } }
+  instances { mesh { mesh_descriptor: "M0" mesh_id: 3 } }
+  instances { mesh { mesh_descriptor: "M0" mesh_id: 4 } }
+  instances { mesh { mesh_descriptor: "M0" mesh_id: 5 } }
+  instances { mesh { mesh_descriptor: "M0" mesh_id: 6 } }
+  instances { mesh { mesh_descriptor: "M0" mesh_id: 7 } }
+  instances { mesh { mesh_descriptor: "M0" mesh_id: 8 } }
+  instances { mesh { mesh_descriptor: "M0" mesh_id: 9 } }
+  instances { mesh { mesh_descriptor: "M0" mesh_id: 10 } }
+  instances { mesh { mesh_descriptor: "M0" mesh_id: 11 } }
+  instances { mesh { mesh_descriptor: "M0" mesh_id: 12 } }
+  instances { mesh { mesh_descriptor: "M0" mesh_id: 13 } }
+  instances { mesh { mesh_descriptor: "M0" mesh_id: 14 } }
+  instances { mesh { mesh_descriptor: "M0" mesh_id: 15 } }
+
+  connections {
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 0 } }
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 1 } }
+    channels { count: 8 policy: RELAXED }
+  }
+  connections {
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 1 } }
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 2 } }
+    channels { count: 8 policy: RELAXED }
+  }
+  connections {
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 2 } }
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 3 } }
+    channels { count: 8 policy: RELAXED }
+  }
+  connections {
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 3 } }
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 4 } }
+    channels { count: 8 policy: RELAXED }
+  }
+  connections {
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 4 } }
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 5 } }
+    channels { count: 8 policy: RELAXED }
+  }
+  connections {
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 5 } }
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 6 } }
+    channels { count: 8 policy: RELAXED }
+  }
+  connections {
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 6 } }
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 7 } }
+    channels { count: 8 policy: RELAXED }
+  }
+  connections {
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 7 } }
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 8 } }
+    channels { count: 8 policy: RELAXED }
+  }
+  connections {
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 8 } }
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 9 } }
+    channels { count: 8 policy: RELAXED }
+  }
+  connections {
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 9 } }
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 10 } }
+    channels { count: 8 policy: RELAXED }
+  }
+  connections {
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 10 } }
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 11 } }
+    channels { count: 8 policy: RELAXED }
+  }
+  connections {
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 11 } }
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 12 } }
+    channels { count: 8 policy: RELAXED }
+  }
+  connections {
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 12 } }
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 13 } }
+    channels { count: 8 policy: RELAXED }
+  }
+  connections {
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 13 } }
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 14 } }
+    channels { count: 8 policy: RELAXED }
+  }
+  connections {
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 14 } }
+    nodes { mesh { mesh_descriptor: "M0" mesh_id: 15 } }
+    channels { count: 8 policy: RELAXED }
+  }
+}
+
+# --- Instantiation ----------------------------------------------------------
+top_level_instance { graph { graph_descriptor: "G0" graph_id: 0 } }

--- a/models/demos/deepseek_v3_b1/scaleout_configs/blitz_pipeline_config.yaml
+++ b/models/demos/deepseek_v3_b1/scaleout_configs/blitz_pipeline_config.yaml
@@ -1,0 +1,55 @@
+# Maps each pipeline stage to a (host, slice) pair.
+
+stage_to_slice_mapping:
+  0:
+    host: bh-glx-d04u02
+    slice: 0
+  1:
+    host: bh-glx-d04u02
+    slice: 1
+  2:
+    host: bh-glx-d04u02
+    slice: 2
+  3:
+    host: bh-glx-d04u02
+    slice: 3
+  4:
+    host: bh-glx-d04u08
+    slice: 0
+  5:
+    host: bh-glx-d04u08
+    slice: 1
+  6:
+    host: bh-glx-d04u08
+    slice: 2
+  7:
+    host: bh-glx-d04u08
+    slice: 3
+  8:
+    host: bh-glx-d03u08
+    slice: 0
+  9:
+    host: bh-glx-d03u08
+    slice: 1
+  10:
+    host: bh-glx-d03u08
+    slice: 2
+  11:
+    host: bh-glx-d03u08
+    slice: 3
+  12:
+    host: bh-glx-d03u02
+    slice: 0
+  13:
+    host: bh-glx-d03u02
+    slice: 1
+  14:
+    host: bh-glx-d03u02
+    slice: 2
+  15:
+    host: bh-glx-d03u02
+    slice: 3
+
+mesh_graph_desc_path: models/demos/deepseek_v3_b1/scaleout_configs/blitz_decode_mesh_graph_descriptor.textproto
+rank_binding_file: blitz_decode_pipeline_rank_binding.yaml
+rank_file: blitz_decode_pipeline_rank_file

--- a/models/demos/deepseek_v3_b1/scaleout_configs/generate_blitz_decode_pipeline_configs.py
+++ b/models/demos/deepseek_v3_b1/scaleout_configs/generate_blitz_decode_pipeline_configs.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+import argparse
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import yaml
+from loguru import logger
+
+
+def generate_slice_to_pcie_device_mapping(mapping_file, host_vector):
+    # Use absolute path to the test executable
+    test_executable = Path("build/test/tt_metal/tt_fabric/test_physical_discovery")
+
+    if not test_executable.exists():
+        logger.error(f"Test executable not found at {test_executable}")
+        logger.info("Please build with: ./build_metal.sh --build-tests")
+        sys.exit(1)
+    host_vector_str = ",".join(host_vector)
+    MAPPING_GENERATION_CMD = [
+        "mpirun",
+        "--np",
+        str(len(host_vector)),
+        "--host",
+        host_vector_str,
+        "--mca",
+        "btl",
+        "self,tcp",
+        "--mca",
+        "btl_tcp_if_include",
+        "ens5f0np0",
+        "--bind-to",
+        "none",
+        "--tag-output",
+        str(test_executable),
+        "--gtest_filter=*Generate2x4SliceToPCIeDeviceMapping*",
+    ]
+
+    logger.info(f"Running: {' '.join(MAPPING_GENERATION_CMD)}")
+
+    try:
+        result = subprocess.run(MAPPING_GENERATION_CMD)
+        if result.returncode != 0:
+            logger.error(f"{MAPPING_GENERATION_CMD} Failed to generate slice to PCIe device mapping")
+            sys.exit(result.returncode)
+    except KeyboardInterrupt:
+        logger.error(f"{MAPPING_GENERATION_CMD} Interrupted")
+        sys.exit(1)
+
+    if not os.path.exists(mapping_file):
+        logger.error(f"{mapping_file} not found")
+        sys.exit(1)
+
+
+def generate_rank_bindings(pipeline_config, physical_mapping_file):
+    with open(physical_mapping_file, "r") as f:
+        slice_to_pcie_device_mapping = yaml.safe_load(f)
+
+    num_pipeline_stages = len(pipeline_config["stage_to_slice_mapping"])
+    rank_bindings = []
+
+    for stage in range(num_pipeline_stages):
+        if stage not in pipeline_config["stage_to_slice_mapping"]:
+            logger.error(f"Stage {stage} not found in stage to slice mapping. Please check the pipeline config file.")
+            sys.exit(1)
+        stage_host = pipeline_config["stage_to_slice_mapping"][stage]["host"]
+        stage_slice = pipeline_config["stage_to_slice_mapping"][stage]["slice"]
+        devices_for_stage = sorted(slice_to_pcie_device_mapping["device_mapping"][stage_host][stage_slice])
+        rank_bindings.append(
+            {
+                "rank": stage,
+                "mesh_id": stage,
+                "mesh_host_rank": 0,
+                "env_overrides": {"TT_VISIBLE_DEVICES": ",".join(map(str, devices_for_stage))},
+            }
+        )
+
+    rank_binding_configs = {
+        "rank_bindings": rank_bindings,
+        "mesh_graph_desc_path": pipeline_config["mesh_graph_desc_path"],
+    }
+    with open(pipeline_config["rank_binding_file"], "w") as f:
+        yaml.dump(rank_binding_configs, f, default_flow_style=False, sort_keys=False)
+
+
+def generate_rank_file(pipeline_config):
+    num_pipeline_stages = len(pipeline_config["stage_to_slice_mapping"])
+    with open(pipeline_config["rank_file"], "w") as f:
+        for stage in range(num_pipeline_stages):
+            host = pipeline_config["stage_to_slice_mapping"][stage]["host"]
+            f.write(f"rank {stage}={host} slot=0-31\n")
+
+
+def generate_pipeline_config_files(pipeline_config_file):
+    with open(pipeline_config_file, "r") as f:
+        config = yaml.safe_load(f)
+
+    host_vector = []
+    seen_hosts = set()
+    for entry in config["stage_to_slice_mapping"].values():
+        host = entry["host"]
+        if host not in seen_hosts:
+            host_vector.append(host)
+            seen_hosts.add(host)
+    # Generate the list of PCIe devices for each physical slice in the pipeline
+    # Metal generates the list of PCIe devices per physical slice in this file
+    # when generate_slice_to_pcie_device_mapping is called
+    physical_mapping_file = "slice_to_pcie_device_mapping.yaml"
+    generate_slice_to_pcie_device_mapping(physical_mapping_file, host_vector)
+    # Using the generated list of PCIe devices per slice and the stage to physical
+    # slice mapping, generate rank bindings for the pipeline
+    generate_rank_bindings(config, physical_mapping_file)
+
+    # Using the stage to physical slice mapping, generate the rank file for the pipeline
+    generate_rank_file(config)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Generate pipeline config files for blitz decode")
+    parser.add_argument("pipeline_config_file", type=str, help="Path to the pipeline config YAML file")
+    args = parser.parse_args()
+    generate_pipeline_config_files(args.pipeline_config_file)

--- a/tt_metal/fabric/physical_system_descriptor.hpp
+++ b/tt_metal/fabric/physical_system_descriptor.hpp
@@ -205,6 +205,15 @@ public:
     const std::unordered_map<std::string, uint32_t>& get_host_to_rank_map() const { return host_to_rank_; }
     const ExitNodeConnectionTable& get_exit_node_connection_table() const { return exit_node_connection_table_; }
     const tt::umd::semver_t& get_ethernet_firmware_version() const { return ethernet_firmware_version_; }
+    const std::unordered_map<std::string, std::unordered_map<uint32_t, std::unordered_set<uint32_t>>>&
+    get_pcie_devices_per_tray() const {
+        return pcie_devices_per_tray_;
+    }
+    const std::unordered_map<std::string, std::unordered_map<uint32_t, ASICLocation>>& get_pcie_id_to_asic_location()
+        const {
+        return pcie_id_to_asic_location_;
+    }
+
     tt::TargetDevice get_target_device_type() const { return target_device_type_; }
     LocalEthernetMetrics query_local_ethernet_metrics() const;
 
@@ -214,6 +223,13 @@ public:
     std::unordered_map<std::string, uint32_t>& get_host_to_rank_map() { return host_to_rank_; }
     ExitNodeConnectionTable& get_exit_node_connection_table() { return exit_node_connection_table_; }
     tt::umd::semver_t& get_ethernet_firmware_version() { return ethernet_firmware_version_; }
+    std::unordered_map<std::string, std::unordered_map<uint32_t, std::unordered_set<uint32_t>>>&
+    get_pcie_devices_per_tray() {
+        return pcie_devices_per_tray_;
+    }
+    std::unordered_map<std::string, std::unordered_map<uint32_t, ASICLocation>>& get_pcie_id_to_asic_location() {
+        return pcie_id_to_asic_location_;
+    }
 
     static const std::unique_ptr<tt::umd::Cluster> null_cluster;
 
@@ -221,9 +237,6 @@ public:
     void dump_to_yaml(const std::optional<std::string>& path_to_yaml = std::nullopt) const;
     YAML::Node generate_yaml_node() const;
     void emit_to_text_proto(const std::optional<std::string>& file_path = std::nullopt) const;
-    const std::unordered_map<uint32_t, std::unordered_set<uint32_t>>& get_pcie_devices_per_tray() const {
-        return pcie_devices_per_tray_;
-    }
 
 private:
     void run_local_discovery(bool run_live_discovery);
@@ -254,7 +267,8 @@ private:
     ExitNodeConnectionTable exit_node_connection_table_;
     bool all_hostnames_unique_ = true;
     tt::umd::semver_t ethernet_firmware_version_;
-    std::unordered_map<uint32_t, std::unordered_set<uint32_t>> pcie_devices_per_tray_;
+    std::unordered_map<std::string, std::unordered_map<uint32_t, std::unordered_set<uint32_t>>> pcie_devices_per_tray_;
+    std::unordered_map<std::string, std::unordered_map<uint32_t, ASICLocation>> pcie_id_to_asic_location_;
 };
 
 }  // namespace tt::tt_metal

--- a/tt_metal/fabric/protobuf/physical_system_descriptor.proto
+++ b/tt_metal/fabric/protobuf/physical_system_descriptor.proto
@@ -96,6 +96,30 @@ message EthernetFirmwareVersion {
     uint32 patch = 3;
 }
 
+// PCIe devices per tray for a specific host
+message PcieDevicesPerTray {
+    uint32 tray_id = 1;
+    repeated uint32 pcie_device_ids = 2;
+}
+
+// Map entry for host to PCIe devices per tray
+message HostPcieDevicesMap {
+    string host_name = 1;
+    repeated PcieDevicesPerTray pcie_devices_per_tray = 2;
+}
+
+// PCIe ID to ASIC location mapping entry
+message PcieIdToAsicLocation {
+    uint32 pcie_id = 1;
+    uint32 asic_location = 2;
+}
+
+// Map entry for host to PCIe ID to ASIC location mappings
+message HostPcieIdToAsicLocationMap {
+    string host_name = 1;
+    repeated PcieIdToAsicLocation pcie_id_to_asic_location = 2;
+}
+
 // Top-level Physical System Descriptor message
 message PhysicalSystemDescriptor {
     PhysicalConnectivityGraph system_graph = 1;
@@ -105,4 +129,6 @@ message PhysicalSystemDescriptor {
     repeated ExitNodeConnectionTable exit_node_connection_table = 5;
     uint32 target_device_type = 6;
     EthernetFirmwareVersion ethernet_firmware_version = 7;
+    repeated HostPcieDevicesMap pcie_devices_per_tray = 8;
+    repeated HostPcieIdToAsicLocationMap pcie_id_to_asic_location = 9;
 }


### PR DESCRIPTION
### Ticket
No Ticket.

### Problem description
- Blitz Decode will require a 61+ stage pipeline across 16 hosts. Each host can have up t0 4 pipeline stages
- Managing Rank Files, Rank Binding Files and Mesh Graph Descriptors for this use case is extremely error prone
- We must be able to encode our pipeline layout in a top level config file

### What's changed
- Add `generate_blitz_decode_pipeline_configs.py` to generate rankfiles and rank binding files based on a pipeline config file that a user specifies
- Pipeline Config currently looks like this:

```
stage_to_slice_mapping:
  0:
    host: bh-glx-d04u02
    slice: 0
  1:
    host: bh-glx-d04u02
    slice: 1
  2:
    host: bh-glx-d04u02
    slice: 2
.....

mesh_graph_desc_path: models/demos/deepseek_v3_b1/scaleout_configs/blitz_decode_mesh_graph_descriptor.textproto
rank_binding_file: blitz_decode_pipeline_rank_binding.yaml
rank_file: blitz_decode_pipeline_rank_file
```
- Note that this specifies how pipeline stages are physically mapped to each host
- Also note that a user needs to manually generate and specify an MGD. Next step will be to automate the generation of the MGD
 


### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=asaigal/pipeline_device_isolation)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:asaigal/pipeline_device_isolation)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=asaigal/pipeline_device_isolation)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:asaigal/pipeline_device_isolation)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=asaigal/pipeline_device_isolation)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:asaigal/pipeline_device_isolation)
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=asaigal/pipeline_device_isolation)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:asaigal/pipeline_device_isolation)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=asaigal/pipeline_device_isolation)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:asaigal/pipeline_device_isolation)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=asaigal/pipeline_device_isolation)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:asaigal/pipeline_device_isolation)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
