### PR TITLE
H<->D Ops for Blitz + Changes to support Async Slow Dispatch

### DIFF
--- a/.github/workflows/blackhole-multi-card-unit-tests-impl.yaml
+++ b/.github/workflows/blackhole-multi-card-unit-tests-impl.yaml
@@ -50,7 +50,9 @@ jobs:
             timeout: 15
             test-type: fast
           - name: Sockets fast unit test
-            cmd: ./build/test/tt_metal/distributed/distributed_unit_tests --gtest_filter="*HDSocketFixture*"
+            cmd: |
+              ./build/test/tt_metal/distributed/distributed_unit_tests --gtest_filter="*HDSocketFixture*"
+              TT_METAL_SLOW_DISPATCH_MODE=1 pytest -svv models/demos/deepseek_v3_b1/tests/unit_tests/test_host_io.py
             timeout: 10
             test-type: fast
           - name: cpp fast unit tests (eth, single erisc)

--- a/models/demos/deepseek_v3_b1/micro_ops/host_io/kernels/d2h_sender.cpp
+++ b/models/demos/deepseek_v3_b1/micro_ops/host_io/kernels/d2h_sender.cpp
@@ -1,0 +1,106 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+#include <cstdint>
+#include "api/dataflow/dataflow_api.h"
+#include "api/socket_api.h"
+#include "api/debug/dprint.h"
+
+FORCE_INLINE bool socket_wait_for_pages_with_termination(
+    const SocketReceiverInterface& socket, uint32_t num_pages, volatile tt_l1_ptr uint32_t* termination_semaphore) {
+    constexpr uint32_t termination_value = 1;
+    while (!socket_wait_for_pages(socket, num_pages, 1000)) {
+        invalidate_l1_cache();
+        if (termination_semaphore[0] == termination_value) {
+            return false;
+        }
+    }
+    return true;
+}
+
+FORCE_INLINE bool cb_wait_for_pages_with_termination(
+    uint32_t cb_index, uint32_t num_pages, volatile tt_l1_ptr uint32_t* termination_semaphore) {
+    constexpr uint32_t termination_value = 1;
+    while (!cb_pages_available_at_front(cb_index, num_pages)) {
+        invalidate_l1_cache();
+        if (termination_semaphore[0] == termination_value) {
+            return false;
+        }
+    }
+    return true;
+}
+
+void kernel_main() {
+    // Get this value from MeshSocket struct on host
+    constexpr uint32_t send_socket_config_addr = get_compile_time_arg_val(0);
+    constexpr uint32_t termination_semaphore_addr = get_compile_time_arg_val(1);
+    constexpr uint32_t page_size = get_compile_time_arg_val(2);
+    constexpr bool loopback_mode = get_compile_time_arg_val(3);
+    constexpr uint32_t upstream_interface_index = get_compile_time_arg_val(4);
+
+    SocketSenderInterface sender_socket = create_sender_socket_interface(send_socket_config_addr);
+    SocketReceiverInterface receiver_socket = {};
+
+    if constexpr (!loopback_mode) {
+        receiver_socket = create_receiver_socket_interface(upstream_interface_index);
+        set_receiver_socket_page_size(receiver_socket, page_size);
+    }
+    set_sender_socket_page_size(sender_socket, page_size);
+
+    uint32_t write_addr_hi = sender_socket.d2h.data_addr_hi;
+    uint32_t pcie_xy_enc = sender_socket.d2h.pcie_xy_enc;
+
+    noc_write_init_state<write_cmd_buf>(NOC_INDEX, NOC_UNICAST_WRITE_VC);
+
+    volatile tt_l1_ptr uint32_t* termination_semaphore =
+        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(termination_semaphore_addr);
+    while (true) {
+        // Wait for space in D2H socket
+        socket_reserve_pages(sender_socket, 1);
+        if constexpr (loopback_mode) {
+            // Wait for data in CB with termination checks
+            if (!cb_wait_for_pages_with_termination(upstream_interface_index, 1, termination_semaphore)) {
+                break;
+            }
+            uint32_t read_addr = get_read_ptr(upstream_interface_index);
+            noc_wwrite_with_state<noc_mode, write_cmd_buf, CQ_NOC_SNDL, CQ_NOC_SEND, CQ_NOC_WAIT, true, false>(
+                NOC_INDEX,
+                read_addr,
+                pcie_xy_enc,
+                ((static_cast<uint64_t>(write_addr_hi) << 32) | sender_socket.downstream_fifo_addr) +
+                    sender_socket.write_ptr,
+                page_size,
+                1);
+            noc_async_writes_flushed();
+            cb_pop_front(upstream_interface_index, 1);
+        } else {
+            // Wait for pages in receiver socket with timeout and termination checks
+            if (!socket_wait_for_pages_with_termination(receiver_socket, 1, termination_semaphore)) {
+                break;
+            }
+            uint32_t read_addr = receiver_socket.read_ptr;
+            noc_wwrite_with_state<noc_mode, write_cmd_buf, CQ_NOC_SNDL, CQ_NOC_SEND, CQ_NOC_WAIT, true, false>(
+                NOC_INDEX,
+                read_addr,
+                pcie_xy_enc,
+                ((static_cast<uint64_t>(write_addr_hi) << 32) | sender_socket.downstream_fifo_addr) +
+                    sender_socket.write_ptr,
+                page_size,
+                1);
+            socket_pop_pages(receiver_socket, 1);
+            noc_async_writes_flushed();
+            socket_notify_sender(receiver_socket);
+        }
+
+        socket_push_pages(sender_socket, 1);
+        socket_notify_receiver(sender_socket);
+        invalidate_l1_cache();
+    }
+
+    update_socket_config(sender_socket);
+    socket_barrier(sender_socket);
+
+    noc_async_write_barrier();
+    noc_async_read_barrier();
+    DPRINT << "End D2H Main Loop" << ENDL();
+}

