### PR TITLE
Dgomeztt/program cache

### DIFF
--- a/ttnn/api/ttnn/device_operation.hpp
+++ b/ttnn/api/ttnn/device_operation.hpp
@@ -237,7 +237,11 @@ void handle_mesh_adapter_cache_hit(
     ttnn::MeshDevice* mesh_device,
     tt::tt_metal::program_cache::detail::ProgramCache& program_cache,
     tt::stl::hash::hash_t program_hash) {
-    mesh_device_operation_t::validate_on_program_cache_hit(operation_attributes, tensor_args);
+    if constexpr (HasValidateOnProgramCacheHit<mesh_device_operation_t>) {
+        mesh_device_operation_t::validate_on_program_cache_hit(operation_attributes, tensor_args);
+    } else {
+        mesh_device_operation_t::validate_on_program_cache_miss(operation_attributes, tensor_args);
+    }
 
     auto& cached_program_factory = program_cache.get(program_hash);
     auto program_factory_index = cached_program_factory.program_factory_index;

--- a/ttnn/api/ttnn/device_operation.hpp
+++ b/ttnn/api/ttnn/device_operation.hpp
@@ -11,6 +11,7 @@
 #include <tt_stl/overloaded.hpp>
 #include <tt_stl/indestructible.hpp>
 #include "ttnn/tensor/tensor.hpp"
+#include "ttnn/tensor/tensor_ops.hpp"
 #include <unordered_map>
 
 #include <tt-metalium/program_cache.hpp>
@@ -543,6 +544,28 @@ ttnn::MeshDevice* get_mesh_device(
     return mesh_device;
 }
 
+// Framework helper: create output tensors.
+// If the operation provides create_output_tensors, use it.
+// Otherwise, auto-generate from compute_output_specs (single-output operations only).
+template <typename device_operation_t>
+typename device_operation_t::tensor_return_value_t create_output_tensors(
+    const typename device_operation_t::operation_attributes_t& operation_attributes,
+    const typename device_operation_t::tensor_args_t& tensor_args) {
+    if constexpr (HasCreateOutputTensors<device_operation_t>) {
+        return device_operation_t::create_output_tensors(operation_attributes, tensor_args);
+    } else {
+        static_assert(
+            std::is_same_v<typename device_operation_t::tensor_return_value_t, Tensor>,
+            "create_output_tensors must be defined for operations with non-Tensor return types "
+            "(e.g. std::vector<Tensor>, std::tuple<Tensor, ...>). "
+            "Use default_create_output_tensors<Op> helper for preallocated output patterns. "
+            "See: ttnn/api/ttnn/device_operation.hpp or docs/source/ttnn/ttnn/adding_new_ttnn_operation.rst");
+        auto output_spec = device_operation_t::compute_output_specs(operation_attributes, tensor_args);
+        auto first_tensor = tt::stl::reflection::get_first_object_of_type<Tensor>(tensor_args);
+        return create_device_tensor(output_spec, first_tensor.value().device());
+    }
+}
+
 /**
  * Launch an operation on a mesh device.
  *
@@ -569,7 +592,7 @@ typename device_operation_t::tensor_return_value_t launch(
             "Device Operations expect tensor with Device storage in inputs");
     }
 
-    auto tensor_return_value = device_operation_t::create_output_tensors(operation_attributes, tensor_args);
+    auto tensor_return_value = create_output_tensors<device_operation_t>(operation_attributes, tensor_args);
 
     ttnn::MeshDevice* mesh_device = detail::get_mesh_device<device_operation_t>(operation_attributes, tensor_args);
 
@@ -635,5 +658,28 @@ typename device_operation_t::tensor_return_value_t invoke(
 }  // namespace detail
 
 using ttnn::device_operation::detail::launch;
+
+// Helper to create output tensors from compute_output_specs.
+// Works for single-output operations (TensorSpec -> Tensor).
+// Pass an optional preallocated tensor to return it instead of creating a new one.
+//
+// Usage:
+//   // Pattern 1: no preallocated output
+//   return default_create_output_tensors<MyOp>(attrs, tensor_args);
+//
+//   // Pattern 2: with preallocated output
+//   return default_create_output_tensors<MyOp>(attrs, tensor_args, tensor_args.output);
+template <typename device_operation_t>
+typename device_operation_t::tensor_return_value_t default_create_output_tensors(
+    const typename device_operation_t::operation_attributes_t& operation_attributes,
+    const typename device_operation_t::tensor_args_t& tensor_args,
+    const std::optional<Tensor>& preallocated = std::nullopt) {
+    if (preallocated.has_value()) {
+        return preallocated.value();
+    }
+    auto output_spec = device_operation_t::compute_output_specs(operation_attributes, tensor_args);
+    auto first_tensor = tt::stl::reflection::get_first_object_of_type<Tensor>(tensor_args);
+    return create_device_tensor(output_spec, first_tensor.value().device());
+}
 
 }  // namespace ttnn::device_operation

--- a/ttnn/api/ttnn/mesh_device_operation_adapter.hpp
+++ b/ttnn/api/ttnn/mesh_device_operation_adapter.hpp
@@ -43,10 +43,19 @@ struct MeshDeviceOperationAdapter {
     using tensor_return_value_t = typename DeviceOperation::tensor_return_value_t;
     using program_factory_t = typename DeviceOperation::program_factory_t;
 
-    // Delegate to base operation methods
+    // Delegate to base operation methods.
+    // Uses the framework helper: if the operation provides select_program_factory, it is called;
+    // otherwise, for single-variant program_factory_t, returns the sole type automatically.
     static program_factory_t select_program_factory(
         const operation_attributes_t& attrs, const tensor_args_t& tensor_args) {
-        return DeviceOperation::select_program_factory(attrs, tensor_args);
+        if constexpr (HasSelectProgramFactory<DeviceOperation>) {
+            return DeviceOperation::select_program_factory(attrs, tensor_args);
+        } else {
+            static_assert(
+                std::variant_size_v<program_factory_t> == 1,
+                "select_program_factory must be provided when program_factory_t has more than one type");
+            return program_factory_t{std::variant_alternative_t<0, program_factory_t>{}};
+        }
     }
 
     template <typename... Args>

--- a/ttnn/api/ttnn/mesh_device_operation_adapter.hpp
+++ b/ttnn/api/ttnn/mesh_device_operation_adapter.hpp
@@ -61,7 +61,11 @@ struct MeshDeviceOperationAdapter {
     }
 
     static void validate_on_program_cache_hit(const operation_attributes_t& attrs, const tensor_args_t& tensor_args) {
-        DeviceOperation::validate_on_program_cache_hit(attrs, tensor_args);
+        if constexpr (HasValidateOnProgramCacheHit<DeviceOperation>) {
+            DeviceOperation::validate_on_program_cache_hit(attrs, tensor_args);
+        } else {
+            DeviceOperation::validate_on_program_cache_miss(attrs, tensor_args);
+        }
     }
 
     static void validate_on_program_cache_miss(const operation_attributes_t& attrs, const tensor_args_t& tensor_args) {

--- a/ttnn/api/ttnn/operation_concepts.hpp
+++ b/ttnn/api/ttnn/operation_concepts.hpp
@@ -8,6 +8,7 @@
 #include <optional>
 #include <random>
 #include <type_traits>
+#include <variant>
 
 #include <tt-metalium/distributed.hpp>
 #include <tt-metalium/graph_tracking.hpp>
@@ -69,8 +70,37 @@ concept HasValidateOnProgramCacheHit = requires(
     device_operation_t::validate_on_program_cache_hit(attrs, tensor_args);
 };
 
+// Detect if operation provides a custom select_program_factory.
+// If not provided and program_factory_t is a single-type variant, the framework returns it automatically.
+template <typename device_operation_t>
+concept HasSelectProgramFactory = requires(
+    const typename device_operation_t::operation_attributes_t& attrs,
+    const typename device_operation_t::tensor_args_t& tensor_args) {
+    {
+        device_operation_t::select_program_factory(attrs, tensor_args)
+    } -> std::same_as<typename device_operation_t::program_factory_t>;
+};
+
+// Validate that all variant alternatives in a program_factory_t satisfy exactly one of
+// ProgramFactoryConcept or MeshWorkloadFactoryConcept.
+namespace detail {
+template <typename Variant, std::size_t... Is>
+consteval bool all_factories_valid(std::index_sequence<Is...>) {
+    return (
+        (ProgramFactoryConcept<std::variant_alternative_t<Is, Variant>> !=
+         MeshWorkloadFactoryConcept<std::variant_alternative_t<Is, Variant>>) &&
+        ...);
+}
+}  // namespace detail
+
+template <typename Variant>
+concept AllFactoriesValid =
+    detail::all_factories_valid<Variant>(std::make_index_sequence<std::variant_size_v<Variant>>{});
+
 template <typename device_operation_t>
 concept DeviceOperationConcept = requires {
+    typename device_operation_t::program_factory_t;
+
     [](const typename device_operation_t::operation_attributes_t& operation_attributes,
        const typename device_operation_t::tensor_args_t& tensor_args) {
         device_operation_t::validate_on_program_cache_miss(operation_attributes, tensor_args);
@@ -79,15 +109,8 @@ concept DeviceOperationConcept = requires {
         static_assert(std::same_as<
                       decltype(device_operation_t::create_output_tensors(operation_attributes, tensor_args)),
                       tensor_return_value_t>);
-
-        // All program factories returned by `select_program_factory` must implement exactly one of
-        // `ProgramFactoryConcept` or `MeshWorkloadFactoryConcept`.
-        const auto program_factory = device_operation_t::select_program_factory(operation_attributes, tensor_args);
-        std::visit(
-            []<typename T>(const T&) { static_assert(ProgramFactoryConcept<T> != MeshWorkloadFactoryConcept<T>); },
-            program_factory);
     };
-} && HasComputeOutputSpecs<device_operation_t>;
+} && HasComputeOutputSpecs<device_operation_t> && AllFactoriesValid<typename device_operation_t::program_factory_t>;
 
 template <typename device_operation_t>
 concept DeviceOperationWithCustomProgramCacheConcept =

--- a/ttnn/api/ttnn/operation_concepts.hpp
+++ b/ttnn/api/ttnn/operation_concepts.hpp
@@ -60,11 +60,19 @@ concept HasComputeOutputSpecs = requires(
     } -> std::same_as<typename device_operation_t::spec_return_value_t>;
 };
 
+// Detect if operation provides custom cache-hit validation.
+// If not provided, the framework defaults to calling validate_on_program_cache_miss.
+template <typename device_operation_t>
+concept HasValidateOnProgramCacheHit = requires(
+    const typename device_operation_t::operation_attributes_t& attrs,
+    const typename device_operation_t::tensor_args_t& tensor_args) {
+    device_operation_t::validate_on_program_cache_hit(attrs, tensor_args);
+};
+
 template <typename device_operation_t>
 concept DeviceOperationConcept = requires {
     [](const typename device_operation_t::operation_attributes_t& operation_attributes,
        const typename device_operation_t::tensor_args_t& tensor_args) {
-        device_operation_t::validate_on_program_cache_hit(operation_attributes, tensor_args);
         device_operation_t::validate_on_program_cache_miss(operation_attributes, tensor_args);
 
         using tensor_return_value_t = typename device_operation_t::tensor_return_value_t;

--- a/ttnn/cpp/ttnn/operations/bernoulli/device/bernoulli_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/bernoulli/device/bernoulli_device_operation.cpp
@@ -56,11 +56,8 @@ BernoulliDeviceOperation::spec_return_value_t BernoulliDeviceOperation::compute_
 
 BernoulliDeviceOperation::tensor_return_value_t BernoulliDeviceOperation::create_output_tensors(
     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
-    if (tensor_args.output.has_value()) {
-        return tensor_args.output.value();
-    }
-
-    return create_device_tensor(compute_output_specs(operation_attributes, tensor_args), tensor_args.input.device());
+    return ttnn::device_operation::default_create_output_tensors<BernoulliDeviceOperation>(
+        operation_attributes, tensor_args, tensor_args.output);
 }
 
 }  // namespace ttnn::operations::bernoulli

--- a/ttnn/cpp/ttnn/operations/bernoulli/device/bernoulli_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/bernoulli/device/bernoulli_device_operation.cpp
@@ -59,7 +59,9 @@ BernoulliDeviceOperation::spec_return_value_t BernoulliDeviceOperation::compute_
     return TensorSpec(
         output_shape,
         tt::tt_metal::TensorLayout(
-            operation_attributes.dtype, tt::tt_metal::PageConfig(Layout::TILE), operation_attributes.memory_config));
+            operation_attributes.compile_time.dtype,
+            tt::tt_metal::PageConfig(Layout::TILE),
+            operation_attributes.compile_time.memory_config));
 }
 
 BernoulliDeviceOperation::tensor_return_value_t BernoulliDeviceOperation::create_output_tensors(
@@ -69,13 +71,6 @@ BernoulliDeviceOperation::tensor_return_value_t BernoulliDeviceOperation::create
     }
 
     return create_device_tensor(compute_output_specs(operation_attributes, tensor_args), tensor_args.input.device());
-}
-
-tt::stl::hash::hash_t BernoulliDeviceOperation::compute_program_hash(
-    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
-    auto cached_operation_attributes = operation_attributes;
-    cached_operation_attributes.seed = 0;
-    return tt::stl::hash::hash_objects_with_default_seed(cached_operation_attributes, tensor_args);
 }
 
 }  // namespace ttnn::operations::bernoulli
@@ -92,10 +87,16 @@ ttnn::operations::bernoulli::BernoulliDeviceOperation::tensor_return_value_t ber
     TT_FATAL(input.device() != nullptr, "Bernoulli: Input tensor needs to be on device");
 
     auto operation_attributes = OperationType::operation_attributes_t{
-        seed,
-        dtype.value_or(DataType::FLOAT32),
-        memory_config.value_or(input.memory_config()),
-        init_device_compute_kernel_config(input.device()->arch(), compute_kernel_config, MathFidelity::HiFi4)};
+        .compile_time = {
+            .dtype = dtype.value_or(DataType::FLOAT32),
+            .memory_config = memory_config.value_or(input.memory_config()),
+            .compute_kernel_config = init_device_compute_kernel_config(
+                input.device()->arch(), compute_kernel_config, MathFidelity::HiFi4),
+        },
+        .runtime = {
+            .seed = seed,
+        },
+    };
     auto tensor_args = OperationType::tensor_args_t{input, output};
 
     return ttnn::device_operation::launch<OperationType>(operation_attributes, tensor_args);

--- a/ttnn/cpp/ttnn/operations/bernoulli/device/bernoulli_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/bernoulli/device/bernoulli_device_operation.cpp
@@ -8,11 +8,6 @@
 
 namespace ttnn::operations::bernoulli {
 
-BernoulliDeviceOperation::program_factory_t BernoulliDeviceOperation::select_program_factory(
-    const operation_attributes_t& /*operation_attributes*/, const tensor_args_t& /*tensor_args*/) {
-    return ProgramFactory{};
-}
-
 void BernoulliDeviceOperation::validate_inputs(
     const operation_attributes_t& /*operation_attributes*/, const tensor_args_t& tensor_args) {
     const auto& input = tensor_args.input;

--- a/ttnn/cpp/ttnn/operations/bernoulli/device/bernoulli_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/bernoulli/device/bernoulli_device_operation.cpp
@@ -44,11 +44,6 @@ void BernoulliDeviceOperation::validate_on_program_cache_miss(
     validate_inputs(operation_attributes, tensor_args);
 }
 
-void BernoulliDeviceOperation::validate_on_program_cache_hit(
-    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
-    validate_inputs(operation_attributes, tensor_args);
-}
-
 BernoulliDeviceOperation::spec_return_value_t BernoulliDeviceOperation::compute_output_specs(
     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
     if (tensor_args.output.has_value()) {

--- a/ttnn/cpp/ttnn/operations/bernoulli/device/bernoulli_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/bernoulli/device/bernoulli_device_operation.hpp
@@ -11,10 +11,17 @@ namespace ttnn::operations::bernoulli {
 
 struct BernoulliDeviceOperation {
     struct operation_attributes_t {
-        uint32_t seed;
-        const DataType dtype;
-        const MemoryConfig memory_config;
-        const DeviceComputeKernelConfig compute_kernel_config;
+        // Affects program structure - automatically hashed for cache lookup
+        struct compile_time_t {
+            DataType dtype;
+            MemoryConfig memory_config;
+            DeviceComputeKernelConfig compute_kernel_config;
+        } compile_time;
+
+        // Only passed to kernels - NOT hashed, changes don't trigger recompilation
+        struct runtime_t {
+            uint32_t seed;
+        } runtime;
     };
 
     struct tensor_args_t {
@@ -55,8 +62,6 @@ struct BernoulliDeviceOperation {
     static void validate_on_program_cache_hit(const operation_attributes_t&, const tensor_args_t&);
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
-
-    static tt::stl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
 };
 
 }  // namespace ttnn::operations::bernoulli

--- a/ttnn/cpp/ttnn/operations/bernoulli/device/bernoulli_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/bernoulli/device/bernoulli_device_operation.hpp
@@ -59,7 +59,6 @@ struct BernoulliDeviceOperation {
     static program_factory_t select_program_factory(const operation_attributes_t&, const tensor_args_t&);
     static void validate_inputs(const operation_attributes_t& attributes, const tensor_args_t& tensor_args);
     static void validate_on_program_cache_miss(const operation_attributes_t&, const tensor_args_t&);
-    static void validate_on_program_cache_hit(const operation_attributes_t&, const tensor_args_t&);
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
 };

--- a/ttnn/cpp/ttnn/operations/bernoulli/device/bernoulli_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/bernoulli/device/bernoulli_device_operation.hpp
@@ -56,7 +56,8 @@ struct BernoulliDeviceOperation {
 
     using program_factory_t = std::variant<ProgramFactory>;
 
-    static program_factory_t select_program_factory(const operation_attributes_t&, const tensor_args_t&);
+    // select_program_factory is not needed: single-variant program_factory_t is auto-selected by framework.
+
     static void validate_inputs(const operation_attributes_t& attributes, const tensor_args_t& tensor_args);
     static void validate_on_program_cache_miss(const operation_attributes_t&, const tensor_args_t&);
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);

--- a/ttnn/cpp/ttnn/operations/bernoulli/device/bernoulli_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/bernoulli/device/bernoulli_device_operation.hpp
@@ -56,8 +56,6 @@ struct BernoulliDeviceOperation {
 
     using program_factory_t = std::variant<ProgramFactory>;
 
-    // select_program_factory is not needed: single-variant program_factory_t is auto-selected by framework.
-
     static void validate_inputs(const operation_attributes_t& attributes, const tensor_args_t& tensor_args);
     static void validate_on_program_cache_miss(const operation_attributes_t&, const tensor_args_t&);
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);

--- a/ttnn/cpp/ttnn/operations/bernoulli/device/bernoulli_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/bernoulli/device/bernoulli_program_factory.cpp
@@ -91,7 +91,7 @@ BernoulliDeviceOperation::ProgramFactory::cached_program_t BernoulliDeviceOperat
     KernelHandle writer_kernel_id = tt_metal::CreateKernel(
         program, writer_file_path, all_cores, WriterDataMovementConfig(writer_compile_time_args, writer_defines));
     auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
-        get_compute_kernel_config_args(device->arch(), operation_attributes.compute_kernel_config);
+        get_compute_kernel_config_args(device->arch(), operation_attributes.compile_time.compute_kernel_config);
     KernelHandle compute_kernel_id = CreateKernel(
         program,
         compute_file_path,
@@ -121,7 +121,8 @@ BernoulliDeviceOperation::ProgramFactory::cached_program_t BernoulliDeviceOperat
         SetRuntimeArgs(program, reader_kernel_id, core, reader_runtime_args);
 
         // Each core has its own seed to increase the number of generated random numbers
-        uint32_t seed = operation_attributes.seed != 0 ? operation_attributes.seed + i : get_random_seed();
+        uint32_t seed =
+            operation_attributes.runtime.seed != 0 ? operation_attributes.runtime.seed + i : get_random_seed();
 
         std::vector<uint32_t> compute_runtime_args = {seed, tile_offset, units_per_core};
         SetRuntimeArgs(program, compute_kernel_id, core, compute_runtime_args);
@@ -161,7 +162,8 @@ void BernoulliDeviceOperation::ProgramFactory::override_runtime_arguments(
         }
         {
             auto& runtime_args = GetRuntimeArgs(program, compute_kernel_id, cores[i]);
-            runtime_args[0] = operation_attributes.seed != 0 ? operation_attributes.seed + i : get_random_seed();
+            runtime_args[0] =
+                operation_attributes.runtime.seed != 0 ? operation_attributes.runtime.seed + i : get_random_seed();
         }
         {
             auto& runtime_args = GetRuntimeArgs(program, writer_kernel_id, cores[i]);

--- a/ttnn/cpp/ttnn/operations/examples/example/device/example_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/examples/example/device/example_device_operation.cpp
@@ -20,9 +20,6 @@ ExampleDeviceOperation::program_factory_t ExampleDeviceOperation::select_program
 void ExampleDeviceOperation::validate_on_program_cache_miss(
     const operation_attributes_t& /*attributes*/, const tensor_args_t& /*tensor_args*/) {}
 
-void ExampleDeviceOperation::validate_on_program_cache_hit(
-    const operation_attributes_t& /*attributes*/, const tensor_args_t& /*tensor_args*/) {}
-
 ExampleDeviceOperation::spec_return_value_t ExampleDeviceOperation::compute_output_specs(
     const operation_attributes_t&, const tensor_args_t& tensor_args) {
     const auto& input_tensor = tensor_args.input_tensor;

--- a/ttnn/cpp/ttnn/operations/examples/example/device/example_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/examples/example/device/example_device_operation.cpp
@@ -29,12 +29,6 @@ ExampleDeviceOperation::spec_return_value_t ExampleDeviceOperation::compute_outp
             input_tensor.dtype(), tt::tt_metal::PageConfig(input_tensor.layout()), MemoryConfig{}));
 }
 
-ExampleDeviceOperation::tensor_return_value_t ExampleDeviceOperation::create_output_tensors(
-    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
-    auto output_spec = compute_output_specs(operation_attributes, tensor_args);
-    return create_device_tensor(output_spec, tensor_args.input_tensor.device());
-}
-
 }  // namespace ttnn::operations::examples
 
 namespace ttnn::prim {

--- a/ttnn/cpp/ttnn/operations/examples/example/device/example_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/examples/example/device/example_device_operation.hpp
@@ -123,8 +123,12 @@ struct ExampleDeviceOperation {
     // Compute the output specs based on the operation attributes and tensor args
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
 
-    // Create the output tensors based on the operation attributes and tensor args
-    static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
+    // Optional: create_output_tensors.
+    // For single-output operations (tensor_return_value_t = Tensor), the framework auto-generates it
+    // from compute_output_specs. Override to handle preallocated outputs or complex cases.
+    // Use default_create_output_tensors<Op> helper for the preallocated output pattern:
+    //   return default_create_output_tensors<MyOp>(attrs, args, args.output);
+    // static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
 };
 
 }  // namespace ttnn::operations::examples

--- a/ttnn/cpp/ttnn/operations/examples/example/device/example_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/examples/example/device/example_device_operation.hpp
@@ -112,11 +112,12 @@ struct ExampleDeviceOperation {
     // Select the program factory based on the operation attributes and tensor args
     static program_factory_t select_program_factory(const operation_attributes_t&, const tensor_args_t&);
 
-    // Validate the operation when it creates a program. Usually will have more checks
+    // Validate the operation when it creates a program. Also called on cache hit by default.
     static void validate_on_program_cache_miss(const operation_attributes_t&, const tensor_args_t&);
 
-    // Validate the operation when it reuses a program. Usually will have less checks
-    static void validate_on_program_cache_hit(const operation_attributes_t&, const tensor_args_t&);
+    // Optional: override to use lighter validation on cache hit.
+    // If not provided, the framework calls validate_on_program_cache_miss.
+    // static void validate_on_program_cache_hit(const operation_attributes_t&, const tensor_args_t&);
 
     // Compute the output specs based on the operation attributes and tensor args
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);

--- a/ttnn/cpp/ttnn/operations/examples/example/device/example_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/examples/example/device/example_device_operation.hpp
@@ -107,10 +107,11 @@ struct ExampleDeviceOperation {
 
     using program_factory_t = std::variant<SingleCore, MultiCore>;
 
-    // Mandatory methods
-
-    // Select the program factory based on the operation attributes and tensor args
+    // Required only when program_factory_t has more than one variant.
+    // For single-variant program_factory_t, the framework auto-selects it.
     static program_factory_t select_program_factory(const operation_attributes_t&, const tensor_args_t&);
+
+    // Mandatory methods
 
     // Validate the operation when it creates a program. Also called on cache hit by default.
     static void validate_on_program_cache_miss(const operation_attributes_t&, const tensor_args_t&);


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Provide context for the problem.

### What's changed
Describe the approach used to solve the problem.
Summarize the changes made and its impact.

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=dgomeztt/program_cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:dgomeztt/program_cache)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=dgomeztt/program_cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:dgomeztt/program_cache)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=dgomeztt/program_cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:dgomeztt/program_cache)
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=dgomeztt/program_cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:dgomeztt/program_cache)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=dgomeztt/program_cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:dgomeztt/program_cache)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=dgomeztt/program_cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:dgomeztt/program_cache)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
