### PR TITLE
Move CRTAs to Kernel groups

### DIFF
--- a/tests/tt_metal/tt_metal/api/test_runtime_args.cpp
+++ b/tests/tt_metal/tt_metal/api/test_runtime_args.cpp
@@ -370,7 +370,7 @@ void verify_quasar_crtas(
 
     for (uint32_t dm_id = 0; dm_id < max_dms; dm_id++) {
         const auto& expected_crtas = per_kernel_crtas[dm_id];
-        uint32_t dm_crta_addr = results_base + (kCommonRTASeparation + dm_id * num_crtas) * sizeof(uint32_t);
+        uint32_t dm_crta_addr = results_base + ((kCommonRTASeparation + dm_id * num_crtas) * sizeof(uint32_t));
 
         std::vector<uint32_t> observed;
         tt_metal::detail::ReadFromDeviceL1(device, core, dm_crta_addr, num_crtas * sizeof(uint32_t), observed);
@@ -381,9 +381,9 @@ void verify_quasar_crtas(
     }
 
     // Address slot starts right after CRTA values
-    uint32_t addr_base = results_base + (kCommonRTASeparation + max_dms * num_crtas) * sizeof(uint32_t);
+    uint32_t addr_base = results_base + ((kCommonRTASeparation + max_dms * num_crtas) * sizeof(uint32_t));
     for (uint32_t dm_id = 0; dm_id < max_dms; dm_id++) {
-        uint32_t addr_offset = addr_base + dm_id * sizeof(uint32_t);
+        uint32_t addr_offset = addr_base + (dm_id * sizeof(uint32_t));
         std::vector<uint32_t> addr;
         tt_metal::detail::ReadFromDeviceL1(device, core, addr_offset, sizeof(uint32_t), addr);
         crta_addrs.push_back(addr[0]);
@@ -896,7 +896,7 @@ TEST_F(MeshDeviceFixture, IdleEthIllegalTooManyRuntimeArgs) {
 }
 
 // Quasar only test: Single kernel running on all 8 DM processors with shared CRTAs.
-// Verifies all DMs receive identical CRTA values from the same kernel
+// Verifies all DMs receive identical CRTA values at the same L1 address
 // TODO: Once SW supports multiple quasar clusters/cores, expand to multiple CoreRangeSets
 // to verify CRTA dispatch across different Kernel groups
 TEST_F(MeshDeviceSingleCardFixture, QuasarCRTASharedL1Address) {
@@ -927,7 +927,7 @@ TEST_F(MeshDeviceSingleCardFixture, QuasarCRTASharedL1Address) {
 }
 
 // Quasar only test: 8 separate kernels, each running on a unique DM processor, with unique CRTAs.
-// Verifies each kernel receives its own distinct CRTA values via kernel_id indexing
+// Verifies each kernel receives its own distinct CRTA values at different L1 addresses
 // TODO: Once SW supports multiple quasar clusters/cores, expand to multiple CoreRangeSets
 // to verify CRTA dispatch across different Kernel groups
 TEST_F(MeshDeviceSingleCardFixture, QuasarCRTAUniqueL1Addresses) {

--- a/tests/tt_metal/tt_metal/api/test_runtime_args.cpp
+++ b/tests/tt_metal/tt_metal/api/test_runtime_args.cpp
@@ -29,6 +29,7 @@
 #include <tt-metalium/tt_backend_api_types.hpp>
 #include <tt-metalium/tt_metal.hpp>
 #include <tt_stl/span.hpp>
+#include <tt-metalium/experimental/host_api.hpp>
 
 #include "device_fixture.hpp"
 #include <umd/device/types/xy_pair.hpp>
@@ -55,19 +56,33 @@ uint32_t get_runtime_arg_addr(
     // Spread results out a bit, overly generous
     constexpr uint32_t runtime_args_space = 1024 * sizeof(uint32_t);
 
+    const auto& hal = tt::tt_metal::MetalContext::instance().hal();
+    uint32_t num_dm = hal.get_processor_types_count(
+        HalProgrammableCoreType::TENSIX, ttsl::as_underlying_type(tt::tt_metal::HalProcessorClassType::DM));
+    const uint32_t cache_offset =
+        (MetalContext::instance().hal().get_arch() == tt::ARCH::QUASAR)
+            ? MetalContext::instance().hal().get_dev_size(HalProgrammableCoreType::TENSIX, HalL1MemAddrType::BASE)
+            : 0;
+
     switch (processor_class) {
         case tt::tt_metal::HalProcessorClassType::DM:
-            TT_FATAL(0 <= processor_id && processor_id < 2, "processor_id {} must be 0 or 1 for DM", processor_id);
+            TT_FATAL(
+                0 <= processor_id && processor_id < num_dm,
+                "processor_id {} must be 0 to {} for DM",
+                processor_id,
+                num_dm - 1);
             result_base = l1_unreserved_base + processor_id * runtime_args_space;
             break;
         case tt::tt_metal::HalProcessorClassType::COMPUTE:
-            result_base = l1_unreserved_base + 2 * runtime_args_space;
+            result_base = l1_unreserved_base + num_dm * runtime_args_space;
             break;
         default: TT_THROW("Unknown processor");
     }
 
-    uint32_t offset = is_common ? 3 * runtime_args_space : 0;
-    return result_base + offset;
+    // Common args go after all unique arg slots
+    uint32_t total_processors = hal.get_num_risc_processors(HalProgrammableCoreType::TENSIX);
+    uint32_t offset = is_common ? total_processors * runtime_args_space : 0;
+    return (result_base + offset + cache_offset);
 };
 
 distributed::MeshWorkload initialize_program_data_movement(
@@ -122,6 +137,50 @@ distributed::MeshWorkload initialize_program_data_movement_rta(
 
     workload.add_program(device_range, std::move(program));
     return workload;
+}
+
+// Quasar-specific helper - handles all Quasar DM kernel patterns
+std::pair<distributed::MeshWorkload, std::vector<KernelHandle>> initialize_program_data_movement_rta_quasar(
+    const std::shared_ptr<distributed::MeshDevice>& mesh_device,
+    const CoreRangeSet& core_range_set,
+    uint32_t num_runtime_args,
+    bool common_rtas,
+    uint32_t num_kernels,
+    uint32_t dm_processors_per_kernel) {
+    TT_ASSERT(MetalContext::instance().hal().get_arch() == tt::ARCH::QUASAR, "This helper is only for Quasar");
+
+    distributed::MeshWorkload workload;
+    auto zero_coord = distributed::MeshCoordinate(0, 0);
+    auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
+    tt::tt_metal::Program program = tt_metal::CreateProgram();
+
+    std::vector<KernelHandle> kernel_handles(num_kernels);
+    uint32_t rta_base = get_runtime_arg_addr(
+        mesh_device->allocator()->get_base_allocator_addr(tt::tt_metal::HalMemType::L1),
+        tt::tt_metal::HalProcessorClassType::DM,
+        0,
+        common_rtas);
+
+    std::map<std::string, std::string> dm_defines = {
+        {"DATA_MOVEMENT", "1"},
+        {"MAX_DMS", std::to_string(num_kernels * dm_processors_per_kernel)},
+        {"NUM_RUNTIME_ARGS", std::to_string(num_runtime_args)},
+        {"RESULTS_ADDR", std::to_string(rta_base)}};
+    if (common_rtas) {
+        dm_defines["COMMON_RUNTIME_ARGS"] = "1";
+    }
+
+    for (uint32_t k = 0; k < num_kernels; k++) {
+        kernel_handles[k] = tt::tt_metal::experimental::quasar::CreateKernel(
+            program,
+            "tests/tt_metal/tt_metal/test_kernels/misc/runtime_args_kernel.cpp",
+            core_range_set,
+            tt::tt_metal::experimental::quasar::QuasarDataMovementConfig{
+                .num_processors_per_cluster = dm_processors_per_kernel, .defines = dm_defines});
+    }
+
+    workload.add_program(device_range, std::move(program));
+    return {std::move(workload), kernel_handles};
 }
 
 tt::tt_metal::KernelHandle initialize_program_compute(
@@ -280,6 +339,59 @@ void verify_results(
                             common_arg_incr_val);
                     }
                 }
+            }
+        }
+    }
+}
+
+void verify_quasar_crtas(
+    const std::shared_ptr<distributed::MeshDevice>& mesh_device,
+    const CoreCoord& core,
+    const std::vector<std::vector<uint32_t>>& per_kernel_crtas,
+    bool expect_shared_address) {
+    auto* device = mesh_device->get_devices()[0];
+    uint32_t l1_base = mesh_device->allocator()->get_base_allocator_addr(tt::tt_metal::HalMemType::L1);
+    uint32_t results_base = get_runtime_arg_addr(l1_base, tt::tt_metal::HalProcessorClassType::DM, 0, true);
+
+    constexpr uint32_t kCommonRTASeparation = 1024;
+    constexpr uint32_t kMaxDMs = 8;
+    const uint32_t num_crtas = per_kernel_crtas[0].size();
+    std::vector<uint32_t> crta_addrs;
+
+    for (uint32_t dm_id = 0; dm_id < per_kernel_crtas.size(); dm_id++) {
+        const auto& expected_crtas = per_kernel_crtas[dm_id];
+        uint32_t dm_crta_addr =
+            results_base + (kCommonRTASeparation + dm_id * expected_crtas.size()) * sizeof(uint32_t);
+
+        std::vector<uint32_t> observed;
+        tt_metal::detail::ReadFromDeviceL1(
+            device, core, dm_crta_addr, expected_crtas.size() * sizeof(uint32_t), observed);
+
+        for (size_t i = 0; i < expected_crtas.size(); i++) {
+            EXPECT_EQ(observed[i], expected_crtas[i]) << "DM" << dm_id << " CRTA[" << i << "]";
+        }
+    }
+
+    // Address slot starts right after CRTA values
+    uint32_t addr_base = results_base + (kCommonRTASeparation + kMaxDMs * num_crtas) * sizeof(uint32_t);
+    for (uint32_t dm_id = 0; dm_id < per_kernel_crtas.size(); dm_id++) {
+        uint32_t addr_offset = addr_base + dm_id * sizeof(uint32_t);
+        std::vector<uint32_t> addr;
+        tt_metal::detail::ReadFromDeviceL1(device, core, addr_offset, sizeof(uint32_t), addr);
+        crta_addrs.push_back(addr[0]);
+    }
+
+    if (expect_shared_address) {
+        // All DMs should have same CRTA address
+        for (size_t i = 1; i < crta_addrs.size(); i++) {
+            EXPECT_EQ(crta_addrs[0], crta_addrs[i]) << "All DMs should share same CRTA L1 address";
+        }
+    } else {
+        // All DMs should have different CRTA addresses
+        for (size_t i = 0; i < crta_addrs.size(); i++) {
+            for (size_t j = i + 1; j < crta_addrs.size(); j++) {
+                EXPECT_NE(crta_addrs[i], crta_addrs[j])
+                    << "DM" << i << " and DM" << j << " have same CRTA address: 0x" << std::hex << crta_addrs[i];
             }
         }
     }
@@ -773,6 +885,72 @@ TEST_F(MeshDeviceFixture, IdleEthIllegalTooManyRuntimeArgs) {
         std::vector<uint32_t> max_unique_args(idle_eth_max_runtime_args);
         EXPECT_NO_THROW(SetRuntimeArgs(program2_ref, kernel2, eth_core, max_unique_args));
     }
+}
+
+// Quasar only test: Single kernel running on all 8 DM processors with shared CRTAs.
+// Verifies all DMs receive identical CRTA values from the same kernel
+// TODO: Once SW supports multiple quasar clusters/cores, expand to multiple CoreRangeSets
+// to verify CRTA dispatch across different Kernel groups
+TEST_F(MeshDeviceSingleCardFixture, QuasarCRTASharedL1Address) {
+    if (arch_ != tt::ARCH::QUASAR) {
+        GTEST_SKIP() << "This test is only meant for Quasar";
+    }
+
+    auto mesh_device = devices_[0];
+    constexpr CoreCoord core = {0, 0};
+    CoreRange core_range(core);
+    CoreRangeSet core_range_set(std::vector{core_range});
+
+    auto zero_coord = distributed::MeshCoordinate(0, 0);
+    auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
+    distributed::MeshCommandQueue& cq = mesh_device->mesh_command_queue();
+    uint32_t num_dm = MetalContext::instance().hal().get_processor_types_count(
+        HalProgrammableCoreType::TENSIX, ttsl::as_underlying_type(tt::tt_metal::HalProcessorClassType::DM));
+    std::vector<uint32_t> common_rtas{0xdeadbeef, 0xabcd1234, 0x101};
+    // Single kernel on all DMs: all DMs should receive identical CRTAs
+    std::vector<std::vector<uint32_t>> all_crtas(num_dm, common_rtas);
+    auto [workload, handles] = unit_tests::runtime_args::initialize_program_data_movement_rta_quasar(
+        mesh_device, core_range_set, common_rtas.size(), true, /*num_kernels*/ 1, num_dm);
+    auto& program = workload.get_programs().at(device_range);
+    SetCommonRuntimeArgs(program, handles[0], common_rtas);
+    distributed::EnqueueMeshWorkload(cq, workload, false);
+    // Verify all DMs share the same CRTA L1 address
+    unit_tests::runtime_args::verify_quasar_crtas(mesh_device, core, all_crtas, /*expect_shared_address*/ true);
+}
+
+// Quasar only test: 8 separate kernels, each running on a unique DM processor, with unique CRTAs.
+// Verifies each kernel receives its own distinct CRTA values via kernel_id indexing
+// TODO: Once SW supports multiple quasar clusters/cores, expand to multiple CoreRangeSets
+// to verify CRTA dispatch across different Kernel groups
+TEST_F(MeshDeviceSingleCardFixture, QuasarCRTAUniqueL1Addresses) {
+    if (arch_ != tt::ARCH::QUASAR) {
+        GTEST_SKIP() << "This test is only meant for Quasar";
+    }
+
+    auto mesh_device = devices_[0];
+    constexpr CoreCoord core = {0, 0};
+    CoreRange core_range(core);
+    CoreRangeSet core_range_set(std::vector{core_range});
+
+    auto zero_coord = distributed::MeshCoordinate(0, 0);
+    auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
+    distributed::MeshCommandQueue& cq = mesh_device->mesh_command_queue();
+    std::vector<uint32_t> base_crtas = {0x101, 0x202, 0x303};
+    // One kernel per DM: each kernel gets its own CRTA offset
+    uint32_t num_kernels = MetalContext::instance().hal().get_processor_types_count(
+        HalProgrammableCoreType::TENSIX, ttsl::as_underlying_type(tt::tt_metal::HalProcessorClassType::DM));
+    auto [workload, handles] = unit_tests::runtime_args::initialize_program_data_movement_rta_quasar(
+        mesh_device, core_range_set, base_crtas.size(), true, num_kernels, /*dm_processors_per_kernel*/ 1);
+    auto& program = workload.get_programs().at(device_range);
+    std::vector<std::vector<uint32_t>> all_crtas;
+    for (uint32_t i = 0; i < handles.size(); i++) {
+        std::vector<uint32_t> kernel_crtas = {base_crtas[0] + i, base_crtas[1] + i, base_crtas[2] + i};
+        all_crtas.push_back(kernel_crtas);
+        SetCommonRuntimeArgs(program, handles[i], kernel_crtas);
+    }
+    distributed::EnqueueMeshWorkload(cq, workload, false);
+    // Verify each kernel has a unique CRTA L1 address
+    unit_tests::runtime_args::verify_quasar_crtas(mesh_device, core, all_crtas, /*expect_shared_address*/ false);
 }
 
 }  // namespace tt::tt_metal