--- a/models/demos/deepseek_v3_b1/micro_ops/host_io/kernels/h2d_receiver.cpp
+++ b/models/demos/deepseek_v3_b1/micro_ops/host_io/kernels/h2d_receiver.cpp
@@ -1,0 +1,96 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+#include <cstdint>
+#include "api/dataflow/dataflow_api.h"
+#include "api/socket_api.h"
+
+FORCE_INLINE bool socket_wait_for_pages_with_termination(
+    const SocketReceiverInterface& socket, uint32_t num_pages, volatile tt_l1_ptr uint32_t* termination_semaphore) {
+    constexpr uint32_t termination_value = 1;
+    while (!socket_wait_for_pages(socket, num_pages, 1000)) {
+        invalidate_l1_cache();
+        if (termination_semaphore[0] == termination_value) {
+            return false;
+        }
+    }
+    return true;
+}
+
+void kernel_main() {
+    // Get this value from MeshSocket struct on host
+    constexpr uint32_t recv_socket_config_addr = get_compile_time_arg_val(0);
+    constexpr uint32_t termination_semaphore_addr = get_compile_time_arg_val(1);
+    constexpr uint32_t page_size = get_compile_time_arg_val(2);
+    constexpr bool pull_from_host = get_compile_time_arg_val(3);
+    constexpr bool loopback_mode = get_compile_time_arg_val(4);
+    constexpr uint32_t downstream_interface_index = get_compile_time_arg_val(5);
+
+    SocketReceiverInterface receiver_socket = create_receiver_socket_interface(recv_socket_config_addr);
+    SocketSenderInterface sender_socket = {};
+
+    if constexpr (!loopback_mode) {
+        sender_socket = create_sender_socket_interface(downstream_interface_index);
+        set_sender_socket_page_size(sender_socket, page_size);
+    }
+    set_receiver_socket_page_size(receiver_socket, page_size);
+
+    uint32_t read_addr_hi = receiver_socket.h2d.data_addr_hi;
+    uint32_t read_addr_lo = receiver_socket.h2d.data_addr_lo;
+    uint32_t pcie_xy_enc = receiver_socket.h2d.pcie_xy_enc;
+
+    noc_write_init_state<write_cmd_buf>(NOC_INDEX, NOC_UNICAST_WRITE_VC);
+
+    volatile tt_l1_ptr uint32_t* termination_semaphore =
+        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(termination_semaphore_addr);
+    while (true) {
+        // Wait for pages in H2D socket
+        if (!socket_wait_for_pages_with_termination(receiver_socket, 1, termination_semaphore)) {
+            break;
+        }
+        if constexpr (pull_from_host) {
+            // Pages available in H2D socket - read over PCIe
+            noc_read_with_state<noc_mode, read_cmd_buf, CQ_NOC_SNDL, CQ_NOC_SEND, CQ_NOC_WAIT>(
+                NOC_INDEX,
+                pcie_xy_enc,
+                ((static_cast<uint64_t>(read_addr_hi) << 32) | read_addr_lo) + receiver_socket.read_ptr -
+                    receiver_socket.fifo_addr,
+                receiver_socket.read_ptr,
+                page_size);
+            noc_async_read_barrier();
+        }
+        if constexpr (loopback_mode) {
+            cb_reserve_back(downstream_interface_index, 1);
+            noc_async_write(
+                receiver_socket.read_ptr, get_noc_addr(get_write_ptr(downstream_interface_index)), page_size);
+            noc_async_write_barrier();
+            cb_push_back(downstream_interface_index, 1);
+        } else {
+            socket_reserve_pages(sender_socket, 1);
+            sender_downstream_encoding downstream_enc = get_downstream_encoding(sender_socket, 0);
+            noc_async_write(
+                receiver_socket.read_ptr,
+                get_noc_addr(
+                    downstream_enc.d2d.downstream_noc_x,
+                    downstream_enc.d2d.downstream_noc_y,
+                    sender_socket.write_ptr + sender_socket.downstream_fifo_addr),
+                page_size);
+            socket_push_pages(sender_socket, 1);
+            socket_notify_receiver(sender_socket);
+            noc_async_writes_flushed();
+        }
+        socket_pop_pages(receiver_socket, 1);
+        // Notify Host that pages were popped from H2D socket
+        socket_notify_sender(receiver_socket);
+        invalidate_l1_cache();
+    }
+
+    update_socket_config(receiver_socket);
+    if constexpr (!loopback_mode) {
+        socket_barrier(sender_socket);
+    }
+
+    noc_async_write_barrier();
+    noc_async_read_barrier();
+    DPRINT << "End H2D Main Loop" << ENDL();
+}

