### PR TITLE
[skip ci] Fix Package and release workflow

### DIFF
--- a/.github/workflows/release-build-test-publish.yaml
+++ b/.github/workflows/release-build-test-publish.yaml
@@ -90,7 +90,6 @@ jobs:
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       enabled-skus: "wh_llmbox_perf"
       mlperf-read-only: ${{ !(github.ref == 'refs/heads/stable' || startsWith(github.ref, 'refs/tags/v')) }}
-      extra-tag: "in-release"
 
   galaxy-demos:
     needs: build-artifact


### PR DESCRIPTION
### Problem description
Currently Package and release workflow is failing because extra tag doesn't exist anymore in t3k demo tests

### What's changed
Remove extra tag

