### PR TITLE
TTNN Tensor Cleanup in preparation of Metal Tensor Split

### DIFF
--- a/tests/ttnn/unit_tests/gtests/tensor/test_mesh_tensor.cpp
+++ b/tests/ttnn/unit_tests/gtests/tensor/test_mesh_tensor.cpp
@@ -159,11 +159,10 @@ TEST_F(MeshTensorTest, ToDeviceMemoryConfigOverride) {
     EXPECT_TRUE(input_host_tensor.storage_type() == StorageType::HOST);
     EXPECT_EQ(input_host_tensor.tensor_spec().memory_config().buffer_type(), BufferType::L1);
 
-    Tensor device_tensor_default = tensor_impl::to_device(input_host_tensor, mesh_device_.get());
+    Tensor device_tensor_default = to_device(input_host_tensor, mesh_device_.get());
     EXPECT_EQ(device_tensor_default.tensor_spec().memory_config().buffer_type(), BufferType::L1);
 
-    Tensor device_tensor_dram =
-        tensor_impl::to_device(input_host_tensor, mesh_device_.get(), MemoryConfig{BufferType::DRAM});
+    Tensor device_tensor_dram = to_device(input_host_tensor, mesh_device_.get(), MemoryConfig{BufferType::DRAM});
     EXPECT_EQ(device_tensor_dram.tensor_spec().memory_config().buffer_type(), BufferType::DRAM);
 }
 