--- a/models/demos/deepseek_v3_b1/micro_ops/host_io/op.py
+++ b/models/demos/deepseek_v3_b1/micro_ops/host_io/op.py
@@ -1,0 +1,184 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Host-Device Communication Interface.
+
+Provides bidirectional communication between host and device using H2D (Host-to-Device)
+and D2H (Device-to-Host) sockets with termination support.
+
+Current Limitations:
+- Only supports communication with a single core on a single chip
+- H2D and D2H sockets must be on the same core
+- No multi-chip or multi-core host communication support
+
+Modes:
+- Loopback mode: H2D receiver and D2H sender communicate via circular buffers (CBs)
+  for testing purposes
+- Socket mode: H2D receiver and D2H sender forward data to/from downstream/upstream cores
+  via D2D (Device-to-Device) sockets
+
+Components:
+- H2D receiver: Pulls data from host (or receives via PCIe push), forwards to downstream
+- D2H sender: Receives data from upstream, pushes to host via PCIe
+
+Termination:
+- Controlled via global semaphore that both kernels poll during blocking operations
+- Ensures clean shutdown within ~1000 device cycles without hanging on socket/CB waits
+
+Kernel implementation uses polling loops with termination checks to avoid indefinite
+blocking on socket_wait_for_pages() and cb_wait_front() operations.
+"""
+
+import ttnn
+
+
+class HostInterface:
+    def __init__(
+        self,
+        h2d_socket,
+        d2h_socket,
+        page_size,
+        core_to_core_socket_buffer_size=1024,
+        h2d_downstream_core=ttnn.CoreCoord(0, 0),
+        d2h_upstream_core=ttnn.CoreCoord(0, 0),
+        loopback_mode=False,
+    ):
+        self.h2d_socket = h2d_socket
+        self.d2h_socket = d2h_socket
+        self.page_size = page_size
+        self.h2d_socket.set_page_size(self.page_size)
+        self.d2h_socket.set_page_size(self.page_size)
+        self.loopback_mode = loopback_mode
+        self.core_to_core_socket_buffer_size = core_to_core_socket_buffer_size
+
+        # Validate single-core, single-chip constraint
+        # Current implementation only supports host communication with one core on one chip
+        if len(h2d_socket.get_active_cores()) != 1 or len(d2h_socket.get_active_cores()) != 1:
+            raise ValueError("Host <-> Device Communication for Blitz Decode must be on a single core.")
+        if h2d_socket.get_active_cores()[0] != d2h_socket.get_active_cores()[0]:
+            raise ValueError("Expected Host <-> Device Communication for Blitz Decode to be on the same core.")
+        if h2d_socket.get_mesh_device() != d2h_socket.get_mesh_device():
+            raise ValueError("Expected Host <-> Device Communication for Blitz Decode to be on the same mesh device.")
+
+        self.mesh_device = h2d_socket.get_mesh_device()
+        self.mesh_core_coord = self.h2d_socket.get_active_cores()[0]
+        self.termination_semaphore = ttnn.create_global_semaphore(
+            self.mesh_device,
+            ttnn.CoreRangeSet([ttnn.CoreRange(self.mesh_core_coord.core_coord, self.mesh_core_coord.core_coord)]),
+            0,
+            ttnn.BufferType.L1,
+        )
+        # Loopback mode is for testing purposes only - H2D receiver <-> D2H sender communication over CBs
+        # For real workloads, downstream/upstream cores connect to H2D receiver and D2H sender via D2D sockets
+        # NOTE: Downstream and upstream cores must be on the same device as the host I/O core (single-chip constraint)
+        if not loopback_mode:
+            downstream_socket_connection = ttnn.SocketConfig(
+                self.mesh_core_coord,
+                ttnn.MeshCoreCoord(self.mesh_core_coord.device_coord, h2d_downstream_core),
+            )
+            upstream_socket_connection = ttnn.SocketConfig(
+                ttnn.MeshCoreCoord(self.mesh_core_coord.device_coord, d2h_upstream_core),
+                self.mesh_core_coord,
+            )
+            socket_memory_config = ttnn.SocketMemoryConfig(ttnn.BufferType.L1, core_to_core_socket_buffer_size)
+
+            downstream_socket_config = ttnn.SocketConfig(
+                [downstream_socket_connection],
+                socket_memory_config,
+            )
+
+            upstream_socket_config = ttnn.SocketConfig(
+                [upstream_socket_connection],
+                socket_memory_config,
+            )
+
+            self.downstream_socket_pair = ttnn.create_socket_pair(
+                self.mesh_device, self.mesh_device, downstream_socket_config
+            )
+            self.upstream_socket_pair = ttnn.create_socket_pair(
+                self.mesh_device, self.mesh_device, upstream_socket_config
+            )
+
+    def run(self):
+        dummy_tensor = ttnn.allocate_tensor_on_device(
+            ttnn.Shape([0, 0, 0, 0]), ttnn.uint32, ttnn.ROW_MAJOR_LAYOUT, self.h2d_socket.get_mesh_device()
+        )
+
+        intermed_cb_index = 0
+        h2d_socket_kernel_ct_args = [
+            self.h2d_socket.get_config_buffer_address(),
+            ttnn.get_global_semaphore_address(self.termination_semaphore),
+            self.page_size,
+            self.h2d_socket.get_h2d_mode() == ttnn.H2DMode.DEVICE_PULL,
+            self.loopback_mode,
+            # Use a local CB if doing loopback, otherwise communicate with downstream over sockets
+            intermed_cb_index if self.loopback_mode else self.downstream_socket_pair[0].get_config_buffer_address(),
+        ]
+
+        d2h_socket_kernel_ct_args = [
+            self.d2h_socket.get_config_buffer_address(),
+            ttnn.get_global_semaphore_address(self.termination_semaphore),
+            self.page_size,
+            self.loopback_mode,
+            # Use a local CB if doing loopback, otherwise communicate with downstream over sockets
+            intermed_cb_index if self.loopback_mode else self.upstream_socket_pair[0].get_config_buffer_address(),
+        ]
+
+        h2d_kernel = ttnn.KernelDescriptor(
+            kernel_source="models/demos/deepseek_v3_b1/micro_ops/host_io/kernels/h2d_receiver.cpp",
+            source_type=ttnn.KernelDescriptor.SourceType.FILE_PATH,
+            core_ranges=ttnn.CoreRangeSet(
+                [ttnn.CoreRange(self.mesh_core_coord.core_coord, self.mesh_core_coord.core_coord)]
+            ),
+            compile_time_args=h2d_socket_kernel_ct_args,
+            config=ttnn.WriterConfigDescriptor(),
+        )
+        d2h_kernel = ttnn.KernelDescriptor(
+            kernel_source="models/demos/deepseek_v3_b1/micro_ops/host_io/kernels/d2h_sender.cpp",
+            source_type=ttnn.KernelDescriptor.SourceType.FILE_PATH,
+            core_ranges=ttnn.CoreRangeSet(
+                [ttnn.CoreRange(self.mesh_core_coord.core_coord, self.mesh_core_coord.core_coord)]
+            ),
+            compile_time_args=d2h_socket_kernel_ct_args,
+            config=ttnn.ReaderConfigDescriptor(),
+        )
+        cb_descriptors = []
+        if self.loopback_mode:
+            intermed_cb_desc = ttnn.CBDescriptor(
+                total_size=self.core_to_core_socket_buffer_size,
+                core_ranges=ttnn.CoreRangeSet(
+                    [ttnn.CoreRange(self.mesh_core_coord.core_coord, self.mesh_core_coord.core_coord)]
+                ),
+                format_descriptors=[
+                    ttnn.CBFormatDescriptor(
+                        buffer_index=intermed_cb_index,
+                        data_format=ttnn.uint32,
+                        page_size=self.page_size,
+                    )
+                ],
+            )
+            cb_descriptors.append(intermed_cb_desc)
+        program = ttnn.ProgramDescriptor(
+            kernels=[h2d_kernel, d2h_kernel],
+            semaphores=[],
+            cbs=cb_descriptors,
+        )
+        mesh_program_descriptor = ttnn.MeshProgramDescriptor()
+        mesh_program_descriptor[
+            ttnn.MeshCoordinateRange(self.mesh_core_coord.device_coord, self.mesh_core_coord.device_coord)
+        ] = program
+
+        io_tensors = [
+            dummy_tensor,
+            dummy_tensor,
+        ]
+
+        return ttnn.generic_op(io_tensors, mesh_program_descriptor)
+
+    def terminate(self):
+        self.h2d_socket.barrier()
+        self.d2h_socket.barrier()
+        ttnn.reset_global_semaphore_value(self.termination_semaphore, 1)
+        ttnn.synchronize_device(self.mesh_device)

--- a/models/demos/deepseek_v3_b1/micro_ops/host_io/op.py
+++ b/models/demos/deepseek_v3_b1/micro_ops/host_io/op.py
@@ -59,7 +59,7 @@ class HostInterface:
             raise ValueError("Host <-> Device Communication for Blitz Decode must be on a single core.")
         if h2d_socket.get_active_cores()[0] != d2h_socket.get_active_cores()[0]:
             raise ValueError("Expected Host <-> Device Communication for Blitz Decode to be on the same core.")
-        if h2d_socket.get_mesh_device() != d2h_socket.get_mesh_device():
+        if h2d_socket.get_mesh_device().id() != d2h_socket.get_mesh_device().id():
             raise ValueError("Expected Host <-> Device Communication for Blitz Decode to be on the same mesh device.")
 
         self.mesh_device = h2d_socket.get_mesh_device()

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_host_io.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_host_io.py
@@ -1,0 +1,73 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Tests for HostInterface H2D/D2H socket loopback.
+
+"""
+import pytest
+import torch
+from loguru import logger
+
+import ttnn
+from models.common.utility_functions import is_slow_dispatch
+from models.demos.deepseek_v3_b1.micro_ops.host_io.op import HostInterface
+
+
+@pytest.mark.parametrize(
+    "tensor_size_bytes, fifo_size, num_iterations",
+    [
+        (64, 128, 512),
+        (64, 256, 512),
+        (64, 512, 512),
+        (64, 1024, 512),
+        (512, 1024, 512),
+        (1024, 2048, 128),
+    ],
+)
+@pytest.mark.parametrize(
+    "h2d_mode",
+    [
+        ttnn.H2DMode.HOST_PUSH,
+        ttnn.H2DMode.DEVICE_PULL,
+    ],
+)
+def test_host_io_loopback(mesh_device, tensor_size_bytes, fifo_size, num_iterations, h2d_mode):
+    if not is_slow_dispatch():
+        pytest.skip("Skipping test in fast dispatch mode")
+
+    tensor_size_datums = tensor_size_bytes // 4
+
+    device_coord = ttnn.MeshCoordinate(0, 0)
+    core_coord = ttnn.CoreCoord(0, 0)
+    socket_core = ttnn.MeshCoreCoord(device_coord, core_coord)
+
+    logger.info("Creating and Running Host Interface")
+    h2d_socket = ttnn.H2DSocket(mesh_device, socket_core, ttnn.BufferType.L1, fifo_size, h2d_mode)
+    d2h_socket = ttnn.D2HSocket(mesh_device, socket_core, fifo_size)
+    host_io = HostInterface(
+        h2d_socket, d2h_socket, tensor_size_bytes, core_to_core_socket_buffer_size=fifo_size, loopback_mode=True
+    )
+    host_io.run()
+
+    logger.info(f"Transferring Data Over H <-> D Interface for {num_iterations} iterations")
+    logger.info(f"Tensor Size: {tensor_size_bytes} bytes, FIFO Size: {fifo_size} bytes")
+    logger.info(f"H2D Mode: {h2d_mode}")
+    logger.info(f"FIFO Size: {fifo_size} bytes")
+    for i in range(num_iterations):
+        torch_input = torch.arange(i * tensor_size_datums, (i + 1) * tensor_size_datums, dtype=torch.int32).reshape(
+            1, tensor_size_datums
+        )
+        input_tensor = ttnn.from_torch(torch_input, dtype=ttnn.uint32, layout=ttnn.ROW_MAJOR_LAYOUT)
+        torch_output = torch.zeros(1, tensor_size_datums, dtype=torch.int32)
+        output_tensor = ttnn.from_torch(torch_output, dtype=ttnn.uint32, layout=ttnn.ROW_MAJOR_LAYOUT)
+
+        h2d_socket.write_tensor(input_tensor)
+        d2h_socket.read_tensor(output_tensor)
+
+        result_torch = ttnn.to_torch(output_tensor)
+        match = torch.equal(torch_input, result_torch)
+        assert match, f"H2D → D2H loopback data mismatch!\nExpected: {torch_input}\nGot: {result_torch}"
+
+    host_io.terminate()

