### PR TITLE
Fix yaml path reading in nano_gpt and mesh shape in autograd

### DIFF
--- a/tt-train/sources/examples/nano_gpt/main.cpp
+++ b/tt-train/sources/examples/nano_gpt/main.cpp
@@ -313,7 +313,11 @@ int main(int argc, char **argv) {
 
     TrainingConfig training_config = parse_config(yaml_config);
     DeviceConfig device_config = parse_device_config(yaml_config);
-    ModelConfig model_config = parse_model_config(YAML::LoadFile(training_config.model_config));
+    // Resolve model_config path relative to tt-train root (configs/training_configs/ -> configs/ -> tt-train)
+    auto training_config_path = std::filesystem::path(training_config_name).parent_path();
+    std::string model_config_path =
+        (training_config_path.parent_path().parent_path() / training_config.model_config).string();
+    ModelConfig model_config = parse_model_config(YAML::LoadFile(model_config_path));
 
     // Pass tt::tt_metal::IGraphProcessor::RunMode::NO_DISPATCH to measure memory usage
     // of model that doesn't fit in the memory of the device.

--- a/tt-train/sources/ttml/autograd/auto_context.cpp
+++ b/tt-train/sources/ttml/autograd/auto_context.cpp
@@ -131,9 +131,13 @@ void AutoContext::initialize_socket_manager(ttnn::distributed::SocketType socket
 
 ParallelismContext::ParallelismContext(
     const ttnn::distributed::MeshDevice& mesh_device, const DistributedConfig& config) {
+    const uint32_t num_axes = (uint32_t)config.enable_ddp + (uint32_t)config.enable_tp;
+    const size_t mesh_dims = mesh_device.shape().dims();
+    const size_t mesh_size = mesh_device.shape().mesh_size();
     TT_FATAL(
-        (uint32_t)config.enable_ddp + (uint32_t)config.enable_tp == mesh_device.shape().dims(),
-        "The number of parallelization axes must be equal to the number of mesh shape dimensions");
+        (mesh_size == 1 && num_axes == 0) || (mesh_size > 1 && num_axes == mesh_dims),
+        "Invalid parallelization configuration: for a single-device mesh, the number of parallelization axes must be "
+        "0; for a multi-device mesh, it must be equal to the number of mesh shape dimensions.");
 
     uint32_t axis = 0;
     if (config.enable_ddp) {


### PR DESCRIPTION
### Ticket
None

### Problem description

When trying to run the `nano_gpt` on BH via the command bellow 2 errors occur:

`TT_LOGGER_LEVEL=FATAL ./build_Release/tt-train/sources/examples/nano_gpt/nano_gpt -c ./tt-train/configs/training_configs/training_shakespeare_nanogpt.yaml`

First error is:
```
terminate called after throwing an instance of 'YAML::BadFile'
  what():  bad file: configs/model_configs/nanogpt.yaml
```

Second error happens on a single BH card:
```
2026-02-13 11:37:04.836 | critical |          Always | TT_FATAL: The number of parallelization axes must be equal to the number of mesh shape dimensions (assert.hpp:104)
terminate called after throwing an instance of 'std::runtime_error'
  what():  TT_FATAL @ /proj_sw/user_dev/vtsilytskyi/tt-metal/tt-train/sources/ttml/autograd/auto_context.cpp:136: (uint32_t)config.enable_ddp + (uint32_t)config.enable_tp == mesh_device.shape().dims()
```

### What's changed
1. Resolve model_config path relative to tt-train root
2. Enforce a single, consistent rule between the mesh shape and the parallelization config, and to fail fast when they don’t match.

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=vlad/fix-yaml-path)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:vlad/fix-yaml-path)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=vlad/fix-yaml-path)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:vlad/fix-yaml-path)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=vlad/fix-yaml-path)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:vlad/fix-yaml-path)
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=vlad/fix-yaml-path)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:vlad/fix-yaml-path)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=vlad/fix-yaml-path)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:vlad/fix-yaml-path)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=vlad/fix-yaml-path)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:vlad/fix-yaml-path)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
