### PR TITLE
Reduce DeepSeek long-seq decoder override to 12288

### DIFF
--- a/.github/workflows/galaxy-deepseek-tests-impl.yaml
+++ b/.github/workflows/galaxy-deepseek-tests-impl.yaml
@@ -81,7 +81,7 @@ jobs:
       volumes:
         - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
         - /dev/hugepages-1G:/dev/hugepages-1G
-        - /mnt/MLPerf:/mnt/MLPerf:ro
+        - /mnt/MLPerf:/mnt/MLPerf:rw
       options: "--device /dev/tenstorrent"
     defaults:
       run:

--- a/.github/workflows/galaxy-deepseek-tests-impl.yaml
+++ b/.github/workflows/galaxy-deepseek-tests-impl.yaml
@@ -122,7 +122,7 @@ jobs:
         run: |
           uv pip install -r models/demos/deepseek_v3/reference/deepseek/requirements.txt
           DEEPSEEK_MAX_SEQ_LEN_OVERRIDE=16384 pytest models/demos/deepseek_v3/tests/test_mla.py --timeout 900 --durations=0
-          DEEPSEEK_MAX_SEQ_LEN_OVERRIDE=16384 pytest models/demos/deepseek_v3/tests/test_decoder_block.py --timeout 2400 --durations=0
+          DEEPSEEK_MAX_SEQ_LEN_OVERRIDE=12288 pytest models/demos/deepseek_v3/tests/test_decoder_block.py --timeout 2400 --durations=0
           # TODO: set DEEPSEEK_MAX_SEQ_LEN_OVERRIDE to large value if test does not get killed in CI.
           DEEPSEEK_MAX_SEQ_LEN_OVERRIDE=1024 pytest models/demos/deepseek_v3/tests/test_model.py --timeout 2500 --durations=0
       - uses: tenstorrent/tt-metal/.github/actions/slack-report@main

--- a/.github/workflows/galaxy-deepseek-tests-impl.yaml
+++ b/.github/workflows/galaxy-deepseek-tests-impl.yaml
@@ -81,7 +81,7 @@ jobs:
       volumes:
         - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
         - /dev/hugepages-1G:/dev/hugepages-1G
-        - /mnt/MLPerf:/mnt/MLPerf:rw
+        - /mnt/MLPerf:/mnt/MLPerf:ro
       options: "--device /dev/tenstorrent"
     defaults:
       run:


### PR DESCRIPTION
## Background
The Galaxy long-seq decoder-block job in [run #21973954244/job/63481804018](https://github.com/tenstorrent/tt-metal/actions/runs/21973954244/job/63481804018) was OOM-killed on host at `DEEPSEEK_MAX_SEQ_LEN_OVERRIDE=16384`.

## Change
This PR reduces the decoder-block override only:
- `DEEPSEEK_MAX_SEQ_LEN_OVERRIDE=12288` for `models/demos/deepseek_v3/tests/test_decoder_block.py`

The `test_mla.py` invocation remains at `16384`, and `test_model.py` stays at `1024`.

## Why
`12288` lowers peak memory for the long sequence decoder-block path while preserving the extended long-seq coverage in CI. It targets the specific failure mode seen in the run above without weakening other test matrix coverage.

## Verification
A rerun was kicked off on this branch:
- [![Galaxy DeepSeek long-seq](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-deepseek-tests.yaml/badge.svg?branch=chore/reduce-deepseek-decoder-seq-len-12288&event=workflow_dispatch)](https://github.com/tenstorrent/tt-metal/actions/runs/21983835196)
- Run URL: https://github.com/tenstorrent/tt-metal/actions/runs/21983835196
