### PR TITLE
[WATCHER] Skipping ops-unit-test from APC with watcher due to code size being too large

### DIFF
--- a/.github/workflows/ops-post-commit.yaml
+++ b/.github/workflows/ops-post-commit.yaml
@@ -147,6 +147,7 @@ jobs:
           auto-triage: ${{ !inputs.enable-watcher }}
 
       - name: ${{ matrix.test-group.name }} tests
+        if: ${{ !inputs.enable-watcher }}
         timeout-minutes: ${{ matrix.test-group.timeout }}
         env:
           TRACY_NO_INVARIANT_CHECK: 1
@@ -160,7 +161,7 @@ jobs:
           cat $DEVICE_PERF_REPORT_FILENAME
 
       - name: Merge and check test reports
-        if: ${{ github.event.pull_request.head.repo.fork == false }}
+        if: ${{ !inputs.enable-watcher && github.event.pull_request.head.repo.fork == false }}
         timeout-minutes: 5
         env:
           TRACY_NO_INVARIANT_CHECK: 1

--- a/models/experimental/stable_diffusion_xl_base/tests/test_sdxl_op_unit_test_perf.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/test_sdxl_op_unit_test_perf.py
@@ -5,6 +5,7 @@
 import pytest
 import ttnn
 
+from models.common.utility_functions import is_watcher_enabled
 from models.perf.device_perf_utils import run_device_perf_detailed
 
 MARGIN = 0.015
@@ -13,6 +14,9 @@ USE_PERF_TEST_MODE = True
 
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 0}], indirect=True)
 def test_dram_group_norm_welford_reciprocal_vae(device):
+    if is_watcher_enabled():
+        pytest.skip("Skipping test with watcher enabled due to code size being bloated")
+
     from tests.ttnn.unit_tests.operations.fused.test_group_norm_DRAM import test_group_norm_DRAM
 
     test_group_norm_DRAM(device, 1, 256, 256, 256, 32, 4, 8, 8, "welford_reciprocal", perf_test_mode=USE_PERF_TEST_MODE)

--- a/models/experimental/stable_diffusion_xl_base/tests/test_sdxl_op_unit_test_perf.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/test_sdxl_op_unit_test_perf.py
@@ -5,7 +5,6 @@
 import pytest
 import ttnn
 
-from models.common.utility_functions import is_watcher_enabled
 from models.perf.device_perf_utils import run_device_perf_detailed
 
 MARGIN = 0.015
@@ -14,9 +13,6 @@ USE_PERF_TEST_MODE = True
 
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 0}], indirect=True)
 def test_dram_group_norm_welford_reciprocal_vae(device):
-    if is_watcher_enabled():
-        pytest.skip("Skipping test with watcher enabled due to code size being bloated")
-
     from tests.ttnn.unit_tests.operations.fused.test_group_norm_DRAM import test_group_norm_DRAM
 
     test_group_norm_DRAM(device, 1, 256, 256, 256, 32, 4, 8, 8, "welford_reciprocal", perf_test_mode=USE_PERF_TEST_MODE)


### PR DESCRIPTION
### Ticket
[#27840](https://github.com/tenstorrent/tt-metal/issues/27840)

### Problem description
Sdxl model being run with watcher enabled causes code size being bloated. Moreover perf test are not expected to be run with watcher enabled.

### What's changed
Adding a skip to the step in APC if watcher is enabled 

### Checklist

- [x] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=dstoiljkovic/apc_select_watcher_9)](https://github.com/tenstorrent/tt-metal/actions/runs/21904355147?query=branch:dstoiljkovic/apc_select_watcher_9)
