### PR TITLE
[WATCHER] Following issues are detected when watcher is enabled on BH post commit

### DIFF
--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_flash_mla.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_flash_mla.py
@@ -12,7 +12,7 @@ import torch
 from loguru import logger
 
 import ttnn
-from models.common.utility_functions import comp_pcc
+from models.common.utility_functions import comp_pcc, is_blackhole, is_watcher_enabled
 from models.demos.deepseek_v3_b1.micro_ops.flash_mla.op import FlashMLADecode
 
 
@@ -22,6 +22,9 @@ from models.demos.deepseek_v3_b1.micro_ops.flash_mla.op import FlashMLADecode
 @pytest.mark.parametrize("max_seq_len", [32 * 1024])  # 32k max sequence length per chip
 def test_flash_mla_decode(device, batch_size, num_chunks, k_chunk_size, max_seq_len):
     """Test FlashMLADecode op."""
+    if is_blackhole() and is_watcher_enabled():
+        pytest.skip("Skipping test on Blackhole with watcher enabled, see issue #37631")
+
     # Calculate decode_position from num_chunks and k_chunk_size
     decode_position = num_chunks * k_chunk_size - 1
     torch.manual_seed(0)

--- a/tests/ttnn/unit_tests/operations/fused/test_group_norm_DRAM.py
+++ b/tests/ttnn/unit_tests/operations/fused/test_group_norm_DRAM.py
@@ -13,7 +13,7 @@ import math
 
 from tests.ttnn.utils_for_testing import assert_with_pcc
 from tests.ttnn.unit_tests.base_functionality.test_bh_20_cores_sharding import skip_if_not_blackhole_20_cores
-from models.common.utility_functions import run_for_blackhole
+from models.common.utility_functions import is_blackhole, is_watcher_enabled, run_for_blackhole
 
 
 # perf_test_mode is used to skip the torch execution and pcc comparison, and always runs the operation once
@@ -231,6 +231,17 @@ def test_sdxl_base_group_norm_split(device, N, C, H, W, num_groups, num_splits):
     torch.manual_seed(0)
     if device.core_grid.y == 7:
         pytest.skip()
+
+    if (
+        is_blackhole()
+        and is_watcher_enabled()
+        and N == 1
+        and H == 512
+        and W == 512
+        and num_groups == 32
+        and (C, num_splits) in [(256, 8), (512, 16)]
+    ):
+        pytest.skip("Skipping test on Blackhole with watcher enabled, see issue #37645")
 
     grid_size = ttnn.CoreGrid(y=8, x=8)
 


### PR DESCRIPTION
### Ticket
[#27840](https://github.com/tenstorrent/tt-metal/issues/27840)

### Problem description
In order to schedule a run with watcher enabled on BH post commit there is a need to establish a somewhat green state of the pipeline. Therefore issues that are currently present on main are detected, filled as gh issues and assigned to corresponding owners and the issues are skipped until fixed. 

### What's changed
Adding skips with watcher enabled for the tests that are failing with watcher enabled.

### Checklist

- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=dstoiljkovic/bh_skips_for_apc)](https://github.com/tenstorrent/tt-metal/actions/runs/21947327504/job/63389028144?query=branch:dstoiljkovic/bh_skips_for_apc)