--- a/tests/tt_metal/tt_metal/test_kernels/misc/runtime_args_kernel.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/misc/runtime_args_kernel.cpp
@@ -14,14 +14,22 @@
 
 void kernel_main() {
     volatile uint32_t tt_l1_ptr* results = (volatile uint32_t tt_l1_ptr*)RESULTS_ADDR;
-    int i;
-    for (i = 0; i < NUM_RUNTIME_ARGS; i++) {
+    constexpr uint32_t kCommonRTASeparation = 1024;
+    uint64_t hartid = 0;
+    for (uint32_t i = 0; i < NUM_RUNTIME_ARGS; i++) {
 #ifdef COMMON_RUNTIME_ARGS
-            constexpr uint32_t kCommonRTASeparation = 1024;
-            results[i + kCommonRTASeparation] = get_common_arg_val<uint32_t>(i);
+#ifdef COMPILE_FOR_DM
+            // Quasar only: Get DM processor ID
+            asm volatile("csrr %0, mhartid" : "=r"(hartid));
+#endif
+            results[i + kCommonRTASeparation + hartid * NUM_RUNTIME_ARGS] = get_common_arg_val<uint32_t>(i);
 #endif
             results[i] = get_arg_val<uint32_t>(i);
     }
+#ifdef COMPILE_FOR_DM
+    // Quasar only: write the actual L1 base addresses at the end of CRTA payload from all DMs
+    results[kCommonRTASeparation + MAX_DMS * NUM_RUNTIME_ARGS + hartid] = static_cast<uint32_t>(get_common_arg_addr(0));
+#endif
 
 #ifdef COORDS_ADDR
 #ifdef DATA_MOVEMENT

--- a/tests/tt_metal/tt_metal/test_kernels/misc/runtime_args_kernel.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/misc/runtime_args_kernel.cpp
@@ -16,20 +16,18 @@ void kernel_main() {
     volatile uint32_t tt_l1_ptr* results = (volatile uint32_t tt_l1_ptr*)RESULTS_ADDR;
     constexpr uint32_t kCommonRTASeparation = 1024;
     uint64_t hartid = 0;
-    for (uint32_t i = 0; i < NUM_RUNTIME_ARGS; i++) {
-#ifdef COMMON_RUNTIME_ARGS
 #ifdef COMPILE_FOR_DM
-            // Quasar only: Get DM processor ID
-            asm volatile("csrr %0, mhartid" : "=r"(hartid));
-#endif
-            results[i + kCommonRTASeparation + hartid * NUM_RUNTIME_ARGS] = get_common_arg_val<uint32_t>(i);
-#endif
-            results[i] = get_arg_val<uint32_t>(i);
-    }
-#ifdef COMPILE_FOR_DM
-    // Quasar only: write the actual L1 base addresses at the end of CRTA payload from all DMs
+    // Quasar DM only: Get DM processor ID
+    asm volatile("csrr %0, mhartid" : "=r"(hartid));
+    // Quasar DM only: write the actual L1 base addresses at the end of CRTA payload from all DMs
     results[kCommonRTASeparation + MAX_DMS * NUM_RUNTIME_ARGS + hartid] = static_cast<uint32_t>(get_common_arg_addr(0));
 #endif
+    for (uint32_t i = 0; i < NUM_RUNTIME_ARGS; i++) {
+#ifdef COMMON_RUNTIME_ARGS
+        results[i + kCommonRTASeparation + hartid * NUM_RUNTIME_ARGS] = get_common_arg_val<uint32_t>(i);
+#endif
+        results[i] = get_arg_val<uint32_t>(i);
+    }
 
 #ifdef COORDS_ADDR
 #ifdef DATA_MOVEMENT

--- a/tt_metal/impl/kernels/kernel.hpp
+++ b/tt_metal/impl/kernels/kernel.hpp
@@ -107,7 +107,6 @@ public:
     RuntimeArgsData& common_runtime_args_data();
     void set_common_runtime_args_count(uint32_t count);
     uint32_t get_common_runtime_args_count() const { return this->common_runtime_args_count_; }
-    uint32_t dispatch_class() const { return this->dispatch_class_; }
 
     virtual bool configure(
         IDevice* device, const CoreCoord& logical_core, uint32_t base_address, const uint32_t offsets[]) const = 0;
@@ -178,7 +177,6 @@ protected:
     KernelSource kernel_src_;
     std::string kernel_full_name_;  // Name + hash
     CoreRangeSet core_range_set_;
-    uint8_t dispatch_class_{};
     std::vector<uint32_t> compile_time_args_;
     std::unordered_map<std::string, uint32_t> named_compile_time_args_;
     std::vector<std::vector<std::vector<uint32_t>>> core_to_runtime_args_;
@@ -217,9 +215,7 @@ public:
             config.compile_args,
             config.defines,
             config.named_compile_args),
-        config_(config) {
-        this->dispatch_class_ = DISPATCH_CLASS_TENSIX_DM0 + enchantum::to_underlying(config.processor);
-    }
+        config_(config) {}
 
     ~DataMovementKernel() override = default;
 
@@ -257,9 +253,7 @@ public:
             config.compile_args,
             config.defines,
             config.named_compile_args),
-        config_(config) {
-        this->dispatch_class_ = DISPATCH_CLASS_ETH_DM0 + enchantum::to_underlying(config.processor);
-    }
+        config_(config) {}
 
     ~EthernetKernel() override = default;
 
@@ -297,11 +291,7 @@ public:
             config.compile_args,
             config.defines,
             config.named_compile_args),
