### PR TITLE
Clean-up topk and topk sweep tests

### DIFF
--- a/tests/sweep_framework/sweeps/reduction/topk/topk_output.py
+++ b/tests/sweep_framework/sweeps/reduction/topk/topk_output.py
@@ -63,19 +63,21 @@ def invalidate_vector(test_vector) -> Tuple[bool, Optional[str]]:
     print(f"test_vector[dim]: ", test_vector["dim"])
     print(f"test_vector[k]: ", test_vector["k"])
     if test_vector["dim"] is None:
-        return True, "dim parameter cannot be None."
+        return True, "Invalid input configuration: dim parameter cannot be None."
+    if (
+        test_vector["dim"] * (-1) > len(test_vector["input_shape"])
+        and test_vector["dim"] < 0
+        or test_vector["dim"] > (len(test_vector["input_shape"]) - 1)
+        and test_vector["dim"] >= 0
+    ):
+        return (
+            True,
+            "Invalid input configuration: Absolute value of dim must be less or equal than the rank of input tensor.",
+        )
     if test_vector["input_shape"][test_vector["dim"]] < test_vector["k"]:
-        return True, "k must be less than or equal to the maximum dimension size."
-    if test_vector["dim"] is not None:
-        if (
-            test_vector["dim"] * (-1) > len(test_vector["input_shape"])
-            and test_vector["dim"] < 0
-            or test_vector["dim"] > (len(test_vector["input_shape"]) - 1)
-            and test_vector["dim"] >= 0
-        ):
-            return True, "Absolute value of dim must be less or equal than the rank of input tensor."
+        return True, "Invalid input configuration: k must be less than or equal to the maximum dimension size."
     if test_vector["input_layout"] == ttnn.ROW_MAJOR_LAYOUT:
-        return True, "TopK operation requires tensor to be in Tile layout."
+        return True, "Unsupported configuration: TopK operation requires tensor to be in Tile layout."
     return False, None
 
 
