### PR TITLE
Matmul - Add Support for 2D DRAM interleaved in0 + batched height sharded in1

### DIFF
--- a/tests/ttnn/unit_tests/operations/matmul/test_matmul_deepseek.py
+++ b/tests/ttnn/unit_tests/operations/matmul/test_matmul_deepseek.py
@@ -816,7 +816,8 @@ def test_matmul_batched_dram_sharded_program_cache(device, batch, m, k, n):
     ],
 )
 @pytest.mark.parametrize("seq_len", [128])  # , 1024, 4096, 8192])  # 32768, 131072])
-def test_matmul_seq_len_sweep_dram_sharded(device, test_case, seq_len):
+@skip_for_blackhole("Deepseek tests target Wormhole")
+def test_prefill_mm_interleaved_sharded(device, test_case, seq_len):
     """
     Tests the MLA prefill matmuls with in0 DRAM interleaved and in1 DRAM sharded.
     Uses MatmulMultiCoreReuseMultiCastProgramConfig (2D multicast).

--- a/tests/ttnn/unit_tests/operations/matmul/test_matmul_deepseek.py
+++ b/tests/ttnn/unit_tests/operations/matmul/test_matmul_deepseek.py
@@ -990,14 +990,6 @@ def test_prefill_mm_interleaved_sharded(device, test_case, seq_len):
             out_subblock_h = sh
             break
 
-    logger.info(
-        f"batch={batch}, seq_len={seq_len}, K={k}, N={n}, "
-        f"grid_size={grid_size}, in0_block_w={in0_block_w}, "
-        f"per_core_M={per_core_M}, per_core_N={per_core_N}, "
-        f"out_block_h={actual_out_block_h}, out_block_w={out_block_w}, "
-        f"out_subblock_h={out_subblock_h}, out_subblock_w={out_subblock_w}"
-    )
-
     program_config = ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
         compute_with_storage_grid_size=grid_size,
         in0_block_w=in0_block_w,
@@ -1038,5 +1030,4 @@ def test_prefill_mm_interleaved_sharded(device, test_case, seq_len):
         pt_out = torch.matmul(in0_orig, in1_orig)
 
     pcc_passed, pcc_message = comp_pcc(pt_out, output_tensor, expected_pcc)
-    logger.info(pcc_message)
     assert pcc_passed, f"PCC check failed: {pcc_message}"

--- a/tests/ttnn/unit_tests/operations/matmul/test_matmul_deepseek.py
+++ b/tests/ttnn/unit_tests/operations/matmul/test_matmul_deepseek.py
@@ -940,7 +940,7 @@ def test_matmul_seq_len_sweep_dram_interleaved(device, test_case, seq_len):
         "wkv_b2_8banks",
     ],
 )
-@pytest.mark.parametrize("seq_len", [128])  # 1024, 4096, 8192])# 32768, 131072])
+@pytest.mark.parametrize("seq_len", [128, 1024, 4096, 8192])  # 32768, 131072])
 @skip_with_watcher("Skipping test with watcher enabled due to failure, see github issue #36314")
 def test_matmul_seq_len_sweep_dram_sharded(device, test_case, seq_len):
     """

