### PR TITLE
SDPA reduce to all positional logic

### DIFF
--- a/models/demos/deepseek_v3_b1/micro_ops/sdpa_reduce_to_all/kernels/compute.cpp
+++ b/models/demos/deepseek_v3_b1/micro_ops/sdpa_reduce_to_all/kernels/compute.cpp
@@ -42,7 +42,7 @@ static constexpr uint32_t num_l_chunks = get_compile_time_arg_val(12);       // 
 // Position mask parameters (for conditional reduction)
 static constexpr uint32_t cb_position = get_compile_time_arg_val(13);
 static constexpr uint32_t position_enabled = get_compile_time_arg_val(14);
-static constexpr uint32_t num_devices = get_compile_time_arg_val(15);  // Total number of devices
+static constexpr bool final_reduction = get_compile_time_arg_val(15);
 
 // SDPA uses "block_size" terminology - alias for clarity
 static constexpr uint32_t block_size = tiles_per_l_chunk;
@@ -59,211 +59,6 @@ static constexpr uint32_t block_size = tiles_per_l_chunk;
  * This enables the reduce-to-all operation to work when only a subset of devices
  * have valid data, by having invalid devices forward valid data without reduction.
  */
-template <
-    bool SDPA_EXP_APPROX_MODE,
-    bool normalize,
-    uint32_t block_size,
-    uint32_t scale_fp32,
-    uint32_t num_l_chunks,
-    int vector_mode = (int)VectorMode::C>
-ALWI void sdpa_tail_streaming_conditional(
-    uint32_t cb_worker_max_sum,
-    uint32_t cb_prev_max_sum,
-    uint32_t cb_cur_max_sum,
-    uint32_t cb_l1,
-    uint32_t cb_l2,
-    uint32_t cb_l_out,
-    bool neighbor_valid,
-    bool local_valid) {
-    // Case 1: Both invalid - error case (shouldn't happen)
-    // Just copy local data as fallback
-    if (!neighbor_valid && !local_valid) {
-        // Copy local MS to output MS (needed for R1->R2 handoff)
-        DPRINT << "not neighbour valid and not local valid\n";
-        cb_wait_front(cb_prev_max_sum, 1);
-        cb_reserve_back(cb_cur_max_sum, 1);
-
-        tile_regs_acquire();
-        copy_tile_init(cb_prev_max_sum);
-        copy_tile(cb_prev_max_sum, 0, 0);
-        tile_regs_commit();
-
-        tile_regs_wait();
-        pack_tile(0, cb_cur_max_sum);
-        tile_regs_release();
-
-        cb_push_back(cb_cur_max_sum, 1);
-
-        // Copy local L to output L
-        for (uint32_t chunk = 0; chunk < num_l_chunks; chunk++) {
-            cb_wait_front(cb_l2, (chunk + 1) * block_size);
-            cb_reserve_back(cb_l_out, block_size);
-
-            uint32_t tile_index = chunk * block_size;
-            for (uint32_t i = 0; i < block_size; i++) {
-                tile_regs_acquire();
-                copy_tile_init(cb_l2);
-                copy_tile(cb_l2, tile_index + i, i);
-                tile_regs_commit();
-
-                tile_regs_wait();
-                pack_tile(i, cb_l_out);
-                tile_regs_release();
-            }
-
-            cb_push_back(cb_l_out, block_size);
-        }
-        DPRINT << "end of not neighbour valid and not local valid\n";
-        return;
-    }
-
-    // Case 2: Only local valid - copy local data (cb_l2) to output and normalize if requested
-    if (!neighbor_valid && local_valid) {
-        DPRINT << "Case 2: only local valid, normalize=" << (uint32_t)normalize << "\n";
-
-        // If normalization requested, use SDPA path to normalize
-        if constexpr (normalize) {
-            // Setup normalization using MS reduce (even with single input, this sets up the divider)
-            ckernel::sdpa_tail_ms_reduce<SDPA_EXP_APPROX_MODE, normalize, block_size, scale_fp32, vector_mode>(
-                cb_prev_max_sum, cb_prev_max_sum, cb_cur_max_sum, cb_l2);
-
-            // Process L chunks with normalization
-            for (uint32_t chunk = 0; chunk < num_l_chunks; chunk++) {
-                cb_wait_front(cb_l2, (chunk + 1) * block_size);
-                cb_reserve_back(cb_l_out, block_size);
-
-                uint32_t tile_index = chunk * block_size;
-                bool acquire_regs = !(normalize && chunk == 0);
-                ckernel::sdpa_tail_l_block<block_size>(cb_l2, cb_l2, cb_l_out, tile_index, acquire_regs);
-
-                cb_push_back(cb_l_out, block_size);
-            }
-
-            ckernel::sdpa_tail_finalize(cb_prev_max_sum, cb_prev_max_sum);
-        } else {
-            // No normalization - just copy
-            // Copy local MS to output MS
-            cb_wait_front(cb_prev_max_sum, 1);
-            cb_reserve_back(cb_cur_max_sum, 1);
-
-            tile_regs_acquire();
-            copy_tile_init(cb_prev_max_sum);
-            copy_tile(cb_prev_max_sum, 0, 0);
-            tile_regs_commit();
-
-            tile_regs_wait();
-            pack_tile(0, cb_cur_max_sum);
-            tile_regs_release();
-
-            cb_push_back(cb_cur_max_sum, 1);
-
-            // Copy local L to output L
-            for (uint32_t chunk = 0; chunk < num_l_chunks; chunk++) {
-                cb_wait_front(cb_l2, (chunk + 1) * block_size);
-                cb_reserve_back(cb_l_out, block_size);
-
-                uint32_t tile_index = chunk * block_size;
-                for (uint32_t i = 0; i < block_size; i++) {
-                    tile_regs_acquire();
-                    copy_tile_init(cb_l2);
-                    copy_tile(cb_l2, tile_index + i, i);
-                    tile_regs_commit();
-
-                    tile_regs_wait();
-                    pack_tile(i, cb_l_out);
-                    tile_regs_release();
-                }
-
-                cb_push_back(cb_l_out, block_size);
-            }
-        }
-        DPRINT << "Case 2: done\n";
-        return;
-    }
-
-    // Case 3: Only neighbor valid - copy neighbor data (cb_l1) to output and normalize if requested
-    if (neighbor_valid && !local_valid) {
-        DPRINT << "Case 3: only neighbor valid, normalize=" << (uint32_t)normalize << "\n";
-
-        // If normalization requested, use SDPA path to normalize
-        if constexpr (normalize) {
-            // Setup normalization using MS reduce
-            ckernel::sdpa_tail_ms_reduce<SDPA_EXP_APPROX_MODE, normalize, block_size, scale_fp32, vector_mode>(
-                cb_worker_max_sum, cb_worker_max_sum, cb_cur_max_sum, cb_l1);
-
-            // Process L chunks with normalization
-            for (uint32_t chunk = 0; chunk < num_l_chunks; chunk++) {
-                cb_wait_front(cb_l1, (chunk + 1) * block_size);
-                cb_reserve_back(cb_l_out, block_size);
-
-                uint32_t tile_index = chunk * block_size;
-                bool acquire_regs = !(normalize && chunk == 0);
-                ckernel::sdpa_tail_l_block<block_size>(cb_l1, cb_l1, cb_l_out, tile_index, acquire_regs);
-
-                cb_push_back(cb_l_out, block_size);
-            }
-
-            ckernel::sdpa_tail_finalize(cb_worker_max_sum, cb_worker_max_sum);
-        } else {
-            // No normalization - just copy
-            // Copy neighbor MS to output MS
-            cb_wait_front(cb_worker_max_sum, 1);
-            cb_reserve_back(cb_cur_max_sum, 1);
-
-            tile_regs_acquire();
-            copy_tile_init(cb_worker_max_sum);
-            copy_tile(cb_worker_max_sum, 0, 0);
-            tile_regs_commit();
-
-            tile_regs_wait();
-            pack_tile(0, cb_cur_max_sum);
-            tile_regs_release();
-
-            cb_push_back(cb_cur_max_sum, 1);
-
-            // Copy neighbor L to output L
-            for (uint32_t chunk = 0; chunk < num_l_chunks; chunk++) {
-                cb_wait_front(cb_l1, (chunk + 1) * block_size);
-                cb_reserve_back(cb_l_out, block_size);
-
-                uint32_t tile_index = chunk * block_size;
-                for (uint32_t i = 0; i < block_size; i++) {
-                    tile_regs_acquire();
-                    copy_tile_init(cb_l1);
-                    copy_tile(cb_l1, tile_index + i, i);
-                    tile_regs_commit();
-
-                    tile_regs_wait();
-                    pack_tile(i, cb_l_out);
-                    tile_regs_release();
-                }
-
-                cb_push_back(cb_l_out, block_size);
-            }
-        }
-        DPRINT << "Case 3: done\n";
-        return;
-    }
-
-    // Case 4: Both valid - perform normal SDPA reduction
-    ckernel::sdpa_tail_ms_reduce<SDPA_EXP_APPROX_MODE, normalize, block_size, scale_fp32, vector_mode>(
-        cb_worker_max_sum, cb_prev_max_sum, cb_cur_max_sum, cb_l1);
-
-    for (uint32_t chunk = 0; chunk < num_l_chunks; chunk++) {
-        cb_wait_front(cb_l1, (chunk + 1) * block_size);
-        cb_wait_front(cb_l2, (chunk + 1) * block_size);
-        cb_reserve_back(cb_l_out, block_size);
-
-        uint32_t tile_index = chunk * block_size;
-        bool acquire_regs = !(normalize && chunk == 0);
-        ckernel::sdpa_tail_l_block<block_size>(cb_l1, cb_l2, cb_l_out, tile_index, acquire_regs);
-
-        cb_push_back(cb_l_out, block_size);
-    }
-
-    ckernel::sdpa_tail_finalize(cb_worker_max_sum, cb_prev_max_sum);
-}
-
 /**
  * Streaming SDPA tail reduction that processes L tiles in chunks.
  *
@@ -326,6 +121,97 @@ ALWI void sdpa_tail_streaming(
     ckernel::sdpa_tail_finalize(cb_worker_max_sum, cb_prev_max_sum);
 }
 
+ALWI void forward_data(
+    uint32_t cb_prev_max_sum,
+    uint32_t cb_cur_max_sum,
+    uint32_t num_l_chunks,
+    uint32_t cb_l1,
+    uint32_t cb_l_out,
+    uint32_t block_size) {
+    cb_wait_front(cb_prev_max_sum, 1);
+    cb_reserve_back(cb_cur_max_sum, 1);
+
+    tile_regs_acquire();
+    copy_tile_init(cb_prev_max_sum);
+    copy_tile(cb_prev_max_sum, 0, 0);
+    tile_regs_commit();
+
+    tile_regs_wait();
+    pack_tile(0, cb_cur_max_sum);
+    tile_regs_release();
+
+    cb_push_back(cb_cur_max_sum, 1);
+
+    // Copy neighbor L to output L
+    for (uint32_t chunk = 0; chunk < num_l_chunks; chunk++) {
+        cb_wait_front(cb_l1, (chunk + 1) * block_size);
+        cb_reserve_back(cb_l_out, block_size);
+
+        uint32_t tile_index = chunk * block_size;
+        for (uint32_t i = 0; i < block_size; i++) {
+            tile_regs_acquire();
+            copy_tile_init(cb_l1);
+            copy_tile(cb_l1, tile_index + i, i);
+            tile_regs_commit();
+
+            tile_regs_wait();
+            pack_tile(i, cb_l_out);
+            tile_regs_release();
+        }
+
+        cb_push_back(cb_l_out, block_size);
+    }
+}
+template <
+    bool SDPA_EXP_APPROX_MODE,
+    bool normalize,
+    uint32_t block_size,
+    uint32_t scale_fp32,
+    uint32_t num_l_chunks,
+    int vector_mode = (int)VectorMode::C>
+ALWI void sdpa_tail_streaming_conditional(
+    uint32_t cb_worker_max_sum,
+    uint32_t cb_prev_max_sum,
+    uint32_t cb_cur_max_sum,
+    uint32_t cb_l1,
+    uint32_t cb_l2,
+    uint32_t cb_l_out,
+    bool neighbor_valid,
+    bool local_valid) {
+    // Only local valid - copy local data to output
+    if (!neighbor_valid && local_valid) {
+        DPRINT << "Case 2: only local valid, normalize=" << (uint32_t)normalize << "\n";
+        if constexpr (normalize) {
+            // Normalize local data: pass same CB twice to trigger single-input path
+            sdpa_tail_streaming<SDPA_EXP_APPROX_MODE, normalize, block_size, scale_fp32, num_l_chunks, vector_mode>(
+                cb_prev_max_sum, cb_prev_max_sum, cb_cur_max_sum, cb_l2, cb_l2, cb_l_out);
+        } else {
+            // No normalization - just copy
+            forward_data(cb_prev_max_sum, cb_cur_max_sum, num_l_chunks, cb_l2, cb_l_out, block_size);
+        }
+        return;
+    }
+
+    // Only neighbor valid - copy neighbor data to output
+    if (neighbor_valid && !local_valid) {
+        DPRINT << "Case 3: only neighbor valid, normalize=" << (uint32_t)normalize << "\n";
+        if constexpr (normalize) {
+            // Normalize neighbor data: pass same CB twice to trigger single-input path
+            sdpa_tail_streaming<SDPA_EXP_APPROX_MODE, normalize, block_size, scale_fp32, num_l_chunks, vector_mode>(
+                cb_worker_max_sum, cb_worker_max_sum, cb_cur_max_sum, cb_l1, cb_l1, cb_l_out);
+        } else {
+            // No normalization - just copy
+            forward_data(cb_worker_max_sum, cb_cur_max_sum, num_l_chunks, cb_l1, cb_l_out, block_size);
+        }
+        return;
+    }
+
+    // Case 4: Both valid - perform normal SDPA reduction
+    DPRINT << "Case 4: both valid, normalize=" << (uint32_t)normalize << ", normal SDPA reduction\n";
+    sdpa_tail_streaming<SDPA_EXP_APPROX_MODE, normalize, block_size, scale_fp32, num_l_chunks, vector_mode>(
+        cb_worker_max_sum, cb_prev_max_sum, cb_cur_max_sum, cb_l1, cb_l2, cb_l_out);
+}
+
 void kernel_main() {
     constexpr int vector_mode = VectorMode::RC_custom;
 
@@ -354,47 +240,18 @@ void kernel_main() {
         r2_neighbor_device_idx = get_arg_val<uint32_t>(arg_idx++);
         uint32_t r2_neighbor_r1_neighbor_idx = get_arg_val<uint32_t>(arg_idx++);
 
-        // Read position values from CB (similar to flash_mla pattern)
-        // Position tensor contains validity flags (0 or non-zero) for each device
-        DPRINT << "COMPUTE device_idx: " << (uint32_t)device_idx
-               << ", r1_neighbor_device_idx: " << (uint32_t)r1_neighbor_device_idx
-               << ", r2_neighbor_device_idx: " << (uint32_t)r2_neighbor_device_idx << "\n";
         cb_wait_front(cb_position, 1);
-        DPRINT << "COMPUTE after cb wait front\n";
-
-        // Read ALL position values at once (including R2 neighbor's R1 neighbor)
-        // Position is stored as uint32, we just check if non-zero
         uint32_t local_val = read_tile_value(cb_position, 0, device_idx);
-        DPRINT << "COMPUTE read local_val at index " << (uint32_t)device_idx << ": " << (uint32_t)local_val << "\n";
-
         uint32_t r1_val = read_tile_value(cb_position, 0, r1_neighbor_device_idx);
-        DPRINT << "COMPUTE read r1_val at index " << (uint32_t)r1_neighbor_device_idx << ": " << (uint32_t)r1_val
-               << "\n";
-
         uint32_t r2_val = read_tile_value(cb_position, 0, r2_neighbor_device_idx);
-        DPRINT << "COMPUTE read r2_val at index " << (uint32_t)r2_neighbor_device_idx << ": " << (uint32_t)r2_val
-               << "\n";
-
         uint32_t r2_neighbor_r1_val = read_tile_value(cb_position, 0, r2_neighbor_r1_neighbor_idx);
-        DPRINT << "COMPUTE read r2_neighbor_r1_val at index " << (uint32_t)r2_neighbor_r1_neighbor_idx << ": "
-               << (uint32_t)r2_neighbor_r1_val << "\n";
-
-        DPRINT << "COMPUTE after reading position values\n";
-
         cb_pop_front(cb_position, 1);
-        DPRINT << "COMPUTE after cb pop front\n";
 
         // Convert to boolean (non-zero means valid)
         local_valid = (local_val != 0);
         r1_neighbor_valid = (r1_val != 0);
         r2_neighbor_valid =
             (r2_val != 0) || (r2_neighbor_r1_val != 0);  // R2 neighbor's R1 result is valid if either device was valid
-        DPRINT << "COMPUTE r1_val: " << (uint32_t)r1_val << ", r2_val: " << (uint32_t)r2_val
-               << ", local_val: " << (uint32_t)local_val << ", r2_neighbor_r1_val: " << (uint32_t)r2_neighbor_r1_val
-               << "\n";
-        DPRINT << "COMPUTE local_valid: " << (uint32_t)local_valid
-               << ", r1_neighbor_valid: " << (uint32_t)r1_neighbor_valid
-               << ", r2_neighbor_valid: " << (uint32_t)r2_neighbor_valid << "\n";
     }
 
     // =========================================================================
@@ -425,14 +282,10 @@ void kernel_main() {
     bool local_r1_valid = local_valid || r1_neighbor_valid;
     bool r2_neighbor_r1_valid = r2_neighbor_valid;
 
-    DPRINT << "COMPUTE starting R2 reduction\n";
-    DPRINT << "COMPUTE local_r1_valid: " << (uint32_t)local_r1_valid
-           << ", r2_neighbor_r1_valid: " << (uint32_t)r2_neighbor_r1_valid << "\n";
-
     // R2: ALWAYS normalize (simplest approach - always do L/S at the end)
     sdpa_tail_streaming_conditional<
         EXP_APPROX_MODE,
-        true /* always normalize */,
+        final_reduction, /* always normalize */
         block_size,
         scale_fp32,
         num_l_chunks,

