### PR TITLE
Halo Check Output Grid Matches Input Grid

### DIFF
--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d.cpp
@@ -272,7 +272,6 @@ Result conv2d_L1(
                 0,
                 false,
                 parallel_config.shard_orientation == ShardOrientation::COL_MAJOR,
-                input_tensor_post_tm.memory_config(),
                 true,
                 conv_config.config_tensors_in_dram);
 

--- a/ttnn/cpp/ttnn/operations/conv/conv_transpose2d/conv_transpose2d.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv_transpose2d/conv_transpose2d.cpp
@@ -293,7 +293,6 @@ ConvTranspose2dResult conv_transpose2d_L1(
             0,
             false,
             parallel_config.shard_orientation == ShardOrientation::COL_MAJOR,
-            input_tensor_post_tm.memory_config(),
             /*is_out_tiled*/ true,
             conv_config.config_tensors_in_dram);
 

--- a/ttnn/cpp/ttnn/operations/data_movement/fold/fold.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fold/fold.cpp
@@ -331,8 +331,7 @@ static Tensor apply_halo_padding(
     ttnn::Shape new_shape({1, 1, input_shape[0] * input_shape[1] * input_shape[2], input_shape[3]});
     auto reshaped_tensor = ttnn::reshape(input_tensor, new_shape);
 
-    auto halo_output =
-        ttnn::halo(reshaped_tensor, sliding_window_config, 0, false, false, reshaped_tensor.memory_config(), false);
+    auto halo_output = ttnn::halo(reshaped_tensor, sliding_window_config, 0, false, false, false);
 
     // Reshape back to padded original dimensions
     ttnn::Shape padded_shape(

--- a/ttnn/cpp/ttnn/operations/pool/generic/generic_pools.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/generic_pools.cpp
@@ -297,7 +297,6 @@ static std::vector<Tensor> pool2d_L1(
         get_bf16_pool_init_value(pool_type),  // pad_val
         false,
         parallel_config.shard_orientation == ShardOrientation::COL_MAJOR,
-        input_tensor_sharded.memory_config(),
         is_out_tiled,
         config_tensor_in_dram);
 

--- a/ttnn/cpp/ttnn/operations/pool/upsample/upsample.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/upsample/upsample.cpp
@@ -49,10 +49,9 @@ static std::pair<Tensor, sliding_window::SlidingWindowConfig> apply_bilinear_hal
     tt::tt_metal::Tensor haloed_tensor = ttnn::halo(
         input_tensor_reshaped,
         sliding_window_config,
-        0,      // pad_val
-        false,  // remote_read
-        false,  // transpose_mcast
-        input_tensor_reshaped.memory_config(),
+        0,       // pad_val
+        false,   // remote_read
+        false,   // transpose_mcast
         false);  // is_out_tiled
 
     return {haloed_tensor, sliding_window_config};

--- a/ttnn/cpp/ttnn/operations/sliding_window/halo/device/halo_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/sliding_window/halo/device/halo_device_operation.cpp
@@ -78,7 +78,7 @@ HaloDeviceOperation::spec_return_value_t HaloDeviceOperation::compute_output_spe
         tt::div_up(output_shape[0] * output_shape[2], args.config.num_cores_nhw),
         input_tensor.memory_config().shard_spec()->shape[1]};
 
-    auto out_mem_config = input_tensor.memory_config();
+    const auto& out_mem_config = input_tensor.memory_config();
     auto padded_output_shape = output_shape;
     padded_output_shape[-2] = tt::round_up(padded_output_shape[-2], shard_shape[0]);
     padded_output_shape[-1] = tt::round_up(padded_output_shape[-1], shard_shape[1]);

--- a/ttnn/cpp/ttnn/operations/sliding_window/halo/device/halo_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/sliding_window/halo/device/halo_device_operation.cpp
@@ -78,7 +78,10 @@ HaloDeviceOperation::spec_return_value_t HaloDeviceOperation::compute_output_spe
         tt::div_up(output_shape[0] * output_shape[2], args.config.num_cores_nhw),
         input_tensor.memory_config().shard_spec()->shape[1]};
 
-    const auto& out_mem_config = input_tensor.memory_config();
+    auto out_mem_config = input_tensor.memory_config().with_shard_spec(ShardSpec{
+        input_tensor.memory_config().shard_spec()->grid,
+        shard_shape,
+        input_tensor.memory_config().shard_spec()->orientation});
     auto padded_output_shape = output_shape;
     padded_output_shape[-2] = tt::round_up(padded_output_shape[-2], shard_shape[0]);
     padded_output_shape[-1] = tt::round_up(padded_output_shape[-1], shard_shape[1]);

--- a/ttnn/cpp/ttnn/operations/sliding_window/halo/device/halo_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/sliding_window/halo/device/halo_device_operation.hpp
@@ -39,7 +39,6 @@ Tensor halo(
     uint32_t pad_val,
     bool remote_read,
     bool transpose_mcast,
-    const MemoryConfig& output_memory_config,
     bool is_out_tiled,
     bool config_tensors_in_dram);
 

--- a/ttnn/cpp/ttnn/operations/sliding_window/halo/halo.cpp
+++ b/ttnn/cpp/ttnn/operations/sliding_window/halo/halo.cpp
@@ -13,17 +13,9 @@ Tensor HaloOperation::invoke(
     uint32_t pad_val,
     bool remote_read,
     bool transpose_mcast,
-    const MemoryConfig& output_memory_config,
     bool is_out_tiled,
     bool config_tensors_in_dram) {
     return ttnn::prim::halo(
-        input_tensor,
-        config,
-        pad_val,
-        remote_read,
-        transpose_mcast,
-        output_memory_config,
-        is_out_tiled,
-        config_tensors_in_dram);
+        input_tensor, config, pad_val, remote_read, transpose_mcast, is_out_tiled, config_tensors_in_dram);
 }
 };  // namespace ttnn::operations::sliding_window::halo

--- a/ttnn/cpp/ttnn/operations/sliding_window/halo/halo.hpp
+++ b/ttnn/cpp/ttnn/operations/sliding_window/halo/halo.hpp
@@ -17,7 +17,6 @@ struct HaloOperation {
         uint32_t pad_val = 0x0,
         bool remote_read = false,
         bool transpose_mcast = true,
-        const tt::tt_metal::MemoryConfig& output_memory_config = tt::tt_metal::operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
         bool is_out_tiled = true,
         bool config_tensors_in_dram = false);
 


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/33980

### Problem description
Currently the user can specify an output memory config which contains a core grid different from that used in the input tensor's memory config.  This will cause undefined behavior.

### What's changed
We now assert that the grid's match.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes:
https://github.com/tenstorrent/tt-metal/actions/runs/22001330861
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes:
https://github.com/tenstorrent/tt-metal/actions/runs/22001340748
- [x] [Nightly L2](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml) CI passes:
https://github.com/tenstorrent/tt-metal/actions/runs/22001353480
- [x] [Nightly Blackhole](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-nightly-tests.yaml) CI passes:
https://github.com/tenstorrent/tt-metal/actions/runs/22001344023
- [x] [Frequent model](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml) CI passes:
https://github.com/tenstorrent/tt-metal/actions/runs/22001349891
unrelated errors