### PR TITLE
Convert Sparse Multicast Static Asserts to Runtime Asserts

### DIFF
--- a/tt_metal/fabric/fabric_edm_packet_header.hpp
+++ b/tt_metal/fabric/fabric_edm_packet_header.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/tt_metal/fabric/fabric_edm_packet_header.hpp
+++ b/tt_metal/fabric/fabric_edm_packet_header.hpp
@@ -905,13 +905,12 @@ public:
     // Helper to calculate routing fields for sparse multicast
     static LowLatencyRoutingFieldsT<ExtensionWords> calculate_chip_sparse_multicast_routing_fields(
         const SPARSE_MCAST_ROUTING_CMD_HDR_TYPE& chip_sparse_multicast_command_header) {
-        // Delegate to canonical encoder
-        // We currently only support a base packet header, not extension words.
-        static_assert(
-            is_sparse_multicast_supported<ExtensionWords>::value,
-            "Sparse multicast is currently only supported for ExtensionWords = 0");
-
+        // Sparse multicast currently only supports a base packet header, not extension words.
+#if defined(KERNEL_BUILD) || defined(FW_BUILD)
+        ASSERT(is_sparse_multicast_supported<ExtensionWords>::value);
+#endif
         uint32_t buffer;
+        // Delegate to canonical encoder
         routing_encoding::encode_1d_sparse_multicast(chip_sparse_multicast_command_header.hop_mask, buffer);
         // Unpack using helper
         return LowLatencyRoutingFieldsT<ExtensionWords>::from_buffer(&buffer);

--- a/tt_metal/hostdevcommon/api/hostdevcommon/fabric_common.h
+++ b/tt_metal/hostdevcommon/api/hostdevcommon/fabric_common.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/tt_metal/hostdevcommon/api/hostdevcommon/fabric_common.h
+++ b/tt_metal/hostdevcommon/api/hostdevcommon/fabric_common.h
@@ -363,9 +363,10 @@ template <typename HopMaskType>
 inline void encode_1d_sparse_multicast(HopMaskType hop_mask, uint32_t& buffer) {
     using LowLatencyFields = RoutingFieldsConstants::LowLatency;
 
-    static_assert(
-        std::is_unsigned_v<HopMaskType> && (sizeof(HopMaskType) == sizeof(uint16_t)),
-        "hop_mask must be an unsigned integer and currently only supports uint16_t, tracked in #36581");
+// Currently, hop_mask must be an unsigned integer and currently only supports uint16_t, tracked in #36581
+#if defined(KERNEL_BUILD) || defined(FW_BUILD)
+    ASSERT(std::is_unsigned_v<HopMaskType> && (sizeof(HopMaskType) == sizeof(uint16_t)));
+#endif
 
     auto set_hop_field = [&](uint32_t hop_index, uint32_t field_value) {
         const uint32_t bit_pos = (hop_index % LowLatencyFields::BASE_HOPS) * LowLatencyFields::FIELD_WIDTH;


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/37564

### Problem description
When we added sparse multicast messaging to fabric, we only enabled and tested it for 1D LowLatency packet headers with 0 extension words. To catch invalid use-cases, we inserted static_asserts that verify ExtensionWords is set to 0, and by extension, a sparse multicast hop mask is only 16 bits wide.

However, these static asserts are being triggered whenever ExtensionWords is set to 1, even if sparse multicast is not being used. This is blocking CCL work.

### What's changed
- Modified both static_asserts into runtime asserts, so that they only trigger when sparse multicast functions are called and watcher is enabled
- NOTE: This is a temporary fix, and work still needs to be done to catch these conditions without blocking others. 
- NOTE: More work needs to be done to test the cases where `ExtensionWords=1`. First, to save time we did not actually test on a machine with more than 17 hops. Instead, we forced `ExtensionWords=1` in our existing unit tests, which caused the tests to hang. Thus, even though the ASSERTS were silent when expected, we're not sure if it's because the ASSERTs were silent or because the tests hung before they got to that stage. The sparse mcast tests also hung without asserting, and thus it's possible the ASSERTs are not properly working. 
 
### Checklist
- [x] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=jhaiTT/37564-hotfix-sparse-mcast-extension-words)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:jhaiTT/37564-hotfix-sparse-mcast-extension-words) https://github.com/tenstorrent/tt-metal/actions/runs/21886398908
- [x] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=jhaiTT/37564-hotfix-sparse-mcast-extension-words)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:jhaiTT/37564-hotfix-sparse-mcast-extension-words) https://github.com/tenstorrent/tt-metal/actions/runs/21886409585
- [x] TM-Fabric Tests https://github.com/tenstorrent/tt-metal/actions/runs/21886417712 (fails like main)