### PR TITLE
Add bfloat8 kv cache update

### DIFF
--- a/models/demos/deepseek_v3_b1/micro_ops/kv_cache_update/kernels/kv_cache_update_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/micro_ops/kv_cache_update/kernels/kv_cache_update_kernel.cpp
@@ -1,0 +1,54 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+// SPDX-License-Identifier: Apache-2.0
+
+// KV Cache Update kernel: uses KVCacheUpdate Op from kv_cache_update.hpp
+//
+// NCRISC (IsNopeCore): Read 16 BFP8 tiles from DRAM into kv_cache_input_cb
+// NCRISC (IsRopeCore): Pop krope_output_cb
+// BRISC (IsNopeCore): Wait on intermed/rmsnorm, push intermed, read output_cb
+// TRISC (IsNopeCore): Untilize input_cb -> intermed_cb, tilize intermed_cb -> output_cb
+
+#include "../../../unified_kernels/kernel_op_api.hpp"
+#include "../../../unified_kernels/kernel_utils.hpp"
+#include "../../../unified_kernels/kv_cache_update.hpp"
+
+struct Core {
+    static constexpr bool is_nope_core = get_named_compile_time_arg_val("is_nope_core") == 1;
+    static constexpr bool is_rope_core = get_named_compile_time_arg_val("is_rope_core") == 1;
+};
+
+void kernel_main() {
+#if defined(COMPILE_FOR_NCRISC)
+    deepseek_b1_ops::KVCacheUpdate::ReaderArgs args{};
+    if (Core::is_nope_core) {
+        uint32_t kv_rmsnorm_output_cb = get_named_compile_time_arg_val("kv_rmsnorm_output_cb");
+        unified_kernels::setup_sharded_buffer(kv_rmsnorm_output_cb, 1);
+    }
+    if (Core::is_rope_core) {
+        uint32_t krope_output_cb = get_named_compile_time_arg_val("krope_output_cb");
+        unified_kernels::setup_sharded_buffer(krope_output_cb, 1);
+    }
+#elif defined(COMPILE_FOR_BRISC)
+    deepseek_b1_ops::KVCacheUpdate::WriterArgs args{
+        .kv_cache_buffer_base_addr = get_common_arg_val<uint32_t>(0),
+        .position_id = get_common_arg_val<uint32_t>(1),
+        .kv_cache_input_cb = get_named_compile_time_arg_val("kv_cache_input_cb"),
+        .kv_cache_intermed_cb = get_named_compile_time_arg_val("kv_cache_intermed_cb"),
+        .kv_cache_output_cb = get_named_compile_time_arg_val("kv_cache_output_cb"),
+        .kv_rmsnorm_output_cb = get_named_compile_time_arg_val("kv_rmsnorm_output_cb"),
+        .krope_output_cb = get_named_compile_time_arg_val("krope_output_cb"),
+        .grid_start_y = get_named_compile_time_arg_val("kv_cache_grid_start_y"),
+    };
+#elif defined(COMPILE_FOR_TRISC)
+    deepseek_b1_ops::KVCacheUpdate::ComputeArgs args{
+        .kv_cache_input_cb = get_named_compile_time_arg_val("kv_cache_input_cb"),
+        .kv_cache_output_cb = get_named_compile_time_arg_val("kv_cache_output_cb"),
+        .kv_cache_intermed_cb = get_named_compile_time_arg_val("kv_cache_intermed_cb"),
+    };
+
+    compute_kernel_hw_startup(0, 0, 0);
+#endif
+
+    deepseek_b1_ops::KVCacheUpdate::Op<Core::is_nope_core, Core::is_rope_core> op;
+    op(args);
+}

