### PR TITLE
LLK API support for 8x32 tilize

### DIFF
--- a/models/demos/deepseek_v3_b1/micro_ops/tilize_8x32/kernels/tilize_8x32_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/micro_ops/tilize_8x32/kernels/tilize_8x32_kernel.cpp
@@ -12,23 +12,12 @@ void kernel_main() {
 #if defined(COMPILE_FOR_TRISC)
     constexpr uint32_t in_cb = get_named_compile_time_arg_val("in_cb");
     constexpr uint32_t out_cb = get_named_compile_time_arg_val("out_cb");
-    constexpr uint32_t num_blocks = get_named_compile_time_arg_val("num_blocks");
     constexpr uint32_t block_size = get_named_compile_time_arg_val("block_size");
 
     compute_kernel_hw_startup(in_cb, out_cb);
     tilize_init(in_cb, block_size, out_cb);
 
-    for (uint32_t i = 0; i < num_blocks; i++) {
-        // DPRINT << "BEFORE WAIT FRONT" << ENDL();
-        // cb_wait_front(in_cb, block_size);
-        // DPRINT << "AFTER WAIT FRONT" << ENDL();
-        // cb_reserve_back(out_cb, block_size);
-        // DPRINT << "AFTER RESERVE BACK" << ENDL();
-        tilize_block(in_cb, block_size, out_cb);
-        // DPRINT << "AFTER TILIZE BLOCK" << ENDL();
-        // cb_push_back(out_cb, block_size);
-        // DPRINT << "AFTER PUSH BACK" << ENDL();
-        cb_pop_front(in_cb, block_size);
-    }
+    tilize_block(in_cb, block_size, out_cb);
+    cb_pop_front(in_cb, block_size);
 #endif
 }

--- a/models/demos/deepseek_v3_b1/micro_ops/tilize_8x32/kernels/tilize_8x32_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/micro_ops/tilize_8x32/kernels/tilize_8x32_kernel.cpp
@@ -1,0 +1,34 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+// SPDX-License-Identifier: Apache-2.0
+
+#include "../../../unified_kernels/kernel_op_api.hpp"
+#include "../../../unified_kernels/kernel_utils.hpp"
+
+#if defined(COMPILE_FOR_TRISC)
+#include "api/compute/tilize.h"
+#endif
+
+void kernel_main() {
+#if defined(COMPILE_FOR_TRISC)
+    constexpr uint32_t in_cb = get_named_compile_time_arg_val("in_cb");
+    constexpr uint32_t out_cb = get_named_compile_time_arg_val("out_cb");
+    constexpr uint32_t num_blocks = get_named_compile_time_arg_val("num_blocks");
+    constexpr uint32_t block_size = get_named_compile_time_arg_val("block_size");
+
+    compute_kernel_hw_startup(in_cb, out_cb);
+    tilize_init(in_cb, block_size, out_cb);
+
+    for (uint32_t i = 0; i < num_blocks; i++) {
+        // DPRINT << "BEFORE WAIT FRONT" << ENDL();
+        // cb_wait_front(in_cb, block_size);
+        // DPRINT << "AFTER WAIT FRONT" << ENDL();
+        // cb_reserve_back(out_cb, block_size);
+        // DPRINT << "AFTER RESERVE BACK" << ENDL();
+        tilize_block(in_cb, block_size, out_cb);
+        // DPRINT << "AFTER TILIZE BLOCK" << ENDL();
+        // cb_push_back(out_cb, block_size);
+        // DPRINT << "AFTER PUSH BACK" << ENDL();
+        cb_pop_front(in_cb, block_size);
+    }
+#endif
+}

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_tilize_8x32.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_tilize_8x32.py
@@ -1,0 +1,109 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+TTNN Tilize 8x32 Test - Single Core
+Tests tilize operation for 8xN tensors, tiling into 8x32 blocks.
+
+Input: Row-major 8xN tensor
+Output: Tiled 8xN tensor (tiled into 8x32 blocks)
+"""
+
+import pytest
+import torch
+from loguru import logger
+
+import ttnn
+from models.common.utility_functions import comp_pcc
+from models.demos.deepseek_v3_b1.micro_ops.tilize_8x32.op import golden, tilize_8x32_kernel
+
+
+@pytest.mark.parametrize("N", [256, 64])
+@pytest.mark.parametrize("pcc", [0.999])
+def test_tilize_8x32(device, N, pcc):
+    """
+    Test tilize operation: row-major 8xN tensor -> tiled 8x32 blocks.
+
+    Args:
+        device: TTNN device
+        N: Width dimension (must be divisible by 32)
+        pcc: PCC threshold for validation
+    """
+    torch.manual_seed(42)
+
+    H = 8
+    input_shape = (H, N)
+    logger.info(f"Testing tilize 8x32 with input shape {input_shape}")
+
+    # Create input tensor in row-major format
+    torch_input = torch.randn(input_shape, dtype=torch.bfloat16)
+
+    # Single core
+    core = ttnn.CoreCoord(0, 0)
+    core_grid = ttnn.CoreRangeSet({ttnn.CoreRange(core, core)})
+
+    # Create HEIGHT_SHARDED memory config for input
+    input_shard_shape = (H, N)
+    input_shard_spec = ttnn.ShardSpec(
+        core_grid,
+        input_shard_shape,
+        ttnn.ShardOrientation.ROW_MAJOR,
+    )
+    input_mem_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, input_shard_spec)
+
+    # Input tile: 8x32 - represents the logical tile size
+    # The data is in row-major format before tilizing
+    input_tile = ttnn.Tile((8, 32))
+
+    # Create input tensor - use ROW_MAJOR_LAYOUT since tilize_block expects row-major input
+    # The tilize_block kernel will convert from row-major to tiled format
+    ttnn_input = ttnn.from_torch(
+        torch_input,
+        dtype=ttnn.bfloat16,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        device=device,
+        memory_config=input_mem_config,
+        tile=input_tile,
+    )
+
+    logger.info(f"Created input tensor with shard shape {input_shard_shape}")
+
+    # Create output tensor in tiled format
+    output_shard_shape = (H, N)
+    output_shard_spec = ttnn.ShardSpec(
+        core_grid,
+        output_shard_shape,
+        ttnn.ShardOrientation.ROW_MAJOR,
+    )
+    output_mem_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, output_shard_spec)
+
+    # Output tile: 8x32 (tiled format)
+    output_tile = ttnn.Tile((8, 32))
+
+    # Create output tensor (will be filled by kernel)
+    torch_output_zeros = torch.zeros(input_shape, dtype=torch.bfloat16)
+    ttnn_output = ttnn.from_torch(
+        torch_output_zeros,
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        memory_config=output_mem_config,
+        tile=output_tile,
+    )
+
+    # Run tilize kernel
+    ttnn_output = tilize_8x32_kernel(ttnn_input, ttnn_output)
+
+    # Read back output
+    tt_out_torch = ttnn.to_torch(ttnn_output)
+
+    # Compute reference using golden function
+    ref_output = golden(torch_input)
+
+    # Compare results
+    passing, pcc_msg = comp_pcc(ref_output, tt_out_torch, pcc)
+    logger.info(pcc_msg)
+    assert passing, f"PCC check failed: {pcc_msg}"
+
+    logger.info("✓ Tilize 8x32 test passed!")

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_tilize_8x32.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_tilize_8x32.py
@@ -20,15 +20,13 @@ from models.demos.deepseek_v3_b1.micro_ops.tilize_8x32.op import golden, tilize_
 
 
 @pytest.mark.parametrize("N", [256, 64])
-@pytest.mark.parametrize("pcc", [0.999])
-def test_tilize_8x32(device, N, pcc):
+def test_tilize_8x32(device, N):
     """
     Test tilize operation: row-major 8xN tensor -> tiled 8x32 blocks.
 
     Args:
         device: TTNN device
         N: Width dimension (must be divisible by 32)
