### PR TITLE
Use gh_run_number for Superset dashboard links in Slack notifications

### DIFF
--- a/.github/actions/sweep-run-analysis/scripts/send_slack_notification.py
+++ b/.github/actions/sweep-run-analysis/scripts/send_slack_notification.py
@@ -8,7 +8,6 @@ import json
 import os
 import sys
 import time
-from typing import Optional
 
 import requests
 
@@ -341,7 +340,7 @@ def build_cancelled_block() -> list[dict]:
     ]
 
 
-def build_superset_link_block(run_id: Optional[int]) -> dict:
+def build_superset_link_block() -> dict:
     """Build the Superset dashboard link block.
 
     Uses gh_run_number (GITHUB_RUN_ID) since it's available immediately,
@@ -424,7 +423,7 @@ def build_slack_message(results: dict, conclusion: str) -> dict:
 
     # Superset link
     blocks.append({"type": "divider"})
-    blocks.append(build_superset_link_block(results.get("run_id")))
+    blocks.append(build_superset_link_block())
 
     return {"blocks": blocks}
 

--- a/.github/actions/sweep-run-analysis/scripts/send_slack_notification.py
+++ b/.github/actions/sweep-run-analysis/scripts/send_slack_notification.py
@@ -342,9 +342,14 @@ def build_cancelled_block() -> list[dict]:
 
 
 def build_superset_link_block(run_id: Optional[int]) -> dict:
-    """Build the Superset dashboard link block."""
-    if run_id:
-        url = f"{SUPERSET_BASE_URL}?run_id={run_id}"
+    """Build the Superset dashboard link block.
+
+    Uses gh_run_number (GITHUB_RUN_ID) since it's available immediately,
+    whereas run_id (database PK) requires Airflow ingestion first.
+    """
+    if GITHUB_RUN_ID:
+        # Use GitHub run ID - works immediately, dashboard shows data after ingestion
+        url = f"{SUPERSET_BASE_URL}?gh_run_number={GITHUB_RUN_ID}"
         text = f"<{url}|View in Superset>"
     else:
         text = f"<{GITHUB_ACTIONS_URL}|View in GitHub Actions>"


### PR DESCRIPTION
  Previously, the Superset link used `run_id` (database primary key) which
  is only available after Airflow ingests the data. This caused the link
  to fall back to GitHub Actions URL since run_id wasn't known at
  notification time.

  Now uses `gh_run_number` (GitHub Actions run ID) which is available
  immediately. The Superset datasets have been updated to accept this
  parameter and resolve it to the correct op_run_id via subquery.

  This allows users to click the Superset link right away - the dashboard
  will show data once Airflow ingestion completes.

### Ticket
Link to Github Issue

### Problem description
Provide context for the problem.

### What's changed
Describe the approach used to solve the problem.
Summarize the changes made and its impact.

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=stevendae/filter_lead_model_by_gh_run_number)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:stevendae/filter_lead_model_by_gh_run_number)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=stevendae/filter_lead_model_by_gh_run_number)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:stevendae/filter_lead_model_by_gh_run_number)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=stevendae/filter_lead_model_by_gh_run_number)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:stevendae/filter_lead_model_by_gh_run_number)
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=stevendae/filter_lead_model_by_gh_run_number)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:stevendae/filter_lead_model_by_gh_run_number)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=stevendae/filter_lead_model_by_gh_run_number)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:stevendae/filter_lead_model_by_gh_run_number)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=stevendae/filter_lead_model_by_gh_run_number)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:stevendae/filter_lead_model_by_gh_run_number)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
