### PR TITLE
Disable stable_diffusion model perf test on blackhole (#37617)

### DIFF
--- a/.github/workflows/perf-models-impl.yaml
+++ b/.github/workflows/perf-models-impl.yaml
@@ -94,7 +94,8 @@ jobs:
         uses: tenstorrent/tt-metal/.github/actions/single-card-perf-test@main
         with:
           commands: pytest models/demos/vision/generative/stable_diffusion/${{ matrix.test-info.arch == 'blackhole' && 'blackhole' || 'wormhole' }}/tests -m models_performance_bare_metal --timeout=480
-        if: ${{ !cancelled() && matrix.test-info.model-group == 'cnn_javelin' && (inputs.model == 'all' || inputs.model == 'stable_diffusion') }}
+        # Disabled on blackhole until the test is fixed; issue #37617
+        if: ${{ !cancelled() && matrix.test-info.model-group == 'cnn_javelin' && matrix.test-info.arch != 'blackhole' && (inputs.model == 'all' || inputs.model == 'stable_diffusion') }}
       # Disabled until the test is fixed; issue #35263
       # - name: Run sentence_bert model_perf test
       #   timeout-minutes: ${{ matrix.test-info.timeout }}


### PR DESCRIPTION
### Ticket
#37617

### Problem description
SD nd failing often on BH 150 model perf pipeline; Seems like a hang, disabling until debugged, more info in the issue.

### Checklist
Model perf pipeline: https://github.com/tenstorrent/tt-metal/actions/runs/21905455183