### PR TITLE
#37982: Overlap pre-SDPA memory regions

### DIFF
--- a/models/demos/deepseek_v3_b1/fused_ops/pre_sdpa/op.py
+++ b/models/demos/deepseek_v3_b1/fused_ops/pre_sdpa/op.py
@@ -1152,6 +1152,8 @@ class PreSDPA:
                     ("skip_ccl", 1 if skip_ccl else 0),
                 ]
 
+                sdpa_out_interm_running_offset = 0
+
                 # Create circular buffer descriptors
                 # CB: Input (created from sharded tensor)
                 cb0_backing_tensor = input_tensor_device if skip_ccl else intermediate_tensor_device
@@ -1187,74 +1189,12 @@ class PreSDPA:
                 rmsnorm2_gamma_cb_descriptor.format_descriptors[0].tile = rmsnorm2_tile_descriptor
                 rmsnorm2_gamma_cb_descriptor.format_descriptors[0].page_size = rmsnorm2_page_size
 
-                # CB 7: RMSNorm2 input buffer (3 tiles) — overlap with sdpa_out_interm L1 buffer
-                # at offset 64 B. This CB is consumed before SDPA runs.
-                rmsnorm2_input_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(
-                    rmsnorm2_input_cb,
-                    sdpa_out_interm_buffer_device,
-                    address_offset=64,
-                    total_size=rmsnorm2_num_tiles * rmsnorm2_page_size,
-                )
-                rmsnorm2_input_cb_descriptor.format_descriptors = [
-                    ttnn.CBFormatDescriptor(
-                        buffer_index=rmsnorm2_input_cb,
-                        data_format=data_format,
-                        page_size=rmsnorm2_page_size,
-                        tile=rmsnorm2_tile_descriptor,
-                    )
-                ]
-
-                # CB: RMSNorm2 output buffer (3 tiles)
-                rmsnorm2_output_cb_format = ttnn.CBFormatDescriptor(
-                    buffer_index=rmsnorm2_output_cb,
-                    data_format=data_format,
-                    page_size=rmsnorm2_page_size,
-                    tile=rmsnorm2_tile_descriptor,
-                )
-                rmsnorm2_output_cb_core_ranges = rmsnorm_core_grid
-
-                rmsnorm2_output_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(
-                    rmsnorm2_output_cb,
-                    sdpa_out_interm_buffer_device,
-                    address_offset=6208,
-                    total_size=rmsnorm2_num_tiles * rmsnorm2_page_size,
-                )
-                rmsnorm2_output_cb_descriptor.format_descriptors = [
-                    ttnn.CBFormatDescriptor(
-                        buffer_index=rmsnorm2_output_cb,
-                        data_format=data_format,
-                        page_size=rmsnorm2_page_size,
-                        tile=rmsnorm2_tile_descriptor,
-                    )
-                ]
-
-                # CB9 lifecycle:
-                # 1) RMSNorm2 writes normalized output here
-                # 2) Mcast2 reads from CB9 and writes to matmul2 input CB
-
-                # CB 8: gather_reduce half1 scratch buffer (3 tiles) — overlap with sdpa_out_interm L1 buffer
-                # at offset 3136 B. This CB is consumed before SDPA runs.
-                gather_reduce_half1_scratch_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(
-                    gather_reduce_half1_scratch_cb,
-                    sdpa_out_interm_buffer_device,
-                    address_offset=3136,
-                    total_size=rmsnorm2_num_tiles * rmsnorm2_page_size,
-                )
-                gather_reduce_half1_scratch_cb_descriptor.format_descriptors = [
-                    ttnn.CBFormatDescriptor(
-                        buffer_index=gather_reduce_half1_scratch_cb,
-                        data_format=data_format,
-                        page_size=rmsnorm2_page_size,
-                        tile=rmsnorm2_tile_descriptor,
-                    )
-                ]
-
                 # CB: RMSNorm output buffer — overlap with kv_cache L1 buffer
                 # at offset 0 B. This CB is consumed before SDPA runs.
                 rmsnorm_output_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(
                     rmsnorm_output_cb,
                     sdpa_kv_cache_buffer_device,
-                    address_offset=0,
+                    address_offset=0,  # 0 B (only CB being overlapped with sdpa_kv_cache_buffer)
                     total_size=num_tiles * cb_page_size,
                 )
                 rmsnorm_output_cb_descriptor.format_descriptors = [
@@ -1275,14 +1215,12 @@ class PreSDPA:
                 # Senders will query the write pointer of this CB to get the receiver address.
                 # Tensor-backed on full device grid (superset of sender/receiver grids) so senders
                 # can use get_write_ptr to get receiver address. This CB is consumed before SDPA runs.
-                # Note: TILE_1x32, matmul_input_page_size, and matmul_input_total_size
-                # were already calculated above for mcast page count calculation
-                matmul_input_tile_descriptor = ttnn.TileDescriptor(TILE_1x32)
                 # CB: Matmul input — overlap with kv_cache L1 buffer at offset 14336 B.
+                matmul_input_tile_descriptor = ttnn.TileDescriptor(TILE_1x32)
                 matmul_input_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(
                     matmul_input_cb,
-                    sdpa_kv_cache_buffer_device,
-                    address_offset=14336,
+                    sdpa_out_interm_buffer_device,
+                    address_offset=sdpa_out_interm_running_offset,  # 0 B
                     total_size=matmul_input_total_size,
                 )
                 matmul_input_cb_descriptor.format_descriptors = [
@@ -1293,6 +1231,7 @@ class PreSDPA:
                         tile=matmul_input_tile_descriptor,
                     )
                 ]
+                sdpa_out_interm_running_offset += matmul_input_cb_descriptor.total_size  # +14336 B
 
                 # CB: Matmul output buffer (single tile) — overlap with sdpa_out_interm L1 buffer
                 # at offset 0 B. This CB is consumed before SDPA runs.
@@ -1301,7 +1240,7 @@ class PreSDPA:
                 matmul_output_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(
                     matmul_output_cb,
                     sdpa_out_interm_buffer_device,
-                    address_offset=0,
+                    address_offset=sdpa_out_interm_running_offset,  # 14336 B
                     total_size=matmul_output_page_size,
                 )
                 matmul_output_cb_descriptor.format_descriptors = [
@@ -1312,6 +1251,72 @@ class PreSDPA:
                         tile=matmul_output_tile_descriptor,
                     )
                 ]
+                sdpa_out_interm_running_offset += matmul_output_cb_descriptor.total_size  # +64 B
+
+                # CB 7: RMSNorm2 input buffer (3 tiles) — overlap with sdpa_out_interm L1 buffer
+                # at offset 64 B. This CB is consumed before SDPA runs.
+                rmsnorm2_input_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(
+                    rmsnorm2_input_cb,
+                    sdpa_out_interm_buffer_device,
+                    address_offset=sdpa_out_interm_running_offset,  # 14400 B
+                    total_size=rmsnorm2_num_tiles * rmsnorm2_page_size,
+                )
+                rmsnorm2_input_cb_descriptor.format_descriptors = [
+                    ttnn.CBFormatDescriptor(
+                        buffer_index=rmsnorm2_input_cb,
+                        data_format=data_format,
+                        page_size=rmsnorm2_page_size,
+                        tile=rmsnorm2_tile_descriptor,
+                    )
+                ]
+                sdpa_out_interm_running_offset += rmsnorm2_input_cb_descriptor.total_size  # +3072 B
+
+                # CB9 lifecycle:
+                # 1) RMSNorm2 writes normalized output here
+                # 2) Mcast2 reads from CB9 and writes to matmul2 input CB
+
+                # CB 8: gather_reduce half1 scratch buffer (3 tiles) — overlap with sdpa_out_interm L1 buffer
+                # at offset 3136 B. This CB is consumed before SDPA runs.
+                gather_reduce_half1_scratch_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(
+                    gather_reduce_half1_scratch_cb,
+                    sdpa_out_interm_buffer_device,
+                    address_offset=sdpa_out_interm_running_offset,  # 17472 B
+                    total_size=rmsnorm2_num_tiles * rmsnorm2_page_size,
+                )
+                gather_reduce_half1_scratch_cb_descriptor.format_descriptors = [
+                    ttnn.CBFormatDescriptor(
+                        buffer_index=gather_reduce_half1_scratch_cb,
+                        data_format=data_format,
+                        page_size=rmsnorm2_page_size,
+                        tile=rmsnorm2_tile_descriptor,
+                    )
+                ]
+                sdpa_out_interm_running_offset += gather_reduce_half1_scratch_cb_descriptor.total_size  # +3072 B
+
+                # CB: RMSNorm2 output buffer (3 tiles)
+                rmsnorm2_output_cb_format = ttnn.CBFormatDescriptor(
+                    buffer_index=rmsnorm2_output_cb,
+                    data_format=data_format,
+                    page_size=rmsnorm2_page_size,
+                    tile=rmsnorm2_tile_descriptor,
+                )
+                rmsnorm2_output_cb_core_ranges = rmsnorm_core_grid
+
+                rmsnorm2_output_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(
+                    rmsnorm2_output_cb,
+                    sdpa_out_interm_buffer_device,
+                    address_offset=sdpa_out_interm_running_offset,  # 20544 B
+                    total_size=rmsnorm2_num_tiles * rmsnorm2_page_size,
+                )
+                rmsnorm2_output_cb_descriptor.format_descriptors = [
+                    ttnn.CBFormatDescriptor(
+                        buffer_index=rmsnorm2_output_cb,
+                        data_format=data_format,
+                        page_size=rmsnorm2_page_size,
+                        tile=rmsnorm2_tile_descriptor,
+                    )
+                ]
+                sdpa_out_interm_running_offset += rmsnorm2_output_cb_descriptor.total_size  # +3072 B
 
                 # CB: Matmul2 input buffer (1x1536 with 1x32 tiles = 48 tiles) — overlap with
                 # sdpa_out_interm L1 buffer at offset 9280 B. This CB is consumed before SDPA runs.
@@ -1319,7 +1324,7 @@ class PreSDPA:
                 matmul2_input_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(
                     matmul2_input_cb,
                     sdpa_out_interm_buffer_device,
-                    address_offset=9280,
+                    address_offset=sdpa_out_interm_running_offset,  # 23616 B
                     total_size=matmul2_input_total_size,
                 )
                 matmul2_input_cb_descriptor.format_descriptors = [
@@ -1330,6 +1335,7 @@ class PreSDPA:
                         tile=matmul_input_tile_descriptor,
                     )
                 ]
+                sdpa_out_interm_running_offset += matmul2_input_cb_descriptor.total_size  # +3072 B
 
                 # CB: Matmul2 weights (created from sharded tensor, 4 tiles per core)
                 matmul2_weights_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(
@@ -1342,7 +1348,7 @@ class PreSDPA:
                 matmul2_output_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(
                     matmul2_output_cb,
                     sdpa_out_interm_buffer_device,
-                    address_offset=12352,
+                    address_offset=sdpa_out_interm_running_offset,  # 26688 B
                     total_size=matmul2_output_total_size,
                 )
                 matmul2_output_cb_descriptor.format_descriptors = [
@@ -1353,6 +1359,7 @@ class PreSDPA:
                         tile=matmul_output_tile_descriptor,
                     )
                 ]
+                sdpa_out_interm_running_offset += matmul2_output_cb_descriptor.total_size  # +256 B
 
                 # CB 13: Matmul3 weights (created from sharded tensor on Qnope grid)
                 matmul3_weights_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(
@@ -1367,7 +1374,7 @@ class PreSDPA:
                 matmul3_output_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(
                     matmul3_output_cb,
                     sdpa_out_interm_buffer_device,
-                    address_offset=12608,
+                    address_offset=sdpa_out_interm_running_offset,  # 26944 B
                     total_size=matmul3_output_total_size,
                 )
                 matmul3_output_cb_descriptor.format_descriptors = [
@@ -1378,6 +1385,28 @@ class PreSDPA:
                         tile=matmul3_output_tile_descriptor,
                     )
                 ]
