### PR TITLE
Add  DeepSeek V3 B1 demo host interface integration tests 

### DIFF
--- a/models/demos/deepseek_v3_b1/model.py
+++ b/models/demos/deepseek_v3_b1/model.py
@@ -1,0 +1,229 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+DeepSeek V3 B1 model (host interface).
+
+Orchestrates prefill (token-by-token prompt processing) and autoregressive decode
+over the socket interface. Uses HostInterface in loopback mode as a mock decoder
+until the real decoder pipeline is composed from Pre-SDPA, Flash MLA, Post-SDPA, MoE.
+
+Algorithm (prefill-by-decode then generation):
+  - Prefill: for i = 0..S-1, call with input_ids = x[i] (B, 1); device uses/updates
+    cache; ignore logits for i < S-1. prefill() returns the last step output (logits
+    in real decoder) so caller can sample y0.
+  - Start generation: last_logits = prefill(prompt_tokens); y0 = sample(last_logits).
+  - Generation loop: for t = 0,1,..., feed y[t] (B, 1) via decode_step(), get logits,
+    sample y[t+1], repeat.
+
+Input tensor shape (H2D):
+  - Only (B, 1) is supported: one token per batch element per step. The embedding layer
+    runs on device; the host sends token IDs (int32). Payload size is B * TOKEN_ID_BYTES.
+
+Interface vs real decoder:
+  - One H2D write and one D2H read per step. The real decoder will also need per-step
+    position (cur_pos_tensor / kv_cache_write_index); the engine tracks position for
+    when the protocol is extended.
+"""
+
+import torch
+from loguru import logger
+
+import ttnn
+from models.demos.deepseek_v3_b1.micro_ops.host_io.op import HostInterface
+
+# Token IDs are int32 over the socket; payload size per step is B * TOKEN_ID_BYTES.
+TOKEN_ID_BYTES: int = 4
+
+# Socket page_size must be PCIe-aligned (see h2d_socket.cpp). Use 64 to work across devices.
+PCIE_PAGE_ALIGNMENT_BYTES: int = 64
+
+
+def align_up(value: int, alignment: int) -> int:
+    """Round value up to the next multiple of alignment."""
+    return (value + alignment - 1) // alignment * alignment
+
+
+def page_size_bytes(batch_size: int) -> int:
+    """PCIe-aligned page (and FIFO) size in bytes for (B, 1) token IDs. Use for socket creation."""
+    return align_up(batch_size * TOKEN_ID_BYTES, PCIE_PAGE_ALIGNMENT_BYTES)
+
+
+def create_output_buffer(page_size_datums: int) -> ttnn.Tensor:
+    """Allocate a host output tensor (1, page_size_datums) int32 for socket read_tensor."""
+    torch_output = torch.zeros(1, page_size_datums, dtype=torch.int32)
+    return ttnn.from_torch(torch_output, dtype=ttnn.uint32, layout=ttnn.ROW_MAJOR_LAYOUT)
+
+
+def to_padded_input(
+    token: torch.Tensor | ttnn.Tensor,
+    batch_size: int,
+    page_size_datums: int,
+) -> ttnn.Tensor:
+    """Copy (B, 1) token into a PCIe-aligned padded buffer for write_tensor."""
+    if isinstance(token, ttnn.Tensor):
+        token = ttnn.to_torch(token)
+    torch_padded = torch.zeros(1, page_size_datums, dtype=torch.int32)
+    torch_padded[0, :batch_size] = token.flatten()[:batch_size]
+    return ttnn.from_torch(torch_padded, dtype=ttnn.uint32, layout=ttnn.ROW_MAJOR_LAYOUT)
+
+
+class DeepSeekV3:
+    """
+    Host-side model interface for prefill and decode over H2D/D2H sockets.
+    Tracks position for compatibility with the real decoder (position_ids, kv_cache_write_index).
+
+    Prefill uses DEVICE_PULL H2D; decode uses HOST_PUSH H2D. Two HostInterface programs
+    run one at a time on the same core; the first decode_step() transitions from prefill
+    to decode host I/O.
+    """
+
+    def __init__(
+        self,
+        h2d_socket_prefill: ttnn.H2DSocket,
+        h2d_socket_decode: ttnn.H2DSocket,
+        d2h_socket: ttnn.D2HSocket,
+        batch_size: int = 1,
+        loopback_mode: bool = False,
+    ) -> None:
+        """
+        Args:
+            h2d_socket_prefill: H2D socket for prefill; must use DEVICE_PULL mode.
+            h2d_socket_decode: H2D socket for decode; must use HOST_PUSH mode.
+            d2h_socket: D2H socket for device-to-host (shared by prefill and decode).
+            batch_size: Batch size B. Current implementation supports only B=1;
+                payload size is B * TOKEN_ID_BYTES (int32).
+            loopback_mode: If True, host I/O uses circular buffers for H2D/D2H loopback
+                If False, host I/O forwards to downstream/upstream cores via D2D sockets.
+
+        Sockets must be created with FIFO size equal to page_size_bytes(batch_size).
+        """
+        if batch_size != 1:
+            raise ValueError(f"DeepSeekV3 currently supports only batch_size=1, got {batch_size}")
+        if h2d_socket_prefill.get_h2d_mode() != ttnn.H2DMode.DEVICE_PULL:
+            raise ValueError(
+                "h2d_socket_prefill must use H2DMode.DEVICE_PULL, got " f"{h2d_socket_prefill.get_h2d_mode()}"
+            )
+        if h2d_socket_decode.get_h2d_mode() != ttnn.H2DMode.HOST_PUSH:
+            raise ValueError("h2d_socket_decode must use H2DMode.HOST_PUSH, got " f"{h2d_socket_decode.get_h2d_mode()}")
+
+        self.h2d_socket_prefill = h2d_socket_prefill
+        self.h2d_socket_decode = h2d_socket_decode
+        self.d2h_socket = d2h_socket
+        self.batch_size = batch_size
+        payload_bytes: int = batch_size * TOKEN_ID_BYTES
+        logger.debug(f"Payload bytes: {payload_bytes} bytes")
+        self._tensor_size_bytes: int = align_up(payload_bytes, PCIE_PAGE_ALIGNMENT_BYTES)
+        self._page_size_datums: int = self._tensor_size_bytes // TOKEN_ID_BYTES
+
+        logger.debug(f"Creating DeepSeekV3 model with batch size {batch_size}")
+        logger.debug(
+            f"Creating host I/O for prefill and decode with aligned page size {self._tensor_size_bytes} bytes (payload size is {payload_bytes} bytes)"
+        )
+
+        self._host_io_prefill: HostInterface = HostInterface(
+            h2d_socket_prefill,
+            d2h_socket,
+            self._tensor_size_bytes,
+            self._tensor_size_bytes,
+            core_to_core_socket_buffer_size=self._tensor_size_bytes,
+            loopback_mode=loopback_mode,
+        )
+        self._host_io_decode: HostInterface = HostInterface(
+            h2d_socket_decode,
+            d2h_socket,
+            self._tensor_size_bytes,
+            self._tensor_size_bytes,
+            core_to_core_socket_buffer_size=self._tensor_size_bytes,
+            loopback_mode=loopback_mode,
+        )
+        self._prefill_active: bool = False
+        self._decode_active: bool = False
+        self._position: int = 0
+        self._output_buffer: ttnn.Tensor = create_output_buffer(self._page_size_datums)
+
+    def start(self) -> None:
+        """Launch the prefill mock decoder program (DEVICE_PULL H2D) on device."""
+        self._host_io_prefill.run()
+        self._prefill_active = True
+        self._decode_active = False
+
+    def _switch_to_decode(self) -> None:
+        """One-time transition: terminate prefill host I/O, launch decode host I/O (HOST_PUSH)."""
+        if self._decode_active:
+            return
+        if self._prefill_active:
+            logger.debug(f"Terminating prefill host I/O")
+            self._host_io_prefill.terminate()
+            self._prefill_active = False
+        logger.debug(f"Switching to decode host I/O")
+        self._host_io_decode.run()
+        self._decode_active = True
+
+    def prefill(self, prompt_tokens: list[ttnn.Tensor]) -> ttnn.Tensor:
+        """
+        Prefill-by-decode: for i = 0..S-1, send input_ids = x[i], get logits
+        (and device updates cache). Outputs for i < S-1 are discarded. Returns the
+        last step output so the caller can sample y0 (first generated token).
+
+        Args:
+            prompt_tokens: List of ttnn.Tensor, each already padded for the socket
+                (PCIe-aligned, size in bytes equal to page_size_bytes(batch_size)).
+                Caller is responsible for padding; use to_padded_input() if needed.
+
+        Returns:
+            Last step output tensor; valid data is first batch_size elements (logits
+            (B, V) in real decoder). None if prompt_tokens is empty. Caller uses this
+            to sample(logits) -> y0 for the generation loop.
+        """
+        if len(prompt_tokens) == 0:
+            raise ValueError("Expected at least one prompt token")
+
+        last_output: ttnn.Tensor | None = None
+        for token in prompt_tokens:
+            self.h2d_socket_prefill.write_tensor(token)
+            self.d2h_socket.read_tensor(self._output_buffer)
+            last_output = self._output_buffer
+            self._position += 1
+        assert last_output is not None, "Last output tensor is None"
+        return last_output
+
+    def decode_step(self, input_tensor: ttnn.Tensor) -> ttnn.Tensor:
+        """
+        Single decode step: send input via H2D, receive output via D2H.
+        On first call, transitions from prefill host I/O to decode host I/O (HOST_PUSH).
+        Returns the output tensor. Increments position.
+
+        Args:
+            input_tensor: Token IDs (B, 1), torch or ttnn.
+
+        Returns:
+            Output tensor; valid data is first batch_size elements. In loopback mode
+            that matches the input.
+        """
+        assert len(input_tensor.shape) == 2, f"Input tensor shape must be (B, 1), got {input_tensor.shape}"
+        assert (
+            input_tensor.shape[0] == self.batch_size
+        ), f"Input tensor batch size must be {self.batch_size}, got {input_tensor.shape[0]}"
+
+        self._switch_to_decode()
+        padded_input = to_padded_input(input_tensor, self.batch_size, self._page_size_datums)
+        self.h2d_socket_decode.write_tensor(padded_input)
+        self.d2h_socket.read_tensor(self._output_buffer)
+        self._position += 1
+        return self._output_buffer
+
+    @property
+    def position(self) -> int:
+        """Current sequence position (number of tokens processed so far)."""
+        return self._position
+
+    def stop(self) -> None:
+        """Clean shutdown of whichever mock decoder (prefill or decode) is active."""
+        if self._prefill_active:
+            self._host_io_prefill.terminate()
+            self._prefill_active = False
+        if self._decode_active:
+            self._host_io_decode.terminate()
+            self._decode_active = False

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_model.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_model.py
@@ -1,0 +1,88 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Tests for DeepSeek V3 B1 model (prefill harness and decode flow).
+
+Uses HostInterface in loopback mode as a mock decoder; validates prefill
+(token-by-token with outputs discarded) and autoregressive decode (input → output).
+"""
+
+from __future__ import annotations
+
+import pytest
+import torch
+from loguru import logger
+
+import ttnn
+from models.common.utility_functions import is_slow_dispatch
+from models.demos.deepseek_v3_b1.model import TOKEN_ID_BYTES, DeepSeekV3, page_size_bytes, to_padded_input
+
+
+@pytest.mark.parametrize("loopback_mode", [True, False])
+@pytest.mark.parametrize("batch_size", [1])
+@pytest.mark.parametrize("prompt_length", [1, 8, 64, 128])
+@pytest.mark.parametrize("num_decode_steps", [1, 16, 32])
+def test_prefill_and_decode(
+    mesh_device: ttnn.MeshDevice,
+    loopback_mode: bool,
+    batch_size: int,
+    prompt_length: int,
+    num_decode_steps: int,
+) -> None:
+    if not is_slow_dispatch():
+        pytest.skip("Skipping test in fast dispatch mode")
+    if not loopback_mode:
+        pytest.skip("Non-loopback mode is not currently supported")
+
+    fifo_size = page_size_bytes(batch_size)
+
+    device_coord: ttnn.MeshCoordinate = ttnn.MeshCoordinate(0, 0)
+    core_coord: ttnn.CoreCoord = ttnn.CoreCoord(0, 0)
+    socket_core: ttnn.MeshCoreCoord = ttnn.MeshCoreCoord(device_coord, core_coord)
+
+    logger.info("Creating sockets and DeepSeekV3 model (prefill=DEVICE_PULL, decode=HOST_PUSH)")
+    h2d_socket_prefill = ttnn.H2DSocket(
+        mesh_device, socket_core, ttnn.BufferType.L1, fifo_size, ttnn.H2DMode.DEVICE_PULL
+    )
+    h2d_socket_decode = ttnn.H2DSocket(mesh_device, socket_core, ttnn.BufferType.L1, fifo_size, ttnn.H2DMode.HOST_PUSH)
+    d2h_socket = ttnn.D2HSocket(mesh_device, socket_core, fifo_size)
+    model = DeepSeekV3(h2d_socket_prefill, h2d_socket_decode, d2h_socket, batch_size, loopback_mode=loopback_mode)
+    model.start()
+
+    logger.info(f"B={batch_size}, prefill {prompt_length} tokens, then {num_decode_steps} decode steps")
+
+    # Phase 1: Prefill - list of padded ttnn.Tensor tokens
+    page_size_datums = page_size_bytes(batch_size) // TOKEN_ID_BYTES
+    prompt_tokens: list[ttnn.Tensor] = [
+        to_padded_input(
+            torch.full((batch_size, 1), i, dtype=torch.int32),
+            batch_size,
+            page_size_datums,
+        )
+        for i in range(prompt_length)
+    ]
+    model.prefill(prompt_tokens)
+    assert model.position == prompt_length, f"Position after prefill: expected {prompt_length}, got {model.position}"
+
+    # Phase 2: Decode - each step (B, 1) in, (B, 1) out; loopback => output == input
+    for step in range(num_decode_steps):
+        token_id = prompt_length + step
+        torch_input = torch.full((batch_size, 1), token_id, dtype=torch.int32)
+        input_tensor = ttnn.from_torch(torch_input, dtype=ttnn.uint32, layout=ttnn.ROW_MAJOR_LAYOUT)
+        output_tensor = model.decode_step(input_tensor)
+        result_torch = ttnn.to_torch(output_tensor)
+
+        # Output is padded to PCIe alignment; valid data is first batch_size elements
+        result_valid = result_torch.reshape(-1)[:batch_size].reshape(batch_size, 1)
+        assert torch.equal(
+            torch_input, result_valid
+        ), f"Decode step {step} loopback mismatch: expected {torch_input}, got {result_valid}"
+
+    assert (
+        model.position == prompt_length + num_decode_steps
+    ), f"Position after decode: expected {prompt_length + num_decode_steps}, got {model.position}"
+
+    model.stop()
+    logger.info("Prefill and decode test passed")

