### PR TITLE
[tt_dit] Reduce module cache data size

### DIFF
--- a/models/experimental/stable_diffusion_xl_base/tests/pcc/test_sdxl_clip_encoders.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/pcc/test_sdxl_clip_encoders.py
@@ -6,12 +6,12 @@ import time
 
 import pytest
 import torch
-from models.experimental.stable_diffusion_xl_base.tests.test_common import SDXL_L1_SMALL_SIZE
-import ttnn
 from loguru import logger
-from transformers import CLIPTextModelWithProjection, CLIPTokenizer, CLIPTextModel
+from transformers import CLIPTextModel, CLIPTextModelWithProjection, CLIPTokenizer
 
-from models.tt_dit.encoders.clip.model_clip import CLIPEncoder, CLIPConfig
+import ttnn
+from models.experimental.stable_diffusion_xl_base.tests.test_common import SDXL_L1_SMALL_SIZE
+from models.tt_dit.encoders.clip.model_clip import CLIPConfig, CLIPEncoder
 from models.tt_dit.parallel.config import EncoderParallelConfig, ParallelFactor
 from models.tt_dit.utils.check import assert_quality
 

--- a/models/tt_dit/encoders/qwen25vl/encoder_pair.py
+++ b/models/tt_dit/encoders/qwen25vl/encoder_pair.py
@@ -90,18 +90,15 @@ class Qwen25VlTokenizerEncoderPair:
         # Store state dict for potential reloading
         self._encoder_state_dict = torch_state_dict
 
-        if not cache.initialize_from_cache(
+        cache.load_model(
             tt_model=model,
-            torch_state_dict=torch_state_dict,
+            get_torch_state_dict=lambda: torch_state_dict,
             model_name=checkpoint,
             subfolder=subfolder if subfolder is not None else "",
             parallel_config=self._parallel_config,
             mesh_shape=tuple(self._device.shape),
-            dtype="bf16",
             is_fsdp=self._is_fsdp,
-        ):
-            logger.info("loading encoder from torch state...")
-            model.load_torch_state_dict(torch_state_dict)
+        )
 
         return model
 
@@ -114,17 +111,15 @@ class Qwen25VlTokenizerEncoderPair:
             return
 
         logger.info("reloading encoder weights to device...")
-        if not cache.initialize_from_cache(
+        cache.load_model(
             tt_model=self._encoder,
-            torch_state_dict=self._encoder_state_dict,
+            get_torch_state_dict=lambda: self._encoder_state_dict,
             model_name=self._checkpoint,
             subfolder=self._encoder_subfolder if self._encoder_subfolder is not None else "",
             parallel_config=self._parallel_config,
             mesh_shape=tuple(self._device.shape),
-            dtype="bf16",
             is_fsdp=self._is_fsdp,
-        ):
-            self._encoder.load_torch_state_dict(self._encoder_state_dict)
+        )
 
         self._encoder_loaded = True
         ttnn.synchronize_device(self._device)

--- a/models/tt_dit/encoders/t5/encoder_pair.py
+++ b/models/tt_dit/encoders/t5/encoder_pair.py
@@ -79,17 +79,14 @@ class T5TokenizerEncoderPair:
             parallel_config=self._parallel_config,
         )
 
-        if not cache.initialize_from_cache(
+        cache.load_model(
             tt_model=model,
-            torch_state_dict=torch_model.state_dict(),
+            get_torch_state_dict=torch_model.state_dict,
             model_name=checkpoint,
             subfolder="",
             parallel_config=self._parallel_config,
             mesh_shape=tuple(self._device.shape),
-            dtype="bf16",
-        ):
-            logger.info("loading T5 encoder from torch state...")
-            model.load_torch_state_dict(torch_model.state_dict())
+        )
 
         return model
 

--- a/models/tt_dit/layers/module.py
+++ b/models/tt_dit/layers/module.py
@@ -419,7 +419,7 @@ class Parameter:
                 msg = "expected host tensor, got device tensor"
                 raise LoadingError(msg)
         elif value.device() is None:
-            if not self.on_host and not allow_on_host:
+            if not allow_on_host:
                 msg = "expected device tensor, got host tensor"
                 raise LoadingError(msg)
         elif value.device() != self.device:

