### PR TITLE
Decouple Cluster initialization from HAL

### DIFF
--- a/tt_metal/impl/context/metal_context.cpp
+++ b/tt_metal/impl/context/metal_context.cpp
@@ -16,6 +16,7 @@
 #include "metal_context.hpp"
 #include "core_coord.hpp"
 #include "dispatch/dispatch_settings.hpp"
+#include "firmware_capability.hpp"
 #include "hal.hpp"
 #include "hal_types.hpp"
 #include "fabric/fabric_host_utils.hpp"
@@ -514,27 +515,26 @@ void MetalContext::initialize_base_objects() {
         Cluster::is_base_routing_fw_enabled(Cluster::get_cluster_type_from_cluster_desc(rtoptions_));
     const auto platform_arch = get_platform_architecture(rtoptions_);
 
-    const auto initialize_objects = [&]() {
-        hal_ = std::make_unique<Hal>(
-            platform_arch,
-            is_base_routing_fw_enabled,
-            rtoptions_.get_enable_2_erisc_mode(),
-            get_profiler_dram_bank_size_for_hal_allocation(rtoptions_));
-        rtoptions_.ParseAllFeatureEnv(*hal_);
-        cluster_ = std::make_unique<Cluster>(rtoptions_, *hal_);
-        distributed_context_ = distributed::multihost::DistributedContext::get_current_world();
-    };
+    cluster_ = std::make_unique<Cluster>(rtoptions_);
 
-    initialize_objects();
+    FirmwareCapabilityRequest req;
+    req.enable_2_erisc_mode = rtoptions_.get_enable_2_erisc_mode();
 
-    // Requires reinit with features disabled
-    // This will maintain backward compatibility with clusters that have legacy firmware but it will cause a slowdown
-    // during the first init
-    if (!cluster_->verify_eth_fw_capability()) {
-        rtoptions_.set_enable_2_erisc_mode(false);
-        teardown_base_objects();
-        initialize_objects();
+    FirmwareCapabilityResult res;
+
+    if (!check_firmware_capabilities(platform_arch, {.eth_fw = cluster_->get_ethernet_firmware_version()}, req, res)) {
+        rtoptions_.set_enable_2_erisc_mode(res.enable_2_erisc_mode);
     }
+
+    distributed_context_ = distributed::multihost::DistributedContext::get_current_world();
+    hal_ = std::make_unique<Hal>(
+        platform_arch,
+        is_base_routing_fw_enabled,
+        rtoptions_.get_enable_2_erisc_mode(),
+        get_profiler_dram_bank_size_for_hal_allocation(rtoptions_));
+
+    rtoptions_.ParseAllFeatureEnv(*hal_);
+    cluster_->set_hal(hal_.get());
 }
 
 MetalContext::MetalContext() {

--- a/tt_metal/llrt/CMakeLists.txt
+++ b/tt_metal/llrt/CMakeLists.txt
@@ -3,6 +3,7 @@
 set(LLRT_SRC
     llrt.cpp
     core_descriptor.cpp
+    firmware_capability.cpp
     rtoptions.cpp
     tlb_config.cpp
     tt_cluster.cpp

--- a/tt_metal/llrt/firmware_capability.cpp
+++ b/tt_metal/llrt/firmware_capability.cpp
@@ -21,8 +21,9 @@ void compare_requested_and_actual_capabilities(
     switch (arch) {
         case tt::ARCH::BLACKHOLE: {
             constexpr tt::umd::semver_t k_min_2_erisc_version(1, 7, 0);
-            // Disable if eth firmware is not known to be safe
-            const bool eth_fw_ok = fw_versions.eth_fw && (fw_versions.eth_fw.value() >= k_min_2_erisc_version);
+            // If ethernet firmware cannot be queried assume it's ok
+            // This occurs on the simulator
+            const bool eth_fw_ok = !fw_versions.eth_fw || (fw_versions.eth_fw.value() >= k_min_2_erisc_version);
             if (requested.enable_2_erisc_mode && !eth_fw_ok) {
                 log_warning(
                     tt::LogLLRuntime,

--- a/tt_metal/llrt/firmware_capability.cpp
+++ b/tt_metal/llrt/firmware_capability.cpp
@@ -5,6 +5,7 @@
 #include "firmware_capability.hpp"
 
 #include <tt-logger/tt-logger.hpp>
+#include "tt_stl/assert.hpp"
 
 namespace tt::tt_metal {
 
@@ -34,9 +35,9 @@ void compare_requested_and_actual_capabilities(
             break;
         }
         case tt::ARCH::WORMHOLE_B0:
-        case tt::ARCH::QUASAR:
+        case tt::ARCH::QUASAR: break;
         case tt::ARCH::Invalid:
-        default: break;
+        default: TT_THROW("Unsupported arch {} for firmware capability check", arch);
     }
 }
 

--- a/tt_metal/llrt/firmware_capability.cpp
+++ b/tt_metal/llrt/firmware_capability.cpp
@@ -1,0 +1,54 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "firmware_capability.hpp"
+
+#include <tt-logger/tt-logger.hpp>
+
+namespace tt::tt_metal {
+
+namespace {
+
+void compare_requested_and_actual_capabilities(
+    tt::ARCH arch,
+    const FirmwareVersions& fw_versions,
+    const FirmwareCapabilityRequest& requested,
+    FirmwareCapabilityResult& resolved) {
+    resolved = {requested.enable_2_erisc_mode};
+
+    switch (arch) {
+        case tt::ARCH::BLACKHOLE: {
+            constexpr tt::umd::semver_t k_min_2_erisc_version(1, 7, 0);
+            // Disable if eth firmware is not known to be safe
+            const bool eth_fw_ok = fw_versions.eth_fw && (fw_versions.eth_fw.value() >= k_min_2_erisc_version);
+            if (requested.enable_2_erisc_mode && !eth_fw_ok) {
+                log_warning(
+                    tt::LogLLRuntime,
+                    "Blackhole multi erisc mode requires ethernet firmware version {} or higher, but detected version "
+                    "{}. Automatically falling back to single erisc mode for compatibility.",
+                    k_min_2_erisc_version.to_string(),
+                    fw_versions.eth_fw ? fw_versions.eth_fw->to_string() : "unknown");
+                resolved.enable_2_erisc_mode = false;
+            }
+            break;
+        }
+        case tt::ARCH::WORMHOLE_B0:
+        case tt::ARCH::QUASAR:
+        case tt::ARCH::Invalid:
+        default: break;
+    }
+}
+
+}  // namespace
+
+bool check_firmware_capabilities(
+    tt::ARCH arch,
+    const FirmwareVersions& fw_versions,
+    const FirmwareCapabilityRequest& requested,
+    FirmwareCapabilityResult& resolved_out) {
+    compare_requested_and_actual_capabilities(arch, fw_versions, requested, resolved_out);
+    return resolved_out.enable_2_erisc_mode == requested.enable_2_erisc_mode;
+}
+
+}  // namespace tt::tt_metal

--- a/tt_metal/llrt/firmware_capability.hpp
+++ b/tt_metal/llrt/firmware_capability.hpp
@@ -1,0 +1,41 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <optional>
+
+#include <umd/device/types/arch.hpp>
+#include <umd/device/utils/semver.hpp>
+
+namespace tt::tt_metal {
+
+struct FirmwareVersions {
+    std::optional<tt::umd::semver_t> eth_fw;
+};
+
+struct FirmwareCapabilityRequest {
+    bool enable_2_erisc_mode = false;
+};
+
+struct FirmwareCapabilityResult {
+    bool enable_2_erisc_mode = false;
+};
+
+/**
+ * Check if the firmware versions are compatible with the requested capabilities.
+ *
+ * @param arch Platform architecture (from cluster/rtoptions, not HAL).
+ * @param fw_versions Available firmware versions (e.g. from cluster driver).
+ * @param requested Requested feature flags and integer parameters.
+ * @param resolved_out Output: supported capabilities which may be less than what was requested
+ * @return true if resolved equals requested; false if any reduction was applied.
+ */
+bool check_firmware_capabilities(
+    tt::ARCH arch,
+    const FirmwareVersions& fw_versions,
+    const FirmwareCapabilityRequest& requested,
+    FirmwareCapabilityResult& resolved_out);
+
+}  // namespace tt::tt_metal

--- a/tt_metal/llrt/hal.hpp
+++ b/tt_metal/llrt/hal.hpp
@@ -357,7 +357,6 @@ private:
     DispatchFeatureQueryFunc device_features_func_;
     std::unique_ptr<HalJitBuildQueryInterface> jit_build_query_;
     SetIRAMTextSizeFunc set_iram_text_size_func_;
-    VerifyFwVersionFunc verify_eth_fw_version_func_;
 
 public:
     Hal(tt::ARCH arch,
@@ -548,12 +547,6 @@ public:
     // Inclusive upper bound
     uint64_t get_pcie_addr_upper_bound() const;
     bool get_supports_64_bit_pcie_addressing() const { return supports_64_bit_pcie_addressing_; }
-
-    // Verify that the eth version is compatible with the HAL capabilities. Throws an exception if version is
-    // not compatible.
-    bool verify_eth_fw_version(tt::umd::semver_t eth_fw_version) const {
-        return this->verify_eth_fw_version_func_(eth_fw_version);
-    }
 
     size_t get_max_pinned_memory_count() const { return max_pinned_memory_count_; }
     size_t get_total_pinned_memory_size() const { return total_pinned_memory_size_; }

--- a/tt_metal/llrt/hal/tt-1xx/blackhole/bh_hal.cpp
+++ b/tt_metal/llrt/hal/tt-1xx/blackhole/bh_hal.cpp
@@ -421,22 +421,6 @@ void Hal::initialize_bh(bool enable_2_erisc_mode, std::uint32_t profiler_dram_ba
 
     this->jit_build_query_ = std::make_unique<HalJitBuildQueryBlackHole>(enable_2_erisc_mode);
 
-    this->verify_eth_fw_version_func_ = [=](tt::umd::semver_t fw_version) {
-        if (enable_2_erisc_mode) {
-            tt::umd::semver_t min_version(1, 7, 0);
-            if (!(fw_version >= min_version)) {
-                log_warning(
-                    tt::LogLLRuntime,
-                    "Blackhole multi erisc mode requires ethernet firmware version {} or higher, but detected version "
-                    "{}. Automatically falling back to single erisc mode for compatibility.",
-                    min_version.to_string(),
-                    fw_version.to_string());
-                return false;
-            }
-        }
-        return true;
-    };
-
     this->max_pinned_memory_count_ = std::numeric_limits<size_t>::max();
     this->total_pinned_memory_size_ = std::numeric_limits<size_t>::max();
 }

--- a/tt_metal/llrt/hal/tt-1xx/wormhole/wh_hal.cpp
+++ b/tt_metal/llrt/hal/tt-1xx/wormhole/wh_hal.cpp
@@ -380,11 +380,6 @@ void Hal::initialize_wh(bool is_base_routing_fw_enabled, std::uint32_t profiler_
         }
     };
 
-    this->verify_eth_fw_version_func_ = [](tt::umd::semver_t /*eth_fw_version*/) {
-        // No checks
-        return true;
-    };
-
     this->max_pinned_memory_count_ = 12;
     this->total_pinned_memory_size_ =
         4ULL * 1024ULL * 1024ULL * 1024ULL - static_cast<uint64_t>(tt::tt_metal::DispatchSettings::MAX_HUGEPAGE_SIZE);

--- a/tt_metal/llrt/hal/tt-2xx/quasar/qa_hal.cpp
+++ b/tt_metal/llrt/hal/tt-2xx/quasar/qa_hal.cpp
@@ -368,11 +368,6 @@ void Hal::initialize_qa(std::uint32_t profiler_dram_bank_size_per_risc_bytes) {
     this->noc_y_id_translate_table_ = {};
 
     this->jit_build_query_ = std::make_unique<HalJitBuildQueryQuasar>();
-
-    this->verify_eth_fw_version_func_ = [](tt::umd::semver_t /*eth_fw_version*/) {
-        // No checks
-        return true;
-    };
 }
 
 }  // namespace tt::tt_metal

--- a/tt_metal/llrt/tt_cluster.cpp
+++ b/tt_metal/llrt/tt_cluster.cpp
@@ -217,14 +217,11 @@ bool Cluster::is_iommu_enabled() const { return this->iommu_enabled_; }
 
 bool Cluster::is_noc_mapping_enabled() const { return this->noc_mapping_enabled_; }
 
-Cluster::Cluster(llrt::RunTimeOptions& rtoptions, const tt_metal::Hal& hal) : rtoptions_(rtoptions), hal_(hal) {
+Cluster::Cluster(llrt::RunTimeOptions& rtoptions) : rtoptions_(rtoptions) {
     ZoneScoped;
     log_info(tt::LogDevice, "Opening user mode device driver");
 
     this->detect_arch_and_target();
-
-    routing_info_addr_ = hal_.get_dev_addr(
-        tt::tt_metal::HalProgrammableCoreType::ACTIVE_ETH, tt::tt_metal::HalL1MemAddrType::APP_ROUTING_INFO);
 
     this->initialize_device_drivers();
 
@@ -424,16 +421,25 @@ void Cluster::open_driver(const bool& /*skip_driver_allocs*/) {
         });
     }
 
+    this->driver_ = std::move(device_driver);
+}
+
+void Cluster::set_hal(const tt_metal::Hal* hal) {
+    this->hal_ = hal;
+    this->routing_info_addr_ = hal->get_dev_addr(
+        tt::tt_metal::HalProgrammableCoreType::ACTIVE_ETH, tt::tt_metal::HalL1MemAddrType::APP_ROUTING_INFO);
+    this->num_nocs_ = hal->get_num_nocs();
+    this->retrain_count_addr_ = hal->get_dev_addr(
+        tt::tt_metal::HalProgrammableCoreType::ACTIVE_ETH, tt::tt_metal::HalL1MemAddrType::RETRAIN_COUNT);
+
     umd::BarrierAddressParams barrier_params;
     barrier_params.tensix_l1_barrier_base =
-        hal_.get_dev_addr(tt_metal::HalProgrammableCoreType::TENSIX, tt_metal::HalL1MemAddrType::BARRIER);
-    barrier_params.dram_barrier_base = hal_.get_dev_addr(tt_metal::HalDramMemAddrType::BARRIER);
+        hal->get_dev_addr(tt_metal::HalProgrammableCoreType::TENSIX, tt_metal::HalL1MemAddrType::BARRIER);
+    barrier_params.dram_barrier_base = hal->get_dev_addr(tt_metal::HalDramMemAddrType::BARRIER);
 
     barrier_params.eth_l1_barrier_base =
-        hal_.get_dev_addr(tt_metal::HalProgrammableCoreType::ACTIVE_ETH, tt_metal::HalL1MemAddrType::BARRIER);
-    device_driver->set_barrier_address_params(barrier_params);
-
-    this->driver_ = std::move(device_driver);
+        hal->get_dev_addr(tt_metal::HalProgrammableCoreType::ACTIVE_ETH, tt_metal::HalL1MemAddrType::BARRIER);
+    this->driver_->set_barrier_address_params(barrier_params);
 }
 
 void Cluster::start_driver(umd::DeviceParams& device_params) const {
@@ -553,7 +559,7 @@ void Cluster::generate_virtual_to_umd_coord_mapping() {
                 this->virtual_pcie_cores_[chip_id].insert({core.x, core.y});
             }
 
-            for (uint32_t noc = 0; noc < hal_.get_num_nocs(); noc++) {
+            for (uint32_t noc = 0; noc < this->num_nocs_; noc++) {
                 for (auto dram_channel = 0; dram_channel < this->get_soc_desc(chip_id).get_num_dram_views();
                      dram_channel++) {
                     auto worker_dram_ep =
@@ -957,16 +963,8 @@ void Cluster::verify_sw_fw_versions(
     }
 }
 
-bool Cluster::verify_eth_fw_capability() const {
-    // get_ethernet_fw_version is not supported in the simulation environment. assume it's correct!
-    if (rtoptions_.get_simulator_enabled()) {
-        return true;
-    }
-    const auto fw_version = this->driver_->get_ethernet_firmware_version();
-    if (fw_version) {
-        return hal_.verify_eth_fw_version(fw_version.value());
-    }
-    return true;
+std::optional<tt::umd::semver_t> Cluster::get_ethernet_firmware_version() const {
+    return this->driver_->get_ethernet_firmware_version();
 }
 
 // DRAM barrier is used to implement host-to-device synchronization and should be used when all previous writes to DRAM
@@ -1086,10 +1084,7 @@ void Cluster::disable_ethernet_cores_with_retrain() {
                     this->cluster_desc_->get_board_type(chip_id) == BoardType::UBB) {
                     tt_cxy_pair virtual_eth_core(
                         chip_id, get_virtual_coordinate_from_logical_coordinates(chip_id, eth_core, CoreType::ETH));
-                    auto retrain_count_addr = hal_.get_dev_addr(
-                        tt::tt_metal::HalProgrammableCoreType::ACTIVE_ETH,
-                        tt::tt_metal::HalL1MemAddrType::RETRAIN_COUNT);
-                    this->read_core(read_vec, sizeof(uint32_t), virtual_eth_core, retrain_count_addr);
+                    this->read_core(read_vec, sizeof(uint32_t), virtual_eth_core, retrain_count_addr_);
                     if (read_vec[0] != 0) {
                         log_warning(
                             LogDevice,
@@ -1366,7 +1361,7 @@ void Cluster::set_internal_routing_info_for_ethernet_cores(
         non_mmio_devices.emplace_back(chip_id);
     }
 
-    auto dev_msgs_factory = hal_.get_dev_msgs_factory(tt_metal::HalProgrammableCoreType::ACTIVE_ETH);
+    auto dev_msgs_factory = this->hal_->get_dev_msgs_factory(tt_metal::HalProgrammableCoreType::ACTIVE_ETH);
     if (enable_internal_routing) {
         auto routing_info_enabled = dev_msgs_factory.create<tt_metal::dev_msgs::routing_info_t>();
         routing_info_enabled.view().routing_enabled() = 1;
@@ -1460,7 +1455,7 @@ bool Cluster::is_external_cable(ChipId physical_chip_id, CoreCoord eth_core) con
 
 uint32_t Cluster::get_alignment_requirements(ChipId chip_id, uint32_t size_in_bytes) const {
     if (this->supports_dma_operations(chip_id, size_in_bytes)) {
-        return this->hal_.get_dma_alignment();
+        return this->hal_->get_dma_alignment();
     }
     return 1;
 }

--- a/tt_metal/llrt/tt_cluster.cpp
+++ b/tt_metal/llrt/tt_cluster.cpp
@@ -972,6 +972,7 @@ std::optional<tt::umd::semver_t> Cluster::get_ethernet_firmware_version() const 
 // (default ordering is posted) This barrier is intended to prevent races caused by out of order writes, specifically to
 // ensure metadata and data to compute on are committed before launching kernels
 void Cluster::dram_barrier(ChipId chip_id) const {
+    TT_ASSERT(this->hal_ != nullptr, "Hal is not set. Need to call set_hal() first.");
     std::unordered_set<uint32_t> dram_channels;
     for (uint32_t channel = 0; channel < this->get_soc_desc(chip_id).get_num_dram_channels(); channel++) {
         dram_channels.insert(channel);
@@ -984,6 +985,7 @@ void Cluster::dram_barrier(ChipId chip_id) const {
 // ordering is posted) This barrier is intended to prevent races caused by out of order writes, specifically to ensure
 // binaries, metadata, and data to compute on are committed before launching kernels
 void Cluster::l1_barrier(ChipId chip_id) const {
+    TT_ASSERT(this->hal_ != nullptr, "Hal is not set. Need to call set_hal() first.");
     // Sets and resets L1 barrier of all tensix cores and ethernet cores
     this->driver_->l1_membar(chip_id);
 }

--- a/tt_metal/llrt/tt_cluster.hpp
+++ b/tt_metal/llrt/tt_cluster.hpp
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include "hal/generated/dev_msgs.hpp"
 #include "hostdevcommon/fabric_common.h"
 #include <tt-metalium/experimental/fabric/fabric_types.hpp>
 #include "llrt/metal_soc_descriptor.hpp"
@@ -69,7 +70,7 @@ public:
     Cluster(const Cluster&) = delete;
     Cluster(Cluster&& other) noexcept = delete;
 
-    Cluster(llrt::RunTimeOptions& rtoptions, const tt_metal::Hal& hal);
+    Cluster(llrt::RunTimeOptions& rtoptions);
     ~Cluster();
 
     // For TG Galaxy systems, mmio chips are gateway chips that are only used for dispatch, so user_devices are meant
@@ -97,6 +98,9 @@ public:
         TT_FATAL(driver_ != nullptr, "UMD driver is not initialized.");
         return driver_;
     }
+
+    // Sets the HAL to be used for this Cluster
+    void set_hal(const tt_metal::Hal* hal);
 
     // TODO: UMD will eventually consolidate ethernet coordinates and unique ids, we can remove the ethernet coord
     // getter after that change is in
@@ -136,7 +140,7 @@ public:
 
     //! device driver and misc apis
     void verify_sw_fw_versions(int device_id, std::uint32_t sw_version, std::vector<std::uint32_t>& fw_versions) const;
-    bool verify_eth_fw_capability() const;
+    std::optional<tt::umd::semver_t> get_ethernet_firmware_version() const;
 
     void deassert_risc_reset_at_core(
         const tt_cxy_pair& core, const tt::umd::RiscType& soft_resets, bool staggered_start = true) const;
@@ -461,11 +465,13 @@ private:
     std::unordered_map<ChipId, std::unordered_map<ChipId, std::vector<CoreCoord>>> ethernet_sockets_;
 
     uint32_t routing_info_addr_ = 0;
+    uint32_t retrain_count_addr_ = 0;
+    uint8_t num_nocs_ = 0;
 
     // Cluster depends on RunTimeOptions and Hal to set up, but they're all initialized/accessed by MetalContext, so
     // keep a local reference for init.
     const llrt::RunTimeOptions& rtoptions_;
-    const tt_metal::Hal& hal_;
+    const tt_metal::Hal* hal_;
 };
 
 }  // namespace tt

--- a/tt_metal/llrt/tt_cluster.hpp
+++ b/tt_metal/llrt/tt_cluster.hpp
@@ -4,7 +4,6 @@
 
 #pragma once
 
-#include "hal/generated/dev_msgs.hpp"
 #include "hostdevcommon/fabric_common.h"
 #include <tt-metalium/experimental/fabric/fabric_types.hpp>
 #include "llrt/metal_soc_descriptor.hpp"
@@ -471,7 +470,7 @@ private:
     // Cluster depends on RunTimeOptions and Hal to set up, but they're all initialized/accessed by MetalContext, so
     // keep a local reference for init.
     const llrt::RunTimeOptions& rtoptions_;
-    const tt_metal::Hal* hal_;
+    const tt_metal::Hal* hal_ = nullptr;
 };
 
 }  // namespace tt


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/37247
https://github.com/tenstorrent/tt-metal/issues/21245

### Problem description
- There's a circular dependency between the Cluster and the HAL. We need the HAL to initialize Cluster but we need the Cluster to query the firmware version for the HAL.
- In MetalContext init we could reinit due to downgrade the enabled features due to the firmware mismatch

### What's changed
- Remove the HAL from the `tt::Cluster` constructor. This way we can create the cluster and query the firmware version without the HAL. Once the firmware version and arch is known, we can create a HAL according to that information and attach it to the Cluster using `set_hal`
- Split the verify_eth_fw_version function out of the HAL into their own functions to compare fw version
- Remove the Cluster reinit code from the MetalContext constructor

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=nhuang/decouple-cluster)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:nhuang/decouple-cluster)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=nhuang/decouple-cluster)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:nhuang/decouple-cluster)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nhuang/decouple-cluster)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nhuang/decouple-cluster)
- [ ] New/Existing tests provide coverage for changes

Multihost
https://github.com/tenstorrent/tt-metal/actions/runs/21928700515

Profiler CI
https://github.com/tenstorrent/tt-metal/actions/runs/21960177665

#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:{{branch_name}})
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:{{branch_name}})
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:{{branch_name}})
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
