### PR TITLE
[skip ci] Remove t3k select pipeline extra-tag inputs

### DIFF
--- a/.github/workflows/pipeline-select-t3k.yaml
+++ b/.github/workflows/pipeline-select-t3k.yaml
@@ -203,7 +203,6 @@ jobs:
     uses: ./.github/workflows/t3000-unit-tests-impl.yaml
     with:
       enabled-skus: "wh_llmbox"
-      extra-tag: ${{ inputs.extra-tag }}
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
@@ -215,7 +214,6 @@ jobs:
     uses: ./.github/workflows/t3000-demo-tests-impl.yaml
     with:
       enabled-skus: "wh_llmbox_perf"
-      extra-tag: ${{ inputs.extra-tag }}
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
@@ -227,7 +225,6 @@ jobs:
     uses: ./.github/workflows/t3000-perf-tests-impl.yaml
     with:
       enabled-skus: "wh_llmbox_perf"
-      extra-tag: ${{ inputs.extra-tag }}
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
@@ -239,7 +236,6 @@ jobs:
     uses: ./.github/workflows/t3000-integration-tests-impl.yaml
     with:
       enabled-skus: "wh_llmbox"
-      extra-tag: ${{ inputs.extra-tag }}
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
@@ -251,7 +247,6 @@ jobs:
     uses: ./.github/workflows/t3000-e2e-tests-impl.yaml
     with:
       enabled-skus: "wh_llmbox"
-      extra-tag: ${{ inputs.extra-tag }}
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}


### PR DESCRIPTION
`extra-tag` were [removed from some t3k pipelines](https://github.com/tenstorrent/tt-metal/pull/37801) but not removed from t3k choose your own pipeline, causing a syntax error.


Testing:

- [x] T3k select doesn't throw syntax error https://github.com/tenstorrent/tt-metal/actions/runs/21967365123