### PR TITLE
#37464: Update unary LLK Tile API's

### DIFF
--- a/docs/Doxyfile
+++ b/docs/Doxyfile
@@ -942,7 +942,7 @@ INPUT                  = tt_metal/hw/inc/api/compile_time_args.h \
                          tt_metal/hw/inc/api/compute/eltwise_unary/i1.h \
                          tt_metal/hw/inc/api/compute/eltwise_unary/reverseops.h \
                          tt_metal/hw/inc/api/compute/eltwise_unary/isinf_isnan.h \
-                         tt_metal/hw/inc/api/compute/eltwise_unary/logical_not_noti.h \
+                         tt_metal/hw/inc/api/compute/eltwise_unary/logical_not.h \
                          tt_metal/hw/inc/api/compute/eltwise_unary/trigonometry.h \
                          tt_metal/hw/inc/api/compute/eltwise_unary/rounding.h \
                          tt_metal/hw/inc/api/compute/eltwise_unary/activations.h \

--- a/docs/source/tt-metalium/tt_metal/apis/kernel_apis/compute/logical_not_unary_tile.rst
+++ b/docs/source/tt-metalium/tt_metal/apis/kernel_apis/compute/logical_not_unary_tile.rst
@@ -1,7 +1,5 @@
 logical_not_unary_tile
 ======================
 
-.. doxygenfunction:: logical_not_unary_tile_init()
-.. doxygenfunction:: logical_not_unary_tile(uint32_t idst)
-.. doxygenfunction:: logical_not_unary_tile_int32(uint32_t idst)
-.. doxygenfunction:: logical_not_unary_tile_uint32(uint32_t idst)
+.. doxygenfunction:: logical_not_tile_init()
+.. doxygenfunction:: logical_not_tile(uint32_t idst)

--- a/tests/ttnn/unit_tests/operations/eltwise/test_unary_ops_ttnn.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_unary_ops_ttnn.py
@@ -431,47 +431,6 @@ def test_unary_leaky_relu_ttnn(input_shapes, negative_slope, device):
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-@pytest.mark.parametrize(
-    "torch_dtype, ttnn_dtype",
-    [
-        (torch.float32, ttnn.float32),
-        (torch.bfloat16, ttnn.bfloat16),
-    ],
-)
-def test_unary_logical_not_ttnn(input_shapes, torch_dtype, ttnn_dtype, device):
-    num_elements = max(int(torch.prod(torch.tensor(input_shapes)).item()), 1)
-    in_data = torch.linspace(-100, 100, num_elements, dtype=torch_dtype)
-    in_data[::5] = 0  # every 5th element is zero
-    in_data = in_data[:num_elements].reshape(input_shapes).nan_to_num(0.0)
-
-    input_tensor = ttnn.from_torch(
-        in_data,
-        dtype=ttnn_dtype,
-        device=device,
-        layout=ttnn.TILE_LAYOUT,
-        memory_config=ttnn.DRAM_MEMORY_CONFIG,
-    )
-
-    _, output_tensor = data_gen_with_range(input_shapes, -1, 1, device)
-
-    cq_id = 0
-    ttnn.logical_not(input_tensor, output_tensor=output_tensor, queue_id=cq_id)
-    output_tensor = ttnn.to_torch(output_tensor, dtype=torch_dtype)
-
-    golden_function = ttnn.get_golden_function(ttnn.logical_not)
-    golden_tensor = golden_function(in_data, device=device)
-
-    assert torch.equal(output_tensor, golden_tensor.to(torch_dtype))
-
-
-@pytest.mark.parametrize(
-    "input_shapes",
-    (
-        (torch.Size([1, 1, 32, 32])),
-        (torch.Size([1, 1, 320, 384])),
-        (torch.Size([1, 3, 320, 384])),
-    ),
-)
 def test_unary_i0_ttnn(input_shapes, device):
     in_data, input_tensor = data_gen_with_range(input_shapes, -10, 10, device)
     _, output_tensor = data_gen_with_range(input_shapes, -1, 1, device)