--- a/models/demos/deepseek_v3_b1/micro_ops/sdpa_reduce_to_all/kernels/compute.cpp
+++ b/models/demos/deepseek_v3_b1/micro_ops/sdpa_reduce_to_all/kernels/compute.cpp
@@ -192,6 +192,12 @@ ALWI void sdpa_tail_streaming_conditional(
         return;
     }
 
+    // Just copy local data as fallback
+    if (!neighbor_valid && !local_valid) {
+        forward_data(cb_prev_max_sum, cb_cur_max_sum, num_l_chunks, cb_l2, cb_l_out, block_size);
+        return;
+    }
+
     // Both valid - perform normal SDPA reduction
     sdpa_tail_streaming<SDPA_EXP_APPROX_MODE, normalize, block_size, scale_fp32, num_l_chunks, vector_mode>(
         cb_worker_max_sum, cb_prev_max_sum, cb_cur_max_sum, cb_l1, cb_l2, cb_l_out);

--- a/models/demos/deepseek_v3_b1/micro_ops/sdpa_reduce_to_all/kernels/reader.cpp
+++ b/models/demos/deepseek_v3_b1/micro_ops/sdpa_reduce_to_all/kernels/reader.cpp
@@ -145,7 +145,7 @@ void kernel_main() {
     }
 
     // =========================================================================
