### PR TITLE
[Blitz Decode] Integrate Embedding with H2D

### DIFF
--- a/models/demos/deepseek_v3_b1/micro_ops/host_io/kernels/d2h_sender.cpp
+++ b/models/demos/deepseek_v3_b1/micro_ops/host_io/kernels/d2h_sender.cpp
@@ -4,7 +4,7 @@
 #include <cstdint>
 #include "api/dataflow/dataflow_api.h"
 #include "api/socket_api.h"
-#include "api/debug/dprint.h"
+#include <pcie_noc_utils.h>
 
 FORCE_INLINE bool socket_wait_for_pages_with_termination(
     const SocketReceiverInterface& socket, uint32_t num_pages, volatile tt_l1_ptr uint32_t* termination_semaphore) {
@@ -63,14 +63,13 @@ void kernel_main() {
                 break;
             }
             uint32_t read_addr = get_read_ptr(upstream_interface_index);
-            noc_wwrite_with_state<noc_mode, write_cmd_buf, CQ_NOC_SNDL, CQ_NOC_SEND, CQ_NOC_WAIT, true, false>(
+            noc_async_wide_write_any_len_with_state(
                 NOC_INDEX,
                 read_addr,
                 pcie_xy_enc,
                 ((static_cast<uint64_t>(write_addr_hi) << 32) | sender_socket.downstream_fifo_addr) +
                     sender_socket.write_ptr,
-                page_size,
-                1);
+                page_size);
             noc_async_writes_flushed();
             cb_pop_front(upstream_interface_index, 1);
         } else {
@@ -79,14 +78,13 @@ void kernel_main() {
                 break;
             }
             uint32_t read_addr = receiver_socket.read_ptr;
-            noc_wwrite_with_state<noc_mode, write_cmd_buf, CQ_NOC_SNDL, CQ_NOC_SEND, CQ_NOC_WAIT, true, false>(
+            noc_async_wide_write_any_len_with_state(
                 NOC_INDEX,
                 read_addr,
                 pcie_xy_enc,
                 ((static_cast<uint64_t>(write_addr_hi) << 32) | sender_socket.downstream_fifo_addr) +
                     sender_socket.write_ptr,
-                page_size,
-                1);
+                page_size);
             socket_pop_pages(receiver_socket, 1);
             noc_async_writes_flushed();
             socket_notify_sender(receiver_socket);
@@ -102,5 +100,4 @@ void kernel_main() {
 
     noc_async_write_barrier();
     noc_async_read_barrier();
-    DPRINT << "End D2H Main Loop" << ENDL();
 }

--- a/models/demos/deepseek_v3_b1/micro_ops/host_io/kernels/d2h_sender.cpp
+++ b/models/demos/deepseek_v3_b1/micro_ops/host_io/kernels/d2h_sender.cpp
@@ -4,7 +4,7 @@
 #include <cstdint>
 #include "api/dataflow/dataflow_api.h"
 #include "api/socket_api.h"
-#include <pcie_noc_utils.h>
+#include "pcie_noc_utils.h"
 
 FORCE_INLINE bool socket_wait_for_pages_with_termination(
     const SocketReceiverInterface& socket, uint32_t num_pages, volatile tt_l1_ptr uint32_t* termination_semaphore) {

--- a/models/demos/deepseek_v3_b1/micro_ops/host_io/kernels/fused_h2d_receiver_embedding.cpp
+++ b/models/demos/deepseek_v3_b1/micro_ops/host_io/kernels/fused_h2d_receiver_embedding.cpp
@@ -4,6 +4,7 @@
 #include <cstdint>
 #include "api/dataflow/dataflow_api.h"
 #include "api/socket_api.h"
+#include "api/tensor/tensor_accessor.h"
 #include <pcie_noc_utils.h>
 
 FORCE_INLINE bool socket_wait_for_pages_with_termination(
@@ -22,25 +23,32 @@ void kernel_main() {
     // Get this value from MeshSocket struct on host
     constexpr uint32_t recv_socket_config_addr = get_compile_time_arg_val(0);
     constexpr uint32_t termination_semaphore_addr = get_compile_time_arg_val(1);
-    constexpr uint32_t page_size = get_compile_time_arg_val(2);
+    constexpr uint32_t token_page_size = get_compile_time_arg_val(2);
     constexpr bool pull_from_host = get_compile_time_arg_val(3);
     constexpr bool loopback_mode = get_compile_time_arg_val(4);
     constexpr uint32_t downstream_interface_index = get_compile_time_arg_val(5);
+    constexpr uint32_t embedding_cb_index = get_compile_time_arg_val(6);
+    constexpr uint32_t embedding_page_size = get_compile_time_arg_val(7);
+    constexpr uint32_t embedding_addr = get_compile_time_arg_val(8);
+    // TensorAccessorArgs for embedding tensor at CT arg index 9
+    constexpr auto embedding_args = TensorAccessorArgs<9>();
+
+    auto embedding_accessor = TensorAccessor(embedding_args, embedding_addr, embedding_page_size);
 
     SocketReceiverInterface receiver_socket = create_receiver_socket_interface(recv_socket_config_addr);
     SocketSenderInterface sender_socket = {};
 
     if constexpr (!loopback_mode) {
         sender_socket = create_sender_socket_interface(downstream_interface_index);
-        set_sender_socket_page_size(sender_socket, page_size);
+        set_sender_socket_page_size(sender_socket, embedding_page_size);
     }
-    set_receiver_socket_page_size(receiver_socket, page_size);
+    set_receiver_socket_page_size(receiver_socket, token_page_size);
+
+    // Read first page of embedding tensor from DRAM into CB
 
     uint32_t read_addr_hi = receiver_socket.h2d.data_addr_hi;
     uint32_t read_addr_lo = receiver_socket.h2d.data_addr_lo;
     uint32_t pcie_xy_enc = receiver_socket.h2d.pcie_xy_enc;
-
-    noc_write_init_state<write_cmd_buf>(NOC_INDEX, NOC_UNICAST_WRITE_VC);
 
     volatile tt_l1_ptr uint32_t* termination_semaphore =
         reinterpret_cast<volatile tt_l1_ptr uint32_t*>(termination_semaphore_addr);
@@ -57,32 +65,40 @@ void kernel_main() {
                 ((static_cast<uint64_t>(read_addr_hi) << 32) | read_addr_lo) + receiver_socket.read_ptr -
                     receiver_socket.fifo_addr,
                 receiver_socket.read_ptr,
-                page_size);
+                token_page_size);
             noc_async_read_barrier();
         }
+
+        volatile tt_l1_ptr uint32_t* token_id_ptr =
+            reinterpret_cast<volatile tt_l1_ptr uint32_t*>(receiver_socket.read_ptr);
+        uint32_t l1_write_addr = get_write_ptr(embedding_cb_index);
+        uint64_t noc_addr = embedding_accessor.get_noc_addr(*token_id_ptr);
+        noc_async_read(noc_addr, l1_write_addr, embedding_page_size);
+        noc_async_read_barrier();
 
         if constexpr (loopback_mode) {
             cb_reserve_back(downstream_interface_index, 1);
             noc_async_write(
-                receiver_socket.read_ptr, get_noc_addr(get_write_ptr(downstream_interface_index)), page_size);
+                get_noc_addr(get_read_ptr(embedding_cb_index)),
+                get_noc_addr(get_write_ptr(downstream_interface_index)),
+                embedding_page_size);
             noc_async_write_barrier();
             cb_push_back(downstream_interface_index, 1);
         } else {
             sender_downstream_encoding downstream_enc = get_downstream_encoding(sender_socket, 0);
             socket_reserve_pages(sender_socket, 1);
             noc_async_write(
-                receiver_socket.read_ptr,
+                get_noc_addr(get_read_ptr(embedding_cb_index)),
                 get_noc_addr(
                     downstream_enc.d2d.downstream_noc_x,
                     downstream_enc.d2d.downstream_noc_y,
                     sender_socket.write_ptr + sender_socket.downstream_fifo_addr),
-                page_size);
+                embedding_page_size);
             socket_push_pages(sender_socket, 1);
             socket_notify_receiver(sender_socket);
             noc_async_writes_flushed();
         }
         socket_pop_pages(receiver_socket, 1);
