### PR TITLE
[skip ci] Include conv2d.hpp and deps in the public API

### DIFF
--- a/ttnn/cpp/ttnn/operations/conv/CMakeLists.txt
+++ b/ttnn/cpp/ttnn/operations/conv/CMakeLists.txt
@@ -19,6 +19,11 @@ target_sources(
         TYPE HEADERS
         BASE_DIRS ${FixmeOpAPIDir}
         FILES
+            conv2d/conv2d.hpp
+            conv2d/device/conv2d_device_operation_types.hpp
+            conv2d/device/conv2d_device_operation.hpp
+            conv2d/device/conv2d_op_sharded_program_factory.hpp
+            conv2d/device/conv2d_op_width_sharded_program_factory.hpp
         FILE_SET kernels
         TYPE HEADERS
         BASE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}
@@ -52,4 +57,4 @@ install(
         DESTINATION ${CMAKE_INSTALL_LIBEXECDIR}/tt-metalium/ttnn/cpp/ttnn/operations/conv
         COMPONENT ttnn-runtime
 )
-install(TARGETS ttnn_op_conv LIBRARY COMPONENT tar)
+install(TARGETS ttnn_op_conv FILE_SET api COMPONENT ttnn-dev LIBRARY COMPONENT tar)

--- a/ttnn/cpp/ttnn/operations/conv/CMakeLists.txt
+++ b/ttnn/cpp/ttnn/operations/conv/CMakeLists.txt
@@ -42,12 +42,7 @@ target_sources(
 )
 
 target_include_directories(ttnn_op_conv PRIVATE ${FixmeOpIncDirs})
-target_link_libraries(
-    ttnn_op_conv
-    PRIVATE
-        TT::Metalium
-        TTNN::Core
-)
+target_link_libraries(ttnn_op_conv PUBLIC TTNN::Core PRIVATE TT::Metalium)
 
 install(
     TARGETS

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/CMakeLists.txt
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/CMakeLists.txt
@@ -17,7 +17,12 @@ target_sources(
         FILE_SET api
         TYPE HEADERS
         BASE_DIRS ${FixmeOpAPIDir}
-        FILES common/unary_op_types.hpp device/unary_composite_op.hpp unary.hpp unary_composite.hpp
+        FILES
+            common/unary_op_types.hpp
+            common/unary_op_utils.hpp
+            device/unary_composite_op.hpp
+            unary.hpp
+            unary_composite.hpp
         FILE_SET kernels
         TYPE HEADERS
         BASE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}

--- a/ttnn/cpp/ttnn/operations/sliding_window/CMakeLists.txt
+++ b/ttnn/cpp/ttnn/operations/sliding_window/CMakeLists.txt
@@ -18,7 +18,7 @@ target_sources(
         FILE_SET api
         TYPE HEADERS
         BASE_DIRS ${FixmeOpAPIDir}
-        FILES
+        FILES sliding_window.hpp op_slicing/op_slicing.hpp
         FILE_SET kernels
         TYPE HEADERS
         BASE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}
@@ -47,4 +47,4 @@ install(
         DESTINATION ${CMAKE_INSTALL_LIBEXECDIR}/tt-metalium/ttnn/cpp/ttnn/operations/sliding_window
         COMPONENT ttnn-runtime
 )
-install(TARGETS ttnn_op_sliding_window LIBRARY COMPONENT tar)
+install(TARGETS ttnn_op_sliding_window FILE_SET api COMPONENT ttnn-dev LIBRARY COMPONENT tar)

--- a/ttnn/cpp/ttnn/operations/sliding_window/CMakeLists.txt
+++ b/ttnn/cpp/ttnn/operations/sliding_window/CMakeLists.txt
@@ -32,12 +32,7 @@ target_sources(
 )
 
 target_include_directories(ttnn_op_sliding_window PRIVATE ${FixmeOpIncDirs})
-target_link_libraries(
-    ttnn_op_sliding_window
-    PRIVATE
-        TT::Metalium
-        TTNN::Core
-)
+target_link_libraries(ttnn_op_sliding_window PUBLIC TTNN::Core PRIVATE TT::Metalium)
 
 install(
     TARGETS


### PR DESCRIPTION
### Ticket
Fixes #37068

### Problem description
conv2d.hpp should be exposed as part of the public API.  It wasn't.

### What's changed
Package it and transitive includes for use by consumers.
