### PR TITLE
Bug fix: Fix profiler flush in dynamic noc mode

### DIFF
--- a/tt_metal/hw/firmware/src/tt-1xx/brisc.cc
+++ b/tt_metal/hw/firmware/src/tt-1xx/brisc.cc
@@ -517,13 +517,6 @@ int main() {
                 auto stack_free = reinterpret_cast<uint32_t (*)()>(kernel_lma)();
                 record_stack_usage(stack_free);
             } else {
-#if defined(PROFILE_KERNEL)
-                // This was not initialized in the kernel
-                // Currently FW does not issue a barrier except when using profiler
-                if (noc_mode == DM_DEDICATED_NOC) {
-                    noc_local_state_init(noc_index);
-                }
-#endif
                 // Brisc is responsible for issuing any noc cmds needed when initializing remote cbs
                 // So have brisc setup remote cb interfaces even when brisc is not in use
                 if (launch_msg_address->kernel_config.enables) {
@@ -563,13 +556,6 @@ int main() {
                     WAYPOINT("NKFD");
                 }
             }
-
-#if defined(PROFILE_KERNEL)
-            if (noc_mode == DM_DYNAMIC_NOC) {
-                // re-init for profiler to able to run barrier in dedicated noc mode
-                noc_local_state_init(noc_index);
-            }
-#endif
 
             uint32_t go_message_index = mailboxes->go_message_index;
             mailboxes->go_messages[go_message_index].signal = RUN_MSG_DONE;

--- a/tt_metal/hw/firmware/src/tt-1xx/brisc.cc
+++ b/tt_metal/hw/firmware/src/tt-1xx/brisc.cc
@@ -517,6 +517,13 @@ int main() {
                 auto stack_free = reinterpret_cast<uint32_t (*)()>(kernel_lma)();
                 record_stack_usage(stack_free);
             } else {
+#if defined(PROFILE_KERNEL)
+                // This was not initialized in the kernel
+                // Currently FW does not issue a barrier except when using profiler
+                if (noc_mode == DM_DEDICATED_NOC) {
+                    noc_local_state_init(noc_index);
+                }
+#endif
                 // Brisc is responsible for issuing any noc cmds needed when initializing remote cbs
                 // So have brisc setup remote cb interfaces even when brisc is not in use
                 if (launch_msg_address->kernel_config.enables) {
@@ -556,6 +563,13 @@ int main() {
                     WAYPOINT("NKFD");
                 }
             }
+
+#if defined(PROFILE_KERNEL)
+            if (noc_mode == DM_DYNAMIC_NOC) {
+                // re-init for profiler to able to run barrier in dedicated noc mode
+                noc_local_state_init(noc_index);
+            }
+#endif
 
             uint32_t go_message_index = mailboxes->go_message_index;
             mailboxes->go_messages[go_message_index].signal = RUN_MSG_DONE;

--- a/tt_metal/tools/profiler/kernel_profiler.hpp
+++ b/tt_metal/tools/profiler/kernel_profiler.hpp
@@ -265,7 +265,16 @@ inline void __attribute__((always_inline)) profiler_noc_async_write_posted(
 FORCE_INLINE
 void profiler_noc_async_flush_posted_write(uint8_t noc = noc_index) {
     WAYPOINT("NPPW");
-    while (!ncrisc_noc_posted_writes_sent(noc));
+#if !defined(KERNEL_BUILD)
+    constexpr uint8_t noc_mode = DM_DEDICATED_NOC;
+#endif
+    if constexpr (noc_mode == DM_DYNAMIC_NOC) {
+        do {
+            invalidate_l1_cache();
+        } while (!ncrisc_dynamic_noc_posted_writes_sent(noc));
+    } else {
+        while (!ncrisc_noc_posted_writes_sent(noc));
+    }
     WAYPOINT("NPPD");
 }
 

--- a/tt_metal/tools/profiler/kernel_profiler.hpp
+++ b/tt_metal/tools/profiler/kernel_profiler.hpp
@@ -275,6 +275,7 @@ void profiler_noc_async_flush_posted_write(uint8_t noc = noc_index) {
     } else {
         while (!ncrisc_noc_posted_writes_sent(noc));
     }
+    invalidate_l1_cache();
     WAYPOINT("NPPD");
 }
 


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
Fixes https://github.com/tenstorrent/tt-metal/issues/37630

Currently, profiler_noc_async_flush_posted_write always uses ncrisc_noc_posted_writes_sent which uses sw counters to check writes have been flushed. In dynamic noc mode, we need to use ncrisc_dynamic_noc_posted_writes_sent (see below for explanation). With the changes, this is essentially identical to noc_async_writes_flushed in the dataflow api.

Explanation:
In dynamic noc mode, the same noc can be used by both brisc and ncrisc so we need to track sw counters for both riscs on each noc as well in order to compare with the the hw counter (NIU_MST_POSTED_WR_REQ_SENT) when performing a flush/barrier. We also need to continually invalidate l1 cache since the counters are on l1 and being updated by both riscs.

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=snadeem/dynamic_noc_profiler_support_v3)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:snadeem/dynamic_noc_profiler_support_v3)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=snadeem/dynamic_noc_profiler_support_v3)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:snadeem/dynamic_noc_profiler_support_v3)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=snadeem/dynamic_noc_profiler_support_v3)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:snadeem/dynamic_noc_profiler_support_v3)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=snadeem/dynamic_noc_profiler_support_v3)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:snadeem/dynamic_noc_profiler_support_v3)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=snadeem/dynamic_noc_profiler_support_v3)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:snadeem/dynamic_noc_profiler_support_v3)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=snadeem/dynamic_noc_profiler_support_v3)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:snadeem/dynamic_noc_profiler_support_v3)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=snadeem/dynamic_noc_profiler_support_v3)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:snadeem/dynamic_noc_profiler_support_v3)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=snadeem/dynamic_noc_profiler_support_v3)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:snadeem/dynamic_noc_profiler_support_v3)