### PR TITLE
Add watcher stack usage support for Quasar

### DIFF
--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_stack_usage.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_stack_usage.cpp
@@ -7,71 +7,114 @@
 #include <tt-metalium/core_coord.hpp>
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/kernel_types.hpp>
+#include <tt-metalium/experimental/host_api.hpp>
 #include <gtest/gtest.h>
 #include "debug_tools_fixture.hpp"
 #include "debug_tools_test_utils.hpp"
+#include "hal_types.hpp"
+#include "impl/context/metal_context.hpp"
 #include <fmt/base.h>
 #include <string>
 #include <vector>
+#include <optional>
 
 using namespace tt;
 using namespace tt::tt_metal;
 
 namespace {
+
 void RunOneTest(
-    MeshWatcherFixture* fixture, const std::shared_ptr<distributed::MeshDevice>& mesh_device, unsigned free) {
-    static const char* const names[] = {"BRISC", "NCRISC", "TRISC0", "TRISC1", "TRISC2", "aerisc", "ierisc"};
+    MeshWatcherFixture* fixture,
+    const std::shared_ptr<distributed::MeshDevice>& mesh_device,
+    unsigned free,
+    std::optional<uint32_t> quasar_dms_per_kernel = std::nullopt) {
+    const auto& hal = MetalContext::instance().hal();
+    const bool is_quasar = hal.get_arch() == tt::ARCH::QUASAR;
     const std::string path = "tests/tt_metal/tt_metal/test_kernels/misc/watcher_stack.cpp";
-    auto msg = [&](std::vector<std::string> &msgs, const char *cpu, unsigned free) {
-        if (msgs.empty()) {
-            msgs.push_back("Stack usage summary:");
-        }
-        msgs.push_back(fmt::format("{} highest stack usage: {} bytes free, on core "
-                                   "* running kernel {} ({})",
-                                   cpu, free, path, !free ? "OVERFLOW" : "Close to overflow"));
-    };
 
     // Set up program
     distributed::MeshWorkload workload;
     auto zero_coord = distributed::MeshCoordinate(0, 0);
     auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
-    Program program = Program();
-    workload.add_program(device_range, std::move(program));
-    auto& program_ = workload.get_programs().at(device_range);
+    workload.add_program(device_range, {});
+    auto& program = workload.get_programs().at(device_range);
     auto* device = mesh_device->get_devices()[0];
 
     CoreCoord coord = {0, 0};
     std::vector<uint32_t> compile_args{free};
     std::vector<std::string> expected;
 
-    CreateKernel(
-        program_,
-        path,
-        coord,
-        DataMovementConfig{
-            .processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default, .compile_args = compile_args});
-    msg(expected, names[0], free);
+    // Helper to add expected message in watcher logs
+    auto add_expected_msg = [&](const std::string& cpu) {
+        if (expected.empty()) {
+            expected.push_back("Stack usage summary:");
+        }
+        expected.push_back(fmt::format(
+            "{} highest stack usage: {} bytes free, on core "
+            "* running kernel {} ({})",
+            cpu,
+            free,
+            path,
+            !free ? "OVERFLOW" : "Close to overflow"));
+    };
 
-    CreateKernel(
-        program_,
-        path,
-        coord,
-        DataMovementConfig{
-            .processor = DataMovementProcessor::RISCV_1, .noc = NOC::RISCV_1_default, .compile_args = compile_args});
-    msg(expected, names[1], free);
+    // Create DM kernels
+    auto num_dms = hal.get_processor_types_count(HalProgrammableCoreType::TENSIX, 0);
+    if (is_quasar) {
+        // quasar_dms_per_kernel = 8, num_kernels = 1. Same Kernel launched on all DMs (default)
+        // quasar_dms_per_kernel = 1, num_kernels = 8. A single kernel launched on a unique DM
+        uint32_t dms_per_kernel = quasar_dms_per_kernel.value_or(num_dms);
+        TT_FATAL(
+            dms_per_kernel > 0 && num_dms % dms_per_kernel == 0,
+            "dms_per_kernel ({}) must be positive and evenly divide num_dms ({})",
+            dms_per_kernel,
+            num_dms);
+        uint32_t num_kernels = num_dms / dms_per_kernel;
+        for (uint32_t i = 0; i < num_kernels; i++) {
+            experimental::quasar::CreateKernel(
+                program,
+                path,
+                coord,
+                experimental::quasar::QuasarDataMovementConfig{
+                    .num_processors_per_cluster = dms_per_kernel, .compile_args = compile_args});
+        }
+    } else {
+        // BH/WH:
+        for (uint32_t type_idx = 0; type_idx < num_dms; type_idx++) {
+            DataMovementConfig dm_config{};
+            dm_config.processor = static_cast<DataMovementProcessor>(type_idx);
+            dm_config.noc = (type_idx == 1) ? NOC::RISCV_1_default : NOC::RISCV_0_default;
+            dm_config.compile_args = compile_args;
+            CreateKernel(program, path, coord, dm_config);
+        }
+    }
+    // Add expected messages for all DMs
+    for (uint32_t type_idx = 0; type_idx < num_dms; type_idx++) {
+        uint32_t processor_idx =
+            hal.get_processor_index(HalProgrammableCoreType::TENSIX, HalProcessorClassType::DM, type_idx);
+        add_expected_msg(hal.get_processor_class_name(HalProgrammableCoreType::TENSIX, processor_idx, false));
+    }
 
-    CreateKernel(program_, path, coord, ComputeConfig{.compile_args = compile_args});
-    for (unsigned ix = 0; ix != 2; ix++) {
-        msg(expected, names[2 + ix], free);
+    // Create compute kernels
+    // TODO: Watcher feature are temporarily skipped on Quasar until basic runtime bring-up is complete
+    auto num_processor_classes = hal.get_processor_classes_count(HalProgrammableCoreType::TENSIX);
+    if (!is_quasar && num_processor_classes > 1) {
+        auto num_compute_types = hal.get_processor_types_count(HalProgrammableCoreType::TENSIX, 1);
+        CreateKernel(program, path, coord, ComputeConfig{.compile_args = compile_args});
+        for (uint32_t type_idx = 0; type_idx < num_compute_types; type_idx++) {
+            uint32_t processor_idx =
+                hal.get_processor_index(HalProgrammableCoreType::TENSIX, HalProcessorClassType::COMPUTE, type_idx);
+            add_expected_msg(hal.get_processor_class_name(HalProgrammableCoreType::TENSIX, processor_idx, false));
+        }
     }
 
     // Also run on idle ethernet, if present
-    auto const &inactive_eth_cores = device->get_inactive_ethernet_cores();
+    const auto& inactive_eth_cores = device->get_inactive_ethernet_cores();
     if (!inactive_eth_cores.empty() && fixture->IsSlowDispatch()) {
         // Just pick the first core
         CoreCoord idle_coord = CoreCoord(*inactive_eth_cores.begin());
         CreateKernel(
-            program_,
+            program,
             path,
             idle_coord,
             tt_metal::EthernetConfig{
@@ -79,29 +122,55 @@ void RunOneTest(
                 .noc = tt_metal::NOC::NOC_0,
                 .processor = DataMovementProcessor::RISCV_0,
                 .compile_args = compile_args});
-        msg(expected, names[6], free);
+        add_expected_msg(hal.get_processor_class_name(HalProgrammableCoreType::IDLE_ETH, 0, false));
     }
 
     fixture->RunProgram(mesh_device, workload, true);
-
     EXPECT_TRUE(FileContainsAllStringsInOrder(fixture->log_file_name, expected));
-}
-
-template <uint32_t Free>
-void RunTest(MeshWatcherFixture* fixture, const std::shared_ptr<distributed::MeshDevice>& mesh_device) {
-    RunOneTest(fixture, mesh_device, Free);
 }
 
 } // namespace
 
-TEST_F(MeshWatcherFixture, TestWatcherStackUsage0) {
+// Standard tests on all archs (Default Quasar uses single kernel with all DMs)
+TEST_F(MeshWatcherFixture, TestWatcherStackcUsage0) {
     for (auto& mesh_device : this->devices_) {
-        this->RunTestOnDevice(RunTest<0>, mesh_device);
+        this->RunTestOnDevice(
+            [](MeshWatcherFixture* f, const std::shared_ptr<distributed::MeshDevice>& d) { RunOneTest(f, d, 0); },
+            mesh_device);
     }
 }
 
 TEST_F(MeshWatcherFixture, TestWatcherStackUsage16) {
     for (auto& mesh_device : this->devices_) {
-        this->RunTestOnDevice(RunTest<16>, mesh_device);
+        this->RunTestOnDevice(
+            [](MeshWatcherFixture* f, const std::shared_ptr<distributed::MeshDevice>& d) { RunOneTest(f, d, 16); },
+            mesh_device);
+    }
+}
+
+// Quasar-specific: multi-kernel mode (8 kernels, 1 DM each)
+TEST_F(MeshWatcherFixture, TestWatcherStackUsage0_QuasarMultiKernel) {
+    if (MetalContext::instance().hal().get_arch() != tt::ARCH::QUASAR) {
+        GTEST_SKIP() << "Test only applicable to Quasar";
+    }
+    for (auto& mesh_device : this->devices_) {
+        this->RunTestOnDevice(
+            [](MeshWatcherFixture* f, const std::shared_ptr<distributed::MeshDevice>& d) {
+                RunOneTest(f, d, 0, 1);  // 1 DM per kernel
+            },
+            mesh_device);
+    }
+}
+
+TEST_F(MeshWatcherFixture, TestWatcherStackUsage16_QuasarMultiKernel) {
+    if (MetalContext::instance().hal().get_arch() != tt::ARCH::QUASAR) {
+        GTEST_SKIP() << "Test only applicable to Quasar";
+    }
+    for (auto& mesh_device : this->devices_) {
+        this->RunTestOnDevice(
+            [](MeshWatcherFixture* f, const std::shared_ptr<distributed::MeshDevice>& d) {
+                RunOneTest(f, d, 16, 1);  // 1 DM per kernel
+            },
+            mesh_device);
     }
 }

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_stack_usage.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_stack_usage.cpp
@@ -37,18 +37,15 @@ void RunOneTest(
     auto zero_coord = distributed::MeshCoordinate(0, 0);
     auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
     workload.add_program(device_range, {});
-    auto& program = workload.get_programs().at(device_range);
+    auto& program_ = workload.get_programs().at(device_range);
     auto* device = mesh_device->get_devices()[0];
 
     CoreCoord coord = {0, 0};
     std::vector<uint32_t> compile_args{free};
-    std::vector<std::string> expected;
+    std::vector<std::string> expected{"Stack usage summary:"};
 
     // Helper to add expected message in watcher logs
     auto add_expected_msg = [&](const std::string& cpu) {
-        if (expected.empty()) {
-            expected.push_back("Stack usage summary:");
-        }
         expected.push_back(fmt::format(
             "{} highest stack usage: {} bytes free, on core "
             "* running kernel {} ({})",
@@ -72,7 +69,7 @@ void RunOneTest(
         uint32_t num_kernels = num_dms / dms_per_kernel;
         for (uint32_t i = 0; i < num_kernels; i++) {
             experimental::quasar::CreateKernel(
-                program,
+                program_,
                 path,
                 coord,
                 experimental::quasar::QuasarDataMovementConfig{
@@ -85,7 +82,7 @@ void RunOneTest(
             dm_config.processor = static_cast<DataMovementProcessor>(type_idx);
             dm_config.noc = (type_idx == 1) ? NOC::RISCV_1_default : NOC::RISCV_0_default;
             dm_config.compile_args = compile_args;
-            CreateKernel(program, path, coord, dm_config);
+            CreateKernel(program_, path, coord, dm_config);
         }
     }
     // Add expected messages for all DMs
@@ -96,11 +93,11 @@ void RunOneTest(
     }
 
     // Create compute kernels
-    // TODO: Watcher feature are temporarily skipped on Quasar until basic runtime bring-up is complete
+    // TODO: Watcher features are temporarily skipped on Quasar until basic runtime bring-up for TRISCs is complete
     auto num_processor_classes = hal.get_processor_classes_count(HalProgrammableCoreType::TENSIX);
     if (!is_quasar && num_processor_classes > 1) {
         auto num_compute_types = hal.get_processor_types_count(HalProgrammableCoreType::TENSIX, 1);
-        CreateKernel(program, path, coord, ComputeConfig{.compile_args = compile_args});
+        CreateKernel(program_, path, coord, ComputeConfig{.compile_args = compile_args});
         for (uint32_t type_idx = 0; type_idx < num_compute_types; type_idx++) {
             uint32_t processor_idx =
                 hal.get_processor_index(HalProgrammableCoreType::TENSIX, HalProcessorClassType::COMPUTE, type_idx);
@@ -114,7 +111,7 @@ void RunOneTest(
         // Just pick the first core
         CoreCoord idle_coord = CoreCoord(*inactive_eth_cores.begin());
         CreateKernel(
-            program,
+            program_,
             path,
             idle_coord,
             tt_metal::EthernetConfig{
@@ -122,7 +119,9 @@ void RunOneTest(
                 .noc = tt_metal::NOC::NOC_0,
                 .processor = DataMovementProcessor::RISCV_0,
                 .compile_args = compile_args});
-        add_expected_msg(hal.get_processor_class_name(HalProgrammableCoreType::IDLE_ETH, 0, false));
+        // TODO: replace string literal "ierisc" with hal.get_processor_class_name() after
+        // unifying all tests + watcher_device_reader::get_riscv_name() with same method
+        add_expected_msg("ierisc");
     }
 
     fixture->RunProgram(mesh_device, workload, true);
@@ -131,46 +130,40 @@ void RunOneTest(
 
 } // namespace
 
-// Standard tests on all archs (Default Quasar uses single kernel with all DMs)
-TEST_F(MeshWatcherFixture, TestWatcherStackcUsage0) {
-    for (auto& mesh_device : this->devices_) {
-        this->RunTestOnDevice(
-            [](MeshWatcherFixture* f, const std::shared_ptr<distributed::MeshDevice>& d) { RunOneTest(f, d, 0); },
-            mesh_device);
-    }
-}
+struct StackUsageTestParams {
+    std::string test_name;
+    unsigned free_bytes;
+    std::optional<uint32_t> quasar_dms_per_kernel;  // nullopt = default (all DMs), value = multi-kernel mode
+    bool quasar_only;                               // If true, skip on non-Quasar
+};
 
-TEST_F(MeshWatcherFixture, TestWatcherStackUsage16) {
-    for (auto& mesh_device : this->devices_) {
-        this->RunTestOnDevice(
-            [](MeshWatcherFixture* f, const std::shared_ptr<distributed::MeshDevice>& d) { RunOneTest(f, d, 16); },
-            mesh_device);
-    }
-}
+class StackUsageTest : public MeshWatcherFixture, public ::testing::WithParamInterface<StackUsageTestParams> {};
 
-// Quasar-specific: multi-kernel mode (8 kernels, 1 DM each)
-TEST_F(MeshWatcherFixture, TestWatcherStackUsage0_QuasarMultiKernel) {
-    if (MetalContext::instance().hal().get_arch() != tt::ARCH::QUASAR) {
+TEST_P(StackUsageTest, TestWatcherStackUsage) {
+    const auto& params = GetParam();
+
+    // Skip Quasar-only tests on other architectures
+    if (params.quasar_only && MetalContext::instance().hal().get_arch() != tt::ARCH::QUASAR) {
         GTEST_SKIP() << "Test only applicable to Quasar";
     }
+
     for (auto& mesh_device : this->devices_) {
         this->RunTestOnDevice(
-            [](MeshWatcherFixture* f, const std::shared_ptr<distributed::MeshDevice>& d) {
-                RunOneTest(f, d, 0, 1);  // 1 DM per kernel
+            [&params](MeshWatcherFixture* f, const std::shared_ptr<distributed::MeshDevice>& d) {
+                RunOneTest(f, d, params.free_bytes, params.quasar_dms_per_kernel);
             },
             mesh_device);
     }
 }
 
-TEST_F(MeshWatcherFixture, TestWatcherStackUsage16_QuasarMultiKernel) {
-    if (MetalContext::instance().hal().get_arch() != tt::ARCH::QUASAR) {
-        GTEST_SKIP() << "Test only applicable to Quasar";
-    }
-    for (auto& mesh_device : this->devices_) {
-        this->RunTestOnDevice(
-            [](MeshWatcherFixture* f, const std::shared_ptr<distributed::MeshDevice>& d) {
-                RunOneTest(f, d, 16, 1);  // 1 DM per kernel
-            },
-            mesh_device);
-    }
-}
+INSTANTIATE_TEST_SUITE_P(
+    WatcherStackUsageTests,
+    StackUsageTest,
+    ::testing::Values(
+        // Standard tests (all architectures, default Quasar uses single kernel with all DMs)
+        StackUsageTestParams{"StackUsage0", 0, std::nullopt, false},
+        StackUsageTestParams{"StackUsage16", 16, std::nullopt, false},
+        // Quasar only: multi-kernel mode (launch 8 kernels in total, each mapped to a unique DM each)
+        StackUsageTestParams{"StackUsage0_QuasarMultiKernel", 0, 1, true},
+        StackUsageTestParams{"StackUsage16_QuasarMultiKernel", 16, 1, true}),
+    [](const ::testing::TestParamInfo<StackUsageTestParams>& info) { return info.param.test_name; });

--- a/tests/tt_metal/tt_metal/test_kernels/misc/watcher_stack.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/misc/watcher_stack.cpp
@@ -5,16 +5,12 @@
 // Scribble on the stack to check stack usage detection.
 
 #include "api/compile_time_args.h"
-#include <dev_mem_map.h>
+#include "internal/debug/stack_usage.h"
 
-extern uint32_t __stack_base[];
-
-#if defined(COMPILE_FOR_TRISC)
-#include "api/compute/common.h"
-#endif
 void kernel_main() {
     uint32_t usage = get_compile_time_arg_val (0);
-    auto point = &__stack_base[usage / sizeof(uint32_t)];
+    uint32_t* stack_base = get_stack_base();
+    auto point = &stack_base[usage / sizeof(uint32_t)];
     uint32_t *sp;
     asm ("mv %0,sp" : "=r"(sp));
 

--- a/tt_metal/hw/inc/internal/debug/stack_usage.h
+++ b/tt_metal/hw/inc/internal/debug/stack_usage.h
@@ -5,7 +5,6 @@
 #pragma once
 
 #include "watcher_common.h"
-#include "core_config.h"
 #include "dev_mem_map.h"
 
 // We don't control the stack size for active erisc, and share the stack with base FW, so don't implement for ERISC.
@@ -62,13 +61,13 @@ static inline void record_stack_usage(uint32_t stack_free) {
     }
 
     std::uint64_t cpu_index = 0;
+    // TODO: This logic should be moved to an internal get_cpu_idx() API.
+    // Deferred to a follow-up PR
 #if defined(ARCH_QUASAR)
-    // TODO: The below code is recurring on Quasar.
-    // It needs to be in a get_cpu_idx() API for Quasar
 #if defined(COMPILE_FOR_TRISC)
     std::uint32_t neo_id = ckernel::csr_read<ckernel::CSR::NEO_ID>();
     std::uint32_t trisc_id = ckernel::csr_read<ckernel::CSR::TRISC_ID>();
-    cpu_index = MaxDMProcessorsPerCoreType + NUM_TRISC_CORES * neo_id + trisc_id;  // after 8 DM cores
+    cpu_index = NUM_DM_CORES + NUM_TRISC_CORES * neo_id + trisc_id;  // after 8 DM cores
 #else
     asm volatile("csrr %0, mhartid" : "=r"(cpu_index));
 #endif
@@ -93,7 +92,7 @@ static inline void record_stack_usage(uint32_t stack_free) {
 #else  // !WATCHER_ENABLED
 
 static inline void mark_stack_usage() {}
-static inline int measure_stack_usage() { return 0; }
+static inline uint32_t measure_stack_usage() { return 0; }
 static inline void record_stack_usage(uint32_t) {}
 
 #endif  // WATCHER_ENABLED

--- a/tt_metal/hw/inc/internal/debug/stack_usage.h
+++ b/tt_metal/hw/inc/internal/debug/stack_usage.h
@@ -5,6 +5,8 @@
 #pragma once
 
 #include "watcher_common.h"
+#include "core_config.h"
+#include "dev_mem_map.h"
 
 // We don't control the stack size for active erisc, and share the stack with base FW, so don't implement for ERISC.
 #if defined(WATCHER_ENABLED) && \
@@ -14,14 +16,21 @@
 
 constexpr uint32_t stack_usage_pattern = 0xBABABABA;
 
-static inline void mark_stack_usage() {
+// Helper to resolve the stack base without triggering a global constructor
+static inline uint32_t* get_stack_base() {
 #if defined(ARCH_QUASAR)
     extern thread_local uint32_t __stack_base_lwm[];
     extern char __stack_base_offset;
     uint32_t* __stack_base = &__stack_base_lwm[uintptr_t(&__stack_base_offset)];
+    return __stack_base;
 #else
     extern uint32_t __stack_base[];
+    return __stack_base;
 #endif
+}
+
+static inline void mark_stack_usage() {
+    uint32_t* __stack_base = get_stack_base();
     uint32_t tt_l1_ptr *ptr;
     asm ("mv %0,sp" : "=r"(ptr));
 
@@ -32,13 +41,7 @@ static inline void mark_stack_usage() {
 
 // Returns unused stack + 1. (0 means unknown.)
 static inline uint32_t measure_stack_usage() {
-#if defined(ARCH_QUASAR)
-    extern thread_local uint32_t __stack_base_lwm[];
-    extern char __stack_base_offset;
-    uint32_t* __stack_base = &__stack_base_lwm[uintptr_t(&__stack_base_offset)];
-#else
-    extern uint32_t __stack_base[];
-#endif
+    uint32_t* __stack_base = get_stack_base();
     uint32_t tt_l1_ptr* stack_ptr = __stack_base;
     // We don't need to check size here, as we know we'll hit a
     // non-dirty value at some point (a set of return addresses).
@@ -58,7 +61,21 @@ static inline void record_stack_usage(uint32_t stack_free) {
         return;
     }
 
-    auto tt_l1_ptr* usage = &GET_MAILBOX_ADDRESS_DEV(watcher.stack_usage)->cpu[PROCESSOR_INDEX];
+    std::uint64_t cpu_index = 0;
+#if defined(ARCH_QUASAR)
+    // TODO: The below code is recurring on Quasar.
+    // It needs to be in a get_cpu_idx() API for Quasar
+#if defined(COMPILE_FOR_TRISC)
+    std::uint32_t neo_id = ckernel::csr_read<ckernel::CSR::NEO_ID>();
+    std::uint32_t trisc_id = ckernel::csr_read<ckernel::CSR::TRISC_ID>();
+    cpu_index = MaxDMProcessorsPerCoreType + NUM_TRISC_CORES * neo_id + trisc_id;  // after 8 DM cores
+#else
+    asm volatile("csrr %0, mhartid" : "=r"(cpu_index));
+#endif
+#else
+    cpu_index = PROCESSOR_INDEX;
+#endif
+    auto tt_l1_ptr* usage = &GET_MAILBOX_ADDRESS_DEV(watcher.stack_usage)->cpu[cpu_index];
     // min_free is initialized to zero, which we want to compare as
     // least noteworthy, and an offset free stack of one as the most
     // noteworthy. Decrement the former, so zero wraps around before
@@ -68,7 +85,7 @@ static inline void record_stack_usage(uint32_t stack_free) {
         usage->min_free = stack_free;
         unsigned launch_idx = *GET_MAILBOX_ADDRESS_DEV(launch_msg_rd_ptr);
         launch_msg_t tt_l1_ptr* launch_msg = GET_MAILBOX_ADDRESS_DEV(launch[launch_idx]);
-        usage->watcher_kernel_id = launch_msg->kernel_config.watcher_kernel_ids[PROCESSOR_INDEX];
+        usage->watcher_kernel_id = launch_msg->kernel_config.watcher_kernel_ids[cpu_index];
     }
 }
 #endif  // KERNEL_BUILD


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/38105

### Problem description
Add Watcher stack usage detection for all 8 DMs on Quasar.

### What's changed
- Added `get_stack_base()` helper in `stack_usage.h` (abstract Quasar's thread_local `__stack_base_lwm[]` vs `__stack_base[]` on WH/BH)
- Updated `test_stack_usage.cpp` to use HAL APIs for processor names and added Quasar multi-kernel mode tests

Note: Placeholders for Quasar TRISC stack usage tests are inserted but testing is deferred until TRISC runtime bring-up is complete.

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=snadkarni/watcher_stack_usage_quasar)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:snadkarni/watcher_stack_usage_quasar)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=snadkarni/watcher_stack_usage_quasar)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:snadkarni/watcher_stack_usage_quasar)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=snadkarni/watcher_stack_usage_quasar)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:snadkarni/watcher_stack_usage_quasar)
- [x] New/Existing tests provide coverage for changes

Quasar emulator test runs: https://gist.github.com/sidnadTT/1e2b4a9f274e0599b47ab3d45e641968


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=snadkarni/watcher_stack_usage_quasar)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:snadkarni/watcher_stack_usage_quasar)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=snadkarni/watcher_stack_usage_quasar)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:snadkarni/watcher_stack_usage_quasar)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=snadkarni/watcher_stack_usage_quasar)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:snadkarni/watcher_stack_usage_quasar)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
