### PR TITLE
Fix CMAKE_BINARY_DIR usage in scaleout tools for add_subdirectory consumption

### DIFF
--- a/tools/scaleout/CMakeLists.txt
+++ b/tools/scaleout/CMakeLists.txt
@@ -120,7 +120,7 @@ set_target_properties(
     2d_big_mesh_cabling_gen
     PROPERTIES
         RUNTIME_OUTPUT_DIRECTORY
-            ${CMAKE_BINARY_DIR}/tools/scaleout
+            ${Metalium_BINARY_DIR}/tools/scaleout
 )
 
 add_dependencies(2d_big_mesh_cabling_gen scaleout_generated_protos)
@@ -141,7 +141,7 @@ set_target_properties(
     run_cabling_generator
     PROPERTIES
         RUNTIME_OUTPUT_DIRECTORY
-            ${CMAKE_BINARY_DIR}/tools/scaleout
+            ${Metalium_BINARY_DIR}/tools/scaleout
 )
 
 add_dependencies(run_cabling_generator scaleout_generated_protos)
@@ -162,7 +162,7 @@ set_target_properties(
     generate_cluster_descriptor
     PROPERTIES
         RUNTIME_OUTPUT_DIRECTORY
-            ${CMAKE_BINARY_DIR}/tools/scaleout
+            ${Metalium_BINARY_DIR}/tools/scaleout
 )
 
 add_dependencies(generate_cluster_descriptor scaleout_generated_protos)
@@ -183,6 +183,7 @@ add_library(generate_mgd_lib OBJECT generate_mgd/generate_mgd.cpp)
 add_dependencies(
     generate_mgd_lib
     scaleout_generated_protos
+    fabric_generated_protos
     fabric
 )
 
