### PR TITLE
[Deepseek Blitz] Pipeline setup pybinds

### DIFF
--- a/tt_metal/CMakeLists.txt
+++ b/tt_metal/CMakeLists.txt
@@ -263,6 +263,7 @@ target_link_libraries(
         detail
         distributed
         fabric
+        tt_metal_scaleout
         FlatBuffers::FlatBuffers
         TT::Metalium::Logging
         TT::ScaleoutTools
@@ -314,6 +315,7 @@ add_subdirectory(detail)
 add_subdirectory(distributed)
 add_subdirectory(fabric)
 add_subdirectory(experimental/udm)
+add_subdirectory(experimental/scaleout)
 if(TT_METAL_BUILD_TESTS)
     add_subdirectory(test)
 endif()

--- a/tt_metal/experimental/scaleout/CMakeLists.txt
+++ b/tt_metal/experimental/scaleout/CMakeLists.txt
@@ -1,0 +1,23 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set(SCALEOUT_SRCS ${CMAKE_CURRENT_SOURCE_DIR}/blitz_decode_pipeline.cpp)
+
+add_library(tt_metal_scaleout OBJECT ${SCALEOUT_SRCS})
+
+target_include_directories(
+    tt_metal_scaleout
+    PRIVATE
+        ${PROJECT_SOURCE_DIR}
+        ${PROJECT_SOURCE_DIR}/tt_metal
+)
+
+target_link_libraries(
+    tt_metal_scaleout
+    PRIVATE
+        TT::Metalium::Common
+        TT::Metalium::HostDevCommon
+)
+
+install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} DESTINATION include/tt_metal FILES_MATCHING PATTERN "*.hpp")

