### PR TITLE
Enable PCH and Unity builds for tt-metal tests and impl targets

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,9 @@ repos:
   rev: v3.2.0
   hooks:
     - id: trailing-whitespace
+      exclude: \.patch$
     - id: end-of-file-fixer
+      exclude: \.patch$
     - id: check-yaml
       args: ["--unsafe"]
     - id: check-added-large-files

--- a/tests/tt_metal/tt_metal/CMakeLists.txt
+++ b/tests/tt_metal/tt_metal/CMakeLists.txt
@@ -12,6 +12,8 @@ include(sources.cmake)
 
 add_executable(unit_tests_legacy)
 target_sources(unit_tests_legacy PRIVATE ${UNIT_TESTS_LEGACY_SRC})
+TT_ENABLE_UNITY_BUILD(unit_tests_legacy)
+target_precompile_headers(unit_tests_legacy REUSE_FROM metal_common_pch)
 target_link_libraries(unit_tests_legacy PUBLIC test_metal_common_libs)
 target_include_directories(
     unit_tests_legacy
@@ -32,6 +34,7 @@ list(APPEND METAL_TEST_TARGETS unit_tests_legacy)
 
 # Standalone test_clean_init executable (not a gtest - requires custom main with skip-teardown handling)
 add_executable(test_clean_init test_clean_init.cpp)
+target_precompile_headers(test_clean_init REUSE_FROM metal_common_pch)
 target_link_libraries(test_clean_init PUBLIC Metalium::Metal)
 target_include_directories(
     test_clean_init

--- a/tests/tt_metal/tt_metal/api/CMakeLists.txt
+++ b/tests/tt_metal/tt_metal/api/CMakeLists.txt
@@ -28,6 +28,7 @@ target_link_libraries(
 )
 
 TT_ENABLE_UNITY_BUILD(unit_tests_api_lib)
+target_precompile_headers(unit_tests_api_lib REUSE_FROM metal_common_pch)
 
 # Create the test executable
 add_executable(unit_tests_api)

--- a/tests/tt_metal/tt_metal/data_movement/CMakeLists.txt
+++ b/tests/tt_metal/tt_metal/data_movement/CMakeLists.txt
@@ -3,6 +3,7 @@ include(sources.cmake)
 
 add_executable(unit_tests_data_movement ${UNIT_TESTS_DATA_MOVEMENT_SRC})
 TT_ENABLE_UNITY_BUILD(unit_tests_data_movement)
+target_precompile_headers(unit_tests_data_movement REUSE_FROM metal_common_pch)
 
 target_link_libraries(unit_tests_data_movement PUBLIC test_metal_common_libs)
 target_include_directories(

--- a/tests/tt_metal/tt_metal/debug_tools/CMakeLists.txt
+++ b/tests/tt_metal/tt_metal/debug_tools/CMakeLists.txt
@@ -9,6 +9,7 @@ function(create_unit_test_executable)
 
     # Enable unity build for the executable
     TT_ENABLE_UNITY_BUILD(${exec_name})
+    target_precompile_headers(${exec_name} REUSE_FROM metal_common_pch)
 
     # Link libraries
     target_link_libraries(${exec_name} PRIVATE test_metal_common_libs)
@@ -42,6 +43,7 @@ add_executable(unit_tests_inspector ${UNIT_TESTS_INSPECTOR_SRC})
 
 # Enable unity build for the executable
 TT_ENABLE_UNITY_BUILD(unit_tests_inspector)
+target_precompile_headers(unit_tests_inspector REUSE_FROM metal_common_pch)
 
 # Link libraries
 target_link_libraries(

--- a/tests/tt_metal/tt_metal/device/CMakeLists.txt
+++ b/tests/tt_metal/tt_metal/device/CMakeLists.txt
@@ -5,6 +5,7 @@ include(sources.cmake)
 add_library(unit_tests_device_smoke OBJECT)
 add_library(TT::Metalium::Test::Device::Smoke ALIAS unit_tests_device_smoke)
 TT_ENABLE_UNITY_BUILD(unit_tests_device_smoke)
+target_precompile_headers(unit_tests_device_smoke REUSE_FROM metal_common_pch)
 target_sources(unit_tests_device_smoke PRIVATE ${UNIT_TESTS_DEVICE_SMOKE_SOURCES})
 target_include_directories(
     unit_tests_device_smoke

--- a/tests/tt_metal/tt_metal/dispatch/CMakeLists.txt
+++ b/tests/tt_metal/tt_metal/dispatch/CMakeLists.txt
@@ -5,6 +5,7 @@ include(sources.cmake)
 add_library(unit_tests_dispatch_smoke OBJECT)
 add_library(TT::Metalium::Test::Dispatch::Smoke ALIAS unit_tests_dispatch_smoke)
 TT_ENABLE_UNITY_BUILD(unit_tests_dispatch_smoke)
+target_precompile_headers(unit_tests_dispatch_smoke REUSE_FROM metal_common_pch)
 target_sources(unit_tests_dispatch_smoke PRIVATE ${UNIT_TESTS_DISPATCH_SMOKE_SOURCES})
 target_include_directories(
     unit_tests_dispatch_smoke
@@ -21,6 +22,7 @@ target_link_libraries(unit_tests_dispatch_smoke PRIVATE test_metal_common_libs)
 add_library(unit_tests_dispatch_basic OBJECT)
 add_library(TT::Metalium::Test::Dispatch::Basic ALIAS unit_tests_dispatch_basic)
 TT_ENABLE_UNITY_BUILD(unit_tests_dispatch_basic)
+target_precompile_headers(unit_tests_dispatch_basic REUSE_FROM metal_common_pch)
 target_sources(unit_tests_dispatch_basic PRIVATE ${UNIT_TESTS_DISPATCH_BASIC_SOURCES})
 target_include_directories(
     unit_tests_dispatch_basic
@@ -36,6 +38,7 @@ target_link_libraries(unit_tests_dispatch_basic PRIVATE test_metal_common_libs)
 add_library(unit_tests_dispatch_slow OBJECT)
 add_library(TT::Metalium::Test::Dispatch::Slow ALIAS unit_tests_dispatch_slow)
 TT_ENABLE_UNITY_BUILD(unit_tests_dispatch_slow)
+target_precompile_headers(unit_tests_dispatch_slow REUSE_FROM metal_common_pch)
 target_sources(unit_tests_dispatch_slow PRIVATE ${UNIT_TESTS_DISPATCH_SLOW_SOURCES})
 target_include_directories(
     unit_tests_dispatch_slow

--- a/tests/tt_metal/tt_metal/eth/CMakeLists.txt
+++ b/tests/tt_metal/tt_metal/eth/CMakeLists.txt
@@ -9,6 +9,7 @@ function(create_unit_test_executable)
 
     # Enable unity build for the executable
     TT_ENABLE_UNITY_BUILD(${exec_name})
+    target_precompile_headers(${exec_name} REUSE_FROM metal_common_pch)
 
     # Link libraries
     target_link_libraries(${exec_name} PRIVATE test_metal_common_libs)

--- a/tests/tt_metal/tt_metal/integration/CMakeLists.txt
+++ b/tests/tt_metal/tt_metal/integration/CMakeLists.txt
@@ -3,6 +3,7 @@ include(sources.cmake)
 
 add_executable(unit_tests_integration ${UNIT_TESTS_INTEGRATION_SRC})
 TT_ENABLE_UNITY_BUILD(unit_tests_integration)
+target_precompile_headers(unit_tests_integration REUSE_FROM metal_common_pch)
 
 target_link_libraries(unit_tests_integration PUBLIC test_metal_common_libs)
 target_include_directories(

--- a/tests/tt_metal/tt_metal/jit_build/CMakeLists.txt
+++ b/tests/tt_metal/tt_metal/jit_build/CMakeLists.txt
@@ -3,6 +3,7 @@ include(sources.cmake)
 
 add_executable(unit_tests_jit_build ${UNIT_TESTS_JIT_BUILD_SRC})
 TT_ENABLE_UNITY_BUILD(unit_tests_jit_build)
+target_precompile_headers(unit_tests_jit_build REUSE_FROM metal_common_pch)
 
 target_link_libraries(unit_tests_jit_build PUBLIC test_metal_common_libs)
 

--- a/tests/tt_metal/tt_metal/lightmetal/CMakeLists.txt
+++ b/tests/tt_metal/tt_metal/lightmetal/CMakeLists.txt
@@ -3,6 +3,7 @@ include(sources.cmake)
 
 add_executable(unit_tests_lightmetal ${UNIT_TESTS_LIGHTMETAL_SRC})
 TT_ENABLE_UNITY_BUILD(unit_tests_lightmetal)
+target_precompile_headers(unit_tests_lightmetal REUSE_FROM metal_common_pch)
 
 target_link_libraries(
     unit_tests_lightmetal

--- a/tests/tt_metal/tt_metal/llk/CMakeLists.txt
+++ b/tests/tt_metal/tt_metal/llk/CMakeLists.txt
@@ -3,6 +3,7 @@ include(sources.cmake)
 
 add_executable(unit_tests_llk ${UNIT_TESTS_LLK_SRC})
 TT_ENABLE_UNITY_BUILD(unit_tests_llk)
+target_precompile_headers(unit_tests_llk REUSE_FROM metal_common_pch)
 
 target_link_libraries(unit_tests_llk PUBLIC test_metal_common_libs)
 target_include_directories(

--- a/tests/tt_metal/tt_metal/misc/CMakeLists.txt
+++ b/tests/tt_metal/tt_metal/misc/CMakeLists.txt
@@ -6,6 +6,7 @@ add_executable(unit_tests_misc ${UNIT_TESTS_MISC_SRC})
 
 # Enable unity build for the executable
 TT_ENABLE_UNITY_BUILD(unit_tests_misc)
+target_precompile_headers(unit_tests_misc REUSE_FROM metal_common_pch)
 
 # Link libraries
 target_link_libraries(

--- a/tests/tt_metal/tt_metal/noc/CMakeLists.txt
+++ b/tests/tt_metal/tt_metal/noc/CMakeLists.txt
@@ -3,6 +3,7 @@ include(sources.cmake)
 
 add_executable(unit_tests_noc ${UNIT_TESTS_NOC_SRC})
 TT_ENABLE_UNITY_BUILD(unit_tests_noc)
+target_precompile_headers(unit_tests_noc REUSE_FROM metal_common_pch)
 
 target_link_libraries(unit_tests_noc PUBLIC test_metal_common_libs)
 

--- a/tests/tt_metal/tt_metal/noc_debugging/CMakeLists.txt
+++ b/tests/tt_metal/tt_metal/noc_debugging/CMakeLists.txt
@@ -4,6 +4,7 @@ include(sources.cmake)
 add_executable(unit_tests_noc_debugging ${UNIT_TESTS_NOC_DEBUGGING_SRC})
 
 TT_ENABLE_UNITY_BUILD(unit_tests_noc_debugging)
+target_precompile_headers(unit_tests_noc_debugging REUSE_FROM metal_common_pch)
 
 target_link_libraries(unit_tests_noc_debugging PRIVATE test_metal_common_libs)
 

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/CMakeLists.txt
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/CMakeLists.txt
@@ -16,6 +16,7 @@ foreach(TEST_SRC ${PERF_MICROBENCH_TESTS_SRCS})
     string(REPLACE "wormhole" "wormhole_b0" TEST_TARGET ${TEST_TARGET})
 
     add_executable(${TEST_TARGET} ${TEST_SRC})
+    target_precompile_headers(${TEST_TARGET} REUSE_FROM metal_common_pch)
     target_link_libraries(${TEST_TARGET} PRIVATE test_metal_common_libs)
 
     if(${TEST_SRC} STREQUAL "dispatch/test_pgm_dispatch.cpp")

--- a/tests/tt_metal/tt_metal/sfpi/CMakeLists.txt
+++ b/tests/tt_metal/tt_metal/sfpi/CMakeLists.txt
@@ -6,6 +6,7 @@ add_library(unit_tests_sfpi_lib OBJECT)
 add_library(TT::Metalium::Test::SFPI ALIAS unit_tests_sfpi_lib)
 
 target_sources(unit_tests_sfpi_lib PRIVATE ${UNIT_TESTS_SFPI_SOURCES})
+target_precompile_headers(unit_tests_sfpi_lib REUSE_FROM metal_common_pch)
 target_include_directories(
     unit_tests_sfpi_lib
     BEFORE

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -374,4 +374,5 @@ CPMAddPackage(
         "CMAKE_CXX_EXTENSIONS ON"
     PATCHES
         capnproto_capture_this.patch
+        capnproto_pthread.patch
 )

--- a/third_party/capnproto_pthread.patch
+++ b/third_party/capnproto_pthread.patch
@@ -1,0 +1,41 @@
+diff --git a/c++/CMakeLists.txt b/c++/CMakeLists.txt
+index dcb370b5..2e3f660b 100644
+--- a/c++/CMakeLists.txt
++++ b/c++/CMakeLists.txt
+@@ -158,9 +158,6 @@ else()
+     message(SEND_ERROR "Cap'n Proto requires compiler-specific extensions (e.g., -std=gnu++14). Please leave CMAKE_CXX_EXTENSIONS undefined or ON.")
+   endif()
+ 
+-  if (NOT ANDROID)
+-    add_compile_options(-pthread)
+-  endif()
+ endif()
+ 
+ # Source =======================================================================
+diff --git a/c++/src/kj/CMakeLists.txt b/c++/src/kj/CMakeLists.txt
+index 48c49b74..3e47a2f8 100644
+--- a/c++/src/kj/CMakeLists.txt
++++ b/c++/src/kj/CMakeLists.txt
+@@ -80,8 +80,9 @@ add_library(kj ${kj_sources})
+ add_library(CapnProto::kj ALIAS kj)
+ target_compile_features(kj PUBLIC cxx_std_17)
+ 
++find_package(Threads REQUIRED)
+ if(UNIX AND NOT ANDROID)
+-  target_link_libraries(kj PUBLIC pthread)
++  target_link_libraries(kj PUBLIC Threads::Threads)
+ endif()
+ #make sure the lite flag propagates to all users (internal + external) of this library
+ target_compile_definitions(kj PUBLIC ${CAPNP_LITE_FLAG})
+@@ -149,10 +150,7 @@ if(NOT CAPNP_LITE)
+     target_compile_definitions(kj-async PUBLIC KJ_USE_FIBERS=0)
+   endif()
+ 
+-  if(UNIX)
+-    # external clients of this library need to link to pthreads
+-    target_compile_options(kj-async INTERFACE "-pthread")
+-  elseif(WIN32)
++  if(WIN32)
+     target_link_libraries(kj-async PUBLIC ws2_32)
+   endif()
+   # Ensure the library has a version set to match autotools build

--- a/tt_metal/common/CMakeLists.txt
+++ b/tt_metal/common/CMakeLists.txt
@@ -3,6 +3,7 @@ add_library(TT::Metalium::Common ALIAS common)
 
 # Enable unity builds for faster compilation
 TT_ENABLE_UNITY_BUILD(common)
+target_precompile_headers(common REUSE_FROM metal_common_pch)
 
 target_sources(
     common

--- a/tt_metal/detail/CMakeLists.txt
+++ b/tt_metal/detail/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(DETAIL_SRC ${CMAKE_CURRENT_SOURCE_DIR}/reports/memory_reporter.cpp)
 
 add_library(detail OBJECT ${DETAIL_SRC})
+target_precompile_headers(detail REUSE_FROM metal_common_pch)
 target_link_libraries(
     detail
     PUBLIC

--- a/tt_metal/distributed/CMakeLists.txt
+++ b/tt_metal/distributed/CMakeLists.txt
@@ -84,6 +84,7 @@ add_library(distributed OBJECT ${DISTRIBUTED_SRC})
 
 # Enable unity builds for faster compilation
 TT_ENABLE_UNITY_BUILD(distributed)
+target_precompile_headers(distributed REUSE_FROM metal_common_pch)
 
 foreach(FBS_FILE ${FLATBUFFER_SCHEMAS})
     GENERATE_FBS_HEADER(${FBS_FILE} TARGET distributed)

--- a/tt_metal/impl/CMakeLists.txt
+++ b/tt_metal/impl/CMakeLists.txt
@@ -172,6 +172,7 @@ add_library(Metalium::Metal::Impl ALIAS impl)
 
 # Enable unity builds for faster compilation
 TT_ENABLE_UNITY_BUILD(impl)
+target_precompile_headers(impl REUSE_FROM metal_common_pch)
 
 target_link_libraries(
     impl

--- a/tt_metal/jit_build/CMakeLists.txt
+++ b/tt_metal/jit_build/CMakeLists.txt
@@ -13,6 +13,7 @@ add_library(jit_build OBJECT ${JIT_BUILD_SRCS})
 
 # Enable unity builds for faster compilation
 TT_ENABLE_UNITY_BUILD(jit_build)
+target_precompile_headers(jit_build REUSE_FROM metal_common_pch)
 
 target_link_libraries(
     jit_build

--- a/tt_metal/llrt/CMakeLists.txt
+++ b/tt_metal/llrt/CMakeLists.txt
@@ -18,6 +18,7 @@ add_library(Metalium::Metal::LLRT ALIAS llrt)
 
 # Enable unity builds for faster compilation
 TT_ENABLE_UNITY_BUILD(llrt)
+target_precompile_headers(llrt REUSE_FROM metal_common_pch)
 
 add_subdirectory(hal)
 add_dependencies(llrt hal_generate_dev_msgs_header)

--- a/tt_metal/tools/CMakeLists.txt
+++ b/tt_metal/tools/CMakeLists.txt
@@ -5,6 +5,7 @@ add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/mem_bench)
 set(TOOLS_SRC ${CMAKE_CURRENT_SOURCE_DIR}/memset.cpp)
 
 add_library(tools OBJECT ${TOOLS_SRC})
+target_precompile_headers(tools REUSE_FROM metal_common_pch)
 target_link_libraries(
     tools
     PUBLIC


### PR DESCRIPTION
## Summary

Enable precompiled headers (PCH) and Unity builds across `tt_metal` to improve compilation times.

Clean build compile time improved about 5%

### Changes

**PCH (`metal_common_pch`) reuse — `tests/tt_metal`:**
- `unit_tests_legacy` — added Unity build + PCH
- `test_clean_init` — added PCH
- All test subdirectory targets (`api`, `data_movement`, `debug_tools`, `device`, `dispatch`, `eth`, `integration`, `jit_build`, `lightmetal`, `llk`, `misc`, `noc`, `noc_debugging`, `perf_microbenchmark`, `sfpi`) — added PCH

**PCH (`metal_common_pch`) reuse — `tt_metal/` impl targets:**
- `common`, `detail`, `distributed`, `impl`, `jit_build`, `llrt`, `tools` — added PCH

**capnproto `-pthread` patch (`third_party/capnproto_pthread.patch`):**
- capnproto v1.2.0 unconditionally injects `-pthread` as a compile option via `add_compile_options(-pthread)` and `target_compile_options(kj-async INTERFACE "-pthread")`. On modern glibc (2.34+), `FindThreads` correctly determines `-pthread` is unnecessary, so these hardcoded flags create a mismatch with the PCH (compiled without `-pthread`), causing build failures.
- The patch replaces `target_link_libraries(kj PUBLIC pthread)` with `Threads::Threads` (modern CMake), removes the `INTERFACE "-pthread"` from `kj-async`, and removes the directory-scoped `add_compile_options(-pthread)`.

**Pre-commit config:**
- Exclude `.patch` files from `trailing-whitespace` and `end-of-file-fixer` hooks, since trailing whitespace is meaningful in unified diff format.

### Testing
Full `./build_metal.sh --build-all` completes successfully.
- [x] [APC](https://github.com/tenstorrent/tt-metal/actions/runs/21923671022)