### PR TITLE
SDXL fix clip encoders

### DIFF
--- a/models/experimental/stable_diffusion_xl_base/tests/pcc/test_sdxl_clip_encoders.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/pcc/test_sdxl_clip_encoders.py
@@ -117,10 +117,11 @@ def test_clip_encoder(
         layer_norm_eps=hf_model.config.layer_norm_eps,
         attention_dropout=hf_model.config.attention_dropout,
         hidden_act=hf_model.config.hidden_act,
+        projection_dim=hf_model.config.projection_dim if has_projection else None,
     )
 
     tt_clip = CLIPEncoder(config, mesh_device, ccl_manager, parallel_config, eos_token_id)
-    tt_clip.load_state_dict(hf_model.state_dict())
+    tt_clip.load_torch_state_dict(hf_model.state_dict())
     logger.info(f"text encoder creation time: {time.time() - start_time}")
 
     # cannot use randn tensor, since HF tokenizer appends a specific eos token syntax
@@ -151,14 +152,14 @@ def test_clip_encoder(
     logger.info(f"HF text encoder 1 pooled output mean: {pooled_output.mean():.6f}, std: {pooled_output.std():.6f}")
 
     logger.info("compiling text encoder...")
-    tt_clip(tt_tokens, mesh_device, with_projection=has_projection)
+    tt_clip(tt_tokens, mesh_device)
 
     logger.info("executing text encoder...")
     start_time = time.time()
 
     ttnn.ReadDeviceProfiler(mesh_device)
 
-    tt_sequence_output, tt_projected_output = tt_clip(tt_tokens, mesh_device, with_projection=has_projection)
+    tt_sequence_output, tt_projected_output = tt_clip(tt_tokens, mesh_device)
 
     logger.info(f"text encoder TT-NN runtime: {time.time() - start_time}")
     logger.info("text encoder done...")

--- a/models/experimental/stable_diffusion_xl_base/tests/test_common.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/test_common.py
@@ -81,7 +81,7 @@ def create_tt_clip_text_encoders(pipeline, ttnn_device):
         tt_text_encoder = CLIPEncoder(
             config_1, ttnn_device, ccl_manager, parallel_config_1, text_encoder_1.config.eos_token_id
         )
-        tt_text_encoder.load_state_dict(text_encoder_1.state_dict())
+        tt_text_encoder.load_torch_state_dict(text_encoder_1.state_dict())
     else:
         tt_text_encoder = None
 
@@ -96,6 +96,7 @@ def create_tt_clip_text_encoders(pipeline, ttnn_device):
         layer_norm_eps=text_encoder_2.config.layer_norm_eps,
         attention_dropout=text_encoder_2.config.attention_dropout,
         hidden_act=text_encoder_2.config.hidden_act,
+        projection_dim=text_encoder_2.config.projection_dim,
     )
 
     # Note: Factor for SDXL CLIP encoder should always be 1; since it doesn't support TP
@@ -106,7 +107,7 @@ def create_tt_clip_text_encoders(pipeline, ttnn_device):
     tt_text_encoder_2 = CLIPEncoder(
         config_2, ttnn_device, ccl_manager, parallel_config_2, text_encoder_2.config.eos_token_id
     )
-    tt_text_encoder_2.load_state_dict(text_encoder_2.state_dict())
+    tt_text_encoder_2.load_torch_state_dict(text_encoder_2.state_dict())
 
     return tt_text_encoder, tt_text_encoder_2
 
@@ -130,7 +131,7 @@ def warmup_tt_text_encoders(tt_text_encoder, tt_text_encoder_2, tokenizer, token
             device=ttnn_device,
             mesh_mapper=ttnn.ShardTensorToMesh(ttnn_device, dim=0),
         )
-        _, _ = tt_text_encoder(tt_tokens_1, ttnn_device, with_projection=False)
+        _, _ = tt_text_encoder(tt_tokens_1, ttnn_device)
 
     dummy_ids_2 = tokenizer_2(
         dummy_prompt,
@@ -146,7 +147,7 @@ def warmup_tt_text_encoders(tt_text_encoder, tt_text_encoder_2, tokenizer, token
         device=ttnn_device,
         mesh_mapper=ttnn.ShardTensorToMesh(ttnn_device, dim=0),
     )
-    _, _ = tt_text_encoder_2(tt_tokens_2, ttnn_device, with_projection=True)
+    _, _ = tt_text_encoder_2(tt_tokens_2, ttnn_device)
     ttnn.synchronize_device(ttnn_device)
 
 
@@ -342,7 +343,7 @@ def batch_encode_prompt_on_device(
                 mesh_mapper=ttnn.ShardTensorToMesh(ttnn_device, dim=0),
             )
 
-            tt_sequence_output, tt_pooled_output = text_encoder(tt_tokens, ttnn_device, with_projection=with_projection)
+            tt_sequence_output, tt_pooled_output = text_encoder(tt_tokens, ttnn_device)
 
             tt_sequence_output_torch = ttnn.to_torch(
                 tt_sequence_output[-2],
@@ -429,9 +430,7 @@ def batch_encode_prompt_on_device(
                 device=ttnn_device,
                 mesh_mapper=ttnn.ShardTensorToMesh(ttnn_device, dim=0),
             )
-            tt_sequence_output_neg, tt_pooled_output_neg = text_encoder(
-                tt_tokens, ttnn_device, with_projection=with_projection
-            )
+            tt_sequence_output_neg, tt_pooled_output_neg = text_encoder(tt_tokens, ttnn_device)
             tt_sequence_output_neg_torch = ttnn.to_torch(
                 tt_sequence_output_neg[-2],
                 mesh_composer=ConcatMeshToTensor(ttnn_device, dim=0),


### PR DESCRIPTION
### Problem description
PR #37117 refactored CLIPEncoder in models/tt_dit. As part of this refactor, all tt_dit models are now derived from the Module base class. This changed the API in several ways:

- `load_state_dict()` was deprecated in favor of `load_torch_state_dict()`
- `with_projection` parameter was removed from CLIPEncoder.forward()
- CLIPConfig now requires `projection_dim` to be explicitly set for encoders that use text projection (e.g. CLIP text encoder 2)

The SDXL experimental model tests were not updated to reflect these changes, causing failures in the PCC tests, demo, and accuracy tests in Metal and Shield CI

### Checklist
- [x] [SDXL (Single-card) Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/runs/21907904407) passes
- [x] [(Single-card) Demo tests](https://github.com/tenstorrent/tt-metal/actions/runs/21907871281) passes