--- a/tt_metal/experimental/scaleout/blitz_decode_pipeline.cpp
+++ b/tt_metal/experimental/scaleout/blitz_decode_pipeline.cpp
@@ -1,0 +1,186 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "tt_metal/experimental/scaleout/blitz_decode_pipeline.hpp"
+
+#include <cstddef>
+#include <cstdint>
+#include <unordered_map>
+#include <vector>
+
+#include <tt-metalium/base_types.hpp>
+#include <tt-metalium/distributed_context.hpp>
+#include <tt-metalium/experimental/fabric/control_plane.hpp>
+#include <tt_stl/span.hpp>
+
+#include "tt_metal/impl/context/metal_context.hpp"
+#include "tt_metal/fabric/physical_system_descriptor.hpp"
+#include "tt_metal/llrt/tt_cluster.hpp"
+
+namespace tt::tt_metal::experimental::scaleout {
+
+namespace {
+
+struct PhysicalPipelineStageConfig {
+    uint32_t tray_id;
+    uint32_t entry_node_asic_location;
+    uint32_t exit_node_asic_location;
+};
+
+std::unordered_map<tt::tt_metal::AsicID, distributed::MeshCoordinate> get_asic_id_to_mesh_coord_map(
+    const distributed::MeshDevice& mesh_device) {
+    const auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
+    std::unordered_map<tt::tt_metal::AsicID, distributed::MeshCoordinate> asic_id_to_mesh_coord_map;
+
+    for (const auto& coord : distributed::MeshCoordinateRange(mesh_device.shape())) {
+        tt_fabric::FabricNodeId fabric_node_id = mesh_device.get_fabric_node_id(coord);
+        tt_metal::AsicID asic_id = control_plane.get_asic_id_from_fabric_node_id(fabric_node_id);
+        asic_id_to_mesh_coord_map.emplace(asic_id, coord);
+    }
+
+    auto& distributed_context = tt_metal::distributed::multihost::DistributedContext::get_current_world();
+    for (auto rank = 0; rank < *(distributed_context->size()); rank++) {
+        if (rank == *(distributed_context->rank())) {
+            std::size_t num_entries = asic_id_to_mesh_coord_map.size();
+            distributed_context->broadcast(
+                tt::stl::Span<std::byte>(reinterpret_cast<std::byte*>(&num_entries), sizeof(num_entries)),
+                distributed::multihost::Rank{rank});
+            for (auto& [asic_id, mesh_coord] : asic_id_to_mesh_coord_map) {
+                distributed_context->broadcast(
+                    tt::stl::Span<std::byte>(
+                        reinterpret_cast<std::byte*>(const_cast<tt_metal::AsicID*>(&asic_id)), sizeof(asic_id)),
+                    distributed::multihost::Rank{rank});
+                distributed_context->broadcast(
+                    tt::stl::Span<std::byte>(reinterpret_cast<std::byte*>(&(mesh_coord[0])), sizeof(mesh_coord[0])),
+                    distributed::multihost::Rank{rank});
+                distributed_context->broadcast(
+                    tt::stl::Span<std::byte>(reinterpret_cast<std::byte*>(&(mesh_coord[1])), sizeof(mesh_coord[1])),
+                    distributed::multihost::Rank{rank});
+            }
+        } else {
+            std::size_t num_entries = 0;
+            distributed_context->broadcast(
+                tt::stl::Span<std::byte>(reinterpret_cast<std::byte*>(&num_entries), sizeof(num_entries)),
+                distributed::multihost::Rank{rank});
+            for (std::size_t i = 0; i < num_entries; i++) {
+                tt_metal::AsicID asic_id;
+                distributed::MeshCoordinate mesh_coord = distributed::MeshCoordinate(0, 0);
+                distributed_context->broadcast(
+                    tt::stl::Span<std::byte>(reinterpret_cast<std::byte*>(&asic_id), sizeof(asic_id)),
+                    distributed::multihost::Rank{rank});
+                distributed_context->broadcast(
+                    tt::stl::Span<std::byte>(reinterpret_cast<std::byte*>(&(mesh_coord[0])), sizeof(mesh_coord[0])),
+                    distributed::multihost::Rank{rank});
+                distributed_context->broadcast(
+                    tt::stl::Span<std::byte>(reinterpret_cast<std::byte*>(&(mesh_coord[1])), sizeof(mesh_coord[1])),
+                    distributed::multihost::Rank{rank});
+                asic_id_to_mesh_coord_map.emplace(asic_id, mesh_coord);
+            }
+        }
+    }
+
+    return asic_id_to_mesh_coord_map;
+}
+
+PhysicalSystemDescriptor create_physical_system_descriptor() {
+    const auto& cluster = tt::tt_metal::MetalContext::instance().get_cluster();
+    const auto& distributed_context = tt::tt_metal::MetalContext::instance().get_distributed_context_ptr();
+    const auto& hal = tt::tt_metal::MetalContext::instance().hal();
+    const auto& rtoptions = tt::tt_metal::MetalContext::instance().rtoptions();
+    constexpr bool run_discovery = true;
+    const auto& driver = cluster.get_driver();
+
+    return tt::tt_metal::PhysicalSystemDescriptor(driver, distributed_context, &hal, rtoptions, run_discovery);
+}
+
+std::vector<BlitzDecodePipelineStage> build_pipeline(
+    const tt::tt_metal::PhysicalSystemDescriptor& physical_system_descriptor,
+    const std::unordered_map<tt::tt_metal::AsicID, distributed::MeshCoordinate>& asic_id_to_mesh_coord) {
+    std::vector<PhysicalPipelineStageConfig> physical_pipeline_stage_configs = {
+        {.tray_id = 3, .entry_node_asic_location = 7, .exit_node_asic_location = 3},
+        {.tray_id = 1, .entry_node_asic_location = 3, .exit_node_asic_location = 7},
+        {.tray_id = 3, .entry_node_asic_location = 7, .exit_node_asic_location = 4},
+        {.tray_id = 4, .entry_node_asic_location = 4, .exit_node_asic_location = 6},
+        {.tray_id = 2, .entry_node_asic_location = 6, .exit_node_asic_location = 2},
+        {.tray_id = 4, .entry_node_asic_location = 2, .exit_node_asic_location = 5},
+        {.tray_id = 3, .entry_node_asic_location = 5, .exit_node_asic_location = 2},
+        {.tray_id = 1, .entry_node_asic_location = 2, .exit_node_asic_location = 6},
+        {.tray_id = 3, .entry_node_asic_location = 6, .exit_node_asic_location = 4},
+        {.tray_id = 4, .entry_node_asic_location = 4, .exit_node_asic_location = 7},
+        {.tray_id = 2, .entry_node_asic_location = 7, .exit_node_asic_location = 3},
+        {.tray_id = 4, .entry_node_asic_location = 3, .exit_node_asic_location = 7},
+        {.tray_id = 2, .entry_node_asic_location = 7, .exit_node_asic_location = 4},
+        {.tray_id = 1, .entry_node_asic_location = 4, .exit_node_asic_location = 1},
+        {.tray_id = 2, .entry_node_asic_location = 1, .exit_node_asic_location = 4},
+        {.tray_id = 1, .entry_node_asic_location = 4, .exit_node_asic_location = 1},
+
+        {.tray_id = 2, .entry_node_asic_location = 1, .exit_node_asic_location = 7},
+        {.tray_id = 4, .entry_node_asic_location = 7, .exit_node_asic_location = 3},
+        {.tray_id = 2, .entry_node_asic_location = 3, .exit_node_asic_location = 7},
+        {.tray_id = 4, .entry_node_asic_location = 7, .exit_node_asic_location = 4},
+        {.tray_id = 3, .entry_node_asic_location = 4, .exit_node_asic_location = 6},
+        {.tray_id = 1, .entry_node_asic_location = 6, .exit_node_asic_location = 2},
+        {.tray_id = 3, .entry_node_asic_location = 2, .exit_node_asic_location = 6},
+        {.tray_id = 1, .entry_node_asic_location = 6, .exit_node_asic_location = 1},
+        {.tray_id = 2, .entry_node_asic_location = 1, .exit_node_asic_location = 7},
+        {.tray_id = 4, .entry_node_asic_location = 7, .exit_node_asic_location = 3},
+        {.tray_id = 2, .entry_node_asic_location = 3, .exit_node_asic_location = 7},
+        {.tray_id = 4, .entry_node_asic_location = 7, .exit_node_asic_location = 4},
+        {.tray_id = 3, .entry_node_asic_location = 4, .exit_node_asic_location = 6},
+        {.tray_id = 1, .entry_node_asic_location = 6, .exit_node_asic_location = 2},
+        {.tray_id = 3, .entry_node_asic_location = 2, .exit_node_asic_location = 6},
+        {.tray_id = 1, .entry_node_asic_location = 6, .exit_node_asic_location = 1},
+
+        {.tray_id = 2, .entry_node_asic_location = 1, .exit_node_asic_location = 4},
+        {.tray_id = 1, .entry_node_asic_location = 4, .exit_node_asic_location = 1},
+        {.tray_id = 2, .entry_node_asic_location = 1, .exit_node_asic_location = 4},
+        {.tray_id = 1, .entry_node_asic_location = 4, .exit_node_asic_location = 6},
+        {.tray_id = 3, .entry_node_asic_location = 6, .exit_node_asic_location = 2},
+        {.tray_id = 1, .entry_node_asic_location = 2, .exit_node_asic_location = 6},
+        {.tray_id = 3, .entry_node_asic_location = 6, .exit_node_asic_location = 4},
+        {.tray_id = 4, .entry_node_asic_location = 4, .exit_node_asic_location = 7},
+        {.tray_id = 2, .entry_node_asic_location = 7, .exit_node_asic_location = 3},
+        {.tray_id = 4, .entry_node_asic_location = 3, .exit_node_asic_location = 5},
+        {.tray_id = 3, .entry_node_asic_location = 5, .exit_node_asic_location = 2},
+        {.tray_id = 1, .entry_node_asic_location = 2, .exit_node_asic_location = 6},
+        {.tray_id = 3, .entry_node_asic_location = 6, .exit_node_asic_location = 4},
+        {.tray_id = 4, .entry_node_asic_location = 4, .exit_node_asic_location = 7},
+        {.tray_id = 2, .entry_node_asic_location = 7, .exit_node_asic_location = 3},
+        {.tray_id = 4, .entry_node_asic_location = 3, .exit_node_asic_location = 1},
+
+        {.tray_id = 3, .entry_node_asic_location = 1, .exit_node_asic_location = 7}};
+
+    const auto num_procs = *(tt::tt_metal::MetalContext::instance().get_distributed_context_ptr()->size());
+    std::vector<BlitzDecodePipelineStage> logical_pipeline_stage_configs;
+    logical_pipeline_stage_configs.reserve(physical_pipeline_stage_configs.size());
+
+    for (std::size_t stage_index = 0; stage_index < physical_pipeline_stage_configs.size(); stage_index++) {
+        const auto& stage_config = physical_pipeline_stage_configs[stage_index];
+        auto stage_hostname = physical_system_descriptor.get_hostname_for_rank(stage_index % num_procs);
+        auto entry_node_asic_id = physical_system_descriptor.get_asic_id(
+            stage_hostname,
+            tt::tt_metal::TrayID(stage_config.tray_id),
+            tt::tt_metal::ASICLocation(stage_config.entry_node_asic_location));
+        auto exit_node_asic_id = physical_system_descriptor.get_asic_id(
+            stage_hostname,
+            tt::tt_metal::TrayID(stage_config.tray_id),
+            tt::tt_metal::ASICLocation(stage_config.exit_node_asic_location));
+        logical_pipeline_stage_configs.emplace_back(BlitzDecodePipelineStage{
+            .stage_index = stage_index,
+            .entry_node_coord = asic_id_to_mesh_coord.at(entry_node_asic_id),
+            .exit_node_coord = asic_id_to_mesh_coord.at(exit_node_asic_id)});
+    }
+
+    return logical_pipeline_stage_configs;
+}
+
+}  // namespace
+
+std::vector<BlitzDecodePipelineStage> generate_blitz_decode_pipeline(const distributed::MeshDevice& mesh_device) {
+    auto physical_system_descriptor = create_physical_system_descriptor();
+    auto asic_id_to_mesh_coord = get_asic_id_to_mesh_coord_map(mesh_device);
+    return build_pipeline(physical_system_descriptor, asic_id_to_mesh_coord);
+}
+
+}  // namespace tt::tt_metal::experimental::scaleout

