### PR TITLE
Removed not needed barrier between data and semaphore multicast in MMs

### DIFF
--- a/tests/tt_metal/tt_metal/perf_microbenchmark/old/matmul/kernels/reader_bmm_tile_layout_in0_sender_padding.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/old/matmul/kernels/reader_bmm_tile_layout_in0_sender_padding.cpp
@@ -106,11 +106,6 @@ void kernel_main() {
             // Note: no need for write barrier, since these two multicasts are done on the same noc id and same vc even
             // though cmd bufs are different Also, this only works because we are setting VCs statically (using
             // NOC_CMD_STATIC_VC).
-#ifdef ARCH_BLACKHOLE
-            // On Blackhole the flush is needed because the commands go into separate cmd buffer FIFOs and may not be
-            // sent in order they are issued
-            noc_async_writes_flushed();
-#endif
 
             // We should also multicast the flag to destinations
             uint64_t in0_mcast_receiver_semaphore_noc_addr = get_noc_multicast_addr(

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/old/matmul/kernels/reader_bmm_tile_layout_in1_sender_writer_padding.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/old/matmul/kernels/reader_bmm_tile_layout_in1_sender_writer_padding.cpp
@@ -182,11 +182,6 @@ void kernel_main() {
             // Note: no need for write barrier, since these two multicasts are done on the same noc id and same vc even
             // though cmd bufs are different Also, this only works because we are setting VCs statically (using
             // NOC_CMD_STATIC_VC).
-#ifdef ARCH_BLACKHOLE
-            // On Blackhole the flush is needed because the commands go into separate cmd buffer FIFOs and may not be
-            // sent in order they are issued
-            noc_async_writes_flushed();
-#endif
 
             // We should also multicast the flag to destinations
             uint64_t in1_mcast_receiver_semaphore_noc_addr = get_noc_multicast_addr(
@@ -250,11 +245,6 @@ void kernel_main() {
             // Note: no need for write barrier, since these two multicasts are done on the same noc id and same vc even
             // though cmd bufs are different Also, this only works because we are setting VCs statically (using
             // NOC_CMD_STATIC_VC).
-#ifdef ARCH_BLACKHOLE
-            // On Blackhole the flush is needed because the commands go into separate cmd buffer FIFOs and may not be
-            // sent in order they are issued
-            noc_async_writes_flushed();
-#endif
 
             // We should also multicast the flag to destinations
             uint64_t in3_mcast_receiver_semaphore_noc_addr = get_noc_multicast_addr(

--- a/tt_metal/programming_examples/matmul/matmul_common/kernels/dataflow/reader_bmm_tile_layout_in0_receiver_in1_sender.cpp
+++ b/tt_metal/programming_examples/matmul/matmul_common/kernels/dataflow/reader_bmm_tile_layout_in0_receiver_in1_sender.cpp
@@ -147,11 +147,6 @@ void kernel_main() {
             // Note: no need for write barrier, since these two multicasts are done on the same noc id and same vc even
             // though cmd bufs are different Also, this only works because we are setting VCs statically (using
             // NOC_CMD_STATIC_VC).
-#ifdef ARCH_BLACKHOLE
-            // On Blackhole the flush is needed because the commands go into separate cmd buffer FIFOs and may not be
-            // sent in order they are issued
-            noc_async_writes_flushed();
-#endif
 
             // We should also multicast the flag to destinations
             uint64_t in1_mcast_receiver_semaphore_noc_addr = get_noc_multicast_addr(

--- a/tt_metal/programming_examples/matmul/matmul_common/kernels/dataflow/reader_bmm_tile_layout_in0_sender_in1_receiver.cpp
+++ b/tt_metal/programming_examples/matmul/matmul_common/kernels/dataflow/reader_bmm_tile_layout_in0_sender_in1_receiver.cpp
@@ -128,11 +128,6 @@ void kernel_main() {
             // Note: no need for write barrier, since these two multicasts are done on the same noc id and same vc even
             // though cmd bufs are different Also, this only works because we are setting VCs statically (using
             // NOC_CMD_STATIC_VC).
-#ifdef ARCH_BLACKHOLE
-            // On Blackhole the flush is needed because the commands go into separate cmd buffer FIFOs and may not be
-            // sent in order they are issued
-            noc_async_writes_flushed();
-#endif
 
             // We should also multicast the flag to destinations
             uint64_t in0_mcast_receiver_semaphore_noc_addr = get_noc_multicast_addr(

--- a/tt_metal/programming_examples/matmul/matmul_common/kernels/dataflow/reader_bmm_tile_layout_in0_sender_in1_sender.cpp
+++ b/tt_metal/programming_examples/matmul/matmul_common/kernels/dataflow/reader_bmm_tile_layout_in0_sender_in1_sender.cpp
@@ -143,11 +143,6 @@ void kernel_main() {
             // Note: no need for write barrier, since these two multicasts are done on the same noc id and same vc even
             // though cmd bufs are different Also, this only works because we are setting VCs statically (using
             // NOC_CMD_STATIC_VC).
-#ifdef ARCH_BLACKHOLE
-            // On Blackhole the flush is needed because the commands go into separate cmd buffer FIFOs and may not be
-            // sent in order they are issued
-            noc_async_writes_flushed();
-#endif
 
             // We should also multicast the flag to destinations
             uint64_t in0_mcast_receiver_semaphore_noc_addr = get_noc_multicast_addr(
@@ -205,11 +200,6 @@ void kernel_main() {
             // Note: no need for write barrier, since these two multicasts are done on the same noc id and same vc even
             // though cmd bufs are different Also, this only works because we are setting VCs statically (using
             // NOC_CMD_STATIC_VC).
-#ifdef ARCH_BLACKHOLE
-            // On Blackhole the flush is needed because the commands go into separate cmd buffer FIFOs and may not be
-            // sent in order they are issued
-            noc_async_writes_flushed();
-#endif
 
             // We should also multicast the flag to destinations
             uint64_t in1_mcast_receiver_semaphore_noc_addr = get_noc_multicast_addr(

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/activation_reader_width_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/activation_reader_width_sharded.cpp
@@ -237,11 +237,6 @@ void kernel_main() {
                     // vc even though cmd bufs are different Also, this only works because we are setting VCs statically
                     // (using NOC_CMD_STATIC_VC).
 
-#ifdef ARCH_BLACKHOLE
-                    // On Blackhole the flush is needed because the commands go into separate cmd buffer FIFOs and may
-                    // not be sent in order they are issued
-                    noc_async_writes_flushed();
-#endif
                     // We should also multicast VALID flag to destinations for receiver semaphore
                     noc_semaphore_set_multicast_loopback_src(
                         act_mcast_sender_semaphore_valid_addr,

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/reader_conv_activations_2d_mcast_padded_with_halo_3x3_weights_v2.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/reader_conv_activations_2d_mcast_padded_with_halo_3x3_weights_v2.cpp
@@ -282,11 +282,6 @@ void kernel_main() {
                     // Note: no need for write barrier, since these two multicasts are done on the same noc id and
                     // same vc even though cmd bufs are different Also, this only works because we are setting VCs
                     // statically (using NOC_CMD_STATIC_VC).
-#ifdef ARCH_BLACKHOLE
-                    // On Blackhole the flush is needed because the commands go into separate cmd buffer FIFOs and
-                    // may not be sent in order they are issued
-                    noc_async_writes_flushed();
-#endif
 
                     if (is_receiver_core) {
                         // We should also multicast VALID flag to destinations for receiver semaphore

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/reader_writer_tiled_out_1d_mcast_sender_conv_weights_tiled_col_to_rm_blocks.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/reader_writer_tiled_out_1d_mcast_sender_conv_weights_tiled_col_to_rm_blocks.cpp
@@ -255,12 +255,6 @@ void kernel_main() {
                 // Note: no need for write barrier, since these two multicasts are done on the same noc id and
                 // same vc even though cmd bufs are different Also, this only works because we are setting VCs
                 // statically (using NOC_CMD_STATIC_VC).
-#ifdef ARCH_BLACKHOLE
-                // On Blackhole the flush is needed because the commands go into separate cmd buffer FIFOs and
-                // may not be sent in order they are issued
-                noc_async_writes_flushed();
-#endif
-
                 // We should also multicast the flag to destinations
                 // num_dests must not include source, since we are NOT really doing a local copy!
                 noc_semaphore_set_multicast(
@@ -314,12 +308,6 @@ void kernel_main() {
                 // Note: no need for write barrier, since these two multicasts are done on the same noc id and same vc
                 // even though cmd bufs are different Also, this only works because we are setting VCs statically (using
                 // NOC_CMD_STATIC_VC).
-#ifdef ARCH_BLACKHOLE
-                // On Blackhole the flush is needed because the commands go into separate cmd buffer FIFOs and may not
-                // be sent in order they are issued
-                noc_async_writes_flushed();
-#endif
-
                 // We should also multicast the flag to destinations
                 // num_dests must not include source, since we are NOT really doing a local copy!
                 noc_semaphore_set_multicast(

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/writer_tiled_out_2d_mcast_sender_conv_weights_tiled_col_to_rm_blocks.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/writer_tiled_out_2d_mcast_sender_conv_weights_tiled_col_to_rm_blocks.cpp
@@ -267,11 +267,6 @@ void kernel_main() {
                     // Note: no need for write barrier, since these two multicasts are done on the same noc id and same
                     // vc even though cmd bufs are different Also, this only works because we are setting VCs statically
                     // (using NOC_CMD_STATIC_VC).
-#ifdef ARCH_BLACKHOLE
-                    // On Blackhole the flush is needed because the commands go into separate cmd buffer FIFOs and may
-                    // not be sent in order they are issued
-                    noc_async_writes_flushed();
-#endif
                     // We should also multicast the flag to destinations
                     // num_dests must not include source, since we are NOT really doing a local copy!
                     noc_semaphore_set_multicast(
@@ -332,11 +327,6 @@ void kernel_main() {
                     // Note: no need for write barrier, since these two multicasts are done on the same noc id and same
                     // vc even though cmd bufs are different Also, this only works because we are setting VCs statically
                     // (using NOC_CMD_STATIC_VC).
-#ifdef ARCH_BLACKHOLE
-                    // On Blackhole the flush is needed because the commands go into separate cmd buffer FIFOs and may
-                    // not be sent in order they are issued
-                    noc_async_writes_flushed();
-#endif
                     // We should also multicast the flag to destinations
                     // num_dests must not include source, since we are NOT really doing a local copy!
                     noc_semaphore_set_multicast(

--- a/ttnn/cpp/ttnn/operations/experimental/matmul/group_attn_matmul/device/kernels/dataflow/reader_mcast_transformer_group_attn_matmul.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/matmul/group_attn_matmul/device/kernels/dataflow/reader_mcast_transformer_group_attn_matmul.cpp
@@ -253,11 +253,6 @@ void kernel_main() {
                                 // Note: no need for write barrier, since these two multicasts are done on the same noc
                                 // id and same vc even though cmd bufs are different Also, this only works because we
                                 // are setting VCs statically (using NOC_CMD_STATIC_VC).
-#ifdef ARCH_BLACKHOLE
-                                // On Blackhole the flush is needed because the commands go into separate cmd buffer
-                                // FIFOs and may not be sent in order they are issued
-                                noc_async_writes_flushed();
-#endif
 
                                 // We should also multicast VALID flag to destinations for receiver semaphore
                                 noc_semaphore_set_multicast(

--- a/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/device/kernels/dm_in0_sender.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/device/kernels/dm_in0_sender.cpp
@@ -246,10 +246,6 @@ void kernel_main() {
                      */
                     noc_async_write(in0_start_address, in0_unicast_data_addr, current_block_bytes);
 
-#ifdef ARCH_BLACKHOLE
-                    noc_async_writes_flushed();
-#endif
-
                     noc_semaphore_set_remote(in0_valid_semaphore_addr, in0_receiver_semaphore_noc_addr);
                 }
             }

--- a/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/device/kernels/dm_in1_sender_out.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/device/kernels/dm_in1_sender_out.cpp
@@ -218,10 +218,6 @@ void kernel_main() {
                         in1_start_address += full_N_tiles_bytes;
                     }
 
-#ifdef ARCH_BLACKHOLE
-                    noc_async_writes_flushed();
-#endif
-
                     noc_semaphore_set_remote(in1_valid_semaphore_addr, in1_receiver_semaphore_noc_addr);
                 }
             }

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_sender_padding.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_sender_padding.cpp
@@ -298,12 +298,6 @@ void kernel_main() {
                         // Note: no need for write barrier, since these two multicasts are done on the same noc id, same
                         // vc, same cmd_buf Also, this only works because we are setting VCs statically (using
                         // NOC_CMD_STATIC_VC).
-#ifdef ARCH_BLACKHOLE
-                        // On Blackhole the flush is needed because NoC latency is higherthan L1 <-> RISCV
-                        // latency which means data could be changed before write is issued.
-                        noc_async_writes_flushed();
-#endif  // ARCH_BLACKHOLE
-
                         // We should also multicast the flag to destinations
                         // num_dests must not include source, since we are NOT really doing a local copy!
                         noc_semaphore_set_multicast(

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_sender_receiver_padding_block_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_sender_receiver_padding_block_sharded.cpp
@@ -267,12 +267,6 @@ void kernel_main() {
                         // Note: no need for write barrier, since these two multicasts are done on the same noc id and
                         // same vc even though cmd bufs are different Also, this only works because we are setting VCs
                         // statically (using NOC_CMD_STATIC_VC).
-#ifdef ARCH_BLACKHOLE
-                        // On Blackhole the flush is needed because NoC latency is higher than L1 <-> RISCV latency
-                        // which means data could be changed before
-                        //  write is issued.
-                        noc_async_writes_flushed();
-#endif
 
                     } else if constexpr (core_in_in0_receiver_mcast_grid) {
                         uint64_t in0_mcast_sender_semaphore_noc_addr = remote_sender_noc_addrs[block_id];

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_sender_writer_padding.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_sender_writer_padding.cpp
@@ -358,13 +358,6 @@ void kernel_main() {
                         // Note: no need for write barrier, since these two multicasts are done on the same noc id and
                         // same vc even though cmd bufs are different Also, this only works because we are setting VCs
                         // statically (using NOC_CMD_STATIC_VC).
-#ifdef ARCH_BLACKHOLE
-                        // On Blackhole the flush is needed because NoC latency is higher than L1 <-> RISCV latency
-                        // which means data could be changed before
-                        //  write is issued.
-                        noc_async_writes_flushed();
-#endif  // ARCH_BLACKHOLE
-
                         // We should also multicast the flag to destinations
                         // num_dests must not include source, since we are NOT really doing a local copy!
                         noc_semaphore_set_multicast(
@@ -463,12 +456,6 @@ void kernel_main() {
                         // Note: no need for write barrier, since these two multicasts are done on the same noc id, same
                         // vc, same cmd_buf Also, this only works because we are setting VCs statically (using
                         // NOC_CMD_STATIC_VC).
-#ifdef ARCH_BLACKHOLE
-                        // On Blackhole the flush is needed because NoC latency is higherthan L1 <-> RISCV
-                        // latency which means data could be changed before write is issued.
-                        noc_async_writes_flushed();
-#endif  // ARCH_BLACKHOLE
-
                         // We should also multicast the flag to destinations
                         // num_dests must not include source, since we are NOT really doing a local copy!
                         noc_semaphore_set_multicast(


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
In matmul data movement kernels we have this pattern 

```
noc_async_write_multicast(..)
#ifdef ARCH_BLACKHOLE
                    // On Blackhole the flush is needed because the commands go into separate cmd buffer FIFOs and may
                    // not be sent in order they are issued
                    noc_async_writes_flushed();
#endif
noc_async_semaphore_set(..)
```

After disabling cmd_buff_fifo feature (disabled during bring up) `noc_async_writes_flushed();` is not needed and can be removed. In most cases this wont show any improvements, but for large multicasts this can be a noticeable speed up.  

### What's changed
Describe the approach used to solve the problem.
Summarize the changes made and its impact.

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=vvukomanovic/0226-mm-flushed-barrier-remvoal)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:vvukomanovic/0226-mm-flushed-barrier-remvoal)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=vvukomanovic/0226-mm-flushed-barrier-remvoal)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:vvukomanovic/0226-mm-flushed-barrier-remvoal)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=vvukomanovic/0226-mm-flushed-barrier-remvoal)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:vvukomanovic/0226-mm-flushed-barrier-remvoal)
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=vvukomanovic/0226-mm-flushed-barrier-remvoal)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:vvukomanovic/0226-mm-flushed-barrier-remvoal)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=vvukomanovic/0226-mm-flushed-barrier-remvoal)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:vvukomanovic/0226-mm-flushed-barrier-remvoal)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=vvukomanovic/0226-mm-flushed-barrier-remvoal)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:vvukomanovic/0226-mm-flushed-barrier-remvoal)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
