### PR TITLE
Subtract grid offset when computing 0-based indices in sharded LN factory

### DIFF
--- a/tests/ttnn/unit_tests/operations/fused/test_layer_norm_sharded.py
+++ b/tests/ttnn/unit_tests/operations/fused/test_layer_norm_sharded.py
@@ -350,3 +350,124 @@ def test_layer_norm_sharded_width_default_config(device, h, w, dtype):
     golden_output = golden(torch_input_tensor, weight=torch_weight[0], bias=torch_bias[0]).to(dtype)
 
     assert_with_pcc(golden_output, output_tensor, 0.9998)
+
+
+@pytest.mark.parametrize("grid_offset", [(1, 1), (2, 0), (0, 2)])
+@pytest.mark.parametrize("use_welford", [True, False])
+@pytest.mark.parametrize("use_weight_bias", [True, False])
+def test_layer_norm_sharded_2d_with_grid_offset(device, grid_offset, use_welford, use_weight_bias):
+    """Test 2D reduce block-sharded layernorm with a non-zero grid origin."""
+
+    h, w = 64, 64  # 2x2 tiles
+    num_cores_h, num_cores_w = 2, 2
+    offset_x, offset_y = grid_offset
+
+    shard_height = h // num_cores_h  # 32
+    shard_width = w // num_cores_w  # 32
+    block_ht = shard_height // 32  # 1
+    block_wt = shard_width // 32  # 1
+
+    shard_spec = ttnn.ShardSpec(
+        ttnn.CoreRangeSet(
+            {
+                ttnn.CoreRange(
+                    ttnn.CoreCoord(offset_x, offset_y),
+                    ttnn.CoreCoord(offset_x + num_cores_w - 1, offset_y + num_cores_h - 1),
+                )
+            }
+        ),
+        [shard_height, shard_width],
+        ttnn.ShardOrientation.ROW_MAJOR,
+    )
+    sharded_mem_config = ttnn.MemoryConfig(
+        memory_layout=ttnn.TensorMemoryLayout.BLOCK_SHARDED,
+        buffer_type=ttnn.BufferType.L1,
+        shard_spec=shard_spec,
+    )
+
+    torch_input = generate_input_tensor(h, w, "random", torch.bfloat16)
+
+    torch_weight = None
+    torch_bias = None
+    tt_weight = None
+    tt_bias = None
+    if use_weight_bias:
+        torch_weight = generate_input_tensor(1, w, "random", torch.bfloat16)[0]
+        torch_bias = generate_input_tensor(1, w, "random_normal", torch.bfloat16)[0]
+        tt_weight = ttnn.from_torch(torch_weight, layout=ttnn.TILE_LAYOUT, device=device)
+        tt_bias = ttnn.from_torch(torch_bias, layout=ttnn.TILE_LAYOUT, device=device)
+
+    ref_output = torch.nn.functional.layer_norm(torch_input, [w], weight=torch_weight, bias=torch_bias)
+
+    tt_input = ttnn.from_torch(
+        torch_input,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        memory_config=sharded_mem_config,
+    )
+
+    output = ttnn_layer_norm_sharded(
+        device,
+        tt_input,
+        use_welford,
+        block_ht=block_ht,
+        block_wt=block_wt,
+        subblock_w=1,
+        weight=tt_weight,
+        bias=tt_bias,
+    )
+
+    assert_with_pcc(ref_output, output, 0.9998)
+
+
+@pytest.mark.parametrize("grid_offset", [(2, 0), (1, 1)])
+@pytest.mark.parametrize("use_welford", [True, False])
+def test_layer_norm_sharded_1d_mcast_with_grid_offset(device, grid_offset, use_welford):
+    """Test 1D mcast layernorm with a non-zero grid origin."""
+    torch.manual_seed(0)
+
+    h, w = 32, 128  # 1 tile row, 4 tile cols
+    num_cores_w = 4
+    offset_x, offset_y = grid_offset
+
+    shard_height = h  # full height → triggers mcast_1d (M == block_h)
+    shard_width = w // num_cores_w  # 32
+
+    shard_spec = ttnn.ShardSpec(
+        ttnn.CoreRangeSet(
+            {
+                ttnn.CoreRange(
+                    ttnn.CoreCoord(offset_x, offset_y),
+                    ttnn.CoreCoord(offset_x + num_cores_w - 1, offset_y),
+                )
+            }
+        ),
+        [shard_height, shard_width],
+        ttnn.ShardOrientation.ROW_MAJOR,
+    )
+    sharded_mem_config = ttnn.MemoryConfig(
+        memory_layout=ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+        buffer_type=ttnn.BufferType.L1,
+        shard_spec=shard_spec,
+    )
+
+    torch_input = generate_input_tensor(h, w, "random", torch.bfloat16)
+    ref_output = torch.nn.functional.layer_norm(torch_input, [w])
+
+    tt_input = ttnn.from_torch(
+        torch_input,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        memory_config=sharded_mem_config,
+    )
+
+    output = ttnn_layer_norm_sharded(
+        device,
+        tt_input,
+        use_welford,
+        block_ht=1,
+        block_wt=1,
+        subblock_w=1,
+    )
+
+    assert_with_pcc(ref_output, output, 0.9998)

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/layernorm_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/layernorm_device_operation.cpp
@@ -256,28 +256,30 @@ void LayerNormDeviceOperation::validate_on_program_cache_miss(
                         "Height sharded memory layout is not supported, got: {}",
                         a.memory_config().memory_layout());
                 } else {
+                    uint32_t num_cores_c = bbox.end_coord.x - bbox.start_coord.x + 1;
+                    uint32_t num_cores_r = bbox.end_coord.y - bbox.start_coord.y + 1;
                     if (row_wise) {
                         TT_FATAL(
-                            tt::div_up(Kt, (bbox.end_coord.x + 1)) == program_config.block_w,
+                            tt::div_up(Kt, num_cores_c) == program_config.block_w,
                             "block_w ({}) must equal to K (in tiles) / num_cores_c ({})",
                             program_config.block_w,
-                            tt::div_up(Kt, (bbox.end_coord.x + 1)));
+                            tt::div_up(Kt, num_cores_c));
                         TT_FATAL(
-                            Mt / (bbox.end_coord.y + 1) == program_config.block_h,
+                            Mt / num_cores_r == program_config.block_h,
                             "block_h ({}) must equal to M (in tiles)/ num_cores_r ({})",
                             program_config.block_h,
-                            Mt / (bbox.end_coord.y + 1));
+                            Mt / num_cores_r);
                     } else {
                         TT_FATAL(
-                            tt::div_up(Kt, (bbox.end_coord.y + 1)) == program_config.block_w,
+                            tt::div_up(Kt, num_cores_r) == program_config.block_w,
                             "block_w ({}) must equal to K (in tiles) / num_cores_r ({})",
                             program_config.block_w,
-                            tt::div_up(Kt, (bbox.end_coord.y + 1)));
+                            tt::div_up(Kt, num_cores_r));
                         TT_FATAL(
-                            Mt / (bbox.end_coord.x + 1) == program_config.block_h,
+                            Mt / num_cores_c == program_config.block_h,
                             "block_h ({}) must equal to M (in tiles) / num_cores_c ({})",
                             program_config.block_h,
-                            Mt / (bbox.end_coord.x + 1));
+                            Mt / num_cores_c);
                     }
                 }
                 if (b.has_value()) {

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/sharded_layernorm_factory_helpers.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/sharded_layernorm_factory_helpers.cpp
@@ -1114,12 +1114,15 @@ CoreIndices CoreIndices::compute(uint32_t core_idx, const CoreCoord& core, const
         idx.height_index = 0;
         idx.width_index = core_idx;
     } else {
+        // In the non-mcast 1d case, core coordinates come from the shard spec grid which already has
+        // the grid offset embedded. Subtract it to get 0-based grid-relative indices.
+        CoreCoord offset = ctx.grid.grid_offset.value_or(CoreCoord{0, 0});
         if (ctx.grid.row_wise) {
-            idx.height_index = core.y;
-            idx.width_index = core.x;
+            idx.height_index = core.y - offset.y;
+            idx.width_index = core.x - offset.x;
         } else {
-            idx.height_index = core.x;
-            idx.width_index = core.y;
+            idx.height_index = core.x - offset.x;
+            idx.width_index = core.y - offset.y;
         }
     }
 


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/37767

### Problem description
Fixes a bug with non-zero core grid offsets in sharded layernorm.

### What's changed
Compute the correct relative core index when an offset is provided.

### Checklist

- [x] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=rmillerTT/37767_grid_offset)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:rmillerTT/37767_grid_offset)
- [x] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=rmillerTT/37767_grid_offset)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:rmillerTT/37767_grid_offset)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=rmillerTT/37767_grid_offset)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:rmillerTT/37767_grid_offset)
- [x] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=rmillerTT/37767_grid_offset)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:rmillerTT/37767_grid_offset)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=rmillerTT/37767_grid_offset)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:rmillerTT/37767_grid_offset)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=rmillerTT/37767_grid_offset)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:rmillerTT/37767_grid_offset)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
