### PR TITLE
Add col_tilize option to from_torch for column-wise BFP tilization

### DIFF
--- a/tests/ttnn/unit_tests/operations/matmul/test_matmul.py
+++ b/tests/ttnn/unit_tests/operations/matmul/test_matmul.py
@@ -2912,3 +2912,39 @@ def test_from_torch_col_tilize_validation():
     spec = ttnn.TensorSpec((32, 64), ttnn.bfloat8_b, ttnn.TILE_LAYOUT)
     with pytest.raises(RuntimeError, match="col_tilize=True is not supported with spec"):
         ttnn.from_torch(torch_tensor_2d, spec=spec, col_tilize=True)
+
+
+@pytest.mark.parametrize(
+    "weight_dtype, pcc_threshold",
+    [
+        (ttnn.bfloat8_b, 0.99),
+        (ttnn.bfloat4_b, 0.98),
+    ],
+)
+@pytest.mark.parametrize(
+    "K, N",
+    [
+        (32, 64),
+        (128, 256),
+        (64, 512),
+    ],
+)
+def test_from_torch_col_tilize_matches_manual_transpose(weight_dtype, pcc_threshold, K, N):
+    """Verify that from_torch(..., col_tilize=True) produces the same tensor as
+    manually transposing in torch and then calling from_torch on W^T."""
+    torch.manual_seed(0)
+    torch_W = torch.randn(1, 1, K, N, dtype=torch.bfloat16)
+
+    # col_tilize path
+    tt_col = ttnn.from_torch(torch_W, dtype=weight_dtype, col_tilize=True)
+    result_col = ttnn.to_torch(tt_col)
+
+    # Manual transpose path: torch transpose then from_torch
+    torch_W_T = torch_W.transpose(-1, -2).contiguous()
+    tt_manual = ttnn.from_torch(torch_W_T, dtype=weight_dtype)
+    result_manual = ttnn.to_torch(tt_manual)
+
+    assert (
+        result_col.shape == result_manual.shape
+    ), f"Shape mismatch: col_tilize={result_col.shape} vs manual={result_manual.shape}"
+    assert_with_pcc(result_manual, result_col, pcc=pcc_threshold)

--- a/tests/ttnn/unit_tests/operations/matmul/test_matmul.py
+++ b/tests/ttnn/unit_tests/operations/matmul/test_matmul.py
@@ -2913,6 +2913,10 @@ def test_from_torch_col_tilize_validation():
     with pytest.raises(RuntimeError, match="col_tilize=True is not supported with spec"):
         ttnn.from_torch(torch_tensor_2d, spec=spec, col_tilize=True)
 