--- a/tt_metal/experimental/scaleout/blitz_decode_pipeline.hpp
+++ b/tt_metal/experimental/scaleout/blitz_decode_pipeline.hpp
@@ -1,0 +1,23 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstddef>
+#include <vector>
+
+#include <tt-metalium/mesh_coord.hpp>
+#include <tt-metalium/mesh_device.hpp>
+
+namespace tt::tt_metal::experimental::scaleout {
+
+struct BlitzDecodePipelineStage {
+    std::size_t stage_index;
+    distributed::MeshCoordinate entry_node_coord;
+    distributed::MeshCoordinate exit_node_coord;
+};
+
+std::vector<BlitzDecodePipelineStage> generate_blitz_decode_pipeline(const distributed::MeshDevice& mesh_device);
+
+}  // namespace tt::tt_metal::experimental::scaleout

--- a/ttnn/CMakeLists.txt
+++ b/ttnn/CMakeLists.txt
@@ -283,6 +283,7 @@ set(TTNN_SRC_PYBIND
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/experimental/isin/isin_nanobind.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/experimental/adaptive_pool/adaptive_pools_nanobind.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/experimental/experimental_nanobind.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/experimental/scaleout/blitz_decode_pipeline_nanobind.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/experimental/matmul/attn_matmul/attn_matmul_nanobind.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/experimental/matmul/group_attn_matmul/group_attn_matmul_nanobind.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/experimental/paged_cache/paged_cache_nanobind.cpp

--- a/ttnn/cpp/ttnn/operations/experimental/experimental_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/experimental_nanobind.cpp
@@ -15,6 +15,7 @@
 #include "ttnn/operations/experimental/reduction/integral_image/intimg_nanobind.hpp"
 #include "ttnn/operations/experimental/reduction/deepseek_grouped_gate/deepseek_grouped_gate_nanobind.hpp"
 #include "ttnn/operations/experimental/slice_write/slice_write_nanobind.hpp"
+#include "ttnn/operations/experimental/scaleout/blitz_decode_pipeline_nanobind.hpp"
 #include "ttnn/operations/experimental/ssm/hc_sum_reduce/hc_sum_reduce_nanobind.hpp"
 #include "ttnn/operations/experimental/ssm/prefix_scan/prefix_scan_nanobind.hpp"
 #include "ttnn/operations/experimental/ssm/repeat_and_interleave_eltwise_mul/repeat_and_interleave_eltwise_mul_nanobind.hpp"
@@ -114,6 +115,7 @@ void py_module(nb::module_& mod) {
     plusone::detail::bind_experimental_plusone_operation(mod);
     dropout::detail::bind_experimental_dropout_operation(mod);
     reshape::detail::bind_view(mod);
+    scaleout::detail::bind_blitz_decode_pipeline(mod);
 
     gelu_backward::detail::bind_experimental_gelu_backward_operation(mod);
 

--- a/ttnn/cpp/ttnn/operations/experimental/scaleout/blitz_decode_pipeline_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/scaleout/blitz_decode_pipeline_nanobind.cpp
@@ -1,0 +1,48 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "blitz_decode_pipeline_nanobind.hpp"
+
+#include <sstream>
+
+#include <nanobind/nanobind.h>
+#include <nanobind/stl/vector.h>
+
+#include "tt_metal/experimental/scaleout/blitz_decode_pipeline.hpp"
+
+namespace ttnn::operations::experimental::scaleout::detail {
+
+void bind_blitz_decode_pipeline(nb::module_& mod) {
+    using tt::tt_metal::experimental::scaleout::BlitzDecodePipelineStage;
+
+    nb::class_<BlitzDecodePipelineStage>(mod, "BlitzDecodePipelineStage")
+        .def_ro("stage_index", &BlitzDecodePipelineStage::stage_index)
+        .def_ro("entry_node_coord", &BlitzDecodePipelineStage::entry_node_coord)
+        .def_ro("exit_node_coord", &BlitzDecodePipelineStage::exit_node_coord)
+        .def("__repr__", [](const BlitzDecodePipelineStage& stage) {
+            std::ostringstream repr;
+            repr << "BlitzDecodePipelineStage(stage_index=" << stage.stage_index
+                 << ", entry_node_coord=" << stage.entry_node_coord << ", exit_node_coord=" << stage.exit_node_coord
+                 << ")";
+            return repr.str();
+        });
+
+    mod.def(
+        "generate_blitz_decode_pipeline",
+        [](tt::tt_metal::distributed::MeshDevice& mesh_device) {
+            return tt::tt_metal::experimental::scaleout::generate_blitz_decode_pipeline(mesh_device);
+        },
+        nb::arg("mesh_device"),
+        R"doc(
+            Generate the Blitz decode pipeline stages for the provided mesh device.
+
+            Args:
+                mesh_device (MeshDevice): Mesh device for which to generate the pipeline stages.
+
+            Returns:
+                List[BlitzDecodePipelineStage]: Ordered pipeline stages for Blitz decode.
+        )doc");
+}
+
+}  // namespace ttnn::operations::experimental::scaleout::detail

--- a/ttnn/cpp/ttnn/operations/experimental/scaleout/blitz_decode_pipeline_nanobind.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/scaleout/blitz_decode_pipeline_nanobind.hpp
@@ -1,0 +1,14 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ttnn-nanobind/nanobind_fwd.hpp"
+
+namespace ttnn::operations::experimental::scaleout::detail {
+
+namespace nb = nanobind;
+void bind_blitz_decode_pipeline(nb::module_& mod);
+
+}  // namespace ttnn::operations::experimental::scaleout::detail


### PR DESCRIPTION
### Ticket
Closes: https://github.com/tenstorrent/tt-metal/issues/37787

### Problem description
Provide context for the problem.

### What's changed
Describe the approach used to solve the problem.
Summarize the changes made and its impact.

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=aagarwal/blitz-pipeline-bindings)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:aagarwal/blitz-pipeline-bindings)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=aagarwal/blitz-pipeline-bindings)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:aagarwal/blitz-pipeline-bindings)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=aagarwal/blitz-pipeline-bindings)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:aagarwal/blitz-pipeline-bindings)
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=aagarwal/blitz-pipeline-bindings)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:aagarwal/blitz-pipeline-bindings)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=aagarwal/blitz-pipeline-bindings)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:aagarwal/blitz-pipeline-bindings)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=aagarwal/blitz-pipeline-bindings)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:aagarwal/blitz-pipeline-bindings)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