+                sdpa_out_interm_running_offset += matmul3_output_cb_descriptor.total_size  # +1024 B
+
+                # CB 15: Qrope output buffer — overlap with sdpa_out_interm L1 buffer
+                # at offset 13632 B. This CB is consumed before SDPA runs.
+                qrope_output_tile_descriptor = ttnn.TileDescriptor(TILE_1x32)
+                qrope_output_page_size = TILE_1x32.get_tile_size(data_format)
+                qrope_output_total_size = matmul2_out_w * qrope_output_page_size  # 4 tiles
+                qrope_output_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(
+                    qrope_output_cb,
+                    sdpa_out_interm_buffer_device,
+                    address_offset=sdpa_out_interm_running_offset,  # 27968 B
+                    total_size=qrope_output_total_size,
+                )
+                qrope_output_cb_descriptor.format_descriptors = [
+                    ttnn.CBFormatDescriptor(
+                        buffer_index=qrope_output_cb,
+                        data_format=data_format,
+                        page_size=qrope_output_page_size,
+                        tile=qrope_output_tile_descriptor,
+                    )
+                ]
+                sdpa_out_interm_running_offset += qrope_output_cb_descriptor.total_size  # +256 B
 
                 # CB 17: Cos (sharded tensor)
                 qrope_cos_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(qrope_cos_cb, qrope_cos_tensor_device)
@@ -1396,7 +1425,7 @@ class PreSDPA:
                 qrope_rotated_input_interm_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(
                     qrope_rotated_input_interm_cb,
                     sdpa_out_interm_buffer_device,
-                    address_offset=13888,
+                    address_offset=sdpa_out_interm_running_offset,  # 28224 B
                     total_size=qrope_interm_tile_size,
                 )
                 qrope_rotated_input_interm_cb_descriptor.format_descriptors = [
@@ -1407,13 +1436,14 @@ class PreSDPA:
                         tile=ttnn.TileDescriptor(TILE_1x32),
                     )
                 ]
+                sdpa_out_interm_running_offset += qrope_rotated_input_interm_cb_descriptor.total_size  # +128 B
 
                 # CB 21: Cos intermediate CB — overlap with sdpa_out_interm L1 buffer
                 # at offset 14016 B. This CB is consumed before SDPA runs.
                 qrope_cos_interm_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(
                     qrope_cos_interm_cb,
                     sdpa_out_interm_buffer_device,
-                    address_offset=14016,
+                    address_offset=sdpa_out_interm_running_offset,  # 28352 B
                     total_size=qrope_interm_tile_size,
                 )
                 qrope_cos_interm_cb_descriptor.format_descriptors = [
@@ -1424,13 +1454,14 @@ class PreSDPA:
                         tile=ttnn.TileDescriptor(TILE_1x32),
                     )
                 ]
+                sdpa_out_interm_running_offset += qrope_cos_interm_cb_descriptor.total_size  # +128 B
 
                 # CB 22: Sin intermediate CB — overlap with sdpa_out_interm L1 buffer
                 # at offset 14144 B. This CB is consumed before SDPA runs.
                 qrope_sin_interm_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(
                     qrope_sin_interm_cb,
                     sdpa_out_interm_buffer_device,
-                    address_offset=14144,
+                    address_offset=sdpa_out_interm_running_offset,  # 28480 B
                     total_size=qrope_interm_tile_size,
                 )
                 qrope_sin_interm_cb_descriptor.format_descriptors = [
@@ -1441,26 +1472,7 @@ class PreSDPA:
                         tile=ttnn.TileDescriptor(TILE_1x32),
                     )
                 ]
-
-                # CB 15: Qrope output buffer — overlap with sdpa_out_interm L1 buffer
-                # at offset 13632 B. This CB is consumed before SDPA runs.
-                qrope_output_tile_descriptor = ttnn.TileDescriptor(TILE_1x32)
-                qrope_output_page_size = TILE_1x32.get_tile_size(data_format)
-                qrope_output_total_size = matmul2_out_w * qrope_output_page_size  # 4 tiles
-                qrope_output_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(
-                    qrope_output_cb,
-                    sdpa_out_interm_buffer_device,
-                    address_offset=13632,
-                    total_size=qrope_output_total_size,
-                )
-                qrope_output_cb_descriptor.format_descriptors = [
-                    ttnn.CBFormatDescriptor(
-                        buffer_index=qrope_output_cb,
-                        data_format=data_format,
-                        page_size=qrope_output_page_size,
-                        tile=qrope_output_tile_descriptor,
-                    )
-                ]
+                sdpa_out_interm_running_offset += qrope_sin_interm_cb_descriptor.total_size  # +128 B
 
                 # CB 31: CreateQHeads intermediate buffer (row-major data before tilization)
                 # Senders write row-major data here via NOC, receiver marks pages, TRISC tilizes to output
@@ -1475,7 +1487,7 @@ class PreSDPA:
                 create_q_heads_interm_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(
                     create_q_heads_receiver_in_cb,
                     sdpa_out_interm_buffer_device,
-                    address_offset=16448,
+                    address_offset=sdpa_out_interm_running_offset,  # 28608 B
                     total_size=create_q_heads_interm_total_size,
                 )
                 create_q_heads_interm_cb_descriptor.format_descriptors = [
@@ -1486,6 +1498,7 @@ class PreSDPA:
                         tile=create_q_heads_interm_tile_descriptor,
                     )
                 ]
+                sdpa_out_interm_running_offset += create_q_heads_interm_cb_descriptor.total_size  # +9216 B
 
                 # CB 16: CreateQHeads output buffer (tilized data, backed by output tensor)
                 # Only allocated on receiver cores (SDPA Input grid) - senders no longer write here
@@ -1505,7 +1518,7 @@ class PreSDPA:
                 dkv_matmul_output_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(
                     dkv_matmul_output_cb,
                     sdpa_out_interm_buffer_device,
-                    address_offset=14272,
+                    address_offset=sdpa_out_interm_running_offset,  # 37824 B
                     total_size=dkv_matmul_output_page_size,
                 )
                 dkv_matmul_output_cb_descriptor.format_descriptors = [
@@ -1516,6 +1529,7 @@ class PreSDPA:
                         tile=dkv_matmul_output_tile_descriptor,
                     )
                 ]
+                sdpa_out_interm_running_offset += dkv_matmul_output_cb_descriptor.total_size  # +64 B
 
                 # CB 25: KV RMSNorm input buffer — overlap with sdpa_out_interm L1 buffer
                 # at offset 14336 B. This CB is consumed before SDPA runs.
@@ -1524,7 +1538,7 @@ class PreSDPA:
                 kv_rmsnorm_input_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(
                     kv_rmsnorm_input_cb,
                     sdpa_out_interm_buffer_device,
-                    address_offset=14336,
+                    address_offset=sdpa_out_interm_running_offset,  # 37888 B
                     total_size=1 * kv_rmsnorm_page_size,
                 )
                 kv_rmsnorm_input_cb_descriptor.format_descriptors = [
@@ -1535,6 +1549,7 @@ class PreSDPA:
                         tile=kv_rmsnorm_tile_descriptor,
                     )
                 ]
+                sdpa_out_interm_running_offset += kv_rmsnorm_input_cb_descriptor.total_size  # +1024 B
 
                 # CB: KV RMSNorm gamma buffer
                 kv_rmsnorm_gamma_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(
@@ -1548,7 +1563,7 @@ class PreSDPA:
                 kv_rmsnorm_output_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(
                     kv_rmsnorm_output_cb,
                     sdpa_out_interm_buffer_device,
-                    address_offset=15360,
+                    address_offset=sdpa_out_interm_running_offset,  # 38912 B
                     total_size=kv_rmsnorm_num_tiles * kv_rmsnorm_page_size,
                 )
                 kv_rmsnorm_output_cb_descriptor.format_descriptors = [
@@ -1559,6 +1574,7 @@ class PreSDPA:
                         tile=kv_rmsnorm_tile_descriptor,
                     )
                 ]
+                sdpa_out_interm_running_offset += kv_rmsnorm_output_cb_descriptor.total_size  # +1024 B
 
                 # CB: Cos (sharded tensor)
                 krope_cos_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(krope_cos_cb, krope_cos_tensor_device)
@@ -1571,7 +1587,7 @@ class PreSDPA:
                 krope_output_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(
                     krope_output_cb,
                     sdpa_out_interm_buffer_device,
-                    address_offset=16384,
+                    address_offset=sdpa_out_interm_running_offset,  # 39936 B
                     total_size=1 * krope_tile_size,
                 )
                 krope_output_cb_descriptor.format_descriptors = [
@@ -1582,6 +1598,8 @@ class PreSDPA:
                         tile=ttnn.TileDescriptor(TILE_1x32),
                     )
                 ]
+                sdpa_out_interm_running_offset += krope_output_cb_descriptor.total_size  # +64 B
+
                 dkv_rmsnorm_grid = dkv_rmsnorm_gamma_tensor_device.memory_config().shard_spec.grid
                 TILE_32x32 = ttnn.Tile((32, 32))
                 kv_cache_page_size = TILE_32x32.get_tile_size(ttnn.bfloat8_b)

--- a/models/demos/deepseek_v3_b1/fused_ops/pre_sdpa/op.py
+++ b/models/demos/deepseek_v3_b1/fused_ops/pre_sdpa/op.py
@@ -1185,8 +1185,6 @@ class PreSDPA:
 
                 # CB 7: RMSNorm2 input buffer (3 tiles) — overlap with sdpa_out_interm L1 buffer
                 # at offset 64 B. This CB is consumed before SDPA runs.