--- a/models/tt_dit/layers/module.py
+++ b/models/tt_dit/layers/module.py
@@ -99,6 +99,7 @@ class Module(ABC):
         module_key_prefix: str,
         missing_keys: MutableSequence[str],
         unexpected_keys: MutableSequence[str],
+        on_host: bool,
     ) -> None:
         state_dict = dict(state_dict)
         self._prepare_torch_state(state_dict)
@@ -112,6 +113,7 @@ class Module(ABC):
                     module_key_prefix=f"{module_key_prefix}{name}.",
                     missing_keys=missing_keys,
                     unexpected_keys=unexpected_keys,
+                    on_host=on_host,
                 )
             except LoadingError:
                 raise
@@ -122,7 +124,7 @@ class Module(ABC):
         for name, parameter in self.named_parameters():
             if name in state_dict:
                 try:
-                    parameter.load_torch_tensor(state_dict.pop(name))
+                    parameter.load_torch_tensor(state_dict.pop(name), on_host=on_host)
                 except LoadingError as err:
                     msg = f"while loading '{module_key_prefix}{name}': {err}"
                     raise LoadingError(msg) from err
@@ -132,12 +134,30 @@ class Module(ABC):
         for name in state_dict:
             unexpected_keys.append(f"{module_key_prefix}{name}")
 
-    def load_torch_state_dict(self, state_dict: Mapping[str, torch.Tensor], *, strict: bool = True) -> IncompatibleKeys:
+    def load_torch_state_dict(
+        self, state_dict: Mapping[str, torch.Tensor], *, strict: bool = True, on_host: bool = False
+    ) -> IncompatibleKeys:
+        """Load PyTorch state dict into module parameters.
+
+        Args:
+            state_dict: Mapping of parameter names to PyTorch tensors.
+            strict: If `True`, raises ValueError on missing or unexpected keys.
+            on_host: If `True`, keeps tensors in host memory. This is used when saving the module
+                to disk, since for device tensors, every shard is currently stored to disk, even
+                for replicated tensors, leading to redundant copies of data.
+
+        Returns:
+            `IncompatibleKeys` containing lists of missing and unexpected keys.
+        """
         missing_keys = []
         unexpected_keys = []
 
         self._load_torch_state_dict_inner(
-            state_dict, module_key_prefix="", missing_keys=missing_keys, unexpected_keys=unexpected_keys
+            state_dict,
+            module_key_prefix="",
+            missing_keys=missing_keys,
+            unexpected_keys=unexpected_keys,
+            on_host=on_host,
         )
 
         if strict and (missing_keys or unexpected_keys):
@@ -173,37 +193,6 @@ class Module(ABC):
 
         for name, parameter in self.named_parameters():
             path = directory / f"{prefix}{name}.tensorbin"
-            try:
-                parameter.load(path)
-            except LoadingError as err:
-                msg = f"{err} while loading '{path}'"
-                raise LoadingError(msg) from err
-
-        self._is_loaded = True
-
-    def to_cached_state_dict(self, path_prefix: str) -> dict[str, str]:
-        cache_dict = {}
-
-        for name, child in self.named_children():
-            child_cache_dict = child.to_cached_state_dict(f"{path_prefix}{name}.")
-            cache_dict.update({f"{name}.{k}": v for k, v in child_cache_dict.items()})
-
-        for name, parameter in self.named_parameters():
-            cache_dict[name] = path = f"{path_prefix}{name}.tensorbin"
-            parameter.save(path)
-
-        return cache_dict
-
-    def from_cached_state_dict(self, cache_dict: Mapping[str, str]) -> None:
-        def substate(state: Mapping[str, str], key: str) -> dict[str, str]:
-            prefix = f"{key}."
-            return {k.removeprefix(prefix): v for k, v in state.items() if k.startswith(prefix)}
-
-        for name, child in self.named_children():
-            child.from_cached_state_dict(substate(cache_dict, name))
-
-        for name, parameter in self.named_parameters():
-            path = cache_dict[name]
             try:
                 parameter.load(path)
             except LoadingError as err:
@@ -378,13 +367,13 @@ class Parameter:
         self.on_host = on_host
         self._data = None
 
-    def load_torch_tensor(self, torch_tensor: torch.Tensor, /) -> None:
+    def load_torch_tensor(self, torch_tensor: torch.Tensor, /, *, on_host: bool = False) -> None:
         shape = tuple(torch_tensor.shape)
         if shape != self.total_shape:
             msg = f"expected tensor shape {self.total_shape}, got {shape}"
             raise LoadingError(msg)
 