@@ -197,7 +198,7 @@ target_include_directories(
     SYSTEM
     PUBLIC
         ${CMAKE_CURRENT_BINARY_DIR}
-        ${CMAKE_BINARY_DIR}/tt_metal/fabric
+        $<TARGET_PROPERTY:fabric,BINARY_DIR>
 )
 
 target_link_libraries(
@@ -213,6 +214,7 @@ add_executable(generate_mgd generate_mgd/generate_mgd_main.cpp)
 add_dependencies(
     generate_mgd
     scaleout_generated_protos
+    fabric_generated_protos
     fabric
 )
 
@@ -220,15 +222,15 @@ set_target_properties(
     generate_mgd
     PROPERTIES
         RUNTIME_OUTPUT_DIRECTORY
-            ${CMAKE_BINARY_DIR}/tools/scaleout
+            ${Metalium_BINARY_DIR}/tools/scaleout
 )
 
 target_include_directories(
     generate_mgd
     SYSTEM
     PRIVATE
-        ${CMAKE_BINARY_DIR}/tools/scaleout
-        ${CMAKE_BINARY_DIR}/tt_metal/fabric
+        ${CMAKE_CURRENT_BINARY_DIR}
+        $<TARGET_PROPERTY:fabric,BINARY_DIR>
 )
 
 target_sources(generate_mgd PRIVATE $<TARGET_OBJECTS:fabric>)

--- a/tools/tests/scaleout/CMakeLists.txt
+++ b/tools/tests/scaleout/CMakeLists.txt
@@ -8,7 +8,7 @@ set_target_properties(
 )
 
 # Add the protobuf generated headers directory for tests
-target_include_directories(test_factory_system_descriptor SYSTEM PRIVATE ${CMAKE_BINARY_DIR}/tools/scaleout)
+target_include_directories(test_factory_system_descriptor SYSTEM PRIVATE ${Metalium_BINARY_DIR}/tools/scaleout)
 
 target_link_libraries(
     test_factory_system_descriptor
@@ -33,7 +33,7 @@ set_target_properties(
             ${PROJECT_BINARY_DIR}/test/tools/scaleout
 )
 
-target_include_directories(test_descriptor_merger SYSTEM PRIVATE ${CMAKE_BINARY_DIR}/tools/scaleout)
+target_include_directories(test_descriptor_merger SYSTEM PRIVATE ${Metalium_BINARY_DIR}/tools/scaleout)
 
 target_link_libraries(
     test_descriptor_merger
@@ -73,7 +73,7 @@ target_include_directories(
     test_link_retraining
     SYSTEM
     PRIVATE
-        ${CMAKE_BINARY_DIR}/tools/scaleout # For generated protobuf headers
+        ${Metalium_BINARY_DIR}/tools/scaleout # For generated protobuf headers
 )
 
 target_link_libraries(
@@ -104,8 +104,8 @@ target_include_directories(
     PRIVATE
         ${PROJECT_SOURCE_DIR}
         ${PROJECT_SOURCE_DIR}/tt_metal
-        ${CMAKE_BINARY_DIR}/tools/scaleout
-        ${CMAKE_BINARY_DIR}/tt_metal/fabric
+        ${Metalium_BINARY_DIR}/tools/scaleout
+        $<TARGET_PROPERTY:fabric,BINARY_DIR>
         "$<TARGET_PROPERTY:TT::Metalium,INCLUDE_DIRECTORIES>"
 )
 
@@ -121,4 +121,5 @@ target_link_libraries(
 
 # Make sure protobuf files are generated before compiling
 add_dependencies(test_cabling_descriptor_mgd_generation scaleout_generated_protos)
+add_dependencies(test_cabling_descriptor_mgd_generation fabric_generated_protos)
 add_dependencies(test_cabling_descriptor_mgd_generation tt_metal)

--- a/tt_metal/fabric/CMakeLists.txt
+++ b/tt_metal/fabric/CMakeLists.txt
@@ -96,6 +96,14 @@ foreach(PROTO_FILE ${PROTO_SCHEMAS})
     list(APPEND GENERATED_PROTO_SRCS ${PROTO_SRCS})
 endforeach()
 
+# Expose a custom target for the generated protobuf files so that external consumers
+# can depend on them directly without going through the fabric OBJECT library.
+add_custom_target(fabric_generated_protos DEPENDS ${GENERATED_PROTO_SRCS})
+add_dependencies(fabric fabric_generated_protos)
+if(TARGET all_generated_files)
+    add_dependencies(all_generated_files fabric_generated_protos)
+endif()
+
 # Exclude protobuf generated files from unity builds (they have conflicting static symbols)
 set_source_files_properties(
     ${GENERATED_PROTO_SRCS}


### PR DESCRIPTION
## Problem

When tt-metal is consumed via CMake's `add_subdirectory()` (as demonstrated in [cpp-tt-metalium-project-template-submodule](https://github.com/blozano-tt/cpp-tt-metalium-project-template-submodule)), the build fails with:

```
fatal error: 'protobuf/mesh_graph_descriptor.pb.h' file not found
```

Reported in Discord: https://discord.com/channels/863154240319258674/1177107133167321158/1470034167566827612

## Root Cause

Several `target_include_directories()` and `RUNTIME_OUTPUT_DIRECTORY` entries in `tools/scaleout/CMakeLists.txt` and `tools/tests/scaleout/CMakeLists.txt` use `CMAKE_BINARY_DIR` to construct paths to generated protobuf headers.

`CMAKE_BINARY_DIR` always refers to the **top-level** project's build directory. When tt-metal is the top-level project, this happens to be the same as its own build directory. But when consumed via `add_subdirectory(tt-metal)`, `CMAKE_BINARY_DIR` points to the parent project's build directory, causing paths like `${CMAKE_BINARY_DIR}/tt_metal/fabric` to resolve incorrectly (they miss the `tt-metal/` subdirectory prefix).

Additionally, there was no explicit custom target for fabric's generated protobuf files, meaning consumers had to depend on the `fabric` OBJECT library transitively — which can cause race conditions with the Makefile generator.

## Fix

### 1. Add `fabric_generated_protos` custom target (`tt_metal/fabric/CMakeLists.txt`)

Creates an explicit dependency target for fabric's generated protobuf headers, following the same pattern as `scaleout_generated_protos`. Registers it with `all_generated_files` for completeness.

### 2. Fix include directory paths (`tools/scaleout/CMakeLists.txt`, `tools/tests/scaleout/CMakeLists.txt`)

Replace `CMAKE_BINARY_DIR` with:
- **`$<TARGET_PROPERTY:fabric,BINARY_DIR>`** — for the fabric proto include path (idiomatic CMake generator expression, decoupled from project name)
- **`CMAKE_CURRENT_BINARY_DIR`** — for self-references within the scaleout directory
- **`Metalium_BINARY_DIR`** — for cross-directory references to the scaleout binary dir from tests

### 3. Add explicit `fabric_generated_protos` dependencies

Add `fabric_generated_protos` as a direct dependency on `generate_mgd`, `generate_mgd_lib`, and `test_cabling_descriptor_mgd_generation` to avoid race conditions through OBJECT library transitive dependencies.

### 4. Fix `RUNTIME_OUTPUT_DIRECTORY` for scaleout executables

Use `Metalium_BINARY_DIR` instead of `CMAKE_BINARY_DIR` so executables are placed in the correct location.

When building standalone, `Metalium_BINARY_DIR == CMAKE_BINARY_DIR` and `$<TARGET_PROPERTY:fabric,BINARY_DIR>` resolves to the same path as before, so there is no change in behavior.

## Testing

- ✅ Full standalone tt-metal build with Ninja (1012/1012 targets)
- ✅ Full `add_subdirectory` build via template project with latest main (1014/1014 targets)