+    # col_tilize requires tile layout
+    with pytest.raises(RuntimeError, match="col_tilize=True requires layout to be None or ttnn.TILE_LAYOUT"):
+        ttnn.from_torch(torch_tensor_2d, dtype=ttnn.bfloat8_b, layout=ttnn.ROW_MAJOR_LAYOUT, col_tilize=True)
+
 
 @pytest.mark.parametrize(
     "weight_dtype, pcc_threshold",
@@ -2948,3 +2952,28 @@ def test_from_torch_col_tilize_matches_manual_transpose(weight_dtype, pcc_thresh
         result_col.shape == result_manual.shape
     ), f"Shape mismatch: col_tilize={result_col.shape} vs manual={result_manual.shape}"
     assert_with_pcc(result_manual, result_col, pcc=pcc_threshold)
+
+
+@pytest.mark.parametrize("weight_dtype", [ttnn.bfloat8_b, ttnn.bfloat4_b])
+@pytest.mark.parametrize(
+    "shape",
+    [
+        (64, 32),  # 2D
+        (2, 64, 32),  # 3D with batch
+        (2, 3, 64, 32),  # 4D with batch
+    ],
+)
+def test_from_torch_col_tilize_batched(weight_dtype, shape):
+    """Verify col_tilize works correctly for tensors of various ranks (2D through 4D)."""
+    torch.manual_seed(0)
+    torch_W = torch.randn(shape, dtype=torch.bfloat16)
+
+    tt_col = ttnn.from_torch(torch_W, dtype=weight_dtype, col_tilize=True)
+    result_col = ttnn.to_torch(tt_col)
+
+    torch_W_T = torch_W.transpose(-1, -2).contiguous()
+    tt_manual = ttnn.from_torch(torch_W_T, dtype=weight_dtype)
+    result_manual = ttnn.to_torch(tt_manual)
+
+    assert result_col.shape == result_manual.shape
+    assert_with_pcc(result_manual, result_col, pcc=0.98)

--- a/tests/ttnn/unit_tests/operations/matmul/test_matmul.py
+++ b/tests/ttnn/unit_tests/operations/matmul/test_matmul.py
@@ -2853,3 +2853,62 @@ def test_matmul_on_subdevice_1d_mcast(device, m_size, k_size, n_size):
         assert_with_pcc(torch_output, output, 0.999)
     finally:
         _teardown_subdevice(device, sub_device_manager)
+
+
+@pytest.mark.parametrize(
+    "weight_dtype, pcc_threshold",
+    [
+        (ttnn.bfloat8_b, 0.99),
+        (ttnn.bfloat4_b, 0.98),
+    ],
+)
+@pytest.mark.parametrize(
+    "M, K, N",
+    [
+        (32, 64, 32),
+        (128, 256, 128),
+        (64, 512, 256),
+    ],
+)
+def test_matmul_column_wise_bfp_tilize_via_transpose_b(device, weight_dtype, pcc_threshold, M, K, N):
+    torch.manual_seed(0)
+    torch_A = torch.randn(1, 1, M, K, dtype=torch.bfloat16)
+    torch_W = torch.randn(1, 1, K, N, dtype=torch.bfloat16)
+
+    # Golden in float32
+    golden = torch.matmul(torch_A.float(), torch_W.float())
+
+    # Conventional path: row-wise BFP grouping (along N)
+    tt_A_conv = ttnn.from_torch(torch_A, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
+    tt_W_conv = ttnn.from_torch(torch_W, dtype=weight_dtype, layout=ttnn.TILE_LAYOUT, device=device)
+    result_conv = ttnn.to_torch(ttnn.matmul(tt_A_conv, tt_W_conv))
+
+    # Column-tilize path: use col_tilize=True instead of manual torch transpose
+    tt_A_col = ttnn.from_torch(torch_A, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
+    tt_W_col = ttnn.from_torch(torch_W, dtype=weight_dtype, device=device, col_tilize=True)
+    result_col = ttnn.to_torch(ttnn.matmul(tt_A_col, tt_W_col, transpose_b=True))
+
+    # Both paths should match golden
+    assert_with_pcc(golden, result_conv, pcc=pcc_threshold)
+    assert_with_pcc(golden, result_col, pcc=pcc_threshold)
+
+    # The two paths should match each other
+    assert_with_pcc(result_conv, result_col, pcc=pcc_threshold)
+
+
+def test_from_torch_col_tilize_validation():
+    torch_tensor_2d = torch.randn(32, 64, dtype=torch.bfloat16)
+    torch_tensor_1d = torch.randn(64, dtype=torch.bfloat16)
+
+    # col_tilize requires BFP dtype
+    with pytest.raises(RuntimeError, match="col_tilize=True requires BFP dtype"):
+        ttnn.from_torch(torch_tensor_2d, dtype=ttnn.bfloat16, col_tilize=True)
+
+    # col_tilize requires ndim >= 2
+    with pytest.raises(RuntimeError, match="col_tilize=True requires tensor.ndim >= 2"):
+        ttnn.from_torch(torch_tensor_1d, dtype=ttnn.bfloat8_b, col_tilize=True)
+
+    # col_tilize not supported with spec
+    spec = ttnn.TensorSpec((32, 64), ttnn.bfloat8_b, ttnn.TILE_LAYOUT)
+    with pytest.raises(RuntimeError, match="col_tilize=True is not supported with spec"):
+        ttnn.from_torch(torch_tensor_2d, spec=spec, col_tilize=True)

--- a/tests/ttnn/unit_tests/operations/matmul/test_matmul.py
+++ b/tests/ttnn/unit_tests/operations/matmul/test_matmul.py
@@ -2958,13 +2958,17 @@ def test_from_torch_col_tilize_matches_manual_transpose(weight_dtype, pcc_thresh
 @pytest.mark.parametrize(
     "shape",
     [
-        (64, 32),  # 2D
+        (64, 32),  # 2D, tile-aligned
         (2, 64, 32),  # 3D with batch
         (2, 3, 64, 32),  # 4D with batch
+        (48, 80),  # 2D, non-tile-aligned
+        (1, 1, 50, 70),  # 4D, non-tile-aligned K and N
+        (3, 33, 65),  # 3D, odd non-tile-aligned dims
     ],
 )
 def test_from_torch_col_tilize_batched(weight_dtype, shape):
-    """Verify col_tilize works correctly for tensors of various ranks (2D through 4D)."""
+    """Verify col_tilize works correctly for tensors of various ranks and shapes,
+    including non-tile-aligned dimensions that exercise the padding path."""
     torch.manual_seed(0)
     torch_W = torch.randn(shape, dtype=torch.bfloat16)
 

--- a/ttnn/api/ttnn/tensor/py_to_tt_tensor.hpp
+++ b/ttnn/api/ttnn/tensor/py_to_tt_tensor.hpp
@@ -24,5 +24,6 @@ tt::tt_metal::Tensor convert_python_tensor_to_tt_tensor(
     std::optional<tt::tt_metal::distributed::MeshDevice*> device,
     std::optional<ttnn::QueueId> cq_id,
     const ttnn::distributed::TensorToMesh* mesh_mapper,
-    std::optional<float> pad_value = std::nullopt);
+    std::optional<float> pad_value = std::nullopt,
+    bool col_tilize = false);
 }  // namespace ttnn

--- a/ttnn/core/tensor/py_to_tt_tensor.cpp
+++ b/ttnn/core/tensor/py_to_tt_tensor.cpp
@@ -206,7 +206,8 @@ Tensor convert_python_tensor_to_tt_tensor(
     std::optional<distributed::MeshDevice*> device,
     std::optional<ttnn::QueueId> cq_id,
     const ttnn::distributed::TensorToMesh* mesh_mapper,
-    std::optional<float> pad_value) {
+    std::optional<float> pad_value,
+    bool col_tilize) {
     ZoneScoped;
 
     if (dst_dtype == DataType::BFLOAT8_B || dst_dtype == DataType::BFLOAT4_B) {
@@ -226,12 +227,51 @@ Tensor convert_python_tensor_to_tt_tensor(
 
     auto host_dtype = compute_host_dtype(src_data_type, dst_dtype, memory_config.is_sharded());
     auto host_buffer = get_host_tensor(host_dtype);
+
+    ttnn::Shape effective_shape = tensor_shape;
+    if (col_tilize) {
+        // Transpose the last two dims of the float32 host buffer in-place
+        // so that BFP exponent grouping happens along columns instead of rows.
+        auto rank = tensor_shape.rank();
+        TT_FATAL(rank >= 2, "col_tilize requires tensor rank >= 2, got {}", rank);
+        TT_FATAL(
+            dst_dtype == DataType::BFLOAT8_B || dst_dtype == DataType::BFLOAT4_B,
+            "col_tilize requires BFP dtype (BFLOAT8_B or BFLOAT4_B)");
+
+        const auto K = tensor_shape[-2];
+        const auto N = tensor_shape[-1];
+        size_t batch_size = 1;
+        for (size_t i = 0; i < rank - 2; ++i) {
+            batch_size *= tensor_shape[i];
+        }
+
+        const float* src = host_buffer.view_as<float>().data();
+        std::vector<float> transposed(batch_size * K * N);
+        for (size_t b = 0; b < batch_size; ++b) {
+            for (size_t i = 0; i < static_cast<size_t>(N); ++i) {
+                for (size_t j = 0; j < static_cast<size_t>(K); ++j) {
+                    transposed[b * N * K + i * K + j] = src[b * K * N + j * N + i];
+                }
+            }
+        }
+        host_buffer = HostBuffer(std::move(transposed));
+
+        // Build transposed shape: swap last two dims
+        std::vector<uint32_t> new_dims;
+        for (size_t i = 0; i < rank - 2; ++i) {
+            new_dims.push_back(tensor_shape[i]);
+        }
+        new_dims.push_back(N);
+        new_dims.push_back(K);
+        effective_shape = ttnn::Shape(tt::stl::Span<const uint32_t>(new_dims.data(), new_dims.size()));
+    }
+
     Tensor output = create_tt_tensor_from_host_data(
         host_buffer,
         host_dtype,
         dst_dtype,
         layout,
-        tensor_shape,
+        effective_shape,
         memory_config,
         optional_tile,
         pad_value.value_or(0.0f),

--- a/ttnn/core/tensor/py_to_tt_tensor.cpp
+++ b/ttnn/core/tensor/py_to_tt_tensor.cpp
@@ -230,8 +230,9 @@ Tensor convert_python_tensor_to_tt_tensor(
 
     ttnn::Shape effective_shape = tensor_shape;
     if (col_tilize) {
-        // Transpose the last two dims of the float32 host buffer in-place
-        // so that BFP exponent grouping happens along columns instead of rows.
+        // Transpose the last two dims of the float32 host buffer by creating a new
+        // buffer and replacing host_buffer, so that BFP exponent grouping happens
+        // along columns instead of rows.
         auto rank = tensor_shape.rank();
         TT_FATAL(rank >= 2, "col_tilize requires tensor rank >= 2, got {}", rank);
         TT_FATAL(

--- a/ttnn/core/tensor/py_to_tt_tensor.cpp
+++ b/ttnn/core/tensor/py_to_tt_tensor.cpp
@@ -251,7 +251,7 @@ Tensor convert_python_tensor_to_tt_tensor(
         for (size_t b = 0; b < batch_size; ++b) {
             for (size_t i = 0; i < static_cast<size_t>(N); ++i) {
                 for (size_t j = 0; j < static_cast<size_t>(K); ++j) {
-                    transposed[b * N * K + i * K + j] = src[b * K * N + j * N + i];
+                    transposed[(b * N * K) + (i * K) + j] = src[(b * K * N) + (j * N) + i];
                 }
             }
         }
@@ -259,6 +259,7 @@ Tensor convert_python_tensor_to_tt_tensor(
 
         // Build transposed shape: swap last two dims
         std::vector<uint32_t> new_dims;
+        new_dims.reserve(rank);
         for (size_t i = 0; i < rank - 2; ++i) {
             new_dims.push_back(tensor_shape[i]);
         }

--- a/ttnn/cpp/ttnn-nanobind/pytensor.cpp
+++ b/ttnn/cpp/ttnn-nanobind/pytensor.cpp
@@ -641,7 +641,8 @@ void pytensor_module(nb::module_& mod) {
                const std::optional<Tile>& tile,
                std::optional<ttnn::QueueId> cq_id,
                std::optional<float> pad_value,
-               const distributed::TensorToMesh* mesh_mapper) {
+               const distributed::TensorToMesh* mesh_mapper,
+               bool col_tilize) {
                 auto py_tensor_dtype = dlpack_tensor.dtype();
 
                 // handle bool types by changing them to uint8
@@ -672,7 +673,8 @@ void pytensor_module(nb::module_& mod) {
                     device,
                     cq_id,
                     mesh_mapper,
-                    pad_value));
+                    pad_value,
+                    col_tilize));
             },
             nb::arg("tensor").noconvert(false),
             nb::arg("data_type") = nb::none(),
@@ -683,6 +685,7 @@ void pytensor_module(nb::module_& mod) {
             nb::arg("cq_id") = nb::none(),
             nb::arg("pad_value") = nb::none(),
             nb::arg("mesh_mapper") = nullptr,
+            nb::arg("col_tilize") = false,
             nb::keep_alive<1, 4>(),  // test: matches other k_a
             nb::rv_policy::move,
             R"doc(

--- a/ttnn/cpp/ttnn-nanobind/pytensor.cpp
+++ b/ttnn/cpp/ttnn-nanobind/pytensor.cpp
@@ -710,6 +710,8 @@ void pytensor_module(nb::module_& mod) {
                 +--------------+--------------------------------+
                 | mesh_mapper  | TT-NN Mesh Mapper (optional)    |
                 +--------------+--------------------------------+
+                | col_tilize   | Column-wise BFP tilize (false)  |
+                +--------------+--------------------------------+
 
                 Example of creating a TT Tensor from numpy tensor:
 

--- a/ttnn/ttnn/operations/core.py
+++ b/ttnn/ttnn/operations/core.py
@@ -293,6 +293,8 @@ def from_torch(
             raise RuntimeError("ttnn.from_torch: col_tilize=True requires BFP dtype (bfloat8_b or bfloat4_b)")
         if tensor.ndim < 2:
             raise RuntimeError("ttnn.from_torch: col_tilize=True requires tensor.ndim >= 2")
+        if layout is not None and layout is not ttnn.TILE_LAYOUT:
+            raise RuntimeError("ttnn.from_torch: col_tilize=True requires layout to be None or ttnn.TILE_LAYOUT")
 
     if spec is not None:
         if spec.shape != tensor.shape:

--- a/ttnn/ttnn/operations/core.py
+++ b/ttnn/ttnn/operations/core.py
@@ -274,10 +274,14 @@ def from_torch(
         memory_config (ttnn.MemoryConfig, optional): The desired `ttnn` memory configuration. Defaults to `None`.
         mesh_mapper (ttnn.TensorToMesh, optional): The desired `ttnn` mesh mapper. Defaults to `None`.
         cq_id (int, optional): The command queue ID to use. Defaults to `0`.
-        col_tilize (bool, optional): If True, transpose the last two dimensions before BFP tilization so that
-            exponents are shared along columns instead of rows. Requires BFP dtype (bfloat8_b or bfloat4_b),
-            tensor.ndim >= 2, and spec must be None. The returned tensor has the last two dims swapped.
-            Use with ``transpose_b=True`` in matmul. Defaults to `False`.
+        col_tilize (bool, optional): If True, transpose the last two dimensions of the tensor in host
+            memory (float32) before BFP tile encoding.  In BFP format one exponent byte is shared
+            across 16 consecutive datums within a tile face row; transposing before packing redirects
+            that sharing onto the column dimension of the original tensor.  The returned tensor has
+            shape (..., N, K) instead of (..., K, N).  This transpose is applied to the raw float32
+            host data and is unrelated to Tile-level transpose flags (transpose_within_face /
+            transpose_of_faces).  Requires dtype bfloat8_b or bfloat4_b, tensor.ndim >= 2, spec=None.
+            Defaults to `False`.
 
     Returns:
         ttnn.Tensor | None: A `ttnn.Tensor` created from the input `torch.Tensor`, or `None` if `tensor` is `None`.


### PR DESCRIPTION
### Ticket
N/A

### Problem description
Provide a toggle to permit tilizing weights along columns, instead of rows.

### What's changed
Introduced a new parameter in `ttnn.from_torch(..., col_tilize: bool)` to tilize based on columns instead of rows. 

### CI
- [All post-commit tests run](https://github.com/tenstorrent/tt-metal/actions/runs/22323310363)

### Checklist

- [x] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=jchu/col-tilize)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:jchu/col-tilize)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=jchu/col-tilize)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:jchu/col-tilize)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=jchu/col-tilize)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jchu/col-tilize)
- [x] New/Existing tests provide coverage for changes