### PR TITLE
add wrapraround for neighbor exchange

### DIFF
--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_bh_glx_2d_torus_short_running.yaml
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_bh_glx_2d_torus_short_running.yaml
@@ -80,3 +80,19 @@ Tests:
     patterns:
       - type: all_to_all
         iterations: 1
+
+  - name: "SequentialNeighborExchangeLatency"
+    latency_test_mode: true
+
+    fabric_setup:
+      topology: Torus
+      torus_config: XY
+
+    defaults:
+      ftype: unicast
+      ntype: unicast_write
+      size: 1024
+      num_packets: 128
+
+    patterns:
+      - type: sequential_neighbor_exchange

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_bh_glx_2d_torus_short_running.yaml
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_bh_glx_2d_torus_short_running.yaml
@@ -41,6 +41,22 @@ Tests:
       - type: all_to_all
         iterations: 1
 
+  - name: "SequentialNeighborExchangeLatency"
+    latency_test_mode: true
+
+    fabric_setup:
+      topology: Torus
+      torus_config: XY
+
+    defaults:
+      ftype: unicast
+      ntype: unicast_write
+      size: 1024
+      num_packets: 128
+
+    patterns:
+      - type: sequential_neighbor_exchange
+
 # ================================================
 # Fabric 1D Tests (Line and Ring)
 # ================================================
@@ -80,19 +96,3 @@ Tests:
     patterns:
       - type: all_to_all
         iterations: 1
-
-  - name: "SequentialNeighborExchangeLatency"
-    latency_test_mode: true
-
-    fabric_setup:
-      topology: Torus
-      torus_config: XY
-
-    defaults:
-      ftype: unicast
-      ntype: unicast_write
-      size: 1024
-      num_packets: 128
-
-    patterns:
-      - type: sequential_neighbor_exchange

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_sanity_common.yaml
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_sanity_common.yaml
@@ -554,6 +554,7 @@ Tests:
 
     patterns:
       - type: sequential_neighbor_exchange
+
   - name: "SimpleNOCSelect"
     fabric_setup:
       topology: Linear
@@ -618,3 +619,19 @@ Tests:
           - destination:
               device: [0, 0]
               core: [0, 5]
+
+  - name: "SequentialNeighborExchangeLatency"
+    latency_test_mode: true
+
+    fabric_setup:
+      topology: Torus
+      torus_config: XY
+
+    defaults:
+      ftype: unicast
+      ntype: unicast_write
+      size: 1024
+      num_packets: 128
+
+    patterns:
+      - type: sequential_neighbor_exchange

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_sanity_common.yaml
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_sanity_common.yaml
@@ -619,19 +619,3 @@ Tests:
           - destination:
               device: [0, 0]
               core: [0, 5]
-
-  - name: "SequentialNeighborExchangeLatency"
-    latency_test_mode: true
-
-    fabric_setup:
-      topology: Torus
-      torus_config: XY
-
-    defaults:
-      ftype: unicast
-      ntype: unicast_write
-      size: 1024
-      num_packets: 128
-
-    patterns:
-      - type: sequential_neighbor_exchange

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_common.hpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_common.hpp
@@ -881,12 +881,12 @@ public:
             is_galaxy && (topology_ == Topology::Ring || topology_ == Topology::Torus);
 
         for (const auto& src_node : device_ids) {
+            const auto src_coord = get_device_coord(src_node);
             for (const auto& direction : directions) {
                 std::optional<FabricNodeId> neighbor_opt;
 
                 if (use_coordinate_neighbors) {
                     // Coordinate-based neighbor lookup with boundary wrapping
-                    const auto src_coord = get_device_coord(src_node);
                     const auto neighbor_coord = src_coord.get_neighbor(
                         mesh_shape_,
                         get_step_for_direction(direction),

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_common.hpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_common.hpp
@@ -857,22 +857,19 @@ public:
              cluster_t == tt::tt_metal::ClusterType::BLACKHOLE_GALAXY);
 
         // non-wraparound Ring topology uses perimeter ring
-        if (!is_galaxy && topology_ == Topology::Ring) {
-            for (const auto& src_node : device_ids) {
-                auto ring_neighbors = get_wrap_around_mesh_ring_neighbors(src_node, device_ids);
-                if (ring_neighbors.has_value()) {
-                    auto [forward_neighbor, backward_neighbor] = ring_neighbors.value();
-                    if (forward_neighbor != src_node) {
-                        pairs.emplace_back(src_node, forward_neighbor);
-                    }
-                    if (backward_neighbor != src_node) {
-                        pairs.emplace_back(src_node, backward_neighbor);
-                    }
-                }
-            }
-            return pairs;
+        bool use_perimeter_ring_exchange = !is_galaxy && topology_ == Topology::Ring;
+        if (use_perimeter_ring_exchange) {
+            pairs = get_non_wrap_around_ring_pairs(device_ids);
+        } else {
+            pairs = get_directional_neighbor_pairs(device_ids, is_galaxy);
         }
 
+        return pairs;
+    }
+
+    std::vector<std::pair<FabricNodeId, FabricNodeId>> get_directional_neighbor_pairs(
+        const std::vector<FabricNodeId>& device_ids, bool is_galaxy) const override {
+        std::vector<std::pair<FabricNodeId, FabricNodeId>> pairs;
         const std::vector<RoutingDirection> directions = {
             RoutingDirection::N, RoutingDirection::S, RoutingDirection::E, RoutingDirection::W};
 
@@ -926,7 +923,24 @@ public:
                 }
             }
         }
+        return pairs;
+    }
 
