### PR TITLE
Fix buffer not sharded error in ring matmul 1d unit tests

### DIFF
--- a/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_mcast_1d_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_mcast_1d_program_factory.cpp
@@ -2266,8 +2266,9 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_gather_in0
     std::map<uint32_t, uint32_t> worker_y_to_dram_bank_first_col;
     std::map<uint32_t, uint32_t> worker_y_to_dram_bank_second_col;
     uint32_t first_col_max_x = device->arch() == tt::ARCH::WORMHOLE_B0 ? 3 : 7;
-    uint32_t num_receiver_cores_per_dram = ring_size / in1_buffer->shard_spec().grid().num_cores();
+    uint32_t num_receiver_cores_per_dram = 2;  // default to 2 for wormhole b0 and blackhole
     if (in1_is_dram_sharded) {
+        num_receiver_cores_per_dram = ring_size / in1_buffer->shard_spec().grid().num_cores();
         if (device->arch() == tt::ARCH::WORMHOLE_B0) {
             worker_y_to_dram_bank_first_col[0] = 1;
             worker_y_to_dram_bank_first_col[4] = 2;


### PR DESCRIPTION
### Ticket
NA

### Problem description
L2 nightly failures for `test_matmul_1d_gather_in0` due to accessing the shard spec of in1 even with in1 is not DRAM sharded. Fix was to move it inside the in1 dram sharded check.

### What's changed
- Move access for shard spec inside a valid check

### Checklist
- [L2 nightly tests](https://github.com/tenstorrent/tt-metal/actions/runs/22088625833) ring mm unit tests pass, other failures are irrelevant 
- [APC](https://github.com/tenstorrent/tt-metal/actions/runs/22088675053) passing