-        self.data = tensor.from_torch(
+        data = tensor.from_torch(
             torch_tensor,
             device=self.device,
             layout=self.layout,
@@ -392,8 +381,9 @@ class Parameter:
             memory_config=self.memory_config,
             pad_value=self.pad_value,
             mesh_axes=self.mesh_axes,
-            on_host=self.on_host,
+            on_host=self.on_host or on_host,
         )
+        self._set_data(data, allow_on_host=on_host)
 
     def save(self, path: str | Path, /) -> None:
         ttnn.dump_tensor(path, self.data)
@@ -415,8 +405,7 @@ class Parameter:
 
     @data.setter
     def data(self, value: ttnn.Tensor) -> None:
-        self._check_data(value)
-        self._data = value
+        self._set_data(value)
 
     def deallocate(self) -> None:
         """Deallocate the parameter's device memory."""
@@ -424,10 +413,14 @@ class Parameter:
             ttnn.deallocate(self._data)
             self._data = None
 
-    def _check_data(self, value: ttnn.Tensor) -> None:
+    def _set_data(self, value: ttnn.Tensor, *, allow_on_host: bool = False) -> None:
         if self.on_host:
             if value.device() is not None:
                 msg = "expected host tensor, got device tensor"
+                raise LoadingError(msg)
+        elif value.device() is None:
+            if not self.on_host and not allow_on_host:
+                msg = "expected device tensor, got host tensor"
                 raise LoadingError(msg)
         elif value.device() != self.device:
             msg = "device mismatch"
@@ -448,3 +441,5 @@ class Parameter:
         if value.shape != self.local_shape:
             msg = f"shape mismatch: expected {self.local_shape}, got {tuple(value.shape)}"
             raise LoadingError(msg)
+
+        self._data = value

--- a/models/tt_dit/pipelines/flux1/pipeline_flux1.py
+++ b/models/tt_dit/pipelines/flux1/pipeline_flux1.py
@@ -156,16 +156,14 @@ class Flux1Pipeline:
             )
 
             model_name = os.path.basename(checkpoint_name)
-            if not cache.initialize_from_cache(
+            cache.load_model(
                 tt_transformer,
-                torch_transformer.state_dict(),
-                model_name,
-                "transformer",
-                parallel_config,
-                tuple(submesh_device.shape),
-            ):
-                logger.info(f"Loading transformer weights from PyTorch state dict")
-                tt_transformer.load_torch_state_dict(torch_transformer.state_dict())
+                get_torch_state_dict=torch_transformer.state_dict,
+                model_name=model_name,
+                subfolder="transformer",
+                parallel_config=parallel_config,
+                mesh_shape=tuple(submesh_device.shape),
+            )
 
             self.transformers.append(tt_transformer)
             ttnn.synchronize_device(submesh_device)
@@ -237,16 +235,14 @@ class Flux1Pipeline:
                     parallel_config=encoder_parallel_config,
                 )
 
-                if not cache.initialize_from_cache(
+                cache.load_model(
                     self._t5_text_encoder,
-                    torch_t5_text_encoder.state_dict(),
-                    model_name,
-                    "t5_text_encoder",
-                    encoder_parallel_config,
-                    tuple(self.encoder_device.shape),
-                ):
-                    logger.info(f"Loading T5 text encoder weights from PyTorch state dict")
-                    self._t5_text_encoder.load_torch_state_dict(torch_t5_text_encoder.state_dict())
+                    get_torch_state_dict=torch_t5_text_encoder.state_dict,
+                    model_name=model_name,
+                    subfolder="t5_text_encoder",
+                    parallel_config=encoder_parallel_config,
+                    mesh_shape=tuple(self.encoder_device.shape),
+                )
         else:
             self._t5_text_encoder = None
 

