### PR TITLE
Fix deepseek test_moe device_params ordering for cache paths

### DIFF
--- a/models/demos/deepseek_v3/tests/test_moe.py
+++ b/models/demos/deepseek_v3/tests/test_moe.py
@@ -37,18 +37,18 @@ _prefill_seq_len = int(_max_seq_len_env) if _max_seq_len_env is not None else DE
 
 @pytest.mark.timeout(1200)
 @pytest.mark.parametrize(
-    "mode,num_tokens",
-    [
-        ("decode", 128),
-        ("prefill", _prefill_seq_len),
-    ],
-)
-@pytest.mark.parametrize(
     "device_params",
     [
         {"fabric_config": ttnn.FabricConfig.FABRIC_1D},
     ],
     indirect=True,
+)
+@pytest.mark.parametrize(
+    "mode,num_tokens",
+    [
+        ("decode", 128),
+        ("prefill", _prefill_seq_len),
+    ],
 )
 @pytest.mark.parametrize(
     "topk_fallback",


### PR DESCRIPTION
## Summary
- Apply the same decorator ordering fix from #37894 to DeepSeek `test_moe`.
- Move `device_params` to the topmost `@pytest.mark.parametrize(...)` so `device_params0` is placed last in pytest argument/cache path ordering.

## CI
- Galaxy DeepSeek tests now pass (except long sequence tests, they have their own PR for another issue)

Follow-up to #37894.
