### PR TITLE
[WATCHER] Increasing timeout for bh post commit with watcher enabled

### DIFF
--- a/.github/workflows/blackhole-post-commit.yaml
+++ b/.github/workflows/blackhole-post-commit.yaml
@@ -222,6 +222,7 @@ jobs:
     with:
       arch: blackhole
       runner-label: ${{ matrix.test-group }}
+      timeout: ${{ (inputs.enable-watcher && 120) || 40 }}
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
       enable-watcher: ${{ inputs.enable-watcher || false }}


### PR DESCRIPTION
### Ticket
[#27840](https://github.com/tenstorrent/tt-metal/issues/27840)

### Problem description
The tests are timing out when watcher is enabled as it can be seen in following [run](https://github.com/tenstorrent/tt-metal/actions/runs/21868604185/job/63117829359). This needs to be increased in order for all the test cases to have enough time to run with watcher. 

### What's changed
Timeout increased only if watcher is enabled.