-    // ROUND 1: Prepare R1 neighbor data for compute
+    // Prepare R1 neighbor data for compute
     // =========================================================================
     if (r1_neighbor_valid) {
         prepare_data_for_compute(cb_r1_neighbor_l, cb_r1_neighbor_ms, r1_neighbor_sem_addr, r1_recv_buffer_addr);
@@ -157,7 +157,7 @@ void kernel_main() {
         cb_push_back(cb_r1_neighbor_l, out_tiles);
     }
     // =========================================================================
-    // ROUND 2: Prepare R2 neighbor data for compute
+    // Prepare R2 neighbor data for compute
     // =========================================================================
 
     // Only receive R2 data if R2 neighbor's R1 result is valid

--- a/models/demos/deepseek_v3_b1/micro_ops/sdpa_reduce_to_all/kernels/reader.cpp
+++ b/models/demos/deepseek_v3_b1/micro_ops/sdpa_reduce_to_all/kernels/reader.cpp
@@ -126,7 +126,6 @@ void kernel_main() {
 
     if constexpr (position_enabled) {
         // Get r2_neighbor_r1_neighbor_idx from runtime args
-        uint32_t device_idx = get_arg_val<uint32_t>(arg_idx++);
         uint32_t r1_neighbor_device_idx = get_arg_val<uint32_t>(arg_idx++);
         uint32_t r2_neighbor_device_idx = get_arg_val<uint32_t>(arg_idx++);
         uint32_t r2_neighbor_r1_neighbor_idx = get_arg_val<uint32_t>(arg_idx++);

--- a/models/demos/deepseek_v3_b1/micro_ops/sdpa_reduce_to_all/kernels/writer.cpp
+++ b/models/demos/deepseek_v3_b1/micro_ops/sdpa_reduce_to_all/kernels/writer.cpp
@@ -296,7 +296,6 @@ struct ChunkSender {
 using Sender = ChunkSender<slot_size, ms_tile_size_bytes, l_chunk_size_bytes, num_l_chunks, tiles_per_l_chunk>;
 
 void kernel_main() {
-    DPRINT << "WRITER kernel_main started\n";
     size_t arg_idx = 0;
 
     // R1 destination - intermediate tensor address on neighbor device
@@ -327,7 +326,6 @@ void kernel_main() {
     const uint32_t r2_fwd_sem_addr = get_semaphore(get_arg_val<uint32_t>(arg_idx++));
     const uint32_t r2_base_slot_idx = get_arg_val<uint32_t>(arg_idx++);
 
-    DPRINT << "WRITER args parsed\n";
     // Initialize sender with core coordinates
     Sender sender{current_core_x, current_core_y, fwd_core_x, fwd_core_y};
 
@@ -335,7 +333,6 @@ void kernel_main() {
     // ROUND 1: Send local input to R1 neighbor via forwarder
     // All local data is ready, send all packets immediately
     // ==========================================================================
-    DPRINT << "WRITER starting R1 send\n";
     sender.setup_round(
         {cb_local_l,
          cb_local_ms,
@@ -348,13 +345,11 @@ void kernel_main() {
          r1_base_slot_idx});
     sender.send_all();
     sender.finish_round();
-    DPRINT << "WRITER finished R1 send\n";
 
     // ==========================================================================
     // ROUND 2: Send R1 result to R2 neighbor via forwarder (STREAMING)
     // Overlap R2 fabric transfer with R1 compute by sending as data is produced
     // ==========================================================================
-    DPRINT << "WRITER starting R2 send\n";
     sender.setup_round(
         {cb_r1_result_l,
          cb_r1_result_ms,
@@ -367,7 +362,6 @@ void kernel_main() {
          r2_base_slot_idx});
     sender.send_streaming();
     sender.finish_round();
-    DPRINT << "WRITER finished R2 send\n";
 
     noc_async_full_barrier();
 

--- a/models/demos/deepseek_v3_b1/micro_ops/sdpa_reduce_to_all/op.py
+++ b/models/demos/deepseek_v3_b1/micro_ops/sdpa_reduce_to_all/op.py
@@ -36,7 +36,9 @@ def _get_element_size_bytes(dtype):
 
 class SdpaReduceToAll:
     @staticmethod
-    def golden(l_data_per_device, s_data_per_device, m_data_per_device, num_cores=8, scale_value=1.0):
+    def golden(
+        l_data_per_device, s_data_per_device, m_data_per_device, num_cores=8, scale_value=1.0, position_mask=None
+    ):
         """
         PyTorch reference implementation for SDPA reduce-to-all.
 
@@ -44,17 +46,47 @@ class SdpaReduceToAll:
             l_data_per_device: list of L tensors [batch, l_width * num_cores]
             s_data_per_device: list of S tensors [batch, num_cores]
             m_data_per_device: list of M tensors [batch, num_cores]
+            position_mask: optional tensor [num_devices] with 1.0 for valid devices, 0.0 for masked devices
         """
 
-        def compute_reduction(l1, s1, m1, l2, s2, m2, scale):
-            m_new = torch.maximum(m1, m2)
-            exp_m1 = torch.exp((m1 - m_new) * scale)
-            exp_m2 = torch.exp((m2 - m_new) * scale)
-            s_new = s1 * exp_m1 + s2 * exp_m2
-            l_new = l1 * exp_m1 + l2 * exp_m2
-            return l_new, s_new, m_new
+        def compute_reduction(l1, s1, m1, l2, s2, m2, scale, valid1, valid2, normalize=False):
+            """Conditional reduction based on validity flags.
+
+            Args:
+                normalize: If True, normalize the output L by dividing by S
+            """
+            if not valid1 and not valid2:
+                l_out = l1
+                s_out = s1
+                m_out = m1
+            elif valid1 and not valid2:
+                l_out = l1
+                s_out = s1
+                m_out = m1
+            elif not valid1 and valid2:
+                l_out = l2
+                s_out = s2
+                m_out = m2
+            # Both valid: perform normal reduction
+            else:
+                m_new = torch.maximum(m1, m2)
+                exp_m1 = torch.exp((m1 - m_new) * scale)
+                exp_m2 = torch.exp((m2 - m_new) * scale)
+                s_out = s1 * exp_m1 + s2 * exp_m2
+                l_out = l1 * exp_m1 + l2 * exp_m2
+                m_out = m_new
+
+            # Normalize if requested
+            if normalize:
+                l_out = l_out / s_out.expand(-1, l_out.shape[1])
+
+            return l_out, s_out, m_out
 
         num_devices = len(l_data_per_device)
+
+        # Default mask: all devices valid
+        if position_mask is None:
+            position_mask = torch.ones(num_devices, dtype=torch.float32)
 
         def split_by_cores(tensor_list, num_cores):
             result = []
@@ -74,18 +106,54 @@ class SdpaReduceToAll:
             s_dev = [s_data_per_device[d][:, core_idx : core_idx + 1] for d in range(num_devices)]
             m_dev = [m_data_per_device[d][:, core_idx : core_idx + 1] for d in range(num_devices)]
 
+            # Count total valid devices
+            num_valid_devices = int(sum(position_mask > 0.5))
+
+            # Round 1: reduce (0,1) and (2,3) WITHOUT normalization
             l_r1_01, s_r1_01, m_r1_01 = compute_reduction(
-                l_dev[0], s_dev[0], m_dev[0], l_dev[1], s_dev[1], m_dev[1], scale_value
+                l_dev[0],
+                s_dev[0],
+                m_dev[0],
+                l_dev[1],
+                s_dev[1],
+                m_dev[1],
+                scale_value,
+                position_mask[0].item() > 0.5,
+                position_mask[1].item() > 0.5,
+                normalize=False,  # R1 doesn't normalize
             )
             l_r1_23, s_r1_23, m_r1_23 = compute_reduction(
-                l_dev[2], s_dev[2], m_dev[2], l_dev[3], s_dev[3], m_dev[3], scale_value
-            )
-            l_final, s_final, m_final = compute_reduction(
-                l_r1_01, s_r1_01, m_r1_01, l_r1_23, s_r1_23, m_r1_23, scale_value
+                l_dev[2],
+                s_dev[2],
+                m_dev[2],
+                l_dev[3],
+                s_dev[3],
+                m_dev[3],
+                scale_value,
+                position_mask[2].item() > 0.5,
+                position_mask[3].item() > 0.5,
+                normalize=False,  # R1 doesn't normalize
             )
 
-            l_out = l_final / s_final.expand(-1, l_final.shape[1])
-            l_final_cores.append(l_out)
+            r1_01_valid = (position_mask[0].item() > 0.5) or (position_mask[1].item() > 0.5)
+            r1_23_valid = (position_mask[2].item() > 0.5) or (position_mask[3].item() > 0.5)
+
+            # Always normalize in R2 (simplest approach)
+            l_final, s_final, m_final = compute_reduction(
+                l_r1_01,
+                s_r1_01,
+                m_r1_01,
+                l_r1_23,
+                s_r1_23,
+                m_r1_23,
+                scale_value,
+                r1_01_valid,
+                r1_23_valid,
+                normalize=True,  # Always normalize at the end
+            )
+
+            # Output is normalized if >1 device had data
+            l_final_cores.append(l_final)
             s_final_cores.append(s_final)
             m_final_cores.append(m_final)
 
@@ -105,11 +173,13 @@ class SdpaReduceToAll:
         input_forwarder_cores=None,
         scatter_dest_tensor_mesh=None,
         scatter_dest_grid=None,
+        position_tensor_mesh=None,
     ):
         mesh_device = input_tensor_l_mesh.device()
         mesh_shape = mesh_device.shape
         mesh_rows = mesh_shape[0]
         mesh_cols = mesh_shape[1]
+        num_devices = mesh_rows * mesh_cols
 
         if input_forwarder_cores is None or len(input_forwarder_cores) != 2:
             raise ValueError("input_forwarder_cores must be provided with exactly 2 cores")
@@ -117,12 +187,20 @@ class SdpaReduceToAll:
         forwarder_cores = input_forwarder_cores
         forwarder_core_range_set = ttnn.CoreRangeSet([ttnn.CoreRange(core, core) for core in forwarder_cores])
 
+        # Position tensor setup (optional conditional reduction)
+        # Position tensor will be passed to kernel via CB (no host-side extraction)
+        position_enabled = position_tensor_mesh is not None
+
         input_l_per_device = ttnn.get_device_tensors(input_tensor_l_mesh)
         input_ms_per_device = ttnn.get_device_tensors(input_tensor_ms_mesh)
         output_l_per_device = ttnn.get_device_tensors(output_tensor_l_mesh)
         r1_recv_per_device = ttnn.get_device_tensors(r1_recv_tensor_mesh)
         r2_recv_per_device = ttnn.get_device_tensors(r2_recv_tensor_mesh)
         fwd_scratch_per_device = ttnn.get_device_tensors(forwarder_scratch_mesh)
+        position_per_device = None
+
+        if position_enabled:
+            position_per_device = ttnn.get_device_tensors(position_tensor_mesh)
 
         # Scatter destination setup (optional)
         scatter_enabled = scatter_dest_tensor_mesh is not None and scatter_dest_grid is not None
@@ -157,6 +235,10 @@ class SdpaReduceToAll:
                 r1_recv_device = r1_recv_per_device[device_idx]
                 r2_recv_device = r2_recv_per_device[device_idx]
                 fwd_scratch_device = fwd_scratch_per_device[device_idx]
+
+                position_device = None
+                if position_enabled:
+                    position_device = position_per_device[device_idx]
 
                 device = input_l_device.device()
 
@@ -229,6 +311,7 @@ class SdpaReduceToAll:
                 cb_l_out = 8
                 cb_ms_out = 9
                 cb_packet_slot = 10
+                cb_position = 11
 
                 # Kernel compile-time args
                 reader_ct_args = [
@@ -242,6 +325,8 @@ class SdpaReduceToAll:
                     l_chunk_size_bytes,
                     num_l_chunks,
                     tiles_per_l_chunk,
+                    cb_position,  # Position CB index
+                    1 if position_enabled else 0,  # Enable/disable position
                 ]
 
                 # Scatter compile-time parameters
@@ -301,6 +386,9 @@ class SdpaReduceToAll:
                     scale_val,
                     tiles_per_l_chunk,
                     num_l_chunks,
+                    cb_position,  # Position CB index
+                    1 if position_enabled else 0,  # Enable/disable conditional reduction
+                    num_devices,  # Total number of devices (for position array indexing)
                 ]
 
                 forwarder_ct_args = [slots_per_round, slot_size, r2_buffer_offset]
@@ -450,6 +538,24 @@ class SdpaReduceToAll:
                     ],
                 )
 
+                # Position CB (aliased from position tensor if enabled, otherwise dummy)
+                if position_enabled:
+                    cb_position_desc = ttnn.cb_descriptor_from_sharded_tensor(cb_position, position_device)
+                else:
+                    # Dummy CB when position is disabled
+                    cb_position_desc = ttnn.CBDescriptor(
+                        total_size=aligned_page_size,
+                        core_ranges=shard_grid,
+                        format_descriptors=[
+                            ttnn.CBFormatDescriptor(
+                                buffer_index=cb_position,
+                                data_format=input_dtype,
+                                page_size=aligned_page_size,
+                                tile=tile_desc,
+                            )
+                        ],
+                    )
+
                 # Semaphores
                 forwarder_semaphores = [
                     ttnn.SemaphoreDescriptor(id=fwd_r1_sem_id, core_ranges=forwarder_core_range_set, initial_value=0),
@@ -479,12 +585,14 @@ class SdpaReduceToAll:
                         cb_l_out_desc,
                         cb_ms_out_desc,
                         cb_packet_slot_desc,
+                        cb_position_desc,
                     ],
                 )
 
                 # Runtime args
                 reader_rt_args = ttnn.RuntimeArgs()
                 writer_rt_args = ttnn.RuntimeArgs()
+                compute_rt_args = ttnn.RuntimeArgs()
                 forwarder_brisc_rt_args = ttnn.RuntimeArgs()
                 forwarder_ncrisc_rt_args = ttnn.RuntimeArgs()
 
@@ -497,6 +605,10 @@ class SdpaReduceToAll:
 
                 fwd_coord = ttnn.MeshCoordinate(fwd_row, fwd_col)
                 bwd_coord = ttnn.MeshCoordinate(bwd_row, bwd_col)
+
+                # Calculate forward and backward device indices (for position mask lookup)
+                fwd_device_idx = fwd_row * mesh_cols + fwd_col
+                bwd_device_idx = bwd_row * mesh_cols + bwd_col
 
                 fabric_node_id = mesh_device.get_fabric_node_id(coord)
                 fwd_fabric_node_id = mesh_device.get_fabric_node_id(fwd_coord)
@@ -516,7 +628,8 @@ class SdpaReduceToAll:
                         self.r1_worker_count = 0
                         self.r2_worker_count = 0
 
-                # Reader args are identical for all worker cores.
+                # Reader args - need to be set per-core for position indices
+                # Set base args first (common to all cores)
                 for core in shard_cores:
                     reader_rt_args[core.x][core.y] = [
                         r1_recv_sem_addr,
@@ -540,6 +653,39 @@ class SdpaReduceToAll:
 
                     for worker_idx, core in enumerate(cores_for_link):
                         is_type_a = ((row + worker_idx) % 2) == 0
+
+                        # Add position device indices to reader runtime args
+                        if position_enabled:
+                            if is_type_a:
+                                r1_neighbor_device_idx = fwd_device_idx
+                                r2_neighbor_device_idx = bwd_device_idx
+                            else:
+                                r1_neighbor_device_idx = bwd_device_idx
+                                r2_neighbor_device_idx = fwd_device_idx
+
+                            # Compute R2 neighbor's R1 neighbor based on R2 neighbor's type
+                            # R2 neighbor's worker_idx at the same core position
+                            r2_neighbor_worker_idx = worker_idx  # Same relative position in the link
+                            r2_neighbor_row = r2_neighbor_device_idx // mesh_cols
+                            r2_neighbor_is_type_a = ((r2_neighbor_row + r2_neighbor_worker_idx) % 2) == 0
+
+                            # R2 neighbor's R1 direction
+                            if r2_neighbor_is_type_a:
+                                # R2 neighbor is Type A → its R1 is forward
+                                r2_neighbor_r1_neighbor_idx = (r2_neighbor_device_idx + 1) % num_devices
+                            else:
+                                # R2 neighbor is Type B → its R1 is backward
+                                r2_neighbor_r1_neighbor_idx = (r2_neighbor_device_idx - 1 + num_devices) % num_devices
+
+                            # Append device indices to reader args
+                            reader_rt_args[core.x][core.y].extend(
+                                [
+                                    device_idx,
+                                    r1_neighbor_device_idx,
+                                    r2_neighbor_device_idx,
+                                    r2_neighbor_r1_neighbor_idx,
+                                ]
+                            )
 
                         r1_cfg = fwd_cfg if is_type_a else bwd_cfg
                         r2_cfg = bwd_cfg if is_type_a else fwd_cfg
@@ -574,6 +720,41 @@ class SdpaReduceToAll:
                             r2_cfg.r2_sem,
                             r2_slot_idx,
                         ]
+
+                        # Compute runtime args: device indices for position lookup
+                        if position_enabled:
+                            # Determine this core's neighbor device IDs based on direction
+                            # Type A: R1=forward, R2=backward
+                            # Type B: R1=backward, R2=forward
+                            if is_type_a:
+                                r1_neighbor_device_idx = fwd_device_idx
+                                r2_neighbor_device_idx = bwd_device_idx
+                            else:
+                                r1_neighbor_device_idx = bwd_device_idx
+                                r2_neighbor_device_idx = fwd_device_idx
+
+                            # Compute R2 neighbor's R1 neighbor based on R2 neighbor's type
+                            # R2 neighbor's worker_idx at the same core position
+                            r2_neighbor_worker_idx = worker_idx  # Same relative position in the link
+                            r2_neighbor_row = r2_neighbor_device_idx // mesh_cols
+                            r2_neighbor_is_type_a = ((r2_neighbor_row + r2_neighbor_worker_idx) % 2) == 0
+
+                            # R2 neighbor's R1 direction
+                            if r2_neighbor_is_type_a:
+                                # R2 neighbor is Type A → its R1 is forward
+                                r2_neighbor_r1_neighbor_idx = (r2_neighbor_device_idx + 1) % num_devices
+                            else:
+                                # R2 neighbor is Type B → its R1 is backward
+                                r2_neighbor_r1_neighbor_idx = (r2_neighbor_device_idx - 1 + num_devices) % num_devices
+
+                            # Pass device indices - kernel will read position values from CB
+                            compute_rt_args[core.x][core.y] = [
+                                device_idx,
+                                r1_neighbor_device_idx,
+                                r2_neighbor_device_idx,
+                                r2_neighbor_r1_neighbor_idx,
+                            ]
+                        # If position is disabled, no runtime args needed (compute kernel uses defaults)
 
                         # Append scatter runtime args (only when scatter is enabled)
                         if scatter_enabled:
@@ -618,6 +799,7 @@ class SdpaReduceToAll:
 
                 program.kernels[0].runtime_args = reader_rt_args
                 program.kernels[1].runtime_args = writer_rt_args
+                program.kernels[2].runtime_args = compute_rt_args
                 program.kernels[3].runtime_args = forwarder_brisc_rt_args
                 program.kernels[4].runtime_args = forwarder_ncrisc_rt_args
 
@@ -633,6 +815,8 @@ class SdpaReduceToAll:
         ]
         if scatter_enabled:
             io_tensors.append(scatter_dest_tensor_mesh)
+        if position_enabled:
+            io_tensors.append(position_tensor_mesh)
         ttnn.generic_op(io_tensors, mesh_program_descriptor)
 
         return output_tensor_l_mesh

--- a/models/demos/deepseek_v3_b1/micro_ops/sdpa_reduce_to_all/op.py
+++ b/models/demos/deepseek_v3_b1/micro_ops/sdpa_reduce_to_all/op.py
@@ -145,8 +145,6 @@ class SdpaReduceToAll:
                 r1_01_valid,
                 r1_23_valid,
             )
-
-            print("final_reduction:", final_reduction)
             if final_reduction:
                 l_final = l_final / s_final.expand(-1, l_final.shape[1])
             l_final_cores.append(l_final)
@@ -721,6 +719,7 @@ class SdpaReduceToAll:
                             reader_rt_args[core.x][core.y].extend(
                                 [
                                     device_idx,
+                                    r1_neighbor_device_idx,
                                     r2_neighbor_device_idx,
                                     r2_neighbor_r1_neighbor_idx,
                                 ]

--- a/models/demos/deepseek_v3_b1/micro_ops/sdpa_reduce_to_all/op.py
+++ b/models/demos/deepseek_v3_b1/micro_ops/sdpa_reduce_to_all/op.py
@@ -133,7 +133,6 @@ class SdpaReduceToAll:
             r1_01_valid = (position_mask[0].item() > 0.5) or (position_mask[1].item() > 0.5)
             r1_23_valid = (position_mask[2].item() > 0.5) or (position_mask[3].item() > 0.5)
 
-            # Always normalize in R2 (simplest approach)
             l_final, s_final, m_final = compute_reduction(
                 l_r1_01,
                 s_r1_01,
@@ -717,7 +716,6 @@ class SdpaReduceToAll:
 
                             reader_rt_args[core.x][core.y].extend(
                                 [
-                                    device_idx,
                                     r1_neighbor_device_idx,
                                     r2_neighbor_device_idx,
                                     r2_neighbor_r1_neighbor_idx,

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_sdpa_reduce_to_all.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_sdpa_reduce_to_all.py
@@ -124,7 +124,6 @@ def test_sdpa_reduce_to_all(bh_1d_mesh_device, scatter_enabled, position_vector)
 
     position_mask = torch.tensor(position_vector, dtype=torch.bfloat16)
     final_reduction = position_mask.sum() > 1.0
-    print("final_reduction:", final_reduction)
 
     m_data_per_device = []
     s_data_per_device = []
@@ -179,6 +178,8 @@ def test_sdpa_reduce_to_all(bh_1d_mesh_device, scatter_enabled, position_vector)
         memory_config=position_mem_config,
         mesh_mapper=mesh_mapper,
     )
+    if position_vector == [1.0, 1.0, 1.0, 1.0]:
+        position_mesh = None
 
     input_l_mesh = ttnn.from_torch(
         l_data_all,

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_sdpa_reduce_to_all.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_sdpa_reduce_to_all.py
@@ -341,6 +341,6 @@ def test_sdpa_reduce_to_all(bh_1d_mesh_device, scatter_enabled, position_vector)
                 diff = torch.max(torch.abs(actual - expected)).item()
                 scatter_max_diff = max(scatter_max_diff, diff)
 
-        scatter_match = scatter_max_diff < 0.13  # Increased tolerance to match L tensor tolerance
+        scatter_match = scatter_max_diff < 0.07
         logger.info(f"Scatter output match: {scatter_match}, max_diff: {scatter_max_diff:.4f}")
         assert scatter_match, f"Scatter output mismatch! Max diff: {scatter_max_diff}"

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_sdpa_reduce_to_all.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_sdpa_reduce_to_all.py
@@ -123,7 +123,7 @@ def test_sdpa_reduce_to_all(bh_1d_mesh_device, scatter_enabled, position_vector)
     ms_data_per_device = [torch.randn(ms_shape, dtype=torch.float32).to(torch.bfloat16) for _ in range(num_devices)]
 
     position_mask = torch.tensor(position_vector, dtype=torch.bfloat16)
-    final_reduction = position_mask.sum() > 1.0
+    final_reduction = (position_mask.sum() > 1.0).item()
 
     m_data_per_device = []
     s_data_per_device = []


### PR DESCRIPTION
### Ticket
Link to Github Issue https://github.com/tenstorrent/tt-metal/issues/37773

### Problem description
Provide context for the problem.

### What's changed
-For short sequence lengths, data might be located on a subset of devices
-This PR modifies SDPA reduce to all to only reduce on valid data
-Compute kernel skips reduction for invalid device data
-for 4 devices, this op is tested for position indices: [1,0,0,0], [1,1,0,0], [1,1,1,0] and [1,1,1,1]

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=nardo/r2a)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:nardo/r2a)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=nardo/r2a)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:nardo/r2a)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nardo/r2a)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nardo/r2a)
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nardo/r2a)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nardo/r2a)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nardo/r2a)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nardo/r2a)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nardo/r2a)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nardo/r2a)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
