### PR TITLE
[tt-train] Add training log comparison plotting script

### DIFF
--- a/tt-train/docs/TRAINING_LOG_COMPARISON.md
+++ b/tt-train/docs/TRAINING_LOG_COMPARISON.md
@@ -1,0 +1,190 @@
+# Training Log Comparison Analysis
+
+> **Quick start:**
+> 1. Run your training binary multiple times with different configurations
+> 2. Save the logs to text files (e.g., `baseline.txt`, `optimized.txt`)
+> 3. Run `python scripts/plot_training_comparison.py --baseline baseline.txt --compare optimized.txt`
+
+---
+
+## Table of Contents
+
+1. [Purpose](#purpose)
+2. [Prerequisites](#prerequisites)
+3. [Log Format](#log-format)
+4. [Usage](#usage)
+5. [Output](#output)
+6. [Example Workflow](#example-workflow)
+
+---
+
+## Purpose
+
+This tool helps evaluate the impact of kernel optimizations, fusion strategies, or configuration changes in tt-train by:
+
+- **Comparing training loss curves** across multiple runs
+- **Visualizing loss differences** relative to a baseline
+- **Analyzing step time performance** to measure speedups
+- **Computing summary statistics** (mean step time, speedup factors, final loss)
+
+Use this when you've made changes to kernels (e.g., fusing operations) and want to verify:
+1. The optimization doesn't degrade training quality (loss should match or improve)
+2. The optimization improves performance (step time should decrease)
+
+---
+
+## Prerequisites
+
+| Requirement | Version | Notes |
+|-------------|---------|-------|
+| Python | 3.10+ | Via `create_venv.sh` |
+| NumPy | - | Included in dev dependencies |
+| Matplotlib | - | Included in dev dependencies |
+
+> **Note:** All dependencies are installed automatically when you run `create_venv.sh`.
+
+---
+
+## Log Format
+
+The script expects log files from tt-train's main training binary (e.g., `nano_gpt`). The logs should contain lines in the following format:
+
+```
+Step: 1, Loss: 11.0234375
+Full step time 703.141 ms
+Step: 2, Loss: 10.8765432
+Full step time 698.234 ms
+...
+```
+
+The script extracts:
+- **Loss values**: From lines matching `Step: \d+, Loss: ([\d.]+)`
+- **Step times**: From lines matching `Full step time ([\d.]+) ms`
+
+---
+
+## Usage
+
+### Basic Comparison
+
+Compare a baseline run against an optimized version:
+
+```bash
+python scripts/plot_training_comparison.py \
+    --baseline run_baseline.txt \
+    --compare run_optimized.txt
+```
+
+### Multiple Comparisons with Labels
+
+Compare multiple optimization strategies:
+
+```bash
+python scripts/plot_training_comparison.py \
+    --baseline fw_only.txt \
+    --compare fw_bw_3_packs.txt fw_bw_4_packs.txt \
+    --labels "Forward Only" "FW+BW 3 Packs" "FW+BW 4 Packs"
+```
+
+### Customization Options
+
+```bash
+python scripts/plot_training_comparison.py \
+    --baseline baseline.txt \
+    --compare optimized.txt \
+    --output-dir ./plots \
+    --warmup-steps 20 \
+    --max-steps 5000 \
+    --title-prefix "NanoLlama SiLU "
+```
+
+### All Options
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `--baseline` | (required) | Path to baseline log file |
+| `--compare` | `[]` | Paths to log files to compare |
+| `--labels` | filenames | Custom labels for each run |
+| `--output-dir` | `.` | Directory for output plots |
+| `--warmup-steps` | `15` | Steps to skip for timing analysis |
+| `--max-steps` | all | Limit steps in loss plots |
+| `--title-prefix` | `""` | Prefix for plot titles |
+
+---
+
+## Output
+
+The script generates three plots:
+
+### 1. `losses.png` - Loss Comparison
+Shows training loss curves for all runs overlaid. Useful for verifying that optimizations don't degrade convergence.
+
+### 2. `losses_diff.png` - Loss Difference
+Shows the difference in loss between each compared run and the baseline. Values near zero indicate equivalent training quality.
+
+### 3. `step_time.png` - Step Time Comparison
+Shows per-step execution time for all runs. Lower is better.
+
+### Console Output
+
+The script also prints summary statistics:
+
+```
+SUMMARY STATISTICS
+============================================================
+
+Mean Step Times:
+  baseline: 703.14 ms (std: 12.34 ms)
+  optimized: 650.22 ms (std: 10.56 ms)
+
+Speedup relative to 'baseline':
+  optimized: 1.081x
+
+Final Loss (last 100 steps average):
+  baseline: 3.456789
+  optimized: 3.456123
+```
+
+---
+
+## Example Workflow
+
+### Evaluating a SiLU Kernel Fusion
+
+1. **Run baseline training:**
+   ```bash
+   ./build/tt-train/sources/examples/nano_gpt/nano_gpt > baseline.txt 2>&1
+   ```
+
+2. **Apply your kernel optimization and rebuild:**
+   ```bash
+   ./build_metal.sh -b Release --build-tt-train
+   ```
+
+3. **Run optimized training:**
+   ```bash
+   ./build/tt-train/sources/examples/nano_gpt/nano_gpt > optimized.txt 2>&1
+   ```
+
+4. **Compare results:**
+   ```bash
+   python scripts/plot_training_comparison.py \
+       --baseline baseline.txt \
+       --compare optimized.txt \
+       --labels "Baseline" "SiLU Fused" \
+       --output-dir ./silu_comparison \
+       --title-prefix "SiLU Fusion: "
+   ```
+
+5. **Review:**
+   - Check `losses.png` - curves should overlap closely
+   - Check `losses_diff.png` - differences should be near zero
+   - Check `step_time.png` - optimized should be faster
+   - Review printed speedup factor
+
+---
+
+## See Also
+
+- [PROFILER.md](PROFILER.md) - Detailed kernel-level profiling
+- [MEMORY_TRACKING.md](MEMORY_TRACKING.md) - Memory usage analysis

--- a/tt-train/docs/TRAINING_LOG_COMPARISON.md
+++ b/tt-train/docs/TRAINING_LOG_COMPARISON.md
@@ -3,7 +3,7 @@
 > **Quick start:**
 > 1. Run your training binary multiple times with different configurations
 > 2. Save the logs to text files (e.g., `baseline.txt`, `optimized.txt`)
-> 3. Run `python scripts/plot_training_comparison.py --baseline baseline.txt --compare optimized.txt`
+> 3. Run `python tt-train/scripts/plot_training_comparison.py --baseline baseline.txt --compare optimized.txt`
 
 ---
 
@@ -70,7 +70,7 @@ The script extracts:
 Compare a baseline run against an optimized version:
 
 ```bash
-python scripts/plot_training_comparison.py \
+python tt-train/scripts/plot_training_comparison.py \
     --baseline run_baseline.txt \
     --compare run_optimized.txt
 ```
@@ -80,7 +80,7 @@ python scripts/plot_training_comparison.py \
 Compare multiple optimization strategies:
 
 ```bash
-python scripts/plot_training_comparison.py \
+python tt-train/scripts/plot_training_comparison.py \
     --baseline fw_only.txt \
     --compare fw_bw_3_packs.txt fw_bw_4_packs.txt \
     --labels "Forward Only" "FW+BW 3 Packs" "FW+BW 4 Packs"
@@ -89,7 +89,7 @@ python scripts/plot_training_comparison.py \
 ### Customization Options
 
 ```bash
-python scripts/plot_training_comparison.py \
+python tt-train/scripts/plot_training_comparison.py \
     --baseline baseline.txt \
     --compare optimized.txt \
     --output-dir ./plots \
@@ -168,7 +168,7 @@ Final Loss (last 100 steps average):
 
 4. **Compare results:**
    ```bash
-   python scripts/plot_training_comparison.py \
+   python tt-train/scripts/plot_training_comparison.py \
        --baseline baseline.txt \
        --compare optimized.txt \
        --labels "Baseline" "SiLU Fused" \

--- a/tt-train/scripts/plot_training_comparison.py
+++ b/tt-train/scripts/plot_training_comparison.py
@@ -1,0 +1,337 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+"""
+Training log comparison and visualization script.
+
+This script parses log files from tt-train's main training binary (e.g., nano_gpt)
+and generates comparison plots for:
+  - Training loss curves
+  - Loss differences between runs (relative to a baseline)
+  - Step time performance
+
+This is useful for evaluating kernel optimizations, fusion strategies, or
+configuration changes by comparing multiple training runs side-by-side.
+
+Usage:
+    python plot_training_comparison.py --baseline run_baseline.txt --compare run_optimized.txt run_fused.txt \\
+        --labels baseline optimized fused --output-dir ./plots
+
+Expected log format:
+    The script expects log files containing lines like:
+        "Full step time 703.141 ms"
+        "Step: 1, Loss: 11.0234375"
+"""
+
+import argparse
+import re
+import sys
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+import matplotlib.pyplot as plt
+import numpy as np
+
+
+def parse_log(filepath: str, warmup_steps: int = 15) -> Tuple[List[float], List[float]]:
+    """
+    Parse a training log file and extract step times and losses.
+
+    Args:
+        filepath: Path to the log file
+        warmup_steps: Number of initial steps to skip for step time statistics
+                      (warmup steps may have unreliable timing)
+
+    Returns:
+        Tuple of (step_times, losses) lists
+    """
+    with open(filepath, "r") as f:
+        lines = f.readlines()
+
+    step_times = []
+    losses = []
+
+    for line in lines:
+        # Match full step time: "Full step time 703.141 ms"
+        step_time_match = re.search(r"Full step time ([\d.]+) ms", line)
+        if step_time_match:
+            step_times.append(float(step_time_match.group(1)))
+
+        # Match losses: "Step: 1, Loss: 11.0234375"
+        loss_match = re.search(r"Step: \d+, Loss: ([\d.]+)", line)
+        if loss_match:
+            losses.append(float(loss_match.group(1)))
+
+    # Skip warmup steps for step time analysis
+    step_times = step_times[warmup_steps:]
+
+    return step_times, losses
+
+
+def print_statistics(all_data: Dict[str, Dict[str, List[float]]]) -> None:
+    """Print summary statistics for all runs."""
+    print("\n" + "=" * 60)
+    print("SUMMARY STATISTICS")
+    print("=" * 60)
+
+    print("\nMean Step Times:")
+    for name, data in all_data.items():
+        if data["step_times"]:
+            mean_time = np.mean(data["step_times"])
+            std_time = np.std(data["step_times"])
+            print(f"  {name}: {mean_time:.2f} ms (std: {std_time:.2f} ms)")
+
+    # Find baseline for speedup calculation
+    names = list(all_data.keys())
+    if len(names) > 1:
+        baseline_name = names[0]
+        baseline_time = np.mean(all_data[baseline_name]["step_times"])
+        print(f"\nSpeedup relative to '{baseline_name}':")
+        for name, data in all_data.items():
+            if name != baseline_name and data["step_times"]:
+                mean_time = np.mean(data["step_times"])
+                speedup = baseline_time / mean_time
+                print(f"  {name}: {speedup:.3f}x")
+
+    print("\nFinal Loss (last 100 steps average):")
+    for name, data in all_data.items():
+        if len(data["losses"]) >= 100:
+            final_loss = np.mean(data["losses"][-100:])
+            print(f"  {name}: {final_loss:.6f}")
+        elif data["losses"]:
+            final_loss = np.mean(data["losses"])
+            print(f"  {name}: {final_loss:.6f} (all {len(data['losses'])} steps)")
+
+
+def plot_loss_comparison(
+    all_data: Dict[str, Dict[str, List[float]]],
+    output_path: Path,
+    title_prefix: str = "",
+    max_steps: Optional[int] = None,
+) -> None:
+    """Plot loss curves for all runs."""
+    plt.figure(figsize=(20, 10))
+
+    for name, data in all_data.items():
+        losses = data["losses"]
+        if max_steps:
+            losses = losses[:max_steps]
+        plt.plot(losses, label=name, linewidth=2)
+
+    title = (
+        f"{title_prefix}Loss Comparison: All Runs"
+        if title_prefix
+        else "Loss Comparison: All Runs"
+    )
+    plt.title(title, fontsize=20)
+    plt.xlabel("Step", fontsize=16)
+    plt.ylabel("Loss", fontsize=16)
+    plt.legend(fontsize=14)
+    plt.grid(True)
+    plt.tick_params(axis="both", which="major", labelsize=14)
+
+    output_file = output_path / "losses.png"
+    plt.savefig(output_file, dpi=150, bbox_inches="tight")
+    plt.close()
+    print(f"Saved: {output_file}")
+
+
+def plot_loss_difference(
+    all_data: Dict[str, Dict[str, List[float]]],
+    baseline_name: str,
+    output_path: Path,
+    title_prefix: str = "",
+    max_steps: Optional[int] = None,
+) -> None:
+    """Plot loss differences relative to baseline."""
+    if baseline_name not in all_data:
+        print(
+            f"Warning: Baseline '{baseline_name}' not found, skipping loss difference plot"
+        )
+        return
+
+    baseline_losses = all_data[baseline_name]["losses"]
+    if max_steps:
+        baseline_losses = baseline_losses[:max_steps]
+
+    plt.figure(figsize=(20, 10))
+
+    for name, data in all_data.items():
+        if name != baseline_name:
+            losses = data["losses"]
+            if max_steps:
+                losses = losses[:max_steps]
+
+            # Ensure same length for comparison
+            min_len = min(len(losses), len(baseline_losses))
+            loss_diff = np.array(losses[:min_len]) - np.array(baseline_losses[:min_len])
+            plt.plot(loss_diff, label=f"{name} vs {baseline_name}", linewidth=2)
+
+    title = (
+        f"{title_prefix}Loss Difference: Compared Runs vs Baseline"
+        if title_prefix
+        else "Loss Difference: Compared Runs vs Baseline"
+    )
+    plt.title(title, fontsize=20)
+    plt.xlabel("Step", fontsize=16)
+    plt.ylabel("Loss Difference", fontsize=16)
+    plt.legend(fontsize=14)
+    plt.grid(True)
+    plt.tick_params(axis="both", which="major", labelsize=14)
+
+    output_file = output_path / "losses_diff.png"
+    plt.savefig(output_file, dpi=150, bbox_inches="tight")
+    plt.close()
+    print(f"Saved: {output_file}")
+
+
+def plot_step_time(
+    all_data: Dict[str, Dict[str, List[float]]],
+    output_path: Path,
+    title_prefix: str = "",
+) -> None:
+    """Plot step time comparison."""
+    plt.figure(figsize=(20, 10))
+
+    for name, data in all_data.items():
+        step_times = data["step_times"]
+        if step_times:
+            steps = range(len(step_times))
+            plt.plot(steps, step_times, label=name, linewidth=2)
+
+    title = (
+        f"{title_prefix}Step Time Comparison"
+        if title_prefix
+        else "Step Time Comparison"
+    )
+    plt.title(title, fontsize=20)
+    plt.xlabel("Step (after warmup)", fontsize=16)
+    plt.ylabel("Time (ms)", fontsize=16)
+    plt.legend(fontsize=14)
+    plt.grid(True)
+    plt.tick_params(axis="both", which="major", labelsize=14)
+
+    output_file = output_path / "step_time.png"
+    plt.savefig(output_file, dpi=150, bbox_inches="tight")
+    plt.close()
+    print(f"Saved: {output_file}")
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Compare training logs and generate comparison plots.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+    # Compare baseline against optimized version
+    python plot_training_comparison.py --baseline run_baseline.txt --compare run_optimized.txt
+
+    # Compare multiple runs with custom labels
+    python plot_training_comparison.py --baseline baseline.txt \\
+        --compare fusion_v1.txt fusion_v2.txt \\
+        --labels baseline fusion-v1 fusion-v2 \\
+        --title-prefix "SiLU Kernel "
+
+    # Specify output directory and limit steps
+    python plot_training_comparison.py --baseline run1.txt --compare run2.txt \\
+        --output-dir ./my_plots --max-steps 5000
+        """,
+    )
+
+    parser.add_argument(
+        "--baseline",
+        required=True,
+        help="Path to baseline log file (used as reference for comparisons)",
+    )
+    parser.add_argument(
+        "--compare",
+        nargs="+",
+        default=[],
+        help="Paths to log files to compare against baseline",
+    )
+    parser.add_argument(
+        "--labels",
+        nargs="+",
+        help="Labels for the runs (baseline first, then compare runs). "
+        "If not provided, filenames are used.",
+    )
+    parser.add_argument(
+        "--output-dir",
+        default=".",
+        help="Directory to save output plots (default: current directory)",
+    )
+    parser.add_argument(
+        "--warmup-steps",
+        type=int,
+        default=15,
+        help="Number of warmup steps to skip for step time analysis (default: 15)",
+    )
+    parser.add_argument(
+        "--max-steps",
+        type=int,
+        default=None,
+        help="Maximum number of steps to include in loss plots (default: all)",
+    )
+    parser.add_argument(
+        "--title-prefix",
+        default="",
+        help="Prefix for plot titles (e.g., 'NanoLlama SiLU ')",
+    )
+
+    args = parser.parse_args()
+
+    # Collect all log files
+    all_files = [args.baseline] + args.compare
+
+    # Generate labels
+    if args.labels:
+        if len(args.labels) != len(all_files):
+            print(
+                f"Error: Number of labels ({len(args.labels)}) must match "
+                f"number of files ({len(all_files)})"
+            )
+            sys.exit(1)
+        labels = args.labels
+    else:
+        labels = [Path(f).stem for f in all_files]
+
+    # Parse all log files
+    print("Parsing log files...")
+    all_data = {}
+    for filepath, label in zip(all_files, labels):
+        if not Path(filepath).exists():
+            print(f"Warning: File not found: {filepath}")
+            continue
+
+        step_times, losses = parse_log(filepath, args.warmup_steps)
+        all_data[label] = {"step_times": step_times, "losses": losses}
+        print(f"  {label}: {len(losses)} loss values, {len(step_times)} step times")
+
+    if not all_data:
+        print("Error: No valid log files found")
+        sys.exit(1)
+
+    # Print statistics
+    print_statistics(all_data)
+
+    # Create output directory
+    output_path = Path(args.output_dir)
+    output_path.mkdir(parents=True, exist_ok=True)
+
+    # Generate plots
+    print("\nGenerating plots...")
+    baseline_label = labels[0]
+
+    plot_loss_comparison(all_data, output_path, args.title_prefix, args.max_steps)
+    plot_step_time(all_data, output_path, args.title_prefix)
+
+    if len(all_data) > 1:
+        plot_loss_difference(
+            all_data, baseline_label, output_path, args.title_prefix, args.max_steps
+        )
+
+    print("\nDone!")
+
+
+if __name__ == "__main__":
+    main()

--- a/tt-train/scripts/plot_training_comparison.py
+++ b/tt-train/scripts/plot_training_comparison.py
@@ -85,13 +85,14 @@ def print_statistics(all_data: Dict[str, Dict[str, List[float]]]) -> None:
     names = list(all_data.keys())
     if len(names) > 1:
         baseline_name = names[0]
-        baseline_time = np.mean(all_data[baseline_name]["step_times"])
-        print(f"\nSpeedup relative to '{baseline_name}':")
-        for name, data in all_data.items():
-            if name != baseline_name and data["step_times"]:
-                mean_time = np.mean(data["step_times"])
-                speedup = baseline_time / mean_time
-                print(f"  {name}: {speedup:.3f}x")
+        if all_data[baseline_name]["step_times"]:
+            baseline_time = np.mean(all_data[baseline_name]["step_times"])
+            print(f"\nSpeedup relative to '{baseline_name}':")
+            for name, data in all_data.items():
+                if name != baseline_name and data["step_times"]:
+                    mean_time = np.mean(data["step_times"])
+                    speedup = baseline_time / mean_time
+                    print(f"  {name}: {speedup:.3f}x")
 
     print("\nFinal Loss (last 100 steps average):")
     for name, data in all_data.items():
@@ -294,6 +295,11 @@ Examples:
         labels = args.labels
     else:
         labels = [Path(f).stem for f in all_files]
+
+    # Fail fast if baseline file is missing (--baseline is required)
+    if not Path(args.baseline).exists():
+        print(f"Error: Baseline file not found: {args.baseline}")
+        sys.exit(1)
 
     # Parse all log files
     print("Parsing log files...")


### PR DESCRIPTION
## Changes:
- Add `scripts/plot_training_comparison.py` for comparing training runs
- Add `docs/TRAINING_LOG_COMPARISON.md` with usage documentation
- Supports comparing baseline vs optimized runs with loss/step time plots
- Generates summary statistics with speedup calculations

### Problem description
When developing kernel optimizations (e.g., operation fusion, memory layout changes), we need to verify two critical properties:
1. **Correctness**: The optimization doesn't degrade training quality (loss curves should match baseline)
2. **Performance**: The optimization improves execution time (step time should decrease)

Previously, this analysis required manual log parsing and plotting, making it difficult to systematically compare multiple optimization strategies or track improvements across iterations.

### What's changed
Added a general-purpose training log comparison tool in `tt-train/scripts/`:

**Script features:**
- Parses tt-train binary logs (e.g., `nano_gpt`) for loss values and step times
- Generates three comparison plots:
  - `losses.png` - overlaid loss curves for all runs
  - `losses_diff.png` - loss difference relative to baseline
  - `step_time.png` - per-step execution time comparison
- Prints summary statistics: mean step time, speedup factors, final loss
- Supports multiple runs with custom labels and configurable warmup periods

**Usage:**
```bash
python scripts/plot_training_comparison.py \
    --baseline run_baseline.txt \
    --compare run_optimized.txt run_fused.txt \
    --labels baseline optimized fused \
    --output-dir ./plots
```

**Documentation:**
- Added `TRAINING_LOG_COMPARISON.md` with:
  - Quick start guide
  - Log format requirements
  - Usage examples for kernel optimization workflows
  - Output interpretation guidelines

### Example: RMSNorm Composite vs Fused (NanoLlama, 1000 steps, Shakespeare)

```
$ python tt-train/scripts/plot_training_comparison.py \
    --baseline rmsnorm_composite.txt \
    --compare rmsnorm_fused.txt \
    --labels "RMSNorm Composite" "RMSNorm Fused" \
    --output-dir ./plots --title-prefix "NanoLlama RMSNorm: "

Parsing log files...
  RMSNorm Composite: 1000 loss values, 984 step times
  RMSNorm Fused: 1000 loss values, 984 step times

============================================================
SUMMARY STATISTICS
============================================================

Mean Step Times:
  RMSNorm Composite: 242.87 ms (std: 2.14 ms)
  RMSNorm Fused: 217.91 ms (std: 1.35 ms)

Speedup relative to 'RMSNorm Composite':
  RMSNorm Fused: 1.115x

Final Loss (last 100 steps average):
  RMSNorm Composite: 1.052969
  RMSNorm Fused: 1.057578

Generating plots...
Saved: tt-train/docs/example_plots/losses.png
Saved: tt-train/docs/example_plots/step_time.png
Saved: tt-train/docs/example_plots/losses_diff.png

Done!
```

**Loss Comparison:**

<img width="2457" height="1314" alt="losses" src="https://github.com/user-attachments/assets/88d0220b-dd0b-41e1-b31a-81a736ff6246" />


**Loss Difference (Fused vs Composite):**

<img width="2499" height="1314" alt="losses_diff" src="https://github.com/user-attachments/assets/79df484e-53c5-4568-a396-640ffa5c3b3f" />

**Step Time Comparison:**

<img width="2466" height="1314" alt="step_time" src="https://github.com/user-attachments/assets/55934c80-c6d0-46bb-a0e3-b7afb7574132" />

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=mdragula/training-log-analysis-plots)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:mdragula/training-log-analysis-plots)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=mdragula/training-log-analysis-plots)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:mdragula/training-log-analysis-plots)
- [ ] [![tt-train-nightly](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mdragula/training-log-analysis-plots)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-train-nightly.yaml?query=branch:mdragula/training-log-analysis-plots)
- [x] Documentation-only change (no functional code changes)

#### Notes
This is a developer tooling/documentation addition. No model tests required as this only adds analysis scripts for comparing training logs.
