### PR TITLE
[WATCHER]: Fix reader runtime args for idle cores in SDPA decode

### DIFF
--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/sdpa_decode_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/sdpa_decode_program_factory.cpp
@@ -1010,8 +1010,9 @@ SdpaDecodeProgramFactory::cached_program_t SdpaDecodeProgramFactory::create(
         // Set the rest of the cores to idle
         for (auto core : core_group_idle) {
             log_debug(tt::LogOp, "Setting core {} to idle", core);
+
             // reader runtime args
-            std::vector<uint32_t> reader_rt_args = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+            std::vector<uint32_t> reader_rt_args = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
 
             // writer runtime args
             std::vector<uint32_t> writer_rt_args = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0};


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/37631

### Problem description
SDPA decode runs into runtime args out of bounds error in the reader for the IDLE cores when watcher is enabled

### What's changed
Update the reader to extend the runtime arg count properly to 15 instead of 14

### Checklist
- [L2 Nightly tests](https://github.com/tenstorrent/tt-metal/actions/runs/21967029711)
- [APC](https://github.com/tenstorrent/tt-metal/actions/runs/21966955163)