### PR TITLE
[TT-Train] Fix GCC build: qualify self-referential using declarations (#37922)

### DIFF
--- a/tt-train/sources/ttml/metal/ops/layernorm_bw/device/layernorm_bw_device_operation.hpp
+++ b/tt-train/sources/ttml/metal/ops/layernorm_bw/device/layernorm_bw_device_operation.hpp
@@ -13,10 +13,10 @@
 namespace ttml::metal::ops::layernorm_bw::device {
 
 struct LayerNormBackwardDeviceOperation {
-    using operation_attributes_t = operation_attributes_t;
-    using tensor_args_t = tensor_args_t;
-    using spec_return_value_t = spec_return_value_t;
-    using tensor_return_value_t = tensor_return_value_t;
+    using operation_attributes_t = ttml::metal::ops::layernorm_bw::device::operation_attributes_t;
+    using tensor_args_t = ttml::metal::ops::layernorm_bw::device::tensor_args_t;
+    using spec_return_value_t = ttml::metal::ops::layernorm_bw::device::spec_return_value_t;
+    using tensor_return_value_t = ttml::metal::ops::layernorm_bw::device::tensor_return_value_t;
     using program_factory_t = std::variant<LayerNormBackwardProgramFactory>;
 
     static program_factory_t select_program_factory(const operation_attributes_t&, const tensor_args_t&);

--- a/tt-train/sources/ttml/metal/ops/layernorm_fw/device/layernorm_fw_device_operation.hpp
+++ b/tt-train/sources/ttml/metal/ops/layernorm_fw/device/layernorm_fw_device_operation.hpp
@@ -13,10 +13,10 @@
 namespace ttml::metal::ops::layernorm_fw::device {
 
 struct LayerNormForwardDeviceOperation {
-    using operation_attributes_t = operation_attributes_t;
-    using tensor_args_t = tensor_args_t;
-    using spec_return_value_t = spec_return_value_t;
-    using tensor_return_value_t = tensor_return_value_t;
+    using operation_attributes_t = ttml::metal::ops::layernorm_fw::device::operation_attributes_t;
+    using tensor_args_t = ttml::metal::ops::layernorm_fw::device::tensor_args_t;
+    using spec_return_value_t = ttml::metal::ops::layernorm_fw::device::spec_return_value_t;
+    using tensor_return_value_t = ttml::metal::ops::layernorm_fw::device::tensor_return_value_t;
     using program_factory_t = std::variant<LayerNormForwardProgramFactory>;
 
     static program_factory_t select_program_factory(const operation_attributes_t&, const tensor_args_t&);

--- a/tt-train/sources/ttml/metal/ops/swiglu_fw/device/swiglu_fw_device_operation.hpp
+++ b/tt-train/sources/ttml/metal/ops/swiglu_fw/device/swiglu_fw_device_operation.hpp
@@ -13,10 +13,10 @@
 namespace ttml::metal::ops::swiglu_fw::device {
 
 struct SwiGLUForwardDeviceOperation {
-    using operation_attributes_t = operation_attributes_t;
-    using tensor_args_t = tensor_args_t;
-    using spec_return_value_t = spec_return_value_t;
-    using tensor_return_value_t = tensor_return_value_t;
+    using operation_attributes_t = ttml::metal::ops::swiglu_fw::device::operation_attributes_t;
+    using tensor_args_t = ttml::metal::ops::swiglu_fw::device::tensor_args_t;
+    using spec_return_value_t = ttml::metal::ops::swiglu_fw::device::spec_return_value_t;
+    using tensor_return_value_t = ttml::metal::ops::swiglu_fw::device::tensor_return_value_t;
     using program_factory_t = std::variant<SwiGLUForwardProgramFactory>;
 
     static program_factory_t select_program_factory(const operation_attributes_t&, const tensor_args_t&);

--- a/tt-train/sources/ttml/metal/optimizers/adamw/device/adamw_device_operation.hpp
+++ b/tt-train/sources/ttml/metal/optimizers/adamw/device/adamw_device_operation.hpp
@@ -13,10 +13,10 @@
 namespace ttml::metal::optimizers::adamw::device {
 
 struct AdamWDeviceOperation {
-    using operation_attributes_t = operation_attributes_t;
-    using tensor_args_t = tensor_args_t;
-    using spec_return_value_t = spec_return_value_t;
-    using tensor_return_value_t = tensor_return_value_t;
+    using operation_attributes_t = ttml::metal::optimizers::adamw::device::operation_attributes_t;
+    using tensor_args_t = ttml::metal::optimizers::adamw::device::tensor_args_t;
+    using spec_return_value_t = ttml::metal::optimizers::adamw::device::spec_return_value_t;
+    using tensor_return_value_t = ttml::metal::optimizers::adamw::device::tensor_return_value_t;
     using program_factory_t = std::variant<AdamWProgramFactory>;
 
     static program_factory_t select_program_factory(const operation_attributes_t&, const tensor_args_t&);

--- a/tt-train/sources/ttml/metal/optimizers/sgd_fused/device/sgd_fused_device_operation.hpp
+++ b/tt-train/sources/ttml/metal/optimizers/sgd_fused/device/sgd_fused_device_operation.hpp
@@ -13,10 +13,10 @@
 namespace ttml::metal::optimizers::sgd_fused::device {
 
 struct SGDFusedDeviceOperation {
-    using operation_attributes_t = operation_attributes_t;
-    using tensor_args_t = tensor_args_t;
-    using spec_return_value_t = spec_return_value_t;
-    using tensor_return_value_t = tensor_return_value_t;
+    using operation_attributes_t = ttml::metal::optimizers::sgd_fused::device::operation_attributes_t;
+    using tensor_args_t = ttml::metal::optimizers::sgd_fused::device::tensor_args_t;
+    using spec_return_value_t = ttml::metal::optimizers::sgd_fused::device::spec_return_value_t;
+    using tensor_return_value_t = ttml::metal::optimizers::sgd_fused::device::tensor_return_value_t;
     using program_factory_t = std::variant<SGDFusedProgramFactory>;
 
     static program_factory_t select_program_factory(const operation_attributes_t&, const tensor_args_t&);


### PR DESCRIPTION
### Ticket
Fixes #37922

### Problem description
5 tt-train device operation headers use self-referential `using` type alias declarations:
```cpp
using operation_attributes_t = operation_attributes_t;  // unqualified — self-referential
```
This violates C++ [basic.scope.class]/2: the member name on the left shadows the namespace-scope type on the right, making the declaration self-referential. GCC (all versions) correctly rejects this with `-fpermissive`; Clang is lenient and accepts it.

8 other device operations in the same codebase already use the correct fully-qualified pattern.

### What's changed
Added full namespace qualification to the `using` declarations in the 5 affected files, matching the pattern already used by rmsnorm_fw, rmsnorm_bw, softmax, silu_bw, cross_entropy_fw, cross_entropy_bw, sdpa_fw, and profiler_no_op.

#### Before (broken with GCC)
```cpp
namespace ttml::metal::ops::layernorm_fw::device {
struct LayerNormForwardDeviceOperation {
    using operation_attributes_t = operation_attributes_t;
};
}
```

#### After (works with both GCC and Clang)
```cpp
namespace ttml::metal::ops::layernorm_fw::device {
struct LayerNormForwardDeviceOperation {
    using operation_attributes_t = ttml::metal::ops::layernorm_fw::device::operation_attributes_t;
};
}
```

#### Files changed (5 files, 20 lines)
- `tt-train/sources/ttml/metal/ops/layernorm_fw/device/layernorm_fw_device_operation.hpp`
- `tt-train/sources/ttml/metal/ops/layernorm_bw/device/layernorm_bw_device_operation.hpp`
- `tt-train/sources/ttml/metal/ops/swiglu_fw/device/swiglu_fw_device_operation.hpp`
- `tt-train/sources/ttml/metal/optimizers/adamw/device/adamw_device_operation.hpp`
- `tt-train/sources/ttml/metal/optimizers/sgd_fused/device/sgd_fused_device_operation.hpp`

#### Verification
Container build with `--tt-train-compiler gcc-12` merging this fix + PR #37166 (compiler selection) on top of main — verifies tt-train compiles successfully with GCC 12.

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=ivoitovych/issue-37922-fix-gcc-self-referential-using)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:ivoitovych/issue-37922-fix-gcc-self-referential-using)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ivoitovych/issue-37922-fix-gcc-self-referential-using)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ivoitovych/issue-37922-fix-gcc-self-referential-using)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ivoitovych/issue-37922-fix-gcc-self-referential-using)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ivoitovych/issue-37922-fix-gcc-self-referential-using)
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ivoitovych/issue-37922-fix-gcc-self-referential-using)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ivoitovych/issue-37922-fix-gcc-self-referential-using)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ivoitovych/issue-37922-fix-gcc-self-referential-using)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ivoitovych/issue-37922-fix-gcc-self-referential-using)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ivoitovych/issue-37922-fix-gcc-self-referential-using)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ivoitovych/issue-37922-fix-gcc-self-referential-using)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