-        // Notify Host that pages were popped from H2D socket
         socket_notify_sender(receiver_socket);
         invalidate_l1_cache();
     }

--- a/models/demos/deepseek_v3_b1/micro_ops/host_io/kernels/fused_h2d_receiver_embedding.cpp
+++ b/models/demos/deepseek_v3_b1/micro_ops/host_io/kernels/fused_h2d_receiver_embedding.cpp
@@ -5,7 +5,7 @@
 #include "api/dataflow/dataflow_api.h"
 #include "api/socket_api.h"
 #include "api/tensor/tensor_accessor.h"
-#include <pcie_noc_utils.h>
+#include "pcie_noc_utils.h"
 
 FORCE_INLINE bool socket_wait_for_pages_with_termination(
     const SocketReceiverInterface& socket, uint32_t num_pages, volatile tt_l1_ptr uint32_t* termination_semaphore) {
@@ -69,8 +69,11 @@ void kernel_main() {
             noc_async_read_barrier();
         }
 
+        // TODO: Add and assert that token id is within vocab size
         volatile tt_l1_ptr uint32_t* token_id_ptr =
             reinterpret_cast<volatile tt_l1_ptr uint32_t*>(receiver_socket.read_ptr);
+        // Embedding CB is a scratch pad for now. We only read into the first slot of the CB.
+        // TODO: Setup separate reader to pipeline reads.
         uint32_t l1_write_addr = get_write_ptr(embedding_cb_index);
         uint64_t noc_addr = embedding_accessor.get_noc_addr(*token_id_ptr);
         noc_async_read(noc_addr, l1_write_addr, embedding_page_size);

--- a/models/demos/deepseek_v3_b1/micro_ops/host_io/kernels/h2d_receiver.cpp
+++ b/models/demos/deepseek_v3_b1/micro_ops/host_io/kernels/h2d_receiver.cpp
@@ -4,7 +4,7 @@
 #include <cstdint>
 #include "api/dataflow/dataflow_api.h"
 #include "api/socket_api.h"
-#include <pcie_noc_utils.h>
+#include "pcie_noc_utils.h"
 
 FORCE_INLINE bool socket_wait_for_pages_with_termination(
     const SocketReceiverInterface& socket, uint32_t num_pages, volatile tt_l1_ptr uint32_t* termination_semaphore) {

--- a/models/demos/deepseek_v3_b1/micro_ops/host_io/kernels/pcie_noc_utils.h
+++ b/models/demos/deepseek_v3_b1/micro_ops/host_io/kernels/pcie_noc_utils.h
@@ -1,0 +1,39 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+#include "api/dataflow/dataflow_api.h"
+
+// Contains utility functions to perform IO operations of variable length
+// over PCIe.
+
+// This implementation is currently not optimized to minimize RISC cycles.
+// APIs can be made more stateful, especially for the HostIO op, since the PCIe
+// NOC encoding is constant.
+
+FORCE_INLINE void noc_async_wide_write_any_len_with_state(
+    uint32_t noc, uint32_t src_addr, uint32_t dst_noc_addr, uint64_t dst_addr, uint32_t len_bytes) {
+    while (len_bytes > NOC_MAX_BURST_SIZE) {
+        noc_wwrite_with_state<noc_mode, write_cmd_buf, CQ_NOC_SNDL, CQ_NOC_SEND, CQ_NOC_WAIT, true, false>(
+            noc, src_addr, dst_noc_addr, dst_addr, NOC_MAX_BURST_SIZE, 1);
+        len_bytes -= NOC_MAX_BURST_SIZE;
+        src_addr += NOC_MAX_BURST_SIZE;
+        dst_addr += NOC_MAX_BURST_SIZE;
+    }
+    noc_wwrite_with_state<noc_mode, write_cmd_buf, CQ_NOC_SNDL, CQ_NOC_SEND, CQ_NOC_WAIT, true, false>(
+        noc, src_addr, dst_noc_addr, dst_addr, len_bytes, 1);
+}
+
+FORCE_INLINE void noc_async_wide_read_any_len_with_state(
+    uint32_t noc, uint64_t src_noc_encoding, uint64_t src_addr, uint32_t dst_addr, uint32_t len_bytes) {
+    while (len_bytes > NOC_MAX_BURST_SIZE) {
+        noc_read_with_state<noc_mode, read_cmd_buf, CQ_NOC_SNDL, CQ_NOC_SEND, CQ_NOC_WAIT>(
+            noc, src_noc_encoding, src_addr, dst_addr, NOC_MAX_BURST_SIZE);
+        len_bytes -= NOC_MAX_BURST_SIZE;
+        src_addr += NOC_MAX_BURST_SIZE;
+        dst_addr += NOC_MAX_BURST_SIZE;
+    }
+    noc_read_with_state<noc_mode, read_cmd_buf, CQ_NOC_SNDL, CQ_NOC_SEND, CQ_NOC_WAIT>(
+        noc, src_noc_encoding, src_addr, dst_addr, len_bytes);
+}

--- a/models/demos/deepseek_v3_b1/micro_ops/host_io/kernels/pcie_noc_utils.h
+++ b/models/demos/deepseek_v3_b1/micro_ops/host_io/kernels/pcie_noc_utils.h
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
+#pragma once
 
 #include <cstdint>
 #include "api/dataflow/dataflow_api.h"

--- a/models/demos/deepseek_v3_b1/micro_ops/host_io/op.py
+++ b/models/demos/deepseek_v3_b1/micro_ops/host_io/op.py
@@ -32,6 +32,8 @@ blocking on socket_wait_for_pages() and cb_wait_front() operations.
 """
 
 import ttnn
+from models.demos.deepseek_v3_b1.micro_ops.flash_mla.op import get_interleaved_tensor_accessor_args
+from models.demos.deepseek_v3_b1.micro_ops.host_io.utils import dtype_size
 
 
 class HostInterface:
@@ -39,20 +41,23 @@ class HostInterface:
         self,
         h2d_socket,
         d2h_socket,
-        page_size,
+        h2d_page_size,
+        d2h_page_size,
         core_to_core_socket_buffer_size=1024,
         h2d_downstream_core=ttnn.CoreCoord(0, 0),
         d2h_upstream_core=ttnn.CoreCoord(0, 0),
+        embedding_tensor=None,
         loopback_mode=False,
     ):
         self.h2d_socket = h2d_socket
         self.d2h_socket = d2h_socket
-        self.page_size = page_size
-        self.h2d_socket.set_page_size(self.page_size)
-        self.d2h_socket.set_page_size(self.page_size)
+        self.h2d_page_size = h2d_page_size
+        self.d2h_page_size = d2h_page_size
+        self.h2d_socket.set_page_size(self.h2d_page_size)
+        self.d2h_socket.set_page_size(self.d2h_page_size)
         self.loopback_mode = loopback_mode
         self.core_to_core_socket_buffer_size = core_to_core_socket_buffer_size
-
+        self.embedding_tensor = embedding_tensor
         # Validate single-core, single-chip constraint
         # Current implementation only supports host communication with one core on one chip
         if len(h2d_socket.get_active_cores()) != 1 or len(d2h_socket.get_active_cores()) != 1:
@@ -100,34 +105,47 @@ class HostInterface:
             self.upstream_socket_pair = ttnn.create_socket_pair(
                 self.mesh_device, self.mesh_device, upstream_socket_config
             )
+        else:
+            self.intermed_cb_index = 0
 
-    def run(self):
-        dummy_tensor = ttnn.allocate_tensor_on_device(
-            ttnn.Shape([0, 0, 0, 0]), ttnn.uint32, ttnn.ROW_MAJOR_LAYOUT, self.h2d_socket.get_mesh_device()
-        )
+        self.has_embedding = self.embedding_tensor is not None
+        if self.has_embedding:
+            self.embedding_page_size = self.embedding_tensor.spec.compute_page_size_bytes()
+            # For now, we assume that tokens will be passed in as 64 bytes packets to embedding.
+            # This allows us to add more information in the input packet as needed.
+            assert self.h2d_page_size == 64
+            assert self.embedding_tensor.memory_config().buffer_type == ttnn.BufferType.DRAM
+            assert self.embedding_page_size == self.embedding_tensor.shape[3] * dtype_size(
+                self.embedding_tensor.dtype
+            ), f"Expected embedding tensor to be DRAM interleaved with page size {self.embedding_page_size} bytes for shape {self.embedding_tensor.shape}"
+            self.embedding_cb_index = 2
 
-        intermed_cb_index = 0
+    def _create_h2d_kernel(self):
         h2d_socket_kernel_ct_args = [
             self.h2d_socket.get_config_buffer_address(),
             ttnn.get_global_semaphore_address(self.termination_semaphore),
-            self.page_size,
+            self.h2d_page_size,
             self.h2d_socket.get_h2d_mode() == ttnn.H2DMode.DEVICE_PULL,
             self.loopback_mode,
-            # Use a local CB if doing loopback, otherwise communicate with downstream over sockets
-            intermed_cb_index if self.loopback_mode else self.downstream_socket_pair[0].get_config_buffer_address(),
+            self.intermed_cb_index
+            if self.loopback_mode
+            else self.downstream_socket_pair[0].get_config_buffer_address(),
         ]
+        # Add CTAs for fused embedding op if needed
+        if self.has_embedding:
+            h2d_socket_kernel_ct_args.extend(
+                [self.embedding_cb_index, self.embedding_page_size, self.embedding_tensor.buffer_address()]
+            )
+            h2d_socket_kernel_ct_args.extend(get_interleaved_tensor_accessor_args(self.embedding_tensor))
 
-        d2h_socket_kernel_ct_args = [
-            self.d2h_socket.get_config_buffer_address(),
-            ttnn.get_global_semaphore_address(self.termination_semaphore),
-            self.page_size,
-            self.loopback_mode,
-            # Use a local CB if doing loopback, otherwise communicate with downstream over sockets
-            intermed_cb_index if self.loopback_mode else self.upstream_socket_pair[0].get_config_buffer_address(),
-        ]
+        kernel_source = (
+            "models/demos/deepseek_v3_b1/micro_ops/host_io/kernels/fused_h2d_receiver_embedding.cpp"
+            if self.has_embedding
+            else "models/demos/deepseek_v3_b1/micro_ops/host_io/kernels/h2d_receiver.cpp"
+        )
 
         h2d_kernel = ttnn.KernelDescriptor(
-            kernel_source="models/demos/deepseek_v3_b1/micro_ops/host_io/kernels/h2d_receiver.cpp",
+            kernel_source=kernel_source,
             source_type=ttnn.KernelDescriptor.SourceType.FILE_PATH,
             core_ranges=ttnn.CoreRangeSet(
                 [ttnn.CoreRange(self.mesh_core_coord.core_coord, self.mesh_core_coord.core_coord)]
@@ -135,6 +153,18 @@ class HostInterface:
             compile_time_args=h2d_socket_kernel_ct_args,
             config=ttnn.WriterConfigDescriptor(),
         )
+        return h2d_kernel
+
+    def _create_d2h_kernel(self):
+        d2h_socket_kernel_ct_args = [
+            self.d2h_socket.get_config_buffer_address(),
+            ttnn.get_global_semaphore_address(self.termination_semaphore),
+            self.d2h_page_size,
+            self.loopback_mode,
+            # Use a local CB if doing loopback, otherwise communicate with downstream over sockets
+            self.intermed_cb_index if self.loopback_mode else self.upstream_socket_pair[0].get_config_buffer_address(),
+        ]
+
         d2h_kernel = ttnn.KernelDescriptor(
             kernel_source="models/demos/deepseek_v3_b1/micro_ops/host_io/kernels/d2h_sender.cpp",
             source_type=ttnn.KernelDescriptor.SourceType.FILE_PATH,
@@ -144,6 +174,9 @@ class HostInterface:
             compile_time_args=d2h_socket_kernel_ct_args,
             config=ttnn.ReaderConfigDescriptor(),
         )
+        return d2h_kernel
+
+    def _create_cb_descriptors(self):
         cb_descriptors = []
         if self.loopback_mode:
             intermed_cb_desc = ttnn.CBDescriptor(
@@ -153,13 +186,41 @@ class HostInterface:
                 ),
                 format_descriptors=[
                     ttnn.CBFormatDescriptor(
-                        buffer_index=intermed_cb_index,
+                        buffer_index=self.intermed_cb_index,
                         data_format=ttnn.uint32,
-                        page_size=self.page_size,
+                        page_size=self.d2h_page_size,
                     )
                 ],
             )
             cb_descriptors.append(intermed_cb_desc)
+
+        # CB for embedding DRAM reads
+        if self.has_embedding:
+            embedding_cb_desc = ttnn.CBDescriptor(
+                total_size=self.embedding_page_size,
+                core_ranges=ttnn.CoreRangeSet(
+                    [ttnn.CoreRange(self.mesh_core_coord.core_coord, self.mesh_core_coord.core_coord)]
+                ),
+                format_descriptors=[
+                    ttnn.CBFormatDescriptor(
+                        buffer_index=self.embedding_cb_index,
+                        data_format=ttnn.bfloat16,
+                        page_size=self.embedding_page_size,
+                    )
+                ],
+            )
+            cb_descriptors.append(embedding_cb_desc)
+        return cb_descriptors
+
+    def run(self):
+        dummy_tensor = ttnn.allocate_tensor_on_device(
+            ttnn.Shape([0, 0, 0, 0]), ttnn.uint32, ttnn.ROW_MAJOR_LAYOUT, self.h2d_socket.get_mesh_device()
+        )
+
+        h2d_kernel = self._create_h2d_kernel()
+        d2h_kernel = self._create_d2h_kernel()
+        cb_descriptors = self._create_cb_descriptors()
+
         program = ttnn.ProgramDescriptor(
             kernels=[h2d_kernel, d2h_kernel],
             semaphores=[],

--- a/models/demos/deepseek_v3_b1/micro_ops/host_io/op.py
+++ b/models/demos/deepseek_v3_b1/micro_ops/host_io/op.py
@@ -187,7 +187,8 @@ class HostInterface:
                 format_descriptors=[
                     ttnn.CBFormatDescriptor(
                         buffer_index=self.intermed_cb_index,
-                        data_format=ttnn.uint32,
+                        # Setup CB data format for consistency. Value gets ignored in kernel.
+                        data_format=self.embedding_tensor.dtype if self.embedding_tensor else ttnn.uint32,
                         page_size=self.d2h_page_size,
                     )
                 ],

--- a/models/demos/deepseek_v3_b1/micro_ops/host_io/op.py
+++ b/models/demos/deepseek_v3_b1/micro_ops/host_io/op.py
@@ -110,14 +110,16 @@ class HostInterface:
 
         self.has_embedding = self.embedding_tensor is not None
         if self.has_embedding:
-            self.embedding_page_size = self.embedding_tensor.spec.compute_page_size_bytes()
             # For now, we assume that tokens will be passed in as 64 bytes packets to embedding.
             # This allows us to add more information in the input packet as needed.
             assert self.h2d_page_size == 64
-            assert self.embedding_tensor.memory_config().buffer_type == ttnn.BufferType.DRAM
-            assert self.embedding_page_size == self.embedding_tensor.shape[3] * dtype_size(
-                self.embedding_tensor.dtype
+            assert (
+                self.embedding_tensor.layout == ttnn.ROW_MAJOR_LAYOUT
+                and self.embedding_tensor.memory_config().memory_layout == ttnn.TensorMemoryLayout.INTERLEAVED
+                and self.embedding_tensor.memory_config().buffer_type == ttnn.BufferType.DRAM
             ), f"Expected embedding tensor to be DRAM interleaved with page size {self.embedding_page_size} bytes for shape {self.embedding_tensor.shape}"
+            # Tensor is DRAM interleaved, and row major. Page size is inner dim stride.
+            self.embedding_page_size = self.embedding_tensor.shape[3] * dtype_size(self.embedding_tensor.dtype)
             self.embedding_cb_index = 2
 
     def _create_h2d_kernel(self):

--- a/models/demos/deepseek_v3_b1/micro_ops/host_io/utils.py
+++ b/models/demos/deepseek_v3_b1/micro_ops/host_io/utils.py
@@ -1,0 +1,43 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Utility functions for host-io micro-op and tests.
+"""
+import torch
+
+import ttnn
+
+TORCH_TO_TTNN_DTYPE = {
+    torch.bfloat16: ttnn.bfloat16,
+    torch.float32: ttnn.float32,
+    torch.int32: ttnn.int32,
+    torch.uint32: ttnn.uint32,
+    torch.uint16: ttnn.uint16,
+    torch.uint8: ttnn.uint8,
+}
+
+TTNN_TO_TORCH_DTYPE = {v: k for k, v in TORCH_TO_TTNN_DTYPE.items()}
+
+
+def ttnn_dtype_from_torch_dtype(torch_dtype):
+    if torch_dtype not in TORCH_TO_TTNN_DTYPE:
+        raise ValueError(f"No ttnn equivalent for torch dtype: {torch_dtype}")
+    return TORCH_TO_TTNN_DTYPE[torch_dtype]
+
+
+def torch_dtype_from_ttnn_dtype(ttnn_dtype):
+    if ttnn_dtype not in TTNN_TO_TORCH_DTYPE:
+        raise ValueError(f"No torch equivalent for ttnn dtype: {ttnn_dtype}")
+    return TTNN_TO_TORCH_DTYPE[ttnn_dtype]
+
+
+def dtype_size(dtype):
+    """Get element size in bytes for a torch or ttnn dtype."""
+    if isinstance(dtype, torch.dtype):
+        return torch.tensor([], dtype=dtype).element_size()
+    elif dtype in TTNN_TO_TORCH_DTYPE:
+        return torch.tensor([], dtype=TTNN_TO_TORCH_DTYPE[dtype]).element_size()
+    else:
+        raise ValueError(f"Unsupported dtype: {dtype}")

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_host_io.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_host_io.py
@@ -13,6 +13,7 @@ from loguru import logger
 import ttnn
 from models.common.utility_functions import is_slow_dispatch
 from models.demos.deepseek_v3_b1.micro_ops.host_io.op import HostInterface
+from models.demos.deepseek_v3_b1.micro_ops.host_io.utils import dtype_size, ttnn_dtype_from_torch_dtype
 
 
 @pytest.mark.parametrize(
@@ -24,6 +25,7 @@ from models.demos.deepseek_v3_b1.micro_ops.host_io.op import HostInterface
         (64, 1024, 512),
         (512, 1024, 512),
         (1024, 2048, 128),
+        (32768, 65536, 128),
     ],
 )
 @pytest.mark.parametrize(
@@ -47,7 +49,12 @@ def test_host_io_loopback(mesh_device, tensor_size_bytes, fifo_size, num_iterati
     h2d_socket = ttnn.H2DSocket(mesh_device, socket_core, ttnn.BufferType.L1, fifo_size, h2d_mode)
     d2h_socket = ttnn.D2HSocket(mesh_device, socket_core, fifo_size)
     host_io = HostInterface(
-        h2d_socket, d2h_socket, tensor_size_bytes, core_to_core_socket_buffer_size=fifo_size, loopback_mode=True
+        h2d_socket,
+        d2h_socket,
+        tensor_size_bytes,
+        tensor_size_bytes,
+        core_to_core_socket_buffer_size=fifo_size,
+        loopback_mode=True,
     )
     host_io.run()
 
@@ -69,5 +76,106 @@ def test_host_io_loopback(mesh_device, tensor_size_bytes, fifo_size, num_iterati
         result_torch = ttnn.to_torch(output_tensor)
         match = torch.equal(torch_input, result_torch)
         assert match, f"H2D → D2H loopback data mismatch!\nExpected: {torch_input}\nGot: {result_torch}"
+
+    host_io.terminate()
+
+
+@pytest.mark.parametrize(
+    "h2d_mode",
+    [
+        ttnn.H2DMode.HOST_PUSH,
+        ttnn.H2DMode.DEVICE_PULL,
+    ],
+)
+@pytest.mark.parametrize(
+    "vocab_size, embedding_dim",
+    [
+        (64, 14336),
+        (128, 7168),
+        (256, 3584),
+        (512, 1792),
+    ],
+)
+@pytest.mark.parametrize(
+    "token_fifo_size, embedding_fifo_factor",
+    [
+        (128, 2),
+        (256, 4),
+        (512, 8),
+    ],
+)
+def test_host_io_loopback_with_embedding(
+    mesh_device, h2d_mode, vocab_size, embedding_dim, token_fifo_size, embedding_fifo_factor
+):
+    """Test H2D/D2H loopback with an embedding tensor loaded to DRAM."""
+    if not is_slow_dispatch():
+        pytest.skip("Skipping test in fast dispatch mode")
+
+    embedding_dtype = torch.bfloat16
+    token_dtype = torch.uint32
+    token_size_bytes = 64
+
+    embedding_shape = (1, 1, vocab_size, embedding_dim)
+    embedding_fifo_size = embedding_dim * dtype_size(embedding_dtype) * embedding_fifo_factor
+    token_size_datums = token_size_bytes // dtype_size(token_dtype)
+    embedding_size_bytes = embedding_shape[3] * dtype_size(embedding_dtype)
+
+    device_coord = ttnn.MeshCoordinate(0, 0)
+    core_coord = ttnn.CoreCoord(0, 0)
+    socket_core = ttnn.MeshCoreCoord(device_coord, core_coord)
+
+    # Create embedding tensor and load to DRAM
+    logger.info("Creating embedding tensor and loading to DRAM")
+    torch_embedding = torch.randn(embedding_shape, dtype=embedding_dtype)
+    embedding_tensor = ttnn.from_torch(
+        torch_embedding, dtype=ttnn_dtype_from_torch_dtype(embedding_dtype), layout=ttnn.ROW_MAJOR_LAYOUT
+    )
+    embedding_tensor = ttnn.to_device(embedding_tensor, mesh_device, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+    logger.info(f"Embedding tensor loaded to DRAM with shape {embedding_shape}")
+
+    # Create host interface with embedding
+    logger.info("Creating and Running Host Interface with embedding")
+    h2d_socket = ttnn.H2DSocket(mesh_device, socket_core, ttnn.BufferType.L1, token_fifo_size, h2d_mode)
+    d2h_socket = ttnn.D2HSocket(mesh_device, socket_core, embedding_fifo_size)
+    host_io = HostInterface(
+        h2d_socket,
+        d2h_socket,
+        token_size_bytes,
+        embedding_size_bytes,
+        core_to_core_socket_buffer_size=embedding_fifo_size,
+        embedding_tensor=embedding_tensor,
+        loopback_mode=True,
+    )
+    host_io.run()
+
+    embedding_row_elems = embedding_shape[3]
+    logger.info(f"Testing embedding with vocab size {vocab_size} over H2D → D2H loopback")
+
+    for token_id in range(vocab_size):
+        # Write 64-byte packet with token ID as first uint32, rest zeros
+        torch_input = torch.zeros(1, token_size_datums, dtype=token_dtype)
+        torch_input[0, 0] = token_id
+        input_tensor = ttnn.from_torch(
+            torch_input, dtype=ttnn_dtype_from_torch_dtype(token_dtype), layout=ttnn.ROW_MAJOR_LAYOUT
+        )
+
+        # Read embedding row back over D2H socket
+        torch_output = torch.zeros(1, embedding_row_elems, dtype=embedding_dtype)
+        output_tensor = ttnn.from_torch(
+            torch_output, dtype=ttnn_dtype_from_torch_dtype(embedding_dtype), layout=ttnn.ROW_MAJOR_LAYOUT
+        )
+
+        h2d_socket.write_tensor(input_tensor)
+        d2h_socket.read_tensor(output_tensor)
+
+        result_torch = ttnn.to_torch(output_tensor).reshape(-1)
+        expected = torch_embedding[0, 0, token_id, :].reshape(-1)
+        match = torch.equal(expected, result_torch)
+        assert match, (
+            f"Token {token_id}: D2H output does not match embedding row!\n"
+            f"Expected: {expected[:8]}...\nGot: {result_torch[:8]}..."
+        )
+
+    logger.info(f"{vocab_size} token lookups verified successfully")
 
     host_io.terminate()

--- a/ttnn/cpp/ttnn-nanobind/tensor.cpp
+++ b/ttnn/cpp/ttnn-nanobind/tensor.cpp
@@ -395,6 +395,7 @@ void tensor_mem_config_module(nb::module_& m_tensor) {
         .def_prop_ro("dtype", &TensorSpec::data_type, "Dtype of a tensor")
         .def_prop_ro("tile", &TensorSpec::tile, "Tile of a tensor")
         .def_prop_ro("memory_config", &TensorSpec::memory_config, "Memory config of a tensor")
+        .def("compute_page_size_bytes", &TensorSpec::compute_page_size_bytes, "Compute page size in bytes")
         .def(nb::self == nb::self)
         .def(nb::self != nb::self);
 

--- a/ttnn/cpp/ttnn-nanobind/tensor.cpp
+++ b/ttnn/cpp/ttnn-nanobind/tensor.cpp
@@ -395,7 +395,6 @@ void tensor_mem_config_module(nb::module_& m_tensor) {
         .def_prop_ro("dtype", &TensorSpec::data_type, "Dtype of a tensor")
         .def_prop_ro("tile", &TensorSpec::tile, "Tile of a tensor")
         .def_prop_ro("memory_config", &TensorSpec::memory_config, "Memory config of a tensor")
-        .def("compute_page_size_bytes", &TensorSpec::compute_page_size_bytes, "Compute page size in bytes")
         .def(nb::self == nb::self)
         .def(nb::self != nb::self);
 


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/37662)

### Problem description
- We need to add the embedding op for Blitz Decode:
  - `[vocab_size, embedding_dim] = [129280, 7168]`
  - DRAM Interleaved with `page_size = embedding_dim * sizeof(bfloat16)`
- For this implementation, we decided to fuse the embedding lookup with the H2D receiver

### What's changed
- Modify `HostInterface` to accept an embedding tensor as an optional input
- If specified, the interface will be run using the new `fused_h2d_receiver_embedding.cpp` kernel, which does a direct embedding lookup from input tokens and sends the embedding to the downstream receiver
- Bugfix:  Support xfer sizes > `NOC_MAX_BURST_SIZE` in `HostInterface`. The original issue was that the NOC read/write APIs used for interfacing with PCIe only supported up to a single NOC packet. Utility APIs for support arbitrary data sizes are added to `models/demos/deepseek_v3_b1/micro_ops/host_io/kernels/pcie_noc_utils.h`
- Tested main use case for Blitz Decode and additional embedding tensor shapes

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=asaigal/embedding_rebased)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:asaigal/embedding_rebased)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=asaigal/embedding_rebased)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:asaigal/embedding_rebased)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=asaigal/embedding_rebased)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:asaigal/embedding_rebased)
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=asaigal/embedding_rebased)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:asaigal/embedding_rebased)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=asaigal/embedding_rebased)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:asaigal/embedding_rebased)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=asaigal/embedding_rebased)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:asaigal/embedding_rebased)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
