### PR TITLE
Remove static variables from dispatch topology init code

### DIFF
--- a/tt_metal/distributed/dispatch_context.cpp
+++ b/tt_metal/distributed/dispatch_context.cpp
@@ -11,11 +11,11 @@
 #include "impl/context/metal_context.hpp"
 #include "impl/device/device_manager.hpp"
 #include "impl/device/device_impl.hpp"
-#include "impl/dispatch/topology.hpp"
 #include "impl/dispatch/cq_shared_state.hpp"
 #include "llrt/hal/generated/dev_msgs.hpp"
 #include "llrt/rtoptions.hpp"
 #include "llrt/llrt.hpp"
+#include "tt_cluster.hpp"
 
 namespace tt::tt_metal::experimental {
 
@@ -53,8 +53,8 @@ void DispatchContext::initialize_fast_dispatch(distributed::MeshDevice* mesh_dev
         dev->init_command_queue_host();
     }
     // Query the number of command queues requested
-    populate_fd_kernels(active_devices, num_hw_cqs);
-    device_manager->initialize_dispatch_firmware();
+    device_manager->initialize_dispatch_firmware(/*force_recreate_topology=*/true);
+    tt::tt_metal::MetalContext::instance().rtoptions().set_fast_dispatch(fast_dispatch_enabled_);
 
     auto& mesh_device_impl = mesh_device->impl();
     mesh_device_impl.mesh_command_queues_.clear();
@@ -98,7 +98,7 @@ void DispatchContext::terminate_fast_dispatch(distributed::MeshDevice* mesh_devi
     }
 
     for (const auto& dev : active_devices) {
-        auto dispatch_cores = tt::tt_metal::get_virtual_dispatch_cores(dev->id());
+        auto dispatch_cores = device_manager->get_virtual_dispatch_cores(dev->id());
         tt::llrt::internal_::wait_until_cores_done(dev->id(), dev_msgs::RUN_MSG_GO, dispatch_cores, 0);
     }
 

--- a/tt_metal/impl/context/metal_context.cpp
+++ b/tt_metal/impl/context/metal_context.cpp
@@ -296,13 +296,6 @@ void MetalContext::initialize(
         }
     }
 
-    // Populate FD topology across all devices
-    if (rtoptions_.get_fast_dispatch()) {
-        std::set<ChipId> all_devices_set(all_devices.begin(), all_devices.end());
-        // TODO: enable this when dispatch init/teardown moves to MetalContext
-        // populate_fd_kernels(all_devices_set, num_hw_cqs);
-    }
-
     // Set internal routing for active ethernet cores, this is required for our FW to run
     if (has_flag(MetalContext::instance().get_fabric_manager(), tt_fabric::FabricManagerMode::INIT_FABRIC) &&
         cluster_->get_target_device_type() != tt::TargetDevice::Mock) {
@@ -562,9 +555,9 @@ void MetalContext::teardown_dispatch_state() {
             mem_map.reset();
         }
     }
+    device_manager_->reset_dispatch_topology();
     dispatch_query_manager_.reset();
     dispatch_core_manager_.reset();
