### PR TITLE
[QSR] Enable all Neos

### DIFF
--- a/tt_metal/hw/firmware/src/tt-2xx/dm.cc
+++ b/tt_metal/hw/firmware/src/tt-2xx/dm.cc
@@ -90,9 +90,9 @@ void invalidate_trisc_instruction_cache() {
 
 void deassert_trisc() {
     subordinate_sync->allNeo0 = RUN_SYNC_MSG_ALL_INIT;
-    // subordinate_sync->allNeo1 = RUN_SYNC_MSG_ALL_INIT;
-    // subordinate_sync->allNeo2 = RUN_SYNC_MSG_ALL_INIT;
-    // subordinate_sync->allNeo3 = RUN_SYNC_MSG_ALL_INIT;
+    subordinate_sync->allNeo1 = RUN_SYNC_MSG_ALL_INIT;
+    subordinate_sync->allNeo2 = RUN_SYNC_MSG_ALL_INIT;
+    subordinate_sync->allNeo3 = RUN_SYNC_MSG_ALL_INIT;
     deassert_trisc_reset();
 }
 // Definition of the global DFB interface array (declared extern in dataflow_buffer_init.h)
@@ -121,7 +121,10 @@ inline __attribute__((always_inline)) void signal_subordinate_completion() {
 inline void run_triscs(uint32_t enables) {
     // Wait for init_sync_registers to complete. Should always be done by the time we get here.
     DPRINT << "DM-FW: waiting for TRISC0 to complete " << subordinate_sync->neo0_trisc0 << ENDL();
-    while (subordinate_sync->neo0_trisc0 != RUN_SYNC_MSG_DONE) {
+    while (subordinate_sync->allNeo0 != RUN_SYNC_MSG_ALL_SUBORDINATES_DONE ||
+           subordinate_sync->allNeo1 != RUN_SYNC_MSG_ALL_SUBORDINATES_DONE ||
+           subordinate_sync->allNeo2 != RUN_SYNC_MSG_ALL_SUBORDINATES_DONE ||
+           subordinate_sync->allNeo3 != RUN_SYNC_MSG_ALL_SUBORDINATES_DONE) {
         invalidate_l1_cache();
     }
     DPRINT << "DM-FW: running TRISCs " << enables << ENDL();

--- a/tt_metal/hw/firmware/src/tt-2xx/dm.cc
+++ b/tt_metal/hw/firmware/src/tt-2xx/dm.cc
@@ -120,7 +120,7 @@ inline __attribute__((always_inline)) void signal_subordinate_completion() {
 
 inline void run_triscs(uint32_t enables) {
     // Wait for init_sync_registers to complete. Should always be done by the time we get here.
-    DPRINT << "DM-FW: waiting for TRISC0 to complete " << subordinate_sync->neo0_trisc0 << ENDL();
+    DPRINT << "DM-FW: waiting for TRISCs to complete" << ENDL();
     while (subordinate_sync->allNeo0 != RUN_SYNC_MSG_ALL_SUBORDINATES_DONE ||
            subordinate_sync->allNeo1 != RUN_SYNC_MSG_ALL_SUBORDINATES_DONE ||
            subordinate_sync->allNeo2 != RUN_SYNC_MSG_ALL_SUBORDINATES_DONE ||

--- a/tt_metal/hw/firmware/src/tt-2xx/trisc.cc
+++ b/tt_metal/hw/firmware/src/tt-2xx/trisc.cc
@@ -119,7 +119,7 @@ extern "C" uint32_t _start1() {
     *trisc_run = RUN_SYNC_MSG_DONE;
 
     DeviceProfilerInit();
-
+    DPRINT << "TRISC-FW: initialized" << ENDL();
     while (1) {
         WAYPOINT("W");
         while (*trisc_run != RUN_SYNC_MSG_GO) {

--- a/tt_metal/hw/inc/internal/tt-2xx/quasar/core_config.h
+++ b/tt_metal/hw/inc/internal/tt-2xx/quasar/core_config.h
@@ -30,7 +30,15 @@ enum class TensixProcessorTypes : uint8_t {
     E1_MATH1 = 13,
     E1_MATH2 = 14,
     E1_MATH3 = 15,
-    COUNT = 16
+    E2_MATH0 = 16,
+    E2_MATH1 = 17,
+    E2_MATH2 = 18,
+    E2_MATH3 = 19,
+    E3_MATH0 = 20,
+    E3_MATH1 = 21,
+    E3_MATH2 = 22,
+    E3_MATH3 = 23,
+    COUNT = 24
 };
 
 enum class EthProcessorTypes : uint8_t { DM0 = 0, DM1 = 1, COUNT = 2 };

--- a/tt_metal/hw/inc/internal/tt-2xx/quasar/dev_mem_map.h
+++ b/tt_metal/hw/inc/internal/tt-2xx/quasar/dev_mem_map.h
@@ -97,7 +97,7 @@
 #define MEM_MAILBOX_BASE 16
 #define UNCACHED_MEM_MAILBOX_BASE (0x400010)  // workaround for https://github.com/tenstorrent/tt-metal/issues/19265
 // Magic size must be big enough to hold dev_msgs_t.  static_asserts will fire if this is too small
-#define MEM_MAILBOX_SIZE 39408
+#define MEM_MAILBOX_SIZE 57424
 #define MEM_MAILBOX_END (MEM_MAILBOX_BASE + MEM_MAILBOX_SIZE)
 #define MEM_ZEROS_BASE ((MEM_MAILBOX_END + 31) & ~31)
 

--- a/tt_metal/hw/inc/internal/tt-2xx/risc_common.h
+++ b/tt_metal/hw/inc/internal/tt-2xx/risc_common.h
@@ -123,8 +123,12 @@ inline void deassert_trisc_reset() {
     uint32_t soft_reset_0 = READ_REG(NEO_REGS_0__LOCAL_REGS_DEBUG_REGS_SOFT_RESET_0_REG_ADDR);
     uint32_t trisc_reset_mask = T6_DEBUG_REGS_SOFT_RESET_0_RISC_CONTROL_SOFT_RESET_MASK;
     WRITE_REG(NEO_REGS_0__LOCAL_REGS_DEBUG_REGS_SOFT_RESET_0_REG_ADDR, soft_reset_0 & ~trisc_reset_mask);
-    // soft_reset_0 = READ_REG(NEO_REGS_1__LOCAL_REGS_DEBUG_REGS_SOFT_RESET_0_REG_ADDR);
-    // WRITE_REG(NEO_REGS_1__LOCAL_REGS_DEBUG_REGS_SOFT_RESET_0_REG_ADDR, soft_reset_0 & ~trisc_reset_mask);
+    soft_reset_0 = READ_REG(NEO_REGS_1__LOCAL_REGS_DEBUG_REGS_SOFT_RESET_0_REG_ADDR);
+    WRITE_REG(NEO_REGS_1__LOCAL_REGS_DEBUG_REGS_SOFT_RESET_0_REG_ADDR, soft_reset_0 & ~trisc_reset_mask);
+    soft_reset_0 = READ_REG(NEO_REGS_2__LOCAL_REGS_DEBUG_REGS_SOFT_RESET_0_REG_ADDR);
+    WRITE_REG(NEO_REGS_2__LOCAL_REGS_DEBUG_REGS_SOFT_RESET_0_REG_ADDR, soft_reset_0 & ~trisc_reset_mask);
+    soft_reset_0 = READ_REG(NEO_REGS_3__LOCAL_REGS_DEBUG_REGS_SOFT_RESET_0_REG_ADDR);
+    WRITE_REG(NEO_REGS_3__LOCAL_REGS_DEBUG_REGS_SOFT_RESET_0_REG_ADDR, soft_reset_0 & ~trisc_reset_mask);
 }
 
 inline uint32_t special_mult(uint32_t a, uint32_t special_b) {

--- a/tt_metal/llrt/hal.hpp
+++ b/tt_metal/llrt/hal.hpp
@@ -83,7 +83,7 @@ public:
 };
 
 // Compile-time maximum for processor types count for any arch.  Useful for creating bitsets.
-static constexpr int MAX_PROCESSOR_TYPES_COUNT = 8;
+static constexpr int MAX_PROCESSOR_TYPES_COUNT = 24;
 
 // Note: nsidwell will be removing need for fw_base_addr and local_init_addr
 // fw_launch_addr is programmed with fw_launch_addr_value on the master risc

--- a/tt_metal/llrt/hal/tt-2xx/quasar/qa_hal_tensix.cpp
+++ b/tt_metal/llrt/hal/tt-2xx/quasar/qa_hal_tensix.cpp
@@ -161,31 +161,81 @@ HalCoreInfoType create_tensix_mem_map() {
              .fw_launch_addr = 0x0,
              .fw_launch_addr_value = MEM_TRISC3_FIRMWARE_BASE,
              .memory_load = ll_api::memory::Loading::CONTIGUOUS_XIP},
-            // // NEO1
-            // // TRISC0
-            // {.fw_base_addr = MEM_TRISC0_FIRMWARE_BASE,
-            //  .local_init_addr = MEM_TRISC0_INIT_LOCAL_L1_BASE_SCRATCH,
-            //  .fw_launch_addr = 0x0,
-            //  .fw_launch_addr_value = MEM_TRISC0_FIRMWARE_BASE,
-            //  .memory_load = ll_api::memory::Loading::CONTIGUOUS_XIP},
-            // // TRISC1
-            // {.fw_base_addr = MEM_TRISC1_FIRMWARE_BASE,
-            //  .local_init_addr = MEM_TRISC1_INIT_LOCAL_L1_BASE_SCRATCH,
-            //  .fw_launch_addr = 0x0,
-            //  .fw_launch_addr_value = MEM_TRISC1_FIRMWARE_BASE,
-            //  .memory_load = ll_api::memory::Loading::CONTIGUOUS_XIP},
-            // // TRISC2
-            // {.fw_base_addr = MEM_TRISC2_FIRMWARE_BASE,
-            //  .local_init_addr = MEM_TRISC2_INIT_LOCAL_L1_BASE_SCRATCH,
-            //  .fw_launch_addr = 0x0,
-            //  .fw_launch_addr_value = MEM_TRISC2_FIRMWARE_BASE,
-            //  .memory_load = ll_api::memory::Loading::CONTIGUOUS_XIP},
-            // // TRISC3
-            // {.fw_base_addr = MEM_TRISC3_FIRMWARE_BASE,
-            //  .local_init_addr = MEM_TRISC3_INIT_LOCAL_L1_BASE_SCRATCH,
-            //  .fw_launch_addr = 0x0,
-            //  .fw_launch_addr_value = MEM_TRISC3_FIRMWARE_BASE,
-            //  .memory_load = ll_api::memory::Loading::CONTIGUOUS_XIP},
+            // NEO1
+            // TRISC0
+            {.fw_base_addr = MEM_TRISC0_FIRMWARE_BASE,
+             .local_init_addr = MEM_TRISC0_INIT_LOCAL_L1_BASE_SCRATCH,
+             .fw_launch_addr = 0x0,
+             .fw_launch_addr_value = MEM_TRISC0_FIRMWARE_BASE,
+             .memory_load = ll_api::memory::Loading::CONTIGUOUS_XIP},
+            // TRISC1
+            {.fw_base_addr = MEM_TRISC1_FIRMWARE_BASE,
+             .local_init_addr = MEM_TRISC1_INIT_LOCAL_L1_BASE_SCRATCH,
+             .fw_launch_addr = 0x0,
+             .fw_launch_addr_value = MEM_TRISC1_FIRMWARE_BASE,
+             .memory_load = ll_api::memory::Loading::CONTIGUOUS_XIP},
+            // TRISC2
+            {.fw_base_addr = MEM_TRISC2_FIRMWARE_BASE,
+             .local_init_addr = MEM_TRISC2_INIT_LOCAL_L1_BASE_SCRATCH,
+             .fw_launch_addr = 0x0,
+             .fw_launch_addr_value = MEM_TRISC2_FIRMWARE_BASE,
+             .memory_load = ll_api::memory::Loading::CONTIGUOUS_XIP},
+            // TRISC3
+            {.fw_base_addr = MEM_TRISC3_FIRMWARE_BASE,
+             .local_init_addr = MEM_TRISC3_INIT_LOCAL_L1_BASE_SCRATCH,
+             .fw_launch_addr = 0x0,
+             .fw_launch_addr_value = MEM_TRISC3_FIRMWARE_BASE,
+             .memory_load = ll_api::memory::Loading::CONTIGUOUS_XIP},
+            // NEO2
+            // TRISC0
+            {.fw_base_addr = MEM_TRISC0_FIRMWARE_BASE,
+             .local_init_addr = MEM_TRISC0_INIT_LOCAL_L1_BASE_SCRATCH,
+             .fw_launch_addr = 0x0,
+             .fw_launch_addr_value = MEM_TRISC0_FIRMWARE_BASE,
+             .memory_load = ll_api::memory::Loading::CONTIGUOUS_XIP},
+            // TRISC1
+            {.fw_base_addr = MEM_TRISC1_FIRMWARE_BASE,
+             .local_init_addr = MEM_TRISC1_INIT_LOCAL_L1_BASE_SCRATCH,
+             .fw_launch_addr = 0x0,
+             .fw_launch_addr_value = MEM_TRISC1_FIRMWARE_BASE,
+             .memory_load = ll_api::memory::Loading::CONTIGUOUS_XIP},
+            // TRISC2
+            {.fw_base_addr = MEM_TRISC2_FIRMWARE_BASE,
+             .local_init_addr = MEM_TRISC2_INIT_LOCAL_L1_BASE_SCRATCH,
+             .fw_launch_addr = 0x0,
+             .fw_launch_addr_value = MEM_TRISC2_FIRMWARE_BASE,
+             .memory_load = ll_api::memory::Loading::CONTIGUOUS_XIP},
+            // TRISC3
+            {.fw_base_addr = MEM_TRISC3_FIRMWARE_BASE,
+             .local_init_addr = MEM_TRISC3_INIT_LOCAL_L1_BASE_SCRATCH,
+             .fw_launch_addr = 0x0,
+             .fw_launch_addr_value = MEM_TRISC3_FIRMWARE_BASE,
+             .memory_load = ll_api::memory::Loading::CONTIGUOUS_XIP},
+            // // NEO3
+            // TRISC0
+            {.fw_base_addr = MEM_TRISC0_FIRMWARE_BASE,
+             .local_init_addr = MEM_TRISC0_INIT_LOCAL_L1_BASE_SCRATCH,
+             .fw_launch_addr = 0x0,
+             .fw_launch_addr_value = MEM_TRISC0_FIRMWARE_BASE,
+             .memory_load = ll_api::memory::Loading::CONTIGUOUS_XIP},
+            // TRISC1
+            {.fw_base_addr = MEM_TRISC1_FIRMWARE_BASE,
+             .local_init_addr = MEM_TRISC1_INIT_LOCAL_L1_BASE_SCRATCH,
+             .fw_launch_addr = 0x0,
+             .fw_launch_addr_value = MEM_TRISC1_FIRMWARE_BASE,
+             .memory_load = ll_api::memory::Loading::CONTIGUOUS_XIP},
+            // TRISC2
+            {.fw_base_addr = MEM_TRISC2_FIRMWARE_BASE,
+             .local_init_addr = MEM_TRISC2_INIT_LOCAL_L1_BASE_SCRATCH,
+             .fw_launch_addr = 0x0,
+             .fw_launch_addr_value = MEM_TRISC2_FIRMWARE_BASE,
+             .memory_load = ll_api::memory::Loading::CONTIGUOUS_XIP},
+            // TRISC3
+            {.fw_base_addr = MEM_TRISC3_FIRMWARE_BASE,
+             .local_init_addr = MEM_TRISC3_INIT_LOCAL_L1_BASE_SCRATCH,
+             .fw_launch_addr = 0x0,
+             .fw_launch_addr_value = MEM_TRISC3_FIRMWARE_BASE,
+             .memory_load = ll_api::memory::Loading::CONTIGUOUS_XIP},
         },
     };
     std::vector<std::vector<std::pair<std::string, std::string>>> processor_classes_names = {

--- a/tt_metal/llrt/hal/tt-2xx/quasar/qa_hal_tensix.cpp
+++ b/tt_metal/llrt/hal/tt-2xx/quasar/qa_hal_tensix.cpp
@@ -211,7 +211,7 @@ HalCoreInfoType create_tensix_mem_map() {
              .fw_launch_addr = 0x0,
              .fw_launch_addr_value = MEM_TRISC3_FIRMWARE_BASE,
              .memory_load = ll_api::memory::Loading::CONTIGUOUS_XIP},
-            // // NEO3
+            // NEO3
             // TRISC0
             {.fw_base_addr = MEM_TRISC0_FIRMWARE_BASE,
              .local_init_addr = MEM_TRISC0_INIT_LOCAL_L1_BASE_SCRATCH,


### PR DESCRIPTION
### Ticket
N/A

### Problem description
So far only Neo0 was enabled

### What's changed
DM0's FW now deasserts all Neo processors, and host is aware of all existing ones per node. DPRINT is also enabled for all of them

### Checklist

- [x] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=ayaacob/enable_all_neos)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:ayaacob/enable_all_neos)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ayaacob/enable_all_neos)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ayaacob/enable_all_neos)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ayaacob/enable_all_neos)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ayaacob/enable_all_neos)