### PR TITLE
[skip ci] Use civ2 blackhole loudbox for BH post commit

### DIFF
--- a/.github/workflows/blackhole-multi-card-unit-tests-impl.yaml
+++ b/.github/workflows/blackhole-multi-card-unit-tests-impl.yaml
@@ -135,10 +135,11 @@ jobs:
       fail-fast: false
       matrix: ${{ fromJSON(needs.generate-matrix.outputs.matrix) }}
     name: ${{ inputs.arch }} ${{ inputs.runner-label }} ${{ matrix.test-group.name }}
-    runs-on:
-      - in-service
-      - arch-blackhole
-      - ${{ inputs.runner-label }}
+    runs-on: >-
+      ${{
+        (inputs.runner-label == 'BH-LoudBox-viommu') && format('tt-ubuntu-2204-{0}-stable', inputs.runner-label)
+        || fromJSON(format('["in-service", "arch-blackhole", "{0}"]', inputs.runner-label))
+      }}
     container:
       image: ${{ inputs.docker-image || 'docker-image-unresolved' }}
       env:

--- a/.github/workflows/blackhole-post-commit.yaml
+++ b/.github/workflows/blackhole-post-commit.yaml
@@ -307,7 +307,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        test-group: [ "BH-LLMBox", "BH-LoudBox", "P300-viommu"]
+        test-group: [ "BH-LLMBox", "BH-LoudBox-viommu", "P300-viommu"]
     with:
       arch: blackhole
       runner-label: ${{ matrix.test-group }}


### PR DESCRIPTION
### Ticket
None

### What's changed
We've got a fancy new loudbox in CIv2, we should try using it.

### Checklist

- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=williamly/loudbox-viommu)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:williamly/loudbox-viommu)


