### PR TITLE
Fused rmsnorm allow fp32 stat and rope inputs

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/transformer/fused_distributed_rmsnorm/rmsnorm_distributed_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/fused_distributed_rmsnorm/rmsnorm_distributed_nanobind.cpp
@@ -35,6 +35,9 @@ void bind_rmsnorm_pre_all_gather_operation(nb::module_& mod) {
                 * - BFLOAT16
                   - TILE
 
+            Arguments:
+              - :attr:`dtype`: Output dtype for the stats tensor (default BFLOAT16). Can be BFLOAT16 or FLOAT32.
+
             Returns:
               - A TILE-layout tensor of dtype ``dtype`` (default BFLOAT16) with the same leading dimensions as
                 :attr:`input_tensor` and with the last padded dimension equal to TILE_WIDTH (32). The tile holds
@@ -83,7 +86,7 @@ void bind_rmsnorm_post_all_gather_operation(nb::module_& mod) {
 
                 * - dtype
                   - layout
-                * - BFLOAT16
+                * - BFLOAT16 or FLOAT32
                   - TILE
 
               .. list-table:: weight (gamma)
@@ -111,7 +114,7 @@ void bind_rmsnorm_post_all_gather_operation(nb::module_& mod) {
                   - dtype
                   - layout
                 * - [1, 1, seq_len, head_dim]
-                  - BFLOAT16
+                  - BFLOAT16 or FLOAT32
                   - TILE
 
             Arguments:


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/37747

### Problem description
Fused rmsnorm did not allow stats or ROPE inputs to be fp32. This is can be necessary for best correctness results.

### What's changed
Update validation and add a test.

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=cglagovich/rmsnorm_fp32)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:cglagovich/rmsnorm_fp32)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=cglagovich/rmsnorm_fp32)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:cglagovich/rmsnorm_fp32)
- [x] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=cglagovich/rmsnorm_fp32)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:cglagovich/rmsnorm_fp32)
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=cglagovich/rmsnorm_fp32)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:cglagovich/rmsnorm_fp32)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=cglagovich/rmsnorm_fp32)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:cglagovich/rmsnorm_fp32)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=cglagovich/rmsnorm_fp32)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:cglagovich/rmsnorm_fp32)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