--- a/tests/tt_metal/tt_metal/eth/test_basic_eth.cpp
+++ b/tests/tt_metal/tt_metal/eth/test_basic_eth.cpp
@@ -305,6 +305,7 @@ bool noc_reader_and_writer_kernels(
 
     workload.add_program(device_range, std::move(program));
     distributed::EnqueueMeshWorkload(cq, workload, false);
+    distributed::Finish(cq);
 
     auto eth_readback_vec = tt::tt_metal::MetalContext::instance().get_cluster().read_core(
         device->id(), eth_noc_xy, eth_dst_l1_address, byte_size);

--- a/tests/tt_metal/tt_metal/eth/test_erisc_app_direct_send.cpp
+++ b/tests/tt_metal/tt_metal/eth/test_erisc_app_direct_send.cpp
@@ -76,8 +76,8 @@ size_t get_rand_32_byte_aligned_address(const size_t& base, const size_t& max) {
 template <typename FIXTURE>
 bool eth_direct_sender_receiver_kernels(
     FIXTURE* fixture,
-    std::shared_ptr<distributed::MeshDevice> sender_mesh_device,
-    std::shared_ptr<distributed::MeshDevice> receiver_mesh_device,
+    const std::shared_ptr<distributed::MeshDevice>& sender_mesh_device,
+    const std::shared_ptr<distributed::MeshDevice>& receiver_mesh_device,
     const size_t& byte_size,
     const size_t& src_eth_l1_byte_address,
     const size_t& dst_eth_l1_byte_address,
@@ -168,27 +168,13 @@ bool eth_direct_sender_receiver_kernels(
     ////////////////////////////////////////////////////////////////////////////
     //                      Execute Programs
     ////////////////////////////////////////////////////////////////////////////
-    std::thread t1;
-    std::thread t2;
-    if (fixture->IsSlowDispatch()) {
-        sender_workload.add_program(device_range, std::move(sender_program));
-        receiver_workload.add_program(device_range, std::move(receiver_program));
-        t1 = std::thread([&]() { fixture->RunProgram(sender_mesh_device, sender_workload); });
-        t2 = std::thread([&]() { fixture->RunProgram(receiver_mesh_device, receiver_workload); });
-    } else {
-        sender_workload.add_program(device_range, std::move(sender_program));
-        receiver_workload.add_program(device_range, std::move(receiver_program));
-        fixture->RunProgram(sender_mesh_device, sender_workload, true);
-        fixture->RunProgram(receiver_mesh_device, receiver_workload, true);
-    }
+    sender_workload.add_program(device_range, std::move(sender_program));
+    receiver_workload.add_program(device_range, std::move(receiver_program));
+    fixture->RunProgram(sender_mesh_device, sender_workload, true);
+    fixture->RunProgram(receiver_mesh_device, receiver_workload, true);
 
     fixture->FinishCommands(sender_mesh_device);
     fixture->FinishCommands(receiver_mesh_device);
-
-    if (fixture->IsSlowDispatch()) {
-        t1.join();
-        t2.join();
-    }
 
     auto readback_vec = tt::tt_metal::MetalContext::instance().get_cluster().read_core(
         receiver_device->id(),

--- a/tt_metal/api/tt-metalium/experimental/sockets/d2h_socket.hpp
+++ b/tt_metal/api/tt-metalium/experimental/sockets/d2h_socket.hpp
@@ -142,6 +142,10 @@ public:
      */
     void barrier(std::optional<uint32_t> timeout_ms = std::nullopt);
 
+    std::vector<MeshCoreCoord> get_active_cores() const;
+
+    MeshDevice* get_mesh_device() const;
+
 private:
     // Helper struct for pinned buffer NOC address info
     struct PinnedBufferInfo {

--- a/tt_metal/api/tt-metalium/experimental/sockets/h2d_socket.hpp
+++ b/tt_metal/api/tt-metalium/experimental/sockets/h2d_socket.hpp
@@ -119,6 +119,12 @@ public:
      */
     void barrier(std::optional<uint32_t> timeout_ms = std::nullopt);
 
+    std::vector<MeshCoreCoord> get_active_cores() const;
+
+    MeshDevice* get_mesh_device() const;
+
+    H2DMode get_h2d_mode() const;
+
 private:
     // Helper struct for pinned buffer NOC address info
     struct PinnedBufferInfo {

--- a/tt_metal/distributed/d2h_socket.cpp
+++ b/tt_metal/distributed/d2h_socket.cpp
@@ -259,4 +259,8 @@ void D2HSocket::read(void* data, uint32_t num_pages, bool notify_sender) {
     }
 }
 
+std::vector<MeshCoreCoord> D2HSocket::get_active_cores() const { return {sender_core_}; }
+
+MeshDevice* D2HSocket::get_mesh_device() const { return config_buffer_->device(); }
+
 }  // namespace tt::tt_metal::distributed

--- a/tt_metal/distributed/h2d_socket.cpp
+++ b/tt_metal/distributed/h2d_socket.cpp
@@ -321,4 +321,10 @@ void H2DSocket::write(void* data, uint32_t num_pages) {
     this->notify_receiver();
 }
 
+std::vector<MeshCoreCoord> H2DSocket::get_active_cores() const { return {recv_core_}; }
+
+MeshDevice* H2DSocket::get_mesh_device() const { return config_buffer_->device(); }
+
+H2DMode H2DSocket::get_h2d_mode() const { return h2d_mode_; }
+
 }  // namespace tt::tt_metal::distributed

--- a/tt_metal/distributed/pinned_memory.cpp
+++ b/tt_metal/distributed/pinned_memory.cpp
@@ -190,7 +190,7 @@ std::optional<PinnedMemory::NocAddr> PinnedMemoryImpl::get_noc_addr(ChipId devic
         return std::nullopt;
     }
     const auto& soc = tt::tt_metal::MetalContext::instance().get_cluster().get_soc_desc(mmio_device_id);
-    const auto& pcie_cores = soc.get_cores(CoreType::PCIE, CoordSystem::NOC0);
+    const auto& pcie_cores = soc.get_cores(CoreType::PCIE, CoordSystem::TRANSLATED);
     TT_ASSERT(!pcie_cores.empty());
     auto pcie_xy = pcie_cores.front();
     uint32_t pcie_xy_enc = tt::tt_metal::MetalContext::instance().hal().noc_xy_pcie64_encoding(pcie_xy.x, pcie_xy.y);

--- a/tt_metal/distributed/sd_mesh_command_queue.cpp
+++ b/tt_metal/distributed/sd_mesh_command_queue.cpp
@@ -5,6 +5,7 @@
 #include "sd_mesh_command_queue.hpp"
 #include "impl/context/metal_context.hpp"
 #include "tt_metal/common/thread_pool.hpp"
+#include "tt_metal/impl/program/program_impl.hpp"
 #include <mesh_device.hpp>
 #include <mesh_event.hpp>
 #include <tt-metalium/experimental/fabric/control_plane.hpp>
@@ -63,7 +64,7 @@ void SDMeshCommandQueue::read_shard_from_device(
     if (tt::tt_metal::MetalContext::instance().get_cluster().get_target_device_type() == tt::TargetDevice::Mock) {
         return;  // Skip hardware read for mock devices
     }
-
+    wait_for_cores_idle();
     auto* device_buffer = buffer.get_device_buffer(device_coord);
     auto shard_view = device_buffer->view(region.value_or(BufferRegion(0, device_buffer->size())));
 

--- a/tt_metal/distributed/sd_mesh_command_queue.cpp
+++ b/tt_metal/distributed/sd_mesh_command_queue.cpp
@@ -12,6 +12,7 @@
 #include <tt-metalium/graph_tracking.hpp>
 #include <utility>
 #include <llrt/tt_cluster.hpp>
+#include <llrt/llrt.hpp>
 #include <distributed/mesh_device_impl.hpp>
 
 namespace tt::tt_metal::distributed {
@@ -80,6 +81,15 @@ WorkerConfigBufferMgr& SDMeshCommandQueue::get_config_buffer_mgr(uint32_t /*inde
     TT_THROW("Not supported for slow dispatch");
 }
 
+void SDMeshCommandQueue::wait_for_cores_idle() {
+    if (!logical_cores_for_previous_workload_.empty()) {
+        for (const auto& [device_id, logical_cores] : logical_cores_for_previous_workload_) {
+            tt::llrt::internal_::wait_for_idle(device_id, logical_cores);
+        }
+        logical_cores_for_previous_workload_.clear();
+    }
+}
+
 void SDMeshCommandQueue::enqueue_mesh_workload(MeshWorkload& mesh_workload, bool blocking) {
     if (tt::tt_metal::MetalContext::instance().get_cluster().get_target_device_type() == tt::TargetDevice::Mock) {
         return;  // Skip workload execution for mock devices
@@ -90,6 +100,7 @@ void SDMeshCommandQueue::enqueue_mesh_workload(MeshWorkload& mesh_workload, bool
         log_debug(
             tt::LogMetal, "Using Slow Dispatch for {}. This leads to blocking workload execution.", __FUNCTION__);
     }
+    wait_for_cores_idle();
     for (auto& [coord_range, program] : mesh_workload.get_programs()) {
         for (const auto& coord : coord_range) {
             if (mesh_device_->impl().is_local(coord)) {
@@ -98,11 +109,16 @@ void SDMeshCommandQueue::enqueue_mesh_workload(MeshWorkload& mesh_workload, bool
             }
         }
     }
+
     for (auto& [coord_range, program] : mesh_workload.get_programs()) {
         for (const auto& coord : coord_range) {
             if (mesh_device_->impl().is_local(coord)) {
                 auto* device = mesh_device_->impl().get_device(coord);
-                tt_metal::detail::WaitProgramDone(device, program);
+                if (blocking) {
+                    tt_metal::detail::WaitProgramDone(device, program);
+                } else {
+                    logical_cores_for_previous_workload_[device->id()] = program.impl().logical_cores();
+                }
             }
         }
     }
@@ -132,7 +148,7 @@ void SDMeshCommandQueue::finish(tt::stl::Span<const SubDeviceId>) {
     if (tt::tt_metal::MetalContext::instance().get_cluster().get_target_device_type() == tt::TargetDevice::Mock) {
         return;
     }
-
+    wait_for_cores_idle();
     for (const auto& device : mesh_device_->get_devices()) {
         tt::tt_metal::MetalContext::instance().get_cluster().dram_barrier(device->id());
         tt::tt_metal::MetalContext::instance().get_cluster().l1_barrier(device->id());

--- a/tt_metal/distributed/sd_mesh_command_queue.hpp
+++ b/tt_metal/distributed/sd_mesh_command_queue.hpp
@@ -57,6 +57,11 @@ public:
     void record_begin(const MeshTraceId& trace_id, const std::shared_ptr<MeshTraceDescriptor>& ctx) override;
     void record_end() override;
     void enqueue_trace(const MeshTraceId& trace_id, bool blocking) override;
+
+private:
+    void wait_for_cores_idle();
+
+    std::unordered_map<ChipId, std::vector<std::vector<CoreCoord>>> logical_cores_for_previous_workload_;
 };
 
 }  // namespace tt::tt_metal::distributed

--- a/tt_metal/hw/inc/api/socket_api.h
+++ b/tt_metal/hw/inc/api/socket_api.h
@@ -291,6 +291,7 @@ bool socket_wait_for_pages(
     } while (bytes_recv < num_bytes);
     return true;
 #endif
+    return true;
 }
 
 void socket_pop_pages(SocketReceiverInterface& socket, uint32_t num_pages) {

--- a/tt_metal/llrt/llrt.hpp
+++ b/tt_metal/llrt/llrt.hpp
@@ -66,6 +66,8 @@ namespace internal_ {
 void wait_until_cores_done(
     ChipId device_id, int run_state, std::unordered_set<CoreCoord>& not_done_phys_cores, int timeout_ms = 0);
 
+void wait_for_idle(ChipId device_id, const std::vector<std::vector<CoreCoord>>& logical_cores);
+
 // Send a message to the ethernet firmware mailbox, if supported
 // Possible message types can be queried from the Hal. See tt::tt_metal::FWMailboxMsg
 // Maximum number of args depends on the architecture. Args not provided will be set to zero.

--- a/tt_metal/tt_metal.cpp
+++ b/tt_metal/tt_metal.cpp
@@ -796,17 +796,7 @@ void LaunchProgram(IDevice* device, Program& program, bool wait_until_cores_done
 void WaitProgramDone(IDevice* device, Program& program, bool read_device_profiler_results) {
     auto device_id = device->id();
     std::vector<std::vector<CoreCoord>> logical_cores_used_in_program = program.impl().logical_cores();
-    std::unordered_set<CoreCoord> not_done_cores;
-    const auto& hal = MetalContext::instance().hal();
-    for (uint32_t index = 0; index < hal.get_programmable_core_type_count(); index++) {
-        const auto& logical_cores = logical_cores_used_in_program[index];
-        CoreType core_type = hal.get_core_type(index);
-        for (const auto& logical_core : logical_cores) {
-            auto physical_core = device->virtual_core_from_logical_core(logical_core, core_type);
-            not_done_cores.insert(physical_core);
-        }
-    }
-    llrt::internal_::wait_until_cores_done(device_id, dev_msgs::RUN_MSG_GO, not_done_cores);
+    llrt::internal_::wait_for_idle(device_id, logical_cores_used_in_program);
     if (read_device_profiler_results) {
         detail::ReadDeviceProfilerResults(device);
     }

--- a/ttnn/CMakeLists.txt
+++ b/ttnn/CMakeLists.txt
@@ -468,6 +468,7 @@ list(
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn-nanobind/fabric.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn-nanobind/global_circular_buffer.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn-nanobind/global_semaphore.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn-nanobind/hd_socket.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn-nanobind/mesh_socket.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn-nanobind/profiler.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn-nanobind/program_descriptors.cpp

--- a/ttnn/cpp/ttnn-nanobind/__init__.cpp
+++ b/ttnn/cpp/ttnn-nanobind/__init__.cpp
@@ -16,6 +16,7 @@
 #include "ttnn-nanobind/fabric.hpp"
 #include "ttnn-nanobind/global_circular_buffer.hpp"
 #include "ttnn-nanobind/global_semaphore.hpp"
+#include "ttnn-nanobind/hd_socket.hpp"
 #include "ttnn-nanobind/mesh_socket.hpp"
 #include "ttnn-nanobind/operations/copy.hpp"
 #include "ttnn-nanobind/operations/core.hpp"
@@ -236,6 +237,7 @@ NB_MODULE(_ttnn, mod) {
     auto m_events = mod.def_submodule("events", "ttnn events");
     auto m_global_circular_buffer = mod.def_submodule("global_circular_buffer", "ttnn global circular buffer");
     auto m_global_semaphore = mod.def_submodule("global_semaphore", "ttnn global semaphore");
+    auto m_hd_socket = mod.def_submodule("hd_socket", "ttnn host-device sockets");
     auto m_mesh_socket = mod.def_submodule("mesh_socket", "ttnn mesh socket");
     auto m_profiler = mod.def_submodule("profiler", "Submodule defining the profiler");
     auto m_reports = mod.def_submodule("reports", "ttnn reports");
@@ -259,6 +261,7 @@ NB_MODULE(_ttnn, mod) {
     ttnn::events::py_module_types(m_events);
     ttnn::global_circular_buffer::py_module_types(m_global_circular_buffer);
     ttnn::global_semaphore::py_module_types(m_global_semaphore);
+    ttnn::hd_socket::py_module_types(m_hd_socket);
     ttnn::mesh_socket::py_module_types(m_mesh_socket);
     ttnn::reports::py_module_types(m_reports);
     ttnn::program_descriptors::py_module_types(m_program_descriptors);
@@ -292,6 +295,7 @@ NB_MODULE(_ttnn, mod) {
     ttnn::events::py_module(m_events);
     ttnn::global_circular_buffer::py_module(m_global_circular_buffer);
     ttnn::global_semaphore::py_module(m_global_semaphore);
+    ttnn::hd_socket::py_module(m_hd_socket);
     ttnn::mesh_socket::py_module(m_mesh_socket);
     ttnn::profiler::py_module(m_profiler);
     ttnn::reports::py_module(m_reports);

--- a/ttnn/cpp/ttnn-nanobind/hd_socket.cpp
+++ b/ttnn/cpp/ttnn-nanobind/hd_socket.cpp
@@ -108,11 +108,6 @@ void py_module_types(nb::module_& mod) {
                     "write_tensor: tensor data size ({}) is not a multiple of page_size ({})",
                     data_span.size(),
                     page_size);
-                TT_FATAL(
-                    data_span.size() % page_size == 0,
-                    "write_tensor: tensor data size ({}) is not a multiple of socket page_size ({})",
-                    data_span.size(),
-                    page_size);
                 uint32_t num_writes = data_span.size() / page_size;
                 for (uint32_t i = 0; i < num_writes; i++) {
                     self.write(data_span.data() + (i * page_size), 1);

--- a/ttnn/cpp/ttnn-nanobind/hd_socket.cpp
+++ b/ttnn/cpp/ttnn-nanobind/hd_socket.cpp
@@ -1,0 +1,297 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "hd_socket.hpp"
+
+#include <cstdint>
+#include <optional>
+
+#include <nanobind/nanobind.h>
+#include <nanobind/stl/optional.h>
+#include <nanobind/stl/shared_ptr.h>
+#include <nanobind/stl/vector.h>
+
+#include <tt-metalium/experimental/sockets/h2d_socket.hpp>
+#include <tt-metalium/experimental/sockets/d2h_socket.hpp>
+
+#include "ttnn/tensor/tensor.hpp"
+#include "ttnn/tensor/host_buffer/functions.hpp"
+
+namespace ttnn::hd_socket {
+
+void py_module_types(nb::module_& mod) {
+    nb::enum_<tt::tt_metal::distributed::H2DMode>(mod, "H2DMode")
+        .value(
+            "HOST_PUSH",
+            tt::tt_metal::distributed::H2DMode::HOST_PUSH,
+            "Host pushes data to device via UMD TLB writes.")
+        .value(
+            "DEVICE_PULL",
+            tt::tt_metal::distributed::H2DMode::DEVICE_PULL,
+            "Device pulls data from pinned host memory via PCIe NOC reads.");
+
+    nb::class_<tt::tt_metal::distributed::H2DSocket>(mod, "H2DSocket")
+        .def(
+            nb::init<
+                const std::shared_ptr<tt::tt_metal::distributed::MeshDevice>&,
+                const tt::tt_metal::distributed::MeshCoreCoord&,
+                tt::tt_metal::BufferType,
+                uint32_t,
+                tt::tt_metal::distributed::H2DMode>(),
+            nb::arg("mesh_device"),
+            nb::arg("recv_core"),
+            nb::arg("buffer_type"),
+            nb::arg("fifo_size"),
+            nb::arg("h2d_mode"),
+            R"doc(
+                Construct an H2DSocket for streaming data from host to a device core.
+
+                Args:
+                    mesh_device (MeshDevice): The mesh device containing the target core.
+                    recv_core (MeshCoreCoord): The target core coordinate to receive data.
+                    buffer_type (BufferType): Memory type for the device-side FIFO buffer (L1 or DRAM).
+                    fifo_size (int): Size of the circular FIFO buffer in bytes. Must be PCIe-aligned.
+                    h2d_mode (H2DMode): Transfer mode: HOST_PUSH or DEVICE_PULL.
+            )doc")
+        .def(
+            "get_page_size",
+            &tt::tt_metal::distributed::H2DSocket::get_page_size,
+            R"doc(
+                Returns the currently configured page size.
+            )doc")
+        .def(
+            "get_config_buffer_address",
+            &tt::tt_metal::distributed::H2DSocket::get_config_buffer_address,
+            R"doc(
+                Returns the L1 address of the socket configuration buffer on the device.
+                This address is passed to the device kernel to access socket metadata.
+            )doc")
+        .def(
+            "set_page_size",
+            &tt::tt_metal::distributed::H2DSocket::set_page_size,
+            nb::arg("page_size"),
+            R"doc(
+                Sets the page size for subsequent write operations.
+
+                Args:
+                    page_size (int): Page size in bytes. Must be PCIe-aligned.
+            )doc")
+        .def(
+            "write",
+            &tt::tt_metal::distributed::H2DSocket::write,
+            nb::arg("data"),
+            nb::arg("num_pages"),
+            R"doc(
+                Writes data pages to the socket FIFO.
+
+                Blocks if the FIFO does not have enough space, waiting for the device to
+                acknowledge previously written data.
+
+                Args:
+                    data (int): Pointer to the source data buffer (as an integer address).
+                    num_pages (int): Number of pages to write.
+            )doc")
+        .def(
+            "write_tensor",
+            [](tt::tt_metal::distributed::H2DSocket& self, tt::tt_metal::Tensor& tensor) {
+                TT_FATAL(
+                    tensor.storage_type() == tt::tt_metal::StorageType::HOST,
+                    "write_tensor: tensor must be on host (HostStorage)");
+
+                auto host_buffer = tt::tt_metal::host_buffer::get_host_buffer(tensor);
+                auto data_span = host_buffer.view_bytes();
+                uint32_t page_size = self.get_page_size();
+                TT_FATAL(page_size > 0, "write_tensor: page_size must be set before calling write_tensor");
+                TT_FATAL(
+                    data_span.size() % page_size == 0,
+                    "write_tensor: tensor data size ({}) is not a multiple of page_size ({})",
+                    data_span.size(),
+                    page_size);
+                TT_FATAL(
+                    data_span.size() % page_size == 0,
+                    "write_tensor: tensor data size ({}) is not a multiple of socket page_size ({})",
+                    data_span.size(),
+                    page_size);
+                uint32_t num_writes = data_span.size() / page_size;
+                for (uint32_t i = 0; i < num_writes; i++) {
+                    self.write(data_span.data() + i * page_size, 1);
+                }
+            },
+            nb::arg("tensor"),
+            R"doc(
+                Writes a host tensor's data to the socket FIFO.
+
+                The tensor must be on host (HostStorage). The page size must be set
+                via set_page_size() before calling this method. The tensor's data size
+                must be an exact multiple of the page size.
+
+                Args:
+                    tensor (Tensor): A host-resident tensor whose data will be written to the socket.
+            )doc")
+        .def(
+            "barrier",
+            &tt::tt_metal::distributed::H2DSocket::barrier,
+            nb::arg("timeout_ms") = nb::none(),
+            R"doc(
+                Blocks until the device has acknowledged all written data.
+
+                Args:
+                    timeout_ms (int, optional): Timeout in milliseconds. Throws if not met within timeout.
+            )doc")
+        .def(
+            "get_active_cores",
+            &tt::tt_metal::distributed::H2DSocket::get_active_cores,
+            R"doc(
+                Returns the list of active MeshCoreCoords used by this socket.
+
+                Returns:
+                    List[MeshCoreCoord]: The active core coordinates.
+            )doc")
+        .def(
+            "get_mesh_device",
+            &tt::tt_metal::distributed::H2DSocket::get_mesh_device,
+            R"doc(
+                Returns the MeshDevice associated with this socket.
+
+                Returns:
+                    MeshDevice: The mesh device this socket is bound to.
+            )doc")
+        .def(
+            "get_h2d_mode",
+            &tt::tt_metal::distributed::H2DSocket::get_h2d_mode,
+            R"doc(
+                Returns the H2D transfer mode of this socket.
+
+                Returns:
+                    H2DMode: The transfer mode (HOST_PUSH or DEVICE_PULL).
+            )doc");
+
+    nb::class_<tt::tt_metal::distributed::D2HSocket>(mod, "D2HSocket")
+        .def(
+            nb::init<
+                const std::shared_ptr<tt::tt_metal::distributed::MeshDevice>&,
+                const tt::tt_metal::distributed::MeshCoreCoord&,
+                uint32_t>(),
+            nb::arg("mesh_device"),
+            nb::arg("sender_core"),
+            nb::arg("fifo_size"),
+            R"doc(
+                Construct a D2HSocket for streaming data from a device core to host.
+
+                Args:
+                    mesh_device (MeshDevice): The mesh device containing the sender core.
+                    sender_core (MeshCoreCoord): The source core coordinate that sends data.
+                    fifo_size (int): Size of the circular FIFO buffer in bytes. Must be PCIe-aligned.
+            )doc")
+        .def(
+            "get_page_size",
+            &tt::tt_metal::distributed::D2HSocket::get_page_size,
+            R"doc(
+                Returns the currently configured page size.
+            )doc")
+        .def(
+            "get_config_buffer_address",
+            &tt::tt_metal::distributed::D2HSocket::get_config_buffer_address,
+            R"doc(
+                Returns the L1 address of the socket configuration buffer on the device.
+                This address should be passed to the device kernel so it can create a
+                sender socket interface.
+            )doc")
+        .def(
+            "set_page_size",
+            &tt::tt_metal::distributed::D2HSocket::set_page_size,
+            nb::arg("page_size"),
+            R"doc(
+                Sets the page size for subsequent read operations.
+
+                Args:
+                    page_size (int): Page size in bytes. Must be PCIe-aligned.
+            )doc")
+        .def(
+            "read",
+            &tt::tt_metal::distributed::D2HSocket::read,
+            nb::arg("data"),
+            nb::arg("num_pages"),
+            nb::arg("notify_sender") = true,
+            R"doc(
+                Reads data pages from the socket FIFO.
+
+                Blocks until the requested number of pages are available.
+
+                Args:
+                    data (int): Pointer to the destination buffer (as an integer address).
+                    num_pages (int): Number of pages to read.
+                    notify_sender (bool): If True, updates bytes_acked on the device to signal
+                                          that buffer space is available. Default: True.
+            )doc")
+        .def(
+            "read_tensor",
+            [](tt::tt_metal::distributed::D2HSocket& self, tt::tt_metal::Tensor& tensor, bool notify_sender) {
+                TT_FATAL(
+                    tensor.storage_type() == tt::tt_metal::StorageType::HOST,
+                    "read_tensor: tensor must be on host (HostStorage)");
+
+                auto host_buffer = tt::tt_metal::host_buffer::get_host_buffer(tensor);
+                auto data_span = host_buffer.view_bytes();
+                uint32_t page_size = self.get_page_size();
+                TT_FATAL(page_size > 0, "read_tensor: page_size must be set before calling read_tensor");
+                TT_FATAL(
+                    data_span.size() % page_size == 0,
+                    "read_tensor: tensor data size ({}) is not a multiple of page_size ({})",
+                    data_span.size(),
+                    page_size);
+                uint32_t num_pages = data_span.size() / page_size;
+                self.read(data_span.data(), num_pages, notify_sender);
+            },
+            nb::arg("tensor"),
+            nb::arg("notify_sender") = true,
+            R"doc(
+                Reads data from the socket FIFO into a host tensor.
+
+                The tensor must be on host (HostStorage) and pre-allocated with the
+                correct size. The page size must be set via set_page_size() before
+                calling this method. The tensor's data size must be an exact multiple
+                of the page size.
+
+                Args:
+                    tensor (Tensor): A pre-allocated host-resident tensor to read data into.
+                    notify_sender (bool): If True, updates bytes_acked on the device to signal
+                                          that buffer space is available. Default: True.
+            )doc")
+        .def(
+            "barrier",
+            &tt::tt_metal::distributed::D2HSocket::barrier,
+            nb::arg("timeout_ms") = nb::none(),
+            R"doc(
+                Blocks until all sent data has been acknowledged.
+
+                Args:
+                    timeout_ms (int, optional): Timeout in milliseconds. Throws if not met within timeout.
+            )doc")
+        .def(
+            "get_active_cores",
+            &tt::tt_metal::distributed::D2HSocket::get_active_cores,
+            R"doc(
+                Returns the list of active MeshCoreCoords used by this socket.
+
+                Returns:
+                    List[MeshCoreCoord]: The active core coordinates.
+            )doc")
+        .def(
+            "get_mesh_device",
+            &tt::tt_metal::distributed::D2HSocket::get_mesh_device,
+            R"doc(
+                Returns the MeshDevice associated with this socket.
+
+                Returns:
+                    MeshDevice: The mesh device this socket is bound to.
+            )doc");
+}
+
+void py_module(nb::module_& /* mod */) {
+    // No free functions to bind currently.
+    // H2DSocket and D2HSocket are fully bound via py_module_types.
+}
+
+}  // namespace ttnn::hd_socket

--- a/ttnn/cpp/ttnn-nanobind/hd_socket.cpp
+++ b/ttnn/cpp/ttnn-nanobind/hd_socket.cpp
@@ -115,7 +115,7 @@ void py_module_types(nb::module_& mod) {
                     page_size);
                 uint32_t num_writes = data_span.size() / page_size;
                 for (uint32_t i = 0; i < num_writes; i++) {
-                    self.write(data_span.data() + i * page_size, 1);
+                    self.write(data_span.data() + (i * page_size), 1);
                 }
             },
             nb::arg("tensor"),

--- a/ttnn/cpp/ttnn-nanobind/hd_socket.hpp
+++ b/ttnn/cpp/ttnn-nanobind/hd_socket.hpp
@@ -1,0 +1,14 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ttnn-nanobind/nanobind_fwd.hpp"
+
+namespace ttnn::hd_socket {
+namespace nb = nanobind;
+void py_module_types(nb::module_& mod);
+void py_module(nb::module_& mod);
+
+}  // namespace ttnn::hd_socket

--- a/ttnn/cpp/ttnn-nanobind/mesh_socket.cpp
+++ b/ttnn/cpp/ttnn-nanobind/mesh_socket.cpp
@@ -29,7 +29,25 @@ void py_module_types(nb::module_& mod) {
                 Args:
                     device_coord (MeshCoordinate): The device coordinate of the core
                     core_coord (CoreCoord): The core coordinate of the core
-            )doc");
+                )doc")
+        .def_rw("device_coord", &tt::tt_metal::distributed::MeshCoreCoord::device_coord, "Device coordinate")
+        .def_rw("core_coord", &tt::tt_metal::distributed::MeshCoreCoord::core_coord, "Core coordinate")
+        .def(
+            "__eq__",
+            [](const tt::tt_metal::distributed::MeshCoreCoord& a, const tt::tt_metal::distributed::MeshCoreCoord& b) {
+                return a == b;
+            })
+        .def(
+            "__ne__",
+            [](const tt::tt_metal::distributed::MeshCoreCoord& a, const tt::tt_metal::distributed::MeshCoreCoord& b) {
+                return a != b;
+            })
+        .def("__repr__", [](const tt::tt_metal::distributed::MeshCoreCoord& mcc) {
+            std::stringstream ss;
+            ss << "MeshCoreCoord(device=" << mcc.device_coord << ", core=(" << mcc.core_coord.x << ","
+               << mcc.core_coord.y << "))";
+            return ss.str();
+        });
     nb::class_<tt::tt_metal::distributed::SocketConnection>(mod, "SocketConnection")
         .def(
             nb::init<tt::tt_metal::distributed::MeshCoreCoord, tt::tt_metal::distributed::MeshCoreCoord>(),

--- a/ttnn/ttnn/__init__.py
+++ b/ttnn/ttnn/__init__.py
@@ -186,6 +186,12 @@ from ttnn._ttnn.mesh_socket import (
     MeshCoreCoord,
 )
 
+from ttnn._ttnn.hd_socket import (
+    H2DSocket,
+    D2HSocket,
+    H2DMode,
+)
+
 from ttnn.types import (
     TILE_SIZE,
     DataType,


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
- We're missing infra for fusing H <-> D management kernels into the op infra being built for Deepseek Blitz
- These kernels are meant to run with the entire workload and manage H <-> D pipelining
- Additionally Program loading and execution via Slow Dispatch is completely synchronous. This specific workload needs a "fire-and-forget" mode, where:
- Kernels are loaded once at the start
- Host is freed up to perform IO
- Kernels are manually torn down at the end via a terminate command

### What's changed
**`HostInterface` added to DeepSeek Op Infra**
- Added a Python interface in `models/demos/deepseek_v3_b1/micro_ops/host_io/` to manage Host IO through dedicated kernels.
- Setup: Create `H2D` and `D2H` sockets, configures page sizes, and allocates a termination semaphore
- Execution: Launch H2D receiver and D2H sender kernels on a single core using `ttnn.generic_op`
- Termination: Set termination semaphore and synchronize with device to ensure a graceful shutdown

**Runtime Changes**
- Minor change to `PinnedMemory` to return Translated PCIe NOC encodings, instead of `NOC0` encodings. This allows kernels to use both NOCs to interface with host
- `SDMeshCommandQueue::enqueue_mesh_workload` now supports non-blocking execution. Main change here is to ensure that the API waits for cores to be idle before enqueueing the "next" workload.

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=asaigal/h2d_op)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:asaigal/h2d_op)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=asaigal/h2d_op)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:asaigal/h2d_op)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=asaigal/h2d_op)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:asaigal/h2d_op)
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=asaigal/h2d_op)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:asaigal/h2d_op)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=asaigal/h2d_op)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:asaigal/h2d_op)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=asaigal/h2d_op)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:asaigal/h2d_op)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
