### PR TITLE
Refactor & Fix `ttml::from_vector`

### DIFF
--- a/tt-train/sources/ttml/core/tt_tensor_utils.cpp
+++ b/tt-train/sources/ttml/core/tt_tensor_utils.cpp
@@ -126,9 +126,6 @@ tt::tt_metal::Tensor from_vector<bfloat16, ttnn::DataType::BFLOAT16>(
         output = ttnn::to_device(output, device, output_mem_config);
     } else {
         output = ttnn::to_device(output, device, output_mem_config);
-        if (layout == ttnn::Layout::TILE) {
-            output = ttnn::tilize_with_zero_padding(output, output_mem_config, std::nullopt, /* multicore */ true);
-        }
     }
 
     return output;

--- a/tt-train/sources/ttml/core/tt_tensor_utils.cpp
+++ b/tt-train/sources/ttml/core/tt_tensor_utils.cpp
@@ -156,17 +156,9 @@ tt::tt_metal::Tensor from_vector<float, ttnn::DataType::BFLOAT16>(
                                                  ttsl::make_const_span(buffer), shape, tensor_layout, *mesh_mapper)
                                            : ttnn::Tensor::from_vector(buffer, ttnn::TensorSpec(shape, tensor_layout));
 
-    const size_t MAX_TILE_DIMENSION = 16384;
-    // Temporary workaround for the issue with tilize for large size
-    // https://github.com/tenstorrent/tt-metal/issues/15950
-    if (shape[-1] >= MAX_TILE_DIMENSION && layout == ttnn::Layout::TILE) {
-        output = ttnn::to_layout(output, ttnn::Layout::TILE, std::nullopt, output_mem_config);
-        output = ttnn::to_device(output, device, output_mem_config);
-    } else {
-        output = ttnn::to_device(output, device, output_mem_config);
-        if (layout == ttnn::Layout::TILE) {
-            output = ttnn::tilize_with_zero_padding(output, output_mem_config, std::nullopt, /* multicore */ true);
-        }
+    output = ttnn::to_device(output, device, output_mem_config);
+    if (layout == ttnn::Layout::TILE) {
+        output = ttnn::tilize_with_zero_padding(output, output_mem_config, std::nullopt, /* multicore */ true);
     }
 
     return output;

--- a/tt-train/sources/ttml/core/tt_tensor_utils.cpp
+++ b/tt-train/sources/ttml/core/tt_tensor_utils.cpp
@@ -98,16 +98,17 @@ tt::tt_metal::Tensor zeros(const ttnn::Shape& shape, ttnn::distributed::MeshDevi
 tt::tt_metal::Tensor ones(const ttnn::Shape& shape, ttnn::distributed::MeshDevice* device, ttnn::DataType dtype) {
     return core::full(shape, 1.F, device, dtype);
 }
-
-template <>
-tt::tt_metal::Tensor from_vector<bfloat16, ttnn::DataType::BFLOAT16>(
-    const std::vector<bfloat16>& buffer,
+template <class VectorType, ttnn::DataType TensorType>
+tt::tt_metal::Tensor from_vector(
+    const std::vector<VectorType>& buffer,
     const ttnn::Shape& shape,
     ttnn::distributed::MeshDevice* device,
     ttnn::Layout layout,
     const ttnn::distributed::TensorToMesh* mesh_mapper) {
-    assert(device != nullptr);
-    const ttnn::DataType data_type = ttnn::DataType::BFLOAT16;
+    if (device == nullptr) {
+        throw std::runtime_error("from_vector: device == nullptr. Device is required");
+    }
+
     ttnn::MemoryConfig output_mem_config{};
     size_t volume = shape.volume();
     if (buffer.size() != volume) {
@@ -116,70 +117,9 @@ tt::tt_metal::Tensor from_vector<bfloat16, ttnn::DataType::BFLOAT16>(
     }
 
     const auto tensor_layout =
-        ttnn::TensorLayout(data_type, ttnn::PageConfig(ttnn::Layout::ROW_MAJOR), tt::tt_metal::MemoryConfig{});
-    auto output = (mesh_mapper != nullptr) ? ttnn::distributed::create_distributed_tensor(
-                                                 ttsl::make_const_span(buffer), shape, tensor_layout, *mesh_mapper)
-                                           : ttnn::Tensor::from_vector(buffer, ttnn::TensorSpec(shape, tensor_layout));
+        ttnn::TensorLayout(TensorType, ttnn::PageConfig(ttnn::Layout::ROW_MAJOR), tt::tt_metal::MemoryConfig{});
 
-    if (layout == ttnn::Layout::TILE) {
-        output = ttnn::to_layout(output, ttnn::Layout::TILE, std::nullopt, output_mem_config);
-        output = ttnn::to_device(output, device, output_mem_config);
-    } else {
-        output = ttnn::to_device(output, device, output_mem_config);
-    }
-
-    return output;
-}
-
-template <>
-tt::tt_metal::Tensor from_vector<float, ttnn::DataType::BFLOAT16>(
-    const std::vector<float>& buffer,
-    const ttnn::Shape& shape,
-    ttnn::distributed::MeshDevice* device,
-    ttnn::Layout layout,
-    const ttnn::distributed::TensorToMesh* mesh_mapper) {
-    assert(device != nullptr);
-    const ttnn::DataType data_type = ttnn::DataType::BFLOAT16;
-    ttnn::MemoryConfig output_mem_config{};
-    size_t volume = shape.volume();
-    if (buffer.size() != volume) {
-        throw std::logic_error(
-            fmt::format("Current buffer size is {} different from shape volume {}", buffer.size(), volume));
-    }
-
-    const auto tensor_layout =
-        ttnn::TensorLayout(data_type, ttnn::PageConfig(ttnn::Layout::ROW_MAJOR), tt::tt_metal::MemoryConfig{});
-    auto output = (mesh_mapper != nullptr) ? ttnn::distributed::create_distributed_tensor(
-                                                 ttsl::make_const_span(buffer), shape, tensor_layout, *mesh_mapper)
-                                           : ttnn::Tensor::from_vector(buffer, ttnn::TensorSpec(shape, tensor_layout));
-
-    output = ttnn::to_device(output, device, output_mem_config);
-    if (layout == ttnn::Layout::TILE) {
-        output = ttnn::tilize_with_zero_padding(output, output_mem_config, std::nullopt, /* multicore */ true);
-    }
-
-    return output;
-}
-
-template <>
-tt::tt_metal::Tensor from_vector<float, ttnn::DataType::FLOAT32>(
-    const std::vector<float>& buffer,
-    const ttnn::Shape& shape,
-    ttnn::distributed::MeshDevice* device,
-    ttnn::Layout layout,
-    const ttnn::distributed::TensorToMesh* mesh_mapper) {
-    size_t volume = shape.volume();
-    if (buffer.size() != volume) {
-        throw std::logic_error(
-            fmt::format("Current buffer size is {} different from shape volume {}", buffer.size(), volume));
-    }
-
-    ttnn::MemoryConfig output_mem_config{};
     ttnn::Tensor output;
-
-    const auto tensor_layout = ttnn::TensorLayout(
-        ttnn::DataType::FLOAT32, ttnn::PageConfig(ttnn::Layout::ROW_MAJOR), tt::tt_metal::MemoryConfig{});
-
     if (mesh_mapper != nullptr) {
         output = ttnn::distributed::create_distributed_tensor(
             ttsl::make_const_span(buffer), shape, tensor_layout, *mesh_mapper);
@@ -187,78 +127,48 @@ tt::tt_metal::Tensor from_vector<float, ttnn::DataType::FLOAT32>(
         output = ttnn::Tensor::from_vector(buffer, ttnn::TensorSpec(shape, tensor_layout));
     }
 
-    if (layout == ttnn::Layout::TILE) {
-        output = ttnn::to_layout(output, ttnn::Layout::TILE, std::nullopt, output_mem_config);
-    }
-    output = ttnn::to_device(output, device, output_mem_config);
-    return output;
-}
-
-/*
-From vector uint32 doesn't support tilize_with_zero_padding on device
-*/
-template <>
-tt::tt_metal::Tensor from_vector<uint32_t, ttnn::DataType::UINT32>(
-    const std::vector<uint32_t>& buffer,
-    const ttnn::Shape& shape,
-    ttnn::distributed::MeshDevice* device,
-    ttnn::Layout layout,
-    const ttnn::distributed::TensorToMesh* mesh_mapper) {
-    ttnn::MemoryConfig output_mem_config{};
-    auto volume = shape.volume();
-    if (buffer.size() != volume) {
-        throw std::logic_error(
-            fmt::format("Current buffer size is {} different from shape volume {}", buffer.size(), volume));
-    }
-
-    const auto tensor_layout =
-        ttnn::TensorLayout(ttnn::DataType::UINT32, ttnn::PageConfig(ttnn::Layout::ROW_MAJOR), output_mem_config);
-    auto output = (mesh_mapper != nullptr) ? ttnn::distributed::create_distributed_tensor(
-                                                 ttsl::make_const_span(buffer), shape, tensor_layout, *mesh_mapper)
-                                           : ttnn::Tensor::from_vector(buffer, ttnn::TensorSpec(shape, tensor_layout));
-
-    if (device != nullptr) {
-        if (layout != ttnn::Layout::ROW_MAJOR) {
-            output = ttnn::to_layout(output, layout, std::nullopt, output_mem_config);
-        }
+    /* Workaround necessary due to the issue #38186.*/
+    if constexpr (TensorType == ttnn::DataType::FLOAT32) {
+        output = ttnn::to_layout(output, ttnn::Layout::TILE);
         output = ttnn::to_device(output, device, output_mem_config);
-    }
-
-    return output;
-}
-
-/*
-From vector int32 doesn't support tilize_with_zero_padding on device
-*/
-template <>
-tt::tt_metal::Tensor from_vector<int32_t, ttnn::DataType::INT32>(
-    const std::vector<int32_t>& buffer,
-    const ttnn::Shape& shape,
-    ttnn::distributed::MeshDevice* device,
-    ttnn::Layout layout,
-    const ttnn::distributed::TensorToMesh* mesh_mapper) {
-    ttnn::MemoryConfig output_mem_config{};
-    auto volume = shape.volume();
-    if (buffer.size() != volume) {
-        throw std::logic_error(
-            fmt::format("Current buffer size is {} different from shape volume {}", buffer.size(), volume));
-    }
-
-    const auto tensor_layout =
-        ttnn::TensorLayout(ttnn::DataType::INT32, ttnn::PageConfig(ttnn::Layout::ROW_MAJOR), output_mem_config);
-    auto output = (mesh_mapper != nullptr) ? ttnn::distributed::create_distributed_tensor(
-                                                 ttsl::make_const_span(buffer), shape, tensor_layout, *mesh_mapper)
-                                           : ttnn::Tensor::from_vector(buffer, ttnn::TensorSpec(shape, tensor_layout));
-
-    if (device != nullptr) {
-        if (layout != ttnn::Layout::ROW_MAJOR) {
-            output = ttnn::to_layout(output, layout, std::nullopt, output_mem_config);
-        }
+    } else {
         output = ttnn::to_device(output, device, output_mem_config);
+        output = ttnn::tilize_with_zero_padding(output, output_mem_config, std::nullopt, /* multicore */ true);
     }
 
     return output;
 }
+
+template tt::tt_metal::Tensor from_vector<bfloat16, ttnn::DataType::BFLOAT16>(
+    const std::vector<bfloat16>&,
+    const ttnn::Shape&,
+    ttnn::distributed::MeshDevice*,
+    ttnn::Layout,
+    const ttnn::distributed::TensorToMesh*);
+template tt::tt_metal::Tensor from_vector<float, ttnn::DataType::BFLOAT16>(
+    const std::vector<float>&,
+    const ttnn::Shape&,
+    ttnn::distributed::MeshDevice*,
+    ttnn::Layout,
+    const ttnn::distributed::TensorToMesh*);
+template tt::tt_metal::Tensor from_vector<float, ttnn::DataType::FLOAT32>(
+    const std::vector<float>&,
+    const ttnn::Shape&,
+    ttnn::distributed::MeshDevice*,
+    ttnn::Layout,
+    const ttnn::distributed::TensorToMesh*);
+template tt::tt_metal::Tensor from_vector<uint32_t, ttnn::DataType::UINT32>(
+    const std::vector<uint32_t>&,
+    const ttnn::Shape&,
+    ttnn::distributed::MeshDevice*,
+    ttnn::Layout,
+    const ttnn::distributed::TensorToMesh*);
+template tt::tt_metal::Tensor from_vector<int32_t, ttnn::DataType::INT32>(
+    const std::vector<int32_t>&,
+    const ttnn::Shape&,
+    ttnn::distributed::MeshDevice*,
+    ttnn::Layout,
+    const ttnn::distributed::TensorToMesh*);
 
 bool is_tensor_initialized(const tt::tt_metal::Tensor& tensor) {
     return tensor.tensor_attributes != nullptr;

--- a/tt-train/sources/ttml/core/tt_tensor_utils.cpp
+++ b/tt-train/sources/ttml/core/tt_tensor_utils.cpp
@@ -129,11 +129,17 @@ tt::tt_metal::Tensor from_vector(
 
     /* Workaround necessary due to the issue #38186.*/
     if constexpr (TensorType == ttnn::DataType::FLOAT32) {
-        output = ttnn::to_layout(output, ttnn::Layout::TILE);
+        if (layout == ttnn::TILE_LAYOUT) {
+            output = ttnn::to_layout(output, ttnn::Layout::TILE);
+        }
+
         output = ttnn::to_device(output, device, output_mem_config);
     } else {
         output = ttnn::to_device(output, device, output_mem_config);
-        output = ttnn::tilize_with_zero_padding(output, output_mem_config, std::nullopt, /* multicore */ true);
+
+        if (layout == ttnn::TILE_LAYOUT) {
+            output = ttnn::tilize_with_zero_padding(output, output_mem_config, std::nullopt, /* multicore */ true);
+        }
     }
 
     return output;

--- a/tt-train/sources/ttml/core/tt_tensor_utils.cpp
+++ b/tt-train/sources/ttml/core/tt_tensor_utils.cpp
@@ -172,8 +172,6 @@ tt::tt_metal::Tensor from_vector<float, ttnn::DataType::BFLOAT16>(
     return output;
 }
 
-// Workaround implementation due to issue with tilize for float32
-// it is expected that tilize will be fixed in the after next tt-metal main update
 template <>
 tt::tt_metal::Tensor from_vector<float, ttnn::DataType::FLOAT32>(
     const std::vector<float>& buffer,
@@ -181,8 +179,30 @@ tt::tt_metal::Tensor from_vector<float, ttnn::DataType::FLOAT32>(
     ttnn::distributed::MeshDevice* device,
     ttnn::Layout layout,
     const ttnn::distributed::TensorToMesh* mesh_mapper) {
-    auto tensor = from_vector<float, ttnn::DataType::BFLOAT16>(buffer, shape, device, layout, mesh_mapper);
-    return ttnn::typecast(tensor, ttnn::DataType::FLOAT32);
+    size_t volume = shape.volume();
+    if (buffer.size() != volume) {
+        throw std::logic_error(
+            fmt::format("Current buffer size is {} different from shape volume {}", buffer.size(), volume));
+    }
+
+    ttnn::MemoryConfig output_mem_config{};
+    ttnn::Tensor output;
+
+    const auto tensor_layout = ttnn::TensorLayout(
+        ttnn::DataType::FLOAT32, ttnn::PageConfig(ttnn::Layout::ROW_MAJOR), tt::tt_metal::MemoryConfig{});
+
+    if (mesh_mapper != nullptr) {
+        output = ttnn::distributed::create_distributed_tensor(
+            ttsl::make_const_span(buffer), shape, tensor_layout, *mesh_mapper);
+    } else {
+        output = ttnn::Tensor::from_vector(buffer, ttnn::TensorSpec(shape, tensor_layout));
+    }
+
+    if (layout == ttnn::Layout::TILE) {
+        output = ttnn::to_layout(output, ttnn::Layout::TILE, std::nullopt, output_mem_config);
+    }
+    output = ttnn::to_device(output, device, output_mem_config);
+    return output;
 }
 
 /*

--- a/tt-train/tests/CMakeLists.txt
+++ b/tt-train/tests/CMakeLists.txt
@@ -131,15 +131,21 @@ gtest_discover_tests(ttml_tests)
 ############################################################################################################################
 
 if(TARGET benchmark::benchmark)
-    set(BENCHMARK_SOURCES benchmark/matmuls_benchmark.cpp)
-
-    add_executable(ttml_benchmarks ${BENCHMARK_SOURCES})
-    target_link_libraries(
-        ttml_benchmarks
-        PUBLIC
-            ttml
-            TTNN::TTNN
-            benchmark::benchmark
+    set(BENCHMARK_SOURCES
+        benchmark/matmuls_benchmark.cpp
+        benchmark/from_vector_benchmark.cpp
     )
-    target_include_directories(ttml_benchmarks PRIVATE "$<TARGET_PROPERTY:Metalium::Metal,INCLUDE_DIRECTORIES>")
+
+    foreach(BENCH_SRC ${BENCHMARK_SOURCES})
+        get_filename_component(BENCH_TARGET ${BENCH_SRC} NAME_WE)
+        add_executable(${BENCH_TARGET} ${BENCH_SRC})
+        target_link_libraries(
+            ${BENCH_TARGET}
+            PUBLIC
+                ttml
+                TTNN::TTNN
+                benchmark::benchmark
+        )
+        target_include_directories(${BENCH_TARGET} PRIVATE "$<TARGET_PROPERTY:Metalium::Metal,INCLUDE_DIRECTORIES>")
+    endforeach()
 endif()

--- a/tt-train/tests/benchmark/from_vector_benchmark.cpp
+++ b/tt-train/tests/benchmark/from_vector_benchmark.cpp
@@ -1,0 +1,119 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+// SPDX-License-Identifier: Apache-2.0
+
+#include <benchmark/benchmark.h>
+
+#include <random>
+#include <type_traits>
+#include <vector>
+
+#include "core/tt_tensor_utils.hpp"
+#include "ttnn/device.hpp"
+#include "ttnn/tensor/shape/shape.hpp"
+#include "ttnn/tensor/types.hpp"
+#include "ttnn/types.hpp"
+
+namespace {
+
+ttnn::distributed::MeshDevice* g_device = nullptr;
+
+template <typename T>
+std::vector<T> make_random_data(size_t volume, unsigned seed) {
+    std::vector<T> data(volume);
+    std::mt19937 gen(seed);
+    if constexpr (std::is_same_v<T, float>) {
+        std::uniform_real_distribution<float> dist(-1.f, 1.f);
+        for (auto& x : data) x = dist(gen);
+    } else if constexpr (std::is_same_v<T, bfloat16>) {
+        std::uniform_real_distribution<float> dist(-1.f, 1.f);
+        for (auto& x : data) x = bfloat16(dist(gen));
+    } else if constexpr (std::is_same_v<T, uint32_t>) {
+        std::uniform_int_distribution<uint32_t> dist(0, 1000000u);
+        for (auto& x : data) x = dist(gen);
+    } else if constexpr (std::is_same_v<T, int32_t>) {
+        std::uniform_int_distribution<int32_t> dist(-1000000, 1000000);
+        for (auto& x : data) x = dist(gen);
+    }
+    return data;
+}
+
+void BM_FromVector_Bfloat16_BFLOAT16(benchmark::State& state) {
+    const size_t volume = static_cast<size_t>(state.range(0));
+    const ttnn::Shape shape({1, 1, 1, volume});
+    auto data = make_random_data<bfloat16>(volume, 42u);
+    for (auto _ : state) {
+        auto tensor =
+            ttml::core::from_vector<bfloat16, ttnn::DataType::BFLOAT16>(data, shape, g_device, ttnn::Layout::TILE);
+        benchmark::DoNotOptimize(tensor);
+    }
+}
+
+void BM_FromVector_Float_BFLOAT16(benchmark::State& state) {
+    const size_t volume = static_cast<size_t>(state.range(0));
+    const ttnn::Shape shape({1, 1, 1, volume});
+    auto data = make_random_data<float>(volume, 42u);
+    for (auto _ : state) {
+        auto tensor =
+            ttml::core::from_vector<float, ttnn::DataType::BFLOAT16>(data, shape, g_device, ttnn::Layout::TILE);
+        benchmark::DoNotOptimize(tensor);
+    }
+}
+
+void BM_FromVector_Float_FLOAT32(benchmark::State& state) {
+    const size_t volume = static_cast<size_t>(state.range(0));
+    const ttnn::Shape shape({1, 1, 1, volume});
+    auto data = make_random_data<float>(volume, 42u);
+    for (auto _ : state) {
+        auto tensor =
+            ttml::core::from_vector<float, ttnn::DataType::FLOAT32>(data, shape, g_device, ttnn::Layout::TILE);
+        benchmark::DoNotOptimize(tensor);
+    }
+}
+
+void BM_FromVector_Uint32_UINT32(benchmark::State& state) {
+    const size_t volume = static_cast<size_t>(state.range(0));
+    const ttnn::Shape shape({1, 1, 1, volume});
+    auto data = make_random_data<uint32_t>(volume, 42u);
+    for (auto _ : state) {
+        auto tensor =
+            ttml::core::from_vector<uint32_t, ttnn::DataType::UINT32>(data, shape, g_device, ttnn::Layout::TILE);
+        benchmark::DoNotOptimize(tensor);
+    }
+}
+
+void BM_FromVector_Int32_INT32(benchmark::State& state) {
+    const size_t volume = static_cast<size_t>(state.range(0));
+    const ttnn::Shape shape({1, 1, 1, volume});
+    auto data = make_random_data<int32_t>(volume, 42u);
+    for (auto _ : state) {
+        auto tensor =
+            ttml::core::from_vector<int32_t, ttnn::DataType::INT32>(data, shape, g_device, ttnn::Layout::TILE);
+        benchmark::DoNotOptimize(tensor);
+    }
+}
+
+}  // namespace
+
+BENCHMARK(BM_FromVector_Bfloat16_BFLOAT16)->Unit(benchmark::kMicrosecond)->RangeMultiplier(2)->Range(1 << 16, 1 << 20);
+
+BENCHMARK(BM_FromVector_Float_BFLOAT16)->Unit(benchmark::kMicrosecond)->RangeMultiplier(2)->Range(1 << 16, 1 << 20);
+
+BENCHMARK(BM_FromVector_Float_FLOAT32)->Unit(benchmark::kMicrosecond)->RangeMultiplier(2)->Range(1 << 16, 1 << 20);
+
+BENCHMARK(BM_FromVector_Uint32_UINT32)->Unit(benchmark::kMicrosecond)->RangeMultiplier(2)->Range(1 << 16, 1 << 20);
+
+BENCHMARK(BM_FromVector_Int32_INT32)->Unit(benchmark::kMicrosecond)->RangeMultiplier(2)->Range(1 << 16, 1 << 20);
+
+int main(int argc, char** argv) {
+    auto device = ttnn::device::open_mesh_device(0, /*l1_small_size=*/0, /*trace_region_size=*/1048576);
+    g_device = device.get();
+
+    ::benchmark::Initialize(&argc, argv);
+    if (::benchmark::ReportUnrecognizedArguments(argc, argv))
+        return 1;
+    ::benchmark::RunSpecifiedBenchmarks();
+    ::benchmark::Shutdown();
+
+    device->close();
+    return 0;
+}

--- a/tt-train/tests/core/tensor_utils_test.cpp
+++ b/tt-train/tests/core/tensor_utils_test.cpp
@@ -38,6 +38,22 @@ TEST_F(TensorUtilsTest, TestFloatToFromTensorEven) {
     }
 }
 
+TEST_F(TensorUtilsTest, TestFloat32Precision) {
+    /* This test fails if the numbers are converted to BFloat16 inside from_vector. */
+    auto* device = &ttml::autograd::ctx().get_device();
+    std::vector<float> test_data = {1.5F, 1.05F, 1.005F, 1.0005F, 1.00005F};
+
+    auto shape = ttnn::Shape({1, 1, 1, 5});
+    auto tensor = ttml::core::from_vector<float, ttnn::DataType::FLOAT32>(test_data, shape, device);
+
+    auto vec_back = ttml::core::to_vector<float>(tensor);
+
+    ASSERT_EQ(vec_back.size(), test_data.size());
+    for (size_t i = 0; i < test_data.size(); i++) {
+        EXPECT_EQ(vec_back[i], test_data[i]);
+    }
+}
+
 TEST_F(TensorUtilsTest, TestFloatToFromTensorGPT2Tokenizer) {
     auto* device = &ttml::autograd::ctx().get_device();
     const size_t N = 50304;

--- a/tt-train/tests/core/tensor_utils_test.cpp
+++ b/tt-train/tests/core/tensor_utils_test.cpp
@@ -23,14 +23,14 @@ protected:
     }
 };
 
-TEST_F(TensorUtilsTest, TestFloatToFromTensorEven) {
+TEST_F(TensorUtilsTest, TestBFloat16ToFromTensorEven) {
     auto* device = &ttml::autograd::ctx().get_device();
     std::vector<float> test_data = {1.F, 5.F, 10.F, 15.F};
 
     auto shape = ttnn::Shape({1, 1, 1, 4});
-    auto tensor = ttml::core::from_vector(test_data, shape, device);
+    auto tensor = ttml::core::from_vector<float, ttnn::DataType::BFLOAT16>(test_data, shape, device);
 
-    auto vec_back = ttml::core::to_vector(tensor);
+    auto vec_back = ttml::core::to_vector<float>(tensor);
 
     ASSERT_EQ(vec_back.size(), test_data.size());
     for (size_t i = 0; i < test_data.size(); i++) {
@@ -38,7 +38,7 @@ TEST_F(TensorUtilsTest, TestFloatToFromTensorEven) {
     }
 }
 
-TEST_F(TensorUtilsTest, TestFloat32Precision) {
+TEST_F(TensorUtilsTest, TestFloat32ToFromTensor) {
     /* This test fails if the numbers are converted to BFloat16 inside from_vector. */
     auto* device = &ttml::autograd::ctx().get_device();
     std::vector<float> test_data = {1.5F, 1.05F, 1.005F, 1.0005F, 1.00005F};
@@ -54,7 +54,7 @@ TEST_F(TensorUtilsTest, TestFloat32Precision) {
     }
 }
 
-TEST_F(TensorUtilsTest, TestFloat32PrecisionLarge) {
+TEST_F(TensorUtilsTest, TestFloat32ToFromTensorLarge) {
     /* This test fails if the numbers are converted to BFloat16 inside from_vector. */
     auto* device = &ttml::autograd::ctx().get_device();
     std::vector<float> test_data;
@@ -74,15 +74,15 @@ TEST_F(TensorUtilsTest, TestFloat32PrecisionLarge) {
     }
 }
 
-TEST_F(TensorUtilsTest, TestFloatToFromTensorGPT2Tokenizer) {
+TEST_F(TensorUtilsTest, TestBFloat16ToFromTensorGPT2Tokenizer) {
     auto* device = &ttml::autograd::ctx().get_device();
     const size_t N = 50304;
     std::vector<float> test_data(N, 0.F);
 
     auto shape = ttnn::Shape({1, 1, 1, N});
-    auto tensor = ttml::core::from_vector(test_data, shape, device);
+    auto tensor = ttml::core::from_vector<float, ttnn::DataType::BFLOAT16>(test_data, shape, device);
 
-    auto vec_back = ttml::core::to_vector(tensor);
+    auto vec_back = ttml::core::to_vector<float>(tensor);
 
     ASSERT_EQ(vec_back.size(), test_data.size());
     for (size_t i = 0; i < test_data.size(); i++) {
@@ -90,14 +90,14 @@ TEST_F(TensorUtilsTest, TestFloatToFromTensorGPT2Tokenizer) {
     }
 }
 
-TEST_F(TensorUtilsTest, TestFloatToFromTensorOdd) {
+TEST_F(TensorUtilsTest, TestBFloat16ToFromTensorOdd) {
     auto* device = &ttml::autograd::ctx().get_device();
     std::vector<float> test_data = {30.F, 20.F, 2.F};
 
     auto shape = ttnn::Shape({1, 1, 1, 3});
-    auto tensor = ttml::core::from_vector(test_data, shape, device);
+    auto tensor = ttml::core::from_vector<float, ttnn::DataType::BFLOAT16>(test_data, shape, device);
 
-    auto vec_back = ttml::core::to_vector(tensor);
+    auto vec_back = ttml::core::to_vector<float>(tensor);
 
     ASSERT_EQ(vec_back.size(), test_data.size());
     for (size_t i = 0; i < test_data.size(); i++) {
@@ -153,7 +153,7 @@ TEST_F(TensorUtilsTest, TestUint32ToFromTensorLargeWithBatch) {
     }
 }
 
-TEST_F(TensorUtilsTest, TestFloatToFromTensorLargeWithBatch) {
+TEST_F(TensorUtilsTest, TestBFloat16ToFromTensorLargeWithBatch) {
     auto* device = &ttml::autograd::ctx().get_device();
     std::vector<float> test_data;
     uint32_t batch_size = 16;
@@ -163,15 +163,15 @@ TEST_F(TensorUtilsTest, TestFloatToFromTensorLargeWithBatch) {
     }
 
     auto shape = ttnn::Shape({batch_size, 1, 1, vec_size / batch_size});
-    auto tensor = ttml::core::from_vector(test_data, shape, device);
-    auto vec_back = ttml::core::to_vector(tensor);
+    auto tensor = ttml::core::from_vector<float, ttnn::DataType::BFLOAT16>(test_data, shape, device);
+    auto vec_back = ttml::core::to_vector<float>(tensor);
     ASSERT_EQ(vec_back.size(), test_data.size());
     for (size_t i = 0; i < test_data.size(); i++) {
         EXPECT_NEAR(vec_back[i], test_data[i], 0.5F);
     }
 }
 
-TEST_F(TensorUtilsTest, TestToFromTensorLarge) {
+TEST_F(TensorUtilsTest, TestBFloat16ToFromTensorLarge) {
     auto* device = &ttml::autograd::ctx().get_device();
     std::vector<float> test_data;
     uint32_t vec_size = 1337;
@@ -180,22 +180,22 @@ TEST_F(TensorUtilsTest, TestToFromTensorLarge) {
     }
 
     auto shape = ttnn::Shape({1, 1, 1, vec_size});
-    auto tensor = ttml::core::from_vector(test_data, shape, device);
-    auto vec_back = ttml::core::to_vector(tensor);
+    auto tensor = ttml::core::from_vector<float, ttnn::DataType::BFLOAT16>(test_data, shape, device);
+    auto vec_back = ttml::core::to_vector<float>(tensor);
     ASSERT_EQ(vec_back.size(), test_data.size());
     for (size_t i = 0; i < test_data.size(); i++) {
         EXPECT_NEAR(vec_back[i], test_data[i], 0.1F);
     }
 }
 
-TEST_F(TensorUtilsTest, TestToFromTensorBatch) {
+TEST_F(TensorUtilsTest, TestBFloat16ToFromTensorBatch) {
     auto* device = &ttml::autograd::ctx().get_device();
     std::vector<float> test_data = {1.F, 5.F, 10.F, 15.F};
 
     auto shape = ttnn::Shape({2, 1, 1, 2});
-    auto tensor = ttml::core::from_vector(test_data, shape, device);
+    auto tensor = ttml::core::from_vector<float, ttnn::DataType::BFLOAT16>(test_data, shape, device);
 
-    auto vec_back = ttml::core::to_vector(tensor);
+    auto vec_back = ttml::core::to_vector<float>(tensor);
 
     ASSERT_EQ(vec_back.size(), test_data.size());
     for (size_t i = 0; i < test_data.size(); i++) {

--- a/tt-train/tests/core/tensor_utils_test.cpp
+++ b/tt-train/tests/core/tensor_utils_test.cpp
@@ -54,6 +54,26 @@ TEST_F(TensorUtilsTest, TestFloat32Precision) {
     }
 }
 
+TEST_F(TensorUtilsTest, TestFloat32PrecisionLarge) {
+    /* This test fails if the numbers are converted to BFloat16 inside from_vector. */
+    auto* device = &ttml::autograd::ctx().get_device();
+    std::vector<float> test_data;
+    uint32_t vec_size = 50304;
+    for (size_t i = 0; i < vec_size; i++) {
+        test_data.push_back(1.0005F);
+    }
+
+    auto shape = ttnn::Shape({1, 1, 1, vec_size});
+    auto tensor = ttml::core::from_vector<float, ttnn::DataType::FLOAT32>(test_data, shape, device);
+
+    auto vec_back = ttml::core::to_vector<float>(tensor);
+
+    ASSERT_EQ(vec_back.size(), test_data.size());
+    for (size_t i = 0; i < test_data.size(); i++) {
+        EXPECT_EQ(vec_back[i], test_data[i]);
+    }
+}
+
 TEST_F(TensorUtilsTest, TestFloatToFromTensorGPT2Tokenizer) {
     auto* device = &ttml::autograd::ctx().get_device();
     const size_t N = 50304;

--- a/tt-train/tests/core/tensor_utils_test.cpp
+++ b/tt-train/tests/core/tensor_utils_test.cpp
@@ -6,6 +6,7 @@
 
 #include <core/ttnn_all_includes.hpp>
 #include <cstdint>
+#include <limits>
 #include <vector>
 
 #include "autograd/auto_context.hpp"
@@ -23,21 +24,7 @@ protected:
     }
 };
 
-TEST_F(TensorUtilsTest, TestBFloat16ToFromTensorEven) {
-    auto* device = &ttml::autograd::ctx().get_device();
-    std::vector<float> test_data = {1.F, 5.F, 10.F, 15.F};
-
-    auto shape = ttnn::Shape({1, 1, 1, 4});
-    auto tensor = ttml::core::from_vector<float, ttnn::DataType::BFLOAT16>(test_data, shape, device);
-
-    auto vec_back = ttml::core::to_vector<float>(tensor);
-
-    ASSERT_EQ(vec_back.size(), test_data.size());
-    for (size_t i = 0; i < test_data.size(); i++) {
-        EXPECT_EQ(vec_back[i], test_data[i]);
-    }
-}
-
+/* <float, ttnn::DataType::FLOAT32> */
 TEST_F(TensorUtilsTest, TestFloat32ToFromTensor) {
     /* This test fails if the numbers are converted to BFloat16 inside from_vector. */
     auto* device = &ttml::autograd::ctx().get_device();
@@ -74,45 +61,48 @@ TEST_F(TensorUtilsTest, TestFloat32ToFromTensorLarge) {
     }
 }
 
-TEST_F(TensorUtilsTest, TestBFloat16ToFromTensorGPT2Tokenizer) {
+TEST_F(TensorUtilsTest, TestFloat32ToFromTensorLargeWithBatch) {
     auto* device = &ttml::autograd::ctx().get_device();
-    const size_t N = 50304;
-    std::vector<float> test_data(N, 0.F);
+    std::vector<float> test_data;
+    uint32_t batch_size = 256;
+    uint32_t vec_size = 256 * batch_size;
+    for (size_t i = 0; i < vec_size; i++) {
+        test_data.push_back(i / 100.f);
+    }
 
-    auto shape = ttnn::Shape({1, 1, 1, N});
-    auto tensor = ttml::core::from_vector<float, ttnn::DataType::BFLOAT16>(test_data, shape, device);
-
+    auto shape = ttnn::Shape({batch_size, 1, 1, vec_size / batch_size});
+    auto tensor = ttml::core::from_vector<float, ttnn::DataType::FLOAT32>(test_data, shape, device);
     auto vec_back = ttml::core::to_vector<float>(tensor);
-
     ASSERT_EQ(vec_back.size(), test_data.size());
     for (size_t i = 0; i < test_data.size(); i++) {
         EXPECT_EQ(vec_back[i], test_data[i]);
     }
 }
 
-TEST_F(TensorUtilsTest, TestBFloat16ToFromTensorOdd) {
+/* Typed tests for <uint32_t, UINT32> and <int32_t, INT32> */
+struct Uint32Config {
+    using scalar_t = uint32_t;
+    static constexpr ttnn::DataType tensor_dtype = ttnn::DataType::UINT32;
+};
+struct Int32Config {
+    using scalar_t = int32_t;
+    static constexpr ttnn::DataType tensor_dtype = ttnn::DataType::INT32;
+};
+
+template <typename Config>
+class TensorUtilsIntOrUintTest : public TensorUtilsTest {};
+using IntOrUintConfigs = ::testing::Types<Uint32Config, Int32Config>;
+TYPED_TEST_SUITE(TensorUtilsIntOrUintTest, IntOrUintConfigs);
+
+TYPED_TEST(TensorUtilsIntOrUintTest, ToFromTensorEven) {
+    using scalar_t = typename TypeParam::scalar_t;
     auto* device = &ttml::autograd::ctx().get_device();
-    std::vector<float> test_data = {30.F, 20.F, 2.F};
-
-    auto shape = ttnn::Shape({1, 1, 1, 3});
-    auto tensor = ttml::core::from_vector<float, ttnn::DataType::BFLOAT16>(test_data, shape, device);
-
-    auto vec_back = ttml::core::to_vector<float>(tensor);
-
-    ASSERT_EQ(vec_back.size(), test_data.size());
-    for (size_t i = 0; i < test_data.size(); i++) {
-        EXPECT_EQ(vec_back[i], test_data[i]);
-    }
-}
-
-TEST_F(TensorUtilsTest, TestUint32ToFromTensorEven) {
-    auto* device = &ttml::autograd::ctx().get_device();
-    std::vector<uint32_t> test_data = {1, 5, 10, 15};
+    std::vector<scalar_t> test_data = {1, 5, 10, 15};
 
     auto shape = ttnn::Shape({1, 1, 1, 4});
-    auto tensor = ttml::core::from_vector<uint32_t, ttnn::DataType::UINT32>(test_data, shape, device);
+    auto tensor = ttml::core::from_vector<scalar_t, TypeParam::tensor_dtype>(test_data, shape, device);
 
-    auto vec_back = ttml::core::to_vector<uint32_t>(tensor);
+    auto vec_back = ttml::core::to_vector<scalar_t>(tensor);
 
     ASSERT_EQ(vec_back.size(), test_data.size());
     for (size_t i = 0; i < test_data.size(); i++) {
@@ -120,14 +110,15 @@ TEST_F(TensorUtilsTest, TestUint32ToFromTensorEven) {
     }
 }
 
-TEST_F(TensorUtilsTest, TestUint32ToFromTensorOdd) {
+TYPED_TEST(TensorUtilsIntOrUintTest, ToFromTensorOdd) {
+    using scalar_t = typename TypeParam::scalar_t;
     auto* device = &ttml::autograd::ctx().get_device();
-    std::vector<uint32_t> test_data = {30, 20, 2};
+    std::vector<scalar_t> test_data = {30, 20, 2};
 
     auto shape = ttnn::Shape({1, 1, 1, 3});
-    auto tensor = ttml::core::from_vector<uint32_t, ttnn::DataType::UINT32>(test_data, shape, device);
+    auto tensor = ttml::core::from_vector<scalar_t, TypeParam::tensor_dtype>(test_data, shape, device);
 
-    auto vec_back = ttml::core::to_vector<uint32_t>(tensor);
+    auto vec_back = ttml::core::to_vector<scalar_t>(tensor);
 
     ASSERT_EQ(vec_back.size(), test_data.size());
     for (size_t i = 0; i < test_data.size(); i++) {
@@ -135,67 +126,159 @@ TEST_F(TensorUtilsTest, TestUint32ToFromTensorOdd) {
     }
 }
 
-TEST_F(TensorUtilsTest, TestUint32ToFromTensorLargeWithBatch) {
+TYPED_TEST(TensorUtilsIntOrUintTest, ToFromTensorLargeWithBatch) {
+    using scalar_t = typename TypeParam::scalar_t;
     auto* device = &ttml::autograd::ctx().get_device();
-    std::vector<uint32_t> test_data;
+    std::vector<scalar_t> test_data;
     uint32_t batch_size = 16;
     uint32_t vec_size = 256 * batch_size;
     for (size_t i = 0; i < vec_size; i++) {
-        test_data.push_back(i);
+        test_data.push_back(static_cast<scalar_t>(i));
     }
 
     auto shape = ttnn::Shape({batch_size, 1, 1, vec_size / batch_size});
-    auto tensor = ttml::core::from_vector<uint32_t, ttnn::DataType::UINT32>(test_data, shape, device);
-    auto vec_back = ttml::core::to_vector<uint32_t>(tensor);
+    auto tensor = ttml::core::from_vector<scalar_t, TypeParam::tensor_dtype>(test_data, shape, device);
+    auto vec_back = ttml::core::to_vector<scalar_t>(tensor);
     ASSERT_EQ(vec_back.size(), test_data.size());
     for (size_t i = 0; i < test_data.size(); i++) {
         EXPECT_EQ(vec_back[i], test_data[i]);
     }
 }
 
-TEST_F(TensorUtilsTest, TestBFloat16ToFromTensorLargeWithBatch) {
+/* Typed tests for <float, BFLOAT16> and <bfloat16, BFLOAT16> */
+struct FloatBf16Config {
+    using scalar_t = float;
+    static constexpr ttnn::DataType tensor_dtype = ttnn::DataType::BFLOAT16;
+    static constexpr bool use_near = true;
+    static constexpr float tolerance_large_batch = 0.5F;
+    static constexpr float tolerance_large = 0.1F;
+};
+struct Bfloat16Bf16Config {
+    using scalar_t = bfloat16;
+    static constexpr ttnn::DataType tensor_dtype = ttnn::DataType::BFLOAT16;
+    static constexpr bool use_near = false;
+    static constexpr float tolerance_large_batch = 0.F;
+    static constexpr float tolerance_large = 0.F;
+};
+
+template <typename Config>
+class TensorUtilsBf16Test : public TensorUtilsTest {};
+using Bf16Configs = ::testing::Types<FloatBf16Config, Bfloat16Bf16Config>;
+TYPED_TEST_SUITE(TensorUtilsBf16Test, Bf16Configs);
+
+TYPED_TEST(TensorUtilsBf16Test, ToFromTensorLargeWithBatch) {
+    using scalar_t = typename TypeParam::scalar_t;
     auto* device = &ttml::autograd::ctx().get_device();
-    std::vector<float> test_data;
+    std::vector<scalar_t> test_data;
     uint32_t batch_size = 16;
     uint32_t vec_size = 256 * batch_size;
     for (size_t i = 0; i < vec_size; i++) {
-        test_data.push_back((float)i / 100.0F);
+        test_data.push_back(static_cast<scalar_t>((float)i / 100.0F));
     }
 
     auto shape = ttnn::Shape({batch_size, 1, 1, vec_size / batch_size});
-    auto tensor = ttml::core::from_vector<float, ttnn::DataType::BFLOAT16>(test_data, shape, device);
-    auto vec_back = ttml::core::to_vector<float>(tensor);
+    auto tensor = ttml::core::from_vector<scalar_t, TypeParam::tensor_dtype>(test_data, shape, device);
+    auto vec_back = ttml::core::to_vector<scalar_t>(tensor);
     ASSERT_EQ(vec_back.size(), test_data.size());
     for (size_t i = 0; i < test_data.size(); i++) {
-        EXPECT_NEAR(vec_back[i], test_data[i], 0.5F);
+        if constexpr (TypeParam::use_near) {
+            EXPECT_NEAR(
+                static_cast<float>(vec_back[i]), static_cast<float>(test_data[i]), TypeParam::tolerance_large_batch);
+        } else {
+            EXPECT_EQ(vec_back[i], test_data[i]);
+        }
     }
 }
 
-TEST_F(TensorUtilsTest, TestBFloat16ToFromTensorLarge) {
+TYPED_TEST(TensorUtilsBf16Test, ToFromTensorLarge) {
+    using scalar_t = typename TypeParam::scalar_t;
     auto* device = &ttml::autograd::ctx().get_device();
-    std::vector<float> test_data;
+    std::vector<scalar_t> test_data;
     uint32_t vec_size = 1337;
     for (size_t i = 0; i < vec_size; i++) {
-        test_data.push_back((float)i / 100.0F);
+        test_data.push_back(static_cast<scalar_t>((float)i / 100.0F));
     }
 
     auto shape = ttnn::Shape({1, 1, 1, vec_size});
-    auto tensor = ttml::core::from_vector<float, ttnn::DataType::BFLOAT16>(test_data, shape, device);
-    auto vec_back = ttml::core::to_vector<float>(tensor);
+    auto tensor = ttml::core::from_vector<scalar_t, TypeParam::tensor_dtype>(test_data, shape, device);
+    auto vec_back = ttml::core::to_vector<scalar_t>(tensor);
     ASSERT_EQ(vec_back.size(), test_data.size());
     for (size_t i = 0; i < test_data.size(); i++) {
-        EXPECT_NEAR(vec_back[i], test_data[i], 0.1F);
+        if constexpr (TypeParam::use_near) {
+            EXPECT_NEAR(static_cast<float>(vec_back[i]), static_cast<float>(test_data[i]), TypeParam::tolerance_large);
+        } else {
+            EXPECT_EQ(vec_back[i], test_data[i]);
+        }
     }
 }
 
-TEST_F(TensorUtilsTest, TestBFloat16ToFromTensorBatch) {
+TYPED_TEST(TensorUtilsBf16Test, ToFromTensorBatch) {
+    using scalar_t = typename TypeParam::scalar_t;
     auto* device = &ttml::autograd::ctx().get_device();
-    std::vector<float> test_data = {1.F, 5.F, 10.F, 15.F};
+    std::vector<scalar_t> test_data = {
+        static_cast<scalar_t>(1.F),
+        static_cast<scalar_t>(5.F),
+        static_cast<scalar_t>(10.F),
+        static_cast<scalar_t>(15.F)};
 
     auto shape = ttnn::Shape({2, 1, 1, 2});
-    auto tensor = ttml::core::from_vector<float, ttnn::DataType::BFLOAT16>(test_data, shape, device);
+    auto tensor = ttml::core::from_vector<scalar_t, TypeParam::tensor_dtype>(test_data, shape, device);
 
-    auto vec_back = ttml::core::to_vector<float>(tensor);
+    auto vec_back = ttml::core::to_vector<scalar_t>(tensor);
+
+    ASSERT_EQ(vec_back.size(), test_data.size());
+    for (size_t i = 0; i < test_data.size(); i++) {
+        EXPECT_EQ(vec_back[i], test_data[i]);
+    }
+}
+
+TYPED_TEST(TensorUtilsBf16Test, ToFromTensorEven) {
+    using scalar_t = typename TypeParam::scalar_t;
+    auto* device = &ttml::autograd::ctx().get_device();
+    std::vector<scalar_t> test_data = {
+        static_cast<scalar_t>(1.F),
+        static_cast<scalar_t>(5.F),
+        static_cast<scalar_t>(10.F),
+        static_cast<scalar_t>(15.F)};
+
+    auto shape = ttnn::Shape({1, 1, 1, 4});
+    auto tensor = ttml::core::from_vector<scalar_t, TypeParam::tensor_dtype>(test_data, shape, device);
+
+    auto vec_back = ttml::core::to_vector<scalar_t>(tensor);
+
+    ASSERT_EQ(vec_back.size(), test_data.size());
+    for (size_t i = 0; i < test_data.size(); i++) {
+        EXPECT_EQ(vec_back[i], test_data[i]);
+    }
+}
+
+TYPED_TEST(TensorUtilsBf16Test, ToFromTensorGPT2Tokenizer) {
+    using scalar_t = typename TypeParam::scalar_t;
+    auto* device = &ttml::autograd::ctx().get_device();
+    const size_t N = 50304;
+    std::vector<scalar_t> test_data(N, static_cast<scalar_t>(0.F));
+
+    auto shape = ttnn::Shape({1, 1, 1, N});
+    auto tensor = ttml::core::from_vector<scalar_t, TypeParam::tensor_dtype>(test_data, shape, device);
+
+    auto vec_back = ttml::core::to_vector<scalar_t>(tensor);
+
+    ASSERT_EQ(vec_back.size(), test_data.size());
+    for (size_t i = 0; i < test_data.size(); i++) {
+        EXPECT_EQ(vec_back[i], test_data[i]);
+    }
+}
+
+TYPED_TEST(TensorUtilsBf16Test, ToFromTensorOdd) {
+    using scalar_t = typename TypeParam::scalar_t;
+    auto* device = &ttml::autograd::ctx().get_device();
+    std::vector<scalar_t> test_data = {
+        static_cast<scalar_t>(30.F), static_cast<scalar_t>(20.F), static_cast<scalar_t>(2.F)};
+
+    auto shape = ttnn::Shape({1, 1, 1, 3});
+    auto tensor = ttml::core::from_vector<scalar_t, TypeParam::tensor_dtype>(test_data, shape, device);
+
+    auto vec_back = ttml::core::to_vector<scalar_t>(tensor);
 
     ASSERT_EQ(vec_back.size(), test_data.size());
     for (size_t i = 0; i < test_data.size(); i++) {

--- a/tt-train/tests/core/tensor_utils_test.cpp
+++ b/tt-train/tests/core/tensor_utils_test.cpp
@@ -12,6 +12,7 @@
 #include "autograd/auto_context.hpp"
 #include "core/tt_tensor_utils.hpp"
 #include "core/xtensor_utils.hpp"
+#include "ttnn/types.hpp"
 
 class TensorUtilsTest : public ::testing::Test {
 protected:
@@ -107,6 +108,28 @@ TYPED_TEST(TtmlFromVectorIntUintTest, ToFromTensorTypeLimits) {
     for (size_t i = 0; i < test_data.size(); i++) {
         EXPECT_EQ(vec_back[i], test_data[i]);
     }
+}
+
+TYPED_TEST(TtmlFromVectorIntUintTest, RowMajorLayout) {
+    using scalar_t = typename TypeParam::scalar_t;
+    auto* device = &ttml::autograd::ctx().get_device();
+    std::vector<scalar_t> test_data = {1, 2, 3};
+
+    auto shape = ttnn::Shape({1, 1, 1, 3});
+    auto tensor =
+        ttml::core::from_vector<scalar_t, TypeParam::tensor_dtype>(test_data, shape, device, ttnn::ROW_MAJOR_LAYOUT);
+    ASSERT_EQ(tensor.layout(), ttnn::ROW_MAJOR_LAYOUT);
+}
+
+TYPED_TEST(TtmlFromVectorIntUintTest, TileLayout) {
+    using scalar_t = typename TypeParam::scalar_t;
+    auto* device = &ttml::autograd::ctx().get_device();
+    std::vector<scalar_t> test_data = {1, 2, 3};
+
+    auto shape = ttnn::Shape({1, 1, 1, 3});
+    auto tensor =
+        ttml::core::from_vector<scalar_t, TypeParam::tensor_dtype>(test_data, shape, device, ttnn::TILE_LAYOUT);
+    ASSERT_EQ(tensor.layout(), ttnn::TILE_LAYOUT);
 }
 
 /* Typed tests for <float, BFLOAT16> and <bfloat16, BFLOAT16> */
@@ -250,6 +273,28 @@ TYPED_TEST(TtmlFromVectorBf16Test, ToFromTensorOdd) {
     }
 }
 
+TYPED_TEST(TtmlFromVectorBf16Test, RowMajorLayout) {
+    using scalar_t = typename TypeParam::scalar_t;
+    auto* device = &ttml::autograd::ctx().get_device();
+    std::vector<scalar_t> test_data = {1, 2, 3};
+
+    auto shape = ttnn::Shape({1, 1, 1, 3});
+    auto tensor =
+        ttml::core::from_vector<scalar_t, TypeParam::tensor_dtype>(test_data, shape, device, ttnn::ROW_MAJOR_LAYOUT);
+    ASSERT_EQ(tensor.layout(), ttnn::ROW_MAJOR_LAYOUT);
+}
+
+TYPED_TEST(TtmlFromVectorBf16Test, TileLayout) {
+    using scalar_t = typename TypeParam::scalar_t;
+    auto* device = &ttml::autograd::ctx().get_device();
+    std::vector<scalar_t> test_data = {1, 2, 3};
+
+    auto shape = ttnn::Shape({1, 1, 1, 3});
+    auto tensor =
+        ttml::core::from_vector<scalar_t, TypeParam::tensor_dtype>(test_data, shape, device, ttnn::TILE_LAYOUT);
+    ASSERT_EQ(tensor.layout(), ttnn::TILE_LAYOUT);
+}
+
 class TtmlFromVectorFloat32Test : public TensorUtilsTest {};
 
 /* <float, ttnn::DataType::FLOAT32> */
@@ -323,6 +368,25 @@ TEST_F(TtmlFromVectorFloat32Test, TestFloat32ToFromTensorLimits) {
     for (size_t i = 0; i < test_data.size(); i++) {
         EXPECT_EQ(vec_back[i], test_data[i]);
     }
+}
+
+TEST_F(TtmlFromVectorFloat32Test, RowMajorLayout) {
+    auto* device = &ttml::autograd::ctx().get_device();
+    std::vector<float> test_data = {1, 2, 3};
+
+    auto shape = ttnn::Shape({1, 1, 1, 3});
+    auto tensor =
+        ttml::core::from_vector<float, ttnn::DataType::FLOAT32>(test_data, shape, device, ttnn::ROW_MAJOR_LAYOUT);
+    ASSERT_EQ(tensor.layout(), ttnn::ROW_MAJOR_LAYOUT);
+}
+
+TEST_F(TtmlFromVectorFloat32Test, TileLayout) {
+    auto* device = &ttml::autograd::ctx().get_device();
+    std::vector<float> test_data = {1, 2, 3};
+
+    auto shape = ttnn::Shape({1, 1, 1, 3});
+    auto tensor = ttml::core::from_vector<float, ttnn::DataType::FLOAT32>(test_data, shape, device, ttnn::TILE_LAYOUT);
+    ASSERT_EQ(tensor.layout(), ttnn::TILE_LAYOUT);
 }
 
 TEST_F(TensorUtilsTest, TestOnes_0) {

--- a/tt-train/tests/core/tensor_utils_test.cpp
+++ b/tt-train/tests/core/tensor_utils_test.cpp
@@ -295,6 +295,22 @@ TYPED_TEST(TtmlFromVectorBf16Test, TileLayout) {
     ASSERT_EQ(tensor.layout(), ttnn::TILE_LAYOUT);
 }
 
+/* Test for issue #38364 */
+TYPED_TEST(TtmlFromVectorBf16Test, VeryLargeTileLayout) {
+    using scalar_t = typename TypeParam::scalar_t;
+    auto* device = &ttml::autograd::ctx().get_device();
+    std::vector<scalar_t> test_data;
+    uint32_t vec_size = 1048576;
+    for (size_t i = 0; i < vec_size; i++) {
+        test_data.push_back(0);
+    }
+
+    auto shape = ttnn::Shape({1, 1, 1, vec_size});
+    auto tensor =
+        ttml::core::from_vector<scalar_t, TypeParam::tensor_dtype>(test_data, shape, device, ttnn::TILE_LAYOUT);
+    ASSERT_EQ(tensor.layout(), ttnn::TILE_LAYOUT);
+}
+
 class TtmlFromVectorFloat32Test : public TensorUtilsTest {};
 
 /* <float, ttnn::DataType::FLOAT32> */

--- a/tt-train/tests/core/tensor_utils_test.cpp
+++ b/tt-train/tests/core/tensor_utils_test.cpp
@@ -24,61 +24,6 @@ protected:
     }
 };
 
-/* <float, ttnn::DataType::FLOAT32> */
-TEST_F(TensorUtilsTest, TestFloat32ToFromTensor) {
-    /* This test fails if the numbers are converted to BFloat16 inside from_vector. */
-    auto* device = &ttml::autograd::ctx().get_device();
-    std::vector<float> test_data = {1.5F, 1.05F, 1.005F, 1.0005F, 1.00005F};
-
-    auto shape = ttnn::Shape({1, 1, 1, 5});
-    auto tensor = ttml::core::from_vector<float, ttnn::DataType::FLOAT32>(test_data, shape, device);
-
-    auto vec_back = ttml::core::to_vector<float>(tensor);
-
-    ASSERT_EQ(vec_back.size(), test_data.size());
-    for (size_t i = 0; i < test_data.size(); i++) {
-        EXPECT_EQ(vec_back[i], test_data[i]);
-    }
-}
-
-TEST_F(TensorUtilsTest, TestFloat32ToFromTensorLarge) {
-    /* This test fails if the numbers are converted to BFloat16 inside from_vector. */
-    auto* device = &ttml::autograd::ctx().get_device();
-    std::vector<float> test_data;
-    uint32_t vec_size = 50304;
-    for (size_t i = 0; i < vec_size; i++) {
-        test_data.push_back(1.0005F);
-    }
-
-    auto shape = ttnn::Shape({1, 1, 1, vec_size});
-    auto tensor = ttml::core::from_vector<float, ttnn::DataType::FLOAT32>(test_data, shape, device);
-
-    auto vec_back = ttml::core::to_vector<float>(tensor);
-
-    ASSERT_EQ(vec_back.size(), test_data.size());
-    for (size_t i = 0; i < test_data.size(); i++) {
-        EXPECT_EQ(vec_back[i], test_data[i]);
-    }
-}
-
-TEST_F(TensorUtilsTest, TestFloat32ToFromTensorLargeWithBatch) {
-    auto* device = &ttml::autograd::ctx().get_device();
-    std::vector<float> test_data;
-    uint32_t batch_size = 256;
-    uint32_t vec_size = 256 * batch_size;
-    for (size_t i = 0; i < vec_size; i++) {
-        test_data.push_back(i / 100.f);
-    }
-
-    auto shape = ttnn::Shape({batch_size, 1, 1, vec_size / batch_size});
-    auto tensor = ttml::core::from_vector<float, ttnn::DataType::FLOAT32>(test_data, shape, device);
-    auto vec_back = ttml::core::to_vector<float>(tensor);
-    ASSERT_EQ(vec_back.size(), test_data.size());
-    for (size_t i = 0; i < test_data.size(); i++) {
-        EXPECT_EQ(vec_back[i], test_data[i]);
-    }
-}
-
 /* Typed tests for <uint32_t, UINT32> and <int32_t, INT32> */
 struct Uint32Config {
     using scalar_t = uint32_t;
@@ -90,11 +35,11 @@ struct Int32Config {
 };
 
 template <typename Config>
-class TensorUtilsIntOrUintTest : public TensorUtilsTest {};
+class TtmlFromVectorIntUintTest : public TensorUtilsTest {};
 using IntOrUintConfigs = ::testing::Types<Uint32Config, Int32Config>;
-TYPED_TEST_SUITE(TensorUtilsIntOrUintTest, IntOrUintConfigs);
+TYPED_TEST_SUITE(TtmlFromVectorIntUintTest, IntOrUintConfigs);
 
-TYPED_TEST(TensorUtilsIntOrUintTest, ToFromTensorEven) {
+TYPED_TEST(TtmlFromVectorIntUintTest, ToFromTensorEven) {
     using scalar_t = typename TypeParam::scalar_t;
     auto* device = &ttml::autograd::ctx().get_device();
     std::vector<scalar_t> test_data = {1, 5, 10, 15};
@@ -110,7 +55,7 @@ TYPED_TEST(TensorUtilsIntOrUintTest, ToFromTensorEven) {
     }
 }
 
-TYPED_TEST(TensorUtilsIntOrUintTest, ToFromTensorOdd) {
+TYPED_TEST(TtmlFromVectorIntUintTest, ToFromTensorOdd) {
     using scalar_t = typename TypeParam::scalar_t;
     auto* device = &ttml::autograd::ctx().get_device();
     std::vector<scalar_t> test_data = {30, 20, 2};
@@ -126,7 +71,7 @@ TYPED_TEST(TensorUtilsIntOrUintTest, ToFromTensorOdd) {
     }
 }
 
-TYPED_TEST(TensorUtilsIntOrUintTest, ToFromTensorLargeWithBatch) {
+TYPED_TEST(TtmlFromVectorIntUintTest, ToFromTensorLargeWithBatch) {
     using scalar_t = typename TypeParam::scalar_t;
     auto* device = &ttml::autograd::ctx().get_device();
     std::vector<scalar_t> test_data;
@@ -139,6 +84,25 @@ TYPED_TEST(TensorUtilsIntOrUintTest, ToFromTensorLargeWithBatch) {
     auto shape = ttnn::Shape({batch_size, 1, 1, vec_size / batch_size});
     auto tensor = ttml::core::from_vector<scalar_t, TypeParam::tensor_dtype>(test_data, shape, device);
     auto vec_back = ttml::core::to_vector<scalar_t>(tensor);
+    ASSERT_EQ(vec_back.size(), test_data.size());
+    for (size_t i = 0; i < test_data.size(); i++) {
+        EXPECT_EQ(vec_back[i], test_data[i]);
+    }
+}
+
+TYPED_TEST(TtmlFromVectorIntUintTest, ToFromTensorTypeLimits) {
+    using scalar_t = typename TypeParam::scalar_t;
+    auto lowest = std::numeric_limits<scalar_t>::lowest();
+    auto max = std::numeric_limits<scalar_t>::max();
+
+    auto* device = &ttml::autograd::ctx().get_device();
+    std::vector<scalar_t> test_data = {lowest, max, 0};
+
+    auto shape = ttnn::Shape({1, 1, 1, 3});
+    auto tensor = ttml::core::from_vector<scalar_t, TypeParam::tensor_dtype>(test_data, shape, device);
+
+    auto vec_back = ttml::core::to_vector<scalar_t>(tensor);
+
     ASSERT_EQ(vec_back.size(), test_data.size());
     for (size_t i = 0; i < test_data.size(); i++) {
         EXPECT_EQ(vec_back[i], test_data[i]);
@@ -162,11 +126,11 @@ struct Bfloat16Bf16Config {
 };
 
 template <typename Config>
-class TensorUtilsBf16Test : public TensorUtilsTest {};
+class TtmlFromVectorBf16Test : public TensorUtilsTest {};
 using Bf16Configs = ::testing::Types<FloatBf16Config, Bfloat16Bf16Config>;
-TYPED_TEST_SUITE(TensorUtilsBf16Test, Bf16Configs);
+TYPED_TEST_SUITE(TtmlFromVectorBf16Test, Bf16Configs);
 
-TYPED_TEST(TensorUtilsBf16Test, ToFromTensorLargeWithBatch) {
+TYPED_TEST(TtmlFromVectorBf16Test, ToFromTensorLargeWithBatch) {
     using scalar_t = typename TypeParam::scalar_t;
     auto* device = &ttml::autograd::ctx().get_device();
     std::vector<scalar_t> test_data;
@@ -190,7 +154,7 @@ TYPED_TEST(TensorUtilsBf16Test, ToFromTensorLargeWithBatch) {
     }
 }
 
-TYPED_TEST(TensorUtilsBf16Test, ToFromTensorLarge) {
+TYPED_TEST(TtmlFromVectorBf16Test, ToFromTensorLarge) {
     using scalar_t = typename TypeParam::scalar_t;
     auto* device = &ttml::autograd::ctx().get_device();
     std::vector<scalar_t> test_data;
@@ -212,7 +176,7 @@ TYPED_TEST(TensorUtilsBf16Test, ToFromTensorLarge) {
     }
 }
 
-TYPED_TEST(TensorUtilsBf16Test, ToFromTensorBatch) {
+TYPED_TEST(TtmlFromVectorBf16Test, ToFromTensorBatch) {
     using scalar_t = typename TypeParam::scalar_t;
     auto* device = &ttml::autograd::ctx().get_device();
     std::vector<scalar_t> test_data = {
@@ -232,7 +196,7 @@ TYPED_TEST(TensorUtilsBf16Test, ToFromTensorBatch) {
     }
 }
 
-TYPED_TEST(TensorUtilsBf16Test, ToFromTensorEven) {
+TYPED_TEST(TtmlFromVectorBf16Test, ToFromTensorEven) {
     using scalar_t = typename TypeParam::scalar_t;
     auto* device = &ttml::autograd::ctx().get_device();
     std::vector<scalar_t> test_data = {
@@ -252,7 +216,7 @@ TYPED_TEST(TensorUtilsBf16Test, ToFromTensorEven) {
     }
 }
 
-TYPED_TEST(TensorUtilsBf16Test, ToFromTensorGPT2Tokenizer) {
+TYPED_TEST(TtmlFromVectorBf16Test, ToFromTensorGPT2Tokenizer) {
     using scalar_t = typename TypeParam::scalar_t;
     auto* device = &ttml::autograd::ctx().get_device();
     const size_t N = 50304;
@@ -269,7 +233,7 @@ TYPED_TEST(TensorUtilsBf16Test, ToFromTensorGPT2Tokenizer) {
     }
 }
 
-TYPED_TEST(TensorUtilsBf16Test, ToFromTensorOdd) {
+TYPED_TEST(TtmlFromVectorBf16Test, ToFromTensorOdd) {
     using scalar_t = typename TypeParam::scalar_t;
     auto* device = &ttml::autograd::ctx().get_device();
     std::vector<scalar_t> test_data = {
@@ -279,6 +243,81 @@ TYPED_TEST(TensorUtilsBf16Test, ToFromTensorOdd) {
     auto tensor = ttml::core::from_vector<scalar_t, TypeParam::tensor_dtype>(test_data, shape, device);
 
     auto vec_back = ttml::core::to_vector<scalar_t>(tensor);
+
+    ASSERT_EQ(vec_back.size(), test_data.size());
+    for (size_t i = 0; i < test_data.size(); i++) {
+        EXPECT_EQ(vec_back[i], test_data[i]);
+    }
+}
+
+class TtmlFromVectorFloat32Test : public TensorUtilsTest {};
+
+/* <float, ttnn::DataType::FLOAT32> */
+TEST_F(TtmlFromVectorFloat32Test, TestFloat32ToFromTensor) {
+    /* This test fails if the numbers are converted to BFloat16 inside from_vector. */
+    auto* device = &ttml::autograd::ctx().get_device();
+    std::vector<float> test_data = {1.5F, 1.05F, 1.005F, 1.0005F, 1.00005F};
+
+    auto shape = ttnn::Shape({1, 1, 1, 5});
+    auto tensor = ttml::core::from_vector<float, ttnn::DataType::FLOAT32>(test_data, shape, device);
+
+    auto vec_back = ttml::core::to_vector<float>(tensor);
+
+    ASSERT_EQ(vec_back.size(), test_data.size());
+    for (size_t i = 0; i < test_data.size(); i++) {
+        EXPECT_EQ(vec_back[i], test_data[i]);
+    }
+}
+
+TEST_F(TtmlFromVectorFloat32Test, TestFloat32ToFromTensorLarge) {
+    /* This test fails if the numbers are converted to BFloat16 inside from_vector. */
+    auto* device = &ttml::autograd::ctx().get_device();
+    std::vector<float> test_data;
+    uint32_t vec_size = 50304;
+    for (size_t i = 0; i < vec_size; i++) {
+        test_data.push_back(1.0005F);
+    }
+
+    auto shape = ttnn::Shape({1, 1, 1, vec_size});
+    auto tensor = ttml::core::from_vector<float, ttnn::DataType::FLOAT32>(test_data, shape, device);
+
+    auto vec_back = ttml::core::to_vector<float>(tensor);
+
+    ASSERT_EQ(vec_back.size(), test_data.size());
+    for (size_t i = 0; i < test_data.size(); i++) {
+        EXPECT_EQ(vec_back[i], test_data[i]);
+    }
+}
+
+TEST_F(TtmlFromVectorFloat32Test, TestFloat32ToFromTensorLargeWithBatch) {
+    auto* device = &ttml::autograd::ctx().get_device();
+    std::vector<float> test_data;
+    uint32_t batch_size = 256;
+    uint32_t vec_size = 256 * batch_size;
+    for (size_t i = 0; i < vec_size; i++) {
+        test_data.push_back(i / 100.f);
+    }
+
+    auto shape = ttnn::Shape({batch_size, 1, 1, vec_size / batch_size});
+    auto tensor = ttml::core::from_vector<float, ttnn::DataType::FLOAT32>(test_data, shape, device);
+    auto vec_back = ttml::core::to_vector<float>(tensor);
+    ASSERT_EQ(vec_back.size(), test_data.size());
+    for (size_t i = 0; i < test_data.size(); i++) {
+        EXPECT_EQ(vec_back[i], test_data[i]);
+    }
+}
+
+TEST_F(TtmlFromVectorFloat32Test, TestFloat32ToFromTensorLimits) {
+    auto* device = &ttml::autograd::ctx().get_device();
+    auto min = std::numeric_limits<float>::min();
+    auto lowest = std::numeric_limits<float>::lowest();
+    auto max = std::numeric_limits<float>::max();
+    std::vector<float> test_data = {min, lowest, max};
+
+    auto shape = ttnn::Shape({1, 1, 1, 3});
+    auto tensor = ttml::core::from_vector<float, ttnn::DataType::FLOAT32>(test_data, shape, device);
+
+    auto vec_back = ttml::core::to_vector<float>(tensor);
 
     ASSERT_EQ(vec_back.size(), test_data.size());
     for (size_t i = 0; i < test_data.size(); i++) {


### PR DESCRIPTION
### Ticket
[Link](https://github.com/tenstorrent/tt-metal/issues/37273) to Github Issue

### Problem description

### What's changed


### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=ichovpan/ttml_from_vector)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:ichovpan/ttml_from_vector)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ichovpan/ttml_from_vector)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ichovpan/ttml_from_vector)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ichovpan/ttml_from_vector)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ichovpan/ttml_from_vector)
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ichovpan/ttml_from_vector)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ichovpan/ttml_from_vector)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ichovpan/ttml_from_vector)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ichovpan/ttml_from_vector)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ichovpan/ttml_from_vector)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ichovpan/ttml_from_vector)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
