### PR TITLE
fix(sweep): correct lead-models Slack notifier's run context, counts, and alerting

### DIFF
--- a/.github/actions/sweep-run-analysis/action.yaml
+++ b/.github/actions/sweep-run-analysis/action.yaml
@@ -20,6 +20,9 @@ inputs:
   source-git-branch:
     description: 'Git branch from the triggering ttnn-run-sweeps workflow run'
     required: false
+  slack-alert-user-ids:
+    description: 'Comma-separated Slack user IDs to mention on non-green results (e.g., U123,U456)'
+    required: false
   slack-webhook-url:
     description: 'Slack webhook URL for notifications'
     required: true
@@ -81,6 +84,7 @@ runs:
         CONCLUSION: ${{ inputs.conclusion }}
         SOURCE_GITHUB_RUN_ID: ${{ inputs.github-run-id }}
         SOURCE_GITHUB_RUN_NUMBER: ${{ inputs.source-github-run-number }}
+        SLACK_ALERT_USER_IDS: ${{ inputs.slack-alert-user-ids }}
         RESULTS_FILE: sweep_results.json
       run: |
         echo "Sending Slack notification..."

--- a/.github/actions/sweep-run-analysis/action.yaml
+++ b/.github/actions/sweep-run-analysis/action.yaml
@@ -11,6 +11,12 @@ inputs:
   conclusion:
     description: 'Workflow conclusion (success, failure, cancelled)'
     required: true
+  source-git-sha:
+    description: 'Git SHA from the triggering ttnn-run-sweeps workflow run'
+    required: false
+  source-git-branch:
+    description: 'Git branch from the triggering ttnn-run-sweeps workflow run'
+    required: false
   slack-webhook-url:
     description: 'Slack webhook URL for notifications'
     required: true
@@ -35,11 +41,10 @@ runs:
       shell: bash
       env:
         DATABASE_URL: ${{ inputs.database-url }}
-        GITHUB_RUN_ID: ${{ inputs.github-run-id }}
-        RUN_TYPE: ${{ inputs.run-type }}
+        SOURCE_GITHUB_RUN_ID: ${{ inputs.github-run-id }}
         RESULTS_FILE: sweep_results.json
       run: |
-        echo "Querying database for run $GITHUB_RUN_ID..."
+        echo "Querying database for run $SOURCE_GITHUB_RUN_ID..."
         python ${{ github.action_path }}/scripts/extract_sweep_results.py
       continue-on-error: true
 
@@ -60,6 +65,8 @@ runs:
         ARTIFACTS_DIR: ./sweep-results
         RESULTS_FILE: sweep_results.json
         ARCH_NAME: ${{ inputs.run-type }}
+        SOURCE_GIT_SHA: ${{ inputs.source-git-sha }}
+        SOURCE_GIT_BRANCH: ${{ inputs.source-git-branch }}
       run: |
         echo "Database unavailable, parsing artifacts instead..."
         python ${{ github.action_path }}/scripts/parse_sweep_artifacts.py
@@ -69,7 +76,7 @@ runs:
       env:
         SLACK_WEBHOOK_URL: ${{ inputs.slack-webhook-url }}
         CONCLUSION: ${{ inputs.conclusion }}
-        GITHUB_RUN_ID: ${{ inputs.github-run-id }}
+        SOURCE_GITHUB_RUN_ID: ${{ inputs.github-run-id }}
         RESULTS_FILE: sweep_results.json
       run: |
         echo "Sending Slack notification..."

--- a/.github/actions/sweep-run-analysis/action.yaml
+++ b/.github/actions/sweep-run-analysis/action.yaml
@@ -5,6 +5,9 @@ inputs:
   github-run-id:
     description: 'GitHub Actions run ID to analyze'
     required: true
+  source-github-run-number:
+    description: 'GitHub Actions run number from the triggering ttnn-run-sweeps workflow run'
+    required: false
   run-type:
     description: 'Type of sweep run (nightly, comprehensive, model_traced, lead_models)'
     required: true
