### PR TITLE
fix gpt rope post ttt prefetcher merge

### DIFF
--- a/models/demos/gpt_oss/tt/model.py
+++ b/models/demos/gpt_oss/tt/model.py
@@ -229,6 +229,10 @@ class Model:
 
         return instance
 
+    def switch_mode(self, mode: Mode):
+        # No-op; required by tt_transformers generator interface.
+        return None
+
     def _forward_layers_and_head(
         self, hidden_states, rope_mats, current_pos, page_table, kv_cache, get_last_token=-1, is_decode=True, user_id=0
     ):
@@ -340,8 +344,8 @@ class Model:
         else:
             # Slice cos/sin matrices for prefill sequence length (matches tt-transformers model.py lines 156-159)
             rope_mats = [
-                self.rope_setup.cos_matrix[:, :, :seq_len, :],
-                self.rope_setup.sin_matrix[:, :, :seq_len, :],
+                self.rope_setup.cos_matrix_prefill[:, :, :seq_len, :],
+                self.rope_setup.sin_matrix_prefill[:, :, :seq_len, :],
             ]
 
         # Forward through layers and head (shared with decode)
@@ -493,8 +497,8 @@ class Model:
         # Prepare rotation matrices (slice from rope_setup like tt-transformers model.py lines 156-159)
         seq_len = self.args.max_seq_len if trace_enabled else tokens_embd.shape[-2]
         rot_mats_global = [
-            self.rope_setup.cos_matrix[:, :, :seq_len, :],
-            self.rope_setup.sin_matrix[:, :, :seq_len, :],
+            self.rope_setup.cos_matrix_prefill[:, :, :seq_len, :],
+            self.rope_setup.sin_matrix_prefill[:, :, :seq_len, :],
         ]
         rot_mats_local = None
 

--- a/models/tt_transformers/tt/rope.py
+++ b/models/tt_transformers/tt/rope.py
@@ -455,7 +455,7 @@ class RotarySetup(LightweightModule):
                 return ttnn.num_cores_to_corerangeset(batch_size, core_grid, row_wise=True)
 
         self.batch_grid = get_batch_grid(
-            self.doubled_batch_size,
+            self.batch_size_per_device_group,
             self.core_grid,
             self.start_core,
             self.batch_size_per_device_group,


### PR DESCRIPTION
This PR updates RoPE handling after the prefetcher-related merge, aligning GPT-OSS prefill behavior and RotarySetup sharding/grid setup with the intended prefill/decode layouts.

Changes:

Fix RotarySetup.batch_grid initialization to use batch_size_per_device_group (instead of doubled_batch_size) when selecting the batch core grid.
Update GPT-OSS prefill paths to slice RoPE matrices from cos_matrix_prefill/sin_matrix_prefill (tile layout) instead of cos_matrix/sin_matrix.
Add a switch_mode() no-op to satisfy the tt_transformers generator interface.
