### PR TITLE
Add Custom Init for Packing Contiguous Block from DEST

### DIFF
--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_pack_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_pack_api.h
@@ -25,7 +25,7 @@
 
 // TODO NC: Remove as the part of tt-metal#34499
 template <bool untilize = false, bool zero_output = false, bool tilize = false>
-inline void llk_pack_mop_config(const uint32_t output) {
+inline void llk_pack_mop_config(const uint32_t output, std::uint32_t num_tiles = 1) {
     const std::uint32_t output_id = get_output_id(output);
     const std::uint32_t num_faces = get_output_num_faces(output_id);
     const std::uint32_t face_r_dim = get_output_face_r_dim(output_id);
@@ -34,7 +34,7 @@ inline void llk_pack_mop_config(const uint32_t output) {
     const bool narrow_tile = get_output_narrow_tile(output_id);
 
     _llk_pack_mop_config_<untilize, zero_output, tilize>(
-        pack_dst_format[output_id], face_r_dim, tile_c_dim, num_faces, partial_face, narrow_tile);
+        pack_dst_format[output_id], face_r_dim, tile_c_dim, num_faces, partial_face, narrow_tile, num_tiles);
 }
 
 template <bool is_fp32_dest_acc_en>
@@ -101,7 +101,7 @@ inline void llk_pack_untilize_hw_configure_disaggregated(
 }
 
 template <bool untilize = false, bool zero_output = false, bool tilize = false>
-inline void llk_pack_init(const std::uint32_t pack_output = 16) {
+inline void llk_pack_init(const std::uint32_t pack_output = 16, std::uint32_t num_tiles = 1) {
     // TODO (https://github.com/tenstorrent/tt-metal/issues/18948): Revisit for narrow_tile
     const std::uint32_t output_id = get_output_id(pack_output);
     const std::uint32_t face_r_dim = get_output_face_r_dim(output_id);
@@ -111,7 +111,7 @@ inline void llk_pack_init(const std::uint32_t pack_output = 16) {
     const bool narrow_tile = get_output_narrow_tile(output_id);
 
     _llk_pack_init_<untilize, zero_output, tilize>(
-        pack_src_format[output_id], pack_dst_format[output_id], face_r_dim, tile_c_dim, num_faces, partial_face, narrow_tile);
+        pack_src_format[output_id], pack_dst_format[output_id], face_r_dim, tile_c_dim, num_faces, partial_face, narrow_tile, num_tiles);
 }
 
 template <bool out_of_order_output, bool untilize>

--- a/tt_metal/hw/inc/api/compute/experimental/pack_custom.h
+++ b/tt_metal/hw/inc/api/compute/experimental/pack_custom.h
@@ -10,10 +10,9 @@ namespace ckernel {
 
 // clang-format off
 /**
- * Initializes the packer for custom block packing operation. This function configures
- * the packer to pack multiple contiguous tiles from the destination register bank to L1 memory.
+ * Initializes the packer for packing multiple contiguous tiles from the destination register bank to L1 memory.
  *
- * Call this function before using `pack_block_custom`. The function configures the packer
+ * Call this function before using `pack_tile`. The function configures the packer
  * to handle the specified number of tiles (typically the full destination bank size).
  *
  * Return value: None
@@ -26,34 +25,6 @@ namespace ckernel {
 // clang-format on
 ALWI void pack_block_init_custom(uint32_t icb, uint32_t num_tiles) {
     PACK((llk_pack_init<false, false, false>(icb, num_tiles)));
-}
-
-// clang-format off
-/**
- * Packs a custom block of contiguous tiles from the destination register bank to the output circular buffer.
- * This function efficiently packs multiple tiles from the DEST register in a single operation.
- *
- * Before calling this function:
- * 1. Initialize the pack block custom operation with `pack_block_init_custom`
- * 2. Ensure cb_reserve_back has been called on the output CB with sufficient space
- * 3. Data must be present in the destination register (from unpack/math operations)
- * 4. The DEST register buffer must be in acquired state via *acquire_dst* call
- *
- * Each call to `pack_block_custom` will pack the configured number of tiles (set via
- * `pack_block_init_custom`) from the destination register to the output circular buffer.
- *
- *
- * Return value: None
- *
- * | Param Type | Name      | Description                                       | Type     | Valid Range                                          | Required |
- * |------------|-----------|---------------------------------------------------|----------|------------------------------------------------------|----------|
- * | Function   | ifrom_dst | The starting index in the DEST register           | uint32_t | Must be less than the size of the DEST register (16) | True     |
- * | Function   | icb       | The identifier of the output circular buffer (CB) | uint32_t | 0 to 31                                              | True     |
- * | Function   | ntiles    | The number of tiles to pack from DEST to CB       | uint32_t | 1 to 16                                              | True     |
- */
-// clang-format on
-ALWI void pack_block_custom(uint32_t ifrom_dst, uint32_t icb, uint32_t ntiles) {
-    PACK((llk_matmul_pack<DST_ACCUM_MODE, false, false>(ifrom_dst, icb, ntiles)));
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/inc/api/compute/experimental/pack_custom.h
+++ b/tt_metal/hw/inc/api/compute/experimental/pack_custom.h
@@ -1,0 +1,60 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "common_globals.h"
+
+namespace ckernel {
+
+// clang-format off
+/**
+ * Initializes the packer for custom block packing operation. This function configures 
+ * the packer to pack multiple tiles from the destination register bank to L1 memory.
+ *
+ * Call this function before using `pack_block_custom`. The function configures the packer
+ * to handle the specified number of tiles (typically the full destination bank size).
+ *
+ * Return value: None
+ *
+ * | Param Type | Name      | Description                                       | Type     | Valid Range | Required |
+ * |------------|-----------|---------------------------------------------------|----------|-------------|----------|
+ * | Function   | icb       | The identifier of the output circular buffer (CB) | uint32_t | 0 to 31     | True     |
+ * | Function   | num_tiles | Number of tiles to configure the packer for       | uint32_t | 1 to 16     | True     |
+ */
+// clang-format on
+ALWI void pack_block_init_custom(uint32_t icb, uint32_t num_tiles) {
+    PACK((llk_pack_init<false, false, false>(icb, num_tiles)));
+}
+
+// clang-format off
+/**
+ * Packs a custom block of tiles from the destination register bank to the output circular buffer.
+ * This function efficiently packs multiple tiles from the DEST register in a single operation.
+ * 
+ * Before calling this function:
+ * 1. Initialize the pack block custom operation with `pack_block_init_custom`
+ * 2. Ensure cb_reserve_back has been called on the output CB with sufficient space
+ * 3. Data must be present in the destination register (from unpack/math operations)
+ * 4. The DEST register buffer must be in acquired state via *acquire_dst* call
+ *
+ * Each call to `pack_block_custom` will pack the configured number of tiles (set via 
+ * `pack_block_init_custom`) from the destination register to the output circular buffer.
+ *
+ * This call is blocking and is only available on the compute engine.
+ *
+ * Return value: None
+ *
+ * | Param Type | Name      | Description                                       | Type     | Valid Range                                          | Required |
+ * |------------|-----------|---------------------------------------------------|----------|------------------------------------------------------|----------|
+ * | Function   | ifrom_dst | The starting index in the DEST register           | uint32_t | Must be less than the size of the DEST register (16) | True     |
+ * | Function   | icb       | The identifier of the output circular buffer (CB) | uint32_t | 0 to 31                                              | True     |
+ * | Function   | ntiles    | The number of tiles to pack from DEST to CB       | uint32_t | 1 to 16                                              | True     |
+ */
+// clang-format on
+ALWI void pack_block_custom(uint32_t ifrom_dst, uint32_t icb, uint32_t ntiles) {
+    PACK((llk_matmul_pack<DST_ACCUM_MODE, false, false>(ifrom_dst, icb, ntiles)));
+}
+
+}  // namespace ckernel

--- a/tt_metal/hw/inc/api/compute/experimental/pack_custom.h
+++ b/tt_metal/hw/inc/api/compute/experimental/pack_custom.h
@@ -11,7 +11,7 @@ namespace ckernel {
 // clang-format off
 /**
  * Initializes the packer for custom block packing operation. This function configures 
- * the packer to pack multiple tiles from the destination register bank to L1 memory.
+ * the packer to pack multiple contiguous tiles from the destination register bank to L1 memory.
  *
  * Call this function before using `pack_block_custom`. The function configures the packer
  * to handle the specified number of tiles (typically the full destination bank size).
@@ -30,7 +30,7 @@ ALWI void pack_block_init_custom(uint32_t icb, uint32_t num_tiles) {
 
 // clang-format off
 /**
- * Packs a custom block of tiles from the destination register bank to the output circular buffer.
+ * Packs a custom block of contiguous tiles from the destination register bank to the output circular buffer.
  * This function efficiently packs multiple tiles from the DEST register in a single operation.
  * 
  * Before calling this function:
@@ -42,7 +42,6 @@ ALWI void pack_block_init_custom(uint32_t icb, uint32_t num_tiles) {
  * Each call to `pack_block_custom` will pack the configured number of tiles (set via 
  * `pack_block_init_custom`) from the destination register to the output circular buffer.
  *
- * This call is blocking and is only available on the compute engine.
  *
  * Return value: None
  *

--- a/tt_metal/hw/inc/api/compute/experimental/pack_custom.h
+++ b/tt_metal/hw/inc/api/compute/experimental/pack_custom.h
@@ -10,7 +10,7 @@ namespace ckernel {
 
 // clang-format off
 /**
- * Initializes the packer for custom block packing operation. This function configures 
+ * Initializes the packer for custom block packing operation. This function configures
  * the packer to pack multiple contiguous tiles from the destination register bank to L1 memory.
  *
  * Call this function before using `pack_block_custom`. The function configures the packer
@@ -32,14 +32,14 @@ ALWI void pack_block_init_custom(uint32_t icb, uint32_t num_tiles) {
 /**
  * Packs a custom block of contiguous tiles from the destination register bank to the output circular buffer.
  * This function efficiently packs multiple tiles from the DEST register in a single operation.
- * 
+ *
  * Before calling this function:
  * 1. Initialize the pack block custom operation with `pack_block_init_custom`
  * 2. Ensure cb_reserve_back has been called on the output CB with sufficient space
  * 3. Data must be present in the destination register (from unpack/math operations)
  * 4. The DEST register buffer must be in acquired state via *acquire_dst* call
  *
- * Each call to `pack_block_custom` will pack the configured number of tiles (set via 
+ * Each call to `pack_block_custom` will pack the configured number of tiles (set via
  * `pack_block_init_custom`) from the destination register to the output circular buffer.
  *
  *

--- a/tt_metal/hw/inc/api/compute/experimental/pack_custom.h
+++ b/tt_metal/hw/inc/api/compute/experimental/pack_custom.h
@@ -16,7 +16,6 @@ namespace ckernel {
  * to handle the specified number of tiles (typically the full destination bank size).
  *
  * NOTE: This function alters the behavior of the packer only on Blachole.
-
  * Return value: None
  *
  * | Param Type | Name      | Description                                       | Type     | Valid Range | Required |
@@ -26,6 +25,7 @@ namespace ckernel {
  */
 // clang-format on
 ALWI void pack_block_init_custom(uint32_t icb, uint32_t num_tiles) {
+// TODO NC: Should be removed as a custom functionality as a part of tt-metal#37671
 #ifdef ARCH_BLACKHOLE
     PACK((llk_pack_init<false, false, false>(icb, num_tiles)));
 #else

--- a/tt_metal/hw/inc/api/compute/experimental/pack_custom.h
+++ b/tt_metal/hw/inc/api/compute/experimental/pack_custom.h
@@ -15,6 +15,8 @@ namespace ckernel {
  * Call this function before using `pack_tile`. The function configures the packer
  * to handle the specified number of tiles (typically the full destination bank size).
  *
+ * NOTE: This function alters the behavior of the packer only on Blachole.
+
  * Return value: None
  *
  * | Param Type | Name      | Description                                       | Type     | Valid Range | Required |
@@ -24,7 +26,12 @@ namespace ckernel {
  */
 // clang-format on
 ALWI void pack_block_init_custom(uint32_t icb, uint32_t num_tiles) {
+#ifdef ARCH_BLACKHOLE
     PACK((llk_pack_init<false, false, false>(icb, num_tiles)));
+#else
+    (void)num_tiles;
+    PACK((llk_pack_init<false, false, false>(icb)));
+#endif
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/inc/api/compute/pack.h
+++ b/tt_metal/hw/inc/api/compute/pack.h
@@ -62,26 +62,6 @@ ALWI void pack_tile(uint32_t ifrom_dst, uint32_t icb, std::uint32_t output_tile_
     PACK((llk_pack<DST_ACCUM_MODE, out_of_order_output, false>(ifrom_dst, icb, output_tile_index)));
 }
 
-
-
-// clang-format off
-/**
- * Initializes the packer with a specified tile count. This function configures the packer
- * to operate with a specific number of tiles in the destination register.
- *
- * Return value: None
- *
- * | Param Type | Name      | Description                                       | Type     | Valid Range | Required |
- * |------------|-----------|---------------------------------------------------|----------|-------------|----------|
- * | Function   | icb       | The identifier of the output circular buffer (CB) | uint32_t | 0 to 31     | True     |
- * | Function   | num_tiles | Number of tiles to configure the packer for       | uint32_t | 1 to 8      | False    |
- */
-// clang-format on
-ALWI void pack_init(uint32_t icb, uint32_t num_tiles = 1) {
-    PACK((llk_pack_init<false, false, false>(icb, num_tiles)));
-}
-
-
 // clang-format off
 /**
  * Copies a block of tiles from the DEST register buffer starting at a specified index

--- a/tt_metal/hw/inc/api/compute/pack.h
+++ b/tt_metal/hw/inc/api/compute/pack.h
@@ -62,6 +62,26 @@ ALWI void pack_tile(uint32_t ifrom_dst, uint32_t icb, std::uint32_t output_tile_
     PACK((llk_pack<DST_ACCUM_MODE, out_of_order_output, false>(ifrom_dst, icb, output_tile_index)));
 }
 
+
+
+// clang-format off
+/**
+ * Initializes the packer with a specified tile count. This function configures the packer
+ * to operate with a specific number of tiles in the destination register.
+ *
+ * Return value: None
+ *
+ * | Param Type | Name      | Description                                       | Type     | Valid Range | Required |
+ * |------------|-----------|---------------------------------------------------|----------|-------------|----------|
+ * | Function   | icb       | The identifier of the output circular buffer (CB) | uint32_t | 0 to 31     | True     |
+ * | Function   | num_tiles | Number of tiles to configure the packer for       | uint32_t | 1 to 8      | False    |
+ */
+// clang-format on
+ALWI void pack_init(uint32_t icb, uint32_t num_tiles = 1) {
+    PACK((llk_pack_init<false, false, false>(icb, num_tiles)));
+}
+
+
 // clang-format off
 /**
  * Copies a block of tiles from the DEST register buffer starting at a specified index


### PR DESCRIPTION
### Ticket
N/A

### Problem description
SDPA would benefit from reducing the load on TRISC2 as we will move the first sub_exp (the ultra-fast one) to that thread. Current `pack_tile` and `pack_tile_block` reprogram L1 address for each tile, providing no benefit when multiple contiguous tiles are packed from DEST.

### What's changed
We're changing LLK API layer for Blackhole packer to optionally accept `num_tiles` (only affects `llk_pack_mop_config` and `llk_pack_init`) and we're adding a new file `pack_custom.h` that has two new Compute APIs: `pack_block_init_custom` and `pack_block_custom` that will allow the users to initialize the packer with the number of tiles needed for packing.  

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=ldjurovic/pack_dest_bank)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:ldjurovic/pack_dest_bank)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ldjurovic/pack_dest_bank)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ldjurovic/pack_dest_bank)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ldjurovic/pack_dest_bank)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ldjurovic/pack_dest_bank)
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ldjurovic/pack_dest_bank)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ldjurovic/pack_dest_bank)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ldjurovic/pack_dest_bank)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ldjurovic/pack_dest_bank)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ldjurovic/pack_dest_bank)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ldjurovic/pack_dest_bank)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
