### PR TITLE
Linked exported commands with programming examples

### DIFF
--- a/build_metal.sh
+++ b/build_metal.sh
@@ -246,6 +246,12 @@ if [[ "$build_type" == "CodeCoverage" || "$build_type" == "ASanCoverage" ]]; the
     unity_builds="OFF"
 fi
 
+# Kernel IDE indexing relies on compile_commands + fake kernel targets.
+# If the user asks for compile commands, enable fake kernels target by default.
+if [ "$export_compile_commands" = "ON" ] && [ "$enable_fake_kernels_target" = "OFF" ]; then
+    enable_fake_kernels_target="ON"
+fi
+
 # If build-dir is not specified
 # Use build_type to choose a default path
 if [ "$build_dir" = "" ]; then

--- a/tt_metal/jit_build/CMakeLists.txt
+++ b/tt_metal/jit_build/CMakeLists.txt
@@ -30,6 +30,6 @@ if(DEFINED VERSION_HASH)
     target_compile_definitions(jit_build PRIVATE "-DGIT_COMMIT_HASH=\"${VERSION_HASH}\"")
 endif()
 
-if(ENABLE_FAKE_KERNELS_TARGET)
+if(ENABLE_FAKE_KERNELS_TARGET OR CMAKE_EXPORT_COMPILE_COMMANDS)
     add_subdirectory(fake_kernels_target)
 endif()

--- a/tt_metal/jit_build/fake_kernels_target/CMakeLists.txt
+++ b/tt_metal/jit_build/fake_kernels_target/CMakeLists.txt
@@ -17,6 +17,19 @@ file(
     "${CMAKE_SOURCE_DIR}/tt_metal/fabric/impl/kernels/*.cc"
 )
 
+file(
+    GLOB_RECURSE ALL_TT_METAL_PROGRAMMING_EXAMPLE_FILES
+    "${CMAKE_SOURCE_DIR}/tt_metal/programming_examples/*.cpp"
+    "${CMAKE_SOURCE_DIR}/tt_metal/programming_examples/*.cc"
+)
+
+set(TT_METAL_PROGRAMMING_EXAMPLE_KERNELS "")
+foreach(file ${ALL_TT_METAL_PROGRAMMING_EXAMPLE_FILES})
+    if(file MATCHES ".*/kernels/")
+        list(APPEND TT_METAL_PROGRAMMING_EXAMPLE_KERNELS ${file})
+    endif()
+endforeach()
+
 # First find all cpp/cc files under the operations directory
 file(
     GLOB_RECURSE ALL_TTNN_FILES
@@ -38,6 +51,7 @@ list(
     ${TT_METAL_KERNELS}
     ${TT_METAL_DISPATCH_KERNELS}
     ${TT_METAL_FABRIC_KERNELS}
+    ${TT_METAL_PROGRAMMING_EXAMPLE_KERNELS}
     ${TTNN_OPERATION_KERNELS}
 )
 


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Intellisense couldn't properly find references to functions used in kernel implementation.

### What's changed
- Replicated similar procedure already done for other kernels.
- No model changes.

### Checklist

- [x] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=ctr-kgrujcic/fix_exported_cmds)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:ctr-kgrujcic/fix_exported_cmds)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ctr-kgrujcic/fix_exported_cmds)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ctr-kgrujcic/fix_exported_cmds)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ctr-kgrujcic/fix_exported_cmds)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ctr-kgrujcic/fix_exported_cmds)
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ctr-kgrujcic/fix_exported_cmds)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ctr-kgrujcic/fix_exported_cmds)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ctr-kgrujcic/fix_exported_cmds)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ctr-kgrujcic/fix_exported_cmds)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ctr-kgrujcic/fix_exported_cmds)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ctr-kgrujcic/fix_exported_cmds)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
