### PR TITLE
Add scatter to sdpa_reduce_to_all OP

### DIFF
--- a/models/demos/deepseek_v3_b1/micro_ops/sdpa_reduce_to_all/kernels/writer.cpp
+++ b/models/demos/deepseek_v3_b1/micro_ops/sdpa_reduce_to_all/kernels/writer.cpp
@@ -46,6 +46,16 @@ static constexpr uint32_t l_chunk_size_bytes = get_compile_time_arg_val(9);
 static constexpr uint32_t num_l_chunks = get_compile_time_arg_val(10);
 static constexpr uint32_t tiles_per_l_chunk = get_compile_time_arg_val(11);
 
+// Scatter phase compile-time arguments (for distributing output rows to dest cores)
+// scatter_num_rows = 0 disables the scatter phase entirely.
+static constexpr uint32_t cb_l_out = get_compile_time_arg_val(12);
+static constexpr uint32_t scatter_num_tiles = get_compile_time_arg_val(13);
+static constexpr uint32_t scatter_src_tile_size = get_compile_time_arg_val(14);
+static constexpr uint32_t scatter_dst_tile_size = get_compile_time_arg_val(15);
+static constexpr uint32_t scatter_face_size = get_compile_time_arg_val(16);
+static constexpr uint32_t scatter_row_face_size = get_compile_time_arg_val(17);
+static constexpr uint32_t scatter_num_rows = get_compile_time_arg_val(18);
+
 static constexpr size_t packet_header_size_bytes = sizeof(PACKET_HEADER_TYPE);
 
 // Slot indices: MS = slot 0, L_chunk_i = slot (1 + i)
@@ -354,4 +364,72 @@ void kernel_main() {
     sender.finish_round();
 
     noc_async_full_barrier();
+
+    // ==========================================================================
+    // SCATTER PHASE: Distribute output rows to destination cores
+    // Each row of the [batch, width] output is reformatted from batch×32 tiles
+    // to 1×32 tiles and written to a unique destination core via NOC.
+    //
+    // Tile format:
+    //   Source (8×32): Face0 [8×16] at offset 0, Face1 [8×16] at scatter_face_size
+    //   Dest   (1×32): Face0 [1×16] at offset 0, Face1 [1×16] at scatter_row_face_size
+    //
+    // For each row j (0..scatter_num_rows-1):
+    //   1. Local reorder: extract row j from each source tile into 1×32 tile format
+    //   2. NOC write the reordered tiles to the destination core
+    // ==========================================================================
+    if constexpr (scatter_num_rows > 0) {
+        // Read scatter runtime args (only present when scatter is enabled)
+        const uint32_t scatter_dest_l1_addr = get_arg_val<uint32_t>(arg_idx++);
+        uint32_t scatter_dest_noc_x[scatter_num_rows];
+        uint32_t scatter_dest_noc_y[scatter_num_rows];
+        for (uint32_t i = 0; i < scatter_num_rows; i++) {
+            scatter_dest_noc_x[i] = get_arg_val<uint32_t>(arg_idx++);
+            scatter_dest_noc_y[i] = get_arg_val<uint32_t>(arg_idx++);
+        }
+
+        // Wait for all compute output tiles
+        cb_wait_front(cb_l_out, scatter_num_tiles);
+        uint32_t src_base = get_read_ptr(cb_l_out);
+
+        // Reuse R1 result L buffer as temp scratch for reordering
+        // (no longer needed after R2 streaming send; size >= scatter_num_tiles * scatter_dst_tile_size)
+        uint32_t temp_base = get_read_ptr(cb_r1_result_l);
+
+        constexpr uint32_t row_face_words = scatter_row_face_size / sizeof(uint32_t);
+        constexpr uint32_t scatter_payload_bytes = scatter_num_tiles * scatter_dst_tile_size;
+
+        for (uint32_t row = 0; row < scatter_num_rows; row++) {
+            // Reorder: extract row from each source tile into dest tile format
+            for (uint32_t t = 0; t < scatter_num_tiles; t++) {
+                uint32_t src_tile = src_base + t * scatter_src_tile_size;
+                uint32_t dst_tile = temp_base + t * scatter_dst_tile_size;
+
+                // Copy Face 0 row: src face0[row] -> dst face0
+                volatile tt_l1_ptr uint32_t* src_f0 =
+                    reinterpret_cast<volatile tt_l1_ptr uint32_t*>(src_tile + row * scatter_row_face_size);
+                volatile tt_l1_ptr uint32_t* dst_f0 = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(dst_tile);
+                for (uint32_t w = 0; w < row_face_words; w++) {
+                    dst_f0[w] = src_f0[w];
+                }
+
+                // Copy Face 1 row: src face1[row] -> dst face1
+                volatile tt_l1_ptr uint32_t* src_f1 = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(
+                    src_tile + scatter_face_size + row * scatter_row_face_size);
+                volatile tt_l1_ptr uint32_t* dst_f1 =
+                    reinterpret_cast<volatile tt_l1_ptr uint32_t*>(dst_tile + scatter_row_face_size);
+                for (uint32_t w = 0; w < row_face_words; w++) {
+                    dst_f1[w] = src_f1[w];
+                }
+            }
+
+            // Write reordered row to destination core
+            uint64_t dest_noc_addr =
+                get_noc_addr(scatter_dest_noc_x[row], scatter_dest_noc_y[row], scatter_dest_l1_addr);
+            noc_async_write(temp_base, dest_noc_addr, scatter_payload_bytes);
+            noc_async_writes_flushed();  // Ensure temp buffer can be reused for next row
+        }
+
+        noc_async_write_barrier();  // Ensure all scatter writes complete
+    }
 }

