### PR TITLE
Fix SDPA TT_METAL_WATCHER issues

### DIFF
--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_flash_mla.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_flash_mla.py
@@ -12,7 +12,7 @@ import torch
 from loguru import logger
 
 import ttnn
-from models.common.utility_functions import comp_pcc, is_blackhole, is_watcher_enabled
+from models.common.utility_functions import comp_pcc
 from models.demos.deepseek_v3_b1.micro_ops.flash_mla.op import FlashMLADecode
 
 
@@ -24,8 +24,6 @@ from models.demos.deepseek_v3_b1.micro_ops.flash_mla.op import FlashMLADecode
 @pytest.mark.parametrize("max_seq_len", [32 * 1024])  # 32k max sequence length per chip
 def test_flash_mla_decode(device, batch_size, num_chunks, k_chunk_size, max_seq_len):
     """Test FlashMLADecode op."""
-    if is_blackhole() and is_watcher_enabled():
-        pytest.skip("Skipping test on Blackhole with watcher enabled, see issue #37631")
 
     # Calculate decode_position from num_chunks and k_chunk_size
     decode_position = num_chunks * k_chunk_size - 1

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_flash_mla.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_flash_mla.py
@@ -12,7 +12,7 @@ import torch
 from loguru import logger
 
 import ttnn
-from models.common.utility_functions import comp_pcc
+from models.common.utility_functions import comp_pcc, is_blackhole, is_watcher_enabled
 from models.demos.deepseek_v3_b1.micro_ops.flash_mla.op import FlashMLADecode
 
 
@@ -24,6 +24,8 @@ from models.demos.deepseek_v3_b1.micro_ops.flash_mla.op import FlashMLADecode
 @pytest.mark.parametrize("max_seq_len", [32 * 1024])  # 32k max sequence length per chip
 def test_flash_mla_decode(device, batch_size, num_chunks, k_chunk_size, max_seq_len):
     """Test FlashMLADecode op."""
+    if is_blackhole() and is_watcher_enabled():
+        pytest.skip("Skipping test on Blackhole with watcher enabled, see issue #37631")
 
     # Calculate decode_position from num_chunks and k_chunk_size
     decode_position = num_chunks * k_chunk_size - 1

--- a/tests/ttnn/unit_tests/operations/sdpa/test_sdpa_prefill.py
+++ b/tests/ttnn/unit_tests/operations/sdpa/test_sdpa_prefill.py
@@ -20,10 +20,6 @@ def fa_rand(*shape):
     return normal_1 + normal_2 * bernoulli
 
 