@@ -151,19 +153,19 @@ def run_topk(
     return get_run_return(torch_output_values, output_values, expected_pcc, tensors, e2e_perf)
 
 
-@pytest.mark.parametrize("params", list(permutations(parameters["nightly"])))
-def test_nightly(device, params):
-    invalidated, output_str = invalidate_vector(params)
+# @pytest.mark.parametrize("params", list(permutations(parameters["nightly"])))
+# def test_nightly(device, params):
+#     invalidated, output_str = invalidate_vector(params)
 
-    if invalidated:
-        pytest.skip(output_str)
+#     if invalidated:
+#         pytest.skip(output_str)
 
-    (result, msg), e2e_perf = run_topk(**params, device=device)
+#     (result, msg), e2e_perf = run_topk(**params, device=device)
 
-    assert result, msg
-    logger.info(msg)
-    if e2e_perf:
-        logger.info(f"E2E Performance: {e2e_perf}")
+#     assert result, msg
+#     logger.info(msg)
+#     if e2e_perf:
+#         logger.info(f"E2E Performance: {e2e_perf}")
 
 
 @pytest.mark.parametrize("params", list(permutations(parameters["xfail"])))

--- a/tests/sweep_framework/sweeps/reduction/topk/topk_output.py
+++ b/tests/sweep_framework/sweeps/reduction/topk/topk_output.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: © 2026 Tenstorrent Inc.
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tests/sweep_framework/sweeps/reduction/topk/topk_output.py
+++ b/tests/sweep_framework/sweeps/reduction/topk/topk_output.py
@@ -35,7 +35,7 @@ parameters = {
         "dim": [0, 1, 2, 3, -1, -2, -3, -4, None],
         "largest": [True],
         "k": [32],
-        "input_a_dtype": [ttnn.bfloat16],  # , ttnn.bfloat8_b],
+        "input_a_dtype": [ttnn.bfloat16, ttnn.bfloat8_b],
         "input_layout": [ttnn.TILE_LAYOUT],
         "input_a_memory_config": [ttnn.DRAM_MEMORY_CONFIG, ttnn.L1_MEMORY_CONFIG],
         "output_memory_config": [ttnn.DRAM_MEMORY_CONFIG, ttnn.L1_MEMORY_CONFIG],
@@ -47,7 +47,7 @@ parameters = {
         "dim": [0, 1, 2, 3, -1, -2, -3, -4, None],
         "largest": [False],
         "k": [32],
-        "input_a_dtype": [ttnn.bfloat16],  # , ttnn.bfloat8_b],
+        "input_a_dtype": [ttnn.bfloat16, ttnn.bfloat8_b],
         "input_layout": [ttnn.TILE_LAYOUT],
         "input_a_memory_config": [ttnn.DRAM_MEMORY_CONFIG, ttnn.L1_MEMORY_CONFIG],
         "output_memory_config": [ttnn.DRAM_MEMORY_CONFIG, ttnn.L1_MEMORY_CONFIG],
@@ -59,9 +59,6 @@ parameters = {
 # If invalidated, the vector will still be stored but will be skipped.
 # Returns False, None if the vector is valid, and True, str with a reason for invalidation if it is invalid.
 def invalidate_vector(test_vector) -> Tuple[bool, Optional[str]]:
-    print(f"test_vector[input_shape]: ", test_vector["input_shape"])
-    print(f"test_vector[dim]: ", test_vector["dim"])
-    print(f"test_vector[k]: ", test_vector["k"])
     if test_vector["dim"] is None:
         return True, "Invalid input configuration: dim parameter cannot be None."
     if (
@@ -98,12 +95,12 @@ def run_topk(
 
     # Sanitize input shape
     input_shape = sanitize_shape(input_shape, "topk")
-    print("========================================")
-    print(f"Running topk with input_shape: {input_shape}, dim: {dim}, k: {k}, input_a_dtype: {input_a_dtype}")
-    print("========================================")
     torch_input_tensor_a = gen_func_with_cast_tt(
         partial(torch_random, low=-100, high=100, dtype=torch.float32), input_a_dtype
     )(input_shape)
+
+    if input_a_dtype == ttnn.bfloat8_b:
+        pytest.xfail("BFLOAT8_B not supported by pad operation")
 
     output_indices_shape = input_shape.copy()
     output_indices_shape[dim] = k
@@ -153,23 +150,23 @@ def run_topk(
     return get_run_return(torch_output_values, output_values, expected_pcc, tensors, e2e_perf)
 
 
-# @pytest.mark.parametrize("params", list(permutations(parameters["nightly"])))
-# def test_nightly(device, params):
-#     invalidated, output_str = invalidate_vector(params)
+@pytest.mark.parametrize("params", list(permutations(parameters["nightly"])))
+def test_nightly(device, params):
+    invalidated, output_str = invalidate_vector(params)
 
-#     if invalidated:
-#         pytest.skip(output_str)
+    if invalidated:
+        pytest.skip(output_str)
 
-#     (result, msg), e2e_perf = run_topk(**params, device=device)
+    (result, msg), e2e_perf = run_topk(**params, device=device)
 
-#     assert result, msg
-#     logger.info(msg)
-#     if e2e_perf:
-#         logger.info(f"E2E Performance: {e2e_perf}")
+    assert result, msg
+    logger.info(msg)
+    if e2e_perf:
+        logger.info(f"E2E Performance: {e2e_perf}")
 
 
 @pytest.mark.parametrize("params", list(permutations(parameters["xfail"])))
-def test_nightly(device, params):
+def test_xfail(device, params):
     invalidated, output_str = invalidate_vector(params)
 
     if invalidated:

--- a/tests/sweep_framework/sweeps/reduction/topk/topk_output.py
+++ b/tests/sweep_framework/sweeps/reduction/topk/topk_output.py
@@ -125,25 +125,25 @@ def run_topk(
         device=device,
         memory_config=input_a_memory_config,
     )
-    # op_output_values = ttnn.from_torch(
-    #     torch_optional_output[0],
-    #     dtype=input_a_dtype,
-    #     layout=input_layout,
-    #     device=device,
-    #     memory_config=output_memory_config,
-    # )
-    # op_output_indices = ttnn.from_torch(
-    #     torch_optional_output[1],
-    #     dtype=ttnn.uint16,
-    #     layout=input_layout,
-    #     device=device,
-    #     memory_config=output_memory_config,
-    # )
+    op_output_values = ttnn.from_torch(
+        torch_optional_output[0],
+        dtype=input_a_dtype,
+        layout=input_layout,
+        device=device,
+        memory_config=output_memory_config,
+    )
+    op_output_indices = ttnn.from_torch(
+        torch_optional_output[1],
+        dtype=ttnn.uint16,
+        layout=input_layout,
+        device=device,
+        memory_config=output_memory_config,
+    )
 
     start_time = start_measuring_time()
-    op_output_values, op_output_indices = ttnn.topk(
-        input_tensor_a, k=k, dim=dim, largest=largest, sorted=True
-    )  # , output_tensor=(op_output_values, op_output_indices))
+    ttnn.topk(
+        input_tensor_a, k=k, dim=dim, largest=largest, sorted=True, output_tensor=(op_output_values, op_output_indices)
+    )
     output_values = ttnn.to_torch(op_output_values)
     output_indices = ttnn.to_torch(op_output_indices).to(torch.int64)
     e2e_perf = stop_measuring_time(start_time)

--- a/tests/ttnn/unit_tests/operations/reduce/test_topk.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_topk.py
@@ -13,34 +13,6 @@ from tests.ttnn.utils_for_testing import assert_allclose, assert_equal
 UINT16_MAX = 65535
 
 
-def save_tensor(tensor, filename):
-    import pandas as pd
-
-    # Write tensor to CSV file
-    # Tensor data should be
-    # _,0,1,2,3,4, ...
-    # 0,y,y,y,y,y
-    # 1,y,y,y,y,y
-    # 2,y,y,y,y,y
-    # 3,y,y,y,y,y
-    #
-    # First row -> column indices
-    # First column -> row indices
-    # y = data value
-
-    # Convert to numpy 2D (handle torch and ttnn tensors; squeeze batch/extra dims)
-    import numpy as np
-
-    data = np.asarray(tensor.to(torch.float32))
-
-    print("saving tensor to csv {filename}")
-    while data.ndim > 2:
-        data = data[0]
-    df = pd.DataFrame(data)
-    df.index.name = ""
-    df.to_csv(filename, index=True)
-
-
 def run_topk_test(N, C, H, W, k, dtype, dim, sorted, largest, device, sub_core_grids=None, pass_indices_tensor=False):
     torch.manual_seed(2005)
     torch.set_printoptions(profile="full")
@@ -177,14 +149,14 @@ def run_topk_test(N, C, H, W, k, dtype, dim, sorted, largest, device, sub_core_g
     "sorted",
     [
         True,
-        # False,
+        False,
     ],
 )
 @pytest.mark.parametrize(
     "largest",
     [
         True,
-        # False,
+        False,
     ],
 )
 @pytest.mark.parametrize(
@@ -197,7 +169,6 @@ def test_topk(N, C, H, W, dim, k, dtype, sorted, largest, device, sub_core_grids
     run_topk_test(N, C, H, W, k, dtype, dim, sorted, largest, device, sub_core_grids)
 
 
-"""
 @pytest.mark.parametrize(
     "dtype",
     (ttnn.bfloat16,),
@@ -342,4 +313,3 @@ def test_topk_preallocated_dtype_raise(value_dtype, index_dtype, device):
 
     with pytest.raises(Exception):
         ttnn.topk(ttnn_input, k=32, dim=-1, largest=True, sorted=True, out=(value_tensor, index_tensor))
-"""

--- a/tests/ttnn/unit_tests/operations/reduce/test_topk.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_topk.py
@@ -106,6 +106,7 @@ def run_topk_test(N, C, H, W, k, dtype, dim, sorted, largest, device, sub_core_g
         (1, 1, 32, 18992, 3, 32),
         (1, 1, 32, 10000, 3, 32),
         (1, 1, 32, 64128, 3, 32),
+        (1, 1, 65 * 32, 96, 3, 32),
     ),
 )
 @pytest.mark.parametrize(

--- a/tests/ttnn/unit_tests/operations/reduce/test_topk.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_topk.py
@@ -15,13 +15,16 @@ UINT16_MAX = 65535
 
 def run_topk_test(N, C, H, W, k, dtype, dim, sorted, largest, device, sub_core_grids=None, pass_indices_tensor=False):
     torch.manual_seed(2005)
+
+    if dtype == ttnn.bfloat8_b:
+        pytest.xfail("BFLOAT8_B not supported by pad operation in topk")
+
     # Input tensor
     shape = [N, C, H, W]
     ttnn_indices_dtype = ttnn.uint16 if W <= UINT16_MAX else ttnn.uint32
     torch_indices_dtype = torch.uint16 if W <= UINT16_MAX else torch.uint32
     torch_dtype = torch.bfloat16
-    input = torch.randint(0, 100, shape, dtype=torch_dtype)
-
+    input = torch.randn(shape, dtype=torch_dtype) * 0.9
     ttnn_input = ttnn.from_torch(input, dtype, layout=ttnn.Layout.TILE, device=device)
 
     pyt_topk_values, pyt_topk_indices = torch.topk(input, k, dim=dim, largest=largest, sorted=True)
@@ -45,15 +48,16 @@ def run_topk_test(N, C, H, W, k, dtype, dim, sorted, largest, device, sub_core_g
         sub_core_grids=sub_core_grids,
         indices_tensor=indices_tensor,
     )
+
     # Convert TTNN outputs to Torch for comparison
     ttnn_torch_values = ttnn.to_torch(ttnn_topk_values)
     ttnn_torch_indices = ttnn.to_torch(ttnn_topk_indices, dtype=torch_indices_dtype)
 
-    # # Assert output shapes
-    # desired_shape = [N, C, H, W]
-    # desired_shape[dim] = k
-    # assert list(ttnn_topk_values.shape) == desired_shape
-    # assert list(ttnn_topk_indices.shape) == desired_shape
+    # Assert output shapes
+    desired_shape = [N, C, H, W]
+    desired_shape[dim] = k
+    assert list(ttnn_topk_values.shape) == desired_shape
+    assert list(ttnn_topk_indices.shape) == desired_shape
 
     assert_equal(ttnn_torch_values, pyt_topk_values)
 
@@ -76,12 +80,12 @@ def run_topk_test(N, C, H, W, k, dtype, dim, sorted, largest, device, sub_core_g
     "dtype",
     (
         ttnn.bfloat16,
-        # ttnn.bfloat8_b,
+        ttnn.bfloat8_b,
         # ttnn.float32, top bits in float32 get cut off somewhere, LLK does not work for this
     ),
     ids=[
         "BFLOAT16_B",
-        # "BFLOAT8_B",
+        "BFLOAT8_B",
         # "FLOAT32",
     ],
 )
@@ -102,7 +106,6 @@ def run_topk_test(N, C, H, W, k, dtype, dim, sorted, largest, device, sub_core_g
         (1, 1, 32, 18992, 3, 32),
         (1, 1, 32, 10000, 3, 32),
         (1, 1, 32, 64128, 3, 32),
-        (1, 1, 65 * 32, 32 * 3, 3, 32),
         (1, 1, 65 * 32, 32 * 3, 3, 32),
         (1, 10, 32, 512, 2, 32),
         (5, 9, 96, 1024, 2, 32),
@@ -233,23 +236,23 @@ def test_topk_large_2d_shapes(N, C, H, W, dim, k, dtype, sorted, largest, device
 
 
 @pytest.mark.parametrize(
-    "torch_input_tenosr_dtype, ttnn_input_tenosr_dtype",
+    "torch_input_tensor_dtype, ttnn_input_tensor_dtype",
     [
         (torch.float32, ttnn.float32),
         (torch.uint32, ttnn.uint32),
         (torch.int32, ttnn.int32),
     ],
 )
-def test_topk_input_dtypes_raise(torch_input_tenosr_dtype, ttnn_input_tenosr_dtype, device):
+def test_topk_input_dtypes_raise(torch_input_tensor_dtype, ttnn_input_tensor_dtype, device):
     torch.manual_seed(0)
     shape = [1, 1, 32, 64]
 
-    if torch_input_tenosr_dtype == torch.float32:
-        input_torch = torch.randn(shape, dtype=torch_input_tenosr_dtype)
+    if torch_input_tensor_dtype == torch.float32:
+        input_torch = torch.randn(shape, dtype=torch_input_tensor_dtype)
     else:
-        input_torch = torch.randint(0, 100, shape, dtype=torch_input_tenosr_dtype)
+        input_torch = torch.randint(0, 100, shape, dtype=torch_input_tensor_dtype)
 
-    ttnn_input = ttnn.from_torch(input_torch, ttnn_input_tenosr_dtype, layout=ttnn.Layout.TILE, device=device)
+    ttnn_input = ttnn.from_torch(input_torch, ttnn_input_tensor_dtype, layout=ttnn.Layout.TILE, device=device)
 
     with pytest.raises(Exception):
         ttnn.topk(ttnn_input, k=32, dim=-1, largest=True, sorted=True)
@@ -277,4 +280,4 @@ def test_topk_preallocated_dtype_raise(value_dtype, index_dtype, device):
     index_tensor = ttnn.empty_like(ttnn_input, dtype=index_dtype)
 
     with pytest.raises(Exception):
-        ttnn.topk(ttnn_input, k=32, dim=-1, largest=True, sorted=True, out=(value_tensor, index_tensor))
+        ttnn.topk(ttnn_input, k=32, dim=-1, largest=True, sorted=True, output_tensor=(value_tensor, index_tensor))

--- a/tests/ttnn/unit_tests/operations/reduce/test_topk.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_topk.py
@@ -15,40 +15,26 @@ UINT16_MAX = 65535
 
 def run_topk_test(N, C, H, W, k, dtype, dim, sorted, largest, device, sub_core_grids=None, pass_indices_tensor=False):
     torch.manual_seed(2005)
-    torch.set_printoptions(profile="full")
-    torch.set_printoptions(sci_mode=False)
     # Input tensor
     shape = [N, C, H, W]
-    # ttnn_indices_dtype = ttnn.uint16 if W <= UINT16_MAX else ttnn.uint32
-    # torch_indices_dtype = torch.uint16 if W <= UINT16_MAX else torch.uint32
+    ttnn_indices_dtype = ttnn.uint16 if W <= UINT16_MAX else ttnn.uint32
+    torch_indices_dtype = torch.uint16 if W <= UINT16_MAX else torch.uint32
     torch_dtype = torch.bfloat16
     input = torch.randint(0, 100, shape, dtype=torch_dtype)
-
-    # Build an indices tensor with increasing integer values along the 'dim' dimension:
-    indices_shape = list(shape)
-    axis_len = shape[dim]
-    # Create a 1D increasing range and reshape to broadcast along the required axis
-    axis_input = torch.arange(1, axis_len + 1, dtype=torch.int64)
-    # Create a shape with 1 in all dims, except axis which gets axis_len
-    idx_shape = [1] * len(shape)
-    idx_shape[dim] = axis_len
-    axis_input = axis_input.view(*idx_shape)
-    # Broadcast to full shape
-    input = axis_input.expand(*shape)
 
     ttnn_input = ttnn.from_torch(input, dtype, layout=ttnn.Layout.TILE, device=device)
 
     pyt_topk_values, pyt_topk_indices = torch.topk(input, k, dim=dim, largest=largest, sorted=True)
 
-    # if pass_indices_tensor:
-    #     indices_tensor_torch = torch.zeros(shape, dtype=torch_indices_dtype)
-    #     for i in range(W):
-    #         indices_tensor_torch[:, :, :, i] = i
-    #     indices_tensor = ttnn.from_torch(
-    #         indices_tensor_torch, ttnn_indices_dtype, layout=ttnn.Layout.TILE, device=device
-    #     )
-    # else:
-    # indices_tensor = None
+    if pass_indices_tensor:
+        indices_tensor_torch = torch.zeros(shape, dtype=torch_indices_dtype)
+        for i in range(W):
+            indices_tensor_torch[:, :, :, i] = i
+        indices_tensor = ttnn.from_torch(
+            indices_tensor_torch, ttnn_indices_dtype, layout=ttnn.Layout.TILE, device=device
+        )
+    else:
+        indices_tensor = None
 
     ttnn_topk_values, ttnn_topk_indices = ttnn.topk(
         ttnn_input,
@@ -57,25 +43,11 @@ def run_topk_test(N, C, H, W, k, dtype, dim, sorted, largest, device, sub_core_g
         largest=largest,
         sorted=sorted,
         sub_core_grids=sub_core_grids,
-        # indices_tensor=indices_tensor,
+        indices_tensor=indices_tensor,
     )
     # Convert TTNN outputs to Torch for comparison
     ttnn_torch_values = ttnn.to_torch(ttnn_topk_values)
-    print("Input Tensor:")
-    # print(input[0, 0, 2048, :])
-    print("TTNN TopK Values:")
-    # print(ttnn_torch_values[0, 0, 2048, :])
-    print("PyTorch TopK Values:")
-    # print(pyt_topk_values[0, 0, 2048, :])
-    # for n in range(N):
-    #     for c in range(C):
-    #             for i in range(H):
-    #                 ttnn_tensor = ttnn_torch_values[n, c, i, :]
-    #                 torch_tensor = pyt_topk_values[n, c, i, :]
-    #                 print(i, end=', ')
-    #                 assert_equal(ttnn_tensor, torch_tensor)
-    torch.set_printoptions(profile="default")
-    # ttnn_torch_indices = ttnn.to_torch(ttnn_topk_indices, dtype=torch_indices_dtype)
+    ttnn_torch_indices = ttnn.to_torch(ttnn_topk_indices, dtype=torch_indices_dtype)
 
     # # Assert output shapes
     # desired_shape = [N, C, H, W]
@@ -83,28 +55,21 @@ def run_topk_test(N, C, H, W, k, dtype, dim, sorted, largest, device, sub_core_g
     # assert list(ttnn_topk_values.shape) == desired_shape
     # assert list(ttnn_topk_indices.shape) == desired_shape
 
-    # # Assert values correctness
-    # if dtype == ttnn.bfloat8_b:
-    #     assert_allclose(ttnn_torch_values, pyt_topk_values, rtol=1e-1, atol=1e-1)
-    # else:
-    # save_tensor(ttnn_torch_values, "ttnn_torch_values.csv")
-    # save_tensor(pyt_topk_values, "torch_topk_values.csv")
-
     assert_equal(ttnn_torch_values, pyt_topk_values)
 
-    # # Assert indices correctness using gather
-    # # pcc is not a good measure for the raw indices
-    # # if index 49 and index 8 are tied, the order of the indices can be different
-    # # but the values associated with the indices should be the same
-    # # if index 7 and 8 are tied, but swapped, the pcc will be better than if index 49 and 8 are tied but swapped
-    # # rounding may also cause more ties than expected
-    # # the bigger we get, the tighter the distribution of the top K elements, so the pcc will be worse as stability/rounding will cause more ties
-    # # use cosine similarity on the gathered indices as this will show the top elements are all about the same
-    # ttnn_torch_gather_from_indices = torch.gather(input, dim, ttnn_torch_indices.to(torch.int64))
-    # cosine = torch.nn.CosineSimilarity(dim=dim)
-    # ttnn_torch_cosine = torch.mean(cosine(pyt_topk_values, ttnn_torch_gather_from_indices))
+    # Assert indices correctness using gather
+    # pcc is not a good measure for the raw indices
+    # if index 49 and index 8 are tied, the order of the indices can be different
+    # but the values associated with the indices should be the same
+    # if index 7 and 8 are tied, but swapped, the pcc will be better than if index 49 and 8 are tied but swapped
+    # rounding may also cause more ties than expected
+    # the bigger we get, the tighter the distribution of the top K elements, so the pcc will be worse as stability/rounding will cause more ties
+    # use cosine similarity on the gathered indices as this will show the top elements are all about the same
+    ttnn_torch_gather_from_indices = torch.gather(input, dim, ttnn_torch_indices.to(torch.int64))
+    cosine = torch.nn.CosineSimilarity(dim=dim)
+    ttnn_torch_cosine = torch.mean(cosine(pyt_topk_values, ttnn_torch_gather_from_indices))
 
-    # assert ttnn_torch_cosine > 0.99, "Cosine similarity between topk values and gather from indices is less than 0.99"
+    assert ttnn_torch_cosine > 0.99, "Cosine similarity between topk values and gather from indices is less than 0.99"
 
 
 @pytest.mark.parametrize(

--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/compute/topk.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/compute/topk.cpp
@@ -21,23 +21,23 @@
 FORCE_INLINE void transpose_and_pack(
     const uint32_t input_cb_index, const uint32_t dest_cb_index, const uint32_t total_tiles) {
     // Configure data formats for transpose operation
-    reconfig_data_format_srca(input_cb_index);
-    transpose_wh_init_short(input_cb_index);
-    pack_reconfig_data_format(input_cb_index);
+    // reconfig_data_format_srca(input_cb_index);
+    // transpose_wh_init_short(input_cb_index);
+    // pack_reconfig_data_format(input_cb_index);
 
     // Wait for all tiles to be available (double-buffered, hence 2 * total_tiles)
     cb_wait_front(input_cb_index, 2 * total_tiles);
     for (uint32_t i = 0; i < total_tiles; ++i) {
-        acquire_dst();
+        // acquire_dst();
         cb_reserve_back(dest_cb_index, 1);
 
-        // Transpose tile from WH to HW format
-        transpose_wh_tile(input_cb_index, i, 0);
+        // // Transpose tile from WH to HW format
+        // transpose_wh_tile(input_cb_index, i, 0);
 
-        // Pack transposed tile to destination
-        pack_tile(0, dest_cb_index);
+        // // Pack transposed tile to destination
+        // pack_tile(0, dest_cb_index);
         cb_push_back(dest_cb_index, 1);
-        release_dst();
+        // release_dst();
     }  // i loop
     cb_pop_front(input_cb_index, 2 * total_tiles);
 }
@@ -52,14 +52,14 @@ FORCE_INLINE void transpose_and_pack(
  */
 FORCE_INLINE void pack_results(const uint32_t cb0, const uint32_t cb1, const uint32_t base_offset) {
     // Pack first tile (values) to cb0
-    pack_reconfig_data_format(cb0);
-    pack_tile(base_offset, cb0);
+    // pack_reconfig_data_format(cb0);
+    // pack_tile(base_offset, cb0);
 
     // Pack second tile (indices) to cb1, reconfig only if different buffer
-    if (cb0 != cb1) {
-        pack_reconfig_data_format(cb1);
-    }
-    pack_tile(base_offset + 1, cb1);
+    // if (cb0 != cb1) {
+    //     pack_reconfig_data_format(cb1);
+    // }
+    // pack_tile(base_offset + 1, cb1);
 }
 
 /**
@@ -72,15 +72,15 @@ FORCE_INLINE void pack_results(const uint32_t cb0, const uint32_t cb1, const uin
  *                        false to transpose only one tile (tile 0 -> dest base_offset)
  */
 FORCE_INLINE void read_cb_and_transpose(const uint32_t cb, const uint32_t base_offset, const bool get_two = true) {
-    reconfig_data_format_srca(cb);
-    transpose_wh_init_short(cb);
+    // reconfig_data_format_srca(cb);
+    // transpose_wh_init_short(cb);
 
     // Transpose first tile to destination register
-    transpose_wh_tile(cb, 0, base_offset + 0);
-    if (get_two) {
-        // Transpose second tile if processing two tiles at once (initial iteration)
-        transpose_wh_tile(cb, 1, base_offset + 1);
-    }
+    // transpose_wh_tile(cb, 0, base_offset + 0);
+    // if (get_two) {
+    //     // Transpose second tile if processing two tiles at once (initial iteration)
+    //     transpose_wh_tile(cb, 1, base_offset + 1);
+    // }
 }
 
 /**
@@ -107,6 +107,11 @@ FORCE_INLINE void cb_reserve_push_back(const uint32_t cb, const uint32_t count) 
     cb_push_back(cb, count);
 }
 
+// template <typename To>
+// ALWI auto get_pointer_to_cb_data(uint32_t cb_id, uint32_t tile_index) -> To* {
+//     return reinterpret_cast<To*>(get_tile_address(cb_id, tile_index));
+// }
+
 void kernel_main() {
     // Runtime arguments
     const uint32_t work_per_core = get_arg_val<uint32_t>(0);
@@ -126,83 +131,13 @@ void kernel_main() {
     constexpr uint32_t largest = get_compile_time_arg_val(11);                  // 1 for largest K, 0 for smallest K
 
     // Initialize kernel components
-    ckernel::topk_tile_init();
-    transpose_wh_init(input_val_cb_index, output_val_cb_index);
-    transpose_wh_init(input_ind_cb_index, output_ind_cb_index);
+    // ckernel::topk_tile_init();
+    // transpose_wh_init(input_val_cb_index, output_val_cb_index);
+    // transpose_wh_init(input_ind_cb_index, output_ind_cb_index);
 
     constexpr int end_phase = 5;  // The end phase of the local sort, based on topk_local_sort documentation
     for (uint32_t core_loop = 0; core_loop < work_per_core; core_loop++) {
         uint32_t ktiles_saved = 0;
-        /*
-        ================================================================================================
-        TOPK ALGORITHM IMPLEMENTATION - INSERTION SORT WITH DOUBLE BUFFERING
-        ================================================================================================
-
-        This kernel implements TopK using an insertion sort algorithm that maintains a sliding window
-        of the K largest/smallest elements across all input tiles. The algorithm processes input
-        tiles row by row (height dimension) and maintains sorted results in a double-buffered format.
-
-        KEY CONCEPTS:
-        - output_tiles = ceil(K/32): Number of tiles needed to store K elements
-        - Each tile contains 32 elements, so for K=128, we need output_tiles=4
-        - Double buffering: result_prep buffers have size 2*output_tiles for efficient insertion
-        - ktiles_saved: Tracks how many output tiles currently contain valid sorted data
-
-        ALGORITHM PHASES:
-
-        PHASE 1: INITIALIZATION (First iteration, count=1)
-        - Read first TWO input tiles (2 x values + 2 x indices)
-        - Transpose from WH to HW format for processing
-        - Sort these 64 elements using topk_local_sort
-        - Store sorted results in result_prep buffer
-        - Set ktiles_saved = 2 (consumed 2 tiles worth of sorted data)
-
-        PHASE 2: INCREMENTAL INSERTION (count=2 to Wt-1)
-        - Read ONE input tile at a time (32 new elements)
-        - For each of the output_tiles positions, perform insertion sort:
-          * Compare new tile with existing sorted tile at that position
-          * Merge using topk_local_sort (keeping K largest/smallest)
-          * Store result back to result_prep buffer
-
-        PHASE 3: BUFFER MANAGEMENT STRATEGY
-        Three distinct cases based on current state:
-
-        Case A: FIRST SORT (ktiles_saved == 0)
-        - Process initial two transposed tiles
-        - No existing sorted data to merge with
-        - Increment: output_tiles (jump to next buffer half)
-        - Result: ktiles_saved = 2
-
-        Case B: GROWING PHASE (index >= ktiles_saved-1 && ktiles_saved < output_tiles)
-        - Still building up the sorted buffer
-        - Insert new tile at the next available position
-        - Each insertion increases ktiles_saved by 1
-        - Increment: output_tiles - index (adaptive positioning)
-
-        Case C: STEADY STATE (ktiles_saved == output_tiles)
-        - Buffer is full with K best elements
-        - New tiles compete with existing worst elements
-        - Only better elements replace existing ones
-        - Increment: 1 (simple linear processing)
-
-        PHASE 4: DOUBLE BUFFERING MECHANICS
-        - result_prep buffer alternates between two halves of size output_tiles
-        - After each insertion, we flip between reading from one half and writing to the other
-        - This prevents data corruption during the merge operation
-        - The 'incr' variable controls how far to advance buffer pointers
-
-        PHASE 5: OUTPUT GENERATION
-        - After processing all Wt input tiles, result_prep contains the K best elements
-        - Transpose results back from HW to WH format
-        - Pack final results into output circular buffers
-
-        EXAMPLE (K=128, output_tiles=4):
-        Initial: [ ][ ][ ][ ] (4 empty slots)
-        After 2 tiles: [64 elements][sorted][ ][ ] (ktiles_saved=2)
-        After 3 tiles: [32 elements][32 elements][32 elements][ ] (ktiles_saved=3)
-        After 4 tiles: [32][32][32][32] (ktiles_saved=4, buffer full)
-        Subsequent tiles compete with existing elements, replacing worse ones
-        */
 
         // Main processing loop: refactored into single loop to fit TRISC2 memory constraints
         uint32_t input_take = 2;  // First iteration processes 2 tiles, subsequent iterations process 1
@@ -210,33 +145,62 @@ void kernel_main() {
             // Read input tiles (2 on first iteration, 1 on subsequent) and transpose to HW format
             // Wait for input tiles to become available
             cb_wait_front(input_val_cb_index, input_take);
-            cb_wait_front(input_ind_cb_index, input_take);
 
+            for (uint32_t i = 0; i < input_take; i++) {
+                const auto addr = get_tile_address(input_val_cb_index, i);
+                UNPACK(
+                    DPRINT << "Compute: core_loop: " << core_loop << ", count: " << count << ", input_take "
+                           << input_take << " , Addr: " << addr << ENDL());
+
+                // volatile uint16_t* ptr = get_pointer_to_cb_data<uint16_t>(input_val_cb_index, i);
+                // for (int subtile_i = 0; subtile_i < 2; subtile_i++) {
+                //     // Iterate through 16 rows within each subtile row
+                //     for (int local_row = 0; local_row < 16; local_row++) {
+                //         // Calculate the actual row in original matrix
+                //         int row = subtile_i * 16 + local_row;
+                //         // Iterate through 2x2 subtiles horizontally
+                //         for (int subtile_j = 0; subtile_j < 2; subtile_j++) {
+                //             // Iterate through 16 columns within each subtile
+                //             for (int local_col = 0; local_col < 16; local_col++) {
+                //                 // Calculate the actual column in original matrix
+                //                 int col = subtile_j * 16 + local_col;
+                //                 // Calculate index using only multiplication and addition
+                //                 auto index = local_row * 16 + local_col + subtile_i * 512 + subtile_j * 256;
+                //                 // const uint32_t message = read_tile_value(input_val_cb_index, /*tile_index=*/take,
+                //                 // /*element_offset=*/index);ptr
+                //                 UNPACK(DPRINT << ptr[index] << ", ");
+                //             }
+                //         }
+                //         UNPACK(DPRINT << ENDL());
+                //     }
+                // }  // subtile_i
+            }  // i
+            cb_wait_front(input_ind_cb_index, input_take);
             // Reserve space in transposed buffers for processing
             cb_reserve_back(transposed_val_cb_index, input_take);
             cb_reserve_back(transposed_ind_cb_index, input_take);
 
-            acquire_dst();
+            // acquire_dst();
 
-            // Transpose input tiles from WH to HW format and pack to intermediate buffers
-            read_cb_and_transpose(input_val_cb_index, 0, (2 == input_take));  // Values: dest regs 0,1
-            read_cb_and_transpose(input_ind_cb_index, 2, (2 == input_take));  // Indices: dest regs 2,3
+            // // Transpose input tiles from WH to HW format and pack to intermediate buffers
+            // read_cb_and_transpose(input_val_cb_index, 0, (2 == input_take));  // Values: dest regs 0,1
+            // read_cb_and_transpose(input_ind_cb_index, 2, (2 == input_take));  // Indices: dest regs 2,3
 
-            // Pack transposed values
-            pack_reconfig_data_format(transposed_val_cb_index);
-            pack_tile(0, transposed_val_cb_index);
-            if (input_take == 2) {
-                pack_tile(1, transposed_val_cb_index);  // Pack second tile on first iteration
-            }
+            // // Pack transposed values
+            // pack_reconfig_data_format(transposed_val_cb_index);
+            // pack_tile(0, transposed_val_cb_index);
+            // if (input_take == 2) {
+            //     pack_tile(1, transposed_val_cb_index);  // Pack second tile on first iteration
+            // }
 
-            // Pack transposed indices
-            pack_reconfig_data_format(transposed_ind_cb_index);
-            pack_tile(2, transposed_ind_cb_index);
-            if (input_take == 2) {
-                pack_tile(3, transposed_ind_cb_index);  // Pack second tile on first iteration
-            }
+            // // Pack transposed indices
+            // pack_reconfig_data_format(transposed_ind_cb_index);
+            // pack_tile(2, transposed_ind_cb_index);
+            // if (input_take == 2) {
+            //     pack_tile(3, transposed_ind_cb_index);  // Pack second tile on first iteration
+            // }
 
-            release_dst();
+            // release_dst();
 
             // Remove processed tiles from input buffers
             cb_pop_front(input_val_cb_index, input_take);
@@ -296,30 +260,30 @@ void kernel_main() {
                 cb_reserve_back(transposed_val_cb_index, 1);
                 cb_reserve_back(transposed_ind_cb_index, 1);
 
-                acquire_dst();
+                // acquire_dst();
 
-                // Load tiles into destination registers for merging
-                // Load existing sorted values into dest reg 0
-                copy_tile_to_dst_init_short_with_dt(cb1, cb0);
-                copy_tile(cb0, 0, 0);
+                // // Load tiles into destination registers for merging
+                // // Load existing sorted values into dest reg 0
+                // copy_tile_to_dst_init_short_with_dt(cb1, cb0);
+                // copy_tile(cb0, 0, 0);
 
-                // Load existing sorted indices into dest reg 2
-                copy_tile_to_dst_init_short_with_dt(cb0, cb1);
-                copy_tile(cb1, 0, 2);
+                // // Load existing sorted indices into dest reg 2
+                // copy_tile_to_dst_init_short_with_dt(cb0, cb1);
+                // copy_tile(cb1, 0, 2);
 
-                // Load new input values into dest reg 1
-                copy_tile_to_dst_init_short_with_dt(transposed_ind_cb_index, transposed_val_cb_index);
-                copy_tile(transposed_val_cb_index, transposed_offset, 1);
+                // // Load new input values into dest reg 1
+                // copy_tile_to_dst_init_short_with_dt(transposed_ind_cb_index, transposed_val_cb_index);
+                // copy_tile(transposed_val_cb_index, transposed_offset, 1);
 
-                // Load new input indices into dest reg 3
-                copy_tile_to_dst_init_short_with_dt(transposed_val_cb_index, transposed_ind_cb_index);
-                copy_tile(transposed_ind_cb_index, transposed_offset, 3);
+                // // Load new input indices into dest reg 3
+                // copy_tile_to_dst_init_short_with_dt(transposed_val_cb_index, transposed_ind_cb_index);
+                // copy_tile(transposed_ind_cb_index, transposed_offset, 3);
 
-                // Perform merge and sort operation
-                // Merge and sort 64 elements (32 existing + 32 new) using topk_local_sort
-                // Results: dest reg 0 = top 32 elements, dest reg 1 = bottom 32 elements
-                // largest flag determines ascending (0) vs descending (1) sort order
-                ckernel::topk_local_sort(0, (int)!largest, end_phase);
+                // // Perform merge and sort operation
+                // // Merge and sort 64 elements (32 existing + 32 new) using topk_local_sort
+                // // Results: dest reg 0 = top 32 elements, dest reg 1 = bottom 32 elements
+                // // largest flag determines ascending (0) vs descending (1) sort order
+                // ckernel::topk_local_sort(0, (int)!largest, end_phase);
 
                 // Store sorted results back to buffers
                 // Reserve space for storing the best K elements
@@ -327,8 +291,8 @@ void kernel_main() {
                 cb_reserve_back(result_prep_ind_cb_index, incr);
 
                 // Pack sorted results: dest reg 0 -> result buffer, dest reg 1 -> secondary buffer
-                pack_results(result_prep_val_cb_index, cb2, 0);  // Store top 32 elements
-                pack_results(result_prep_ind_cb_index, cb3, 2);  // Store corresponding indices
+                // pack_results(result_prep_val_cb_index, cb2, 0);  // Store top 32 elements
+                // pack_results(result_prep_ind_cb_index, cb3, 2);  // Store corresponding indices
 
                 // Clean up source buffers
                 cb_pop_front(cb0, in_cb_offset);
@@ -338,7 +302,8 @@ void kernel_main() {
                 cb_push_back(result_prep_val_cb_index, incr);
                 cb_push_back(result_prep_ind_cb_index, incr);
 
-                release_dst();
+                // release_dst();
+                // tile_regs_release();
 
                 // Clean up transposed buffers if we consumed from them
                 if (transposed_offset == 0) {

--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/compute/topk.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/compute/topk.cpp
@@ -81,10 +81,6 @@ FORCE_INLINE void read_cb_and_transpose(const uint32_t cb, const uint32_t base_o
 
     // Transpose first tile to destination register
     transpose_wh_tile(cb, 0, base_offset);
-    // if (get_two) {
-    //     // Transpose second tile if processing two tiles at once (initial iteration)
-    //     transpose_wh_tile(cb, 1, base_offset + 1);
-    // }
 }
 
 /**
@@ -109,42 +105,6 @@ FORCE_INLINE void cb_wait_pop_front(const uint32_t cb, const uint32_t count) {
 FORCE_INLINE void cb_reserve_push_back(const uint32_t cb, const uint32_t count) {
     cb_reserve_back(cb, count);
     cb_push_back(cb, count);
-}
-
-template <typename To>
-ALWI auto get_pointer_to_cb_data(uint32_t cb_id, uint32_t tile_index) -> To* {
-    return reinterpret_cast<To*>(get_tile_address(cb_id, tile_index));
-}
-
-FORCE_INLINE
-void print_cb_data(const uint32_t cb_index, uint32_t itile) {
-    const auto addr = get_tile_address(cb_index, itile);
-    // UNPACK(
-    //     DPRINT << "Compute: core_loop: "
-    //             << input_take << " , Addr: " << addr << ENDL());
-
-    volatile uint16_t* ptr = get_pointer_to_cb_data<uint16_t>(cb_index, itile);
-    for (int subtile_i = 0; subtile_i < 2; subtile_i++) {
-        // Iterate through 16 rows within each subtile row
-        for (int local_row = 0; local_row < 16; local_row++) {
-            // Calculate the actual row in original matrix
-            int row = subtile_i * 16 + local_row;
-            // Iterate through 2x2 subtiles horizontally
-            for (int subtile_j = 0; subtile_j < 2; subtile_j++) {
-                // Iterate through 16 columns within each subtile
-                for (int local_col = 0; local_col < 16; local_col++) {
-                    // Calculate the actual column in original matrix
-                    int col = subtile_j * 16 + local_col;
-                    // Calculate index using only multiplication and addition
-                    auto index = local_row * 16 + local_col + subtile_i * 512 + subtile_j * 256;
-                    // const uint32_t message = read_tile_value(input_val_cb_index, /*tile_index=*/take,
-                    // /*element_offset=*/index);ptr
-                    UNPACK(DPRINT << BF16(ptr[index]) << ", ");
-                }
-            }
-            UNPACK(DPRINT << ENDL());
-        }
-    }  // subtile_i
 }
 
 void kernel_main() {
@@ -180,30 +140,8 @@ void kernel_main() {
         // Main processing loop: refactored into single loop to fit TRISC2 memory constraints
         uint32_t input_take = 2;  // First iteration processes 2 tiles, subsequent iterations process 1
         for (uint32_t count = 1; count < Wt; count++) {
-            // Read input tiles (2 on first iteration, 1 on subsequent) and transpose to HW format
-            // Wait for input tiles to become available
-            // cb_wait_front(input_val_cb_index, input_take);
-
-            // for (uint32_t i = 0; i < input_take; i++) {
-            //
-            // // cb_wait_front(input_ind_cb_index, input_take);
-            // // Reserve space in transposed buffers for processing
-
-            // Always reserve by the same amount of space
-            // This ensure that continuous tile indices in the reserved space
-            // do not 'wrap' around CB memory.
-            // For instance, if we had a CB of 2 tiles, and did
-            // 1. reserve(1)
-            // 2. push(1)
-            // 3. reserve(2)
-            // then, at step 3., then first tile would be at the end of the CB memory.
-            // whereas second tile would be at the start of the CB memory (wrapped around)
-            // However, most (all?) LLKs do not handle this, which can lead to wrong results.
-            constexpr uint32_t MAX_INPUT_TAKE = 2;
             cb_reserve_back(transposed_val_cb_index, input_take);
             cb_reserve_back(transposed_ind_cb_index, input_take);
-
-            // acquire_dst();
 
             // // Transpose input tiles from WH to HW format and pack to intermediate buffers
 
@@ -216,16 +154,6 @@ void kernel_main() {
                 read_cb_and_transpose(input_val_cb_index, DST_VAL);  // Values: dest regs 0,1
 
                 pack_reconfig_data_format(transposed_val_cb_index);
-
-                uint32_t tile_addr = get_tile_address(input_val_cb_index, 0);
-
-                MATH(DPRINT << "COMPUTE: reading " << input_take << " tile at address: " << tile_addr << ENDL(););
-                // print_cb_data(input_val_cb_index, 0);
-                MATH(DPRINT << "COMPUTE: input val: " << ENDL(););
-                dprint_tensix_dest_reg(DST_VAL);
-
-                uint32_t transposed_val_addr = get_tile_address(transposed_val_cb_index, 0);
-                MATH(DPRINT << "COMPUTE: writing tile to address: " << transposed_val_addr << ENDL();)
 
                 read_cb_and_transpose(input_ind_cb_index, DST_IND);  // Indices: dest regs 2,3
 
@@ -246,24 +174,6 @@ void kernel_main() {
                 cb_pop_front(input_val_cb_index, 1);
                 cb_pop_front(input_ind_cb_index, 1);
             }
-
-            // // Pack transposed values
-            // pack_reconfig_data_format(transposed_val_cb_index);
-            // pack_tile(0, transposed_val_cb_index);
-            // if (input_take == 2) {
-            //     pack_tile(1, transposed_val_cb_index);  // Pack second tile on first iteration
-            // }
-
-            // // Pack transposed indices
-            // pack_reconfig_data_format(transposed_ind_cb_index);
-            // pack_tile(2, transposed_ind_cb_index);
-            // if (input_take == 2) {
-            //     pack_tile(3, transposed_ind_cb_index);  // Pack second tile on first iteration
-            // }
-
-            // release_dst();
-
-            MATH(DPRINT << "Input have been read and transpoed" << ENDL();)
 
             // Store transposed tiles for insertion sort processing
             cb_push_back(transposed_val_cb_index, input_take);
@@ -321,20 +231,10 @@ void kernel_main() {
 
                 acquire_dst();
 
-                uint32_t cb0_addr = get_tile_address(cb0, 0);
-                uint32_t cb1_addr = get_tile_address(cb1, 0);
-                MATH(DPRINT << "Merge and sort operation" << ENDL();
-                     DPRINT << "Read tiles from at addresses: " << cb0_addr << " and " << cb1_addr << ENDL();
-                     DPRINT << "Transposed offset: " << transposed_offset << ENDL(););
-
-                reconfig_data_format(cb0, cb0);
-                pack_reconfig_data_format(result_prep_val_cb_index);
-
                 // Load tiles into destination registers for merging
                 // Load existing sorted values into dest reg 0
                 copy_tile_to_dst_init_short_with_dt(cb1, cb0);
                 copy_tile(cb0, 0, DST_VAL);
-                dprint_tensix_dest_reg(0);
 
                 // Load existing sorted indices into dest reg 2
                 copy_tile_to_dst_init_short_with_dt(cb0, cb1);
@@ -343,7 +243,6 @@ void kernel_main() {
                 // Load new input values into dest reg 1
                 copy_tile_to_dst_init_short_with_dt(transposed_ind_cb_index, transposed_val_cb_index);
                 copy_tile(transposed_val_cb_index, transposed_offset, 1);
-                dprint_tensix_dest_reg(1);
 
                 // Load new input indices into dest reg 3
                 copy_tile_to_dst_init_short_with_dt(transposed_val_cb_index, transposed_ind_cb_index);
@@ -354,9 +253,6 @@ void kernel_main() {
                 // Results: dest reg 0 = top 32 elements, dest reg 1 = bottom 32 elements
                 // largest flag determines ascending (0) vs descending (1) sort order
                 ckernel::topk_local_sort(0, (int)!largest, end_phase);
-
-                MATH(DPRINT << "Local sort output: " << ENDL(););
-                dprint_tensix_dest_reg(0);
 
                 // Store sorted results back to buffers
                 // Reserve space for storing the best K elements
@@ -376,7 +272,6 @@ void kernel_main() {
                 cb_push_back(result_prep_ind_cb_index, incr);
 
                 release_dst();
-                // tile_regs_release();
 
                 // Clean up transposed buffers if we consumed from them
                 if (transposed_offset == 0) {

--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/compute/topk.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/compute/topk.cpp
@@ -9,10 +9,6 @@
 #include "api/compute/tile_move_copy.h"
 #include "api/compute/reconfig_data_format.h"
 #include "api/compute/pack.h"
-#include "api/compute/eltwise_unary/fill.h"
-
-#include "api/debug/dprint.h"
-#include "api/debug/dprint_tensix.h"
 
 /**
  * Transpose tiles from width-height to height-width format and pack to destination buffer
@@ -67,13 +63,11 @@ FORCE_INLINE void pack_results(const uint32_t cb0, const uint32_t cb1, const uin
 }
 
 /**
- * Read tiles from circular buffer and transpose them to destination registers
+ * Read tile from circular buffer and transpose it to destination register
  * Used to prepare input tiles for sorting operations
  *
- * @param cb               Circular buffer index to read tiles from
- * @param base_offset      Base offset in destination registers where transposed tiles will be stored
- * @param get_two         Boolean flag: true to transpose two tiles (tiles 0,1 -> dest base_offset, base_offset+1),
- *                        false to transpose only one tile (tile 0 -> dest base_offset)
+ * @param cb               Circular buffer index to read tile from
+ * @param base_offset      Base offset in destination register where transposed tile will be stored
  */
 FORCE_INLINE void read_cb_and_transpose(const uint32_t cb, const uint32_t base_offset) {
     reconfig_data_format_srca(cb);

--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/compute/topk.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/compute/topk.cpp
@@ -217,9 +217,6 @@ void kernel_main() {
                 tile_regs_acquire();
 
                 read_cb_and_transpose(input_val_cb_index, DST_VAL);  // Values: dest regs 0,1
-
-                pack_reconfig_data_format(transposed_val_cb_index);
-
                 read_cb_and_transpose(input_ind_cb_index, DST_IND);  // Indices: dest regs 2,3
 
                 tile_regs_commit();

--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/compute/topk.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/compute/topk.cpp
@@ -131,6 +131,77 @@ void kernel_main() {
     for (uint32_t core_loop = 0; core_loop < work_per_core; core_loop++) {
         uint32_t ktiles_saved = 0;
 
+        /*
+        ================================================================================================
+        TOPK ALGORITHM IMPLEMENTATION - INSERTION SORT WITH DOUBLE BUFFERING
+        ================================================================================================
+
+        This kernel implements TopK using an insertion sort algorithm that maintains a sliding window
+        of the K largest/smallest elements across all input tiles. The algorithm processes input
+        tiles row by row (height dimension) and maintains sorted results in a double-buffered format.
+
+        KEY CONCEPTS:
+        - output_tiles = ceil(K/32): Number of tiles needed to store K elements
+        - Each tile contains 32 elements, so for K=128, we need output_tiles=4
+        - Double buffering: result_prep buffers have size 2*output_tiles for efficient insertion
+        - ktiles_saved: Tracks how many output tiles currently contain valid sorted data
+
+        ALGORITHM PHASES:
+
+        PHASE 1: INITIALIZATION (First iteration, count=1)
+        - Read first TWO input tiles (2 x values + 2 x indices)
+        - Transpose from WH to HW format for processing
+        - Sort these 64 elements using topk_local_sort
+        - Store sorted results in result_prep buffer
+        - Set ktiles_saved = 2 (consumed 2 tiles worth of sorted data)
+
+        PHASE 2: INCREMENTAL INSERTION (count=2 to Wt-1)
+        - Read ONE input tile at a time (32 new elements)
+        - For each of the output_tiles positions, perform insertion sort:
+          * Compare new tile with existing sorted tile at that position
+          * Merge using topk_local_sort (keeping K largest/smallest)
+          * Store result back to result_prep buffer
+
+        PHASE 3: BUFFER MANAGEMENT STRATEGY
+        Three distinct cases based on current state:
+
+        Case A: FIRST SORT (ktiles_saved == 0)
+        - Process initial two transposed tiles
+        - No existing sorted data to merge with
+        - Increment: output_tiles (jump to next buffer half)
+        - Result: ktiles_saved = 2
+
+        Case B: GROWING PHASE (index >= ktiles_saved-1 && ktiles_saved < output_tiles)
+        - Still building up the sorted buffer
+        - Insert new tile at the next available position
+        - Each insertion increases ktiles_saved by 1
+        - Increment: output_tiles - index (adaptive positioning)
+
+        Case C: STEADY STATE (ktiles_saved == output_tiles)
+        - Buffer is full with K best elements
+        - New tiles compete with existing worst elements
+        - Only better elements replace existing ones
+        - Increment: 1 (simple linear processing)
+
+        PHASE 4: DOUBLE BUFFERING MECHANICS
+        - result_prep buffer alternates between two halves of size output_tiles
+        - After each insertion, we flip between reading from one half and writing to the other
+        - This prevents data corruption during the merge operation
+        - The 'incr' variable controls how far to advance buffer pointers
+
+        PHASE 5: OUTPUT GENERATION
+        - After processing all Wt input tiles, result_prep contains the K best elements
+        - Transpose results back from HW to WH format
+        - Pack final results into output circular buffers
+
+        EXAMPLE (K=128, output_tiles=4):
+        Initial: [ ][ ][ ][ ] (4 empty slots)
+        After 2 tiles: [64 elements][sorted][ ][ ] (ktiles_saved=2)
+        After 3 tiles: [32 elements][32 elements][32 elements][ ] (ktiles_saved=3)
+        After 4 tiles: [32][32][32][32] (ktiles_saved=4, buffer full)
+        Subsequent tiles compete with existing elements, replacing worse ones
+        */
+
         // Main processing loop: refactored into single loop to fit TRISC2 memory constraints
         uint32_t input_take = 2;  // First iteration processes 2 tiles, subsequent iterations process 1
         for (uint32_t count = 1; count < Wt; count++) {

--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/compute/topk.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/compute/topk.cpp
@@ -143,7 +143,7 @@ void kernel_main() {
             cb_reserve_back(transposed_val_cb_index, input_take);
             cb_reserve_back(transposed_ind_cb_index, input_take);
 
-            // // Transpose input tiles from WH to HW format and pack to intermediate buffers
+            // Transpose input tiles from WH to HW format and pack to intermediate buffers
 
             for (uint32_t i = 0; i < input_take; i++) {
                 cb_wait_front(input_val_cb_index, 1);

--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/dataflow/reader_create_index_tensor.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/dataflow/reader_create_index_tensor.cpp
@@ -46,33 +46,10 @@ void kernel_main() {
             const uint32_t l1_write_addr = get_write_ptr(cb_id_in0);
             noc_async_read_tile(row * Wt + w, inout_tensor_accessor, l1_write_addr);
             noc_async_read_barrier();
-            DPRINT << "Reader: core_loop: " << core_loop << ", row: " << row << ", w: " << w
-                   << " ,address: " << l1_write_addr << ENDL();
-            // volatile tt_l1_ptr uint16_t* ptr = reinterpret_cast<volatile tt_l1_ptr uint16_t*>(l1_write_addr);
-            // for (int subtile_i = 0; subtile_i < 2; subtile_i++) {
-            //     // Iterate through 16 rows within each subtile row
-            //     for (int local_row = 0; local_row < 16; local_row++) {
-            //         // Calculate the actual row in original matrix
-            //         int row = subtile_i * 16 + local_row;
-            //         // Iterate through 2x2 subtiles horizontally
-            //         for (int subtile_j = 0; subtile_j < 2; subtile_j++) {
-            //             // Iterate through 16 columns within each subtile
-            //             for (int local_col = 0; local_col < 16; local_col++) {
-            //                 // Calculate the actual column in original matrix
-            //                 int col = subtile_j * 16 + local_col;
-            //                 // Calculate index using only multiplication and addition
-            //                 auto index = local_row * 16 + local_col + subtile_i * 512 + subtile_j * 256;
-            //                 DPRINT << BF16(ptr[index]) << ", " ;
-            //             }
-            //         }
-            //         DPRINT << ENDL();
-            //     }
-            // }
-            // DPRINT << ENDL();
+
             cb_push_back(cb_id_in0, onetile);
 #if GENERATE_INDICES
             if (uint16_output) {
-                // DPRINT << "Reader: core_loop: " << core_loop << ", row: " << row << ", w: " << w << ENDL();
                 generate_index_tile<uint16_t>(cb_intermed_index, w);
             } else {
                 generate_index_tile<uint32_t>(cb_intermed_index, w);
@@ -86,9 +63,5 @@ void kernel_main() {
             cb_push_back(cb_intermed_index, onetile);
 #endif  // GENERATE_INDICES
         }  // w loop
-        // Add delay loop with assembly NOPs
-        // for (uint32_t nop_i = 0; nop_i < 10000000; ++nop_i) {
-        //     asm volatile("nop");
-        // }
     }  // core_loop loop
 }

--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/dataflow/reader_create_index_tensor.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/dataflow/reader_create_index_tensor.cpp
@@ -46,9 +46,33 @@ void kernel_main() {
             const uint32_t l1_write_addr = get_write_ptr(cb_id_in0);
             noc_async_read_tile(row * Wt + w, inout_tensor_accessor, l1_write_addr);
             noc_async_read_barrier();
+            DPRINT << "Reader: core_loop: " << core_loop << ", row: " << row << ", w: " << w
+                   << " ,address: " << l1_write_addr << ENDL();
+            // volatile tt_l1_ptr uint16_t* ptr = reinterpret_cast<volatile tt_l1_ptr uint16_t*>(l1_write_addr);
+            // for (int subtile_i = 0; subtile_i < 2; subtile_i++) {
+            //     // Iterate through 16 rows within each subtile row
+            //     for (int local_row = 0; local_row < 16; local_row++) {
+            //         // Calculate the actual row in original matrix
+            //         int row = subtile_i * 16 + local_row;
+            //         // Iterate through 2x2 subtiles horizontally
+            //         for (int subtile_j = 0; subtile_j < 2; subtile_j++) {
+            //             // Iterate through 16 columns within each subtile
+            //             for (int local_col = 0; local_col < 16; local_col++) {
+            //                 // Calculate the actual column in original matrix
+            //                 int col = subtile_j * 16 + local_col;
+            //                 // Calculate index using only multiplication and addition
+            //                 auto index = local_row * 16 + local_col + subtile_i * 512 + subtile_j * 256;
+            //                 DPRINT << BF16(ptr[index]) << ", " ;
+            //             }
+            //         }
+            //         DPRINT << ENDL();
+            //     }
+            // }
+            // DPRINT << ENDL();
             cb_push_back(cb_id_in0, onetile);
 #if GENERATE_INDICES
             if (uint16_output) {
+                // DPRINT << "Reader: core_loop: " << core_loop << ", row: " << row << ", w: " << w << ENDL();
                 generate_index_tile<uint16_t>(cb_intermed_index, w);
             } else {
                 generate_index_tile<uint32_t>(cb_intermed_index, w);
@@ -62,5 +86,9 @@ void kernel_main() {
             cb_push_back(cb_intermed_index, onetile);
 #endif  // GENERATE_INDICES
         }  // w loop
+        // Add delay loop with assembly NOPs
+        // for (uint32_t nop_i = 0; nop_i < 10000000; ++nop_i) {
+        //     asm volatile("nop");
+        // }
     }  // core_loop loop
 }

--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/dataflow/reader_create_index_tensor.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/dataflow/reader_create_index_tensor.cpp
@@ -21,11 +21,11 @@ void kernel_main() {
     constexpr uint32_t Wt = get_compile_time_arg_val(3);
     constexpr uint32_t total_number_of_cores = get_compile_time_arg_val(4);
     constexpr bool uint16_output = get_compile_time_arg_val(5) == 1;
-    constexpr auto s_args = TensorAccessorArgs<6>();
+    constexpr auto inout_tensor_args = TensorAccessorArgs<6>();
 
 #if not GENERATE_INDICES
     // Precomputed indices tensor accessor
-    constexpr auto indices_args = TensorAccessorArgs<s_args.next_compile_time_args_offset()>();
+    constexpr auto indices_args = TensorAccessorArgs<inout_tensor_args.next_compile_time_args_offset()>();
     const uint32_t src_indices_addr = get_arg_val<uint32_t>(3);
     constexpr uint32_t indices_tile_bytes = get_tile_size(cb_intermed_index);
     const auto indices_accessor = TensorAccessor(indices_args, src_indices_addr, indices_tile_bytes);
@@ -36,31 +36,31 @@ void kernel_main() {
 
     // Tensor accessor
     constexpr uint32_t tile_bytes = get_tile_size(cb_id_in0);
-    const auto s = TensorAccessor(s_args, src_addr, tile_bytes);
+    const auto inout_tensor_accessor = TensorAccessor(inout_tensor_args, src_addr, tile_bytes);
 
     // Read data and generate indices
     for (uint32_t core_loop = 0; core_loop < work_per_core; core_loop++) {
-        const uint32_t i = id + core_loop * total_number_of_cores;
-        for (uint32_t j = 0; j < Wt; ++j) {
+        const uint32_t row = id + core_loop * total_number_of_cores;
+        for (uint32_t w = 0; w < Wt; ++w) {
             cb_reserve_back(cb_id_in0, onetile);
             const uint32_t l1_write_addr = get_write_ptr(cb_id_in0);
-            noc_async_read_tile(i * Wt + j, s, l1_write_addr);
+            noc_async_read_tile(row * Wt + w, inout_tensor_accessor, l1_write_addr);
             noc_async_read_barrier();
             cb_push_back(cb_id_in0, onetile);
 #if GENERATE_INDICES
             if (uint16_output) {
-                generate_index_tile<uint16_t>(cb_intermed_index, j);
+                generate_index_tile<uint16_t>(cb_intermed_index, w);
             } else {
-                generate_index_tile<uint32_t>(cb_intermed_index, j);
+                generate_index_tile<uint32_t>(cb_intermed_index, w);
             }
 #else
             // Read precomputed indices to circular buffer
             cb_reserve_back(cb_intermed_index, onetile);
             const uint32_t l1_write_addr_ind = get_write_ptr(cb_intermed_index);
-            noc_async_read_tile(i * Wt + j, indices_accessor, l1_write_addr_ind);
+            noc_async_read_tile(row * Wt + w, indices_accessor, l1_write_addr_ind);
             noc_async_read_barrier();
             cb_push_back(cb_intermed_index, onetile);
 #endif  // GENERATE_INDICES
-        }  // j loop
+        }  // w loop
     }  // core_loop loop
 }

--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/dataflow/topk_dataflow_common.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/dataflow/topk_dataflow_common.hpp
@@ -51,7 +51,27 @@ FORCE_INLINE void generate_index_tile(const uint32_t cb_id, const uint32_t wt) {
             }  // k loop
         }  // j loop
     }  // i loop
-
+    // volatile tt_l1_ptr uint16_t* ptr = reinterpret_cast<volatile tt_l1_ptr uint16_t*>(l1_write_addr);
+    // for (int subtile_i = 0; subtile_i < 2; subtile_i++) {
+    //     // Iterate through 16 rows within each subtile row
+    //     for (int local_row = 0; local_row < 16; local_row++) {
+    //         // Calculate the actual row in original matrix
+    //         int row = subtile_i * 16 + local_row;
+    //         // Iterate through 2x2 subtiles horizontally
+    //         for (int subtile_j = 0; subtile_j < 2; subtile_j++) {
+    //             // Iterate through 16 columns within each subtile
+    //             for (int local_col = 0; local_col < 16; local_col++) {
+    //                 // Calculate the actual column in original matrix
+    //                 int col = subtile_j * 16 + local_col;
+    //                 // Calculate index using only multiplication and addition
+    //                 auto index = local_row * 16 + local_col + subtile_i * 512 + subtile_j * 256;
+    //                 DPRINT << ptr[index] << ", " ;
+    //             }
+    //         }
+    //         DPRINT << ENDL();
+    //     }
+    // }
+    // DPRINT << ENDL();
     // Push the tile
     cb_push_back(cb_id, one_tile);
 }

--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/dataflow/topk_dataflow_common.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/dataflow/topk_dataflow_common.hpp
@@ -51,27 +51,6 @@ FORCE_INLINE void generate_index_tile(const uint32_t cb_id, const uint32_t wt) {
             }  // k loop
         }  // j loop
     }  // i loop
-    // volatile tt_l1_ptr uint16_t* ptr = reinterpret_cast<volatile tt_l1_ptr uint16_t*>(l1_write_addr);
-    // for (int subtile_i = 0; subtile_i < 2; subtile_i++) {
-    //     // Iterate through 16 rows within each subtile row
-    //     for (int local_row = 0; local_row < 16; local_row++) {
-    //         // Calculate the actual row in original matrix
-    //         int row = subtile_i * 16 + local_row;
-    //         // Iterate through 2x2 subtiles horizontally
-    //         for (int subtile_j = 0; subtile_j < 2; subtile_j++) {
-    //             // Iterate through 16 columns within each subtile
-    //             for (int local_col = 0; local_col < 16; local_col++) {
-    //                 // Calculate the actual column in original matrix
-    //                 int col = subtile_j * 16 + local_col;
-    //                 // Calculate index using only multiplication and addition
-    //                 auto index = local_row * 16 + local_col + subtile_i * 512 + subtile_j * 256;
-    //                 DPRINT << ptr[index] << ", " ;
-    //             }
-    //         }
-    //         DPRINT << ENDL();
-    //     }
-    // }
-    // DPRINT << ENDL();
     // Push the tile
     cb_push_back(cb_id, one_tile);
 }

--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/dataflow/writer_binary_interleaved.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/dataflow/writer_binary_interleaved.cpp
@@ -34,14 +34,11 @@ void kernel_main() {
     // Get Kt rows of values and then Kt rows of indices from compute kernel
     for (uint32_t core_loop = 0; core_loop < work_per_core; core_loop++) {
         const uint32_t row = id + core_loop * total_number_of_cores;
-        // DPRINT << "Writer: core_loop: " << core_loop << ", row: " << row << ", Kt: " << Kt << ENDL();
 
         // TopK values
         for (uint32_t k = 0; k < Kt; ++k) {
             cb_wait_front(values_cb_index, onetile);
             const uint32_t l1_read_addr_val = get_read_ptr(values_cb_index);
-            // DPRINT << "Writer: core_loop: " << core_loop << ", row: " << row << ", w: " << k
-            //        << " , address: " << l1_read_addr_val << ENDL();
 
             noc_async_write_tile(row * Kt + k, values_tensor_accessor, l1_read_addr_val);
             noc_async_write_barrier();

--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/dataflow/writer_binary_interleaved.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/dataflow/writer_binary_interleaved.cpp
@@ -20,6 +20,8 @@ void kernel_main() {
     constexpr auto values_tensor_args = TensorAccessorArgs<5>();
     constexpr auto indices_tensor_args = TensorAccessorArgs<values_tensor_args.next_compile_time_args_offset()>();
 
+    DPRINT << "Writer binary interleaved" << ENDL();
+
     // Constants
     constexpr uint32_t onetile = 1;
 
@@ -32,10 +34,15 @@ void kernel_main() {
     // Get Kt rows of values and then Kt rows of indices from compute kernel
     for (uint32_t core_loop = 0; core_loop < work_per_core; core_loop++) {
         const uint32_t row = id + core_loop * total_number_of_cores;
+        // DPRINT << "Writer: core_loop: " << core_loop << ", row: " << row << ", Kt: " << Kt << ENDL();
+
         // TopK values
         for (uint32_t k = 0; k < Kt; ++k) {
             cb_wait_front(values_cb_index, onetile);
             const uint32_t l1_read_addr_val = get_read_ptr(values_cb_index);
+            // DPRINT << "Writer: core_loop: " << core_loop << ", row: " << row << ", w: " << k
+            //        << " , address: " << l1_read_addr_val << ENDL();
+
             noc_async_write_tile(row * Kt + k, values_tensor_accessor, l1_read_addr_val);
             noc_async_write_barrier();
             cb_pop_front(values_cb_index, onetile);

--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/dataflow/writer_binary_interleaved.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/dataflow/writer_binary_interleaved.cpp
@@ -17,38 +17,37 @@ void kernel_main() {
     constexpr uint32_t Ht = get_compile_time_arg_val(2);
     constexpr uint32_t Kt = get_compile_time_arg_val(3);
     constexpr uint32_t total_number_of_cores = get_compile_time_arg_val(4);
-    constexpr auto interleaved_accessor0_args = TensorAccessorArgs<5>();
-    constexpr auto interleaved_accessor1_args =
-        TensorAccessorArgs<interleaved_accessor0_args.next_compile_time_args_offset()>();
+    constexpr auto values_tensor_args = TensorAccessorArgs<5>();
+    constexpr auto indices_tensor_args = TensorAccessorArgs<values_tensor_args.next_compile_time_args_offset()>();
 
     // Constants
     constexpr uint32_t onetile = 1;
 
     // Tensor config
     const uint32_t tile_bytes_values = get_tile_size(values_cb_index);
-    const auto interleaved_accessor0 = TensorAccessor(interleaved_accessor0_args, dst_addr0, tile_bytes_values);
+    const auto values_tensor_accessor = TensorAccessor(values_tensor_args, dst_addr0, tile_bytes_values);
     const uint32_t tile_bytes_ind = get_tile_size(output_ind_cb_index);
-    const auto interleaved_accessor1 = TensorAccessor(interleaved_accessor1_args, dst_addr1, tile_bytes_ind);
+    const auto indices_tensor_accessor = TensorAccessor(indices_tensor_args, dst_addr1, tile_bytes_ind);
 
     // Get Kt rows of values and then Kt rows of indices from compute kernel
     for (uint32_t core_loop = 0; core_loop < work_per_core; core_loop++) {
-        const uint32_t j = id + core_loop * total_number_of_cores;
+        const uint32_t row = id + core_loop * total_number_of_cores;
         // TopK values
-        for (uint32_t i = 0; i < Kt; ++i) {
+        for (uint32_t k = 0; k < Kt; ++k) {
             cb_wait_front(values_cb_index, onetile);
-            const uint32_t l1_read_addr = get_read_ptr(values_cb_index);
-            noc_async_write_tile(j * Kt + i, interleaved_accessor0, l1_read_addr);
+            const uint32_t l1_read_addr_val = get_read_ptr(values_cb_index);
+            noc_async_write_tile(row * Kt + k, values_tensor_accessor, l1_read_addr_val);
             noc_async_write_barrier();
             cb_pop_front(values_cb_index, onetile);
-        }  // i loop
+        }  // k loop
 
         // TopK indices
-        for (uint32_t i = 0; i < Kt; ++i) {
+        for (uint32_t k = 0; k < Kt; ++k) {
             cb_wait_front(output_ind_cb_index, onetile);
-            const uint32_t l1_read_addr = get_read_ptr(output_ind_cb_index);
-            noc_async_write_tile(j * Kt + i, interleaved_accessor1, l1_read_addr);
+            const uint32_t l1_read_addr_idx = get_read_ptr(output_ind_cb_index);
+            noc_async_write_tile(row * Kt + k, indices_tensor_accessor, l1_read_addr_idx);
             noc_async_write_barrier();
             cb_pop_front(output_ind_cb_index, onetile);
-        }  // i loop
+        }  // k loop
     }  // core_loop loop
 }

--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/dataflow/writer_binary_interleaved.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/dataflow/writer_binary_interleaved.cpp
@@ -20,8 +20,6 @@ void kernel_main() {
     constexpr auto values_tensor_args = TensorAccessorArgs<5>();
     constexpr auto indices_tensor_args = TensorAccessorArgs<values_tensor_args.next_compile_time_args_offset()>();
 
-    DPRINT << "Writer binary interleaved" << ENDL();
-
     // Constants
     constexpr uint32_t onetile = 1;
 

--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_multi_core_program_factory.cpp
@@ -64,6 +64,8 @@ TopKMultiCoreProgramFactory::cached_program_t TopKMultiCoreProgramFactory::creat
     const TopkParams& args, const TopkInputs& tensor_args, std::tuple<Tensor, Tensor>& output_tensors) {
     using namespace tt::constants;
 
+    // std::cout << "TOPK MULTI CORE PROGRAM FACTORY" << std::endl;
+
     // Tensor references
     const auto& input_tensor = tensor_args.input;
     const auto& input_indices_tensor = tensor_args.indices;
@@ -109,6 +111,8 @@ TopKMultiCoreProgramFactory::cached_program_t TopKMultiCoreProgramFactory::creat
         index_tile_size);            // Index tile memory footprint
 
     constexpr bool select_cores_row_wise = false;
+
+    // std::cout << "num cores = " << num_cores << std::endl;
 
     // Configure local processing cores (handle width chunks)
     auto local_cores_range =

--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_multi_core_program_factory.cpp
@@ -64,8 +64,6 @@ TopKMultiCoreProgramFactory::cached_program_t TopKMultiCoreProgramFactory::creat
     const TopkParams& args, const TopkInputs& tensor_args, std::tuple<Tensor, Tensor>& output_tensors) {
     using namespace tt::constants;
 
-    // std::cout << "TOPK MULTI CORE PROGRAM FACTORY" << std::endl;
-
     // Tensor references
     const auto& input_tensor = tensor_args.input;
     const auto& input_indices_tensor = tensor_args.indices;
@@ -111,8 +109,6 @@ TopKMultiCoreProgramFactory::cached_program_t TopKMultiCoreProgramFactory::creat
         index_tile_size);            // Index tile memory footprint
 
     constexpr bool select_cores_row_wise = false;
-
-    // std::cout << "num cores = " << num_cores << std::endl;
 
     // Configure local processing cores (handle width chunks)
     auto local_cores_range =

--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_single_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_single_core_program_factory.cpp
@@ -72,7 +72,7 @@ TopKSingleCoreProgramFactory::cached_program_t TopKSingleCoreProgramFactory::cre
     // Input CB -> Reader Kernel -> Transposed CBs -> Compute Kernel -> Result Prep CBs -> Output CBs -> Writer Kernel
     const uint32_t num_cb_unit = 2;                         // Base unit for double buffering
     const uint32_t cb_in_units = 2 * num_cb_unit;           // 4 units total for input double buffering
-    const uint32_t input_cb_tile_count = cb_in_units + 1;   // Input stream buffer size
+    const uint32_t input_cb_tile_count = cb_in_units;       // Input stream buffer size
     const uint32_t transposed_cb_tile_count = 4;            // Transposed data staging
     const uint32_t result_prep_cb_tile_count = 2 * Ktiles;  // Intermediate TopK results (double-buffered)
     const uint32_t output_cb_tile_count = Ktiles;           // Final output buffer

--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_single_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_single_core_program_factory.cpp
@@ -72,7 +72,7 @@ TopKSingleCoreProgramFactory::cached_program_t TopKSingleCoreProgramFactory::cre
     // Input CB -> Reader Kernel -> Transposed CBs -> Compute Kernel -> Result Prep CBs -> Output CBs -> Writer Kernel
     const uint32_t num_cb_unit = 2;                         // Base unit for double buffering
     const uint32_t cb_in_units = 2 * num_cb_unit;           // 4 units total for input double buffering
-    const uint32_t input_cb_tile_count = cb_in_units;       // Input stream buffer size
+    const uint32_t input_cb_tile_count = cb_in_units + 1;   // Input stream buffer size
     const uint32_t transposed_cb_tile_count = 4;            // Transposed data staging
     const uint32_t result_prep_cb_tile_count = 2 * Ktiles;  // Intermediate TopK results (double-buffered)
     const uint32_t output_cb_tile_count = Ktiles;           // Final output buffer
@@ -81,7 +81,7 @@ TopKSingleCoreProgramFactory::cached_program_t TopKSingleCoreProgramFactory::cre
     const uint32_t input_cb_index = tt::CBIndex::c_0;
     const tt::tt_metal::CircularBufferConfig input_cb_config =
         tt::tt_metal::CircularBufferConfig(
-            input_cb_tile_count * value_tile_size, {{input_cb_index, input_cb_data_format}})
+            input_cb_tile_count * input_tile_size, {{input_cb_index, input_cb_data_format}})
             .set_page_size(input_cb_index, input_tile_size);
     tt::tt_metal::CreateCircularBuffer(program, core_range, input_cb_config);
 
@@ -95,7 +95,7 @@ TopKSingleCoreProgramFactory::cached_program_t TopKSingleCoreProgramFactory::cre
     constexpr uint32_t transposed_val_cb_index = tt::CBIndex::c_2;
     const tt::tt_metal::CircularBufferConfig transposed_val_cb_config =
         tt::tt_metal::CircularBufferConfig(
-            transposed_cb_tile_count * value_tile_size, {{transposed_val_cb_index, input_cb_data_format}})
+            transposed_cb_tile_count * input_tile_size, {{transposed_val_cb_index, input_cb_data_format}})
             .set_page_size(transposed_val_cb_index, input_tile_size);
     tt::tt_metal::CreateCircularBuffer(program, core_range, transposed_val_cb_config);
 
@@ -109,7 +109,7 @@ TopKSingleCoreProgramFactory::cached_program_t TopKSingleCoreProgramFactory::cre
     constexpr uint32_t result_prep_val_cb_index = tt::CBIndex::c_4;
     const tt::tt_metal::CircularBufferConfig result_prep_val_cb_config =
         tt::tt_metal::CircularBufferConfig(
-            result_prep_cb_tile_count * value_tile_size, {{result_prep_val_cb_index, input_cb_data_format}})
+            result_prep_cb_tile_count * input_tile_size, {{result_prep_val_cb_index, input_cb_data_format}})
             .set_page_size(result_prep_val_cb_index, input_tile_size);
     tt::tt_metal::CreateCircularBuffer(program, core_range, result_prep_val_cb_config);
 
@@ -171,7 +171,7 @@ TopKSingleCoreProgramFactory::cached_program_t TopKSingleCoreProgramFactory::cre
         core_range,
         tt::tt_metal::WriterDataMovementConfig(writer_compile_time_args));
 
-    std::vector<uint32_t> compute_args = {
+    const std::vector<uint32_t> compute_args = {
         input_cb_index,                            // Input values
         index_cb_index,                            // Input indices
         transposed_val_cb_index,                   // Transposed values

--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_single_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_single_core_program_factory.cpp
@@ -19,6 +19,9 @@ namespace ttnn::prim {
 TopKSingleCoreProgramFactory::cached_program_t TopKSingleCoreProgramFactory::create(
     const TopkParams& args, const TopkInputs& tensor_args, std::tuple<Tensor, Tensor>& output_tensors) {
     using namespace tt::constants;
+
+    // std::cout << "TOPK SINGLE CORE PROGRAM FACTORY" << std::endl;
+
     // Tensor references
     const auto& input_tensor = tensor_args.input;
     const auto& value_tensor = std::get<0>(output_tensors);
@@ -64,6 +67,8 @@ TopKSingleCoreProgramFactory::cached_program_t TopKSingleCoreProgramFactory::cre
         std::make_pair(core_group_1, num_tiles_per_core_group_1),
         std::make_pair(core_group_2, num_tiles_per_core_group_2)};
     const std::vector<CoreCoord>& cores = corerange_to_cores(core_range, total_number_of_cores, true);
+
+    // std::cout << "total_number_of_cores = " << total_number_of_cores << std::endl;
 
     // Number of tiles needed to store K top elements
     const uint32_t Ktiles = tt::div_up(args.k, tt::constants::TILE_WIDTH);

--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_single_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_single_core_program_factory.cpp
@@ -135,13 +135,6 @@ TopKSingleCoreProgramFactory::cached_program_t TopKSingleCoreProgramFactory::cre
             .set_page_size(output_ind_cb_index, index_tile_size);
     tt::tt_metal::CreateCircularBuffer(program, core_range, output_ind_cb_config);
 
-    constexpr uint32_t synchronization_cb_index = tt::CBIndex::c_8;
-    constexpr uint32_t synchronization_cb_size = tt::constants::TILE_HW * sizeof(uint8_t);
-    const tt::tt_metal::CircularBufferConfig synchronization_cb_config =
-        tt::tt_metal::CircularBufferConfig(synchronization_cb_size, {{synchronization_cb_index, tt::DataFormat::UInt8}})
-            .set_page_size(synchronization_cb_index, synchronization_cb_size);
-    tt::tt_metal::CreateCircularBuffer(program, core_range, synchronization_cb_config);
-
     // Kernel Creations:
     std::vector<uint32_t> reader_compile_time_args = {
         input_cb_index,                       // Input values
@@ -192,7 +185,6 @@ TopKSingleCoreProgramFactory::cached_program_t TopKSingleCoreProgramFactory::cre
         Wt,                                        // Width in tiles
         Ktiles,                                    // K value in tiles
         static_cast<std::uint32_t>(args.largest),  // Sort order: largest (true) or smallest (false)
-        synchronization_cb_index,
     };
     tt::tt_metal::KernelHandle compute_kernel_id = tt::tt_metal::CreateKernel(
         program,

--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_single_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_single_core_program_factory.cpp
@@ -20,8 +20,6 @@ TopKSingleCoreProgramFactory::cached_program_t TopKSingleCoreProgramFactory::cre
     const TopkParams& args, const TopkInputs& tensor_args, std::tuple<Tensor, Tensor>& output_tensors) {
     using namespace tt::constants;
 
-    // std::cout << "TOPK SINGLE CORE PROGRAM FACTORY" << std::endl;
-
     // Tensor references
     const auto& input_tensor = tensor_args.input;
     const auto& value_tensor = std::get<0>(output_tensors);
@@ -67,8 +65,6 @@ TopKSingleCoreProgramFactory::cached_program_t TopKSingleCoreProgramFactory::cre
         std::make_pair(core_group_1, num_tiles_per_core_group_1),
         std::make_pair(core_group_2, num_tiles_per_core_group_2)};
     const std::vector<CoreCoord>& cores = corerange_to_cores(core_range, total_number_of_cores, true);
-
-    // std::cout << "total_number_of_cores = " << total_number_of_cores << std::endl;
 
     // Number of tiles needed to store K top elements
     const uint32_t Ktiles = tt::div_up(args.k, tt::constants::TILE_WIDTH);

--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_single_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_single_core_program_factory.cpp
@@ -72,7 +72,7 @@ TopKSingleCoreProgramFactory::cached_program_t TopKSingleCoreProgramFactory::cre
     // Pipeline Flow:
     // Input CB -> Reader Kernel -> Transposed CBs -> Compute Kernel -> Result Prep CBs -> Output CBs -> Writer Kernel
     const uint32_t num_cb_unit = 2;                         // Base unit for double buffering
-    const uint32_t cb_in_units = num_cb_unit;               // 4 units total for input double buffering
+    const uint32_t cb_in_units = num_cb_unit;               // 2 units total for input double buffering
     const uint32_t input_cb_tile_count = cb_in_units;       // Input stream buffer size
     const uint32_t transposed_cb_tile_count = 4;            // Transposed data staging
     const uint32_t result_prep_cb_tile_count = 2 * Ktiles;  // Intermediate TopK results (double-buffered)

--- a/ttnn/cpp/ttnn/operations/reduction/topk/topk.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/topk.cpp
@@ -287,6 +287,12 @@ std::vector<Tensor> topk(
     output_tensor_vec.push_back(std::move(output_value_tensor));
     output_tensor_vec.push_back(std::move(output_index_tensor));
 
+    // Save pre-transformed tensor buffers for comparison (needed to check if device op changed buffers)
+    auto* pre_transform_buffer_0 =
+        preallocated_output_tensors.has_value() ? std::get<0>(output_tensors.value()).buffer() : nullptr;
+    auto* pre_transform_buffer_1 =
+        preallocated_output_tensors.has_value() ? std::get<1>(output_tensors.value()).buffer() : nullptr;
+
     // Apply post-processing transformations to restore original format
     auto post_transform_output_tensors =
         operations::reduction::topk::CMAKE_UNIQUE_NAMESPACE::post_topk_transform_tensor(
@@ -301,10 +307,10 @@ std::vector<Tensor> topk(
 
     // Check if padding or dtype conversion changed buffer address
     if (preallocated_output_tensors.has_value()) {
-        if (std::get<0>(preallocated_output_tensors.value()).buffer() != output_tensor_vec.at(0).buffer()) {
+        if (std::get<0>(preallocated_output_tensors.value()).buffer() != pre_transform_buffer_0) {
             std::get<0>(preallocated_output_tensors.value()) = post_transform_output_tensors.at(0);
         }
-        if (std::get<1>(preallocated_output_tensors.value()).buffer() != output_tensor_vec.at(1).buffer()) {
+        if (std::get<1>(preallocated_output_tensors.value()).buffer() != pre_transform_buffer_1) {
             std::get<1>(preallocated_output_tensors.value()) = post_transform_output_tensors.at(1);
         }
     }

--- a/ttnn/cpp/ttnn/operations/reduction/topk/topk.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/topk.cpp
@@ -189,7 +189,7 @@ std::vector<Tensor> topk(
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<CoreRangeSet>& sub_core_grids,
     const std::optional<Tensor>& indices_tensor,
-    const std::optional<std::tuple<Tensor, Tensor>>& preallocated_output_tensors) {
+    std::optional<std::tuple<Tensor&, Tensor&>> preallocated_output_tensors) {
     // Store original shape for final output validation
     const ttnn::Shape& original_lshape = input_tensor.logical_shape();
 
@@ -288,15 +288,27 @@ std::vector<Tensor> topk(
     output_tensor_vec.push_back(std::move(output_index_tensor));
 
     // Apply post-processing transformations to restore original format
-    return operations::reduction::topk::CMAKE_UNIQUE_NAMESPACE::post_topk_transform_tensor(
-        transposed_tensor,
-        output_tensor_vec,
-        dim,
-        is_dim_last_idx,
-        k,
-        adjusted_k,
-        original_lshape,
-        input_memory_config);
+    auto post_transform_output_tensors =
+        operations::reduction::topk::CMAKE_UNIQUE_NAMESPACE::post_topk_transform_tensor(
+            transposed_tensor,
+            output_tensor_vec,
+            dim,
+            is_dim_last_idx,
+            k,
+            adjusted_k,
+            original_lshape,
+            input_memory_config);
+
+    // Check if padding or dtype conversion changed buffer address
+    if (preallocated_output_tensors.has_value()) {
+        if (std::get<0>(preallocated_output_tensors.value()).buffer() != output_tensor_vec.at(0).buffer()) {
+            std::get<0>(preallocated_output_tensors.value()) = post_transform_output_tensors.at(0);
+        }
+        if (std::get<1>(preallocated_output_tensors.value()).buffer() != output_tensor_vec.at(1).buffer()) {
+            std::get<1>(preallocated_output_tensors.value()) = post_transform_output_tensors.at(1);
+        }
+    }
+    return post_transform_output_tensors;
 }
 
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/reduction/topk/topk.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/topk.hpp
@@ -38,6 +38,6 @@ std::vector<Tensor> topk(
     const std::optional<tt::tt_metal::MemoryConfig>& memory_config = std::nullopt,
     const std::optional<tt::tt_metal::CoreRangeSet>& sub_core_grids = std::nullopt,
     const std::optional<Tensor>& indices_tensor = std::nullopt,
-    const std::optional<std::tuple<Tensor, Tensor>>& preallocated_output_tensors = std::nullopt);
+    std::optional<std::tuple<Tensor&, Tensor&>> preallocated_output_tensors = std::nullopt);
 
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/reduction/topk/topk.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/topk.hpp
@@ -12,6 +12,21 @@
 #include <tuple>
 #include <vector>
 
+namespace ttnn::operations::reduction::topk {
+struct ExecuteTopK {
+    static std::vector<Tensor> invoke(
+        const Tensor& input_tensor,
+        uint32_t k,
+        int8_t dim,
+        bool largest,
+        bool sorted,
+        const std::optional<tt::tt_metal::MemoryConfig>& memory_config = std::nullopt,
+        const std::optional<tt::tt_metal::CoreRangeSet>& sub_core_grids = std::nullopt,
+        const std::optional<Tensor>& indices_tensor = std::nullopt,
+        std::optional<std::tuple<Tensor&, Tensor&>> preallocated_output_tensors = std::nullopt);
+};
+}  // namespace ttnn::operations::reduction::topk
+
 namespace ttnn {
 
 std::vector<Tensor> topk(

--- a/ttnn/cpp/ttnn/operations/reduction/topk/topk_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/topk_nanobind.cpp
@@ -32,7 +32,7 @@ void bind_reduction_topk_operation(nb::module_& mod) {
 
             .. code-block:: python
 
-                return torch.topk(input_tensor, k, dim=dim, largest=largest, sorted=sorted, *, out=None)
+                return torch.topk(input_tensor, k, dim=dim, largest=largest, sorted=sorted, *, output_tensor=None)
 
             Args:
                 input_tensor (ttnn.Tensor): the input tensor.

--- a/ttnn/cpp/ttnn/operations/reduction/topk/topk_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/topk_nanobind.cpp
@@ -10,6 +10,7 @@
 #include <nanobind/nanobind.h>
 #include <nanobind/stl/optional.h>
 #include <nanobind/stl/tuple.h>
+#include <nanobind/stl/vector.h>
 
 #include "ttnn-nanobind/bind_function.hpp"
 #include "ttnn/operations/reduction/topk/topk.hpp"
@@ -47,7 +48,7 @@ void bind_reduction_topk_operation(nb::module_& mod) {
                 indices_tensor (ttnn.Tensor, optional): Preallocated indices tensor with filled values. Defaults to `None`.
 
             Returns:
-                List of ttnn.Tensor: the output tensor.
+                tuple[ttnn.Tensor, ttnn.Tensor]: a tuple of (values_tensor, indices_tensor).
 
             Note:
                 The :attr:`input_tensor` supports the following data type and layout:


### PR DESCRIPTION
### Ticket
#23004

### Problem description
topk sweep tests had failures. 

### What's changed
This fixes the failures in topk sweep tests. Top-k sweep tests are either green or xfail (e.g. bfloat8_b inputs)

### Checklist

- [x] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=23004-TopK-debug-branch)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:23004-TopK-debug-branch)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=23004-TopK-debug-branch)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:23004-TopK-debug-branch) (failures in main)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=23004-TopK-debug-branch)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:23004-TopK-debug-branch)
- [x] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=23004-TopK-debug-branch)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:23004-TopK-debug-branch)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=23004-TopK-debug-branch)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:23004-TopK-debug-branch)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=23004-TopK-debug-branch)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:23004-TopK-debug-branch)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