--- a/models/demos/deepseek_v3_b1/micro_ops/sdpa_reduce_to_all/kernels/writer.cpp
+++ b/models/demos/deepseek_v3_b1/micro_ops/sdpa_reduce_to_all/kernels/writer.cpp
@@ -409,6 +409,7 @@ void kernel_main() {
                 volatile tt_l1_ptr uint32_t* src_f0 =
                     reinterpret_cast<volatile tt_l1_ptr uint32_t*>(src_tile + row * scatter_row_face_size);
                 volatile tt_l1_ptr uint32_t* dst_f0 = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(dst_tile);
+#pragma GCC unroll 8
                 for (uint32_t w = 0; w < row_face_words; w++) {
                     dst_f0[w] = src_f0[w];
                 }
@@ -418,6 +419,7 @@ void kernel_main() {
                     src_tile + scatter_face_size + row * scatter_row_face_size);
                 volatile tt_l1_ptr uint32_t* dst_f1 =
                     reinterpret_cast<volatile tt_l1_ptr uint32_t*>(dst_tile + scatter_row_face_size);
+#pragma GCC unroll 8
                 for (uint32_t w = 0; w < row_face_words; w++) {
                     dst_f1[w] = src_f1[w];
                 }

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_sdpa_reduce_to_all.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_sdpa_reduce_to_all.py
@@ -61,7 +61,8 @@ def compute_forwarder_scratch_size(
     [{"fabric_config": ttnn.FabricConfig.FABRIC_2D}],
     indirect=["device_params"],
 )
-def test_sdpa_reduce_to_all(bh_1d_mesh_device):
+@pytest.mark.parametrize("scatter_enabled", [False, True], ids=["reduce_only", "reduce_and_scatter"])
+def test_sdpa_reduce_to_all(bh_1d_mesh_device, scatter_enabled):
     num_devices = 4
     num_cores = 8
     l_width = 512
@@ -220,10 +221,38 @@ def test_sdpa_reduce_to_all(bh_1d_mesh_device):
         mesh_mapper=mesh_mapper2,
     )
 
+    # ========================================================================
+    # Scatter destination tensor (optional): HEIGHT_SHARDED, 1x32 tiles, 8x8 grid
+    # Each of the 64 cores gets [1, 512] after scatter
+    # ========================================================================
+    scatter_dest_mesh = None
+    scatter_grid = None
+    num_scatter_cores = num_cores * batch_size  # 8 * 8 = 64
+
+    if scatter_enabled:
+        scatter_tile = ttnn.Tile((1, 32))
+        scatter_grid = ttnn.CoreRangeSet(
+            {ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(num_cores - 1, batch_size - 1))}
+        )
+        scatter_shard_shape = [1, l_width]  # [1, 512] per core
+        scatter_shard_spec = ttnn.ShardSpec(scatter_grid, scatter_shard_shape, ttnn.ShardOrientation.ROW_MAJOR)
+        scatter_mem_config = ttnn.MemoryConfig(
+            ttnn.types.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.types.BufferType.L1, scatter_shard_spec
+        )
+        scatter_dest_mesh = ttnn.from_torch(
+            torch.zeros([num_scatter_cores, l_width], dtype=torch.bfloat16),
+            device=submesh_device,
+            layout=layout,
+            tile=scatter_tile,
+            dtype=dtype,
+            memory_config=scatter_mem_config,
+            mesh_mapper=mesh_mapper2,
+        )
+
     semaphores = [ttnn.create_global_semaphore(submesh_device, shard_grid, 0) for _ in range(2)]
     ttnn.synchronize_device(submesh_device)
 