@@ -77,6 +80,7 @@ runs:
         SLACK_WEBHOOK_URL: ${{ inputs.slack-webhook-url }}
         CONCLUSION: ${{ inputs.conclusion }}
         SOURCE_GITHUB_RUN_ID: ${{ inputs.github-run-id }}
+        SOURCE_GITHUB_RUN_NUMBER: ${{ inputs.source-github-run-number }}
         RESULTS_FILE: sweep_results.json
       run: |
         echo "Sending Slack notification..."

--- a/.github/actions/sweep-run-analysis/scripts/extract_sweep_results.py
+++ b/.github/actions/sweep-run-analysis/scripts/extract_sweep_results.py
@@ -41,7 +41,7 @@ def get_current_run(conn, github_run_id: int) -> Optional[dict]:
         return dict(row) if row else None
 
 
-def get_previous_run(conn, run_contents: str, card_type: str, current_run_id: int) -> Optional[dict]:
+def get_previous_run(conn, run_contents: str, card_type: str, git_branch: str, current_run_id: int) -> Optional[dict]:
     """Find previous run of same type for comparison."""
     with conn.cursor(cursor_factory=RealDictCursor) as cur:
         cur.execute(
@@ -52,11 +52,12 @@ def get_previous_run(conn, run_contents: str, card_type: str, current_run_id: in
             FROM sweep_run
             WHERE run_contents = %s
               AND card_type = %s
+              AND git_branch = %s
               AND run_id < %s
             ORDER BY run_id DESC
             LIMIT 1
             """,
-            (run_contents, card_type, current_run_id),
+            (run_contents, card_type, git_branch, current_run_id),
         )
         row = cur.fetchone()
         return dict(row) if row else None
@@ -296,6 +297,7 @@ def main():
             conn,
             current_run["run_contents"],
             current_run["card_type"],
+            current_run["git_branch"],
             current_run_id,
         )
 

--- a/.github/actions/sweep-run-analysis/scripts/extract_sweep_results.py
+++ b/.github/actions/sweep-run-analysis/scripts/extract_sweep_results.py
@@ -269,9 +269,9 @@ def get_models_tested(conn, current_run_id: int) -> list[str]:
 
 
 def main():
-    github_run_id = int(os.environ.get("GITHUB_RUN_ID", 0))
+    github_run_id = int(os.environ.get("SOURCE_GITHUB_RUN_ID", os.environ.get("GITHUB_RUN_ID", 0)))
     if not github_run_id:
-        print("ERROR: GITHUB_RUN_ID environment variable not set", file=sys.stderr)
+        print("ERROR: SOURCE_GITHUB_RUN_ID environment variable not set", file=sys.stderr)
         sys.exit(1)
 
     try:
@@ -281,7 +281,8 @@ def main():
         sys.exit(1)
 
     try:
-        # Get current run
+        # Get current run by source workflow run id.
+        # This must match the exact run pushed by ttnn-run-sweeps.
         current_run = get_current_run(conn, github_run_id)
         if not current_run:
             print(f"ERROR: No run found for github_pipeline_id={github_run_id}", file=sys.stderr)

--- a/.github/actions/sweep-run-analysis/scripts/parse_sweep_artifacts.py
+++ b/.github/actions/sweep-run-analysis/scripts/parse_sweep_artifacts.py
@@ -70,10 +70,12 @@ def parse_artifacts(artifacts_dir: str) -> dict:
         for model, count in sorted(failures_by_model.items(), key=lambda x: -x[1])
     ]
 
-    # Get card_type and git info from environment or first test
+    # Get card_type and source git info from workflow inputs.
+    # SOURCE_* vars are used because default GITHUB_* vars point to the notifier workflow run.
     card_type = os.environ.get("ARCH_NAME", "unknown")
-    git_sha = os.environ.get("GITHUB_SHA", "")[:8] if os.environ.get("GITHUB_SHA") else ""
-    git_branch = os.environ.get("GITHUB_REF_NAME", "")
+    source_git_sha = os.environ.get("SOURCE_GIT_SHA", "")
+    git_sha = source_git_sha[:8] if source_git_sha else ""
+    git_branch = os.environ.get("SOURCE_GIT_BRANCH", "")
 
     results = {
         "run_id": None,  # No run_id when parsing artifacts
@@ -109,8 +111,8 @@ def create_empty_results() -> dict:
             "pass_pct": 0,
             "prev_pass_pct": None,
             "card_type": os.environ.get("ARCH_NAME", "unknown"),
-            "git_sha": os.environ.get("GITHUB_SHA", "")[:8] if os.environ.get("GITHUB_SHA") else "",
-            "git_branch": os.environ.get("GITHUB_REF_NAME", ""),
+            "git_sha": os.environ.get("SOURCE_GIT_SHA", "")[:8] if os.environ.get("SOURCE_GIT_SHA") else "",
+            "git_branch": os.environ.get("SOURCE_GIT_BRANCH", ""),
         },
         "pass_rate_regressions": [],
         "perf_regressions_by_op": [],

--- a/.github/actions/sweep-run-analysis/scripts/send_slack_notification.py
+++ b/.github/actions/sweep-run-analysis/scripts/send_slack_notification.py
@@ -19,6 +19,7 @@ SLACK_CHANNEL = os.environ.get("SLACK_CHANNEL", "")  # Required with bot token
 CONCLUSION = os.environ.get("CONCLUSION", "success")  # success, failure, cancelled
 GITHUB_RUN_ID = os.environ.get("SOURCE_GITHUB_RUN_ID", os.environ.get("GITHUB_RUN_ID", ""))
 GITHUB_RUN_NUMBER = os.environ.get("SOURCE_GITHUB_RUN_NUMBER", "")
+SLACK_ALERT_USER_IDS = os.environ.get("SLACK_ALERT_USER_IDS", "")
 SUPERSET_BASE_URL = "https://superset.tenstorrent.com/superset/dashboard/lead-models-sweep-run/"
 GITHUB_ACTIONS_URL = f"https://github.com/tenstorrent/tt-metal/actions/runs/{GITHUB_RUN_ID}"
 
@@ -93,6 +94,40 @@ def build_header_block(emoji: str, status_text: str, suffix: str) -> dict:
     }
 
 
+def parse_alert_mentions(raw_ids: str) -> list[str]:
+    """Parse and normalize configured Slack alert mentions."""
+    if not raw_ids:
+        return []
+
+    mentions = []
+    for token in raw_ids.replace(";", ",").split(","):
+        value = token.strip()
+        if not value:
+            continue
+
+        # Allow explicit mention tokens or plain user IDs.
+        if value.startswith("<@") and value.endswith(">"):
+            mentions.append(value)
+        elif value.startswith("<!subteam^") and value.endswith(">"):
+            mentions.append(value)
+        else:
+            mentions.append(f"<@{value}>")
+
+    return mentions
+
+
+def build_alert_mentions_block() -> dict | None:
+    """Build an alert block with Slack mentions for non-green runs."""
+    mentions = parse_alert_mentions(SLACK_ALERT_USER_IDS)
+    if not mentions:
+        return None
+
+    return {
+        "type": "section",
+        "text": {"type": "mrkdwn", "text": f"*:rotating_light: Attention:* {' '.join(mentions)}"},
+    }
+
+
 def build_context_block(results: dict) -> dict:
     """Build the context block with architecture, commit, branch."""
     summary = results["run_summary"]
@@ -159,7 +194,7 @@ def build_pass_rate_regressions_block(regressions: list[dict]) -> list[dict]:
 
     # Build table
     lines = ["```"]
-    lines.append(f"{'Module':<35} {'Prev':>8} {'Now':>8} {'Delta':>8}")
+    lines.append(f"{'Sweep test':<35} {'Prev':>8} {'Now':>8} {'Delta':>8}")
     for reg in regressions[:10]:  # Limit to top 10
         module = reg["module"][:35]
         prev = f"{float(reg['prev']):.1f}%" if reg.get("prev") is not None else "N/A"
@@ -218,7 +253,8 @@ def build_perf_regressions_block(op_regressions: list[dict], test_regressions: l
             test_name = reg.get("full_test_name", "unknown")
             model = reg.get("model_name", "")
             if model:
-                display_name = f"{test_name[:35]}[{model[:10]}]"
+                model_display = model.removeprefix("models/demos/")
+                display_name = f"{test_name[:35]}[{model_display[:10]}]"
             else:
                 display_name = test_name[:50]
             prev = format_duration(reg.get("prev_ns"))
@@ -373,6 +409,12 @@ def build_slack_message(results: dict, conclusion: str) -> dict:
 
     # Header
     blocks.append(build_header_block(emoji, status_text, suffix))
+
+    # Mention configured users for all non-green outcomes.
+    if emoji != ":large_green_circle:":
+        alert_block = build_alert_mentions_block()
+        if alert_block:
+            blocks.append(alert_block)
 
     # Handle infrastructure failure
     if conclusion == "failure" and results["run_summary"]["test_count"] == 0:

--- a/.github/actions/sweep-run-analysis/scripts/send_slack_notification.py
+++ b/.github/actions/sweep-run-analysis/scripts/send_slack_notification.py
@@ -17,7 +17,7 @@ SLACK_WEBHOOK_URL = os.environ.get("SLACK_WEBHOOK_URL", "")
 SLACK_BOT_TOKEN = os.environ.get("SLACK_BOT_TOKEN", "")  # Alternative: OAuth bot token
 SLACK_CHANNEL = os.environ.get("SLACK_CHANNEL", "")  # Required with bot token
 CONCLUSION = os.environ.get("CONCLUSION", "success")  # success, failure, cancelled
-GITHUB_RUN_ID = os.environ.get("GITHUB_RUN_ID", "")
+GITHUB_RUN_ID = os.environ.get("SOURCE_GITHUB_RUN_ID", os.environ.get("GITHUB_RUN_ID", ""))
 SUPERSET_BASE_URL = "https://superset.tenstorrent.com/superset/dashboard/lead-models-sweep-run/"
 GITHUB_ACTIONS_URL = f"https://github.com/tenstorrent/tt-metal/actions/runs/{GITHUB_RUN_ID}"
 

--- a/.github/actions/sweep-run-analysis/scripts/send_slack_notification.py
+++ b/.github/actions/sweep-run-analysis/scripts/send_slack_notification.py
@@ -18,6 +18,7 @@ SLACK_BOT_TOKEN = os.environ.get("SLACK_BOT_TOKEN", "")  # Alternative: OAuth bo
 SLACK_CHANNEL = os.environ.get("SLACK_CHANNEL", "")  # Required with bot token
 CONCLUSION = os.environ.get("CONCLUSION", "success")  # success, failure, cancelled
 GITHUB_RUN_ID = os.environ.get("SOURCE_GITHUB_RUN_ID", os.environ.get("GITHUB_RUN_ID", ""))
+GITHUB_RUN_NUMBER = os.environ.get("SOURCE_GITHUB_RUN_NUMBER", "")
 SUPERSET_BASE_URL = "https://superset.tenstorrent.com/superset/dashboard/lead-models-sweep-run/"
 GITHUB_ACTIONS_URL = f"https://github.com/tenstorrent/tt-metal/actions/runs/{GITHUB_RUN_ID}"
 
@@ -343,17 +344,19 @@ def build_cancelled_block() -> list[dict]:
 def build_superset_link_block() -> dict:
     """Build the run links block with both Superset and GitHub links.
 
-    Uses gh_run_number (GITHUB_RUN_ID) for Superset since it's available immediately,
+    Uses gh_run_number (GITHUB_RUN_NUMBER) for Superset since it's available immediately,
     whereas run_id (database PK) requires Airflow ingestion first.
     """
     links = []
-    if GITHUB_RUN_ID:
-        superset_url = f"{SUPERSET_BASE_URL}?gh_run_number={GITHUB_RUN_ID}"
-        github_url = GITHUB_ACTIONS_URL
+    if GITHUB_RUN_NUMBER:
+        superset_url = f"{SUPERSET_BASE_URL}?gh_run_number={GITHUB_RUN_NUMBER}"
         links.append(f"<{superset_url}|View in Superset>")
-        links.append(f"<{github_url}|View in GitHub Actions>")
     else:
-        links.append("Superset link unavailable (missing run ID)")
+        links.append("Superset link unavailable (missing run number)")
+
+    if GITHUB_RUN_ID:
+        links.append(f"<{GITHUB_ACTIONS_URL}|View in GitHub Actions>")
+    else:
         links.append("GitHub Actions link unavailable (missing run ID)")
 
     return {

--- a/.github/actions/sweep-run-analysis/scripts/send_slack_notification.py
+++ b/.github/actions/sweep-run-analysis/scripts/send_slack_notification.py
@@ -341,21 +341,24 @@ def build_cancelled_block() -> list[dict]:
 
 
 def build_superset_link_block() -> dict:
-    """Build the Superset dashboard link block.
+    """Build the run links block with both Superset and GitHub links.
 
-    Uses gh_run_number (GITHUB_RUN_ID) since it's available immediately,
+    Uses gh_run_number (GITHUB_RUN_ID) for Superset since it's available immediately,
     whereas run_id (database PK) requires Airflow ingestion first.
     """
+    links = []
     if GITHUB_RUN_ID:
-        # Use GitHub run ID - works immediately, dashboard shows data after ingestion
-        url = f"{SUPERSET_BASE_URL}?gh_run_number={GITHUB_RUN_ID}"
-        text = f"<{url}|View in Superset>"
+        superset_url = f"{SUPERSET_BASE_URL}?gh_run_number={GITHUB_RUN_ID}"
+        github_url = GITHUB_ACTIONS_URL
+        links.append(f"<{superset_url}|View in Superset>")
+        links.append(f"<{github_url}|View in GitHub Actions>")
     else:
-        text = f"<{GITHUB_ACTIONS_URL}|View in GitHub Actions>"
+        links.append("Superset link unavailable (missing run ID)")
+        links.append("GitHub Actions link unavailable (missing run ID)")
 
     return {
         "type": "section",
-        "text": {"type": "mrkdwn", "text": text},
+        "text": {"type": "mrkdwn", "text": " | ".join(links)},
     }
 
 

--- a/.github/workflows/ttnn-sweeps-slack-notify.yaml
+++ b/.github/workflows/ttnn-sweeps-slack-notify.yaml
@@ -31,6 +31,7 @@ jobs:
           SHOULD_NOTIFY="false"
           RUN_TYPE=""
           RUN_ID=""
+          RUN_NUMBER=""
           CONCLUSION=""
           SOURCE_GIT_SHA=""
           SOURCE_GIT_BRANCH=""
@@ -44,6 +45,7 @@ jobs:
             WORKFLOW_INFO=$(gh api repos/${{ github.repository }}/actions/runs/${RUN_ID} 2>/dev/null || echo "{}")
             CONCLUSION=$(echo "$WORKFLOW_INFO" | jq -r '.conclusion // "unknown"')
             RUN_NAME=$(echo "$WORKFLOW_INFO" | jq -r '.name // ""')
+            RUN_NUMBER=$(echo "$WORKFLOW_INFO" | jq -r '.run_number // ""')
             SOURCE_GIT_SHA=$(echo "$WORKFLOW_INFO" | jq -r '.head_sha // ""')
             SOURCE_GIT_BRANCH=$(echo "$WORKFLOW_INFO" | jq -r '.head_branch // ""')
 
@@ -63,6 +65,7 @@ jobs:
           elif [[ "${{ github.event_name }}" == "workflow_run" ]]; then
             # Triggered by workflow_run event
             RUN_ID="${{ github.event.workflow_run.id }}"
+            RUN_NUMBER="${{ github.event.workflow_run.run_number }}"
             CONCLUSION="${{ github.event.workflow_run.conclusion }}"
             RUN_NAME="${{ github.event.workflow_run.name }}"
             EVENT_TYPE="${{ github.event.workflow_run.event }}"
@@ -100,6 +103,7 @@ jobs:
           echo "should_notify=$SHOULD_NOTIFY" >> $GITHUB_OUTPUT
           echo "run_type=$RUN_TYPE" >> $GITHUB_OUTPUT
           echo "run_id=$RUN_ID" >> $GITHUB_OUTPUT
+          echo "run_number=$RUN_NUMBER" >> $GITHUB_OUTPUT
           echo "conclusion=$CONCLUSION" >> $GITHUB_OUTPUT
           echo "source_git_sha=$SOURCE_GIT_SHA" >> $GITHUB_OUTPUT
           echo "source_git_branch=$SOURCE_GIT_BRANCH" >> $GITHUB_OUTPUT
@@ -109,6 +113,7 @@ jobs:
           echo "Should notify: $SHOULD_NOTIFY"
           echo "Run type: $RUN_TYPE"
           echo "Run ID: $RUN_ID"
+          echo "Run Number: ${RUN_NUMBER:-unknown}"
           echo "Conclusion: $CONCLUSION"
           echo "Source Git SHA: ${SOURCE_GIT_SHA:-unknown}"
           echo "Source Git Branch: ${SOURCE_GIT_BRANCH:-unknown}"
@@ -118,6 +123,7 @@ jobs:
         uses: ./.github/actions/sweep-run-analysis
         with:
           github-run-id: ${{ steps.check.outputs.run_id }}
+          source-github-run-number: ${{ steps.check.outputs.run_number }}
           run-type: ${{ steps.check.outputs.run_type }}
           conclusion: ${{ steps.check.outputs.conclusion }}
           source-git-sha: ${{ steps.check.outputs.source_git_sha }}

--- a/.github/workflows/ttnn-sweeps-slack-notify.yaml
+++ b/.github/workflows/ttnn-sweeps-slack-notify.yaml
@@ -128,6 +128,7 @@ jobs:
           conclusion: ${{ steps.check.outputs.conclusion }}
           source-git-sha: ${{ steps.check.outputs.source_git_sha }}
           source-git-branch: ${{ steps.check.outputs.source_git_branch }}
+          slack-alert-user-ids: ${{ secrets.SLACK_LEAD_MODEL_SWEEPS_ALERT_USER_IDS }}
           slack-webhook-url: ${{ secrets.SLACK_LEAD_MODEL_SWEEPS_WEBHOOK_URL }}
           database-url: ${{ secrets.TTNN_OPS_LEAD_MODELS_DATABASE_URL }}
 

--- a/.github/workflows/ttnn-sweeps-slack-notify.yaml
+++ b/.github/workflows/ttnn-sweeps-slack-notify.yaml
@@ -32,6 +32,8 @@ jobs:
           RUN_TYPE=""
           RUN_ID=""
           CONCLUSION=""
+          SOURCE_GIT_SHA=""
+          SOURCE_GIT_BRANCH=""
 
           if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
             # Manual trigger - always notify
@@ -42,6 +44,8 @@ jobs:
             WORKFLOW_INFO=$(gh api repos/${{ github.repository }}/actions/runs/${RUN_ID} 2>/dev/null || echo "{}")
             CONCLUSION=$(echo "$WORKFLOW_INFO" | jq -r '.conclusion // "unknown"')
             RUN_NAME=$(echo "$WORKFLOW_INFO" | jq -r '.name // ""')
+            SOURCE_GIT_SHA=$(echo "$WORKFLOW_INFO" | jq -r '.head_sha // ""')
+            SOURCE_GIT_BRANCH=$(echo "$WORKFLOW_INFO" | jq -r '.head_branch // ""')
 
             # Determine run type from name
             if [[ "$RUN_NAME" == *"lead models"* ]] || [[ "$RUN_NAME" == *"Lead Models"* ]]; then
@@ -62,6 +66,8 @@ jobs:
             CONCLUSION="${{ github.event.workflow_run.conclusion }}"
             RUN_NAME="${{ github.event.workflow_run.name }}"
             EVENT_TYPE="${{ github.event.workflow_run.event }}"
+            SOURCE_GIT_SHA="${{ github.event.workflow_run.head_sha }}"
+            SOURCE_GIT_BRANCH="${{ github.event.workflow_run.head_branch }}"
 
             echo "Workflow run event: name='$RUN_NAME', event='$EVENT_TYPE', conclusion='$CONCLUSION'"
 
@@ -95,6 +101,8 @@ jobs:
           echo "run_type=$RUN_TYPE" >> $GITHUB_OUTPUT
           echo "run_id=$RUN_ID" >> $GITHUB_OUTPUT
           echo "conclusion=$CONCLUSION" >> $GITHUB_OUTPUT
+          echo "source_git_sha=$SOURCE_GIT_SHA" >> $GITHUB_OUTPUT
+          echo "source_git_branch=$SOURCE_GIT_BRANCH" >> $GITHUB_OUTPUT
 
           echo ""
           echo "=== Decision ==="
@@ -102,6 +110,8 @@ jobs:
           echo "Run type: $RUN_TYPE"
           echo "Run ID: $RUN_ID"
           echo "Conclusion: $CONCLUSION"
+          echo "Source Git SHA: ${SOURCE_GIT_SHA:-unknown}"
+          echo "Source Git Branch: ${SOURCE_GIT_BRANCH:-unknown}"
 
       - name: Run sweep analysis and notify
         if: steps.check.outputs.should_notify == 'true'
@@ -110,6 +120,8 @@ jobs:
           github-run-id: ${{ steps.check.outputs.run_id }}
           run-type: ${{ steps.check.outputs.run_type }}
           conclusion: ${{ steps.check.outputs.conclusion }}
+          source-git-sha: ${{ steps.check.outputs.source_git_sha }}
+          source-git-branch: ${{ steps.check.outputs.source_git_branch }}
           slack-webhook-url: ${{ secrets.SLACK_LEAD_MODEL_SWEEPS_WEBHOOK_URL }}
           database-url: ${{ secrets.TTNN_OPS_LEAD_MODELS_DATABASE_URL }}
 


### PR DESCRIPTION
## Summary
- Fix Slack notification to use source `ttnn-run-sweeps.yaml` run context (SHA, branch, run ID/number) instead of notifier workflow context
- Fix database query to target correct pipeline run
- Prevent double-counting of test results when pushing to database
- Add configurable Slack mentions for non-green results
- Improve previous run comparison logic with branch-aware fallback

## Changes

### Core Fixes
- Pass source workflow `run_id`, `run_number`, `git_sha`, and `git_branch` from `ttnn-run-sweeps` into `ttnn-sweeps-slack-notify`
- Update DB extraction and fallback parsing to use `SOURCE_GITHUB_RUN_ID` and source git metadata
- Fix `push_sweep_results.py` to prefer consolidated `oprun_*.json` files, avoiding duplicate test ingestion
- Use `run_number` for Superset dashboard links (matches `gh_run_number` filter), `run_id` for GitHub Actions links

### Regression Analysis
- Add `git_branch` requirement to previous run matching in DB queries
- Fallback to latest `main` branch run when no same-branch comparison available

### Slack Notification Improvements
- Add configurable alert mentions (via `SLACK_LEAD_MODEL_SWEEPS_ALERT_USER_IDS` secret) for all non-green outcomes
- Change "Module" label to "Sweep test" in pass rate regressions table
- Strip `models/demos/` prefix from model names in performance regression display
- Show both Superset and GitHub Actions links


### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=stevendae/fix_sweep_slack_notification)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:stevendae/fix_sweep_slack_notification)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=stevendae/fix_sweep_slack_notification)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:stevendae/fix_sweep_slack_notification)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=stevendae/fix_sweep_slack_notification)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:stevendae/fix_sweep_slack_notification)
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=stevendae/fix_sweep_slack_notification)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:stevendae/fix_sweep_slack_notification)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=stevendae/fix_sweep_slack_notification)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:stevendae/fix_sweep_slack_notification)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=stevendae/fix_sweep_slack_notification)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:stevendae/fix_sweep_slack_notification)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
