### PR TITLE
fix processor names in watcher tests

### DIFF
--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_assert.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_assert.cpp
@@ -90,7 +90,7 @@ static void RunTest(
                                 DataMovementConfig{
                                     .processor = tt_metal::DataMovementProcessor::RISCV_0,
                                     .noc = tt_metal::NOC::RISCV_0_default});
-                            risc = " brisc";
+                            risc = "BRISC";
                             break;
                         case 1:
                             assert_kernel = CreateKernel(
@@ -100,7 +100,7 @@ static void RunTest(
                                 DataMovementConfig{
                                     .processor = tt_metal::DataMovementProcessor::RISCV_1,
                                     .noc = tt_metal::NOC::RISCV_1_default});
-                            risc = "ncrisc";
+                            risc = "NCRISC";
                             break;
                         default: TT_THROW("Unsupported DM processor id {}", processor_id);
                     }
@@ -115,7 +115,7 @@ static void RunTest(
                         "tests/tt_metal/tt_metal/test_kernels/misc/watcher_asserts.cpp",
                         logical_core,
                         ComputeConfig{.defines = {{fmt::format("TRISC{}", processor_id), "1"}}});
-                    risc = fmt::format("trisc{}", processor_id);
+                    risc = fmt::format("TRISC{}", processor_id);
                     break;
             }
             break;

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_sanitize.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_sanitize.cpp
@@ -280,9 +280,9 @@ void RunTestOnCore(
     std::string expected;
     CoreCoord input_core_virtual_coords = device->virtual_noc0_coordinate(noc, input_buf_noc_xy);
     CoreCoord output_core_virtual_coords = device->virtual_noc0_coordinate(noc, output_buf_noc_xy);
-    std::string risc_name = (is_eth_core) ? "erisc" : " brisc";
+    std::string risc_name = (is_eth_core) ? "erisc" : "BRISC";
     if (use_ncrisc) {
-        risc_name = "ncrisc";
+        risc_name = "NCRISC";
     }
     switch (feature) {
         case SanitizeNOCAddress:


### PR DESCRIPTION
### Ticket
N/A

### Problem description
We changed the capitalization of processor names, which broke some tests

### What's changed
Updated tests to use the correct spelling of processors

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=ayaacob/fix_watcher_tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:ayaacob/fix_watcher_tests)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ayaacob/fix_watcher_tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ayaacob/fix_watcher_tests)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ayaacob/fix_watcher_tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ayaacob/fix_watcher_tests)
- [ ] New/Existing tests provide coverage for changes