### PR TITLE
Fix TTTv2 MLP 1d from model args mismatch + BH Stress test pytest id

### DIFF
--- a/models/common/modules/mlp/mlp_1d.py
+++ b/models/common/modules/mlp/mlp_1d.py
@@ -351,8 +351,10 @@ class MLP1D(LightweightModule):
 
         return w2_out_reduced
 
-    def forward(self, x: ttnn.Tensor | LazyWeight, mode: str) -> ttnn.Tensor:
+    def forward(self, x: ttnn.Tensor | LazyWeight, mode: str | Mode) -> ttnn.Tensor:
         """Dispatch to the appropriate forward method based on mode."""
+        if isinstance(mode, Mode):
+            mode = mode.value
         if mode == "decode":
             return self.decode_forward(x)
         else:

--- a/models/common/modules/mlp/mlp_1d.py
+++ b/models/common/modules/mlp/mlp_1d.py
@@ -434,6 +434,7 @@ class MLP1D(LightweightModule):
         dtype=None,
         model_config=None,
         state_dict_prefix: Optional[str] = None,
+        prefetcher=None,
     ):
         """Factory method for backward compatibility with ModelArgs.
 

--- a/models/common/tests/modules/attention/test_attention_1d.py
+++ b/models/common/tests/modules/attention/test_attention_1d.py
@@ -2027,7 +2027,7 @@ def test_attention_1d_vs_reference_from_model_args(ttnn_mesh_device: ttnn.MeshDe
     from models.tt_transformers.tests.test_utils import get_ref_model_dype
     from models.tt_transformers.tt.ccl import TT_CCL
     from models.tt_transformers.tt.common import precompute_freqs
-    from models.tt_transformers.tt.model_config import ModelArgs
+    from models.tt_transformers.tt.model_config import Mode, ModelArgs
     from models.tt_transformers.tt.rope import RotarySetup, get_rot_mats
 
     # Use HF_MODEL env var if set, otherwise use appropriate default based on device count
@@ -2241,7 +2241,7 @@ def test_attention_1d_vs_reference_from_model_args(ttnn_mesh_device: ttnn.MeshDe
         # Prepare decode input for TT
         attention_input = model_args.prepare_residual_tensor_decode(
             pt_decode_input.clone(),
-            model_args.model_config["SHARDED_ATTN_INPUT_MEMCFG"],
+            model_args.get_attn_input_mem_config(Mode.DECODE),
             force_replicated=True,
         )
 

--- a/models/tt_transformers/demo/simple_text_demo.py
+++ b/models/tt_transformers/demo/simple_text_demo.py
@@ -742,6 +742,7 @@ def prepare_generator_args(
         "device-perf",  # Device perf
     ],
 )
+# NOTE: Please do not add new pytest parameters bewteen optimizations and the demo parameters above, certain tests ids depend on the order of the parameters.
 @pytest.mark.parametrize(
     "optimizations",
     [

--- a/tests/pipeline_reorg/t3k_e2e_tests.yaml
+++ b/tests/pipeline_reorg/t3k_e2e_tests.yaml
@@ -67,10 +67,11 @@
 
 - name: models_tttv2_attention_full_set_unit_tests
   cmd: HF_HUB_OFFLINE=1 HF_HOME=/mnt/MLPerf/huggingface TT_CACHE_PATH=/mnt/MLPerf/huggingface/tt_cache/tttv2/attention_1d pytest --tb=short models/common/tests/modules/attention
-  sku: wh_llmbox
+  skus:
+    wh_llmbox:
+      timeout: 60
   owner_id: U07RY6B5FLJ # Gongyu Wang
   team: models
-  timeout: 60
 
 - name: models_tttv2_llama31_8B_tests
   cmd: MESH_DEVICE=T3K HF_HUB_OFFLINE=1 HF_HOME=/mnt/MLPerf/huggingface HF_MODEL=meta-llama/Llama-3.1-8B-Instruct TT_CACHE_PATH=/mnt/MLPerf/huggingface/tt_cache/meta-llama--Llama-3.1-8B-Instruct pytest --tb=short models/common/demos/llama31_8B_demo.py


### PR DESCRIPTION
### Ticket
NA

### Problem description
prefetcher arg was missing in MLP1d from model args function since prefetcher was added.
BH stress tests were not running because of a pytest id issue

### What's changed
- pass prefetcher back into MLP from model args
- change pytest id to `performance and stress`

### Checklist
- [BH multi card demo tests](https://github.com/tenstorrent/tt-metal/actions/runs/21889158668)
- [T3K e2e demo tests](https://github.com/tenstorrent/tt-metal/actions/runs/21967055384)