-def is_watcher_enabled():
-    return os.environ.get("TT_METAL_WATCHER") is not None
-
-
 def create_sliding_window_mask_prefill(b, nh, seq_len, sliding_window=0, is_causal=True):
     """
     Create attention mask for sliding window attention in prefill mode.
@@ -568,7 +564,6 @@ def run_test_sdpa_with_attention_sink(
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.skipif(is_watcher_enabled(), reason="Kernel OOM with watcher enabled")
 @pytest.mark.parametrize("dtype", [ttnn.bfloat8_b], ids=["bfp8"])
 @pytest.mark.parametrize("memory_config", [ttnn.DRAM_MEMORY_CONFIG], ids=["dram_interleaved"])
 @pytest.mark.parametrize("q_chunk_size", [128], ids=["q128"])
@@ -598,7 +593,6 @@ def test_sdpa_tt(device, b, nh, nkv, s, d, q_chunk_size, k_chunk_size, dtype, me
     )
 
 
-@pytest.mark.skipif(is_watcher_enabled(), reason="Kernel OOM with watcher enabled")
 @pytest.mark.parametrize("dtype", [ttnn.bfloat16], ids=["bf16"])
 @pytest.mark.parametrize("q_chunk_size", [128], ids=["q128"])
 @pytest.mark.parametrize("k_chunk_size", [128], ids=["k128"])
@@ -615,7 +609,6 @@ def test_sdpa_noncausal(device, b, nh, nkv, s, d, q_chunk_size, k_chunk_size, dt
     run_sdpa_noncausal(device, b, nh, nkv, s, d, q_chunk_size, k_chunk_size, dtype, rmse_threshold=rmse_threshold)
 
 
-@pytest.mark.skipif(is_watcher_enabled(), reason="Kernel OOM with watcher enabled")
 @pytest.mark.parametrize("dtype", [ttnn.bfloat8_b], ids=["bfp8"])
 @pytest.mark.parametrize("q_chunk_size", [128], ids=["q128"])
 @pytest.mark.parametrize("k_chunk_size", [128], ids=["k128"])
@@ -635,7 +628,6 @@ def test_sdpa_tt_with_program_cache(device, b, nh, nkv, s, d, q_chunk_size, k_ch
     assert device.num_program_cache_entries() == 1
 
 
-@pytest.mark.skipif(is_watcher_enabled(), reason="Kernel OOM with watcher enabled")
 @pytest.mark.parametrize("dtype", [ttnn.bfloat8_b], ids=["bfp8"])
 @pytest.mark.parametrize("q_chunk_size", [256], ids=["q256"])
 @pytest.mark.parametrize("k_chunk_size", [256], ids=["k256"])

--- a/ttnn/cpp/ttnn/kernel/dataflow/generate_reduce_scaler.hpp
+++ b/ttnn/cpp/ttnn/kernel/dataflow/generate_reduce_scaler.hpp
@@ -8,10 +8,11 @@
 
 // Tile is assumed to have 16-bit elements
 // Scaler is assumed to be a 16-bit value double packed into a u32
+template <bool half_tile = false>
 FORCE_INLINE void generate_reduce_scaler(const uint32_t cb_id, const uint32_t scaler) {
     cb_reserve_back(cb_id, 1);
 
-    constexpr uint32_t num_zeros_reads = 2048 / MEM_ZEROS_SIZE;
+    constexpr uint32_t num_zeros_reads = (half_tile ? 1024 : 2048) / MEM_ZEROS_SIZE;
     static_assert(num_zeros_reads > 0, "num_zeros_reads must be greater than 0");
     uint64_t zeros_noc_addr = get_noc_addr(MEM_ZEROS_BASE);
     uint32_t write_addr = get_write_ptr(cb_id);
@@ -27,7 +28,7 @@ FORCE_INLINE void generate_reduce_scaler(const uint32_t cb_id, const uint32_t sc
     noc_async_read_barrier();
 
     if (scaler != 0) {
-        for (int k = 0; k < 4; ++k) {
+        for (int k = 0; k < (half_tile ? 2 : 4); ++k) {
             uint32_t idx = k << 7;
             for (int j = 0; j < 8; ++j) {
                 ptr[idx + j] = scaler;

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/dataflow/writer_decode_all.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/dataflow/writer_decode_all.cpp
@@ -134,9 +134,9 @@ void kernel_main() {
     constexpr uint32_t cb_out_l = tt::CBIndex::c_18;
 
     // generate and send scaler to compute
-    // These helper functions respect tile size of CBs (ie. no need for special handling of tiny tiles)
-    generate_reduce_scaler(cb_identity_scale_in, identity_scalar_packed);
-    generate_reduce_scaler(cb_zero_in, zero_scalar_packed);
+    constexpr bool is_half_tile = (get_tile_size(cb_identity_scale_in) < 2 * tt::constants::TILE_HW);
+    generate_reduce_scaler<is_half_tile>(cb_identity_scale_in, identity_scalar_packed);
+    generate_reduce_scaler<is_half_tile>(cb_zero_in, zero_scalar_packed);
     generate_bcast_col_scalar(cb_col_identity, identity_scalar_packed);
 
     if (k_chunk_start == window_start_chunk && window_start_unaligned > 0) {

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/sdpa_decode_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/sdpa_decode_program_factory.cpp
@@ -1011,7 +1011,7 @@ SdpaDecodeProgramFactory::cached_program_t SdpaDecodeProgramFactory::create(
         for (auto core : core_group_idle) {
             log_debug(tt::LogOp, "Setting core {} to idle", core);
             // reader runtime args
-            std::vector<uint32_t> reader_rt_args = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+            std::vector<uint32_t> reader_rt_args = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
 
             // writer runtime args
             std::vector<uint32_t> writer_rt_args = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0};


### PR DESCRIPTION
Commit 89175b6e79d9386349aee72aea0abacd522dd0d7 introduced SDPA op to all post commit workflow.
This workflow is now covered in CI by TT_METAL_WATCHER checks. Now they will start to fail.

`generate_reduce_scaler` hardcoded 2048 bytes and 4 faces, assuming full 32x32 bf16 tiles. When circular buffers use half tiles (1024B, 2 faces), this overwrites adjacent L1 memory causing watcher-detected corruption.

Restore the `half_tile` template parameter (previously removed in cleanup) so the zero-fill size and face iteration adapt to the actual tile dimensions. Also fix idle core runtime args count mismatch in sdpa_decode_program_factory.

Fixes: https://github.com/tenstorrent/tt-metal/issues/37631
Fixes: https://github.com/tenstorrent/tt-metal/issues/29225

  - [x] [All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/runs/21982040978)                                                                 
  - [ ] [Blackhole post-commit tests](https://github.com/tenstorrent/tt-metal/actions/runs/21982049043)                                                           
  - [x] [Nightly tt-metal L2 tests](https://github.com/tenstorrent/tt-metal/actions/runs/21982072169)                                                             
  - [ ] [apc nightly debug run with watcher](https://github.com/tenstorrent/tt-metal/actions/runs/22019008948)