--- a/models/tt_dit/pipelines/flux1/pipeline_flux1.py
+++ b/models/tt_dit/pipelines/flux1/pipeline_flux1.py
@@ -469,9 +469,11 @@ class Flux1Pipeline:
                 )
 
                 tt_pooled_prompt_embeds = ttnn.from_torch(
-                    pooled_prompt_embeds[i : i + 1]
-                    if self._parallel_config.cfg_parallel.factor == 2
-                    else pooled_prompt_embeds,
+                    (
+                        pooled_prompt_embeds[i : i + 1]
+                        if self._parallel_config.cfg_parallel.factor == 2
+                        else pooled_prompt_embeds
+                    ),
                     layout=ttnn.TILE_LAYOUT,
                     dtype=ttnn.bfloat16,
                     device=submesh_device if not traced else None,
@@ -612,9 +614,9 @@ class Flux1Pipeline:
                                 fill_value=sigma_difference,
                                 layout=ttnn.TILE_LAYOUT,
                                 dtype=ttnn.bfloat16,
-                                device=submesh_device
-                                if not traced
-                                else None,  # Not used in trace region, can be on device always.
+                                device=(
+                                    submesh_device if not traced else None
+                                ),  # Not used in trace region, can be on device always.
                             )
                             tt_sigma_difference_list.append(tt_sigma_difference)
 

--- a/models/tt_dit/pipelines/motif/pipeline_motif.py
+++ b/models/tt_dit/pipelines/motif/pipeline_motif.py
@@ -172,17 +172,14 @@ class MotifPipeline:
                 padding_config=padding_config,
             )
 
-            if not cache.initialize_from_cache(
+            cache.load_model(
                 tt_model=tt_transformer,
-                torch_state_dict=transformer_state_dict,
+                get_torch_state_dict=lambda: transformer_state_dict,
                 model_name="motif-image-6b",
                 subfolder="transformer",
                 parallel_config=self._parallel_config,
                 mesh_shape=tuple(submesh_device.shape),
-                dtype="bf16",
-            ):
-                logger.info("Loading transformer weights from PyTorch state dict")
-                tt_transformer.load_torch_state_dict(transformer_state_dict)
+            )
 
             self.transformers.append(tt_transformer)
             ttnn.synchronize_device(submesh_device)

--- a/models/tt_dit/pipelines/qwenimage/pipeline_qwenimage.py
+++ b/models/tt_dit/pipelines/qwenimage/pipeline_qwenimage.py
@@ -241,18 +241,15 @@ class QwenImagePipeline:
         if self.transformers[idx].is_loaded():
             return
 
-        if not cache.initialize_from_cache(
+        cache.load_model(
             tt_model=self.transformers[idx],
-            torch_state_dict=self._transformer_state_dict,
+            get_torch_state_dict=lambda: self._transformer_state_dict,
             model_name=self._checkpoint_name,
             subfolder="transformer",
             parallel_config=self._parallel_config,
             mesh_shape=tuple(self._submesh_devices[idx].shape),
-            dtype="bf16",
             is_fsdp=self._is_fsdp,
-        ):
-            logger.info("Loading transformer weights from PyTorch state dict")
-            self.transformers[idx].load_torch_state_dict(self._transformer_state_dict)
+        )
 
         ttnn.synchronize_device(self._submesh_devices[idx])
 

--- a/models/tt_dit/pipelines/stable_diffusion_35_large/pipeline_stable_diffusion_35_large.py
+++ b/models/tt_dit/pipelines/stable_diffusion_35_large/pipeline_stable_diffusion_35_large.py
@@ -173,17 +173,14 @@ class StableDiffusion3Pipeline:
                 padding_config=padding_config,
             )
 
-            if not cache.initialize_from_cache(
+            cache.load_model(
                 tt_model=tt_transformer,
-                torch_state_dict=torch_transformer.state_dict(),
+                get_torch_state_dict=torch_transformer.state_dict,
                 model_name="stable-diffusion-3.5-large",
                 subfolder="transformer",
                 parallel_config=self.dit_parallel_config,
                 mesh_shape=tuple(submesh_device.shape),
-                dtype="bf16",
-            ):
-                logger.info("Loading transformer weights from PyTorch state dict")
-                tt_transformer.load_state_dict(torch_transformer.state_dict())
+            )
 
             self.transformers.append(tt_transformer)
             ttnn.synchronize_device(submesh_device)