-        config_(config) {
-        // Note: it's wrong to use HalProcessorClassType here, because DM == 0 and COMPUTE == 1,
-        // but DISPATCH_CLASS_TENSIX_COMPUTE == 2.
-        this->dispatch_class_ = DISPATCH_CLASS_TENSIX_COMPUTE;
-    }
+        config_(config) {}
 
     ~ComputeKernel() override = default;
 

--- a/tt_metal/impl/program/dispatch.cpp
+++ b/tt_metal/impl/program/dispatch.cpp
@@ -197,7 +197,7 @@ uint32_t configure_rta_offsets_for_kernel_groups(
         offset = tt::align(offset, l1_alignment);
         max_unique_rta_size = std::max(offset, max_unique_rta_size);
     }
-    return max_unique_rta_size;  // worst-case KG determines L1 reservation
+    return max_unique_rta_size;
 }
 
 uint32_t configure_crta_offsets_for_kernel_groups(

--- a/tt_metal/impl/program/dispatch.hpp
+++ b/tt_metal/impl/program/dispatch.hpp
@@ -73,18 +73,14 @@ uint32_t configure_crta_offsets_for_kernel_groups(
     uint32_t programmable_core_type_index,
     std::unordered_map<KernelHandle, std::shared_ptr<Kernel>>& kernels,
     std::vector<std::shared_ptr<KernelGroup>>& kernel_groups,
-    uint32_t crta_base_offset,
-    std::array<uint32_t, DISPATCH_CLASS_MAX>& crta_offsets,
-    std::array<uint32_t, DISPATCH_CLASS_MAX>& crta_sizes);
+    uint32_t crta_base_offset);
 
 uint32_t finalize_rt_args(
     std::unordered_map<KernelHandle, std::shared_ptr<Kernel>>& kernels,
     std::vector<std::shared_ptr<KernelGroup>>& kernel_groups,
     uint32_t base_offset,
     uint32_t programmable_core_type_index,
-    uint32_t& rta_offset,
-    std::array<uint32_t, DISPATCH_CLASS_MAX>& crta_offsets,
-    std::array<uint32_t, DISPATCH_CLASS_MAX>& crta_sizes);
+    uint32_t& rta_offset);
 
 uint32_t finalize_sems(
     uint32_t programmable_core_type_index,

--- a/tt_metal/impl/program/program_impl.hpp
+++ b/tt_metal/impl/program/program_impl.hpp
@@ -69,10 +69,10 @@ void assemble_device_commands(
 struct KernelGroup {
     uint32_t programmable_core_type_index{};
     CoreRangeSet core_ranges;
-    // kernel_ids are ordered by dispatch class
+    // kernel_ids are ordered by processor index
     std::vector<KernelHandle> kernel_ids;
+    // RTA/CRTA layout for each kernel
     std::vector<uint32_t> rta_sizes;
-    // Common RTA offsets and sizes.
     std::vector<uint32_t> crta_offsets;
     std::vector<uint32_t> crta_sizes;
     uint32_t total_rta_size{};

--- a/tt_metal/impl/program/program_impl.hpp
+++ b/tt_metal/impl/program/program_impl.hpp
@@ -52,19 +52,6 @@ class MeshWorkload;
 class MeshWorkloadImpl;
 }  // namespace distributed
 
-enum dispatch_core_processor_classes {
-    // Tensix processor classes
-    DISPATCH_CLASS_TENSIX_DM0 = 0,
-    DISPATCH_CLASS_TENSIX_DM1 = 1,
-    DISPATCH_CLASS_TENSIX_COMPUTE = 2,
-
-    // Ethernet processor classes
-    DISPATCH_CLASS_ETH_DM0 = 0,
-    DISPATCH_CLASS_ETH_DM1 = 1,
-
-    DISPATCH_CLASS_MAX = 3,
-};
-
 namespace experimental {
 class GlobalCircularBuffer;
 }
@@ -84,7 +71,10 @@ struct KernelGroup {
     CoreRangeSet core_ranges;
     // kernel_ids are ordered by dispatch class
     std::vector<KernelHandle> kernel_ids;
-    uint32_t rta_sizes[DISPATCH_CLASS_MAX]{};
+    std::vector<uint32_t> rta_sizes;
+    // Common RTA offsets and sizes.
+    std::vector<uint32_t> crta_offsets;
+    std::vector<uint32_t> crta_sizes;
     uint32_t total_rta_size{};
     // kernel_text_offsets is indexed by processor index within core.
     std::vector<uint32_t> kernel_text_offsets;
@@ -106,8 +96,6 @@ struct KernelGroup {
 // Contains the program's worker memory map
 struct ProgramConfig {
     uint32_t rta_offset;
-    std::array<uint32_t, DISPATCH_CLASS_MAX> crta_offsets;
-    std::array<uint32_t, DISPATCH_CLASS_MAX> crta_sizes;
     uint32_t sem_offset;
     uint32_t sem_size;
     uint32_t cb_offset;
@@ -136,9 +124,6 @@ struct ProgramOffsetsState {
     uint32_t offset = 0;
     // Unique RTA offset.
     uint32_t rta_offset = 0;
-    // Common RTA offsets and sizes.
-    std::array<uint32_t, DISPATCH_CLASS_MAX> crta_offsets{};
-    std::array<uint32_t, DISPATCH_CLASS_MAX> crta_sizes{};
     // Semaphore offsets and sizes.
     uint32_t sem_offset = 0;
     uint32_t sem_size = 0;


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/37591

### Problem description
The current dispatch system uses a rigid `dispatch_class` concept for common runtime args allocation, which assumes a fixed number of processor classes (`DM0`, `DM1`, `COMPUTE` = 3 dispatch classes total). For quasar's (which has 8 DM cores + 1 COMPUTE = 9 dispatch classes total) flexible programming model, this approach is inefficient for L1 CRTA allocation (e.g. same kernel with CRTAs on multiple DMs will lead to possibly 9 L1 allocations). So, it's more efficient to have CRTA offsets tied to kernel groups rather than global dispatch classes.

### What's changed
- Removed `Kernel::dispatch_class_` and the `dispatch_core_processor_classes` enum
- Moved CRTA offset/size storage from global `ProgramConfig` to `KernelGroup`
- Changed all fixed array RTA sizes/offsets to `std::vector` indexed parallel to `KernelGroup::kernel_ids`
- `configure_crta_offsets_for_kernel_groups()` now computes CRTA offsets per kernel group, similar to unique RTAs
- The uncommon case where kernels are spread across non-overlapping core ranges (more kernel groups than kernels) will be slightly less efficient due to multicasting to kernel group being the only route now (instead of per-kernel multicasting).

Tests:
- Added `QuasarCRTASharedL1Address`: Single kernel on all 8 DMs verifies shared single CRTA address
- Added `QuasarCRTAUniqueL1Addresses`: 8 kernels on separate DMs verifies unique CRTA offsets

Note: These tests need to be expanded to multiple quasar clusters once Quasar runtime is fully brought up to verify the CRTA kernel-group multicasting.

### Checklist

- [x] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=snadkarni/plug_crtas_into_kg)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:snadkarni/plug_crtas_into_kg)
- [x] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=snadkarni/plug_crtas_into_kg)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:snadkarni/plug_crtas_into_kg)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=snadkarni/plug_crtas_into_kg)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:snadkarni/plug_crtas_into_kg)
- [x] New/Existing tests provide coverage for changes

Quasar emulator test runs: https://gist.github.com/sidnadTT/907223d95d3a5bdde744697012d3677c


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=snadkarni/plug_crtas_into_kg)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:snadkarni/plug_crtas_into_kg)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=snadkarni/plug_crtas_into_kg)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:snadkarni/plug_crtas_into_kg)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=snadkarni/plug_crtas_into_kg)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:snadkarni/plug_crtas_into_kg)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
