### PR TITLE
Pages table creation API changes

### DIFF
--- a/models/demos/deepseek_v3/tt/generator.py
+++ b/models/demos/deepseek_v3/tt/generator.py
@@ -131,7 +131,9 @@ class DeepseekGenerator(WarmupForwardMixin):
         # Paged attention setup
         self.batch_size_per_row = USERS_PER_ROW
         self.batch_size = self.batch_size_per_row * self.mesh_device.shape[0]
-        self.paged_config = MLA2D.get_valid_paged_config(self.hf_config.max_seq_len, self.batch_size, self.dp_factor)
+        self.paged_config = MLA2D.get_valid_paged_config(
+            self.hf_config.max_seq_len, self.batch_size_per_row, self.dp_factor
+        )
 
         self.random_weights = random_weights
         self.single_layer = single_layer
@@ -462,7 +464,7 @@ class DeepseekGenerator(WarmupForwardMixin):
             MLA2D.create_page_table(
                 paged_config=self.paged_config,
                 mesh_device=self.mesh_device,
-                batch_size_per_row=int(self.batch_size_per_row / self.mesh_device.shape[0]),
+                batch=self.batch_size_per_row,
             )
             for _ in range(self.hf_config.num_hidden_layers)
         )
@@ -1141,7 +1143,7 @@ class DeepseekGenerator(WarmupForwardMixin):
             paged_config=self.paged_config,
             mesh_device=self.mesh_device,
             page_table=full_page_table,
-            batch_size_per_row=self.batch_size_per_row // self.mesh_device.shape[0],
+            batch_size=self.batch_size_per_row,
         )
 
         num_layers = self.hf_config.num_hidden_layers

--- a/models/demos/deepseek_v3/tt/mla/mla2d.py
+++ b/models/demos/deepseek_v3/tt/mla/mla2d.py
@@ -103,21 +103,6 @@ class MLA2D(MLA1D):
         }
 
     @classmethod
-    def create_page_table(
-        cls,
-        paged_config: PagedAttentionConfig,
-        mesh_device: ttnn.MeshDevice,
-        page_table: torch.Tensor | None = None,
-        batch_size_per_row: int = USERS_PER_ROW,
-    ) -> ttnn.Tensor:
-        return super().create_page_table(
-            paged_config=paged_config,
-            mesh_device=mesh_device,
-            page_table=page_table,
-            batch_size=batch_size_per_row * mesh_device.shape[0],
-        )
-
-    @classmethod
     def create_state(
         cls,
         hf_config: PretrainedConfig,


### PR DESCRIPTION
### Summary
This PR adjusts DeepSeek MLA paged-attention sizing to be explicit and consistent across call sites.

- Changed `MLA2D.create_page_table(...)` API usage from a wrapper form to direct `create_page_table(..., batch=...)` usage.
- Switched paged config sizing to use `batch_size_per_row` for `max_num_blocks` calculation (instead of total `batch_size`).
- Updated page-table construction paths in `generator.py` so both default and vLLM-converted flows pass the intended per-row batch value.

Effect:
- For `8x8` mesh, this reduces requested paging budget by ~8x versus the old implicit row-scaling path.
- This is a behavior correction to avoid over-allocation and duplicate hidden scaling assumptions in the API.

### PR status
[![Galaxy DeepSeek tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-deepseek-tests.yaml/badge.svg?branch=pprajapati/page_table_fixes)](https://github.com/tenstorrent/tt-metal/actions/runs/21984586380)

### Ticket
Link to Github Issue

### Problem description
Provide context for the problem.

### What's changed
Summarize the changes made and its impact.

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=pprajapati/page_table_fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:pprajapati/page_table_fixes)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=pprajapati/page_table_fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:pprajapati/page_table_fixes)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=pprajapati/page_table_fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:pprajapati/page_table_fixes)
- [ ] New/Existing tests provide coverage for changes

#### Model tests
If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets. The former includes a minimal set of tests, to be run always. The latter extends that with additional ones.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=pprajapati/page_table_fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:pprajapati/page_table_fixes)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=pprajapati/page_table_fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:pprajapati/page_table_fixes)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=pprajapati/page_table_fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:pprajapati/page_table_fixes)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

