### PR TITLE
round up mem config shapes

### DIFF
--- a/models/demos/deepseek_v3/tt/rms_norm/distributed_rms_norm.py
+++ b/models/demos/deepseek_v3/tt/rms_norm/distributed_rms_norm.py
@@ -93,7 +93,7 @@ class DistributedRMSNorm(RMSNormBase):
         shard_core_grid = ttnn.CoreGrid(x=4, y=7)
         memory_config = ttnn.create_sharded_memory_config(
             shape=(
-                USERS_PER_ROW,
+                ttnn.core.roundup(USERS_PER_ROW, ttnn.TILE_SIZE),
                 ttnn.core.roundup(
                     even_int_div(hf_config.hidden_size, shard_core_grid.num_cores * mesh_device.shape[1]),
                     ttnn.TILE_SIZE,


### PR DESCRIPTION
### Ticket
None

### Problem description
Round up sharded memory config shapes in MLA decode and DistributedRMSNorm
to avoid non‑tile shard heights during resharding.

This allows non‑tile‑size `USERS_PER_ROW` values. We round tensor sharding up
to the tile size, while still saving memory in page tables/KV cache when
`USERS_PER_ROW` is smaller and not tile‑aligned.
