### PR TITLE
Remove unnecessary flushed barrier between data and semaphore multicast in conv ops

### DIFF
--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/activation_reader_width_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/activation_reader_width_sharded.cpp
@@ -237,11 +237,6 @@ void kernel_main() {
                     // vc even though cmd bufs are different Also, this only works because we are setting VCs statically
                     // (using NOC_CMD_STATIC_VC).
 
-#ifdef ARCH_BLACKHOLE
-                    // On Blackhole the flush is needed because the commands go into separate cmd buffer FIFOs and may
-                    // not be sent in order they are issued
-                    noc_async_writes_flushed();
-#endif
                     // We should also multicast VALID flag to destinations for receiver semaphore
                     noc_semaphore_set_multicast_loopback_src(
                         act_mcast_sender_semaphore_valid_addr,

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/reader_conv_activations_2d_mcast_padded_with_halo_3x3_weights_v2.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/reader_conv_activations_2d_mcast_padded_with_halo_3x3_weights_v2.cpp
@@ -282,11 +282,6 @@ void kernel_main() {
                     // Note: no need for write barrier, since these two multicasts are done on the same noc id and
                     // same vc even though cmd bufs are different Also, this only works because we are setting VCs
                     // statically (using NOC_CMD_STATIC_VC).
-#ifdef ARCH_BLACKHOLE
-                    // On Blackhole the flush is needed because the commands go into separate cmd buffer FIFOs and
-                    // may not be sent in order they are issued
-                    noc_async_writes_flushed();
-#endif
 
                     if (is_receiver_core) {
                         // We should also multicast VALID flag to destinations for receiver semaphore

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/reader_writer_tiled_out_1d_mcast_sender_conv_weights_tiled_col_to_rm_blocks.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/reader_writer_tiled_out_1d_mcast_sender_conv_weights_tiled_col_to_rm_blocks.cpp
@@ -255,12 +255,6 @@ void kernel_main() {
                 // Note: no need for write barrier, since these two multicasts are done on the same noc id and
                 // same vc even though cmd bufs are different Also, this only works because we are setting VCs
                 // statically (using NOC_CMD_STATIC_VC).
-#ifdef ARCH_BLACKHOLE
-                // On Blackhole the flush is needed because the commands go into separate cmd buffer FIFOs and
-                // may not be sent in order they are issued
-                noc_async_writes_flushed();
-#endif
-
                 // We should also multicast the flag to destinations
                 // num_dests must not include source, since we are NOT really doing a local copy!
                 noc_semaphore_set_multicast(
@@ -314,12 +308,6 @@ void kernel_main() {
                 // Note: no need for write barrier, since these two multicasts are done on the same noc id and same vc
                 // even though cmd bufs are different Also, this only works because we are setting VCs statically (using
                 // NOC_CMD_STATIC_VC).
-#ifdef ARCH_BLACKHOLE
-                // On Blackhole the flush is needed because the commands go into separate cmd buffer FIFOs and may not
-                // be sent in order they are issued
-                noc_async_writes_flushed();
-#endif
-
                 // We should also multicast the flag to destinations
                 // num_dests must not include source, since we are NOT really doing a local copy!
                 noc_semaphore_set_multicast(

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/writer_tiled_out_2d_mcast_sender_conv_weights_tiled_col_to_rm_blocks.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/writer_tiled_out_2d_mcast_sender_conv_weights_tiled_col_to_rm_blocks.cpp
@@ -267,11 +267,6 @@ void kernel_main() {
                     // Note: no need for write barrier, since these two multicasts are done on the same noc id and same
                     // vc even though cmd bufs are different Also, this only works because we are setting VCs statically
                     // (using NOC_CMD_STATIC_VC).
-#ifdef ARCH_BLACKHOLE
-                    // On Blackhole the flush is needed because the commands go into separate cmd buffer FIFOs and may
-                    // not be sent in order they are issued
-                    noc_async_writes_flushed();
-#endif
                     // We should also multicast the flag to destinations
                     // num_dests must not include source, since we are NOT really doing a local copy!
                     noc_semaphore_set_multicast(
@@ -332,11 +327,6 @@ void kernel_main() {
                     // Note: no need for write barrier, since these two multicasts are done on the same noc id and same
                     // vc even though cmd bufs are different Also, this only works because we are setting VCs statically
                     // (using NOC_CMD_STATIC_VC).
-#ifdef ARCH_BLACKHOLE
-                    // On Blackhole the flush is needed because the commands go into separate cmd buffer FIFOs and may
-                    // not be sent in order they are issued
-                    noc_async_writes_flushed();
-#endif
                     // We should also multicast the flag to destinations
                     // num_dests must not include source, since we are NOT really doing a local copy!
                     noc_semaphore_set_multicast(


### PR DESCRIPTION
### Problem description
- Remove `ARCH_BLACKHOLE`-gated `noc_async_writes_flushed()` calls between data multicast and semaphore multicast in convolution dataflow kernels.
- These barriers are not needed since the multicasts use the same NOC id and VC with static VC assignment (`NOC_CMD_STATIC_VC`).

This async_writes_flushed() was needed while blackhole cmd buffer fifo feature was on. It was disabled  on Sep 25, 2024
868dae19444.

### What's changed
- `activation_reader_width_sharded.cpp`
- `reader_conv_activations_2d_mcast_padded_with_halo_3x3_weights_v2.cpp`
- `reader_writer_tiled_out_1d_mcast_sender_conv_weights_tiled_col_to_rm_blocks.cpp`
- `writer_tiled_out_2d_mcast_sender_conv_weights_tiled_col_to_rm_blocks.cpp`

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=vvukomanovic/conv-flushed-barrier-removal)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:vvukomanovic/conv-flushed-barrier-removal)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=vvukomanovic/conv-flushed-barrier-removal)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:vvukomanovic/conv-flushed-barrier-removal)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=vvukomanovic/conv-flushed-barrier-removal)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:vvukomanovic/conv-flushed-barrier-removal)
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=vvukomanovic/conv-flushed-barrier-removal)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:vvukomanovic/conv-flushed-barrier-removal)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=vvukomanovic/conv-flushed-barrier-removal)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:vvukomanovic/conv-flushed-barrier-removal)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=vvukomanovic/conv-flushed-barrier-removal)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:vvukomanovic/conv-flushed-barrier-removal)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