-    tt::tt_metal::reset_topology_state();
 }
 
 void MetalContext::initialize_base_objects() {
@@ -951,11 +944,11 @@ tt_fabric::FabricUDMMode MetalContext::get_fabric_udm_mode() const { return fabr
 tt_fabric::FabricManagerMode MetalContext::get_fabric_manager() const { return fabric_manager_; }
 
 std::shared_ptr<ContextDescriptor> MetalContext::create_context_descriptor(
-    int num_hw_cqs, size_t l1_small_size, size_t trace_region_size, size_t worker_l1_size) const {
+    int num_hw_cqs, size_t l1_small_size, size_t trace_region_size, size_t worker_l1_size) {
     return std::make_shared<ContextDescriptor>(
         *hal_,
         *cluster_,
-        rtoptions_,
+        rtoptions(),
         fabric_config_,
         fabric_reliability_mode_,
         fabric_tensix_config_,
@@ -1149,8 +1142,12 @@ void MetalContext::reset_cores(ChipId device_id) {
 }
 
 void MetalContext::assert_cores(ChipId device_id) {
-    auto dispatch_cores = get_virtual_dispatch_cores(device_id);
-    auto routing_cores = get_virtual_dispatch_routing_cores(device_id);
+    std::unordered_set<CoreCoord> dispatch_cores;
+    std::unordered_set<CoreCoord> routing_cores;
+    if (device_manager_) {
+        dispatch_cores = device_manager_->get_virtual_dispatch_cores(device_id);
+        routing_cores = device_manager_->get_virtual_dispatch_routing_cores(device_id);
+    }
 
     // Assert riscs on Tensix
     CoreCoord grid_size = cluster_->get_soc_desc(device_id).get_grid_size(CoreType::TENSIX);

--- a/tt_metal/impl/context/metal_context.cpp
+++ b/tt_metal/impl/context/metal_context.cpp
@@ -948,7 +948,7 @@ std::shared_ptr<ContextDescriptor> MetalContext::create_context_descriptor(
     return std::make_shared<ContextDescriptor>(
         *hal_,
         *cluster_,
-        rtoptions(),
+        rtoptions_,
         fabric_config_,
         fabric_reliability_mode_,
         fabric_tensix_config_,

--- a/tt_metal/impl/context/metal_context.hpp
+++ b/tt_metal/impl/context/metal_context.hpp
@@ -77,7 +77,7 @@ public:
     bool is_device_manager_initialized() const { return device_manager_ != nullptr; }
 
     std::shared_ptr<ContextDescriptor> create_context_descriptor(
-        int num_hw_cqs, size_t l1_small_size, size_t trace_region_size, size_t worker_l1_size) const;
+        int num_hw_cqs, size_t l1_small_size, size_t trace_region_size, size_t worker_l1_size);
 
     std::unique_ptr<NOCDebugState>& noc_debug_state() { return noc_debug_state_; }
 

--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -162,7 +162,7 @@ std::unique_ptr<AllocatorImpl> Device::initialize_allocator(
 
 // Writes issue and completion queue pointers to device and in sysmem and loads fast dispatch program onto dispatch
 // cores
-void Device::configure_command_queue_programs() {
+void Device::configure_command_queue_programs(DispatchTopology* dispatch_topology) {
     ChipId device_id = this->id();
     ChipId mmio_device_id = tt::tt_metal::MetalContext::instance().get_cluster().get_associated_mmio_device(device_id);
 
@@ -219,7 +219,10 @@ void Device::configure_command_queue_programs() {
     }
 
     // Write device-side cq pointers
-    configure_dispatch_cores(this);
+    TT_ASSERT(
+        dispatch_topology != nullptr,
+        "Dispatch topology required for configure_command_queue_programs (fast dispatch)");
+    dispatch_topology->configure_dispatch_cores(this);
 
     // Run the cq program
     command_queue_program.impl().finalize_offsets(this);
@@ -242,10 +245,11 @@ void Device::init_command_queue_host() {
     }
 }
 
-void Device::init_command_queue_device() {
-    this->command_queue_programs_.push_back(get_compiled_cq_program(this));
+void Device::init_command_queue_device_with_topology(DispatchTopology* topo) {
+    TT_ASSERT(topo != nullptr, "Dispatch topology required for init_command_queue_device_with_topology");
+    this->command_queue_programs_.push_back(topo->get_compiled_cq_program(this));
     TT_ASSERT(this->command_queue_programs_.size() == 1);
-    this->configure_command_queue_programs();
+    this->configure_command_queue_programs(topo);
     Program& command_queue_program = *this->command_queue_programs_[0];
 
     // Write 0 to all workers launch message read pointer. Need to do this since dispatch cores are written new on each
@@ -347,6 +351,8 @@ void Device::init_command_queue_device() {
         hw_cq->set_go_signal_noc_data_and_dispatch_sems(num_sub_devices(), noc_mcast_unicast_data);
     }
 }
+
+void Device::init_command_queue_device() { TT_FATAL(false, "Call init_command_queue_device_with_topology instead"); }
 
 bool Device::compile_fabric() {
     fabric_program_ = tt::tt_fabric::create_and_compile_fabric_program(this);

--- a/tt_metal/impl/device/device_impl.hpp
+++ b/tt_metal/impl/device/device_impl.hpp
@@ -22,6 +22,7 @@
 namespace tt::tt_metal {
 class SubDeviceManagerTracker;
 class AllocatorImpl;
+class DispatchTopology;
 
 namespace experimental {
 class DispatchContext;
@@ -133,6 +134,8 @@ public:
     void init_command_queue_host() override;
     void init_command_queue_device() override;
 
+    void init_command_queue_device_with_topology(DispatchTopology* topology);
+
     bool compile_fabric() override;
     void configure_fabric() override;
     // Puts device into reset
@@ -194,7 +197,7 @@ private:
         size_t worker_l1_unreserved_start,
         tt::stl::Span<const std::uint32_t> l1_bank_remap = {});
 
-    void configure_command_queue_programs();
+    void configure_command_queue_programs(DispatchTopology* topology);
 
     // NOLINTNEXTLINE(readability-make-member-function-const)
     void mark_allocations_unsafe();

--- a/tt_metal/impl/device/device_manager.cpp
+++ b/tt_metal/impl/device/device_manager.cpp
@@ -498,9 +498,10 @@ void DeviceManager::initialize_dispatch_firmware(bool force_recreate_topology) {
 }
 
 const std::unordered_set<CoreCoord>& DeviceManager::get_virtual_dispatch_cores(ChipId dev_id) const {
-    TT_ASSERT(
-        initializers_.contains(DispatchKernelInitializer::key),
-        "Dispatch firmware not initialized yet. Call initialize_dispatch_firmware() first.");
+    if (!initializers_.contains(DispatchKernelInitializer::key)) {
+        // Dispatch firmware is not initialized in minimal mode
+        return this->empty_container_;
+    }
     auto* dispatch_kernel_initializer =
         dynamic_cast<DispatchKernelInitializer*>(initializers_.at(DispatchKernelInitializer::key).get());
     TT_ASSERT(
@@ -510,9 +511,10 @@ const std::unordered_set<CoreCoord>& DeviceManager::get_virtual_dispatch_cores(C
 }
 
 const std::unordered_set<CoreCoord>& DeviceManager::get_virtual_dispatch_routing_cores(ChipId dev_id) const {
-    TT_ASSERT(
-        initializers_.contains(DispatchKernelInitializer::key),
-        "Dispatch firmware not initialized yet. Call initialize_dispatch_firmware() first.");
+    if (!initializers_.contains(DispatchKernelInitializer::key)) {
+        // Dispatch firmware is not initialized in minimal mode
+        return this->empty_container_;
+    }
     auto* dispatch_kernel_initializer =
         dynamic_cast<DispatchKernelInitializer*>(initializers_.at(DispatchKernelInitializer::key).get());
     TT_ASSERT(

--- a/tt_metal/impl/device/device_manager.cpp
+++ b/tt_metal/impl/device/device_manager.cpp
@@ -12,6 +12,7 @@
 #include <tt_stl/assert.hpp>
 #include <tt-logger/tt-logger.hpp>
 #include <tt_metal.hpp>
+#include "dispatch/dispatch_query_manager.hpp"
 #include "fabric/fabric_host_utils.hpp"
 #include "impl/context/metal_context.hpp"
 #include "impl/context/context_descriptor.hpp"
@@ -270,6 +271,8 @@ void DeviceManager::open_devices(const std::vector<ChipId>& device_ids) {
             fabric_config = tt::tt_fabric::FabricConfig::FABRIC_1D;
             tt::tt_fabric::SetFabricConfig(
                 fabric_config, tt::tt_fabric::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE, 1);
+            // Update the fabric config in the descriptor
+            descriptor_->fabric_config_ = fabric_config;
             // Call initialize again because previously it was a no-op
             tt::tt_metal::MetalContext::instance().initialize_fabric_config();
             log_info(
@@ -282,6 +285,7 @@ void DeviceManager::open_devices(const std::vector<ChipId>& device_ids) {
             tt::tt_fabric::SetFabricConfig(
                 fabric_config, tt::tt_fabric::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE, 1);
         }
+        descriptor_->reliability_mode_ = tt::tt_fabric::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE;
         log_info(tt::LogMetal, "Dispatch on {} with {} Command Queues\n", fabric_config, num_hw_cqs_);
     }
 
@@ -290,9 +294,6 @@ void DeviceManager::open_devices(const std::vector<ChipId>& device_ids) {
 
     // Initialize fabric tensix datamover config after devices are added to the pool
     tt::tt_metal::MetalContext::instance().initialize_fabric_tensix_datamover_config();
-
-    descriptor_ = tt::tt_metal::MetalContext::instance().create_context_descriptor(
-        num_hw_cqs_, l1_small_size_, trace_region_size_, worker_l1_size_);
 
     init_firmware_on_active_devices();
 }
@@ -404,9 +405,11 @@ void DeviceManager::add_devices_to_pool(const std::vector<ChipId>& device_ids) {
         }
     }
 
+    std::vector<Device*> activated_devices;
     for (const auto& device_id : devices_to_activate) {
         if (not this->is_device_active(device_id)) {
             this->activate_device(device_id);
+            activated_devices.push_back(this->get_device(device_id));
         }
     }
 
@@ -432,9 +435,14 @@ void DeviceManager::add_devices_to_pool(const std::vector<ChipId>& device_ids) {
         }
     }
 
-    if (this->using_fast_dispatch_ && !devices_to_activate.empty()) {
-        populate_fd_kernels(devices_to_activate, this->num_hw_cqs_);
+    // populate_fd_kernels_only needs to be done before Fabric initialization.
+    // It allocates dispatch cores to dispatch_core_manager.
+    auto dispatch_kernel_initializer =
+        std::make_unique<DispatchKernelInitializer>(descriptor_, MetalContext::instance().get_dispatch_core_manager());
+    if (!activated_devices.empty()) {
+        dispatch_kernel_initializer->populate_fd_kernels_only(activated_devices);
     }
+    initializers_[DispatchKernelInitializer::key] = std::move(dispatch_kernel_initializer);
 }
 
 void DeviceManager::initialize_profiler() {
@@ -462,7 +470,6 @@ void DeviceManager::initialize_fabric_and_dispatch_fw() {
     initializers_[FabricFirmwareInitializer::key]->init(active_devices, init_done_);
     init_done_.insert(FabricFirmwareInitializer::key);
 
-    initializers_[DispatchKernelInitializer::key] = std::make_unique<DispatchKernelInitializer>(descriptor_);
     initializers_[DispatchKernelInitializer::key]->init(active_devices, init_done_);
     init_done_.insert(DispatchKernelInitializer::key);
 
@@ -472,16 +479,50 @@ void DeviceManager::initialize_fabric_and_dispatch_fw() {
     log_trace(tt::LogMetal, "Fabric and Dispatch Firmware initialized");
 }
 
-void DeviceManager::initialize_dispatch_firmware() {
+void DeviceManager::reset_dispatch_topology() {
+    auto dispatch_kernel_initializer =
+        std::make_unique<DispatchKernelInitializer>(descriptor_, MetalContext::instance().get_dispatch_core_manager());
+    const auto& active_devices = this->get_all_active_devices_impl();
+    dispatch_kernel_initializer->populate_fd_kernels_only(active_devices);
+    initializers_[DispatchKernelInitializer::key] = std::move(dispatch_kernel_initializer);
+    init_done_.erase(DispatchKernelInitializer::key);
+}
+
+void DeviceManager::initialize_dispatch_firmware(bool force_recreate_topology) {
     // This function is used by DispatchContext for manual FD setup.
-    // It will re initialize the dispatch firmware on the active devices as they were manually
-    // disabled
+    // It will re initialize the dispatch firmware on the active devices after it was manually disabled
     auto active_devices = this->get_all_active_devices_impl();
     init_done_.erase(DispatchKernelInitializer::key);
-    initializers_[DispatchKernelInitializer::key] = std::make_unique<DispatchKernelInitializer>(descriptor_);
+    if (force_recreate_topology) {
+        reset_dispatch_topology();
+    }
     initializers_[DispatchKernelInitializer::key]->init(active_devices, init_done_);
     initializers_[DispatchKernelInitializer::key]->configure();
     init_done_.insert(DispatchKernelInitializer::key);
+}
+
+const std::unordered_set<CoreCoord>& DeviceManager::get_virtual_dispatch_cores(ChipId dev_id) const {
+    TT_ASSERT(
+        initializers_.contains(DispatchKernelInitializer::key),
+        "Dispatch firmware not initialized yet. Call initialize_dispatch_firmware() first.");
+    auto* dispatch_kernel_initializer =
+        dynamic_cast<DispatchKernelInitializer*>(initializers_.at(DispatchKernelInitializer::key).get());
+    TT_ASSERT(
+        dispatch_kernel_initializer != nullptr,
+        "Expected DispatchKernelInitializer but got different FirmwareInitializer subclass");
+    return dispatch_kernel_initializer->get_virtual_dispatch_cores(dev_id);
+}
+
+const std::unordered_set<CoreCoord>& DeviceManager::get_virtual_dispatch_routing_cores(ChipId dev_id) const {
+    TT_ASSERT(
+        initializers_.contains(DispatchKernelInitializer::key),
+        "Dispatch firmware not initialized yet. Call initialize_dispatch_firmware() first.");
+    auto* dispatch_kernel_initializer =
+        dynamic_cast<DispatchKernelInitializer*>(initializers_.at(DispatchKernelInitializer::key).get());
+    TT_ASSERT(
+        dispatch_kernel_initializer != nullptr,
+        "Expected DispatchKernelInitializer but got different FirmwareInitializer subclass");
+    return dispatch_kernel_initializer->get_virtual_dispatch_routing_cores(dev_id);
 }
 
 void DeviceManager::init_firmware_on_active_devices() {
@@ -633,9 +674,6 @@ bool DeviceManager::close_devices(const std::vector<IDevice*>& devices, bool /*s
     initializers_[ProfilerInitializer::key]->post_teardown();
     initializers_[CommandQueueInitializer::key]->post_teardown();
 
-    init_done_.clear();
-    initializers_.clear();
-
     bool pass = true;
     for (const auto& dev_id : devices_to_close) {
         auto* dev = this->get_active_device(dev_id);
@@ -655,9 +693,9 @@ DeviceManager::~DeviceManager() {
         }
     }
     this->devices_.clear();
-    TT_ASSERT(init_done_.empty(), "Init done set is not empty. Devices not properly teared down.");
     init_done_.clear();
     initializers_.clear();
+    descriptor_.reset();
 }
 }  // namespace tt_metal
 }  // namespace tt

--- a/tt_metal/impl/device/device_manager.cpp
+++ b/tt_metal/impl/device/device_manager.cpp
@@ -480,12 +480,8 @@ void DeviceManager::initialize_fabric_and_dispatch_fw() {
 }
 
 void DeviceManager::reset_dispatch_topology() {
-    auto dispatch_kernel_initializer =
-        std::make_unique<DispatchKernelInitializer>(descriptor_, MetalContext::instance().get_dispatch_core_manager());
-    const auto& active_devices = this->get_all_active_devices_impl();
-    dispatch_kernel_initializer->populate_fd_kernels_only(active_devices);
-    initializers_[DispatchKernelInitializer::key] = std::move(dispatch_kernel_initializer);
-    init_done_.erase(DispatchKernelInitializer::key);
+    initializers_.erase(DispatchKernelInitializer::key);
+    init_done_.insert(DispatchKernelInitializer::key);
 }
 
 void DeviceManager::initialize_dispatch_firmware(bool force_recreate_topology) {

--- a/tt_metal/impl/device/device_manager.hpp
+++ b/tt_metal/impl/device/device_manager.hpp
@@ -24,6 +24,7 @@ class IDevice;
 class FirmwareInitializer;
 enum class InitializerKey;
 
+// Initializes and Teardowns device firmware
 class DeviceManager {
 public:
     ~DeviceManager();
@@ -49,8 +50,14 @@ public:
     // Called by the mesh device
     void initialize_profiler();
     void initialize_fabric_and_dispatch_fw();
+    // Initialize dispatch firmware (compile + configure device CQs). This may be used by dispatchcontext to
+    // re-enable fast dispatch after it was disabled at runtime.
+    void initialize_dispatch_firmware(bool force_recreate_topology);
+    void reset_dispatch_topology();
     // API needed due to Issue #19729
     std::size_t get_max_num_eth_cores_across_all_devices() const;
+    const std::unordered_set<CoreCoord>& get_virtual_dispatch_cores(ChipId dev_id) const;
+    const std::unordered_set<CoreCoord>& get_virtual_dispatch_routing_cores(ChipId dev_id) const;
 
 private:
     uint8_t num_hw_cqs_{};
@@ -84,9 +91,6 @@ private:
     void add_devices_to_pool(const std::vector<ChipId>& device_ids);
     Device* get_device(ChipId id) const;
     std::vector<Device*> get_all_active_devices_impl() const;
-
-    // Initialize dispatch firmware (compile + configure device CQs).
-    void initialize_dispatch_firmware();
 
     friend class experimental::DispatchContext;
 };

--- a/tt_metal/impl/device/device_manager.hpp
+++ b/tt_metal/impl/device/device_manager.hpp
@@ -74,6 +74,7 @@ private:
     std::vector<std::unique_ptr<Device>> devices_;
 
     bool skip_remote_devices_{};
+    const std::unordered_set<CoreCoord> empty_container_;
 
     std::shared_ptr<ContextDescriptor> descriptor_;
     std::map<InitializerKey, std::unique_ptr<FirmwareInitializer>> initializers_;

--- a/tt_metal/impl/device/firmware/dispatch_kernel_initializer.cpp
+++ b/tt_metal/impl/device/firmware/dispatch_kernel_initializer.cpp
@@ -9,7 +9,6 @@
 #include <llrt/tt_cluster.hpp>
 #include <tt_metal.hpp>
 #include "common/executor.hpp"
-#include "device/firmware/fabric_firmware_initializer.hpp"
 #include "device/firmware/firmware_initializer.hpp"
 #include "impl/context/context_descriptor.hpp"
 #include "impl/dispatch/dispatch_mem_map.hpp"
@@ -61,8 +60,7 @@ void DispatchKernelInitializer::init(
 
     // Dispatch requires Fabric, Profiler, and Command Queue
     TT_ASSERT(
-        init_done.contains(FabricFirmwareInitializer::key),
-        "Fabric firmware must be initialized before dispatch firmware");
+        init_done.contains(InitializerKey::Fabric), "Fabric firmware must be initialized before dispatch firmware");
     TT_ASSERT(
         init_done.contains(InitializerKey::Profiler), "Profiler firmware must be initialized before dispatch firmware");
     TT_ASSERT(
@@ -166,7 +164,7 @@ void DispatchKernelInitializer::init_device_command_queues() {
         events.emplace_back(detail::async([this, dev, mmio_device_id]() {
             auto tunnels_from_mmio = cluster_.get_tunnels_from_mmio_device(mmio_device_id);
             dev->init_command_queue_device_with_topology(dispatch_topology_.get());
-            log_trace(tt::LogMetal, "Command Queue initialized on Device {}", dev->id());
+            log_debug(tt::LogMetal, "Command Queue initialized on Device {}", dev->id());
             for (const auto& tunnel : tunnels_from_mmio) {
                 for (uint32_t ts = tunnel.size() - 1; ts > 0; ts--) {
                     uint32_t mmio_controlled_device_id = tunnel[ts];
@@ -175,7 +173,7 @@ void DispatchKernelInitializer::init_device_command_queues() {
                     });
                     if (it != devices_.end()) {
                         (*it)->init_command_queue_device_with_topology(dispatch_topology_.get());
-                        log_trace(tt::LogMetal, "Command Queue initialized on Device {}", (*it)->id());
+                        log_debug(tt::LogMetal, "Command Queue initialized on Device {}", (*it)->id());
                     }
                 }
             }
@@ -192,7 +190,6 @@ void DispatchKernelInitializer::terminate_command_queues() {
         TT_ASSERT(device != nullptr, "Expected concrete Device but got different IDevice subclass");
         for (int cq_id = 0; cq_id < device->num_hw_cqs(); cq_id++) {
             auto& cq = device->command_queue(cq_id);
-            log_info(tt::LogMetal, "Terminating command queue {} on device {}", cq_id, dev->id());
             cq.terminate();
         }
     }
@@ -214,14 +211,6 @@ void DispatchKernelInitializer::wait_for_dispatch_cores() const {
         }
 
         auto dispatch_cores = get_virtual_dispatch_cores(dev->id());
-        log_info(
-            tt::LogMetal,
-            "Waiting for dispatch cores to finish on device {}. {} dispatch cores",
-            dev->id(),
-            dispatch_cores.size());
-        for (const auto& core : dispatch_cores) {
-            log_info(tt::LogMetal, "Dispatch core: {}", core.str());
-        }
         // Wrap in try-catch so that device close continues even if dispatch cores fail or timeout.
         // This allows the device handles to be properly released, enabling subsequent
         // device opens and tt-smi resets to succeed.

--- a/tt_metal/impl/device/firmware/dispatch_kernel_initializer.cpp
+++ b/tt_metal/impl/device/firmware/dispatch_kernel_initializer.cpp
@@ -10,7 +10,10 @@
 #include <tt_metal.hpp>
 #include "common/executor.hpp"
 #include "device/firmware/fabric_firmware_initializer.hpp"
+#include "device/firmware/firmware_initializer.hpp"
 #include "impl/context/context_descriptor.hpp"
+#include "impl/dispatch/dispatch_mem_map.hpp"
+#include "impl/dispatch/dispatch_core_manager.hpp"
 #include "device/device_impl.hpp"
 
 #include "dispatch/topology.hpp"
@@ -24,6 +27,19 @@ void wait_until_cores_done(
 
 namespace tt::tt_metal {
 
+DispatchKernelInitializer::DispatchKernelInitializer(
+    std::shared_ptr<const ContextDescriptor> descriptor, dispatch_core_manager& dispatch_core_manager) :
+    FirmwareInitializer(std::move(descriptor)), dispatch_core_manager_(dispatch_core_manager) {
+    dispatch_topology_ = std::make_unique<tt::tt_metal::DispatchTopology>(*descriptor_, dispatch_core_manager_);
+}
+
+void DispatchKernelInitializer::populate_fd_kernels_only(const std::vector<Device*>& devices) {
+    if (!using_fast_dispatch() || devices.empty()) {
+        return;
+    }
+    dispatch_topology_->populate_fd_kernels(devices, descriptor_->num_cqs());
+}
+
 void DispatchKernelInitializer::init(
     const std::vector<Device*>& devices, [[maybe_unused]] const std::unordered_set<InitializerKey>& init_done) {
     if (!using_fast_dispatch()) {
@@ -32,22 +48,27 @@ void DispatchKernelInitializer::init(
 
     devices_ = devices;
 
+    dispatch_mem_map_[enchantum::to_underlying(CoreType::WORKER)] =
+        std::make_unique<tt::tt_metal::DispatchMemMap>(CoreType::WORKER, descriptor_->num_cqs());
+    dispatch_mem_map_[enchantum::to_underlying(CoreType::ETH)] =
+        std::make_unique<tt::tt_metal::DispatchMemMap>(CoreType::ETH, descriptor_->num_cqs());
+
     // Skip firmware initialization for mock devices
     if (descriptor_->is_mock_device()) {
         log_info(tt::LogMetal, "Skipping dispatch firmware initialization for mock devices");
         return;
     }
 
+    // Dispatch requires Fabric, Profiler, and Command Queue
     TT_ASSERT(
         init_done.contains(FabricFirmwareInitializer::key),
         "Fabric firmware must be initialized before dispatch firmware");
-
-    // Compile dispatch kernels if using fast dispatch.
-    // Note: Host-side init (profiler buffer clear, CQ host init) is a prerequisite
-    // that must be performed by the caller before this point.
-    if (using_fast_dispatch()) {
-        compile_dispatch_kernels();
-    }
+    TT_ASSERT(
+        init_done.contains(InitializerKey::Profiler), "Profiler firmware must be initialized before dispatch firmware");
+    TT_ASSERT(
+        init_done.contains(InitializerKey::CommandQueue),
+        "Host-side command queue firmware must be initialized before dispatch firmware");
+    compile_dispatch_kernels();
 }
 
 void DispatchKernelInitializer::configure() {
@@ -81,8 +102,6 @@ void DispatchKernelInitializer::teardown() {
 bool DispatchKernelInitializer::is_initialized() const { return initialized_; }
 
 void DispatchKernelInitializer::compile_dispatch_kernels() {
-    // Compile dispatch firmware: populate static args, create CQ programs, compile.
-
     if (descriptor_->is_mock_device()) {
         return;
     }
@@ -94,14 +113,14 @@ void DispatchKernelInitializer::compile_dispatch_kernels() {
         }
 
         auto tunnels_from_mmio = cluster_.get_tunnels_from_mmio_device(dev->id());
-        populate_cq_static_args(dev);
+        dispatch_topology_->populate_cq_static_args(dev);
         for (const auto& tunnel : tunnels_from_mmio) {
             for (uint32_t ts = tunnel.size() - 1; ts > 0; ts--) {
                 uint32_t mmio_controlled_device_id = tunnel[ts];
                 auto it = std::find_if(
                     devices_.begin(), devices_.end(), [&](IDevice* d) { return d->id() == mmio_controlled_device_id; });
                 if (it != devices_.end()) {
-                    populate_cq_static_args(*it);
+                    dispatch_topology_->populate_cq_static_args(*it);
                 }
             }
         }
@@ -113,7 +132,7 @@ void DispatchKernelInitializer::compile_dispatch_kernels() {
             continue;
         }
 
-        create_cq_program(dev);
+        dispatch_topology_->create_cq_program(dev);
         auto tunnels_from_mmio = cluster_.get_tunnels_from_mmio_device(dev->id());
         for (const auto& tunnel : tunnels_from_mmio) {
             for (uint32_t ts = tunnel.size() - 1; ts > 0; ts--) {
@@ -121,14 +140,14 @@ void DispatchKernelInitializer::compile_dispatch_kernels() {
                 auto it = std::find_if(
                     devices_.begin(), devices_.end(), [&](IDevice* d) { return d->id() == mmio_controlled_device_id; });
                 if (it != devices_.end()) {
-                    create_cq_program(*it);
+                    dispatch_topology_->create_cq_program(*it);
                 }
             }
         }
     }
 
     // Compile all programs
-    compile_cq_programs();
+    dispatch_topology_->compile_cq_programs();
 }
 
 void DispatchKernelInitializer::init_device_command_queues() {
@@ -146,8 +165,8 @@ void DispatchKernelInitializer::init_device_command_queues() {
         ChipId mmio_device_id = dev->id();
         events.emplace_back(detail::async([this, dev, mmio_device_id]() {
             auto tunnels_from_mmio = cluster_.get_tunnels_from_mmio_device(mmio_device_id);
-            dev->init_command_queue_device();
-            log_debug(tt::LogMetal, "Command Queue initialized on Device {}", dev->id());
+            dev->init_command_queue_device_with_topology(dispatch_topology_.get());
+            log_trace(tt::LogMetal, "Command Queue initialized on Device {}", dev->id());
             for (const auto& tunnel : tunnels_from_mmio) {
                 for (uint32_t ts = tunnel.size() - 1; ts > 0; ts--) {
                     uint32_t mmio_controlled_device_id = tunnel[ts];
@@ -155,8 +174,8 @@ void DispatchKernelInitializer::init_device_command_queues() {
                         return d->id() == mmio_controlled_device_id;
                     });
                     if (it != devices_.end()) {
-                        (*it)->init_command_queue_device();
-                        log_info(tt::LogMetal, "Command Queue initialized on Device {}", (*it)->id());
+                        (*it)->init_command_queue_device_with_topology(dispatch_topology_.get());
+                        log_trace(tt::LogMetal, "Command Queue initialized on Device {}", (*it)->id());
                     }
                 }
             }
@@ -173,9 +192,19 @@ void DispatchKernelInitializer::terminate_command_queues() {
         TT_ASSERT(device != nullptr, "Expected concrete Device but got different IDevice subclass");
         for (int cq_id = 0; cq_id < device->num_hw_cqs(); cq_id++) {
             auto& cq = device->command_queue(cq_id);
+            log_info(tt::LogMetal, "Terminating command queue {} on device {}", cq_id, dev->id());
             cq.terminate();
         }
     }
+}
+
+const std::unordered_set<CoreCoord>& DispatchKernelInitializer::get_virtual_dispatch_cores(ChipId dev_id) const {
+    return dispatch_topology_->get_virtual_dispatch_cores(dev_id);
+}
+
+const std::unordered_set<CoreCoord>& DispatchKernelInitializer::get_virtual_dispatch_routing_cores(
+    ChipId dev_id) const {
+    return dispatch_topology_->get_virtual_dispatch_routing_cores(dev_id);
 }
 
 void DispatchKernelInitializer::wait_for_dispatch_cores() const {
@@ -185,6 +214,14 @@ void DispatchKernelInitializer::wait_for_dispatch_cores() const {
         }
 
         auto dispatch_cores = get_virtual_dispatch_cores(dev->id());
+        log_info(
+            tt::LogMetal,
+            "Waiting for dispatch cores to finish on device {}. {} dispatch cores",
+            dev->id(),
+            dispatch_cores.size());
+        for (const auto& core : dispatch_cores) {
+            log_info(tt::LogMetal, "Dispatch core: {}", core.str());
+        }
         // Wrap in try-catch so that device close continues even if dispatch cores fail or timeout.
         // This allows the device handles to be properly released, enabling subsequent
         // device opens and tt-smi resets to succeed.
@@ -203,7 +240,7 @@ void DispatchKernelInitializer::wait_for_dispatch_cores() const {
 
 void DispatchKernelInitializer::process_termination_signals() const {
     for (auto* dev : devices_) {
-        const auto& info = get_registered_termination_cores(dev->id());
+        const auto& info = dispatch_topology_->get_registered_termination_cores(dev->id());
         for (const auto& core_to_terminate : info) {
             std::vector<uint32_t> val{core_to_terminate.val};
             detail::WriteToDeviceL1(

--- a/tt_metal/impl/device/firmware/dispatch_kernel_initializer.hpp
+++ b/tt_metal/impl/device/firmware/dispatch_kernel_initializer.hpp
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include "dispatch/dispatch_mem_map.hpp"
+#include "dispatch/topology.hpp"
 #include "firmware_initializer.hpp"
 
 namespace tt::tt_metal {
@@ -12,13 +14,19 @@ class DispatchKernelInitializer final : public FirmwareInitializer {
 public:
     static constexpr InitializerKey key = InitializerKey::Dispatch;
 
-    using FirmwareInitializer::FirmwareInitializer;
+    DispatchKernelInitializer(
+        std::shared_ptr<const ContextDescriptor> descriptor, dispatch_core_manager& dispatch_core_manager);
 
     void init(const std::vector<Device*>& devices, const std::unordered_set<InitializerKey>& init_done) override;
     void configure() override;
     void teardown() override;
     // Returns true if fast dispatch is enabled and has been configured
     bool is_initialized() const override;
+    const std::unordered_set<CoreCoord>& get_virtual_dispatch_cores(ChipId dev_id) const;
+    const std::unordered_set<CoreCoord>& get_virtual_dispatch_routing_cores(ChipId dev_id) const;
+
+    // Populate the FD kernels only. This will cause dispatch cores to be allocated in dispatch_core_manager
+    void populate_fd_kernels_only(const std::vector<Device*>& devices);
 
 private:
     void compile_dispatch_kernels();
@@ -35,6 +43,9 @@ private:
 
     std::vector<Device*> devices_;
     bool initialized_ = false;
+    std::unique_ptr<tt::tt_metal::DispatchTopology> dispatch_topology_;
+    std::array<std::unique_ptr<DispatchMemMap>, static_cast<size_t>(CoreType::COUNT)> dispatch_mem_map_;
+    dispatch_core_manager& dispatch_core_manager_;
 };
 
 }  // namespace tt::tt_metal

--- a/tt_metal/impl/dispatch/topology.cpp
+++ b/tt_metal/impl/dispatch/topology.cpp
@@ -4,6 +4,7 @@
 
 #include "topology.hpp"
 
+#include "context/metal_context.hpp"
 #include "device/device_manager.hpp"
 #include <host_api.hpp>
 #include <enchantum/enchantum.hpp>
@@ -22,7 +23,6 @@
 #include "core_coord.hpp"
 #include "data_types.hpp"
 #include "device.hpp"
-#include "context/metal_context.hpp"
 #include "dispatch_core_common.hpp"
 #include "kernel_config/fd_kernel.hpp"
 #include "program/program_impl.hpp"
@@ -392,19 +392,23 @@ static const std::vector<DispatchKernelNode> galaxy_nine_chip_arch_2cq_fabric = 
 };
 // clang-format on
 
-// TODO: Move into MetalContext or DeviceManager.
-std::vector<FDKernel*> node_id_to_kernel;
-detail::ProgramCompileGroup command_queue_compile_group;
-std::unordered_map<ChipId, std::unordered_set<CoreCoord>> dispatch_cores;
-std::unordered_map<ChipId, std::unordered_set<CoreCoord>> routing_cores;
-std::unordered_map<ChipId, std::unordered_set<CoreCoord>> empty_cores;
-std::unordered_map<ChipId, std::unordered_set<TerminationInfo>> termination_info;
+DispatchTopology::DispatchTopology(const ContextDescriptor& descriptor, dispatch_core_manager& dispatch_core_manager) :
+    descriptor_(descriptor), dispatch_core_manager_(dispatch_core_manager) {
+    command_queue_compile_group_ = std::make_unique<detail::ProgramCompileGroup>();
+    dispatch_mem_map_[enchantum::to_underlying(CoreType::WORKER)] =
+        std::make_unique<DispatchMemMap>(CoreType::WORKER, descriptor_.num_cqs());
+    dispatch_mem_map_[enchantum::to_underlying(CoreType::ETH)] =
+        std::make_unique<DispatchMemMap>(CoreType::ETH, descriptor_.num_cqs());
+}
 
-// Helper function to automatically generate dispatch nodes given devices + num hw CQs + detection of card type.
-std::vector<DispatchKernelNode> generate_nodes(const std::set<ChipId>& device_ids, uint32_t num_hw_cqs) {
+DispatchTopology::~DispatchTopology() { reset(); }
+
+// Helper to automatically generate dispatch nodes given devices + num hw CQs + detection of card type.
+std::vector<DispatchKernelNode> DispatchTopology::generate_nodes(
+    const std::set<ChipId>& device_ids, uint32_t num_hw_cqs) const {
     // Select/generate the right input table, depends on (1) board [detected from total # of devices], and (2) number
     // of active devices. TODO: read this out of YAML instead of the structs above?
-    uint32_t total_devices = MetalContext::instance().get_cluster().number_of_devices();
+    uint32_t total_devices = descriptor_.cluster().number_of_devices();
     TT_ASSERT(
         total_devices == 1 or total_devices == 2 or total_devices == 4 or total_devices == 8 or total_devices == 32 or
             total_devices == 36,
@@ -417,7 +421,7 @@ std::vector<DispatchKernelNode> generate_nodes(const std::set<ChipId>& device_id
     std::set<ChipId> mmio_devices;
     std::set<ChipId> remote_devices;
     for (auto id : device_ids) {
-        if (MetalContext::instance().get_cluster().get_associated_mmio_device(id) == id) {
+        if (descriptor_.cluster().get_associated_mmio_device(id) == id) {
             mmio_devices.insert(id);
         } else {
             remote_devices.insert(id);
@@ -430,7 +434,7 @@ std::vector<DispatchKernelNode> generate_nodes(const std::set<ChipId>& device_id
             return single_chip_arch_1cq;
         }  // TODO: determine whether dispatch_s is inserted at this level, instead of inside
            // Device::dispatch_s_enabled().
-        if (MetalContext::instance().get_dispatch_core_manager().get_dispatch_core_type() == CoreType::WORKER) {
+        if (this->dispatch_core_manager_.get_dispatch_core_type() == CoreType::WORKER) {
             return single_chip_arch_2cq_dispatch_s;
         }
         return single_chip_arch_2cq;
@@ -452,7 +456,7 @@ std::vector<DispatchKernelNode> generate_nodes(const std::set<ChipId>& device_id
     } else {
         // Need to handle N300/T3000 separately from TG/TGG since they have different templates/tunnel depths
         // If using fabric, upstream would have already initalized to the proper config for dispatch
-        if (MetalContext::instance().get_cluster().is_galaxy_cluster()) {
+        if (descriptor_.cluster().is_galaxy_cluster()) {
             // For Galaxy, we always init all remote devices associated with an mmio device.
             std::vector<DispatchKernelNode> nodes_for_one_mmio =
                 (num_hw_cqs == 1) ? galaxy_nine_chip_arch_1cq_fabric : galaxy_nine_chip_arch_2cq_fabric;
@@ -461,8 +465,7 @@ std::vector<DispatchKernelNode> generate_nodes(const std::set<ChipId>& device_id
                 // Need a mapping from templated device id (1-8) to actual device id (from the tunnel)
                 std::vector<ChipId> template_id_to_device_id;
                 template_id_to_device_id.push_back(mmio_device_id);
-                for (const auto& tunnel :
-                     MetalContext::instance().get_cluster().get_tunnels_from_mmio_device(mmio_device_id)) {
+                for (const auto& tunnel : descriptor_.cluster().get_tunnels_from_mmio_device(mmio_device_id)) {
                     TT_ASSERT(tunnel.size() == 5, "Galaxy expected 4-deep tunnels.");
                     for (auto remote_device_id : tunnel) {
                         if (remote_device_id != mmio_device_id) {
@@ -505,7 +508,7 @@ std::vector<DispatchKernelNode> generate_nodes(const std::set<ChipId>& device_id
                 ChipId remote_device_id{};
                 bool found_remote = false;
                 for (auto id : remote_devices) {
-                    if (MetalContext::instance().get_cluster().get_associated_mmio_device(id) == mmio_device_id) {
+                    if (descriptor_.cluster().get_associated_mmio_device(id) == mmio_device_id) {
                         remote_device_id = id;
                         found_remote = true;
                         break;
@@ -545,10 +548,7 @@ std::vector<DispatchKernelNode> generate_nodes(const std::set<ChipId>& device_id
     return nodes;
 }
 
-// Populate node_id_to_kernel and set up kernel objects. Do this once at the beginning since they (1) don't need a valid
-// Device until fields are populated, (2) need to be connected to kernel objects for devices that aren't created yet,
-// and (3) the table to choose depends on total number of devices, not know at Device creation.
-void populate_fd_kernels(const std::vector<IDevice*>& devices, uint32_t num_hw_cqs) {
+void DispatchTopology::populate_fd_kernels(const std::vector<Device*>& devices, uint32_t num_hw_cqs) {
     std::set<ChipId> device_ids;
     for (const auto& device : devices) {
         device_ids.insert(device->id());
@@ -556,27 +556,27 @@ void populate_fd_kernels(const std::vector<IDevice*>& devices, uint32_t num_hw_c
     populate_fd_kernels(generate_nodes(device_ids, num_hw_cqs));
 }
 
-void populate_fd_kernels(const std::set<ChipId>& device_ids, uint32_t num_hw_cqs) {
+void DispatchTopology::populate_fd_kernels(const std::set<ChipId>& device_ids, uint32_t num_hw_cqs) {
     populate_fd_kernels(generate_nodes(device_ids, num_hw_cqs));
 }
 
-void populate_fd_kernels(const std::vector<DispatchKernelNode>& nodes) {
+void DispatchTopology::populate_fd_kernels(const std::vector<DispatchKernelNode>& nodes) {
     // If we already had nodes from a previous run, clear them (since we could have a different # of devices or CQs).
-    if (!node_id_to_kernel.empty()) {
-        for (auto& kernel : node_id_to_kernel) {
+    if (!node_id_to_kernel_.empty()) {
+        for (auto& kernel : node_id_to_kernel_) {
             delete kernel;
         }
-        node_id_to_kernel.clear();
-        command_queue_compile_group.clear();
+        node_id_to_kernel_.clear();
+        command_queue_compile_group_->clear();
     }
 
     // Read the input table, create configs for each node + track mmio devices and number of cqs.
     std::unordered_set<ChipId> mmio_device_ids;
     std::unordered_set<uint8_t> hw_cq_ids;
-    node_id_to_kernel.reserve(nodes.size());
+    node_id_to_kernel_.reserve(nodes.size());
     for (const auto& node : nodes) {
-        TT_ASSERT(node_id_to_kernel.size() == node.id);
-        node_id_to_kernel.emplace_back(FDKernel::Generate(
+        TT_ASSERT(node_id_to_kernel_.size() == node.id);
+        node_id_to_kernel_.emplace_back(FDKernel::Generate(
             node.id,
             node.device_id,
             node.servicing_device_id,
@@ -584,7 +584,7 @@ void populate_fd_kernels(const std::vector<DispatchKernelNode>& nodes) {
             node.noc_selection,
             node.kernel_type,
             node.tunnel_index));
-        if (MetalContext::instance().get_cluster().get_associated_mmio_device(node.device_id) == node.device_id) {
+        if (descriptor_.cluster().get_associated_mmio_device(node.device_id) == node.device_id) {
             mmio_device_ids.insert(node.device_id);
         }
         hw_cq_ids.insert(node.cq_id);
@@ -596,21 +596,21 @@ void populate_fd_kernels(const std::vector<DispatchKernelNode>& nodes) {
         for (int idx = 0; idx < node.upstream_ids.size(); idx++) {
             if (node.upstream_ids[idx] >= 0) {
                 TT_ASSERT(
-                    node.upstream_ids[idx] < node_id_to_kernel.size(),
+                    node.upstream_ids[idx] < node_id_to_kernel_.size(),
                     "Upstream kernel id {} out of bounds (max = {})",
                     node.upstream_ids[idx],
-                    node_id_to_kernel.size());
-                node_id_to_kernel.at(node.id)->AddUpstreamKernel(node_id_to_kernel.at(node.upstream_ids[idx]));
+                    node_id_to_kernel_.size());
+                node_id_to_kernel_.at(node.id)->AddUpstreamKernel(node_id_to_kernel_.at(node.upstream_ids[idx]));
             }
         }
         for (int idx = 0; idx < node.downstream_ids.size(); idx++) {
             if (node.downstream_ids[idx] >= 0) {
                 TT_ASSERT(
-                    node.downstream_ids[idx] < node_id_to_kernel.size(),
+                    node.downstream_ids[idx] < node_id_to_kernel_.size(),
                     "Downstream kernel id {} out of bounds (max = {})",
                     node.downstream_ids[idx],
-                    node_id_to_kernel.size());
-                node_id_to_kernel.at(node.id)->AddDownstreamKernel(node_id_to_kernel.at(node.downstream_ids[idx]));
+                    node_id_to_kernel_.size());
+                node_id_to_kernel_.at(node.id)->AddDownstreamKernel(node_id_to_kernel_.at(node.downstream_ids[idx]));
             }
         }
     }
@@ -619,7 +619,7 @@ void populate_fd_kernels(const std::vector<DispatchKernelNode>& nodes) {
     std::map<ChipId, uint32_t> device_id_to_tunnel_stop;
     std::map<ChipId, std::vector<ChipId>> mmio_device_id_to_serviced_devices;
     for (auto mmio_device_id : mmio_device_ids) {
-        if (MetalContext::instance().get_cluster().get_associated_mmio_device(mmio_device_id) != mmio_device_id) {
+        if (descriptor_.cluster().get_associated_mmio_device(mmio_device_id) != mmio_device_id) {
             continue;
         }
 
@@ -628,7 +628,7 @@ void populate_fd_kernels(const std::vector<DispatchKernelNode>& nodes) {
             mmio_device_id_to_serviced_devices[mmio_device_id].push_back(mmio_device_id);
         }
         std::vector<ChipId> remote_devices;
-        for (auto tunnel : MetalContext::instance().get_cluster().get_tunnels_from_mmio_device(mmio_device_id)) {
+        for (auto tunnel : descriptor_.cluster().get_tunnels_from_mmio_device(mmio_device_id)) {
             for (uint32_t tunnel_stop = 0; tunnel_stop < tunnel.size(); tunnel_stop++) {
                 ChipId remote_device_id = tunnel[tunnel_stop];
                 device_id_to_tunnel_stop[remote_device_id] = tunnel_stop;
@@ -645,13 +645,13 @@ void populate_fd_kernels(const std::vector<DispatchKernelNode>& nodes) {
     }
 }
 
-void populate_cq_static_args(IDevice* device) {
+void DispatchTopology::populate_cq_static_args(Device* device) {
     TT_ASSERT(
-        !node_id_to_kernel.empty(),
+        !node_id_to_kernel_.empty(),
         "Tried to populate static args on nodes without the nodes populated (need to run populate_fd_kernels()");
     // First pass, add device/program to all kernels for this device and generate static configs.
     auto cq_program_ptr = std::make_unique<Program>();
-    for (auto* node_and_kernel : node_id_to_kernel) {
+    for (auto* node_and_kernel : node_id_to_kernel_) {
         // GetDeviceId() uses Id from topology as IDevice* is not present yet
         if (node_and_kernel->GetDeviceId() == device->id()) {
             node_and_kernel->AddDevice(device);
@@ -663,18 +663,17 @@ void populate_cq_static_args(IDevice* device) {
     }
 
     // Move program into the storage for later steps
-    command_queue_compile_group.add_program(device, std::move(cq_program_ptr));
+    command_queue_compile_group_->add_program(device, std::move(cq_program_ptr));
 }
 
-void create_cq_program(IDevice* device) {
+void DispatchTopology::create_cq_program(Device* device) {
     TT_FATAL(
-        command_queue_compile_group.contains(device),
+        command_queue_compile_group_->contains(device),
         "Tried to create and compile CQ program on device {} without static args populated (need to run "
         "populate_cq_static_args())",
         device->id());
-    empty_cores.clear();
     // Third pass, populate dependent configs, runtime configs, and create kernels for each node
-    for (auto* node_and_kernel : node_id_to_kernel) {
+    for (auto* node_and_kernel : node_id_to_kernel_) {
         if (node_and_kernel->GetDeviceId() == device->id()) {
             node_and_kernel->GenerateDependentConfigs();
             node_and_kernel->InitializeRuntimeArgsValues();
@@ -684,14 +683,14 @@ void create_cq_program(IDevice* device) {
     }
 
     // Register core coordinates for this device
-    for (auto* node_and_kernel : node_id_to_kernel) {
+    for (auto* node_and_kernel : node_id_to_kernel_) {
         if (node_and_kernel->GetDeviceId() != device->id()) {
             continue;
         }
 
         switch (node_and_kernel->GetKernelType()) {
-            case FDKernelType::DISPATCH: dispatch_cores[device->id()].insert(node_and_kernel->GetVirtualCore()); break;
-            case FDKernelType::ROUTING: routing_cores[device->id()].insert(node_and_kernel->GetVirtualCore()); break;
+            case FDKernelType::DISPATCH: dispatch_cores_[device->id()].insert(node_and_kernel->GetVirtualCore()); break;
+            case FDKernelType::ROUTING: routing_cores_[device->id()].insert(node_and_kernel->GetVirtualCore()); break;
             case FDKernelType::VIRTUAL:
                 // Not a real kernel
                 break;
@@ -706,48 +705,45 @@ void create_cq_program(IDevice* device) {
     }
 
     // Register termination info
-    for (auto* node_and_kernel : node_id_to_kernel) {
+    for (auto* node_and_kernel : node_id_to_kernel_) {
         if (node_and_kernel->GetDeviceId() != device->id()) {
             continue;
         }
 
         const auto& info = node_and_kernel->GetTerminationInfo();
         if (info.has_value()) {
-            termination_info[device->id()].insert(info.value());
+            termination_info_[device->id()].insert(info.value());
         }
     }
 }
 
-void compile_cq_programs() {
-    command_queue_compile_group.compile_all(/*force_slow_dispatch=*/true);
+void DispatchTopology::compile_cq_programs() {
+    command_queue_compile_group_->compile_all(/*force_slow_dispatch=*/true);
 
     // Write runtime args to device
-    command_queue_compile_group.write_runtime_args(/*force_slow_dispatch=*/true);
+    command_queue_compile_group_->write_runtime_args(/*force_slow_dispatch=*/true);
 }
 
-std::unique_ptr<Program> get_compiled_cq_program(IDevice* device) {
-    return command_queue_compile_group.remove_program(device);
+std::unique_ptr<Program> DispatchTopology::get_compiled_cq_program(Device* device) {
+    return command_queue_compile_group_->remove_program(device);
 }
 
-void configure_dispatch_cores(IDevice* device) {
+void DispatchTopology::configure_dispatch_cores(Device* device) {
     // Set up completion_queue_writer core. This doesn't actually have a kernel so keep it out of the struct and config
     // it here. TODO: should this be in the struct?
-    CoreType dispatch_core_type = MetalContext::instance().get_dispatch_core_manager().get_dispatch_core_type();
-    const auto& my_dispatch_constants = MetalContext::instance().dispatch_mem_map();
+    CoreType dispatch_core_type = this->dispatch_core_manager_.get_dispatch_core_type();
+    const auto& my_dispatch_constants = *dispatch_mem_map_[enchantum::to_underlying(dispatch_core_type)];
     uint32_t cq_start = my_dispatch_constants.get_host_command_queue_addr(CommandQueueHostAddrType::UNRESERVED);
     uint32_t cq_size = device->sysmem_manager().get_cq_size();
     std::vector<uint32_t> zero = {0x0};
 
     // Need to set up for all devices serviced by an mmio chip
     if (device->is_mmio_capable()) {
-        for (ChipId serviced_device_id :
-             MetalContext::instance().get_cluster().get_devices_controlled_by_mmio_device(device->id())) {
-            uint16_t channel =
-                MetalContext::instance().get_cluster().get_assigned_channel_for_device(serviced_device_id);
+        for (ChipId serviced_device_id : descriptor_.cluster().get_devices_controlled_by_mmio_device(device->id())) {
+            uint16_t channel = descriptor_.cluster().get_assigned_channel_for_device(serviced_device_id);
             for (uint8_t cq_id = 0; cq_id < device->num_hw_cqs(); cq_id++) {
                 tt_cxy_pair completion_q_writer_location =
-                    MetalContext::instance().get_dispatch_core_manager().completion_queue_writer_core(
-                        serviced_device_id, channel, cq_id);
+                    this->dispatch_core_manager_.completion_queue_writer_core(serviced_device_id, channel, cq_id);
                 IDevice* mmio_device =
                     MetalContext::instance().device_manager()->get_active_device(completion_q_writer_location.chip);
                 uint32_t completion_q_wr_ptr =
@@ -784,45 +780,43 @@ void configure_dispatch_cores(IDevice* device) {
         }
     }
     // Configure cores for all nodes corresponding to this device
-    for (auto& kernel : node_id_to_kernel) {
+    for (auto& kernel : node_id_to_kernel_) {
         if (kernel->GetDeviceId() == device->id()) {
             kernel->ConfigureCore();
         }
     }
 }
 
-const std::unordered_set<CoreCoord>& get_virtual_dispatch_cores(ChipId dev_id) {
-    if (!dispatch_cores.contains(dev_id)) {
-        return empty_cores[dev_id];
+const std::unordered_set<CoreCoord>& DispatchTopology::get_virtual_dispatch_cores(ChipId dev_id) const {
+    if (!dispatch_cores_.contains(dev_id)) {
+        return this->empty_container_;
     }
-    return dispatch_cores[dev_id];
+    return dispatch_cores_.at(dev_id);
 }
 
-const std::unordered_set<CoreCoord>& get_virtual_dispatch_routing_cores(ChipId dev_id) {
-    if (!routing_cores.contains(dev_id)) {
-        return empty_cores[dev_id];
+const std::unordered_set<CoreCoord>& DispatchTopology::get_virtual_dispatch_routing_cores(ChipId dev_id) const {
+    if (!routing_cores_.contains(dev_id)) {
+        return this->empty_container_;
     }
-    return routing_cores[dev_id];
+    return routing_cores_.at(dev_id);
 }
 
-const std::unordered_set<TerminationInfo>& get_registered_termination_cores(ChipId dev_id) {
-    if (!termination_info.contains(dev_id)) {
-        termination_info[dev_id] = {};
+const std::unordered_set<TerminationInfo>& DispatchTopology::get_registered_termination_cores(ChipId dev_id) const {
+    if (!termination_info_.contains(dev_id)) {
+        return this->empty_termination_info_container_;
     }
-    return termination_info.at(dev_id);
+    return termination_info_.at(dev_id);
 }
 
-void reset_topology_state() {
-    // TODO: https://github.com/tenstorrent/tt-metal/issues/24439
-    for (auto& kernel : node_id_to_kernel) {
+void DispatchTopology::reset() {
+    for (auto& kernel : node_id_to_kernel_) {
         delete kernel;
     }
-    node_id_to_kernel.clear();
-    command_queue_compile_group.clear();
-    dispatch_cores.clear();
-    routing_cores.clear();
-    empty_cores.clear();
-    termination_info.clear();
+    node_id_to_kernel_.clear();
+    command_queue_compile_group_->clear();
+    dispatch_cores_.clear();
+    routing_cores_.clear();
+    termination_info_.clear();
 }
 
 }  // namespace tt::tt_metal


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/37247

### Problem description
- Static variables in dispatch topology make it difficult to support the possibility of having multiple runtime "contexts"

### What's changed
- Move everything into a DispatchTopology class which is owned by the DispatchKernelInitializer class

https://github.com/tenstorrent/tt-metal/pull/37453 needs to be merged before this PR as that PR includes the ContextDescriptor object

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=nhuang/topology)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:nhuang/topology)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=nhuang/topology)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:nhuang/topology)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nhuang/topology)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nhuang/topology)
- [ ] New/Existing tests provide coverage for changes

Profiler CI
https://github.com/tenstorrent/tt-metal/actions/runs/22162175874

Merge Gate Tests
https://github.com/tenstorrent/tt-metal/actions/runs/22161667471

Multi Host
https://github.com/tenstorrent/tt-metal/actions/runs/22163987260

T3K Fast
https://github.com/tenstorrent/tt-metal/actions/runs/22164366976


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nhuang/topology)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nhuang/topology)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nhuang/topology)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nhuang/topology)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nhuang/topology)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nhuang/topology)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
