### PR TITLE
Add Python bindings to return MeshMapperConfig from any TensorToMesh

### DIFF
--- a/tests/ttnn/unit_tests/gtests/tensor/test_distributed_tensor.cpp
+++ b/tests/ttnn/unit_tests/gtests/tensor/test_distributed_tensor.cpp
@@ -375,6 +375,19 @@ INSTANTIATE_TEST_SUITE_P(
     TensorDistribution2x4Test2D,
     ::testing::Values(MeshShape(1, 1), MeshShape(2, 2), MeshShape(2, 4), MeshShape(1, 3)));
 
+TEST_F(TensorDistribution2x4Test, TensorToMeshGetConfigReturnsMatchingConfig) {
+    // Call create_mesh_mapper with explicit config: get_config() should return the same config
+    const auto mesh_mapper_config = MeshMapperConfig{
+        .placements = {MeshMapperConfig::Shard{1}, MeshMapperConfig::Replicate{}},
+        .mesh_shape_override = MeshShape(2, 4),
+    };
+    auto mapper = create_mesh_mapper(*mesh_device_, mesh_mapper_config);
+    const MeshMapperConfig& returned_config = mapper->get_config();
+    EXPECT_EQ(returned_config.placements, mesh_mapper_config.placements);
+    ASSERT_TRUE(returned_config.mesh_shape_override.has_value());
+    EXPECT_EQ(*returned_config.mesh_shape_override, *mesh_mapper_config.mesh_shape_override);
+}
+
 TEST_F(TensorDistribution2x4Test, NdMapperInvalidShape) {
     EXPECT_ANY_THROW(create_mesh_mapper(
         *mesh_device_,

--- a/ttnn/api/ttnn/distributed/distributed_tensor.hpp
+++ b/ttnn/api/ttnn/distributed/distributed_tensor.hpp
@@ -44,6 +44,8 @@ public:
         const tt::tt_metal::TensorLayout& layout,
         T pad_value = 0) const;
 
+    const MeshMapperConfig& get_config() const;
+
 private:
     class Impl;
 

--- a/ttnn/core/distributed/distributed_tensor.cpp
+++ b/ttnn/core/distributed/distributed_tensor.cpp
@@ -254,6 +254,8 @@ public:
         return create_tensor<T>(sharded_xtensor_views, layout, pad_value);
     }
 
+    const MeshMapperConfig& config() const { return config_; }
+
 private:
     template <typename T>
     Tensor create_tensor(
@@ -424,6 +426,7 @@ TensorToMesh::~TensorToMesh() = default;
 TensorToMesh::TensorToMesh(TensorToMesh&& other) noexcept = default;
 TensorToMesh& TensorToMesh::operator=(TensorToMesh&& other) noexcept = default;
 Tensor TensorToMesh::operator()(const Tensor& tensor) const { return (*impl_)(tensor); }
+const MeshMapperConfig& TensorToMesh::get_config() const { return impl_->config(); }
 
 template <typename T>
 Tensor TensorToMesh::operator()(

--- a/ttnn/ttnn/distributed/distributed.py
+++ b/ttnn/ttnn/distributed/distributed.py
@@ -723,6 +723,9 @@ class ReplicateTensorToMeshWrapper:
     def unwrap(self):
         return self._mapper
 
+    def get_config(self):
+        return self._mapper.get_config()
+
 
 # Deprecated. Use `ttnn.replicate_tensor_to_mesh_mapper` directly.
 def ReplicateTensorToMesh(mesh_device: MeshDevice):


### PR DESCRIPTION
### Summary

Python code had no way to read the `MeshMapperConfig` (placements, mesh shape override) from a `TensorToMesh` mapper.

### What's changed

- C++: Added `get_config() const` on `TensorToMesh` returning `const MeshMapperConfig&`
- Python bindings: Exposed `get_config()` on `CppTensorToMesh` via nanobind, and added readable properties on `MeshMapperConfig` (placements, mesh_shape_override) so Python can inspect the config.
- Python API: Added `get_config()` on the `TensorToMesh` wrapper in `ttnn.distributed` so both `CppTensorToMesh` and `ReplicateTensorToMeshWrapper` support the same interface.
- Tests: Added a sanity check test C++

### Motivation

To support automatic cache invalidation for DeepSeekV3, we need to include the mesh mapper configuration in the fingerprint. 

### Checklist

- [x] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=esmal/distributed-get-config)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:esmal/distributed-get-config)
- [x] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=esmal/distributed-get-config)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:esmal/distributed-get-config)
- [x] New/Existing tests provide coverage for changes