### PR TITLE
Prompt correct type information for `create_device_tensor`

### DIFF
--- a/tests/ttnn/unit_tests/gtests/test_graph_basic.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_graph_basic.cpp
@@ -58,7 +58,7 @@ TEST_P(BufferTestFixture, BufferTest) {
     auto params = std::get<0>(param_combination);
     auto run_mode = std::get<1>(param_combination);
 
-    tt::tt_metal::IDevice* device = device_;
+    tt::tt_metal::distributed::MeshDevice* device = device_;
     {
         ttnn::graph::GraphProcessor::begin_graph_capture(run_mode);
         {
@@ -155,7 +155,7 @@ INSTANTIATE_TEST_SUITE_P(
 
 class TestScopedGraphCapture : public ttnn::TTNNFixtureWithDevice {};
 TEST_F(TestScopedGraphCapture, ScopedGraphCapture) {
-    tt::tt_metal::IDevice* device = device_;
+    tt::tt_metal::distributed::MeshDevice* device = device_;
 
     auto operation = [&device](tt::tt_metal::DataType datatype) {
         const auto input_a = ttnn::TensorSpec(
@@ -235,7 +235,7 @@ TEST_F(TestScopedGraphCapture, ScopedGraphCapture) {
 }
 
 TEST_F(TestScopedGraphCapture, OrderOfArgsTest) {
-    tt::tt_metal::IDevice* device = device_;
+    tt::tt_metal::distributed::MeshDevice* device = device_;
 
     const auto tensor_spec = ttnn::TensorSpec(
         ttnn::Shape(tt::tt_metal::Array2D{32, 64}),
@@ -310,7 +310,7 @@ TEST_F(TestScopedGraphCapture, OrderOfArgsTest) {
 }
 
 TEST_F(TestScopedGraphCapture, SameTensorMultipleTimesTest) {
-    tt::tt_metal::IDevice* device = device_;
+    tt::tt_metal::distributed::MeshDevice* device = device_;
 
     const auto tensor_spec = ttnn::TensorSpec(
         ttnn::Shape(tt::tt_metal::Array2D{32, 64}),
@@ -359,7 +359,7 @@ TEST_F(TestScopedGraphCapture, TernaryOpDifferentOrderTest) {
     GTEST_SKIP()
         << "High-level function tracing was removed - argument order testing at function level is no longer available";
 
-    tt::tt_metal::IDevice* device = device_;
+    tt::tt_metal::distributed::MeshDevice* device = device_;
 
     const auto tensor_spec = ttnn::TensorSpec(
         ttnn::Shape(tt::tt_metal::Array2D{32, 64}),
@@ -434,7 +434,7 @@ TEST_F(TestScopedGraphCapture, TernaryOpRepeatedTensorsTest) {
     GTEST_SKIP()
         << "High-level function tracing was removed - argument order testing at function level is no longer available";
 
-    tt::tt_metal::IDevice* device = device_;
+    tt::tt_metal::distributed::MeshDevice* device = device_;
 
     const auto tensor_spec = ttnn::TensorSpec(
         ttnn::Shape(tt::tt_metal::Array2D{32, 64}),
@@ -503,7 +503,7 @@ TEST_F(TestScopedGraphCapture, MatmulDifferentOrdersTest) {
     GTEST_SKIP()
         << "High-level function tracing was removed - argument order testing at function level is no longer available";
 
-    tt::tt_metal::IDevice* device = device_;
+    tt::tt_metal::distributed::MeshDevice* device = device_;
 
     const auto tensor_spec = ttnn::TensorSpec(
         ttnn::Shape(tt::tt_metal::Array2D{64, 64}),
@@ -582,7 +582,7 @@ TEST_F(TestScopedGraphCapture, SubtractArgumentOrderWithCapturedTensorsTest) {
     // the graph correctly tracks the argument order for non-commutative operations like subtract.
     // We test subtract(a, b) vs subtract(b, a) to ensure the order is preserved.
 
-    tt::tt_metal::IDevice* device = device_;
+    tt::tt_metal::distributed::MeshDevice* device = device_;
 
     auto operation = [&device]() {
         // Create tensors INSIDE the capture
@@ -667,7 +667,6 @@ class DurationTrackingTest : public ttnn::TTNNFixtureWithDevice,
 
 TEST_P(DurationTrackingTest, DurationTracking) {
     auto run_mode = GetParam();
-    tt::tt_metal::IDevice* device = device_;
 
     nlohmann::json trace;
     {
@@ -679,7 +678,7 @@ TEST_P(DurationTrackingTest, DurationTracking) {
                 tt::tt_metal::DataType::BFLOAT16,
                 tt::tt_metal::PageConfig(tt::tt_metal::Layout::TILE),
                 ttnn::L1_MEMORY_CONFIG));
-        const auto input_tensor = tt::tt_metal::create_device_tensor(tensor_spec, device);
+        const auto input_tensor = tt::tt_metal::create_device_tensor(tensor_spec, device_);
         const auto output_tensor = ttnn::softmax(input_tensor, -1);
 
         trace = capture.end_graph_capture();
@@ -737,7 +736,6 @@ class TensorInfoTest : public ttnn::TTNNFixtureWithDevice,
 
 TEST_P(TensorInfoTest, FullTensorInfoCaptured) {
     auto run_mode = GetParam();
-    tt::tt_metal::IDevice* device = device_;
 
     nlohmann::json trace;
     {
@@ -749,7 +747,7 @@ TEST_P(TensorInfoTest, FullTensorInfoCaptured) {
                 tt::tt_metal::DataType::BFLOAT16,
                 tt::tt_metal::PageConfig(tt::tt_metal::Layout::TILE),
                 ttnn::L1_MEMORY_CONFIG));
-        const auto input_tensor = tt::tt_metal::create_device_tensor(tensor_spec, device);
+        const auto input_tensor = tt::tt_metal::create_device_tensor(tensor_spec, device_);
 
         trace = capture.end_graph_capture();
     }
@@ -813,7 +811,6 @@ INSTANTIATE_TEST_SUITE_P(
 
 // Test report contains cluster_descriptor when devices are present
 TEST_F(TestScopedGraphCapture, ReportContainsClusterDescriptor) {
-    tt::tt_metal::IDevice* device = device_;
 
     auto report_path = std::filesystem::temp_directory_path() / "test_cluster_desc_report.json";
     {
@@ -825,7 +822,7 @@ TEST_F(TestScopedGraphCapture, ReportContainsClusterDescriptor) {
                 tt::tt_metal::DataType::BFLOAT16,
                 tt::tt_metal::PageConfig(tt::tt_metal::Layout::TILE),
                 ttnn::L1_MEMORY_CONFIG));
-        const auto input_tensor = tt::tt_metal::create_device_tensor(tensor_spec, device);
+        const auto input_tensor = tt::tt_metal::create_device_tensor(tensor_spec, device_);
 
         capture.end_graph_capture_to_file(report_path);
     }
@@ -846,7 +843,6 @@ TEST_F(TestScopedGraphCapture, ReportContainsClusterDescriptor) {
 }
 
 TEST_F(TestScopedGraphCapture, ExactBufferTypeAndMaxSizePerBankTest) {
-    tt::tt_metal::IDevice* device = device_;
 
     nlohmann::json trace;
     {
@@ -858,7 +854,7 @@ TEST_F(TestScopedGraphCapture, ExactBufferTypeAndMaxSizePerBankTest) {
                 tt::tt_metal::DataType::BFLOAT16,
                 tt::tt_metal::PageConfig(tt::tt_metal::Layout::TILE),
                 ttnn::L1_MEMORY_CONFIG));
-        const auto input_tensor = tt::tt_metal::create_device_tensor(tensor_spec, device);
+        const auto input_tensor = tt::tt_metal::create_device_tensor(tensor_spec, device_);
 
         trace = capture.end_graph_capture();
     }
@@ -882,7 +878,6 @@ TEST_F(TestScopedGraphCapture, ExactBufferTypeAndMaxSizePerBankTest) {
 }
 
 TEST_F(TestScopedGraphCapture, PerOperationBuffersInReportTest) {
-    tt::tt_metal::IDevice* device = device_;
 
     auto report_path = std::filesystem::temp_directory_path() / "test_per_op_buffers_report.json";
     {
@@ -895,7 +890,7 @@ TEST_F(TestScopedGraphCapture, PerOperationBuffersInReportTest) {
                 tt::tt_metal::DataType::BFLOAT16,
                 tt::tt_metal::PageConfig(tt::tt_metal::Layout::TILE),
                 ttnn::L1_MEMORY_CONFIG));
-        const auto input_tensor = tt::tt_metal::create_device_tensor(tensor_spec, device);
+        const auto input_tensor = tt::tt_metal::create_device_tensor(tensor_spec, device_);
         const auto output_tensor = ttnn::softmax(input_tensor, -1);
 
         capture.end_graph_capture_to_file(report_path);
@@ -926,7 +921,6 @@ TEST_F(TestScopedGraphCapture, PerOperationBuffersInReportTest) {
 }
 
 TEST_F(TestScopedGraphCapture, DeallocateContainsBufferTypeTest) {
-    tt::tt_metal::IDevice* device = device_;
 
     nlohmann::json trace;
     {
@@ -938,7 +932,7 @@ TEST_F(TestScopedGraphCapture, DeallocateContainsBufferTypeTest) {
                 tt::tt_metal::DataType::BFLOAT16,
                 tt::tt_metal::PageConfig(tt::tt_metal::Layout::TILE),
                 ttnn::L1_MEMORY_CONFIG));
-        const auto input_tensor = tt::tt_metal::create_device_tensor(tensor_spec, device);
+        const auto input_tensor = tt::tt_metal::create_device_tensor(tensor_spec, device_);
         const auto output_tensor = ttnn::softmax(input_tensor, -1);
 
         trace = capture.end_graph_capture();

--- a/tests/ttnn/unit_tests/gtests/test_levelized_graph.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_levelized_graph.cpp
@@ -40,7 +40,7 @@ std::string shape_to_string(tt::stl::Span<const uint32_t> shape) {
 
 class TestLevelizedGraphCapture : public ttnn::TTNNFixtureWithDevice {};
 TEST_F(TestLevelizedGraphCapture, SimpleBinaryOp) {
-    tt::tt_metal::IDevice* device = device_;
+    tt::tt_metal::distributed::MeshDevice* device = device_;
 
     const auto input = ttnn::TensorSpec(
         ttnn::Shape(tt::tt_metal::Array2D{64, 128}),
@@ -112,7 +112,7 @@ TEST_F(TestLevelizedGraphCapture, SimpleBinaryOp) {
 }
 
 TEST_F(TestLevelizedGraphCapture, ReductionOp) {
-    tt::tt_metal::IDevice* device = device_;
+    tt::tt_metal::distributed::MeshDevice* device = device_;
 
     const auto input = ttnn::TensorSpec(
         ttnn::Shape(tt::tt_metal::Array2D{256, 128}),
@@ -171,7 +171,7 @@ TEST_F(TestLevelizedGraphCapture, ReductionOp) {
 }
 
 TEST_F(TestLevelizedGraphCapture, OutputLayoutInfo) {
-    tt::tt_metal::IDevice* device = device_;
+    tt::tt_metal::distributed::MeshDevice* device = device_;
 
     const auto input = ttnn::TensorSpec(
         ttnn::Shape(tt::tt_metal::Array3D{16, 32, 64}),
@@ -237,7 +237,7 @@ TEST_F(TestLevelizedGraphCapture, OutputLayoutInfo) {
 }
 
 TEST_F(TestLevelizedGraphCapture, MatmulWithBiasTest) {
-    tt::tt_metal::IDevice* device = device_;
+    tt::tt_metal::distributed::MeshDevice* device = device_;
 
     const auto input = ttnn::TensorSpec(
         ttnn::Shape(tt::tt_metal::Array2D{32, 32}),
@@ -305,7 +305,7 @@ TEST_F(TestLevelizedGraphCapture, MatmulWithBiasTest) {
 }
 
 TEST_F(TestLevelizedGraphCapture, CompositeOpTest) {
-    tt::tt_metal::IDevice* device = device_;
+    tt::tt_metal::distributed::MeshDevice* device = device_;
 
     const auto input = ttnn::TensorSpec(
         ttnn::Shape(tt::tt_metal::Array2D{12, 19}),
@@ -368,7 +368,7 @@ TEST_F(TestLevelizedGraphCapture, CompositeOpTest) {
 }
 
 TEST_F(TestLevelizedGraphCapture, MultiplySelfTest) {
-    tt::tt_metal::IDevice* device = device_;
+    tt::tt_metal::distributed::MeshDevice* device = device_;
 
     const auto input = ttnn::TensorSpec(
         ttnn::Shape(tt::tt_metal::Array2D{64, 128}),
@@ -471,7 +471,7 @@ TEST_F(TestLevelizedGraphCapture, MultiplySelfTest) {
 }
 
 TEST_F(TestLevelizedGraphCapture, ForkTest) {
-    tt::tt_metal::IDevice* device = device_;
+    tt::tt_metal::distributed::MeshDevice* device = device_;
 
     const auto input = ttnn::TensorSpec(
         ttnn::Shape(tt::tt_metal::Array2D{64, 128}),
@@ -565,7 +565,7 @@ TEST_F(TestLevelizedGraphCapture, ForkTest) {
 }
 
 TEST_F(TestLevelizedGraphCapture, JoinTest) {
-    tt::tt_metal::IDevice* device = device_;
+    tt::tt_metal::distributed::MeshDevice* device = device_;
 
     const auto input_a = ttnn::TensorSpec(
         ttnn::Shape(tt::tt_metal::Array2D{64, 128}),
@@ -647,7 +647,7 @@ TEST_F(TestLevelizedGraphCapture, JoinTest) {
 }
 
 TEST_F(TestLevelizedGraphCapture, OrderOfArgs) {
-    tt::tt_metal::IDevice* device = device_;
+    tt::tt_metal::distributed::MeshDevice* device = device_;
 
     const auto tensor_spec = ttnn::TensorSpec(
         ttnn::Shape(tt::tt_metal::Array2D{32, 64}),
@@ -744,7 +744,7 @@ TEST_F(TestLevelizedGraphCapture, OrderOfArgs) {
 }
 
 TEST_F(TestLevelizedGraphCapture, OrderOfArgsIntermediateTensorTest) {
-    tt::tt_metal::IDevice* device = device_;
+    tt::tt_metal::distributed::MeshDevice* device = device_;
 
     const auto tensor_spec = ttnn::TensorSpec(
         ttnn::Shape(tt::tt_metal::Array2D{32, 64}),
@@ -842,7 +842,7 @@ TEST_F(TestLevelizedGraphCapture, OrderOfArgsIntermediateTensorTest) {
 }
 
 TEST_F(TestLevelizedGraphCapture, SameTensorMultipleTimes) {
-    tt::tt_metal::IDevice* device = device_;
+    tt::tt_metal::distributed::MeshDevice* device = device_;
 
     const auto tensor_spec = ttnn::TensorSpec(
         ttnn::Shape(tt::tt_metal::Array2D{32, 64}),
@@ -910,7 +910,7 @@ TEST_F(TestLevelizedGraphCapture, SameTensorMultipleTimes) {
 }
 
 TEST_F(TestLevelizedGraphCapture, TernaryOpDifferentOrder) {
-    tt::tt_metal::IDevice* device = device_;
+    tt::tt_metal::distributed::MeshDevice* device = device_;
 
     const auto tensor_spec = ttnn::TensorSpec(
         ttnn::Shape(tt::tt_metal::Array2D{32, 64}),
@@ -1011,7 +1011,7 @@ TEST_F(TestLevelizedGraphCapture, TernaryOpDifferentOrder) {
 }
 
 TEST_F(TestLevelizedGraphCapture, TernaryOpRepeatedTensors) {
-    tt::tt_metal::IDevice* device = device_;
+    tt::tt_metal::distributed::MeshDevice* device = device_;
 
     const auto tensor_spec = ttnn::TensorSpec(
         ttnn::Shape(tt::tt_metal::Array2D{32, 64}),
@@ -1112,7 +1112,7 @@ TEST_F(TestLevelizedGraphCapture, TernaryOpRepeatedTensors) {
 }
 
 TEST_F(TestLevelizedGraphCapture, MatmulDifferentOrders) {
-    tt::tt_metal::IDevice* device = device_;
+    tt::tt_metal::distributed::MeshDevice* device = device_;
 
     const auto tensor_spec = ttnn::TensorSpec(
         ttnn::Shape(tt::tt_metal::Array2D{64, 64}),
@@ -1241,7 +1241,7 @@ for (auto t : tensor_vertices) {
 }
 
 TEST_F(TestLevelizedGraphCapture, ExtractLevelizedGraphJsonTest) {
-    tt::tt_metal::IDevice* device = device_;
+    tt::tt_metal::distributed::MeshDevice* device = device_;
 
     const auto input = ttnn::TensorSpec(
         ttnn::Shape(tt::tt_metal::Array2D{32, 64}),
@@ -1338,7 +1338,7 @@ TEST_F(TestLevelizedGraphCapture, ExtractLevelizedGraphJsonTest) {
 }
 
 TEST_F(TestLevelizedGraphCapture, MultiplyAndAddTest) {
-    tt::tt_metal::IDevice* device = device_;
+    tt::tt_metal::distributed::MeshDevice* device = device_;
 
     const auto input_a = ttnn::TensorSpec(
         ttnn::Shape(tt::tt_metal::Array2D{32, 64}),
@@ -1426,7 +1426,7 @@ TEST_F(TestLevelizedGraphCapture, MultiplyAndAddTest) {
 }
 
 TEST_F(TestLevelizedGraphCapture, MultiplyAndAddWithCapturedTensorsTest) {
-    tt::tt_metal::IDevice* device = device_;
+    tt::tt_metal::distributed::MeshDevice* device = device_;
 
     // This test demonstrates that when create_device_tensor is captured (tensors created INSIDE the capture),
     // the levelized graph includes BOTH the create_device_tensor operations AND the tensor nodes.
@@ -1542,7 +1542,7 @@ TEST_F(TestLevelizedGraphCapture, MultiplyAndAddWithCapturedTensorsTest) {
 }
 
 TEST_F(TestLevelizedGraphCapture, SubtractArgumentOrderWithCapturedTensorsTest) {
-    tt::tt_metal::IDevice* device = device_;
+    tt::tt_metal::distributed::MeshDevice* device = device_;
 
     // This test verifies that when tensors are created within the capture,
     // the graph correctly tracks the argument order for non-commutative operations like subtract.

--- a/ttnn/api/ttnn/tensor/tensor_ops.hpp
+++ b/ttnn/api/ttnn/tensor/tensor_ops.hpp
@@ -22,8 +22,7 @@ class TensorSpec;
 // Allocates a tensor on host.
 // Uses `mesh_device` to allocate sufficient number of host buffers for each multi-device shard.
 Tensor allocate_tensor_on_host(const TensorSpec& tensor_spec, distributed::MeshDevice* mesh_device);
-Tensor create_device_tensor(
-    const TensorSpec& tensor_spec, IDevice* device, std::optional<TensorTopology> tensor_topology = std::nullopt);
+Tensor create_device_tensor(const TensorSpec& tensor_spec, distributed::MeshDevice* mesh_device, std::optional<TensorTopology> tensor_topology = std::nullopt);
 
 tt::tt_metal::Tensor to_device(
     const tt::tt_metal::Tensor& input_tensor,

--- a/ttnn/core/tensor/tensor_ops.cpp
+++ b/ttnn/core/tensor/tensor_ops.cpp
@@ -42,18 +42,16 @@ Tensor allocate_tensor_on_host(const TensorSpec& tensor_spec, distributed::MeshD
 }
 
 Tensor create_device_tensor(
-    const TensorSpec& tensor_spec, IDevice* device, std::optional<TensorTopology> tensor_topology) {
+    const TensorSpec& tensor_spec, distributed::MeshDevice* mesh_device, std::optional<TensorTopology> tensor_topology) {
     GraphTracker::instance().track_function_start(
         "tt::tt_metal::create_device_tensor",
         tensor_spec.logical_shape(),
         tensor_spec.tensor_layout().get_data_type(),
         tensor_spec.tensor_layout().get_layout(),
-        device,
+        mesh_device,
         tensor_spec.tensor_layout().get_memory_config());
 
     Tensor output;
-    distributed::MeshDevice* mesh_device = dynamic_cast<distributed::MeshDevice*>(device);
-
     auto topology = std::invoke([&]() {
         if (tensor_topology.has_value()) {
             return std::move(*tensor_topology);


### PR DESCRIPTION
### Ticket
Closes #37451
Arguably #21099

### Problem description
`create_device_tensor` currently takes an `IDevice*` and **downcast** it to a `MeshDevice*` internally.

Current function:
```C++
Tensor create_device_tensor(const TensorSpec& tensor_spec, IDevice* device) {
    // ...
    Tensor output;
    distributed::MeshDevice* mesh_device = dynamic_cast<distributed::MeshDevice*>(device);
    output = allocate_tensor_on_device(tensor_spec, mesh_device);
    // ...
}
```

This is error prone as down-casting could lead to UB and does not correctly communicate the intent of the function.
Use sites of the functions all holds `MeshDevice*` already.

### What's changed
Updated function prototype from taking in a `IDevice` to a `MeshDevice`.
Updated all use sites to void any casting.

### Checklist

-  Compilation should indicate soundness

### CI Status
_Auto-generated on every push. Badges update live. Click a pipeline name or badge to filter by this branch._

| Pipeline | Status | Latest Run |
|---|:---:|---|
| [Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:riverwu/create_device_tensor-mesh) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=riverwu/create_device_tensor-mesh)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:riverwu/create_device_tensor-mesh) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:riverwu/create_device_tensor-mesh) |
| [Blackhole post-commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:riverwu/create_device_tensor-mesh) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=riverwu/create_device_tensor-mesh)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:riverwu/create_device_tensor-mesh) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:riverwu/create_device_tensor-mesh) |
| [L2 Nightly](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:riverwu/create_device_tensor-mesh) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=riverwu/create_device_tensor-mesh)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:riverwu/create_device_tensor-mesh) | [#3357](https://github.com/tenstorrent/tt-metal/actions/runs/21930162608) |
| [(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:riverwu/create_device_tensor-mesh) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=riverwu/create_device_tensor-mesh)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:riverwu/create_device_tensor-mesh) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:riverwu/create_device_tensor-mesh) |
| [(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:riverwu/create_device_tensor-mesh) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=riverwu/create_device_tensor-mesh)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:riverwu/create_device_tensor-mesh) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:riverwu/create_device_tensor-mesh) |
| [(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:riverwu/create_device_tensor-mesh) | [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=riverwu/create_device_tensor-mesh)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:riverwu/create_device_tensor-mesh) | [Launch ↗](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:riverwu/create_device_tensor-mesh) |