--- a/ttnn/cpp/ttnn-nanobind/mesh_socket.cpp
+++ b/ttnn/cpp/ttnn-nanobind/mesh_socket.cpp
@@ -128,6 +128,15 @@ void py_module_types(nb::module_& mod) {
                 Note:
                     Sockets should typically be created in pairs using create_socket_pair()
                     rather than using this constructor directly.
+            )doc")
+        .def(
+            "get_config_buffer_address",
+            [](const tt::tt_metal::distributed::MeshSocket& socket) {
+                return static_cast<uint32_t>(socket.get_config_buffer()->address());
+            },
+            R"doc(
+                Returns the L1 address of the socket configuration buffer on the device.
+                This address is passed to device kernels to access socket metadata.
             )doc");
 }
 


### PR DESCRIPTION
### Summary

This change adds a host-side DeepSeekV3 interface for the B1 demo (prefill + decode over H2D/D2H sockets). Currently, we use separate H2D sockets for prefill (DEVICE_PULL) and decode (HOST_PUSH) with a one-time switch on first decode step.

### What's changed
- Adds host interface for B1 demo: `DeepSeekV3(h2d_socket_prefill, h2d_socket_decode, d2h_socket, batch_size=1, loopback_mode=False)`
- Added `test_model.py::test_prefill_and_decode`: Creates `DeepSeekV3` host interface and runs prefill then decode, asserts position and loopback output. Currently skips when `loopback_mode=False`

Changes to `HostInterface`:
- Fixed non-loopback socket construction (need to create `SocketConnection(sender_core, receiver_core)` for each link, then `SocketConfig([connection], SocketMemoryConfig(...))` for downstream and upstream)
- Upstream socket index: In non-loopback, the D2H kernel compile-time arg now uses self.upstream_socket_pair[1] (receiver socket on the host I/O core) instead of [0] (sender on the upstream core), so the kernel gets the config buffer for the core that actually receives from upstream.
- Added `get_config_buffer_address()` on MeshSocket so non-loopback HostInterface can pass the D2D socket config buffer address into the kernels the same way H2D/D2H sockets do.

### Checklist

- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/22102677023)
