### PR TITLE
Move prefetcher pytest option to avoid breaking CI tests

### DIFF
--- a/models/tt_transformers/demo/simple_text_demo.py
+++ b/models/tt_transformers/demo/simple_text_demo.py
@@ -743,16 +743,16 @@ def prepare_generator_args(
     ],
 )
 @pytest.mark.parametrize(
-    "use_prefetcher",
-    ([False]),
-)
-@pytest.mark.parametrize(
     "optimizations",
     [
         lambda model_args: DecodersPrecision.performance(model_args.n_layers, model_args.model_name),
         lambda model_args: DecodersPrecision.accuracy(model_args.n_layers, model_args.model_name),
     ],
     ids=["performance", "accuracy"],
+)
+@pytest.mark.parametrize(
+    "use_prefetcher",
+    ([False]),
 )
 @pytest.mark.parametrize(
     "device_params",


### PR DESCRIPTION
### Problem description
Provide context for the problem.

With the recent commit adding the prefetcher module, an option to disable prefetcher was added to `simple_text_demo.py` in TTT. The position of the option messes up the previous testing arguments, which will affect some CI tests that rely on this. 

Now instead, a simple_text_demo call would look like: `[wormhole_b0-8-device_params0-performance-False-batch-1]`. That `False` parameter, between performance and what comes next might mess things up.

For example `tt-metal/dockerfile/upstream_test_images/run_upstream_tests_vanilla.sh` calls `pytest models/tt_transformers/demo/simple_text_demo.py -k performance-batch-1` which would be skipped now.