-                # Must be allocated on union of matmul cores and rmsnorm core for gather to get write_ptr.
-                # Tensor-backing on full device grid is a superset, so this is satisfied.
                 rmsnorm2_input_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(
                     rmsnorm2_input_cb,
                     sdpa_out_interm_tensor_device,

--- a/models/demos/deepseek_v3_b1/fused_ops/pre_sdpa/op.py
+++ b/models/demos/deepseek_v3_b1/fused_ops/pre_sdpa/op.py
@@ -162,9 +162,9 @@ class PreSDPA:
         kv_cache_tensor,
         position_id,
         output_tensor,
+        sdpa_kv_cache_buffer,
+        sdpa_out_interm_buffer,
         sender_coord,
-        kv_cache_tensor,
-        sdpa_out_interm_tensor,
         semaphores=None,
         cluster_axis=0,
         secondary_cluster_axis=1,
@@ -226,7 +226,8 @@ class PreSDPA:
         dkv_matmul_weights_tensors_per_device = ttnn.get_device_tensors(dkv_matmul_weights_tensor)
         dkv_rmsnorm_gamma_tensors_per_device = ttnn.get_device_tensors(dkv_rmsnorm_gamma_tensor)
         kv_cache_tensors_per_device = ttnn.get_device_tensors(kv_cache_tensor)
-        sdpa_out_interm_tensors_per_device = ttnn.get_device_tensors(sdpa_out_interm_tensor)
+        sdpa_out_interm_buffers_per_device = ttnn.get_device_tensors(sdpa_out_interm_buffer)
+        sdpa_kv_cache_buffers_per_device = ttnn.get_device_tensors(sdpa_kv_cache_buffer)
 
         # Semaphore addresses (only needed for CCL mode)
         out_ready_sem_addr = 0
@@ -1080,7 +1081,8 @@ class PreSDPA:
                 krope_cos_tensor_device = krope_cos_tensors_per_device[device_idx]
                 krope_sin_tensor_device = krope_sin_tensors_per_device[device_idx]
                 kv_cache_tensor_device = kv_cache_tensors_per_device[device_idx]
-                sdpa_out_interm_tensor_device = sdpa_out_interm_tensors_per_device[device_idx]
+                sdpa_kv_cache_buffer_device = sdpa_kv_cache_buffers_per_device[device_idx]
+                sdpa_out_interm_buffer_device = sdpa_out_interm_buffers_per_device[device_idx]
 
                 # Get worker core from per-device input tensor shard grid
                 device_local = input_tensor_device.device()
@@ -1187,7 +1189,7 @@ class PreSDPA:
                 # at offset 64 B. This CB is consumed before SDPA runs.
                 rmsnorm2_input_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(
                     rmsnorm2_input_cb,
-                    sdpa_out_interm_tensor_device,
+                    sdpa_out_interm_buffer_device,
                     address_offset=64,
                     total_size=rmsnorm2_num_tiles * rmsnorm2_page_size,
                 )
@@ -1211,7 +1213,7 @@ class PreSDPA:
 
                 rmsnorm2_output_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(
                     rmsnorm2_output_cb,
-                    sdpa_out_interm_tensor_device,
+                    sdpa_out_interm_buffer_device,
                     address_offset=6208,
                     total_size=rmsnorm2_num_tiles * rmsnorm2_page_size,
                 )
@@ -1232,7 +1234,7 @@ class PreSDPA:
                 # at offset 3136 B. This CB is consumed before SDPA runs.
                 gather_reduce_half1_scratch_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(
                     gather_reduce_half1_scratch_cb,
-                    sdpa_out_interm_tensor_device,
+                    sdpa_out_interm_buffer_device,
                     address_offset=3136,
                     total_size=rmsnorm2_num_tiles * rmsnorm2_page_size,
                 )
@@ -1249,7 +1251,7 @@ class PreSDPA:
                 # at offset 0 B. This CB is consumed before SDPA runs.
                 rmsnorm_output_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(
                     rmsnorm_output_cb,
-                    kv_cache_tensor_device,
+                    sdpa_kv_cache_buffer_device,
                     address_offset=0,
                     total_size=num_tiles * cb_page_size,
                 )
@@ -1277,7 +1279,7 @@ class PreSDPA:
                 # CB: Matmul input — overlap with kv_cache L1 buffer at offset 14336 B.
                 matmul_input_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(
                     matmul_input_cb,
-                    kv_cache_tensor_device,
+                    sdpa_kv_cache_buffer_device,
                     address_offset=14336,
                     total_size=matmul_input_total_size,
                 )
@@ -1296,7 +1298,7 @@ class PreSDPA:
                 matmul_output_page_size = TILE_1x32.get_tile_size(data_format)
                 matmul_output_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(
                     matmul_output_cb,
-                    sdpa_out_interm_tensor_device,
+                    sdpa_out_interm_buffer_device,
                     address_offset=0,
                     total_size=matmul_output_page_size,
                 )
@@ -1314,7 +1316,7 @@ class PreSDPA:
                 matmul2_input_total_size = matmul2_num_tiles_k * matmul_input_page_size  # 48 * 64 bytes
                 matmul2_input_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(
                     matmul2_input_cb,
-                    sdpa_out_interm_tensor_device,
+                    sdpa_out_interm_buffer_device,
                     address_offset=9280,
                     total_size=matmul2_input_total_size,
                 )
@@ -1337,7 +1339,7 @@ class PreSDPA:
                 matmul2_output_total_size = matmul2_out_w * matmul_output_page_size  # 4 * 64 = 256 bytes per core
                 matmul2_output_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(
                     matmul2_output_cb,
-                    sdpa_out_interm_tensor_device,
+                    sdpa_out_interm_buffer_device,
                     address_offset=12352,
                     total_size=matmul2_output_total_size,
                 )
@@ -1362,7 +1364,7 @@ class PreSDPA:
                 matmul3_output_total_size = matmul3_out_w * matmul3_output_page_size  # 16 tiles
                 matmul3_output_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(
                     matmul3_output_cb,
-                    sdpa_out_interm_tensor_device,
+                    sdpa_out_interm_buffer_device,
                     address_offset=12608,
                     total_size=matmul3_output_total_size,
                 )
@@ -1391,7 +1393,7 @@ class PreSDPA:
                 qrope_interm_tile_size = qrope_head_dim_per_core_t * TILE_1x32.get_tile_size(data_format)
                 qrope_rotated_input_interm_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(
                     qrope_rotated_input_interm_cb,
-                    sdpa_out_interm_tensor_device,
+                    sdpa_out_interm_buffer_device,
                     address_offset=13888,
                     total_size=qrope_interm_tile_size,
                 )
@@ -1408,7 +1410,7 @@ class PreSDPA:
                 # at offset 14016 B. This CB is consumed before SDPA runs.
                 qrope_cos_interm_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(
                     qrope_cos_interm_cb,
-                    sdpa_out_interm_tensor_device,
+                    sdpa_out_interm_buffer_device,
                     address_offset=14016,
                     total_size=qrope_interm_tile_size,
                 )
@@ -1425,7 +1427,7 @@ class PreSDPA:
                 # at offset 14144 B. This CB is consumed before SDPA runs.
                 qrope_sin_interm_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(
                     qrope_sin_interm_cb,
-                    sdpa_out_interm_tensor_device,
+                    sdpa_out_interm_buffer_device,
                     address_offset=14144,
                     total_size=qrope_interm_tile_size,
                 )
@@ -1445,7 +1447,7 @@ class PreSDPA:
                 qrope_output_total_size = matmul2_out_w * qrope_output_page_size  # 4 tiles
                 qrope_output_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(
                     qrope_output_cb,
-                    sdpa_out_interm_tensor_device,
+                    sdpa_out_interm_buffer_device,
                     address_offset=13632,
                     total_size=qrope_output_total_size,
                 )
@@ -1470,7 +1472,7 @@ class PreSDPA:
                 ) * create_q_heads_interm_page_size  # 18 pages (all phases: 8+8+2)
                 create_q_heads_interm_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(
                     create_q_heads_receiver_in_cb,
-                    sdpa_out_interm_tensor_device,
+                    sdpa_out_interm_buffer_device,
                     address_offset=16448,
                     total_size=create_q_heads_interm_total_size,
                 )
@@ -1500,7 +1502,7 @@ class PreSDPA:
                 dkv_matmul_output_page_size = TILE_1x32.get_tile_size(data_format)
                 dkv_matmul_output_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(
                     dkv_matmul_output_cb,
-                    sdpa_out_interm_tensor_device,
+                    sdpa_out_interm_buffer_device,
                     address_offset=14272,
                     total_size=dkv_matmul_output_page_size,
                 )
@@ -1519,7 +1521,7 @@ class PreSDPA:
                 kv_rmsnorm_page_size = TILE_16x32.get_tile_size(input_tensor_sample.dtype)
                 kv_rmsnorm_input_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(
                     kv_rmsnorm_input_cb,
-                    sdpa_out_interm_tensor_device,
+                    sdpa_out_interm_buffer_device,
                     address_offset=14336,
                     total_size=1 * kv_rmsnorm_page_size,
                 )
@@ -1543,7 +1545,7 @@ class PreSDPA:
                 # at offset 15360 B. This CB is consumed before SDPA runs.
                 kv_rmsnorm_output_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(
                     kv_rmsnorm_output_cb,
-                    sdpa_out_interm_tensor_device,
+                    sdpa_out_interm_buffer_device,
                     address_offset=15360,
                     total_size=kv_rmsnorm_num_tiles * kv_rmsnorm_page_size,
                 )
@@ -1566,7 +1568,7 @@ class PreSDPA:
                 krope_tile_size = TILE_1x32.get_tile_size(data_format)
                 krope_output_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(
                     krope_output_cb,
-                    sdpa_out_interm_tensor_device,
+                    sdpa_out_interm_buffer_device,
                     address_offset=16384,
                     total_size=1 * krope_tile_size,
                 )
@@ -1575,9 +1577,10 @@ class PreSDPA:
                         buffer_index=krope_output_cb,
                         data_format=data_format,
                         page_size=krope_tile_size,
-                        tile=tile_descriptor,
+                        tile=ttnn.TileDescriptor(TILE_1x32),
                     )
                 ]
+                dkv_rmsnorm_grid = dkv_rmsnorm_gamma_tensor_device.memory_config().shard_spec.grid
                 TILE_32x32 = ttnn.Tile((32, 32))
                 kv_cache_page_size = TILE_32x32.get_tile_size(ttnn.bfloat8_b)
                 kv_cache_update_grid = dkv_rmsnorm_grid.merge(krope_grid)
@@ -1959,7 +1962,8 @@ class PreSDPA:
                 dkv_matmul_weights_tensor,
                 dkv_rmsnorm_gamma_tensor,
                 kv_cache_tensor,
-                sdpa_out_interm_tensor,
+                sdpa_kv_cache_buffer,
+                sdpa_out_interm_buffer,
                 output_tensor,
             ],
             mesh_program_descriptor,

--- a/models/demos/deepseek_v3_b1/fused_ops/pre_sdpa/op.py
+++ b/models/demos/deepseek_v3_b1/fused_ops/pre_sdpa/op.py
@@ -163,6 +163,7 @@ class PreSDPA:
         position_id,
         output_tensor,
         sender_coord,
+        kv_cache_tensor,
         semaphores=None,
         cluster_axis=0,
         secondary_cluster_axis=1,
@@ -1225,18 +1226,22 @@ class PreSDPA:
                     format_descriptors=[gather_reduce_half1_scratch_cb_format],
                 )
 