--- a/tt_metal/hw/CMakeLists.txt
+++ b/tt_metal/hw/CMakeLists.txt
@@ -586,7 +586,7 @@ target_sources(
             inc/api/compute/eltwise_unary/isinf_isnan.h
             inc/api/compute/eltwise_unary/left_shift.h
             inc/api/compute/eltwise_unary/log1p.h
-            inc/api/compute/eltwise_unary/logical_not_noti.h
+            inc/api/compute/eltwise_unary/logical_not.h
             inc/api/compute/eltwise_unary/negative.h
             inc/api/compute/eltwise_unary/prelu.h
             inc/api/compute/eltwise_unary/rand.h

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_logical_not.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_logical_not.h
@@ -10,32 +10,27 @@
 
 namespace ckernel::sfpu {
 
-template <typename V, typename T>
-inline void calculate_logical_not_unary() {
-#pragma GCC unroll 0
-    for (int d = 0; d < 8; d++) {
-        V v = sfpi::dst_reg[0];
-        v_if(v == 0) { sfpi::dst_reg[0] = T(1); }
-        v_else { sfpi::dst_reg[0] = T(0); }
-        v_endif;
-        sfpi::dst_reg++;
-    }
-}
-
-template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
-inline void calculate_logical_not_unary_uint16() {
+template <bool APPROXIMATION_MODE, InstrModLoadStore INSTRUCTION_MODE, int ITERATIONS>
+inline void calculate_logical_not() {
+    static_assert(
+        INSTRUCTION_MODE == InstrModLoadStore::DEFAULT || INSTRUCTION_MODE == InstrModLoadStore::LO16 ||
+            INSTRUCTION_MODE == InstrModLoadStore::INT32,
+        "INSTRUCTION_MODE must be one of: DEFAULT, LO16, INT32.");
+#pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++) {
-        // full tile size
         constexpr int tile_size = 64;
         // load in conditional uint16 value
-        TTI_SFPLOAD(p_sfpu::LREG0, LO16, ADDR_MOD_3, 0);
+        TTI_SFPLOAD(p_sfpu::LREG0, INSTRUCTION_MODE, ADDR_MOD_7, 0);
         // initially put 0 into output
         TTI_SFPMOV(0, p_sfpu::LCONST_0, p_sfpu::LREG1, 0);
         // if (REG0 == 0)
         TTI_SFPSETCC(0, 0, 0, sfpi::SFPSETCC_MOD1_LREG_EQ0);
-        // load in (int) 1
-        TTI_SFPLOADI(p_sfpu::LREG1, sfpi::SFPLOADI_MOD0_USHORT, 0x0001);
-
+        // load in 1
+        if constexpr (INSTRUCTION_MODE == InstrModLoadStore::DEFAULT) {
+            TTI_SFPMOV(0, p_sfpu::LCONST_1, p_sfpu::LREG1, 0);
+        } else {
+            TTI_SFPLOADI(p_sfpu::LREG1, sfpi::SFPLOADI_MOD0_USHORT, 0x0001);
+        }
         // TTI_SFPENCC(IMM12_MATH, LREG_C, LREG_DEST, INSTR_MOD1);
         // IMM12_MATH: optional immediate value for math operations
         // LREG_C: unused
@@ -43,7 +38,7 @@ inline void calculate_logical_not_unary_uint16() {
         // INSTR_MOD1: 0 => condition code enable reg is not modified.
         TTI_SFPENCC(0, 0, 0, 0);
         // store result
-        TTI_SFPSTORE(p_sfpu::LREG1, LO16, ADDR_MOD_3, 0);
+        TTI_SFPSTORE(p_sfpu::LREG1, INSTRUCTION_MODE, ADDR_MOD_7, 0);
         sfpi::dst_reg++;
     }
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_logical_not.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_logical_not.h
@@ -10,32 +10,27 @@
 
 namespace ckernel::sfpu {
 
-template <typename V, typename T>
-inline void calculate_logical_not_unary() {
-#pragma GCC unroll 0
-    for (int d = 0; d < 8; d++) {
-        V v = sfpi::dst_reg[0];
-        v_if(v == 0) { sfpi::dst_reg[0] = T(1); }
-        v_else { sfpi::dst_reg[0] = T(0); }
-        v_endif;
-        sfpi::dst_reg++;
-    }
-}
-
-template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
-inline void calculate_logical_not_unary_uint16() {
+template <bool APPROXIMATION_MODE, InstrModLoadStore INSTRUCTION_MODE, int ITERATIONS>
+inline void calculate_logical_not() {
+    static_assert(
+        INSTRUCTION_MODE == InstrModLoadStore::DEFAULT || INSTRUCTION_MODE == InstrModLoadStore::LO16 ||
+            INSTRUCTION_MODE == InstrModLoadStore::INT32,
+        "INSTRUCTION_MODE must be one of: DEFAULT, LO16, INT32.");
+#pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++) {
-        // full tile size
         constexpr int tile_size = 64;
         // load in conditional uint16 value
-        TTI_SFPLOAD(p_sfpu::LREG0, LO16, ADDR_MOD_7, 0);
+        TTI_SFPLOAD(p_sfpu::LREG0, INSTRUCTION_MODE, ADDR_MOD_3, 0);
         // initially put 0 into output
         TTI_SFPMOV(0, p_sfpu::LCONST_0, p_sfpu::LREG1, 0);
         // if (REG0 == 0)
         TTI_SFPSETCC(0, 0, 0, sfpi::SFPSETCC_MOD1_LREG_EQ0);
-        // load in (int) 1
-        TTI_SFPLOADI(p_sfpu::LREG1, sfpi::SFPLOADI_MOD0_USHORT, 0x0001);
-
+        // load in 1
+        if constexpr (INSTRUCTION_MODE == InstrModLoadStore::DEFAULT) {
+            TTI_SFPMOV(0, p_sfpu::LCONST_1, p_sfpu::LREG1, 0);
+        } else {
+            TTI_SFPLOADI(p_sfpu::LREG1, sfpi::SFPLOADI_MOD0_USHORT, 0x0001);
+        }
         // TTI_SFPENCC(IMM12_MATH, LREG_C, LREG_DEST, INSTR_MOD1);
         // IMM12_MATH: optional immediate value for math operations
         // LREG_C: unused
@@ -43,9 +38,8 @@ inline void calculate_logical_not_unary_uint16() {
         // INSTR_MOD1: 0 => condition code enable reg is not modified.
         TTI_SFPENCC(0, 0, 0, 0);
         // store result
-        TTI_SFPSTORE(p_sfpu::LREG1, LO16, ADDR_MOD_7, 0);
+        TTI_SFPSTORE(p_sfpu::LREG1, INSTRUCTION_MODE, ADDR_MOD_3, 0);
         sfpi::dst_reg++;
     }
 }
-
 }  // namespace ckernel::sfpu

--- a/tt_metal/hw/inc/api/compute/eltwise_unary/logical_not.h
+++ b/tt_metal/hw/inc/api/compute/eltwise_unary/logical_not.h
@@ -6,17 +6,20 @@
 
 #include "api/compute/common_globals.h"
 #ifdef TRISC_MATH
-#include "ckernel_sfpu_logical_not_noti.h"
+#include "ckernel_sfpu_logical_not.h"
 #include "llk_math_eltwise_unary_sfpu_macros.h"
 #endif
 
 namespace ckernel {
 // clang-format off
 /**
- * Performs element-wise computation of the logical not unary operation on each element of a tile
+ * Performs element-wise computation of the logical not operation on each element of a tile
  * in DST register at index tile_index. The DST register buffer must be in
  * acquired state via *acquire_dst* call. This call is blocking and is only
  * available on the compute engine.
+ *
+ * @tparam data_format Template argument specifying the data type.
+ * Supported data formats are: DataFormat::Int32, DataFormat::UInt32, DataFormat::UInt16, DataFormat::Float32, DataFormat::Float16_b, DataFormat::Bfp8_b.
  *
  * Return value: None
  *
@@ -25,25 +28,14 @@ namespace ckernel {
  * | tile_index     | The index of the tile in DST register buffer to perform the computation on | uint32_t | Must be less than the size of the DST register buffer | True     |
  */
 // clang-format on
-ALWI void logical_not_unary_tile(uint32_t idst) {
-    MATH(SFPU_UNARY_KERNEL_THREE_TEMPLATE_ARGS_FN(calculate_logical_not_unary, APPROX, sfpi::vFloat, float, idst));
-}
-
-ALWI void logical_not_unary_tile_int32(uint32_t idst) {
-    MATH(SFPU_UNARY_KERNEL_THREE_TEMPLATE_ARGS_FN(calculate_logical_not_unary, APPROX, sfpi::vInt, int16_t, idst));
-}
-
-ALWI void logical_not_unary_tile_uint32(uint32_t idst) {
-    MATH(SFPU_UNARY_KERNEL_THREE_TEMPLATE_ARGS_FN(calculate_logical_not_unary, APPROX, sfpi::vUInt, uint16_t, idst));
-}
-
-ALWI void logical_not_unary_tile_uint16(uint32_t idst) {
-    MATH((SFPU_UNARY_NO_PARAM_KERNEL_FN(calculate_logical_not_unary_uint16, RC, APPROX, idst)));
+template <DataFormat DATA_FORMAT>
+ALWI void logical_not_tile(uint32_t idst) {
+    MATH(SFPU_UNARY_KERNEL_THREE_TEMPLATE_ARGS_FN(calculate_logical_not, APPROX, DATA_FORMAT, 8, idst, RC));
 }
 
 /**
  * Please refer to documentation for any_init.
  */
-ALWI void logical_not_unary_tile_init() { MATH(SFPU_UNARY_KERNEL_INIT(logical_not_unary, APPROX)); }
+ALWI void logical_not_tile_init() { MATH(SFPU_UNARY_KERNEL_INIT(logical_not_unary, APPROX)); }
 
 }  // namespace ckernel

--- a/tt_metal/hw/inc/api/compute/eltwise_unary/sfpu_split_includes.h
+++ b/tt_metal/hw/inc/api/compute/eltwise_unary/sfpu_split_includes.h
@@ -12,8 +12,8 @@
 #include "api/compute/eltwise_unary/erf_erfc.h"
 #endif
 
-#if SFPU_OP_LOGICAL_NOT_NOTI_INCLUDE
-#include "api/compute/eltwise_unary/logical_not_noti.h"
+#if SFPU_OP_LOGICAL_NOT_INCLUDE
+#include "api/compute/eltwise_unary/logical_not.h"
 #endif
 
 #if SFPU_OP_EXP_INCLUDE

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_utils.cpp
@@ -45,7 +45,7 @@ std::string get_macro_definition(UnaryOpType op_type) {
         case UnaryOpType::ISNEGINF:
         case UnaryOpType::ISPOSINF:
         case UnaryOpType::ISFINITE: return "SFPU_OP_ISINF_ISNAN_INCLUDE";
-        case UnaryOpType::LOGICAL_NOT_UNARY: return "SFPU_OP_LOGICAL_NOT_NOTI_INCLUDE";
+        case UnaryOpType::LOGICAL_NOT_UNARY: return "SFPU_OP_LOGICAL_NOT_INCLUDE";
         case UnaryOpType::I0: return "SFPU_OP_I0_INCLUDE";
         case UnaryOpType::I1: return "SFPU_OP_I1_INCLUDE";
         case UnaryOpType::ACOSH:
@@ -597,19 +597,22 @@ std::pair<std::string, std::string> get_op_init_and_func_default(
         case UnaryOpType::ISPOSINF: return {"isposinf_tile_init();", fmt::format("isposinf_tile({});", idst)};
         case UnaryOpType::ISNEGINF: return {"isneginf_tile_init();", fmt::format("isneginf_tile({});", idst)};
         case UnaryOpType::ISNAN: return {"isnan_tile_init();", fmt::format("isnan_tile({});", idst)};
-        case UnaryOpType::LOGICAL_NOT_UNARY:
+        case UnaryOpType::LOGICAL_NOT_UNARY: {
             TT_FATAL(
                 input_dtype.has_value(), "Missing input dtype: Expected a valid input dtype, but none was provided.");
-            if (input_dtype == DataType::INT32) {
-                return {"logical_not_unary_tile_init();", fmt::format("logical_not_unary_tile_int32({});", idst)};
+            const char* data_format;
+            switch (input_dtype.value()) {
+                case DataType::INT32: data_format = "Int32"; break;
+                case DataType::UINT32: data_format = "UInt32"; break;
+                case DataType::UINT16: data_format = "UInt16"; break;
+                case DataType::FLOAT32: data_format = "Float32"; break;
+                case DataType::BFLOAT16: data_format = "Float16_b"; break;
+                case DataType::BFLOAT8_B: data_format = "Bfp8_b"; break;
+                default: TT_THROW("Unsupported data format for logical not unary: {}", input_dtype);
             }
-            if (input_dtype == DataType::UINT32) {
-                return {"logical_not_unary_tile_init();", fmt::format("logical_not_unary_tile_uint32({});", idst)};
-            }
-            if (input_dtype == DataType::UINT16) {
-                return {"logical_not_unary_tile_init();", fmt::format("logical_not_unary_tile_uint16({});", idst)};
-            }
-            return {"logical_not_unary_tile_init();", fmt::format("logical_not_unary_tile({});", idst)};
+            return {
+                "logical_not_tile_init();", fmt::format("logical_not_tile<DataFormat::{0}>({1});", data_format, idst)};
+        }
         case UnaryOpType::I0: return {"i0_tile_init();", fmt::format("i0_tile({});", idst)};
         case UnaryOpType::I1: return {"i1_tile_init();", fmt::format("i1_tile({});", idst)};
         case UnaryOpType::EXP: return {"exp_tile_init();", fmt::format("exp_tile({});", idst)};

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/unary_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/unary_nanobind.cpp
@@ -2042,7 +2042,7 @@ void py_module(nb::module_& mod) {
         ttnn::logical_not,
         R"doc(\mathrm{{output\_tensor}}_i = \mathrm{{!input\_tensor_i}})doc",
         "",
-        R"doc(BFLOAT16, BFLOAT8_B, INT32, UINT16 (range: 0 - 65535), UINT32 (range: 0 - 4294967295))doc");
+        R"doc(BFLOAT16, BFLOAT8_B, FLOAT32, INT32, UINT16 (range: 0 - 65535), UINT32 (range: 0 - 4294967295))doc");
     bind_unary_operation_subcoregrids(
         mod,
         ttnn::ltz,
@@ -2371,7 +2371,7 @@ void py_module(nb::module_& mod) {
         ttnn::logical_not_,
         R"doc(Performs logical_not inplace function on :attr:`input_tensor`.)doc",
         "",
-        R"doc(BFLOAT16, BFLOAT8_B, INT32, UINT32)doc");
+        R"doc(BFLOAT16, BFLOAT8_B, FLOAT32, INT32, UINT16 (range: 0 - 65535), UINT32 (range: 0 - 4294967295))doc");
     bind_unary_composite(
         mod,
         ttnn::normalize_global,


### PR DESCRIPTION
### Ticket
Link to Github Issue #37464 

### What's changed
Updated the LLK unary tiles so that each API uses a single tile api for different dtypes


### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=mouliraj/unary_llk_changes)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:mouliraj/unary_llk_changes)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=mouliraj/unary_llk_changes)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:mouliraj/unary_llk_changes)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mouliraj/unary_llk_changes)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mouliraj/unary_llk_changes)