--- a/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_mcast_2d_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_mcast_2d_program_factory.cpp
@@ -593,7 +593,7 @@ MatmulMultiCoreReuseMcast2DProgramFactory::cached_program_t create_program_mcast
     if (in1_is_sharded) {
         if (in1_is_dram) {
             if (in1_is_width_sharded) {
-                mm_kernel_in1_sender_writer_defines["IN1_DRAM_SHARDED"] = "1";
+                mm_kernel_in1_sender_writer_defines["IN1_DRAM_WIDTH_SHARDED"] = "1";
             } else {
                 mm_kernel_in1_sender_writer_defines["IN1_DRAM_HEIGHT_SHARDED"] = "1";
             }

--- a/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_mcast_2d_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_mcast_2d_program_factory.cpp
@@ -1261,9 +1261,8 @@ MatmulMultiCoreReuseMcast2DProgramFactory::cached_program_t create_program_mcast
                         }
                         mm_in1_sender_writer_args.insert(mm_in1_sender_writer_args.begin() + num_iter_index, num_iter);
                     } else {
-                        // Height sharded: just need vc for DRAM reads
-                        vc = vc == 3 ? 0 : vc + 1;
-                        mm_in1_sender_writer_args.push_back(vc);
+                        // Height sharded: no additional runtime args needed
+                        // (bank/offset computed from compile-time args + batch index)
                     }
                 }
                 if (fuse_op) {

--- a/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_mcast_2d_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_mcast_2d_program_factory.cpp
@@ -98,7 +98,9 @@ MatmulMultiCoreReuseMcast2DProgramFactory::cached_program_t create_program_mcast
     const bool in0_block_sharded = in0_memory_layout == TensorMemoryLayout::BLOCK_SHARDED;
     const bool in0_height_sharded = in0_memory_layout == TensorMemoryLayout::HEIGHT_SHARDED;
     const bool in0_is_sharded = in0_block_sharded || in0_height_sharded;
-    const bool in1_is_sharded = in1_buffer->buffer_layout() == TensorMemoryLayout::WIDTH_SHARDED;
+    const bool in1_is_width_sharded = in1_buffer->buffer_layout() == TensorMemoryLayout::WIDTH_SHARDED;
+    const bool in1_is_height_sharded = in1_buffer->buffer_layout() == TensorMemoryLayout::HEIGHT_SHARDED;
+    const bool in1_is_sharded = in1_is_width_sharded || in1_is_height_sharded;
     const bool output_is_sharded = out_buffer->buffer_layout() == TensorMemoryLayout::BLOCK_SHARDED;
 
     bool do_not_inplace_interm0_out_CB = output_is_sharded && (per_core_M != out_block_h);
@@ -319,9 +321,16 @@ MatmulMultiCoreReuseMcast2DProgramFactory::cached_program_t create_program_mcast
 
     uint32_t num_dram_banks = 0;
     uint32_t per_core_N_storage = 0;
+    uint32_t batches_per_bank = 0;
     if (in1_is_sharded and in1_is_dram) {
         num_dram_banks = device->num_dram_channels();
-        per_core_N_storage = (N + num_dram_banks - 1) / num_dram_banks;
+        if (in1_is_width_sharded) {
+            per_core_N_storage = (N + num_dram_banks - 1) / num_dram_banks;
+        } else {
+            // Height sharded: batches are distributed across DRAM banks
+            uint32_t in1_shard_height_in_tiles = in1_buffer->shard_spec().shape()[0] / in1_tile.get_height();
+            batches_per_bank = in1_shard_height_in_tiles / K;
+        }
     }
 
     const auto in0_tensor_stride_w = transpose_a ? M : 1;
@@ -471,8 +480,14 @@ MatmulMultiCoreReuseMcast2DProgramFactory::cached_program_t create_program_mcast
     }
 
     if (in1_is_sharded and in1_is_dram) {
-        in1_sender_writer_compile_time_args.push_back((std::uint32_t)per_core_N_storage * in0_block_w);
-        in1_sender_writer_compile_time_args.push_back((std::uint32_t)per_core_N_storage * in1_single_tile_size);
+        if (in1_is_width_sharded) {
+            in1_sender_writer_compile_time_args.push_back((std::uint32_t)per_core_N_storage * in0_block_w);
+            in1_sender_writer_compile_time_args.push_back((std::uint32_t)per_core_N_storage * in1_single_tile_size);
+        } else {
+            // Height sharded: pass tiles per batch and batches per bank
+            in1_sender_writer_compile_time_args.push_back((std::uint32_t)(K * N));  // KtNt per batch (tiles)
+            in1_sender_writer_compile_time_args.push_back((std::uint32_t)batches_per_bank);
+        }
     }
     std::vector<uint32_t> in0_receiver_compile_time_args = {
         // in0 block args
@@ -577,7 +592,11 @@ MatmulMultiCoreReuseMcast2DProgramFactory::cached_program_t create_program_mcast
     }
     if (in1_is_sharded) {
         if (in1_is_dram) {
-            mm_kernel_in1_sender_writer_defines["IN1_DRAM_SHARDED"] = "1";
+            if (in1_is_width_sharded) {
+                mm_kernel_in1_sender_writer_defines["IN1_DRAM_SHARDED"] = "1";
+            } else {
+                mm_kernel_in1_sender_writer_defines["IN1_DRAM_HEIGHT_SHARDED"] = "1";
+            }
         } else {
             mm_kernel_in1_sender_writer_defines["IN1_SHARDED"] = "1";
         }
@@ -1180,66 +1199,72 @@ MatmulMultiCoreReuseMcast2DProgramFactory::cached_program_t create_program_mcast
                 }
 
                 if (in1_is_sharded and in1_is_dram) {  // in1 is dram sharded
-                    uint32_t num_iter_index = mm_in1_sender_writer_args.size() + 1;
-                    vc = vc == 3 ? 0 : vc + 1;
-                    mm_in1_sender_writer_args.push_back(vc);
+                    if (in1_is_width_sharded) {
+                        uint32_t num_iter_index = mm_in1_sender_writer_args.size() + 1;
+                        vc = vc == 3 ? 0 : vc + 1;
+                        mm_in1_sender_writer_args.push_back(vc);
 
-                    uint32_t num_iter = 0;  // iterate how many banks, till fill the current worker block
+                        uint32_t num_iter = 0;  // iterate how many banks, till fill the current worker block
 
-                    if (curr_storage_core < num_dram_banks) {
-                        num_iter++;
-
-                        worker_core_stride = per_core_N_storage - storage_core_stride;
-
-                        mm_in1_sender_writer_args.push_back(
-                            storage_core_stride * in1_single_tile_size);  // dram_tensor_start_offset
-                        mm_in1_sender_writer_args.push_back(
-                            worker_core_stride * in1_single_tile_size);          // per_core_N_dram_bytes
-                        mm_in1_sender_writer_args.push_back(curr_storage_core);  // current_dram_bank_id
-
-                        log_debug(
-                            tt::LogOp,
-                            "curr worker core: {} read {} tiles from dram bank: {}, start from index: {}",
-                            curr_worker_core,
-                            worker_core_stride,
-                            curr_storage_core,
-                            storage_core_stride);
-
-                        curr_storage_core += (storage_core_stride + worker_core_stride) / per_core_N_storage;
-                        storage_core_stride = (storage_core_stride + worker_core_stride) % per_core_N_storage;
-
-                        uint32_t curr_worker_core_old = curr_worker_core;
-                        if (worker_core_stride >= per_core_N) {
-                            curr_worker_core += 1;
-                        }
-
-                        while (curr_worker_core <= curr_worker_core_old and curr_storage_core < num_dram_banks) {
+                        if (curr_storage_core < num_dram_banks) {
                             num_iter++;
 
-                            uint32_t stride = worker_core_stride + per_core_N_storage;
-                            stride = std::min(stride, per_core_N);
+                            worker_core_stride = per_core_N_storage - storage_core_stride;
 
                             mm_in1_sender_writer_args.push_back(
-                                (stride - worker_core_stride) * in1_single_tile_size);  // per_core_N_dram_bytes
-                            mm_in1_sender_writer_args.push_back(curr_storage_core);     // current_dram_bank_id
+                                storage_core_stride * in1_single_tile_size);  // dram_tensor_start_offset
+                            mm_in1_sender_writer_args.push_back(
+                                worker_core_stride * in1_single_tile_size);          // per_core_N_dram_bytes
+                            mm_in1_sender_writer_args.push_back(curr_storage_core);  // current_dram_bank_id
 
                             log_debug(
                                 tt::LogOp,
                                 "curr worker core: {} read {} tiles from dram bank: {}, start from index: {}",
                                 curr_worker_core,
-                                (stride - worker_core_stride),
+                                worker_core_stride,
                                 curr_storage_core,
                                 storage_core_stride);
 
-                            if (stride >= per_core_N) {
+                            curr_storage_core += (storage_core_stride + worker_core_stride) / per_core_N_storage;
+                            storage_core_stride = (storage_core_stride + worker_core_stride) % per_core_N_storage;
+
+                            uint32_t curr_worker_core_old = curr_worker_core;
+                            if (worker_core_stride >= per_core_N) {
                                 curr_worker_core += 1;
                             }
-                            storage_core_stride = (stride - worker_core_stride) % per_core_N_storage;
-                            curr_storage_core += (stride - worker_core_stride) / per_core_N_storage;
-                            worker_core_stride = stride;
+
+                            while (curr_worker_core <= curr_worker_core_old and curr_storage_core < num_dram_banks) {
+                                num_iter++;
+
+                                uint32_t stride = worker_core_stride + per_core_N_storage;
+                                stride = std::min(stride, per_core_N);
+
+                                mm_in1_sender_writer_args.push_back(
+                                    (stride - worker_core_stride) * in1_single_tile_size);  // per_core_N_dram_bytes
+                                mm_in1_sender_writer_args.push_back(curr_storage_core);     // current_dram_bank_id
+
+                                log_debug(
+                                    tt::LogOp,
+                                    "curr worker core: {} read {} tiles from dram bank: {}, start from index: {}",
+                                    curr_worker_core,
+                                    (stride - worker_core_stride),
+                                    curr_storage_core,
+                                    storage_core_stride);
+
+                                if (stride >= per_core_N) {
+                                    curr_worker_core += 1;
+                                }
+                                storage_core_stride = (stride - worker_core_stride) % per_core_N_storage;
+                                curr_storage_core += (stride - worker_core_stride) / per_core_N_storage;
+                                worker_core_stride = stride;
+                            }
                         }
+                        mm_in1_sender_writer_args.insert(mm_in1_sender_writer_args.begin() + num_iter_index, num_iter);
+                    } else {
+                        // Height sharded: just need vc for DRAM reads
+                        vc = vc == 3 ? 0 : vc + 1;
+                        mm_in1_sender_writer_args.push_back(vc);
                     }
-                    mm_in1_sender_writer_args.insert(mm_in1_sender_writer_args.begin() + num_iter_index, num_iter);
                 }
                 if (fuse_op) {
                     if (fused_op_signaler->is_all_gather()) {

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_sender_writer_padding.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_sender_writer_padding.cpp
@@ -151,8 +151,6 @@ void kernel_main() {
 #endif  // IN1_DRAM_SHARDED
 
 #ifdef IN1_DRAM_HEIGHT_SHARDED
-    const uint32_t vc = get_arg_val<uint32_t>(rt_args_idx++);
-
     constexpr uint32_t in1_KtNt_per_batch = get_compile_time_arg_val(after_bias_offset);        // K*N tiles per batch
     constexpr uint32_t in1_batches_per_bank = get_compile_time_arg_val(after_bias_offset + 1);  // batches per DRAM bank
 #endif  // IN1_DRAM_HEIGHT_SHARDED
@@ -263,8 +261,9 @@ void kernel_main() {
                 for (uint32_t bw = 0; bw < num_blocks_w_dim; ++bw) {
                     uint32_t in1_tensor_current_inner_dim_block_start_tile_id = in1_tensor_current_w_dim_block_tile_id;
 #ifdef IN1_DRAM_SHARDED
-                    // Reset DRAM read offset for each output block — in1 K×N data
-                    // is the same for all (bh, bw) output blocks
+                    // Reset DRAM read offset for each bh block — the inner dim loop
+                    // advances through K, and each output row block re-reads the same
+                    // in1 columns from K=0. (bw is always 1 for DRAM-sharded senders.)
                     uint32_t l1_read_addr_in1_offset = 0;
 #endif  // IN1_DRAM_SHARDED
 

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_sender_writer_padding.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_sender_writer_padding.cpp
@@ -150,6 +150,13 @@ void kernel_main() {
     constexpr uint32_t in1_block_w_dram_bytes = get_compile_time_arg_val(after_bias_offset + 1);
 #endif  // IN1_DRAM_SHARDED
 
+#ifdef IN1_DRAM_HEIGHT_SHARDED
+    const uint32_t vc = get_arg_val<uint32_t>(rt_args_idx++);
+
+    constexpr uint32_t in1_KtNt_per_batch = get_compile_time_arg_val(after_bias_offset);        // K*N tiles per batch
+    constexpr uint32_t in1_batches_per_bank = get_compile_time_arg_val(after_bias_offset + 1);  // batches per DRAM bank
+#endif  // IN1_DRAM_HEIGHT_SHARDED
+
 #ifdef FUSE_BIAS
 #ifndef BIAS_SHARDED
     const auto s3 = TensorAccessor(bias_args, in3_tensor_addr, bias_single_tile_size_bytes);
@@ -216,8 +223,20 @@ void kernel_main() {
     uint32_t in1_block_w_bytes = in1_block_w * in1_single_tile_size_bytes;
 #endif  // IN1_DRAM_SHARDED
 
+#ifdef IN1_DRAM_HEIGHT_SHARDED
+    constexpr uint32_t in1_batch_stride_bytes = in1_KtNt_per_batch * in1_single_tile_size_bytes;
+#endif  // IN1_DRAM_HEIGHT_SHARDED
+
     for (uint32_t b = 0; b < batch; ++b) {
         uint32_t in1_batch_tile_id = in1_tensor_start_tile_id;
+
+#ifdef IN1_DRAM_HEIGHT_SHARDED
+        // Compute DRAM bank and offset for this batch
+        uint32_t in1_dram_bank_id = b / in1_batches_per_bank;
+        uint32_t in1_batch_in_shard = b % in1_batches_per_bank;
+        uint64_t in1_dram_base_addr = get_noc_addr_from_bank_id<true>(in1_dram_bank_id, in1_tensor_addr);
+        uint32_t in1_dram_batch_offset = in1_batch_in_shard * in1_batch_stride_bytes;
+#endif  // IN1_DRAM_HEIGHT_SHARDED
 
         if constexpr (batchB > 0) {
             noc_async_read_page(b, s_sparsity, l1_write_addr_sparsity);
@@ -252,8 +271,8 @@ void kernel_main() {
                             fused_op_receiver.update_current_block_start_tile_id(
                                 block, in1_tensor_current_inner_dim_block_start_tile_id, in1_batch_tile_id);
                         }
-#ifdef IN1_DRAM_SHARDED
-                        // Operand 1
+#if defined(IN1_DRAM_SHARDED)
+                        // Operand 1 - DRAM width sharded
                         cb_reserve_back(cb_id_in1, in1_block_num_tiles);
 
                         uint64_t in1_start_address =
@@ -295,9 +314,41 @@ void kernel_main() {
                         }
                         l1_read_addr_in1_offset += in1_dram_block_size_bytes;
                         noc_async_read_barrier();
-#else
-#ifndef IN1_SHARDED
-                        // Operand 1
+#elif defined(IN1_DRAM_HEIGHT_SHARDED)
+                        // Operand 1 - DRAM height sharded (batched)
+                        // Each DRAM bank holds batches_per_bank complete [K, N] matrices
+                        // Bank and offset computed at start of batch loop
+                        cb_reserve_back(cb_id_in1, in1_block_num_tiles);
+
+                        l1_write_addr_in1 = get_write_ptr(cb_id_in1);
+                        uint64_t in1_start_address =
+                            l1_write_addr_in1;  // copy start address of block, to be used for mcasting
+
+                        // Read in1 block from the correct DRAM bank
+                        // Tile layout within a batch: row-major [K, N], same strides as interleaved
+                        uint32_t in1_tensor_row_start_tile_id = in1_tensor_current_inner_dim_block_start_tile_id;
+                        for (uint32_t h = 0; h < in1_block_h; ++h) {
+                            uint32_t in1_tensor_tile_id = in1_tensor_row_start_tile_id;
+                            for (uint32_t w = 0; w < in1_block_w; ++w) {
+                                if (bw < num_blocks_w_dim - 1 || w < last_block_w) {
+                                    uint32_t tile_byte_offset =
+                                        in1_dram_batch_offset + in1_tensor_tile_id * in1_single_tile_size_bytes;
+                                    noc_async_read(
+                                        in1_dram_base_addr + tile_byte_offset,
+                                        l1_write_addr_in1,
+                                        in1_single_tile_size_bytes);
+                                }
+                                l1_write_addr_in1 += in1_single_tile_size_bytes;
+                                in1_tensor_tile_id += in1_tensor_stride_w;
+                            }
+                            in1_tensor_row_start_tile_id += in1_tensor_stride_h;
+                        }
+                        in1_tensor_current_inner_dim_block_start_tile_id += in1_tensor_next_block_stride;
+
+                        // Barrier! make sure the reads are done
+                        noc_async_read_barrier();
+#elif !defined(IN1_SHARDED)
+                        // Operand 1 - interleaved
                         cb_reserve_back(cb_id_in1, in1_block_num_tiles);
 #ifdef INTERMEDIATE_CB_READ
                         constexpr uint32_t in1_intermediate_cb_index = tt::CBIndex::c_9;
@@ -334,8 +385,7 @@ void kernel_main() {
 
                         // Barrier! make sure the reads are done
                         noc_async_read_barrier();
-#endif  // IN1_SHARDED
-#endif  // IN1_DRAM_SHARDED
+#endif  // IN1_DRAM_SHARDED / IN1_DRAM_HEIGHT_SHARDED / IN1_SHARDED
 
 #ifndef SKIP_MCAST
                         // wait until all in1 mcast destinations have atomically incremented the in1 semaphore_addr
@@ -560,7 +610,11 @@ void kernel_main() {
             in1_batch_tile_id += KtNt;
         }
         if constexpr (bcast_B == 0) {
+#ifndef IN1_DRAM_HEIGHT_SHARDED
+            // For height-sharded DRAM, tile IDs are relative within a batch;
+            // batch offset is handled by switching DRAM banks
             in1_tensor_start_tile_id += KtNt;
+#endif
         }
 
         if (fuse_op_reduce_scatter) {

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_sender_writer_padding.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_sender_writer_padding.cpp
@@ -252,9 +252,6 @@ void kernel_main() {
                 }
             }
 
-#ifdef IN1_DRAM_SHARDED
-            uint32_t l1_read_addr_in1_offset = 0;
-#endif  // IN1_DRAM_SHARDED
             uint32_t in1_tensor_current_h_dim_block_tile_id = in1_batch_tile_id;
             uint32_t out_tensor_current_h_dim_block_tile_id = out_tensor_start_tile_id;
             for (uint32_t bh = 0; bh < num_blocks_h_dim; ++bh) {
@@ -265,6 +262,11 @@ void kernel_main() {
 #endif  // FUSE_BIAS
                 for (uint32_t bw = 0; bw < num_blocks_w_dim; ++bw) {
                     uint32_t in1_tensor_current_inner_dim_block_start_tile_id = in1_tensor_current_w_dim_block_tile_id;
+#ifdef IN1_DRAM_SHARDED
+                    // Reset DRAM read offset for each output block — in1 K×N data
+                    // is the same for all (bh, bw) output blocks
+                    uint32_t l1_read_addr_in1_offset = 0;
+#endif  // IN1_DRAM_SHARDED
 
                     for (uint32_t block = 0; block < num_blocks_inner_dim; ++block) {
                         if constexpr (fuse_op_all_gather) {

--- a/ttnn/cpp/ttnn/operations/matmul/matmul_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/matmul_nanobind.cpp
@@ -709,10 +709,10 @@ void py_module(nb::module_& mod) {
                   - Height Sharded (DRAM)
                 * - MatmulMultiCoreReuseMultiCastProgramConfig
                   - Interleaved (L1/DRAM), Block Sharded (L1)
-                  - Interleaved (L1/DRAM)
+                  - Interleaved (L1/DRAM), Width Sharded (DRAM)
                 * - MatmulMultiCoreReuseMultiCastProgramConfig (only for row major orientation without transpose multicast)
                   - Interleaved (L1/DRAM), Height Sharded (L1)
-                  - Interleaved (L1/DRAM), Width Sharded (L1)
+                  - Interleaved (L1/DRAM), Width Sharded (L1/DRAM), Height Sharded (DRAM)
                 * - MatmulMultiCoreReuseMultiCast1DProgramConfig (mcast_in0=False)
                   - Interleaved (L1/DRAM), Width Sharded (L1)
                   - Interleaved (L1/DRAM), Width Sharded (L1)

--- a/ttnn/cpp/ttnn/operations/matmul/matmul_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/matmul_nanobind.cpp
@@ -712,7 +712,7 @@ void py_module(nb::module_& mod) {
                   - Interleaved (L1/DRAM), Width Sharded (DRAM)
                 * - MatmulMultiCoreReuseMultiCastProgramConfig (only for row major orientation without transpose multicast)
                   - Interleaved (L1/DRAM), Height Sharded (L1)
-                  - Interleaved (L1/DRAM), Width Sharded (L1/DRAM), Height Sharded (DRAM)
+                  - Interleaved (L1/DRAM), Width Sharded (L1/DRAM), Height Sharded (DRAM, batch-sharded only: fuse_batch=false, each bank holds complete [K,N] matrices for B/num_banks batches)
                 * - MatmulMultiCoreReuseMultiCast1DProgramConfig (mcast_in0=False)
                   - Interleaved (L1/DRAM), Width Sharded (L1)
                   - Interleaved (L1/DRAM), Width Sharded (L1)

--- a/ttnn/cpp/ttnn/operations/matmul/matmul_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/matmul_nanobind.cpp
@@ -712,7 +712,7 @@ void py_module(nb::module_& mod) {
                   - Interleaved (L1/DRAM), Width Sharded (DRAM)
                 * - MatmulMultiCoreReuseMultiCastProgramConfig (only for row major orientation without transpose multicast)
                   - Interleaved (L1/DRAM), Height Sharded (L1)
-                  - Interleaved (L1/DRAM), Width Sharded (L1/DRAM), Height Sharded (DRAM, batch-sharded only: fuse_batch=false, each bank holds complete [K,N] matrices for B/num_banks batches)
+                  - Interleaved (L1/DRAM), Width Sharded (L1/DRAM), Height Sharded (DRAM batched matmuls where each bank holds B/num_banks complete [K,N] matrices)
                 * - MatmulMultiCoreReuseMultiCast1DProgramConfig (mcast_in0=False)
                   - Interleaved (L1/DRAM), Width Sharded (L1)
                   - Interleaved (L1/DRAM), Width Sharded (L1)


### PR DESCRIPTION
### Ticket
#37403

### Problem description
For Deepseek MLA, prefill must reuse the same weights as decode. Optimised decode will require sharded weights, while prefill has assumed interleaved inputs. To reuse the sharded weights, prefill will need to run with interleaved activations and sharded weights. For the batched matmuls, this combination of inputs was not supported.

Based on past experience in Llama, it's expected this will slow down matmuls by 30%.

### What's changed
This PR adds support for the specific case where in1 is a height sharded batched matmul, where the sharding cleanly splits in1 along B/num_banks. The in1 reader is updated to correctly index the data, while in0/compute remain unchanged. The PR also includes a test to exercise all of the prefill matmuls with this interleaved + sharded pattern, with the sequence length left at the minimum (128) due to the test time required for the larger sequence lengths.


These matmuls were profiled and compared to interleaved+interleaved matmuls with no program config (i.e. current prefill implementation) at sequence lengths up to 8k (the larger 32k and 128k sequence lengths are too unwieldy to profile). The relative slowdown worsens as sequence length increases. The best case speedup is 0.47x, the worse case slowdown is 1.16x.

Also note that the wkv_b1 numbers are assuming using 8 DRAM banks. Adding this support is in progress and should be complete before prefill perf becomes a focus. However, if wkv_b1 is instead padded for 12 DRAM banks (as it will be for the very first implementation), it will be about 1.5x slower than currently shown. This does not impact the other matmuls.

<img width="995" height="608" alt="image" src="https://github.com/user-attachments/assets/d41fe9d2-bdc8-4d64-b7d2-898b38c4eb61" />


### Checklist

- [x] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=edwinlee/37403/deepseek_prefill_sharded)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:edwinlee/37403/deepseek_prefill_sharded)
- [x] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=edwinlee/37403/deepseek_prefill_sharded)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:edwinlee/37403/deepseek_prefill_sharded)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=edwinlee/37403/deepseek_prefill_sharded)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:edwinlee/37403/deepseek_prefill_sharded)
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=edwinlee/37403/deepseek_prefill_sharded)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:edwinlee/37403/deepseek_prefill_sharded)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=edwinlee/37403/deepseek_prefill_sharded)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:edwinlee/37403/deepseek_prefill_sharded)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=edwinlee/37403/deepseek_prefill_sharded)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:edwinlee/37403/deepseek_prefill_sharded)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
