### PR TITLE
Add precompiled headers to tt-train for faster compilation

### DIFF
--- a/build_metal.sh
+++ b/build_metal.sh
@@ -422,5 +422,12 @@ fi
 # Build libraries and cpp tests
 if [ "$configure_only" = "OFF" ]; then
     echo "INFO: Building Project"
-    cmake --build $build_dir --target $target
+    # Limit parallelism to 32 cores for reliable/reproducible build timing
+    build_start=$(date +%s)
+    cmake --build $build_dir --target $target --parallel 32
+    build_end=$(date +%s)
+    build_elapsed=$((build_end - build_start))
+    build_min=$((build_elapsed / 60))
+    build_sec=$((build_elapsed % 60))
+    echo "INFO: Build step completed in ${build_min}m ${build_sec}s (${build_elapsed}s total)"
 fi

--- a/build_metal.sh
+++ b/build_metal.sh
@@ -422,12 +422,5 @@ fi
 # Build libraries and cpp tests
 if [ "$configure_only" = "OFF" ]; then
     echo "INFO: Building Project"
-    # Limit parallelism to 32 cores for reliable/reproducible build timing
-    build_start=$(date +%s)
-    cmake --build $build_dir --target $target --parallel 32
-    build_end=$(date +%s)
-    build_elapsed=$((build_end - build_start))
-    build_min=$((build_elapsed / 60))
-    build_sec=$((build_elapsed % 60))
-    echo "INFO: Build step completed in ${build_min}m ${build_sec}s (${build_elapsed}s total)"
+    cmake --build $build_dir --target $target
 fi

--- a/tt-train/sources/ttml/CMakeLists.txt
+++ b/tt-train/sources/ttml/CMakeLists.txt
@@ -349,6 +349,40 @@ message(STATUS "xtensor-blas_SOURCE_DIR: ${xtensor-blas_SOURCE_DIR}")
 message(STATUS "cli11_SOURCE_DIR: ${CLI11_SOURCE_DIR}")
 target_include_directories(ttml PUBLIC ${CLI11_SOURCE_DIR}/include)
 
+##################################################
+# Precompiled headers for ttml
+# The ttml library includes massive TTNN/Metalium headers across 100+ source files.
+# Precompiling them once dramatically reduces compile time.
+##################################################
+
+target_precompile_headers(
+    ttml
+    PRIVATE
+        # Standard library headers (widely used across tt-train)
+        <algorithm>
+        <cmath>
+        <cstdint>
+        <cstring>
+        <functional>
+        <memory>
+        <optional>
+        <span>
+        <stdexcept>
+        <string>
+        <tuple>
+        <unordered_map>
+        <variant>
+        <vector>
+        # Third-party headers
+        <fmt/core.h>
+        <fmt/format.h>
+        <nlohmann/json.hpp>
+        <enchantum/enchantum.hpp>
+        # Heavy TTNN/Metalium umbrella headers used across tt-train sources
+        "core/ttnn_all_includes.hpp"
+        "metal/ttnn_all_includes.hpp"
+)
+
 if(ENABLE_LIBCXX)
     target_link_libraries(
         PUBLIC

--- a/tt-train/tests/CMakeLists.txt
+++ b/tt-train/tests/CMakeLists.txt
@@ -70,6 +70,10 @@ target_link_libraries(
     GTest::gmock_main
     ttml
 )
+
+# Reuse the ttml precompiled header for test compilation
+target_precompile_headers(ttml_tests REUSE_FROM ttml)
+
 add_definitions(-DTEST_DATA_DIR="${CMAKE_SOURCE_DIR}/data")
 
 # Define the target file location

--- a/tt-train/tests/CMakeLists.txt
+++ b/tt-train/tests/CMakeLists.txt
@@ -71,7 +71,16 @@ target_link_libraries(
     ttml
 )
 
-# Reuse the ttml precompiled header for test compilation
+# Reuse the ttml precompiled header for test compilation.
+# Force -fPIC to match ttml's compile flags (executables default to -fPIE,
+# which is incompatible with library PCH in Clang).
+set_target_properties(
+    ttml_tests
+    PROPERTIES
+        POSITION_INDEPENDENT_CODE
+            TRUE
+)
+target_compile_options(ttml_tests PRIVATE -fPIC)
 target_precompile_headers(ttml_tests REUSE_FROM ttml)
 
 add_definitions(-DTEST_DATA_DIR="${CMAKE_SOURCE_DIR}/data")


### PR DESCRIPTION
### Ticket
N/A - Build infrastructure improvement

### Problem description
The tt-train library (`ttml`) includes massive TTNN/Metalium headers across 100+ source files. Two umbrella headers — `core/ttnn_all_includes.hpp` (87 TTNN operation includes) and `metal/ttnn_all_includes.hpp` (key device operation includes) — are parsed from scratch for every translation unit, dominating compile time.

### What's changed

**1. Precompiled headers for `ttml` library** (`tt-train/sources/ttml/CMakeLists.txt`)
- Added `target_precompile_headers(ttml PRIVATE ...)` with:
  - Standard library headers (`<vector>`, `<memory>`, `<optional>`, etc.)
  - Third-party headers (`fmt`, `nlohmann_json`, `enchantum`)
  - The two heavy TTNN umbrella headers (`core/ttnn_all_includes.hpp`, `metal/ttnn_all_includes.hpp`)
- PCH is `PRIVATE` — does not leak to consumers

**2. PCH reuse for tests** (`tt-train/tests/CMakeLists.txt`)
- `target_precompile_headers(ttml_tests REUSE_FROM ttml)` — reuses the same `.pch` file with zero additional compile cost
- `REUSE_FROM` is only used within tt-train (not across the ttnn/tt-train boundary)

**Benchmark results** (ttml library rebuild):

| Test | Without PCH | With PCH | Speedup |
|------|------------|----------|---------|
| Single file (binary_ops.cpp) | 15.9s | 4.8s | **3.3x** |
| Single file (metal ops) | 16.1s | 7.3s | **2.2x** |
| Library rebuild (-j4) wall clock | 8m 42s | 3m 36s | **2.4x** |
| Library rebuild (-j4) CPU time | 32m 43s | 12m 53s | **2.5x** |
| Library rebuild (-j32) wall clock | 78s | 48s | **1.6x** |
| Full --build-all (-j32) | 464s | 443s | ~21s saved |

The PCH is 119MB and includes ~170 transitively included headers. All three tt-train build flows (tt-metal master project, standalone, installed packages) are supported since the PCH is defined on `ttml` directly — no cross-project dependencies.

### Checklist

- [x] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=blozano/tt-train-pch)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:blozano/tt-train-pch)
- [x] New/Existing tests provide coverage for changes