### PR TITLE
Improve Include Hygiene

### DIFF
--- a/build_metal.sh
+++ b/build_metal.sh
@@ -434,5 +434,5 @@ fi
 # Build libraries and cpp tests
 if [ "$configure_only" = "OFF" ]; then
     echo "INFO: Building Project"
-    time cmake --build $build_dir --target $target --parallel 32
+    cmake --build $build_dir --target $target
 fi

--- a/build_metal.sh
+++ b/build_metal.sh
@@ -38,6 +38,7 @@ show_help() {
     echo "  --debug                          Set the build type as Debug."
     echo "  --clean                          Remove build workspaces."
     echo "  --build-static-libs              Build tt_metal (not ttnn) as a static lib (BUILD_SHARED_LIBS=OFF)"
+    echo "  --disable-pch                    Disable precompiled headers"
     echo "  --disable-unity-builds           Disable Unity builds"
     echo "  --disable-light-metal-trace      Disable Light Metal tracing to binary."
     echo "  --cxx-compiler-path              Set path to C++ compiler."
@@ -76,6 +77,7 @@ build_umd_tests="OFF"
 build_programming_examples="OFF"
 build_tt_train="OFF"
 build_static_libs="OFF"
+pch="ON"
 unity_builds="ON"
 light_metal_trace="ON"
 build_packages="OFF"
@@ -114,6 +116,7 @@ build-programming-examples
 build-tt-train
 build-packages
 build-static-libs
+disable-pch
 disable-unity-builds
 disable-light-metal-trace
 release
@@ -194,6 +197,8 @@ while true; do
             enable_fake_kernels_target="ON";;
         --enable-lto)
             enable_lto="ON";;
+        --disable-pch)
+	    pch="OFF";;
         --disable-unity-builds)
 	    unity_builds="OFF";;
         --disable-light-metal-trace)
@@ -272,6 +277,7 @@ echo "INFO: Enable time trace: $enable_time_trace"
 echo "INFO: Build directory: $build_dir"
 echo "INFO: Install Prefix: $cmake_install_prefix"
 echo "INFO: Build tests: $build_tests"
+echo "INFO: Enable PCH: $pch"
 echo "INFO: Enable Unity builds: $unity_builds"
 echo "INFO: TTNN Shared sub libs : $ttnn_shared_sub_libs"
 echo "INFO: Enable Light Metal Trace: $light_metal_trace"
@@ -352,6 +358,12 @@ if [ "$build_static_libs" = "ON" ]; then
     cmake_args+=("-DTT_INSTALL=OFF")
 fi
 
+if [ "$pch" = "OFF" ]; then
+    cmake_args+=("-DCMAKE_DISABLE_PRECOMPILE_HEADERS=ON")
+else
+    echo ""
+fi
+
 if [ "$unity_builds" = "ON" ]; then
     cmake_args+=("-DTT_UNITY_BUILDS=ON")
 else
@@ -422,5 +434,5 @@ fi
 # Build libraries and cpp tests
 if [ "$configure_only" = "OFF" ]; then
     echo "INFO: Building Project"
-    cmake --build $build_dir --target $target
+    time cmake --build $build_dir --target $target --parallel 32
 fi

--- a/build_metal.sh
+++ b/build_metal.sh
@@ -360,8 +360,6 @@ fi
 
 if [ "$pch" = "OFF" ]; then
     cmake_args+=("-DCMAKE_DISABLE_PRECOMPILE_HEADERS=ON")
-else
-    echo ""
 fi
 
 if [ "$unity_builds" = "ON" ]; then

