### PR TITLE
POC: Vconst verifier for silu

### DIFF
--- a/tt_metal/hw/CMakeLists.txt
+++ b/tt_metal/hw/CMakeLists.txt
@@ -375,6 +375,7 @@ foreach(ARCH IN LISTS ARCHS)
         -I${PROJECT_SOURCE_DIR}/tt_metal/third_party/umd/device/${ARCH}
         -I${PROJECT_SOURCE_DIR}/tt_metal/hw/ckernels/${ARCH_ALIAS}/metal/common
         -I${PROJECT_SOURCE_DIR}/tt_metal/hw/ckernels/${ARCH_ALIAS}/metal/llk_io
+        -I${PROJECT_SOURCE_DIR}/tt_metal/third_party/tt_llk/common/inc
         -I${PROJECT_SOURCE_DIR}/tt_metal/third_party/tt_llk/tt_llk_${ARCH_ALIAS}/common/inc
         -I${PROJECT_SOURCE_DIR}/tt_metal/third_party/tt_llk/tt_llk_${ARCH_ALIAS}/llk_lib
     )

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_sigmoid.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_sigmoid.h
@@ -8,11 +8,12 @@
 #include "ckernel_defs.h"
 #include "ckernel_sfpu_sigmoid_appx.h"
 #include "ckernel_sfpu_recip.h"