--- a/models/tt_dit/pipelines/stable_diffusion_35_large/pipeline_stable_diffusion_35_large.py
+++ b/models/tt_dit/pipelines/stable_diffusion_35_large/pipeline_stable_diffusion_35_large.py
@@ -512,9 +512,11 @@ class StableDiffusion3Pipeline:
             tt_latents_step_list = []
             for i, submesh_device in enumerate(self.submesh_devices):
                 tt_prompt_embeds = ttnn.from_torch(
-                    prompt_embeds[i].unsqueeze(0).unsqueeze(0)
-                    if self.dit_parallel_config.cfg_parallel.factor == 2
-                    else prompt_embeds,
+                    (
+                        prompt_embeds[i].unsqueeze(0).unsqueeze(0)
+                        if self.dit_parallel_config.cfg_parallel.factor == 2
+                        else prompt_embeds
+                    ),
                     layout=ttnn.TILE_LAYOUT,
                     dtype=ttnn.bfloat16,
                     device=submesh_device if not traced else None,
@@ -526,9 +528,11 @@ class StableDiffusion3Pipeline:
                 )
 
                 tt_pooled_prompt_embeds = ttnn.from_torch(
-                    pooled_prompt_embeds[i].unsqueeze(0).unsqueeze(0).unsqueeze(0)
-                    if self.dit_parallel_config.cfg_parallel.factor == 2
-                    else pooled_prompt_embeds,
+                    (
+                        pooled_prompt_embeds[i].unsqueeze(0).unsqueeze(0).unsqueeze(0)
+                        if self.dit_parallel_config.cfg_parallel.factor == 2
+                        else pooled_prompt_embeds
+                    ),
                     layout=ttnn.TILE_LAYOUT,
                     dtype=ttnn.bfloat16,
                     device=submesh_device if not traced else None,

--- a/models/tt_dit/tests/models/flux1/test_transformer_flux1.py
+++ b/models/tt_dit/tests/models/flux1/test_transformer_flux1.py
@@ -274,19 +274,14 @@ def test_transformer(
         padding_config=padding_config,
     )
 
-    if not cache.initialize_from_cache(
+    cache.load_model(
         tt_model,
-        torch_model.state_dict(),
-        "Flux.1-dev",
-        "transformer",
-        parallel_config,
-        tuple(submesh_device.shape),
-        "bf16",
-    ):
-        logger.info(
-            "Loading transformer weights from PyTorch state dict. To use cache, set TT_DIT_CACHE_DIR environment variable."
-        )
-        tt_model.load_torch_state_dict(torch_model.state_dict())
+        get_torch_state_dict=torch_model.state_dict,
+        model_name="Flux.1-dev",
+        subfolder="transformer",
+        parallel_config=parallel_config,
+        mesh_shape=tuple(submesh_device.shape),
+    )
 
     torch.manual_seed(0)
     spatial = torch.randn([batch_size, spatial_seq_len, in_channels])

--- a/models/tt_dit/tests/models/mochi/test_transformer_accuracy.py
+++ b/models/tt_dit/tests/models/mochi/test_transformer_accuracy.py
@@ -17,7 +17,7 @@ import ttnn
 from ....models.transformers.transformer_mochi import MochiTransformer3DModel
 from ....parallel.config import DiTParallelConfig, ParallelFactor
 from ....parallel.manager import CCLManager
-from ....utils.cache import get_cache_path, load_cache_dict
+from ....utils import cache
 
 
 @pytest.mark.parametrize(
@@ -124,18 +124,13 @@ def test_transformer_accuracy(
         is_fsdp=True,
     )
 
-    cache_path = get_cache_path(
+    cache.load_model(
+        tt_model,
         model_name="mochi-1-preview",
         subfolder="transformer",
         parallel_config=parallel_config,
         mesh_shape=tuple(mesh_device.shape),
-        dtype="bf16",
     )
-    assert os.path.exists(
-        cache_path
-    ), "Cache path does not exist. Run test_mochi_transformer_model_caching first with the desired parallel config."
-    cache_dict = load_cache_dict(cache_path)
-    tt_model.from_cached_state_dict(cache_dict)
 
     # Get list of step directories
     step_dirs = [d for d in os.listdir(ground_truth_dir) if d.startswith("step_")]

--- a/models/tt_dit/tests/models/mochi/test_transformer_mochi.py
+++ b/models/tt_dit/tests/models/mochi/test_transformer_mochi.py
@@ -495,7 +495,7 @@ def test_mochi_transformer_model_caching(
         is_fsdp=True,
     )
     start = time.time()
-    tt_model.load_torch_state_dict(torch_model.state_dict())
+    tt_model.load_torch_state_dict(torch_model.state_dict(), on_host=True)
     end = time.time()
     logger.info(f"Time taken to load state dict: {end - start} seconds")
 

--- a/models/tt_dit/tests/models/mochi/test_vae_mochi.py
+++ b/models/tt_dit/tests/models/mochi/test_vae_mochi.py
@@ -18,6 +18,7 @@ from ....models.vae.vae_mochi import MochiVAEDecoder as TtDecoder
 from ....models.vae.vae_mochi import ResBlock as TtResBlock
 from ....parallel.config import MochiVAEParallelConfig, ParallelFactor
 from ....parallel.manager import CCLManager
+from ....utils import cache
 from ....utils.check import assert_quality
 
 
@@ -674,7 +675,6 @@ def load_dit(
 
     from ....models.transformers.transformer_mochi import MochiTransformer3DModel
     from ....parallel.config import DiTParallelConfig
-    from ....utils.cache import get_cache_path, load_cache_dict
 
     torch_transformer = TorchMochiTransformer3DModel.from_pretrained(
         model_name, subfolder="transformer", torch_dtype=torch.float32
@@ -705,18 +705,14 @@ def load_dit(
 
     # Load state dict into TT transformer
     if use_cache:
-        cache_path = get_cache_path(
+        cache.load_model(
+            transformer,
             model_name="mochi-1-preview",
             subfolder="transformer",
             parallel_config=parallel_config,
             mesh_shape=tuple(mesh_device.shape),
             dtype="bf16",
         )
-        assert os.path.exists(
-            cache_path
-        ), f"Cache path: {cache_path} does not exist. Run test_mochi_transformer_model_caching first with the desired parallel config."
-        cache_dict = load_cache_dict(cache_path)
-        transformer.from_cached_state_dict(cache_dict)
     else:
         transformer.load_torch_state_dict(torch_transformer.state_dict())
 

--- a/models/tt_dit/tests/models/qwenimage/test_transformer_qwenimage.py
+++ b/models/tt_dit/tests/models/qwenimage/test_transformer_qwenimage.py
@@ -103,16 +103,14 @@ def test_transformer(
         padding_config=padding_config,
     )
 
-    if not cache.initialize_from_cache(
+    cache.load_model(
         tt_model=tt_model,
-        torch_state_dict=torch_model.state_dict(),
+        get_torch_state_dict=torch_model.state_dict,
         model_name="qwen-image",
         subfolder="transformer",
         parallel_config=parallel_config,
         mesh_shape=tuple(mesh_device.shape),
-        dtype="bf16",
-    ):
-        tt_model.load_torch_state_dict(torch_model.state_dict())
+    )
 
     spatial_seq_len = (latents_height // patch_size) * (latents_width // patch_size)
 

--- a/models/tt_dit/tests/models/sd35/test_transformer_sd35.py
+++ b/models/tt_dit/tests/models/sd35/test_transformer_sd35.py
@@ -460,7 +460,7 @@ def test_sd35_transformer_model_caching(
         padding_config=padding_config,
     )
     start = time.time()
-    tt_model.load_torch_state_dict(torch_model.state_dict())
+    tt_model.load_torch_state_dict(torch_model.state_dict(), on_host=True)
     end = time.time()
     logger.info(f"Time taken to load state dict: {end - start} seconds")
 

--- a/models/tt_dit/tests/models/wan2_2/test_transformer_wan.py
+++ b/models/tt_dit/tests/models/wan2_2/test_transformer_wan.py
@@ -460,7 +460,7 @@ def test_wan_transformer_model_caching(
         is_fsdp=is_fsdp,
     )
     start = time.time()
-    tt_model.load_torch_state_dict(torch_model.state_dict())
+    tt_model.load_torch_state_dict(torch_model.state_dict(), on_host=True)
     end = time.time()
     logger.info(f"Time taken to load state dict: {end - start} seconds")
 


### PR DESCRIPTION
### Problem description

When saving device tensors to disk, every mesh shard is stored even for replicated tensors, which leads to unnecessary disk usage. This is not true for host tensors that are directly created from PyTorch tensors.

### What's changed

Use host tensors instead of device tensors when creating module caches in order to eliminate redundant storage.

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=friedrich/caching)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:friedrich/caching)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=friedrich/caching)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:friedrich/caching)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=friedrich/caching)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:friedrich/caching)
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=friedrich/caching)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:friedrich/caching)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [x] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=friedrich/caching)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:friedrich/caching)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [x] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=friedrich/caching)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:friedrich/caching)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [x] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