-    logger.info("Running SDPA reduce-to-all (single run)...")
+    logger.info(f"Running SDPA reduce-to-all (scatter={'enabled' if scatter_enabled else 'disabled'})...")
     output_mesh = SdpaReduceToAll.op(
         input_l_mesh,
         input_ms_mesh,
@@ -235,9 +264,14 @@ def test_sdpa_reduce_to_all(bh_1d_mesh_device):
         scale_fp32=scale_value,
         cluster_axis=0,
         input_forwarder_cores=forwarder_cores,
+        scatter_dest_tensor_mesh=scatter_dest_mesh,
+        scatter_dest_grid=scatter_grid,
     )
     ttnn.synchronize_device(submesh_device)
 
+    # ========================================================================
+    # Verify L output (original reduce-to-all correctness check)
+    # ========================================================================
     output_l_torch = ttnn.to_torch(output_mesh, mesh_composer=ttnn.ConcatMeshToTensor(submesh_device, dim=0))
     out_l_root = output_l_torch[0]
 
@@ -246,3 +280,28 @@ def test_sdpa_reduce_to_all(bh_1d_mesh_device):
 
     logger.info(f"L tensor match: {match}, max_diff: {max_diff:.4f}")
     assert match, f"L tensor mismatch! Max diff: {max_diff}"
+
+    # ========================================================================
+    # Verify scatter output (only when scatter is enabled)
+    # Each core (x=i, y=j) should have ref_l[j, i*l_width:(i+1)*l_width]
+    # In HEIGHT_SHARDED ROW_MAJOR order: tensor row (j * num_cores + i) = core (x=i, y=j)
+    # ========================================================================
+    if scatter_enabled:
+        scatter_out_torch = ttnn.to_torch(
+            scatter_dest_mesh, mesh_composer=ttnn.ConcatMeshToTensor(submesh_device, dim=0)
+        )
+        scatter_out_root = scatter_out_torch[:num_scatter_cores, :]  # First device
+
+        scatter_max_diff = 0.0
+        for j in range(batch_size):
+            for i in range(num_cores):
+                row_idx = j * num_cores + i
+                expected = ref_l[j, i * l_width : (i + 1) * l_width].float()
+                actual = scatter_out_root[row_idx, :].float()
+                diff = torch.max(torch.abs(actual - expected)).item()
+                scatter_max_diff = max(scatter_max_diff, diff)
+                logger.info(f"Scatter output match: Core {i}, {j}: expected: {expected[:10]}, actual: {actual[:10]}")
+
+        scatter_match = scatter_max_diff < 0.07
+        logger.info(f"Scatter output match: {scatter_match}, max_diff: {scatter_max_diff:.4f}")
+        assert scatter_match, f"Scatter output mismatch! Max diff: {scatter_max_diff}"

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_sdpa_reduce_to_all.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_sdpa_reduce_to_all.py
@@ -300,7 +300,6 @@ def test_sdpa_reduce_to_all(bh_1d_mesh_device, scatter_enabled):
                 actual = scatter_out_root[row_idx, :].float()
                 diff = torch.max(torch.abs(actual - expected)).item()
                 scatter_max_diff = max(scatter_max_diff, diff)
-                logger.info(f"Scatter output match: Core {i}, {j}: expected: {expected[:10]}, actual: {actual[:10]}")
 
         scatter_match = scatter_max_diff < 0.07
         logger.info(f"Scatter output match: {scatter_match}, max_diff: {scatter_max_diff:.4f}")


### PR DESCRIPTION
Add scatter option to sdpa_all_reduce op. Scatter can be enabled/disabled via test/op options. Currently reduce scatter op will manually untilize since the current reduce op is outputting 8x32 tiles while scatter needs 1x32 tiles.
When llk team provides the compute kernel that provides untiled output, we can remove the untilize from `writer.cpp`

### Ticket
https://github.com/tenstorrent/tt-metal/issues/37298

### Problem description
Provide context for the problem.

### What's changed
Describe the approach used to solve the problem.
Summarize the changes made and its impact.

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=ucheema/deepseek-b1-scatter-heads)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:ucheema/deepseek-b1-scatter-heads)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ucheema/deepseek-b1-scatter-heads)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ucheema/deepseek-b1-scatter-heads)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ucheema/deepseek-b1-scatter-heads)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ucheema/deepseek-b1-scatter-heads)
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ucheema/deepseek-b1-scatter-heads)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ucheema/deepseek-b1-scatter-heads)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ucheema/deepseek-b1-scatter-heads)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ucheema/deepseek-b1-scatter-heads)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ucheema/deepseek-b1-scatter-heads)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ucheema/deepseek-b1-scatter-heads)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