+    std::vector<std::pair<FabricNodeId, FabricNodeId>> get_non_wrap_around_ring_pairs(
+        const std::vector<FabricNodeId>& device_ids) const override {
+        std::vector<std::pair<FabricNodeId, FabricNodeId>> pairs;
+        for (const auto& src_node : device_ids) {
+            auto ring_neighbors = get_wrap_around_mesh_ring_neighbors(src_node, device_ids);
+            if (ring_neighbors.has_value()) {
+                auto [forward_neighbor, backward_neighbor] = ring_neighbors.value();
+                if (forward_neighbor != src_node) {
+                    pairs.emplace_back(src_node, forward_neighbor);
+                }
+                if (backward_neighbor != src_node) {
+                    pairs.emplace_back(src_node, backward_neighbor);
+                }
+            }
+        }
         return pairs;
     }
 

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_interfaces.hpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_interfaces.hpp
@@ -97,6 +97,10 @@ public:
     virtual std::unordered_map<RoutingDirection, uint32_t> get_unidirectional_linear_mcast_hops(
         const FabricNodeId& src_node_id, uint32_t dim) const = 0;
     virtual std::vector<std::pair<FabricNodeId, FabricNodeId>> get_neighbor_exchange_pairs() const = 0;
+    virtual std::vector<std::pair<FabricNodeId, FabricNodeId>> get_non_wrap_around_ring_pairs(
+        const std::vector<FabricNodeId>& device_ids) const = 0;
+    virtual std::vector<std::pair<FabricNodeId, FabricNodeId>> get_directional_neighbor_pairs(
+        const std::vector<FabricNodeId>& device_ids, bool is_galaxy) const = 0;
     virtual std::optional<std::pair<FabricNodeId, FabricNodeId>> get_wrap_around_mesh_ring_neighbors(
         const FabricNodeId& src_node, const std::vector<FabricNodeId>& devices) const = 0;
     virtual std::unordered_map<RoutingDirection, uint32_t> get_wrap_around_mesh_full_or_half_ring_mcast_hops(


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/37635)

### Problem description
Expand neighbor exchange pattern to support wraparound topologies (Ring/Torus)

### What's changed
Chang the neighbor exchange generation pattern to generate different patterns for wraparound topologies when supported.

<img width="1598" height="317" alt="image" src="https://github.com/user-attachments/assets/11f70823-0a06-4af6-8d02-1372ad17d9d3" />


### Checklist
same fails on main
- [x] [![Fabric tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tm-fabric-tests.yaml/badge.svg?branch=nzhao/neighbor-exchange-ring-torus)](https://github.com/tenstorrent/tt-metal/actions/workflows/tm-fabric-tests.yaml?query=branch:nzhao/neighbor-exchange-ring-torus)



#### Model tests
N/A