### PR TITLE
Updating slice_write tests to use the ttnn.experimental module

### DIFF
--- a/scripts/detect_undocumented_ttnn_ops.py
+++ b/scripts/detect_undocumented_ttnn_ops.py
@@ -66,7 +66,6 @@ SKIPPED_OPS = [
     "ttnn.pearson_correlation_coefficient",  # Internal operation only.
     "ttnn.plus_one",  # Experimental operation, but wrongly registered without ttnn.experimental.
     "ttnn.hang_device_operation",  # Internal operation only.
-    "ttnn.experimental.slice_write",
     "ttnn.tosa_gather",  # TOSA operation omitted for docs.
     "ttnn.tosa_scatter",  # TOSA operation omitted for docs.
 ]

--- a/scripts/detect_undocumented_ttnn_ops.py
+++ b/scripts/detect_undocumented_ttnn_ops.py
@@ -66,7 +66,7 @@ SKIPPED_OPS = [
     "ttnn.pearson_correlation_coefficient",  # Internal operation only.
     "ttnn.plus_one",  # Experimental operation, but wrongly registered without ttnn.experimental.
     "ttnn.hang_device_operation",  # Internal operation only.
-    "ttnn.slice_write",  # Experimental operation, but wrongly registered without ttnn.experimental.
+    "ttnn.experimental.slice_write",
     "ttnn.tosa_gather",  # TOSA operation omitted for docs.
     "ttnn.tosa_scatter",  # TOSA operation omitted for docs.
 ]

--- a/tests/ttnn/nightly/unit_tests/operations/data_movement/test_slice_for_conv.py
+++ b/tests/ttnn/nightly/unit_tests/operations/data_movement/test_slice_for_conv.py
@@ -140,7 +140,7 @@ def test_slice_write_height_sharded(device, dims, slice_dim, slice_size, cores, 
 
         this_ttnn_input = ttnn.to_memory_config(this_ttnn_input, memory_config)
         ends[-1] = ttnn_output.shape[-1]
-        ttnn.slice_write(this_ttnn_input, ttnn_output, begins, ends, strides)
+        ttnn.experimental.slice_write(this_ttnn_input, ttnn_output, begins, ends, strides)
 
     output = ttnn.to_torch(ttnn_output)
     assert_with_pcc(torch_input, output, 0.9999)
@@ -211,7 +211,7 @@ def test_slice_write_width_sharded(device, dims, slice_dim, slice_size, cores, l
 
         this_ttnn_input = ttnn.to_memory_config(this_ttnn_input, memory_config)
         ends[-1] = ttnn_output.shape[-1]
-        ttnn.slice_write(this_ttnn_input, ttnn_output, begins, ends, strides)
+        ttnn.experimental.slice_write(this_ttnn_input, ttnn_output, begins, ends, strides)
 
     output = ttnn.to_torch(ttnn_output)
     assert_with_pcc(torch_input, output, 0.9999)
@@ -281,7 +281,7 @@ def test_slice_write_block_sharded(device, dims, slice_dim, slice_size, core_x, 
         )
 
         this_ttnn_input = ttnn.to_memory_config(this_ttnn_input, memory_config)
-        ttnn.slice_write(this_ttnn_input, ttnn_output, begins, ends, strides)
+        ttnn.experimental.slice_write(this_ttnn_input, ttnn_output, begins, ends, strides)
 
     output = ttnn.to_torch(ttnn_output)
     assert_with_pcc(torch_input, output, 0.9999)

--- a/tests/ttnn/unit_tests/operations/data_movement/test_slice.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_slice.py
@@ -99,7 +99,7 @@ def test_slice_write_four_dim(dims, begins, ends, layout, dtype, device):
     ttnn_output = ttnn.to_memory_config(ttnn_output, ttnn.DRAM_MEMORY_CONFIG)
     ttnn_input = ttnn.from_torch(torch_input, device=device, layout=layout, dtype=ttnn.bfloat16)
     ttnn_input = ttnn.to_memory_config(ttnn_input, ttnn.L1_MEMORY_CONFIG)
-    ttnn.slice_write(ttnn_input, ttnn_output, begins, ends, strides)
+    ttnn.experimental.slice_write(ttnn_input, ttnn_output, begins, ends, strides)
     output = ttnn.to_torch(ttnn_output)
     torch_output[slices[0], slices[1], slices[2], slices[3]] = torch_input
     written_output = output[slices[0], slices[1], slices[2], slices[3]]
@@ -134,7 +134,7 @@ def test_slice_write_copy(device, dims, slice_dim, slice_size, layout):
             )
 
             this_ttnn_input = ttnn.to_memory_config(this_ttnn_input, ttnn.L1_MEMORY_CONFIG)
-            ttnn.slice_write(this_ttnn_input, ttnn_output, begins, ends, strides)
+            ttnn.experimental.slice_write(this_ttnn_input, ttnn_output, begins, ends, strides)
 
     output = ttnn.to_torch(ttnn_output)
     assert_with_pcc(torch_input, output, 0.9999)

--- a/tests/ttnn/unit_tests/operations/data_movement/test_slice_write.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_slice_write.py
@@ -120,7 +120,7 @@ def test_slice_write_nd(rank, layout, device):
     tt_in = ttnn.to_memory_config(tt_in, ttnn.L1_MEMORY_CONFIG)
 
     # Perform the slice write
-    ttnn.slice_write(tt_in, tt_out, begins, ends, strides)
+    ttnn.experimental.slice_write(tt_in, tt_out, begins, ends, strides)
 
     # Compare full tensors and the written region explicitly
     out_host = ttnn.to_torch(tt_out)


### PR DESCRIPTION
### Ticket
N/A

### Problem description
Tests with the ttnn slice_write op were not updated to reflect the changes made to the op in https://github.com/tenstorrent/tt-metal/pull/37815.

### What's changed
Updated all instances of `ttnn.slice_write` to `ttnn.experimental.slice_write`.

### Checklist

- [x] [All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/runs/22113777634)
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/22113755024) compared to [Main Results](https://github.com/tenstorrent/tt-metal/actions/runs/22106188120)
- [ ] [L2 Nightly](https://github.com/tenstorrent/tt-metal/actions/runs/22113735979)
- [x] New/Existing tests provide coverage for changes