### PR TITLE
Fix rest of cq for leaks from noc_non_blocking_api - vol #2

### DIFF
--- a/tt_metal/hw/inc/internal/tt-1xx/blackhole/noc_nonblocking_api.h
+++ b/tt_metal/hw/inc/internal/tt-1xx/blackhole/noc_nonblocking_api.h
@@ -340,6 +340,48 @@ inline __attribute__((always_inline)) void noc_increment_nonposted_writes_issued
     noc_nonposted_writes_num_issued[noc] += delta;
 }
 
+/**
+ * Increments the read transactions issued counter by the specified delta.
+ *
+ * Return value: None
+ *
+ * | Argument | Description                                    | Data type | Valid range | Required |
+ * |----------|------------------------------------------------|-----------|-------------|----------|
+ * | noc      | NOC index                                      | uint32_t  | 0 or 1      | True     |
+ * | delta    | Amount to increment the counter by             | uint32_t  | 0..2^32-1   | True     |
+ */
+inline __attribute__((always_inline)) void noc_increment_reads_issued(uint32_t noc, uint32_t delta) {
+    noc_reads_num_issued[noc] += delta;
+}
+
+/**
+ * Increments the nonposted atomic acknowledgments counter by the specified delta.
+ *
+ * Return value: None
+ *
+ * | Argument | Description                                    | Data type | Valid range | Required |
+ * |----------|------------------------------------------------|-----------|-------------|----------|
+ * | noc      | NOC index                                      | uint32_t  | 0 or 1      | True     |
+ * | delta    | Amount to increment the counter by             | uint32_t  | 0..2^32-1   | True     |
+ */
+inline __attribute__((always_inline)) void noc_increment_nonposted_atomics_acked(uint32_t noc, uint32_t delta) {
+    noc_nonposted_atomics_acked[noc] += delta;
+}
+
+/**
+ * Increments the posted write transactions issued counter by the specified delta.
+ *
+ * Return value: None
+ *
+ * | Argument | Description                                    | Data type | Valid range | Required |
+ * |----------|------------------------------------------------|-----------|-------------|----------|
+ * | noc      | NOC index                                      | uint32_t  | 0 or 1      | True     |
+ * | delta    | Amount to increment the counter by             | uint32_t  | 0..2^32-1   | True     |
+ */
+inline __attribute__((always_inline)) void noc_increment_posted_writes_issued(uint32_t noc, uint32_t delta) {
+    noc_posted_writes_num_issued[noc] += delta;
+}
+
 // True if hardware nonposted-writes-sent count has reached expected_count (wrap-around safe).
 inline __attribute__((always_inline)) bool noc_nonposted_writes_sent_at_count(uint32_t noc, uint32_t expected_count) {
     uint32_t sent = NOC_STATUS_READ_REG(noc, NIU_MST_NONPOSTED_WR_REQ_SENT);
@@ -421,6 +463,25 @@ inline __attribute__((always_inline)) void noc_cmd_buf_set_ret_addr(uint32_t noc
 // Debug only: returns NOC_AT_LEN_BE for cmd_buf (transaction length). Requires NOC_LOGGING_ENABLED.
 inline __attribute__((always_inline)) uint32_t noc_debug_read_at_len_be(uint32_t noc, uint32_t cmd_buf) {
     return NOC_CMD_BUF_READ_REG(noc, cmd_buf, NOC_AT_LEN_BE);
+}
+
+// Returns true if the command buffer has the NOC_CMD_VC_LINKED bit set in its control register.
+inline __attribute__((always_inline)) bool noc_cmd_buf_is_linked(uint32_t noc, uint32_t cmd_buf) {
+    return NOC_CMD_BUF_READ_REG(noc, cmd_buf, NOC_CTRL) & NOC_CMD_VC_LINKED;
+}
+
+/**
+ * Sets the nonposted write acknowledgments counter to the specified value.
+ *
+ * Return value: None
+ *
+ * | Argument | Description                                    | Data type | Valid range | Required |
+ * |----------|------------------------------------------------|-----------|-------------|----------|
+ * | noc      | NOC index                                      | uint32_t  | 0 or 1      | True     |
+ * | val      | Value to set the counter to                    | uint32_t  | 0..2^32-1   | True     |
+ */
+inline __attribute__((always_inline)) void noc_set_nonposted_writes_acked(uint32_t noc, uint32_t val) {
+    noc_nonposted_writes_acked[noc] = val;
 }
 
 inline __attribute__((always_inline)) uint32_t noc_get_interim_inline_value_addr(uint32_t noc, uint64_t dst_noc_addr) {

--- a/tt_metal/hw/inc/internal/tt-1xx/blackhole/noc_nonblocking_api.h
+++ b/tt_metal/hw/inc/internal/tt-1xx/blackhole/noc_nonblocking_api.h
@@ -465,7 +465,17 @@ inline __attribute__((always_inline)) uint32_t noc_debug_read_at_len_be(uint32_t
     return NOC_CMD_BUF_READ_REG(noc, cmd_buf, NOC_AT_LEN_BE);
 }
 
-// Returns true if the command buffer has the NOC_CMD_VC_LINKED bit set in its control register.
+/**
+ * Checks whether the specified command buffer has the NOC_CMD_VC_LINKED bit set in its control register.
+ * When linked, the NOC virtual channel is held open between transactions to reduce latency.
+ *
+ * Return value: true if the linked bit is set, false otherwise
+ *
+ * | Argument | Description                                    | Data type | Valid range | Required |
+ * |----------|------------------------------------------------|-----------|-------------|----------|
+ * | noc      | NOC index                                      | uint32_t  | 0 or 1      | True     |
+ * | cmd_buf  | Command buffer index                           | uint32_t  | 0 - 3       | True     |
+ */
 inline __attribute__((always_inline)) bool noc_cmd_buf_is_linked(uint32_t noc, uint32_t cmd_buf) {
     return NOC_CMD_BUF_READ_REG(noc, cmd_buf, NOC_CTRL) & NOC_CMD_VC_LINKED;
 }

--- a/tt_metal/hw/inc/internal/tt-1xx/wormhole/noc_nonblocking_api.h
+++ b/tt_metal/hw/inc/internal/tt-1xx/wormhole/noc_nonblocking_api.h
@@ -310,6 +310,48 @@ inline __attribute__((always_inline)) void noc_increment_nonposted_writes_issued
     noc_nonposted_writes_num_issued[noc] += delta;
 }
 
+/**
+ * Increments the read transactions issued counter by the specified delta.
+ *
+ * Return value: None
+ *
+ * | Argument | Description                                    | Data type | Valid range | Required |
+ * |----------|------------------------------------------------|-----------|-------------|----------|
+ * | noc      | NOC index                                      | uint32_t  | 0 or 1      | True     |
+ * | delta    | Amount to increment the counter by             | uint32_t  | 0..2^32-1   | True     |
+ */
+inline __attribute__((always_inline)) void noc_increment_reads_issued(uint32_t noc, uint32_t delta) {
+    noc_reads_num_issued[noc] += delta;
+}
+
+/**
+ * Increments the nonposted atomic acknowledgments counter by the specified delta.
+ *
+ * Return value: None
+ *
+ * | Argument | Description                                    | Data type | Valid range | Required |
+ * |----------|------------------------------------------------|-----------|-------------|----------|
+ * | noc      | NOC index                                      | uint32_t  | 0 or 1      | True     |
+ * | delta    | Amount to increment the counter by             | uint32_t  | 0..2^32-1   | True     |
+ */
+inline __attribute__((always_inline)) void noc_increment_nonposted_atomics_acked(uint32_t noc, uint32_t delta) {
+    noc_nonposted_atomics_acked[noc] += delta;
+}
+
+/**
+ * Increments the posted write transactions issued counter by the specified delta.
+ *
+ * Return value: None
+ *
+ * | Argument | Description                                    | Data type | Valid range | Required |
+ * |----------|------------------------------------------------|-----------|-------------|----------|
+ * | noc      | NOC index                                      | uint32_t  | 0 or 1      | True     |
+ * | delta    | Amount to increment the counter by             | uint32_t  | 0..2^32-1   | True     |
+ */
+inline __attribute__((always_inline)) void noc_increment_posted_writes_issued(uint32_t noc, uint32_t delta) {
+    noc_posted_writes_num_issued[noc] += delta;
+}
+
 // Returns true if the hardware nonposted-write counter has reached (or passed) expected_count.
 inline __attribute__((always_inline)) bool noc_nonposted_writes_sent_at_count(uint32_t noc, uint32_t expected_count) {
     uint32_t sent = NOC_STATUS_READ_REG(noc, NIU_MST_NONPOSTED_WR_REQ_SENT);
@@ -389,6 +431,25 @@ inline __attribute__((always_inline)) void noc_cmd_buf_set_ret_addr(uint32_t noc
 // Debug only: returns NOC_AT_LEN_BE for cmd_buf (transaction length). Requires NOC_LOGGING_ENABLED.
 inline __attribute__((always_inline)) uint32_t noc_debug_read_at_len_be(uint32_t noc, uint32_t cmd_buf) {
     return NOC_CMD_BUF_READ_REG(noc, cmd_buf, NOC_AT_LEN_BE);
+}
+
+// Returns true if the command buffer has the NOC_CMD_VC_LINKED bit set in its control register.
+inline __attribute__((always_inline)) bool noc_cmd_buf_is_linked(uint32_t noc, uint32_t cmd_buf) {
+    return NOC_CMD_BUF_READ_REG(noc, cmd_buf, NOC_CTRL) & NOC_CMD_VC_LINKED;
+}
+
+/**
+ * Sets the nonposted write acknowledgments counter to the specified value.
+ *
+ * Return value: None
+ *
+ * | Argument | Description                                    | Data type | Valid range | Required |
+ * |----------|------------------------------------------------|-----------|-------------|----------|
+ * | noc      | NOC index                                      | uint32_t  | 0 or 1      | True     |
+ * | val      | Value to set the counter to                    | uint32_t  | 0..2^32-1   | True     |
+ */
+inline __attribute__((always_inline)) void noc_set_nonposted_writes_acked(uint32_t noc, uint32_t val) {
+    noc_nonposted_writes_acked[noc] = val;
 }
 
 template <uint8_t noc_mode = DM_DEDICATED_NOC>

--- a/tt_metal/hw/inc/internal/tt-1xx/wormhole/noc_nonblocking_api.h
+++ b/tt_metal/hw/inc/internal/tt-1xx/wormhole/noc_nonblocking_api.h
@@ -433,7 +433,17 @@ inline __attribute__((always_inline)) uint32_t noc_debug_read_at_len_be(uint32_t
     return NOC_CMD_BUF_READ_REG(noc, cmd_buf, NOC_AT_LEN_BE);
 }
 
-// Returns true if the command buffer has the NOC_CMD_VC_LINKED bit set in its control register.
+/**
+ * Checks whether the specified command buffer has the NOC_CMD_VC_LINKED bit set in its control register.
+ * When linked, the NOC virtual channel is held open between transactions to reduce latency.
+ *
+ * Return value: true if the linked bit is set, false otherwise
+ *
+ * | Argument | Description                                    | Data type | Valid range | Required |
+ * |----------|------------------------------------------------|-----------|-------------|----------|
+ * | noc      | NOC index                                      | uint32_t  | 0 or 1      | True     |
+ * | cmd_buf  | Command buffer index                           | uint32_t  | 0 - 3       | True     |
+ */
 inline __attribute__((always_inline)) bool noc_cmd_buf_is_linked(uint32_t noc, uint32_t cmd_buf) {
     return NOC_CMD_BUF_READ_REG(noc, cmd_buf, NOC_CTRL) & NOC_CMD_VC_LINKED;
 }

--- a/tt_metal/hw/inc/internal/tt-2xx/quasar/noc_nonblocking_api.h
+++ b/tt_metal/hw/inc/internal/tt-2xx/quasar/noc_nonblocking_api.h
@@ -327,6 +327,48 @@ inline __attribute__((always_inline)) void noc_increment_nonposted_writes_issued
     noc_nonposted_writes_num_issued[noc] += delta;
 }
 
+/**
+ * Increments the read transactions issued counter by the specified delta.
+ *
+ * Return value: None
+ *
+ * | Argument | Description                                    | Data type | Valid range | Required |
+ * |----------|------------------------------------------------|-----------|-------------|----------|
+ * | noc      | NOC index                                      | uint32_t  | 0 or 1      | True     |
+ * | delta    | Amount to increment the counter by             | uint32_t  | 0..2^32-1   | True     |
+ */
+inline __attribute__((always_inline)) void noc_increment_reads_issued(uint32_t noc, uint32_t delta) {
+    noc_reads_num_issued[noc] += delta;
+}
+
+/**
+ * Increments the nonposted atomic acknowledgments counter by the specified delta.
+ *
+ * Return value: None
+ *
+ * | Argument | Description                                    | Data type | Valid range | Required |
+ * |----------|------------------------------------------------|-----------|-------------|----------|
+ * | noc      | NOC index                                      | uint32_t  | 0 or 1      | True     |
+ * | delta    | Amount to increment the counter by             | uint32_t  | 0..2^32-1   | True     |
+ */
+inline __attribute__((always_inline)) void noc_increment_nonposted_atomics_acked(uint32_t noc, uint32_t delta) {
+    noc_nonposted_atomics_acked[noc] += delta;
+}
+
+/**
+ * Increments the posted write transactions issued counter by the specified delta.
+ *
+ * Return value: None
+ *
+ * | Argument | Description                                    | Data type | Valid range | Required |
+ * |----------|------------------------------------------------|-----------|-------------|----------|
+ * | noc      | NOC index                                      | uint32_t  | 0 or 1      | True     |
+ * | delta    | Amount to increment the counter by             | uint32_t  | 0..2^32-1   | True     |
+ */
+inline __attribute__((always_inline)) void noc_increment_posted_writes_issued(uint32_t noc, uint32_t delta) {
+    noc_posted_writes_num_issued[noc] += delta;
+}
+
 // True if hardware nonposted-writes-sent count has reached expected_count (wrap-around safe).
 inline __attribute__((always_inline)) bool noc_nonposted_writes_sent_at_count(uint32_t noc, uint32_t expected_count) {
     uint32_t sent = NOC_STATUS_READ_REG(noc, NIU_MST_NONPOSTED_WR_REQ_SENT);
@@ -408,6 +450,25 @@ inline __attribute__((always_inline)) void noc_cmd_buf_set_ret_addr(uint32_t noc
 // Debug only: returns NOC_AT_LEN for cmd_buf (transaction length). Requires NOC_LOGGING_ENABLED.
 inline __attribute__((always_inline)) uint32_t noc_debug_read_at_len_be(uint32_t noc, uint32_t cmd_buf) {
     return NOC_CMD_BUF_READ_REG(noc, cmd_buf, NOC_AT_LEN);
+}
+
+// Returns true if the command buffer has the NOC_CMD_VC_LINKED bit set in its control register.
+inline __attribute__((always_inline)) bool noc_cmd_buf_is_linked(uint32_t noc, uint32_t cmd_buf) {
+    return NOC_CMD_BUF_READ_REG(noc, cmd_buf, NOC_CTRL) & NOC_CMD_VC_LINKED;
+}
+
+/**
+ * Sets the nonposted write acknowledgments counter to the specified value.
+ *
+ * Return value: None
+ *
+ * | Argument | Description                                    | Data type | Valid range | Required |
+ * |----------|------------------------------------------------|-----------|-------------|----------|
+ * | noc      | NOC index                                      | uint32_t  | 0 or 1      | True     |
+ * | val      | Value to set the counter to                    | uint32_t  | 0..2^32-1   | True     |
+ */
+inline __attribute__((always_inline)) void noc_set_nonposted_writes_acked(uint32_t noc, uint32_t val) {
+    noc_nonposted_writes_acked[noc] = val;
 }
 
 inline __attribute__((always_inline)) uint32_t noc_get_interim_inline_value_addr(uint32_t noc, uint64_t dst_noc_addr) {

--- a/tt_metal/hw/inc/internal/tt-2xx/quasar/noc_nonblocking_api.h
+++ b/tt_metal/hw/inc/internal/tt-2xx/quasar/noc_nonblocking_api.h
@@ -452,7 +452,17 @@ inline __attribute__((always_inline)) uint32_t noc_debug_read_at_len_be(uint32_t
     return NOC_CMD_BUF_READ_REG(noc, cmd_buf, NOC_AT_LEN);
 }
 
-// Returns true if the command buffer has the NOC_CMD_VC_LINKED bit set in its control register.
+/**
+ * Checks whether the specified command buffer has the NOC_CMD_VC_LINKED bit set in its control register.
+ * When linked, the NOC virtual channel is held open between transactions to reduce latency.
+ *
+ * Return value: true if the linked bit is set, false otherwise
+ *
+ * | Argument | Description                                    | Data type | Valid range | Required |
+ * |----------|------------------------------------------------|-----------|-------------|----------|
+ * | noc      | NOC index                                      | uint32_t  | 0 or 1      | True     |
+ * | cmd_buf  | Command buffer index                           | uint32_t  | 0 - 3       | True     |
+ */
 inline __attribute__((always_inline)) bool noc_cmd_buf_is_linked(uint32_t noc, uint32_t cmd_buf) {
     return NOC_CMD_BUF_READ_REG(noc, cmd_buf, NOC_CTRL) & NOC_CMD_VC_LINKED;
 }

--- a/tt_metal/impl/dispatch/kernels/cq_relay.hpp
+++ b/tt_metal/impl/dispatch/kernels/cq_relay.hpp
@@ -149,8 +149,8 @@ public:
 #else
         cq_noc_inline_dw_write_with_state<CQ_NOC_INLINE_nDVB>(dst, val, 0xF, noc_idx);
         if constexpr (count) {
-            noc_nonposted_writes_num_issued[noc_idx]++;
-            noc_nonposted_writes_acked[noc_idx]++;
+            noc_increment_nonposted_writes_issued(noc_idx, 1);
+            noc_increment_nonposted_writes_acked(noc_idx, 1);
         }
 #endif
     }
@@ -207,8 +207,8 @@ public:
                 downstream_cmd_buf>(data_ptr, dst_ptr, length, 1, noc_idx);
         }
         if (count) {
-            noc_nonposted_writes_num_issued[noc_idx]++;
-            noc_nonposted_writes_acked[noc_idx]++;
+            noc_increment_nonposted_writes_issued(noc_idx, 1);
+            noc_increment_nonposted_writes_acked(noc_idx, 1);
         }
 #endif
     }

--- a/tt_metal/tools/profiler/kernel_profiler.hpp
+++ b/tt_metal/tools/profiler/kernel_profiler.hpp
@@ -376,13 +376,8 @@ __attribute__((noinline)) void quick_push() {
     (defined(COMPILE_FOR_AERISC) && (COMPILE_FOR_AERISC == 0)))
 
     // tt-metal/issues/22578 - forbid quick_push if any cmd buffer has NOC_CMD_VC_LINKED bit set
-    auto linked_bit_is_set = [](const uint32_t reg_val) { return reg_val & NOC_CMD_VC_LINKED; };
-    uint32_t read_buf_reg = NOC_CMD_BUF_READ_REG(noc_index, read_cmd_buf, NOC_CTRL);
-    uint32_t write_buf_reg = NOC_CMD_BUF_READ_REG(noc_index, write_cmd_buf, NOC_CTRL);
-    uint32_t write_reg_buf_reg = NOC_CMD_BUF_READ_REG(noc_index, write_reg_cmd_buf, NOC_CTRL);
-    uint32_t write_at_buf_reg = NOC_CMD_BUF_READ_REG(noc_index, write_at_cmd_buf, NOC_CTRL);
-    if (linked_bit_is_set(read_buf_reg) || linked_bit_is_set(write_buf_reg) || linked_bit_is_set(write_reg_buf_reg) ||
-        linked_bit_is_set(write_at_buf_reg)) {
+    if (noc_cmd_buf_is_linked(noc_index, read_cmd_buf) || noc_cmd_buf_is_linked(noc_index, write_cmd_buf) ||
+        noc_cmd_buf_is_linked(noc_index, write_reg_cmd_buf) || noc_cmd_buf_is_linked(noc_index, write_at_cmd_buf)) {
         return;
     }
     if (!profiler_control_buffer[DRAM_PROFILER_ADDRESS] || get_dropped_timestamps(myRiscID)) {
@@ -461,9 +456,7 @@ void quick_push_if_linked(uint32_t cmd_buf, bool linked) {
     if (!linked) {
         return;
     }
-    uint32_t cmd_buf_reg_val = NOC_CMD_BUF_READ_REG(noc_index, cmd_buf, NOC_CTRL);
-    bool cmd_buf_currently_linked = cmd_buf_reg_val & NOC_CMD_VC_LINKED;
-    if (!cmd_buf_currently_linked) {
+    if (!noc_cmd_buf_is_linked(noc_index, cmd_buf)) {
         kernel_profiler::quick_push();
     }
 #endif


### PR DESCRIPTION
### Problem description
Next step in fixing encapsulation of noc_non_blocking api from previous [PR](https://github.com/tenstorrent/tt-metal/pull/36959).

### What's changed

#### NOC API (Wormhole / Blackhole / Quasar)

Added new encapsulation helpers to all three architecture headers:
- `noc_increment_reads_issued()`
- `noc_increment_nonposted_atomics_acked()`
- `noc_increment_posted_writes_issued()`
- `noc_set_nonposted_writes_acked()`
- `noc_cmd_buf_is_linked()`

#### Dispatch (`cq_dispatch.cpp`)

Replaced all 9 remaining direct counter array accesses with API wrappers across `process_write_host_h`, `process_write_linear`, `process_write_packed`, `process_write_packed_large`, and `process_go_signal_mcast_cmd`.

#### Relay (`cq_relay.hpp`)

Replaced 4 direct counter increments with `noc_increment_nonposted_writes_issued` / `noc_increment_nonposted_writes_acked`.

#### Profiler (`kernel_profiler.hpp`)

Replaced raw `NOC_CMD_BUF_READ_REG` + `NOC_CMD_VC_LINKED` bit checks with `noc_cmd_buf_is_linked()` in both `quick_push()` and `quick_push_if_linked()`.

After this change, dispatch, relay, and profiler no longer access any raw NOC counter arrays or command-buffer registers directly.

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=vvukomanovic/0226-cq-encapsulation-vol2)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:vvukomanovic/0226-cq-encapsulation-vol2)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=vvukomanovic/0226-cq-encapsulation-vol2)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:vvukomanovic/0226-cq-encapsulation-vol2)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=vvukomanovic/0226-cq-encapsulation-vol2)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:vvukomanovic/0226-cq-encapsulation-vol2)
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=vvukomanovic/0226-cq-encapsulation-vol2)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:vvukomanovic/0226-cq-encapsulation-vol2)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=vvukomanovic/0226-cq-encapsulation-vol2)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:vvukomanovic/0226-cq-encapsulation-vol2)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=vvukomanovic/0226-cq-encapsulation-vol2)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:vvukomanovic/0226-cq-encapsulation-vol2)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
