### PR TITLE
Add experimental EZ convenience API for simplified Metalium programming

### DIFF
--- a/tests/tt_metal/tt_metal/CMakeLists.txt
+++ b/tests/tt_metal/tt_metal/CMakeLists.txt
@@ -65,6 +65,7 @@ add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/noc_debugging)
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/lightmetal)
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/sfpi)
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/misc)
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/ez)
 
 add_custom_target(
     metal_tests
@@ -85,6 +86,7 @@ add_custom_target(
         unit_tests_lightmetal
         unit_tests_sfpi
         unit_tests_misc
+        unit_tests_ez
 )
 
 add_library(metalium_test_files INTERFACE)

--- a/tests/tt_metal/tt_metal/ez/CMakeLists.txt
+++ b/tests/tt_metal/tt_metal/ez/CMakeLists.txt
@@ -1,0 +1,33 @@
+# Include source file lists
+include(sources.cmake)
+
+# Create the test executable
+add_executable(unit_tests_ez ${UNIT_TESTS_EZ_SRC})
+
+# Link libraries
+target_link_libraries(
+    unit_tests_ez
+    PRIVATE
+        test_metal_common_libs
+        tt_metal_ez
+        Boost::smart_ptr
+)
+
+# Set include directories
+target_include_directories(
+    unit_tests_ez
+    BEFORE
+    PRIVATE
+        "$<TARGET_PROPERTY:Metalium::Metal,INCLUDE_DIRECTORIES>"
+        ${PROJECT_SOURCE_DIR}/tests
+        ${PROJECT_SOURCE_DIR}/tests/tt_metal/tt_metal/common
+        ${CMAKE_CURRENT_SOURCE_DIR}
+)
+
+# Set runtime output directory
+set_target_properties(
+    unit_tests_ez
+    PROPERTIES
+        RUNTIME_OUTPUT_DIRECTORY
+            ${PROJECT_BINARY_DIR}/test/tt_metal
+)

--- a/tests/tt_metal/tt_metal/ez/kernels/read_tiles.cpp
+++ b/tests/tt_metal/tt_metal/ez/kernels/read_tiles.cpp
@@ -1,0 +1,32 @@
+// SPDX-FileCopyrightText: (c) 2026 Olof Johansson <olof@lixom.net>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+
+void kernel_main() {
+    uint32_t in0_addr = get_arg_val<uint32_t>(0);
+    uint32_t in1_addr = get_arg_val<uint32_t>(1);
+    uint32_t n_tiles = get_arg_val<uint32_t>(2);
+
+    constexpr uint32_t cb_in0 = tt::CBIndex::c_0;
+    constexpr uint32_t cb_in1 = tt::CBIndex::c_1;
+    const uint32_t tile_size_bytes = get_tile_size(cb_in0);
+
+    constexpr auto in0_args = TensorAccessorArgs<0>();
+    const auto in0 = TensorAccessor(in0_args, in0_addr, tile_size_bytes);
+    constexpr auto in1_args = TensorAccessorArgs<in0_args.next_compile_time_args_offset()>();
+    const auto in1 = TensorAccessor(in1_args, in1_addr, tile_size_bytes);
+
+    for (uint32_t i = 0; i < n_tiles; i++) {
+        cb_reserve_back(cb_in0, 1);
+        cb_reserve_back(cb_in1, 1);
+        uint32_t cb_in0_addr = get_write_ptr(cb_in0);
+        uint32_t cb_in1_addr = get_write_ptr(cb_in1);
+        noc_async_read_tile(i, in0, cb_in0_addr);
+        noc_async_read_tile(i, in1, cb_in1_addr);
+        noc_async_read_barrier();
+        cb_push_back(cb_in0, 1);
+        cb_push_back(cb_in1, 1);
+    }
+}

--- a/tests/tt_metal/tt_metal/ez/kernels/tiles_add.cpp
+++ b/tests/tt_metal/tt_metal/ez/kernels/tiles_add.cpp
@@ -1,0 +1,36 @@
+// SPDX-FileCopyrightText: (c) 2026 Olof Johansson <olof@lixom.net>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+#include "api/compute/common.h"
+#include "api/compute/tile_move_copy.h"
+#include "api/compute/eltwise_binary.h"
+#include "api/compute/compute_kernel_api.h"
+
+void kernel_main() {
+    uint32_t n_tiles = get_arg_val<uint32_t>(0);
+
+    constexpr auto cb_in0 = tt::CBIndex::c_0;
+    constexpr auto cb_in1 = tt::CBIndex::c_1;
+    constexpr auto cb_out0 = tt::CBIndex::c_16;
+    constexpr uint32_t dst_reg = 0;
+
+    binary_op_init_common(cb_in0, cb_in1, cb_out0);
+    add_tiles_init(cb_in0, cb_in1);
+
+    for (uint32_t i = 0; i < n_tiles; i++) {
+        cb_wait_front(cb_in0, 1);
+        cb_wait_front(cb_in1, 1);
+        tile_regs_acquire();
+        add_tiles(cb_in0, cb_in1, 0, 0, dst_reg);
+        tile_regs_commit();
+        tile_regs_wait();
+        cb_reserve_back(cb_out0, 1);
+        pack_tile(dst_reg, cb_out0);
+        cb_push_back(cb_out0, 1);
+        cb_pop_front(cb_in0, 1);
+        cb_pop_front(cb_in1, 1);
+        tile_regs_release();
+    }
+}

--- a/tests/tt_metal/tt_metal/ez/kernels/tiles_add_named.cpp
+++ b/tests/tt_metal/tt_metal/ez/kernels/tiles_add_named.cpp
@@ -1,0 +1,39 @@
+// SPDX-FileCopyrightText: (c) 2026 Olof Johansson <olof@lixom.net>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Variant of tiles_add that reads CB indices from named compile-time args
+// instead of hardcoding them. Used to test per-kernel named_args on KernelRef.
+
+#include <cstdint>
+#include "api/compute/common.h"
+#include "api/compute/tile_move_copy.h"
+#include "api/compute/eltwise_binary.h"
+#include "api/compute/compute_kernel_api.h"
+
+void kernel_main() {
+    uint32_t n_tiles = get_arg_val<uint32_t>(0);
+
+    constexpr auto cb_in0 = get_named_compile_time_arg_val("cb_in0");
+    constexpr auto cb_in1 = get_named_compile_time_arg_val("cb_in1");
+    constexpr auto cb_out0 = get_named_compile_time_arg_val("cb_out0");
+    constexpr uint32_t dst_reg = 0;
+
+    binary_op_init_common(cb_in0, cb_in1, cb_out0);
+    add_tiles_init(cb_in0, cb_in1);
+
+    for (uint32_t i = 0; i < n_tiles; i++) {
+        cb_wait_front(cb_in0, 1);
+        cb_wait_front(cb_in1, 1);
+        tile_regs_acquire();
+        add_tiles(cb_in0, cb_in1, 0, 0, dst_reg);
+        tile_regs_commit();
+        tile_regs_wait();
+        cb_reserve_back(cb_out0, 1);
+        pack_tile(dst_reg, cb_out0);
+        cb_push_back(cb_out0, 1);
+        cb_pop_front(cb_in0, 1);
+        cb_pop_front(cb_in1, 1);
+        tile_regs_release();
+    }
+}

--- a/tests/tt_metal/tt_metal/ez/kernels/void_compute.cpp
+++ b/tests/tt_metal/tt_metal/ez/kernels/void_compute.cpp
@@ -1,0 +1,9 @@
+// SPDX-FileCopyrightText: (c) 2026 Olof Johansson <olof@lixom.net>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "api/compute/compute_kernel_api.h"
+
+void kernel_main() {
+    // No-op compute kernel for testing.
+}

--- a/tests/tt_metal/tt_metal/ez/kernels/write_tile.cpp
+++ b/tests/tt_metal/tt_metal/ez/kernels/write_tile.cpp
@@ -1,0 +1,24 @@
+// SPDX-FileCopyrightText: (c) 2026 Olof Johansson <olof@lixom.net>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+
+void kernel_main() {
+    uint32_t c_addr = get_arg_val<uint32_t>(0);
+    uint32_t n_tiles = get_arg_val<uint32_t>(1);
+
+    constexpr uint32_t cb_out0 = tt::CBIndex::c_16;
+    const uint32_t tile_size_bytes = get_tile_size(cb_out0);
+
+    constexpr auto out0_args = TensorAccessorArgs<0>();
+    const auto out0 = TensorAccessor(out0_args, c_addr, tile_size_bytes);
+
+    for (uint32_t i = 0; i < n_tiles; i++) {
+        cb_wait_front(cb_out0, 1);
+        uint32_t cb_out0_addr = get_read_ptr(cb_out0);
+        noc_async_write_tile(i, out0, cb_out0_addr);
+        noc_async_write_barrier();
+        cb_pop_front(cb_out0, 1);
+    }
+}

--- a/tests/tt_metal/tt_metal/ez/sources.cmake
+++ b/tests/tt_metal/tt_metal/ez/sources.cmake
@@ -1,0 +1,3 @@
+# Source files for ez API tests
+
+set(UNIT_TESTS_EZ_SRC test_ez_api.cpp)

--- a/tests/tt_metal/tt_metal/ez/test_ez_api.cpp
+++ b/tests/tt_metal/tt_metal/ez/test_ez_api.cpp
@@ -1,0 +1,236 @@
+// SPDX-FileCopyrightText: (c) 2026 Olof Johansson <olof@lixom.net>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <gtest/gtest.h>
+#include <random>
+#include <vector>
+
+#include <tt-metalium/bfloat16.hpp>
+#include <tt-metalium/distributed.hpp>
+#include <tt-metalium/experimental/ez/ez.hpp>
+
+using namespace tt::tt_metal;
+using namespace tt::tt_metal::experimental::ez;
+
+class EzApiTest : public ::testing::Test {};
+
+TEST_F(EzApiTest, HelloWorld) {
+    // Verify that DeviceContext + ProgramBuilder can create and run a trivial compute kernel.
+    DeviceContext ctx(0);
+    auto program = ProgramBuilder(CoreCoord{0, 0})
+                       .compute("tests/tt_metal/tt_metal/ez/kernels/void_compute.cpp")
+                       .done()
+                       .build();
+    ctx.run(std::move(program));
+}
+
+TEST_F(EzApiTest, DramBufferRoundtrip) {
+    // Verify write/read roundtrip through a DRAM tile buffer.
+    DeviceContext ctx(0);
+    constexpr uint32_t n_tiles = 4;
+    auto buf = ctx.dram_tile_buffer(n_tiles);
+
+    constexpr uint32_t elements = n_tiles * tt::constants::TILE_WIDTH * tt::constants::TILE_HEIGHT;
+    std::vector<bfloat16> src(elements);
+    std::mt19937 rng(42);
+    std::uniform_real_distribution<float> dist(0.0f, 1.0f);
+    for (auto& v : src) {
+        v = bfloat16(dist(rng));
+    }
+
+    ctx.write(buf, src);
+    ctx.finish();  // ensure write completes
+    auto dst = ctx.read<bfloat16>(buf);
+
+    ASSERT_EQ(dst.size(), src.size());
+    for (size_t i = 0; i < src.size(); ++i) {
+        EXPECT_EQ(static_cast<float>(src[i]), static_cast<float>(dst[i])) << "Mismatch at index " << i;
+    }
+}
+
+TEST_F(EzApiTest, EltwiseBinary) {
+    // Full reader/writer/compute pipeline: add two tile buffers.
+    DeviceContext ctx(0);
+    constexpr uint32_t n_tiles = 16;
+    constexpr uint32_t elements = n_tiles * tt::constants::TILE_WIDTH * tt::constants::TILE_HEIGHT;
+
+    auto src0 = ctx.dram_tile_buffer(n_tiles);
+    auto src1 = ctx.dram_tile_buffer(n_tiles);
+    auto dst = ctx.dram_tile_buffer(n_tiles);
+
+    std::mt19937 rng(123);
+    std::uniform_real_distribution<float> dist(0.0f, 1.0f);
+    std::vector<bfloat16> a_data(elements), b_data(elements);
+    for (size_t i = 0; i < elements; ++i) {
+        a_data[i] = bfloat16(dist(rng));
+        b_data[i] = bfloat16(dist(rng));
+    }
+
+    ctx.write(src0, a_data);
+    ctx.write(src1, b_data);
+
+    constexpr CoreCoord core = {0, 0};
+    auto program = ProgramBuilder(core)
+                       .cb(tt::CBIndex::c_0)
+                       .cb(tt::CBIndex::c_1)
+                       .cb(tt::CBIndex::c_16)
+                       .reader(
+                           "tests/tt_metal/tt_metal/ez/kernels/read_tiles.cpp",
+                           {src0, src1})
+                       .runtime_args({src0->address(), src1->address(), n_tiles})
+                       .done()
+                       .compute("tests/tt_metal/tt_metal/ez/kernels/tiles_add.cpp")
+                       .runtime_args({n_tiles})
+                       .done()
+                       .writer(
+                           "tests/tt_metal/tt_metal/ez/kernels/write_tile.cpp",
+                           {dst})
+                       .runtime_args({dst->address(), n_tiles})
+                       .done()
+                       .build();
+
+    ctx.run(std::move(program));
+    auto result = ctx.read<bfloat16>(dst);
+
+    ASSERT_EQ(result.size(), elements);
+    constexpr float eps = 1e-2f;
+    for (size_t i = 0; i < elements; ++i) {
+        float expected = static_cast<float>(a_data[i]) + static_cast<float>(b_data[i]);
+        float actual = static_cast<float>(result[i]);
+        EXPECT_NEAR(expected, actual, eps) << "Mismatch at index " << i;
+    }
+}
+
+TEST_F(EzApiTest, MultiCore) {
+    // ProgramBuilder with CoreRange and per-core runtime args.
+    DeviceContext ctx(0);
+    CoreRange cores({0, 0}, {1, 0});
+
+    auto builder = ProgramBuilder(cores);
+    auto& k = builder.compute("tests/tt_metal/tt_metal/ez/kernels/void_compute.cpp");
+    k.runtime_args_at(CoreCoord{0, 0}, {});
+    k.runtime_args_at(CoreCoord{1, 0}, {});
+    k.done();
+
+    auto program = builder.build();
+    ctx.run(std::move(program));
+}
+
+TEST_F(EzApiTest, PerCoreLambdaArgs) {
+    // Verify lambda-based runtime_args iterates over all cores in a CoreRange.
+    DeviceContext ctx(0);
+    CoreRange cores({0, 0}, {1, 0});
+
+    auto builder = ProgramBuilder(cores);
+    builder.compute("tests/tt_metal/tt_metal/ez/kernels/void_compute.cpp")
+        .runtime_args([](const CoreCoord& core) -> std::vector<uint32_t> {
+            // Each core gets a unique arg based on its x coordinate.
+            return {core.x};
+        })
+        .done();
+
+    auto program = builder.build();
+    ctx.run(std::move(program));
+}
+
+TEST_F(EzApiTest, CoreOverride) {
+    // Use .on() to place a kernel on a different core than the default.
+    DeviceContext ctx(0);
+    constexpr CoreCoord default_core = {0, 0};
+    constexpr CoreCoord other_core = {1, 0};
+
+    auto program = ProgramBuilder(default_core)
+                       .compute("tests/tt_metal/tt_metal/ez/kernels/void_compute.cpp")
+                       .done()
+                       .on(other_core)
+                       .compute("tests/tt_metal/tt_metal/ez/kernels/void_compute.cpp")
+                       .done()
+                       .build();
+
+    ctx.run(std::move(program));
+}
+
+TEST_F(EzApiTest, ShardedL1Buffer) {
+    // Verify sharded_l1_buffer creates a valid L1 sharded buffer.
+    DeviceContext ctx(0);
+    constexpr uint32_t n_tiles_x = 1;
+    constexpr uint32_t n_tiles_y = 2;
+    CoreRangeSet cores(CoreRange({0, 0}, {0, 1}));
+
+    ShardConfig config{
+        .cores = cores,
+        .shard_shape = {tt::constants::TILE_HEIGHT, n_tiles_x * tt::constants::TILE_WIDTH},
+        .tensor2d_shape_in_pages = {n_tiles_y, n_tiles_x},
+        .layout = TensorMemoryLayout::HEIGHT_SHARDED,
+    };
+    auto buf = ctx.sharded_l1_buffer(config);
+    ASSERT_NE(buf, nullptr);
+    EXPECT_GT(buf->address(), 0u);
+}
+
+TEST_F(EzApiTest, L1BackedCircularBuffer) {
+    // Verify cb() overload that backs a CB with an existing L1 buffer.
+    DeviceContext ctx(0);
+    constexpr uint32_t n_tiles = 4;
+    auto ts = tt::tile_size(tt::DataFormat::Float16_b);
+    auto l1_buf = ctx.l1_buffer(n_tiles * ts, ts);
+
+    auto program = ProgramBuilder(CoreCoord{0, 0})
+                       .cb(tt::CBIndex::c_0, l1_buf)
+                       .compute("tests/tt_metal/tt_metal/ez/kernels/void_compute.cpp")
+                       .done()
+                       .build();
+    ctx.run(std::move(program));
+}
+
+TEST_F(EzApiTest, WrapExistingDevice) {
+    // DeviceContext wrapping an existing MeshDevice does NOT close it on destruction.
+    auto mesh_device = distributed::MeshDevice::create_unit_mesh(0);
+    {
+        DeviceContext ctx(mesh_device);
+        // Use the context briefly.
+        auto buf = ctx.dram_tile_buffer(1);
+        // ctx goes out of scope here — should NOT close mesh_device.
+    }
+    // Device should still be usable.
+    auto& cq = mesh_device->mesh_command_queue();
+    distributed::Finish(cq);
+    mesh_device->close();
+}
+
+TEST_F(EzApiTest, Semaphore) {
+    // Verify semaphore creation and use via ProgramBuilder.
+    DeviceContext ctx(0);
+    CoreRange cores({0, 0}, {0, 1});
+
+    auto builder = ProgramBuilder(cores);
+    uint32_t sem_addr = builder.semaphore(0);
+
+    builder.compute("tests/tt_metal/tt_metal/ez/kernels/void_compute.cpp")
+        .runtime_args([&](const CoreCoord&) -> std::vector<uint32_t> { return {sem_addr}; })
+        .done();
+    auto program = builder.build();
+    ctx.run(std::move(program));
+}
+
+TEST_F(EzApiTest, PhysicalCore) {
+    // Verify physical_core returns a valid physical coordinate.
+    DeviceContext ctx(0);
+    CoreCoord logical = {0, 0};
+    CoreCoord physical = ctx.physical_core(logical);
+    // Physical coords should be valid (non-negative) — exact values are device-dependent.
+    EXPECT_GE(physical.x, 0u);
+    EXPECT_GE(physical.y, 0u);
+}
+
+TEST_F(EzApiTest, NonBlockingLaunchAndFinish) {
+    // Verify launch() + finish() works as an alternative to run().
+    DeviceContext ctx(0);
+    auto program = ProgramBuilder(CoreCoord{0, 0})
+                       .compute("tests/tt_metal/tt_metal/ez/kernels/void_compute.cpp")
+                       .done()
+                       .build();
+    ctx.launch(std::move(program));
+    ctx.finish();
+}

--- a/tests/tt_metal/tt_metal/ez/test_ez_api.cpp
+++ b/tests/tt_metal/tt_metal/ez/test_ez_api.cpp
@@ -20,7 +20,6 @@ TEST_F(EzApiTest, HelloWorld) {
     DeviceContext ctx(0);
     auto program = ProgramBuilder(CoreCoord{0, 0})
                        .compute("tests/tt_metal/tt_metal/ez/kernels/void_compute.cpp")
-                       .done()
                        .build();
     ctx.run(std::move(program));
 }
@@ -79,15 +78,12 @@ TEST_F(EzApiTest, EltwiseBinary) {
                            "tests/tt_metal/tt_metal/ez/kernels/read_tiles.cpp",
                            {src0, src1})
                        .runtime_args({src0->address(), src1->address(), n_tiles})
-                       .done()
                        .compute("tests/tt_metal/tt_metal/ez/kernels/tiles_add.cpp")
                        .runtime_args({n_tiles})
-                       .done()
                        .writer(
                            "tests/tt_metal/tt_metal/ez/kernels/write_tile.cpp",
                            {dst})
                        .runtime_args({dst->address(), n_tiles})
-                       .done()
                        .build();
 
     ctx.run(std::move(program));
@@ -111,7 +107,6 @@ TEST_F(EzApiTest, MultiCore) {
     auto& k = builder.compute("tests/tt_metal/tt_metal/ez/kernels/void_compute.cpp");
     k.runtime_args_at(CoreCoord{0, 0}, {});
     k.runtime_args_at(CoreCoord{1, 0}, {});
-    k.done();
 
     auto program = builder.build();
     ctx.run(std::move(program));
@@ -127,8 +122,7 @@ TEST_F(EzApiTest, PerCoreLambdaArgs) {
         .runtime_args([](const CoreCoord& core) -> std::vector<uint32_t> {
             // Each core gets a unique arg based on its x coordinate.
             return {core.x};
-        })
-        .done();
+        });
 
     auto program = builder.build();
     ctx.run(std::move(program));
@@ -142,10 +136,8 @@ TEST_F(EzApiTest, CoreOverride) {
 
     auto program = ProgramBuilder(default_core)
                        .compute("tests/tt_metal/tt_metal/ez/kernels/void_compute.cpp")
-                       .done()
                        .on(other_core)
                        .compute("tests/tt_metal/tt_metal/ez/kernels/void_compute.cpp")
-                       .done()
                        .build();
 
     ctx.run(std::move(program));
@@ -179,7 +171,6 @@ TEST_F(EzApiTest, L1BackedCircularBuffer) {
     auto program = ProgramBuilder(CoreCoord{0, 0})
                        .cb(tt::CBIndex::c_0, l1_buf)
                        .compute("tests/tt_metal/tt_metal/ez/kernels/void_compute.cpp")
-                       .done()
                        .build();
     ctx.run(std::move(program));
 }
@@ -208,8 +199,7 @@ TEST_F(EzApiTest, Semaphore) {
     uint32_t sem_addr = builder.semaphore(0);
 
     builder.compute("tests/tt_metal/tt_metal/ez/kernels/void_compute.cpp")
-        .runtime_args([&](const CoreCoord&) -> std::vector<uint32_t> { return {sem_addr}; })
-        .done();
+        .runtime_args([&](const CoreCoord&) -> std::vector<uint32_t> { return {sem_addr}; });
     auto program = builder.build();
     ctx.run(std::move(program));
 }
@@ -229,8 +219,63 @@ TEST_F(EzApiTest, NonBlockingLaunchAndFinish) {
     DeviceContext ctx(0);
     auto program = ProgramBuilder(CoreCoord{0, 0})
                        .compute("tests/tt_metal/tt_metal/ez/kernels/void_compute.cpp")
-                       .done()
                        .build();
     ctx.launch(std::move(program));
     ctx.finish();
+}
+
+TEST_F(EzApiTest, PerKernelNamedArgs) {
+    // Verify that named_args() called on a KernelRef applies to that kernel only.
+    // The compute kernel reads CB indices from named compile-time args; if they
+    // were routed to the wrong kernel (or lost), compilation would fail.
+    DeviceContext ctx(0);
+    constexpr uint32_t n_tiles = 4;
+    constexpr uint32_t elements = n_tiles * tt::constants::TILE_WIDTH * tt::constants::TILE_HEIGHT;
+
+    auto src0 = ctx.dram_tile_buffer(n_tiles);
+    auto src1 = ctx.dram_tile_buffer(n_tiles);
+    auto dst = ctx.dram_tile_buffer(n_tiles);
+
+    std::mt19937 rng(999);
+    std::uniform_real_distribution<float> dist(0.0f, 1.0f);
+    std::vector<bfloat16> a_data(elements), b_data(elements);
+    for (size_t i = 0; i < elements; ++i) {
+        a_data[i] = bfloat16(dist(rng));
+        b_data[i] = bfloat16(dist(rng));
+    }
+
+    ctx.write(src0, a_data);
+    ctx.write(src1, b_data);
+
+    // named_args() is called on the KernelRef returned by .compute(), not on the builder.
+    constexpr CoreCoord core = {0, 0};
+    auto program = ProgramBuilder(core)
+                       .cb(tt::CBIndex::c_0)
+                       .cb(tt::CBIndex::c_1)
+                       .cb(tt::CBIndex::c_16)
+                       .reader(
+                           "tests/tt_metal/tt_metal/ez/kernels/read_tiles.cpp",
+                           {src0, src1})
+                       .runtime_args({src0->address(), src1->address(), n_tiles})
+                       .compute("tests/tt_metal/tt_metal/ez/kernels/tiles_add_named.cpp")
+                       .named_args({{"cb_in0", (uint32_t)tt::CBIndex::c_0},
+                                    {"cb_in1", (uint32_t)tt::CBIndex::c_1},
+                                    {"cb_out0", (uint32_t)tt::CBIndex::c_16}})
+                       .runtime_args({n_tiles})
+                       .writer(
+                           "tests/tt_metal/tt_metal/ez/kernels/write_tile.cpp",
+                           {dst})
+                       .runtime_args({dst->address(), n_tiles})
+                       .build();
+
+    ctx.run(std::move(program));
+    auto result = ctx.read<bfloat16>(dst);
+
+    ASSERT_EQ(result.size(), elements);
+    constexpr float eps = 1e-2f;
+    for (size_t i = 0; i < elements; ++i) {
+        float expected = static_cast<float>(a_data[i]) + static_cast<float>(b_data[i]);
+        float actual = static_cast<float>(result[i]);
+        EXPECT_NEAR(expected, actual, eps) << "Mismatch at index " << i;
+    }
 }

--- a/tt_metal/CMakeLists.txt
+++ b/tt_metal/CMakeLists.txt
@@ -122,6 +122,9 @@ set(TT_METAL_PUBLIC_API
     api/tt-metalium/experimental/tensor/spec/memory_config/memory_config.hpp
     api/tt-metalium/experimental/tensor/topology/distributed_tensor_configs.hpp
     api/tt-metalium/experimental/tensor/topology/tensor_topology.hpp
+    api/tt-metalium/experimental/ez/ez.hpp
+    api/tt-metalium/experimental/ez/device_context.hpp
+    api/tt-metalium/experimental/ez/program_builder.hpp
 )
 target_sources(
     tt_metal
@@ -315,6 +318,7 @@ add_subdirectory(detail)
 add_subdirectory(distributed)
 add_subdirectory(fabric)
 add_subdirectory(experimental/udm)
+add_subdirectory(experimental/ez)
 if(TT_METAL_BUILD_TESTS)
     add_subdirectory(test)
 endif()

--- a/tt_metal/api/tt-metalium/experimental/ez/device_context.hpp
+++ b/tt_metal/api/tt-metalium/experimental/ez/device_context.hpp
@@ -1,0 +1,115 @@
+// SPDX-FileCopyrightText: (c) 2026 Olof Johansson <olof@lixom.net>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <array>
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+#include <tt-metalium/buffer.hpp>
+#include <tt-metalium/buffer_types.hpp>
+#include <tt-metalium/constants.hpp>
+#include <tt-metalium/core_coord.hpp>
+#include <tt-metalium/mesh_buffer.hpp>
+#include <tt-metalium/mesh_command_queue.hpp>
+#include <tt-metalium/mesh_coord.hpp>
+#include <tt-metalium/mesh_device.hpp>
+#include <tt-metalium/program.hpp>
+#include <tt-metalium/tt_backend_api_types.hpp>
+
+namespace tt::tt_metal::experimental::ez {
+
+// Configuration for creating a sharded L1 buffer.
+struct ShardConfig {
+    CoreRangeSet cores;
+    std::array<uint32_t, 2> shard_shape;  // {height, width} in elements
+    std::array<uint32_t, 2> tensor2d_shape_in_pages;  // full tensor shape in tiles {n_tiles_y, n_tiles_x}
+    TensorMemoryLayout layout = TensorMemoryLayout::HEIGHT_SHARDED;
+    ShardOrientation orientation = ShardOrientation::ROW_MAJOR;
+    std::array<uint32_t, 2> page_shape = {tt::constants::TILE_HEIGHT, tt::constants::TILE_WIDTH};
+    tt::DataFormat fmt = tt::DataFormat::Float16_b;
+};
+
+// RAII wrapper around MeshDevice that simplifies common device operations.
+// Provides one-line buffer creation, data transfer, and program execution.
+class DeviceContext {
+public:
+    // Create a single-device context on the given device ID.
+    explicit DeviceContext(int device_id = 0);
+
+    // Create a multi-device mesh context.
+    DeviceContext(size_t rows, size_t cols);
+
+    // Wrap an existing MeshDevice without taking ownership (device is NOT closed on destruction).
+    explicit DeviceContext(std::shared_ptr<distributed::MeshDevice> device);
+
+    ~DeviceContext();
+
+    DeviceContext(DeviceContext&& other) noexcept;
+    DeviceContext& operator=(DeviceContext&& other) noexcept;
+
+    DeviceContext(const DeviceContext&) = delete;
+    DeviceContext& operator=(const DeviceContext&) = delete;
+
+    // Buffer creation helpers.
+    std::shared_ptr<distributed::MeshBuffer> dram_buffer(DeviceAddr size, DeviceAddr page_size) const;
+    std::shared_ptr<distributed::MeshBuffer> l1_buffer(DeviceAddr size, DeviceAddr page_size) const;
+    std::shared_ptr<distributed::MeshBuffer> dram_tile_buffer(
+        uint32_t n_tiles, tt::DataFormat fmt = tt::DataFormat::Float16_b) const;
+    std::shared_ptr<distributed::MeshBuffer> sharded_l1_buffer(const ShardConfig& config) const;
+
+    // Data transfer: write host data to a mesh buffer.
+    template <typename T>
+    void write(const std::shared_ptr<distributed::MeshBuffer>& buf, const std::vector<T>& data, bool blocking = false);
+
+    // Data transfer: read mesh buffer contents back to host.
+    template <typename T>
+    std::vector<T> read(const std::shared_ptr<distributed::MeshBuffer>& buf, bool blocking = true);
+
+    // Execute a program synchronously (enqueue + finish).
+    void run(Program&& program);
+
+    // Enqueue a program without waiting for completion.
+    void launch(Program&& program);
+
+    // Block until all enqueued work completes.
+    void finish();
+
+    // Convert a logical core coordinate to a physical NoC coordinate.
+    CoreCoord physical_core(const CoreCoord& logical) const;
+
+    // Escape hatches to the underlying API.
+    distributed::MeshDevice& device();
+    const distributed::MeshDevice& device() const;
+    distributed::MeshCommandQueue& cq();
+    const distributed::MeshCommandQueue& cq() const;
+    distributed::MeshCoordinateRange full_range() const;
+
+private:
+    std::shared_ptr<distributed::MeshDevice> mesh_device_;
+    bool owns_device_ = true;
+};
+
+// Template implementations.
+template <typename T>
+void DeviceContext::write(
+    const std::shared_ptr<distributed::MeshBuffer>& buf, const std::vector<T>& data, bool blocking) {
+    cq().enqueue_write_mesh_buffer(buf, data.data(), blocking);
+}
+
+template <typename T>
+std::vector<T> DeviceContext::read(const std::shared_ptr<distributed::MeshBuffer>& buf, bool blocking) {
+    std::vector<T> result;
+    if (buf->global_layout() == distributed::MeshBufferLayout::SHARDED) {
+        result.resize(buf->global_shard_spec().global_size / sizeof(T));
+    } else {
+        result.resize(buf->size() / sizeof(T));
+    }
+    cq().enqueue_read_mesh_buffer(result.data(), buf, blocking);
+    return result;
+}
+
+}  // namespace tt::tt_metal::experimental::ez

--- a/tt_metal/api/tt-metalium/experimental/ez/ez.hpp
+++ b/tt_metal/api/tt-metalium/experimental/ez/ez.hpp
@@ -1,0 +1,8 @@
+// SPDX-FileCopyrightText: (c) 2026 Olof Johansson <olof@lixom.net>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <tt-metalium/experimental/ez/device_context.hpp>
+#include <tt-metalium/experimental/ez/program_builder.hpp>

--- a/tt_metal/api/tt-metalium/experimental/ez/program_builder.hpp
+++ b/tt_metal/api/tt-metalium/experimental/ez/program_builder.hpp
@@ -1,0 +1,159 @@
+// SPDX-FileCopyrightText: (c) 2026 Olof Johansson <olof@lixom.net>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+#include <functional>
+#include <map>
+#include <memory>
+#include <optional>
+#include <string>
+#include <unordered_map>
+#include <variant>
+#include <vector>
+
+#include <tt-metalium/circular_buffer_config.hpp>
+#include <tt-metalium/core_coord.hpp>
+#include <tt-metalium/kernel_types.hpp>
+#include <tt-metalium/mesh_buffer.hpp>
+#include <tt-metalium/program.hpp>
+#include <tt-metalium/tt_backend_api_types.hpp>
+
+namespace tt::tt_metal::experimental::ez {
+
+using CoreSpec = std::variant<CoreCoord, CoreRange, CoreRangeSet>;
+
+class ProgramBuilder;
+
+// Handle to a kernel added via ProgramBuilder, supporting fluent runtime_args configuration.
+class KernelRef {
+public:
+    // Set runtime args applied uniformly across all cores in the kernel's core spec.
+    KernelRef& runtime_args(std::initializer_list<uint32_t> args);
+    KernelRef& runtime_args(const std::vector<uint32_t>& args);
+
+    // Set per-core runtime args via a lambda called for each core in the kernel's core spec.
+    KernelRef& runtime_args(std::function<std::vector<uint32_t>(const CoreCoord&)> fn);
+
+    // Set runtime args for a specific core.
+    KernelRef& runtime_args_at(const CoreCoord& core, const std::vector<uint32_t>& args);
+
+    // Return to the ProgramBuilder for chaining.
+    ProgramBuilder& done();
+
+    // Access the underlying kernel handle.
+    KernelHandle handle() const;
+
+private:
+    friend class ProgramBuilder;
+    KernelRef(ProgramBuilder& builder, KernelHandle handle, CoreSpec core_spec);
+
+    ProgramBuilder& builder_;
+    KernelHandle handle_;
+    CoreSpec core_spec_;
+};
+
+// Fluent builder for constructing a Program with circular buffers and kernels.
+class ProgramBuilder {
+public:
+    explicit ProgramBuilder(const CoreSpec& core_spec);
+
+    // Non-copyable and non-movable: KernelRef objects hold references back to
+    // this builder, so moving it would leave dangling references.
+    ProgramBuilder(const ProgramBuilder&) = delete;
+    ProgramBuilder& operator=(const ProgramBuilder&) = delete;
+    ProgramBuilder(ProgramBuilder&&) = delete;
+    ProgramBuilder& operator=(ProgramBuilder&&) = delete;
+
+    // Add a circular buffer with sensible defaults (bfloat16, tile-sized pages).
+    ProgramBuilder& cb(tt::CBIndex index, uint32_t num_tiles = 2,
+                       tt::DataFormat fmt = tt::DataFormat::Float16_b);
+
+    // Add a circular buffer with explicit format, tile count, and page size.
+    ProgramBuilder& cb(tt::CBIndex index, tt::DataFormat fmt, uint32_t num_tiles, uint32_t page_size);
+
+    // Add a circular buffer backed by an existing L1 MeshBuffer (no extra allocation).
+    ProgramBuilder& cb(tt::CBIndex index, const std::shared_ptr<distributed::MeshBuffer>& l1_buffer,
+                       uint32_t num_tiles = 0, tt::DataFormat fmt = tt::DataFormat::Float16_b);
+
+    // Add a circular buffer with a raw CircularBufferConfig for advanced use cases
+    // such as shared circular buffer indices (multiple CB indices aliasing the same L1 memory).
+    ProgramBuilder& cb(const CircularBufferConfig& config);
+
+    // Add a reader data movement kernel (RISCV_1, architecture-preferred read NOC).
+    // compile_args are placed first, followed by auto-generated TensorAccessorArgs from buffers.
+    // This matches the dominant codebase convention (e.g. CB indices before accessor metadata).
+    //
+    // Note: buffers must use interleaved layout. Sharded buffers require runtime args
+    // (via SetCommonRuntimeArgs) which this API does not support. For sharded buffers,
+    // use the lower-level CreateKernel/SetRuntimeArgs APIs directly.
+    KernelRef& reader(
+        const std::string& path,
+        const std::vector<std::shared_ptr<distributed::MeshBuffer>>& buffers = {},
+        const std::vector<uint32_t>& compile_args = {});
+
+    // Add a writer data movement kernel (RISCV_0, architecture-preferred write NOC).
+    // compile_args are placed first, followed by auto-generated TensorAccessorArgs from buffers.
+    //
+    // Note: buffers must use interleaved layout. Sharded buffers require runtime args
+    // (via SetCommonRuntimeArgs) which this API does not support. For sharded buffers,
+    // use the lower-level CreateKernel/SetRuntimeArgs APIs directly.
+    KernelRef& writer(
+        const std::string& path,
+        const std::vector<std::shared_ptr<distributed::MeshBuffer>>& buffers = {},
+        const std::vector<uint32_t>& compile_args = {});
+
+    // Add a compute kernel with the given math fidelity.
+    KernelRef& compute(
+        const std::string& path,
+        MathFidelity fidelity = MathFidelity::HiFi4,
+        const std::vector<uint32_t>& compile_args = {});
+
+    // Add a compute kernel with a full ComputeConfig.
+    KernelRef& compute(const std::string& path, const ComputeConfig& config);
+
+    // Add a kernel with an arbitrary config (full control).
+    KernelRef& kernel(
+        const std::string& path,
+        const std::variant<DataMovementConfig, ComputeConfig, EthernetConfig>& config);
+
+    // Override core spec for the next kernel or CB operation only.
+    ProgramBuilder& on(const CoreSpec& core_spec);
+
+    // Set preprocessor defines for the next kernel only (consumed by the next
+    // reader/writer/compute call, similar to how on() works for core spec).
+    // Each define produces a #define in the kernel's generated header file.
+    ProgramBuilder& defines(const std::map<std::string, std::string>& defs);
+
+    // Set named compile-time args for the next kernel only (consumed by the next
+    // reader/writer/compute call, similar to how on() works for core spec).
+    // Named args let device kernels access compile-time values by string name
+    // via get_named_compile_time_arg_val("name") instead of by positional index.
+    ProgramBuilder& named_args(const std::unordered_map<std::string, uint32_t>& args);
+
+    // Create a semaphore on the given cores (or default core spec) and return its address.
+    uint32_t semaphore(uint32_t initial_value = 0);
+    uint32_t semaphore(const CoreSpec& cores, uint32_t initial_value = 0);
+
+    // Finalize and return the built Program. Can only be called once.
+    Program build();
+
+private:
+    friend class KernelRef;
+
+    Program program_;
+    CoreSpec default_core_spec_;
+    std::optional<CoreSpec> override_core_spec_;
+    std::optional<std::map<std::string, std::string>> override_defines_;
+    std::optional<std::unordered_map<std::string, uint32_t>> override_named_compile_args_;
+    std::vector<std::unique_ptr<KernelRef>> kernel_refs_;
+    bool built_ = false;
+
+    CoreSpec active_core_spec();
+    std::map<std::string, std::string> active_defines();
+    std::unordered_map<std::string, uint32_t> active_named_compile_args();
+};
+
+}  // namespace tt::tt_metal::experimental::ez

--- a/tt_metal/api/tt-metalium/experimental/ez/program_builder.hpp
+++ b/tt_metal/api/tt-metalium/experimental/ez/program_builder.hpp
@@ -27,9 +27,23 @@ using CoreSpec = std::variant<CoreCoord, CoreRange, CoreRangeSet>;
 
 class ProgramBuilder;
 
-// Handle to a kernel added via ProgramBuilder, supporting fluent runtime_args configuration.
+// Deferred kernel descriptor added via ProgramBuilder. Stores all configuration
+// and defers CreateKernel + SetRuntimeArgs to build() time.
+// Supports fluent chaining: methods for kernel configuration (defines, named_args,
+// runtime_args) return KernelRef&, while builder methods (cb, reader, writer,
+// compute, kernel, on, semaphore, build) forward to the parent ProgramBuilder.
 class KernelRef {
 public:
+    enum class Type { Reader, Writer, Compute, Custom };
+
+    // Kernel configuration methods (return KernelRef& for chaining).
+
+    // Set preprocessor defines for this kernel.
+    KernelRef& defines(const std::map<std::string, std::string>& defs);
+
+    // Set named compile-time args for this kernel.
+    KernelRef& named_args(const std::unordered_map<std::string, uint32_t>& args);
+
     // Set runtime args applied uniformly across all cores in the kernel's core spec.
     KernelRef& runtime_args(std::initializer_list<uint32_t> args);
     KernelRef& runtime_args(const std::vector<uint32_t>& args);
@@ -40,19 +54,70 @@ public:
     // Set runtime args for a specific core.
     KernelRef& runtime_args_at(const CoreCoord& core, const std::vector<uint32_t>& args);
 
-    // Return to the ProgramBuilder for chaining.
-    ProgramBuilder& done();
+    // Forwarding methods to ProgramBuilder (return appropriate type for chaining).
 
-    // Access the underlying kernel handle.
-    KernelHandle handle() const;
+    ProgramBuilder& cb(tt::CBIndex index, uint32_t num_tiles = 2,
+                       tt::DataFormat fmt = tt::DataFormat::Float16_b);
+    ProgramBuilder& cb(tt::CBIndex index, tt::DataFormat fmt, uint32_t num_tiles, uint32_t page_size);
+    ProgramBuilder& cb(tt::CBIndex index, const std::shared_ptr<distributed::MeshBuffer>& l1_buffer,
+                       uint32_t num_tiles = 0, tt::DataFormat fmt = tt::DataFormat::Float16_b);
+    ProgramBuilder& cb(const CircularBufferConfig& config);
+
+    KernelRef& reader(
+        const std::string& path,
+        const std::vector<std::shared_ptr<distributed::MeshBuffer>>& buffers = {},
+        const std::vector<uint32_t>& compile_args = {});
+    KernelRef& writer(
+        const std::string& path,
+        const std::vector<std::shared_ptr<distributed::MeshBuffer>>& buffers = {},
+        const std::vector<uint32_t>& compile_args = {});
+    KernelRef& compute(
+        const std::string& path,
+        MathFidelity fidelity = MathFidelity::HiFi4,
+        const std::vector<uint32_t>& compile_args = {});
+    KernelRef& compute(const std::string& path, const ComputeConfig& config);
+    KernelRef& kernel(
+        const std::string& path,
+        const std::variant<DataMovementConfig, ComputeConfig, EthernetConfig>& config);
+
+    ProgramBuilder& on(const CoreSpec& core_spec);
+    ProgramBuilder& defines_next(const std::map<std::string, std::string>& defs);
+    ProgramBuilder& named_args_next(const std::unordered_map<std::string, uint32_t>& args);
+    uint32_t semaphore(uint32_t initial_value = 0);
+    uint32_t semaphore(const CoreSpec& cores, uint32_t initial_value = 0);
+    Program build();
 
 private:
     friend class ProgramBuilder;
-    KernelRef(ProgramBuilder& builder, KernelHandle handle, CoreSpec core_spec);
+
+    using DeferredRuntimeArgs = std::function<void(Program&, KernelHandle, const CoreSpec&)>;
+
+    KernelRef(ProgramBuilder& builder, Type type, std::string path, CoreSpec core_spec);
 
     ProgramBuilder& builder_;
-    KernelHandle handle_;
+    Type type_;
+    std::string path_;
     CoreSpec core_spec_;
+
+    // Reader/Writer specific.
+    std::vector<std::shared_ptr<distributed::MeshBuffer>> buffers_;
+    std::vector<uint32_t> compile_args_;
+
+    // Compute specific.
+    MathFidelity fidelity_ = MathFidelity::HiFi4;
+
+    // Custom kernel config (for kernel() with full config).
+    std::optional<std::variant<DataMovementConfig, ComputeConfig, EthernetConfig>> custom_config_;
+
+    // Shared.
+    std::map<std::string, std::string> defines_;
+    std::unordered_map<std::string, uint32_t> named_compile_args_;
+
+    // Deferred runtime args — replayed at build() time.
+    std::vector<DeferredRuntimeArgs> deferred_runtime_args_;
+
+    // Materialize this kernel into the program. Called by ProgramBuilder::build().
+    void materialize(Program& program);
 };
 
 // Fluent builder for constructing a Program with circular buffers and kernels.

--- a/tt_metal/experimental/ez/CMakeLists.txt
+++ b/tt_metal/experimental/ez/CMakeLists.txt
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: (c) 2026 Olof Johansson <olof@lixom.net>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set(EZ_SRCS
+    ${CMAKE_CURRENT_SOURCE_DIR}/device_context.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/program_builder.cpp
+)
+
+add_library(tt_metal_ez STATIC ${EZ_SRCS})
+
+target_include_directories(tt_metal_ez PRIVATE ${PROJECT_SOURCE_DIR})
+
+target_link_libraries(
+    tt_metal_ez
+    PUBLIC
+        metal_common_libs
+        tt_metal
+)

--- a/tt_metal/experimental/ez/device_context.cpp
+++ b/tt_metal/experimental/ez/device_context.cpp
@@ -1,0 +1,120 @@
+// SPDX-FileCopyrightText: (c) 2026 Olof Johansson <olof@lixom.net>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <tt-metalium/experimental/ez/device_context.hpp>
+
+#include <tt-metalium/distributed.hpp>
+#include <tt-metalium/mesh_config.hpp>
+#include <tt-metalium/mesh_workload.hpp>
+
+namespace tt::tt_metal::experimental::ez {
+
+DeviceContext::DeviceContext(int device_id) :
+    mesh_device_(distributed::MeshDevice::create_unit_mesh(device_id)), owns_device_(true) {}
+
+DeviceContext::DeviceContext(size_t rows, size_t cols) :
+    mesh_device_(distributed::MeshDevice::create(
+        distributed::MeshDeviceConfig(distributed::MeshShape(rows, cols)))),
+    owns_device_(true) {}
+
+DeviceContext::DeviceContext(std::shared_ptr<distributed::MeshDevice> device) :
+    mesh_device_(std::move(device)), owns_device_(false) {}
+
+DeviceContext::~DeviceContext() {
+    if (owns_device_ && mesh_device_) {
+        try {
+            mesh_device_->close();
+        } catch (...) {
+        }
+    }
+}
+
+DeviceContext::DeviceContext(DeviceContext&& other) noexcept :
+    mesh_device_(std::move(other.mesh_device_)), owns_device_(other.owns_device_) {
+    other.owns_device_ = false;
+}
+
+DeviceContext& DeviceContext::operator=(DeviceContext&& other) noexcept {
+    if (this != &other) {
+        if (owns_device_ && mesh_device_) {
+            mesh_device_->close();
+        }
+        mesh_device_ = std::move(other.mesh_device_);
+        owns_device_ = other.owns_device_;
+        other.owns_device_ = false;
+    }
+    return *this;
+}
+
+std::shared_ptr<distributed::MeshBuffer> DeviceContext::dram_buffer(
+    DeviceAddr size, DeviceAddr page_size) const {
+    distributed::DeviceLocalBufferConfig local_config{
+        .page_size = page_size, .buffer_type = BufferType::DRAM};
+    distributed::ReplicatedBufferConfig replicated_config{.size = size};
+    return distributed::MeshBuffer::create(replicated_config, local_config, mesh_device_.get());
+}
+
+std::shared_ptr<distributed::MeshBuffer> DeviceContext::l1_buffer(
+    DeviceAddr size, DeviceAddr page_size) const {
+    distributed::DeviceLocalBufferConfig local_config{
+        .page_size = page_size, .buffer_type = BufferType::L1};
+    distributed::ReplicatedBufferConfig replicated_config{.size = size};
+    return distributed::MeshBuffer::create(replicated_config, local_config, mesh_device_.get());
+}
+
+std::shared_ptr<distributed::MeshBuffer> DeviceContext::sharded_l1_buffer(const ShardConfig& config) const {
+    auto ts = tt::tile_size(config.fmt);
+    auto total_pages =
+        static_cast<DeviceAddr>(config.tensor2d_shape_in_pages[0]) * config.tensor2d_shape_in_pages[1];
+    auto total_size = total_pages * ts;
+
+    ShardSpecBuffer shard_spec(
+        config.cores, config.shard_shape, config.orientation, config.page_shape, config.tensor2d_shape_in_pages);
+    BufferShardingArgs sharding_args(shard_spec, config.layout);
+
+    distributed::DeviceLocalBufferConfig local_config{
+        .page_size = ts,
+        .buffer_type = BufferType::L1,
+        .sharding_args = sharding_args,
+    };
+    distributed::ReplicatedBufferConfig replicated_config{.size = total_size};
+    return distributed::MeshBuffer::create(replicated_config, local_config, mesh_device_.get());
+}
+
+std::shared_ptr<distributed::MeshBuffer> DeviceContext::dram_tile_buffer(
+    uint32_t n_tiles, tt::DataFormat fmt) const {
+    auto ts = tt::tile_size(fmt);
+    return dram_buffer(n_tiles * ts, ts);
+}
+
+void DeviceContext::run(Program&& program) {
+    launch(std::move(program));
+    finish();
+}
+
+void DeviceContext::launch(Program&& program) {
+    distributed::MeshWorkload workload;
+    workload.add_program(full_range(), std::move(program));
+    distributed::EnqueueMeshWorkload(cq(), workload, false);
+}
+
+void DeviceContext::finish() { distributed::Finish(cq()); }
+
+CoreCoord DeviceContext::physical_core(const CoreCoord& logical) const {
+    return mesh_device_->worker_core_from_logical_core(logical);
+}
+
+distributed::MeshDevice& DeviceContext::device() { return *mesh_device_; }
+
+const distributed::MeshDevice& DeviceContext::device() const { return *mesh_device_; }
+
+distributed::MeshCommandQueue& DeviceContext::cq() { return mesh_device_->mesh_command_queue(); }
+
+const distributed::MeshCommandQueue& DeviceContext::cq() const { return mesh_device_->mesh_command_queue(); }
+
+distributed::MeshCoordinateRange DeviceContext::full_range() const {
+    return distributed::MeshCoordinateRange(mesh_device_->shape());
+}
+
+}  // namespace tt::tt_metal::experimental::ez

--- a/tt_metal/experimental/ez/program_builder.cpp
+++ b/tt_metal/experimental/ez/program_builder.cpp
@@ -32,62 +32,214 @@ std::variant<CoreRange, CoreRangeSet> to_semaphore_core_spec(const CoreSpec& cs)
 
 // --- KernelRef ---
 
-KernelRef::KernelRef(ProgramBuilder& builder, KernelHandle handle, CoreSpec core_spec) :
-    builder_(builder), handle_(handle), core_spec_(std::move(core_spec)) {}
+KernelRef::KernelRef(ProgramBuilder& builder, Type type, std::string path, CoreSpec core_spec) :
+    builder_(builder), type_(type), path_(std::move(path)), core_spec_(std::move(core_spec)) {}
+
+KernelRef& KernelRef::defines(const std::map<std::string, std::string>& defs) {
+    for (const auto& [k, v] : defs) {
+        defines_[k] = v;
+    }
+    return *this;
+}
+
+KernelRef& KernelRef::named_args(const std::unordered_map<std::string, uint32_t>& args) {
+    for (const auto& [k, v] : args) {
+        named_compile_args_[k] = v;
+    }
+    return *this;
+}
 
 KernelRef& KernelRef::runtime_args(std::initializer_list<uint32_t> args) {
-    SetRuntimeArgs(builder_.program_, handle_, core_spec_, args);
+    auto captured = std::vector<uint32_t>(args);
+    deferred_runtime_args_.emplace_back(
+        [captured](Program& program, KernelHandle handle, const CoreSpec& cs) {
+            SetRuntimeArgs(program, handle, cs, captured);
+        });
     return *this;
 }
 
 KernelRef& KernelRef::runtime_args(const std::vector<uint32_t>& args) {
-    SetRuntimeArgs(builder_.program_, handle_, core_spec_, tt::stl::Span<const uint32_t>(args));
+    deferred_runtime_args_.emplace_back(
+        [args](Program& program, KernelHandle handle, const CoreSpec& cs) {
+            SetRuntimeArgs(program, handle, cs, tt::stl::Span<const uint32_t>(args));
+        });
     return *this;
 }
 
 KernelRef& KernelRef::runtime_args(std::function<std::vector<uint32_t>(const CoreCoord&)> fn) {
-    auto set_for_core = [&](const CoreCoord& core) {
-        auto args = fn(core);
-        SetRuntimeArgs(
-            builder_.program_,
-            handle_,
-            std::variant<CoreCoord, CoreRange, CoreRangeSet>(core),
-            tt::stl::Span<const uint32_t>(args));
-    };
+    deferred_runtime_args_.emplace_back(
+        [fn = std::move(fn)](Program& program, KernelHandle handle, const CoreSpec& cs) {
+            auto set_for_core = [&](const CoreCoord& core) {
+                auto args = fn(core);
+                SetRuntimeArgs(
+                    program,
+                    handle,
+                    std::variant<CoreCoord, CoreRange, CoreRangeSet>(core),
+                    tt::stl::Span<const uint32_t>(args));
+            };
 
-    std::visit(
-        [&](auto&& cs) {
-            using T = std::decay_t<decltype(cs)>;
-            if constexpr (std::is_same_v<T, CoreCoord>) {
-                set_for_core(cs);
-            } else if constexpr (std::is_same_v<T, CoreRange>) {
-                for (const auto& core : cs) {
-                    set_for_core(core);
-                }
-            } else if constexpr (std::is_same_v<T, CoreRangeSet>) {
-                for (const auto& range : cs.ranges()) {
-                    for (const auto& core : range) {
-                        set_for_core(core);
+            std::visit(
+                [&](auto&& v) {
+                    using T = std::decay_t<decltype(v)>;
+                    if constexpr (std::is_same_v<T, CoreCoord>) {
+                        set_for_core(v);
+                    } else if constexpr (std::is_same_v<T, CoreRange>) {
+                        for (const auto& core : v) {
+                            set_for_core(core);
+                        }
+                    } else if constexpr (std::is_same_v<T, CoreRangeSet>) {
+                        for (const auto& range : v.ranges()) {
+                            for (const auto& core : range) {
+                                set_for_core(core);
+                            }
+                        }
                     }
-                }
-            }
-        },
-        core_spec_);
+                },
+                cs);
+        });
     return *this;
 }
 
 KernelRef& KernelRef::runtime_args_at(const CoreCoord& core, const std::vector<uint32_t>& args) {
-    SetRuntimeArgs(
-        builder_.program_,
-        handle_,
-        std::variant<CoreCoord, CoreRange, CoreRangeSet>(core),
-        tt::stl::Span<const uint32_t>(args));
+    deferred_runtime_args_.emplace_back(
+        [core, args](Program& program, KernelHandle handle, const CoreSpec&) {
+            SetRuntimeArgs(
+                program,
+                handle,
+                std::variant<CoreCoord, CoreRange, CoreRangeSet>(core),
+                tt::stl::Span<const uint32_t>(args));
+        });
     return *this;
 }
 
-ProgramBuilder& KernelRef::done() { return builder_; }
+// Forwarding methods to ProgramBuilder.
 
-KernelHandle KernelRef::handle() const { return handle_; }
+ProgramBuilder& KernelRef::cb(tt::CBIndex index, uint32_t num_tiles, tt::DataFormat fmt) {
+    return builder_.cb(index, num_tiles, fmt);
+}
+
+ProgramBuilder& KernelRef::cb(tt::CBIndex index, tt::DataFormat fmt, uint32_t num_tiles, uint32_t page_size) {
+    return builder_.cb(index, fmt, num_tiles, page_size);
+}
+
+ProgramBuilder& KernelRef::cb(
+    tt::CBIndex index,
+    const std::shared_ptr<distributed::MeshBuffer>& l1_buffer,
+    uint32_t num_tiles,
+    tt::DataFormat fmt) {
+    return builder_.cb(index, l1_buffer, num_tiles, fmt);
+}
+
+ProgramBuilder& KernelRef::cb(const CircularBufferConfig& config) {
+    return builder_.cb(config);
+}
+
+KernelRef& KernelRef::reader(
+    const std::string& path,
+    const std::vector<std::shared_ptr<distributed::MeshBuffer>>& buffers,
+    const std::vector<uint32_t>& compile_args) {
+    return builder_.reader(path, buffers, compile_args);
+}
+
+KernelRef& KernelRef::writer(
+    const std::string& path,
+    const std::vector<std::shared_ptr<distributed::MeshBuffer>>& buffers,
+    const std::vector<uint32_t>& compile_args) {
+    return builder_.writer(path, buffers, compile_args);
+}
+
+KernelRef& KernelRef::compute(
+    const std::string& path,
+    MathFidelity fidelity,
+    const std::vector<uint32_t>& compile_args) {
+    return builder_.compute(path, fidelity, compile_args);
+}
+
+KernelRef& KernelRef::compute(const std::string& path, const ComputeConfig& config) {
+    return builder_.compute(path, config);
+}
+
+KernelRef& KernelRef::kernel(
+    const std::string& path,
+    const std::variant<DataMovementConfig, ComputeConfig, EthernetConfig>& config) {
+    return builder_.kernel(path, config);
+}
+
+ProgramBuilder& KernelRef::on(const CoreSpec& core_spec) {
+    return builder_.on(core_spec);
+}
+
+ProgramBuilder& KernelRef::defines_next(const std::map<std::string, std::string>& defs) {
+    return builder_.defines(defs);
+}
+
+ProgramBuilder& KernelRef::named_args_next(const std::unordered_map<std::string, uint32_t>& args) {
+    return builder_.named_args(args);
+}
+
+uint32_t KernelRef::semaphore(uint32_t initial_value) {
+    return builder_.semaphore(initial_value);
+}
+
+uint32_t KernelRef::semaphore(const CoreSpec& cores, uint32_t initial_value) {
+    return builder_.semaphore(cores, initial_value);
+}
+
+Program KernelRef::build() {
+    return builder_.build();
+}
+
+void KernelRef::materialize(Program& program) {
+    KernelHandle handle;
+
+    switch (type_) {
+        case Type::Reader: {
+            std::vector<uint32_t> all_args(compile_args_);
+            for (const auto& buf : buffers_) {
+                TT_FATAL(
+                    !is_sharded(buf->device_local_config().sharding_args.buffer_layout()),
+                    "reader() requires interleaved buffers; use the lower-level CreateKernel API for sharded buffers");
+                TensorAccessorArgs(*buf).append_to(all_args);
+            }
+            handle = CreateKernel(
+                program, path_, core_spec_, ReaderDataMovementConfig{all_args, defines_, named_compile_args_});
+            break;
+        }
+        case Type::Writer: {
+            std::vector<uint32_t> all_args(compile_args_);
+            for (const auto& buf : buffers_) {
+                TT_FATAL(
+                    !is_sharded(buf->device_local_config().sharding_args.buffer_layout()),
+                    "writer() requires interleaved buffers; use the lower-level CreateKernel API for sharded buffers");
+                TensorAccessorArgs(*buf).append_to(all_args);
+            }
+            handle = CreateKernel(
+                program, path_, core_spec_, WriterDataMovementConfig{all_args, defines_, named_compile_args_});
+            break;
+        }
+        case Type::Compute: {
+            handle = CreateKernel(
+                program,
+                path_,
+                core_spec_,
+                ComputeConfig{
+                    .math_fidelity = fidelity_,
+                    .compile_args = compile_args_,
+                    .defines = defines_,
+                    .named_compile_args = named_compile_args_});
+            break;
+        }
+        case Type::Custom: {
+            TT_FATAL(custom_config_.has_value(), "Custom kernel has no config");
+            handle = CreateKernel(program, path_, core_spec_, *custom_config_);
+            break;
+        }
+    }
+
+    for (const auto& action : deferred_runtime_args_) {
+        action(program, handle, core_spec_);
+    }
+}
 
 // --- ProgramBuilder ---
 
@@ -159,44 +311,36 @@ KernelRef& ProgramBuilder::reader(
     const std::string& path,
     const std::vector<std::shared_ptr<distributed::MeshBuffer>>& buffers,
     const std::vector<uint32_t>& compile_args) {
-    // compile_args first, then TensorAccessorArgs — matches the dominant codebase convention.
-    std::vector<uint32_t> all_args(compile_args);
-    for (const auto& buf : buffers) {
-        TT_FATAL(
-            !is_sharded(buf->device_local_config().sharding_args.buffer_layout()),
-            "reader() requires interleaved buffers; use the lower-level CreateKernel API for sharded buffers");
-        TensorAccessorArgs(*buf).append_to(all_args);
-    }
-
     auto cs = active_core_spec();
     auto defs = active_defines();
     auto nca = active_named_compile_args();
 
-    auto handle = CreateKernel(program_, path, cs, ReaderDataMovementConfig{all_args, defs, nca});
-    kernel_refs_.push_back(std::unique_ptr<KernelRef>(new KernelRef(*this, handle, cs)));
-    return *kernel_refs_.back();
+    kernel_refs_.push_back(
+        std::unique_ptr<KernelRef>(new KernelRef(*this, KernelRef::Type::Reader, path, cs)));
+    auto& ref = *kernel_refs_.back();
+    ref.buffers_ = buffers;
+    ref.compile_args_ = compile_args;
+    ref.defines_ = std::move(defs);
+    ref.named_compile_args_ = std::move(nca);
+    return ref;
 }
 
 KernelRef& ProgramBuilder::writer(
     const std::string& path,
     const std::vector<std::shared_ptr<distributed::MeshBuffer>>& buffers,
     const std::vector<uint32_t>& compile_args) {
-    // compile_args first, then TensorAccessorArgs — matches the dominant codebase convention.
-    std::vector<uint32_t> all_args(compile_args);
-    for (const auto& buf : buffers) {
-        TT_FATAL(
-            !is_sharded(buf->device_local_config().sharding_args.buffer_layout()),
-            "writer() requires interleaved buffers; use the lower-level CreateKernel API for sharded buffers");
-        TensorAccessorArgs(*buf).append_to(all_args);
-    }
-
     auto cs = active_core_spec();
     auto defs = active_defines();
     auto nca = active_named_compile_args();
 
-    auto handle = CreateKernel(program_, path, cs, WriterDataMovementConfig{all_args, defs, nca});
-    kernel_refs_.push_back(std::unique_ptr<KernelRef>(new KernelRef(*this, handle, cs)));
-    return *kernel_refs_.back();
+    kernel_refs_.push_back(
+        std::unique_ptr<KernelRef>(new KernelRef(*this, KernelRef::Type::Writer, path, cs)));
+    auto& ref = *kernel_refs_.back();
+    ref.buffers_ = buffers;
+    ref.compile_args_ = compile_args;
+    ref.defines_ = std::move(defs);
+    ref.named_compile_args_ = std::move(nca);
+    return ref;
 }
 
 KernelRef& ProgramBuilder::compute(
@@ -207,25 +351,24 @@ KernelRef& ProgramBuilder::compute(
     auto defs = active_defines();
     auto nca = active_named_compile_args();
 
-    auto handle = CreateKernel(
-        program_,
-        path,
-        cs,
-        ComputeConfig{
-            .math_fidelity = fidelity,
-            .compile_args = compile_args,
-            .defines = defs,
-            .named_compile_args = nca});
-    kernel_refs_.push_back(std::unique_ptr<KernelRef>(new KernelRef(*this, handle, cs)));
-    return *kernel_refs_.back();
+    kernel_refs_.push_back(
+        std::unique_ptr<KernelRef>(new KernelRef(*this, KernelRef::Type::Compute, path, cs)));
+    auto& ref = *kernel_refs_.back();
+    ref.fidelity_ = fidelity;
+    ref.compile_args_ = compile_args;
+    ref.defines_ = std::move(defs);
+    ref.named_compile_args_ = std::move(nca);
+    return ref;
 }
 
 KernelRef& ProgramBuilder::compute(const std::string& path, const ComputeConfig& config) {
     auto cs = active_core_spec();
 
-    auto handle = CreateKernel(program_, path, cs, config);
-    kernel_refs_.push_back(std::unique_ptr<KernelRef>(new KernelRef(*this, handle, cs)));
-    return *kernel_refs_.back();
+    kernel_refs_.push_back(
+        std::unique_ptr<KernelRef>(new KernelRef(*this, KernelRef::Type::Custom, path, cs)));
+    auto& ref = *kernel_refs_.back();
+    ref.custom_config_ = config;
+    return ref;
 }
 
 KernelRef& ProgramBuilder::kernel(
@@ -233,9 +376,11 @@ KernelRef& ProgramBuilder::kernel(
     const std::variant<DataMovementConfig, ComputeConfig, EthernetConfig>& config) {
     auto cs = active_core_spec();
 
-    auto handle = CreateKernel(program_, path, cs, config);
-    kernel_refs_.push_back(std::unique_ptr<KernelRef>(new KernelRef(*this, handle, cs)));
-    return *kernel_refs_.back();
+    kernel_refs_.push_back(
+        std::unique_ptr<KernelRef>(new KernelRef(*this, KernelRef::Type::Custom, path, cs)));
+    auto& ref = *kernel_refs_.back();
+    ref.custom_config_ = config;
+    return ref;
 }
 
 ProgramBuilder& ProgramBuilder::on(const CoreSpec& core_spec) {
@@ -282,6 +427,11 @@ uint32_t ProgramBuilder::semaphore(const CoreSpec& cores, uint32_t initial_value
 Program ProgramBuilder::build() {
     TT_FATAL(!built_, "ProgramBuilder::build() can only be called once");
     built_ = true;
+
+    for (auto& ref : kernel_refs_) {
+        ref->materialize(program_);
+    }
+
     return std::move(program_);
 }
 

--- a/tt_metal/experimental/ez/program_builder.cpp
+++ b/tt_metal/experimental/ez/program_builder.cpp
@@ -1,0 +1,288 @@
+// SPDX-FileCopyrightText: (c) 2026 Olof Johansson <olof@lixom.net>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <tt-metalium/experimental/ez/program_builder.hpp>
+
+#include <tt-metalium/buffer.hpp>
+#include <tt-metalium/circular_buffer_config.hpp>
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/tensor_accessor_args.hpp>
+#include <tt_stl/assert.hpp>
+
+namespace tt::tt_metal::experimental::ez {
+
+namespace {
+// Convert CoreSpec to the variant that CreateSemaphore expects.
+std::variant<CoreRange, CoreRangeSet> to_semaphore_core_spec(const CoreSpec& cs) {
+    return std::visit(
+        [](auto&& v) -> std::variant<CoreRange, CoreRangeSet> {
+            using T = std::decay_t<decltype(v)>;
+            if constexpr (std::is_same_v<T, CoreCoord>) {
+                return CoreRange(v, v);
+            } else if constexpr (std::is_same_v<T, CoreRange>) {
+                return v;
+            } else {
+                return v;
+            }
+        },
+        cs);
+}
+}  // namespace
+
+// --- KernelRef ---
+
+KernelRef::KernelRef(ProgramBuilder& builder, KernelHandle handle, CoreSpec core_spec) :
+    builder_(builder), handle_(handle), core_spec_(std::move(core_spec)) {}
+
+KernelRef& KernelRef::runtime_args(std::initializer_list<uint32_t> args) {
+    SetRuntimeArgs(builder_.program_, handle_, core_spec_, args);
+    return *this;
+}
+
+KernelRef& KernelRef::runtime_args(const std::vector<uint32_t>& args) {
+    SetRuntimeArgs(builder_.program_, handle_, core_spec_, tt::stl::Span<const uint32_t>(args));
+    return *this;
+}
+
+KernelRef& KernelRef::runtime_args(std::function<std::vector<uint32_t>(const CoreCoord&)> fn) {
+    auto set_for_core = [&](const CoreCoord& core) {
+        auto args = fn(core);
+        SetRuntimeArgs(
+            builder_.program_,
+            handle_,
+            std::variant<CoreCoord, CoreRange, CoreRangeSet>(core),
+            tt::stl::Span<const uint32_t>(args));
+    };
+
+    std::visit(
+        [&](auto&& cs) {
+            using T = std::decay_t<decltype(cs)>;
+            if constexpr (std::is_same_v<T, CoreCoord>) {
+                set_for_core(cs);
+            } else if constexpr (std::is_same_v<T, CoreRange>) {
+                for (const auto& core : cs) {
+                    set_for_core(core);
+                }
+            } else if constexpr (std::is_same_v<T, CoreRangeSet>) {
+                for (const auto& range : cs.ranges()) {
+                    for (const auto& core : range) {
+                        set_for_core(core);
+                    }
+                }
+            }
+        },
+        core_spec_);
+    return *this;
+}
+
+KernelRef& KernelRef::runtime_args_at(const CoreCoord& core, const std::vector<uint32_t>& args) {
+    SetRuntimeArgs(
+        builder_.program_,
+        handle_,
+        std::variant<CoreCoord, CoreRange, CoreRangeSet>(core),
+        tt::stl::Span<const uint32_t>(args));
+    return *this;
+}
+
+ProgramBuilder& KernelRef::done() { return builder_; }
+
+KernelHandle KernelRef::handle() const { return handle_; }
+
+// --- ProgramBuilder ---
+
+ProgramBuilder::ProgramBuilder(const CoreSpec& core_spec) :
+    program_(CreateProgram()), default_core_spec_(core_spec) {}
+
+CoreSpec ProgramBuilder::active_core_spec() {
+    if (override_core_spec_.has_value()) {
+        CoreSpec cs = std::move(*override_core_spec_);
+        override_core_spec_.reset();
+        return cs;
+    }
+    return default_core_spec_;
+}
+
+ProgramBuilder& ProgramBuilder::cb(tt::CBIndex index, uint32_t num_tiles, tt::DataFormat fmt) {
+    auto ts = tt::tile_size(fmt);
+    auto cs = active_core_spec();
+
+    CreateCircularBuffer(
+        program_,
+        cs,
+        CircularBufferConfig(num_tiles * ts, {{index, fmt}}).set_page_size(index, ts));
+    return *this;
+}
+
+ProgramBuilder& ProgramBuilder::cb(
+    tt::CBIndex index, tt::DataFormat fmt, uint32_t num_tiles, uint32_t page_size) {
+    auto cs = active_core_spec();
+
+    CreateCircularBuffer(
+        program_,
+        cs,
+        CircularBufferConfig(num_tiles * page_size, {{index, fmt}}).set_page_size(index, page_size));
+    return *this;
+}
+
+ProgramBuilder& ProgramBuilder::cb(const CircularBufferConfig& config) {
+    auto cs = active_core_spec();
+
+    CreateCircularBuffer(program_, cs, config);
+    return *this;
+}
+
+ProgramBuilder& ProgramBuilder::cb(
+    tt::CBIndex index,
+    const std::shared_ptr<distributed::MeshBuffer>& l1_buffer,
+    uint32_t num_tiles,
+    tt::DataFormat fmt) {
+    auto ts = tt::tile_size(fmt);
+    auto* backing = l1_buffer->get_backing_buffer();
+    TT_FATAL(backing != nullptr, "L1 MeshBuffer has no backing buffer (was it constructed with an explicit address?)");
+    // If num_tiles is 0, infer from the buffer size.
+    if (num_tiles == 0) {
+        num_tiles = static_cast<uint32_t>(backing->aligned_size_per_bank() / ts);
+    }
+    auto cs = active_core_spec();
+
+    CreateCircularBuffer(
+        program_,
+        cs,
+        CircularBufferConfig(num_tiles * ts, {{index, fmt}})
+            .set_page_size(index, ts)
+            .set_globally_allocated_address(*backing));
+    return *this;
+}
+
+KernelRef& ProgramBuilder::reader(
+    const std::string& path,
+    const std::vector<std::shared_ptr<distributed::MeshBuffer>>& buffers,
+    const std::vector<uint32_t>& compile_args) {
+    // compile_args first, then TensorAccessorArgs — matches the dominant codebase convention.
+    std::vector<uint32_t> all_args(compile_args);
+    for (const auto& buf : buffers) {
+        TT_FATAL(
+            !is_sharded(buf->device_local_config().sharding_args.buffer_layout()),
+            "reader() requires interleaved buffers; use the lower-level CreateKernel API for sharded buffers");
+        TensorAccessorArgs(*buf).append_to(all_args);
+    }
+
+    auto cs = active_core_spec();
+    auto defs = active_defines();
+    auto nca = active_named_compile_args();
+
+    auto handle = CreateKernel(program_, path, cs, ReaderDataMovementConfig{all_args, defs, nca});
+    kernel_refs_.push_back(std::unique_ptr<KernelRef>(new KernelRef(*this, handle, cs)));
+    return *kernel_refs_.back();
+}
+
+KernelRef& ProgramBuilder::writer(
+    const std::string& path,
+    const std::vector<std::shared_ptr<distributed::MeshBuffer>>& buffers,
+    const std::vector<uint32_t>& compile_args) {
+    // compile_args first, then TensorAccessorArgs — matches the dominant codebase convention.
+    std::vector<uint32_t> all_args(compile_args);
+    for (const auto& buf : buffers) {
+        TT_FATAL(
+            !is_sharded(buf->device_local_config().sharding_args.buffer_layout()),
+            "writer() requires interleaved buffers; use the lower-level CreateKernel API for sharded buffers");
+        TensorAccessorArgs(*buf).append_to(all_args);
+    }
+
+    auto cs = active_core_spec();
+    auto defs = active_defines();
+    auto nca = active_named_compile_args();
+
+    auto handle = CreateKernel(program_, path, cs, WriterDataMovementConfig{all_args, defs, nca});
+    kernel_refs_.push_back(std::unique_ptr<KernelRef>(new KernelRef(*this, handle, cs)));
+    return *kernel_refs_.back();
+}
+
+KernelRef& ProgramBuilder::compute(
+    const std::string& path,
+    MathFidelity fidelity,
+    const std::vector<uint32_t>& compile_args) {
+    auto cs = active_core_spec();
+    auto defs = active_defines();
+    auto nca = active_named_compile_args();
+
+    auto handle = CreateKernel(
+        program_,
+        path,
+        cs,
+        ComputeConfig{
+            .math_fidelity = fidelity,
+            .compile_args = compile_args,
+            .defines = defs,
+            .named_compile_args = nca});
+    kernel_refs_.push_back(std::unique_ptr<KernelRef>(new KernelRef(*this, handle, cs)));
+    return *kernel_refs_.back();
+}
+
+KernelRef& ProgramBuilder::compute(const std::string& path, const ComputeConfig& config) {
+    auto cs = active_core_spec();
+
+    auto handle = CreateKernel(program_, path, cs, config);
+    kernel_refs_.push_back(std::unique_ptr<KernelRef>(new KernelRef(*this, handle, cs)));
+    return *kernel_refs_.back();
+}
+
+KernelRef& ProgramBuilder::kernel(
+    const std::string& path,
+    const std::variant<DataMovementConfig, ComputeConfig, EthernetConfig>& config) {
+    auto cs = active_core_spec();
+
+    auto handle = CreateKernel(program_, path, cs, config);
+    kernel_refs_.push_back(std::unique_ptr<KernelRef>(new KernelRef(*this, handle, cs)));
+    return *kernel_refs_.back();
+}
+
+ProgramBuilder& ProgramBuilder::on(const CoreSpec& core_spec) {
+    override_core_spec_ = core_spec;
+    return *this;
+}
+
+ProgramBuilder& ProgramBuilder::defines(const std::map<std::string, std::string>& defs) {
+    override_defines_ = defs;
+    return *this;
+}
+
+ProgramBuilder& ProgramBuilder::named_args(const std::unordered_map<std::string, uint32_t>& args) {
+    override_named_compile_args_ = args;
+    return *this;
+}
+
+std::map<std::string, std::string> ProgramBuilder::active_defines() {
+    if (override_defines_.has_value()) {
+        auto defs = std::move(*override_defines_);
+        override_defines_.reset();
+        return defs;
+    }
+    return {};
+}
+
+std::unordered_map<std::string, uint32_t> ProgramBuilder::active_named_compile_args() {
+    if (override_named_compile_args_.has_value()) {
+        auto nca = std::move(*override_named_compile_args_);
+        override_named_compile_args_.reset();
+        return nca;
+    }
+    return {};
+}
+
+uint32_t ProgramBuilder::semaphore(uint32_t initial_value) {
+    return CreateSemaphore(program_, to_semaphore_core_spec(active_core_spec()), initial_value);
+}
+
+uint32_t ProgramBuilder::semaphore(const CoreSpec& cores, uint32_t initial_value) {
+    return CreateSemaphore(program_, to_semaphore_core_spec(cores), initial_value);
+}
+
+Program ProgramBuilder::build() {
+    TT_FATAL(!built_, "ProgramBuilder::build() can only be called once");
+    built_ = true;
+    return std::move(program_);
+}
+
+}  // namespace tt::tt_metal::experimental::ez

--- a/tt_metal/programming_examples/NoC_tile_transfer/CMakeLists.txt
+++ b/tt_metal/programming_examples/NoC_tile_transfer/CMakeLists.txt
@@ -7,4 +7,9 @@ target_sources(metal_example_noc_tile_transfer PRIVATE noc_tile_transfer.cpp)
 if(NOT TARGET TT::Metalium)
     find_package(TT-Metalium REQUIRED)
 endif()
-target_link_libraries(metal_example_noc_tile_transfer PUBLIC TT::Metalium)
+target_link_libraries(
+    metal_example_noc_tile_transfer
+    PUBLIC
+        TT::Metalium
+        tt_metal_ez
+)

--- a/tt_metal/programming_examples/NoC_tile_transfer/noc_tile_transfer.cpp
+++ b/tt_metal/programming_examples/NoC_tile_transfer/noc_tile_transfer.cpp
@@ -81,7 +81,6 @@ int main() {
             {src_dram_buffer},
             {src0_cb_index})
         .runtime_args({src_dram_buffer->address()})
-        .done()
 
         // Core 0: writer sends cb_0 to Core 1's cb_1 via NoC.
         .on(core0)
@@ -90,7 +89,6 @@ int main() {
             {},  // No DRAM buffer access
             {src0_cb_index, src1_cb_index})
         .runtime_args({core1_physical.x, core1_physical.y, sem_id})
-        .done()
 
         // Core 1: reader waits for data from Core 0.
         .on(core1)
@@ -99,7 +97,6 @@ int main() {
             {},  // No DRAM buffer access
             {src0_cb_index, src1_cb_index})
         .runtime_args({core0_physical.x, core0_physical.y, sem_id})
-        .done()
 
         // Core 1: writer writes cb_1 to DRAM.
         .on(core1)
@@ -107,8 +104,7 @@ int main() {
             OVERRIDE_KERNEL_PREFIX "NoC_tile_transfer/kernels/dataflow/writer1.cpp",
             {dst_dram_buffer},
             {src1_cb_index})
-        .runtime_args({dst_dram_buffer->address()})
-        .done();
+        .runtime_args({dst_dram_buffer->address()});
 
     auto program = builder.build();
 

--- a/tt_metal/programming_examples/NoC_tile_transfer/noc_tile_transfer.cpp
+++ b/tt_metal/programming_examples/NoC_tile_transfer/noc_tile_transfer.cpp
@@ -2,9 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <tt-metalium/host_api.hpp>
-#include <tt-metalium/tensor_accessor_args.hpp>
-#include <tt-metalium/distributed.hpp>
+#include <tt-metalium/experimental/ez/ez.hpp>
 
 #include <cstdint>
 #include <vector>
@@ -15,26 +13,10 @@
 
 using namespace tt;
 using namespace tt::tt_metal;
+using namespace tt::tt_metal::experimental::ez;
 
 int main() {
-    // Create a 1x1 mesh device (Mesh API). For multi-device setups, create a larger mesh shape.
-    std::shared_ptr<distributed::MeshDevice> mesh_device = distributed::MeshDevice::create_unit_mesh(0);
-
-    // Mesh command queue and program setup
-    distributed::MeshCommandQueue& cq = mesh_device->mesh_command_queue();
-    distributed::MeshWorkload workload;
-    distributed::MeshCoordinateRange device_range = distributed::MeshCoordinateRange(mesh_device->shape());
-    Program program = CreateProgram();
-
-    // Core range setup
-    constexpr CoreCoord core0 = {0, 0};
-    constexpr CoreCoord core1 = {0, 1};
-    const auto core0_physical_coord = mesh_device->worker_core_from_logical_core(core0);
-    const auto core1_physical_coord = mesh_device->worker_core_from_logical_core(core1);
-
-    CoreRange sem_core_range = CoreRange(core0, core1);
-
-    // Check if the environment variable for kernels print is set
+    // Check if the environment variable for kernel debug printing is set.
     char* env_var = std::getenv("TT_METAL_DPRINT_CORES");
     if (env_var == nullptr) {
         fmt::print(
@@ -43,82 +25,97 @@ int main() {
             "the Data Movement kernels. Command: export TT_METAL_DPRINT_CORES=(0,0),(0,1)\n");
     }
 
-    // Input data preparation
+    DeviceContext ctx(0);
+
+    // Core setup — this example uses two cores that communicate via the NoC.
+    // Core 0 reads data from DRAM, sends it to Core 1 via NoC, and Core 1 writes it back to DRAM.
+    constexpr CoreCoord core0 = {0, 0};
+    constexpr CoreCoord core1 = {0, 1};
+    const auto core0_physical = ctx.physical_core(core0);
+    const auto core1_physical = ctx.physical_core(core1);
+
+    // Input data preparation — a single tile of uint16 data.
     constexpr uint32_t single_tile_size = sizeof(uint16_t) * tt::constants::TILE_HW;
-    distributed::DeviceLocalBufferConfig dram_config{
-        .page_size = single_tile_size, .buffer_type = tt_metal::BufferType::DRAM};
-    distributed::ReplicatedBufferConfig buffer_config{.size = single_tile_size};
+    auto src_dram_buffer = ctx.dram_buffer(single_tile_size, single_tile_size);
+    auto dst_dram_buffer = ctx.dram_buffer(single_tile_size, single_tile_size);
 
-    auto src_dram_buffer =
-        distributed::MeshBuffer::create(buffer_config, dram_config, mesh_device.get());  // replicated per device
-    auto dst_dram_buffer = distributed::MeshBuffer::create(buffer_config, dram_config, mesh_device.get());
-
-    // Core synchronization semaphore setup
-    const uint32_t sem_id = CreateSemaphore(program, sem_core_range, 0);
-
-    // Source data preparation and DRAM transfer
-    const uint16_t input_data = 14;  // Example input data
+    // Upload source data to DRAM.
+    const uint16_t input_data = 14;
     std::vector<uint16_t> src_vec(1, input_data);
-    distributed::EnqueueWriteMeshBuffer(cq, src_dram_buffer, src_vec, false);
+    ctx.write(src_dram_buffer, src_vec);
 
-    // L1 circular buffer setup
+    // Build the program with kernels on two cores, coordinated by a semaphore:
+    //
+    //   Core 0:
+    //     reader0 → reads tile from DRAM into cb_0
+    //     writer0 → sends cb_0 data to Core 1's cb_1 via NoC, signals semaphore
+    //
+    //   Core 1:
+    //     reader1 → waits on semaphore, receives data into cb_1
+    //     writer1 → writes cb_1 data back to DRAM
+    //
+    // Circular buffers cb_0 and cb_1 are created on both cores (same core range).
+    // The semaphore ensures Core 1 doesn't read before Core 0 has finished writing.
+    //
+    // For kernels that access DRAM buffers (reader0, writer1), the CB index is passed as a
+    // compile-time arg before the auto-generated TensorAccessorArgs. For kernels that only do
+    // inter-core NoC transfers (writer0, reader1), only CB indices are needed (no buffers).
+    CoreRange sem_core_range = CoreRange(core0, core1);
     constexpr uint32_t src0_cb_index = CBIndex::c_0;
-    CircularBufferConfig cb_src0_config =
-        CircularBufferConfig(single_tile_size, {{src0_cb_index, tt::DataFormat::UInt16}})
-            .set_page_size(src0_cb_index, single_tile_size);
-    tt_metal::CreateCircularBuffer(program, sem_core_range, cb_src0_config);
-
     constexpr uint32_t src1_cb_index = CBIndex::c_1;
-    CircularBufferConfig cb_src1_config =
-        CircularBufferConfig(single_tile_size, {{src1_cb_index, tt::DataFormat::UInt16}})
-            .set_page_size(src1_cb_index, single_tile_size);
-    tt_metal::CreateCircularBuffer(program, sem_core_range, cb_src1_config);
 
-    // Kernels setup
-    // Core 0 kernels
-    std::vector<uint32_t> reader_compile_time_args = {src0_cb_index};
-    TensorAccessorArgs(*src_dram_buffer).append_to(reader_compile_time_args);
-    KernelHandle core0_reader_kernel_id = CreateKernel(
-        program,
-        OVERRIDE_KERNEL_PREFIX "NoC_tile_transfer/kernels/dataflow/reader0.cpp",
-        core0,
-        tt::tt_metal::ReaderDataMovementConfig{reader_compile_time_args});
-    KernelHandle core0_writer_kernel_id = CreateKernel(
-        program,
-        OVERRIDE_KERNEL_PREFIX "NoC_tile_transfer/kernels/dataflow/writer0.cpp",
-        core0,
-        tt::tt_metal::WriterDataMovementConfig{{src0_cb_index, src1_cb_index}});
+    // Build the program step by step so we can store the semaphore ID for reuse.
+    auto builder = ProgramBuilder(sem_core_range);
 
-    // Core 1 kernels
-    KernelHandle core1_reader_kernel_id = CreateKernel(
-        program,
-        OVERRIDE_KERNEL_PREFIX "NoC_tile_transfer/kernels/dataflow/reader1.cpp",
-        core1,
-        tt::tt_metal::ReaderDataMovementConfig{{src0_cb_index, src1_cb_index}});
-    std::vector<uint32_t> writer_compile_time_args = {src1_cb_index};
-    TensorAccessorArgs(*dst_dram_buffer).append_to(writer_compile_time_args);
-    KernelHandle core1_writer_kernel_id = CreateKernel(
-        program,
-        OVERRIDE_KERNEL_PREFIX "NoC_tile_transfer/kernels/dataflow/writer1.cpp",
-        core1,
-        tt::tt_metal::WriterDataMovementConfig{writer_compile_time_args});
+    // Circular buffers on both cores (same config).
+    builder.cb(tt::CBIndex::c_0, tt::DataFormat::UInt16, /*num_tiles=*/1, /*page_size=*/single_tile_size)
+        .cb(tt::CBIndex::c_1, tt::DataFormat::UInt16, /*num_tiles=*/1, /*page_size=*/single_tile_size);
 
-    // Runtime args setup
-    SetRuntimeArgs(program, core0_reader_kernel_id, core0, {src_dram_buffer->address()});
-    SetRuntimeArgs(program, core0_writer_kernel_id, core0, {core1_physical_coord.x, core1_physical_coord.y, sem_id});
-    SetRuntimeArgs(program, core1_reader_kernel_id, core1, {core0_physical_coord.x, core0_physical_coord.y, sem_id});
-    SetRuntimeArgs(program, core1_writer_kernel_id, core1, {dst_dram_buffer->address()});
+    // Create a single semaphore on both cores for synchronization.
+    const uint32_t sem_id = builder.semaphore();
 
-    // Program enqueue (non-blocking). Wait for completion before reading back.
-    workload.add_program(device_range, std::move(program));
-    distributed::EnqueueMeshWorkload(cq, workload, false);
-    distributed::Finish(cq);
+    // Core 0: reader reads from DRAM into cb_0.
+    builder.on(core0)
+        .reader(
+            OVERRIDE_KERNEL_PREFIX "NoC_tile_transfer/kernels/dataflow/reader0.cpp",
+            {src_dram_buffer},
+            {src0_cb_index})
+        .runtime_args({src_dram_buffer->address()})
+        .done()
 
-    // Data transfer back to host machine
-    std::vector<uint16_t> result_vec;
-    distributed::EnqueueReadMeshBuffer(cq, result_vec, dst_dram_buffer, true);
+        // Core 0: writer sends cb_0 to Core 1's cb_1 via NoC.
+        .on(core0)
+        .writer(
+            OVERRIDE_KERNEL_PREFIX "NoC_tile_transfer/kernels/dataflow/writer0.cpp",
+            {},  // No DRAM buffer access
+            {src0_cb_index, src1_cb_index})
+        .runtime_args({core1_physical.x, core1_physical.y, sem_id})
+        .done()
+
+        // Core 1: reader waits for data from Core 0.
+        .on(core1)
+        .reader(
+            OVERRIDE_KERNEL_PREFIX "NoC_tile_transfer/kernels/dataflow/reader1.cpp",
+            {},  // No DRAM buffer access
+            {src0_cb_index, src1_cb_index})
+        .runtime_args({core0_physical.x, core0_physical.y, sem_id})
+        .done()
+
+        // Core 1: writer writes cb_1 to DRAM.
+        .on(core1)
+        .writer(
+            OVERRIDE_KERNEL_PREFIX "NoC_tile_transfer/kernels/dataflow/writer1.cpp",
+            {dst_dram_buffer},
+            {src1_cb_index})
+        .runtime_args({dst_dram_buffer->address()})
+        .done();
+
+    auto program = builder.build();
+
+    ctx.run(std::move(program));
+
+    // Read result back from DRAM.
+    auto result_vec = ctx.read<uint16_t>(dst_dram_buffer);
 
     fmt::print("Result = {} : Expected = {}\n", result_vec[0], input_data);
-
-    mesh_device->close();
 }

--- a/tt_metal/programming_examples/add_2_integers_in_compute/CMakeLists.txt
+++ b/tt_metal/programming_examples/add_2_integers_in_compute/CMakeLists.txt
@@ -7,4 +7,9 @@ target_sources(metal_example_add_2_integers_in_compute PRIVATE add_2_integers_in
 if(NOT TARGET TT::Metalium)
     find_package(TT-Metalium REQUIRED)
 endif()
-target_link_libraries(metal_example_add_2_integers_in_compute PUBLIC TT::Metalium)
+target_link_libraries(
+    metal_example_add_2_integers_in_compute
+    PUBLIC
+        TT::Metalium
+        tt_metal_ez
+)

--- a/tt_metal/programming_examples/add_2_integers_in_compute/add_2_integers_in_compute.cpp
+++ b/tt_metal/programming_examples/add_2_integers_in_compute/add_2_integers_in_compute.cpp
@@ -2,18 +2,19 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <random>
-#include <tt-metalium/host_api.hpp>
-#include <tt-metalium/device.hpp>
 #include <tt-metalium/bfloat16.hpp>
-#include "tt-metalium/constants.hpp"
-#include <tt-metalium/distributed.hpp>
+#include <tt-metalium/experimental/ez/ez.hpp>
 
-using namespace tt;
+#include <random>
+#include <vector>
+
 using namespace tt::tt_metal;
+using namespace tt::tt_metal::experimental::ez;
+
 #ifndef OVERRIDE_KERNEL_PREFIX
 #define OVERRIDE_KERNEL_PREFIX ""
 #endif
+
 int main() {
     // Ensure printing from kernel is enabled (so we can see the output of the Data Movement kernels).
     char* env_var = std::getenv("TT_METAL_DPRINT_CORES");
@@ -24,99 +25,19 @@ int main() {
         fmt::print("WARNING: For example, export TT_METAL_DPRINT_CORES=0,0\n");
     }
 
-    // A MeshDevice is a software concept that allows developers to virtualize a cluster of connected devices as a
-    // single object, maintaining uniform memory and runtime state across all physical devices. A UnitMesh is a 1x1
-    // MeshDevice that allows users to interface with a single physical device.
-    std::shared_ptr<distributed::MeshDevice> mesh_device = distributed::MeshDevice::create_unit_mesh(0);
+    // DeviceContext opens a single Tenstorrent device and provides helpers for buffer allocation,
+    // data transfers, and program execution.
+    DeviceContext ctx(0);
 
-    // In Metalium, submitting operations to the device is done through a command queue. This includes
-    // uploading/downloading data to/from the device, and executing programs.
-    // A MeshCommandQueue is a software concept that allows developers to submit operations to a MeshDevice.
-    distributed::MeshCommandQueue& cq = mesh_device->mesh_command_queue();
+    // Most data on Tensix is stored in tiles. A tile is a 2D array of 32x32 values. With BFloat16 as the
+    // data format, each tile occupies 32x32x2 = 2048 bytes.
+    // dram_tile_buffer() allocates DRAM-backed storage sized for the given number of tiles.
+    auto src0 = ctx.dram_tile_buffer(1);
+    auto src1 = ctx.dram_tile_buffer(1);
+    auto dst = ctx.dram_tile_buffer(1);
 
-    // A MeshWorkload is a collection of programs that are executed on a MeshDevice.
-    // The specific physical devices that the workload is executed on are determined by the MeshCoordinateRange.
-    distributed::MeshWorkload workload;
-    distributed::MeshCoordinateRange device_range = distributed::MeshCoordinateRange(mesh_device->shape());
-    // A program is a collection of kernels. Note that unlike OpenCL/CUDA where every core must run the
-    // same kernel at a given time. Metalium allows you to run different kernels on different cores
-    // simultaneously.
-    Program program = CreateProgram();
-    // We will only be using one Tensix core for this particular example. As Tenstorrent processors are a 2D grid of
-    // cores we can specify the core coordinates as (0, 0).
-    constexpr CoreCoord core = {0, 0};
-
-    // Most data on Tensix is stored in tiles. A tile is a 2D array of (usually) 32x32 values. And the Tensix uses
-    // BFloat16 as the most well supported data type. Thus the tile size is 32x32x2 = 2048 bytes.
+    // Create random input data: src0 in [0, 14) and src1 in [0, 8).
     constexpr uint32_t n_elements_per_tile = tt::constants::TILE_WIDTH * tt::constants::TILE_WIDTH;
-    constexpr uint32_t single_tile_size = sizeof(bfloat16) * n_elements_per_tile;
-
-    // MeshBuffer Creation:
-    // To create a MeshBuffer, we need to specify the page size, the buffer type, and the size of the buffer.
-    // For this example, we will be using a DRAM buffer.
-    // A DeviceLocalBufferConfig is a configuration object that specifies the properties of a buffer that is allocated
-    // on a single device. A ReplicatedBufferConfig is a configuration object that specifies the properties of a buffer
-    // that is replicated across all devices in the Mesh.
-    distributed::DeviceLocalBufferConfig dram_config{
-        .page_size = single_tile_size,  // Number of bytes when round-robin between banks. Usually this is the same
-                                        // as the tile size for efficiency.
-        .buffer_type = tt_metal::BufferType::DRAM};  // Type of buffer (DRAM or L1(SRAM))
-    distributed::ReplicatedBufferConfig distributed_buffer_config{
-        .size = single_tile_size  // Size of the buffer in bytes
-    };
-    // Create 3 buffers in DRAM to hold the 2 input tiles and 1 output tile.
-    auto src0_dram_buffer = distributed::MeshBuffer::create(distributed_buffer_config, dram_config, mesh_device.get());
-    auto src1_dram_buffer = distributed::MeshBuffer::create(distributed_buffer_config, dram_config, mesh_device.get());
-    auto dst_dram_buffer = distributed::MeshBuffer::create(distributed_buffer_config, dram_config, mesh_device.get());
-
-    // Create 3 circular buffers. Think them like pipes moving data from one core to another. cb_src0 and cb_src1 are
-    // used to move data from the reader kernel to the compute kernel. cb_dst is used to move data from the compute
-    // kernel to the writer kernel. Each circular buffer is made up of 2 tiles. Thus when one tile is pushed and being
-    // used by the receiving end, the sending end can get the next piece of data ready to be pushed. Overlapping the
-    // operations. Leading to better performance. However there is a trade off, The more tiles in a circular buffer, the
-    // more memory is used. And Circular buffers are backed by L1(SRAM) memory and L1 is a precious resource. The
-    // hardware supports up to 32 circular buffers and they all act the same.
-    constexpr uint32_t num_tiles = 1;
-    auto make_cb_config = [&](CBIndex cb_index) {
-        return CircularBufferConfig(num_tiles * single_tile_size, {{cb_index, DataFormat::Float16_b}})
-            .set_page_size(cb_index, single_tile_size);
-    };
-
-    tt_metal::CreateCircularBuffer(program, core, make_cb_config(CBIndex::c_0));
-    tt_metal::CreateCircularBuffer(program, core, make_cb_config(CBIndex::c_1));
-    tt_metal::CreateCircularBuffer(program, core, make_cb_config(CBIndex::c_16));
-
-    // Create the reader, writer and compute kernels. The kernels do the following:
-    // * Reader: Reads data from the DRAM buffer and pushes it into the circular buffer.
-    // * Compute: Waits for data to be available in the circular buffer, pops it, adds the two inputs together and
-    // pushes the result
-    //   into the output circular buffer.
-    // * Writer: Waits for data to be available in the output circular buffer, pops it and writes it back into DRAM.
-    // These kernels work together to form a pipeline. The reader reads data from the DRAM buffer and makes them
-    // available in the compute kernel. The compute kernel does math and pushes the result into the writer kernel. The
-    // writer kernel writes the result back to DRAM.
-    KernelHandle binary_reader_kernel_id = CreateKernel(
-        program,
-        OVERRIDE_KERNEL_PREFIX "add_2_integers_in_compute/kernels/dataflow/reader_binary_1_tile.cpp",
-        core,
-        DataMovementConfig{.processor = DataMovementProcessor::RISCV_1, .noc = NOC::RISCV_1_default});
-
-    KernelHandle unary_writer_kernel_id = CreateKernel(
-        program,
-        OVERRIDE_KERNEL_PREFIX "add_2_integers_in_compute/kernels/dataflow/writer_1_tile.cpp",
-        core,
-        DataMovementConfig{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default});
-
-    // This kernel performs the actual addition of the two input tiles
-    KernelHandle eltwise_binary_kernel_id = CreateKernel(
-        program,
-        OVERRIDE_KERNEL_PREFIX "add_2_integers_in_compute/kernels/compute/add_2_tiles.cpp",
-        core,
-        ComputeConfig{.math_fidelity = MathFidelity::HiFi4, .fp32_dest_acc_en = false, .math_approx_mode = false});
-
-    // Create the data that will be used as input to the kernels.
-    // src0 is a vector of bfloat16 values initialized to random values between 0.0f and 14.0f.
-    // src1 is a vector of bfloat16 values initialized to random values between 0.0f and 8.0f.
     std::vector<bfloat16> src0_vec(n_elements_per_tile);
     std::vector<bfloat16> src1_vec(n_elements_per_tile);
     std::mt19937 rng(std::random_device{}());
@@ -127,37 +48,43 @@ int main() {
         src1_vec[i] = bfloat16(dist2(rng));
     }
 
-    // Upload the data from host to the device. The last argument indicates if the operation is blocking or not.
-    // Setting it to false allows the function to immediately return after queuing the operation, enabling
-    // overlapping of data transfers with other operations. At the cost of user responsibility to ensure the data
-    // is not released before the operation is complete.
-    // In this case, we will wait for the program to finish eventually in the same scope, so we can set it
-    // to false safely.
-    EnqueueWriteMeshBuffer(cq, src0_dram_buffer, src0_vec, false);
-    EnqueueWriteMeshBuffer(cq, src1_dram_buffer, src1_vec, false);
+    // Upload input data from host to device DRAM.
+    ctx.write(src0, src0_vec);
+    ctx.write(src1, src1_vec);
 
-    // Setup arguments for the kernels in the program.
-    // Unlike OpenCL/CUDA, every kernel can have its own set of arguments.
-    SetRuntimeArgs(
-        program,
-        binary_reader_kernel_id,
-        core,
-        {(uint32_t)src0_dram_buffer->address(), (uint32_t)src1_dram_buffer->address()});
-    SetRuntimeArgs(program, eltwise_binary_kernel_id, core, {});
-    SetRuntimeArgs(program, unary_writer_kernel_id, core, {(uint32_t)dst_dram_buffer->address()});
+    // A program is a collection of kernels. Unlike OpenCL/CUDA where every core must run the same kernel
+    // at a given time, Metalium allows different kernels on different cores simultaneously.
+    // We use a single Tensix core {0, 0} for this example.
+    constexpr CoreCoord core = {0, 0};
 
-    // Add the program to the workload and execute it.
-    workload.add_program(device_range, std::move(program));
-    distributed::EnqueueMeshWorkload(cq, workload, false);
-    distributed::Finish(cq);
+    // Build the program with 3 kernels forming a pipeline:
+    //   Reader  → reads data from DRAM and pushes into circular buffers
+    //   Compute → pops data from input CBs, adds two tiles, pushes result to output CB
+    //   Writer  → pops data from output CB and writes back to DRAM
+    //
+    // Circular buffers (CBs) act as pipes between kernels on the same core. They are backed by L1 (SRAM)
+    // memory. Each CB here holds 1 tile. The hardware supports up to 32 circular buffers.
+    // cb_0 and cb_1 carry input data; cb_16 carries the output.
+    auto program =
+        ProgramBuilder(core)
+            .cb(tt::CBIndex::c_0, /*num_tiles=*/1)
+            .cb(tt::CBIndex::c_1, /*num_tiles=*/1)
+            .cb(tt::CBIndex::c_16, /*num_tiles=*/1)
+            .reader(OVERRIDE_KERNEL_PREFIX "add_2_integers_in_compute/kernels/dataflow/reader_binary_1_tile.cpp")
+            .runtime_args({src0->address(), src1->address()})
+            .done()
+            .compute(OVERRIDE_KERNEL_PREFIX "add_2_integers_in_compute/kernels/compute/add_2_tiles.cpp")
+            .done()
+            .writer(OVERRIDE_KERNEL_PREFIX "add_2_integers_in_compute/kernels/dataflow/writer_1_tile.cpp")
+            .runtime_args({dst->address()})
+            .done()
+            .build();
 
-    // Data can be read from a MeshBuffer using the ReadShard function. This function is used to read data from a
-    // specific shard of a MeshBuffer. The shard is specified by the MeshCoordinate. The last argument indicates if the
-    // operation is blocking or not.
-    std::vector<bfloat16> result_vec;
-    distributed::EnqueueReadMeshBuffer(cq, result_vec, dst_dram_buffer, true);
+    // Execute the program and read the result back to the host.
+    ctx.run(std::move(program));
+    auto result_vec = ctx.read<bfloat16>(dst);
 
-    // compare the results with the expected values.
+    // Compare results.
     bool success = true;
     for (size_t i = 0; i < n_elements_per_tile; ++i) {
         float expected = static_cast<float>(src0_vec[i]) + static_cast<float>(src1_vec[i]);
@@ -172,5 +99,4 @@ int main() {
     } else {
         fmt::print("Success: Result matches expected value!\n");
     }
-    mesh_device->close();
 }

--- a/tt_metal/programming_examples/add_2_integers_in_compute/add_2_integers_in_compute.cpp
+++ b/tt_metal/programming_examples/add_2_integers_in_compute/add_2_integers_in_compute.cpp
@@ -72,12 +72,9 @@ int main() {
             .cb(tt::CBIndex::c_16, /*num_tiles=*/1)
             .reader(OVERRIDE_KERNEL_PREFIX "add_2_integers_in_compute/kernels/dataflow/reader_binary_1_tile.cpp")
             .runtime_args({src0->address(), src1->address()})
-            .done()
             .compute(OVERRIDE_KERNEL_PREFIX "add_2_integers_in_compute/kernels/compute/add_2_tiles.cpp")
-            .done()
             .writer(OVERRIDE_KERNEL_PREFIX "add_2_integers_in_compute/kernels/dataflow/writer_1_tile.cpp")
             .runtime_args({dst->address()})
-            .done()
             .build();
 
     // Execute the program and read the result back to the host.

--- a/tt_metal/programming_examples/add_2_integers_in_riscv/CMakeLists.txt
+++ b/tt_metal/programming_examples/add_2_integers_in_riscv/CMakeLists.txt
@@ -7,4 +7,9 @@ target_sources(metal_example_add_2_integers_in_riscv PRIVATE add_2_integers_in_r
 if(NOT TARGET TT::Metalium)
     find_package(TT-Metalium REQUIRED)
 endif()
-target_link_libraries(metal_example_add_2_integers_in_riscv PUBLIC TT::Metalium)
+target_link_libraries(
+    metal_example_add_2_integers_in_riscv
+    PUBLIC
+        TT::Metalium
+        tt_metal_ez
+)

--- a/tt_metal/programming_examples/add_2_integers_in_riscv/add_2_integers_in_riscv.cpp
+++ b/tt_metal/programming_examples/add_2_integers_in_riscv/add_2_integers_in_riscv.cpp
@@ -68,7 +68,6 @@ int main() {
                 src1_l1->address(),
                 dst_l1->address(),
             })
-            .done()
             .build();
 
     ctx.run(std::move(program));

--- a/tt_metal/programming_examples/add_2_integers_in_riscv/add_2_integers_in_riscv.cpp
+++ b/tt_metal/programming_examples/add_2_integers_in_riscv/add_2_integers_in_riscv.cpp
@@ -2,18 +2,18 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <cstdint>
-#include <memory>
-#include <tt-metalium/host_api.hpp>
-#include <tt-metalium/device.hpp>
-#include "tt-metalium/buffer.hpp"
-#include <tt-metalium/distributed.hpp>
+#include <tt-metalium/experimental/ez/ez.hpp>
 
-using namespace tt;
+#include <cstdint>
+#include <vector>
+
 using namespace tt::tt_metal;
+using namespace tt::tt_metal::experimental::ez;
+
 #ifndef OVERRIDE_KERNEL_PREFIX
 #define OVERRIDE_KERNEL_PREFIX ""
 #endif
+
 int main() {
     // Ensure printing from kernel is enabled (so we can see the output of the Data Movement kernels).
     char* env_var = std::getenv("TT_METAL_DPRINT_CORES");
@@ -24,113 +24,67 @@ int main() {
         fmt::print("WARNING: For example, export TT_METAL_DPRINT_CORES=0,0\n");
     }
 
-    // A MeshDevice is a software concept that allows developers to virtualize a cluster of connected devices as a
-    // single object, maintaining uniform memory and runtime state across all physical devices. A UnitMesh is a 1x1
-    // MeshDevice that allows users to interface with a single physical device.
-    std::shared_ptr<distributed::MeshDevice> mesh_device = distributed::MeshDevice::create_unit_mesh(0);
+    // DeviceContext opens a single Tenstorrent device and provides helpers for buffer allocation,
+    // data transfers, and program execution.
+    DeviceContext ctx(0);
 
-    // In Metalium, submitting operations to the device is done through a command queue. This includes
-    // uploading/downloading data to/from the device, and executing programs.
-    // A MeshCommandQueue is a software concept that allows developers to submit operations to a MeshDevice.
-    distributed::MeshCommandQueue& cq = mesh_device->mesh_command_queue();
-    // A MeshWorkload is a collection of programs that are executed on a MeshDevice.
-    // The specific physical devices that the workload is executed on are determined by the MeshCoordinateRange.
-    distributed::MeshWorkload workload;
-    distributed::MeshCoordinateRange device_range = distributed::MeshCoordinateRange(mesh_device->shape());
-    // A Program contains kernels that perform computations or data movement.
-    Program program = CreateProgram();
-    // We will only be using one Tensix core for this particular example. As Tenstorrent processors are a 2D grid of
-    // cores we can specify the core coordinates as (0, 0).
-    constexpr CoreCoord core = {0, 0};
-
-    // Adding 2 integers in RISC-V thus a buffer size of 4 bytes.
+    // Adding 2 integers in RISC-V: a buffer size of 4 bytes.
     constexpr uint32_t buffer_size = sizeof(uint32_t);
 
-    // There are many modes of buffer allocation, here we use interleaved buffers. Interleaved buffers are the most
-    // flexible and generally recommended buffer type for most applications. As the Tensix core does not have direct
-    // access to DRAM, an extra buffer on L1 (SRAM) is required to read/write data from/to DRAM.
-    // page_size is the size of each page in the buffer. In most applications this will be set to the size of a tile.
-    // But for this example we set it to the size of a single integer as that is what we are adding.
-    distributed::DeviceLocalBufferConfig dram_config{
-        .page_size = buffer_size,
-        .buffer_type = BufferType::DRAM};
-    distributed::DeviceLocalBufferConfig l1_config{
-        .page_size = buffer_size,
-        .buffer_type = BufferType::L1};
-    distributed::ReplicatedBufferConfig buffer_config{
-        .size = buffer_size,
-    };
+    // The Tensix core does not have direct access to DRAM, so an extra buffer in L1 (SRAM) is required
+    // to stage data for reads/writes. We allocate both DRAM and L1 buffers here:
+    //   - DRAM buffers hold the persistent input/output data
+    //   - L1 buffers serve as on-core scratch space for the Data Movement kernel
+    auto src0_dram = ctx.dram_buffer(buffer_size, buffer_size);
+    auto src1_dram = ctx.dram_buffer(buffer_size, buffer_size);
+    auto dst_dram = ctx.dram_buffer(buffer_size, buffer_size);
+    auto src0_l1 = ctx.l1_buffer(buffer_size, buffer_size);
+    auto src1_l1 = ctx.l1_buffer(buffer_size, buffer_size);
+    auto dst_l1 = ctx.l1_buffer(buffer_size, buffer_size);
 
-    // Create the DRAM and SRAM buffers:
-    // MeshBuffer objects are allocated per device according to the DeviceLocalBufferConfig (location, page size)
-    // and sized by the ReplicatedBufferConfig. Here we create three DRAM buffers for inputs/outputs and three L1
-    // buffers used as on-core scratch space for the Data Movement kernels.
-    auto src0_dram_buffer = distributed::MeshBuffer::create(buffer_config, dram_config, mesh_device.get());
-    auto src1_dram_buffer = distributed::MeshBuffer::create(buffer_config, dram_config, mesh_device.get());
-    auto dst_dram_buffer = distributed::MeshBuffer::create(buffer_config, dram_config, mesh_device.get());
-    auto src0_l1_buffer = distributed::MeshBuffer::create(buffer_config, l1_config, mesh_device.get());
-    auto src1_l1_buffer = distributed::MeshBuffer::create(buffer_config, l1_config, mesh_device.get());
-    auto dst_l1_buffer = distributed::MeshBuffer::create(buffer_config, l1_config, mesh_device.get());
-
-    // Create source data and write to DRAM
+    // Upload source data to DRAM.
     std::vector<uint32_t> src0_vec = {14};
     std::vector<uint32_t> src1_vec = {7};
+    ctx.write(src0_dram, src0_vec);
+    ctx.write(src1_dram, src1_vec);
 
-    // Enqueue write operations to copy data from host vectors to DRAM buffers. The last argument specifies whether the
-    // write operation should block until the data is written to the device. In this case, we set it to false for
-    // asynchronous writes, allowing the program to continue executing while the data is being written. This is
-    // recommended for most writes to device in applications to improve performance.
-    EnqueueWriteMeshBuffer(cq, src0_dram_buffer, src0_vec, /*blocking=*/false);
-    EnqueueWriteMeshBuffer(cq, src1_dram_buffer, src1_vec, /*blocking=*/false);
+    // The Data Movement cores are the only cores that can read/write data from/to DRAM. In practice you
+    // would use the compute kernel for addition (which has access to much more powerful vector and matrix
+    // engines), but the Data Movement cores are still fully capable of simple arithmetic — just slower.
+    // Here we use a single Data Movement kernel that reads two integers from DRAM via L1, adds them,
+    // and writes the result back.
+    // The original kernel runs on RISCV_0 (Data Movement processor 0 / "BR"). We use .kernel() with
+    // explicit DataMovementConfig to preserve this assignment, since .reader() would use RISCV_1.
+    auto program =
+        ProgramBuilder(CoreCoord{0, 0})
+            .kernel(
+                OVERRIDE_KERNEL_PREFIX "add_2_integers_in_riscv/kernels/reader_writer_add_in_riscv.cpp",
+                DataMovementConfig{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default})
+            .runtime_args({
+                src0_dram->address(),
+                src1_dram->address(),
+                dst_dram->address(),
+                src0_l1->address(),
+                src1_l1->address(),
+                dst_l1->address(),
+            })
+            .done()
+            .build();
 
-    // Create the kernel (code that runs on the Tensix core) that will perform the addition of the 2 integers.
-    // The Data Movement cores are the only cores that can read/write data from/to DRAM. Thus we use them for
-    // demonstration purposes here. In practice, you would perform addition using the compute kernel which have access
-    // to much more powerful vector and matrix engines. The Data Movement cores are used for data movement tasks such as
-    // reading/writing data from/to DRAM. But they are still fully capable of performing simple arithmetic operations
-    // like addition. Just slower.
-    KernelHandle kernel_id = CreateKernel(
-        program,
-        OVERRIDE_KERNEL_PREFIX "add_2_integers_in_riscv/kernels/reader_writer_add_in_riscv.cpp",
-        core,
-        DataMovementConfig{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default});
+    ctx.run(std::move(program));
 
-    // Set the arguments for the kernel. The arguments are set in the order they are defined in the kernel source code.
-    SetRuntimeArgs(
-        program,
-        kernel_id,
-        core,
-        {
-            src0_dram_buffer->address(),
-            src1_dram_buffer->address(),
-            dst_dram_buffer->address(),
-            src0_l1_buffer->address(),
-            src1_l1_buffer->address(),
-            dst_l1_buffer->address(),
-        });
+    // Read the result back from DRAM. Everything on the command queue executes in FIFO order, so a
+    // blocking read will not start until the prior kernel finishes.
+    auto result_vec = ctx.read<uint32_t>(dst_dram);
 
-    // Add the program to the workload and enqueue it for execution on the MeshDevice.
-    // Setting blocking=false returns immediately; commands on the queue execute in FIFO order.
-    workload.add_program(device_range, std::move(program));
-    distributed::EnqueueMeshWorkload(cq, workload, /*blocking=*/false);
-
-    // Read a shard of the destination MeshBuffer back to host.
-    // ReadShard reads from a specific device identified by MeshCoordinate; the last argument controls blocking.
-    // This time we set blocking=true since we must have the data before comparing.
-    // NOTE: Everything on the command queue executes in order; a read will not run before the prior kernel finishes.
-    std::vector<uint32_t> result_vec;
-    distributed::EnqueueReadMeshBuffer(cq, result_vec, dst_dram_buffer, /*blocking=*/true);
     if (result_vec.size() != 1) {
-        std::cout << "Error: Expected result vector size of 1, got " << result_vec.size() << std::endl;
-        mesh_device->close();
+        fmt::print(stderr, "Error: Expected result vector size of 1, got {}\n", result_vec.size());
         return -1;
     }
     if (result_vec[0] != 21) {
-        std::cout << "Error: Expected result of 21, got " << result_vec[0] << std::endl;
-        mesh_device->close();
+        fmt::print(stderr, "Error: Expected result of 21, got {}\n", result_vec[0]);
         return -1;
     }
 
-    std::cout << "Success: Result is " << result_vec[0] << std::endl;
-    mesh_device->close();
+    fmt::print("Success: Result is {}\n", result_vec[0]);
 }

--- a/tt_metal/programming_examples/contributed/CMakeLists.txt
+++ b/tt_metal/programming_examples/contributed/CMakeLists.txt
@@ -2,6 +2,8 @@ set(VECADD_SRCS ${CMAKE_CURRENT_SOURCE_DIR}/vecadd/vecadd.cpp)
 set(MULTICAST_SRCS ${CMAKE_CURRENT_SOURCE_DIR}/multicast/multicast.cpp)
 
 CREATE_PGM_EXAMPLES_EXE("${VECADD_SRCS}" "contributed") # output binaries to build/programming_examples/contributed
+target_link_libraries(vecadd PUBLIC tt_metal_ez)
 CREATE_PGM_EXAMPLES_EXE("${MULTICAST_SRCS}" "contributed")
+target_link_libraries(multicast PUBLIC tt_metal_ez)
 
 add_custom_target(contributed DEPENDS ${PROGRAMMING_EXAMPLES_TEST_TARGETS})

--- a/tt_metal/programming_examples/contributed/multicast/multicast.cpp
+++ b/tt_metal/programming_examples/contributed/multicast/multicast.cpp
@@ -190,7 +190,6 @@ int main(int /*argc*/, char** argv) {
              src0_dram_buffer->address(),
              sizeof(bfloat16) * TILE_HW,
              (uint32_t)num_dests})
-        .done()
 
         ////////// DATAFLOW KERNELS SETUP //////////
         // Inbound kernel: receiver cores wait for the multicast from the sender core.
@@ -201,8 +200,7 @@ int main(int /*argc*/, char** argv) {
             {(uint32_t)(sender_core_physical.x),
              (uint32_t)(sender_core_physical.y),
              sender_sem,
-             receiver_sem})
-        .done();
+             receiver_sem});
 
     // Outbound kernel: receiver cores write the received tile from cb_16 back to DRAM.
     // Per-core runtime args: each receiver writes to a different tile index.

--- a/tt_metal/programming_examples/contributed/multicast/multicast.cpp
+++ b/tt_metal/programming_examples/contributed/multicast/multicast.cpp
@@ -10,15 +10,11 @@
 */
 
 #include <tt-metalium/bfloat16.hpp>
-#include <tt-metalium/core_coord.hpp>
-#include <tt-metalium/host_api.hpp>
-#include <tt-metalium/tensor_accessor_args.hpp>
-#include <tt-metalium/distributed.hpp>
+#include <tt-metalium/experimental/ez/ez.hpp>
+
 #include <cstdint>
 #include <vector>
-#include <memory>
 #include <iostream>
-#include <tt-metalium/tt_metal.hpp>
 
 // Optional: For verbose host-side tile verification prints.
 #include <optional>
@@ -30,29 +26,12 @@
 using namespace tt;
 using namespace tt::tt_metal;
 using namespace tt::constants;
+using namespace tt::tt_metal::experimental::ez;
 using namespace std;
-using CoreSpec = std::variant<CoreCoord, CoreRange, CoreRangeSet>;
 
 #ifndef OVERRIDE_KERNEL_PREFIX
 #define OVERRIDE_KERNEL_PREFIX ""
 #endif
-
-std::shared_ptr<distributed::MeshBuffer> MakeBufferBFP16(
-    const std::shared_ptr<distributed::MeshDevice>& mesh_device, uint32_t n_tiles, bool sram) {
-    constexpr uint32_t tile_size = sizeof(bfloat16) * TILE_WIDTH * TILE_HEIGHT;
-    const uint32_t page_tiles = sram ? n_tiles : 1;
-    const distributed::DeviceLocalBufferConfig device_local_config{
-        .page_size = page_tiles * tile_size,
-        .buffer_type = (sram ? BufferType::L1 : BufferType::DRAM),
-        .bottom_up = false};
-    const distributed::ReplicatedBufferConfig buffer_config{.size = tile_size * n_tiles};
-    return distributed::MeshBuffer::create(buffer_config, device_local_config, mesh_device.get());
-}
-
-CBHandle MakeCircularBufferBFP16(Program& program, const CoreSpec& core, tt::CBIndex cb, uint32_t n_tiles) {
-    constexpr uint32_t tile_size = sizeof(bfloat16) * TILE_WIDTH * TILE_HEIGHT;
-    return CreateCircularBuffer(program, core, CircularBufferConfig(n_tiles * tile_size, {{cb, tt::DataFormat::Float16_b}}).set_page_size(cb, tile_size));
-}
 
 void VerifyDPRINTEnvironment(const std::string& program_path) {
     fmt::print("\n=========== DPRINT ENVIRONMENT CHECK ===========\n");
@@ -154,160 +133,126 @@ void verify_tiles(
 
 int main(int /*argc*/, char** argv) {
     ////////// DEVICE SETUP //////////
-    // A MeshDevice is a software concept that allows developers to virtualize a cluster of connected devices as a
-    // single object, maintaining uniform memory and runtime state across all physical devices. A UnitMesh is a 1x1
-    // MeshDevice that allows users to interface with a single physical device.
+    // DeviceContext wraps MeshDevice creation, command queue, and teardown in RAII.
+    // A UnitMesh is a 1x1 MeshDevice that interfaces with a single physical device.
     int device_id = 0;
-    auto mesh_device = distributed::MeshDevice::create_unit_mesh(device_id);
-    distributed::MeshCommandQueue& cq = mesh_device->mesh_command_queue();
-    distributed::MeshCoordinateRange device_range = distributed::MeshCoordinateRange(mesh_device->shape());
+    DeviceContext ctx(device_id);
 
-    ////////// PROGRAM BLOCK //////////
-    {
-        distributed::MeshWorkload workload;
-        Program program = CreateProgram();
-        const auto device_coord = distributed::MeshCoordinate(0, 0);
+    ////////// TENSIX CORE SETUP //////////
+    // Define logical sender core and receiver core range (for kernel creation on the host).
+    CoreRange all_cores_logical = CoreRange({0, 0}, {3, 0});
+    CoreCoord sender_core_logical = {0, 0};
+    CoreRange receiver_cores_logical = CoreRange({1, 0}, {3, 0});
+    // Convert logical coordinates to physical coordinates (necessary for multicasting).
+    // Multicast NoC operations require physical addresses, not logical core coordinates.
+    CoreCoord sender_core_physical = ctx.physical_core(sender_core_logical);
+    CoreCoord receiver_start_physical = ctx.physical_core(receiver_cores_logical.start_coord);
+    CoreCoord receiver_end_physical = ctx.physical_core(receiver_cores_logical.end_coord);
+    // Grab the number of destinations, which will act as our "atomic counter" for semaphores, and as a general
+    // reference for num of receivers.
+    size_t num_dests = receiver_cores_logical.size();
 
-        ////////// TENSIX CORE SETUP //////////
-        // Define logical sender core and receiver core range (for kernel creation on the host).
-        CoreRange all_cores_logical = CoreRange({0, 0}, {3, 0});
-        CoreCoord sender_core_logical = {0, 0};
-        CoreRange receiver_cores_logical = CoreRange({1, 0}, {3, 0});
-        // Convert logical coordinates to physical coordinates (necessary for multicasting).
-        CoreCoord sender_core_physical = mesh_device->worker_core_from_logical_core(sender_core_logical);
-        CoreRange receiver_cores_physical = CoreRange(
-            mesh_device->worker_core_from_logical_core(receiver_cores_logical.start_coord),
-            mesh_device->worker_core_from_logical_core(receiver_cores_logical.end_coord));
-        // Define physical sender core and receiver core range (for runtime arguments on the device).
-        CoreCoord sender_core = sender_core_physical;
-        CoreCoord receiver_core_start = receiver_cores_physical.start_coord;
-        CoreCoord receiver_core_end = receiver_cores_physical.end_coord;
-        // Grab the number of destinations, which will act as our "atomic counter" for semaphores, and as a general
-        // reference for num of receivers.
-        size_t num_dests = receiver_cores_logical.size();
+    ////////// DRAM & SRAM BUFFERS SETUP //////////
+    constexpr uint32_t num_tiles = 1;
+    uint32_t dram_bank_id = 0;
+    auto src0_dram_buffer = ctx.dram_tile_buffer(num_tiles);
+    auto output_dram_buffer = ctx.dram_tile_buffer(num_dests * num_tiles);
 
-        ////////// SEMAPHORE SETUP //////////
-        uint32_t sender = CreateSemaphore(program, all_cores_logical, 0);
-        uint32_t receiver = CreateSemaphore(program, all_cores_logical, 0);
+    ////////// PROGRAM SETUP //////////
+    // Build the program with circular buffers, semaphores, and kernels.
+    // Circular buffers c_0 and c_16 are created on all cores (sender + receivers).
+    auto builder = ProgramBuilder(all_cores_logical);
+    builder.cb(tt::CBIndex::c_0, num_tiles)
+        .cb(tt::CBIndex::c_16, num_tiles);
 
-        ////////// DRAM & SRAM BUFFERS SETUP //////////
-        constexpr uint32_t num_tiles = 1;
-        uint32_t dram_bank_id = 0;
-        auto src0_dram_buffer = MakeBufferBFP16(mesh_device, num_tiles, false);
-        auto output_dram_buffer = MakeBufferBFP16(mesh_device, num_dests * num_tiles, false);
-        MakeCircularBufferBFP16(program, all_cores_logical, tt::CBIndex::c_0, num_tiles);
-        MakeCircularBufferBFP16(program, all_cores_logical, tt::CBIndex::c_16, num_tiles);
+    ////////// SEMAPHORE SETUP //////////
+    // Semaphores coordinate the multicast handshake between sender and receivers.
+    // The sender signals when data is ready; receivers signal when they've consumed it.
+    uint32_t sender_sem = builder.semaphore();
+    uint32_t receiver_sem = builder.semaphore();
 
-        ////////// DATA MOVEMENT CONFIG SETUP //////////
-        DataMovementConfig DataMovementConfigIn = {.processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default};
-        std::vector<uint32_t> writer_compile_time_args;
-        TensorAccessorArgs(*output_dram_buffer).append_to(writer_compile_time_args);
-        DataMovementConfig DataMovementConfigOut = {
-            .processor = DataMovementProcessor::RISCV_1,
-            .noc = NOC::RISCV_1_default,
-            .compile_args = writer_compile_time_args};
-
-        ////////// COORDINATOR KERNEL SETUP //////////
-        KernelHandle coordinator_kernel_id = CreateKernel(
-            program,
-            "tt_metal/programming_examples/contributed/multicast/kernels/dataflow/coordinator_kernel.cpp",
-            sender_core_logical,
-            DataMovementConfigIn);
-
-        ////////// DATAFLOW KERNELS SETUP //////////
-        KernelHandle inbound_kernel_id = CreateKernel(
-            program,
-            "tt_metal/programming_examples/contributed/multicast/kernels/dataflow/inbound_kernel.cpp",
-            receiver_cores_logical,
-            DataMovementConfigIn);
-        KernelHandle outbound_kernel_id = CreateKernel(
-            program,
-            "tt_metal/programming_examples/contributed/multicast/kernels/dataflow/outbound_kernel.cpp",
-            receiver_cores_logical,
-            DataMovementConfigOut);
-
-        ////////// COMPUTE KERNEL SETUP //////////
-        vector<uint32_t> compute_kernel_args = {};
-        CreateKernel(
-            program,
-            "tt_metal/programming_examples/contributed/multicast/kernels/compute/void_compute_kernel.cpp",
-            receiver_cores_logical,
-            ComputeConfig{
-                .math_fidelity = MathFidelity::HiFi4,
-                .fp32_dest_acc_en = false,
-                .math_approx_mode = false,
-                .compile_args = compute_kernel_args});
-
-        ////////// IDENTITY MATRIX TILE SETUP //////////
-        std::vector<bfloat16> identity_tile = create_identity_matrix(TILE_WIDTH, TILE_HEIGHT, TILE_WIDTH);
-        distributed::EnqueueWriteMeshBuffer(cq, src0_dram_buffer, identity_tile);
-
-        ////////// RUNTIME ARGS SETUP //////////
-        // Args for the sender core to multicast tile.
-        // They must have access to coordinates of all receiver cores, to execute multicast operation.
-        SetRuntimeArgs(
-            program,
-            coordinator_kernel_id,
-            sender_core_logical,
-            {(uint32_t)(receiver_core_start.x),
-             (uint32_t)(receiver_core_start.y),
-             (uint32_t)(receiver_core_end.x),
-             (uint32_t)(receiver_core_end.y),
-             sender,
-             receiver,
+    ////////// COORDINATOR KERNEL SETUP //////////
+    // The coordinator (sender) reads a tile from DRAM into cb_0, then multicasts it to all receiver cores.
+    // We use .kernel() with explicit RISCV_0/NOC_0 to match the original: multicast is NOC-specific,
+    // and the coordinator does not use TensorAccessorArgs (it reads DRAM via direct bank addressing).
+    builder.on(sender_core_logical)
+        .kernel(
+            OVERRIDE_KERNEL_PREFIX "contributed/multicast/kernels/dataflow/coordinator_kernel.cpp",
+            DataMovementConfig{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default})
+        .runtime_args(
+            {(uint32_t)(receiver_start_physical.x),
+             (uint32_t)(receiver_start_physical.y),
+             (uint32_t)(receiver_end_physical.x),
+             (uint32_t)(receiver_end_physical.y),
+             sender_sem,
+             receiver_sem,
              dram_bank_id,
              src0_dram_buffer->address(),
              sizeof(bfloat16) * TILE_HW,
-             num_dests});
-        // Args for the receiver cores to receive tile.
-        // They must have access to coordinates of the sender core, to listen for multicast operation.
-        SetRuntimeArgs(
-            program,
-            inbound_kernel_id,
-            receiver_cores_logical,
-            {(uint32_t)(sender_core.x), (uint32_t)(sender_core.y), sender, receiver});
+             (uint32_t)num_dests})
+        .done()
 
-        // Args for the receiver cores to send tile back to DRAM.
-        int tile_index = 0;
-        for (const CoreCoord& core : receiver_cores_logical) {
-            SetRuntimeArgs(
-                program, outbound_kernel_id, core, {output_dram_buffer->address(), static_cast<uint32_t>(tile_index)});
-            tile_index++;
-        }
+        ////////// DATAFLOW KERNELS SETUP //////////
+        // Inbound kernel: receiver cores wait for the multicast from the sender core.
+        .on(receiver_cores_logical)
+        .reader(
+            OVERRIDE_KERNEL_PREFIX "contributed/multicast/kernels/dataflow/inbound_kernel.cpp")
+        .runtime_args(
+            {(uint32_t)(sender_core_physical.x),
+             (uint32_t)(sender_core_physical.y),
+             sender_sem,
+             receiver_sem})
+        .done();
 
-        ////////// PROGRAM LAUNCH AND CLOSE //////////
-        VerifyDPRINTEnvironment(argv[0]);
-        fmt::print("Launching program\n");
-        fmt::print(
-            "Hello, Core ({}, {}) on Device {}, please multicast the tile to your neighbors.\n",
-            sender_core_logical.x,
-            sender_core_logical.y,
-            device_id);
-        workload.add_program(device_range, std::move(program));
-        distributed::EnqueueMeshWorkload(cq, workload, false);
-        fmt::print("Waiting until program finishes\n");
-        distributed::Finish(cq);
-        fmt::print(
-            "Thank you, Core ({}, {}) on Device {}, for the multicast.\n",
-            sender_core_logical.x,
-            sender_core_logical.y,
-            device_id);
-
-        // introduce artificial delay to avoid jumbling host-side tile verification prints with potentially echoing
-        // device-side DPRINTs.  Delay may be adjusted or removed as needed.
-        this_thread::sleep_for(chrono::milliseconds(200));
-
-        ////////// TILE MULTICAST VERIFICATION //////////
-        std::vector<bfloat16> received_tiles(num_dests * TILE_HW);
-
-        // We're reading from a shard allocated on Device Coordinate 0, 0, since this is a 1x1
-        //  When the MeshDevice is 2 dimensional, this API can be used to target specific physical devices
-        distributed::EnqueueReadMeshBuffer(cq, received_tiles, output_dram_buffer, true);
-        bool verbose_verify =
-            false;  // if enabled, the original and all multicast-received tiles are printed in full (32x32).
-        verify_tiles(identity_tile, received_tiles, num_dests, verbose_verify);
+    // Outbound kernel: receiver cores write the received tile from cb_16 back to DRAM.
+    // Per-core runtime args: each receiver writes to a different tile index.
+    auto& outbound_ref = builder.on(receiver_cores_logical)
+        .writer(
+            OVERRIDE_KERNEL_PREFIX "contributed/multicast/kernels/dataflow/outbound_kernel.cpp",
+            {output_dram_buffer});
+    uint32_t tile_index = 0;
+    for (const CoreCoord& core : receiver_cores_logical) {
+        outbound_ref.runtime_args_at(core, {output_dram_buffer->address(), tile_index});
+        tile_index++;
     }
 
-    mesh_device->close();
+    ////////// COMPUTE KERNEL SETUP //////////
+    // Void compute kernel on receiver cores — placeholder for the compute pipeline stage.
+    builder.on(receiver_cores_logical)
+        .compute(
+            OVERRIDE_KERNEL_PREFIX "contributed/multicast/kernels/compute/void_compute_kernel.cpp",
+            MathFidelity::HiFi4);
+
+    ////////// IDENTITY MATRIX TILE SETUP //////////
+    std::vector<bfloat16> identity_tile = create_identity_matrix(TILE_WIDTH, TILE_HEIGHT, TILE_WIDTH);
+    ctx.write(src0_dram_buffer, identity_tile);
+
+    ////////// PROGRAM LAUNCH AND CLOSE //////////
+    VerifyDPRINTEnvironment(argv[0]);
+    fmt::print("Launching program\n");
+    fmt::print(
+        "Hello, Core ({}, {}) on Device {}, please multicast the tile to your neighbors.\n",
+        sender_core_logical.x,
+        sender_core_logical.y,
+        device_id);
+    ctx.launch(builder.build());
+    fmt::print("Waiting until program finishes\n");
+    ctx.finish();
+    fmt::print(
+        "Thank you, Core ({}, {}) on Device {}, for the multicast.\n",
+        sender_core_logical.x,
+        sender_core_logical.y,
+        device_id);
+
+    // introduce artificial delay to avoid jumbling host-side tile verification prints with potentially echoing
+    // device-side DPRINTs.  Delay may be adjusted or removed as needed.
+    this_thread::sleep_for(chrono::milliseconds(200));
+
+    ////////// TILE MULTICAST VERIFICATION //////////
+    auto received_tiles = ctx.read<bfloat16>(output_dram_buffer);
+    bool verbose_verify =
+        false;  // if enabled, the original and all multicast-received tiles are printed in full (32x32).
+    verify_tiles(identity_tile, received_tiles, num_dests, verbose_verify);
+
     return 0;
 }

--- a/tt_metal/programming_examples/contributed/vecadd/vecadd.cpp
+++ b/tt_metal/programming_examples/contributed/vecadd/vecadd.cpp
@@ -2,70 +2,21 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <tt-metalium/core_coord.hpp>
-#include <tt-metalium/host_api.hpp>
-#include <tt-metalium/device.hpp>
 #include <tt-metalium/bfloat16.hpp>
-#include <tt-metalium/tensor_accessor_args.hpp>
-#include <tt-metalium/distributed.hpp>
-#include <cstddef>
+#include <tt-metalium/experimental/ez/ez.hpp>
+
 #include <cstdint>
-#include <memory>
 #include <random>
 #include <string_view>
 #include <vector>
 
+using namespace tt;
 using namespace tt::tt_metal;
-using CoreSpec = std::variant<CoreCoord, CoreRange, CoreRangeSet>;
+using namespace tt::tt_metal::experimental::ez;
 
-constexpr uint32_t TILE_WIDTH = 32;
-constexpr uint32_t TILE_HEIGHT = 32;
-
-std::shared_ptr<distributed::MeshBuffer> MakeBuffer(
-    const std::shared_ptr<distributed::MeshDevice>& mesh_device, uint32_t size, uint32_t /*page_size*/, bool sram) {
-    constexpr uint32_t tile_size = sizeof(bfloat16) * TILE_WIDTH * TILE_HEIGHT;
-    const uint32_t page_tiles = sram ? size : 1;
-    const distributed::DeviceLocalBufferConfig device_local_config{
-        .page_size = page_tiles * tile_size, .buffer_type = (sram ? BufferType::L1 : BufferType::DRAM)};
-    const distributed::ReplicatedBufferConfig buffer_config{.size = tile_size * size};
-    return distributed::MeshBuffer::create(buffer_config, device_local_config, mesh_device.get());
-}
-
-// Allocate a buffer on DRAM or SRAM. Assuming the buffer holds BFP16 data.
-// A tile on Tenstorrent is 32x32 elements, given us using BFP16, we need 2 bytes per element.
-// Making the tile size 32x32x2 = 2048 bytes.
-// @param device: The device to allocate the buffer on.
-// @param n_tiles: The number of tiles to allocate.
-// @param sram: If true, allocate the buffer on SRAM, otherwise allocate it on DRAM.
-std::shared_ptr<distributed::MeshBuffer> MakeBufferBFP16(
-    const std::shared_ptr<distributed::MeshDevice>& mesh_device, uint32_t n_tiles, bool sram) {
-    constexpr uint32_t tile_size = sizeof(bfloat16) * TILE_WIDTH * TILE_HEIGHT;
-    const uint32_t page_tiles = sram ? n_tiles : 1;
-    const distributed::DeviceLocalBufferConfig device_local_config{
-        .page_size = page_tiles * tile_size,
-        .buffer_type = (sram ? BufferType::L1 : BufferType::DRAM),
-        .bottom_up = false};
-    const distributed::ReplicatedBufferConfig buffer_config{.size = tile_size * n_tiles};
-    return distributed::MeshBuffer::create(buffer_config, device_local_config, mesh_device.get());
-}
-
-CBHandle MakeCircularBuffer(
-    Program& program, const CoreSpec& core, tt::CBIndex cb, uint32_t size, uint32_t page_size, tt::DataFormat format) {
-    CircularBufferConfig cb_config = CircularBufferConfig(size, {{cb, format}}).set_page_size(cb, page_size);
-    return CreateCircularBuffer(program, core, cb_config);
-}
-
-// Circular buffers are Tenstorrent's way of communicating between the data movement and the compute kernels.
-// kernels queue tiles into the circular buffer and takes them when they are ready. The circular buffer is
-// backed by SRAM. There can be multiple circular buffers on a single Tensix core.
-// @param program: The program to create the circular buffer on.
-// @param core: The core to create the circular buffer on.
-// @param cb: Which circular buffer to create (c_in0, c_in1, c_out0, c_out1, etc..). This is just an ID
-// @param n_tiles: The number of tiles the circular buffer can hold.
-CBHandle MakeCircularBufferBFP16(Program& program, const CoreSpec& core, tt::CBIndex cb, uint32_t n_tiles) {
-    constexpr uint32_t tile_size = sizeof(bfloat16) * TILE_WIDTH * TILE_HEIGHT;
-    return MakeCircularBuffer(program, core, cb, n_tiles * tile_size, tile_size, tt::DataFormat::Float16_b);
-}
+#ifndef OVERRIDE_KERNEL_PREFIX
+#define OVERRIDE_KERNEL_PREFIX ""
+#endif
 
 std::string next_arg(int& i, int argc, char** argv) {
     if (i + 1 >= argc) {
@@ -85,9 +36,6 @@ void help(std::string_view program_name) {
     exit(0);
 }
 
-#ifndef OVERRIDE_KERNEL_PREFIX
-#define OVERRIDE_KERNEL_PREFIX ""
-#endif
 int main(int argc, char** argv) {
     int seed = std::random_device{}();
     int device_id = 0;
@@ -108,39 +56,24 @@ int main(int argc, char** argv) {
         }
     }
 
-    std::shared_ptr<distributed::MeshDevice> mesh_device = distributed::MeshDevice::create_unit_mesh(device_id);
-    auto device_range = distributed::MeshCoordinateRange(mesh_device->shape());
-    distributed::MeshWorkload workload;
-    Program program = CreateProgram();
+    // DeviceContext wraps MeshDevice creation, command queue, and teardown in RAII.
+    DeviceContext ctx(device_id);
+
     // This example program will only use 1 Tensix core. So we set the core to {0, 0}.
     CoreCoord core = {0, 0};
-    const auto device_coord = distributed::MeshCoordinate(0, 0);
 
-    distributed::MeshCommandQueue& cq = mesh_device->mesh_command_queue();
     const uint32_t n_tiles = 64;
-    const uint32_t tile_size = TILE_WIDTH * TILE_HEIGHT;
-    // Create 3 buffers on DRAM. These will hold the input and output data. A and B are the input buffers, C is the
-    // output buffer.
-    auto a = MakeBufferBFP16(mesh_device, n_tiles, false);
-    auto b = MakeBufferBFP16(mesh_device, n_tiles, false);
-    auto c = MakeBufferBFP16(mesh_device, n_tiles, false);
+    const uint32_t tile_size = tt::constants::TILE_WIDTH * tt::constants::TILE_HEIGHT;
+
+    // Create 3 DRAM tile buffers: A and B are inputs, C is the output.
+    // A tile on Tenstorrent is 32x32 elements; with BFloat16, each tile occupies 2048 bytes.
+    auto a = ctx.dram_tile_buffer(n_tiles);
+    auto b = ctx.dram_tile_buffer(n_tiles);
+    auto c = ctx.dram_tile_buffer(n_tiles);
 
     std::mt19937 rng(seed);
     std::vector<uint32_t> a_data = create_random_vector_of_bfloat16(tile_size * n_tiles * 2, 10, rng());
     std::vector<uint32_t> b_data = create_random_vector_of_bfloat16(tile_size * n_tiles * 2, 10, rng());
-
-    const uint32_t tiles_per_cb = 4;
-    // Create 3 circular buffers. These will be used by the data movement kernels to stream data into the compute cores
-    // and for the compute cores to stream data out.
-    MakeCircularBufferBFP16(program, core, tt::CBIndex::c_0, tiles_per_cb);
-    MakeCircularBufferBFP16(program, core, tt::CBIndex::c_1, tiles_per_cb);
-    MakeCircularBufferBFP16(program, core, tt::CBIndex::c_16, tiles_per_cb);
-
-    // We're writing to a shard allocated on MeshCoordinate 0, 0, since this is a 1x1 MeshDevice
-    //  When the MeshDevice is 2 dimensional, this API can be used to target specific physical devices
-    // The last argument indicates if the operation is blocking or not.
-    distributed::WriteShard(cq, a, a_data, device_coord, false);
-    distributed::WriteShard(cq, b, b_data, device_coord, false);
 
     // A Tensix core is made up with 5 processors. 2 data movement processors, and 3 compute processors. The 2 data
     // movement processors act independent to other cores. And the 3 compute processors act together (hence 1 kerenl for
@@ -153,57 +86,45 @@ int main(int argc, char** argv) {
     // into 2 circular buffers. `add` reads tiles from the circular buffers, adds them together, and dumps the result
     // into a third circular buffer. `tile_write` reads tiles from the third circular buffer and writes them to the
     // output buffer C.
-    std::vector<uint32_t> reader_compile_time_args;
-    TensorAccessorArgs(*a).append_to(reader_compile_time_args);
-    TensorAccessorArgs(*b).append_to(reader_compile_time_args);
-    auto reader = CreateKernel(
-        program,
+    //
+    // Circular buffers are Tenstorrent's way of communicating between the data movement and the compute kernels.
+    // Kernels queue tiles into the circular buffer and takes them when they are ready. The circular buffer is
+    // backed by SRAM. There can be multiple circular buffers on a single Tensix core.
+    constexpr uint32_t tiles_per_cb = 4;
+
+    auto builder = ProgramBuilder(core);
+    builder.cb(tt::CBIndex::c_0, tiles_per_cb)
+        .cb(tt::CBIndex::c_1, tiles_per_cb)
+        .cb(tt::CBIndex::c_16, tiles_per_cb);
+
+    // Reader kernel: reads tiles from A and B into circular buffers c_0 and c_1.
+    // The EZ API auto-generates TensorAccessorArgs from the buffer list {a, b}.
+    auto& reader_ref = builder.reader(
         OVERRIDE_KERNEL_PREFIX "contributed/vecadd/kernels/interleaved_tile_read.cpp",
-        core,
-        DataMovementConfig{
-            .processor = DataMovementProcessor::RISCV_0,
-            .noc = NOC::RISCV_0_default,
-            .compile_args = reader_compile_time_args});
-    std::vector<uint32_t> writer_compile_time_args;
-    TensorAccessorArgs(*c).append_to(writer_compile_time_args);
-    auto writer = CreateKernel(
-        program,
+        {a, b});
+    // Writer kernel: reads from c_16 and writes tiles to output buffer C.
+    auto& writer_ref = builder.writer(
         OVERRIDE_KERNEL_PREFIX "contributed/vecadd/kernels/tile_write.cpp",
-        core,
-        DataMovementConfig{
-            .processor = DataMovementProcessor::RISCV_1,
-            .noc = NOC::RISCV_1_default,
-            .compile_args = writer_compile_time_args});
-    auto compute = CreateKernel(
-        program,
-        OVERRIDE_KERNEL_PREFIX "contributed/vecadd/kernels/add.cpp",
-        core,
-        ComputeConfig{.math_approx_mode = false, .compile_args = {}, .defines = {}});
+        {c});
+    // Compute kernel: reads from c_0 and c_1, adds tiles, writes result to c_16.
+    auto& compute_ref = builder.compute(
+        OVERRIDE_KERNEL_PREFIX "contributed/vecadd/kernels/add.cpp");
 
-    // Set the runtime arguments for the kernels. This also registers
-    // the kernels with the program.
-    SetRuntimeArgs(program, reader, core, {a->address(), b->address(), n_tiles});
-    SetRuntimeArgs(program, writer, core, {c->address(), n_tiles});
-    SetRuntimeArgs(program, compute, core, {n_tiles});
+    // Set the runtime arguments for the kernels.
+    reader_ref.runtime_args({a->address(), b->address(), n_tiles});
+    writer_ref.runtime_args({c->address(), n_tiles});
+    compute_ref.runtime_args({n_tiles});
 
-    // We have setup the program. Now we can add it to the workload and queue it for execution.
-    // The last argument to EnqueueMeshWorkload is a boolean that specifies whether
-    // we wait for the program to finish execution before returning. I've set
-    // it to true. But alternatively, you can set it to false and call
-    // `Finish(cq)` to wait for all programs to finish.
-    // But it shouldn't matter in this case since we block on reading the output
-    // buffer.
-    workload.add_program(device_range, std::move(program));
-    distributed::EnqueueMeshWorkload(cq, workload, true);
-    // distributed::Finish(cq);
+    // Upload input data (non-blocking), execute program, then read back the result.
+    // The last write blocks to ensure data is ready before kernel execution.
+    ctx.write(a, a_data);
+    ctx.write(b, b_data);
+    ctx.run(builder.build());
+
     std::cout << "Kernel execution finished" << std::endl;
 
     // Read the output buffer.
-    std::vector<uint32_t> c_data;
-
-    // We're reading from a shard allocated on Device Coordinate 0, 0, since this is a 1x1
-    //  When the MeshDevice is 2 dimensional, this API can be used to target specific physical devices
-    distributed::EnqueueReadMeshBuffer(cq, c_data, c, true);
+    auto c_data = ctx.read<uint32_t>(c);
 
     // Print partial results so we can see the output is correct (plus or minus some error due to BFP16 precision)
     std::cout << "Partial results: (note we are running under BFP16. It's going to be less accurate)\n";
@@ -211,13 +132,11 @@ int main(int argc, char** argv) {
     bfloat16* a_bf16 = reinterpret_cast<bfloat16*>(a_data.data());
     bfloat16* b_bf16 = reinterpret_cast<bfloat16*>(b_data.data());
     bfloat16* c_bf16 = reinterpret_cast<bfloat16*>(c_data.data());
-    for (int i = 0; i < n; i++) {
+    for (size_t i = 0; i < n; i++) {
         std::cout << "  " << static_cast<float>(a_bf16[i]) << " + " << static_cast<float>(b_bf16[i]) << " = "
                   << static_cast<float>(c_bf16[i]) << "\n";
     }
     std::cout << std::flush;
 
-    // Finally, we close the device.
-    mesh_device->close();
     return 0;
 }

--- a/tt_metal/programming_examples/custom_sfpi_add/CMakeLists.txt
+++ b/tt_metal/programming_examples/custom_sfpi_add/CMakeLists.txt
@@ -7,4 +7,9 @@ target_sources(metal_example_custom_sfpi_add PRIVATE custom_sfpi_add.cpp)
 if(NOT TARGET TT::Metalium)
     find_package(TT-Metalium REQUIRED)
 endif()
-target_link_libraries(metal_example_custom_sfpi_add PUBLIC TT::Metalium)
+target_link_libraries(
+    metal_example_custom_sfpi_add
+    PUBLIC
+        TT::Metalium
+        tt_metal_ez
+)

--- a/tt_metal/programming_examples/custom_sfpi_add/custom_sfpi_add.cpp
+++ b/tt_metal/programming_examples/custom_sfpi_add/custom_sfpi_add.cpp
@@ -2,22 +2,16 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <fmt/ostream.h>
-#include <tt-metalium/core_coord.hpp>
-#include <tt-metalium/host_api.hpp>
-#include <tt-metalium/device.hpp>
-#include <tt-metalium/distributed.hpp>
 #include <tt-metalium/bfloat16.hpp>
-#include <tt-metalium/tensor_accessor_args.hpp>
-#include <cstddef>
-#include <cstdint>
-#include <memory>
+#include <tt-metalium/experimental/ez/ez.hpp>
+
+#include <cmath>
 #include <random>
-#include <string_view>
 #include <vector>
-#include "tt-metalium/base_types.hpp"
 
 using namespace tt::tt_metal;
+using namespace tt::tt_metal::experimental::ez;
+
 #ifndef OVERRIDE_KERNEL_PREFIX
 #define OVERRIDE_KERNEL_PREFIX ""
 #endif
@@ -26,161 +20,87 @@ int main() {
     bool pass = true;
 
     try {
-        // Create a 1x1 mesh on device 0 (same API scales to multi-device meshes)
-        constexpr int device_id = 0;
-        auto mesh_device = distributed::MeshDevice::create_unit_mesh(device_id);
-
-        // Submit work via the mesh command queue: uploads/downloads and program execution.
-        distributed::MeshCommandQueue& cq = mesh_device->mesh_command_queue();
-
-        // Define some constants that will be used throughout the program.
-        // * Processing 64 tiles
-        // * Each tile is 32x32 elements
-        // * Each element is a bfloat16 (2 bytes)
+        // Processing 64 tiles, each 32x32 BFloat16 elements.
         constexpr uint32_t n_tiles = 64;
-        constexpr uint32_t elements_per_tile = tt::constants::TILE_WIDTH * tt::constants::TILE_HEIGHT;
-        constexpr uint32_t tile_size_bytes = sizeof(bfloat16) * elements_per_tile;
-        constexpr uint32_t dram_buffer_size = tile_size_bytes * n_tiles;
+        constexpr uint32_t elements = n_tiles * tt::constants::TILE_WIDTH * tt::constants::TILE_HEIGHT;
 
-        // Configure mesh buffers. Use single-tile page size so transfers operate tile-by-tile.
-        distributed::DeviceLocalBufferConfig dram_config{
-            .page_size = tile_size_bytes,    // Number of bytes when round-robin between banks
-            .buffer_type = BufferType::DRAM  // Type of buffer (DRAM or L1)
-        };
-        distributed::ReplicatedBufferConfig dram_buffer_config{
-            // Size per device (replicated across mesh). Since we are operating on a unit mesh this is the total size.
-            .size = dram_buffer_size};
+        // DeviceContext opens a single Tenstorrent device and provides helpers for buffer allocation,
+        // data transfers, and program execution.
+        DeviceContext ctx(0);
 
-        // Allocate the buffers (replicated across mesh; on unit mesh ⇒ single device allocation)
-        // src0, src1 are input buffers; dst is output buffer
-        auto src0_dram_buffer = distributed::MeshBuffer::create(dram_buffer_config, dram_config, mesh_device.get());
-        auto src1_dram_buffer = distributed::MeshBuffer::create(dram_buffer_config, dram_config, mesh_device.get());
-        auto dst_dram_buffer = distributed::MeshBuffer::create(dram_buffer_config, dram_config, mesh_device.get());
+        // Allocate DRAM-backed tile buffers: two inputs and one output.
+        auto src0 = ctx.dram_tile_buffer(n_tiles);
+        auto src1 = ctx.dram_tile_buffer(n_tiles);
+        auto dst = ctx.dram_tile_buffer(n_tiles);
 
-        // A program is a collection of kernels. Note that unlike OpenCL/CUDA where every core must run the
-        // same kernel at a given time. Metalium allows you to run different kernels on different cores
-        // simultaneously.
-        Program program = CreateProgram();
-
-        // A MeshWorkload is a collection of programs that will be executed on the mesh. Each workload is
-        // local to a single device. Here we create a workload for our single-device mesh.
-        distributed::MeshWorkload workload;
-        distributed::MeshCoordinateRange device_range = distributed::MeshCoordinateRange(mesh_device->shape());
-
-        // This example program will only use 1 Tensix core. So we set the core to {0, 0} (the most top-left core).
-        constexpr CoreCoord core = {0, 0};
-
-        // Create 3 circular buffers. Think of them as pipes moving data from one core to another.
-        // cb_src0 and cb_src1 are used to move data from the reader kernel to the compute kernel.
-        // cb_dst is used to move data from the compute kernel to the writer kernel.
-        // Each circular buffer is made up of 2 tiles. Thus when one tile is pushed and being used by the receiving end,
-        // the sending end can get the next piece of data ready to be pushed. Overlapping the operations leads to better
-        // performance. However, there is a trade off: the more tiles in a circular buffer, the more memory is used.
-        // Circular buffers are backed by L1(SRAM) memory and L1 is a precious resource. The hardware supports up to 32
-        // circular buffers and they all act the same.
-        constexpr uint32_t tiles_per_cb = 2;
-        tt::CBIndex src0_cb_index = tt::CBIndex::c_0;
-        CreateCircularBuffer(
-            program,
-            core,
-            CircularBufferConfig(
-                /*total_size=*/tiles_per_cb * tile_size_bytes,
-                /*data_format_spec=*/{{src0_cb_index, tt::DataFormat::Float16_b}})
-                .set_page_size(src0_cb_index, tile_size_bytes));
-        tt::CBIndex src1_cb_index = tt::CBIndex::c_1;
-        CreateCircularBuffer(program, core, CircularBufferConfig(
-            /*total_size=*/tiles_per_cb * tile_size_bytes,
-            /*data_format_spec=*/{{src1_cb_index, tt::DataFormat::Float16_b}})
-            .set_page_size(src1_cb_index, tile_size_bytes));
-        tt::CBIndex dst_cb_index = tt::CBIndex::c_16;
-        CreateCircularBuffer(program, core, CircularBufferConfig(
-            /*total_size=*/tiles_per_cb * tile_size_bytes,
-            /*data_format_spec=*/{{dst_cb_index, tt::DataFormat::Float16_b}})
-            .set_page_size(dst_cb_index, tile_size_bytes));
-
-        // Create the reader, writer and compute kernels. The kernels do the following:
-        // * Reader: Reads data from the DRAM buffer and pushes it into the circular buffer.
-        // * Compute: Waits for data to be available in the circular buffer, pops it, adds the two inputs together and pushes the result
-        //   into the output circular buffer.
-        // * Writer: Waits for data to be available in the output circular buffer, pops it and writes it back into DRAM.
-        // These kernels work together to form a pipeline. The reader reads data from the DRAM buffer and makes them available in the
-        // compute kernel. The compute kernel does math and pushes the result into the writer kernel. The writer kernel writes the result
-        // back to DRAM.
-        std::vector<uint32_t> reader_compile_time_args;
-        TensorAccessorArgs(*src0_dram_buffer->get_backing_buffer()).append_to(reader_compile_time_args);
-        TensorAccessorArgs(*src1_dram_buffer->get_backing_buffer()).append_to(reader_compile_time_args);
-        auto reader = CreateKernel(
-            program,
-            OVERRIDE_KERNEL_PREFIX "custom_sfpi_add/kernels/dataflow/read_tiles.cpp",
-            core,
-            DataMovementConfig{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default, .compile_args = reader_compile_time_args});
-        std::vector<uint32_t> writer_compile_time_args;
-        TensorAccessorArgs(*dst_dram_buffer->get_backing_buffer()).append_to(writer_compile_time_args);
-        auto writer = CreateKernel(
-            program,
-            OVERRIDE_KERNEL_PREFIX "custom_sfpi_add/kernels/dataflow/write_tile.cpp",
-            core,
-            DataMovementConfig{.processor = DataMovementProcessor::RISCV_1, .noc = NOC::RISCV_1_default, .compile_args = writer_compile_time_args});
-        auto compute = CreateKernel(
-            program,
-            OVERRIDE_KERNEL_PREFIX "custom_sfpi_add/kernels/compute/tiles_add.cpp",
-            core,
-            ComputeConfig{
-                .fp32_dest_acc_en = false, // We don't need the destination accumulator to be FP32 as input and output are BFP16
-            });
-
-        // Initialize the input buffers with random data. For this example, src0 is a random vector of bfloat16 values
+        // Initialize the input data: src0 is random values in [0,1), src1 is all -1.0.
         std::mt19937 rng(std::random_device{}());
-        std::uniform_real_distribution<float> distribution(0.0f, 1.0f);
-        std::vector<bfloat16> a_data(elements_per_tile * n_tiles);
+        std::uniform_real_distribution<float> dist(0.0f, 1.0f);
+        std::vector<bfloat16> a_data(elements);
         for (auto& val : a_data) {
-            val = bfloat16(distribution(rng));
+            val = bfloat16(dist(rng));
         }
-
-        // ... and src1 is a vector of bfloat16 values initialized to -1.0f.
         constexpr float val_to_add = -1.0f;
-        std::vector<bfloat16> b_data(elements_per_tile * n_tiles, bfloat16(val_to_add));
+        std::vector<bfloat16> b_data(elements, bfloat16(val_to_add));
 
-        // Upload the data from host to the device. The final argument is set to false. This indicates to Metalium that
-        // the upload is non-blocking, an upload will be launched, but the function will return immediately, before the
-        // upload is complete. This is useful for performance reasons, as it allows the host to continue while the
-        // upload is in progress. Note that the host is responsible for ensuring that the upload is complete before the
-        // memory holding the data is freed.
-        distributed::EnqueueWriteMeshBuffer(cq, src0_dram_buffer, a_data, /*blocking=*/false);
-        distributed::EnqueueWriteMeshBuffer(cq, src1_dram_buffer, b_data, /*blocking=*/false);
+        // Upload input data from host to device DRAM. ctx.write() is non-blocking by default: it
+        // enqueues the transfer and returns immediately. ctx.run() calls finish() to wait for all
+        // enqueued work (including writes) before reading results.
+        ctx.write(src0, a_data);
+        ctx.write(src1, b_data);
 
-        // Set the runtime arguments for the kernels. This also registers the kernels with the program.
-        SetRuntimeArgs(program, reader, core, {src0_dram_buffer->address(), src1_dram_buffer->address(), n_tiles});
-        SetRuntimeArgs(program, writer, core, {dst_dram_buffer->address(), n_tiles});
-        SetRuntimeArgs(program, compute, core, {n_tiles});
+        // Build the program with 3 kernels forming a reader → compute → writer pipeline:
+        //   Reader  → reads tiles from DRAM and pushes into circular buffers (cb_0, cb_1)
+        //   Compute → pops tiles from input CBs, adds them using custom SFPI, pushes to output CB (cb_16)
+        //   Writer  → pops tiles from output CB and writes back to DRAM
+        //
+        // Circular buffers act as pipes between kernels on the same core. They are backed by L1 (SRAM)
+        // memory. Each CB here uses the default of 2 tiles for double-buffering: while one tile is being
+        // consumed by the receiving kernel, the sending kernel can prepare the next tile. The hardware
+        // supports up to 32 circular buffers.
+        //
+        // Passing buffers (e.g. {src0, src1}) to .reader() automatically generates TensorAccessorArgs
+        // as compile-time arguments, telling the kernel how to access each buffer's layout.
+        constexpr CoreCoord core = {0, 0};
+        auto program =
+            ProgramBuilder(core)
+                .cb(tt::CBIndex::c_0)
+                .cb(tt::CBIndex::c_1)
+                .cb(tt::CBIndex::c_16)
+                .reader(
+                    OVERRIDE_KERNEL_PREFIX "custom_sfpi_add/kernels/dataflow/read_tiles.cpp",
+                    {src0, src1})
+                .runtime_args({src0->address(), src1->address(), n_tiles})
+                .done()
+                .compute(
+                    OVERRIDE_KERNEL_PREFIX "custom_sfpi_add/kernels/compute/tiles_add.cpp",
+                    // HiFi4 is the most accurate math fidelity mode. The ComputeConfig also supports
+                    // fp32_dest_acc_en (FP32 destination accumulator), which defaults to false here since
+                    // our inputs and outputs are BFloat16 and don't need FP32 accumulation precision.
+                    MathFidelity::HiFi4)
+                .runtime_args({n_tiles})
+                .done()
+                .writer(
+                    OVERRIDE_KERNEL_PREFIX "custom_sfpi_add/kernels/dataflow/write_tile.cpp",
+                    {dst})
+                .runtime_args({dst->address(), n_tiles})
+                .done()
+                .build();
 
-        // Add the program to the workload for the mesh.
-        workload.add_program(device_range, std::move(program));
-        // Enqueue the workload for execution on the mesh (non-blocking) and wait for completion before reading back.
-        distributed::EnqueueMeshWorkload(cq, workload, /*blocking=*/false);
-        distributed::Finish(cq);
-        // NOTE: The above is equivalent to a blocking enqueue of the workload.
+        // Execute the program and read the result back to the host.
+        ctx.run(std::move(program));
+        auto result = ctx.read<bfloat16>(dst);
 
-        // Read the result back from the shard at mesh coordinate {0,0}. Use blocking=true to wait for completion.
-        // The vector is automatically resized to fit the data.
-        std::vector<bfloat16> result_vec;
-        distributed::EnqueueReadMeshBuffer(cq, result_vec, dst_dram_buffer, /*blocking*/ true);
-
-        // Compare the result with the input. The result should be the input plus val_to_add.
-        constexpr float eps = 1e-2f; // loose tolerance because of the nature of bfloat16
-        TT_FATAL(result_vec.size() == a_data.size(), "Result vector size mismatch");
-        for (size_t i = 0; i < result_vec.size(); ++i) {
+        // Compare results with a loose tolerance due to BFloat16 precision.
+        constexpr float eps = 1e-2f;
+        TT_FATAL(result.size() == a_data.size(), "Result vector size mismatch");
+        for (size_t i = 0; i < result.size(); ++i) {
             const float expected = static_cast<float>(a_data[i]) + val_to_add;
-            const float actual = static_cast<float>(result_vec[i]);
+            const float actual = static_cast<float>(result[i]);
             if (std::abs(expected - actual) > eps) {
                 pass = false;
                 fmt::print(stderr, "Result mismatch at index {}: expected {}, got {}\n", i, expected, actual);
             }
-        }
-
-        // Close the device
-        if (!mesh_device->close()) {
-            pass = false;
         }
 
     } catch (const std::exception& e) {
@@ -194,6 +114,5 @@ int main() {
     } else {
         TT_THROW("Test Failed");
     }
-
     return 0;
 }

--- a/tt_metal/programming_examples/custom_sfpi_add/custom_sfpi_add.cpp
+++ b/tt_metal/programming_examples/custom_sfpi_add/custom_sfpi_add.cpp
@@ -71,7 +71,6 @@ int main() {
                     OVERRIDE_KERNEL_PREFIX "custom_sfpi_add/kernels/dataflow/read_tiles.cpp",
                     {src0, src1})
                 .runtime_args({src0->address(), src1->address(), n_tiles})
-                .done()
                 .compute(
                     OVERRIDE_KERNEL_PREFIX "custom_sfpi_add/kernels/compute/tiles_add.cpp",
                     // HiFi4 is the most accurate math fidelity mode. The ComputeConfig also supports
@@ -79,12 +78,10 @@ int main() {
                     // our inputs and outputs are BFloat16 and don't need FP32 accumulation precision.
                     MathFidelity::HiFi4)
                 .runtime_args({n_tiles})
-                .done()
                 .writer(
                     OVERRIDE_KERNEL_PREFIX "custom_sfpi_add/kernels/dataflow/write_tile.cpp",
                     {dst})
                 .runtime_args({dst->address(), n_tiles})
-                .done()
                 .build();
 
         // Execute the program and read the result back to the host.

--- a/tt_metal/programming_examples/custom_sfpi_smoothstep/CMakeLists.txt
+++ b/tt_metal/programming_examples/custom_sfpi_smoothstep/CMakeLists.txt
@@ -7,4 +7,9 @@ target_sources(metal_example_custom_smoothstep PRIVATE custom_sfpi_smoothstep.cp
 if(NOT TARGET TT::Metalium)
     find_package(TT-Metalium REQUIRED)
 endif()
-target_link_libraries(metal_example_custom_smoothstep PUBLIC TT::Metalium)
+target_link_libraries(
+    metal_example_custom_smoothstep
+    PUBLIC
+        TT::Metalium
+        tt_metal_ez
+)

--- a/tt_metal/programming_examples/custom_sfpi_smoothstep/custom_sfpi_smoothstep.cpp
+++ b/tt_metal/programming_examples/custom_sfpi_smoothstep/custom_sfpi_smoothstep.cpp
@@ -2,152 +2,87 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <fmt/ostream.h>
-#include <tt-metalium/core_coord.hpp>
-#include <tt-metalium/host_api.hpp>
-#include <tt-metalium/distributed.hpp>
 #include <tt-metalium/bfloat16.hpp>
-#include <tt-metalium/tensor_accessor_args.hpp>
-#include <cstddef>
-#include <cstdint>
-#include <memory>
+#include <tt-metalium/experimental/ez/ez.hpp>
+
+#include <algorithm>
+#include <cmath>
 #include <random>
 #include <vector>
 
 using namespace tt::tt_metal;
+using namespace tt::tt_metal::experimental::ez;
+
 #ifndef OVERRIDE_KERNEL_PREFIX
 #define OVERRIDE_KERNEL_PREFIX ""
 #endif
-int main(int /*argc*/, char** /*argv*/) {
+
+int main() {
     bool pass = true;
 
-    // clang-format off
     try {
-        // Create a 1x1 mesh on device 0 (same API scales to multi-device meshes)
-        constexpr int device_id = 0;
-        auto mesh_device = distributed::MeshDevice::create_unit_mesh(device_id);
-
-        // Submit work via the mesh command queue: uploads/downloads and program execution.
-        distributed::MeshCommandQueue& cq = mesh_device->mesh_command_queue();
-        // A program is a collection of kernels. Note that unlike OpenCL/CUDA where every core must run the
-        // same kernel at a given time. Metalium allows you to run different kernels on different cores
-        // simultaneously.
-        Program program = CreateProgram();
-
-        // This example program will only use 1 Tensix core. So we set the core to {0, 0}.
-        constexpr CoreCoord core = {0, 0};
-
-        // Define some constants that will be used throughout the program.
-        // * Processing 64 tiles
-        // * Each tile is 32x32 elements
-        // * Each element is a bfloat16 (2 bytes)
+        // Processing 64 tiles, each 32x32 BFloat16 elements.
         constexpr uint32_t n_tiles = 64;
-        constexpr uint32_t elements_per_tile = tt::constants::TILE_WIDTH * tt::constants::TILE_HEIGHT;
-        constexpr uint32_t tile_size_bytes = sizeof(bfloat16) * elements_per_tile;
-        constexpr uint32_t dram_buffer_size = tile_size_bytes * n_tiles;
+        constexpr uint32_t elements = n_tiles * tt::constants::TILE_WIDTH * tt::constants::TILE_HEIGHT;
 
-        // Configure mesh buffers. Use single-tile page size so transfers operate tile-by-tile.
-        distributed::DeviceLocalBufferConfig dram_config{
-            .page_size = tile_size_bytes,    // Number of bytes when round-robin between banks
-            .buffer_type = BufferType::DRAM  // Type of buffer (DRAM or L1)
-        };
-        distributed::ReplicatedBufferConfig dram_buffer_config{
-            // Size per device (replicated across mesh). Since we are operating on a unit mesh this is the total size.
-            .size = dram_buffer_size};
+        // DeviceContext opens a single Tenstorrent device and provides helpers for buffer allocation,
+        // data transfers, and program execution.
+        DeviceContext ctx(0);
 
-        // Allocate the buffers (replicated across mesh; on unit mesh ⇒ single device allocation)
-        // src0 is input buffer; dst is output buffer
-        auto src0_dram_buffer = distributed::MeshBuffer::create(dram_buffer_config, dram_config, mesh_device.get());
-        auto dst_dram_buffer = distributed::MeshBuffer::create(dram_buffer_config, dram_config, mesh_device.get());
+        // Allocate DRAM-backed tile buffers: one input and one output.
+        auto src0 = ctx.dram_tile_buffer(n_tiles);
+        auto dst = ctx.dram_tile_buffer(n_tiles);
 
-        // Initialize the input buffers with random data. For this example, src0 is a random vector of bfloat16 values
+        // Generate random input data in [0, 1).
         std::mt19937 rng(std::random_device{}());
-        std::uniform_real_distribution<float> distribution(0.0f, 1.0f);
-        std::vector<bfloat16> a_data(elements_per_tile * n_tiles);
-        for(auto& val : a_data) {
-            val = bfloat16(distribution(rng));
+        std::uniform_real_distribution<float> dist(0.0f, 1.0f);
+        std::vector<bfloat16> a_data(elements);
+        for (auto& val : a_data) {
+            val = bfloat16(dist(rng));
         }
 
+        // Upload input data from host to device DRAM.
+        ctx.write(src0, a_data);
 
-        // Upload the data from host to the device.
-        distributed::EnqueueWriteMeshBuffer(cq, src0_dram_buffer, a_data, false);
+        // Build the program with 3 kernels forming a reader → compute → writer pipeline:
+        //   Reader  → reads tiles from DRAM and pushes into circular buffer cb_0
+        //   Compute → pops tiles from cb_0, applies smoothstep via custom SFPI, pushes to cb_16
+        //   Writer  → pops tiles from cb_16 and writes back to DRAM
+        //
+        // Circular buffers act as pipes between kernels on the same core. They are backed by L1 (SRAM)
+        // memory. Each CB here uses the default of 2 tiles for double-buffering: while one tile is being
+        // consumed by the receiving kernel, the sending kernel can prepare the next tile.
+        //
+        // Passing buffers (e.g. {src0}) to .reader() automatically generates TensorAccessorArgs as
+        // compile-time arguments, telling the kernel how to access the buffer's layout.
+        constexpr CoreCoord core = {0, 0};
+        auto program =
+            ProgramBuilder(core)
+                .cb(tt::CBIndex::c_0)
+                .cb(tt::CBIndex::c_16)
+                .reader(
+                    OVERRIDE_KERNEL_PREFIX "custom_sfpi_smoothstep/kernels/dataflow/read_tiles.cpp",
+                    {src0})
+                .runtime_args({src0->address(), n_tiles})
+                .done()
+                .compute(OVERRIDE_KERNEL_PREFIX "custom_sfpi_smoothstep/kernels/compute/tiles_smoothstep.cpp")
+                .runtime_args({n_tiles})
+                .done()
+                .writer(
+                    OVERRIDE_KERNEL_PREFIX "custom_sfpi_smoothstep/kernels/dataflow/write_tile.cpp",
+                    {dst})
+                .runtime_args({dst->address(), n_tiles})
+                .done()
+                .build();
 
-        // Create 3 circular buffers. Think them like pipes moving data from one core to another. cb_src0 and cb_src1 are used to
-        // move data from the reader kernel to the compute kernel. cb_dst is used to move data from the compute kernel to the writer
-        // kernel. Each circular buffer is made up of 2 tiles. Thus when one tile is pushed and being used by the receiving end, the
-        // sending end can get the next piece of data ready to be pushed. Overlapping the operations. Leading to better performance.
-        // However there is a trade off, The more tiles in a circular buffer, the more memory is used. And Circular buffers are
-        // backed by L1(SRAM) memory and L1 is a precious resource.
-        // The hardware supports up to 32 circular buffers and they all act the same.
-        constexpr uint32_t tiles_per_cb = 2;
-        tt::CBIndex src0_cb_index = tt::CBIndex::c_0;
-        CreateCircularBuffer(program, core, CircularBufferConfig(
-            /*total_size=*/tiles_per_cb * tile_size_bytes,                    // The total size of the circular buffer in bytes
-            /*data_format_spec=*/{{src0_cb_index, tt::DataFormat::Float16_b}})// The circular buffer index and data format it'll hold
-            .set_page_size(src0_cb_index, tile_size_bytes));                  // Since we will be sending one tile at a time, we set
-                                                                              // the page size to the tile size (and thus
-                                                                              // total_size / page_size = tiles_per is the number of
-                                                                              // entries in the circular buffer)
-        tt::CBIndex dst_cb_index = tt::CBIndex::c_16;
-        CreateCircularBuffer(program, core, CircularBufferConfig(
-            /*total_size=*/tiles_per_cb * tile_size_bytes,
-            /*data_format_spec=*/{{dst_cb_index, tt::DataFormat::Float16_b}})
-            .set_page_size(dst_cb_index, tile_size_bytes));
+        // Execute the program and read the result back to the host.
+        ctx.run(std::move(program));
+        auto result = ctx.read<bfloat16>(dst);
 
-        // Create the reader, writer and compute kernels. The kernels do the following:
-        // * Reader: Reads data from the DRAM buffer and pushes it into the circular buffer.
-        // * Compute: Waits for data to be available in the circular buffer, pops it, adds the two inputs together and pushes the result
-        //   into the output circular buffer.
-        // * Writer: Waits for data to be available in the output circular buffer, pops it and writes it back into DRAM.
-        // These kernels work together to form a pipeline. The reader reads data from the DRAM buffer and makes them available in the
-        // compute kernel. The compute kernel does math and pushes the result into the writer kernel. The writer kernel writes the result
-        // back to DRAM.
-        std::vector<uint32_t> reader_compile_time_args;
-        TensorAccessorArgs(*src0_dram_buffer->get_backing_buffer()).append_to(reader_compile_time_args);
-        auto reader = CreateKernel(
-            program,
-            OVERRIDE_KERNEL_PREFIX "custom_sfpi_smoothstep/kernels/dataflow/read_tiles.cpp",
-            core,
-            DataMovementConfig{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default, .compile_args = reader_compile_time_args});
-        std::vector<uint32_t> writer_compile_time_args;
-        TensorAccessorArgs(*dst_dram_buffer->get_backing_buffer()).append_to(writer_compile_time_args);
-        auto writer = CreateKernel(
-            program,
-            OVERRIDE_KERNEL_PREFIX "custom_sfpi_smoothstep/kernels/dataflow/write_tile.cpp",
-            core,
-            DataMovementConfig{.processor = DataMovementProcessor::RISCV_1, .noc = NOC::RISCV_1_default, .compile_args = writer_compile_time_args});
-        auto compute = CreateKernel(
-            program,
-            OVERRIDE_KERNEL_PREFIX "custom_sfpi_smoothstep/kernels/compute/tiles_smoothstep.cpp",
-            core,
-            ComputeConfig{
-                .fp32_dest_acc_en = false, // We don't need the destination accumulator to be FP32 as input and output are BFP16
-            });
-
-        // Set the runtime arguments for the kernels. This also registers
-        // the kernels with the program.
-        SetRuntimeArgs(program, reader, core, {src0_dram_buffer->address(), n_tiles});
-        SetRuntimeArgs(program, writer, core, {dst_dram_buffer->address(), n_tiles});
-        SetRuntimeArgs(program, compute, core, {n_tiles});
-
-        // A MeshWorkload is a collection of programs that will be executed on the mesh. Each workload is
-        // local to a single device. Here we create a workload for our single-device mesh.
-        distributed::MeshWorkload workload;
-        distributed::MeshCoordinateRange device_range = distributed::MeshCoordinateRange(mesh_device->shape());
-        // Add the program to the workload for the mesh.
-        workload.add_program(device_range, std::move(program));
-        // Enqueue the workload for execution on the mesh (non-blocking) and wait for completion before reading back.
-        distributed::EnqueueMeshWorkload(cq, workload, /*blocking=*/false);
-        distributed::Finish(cq);
-        // NOTE: The above is equivalent to a blocking enqueue of the workload.
-
-        // Read the output buffer and compare it with the expected output.
-        std::vector<bfloat16> result_vec;
-        distributed::EnqueueReadMeshBuffer(cq, result_vec, dst_dram_buffer, /*blocking*/ true);
-
-        constexpr float eps = 1e-2f; // loose tolerance because of the nature of bfloat16
-        TT_FATAL(result_vec.size() == a_data.size(), "Result vector size mismatch");
-        for (size_t i = 0; i < result_vec.size(); ++i) {
+        // Compare with CPU-side smoothstep. Loose tolerance due to BFloat16 precision.
+        constexpr float eps = 1e-2f;
+        TT_FATAL(result.size() == a_data.size(), "Result vector size mismatch");
+        for (size_t i = 0; i < result.size(); ++i) {
             auto smoothstep = [](float edge0, float edge1, float x) {
                 // Scale, bias and saturate x to 0..1 range
                 x = (x - edge0) / (edge1 - edge0);
@@ -156,31 +91,23 @@ int main(int /*argc*/, char** /*argv*/) {
                 return x * x * (3 - 2 * x);
             };
             const float expected = smoothstep(0.0f, 1.0f, static_cast<float>(a_data[i]));
-            const float actual = static_cast<float>(result_vec[i]);
-
+            const float actual = static_cast<float>(result[i]);
             if (std::abs(expected - actual) > eps) {
                 pass = false;
                 fmt::print(stderr, "Result mismatch at index {}: expected {}, got {}\n", i, expected, actual);
             }
         }
 
-        // Finally, we close the device.
-        if (!mesh_device->close()) {
-            pass = false;
-        }
     } catch (const std::exception& e) {
         fmt::print(stderr, "Test failed with exception!\n");
         fmt::print(stderr, "{}\n", e.what());
-
         throw;
     }
-    // clang-format on
 
     if (pass) {
         fmt::print("Test Passed\n");
     } else {
         TT_THROW("Test Failed");
     }
-
     return 0;
 }

--- a/tt_metal/programming_examples/custom_sfpi_smoothstep/custom_sfpi_smoothstep.cpp
+++ b/tt_metal/programming_examples/custom_sfpi_smoothstep/custom_sfpi_smoothstep.cpp
@@ -64,15 +64,12 @@ int main() {
                     OVERRIDE_KERNEL_PREFIX "custom_sfpi_smoothstep/kernels/dataflow/read_tiles.cpp",
                     {src0})
                 .runtime_args({src0->address(), n_tiles})
-                .done()
                 .compute(OVERRIDE_KERNEL_PREFIX "custom_sfpi_smoothstep/kernels/compute/tiles_smoothstep.cpp")
                 .runtime_args({n_tiles})
-                .done()
                 .writer(
                     OVERRIDE_KERNEL_PREFIX "custom_sfpi_smoothstep/kernels/dataflow/write_tile.cpp",
                     {dst})
                 .runtime_args({dst->address(), n_tiles})
-                .done()
                 .build();
 
         // Execute the program and read the result back to the host.

--- a/tt_metal/programming_examples/eltwise_binary/CMakeLists.txt
+++ b/tt_metal/programming_examples/eltwise_binary/CMakeLists.txt
@@ -7,4 +7,9 @@ target_sources(metal_example_eltwise_binary PRIVATE eltwise_binary.cpp)
 if(NOT TARGET TT::Metalium)
     find_package(TT-Metalium REQUIRED)
 endif()
-target_link_libraries(metal_example_eltwise_binary PUBLIC TT::Metalium)
+target_link_libraries(
+    metal_example_eltwise_binary
+    PUBLIC
+        TT::Metalium
+        tt_metal_ez
+)

--- a/tt_metal/programming_examples/eltwise_binary/eltwise_binary.cpp
+++ b/tt_metal/programming_examples/eltwise_binary/eltwise_binary.cpp
@@ -79,15 +79,12 @@ int main(int /*argc*/, char** /*argv*/) {
                     OVERRIDE_KERNEL_PREFIX "eltwise_binary/kernels/dataflow/read_tiles.cpp",
                     {src0_dram_buffer, src1_dram_buffer})
                 .runtime_args({src0_dram_buffer->address(), src1_dram_buffer->address(), n_tiles})
-                .done()
                 .compute(OVERRIDE_KERNEL_PREFIX "eltwise_binary/kernels/compute/tiles_add.cpp")
                 .runtime_args({n_tiles})
-                .done()
                 .writer(
                     OVERRIDE_KERNEL_PREFIX "eltwise_binary/kernels/dataflow/write_tile.cpp",
                     {dst_dram_buffer})
                 .runtime_args({dst_dram_buffer->address(), n_tiles})
-                .done()
                 .build();
 
         // Execute the program synchronously (enqueue + wait for completion).

--- a/tt_metal/programming_examples/eltwise_binary/eltwise_binary.cpp
+++ b/tt_metal/programming_examples/eltwise_binary/eltwise_binary.cpp
@@ -2,42 +2,28 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <tt-metalium/core_coord.hpp>
-#include <tt-metalium/host_api.hpp>
-#include <tt-metalium/device.hpp>
 #include <tt-metalium/bfloat16.hpp>
-#include <tt-metalium/tensor_accessor_args.hpp>
-#include <tt-metalium/distributed.hpp>
+#include <tt-metalium/experimental/ez/ez.hpp>
+
 #include <cstddef>
 #include <cstdint>
-#include <memory>
 #include <random>
-#include <string_view>
 #include <vector>
-#include "tt-metalium/base_types.hpp"
 
 using namespace tt::tt_metal;
+using namespace tt::tt_metal::experimental::ez;
+
 #ifndef OVERRIDE_KERNEL_PREFIX
 #define OVERRIDE_KERNEL_PREFIX ""
 #endif
+
 int main(int /*argc*/, char** /*argv*/) {
     bool pass = true;
 
     // clang-format off
     try {
         // Create a 1x1 mesh on device 0. The same API scales to multi-device meshes.
-        constexpr int device_id = 0;
-        std::shared_ptr<distributed::MeshDevice> mesh_device = distributed::MeshDevice::create_unit_mesh(device_id);
-
-        // Submit work via a mesh command queue: data uploads/downloads and program execution.
-        distributed::MeshCommandQueue& cq = mesh_device->mesh_command_queue();
-        // A program is a collection of kernels. Note that unlike OpenCL/CUDA where every core must run the
-        // same kernel at a given time. Metalium allows you to run different kernels on different cores
-        // simultaneously.
-        distributed::MeshWorkload workload;
-        // Execute across this device range. Here it spans the whole mesh (1x1).
-        auto device_range = distributed::MeshCoordinateRange(mesh_device->shape());
-        Program program = CreateProgram();
+        DeviceContext ctx(0);
 
         // This example program will only use 1 Tensix core. So we set the core to {0, 0}.
         constexpr CoreCoord core = {0, 0};
@@ -48,21 +34,14 @@ int main(int /*argc*/, char** /*argv*/) {
         // * Each element is a bfloat16 (2 bytes)
         constexpr uint32_t n_tiles = 64;
         constexpr uint32_t elements_per_tile = tt::constants::TILE_WIDTH * tt::constants::TILE_HEIGHT;
-        constexpr uint32_t tile_size_bytes = sizeof(bfloat16) * elements_per_tile;
 
-        // Create 3 DRAM-backed mesh buffers: two inputs (src0, src1) and one output (dst).
-        distributed::DeviceLocalBufferConfig dram_config{
-            .page_size = tile_size_bytes, //The page size of the buffer in bytes. Unlike the `loopback` example, we
-                                          // need the page size to be the same as the tile size for a large portion of the NoC transfer APIs to work.
-            .buffer_type = BufferType::DRAM}; // This is a DRAM buffer.
-        distributed::ReplicatedBufferConfig buffer_config{
-            .size = n_tiles * tile_size_bytes // Total bytes per device (replicated across the mesh).
-        };
-
-        auto src0_dram_buffer = distributed::MeshBuffer::create(buffer_config, dram_config, mesh_device.get());
-        auto src1_dram_buffer = distributed::MeshBuffer::create(buffer_config, dram_config, mesh_device.get());
-        auto dst_dram_buffer = distributed::MeshBuffer::create(buffer_config, dram_config, mesh_device.get());
-        // Each handle represents a mesh-wide replicated buffer; on a unit mesh this is a single device allocation.
+        // Create 3 DRAM-backed tile buffers: two inputs (src0, src1) and one output (dst).
+        // dram_tile_buffer() computes page_size and total_size from tile count and data format.
+        // The page size is set to the tile size, which is required for a large portion of the NoC
+        // transfer APIs to work correctly (unlike raw L1 buffers where page size can differ).
+        auto src0_dram_buffer = ctx.dram_tile_buffer(n_tiles);
+        auto src1_dram_buffer = ctx.dram_tile_buffer(n_tiles);
+        auto dst_dram_buffer = ctx.dram_tile_buffer(n_tiles);
 
         // Initialize the input buffers with random data. For this example, src0 is a random vector of bfloat16 values
         std::mt19937 rng(std::random_device{}());
@@ -77,88 +56,45 @@ int main(int /*argc*/, char** /*argv*/) {
         std::vector<bfloat16> b_data(elements_per_tile * n_tiles, bfloat16(val_to_add));
 
         // Upload host vectors into the mesh buffers.
-        distributed::EnqueueWriteMeshBuffer(cq, src0_dram_buffer, a_data, false);
-        distributed::EnqueueWriteMeshBuffer(cq, src1_dram_buffer, b_data, false);
+        ctx.write(src0_dram_buffer, a_data);
+        ctx.write(src1_dram_buffer, b_data);
 
-        // Create 3 circular buffers. Think them like pipes moving data from one core to another. cb_src0 and cb_src1 are used to
-        // move data from the reader kernel to the compute kernel. cb_dst is used to move data from the compute kernel to the writer
-        // kernel. Each circular buffer is made up of 2 tiles. Thus when one tile is pushed and being used by the receiving end, the
-        // sending end can get the next piece of data ready to be pushed. Overlapping the operations. Leading to better performance.
-        // However there is a trade off, The more tiles in a circular buffer, the more memory is used. And Circular buffers are
-        // backed by L1(SRAM) memory and L1 is a precious resource.
-        // The hardware supports up to 32 circular buffers and they all act the same.
-        constexpr uint32_t tiles_per_cb = 2;
-        tt::CBIndex src0_cb_index = tt::CBIndex::c_0;
-        CreateCircularBuffer(program, core, CircularBufferConfig(
-            /*total_size=*/tiles_per_cb * tile_size_bytes,                    // The total size of the circular buffer in bytes
-            /*data_format_spec=*/{{src0_cb_index, tt::DataFormat::Float16_b}})// The circular buffer index and data format it'll hold
-            .set_page_size(src0_cb_index, tile_size_bytes));                  // Since we will be sending one tile at a time, we set
-                                                                              // the page size to the tile size (and thus
-                                                                              // total_size / page_size = tiles_per is the number of
-                                                                              // entries in the circular buffer)
-        tt::CBIndex src1_cb_index = tt::CBIndex::c_1;
-        CreateCircularBuffer(program, core, CircularBufferConfig(
-            /*total_size=*/tiles_per_cb * tile_size_bytes,
-            /*data_format_spec=*/{{src1_cb_index, tt::DataFormat::Float16_b}})
-            .set_page_size(src1_cb_index, tile_size_bytes));
-        tt::CBIndex dst_cb_index = tt::CBIndex::c_16;
-        CreateCircularBuffer(program, core, CircularBufferConfig(
-            /*total_size=*/tiles_per_cb * tile_size_bytes,
-            /*data_format_spec=*/{{dst_cb_index, tt::DataFormat::Float16_b}})
-            .set_page_size(dst_cb_index, tile_size_bytes));
+        // Build the program using ProgramBuilder. This creates:
+        // * 3 circular buffers (2 input, 1 output) — think of them as pipes moving data between kernels.
+        //   Each CB holds 2 tiles, allowing double-buffering for overlapped reads/computes/writes.
+        //   More tiles per CB can further hide latency, but there is a trade-off: circular buffers are
+        //   backed by L1 (SRAM) memory, which is a precious and limited resource on each Tensix core.
+        //   The hardware supports up to 32 circular buffers per core.
+        // * Reader kernel: Reads tiles from DRAM and pushes them into CBs c_0 and c_1.
+        //   Buffer references are automatically converted to TensorAccessorArgs compile-time args.
+        // * Compute kernel: Pops tiles from c_0 and c_1, adds them, pushes results into c_16.
+        //   HiFi4 is the most accurate math fidelity mode (alternatives: HiFi3, HiFi2, LoFi).
+        // * Writer kernel: Pops tiles from c_16 and writes them back to DRAM.
+        auto program =
+            ProgramBuilder(core)
+                .cb(tt::CBIndex::c_0)
+                .cb(tt::CBIndex::c_1)
+                .cb(tt::CBIndex::c_16)
+                .reader(
+                    OVERRIDE_KERNEL_PREFIX "eltwise_binary/kernels/dataflow/read_tiles.cpp",
+                    {src0_dram_buffer, src1_dram_buffer})
+                .runtime_args({src0_dram_buffer->address(), src1_dram_buffer->address(), n_tiles})
+                .done()
+                .compute(OVERRIDE_KERNEL_PREFIX "eltwise_binary/kernels/compute/tiles_add.cpp")
+                .runtime_args({n_tiles})
+                .done()
+                .writer(
+                    OVERRIDE_KERNEL_PREFIX "eltwise_binary/kernels/dataflow/write_tile.cpp",
+                    {dst_dram_buffer})
+                .runtime_args({dst_dram_buffer->address(), n_tiles})
+                .done()
+                .build();
 
-        // Create the reader, writer and compute kernels. The kernels do the following:
-        // * Reader: Reads data from the DRAM buffer and pushes it into the circular buffer.
-        // * Compute: Waits for data to be available in the circular buffer, pops it, adds the two inputs together and pushes the result
-        //   into the output circular buffer.
-        // * Writer: Waits for data to be available in the output circular buffer, pops it and writes it back into DRAM.
-        // These kernels work together to form a pipeline. The reader reads data from the DRAM buffer and makes them available in the
-        // compute kernel. The compute kernel does math and pushes the result into the writer kernel. The writer kernel writes the result
-        // back to DRAM.
-        std::vector<uint32_t> reader_compile_time_args;
-        TensorAccessorArgs(*src0_dram_buffer).append_to(reader_compile_time_args);
-        TensorAccessorArgs(*src1_dram_buffer).append_to(reader_compile_time_args);
-        auto reader = CreateKernel(
-            program,
-            OVERRIDE_KERNEL_PREFIX "eltwise_binary/kernels/dataflow/read_tiles.cpp",
-            core,
-            DataMovementConfig{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default, .compile_args = reader_compile_time_args});
-        std::vector<uint32_t> writer_compile_time_args;
-        TensorAccessorArgs(*dst_dram_buffer).append_to(writer_compile_time_args);
-        auto writer = CreateKernel(
-            program,
-            OVERRIDE_KERNEL_PREFIX "eltwise_binary/kernels/dataflow/write_tile.cpp",
-            core,
-            DataMovementConfig{.processor = DataMovementProcessor::RISCV_1, .noc = NOC::RISCV_1_default, .compile_args = writer_compile_time_args});
-        auto compute = CreateKernel(
-            program,
-            OVERRIDE_KERNEL_PREFIX "eltwise_binary/kernels/compute/tiles_add.cpp",
-            core,
-            ComputeConfig{.math_fidelity = MathFidelity::HiFi4});   // There's different math fidelity modes (for the tensor engine)
-                                                                // that trade off performance for accuracy. HiFi4 is the most accurate
-                                                                // mode. The other modes are HiFi3, HiFi2, HiFi1 and LoFi. The
-                                                                // difference between them is the number of bits used during computation.
+        // Execute the program synchronously (enqueue + wait for completion).
+        ctx.run(std::move(program));
 
-        // Set the runtime arguments for the kernels. This also registers
-        // the kernels with the program.
-        SetRuntimeArgs(program, reader, core, {src0_dram_buffer->address(), src1_dram_buffer->address(), n_tiles});
-        SetRuntimeArgs(program, writer, core, {dst_dram_buffer->address(), n_tiles});
-        SetRuntimeArgs(program, compute, core, {n_tiles});
-
-        // We have setup the program. Now we queue the kernel for execution. The final argument is set to false. This indicates
-        // to Metalium that the operation is non-blocking. The function is allowed to return upon the kernel being queued. We must
-        // ensure that the kernel is finished before we read the output buffer. This is done by calling distributed::Finish(cq) which waits until
-        // all operations in the command queue are finished. This is equivalent to calling EnqueueMeshWorkload(cq, program, true); telling
-        // Metalium to wait until the program is finished before returning.
-        workload.add_program(device_range, std::move(program));
-        distributed::EnqueueMeshWorkload(cq, workload, false);
-        distributed::Finish(cq);
-        // Equivalently:
-        // distributed::EnqueueMeshWorkload(cq, workload, true);
-
-        // Read the output buffer (from shard at mesh coordinate {0,0} on a unit mesh) and validate.
-        std::vector<bfloat16> result_vec;
-        distributed::EnqueueReadMeshBuffer(cq, result_vec, dst_dram_buffer, true);
+        // Read the output buffer and validate.
+        auto result_vec = ctx.read<bfloat16>(dst_dram_buffer);
 
         constexpr float eps = 1e-2f; // loose tolerance because of the nature of bfloat16
         TT_FATAL(result_vec.size() == a_data.size(), "Result vector size mismatch");
@@ -172,8 +108,7 @@ int main(int /*argc*/, char** /*argv*/) {
             }
         }
 
-        // Finally, we close the device.
-        pass &= mesh_device->close();
+        // DeviceContext closes the device automatically when it goes out of scope.
     } catch (const std::exception& e) {
         fmt::print(stderr, "Test failed with exception!\n");
         fmt::print(stderr, "{}\n", e.what());

--- a/tt_metal/programming_examples/eltwise_sfpu/CMakeLists.txt
+++ b/tt_metal/programming_examples/eltwise_sfpu/CMakeLists.txt
@@ -7,4 +7,9 @@ target_sources(metal_example_eltwise_sfpu PRIVATE eltwise_sfpu.cpp)
 if(NOT TARGET TT::Metalium)
     find_package(TT-Metalium REQUIRED)
 endif()
-target_link_libraries(metal_example_eltwise_sfpu PUBLIC TT::Metalium)
+target_link_libraries(
+    metal_example_eltwise_sfpu
+    PUBLIC
+        TT::Metalium
+        tt_metal_ez
+)

--- a/tt_metal/programming_examples/eltwise_sfpu/eltwise_sfpu.cpp
+++ b/tt_metal/programming_examples/eltwise_sfpu/eltwise_sfpu.cpp
@@ -4,108 +4,38 @@
 
 #include <cmath>
 #include <random>
-#include <tt-metalium/host_api.hpp>
+
 #include <tt-metalium/bfloat16.hpp>
-#include <tt-metalium/device.hpp>
-#include <tt-metalium/distributed.hpp>
-#include <tt-metalium/tensor_accessor_args.hpp>
+#include <tt-metalium/experimental/ez/ez.hpp>
 
 using namespace tt;
 using namespace tt::tt_metal;
+using namespace tt::tt_metal::experimental::ez;
 
 /*
  * 1. Host creates one vector of data.
- * 2. Device eltwise performs a unary SFPU operation on the data.
+ * 2. Device eltwise performs a unary SFPU operation (exp) on the data.
  * 3. Read result back and compare to golden.
  * */
 #ifndef OVERRIDE_KERNEL_PREFIX
 #define OVERRIDE_KERNEL_PREFIX ""
 #endif
+
 int main() {
     bool pass = true;
 
     try {
-        // Initialize the device (here we use the 1st device, but you can use any device)
-        constexpr int device_id = 0;
-        std::shared_ptr<distributed::MeshDevice> mesh_device = distributed::MeshDevice::create_unit_mesh(device_id);
-
-        // In Metalium, submitting operations to the device is done through a command queue. This includes
-        // uploading/downloading data to/from the device, and executing programs.
-        distributed::MeshCommandQueue& cq = mesh_device->mesh_command_queue();
-        // A program is a collection of kernels. Note that unlike OpenCL/CUDA where every core must run the
-        // same kernel at a given time. Metalium allows you to run different kernels on different cores
-        // simultaneously.
-        distributed::MeshWorkload workload;
-        distributed::MeshCoordinateRange device_range = distributed::MeshCoordinateRange(mesh_device->shape());
-        Program program = CreateProgram();
-
-        // This example program will only use 1 Tensix core. So we set the core to {0, 0}.
+        DeviceContext ctx(0);
         constexpr CoreCoord core = {0, 0};
 
         constexpr uint32_t n_tiles = 64;
         constexpr uint32_t elements_per_tile = tt::constants::TILE_WIDTH * tt::constants::TILE_HEIGHT;
-        constexpr uint32_t tile_size_bytes = sizeof(bfloat16) * elements_per_tile;
 
-        // Allocate DRAM buffers for the input and output data.
-        distributed::DeviceLocalBufferConfig dram_config{
-            .page_size = tile_size_bytes, .buffer_type = tt_metal::BufferType::DRAM};
-        distributed::ReplicatedBufferConfig buffer_config{
-            .size = tile_size_bytes * n_tiles};  // Replicated across the mesh (unit mesh ⇒ single device)
+        // Allocate DRAM tile buffers for the input and output.
+        auto src0_dram_buffer = ctx.dram_tile_buffer(n_tiles);
+        auto dst_dram_buffer = ctx.dram_tile_buffer(n_tiles);
 
-        // Allocate an input and output buffer on DRAM. We will perform a unary operation on the input buffer and write
-        // the result.
-        std::shared_ptr<distributed::MeshBuffer> src0_dram_buffer =
-            distributed::MeshBuffer::create(buffer_config, dram_config, mesh_device.get());
-        std::shared_ptr<distributed::MeshBuffer> dst_dram_buffer =
-            distributed::MeshBuffer::create(buffer_config, dram_config, mesh_device.get());
-        // Each handle refers to the per-device allocation; on a 1x1 mesh it's a single device buffer.
-
-        // Allocate 2 circular buffers for input and output.
-        constexpr uint32_t src0_cb_index = tt::CBIndex::c_0;
-        constexpr uint32_t num_input_tiles = 2;
-        CircularBufferConfig cb_src0_config =
-            CircularBufferConfig(num_input_tiles * tile_size_bytes, {{src0_cb_index, tt::DataFormat::Float16_b}})
-                .set_page_size(src0_cb_index, tile_size_bytes);
-        tt_metal::CreateCircularBuffer(program, core, cb_src0_config);
-
-        constexpr uint32_t output_cb_index = tt::CBIndex::c_16;
-        CircularBufferConfig cb_output_config =
-            CircularBufferConfig(num_input_tiles * tile_size_bytes, {{output_cb_index, tt::DataFormat::Float16_b}})
-                .set_page_size(output_cb_index, tile_size_bytes);
-        tt_metal::CreateCircularBuffer(program, core, cb_output_config);
-
-        // Create the 2 data movement kernels and the compute kernel.
-        std::vector<uint32_t> reader_compile_time_args;
-        TensorAccessorArgs(*src0_dram_buffer).append_to(reader_compile_time_args);
-        KernelHandle unary_reader_kernel_id = CreateKernel(
-            program,
-            OVERRIDE_KERNEL_PREFIX "eltwise_sfpu/kernels/dataflow/read_tile.cpp",
-            core,
-            DataMovementConfig{
-                .processor = DataMovementProcessor::RISCV_1,
-                .noc = NOC::RISCV_1_default,
-                .compile_args = reader_compile_time_args});
-
-        std::vector<uint32_t> writer_compile_time_args;
-        TensorAccessorArgs(*dst_dram_buffer).append_to(writer_compile_time_args);
-        KernelHandle unary_writer_kernel_id = CreateKernel(
-            program,
-            OVERRIDE_KERNEL_PREFIX "eltwise_sfpu/kernels/dataflow/write_tile.cpp",
-            core,
-            DataMovementConfig{
-                .processor = DataMovementProcessor::RISCV_0,
-                .noc = NOC::RISCV_0_default,
-                .compile_args = writer_compile_time_args});
-        KernelHandle eltwise_sfpu_kernel_id = CreateKernel(
-            program,
-            OVERRIDE_KERNEL_PREFIX "eltwise_sfpu/kernels/compute/eltwise_sfpu.cpp",
-            core,
-            ComputeConfig{
-                .math_fidelity = MathFidelity::HiFi4,
-                .math_approx_mode = false,
-            });
-
-        // Initialize the input data with random values and use as the input to the kernel.
+        // Initialize the input data with random values.
         std::mt19937 rng(std::random_device{}());
         std::uniform_real_distribution<float> dist(0.f, 1.0f);
         std::vector<bfloat16> src0_vec(n_tiles * elements_per_tile);
@@ -113,37 +43,32 @@ int main() {
             v = bfloat16(dist(rng));
         }
 
-        // Write the data on host to the input buffer on the device.
-        // setting blocking to false allows us to overlap the data movement and following host operations (
-        // setting kerenel args) in this case
-        distributed::EnqueueWriteMeshBuffer(cq, src0_dram_buffer, src0_vec, /*blocking=*/false);
+        ctx.write(src0_dram_buffer, src0_vec);
 
-        // Set up the runtime arguments for the kernels.
-        SetRuntimeArgs(program, eltwise_sfpu_kernel_id, core, {n_tiles});
-        SetRuntimeArgs(
-            program,
-            unary_reader_kernel_id,
-            core,
-            {
-                src0_dram_buffer->address(),
-                n_tiles,
-            });
+        // Build the program: reader → compute (exp) → writer.
+        auto program =
+            ProgramBuilder(core)
+                .cb(tt::CBIndex::c_0)
+                .cb(tt::CBIndex::c_16)
+                .reader(
+                    OVERRIDE_KERNEL_PREFIX "eltwise_sfpu/kernels/dataflow/read_tile.cpp",
+                    {src0_dram_buffer})
+                .runtime_args({src0_dram_buffer->address(), n_tiles})
+                .done()
+                .compute(OVERRIDE_KERNEL_PREFIX "eltwise_sfpu/kernels/compute/eltwise_sfpu.cpp")
+                .runtime_args({n_tiles})
+                .done()
+                .writer(
+                    OVERRIDE_KERNEL_PREFIX "eltwise_sfpu/kernels/dataflow/write_tile.cpp",
+                    {dst_dram_buffer})
+                .runtime_args({dst_dram_buffer->address(), n_tiles})
+                .done()
+                .build();
 
-        SetRuntimeArgs(program, unary_writer_kernel_id, core, {dst_dram_buffer->address(), n_tiles});
+        ctx.run(std::move(program));
+        auto result_vec = ctx.read<bfloat16>(dst_dram_buffer);
 
-        // Enqueue the program as a mesh workload (non-blocking) and wait for completion before reading results.
-        workload.add_program(device_range, std::move(program));
-        distributed::EnqueueMeshWorkload(cq, workload, false);
-        distributed::Finish(cq);
-
-        // Read the result (from shard at mesh coordinate {0,0} on a unit mesh) and compare to our expected result.
-        std::vector<bfloat16> result_vec;
-        distributed::EnqueueReadMeshBuffer(cq, result_vec, dst_dram_buffer, true);
-
-        // Compute the same thing on CPU for comparison
-
-        // Compare the result to the golden vector. Loose tolerance of 2e-2f because bfloat16 is not as accurate as 32
-        // bit float.
+        // Compare to golden (CPU exp).
         constexpr float eps = 5e-2f;
         for (uint32_t i = 0; i < result_vec.size(); ++i) {
             float expected = static_cast<float>(bfloat16(std::exp(static_cast<float>(src0_vec[i]))));
@@ -154,13 +79,9 @@ int main() {
             }
         }
 
-        // Finally, close the device.
-        pass &= mesh_device->close();
-
     } catch (const std::exception& e) {
         fmt::print(stderr, "Test failed with exception!\n");
         fmt::print(stderr, "{}\n", e.what());
-
         throw;
     }
 

--- a/tt_metal/programming_examples/eltwise_sfpu/eltwise_sfpu.cpp
+++ b/tt_metal/programming_examples/eltwise_sfpu/eltwise_sfpu.cpp
@@ -54,15 +54,12 @@ int main() {
                     OVERRIDE_KERNEL_PREFIX "eltwise_sfpu/kernels/dataflow/read_tile.cpp",
                     {src0_dram_buffer})
                 .runtime_args({src0_dram_buffer->address(), n_tiles})
-                .done()
                 .compute(OVERRIDE_KERNEL_PREFIX "eltwise_sfpu/kernels/compute/eltwise_sfpu.cpp")
                 .runtime_args({n_tiles})
-                .done()
                 .writer(
                     OVERRIDE_KERNEL_PREFIX "eltwise_sfpu/kernels/dataflow/write_tile.cpp",
                     {dst_dram_buffer})
                 .runtime_args({dst_dram_buffer->address(), n_tiles})
-                .done()
                 .build();
 
         ctx.run(std::move(program));

--- a/tt_metal/programming_examples/hello_world_compute_kernel/CMakeLists.txt
+++ b/tt_metal/programming_examples/hello_world_compute_kernel/CMakeLists.txt
@@ -7,4 +7,9 @@ target_sources(metal_example_hello_world_compute_kernel PRIVATE hello_world_comp
 if(NOT TARGET TT::Metalium)
     find_package(TT-Metalium REQUIRED)
 endif()
-target_link_libraries(metal_example_hello_world_compute_kernel PUBLIC TT::Metalium)
+target_link_libraries(
+    metal_example_hello_world_compute_kernel
+    PUBLIC
+        TT::Metalium
+        tt_metal_ez
+)

--- a/tt_metal/programming_examples/hello_world_compute_kernel/hello_world_compute_kernel.cpp
+++ b/tt_metal/programming_examples/hello_world_compute_kernel/hello_world_compute_kernel.cpp
@@ -2,13 +2,10 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <tt-metalium/host_api.hpp>
-#include <tt-metalium/device.hpp>
-#include <tt-metalium/distributed.hpp>
-#include "tt-metalium/kernel_types.hpp"
+#include <tt-metalium/experimental/ez/ez.hpp>
 
-using namespace tt;
 using namespace tt::tt_metal;
+using namespace tt::tt_metal::experimental::ez;
 
 // A bit of a hack to handle packaged examples but also work inside the Metalium git repo.
 #ifndef OVERRIDE_KERNEL_PREFIX
@@ -24,48 +21,32 @@ int main() {
         fmt::print("WARNING: For example, export TT_METAL_DPRINT_CORES=0,0\n");
     }
 
-    // Initialize mesh device, command queue, workload, device range, and program
-    constexpr CoreCoord core = {0, 0};
-    int device_id = 0;
-    std::shared_ptr<distributed::MeshDevice> mesh_device =
-        distributed::MeshDevice::create_unit_mesh(device_id);  // 1x1 mesh
-    distributed::MeshCommandQueue& cq = mesh_device->mesh_command_queue();
-    distributed::MeshWorkload workload;
-    distributed::MeshCoordinateRange device_range = distributed::MeshCoordinateRange(mesh_device->shape());
-    Program program = CreateProgram();
-
-    // Configure and create the kernel
-    // This kernel does not perform any computation, it simply prints a message to show the compute cores running.
+    // Create a single-device context and run a trivial compute kernel on core {0, 0}.
     // Within a Tensix, 3 RISC-V cores run collaboratively to perform compute tasks. These are the UNPACK, MATH,
     // and PACK cores.
     // Please view the respective documentation for more information:
     // https://github.com/tenstorrent/tt-metal/blob/main/METALIUM_GUIDE.md#tenstorrent-architecture-overview
-    KernelHandle void_compute_kernel_id = CreateKernel(
-        program,
-        OVERRIDE_KERNEL_PREFIX "hello_world_compute_kernel/kernels/compute/void_compute_kernel.cpp",
-        core,
-        ComputeConfig{});
+    DeviceContext ctx(0);
 
-    // Configure program and enqueue it as a mesh workload (non-blocking)
-    SetRuntimeArgs(program, void_compute_kernel_id, core, {});
-    workload.add_program(device_range, std::move(program));
-    distributed::EnqueueMeshWorkload(cq, workload, false);
+    auto program = ProgramBuilder(CoreCoord{0, 0})
+                       .compute(OVERRIDE_KERNEL_PREFIX "hello_world_compute_kernel/kernels/compute/void_compute_kernel.cpp")
+                       .done()
+                       .build();
+
     fmt::print("Hello, Core (0, 0) on Device 0, I am sending you a compute kernel. Standby awaiting communication.\n");
+    ctx.run(std::move(program));
 
-    // Wait Until MeshWorkload Finishes. The kernel will print the following messages:
+    // The kernel will print the following messages (with TT_METAL_DPRINT_CORES=0,0):
     // 0:(x=0,y=0):TR0: Hello, I am the UNPACK core running the compute kernel
     // 0:(x=0,y=0):TR1: Hello, I am the MATH core running the compute kernel
     // 0:(x=0,y=0):TR2: Hello, I am the PACK core running the compute kernel
+    //
     // Deconstructing the output:
     // 0: - Device ID
     // (x=0,y=0): - Tensix core coordinates (so the 3 compute cores are all on the same core {0, 0})
     // TR0: Compute core 0 (UNPACK)
     // TR1: Compute core 1 (MATH)
     // TR2: Compute core 2 (PACK)
-
-    // Wait for the workload to finish execution, then close the mesh device.
-    distributed::Finish(cq);
     printf("Thank you, Core {0, 0} on Device 0, for the completed task.\n");
-    mesh_device->close();
     return 0;
 }

--- a/tt_metal/programming_examples/hello_world_compute_kernel/hello_world_compute_kernel.cpp
+++ b/tt_metal/programming_examples/hello_world_compute_kernel/hello_world_compute_kernel.cpp
@@ -30,7 +30,6 @@ int main() {
 
     auto program = ProgramBuilder(CoreCoord{0, 0})
                        .compute(OVERRIDE_KERNEL_PREFIX "hello_world_compute_kernel/kernels/compute/void_compute_kernel.cpp")
-                       .done()
                        .build();
 
     fmt::print("Hello, Core (0, 0) on Device 0, I am sending you a compute kernel. Standby awaiting communication.\n");

--- a/tt_metal/programming_examples/hello_world_datamovement_kernel/CMakeLists.txt
+++ b/tt_metal/programming_examples/hello_world_datamovement_kernel/CMakeLists.txt
@@ -7,4 +7,9 @@ target_sources(metal_example_hello_world_datamovement_kernel PRIVATE hello_world
 if(NOT TARGET TT::Metalium)
     find_package(TT-Metalium REQUIRED)
 endif()
-target_link_libraries(metal_example_hello_world_datamovement_kernel PUBLIC TT::Metalium)
+target_link_libraries(
+    metal_example_hello_world_datamovement_kernel
+    PUBLIC
+        TT::Metalium
+        tt_metal_ez
+)

--- a/tt_metal/programming_examples/hello_world_datamovement_kernel/hello_world_datamovement_kernel.cpp
+++ b/tt_metal/programming_examples/hello_world_datamovement_kernel/hello_world_datamovement_kernel.cpp
@@ -29,9 +29,7 @@ int main() {
     auto program =
         ProgramBuilder(CoreCoord{0, 0})
             .reader(OVERRIDE_KERNEL_PREFIX "hello_world_datamovement_kernel/kernels/dataflow/void_dataflow_kernel.cpp")
-            .done()
             .writer(OVERRIDE_KERNEL_PREFIX "hello_world_datamovement_kernel/kernels/dataflow/void_dataflow_kernel.cpp")
-            .done()
             .build();
 
     fmt::print("Hello, Core (0, 0) on Device 0, Please start execution. I will standby for your communication.\n");

--- a/tt_metal/programming_examples/hello_world_datamovement_kernel/hello_world_datamovement_kernel.cpp
+++ b/tt_metal/programming_examples/hello_world_datamovement_kernel/hello_world_datamovement_kernel.cpp
@@ -2,64 +2,43 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <tt-metalium/host_api.hpp>
-#include <tt-metalium/device.hpp>
-#include <tt-metalium/distributed.hpp>
+#include <tt-metalium/experimental/ez/ez.hpp>
+
+using namespace tt::tt_metal;
+using namespace tt::tt_metal::experimental::ez;
 
 #ifndef OVERRIDE_KERNEL_PREFIX
 #define OVERRIDE_KERNEL_PREFIX ""
 #endif
 
 int main() {
-    using namespace tt;
-    using namespace tt::tt_metal;
-
     char* env_var = std::getenv("TT_METAL_DPRINT_CORES");
     if (env_var == nullptr) {
-        std::cerr << "WARNING: Please set the environment variable TT_METAL_DPRINT_CORES to 0,0 to see the output of "
-                     "the Data Movement kernels."
-                  << std::endl;
-        std::cerr << "WARNING: For example, export TT_METAL_DPRINT_CORES=0,0" << std::endl;
+        fmt::print(
+            "WARNING: Please set the environment variable TT_METAL_DPRINT_CORES to 0,0 to see the output of the Data "
+            "Movement kernels.\n");
+        fmt::print("WARNING: For example, export TT_METAL_DPRINT_CORES=0,0\n");
     }
 
-    // Initialize mesh device (1x1), command queue, workload, device range, and program.
-    // We are going to use the first device (0) and the first core (0, 0) on the device.
-    constexpr CoreCoord core = {0, 0};
-    std::shared_ptr<distributed::MeshDevice> mesh_device = distributed::MeshDevice::create_unit_mesh(0);
-    // Command queue lets us submit work (execute programs and read/write buffers) to the device.
-    distributed::MeshCommandQueue& cq = mesh_device->mesh_command_queue();
-    // Prepare a workload and a device coordinate range that spans the mesh.
-    distributed::MeshWorkload workload;
-    distributed::MeshCoordinateRange device_range = distributed::MeshCoordinateRange(mesh_device->shape());
-    Program program = CreateProgram();
-
-    // Configure and create Data Movement kernels
+    // Create a single-device context and run two data movement kernels on core {0, 0}.
     // There are 2 Data Movement cores per Tensix. In applications one is usually used for reading data from DRAM and
     // the other for writing data. However for demonstration purposes, we will create 2 Data Movement kernels that
-    // simply prints a message to show them running at the same time.
-    KernelHandle data_movement_kernel_0 = CreateKernel(
-        program,
-        OVERRIDE_KERNEL_PREFIX "hello_world_datamovement_kernel/kernels/dataflow/void_dataflow_kernel.cpp",
-        core,
-        DataMovementConfig{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default});
+    // simply print a message to show them running at the same time.
+    DeviceContext ctx(0);
 
-    KernelHandle data_movement_kernel_1 = CreateKernel(
-        program,
-        OVERRIDE_KERNEL_PREFIX "hello_world_datamovement_kernel/kernels/dataflow/void_dataflow_kernel.cpp",
-        core,
-        DataMovementConfig{.processor = DataMovementProcessor::RISCV_1, .noc = NOC::RISCV_1_default});
+    auto program =
+        ProgramBuilder(CoreCoord{0, 0})
+            .reader(OVERRIDE_KERNEL_PREFIX "hello_world_datamovement_kernel/kernels/dataflow/void_dataflow_kernel.cpp")
+            .done()
+            .writer(OVERRIDE_KERNEL_PREFIX "hello_world_datamovement_kernel/kernels/dataflow/void_dataflow_kernel.cpp")
+            .done()
+            .build();
 
-    // Set Runtime Arguments for the Data Movement Kernels (none in this case and execute the program)
-    SetRuntimeArgs(program, data_movement_kernel_0, core, {});
-    SetRuntimeArgs(program, data_movement_kernel_1, core, {});
-    std::cout << "Hello, Core {0, 0} on Device 0, Please start execution. I will standby for your communication."
-              << std::endl;
+    fmt::print("Hello, Core (0, 0) on Device 0, Please start execution. I will standby for your communication.\n");
+    ctx.run(std::move(program));
 
-    workload.add_program(device_range, std::move(program));
-    distributed::EnqueueMeshWorkload(cq, workload, false);
-    distributed::Finish(cq);
-    // Wait Until MeshWorkload Finishes. The program should print the following (NC and BR is Data movement core 1 and 0
-    // respectively):
+    // The program should print the following (with TT_METAL_DPRINT_CORES=0,0):
+    // NC and BR are Data Movement core 1 and 0 respectively.
     //
     // 0:(x=0,y=0):NC: My logical coordinates are 0,0
     // 0:(x=0,y=0):NC: Hello, host, I am running a void data movement kernel on Data Movement core 1.
@@ -68,11 +47,10 @@ int main() {
     //
     // Deconstructing the output:
     // 0: - Device ID
-    // (x=0,y=0): - Tensix core coordinates (so both Data Movement cores are on the same Tensix core
+    // (x=0,y=0): - Tensix core coordinates (so both Data Movement cores are on the same Tensix core)
     // NC: - Data Movement core 1
     // BR: - Data Movement core 0
 
-    std::cout << "Thank you, Core {0, 0} on Device 0, for the completed task." << std::endl;
-    mesh_device->close();
+    fmt::print("Thank you, Core (0, 0) on Device 0, for the completed task.\n");
     return 0;
 }

--- a/tt_metal/programming_examples/hello_world_datatypes_kernel/CMakeLists.txt
+++ b/tt_metal/programming_examples/hello_world_datatypes_kernel/CMakeLists.txt
@@ -7,4 +7,9 @@ target_sources(metal_example_hello_world_datatypes_kernel PRIVATE hello_world_da
 if(NOT TARGET TT::Metalium)
     find_package(TT-Metalium REQUIRED)
 endif()
-target_link_libraries(metal_example_hello_world_datatypes_kernel PUBLIC TT::Metalium)
+target_link_libraries(
+    metal_example_hello_world_datatypes_kernel
+    PUBLIC
+        TT::Metalium
+        tt_metal_ez
+)

--- a/tt_metal/programming_examples/hello_world_datatypes_kernel/hello_world_datatypes_kernel.cpp
+++ b/tt_metal/programming_examples/hello_world_datatypes_kernel/hello_world_datatypes_kernel.cpp
@@ -2,12 +2,10 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <tt-metalium/host_api.hpp>
-#include <tt-metalium/device.hpp>
-#include <tt-metalium/distributed.hpp>
+#include <tt-metalium/experimental/ez/ez.hpp>
 
-using namespace tt;
 using namespace tt::tt_metal;
+using namespace tt::tt_metal::experimental::ez;
 
 #ifndef OVERRIDE_KERNEL_PREFIX
 #define OVERRIDE_KERNEL_PREFIX ""
@@ -28,53 +26,32 @@ int main() {
         fmt::print("WARNING: For example, export TT_METAL_DPRINT_CORES=0,0\n");
     }
 
-    // Initialize mesh device, command queue, workload, device range, and program
-    constexpr CoreCoord core = {0, 0};
-    std::shared_ptr<distributed::MeshDevice> mesh_device = distributed::MeshDevice::create_unit_mesh(0);
-    distributed::MeshCommandQueue& cq = mesh_device->mesh_command_queue();
-    distributed::MeshWorkload workload;
-    distributed::MeshCoordinateRange device_range = distributed::MeshCoordinateRange(mesh_device->shape());
-    Program program = CreateProgram();
+    DeviceContext ctx(0);
 
-    // Define and create a DRAM-backed replicated mesh buffer with float data type
-    // ReplicatedBufferConfig allocates an identical buffer per device in the mesh (unit mesh ⇒ single device)
+    // Create a small DRAM buffer to hold a single float value.
     constexpr uint32_t buffer_size = 2 * 1024;
-    distributed::DeviceLocalBufferConfig dram_config{
-        .page_size = buffer_size, .buffer_type = tt_metal::BufferType::DRAM};
-    distributed::ReplicatedBufferConfig buffer_config{.size = buffer_size};
-    std::shared_ptr<distributed::MeshBuffer> dram_buffer =
-        distributed::MeshBuffer::create(buffer_config, dram_config, mesh_device.get());
+    auto dram_buffer = ctx.dram_buffer(buffer_size, buffer_size);
 
-    // Configure and create an L1 circular buffer (to move data from DRAM to L1)
-    // Set page size equal to buffer_size so one page equals one transfer unit
-    constexpr uint32_t src0_cb_index = CBIndex::c_0;
-    CircularBufferConfig cb_src0_config =
-        CircularBufferConfig(buffer_size, {{src0_cb_index, tt::DataFormat::Float16_b}})
-            .set_page_size(src0_cb_index, buffer_size);
-    tt_metal::CreateCircularBuffer(program, core, cb_src0_config);
-
-    // Configure and create the kernel
-    KernelHandle data_reader_kernel_id = CreateKernel(
-        program,
-        OVERRIDE_KERNEL_PREFIX "hello_world_datatypes_kernel/kernels/dataflow/float_dataflow_kernel.cpp",
-        core,
-        DataMovementConfig{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default});
-
-    // Initialize Float data on host and upload to the DRAM buffer (non-blocking upload)
+    // Upload a float value to the device.
     std::vector<float> init_data = {1.23};
-    distributed::EnqueueWriteMeshBuffer(cq, dram_buffer, init_data, false);
+    ctx.write(dram_buffer, init_data);
 
-    // Set runtime args, add program to mesh workload, and enqueue (non-blocking)
-    SetRuntimeArgs(program, data_reader_kernel_id, core, {dram_buffer->address()});
-    workload.add_program(device_range, std::move(program));
-    distributed::EnqueueMeshWorkload(cq, workload, false);
+    // Build the program: a data movement kernel with a CB to transfer data from DRAM to L1.
+    // We use .kernel() with explicit DataMovementConfig to keep the kernel on RISCV_0 (Data Movement
+    // processor 0 / "BR"), matching the original example. (.reader() would assign RISCV_1 instead.)
+    auto program =
+        ProgramBuilder(CoreCoord{0, 0})
+            .cb(tt::CBIndex::c_0, tt::DataFormat::Float16_b, /*num_tiles=*/1, /*page_size=*/buffer_size)
+            .kernel(
+                OVERRIDE_KERNEL_PREFIX "hello_world_datatypes_kernel/kernels/dataflow/float_dataflow_kernel.cpp",
+                DataMovementConfig{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default})
+            .runtime_args({dram_buffer->address()})
+            .done()
+            .build();
 
-    fmt::print("Hello, Core {{0, 0}} on Device 0, please handle the data.\n");
-
-    // Wait for completion and close the mesh device
-    distributed::Finish(cq);
-    fmt::print("Thank you, Core {{0, 0}} on Device 0, for handling the data.\n");
-    mesh_device->close();
+    fmt::print("Hello, Core (0, 0) on Device 0, please handle the data.\n");
+    ctx.run(std::move(program));
+    fmt::print("Thank you, Core (0, 0) on Device 0, for handling the data.\n");
 
     return 0;
 }

--- a/tt_metal/programming_examples/hello_world_datatypes_kernel/hello_world_datatypes_kernel.cpp
+++ b/tt_metal/programming_examples/hello_world_datatypes_kernel/hello_world_datatypes_kernel.cpp
@@ -46,7 +46,6 @@ int main() {
                 OVERRIDE_KERNEL_PREFIX "hello_world_datatypes_kernel/kernels/dataflow/float_dataflow_kernel.cpp",
                 DataMovementConfig{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default})
             .runtime_args({dram_buffer->address()})
-            .done()
             .build();
 
     fmt::print("Hello, Core (0, 0) on Device 0, please handle the data.\n");

--- a/tt_metal/programming_examples/loopback/CMakeLists.txt
+++ b/tt_metal/programming_examples/loopback/CMakeLists.txt
@@ -7,4 +7,9 @@ target_sources(metal_example_loopback PRIVATE loopback.cpp)
 if(NOT TARGET TT::Metalium)
     find_package(TT-Metalium REQUIRED)
 endif()
-target_link_libraries(metal_example_loopback PUBLIC TT::Metalium)
+target_link_libraries(
+    metal_example_loopback
+    PUBLIC
+        TT::Metalium
+        tt_metal_ez
+)

--- a/tt_metal/programming_examples/loopback/loopback.cpp
+++ b/tt_metal/programming_examples/loopback/loopback.cpp
@@ -66,7 +66,6 @@ int main() {
                     {input_dram_buffer, output_dram_buffer})
                 .runtime_args({l1_buffer->address(), input_dram_buffer->address(),
                                output_dram_buffer->address(), num_tiles})
-                .done()
                 .build();
 
         ctx.run(std::move(program));

--- a/tt_metal/programming_examples/loopback/loopback.cpp
+++ b/tt_metal/programming_examples/loopback/loopback.cpp
@@ -2,95 +2,48 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <fmt/ostream.h>
-#include <cstdint>
-#include <random>
-#include <tt-metalium/host_api.hpp>
-#include <tt-metalium/device.hpp>
-#include <tt-metalium/distributed.hpp>
-#include <tt-metalium/bfloat16.hpp>
-#include <tt-metalium/tensor_accessor_args.hpp>
-
 // This example demonstrates a simple data copy from DRAM into L1(SRAM) and to another place in DRAM.
+// A single data movement kernel reads tiles from input DRAM, stages through L1, and writes to output DRAM.
+//
 // The general flow is as follows:
-// 1. Initialize the device
-// 2. Create the data movement kernel (fancy word of specialized subroutines) on core {0, 0}
-//    that will perform the copy
-// 3. Create the buffer (both on DRAM And L1) and fill DRAM with data. Point the kernel to the buffers.
-// 4. Execute the kernel
-// 5. Read the data back from the buffer
-// 6. Validate the data
-// 7. Clean up the device. Exit
+// 1. Open a device (DeviceContext handles initialization and teardown)
+// 2. Allocate DRAM and L1 buffers for input, output, and staging
+// 3. Fill the input DRAM buffer with random data
+// 4. Create a data movement kernel on core {0, 0} to copy DRAM→L1→DRAM
+// 5. Execute the program
+// 6. Read back the output and validate against the input
+// 7. DeviceContext automatically cleans up the device on scope exit
+
+#include <random>
+#include <vector>
+
+#include <tt-metalium/bfloat16.hpp>
+#include <tt-metalium/experimental/ez/ez.hpp>
 
 using namespace tt::tt_metal;
+using namespace tt::tt_metal::experimental::ez;
+
 #ifndef OVERRIDE_KERNEL_PREFIX
 #define OVERRIDE_KERNEL_PREFIX ""
 #endif
+
 int main() {
     bool pass = true;
 
     try {
-        // Create a 1x1 mesh on device 0 (same API scales to multi-device meshes)
-        constexpr int device_id = 0;
-        std::shared_ptr<distributed::MeshDevice> mesh_device = distributed::MeshDevice::create_unit_mesh(device_id);
+        DeviceContext ctx(0);
+        constexpr CoreCoord core = {0, 0};
 
-        // Submit work via the mesh command queue: uploads/downloads and program execution.
-        distributed::MeshCommandQueue& cq = mesh_device->mesh_command_queue();
-
-        // Data on Tensix is stored in tiles. A tile is a 2D array of (usually) 32x32 values. And the Tensix uses
-        // BFloat16 as the most well supported data type. Thus the tile size is 32x32x2 = 2048 bytes.
         constexpr uint32_t num_tiles = 50;
         constexpr uint32_t elements_per_tile = tt::constants::TILE_WIDTH * tt::constants::TILE_HEIGHT;
         constexpr uint32_t tile_size_bytes = sizeof(bfloat16) * elements_per_tile;
-        constexpr uint32_t dram_buffer_size = tile_size_bytes * num_tiles;
 
-        // Configure mesh buffers. Use single-tile page size so transfers operate tile-by-tile.
-        distributed::DeviceLocalBufferConfig dram_config{
-            .page_size = tile_size_bytes,  // Number of bytes when round-robin between banks. Usually this is the same
-                                           // as the tile size for efficiency.
-            .buffer_type = tt::tt_metal::BufferType::DRAM};  // Type of buffer (DRAM or L1(SRAM))
-        distributed::DeviceLocalBufferConfig l1_config{
-            .page_size = tile_size_bytes, .buffer_type = tt::tt_metal::BufferType::L1};  // This time we allocate on L1
+        // Allocate DRAM buffers for input/output and an L1 scratch buffer for staging.
+        auto input_dram_buffer = ctx.dram_tile_buffer(num_tiles);
+        auto output_dram_buffer = ctx.dram_tile_buffer(num_tiles);
+        auto l1_buffer = ctx.l1_buffer(tile_size_bytes, tile_size_bytes);
 
-        distributed::ReplicatedBufferConfig dram_buffer_config{
-            .size = dram_buffer_size};  // Size per device (replicated across mesh). Since we are operating on a unit
-                                        // mesh this is the total size.
-        distributed::ReplicatedBufferConfig l1_buffer_config{.size = tile_size_bytes};
-
-        // Allocate the buffers (replicated across mesh; on unit mesh ⇒ single device allocation)
-        auto l1_buffer = distributed::MeshBuffer::create(l1_buffer_config, l1_config, mesh_device.get());
-        auto input_dram_buffer = distributed::MeshBuffer::create(dram_buffer_config, dram_config, mesh_device.get());
-        auto output_dram_buffer = distributed::MeshBuffer::create(dram_buffer_config, dram_config, mesh_device.get());
-
-        // A program is a collection of kernels. Note that unlike OpenCL/CUDA where every core must run the
-        // same kernel at a given time. Metalium allows you to run different kernels on different cores
-        // simultaneously.
-        Program program = CreateProgram();
-
-        // A MeshWorkload is a collection of programs that will be executed on the mesh. Each workload is
-        // local to a single device. Here we create a workload for our single-device mesh.
-        distributed::MeshWorkload workload;
-        distributed::MeshCoordinateRange device_range = distributed::MeshCoordinateRange(mesh_device->shape());
-
-        // This example program will only use 1 Tensix core. So we set the core to {0, 0} (the most top-left core).
-        constexpr CoreCoord core = {0, 0};
-
-        // Create the data movement kernel. This kernel will be used to copy data from DRAM to DRAM (see the
-        // `loopback_dram_copy.cpp` file for the actual implementation). The kernel is created on the Tensix core
-        // {0, 0} and uses the default NoC.
-        std::vector<uint32_t> dram_copy_compile_time_args;
-        TensorAccessorArgs(*input_dram_buffer->get_backing_buffer()).append_to(dram_copy_compile_time_args);
-        TensorAccessorArgs(*output_dram_buffer->get_backing_buffer()).append_to(dram_copy_compile_time_args);
-        KernelHandle dram_copy_kernel_id = CreateKernel(
-            program,
-            OVERRIDE_KERNEL_PREFIX "loopback/kernels/loopback_dram_copy.cpp",
-            core,
-            DataMovementConfig{
-                .processor = DataMovementProcessor::RISCV_0,
-                .noc = NOC::RISCV_0_default,
-                .compile_args = dram_copy_compile_time_args});
-
-        // Initialize the input buffer with random data.
+        // Initialize with random data.
         std::vector<bfloat16> input_vec(elements_per_tile * num_tiles);
         std::mt19937 rng(std::random_device{}());
         std::uniform_real_distribution<float> distribution(0.0f, 100.0f);
@@ -98,47 +51,37 @@ int main() {
             val = bfloat16(distribution(rng));
         }
 
-        // Upload the data from host to the device. The final argument is set to false. This indicates to Metalium that
-        // the upload is non-blocking, an upload will be launched, but the function will return immediately, before the
-        // upload is complete. This is useful for performance reasons, as it allows the host to continue while the
-        // upload is in progress. Note that the host is responsible for ensuring that the upload is complete before the
-        // memory holding the data is freed.
-        distributed::EnqueueWriteMeshBuffer(cq, input_dram_buffer, input_vec, /*blocking=*/false);
+        // Upload the data from host to device DRAM. ctx.write() is non-blocking by default: it
+        // enqueues the transfer and returns immediately. ctx.run() calls finish() to wait for all
+        // enqueued work (including writes) before reading results.
+        ctx.write(input_dram_buffer, input_vec);
 
-        // Set runtime arguments for the kernel.
-        const std::vector<uint32_t> runtime_args = {
-            l1_buffer->address(), input_dram_buffer->address(), output_dram_buffer->address(), num_tiles};
+        // Build the program with a single data movement kernel that copies DRAM→L1→DRAM.
+        // This kernel acts as both reader and writer. .reader() assigns RISCV_1 with the
+        // architecture-preferred read NOC, and auto-generates TensorAccessorArgs for both buffers.
+        auto program =
+            ProgramBuilder(core)
+                .reader(
+                    OVERRIDE_KERNEL_PREFIX "loopback/kernels/loopback_dram_copy.cpp",
+                    {input_dram_buffer, output_dram_buffer})
+                .runtime_args({l1_buffer->address(), input_dram_buffer->address(),
+                               output_dram_buffer->address(), num_tiles})
+                .done()
+                .build();
 
-        SetRuntimeArgs(program, dram_copy_kernel_id, core, runtime_args);
+        ctx.run(std::move(program));
+        auto result_vec = ctx.read<bfloat16>(output_dram_buffer);
 
-        // Add the program to the workload for the mesh.
-        workload.add_program(device_range, std::move(program));
-        // Enqueue the workload for execution on the mesh (non-blocking) and wait for completion before reading back.
-        distributed::EnqueueMeshWorkload(cq, workload, /*blocking=*/false);
-        distributed::Finish(cq);
-        // NOTE: The above is equivalent to a blocking enqueue of the workload.
-
-        // Read the result back from the shard at mesh coordinate {0,0}. Use blocking=true to wait for completion.
-        // The vector is automatically resized to fit the data.
-        std::vector<bfloat16> result_vec;
-        distributed::EnqueueReadMeshBuffer(cq, result_vec, output_dram_buffer, /*blocking*/ true);
-
-        // Compare the result with the input. The result should be the same as the input.
         TT_FATAL(
             result_vec.size() == input_vec.size(),
             "Result vector size {} does not match input vector size {}",
             result_vec.size(),
             input_vec.size());
-        for (int i = 0; i < input_vec.size(); i++) {
+        for (size_t i = 0; i < input_vec.size(); i++) {
             if (input_vec[i] != result_vec[i]) {
                 pass = false;
                 break;
             }
-        }
-
-        // Close the device
-        if (!mesh_device->close()) {
-            pass = false;
         }
 
     } catch (const std::exception& e) {

--- a/tt_metal/programming_examples/matmul/matmul_multi_core/CMakeLists.txt
+++ b/tt_metal/programming_examples/matmul/matmul_multi_core/CMakeLists.txt
@@ -10,4 +10,5 @@ target_link_libraries(
     PRIVATE
         TT::Metalium
         Matmul::Common
+        tt_metal_ez
 )

--- a/tt_metal/programming_examples/matmul/matmul_multi_core/matmul_multi_core.cpp
+++ b/tt_metal/programming_examples/matmul/matmul_multi_core/matmul_multi_core.cpp
@@ -3,21 +3,20 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <random>
-#include <tt-metalium/host_api.hpp>
-#include <tt-metalium/constants.hpp>
 #include <tt-metalium/bfloat16.hpp>
+#include <tt-metalium/constants.hpp>
+#include <tt-metalium/experimental/ez/ez.hpp>
 #include <tt-metalium/tilize_utils.hpp>
-#include <tt-metalium/distributed.hpp>
 #include <tt-metalium/work_split.hpp>
-#include <tt-metalium/tensor_accessor_args.hpp>
 #include <bmm_op.hpp>
-#include <tt-metalium/device.hpp>
-#include <fmt/core.h>
+
+#include <cstdint>
+#include <vector>
 
 using namespace tt::constants;
-using namespace std;
 using namespace tt;
 using namespace tt::tt_metal;
+using namespace tt::tt_metal::experimental::ez;
 
 #ifndef OVERRIDE_KERNEL_PREFIX
 #define OVERRIDE_KERNEL_PREFIX ""
@@ -33,27 +32,13 @@ void golden_matmul(
     uint32_t M,
     uint32_t N,
     uint32_t K) {
-    std::uint32_t idx_c = 0;
-    std::uint32_t idx_a = 0;
-    std::uint32_t idx_b = 0;
-
-    float c_f;
-    float float_tmp;
-    std::vector<bfloat16> c_bf(M * N, 0);
-
-    for (int i = 0; i < M; i++) {
-        for (int j = 0; j < N; j++) {
-            idx_c = j + (i * N);
-            idx_a = i * K;
-            idx_b = j;
-            c_f = 0;
-            for (int k_m = 0; k_m < K; k_m++) {
-                float_tmp = static_cast<float>(a[idx_a]) * static_cast<float>(b[idx_b]);
-                c_f += float_tmp;
-                idx_a += 1;
-                idx_b += N;
+    for (uint32_t i = 0; i < M; i++) {
+        for (uint32_t j = 0; j < N; j++) {
+            float c_f = 0;
+            for (uint32_t k_m = 0; k_m < K; k_m++) {
+                c_f += static_cast<float>(a[i * K + k_m]) * static_cast<float>(b[k_m * N + j]);
             }
-            output.at(idx_c) = bfloat16(c_f);
+            output.at(j + i * N) = bfloat16(c_f);
         }
     }
 }
@@ -73,13 +58,13 @@ void golden_matmul(
  * Work distribution is handled automatically - if output tiles don't divide evenly
  * across cores, some cores get one extra tile to balance the workload.
  *
- * @param a Input matrix A in row-major format (bfloat16 elements)
- * @param b Input matrix B in row-major format (bfloat16 elements)
- * @param output Output matrix C to store A*B result (bfloat16 elements)
+ * @param a Input matrix A in tilized format (bfloat16 elements)
+ * @param b Input matrix B in tilized format (bfloat16 elements)
+ * @param output Output matrix C to store A*B result (bfloat16 elements, tilized)
  * @param M Number of rows in matrix A and output matrix C
  * @param N Number of columns in matrix B and output matrix C
  * @param K Number of columns in matrix A and rows in matrix B
- * @param mesh_device Target mesh device (1x1 or larger) for computation
+ * @param ctx DeviceContext providing device access, buffer allocation, and execution
  *
  * @note Matrix dimensions must be divisible by tile size (32x32) for this implementation
  * @note Uses circular buffers with 2 tiles for double-buffering to overlap compute and data movement
@@ -91,7 +76,7 @@ void matmul_multi_core(
     uint32_t M,
     uint32_t N,
     uint32_t K,
-    const std::shared_ptr<distributed::MeshDevice>& mesh_device) {
+    DeviceContext& ctx) {
     // Check if the configuration is valid - matrices must be divisible by tile dimensions
     TT_ASSERT(
         (M * N) % TILE_HW == 0,
@@ -100,14 +85,8 @@ void matmul_multi_core(
         N,
         TILE_HW);
 
-    // Set up mesh command queue, workload, device range, and program for multi-core execution
-    distributed::MeshCommandQueue& cq = mesh_device->mesh_command_queue();
-    distributed::MeshWorkload workload;
-    distributed::MeshCoordinateRange device_range = distributed::MeshCoordinateRange(mesh_device->shape());
-    Program program{};
-
     // Get the compute grid size to determine how many cores are available
-    auto core_grid = mesh_device->compute_with_storage_grid_size();
+    auto core_grid = ctx.device().compute_with_storage_grid_size();
     auto num_output_tiles_total = (M * N) / TILE_HW;
 
     // Use the split_work_to_cores utility function to distribute matrix multiplication work
@@ -128,87 +107,41 @@ void matmul_multi_core(
     const uint32_t Kt = K / TILE_WIDTH;   // Number of tiles in K dimension
     const uint32_t Nt = N / TILE_WIDTH;   // Number of tiles in N dimension
 
-    // Create DRAM buffers for input and output matrices (replicated per device across the mesh).
-    // We allocate DRAM buffers for the input matrices and output matrix.
+    // Create DRAM buffers for input and output matrices.
     // Setting page_size to single_tile_size is the most common configuration for memory buffers in Metalium
     // as it is generic, works for most cases and achieves good performance.
-    // Writing data from input vectors to source buffers.
-    constexpr uint32_t single_tile_size = sizeof(bfloat16) * TILE_HEIGHT * TILE_WIDTH;  // 2 * 32 * 32 = 2048 bytes
-
-    distributed::DeviceLocalBufferConfig dram_config{
-        .page_size = single_tile_size, .buffer_type = tt_metal::BufferType::DRAM};
-
-    distributed::ReplicatedBufferConfig buffer_config_A{.size = single_tile_size * Mt * Kt};
-
-    distributed::ReplicatedBufferConfig buffer_config_B{.size = single_tile_size * Nt * Kt};
-
-    distributed::ReplicatedBufferConfig buffer_config_C{.size = single_tile_size * Mt * Nt};
-
-    auto src0_dram_buffer = distributed::MeshBuffer::create(buffer_config_A, dram_config, mesh_device.get());
-    auto src1_dram_buffer = distributed::MeshBuffer::create(buffer_config_B, dram_config, mesh_device.get());
-    auto dst_dram_buffer = distributed::MeshBuffer::create(buffer_config_C, dram_config, mesh_device.get());
-    // Each handle is a mesh-wide replicated allocation; on a unit mesh this is a single device buffer
+    auto src0_dram_buffer = ctx.dram_tile_buffer(Mt * Kt);
+    auto src1_dram_buffer = ctx.dram_tile_buffer(Kt * Nt);
+    auto dst_dram_buffer = ctx.dram_tile_buffer(Mt * Nt);
 
     // Configure Circular Buffers
     // Circular buffers act as staging areas for data movement between DRAM and compute units.
     // Using 2 tiles per circular buffer to allow for double buffering (data movement can be reading from one tile while
     // the compute kernel is using the other tile). This number can be adjusted based on the use case, but generally
     // diminishing returns are observed after several tiles.
-    // input tiles count is = 2 so one tile can be read while the other is being processed
-    const auto cb_data_format = tt::DataFormat::Float16_b;
-    uint32_t num_input_tiles = 2;
-    tt_metal::CreateCircularBuffer(
-        program,
-        all_cores,  // create on all cores
-        CircularBufferConfig(num_input_tiles * single_tile_size, {{CBIndex::c_0, cb_data_format}})
-            .set_page_size(CBIndex::c_0, single_tile_size));
+    constexpr uint32_t num_input_tiles = 2;
 
-    tt_metal::CreateCircularBuffer(
-        program,
-        all_cores,  // create on all cores
-        CircularBufferConfig(num_input_tiles * single_tile_size, {{CBIndex::c_1, cb_data_format}})
-            .set_page_size(CBIndex::c_1, single_tile_size));
-
-    tt_metal::CreateCircularBuffer(
-        program,
-        all_cores,  // create on all cores
-        CircularBufferConfig(num_input_tiles * single_tile_size, {{CBIndex::c_16, cb_data_format}})
-            .set_page_size(CBIndex::c_16, single_tile_size));
+    auto builder = ProgramBuilder(all_cores);
+    builder.cb(tt::CBIndex::c_0, num_input_tiles)
+        .cb(tt::CBIndex::c_1, num_input_tiles)
+        .cb(tt::CBIndex::c_16, num_input_tiles);
 
     // Create Kernels (Reader, Writer, Compute)
     // - Reader kernel: Handles reading input data from DRAM into circular buffers
     // - Writer kernel: Handles writing output data from circular buffers back to DRAM
     // - Compute kernel: Performs the actual matrix multiplication computation
-    // All kernels run across all cores to enable parallel execution
+    // All kernels run across all cores to enable parallel execution.
+    // The EZ API auto-generates TensorAccessorArgs from the buffer lists.
     MathFidelity math_fidelity = MathFidelity::HiFi4;  // High fidelity math for accurate results
-    std::vector<uint32_t> reader_compile_time_args;
-    TensorAccessorArgs(*src0_dram_buffer).append_to(reader_compile_time_args);
-    TensorAccessorArgs(*src1_dram_buffer).append_to(reader_compile_time_args);
-    auto reader_id = tt_metal::CreateKernel(
-        program,
+    auto& reader_ref = builder.reader(
         OVERRIDE_KERNEL_PREFIX "matmul/matmul_multi_core/kernels/dataflow/reader_mm_output_tiles_partitioned.cpp",
-        all_cores,
-        tt_metal::DataMovementConfig{
-            .processor = DataMovementProcessor::RISCV_1,
-            .noc = NOC::RISCV_1_default,
-            .compile_args = reader_compile_time_args});
-
-    std::vector<uint32_t> writer_compile_time_args;
-    TensorAccessorArgs(*dst_dram_buffer).append_to(writer_compile_time_args);
-    auto writer_id = tt_metal::CreateKernel(
-        program,
+        {src0_dram_buffer, src1_dram_buffer});
+    auto& writer_ref = builder.writer(
         OVERRIDE_KERNEL_PREFIX "matmul/matmul_multi_core/kernels/dataflow/writer_unary_interleaved_start_id.cpp",
-        all_cores,
-        tt_metal::DataMovementConfig{
-            .processor = DataMovementProcessor::RISCV_0,
-            .noc = NOC::RISCV_0_default,
-            .compile_args = writer_compile_time_args});
-
-    auto compute_kernel_id = tt_metal::CreateKernel(
-        program,
+        {dst_dram_buffer});
+    auto& compute_ref = builder.compute(
         OVERRIDE_KERNEL_PREFIX "matmul/matmul_multi_core/kernels/compute/mm.cpp",
-        all_cores,
-        tt_metal::ComputeConfig{.math_fidelity = math_fidelity, .compile_args = {}});
+        math_fidelity);
 
     // Set Runtime Arguments for Kernels
     // Each core needs to know which portion of the work it's responsible for. We are parallelizing across output
@@ -222,9 +155,7 @@ void matmul_multi_core(
         for (const auto& range : ranges.ranges()) {
             for (const auto& core : range) {
                 // Set arguments for the reader kernel (data input)
-                tt_metal::SetRuntimeArgs(
-                    program,
-                    reader_id,
+                reader_ref.runtime_args_at(
                     core,
                     {src0_dram_buffer->address(),  // Address of matrix A in DRAM
                      src1_dram_buffer->address(),  // Address of matrix B in DRAM
@@ -235,16 +166,13 @@ void matmul_multi_core(
                      work_per_core});              // Amount of work for this core
 
                 // Set arguments for the writer kernel (data output)
-                tt_metal::SetRuntimeArgs(
-                    program, writer_id, core, {dst_dram_buffer->address(), work_per_core, work_offset});
+                writer_ref.runtime_args_at(core, {dst_dram_buffer->address(), work_per_core, work_offset});
 
                 // Set arguments for the compute kernel
-                tt_metal::SetRuntimeArgs(
-                    program,
-                    compute_kernel_id,
+                compute_ref.runtime_args_at(
                     core,
-                    {work_per_core,            // Amount of work for this core
-                     Kt});                     // Number of tiles in K dimension for dot product
+                    {work_per_core,  // Amount of work for this core
+                     Kt});           // Number of tiles in K dimension for dot product
                 work_offset += work_per_core;  // Update offset for next core
             }
         }
@@ -254,14 +182,10 @@ void matmul_multi_core(
     // 1. Upload input data to DRAM buffers
     // 2. Execute the program (all kernels run in parallel across cores)
     // 3. Read back the result from DRAM to host memory
-    // The 'true' parameter in EnqueueReadMeshBuffer ensures we wait for completion (so when the function
-    // returns, the output vector is fully populated).
-    distributed::EnqueueWriteMeshBuffer(cq, src0_dram_buffer, a, false);
-    distributed::EnqueueWriteMeshBuffer(cq, src1_dram_buffer, b, false);
-    workload.add_program(device_range, std::move(program));
-    distributed::EnqueueMeshWorkload(cq, workload, false);
-    // Blocking read waits for completion before returning and resizes 'output' as needed
-    distributed::EnqueueReadMeshBuffer(cq, output, dst_dram_buffer, true);
+    ctx.write(src0_dram_buffer, a);
+    ctx.write(src1_dram_buffer, b);
+    ctx.run(builder.build());
+    output = ctx.read<bfloat16>(dst_dram_buffer);
 }
 
 ///////////////////////////////////////
@@ -271,7 +195,7 @@ int main() {
 
     try {
         constexpr int device_id = 0;
-        std::shared_ptr<distributed::MeshDevice> mesh_device = distributed::MeshDevice::create_unit_mesh(device_id);
+        DeviceContext ctx(device_id);
 
         // Create source data with specified matrix dimensions
         constexpr uint32_t M = 640;  // Number of rows in matrix A (user-defined)
@@ -283,21 +207,12 @@ int main() {
         static_assert(N % TILE_WIDTH == 0, "N must be divisible by TILE_WIDTH");
         static_assert(K % TILE_WIDTH == 0, "K must be divisible by TILE_WIDTH");
 
-        // Calculate matrix dimensions in tiles for the accelerator
-        uint32_t Mt = M / TILE_HEIGHT;
-        uint32_t Nt = N / TILE_WIDTH;
-
-        // Calculate buffer sizes needed for each matrix in bytes
-        constexpr uint32_t single_tile_size = sizeof(bfloat16) * TILE_HEIGHT * TILE_WIDTH;  // 2 * 32 * 32 = 2048 bytes
-        uint32_t dram_buffer_C_size = single_tile_size * Mt * Nt;  // num_tiles of FP16_B
-
         // Create random input vectors for matrices A and B
         std::mt19937 rng(std::random_device{}());
         std::uniform_real_distribution<float> dist(-0.5f, 0.5f);
 
         std::vector<bfloat16> src0_vec(M * K, 0);  // Matrix A (MxK)
         std::vector<bfloat16> src1_vec(K * N, 0);  // Matrix B (KxN)
-        // // Fill with random bfloat16 values
         for (bfloat16& v : src0_vec) {
             v = bfloat16(dist(rng));
         }
@@ -309,7 +224,7 @@ int main() {
         std::vector<bfloat16> golden_vec(M * N, 0);
         golden_matmul(src0_vec, src1_vec, golden_vec, M, N, K);
 
-        // Input vector tilizing to match device expected tiled layout
+        // Input vector tilizing to match device expected tiled layout.
         // The Tenstorrent hardware operates on data in 32x32 tiles rather than standard row-major format.
         // tilize_nfaces() converts the input matrices from row-major layout to the tiled layout expected by the device.
         // This transformation groups elements into 32x32 blocks and reorders them in memory so that each tile
@@ -319,21 +234,22 @@ int main() {
         src1_vec = tilize_nfaces(src1_vec, K, N);
 
         /* Calling the MatMul host program. Read in result into a host vector */
+        uint32_t Mt = M / TILE_HEIGHT;
+        uint32_t Nt = N / TILE_WIDTH;
+        constexpr uint32_t single_tile_size = sizeof(bfloat16) * TILE_HEIGHT * TILE_WIDTH;
+        uint32_t dram_buffer_C_size = single_tile_size * Mt * Nt;
         std::vector<bfloat16> result_vec(dram_buffer_C_size / sizeof(bfloat16));
-        matmul_multi_core(src0_vec, src1_vec, result_vec, M, N, K, mesh_device);
+        matmul_multi_core(src0_vec, src1_vec, result_vec, M, N, K, ctx);
         // Reverse the tilization to get the result in the row-major format that the CPU expects
         result_vec = untilize_nfaces(result_vec, M, N);
 
         fmt::print("Output vector of size {}\n", result_vec.size());
 
-        // Calculate the Pearson correlation coefficient (PCC) between the golden vector and the result vector
-        // This is a measure of how similar the two vectors are.
+        // Calculate the Pearson correlation coefficient (PCC) between the golden vector and the result vector.
         // A PCC close to 1 indicates that the two vectors are very similar.
         float pearson = check_bfloat16_vector_pcc(golden_vec, result_vec);
         fmt::print("Metalium vs Golden -- PCC = {}\n", pearson);
         TT_FATAL(pearson > 0.97, "PCC not high enough. Result PCC: {}, Expected PCC: 0.97", pearson);
-
-        pass &= mesh_device->close();
 
     } catch (const std::exception& e) {
         fmt::print(stderr, "Test failed with exception!\n");

--- a/tt_metal/programming_examples/matmul/matmul_multicore_reuse/CMakeLists.txt
+++ b/tt_metal/programming_examples/matmul/matmul_multicore_reuse/CMakeLists.txt
@@ -10,4 +10,5 @@ target_link_libraries(
     PRIVATE
         TT::Metalium
         Matmul::Common
+        tt_metal_ez
 )

--- a/tt_metal/programming_examples/matmul/matmul_multicore_reuse/matmul_multicore_reuse.cpp
+++ b/tt_metal/programming_examples/matmul/matmul_multicore_reuse/matmul_multicore_reuse.cpp
@@ -2,22 +2,19 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <tt-metalium/host_api.hpp>
-#include <tt-metalium/constants.hpp>
 #include <tt-metalium/bfloat16.hpp>
+#include <tt-metalium/constants.hpp>
+#include <tt-metalium/experimental/ez/ez.hpp>
 #include <tt-metalium/tilize_utils.hpp>
-#include <tt-metalium/device.hpp>
-#include <tt-metalium/tt_metal.hpp>
-#include <tt-metalium/tensor_accessor_args.hpp>
-#include <tt-metalium/distributed.hpp>
 #include <bmm_op.hpp>
-#include <fmt/core.h>
-#include <iostream>
+
+#include <cstdint>
+#include <vector>
 
 using namespace tt::constants;
-using namespace std;
 using namespace tt;
 using namespace tt::tt_metal;
+using namespace tt::tt_metal::experimental::ez;
 
 #ifndef OVERRIDE_KERNEL_PREFIX
 #define OVERRIDE_KERNEL_PREFIX ""
@@ -31,27 +28,13 @@ void golden_matmul(
     uint32_t N,
     uint32_t K,
     uint32_t /*B*/) {
-    std::uint32_t idx_c = 0;
-    std::uint32_t idx_a = 0;
-    std::uint32_t idx_b = 0;
-
-    float c_f;
-    float float_tmp;
-    std::vector<bfloat16> c_bf(M * N, 0);
-
-    for (int i = 0; i < M; i++) {
-        for (int j = 0; j < N; j++) {
-            idx_c = j + (i * N);
-            idx_a = i * K;
-            idx_b = j;
-            c_f = 0;
-            for (int k_m = 0; k_m < K; k_m++) {
-                float_tmp = static_cast<float>(a[idx_a]) * static_cast<float>(b[idx_b]);
-                c_f += float_tmp;
-                idx_a += 1;
-                idx_b += N;
+    for (uint32_t i = 0; i < M; i++) {
+        for (uint32_t j = 0; j < N; j++) {
+            float c_f = 0;
+            for (uint32_t k_m = 0; k_m < K; k_m++) {
+                c_f += static_cast<float>(a[i * K + k_m]) * static_cast<float>(b[k_m * N + j]);
             }
-            output.at(idx_c) = bfloat16(c_f);
+            output.at(j + i * N) = bfloat16(c_f);
         }
     }
 }
@@ -65,27 +48,22 @@ void matmul_multicore_reuse(
     uint32_t N,
     uint32_t K,
     uint32_t B,
-    const std::shared_ptr<distributed::MeshDevice>& mesh_device) {
+    DeviceContext& ctx) {
     /*
-     * Set up Mesh API constructs: command queue, workload, device range, and program.
-     * We'll distribute work across multiple cores using the device's compute grid.
+     * The EZ API's DeviceContext and ProgramBuilder handle device setup, command queue,
+     * and program management. We'll distribute work across multiple cores using the device's compute grid.
      */
-    distributed::MeshCommandQueue& cq = mesh_device->mesh_command_queue();
-    distributed::MeshWorkload workload;
-    distributed::MeshCoordinateRange device_range = distributed::MeshCoordinateRange(mesh_device->shape());
-    Program program{};
 
     tt::DataFormat cb_data_format = tt::DataFormat::Float16_b;
     MathFidelity math_fidelity = MathFidelity::HiFi4;
     uint32_t single_tile_size = tt::tile_size(cb_data_format);
-    // uint32_t single_tile_size = 2 * 1024;
 
-    auto compute_with_storage_grid_size = mesh_device->compute_with_storage_grid_size();
+    auto compute_with_storage_grid_size = ctx.device().compute_with_storage_grid_size();
     uint32_t num_cores_x = compute_with_storage_grid_size.x;
     uint32_t num_cores_y = compute_with_storage_grid_size.y;
 
     /*
-     * EXtracting Matrix dimensions from input/output vectors
+     * Extracting Matrix dimensions from input/output vectors
      */
     // C = A*B
     // MN = MK*KN
@@ -96,10 +74,6 @@ void matmul_multicore_reuse(
     // NOTE: Only supports matmuls where output is blocks of 16 x 16 tiles (ie. multiples of 16*32 x 16*32)
     // NOTE: Maximum number of tiles in output is 120 * 16^2 = 30,720 (eg. [1, 1, 5120, 6144])2
     uint32_t in0_block_w = 2;
-    // uint32_t out_subblock_h = 4;
-    // uint32_t out_subblock_w = 2;
-    // uint32_t per_core_M = 16;
-    // uint32_t per_core_N = 16;
 
     // Get large matmul params
     auto matmul_params = bmm_op_utils::get_large_matmul_params(Mt, Nt, num_cores_y, num_cores_x, in0_block_w);
@@ -122,10 +96,8 @@ void matmul_multicore_reuse(
 
     uint32_t in0_block_tiles = per_core_M * in0_block_w;
     uint32_t in0_CB_tiles = in0_block_tiles * 2;  // double buffer
-    uint32_t in0_CB_size = in0_CB_tiles * single_tile_size;
     uint32_t in1_block_tiles = per_core_N * in0_block_w;
     uint32_t in1_CB_tiles = in1_block_tiles * 2;  // double buffer
-    uint32_t in1_CB_size = in1_CB_tiles * single_tile_size;
     uint32_t out_block_tiles = per_core_M * per_core_N;
     uint32_t out_CB_tiles = out_block_tiles;  // No double buffer
     uint32_t out_CB_size = out_CB_tiles * single_tile_size;
@@ -164,10 +136,6 @@ void matmul_multicore_reuse(
     /*
      * Multi-Core prep
      */
-    // auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
-    // uint32_t num_cores_x = compute_with_storage_grid_size.x;
-    // uint32_t num_cores_y = compute_with_storage_grid_size.y;
-
     uint32_t num_blocks_y = Mt / per_core_M;
     uint32_t num_blocks_x = Nt / per_core_N;
     uint32_t num_blocks_total = num_blocks_y * num_blocks_x;
@@ -177,91 +145,51 @@ void matmul_multicore_reuse(
 
     //////////////////////////////////////////////////
     /*
-     * Create DRAM buffers for input and output matrices (replicated per device across the mesh).
-     * We'll upload input vectors into these mesh buffers prior to launching the program.
+     * Create DRAM buffers for input and output matrices.
+     * We'll upload input vectors into these buffers prior to launching the program.
      */
-
-    uint32_t dram_buffer_A_size =
-        single_tile_size * Mt * Kt;  // num_tiles of FP16_B, hard-coded in the reader/writer kernels
-    uint32_t dram_buffer_B_size =
-        single_tile_size * Nt * Kt;  // num_tiles of FP16_B, hard-coded in the reader/writer kernels
-    uint32_t dram_buffer_C_size =
-        single_tile_size * Mt * Nt;  // num_tiles of FP16_B, hard-coded in the reader/writer kernels
-
-    distributed::DeviceLocalBufferConfig dram_config{
-        .page_size = single_tile_size, .buffer_type = tt_metal::BufferType::DRAM};
-
-    distributed::ReplicatedBufferConfig buffer_config_A{.size = dram_buffer_A_size};
-
-    distributed::ReplicatedBufferConfig buffer_config_B{.size = dram_buffer_B_size};
-
-    distributed::ReplicatedBufferConfig buffer_config_C{.size = dram_buffer_C_size};
-
-    auto src0_dram_buffer = distributed::MeshBuffer::create(buffer_config_A, dram_config, mesh_device.get());
-    auto src1_dram_buffer = distributed::MeshBuffer::create(buffer_config_B, dram_config, mesh_device.get());
-    auto dst_dram_buffer = distributed::MeshBuffer::create(buffer_config_C, dram_config, mesh_device.get());
+    auto src0_dram_buffer = ctx.dram_tile_buffer(Mt * Kt);
+    auto src1_dram_buffer = ctx.dram_tile_buffer(Kt * Nt);
+    auto dst_dram_buffer = ctx.dram_tile_buffer(Mt * Nt);
 
     /*
      * Config of Circular Buffer in the device L1
      * input tiles count is = 2 because it's single tile process, and double-buffer
      */
-    uint32_t src0_cb_index = CBIndex::c_0;  // 0
-    CircularBufferConfig cb_src0_config = CircularBufferConfig(in0_CB_size, {{src0_cb_index, cb_data_format}})
-                                              .set_page_size(src0_cb_index, single_tile_size);
-    tt_metal::CreateCircularBuffer(program, all_cores, cb_src0_config);
+    auto builder = ProgramBuilder(all_cores);
+    builder.cb(tt::CBIndex::c_0, in0_CB_tiles)
+        .cb(tt::CBIndex::c_1, in1_CB_tiles);
 
-    uint32_t src1_cb_index = CBIndex::c_1;  // 1
-    CircularBufferConfig cb_src1_config = CircularBufferConfig(in1_CB_size, {{src1_cb_index, cb_data_format}})
-                                              .set_page_size(src1_cb_index, single_tile_size);
-    tt_metal::CreateCircularBuffer(program, all_cores, cb_src1_config);
-
-    uint32_t output_cb_index = tt::CBIndex::c_16;
+    // Output and intermediate accumulation circular buffers (c_16 and c_24) share the same
+    // L1 memory. This is a hardware optimization: during computation, results are accumulated
+    // in the intermediate buffer (c_24), and the final output is read from c_16. Because they
+    // alias the same memory, no explicit copy is needed between pipeline stages.
+    uint32_t output_cb_index = CBIndex::c_16;
     uint32_t interm0_cb_index = 24;
     std::map<uint8_t, tt::DataFormat> output_cb_data_format_spec{
         {output_cb_index, cb_data_format}, {interm0_cb_index, cb_data_format}};
-    CircularBufferConfig cb_output_config = CircularBufferConfig(out_CB_size, output_cb_data_format_spec)
-                                                .set_page_size(output_cb_index, single_tile_size)
-                                                .set_page_size(interm0_cb_index, single_tile_size);
-    tt_metal::CreateCircularBuffer(program, all_cores, cb_output_config);
-
-    /*
-     * Compile time arguments
-     */
-    std::vector<uint32_t> reader_compile_time_args;
-    TensorAccessorArgs(*src0_dram_buffer).append_to(reader_compile_time_args);
-    TensorAccessorArgs(*src1_dram_buffer).append_to(reader_compile_time_args);
-
-    std::vector<uint32_t> writer_compile_time_args;
-    TensorAccessorArgs(*dst_dram_buffer).append_to(writer_compile_time_args);
+    builder.cb(CircularBufferConfig(out_CB_size, output_cb_data_format_spec)
+                   .set_page_size(output_cb_index, single_tile_size)
+                   .set_page_size(interm0_cb_index, single_tile_size));
 
     /*
      * Create Kernels (Reader, Writer, Compute)
+     * The EZ API auto-generates TensorAccessorArgs from the buffer lists.
      */
     // Create reader and writer kernels per core
-    auto reader_id = tt_metal::CreateKernel(
-        program,
+    auto& reader_ref = builder.reader(
         OVERRIDE_KERNEL_PREFIX "matmul/matmul_common/kernels/dataflow/reader_bmm_tile_layout.cpp",
-        all_cores,
-        tt_metal::DataMovementConfig{
-            .processor = DataMovementProcessor::RISCV_1,
-            .noc = NOC::RISCV_1_default,
-            .compile_args = reader_compile_time_args});
+        {src0_dram_buffer, src1_dram_buffer});
 
-    auto writer_id = tt_metal::CreateKernel(
-        program,
+    auto& writer_ref = builder.writer(
         OVERRIDE_KERNEL_PREFIX "matmul/matmul_common/kernels/dataflow/writer_bmm_tile_layout.cpp",
-        all_cores,
-        tt_metal::DataMovementConfig{
-            .processor = DataMovementProcessor::RISCV_0,
-            .noc = NOC::RISCV_0_default,
-            .compile_args = writer_compile_time_args});
+        {dst_dram_buffer});
 
     // Create compute kernel
-    tt_metal::CreateKernel(
-        program,
+    builder.compute(
         OVERRIDE_KERNEL_PREFIX "matmul/matmul_common/kernels/compute/bmm_large_block_zm.cpp",
-        all_cores,
-        tt_metal::ComputeConfig{.math_fidelity = math_fidelity, .compile_args = compute_kernel_args});
+        math_fidelity,
+        compute_kernel_args);
 
     /*
      * Kernels - Runtime arguments
@@ -322,22 +250,18 @@ void matmul_multicore_reuse(
                 (std::uint32_t)B         // batch
             };
 
-            tt_metal::SetRuntimeArgs(program, reader_id, core, mm_reader_args);
-            tt_metal::SetRuntimeArgs(program, writer_id, core, writer_args);
+            reader_ref.runtime_args_at(core, mm_reader_args);
+            writer_ref.runtime_args_at(core, writer_args);
 
             num_blocks_read++;
         }
     }
 
     /* Launch program & read back results */
-
-    // Non-blocking uploads allow overlapping host setup with device transfers
-    distributed::EnqueueWriteMeshBuffer(cq, src0_dram_buffer, a, false);
-    distributed::EnqueueWriteMeshBuffer(cq, src1_dram_buffer, b, false);
-    workload.add_program(device_range, std::move(program));
-    distributed::EnqueueMeshWorkload(cq, workload, false);
-    // Blocking read from shard {0,0} waits for completion and populates 'output'
-    distributed::EnqueueReadMeshBuffer(cq, output, dst_dram_buffer, true);
+    ctx.write(src0_dram_buffer, a);
+    ctx.write(src1_dram_buffer, b);
+    ctx.run(builder.build());
+    output = ctx.read<bfloat16>(dst_dram_buffer);
 }
 
 ///////////////////////////////////////
@@ -347,8 +271,9 @@ int main() {
 
     try {
         /* Silicon accelerator setup */
+        // DeviceContext wraps MeshDevice creation, command queue, and teardown in RAII.
         constexpr int device_id = 0;
-        std::shared_ptr<distributed::MeshDevice> mesh_device = distributed::MeshDevice::create_unit_mesh(device_id);
+        DeviceContext ctx(device_id);
 
         ////////////////////////////////////////////////////////////////////////////
         //                      Matmul Parameters Setup
@@ -367,13 +292,11 @@ int main() {
         uint32_t Nt = N / TILE_WIDTH;
 
         constexpr uint32_t single_tile_size = 2 * 1024;
-        uint32_t dram_buffer_A_size = single_tile_size * Mt * Kt;  // num_tiles of FP16_B
-        uint32_t dram_buffer_B_size = single_tile_size * Nt * Kt;  // num_tiles of FP16_B
         uint32_t dram_buffer_C_size = single_tile_size * Mt * Nt;  // num_tiles of FP16_B
 
         /* input vectors */
-        std::vector<bfloat16> src0_vec = create_random_vector_of_bfloat16_native(dram_buffer_A_size, 1, 123, -0.4);
-        std::vector<bfloat16> src1_vec = create_random_vector_of_bfloat16_native(dram_buffer_B_size, 1, 12522, -0.3);
+        std::vector<bfloat16> src0_vec = create_random_vector_of_bfloat16_native(single_tile_size * Mt * Kt, 1, 123, -0.4);
+        std::vector<bfloat16> src1_vec = create_random_vector_of_bfloat16_native(single_tile_size * Nt * Kt, 1, 12522, -0.3);
 
         /* Golden Matmul running on CPU (Float)*/
         std::vector<bfloat16> golden_vec(M * N, 0);
@@ -385,7 +308,7 @@ int main() {
 
         /* Calling the MatMul host program. Read in result into a host vector */
         std::vector<bfloat16> result_vec(dram_buffer_C_size / sizeof(bfloat16));
-        matmul_multicore_reuse(src0_vec, src1_vec, result_vec, false, M, N, K, B, mesh_device);
+        matmul_multicore_reuse(src0_vec, src1_vec, result_vec, false, M, N, K, B, ctx);
         result_vec = untilize_nfaces(result_vec, M, N);
 
         fmt::print("Output vector of size {}\n", result_vec.size());
@@ -393,8 +316,6 @@ int main() {
         float pearson = check_bfloat16_vector_pcc(golden_vec, result_vec);
         fmt::print("Metalium vs Golden -- PCC = {}\n", pearson);
         TT_FATAL(pearson > 0.99, "PCC not high enough. Result PCC: {}, Expected PCC: 0.99", pearson);
-
-        pass &= mesh_device->close();
 
     } catch (const std::exception& e) {
         fmt::print(stderr, "Test failed with exception! what: {}\n", e.what());

--- a/tt_metal/programming_examples/matmul/matmul_single_core/CMakeLists.txt
+++ b/tt_metal/programming_examples/matmul/matmul_single_core/CMakeLists.txt
@@ -10,4 +10,5 @@ target_link_libraries(
     PRIVATE
         TT::Metalium
         Matmul::Common
+        tt_metal_ez
 )

--- a/tt_metal/programming_examples/matmul/matmul_single_core/matmul_single_core.cpp
+++ b/tt_metal/programming_examples/matmul/matmul_single_core/matmul_single_core.cpp
@@ -3,20 +3,19 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <random>
-#include <tt-metalium/host_api.hpp>
-#include <tt-metalium/constants.hpp>
 #include <tt-metalium/bfloat16.hpp>
+#include <tt-metalium/constants.hpp>
+#include <tt-metalium/experimental/ez/ez.hpp>
 #include <tt-metalium/tilize_utils.hpp>
-#include <tt-metalium/distributed.hpp>
 #include <bmm_op.hpp>
-#include <tt-metalium/device.hpp>
-#include <tt-metalium/tensor_accessor_args.hpp>
-#include "tt-metalium/core_coord.hpp"
+
+#include <cstdint>
+#include <vector>
 
 using namespace tt::constants;
-using namespace std;
 using namespace tt;
 using namespace tt::tt_metal;
+using namespace tt::tt_metal::experimental::ez;
 
 // Reference implementation of matrix multiplication.
 // Array A is of size MxK, Array B is of size KxN, and the output C is of size MxN.
@@ -33,20 +32,13 @@ void golden_matmul(
     uint32_t M,
     uint32_t N,
     uint32_t K) {
-    std::vector<bfloat16> c_bf(M * N, 0);
-
-    for (int i = 0; i < M; i++) {
-        for (int j = 0; j < N; j++) {
-            std::uint32_t idx_c = j + (i * N);
-            std::uint32_t idx_a = i * K;
-            std::uint32_t idx_b = j;
+    for (uint32_t i = 0; i < M; i++) {
+        for (uint32_t j = 0; j < N; j++) {
             float c_f = 0;
-            for (int k_m = 0; k_m < K; k_m++) {
-                c_f += static_cast<float>(a[idx_a]) * static_cast<float>(b[idx_b]);
-                idx_a += 1;
-                idx_b += N;
+            for (uint32_t k_m = 0; k_m < K; k_m++) {
+                c_f += static_cast<float>(a[i * K + k_m]) * static_cast<float>(b[k_m * N + j]);
             }
-            output.at(idx_c) = bfloat16(c_f);
+            output.at(j + i * N) = bfloat16(c_f);
         }
     }
 }
@@ -60,124 +52,70 @@ void matmul_single_core(
     const std::vector<bfloat16>& a,
     const std::vector<bfloat16>& b,
     std::vector<bfloat16>& output,
-    bool /*bcast_batch*/,
     uint32_t M,
     uint32_t N,
     uint32_t K,
-    const std::shared_ptr<distributed::MeshDevice>& mesh_device) {
-    // Set up mesh command queue, workload, device range, and program. This is a single-core example using core {0,0}.
-    distributed::MeshCommandQueue& cq = mesh_device->mesh_command_queue();
-    distributed::MeshWorkload workload;
-    distributed::MeshCoordinateRange device_range = distributed::MeshCoordinateRange(mesh_device->shape());
-    Program program{};
-    // Core range from x: [0, 0] to y: [0, 0] (single core at {0, 0})
+    DeviceContext& ctx) {
+    // This is a single-core example using core {0,0}.
     CoreCoord core({0, 0});
 
-    // Calcaulate the number of tiles for each dimension.
+    // Calculate the number of tiles for each dimension.
     uint32_t Mt = M / TILE_HEIGHT;
     uint32_t Kt = K / TILE_WIDTH;
     uint32_t Nt = N / TILE_WIDTH;
 
     // Create DRAM buffers for the input and output data.
-    uint32_t single_tile_size = sizeof(bfloat16) * TILE_HEIGHT * TILE_WIDTH;
-
+    // A tile on Tenstorrent is 32x32 elements; with BFloat16, each tile occupies 2048 bytes.
     // We allocate DRAM buffers for the input and output data (replicated per device across the mesh).
     // Setting page_size to single_tile_size is the most common configuration for memory buffers in Metalium
     // as it is generic, works for most cases and achieves good performance.
-    distributed::DeviceLocalBufferConfig dram_config{
-        .page_size = single_tile_size, .buffer_type = tt_metal::BufferType::DRAM};
-
-    distributed::ReplicatedBufferConfig buffer_config_A{.size = sizeof(bfloat16) * a.size()};
-    distributed::ReplicatedBufferConfig buffer_config_B{.size = sizeof(bfloat16) * b.size()};
-    distributed::ReplicatedBufferConfig buffer_config_C{.size = sizeof(bfloat16) * output.size()};
-
-    auto src0_dram_buffer = distributed::MeshBuffer::create(buffer_config_A, dram_config, mesh_device.get());
-    auto src1_dram_buffer = distributed::MeshBuffer::create(buffer_config_B, dram_config, mesh_device.get());
-    auto dst_dram_buffer = distributed::MeshBuffer::create(buffer_config_C, dram_config, mesh_device.get());
+    auto src0_dram_buffer = ctx.dram_tile_buffer(Mt * Kt);
+    auto src1_dram_buffer = ctx.dram_tile_buffer(Kt * Nt);
+    auto dst_dram_buffer = ctx.dram_tile_buffer(Mt * Nt);
 
     // Create circular buffers for the input and output data.
     // Using 2 tiles per circular buffer to allow for double buffering (data movement can be reading from one tile while
-    // the compute kernel is using the other tile). This number can be adjusted based on the use case. But geberally
+    // the compute kernel is using the other tile). This number can be adjusted based on the use case. But generally
     // diminishing returns observed after several tiles.
-    tt::DataFormat cb_data_format = tt::DataFormat::Float16_b;
-    MathFidelity math_fidelity = MathFidelity::HiFi4;
-    uint32_t src0_cb_index = CBIndex::c_0;
-    uint32_t num_input_tiles = 2;
-    CircularBufferConfig cb_src0_config =
-        CircularBufferConfig(num_input_tiles * single_tile_size, {{src0_cb_index, cb_data_format}})
-            .set_page_size(src0_cb_index, single_tile_size);
-    tt_metal::CreateCircularBuffer(program, core, cb_src0_config);
+    constexpr uint32_t num_input_tiles = 2;
+    constexpr uint32_t num_output_tiles = 2;
 
-    uint32_t src1_cb_index = CBIndex::c_1;
-    CircularBufferConfig cb_src1_config =
-        CircularBufferConfig(num_input_tiles * single_tile_size, {{src1_cb_index, cb_data_format}})
-            .set_page_size(src1_cb_index, single_tile_size);
-    tt_metal::CreateCircularBuffer(program, core, cb_src1_config);
+    auto builder = ProgramBuilder(core);
+    builder.cb(tt::CBIndex::c_0, num_input_tiles)
+        .cb(tt::CBIndex::c_1, num_input_tiles)
+        .cb(tt::CBIndex::c_16, num_output_tiles);
 
-    uint32_t output_cb_index = tt::CBIndex::c_16;
-    uint32_t num_output_tiles = 2;
-    CircularBufferConfig cb_output_config =
-        CircularBufferConfig(num_output_tiles * single_tile_size, {{output_cb_index, cb_data_format}})
-            .set_page_size(output_cb_index, single_tile_size);
-    tt_metal::CreateCircularBuffer(program, core, cb_output_config);
-
-    // Create the data movement kernels and the compute kernel
-    std::vector<uint32_t> reader_compile_time_args;
-    TensorAccessorArgs(*src0_dram_buffer).append_to(reader_compile_time_args);
-    TensorAccessorArgs(*src1_dram_buffer).append_to(reader_compile_time_args);
-    auto reader_id = tt_metal::CreateKernel(
-        program,
+    // Create the data movement kernels and the compute kernel.
+    // Reader: loads A and B tiles from DRAM into circular buffers c_0 and c_1.
+    // Writer: stores computed output tiles from c_16 back to DRAM.
+    // The EZ API auto-generates TensorAccessorArgs from the buffer lists.
+    auto& reader_ref = builder.reader(
         OVERRIDE_KERNEL_PREFIX "matmul/matmul_single_core/kernels/dataflow/reader_single_core_mm.cpp",
-        core,
-        tt_metal::DataMovementConfig{
-            .processor = DataMovementProcessor::RISCV_1,
-            .noc = NOC::RISCV_1_default,
-            .compile_args = reader_compile_time_args});
-
-    std::vector<uint32_t> writer_compile_time_args;
-    TensorAccessorArgs(*dst_dram_buffer).append_to(writer_compile_time_args);
-    auto writer_id = tt_metal::CreateKernel(
-        program,
+        {src0_dram_buffer, src1_dram_buffer});
+    auto& writer_ref = builder.writer(
         OVERRIDE_KERNEL_PREFIX "matmul/matmul_single_core/kernels/dataflow/writer_single_core_mm.cpp",
-        core,
-        tt_metal::DataMovementConfig{
-            .processor = DataMovementProcessor::RISCV_0,
-            .noc = NOC::RISCV_0_default,
-            .compile_args = writer_compile_time_args});
+        {dst_dram_buffer});
 
-    // Compile time arguments for the kernels
-    // Note that these take effect at the kernel's compile time. Chaning these values will require recompilation of the
+    // Compile time arguments for the compute kernel.
+    // Note that these take effect at the kernel's compile time. Changing these values will require recompilation of the
     // kernel. Having arguments at compile time allows the compiler to optimize the kernel for the specific use case.
     // Like applying loop unrolling, constant folding, etc.. resulting in a more efficient kernel.
-    std::vector<uint32_t> compute_compile_time_args = {
-        Mt,  // Mt
-        Kt,  // Kt
-        Nt   // Nt
-    };
-    tt_metal::CreateKernel(
-        program,
+    builder.compute(
         OVERRIDE_KERNEL_PREFIX "matmul/matmul_single_core/kernels/compute/mm.cpp",
-        core,
-        tt_metal::ComputeConfig{.math_fidelity = math_fidelity, .compile_args = compute_compile_time_args});
+        MathFidelity::HiFi4,
+        {Mt, Kt, Nt});
 
-    // Set kernel arguments
-    uint32_t src0_addr = src0_dram_buffer->address();
-    uint32_t src1_addr = src1_dram_buffer->address();
-    uint32_t dst_addr = dst_dram_buffer->address();
-    tt_metal::SetRuntimeArgs(program, reader_id, core, {src0_addr, src1_addr, Mt, Kt, Nt});
+    // Set kernel runtime arguments.
+    reader_ref.runtime_args({src0_dram_buffer->address(), src1_dram_buffer->address(), Mt, Kt, Nt});
+    writer_ref.runtime_args({dst_dram_buffer->address(), Mt, Kt, Nt});
+    // NOTE: We never set the runtime arguments for the compute kernel. Everything needed has
+    // been set at compile time. The compute kernel does not need any runtime arguments to execute.
 
-    tt_metal::SetRuntimeArgs(program, writer_id, core, {dst_addr, Mt, Kt, Nt});
-    // NOTE: Note that we never set the runtime arguments for the compute kernel. This is because everything needed has
-    // been set at compile time. The compute kernel does not need any runtime arguments to execute. And so we can skip
-    // this step.
-
-    // Upload the input data to the DRAM buffers, execute the kernels, wait for the result to be read into the output
-    // buffer
-    distributed::EnqueueWriteMeshBuffer(cq, src0_dram_buffer, a, false);
-    distributed::EnqueueWriteMeshBuffer(cq, src1_dram_buffer, b, false);
-    workload.add_program(device_range, std::move(program));
-    distributed::EnqueueMeshWorkload(cq, workload, false);
-    distributed::EnqueueReadMeshBuffer(cq, output, dst_dram_buffer, true);
+    // Upload the input data to the DRAM buffers, execute the kernels, read back the result.
+    ctx.write(src0_dram_buffer, a);
+    ctx.write(src1_dram_buffer, b);
+    ctx.run(builder.build());
+    output = ctx.read<bfloat16>(dst_dram_buffer);
 }
 
 ///////////////////////////////////////
@@ -186,9 +124,10 @@ int main() {
     bool pass = true;
 
     try {
-        // Open device
+        // Open device.
+        // DeviceContext wraps MeshDevice creation, command queue, and teardown in RAII.
         constexpr int device_id = 0;
-        std::shared_ptr<distributed::MeshDevice> mesh_device = distributed::MeshDevice::create_unit_mesh(device_id);
+        DeviceContext ctx(device_id);
 
         // parameters for the matrix multiplication
         constexpr uint32_t M = 640;  // user-defined
@@ -216,7 +155,7 @@ int main() {
         std::vector<bfloat16> golden_vec(M * N, 0);
         golden_matmul(src0_vec, src1_vec, golden_vec, M, N, K);
 
-        // Tilize the input vectors to match the expected tiled layout for the device
+        // Tilize the input vectors to match the expected tiled layout for the device.
         // The Tenstorrent hardware operates on data in 32x32 tiles rather than standard row-major format.
         // tilize_nfaces() converts the input matrices from row-major layout to the tiled layout expected by the device.
         // This transformation groups elements into 32x32 blocks and reorders them in memory so that each tile
@@ -227,20 +166,18 @@ int main() {
 
         // Invoke the matrix multiplication on the device
         std::vector<bfloat16> result_vec(M * N, 0);
-        matmul_single_core(src0_vec, src1_vec, result_vec, false, M, N, K, mesh_device);
+        matmul_single_core(src0_vec, src1_vec, result_vec, M, N, K, ctx);
         // Reverse the tilization to get the result in the row-major format that the CPU expects
         result_vec = untilize_nfaces(result_vec, M, N);
 
         fmt::print("Output vector of size {}\n", result_vec.size());
 
-        // Calculate the Pearson correlation coefficient (PCC) between the golden vector and the result vector
+        // Calculate the Pearson correlation coefficient (PCC) between the golden vector and the result vector.
         // This is a measure of how similar the two vectors are.
         // A PCC close to 1 indicates that the two vectors are very similar.
         float pearson = check_bfloat16_vector_pcc(golden_vec, result_vec);
         fmt::print("Metalium vs Golden -- PCC = {}\n", pearson);
         TT_FATAL(pearson > 0.97, "PCC not high enough. Result PCC: {}, Expected PCC: 0.97", pearson);
-
-        pass &= mesh_device->close();
 
     } catch (const std::exception& e) {
         fmt::print(stderr, "Test failed with exception!\n");

--- a/tt_metal/programming_examples/pad_multi_core/CMakeLists.txt
+++ b/tt_metal/programming_examples/pad_multi_core/CMakeLists.txt
@@ -7,4 +7,9 @@ target_sources(metal_example_pad_multi_core PRIVATE pad_multi_core.cpp)
 if(NOT TARGET TT::Metalium)
     find_package(TT-Metalium REQUIRED)
 endif()
-target_link_libraries(metal_example_pad_multi_core PUBLIC TT::Metalium)
+target_link_libraries(
+    metal_example_pad_multi_core
+    PUBLIC
+        TT::Metalium
+        tt_metal_ez
+)

--- a/tt_metal/programming_examples/pad_multi_core/pad_multi_core.cpp
+++ b/tt_metal/programming_examples/pad_multi_core/pad_multi_core.cpp
@@ -2,30 +2,24 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <tt-metalium/host_api.hpp>
 #include <tt-metalium/bfloat16.hpp>
-#include <tt-metalium/tt_metal.hpp>
-#include <tt-metalium/device.hpp>
-#include <tt-metalium/tensor_accessor_args.hpp>
-#include <tt-metalium/distributed.hpp>
+#include <tt-metalium/experimental/ez/ez.hpp>
+
+#include <cstdint>
+#include <vector>
 
 using namespace tt;
 using namespace tt::tt_metal;
+using namespace tt::tt_metal::experimental::ez;
 
 #ifndef OVERRIDE_KERNEL_PREFIX
 #define OVERRIDE_KERNEL_PREFIX ""
 #endif
 
 int main() {
-    // Initialize Mesh API constructs: mesh device, command queue, workload, device range, and program
-    int device_id = 0;
-    std::shared_ptr<distributed::MeshDevice> mesh_device = distributed::MeshDevice::create_unit_mesh(device_id);
-    distributed::MeshCommandQueue& cq = mesh_device->mesh_command_queue();
-    distributed::MeshWorkload workload;
-    distributed::MeshCoordinateRange device_range = distributed::MeshCoordinateRange(mesh_device->shape());
-    Program program = CreateProgram();
+    DeviceContext ctx(0);
 
-    // initialize source data
+    // Initialize source data — a (64, 32) matrix of bfloat16 packed into uint32 pairs.
     constexpr uint32_t src_M = 64;
     constexpr uint32_t src_N = 32;
     constexpr uint32_t packed_data_size = sizeof(uint32_t);
@@ -41,111 +35,102 @@ int main() {
         src_vec[i] = pack_two_bfloat16_into_uint32(std::pair<bfloat16, bfloat16>(bfloat_val1, bfloat_val2));
     }
 
-    // create pad vector
+    // Create pad vector — pad with bfloat16(2).
     bfloat16 pad_value = bfloat16(2);
     std::vector<uint32_t> pad_vec(
         1, pack_two_bfloat16_into_uint32(std::pair<bfloat16, bfloat16>(pad_value, pad_value)));
 
-    // create destination vector
+    // Destination tensor shape — padded from (64, 32) to (64, 64).
     constexpr uint32_t dst_M = 64;
     constexpr uint32_t dst_N = 64;
     uint32_t dst_num_values_unpacked = dst_M * dst_N;
     uint32_t dst_num_values_packed = dst_num_values_unpacked / packing_ratio;
     std::vector<uint32_t> dst_vec(dst_num_values_packed, 0);
 
-    // designate cores and core specs
+    // Designate cores and core specs — use 4 cores for multi-core padding.
     CoreCoord start_core = {0, 0};
     CoreCoord end_core = {0, 3};
     CoreRange cores(start_core, end_core);
     uint32_t num_cores = cores.size();
 
-    // configure and create DRAM buffers for input, pad, output
+    // Configure DRAM buffers for input, pad, and output.
     uint32_t src_buffer_size = packed_data_size * src_num_values_packed;
-    distributed::DeviceLocalBufferConfig dram_config{
-        .page_size = packed_data_size, .buffer_type = tt_metal::BufferType::DRAM};
-    distributed::ReplicatedBufferConfig input_buffer_config{.size = src_buffer_size};
-    auto src_buffer = distributed::MeshBuffer::create(input_buffer_config, dram_config, mesh_device.get());
+    auto src_buffer = ctx.dram_buffer(src_buffer_size, packed_data_size);
     uint32_t src_addr = src_buffer->address();
 
     uint32_t pad_buffer_size = packed_data_size * pad_vec.size();
-    distributed::ReplicatedBufferConfig pad_buffer_config{.size = pad_buffer_size};
-    auto pad_buffer = distributed::MeshBuffer::create(pad_buffer_config, dram_config, mesh_device.get());
+    auto pad_buffer = ctx.dram_buffer(pad_buffer_size, packed_data_size);
 
     uint32_t dst_buffer_size = packed_data_size * dst_num_values_packed;
-    distributed::ReplicatedBufferConfig output_buffer_config{.size = dst_buffer_size};
-    auto dst_buffer = distributed::MeshBuffer::create(output_buffer_config, dram_config, mesh_device.get());
+    auto dst_buffer = ctx.dram_buffer(dst_buffer_size, packed_data_size);
     uint32_t dst_addr = dst_buffer->address();
 
-    // configure circular buffers expected by TTNN reader/writer: c_0 (main), c_1 (pad), c_2 (align)
+    // Circular buffer configuration expected by TTNN reader/writer: c_0 (main), c_1 (pad), c_2 (align).
     constexpr uint32_t cb0 = CBIndex::c_0;
     constexpr uint32_t cb1 = CBIndex::c_1;
     constexpr uint32_t cb2 = CBIndex::c_2;
     tt::DataFormat cb_df = tt::DataFormat::UInt32;
-    const uint32_t stick_size_bytes = packed_data_size;              // 4 bytes per stick (one packed uint32)
-    // Use TTNN row-major minimum of 64B per stick in L1 for padding pattern
+    const uint32_t stick_size_bytes = packed_data_size;     // 4 bytes per stick (one packed uint32)
+    // Use TTNN row-major minimum of 64B per stick in L1 for padding pattern.
     const uint32_t stick_size_padded = 64;
     const uint32_t stick_size_padded_aligned = 64;
     const uint32_t num_packed_row_src = src_N / packing_ratio;
     const uint32_t num_packed_row_dst = dst_N / packing_ratio;
-    const uint32_t num_sticks_per_barrier = num_packed_row_dst;      // process one row per barrier
-    // c_0 needs capacity for one row of padded sticks
-    CircularBufferConfig cb_cfg = tt::tt_metal::CircularBufferConfig(
-                                       num_sticks_per_barrier * stick_size_padded_aligned,
-                                       {{cb0, cb_df}, {cb1, cb_df}, {cb2, cb_df}})
-                                       .set_page_size(cb0, stick_size_padded_aligned)
-                                       .set_page_size(cb1, stick_size_padded)
-                                       .set_page_size(cb2, stick_size_bytes);
-    tt_metal::CreateCircularBuffer(program, cores, cb_cfg);
+    const uint32_t num_sticks_per_barrier = num_packed_row_dst;  // process one row per barrier
 
-    // specify compile time args for TTNN reader/writer
-    std::vector<uint32_t> reader_compile_time_args;
-    // N, H, C (treat rows as N, single H=1, columns (packed) as C)
-    reader_compile_time_args.push_back(src_M);                // N
-    reader_compile_time_args.push_back(1);                    // H
-    reader_compile_time_args.push_back(num_packed_row_src);   // C
-    reader_compile_time_args.push_back(stick_size_bytes);     // stick_size_bytes
-    reader_compile_time_args.push_back(src_M);                // N_padded (same)
-    reader_compile_time_args.push_back(1);                    // H_padded
-    reader_compile_time_args.push_back(num_packed_row_dst);   // C_padded
-    reader_compile_time_args.push_back(stick_size_padded);    // stick_size_padded (32B pad pattern)
-    reader_compile_time_args.push_back(0);                    // stick_size_padded_front (left-align)
-    reader_compile_time_args.push_back(0);                    // stick_size_padded_end
-    reader_compile_time_args.push_back(1);                    // num_zero_pad_sticks_read
-    reader_compile_time_args.push_back(stick_size_padded);    // last_zero_stick_size (32)
-    reader_compile_time_args.push_back(1);                    // not_pad_by_zero
-    // pass packed pad value directly as compile-time arg as TTNN does
-    reader_compile_time_args.push_back(pad_vec[0]);           // packed_pad_value
-    reader_compile_time_args.push_back(stick_size_padded);    // row_major_min_bytes (32)
-    reader_compile_time_args.push_back(0);                    // num_front_pad_sticks_read
-    reader_compile_time_args.push_back(0);                    // num_end_pad_sticks_read
-    reader_compile_time_args.push_back(1);                    // num_sticks_padded_read per stick
-    reader_compile_time_args.push_back(stick_size_padded_aligned); // stick_size_padded_aligned (32)
-    reader_compile_time_args.push_back(0);                    // unaligned = false
-    TensorAccessorArgs(*src_buffer).append_to(reader_compile_time_args);
+    // Specify compile-time args for the TTNN-derived reader kernel.
+    // These 20 args come BEFORE the auto-generated TensorAccessorArgs, matching the kernel's
+    // expectation of TensorAccessorArgs<20>() at offset 20.
+    std::vector<uint32_t> reader_compile_args = {
+        src_M,                     // 0: N
+        1,                         // 1: H
+        num_packed_row_src,        // 2: C
+        stick_size_bytes,          // 3: stick_size_bytes
+        src_M,                     // 4: N_padded (same)
+        1,                         // 5: H_padded
+        num_packed_row_dst,        // 6: C_padded
+        stick_size_padded,         // 7: stick_size_padded (64B pad pattern)
+        0,                         // 8: stick_size_padded_front (left-align)
+        0,                         // 9: stick_size_padded_end
+        1,                         // 10: num_zero_pad_sticks_read
+        stick_size_padded,         // 11: last_zero_stick_size (64)
+        1,                         // 12: not_pad_by_zero
+        pad_vec[0],                // 13: packed_pad_value (passed as compile-time arg as TTNN does)
+        stick_size_padded,         // 14: row_major_min_bytes (64)
+        0,                         // 15: num_front_pad_sticks_read
+        0,                         // 16: num_end_pad_sticks_read
+        1,                         // 17: num_sticks_padded_read per stick
+        stick_size_padded_aligned, // 18: stick_size_padded_aligned (64)
+        0,                         // 19: unaligned = false
+    };
 
-    std::vector<uint32_t> writer_compile_time_args = {
-        cb0, stick_size_bytes, stick_size_padded_aligned};
-    TensorAccessorArgs(*dst_buffer).append_to(writer_compile_time_args);
+    // Writer compile-time args: CB index and stick sizes before TensorAccessorArgs.
+    std::vector<uint32_t> writer_compile_args = {cb0, stick_size_bytes, stick_size_padded_aligned};
 
-    // create kernels (borrowed from TTNN production code)
-    KernelHandle reader_id = CreateKernel(
-        program,
-        "tt_metal/programming_examples/pad_multi_core/kernels/pad_reader_dims_rm_interleaved.cpp",
-        cores,
-        tt_metal::DataMovementConfig{
-            .processor = DataMovementProcessor::RISCV_0,
-            .noc = NOC::RISCV_0_default,
-            .compile_args = reader_compile_time_args});
-    KernelHandle writer_id = CreateKernel(
-        program,
-        "tt_metal/programming_examples/pad_multi_core/kernels/pad_writer_dims_rm_interleaved.cpp",
-        cores,
-        tt_metal::DataMovementConfig{
-            .processor = DataMovementProcessor::RISCV_1,
-            .noc = NOC::RISCV_1_default,
-            .compile_args = writer_compile_time_args});
+    // Build the program with reader and writer kernels on all cores.
+    // The kernel uses three CB indices sharing the same L1 allocation, each with a different page size:
+    //   c_0: padded+aligned sticks (main data path)
+    //   c_1: padded sticks (pad pattern)
+    //   c_2: raw sticks (unpadded source data)
+    auto builder = ProgramBuilder(cores);
+    builder.cb(CircularBufferConfig(
+                   num_sticks_per_barrier * stick_size_padded_aligned,
+                   {{cb0, cb_df}, {cb1, cb_df}, {cb2, cb_df}})
+                   .set_page_size(cb0, stick_size_padded_aligned)
+                   .set_page_size(cb1, stick_size_padded)
+                   .set_page_size(cb2, stick_size_bytes));
 
-    // set kernel runtime arguments
+    auto& reader_ref = builder.reader(
+        OVERRIDE_KERNEL_PREFIX "pad_multi_core/kernels/pad_reader_dims_rm_interleaved.cpp",
+        {src_buffer},
+        reader_compile_args);
+
+    auto& writer_ref = builder.writer(
+        OVERRIDE_KERNEL_PREFIX "pad_multi_core/kernels/pad_writer_dims_rm_interleaved.cpp",
+        {dst_buffer},
+        writer_compile_args);
+
+    // Set per-core runtime arguments to distribute rows across cores.
     uint32_t start_src_idx = 0;
     uint32_t start_dst_idx = 0;
     uint32_t num_rows_per_core = src_M / num_cores;
@@ -154,33 +139,25 @@ int main() {
         CoreCoord core = {0, core_idx};
         uint32_t num_sticks_per_core = num_rows_per_core * num_packed_row_dst;
         uint32_t num_sticks_per_barrier_rt = num_packed_row_dst;  // one row per barrier
-        // Reader runtime: src_addr, num_sticks_per_core, num_sticks_per_barrier, start_id, front_pad_n,c,h, start_dim_offset[0..3]
-        std::vector<uint32_t> reader_rt = {src_addr,
-                                           num_sticks_per_core,
-                                           num_sticks_per_barrier_rt,
-                                           start_src_idx,
-                                           0,
-                                           0,
-                                           0,
-                                           0,
-                                           0,
-                                           0,
-                                           0};
-        tt_metal::SetRuntimeArgs(program, reader_id, core, reader_rt);
+
+        // Reader runtime: src_addr, num_sticks_per_core, num_sticks_per_barrier, start_id,
+        //   front_pad_n, front_pad_c, front_pad_h, start_dim_offset[0..3]
+        reader_ref.runtime_args_at(core, {src_addr,
+                                          num_sticks_per_core,
+                                          num_sticks_per_barrier_rt,
+                                          start_src_idx,
+                                          0, 0, 0,
+                                          0, 0, 0, 0});
         // Writer runtime: dst_addr, num_sticks_per_core, num_sticks_per_barrier, start_id
-        std::vector<uint32_t> writer_rt = {dst_addr, num_sticks_per_core, num_sticks_per_barrier_rt, start_dst_idx};
-        tt_metal::SetRuntimeArgs(program, writer_id, core, writer_rt);
+        writer_ref.runtime_args_at(core, {dst_addr, num_sticks_per_core, num_sticks_per_barrier_rt, start_dst_idx});
+
         start_src_idx += num_src_sticks_per_core;
         start_dst_idx += num_packed_row_dst * num_rows_per_core;
     }
 
     printf(
         "Padding tensor of shape (%d, %d) to shape (%d, %d) with pad value: %d\n",
-        src_M,
-        src_N,
-        dst_M,
-        dst_N,
-        std::bit_cast<uint16_t>(pad_value));
+        src_M, src_N, dst_M, dst_N, std::bit_cast<uint16_t>(pad_value));
     printf("Original tensor with shape (%d, %d):\n", src_M, src_N);
     for (uint32_t m = 0; m < src_M; m++) {
         for (uint32_t n = 0; n < num_packed_row_src; n++) {
@@ -191,13 +168,11 @@ int main() {
     }
     printf("\n");
 
-    // Upload inputs (non-blocking), enqueue mesh workload (non-blocking), read back result, then wait for completion
-    distributed::EnqueueWriteMeshBuffer(cq, src_buffer, src_vec, false);
-    distributed::EnqueueWriteMeshBuffer(cq, pad_buffer, pad_vec, false);
-    workload.add_program(device_range, std::move(program));
-    distributed::EnqueueMeshWorkload(cq, workload, false);
-    distributed::EnqueueReadMeshBuffer(cq, dst_vec, dst_buffer, true);
-    distributed::Finish(cq);
+    // Upload inputs (non-blocking), execute program, read back result.
+    ctx.write(src_buffer, src_vec);
+    ctx.write(pad_buffer, pad_vec);
+    ctx.run(builder.build());
+    dst_vec = ctx.read<uint32_t>(dst_buffer);
 
     printf("Padded tensor with shape (%d, %d):\n", dst_M, dst_N);
     for (uint32_t m = 0; m < dst_M; m++) {
@@ -207,6 +182,4 @@ int main() {
         }
         printf("\n");
     }
-
-    mesh_device->close();
 }

--- a/tt_metal/programming_examples/sfpu_eltwise_chain/CMakeLists.txt
+++ b/tt_metal/programming_examples/sfpu_eltwise_chain/CMakeLists.txt
@@ -7,4 +7,9 @@ target_sources(metal_example_sfpu_eltwise_chain PRIVATE sfpu_eltwise_chain.cpp)
 if(NOT TARGET TT::Metalium)
     find_package(TT-Metalium REQUIRED)
 endif()
-target_link_libraries(metal_example_sfpu_eltwise_chain PUBLIC TT::Metalium)
+target_link_libraries(
+    metal_example_sfpu_eltwise_chain
+    PUBLIC
+        TT::Metalium
+        tt_metal_ez
+)

--- a/tt_metal/programming_examples/sfpu_eltwise_chain/sfpu_eltwise_chain.cpp
+++ b/tt_metal/programming_examples/sfpu_eltwise_chain/sfpu_eltwise_chain.cpp
@@ -150,18 +150,15 @@ int main() {
                 {src_dram_buffer},
                 {src_cb_index, ones_cb_index})
             .runtime_args({src_dram_buffer->address()})
-            .done()
             .writer(
                 OVERRIDE_KERNEL_PREFIX "sfpu_eltwise_chain/kernels/dataflow/writer.cpp",
                 {dst_dram_buffer},
                 {result_cb_index})
             .runtime_args({dst_dram_buffer->address()})
-            .done()
             .compute(
                 OVERRIDE_KERNEL_PREFIX "sfpu_eltwise_chain/kernels/compute/compute.cpp",
                 MathFidelity::HiFi4,
                 {src_cb_index, ones_cb_index, result_cb_index})
-            .done()
             .build();
 
     // Execute program and read result back to host.

--- a/tt_metal/programming_examples/sfpu_eltwise_chain/sfpu_eltwise_chain.cpp
+++ b/tt_metal/programming_examples/sfpu_eltwise_chain/sfpu_eltwise_chain.cpp
@@ -2,15 +2,13 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <tt-metalium/host_api.hpp>
-#include <tt-metalium/tensor_accessor_args.hpp>
+#include <tt-metalium/bfloat16.hpp>
+#include <tt-metalium/experimental/ez/ez.hpp>
 #include <tt-metalium/tilize_utils.hpp>
-#include <tt-metalium/constants.hpp>
-#include <tt-metalium/distributed.hpp>
 
 #include <cmath>
-#include <random>
 #include <cstdint>
+#include <random>
 #include <vector>
 
 #ifndef OVERRIDE_KERNEL_PREFIX
@@ -19,6 +17,7 @@
 
 using namespace tt;
 using namespace tt::tt_metal;
+using namespace tt::tt_metal::experimental::ez;
 
 /**
  * @brief Computes the softplus activation function element-wise on input vector
@@ -92,124 +91,90 @@ inline float check_bfloat16_vector_pcc(const std::vector<bfloat16>& vec_a, const
     y_stddev /= vec_b.size();
 
     // Calculate the correlation coefficient
-    float correlation_coefficient_ = covariance / (std::sqrt(x_stddev) * std::sqrt(y_stddev));
-    return correlation_coefficient_;
+    float correlation_coefficient = covariance / (std::sqrt(x_stddev) * std::sqrt(y_stddev));
+    return correlation_coefficient;
 }
 
 int main() {
-    // Device setup
-    std::shared_ptr<distributed::MeshDevice> mesh_device = distributed::MeshDevice::create_unit_mesh(0);
+    DeviceContext ctx(0);
 
-    // Device command queue and program setup
-    distributed::MeshCommandQueue& cq = mesh_device->mesh_command_queue();
-    distributed::MeshWorkload workload;
-    distributed::MeshCoordinateRange device_range = distributed::MeshCoordinateRange(mesh_device->shape());
-    Program program = CreateProgram();
-
-    // Core range setup
     constexpr CoreCoord core = {0, 0};
 
-    // Input data preparation
+    // Input data preparation — fill one tile with random values in [0, 1).
     std::mt19937 rng(std::random_device{}());
     std::uniform_real_distribution<float> dist(0.f, 1.0f);
 
-    // Fill the source vector with random values
     std::vector<bfloat16> src_vec(constants::TILE_HW);
     for (bfloat16& v : src_vec) {
         v = bfloat16(dist(rng));
     }
 
-    // Calculate golden function results on CPU
+    // Calculate golden function results on CPU for later comparison.
     std::vector<bfloat16> golden_vec(constants::TILE_HW, 0);
     golden_softplus(src_vec, golden_vec);
 
-    // Tilize the input vectors to match the expected tiled layout for the device
+    // Tilize the input vectors to match the expected tiled layout for the device.
     // The Tenstorrent hardware operates on data in 32x32 tiles rather than standard row-major format.
-    // tilize_nfaces() converts the input matrices from row-major layout to the tiled layout expected by the device.
-    // This transformation groups elements into 32x32 blocks and reorders them in memory so that each tile
-    // (32x32 elements) is stored contiguously. This matches the native data access patterns of the matrix engine
-    // and enables efficient operations on the accelerator.
+    // tilize_nfaces() converts the input matrices from row-major layout to the tiled layout expected by
+    // the device. This transformation groups elements into 32x32 blocks and reorders them in memory so
+    // that each tile (32x32 elements) is stored contiguously. This matches the native data access
+    // patterns of the matrix engine and enables efficient operations on the accelerator.
     src_vec = tilize_nfaces(src_vec, constants::TILE_WIDTH, constants::TILE_HEIGHT);
 
-    // Dram buffer config
-    constexpr uint32_t single_tile_size = sizeof(bfloat16) * constants::TILE_HEIGHT * constants::TILE_WIDTH;
-    distributed::DeviceLocalBufferConfig dram_config{
-        .page_size = single_tile_size, .buffer_type = tt_metal::BufferType::DRAM};
-    distributed::ReplicatedBufferConfig buffer_config{.size = sizeof(bfloat16) * src_vec.size()};
-    std::shared_ptr<distributed::MeshBuffer> src_dram_buffer =
-        distributed::MeshBuffer::create(buffer_config, dram_config, mesh_device.get());  // Input buffer
-    std::shared_ptr<distributed::MeshBuffer> dst_dram_buffer =
-        distributed::MeshBuffer::create(buffer_config, dram_config, mesh_device.get());  // Output buffer
+    // DRAM buffer setup — allocate tile buffers for input and output.
+    auto src_dram_buffer = ctx.dram_tile_buffer(1);
+    auto dst_dram_buffer = ctx.dram_tile_buffer(1);
 
-    // DRAM transfer
-    distributed::EnqueueWriteMeshBuffer(cq, src_dram_buffer, src_vec, false);
+    // Upload data from host to device DRAM.
+    ctx.write(src_dram_buffer, src_vec);
 
-    // L1 circular buffer setup
+    // Build the program with 3 kernels forming a pipeline:
+    //   Reader  → reads tile from DRAM into cb_0, also fills cb_1 with ones (for softplus computation)
+    //   Compute → applies softplus (exp → add_ones → log) via SFPU, writes result to cb_2
+    //   Writer  → writes result tile from cb_2 back to DRAM
+    //
+    // The CB indices are passed as compile-time args before the auto-generated TensorAccessorArgs.
+    // The compute kernel receives CB indices but does NOT need TensorAccessorArgs since it only
+    // operates on L1 circular buffers, not DRAM.
     constexpr uint32_t src_cb_index = CBIndex::c_0;
-    CircularBufferConfig cb_src_config =
-        CircularBufferConfig(single_tile_size, {{src_cb_index, tt::DataFormat::Float16_b}})
-            .set_page_size(src_cb_index, single_tile_size);
-    tt_metal::CreateCircularBuffer(program, core, cb_src_config);
-
     constexpr uint32_t ones_cb_index = CBIndex::c_1;
-    CircularBufferConfig cb_ones_config =
-        CircularBufferConfig(single_tile_size, {{ones_cb_index, tt::DataFormat::Float16_b}})
-            .set_page_size(ones_cb_index, single_tile_size);
-    tt_metal::CreateCircularBuffer(program, core, cb_ones_config);
-
     constexpr uint32_t result_cb_index = CBIndex::c_2;
-    CircularBufferConfig cb_result_config =
-        CircularBufferConfig(single_tile_size, {{result_cb_index, tt::DataFormat::Float16_b}})
-            .set_page_size(result_cb_index, single_tile_size);
-    tt_metal::CreateCircularBuffer(program, core, cb_result_config);
 
-    // Kernels setup
-    // Data movement kernels
-    std::vector<uint32_t> reader_compile_time_args = {src_cb_index, ones_cb_index};
-    TensorAccessorArgs(*src_dram_buffer).append_to(reader_compile_time_args);
-    KernelHandle reader_kernel_id = CreateKernel(
-        program,
-        OVERRIDE_KERNEL_PREFIX "sfpu_eltwise_chain/kernels/dataflow/reader.cpp",
-        core,
-        tt::tt_metal::ReaderDataMovementConfig{reader_compile_time_args});
-    std::vector<uint32_t> writer_compile_time_args = {result_cb_index};
-    TensorAccessorArgs(*dst_dram_buffer).append_to(writer_compile_time_args);
-    KernelHandle writer_kernel_id = CreateKernel(
-        program,
-        OVERRIDE_KERNEL_PREFIX "sfpu_eltwise_chain/kernels/dataflow/writer.cpp",
-        core,
-        tt::tt_metal::WriterDataMovementConfig{writer_compile_time_args});
+    auto program =
+        ProgramBuilder(core)
+            .cb(tt::CBIndex::c_0, /*num_tiles=*/1)
+            .cb(tt::CBIndex::c_1, /*num_tiles=*/1)
+            .cb(tt::CBIndex::c_2, /*num_tiles=*/1)
+            .reader(
+                OVERRIDE_KERNEL_PREFIX "sfpu_eltwise_chain/kernels/dataflow/reader.cpp",
+                {src_dram_buffer},
+                {src_cb_index, ones_cb_index})
+            .runtime_args({src_dram_buffer->address()})
+            .done()
+            .writer(
+                OVERRIDE_KERNEL_PREFIX "sfpu_eltwise_chain/kernels/dataflow/writer.cpp",
+                {dst_dram_buffer},
+                {result_cb_index})
+            .runtime_args({dst_dram_buffer->address()})
+            .done()
+            .compute(
+                OVERRIDE_KERNEL_PREFIX "sfpu_eltwise_chain/kernels/compute/compute.cpp",
+                MathFidelity::HiFi4,
+                {src_cb_index, ones_cb_index, result_cb_index})
+            .done()
+            .build();
 
-    // Compute kernel
-    std::vector<uint32_t> compute_compile_time_args = {src_cb_index, ones_cb_index, result_cb_index};
-    CreateKernel(
-        program,
-        OVERRIDE_KERNEL_PREFIX "sfpu_eltwise_chain/kernels/compute/compute.cpp",
-        core,
-        tt::tt_metal::ComputeConfig{.compile_args = compute_compile_time_args});
+    // Execute program and read result back to host.
+    ctx.run(std::move(program));
+    auto result_vec = ctx.read<bfloat16>(dst_dram_buffer);
 
-    // Runtime args setup
-    SetRuntimeArgs(program, reader_kernel_id, core, {src_dram_buffer->address()});
-    SetRuntimeArgs(program, writer_kernel_id, core, {dst_dram_buffer->address()});
-
-    // Program enqueue
-    workload.add_program(device_range, std::move(program));
-    distributed::EnqueueMeshWorkload(cq, workload, false);
-    distributed::Finish(cq);
-
-    // Data transfer back to host machine
-    std::vector<bfloat16> result_vec(constants::TILE_HW, 0);
-    distributed::EnqueueReadMeshBuffer(cq, result_vec, dst_dram_buffer, true);
-
-    // Reverse the tilization to get the result in the row-major format that the CPU expects
+    // Reverse the tilization to get the result in the row-major format that the CPU expects.
     result_vec = untilize_nfaces(result_vec, constants::TILE_WIDTH, constants::TILE_HEIGHT);
 
-    // Calculate the Pearson correlation coefficient (PCC) between the golden vector and the result vector
+    // Calculate the Pearson correlation coefficient (PCC) between the golden vector and the result vector.
     // This is a measure of how similar the two vectors are.
     // A PCC close to 1 indicates that the two vectors are very similar.
     const float pearson = check_bfloat16_vector_pcc(golden_vec, result_vec);
     fmt::print("Metalium vs Golden -- PCC = {}\n", pearson);
     TT_FATAL(pearson > 0.999, "PCC not high enough. Result PCC: {}, Expected PCC: 0.999", pearson);
-
-    mesh_device->close();
 }

--- a/tt_metal/programming_examples/shard_data_rm/CMakeLists.txt
+++ b/tt_metal/programming_examples/shard_data_rm/CMakeLists.txt
@@ -7,4 +7,9 @@ target_sources(metal_example_shard_data_rm PRIVATE shard_data_rm.cpp)
 if(NOT TARGET TT::Metalium)
     find_package(TT-Metalium REQUIRED)
 endif()
-target_link_libraries(metal_example_shard_data_rm PUBLIC TT::Metalium)
+target_link_libraries(
+    metal_example_shard_data_rm
+    PUBLIC
+        TT::Metalium
+        tt_metal_ez
+)

--- a/tt_metal/programming_examples/shard_data_rm/shard_data_rm.cpp
+++ b/tt_metal/programming_examples/shard_data_rm/shard_data_rm.cpp
@@ -116,7 +116,6 @@ int main() {
                 uint32_t stick_id = idx_h * shard_width / values_per_stick;
                 return {src_addr, shard_size, padded_offset_bytes, stick_id};
             })
-            .done()
             .build();
 
     fmt::print("Original tensor values: ");

--- a/tt_metal/programming_examples/shard_data_rm/shard_data_rm.cpp
+++ b/tt_metal/programming_examples/shard_data_rm/shard_data_rm.cpp
@@ -2,17 +2,17 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <tt-metalium/host_api.hpp>
 #include <tt-metalium/bfloat16.hpp>
-#include <tt-metalium/tt_metal.hpp>
-#include <tt-metalium/device.hpp>
+#include <tt-metalium/experimental/ez/ez.hpp>
 #include <tt-metalium/allocator.hpp>
-#include <tt-metalium/tensor_accessor_args.hpp>
-#include <tt-metalium/distributed.hpp>
 #include <tt-metalium/tt_align.hpp>
+
+#include <cstdint>
+#include <vector>
 
 using namespace tt;
 using namespace tt::tt_metal;
+using namespace tt::tt_metal::experimental::ez;
 
 #ifndef OVERRIDE_KERNEL_PREFIX
 #define OVERRIDE_KERNEL_PREFIX ""
@@ -25,14 +25,6 @@ int main() {
     // Here, a row-major matrix of shape (M, N) is sharded across 4 cores along the M dimension, resulting in 4 shards
     // of shape (M/4, N).
 
-    // Select device 0 and create a command queue and program object for kernel/buffer management.
-    int device_id = 0;
-    std::shared_ptr<distributed::MeshDevice> mesh_device = distributed::MeshDevice::create_unit_mesh(device_id);
-    distributed::MeshCommandQueue& cq = mesh_device->mesh_command_queue();
-    distributed::MeshWorkload workload;
-    distributed::MeshCoordinateRange device_range = distributed::MeshCoordinateRange(mesh_device->shape());
-    Program program = CreateProgram();           // Encapsulates kernels and buffers
-
     const char* dprint_env = std::getenv("TT_METAL_DPRINT_CORES");
     if (!dprint_env || std::string(dprint_env).empty()) {
         fmt::print(stderr, "[WARNING] TT_METAL_DPRINT_CORES is not set.\n");
@@ -40,6 +32,8 @@ int main() {
         fmt::print(stderr, "          To enable output, run:\n");
         fmt::print(stderr, "              export TT_METAL_DPRINT_CORES='(0,0)-(0,3)'\n");
     }
+
+    DeviceContext ctx(0);
 
     // Create a vector of shape (16, 1) with values {2, 4, 6, ..., 32} in bfloat16 format.
     // See the following visualization of the data layout (transposed to make showing easier in text)
@@ -60,7 +54,7 @@ int main() {
     constexpr uint32_t M = 16;  // Number of columns
     constexpr uint32_t N = 1;   // Number of rows
     // Use 4 cores: (0,0), (0,1), (0,2), (0,3) for sharding.
-    constexpr uint32_t num_cores = 4;  // Number of cores
+    constexpr uint32_t num_cores = 4;
     CoreCoord start_core = {0, 0};
     CoreCoord end_core = {0, num_cores - 1};
     CoreRange cores(start_core, end_core);  // Rectangle of cores (note: end is inclusive)
@@ -79,57 +73,51 @@ int main() {
     // Shard height: number of rows per core (in units of uint32_t pages)
     // Shard width: number of columns per core
     // Shard size: total elements per core
-    // input_unit_size: size of a page (uint32_t, alignment requirement)
-    // shard_width_bytes: width in bytes for each shard
-    uint32_t shard_height = M / num_cores;                       // Height per shard (see note below)
+    uint32_t shard_height = M / num_cores;                       // Height per shard
     uint32_t shard_width = N;                                    // Width per shard
     uint32_t shard_size = shard_height * shard_width;            // Elements per shard
     constexpr uint32_t input_unit_size = sizeof(uint32_t);       // Page size for buffer (alignment need on core)
 
     // Note: Since bfloat16 is 2 bytes and uint32_t is 4 bytes, each page contains 2 bfloat16 values.
     // The division by data_size ensures correct mapping of values to pages.
-    uint32_t padded_offset_bytes = align(input_unit_size, mesh_device->allocator()->get_alignment(BufferType::DRAM));
+    uint32_t padded_offset_bytes =
+        align(input_unit_size, ctx.device().allocator()->get_alignment(BufferType::DRAM));
 
-    // configure and create interleaved DRAM buffer to insert source data into
+    // Create interleaved DRAM buffer to hold the source data.
     uint32_t src_buffer_size = num_values * data_size;
-    distributed::DeviceLocalBufferConfig input_dram_config{
-        .page_size = input_unit_size, .buffer_type = tt_metal::BufferType::DRAM};
-    distributed::ReplicatedBufferConfig buffer_config{.size = src_buffer_size};
-    std::shared_ptr<distributed::MeshBuffer> src_buffer =
-        distributed::MeshBuffer::create(buffer_config, input_dram_config, mesh_device.get());
+    auto src_buffer = ctx.dram_buffer(src_buffer_size, input_unit_size);
     const uint32_t src_addr = src_buffer->address();
-    distributed::EnqueueWriteMeshBuffer(cq, src_buffer, src_vec, false);
+    ctx.write(src_buffer, src_vec);
 
-    // configure and create circular buffers with the same address on each of the designated cores
-    // Create a circular buffer on each core to hold its shard of data
+    // Build the program: a reader kernel on each core that reads its shard from DRAM.
+    // The CB index is passed as a compile-time arg before the auto-generated TensorAccessorArgs,
+    // matching the convention used by the kernel (TensorAccessorArgs<1>() expects offset 1).
+    //
+    // A circular buffer on each core holds its shard of data. The per-core runtime args set each
+    // core's starting position in the DRAM buffer:
+    //   - src_addr: base address of the source DRAM buffer
+    //   - shard_size: number of elements this core will process
+    //   - padded_offset_bytes: DRAM page alignment
+    //   - stick_id: index of the first stick in this core's shard
+    //     (recall a stick is 2 bfloat16 values = 4 bytes in this example)
     uint32_t input_cb_index = CBIndex::c_0;
-    size_t cb_total_size = shard_size * input_unit_size;  // Total buffer size per core
-    CircularBufferConfig input_cb_config = CircularBufferConfig(cb_total_size, {{input_cb_index, cb_data_format}})
-                                               .set_page_size(input_cb_index, input_unit_size);
+    const uint32_t values_per_stick = input_unit_size / data_size; // Number of bfloat16 values per stick
 
-    CreateCircularBuffer(program, cores, input_cb_config);
-
-    // create data movement kernel to shard data
-    std::vector<uint32_t> reader_compile_time_args = {(std::uint32_t)input_cb_index};
-    TensorAccessorArgs(*src_buffer).append_to(reader_compile_time_args);
-    const uint32_t values_per_stick = input_unit_size / data_size;  // Number of bfloat16 values per stick
-    auto reader_id = tt_metal::CreateKernel(
-        program,
-        OVERRIDE_KERNEL_PREFIX "shard_data_rm/kernels/reader_sharded_rm.cpp",
-        cores,
-        tt_metal::DataMovementConfig{
-            .processor = DataMovementProcessor::RISCV_0,
-            .noc = NOC::RISCV_0_default,
-            .compile_args = reader_compile_time_args});
-
-    // Set the parameters for each core to read its shard of data
-    for (uint32_t i = 0; i < num_cores; i++) {
-        CoreCoord core = {0, i};
-        uint32_t idx_h = i * shard_height;
-        // stick_id is the index of the first stick in the shard (recall a stick is 2 bfloat16 values in this example)
-        uint32_t stick_id = idx_h * shard_width / values_per_stick;
-        tt_metal::SetRuntimeArgs(program, reader_id, core, {src_addr, shard_size, padded_offset_bytes, stick_id});
-    }
+    auto program =
+        ProgramBuilder(cores)
+            .cb(tt::CBIndex::c_0, cb_data_format, /*num_tiles=*/shard_size, /*page_size=*/input_unit_size)
+            .reader(
+                OVERRIDE_KERNEL_PREFIX "shard_data_rm/kernels/reader_sharded_rm.cpp",
+                {src_buffer},
+                {input_cb_index})
+            .runtime_args([&](const CoreCoord& core) -> std::vector<uint32_t> {
+                uint32_t i = core.y;
+                uint32_t idx_h = i * shard_height;
+                uint32_t stick_id = idx_h * shard_width / values_per_stick;
+                return {src_addr, shard_size, padded_offset_bytes, stick_id};
+            })
+            .done()
+            .build();
 
     fmt::print("Original tensor values: ");
     for (auto val : src_vec) {
@@ -137,17 +125,12 @@ int main() {
     }
     fmt::print("\n");
 
-    // start/finish program and close device
-    workload.add_program(device_range, std::move(program));
-    distributed::EnqueueMeshWorkload(cq, workload, false);
-    // Kernel prints to console. No need to print the output here.
-    //
-    // You should see the following output in the console:
+    // Execute the program. Kernel prints to console (with TT_METAL_DPRINT_CORES set).
+    // Expected output:
     // 0:(x=0,y=0):BR: Core (0,0): 2 4 6 8
     // 0:(x=0,y=1):BR: Core (0,1): 10 12 14 16
     // 0:(x=0,y=2):BR: Core (0,2): 18 20 22 24
     // 0:(x=0,y=3):BR: Core (0,3): 26 28 30 32
-    distributed::Finish(cq);
-    mesh_device->close();
+    ctx.run(std::move(program));
     fmt::print("Program finished successfully.\n");
 }

--- a/tt_metal/programming_examples/vecadd_multi_core/CMakeLists.txt
+++ b/tt_metal/programming_examples/vecadd_multi_core/CMakeLists.txt
@@ -7,4 +7,9 @@ target_sources(metal_example_vecadd_multi_core PRIVATE vecadd_multi_core.cpp)
 if(NOT TARGET TT::Metalium)
     find_package(TT-Metalium REQUIRED)
 endif()
-target_link_libraries(metal_example_vecadd_multi_core PUBLIC TT::Metalium)
+target_link_libraries(
+    metal_example_vecadd_multi_core
+    PUBLIC
+        TT::Metalium
+        tt_metal_ez
+)

--- a/tt_metal/programming_examples/vecadd_multi_core/vecadd_multi_core.cpp
+++ b/tt_metal/programming_examples/vecadd_multi_core/vecadd_multi_core.cpp
@@ -1,72 +1,22 @@
-// SPDX-FileCopyrightText: © 2025 TenstorrentAI ULC
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 
-// this programing example is based on the vecadd single core example in the
-// contributed folder it illustarted using multiple cores to perform vector
-// addition the program will use 4 cores to perform the vector addition
+// This programming example is based on the vecadd single core example in the
+// contributed folder. It illustrates using multiple cores to perform vector
+// addition. The program will use all available cores to perform the vector addition.
 #include <tt-metalium/bfloat16.hpp>
-#include <tt-metalium/core_coord.hpp>
-#include <tt-metalium/host_api.hpp>
-#include <tt-metalium/device.hpp>
+#include <tt-metalium/experimental/ez/ez.hpp>
 #include <tt-metalium/work_split.hpp>
-#include <tt-metalium/tensor_accessor_args.hpp>
-#include <tt-metalium/distributed.hpp>
 
-#include <cstddef>
 #include <cstdint>
-#include <memory>
 #include <random>
 #include <string_view>
 #include <vector>
 
 using namespace tt;
 using namespace tt::tt_metal;
-
-using CoreSpec = std::variant<CoreCoord, CoreRange, CoreRangeSet>;
-
-std::shared_ptr<distributed::MeshBuffer> MakeMeshBuffer(
-    const std::shared_ptr<distributed::MeshDevice>& mesh_device, uint32_t size, uint32_t page_size, bool sram) {
-    distributed::DeviceLocalBufferConfig local_config{
-        .page_size = page_size, .buffer_type = (sram ? BufferType::L1 : BufferType::DRAM)};
-    distributed::ReplicatedBufferConfig buffer_config{.size = size};
-    return distributed::MeshBuffer::create(buffer_config, local_config, mesh_device.get());
-}
-
-// Allocate a buffer on DRAM or SRAM. Assuming the buffer holds BFP16 data.
-// A tile on Tenstorrent is 32x32 elements, given us using BFP16, we need 2
-// bytes per element. Making the tile size 32x32x2 = 2048 bytes.
-// @param device: The device to allocate the buffer on.
-// @param n_tiles: The number of tiles to allocate.
-// @param sram: If true, allocate the buffer on SRAM, otherwise allocate it on
-// DRAM.
-std::shared_ptr<distributed::MeshBuffer> MakeMeshBufferBFP16(
-    const std::shared_ptr<distributed::MeshDevice>& mesh_device, uint32_t n_tiles, bool sram) {
-    constexpr uint32_t tile_size = sizeof(bfloat16) * tt::constants::TILE_WIDTH * tt::constants::TILE_HEIGHT;
-    // For simplicity, all DRAM buffers have page size = tile size.
-    const uint32_t page_tiles = sram ? n_tiles : 1;
-    return MakeMeshBuffer(mesh_device, tile_size * n_tiles, page_tiles * tile_size, sram);
-}
-
-CBHandle MakeCircularBuffer(
-    Program& program, const CoreSpec& core, tt::CBIndex cb, uint32_t size, uint32_t page_size, tt::DataFormat format) {
-    CircularBufferConfig cb_src0_config = CircularBufferConfig(size, {{cb, format}}).set_page_size(cb, page_size);
-    return CreateCircularBuffer(program, core, cb_src0_config);
-}
-
-// Circular buffers are Tenstorrent's way of communicating between the data
-// movement and the compute kernels. kernels queue tiles into the circular
-// buffer and takes them when they are ready. The circular buffer is backed by
-// SRAM. There can be multiple circular buffers on a single Tensix core.
-// @param program: The program to create the circular buffer on.
-// @param core: The core to create the circular buffer on.
-// @param cb: Which circular buffer to create (c_in0, c_in1, c_out0, c_out1,
-// etc..). This is just an ID
-// @param n_tiles: The number of tiles the circular buffer can hold.
-CBHandle MakeCircularBufferBFP16(Program& program, const CoreSpec& core, tt::CBIndex cb, uint32_t n_tiles) {
-    constexpr uint32_t tile_size = sizeof(bfloat16) * tt::constants::TILE_WIDTH * tt::constants::TILE_HEIGHT;
-    return MakeCircularBuffer(program, core, cb, n_tiles * tile_size, tile_size, tt::DataFormat::Float16_b);
-}
+using namespace tt::tt_metal::experimental::ez;
 
 std::string next_arg(int& i, int argc, char** argv) {
     if (i + 1 >= argc) {
@@ -104,25 +54,20 @@ int main(int argc, char** argv) {
             help(argv[0]);
         }
     }
-    // n_tiles is number of tiles of data for this programming example to add two vectors
+
+    // n_tiles is the number of tiles of data for this example to add two vectors.
     const uint32_t n_tiles = 640;
 
-    std::shared_ptr<distributed::MeshDevice> mesh_device = distributed::MeshDevice::create_unit_mesh(device_id);
-
-    distributed::MeshWorkload workload;
-    distributed::MeshCoordinateRange device_range = distributed::MeshCoordinateRange(mesh_device->shape());
-    Program program = CreateProgram();
-
-    distributed::MeshCommandQueue& cq = mesh_device->mesh_command_queue();
+    DeviceContext ctx(device_id);
 
     const uint32_t tile_size = tt::constants::TILE_WIDTH * tt::constants::TILE_HEIGHT;
     std::map<CoreCoord, uint32_t> core_tile_idx;
 
-    // Create 3 buffers on DRAM. These will hold the input and output data. A
-    // and B are the input buffers, C is the output buffer.
-    auto a = MakeMeshBufferBFP16(mesh_device, n_tiles, false);
-    auto b = MakeMeshBufferBFP16(mesh_device, n_tiles, false);
-    auto c = MakeMeshBufferBFP16(mesh_device, n_tiles, false);
+    // Create 3 DRAM tile buffers: A and B are inputs, C is the output.
+    // A tile on Tenstorrent is 32x32 elements; with BFloat16, each tile occupies 2048 bytes.
+    auto a = ctx.dram_tile_buffer(n_tiles);
+    auto b = ctx.dram_tile_buffer(n_tiles);
+    auto c = ctx.dram_tile_buffer(n_tiles);
 
     std::mt19937 rng(seed);
     std::uniform_real_distribution<float> dist(0, 10.0f);
@@ -133,25 +78,17 @@ int main(int argc, char** argv) {
         b_data[i] = bfloat16(dist(rng));
     }
 
-    auto core_grid = mesh_device->compute_with_storage_grid_size();
+    auto core_grid = ctx.device().compute_with_storage_grid_size();
     uint32_t num_cores_x = core_grid.x;
     uint32_t num_cores_y = core_grid.y;
-    // CoreRnge uses inclusive start and exclusive end coordinates so range is [0, 0] to [num_cores_x - 1, num_cores_y -
-    // 1]. instead of the more intuitive [0, num_cores_x) and [0, num_cores_y).
+    // CoreRange uses inclusive start and end coordinates: [0, 0] to [num_cores_x - 1, num_cores_y - 1].
     auto all_device_cores = CoreRange({0, 0}, {num_cores_x - 1, num_cores_y - 1});
 
-    const uint32_t cir_buf_num_title = 4;
-    MakeCircularBufferBFP16(program, all_device_cores, tt::CBIndex::c_0, cir_buf_num_title);
-    MakeCircularBufferBFP16(program, all_device_cores, tt::CBIndex::c_1, cir_buf_num_title);
-    MakeCircularBufferBFP16(program, all_device_cores, tt::CBIndex::c_2, cir_buf_num_title);
-
-    // Calculate the work distribution across the cores. The work is split into 2 groups of cores. Primary and
-    // secondary. The primary group will process more tiles pre core than the secondary group, in case the number of
-    // work is not evenly divisible by the number of available cores. This function guarantees that the work is exactly
-    // split across the cores. No more, no less.
-    constexpr bool row_major =
-        true;  // Distribute the work in row-major order (across the grid of cores). For this application, it doesn't
-               // matter much But it may for kernels with more complex data access patterns.
+    // Calculate the work distribution across the cores. The work is split into 2 groups of cores.
+    // Primary and secondary. The primary group will process more tiles per core than the secondary
+    // group, in case the number of tiles is not evenly divisible by the number of available cores.
+    // This function guarantees that the work is exactly split across the cores. No more, no less.
+    constexpr bool row_major = true;
     auto
         [num_cores,                   // number of cores utilized
          all_cores,                   // set of all cores used
@@ -161,103 +98,84 @@ int main(int argc, char** argv) {
          num_tiles_per_core_group_2   // Number of tiles each core in the secondary group processes
     ] = tt::tt_metal::split_work_to_cores(core_grid, n_tiles, row_major);
 
-    // A Tensix core is made up with 5 processors. 2 data movement processors,
-    // and 3 compute processors. The 2 data movement processors act independent
-    // to other cores. And the 3 compute processors act together (hence 1 kerenl
-    // for compute). There is no need to explicitly parallelize the compute
-    // kernels. Unlike traditional CPU/GPU style SPMD programming, the 3 compute
-    // processors moves data from SRAM into the FPU(tensor engine)/SFPU(SIMD
-    // engine), operates on the data, and move it back to SRAM. The data
-    // movement processors moves data from the NoC, or in our case, the DRAM,
-    // into the SRAM.
+    // A Tensix core is made up of 5 processors: 2 data movement processors and 3 compute processors.
+    // The 2 data movement processors act independently. The 3 compute processors act together
+    // (hence 1 kernel for compute). The data movement processors move data from the NoC (or DRAM)
+    // into SRAM, and the compute processors move data from SRAM into the FPU/SFPU, operate on it,
+    // and move it back.
     //
-    // Though the multi-Tensix parallelization strategy is SPMD for this example
+    // The vector add example consists of 3 kernels:
+    //   interleaved_tile_read → reads tiles from A and B into circular buffers c_0 and c_1
+    //   add_multi_core        → reads from c_0 and c_1, adds tiles, writes result to c_2
+    //   tile_write             → reads from c_2 and writes tiles to output buffer C
     //
-    // The vector add example consists of 3 kernels. `interleaved_tile_read`
-    // reads tiles from the input buffers A and B into 2 circular buffers. `add`
-    // reads tiles from the circular buffers, adds them together, and dumps the
-    // result into a third circular buffer. `tile_write` reads tiles from the
-    // third circular buffer and writes them to the output buffer C.
-    std::vector<uint32_t> reader_compile_time_args = {(std::uint32_t)tt::CBIndex::c_0, (std::uint32_t)tt::CBIndex::c_1};
-    std::unordered_map<std::string, uint32_t> reader_named_compile_time_args = {
-        {"c_0", (std::uint32_t)tt::CBIndex::c_0}, {"c_1", (std::uint32_t)tt::CBIndex::c_1}};
-    TensorAccessorArgs(*a).append_to(reader_compile_time_args);
-    TensorAccessorArgs(*b).append_to(reader_compile_time_args);
-    std::vector<uint32_t> writer_compile_time_args = {(std::uint32_t)tt::CBIndex::c_2};
-    TensorAccessorArgs(*c).append_to(writer_compile_time_args);
-    std::vector<uint32_t> compute_compile_time_args = {
-        (std::uint32_t)tt::CBIndex::c_0, (std::uint32_t)tt::CBIndex::c_1, (std::uint32_t)tt::CBIndex::c_2};
-    std::unordered_map<std::string, uint32_t> compute_named_compile_time_args = {
-        {"c_0", (std::uint32_t)tt::CBIndex::c_0},
-        {"c_1", (std::uint32_t)tt::CBIndex::c_1},
-        {"c_2", (std::uint32_t)tt::CBIndex::c_2}};
+    // Circular buffers act as pipes between kernels on the same core. They are backed by L1 (SRAM)
+    // memory. Each CB here holds 4 tiles for multi-buffering to overlap data movement and compute.
+    //
+    // The CB indices are passed as compile-time args before the auto-generated TensorAccessorArgs,
+    // matching the kernels' expectation (e.g. TensorAccessorArgs<2>() at offset 2 in the reader).
+    constexpr uint32_t cir_buf_num_tiles = 4;
 
-    auto reader = CreateKernel(
-        program,
-        "tt_metal/programming_examples/vecadd_multi_core/kernels/"
-        "interleaved_tile_read_multi_core.cpp",
-        all_cores,
-        DataMovementConfig{
-            .processor = DataMovementProcessor::RISCV_0,
-            .noc = NOC::RISCV_0_default,
-            .compile_args = reader_compile_time_args,
-            .named_compile_args = reader_named_compile_time_args});
-    auto writer = CreateKernel(
-        program,
-        "tt_metal/programming_examples/vecadd_multi_core/kernels/"
-        "tile_write_multi_core.cpp",
-        all_cores,
-        DataMovementConfig{
-            .processor = DataMovementProcessor::RISCV_1,
-            .noc = NOC::RISCV_1_default,
-            .compile_args = writer_compile_time_args});
-    auto compute = CreateKernel(
-        program,
-        "tt_metal/programming_examples/vecadd_multi_core/"
-        "kernels/add_multi_core.cpp",
-        all_cores,
-        ComputeConfig{
-            .math_approx_mode = false,
-            .compile_args = compute_compile_time_args,
-            .defines = {},
-            .named_compile_args = compute_named_compile_time_args});
+    auto builder = ProgramBuilder(all_cores);
+    builder.cb(tt::CBIndex::c_0, cir_buf_num_tiles)
+        .cb(tt::CBIndex::c_1, cir_buf_num_tiles)
+        .cb(tt::CBIndex::c_2, cir_buf_num_tiles);
 
+    auto& reader_ref = builder
+        .named_args({{"c_0", (uint32_t)tt::CBIndex::c_0}, {"c_1", (uint32_t)tt::CBIndex::c_1}})
+        .reader(
+            "tt_metal/programming_examples/vecadd_multi_core/kernels/interleaved_tile_read_multi_core.cpp",
+            {a, b},
+            {(uint32_t)tt::CBIndex::c_0, (uint32_t)tt::CBIndex::c_1});
+
+    auto& writer_ref = builder.writer(
+        "tt_metal/programming_examples/vecadd_multi_core/kernels/tile_write_multi_core.cpp",
+        {c},
+        {(uint32_t)tt::CBIndex::c_2});
+
+    auto& compute_ref = builder
+        .named_args({{"c_0", (uint32_t)tt::CBIndex::c_0},
+                     {"c_1", (uint32_t)tt::CBIndex::c_1},
+                     {"c_2", (uint32_t)tt::CBIndex::c_2}})
+        .compute(
+            "tt_metal/programming_examples/vecadd_multi_core/kernels/add_multi_core.cpp",
+            MathFidelity::HiFi4,
+            {(uint32_t)tt::CBIndex::c_0, (uint32_t)tt::CBIndex::c_1, (uint32_t)tt::CBIndex::c_2});
+
+    // Set per-core runtime arguments to achieve SPMD — each core gets a different starting tile
+    // and number of tiles to process.
     auto work_groups = {
         std::make_pair(core_group_1, num_tiles_per_core_group_1),
         std::make_pair(core_group_2, num_tiles_per_core_group_2)};
-    // Set the runtime arguments for each core in the work groups. Give them a different starting and ending point to
-    // achieve SPMD
     uint32_t start_tile_id = 0;
     for (const auto& [group, work_per_core] : work_groups) {
         for (const auto& range : group.ranges()) {
             for (const auto& core : range) {
-                SetRuntimeArgs(program, reader, core, {a->address(), b->address(), work_per_core, start_tile_id});
-                SetRuntimeArgs(program, writer, core, {c->address(), work_per_core, start_tile_id});
-                SetRuntimeArgs(program, compute, core, {work_per_core, start_tile_id});
-                core_tile_idx[core] = start_tile_id;  // Save the mapping so we can print the results later.
+                reader_ref.runtime_args_at(core, {a->address(), b->address(), work_per_core, start_tile_id});
+                writer_ref.runtime_args_at(core, {c->address(), work_per_core, start_tile_id});
+                compute_ref.runtime_args_at(core, {work_per_core, start_tile_id});
+                core_tile_idx[core] = start_tile_id;
 
                 start_tile_id += work_per_core;
             }
         }
     }
 
-    EnqueueWriteMeshBuffer(cq, a, a_data, false);
-    EnqueueWriteMeshBuffer(cq, b, b_data, false);
-    // Enqueue the program
-    workload.add_program(device_range, std::move(program));
-    distributed::EnqueueMeshWorkload(cq, workload, false);
+    ctx.write(a, a_data);
+    ctx.write(b, b_data);
+
+    // Execute the program.
+    ctx.run(builder.build());
 
     std::cout << "Kernel execution finished" << std::endl;
 
     // Read the output buffer.
-    std::vector<bfloat16> c_data;
-    distributed::EnqueueReadMeshBuffer(cq, c_data, c, true);
+    auto c_data = ctx.read<bfloat16>(c);
 
     // Print partial results so we can see the output is correct (plus or minus
-    // some error due to BFP16 precision)
+    // some error due to BFP16 precision).
     std::cout << "Partial results: (note we are running under BFP16. It's going "
                  "to be less accurate)\n";
-    // Print some results from some of the cores to illustrate the computation
     for (uint32_t core_y = 0; core_y < num_cores_y; core_y++) {
         CoreCoord core(0, core_y);
         if (!core_tile_idx.contains(core)) {
@@ -281,7 +199,7 @@ int main(int argc, char** argv) {
     bool pass = true;
     for (size_t i = 0; i < c_data.size(); i++) {
         float expected = static_cast<float>(a_data[i]) + static_cast<float>(b_data[i]);
-        if (std::abs(static_cast<float>(c_data[i]) - expected) > 0.3f) {  // Allow some tolerance due to BFP16 precision
+        if (std::abs(static_cast<float>(c_data[i]) - expected) > 0.3f) {
             fmt::print(
                 "Mismatch at index {}: {} + {} = {}, expected {}\n",
                 i,
@@ -298,7 +216,5 @@ int main(int argc, char** argv) {
         fmt::print(stderr, "Some results did not match expected values.\n");
     }
 
-    // Finally, we close the device.
-    mesh_device->close();
     return 0;
 }

--- a/tt_metal/programming_examples/vecadd_sharding/CMakeLists.txt
+++ b/tt_metal/programming_examples/vecadd_sharding/CMakeLists.txt
@@ -7,4 +7,9 @@ target_sources(metal_example_vecadd_sharding PRIVATE vecadd_sharding.cpp)
 if(NOT TARGET TT::Metalium)
     find_package(TT-Metalium REQUIRED)
 endif()
-target_link_libraries(metal_example_vecadd_sharding PUBLIC TT::Metalium)
+target_link_libraries(
+    metal_example_vecadd_sharding
+    PUBLIC
+        TT::Metalium
+        tt_metal_ez
+)

--- a/tt_metal/programming_examples/vecadd_sharding/vecadd_sharding.cpp
+++ b/tt_metal/programming_examples/vecadd_sharding/vecadd_sharding.cpp
@@ -8,66 +8,21 @@
 // Data copy is avoided and reader and writer kernels are not needed.
 
 #include <tt-metalium/bfloat16.hpp>
-#include <tt-metalium/core_coord.hpp>
-#include <tt-metalium/host_api.hpp>
-#include <tt-metalium/device.hpp>
-#include <tt-metalium/tt_metal.hpp>
-#include "tt-metalium/buffer.hpp"
-#include "tt-metalium/buffer_types.hpp"
-#include "tt-metalium/constants.hpp"
-#include <tt-metalium/distributed.hpp>
+#include <tt-metalium/experimental/ez/ez.hpp>
 
-#include <cstddef>
 #include <cstdint>
-#include <memory>
 #include <random>
 #include <string_view>
 #include <vector>
 
 using namespace tt::tt_metal;
-
-using CoreSpec = std::variant<CoreCoord, CoreRange, CoreRangeSet>;
+using namespace tt::tt_metal::experimental::ez;
 
 struct DistributionConfig {
-    DistributionConfig(TensorMemoryLayout layout, uint32_t num_cores_y, uint32_t num_cores_x) :
-        layout(layout), num_cores_y(num_cores_y), num_cores_x(num_cores_x) {}
-
     TensorMemoryLayout layout;
     uint32_t num_cores_y;
     uint32_t num_cores_x;
 };
-
-std::shared_ptr<distributed::MeshBuffer> MakeShardedL1MeshBufferBFP16(
-    const std::shared_ptr<distributed::MeshDevice>& mesh_device,
-    size_t size,
-    const DistributionConfig& config,
-    const ShardSpecBuffer& shard_config) {
-    BufferShardingArgs sharding_args = BufferShardingArgs(shard_config, config.layout);
-    distributed::DeviceLocalBufferConfig local_config{
-        .page_size = tt::constants::TILE_HW * sizeof(bfloat16),
-        .buffer_type = BufferType::L1,
-        .sharding_args = sharding_args,
-    };
-    distributed::ReplicatedBufferConfig buffer_config{
-        .size = size,
-    };
-    return distributed::MeshBuffer::create(buffer_config, local_config, mesh_device.get());
-}
-
-CBHandle MakeCircularBufferBFP16(
-    Program& program,
-    const CoreSpec& core,
-    tt::CBIndex cb,
-    uint32_t n_tiles,
-    const std::shared_ptr<distributed::MeshBuffer>& l1_buf) {
-    constexpr uint32_t tile_size = sizeof(bfloat16) * tt::constants::TILE_HW;
-    CircularBufferConfig cb_config = CircularBufferConfig(n_tiles * tile_size, {{cb, tt::DataFormat::Float16_b}})
-                                         .set_page_size(cb, tile_size)
-                                         // IMPORTANT: assign L1 buffer address to circular buffer directly so that
-                                         // no extra allocation and data copy
-                                         .set_globally_allocated_address(*(l1_buf->get_backing_buffer()));
-    return CreateCircularBuffer(program, core, cb_config);
-}
 
 std::string next_arg(int& i, int argc, char** argv) {
     if (i + 1 >= argc) {
@@ -140,11 +95,7 @@ int main(int argc, char** argv) {
         }
     }
 
-    std::shared_ptr<distributed::MeshDevice> mesh_device = distributed::MeshDevice::create_unit_mesh(device_id);
-    distributed::MeshWorkload workload;
-    distributed::MeshCoordinateRange device_range = distributed::MeshCoordinateRange(mesh_device->shape());
-    Program program = CreateProgram();
-
+    DeviceContext ctx(device_id);
     const auto& config = test_configs.at(sharding_type);
 
     // In this example we will distribute 16 tiles (4x4) across 4 cores.
@@ -154,6 +105,7 @@ int main(int argc, char** argv) {
     // Calculate the number of tiles per core in each dimension based on the configuration.
     const uint32_t num_tiles_per_core_x = n_tiles_x / config.num_cores_x;
     const uint32_t num_tiles_per_core_y = n_tiles_y / config.num_cores_y;
+    const uint32_t num_tiles_per_core = num_tiles_per_core_x * num_tiles_per_core_y;
 
     fmt::print(
         "Sharding {}x{} tiles to {}x{} cores in {} mode\n",
@@ -164,29 +116,20 @@ int main(int argc, char** argv) {
         config.layout);
     fmt::print("Each core will handle {}x{} tiles\n\n", num_tiles_per_core_y, num_tiles_per_core_x);
 
-    // Construct the L1 configuration. The configuration is very detailed to enable maximum performance.
     // The cores that the buffer will be sharded across.
     const CoreRange cores(CoreCoord(0, 0), CoreCoord(config.num_cores_y - 1, config.num_cores_x - 1));
-    // The sharing configuration for the buffer
-    ShardSpecBuffer spec(
-        // core_sets: The set of cores to shard the buffer across
-        cores,
-        // shard_shape: The size of each shard in the buffer
-        {uint32_t(num_tiles_per_core_x * tt::constants::TILE_HEIGHT),
-         uint32_t(num_tiles_per_core_y * tt::constants::TILE_WIDTH)},
-        // shard_orientation: The orientation of the shards in the buffer
-        ShardOrientation::ROW_MAJOR,
-        // page_shape: The shape of each page in the buffer (most likely equals to tile size as that's what the compute
-        // engines expect)
-        {tt::constants::TILE_HEIGHT, tt::constants::TILE_WIDTH},
-        // tensor2d_shape_in_pages: The shape of the tensor in pages/(tiles)
-        {n_tiles_y, n_tiles_x});
 
-    // Create the input and output buffers that lives on L1(SRAM)
-    size_t size_bytes = n_tiles_y * n_tiles_x * tt::constants::TILE_HW * sizeof(bfloat16);
-    auto a = MakeShardedL1MeshBufferBFP16(mesh_device, size_bytes, config, spec);
-    auto b = MakeShardedL1MeshBufferBFP16(mesh_device, size_bytes, config, spec);
-    auto c = MakeShardedL1MeshBufferBFP16(mesh_device, size_bytes, config, spec);
+    // Create the input and output buffers that live on L1(SRAM), sharded across cores.
+    ShardConfig shard_config{
+        .cores = CoreRangeSet(cores),
+        .shard_shape =
+            {num_tiles_per_core_x * tt::constants::TILE_HEIGHT, num_tiles_per_core_y * tt::constants::TILE_WIDTH},
+        .tensor2d_shape_in_pages = {n_tiles_y, n_tiles_x},
+        .layout = config.layout,
+    };
+    auto a = ctx.sharded_l1_buffer(shard_config);
+    auto b = ctx.sharded_l1_buffer(shard_config);
+    auto c = ctx.sharded_l1_buffer(shard_config);
 
     // Data to fill the input buffers.
     std::mt19937 rng(seed);
@@ -199,40 +142,33 @@ int main(int argc, char** argv) {
         b_data[i] = bfloat16(dist(rng));
     }
 
-    size_t num_tiles_per_core = n_tiles_x * n_tiles_y / CoreRangeSet(cores).num_cores();
-    // Create circular buffers so the compute APIs can access the data.
-    // NOTE: These are special circular buffers that have explicitly set L1 buffer address. As data already fully
-    // resides in L1, we can simply point the circular buffers to the L1 buffers and avoid any extra allocation or data
-    // copy. This is an impotant optimization for performance. But hyper specific to use cases like this one.
-    MakeCircularBufferBFP16(program, cores, tt::CBIndex::c_0, num_tiles_per_core, a);
-    MakeCircularBufferBFP16(program, cores, tt::CBIndex::c_1, num_tiles_per_core, b);
-    MakeCircularBufferBFP16(program, cores, tt::CBIndex::c_2, num_tiles_per_core, c);
+    // Copy data from host to L1 directly.
+    ctx.write(a, a_data);
+    ctx.write(b, b_data);
 
-    // Create the kernel
-    auto compute = CreateKernel(
-        program,
-        "tt_metal/programming_examples/vecadd_sharding/kernels/add_sharding.cpp",
-        cores,
-        ComputeConfig{
-            .math_approx_mode = false,
-            // pass in compile time arguments
-            .compile_args = {tt::CBIndex::c_0, tt::CBIndex::c_1, tt::CBIndex::c_2}});
+    // Build the program: 3 L1-backed circular buffers + compute kernel.
+    // Because data is already in L1 via sharding, no reader/writer kernels are needed.
+    // The CBs point directly at the sharded L1 buffer memory (no extra allocation or copy).
+    auto program =
+        ProgramBuilder(cores)
+            .cb(tt::CBIndex::c_0, a, num_tiles_per_core)
+            .cb(tt::CBIndex::c_1, b, num_tiles_per_core)
+            .cb(tt::CBIndex::c_2, c, num_tiles_per_core)
+            .compute(
+                "tt_metal/programming_examples/vecadd_sharding/kernels/add_sharding.cpp",
+                ComputeConfig{
+                    .math_approx_mode = false,
+                    .compile_args = {tt::CBIndex::c_0, tt::CBIndex::c_1, tt::CBIndex::c_2}})
+            .runtime_args({num_tiles_per_core})
+            .done()
+            .build();
 
-    // copy data from host to L1 directly
-    distributed::MeshCommandQueue& cq = mesh_device->mesh_command_queue();
-    EnqueueWriteMeshBuffer(cq, a, a_data, false);
-    EnqueueWriteMeshBuffer(cq, b, b_data, false);
-
-    // Setup arguments and run the program.
-    SetRuntimeArgs(program, compute, cores, {num_tiles_per_core});
-    workload.add_program(device_range, std::move(program));
-    distributed::EnqueueMeshWorkload(cq, workload, false);
+    ctx.run(std::move(program));
 
     fmt::print("Kernel execution finished. Reading results...\n");
 
     // Read the output buffer.
-    std::vector<bfloat16> c_data;
-    distributed::EnqueueReadMeshBuffer(cq, c_data, c, true);
+    auto c_data = ctx.read<bfloat16>(c);
 
     // Print partial results so we can see the output is correct (plus or minus
     // some error due to BFP16 precision)
@@ -244,7 +180,7 @@ int main(int argc, char** argv) {
     for ([[maybe_unused]] auto& core : cores) {
         const auto core_offset = core_idx * element_per_core;
         fmt::print("Core {}:\n", core_idx);
-        for (int index = 0; index < print_per_core; index++) {
+        for (size_t index = 0; index < print_per_core; index++) {
             const auto i = core_offset + index;
             fmt::print(
                 "index {}: {} + {} = {}\n",
@@ -274,7 +210,6 @@ int main(int argc, char** argv) {
         fmt::print(stderr, "Some results did not match expected values.\n");
     }
 
-    // Finally, we close the device.
-    mesh_device->close();
+    // DeviceContext closes the device automatically when it goes out of scope.
     return 0;
 }

--- a/tt_metal/programming_examples/vecadd_sharding/vecadd_sharding.cpp
+++ b/tt_metal/programming_examples/vecadd_sharding/vecadd_sharding.cpp
@@ -160,7 +160,6 @@ int main(int argc, char** argv) {
                     .math_approx_mode = false,
                     .compile_args = {tt::CBIndex::c_0, tt::CBIndex::c_1, tt::CBIndex::c_2}})
             .runtime_args({num_tiles_per_core})
-            .done()
             .build();
 
     ctx.run(std::move(program));


### PR DESCRIPTION
### Ticket

N/A — new experimental API

### Problem description

The TT-Metalium programming API is powerful but demands significant boilerplate for even simple programs. A basic "read tiles, compute, write back" example requires manually managing MeshDevice lifecycle, constructing DeviceLocalBufferConfig + ReplicatedBufferConfig + MeshBuffer, assembling CircularBufferConfig objects, building TensorAccessorArgs, wiring DataMovementConfig/ComputeConfig, orchestrating MeshWorkload + EnqueueMeshWorkload, and cleaning up — typically 6-8 disconnected setup steps before any domain logic appears.

This is a steep learning curve for newcomers and makes the programming examples — the primary teaching material — harder to follow than they need to be. The intent of each program gets buried under API ceremony.

### What's changed

A new `tt::tt_metal::experimental::ez` namespace provides two thin RAII wrappers (~690 lines of library code) that let programs express *what* they want instead of *how* to wire it up:

**DeviceContext** — owns device lifecycle, buffer creation, and data transfer:
```cpp
DeviceContext ctx(0);
auto buf = ctx.dram_tile_buffer(n_tiles);
ctx.write(buf, data);
ctx.run(program);
auto result = ctx.read<bfloat16>(buf);
```

**ProgramBuilder** — fluent builder for programs with deferred kernel creation and method chaining:
```cpp
auto program = ProgramBuilder(core)
    .cb(CBIndex::c_0).cb(CBIndex::c_1).cb(CBIndex::c_16)
    .reader("reader.cpp", {src0, src1})
        .runtime_args({src0->address(), n_tiles})
    .compute("compute.cpp")
        .named_args({{"cb_in0", CBIndex::c_0}, {"cb_in1", CBIndex::c_1}})
        .defines({{"ACTIVATION", "relu"}})
        .runtime_args({n_tiles})
    .writer("writer.cpp", {dst})
        .runtime_args({dst->address(), n_tiles})
    .build();
```

Kernel creation is deferred until `build()`. This means per-kernel configuration — `defines()`, `named_args()`, `runtime_args()` — can be called on the `KernelRef` returned by `reader()`/`writer()`/`compute()`, and each applies only to that kernel. Forwarding methods on `KernelRef` allow seamless chaining back to the builder without any intermediate commit step.

The API is intentionally minimal — it wraps existing Metalium primitives without hiding them. `ctx.device()` and `builder.build()` provide escape hatches to the full API at any point.

**All 21 programming examples have been converted.** The reduction is most dramatic in the simpler examples — exactly the ones newcomers encounter first — where up to 45% of the code was pure boilerplate. Even the complex multi-core matmul examples see meaningful cleanup. Educational comments about hardware concepts (tile layout, circular buffers, NoC mechanics, SFPU pipelines) are preserved throughout.

| Example | Before | After | Reduction |
|---------|-------:|------:|----------|
| eltwise_sfpu | 174 | 95 | **45%** |
| add_2_integers_in_compute | 176 | 102 | 42% |
| eltwise_binary | 192 | 127 | 33% |
| vecadd_multi_core | 304 | 220 | 27% |
| matmul_single_core | 261 | 198 | 24% |
| matmul_multicore_reuse | 413 | 334 | 19% |
| **Total (all 21 examples)** | **4,300** | **3,168** | **26%** |

Importantly, the lines removed are *not* comments or logic — they are API plumbing. The domain logic and educational content are preserved.

Key ProgramBuilder features exercised across the examples:
- `reader()`/`writer()` auto-generate TensorAccessorArgs from buffer lists
- `.on(core)` places kernels on specific cores for multi-core programs
- `.runtime_args(lambda)` computes per-core args without manual core iteration
- `.defines()` and `.named_args()` on `KernelRef` for per-kernel compile-time configuration
- `.semaphore()` and `.physical_core()` for synchronization and NoC multicast
- `.cb(index, l1_buffer)` for L1-backed circular buffers
- `.cb(CircularBufferConfig)` raw overload for shared CB index patterns

**Commit structure:**
1. Library + unit tests (12 test cases covering all API surface)
2. Simple single-core example conversions (10 examples)
3. Data movement and compute chain conversions (5 examples)
4. Multi-core example conversions (3 examples)
5. Matmul example conversions (3 examples — most complex)
6. Lazy kernel creation, per-kernel named_args/defines, eliminate done() (13 test cases)

### Checklist

- [ ] Post-commit and Blackhole CI — cannot trigger workflows as an external contributor; maintainers please run.
- [x] New/Existing tests provide coverage for changes
- [x] All 13 unit tests and 19 example binaries verified on Blackhole p100a hardware