### PR TITLE
[DM] Update data movement multi_interleaved tests

### DIFF
--- a/tests/tt_metal/tt_metal/data_movement/multi_interleaved/kernels/barrier_sync.hpp
+++ b/tests/tt_metal/tt_metal/data_movement/multi_interleaved/kernels/barrier_sync.hpp
@@ -1,0 +1,50 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <stdint.h>
+#include "api/dataflow/dataflow_api.h"
+
+/**
+ * @brief Wait for all cores to reach the barrier before proceeding.
+ *
+ * This implements a global barrier synchronization where:
+ * 1. Each core increments a semaphore on the coordinator core
+ * 2. Each core polls the coordinator's semaphore until it equals num_cores
+ * 3. Once all cores have arrived, they all proceed simultaneously
+ *
+ * @param barrier_sem_id      Semaphore ID (call get_semaphore() to get L1 address)
+ * @param barrier_coord_x     Physical X coordinate of the coordinator core
+ * @param barrier_coord_y     Physical Y coordinate of the coordinator core
+ * @param num_cores           Total number of cores participating in the barrier
+ * @param local_scratch_addr  Local L1 address for polling scratch space (4 bytes)
+ */
+FORCE_INLINE void barrier_sync(
+    uint32_t barrier_sem_id,
+    uint32_t barrier_coord_x,
+    uint32_t barrier_coord_y,
+    uint32_t num_cores,
+    uint32_t local_scratch_addr) {
+    // Get the L1 address of the barrier semaphore (same logical address on all cores)
+    uint32_t barrier_sem_addr = get_semaphore(barrier_sem_id);
+
+    // Get NOC address of coordinator's barrier semaphore
+    uint64_t barrier_noc_addr = get_noc_addr(barrier_coord_x, barrier_coord_y, barrier_sem_addr);
+
+    // Increment the coordinator's semaphore to signal this core has arrived
+    noc_semaphore_inc(barrier_noc_addr, 1);
+    noc_async_atomic_barrier();
+
+    // Poll the coordinator's semaphore until all cores have arrived
+    // We read from the coordinator's L1 into our local scratch space
+    volatile tt_l1_ptr uint32_t* local_poll_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(local_scratch_addr);
+    *local_poll_ptr = 0;
+
+    while (*local_poll_ptr < num_cores) {
+        // Read coordinator's semaphore value into local memory
+        noc_async_read(barrier_noc_addr, local_scratch_addr, sizeof(uint32_t));
+        noc_async_read_barrier();
+    }
+}

--- a/tests/tt_metal/tt_metal/data_movement/multi_interleaved/kernels/multi_interleaved_read.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/multi_interleaved/kernels/multi_interleaved_read.cpp
@@ -2,12 +2,11 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <stdint.h>
 #include <cstdint>
 #include "api/dataflow/dataflow_api.h"
 #include "tensix_types.h"
 #include "api/tensor/tensor_accessor.h"
