### PR TITLE
Fix LM head norm config for qwen3vl

### DIFF
--- a/models/demos/qwen3_vl/tt/model.py
+++ b/models/demos/qwen3_vl/tt/model.py
@@ -544,7 +544,8 @@ class Transformer(TTTransformer):
             x = ttnn.slice(x, (0, 0, get_last_token, 0), (1, 1, get_last_token + 32, x.shape[-1]))
 
         # Output norm
-        x = self.norm(x, mode=mode)
+        lm_head_norm_config = self.args.get_norm_config("lm_head", mode, None)
+        x = self.norm(x, mode=mode, norm_config=lm_head_norm_config)
 
         if mode == Mode.PREFILL and self.args.get_lm_head_input_mem_config(mode, None).is_sharded():
             x = ttnn.interleaved_to_sharded(x, self.args.get_lm_head_input_mem_config(mode, None))


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/37640

### Problem description
Qwen3VL demo tests were failing due to missing LM Head norm config due to prefetcher PR that refactored the norm configs to be getters called at runtime. It is more ideal for these configs to be called at runtime because the memory configs depending on the inputs.

### What's changed
- Call the getter for norm config since its no longer a construction time arg, it is runtime arg.


#### Model tests
- [Qwen 3 VL demo tests](https://github.com/tenstorrent/tt-metal/actions/runs/21914377259) Passing