### PR TITLE
Make RNG seed optional and improve per-core seed generation for bernoulli/uniform/rand

### DIFF
--- a/ttnn/cpp/ttnn/operations/bernoulli/bernoulli.cpp
+++ b/ttnn/cpp/ttnn/operations/bernoulli/bernoulli.cpp
@@ -10,7 +10,7 @@
 namespace ttnn::operations::bernoulli {
 Tensor Bernoulli::invoke(
     const Tensor& input,
-    const uint32_t seed,
+    const std::optional<uint32_t> seed,
     const std::optional<Tensor>& output,
     const std::optional<DataType>& dtype,
     const std::optional<MemoryConfig>& memory_config,

--- a/ttnn/cpp/ttnn/operations/bernoulli/bernoulli.hpp
+++ b/ttnn/cpp/ttnn/operations/bernoulli/bernoulli.hpp
@@ -10,7 +10,7 @@ namespace ttnn::operations::bernoulli {
 struct Bernoulli {
     static Tensor invoke(
         const Tensor& input,
-        uint32_t seed,
+        const std::optional<uint32_t> seed,
         const std::optional<Tensor>& output,
         const std::optional<DataType>& dtype,
         const std::optional<MemoryConfig>& memory_config,

--- a/ttnn/cpp/ttnn/operations/bernoulli/bernoulli_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/bernoulli/bernoulli_nanobind.cpp
@@ -58,7 +58,7 @@ void bind_bernoulli_operation(nb::module_& mod) {
         doc,
         ttnn::nanobind_arguments_t{
             nb::arg("input"),
-            nb::arg("seed") = 0,
+            nb::arg("seed") = nb::none(),
             nb::kw_only(),
             nb::arg("output") = nb::none(),
             nb::arg("dtype") = nb::none(),

--- a/ttnn/cpp/ttnn/operations/bernoulli/device/bernoulli_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/bernoulli/device/bernoulli_device_operation.cpp
@@ -69,7 +69,7 @@ BernoulliDeviceOperation::tensor_return_value_t BernoulliDeviceOperation::create
 tt::stl::hash::hash_t BernoulliDeviceOperation::compute_program_hash(
     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
     auto cached_operation_attributes = operation_attributes;
-    cached_operation_attributes.seed = 0;
+    cached_operation_attributes.seed = std::nullopt;
     return tt::stl::hash::hash_objects_with_default_seed(cached_operation_attributes, tensor_args);
 }
 
@@ -78,7 +78,7 @@ tt::stl::hash::hash_t BernoulliDeviceOperation::compute_program_hash(
 namespace ttnn::prim {
 ttnn::operations::bernoulli::BernoulliDeviceOperation::tensor_return_value_t bernoulli(
     const Tensor& input,
-    uint32_t seed,
+    std::optional<uint32_t> seed,
     const std::optional<Tensor>& output,
     const std::optional<DataType>& dtype,
     const std::optional<MemoryConfig>& memory_config,

--- a/ttnn/cpp/ttnn/operations/bernoulli/device/bernoulli_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/bernoulli/device/bernoulli_device_operation.hpp
@@ -11,7 +11,7 @@ namespace ttnn::operations::bernoulli {
 
 struct BernoulliDeviceOperation {
     struct operation_attributes_t {
-        uint32_t seed;
+        std::optional<uint32_t> seed;
         const DataType dtype;
         const MemoryConfig memory_config;
         const DeviceComputeKernelConfig compute_kernel_config;
@@ -63,7 +63,7 @@ struct BernoulliDeviceOperation {
 namespace ttnn::prim {
 ttnn::operations::bernoulli::BernoulliDeviceOperation::tensor_return_value_t bernoulli(
     const Tensor& input,
-    uint32_t seed,
+    std::optional<uint32_t> seed,
     const std::optional<Tensor>& output = std::nullopt,
     const std::optional<DataType>& dtype = std::nullopt,
     const std::optional<MemoryConfig>& memory_config = std::nullopt,

--- a/ttnn/cpp/ttnn/operations/rand/device/rand_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/rand/device/rand_device_operation.cpp
@@ -49,7 +49,7 @@ RandDeviceOperation::tensor_return_value_t RandDeviceOperation::create_output_te
 tt::stl::hash::hash_t RandDeviceOperation::compute_program_hash(
     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
     auto cached_operation_attributes = operation_attributes;
-    cached_operation_attributes.seed = 0;
+    cached_operation_attributes.seed = std::nullopt;
     return tt::stl::hash::hash_objects_with_default_seed(cached_operation_attributes, tensor_args);
 }
 
@@ -64,7 +64,7 @@ ttnn::operations::rand::RandDeviceOperation::tensor_return_value_t uniform(
     MeshDevice& device,
     float from,
     float to,
-    uint32_t seed) {
+    std::optional<uint32_t> seed) {
     using OperationType = ttnn::operations::rand::RandDeviceOperation;
     return ttnn::device_operation::launch<OperationType>(
         OperationType::operation_attributes_t{

--- a/ttnn/cpp/ttnn/operations/rand/device/rand_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/rand/device/rand_device_operation.hpp
@@ -17,7 +17,7 @@ struct RandDeviceOperation {
         MeshDevice* device;
         const float from;
         const float to;
-        uint32_t seed;
+        std::optional<uint32_t> seed;
     };
 
     struct tensor_args_t {};
@@ -67,5 +67,5 @@ ttnn::operations::rand::RandDeviceOperation::tensor_return_value_t uniform(
     MeshDevice& device,
     float from,
     float to,
-    uint32_t seed);
+    std::optional<uint32_t> seed);
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/rand/device/rand_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/rand/device/rand_program_factory.cpp
@@ -14,10 +14,9 @@ namespace ttnn::operations::rand {
 using namespace tt;
 using namespace tt::tt_metal;
 
-std::mt19937 rng(std::time(nullptr));
-std::uniform_int_distribution distribution(1, std::numeric_limits<int32_t>::max());
+std::uniform_int_distribution distribution(0, std::numeric_limits<int32_t>::max());
 
-auto get_random_seed() -> uint32_t { return distribution(rng); }
+auto get_random_seed(std::mt19937& rng) -> uint32_t { return distribution(rng); }
 
 RandDeviceOperation::ProgramFactory::cached_program_t RandDeviceOperation::ProgramFactory::create(
     const operation_attributes_t& operation_attributes,
@@ -86,6 +85,9 @@ RandDeviceOperation::ProgramFactory::cached_program_t RandDeviceOperation::Progr
             .compile_args = compute_compile_time_args,
         });
 
+    std::mt19937 rng = operation_attributes.seed.has_value() ? std::mt19937(*operation_attributes.seed)
+                                                             : std::mt19937(std::time(nullptr));
+
     uint32_t tile_offset = 0;
     for (int i = 0; i < cores.size(); ++i) {
         const auto& core = cores[i];
@@ -106,8 +108,7 @@ RandDeviceOperation::ProgramFactory::cached_program_t RandDeviceOperation::Progr
         f2u_from.f = operation_attributes.from;
         f2u_to.f = operation_attributes.to - eps;  // -eps make sure that generated number is < operation_attributes.to
 
-        // Each core has its own seed to increase the number of generated random numbers
-        uint32_t seed = operation_attributes.seed != 0 ? operation_attributes.seed + i : get_random_seed();
+        uint32_t seed = get_random_seed(rng);
 
         std::vector<uint32_t> compute_runtime_args = {seed, f2u_from.u, f2u_to.u, tile_offset, units_per_core};
         SetRuntimeArgs(program, compute_kernel_id, core, compute_runtime_args);
@@ -135,10 +136,13 @@ void RandDeviceOperation::ProgramFactory::override_runtime_arguments(
 
     const uint32_t output_addr = output.buffer()->address();
 
+    std::mt19937 rng = operation_attributes.seed.has_value() ? std::mt19937(*operation_attributes.seed)
+                                                             : std::mt19937(std::time(nullptr));
+
     for (int i = 0; i < cores.size(); ++i) {
         {
             auto& runtime_args = GetRuntimeArgs(program, compute_kernel_id, cores[i]);
-            runtime_args[0] = operation_attributes.seed != 0 ? operation_attributes.seed + i : get_random_seed();
+            runtime_args[0] = get_random_seed(rng);
         }
         {
             auto& runtime_args = GetRuntimeArgs(program, writer_kernel_id, cores[i]);

--- a/ttnn/cpp/ttnn/operations/rand/rand.cpp
+++ b/ttnn/cpp/ttnn/operations/rand/rand.cpp
@@ -20,7 +20,7 @@ Tensor Rand::invoke(
     const MemoryConfig& memory_config,
     float from,
     float to,
-    uint32_t seed) {
+    std::optional<uint32_t> seed) {
     TT_FATAL(dtype != DataType::UINT8, "[ttnn::rand] DataType::UINT8 is not supported.");
 
     auto tensor = ttnn::prim::uniform(shape, DataType::FLOAT32, Layout::TILE, memory_config, device, from, to, seed);

--- a/ttnn/cpp/ttnn/operations/rand/rand.hpp
+++ b/ttnn/cpp/ttnn/operations/rand/rand.hpp
@@ -15,7 +15,7 @@ struct Rand {
         const MemoryConfig& memory_config = types::DRAM_MEMORY_CONFIG,
         float from = 0.0f,
         float to = 1.0f,
-        uint32_t seed = 0);
+        std::optional<uint32_t> seed = std::nullopt);
 };
 }  // namespace ttnn::operations::rand
 

--- a/ttnn/cpp/ttnn/operations/rand/rand_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/rand/rand_nanobind.cpp
@@ -36,7 +36,7 @@ void bind_rand_operation(nb::module_& mod) {
             low (float, optional): The lower bound of the range (inclusive).
             high (float, optional): The upper bound of the range (exclusive).
             seed (int, optional): An optional seed to initialize the random number generator
-                                for reproducible results. Defaults to 0.
+                                for reproducible results.
 
         Returns:
             ttnn.Tensor: A tensor with specified shape, dtype, and layout containing random values.
@@ -56,7 +56,9 @@ void bind_rand_operation(nb::module_& mod) {
                const MemoryConfig& memory_config,
                float from,
                float to,
-               uint32_t seed) { return self(shape, device, dtype, layout, memory_config, from, to, seed); },
+               std::optional<uint32_t> seed) {
+                return self(shape, device, dtype, layout, memory_config, from, to, seed);
+            },
             nb::arg("shape"),
             nb::arg("device"),
             nb::kw_only(),
@@ -65,6 +67,6 @@ void bind_rand_operation(nb::module_& mod) {
             nb::arg("memory_config") = nb::cast(ttnn::DRAM_MEMORY_CONFIG),
             nb::arg("low") = 0.0f,
             nb::arg("high") = 1.0f,
-            nb::arg("seed") = 0});
+            nb::arg("seed") = nb::none()});
 }
 }  // namespace ttnn::operations::rand

--- a/ttnn/cpp/ttnn/operations/uniform/device/uniform_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/uniform/device/uniform_device_operation.cpp
@@ -41,7 +41,7 @@ UniformDeviceOperation::tensor_return_value_t UniformDeviceOperation::create_out
 
 tt::stl::hash::hash_t UniformDeviceOperation::compute_program_hash(const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
     auto cached_operation_attributes = operation_attributes;
-    cached_operation_attributes.seed = 0;
+    cached_operation_attributes.seed = std::nullopt;
     return tt::stl::hash::hash_objects_with_default_seed(cached_operation_attributes, tensor_args);
 }
 
@@ -52,7 +52,7 @@ ttnn::Tensor uniform(
     const Tensor& input,
     const float from,
     const float to,
-    const uint32_t seed,
+    const std::optional<uint32_t> seed,
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<DeviceComputeKernelConfig>& compute_kernel_config) {
     using OperationType = ttnn::operations::uniform::UniformDeviceOperation;

--- a/ttnn/cpp/ttnn/operations/uniform/device/uniform_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/uniform/device/uniform_device_operation.hpp
@@ -13,7 +13,7 @@ struct UniformDeviceOperation {
     struct operation_attributes_t {
         const float from;
         const float to;
-        uint32_t seed;
+        std::optional<uint32_t> seed;
         const MemoryConfig memory_config;
         const DeviceComputeKernelConfig compute_kernel_config;
     };
@@ -64,7 +64,7 @@ ttnn::Tensor uniform(
     const Tensor& input,
     float from,
     float to,
-    uint32_t seed,
+    std::optional<uint32_t> seed,
     const std::optional<MemoryConfig>& memory_config = std::nullopt,
     const std::optional<DeviceComputeKernelConfig>& compute_kernel_config = std::nullopt);
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/uniform/uniform.cpp
+++ b/ttnn/cpp/ttnn/operations/uniform/uniform.cpp
@@ -12,7 +12,7 @@ Tensor Uniform::invoke(
     const Tensor& input,
     const float from,
     const float to,
-    const uint32_t seed,
+    const std::optional<uint32_t> seed,
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<DeviceComputeKernelConfig>& compute_kernel_config) {
     return ttnn::prim::uniform(input, from, to, seed, memory_config, compute_kernel_config);

--- a/ttnn/cpp/ttnn/operations/uniform/uniform.hpp
+++ b/ttnn/cpp/ttnn/operations/uniform/uniform.hpp
@@ -12,7 +12,7 @@ struct Uniform {
         const Tensor& input,
         float from,
         float to,
-        uint32_t seed,
+        std::optional<uint32_t> seed,
         const std::optional<MemoryConfig>& memory_config,
         const std::optional<DeviceComputeKernelConfig>& compute_kernel_config);
 };

--- a/ttnn/cpp/ttnn/operations/uniform/uniform_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/uniform/uniform_nanobind.cpp
@@ -59,7 +59,7 @@ void bind_uniform_operation(nb::module_& mod) {
             nb::arg("input"),
             nb::arg("from") = 0,
             nb::arg("to") = 1,
-            nb::arg("seed") = 0,
+            nb::arg("seed") = nb::none(),
             nb::kw_only(),
             nb::arg("memory_config") = nb::none(),
             nb::arg("compute_kernel_config") = nb::none()});


### PR DESCRIPTION
### Ticket

### Problem description

`ttnn.bernoulli`, `ttnn.uniform`, and `ttnn.rand` currently take a `uint32_t` seed with 0 acting as a "no-seed / random" sentinel.
This has two issues:
1. The API cannot express "no seed" explicitly, and seed=0 is ambiguous (it could be a valid user seed).
2. The device program previously derived per-core seeds by incrementing the base seed. In practice, this can lead to highly correlated/random streams across adjacent seeds (e.g., results for seed=1 and seed=2 end up looking almost identical), reducing randomness quality and surprising users expecting independent outputs.
    - ref: https://github.com/tenstorrent/tt-metal/blob/0839f4762bf1b6a221408e2dd65ff55e730f75aa/ttnn/cpp/ttnn/operations/rand/device/rand_program_factory.cpp#L109-L110


### What's changed

- Updated the APIs to use `std::optional<uint32_t>` for seeds:
  - Python bindings now default `seed=None` instead of `0`.
  - Operation attributes store `std::optional<uint32_t>` rather than a `uint32_t` with a sentinel.
- Updated program hash computation to ignore seeds by setting the cached seed to `std::nullopt` (consistent with prior behavior where the seed should not affect compilation/caching).
- Reworked per-core seed generation:
  - Instead of incrementing the base seed, we now initialize an `std::mt19937` once per program creation/override using either the user-provided seed or `std::time(nullptr)` when no seed is provided.
  - Each core receives a fresh seed sampled from a uniform distribution, improving independence between cores and avoiding the "seed=1 vs seed=2 are almost the same" behavior.

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:{{branch_name}})
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:{{branch_name}})
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:{{branch_name}})
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:{{branch_name}})
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:{{branch_name}})
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:{{branch_name}})
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