-                # CB: RMSNorm output buffer (dynamically created)
-                rmsnorm_output_cb_format = ttnn.CBFormatDescriptor(
-                    buffer_index=rmsnorm_output_cb,
-                    data_format=data_format,
-                    page_size=cb_page_size,
-                    tile=tile_descriptor,
-                )
-                rmsnorm_output_cb_descriptor = ttnn.CBDescriptor(
+                # CB: RMSNorm output buffer — overlap with kv_cache L1 buffer
+                # at offset 14336 B. This CB is consumed before SDPA runs.
+                rmsnorm_output_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(
+                    rmsnorm_output_cb,
+                    kv_cache_tensor_device,
+                    address_offset=14336,
                     total_size=num_tiles * cb_page_size,
-                    core_ranges=rmsnorm_core_grid,
-                    format_descriptors=[rmsnorm_output_cb_format],
                 )
+                rmsnorm_output_cb_descriptor.format_descriptors = [
+                    ttnn.CBFormatDescriptor(
+                        buffer_index=rmsnorm_output_cb,
+                        data_format=data_format,
+                        page_size=cb_page_size,
+                        tile=tile_descriptor,
+                    )
+                ]
 
                 # CB: Matmul weights (created from sharded tensor)
                 matmul_weights_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(
@@ -1255,19 +1260,22 @@ class PreSDPA:
                 # Note: TILE_1x32, matmul_input_page_size, and matmul_input_total_size
                 # were already calculated above for mcast page count calculation
                 matmul_input_tile_descriptor = ttnn.TileDescriptor(TILE_1x32)
-                matmul_input_cb_format = ttnn.CBFormatDescriptor(
-                    buffer_index=matmul_input_cb,
-                    data_format=data_format,
-                    page_size=matmul_input_page_size,
-                    tile=matmul_input_tile_descriptor,
-                )
-                matmul_input_cb_core_ranges = matmul_weights_core_grid.merge(rmsnorm_core_grid)
-                matmul_input_cb_core_ranges = matmul_input_cb_core_ranges.merge(dkv_matmul_weights_core_grid)
-                matmul_input_cb_descriptor = ttnn.CBDescriptor(
+                # CB: Matmul input — overlap with kv_cache L1 buffer
+                # at offset 28672 B. This CB is consumed before SDPA runs.
+                matmul_input_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(
+                    matmul_input_cb,
+                    kv_cache_tensor_device,
+                    address_offset=28672,
                     total_size=matmul_input_total_size,
-                    core_ranges=matmul_input_cb_core_ranges,
-                    format_descriptors=[matmul_input_cb_format],
                 )
+                matmul_input_cb_descriptor.format_descriptors = [
+                    ttnn.CBFormatDescriptor(
+                        buffer_index=matmul_input_cb,
+                        data_format=data_format,
+                        page_size=matmul_input_page_size,
+                        tile=matmul_input_tile_descriptor,
+                    )
+                ]
 
                 # CB: Matmul output buffer (single tile, on matmul cores only)
                 matmul_output_tile_descriptor = ttnn.TileDescriptor(TILE_1x32)

--- a/models/demos/deepseek_v3_b1/fused_ops/pre_sdpa/op.py
+++ b/models/demos/deepseek_v3_b1/fused_ops/pre_sdpa/op.py
@@ -164,6 +164,7 @@ class PreSDPA:
         output_tensor,
         sender_coord,
         kv_cache_tensor,
+        sdpa_out_interm_tensor,
         semaphores=None,
         cluster_axis=0,
         secondary_cluster_axis=1,
@@ -225,6 +226,7 @@ class PreSDPA:
         dkv_matmul_weights_tensors_per_device = ttnn.get_device_tensors(dkv_matmul_weights_tensor)
         dkv_rmsnorm_gamma_tensors_per_device = ttnn.get_device_tensors(dkv_rmsnorm_gamma_tensor)
         kv_cache_tensors_per_device = ttnn.get_device_tensors(kv_cache_tensor)
+        sdpa_out_interm_tensors_per_device = ttnn.get_device_tensors(sdpa_out_interm_tensor)
 
         # Semaphore addresses (only needed for CCL mode)
         out_ready_sem_addr = 0
@@ -1078,6 +1080,7 @@ class PreSDPA:
                 krope_cos_tensor_device = krope_cos_tensors_per_device[device_idx]
                 krope_sin_tensor_device = krope_sin_tensors_per_device[device_idx]
                 kv_cache_tensor_device = kv_cache_tensors_per_device[device_idx]
+                sdpa_out_interm_tensor_device = sdpa_out_interm_tensors_per_device[device_idx]
 
                 # Get worker core from per-device input tensor shard grid
                 device_local = input_tensor_device.device()
@@ -1180,20 +1183,24 @@ class PreSDPA:
                 rmsnorm2_gamma_cb_descriptor.format_descriptors[0].tile = rmsnorm2_tile_descriptor
                 rmsnorm2_gamma_cb_descriptor.format_descriptors[0].page_size = rmsnorm2_page_size
 
-                # CB: RMSNorm2 input buffer (3 tiles)
-                rmsnorm2_input_cb_format = ttnn.CBFormatDescriptor(
-                    buffer_index=rmsnorm2_input_cb,
-                    data_format=data_format,
-                    page_size=rmsnorm2_page_size,
-                    tile=rmsnorm2_tile_descriptor,
+                # CB 7: RMSNorm2 input buffer (3 tiles) — overlap with sdpa_out_interm L1 buffer
+                # at offset 64 B. This CB is consumed before SDPA runs.
+                # Must be allocated on union of matmul cores and rmsnorm core for gather to get write_ptr.
+                # Tensor-backing on full device grid is a superset, so this is satisfied.
+                rmsnorm2_input_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(
+                    rmsnorm2_input_cb,
+                    sdpa_out_interm_tensor_device,
+                    address_offset=64,
+                    total_size=rmsnorm2_num_tiles * rmsnorm2_page_size,
                 )
-                # Must be allocated on union of matmul cores and rmsnorm core for gather to get write_ptr
-                rmsnorm2_input_cb_core_ranges = matmul_weights_core_grid.merge(rmsnorm_core_grid)
-                rmsnorm2_input_cb_descriptor = ttnn.CBDescriptor(
-                    total_size=rmsnorm2_num_tiles * rmsnorm2_page_size,  # 3 tiles
-                    core_ranges=rmsnorm2_input_cb_core_ranges,
-                    format_descriptors=[rmsnorm2_input_cb_format],
-                )
+                rmsnorm2_input_cb_descriptor.format_descriptors = [
+                    ttnn.CBFormatDescriptor(
+                        buffer_index=rmsnorm2_input_cb,
+                        data_format=data_format,
+                        page_size=rmsnorm2_page_size,
+                        tile=rmsnorm2_tile_descriptor,
+                    )
+                ]
 
                 # CB: RMSNorm2 output buffer (3 tiles)
                 rmsnorm2_output_cb_format = ttnn.CBFormatDescriptor(
@@ -1203,35 +1210,49 @@ class PreSDPA:
                     tile=rmsnorm2_tile_descriptor,
                 )
                 rmsnorm2_output_cb_core_ranges = rmsnorm_core_grid
-                rmsnorm2_output_cb_descriptor = ttnn.CBDescriptor(
-                    total_size=rmsnorm2_num_tiles * rmsnorm2_page_size,  # 3 tiles
-                    core_ranges=rmsnorm2_output_cb_core_ranges,
-                    format_descriptors=[rmsnorm2_output_cb_format],
-                )
-                # CB8 lifecycle:
-                # 1) RMSNorm2 writes normalized output here
-                # 2) Mcast2 reads from CB8 and writes to matmul2 input CB
 
-                # CB: gather_reduce half1 scratch buffer (3 tiles)
-                gather_reduce_half1_scratch_cb_format = ttnn.CBFormatDescriptor(
-                    buffer_index=gather_reduce_half1_scratch_cb,
-                    data_format=data_format,
-                    page_size=rmsnorm2_page_size,
-                    tile=rmsnorm2_tile_descriptor,
+                rmsnorm2_output_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(
+                    rmsnorm2_output_cb,
+                    sdpa_out_interm_tensor_device,
+                    address_offset=6208,
+                    total_size=rmsnorm2_num_tiles * rmsnorm2_page_size,
                 )
-                gather_reduce_half1_scratch_core_ranges = matmul_weights_core_grid.merge(rmsnorm_core_grid)
-                gather_reduce_half1_scratch_cb_descriptor = ttnn.CBDescriptor(
-                    total_size=rmsnorm2_num_tiles * rmsnorm2_page_size,  # 3 tiles
-                    core_ranges=gather_reduce_half1_scratch_core_ranges,
-                    format_descriptors=[gather_reduce_half1_scratch_cb_format],
+                rmsnorm2_output_cb_descriptor.format_descriptors = [
+                    ttnn.CBFormatDescriptor(
+                        buffer_index=rmsnorm2_output_cb,
+                        data_format=data_format,
+                        page_size=rmsnorm2_page_size,
+                        tile=rmsnorm2_tile_descriptor,
+                    )
+                ]
+
+                # CB9 lifecycle:
+                # 1) RMSNorm2 writes normalized output here
+                # 2) Mcast2 reads from CB9 and writes to matmul2 input CB
+
+                # CB 8: gather_reduce half1 scratch buffer (3 tiles) — overlap with sdpa_out_interm L1 buffer
+                # at offset 3136 B. This CB is consumed before SDPA runs.
+                gather_reduce_half1_scratch_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(
+                    gather_reduce_half1_scratch_cb,
+                    sdpa_out_interm_tensor_device,
+                    address_offset=3136,
+                    total_size=rmsnorm2_num_tiles * rmsnorm2_page_size,
                 )
+                gather_reduce_half1_scratch_cb_descriptor.format_descriptors = [
+                    ttnn.CBFormatDescriptor(
+                        buffer_index=gather_reduce_half1_scratch_cb,
+                        data_format=data_format,
+                        page_size=rmsnorm2_page_size,
+                        tile=rmsnorm2_tile_descriptor,
+                    )
+                ]
 
                 # CB: RMSNorm output buffer — overlap with kv_cache L1 buffer
-                # at offset 14336 B. This CB is consumed before SDPA runs.
+                # at offset 0 B. This CB is consumed before SDPA runs.
                 rmsnorm_output_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(
                     rmsnorm_output_cb,
                     kv_cache_tensor_device,
-                    address_offset=14336,
+                    address_offset=0,
                     total_size=num_tiles * cb_page_size,
                 )
                 rmsnorm_output_cb_descriptor.format_descriptors = [
@@ -1250,22 +1271,16 @@ class PreSDPA:
 
                 # CB: Matmul input buffer (1x32 tiles, receives mcast data)
                 # Senders will query the write pointer of this CB to get the receiver address.
-                # Constraints on CB creation:
-                # - Must be allocated and visible on the union of sender and receiver grids,
-                #   even though the sender never uses the space allocated for this CB
-                # - Must be single-buffered so senders can use get_write_ptr to get receiver address
-                # - Dynamically allocated CB is better because less inputs to OP and technically
-                #   uses minimal grid (ie. we can still use the same CB id for cores not in the
-                #   union of sender and receiver grid)
+                # Tensor-backed on full device grid (superset of sender/receiver grids) so senders
+                # can use get_write_ptr to get receiver address. This CB is consumed before SDPA runs.
                 # Note: TILE_1x32, matmul_input_page_size, and matmul_input_total_size
                 # were already calculated above for mcast page count calculation
                 matmul_input_tile_descriptor = ttnn.TileDescriptor(TILE_1x32)
-                # CB: Matmul input — overlap with kv_cache L1 buffer
-                # at offset 28672 B. This CB is consumed before SDPA runs.
+                # CB: Matmul input — overlap with kv_cache L1 buffer at offset 14336 B.
                 matmul_input_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(
                     matmul_input_cb,
                     kv_cache_tensor_device,
-                    address_offset=28672,
+                    address_offset=14336,
                     total_size=matmul_input_total_size,
                 )
                 matmul_input_cb_descriptor.format_descriptors = [
@@ -1277,80 +1292,90 @@ class PreSDPA:
                     )
                 ]
 
-                # CB: Matmul output buffer (single tile, on matmul cores only)
+                # CB: Matmul output buffer (single tile) — overlap with sdpa_out_interm L1 buffer
+                # at offset 0 B. This CB is consumed before SDPA runs.
                 matmul_output_tile_descriptor = ttnn.TileDescriptor(TILE_1x32)
                 matmul_output_page_size = TILE_1x32.get_tile_size(data_format)
-                matmul_output_cb_format = ttnn.CBFormatDescriptor(
-                    buffer_index=matmul_output_cb,
-                    data_format=data_format,
-                    page_size=matmul_output_page_size,
-                    tile=matmul_output_tile_descriptor,
+                matmul_output_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(
+                    matmul_output_cb,
+                    sdpa_out_interm_tensor_device,
+                    address_offset=0,
+                    total_size=matmul_output_page_size,
                 )
-                matmul_output_cb_descriptor = ttnn.CBDescriptor(
-                    total_size=matmul_output_page_size,  # Single tile
-                    core_ranges=matmul_weights_core_grid,
-                    format_descriptors=[matmul_output_cb_format],
-                )
+                matmul_output_cb_descriptor.format_descriptors = [
+                    ttnn.CBFormatDescriptor(
+                        buffer_index=matmul_output_cb,
+                        data_format=data_format,
+                        page_size=matmul_output_page_size,
+                        tile=matmul_output_tile_descriptor,
+                    )
+                ]
 
-                # CB: Matmul2 input buffer (1x1536 with 1x32 tiles = 48 tiles)
-                # Must be allocated on union of sender (rmsnorm input grid) and receiver (matmul2 grid)
-                # Similar constraint as gather CB - senders query write_ptr to get receiver address
+                # CB: Matmul2 input buffer (1x1536 with 1x32 tiles = 48 tiles) — overlap with
+                # sdpa_out_interm L1 buffer at offset 9280 B. This CB is consumed before SDPA runs.
                 matmul2_input_total_size = matmul2_num_tiles_k * matmul_input_page_size  # 48 * 64 bytes
-                matmul2_input_cb_format = ttnn.CBFormatDescriptor(
-                    buffer_index=matmul2_input_cb,
-                    data_format=data_format,
-                    page_size=matmul_input_page_size,
-                    tile=matmul_input_tile_descriptor,
-                )
-                matmul2_input_cb_core_ranges = ttnn.CoreRangeSet([main_grid]).merge(rmsnorm_core_grid)
-                matmul2_input_cb_descriptor = ttnn.CBDescriptor(
+                matmul2_input_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(
+                    matmul2_input_cb,
+                    sdpa_out_interm_tensor_device,
+                    address_offset=9280,
                     total_size=matmul2_input_total_size,
-                    core_ranges=matmul2_input_cb_core_ranges,
-                    format_descriptors=[matmul2_input_cb_format],
                 )
+                matmul2_input_cb_descriptor.format_descriptors = [
+                    ttnn.CBFormatDescriptor(
+                        buffer_index=matmul2_input_cb,
+                        data_format=data_format,
+                        page_size=matmul_input_page_size,
+                        tile=matmul_input_tile_descriptor,
+                    )
+                ]
 
                 # CB: Matmul2 weights (created from sharded tensor, 4 tiles per core)
                 matmul2_weights_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(
                     matmul2_weights_cb, matmul2_weights_tensor_device
                 )
 
-                # CB 12: Matmul2 output buffer (dynamically allocated)
-                # On Qnope cores: intermediate buffer for matmul3 input (4 tiles of 1x32 = 128 elements per core/head)
-                # On Qrope cores: intermediate output for QRoPE (4 tiles of 1x32 = 128 elements per core, 2 tiles per head)
+                # CB 12: Matmul2 output buffer — overlap with sdpa_out_interm L1 buffer
+                # at offset 12352 B. This CB is consumed before SDPA runs.
                 matmul2_output_total_size = matmul2_out_w * matmul_output_page_size  # 4 * 64 = 256 bytes per core
-                matmul2_output_cb_format = ttnn.CBFormatDescriptor(
-                    buffer_index=matmul2_output_cb,
-                    data_format=data_format,
-                    page_size=matmul_output_page_size,
-                    tile=matmul_output_tile_descriptor,
-                )
-                matmul2_output_cb_descriptor = ttnn.CBDescriptor(
+                matmul2_output_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(
+                    matmul2_output_cb,
+                    sdpa_out_interm_tensor_device,
+                    address_offset=12352,
                     total_size=matmul2_output_total_size,
-                    core_ranges=matmul2_weights_core_grid,
-                    format_descriptors=[matmul2_output_cb_format],
                 )
+                matmul2_output_cb_descriptor.format_descriptors = [
+                    ttnn.CBFormatDescriptor(
+                        buffer_index=matmul2_output_cb,
+                        data_format=data_format,
+                        page_size=matmul_output_page_size,
+                        tile=matmul_output_tile_descriptor,
+                    )
+                ]
 
                 # CB 13: Matmul3 weights (created from sharded tensor on Qnope grid)
                 matmul3_weights_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(
                     matmul3_weights_cb, matmul3_weights_tensor_device
                 )
 
-                # CB 14: Matmul3 output buffer (Qnope final output, intermediate CB on Qnope grid)
-                # Each Qnope core outputs [1, 512] = 16 tiles of 1x32
+                # CB 14: Matmul3 output buffer — overlap with sdpa_out_interm L1 buffer
+                # at offset 12608 B. This CB is consumed before SDPA runs.
                 matmul3_output_tile_descriptor = ttnn.TileDescriptor(TILE_1x32)
                 matmul3_output_page_size = TILE_1x32.get_tile_size(data_format)
                 matmul3_output_total_size = matmul3_out_w * matmul3_output_page_size  # 16 tiles
-                matmul3_output_cb_format = ttnn.CBFormatDescriptor(
-                    buffer_index=matmul3_output_cb,
-                    data_format=data_format,
-                    page_size=matmul3_output_page_size,
-                    tile=matmul3_output_tile_descriptor,
-                )
-                matmul3_output_cb_descriptor = ttnn.CBDescriptor(
+                matmul3_output_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(
+                    matmul3_output_cb,
+                    sdpa_out_interm_tensor_device,
+                    address_offset=12608,
                     total_size=matmul3_output_total_size,
-                    core_ranges=qnope_grid,
-                    format_descriptors=[matmul3_output_cb_format],
                 )
+                matmul3_output_cb_descriptor.format_descriptors = [
+                    ttnn.CBFormatDescriptor(
+                        buffer_index=matmul3_output_cb,
+                        data_format=data_format,
+                        page_size=matmul3_output_page_size,
+                        tile=matmul3_output_tile_descriptor,
+                    )
+                ]
 
                 # CB 17: Cos (sharded tensor)
                 qrope_cos_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(qrope_cos_cb, qrope_cos_tensor_device)
@@ -1363,64 +1388,77 @@ class PreSDPA:
                     qrope_trans_mat_cb, trans_mat_tensor_device
                 )
 
-                # CB 20: Rotated input intermediate CB
-                # Sized for one head (Wt tiles = 2 tiles), since RoPE processes one head at a time
+                # CB 20: Rotated input intermediate CB — overlap with sdpa_out_interm L1 buffer
+                # at offset 13888 B. This CB is consumed before SDPA runs.
                 qrope_interm_tile_size = qrope_head_dim_per_core_t * TILE_1x32.get_tile_size(data_format)
-                qrope_rotated_input_interm_cb_format = ttnn.CBFormatDescriptor(
-                    buffer_index=qrope_rotated_input_interm_cb,
-                    data_format=data_format,
-                    page_size=TILE_1x32.get_tile_size(data_format),
-                    tile=ttnn.TileDescriptor(TILE_1x32),
+                qrope_rotated_input_interm_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(
+                    qrope_rotated_input_interm_cb,
+                    sdpa_out_interm_tensor_device,
+                    address_offset=13888,
+                    total_size=qrope_interm_tile_size,
                 )
-                qrope_rotated_input_interm_cb_descriptor = ttnn.CBDescriptor(
-                    total_size=qrope_interm_tile_size,  # Wt tiles = 2 tiles
-                    core_ranges=qkv_grid,
-                    format_descriptors=[qrope_rotated_input_interm_cb_format],
-                )
+                qrope_rotated_input_interm_cb_descriptor.format_descriptors = [
+                    ttnn.CBFormatDescriptor(
+                        buffer_index=qrope_rotated_input_interm_cb,
+                        data_format=data_format,
+                        page_size=TILE_1x32.get_tile_size(data_format),
+                        tile=ttnn.TileDescriptor(TILE_1x32),
+                    )
+                ]
 
-                # CB 21: Cos intermediate CB
-                qrope_cos_interm_cb_format = ttnn.CBFormatDescriptor(
-                    buffer_index=qrope_cos_interm_cb,
-                    data_format=data_format,
-                    page_size=TILE_1x32.get_tile_size(data_format),
-                    tile=ttnn.TileDescriptor(TILE_1x32),
+                # CB 21: Cos intermediate CB — overlap with sdpa_out_interm L1 buffer
+                # at offset 14016 B. This CB is consumed before SDPA runs.
+                qrope_cos_interm_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(
+                    qrope_cos_interm_cb,
+                    sdpa_out_interm_tensor_device,
+                    address_offset=14016,
+                    total_size=qrope_interm_tile_size,
                 )
-                qrope_cos_interm_cb_descriptor = ttnn.CBDescriptor(
-                    total_size=qrope_interm_tile_size,  # Wt tiles = 2 tiles
-                    core_ranges=qkv_grid,
-                    format_descriptors=[qrope_cos_interm_cb_format],
-                )
+                qrope_cos_interm_cb_descriptor.format_descriptors = [
+                    ttnn.CBFormatDescriptor(
+                        buffer_index=qrope_cos_interm_cb,
+                        data_format=data_format,
+                        page_size=TILE_1x32.get_tile_size(data_format),
+                        tile=ttnn.TileDescriptor(TILE_1x32),
+                    )
+                ]
 
-                # CB 22: Sin intermediate CB
-                qrope_sin_interm_cb_format = ttnn.CBFormatDescriptor(
-                    buffer_index=qrope_sin_interm_cb,
-                    data_format=data_format,
-                    page_size=TILE_1x32.get_tile_size(data_format),
-                    tile=ttnn.TileDescriptor(TILE_1x32),
+                # CB 22: Sin intermediate CB — overlap with sdpa_out_interm L1 buffer
+                # at offset 14144 B. This CB is consumed before SDPA runs.
+                qrope_sin_interm_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(
+                    qrope_sin_interm_cb,
+                    sdpa_out_interm_tensor_device,
+                    address_offset=14144,
+                    total_size=qrope_interm_tile_size,
                 )
-                qrope_sin_interm_cb_descriptor = ttnn.CBDescriptor(
-                    total_size=qrope_interm_tile_size,  # Wt tiles = 2 tiles
-                    core_ranges=qkv_grid,
-                    format_descriptors=[qrope_sin_interm_cb_format],
-                )
+                qrope_sin_interm_cb_descriptor.format_descriptors = [
+                    ttnn.CBFormatDescriptor(
+                        buffer_index=qrope_sin_interm_cb,
+                        data_format=data_format,
+                        page_size=TILE_1x32.get_tile_size(data_format),
+                        tile=ttnn.TileDescriptor(TILE_1x32),
+                    )
+                ]
 
-                # CB 15: Qrope output buffer (RoPE output on Qrope grid)
-                # Each Qrope core outputs [1, 128] = 4 tiles of 1x32 (2 heads × 64 elements)
-                # RoPE reads from matmul2_output_cb and writes to this CB
+                # CB 15: Qrope output buffer — overlap with sdpa_out_interm L1 buffer
+                # at offset 13632 B. This CB is consumed before SDPA runs.
                 qrope_output_tile_descriptor = ttnn.TileDescriptor(TILE_1x32)
                 qrope_output_page_size = TILE_1x32.get_tile_size(data_format)
                 qrope_output_total_size = matmul2_out_w * qrope_output_page_size  # 4 tiles
-                qrope_output_cb_format = ttnn.CBFormatDescriptor(
-                    buffer_index=qrope_output_cb,
-                    data_format=data_format,
-                    page_size=qrope_output_page_size,
-                    tile=qrope_output_tile_descriptor,
-                )
-                qrope_output_cb_descriptor = ttnn.CBDescriptor(
+                qrope_output_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(
+                    qrope_output_cb,
+                    sdpa_out_interm_tensor_device,
+                    address_offset=13632,
                     total_size=qrope_output_total_size,
-                    core_ranges=qrope_grid,
-                    format_descriptors=[qrope_output_cb_format],
                 )
+                qrope_output_cb_descriptor.format_descriptors = [
+                    ttnn.CBFormatDescriptor(
+                        buffer_index=qrope_output_cb,
+                        data_format=data_format,
+                        page_size=qrope_output_page_size,
+                        tile=qrope_output_tile_descriptor,
+                    )
+                ]
 
                 # CB 31: CreateQHeads intermediate buffer (row-major data before tilization)
                 # Senders write row-major data here via NOC, receiver marks pages, TRISC tilizes to output
@@ -1429,19 +1467,23 @@ class PreSDPA:
                 TILE_8x32 = ttnn.Tile((8, 32))
                 create_q_heads_interm_tile_descriptor = ttnn.TileDescriptor(TILE_8x32)
                 create_q_heads_interm_page_size = TILE_8x32.get_tile_size(data_format)  # 8*32*2 = 512 bytes
-                create_q_heads_interm_cb_core_ranges = qnope_grid.merge(qrope_grid).merge(sdpa_input_grid)
-                create_q_heads_interm_cb_format = ttnn.CBFormatDescriptor(
-                    buffer_index=create_q_heads_receiver_in_cb,
-                    data_format=data_format,
-                    page_size=create_q_heads_interm_page_size,
-                    tile=create_q_heads_interm_tile_descriptor,
+                create_q_heads_interm_total_size = (
+                    2 * nope_tiles + rope_tiles
+                ) * create_q_heads_interm_page_size  # 18 pages (all phases: 8+8+2)
+                create_q_heads_interm_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(
+                    create_q_heads_receiver_in_cb,
+                    sdpa_out_interm_tensor_device,
+                    address_offset=16448,
+                    total_size=create_q_heads_interm_total_size,
                 )
-                create_q_heads_interm_cb_descriptor = ttnn.CBDescriptor(
-                    total_size=(2 * nope_tiles + rope_tiles)
-                    * create_q_heads_interm_page_size,  # 18 pages (all phases: 8+8+2)
-                    core_ranges=create_q_heads_interm_cb_core_ranges,
-                    format_descriptors=[create_q_heads_interm_cb_format],
-                )
+                create_q_heads_interm_cb_descriptor.format_descriptors = [
+                    ttnn.CBFormatDescriptor(
+                        buffer_index=create_q_heads_receiver_in_cb,
+                        data_format=data_format,
+                        page_size=create_q_heads_interm_page_size,
+                        tile=create_q_heads_interm_tile_descriptor,
+                    )
+                ]
 
                 # CB 16: CreateQHeads output buffer (tilized data, backed by output tensor)
                 # Only allocated on receiver cores (SDPA Input grid) - senders no longer write here
@@ -1454,34 +1496,43 @@ class PreSDPA:
                     dkv_matmul_weights_cb, dkv_matmul_weights_tensor_device
                 )
 
+                # CB 24: DKV Matmul output — overlap with sdpa_out_interm L1 buffer
+                # at offset 14272 B. This CB is consumed before SDPA runs.
                 dkv_matmul_output_tile_descriptor = ttnn.TileDescriptor(TILE_1x32)
                 dkv_matmul_output_page_size = TILE_1x32.get_tile_size(data_format)
-                dkv_matmul_output_cb_format = ttnn.CBFormatDescriptor(
-                    buffer_index=dkv_matmul_output_cb,
-                    data_format=data_format,
-                    page_size=dkv_matmul_output_page_size,
-                    tile=dkv_matmul_output_tile_descriptor,
-                )
-                dkv_matmul_output_cb_descriptor = ttnn.CBDescriptor(
+                dkv_matmul_output_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(
+                    dkv_matmul_output_cb,
+                    sdpa_out_interm_tensor_device,
+                    address_offset=14272,
                     total_size=dkv_matmul_output_page_size,
-                    core_ranges=dkv_matmul_weights_core_grid,
-                    format_descriptors=[dkv_matmul_output_cb_format],
                 )
+                dkv_matmul_output_cb_descriptor.format_descriptors = [
+                    ttnn.CBFormatDescriptor(
+                        buffer_index=dkv_matmul_output_cb,
+                        data_format=data_format,
+                        page_size=dkv_matmul_output_page_size,
+                        tile=dkv_matmul_output_tile_descriptor,
+                    )
+                ]
 
-                # CB: KV RMSNorm input buffer (on rmsnorm core, receives gathered data)
+                # CB 25: KV RMSNorm input buffer — overlap with sdpa_out_interm L1 buffer
+                # at offset 14336 B. This CB is consumed before SDPA runs.
                 kv_rmsnorm_tile_descriptor = ttnn.TileDescriptor(TILE_16x32)
                 kv_rmsnorm_page_size = TILE_16x32.get_tile_size(input_tensor_sample.dtype)
-                kv_rmsnorm_input_cb_format = ttnn.CBFormatDescriptor(
-                    buffer_index=kv_rmsnorm_input_cb,
-                    data_format=data_format,
-                    page_size=kv_rmsnorm_page_size,
-                    tile=kv_rmsnorm_tile_descriptor,
-                )
-                kv_rmsnorm_input_cb_descriptor = ttnn.CBDescriptor(
+                kv_rmsnorm_input_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(
+                    kv_rmsnorm_input_cb,
+                    sdpa_out_interm_tensor_device,
+                    address_offset=14336,
                     total_size=1 * kv_rmsnorm_page_size,
-                    core_ranges=dkv_gather_sender_grid,
-                    format_descriptors=[kv_rmsnorm_input_cb_format],
                 )
+                kv_rmsnorm_input_cb_descriptor.format_descriptors = [
+                    ttnn.CBFormatDescriptor(
+                        buffer_index=kv_rmsnorm_input_cb,
+                        data_format=data_format,
+                        page_size=kv_rmsnorm_page_size,
+                        tile=kv_rmsnorm_tile_descriptor,
+                    )
+                ]
 
                 # CB: KV RMSNorm gamma buffer
                 kv_rmsnorm_gamma_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(
@@ -1490,37 +1541,45 @@ class PreSDPA:
                 kv_rmsnorm_gamma_cb_descriptor.format_descriptors[0].tile = kv_rmsnorm_tile_descriptor
                 kv_rmsnorm_gamma_cb_descriptor.format_descriptors[0].page_size = kv_rmsnorm_page_size
 
-                # CB: KV RMSNorm output buffer
-                dkv_rmsnorm_grid = dkv_rmsnorm_gamma_tensor_device.memory_config().shard_spec.grid
-                kv_rmsnorm_output_cb_format = ttnn.CBFormatDescriptor(
-                    buffer_index=kv_rmsnorm_output_cb,
-                    data_format=data_format,
-                    page_size=kv_rmsnorm_page_size,
-                    tile=kv_rmsnorm_tile_descriptor,
-                )
-                kv_rmsnorm_output_cb_descriptor = ttnn.CBDescriptor(
+                # CB 27: KV RMSNorm output buffer — overlap with sdpa_out_interm L1 buffer
+                # at offset 15360 B. This CB is consumed before SDPA runs.
+                kv_rmsnorm_output_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(
+                    kv_rmsnorm_output_cb,
+                    sdpa_out_interm_tensor_device,
+                    address_offset=15360,
                     total_size=kv_rmsnorm_num_tiles * kv_rmsnorm_page_size,
-                    core_ranges=dkv_rmsnorm_grid,
-                    format_descriptors=[kv_rmsnorm_output_cb_format],
                 )
+                kv_rmsnorm_output_cb_descriptor.format_descriptors = [
+                    ttnn.CBFormatDescriptor(
+                        buffer_index=kv_rmsnorm_output_cb,
+                        data_format=data_format,
+                        page_size=kv_rmsnorm_page_size,
+                        tile=kv_rmsnorm_tile_descriptor,
+                    )
+                ]
 
                 # CB: Cos (sharded tensor)
                 krope_cos_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(krope_cos_cb, krope_cos_tensor_device)
                 # CB: Sin (sharded tensor)
                 krope_sin_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(krope_sin_cb, krope_sin_tensor_device)
 
+                # CB 28: KRoPE output — overlap with sdpa_out_interm L1 buffer
+                # at offset 16384 B. This CB is consumed before SDPA runs.
                 krope_tile_size = TILE_1x32.get_tile_size(data_format)
-                krope_output_cb_format = ttnn.CBFormatDescriptor(
-                    buffer_index=krope_output_cb,
-                    data_format=data_format,
-                    page_size=krope_tile_size,
-                    tile=ttnn.TileDescriptor(TILE_1x32),
-                )
-                krope_output_cb_descriptor = ttnn.CBDescriptor(
+                krope_output_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(
+                    krope_output_cb,
+                    sdpa_out_interm_tensor_device,
+                    address_offset=16384,
                     total_size=1 * krope_tile_size,
-                    core_ranges=krope_grid,
-                    format_descriptors=[krope_output_cb_format],
                 )
+                krope_output_cb_descriptor.format_descriptors = [
+                    ttnn.CBFormatDescriptor(
+                        buffer_index=krope_output_cb,
+                        data_format=data_format,
+                        page_size=krope_tile_size,
+                        tile=tile_descriptor,
+                    )
+                ]
                 TILE_32x32 = ttnn.Tile((32, 32))
                 kv_cache_page_size = TILE_32x32.get_tile_size(ttnn.bfloat8_b)
                 kv_cache_update_grid = dkv_rmsnorm_grid.merge(krope_grid)
@@ -1902,6 +1961,7 @@ class PreSDPA:
                 dkv_matmul_weights_tensor,
                 dkv_rmsnorm_gamma_tensor,
                 kv_cache_tensor,
+                sdpa_out_interm_tensor,
                 output_tensor,
             ],
             mesh_program_descriptor,

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_pre_sdpa.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_pre_sdpa.py
@@ -115,6 +115,42 @@ def test_pre_sdpa(
     matmul2_grid_x = min(TOTAL_COLS, device_grid_size.x)  # Must be exactly 12 for correct sharding
     matmul2_grid_y = 8
 
+    # SDPA KV Cache tensor declared here to overlap with pre-SDPA CBs.
+    # Matches flash_mla's double-buffered KV CB sizing: shard = (2 * k_chunk_size, kvpe_dim)
+    # = (256, 576) per core, giving 156,672 bytes/core — same as flash_mla's cb_k_in.
+    # Total height = shard_height * num_cores must be divisible by tile height (32).
+    kvpe_dim = KNOPE_DIM + KROPE_DIM  # 576
+    kv_cache_num_cores_x = device_grid_size.x
+    kv_cache_num_cores_y = device_grid_size.y
+    kv_cache_num_cores = kv_cache_num_cores_x * kv_cache_num_cores_y
+    kv_cache_shard_height = 256  # 2 * k_chunk_size (128), matching flash_mla double-buffer
+    kv_cache_total_height = kv_cache_shard_height * kv_cache_num_cores
+
+    kv_cache_shard_spec = ttnn.ShardSpec(
+        ttnn.CoreRangeSet(
+            {
+                ttnn.CoreRange(
+                    ttnn.CoreCoord(0, 0),
+                    ttnn.CoreCoord(kv_cache_num_cores_x - 1, kv_cache_num_cores_y - 1),
+                )
+            }
+        ),
+        (kv_cache_shard_height, kvpe_dim),
+        ttnn.ShardOrientation.ROW_MAJOR,
+    )
+    kv_cache_tensor = ttnn.from_torch(
+        torch.randn((1, 1, kv_cache_total_height, kvpe_dim), dtype=torch.bfloat16),
+        dtype=ttnn.bfloat8_b,
+        layout=ttnn.TILE_LAYOUT,
+        device=submesh,
+        memory_config=ttnn.MemoryConfig(
+            ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+            ttnn.BufferType.L1,
+            kv_cache_shard_spec,
+        ),
+        mesh_mapper=ttnn.ReplicateTensorToMesh(submesh),
+    )
+
     # Matmul2 output width (interleaved Qnope/Qrope)
     matmul2_width = NUM_QNOPE_HEADS * QNOPE_HEAD_DIM + NUM_QROPE_HEADS * QROPE_HEAD_DIM  # 8192 + 4096 = 12288
     matmul2_weights_shape = (1536, matmul2_width)
@@ -635,6 +671,7 @@ def test_pre_sdpa(
             position_ids,
             ttnn_sdpa_input_output,
             sender_coord,
+            kv_cache_tensor=kv_cache_tensor,
             semaphores=semaphores,
             cluster_axis=cluster_axis,
             secondary_cluster_axis=secondary_cluster_axis,

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_pre_sdpa.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_pre_sdpa.py
@@ -141,7 +141,7 @@ def test_pre_sdpa(
         ttnn.ShardOrientation.ROW_MAJOR,
     )
     sdpa_kv_cache_buffer = ttnn.from_torch(
-        torch.randn((1, 1, kv_cache_total_height, kvpe_dim), dtype=torch.bfloat16),
+        torch.randn((kv_cache_total_height, kvpe_dim), dtype=torch.bfloat16),
         dtype=ttnn.bfloat8_b,
         layout=ttnn.TILE_LAYOUT,
         device=submesh,
@@ -174,7 +174,7 @@ def test_pre_sdpa(
         ttnn.ShardOrientation.ROW_MAJOR,
     )
     sdpa_out_interm_buffer = ttnn.from_torch(
-        torch.zeros((1, 1, sdpa_out_interm_total_height, sdpa_out_interm_shard_width), dtype=torch.bfloat16),
+        torch.zeros((sdpa_out_interm_total_height, sdpa_out_interm_shard_width), dtype=torch.bfloat16),
         dtype=ttnn.bfloat16,
         layout=ttnn.TILE_LAYOUT,
         device=submesh,

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_pre_sdpa.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_pre_sdpa.py
@@ -716,42 +716,6 @@ def test_pre_sdpa(
         )
     ttnn.synchronize_device(submesh)
 
-    # ========================================================================
-    # Verify CB overlap addresses
-    # CB descriptors backed by kv_cache_tensor or sdpa_out_interm_tensor should
-    # have their L1 addresses within the backing tensor's buffer region.
-    # We verify this by checking that buffer_address() values are valid and
-    # that the expected overlap relationships hold.
-    # ========================================================================
-    kv_cache_per_device = ttnn.get_device_tensors(kv_cache_tensor)
-    sdpa_out_interm_per_device = ttnn.get_device_tensors(sdpa_out_interm_tensor)
-
-    for device_idx in range(mesh_rows * mesh_cols):
-        kv_addr = kv_cache_per_device[device_idx].buffer_address()
-        sdpa_interm_addr = sdpa_out_interm_per_device[device_idx].buffer_address()
-
-        logger.info(f"Device {device_idx}: kv_cache buffer_address = {kv_addr} (0x{kv_addr:X})")
-        logger.info(
-            f"Device {device_idx}: sdpa_out_interm buffer_address = {sdpa_interm_addr} (0x{sdpa_interm_addr:X})"
-        )
-
-        # Log expected overlap layout for manual verification:
-        # kv_cache-backed CBs: CB2 at +14336, CB5 at +28672
-        # sdpa_out_interm-backed CBs: CB4 at +0, CB9 at +6208, CB10 at +9280, CB12 at +12352, etc.
-        logger.info(f"Device {device_idx}: Expected CB2 (rmsnorm_out) addr = {kv_addr} (0x{kv_addr:X})")
-        logger.info(f"Device {device_idx}: Expected CB5 (matmul_in) addr = {kv_addr + 14336} (0x{kv_addr + 14336:X})")
-        logger.info(
-            f"Device {device_idx}: Expected CB4 (matmul_out) addr = {sdpa_interm_addr} (0x{sdpa_interm_addr:X})"
-        )
-        logger.info(
-            f"Device {device_idx}: Expected CB9 (rmsn2_out) addr = {sdpa_interm_addr + 6208} (0x{sdpa_interm_addr + 6208:X})"
-        )
-        logger.info(
-            f"Device {device_idx}: Expected CB10 (matmul2_in) addr = {sdpa_interm_addr + 9280} (0x{sdpa_interm_addr + 9280:X})"
-        )
-
-    logger.info("CB overlap address verification passed.")
-
     # Convert back to torch for verification
     sdpa_input_output_torch = ttnn.to_torch(
         ttnn_sdpa_input_result, mesh_composer=ttnn.ConcatMeshToTensor(submesh, dim=0)

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_pre_sdpa.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_pre_sdpa.py
@@ -138,7 +138,7 @@ def test_pre_sdpa(
         (kv_cache_shard_height, kvpe_dim),
         ttnn.ShardOrientation.ROW_MAJOR,
     )
-    kv_cache_tensor = ttnn.from_torch(
+    sdpa_kv_cache_buffer = ttnn.from_torch(
         torch.randn((1, 1, kv_cache_total_height, kvpe_dim), dtype=torch.bfloat16),
         dtype=ttnn.bfloat8_b,
         layout=ttnn.TILE_LAYOUT,
@@ -171,7 +171,7 @@ def test_pre_sdpa(
         (sdpa_out_interm_shard_height, sdpa_out_interm_shard_width),
         ttnn.ShardOrientation.ROW_MAJOR,
     )
-    sdpa_out_interm_tensor = ttnn.from_torch(
+    sdpa_out_interm_buffer = ttnn.from_torch(
         torch.zeros((1, 1, sdpa_out_interm_total_height, sdpa_out_interm_shard_width), dtype=torch.bfloat16),
         dtype=ttnn.bfloat16,
         layout=ttnn.TILE_LAYOUT,
@@ -704,9 +704,9 @@ def test_pre_sdpa(
             ttnn_kv_cache,
             position_ids,
             ttnn_sdpa_input_output,
+            sdpa_kv_cache_buffer,
+            sdpa_out_interm_buffer,
             sender_coord,
-            kv_cache_tensor=kv_cache_tensor,
-            sdpa_out_interm_tensor=sdpa_out_interm_tensor,
             semaphores=semaphores,
             cluster_axis=cluster_axis,
             secondary_cluster_axis=secondary_cluster_axis,
@@ -715,6 +715,8 @@ def test_pre_sdpa(
             skip_ccl=skip_ccl,
         )
     ttnn.synchronize_device(submesh)
+
+    kv_cache_output_torch = ttnn.to_torch(ttnn_kv_cache, mesh_composer=ttnn.ConcatMeshToTensor(submesh, dim=0))
 
     # Convert back to torch for verification
     sdpa_input_output_torch = ttnn.to_torch(

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_pre_sdpa.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_pre_sdpa.py
@@ -112,10 +112,10 @@ def test_pre_sdpa(
             f"Device grid {device_grid_size.x}x{device_grid_size.y} too small for {TOTAL_COLS} columns required (P100 has 11 columns)"
         )
 
-    matmul2_grid_x = min(TOTAL_COLS, device_grid_size.x)  # Must be exactly 12 for correct sharding
+    matmul2_grid_x = 12
     matmul2_grid_y = 8
 
-    # SDPA KV Cache tensor declared here to overlap with pre-SDPA CBs.
+    # SDPA KV Cache tensor declared here to overlap with pre-SDPA, pre-KV cache branch CBs.
     # Matches flash_mla's double-buffered KV CB sizing: shard = (2 * k_chunk_size, kvpe_dim)
     # = (256, 576) per core, giving 156,672 bytes/core — same as flash_mla's cb_k_in.
     # Total height = shard_height * num_cores must be divisible by tile height (32).
@@ -149,6 +149,40 @@ def test_pre_sdpa(
             kv_cache_shard_spec,
         ),
         mesh_mapper=ttnn.ReplicateTensorToMesh(submesh),
+    )
+
+    # SDPA output intermediate tensor declared here to overlap with remaining pre-SDPA CBs.
+    # Matches flash_mla's cb_out_im sizing: 85 tiles of [8, 32] at bfloat16 = 43520 B per core.
+    # Shard shape (40, 544) = 5 tile-rows x 17 tile-cols = 85 tiles per core.
+    sdpa_out_interm_num_cores = device_grid_size.x * device_grid_size.y
+    sdpa_out_interm_shard_height = 40  # 5 tile-rows of [8, 32]
+    sdpa_out_interm_shard_width = 544  # 17 tile-cols of [8, 32]
+    sdpa_out_interm_total_height = sdpa_out_interm_shard_height * sdpa_out_interm_num_cores
+
+    sdpa_out_interm_shard_spec = ttnn.ShardSpec(
+        ttnn.CoreRangeSet(
+            {
+                ttnn.CoreRange(
+                    ttnn.CoreCoord(0, 0),
+                    ttnn.CoreCoord(device_grid_size.x - 1, device_grid_size.y - 1),
+                )
+            }
+        ),
+        (sdpa_out_interm_shard_height, sdpa_out_interm_shard_width),
+        ttnn.ShardOrientation.ROW_MAJOR,
+    )
+    sdpa_out_interm_tensor = ttnn.from_torch(
+        torch.zeros((1, 1, sdpa_out_interm_total_height, sdpa_out_interm_shard_width), dtype=torch.bfloat16),
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        device=submesh,
+        memory_config=ttnn.MemoryConfig(
+            ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+            ttnn.BufferType.L1,
+            sdpa_out_interm_shard_spec,
+        ),
+        mesh_mapper=ttnn.ReplicateTensorToMesh(submesh),
+        tile=ttnn.Tile([8, 32]),
     )
 
     # Matmul2 output width (interleaved Qnope/Qrope)
@@ -672,6 +706,7 @@ def test_pre_sdpa(
             ttnn_sdpa_input_output,
             sender_coord,
             kv_cache_tensor=kv_cache_tensor,
+            sdpa_out_interm_tensor=sdpa_out_interm_tensor,
             semaphores=semaphores,
             cluster_axis=cluster_axis,
             secondary_cluster_axis=secondary_cluster_axis,
@@ -681,7 +716,42 @@ def test_pre_sdpa(
         )
     ttnn.synchronize_device(submesh)
 
-    kv_cache_output_torch = ttnn.to_torch(ttnn_kv_cache, mesh_composer=ttnn.ConcatMeshToTensor(submesh, dim=0))
+    # ========================================================================
+    # Verify CB overlap addresses
+    # CB descriptors backed by kv_cache_tensor or sdpa_out_interm_tensor should
+    # have their L1 addresses within the backing tensor's buffer region.
+    # We verify this by checking that buffer_address() values are valid and
+    # that the expected overlap relationships hold.
+    # ========================================================================
+    kv_cache_per_device = ttnn.get_device_tensors(kv_cache_tensor)
+    sdpa_out_interm_per_device = ttnn.get_device_tensors(sdpa_out_interm_tensor)
+
+    for device_idx in range(mesh_rows * mesh_cols):
+        kv_addr = kv_cache_per_device[device_idx].buffer_address()
+        sdpa_interm_addr = sdpa_out_interm_per_device[device_idx].buffer_address()
+
+        logger.info(f"Device {device_idx}: kv_cache buffer_address = {kv_addr} (0x{kv_addr:X})")
+        logger.info(
+            f"Device {device_idx}: sdpa_out_interm buffer_address = {sdpa_interm_addr} (0x{sdpa_interm_addr:X})"
+        )
+
+        # Log expected overlap layout for manual verification:
+        # kv_cache-backed CBs: CB2 at +14336, CB5 at +28672
+        # sdpa_out_interm-backed CBs: CB4 at +0, CB9 at +6208, CB10 at +9280, CB12 at +12352, etc.
+        logger.info(f"Device {device_idx}: Expected CB2 (rmsnorm_out) addr = {kv_addr} (0x{kv_addr:X})")
+        logger.info(f"Device {device_idx}: Expected CB5 (matmul_in) addr = {kv_addr + 14336} (0x{kv_addr + 14336:X})")
+        logger.info(
+            f"Device {device_idx}: Expected CB4 (matmul_out) addr = {sdpa_interm_addr} (0x{sdpa_interm_addr:X})"
+        )
+        logger.info(
+            f"Device {device_idx}: Expected CB9 (rmsn2_out) addr = {sdpa_interm_addr + 6208} (0x{sdpa_interm_addr + 6208:X})"
+        )
+        logger.info(
+            f"Device {device_idx}: Expected CB10 (matmul2_in) addr = {sdpa_interm_addr + 9280} (0x{sdpa_interm_addr + 9280:X})"
+        )
+
+    logger.info("CB overlap address verification passed.")
+
     # Convert back to torch for verification
     sdpa_input_output_torch = ttnn.to_torch(
         ttnn_sdpa_input_result, mesh_composer=ttnn.ConcatMeshToTensor(submesh, dim=0)

--- a/tt_metal/api/tt-metalium/circular_buffer_config.hpp
+++ b/tt_metal/api/tt-metalium/circular_buffer_config.hpp
@@ -86,6 +86,8 @@ public:
     uint32_t max_size() const;
     uint32_t buffer_size() const;
 
+    uint32_t address_offset() const;
+
     const Buffer* shadow_global_buffer{nullptr};
 
     class Builder {
@@ -132,6 +134,7 @@ private:
     // Will be removed once tests are updated to respect the correct `max_size_` constraint
     uint32_t max_size_ = 0;
     uint32_t buffer_size_ = 0;
+    uint32_t address_offset_ = 0;
 };
 
 bool operator==(const CircularBufferConfig& lhs, const CircularBufferConfig& rhs);

--- a/tt_metal/api/tt-metalium/program_descriptors.hpp
+++ b/tt_metal/api/tt-metalium/program_descriptors.hpp
@@ -65,6 +65,7 @@ struct CBDescriptor {
 
     // TODO: Investigate avoiding storing pointers here
     Buffer* buffer = nullptr;
+    uint32_t address_offset = 0;  // byte offset from buffer base address
     const experimental::GlobalCircularBuffer* global_circular_buffer = nullptr;
 };
 

--- a/tt_metal/api/tt-metalium/program_descriptors.hpp
+++ b/tt_metal/api/tt-metalium/program_descriptors.hpp
@@ -65,7 +65,7 @@ struct CBDescriptor {
 
     // TODO: Investigate avoiding storing pointers here
     Buffer* buffer = nullptr;
-    uint32_t address_offset = 0;  // byte offset from buffer base address
+    uint32_t address_offset = 0;
     const experimental::GlobalCircularBuffer* global_circular_buffer = nullptr;
 };
 

--- a/tt_metal/impl/buffers/circular_buffer.cpp
+++ b/tt_metal/impl/buffers/circular_buffer.cpp
@@ -163,7 +163,7 @@ uint32_t CircularBufferImpl::address() const {
 }
 
 void CircularBufferImpl::assign_global_address() {
-    globally_allocated_address_ = config_.shadow_global_buffer->address();
+    globally_allocated_address_ = config_.shadow_global_buffer->address() + config_.address_offset();
 }
 
 void CircularBufferImpl::set_global_circular_buffer(const experimental::GlobalCircularBuffer& global_circular_buffer) {

--- a/tt_metal/impl/buffers/circular_buffer_config.cpp
+++ b/tt_metal/impl/buffers/circular_buffer_config.cpp
@@ -9,6 +9,7 @@
 #include <tt_stl/assert.hpp>
 #include "buffer.hpp"
 #include <tt-logger/tt-logger.hpp>
+#include "hal.hpp"
 #include "impl/context/metal_context.hpp"
 
 namespace tt {
@@ -39,6 +40,22 @@ CircularBufferConfig::CircularBufferConfig(
 CircularBufferConfig::CircularBufferConfig(const CBDescriptor& descriptor) : total_size_(descriptor.total_size) {
     if (descriptor.buffer) {
         this->set_globally_allocated_address(*descriptor.buffer);
+        if (descriptor.address_offset != 0) {
+            uint32_t l1_alignment = hal::get_l1_alignment();
+            TT_FATAL(
+                descriptor.address_offset % l1_alignment == 0,
+                "address_offset ({}) must be aligned to L1 alignment ({})",
+                descriptor.address_offset,
+                l1_alignment);
+            this->globally_allocated_address_ = this->globally_allocated_address_.value() + descriptor.address_offset;
+            this->max_size_ -= descriptor.address_offset;
+            TT_FATAL(
+                this->total_size_ <= this->max_size_,
+                "address_offset ({}) + total_size ({}) exceeds buffer bank size ({})",
+                descriptor.address_offset,
+                this->total_size_,
+                this->max_size_ + descriptor.address_offset);
+        }
     }
 
     auto process_format_descriptor = [this](const CBFormatDescriptor& format_descriptor) {

--- a/tt_metal/impl/buffers/circular_buffer_config.cpp
+++ b/tt_metal/impl/buffers/circular_buffer_config.cpp
@@ -47,6 +47,7 @@ CircularBufferConfig::CircularBufferConfig(const CBDescriptor& descriptor) : tot
                 "address_offset ({}) must be aligned to L1 alignment ({})",
                 descriptor.address_offset,
                 l1_alignment);
+            this->address_offset_ = descriptor.address_offset;
             this->globally_allocated_address_ = this->globally_allocated_address_.value() + descriptor.address_offset;
             this->max_size_ -= descriptor.address_offset;
             TT_FATAL(
@@ -210,6 +211,8 @@ bool CircularBufferConfig::dynamic_cb() const { return this->dynamic_cb_; }
 uint32_t CircularBufferConfig::max_size() const { return this->max_size_; }
 
 uint32_t CircularBufferConfig::buffer_size() const { return this->buffer_size_; }
+
+uint32_t CircularBufferConfig::address_offset() const { return this->address_offset_; }
 
 CircularBufferConfig::Builder CircularBufferConfig::Builder::LocalBuilder(
     CircularBufferConfig& parent, uint8_t buffer_index) {

--- a/ttnn/api/ttnn/tensor/tensor_utils.hpp
+++ b/ttnn/api/ttnn/tensor/tensor_utils.hpp
@@ -54,6 +54,7 @@ bool is_device_tensor(const Tensor& tensor);
  *   CBDescriptor cb = cb_descriptor_from_sharded_tensor(in_cb_id, device_input_tensor);
  * @endcode
  */
-CBDescriptor cb_descriptor_from_sharded_tensor(uint8_t cb_index, const Tensor& tensor);
+CBDescriptor cb_descriptor_from_sharded_tensor(
+    uint8_t cb_index, const Tensor& tensor, uint32_t address_offset = 0, uint32_t total_size = 0);
 
 }  // namespace tt::tt_metal

--- a/ttnn/core/tensor/tensor_utils.cpp
+++ b/ttnn/core/tensor/tensor_utils.cpp
@@ -23,6 +23,9 @@ bool is_device_tensor(const Tensor& tensor) { return tensor.storage_type() == St
 CBDescriptor cb_descriptor_from_sharded_tensor(
     uint8_t cb_index, const Tensor& tensor, uint32_t address_offset, uint32_t total_size) {
     TT_FATAL(tensor.is_sharded(), "Tensor must be sharded to automatically create a CBDescriptor");
+    TT_FATAL(
+        (address_offset + total_size) <= tensor.buffer()->aligned_size_per_bank(),
+        "Address offset + total size exceeds buffer size");
 
     uint32_t effective_total_size = (total_size != 0) ? total_size : tensor.buffer()->aligned_size_per_bank();
 


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/37982)

### Problem description
To save L1 space and avoid reconfiguring CBs, we can overlap CB memory regions if the overlapped regions are guaranteed to be consumed / produced into in a serialized fashion. Large CBs can have multiple smaller CBs overlap their memory region.

### What's changed

- CB descriptors now store an address offset field, which is the initial location of the read/write ptrs relative to the base CB address (0 by default)
- `cb_descriptor_from_sharded_tensor` API updated to intake address offset and total size, so that multiple smaller CBs can be backed by the same larger tensor
- Deepseek Blitz: Overlapped pre-SDPA, pre-KV-cache-branch CBs with the KV-cache-input CB which is used in SDPA
- Deepseek Blitz: Overlapped all other non-weight CBs with the SDPA out intermediate CB (except pre-SDPA input CB)


CB Index | CB Name | Backing Tensor | Address Offset (B) | Size (B) | Tile Size | Description
-- | -- | -- | -- | -- | -- | --
2 | rmsnorm_output_cb | sdpa_kv_cache_buffer | 0 | 14336 | 16×32 | RMSNorm output buffer
5 | matmul_input_cb | sdpa_out_interm_buffer | 0 | 14336 | 1×32 | Matmul input buffer (48 tiles)
4 | matmul_output_cb | sdpa_out_interm_buffer | 14336 | 64 | 1×32 | Matmul output buffer (single tile)
7 | rmsnorm2_input_cb | sdpa_out_interm_buffer | 14400 | 3072 | 16×32 | RMSNorm2 input buffer (3 tiles)
8 | gather_reduce_half1_scratch_cb | sdpa_out_buffer_tensor | 17472 | 3072 | 16×32 | Gather-reduce half1 scratch (3 tiles)
9 | rmsnorm2_output_cb | sdpa_out_interm_buffer | 20544 | 3072 | 16×32 | RMSNorm2 output buffer (3 tiles)
10 | matmul2_input_cb | sdpa_out_interm_buffer | 23616 | 3072 | 1×32 | Matmul2 input buffer (48 tiles)
12 | matmul2_output_cb | sdpa_out_interm_buffer | 26688 | 256 | 1×32 | Matmul2 output buffer (4 tiles)
14 | matmul3_output_cb | sdpa_out_interm_buffer | 26944 | 1024 | 1×32 | Matmul3 output buffer (16 tiles)
15 | qrope_output_cb | sdpa_out_interm_buffer | 27968 | 256 | 1×32 | QRoPE output buffer (4 tiles)
20 | qrope_rotated_input_interm_cb | sdpa_out_interm_buffer | 28224 | 128 | 1×32 | QRoPE rotated input intermediate (2 tiles)
21 | qrope_cos_interm_cb | sdpa_out_interm_buffer | 28352 | 128 | 1×32 | QRoPE cos intermediate (2 tiles)
22 | qrope_sin_interm_cb | sdpa_out_interm_buffer | 28480 | 128 | 1×32 | QRoPE sin intermediate (2 tiles)
31 | create_q_heads_interm_cb | sdpa_out_interm_buffer | 28608 | 9216 | 8×32 | CreateQHeads intermediate buffer (18 tiles)
24 | dkv_matmul_output_cb | sdpa_out_interm_buffer | 37824 | 64 | 1×32 | DKV Matmul output buffer (single tile)
25 | kv_rmsnorm_input_cb | sdpa_out_interm_buffer | 37888 | 1024 | 16×32 | KV RMSNorm input buffer (single tile)
27 | kv_rmsnorm_output_cb | sdpa_out_interm_buffer | 38912 | 1024 | 16×32 | KV RMSNorm output buffer (single tile)
28 | krope_output_cb | sdpa_out_interm_buffer | 39936 | 64 | 1×32 | KRoPE output buffer (single tile)




### Checklist

- [x] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=ssundaram/overlap_cbs)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:ssundaram/overlap_cbs)
- [x] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ssundaram/overlap_cbs)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ssundaram/overlap_cbs)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ssundaram/overlap_cbs)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ssundaram/overlap_cbs)
- [x] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ssundaram/overlap_cbs)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ssundaram/overlap_cbs)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ssundaram/overlap_cbs)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ssundaram/overlap_cbs)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ssundaram/overlap_cbs)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ssundaram/overlap_cbs)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
