### PR TITLE
Fix custom_mm leaving counters in nonzero state

### DIFF
--- a/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_math_custom_mm_api.h
+++ b/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_math_custom_mm_api.h
@@ -13,7 +13,7 @@
  * in0 tile shape: [{1, 2, 4, 8}, 32]
  * in1 tile shape: [32, 32]
  * rt_dim: 1
- * ct_dim: {1, 2, 4, 6, 8, 10, 11, 12, 14, 16}
+ * ct_dim: {1, 2, 4, 6, 8, 10, 12, 14, 16}
  * kt_dim: even number from 2 to 256 (inclusive)
  * fidelity: LoFi only
  * throttle: not supported

--- a/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_math_custom_mm_api.h
+++ b/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_math_custom_mm_api.h
@@ -6,10 +6,26 @@
 #include "../../../../../third_party/tt_llk/tt_llk_blackhole/llk_lib/llk_math_custom_mm.h"
 #include "llk_math_common_api.h"
 
+/*************************************************************************
+ * LLK MATH CUSTOM_MM
+ *
+ * Custom version of matmul that performs a full matrix multiplication more optimally but has the following limitations:
+ * in0 tile shape: [{1, 2, 4, 8}, 32]
+ * in1 tile shape: [32, 32]
+ * rt_dim: 1
+ * ct_dim: {1, 2, 4, 6, 8, 10, 11, 12, 14, 16}
+ * kt_dim: even number from 2 to 256 (inclusive)
+ * fidelity: LoFi only
+ * throttle: not supported
+ *
+ * Uses llk_math_custom_mm.h as the low-level implementation.
+ *************************************************************************/
+
 template <bool transpose = false, bool split_acc = false, bool dense_packing = false>
 inline void llk_math_custom_mm_init(
-    const std::uint32_t operandA, const std::uint32_t operandB, const std::uint32_t ct_dim = 1) {
-    const std::uint32_t operandB_id = get_operand_id(operandA);
+    const std::uint32_t operand0, const std::uint32_t operand1, const std::uint32_t ct_dim = 1) {
+    // Swap operands, for matmul operand0 goes to SrcB and operand1 goes to SrcA
+    const std::uint32_t operandB_id = get_operand_id(operand0);
     const std::uint32_t operandB_face_r_dim = get_operand_face_r_dim(operandB_id);
 
     _llk_math_custom_mm_init_<transpose, split_acc, dense_packing>(operandB_face_r_dim, ct_dim);
@@ -17,12 +33,13 @@ inline void llk_math_custom_mm_init(
 
 template <bool finalize = true>
 inline void llk_math_custom_mm(
-    const std::uint32_t operandA,
-    const std::uint32_t operandB,
+    const std::uint32_t operand0,
+    const std::uint32_t operand1,
     const std::uint32_t dst_index,
     const std::uint32_t kt_dim,
     const std::uint32_t ct_dim = 1) {
-    const std::uint32_t operandB_id = get_operand_id(operandA);
+    // Swap operands, for matmul operand0 goes to SrcB and operand1 goes to SrcA
+    const std::uint32_t operandB_id = get_operand_id(operand0);
     const std::uint32_t operandB_face_r_dim = get_operand_face_r_dim(operandB_id);
 
     _llk_math_custom_mm_<finalize>(operandB_face_r_dim, dst_index, kt_dim, ct_dim);

--- a/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_AB_custom_mm_api.h
+++ b/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_AB_custom_mm_api.h
@@ -13,7 +13,7 @@
  * in0 tile shape: [{1, 2, 4, 8}, 32]
  * in1 tile shape: [32, 32]
  * rt_dim: 1
- * ct_dim: {1, 2, 4, 6, 8, 10, 11, 12, 14, 16}
+ * ct_dim: {1, 2, 4, 6, 8, 10, 12, 14, 16}
  * kt_dim: even number from 2 to 256 (inclusive)
  * fidelity: LoFi only
  * throttle: not supported

--- a/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_AB_custom_mm_api.h
+++ b/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_AB_custom_mm_api.h
@@ -6,30 +6,49 @@
 #include "../../../../../third_party/tt_llk/tt_llk_blackhole/llk_lib/llk_unpack_AB_custom_mm.h"
 #include "llk_unpack_common_api.h"
 
+/*************************************************************************
+ * LLK UNPACK AB CUSTOM_MM
+ *
+ * Custom version of matmul that performs a full matrix multiplication more optimally but has the following limitations:
+ * in0 tile shape: [{1, 2, 4, 8}, 32]
+ * in1 tile shape: [32, 32]
+ * rt_dim: 1
+ * ct_dim: {1, 2, 4, 6, 8, 10, 11, 12, 14, 16}
+ * kt_dim: even number from 2 to 256 (inclusive)
+ * fidelity: LoFi only
+ * throttle: not supported
+ *
+ * Uses llk_unpack_AB_custom_mm.h as the low-level implementation.
+ *************************************************************************/
+
 template <bool transpose = false>
 inline void llk_unpack_AB_custom_mm_init(
-    const std::uint32_t operandA, const std::uint32_t operandB, const std::uint32_t ct_dim = 1) {
-    const std::uint32_t operandB_id = get_operand_id(operandA);
-    const std::uint32_t unpB_face_r_dim = get_operand_face_r_dim(operandB_id);
+    const std::uint32_t operand0, const std::uint32_t operand1, const std::uint32_t ct_dim = 1) {
+    // Swap operands, for matmul operand0 goes to SrcB and operand1 goes to SrcA
+    const std::uint32_t operandB_id = get_operand_id(operand0);
+    const std::uint32_t operandB_face_r_dim = get_operand_face_r_dim(operandB_id);
 
-    _llk_unpack_AB_custom_mm_init_<transpose>(unpB_face_r_dim, ct_dim);
+    _llk_unpack_AB_custom_mm_init_<transpose>(operandB_face_r_dim, ct_dim);
 }
 
 template <bool read_transposed = false>
 inline void llk_unpack_AB_custom_mm(
-    const std::uint32_t operandA,
-    const std::uint32_t operandB,
-    const std::uint32_t tile_index_a,
-    const std::uint32_t tile_index_b,
+    const std::uint32_t operand0,
+    const std::uint32_t operand1,
+    const std::uint32_t tile_index_0,
+    const std::uint32_t tile_index_1,
     const std::uint32_t kt_dim,
     const std::uint32_t ct_dim = 1) {
-    const std::uint32_t operandA_id = get_operand_id(operandB);
-    const std::uint32_t operandB_id = get_operand_id(operandA);
-    std::uint32_t base_address_a = get_local_cb_interface(operandA_id).fifo_rd_ptr - 1;
-    std::uint32_t base_address_b = get_local_cb_interface(operandB_id).fifo_rd_ptr - 1;
-    std::uint32_t tile_size_a = get_local_cb_interface(operandA_id).fifo_page_size;
-    std::uint32_t tile_size_b = get_local_cb_interface(operandB_id).fifo_page_size;
+    // Swap operands, for matmul operand0 goes to SrcB and operand1 goes to SrcA
+    const std::uint32_t operandA_id = get_operand_id(operand1);
+    const std::uint32_t operandB_id = get_operand_id(operand0);
+    const std::uint32_t base_address_A = get_local_cb_interface(operandA_id).fifo_rd_ptr - 1;
+    const std::uint32_t base_address_B = get_local_cb_interface(operandB_id).fifo_rd_ptr - 1;
+    const std::uint32_t tile_index_A = tile_index_1;
+    const std::uint32_t tile_index_B = tile_index_0;
+    const std::uint32_t tile_size_A = get_local_cb_interface(operandA_id).fifo_page_size;
+    const std::uint32_t tile_size_B = get_local_cb_interface(operandB_id).fifo_page_size;
 
     _llk_unpack_AB_custom_mm_<read_transposed>(
-        base_address_a, base_address_b, tile_index_b, tile_index_a, tile_size_a, tile_size_b, kt_dim, ct_dim);
+        base_address_A, base_address_B, tile_index_A, tile_index_B, tile_size_A, tile_size_B, kt_dim, ct_dim);
 }

--- a/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/include/compute_kernel_api/custom_mm.h
+++ b/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/include/compute_kernel_api/custom_mm.h
@@ -15,29 +15,29 @@ namespace ckernel {
 
 // clang-format off
 /**
- * Full initialization for custom_mm_block operation. Must be called before custom_mm_block and only once at the beggining of the kernel.
+ * Full initialization for custom_mm_block operation. Must be called before custom_mm_block and only once at the beginning of the kernel.
  * For initializing custom_mm_block in the middle of the kernel, please use custom_mm_block_init_short.
  *
  * Custom version of matmul that performs a full matrix multiplication more optimally but has the following limitations:
  * in0 tile shape: [{1, 2, 4, 8}, 32]
  * in1 tile shape: [32, 32]
  * rt_dim: 1
- * ct_dim: {1, 2, 4, 6, 8, 10, 11, 12, 14, 16}
+ * ct_dim: {1, 2, 4, 6, 8, 10, 12, 14, 16}
  * kt_dim: even number from 2 to 256 (inclusive)
  * fidelity: LoFi only
  * throttle: not supported
  *
  * Return value: None
  *
- * | Argument       | Description                                                                            | Type     | Valid Range                  | Required              |
- * |----------------|----------------------------------------------------------------------------------------|----------|------------------------------|-----------------------|
- * | transpose      | The transpose flag for performing transpose operation on in1                           | bool     | true/false                   | False (default false) |
- * | split_acc      | Wether to accumulate partials within a single tile in different dest locations         | bool     | true/false                   | False (default false) |
- * | dense_packing  | Whether to pack consecutive tiles 32 rows apart (instead of 64, doubles dest capacity) | bool     | true/false                   | False (default false) |
- * | in0_cb_id      | The identifier of the first input circular buffer (CB)                                 | uint32_t | 0 to 31                      | True                  |
- * | in1_cb_id      | The identifier of the second input circular buffer (CB)                                | uint32_t | 0 to 31                      | True                  |
- * | out_cb_id      | The identifier of the output circular buffer (CB)                                      | uint32_t | 0 to 31                      | True                  |
- * | ct_dim         | The width of the output matrix in tiles                                                | uint32_t | {1, 2, 4, 8, 10, 12, 14, 16} | False (default 1)     |
+ * | Argument       | Description                                                                            | Type     | Valid Range                     | Required              |
+ * |----------------|----------------------------------------------------------------------------------------|----------|---------------------------------|-----------------------|
+ * | transpose      | The transpose flag for performing transpose operation on in1                           | bool     | true/false                      | False (default false) |
+ * | split_acc      | Whether to accumulate partials within a single tile in different dest locations        | bool     | true/false                      | False (default false) |
+ * | dense_packing  | Whether to pack consecutive tiles 32 rows apart (instead of 64, doubles dest capacity) | bool     | true/false                      | False (default false) |
+ * | in0_cb_id      | The identifier of the first input circular buffer (CB)                                 | uint32_t | 0 to 31                         | True                  |
+ * | in1_cb_id      | The identifier of the second input circular buffer (CB)                                | uint32_t | 0 to 31                         | True                  |
+ * | out_cb_id      | The identifier of the output circular buffer (CB)                                      | uint32_t | 0 to 31                         | True                  |
+ * | ct_dim         | The width of the output matrix in tiles                                                | uint32_t | {1, 2, 4, 6, 8, 10, 12, 14, 16} | False (default 1)     |
  */
 // clang-format on
 template <bool transpose = false, bool split_acc = false, bool dense_packing = false, bool fp32_dest_acc_en = DST_ACCUM_MODE>
@@ -73,22 +73,22 @@ ALWI void custom_mm_block_init(
  * in0 tile shape: [{1, 2, 4, 8}, 32]
  * in1 tile shape: [32, 32]
  * rt_dim: 1
- * ct_dim: {1, 2, 4, 6, 8, 10, 11, 12, 14, 16}
+ * ct_dim: {1, 2, 4, 6, 8, 10, 12, 14, 16}
  * kt_dim: even number from 2 to 256 (inclusive)
  * fidelity: LoFi only
  * throttle: not supported
  *
  * Return value: None
  *
- * | Argument       | Description                                                                            | Type     | Valid Range                  | Required              |
- * |----------------|----------------------------------------------------------------------------------------|----------|------------------------------|-----------------------|
- * | transpose      | The transpose flag for performing transpose operation on in1                           | bool     | true/false                   | False (default false) |
- * | split_acc      | Wether to accumulate partials within a single tile in different dest locations         | bool     | true/false                   | False (default false) |
- * | dense_packing  | Whether to pack consecutive tiles 32 rows apart (instead of 64, doubles dest capacity) | bool     | true/false                   | False (default false) |
- * | in0_cb_id      | The identifier of the first input circular buffer (CB)                                 | uint32_t | 0 to 31                      | True                  |
- * | in1_cb_id      | The identifier of the second input circular buffer (CB)                                | uint32_t | 0 to 31                      | True                  |
- * | out_cb_id      | The identifier of the output circular buffer (CB)                                      | uint32_t | 0 to 31                      | True                  |
- * | ct_dim         | The width of the output matrix in tiles                                                | uint32_t | {1, 2, 4, 8, 10, 12, 14, 16} | False (default 1)     |
+ * | Argument       | Description                                                                            | Type     | Valid Range                     | Required              |
+ * |----------------|----------------------------------------------------------------------------------------|----------|---------------------------------|-----------------------|
+ * | transpose      | The transpose flag for performing transpose operation on in1                           | bool     | true/false                      | False (default false) |
+ * | split_acc      | Whether to accumulate partials within a single tile in different dest locations        | bool     | true/false                      | False (default false) |
+ * | dense_packing  | Whether to pack consecutive tiles 32 rows apart (instead of 64, doubles dest capacity) | bool     | true/false                      | False (default false) |
+ * | in0_cb_id      | The identifier of the first input circular buffer (CB)                                 | uint32_t | 0 to 31                         | True                  |
+ * | in1_cb_id      | The identifier of the second input circular buffer (CB)                                | uint32_t | 0 to 31                         | True                  |
+ * | out_cb_id      | The identifier of the output circular buffer (CB)                                      | uint32_t | 0 to 31                         | True                  |
+ * | ct_dim         | The width of the output matrix in tiles                                                | uint32_t | {1, 2, 4, 6, 8, 10, 12, 14, 16} | False (default 1)     |
  */
 // clang-format on
 template <bool transpose = false, bool split_acc = false, bool dense_packing = false>
@@ -120,24 +120,24 @@ ALWI void custom_mm_block_init_short(
  * in0 tile shape: [{1, 2, 4, 8}, 32]
  * in1 tile shape: [32, 32]
  * rt_dim: 1
- * ct_dim: {1, 2, 4, 6, 8, 10, 11, 12, 14, 16}
+ * ct_dim: {1, 2, 4, 6, 8, 10, 12, 14, 16}
  * kt_dim: even number from 2 to 256 (inclusive)
  * fidelity: LoFi only
  * throttle: not supported
  *
  * Return value: None
  *
- * | Argument        | Description                                                                                                    | Type     | Valid Range                                      | Required              |
- * |-----------------|----------------------------------------------------------------------------------------------------------------|----------|--------------------------------------------------|-----------------------|
- * | finalize        | Wether to perform the finalization step which merges split_accumulation partials                               | bool     | true/false (must be false if split_acc is false) | False (default true)  |
- * | read_transposed | Wether to read in1 tiles in transposed order (read ct tiles with a stride of kt, then move over a single tile) | bool     | true/false                                       | False (default false) |
- * | in0_cb_id       | The identifier of the first input circular buffer (CB)                                                         | uint32_t | 0 to 31                                          | True                  |
- * | in1_cb_id       | The identifier of the second input circular buffer (CB)                                                        | uint32_t | 0 to 31                                          | True                  |
- * | in0_tile_index  | The index of the tile in block A from the first input CB                                                       | uint32_t | Must be less than the size of the CB             | True                  |
- * | in1_tile_index  | The index of the tile in block B from the second input CB                                                      | uint32_t | Must be less than the size of the CB             | True                  |
- * | dst_index       | The index of the tile in DST REG to which the result C will be written                                         | uint32_t | Must be less than the acquired size of DST REG   | True                  |
- * | kt_dim          | The inner dimension in tiles                                                                                   | uint32_t | Must be an even number from 2 to 256 (inclusive) | True                  |
- * | ct_dim          | The width of the output matrix in tiles                                                                        | uint32_t | {1, 2, 4, 6, 8, 10, 11, 12, 14, 16}              | False (default 1)     |
+ * | Argument        | Description                                                                                                     | Type     | Valid Range                                      | Required              |
+ * |-----------------|-----------------------------------------------------------------------------------------------------------------|----------|--------------------------------------------------|-----------------------|
+ * | finalize        | Whether to perform the finalization step which merges split_accumulation partials                               | bool     | true/false (must be false if split_acc is false) | False (default true)  |
+ * | read_transposed | Whether to read in1 tiles in transposed order (read ct tiles with a stride of kt, then move over a single tile) | bool     | true/false                                       | False (default false) |
+ * | in0_cb_id       | The identifier of the first input circular buffer (CB)                                                          | uint32_t | 0 to 31                                          | True                  |
+ * | in1_cb_id       | The identifier of the second input circular buffer (CB)                                                         | uint32_t | 0 to 31                                          | True                  |
+ * | in0_tile_index  | The index of the tile in block A from the first input CB                                                        | uint32_t | Must be less than the size of the CB             | True                  |
+ * | in1_tile_index  | The index of the tile in block B from the second input CB                                                       | uint32_t | Must be less than the size of the CB             | True                  |
+ * | dst_index       | The index of the tile in DST REG to which the result C will be written                                          | uint32_t | Must be less than the acquired size of DST REG   | True                  |
+ * | kt_dim          | The inner dimension in tiles                                                                                    | uint32_t | Must be an even number from 2 to 256 (inclusive) | True                  |
+ * | ct_dim          | The width of the output matrix in tiles                                                                         | uint32_t | {1, 2, 4, 6, 8, 10, 12, 14, 16}                  | False (default 1)     |
  */
 // clang-format on
 template <bool finalize = true, bool read_transposed = false>
@@ -165,22 +165,22 @@ ALWI void custom_mm_block(
  * in0 tile shape: [{1, 2, 4, 8}, 32]
  * in1 tile shape: [32, 32]
  * rt_dim: 1
- * ct_dim: {1, 2, 4, 6, 8, 10, 11, 12, 14, 16}
+ * ct_dim: {1, 2, 4, 6, 8, 10, 12, 14, 16}
  * kt_dim: even number from 2 to 256 (inclusive)
  * fidelity: LoFi only
  * throttle: not supported
  *
  * Return value: None
  *
- * | Argument        | Description                                                                                                    | Type     | Valid Range                                      | Required              |
- * |-----------------|----------------------------------------------------------------------------------------------------------------|----------|--------------------------------------------------|-----------------------|
- * | read_transposed | Wether to read in1 tiles in transposed order (read ct tiles with a stride of kt, then move over a single tile) | bool     | true/false                                       | False (default false) |
- * | in0_cb_id       | The identifier of the first input circular buffer (CB)                                                         | uint32_t | 0 to 31                                          | True                  |
- * | in1_cb_id       | The identifier of the second input circular buffer (CB)                                                        | uint32_t | 0 to 31                                          | True                  |
- * | in0_tile_index  | The index of the tile in block A from the first input CB                                                       | uint32_t | Must be less than the size of the CB             | True                  |
- * | in1_tile_index  | The index of the tile in block B from the second input CB                                                      | uint32_t | Must be less than the size of the CB             | True                  |
- * | kt_dim          | The inner dimension in tiles                                                                                   | uint32_t | Must be an even number from 2 to 256 (inclusive) | True                  |
- * | ct_dim          | The width of the output matrix in tiles                                                                        | uint32_t | {1, 2, 4, 6, 8, 10, 11, 12, 14, 16}              | False (default 1)     |
+ * | Argument        | Description                                                                                                     | Type     | Valid Range                                      | Required              |
+ * |-----------------|-----------------------------------------------------------------------------------------------------------------|----------|--------------------------------------------------|-----------------------|
+ * | read_transposed | Whether to read in1 tiles in transposed order (read ct tiles with a stride of kt, then move over a single tile) | bool     | true/false                                       | False (default false) |
+ * | in0_cb_id       | The identifier of the first input circular buffer (CB)                                                          | uint32_t | 0 to 31                                          | True                  |
+ * | in1_cb_id       | The identifier of the second input circular buffer (CB)                                                         | uint32_t | 0 to 31                                          | True                  |
+ * | in0_tile_index  | The index of the tile in block A from the first input CB                                                        | uint32_t | Must be less than the size of the CB             | True                  |
+ * | in1_tile_index  | The index of the tile in block B from the second input CB                                                       | uint32_t | Must be less than the size of the CB             | True                  |
+ * | kt_dim          | The inner dimension in tiles                                                                                    | uint32_t | Must be an even number from 2 to 256 (inclusive) | True                  |
+ * | ct_dim          | The width of the output matrix in tiles                                                                         | uint32_t | {1, 2, 4, 6, 8, 10, 12, 14, 16}                  | False (default 1)     |
  */
 // clang-format on
 template <bool read_transposed = false>
@@ -206,7 +206,7 @@ ALWI void custom_mm_block_unpack(
  * in0 tile shape: [{1, 2, 4, 8}, 32]
  * in1 tile shape: [32, 32]
  * rt_dim: 1
- * ct_dim: {1, 2, 4, 6, 8, 10, 11, 12, 14, 16}
+ * ct_dim: {1, 2, 4, 6, 8, 10, 12, 14, 16}
  * kt_dim: even number from 2 to 256 (inclusive)
  * fidelity: LoFi only
  * throttle: not supported
@@ -215,12 +215,12 @@ ALWI void custom_mm_block_unpack(
  *
  * | Argument        | Description                                                                                                    | Type     | Valid Range                                      | Required              |
  * |-----------------|----------------------------------------------------------------------------------------------------------------|----------|--------------------------------------------------|-----------------------|
- * | finalize        | Wether to perform the finalization step which merges split_accumulation partials                               | bool     | true/false (must be false if split_acc is false) | False (default true)  |
+ * | finalize        | Whether to perform the finalization step which merges split_accumulation partials                              | bool     | true/false (must be false if split_acc is false) | False (default true)  |
  * | in0_cb_id       | The identifier of the first input circular buffer (CB)                                                         | uint32_t | 0 to 31                                          | True                  |
  * | in1_cb_id       | The identifier of the second input circular buffer (CB)                                                        | uint32_t | 0 to 31                                          | True                  |
  * | dst_index       | The index of the tile in DST REG to which the result C will be written                                         | uint32_t | Must be less than the acquired size of DST REG   | True                  |
  * | kt_dim          | The inner dimension in tiles                                                                                   | uint32_t | Must be an even number from 2 to 256 (inclusive) | True                  |
- * | ct_dim          | The width of the output matrix in tiles                                                                        | uint32_t | {1, 2, 4, 6, 8, 10, 11, 12, 14, 16}              | False (default 1)     |
+ * | ct_dim          | The width of the output matrix in tiles                                                                        | uint32_t | {1, 2, 4, 6, 8, 10, 12, 14, 16}                  | False (default 1)     |
  */
 // clang-format on
 template <bool finalize = true>

--- a/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/include/compute_kernel_api/custom_mm.h
+++ b/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/include/compute_kernel_api/custom_mm.h
@@ -13,12 +13,40 @@
 #endif
 namespace ckernel {
 
+// clang-format off
+/**
+ * Full initialization for custom_mm_block operation. Must be called before custom_mm_block and only once at the beggining of the kernel.
+ * For initializing custom_mm_block in the middle of the kernel, please use custom_mm_block_init_short.
+ *
+ * Custom version of matmul that performs a full matrix multiplication more optimally but has the following limitations:
+ * in0 tile shape: [{1, 2, 4, 8}, 32]
+ * in1 tile shape: [32, 32]
+ * rt_dim: 1
+ * ct_dim: {1, 2, 4, 6, 8, 10, 11, 12, 14, 16}
+ * kt_dim: even number from 2 to 256 (inclusive)
+ * fidelity: LoFi only
+ * throttle: not supported
+ *
+ * Return value: None
+ *
+ * | Argument       | Description                                                                            | Type     | Valid Range                  | Required              |
+ * |----------------|----------------------------------------------------------------------------------------|----------|------------------------------|-----------------------|
+ * | transpose      | The transpose flag for performing transpose operation on in1                           | bool     | true/false                   | False (default false) |
+ * | split_acc      | Wether to accumulate partials within a single tile in different dest locations         | bool     | true/false                   | False (default false) |
+ * | dense_packing  | Whether to pack consecutive tiles 32 rows apart (instead of 64, doubles dest capacity) | bool     | true/false                   | False (default false) |
+ * | in0_cb_id      | The identifier of the first input circular buffer (CB)                                 | uint32_t | 0 to 31                      | True                  |
+ * | in1_cb_id      | The identifier of the second input circular buffer (CB)                                | uint32_t | 0 to 31                      | True                  |
+ * | out_cb_id      | The identifier of the output circular buffer (CB)                                      | uint32_t | 0 to 31                      | True                  |
+ * | ct_dim         | The width of the output matrix in tiles                                                | uint32_t | {1, 2, 4, 8, 10, 12, 14, 16} | False (default 1)     |
+ */
+// clang-format on
 template <bool transpose = false, bool split_acc = false, bool dense_packing = false, bool fp32_dest_acc_en = DST_ACCUM_MODE>
 ALWI void custom_mm_block_init(
     const std::uint32_t in0_cb_id,
     const std::uint32_t in1_cb_id,
     const std::uint32_t out_cb_id,
     const std::uint32_t ct_dim = 1) {
+    // Intentionally swap in0 and in1 as operation specific hw_configures are deprecated
     UNPACK((llk_unpack_hw_configure<fp32_dest_acc_en>(in1_cb_id, in0_cb_id)));
     UNPACK((llk_unpack_AB_custom_mm_init<transpose>(in0_cb_id, in1_cb_id, ct_dim)));
 
@@ -30,11 +58,88 @@ ALWI void custom_mm_block_init(
     PACK((llk_pack_hw_configure<fp32_dest_acc_en>(out_cb_id)));
     PACK((llk_pack_init<false, false>(out_cb_id)));
     if constexpr (dense_packing) {
+        // Reduce packing stride from tile to tile to 32 rows instead of 64
         PACK((cfg_reg_rmw_tensix<PCK0_ADDR_CTRL_ZW_REG_0_Wstride_RMW>(
             (TILE_NUM_FACES / 2) * FACE_C_DIM * FACE_R_DIM * 2)));
     }
 }
 
+// clang-format off
+/**
+ * Short initialization for custom_mm_block operation. Must be called before custom_mm_block and is safe to call at any point in the kernel.
+ * For initializing custom_mm_block at the beginning of the kernel, please use custom_mm_block_init.
+ *
+ * Custom version of matmul that performs a full matrix multiplication more optimally but has the following limitations:
+ * in0 tile shape: [{1, 2, 4, 8}, 32]
+ * in1 tile shape: [32, 32]
+ * rt_dim: 1
+ * ct_dim: {1, 2, 4, 6, 8, 10, 11, 12, 14, 16}
+ * kt_dim: even number from 2 to 256 (inclusive)
+ * fidelity: LoFi only
+ * throttle: not supported
+ *
+ * Return value: None
+ *
+ * | Argument       | Description                                                                            | Type     | Valid Range                  | Required              |
+ * |----------------|----------------------------------------------------------------------------------------|----------|------------------------------|-----------------------|
+ * | transpose      | The transpose flag for performing transpose operation on in1                           | bool     | true/false                   | False (default false) |
+ * | split_acc      | Wether to accumulate partials within a single tile in different dest locations         | bool     | true/false                   | False (default false) |
+ * | dense_packing  | Whether to pack consecutive tiles 32 rows apart (instead of 64, doubles dest capacity) | bool     | true/false                   | False (default false) |
+ * | in0_cb_id      | The identifier of the first input circular buffer (CB)                                 | uint32_t | 0 to 31                      | True                  |
+ * | in1_cb_id      | The identifier of the second input circular buffer (CB)                                | uint32_t | 0 to 31                      | True                  |
+ * | out_cb_id      | The identifier of the output circular buffer (CB)                                      | uint32_t | 0 to 31                      | True                  |
+ * | ct_dim         | The width of the output matrix in tiles                                                | uint32_t | {1, 2, 4, 8, 10, 12, 14, 16} | False (default 1)     |
+ */
+// clang-format on
+template <bool transpose = false, bool split_acc = false, bool dense_packing = false>
+ALWI void custom_mm_block_init_short(
+    const std::uint32_t in0_cb_id,
+    const std::uint32_t in1_cb_id,
+    const std::uint32_t out_cb_id,
+    const std::uint32_t ct_dim = 1) {
+    UNPACK((llk_unpack_AB_custom_mm_init<transpose>(in0_cb_id, in1_cb_id, ct_dim)));
+
+    MATH((llk_math_custom_mm_init<transpose, split_acc, dense_packing>(in0_cb_id, in1_cb_id, ct_dim)));
+
+    PACK((llk_pack_init<false, false>(out_cb_id)));
+    if constexpr (dense_packing) {
+        // Reduce packing stride from tile to tile to 32 rows instead of 64
+        PACK((cfg_reg_rmw_tensix<PCK0_ADDR_CTRL_ZW_REG_0_Wstride_RMW>(
+            (TILE_NUM_FACES / 2) * FACE_C_DIM * FACE_R_DIM * 2)));
+    }
+}
+
+// clang-format off
+/**
+ * Performs block-sized matrix multiplication *C=A\*B* between the blocks in two
+ * different input CBs and writes the result to DST. The DST register buffer
+ * must be in acquired state via *acquire_dst* call. This call is blocking and
+ * is only available on the compute engine.
+ *
+ * Custom version of matmul that performs a full matrix multiplication more optimally but has the following limitations:
+ * in0 tile shape: [{1, 2, 4, 8}, 32]
+ * in1 tile shape: [32, 32]
+ * rt_dim: 1
+ * ct_dim: {1, 2, 4, 6, 8, 10, 11, 12, 14, 16}
+ * kt_dim: even number from 2 to 256 (inclusive)
+ * fidelity: LoFi only
+ * throttle: not supported
+ *
+ * Return value: None
+ *
+ * | Argument        | Description                                                                                                    | Type     | Valid Range                                      | Required              |
+ * |-----------------|----------------------------------------------------------------------------------------------------------------|----------|--------------------------------------------------|-----------------------|
+ * | finalize        | Wether to perform the finalization step which merges split_accumulation partials                               | bool     | true/false (must be false if split_acc is false) | False (default true)  |
+ * | read_transposed | Wether to read in1 tiles in transposed order (read ct tiles with a stride of kt, then move over a single tile) | bool     | true/false                                       | False (default false) |
+ * | in0_cb_id       | The identifier of the first input circular buffer (CB)                                                         | uint32_t | 0 to 31                                          | True                  |
+ * | in1_cb_id       | The identifier of the second input circular buffer (CB)                                                        | uint32_t | 0 to 31                                          | True                  |
+ * | in0_tile_index  | The index of the tile in block A from the first input CB                                                       | uint32_t | Must be less than the size of the CB             | True                  |
+ * | in1_tile_index  | The index of the tile in block B from the second input CB                                                      | uint32_t | Must be less than the size of the CB             | True                  |
+ * | dst_index       | The index of the tile in DST REG to which the result C will be written                                         | uint32_t | Must be less than the acquired size of DST REG   | True                  |
+ * | kt_dim          | The inner dimension in tiles                                                                                   | uint32_t | Must be an even number from 2 to 256 (inclusive) | True                  |
+ * | ct_dim          | The width of the output matrix in tiles                                                                        | uint32_t | {1, 2, 4, 6, 8, 10, 11, 12, 14, 16}              | False (default 1)     |
+ */
+// clang-format on
 template <bool finalize = true, bool read_transposed = false>
 ALWI void custom_mm_block(
     const std::uint32_t in0_cb_id,
@@ -49,6 +154,35 @@ ALWI void custom_mm_block(
     MATH((llk_math_custom_mm<finalize>(in0_cb_id, in1_cb_id, dst_index, kt_dim, ct_dim)));
 }
 
+// clang-format off
+/**
+ * Performs unpack part of block-sized matrix multiplication *C=A\*B* between the blocks in two
+ * different input CBs and writes the result to DST. The DST register buffer
+ * must be in acquired state via *acquire_dst* call. This call is blocking and
+ * is only available on the compute engine.
+ *
+ * Custom version of matmul that performs a full matrix multiplication more optimally but has the following limitations:
+ * in0 tile shape: [{1, 2, 4, 8}, 32]
+ * in1 tile shape: [32, 32]
+ * rt_dim: 1
+ * ct_dim: {1, 2, 4, 6, 8, 10, 11, 12, 14, 16}
+ * kt_dim: even number from 2 to 256 (inclusive)
+ * fidelity: LoFi only
+ * throttle: not supported
+ *
+ * Return value: None
+ *
+ * | Argument        | Description                                                                                                    | Type     | Valid Range                                      | Required              |
+ * |-----------------|----------------------------------------------------------------------------------------------------------------|----------|--------------------------------------------------|-----------------------|
+ * | read_transposed | Wether to read in1 tiles in transposed order (read ct tiles with a stride of kt, then move over a single tile) | bool     | true/false                                       | False (default false) |
+ * | in0_cb_id       | The identifier of the first input circular buffer (CB)                                                         | uint32_t | 0 to 31                                          | True                  |
+ * | in1_cb_id       | The identifier of the second input circular buffer (CB)                                                        | uint32_t | 0 to 31                                          | True                  |
+ * | in0_tile_index  | The index of the tile in block A from the first input CB                                                       | uint32_t | Must be less than the size of the CB             | True                  |
+ * | in1_tile_index  | The index of the tile in block B from the second input CB                                                      | uint32_t | Must be less than the size of the CB             | True                  |
+ * | kt_dim          | The inner dimension in tiles                                                                                   | uint32_t | Must be an even number from 2 to 256 (inclusive) | True                  |
+ * | ct_dim          | The width of the output matrix in tiles                                                                        | uint32_t | {1, 2, 4, 6, 8, 10, 11, 12, 14, 16}              | False (default 1)     |
+ */
+// clang-format on
 template <bool read_transposed = false>
 ALWI void custom_mm_block_unpack(
     const std::uint32_t in0_cb_id,
@@ -61,6 +195,34 @@ ALWI void custom_mm_block_unpack(
         in0_cb_id, in1_cb_id, in0_tile_index, in1_tile_index, kt_dim, ct_dim)));
 }
 
+// clang-format off
+/**
+ * Performs math part of block-sized matrix multiplication *C=A\*B* between the blocks in two
+ * different input CBs and writes the result to DST. The DST register buffer
+ * must be in acquired state via *acquire_dst* call. This call is blocking and
+ * is only available on the compute engine.
+ *
+ * Custom version of matmul that performs a full matrix multiplication more optimally but has the following limitations:
+ * in0 tile shape: [{1, 2, 4, 8}, 32]
+ * in1 tile shape: [32, 32]
+ * rt_dim: 1
+ * ct_dim: {1, 2, 4, 6, 8, 10, 11, 12, 14, 16}
+ * kt_dim: even number from 2 to 256 (inclusive)
+ * fidelity: LoFi only
+ * throttle: not supported
+ *
+ * Return value: None
+ *
+ * | Argument        | Description                                                                                                    | Type     | Valid Range                                      | Required              |
+ * |-----------------|----------------------------------------------------------------------------------------------------------------|----------|--------------------------------------------------|-----------------------|
+ * | finalize        | Wether to perform the finalization step which merges split_accumulation partials                               | bool     | true/false (must be false if split_acc is false) | False (default true)  |
+ * | in0_cb_id       | The identifier of the first input circular buffer (CB)                                                         | uint32_t | 0 to 31                                          | True                  |
+ * | in1_cb_id       | The identifier of the second input circular buffer (CB)                                                        | uint32_t | 0 to 31                                          | True                  |
+ * | dst_index       | The index of the tile in DST REG to which the result C will be written                                         | uint32_t | Must be less than the acquired size of DST REG   | True                  |
+ * | kt_dim          | The inner dimension in tiles                                                                                   | uint32_t | Must be an even number from 2 to 256 (inclusive) | True                  |
+ * | ct_dim          | The width of the output matrix in tiles                                                                        | uint32_t | {1, 2, 4, 6, 8, 10, 11, 12, 14, 16}              | False (default 1)     |
+ */
+// clang-format on
 template <bool finalize = true>
 ALWI void custom_mm_block_math(
     const std::uint32_t in0_cb_id,
@@ -71,9 +233,22 @@ ALWI void custom_mm_block_math(
     MATH((llk_math_custom_mm<finalize>(in0_cb_id, in1_cb_id, dst_index, kt_dim, ct_dim)));
 }
 
+// clang-format off
+/**
+ * Uninitializes the custom_mm_block operation, must be called after the final custom_mm_block call in a sequence and before initializing another operation.
+ *
+ *
+ * Return value: None
+ *
+ * | Argument       | Description                                                                            | Type     | Valid Range                  | Required              |
+ * |----------------|----------------------------------------------------------------------------------------|----------|------------------------------|-----------------------|
+ * | dense_packing  | Whether to pack consecutive tiles 32 rows apart (instead of 64, doubles dest capacity) | bool     | true/false                   | False (default false) |
+ */
+// clang-format on
 template <bool dense_packing = false>
 ALWI void custom_mm_block_uninit() {
     if constexpr (dense_packing) {
+        // Restore default packing stride of 64 rows between tiles
         PACK((cfg_reg_rmw_tensix<PCK0_ADDR_CTRL_ZW_REG_0_Wstride_RMW>(TILE_NUM_FACES * FACE_C_DIM * FACE_R_DIM * 2)));
     }
 }

--- a/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/third_party/tt_llk/tt_llk_blackhole/llk_lib/llk_math_custom_mm.h
+++ b/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/third_party/tt_llk/tt_llk_blackhole/llk_lib/llk_math_custom_mm.h
@@ -172,7 +172,7 @@ inline void _llk_math_custom_mm_(
     const std::uint32_t replay_buf_len = operandB_face_r_dim == 8 ? 11 : 9;
     math::set_dst_write_addr<DstTileShape::Tile32x32, UnpackDestination::SrcRegs>(dst_index);
 
-    // Run mop kt_dim - 1 times, the last inner dim is handled separately to chose whether to run finalization or not
+    // Run mop kt_dim - 1 times, the last inner dim is handled separately to choose whether to run finalization or not
     for (std::uint32_t i = 0; i < kt_dim - 1; i++) {
         TTI_MOP(1, 0, 0);
     }

--- a/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/third_party/tt_llk/tt_llk_blackhole/llk_lib/llk_math_custom_mm.h
+++ b/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/third_party/tt_llk/tt_llk_blackhole/llk_lib/llk_math_custom_mm.h
@@ -21,7 +21,7 @@ using namespace ckernel::math;
 // in0 tile shape: [{1, 2, 4, 8}, 32]
 // in1 tile shape: [32, 32]
 // rt_dim: 1
-// ct_dim: {1, 2, 4, 6, 8, 10, 11, 12, 14, 16}
+// ct_dim: {1, 2, 4, 6, 8, 10, 12, 14, 16}
 // kt_dim: even number from 2 to 256 (inclusive)
 // fidelity: LoFi only
 // throttle: not supported

--- a/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/third_party/tt_llk/tt_llk_blackhole/llk_lib/llk_math_custom_mm.h
+++ b/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/third_party/tt_llk/tt_llk_blackhole/llk_lib/llk_math_custom_mm.h
@@ -16,6 +16,16 @@
 using namespace ckernel;
 using namespace ckernel::math;
 
+// CUSTOM_MM
+// Custom version of matmul that performs a full matrix multiplication more optimally but has the following limitations:
+// in0 tile shape: [{1, 2, 4, 8}, 32]
+// in1 tile shape: [32, 32]
+// rt_dim: 1
+// ct_dim: {1, 2, 4, 6, 8, 10, 11, 12, 14, 16}
+// kt_dim: even number from 2 to 256 (inclusive)
+// fidelity: LoFi only
+// throttle: not supported
+
 template <bool transpose, bool split_acc, bool dense_packing>
 inline void custom_mm_configure_addrmod() {
     constexpr std::uint8_t ADDR_MOD_0_SRCA_INCR = transpose ? 32 : 16;
@@ -28,56 +38,60 @@ inline void custom_mm_configure_addrmod() {
         .srcb = {.incr = 0, .clr = 0, .cr = 0},
         .dest = {.incr = 16, .clr = 0, .cr = 0},
     }
-        .set(ADDR_MOD_0);
+        .set(ADDR_MOD_0);  // Move to the next face in width dimension, if transpose that is face 2 instead of face 1
 
     addr_mod_t{
         .srca = {.incr = ADDR_MOD_1_SRCA_INCR, .clr = 0, .cr = 0},
         .srcb = {.incr = 16, .clr = 0, .cr = 0},
         .dest = {.incr = ADDR_MOD_1_DEST_INCR, .clr = 0, .cr = 0},
     }
-        .set(ADDR_MOD_1);
+        .set(ADDR_MOD_1);  // Move to the next face in inner dimension, if transpose that is face 1 instead of face 2,
+                           // if split_acc next inner dim is stored at rows 8 and 24 instead of 0 and 16
 
     addr_mod_t{
         .srca = {.incr = 0, .clr = 1, .cr = 0},
         .srcb = {.incr = 0, .clr = 1, .cr = 0},
         .dest = {.incr = ADDR_MOD_2_DEST_INCR, .clr = 0, .cr = 1},
     }
-        .set(ADDR_MOD_2);
+        .set(ADDR_MOD_2);  // Move to the next tile in width dimension,
+                           // if dense_packing next tile starts at row 32 instead of 64
 
     addr_mod_t{
         .srca = {.incr = 0, .clr = 1, .cr = 0},
         .srcb = {.incr = 0, .clr = 1, .cr = 0},
         .dest = {.incr = 0, .clr = 1, .cr = 0},
     }
-        .set(ADDR_MOD_3);
+        .set(ADDR_MOD_3);  // Move to the next inner dimension, resets everything
 
     addr_mod_t{
         .srca = {.incr = 0, .clr = 1, .cr = 0},
         .srcb = {.incr = 0, .clr = 1, .cr = 0},
         .dest = {.incr = 0, .clr = 0, .cr = 1},
     }
-        .set(ADDR_MOD_4);
+        .set(ADDR_MOD_4);  // Last MVMUL if finalization enabled, resets SrcA and SrcB,
+                           // moves Dest to the beginning of the just multiplied tile
 
     addr_mod_t{
         .srca = {.incr = 0, .clr = 0, .cr = 0},
         .srcb = {.incr = 32, .clr = 0, .cr = 0},
         .dest = {.incr = 0, .clr = 0, .cr = 0},
     }
-        .set(ADDR_MOD_5);
+        .set(ADDR_MOD_5);  // Move SrcB to 32 in preparation for finalization ELWADD
 
     addr_mod_t{
         .srca = {.incr = 16, .clr = 0, .cr = 0},
         .srcb = {.incr = 16, .clr = 0, .cr = 0},
         .dest = {.incr = 16, .clr = 0, .cr = 0},
     }
-        .set(ADDR_MOD_6);
+        .set(ADDR_MOD_6);  // Move to next face in all three regs, used for final accumulation
 
     addr_mod_t{
         .srca = {.incr = 0, .clr = 0, .cr = 0},
         .srcb = {.incr = 0, .clr = 0, .cr = 0},
         .dest = {.incr = 0, .clr = 0, .cr = 0},
     }
-        .set(ADDR_MOD_7);
+        .set(ADDR_MOD_7);  // NOP, has to be ADDR_MOD_7 to match with address mods configured in silu
+                           // for fusing matmul and activation
 }
 
 template <bool split_acc>
@@ -85,14 +99,25 @@ inline void custom_mm_configure_mop(const std::uint32_t operandB_face_r_dim, con
     const std::uint32_t replay_buf_len = operandB_face_r_dim == 8 ? 11 : 9;
 
     load_replay_buf(ckernel::math::replay_buf_offset, replay_buf_len, [operandB_face_r_dim] {
-        TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0);  // 0
-        TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_1, 0);  // 16
-        TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0);  // 0  (8  if split_acc)
+        TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0);  // F0 @ F0 => 0
+        TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_1, 0);  // F0 @ F1 (F2 if transpose) => 16
+        TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0);  // F1 @ F2 (F1 if transpose) => 0 (8 if split_acc)
 
         // Finalization phase
-        TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_4, 0);  // 16 (24 if split_acc)
+        TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_4, 0);  // F1 @ F3 => 16 (24 if split_acc) (clear none,
+                                                          // as both SrcA and SrcB banks are required for finalization)
 
+        // We will exploit AddDst for finalization to calculate:
+        // Dst = partial (in dest) + (split partial (moved to SrcB) + 0 (zeroed SrcA))
+        // This way we avoid additional set of moves and move only one set of partials to SrcB
+        // We have to move them to SrcB as we have to zero out the other Src register
+        // and that can only be SrcA as it is not reused
+        // Since we are going to keep reusing SrcB,
+        // we have to move partials in lower half of SrcB as upper half contains inputs that are being reused
+
+        // Move the 4 rows of the F0 split partial to rows 32+ of SrcB for finalization
         TTI_MOVD2B(0, 32, ADDR_MOD_5, p_movd2a::MOV_4_ROWS, 0 + 8);
+        // Move the 4 rows of the F1 split partial to rows 48+ of SrcB for finalization
         TTI_MOVD2B(0, 16, ADDR_MOD_7, p_movd2a::MOV_4_ROWS, 16 + 8);
 
         // Move lower 4 rows if they exist
@@ -101,15 +126,27 @@ inline void custom_mm_configure_mop(const std::uint32_t operandB_face_r_dim, con
             TTI_MOVD2B(0, 16 + 4, ADDR_MOD_7, p_movd2a::MOV_4_ROWS, 16 + 8 + 4);
         }
 
+        // Zero SrcA as it is not reused and we need to add zero to split partials in SrcB
         TTI_ZEROSRC(0, 1, 0, 1);
 
+        // F0 partial in dest + F0 split partial in SrcB (row 32) => final F0 in dest
         TTI_ELWADD(0, 1, p_elwise::SRCB_NO_BCAST, ADDR_MOD_6, 0);
+        // F1 partial in dest + F1 split partial in SrcB (row 48) => final F1 in dest (clear only SrcA as B is reused)
         TTI_ELWADD(1, 1, p_elwise::SRCB_NO_BCAST, ADDR_MOD_2, 0);
     });
 
+    // Top 3 MVMUL instructions from the replay buffer
     const std::uint32_t mvmul_base = lltt::replay_insn(ckernel::math::replay_buf_offset + 0, 3);
+    // F1 @ F3 => 16 (24 if split_acc) (clear only SrcA as SrcB is reused)
     const std::uint32_t mvmul_end_tile = TT_OP_MVMUL(p_setrwc::CLR_A, 0, ADDR_MOD_2, 0);
+    // F1 @ F3 => 16 (24 if split_acc) (clear both SrcA and SrcB as this is the end if the block)
     const std::uint32_t mvmul_end_block = TT_OP_MVMUL(p_setrwc::CLR_AB, 0, ADDR_MOD_3, 0);
+
+    // Mop runs a single inner dim, perform ct_dim tile multiplications while reusing a single SrcB bank
+    // For all ct_dim iterations except the last we run 4 MVMULs from mvmul_base and mvmul_end_tile
+    // (clearing only SrcA and moving to next output tile in Dest)
+    // For the last ct_dim iteration we run 4 MVMULs from mvmul_base and mvmul_end_block
+    // (clearing both SrcA and SrcB and moving back to the beginning of Dest for next inner dim)
 
     ckernel_template tmp = ckernel_template(1, ct_dim, mvmul_base, mvmul_end_tile);
     tmp.set_last_inner_loop_instr(mvmul_end_block);
@@ -135,17 +172,21 @@ inline void _llk_math_custom_mm_(
     const std::uint32_t replay_buf_len = operandB_face_r_dim == 8 ? 11 : 9;
     math::set_dst_write_addr<DstTileShape::Tile32x32, UnpackDestination::SrcRegs>(dst_index);
 
+    // Run mop kt_dim - 1 times, the last inner dim is handled separately to chose whether to run finalization or not
     for (std::uint32_t i = 0; i < kt_dim - 1; i++) {
         TTI_MOP(1, 0, 0);
     }
 
     if constexpr (finalize) {
+        // Run the full replay ct_dim - 1 times as it has the full finalization sequence for cases where SrcB is reused
         for (std::uint32_t i = 0; i < ct_dim - 1; i++) {
             lltt::replay(ckernel::math::replay_buf_offset, replay_buf_len);
         }
+        // Run the full replay - the last ELWADD as it differs on the last ct_dim iteration and is issued directly after
         lltt::replay(ckernel::math::replay_buf_offset, replay_buf_len - 1);
         TTI_ELWADD(3, 1, p_elwise::SRCB_NO_BCAST, ADDR_MOD_3, 0);
     } else {
+        // Just run another mop iteration if not finalizing
         TTI_MOP(1, 0, 0);
     }
 }

--- a/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/third_party/tt_llk/tt_llk_blackhole/llk_lib/llk_unpack_AB_custom_mm.h
+++ b/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/third_party/tt_llk/tt_llk_blackhole/llk_lib/llk_unpack_AB_custom_mm.h
@@ -108,7 +108,7 @@ inline void _llk_unpack_AB_custom_mm_mop_config_(const std::uint32_t ct_dim) {
 
     // When ct_dim == 1 we alternate between full sequences for both contexts kt_dim times in total
     // When ct_dim > 1 we start with full context 0 and then alternate between reuse contexts 1 and 0 ct_dim - 1 times
-    // Since if ct_dim > 1 it must be even full seqence always lands on context 0
+    // Since if ct_dim > 1 it must be even full sequence always lands on context 0
     // thus instruction sequence is same for each kt_dim
     // Mop is configured such that it always covers two iterations of the inner dim loop,
     // this has two benefits:
@@ -128,14 +128,14 @@ inline void _llk_unpack_AB_custom_mm_mop_config_(const std::uint32_t ct_dim) {
     // We just pick first ct_dim / 2 sequences (each sequence is 3 instructions plus first full one is
     // 2 additional instructions, thus getting the equation which calculates first half of the replay length)
     // Similarly second half is just {reuse context 0, reuse context 1} ct_dim / 4 times,
-    // which is just picking ct_dim / 2 seqeunces starting from the first reuse context 0 sequence
+    // which is just picking ct_dim / 2 sequences starting from the first reuse context 0 sequence
     // (each sequence is 3 instructions so replay length calculation is simpler)
-    // To be sure that everything fits, for max ct_dim of 16, second half has to issue 4 pairs of sequnces
+    // To be sure that everything fits, for max ct_dim of 16, second half has to issue 4 pairs of sequences
     // which is exactly what we recorded at the end
     // First sequence already has the first pair as full context 0 and reuse context 1
     // so it needs only 3 additional pair which are covered by the 4 pairs required for the second half
     // Special case is ct_dim == 2 where first half is just full context 0
-    // and second half is just reuse context 1 thus having a earlier staring index
+    // and second half is just reuse context 1 thus having an earlier starting index
 
     const std::uint32_t ctx0_full = lltt::replay_insn(0, 5);
     const std::uint32_t ctx1_full = lltt::replay_insn(5, 5);

--- a/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/third_party/tt_llk/tt_llk_blackhole/llk_lib/llk_unpack_AB_custom_mm.h
+++ b/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/third_party/tt_llk/tt_llk_blackhole/llk_lib/llk_unpack_AB_custom_mm.h
@@ -21,7 +21,7 @@ using namespace ckernel::unpacker;
 // in0 tile shape: [{1, 2, 4, 8}, 32]
 // in1 tile shape: [32, 32]
 // rt_dim: 1
-// ct_dim: {1, 2, 4, 6, 8, 10, 11, 12, 14, 16}
+// ct_dim: {1, 2, 4, 6, 8, 10, 12, 14, 16}
 // kt_dim: even number from 2 to 256 (inclusive)
 // fidelity: LoFi only
 // throttle: not supported
@@ -41,7 +41,7 @@ inline void _llk_unpack_AB_custom_mm_mop_config_(const std::uint32_t ct_dim) {
         // Counters of interest are CH0 Y and Z (both with a stride of a single face in L1
         // (datum_size * 16 * face_r_dim) and CH1 Y with a stride of a face in SrcB (16 rows)
         // Each unpack instruction we move to next face in L1, but this is split among Y and Z counters
-        // Because they are 8 bit counters and to to cover max inner dim of 256
+        // Because they are 8 bit counters and to cover max inner dim of 256
         // we need to increment face counter 512 times thus overflowing if we use a single counter,
         // using both counters allows us to cover exactly 512 needed increments
         // For SrcB first unpack has to land at index 0 and second one at index 16,
@@ -65,7 +65,7 @@ inline void _llk_unpack_AB_custom_mm_mop_config_(const std::uint32_t ct_dim) {
             TTI_UNPACR_COMMON_EXPLICIT_CONTEXT(SrcA, 0b00000000, 1, 1);  // Also set dvalid
 
             // Unpack SrcB (in0, one instruction per face, uses counters to manipulate addresses for both L1 and SrcB)
-            // Same counter shennanigans as descibed above
+            // Same counter shenanigans as described above
             TTI_UNPACR_COMMON(SrcB, 0b00010001, 0);
             TTI_UNPACR_COMMON(SrcB, 0b00110100, 1);  // Also set dvalid
 
@@ -126,7 +126,7 @@ inline void _llk_unpack_AB_custom_mm_mop_config_(const std::uint32_t ct_dim) {
     // Since our replay is organized like:
     // full context 0, reuse context 1, {reuse context 0, reuse context 1} 4 times (which fills all 32 instructions)
     // We just pick first ct_dim / 2 sequences (each sequence is 3 instructions plus first full one is
-    // 2 additional instructions, thus getting the equation which calculates frist half of the replay length)
+    // 2 additional instructions, thus getting the equation which calculates first half of the replay length)
     // Similarly second half is just {reuse context 0, reuse context 1} ct_dim / 4 times,
     // which is just picking ct_dim / 2 seqeunces starting from the first reuse context 0 sequence
     // (each sequence is 3 instructions so replay length calculation is simpler)

--- a/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/third_party/tt_llk/tt_llk_blackhole/llk_lib/llk_unpack_AB_custom_mm.h
+++ b/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/third_party/tt_llk/tt_llk_blackhole/llk_lib/llk_unpack_AB_custom_mm.h
@@ -16,6 +16,16 @@
 using namespace ckernel;
 using namespace ckernel::unpacker;
 
+// CUSTOM_MM
+// Custom version of matmul that performs a full matrix multiplication more optimally but has the following limitations:
+// in0 tile shape: [{1, 2, 4, 8}, 32]
+// in1 tile shape: [32, 32]
+// rt_dim: 1
+// ct_dim: {1, 2, 4, 6, 8, 10, 11, 12, 14, 16}
+// kt_dim: even number from 2 to 256 (inclusive)
+// fidelity: LoFi only
+// throttle: not supported
+
 inline void _llk_unpack_AB_custom_mm_mop_config_(const std::uint32_t ct_dim) {
     const std::uint32_t replay_buf_prog_len = ct_dim == 1 ? 10 : 32;
 
@@ -24,12 +34,24 @@ inline void _llk_unpack_AB_custom_mm_mop_config_(const std::uint32_t ct_dim) {
         // Wait for context available
         t6_semaphore_wait_on_zero<p_stall::STALL_UNPACK>(semaphore::UNPACK_SYNC);
 
-        // Unpack SrcA (in1/inB)
-        TTI_UNPACR_COMMON_EXPLICIT_CONTEXT(SrcA, 0b00000000, 0, 1);
+        // Unpack SrcA (in1, full tile, uses contexts to manipulate L1 address and keeps SrcA address fixed at 0)
+        TTI_UNPACR_COMMON_EXPLICIT_CONTEXT(SrcA, 0b00000000, 0, 1);  // Also set dvalid
 
-        // Unpack SrcB (in0/inA)
+        // Unpack SrcB (in0, one instruction per face, uses counters to manipulate addresses for both L1 and SrcB)
+        // Counters of interest are CH0 Y and Z (both with a stride of a single face in L1
+        // (datum_size * 16 * face_r_dim) and CH1 Y with a stride of a face in SrcB (16 rows)
+        // Each unpack instruction we move to next face in L1, but this is split among Y and Z counters
+        // Because they are 8 bit counters and to to cover max inner dim of 256
+        // we need to increment face counter 512 times thus overflowing if we use a single counter,
+        // using both counters allows us to cover exactly 512 needed increments
+        // For SrcB first unpack has to land at index 0 and second one at index 16,
+        // increment from first to second is straightforward, but moving back to 0 after second requires us to exploit
+        // counter overflow as CH1 counters only use low 6 bits and wrap at the number of rows in a Src reg (64)
+        // thus an increment of 48 rows or 3 CH1 Y increments wraps us back to 0
+        // (which is conveniently the max we can increment in a single instruction)
+
         TTI_UNPACR_COMMON(SrcB, 0b00010001, 0);
-        TTI_UNPACR_COMMON(SrcB, 0b00110100, 1);
+        TTI_UNPACR_COMMON(SrcB, 0b00110100, 1);  // Also set dvalid
 
         // Signal context done
         t6_semaphore_get(semaphore::UNPACK_SYNC);
@@ -39,12 +61,13 @@ inline void _llk_unpack_AB_custom_mm_mop_config_(const std::uint32_t ct_dim) {
             // Wait for context available
             t6_semaphore_wait_on_zero<p_stall::STALL_UNPACK>(semaphore::UNPACK_SYNC);
 
-            // Unpack SrcA (in1/inB)
-            TTI_UNPACR_COMMON_EXPLICIT_CONTEXT(SrcA, 0b00000000, 1, 1);
+            // Unpack SrcA (in1, full tile, uses contexts to manipulate L1 address and keeps SrcA address fixed at 0)
+            TTI_UNPACR_COMMON_EXPLICIT_CONTEXT(SrcA, 0b00000000, 1, 1);  // Also set dvalid
 
-            // Unpack SrcB (in0/inA)
+            // Unpack SrcB (in0, one instruction per face, uses counters to manipulate addresses for both L1 and SrcB)
+            // Same counter shennanigans as descibed above
             TTI_UNPACR_COMMON(SrcB, 0b00010001, 0);
-            TTI_UNPACR_COMMON(SrcB, 0b00110100, 1);
+            TTI_UNPACR_COMMON(SrcB, 0b00110100, 1);  // Also set dvalid
 
             // Signal context done
             t6_semaphore_get(semaphore::UNPACK_SYNC);
@@ -53,8 +76,8 @@ inline void _llk_unpack_AB_custom_mm_mop_config_(const std::uint32_t ct_dim) {
             // Wait for context available
             t6_semaphore_wait_on_zero<p_stall::STALL_UNPACK>(semaphore::UNPACK_SYNC);
 
-            // Unpack SrcA (in1/inB)
-            TTI_UNPACR_COMMON_EXPLICIT_CONTEXT(SrcA, 0b00000000, 1, 1);
+            // Unpack SrcA (in1, full tile, uses contexts to manipulate L1 address and keeps SrcA address fixed at 0)
+            TTI_UNPACR_COMMON_EXPLICIT_CONTEXT(SrcA, 0b00000000, 1, 1);  // Also set dvalid
 
             // Signal context done
             t6_semaphore_get(semaphore::UNPACK_SYNC);
@@ -64,8 +87,8 @@ inline void _llk_unpack_AB_custom_mm_mop_config_(const std::uint32_t ct_dim) {
                 // Wait for context available
                 t6_semaphore_wait_on_zero<p_stall::STALL_UNPACK>(semaphore::UNPACK_SYNC);
 
-                // Unpack SrcA (in1/inB)
-                TTI_UNPACR_COMMON_EXPLICIT_CONTEXT(SrcA, 0b00000000, 0, 1);
+                // Unpack SrcA (in1, full tile, uses contexts to manipulate L1 address)
+                TTI_UNPACR_COMMON_EXPLICIT_CONTEXT(SrcA, 0b00000000, 0, 1);  // Also set dvalid
 
                 // Signal context done
                 t6_semaphore_get(semaphore::UNPACK_SYNC);
@@ -74,14 +97,45 @@ inline void _llk_unpack_AB_custom_mm_mop_config_(const std::uint32_t ct_dim) {
                 // Wait for context available
                 t6_semaphore_wait_on_zero<p_stall::STALL_UNPACK>(semaphore::UNPACK_SYNC);
 
-                // Unpack SrcA (in1/inB)
-                TTI_UNPACR_COMMON_EXPLICIT_CONTEXT(SrcA, 0b00000000, 1, 1);
+                // Unpack SrcA (in1, full tile, uses contexts to manipulate L1 address)
+                TTI_UNPACR_COMMON_EXPLICIT_CONTEXT(SrcA, 0b00000000, 1, 1);  // Also set dvalid
 
                 // Signal context done
                 t6_semaphore_get(semaphore::UNPACK_SYNC);
             }
         }
     });
+
+    // When ct_dim == 1 we alternate between full sequences for both contexts kt_dim times in total
+    // When ct_dim > 1 we start with full context 0 and then alternate between reuse contexts 1 and 0 ct_dim - 1 times
+    // Since if ct_dim > 1 it must be even full seqence always lands on context 0
+    // thus instruction sequence is same for each kt_dim
+    // Mop is configured such that it always covers two iterations of the inner dim loop,
+    // this has two benefits:
+    // With the max number of mop iterations (128) we can cover up to 256 kt_dim, which is the max supported by this API
+    // There is no need to have different templates for contexts 0 and 1 since they are always executed as a pair
+    // In order to be able to usefully issue up to 128 mop iterations we are limited to only using 0s in zmask
+    // (not using SKIP_A/B instructions) since iterations beyond 32 always use 0s for zmask
+    // In ct_dim == 1 case we enable unpackB and two instructions we issue per iteration are replays for
+    // full context 0 and full context 1
+    // In ct_dim > 1 case we enable unpackHalo and thus have 4 instructions to execute two inner dim iterations,
+    // meaning 2 instructions per inner dim
+    // This is achieved with really long replay sequences that each cover half of the ct_dim iterations
+    // First half is:
+    // full context 0, {reuse context 1, reuse context 0} (ct_dim / 4) - 1 times, [reuse context 1] if ct_dim > 2
+    // Since our replay is organized like:
+    // full context 0, reuse context 1, {reuse context 0, reuse context 1} 4 times (which fills all 32 instructions)
+    // We just pick first ct_dim / 2 sequences (each sequence is 3 instructions plus first full one is
+    // 2 additional instructions, thus getting the equation which calculates frist half of the replay length)
+    // Similarly second half is just {reuse context 0, reuse context 1} ct_dim / 4 times,
+    // which is just picking ct_dim / 2 seqeunces starting from the first reuse context 0 sequence
+    // (each sequence is 3 instructions so replay length calculation is simpler)
+    // To be sure that everything fits, for max ct_dim of 16, second half has to issue 4 pairs of sequnces
+    // which is exactly what we recorded at the end
+    // First sequence already has the first pair as full context 0 and reuse context 1
+    // so it needs only 3 additional pair which are covered by the 4 pairs required for the second half
+    // Special case is ct_dim == 2 where first half is just full context 0
+    // and second half is just reuse context 1 thus having a earlier staring index
 
     const std::uint32_t ctx0_full = lltt::replay_insn(0, 5);
     const std::uint32_t ctx1_full = lltt::replay_insn(5, 5);
@@ -108,12 +162,19 @@ template <bool transpose = false>
 inline void _llk_unpack_AB_custom_mm_init_(const std::uint32_t unpB_face_r_dim, const std::uint32_t ct_dim = 1) {
     cfg_reg_rmw_tensix<THCON_SEC0_REG2_Haloize_mode_RMW>(transpose ? 1 : 0);
 
+    // UnpA unpacks full tiles
     constexpr std::uint32_t unpA_x_end = TILE_NUM_FACES * FACE_R_DIM * FACE_C_DIM - 1;
-    const std::uint32_t unpB_x_end = (TILE_NUM_FACES / 2) * unpB_face_r_dim * FACE_C_DIM - 1;
+    // UnpB unpacks [{1, 2, 4, 8}, 32] tiles which only have top two faces and only a single face per instruction
+    // so a single instruction only unpacks unpB_face_r_dim rows
+    const std::uint32_t unpB_x_end = unpB_face_r_dim * FACE_C_DIM - 1;
     TTI_SETADCXX(p_setadc::UNP_A, unpA_x_end, 0x0);
     TT_SETADCXX(p_setadc::UNP_B, unpB_x_end, 0x0);
 
     _llk_unpack_AB_custom_mm_mop_config_(ct_dim);
+
+    // Reset counters here since reset in the execute API is at the end
+    TTI_SETADCZW(0b011, 0, 0, 0, 0, 0b1111);
+    TTI_SETADCXY(0b011, 0, 0, 0, 0, 0b1010);
 }
 
 template <bool read_transposed = false>
@@ -128,18 +189,36 @@ inline void _llk_unpack_AB_custom_mm_(
     const std::uint32_t ct_dim = 1) {
     volatile uint* cfg = get_cfg_pointer();
 
-    const std::uint32_t full_superloops = kt_dim / 128;
-    const std::uint32_t remaining_kt = kt_dim % 128;
-    const std::uint32_t superloop_increment = 128 * (tile_size_b);
     const std::uint32_t block_increment = read_transposed ? kt_dim * tile_size_a : tile_size_a;
     const std::uint32_t inner_increment = read_transposed ? tile_size_a : ct_dim * tile_size_a;
 
     std::uint32_t address_a = base_address_a + tile_size_a * tile_index_a;
     std::uint32_t address_b = base_address_b + tile_size_b * tile_index_b;
 
-    auto kc_loop = [&address_a, ct_dim, block_increment, inner_increment, cfg](const std::uint32_t max_k) {
+    // Wait for all contexts to be free
+    wait_for_next_context(1);
+    reset_config_context();
+
+    // Program SrcB address once, its updated using counters for up to 256 kt_dim
+    cfg[THCON_SEC1_REG3_Base_address_ADDR32] = address_b;
+
+    // We can issue mop only once for up to 256 kt_dim
+    TT_MOP(0, (kt_dim / 2) - 1, 0);
+
+    if (ct_dim == 1) {
 #pragma GCC unroll 8
-        for (std::uint32_t k = 0; k < max_k; k++) {
+        for (std::uint32_t k = 0; k < kt_dim; k += 2) {
+            wait_for_next_context(2);
+            cfg[THCON_SEC0_REG3_Base_address_ADDR32] = address_a;
+            address_a += inner_increment;
+            semaphore_post(semaphore::UNPACK_SYNC);
+            wait_for_next_context(2);
+            cfg[THCON_SEC0_REG3_Base_cntx1_address_ADDR32] = address_a;
+            address_a += inner_increment;
+            semaphore_post(semaphore::UNPACK_SYNC);
+        }
+    } else {
+        for (std::uint32_t k = 0; k < kt_dim; k++) {
             std::uint32_t block_start_address = address_a;
 #pragma GCC unroll 8
             for (std::uint32_t ct = 0; ct < ct_dim; ct += 2) {
@@ -154,51 +233,13 @@ inline void _llk_unpack_AB_custom_mm_(
             }
             address_a += inner_increment;
         }
-    };
-
-    auto k_loop = [&address_a, inner_increment, cfg](const std::uint32_t max_k) {
-#pragma GCC unroll 8
-        for (std::uint32_t k = 0; k < max_k; k += 2) {
-            wait_for_next_context(2);
-            cfg[THCON_SEC0_REG3_Base_address_ADDR32] = address_a;
-            address_a += inner_increment;
-            semaphore_post(semaphore::UNPACK_SYNC);
-            wait_for_next_context(2);
-            cfg[THCON_SEC0_REG3_Base_cntx1_address_ADDR32] = address_a;
-            address_a += inner_increment;
-            semaphore_post(semaphore::UNPACK_SYNC);
-        }
-    };
-
-    wait_for_next_context(1);
-    reset_config_context();
-
-    cfg[THCON_SEC1_REG3_Base_address_ADDR32] = address_b;
-
-    TTI_SETADCZW(0b011, 0, 0, 0, 0, 0b1111);
-    TTI_SETADCXY(0b011, 0, 0, 0, 0, 0b1010);
-    // We can issue mop only once for up to 256 kt_dim
-    TT_MOP(0, (kt_dim / 2) - 1, 0);
-
-    // Need update SrcB base address for each superloop over 128 kt_dim
-    // I guess its due to some counters being overflowed
-    for (std::uint32_t i = 0; i < full_superloops; i++) {
-        if (ct_dim == 1) {
-            k_loop(128);
-        } else {
-            kc_loop(128);
-        }
-    }
-
-    if (remaining_kt != 0) {
-        if (ct_dim == 1) {
-            k_loop(remaining_kt);
-        } else {
-            kc_loop(remaining_kt);
-        }
     }
 
     // Wait for all contexts to be free
     wait_for_next_context(1);
     reset_config_context();
+
+    // Reset counters at the end
+    TTI_SETADCZW(0b011, 0, 0, 0, 0, 0b1111);
+    TTI_SETADCXY(0b011, 0, 0, 0, 0, 0b1010);
 }

--- a/models/demos/deepseek_v3_b1/micro_ops/dram_streaming_matmul/kernels/compute.cpp
+++ b/models/demos/deepseek_v3_b1/micro_ops/dram_streaming_matmul/kernels/compute.cpp
@@ -133,8 +133,8 @@ void kernel_main() {
     constexpr uint32_t num_subblocks_k = get_compile_time_arg_val(6);
     constexpr uint32_t tile_r_dim = get_compile_time_arg_val(7);
 
-    constexpr uint32_t transpose = false;
-    constexpr uint32_t split_acc = true;
+    constexpr bool transpose = false;
+    constexpr bool split_acc = true;
     constexpr uint32_t num_subblocks_n = per_core_N / subblock_w;
     constexpr uint32_t num_tiles_k = subblock_k * num_subblocks_k;
 

--- a/models/demos/deepseek_v3_b1/micro_ops/dram_streaming_matmul/kernels/compute.cpp
+++ b/models/demos/deepseek_v3_b1/micro_ops/dram_streaming_matmul/kernels/compute.cpp
@@ -133,6 +133,8 @@ void kernel_main() {
     constexpr uint32_t num_subblocks_k = get_compile_time_arg_val(6);
     constexpr uint32_t tile_r_dim = get_compile_time_arg_val(7);
 
+    constexpr uint32_t transpose = false;
+    constexpr uint32_t split_acc = true;
     constexpr uint32_t num_subblocks_n = per_core_N / subblock_w;
     constexpr uint32_t num_tiles_k = subblock_k * num_subblocks_k;
 
@@ -141,7 +143,7 @@ void kernel_main() {
 #endif
 
     // Initialize custom matmul
-    custom_mm_block_init<false, true>(cb_id_in0, cb_id_in1, cb_id_out);
+    custom_mm_block_init<transpose, split_acc>(cb_id_in0, cb_id_in1, cb_id_out);
 
     // Wait for all in0 tiles (replicated, tensor-backed - always available)
     cb_wait_front(cb_id_in0, num_tiles_k);

--- a/models/demos/deepseek_v3_b1/unified_kernels/matmul.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/matmul.hpp
@@ -108,9 +108,6 @@ struct Matmul {
             // ================================================================
             // TRISC (Compute)
             // ================================================================
-            constexpr uint32_t out_subblock_h = 1;
-            constexpr uint32_t out_subblock_w = 1;
-            constexpr uint32_t in0_block_w = 1;  // Process one K tile at a time
             constexpr uint32_t out_w = CTArgs::out_w;
             constexpr bool transpose = CTArgs::transpose;
             constexpr bool split_acc = true;


### PR DESCRIPTION
### Ticket
N/A

### Problem description
custom_mm was leaving unpacker counters in non zero state, while this shouldn't be a problem as each execute API should assume nothing about counter state and clear them but this isn't enforced strictly enough.

### What's changed
Unpacker counter clearing in custom MM has been moved to the end of the API.
Also added a bunch of comments explaining the algorithm and tricky parts.
And couple more tiny improvements.

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=lpremovic/custom_mm)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:lpremovic/custom_mm)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=lpremovic/custom_mm)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:lpremovic/custom_mm)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=lpremovic/custom_mm)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:lpremovic/custom_mm)
- [X] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [N/A] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=lpremovic/custom_mm)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:lpremovic/custom_mm)
  - [N/A] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [N/A] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [N/A] other selection - specify runs

- [N/A] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=lpremovic/custom_mm)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:lpremovic/custom_mm)
  - [N/A] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [N/A] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [N/A] other selection - specify runs

- [N/A] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=lpremovic/custom_mm)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:lpremovic/custom_mm})
  - [N/A] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [N/A] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [N/A] other selection - specify runs