-#include "tests/tt_metal/tt_metal/data_movement/multi_interleaved/kernels/barrier_sync.hpp"
+#include "barrier_sync.hpp"
 
 // DRAM to L1 read
 void kernel_main() {

--- a/tests/tt_metal/tt_metal/data_movement/multi_interleaved/kernels/multi_interleaved_read.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/multi_interleaved/kernels/multi_interleaved_read.cpp
@@ -13,12 +13,13 @@
 void kernel_main() {
     uint32_t src_addr = get_arg_val<uint32_t>(0);
     uint32_t l1_write_addr = get_arg_val<uint32_t>(1);
+    uint32_t page_offset = get_arg_val<uint32_t>(2);
     // Barrier synchronization args
-    uint32_t barrier_sem_id = get_arg_val<uint32_t>(2);
-    uint32_t barrier_coord_x = get_arg_val<uint32_t>(3);
-    uint32_t barrier_coord_y = get_arg_val<uint32_t>(4);
-    uint32_t num_cores = get_arg_val<uint32_t>(5);
-    uint32_t local_barrier_addr = get_arg_val<uint32_t>(6);  // Local scratch space for polling
+    uint32_t barrier_sem_id = get_arg_val<uint32_t>(3);
+    uint32_t barrier_coord_x = get_arg_val<uint32_t>(4);
+    uint32_t barrier_coord_y = get_arg_val<uint32_t>(5);
+    uint32_t num_cores = get_arg_val<uint32_t>(6);
+    uint32_t local_barrier_addr = get_arg_val<uint32_t>(7);  // Local scratch space for polling
 
     constexpr uint32_t num_of_transactions = get_compile_time_arg_val(0);
     constexpr uint32_t num_pages = get_compile_time_arg_val(1);
@@ -47,7 +48,7 @@ void kernel_main() {
                 if constexpr (sync) {
                     cb_reserve_back(cb_id_in0, 1);
                 }
-                uint64_t noc_addr = s.get_noc_addr(p);
+                uint64_t noc_addr = s.get_noc_addr(page_offset + p);
                 noc_async_read(noc_addr, l1_write_addr + p * page_size_bytes, page_size_bytes);
                 if constexpr (sync) {
                     noc_async_read_barrier();

--- a/tests/tt_metal/tt_metal/data_movement/multi_interleaved/kernels/multi_interleaved_read.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/multi_interleaved/kernels/multi_interleaved_read.cpp
@@ -7,11 +7,18 @@
 #include "api/dataflow/dataflow_api.h"
 #include "tensix_types.h"
 #include "api/tensor/tensor_accessor.h"
+#include "tests/tt_metal/tt_metal/data_movement/multi_interleaved/kernels/barrier_sync.hpp"
 
 // DRAM to L1 read
 void kernel_main() {
     uint32_t src_addr = get_arg_val<uint32_t>(0);
     uint32_t l1_write_addr = get_arg_val<uint32_t>(1);
+    // Barrier synchronization args
+    uint32_t barrier_sem_id = get_arg_val<uint32_t>(2);
+    uint32_t barrier_coord_x = get_arg_val<uint32_t>(3);
+    uint32_t barrier_coord_y = get_arg_val<uint32_t>(4);
+    uint32_t num_cores = get_arg_val<uint32_t>(5);
+    uint32_t local_barrier_addr = get_arg_val<uint32_t>(6);  // Local scratch space for polling
 
     constexpr uint32_t num_of_transactions = get_compile_time_arg_val(0);
     constexpr uint32_t num_pages = get_compile_time_arg_val(1);
@@ -29,6 +36,9 @@ void kernel_main() {
     DeviceTimestampedData("Number of transactions", num_of_transactions * num_pages);
     DeviceTimestampedData("Transaction size in bytes", transaction_size_bytes);
     DeviceTimestampedData("Test id", test_id);
+
+    // Wait for all cores to reach this point before starting data movement
+    barrier_sync(barrier_sem_id, barrier_coord_x, barrier_coord_y, num_cores, local_barrier_addr);
 
     {
         DeviceZoneScopedN("RISCV0");

--- a/tests/tt_metal/tt_metal/data_movement/multi_interleaved/kernels/multi_interleaved_write.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/multi_interleaved/kernels/multi_interleaved_write.cpp
@@ -2,12 +2,11 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <stdint.h>
 #include <cstdint>
 #include "api/dataflow/dataflow_api.h"
 #include "tensix_types.h"
 #include "api/tensor/tensor_accessor.h"
-#include "tests/tt_metal/tt_metal/data_movement/multi_interleaved/kernels/barrier_sync.hpp"
+#include "barrier_sync.hpp"
 
 // L1 to DRAM write
 void kernel_main() {

--- a/tests/tt_metal/tt_metal/data_movement/multi_interleaved/kernels/multi_interleaved_write.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/multi_interleaved/kernels/multi_interleaved_write.cpp
@@ -13,12 +13,13 @@
 void kernel_main() {
     uint32_t dst_addr = get_arg_val<uint32_t>(0);
     uint32_t l1_read_addr = get_arg_val<uint32_t>(1);
+    uint32_t page_offset = get_arg_val<uint32_t>(2);
     // Barrier synchronization args
-    uint32_t barrier_sem_id = get_arg_val<uint32_t>(2);
-    uint32_t barrier_coord_x = get_arg_val<uint32_t>(3);
-    uint32_t barrier_coord_y = get_arg_val<uint32_t>(4);
-    uint32_t num_cores = get_arg_val<uint32_t>(5);
-    uint32_t local_barrier_addr = get_arg_val<uint32_t>(6);  // Local scratch space for polling
+    uint32_t barrier_sem_id = get_arg_val<uint32_t>(3);
+    uint32_t barrier_coord_x = get_arg_val<uint32_t>(4);
+    uint32_t barrier_coord_y = get_arg_val<uint32_t>(5);
+    uint32_t num_cores = get_arg_val<uint32_t>(6);
+    uint32_t local_barrier_addr = get_arg_val<uint32_t>(7);  // Local scratch space for polling
 
     constexpr uint32_t num_of_transactions = get_compile_time_arg_val(0);
     constexpr uint32_t num_pages = get_compile_time_arg_val(1);
@@ -47,7 +48,7 @@ void kernel_main() {
                 if constexpr (sync) {
                     cb_wait_front(cb_id_out0, 1);
                 }
-                uint64_t noc_addr = s.get_noc_addr(p);
+                uint64_t noc_addr = s.get_noc_addr(page_offset + p);
                 noc_async_write(l1_read_addr + p * page_size_bytes, noc_addr, page_size_bytes);
                 if constexpr (sync) {
                     noc_async_write_barrier();

--- a/tests/tt_metal/tt_metal/data_movement/multi_interleaved/test_multi_interleaved.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/multi_interleaved/test_multi_interleaved.cpp
@@ -109,13 +109,17 @@ bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const MultiI
 
     std::vector<uint32_t> l1_addrs;
     std::vector<CoreCoord> core_list = corerange_to_cores(test_config.cores);
+    constexpr uint32_t barrier_scratch_bytes = 2u * sizeof(uint32_t);
+    const uint32_t required_l1_bytes = per_core_size_bytes + barrier_scratch_bytes;
     for (auto& core : core_list) {
         auto [l1_addr, l1_size] = get_l1_address_and_size(mesh_device, core);
         TT_FATAL(
-            l1_size >= per_core_size_bytes,
-            "L1 size {} must be >= per_core_size_bytes {}",
+            l1_size >= required_l1_bytes,
+            "L1 size {} must be >= per_core_size_bytes {} + barrier scratch {} (total {})",
             l1_size,
-            per_core_size_bytes);
+            per_core_size_bytes,
+            barrier_scratch_bytes,
+            required_l1_bytes);
         l1_addrs.push_back(l1_addr);
     }
 

--- a/tests/tt_metal/tt_metal/data_movement/python/stats_collector.py
+++ b/tests/tt_metal/tt_metal/data_movement/python/stats_collector.py
@@ -141,6 +141,8 @@ class StatsCollector:
             grouped_durations = defaultdict(list)
             grouped_bandwidths = defaultdict(list)
             grouped_cores = defaultdict(list)
+            grouped_start_cycles = defaultdict(list)
+            grouped_end_cycles = defaultdict(list)
 
             for entry in dm_stats[riscv]["analysis"]["series"]:
                 run_host_id = entry["duration_type"][0]["run_host_id"]
@@ -154,6 +156,8 @@ class StatsCollector:
                 grouped_durations[run_host_id].append(duration)
                 grouped_bandwidths[run_host_id].append(bandwidth)
                 grouped_cores[run_host_id].append(entry["core"])
+                grouped_start_cycles[run_host_id].append(entry.get("start_cycle", 0))
+                grouped_end_cycles[run_host_id].append(entry.get("end_cycle", 0))
 
             agg = {}
             for run_host_id, durations in grouped_durations.items():
@@ -161,6 +165,8 @@ class StatsCollector:
                 attributes = dm_stats[riscv]["attributes"][run_host_id]
                 test_id = attributes.get("Test id")
                 cores = grouped_cores[run_host_id]
+                start_cycles = grouped_start_cycles[run_host_id]
+                end_cycles = grouped_end_cycles[run_host_id]
 
                 if method == "median":
                     agg_duration = float(np.median(durations))
@@ -173,13 +179,15 @@ class StatsCollector:
 
                 # Calculate combined bandwidth metrics for multi-core tests
                 # Combined bandwidth = total_bytes / wall_clock_time
-                # With barrier sync, max(duration) ~ wall_clock_time (end_of_last - start_of_first)
+                # Wall clock time = end of last core - start of first core
                 num_cores = len(durations)
-                max_duration = float(np.max(durations))
+                min_start = float(np.min(start_cycles)) if start_cycles else 0
+                max_end = float(np.max(end_cycles)) if end_cycles else 0
+                wall_clock_time = max_end - min_start if max_end > min_start else float(np.max(durations))
                 transaction_size = attributes.get("Transaction size in bytes", 0)
                 num_transactions = attributes.get("Number of transactions", 1)
                 total_bytes = num_cores * transaction_size * num_transactions
-                combined_bandwidth = total_bytes / max_duration if max_duration > 0 else 0
+                combined_bandwidth = total_bytes / wall_clock_time if wall_clock_time > 0 else 0
 
                 agg_data = {
                     "duration_cycles": agg_duration,
@@ -192,7 +200,7 @@ class StatsCollector:
                     "num_transactions": num_transactions,
                     # Combined bandwidth metrics
                     "num_cores": num_cores,
-                    "max_duration": max_duration,
+                    "wall_clock_time": wall_clock_time,
                     "total_bytes": total_bytes,
                     "combined_bandwidth": combined_bandwidth,
                 }

--- a/tests/tt_metal/tt_metal/data_movement/python/stats_collector.py
+++ b/tests/tt_metal/tt_metal/data_movement/python/stats_collector.py
@@ -171,6 +171,16 @@ class StatsCollector:
                 else:
                     raise ValueError(f"Unknown method: {method}")
 
+                # Calculate combined bandwidth metrics for multi-core tests
+                # Combined bandwidth = total_bytes / wall_clock_time
+                # With barrier sync, max(duration) ≈ wall_clock_time (end_of_last - start_of_first)
+                num_cores = len(durations)
+                max_duration = float(np.max(durations))
+                transaction_size = attributes.get("Transaction size in bytes", 0)
+                num_transactions = attributes.get("Number of transactions", 1)
+                total_bytes = num_cores * transaction_size * num_transactions
+                combined_bandwidth = total_bytes / max_duration if max_duration > 0 else 0
+
                 agg_data = {
                     "duration_cycles": agg_duration,
                     "bandwidth": agg_bandwidth,
@@ -178,8 +188,13 @@ class StatsCollector:
                     "all_durations": durations,
                     "all_bandwidths": bandwidths,
                     "all_cores": cores,
-                    "transaction_size": attributes.get("Transaction size in bytes"),
-                    "num_transactions": attributes.get("Number of transactions"),
+                    "transaction_size": transaction_size,
+                    "num_transactions": num_transactions,
+                    # Combined bandwidth metrics
+                    "num_cores": num_cores,
+                    "max_duration": max_duration,
+                    "total_bytes": total_bytes,
+                    "combined_bandwidth": combined_bandwidth,
                 }
 
                 # Dynamically add attributes based on test type

--- a/tests/tt_metal/tt_metal/data_movement/python/stats_collector.py
+++ b/tests/tt_metal/tt_metal/data_movement/python/stats_collector.py
@@ -173,7 +173,7 @@ class StatsCollector:
 
                 # Calculate combined bandwidth metrics for multi-core tests
                 # Combined bandwidth = total_bytes / wall_clock_time
-                # With barrier sync, max(duration) ≈ wall_clock_time (end_of_last - start_of_first)
+                # With barrier sync, max(duration) ~ wall_clock_time (end_of_last - start_of_first)
                 num_cores = len(durations)
                 max_duration = float(np.max(durations))
                 transaction_size = attributes.get("Transaction size in bytes", 0)

--- a/tests/tt_metal/tt_metal/data_movement/python/stats_reporter.py
+++ b/tests/tt_metal/tt_metal/data_movement/python/stats_reporter.py
@@ -207,7 +207,7 @@ class StatsReporter:
                                 [
                                     run_stats.get("num_cores", 1),
                                     run_stats.get("total_bytes", 0),
-                                    run_stats.get("max_duration", run_stats["duration_cycles"]),
+                                    run_stats.get("wall_clock_time", run_stats["duration_cycles"]),
                                     run_stats.get("combined_bandwidth", run_stats["bandwidth"]),
                                 ]
                             )

--- a/tests/tt_metal/tt_metal/data_movement/python/stats_reporter.py
+++ b/tests/tt_metal/tt_metal/data_movement/python/stats_reporter.py
@@ -81,7 +81,13 @@ class StatsReporter:
 
                 # Get test metadata if metadata loader is available
                 test_metadata = None
+                bandwidth_mode = "per_core"  # Default to per-core bandwidth
                 if self.metadata_loader is not None:
+                    # Load bandwidth_mode from test_information.yaml
+                    test_info = self.metadata_loader.load_test_information()
+                    test_data = test_info.get("tests", {}).get(test_id, {})
+                    bandwidth_mode = test_data.get("bandwidth_mode", "per_core")
+
                     try:
                         test_metadata = self.metadata_loader.get_test_metadata(test_id, self.arch)
                     except Exception as e:
@@ -104,7 +110,10 @@ class StatsReporter:
                             header.append(column_name)
 
                     # Add any additional optional fields in alphabetical order
-                    optional_fields = sorted([k for k in test_metadata.keys() if k not in standard_fields])
+                    # Exclude bandwidth_mode as it's a config flag, not data
+                    optional_fields = sorted(
+                        [k for k in test_metadata.keys() if k not in standard_fields and k != "bandwidth_mode"]
+                    )
                     for field in optional_fields:
                         column_name = self.metadata_loader.metadata_field_to_column_name(field)
                         header.append(column_name)
@@ -125,12 +134,22 @@ class StatsReporter:
                         break
 
                 # Add performance metrics at the end
-                header.extend(
-                    [
-                        "Latency (cycles)",
-                        "Bandwidth (bytes/cycle)",
-                    ]
-                )
+                if bandwidth_mode == "combined":
+                    header.extend(
+                        [
+                            "Number of Cores",
+                            "Total Bytes",
+                            "Wall Clock Time (cycles)",
+                            "Combined Bandwidth (bytes/cycle)",
+                        ]
+                    )
+                else:
+                    header.extend(
+                        [
+                            "Latency (cycles)",
+                            "Bandwidth (bytes/cycle)",
+                        ]
+                    )
 
                 writer.writerow(header)
 
@@ -155,7 +174,10 @@ class StatsReporter:
                                     row.append(test_metadata[field])
 
                             # Add any additional optional fields in alphabetical order
-                            optional_fields = sorted([k for k in test_metadata.keys() if k not in standard_fields])
+                            # Exclude bandwidth_mode as it's a config flag, not data
+                            optional_fields = sorted(
+                                [k for k in test_metadata.keys() if k not in standard_fields and k != "bandwidth_mode"]
+                            )
                             for field in optional_fields:
                                 value = test_metadata[field]
                                 # If we have profiled data and it's not set in the test_information
@@ -180,12 +202,22 @@ class StatsReporter:
                                 break
 
                         # Add performance metrics at the end
-                        row.extend(
-                            [
-                                run_stats["duration_cycles"],
-                                run_stats["bandwidth"],
-                            ]
-                        )
+                        if bandwidth_mode == "combined":
+                            row.extend(
+                                [
+                                    run_stats.get("num_cores", 1),
+                                    run_stats.get("total_bytes", 0),
+                                    run_stats.get("max_duration", run_stats["duration_cycles"]),
+                                    run_stats.get("combined_bandwidth", run_stats["bandwidth"]),
+                                ]
+                            )
+                        else:
+                            row.extend(
+                                [
+                                    run_stats["duration_cycles"],
+                                    run_stats["bandwidth"],
+                                ]
+                            )
 
                         writer.writerow(row)
 

--- a/tests/tt_metal/tt_metal/data_movement/python/test_data_movement.py
+++ b/tests/tt_metal/tt_metal/data_movement/python/test_data_movement.py
@@ -66,7 +66,9 @@ def run_dm_tests(profile, verbose, gtest_filter, plot, report, arch_name):
 
     # Plot results
     if plot:
-        plotter = Plotter(dm_stats, aggregate_stats, DEFAULT_OUTPUT_DIR, arch, test_id_to_name, test_id_to_comment)
+        plotter = Plotter(
+            dm_stats, aggregate_stats, DEFAULT_OUTPUT_DIR, arch, test_id_to_name, test_id_to_comment, metadata_loader
+        )
         plotter.plot_dm_stats()
 
     # Check performance

--- a/tests/tt_metal/tt_metal/data_movement/python/test_mappings/test_information.yaml
+++ b/tests/tt_metal/tt_metal/data_movement/python/test_mappings/test_information.yaml
@@ -29,6 +29,15 @@
 #       Examples: true for (0,0)->(0,5), false for (0,0)->(2,2)
 #       Leave empty to use real kernel data (same_axis = "")
 #
+# Bandwidth calculation mode:
+#   - bandwidth_mode: How bandwidth is calculated and reported
+#       Values: "per_core" (default) | "combined"
+#       - "per_core": Reports median/average bandwidth per individual core
+#       - "combined": Reports aggregate bandwidth across all cores
+#           combined_bandwidth = total_bytes / wall_clock_time
+#           where wall_clock_time = max(duration) across all cores
+#           Use this for multi-core DRAM tests where cores are synchronized
+#
 # These metadata fields are automatically injected into CSV files when using the --report flag.
 
 tests:
@@ -333,67 +342,85 @@ tests:
 
   110:
     name: "Multi Interleaved Directed Ideal"
+    bandwidth_mode: "combined"
 
   111:
     name: "Multi Interleaved Sizes"
+    bandwidth_mode: "combined"
     # TODO issue #35917
 
   112:
     name: "Multi Interleaved Read Directed Ideal"
+    bandwidth_mode: "combined"
 
   113:
     name: "Multi Interleaved Read Sizes"
     memory_type: "dram"
     mechanism: "unicast"
     pattern: "one_from_one"
+    bandwidth_mode: "combined"
 
   114:
     name: "Multi Interleaved Write Directed Ideal"
+    bandwidth_mode: "combined"
 
   115:
     name: "Multi Interleaved Write Sizes"
+    bandwidth_mode: "combined"
     # TODO issue #35917
 
   116:
     name: "Multi Interleaved 2x2 Directed Ideal"
+    bandwidth_mode: "combined"
 
   117:
     name: "Multi Interleaved 2x2 Sizes"
+    bandwidth_mode: "combined"
     # TODO issue #35917
 
   118:
     name: "Multi Interleaved 2x2 Read Directed Ideal"
+    bandwidth_mode: "combined"
 
   119:
     name: "Multi Interleaved 2x2 Read Sizes"
+    bandwidth_mode: "combined"
     # TODO issue #35917
 
   120:
     name: "Multi Interleaved 2x2 Write Directed Ideal"
+    bandwidth_mode: "combined"
 
   121:
     name: "Multi Interleaved 2x2 Write Sizes"
+    bandwidth_mode: "combined"
     # TODO issue #35917
 
   122:
     name: "Multi Interleaved 6x6 Directed Ideal"
+    bandwidth_mode: "combined"
 
   123:
     name: "Multi Interleaved 6x6 Sizes"
+    bandwidth_mode: "combined"
     # TODO issue #35917
 
   124:
     name: "Multi Interleaved 6x6 Read Directed Ideal"
+    bandwidth_mode: "combined"
 
   125:
     name: "Multi Interleaved 6x6 Read Sizes"
+    bandwidth_mode: "combined"
     # TODO issue #35917
 
   126:
     name: "Multi Interleaved 6x6 Write Directed Ideal"
+    bandwidth_mode: "combined"
 
   127:
     name: "Multi Interleaved 6x6 Write Sizes"
+    bandwidth_mode: "combined"
     # TODO issue #35917
 
   140:


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/37623)

### Problem description
Current DRAM multi_interleaved tests are not measuring DRAM BW correctly.

### What's changed
Added an option to measure the combined bandwidth rather than core specific.
Added synchronization so that every core starts at relatively the same time.


### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=nstamatovic/dm_dram_tests_update)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:nstamatovic/dm_dram_tests_update)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=nstamatovic/dm_dram_tests_update)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:nstamatovic/dm_dram_tests_update)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nstamatovic/dm_dram_tests_update)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nstamatovic/dm_dram_tests_update)
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nstamatovic/dm_dram_tests_update)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nstamatovic/dm_dram_tests_update)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nstamatovic/dm_dram_tests_update)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nstamatovic/dm_dram_tests_update)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nstamatovic/dm_dram_tests_update)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nstamatovic/dm_dram_tests_update)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