--- a/scripts/validate_api/validate_includes.py
+++ b/scripts/validate_api/validate_includes.py
@@ -50,7 +50,6 @@ ALLOWED_PREFIXES = {
     "fmt",
     "enchantum",
     "nlohmann",
-    "tt-logger",
 }
 
 STD_HEADERS = {

--- a/tests/tt_eager/ops/test_bcast_op.cpp
+++ b/tests/tt_eager/ops/test_bcast_op.cpp
@@ -6,7 +6,6 @@
 #include <fmt/base.h>
 #include <enchantum/enchantum.hpp>
 #include <tt-metalium/constants.hpp>
-#include <tt-metalium/host_api.hpp>
 #include <ttnn/operations/functions.hpp>
 #include <array>
 #include <cstring>

--- a/tests/tt_eager/ops/test_bmm_op.cpp
+++ b/tests/tt_eager/ops/test_bmm_op.cpp
@@ -6,7 +6,6 @@
 #include <fmt/base.h>
 #include <cstdint>
 #include <tt-metalium/constants.hpp>
-#include <tt-metalium/host_api.hpp>
 #include <cstring>
 #include <exception>
 #include <optional>

--- a/tests/tt_eager/ops/test_eltwise_binary_op.cpp
+++ b/tests/tt_eager/ops/test_eltwise_binary_op.cpp
@@ -9,9 +9,7 @@
 #include <tt_stl/assert.hpp>
 #include <tt-metalium/bfloat16.hpp>
 #include <tt-metalium/device.hpp>
-#include <tt-metalium/host_api.hpp>
 #include <tt-metalium/shape.hpp>
-#include "ttnn/decorators.hpp"
 #include "ttnn/operations/eltwise/binary/binary.hpp"
 #include "ttnn/operations/functions.hpp"
 #include "ttnn/tensor/host_buffer/functions.hpp"

--- a/tests/tt_eager/ops/test_eltwise_unary_op.cpp
+++ b/tests/tt_eager/ops/test_eltwise_unary_op.cpp
@@ -4,7 +4,6 @@
 
 #include <fmt/base.h>
 #include <tt-metalium/constants.hpp>
-#include <tt-metalium/host_api.hpp>
 #include <algorithm>
 #include <cmath>
 #include <numbers>

--- a/tests/tt_eager/ops/test_layernorm_op.cpp
+++ b/tests/tt_eager/ops/test_layernorm_op.cpp
@@ -4,7 +4,6 @@
 
 #include <cerrno>
 #include <fmt/base.h>
-#include <tt-metalium/host_api.hpp>
 #include <ttnn/operations/functions.hpp>
 #include <cstring>
 #include <exception>
@@ -13,7 +12,6 @@
 #include <tt-metalium/constants.hpp>
 #include <tt-logger/tt-logger.hpp>
 #include <tt-metalium/shape.hpp>
-#include "ttnn/decorators.hpp"
 #include "ttnn/operations/normalization/layernorm/layernorm.hpp"
 #include "ttnn/tensor/shape/shape.hpp"
 #include "ttnn/tensor/tensor.hpp"

--- a/tests/tt_eager/ops/test_sfpu.cpp
+++ b/tests/tt_eager/ops/test_sfpu.cpp
@@ -10,7 +10,6 @@
 #include <cstdlib>
 #include <sys/types.h>
 #include <tt-metalium/bfloat16.hpp>
-#include <tt-metalium/buffer.hpp>
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/tt_metal.hpp>
 #include <algorithm>

--- a/tests/tt_eager/ops/test_softmax_op.cpp
+++ b/tests/tt_eager/ops/test_softmax_op.cpp
@@ -3,14 +3,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <fmt/base.h>
-#include <tt-metalium/host_api.hpp>
-
 #include <tt_stl/assert.hpp>
 #include <tt-metalium/device.hpp>
 #include <tt-metalium/constants.hpp>
 #include <tt-logger/tt-logger.hpp>
 #include <tt-metalium/shape.hpp>
-#include "ttnn/decorators.hpp"
 #include "ttnn/operations/functions.hpp"
 #include "ttnn/operations/normalization/softmax/softmax.hpp"
 #include "ttnn/tensor/shape/shape.hpp"

--- a/tests/tt_eager/tensors/test_host_device_loopback.cpp
+++ b/tests/tt_eager/tensors/test_host_device_loopback.cpp
@@ -5,7 +5,6 @@
 #include <cerrno>
 #include <fmt/base.h>
 #include <tt-metalium/constants.hpp>
-#include <tt-metalium/host_api.hpp>
 #include <cstring>
 #include <exception>
 

--- a/tests/tt_eager/tensors/test_raw_host_memory_pointer.cpp
+++ b/tests/tt_eager/tensors/test_raw_host_memory_pointer.cpp
@@ -5,7 +5,6 @@
 #include <fmt/base.h>
 #include <tt-metalium/bfloat16.hpp>
 #include <tt-metalium/constants.hpp>
-#include <tt-metalium/host_api.hpp>
 #include <algorithm>
 #include <cstdlib>
 #include <functional>

--- a/tests/tt_metal/distributed/test_mesh_device_reshape.cpp
+++ b/tests/tt_metal/distributed/test_mesh_device_reshape.cpp
@@ -15,7 +15,6 @@
 #include <tt-metalium/device.hpp>
 #include <tt-metalium/dispatch_core_common.hpp>
 #include "gmock/gmock.h"
-#include <tt-metalium/host_api.hpp>
 #include "hostdevcommon/common_values.hpp"
 #include <tt-metalium/mesh_config.hpp>
 #include <tt-metalium/mesh_coord.hpp>

--- a/tests/tt_metal/distributed/test_mesh_events.cpp
+++ b/tests/tt_metal/distributed/test_mesh_events.cpp
@@ -14,7 +14,6 @@
 #include <utility>
 #include <vector>
 
-#include <tt-metalium/buffer.hpp>
 #include <tt-metalium/buffer_types.hpp>
 #include <tt-metalium/core_coord.hpp>
 #include <tt-metalium/mesh_buffer.hpp>

--- a/tests/tt_metal/distributed/utils.cpp
+++ b/tests/tt_metal/distributed/utils.cpp
@@ -14,7 +14,6 @@
 #include <variant>
 
 #include <tt_stl/assert.hpp>
-#include <tt-metalium/buffer.hpp>
 #include <tt-metalium/buffer_types.hpp>
 #include <tt-metalium/circular_buffer_constants.h>
 #include <tt-metalium/circular_buffer_config.hpp>

--- a/tests/tt_metal/tt_fabric/fabric_router/test_custom_routing_tables.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_router/test_custom_routing_tables.cpp
@@ -15,7 +15,6 @@
 #include <tt-metalium/experimental/fabric/control_plane.hpp>
 #include "impl/context/metal_context.hpp"
 #include <tt-metalium/distributed_context.hpp>
-#include <tt-logger/tt-logger.hpp>
 #include "tt_metal/fabric/fabric_host_utils.hpp"
 #include "tests/tt_metal/tt_fabric/common/utils.hpp"
 

--- a/tests/tt_metal/tt_metal/api/allocator/test_overlapped_bank_manager.cpp
+++ b/tests/tt_metal/tt_metal/api/allocator/test_overlapped_bank_manager.cpp
@@ -8,7 +8,6 @@
 #include <tt-metalium/allocator.hpp>
 #include <vector>
 
-#include <tt-metalium/buffer.hpp>
 #include <tt-metalium/buffer_types.hpp>
 #include <tt-metalium/device.hpp>
 #include "device_fixture.hpp"

--- a/tests/tt_metal/tt_metal/api/circular_buffer/test_CircularBuffer_creation.cpp
+++ b/tests/tt_metal/tt_metal/api/circular_buffer/test_CircularBuffer_creation.cpp
@@ -4,7 +4,6 @@
 
 #include <cstdint>
 #include <tt-metalium/allocator.hpp>
-#include <tt-metalium/circular_buffer.hpp>
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/tt_metal.hpp>
 #include <map>

--- a/tests/tt_metal/tt_metal/api/circular_buffer/test_CircularBuffer_wrapping.cpp
+++ b/tests/tt_metal/tt_metal/api/circular_buffer/test_CircularBuffer_wrapping.cpp
@@ -2,14 +2,11 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <tt-logger/tt-logger.hpp>
 #include <vector>
 #include "device_fixture.hpp"
 #include "gtest/gtest.h"
 #include "host_api.hpp"
 #include "tt_metal.hpp"
-#include "circular_buffer.hpp"
-
 namespace tt::tt_metal {
 
 /**

--- a/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer_configs.cpp
+++ b/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer_configs.cpp
@@ -12,7 +12,6 @@
 #include <vector>
 
 #include <gtest/gtest.h>
-#include <tt-metalium/buffer.hpp>
 #include <tt-metalium/buffer_types.hpp>
 #include <tt-metalium/core_coord.hpp>
 #include <tt-metalium/device.hpp>

--- a/tests/tt_metal/tt_metal/api/test_core_local_mem_api.cpp
+++ b/tests/tt_metal/tt_metal/api/test_core_local_mem_api.cpp
@@ -9,7 +9,6 @@
 #include <vector>
 #include <random>
 
-#include <tt_stl/assert.hpp>
 #include <tt-metalium/buffer_types.hpp>
 #include <tt-metalium/circular_buffer_config.hpp>
 #include <tt-metalium/core_coord.hpp>

--- a/tests/tt_metal/tt_metal/api/test_dram_to_l1_multicast.cpp
+++ b/tests/tt_metal/tt_metal/api/test_dram_to_l1_multicast.cpp
@@ -15,7 +15,6 @@
 #include <variant>
 #include <vector>
 
-#include <tt-metalium/buffer.hpp>
 #include <tt-metalium/buffer_types.hpp>
 #include <tt-metalium/core_coord.hpp>
 #include <tt-metalium/data_types.hpp>

--- a/tests/tt_metal/tt_metal/debug_tools/dprint/test_print_tensix_dest.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/dprint/test_print_tensix_dest.cpp
@@ -18,7 +18,6 @@
 #include <vector>
 
 #include <tt-metalium/distributed.hpp>
-#include <tt-metalium/buffer.hpp>
 #include <tt-metalium/buffer_types.hpp>
 #include <tt-metalium/circular_buffer_config.hpp>
 #include <tt-metalium/core_coord.hpp>

--- a/tests/tt_metal/tt_metal/debug_tools/dprint/test_print_tile.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/dprint/test_print_tile.cpp
@@ -18,7 +18,6 @@
 
 #include <tt-metalium/distributed.hpp>
 #include <tt-metalium/bfloat16.hpp>
-#include <tt-metalium/buffer.hpp>
 #include <tt-metalium/buffer_types.hpp>
 #include <tt-metalium/circular_buffer_config.hpp>
 #include <tt-metalium/core_coord.hpp>

--- a/tests/tt_metal/tt_metal/device/test_simulator_device.cpp
+++ b/tests/tt_metal/tt_metal/device/test_simulator_device.cpp
@@ -7,7 +7,6 @@
 #include <cstddef>
 #include <cstdint>
 #include <tt-metalium/allocator.hpp>
-#include <tt-metalium/host_api.hpp>
 #include <tt-metalium/tt_metal.hpp>
 #include <algorithm>
 #include <iostream>
@@ -22,14 +21,12 @@
 
 #include <tt-metalium/buffer_types.hpp>
 #include "impl/dispatch/command_queue_common.hpp"
-#include <tt-metalium/core_coord.hpp>
 #include <tt-metalium/data_types.hpp>
 #include <tt-metalium/device.hpp>
 #include "device_fixture.hpp"
 #include <tt-metalium/hal.hpp>
 #include <tt-metalium/hal_types.hpp>
 #include <tt-metalium/kernel_types.hpp>
-#include <tt-logger/tt-logger.hpp>
 #include <tt-metalium/program.hpp>
 #include "impl/context/metal_context.hpp"
 #include "tt_metal/test_utils/stimulus.hpp"

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_event/test_EnqueueWaitForEvent.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_event/test_EnqueueWaitForEvent.cpp
@@ -15,7 +15,6 @@
 #include <variant>
 #include <vector>
 
-#include <tt_stl/assert.hpp>
 #include <tt-metalium/buffer.hpp>
 #include <tt-metalium/buffer_types.hpp>
 #include "impl/dispatch/dispatch_settings.hpp"

--- a/tests/tt_metal/tt_metal/eth/test_eth_multi_txq_rxq.cpp
+++ b/tests/tt_metal/tt_metal/eth/test_eth_multi_txq_rxq.cpp
@@ -7,7 +7,6 @@
 #include <cstdlib>
 #include <umd/device/types/arch.hpp>
 #include <tt-metalium/host_api.hpp>
-#include <tt-logger/tt-logger.hpp>
 #include <cstdint>
 
 #include <tt_stl/assert.hpp>

--- a/tests/tt_metal/tt_metal/integration/matmul/test_matmul_X_tile.cpp
+++ b/tests/tt_metal/tt_metal/integration/matmul/test_matmul_X_tile.cpp
@@ -22,7 +22,6 @@
 
 #include <tt_stl/assert.hpp>
 #include <tt-metalium/base_types.hpp>
-#include <tt-metalium/buffer.hpp>
 #include <tt-metalium/buffer_types.hpp>
 #include <tt-metalium/circular_buffer_config.hpp>
 #include <tt-metalium/core_coord.hpp>

--- a/tests/tt_metal/tt_metal/integration/matmul/test_matmul_large_block.cpp
+++ b/tests/tt_metal/tt_metal/integration/matmul/test_matmul_large_block.cpp
@@ -21,7 +21,6 @@
 
 #include <tt_stl/assert.hpp>
 #include <tt-metalium/base_types.hpp>
-#include <tt-metalium/buffer.hpp>
 #include <tt-metalium/buffer_types.hpp>
 #include <tt-metalium/circular_buffer_config.hpp>
 #include <tt-metalium/core_coord.hpp>

--- a/tests/tt_metal/tt_metal/integration/matmul/test_matmul_single_core.cpp
+++ b/tests/tt_metal/tt_metal/integration/matmul/test_matmul_single_core.cpp
@@ -23,7 +23,6 @@
 #include <vector>
 
 #include <tt_stl/assert.hpp>
-#include <tt-metalium/buffer.hpp>
 #include <tt-metalium/buffer_types.hpp>
 #include <tt-metalium/circular_buffer_config.hpp>
 #include <tt-metalium/core_coord.hpp>

--- a/tests/tt_metal/tt_metal/integration/test_basic_pipeline.cpp
+++ b/tests/tt_metal/tt_metal/integration/test_basic_pipeline.cpp
@@ -26,7 +26,6 @@
 #include <vector>
 
 #include <tt_stl/assert.hpp>
-#include <tt-metalium/buffer.hpp>
 #include <tt-metalium/buffer_types.hpp>
 #include <tt-metalium/circular_buffer_config.hpp>
 #include "command_queue_fixture.hpp"

--- a/tests/tt_metal/tt_metal/integration/test_sfpu_compute.cpp
+++ b/tests/tt_metal/tt_metal/integration/test_sfpu_compute.cpp
@@ -21,7 +21,6 @@
 
 #include <tt_stl/assert.hpp>
 #include <tt-metalium/bfloat16.hpp>
-#include <tt-metalium/buffer.hpp>
 #include <tt-metalium/buffer_types.hpp>
 #include <tt-metalium/circular_buffer_config.hpp>
 #include "command_queue_fixture.hpp"

--- a/tests/tt_metal/tt_metal/integration/vecadd/test_vecadd_multi_core.cpp
+++ b/tests/tt_metal/tt_metal/integration/vecadd/test_vecadd_multi_core.cpp
@@ -16,7 +16,6 @@
 #include <vector>
 
 #include <tt_stl/assert.hpp>
-#include <tt-metalium/buffer.hpp>
 #include <tt-metalium/buffer_types.hpp>
 #include <tt-metalium/circular_buffer_config.hpp>
 #include <tt-metalium/constants.hpp>

--- a/tests/tt_metal/tt_metal/llk/test_broadcast.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_broadcast.cpp
@@ -17,7 +17,6 @@
 #include <tt_stl/assert.hpp>
 #include <tt-metalium/base_types.hpp>
 #include <tt-metalium/bfloat16.hpp>
-#include <tt-metalium/buffer.hpp>
 #include <tt-metalium/buffer_types.hpp>
 #include <tt-metalium/circular_buffer_config.hpp>
 #include <tt-metalium/core_coord.hpp>

--- a/tests/tt_metal/tt_metal/llk/test_mul_reduce_scalar.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_mul_reduce_scalar.cpp
@@ -24,7 +24,6 @@
 #include <tt-metalium/tt_metal.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
 #include <tt-logger/tt-logger.hpp>
-#include <tt_stl/assert.hpp>
 #include <umd/device/types/arch.hpp>
 
 #include "device_fixture.hpp"

--- a/tests/tt_metal/tt_metal/llk/test_reduce.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_reduce.cpp
@@ -22,7 +22,6 @@
 
 #include <tt_stl/assert.hpp>
 #include <tt-metalium/base_types.hpp>
-#include <tt-metalium/buffer.hpp>
 #include <tt-metalium/buffer_types.hpp>
 #include <tt-metalium/circular_buffer_config.hpp>
 #include <tt-metalium/constants.hpp>

--- a/tests/tt_metal/tt_metal/llk/test_single_core_binary_compute.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_single_core_binary_compute.cpp
@@ -21,7 +21,6 @@
 #include <tt_stl/assert.hpp>
 #include <tt-metalium/base_types.hpp>
 #include <tt-metalium/bfloat16.hpp>
-#include <tt-metalium/buffer.hpp>
 #include <tt-metalium/buffer_types.hpp>
 #include <tt-metalium/circular_buffer_config.hpp>
 #include <tt-metalium/core_coord.hpp>

--- a/tests/tt_metal/tt_metal/llk/test_single_core_matmul_int8.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_single_core_matmul_int8.cpp
@@ -18,7 +18,6 @@
 #include <vector>
 
 #include <tt-metalium/bfloat16.hpp>
-#include <tt-metalium/buffer.hpp>
 #include <tt-metalium/buffer_types.hpp>
 #include <tt-metalium/circular_buffer_config.hpp>
 #include <tt-metalium/core_coord.hpp>
@@ -26,7 +25,6 @@
 #include "device_fixture.hpp"
 #include <tt-metalium/distributed.hpp>
 #include <tt-metalium/kernel_types.hpp>
-#include <tt-logger/tt-logger.hpp>
 #include <tt-metalium/program.hpp>
 #include <tt_stl/span.hpp>
 #include <tt-metalium/tt_backend_api_types.hpp>

--- a/tests/tt_metal/tt_metal/llk/test_stochastic_rounding.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_stochastic_rounding.cpp
@@ -9,7 +9,6 @@
 #include <vector>
 
 #include <tt-metalium/bfloat16.hpp>
-#include <tt-metalium/buffer.hpp>
 #include <tt-metalium/buffer_types.hpp>
 #include <tt-metalium/circular_buffer_config.hpp>
 #include <tt-metalium/circular_buffer_constants.h>

--- a/tests/tt_metal/tt_metal/llk/test_unary_broadcast.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_unary_broadcast.cpp
@@ -18,7 +18,6 @@
 
 #include <tt_stl/assert.hpp>
 #include <tt-metalium/bfloat16.hpp>
-#include <tt-metalium/buffer.hpp>
 #include <tt-metalium/buffer_types.hpp>
 #include <tt-metalium/circular_buffer_config.hpp>
 #include <tt-metalium/core_coord.hpp>

--- a/tests/tt_metal/tt_metal/misc/test_tilize_untilize.cpp
+++ b/tests/tt_metal/tt_metal/misc/test_tilize_untilize.cpp
@@ -11,7 +11,6 @@
 
 #include <tt-metalium/bfloat16.hpp>
 #include <tt-metalium/tilize_utils.hpp>
-#include <tt_stl/assert.hpp>
 #include <tt_stl/span.hpp>
 
 namespace {

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/2_noc_rtor/test_noc_rtor.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/2_noc_rtor/test_noc_rtor.cpp
@@ -22,7 +22,6 @@
 #include <variant>
 #include <vector>
 
-#include <tt-metalium/buffer.hpp>
 #include <tt-metalium/buffer_types.hpp>
 #include <tt-metalium/circular_buffer_config.hpp>
 #include <tt-metalium/core_coord.hpp>

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/benchmark_rw_buffer.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/benchmark_rw_buffer.cpp
@@ -7,7 +7,6 @@
 #include <fmt/format.h>
 #include <cstdint>
 #include <tt-metalium/bfloat16.hpp>
-#include <tt-metalium/host_api.hpp>
 #include <memory>
 #include <string>
 #include <vector>

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/old/matmul/matmul_global_l1.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/old/matmul/matmul_global_l1.cpp
@@ -31,7 +31,6 @@
 
 #include <tt_stl/assert.hpp>
 #include <tt-metalium/base_types.hpp>
-#include <tt-metalium/buffer.hpp>
 #include <tt-metalium/buffer_types.hpp>
 #include <tt-metalium/circular_buffer_config.hpp>
 #include <tt-metalium/core_coord.hpp>

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/old/noc/test_noc_read_global_l1.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/old/noc/test_noc_read_global_l1.cpp
@@ -25,7 +25,6 @@
 #include <vector>
 
 #include <tt_stl/assert.hpp>
-#include <tt-metalium/buffer.hpp>
 #include <tt-metalium/buffer_types.hpp>
 #include <tt-metalium/circular_buffer_config.hpp>
 #include <tt-metalium/core_coord.hpp>

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/old/pcie/test_enqueue_rw_buffer.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/old/pcie/test_enqueue_rw_buffer.cpp
@@ -8,7 +8,6 @@
 #include <cstdint>
 #include <tt-metalium/bfloat16.hpp>
 #include <tt-metalium/device.hpp>
-#include <tt-metalium/host_api.hpp>
 #include <algorithm>
 #include <cstring>
 #include <exception>
@@ -22,7 +21,6 @@
 
 #include <tt_stl/assert.hpp>
 #include <tt-metalium/distributed.hpp>
-#include <tt-metalium/buffer.hpp>
 #include <tt-metalium/buffer_types.hpp>
 #include <tt-logger/tt-logger.hpp>
 #include "test_common.hpp"

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/old/pcie/test_rw_buffer.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/old/pcie/test_rw_buffer.cpp
@@ -7,7 +7,6 @@
 #include <fmt/base.h>
 #include <cstdint>
 #include <tt-metalium/bfloat16.hpp>
-#include <tt-metalium/host_api.hpp>
 #include <tt-metalium/tt_metal.hpp>
 #include <tt-metalium/distributed.hpp>
 #include <tt-metalium/mesh_device.hpp>
@@ -21,7 +20,6 @@
 #include <vector>
 
 #include <tt_stl/assert.hpp>
-#include <tt-metalium/buffer.hpp>
 #include <tt-metalium/buffer_types.hpp>
 #include <tt-logger/tt-logger.hpp>
 #include "test_common.hpp"

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/old/pcie/test_rw_device_dram.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/old/pcie/test_rw_device_dram.cpp
@@ -9,7 +9,6 @@
 #include <cstdlib>
 #include <ctime>
 #include <tt-metalium/bfloat16.hpp>
-#include <tt-metalium/host_api.hpp>
 #include <tt-metalium/tt_metal.hpp>
 #include <tt-metalium/distributed.hpp>
 #include <tt-metalium/mesh_device.hpp>

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/old/pcie/test_rw_device_l1.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/old/pcie/test_rw_device_l1.cpp
@@ -9,7 +9,6 @@
 #include <cstdlib>
 #include <ctime>
 #include <tt-metalium/bfloat16.hpp>
-#include <tt-metalium/host_api.hpp>
 #include <tt-metalium/tt_metal.hpp>
 #include <tt-metalium/distributed.hpp>
 #include <tt-metalium/mesh_device.hpp>

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_progress_monitor.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_progress_monitor.cpp
@@ -12,7 +12,6 @@
 #include "tt_fabric_test_device_setup.hpp"
 #include "tt_metal/llrt/tt_cluster.hpp"
 #include <tt-logger/tt-logger.hpp>
-#include <tt-metalium/host_api.hpp>
 #include <umd/device/types/cluster_descriptor_types.hpp>
 
 namespace tt::tt_fabric::fabric_tests {

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/tensix/test_gathering.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/tensix/test_gathering.cpp
@@ -5,7 +5,6 @@
 #include <map>
 #include <string>
 
-#include <tt_stl/assert.hpp>
 #include <tt-metalium/core_coord.hpp>
 #include <tt-metalium/data_types.hpp>
 #include <tt-metalium/device.hpp>

--- a/tests/tt_metal/tt_metal/test_bmm.cpp
+++ b/tests/tt_metal/tt_metal/test_bmm.cpp
@@ -15,7 +15,6 @@
 #include <tt-metalium/circular_buffer_config.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
 #include <tt-metalium/tilize_utils.hpp>
-#include <tt-logger/tt-logger.hpp>
 #include "test_gold_impls.hpp"
 #include "impl/data_format/bfloat16_utils.hpp"
 

--- a/tests/tt_metal/tt_metal/test_clean_init.cpp
+++ b/tests/tt_metal/tt_metal/test_clean_init.cpp
@@ -16,7 +16,6 @@
 #include <vector>
 
 #include <tt_stl/assert.hpp>
-#include <tt-metalium/buffer.hpp>
 #include <tt-metalium/buffer_types.hpp>
 #include <tt-metalium/core_coord.hpp>
 #include <tt-metalium/data_types.hpp>

--- a/tests/tt_metal/tt_metal/test_compile_program.cpp
+++ b/tests/tt_metal/tt_metal/test_compile_program.cpp
@@ -10,7 +10,6 @@
 #include <unordered_map>
 #include <vector>
 
-#include <tt-logger/tt-logger.hpp>
 #include <tt-metalium/circular_buffer_config.hpp>
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/tt_metal.hpp>

--- a/tests/tt_metal/tt_metal/test_compile_sets_kernel_binaries.cpp
+++ b/tests/tt_metal/tt_metal/test_compile_sets_kernel_binaries.cpp
@@ -17,8 +17,6 @@
 #include <tt-metalium/buffer.hpp>
 #include <tt-metalium/circular_buffer_config.hpp>
 #include <tt-metalium/hal_types.hpp>
-#include <tt-logger/tt-logger.hpp>
-
 #include "jit_build/build.hpp"
 #include "llrt.hpp"
 #include "impl/context/metal_context.hpp"

--- a/tests/tt_metal/tt_metal/test_core_range_set.cpp
+++ b/tests/tt_metal/tt_metal/test_core_range_set.cpp
@@ -14,17 +14,16 @@
 #include <tt-metalium/bfloat16.hpp>
 #include <tt-metalium/circular_buffer.hpp>
 #include <tt-metalium/host_api.hpp>
+#include "impl/buffers/circular_buffer.hpp"
 #include "impl/buffers/semaphore.hpp"
 #include <tt-metalium/tt_metal.hpp>
 #include <tt-metalium/buffer.hpp>
 #include <tt-metalium/circular_buffer_config.hpp>
 #include <tt-metalium/hal_types.hpp>
-#include <tt-logger/tt-logger.hpp>
 #include <umd/device/types/core_coordinates.hpp>
 
 // Access to internal API: ProgramImpl::get_sem_base_addr, get_sem_size, num_kernels, get_kernel
 #include "impl/program/program_impl.hpp"
-#include "impl/buffers/circular_buffer.hpp"
 #include "impl/kernels/kernel.hpp"
 #include "impl/context/metal_context.hpp"
 

--- a/tests/tt_metal/tt_metal/test_datacopy.cpp
+++ b/tests/tt_metal/tt_metal/test_datacopy.cpp
@@ -13,8 +13,6 @@
 #include <tt-metalium/tt_metal.hpp>
 #include <tt-metalium/buffer.hpp>
 #include <tt-metalium/circular_buffer_config.hpp>
-#include <tt-logger/tt-logger.hpp>
-
 using std::vector;
 using namespace tt;
 using namespace tt::tt_metal;

--- a/tests/tt_metal/tt_metal/test_datacopy_bfp8b.cpp
+++ b/tests/tt_metal/tt_metal/test_datacopy_bfp8b.cpp
@@ -13,7 +13,6 @@
 #include <tt-metalium/tt_metal.hpp>
 #include <tt-metalium/buffer.hpp>
 #include <tt-metalium/circular_buffer_config.hpp>
-#include <tt-logger/tt-logger.hpp>
 #include "tt_metal/test_utils/bfloat_utils.hpp"
 
 using std::vector;

--- a/tests/tt_metal/tt_metal/test_datacopy_output_in_l1.cpp
+++ b/tests/tt_metal/tt_metal/test_datacopy_output_in_l1.cpp
@@ -14,7 +14,6 @@
 #include <tt-metalium/tt_metal.hpp>
 #include <tt-metalium/buffer.hpp>
 #include <tt-metalium/circular_buffer_config.hpp>
-#include <tt-logger/tt-logger.hpp>
 #include <umd/device/types/core_coordinates.hpp>
 
 using std::vector;

--- a/tests/tt_metal/tt_metal/test_dram_copy_sticks_multi_core.cpp
+++ b/tests/tt_metal/tt_metal/test_dram_copy_sticks_multi_core.cpp
@@ -21,7 +21,6 @@
 #include <variant>
 #include <vector>
 
-#include <tt_stl/assert.hpp>
 #include <tt-metalium/buffer.hpp>
 #include <tt-metalium/buffer_types.hpp>
 #include <tt-metalium/core_coord.hpp>

--- a/tests/tt_metal/tt_metal/test_dram_loopback_single_core.cpp
+++ b/tests/tt_metal/tt_metal/test_dram_loopback_single_core.cpp
@@ -12,8 +12,6 @@
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/tt_metal.hpp>
 #include <tt-metalium/buffer.hpp>
-#include <tt-logger/tt-logger.hpp>
-
 using namespace tt;
 using namespace tt::tt_metal;
 

--- a/tests/tt_metal/tt_metal/test_eltwise_binary.cpp
+++ b/tests/tt_metal/tt_metal/test_eltwise_binary.cpp
@@ -13,7 +13,6 @@
 
 #include <tt-metalium/bfloat16.hpp>
 #include <tt-metalium/host_api.hpp>
-#include <tt-metalium/buffer.hpp>
 #include <tt-metalium/circular_buffer_config.hpp>
 #include <tt-metalium/distributed.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>

--- a/tests/tt_metal/tt_metal/test_interleaved_l1_buffer.cpp
+++ b/tests/tt_metal/tt_metal/test_interleaved_l1_buffer.cpp
@@ -12,8 +12,6 @@
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/tt_metal.hpp>
 #include <tt-metalium/buffer.hpp>
-#include <tt-logger/tt-logger.hpp>
-
 using namespace tt;
 using namespace tt::tt_metal;
 

--- a/tests/tt_metal/tt_metal/test_interleaved_layouts.cpp
+++ b/tests/tt_metal/tt_metal/test_interleaved_layouts.cpp
@@ -19,7 +19,6 @@
 #include <vector>
 
 #include <tt_stl/assert.hpp>
-#include <tt-metalium/buffer.hpp>
 #include <tt-metalium/buffer_types.hpp>
 #include <tt-metalium/circular_buffer_config.hpp>
 #include <tt-metalium/core_coord.hpp>

--- a/tests/tt_metal/tt_metal/test_matmul_single_tile_bfp8b.cpp
+++ b/tests/tt_metal/tt_metal/test_matmul_single_tile_bfp8b.cpp
@@ -13,7 +13,6 @@
 #include <tt-metalium/tt_metal.hpp>
 #include <tt-metalium/buffer.hpp>
 #include <tt-metalium/circular_buffer_config.hpp>
-#include <tt-logger/tt-logger.hpp>
 #include "tt_metal/test_utils/bfloat_utils.hpp"
 
 using std::vector;

--- a/tests/tt_metal/tt_metal/test_matmul_single_tile_output_in_l1.cpp
+++ b/tests/tt_metal/tt_metal/test_matmul_single_tile_output_in_l1.cpp
@@ -15,7 +15,6 @@
 #include <tt-metalium/tt_metal.hpp>
 #include <tt-metalium/buffer.hpp>
 #include <tt-metalium/circular_buffer_config.hpp>
-#include <tt-logger/tt-logger.hpp>
 #include "tt_metal/test_utils/deprecated/tensor.hpp"
 #include <umd/device/types/core_coordinates.hpp>
 

--- a/tests/tt_metal/tt_metal/test_multi_core_kernel.cpp
+++ b/tests/tt_metal/tt_metal/test_multi_core_kernel.cpp
@@ -16,8 +16,6 @@
 #include <tt-metalium/tt_metal.hpp>
 #include <tt-metalium/buffer.hpp>
 #include <tt-metalium/circular_buffer_config.hpp>
-#include <tt-logger/tt-logger.hpp>
-
 using std::vector;
 using namespace tt;
 using namespace tt::tt_metal;

--- a/tests/tt_metal/tt_metal/test_multiple_programs.cpp
+++ b/tests/tt_metal/tt_metal/test_multiple_programs.cpp
@@ -17,7 +17,6 @@
 #include <tt-metalium/tt_metal.hpp>
 #include <tt-metalium/buffer.hpp>
 #include <tt-metalium/circular_buffer_config.hpp>
-#include <tt-logger/tt-logger.hpp>
 #include "tt_metal/test_utils/deprecated/tensor.hpp"
 
 using std::vector;

--- a/tests/tt_metal/tt_metal/test_transpose_hc.cpp
+++ b/tests/tt_metal/tt_metal/test_transpose_hc.cpp
@@ -16,7 +16,6 @@
 #include <tt-metalium/circular_buffer_config.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
 #include <tt-metalium/tilize_utils.hpp>
-#include <tt-logger/tt-logger.hpp>
 #include "test_gold_impls.hpp"
 #include "impl/data_format/bfloat16_utils.hpp"
 

--- a/tests/ttnn/benchmark/cpp/matmul/test_matmul_benchmark.cpp
+++ b/tests/ttnn/benchmark/cpp/matmul/test_matmul_benchmark.cpp
@@ -12,7 +12,6 @@
 #include <tt-metalium/buffer_types.hpp>
 #include <tt-metalium/core_coord.hpp>
 #include <tt-metalium/device.hpp>
-#include <tt-metalium/host_api.hpp>
 #include <tt-metalium/shape.hpp>
 #include <tt-metalium/shape2d.hpp>
 #include <tt_stl/span.hpp>

--- a/tests/ttnn/unit_tests/gtests/ccl/test_fabric_erisc_data_mover_loopback_with_workers.cpp
+++ b/tests/ttnn/unit_tests/gtests/ccl/test_fabric_erisc_data_mover_loopback_with_workers.cpp
@@ -17,14 +17,10 @@
 #include <unordered_map>
 #include <vector>
 
-#include <tt_stl/assert.hpp>
-#include <tt-metalium/buffer.hpp>
 #include <tt-metalium/buffer_types.hpp>
-#include <tt-metalium/core_coord.hpp>
 #include <tt-metalium/device.hpp>
 #include <tt-metalium/experimental/fabric/fabric_edm_types.hpp>
 #include <tt-metalium/hal_types.hpp>
-#include <tt-metalium/host_api.hpp>
 #include <tt-logger/tt-logger.hpp>
 #include <tt-metalium/mesh_coord.hpp>
 #include <tt-metalium/mesh_device.hpp>
@@ -39,7 +35,6 @@
 #include <tt-metalium/tt_backend_api_types.hpp>
 #include "tt_metal/test_utils/env_vars.hpp"
 #include "ttnn/common/queue_id.hpp"
-#include "ttnn/decorators.hpp"
 #include "ttnn/distributed/api.hpp"
 #include "ttnn/global_semaphore.hpp"
 #include "ttnn/operation.hpp"

--- a/tests/ttnn/unit_tests/gtests/ccl/test_persistent_fabric_ccl_ops.cpp
+++ b/tests/ttnn/unit_tests/gtests/ccl/test_persistent_fabric_ccl_ops.cpp
@@ -16,9 +16,7 @@
 #include <unordered_map>
 #include <vector>
 
-#include <tt-metalium/buffer.hpp>
 #include <tt-metalium/buffer_types.hpp>
-#include <tt-metalium/core_coord.hpp>
 #include <tt-metalium/device.hpp>
 #include <tt-metalium/hal_types.hpp>
 #include <tt-logger/tt-logger.hpp>

--- a/tests/ttnn/unit_tests/gtests/common_test_utils.cpp
+++ b/tests/ttnn/unit_tests/gtests/common_test_utils.cpp
@@ -12,8 +12,6 @@
 #include "ttnn/tensor/tensor.hpp"
 #include "ttnn/operations/functions.hpp"
 #include "ttnn/operations/eltwise/unary/unary.hpp"
-#include <tt-metalium/host_api.hpp>
-
 namespace ttnn::test_utils {
 
 float pcc(const std::vector<float>& x, const std::vector<float>& y) {

--- a/tests/ttnn/unit_tests/gtests/multiprocess/test_host_all_gather.cpp
+++ b/tests/ttnn/unit_tests/gtests/multiprocess/test_host_all_gather.cpp
@@ -9,7 +9,6 @@
 #include <tt-metalium/system_mesh.hpp>
 #include <tt-metalium/mesh_coord.hpp>
 #include <tt-metalium/distributed_host_buffer.hpp>
-#include <tt-metalium/host_buffer.hpp>
 #include <ttnn/tensor/tensor.hpp>
 #include <ttnn/tensor/layout/tensor_layout.hpp>
 #include <ttnn/distributed/distributed_tensor.hpp>

--- a/tests/ttnn/unit_tests/gtests/tensor/common_tensor_test_utils.cpp
+++ b/tests/ttnn/unit_tests/gtests/tensor/common_tensor_test_utils.cpp
@@ -10,7 +10,6 @@
 
 #include <tt-metalium/device.hpp>
 #include "gtest/gtest.h"
-#include <tt-metalium/host_api.hpp>
 #include "ttnn/async_runtime.hpp"
 #include "ttnn/common/queue_id.hpp"
 #include "ttnn/tensor/layout/tensor_layout.hpp"

--- a/tests/ttnn/unit_tests/gtests/tensor/test_create_tensor.cpp
+++ b/tests/ttnn/unit_tests/gtests/tensor/test_create_tensor.cpp
@@ -15,7 +15,6 @@
 #include <tuple>
 #include <vector>
 
-#include <tt-metalium/buffer.hpp>
 #include <tt-metalium/buffer_types.hpp>
 #include "common_tensor_test_utils.hpp"
 #include "gtest/gtest.h"

--- a/tests/ttnn/unit_tests/gtests/tensor/test_create_tensor_with_layout.cpp
+++ b/tests/ttnn/unit_tests/gtests/tensor/test_create_tensor_with_layout.cpp
@@ -6,7 +6,6 @@
 #include <memory>
 #include <optional>
 
-#include <tt-metalium/buffer.hpp>
 #include <tt-metalium/buffer_types.hpp>
 #include "gtest/gtest.h"
 #include <tt-metalium/shape.hpp>

--- a/tests/ttnn/unit_tests/gtests/tensor/test_vector_conversion.cpp
+++ b/tests/ttnn/unit_tests/gtests/tensor/test_vector_conversion.cpp
@@ -16,9 +16,7 @@
 #include <optional>
 #include <vector>
 
-#include <tt-metalium/buffer.hpp>
 #include <tt-metalium/buffer_types.hpp>
-#include <tt-metalium/core_coord.hpp>
 #include "gmock/gmock.h"
 #include <tt-metalium/shape.hpp>
 #include <tt_stl/span.hpp>

--- a/tests/ttnn/unit_tests/gtests/test_async_runtime.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_async_runtime.cpp
@@ -14,8 +14,6 @@
 #include <variant>
 #include <vector>
 
-#include <tt-metalium/host_api.hpp>
-#include <tt-metalium/buffer.hpp>
 #include <tt-metalium/buffer_types.hpp>
 #include <tt-metalium/device.hpp>
 #include <tt-logger/tt-logger.hpp>

--- a/tests/ttnn/unit_tests/gtests/test_conv2d.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_conv2d.cpp
@@ -8,8 +8,6 @@
 #include <optional>
 #include <tuple>
 #include <vector>
-#include <tt_stl/assert.hpp>
-#include <tt-logger/tt-logger.hpp>
 #include <tt_stl/small_vector.hpp>
 #include "ttnn/common/queue_id.hpp"
 #include "ttnn/device.hpp"

--- a/tests/ttnn/unit_tests/gtests/test_graph_add.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_graph_add.cpp
@@ -18,7 +18,6 @@
 
 #include <tt-metalium/buffer.hpp>
 #include <tt-metalium/buffer_types.hpp>
-#include <tt-metalium/core_coord.hpp>
 #include <tt-metalium/device.hpp>
 #include <tt-metalium/graph_tracking.hpp>
 #include "gtest/gtest.h"

--- a/tests/ttnn/unit_tests/gtests/test_graph_query_op_constraints.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_graph_query_op_constraints.cpp
@@ -17,7 +17,6 @@
 
 #include <tt-metalium/buffer.hpp>
 #include <tt-metalium/buffer_types.hpp>
-#include <tt-metalium/core_coord.hpp>
 #include "gtest/gtest.h"
 #include <tt-metalium/shape.hpp>
 #include <tt-metalium/shape_base.hpp>

--- a/tests/ttnn/unit_tests/gtests/test_multi_cq_multi_dev.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_multi_cq_multi_dev.cpp
@@ -15,17 +15,14 @@
 #include <vector>
 
 #include "common_test_utils.hpp"
-#include <tt-metalium/buffer.hpp>
 #include <tt-metalium/buffer_types.hpp>
 #include <tt-metalium/device.hpp>
-#include <tt-metalium/host_api.hpp>
 #include <tt-logger/tt-logger.hpp>
 #include <tt-metalium/shape.hpp>
 #include <tt-metalium/tt_backend_api_types.hpp>
 #include "tt_metal/test_utils/env_vars.hpp"
 #include "ttnn/async_runtime.hpp"
 #include "ttnn/common/queue_id.hpp"
-#include "ttnn/decorators.hpp"
 #include "ttnn/operations/eltwise/unary/unary.hpp"
 #include "ttnn/tensor/layout/page_config.hpp"
 #include "ttnn/tensor/layout/tensor_layout.hpp"

--- a/tests/ttnn/unit_tests/gtests/test_multiprod_queue.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_multiprod_queue.cpp
@@ -12,7 +12,6 @@
 #include <thread>
 #include <vector>
 
-#include <tt-metalium/buffer.hpp>
 #include <tt-metalium/buffer_types.hpp>
 #include <tt-metalium/device.hpp>
 #include "gmock/gmock.h"

--- a/tools/scaleout/factory_system_descriptor/utils.cpp
+++ b/tools/scaleout/factory_system_descriptor/utils.cpp
@@ -23,7 +23,6 @@
 
 #include <umd/device/types/cluster_descriptor_types.hpp>
 #include <umd/device/types/arch.hpp>
-#include <tt_stl/reflection.hpp>
 #include <board/board.hpp>
 #include <cabling_generator/cabling_generator.hpp>
 

--- a/tt_metal/api/tt-metalium/buffer.hpp
+++ b/tt_metal/api/tt-metalium/buffer.hpp
@@ -5,7 +5,6 @@
 #pragma once
 
 #include <nlohmann/json_fwd.hpp>
-#include <tt_stl/concepts.hpp>
 #include <array>
 #include <atomic>
 #include <condition_variable>
@@ -22,7 +21,6 @@
 #include <variant>
 #include <vector>
 
-#include <tt_stl/assert.hpp>
 #include <tt-metalium/bfloat16.hpp>
 #include <tt-metalium/buffer_types.hpp>
 #include <tt-metalium/buffer_distribution_spec.hpp>
@@ -31,7 +29,6 @@
 #include <tt-metalium/sub_device_types.hpp>
 #include <tt-metalium/buffer_page_mapping.hpp>
 #include <umd/device/types/core_coordinates.hpp>
-#include <umd/device/soc_descriptor.hpp>
 #include <umd/device/types/xy_pair.hpp>
 
 namespace tt::stl::json {

--- a/tt_metal/api/tt-metalium/circular_buffer_config.hpp
+++ b/tt_metal/api/tt-metalium/circular_buffer_config.hpp
@@ -13,7 +13,6 @@
 
 #include <tt-metalium/buffer.hpp>
 #include <tt-metalium/circular_buffer_constants.h>
-#include <tt-logger/tt-logger.hpp>
 #include <tt-metalium/tile.hpp>
 #include <tt-metalium/tt_backend_api_types.hpp>
 #include <tt-metalium/program_descriptors.hpp>

--- a/tt_metal/api/tt-metalium/core_coord.hpp
+++ b/tt_metal/api/tt-metalium/core_coord.hpp
@@ -5,9 +5,8 @@
 #pragma once
 
 #include <fmt/base.h>
-#include <nlohmann/json.hpp>
+#include <nlohmann/json_fwd.hpp>
 #include <stdint.h>
-#include <tt_stl/reflection.hpp>
 #include <tt_stl/span.hpp>
 #include <algorithm>
 #include <cstddef>
@@ -19,12 +18,12 @@
 
 #include <umd/device/types/xy_pair.hpp>
 
-namespace tt::stl::json {
+namespace ttsl::json {
 template <typename T>
 struct from_json_t;
 template <typename T>
 struct to_json_t;
-}  // namespace tt::stl::json
+}  // namespace ttsl::json
 
 namespace tt::tt_metal {
 

--- a/tt_metal/api/tt-metalium/dispatch_core_common.hpp
+++ b/tt_metal/api/tt-metalium/dispatch_core_common.hpp
@@ -4,7 +4,6 @@
 
 #pragma once
 
-#include <tt_stl/assert.hpp>
 #include <tt-metalium/core_coord.hpp>
 #include <tt-metalium/data_types.hpp>
 #include <tt_stl/reflection.hpp>

--- a/tt_metal/api/tt-metalium/distributed.hpp
+++ b/tt_metal/api/tt-metalium/distributed.hpp
@@ -10,7 +10,6 @@
 #include <vector>
 
 #include <tt_stl/span.hpp>
-#include <tt_stl/assert.hpp>
 #include <tt-metalium/buffer.hpp>
 #include <tt-metalium/mesh_buffer.hpp>
 #include <tt-metalium/mesh_command_queue.hpp>

--- a/tt_metal/api/tt-metalium/distributed_host_buffer.hpp
+++ b/tt_metal/api/tt-metalium/distributed_host_buffer.hpp
@@ -7,7 +7,6 @@
 #include <tt_stl/span.hpp>
 #include <tt-metalium/mesh_coord.hpp>
 #include <tt-metalium/host_buffer.hpp>
-#include <tt_stl/assert.hpp>
 #include <tt-metalium/mesh_device_view.hpp>
 #include <tt-metalium/distributed_context.hpp>
 

--- a/tt_metal/api/tt-metalium/experimental/fabric/fabric_types.hpp
+++ b/tt_metal/api/tt-metalium/experimental/fabric/fabric_types.hpp
@@ -9,7 +9,6 @@
 #include <ostream>
 #include <optional>
 #include <tt_stl/strong_type.hpp>
-#include <tt_stl/reflection.hpp>
 
 #include <fmt/format.h>
 

--- a/tt_metal/common/multi_producer_single_consumer_queue.hpp
+++ b/tt_metal/common/multi_producer_single_consumer_queue.hpp
@@ -7,7 +7,6 @@
 #include <atomic>
 #include <functional>
 #include <memory>
-#include <tt_stl/assert.hpp>
 
 template <typename T>
 class MultiProducerSingleConsumerQueue {

--- a/tt_metal/distributed/distributed_coordinate_translator.cpp
+++ b/tt_metal/distributed/distributed_coordinate_translator.cpp
@@ -4,7 +4,6 @@
 
 #include "tt_metal/distributed/distributed_coordinate_translator.hpp"
 
-#include <tt-logger/tt-logger.hpp>
 #include <tt_stl/assert.hpp>
 #include <tt-metalium/mesh_coord.hpp>
 

--- a/tt_metal/distributed/distributed_host_buffer.cpp
+++ b/tt_metal/distributed/distributed_host_buffer.cpp
@@ -6,7 +6,6 @@
 #include <tt_stl/indestructible.hpp>
 #include <tt-metalium/mesh_coord.hpp>
 #include <tt-metalium/distributed_host_buffer.hpp>
-#include <tt_stl/assert.hpp>
 #include <tt-metalium/experimental/fabric/control_plane.hpp>
 
 #include <vector>

--- a/tt_metal/distributed/mesh_trace.cpp
+++ b/tt_metal/distributed/mesh_trace.cpp
@@ -30,7 +30,6 @@
 #include "mesh_device.hpp"
 #include "mesh_trace_id.hpp"
 #include "dispatch/system_memory_manager.hpp"
-#include "trace/trace_buffer.hpp"
 #include "tt_metal/impl/dispatch/device_command.hpp"
 #include "tt_metal/impl/trace/dispatch.hpp"
 #include "impl/allocator/allocator.hpp"

--- a/tt_metal/fabric/builder/router_connection_mapping.cpp
+++ b/tt_metal/fabric/builder/router_connection_mapping.cpp
@@ -4,8 +4,6 @@
 #include "tt_metal/fabric/builder/router_connection_mapping.hpp"
 #include "tt_metal/fabric/builder/fabric_builder_config.hpp"
 
-#include <tt-logger/tt-logger.hpp>
-
 namespace tt::tt_fabric {
 
 std::vector<ConnectionTarget> RouterConnectionMapping::get_downstream_targets(

--- a/tt_metal/fabric/channel_trimming_report.cpp
+++ b/tt_metal/fabric/channel_trimming_report.cpp
@@ -11,6 +11,7 @@
 
 #include <tt-logger/tt-logger.hpp>
 #include <tt_stl/assert.hpp>
+#include <tt_stl/reflection.hpp>
 #include <yaml-cpp/yaml.h>
 
 #include "tt_metal/fabric/builder/fabric_builder_config.hpp"

--- a/tt_metal/fabric/control_plane.cpp
+++ b/tt_metal/fabric/control_plane.cpp
@@ -40,7 +40,6 @@
 #include "distributed_context.hpp"
 #include <tt-metalium/experimental/fabric/fabric_types.hpp>
 #include "hal_types.hpp"
-#include "host_api.hpp"
 #include "tt_metal/common/env_lib.hpp"
 #include <tt-logger/tt-logger.hpp>
 #include "mesh_coord.hpp"
@@ -55,7 +54,6 @@
 #include "tt_metal/fabric/fabric_builder_context.hpp"
 #include "tt_metal/fabric/fabric_tensix_builder_impl.hpp"
 #include "tt_metal/fabric/serialization/router_port_directions.hpp"
-#include "tt_stl/small_vector.hpp"
 #include "tt_metal/fabric/physical_system_descriptor.hpp"
 #include "tt_metal/fabric/serialization/port_descriptor_serialization.hpp"
 #include "tt_metal/fabric/serialization/intermesh_connections_serialization.hpp"

--- a/tt_metal/fabric/erisc_datamover_builder.hpp
+++ b/tt_metal/fabric/erisc_datamover_builder.hpp
@@ -4,7 +4,6 @@
 
 #pragma once
 
-#include <tt_stl/assert.hpp>
 #include <tt-metalium/device.hpp>
 #include <tt-metalium/program.hpp>
 #include <tt-metalium/hal.hpp>

--- a/tt_metal/fabric/fabric_context.cpp
+++ b/tt_metal/fabric/fabric_context.cpp
@@ -10,7 +10,6 @@
 #include <tt-metalium/experimental/fabric/fabric_edm_types.hpp>
 #include <tt-metalium/experimental/fabric/fabric_types.hpp>
 #include <tt_stl/assert.hpp>
-#include <tt-metalium/host_api.hpp>
 #include <enchantum/enchantum.hpp>
 #include <tt_stl/reflection.hpp>
 #include "erisc_datamover_builder.hpp"

--- a/tt_metal/impl/buffers/circular_buffer_config.cpp
+++ b/tt_metal/impl/buffers/circular_buffer_config.cpp
@@ -8,6 +8,7 @@
 
 #include <tt_stl/assert.hpp>
 #include "buffer.hpp"
+#include "hal.hpp"
 #include "impl/context/metal_context.hpp"
 
 namespace tt {

--- a/tt_metal/impl/buffers/circular_buffer_config.cpp
+++ b/tt_metal/impl/buffers/circular_buffer_config.cpp
@@ -8,8 +8,6 @@
 
 #include <tt_stl/assert.hpp>
 #include "buffer.hpp"
-#include <tt-logger/tt-logger.hpp>
-#include "hal.hpp"
 #include "impl/context/metal_context.hpp"
 
 namespace tt {

--- a/tt_metal/impl/data_format/blockfloat_common.hpp
+++ b/tt_metal/impl/data_format/blockfloat_common.hpp
@@ -4,7 +4,6 @@
 
 #pragma once
 #include <stdint.h>
-#include <tt_stl/assert.hpp>
 #include <tt-metalium/tile.hpp>
 #include <tt-metalium/tt_backend_api_types.hpp>
 #include <tt_stl/span.hpp>

--- a/tt_metal/impl/debug/inspector/data.cpp
+++ b/tt_metal/impl/debug/inspector/data.cpp
@@ -11,7 +11,6 @@
 #include "distributed/mesh_workload_impl.hpp"
 #include "jit_build/build_env_manager.hpp"
 #include "device/device_manager.hpp"
-#include <tt_stl/reflection.hpp>
 #include <llrt/tt_cluster.hpp>
 
 namespace tt::tt_metal::inspector {

--- a/tt_metal/impl/debug/inspector/inspector.cpp
+++ b/tt_metal/impl/debug/inspector/inspector.cpp
@@ -13,7 +13,6 @@
 #include "program.hpp"
 #include <memory>
 #include <tt-metalium/experimental/inspector.hpp>
-#include <tt-logger/tt-logger.hpp>
 #include "impl/kernels/kernel.hpp"
 
 namespace tt::tt_metal {

--- a/tt_metal/impl/debug/watcher_server.hpp
+++ b/tt_metal/impl/debug/watcher_server.hpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once
+#include <mutex>
 #include <core_coord.hpp>
 #include <stdint.h>
 #include <umd/device/types/cluster_descriptor_types.hpp>

--- a/tt_metal/impl/dispatch/cq_shared_state.cpp
+++ b/tt_metal/impl/dispatch/cq_shared_state.cpp
@@ -4,6 +4,8 @@
 
 #include "cq_shared_state.hpp"
 
+#include <tt_stl/assert.hpp>
+
 namespace tt::tt_metal {
 void CQOwnerState::take_ownership(SubDeviceId id, uint32_t cq_id) {
     if (cq_id_ != std::nullopt && cq_id_ != cq_id) {

--- a/tt_metal/impl/dispatch/cq_shared_state.hpp
+++ b/tt_metal/impl/dispatch/cq_shared_state.hpp
@@ -8,7 +8,6 @@
 #include <optional>
 #include <api/tt-metalium/sub_device_types.hpp>
 
-#include <tt_stl/assert.hpp>
 #include "launch_message_ring_buffer_state.hpp"
 #include "dispatch_settings.hpp"
 

--- a/tt_metal/impl/dispatch/kernel_config/dispatch.hpp
+++ b/tt_metal/impl/dispatch/kernel_config/dispatch.hpp
@@ -7,7 +7,6 @@
 #include <stdint.h>
 #include <optional>
 
-#include <tt_stl/assert.hpp>
 #include "core_coord.hpp"
 #include "dispatch/kernel_config/relay_mux.hpp"
 #include "fd_kernel.hpp"

--- a/tt_metal/impl/dispatch/ringbuffer_cache.hpp
+++ b/tt_metal/impl/dispatch/ringbuffer_cache.hpp
@@ -11,7 +11,6 @@
 #include <vector>
 #include <optional>
 #include <climits>
-#include <tt_stl/assert.hpp>
 #include <memory>
 namespace tt::tt_metal {
 

--- a/tt_metal/impl/experimental/udm/mesh_tensor_builder.cpp
+++ b/tt_metal/impl/experimental/udm/mesh_tensor_builder.cpp
@@ -9,7 +9,6 @@
 #include <tt-metalium/mesh_device.hpp>
 #include <tt_stl/assert.hpp>
 #include <tt_stl/span.hpp>
-#include <tt-logger/tt-logger.hpp>
 #include <array>
 
 namespace tt::tt_metal::experimental::udm {

--- a/tt_metal/impl/flatbuffer/program_types_from_flatbuffer.hpp
+++ b/tt_metal/impl/flatbuffer/program_types_from_flatbuffer.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "program_types_generated.h"
+#include <variant>
 #include <core_coord.hpp>
 #include <kernel_types.hpp>
 #include <sub_device_types.hpp>

--- a/tt_metal/impl/profiler/profiler_analysis.cpp
+++ b/tt_metal/impl/profiler/profiler_analysis.cpp
@@ -9,6 +9,7 @@
 #include <sstream>
 #include <tracy/Tracy.hpp>
 #include <tt-logger/tt-logger.hpp>
+#include <nlohmann/json.hpp>
 #include <tt_stl/assert.hpp>
 #include <tt-metalium/experimental/profiler.hpp>
 #include <fstream>

--- a/tt_metal/impl/profiler/profiler_analysis.hpp
+++ b/tt_metal/impl/profiler/profiler_analysis.hpp
@@ -13,12 +13,10 @@
 #include <unordered_set>
 #include <string>
 #include <vector>
-#include <nlohmann/json.hpp>
 
 #include <umd/device/types/cluster_descriptor_types.hpp>
 #include <common/TracyTTDeviceData.hpp>
 #include <tt-metalium/experimental/profiler.hpp>
-#include <tt_stl/assert.hpp>
 #include "thread_pool.hpp"
 
 namespace tt::tt_metal {

--- a/tt_metal/llrt/hal/tt-2xx/quasar/qa_hal_idle_eth.cpp
+++ b/tt_metal/llrt/hal/tt-2xx/quasar/qa_hal_idle_eth.cpp
@@ -12,7 +12,6 @@ using namespace tt::tt_metal::quasar::idle_eth;
 
 #include <cstdint>
 
-#include <tt_stl/assert.hpp>
 #include "quasar/qa_hal.hpp"
 #include "quasar/qa_hal_eth_asserts.hpp"
 #include "dev_mem_map.h"

--- a/tt_metal/llrt/hal/tt-2xx/quasar/qa_hal_tensix.cpp
+++ b/tt_metal/llrt/hal/tt-2xx/quasar/qa_hal_tensix.cpp
@@ -9,7 +9,6 @@ using namespace tt::tt_metal::quasar::tensix;
 
 #include <cstdint>
 
-#include <tt_stl/assert.hpp>
 #include "quasar/qa_hal.hpp"
 #include "quasar/qa_hal_tensix_asserts.hpp"
 #include "dev_mem_map.h"

--- a/tt_metal/llrt/tlb_config.cpp
+++ b/tt_metal/llrt/tlb_config.cpp
@@ -11,7 +11,6 @@
 #include <unordered_map>
 #include <vector>
 
-#include "core_coord.hpp"
 #include "llrt/metal_soc_descriptor.hpp"
 #include <tt-metalium/tt_backend_api_types.hpp>
 #include "common/tt_backend_api_types.hpp"

--- a/tt_metal/llrt/tt_cluster.cpp
+++ b/tt_metal/llrt/tt_cluster.cpp
@@ -1468,6 +1468,16 @@ uint32_t Cluster::get_alignment_requirements(ChipId chip_id, uint32_t size_in_by
     return 1;
 }
 
+umd::ClusterDescriptor* Cluster::get_cluster_desc() const {
+    TT_FATAL(this->cluster_desc_ != nullptr, "Cluster descriptor is not initialized.");
+    return this->cluster_desc_;
+}
+
+const std::unique_ptr<tt::umd::Cluster>& Cluster::get_driver() const {
+    TT_FATAL(driver_ != nullptr, "UMD driver is not initialized.");
+    return driver_;
+}
+
 }  // namespace tt
 
 std::ostream& operator<<(std::ostream& os, const tt_target_dram& dram) {

--- a/tt_metal/llrt/tt_cluster.hpp
+++ b/tt_metal/llrt/tt_cluster.hpp
@@ -22,7 +22,6 @@
 #include <unordered_set>
 #include <vector>
 
-#include <tt_stl/assert.hpp>
 #include "core_coord.hpp"
 #include <umd/device/cluster.hpp>
 #include <umd/device/driver_atomics.hpp>
@@ -88,15 +87,9 @@ public:
 
     std::set<ChipId> all_pci_chip_ids() const { return this->driver_->get_target_mmio_device_ids(); }
 
-    umd::ClusterDescriptor* get_cluster_desc() const {
-        TT_FATAL(this->cluster_desc_ != nullptr, "Cluster descriptor is not initialized.");
-        return this->cluster_desc_;
-    }
+    umd::ClusterDescriptor* get_cluster_desc() const;
 
-    const std::unique_ptr<tt::umd::Cluster>& get_driver() const {
-        TT_FATAL(driver_ != nullptr, "UMD driver is not initialized.");
-        return driver_;
-    }
+    const std::unique_ptr<tt::umd::Cluster>& get_driver() const;
 
     // Sets the HAL to be used for this Cluster
     void set_hal(const tt_metal::Hal* hal);

--- a/tt_metal/programming_examples/add_2_integers_in_riscv/add_2_integers_in_riscv.cpp
+++ b/tt_metal/programming_examples/add_2_integers_in_riscv/add_2_integers_in_riscv.cpp
@@ -6,7 +6,6 @@
 #include <memory>
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/device.hpp>
-#include "tt-metalium/buffer.hpp"
 #include <tt-metalium/distributed.hpp>
 
 using namespace tt;

--- a/ttnn/api/ttnn/config.hpp
+++ b/ttnn/api/ttnn/config.hpp
@@ -5,14 +5,14 @@
 #pragma once
 
 #include <filesystem>
+#include <iosfwd>
 #include <optional>
 #include <reflect>
 #include <string>
 #include <string_view>
 #include <tuple>
 
-#include <tt-logger/tt-logger.hpp>
-#include <tt_stl/reflection.hpp>
+#include <fmt/base.h>
 
 namespace ttnn {
 
@@ -42,6 +42,9 @@ private:
     mutable std::optional<std::filesystem::path> cached_report_path;
     mutable std::optional<std::string> cached_report_name;
 
+    // Implementation helper for the report_path getter (defined in config.cpp).
+    std::optional<std::filesystem::path> get_report_path_impl() const;
+
 public:
     Config(auto&&... args) : attributes{std::forward<decltype(args)>(args)...} {}
 
@@ -59,66 +62,7 @@ public:
     template <reflect::fixed_string name>
         requires(name == reflect::fixed_string{"report_path"})
     std::optional<std::filesystem::path> get() const {
-        if (this->attributes.report_name.has_value()) {
-            std::string name_str = this->attributes.report_name.value().string();
-
-            // Only recompute if report_name has changed in this run
-            if (!cached_report_name.has_value() || *cached_report_name != name_str) {
-                cached_report_name = name_str;
-
-                // If report_name is too long, truncate it
-                constexpr size_t max_name_length = 64;
-                if (name_str.length() > max_name_length) {
-                    name_str = name_str.substr(0, max_name_length);
-                }
-
-                std::transform(name_str.begin(), name_str.end(), name_str.begin(), [](unsigned char c) {
-                    if (std::isalnum(c)) {
-                        return static_cast<char>(std::tolower(c));
-                    }
-                    return '_';
-                });
-
-                name_str.erase(std::unique(name_str.begin(), name_str.end(), [](char a, char b) {
-                    return a == '_' && b == '_';
-                }), name_str.end());
-
-                if (!name_str.empty() && name_str.front() == '_') {
-                    name_str.erase(0, 1);
-                }
-                if (!name_str.empty() && name_str.back() == '_') {
-                    name_str.pop_back();
-                }
-
-                // Get current date and time
-                auto now = std::chrono::system_clock::now();
-                std::time_t now_c = std::chrono::system_clock::to_time_t(now);
-                std::tm tm{};
-            #if defined(_WIN32)
-                localtime_s(&tm, &now_c);
-            #else
-                localtime_r(&now_c, &tm);
-            #endif
-                std::ostringstream oss;
-                oss << std::put_time(&tm, "%b");
-                std::string month = oss.str();
-                std::transform(month.begin(), month.end(), month.begin(), ::tolower);
-
-                std::ostringstream date_time;
-                date_time << month
-                        << std::setw(2) << std::setfill('0') << tm.tm_mday << "_"
-                        << std::setw(2) << std::setfill('0') << tm.tm_hour
-                        << std::setw(2) << std::setfill('0') << tm.tm_min;
-
-                std::string dir_name = name_str + "_" + date_time.str();
-                cached_report_path = this->attributes.root_report_path / dir_name;
-            }
-
-            // snake_cased(report_name)_monthdd_HHMM
-            return cached_report_path;
-        }
-
-        return std::nullopt;
+        return get_report_path_impl();
     }
 
     template <
@@ -135,57 +79,11 @@ public:
         this->validate(reflect::member_name<index>(this->attributes));
     }
 
-    void validate(std::string_view name) const {
-        if (name == "enable_fast_runtime_mode" or name == "enable_logging") {
-            if (this->attributes.enable_fast_runtime_mode) {
-                if (this->attributes.enable_logging) {
-                    log_warning(
-                        tt::LogAlways,
-                        "Logging cannot be enabled in fast runtime mode. Please disable fast runtime mode if you want "
-                        "to enable logging.");
-                }
-            }
-        }
+    // Defined in config.cpp (uses tt-logger).
+    void validate(std::string_view name) const;
 
-        if (name == "enable_comparison_mode") {
-            if (this->attributes.enable_fast_runtime_mode && this->attributes.enable_comparison_mode) {
-                log_warning(
-                    tt::LogAlways,
-                    "Comparison mode is currently not supported with fast runtime mode enabled. Please disable fast "
-                    "runtime mode ('enable_fast_runtime_mode = false') to use tensor comparison mode.");
-            }
-        }
-
-        if (name == "enable_fast_runtime_mode" or name == "enable_graph_report" or
-            name == "enable_detailed_buffer_report" or name == "enable_detailed_tensor_report") {
-            if (not this->attributes.enable_logging) {
-                if (this->attributes.enable_graph_report) {
-                    log_warning(tt::LogAlways, "Running without logging. Please enable logging to save graph report");
-                }
-                if (this->attributes.enable_detailed_buffer_report) {
-                    log_warning(
-                        tt::LogAlways, "Running without logging. Please enable logging to save detailed buffer report");
-                }
-                if (this->attributes.enable_detailed_tensor_report) {
-                    log_warning(
-                        tt::LogAlways, "Running without logging. Please enable logging to save detailed tensor report");
-                }
-            }
-        }
-    }
-
-    friend std::ostream& operator<<(std::ostream& os, const Config& config) {
-        os << "Config{";
-        reflect::for_each(
-            [&](auto I) {
-                os << reflect::member_name<I>(config.attributes) << "="
-                   << fmt::format("{}", reflect::get<I>(config.attributes)) << ",";
-            },
-            config.attributes);
-        os << fmt::format("{}", config.get<"report_path">());
-        os << "}";
-        return os;
-    }
+    // Defined in config.cpp (uses reflection for_each).
+    friend std::ostream& operator<<(std::ostream& os, const Config& config);
 };
 
 extern Config CONFIG;
@@ -200,9 +98,6 @@ template <>
 struct fmt::formatter<ttnn::Config> {
     constexpr auto parse(format_parse_context& ctx) { return ctx.end(); }
 
-    auto format(const ttnn::Config& config, format_context& ctx) const -> format_context::iterator {
-        std::stringstream ss;
-        ss << config;
-        return fmt::format_to(ctx.out(), "{}", ss.str());
-    }
+    // Defined in config.cpp.
+    auto format(const ttnn::Config& config, format_context& ctx) const -> format_context::iterator;
 };

--- a/ttnn/api/ttnn/operation_concepts.hpp
+++ b/ttnn/api/ttnn/operation_concepts.hpp
@@ -15,7 +15,7 @@
 #include <tt-metalium/graph_tracking.hpp>
 #include <tt-metalium/program_cache.hpp>
 
-#include <tt_stl/reflection.hpp>
+#include <cstdint>
 
 #include "ttnn/distributed/types.hpp"
 
@@ -121,7 +121,7 @@ concept DeviceOperationWithCustomProgramCacheConcept =
         const typename device_operation_t::tensor_args_t& tensor_args) {
         {
             device_operation_t::compute_program_hash(operation_attributes, tensor_args)
-        } -> std::convertible_to<tt::stl::hash::hash_t>;
+        } -> std::convertible_to<std::uint64_t>;
     };
 
 template <typename device_operation_t>

--- a/ttnn/api/ttnn/tensor/host_buffer/functions.hpp
+++ b/ttnn/api/ttnn/tensor/host_buffer/functions.hpp
@@ -5,7 +5,6 @@
 #pragma once
 
 #include <tt_stl/overloaded.hpp>
-#include <tt_stl/reflection.hpp>
 #include <type_traits>
 
 #include "ttnn/tensor/tensor.hpp"

--- a/ttnn/core/config.cpp
+++ b/ttnn/core/config.cpp
@@ -4,7 +4,139 @@
 
 #include "ttnn/config.hpp"
 
+#include <algorithm>
+#include <chrono>
+#include <iomanip>
+#include <ostream>
+#include <sstream>
+
+#include <fmt/format.h>
+#include <reflect>
+#include <tt-logger/tt-logger.hpp>
+#include <tt_stl/reflection.hpp>
+
 namespace ttnn::core {
 
 Config CONFIG{};
+
+std::optional<std::filesystem::path> Config::get_report_path_impl() const {
+    if (this->attributes.report_name.has_value()) {
+        std::string name_str = this->attributes.report_name.value().string();
+
+        // Only recompute if report_name has changed in this run
+        if (!cached_report_name.has_value() || *cached_report_name != name_str) {
+            cached_report_name = name_str;
+
+            // If report_name is too long, truncate it
+            constexpr size_t max_name_length = 64;
+            if (name_str.length() > max_name_length) {
+                name_str = name_str.substr(0, max_name_length);
+            }
+
+            std::transform(name_str.begin(), name_str.end(), name_str.begin(), [](unsigned char c) {
+                if (std::isalnum(c)) {
+                    return static_cast<char>(std::tolower(c));
+                }
+                return '_';
+            });
+
+            name_str.erase(
+                std::unique(name_str.begin(), name_str.end(), [](char a, char b) { return a == '_' && b == '_'; }),
+                name_str.end());
+
+            if (!name_str.empty() && name_str.front() == '_') {
+                name_str.erase(0, 1);
+            }
+            if (!name_str.empty() && name_str.back() == '_') {
+                name_str.pop_back();
+            }
+
+            // Get current date and time
+            auto now = std::chrono::system_clock::now();
+            std::time_t now_c = std::chrono::system_clock::to_time_t(now);
+            std::tm tm{};
+#if defined(_WIN32)
+            localtime_s(&tm, &now_c);
+#else
+            localtime_r(&now_c, &tm);
+#endif
+            std::ostringstream oss;
+            oss << std::put_time(&tm, "%b");
+            std::string month = oss.str();
+            std::transform(month.begin(), month.end(), month.begin(), ::tolower);
+
+            std::ostringstream date_time;
+            date_time << month << std::setw(2) << std::setfill('0') << tm.tm_mday << "_" << std::setw(2)
+                      << std::setfill('0') << tm.tm_hour << std::setw(2) << std::setfill('0') << tm.tm_min;
+
+            std::string dir_name = name_str + "_" + date_time.str();
+            cached_report_path = this->attributes.root_report_path / dir_name;
+        }
+
+        // snake_cased(report_name)_monthdd_HHMM
+        return cached_report_path;
+    }
+
+    return std::nullopt;
+}
+
+void Config::validate(std::string_view name) const {
+    if (name == "enable_fast_runtime_mode" or name == "enable_logging") {
+        if (this->attributes.enable_fast_runtime_mode) {
+            if (this->attributes.enable_logging) {
+                log_warning(
+                    tt::LogAlways,
+                    "Logging cannot be enabled in fast runtime mode. Please disable fast runtime mode if you want "
+                    "to enable logging.");
+            }
+        }
+    }
+
+    if (name == "enable_comparison_mode") {
+        if (this->attributes.enable_fast_runtime_mode && this->attributes.enable_comparison_mode) {
+            log_warning(
+                tt::LogAlways,
+                "Comparison mode is currently not supported with fast runtime mode enabled. Please disable fast "
+                "runtime mode ('enable_fast_runtime_mode = false') to use tensor comparison mode.");
+        }
+    }
+
+    if (name == "enable_fast_runtime_mode" or name == "enable_graph_report" or
+        name == "enable_detailed_buffer_report" or name == "enable_detailed_tensor_report") {
+        if (not this->attributes.enable_logging) {
+            if (this->attributes.enable_graph_report) {
+                log_warning(tt::LogAlways, "Running without logging. Please enable logging to save graph report");
+            }
+            if (this->attributes.enable_detailed_buffer_report) {
+                log_warning(
+                    tt::LogAlways, "Running without logging. Please enable logging to save detailed buffer report");
+            }
+            if (this->attributes.enable_detailed_tensor_report) {
+                log_warning(
+                    tt::LogAlways, "Running without logging. Please enable logging to save detailed tensor report");
+            }
+        }
+    }
+}
+
+std::ostream& operator<<(std::ostream& os, const Config& config) {
+    os << "Config{";
+    reflect::for_each(
+        [&](auto I) {
+            os << reflect::member_name<I>(config.attributes) << "="
+               << fmt::format("{}", reflect::get<I>(config.attributes)) << ",";
+        },
+        config.attributes);
+    os << fmt::format("{}", config.get<"report_path">());
+    os << "}";
+    return os;
+}
+
+}  // namespace ttnn::core
+
+auto fmt::formatter<ttnn::Config>::format(const ttnn::Config& config, format_context& ctx) const
+    -> format_context::iterator {
+    std::stringstream ss;
+    ss << config;
+    return fmt::format_to(ctx.out(), "{}", ss.str());
 }

--- a/ttnn/core/events.cpp
+++ b/ttnn/core/events.cpp
@@ -9,8 +9,6 @@
 #include "ttnn/common/queue_id.hpp"
 #include "ttnn/distributed/types.hpp"
 
-#include <tt-metalium/host_api.hpp>
-
 namespace ttnn::events {
 
 using ::tt::tt_metal::distributed::EventSynchronize;

--- a/ttnn/core/graph/graph_processor.cpp
+++ b/ttnn/core/graph/graph_processor.cpp
@@ -11,9 +11,7 @@
 #include <cxxabi.h>
 #include <memory>
 #include <string>
-#include <tt-metalium/circular_buffer.hpp>
 #include <tt-metalium/program.hpp>
-#include <tt_stl/reflection.hpp>
 #include <unordered_map>
 
 using namespace tt::tt_metal;

--- a/ttnn/core/tensor/tensor_attributes.cpp
+++ b/ttnn/core/tensor/tensor_attributes.cpp
@@ -2,8 +2,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <tt-metalium/host_buffer.hpp>
-
 #include "ttnn/tensor/storage.hpp"
 #include "ttnn/tensor/tensor_attributes.hpp"
 #include "ttnn/tensor/tensor_spec.hpp"

--- a/ttnn/cpp/ttnn-nanobind/bind_function.hpp
+++ b/ttnn/cpp/ttnn-nanobind/bind_function.hpp
@@ -8,7 +8,6 @@
 #include <array>
 #include <cstddef>
 #include <string>
-#include <tt-logger/tt-logger.hpp>
 #include <tuple>
 #include <type_traits>
 #include <utility>
@@ -16,8 +15,6 @@
 #include <nanobind/nanobind.h>
 #include <nanobind/stl/optional.h>
 #include <nanobind/stl/string.h>
-
-#include <tt_stl/assert.hpp>
 
 namespace ttnn {
 

--- a/ttnn/cpp/ttnn-nanobind/global_circular_buffer.cpp
+++ b/ttnn/cpp/ttnn-nanobind/global_circular_buffer.cpp
@@ -13,8 +13,6 @@
 #include <nanobind/stl/vector.h>
 
 #include "ttnn/global_circular_buffer.hpp"
-#include <tt-metalium/global_circular_buffer.hpp>
-
 namespace ttnn::global_circular_buffer {
 
 void py_module_types(nb::module_& mod) {

--- a/ttnn/cpp/ttnn/operations/ccl/all_broadcast/device/all_broadcast_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_broadcast/device/all_broadcast_program_factory.cpp
@@ -12,7 +12,6 @@
 #include "ttnn/operations/ccl/sharding_addrgen_helper.hpp"
 #include "ttnn/global_semaphore.hpp"
 
-#include <tt-metalium/core_coord.hpp>
 #include <tt-metalium/buffer.hpp>
 #include <tt-metalium/experimental/fabric/fabric.hpp>
 #include <tt-metalium/host_api.hpp>

--- a/ttnn/cpp/ttnn/operations/ccl/broadcast/device/broadcast_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/broadcast/device/broadcast_device_operation_types.hpp
@@ -8,8 +8,6 @@
 #include "ttnn/device_operation.hpp"
 #include <tt-metalium/sub_device.hpp>
 #include <tt-metalium/experimental/fabric/fabric.hpp>
-#include <tt_stl/reflection.hpp>
-
 namespace ttnn::prim {
 
 struct BroadcastParams {

--- a/ttnn/cpp/ttnn/operations/ccl/broadcast/device/broadcast_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/broadcast/device/broadcast_program_factory.cpp
@@ -11,7 +11,6 @@
 #include "ttnn/operations/ccl/sharding_addrgen_helper.hpp"
 #include "ttnn/global_semaphore.hpp"
 
-#include <tt-metalium/core_coord.hpp>
 #include <tt-metalium/buffer.hpp>
 #include <tt-metalium/experimental/fabric/fabric.hpp>
 #include <tt-metalium/host_api.hpp>

--- a/ttnn/cpp/ttnn/operations/ccl/mesh_partition/device/mesh_partition_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/mesh_partition/device/mesh_partition_program_factory.cpp
@@ -7,7 +7,6 @@
 #include <tuple>
 #include <vector>
 #include "ttnn/distributed/types.hpp"
-#include <tt-metalium/core_coord.hpp>
 #include <tt-metalium/sub_device.hpp>
 #include <tt-metalium/experimental/fabric/fabric.hpp>
 #include "ttnn/operations/data_movement/slice/device/slice_device_operation.hpp"

--- a/ttnn/cpp/ttnn/operations/ccl/reduce_to_root/reduce_to_root.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/reduce_to_root/reduce_to_root.cpp
@@ -2,8 +2,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 ///
-#include "ttnn/decorators.hpp"
-
 #include "device/reduce_to_root_op.hpp"
 #include "reduce_to_root.hpp"
 

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_device_operation.cpp
@@ -13,7 +13,6 @@
 #include <tt-metalium/math.hpp>
 
 #include <tt-metalium/tt_metal.hpp>
-#include <tt-metalium/circular_buffer.hpp>
 #include <tt-metalium/constants.hpp>
 
 #include <tt-metalium/work_split.hpp>

--- a/ttnn/cpp/ttnn/operations/copy/typecast/device/typecast_rm_chunked_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/copy/typecast/device/typecast_rm_chunked_program_factory.cpp
@@ -4,7 +4,6 @@
 
 #include "typecast_rm_chunked_program_factory.hpp"
 
-#include <tt-logger/tt-logger.hpp>
 #include <tt-metalium/work_split.hpp>
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/host_api.hpp>

--- a/ttnn/cpp/ttnn/operations/data_movement/copy/copy.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/copy/copy.cpp
@@ -7,7 +7,6 @@
 #include <utility>
 
 #include "device/copy_device_operation.hpp"
-#include "ttnn/decorators.hpp"
 #include "ttnn/operation.hpp"
 
 using namespace tt::tt_metal;

--- a/ttnn/cpp/ttnn/operations/data_movement/data_movement_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/data_movement_nanobind.cpp
@@ -6,7 +6,6 @@
 
 #include <nanobind/nanobind.h>
 
-#include "ttnn-nanobind/decorators.hpp"
 #include "ttnn/operations/data_movement/sharded/interleaved_to_sharded/interleaved_to_sharded_nanobind.hpp"
 #include "ttnn/operations/data_movement/sharded/reshard/reshard_nanobind.hpp"
 #include "ttnn/operations/data_movement/sharded/sharded_to_interleaved/sharded_to_interleaved_nanobind.hpp"

--- a/ttnn/cpp/ttnn/operations/data_movement/fill_rm/fill_rm.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fill_rm/fill_rm.cpp
@@ -5,8 +5,6 @@
 #include "fill_rm.hpp"
 #include "device/fill_rm_device_operation.hpp"
 #include "ttnn/operation.hpp"
-#include "ttnn/decorators.hpp"
-
 namespace ttnn::operations::data_movement {
 
 ttnn::Tensor FillRMOperation::invoke(

--- a/ttnn/cpp/ttnn/operations/data_movement/move/move.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/move/move.cpp
@@ -5,7 +5,6 @@
 #include "ttnn/operations/data_movement/move/move.hpp"
 
 #include "device/move_device_operation.hpp"
-#include "ttnn/decorators.hpp"
 #include "ttnn/operation.hpp"
 #include "ttnn/distributed/api.hpp"
 #include "ttnn/tensor/tensor_ops.hpp"

--- a/ttnn/cpp/ttnn/operations/data_movement/repeat/device/repeat_program_factory_higher_dim.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/repeat/device/repeat_program_factory_higher_dim.cpp
@@ -9,7 +9,6 @@
 #include <tt-metalium/tensor_accessor_args.hpp>
 
 #include "ttnn/core.hpp"
-#include "ttnn/decorators.hpp"
 #include "ttnn/device_operation.hpp"
 #include "ttnn/operations/cb_utils.hpp"
 #include "ttnn/operations/math.hpp"

--- a/ttnn/cpp/ttnn/operations/data_movement/repeat/device/repeat_program_factory_last_dim.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/repeat/device/repeat_program_factory_last_dim.cpp
@@ -9,7 +9,6 @@
 #include <tt-metalium/tensor_accessor_args.hpp>
 
 #include "ttnn/core.hpp"
-#include "ttnn/decorators.hpp"
 #include "ttnn/device_operation.hpp"
 #include "ttnn/operations/cb_utils.hpp"
 #include "ttnn/operations/math.hpp"

--- a/ttnn/cpp/ttnn/operations/data_movement/repeat/repeat.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/repeat/repeat.cpp
@@ -4,8 +4,6 @@
 
 #include <functional>
 
-#include <tt-metalium/host_api.hpp>
-
 #include "ttnn/operations/core/core.hpp"
 #include "ttnn/operations/data_movement/sharded/sharded_to_interleaved/sharded_to_interleaved.hpp"
 #include "ttnn/operations/data_movement/sharded/interleaved_to_sharded/interleaved_to_sharded.hpp"

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/interleaved_to_sharded/interleaved_to_sharded_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/interleaved_to_sharded/interleaved_to_sharded_nanobind.cpp
@@ -12,8 +12,6 @@
 #include "ttnn-nanobind/decorators.hpp"
 #include "interleaved_to_sharded.hpp"
 #include "ttnn/types.hpp"
-#include <tt-metalium/core_coord.hpp>
-
 namespace ttnn::operations::data_movement {
 
 namespace detail {

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/reshard_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/reshard_nanobind.cpp
@@ -12,8 +12,6 @@
 #include "ttnn-nanobind/decorators.hpp"
 #include "reshard.hpp"
 #include "ttnn/types.hpp"
-#include <tt-metalium/core_coord.hpp>
-
 namespace ttnn::operations::data_movement {
 
 namespace detail {

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded_partial/interleaved_to_sharded_partial/device/interleaved_to_sharded_partial_op.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded_partial/interleaved_to_sharded_partial/device/interleaved_to_sharded_partial_op.cpp
@@ -6,7 +6,6 @@
 #include "ttnn/device_operation.hpp"
 #include "ttnn/tensor/tensor_ops.hpp"
 
-#include <tt-metalium/host_api.hpp>
 #include <tt-metalium/constants.hpp>
 #include <ttnn/operation.hpp>
 

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded_partial/interleaved_to_sharded_partial/interleaved_to_sharded_partial_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded_partial/interleaved_to_sharded_partial/interleaved_to_sharded_partial_nanobind.cpp
@@ -12,8 +12,6 @@
 #include "ttnn-nanobind/decorators.hpp"
 #include "interleaved_to_sharded_partial.hpp"
 #include "ttnn/types.hpp"
-#include <tt-metalium/core_coord.hpp>
-
 namespace ttnn::operations::data_movement {
 
 namespace detail {

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/device/factories/tilize_with_val_padding_factory_helper.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/device/factories/tilize_with_val_padding_factory_helper.cpp
@@ -4,7 +4,6 @@
 
 #include "ttnn/operations/data_movement/tilize_with_val_padding/device/factories/tilize_with_val_padding_factory_helper.hpp"
 
-#include <tt-metalium/host_api.hpp>
 #include <tt-metalium/bfloat16.hpp>
 #include "ttnn/tensor/types.hpp"
 #include "ttnn/operations/data_movement/common/common.hpp"

--- a/ttnn/cpp/ttnn/operations/debug/apply_device_delay.cpp
+++ b/ttnn/cpp/ttnn/operations/debug/apply_device_delay.cpp
@@ -9,12 +9,9 @@
 #include <cstdint>
 #include <vector>
 
-#include <tt_stl/assert.hpp>
 #include <tt-metalium/distributed.hpp>
 #include <tt-metalium/program.hpp>
 #include <tt-metalium/mesh_device.hpp>
-#include <tt-metalium/host_api.hpp>
-#include <tt-metalium/core_coord.hpp>
 #include <tt-metalium/mesh_coord.hpp>
 
 namespace ttnn::operations::debug {

--- a/ttnn/cpp/ttnn/operations/debug/apply_device_delay_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/debug/apply_device_delay_nanobind.cpp
@@ -12,7 +12,6 @@
 #include <nanobind/stl/optional.h>
 #include <nanobind/stl/vector.h>
 
-#include "ttnn-nanobind/decorators.hpp"
 #include "apply_device_delay.hpp"
 #include <tt-metalium/sub_device_types.hpp>
 

--- a/ttnn/cpp/ttnn/operations/eltwise/complex/complex.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/complex/complex.hpp
@@ -9,7 +9,6 @@
 
 #include "ttnn/tensor/tensor.hpp"
 #include "ttnn/decorators.hpp"
-#include <tt_stl/reflection.hpp>
 
 namespace ttnn {
 namespace operations::complex {

--- a/ttnn/cpp/ttnn/operations/experimental/bcast_to/bcast_to.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/bcast_to/bcast_to.cpp
@@ -5,7 +5,6 @@
 #include <optional>
 
 #include "bcast_to.hpp"
-#include <tt_stl/small_vector.hpp>
 #include "ttnn/operations/core/core.hpp"
 #include "ttnn/operations/experimental/bcast_to/device/bcast_to_device_operation.hpp"
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_device_operation_types.hpp
@@ -10,7 +10,6 @@
 
 #include <tt-metalium/sub_device_types.hpp>
 #include <tt-metalium/core_coord.hpp>
-#include <tt_stl/reflection.hpp>
 #include "ttnn/tensor/tensor.hpp"
 #include "ttnn/operations/ccl/ccl_common.hpp"
 #include "ttnn/operations/ccl/ccl_op_fusion.hpp"

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_concat_heads_fused/device/all_gather_concat_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_concat_heads_fused/device/all_gather_concat_device_operation_types.hpp
@@ -7,7 +7,6 @@
 #include "ttnn/tensor/tensor.hpp"
 #include "ttnn/operations/ccl/ccl_common.hpp"
 #include "ttnn/global_semaphore.hpp"
-#include <tt_stl/reflection.hpp>
 #include <optional>
 #include <vector>
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_matmul_async/device/all_gather_matmul_async_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_matmul_async/device/all_gather_matmul_async_device_operation.cpp
@@ -15,8 +15,6 @@
 #include "ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_device_operation.hpp"
 
 #include "ttnn/operations/experimental/ccl/all_gather_matmul_async/device/all_gather_matmul_async_program_factory.hpp"
-#include <tt-metalium/core_coord.hpp>
-
 namespace ttnn::experimental::prim {
 void AllGatherMatmulAsyncDeviceOperation::validate_on_program_cache_miss(
     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_matmul_async/device/all_gather_matmul_async_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_matmul_async/device/all_gather_matmul_async_program_factory.cpp
@@ -9,7 +9,6 @@
 #include "ttnn/operations/matmul/device/factory/matmul_multicore_reuse_mcast_1d_program_factory.hpp"
 #include "ttnn/operations/ccl/ccl_common.hpp"
 #include "ttnn/operations/ccl/ccl_op_fusion.hpp"
-#include <tt-metalium/core_coord.hpp>
 #include <unordered_map>
 #include <tt_stl/overloaded.hpp>
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce_async/device/all_reduce_async_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce_async/device/all_reduce_async_device_operation_types.hpp
@@ -9,7 +9,6 @@
 #include <vector>
 
 #include <tt-metalium/sub_device_types.hpp>
-#include <tt_stl/reflection.hpp>
 #include "ttnn/tensor/tensor.hpp"
 #include "ttnn/operations/ccl/ccl_common.hpp"
 #include "ttnn/operations/ccl/ccl_op_fusion.hpp"

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/deepseek_moe_reduce_scatter/device/deepseek_moe_reduce_scatter_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/deepseek_moe_reduce_scatter/device/deepseek_moe_reduce_scatter_device_operation_types.hpp
@@ -10,7 +10,6 @@
 
 #include <tt-metalium/core_coord.hpp>
 #include <tt-metalium/host_api.hpp>
-#include <tt_stl/reflection.hpp>
 #include "ttnn/operations/ccl/ccl_host_datastructures.hpp"
 
 namespace ttnn::experimental::prim {

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter_matmul/device/rs_matmul_op.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter_matmul/device/rs_matmul_op.cpp
@@ -4,7 +4,6 @@
 
 #include "ttnn/operations/experimental/ccl/llama_reduce_scatter_matmul/device/rs_matmul_op.hpp"
 
-#include <tt-metalium/core_coord.hpp>
 #include "ttnn/operations/experimental/ccl/llama_reduce_scatter/device/llama_reduce_scatter_device_operation.hpp"
 #include "ttnn/operations/math.hpp"
 #include "ttnn/operations/matmul/device/matmul_device_operation.hpp"

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter_matmul/device/rs_matmul_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter_matmul/device/rs_matmul_program_factory.cpp
@@ -10,7 +10,6 @@
 #include "ttnn/operations/ccl/ccl_common.hpp"
 #include "ttnn/operations/ccl/shared_with_host/sharded_tensor_addr_gen.hpp"
 #include "ttnn/operations/ccl/sharding_addrgen_helper.hpp"
-#include <tt-metalium/core_coord.hpp>
 #include "ttnn/operations/ccl/common/host/ccl_worker_builder.hpp"
 #include <tt-metalium/experimental/fabric/fabric.hpp>
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/matmul_reduce_scatter_async/device/matmul_reduce_scatter_async_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/matmul_reduce_scatter_async/device/matmul_reduce_scatter_async_program_factory.cpp
@@ -7,8 +7,6 @@
 #include <algorithm>
 
 #include <tt-metalium/host_api.hpp>
-#include <tt-metalium/core_coord.hpp>
-#include <tt-metalium/buffer.hpp>
 #include <tt-metalium/work_split.hpp>
 
 #include "ttnn/operations/math.hpp"

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/reduce_scatter_minimal_async_op_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/reduce_scatter_minimal_async_op_device_operation_types.hpp
@@ -10,7 +10,6 @@
 
 #include <tt-metalium/core_coord.hpp>
 #include <tt-metalium/host_api.hpp>
-#include <tt_stl/reflection.hpp>
 #include "ttnn/tensor/tensor.hpp"
 #include "ttnn/operations/ccl/ccl_host_datastructures.hpp"
 #include "ttnn/operations/ccl/ccl_common.hpp"

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/send_recv_async/recv_async/device/recv_async_op_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/send_recv_async/recv_async/device/recv_async_op_device_operation_types.hpp
@@ -7,7 +7,6 @@
 #include <vector>
 
 #include <tt-metalium/experimental/sockets/mesh_socket.hpp>
-#include <tt_stl/reflection.hpp>
 #include "ttnn/tensor/tensor.hpp"
 
 namespace ttnn::experimental::prim {

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/send_recv_async/send_async/device/send_async_op_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/send_recv_async/send_async/device/send_async_op_device_operation_types.hpp
@@ -7,7 +7,6 @@
 #include <vector>
 
 #include <tt-metalium/experimental/sockets/mesh_socket.hpp>
-#include <tt_stl/reflection.hpp>
 #include "ttnn/tensor/tensor.hpp"
 
 namespace ttnn::experimental::prim {

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/send_recv_async/send_async/device/send_async_op_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/send_recv_async/send_async/device/send_async_op_program_factory.cpp
@@ -11,7 +11,6 @@
 #include <utility>
 #include <vector>
 
-#include <tt-metalium/core_coord.hpp>
 #include <tt-metalium/buffer.hpp>
 #include <tt-metalium/experimental/fabric/fabric.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/strided_all_gather_minimal_matmul_async/device/strided_all_gather_minimal_matmul_async_program.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/strided_all_gather_minimal_matmul_async/device/strided_all_gather_minimal_matmul_async_program.cpp
@@ -4,9 +4,6 @@
 ///
 #include <algorithm>
 
-#include <tt-metalium/core_coord.hpp>
-#include <tt-metalium/buffer.hpp>
-
 #include "ttnn/operations/experimental/ccl/strided_all_gather_async/device/strided_all_gather_async_op.hpp"
 #include "ttnn/operations/ccl/shared_with_host/hetergeneous_data_structs.hpp"
 #include "ttnn/operations/ccl/ccl_host_datastructures.hpp"

--- a/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_hwc/device/gather.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_hwc/device/gather.cpp
@@ -7,7 +7,6 @@
  */
 
 #include "gather.hpp"
-#include <tt-metalium/host_api.hpp>
 #include <tt-metalium/math.hpp>
 #include <algorithm>
 #include <cstring>

--- a/ttnn/cpp/ttnn/operations/experimental/copy/typecast/typecast.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/copy/typecast/typecast.cpp
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "ttnn/operation.hpp"
-#include "ttnn/decorators.hpp"
 #include "typecast.hpp"
 #include "ttnn/operations/data_movement/copy/device/copy_device_operation.hpp"
 

--- a/ttnn/cpp/ttnn/operations/experimental/padded_slice/padded_slice.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/padded_slice/padded_slice.cpp
@@ -5,7 +5,6 @@
 #include "device/padded_slice_device_operation.hpp"
 #include <array>
 #include <cstdint>
-#include <tt-logger/tt-logger.hpp>
 #include "ttnn/common/constants.hpp"
 #include "ttnn/operations/creation.hpp"
 #include "ttnn/operations/core/core.hpp"

--- a/ttnn/cpp/ttnn/operations/experimental/plusone/plusone.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/plusone/plusone.cpp
@@ -5,7 +5,6 @@
 #include "device/plusone_device_operation.hpp"
 #include "ttnn/operations/experimental/plusone/plusone.hpp"
 
-#include "ttnn/decorators.hpp"
 #include "ttnn/operations/core/core.hpp"
 
 namespace ttnn::operations::experimental {

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/integral_image/intimg.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/integral_image/intimg.cpp
@@ -4,7 +4,6 @@
 
 #include "device/intimg_device_operation.hpp"
 
-#include <tt_stl/assert.hpp>
 #include "intimg.hpp"
 
 namespace ttnn::operations::experimental::reduction {

--- a/ttnn/cpp/ttnn/operations/experimental/slice_write/device/slice_write_rm_interleaved_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/slice_write/device/slice_write_rm_interleaved_program_factory.cpp
@@ -5,7 +5,6 @@
 #include "slice_write_rm_interleaved_program_factory.hpp"
 
 #include <cstdint>
-#include <tt-logger/tt-logger.hpp>
 #include <tt-metalium/work_split.hpp>
 #include <tt-metalium/hal.hpp>
 #include <tt-metalium/host_api.hpp>

--- a/ttnn/cpp/ttnn/operations/experimental/test/hang_device/hang_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/test/hang_device/hang_device_operation.cpp
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "ttnn/operation.hpp"
-#include "ttnn/decorators.hpp"
 #include "ttnn/operations/core/core.hpp"
 #include "hang_device_operation.hpp"
 #include "ttnn/tensor/tensor_ops.hpp"

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/all_reduce_create_qkv_heads/device/all_reduce_create_qkv_heads_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/all_reduce_create_qkv_heads/device/all_reduce_create_qkv_heads_device_operation_types.hpp
@@ -8,8 +8,6 @@
 #include "ttnn/tensor/tensor.hpp"
 
 #include <tt-metalium/sub_device_types.hpp>
-#include <tt_stl/reflection.hpp>
-
 #include <cstdint>
 #include <optional>
 #include <vector>

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/dit_layernorm_post_all_gather/device/dit_layernorm_post_all_gather_welford_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/dit_layernorm_post_all_gather/device/dit_layernorm_post_all_gather_welford_program_factory.cpp
@@ -7,7 +7,6 @@
 #include <tt-metalium/work_split.hpp>
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/constants.hpp>
-#include <tt-metalium/circular_buffer.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
 #include "ttnn/operations/math.hpp"
 

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/dit_layernorm_pre_all_gather/device/dit_layernorm_pre_all_gather_welford_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/dit_layernorm_pre_all_gather/device/dit_layernorm_pre_all_gather_welford_program_factory.cpp
@@ -7,7 +7,6 @@
 #include <tt-metalium/work_split.hpp>
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/constants.hpp>
-#include <tt-metalium/circular_buffer.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
 #include <tt-metalium/bfloat16.hpp>
 

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/fused_distributed_rmsnorm/device/fused_rmsnorm_post_all_gather_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/fused_distributed_rmsnorm/device/fused_rmsnorm_post_all_gather_program_factory.cpp
@@ -15,7 +15,6 @@
 
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/constants.hpp>
-#include <tt-metalium/circular_buffer.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
 
 namespace ttnn::experimental::prim {

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/fused_distributed_rmsnorm/device/fused_rmsnorm_pre_all_gather_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/fused_distributed_rmsnorm/device/fused_rmsnorm_pre_all_gather_program_factory.cpp
@@ -7,7 +7,6 @@
 #include <tt-metalium/work_split.hpp>
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/constants.hpp>
-#include <tt-metalium/circular_buffer.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
 
 #include "ttnn/operations/math.hpp"

--- a/ttnn/cpp/ttnn/operations/experimental/unary_backward/gelu_backward/device/gelu_backward_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/unary_backward/gelu_backward/device/gelu_backward_device_operation.cpp
@@ -6,8 +6,6 @@
 #include "ttnn/tensor/tensor_ops.hpp"
 #include "gelu_backward_program_factory.hpp"
 
-#include "tt-metalium/host_api.hpp"
-
 using namespace tt::tt_metal;
 
 namespace ttnn::experimental::prim {

--- a/ttnn/cpp/ttnn/operations/experimental/where/device/where_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/where/device/where_device_operation.cpp
@@ -11,8 +11,6 @@
 
 #include <tt-metalium/hal_types.hpp>
 #include <tt-metalium/work_split.hpp>
-#include <tt-metalium/host_api.hpp>
-
 #include <tracy/Tracy.hpp>
 #include <tt_stl/assert.hpp>
 

--- a/ttnn/cpp/ttnn/operations/generic/device/generic_op_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/generic/device/generic_op_program_factory.cpp
@@ -2,7 +2,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <tt-metalium/buffer.hpp>
 #include <tt-metalium/circular_buffer_config.hpp>
 #include <tt-metalium/program.hpp>
 #include <tt-metalium/host_api.hpp>

--- a/ttnn/cpp/ttnn/operations/index_fill/index_fill.cpp
+++ b/ttnn/cpp/ttnn/operations/index_fill/index_fill.cpp
@@ -4,7 +4,6 @@
 
 #include "index_fill.hpp"
 
-#include "ttnn/decorators.hpp"
 #include "ttnn/operations/index_fill/device/index_fill_device_operation.hpp"
 
 namespace ttnn::operations::index_fill {

--- a/ttnn/cpp/ttnn/operations/math.hpp
+++ b/ttnn/cpp/ttnn/operations/math.hpp
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include <tt_stl/assert.hpp>
+#include <cassert>
 namespace tt::tt_metal {
 
 template <typename T>
@@ -14,7 +14,7 @@ bool is_power_of_two(T val) {
 
 template <typename T>
 bool is_power_of_two_at_least(T val, T power2) {
-    TT_ASSERT(is_power_of_two(power2));
+    assert(is_power_of_two(power2));
     return (val & (val - power2)) == T(0);
 }
 

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/layernorm_pre_all_gather_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/layernorm_pre_all_gather_program_factory.cpp
@@ -7,7 +7,6 @@
 #include <tt-metalium/work_split.hpp>
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/constants.hpp>
-#include <tt-metalium/circular_buffer.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
 #include "ttnn/operations/math.hpp"
 

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/layernorm_pre_all_gather_welford_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/layernorm_pre_all_gather_welford_program_factory.cpp
@@ -7,7 +7,6 @@
 #include <tt-metalium/work_split.hpp>
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/constants.hpp>
-#include <tt-metalium/circular_buffer.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
 #include "ttnn/operations/math.hpp"
 

--- a/ttnn/cpp/ttnn/operations/point_to_point/point_to_point.cpp
+++ b/ttnn/cpp/ttnn/operations/point_to_point/point_to_point.cpp
@@ -2,8 +2,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 ///
-#include "ttnn/decorators.hpp"
-
 #include "device/host/point_to_point_device_op.hpp"
 #include "point_to_point.hpp"
 

--- a/ttnn/cpp/ttnn/operations/pool/upsample/device/upsample_program_factory_multicore_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/upsample/device/upsample_program_factory_multicore_sharded.cpp
@@ -12,7 +12,6 @@
 #include <tt-metalium/math.hpp>
 #include <tt-metalium/work_split.hpp>
 
-#include <tt_stl/reflection.hpp>
 #include "ttnn/tensor/host_buffer/functions.hpp"
 #include "ttnn/operations/pool/upsample/device/upsample_program_factory_multicore_sharded.hpp"
 #include "ttnn/operations/pool/upsample/device/upsample_common.hpp"

--- a/ttnn/cpp/ttnn/operations/prefetcher/prefetcher/dram_prefetcher.cpp
+++ b/ttnn/cpp/ttnn/operations/prefetcher/prefetcher/dram_prefetcher.cpp
@@ -4,7 +4,6 @@
 
 #include "dram_prefetcher.hpp"
 #include <optional>
-#include <tt-metalium/global_circular_buffer.hpp>
 #include "device/dram_prefetcher_device_operation.hpp"
 
 namespace ttnn::operations::dram_prefetcher {

--- a/ttnn/cpp/ttnn/operations/reduction/accumulation/cumprod/cumprod.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/accumulation/cumprod/cumprod.cpp
@@ -12,7 +12,6 @@
 #include <ttnn/operations/data_movement/unsqueeze/unsqueeze.hpp>
 #include <utility>
 
-#include <tt_stl/assert.hpp>
 #include "cumprod.hpp"
 
 namespace ttnn {

--- a/ttnn/cpp/ttnn/operations/reduction/accumulation/cumsum/cumsum.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/accumulation/cumsum/cumsum.cpp
@@ -9,8 +9,6 @@
 
 #include "cumsum.hpp"
 
-#include <tt-logger/tt-logger.hpp>
-#include <tt_stl/small_vector.hpp>
 #include <utility>
 #include "ttnn/tensor/tensor.hpp"
 #include "ttnn/tensor/types.hpp"

--- a/ttnn/cpp/ttnn/operations/transformer/transformer_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/transformer_nanobind.cpp
@@ -6,6 +6,7 @@
 
 #include <cstddef>
 #include <optional>
+#include <tt_stl/reflection.hpp>
 
 #include <nanobind/nanobind.h>
 #include <nanobind/stl/optional.h>


### PR DESCRIPTION
Push includes towards cpp translation units and remove unnecessary heavy includes.

## Summary

This PR reduces header include weight through:
1. Moving heavy includes from headers to implementation files
2. Removing unused heavy includes identified via clang-tidy
3. Pushing implementation details to .cpp files

**Net change: -190 lines** (183 added, 373 removed)

Additionally: `build_metal.sh` was enhanced to have a disable-pch flag so we can experiment with measuring build times without PCH.

## Key Changes

### Header-to-Implementation Refactoring
- **config.hpp** (771 downstream): Moved operator<<, validate(), fmt::formatter to .cpp
- **tt_cluster.hpp** (85 downstream): Moved inline getters using TT_FATAL to .cpp
- **math.hpp** (142 downstream): Replaced TT_ASSERT with standard assert

### Removed Unused Heavy Includes
- Removed reflection.hpp from 12 headers
- Removed assert.hpp from 11 headers
- Removed tt-logger.hpp from 3 headers
- Cleaned up 183 unused includes from 155 .cpp files

### Fixed Transitive Include Issues
- Added missing direct includes where needed when unity builds are disabled

### Checklist
- [x] [APC](https://github.com/tenstorrent/tt-metal/actions/runs/21919352812)
- [x] [APC after vacation rebase](https://github.com/tenstorrent/tt-metal/actions/runs/22378908720)