--- a/models/demos/deepseek_v3_b1/micro_ops/kv_cache_update/op.py
+++ b/models/demos/deepseek_v3_b1/micro_ops/kv_cache_update/op.py
@@ -1,0 +1,170 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+KV Cache Update micro op.
+
+Reads 16 BFP8 tiles from DRAM into L1, untilize (BFP8->bfloat16), tilize (bfloat16->BFP8).
+Runs on a grid with nope cores (kv_rmsnorm) and rope cores (krope). Uses kv_cache_update.hpp Op.
+"""
+
+import ttnn
+from models.demos.deepseek_v3_b1.unified_kernel_descriptor import (
+    UnifiedCompileTimeCoreDescriptor,
+    UnifiedKernelDescriptor,
+)
+
+# CB indices used by the kernel (must match named compile-time args)
+KV_CACHE_INPUT_CB = 31
+KV_CACHE_OUTPUT_CB = 30
+KV_CACHE_INTERMED_CB = 29
+KV_RMSNORM_OUTPUT_CB = 26
+KROPE_OUTPUT_CB = 27
+KV_CACHE_NUM_TILES = 16
+KROPE_WT = 1
+OUTPUT_CB = 0
+
+TILE_32x32 = ttnn.Tile((32, 32))
+TILE_16x32 = ttnn.Tile((16, 32))
+TILE_1x32 = ttnn.Tile((1, 32))
+
+
+class KVCacheUpdate:
+    """
+    KV Cache Update: read DRAM -> untilize -> tilize. Uses unified_kernels/kv_cache_update.hpp.
+    """
+
+    @staticmethod
+    def op(
+        nope_cache_tensor,
+        rope_cache_tensor,
+        full_kv_cache_tensor,
+        output_tensor,  # not used
+        position_id: int,
+    ):
+        """
+        Run KV cache update as a standalone program.
+
+        Args:
+            nope_cache_tensor: L1 tensor backing NOPE_CACHE_CB (tilized BFP8 input).
+            rope_cache_tensor: DRAM tensor for rope cache (buffer address + tensor accessor).
+            full_kv_cache_tensor: DRAM tensor for full KV cache (buffer address + tensor accessor).
+            position_id: Write position index.
+            output_tensor: not used, validation is read back from full_kv_cache_tensor
+
+        Returns:
+            Output of generic_op (includes output_tensor when provided).
+        """
+        nope_core_grid = nope_cache_tensor.memory_config().shard_spec.grid
+        rope_core_grid = rope_cache_tensor.memory_config().shard_spec.grid
+        kv_cache_core_grid = nope_core_grid.merge(rope_core_grid)
+
+        tensor_accessor_args = ttnn.TensorAccessorArgs(full_kv_cache_tensor)
+        ncrisc_compile_time_args = tensor_accessor_args.get_compile_time_args()
+        brisc_compile_time_args = tensor_accessor_args.get_compile_time_args()
+
+        # CB indices and krope_Wt passed as named compile-time args; kernel uses get_named_compile_time_arg_val
+        ncrisc_named = [
+            ("kv_rmsnorm_output_cb", KV_RMSNORM_OUTPUT_CB),
+            ("krope_output_cb", KROPE_OUTPUT_CB),
+        ]
+        brisc_named = [
+            ("kv_cache_input_cb", KV_CACHE_INPUT_CB),
+            ("kv_cache_output_cb", KV_CACHE_OUTPUT_CB),
+            ("kv_cache_intermed_cb", KV_CACHE_INTERMED_CB),
+            ("kv_rmsnorm_output_cb", KV_RMSNORM_OUTPUT_CB),
+            ("krope_output_cb", KROPE_OUTPUT_CB),
+            ("kv_cache_grid_start_y", list(rope_core_grid.ranges())[0].start.y),
+        ]
+        trisc_named = [
+            ("kv_cache_input_cb", KV_CACHE_INPUT_CB),
+            ("kv_cache_output_cb", KV_CACHE_OUTPUT_CB),
+            ("kv_cache_intermed_cb", KV_CACHE_INTERMED_CB),
+            ("kv_rmsnorm_output_cb", KV_RMSNORM_OUTPUT_CB),
+            ("krope_output_cb", KROPE_OUTPUT_CB),
+        ]
+
+        kv_cache_page_size = TILE_32x32.get_tile_size(ttnn.bfloat8_b)
+        intermed_page_size = TILE_32x32.get_tile_size(ttnn.bfloat16)
+
+        kv_cache_input_cb_format = ttnn.CBFormatDescriptor(
+            buffer_index=KV_CACHE_INPUT_CB,
+            data_format=ttnn.bfloat8_b,
+            page_size=kv_cache_page_size,
+            tile=ttnn.TileDescriptor(TILE_32x32),
+        )
+        kv_cache_output_cb_format = ttnn.CBFormatDescriptor(
+            buffer_index=KV_CACHE_OUTPUT_CB,
+            data_format=ttnn.bfloat8_b,
+            page_size=kv_cache_page_size,
+            tile=ttnn.TileDescriptor(TILE_32x32),
+        )
+        kv_cache_intermed_cb_format = ttnn.CBFormatDescriptor(
+            buffer_index=KV_CACHE_INTERMED_CB,
+            data_format=ttnn.bfloat16,
+            page_size=intermed_page_size,
+            tile=ttnn.TileDescriptor(TILE_32x32),
+        )
+
+        kv_rmsnorm_output_cb_format = ttnn.cb_descriptor_from_sharded_tensor(KV_RMSNORM_OUTPUT_CB, nope_cache_tensor)
+
+        # Output CB: tensor-backed on nope core when output_tensor provided, else L1-only
+        cbs = [
+            kv_rmsnorm_output_cb_format,
+            ttnn.cb_descriptor_from_sharded_tensor(KROPE_OUTPUT_CB, rope_cache_tensor),
+            ttnn.cb_descriptor_from_sharded_tensor(OUTPUT_CB, output_tensor),
+            ttnn.CBDescriptor(
+                total_size=KV_CACHE_NUM_TILES * kv_cache_page_size,
+                core_ranges=kv_cache_core_grid,
+                format_descriptors=[kv_cache_input_cb_format],
+            ),
+            ttnn.CBDescriptor(
+                total_size=KV_CACHE_NUM_TILES * kv_cache_page_size,
+                core_ranges=kv_cache_core_grid,
+                format_descriptors=[kv_cache_output_cb_format],
+            ),
+            ttnn.CBDescriptor(
+                total_size=(KV_CACHE_NUM_TILES + 1) * intermed_page_size,
+                core_ranges=kv_cache_core_grid,
+                format_descriptors=[kv_cache_intermed_cb_format],
+            ),
+        ]
+
+        ncrisc_common_runtime_args = [full_kv_cache_tensor.buffer_address()]
+        brisc_common_runtime_args = [full_kv_cache_tensor.buffer_address(), position_id]
+
+        kernel_desc = UnifiedKernelDescriptor(
+            kernel_source="models/demos/deepseek_v3_b1/micro_ops/kv_cache_update/kernels/kv_cache_update_kernel.cpp",
+            core_ranges=kv_cache_core_grid,
+            ncrisc_compile_time_args=ncrisc_compile_time_args,
+            brisc_compile_time_args=brisc_compile_time_args,
+            ncrisc_named_compile_time_args=ncrisc_named,
+            brisc_named_compile_time_args=brisc_named,
+            trisc_named_compile_time_args=trisc_named,
+            ncrisc_common_runtime_args=ncrisc_common_runtime_args,
+            brisc_common_runtime_args=brisc_common_runtime_args,
+            unified_compile_time_core_descriptors=[
+                UnifiedCompileTimeCoreDescriptor(
+                    named_compile_time_arg="is_nope_core",
+                    core_range=nope_core_grid,
+                    value=1,
+                    other_value=0,
+                ),
+                UnifiedCompileTimeCoreDescriptor(
+                    named_compile_time_arg="is_rope_core",
+                    core_range=rope_core_grid,
+                    value=1,
+                    other_value=0,
+                ),
+            ],
+        )
+        kernel_result = kernel_desc.get_kernel_descriptors()
+        program_descriptor = ttnn.ProgramDescriptor(
+            kernels=kernel_result.kernels,
+            cbs=cbs,
+        )
+        io_tensors = [nope_cache_tensor, rope_cache_tensor, output_tensor]
+
+        output = ttnn.generic_op(io_tensors, program_descriptor)
+
+        return output

--- a/models/demos/deepseek_v3_b1/unified_kernels/kv_cache_update.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/kv_cache_update.hpp
@@ -1,0 +1,184 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "kernel_op_api.hpp"
+
+#if defined(COMPILE_FOR_BRISC)
+#include "api/dataflow/dataflow_api.h"
+#elif defined(COMPILE_FOR_NCRISC)
+#include "api/dataflow/dataflow_api.h"
+#elif defined(COMPILE_FOR_TRISC)
+#include "api/compute/compute_kernel_api.h"
+#include "api/compute/pack_untilize.h"
+#include "api/compute/tilize.h"
+
+#endif
+
+namespace deepseek_b1_ops {
+
+// ============================================================================
+// RMSNorm micro-op
+//
+// Computes: Update existing KV Cache with 1x576 new cache
+// assumes one core with 1x512 NOPE cache and 2 cores each with 1x32 ROPE cache
+//
+// ============================================================================
+struct KVCacheUpdate {
+    // ========================================================================
+    // Compile-time args structs - only what MUST be compile-time
+    // (used as template parameters or in constexpr expressions)
+    // ========================================================================
+
+    // Reader CTArgs:none needed
+    struct ReaderCTArgs {};
+
+    // Writer CTArgs: none needed
+    struct WriterCTArgs {};
+
+    // Compute CTArgs: none needed
+    struct ComputeCTArgs {};
+
+    // ========================================================================
+    // Runtime args structs - different layout per RISC
+    // CB indices etc. filled in kernel via get_named_compile_time_arg_val
+    // ========================================================================
+    struct ReaderArgs {};
+    struct WriterArgs {
+        uint32_t kv_cache_buffer_base_addr;
+        uint32_t position_id;
+        uint32_t kv_cache_input_cb;
+        uint32_t kv_cache_intermed_cb;
+        uint32_t kv_cache_output_cb;
+        uint32_t kv_rmsnorm_output_cb;
+        uint32_t krope_output_cb;
+        uint32_t grid_start_y;
+    };
+    struct ComputeArgs {
+        uint32_t kv_cache_input_cb;
+        uint32_t kv_cache_output_cb;
+        uint32_t kv_cache_intermed_cb;
+    };
+
+    using RTArgs = unified_kernels::SelectByRISCV<ReaderArgs, WriterArgs, ComputeArgs>;
+
+    // ========================================================================
+    // Op - the actual operation, IsActiveCore
+    // ========================================================================
+    template <bool IsNopeCore, bool IsRopeCore>
+    class Op {
+    public:
+        void operator()([[maybe_unused]] const RTArgs& args) { impl(args); }
+
+    private:
+        void impl([[maybe_unused]] const RTArgs& args) {
+#if defined(COMPILE_FOR_BRISC)
+            if constexpr (IsRopeCore || IsNopeCore) {
+                uint32_t kv_cache_intermed_cb = args.kv_cache_intermed_cb;
+                uint32_t kv_cache_input_cb = args.kv_cache_input_cb;
+                uint32_t kv_cache_output_cb = args.kv_cache_output_cb;
+                uint32_t new_cache_cb = IsRopeCore ? args.krope_output_cb : args.kv_rmsnorm_output_cb;
+                constexpr uint32_t PAGE_SIZE = 1088;
+                constexpr uint32_t PAGES_PER_BLOCK = 18;
+                constexpr uint32_t CACHES_PER_BLOCK = 32;
+                constexpr uint32_t nope_num_pages = 16;  // Offset in 1x576 for rope component
+                constexpr uint32_t kv_cache_num_tiles = IsRopeCore ? 1 : 16;
+
+                constexpr auto k_args = TensorAccessorArgs<0>();
+                auto kv_tensor_accessor = TensorAccessor(k_args, args.kv_cache_buffer_base_addr, PAGE_SIZE);
+
+                // This op needs to update 18 pages starting from kv_cache_page_id_start
+                // If args.position_id % CACHES_PER_BLOCK != 0, there is an offset into the rows
+                uint32_t kv_cache_page_id_start = args.position_id / CACHES_PER_BLOCK * PAGES_PER_BLOCK;
+                uint32_t offset_in_page = args.position_id % CACHES_PER_BLOCK;
+                uint32_t num_bytes_per_core = IsRopeCore ? 64 : 1024;
+
+                if (IsRopeCore) {
+                    uint32_t grid_offset_pages = 1 * (get_absolute_logical_y() - args.grid_start_y);
+                    kv_cache_page_id_start += grid_offset_pages;
+                    kv_cache_page_id_start += nope_num_pages;
+                }
+
+                cb_reserve_back(kv_cache_input_cb, kv_cache_num_tiles);
+                uint32_t cb_addr = get_write_ptr(kv_cache_input_cb);
+                for (uint32_t i = 0; i < kv_cache_num_tiles; i++) {
+                    noc_async_read_page(kv_cache_page_id_start + i, kv_tensor_accessor, cb_addr);
+                    cb_addr += kv_tensor_accessor.page_size;
+                }
+                    noc_async_read_barrier();
+
+                    cb_push_back(kv_cache_input_cb, kv_cache_num_tiles);
+
+                    // wait for unpacker to untilize
+                    cb_wait_front(kv_cache_intermed_cb, kv_cache_num_tiles);
+
+                    // 2. Wait for new cache data and update into kv_cache_intermed_cb
+                    cb_wait_front(new_cache_cb, 1);
+
+                    uint32_t write_addr = get_read_ptr(kv_cache_intermed_cb) + offset_in_page * num_bytes_per_core;
+                    uint32_t new_cache_addr = get_read_ptr(new_cache_cb);
+                    // Local copy data from new cache to intermed, 1x512 for nope, 1x64 for rope (1x32 per core)
+                    {
+                        uint32_t words_per_face = (num_bytes_per_core >> 2);
+                        volatile tt_l1_ptr uint32_t* src =
+                            reinterpret_cast<volatile tt_l1_ptr uint32_t*>(new_cache_addr);
+                        volatile tt_l1_ptr uint32_t* dst = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(write_addr);
+                        for (uint32_t i = 0; i < words_per_face; ++i) {
+                            dst[i] = src[i];
+                        }
+                    }
+                    cb_pop_front(new_cache_cb, 1);
+                    cb_push_back(kv_cache_intermed_cb, 1);
+
+                    // 3. Wait for TRISC to finish tilize into kv_cache_output_cb and write out to DRAM
+                    cb_wait_front(kv_cache_output_cb, kv_cache_num_tiles);
+
+                    cb_addr = get_read_ptr(kv_cache_output_cb);
+                    for (uint32_t i = 0; i < kv_cache_num_tiles; i++) {
+                        noc_async_write_page(kv_cache_page_id_start + i, kv_tensor_accessor, cb_addr);
+                        cb_addr += kv_tensor_accessor.page_size;
+                    }
+                    noc_async_write_barrier();
+                    cb_pop_front(kv_cache_output_cb, kv_cache_num_tiles);
+            }
+#elif defined(COMPILE_FOR_TRISC)
+            if constexpr (IsNopeCore || IsRopeCore) {
+                uint32_t kv_cache_intermed_cb = args.kv_cache_intermed_cb;
+                uint32_t kv_cache_input_cb = args.kv_cache_input_cb;
+                uint32_t kv_cache_output_cb = args.kv_cache_output_cb;
+                constexpr uint32_t kv_cache_num_tiles = IsRopeCore ? 1 : 16;
+                constexpr uint32_t full_ct_dim = IsRopeCore ? 1 : 16;
+                constexpr uint32_t block_ct_dim = IsRopeCore ? 1 : 8;
+
+                reconfig_data_format_srca<false, true>(kv_cache_input_cb);
+                pack_reconfig_data_format<true>(kv_cache_intermed_cb);
+                cb_wait_front(kv_cache_input_cb, kv_cache_num_tiles);
+                cb_reserve_back(kv_cache_intermed_cb, kv_cache_num_tiles + 1);
+                pack_untilize_init<block_ct_dim, full_ct_dim>(kv_cache_input_cb, kv_cache_intermed_cb);
+                pack_untilize_block<block_ct_dim, full_ct_dim>(kv_cache_input_cb, 1, kv_cache_intermed_cb, 0);
+                cb_pop_front(kv_cache_input_cb, block_ct_dim);  // consume first 8 so second block reads tiles 8-15
+                pack_untilize_block<block_ct_dim, full_ct_dim>(kv_cache_input_cb, 1, kv_cache_intermed_cb, 1);
+                pack_untilize_uninit(kv_cache_intermed_cb);
+
+                cb_push_back(kv_cache_intermed_cb, kv_cache_num_tiles);
+                cb_pop_front(kv_cache_input_cb, kv_cache_num_tiles - block_ct_dim);  // pop remaining 8
+
+                cb_wait_front(kv_cache_intermed_cb, kv_cache_num_tiles + 1);
+                cb_reserve_back(kv_cache_output_cb, kv_cache_num_tiles);
+
+                reconfig_data_format_srca<false, true>(kv_cache_intermed_cb);
+                pack_reconfig_data_format<true>(kv_cache_output_cb);
+                tilize_init(kv_cache_intermed_cb, kv_cache_num_tiles, kv_cache_output_cb);
+                tilize_block(kv_cache_intermed_cb, kv_cache_num_tiles, kv_cache_output_cb);
+                tilize_uninit(kv_cache_intermed_cb, kv_cache_output_cb);
+                cb_push_back(kv_cache_output_cb, kv_cache_num_tiles);
+                cb_pop_front(kv_cache_intermed_cb, kv_cache_num_tiles);
+            }
+#endif
+        }
+    };  // class Op
+
+};  // struct KVCacheUpdate
+
+}  // namespace deepseek_b1_ops


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/35536)

### Problem description
Current kv cache if using float16 for testing.

### What's changed
Add kv cache micro op, separate test and fuse into pre_sdpa.

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:{{branch_name}})
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:{{branch_name}})
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:{{branch_name}})
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:{{branch_name}})
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:{{branch_name}})
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:{{branch_name}})
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
