### PR TITLE
Simplify MeshWorkload finalization with per-program config accumulation

### DIFF
--- a/tt_metal/distributed/mesh_workload.cpp
+++ b/tt_metal/distributed/mesh_workload.cpp
@@ -73,9 +73,7 @@ std::optional<MeshCoordinateRange> find_intersection(
 
 }  // namespace
 
-MeshWorkloadImpl::MeshWorkloadImpl() : id(get_next_counter()) {
-    Inspector::mesh_workload_created(this);
-}
+MeshWorkloadImpl::MeshWorkloadImpl() : id(get_next_counter()) { Inspector::mesh_workload_created(this); }
 
 MeshWorkloadImpl::~MeshWorkloadImpl() { Inspector::mesh_workload_destroyed(this); }
 
@@ -343,8 +341,7 @@ void MeshWorkloadImpl::finalize_offsets(MeshDevice* mesh_device) {
     // Determine max kernel binary size across all programs
     this->max_program_kernels_sizeB_ = 0;
     for (auto& [_, program] : programs_) {
-        this->max_program_kernels_sizeB_ =
-            std::max(this->max_program_kernels_sizeB_, program.impl().kernel_bins_sizeB);
+        this->max_program_kernels_sizeB_ = std::max(this->max_program_kernels_sizeB_, program.impl().kernel_bins_sizeB);
     }
 
     set_finalized();

--- a/tt_metal/distributed/mesh_workload.cpp
+++ b/tt_metal/distributed/mesh_workload.cpp
@@ -74,10 +74,6 @@ std::optional<MeshCoordinateRange> find_intersection(
 }  // namespace
 
 MeshWorkloadImpl::MeshWorkloadImpl() : id(get_next_counter()) {
-    // A MeshWorkload tracks maintains its own handles to kernels across all
-    // encapsulated programs
-    kernel_groups_.resize(MetalContext::instance().hal().get_programmable_core_type_count());
-    kernels_.resize(MetalContext::instance().hal().get_programmable_core_type_count());
     Inspector::mesh_workload_created(this);
 }
 
@@ -247,62 +243,17 @@ bool MeshWorkloadImpl::kernel_binary_always_stored_in_ringbuffer() {
     return stored_in_ring_buf;
 }
 
-std::unordered_map<KernelHandle, std::shared_ptr<Kernel>>& MeshWorkloadImpl::get_kernels(
-    uint32_t programmable_core_type_index) {
-    // Get all kernels across all programs in the MeshWorkload
-    if (kernels_.at(programmable_core_type_index).empty()) {
-        uint32_t device_range_idx = 0;
-        for (auto& [device_range, program] : programs_) {
-            const uint32_t device_range_handle = (device_range_idx++) << 16;
-            for (const auto& kernel : program.impl().get_kernels(programmable_core_type_index)) {
-                KernelHandle handle = (device_range_handle | kernel.first);
-                kernels_.at(programmable_core_type_index).insert({handle, kernel.second});
-            }
-        }
-    }
-    return kernels_.at(programmable_core_type_index);
-}
-
-std::vector<std::shared_ptr<KernelGroup>>& MeshWorkloadImpl::get_kernel_groups(uint32_t programmable_core_type_index) {
-    // Get all kernel groups across all programs in the MeshWorkload
-    if (kernel_groups_.at(programmable_core_type_index).empty()) {
-        uint32_t device_range_idx = 0;
-        for (auto& [device_range, program] : programs_) {
-            const uint32_t device_range_handle = (device_range_idx++) << 16;
-            for (auto& kg : program.impl().get_kernel_groups(programmable_core_type_index)) {
-                for (auto& kernel_id : kg->kernel_ids) {
-                    kernel_id |= device_range_handle;
-                }
-                kernel_groups_.at(programmable_core_type_index).push_back(kg);
-            }
-        }
-    }
-    return kernel_groups_.at(programmable_core_type_index);
-}
-
-std::vector<Semaphore>& MeshWorkloadImpl::semaphores() {
-    // Get all semaphores across all programs in the MeshWorkload
-    if (semaphores_.empty()) {
-        for (auto& [device_range, program] : programs_) {
-            semaphores_.insert(
-                semaphores_.end(), program.impl().semaphores().begin(), program.impl().semaphores().end());
-        }
-    }
-    return semaphores_;
-}
-
 std::vector<uint32_t> MeshWorkloadImpl::get_program_config_sizes() {
-    // Get the config sizes for all L1 Program Data Structures
+    // Get the max config sizes across all programs for L1 Program Data Structures
     std::vector<uint32_t> global_program_config_sizes;
-    for (auto& program_on_grid : programs_) {
-        if (!global_program_config_sizes.empty()) {
-            for (int i = 0; i < global_program_config_sizes.size(); i++) {
-                TT_FATAL(
-                    global_program_config_sizes[i] == program_on_grid.second.impl().get_program_config_sizes()[i],
-                    "Expected config sizes to be identical across all programs in a MeshWorkload.");
-            }
+    for (auto& [_, program] : programs_) {
+        auto& sizes = program.impl().get_program_config_sizes();
+        if (global_program_config_sizes.empty()) {
+            global_program_config_sizes = sizes;
         } else {
-            global_program_config_sizes = program_on_grid.second.impl().get_program_config_sizes();
+            for (size_t i = 0; i < global_program_config_sizes.size(); i++) {
+                global_program_config_sizes[i] = std::max(global_program_config_sizes[i], sizes[i]);
+            }
         }
     }
     return global_program_config_sizes;
@@ -353,14 +304,8 @@ uint32_t MeshWorkloadImpl::get_sem_base_addr(
 uint32_t MeshWorkloadImpl::get_sem_size(
     std::shared_ptr<MeshDevice>& mesh_device, CoreCoord logical_core, CoreType core_type) {
     uint32_t sem_size = 0;
-    uint32_t program_idx = 0;
     for (auto& [device_range, program] : programs_) {
-        if (program_idx) {
-            TT_ASSERT(sem_size == program.impl().get_sem_size(mesh_device.get(), logical_core, core_type));
-        } else {
-            sem_size = program.impl().get_sem_size(mesh_device.get(), logical_core, core_type);
-        }
-        program_idx++;
+        sem_size = std::max(sem_size, program.impl().get_sem_size(mesh_device.get(), logical_core, core_type));
     }
     return sem_size;
 }
@@ -379,14 +324,8 @@ uint32_t MeshWorkloadImpl::get_cb_base_addr(
 uint32_t MeshWorkloadImpl::get_cb_size(
     std::shared_ptr<MeshDevice>& mesh_device, CoreCoord logical_core, CoreType core_type) {
     uint32_t cb_size = 0;
-    uint32_t program_idx = 0;
     for (auto& [device_range, program] : programs_) {
-        if (program_idx) {
-            TT_ASSERT(cb_size == program.impl().get_cb_size(mesh_device.get(), logical_core, core_type));
-        } else {
-            cb_size = program.impl().get_cb_size(mesh_device.get(), logical_core, core_type);
-        }
-        program_idx++;
+        cb_size = std::max(cb_size, program.impl().get_cb_size(mesh_device.get(), logical_core, core_type));
     }
     return cb_size;
 }
@@ -396,36 +335,17 @@ void MeshWorkloadImpl::finalize_offsets(MeshDevice* mesh_device) {
         return;
     }
 
-    tt::tt_metal::detail::KernelsGetter kernels_getter =
-        [this](uint32_t index) -> std::unordered_map<KernelHandle, std::shared_ptr<Kernel>>& {
-        return this->get_kernels(index);
-    };
-
-    tt::tt_metal::detail::KernelGroupsGetter kernel_groups_getter =
-        [this](uint32_t index) -> std::vector<std::shared_ptr<KernelGroup>>& { return this->get_kernel_groups(index); };
-
-    tt::tt_metal::detail::SemaphoresGetter semaphores_getter = [this]() -> const std::vector<Semaphore>& {
-        return this->semaphores();
-    };
-
-    // TODO: Add dataflow buffer support to MeshWorkload
-    static const std::vector<std::shared_ptr<tt::tt_metal::experimental::dfb::detail::DataflowBufferImpl>>
-        empty_dataflow_buffers;
-    tt::tt_metal::detail::DataflowBuffersGetter dataflow_buffers_getter =
-        []() -> const std::vector<std::shared_ptr<tt::tt_metal::experimental::dfb::detail::DataflowBufferImpl>>& {
-        return empty_dataflow_buffers;
-    };
-
-    // Create a span with all programs
-    std::vector<tt::tt_metal::detail::ProgramImpl*> program_impls;
-    program_impls.reserve(programs_.size());
+    // Finalize each program independently using its own data
     for (auto& [_, program] : programs_) {
-        program_impls.push_back(&program.impl());
+        program.impl().finalize_offsets(mesh_device);
     }
-    tt::stl::Span<tt::tt_metal::detail::ProgramImpl*> programs(program_impls.data(), program_impls.size());
 
-    this->max_program_kernels_sizeB_ = tt::tt_metal::detail::ProgramImpl::finalize_program_offsets(
-        mesh_device, kernels_getter, kernel_groups_getter, semaphores_getter, dataflow_buffers_getter, programs);
+    // Determine max kernel binary size across all programs
+    this->max_program_kernels_sizeB_ = 0;
+    for (auto& [_, program] : programs_) {
+        this->max_program_kernels_sizeB_ =
+            std::max(this->max_program_kernels_sizeB_, program.impl().kernel_bins_sizeB);
+    }
 
     set_finalized();
 }

--- a/tt_metal/distributed/mesh_workload_impl.hpp
+++ b/tt_metal/distributed/mesh_workload_impl.hpp
@@ -43,9 +43,6 @@ private:
     void compile(MeshDevice* mesh_device);
     void load_binaries(MeshCommandQueue& mesh_cq);
     void generate_dispatch_commands(MeshCommandQueue& mesh_cq);
-    std::unordered_map<KernelHandle, std::shared_ptr<Kernel>>& get_kernels(uint32_t programmable_core_type_index);
-    std::vector<std::shared_ptr<KernelGroup>>& get_kernel_groups(uint32_t programmable_core_type_index);
-    std::vector<Semaphore>& semaphores();
     std::vector<uint32_t> get_program_config_sizes();
     std::unordered_set<SubDeviceId> determine_sub_device_ids(MeshDevice* mesh_device);
     bool kernel_binary_always_stored_in_ringbuffer();
@@ -60,9 +57,6 @@ private:
 
     std::unordered_map<std::size_t, ProgramBinaryStatus> program_binary_status_;
     std::shared_ptr<MeshBuffer> kernel_bin_buf_;
-    std::vector<std::unordered_map<KernelHandle, std::shared_ptr<Kernel>>> kernels_;
-    std::vector<std::vector<std::shared_ptr<KernelGroup>>> kernel_groups_;
-    std::vector<Semaphore> semaphores_;
     std::unordered_map<MeshCoordinateRange, Program> programs_;
     bool finalized_ = false;
     std::unordered_map<MeshCoordinateRange, std::unordered_map<KernelHandle, RuntimeArgsPerCore>> runtime_args_;

--- a/tt_metal/impl/program/program.cpp
+++ b/tt_metal/impl/program/program.cpp
@@ -1714,7 +1714,11 @@ void detail::ProgramImpl::finalize_offsets(IDevice* device) {
     for (uint32_t index = 0; index < hal.get_programmable_core_type_count(); index++) {
         HalProgrammableCoreType programmable_core_type = hal.get_programmable_core_type(index);
         state.offset = program_dispatch::finalize_rt_args(
-            this->get_kernels(index), this->get_kernel_groups(index), state.config_base_offset, index, state.rta_offset);
+            this->get_kernels(index),
+            this->get_kernel_groups(index),
+            state.config_base_offset,
+            index,
+            state.rta_offset);
 
         TT_ASSERT(state.offset == tt::align(state.offset, hal.get_alignment(HalMemType::L1)));
 

--- a/tt_metal/impl/program/program.cpp
+++ b/tt_metal/impl/program/program.cpp
@@ -1705,42 +1705,8 @@ void detail::ProgramImpl::finalize_offsets(IDevice* device) {
         return;
     }
 
-    // Create proper function objects that capture 'this'
-    detail::KernelsGetter kernels_getter =
-        [this](uint32_t index) -> std::unordered_map<KernelHandle, std::shared_ptr<Kernel>>& {
-        return this->get_kernels(index);
-    };
-
-    detail::KernelGroupsGetter kernel_groups_getter = [this](uint32_t index) -> std::vector<std::shared_ptr<KernelGroup>>& {
-        return this->get_kernel_groups(index);
-    };
-
-    detail::SemaphoresGetter semaphores_getter = [this]() -> const std::vector<Semaphore>& { return this->semaphores(); };
-
-    detail::DataflowBuffersGetter dataflow_buffers_getter =
-        [this]() -> const std::vector<std::shared_ptr<tt::tt_metal::experimental::dfb::detail::DataflowBufferImpl>>& {
-        return this->dataflow_buffers_;
-    };
-
-    // Create a span with just this program
-    std::array<ProgramImpl*, 1> programs_array = {this};
-    tt::stl::Span<ProgramImpl*> programs(programs_array);
-
-    (void)ProgramImpl::finalize_program_offsets(
-        device, kernels_getter, kernel_groups_getter, semaphores_getter, dataflow_buffers_getter, programs);
-
-    set_finalized();
-}
-
-// Compute relative offsets (wrt the start of the kernel config ring buffer) and sizes of all
-// program data structures in L1. Will be used when assembling dispatch commands for this program
-uint32_t detail::ProgramImpl::finalize_program_offsets(
-    IDevice* device,
-    const KernelsGetter& kernels_getter,
-    const KernelGroupsGetter& kernel_groups_getter,
-    const SemaphoresGetter& semaphores_getter,
-    const DataflowBuffersGetter& dataflow_buffers_getter,
-    tt::stl::Span<ProgramImpl*> programs) {
+    // Compute relative offsets (wrt the start of the kernel config ring buffer) and sizes of all
+    // program data structures in L1. Will be used when assembling dispatch commands for this program
     ProgramOffsetsState state;
 
     const auto& hal = MetalContext::instance().hal();
@@ -1748,24 +1714,24 @@ uint32_t detail::ProgramImpl::finalize_program_offsets(
     for (uint32_t index = 0; index < hal.get_programmable_core_type_count(); index++) {
         HalProgrammableCoreType programmable_core_type = hal.get_programmable_core_type(index);
         state.offset = program_dispatch::finalize_rt_args(
-            kernels_getter(index), kernel_groups_getter(index), state.config_base_offset, index, state.rta_offset);
+            this->get_kernels(index), this->get_kernel_groups(index), state.config_base_offset, index, state.rta_offset);
 
         TT_ASSERT(state.offset == tt::align(state.offset, hal.get_alignment(HalMemType::L1)));
 
         state.offset =
-            program_dispatch::finalize_sems(index, state.offset, semaphores_getter(), state.sem_offset, state.sem_size);
+            program_dispatch::finalize_sems(index, state.offset, this->semaphores(), state.sem_offset, state.sem_size);
 
         TT_ASSERT(state.offset == tt::align(state.offset, hal.get_alignment(HalMemType::L1)));
 
         state.offset = program_dispatch::finalize_cbs(
-            index, kernel_groups_getter(index), state.offset, state.cb_offset, state.cb_size, state.local_cb_size);
+            index, this->get_kernel_groups(index), state.offset, state.cb_offset, state.cb_size, state.local_cb_size);
 
         TT_ASSERT(state.offset == tt::align(state.offset, hal.get_alignment(HalMemType::L1)));
 
         state.offset = tt::tt_metal::experimental::dfb::detail::finalize_dfbs(
             index,
-            kernel_groups_getter(index),
-            dataflow_buffers_getter(),
+            this->get_kernel_groups(index),
+            this->dataflow_buffers_,
             state.offset,
             state.dfb_offset,
             state.dfb_size);
@@ -1775,8 +1741,8 @@ uint32_t detail::ProgramImpl::finalize_program_offsets(
         state.offset = program_dispatch::finalize_kernel_bins(
             device,
             index,
-            kernels_getter(index),
-            kernel_groups_getter(index),
+            this->get_kernels(index),
+            this->get_kernel_groups(index),
             state.offset,
             state.kernel_text_offset,
             state.kernel_text_size);
@@ -1792,23 +1758,15 @@ uint32_t detail::ProgramImpl::finalize_program_offsets(
             max_size,
             enchantum::to_string(programmable_core_type));
 
-        for (auto& program : programs) {
-            program->set_program_offsets_and_sizes(index, state);
-        }
+        this->set_program_offsets_and_sizes(index, state);
     }
 
     // The sem offsets cross programmable_core_types so must be set after the loop above
-    for (auto& program : programs) {
-        program->set_program_attrs_across_core_types(device);
-    }
+    this->set_program_attrs_across_core_types(device);
 
-    // determine max program size across all programs
-    uint32_t max_program_sizeB = 0;
-    for (auto& program : programs) {
-        program->kernel_bins_sizeB = state.kernel_text_size;
-        max_program_sizeB = std::max(max_program_sizeB, state.kernel_text_size);
-    }
-    return max_program_sizeB;
+    this->kernel_bins_sizeB = state.kernel_text_size;
+
+    set_finalized();
 }
 
 std::unordered_map<uint64_t, ProgramCommandSequence>&

--- a/tt_metal/impl/program/program_impl.hpp
+++ b/tt_metal/impl/program/program_impl.hpp
@@ -138,13 +138,6 @@ struct ProgramOffsetsState {
     uint32_t kernel_text_size = 0;
 };
 
-// Callable types for dependency injection
-using KernelsGetter = std::function<std::unordered_map<KernelHandle, std::shared_ptr<Kernel>>&(uint32_t index)>;
-using KernelGroupsGetter = std::function<std::vector<std::shared_ptr<KernelGroup>>&(uint32_t index)>;
-using SemaphoresGetter = std::function<const std::vector<Semaphore>&()>;
-using DataflowBuffersGetter =
-    std::function<const std::vector<std::shared_ptr<tt::tt_metal::experimental::dfb::detail::DataflowBufferImpl>>&()>;
-
 // Internal class for holding a group of programs for parallel compilation.
 class ProgramCompileGroup {
 private:
@@ -252,17 +245,6 @@ public:
     void populate_dispatch_data(IDevice* device);
 
     void finalize_offsets(IDevice* device);
-
-    // Helper function to finalize program offsets with custom getters. Returns the maximum kernel binaries size among
-    // all the programs, to determine whether the mesh workload can fit in the prefetcher cache all of the programs in
-    // it.
-    static uint32_t finalize_program_offsets(
-        IDevice* device,
-        const KernelsGetter& kernels_getter,
-        const KernelGroupsGetter& kernel_groups_getter,
-        const SemaphoresGetter& semaphores_getter,
-        const DataflowBuffersGetter& dataflow_buffers_getter,
-        tt::stl::Span<ProgramImpl*> programs);
 
     std::vector<uint32_t>& get_program_config_sizes() noexcept { return program_config_sizes_; }
 


### PR DESCRIPTION
### Ticket
N/A

### Problem description
`MeshWorkloadImpl::finalize_offsets` was artificially aggregating kernels, kernel groups, and semaphores from all programs into a single union set, then computing offsets as if all data structures belonged to one program. This forced all programs to have identical config sizes and added unnecessary complexity.

### What's changed
Changed MeshWorkload to finalize each program independently using its own data structures:
- Each program now calls `finalize_offsets()` with its own kernels/semaphores/CBs
- Config sizes use element-wise max across programs instead of requiring identical sizes
- Removed aggregation logic and inlined `finalize_program_offsets` into `finalize_offsets`

This simplifies the code and can reduce memory usage in heterogeneous cases where  programs have different usage of RTAs, CBs, and program binaries.

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=jbauman/perprogramfinalization)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:jbauman/perprogramfinalization)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=jbauman/perprogramfinalization)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:jbauman/perprogramfinalization)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=jbauman/perprogramfinalization)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jbauman/perprogramfinalization)
- [x] New/Existing tests provide coverage for changes
