### PR TITLE
SDXL clip encoder perf targets updated

### DIFF
--- a/models/experimental/stable_diffusion_xl_base/tests/test_sdxl_perf.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/test_sdxl_perf.py
@@ -133,7 +133,7 @@ def test_refiner_unet(
         ),
         (
             "pytest models/experimental/stable_diffusion_xl_base/tests/pcc/test_sdxl_clip_encoders.py::test_clip_encoder -k 'encoder_1'",
-            13_112_562,
+            14_609_421,
             "sdxl_clip_encoder_1",
             "sdxl_clip_encoder_1",
             CLIP_ENCODER_DEVICE_TEST_TOTAL_ITERATIONS,
@@ -143,7 +143,7 @@ def test_refiner_unet(
         ),
         (
             "pytest models/experimental/stable_diffusion_xl_base/tests/pcc/test_sdxl_clip_encoders.py::test_clip_encoder -k 'encoder_2'",
-            63_591_763,  # Note: this is an average value of 30 test runs due to high variability
+            70_551_148,  # Note: this is an average value of 30 test runs due to high variability
             "sdxl_clip_encoder_2",
             "sdxl_clip_encoder_2",
             CLIP_ENCODER_DEVICE_TEST_TOTAL_ITERATIONS,


### PR DESCRIPTION
### Problem description
Clip encoders perf test in (Single-card) Device perf regressions is failing [link](https://github.com/tenstorrent/tt-metal/actions/runs/21983204329/job/63511507999), due to [Respect MM throttle level in minimal_matmul](https://github.com/tenstorrent/tt-metal/commit/bc6d2860911b65ab3a96a38f4dc4dc3ec981b57b)

### What's changed
Encoders perf targets updated

encoders perf results analysis [link](https://docs.google.com/spreadsheets/d/1QqFnAsQaNifQMH27a8Q5QKoGzBW_bWYlJV6xJYdYGgM/edit?usp=sharing)

### Checklist
- [x] [SDXL (Single-card) Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/runs/21985451450) ✅passes

