### PR TITLE
[skip ci] Run test_host_io.py on viommu runners only

### DIFF
--- a/.github/workflows/blackhole-multi-card-unit-tests-impl.yaml
+++ b/.github/workflows/blackhole-multi-card-unit-tests-impl.yaml
@@ -52,9 +52,12 @@ jobs:
           - name: Sockets fast unit test
             cmd: |
               ./build/test/tt_metal/distributed/distributed_unit_tests --gtest_filter="*HDSocketFixture*"
-              TT_METAL_SLOW_DISPATCH_MODE=1 pytest -svv models/demos/deepseek_v3_b1/tests/unit_tests/test_host_io.py
             timeout: 10
             test-type: fast
+          - name: Host IO fast unit test (viommu only)
+            cmd: TT_METAL_SLOW_DISPATCH_MODE=1 pytest -svv models/demos/deepseek_v3_b1/tests/unit_tests/test_host_io.py
+            timeout: 10
+            test-type: fast-viommu
           - name: cpp fast unit tests (eth, single erisc)
             cmd: |
               ./build/test/tt_metal/unit_tests_eth
@@ -104,12 +107,16 @@ jobs:
           )
           all_tests=$(echo "$all_tests_yaml" | ruby -r yaml -r json -e 'puts YAML.load(STDIN.read).to_json')
 
-          # Filter based on fast-only input: when true, only test-type == "fast"
+          # Filter: fast-viommu runs only when runner-label contains viommu; when fast_only, run only fast + fast-viommu (on viommu)
           fast_only="${{ inputs.fast-only }}"
+          runner_label="${{ inputs.runner-label }}"
+          viommu_json="false"
+          if [[ "$runner_label" == *viommu* ]]; then viommu_json="true"; fi
+
           if [ "$fast_only" == "true" ]; then
-            filtered_tests=$(echo "$all_tests" | jq -c '[.[] | select(.["test-type"] == "fast")]')
+            filtered_tests=$(echo "$all_tests" | jq -c --argjson viommu "$viommu_json" '[.[] | select((.["test-type"] == "fast") or (.["test-type"] == "fast-viommu" and $viommu))]')
           else
-            filtered_tests=$(echo "$all_tests" | jq -c '.')
+            filtered_tests=$(echo "$all_tests" | jq -c --argjson viommu "$viommu_json" '[.[] | select((.["test-type"] != "fast-viommu") or $viommu)]')
           fi
 
           echo "Filtered tests: $filtered_tests"

--- a/.github/workflows/blackhole-multi-card-unit-tests-impl.yaml
+++ b/.github/workflows/blackhole-multi-card-unit-tests-impl.yaml
@@ -107,7 +107,7 @@ jobs:
           )
           all_tests=$(echo "$all_tests_yaml" | ruby -r yaml -r json -e 'puts YAML.load(STDIN.read).to_json')
 
-          # Filter: fast-viommu runs only when runner-label contains viommu; when fast_only, run only fast + fast-viommu (on viommu)
+          # Filter: *-viommu test types run only when runner-label contains viommu; when fast_only, run only fast + fast-viommu (on viommu)
           fast_only="${{ inputs.fast-only }}"
           runner_label="${{ inputs.runner-label }}"
           viommu_json="false"
@@ -116,7 +116,7 @@ jobs:
           if [ "$fast_only" == "true" ]; then
             filtered_tests=$(echo "$all_tests" | jq -c --argjson viommu "$viommu_json" '[.[] | select((.["test-type"] == "fast") or (.["test-type"] == "fast-viommu" and $viommu))]')
           else
-            filtered_tests=$(echo "$all_tests" | jq -c --argjson viommu "$viommu_json" '[.[] | select((.["test-type"] != "fast-viommu") or $viommu)]')
+            filtered_tests=$(echo "$all_tests" | jq -c --argjson viommu "$viommu_json" '[.[] | select((.["test-type"] != "fast-viommu" and .["test-type"] != "slow-viommu") or $viommu)]')
           fi
 
           echo "Filtered tests: $filtered_tests"


### PR DESCRIPTION
### Ticket
None

### Problem description
Test added in https://github.com/tenstorrent/tt-metal/commit/1345d865a304d37166f4eccca436f6b6c85e8b48 should only run on VIOMMU runners (breaks BH post commit)

### What's changed
Exclude the test when running on non-VIOMMU runners; separate it out into a viommu-only job in the job matrix.

### Checklist

- [x] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=williamly/skip-viommu-only-pytest)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:williamly/skip-viommu-only-pytest)
- [x] BH nightly: https://github.com/tenstorrent/tt-metal/actions/runs/22112194538
- [x] BHPC: https://github.com/tenstorrent/tt-metal/actions/runs/22112185297

