### PR TITLE
Fix nanobind circular reference by defining MeshDevice.core_grid in c++

### DIFF
--- a/ttnn/core/distributed/distributed_nanobind.cpp
+++ b/ttnn/core/distributed/distributed_nanobind.cpp
@@ -32,6 +32,7 @@
 #include <tt-metalium/system_mesh.hpp>
 #include <tt-metalium/maybe_remote.hpp>
 #include <tt-metalium/distributed_host_buffer.hpp>
+#include <ttnn/api/ttnn/types.hpp>
 #include "ttnn/distributed/distributed_tensor.hpp"
 #include "ttnn/distributed/api.hpp"
 #include "ttnn/distributed/types.hpp"
@@ -291,6 +292,12 @@ void py_module(nb::module_& mod) {
            Returns:
                CoreCoord: The compute grid size of the first device in the device mesh.
        )doc")
+        .def_prop_ro(
+          "core_grid",
+          [](const MeshDevice& device) {
+            const auto& sz = device.compute_with_storage_grid_size();
+            return ttnn::CoreGrid(sz.x, sz.y);
+          })
         .def(
             "dram_grid_size",
             &MeshDevice::dram_grid_size,

--- a/ttnn/ttnn/device.py
+++ b/ttnn/ttnn/device.py
@@ -10,14 +10,8 @@ import ttnn
 from loguru import logger
 
 
-def get_device_core_grid(device):
-    compute_with_storage_grid_size = device.compute_with_storage_grid_size()
-    return ttnn.types.CoreGrid(y=compute_with_storage_grid_size.y, x=compute_with_storage_grid_size.x)
-
-
 # TODO: Device = ttnn._ttnn.Device
 Device = ttnn._ttnn.multi_device.MeshDevice
-Device.core_grid = property(get_device_core_grid)
 DispatchCoreType = ttnn._ttnn.device.DispatchCoreType
 DispatchCoreAxis = ttnn._ttnn.device.DispatchCoreAxis
 Arch = ttnn._ttnn.device.Arch

--- a/ttnn/ttnn/distributed/distributed.py
+++ b/ttnn/ttnn/distributed/distributed.py
@@ -10,13 +10,7 @@ from typing import List, Dict, Optional, Callable, Tuple, Optional, Callable, Un
 import ttnn
 
 
-def get_mesh_device_core_grid(mesh_device):
-    compute_with_storage_grid_size = mesh_device.compute_with_storage_grid_size()
-    return ttnn.CoreGrid(y=compute_with_storage_grid_size.y, x=compute_with_storage_grid_size.x)
-
-
 MeshDevice = ttnn._ttnn.multi_device.MeshDevice
-MeshDevice.core_grid = property(get_mesh_device_core_grid)
 DispatchCoreType = ttnn._ttnn.device.DispatchCoreType
 
 


### PR DESCRIPTION
### Problem description
When quitting a script that uses ttnn I get a bunch of nanobind spam complaining about reference leaks.

I tracked this down to MeshDevice.core_grid being assigned with function pointers defined in python. Since these functions capture globals, and ttnn._ttnn is in globals, this forms a circular reference (MeshDevice -> core_grid impl -> globals -> MeshDevice). 

This can be fixed with: 
1. MeshDevice implements `Py_tp_traverse`/`Py_tp_clear` to allow python runtime to traverse MeshDevice object and get the python object references inside.
2. Don't define core_grid in python.

### What's changed
I went with option 2 and defined `core_grid` in c++ instead, and deleted the python implementations.

I verified that calling device.core_grid still gives me a ttnn.CoreGrid object 

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:{{branch_name}})
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:{{branch_name}})
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:{{branch_name}})
- [ ] New/Existing tests provide coverage for changes

