### PR TITLE
[skip ci] Remove parallelism as we suspect a race condition somewhere

### DIFF
--- a/.github/workflows/ttsim.yaml
+++ b/.github/workflows/ttsim.yaml
@@ -277,7 +277,7 @@ jobs:
       - name: Run TTNN Pytests - ${{ matrix.test-group.name }}
         run: |
           # Run pytest with parallel execution and skip list
-          ${{ matrix.test-group.cmd }} -n 4 ${{ steps.skip-list.outputs.skip_args }}
+          ${{ matrix.test-group.cmd }} ${{ steps.skip-list.outputs.skip_args }}
 
   ttsim-cpp-unit-tests:
     if: ${{ inputs.run-metal-cpp-unit-tests }}


### PR DESCRIPTION
### Ticket
N/A

### Problem description
Non-deterministic failures are seen during the link stage of the JIT build.  We suspect a race condition somewhere.

### What's changed
Remove parallelism.  Will restore after we hunt down and kill the bug.