@@ -181,7 +180,7 @@ TEST_F(MeshTensorTest, ReplicateHostStorageTensor) {
     EXPECT_EQ(input_host_tensor.tensor_spec().logical_shape(), shape);
 
     // Write host tensor to device.
-    Tensor device_tensor = tensor_impl::to_device(input_host_tensor, mesh_device_.get(), MemoryConfig{});
+    Tensor device_tensor = to_device(input_host_tensor, mesh_device_.get(), MemoryConfig{});
     EXPECT_EQ(device_tensor.tensor_spec().logical_shape(), shape);
     EXPECT_EQ(
         device_tensor.tensor_topology(),
@@ -212,7 +211,7 @@ TEST_F(MeshTensorTest, GetDeviceTensors) {
 
     Tensor input_host_tensor = Tensor::from_vector(host_data, tensor_spec);
 
-    Tensor device_tensor = tensor_impl::to_device(input_host_tensor, mesh_device_.get());
+    Tensor device_tensor = to_device(input_host_tensor, mesh_device_.get());
     const auto& device_storage = device_tensor.device_storage();
     EXPECT_NE(device_storage.mesh_buffer, nullptr);
     EXPECT_THAT(device_storage.coords, SizeIs(mesh_device_->num_devices()));
@@ -247,8 +246,8 @@ TEST_F(MeshTensorTest2x4, CombineDeviceTensors) {
 
     Tensor input_host_tensor = Tensor::from_vector(host_data, tensor_spec);
 
-    Tensor device_tensor1 = tensor_impl::to_device(input_host_tensor, mesh_device_.get());
-    Tensor device_tensor2 = tensor_impl::to_device(input_host_tensor, mesh_device_.get());
+    Tensor device_tensor1 = to_device(input_host_tensor, mesh_device_.get());
+    Tensor device_tensor2 = to_device(input_host_tensor, mesh_device_.get());
 
     auto device_tensors1 = get_device_tensors(device_tensor1);
     auto device_tensors2 = get_device_tensors(device_tensor2);
@@ -336,10 +335,10 @@ TEST_P(MeshTensorWriteTest, WriteMultiDeviceHostTensor) {
     auto device_tensor = [&]() {
         if (GetParam().use_pre_allocated_tensor_api) {
             Tensor device_tensor = create_device_tensor(input_host_shards.at(0).tensor_spec(), mesh_device_.get());
-            tensor_impl::copy_to_device(input_host_tensor_sharded, device_tensor);
+            copy_to_device(input_host_tensor_sharded, device_tensor);
             return device_tensor;
         }
-        return tensor_impl::to_device(input_host_tensor_sharded, mesh_device_.get());
+        return to_device(input_host_tensor_sharded, mesh_device_.get());
     }();
 
     EXPECT_EQ(device_tensor.tensor_topology(), input_host_tensor_sharded.tensor_topology());
@@ -350,7 +349,7 @@ TEST_P(MeshTensorWriteTest, WriteMultiDeviceHostTensor) {
     auto output_host_tensor = [&]() {
         if (GetParam().use_pre_allocated_tensor_api) {
             Tensor host_tensor = allocate_tensor_on_host(device_tensor.tensor_spec(), mesh_device_.get());
-            tensor_impl::copy_to_host(device_tensor, host_tensor, /*blocking=*/true);
+            copy_to_host(device_tensor, host_tensor, /*blocking=*/true);
             return host_tensor;
         }
         return device_tensor.cpu();

--- a/tests/ttnn/unit_tests/gtests/tensor/test_mesh_tensor.cpp
+++ b/tests/ttnn/unit_tests/gtests/tensor/test_mesh_tensor.cpp
@@ -36,7 +36,7 @@ TEST(MeshTensorHostTest, ToHostAlreadyOnHost) {
     Tensor input_host_tensor = Tensor::from_vector(std::vector<float>(shape.volume()), tensor_spec);
     EXPECT_TRUE(input_host_tensor.storage_type() == StorageType::HOST);
 
-    EXPECT_ANY_THROW((void)input_host_tensor.cpu());
+    EXPECT_ANY_THROW(cpu(input_host_tensor));
 }
 
 TEST(MeshTensorHostTest, FromHostShardsDifferentSpecs) {
@@ -191,7 +191,7 @@ TEST_F(MeshTensorTest, ReplicateHostStorageTensor) {
     EXPECT_THAT(device_storage.coords, SizeIs(mesh_device_->num_devices()));
 
     // Read the tensor back, and compare it with input data.
-    Tensor output_host_tensor = device_tensor.cpu();
+    Tensor output_host_tensor = cpu(device_tensor);
     EXPECT_TRUE(output_host_tensor.storage_type() == StorageType::HOST);
     EXPECT_EQ(output_host_tensor.tensor_spec().logical_shape(), shape);
 
@@ -352,7 +352,7 @@ TEST_P(MeshTensorWriteTest, WriteMultiDeviceHostTensor) {
             copy_to_host(device_tensor, host_tensor, /*blocking=*/true);
             return host_tensor;
         }
-        return device_tensor.cpu();
+        return cpu(device_tensor);
     }();
 
     EXPECT_EQ(output_host_tensor.tensor_topology(), input_host_tensor_sharded.tensor_topology());

--- a/tests/ttnn/unit_tests/gtests/tensor/test_mesh_tensor.cpp
+++ b/tests/ttnn/unit_tests/gtests/tensor/test_mesh_tensor.cpp
@@ -36,7 +36,7 @@ TEST(MeshTensorHostTest, ToHostAlreadyOnHost) {
     Tensor input_host_tensor = Tensor::from_vector(std::vector<float>(shape.volume()), tensor_spec);
     EXPECT_TRUE(input_host_tensor.storage_type() == StorageType::HOST);
 
-    EXPECT_ANY_THROW(tensor_impl::to_host(input_host_tensor));
+    EXPECT_ANY_THROW((void)input_host_tensor.cpu());
 }
 
 TEST(MeshTensorHostTest, FromHostShardsDifferentSpecs) {
@@ -192,7 +192,7 @@ TEST_F(MeshTensorTest, ReplicateHostStorageTensor) {
     EXPECT_THAT(device_storage.coords, SizeIs(mesh_device_->num_devices()));
 
     // Read the tensor back, and compare it with input data.
-    Tensor output_host_tensor = tensor_impl::to_host(device_tensor);
+    Tensor output_host_tensor = device_tensor.cpu();
     EXPECT_TRUE(output_host_tensor.storage_type() == StorageType::HOST);
     EXPECT_EQ(output_host_tensor.tensor_spec().logical_shape(), shape);
 
@@ -353,7 +353,7 @@ TEST_P(MeshTensorWriteTest, WriteMultiDeviceHostTensor) {
             tensor_impl::copy_to_host(device_tensor, host_tensor, /*blocking=*/true);
             return host_tensor;
         }
-        return tensor_impl::to_host(device_tensor);
+        return device_tensor.cpu();
     }();
 
     EXPECT_EQ(output_host_tensor.tensor_topology(), input_host_tensor_sharded.tensor_topology());

--- a/tests/ttnn/unit_tests/gtests/tensor/test_mesh_tensor.cpp
+++ b/tests/ttnn/unit_tests/gtests/tensor/test_mesh_tensor.cpp
@@ -36,7 +36,7 @@ TEST(MeshTensorHostTest, ToHostAlreadyOnHost) {
     Tensor input_host_tensor = Tensor::from_vector(std::vector<float>(shape.volume()), tensor_spec);
     EXPECT_TRUE(input_host_tensor.storage_type() == StorageType::HOST);
 
-    EXPECT_ANY_THROW(cpu(input_host_tensor));
+    EXPECT_NO_THROW(cpu(input_host_tensor));
 }
 
 TEST(MeshTensorHostTest, FromHostShardsDifferentSpecs) {

--- a/tests/ttnn/unit_tests/gtests/tensor/test_tensor_nd_sharding.cpp
+++ b/tests/ttnn/unit_tests/gtests/tensor/test_tensor_nd_sharding.cpp
@@ -135,7 +135,7 @@ TEST_P(NDShardingTests, RegionWriteReadTest) {
     std::vector<uint16_t> empty_data(volume);
     auto tensor = Tensor::from_vector(empty_data, tensor_spec, device_);
 
-    auto& storage = std::get<DeviceStorage>(tensor.storage());
+    const auto& storage = tensor.device_storage();
     auto buffer = storage.get_mesh_buffer();
 
     size_t region_size = buffer->page_size();

--- a/tests/ttnn/unit_tests/gtests/tensor/test_vector_conversion.cpp
+++ b/tests/ttnn/unit_tests/gtests/tensor/test_vector_conversion.cpp
@@ -179,7 +179,7 @@ TYPED_TEST(BorrowedStorageVectorConversionTest, Roundtrip) {
         EXPECT_EQ(ctor_count, 1);
         EXPECT_EQ(dtor_count, 0);
         {
-            Tensor copy(tensor.storage(), tensor.tensor_spec(), tensor.tensor_topology());
+            Tensor copy(tensor.host_storage(), tensor.tensor_spec(), tensor.tensor_topology());
             EXPECT_EQ(ctor_count, 2);
             EXPECT_EQ(dtor_count, 0);
         }
@@ -211,7 +211,7 @@ TYPED_TEST(BorrowedStorageVectorConversionTest, Callbacks) {
     EXPECT_EQ(ctor_count, 1);
     EXPECT_EQ(dtor_count, 0);
     {
-        Tensor copy(tensor.storage(), tensor.tensor_spec(), tensor.tensor_topology());
+        Tensor copy(tensor.host_storage(), tensor.tensor_spec(), tensor.tensor_topology());
         EXPECT_EQ(ctor_count, 2);
         EXPECT_EQ(dtor_count, 0);
     }

--- a/tests/ttnn/unit_tests/gtests/test_launch_operation.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_launch_operation.cpp
@@ -167,7 +167,7 @@ TEST_F(LaunchOperation2x4Test, FilterTensorShards) {
             ttnn::MeshCoordinate{1, 3}));
 
     // Filter the first 2 shards and the last 3 shards.
-    filter_tensor_shards(
+    auto filtered_tensor = filter_tensor_shards(
         {ttnn::MeshCoordinate{0, 0},
          ttnn::MeshCoordinate{0, 1},
          ttnn::MeshCoordinate{1, 1},
@@ -175,9 +175,9 @@ TEST_F(LaunchOperation2x4Test, FilterTensorShards) {
          ttnn::MeshCoordinate{1, 3}},
         full_tensor);
 
-    EXPECT_FALSE(all_tensors_have_uniform_storage(full_tensor));
+    EXPECT_FALSE(all_tensors_have_uniform_storage(filtered_tensor));
     EXPECT_THAT(
-        extract_tensor_coordinates(full_tensor),
+        extract_tensor_coordinates(filtered_tensor),
         ElementsAre(
             ttnn::MeshCoordinate{0, 0},  //
             ttnn::MeshCoordinate{0, 1},
@@ -186,23 +186,23 @@ TEST_F(LaunchOperation2x4Test, FilterTensorShards) {
             ttnn::MeshCoordinate{1, 3}));
 
     // Filter the first and the last shards.
-    filter_tensor_shards(
+    filtered_tensor = filter_tensor_shards(
         {ttnn::MeshCoordinate{0, 0},  //
          ttnn::MeshCoordinate{1, 3}},
-        full_tensor);
+        filtered_tensor);
 
-    EXPECT_FALSE(all_tensors_have_uniform_storage(full_tensor));
+    EXPECT_FALSE(all_tensors_have_uniform_storage(filtered_tensor));
     EXPECT_THAT(
-        extract_tensor_coordinates(full_tensor),
+        extract_tensor_coordinates(filtered_tensor),
         ElementsAre(
             ttnn::MeshCoordinate{0, 0},  //
             ttnn::MeshCoordinate{1, 3}));
 
     // Filter the rest.
-    filter_tensor_shards(/*tensor_coordinates=*/{}, full_tensor);
+    filtered_tensor = filter_tensor_shards(/*tensor_coordinates=*/{}, filtered_tensor);
 
-    EXPECT_FALSE(all_tensors_have_uniform_storage(full_tensor));
-    EXPECT_THAT(extract_tensor_coordinates(full_tensor), IsEmpty());
+    EXPECT_FALSE(all_tensors_have_uniform_storage(filtered_tensor));
+    EXPECT_THAT(extract_tensor_coordinates(filtered_tensor), IsEmpty());
 }
 
 TEST_F(LaunchOperation2x4Test, LaunchOpFilterTensorShards) {

--- a/tests/ttnn/unit_tests/gtests/udm/test_udm_utils.hpp
+++ b/tests/ttnn/unit_tests/gtests/udm/test_udm_utils.hpp
@@ -562,8 +562,8 @@ inline void log_gcores_info(
  */
 inline tt::tt_metal::experimental::udm::MeshTensorBuilder create_tensor_builder(const ttnn::Tensor& tensor) {
     // Extract MeshBuffer from the distributed tensor
-    TT_FATAL(std::holds_alternative<tt::tt_metal::DeviceStorage>(tensor.storage()), "Tensor must be on device");
-    const auto& device_storage = std::get<tt::tt_metal::DeviceStorage>(tensor.storage());
+    TT_FATAL(is_device_tensor(tensor), "Tensor must be on device");
+    const auto& device_storage = tensor.device_storage();
     TT_FATAL(device_storage.mesh_buffer != nullptr, "Tensor must have a MeshBuffer");
 
     // Extract distribution info from tensor topology

--- a/tt-train/sources/ttml/core/tt_tensor_utils.cpp
+++ b/tt-train/sources/ttml/core/tt_tensor_utils.cpp
@@ -62,7 +62,7 @@ tt::tt_metal::Tensor ttml_create_owned_tensor(
 }
 
 std::vector<tt::tt_metal::HostBuffer> get_as(const ttnn::Tensor& tensor) {
-    TT_FATAL(is_device_tensor(tensor), "Tensor must be on host");
+    TT_FATAL(is_cpu_tensor(tensor), "Tensor must be on host");
     const auto& storage = tensor.host_storage();
     std::vector<tt::tt_metal::HostBuffer> buffers;
     buffers.reserve(storage.buffer().shard_coords().size());

--- a/tt-train/sources/ttml/core/tt_tensor_utils.cpp
+++ b/tt-train/sources/ttml/core/tt_tensor_utils.cpp
@@ -254,7 +254,7 @@ tt::tt_metal::Tensor from_vector<int32_t, ttnn::DataType::INT32>(
 }
 
 bool is_tensor_initialized(const tt::tt_metal::Tensor& tensor) {
-    return tensor.tensor_attributes != nullptr;
+    return !tensor.is_valueless();
 }
 
 void print_tensor_stats(const tt::tt_metal::Tensor& tensor, const std::string& name) {

--- a/tt-train/sources/ttml/core/tt_tensor_utils.cpp
+++ b/tt-train/sources/ttml/core/tt_tensor_utils.cpp
@@ -62,9 +62,7 @@ tt::tt_metal::Tensor ttml_create_owned_tensor(
 }
 
 std::vector<tt::tt_metal::HostBuffer> get_as(const ttnn::Tensor& tensor) {
-    if (is_device_tensor(tensor)) {
-        throw std::runtime_error("Tensor must be on host");
-    }
+    TT_FATAL(is_device_tensor(tensor), "Tensor must be on host");
     const auto& storage = tensor.host_storage();
     std::vector<tt::tt_metal::HostBuffer> buffers;
     buffers.reserve(storage.buffer().shard_coords().size());

--- a/tt-train/sources/ttml/core/tt_tensor_utils.cpp
+++ b/tt-train/sources/ttml/core/tt_tensor_utils.cpp
@@ -254,7 +254,7 @@ tt::tt_metal::Tensor from_vector<int32_t, ttnn::DataType::INT32>(
 }
 
 bool is_tensor_initialized(const tt::tt_metal::Tensor& tensor) {
-    return !tensor.is_valueless();
+    return tensor.tensor_attributes != nullptr;
 }
 
 void print_tensor_stats(const tt::tt_metal::Tensor& tensor, const std::string& name) {

--- a/ttnn/api/ttnn/device_operation.hpp
+++ b/ttnn/api/ttnn/device_operation.hpp
@@ -561,7 +561,7 @@ typename device_operation_t::tensor_return_value_t launch(
     ttnn::MeshDevice* mesh_device = detail::get_mesh_device<device_operation_t>(operation_attributes, tensor_args);
 
     if (!mesh_device_operation_utils::all_tensors_have_uniform_storage(tensor_args)) {
-        mesh_device_operation_utils::filter_tensor_shards(
+        tensor_return_value = mesh_device_operation_utils::filter_tensor_shards(
             mesh_device_operation_utils::extract_tensor_coordinates(tensor_args, mesh_device), tensor_return_value);
     }
 

--- a/ttnn/api/ttnn/device_operation.hpp
+++ b/ttnn/api/ttnn/device_operation.hpp
@@ -11,6 +11,7 @@
 #include <tt_stl/overloaded.hpp>
 #include <tt_stl/indestructible.hpp>
 #include "ttnn/tensor/tensor.hpp"
+#include "ttnn/tensor/tensor_utils.hpp"
 #include <unordered_map>
 
 #include <tt-metalium/program_cache.hpp>
@@ -550,9 +551,8 @@ typename device_operation_t::tensor_return_value_t launch(
 
     auto first_tensor = tt::stl::reflection::get_first_object_of_type<Tensor>(tensor_args);
     if (first_tensor.has_value()) [[likely]] {
-        const auto& storage = first_tensor.value().storage();
         TT_FATAL(
-            std::holds_alternative<tt::tt_metal::DeviceStorage>(storage),
+            tt::tt_metal::is_device_tensor(first_tensor.value()),
             "Device Operations expect tensor with Device storage in inputs");
     }
 

--- a/ttnn/api/ttnn/mesh_device_operation_utils.hpp
+++ b/ttnn/api/ttnn/mesh_device_operation_utils.hpp
@@ -61,8 +61,7 @@ TensorReturnValue filter_tensor_shards(
             tt::tt_metal::DeviceStorage new_storage(old_storage.mesh_buffer, std::move(filtered_coords));
 
             // Return new tensor with new storage
-            return Tensor(
-                tt::tt_metal::Storage(std::move(new_storage)), tensor.tensor_spec(), tensor.tensor_topology());
+            return Tensor(std::move(new_storage), tensor.tensor_spec(), tensor.tensor_topology());
         },
         tensor_return_value);
 }

--- a/ttnn/api/ttnn/tensor/storage.hpp
+++ b/ttnn/api/ttnn/tensor/storage.hpp
@@ -50,9 +50,17 @@ struct DeviceStorage {
 
     Buffer* get_buffer() const;
     std::shared_ptr<distributed::MeshBuffer> get_mesh_buffer() const;
+
+    // Begin internal functions:
+    //
+    // These functions allows the use of the get_mesh_buffer as a view.
+    // These are considered internal functions and are not part of the public API.
+    // They will be replaced with a new initiative as described in: #38093
     const std::shared_ptr<distributed::MeshBuffer>& get_root_mesh_buffer() const;
     void deallocate_root_mesh_buffer();
     void reset_root_mesh_buffer();
+    // End internal functions.
+
     static constexpr auto attribute_names = std::forward_as_tuple();
     auto attribute_values() const { return std::forward_as_tuple(); }
 

--- a/ttnn/api/ttnn/tensor/tensor.hpp
+++ b/ttnn/api/ttnn/tensor/tensor.hpp
@@ -47,7 +47,8 @@ public:
     ~Tensor();
 
     // Constructs a tensor with `Storage`, `TensorSpec`, and `TensorTopology`.
-    [[nodiscard]] Tensor(Storage storage, TensorSpec tensor_spec, TensorTopology tensor_topology);
+    [[nodiscard]] Tensor(HostStorage storage, TensorSpec tensor_spec, TensorTopology tensor_topology);
+    [[nodiscard]] Tensor(DeviceStorage storage, TensorSpec tensor_spec, TensorTopology tensor_topology);
 
     // Constructors of `Tensor` that take physical data encoded in `HostBuffer`.
     // The encoded data type and physical size of the data must match the specified tensor physical shape and data type.
@@ -183,7 +184,11 @@ public:
     // ======================================================================================
     //                                      Getters
     // ======================================================================================
+private:
+    // TODO: remove this, use case has been all cleaned up
     const Storage& storage() const;
+
+public:
     DataType dtype() const;
     Layout layout() const;
     const tt::tt_metal::Shape& logical_shape() const;
@@ -253,7 +258,6 @@ private:
     // TODO: #21099 - This won't be needed after the migration to MeshDevice is complete.
     std::optional<distributed::MeshDevice*> mesh_device_ = std::nullopt;
 
-    void init(Storage storage, TensorSpec tensor_spec, TensorTopology tensor_topology);
     void deallocate_impl(bool force);
 
     // Shared pointer to all attributes associated with this tensor

--- a/ttnn/api/ttnn/tensor/tensor.hpp
+++ b/ttnn/api/ttnn/tensor/tensor.hpp
@@ -36,10 +36,6 @@ public:
     constexpr static std::uint64_t INVALID_TENSOR_ID = std::numeric_limits<std::uint64_t>::max();
     std::uint64_t tensor_id{INVALID_TENSOR_ID};
 
-    // Shared pointer to all attributes associated with this tensor
-    // Can be safely passed between threads when the tensor is copied
-    std::shared_ptr<TensorAttributes> tensor_attributes = nullptr;
-
     // ======================================================================================
     //                                  Hi Level APIs
     // ======================================================================================
@@ -243,10 +239,7 @@ public:
     uint32_t element_size() const;
 
     static constexpr auto attribute_names = std::forward_as_tuple("storage", "tensor_spec");
-    auto attribute_values() const {
-        return std::forward_as_tuple(
-            this->tensor_attributes->get_storage(), this->tensor_attributes->get_tensor_spec());
-    }
+    auto attribute_values() const { return std::forward_as_tuple(storage(), tensor_spec()); }
 
     static std::uint64_t get_tensor_id_counter();
 
@@ -263,6 +256,10 @@ private:
 
     void init(Storage storage, TensorSpec tensor_spec, TensorTopology tensor_topology);
     void deallocate_impl(bool force);
+
+    // Shared pointer to all attributes associated with this tensor
+    // Can be safely passed between threads when the tensor is copied
+    std::shared_ptr<TensorAttributes> tensor_attributes = nullptr;
 };
 
 // The set of memcpy functions below are used to copy data between host buffers/tensors and single-device tensors

--- a/ttnn/api/ttnn/tensor/tensor.hpp
+++ b/ttnn/api/ttnn/tensor/tensor.hpp
@@ -189,7 +189,10 @@ public:
     //                                      Getters
     // ======================================================================================
 private:
-    // TODO: remove this, use case has been all cleaned up
+    // TODO(river):
+    // This will be removed as part of Metal Tensor split lowering (#37692).
+    // The function is removed publicly as the underlying storage of Tensor will be changed as part of the refactoring
+    // effort.
     const Storage& storage() const;
 
 public:

--- a/ttnn/api/ttnn/tensor/tensor.hpp
+++ b/ttnn/api/ttnn/tensor/tensor.hpp
@@ -252,6 +252,12 @@ public:
     // TODO #32045: Remove this function since IDs are assigned in the constructor.
     static std::uint64_t next_tensor_id();
 
+    /**
+     * The tensor could be valueless if it is default initialized or in a moved-from state.
+     * Any operations on a valueless tensor will be undefined behavior.
+     */
+    bool is_valueless() const;
+
 private:
     // Shorthand for checking if this Tensor is allocated on MeshDevice. If set, is never nullptr.
     // If not set, the tensor can either be on host or allocated on a single device.

--- a/ttnn/api/ttnn/tensor/tensor.hpp
+++ b/ttnn/api/ttnn/tensor/tensor.hpp
@@ -36,6 +36,10 @@ public:
     constexpr static std::uint64_t INVALID_TENSOR_ID = std::numeric_limits<std::uint64_t>::max();
     std::uint64_t tensor_id{INVALID_TENSOR_ID};
 
+    // Shared pointer to all attributes associated with this tensor
+    // Can be safely passed between threads when the tensor is copied
+    std::shared_ptr<TensorAttributes> tensor_attributes = nullptr;
+
     // ======================================================================================
     //                                  Hi Level APIs
     // ======================================================================================
@@ -259,10 +263,6 @@ private:
     std::optional<distributed::MeshDevice*> mesh_device_ = std::nullopt;
 
     void deallocate_impl(bool force);
-
-    // Shared pointer to all attributes associated with this tensor
-    // Can be safely passed between threads when the tensor is copied
-    std::shared_ptr<TensorAttributes> tensor_attributes = nullptr;
 };
 
 // The set of memcpy functions below are used to copy data between host buffers/tensors and single-device tensors

--- a/ttnn/api/ttnn/tensor/tensor.hpp
+++ b/ttnn/api/ttnn/tensor/tensor.hpp
@@ -252,12 +252,6 @@ public:
     // TODO #32045: Remove this function since IDs are assigned in the constructor.
     static std::uint64_t next_tensor_id();
 
-    /**
-     * The tensor could be valueless if it is default initialized or in a moved-from state.
-     * Any operations on a valueless tensor will be undefined behavior.
-     */
-    bool is_valueless() const;
-
 private:
     // Shorthand for checking if this Tensor is allocated on MeshDevice. If set, is never nullptr.
     // If not set, the tensor can either be on host or allocated on a single device.

--- a/ttnn/api/ttnn/tensor/tensor.hpp
+++ b/ttnn/api/ttnn/tensor/tensor.hpp
@@ -184,7 +184,6 @@ public:
     //                                      Getters
     // ======================================================================================
     const Storage& storage() const;
-    Storage& storage();
     DataType dtype() const;
     Layout layout() const;
     const tt::tt_metal::Shape& logical_shape() const;

--- a/ttnn/api/ttnn/tensor/tensor_ops.hpp
+++ b/ttnn/api/ttnn/tensor/tensor_ops.hpp
@@ -26,8 +26,8 @@ Tensor create_device_tensor(const TensorSpec& tensor_spec, IDevice* device);
 tt::tt_metal::Tensor to_device(
     const tt::tt_metal::Tensor& input_tensor,
     distributed::MeshDevice* mesh_device,
-    ttsl::optional_reference<const MemoryConfig> mem_config,
-    std::optional<QueueId> cq_id);
+    ttsl::optional_reference<const MemoryConfig> mem_config = std::nullopt,
+    std::optional<QueueId> cq_id = std::nullopt);
 
 void copy_to_device(const Tensor& host_tensor, Tensor& device_tensor, std::optional<QueueId> cq_id = std::nullopt);
 
@@ -43,6 +43,12 @@ void copy_to_host(
     std::byte* dst,
     const std::optional<BufferRegion>& region = std::nullopt,
     bool blocking = true);
+
+void copy_to_host(
+    const Tensor& device_tensor,
+    Tensor& host_tensor,
+    bool blocking = true,
+    std::optional<QueueId> cq_id = std::nullopt);
 
 Tensor to_layout(const Tensor& input_tensor, tt::tt_metal::Layout target_layout);
 

--- a/ttnn/api/ttnn/tensor/tensor_ops.hpp
+++ b/ttnn/api/ttnn/tensor/tensor_ops.hpp
@@ -52,7 +52,7 @@ void copy_to_host(
 
 Tensor to_layout(const Tensor& input_tensor, tt::tt_metal::Layout target_layout);
 
-Tensor cpu(const Tensor& input_tensor, bool blocking, std::optional<QueueId> cq_id);
+Tensor cpu(const Tensor& input_tensor, bool blocking = true, std::optional<QueueId> cq_id = std::nullopt);
 
 Tensor pad(
     const Tensor& input_tensor,

--- a/ttnn/core/tensor/host_buffer/functions.cpp
+++ b/ttnn/core/tensor/host_buffer/functions.cpp
@@ -2,31 +2,23 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <cstddef>
 #include <vector>
 
-#include <tt_stl/overloaded.hpp>
-#include <tt_stl/reflection.hpp>
-
-#include "ttnn/tensor/storage.hpp"
-#include "ttnn/tensor/tensor.hpp"
+#include <ttnn/tensor/host_buffer/functions.hpp>
+#include <ttnn/tensor/tensor.hpp>
+#include <ttnn/tensor/tensor_utils.hpp>
 
 namespace tt::tt_metal::host_buffer {
 
 HostBuffer get_host_buffer(const Tensor& tensor) {
-    return std::visit(
-        tt::stl::overloaded{
-            [](const HostStorage& storage) {
-                std::vector<HostBuffer> buffers;
-                storage.buffer().apply([&buffers](const HostBuffer& shard) { buffers.push_back(shard); });
-                TT_FATAL(
-                    buffers.size() == 1,
-                    "Can't get a single buffer from host storage distributed over mesh shape {}",
-                    storage.buffer().shape());
-                return buffers.front();
-            },
-            [](const auto&) -> HostBuffer { TT_THROW("Tensor must have HostStorage"); },
-        },
-        tensor.storage());
+    TT_FATAL(is_cpu_tensor(tensor), "Tensor must have HostStorage");
+    const auto& storage = tensor.host_storage();
+    std::vector<HostBuffer> buffers;
+    storage.buffer().apply([&buffers](const HostBuffer& shard) { buffers.push_back(shard); });
+    TT_FATAL(
+        buffers.size() == 1,
+        "Can't get a single buffer from host storage distributed over mesh shape {}",
+        storage.buffer().shape());
+    return buffers.front();
 }
 }  // namespace tt::tt_metal::host_buffer

--- a/ttnn/core/tensor/tensor.cpp
+++ b/ttnn/core/tensor/tensor.cpp
@@ -77,20 +77,19 @@ Tensor::Tensor(
 }
 
 Tensor::Tensor(HostBuffer buffer, TensorSpec tensor_spec) :
-    Tensor(Storage(HostStorage(std::move(buffer))), std::move(tensor_spec), TensorTopology{}) {}
+    Tensor(HostStorage(std::move(buffer)), std::move(tensor_spec), TensorTopology{}) {}
 
-Tensor::Tensor(Storage storage, TensorSpec tensor_spec, TensorTopology tensor_topology) :
-    tensor_id(Tensor::next_tensor_id()) {
-    init(Storage(std::move(storage)), std::move(tensor_spec), std::move(tensor_topology));
-}
+Tensor::Tensor(HostStorage storage, TensorSpec tensor_spec, TensorTopology tensor_topology) :
+    tensor_id(Tensor::next_tensor_id()),
+    tensor_attributes(
+        std::make_shared<TensorAttributes>(std::move(storage), std::move(tensor_spec), std::move(tensor_topology))) {}
 
-void Tensor::init(Storage storage, TensorSpec tensor_spec, TensorTopology tensor_topology) {
-    tensor_attributes =
-        std::make_shared<TensorAttributes>(std::move(storage), std::move(tensor_spec), std::move(tensor_topology));
-
-    if (auto* device_storage = std::get_if<DeviceStorage>(&tensor_attributes->get_storage());
-        device_storage != nullptr && device_storage->mesh_buffer != nullptr) {
-        mesh_device_ = device_storage->mesh_buffer->device();
+Tensor::Tensor(DeviceStorage storage, TensorSpec tensor_spec, TensorTopology tensor_topology) :
+    tensor_id(Tensor::next_tensor_id()),
+    tensor_attributes(
+        std::make_shared<TensorAttributes>(std::move(storage), std::move(tensor_spec), std::move(tensor_topology))) {
+    if (device_storage().mesh_buffer != nullptr) {
+        mesh_device_ = storage.mesh_buffer->device();
     }
 }
 

--- a/ttnn/core/tensor/tensor.cpp
+++ b/ttnn/core/tensor/tensor.cpp
@@ -606,6 +606,4 @@ std::ostream& operator<<(std::ostream& os, const tt::tt_metal::Tensor& tensor) {
     return os;
 }
 
-bool Tensor::is_valueless() const { return this->tensor_attributes == nullptr; }
-
 }  // namespace tt::tt_metal

--- a/ttnn/core/tensor/tensor.cpp
+++ b/ttnn/core/tensor/tensor.cpp
@@ -555,8 +555,6 @@ Tensor set_tensor_id(const Tensor& tensor) {
     return output;
 };
 
-Storage& Tensor::storage() { return this->tensor_attributes->get_storage(); }
-
 const Storage& Tensor::storage() const { return this->tensor_attributes->get_storage(); }
 
 const tt::tt_metal::Shape& Tensor::logical_shape() const {

--- a/ttnn/core/tensor/tensor.cpp
+++ b/ttnn/core/tensor/tensor.cpp
@@ -606,4 +606,6 @@ std::ostream& operator<<(std::ostream& os, const tt::tt_metal::Tensor& tensor) {
     return os;
 }
 
+bool Tensor::is_valueless() const { return this->tensor_attributes == nullptr; }
+
 }  // namespace tt::tt_metal

--- a/ttnn/core/tensor/tensor.cpp
+++ b/ttnn/core/tensor/tensor.cpp
@@ -88,8 +88,8 @@ Tensor::Tensor(DeviceStorage storage, TensorSpec tensor_spec, TensorTopology ten
     tensor_id(Tensor::next_tensor_id()),
     tensor_attributes(
         std::make_shared<TensorAttributes>(std::move(storage), std::move(tensor_spec), std::move(tensor_topology))) {
-    if (device_storage().mesh_buffer != nullptr) {
-        mesh_device_ = storage.mesh_buffer->device();
+    if (auto buffer = device_storage().mesh_buffer; buffer != nullptr) {
+        mesh_device_ = buffer->device();
     }
 }
 

--- a/ttnn/core/tensor/tensor_impl.cpp
+++ b/ttnn/core/tensor/tensor_impl.cpp
@@ -468,7 +468,6 @@ std::string to_string_impl(const Tensor& tensor) {
         return ss.str();
     }
 
-    TT_FATAL(is_device_tensor(tensor), "Unsupported storage type");
     const auto& storage = tensor.device_storage();
     auto cpu_tensor = tensor.cpu();
     if (storage.mesh_buffer == nullptr) {

--- a/ttnn/core/tensor/tensor_ops.cpp
+++ b/ttnn/core/tensor/tensor_ops.cpp
@@ -129,6 +129,13 @@ void copy_to_host(
     GraphTracker::instance().track_function_end(device_tensor);
 }
 
+void copy_to_host(const Tensor& device_tensor, Tensor& host_tensor, bool blocking, std::optional<QueueId> cq_id) {
+    GraphTracker::instance().track_function_start(
+        "tt::tt_metal::copy_to_host", device_tensor, host_tensor, blocking, cq_id);
+    tensor_impl::copy_to_host(device_tensor, host_tensor, blocking, cq_id);
+    GraphTracker::instance().track_function_end(host_tensor);
+}
+
 Tensor cpu(const Tensor& input_tensor, bool blocking, std::optional<QueueId> cq_id) {
     if (input_tensor.storage_type() != StorageType::DEVICE) {
         return input_tensor;

--- a/ttnn/core/tensor/tensor_ops.cpp
+++ b/ttnn/core/tensor/tensor_ops.cpp
@@ -245,6 +245,7 @@ Tensor unpad_from_tile(const Tensor& input_tensor, const tt::tt_metal::Shape& ou
 // ======================================================================================
 //                                  .tensor_view()
 // ======================================================================================
+
 Tensor view(const Tensor& input_tensor, const Shape& new_logical_shape, const Shape& new_padded_shape) {
     tt::tt_metal::GraphTracker::instance().track_function_start(
         "Tensor::reshape", input_tensor, new_logical_shape, new_padded_shape);
@@ -285,14 +286,12 @@ Tensor view(const Tensor& input_tensor, const Shape& new_logical_shape, const Sh
             new_logical_shape,
             new_padded_shape));
     // TODO (#25340): Review tensor topology logic for reshape
-    auto output = std::visit(
-        [&input_tensor, &new_spec, &new_logical_shape, &new_padded_shape, &output_memory_config, &changing_last_dim](
-            auto&& storage) -> Tensor {
-            using T = std::decay_t<decltype(storage)>;
+    auto output = std::invoke(
+        [&input_tensor, &new_spec, &new_logical_shape, &output_memory_config, &changing_last_dim]() -> Tensor {
             const auto& tensor = input_tensor;
 
-            if constexpr (std::is_same_v<T, tt::tt_metal::DeviceStorage>) {
-                auto device_storage = std::get<tt::tt_metal::DeviceStorage>(tensor.storage());
+            if (is_device_tensor(tensor)) {
+                auto device_storage = tensor.device_storage();
                 if (tensor.layout() != Layout::ROW_MAJOR || !changing_last_dim) {
                     return Tensor(std::move(device_storage), new_spec, tensor.tensor_topology());
                 }
@@ -336,14 +335,11 @@ Tensor view(const Tensor& input_tensor, const Shape& new_logical_shape, const Sh
                     view_mesh_buffer, device_storage.coords, device_storage.get_root_mesh_buffer());
 
                 return Tensor(view_storage, new_spec, tensor.tensor_topology());
-
-            } else if constexpr (std::is_same_v<T, tt::tt_metal::HostStorage>) {
-                return Tensor(tensor.storage(), new_spec, tensor.tensor_topology());
-            } else {
-                static_assert(tt::stl::concepts::always_false_v<T>, "Unsupported storage type");
             }
-        },
-        input_tensor.storage());
+
+            TT_FATAL(is_cpu_tensor(tensor), "Unsupported storage type");
+            return Tensor(tensor.host_storage(), new_spec, tensor.tensor_topology());
+        });
     output = tt::tt_metal::set_tensor_id(output);
     tt::tt_metal::GraphTracker::instance().track_function_end(output);
     return output;

--- a/ttnn/core/tensor/tensor_ops.cpp
+++ b/ttnn/core/tensor/tensor_ops.cpp
@@ -344,7 +344,6 @@ Tensor view(const Tensor& input_tensor, const Shape& new_logical_shape, const Sh
                 return Tensor(view_storage, new_spec, tensor.tensor_topology());
             }
 
-            TT_FATAL(is_cpu_tensor(tensor), "Unsupported storage type");
             return Tensor(tensor.host_storage(), new_spec, tensor.tensor_topology());
         });
     output = tt::tt_metal::set_tensor_id(output);

--- a/ttnn/core/tensor/to_string.cpp
+++ b/ttnn/core/tensor/to_string.cpp
@@ -5,6 +5,7 @@
 #include "ttnn/tensor/tensor.hpp"
 #include "ttnn/distributed/api.hpp"
 #include "ttnn/tensor/tensor_ops.hpp"
+#include "ttnn/tensor/tensor_utils.hpp"
 
 #include <tt-metalium/graph_tracking.hpp>
 
@@ -24,8 +25,8 @@ std::string to_string(const tt::tt_metal::Tensor& tensor) {
             tensor.layout());
     }
 
-    if (std::holds_alternative<tt::tt_metal::DeviceStorage>(tensor.storage())) {
-        auto storage = std::get<tt::tt_metal::DeviceStorage>(tensor.storage());
+    if (is_device_tensor(tensor)) {
+        const auto& storage = tensor.device_storage();
         if (storage.mesh_buffer != nullptr) {
             auto* mesh_device = storage.mesh_buffer->device();
 

--- a/ttnn/cpp/ttnn-nanobind/operations/core.cpp
+++ b/ttnn/cpp/ttnn-nanobind/operations/core.cpp
@@ -272,7 +272,7 @@ void py_module(nb::module_& mod) {
     mod.def(
         "copy_host_to_device_tensor",
         [](const ttnn::Tensor& host_tensor, ttnn::Tensor& device_tensor, const std::optional<QueueId>& cq_id) {
-            tt::tt_metal::tensor_impl::copy_to_device(host_tensor, device_tensor, cq_id);
+            copy_to_device(host_tensor, device_tensor, cq_id);
         },
         nb::arg("host_tensor"),
         nb::arg("device_tensor"),
@@ -312,7 +312,7 @@ void py_module(nb::module_& mod) {
            ttnn::Tensor& host_tensor,
            bool blocking = true,
            std::optional<ttnn::QueueId> cq_id = std::nullopt) {
-            tt::tt_metal::tensor_impl::copy_to_host(device_tensor, host_tensor, blocking, cq_id);
+            copy_to_host(device_tensor, host_tensor, blocking, cq_id);
         },
         nb::arg("device_tensor"),
         nb::arg("host_tensor"),

--- a/ttnn/cpp/ttnn/operations/creation.hpp
+++ b/ttnn/cpp/ttnn/operations/creation.hpp
@@ -88,7 +88,7 @@ Tensor full_impl(
     Tensor host_tensor(tt::tt_metal::HostBuffer(std::move(owned_buffer)), shape, data_type, layout);
 
     if (optional_output_tensor.has_value()) {
-        tt::tt_metal::tensor_impl::copy_to_device(host_tensor, *optional_output_tensor);
+        copy_to_device(host_tensor, *optional_output_tensor);
         return *optional_output_tensor;
     }
     if (device != nullptr) {

--- a/ttnn/cpp/ttnn/operations/data_movement/move/move.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/move/move.cpp
@@ -19,7 +19,7 @@ using namespace tt::tt_metal;
 namespace ttnn::operations::data_movement {
 
 bool can_deallocate(const Tensor& input_tensor) {
-    if (!is_device_tensor(input_tensor)) {
+    if (is_cpu_tensor(input_tensor)) {
         return false;
     }
     return input_tensor.device_storage().mesh_buffer.use_count() == 1;

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_on_device/reshape.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_on_device/reshape.cpp
@@ -34,7 +34,7 @@ static Tensor manual_insertion(
     auto cpu_tensor = input_tensor.cpu();
     auto output =
         Tensor(
-            cpu_tensor.storage(),
+            cpu_tensor.host_storage(),
             TensorSpec(
                 logical_shape,
                 TensorLayout::fromPaddedShape(

--- a/ttnn/cpp/ttnn/operations/data_movement/sort/sort.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sort/sort.cpp
@@ -169,8 +169,7 @@ std::vector<Tensor> ExecuteSort::invoke(
     if ((original_lshape == ttnn::Shape{}) || (original_lshape == ttnn::Shape{1})) {
         if (CMAKE_UNIQUE_NAMESPACE::validate_optional_output_tensors_for_early_exit(
                 optional_output_tensors, original_lshape)) {
-            std::get<0>(*optional_output_tensors).tensor_attributes->get_storage() =
-                input_tensor.tensor_attributes->get_storage();
+            std::get<0>(*optional_output_tensors).storage() = input_tensor.storage();
             return {std::get<0>(optional_output_tensors.value()), std::get<1>(optional_output_tensors.value())};
         }
         return {input_tensor, ttnn::zeros_like(input_tensor)};

--- a/ttnn/cpp/ttnn/operations/data_movement/sort/sort.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sort/sort.cpp
@@ -169,7 +169,7 @@ std::vector<Tensor> ExecuteSort::invoke(
     if ((original_lshape == ttnn::Shape{}) || (original_lshape == ttnn::Shape{1})) {
         if (CMAKE_UNIQUE_NAMESPACE::validate_optional_output_tensors_for_early_exit(
                 optional_output_tensors, original_lshape)) {
-            std::get<0>(*optional_output_tensors).storage() = input_tensor.storage();
+            std::get<0>(*optional_output_tensors) = input_tensor;
             return {std::get<0>(optional_output_tensors.value()), std::get<1>(optional_output_tensors.value())};
         }
         return {input_tensor, ttnn::zeros_like(input_tensor)};

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_device_operation.cpp
@@ -8,6 +8,7 @@
 
 #include "ttnn/device_operation.hpp"
 #include "ttnn/tensor/tensor_ops.hpp"
+#include "ttnn/tensor/tensor_utils.hpp"
 #include <tt-metalium/work_split.hpp>
 #include <tt-metalium/host_api.hpp>
 
@@ -333,16 +334,10 @@ tt::stl::hash::hash_t BinaryDeviceOperation::compute_program_hash(
     const auto& input_tensor_b = tensor_args.input_tensor_b;
 
     auto program_factory = select_program_factory(attributes, tensor_args);
-    TT_ASSERT(
-        std::holds_alternative<DeviceStorage>(input_tensor_a.storage()),
-        "Unexpected type {}",
-        tt::stl::get_active_type_name_in_variant(input_tensor_a.storage()));
+    TT_ASSERT(is_device_tensor(input_tensor_a), "Unexpected type {}", input_tensor_a.storage_type());
 
     if (input_tensor_b.has_value()) {
-        TT_ASSERT(
-            std::holds_alternative<DeviceStorage>(input_tensor_b->storage()),
-            "Unexpected type {}",
-            tt::stl::get_active_type_name_in_variant(input_tensor_b->storage()));
+        TT_ASSERT(is_device_tensor(*input_tensor_b), "Unexpected type {}", input_tensor_b->storage_type());
 
         return operation::hash_operation<BinaryDeviceOperation>(
             attributes,

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_device_operation.cpp
@@ -334,10 +334,10 @@ tt::stl::hash::hash_t BinaryDeviceOperation::compute_program_hash(
     const auto& input_tensor_b = tensor_args.input_tensor_b;
 
     auto program_factory = select_program_factory(attributes, tensor_args);
-    TT_ASSERT(is_device_tensor(input_tensor_a), "Unexpected type {}", input_tensor_a.storage_type());
+    TT_FATAL(is_device_tensor(input_tensor_a), "Unexpected Tensor type {}", input_tensor_a.storage_type());
 
     if (input_tensor_b.has_value()) {
-        TT_ASSERT(is_device_tensor(*input_tensor_b), "Unexpected type {}", input_tensor_b->storage_type());
+        TT_FATAL(is_device_tensor(*input_tensor_b), "Unexpected Tensor type {}", input_tensor_b->storage_type());
 
         return operation::hash_operation<BinaryDeviceOperation>(
             attributes,

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.cpp
@@ -6,6 +6,7 @@
 #include "ttnn/device_operation.hpp"
 #include "binary_ng_utils.hpp"
 #include "ttnn/tensor/tensor_ops.hpp"
+#include "ttnn/tensor/tensor_utils.hpp"
 
 using namespace tt::tt_metal;
 
@@ -456,16 +457,10 @@ tt::stl::hash::hash_t BinaryNgDeviceOperation::compute_program_hash(
     const auto& input_tensor_a = tensor_args.input_tensor_a;
     const auto& input_tensor_b = tensor_args.input_tensor_b;
 
-    TT_ASSERT(
-        std::holds_alternative<DeviceStorage>(input_tensor_a.storage()),
-        "Unexpected type {}",
-        tt::stl::get_active_type_name_in_variant(input_tensor_a.storage()));
+    TT_ASSERT(is_device_tensor(input_tensor_a), "Unexpected type {}", input_tensor_a.storage_type());
 
     if (input_tensor_b.has_value()) {
-        TT_ASSERT(
-            std::holds_alternative<DeviceStorage>(input_tensor_b->storage()),
-            "Unexpected type {}",
-            tt::stl::get_active_type_name_in_variant(input_tensor_b->storage()));
+        TT_ASSERT(is_device_tensor(*input_tensor_b), "Unexpected type {}", input_tensor_b->storage_type());
 
         const auto shard_volumes = get_shard_volumes(
             input_tensor_a.tensor_spec(), input_tensor_b->tensor_spec(), compute_output_specs(attributes, tensor_args));

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.cpp
@@ -457,10 +457,10 @@ tt::stl::hash::hash_t BinaryNgDeviceOperation::compute_program_hash(
     const auto& input_tensor_a = tensor_args.input_tensor_a;
     const auto& input_tensor_b = tensor_args.input_tensor_b;
 
-    TT_ASSERT(is_device_tensor(input_tensor_a), "Unexpected type {}", input_tensor_a.storage_type());
+    TT_FATAL(is_device_tensor(input_tensor_a), "Unexpected Tensor type {}", input_tensor_a.storage_type());
 
     if (input_tensor_b.has_value()) {
-        TT_ASSERT(is_device_tensor(*input_tensor_b), "Unexpected type {}", input_tensor_b->storage_type());
+        TT_FATAL(is_device_tensor(*input_tensor_b), "Unexpected Tensor type {}", input_tensor_b->storage_type());
 
         const auto shard_volumes = get_shard_volumes(
             input_tensor_a.tensor_spec(), input_tensor_b->tensor_spec(), compute_output_specs(attributes, tensor_args));

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/device/ternary_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/device/ternary_device_operation.cpp
@@ -8,6 +8,7 @@
 #include "ttnn/operations/cb_utils.hpp"
 #include "ttnn/operations/eltwise/unary/common/unary_op_utils.hpp"
 #include "ttnn/tensor/tensor_ops.hpp"
+#include "ttnn/tensor/tensor_utils.hpp"
 #include <tt-metalium/work_split.hpp>
 
 using namespace tt::tt_metal;
@@ -417,22 +418,13 @@ tt::stl::hash::hash_t TernaryDeviceOperation::compute_program_hash(
     const auto& a_shape = input_a.padded_shape();
     TernaryVariant variant = args.ternary_variant;
 
-    TT_ASSERT(
-        std::holds_alternative<DeviceStorage>(input_a.storage()),
-        "Unexpected type {}",
-        tt::stl::get_active_type_name_in_variant(input_a.storage()));
+    TT_ASSERT(is_device_tensor(input_a), "Unexpected type {}", input_a.storage_type());
     tt::stl::hash::hash_t hash = tt::tt_metal::operation::hash_operation<TernaryDeviceOperation>(
         args, input_a.dtype(), input_a.memory_config(), a_shape.volume());
 
     if (variant == TernaryVariant::TTT) {
-        TT_ASSERT(
-            std::holds_alternative<DeviceStorage>(input_b->storage()),
-            "Unexpected type {}",
-            tt::stl::get_active_type_name_in_variant(input_b->storage()));
-        TT_ASSERT(
-            std::holds_alternative<DeviceStorage>(input_c->storage()),
-            "Unexpected type {}",
-            tt::stl::get_active_type_name_in_variant(input_c->storage()));
+        TT_ASSERT(is_device_tensor(*input_b), "Unexpected type {}", input_b->storage_type());
+        TT_ASSERT(is_device_tensor(*input_c), "Unexpected type {}", input_c->storage_type());
 
         const auto shard_volumes = get_shard_volumes(
             input_a.tensor_spec(),
@@ -452,10 +444,7 @@ tt::stl::hash::hash_t TernaryDeviceOperation::compute_program_hash(
             shard_volumes);
 
     } else if (variant == TernaryVariant::TTS) {
-        TT_ASSERT(
-            std::holds_alternative<DeviceStorage>(input_b->storage()),
-            "Unexpected type {}",
-            tt::stl::get_active_type_name_in_variant(input_b->storage()));
+        TT_ASSERT(is_device_tensor(*input_b), "Unexpected type {}", input_b->storage_type());
 
         const auto shard_volumes = get_shard_volumes(
             input_a.tensor_spec(), input_b->tensor_spec(), std::nullopt, compute_output_specs(args, tensor_args));
@@ -469,10 +458,7 @@ tt::stl::hash::hash_t TernaryDeviceOperation::compute_program_hash(
             a_shape.volume(),
             shard_volumes);
     } else if (variant == TernaryVariant::TST) {
-        TT_ASSERT(
-            std::holds_alternative<DeviceStorage>(input_c->storage()),
-            "Unexpected type {}",
-            tt::stl::get_active_type_name_in_variant(input_c->storage()));
+        TT_ASSERT(is_device_tensor(*input_c), "Unexpected type {}", input_c->storage_type());
 
         const auto shard_volumes = get_shard_volumes(
             input_a.tensor_spec(), std::nullopt, input_c->tensor_spec(), compute_output_specs(args, tensor_args));

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/device/ternary_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/device/ternary_device_operation.cpp
@@ -418,13 +418,13 @@ tt::stl::hash::hash_t TernaryDeviceOperation::compute_program_hash(
     const auto& a_shape = input_a.padded_shape();
     TernaryVariant variant = args.ternary_variant;
 
-    TT_ASSERT(is_device_tensor(input_a), "Unexpected type {}", input_a.storage_type());
+    TT_FATAL(is_device_tensor(input_a), "Unexpected Tensor type {}", input_a.storage_type());
     tt::stl::hash::hash_t hash = tt::tt_metal::operation::hash_operation<TernaryDeviceOperation>(
         args, input_a.dtype(), input_a.memory_config(), a_shape.volume());
 
     if (variant == TernaryVariant::TTT) {
-        TT_ASSERT(is_device_tensor(*input_b), "Unexpected type {}", input_b->storage_type());
-        TT_ASSERT(is_device_tensor(*input_c), "Unexpected type {}", input_c->storage_type());
+        TT_FATAL(is_device_tensor(*input_b), "Unexpected Tensor type {}", input_b->storage_type());
+        TT_FATAL(is_device_tensor(*input_c), "Unexpected Tensor type {}", input_c->storage_type());
 
         const auto shard_volumes = get_shard_volumes(
             input_a.tensor_spec(),
@@ -444,7 +444,7 @@ tt::stl::hash::hash_t TernaryDeviceOperation::compute_program_hash(
             shard_volumes);
 
     } else if (variant == TernaryVariant::TTS) {
-        TT_ASSERT(is_device_tensor(*input_b), "Unexpected type {}", input_b->storage_type());
+        TT_FATAL(is_device_tensor(*input_b), "Unexpected Tensor type {}", input_b->storage_type());
 
         const auto shard_volumes = get_shard_volumes(
             input_a.tensor_spec(), input_b->tensor_spec(), std::nullopt, compute_output_specs(args, tensor_args));
@@ -458,7 +458,7 @@ tt::stl::hash::hash_t TernaryDeviceOperation::compute_program_hash(
             a_shape.volume(),
             shard_volumes);
     } else if (variant == TernaryVariant::TST) {
-        TT_ASSERT(is_device_tensor(*input_c), "Unexpected type {}", input_c->storage_type());
+        TT_FATAL(is_device_tensor(*input_c), "Unexpected Tensor type {}", input_c->storage_type());
 
         const auto shard_volumes = get_shard_volumes(
             input_a.tensor_spec(), std::nullopt, input_c->tensor_spec(), compute_output_specs(args, tensor_args));

--- a/ttnn/cpp/ttnn/operations/experimental/matmul/attn_matmul/device/attn_matmul_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/matmul/attn_matmul/device/attn_matmul_device_operation.cpp
@@ -6,6 +6,7 @@
 #include "attn_matmul_program_factory.hpp"
 #include "ttnn/operations/core/core.hpp"
 #include "ttnn/tensor/tensor_ops.hpp"
+#include "ttnn/tensor/tensor_utils.hpp"
 #include <tt-metalium/work_split.hpp>
 
 using namespace tt::tt_metal;
@@ -105,13 +106,9 @@ AttnMatmulDeviceOperation::tensor_return_value_t AttnMatmulDeviceOperation::crea
 tt::stl::hash::hash_t AttnMatmulDeviceOperation::compute_program_hash(
     const operation_attributes_t& args, const tensor_args_t& tensor_args) {
     TT_ASSERT(
-        std::holds_alternative<DeviceStorage>(tensor_args.input_tensor_a.storage()),
-        "Unexpected type {}",
-        tt::stl::get_active_type_name_in_variant(tensor_args.input_tensor_a.storage()));
+        is_device_tensor(tensor_args.input_tensor_a), "Unexpected type {}", tensor_args.input_tensor_a.storage_type());
     TT_ASSERT(
-        std::holds_alternative<DeviceStorage>(tensor_args.input_tensor_b.storage()),
-        "Unexpected type {}",
-        tt::stl::get_active_type_name_in_variant(tensor_args.input_tensor_b.storage()));
+        is_device_tensor(tensor_args.input_tensor_b), "Unexpected type {}", tensor_args.input_tensor_b.storage_type());
     return operation::hash_operation<AttnMatmulDeviceOperation>(
         args,
         args.transpose_hw,

--- a/ttnn/cpp/ttnn/operations/experimental/matmul/attn_matmul/device/attn_matmul_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/matmul/attn_matmul/device/attn_matmul_device_operation.cpp
@@ -105,10 +105,14 @@ AttnMatmulDeviceOperation::tensor_return_value_t AttnMatmulDeviceOperation::crea
 
 tt::stl::hash::hash_t AttnMatmulDeviceOperation::compute_program_hash(
     const operation_attributes_t& args, const tensor_args_t& tensor_args) {
-    TT_ASSERT(
-        is_device_tensor(tensor_args.input_tensor_a), "Unexpected type {}", tensor_args.input_tensor_a.storage_type());
-    TT_ASSERT(
-        is_device_tensor(tensor_args.input_tensor_b), "Unexpected type {}", tensor_args.input_tensor_b.storage_type());
+    TT_FATAL(
+        is_device_tensor(tensor_args.input_tensor_a),
+        "Unexpected Tensor type {}",
+        tensor_args.input_tensor_a.storage_type());
+    TT_FATAL(
+        is_device_tensor(tensor_args.input_tensor_b),
+        "Unexpected Tensor type {}",
+        tensor_args.input_tensor_b.storage_type());
     return operation::hash_operation<AttnMatmulDeviceOperation>(
         args,
         args.transpose_hw,

--- a/ttnn/cpp/ttnn/operations/experimental/matmul/group_attn_matmul/device/group_attn_matmul_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/matmul/group_attn_matmul/device/group_attn_matmul_device_operation.cpp
@@ -209,14 +209,8 @@ tt::stl::hash::hash_t GroupAttnMatmulDeviceOperation::compute_program_hash(
     const auto& input_tensor_a = tensor_args.input_tensor_a;
     const auto& input_tensor_b = tensor_args.input_tensor_b;
 
-    TT_ASSERT(
-        std::holds_alternative<DeviceStorage>(input_tensor_a.storage()),
-        "Unexpected type {}",
-        tt::stl::get_active_type_name_in_variant(input_tensor_a.storage()));
-    TT_ASSERT(
-        std::holds_alternative<DeviceStorage>(input_tensor_b.storage()),
-        "Unexpected type {}",
-        tt::stl::get_active_type_name_in_variant(input_tensor_b.storage()));
+    TT_ASSERT(is_device_tensor(input_tensor_a), "Unexpected type {}", input_tensor_a.storage_type());
+    TT_ASSERT(is_device_tensor(input_tensor_b), "Unexpected type {}", input_tensor_b.storage_type());
     return operation::hash_operation<GroupAttnMatmulDeviceOperation>(
         operation_attributes.transpose_hw,
         operation_attributes.out_subblock_w,

--- a/ttnn/cpp/ttnn/operations/experimental/matmul/group_attn_matmul/device/group_attn_matmul_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/matmul/group_attn_matmul/device/group_attn_matmul_device_operation.cpp
@@ -209,8 +209,8 @@ tt::stl::hash::hash_t GroupAttnMatmulDeviceOperation::compute_program_hash(
     const auto& input_tensor_a = tensor_args.input_tensor_a;
     const auto& input_tensor_b = tensor_args.input_tensor_b;
 
-    TT_ASSERT(is_device_tensor(input_tensor_a), "Unexpected type {}", input_tensor_a.storage_type());
-    TT_ASSERT(is_device_tensor(input_tensor_b), "Unexpected type {}", input_tensor_b.storage_type());
+    TT_FATAL(is_device_tensor(input_tensor_a), "Unexpected Tensor type {}", input_tensor_a.storage_type());
+    TT_FATAL(is_device_tensor(input_tensor_b), "Unexpected Tensor type {}", input_tensor_b.storage_type());
     return operation::hash_operation<GroupAttnMatmulDeviceOperation>(
         operation_attributes.transpose_hw,
         operation_attributes.out_subblock_w,

--- a/ttnn/cpp/ttnn/operations/experimental/where/device/where_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/where/device/where_device_operation.cpp
@@ -5,6 +5,7 @@
 
 #include "ttnn/operations/experimental/where/device/where_device_operation.hpp"
 #include "ttnn/tensor/tensor_ops.hpp"
+#include "ttnn/tensor/tensor_utils.hpp"
 
 #include "ttnn/operation_concepts.hpp"
 
@@ -89,17 +90,17 @@ WhereDeviceOperation::tensor_return_value_t WhereDeviceOperation::create_output_
 tt::stl::hash::hash_t WhereDeviceOperation::compute_program_hash(
     const operation_attributes_t& attributes, const tensor_args_t& args) {
     TT_FATAL(
-        std::holds_alternative<DeviceStorage>(args.condition_tensor.storage()),
+        is_device_tensor(args.condition_tensor),
         "Unexpected type {} for condition_tensor storage",
-        tt::stl::get_active_type_name_in_variant(args.condition_tensor.storage()));
+        args.condition_tensor.storage_type());
     TT_FATAL(
-        std::holds_alternative<DeviceStorage>(args.true_value_tensor.storage()),
+        is_device_tensor(args.true_value_tensor),
         "Unexpected type {} for true_value_tensor storage",
-        tt::stl::get_active_type_name_in_variant(args.true_value_tensor.storage()));
+        args.true_value_tensor.storage_type());
     TT_FATAL(
-        std::holds_alternative<DeviceStorage>(args.false_value_tensor.storage()),
+        is_device_tensor(args.false_value_tensor),
         "Unexpected type {} for false_value_tensor storage",
-        tt::stl::get_active_type_name_in_variant(args.false_value_tensor.storage()));
+        args.false_value_tensor.storage_type());
     return operation::hash_operation<WhereDeviceOperation>(
         attributes,
         args.condition_tensor.memory_config(),

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/batch_norm_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/batch_norm_device_operation.cpp
@@ -4,6 +4,7 @@
 
 #include "batch_norm_device_operation.hpp"
 #include "ttnn/tensor/tensor_ops.hpp"
+#include "ttnn/tensor/tensor_utils.hpp"
 
 #include "ttnn/device_operation.hpp"
 #include "ttnn/operations/moreh/moreh_helper_functions.hpp"
@@ -121,10 +122,7 @@ tt::stl::hash::hash_t BatchNormOperation::compute_program_hash(
     const operation_attributes_t& attributes, const tensor_args_t& tensor_args) {
     const auto& [input, batch_mean, batch_var, weight, bias, output] = tensor_args;
 
-    TT_FATAL(
-        std::holds_alternative<DeviceStorage>(input.storage()),
-        "Unexpected type {}",
-        tt::stl::get_active_type_name_in_variant(input.storage()));
+    TT_FATAL(is_device_tensor(input), "Unexpected type {}", input.storage_type());
 
     // For input tensor
     auto base_tuple = std::make_tuple(attributes, input.dtype(), input.memory_config());

--- a/ttnn/cpp/ttnn/operations/reduction/accumulation/accumulation_common.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/accumulation/accumulation_common.cpp
@@ -121,6 +121,9 @@ Tensor accumulation_invoke(
         op);
     wip_tensor = common::postprocess_output_tensor(wip_tensor, cum_axis, permutation, input_shape, input_rank);
     if (optional_out.has_value()) {
+        // TODO(#37807):
+        // This is a temporary fix, the op needs to be refactored to apply the output directly to optional_out,
+        // or pass in optional_out as a reference.
         optional_out->tensor_attributes->get_storage() = wip_tensor.tensor_attributes->get_storage();
     }
     return wip_tensor;

--- a/ttnn/cpp/ttnn/operations/reduction/accumulation/accumulation_common.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/accumulation/accumulation_common.cpp
@@ -121,7 +121,7 @@ Tensor accumulation_invoke(
         op);
     wip_tensor = common::postprocess_output_tensor(wip_tensor, cum_axis, permutation, input_shape, input_rank);
     if (optional_out.has_value()) {
-        optional_out->storage() = wip_tensor.storage();
+        optional_out = wip_tensor;
     }
     return wip_tensor;
 }

--- a/ttnn/cpp/ttnn/operations/reduction/accumulation/accumulation_common.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/accumulation/accumulation_common.cpp
@@ -121,7 +121,7 @@ Tensor accumulation_invoke(
         op);
     wip_tensor = common::postprocess_output_tensor(wip_tensor, cum_axis, permutation, input_shape, input_rank);
     if (optional_out.has_value()) {
-        optional_out = wip_tensor;
+        optional_out->tensor_attributes->get_storage() = wip_tensor.tensor_attributes->get_storage();
     }
     return wip_tensor;
 }


### PR DESCRIPTION
### Ticket
#37784

### Problem description
Metal is splitting TTNN Tensor into Host and Device Tensor and lowering it into runtime.
There are cleanup work needed to perform this splitting before refactoring can happen.

### Removal of `Storage` related public facing API.

`Storage` is a type alias to `variant<HostStorage, DeviceStorage>`, and is the backing storage of current Tensor.

With the new upcoming refactor, the backing storage will become `variant<HostTensor, DeviceTensor>`, and the current `Storage` type alias will be removed. It is found that all usages related to `Storage` can be redirected to use better alternatives. 

#### Make Const-ref getter private

Use cases and alternatives replaced at use site:
1. To check the variant the Tensor is in (`std::holds_alternative<DeviceStorage>(storage)`),
there already exist a more descriptive way to perform this check via helper functions `is_device_tensor`/ `is_cpu_tensor`.
2. Assert and obtain the concrete storage type. This can be accessed through their respect member functions (e.g. `device_storage()`)

This change removes a lot of ugly `std::visit` patterns and simplifies the codebase.

#### Remove Mutable reference getter: `Storage& storage();`

This used to assign the pointed region of one Tensor to another without updates to tensor spec or tensor topology.

This is a problematic API to start as the invariant of the underlying storage fitting the tensor spec cannot be enforced. This also opens door to silent promotion from host tensor to device tensor.

Use cases for this is replaced with directly assigning one tensor to another.
**This is a potential semantic change and need to be verified**, changed file:
- ttnn/cpp/ttnn/operations/data_movement/sort/sort.cpp
- ttnn/api/ttnn/mesh_device_operation_utils.hpp

Accumulation op currently cannot operate without having mutable access into tensor or an refactor on their side.
In this case, mutable storage is redirected to reach into the `tensor_attributes` member variable directly.
This is made to prioritize tensor lowering effort to not be blocked. Ticket has been created: #37807 , related file:
- ttnn/cpp/ttnn/operations/reduction/accumulation/accumulation_common.cpp

#### Replace Tensor constructor from `Storage` with concrete type:
`Tensor(Storage storage, TensorSpec tensor_spec, TensorTopology tensor_topology);`

This is replaced with two overloads:
- `Tensor(HostStorage storage, TensorSpec tensor_spec, TensorTopology tensor_topology);`
- `Tensor(DeviceStorage storage, TensorSpec tensor_spec, TensorTopology tensor_topology);` 

### Cleanup around `tensor_impl.hpp`

After refactoring, `tensor_impl.hpp` will be removed from the TTNN as the real implementation will be provided by tt_meatl API. This PR cleans up direct usage into the header.

#### Add missing variant of `copy_to_host` to `tensor_ops.hpp`

It was found that there is an overload of `copy_to_host` with following signature that is forwarded via `tensor_ops.hpp` despite being exposed via python binding.

```C++
void copy_to_host(
    const Tensor& device_tensor,
    Tensor& host_tensor,
    bool blocking = true,
    std::optional<QueueId> cq_id = std::nullopt);
```

There is an established pattern of Tensor API in `tensor_ops.hpp` calling `tensor_impl.hpp` for implementation, this function is thus forwarded to `tensor_ops.hpp` following typical wrapping convention.

#### Replace calls into `tensor_impl` with those in `tensor_ops` when approprite

This is often done by simply dropping the `tensor_impl` namespace, which allows the function to be resolved from `tensor_ops.hpp` instead of `tensor_impl.hpp`.

### Checklist

- [x] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=riverwu/runtime-tensor-ttnn-cleanup)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:riverwu/runtime-tensor-ttnn-cleanup)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=riverwu/runtime-tensor-ttnn-cleanup)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:riverwu/runtime-tensor-ttnn-cleanup)
- [x] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=riverwu/runtime-tensor-ttnn-cleanup)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:riverwu/runtime-tensor-ttnn-cleanup)
  - [x] TT-Train
  - [x] cpp-unit-tests
  - [x] ttnn-tutorials
  - [x] models-unit-tests
  - [x] data movement ops
  - [ ] eltwise ops (L2 being poopy, only diffs are in asserts).
  - [x] normalization ops
  - [x] reduction ops
  - [x] experimental ops
- [ ] New/Existing tests provide coverage for changes