### PR TITLE
Upgrade Pillow -> 12.1.1 to fix CVE-2026-25990

### DIFF
--- a/models/experimental/yunet/web_demo/client/requirements.txt
+++ b/models/experimental/yunet/web_demo/client/requirements.txt
@@ -4,4 +4,4 @@ opencv-python>=4.8.0
 numpy
 requests
 av>=10.0.0
-Pillow
+Pillow>=12.1.1

--- a/models/experimental/yunet/web_demo/server/requirements.txt
+++ b/models/experimental/yunet/web_demo/server/requirements.txt
@@ -3,4 +3,4 @@ uvicorn>=0.23.0
 python-multipart>=0.0.6
 numpy
 torch
-Pillow
+Pillow>=12.1.1

--- a/models/tt_dit/tests/dataset_eval/reference/requirements.txt
+++ b/models/tt_dit/tests/dataset_eval/reference/requirements.txt
@@ -13,4 +13,4 @@ git+https://github.com/huggingface/diffusers.git
 open_clip_torch
 
 # vision + utilities
-Pillow>=9.1.0
+Pillow>=12.1.1

--- a/tt_metal/python_env/requirements-dev.txt
+++ b/tt_metal/python_env/requirements-dev.txt
@@ -87,7 +87,7 @@ open_clip_torch==2.32.0 # Required for SDXL accuracy evaluation
 # Needed for various tests
 pyyaml>=5.4
 matplotlib
-Pillow==10.3.0
+Pillow==12.1.1
 jupyterlab==4.2.5
 ipywidgets==8.1.1
 bokeh==3.1.1


### PR DESCRIPTION
## Summary
- Upgrades Pillow from 10.3.0 to 12.1.1 to remediate **CVE-2026-25990** (High severity)
- CVE-2026-25990 ([GHSA-cfh3-3jmp-rvhc](https://github.com/advisories/GHSA-cfh3-3jmp-rvhc)) is an out-of-bounds write triggered when loading specially crafted PSD images, affecting Pillow >= 10.3.0, < 12.1.1
- Codebase usage of Pillow is limited to standard APIs (`Image.open`, `Image.new`, `ImageDraw`, `ImageFont`) which are stable across this version range — no breaking changes expected

## Test plan
- [ ] CI post-commit regression tests pass
- [ ] Verify models that use Pillow for image loading still function correctly (vision models, multimodal demos)
- [ ] Confirm no import or runtime errors from the Pillow upgrade

🤖 Generated with [Claude Code](https://claude.com/claude-code)