### PR TITLE
Update compute kernel API to reflect new changes to fast tilize

### DIFF
--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_math_unary_datacopy_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_math_unary_datacopy_api.h
@@ -76,5 +76,7 @@ inline void llk_math_fast_tilize_block_(
     const std::uint32_t unit_dim,
     const std::uint32_t num_units) {
     const std::uint32_t operand_id = get_operand_id(operand);
-    _llk_math_fast_tilize_block_(dst_index, unpack_dst_format[operand_id], unit_dim, num_units);
+    const std::uint32_t num_faces = get_operand_num_faces(operand_id);
+
+    _llk_math_fast_tilize_block_(dst_index, unpack_dst_format[operand_id], unit_dim, num_units, num_faces);
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_pack_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_pack_api.h
@@ -272,9 +272,11 @@ inline void llk_pack_fast_tilize_init(
     const std::uint32_t input_operand, const std::uint32_t pack_output, const std::uint32_t unit_dim) {
     const std::uint8_t input_id = get_output_id(input_operand);
     const std::uint8_t output_id = get_output_id(pack_output);
+    const std::uint32_t num_faces = get_output_num_faces(output_id);
+
     const uint32_t use_32bit_dest =
         pack_src_format[input_id] == (uint)DataFormat::Float32 || pack_src_format[input_id] == (uint)DataFormat::Tf32;
-    _llk_pack_fast_tilize_init_<DST_SYNC_MODE>(use_32bit_dest, pack_dst_format[output_id], unit_dim);
+    _llk_pack_fast_tilize_init_<DST_SYNC_MODE>(use_32bit_dest, pack_dst_format[output_id], unit_dim, num_faces);
 }
 
 template <bool is_fp32_dest_acc_en>
@@ -296,10 +298,11 @@ inline void llk_pack_fast_tilize_block(
     const std::uint32_t unit_dim,
     const std::uint32_t num_units) {
     const std::uint8_t output_id = get_output_id(output);
+    const std::uint32_t num_faces = get_output_num_faces(output_id);
 
     const std::uint32_t pack_tile_addr = get_output_tile_address<true, false>(output_id, output_tile_index);
 
-    _llk_pack_fast_tilize_block_(tile_index, pack_tile_addr, unit_dim, num_units);
+    _llk_pack_fast_tilize_block_(tile_index, pack_tile_addr, unit_dim, num_units, num_faces);
 }
 
 /*************************************************************************

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_tilize_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_tilize_api.h
@@ -178,10 +178,11 @@ inline void llk_unpack_fast_tilize_block(
     const std::uint32_t num_units,
     const std::uint32_t full_dim) {
     const std::uint32_t operand_id = get_operand_id(operand);
+    const std::uint32_t num_faces = get_operand_num_faces(operand_id);
     const std::uint32_t base_address = get_local_cb_interface(operand_id).fifo_rd_ptr - 1;
 
     _llk_unpack_fast_tilize_block_(
-        base_address, tile_index, unpack_src_format[operand_id], unit_dim, num_units, full_dim);
+        base_address, tile_index, unpack_src_format[operand_id], unit_dim, num_units, full_dim, num_faces);
 }
 
 inline void llk_unpack_tilizeA_B_uninit(const std::uint32_t operand) {


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/35770

Waiting on LLK change: https://github.com/tenstorrent/tt-llk/pull/1280

### Problem description
WH fast tilize does not support tiny tiles. Need to implement 16x32 version

### What's changed
Update compute kernel API to enable usage of new 16x32 functionality on WH fast tilize

### Checklist

- [x] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=pgardner/api-fast-tilize-16x32)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:pgardner/api-fast-tilize-16x32)
- [x] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=pgardner/api-fast-tilize-16x32)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:pgardner/api-fast-tilize-16x32)
- [x] New/Existing tests provide coverage for changes