-        pcc: PCC threshold for validation
     """
     torch.manual_seed(42)
 
@@ -102,8 +100,9 @@ def test_tilize_8x32(device, N, pcc):
     ref_output = golden(torch_input)
 
     # Compare results
-    passing, pcc_msg = comp_pcc(ref_output, tt_out_torch, pcc)
+    passing, pcc_msg = comp_pcc(ref_output, tt_out_torch, 0.999)
     logger.info(pcc_msg)
     assert passing, f"PCC check failed: {pcc_msg}"
 
-    logger.info("✓ Tilize 8x32 test passed!")
+    if passing:
+        logger.info("✓ Tilize 8x32 test passed!")

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_tilize_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_tilize_api.h
@@ -21,9 +21,9 @@ inline void llk_unpack_tilize_init(const std::uint32_t operand, const std::uint3
     const std::uint32_t operand_id = get_operand_id(operand);
     const std::uint32_t face_r_dim = get_operand_face_r_dim(operand_id);
     const bool narrow_tile = get_operand_narrow_tile(operand_id);
-
+    const std::uint32_t num_faces = get_operand_num_faces(operand_id);
     _llk_unpack_tilize_init_(
-        unpack_src_format[operand_id], unpack_dst_format[operand_id], ct_dim, face_r_dim, narrow_tile);
+        unpack_src_format[operand_id], unpack_dst_format[operand_id], ct_dim, face_r_dim, narrow_tile, num_faces);
 }
 
 inline void llk_unpack_tilize_uninit(const std::uint32_t operand, const std::uint32_t face_r_dim = FACE_R_DIM) {


### PR DESCRIPTION
### Ticket
#37385 

### Problem description
Tilize algorithm in _llk_unpack_tilize_ is designed to work for a full tile (32x32 datums).
In order to support Deepseek efforts, the request is to make the algorithm work for 8x32 tiles.

### What's changed

- [A PR on the LLK side](https://github.com/tenstorrent/tt-llk/pull/1263)
- LLK API changes (added `num_faces` to init function)
- Unit test added by @ssundaramTT 

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=pmilenkovic/8x32-support-for-tilize)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:pmilenkovic/8x32-support-for-tilize)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=pmilenkovic/8x32-support-for-tilize)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:pmilenkovic/8x32-support-for-tilize)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=pmilenkovic/8x32-support-for-tilize)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:pmilenkovic/8x32-support-for-tilize)
- [ ] New/Existing tests provide coverage for changes