+#include "vconst_verifier.h"
 
 namespace ckernel {
 namespace sfpu {
 
-template <bool is_fp32_acc_to_dest_mode = true>
+template <bool is_fp32_acc_to_dest_mode = true, typename vConstVerifier = vconst_verifier::disable>
 sfpi_inline sfpi::vFloat _sfpu_sigmoid_(sfpi::vFloat x) {
     // Compute sigmoid as:
     // sigmoid(x) = 1 / (1 + exp(-x))
@@ -30,9 +31,9 @@ sfpi_inline sfpi::vFloat _sfpu_sigmoid_(sfpi::vFloat x) {
 
     sfpi::vFloat result;
     if constexpr (is_fp32_acc_to_dest_mode) {
-        result = _sfpu_reciprocal_<2>(denominator);
+        result = _sfpu_reciprocal_<2, vConstVerifier>(denominator);
     } else {
-        result = _sfpu_reciprocal_<1>(denominator);
+        result = _sfpu_reciprocal_<1, vConstVerifier>(denominator);
     }
 
     return result;
@@ -75,12 +76,13 @@ inline void calculate_sigmoid() {
     }
 }
 
-template <bool APPROXIMATION_MODE>
-inline void sigmoid_init() {
+template <bool APPROXIMATION_MODE, typename vConstVerifier = vconst_verifier::disable>
+inline auto sigmoid_init() {
     if constexpr (!APPROXIMATION_MODE) {
-        _init_sfpu_reciprocal_<false>();
+        return _init_sfpu_reciprocal_<false, vConstVerifier>();
     } else {
         sigmoid_appx_init();
+        return vconst_verifier::unhandled();
     }
 }
 

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_silu.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_silu.h
@@ -5,17 +5,18 @@
 #pragma once
 
 #include "ckernel_sfpu_sigmoid.h"
+#include "vconst_verifier.h"
 
 namespace ckernel::sfpu {
 
-template <bool is_fp32_dest_acc_en, int ITERATIONS>
+template <bool is_fp32_dest_acc_en, int ITERATIONS, typename vConstVerifier = vconst_verifier::disable>
 inline void calculate_silu() {
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++) {
         sfpi::vFloat x = sfpi::dst_reg[0];
 
         // silu(x) = x * sigmoid(x)
-        sfpi::vFloat result = x * _sfpu_sigmoid_<is_fp32_dest_acc_en>(x);
+        sfpi::vFloat result = x * _sfpu_sigmoid_<is_fp32_dest_acc_en, vConstVerifier>(x);
 
         // Round to bfloat16 if not in fp32 accumulation mode
         if constexpr (!is_fp32_dest_acc_en) {
@@ -27,10 +28,10 @@ inline void calculate_silu() {
     }
 }
 
-template <bool APPROXIMATION_MODE>
-inline void silu_init() {
+template <bool APPROXIMATION_MODE, typename vConstVerifier = vconst_verifier::disable>
+inline auto silu_init() {
     // calculate_silu uses the non-approx sigmoid path via _sfpu_sigmoid_, so we must use non-approx sigmoid_init
-    sigmoid_init<false>();
+    return sigmoid_init<false, vConstVerifier>();
 }
 
 }  // namespace ckernel::sfpu

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_init.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_init.h
@@ -15,9 +15,9 @@ inline void llk_math_eltwise_unary_sfpu_init() {
 }
 
 template <SfpuType sfpu_op, bool APPROXIMATE, class F, class... ARGS>
-inline void llk_math_eltwise_unary_sfpu_init(F&& init_func, ARGS&&... args) {
+inline auto llk_math_eltwise_unary_sfpu_init(F&& init_func, ARGS&&... args) {
     _llk_math_eltwise_unary_sfpu_init_<sfpu_op>();
-    init_func(static_cast<ARGS&&>(args)...);
+    return init_func(static_cast<ARGS&&>(args)...);
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_silu.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_silu.h
@@ -7,18 +7,29 @@
 #include "llk_math_eltwise_unary_sfpu_init.h"
 #include "llk_math_eltwise_unary_sfpu_params.h"
 #include "ckernel_sfpu_silu.h"
+#include "vconst_verifier.h"
 
 namespace ckernel {
 
-template <bool APPROXIMATE>
-inline void llk_math_eltwise_unary_sfpu_silu_init() {
-    llk_math_eltwise_unary_sfpu_init<SfpuType::silu, APPROXIMATE>(sfpu::silu_init<APPROXIMATE>);
+template <bool APPROXIMATE, typename vConstVerifier = vconst_verifier::disable>
+inline auto llk_math_eltwise_unary_sfpu_silu_init() {
+    return llk_math_eltwise_unary_sfpu_init<SfpuType::silu, APPROXIMATE>(sfpu::silu_init<APPROXIMATE, vConstVerifier>);
 }
 
-template <bool APPROXIMATE, bool is_fp32_dest_acc_en, int ITERATIONS = 8>
-inline void llk_math_eltwise_unary_sfpu_silu(uint dst_index, int vector_mode = (int)VectorMode::RC) {
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::calculate_silu<is_fp32_dest_acc_en, ITERATIONS>, dst_index, vector_mode);
+template <
+    bool APPROXIMATE,
+    bool is_fp32_dest_acc_en,
+    int ITERATIONS = 8,
+    typename vConstVerifier = vconst_verifier::disable>
+inline auto llk_math_eltwise_unary_sfpu_silu(uint dst_index, int vector_mode = (int)VectorMode::RC) {
+    return _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+        ckernel::sfpu::calculate_silu<is_fp32_dest_acc_en, ITERATIONS, vConstVerifier>, dst_index, vector_mode);
+}
+
+template <bool APPROXIMATE, bool is_fp32_dest_acc_en, typename vConstVerifier>
+inline auto llk_math_eltwise_unary_sfpu_silu(uint dst_index, int vector_mode = (int)VectorMode::RC) {
+    return llk_math_eltwise_unary_sfpu_silu<APPROXIMATE, is_fp32_dest_acc_en, 8, vConstVerifier>(
+        dst_index, vector_mode);
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_sigmoid.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_sigmoid.h
@@ -8,11 +8,12 @@
 #include "ckernel_defs.h"
 #include "ckernel_sfpu_sigmoid_appx.h"
 #include "ckernel_sfpu_recip.h"
+#include "vconst_verifier.h"
 
 namespace ckernel {
 namespace sfpu {
 
-template <bool is_fp32_acc_to_dest_mode = true>
+template <bool is_fp32_acc_to_dest_mode = true, typename vConstVerifier = vconst_verifier::disable>
 sfpi_inline sfpi::vFloat _sfpu_sigmoid_(sfpi::vFloat x) {
     // Compute sigmoid as:
     // sigmoid(x) = 1 / (1 + exp(-x))
@@ -30,9 +31,9 @@ sfpi_inline sfpi::vFloat _sfpu_sigmoid_(sfpi::vFloat x) {
 
     sfpi::vFloat result;
     if constexpr (is_fp32_acc_to_dest_mode) {
-        result = _sfpu_reciprocal_<2>(denominator);
+        result = _sfpu_reciprocal_<2, vConstVerifier>(denominator);
     } else {
-        result = _sfpu_reciprocal_<1>(denominator);
+        result = _sfpu_reciprocal_<1, vConstVerifier>(denominator);
     }
 
     return result;
@@ -76,12 +77,13 @@ inline void calculate_sigmoid() {
     }
 }
 
-template <bool APPROXIMATION_MODE>
-inline void sigmoid_init() {
+template <bool APPROXIMATION_MODE, typename vConstVerifier = vconst_verifier::disable>
+inline auto sigmoid_init() {
     if constexpr (!APPROXIMATION_MODE) {
-        _init_reciprocal_<false, false>();
+        return _init_reciprocal_<false, false, false, vConstVerifier>();
     } else {
         sigmoid_appx_init();
+        return vconst_verifier::unhandled();
     }
 }
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_silu.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_silu.h
@@ -8,14 +8,15 @@
 
 namespace ckernel::sfpu {
 
-template <bool is_fp32_dest_acc_en, int ITERATIONS>
+template <bool is_fp32_dest_acc_en, int ITERATIONS, typename vConstVerifier = vconst_verifier::disable>
 inline void calculate_silu() {
+    static_assert(!std::is_same_v<vConstVerifier, vconst_verifier::disable>);
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++) {
         sfpi::vFloat x = sfpi::dst_reg[0];
 
         // silu(x) = x * sigmoid(x)
-        sfpi::vFloat result = x * _sfpu_sigmoid_<is_fp32_dest_acc_en>(x);
+        sfpi::vFloat result = x * _sfpu_sigmoid_<is_fp32_dest_acc_en, vConstVerifier>(x);
 
         // Round to bfloat16 if not in fp32 accumulation mode
         if constexpr (!is_fp32_dest_acc_en) {
@@ -27,12 +28,12 @@ inline void calculate_silu() {
     }
 }
 
-template <bool APPROXIMATION_MODE>
-inline void silu_init() {
+template <bool APPROXIMATION_MODE, typename vConstVerifier = vconst_verifier::disable>
+inline auto silu_init() {
     if constexpr (!APPROXIMATION_MODE) {
-        _init_sfpu_reciprocal_<false>();
+        return _init_sfpu_reciprocal_<false, vConstVerifier>();
     } else {
-        _init_sfpu_reciprocal_<true>();
+        return _init_sfpu_reciprocal_<true, vConstVerifier>();
     }
 }
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_init.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_init.h
@@ -10,13 +10,13 @@
 namespace ckernel {
 
 template <SfpuType sfpu_op, bool APPROXIMATE>
-inline void llk_math_eltwise_unary_sfpu_init() {
-    _llk_math_eltwise_unary_sfpu_init_<sfpu_op>();
+inline auto llk_math_eltwise_unary_sfpu_init() {
+    return _llk_math_eltwise_unary_sfpu_init_<sfpu_op>();
 }
 
 template <SfpuType sfpu_op, bool APPROXIMATE, class F, class... ARGS>
-inline void llk_math_eltwise_unary_sfpu_init(F&& init_func, ARGS&&... args) {
+inline auto llk_math_eltwise_unary_sfpu_init(F&& init_func, ARGS&&... args) {
     _llk_math_eltwise_unary_sfpu_init_<sfpu_op>();
-    init_func(static_cast<ARGS&&>(args)...);
+    return init_func(static_cast<ARGS&&>(args)...);
 }
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_silu.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_silu.h
@@ -7,18 +7,19 @@
 #include "llk_math_eltwise_unary_sfpu_init.h"
 #include "llk_math_eltwise_unary_sfpu_params.h"
 #include "ckernel_sfpu_silu.h"
+#include "vconst_verifier.h"
 
 namespace ckernel {
 
-template <bool APPROXIMATE>
-inline void llk_math_eltwise_unary_sfpu_silu_init() {
-    llk_math_eltwise_unary_sfpu_init<SfpuType::silu, APPROXIMATE>(sfpu::silu_init<APPROXIMATE>);
+template <bool APPROXIMATE, typename vConstVerifier = vconst_verifier::disable>
+inline auto llk_math_eltwise_unary_sfpu_silu_init() {
+    return llk_math_eltwise_unary_sfpu_init<SfpuType::silu, APPROXIMATE>(sfpu::silu_init<APPROXIMATE, vConstVerifier>);
 }
 
-template <bool APPROXIMATE, bool is_fp32_dest_acc_en>
-inline void llk_math_eltwise_unary_sfpu_silu(uint dst_index, int vector_mode = (int)VectorMode::RC) {
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
-        ckernel::sfpu::calculate_silu<is_fp32_dest_acc_en, 8>, dst_index, vector_mode);
+template <bool APPROXIMATE, bool is_fp32_dest_acc_en, typename vConstVerifier = vconst_verifier::disable>
+inline auto llk_math_eltwise_unary_sfpu_silu(uint dst_index, int vector_mode = (int)VectorMode::RC) {
+    return _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(
+        ckernel::sfpu::calculate_silu<is_fp32_dest_acc_en, 8, vConstVerifier>, dst_index, vector_mode);
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/inc/api/compute/compute_kernel_api.h
+++ b/tt_metal/hw/inc/api/compute/compute_kernel_api.h
@@ -13,6 +13,7 @@
 #include "ckernel_include.h"
 #include "hostdevcommon/kernel_structs.h"
 #include "internal/risc_attribs.h"
+#include "vconst_verifier.h"
 
 #define ALWI inline __attribute__((always_inline))
 
@@ -463,9 +464,19 @@ ALWI void expm1_tile_init() {
  * | idst            | The index of the tile in DST register buffer to perform the computation on | uint32_t | Must be less than the size of the DST register buffer | True     |
  */
 // clang-format on
-ALWI void silu_tile(uint32_t idst) { MATH((llk_math_eltwise_unary_sfpu_silu<APPROX, DST_ACCUM_MODE>(idst))); }
+template <typename vConstVerifier = vconst_verifier::disable>
+ALWI void silu_tile(uint32_t idst) {
+    MATH((llk_math_eltwise_unary_sfpu_silu<APPROX, DST_ACCUM_MODE, vConstVerifier>(idst)));
+}
 
-ALWI void silu_tile_init() { MATH((llk_math_eltwise_unary_sfpu_silu_init<APPROX>())); }
+template <typename vConstVerifier = vconst_verifier::disable>
+ALWI auto silu_tile_init() {
+#ifdef TRISC_MATH
+    return MATH((llk_math_eltwise_unary_sfpu_silu_init<APPROX, vConstVerifier>()));
+#else
+    return vConstVerifier();
+#endif
+}
 
 // topK local sort
 // clang-format off

--- a/tt_metal/llrt/hal/tt-1xx/blackhole/bh_hal.cpp
+++ b/tt_metal/llrt/hal/tt-1xx/blackhole/bh_hal.cpp
@@ -111,6 +111,7 @@ public:
         includes.push_back("tt_metal/hw/inc/internal/tt-1xx/blackhole/noc");
         includes.push_back("tt_metal/third_party/tt_llk/tt_llk_blackhole/common/inc");
         includes.push_back("tt_metal/third_party/tt_llk/tt_llk_blackhole/llk_lib");
+        includes.push_back("tt_metal/third_party/tt_llk/common/inc");
 
         switch (params.core_type) {
             case HalProgrammableCoreType::TENSIX:

--- a/tt_metal/llrt/hal/tt-1xx/wormhole/wh_hal.cpp
+++ b/tt_metal/llrt/hal/tt-1xx/wormhole/wh_hal.cpp
@@ -109,6 +109,7 @@ public:
         includes.push_back("tt_metal/hw/inc/internal/tt-1xx/wormhole/noc");
         includes.push_back("tt_metal/third_party/tt_llk/tt_llk_wormhole_b0/common/inc");
         includes.push_back("tt_metal/third_party/tt_llk/tt_llk_wormhole_b0/llk_lib");
+        includes.push_back("tt_metal/third_party/tt_llk/common/inc");
 
         switch (params.core_type) {
             case HalProgrammableCoreType::TENSIX:

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_utils.cpp
@@ -512,10 +512,7 @@ std::pair<std::string, std::string> get_op_init_and_func_parameterized(
             return {
                 "clamp_tile_init();",
                 fmt::format(
-                    "clamp_tile({}, {}, {});",
-                    idst,
-                    std::bit_cast<uint32_t>(param0),
-                    std::bit_cast<uint32_t>(param1))};
+                    "clamp_tile({}, {}, {});", idst, std::bit_cast<uint32_t>(param0), std::bit_cast<uint32_t>(param1))};
         }
         case UnaryOpType::HARDTANH: {
             float param1 = params[1];
@@ -714,7 +711,10 @@ std::pair<std::string, std::string> get_op_init_and_func_default(
         case UnaryOpType::ATAN: return {"atan_tile_init();", fmt::format("atan_tile({});", idst)};
         case UnaryOpType::ATANH: return {"atanh_tile_init();", fmt::format("atanh_tile({});", idst)};
         case UnaryOpType::TAN: return {"tan_tile_init();", fmt::format("tan_tile({});", idst)};
-        case UnaryOpType::SILU: return {"silu_tile_init();", fmt::format("silu_tile({});", idst)};
+        case UnaryOpType::SILU:
+            return {
+                "auto silu_tile_regs = silu_tile_init<vconst_verifier::no_used_regs>();",
+                fmt::format("silu_tile<decltype(silu_tile_regs)>({});", idst)};
         case UnaryOpType::FLOOR:
             TT_FATAL(
                 input_dtype.has_value(), "Missing input dtype: Expected a valid input dtype, but none was provided.");


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/37896

### Problem description
Kernels initialization can be pretty complex, with multiple layers and parametrization. This may lead to accidental miss of vConst setting, as there is no verification in this matter. As difference in const may cause small enough difference in result, UTs may not be able to catch this. Same for models - with lack of luck this may go unnoticed.

### What's changed
Added compile time mechanism to mark which consts are being set in initialization, and then, in compute part, check whether required const register was initialized.
All sets and checks are done in compile time plus compiler having empty base class optimization and unused result heuristics, which results in 0 run time overhead of this checks (assuming -O1 or higher).

POC done for silu. Tested on WH. Requires 
complementary tt-llk change for testing https://github.com/tenstorrent/tt-llk/pull/1300.

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=mateusznowakTT/guard_from_uninitialized_const_in_kernels)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:mateusznowakTT/guard_from_uninitialized_const_in_kernels)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=mateusznowakTT/guard_from_uninitialized_const_in_kernels)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:mateusznowakTT/guard_from_uninitialized_const_in_kernels)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mateusznowakTT/guard_from_uninitialized_const_in_kernels)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mateusznowakTT/guard_from_uninitialized_const_in_kernels)
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mateusznowakTT/guard_from_uninitialized_const_in_kernels)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mateusznowakTT/guard_from_uninitialized_const_in_kernels)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mateusznowakTT/guard_from_uninitialized_const_in_kernels)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mateusznowakTT/guard_from_uninitialized_const_in_kernels)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mateusznowakTT/guard_from_uninitialized_const_in_kernels)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mateusznowakTT/guard_from_uninitialized_const_in_kernels)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
