### PR TITLE
[skip ci] Enable watcher apc nightly debug

### DIFF
--- a/.github/workflows/_auto-retry-post-commit.yaml
+++ b/.github/workflows/_auto-retry-post-commit.yaml
@@ -19,6 +19,7 @@ on:
       # to want to to
       - "zzz TG Quick tests"
       - "apc nightly debug run"
+      - "apc nightly debug run with watcher"
     types:
       - completed
 

--- a/.github/workflows/_produce-data.yaml
+++ b/.github/workflows/_produce-data.yaml
@@ -37,6 +37,7 @@ on:
       - "All post-commit tests"
       - "PR - All post-commit tests"
       - "apc nightly debug run"
+      - "apc nightly debug run with watcher"
       - "(Single-card) Model perf tests"
       - "(Single-card) Device perf regressions"
       - "(Single-card) Demo tests"

--- a/.github/workflows/all-post-commit-workflows.yaml
+++ b/.github/workflows/all-post-commit-workflows.yaml
@@ -288,7 +288,7 @@ jobs:
         test-group: [
           { arch: wormhole_b0, runner-label: N300 },
         ]
-    if: ${{ needs.tests-to-run.outputs.run-profiler-regression == 'true' && !inputs.enable-watcher && !inputs.enable-lightweight-kernel-asserts}}
+    if: ${{ needs.tests-to-run.outputs.run-profiler-regression == 'true'}}
     uses: ./.github/workflows/run-profiler-regression.yaml
     secrets: inherit
     with:

--- a/.github/workflows/apc-nightly-debug.yaml
+++ b/.github/workflows/apc-nightly-debug.yaml
@@ -4,6 +4,8 @@ on:
   schedule:
     # Runs nightly at 12:00 AM UTC
     - cron: "0 0 * * *"
+    # Runs nightly at 1:00 AM UTC with watcher enabled (Ubuntu 22.04 only)
+    - cron: "0 1 * * *"
 
   workflow_dispatch:
     inputs:
@@ -11,6 +13,10 @@ on:
         default: false
         type: boolean
         description: "Enable Link Time Optimization (LTO)"
+      enable-watcher:
+        default: false
+        type: boolean
+        description: "Enable watcher (Ubuntu 22.04 only)"
 
 permissions:
   actions: read
@@ -23,7 +29,8 @@ permissions:
 
 jobs:
   nightly-debug:
-    name: apc nightly debug run (${{ matrix.platform }})
+    name: apc nightly debug run (${{ matrix.platform }}${{ (github.event.schedule == '0 1 * * *' || inputs.enable-watcher) && matrix.platform == 'Ubuntu 22.04' && ' with watcher' || '' }})
+    if: ${{ github.event.schedule != '0 1 * * *' || github.event_name == 'workflow_dispatch' }}
     strategy:
       matrix:
         platform: ["Ubuntu 22.04", "Ubuntu 24.04"]
@@ -35,12 +42,16 @@ jobs:
       enable-lto: ${{ inputs.enable-lto || false }}
 
   nightly-debug-watcher:
-    name: apc nightly debug run (Ubuntu 22.04 with watcher)
+    name: apc nightly debug run (${{ matrix.platform }} with watcher)
+    if: ${{ github.event.schedule == '0 1 * * *' || (github.event_name == 'workflow_dispatch' && inputs.enable-watcher) }}
+    strategy:
+      matrix:
+        platform: ["Ubuntu 22.04", "Ubuntu 24.04"]
     uses: ./.github/workflows/all-post-commit-workflows.yaml
     secrets: inherit
     with:
       build-type: RelWithDebInfo
-      platform: "Ubuntu 22.04"
+      platform: ${{ matrix.platform }}
       enable-lto: ${{ inputs.enable-lto || false }}
       enable-watcher: true
       run-profiler-regression: false

--- a/.github/workflows/apc-nightly-debug.yaml
+++ b/.github/workflows/apc-nightly-debug.yaml
@@ -16,7 +16,7 @@ on:
       enable-watcher:
         default: false
         type: boolean
-        description: "Enable watcher (Ubuntu 22.04 only)"
+        description: "Enable watcher"
 
 permissions:
   actions: read

--- a/.github/workflows/apc-nightly-debug.yaml
+++ b/.github/workflows/apc-nightly-debug.yaml
@@ -1,5 +1,7 @@
 name: "apc nightly debug run"
 
+run-name: "apc nightly debug run${{ github.event.schedule == '0 1 * * *' && ' with watcher' || (inputs.enable-watcher && ' with watcher' || '') }}"
+
 on:
   schedule:
     # Runs nightly at 12:00 AM UTC
@@ -28,22 +30,22 @@ permissions:
   checks: write
 
 jobs:
-  nightly-debug:
-    name: apc nightly debug run (${{ matrix.platform }}${{ (github.event.schedule == '0 1 * * *' || inputs.enable-watcher) && matrix.platform == 'Ubuntu 22.04' && ' with watcher' || '' }})
-    if: ${{ github.event.schedule != '0 1 * * *' || github.event_name == 'workflow_dispatch' }}
-    strategy:
-      matrix:
-        platform: ["Ubuntu 22.04", "Ubuntu 24.04"]
-    uses: ./.github/workflows/all-post-commit-workflows.yaml
-    secrets: inherit
-    with:
-      build-type: RelWithDebInfo
-      platform: ${{ matrix.platform }}
-      enable-lto: ${{ inputs.enable-lto || false }}
+  determine-watcher:
+    runs-on: ubuntu-latest
+    outputs:
+      enable-watcher: ${{ steps.check.outputs.enable-watcher }}
+    steps:
+      - id: check
+        run: |
+          if [[ "${{ github.event.schedule }}" == "0 1 * * *" || "${{ inputs.enable-watcher }}" == "true" ]]; then
+            echo "enable-watcher=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "enable-watcher=false" >> "$GITHUB_OUTPUT"
+          fi
 
-  nightly-debug-watcher:
-    name: apc nightly debug run (${{ matrix.platform }} with watcher)
-    if: ${{ github.event.schedule == '0 1 * * *' || (github.event_name == 'workflow_dispatch' && inputs.enable-watcher) }}
+  nightly-debug:
+    name: apc nightly debug run (${{ matrix.platform }}${{ needs.determine-watcher.outputs.enable-watcher == 'true' && ' with watcher' || '' }})
+    needs: determine-watcher
     strategy:
       matrix:
         platform: ["Ubuntu 22.04", "Ubuntu 24.04"]
@@ -53,7 +55,7 @@ jobs:
       build-type: RelWithDebInfo
       platform: ${{ matrix.platform }}
       enable-lto: ${{ inputs.enable-lto || false }}
-      enable-watcher: true
-      run-profiler-regression: false
-      run-models-unit-tests: false
-      run-ops-unit-tests: false
+      enable-watcher: ${{ needs.determine-watcher.outputs.enable-watcher == 'true' }}
+      run-profiler-regression: ${{ needs.determine-watcher.outputs.enable-watcher != 'true' }}
+      run-models-unit-tests: ${{ needs.determine-watcher.outputs.enable-watcher != 'true' }}
+      run-ops-unit-tests: ${{ needs.determine-watcher.outputs.enable-watcher != 'true' }}

--- a/.github/workflows/apc-nightly-debug.yaml
+++ b/.github/workflows/apc-nightly-debug.yaml
@@ -56,6 +56,7 @@ jobs:
       platform: ${{ matrix.platform }}
       enable-lto: ${{ inputs.enable-lto || false }}
       enable-watcher: ${{ needs.determine-watcher.outputs.enable-watcher == 'true' }}
-      run-profiler-regression: ${{ needs.determine-watcher.outputs.enable-watcher != 'true' }}
-      run-models-unit-tests: ${{ needs.determine-watcher.outputs.enable-watcher != 'true' }}
+      run-ttnn-unit-tests: ${{ needs.determine-watcher.outputs.enable-watcher != 'true' }}
+      run-tt-train-cpp-unit-tests: ${{ needs.determine-watcher.outputs.enable-watcher != 'true' }}
+      run-t3000-apc-fast-tests: ${{ needs.determine-watcher.outputs.enable-watcher != 'true' }}
       run-ops-unit-tests: ${{ needs.determine-watcher.outputs.enable-watcher != 'true' }}

--- a/.github/workflows/apc-nightly-debug.yaml
+++ b/.github/workflows/apc-nightly-debug.yaml
@@ -57,5 +57,5 @@ jobs:
       enable-lto: ${{ inputs.enable-lto || false }}
       enable-watcher: ${{ needs.determine-watcher.outputs.enable-watcher == 'true' }}
       run-profiler-regression: ${{ needs.determine-watcher.outputs.enable-watcher != 'true' }}
-      run-models-unit-tests: ${{ needs.determine-watcher.outputs.enable-watcher != 'true' }}
       run-ops-unit-tests: ${{ needs.determine-watcher.outputs.enable-watcher != 'true' }}
+      run-t3000-apc-fast-tests: ${{ needs.determine-watcher.outputs.enable-watcher != 'true' }}

--- a/.github/workflows/apc-nightly-debug.yaml
+++ b/.github/workflows/apc-nightly-debug.yaml
@@ -23,20 +23,26 @@ permissions:
 
 jobs:
   nightly-debug:
-    name: apc nightly debug run (${{ matrix.platform }}${{ matrix.enable-watcher && ' with watcher' || '' }})
+    name: apc nightly debug run (${{ matrix.platform }})
     strategy:
       matrix:
-        include:
-          - platform: "Ubuntu 22.04"
-            enable-watcher: false
-          - platform: "Ubuntu 22.04"
-            enable-watcher: true
-          - platform: "Ubuntu 24.04"
-            enable-watcher: false
+        platform: ["Ubuntu 22.04", "Ubuntu 24.04"]
     uses: ./.github/workflows/all-post-commit-workflows.yaml
     secrets: inherit
     with:
       build-type: RelWithDebInfo
       platform: ${{ matrix.platform }}
       enable-lto: ${{ inputs.enable-lto || false }}
-      enable-watcher: ${{ matrix.enable-watcher }}
+
+  nightly-debug-watcher:
+    name: apc nightly debug run (Ubuntu 22.04 with watcher)
+    uses: ./.github/workflows/all-post-commit-workflows.yaml
+    secrets: inherit
+    with:
+      build-type: RelWithDebInfo
+      platform: "Ubuntu 22.04"
+      enable-lto: ${{ inputs.enable-lto || false }}
+      enable-watcher: true
+      run-profiler-regression: false
+      run-models-unit-tests: false
+      run-ops-unit-tests: false

--- a/.github/workflows/apc-nightly-debug.yaml
+++ b/.github/workflows/apc-nightly-debug.yaml
@@ -23,13 +23,20 @@ permissions:
 
 jobs:
   nightly-debug:
-    name: apc nightly debug run (${{ matrix.platform }})
+    name: apc nightly debug run (${{ matrix.platform }}${{ matrix.enable-watcher && ' with watcher' || '' }})
     strategy:
       matrix:
-        platform: ["Ubuntu 22.04", "Ubuntu 24.04"]
+        include:
+          - platform: "Ubuntu 22.04"
+            enable-watcher: false
+          - platform: "Ubuntu 22.04"
+            enable-watcher: true
+          - platform: "Ubuntu 24.04"
+            enable-watcher: false
     uses: ./.github/workflows/all-post-commit-workflows.yaml
     secrets: inherit
     with:
       build-type: RelWithDebInfo
       platform: ${{ matrix.platform }}
       enable-lto: ${{ inputs.enable-lto || false }}
+      enable-watcher: ${{ matrix.enable-watcher }}

--- a/.github/workflows/apc-nightly-debug.yaml
+++ b/.github/workflows/apc-nightly-debug.yaml
@@ -56,7 +56,6 @@ jobs:
       platform: ${{ matrix.platform }}
       enable-lto: ${{ inputs.enable-lto || false }}
       enable-watcher: ${{ needs.determine-watcher.outputs.enable-watcher == 'true' }}
-      run-ttnn-unit-tests: ${{ needs.determine-watcher.outputs.enable-watcher != 'true' }}
-      run-tt-train-cpp-unit-tests: ${{ needs.determine-watcher.outputs.enable-watcher != 'true' }}
-      run-t3000-apc-fast-tests: ${{ needs.determine-watcher.outputs.enable-watcher != 'true' }}
+      run-profiler-regression: ${{ needs.determine-watcher.outputs.enable-watcher != 'true' }}
+      run-models-unit-tests: ${{ needs.determine-watcher.outputs.enable-watcher != 'true' }}
       run-ops-unit-tests: ${{ needs.determine-watcher.outputs.enable-watcher != 'true' }}

--- a/.github/workflows/apc-nightly-debug.yaml
+++ b/.github/workflows/apc-nightly-debug.yaml
@@ -4,7 +4,7 @@ on:
   schedule:
     # Runs nightly at 12:00 AM UTC
     - cron: "0 0 * * *"
-    # Runs nightly at 1:00 AM UTC with watcher enabled (Ubuntu 22.04 only)
+    # Runs nightly at 1:00 AM UTC with watcher enabled
     - cron: "0 1 * * *"
 
   workflow_dispatch:


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/37103)

### Problem description
Currently we don't have watcher enabled in nightly jobs

### What's changed
Create 2 cron jobs in apc debug nightly:
1. The same as before
2. Run with watcher enabled with set of tests that are green when watcher enabled

We needed to create 2 jobs, because we have clash in artifacts naming which then fails whole workflow

Added input for watcher when manually triggered

Removed skip for run profiler tests in all post commit workflow as we have inputs to define this

### Checklist

- [ ] [![apc nightly debug run](https://github.com/tenstorrent/tt-metal/actions/workflows/apc-nightly-debug.yaml/badge.svg?branch=dpopov-enable-watcher-apc-nightly-debug)](https://github.com/tenstorrent/tt-metal/actions/workflows/apc-nightly-debug.yamlquery=branch:dpopov-enable-watcher-apc-nightly-debug)
