### PR TITLE
Add standalone Swin-L backbone TTNN implementation

### DIFF
--- a/models/experimental/swin_l/README.md
+++ b/models/experimental/swin_l/README.md
@@ -1,0 +1,127 @@
+# Swin-L Backbone (TTNN)
+
+Standalone, reusable TTNN implementation of the **Swin Transformer Large** backbone.
+Produces 4 multi-scale feature maps (C2–C5), ready for downstream detection/segmentation heads.
+
+## Architecture
+
+| Stage | Blocks | Channels | Heads | Window | Output Scale |
+|-------|--------|----------|-------|--------|-------------|
+| 0     | 2      | 192      | 6     | 12     | H/4 × W/4  |
+| 1     | 2      | 384      | 12    | 12     | H/8 × W/8  |
+| 2     | 18     | 768      | 24    | 12     | H/16 × W/16|
+| 3     | 2      | 1536     | 48    | 12     | H/32 × W/32|
+
+## Quick Start
+
+### 1. Prerequisites
+
+```bash
+source python_env/bin/activate
+pip install --user openmim
+mim install --user mmdet
+export PYTHONPATH=$TT_METAL_HOME:$HOME/.local/lib/python3.10/site-packages
+```
+
+### 2. Checkpoint
+
+Any mmdet checkpoint containing a Swin-L backbone works.
+For example, DINO-5scale:
+
+```bash
+mim download mmdet \
+    --config dino-5scale_swin-l_8xb2-36e_coco \
+    --dest models/experimental/dino_5scale_swin_l/checkpoints/dino_5scale_swin_l
+```
+
+Or set env vars to use a custom checkpoint:
+
+```bash
+export SWIN_L_CONFIG=/path/to/your/config.py
+export SWIN_L_CKPT=/path/to/your/checkpoint.pth
+```
+
+### 3. Usage
+
+```python
+from models.experimental.swin_l.tt import TtSwinLBackbone, load_backbone_weights, compute_attn_masks
+
+# Load weights from any mmdet checkpoint with Swin-L backbone
+params = load_backbone_weights(checkpoint_path, device)
+attn_masks = compute_attn_masks(input_h, input_w, patch_size=4, window_size=12, device=device)
+
+model = TtSwinLBackbone(device, params, attn_masks=attn_masks)
+features = model(input_nchw)  # Returns list of 4 NCHW feature maps
+```
+
+### 4. Run PCC Tests
+
+```bash
+export PYTHONPATH=$TT_METAL_HOME:$HOME/.local/lib/python3.10/site-packages
+
+# All submodule tests
+pytest models/experimental/swin_l/tests/pcc/ -v
+
+# Individual tests
+pytest models/experimental/swin_l/tests/pcc/test_ttnn_backbone.py -v
+pytest models/experimental/swin_l/tests/pcc/test_ttnn_swin_attention.py -v
+pytest models/experimental/swin_l/tests/pcc/test_ttnn_swin_mlp.py -v
+pytest models/experimental/swin_l/tests/pcc/test_ttnn_swin_block.py -v
+pytest models/experimental/swin_l/tests/pcc/test_ttnn_swin_patch_merge.py -v
+```
+
+## PCC Results (bfloat16, DRAM)
+
+### Backbone E2E
+
+| Stage | Channels | PCC   |
+|-------|----------|-------|
+| 0     | 192      | 0.997 |
+| 1     | 384      | 0.997 |
+| 2     | 768      | 0.984 |
+| 3     | 1536     | 0.994 |
+
+### Submodules
+
+| Module       | Test Case         | PCC   |
+|-------------|-------------------|-------|
+| Attention    | no shift          | 0.998 |
+| Attention    | with shift        | 0.999 |
+| MLP (FFN)    | stage 0 block 0   | 0.999 |
+| Block        | s0 b0 (no shift)  | 0.996 |
+| Block        | s0 b1 (shift)     | 1.000 |
+| Block        | s2 b0 (deep)      | 0.999 |
+| PatchMerge   | stage 0           | 1.000 |
+| PatchMerge   | stage 1           | 1.000 |
+
+## File Structure
+
+```
+models/experimental/swin_l/
+├── common.py                          # Swin-L architecture constants
+├── tt/
+│   ├── __init__.py                    # Public API exports
+│   ├── tt_backbone.py                 # TtSwinLBackbone (full model)
+│   ├── tt_swin_attention.py           # TtSwinAttention
+│   ├── tt_swin_mlp.py                 # TtSwinMLP
+│   ├── tt_swin_block.py               # TtSwinBlock
+│   ├── tt_swin_patch_merge.py         # TtSwinPatchMerge
+│   └── model_preprocessing.py         # Weight loading from mmdet checkpoints
+├── reference/
+│   └── swin_l_reference.py            # PyTorch reference (mmdet wrapper)
+├── tests/pcc/
+│   ├── conftest.py                    # Shared fixtures
+│   ├── test_ttnn_backbone.py          # E2E backbone PCC test
+│   ├── test_ttnn_swin_attention.py    # Attention PCC test
+│   ├── test_ttnn_swin_mlp.py          # MLP PCC test
+│   ├── test_ttnn_swin_block.py        # Block PCC test
+│   └── test_ttnn_swin_patch_merge.py  # PatchMerge PCC test
+└── README.md
+```
+
+## Importing in Other Models
+
+```python
+# In your model (e.g., DINO, ATSS, etc.)
+from models.experimental.swin_l.tt import TtSwinLBackbone, load_backbone_weights, compute_attn_masks
+```

--- a/models/experimental/swin_l/__init__.py
+++ b/models/experimental/swin_l/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0

--- a/models/experimental/swin_l/common.py
+++ b/models/experimental/swin_l/common.py
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Common config and constants for the Swin-L backbone.
+Standalone – no dependency on any downstream detection model.
+"""
+
+# Swin-L architecture parameters
+SWIN_L_EMBED_DIM = 192
+SWIN_L_DEPTHS = [2, 2, 18, 2]
+SWIN_L_NUM_HEADS = [6, 12, 24, 48]
+SWIN_L_WINDOW_SIZE = 12
+SWIN_L_STAGE_CHANNELS = [192, 384, 768, 1536]  # C2, C3, C4, C5
+SWIN_L_MLP_RATIO = 4.0
+
+# Default test input size (DINO-5scale uses 800x1333, but any size works)
+DEFAULT_INPUT_H = 800
+DEFAULT_INPUT_W = 1333

--- a/models/experimental/swin_l/reference/__init__.py
+++ b/models/experimental/swin_l/reference/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0

--- a/models/experimental/swin_l/reference/swin_l_reference.py
+++ b/models/experimental/swin_l/reference/swin_l_reference.py
@@ -1,0 +1,133 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+PyTorch reference helpers for Swin-L submodule PCC tests.
+Loads mmdet backbone and provides per-submodule forward functions
+that return (input, output) pairs for comparison with TTNN.
+
+All submodule helpers return tensors in NHWC [B, H, W, C] format
+to match TTNN conventions (except where noted).
+
+Standalone — works with any mmdet checkpoint containing a Swin-L backbone.
+"""
+
+from typing import List, Tuple
+
+import torch
+
+
+def _load_backbone(config_path: str, checkpoint_path: str):
+    """Load mmdet model and return backbone (eval mode, no grad)."""
+    from mmdet.apis import init_detector
+
+    model = init_detector(str(config_path), str(checkpoint_path), device="cpu")
+    model.eval()
+    return model.backbone
+
+
+class SwinLReference:
+    """
+    Wraps mmdet Swin-L backbone and exposes per-submodule forward
+    for PCC testing against TTNN.
+    """
+
+    def __init__(self, config_path: str, checkpoint_path: str):
+        self.backbone = _load_backbone(config_path, checkpoint_path)
+
+    @torch.no_grad()
+    def get_patch_embed_output(self, x: torch.Tensor) -> Tuple[torch.Tensor, Tuple[int, int]]:
+        """
+        Run patch embedding.
+        Input: [B, 3, H, W]
+        Returns: [B, H', W', C] in NHWC format, and (H', W') tuple.
+        """
+        out, hw = self.backbone.patch_embed(x)  # [B, H*W, C]
+        B, N, C = out.shape
+        H, W = hw
+        return out.view(B, H, W, C), (H, W)
+
+    @torch.no_grad()
+    def get_stage_input(self, x: torch.Tensor, target_stage: int) -> Tuple[torch.Tensor, Tuple[int, int]]:
+        """
+        Run backbone up to (but not including) target_stage.
+        Returns the input tensor for that stage in NHWC [B, H, W, C] format.
+        """
+        out, hw = self.backbone.patch_embed(x)
+        out = self.backbone.drop_after_pos(out)
+        H, W = hw
+
+        for s in range(target_stage):
+            stage = self.backbone.stages[s]
+            out, hw, _, _ = stage(out, hw)
+            H, W = hw
+
+        B, N, C = out.shape
+        return out.view(B, H, W, C), (H, W)
+
+    @torch.no_grad()
+    def forward_attention(
+        self, x_nhwc: torch.Tensor, hw: Tuple[int, int], stage_idx: int, block_idx: int
+    ) -> torch.Tensor:
+        """
+        Run one attention sublayer (norm1 -> ShiftWindowMSA) on input.
+        Input/output: [B, H, W, C] NHWC.
+        """
+        B, H, W, C = x_nhwc.shape
+        x_flat = x_nhwc.view(B, H * W, C)
+        blk = self.backbone.stages[stage_idx].blocks[block_idx]
+        normed = blk.norm1(x_flat)
+        attn_out = blk.attn(normed, hw)
+        return attn_out.view(B, H, W, C)
+
+    @torch.no_grad()
+    def forward_ffn(self, x_nhwc: torch.Tensor, hw: Tuple[int, int], stage_idx: int, block_idx: int) -> torch.Tensor:
+        """
+        Run one FFN sublayer (norm2 -> FFN layers only, no identity) on input.
+        Note: mmdet FFN.forward() adds an internal residual (identity + layers(x)).
+        We call .layers directly so this tests just the two linears + GELU,
+        matching our TTNN TtSwinMLP which also has no internal residual.
+        Input/output: [B, H, W, C] NHWC.
+        """
+        B, H, W, C = x_nhwc.shape
+        x_flat = x_nhwc.view(B, H * W, C)
+        blk = self.backbone.stages[stage_idx].blocks[block_idx]
+        normed = blk.norm2(x_flat)
+        ffn_out = blk.ffn.layers(normed)  # layers only, skip identity addition
+        return ffn_out.view(B, H, W, C)
+
+    @torch.no_grad()
+    def forward_block(self, x_nhwc: torch.Tensor, hw: Tuple[int, int], stage_idx: int, block_idx: int) -> torch.Tensor:
+        """
+        Run one full Swin block via the actual mmdet block forward.
+        Input/output: [B, H, W, C] NHWC.
+        """
+        B, H, W, C = x_nhwc.shape
+        x_flat = x_nhwc.view(B, H * W, C)
+        blk = self.backbone.stages[stage_idx].blocks[block_idx]
+        out = blk(x_flat, hw)
+        return out.view(B, H, W, C)
+
+    @torch.no_grad()
+    def forward_patch_merge(
+        self, x_nhwc: torch.Tensor, hw: Tuple[int, int], stage_idx: int
+    ) -> Tuple[torch.Tensor, Tuple[int, int]]:
+        """
+        Run patch merging (downsample) at end of stage_idx.
+        Input: [B, H, W, C] NHWC.
+        Returns: [B, H', W', C'] NHWC, (H', W').
+        """
+        B, H, W, C = x_nhwc.shape
+        x_flat = x_nhwc.view(B, H * W, C)
+        ds = self.backbone.stages[stage_idx].downsample
+        out, new_hw = ds(x_flat, hw)
+        nH, nW = new_hw
+        return out.view(B, nH, nW, out.shape[-1]), new_hw
+
+    @torch.no_grad()
+    def forward_backbone(self, x: torch.Tensor) -> List[torch.Tensor]:
+        """
+        Full backbone forward. Returns list of 4 NCHW feature maps.
+        """
+        feats = self.backbone(x)
+        return list(feats)

--- a/models/experimental/swin_l/tests/__init__.py
+++ b/models/experimental/swin_l/tests/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0

--- a/models/experimental/swin_l/tests/pcc/__init__.py
+++ b/models/experimental/swin_l/tests/pcc/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0

--- a/models/experimental/swin_l/tests/pcc/conftest.py
+++ b/models/experimental/swin_l/tests/pcc/conftest.py
@@ -1,0 +1,76 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Shared fixtures for standalone Swin-L PCC tests.
+
+By default, uses the DINO-5scale Swin-L checkpoint (any mmdet checkpoint
+with a Swin-L backbone works). Override with environment variables:
+  SWIN_L_CONFIG  — path to mmdet config file
+  SWIN_L_CKPT    — path to mmdet checkpoint file
+"""
+
+import os
+from pathlib import Path
+
+import pytest
+
+
+def _mmdet_importable():
+    try:
+        from mmdet.apis import init_detector  # noqa: F401
+
+        return True
+    except ImportError:
+        return False
+
+
+def _get_config_and_checkpoint():
+    """Resolve config and checkpoint paths, with env-var overrides."""
+    base = Path(os.environ.get("TT_METAL_HOME", Path.cwd()))
+
+    config = os.environ.get(
+        "SWIN_L_CONFIG",
+        str(base / "models/experimental/dino_5scale_swin_l/references/dino_5scale_swin_l.py"),
+    )
+
+    ckpt = os.environ.get("SWIN_L_CKPT", "")
+    if not ckpt:
+        ckpt_dir = base / "models/experimental/dino_5scale_swin_l/checkpoints/dino_5scale_swin_l"
+        ckpt_path = ckpt_dir / "dino_5scale_swin_l.pth"
+        if not ckpt_path.is_file():
+            ckpt_path = ckpt_dir / "dino-5scale_swin-l_8xb2-36e_coco-5486e051.pth"
+        ckpt = str(ckpt_path)
+
+    return str(config), ckpt
+
+
+MMDET_SKIP = "mmdet not importable; export PYTHONPATH=/home/ubuntu/tt-metal:$HOME/.local/lib/python3.10/site-packages"
+CKPT_SKIP = (
+    "Checkpoint not found. Either:\n"
+    "  1) Set SWIN_L_CKPT env var, or\n"
+    "  2) Download DINO-5scale: mim download mmdet --config dino-5scale_swin-l_8xb2-36e_coco "
+    "--dest models/experimental/dino_5scale_swin_l/checkpoints/dino_5scale_swin_l"
+)
+
+
+@pytest.fixture(scope="module")
+def swin_l_ref():
+    """Module-scoped PyTorch Swin-L reference (loaded once, shared across tests)."""
+    if not _mmdet_importable():
+        pytest.skip(MMDET_SKIP)
+    config_path, ckpt_path = _get_config_and_checkpoint()
+    if not Path(ckpt_path).is_file():
+        pytest.skip(CKPT_SKIP)
+    from models.experimental.swin_l.reference.swin_l_reference import SwinLReference
+
+    return SwinLReference(config_path, ckpt_path)
+
+
+@pytest.fixture(scope="module")
+def swin_l_ckpt_path():
+    """Return checkpoint path string."""
+    _, ckpt_path = _get_config_and_checkpoint()
+    if not Path(ckpt_path).is_file():
+        pytest.skip(CKPT_SKIP)
+    return ckpt_path

--- a/models/experimental/swin_l/tests/pcc/test_ttnn_backbone.py
+++ b/models/experimental/swin_l/tests/pcc/test_ttnn_backbone.py
@@ -1,0 +1,98 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+PCC test: TTNN Swin-L backbone (e2e) vs PyTorch reference.
+Tests the complete 4-stage backbone producing 4 multi-scale feature maps.
+
+This is a standalone, reusable Swin-L backbone test — anyone wanting to
+verify the TTNN Swin-L implementation can run this.
+
+Run with:
+  export PYTHONPATH=/home/ubuntu/tt-metal:$HOME/.local/lib/python3.10/site-packages
+  pytest models/experimental/swin_l/tests/pcc/test_ttnn_backbone.py -v
+"""
+
+import pytest
+import torch
+import ttnn
+
+from models.common.utility_functions import comp_pcc
+from models.experimental.swin_l.common import (
+    DEFAULT_INPUT_H,
+    DEFAULT_INPUT_W,
+    SWIN_L_EMBED_DIM,
+    SWIN_L_DEPTHS,
+    SWIN_L_NUM_HEADS,
+    SWIN_L_WINDOW_SIZE,
+    SWIN_L_STAGE_CHANNELS,
+)
+from loguru import logger
+
+
+@pytest.mark.parametrize("device_params", [{"l1_small_size": 32768}], indirect=True)
+def test_ttnn_swin_l_backbone_e2e(device, swin_l_ref, swin_l_ckpt_path, reset_seeds):
+    """
+    Full Swin-L backbone: 4 stages -> 4 multi-scale NCHW feature maps.
+    Compares each stage output against PyTorch mmdet reference.
+
+    PCC results (bfloat16, DRAM):
+      Stage 0: ~0.997  (C2: 192 channels)
+      Stage 1: ~0.997  (C3: 384 channels)
+      Stage 2: ~0.982  (C4: 768 channels)
+      Stage 3: ~0.993  (C5: 1536 channels)
+    """
+    from models.experimental.swin_l.tt.tt_backbone import TtSwinLBackbone
+    from models.experimental.swin_l.tt.model_preprocessing import (
+        load_backbone_weights,
+        compute_attn_masks,
+    )
+
+    # --- PyTorch reference ---
+    torch_input = torch.rand(1, 3, DEFAULT_INPUT_H, DEFAULT_INPUT_W)
+    torch_feats = swin_l_ref.forward_backbone(torch_input)
+    assert len(torch_feats) == 4
+
+    # --- TTNN model ---
+    parameters = load_backbone_weights(
+        swin_l_ckpt_path,
+        device,
+        embed_dim=SWIN_L_EMBED_DIM,
+        depths=tuple(SWIN_L_DEPTHS),
+        num_heads=tuple(SWIN_L_NUM_HEADS),
+        window_size=SWIN_L_WINDOW_SIZE,
+    )
+    attn_masks = compute_attn_masks(DEFAULT_INPUT_H, DEFAULT_INPUT_W, 4, SWIN_L_WINDOW_SIZE, device)
+    ttnn_model = TtSwinLBackbone(
+        device,
+        parameters,
+        embed_dim=SWIN_L_EMBED_DIM,
+        depths=tuple(SWIN_L_DEPTHS),
+        num_heads=tuple(SWIN_L_NUM_HEADS),
+        window_size=SWIN_L_WINDOW_SIZE,
+        attn_masks=attn_masks,
+    )
+
+    ttnn_input = ttnn.from_torch(
+        torch_input,
+        dtype=ttnn.bfloat16,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        device=device,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+    ttnn_feats = ttnn_model(ttnn_input)
+    assert len(ttnn_feats) == 4
+
+    # --- Compare per-stage ---
+    pcc_threshold = 0.97
+    for i, (torch_feat, ttnn_feat) in enumerate(zip(torch_feats, ttnn_feats)):
+        ttnn_out = ttnn.to_torch(ttnn.from_device(ttnn_feat))
+        assert (
+            ttnn_out.shape == torch_feat.shape
+        ), f"Stage {i} shape mismatch: TTNN {ttnn_out.shape} vs PyTorch {torch_feat.shape}"
+        passing, pcc_val = comp_pcc(torch_feat, ttnn_out, pcc_threshold)
+        logger.info(
+            f"Stage {i}: shape={list(torch_feat.shape)}, "
+            f"channels={SWIN_L_STAGE_CHANNELS[i]}, PCC={pcc_val:.6f}, pass={passing}"
+        )
+        assert passing, f"Stage {i} PCC {pcc_val:.6f} < {pcc_threshold}"

--- a/models/experimental/swin_l/tests/pcc/test_ttnn_swin_attention.py
+++ b/models/experimental/swin_l/tests/pcc/test_ttnn_swin_attention.py
@@ -1,0 +1,77 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+PCC test: TTNN Swin-L shifted window attention vs PyTorch reference.
+Tests attention at stage 0 block 0 (no shift) and block 1 (with shift).
+"""
+
+import pytest
+import torch
+import ttnn
+
+from models.common.utility_functions import comp_pcc
+from models.experimental.swin_l.common import (
+    DEFAULT_INPUT_H,
+    DEFAULT_INPUT_W,
+    SWIN_L_EMBED_DIM,
+    SWIN_L_NUM_HEADS,
+    SWIN_L_WINDOW_SIZE,
+)
+from loguru import logger
+
+
+@pytest.mark.parametrize("device_params", [{"l1_small_size": 32768}], indirect=True)
+@pytest.mark.parametrize("block_idx", [0, 1], ids=["no_shift", "with_shift"])
+def test_ttnn_swin_attention_pcc(device, swin_l_ref, swin_l_ckpt_path, block_idx, reset_seeds):
+    """Compare TTNN attention output vs PyTorch at stage 0."""
+    from models.experimental.swin_l.tt.tt_swin_attention import TtSwinAttention
+    from models.experimental.swin_l.tt.model_preprocessing import (
+        load_backbone_weights,
+        compute_attn_masks,
+    )
+
+    stage_idx = 0
+    ws = SWIN_L_WINDOW_SIZE
+
+    # Get PyTorch input (output of patch_embed)
+    torch_input = torch.rand(1, 3, DEFAULT_INPUT_H, DEFAULT_INPUT_W)
+    x_nhwc, hw = swin_l_ref.get_patch_embed_output(torch_input)
+
+    # PyTorch reference attention
+    torch_out = swin_l_ref.forward_attention(x_nhwc, hw, stage_idx, block_idx)
+
+    # TTNN
+    params = load_backbone_weights(swin_l_ckpt_path, device)
+    attn_masks = compute_attn_masks(DEFAULT_INPUT_H, DEFAULT_INPUT_W, 4, ws, device)
+    block_params = params["stages"][stage_idx]["blocks"][block_idx]
+
+    shift = [0, 0] if block_idx % 2 == 0 else [ws // 2, ws // 2]
+    ttnn_attn = TtSwinAttention(
+        device,
+        block_params["attn"],
+        dim=SWIN_L_EMBED_DIM,
+        window_size=[ws, ws],
+        shift_size=shift,
+        num_heads=SWIN_L_NUM_HEADS[stage_idx],
+        attn_mask=attn_masks[stage_idx],
+    )
+
+    # Apply norm1 first (same as reference does)
+    ttnn_x = ttnn.from_torch(
+        x_nhwc, dtype=ttnn.bfloat16, layout=ttnn.ROW_MAJOR_LAYOUT, device=device, memory_config=ttnn.DRAM_MEMORY_CONFIG
+    )
+    ttnn_x = ttnn.to_layout(ttnn_x, ttnn.TILE_LAYOUT, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+    ttnn_normed = ttnn.layer_norm(
+        ttnn_x,
+        weight=block_params["norm1"]["weight"],
+        bias=block_params["norm1"]["bias"],
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+    ttnn_normed = ttnn.to_layout(ttnn_normed, ttnn.ROW_MAJOR_LAYOUT, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+    ttnn_out = ttnn_attn(ttnn_normed)
+
+    result = ttnn.to_torch(ttnn.from_device(ttnn_out))
+    passing, pcc_val = comp_pcc(torch_out, result, 0.97)
+    logger.info(f"Attention stage={stage_idx} block={block_idx}: PCC={pcc_val:.6f}")
+    assert passing, f"Attention PCC {pcc_val:.6f} < 0.97"

--- a/models/experimental/swin_l/tests/pcc/test_ttnn_swin_block.py
+++ b/models/experimental/swin_l/tests/pcc/test_ttnn_swin_block.py
@@ -1,0 +1,81 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+PCC test: TTNN Swin-L transformer block vs PyTorch reference.
+Tests full block (LN -> attention -> residual -> LN -> FFN -> residual).
+"""
+
+import pytest
+import torch
+import ttnn
+
+from models.common.utility_functions import comp_pcc
+from models.experimental.swin_l.common import (
+    DEFAULT_INPUT_H,
+    DEFAULT_INPUT_W,
+    SWIN_L_EMBED_DIM,
+    SWIN_L_NUM_HEADS,
+    SWIN_L_WINDOW_SIZE,
+)
+from loguru import logger
+
+
+@pytest.mark.parametrize("device_params", [{"l1_small_size": 32768}], indirect=True)
+@pytest.mark.parametrize(
+    "stage_idx,block_idx",
+    [(0, 0), (0, 1), (2, 0)],
+    ids=["s0_b0_no_shift", "s0_b1_shift", "s2_b0_deep"],
+)
+def test_ttnn_swin_block_pcc(device, swin_l_ref, swin_l_ckpt_path, stage_idx, block_idx, reset_seeds):
+    """Compare TTNN Swin block output vs PyTorch."""
+    from models.experimental.swin_l.tt.tt_swin_block import TtSwinBlock
+    from models.experimental.swin_l.tt.model_preprocessing import (
+        load_backbone_weights,
+        compute_attn_masks,
+    )
+
+    ws = SWIN_L_WINDOW_SIZE
+
+    # Get input for the target stage
+    torch_input = torch.rand(1, 3, DEFAULT_INPUT_H, DEFAULT_INPUT_W)
+    x_nhwc, hw = swin_l_ref.get_stage_input(torch_input, target_stage=stage_idx)
+
+    # If block_idx > 0, run preceding blocks to get the right input
+    B, H, W, C = x_nhwc.shape
+    x_flat = x_nhwc.view(B, H * W, C)
+    with torch.no_grad():
+        stage = swin_l_ref.backbone.stages[stage_idx]
+        for b in range(block_idx):
+            x_flat = stage.blocks[b](x_flat, hw)
+    x_nhwc = x_flat.view(B, H, W, C)
+
+    # PyTorch reference block
+    torch_out = swin_l_ref.forward_block(x_nhwc, hw, stage_idx, block_idx)
+
+    # TTNN
+    params = load_backbone_weights(swin_l_ckpt_path, device)
+    attn_masks = compute_attn_masks(DEFAULT_INPUT_H, DEFAULT_INPUT_W, 4, ws, device)
+    dim = SWIN_L_EMBED_DIM * (2**stage_idx)
+    shift = [0, 0] if block_idx % 2 == 0 else [ws // 2, ws // 2]
+
+    ttnn_block = TtSwinBlock(
+        device,
+        params["stages"][stage_idx]["blocks"][block_idx],
+        dim=dim,
+        num_heads=SWIN_L_NUM_HEADS[stage_idx],
+        window_size=[ws, ws],
+        shift_size=shift,
+        attn_mask=attn_masks[stage_idx],
+    )
+
+    ttnn_x = ttnn.from_torch(
+        x_nhwc, dtype=ttnn.bfloat16, layout=ttnn.ROW_MAJOR_LAYOUT, device=device, memory_config=ttnn.DRAM_MEMORY_CONFIG
+    )
+    ttnn_x = ttnn.to_layout(ttnn_x, ttnn.TILE_LAYOUT, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+    ttnn_out = ttnn_block(ttnn_x)
+
+    result = ttnn.to_torch(ttnn.from_device(ttnn_out))
+    passing, pcc_val = comp_pcc(torch_out, result, 0.97)
+    logger.info(f"Block stage={stage_idx} block={block_idx}: PCC={pcc_val:.6f}")
+    assert passing, f"Block PCC {pcc_val:.6f} < 0.97"

--- a/models/experimental/swin_l/tests/pcc/test_ttnn_swin_mlp.py
+++ b/models/experimental/swin_l/tests/pcc/test_ttnn_swin_mlp.py
@@ -1,0 +1,59 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+PCC test: TTNN Swin-L MLP (FFN) vs PyTorch reference.
+Tests FFN at stage 0 block 0.
+"""
+
+import pytest
+import torch
+import ttnn
+
+from models.common.utility_functions import comp_pcc
+from models.experimental.swin_l.common import (
+    DEFAULT_INPUT_H,
+    DEFAULT_INPUT_W,
+    SWIN_L_EMBED_DIM,
+)
+from loguru import logger
+
+
+@pytest.mark.parametrize("device_params", [{"l1_small_size": 32768}], indirect=True)
+def test_ttnn_swin_mlp_pcc(device, swin_l_ref, swin_l_ckpt_path, reset_seeds):
+    """Compare TTNN MLP output vs PyTorch at stage 0 block 0."""
+    from models.experimental.swin_l.tt.tt_swin_mlp import TtSwinMLP
+    from models.experimental.swin_l.tt.model_preprocessing import load_backbone_weights
+
+    stage_idx, block_idx = 0, 0
+
+    # Get input
+    torch_input = torch.rand(1, 3, DEFAULT_INPUT_H, DEFAULT_INPUT_W)
+    x_nhwc, hw = swin_l_ref.get_patch_embed_output(torch_input)
+
+    # PyTorch reference FFN
+    torch_out = swin_l_ref.forward_ffn(x_nhwc, hw, stage_idx, block_idx)
+
+    # TTNN
+    params = load_backbone_weights(swin_l_ckpt_path, device)
+    block_params = params["stages"][stage_idx]["blocks"][block_idx]
+
+    ttnn_mlp = TtSwinMLP(device, block_params["mlp"], dim=SWIN_L_EMBED_DIM, mlp_ratio=4.0)
+
+    # Apply norm2 first (same as reference)
+    ttnn_x = ttnn.from_torch(
+        x_nhwc, dtype=ttnn.bfloat16, layout=ttnn.ROW_MAJOR_LAYOUT, device=device, memory_config=ttnn.DRAM_MEMORY_CONFIG
+    )
+    ttnn_x = ttnn.to_layout(ttnn_x, ttnn.TILE_LAYOUT, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+    ttnn_normed = ttnn.layer_norm(
+        ttnn_x,
+        weight=block_params["norm2"]["weight"],
+        bias=block_params["norm2"]["bias"],
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+    ttnn_out = ttnn_mlp(ttnn_normed)
+
+    result = ttnn.to_torch(ttnn.from_device(ttnn_out))
+    passing, pcc_val = comp_pcc(torch_out, result, 0.97)
+    logger.info(f"MLP stage={stage_idx} block={block_idx}: PCC={pcc_val:.6f}")
+    assert passing, f"MLP PCC {pcc_val:.6f} < 0.97"

--- a/models/experimental/swin_l/tests/pcc/test_ttnn_swin_patch_merge.py
+++ b/models/experimental/swin_l/tests/pcc/test_ttnn_swin_patch_merge.py
@@ -1,0 +1,62 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+PCC test: TTNN Swin-L patch merging (downsample) vs PyTorch reference.
+Tests downsample at end of stage 0 and stage 1.
+"""
+
+import pytest
+import torch
+import ttnn
+
+from models.common.utility_functions import comp_pcc
+from models.experimental.swin_l.common import (
+    DEFAULT_INPUT_H,
+    DEFAULT_INPUT_W,
+    SWIN_L_EMBED_DIM,
+)
+from loguru import logger
+
+
+@pytest.mark.parametrize("device_params", [{"l1_small_size": 32768}], indirect=True)
+@pytest.mark.parametrize("stage_idx", [0, 1], ids=["stage0_ds", "stage1_ds"])
+def test_ttnn_swin_patch_merge_pcc(device, swin_l_ref, swin_l_ckpt_path, stage_idx, reset_seeds):
+    """Compare TTNN patch merge output vs PyTorch."""
+    from models.experimental.swin_l.tt.tt_swin_patch_merge import TtSwinPatchMerge
+    from models.experimental.swin_l.tt.model_preprocessing import load_backbone_weights
+
+    # Get input: output of all blocks in target stage (before downsample)
+    torch_input = torch.rand(1, 3, DEFAULT_INPUT_H, DEFAULT_INPUT_W)
+    x_nhwc, hw = swin_l_ref.get_stage_input(torch_input, target_stage=stage_idx)
+
+    # Run all blocks in the stage to get the pre-downsample tensor
+    B, H, W, C = x_nhwc.shape
+    x_flat = x_nhwc.view(B, H * W, C)
+    with torch.no_grad():
+        stage = swin_l_ref.backbone.stages[stage_idx]
+        for blk in stage.blocks:
+            x_flat = blk(x_flat, hw)
+    pre_ds_nhwc = x_flat.view(B, H, W, C)
+
+    # PyTorch reference patch merge
+    torch_out, new_hw = swin_l_ref.forward_patch_merge(pre_ds_nhwc, hw, stage_idx)
+
+    # TTNN
+    params = load_backbone_weights(swin_l_ckpt_path, device)
+    dim = SWIN_L_EMBED_DIM * (2**stage_idx)
+    ttnn_ds = TtSwinPatchMerge(device, params["stages"][stage_idx]["downsample"], dim=dim)
+
+    ttnn_x = ttnn.from_torch(
+        pre_ds_nhwc,
+        dtype=ttnn.bfloat16,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        device=device,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+    ttnn_out = ttnn_ds(ttnn_x)
+
+    result = ttnn.to_torch(ttnn.from_device(ttnn_out))
+    passing, pcc_val = comp_pcc(torch_out, result, 0.97)
+    logger.info(f"PatchMerge stage={stage_idx}: out_shape={list(torch_out.shape)}, PCC={pcc_val:.6f}")
+    assert passing, f"PatchMerge PCC {pcc_val:.6f} < 0.97"

--- a/models/experimental/swin_l/tt/__init__.py
+++ b/models/experimental/swin_l/tt/__init__.py
@@ -1,0 +1,9 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+from models.experimental.swin_l.tt.tt_swin_attention import TtSwinAttention
+from models.experimental.swin_l.tt.tt_swin_mlp import TtSwinMLP
+from models.experimental.swin_l.tt.tt_swin_block import TtSwinBlock
+from models.experimental.swin_l.tt.tt_swin_patch_merge import TtSwinPatchMerge
+from models.experimental.swin_l.tt.tt_backbone import TtSwinLBackbone
+from models.experimental.swin_l.tt.model_preprocessing import load_backbone_weights, compute_attn_masks

--- a/models/experimental/swin_l/tt/model_preprocessing.py
+++ b/models/experimental/swin_l/tt/model_preprocessing.py
@@ -1,0 +1,273 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Weight loading and preprocessing for Swin-L backbone.
+Loads from mmdet checkpoint and converts to TTNN parameter dict.
+
+Works with any mmdet checkpoint that contains a Swin-L backbone
+(e.g., DINO-5scale, ATSS-DyHead, etc.).
+
+mmdet checkpoint key structure (backbone only):
+  backbone.patch_embed.projection.{weight,bias}
+  backbone.patch_embed.norm.{weight,bias}
+  backbone.stages.{s}.blocks.{b}.norm1.{weight,bias}
+  backbone.stages.{s}.blocks.{b}.norm2.{weight,bias}
+  backbone.stages.{s}.blocks.{b}.attn.w_msa.qkv.{weight,bias}
+  backbone.stages.{s}.blocks.{b}.attn.w_msa.proj.{weight,bias}
+  backbone.stages.{s}.blocks.{b}.attn.w_msa.relative_position_bias_table  [529, heads]
+  backbone.stages.{s}.blocks.{b}.attn.w_msa.relative_position_index       [144, 144]
+  backbone.stages.{s}.blocks.{b}.ffn.layers.0.0.{weight,bias}   (MLP fc1)
+  backbone.stages.{s}.blocks.{b}.ffn.layers.1.{weight,bias}     (MLP fc2)
+  backbone.stages.{s}.downsample.norm.{weight,bias}
+  backbone.stages.{s}.downsample.reduction.weight
+  backbone.norm{s}.{weight,bias}                                  (per-stage output norms)
+"""
+
+from typing import Dict, List, Optional, Tuple
+
+import torch
+import ttnn
+
+
+def _get(sd: dict, key: str) -> torch.Tensor:
+    """Get a key from state_dict, raising a clear error if missing."""
+    if key not in sd:
+        raise KeyError(f"Missing key in checkpoint: {key}")
+    return sd[key]
+
+
+def _to_ttnn_linear_weight(weight: torch.Tensor, dtype=ttnn.bfloat16) -> ttnn.Tensor:
+    """Transpose [out, in] -> [in, out] and convert to TTNN tile layout."""
+    return ttnn.from_torch(weight.T.contiguous(), dtype=dtype, layout=ttnn.TILE_LAYOUT)
+
+
+def _to_ttnn_linear_bias(bias: torch.Tensor, dtype=ttnn.bfloat16) -> ttnn.Tensor:
+    """Reshape [out] -> [1, out] and convert to TTNN tile layout."""
+    return ttnn.from_torch(bias.reshape(1, -1), dtype=dtype, layout=ttnn.TILE_LAYOUT)
+
+
+def _to_ttnn_norm_param(param: torch.Tensor, dtype=ttnn.bfloat16) -> ttnn.Tensor:
+    """Reshape [C] -> [1, C] and convert to TTNN tile layout."""
+    return ttnn.from_torch(param.reshape(1, -1), dtype=dtype, layout=ttnn.TILE_LAYOUT)
+
+
+def _compute_relative_position_bias(
+    bias_table: torch.Tensor,
+    bias_index: torch.Tensor,
+    window_size: int,
+) -> ttnn.Tensor:
+    """
+    Precompute relative position bias from table + index.
+    Returns: ttnn tensor [1, num_heads, win*win, win*win] in TILE layout.
+    """
+    N = window_size * window_size
+    rpb = bias_table[bias_index.view(-1).long()]  # [N*N, heads]
+    rpb = rpb.view(N, N, -1).permute(2, 0, 1).contiguous().unsqueeze(0)  # [1, heads, N, N]
+    return ttnn.from_torch(rpb, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT)
+
+
+def _unfold_to_concat_perm(C: int) -> torch.Tensor:
+    """
+    Build permutation to reorder PatchMerging weights from mmdet's nn.Unfold
+    channel ordering to our stride-slice concat ordering.
+
+    mmdet Unfold order (per spatial pos): [ch0_tl, ch0_tr, ch0_bl, ch0_br, ch1_tl, ...]
+    Our concat order: [all_tl (0..C-1), all_bl (C..2C-1), all_tr (2C..3C-1), all_br (3C..4C-1)]
+
+    Returns a 4C index tensor such that: weight_reordered[:, j] = weight[:, perm[j]]
+    """
+    perm = torch.zeros(4 * C, dtype=torch.long)
+    for j in range(C):
+        perm[j] = j * 4 + 0  # tl -> unfold index c*4+0
+        perm[C + j] = j * 4 + 2  # bl -> unfold index c*4+2
+        perm[2 * C + j] = j * 4 + 1  # tr -> unfold index c*4+1
+        perm[3 * C + j] = j * 4 + 3  # br -> unfold index c*4+3
+    return perm
+
+
+def load_backbone_weights(
+    checkpoint_path: str,
+    device: ttnn.Device,
+    embed_dim: int = 192,
+    depths: Tuple[int, ...] = (2, 2, 18, 2),
+    num_heads: Tuple[int, ...] = (6, 12, 24, 48),
+    window_size: int = 12,
+    out_indices: Tuple[int, ...] = (0, 1, 2, 3),
+) -> dict:
+    """
+    Load backbone weights from mmdet checkpoint and return TTNN parameter dict.
+
+    Works with any mmdet checkpoint containing a Swin-L backbone.
+    Only loads per-stage output norms for stages in `out_indices`
+    (e.g., ATSS checkpoint won't have norm0 when out_indices=(1,2,3)).
+
+    Returns nested dict matching the structure expected by TtSwinLBackbone:
+      {
+        "patch_embed": {"projection": {"weight", "bias"}, "norm": {"weight", "bias"}},
+        "stages": {s: {"blocks": {b: {...}}, "downsample": {...}}},
+        "norm{s}": {"weight", "bias"} for s in out_indices,
+      }
+    """
+    ckpt = torch.load(checkpoint_path, map_location="cpu")
+    sd = ckpt.get("state_dict", ckpt)
+
+    params: Dict = {}
+
+    # -- Patch embedding --
+    params["patch_embed"] = {
+        "projection": {
+            "weight": ttnn.from_torch(_get(sd, "backbone.patch_embed.projection.weight"), dtype=ttnn.bfloat16),
+            "bias": ttnn.from_torch(
+                _get(sd, "backbone.patch_embed.projection.bias").reshape(1, 1, 1, -1), dtype=ttnn.bfloat16
+            ),
+        },
+        "norm": {
+            "weight": _to_ttnn_norm_param(_get(sd, "backbone.patch_embed.norm.weight")),
+            "bias": _to_ttnn_norm_param(_get(sd, "backbone.patch_embed.norm.bias")),
+        },
+    }
+
+    # -- Stages --
+    params["stages"] = {}
+    for s in range(4):
+        dim = embed_dim * (2**s)
+        heads = num_heads[s]
+        params["stages"][s] = {"blocks": {}}
+
+        for b in range(depths[s]):
+            prefix = f"backbone.stages.{s}.blocks.{b}"
+
+            # Relative position bias (precomputed on CPU)
+            rpb_table = _get(sd, f"{prefix}.attn.w_msa.relative_position_bias_table")
+            rpb_index = _get(sd, f"{prefix}.attn.w_msa.relative_position_index")
+            rpb = _compute_relative_position_bias(rpb_table, rpb_index, window_size)
+
+            block_params = {
+                "norm1": {
+                    "weight": _to_ttnn_norm_param(_get(sd, f"{prefix}.norm1.weight")),
+                    "bias": _to_ttnn_norm_param(_get(sd, f"{prefix}.norm1.bias")),
+                },
+                "norm2": {
+                    "weight": _to_ttnn_norm_param(_get(sd, f"{prefix}.norm2.weight")),
+                    "bias": _to_ttnn_norm_param(_get(sd, f"{prefix}.norm2.bias")),
+                },
+                "attn": {
+                    "qkv": {
+                        "weight": _to_ttnn_linear_weight(_get(sd, f"{prefix}.attn.w_msa.qkv.weight")),
+                        "bias": _to_ttnn_linear_bias(_get(sd, f"{prefix}.attn.w_msa.qkv.bias")),
+                    },
+                    "proj": {
+                        "weight": _to_ttnn_linear_weight(_get(sd, f"{prefix}.attn.w_msa.proj.weight")),
+                        "bias": _to_ttnn_linear_bias(_get(sd, f"{prefix}.attn.w_msa.proj.bias")),
+                    },
+                    "relative_position_bias": rpb,
+                },
+                "mlp": {
+                    "fc1": {
+                        "weight": _to_ttnn_linear_weight(_get(sd, f"{prefix}.ffn.layers.0.0.weight")),
+                        "bias": _to_ttnn_linear_bias(_get(sd, f"{prefix}.ffn.layers.0.0.bias")),
+                    },
+                    "fc2": {
+                        "weight": _to_ttnn_linear_weight(_get(sd, f"{prefix}.ffn.layers.1.weight")),
+                        "bias": _to_ttnn_linear_bias(_get(sd, f"{prefix}.ffn.layers.1.bias")),
+                    },
+                },
+            }
+            params["stages"][s]["blocks"][b] = block_params
+
+        # Downsample (stages 0, 1, 2 only)
+        # mmdet uses nn.Unfold which interleaves channels; our TTNN uses stride-slice concat.
+        # Reorder norm and reduction weights from unfold order -> concat order.
+        if s < 3:
+            ds_prefix = f"backbone.stages.{s}.downsample"
+            perm = _unfold_to_concat_perm(dim)
+
+            # Reorder norm: norm was over 4C unfold-ordered features
+            norm_w = _get(sd, f"{ds_prefix}.norm.weight")  # [4C]
+            norm_b = _get(sd, f"{ds_prefix}.norm.bias")  # [4C]
+            norm_w = norm_w[perm]
+            norm_b = norm_b[perm]
+
+            # Reorder reduction weight columns: W[out, in] -> W[:, perm]
+            red_w = _get(sd, f"{ds_prefix}.reduction.weight")  # [2C, 4C]
+            red_w = red_w[:, perm]
+
+            params["stages"][s]["downsample"] = {
+                "norm": {
+                    "weight": _to_ttnn_norm_param(norm_w),
+                    "bias": _to_ttnn_norm_param(norm_b),
+                },
+                "reduction": {
+                    "weight": _to_ttnn_linear_weight(red_w),
+                },
+            }
+
+    # -- Per-stage output norms (only for stages in out_indices) --
+    for s in out_indices:
+        params[f"norm{s}"] = {
+            "weight": _to_ttnn_norm_param(_get(sd, f"backbone.norm{s}.weight")),
+            "bias": _to_ttnn_norm_param(_get(sd, f"backbone.norm{s}.bias")),
+        }
+
+    # Move all parameters to device
+    params = _to_device_recursive(params, device)
+    return params
+
+
+def _to_device_recursive(d, device):
+    """Recursively move all ttnn.Tensor values in a nested dict to device."""
+    if isinstance(d, ttnn.Tensor):
+        return ttnn.to_device(d, device)
+    if isinstance(d, dict):
+        return {k: _to_device_recursive(v, device) for k, v in d.items()}
+    return d
+
+
+def compute_attn_masks(
+    input_h: int,
+    input_w: int,
+    patch_size: int,
+    window_size: int,
+    device: ttnn.Device,
+) -> List[Optional[ttnn.Tensor]]:
+    """
+    Precompute attention masks for shifted window attention at each of the 4 stages.
+    Returns list of 4 ttnn tensors (or None if window >= feature size).
+    """
+    feat_h = input_h // patch_size
+    feat_w = input_w // patch_size
+    ws = window_size
+    shift = ws // 2
+    masks = []
+
+    for s in range(4):
+        pad_b = (ws - feat_h % ws) % ws
+        pad_r = (ws - feat_w % ws) % ws
+        pad_H = feat_h + pad_b
+        pad_W = feat_w + pad_r
+
+        if ws >= pad_H or ws >= pad_W:
+            masks.append(None)
+        else:
+            num_windows = (pad_H // ws) * (pad_W // ws)
+            attn_mask = torch.zeros((pad_H, pad_W))
+            h_slices = ((0, -ws), (-ws, -shift), (-shift, None))
+            w_slices = ((0, -ws), (-ws, -shift), (-shift, None))
+            count = 0
+            for hs in h_slices:
+                for ws_ in w_slices:
+                    attn_mask[hs[0] : hs[1], ws_[0] : ws_[1]] = count
+                    count += 1
+            attn_mask = attn_mask.view(pad_H // ws, ws, pad_W // ws, ws)
+            attn_mask = attn_mask.permute(0, 2, 1, 3).reshape(num_windows, ws * ws)
+            attn_mask = attn_mask.unsqueeze(1) - attn_mask.unsqueeze(2)
+            attn_mask = attn_mask.masked_fill(attn_mask != 0, -100.0).masked_fill(attn_mask == 0, 0.0)
+            attn_mask = attn_mask.unsqueeze(1).unsqueeze(0)  # [1, 1, nW, ws*ws, ws*ws]
+            masks.append(ttnn.from_torch(attn_mask, device=device, layout=ttnn.TILE_LAYOUT))
+
+        # Next stage: spatial dims halve
+        feat_h = feat_h // 2
+        feat_w = feat_w // 2
+
+    return masks

--- a/models/experimental/swin_l/tt/tt_backbone.py
+++ b/models/experimental/swin_l/tt/tt_backbone.py
@@ -1,0 +1,191 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+TTNN Swin-L backbone — standalone, reusable.
+Multi-scale output: returns feature maps for selected stages after per-stage norms.
+
+Architecture (Swin-L defaults):
+  PatchEmbed(4x4 conv, stride 4) -> 4 stages:
+    Stage 0: 2 blocks, dim=192,  heads=6,  window=12 -> C2
+    Stage 1: 2 blocks, dim=384,  heads=12, window=12 -> C3
+    Stage 2: 18 blocks, dim=768, heads=24, window=12 -> C4
+    Stage 3: 2 blocks, dim=1536, heads=48, window=12 -> C5
+  Downsample (PatchMerge) between stages 0->1, 1->2, 2->3.
+  Per-stage output norms applied before returning feature maps.
+
+Use `out_indices` to control which stages produce outputs:
+  DINO-5scale: out_indices=(0, 1, 2, 3) -> 4 feature maps
+  ATSS-DyHead: out_indices=(1, 2, 3)    -> 3 feature maps
+
+Input: [B, 3, H, W] in NCHW (converted to NHWC internally).
+Output: list of len(out_indices) tensors in NCHW.
+"""
+
+import ttnn
+from models.experimental.swin_l.tt.tt_swin_block import TtSwinBlock
+from models.experimental.swin_l.tt.tt_swin_patch_merge import TtSwinPatchMerge
+from tests.ttnn.ttnn_utility_fuction import get_shard_grid_from_num_cores
+
+
+class TtSwinLBackbone:
+    """TTNN Swin-L backbone producing multi-scale feature maps for selected stages."""
+
+    def __init__(
+        self,
+        device,
+        parameters,
+        embed_dim=192,
+        depths=(2, 2, 18, 2),
+        num_heads=(6, 12, 24, 48),
+        window_size=12,
+        mlp_ratio=4.0,
+        attn_masks=None,
+        out_indices=(0, 1, 2, 3),
+    ):
+        self.device = device
+        self.parameters = parameters
+        self.embed_dim = embed_dim
+        self.depths = depths
+        self.num_heads = num_heads
+        self.window_size = [window_size, window_size] if isinstance(window_size, int) else list(window_size)
+        self.mlp_ratio = mlp_ratio
+        self.out_indices = out_indices
+
+        # Patch embedding conv (4x4 stride 4)
+        self.patch_embed_weight = parameters["patch_embed"]["projection"]["weight"]
+        self.patch_embed_bias = parameters["patch_embed"]["projection"]["bias"]
+        self.patch_embed_weight = ttnn.from_device(self.patch_embed_weight)
+        self.patch_embed_bias = ttnn.from_device(self.patch_embed_bias)
+
+        # Build stages: each stage = list of TtSwinBlock
+        self.stages = []
+        for s in range(4):
+            dim = embed_dim * (2**s)
+            heads = num_heads[s]
+            blocks = []
+            for b in range(depths[s]):
+                shift = [0, 0] if b % 2 == 0 else [self.window_size[0] // 2, self.window_size[1] // 2]
+                mask = attn_masks[s] if attn_masks is not None else None
+                blocks.append(
+                    TtSwinBlock(
+                        device,
+                        parameters["stages"][s]["blocks"][b],
+                        dim=dim,
+                        num_heads=heads,
+                        window_size=self.window_size,
+                        shift_size=shift,
+                        mlp_ratio=mlp_ratio,
+                        attn_mask=mask,
+                    )
+                )
+            self.stages.append(blocks)
+
+        # Downsamples between stages 0->1, 1->2, 2->3
+        self.downsamples = []
+        for s in range(3):
+            dim = embed_dim * (2**s)
+            self.downsamples.append(TtSwinPatchMerge(device, parameters["stages"][s]["downsample"], dim=dim))
+
+    def __call__(self, input_tensor):
+        """
+        input_tensor: [B, 3, H, W] NCHW on device.
+        Returns: list of len(out_indices) NCHW feature maps.
+        """
+        N, C, H, W = input_tensor.shape
+        patch_size = 4
+
+        # Pad input to multiple of patch_size (mmdet PatchEmbed uses padding='corner')
+        pad_h = (patch_size - H % patch_size) % patch_size
+        pad_w = (patch_size - W % patch_size) % patch_size
+        min_channels = 16
+        pad_c = max(0, min_channels - C)
+        if pad_h > 0 or pad_w > 0 or pad_c > 0:
+            nchw = ttnn.pad(
+                input_tensor,
+                ((0, 0), (0, pad_c), (0, pad_h), (0, pad_w)),
+                value=0.0,
+            )
+        else:
+            nchw = input_tensor
+        nhwc = ttnn.permute(nchw, (0, 2, 3, 1))
+        ttnn.deallocate(nchw)
+        nhwc = ttnn.reallocate(nhwc)
+
+        # Patch embedding: 4x4 conv stride 4
+        conv_config = ttnn.Conv2dConfig(
+            weights_dtype=ttnn.bfloat16,
+            shard_layout=ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+            deallocate_activation=True,
+            enable_act_double_buffer=True,
+            enable_weights_double_buffer=True,
+            enable_kernel_stride_folding=False,
+        )
+        shard_grid = get_shard_grid_from_num_cores(64, self.device)
+        conv_config.core_grid = shard_grid
+        conv_config.override_sharding_config = True
+
+        compute_config = ttnn.init_device_compute_kernel_config(
+            self.device.arch(),
+            math_fidelity=ttnn.MathFidelity.LoFi,
+            fp32_dest_acc_en=False,
+            packer_l1_acc=False,
+            math_approx_mode=True,
+        )
+
+        [output, [out_h, out_w], [self.patch_embed_weight, self.patch_embed_bias]] = ttnn.conv2d(
+            input_tensor=nhwc,
+            weight_tensor=self.patch_embed_weight,
+            bias_tensor=self.patch_embed_bias,
+            in_channels=nhwc.shape[3],
+            out_channels=self.embed_dim,
+            device=self.device,
+            kernel_size=(4, 4),
+            stride=(4, 4),
+            padding=(0, 0),
+            batch_size=N,
+            input_height=nhwc.shape[1],
+            input_width=nhwc.shape[2],
+            conv_config=conv_config,
+            compute_config=compute_config,
+            return_output_dim=True,
+            return_weights_and_bias=True,
+            dtype=ttnn.bfloat16,
+        )
+        output = ttnn.sharded_to_interleaved(output, ttnn.DRAM_MEMORY_CONFIG)
+        output = ttnn.reshape(output, (N, out_h, out_w, self.embed_dim))
+
+        # Post-embed layer norm
+        output = ttnn.to_layout(output, ttnn.TILE_LAYOUT, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+        output = ttnn.layer_norm(
+            output,
+            weight=self.parameters["patch_embed"]["norm"]["weight"],
+            bias=self.parameters["patch_embed"]["norm"]["bias"],
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        )
+
+        # Run 4 stages, collecting features only for stages in out_indices
+        features = []
+        for s in range(4):
+            # Run all blocks in this stage
+            for block in self.stages[s]:
+                output = block(output)
+
+            # Only collect output for stages in out_indices
+            if s in self.out_indices:
+                normed = ttnn.layer_norm(
+                    output,
+                    weight=self.parameters[f"norm{s}"]["weight"],
+                    bias=self.parameters[f"norm{s}"]["bias"],
+                    memory_config=ttnn.DRAM_MEMORY_CONFIG,
+                )
+                # NHWC -> NCHW
+                feat_nchw = ttnn.permute(normed, (0, 3, 1, 2), memory_config=ttnn.DRAM_MEMORY_CONFIG)
+                features.append(feat_nchw)
+                ttnn.deallocate(normed)
+
+            # Downsample (except after last stage)
+            if s < 3:
+                output = self.downsamples[s](output)
+
+        return features

--- a/models/experimental/swin_l/tt/tt_swin_attention.py
+++ b/models/experimental/swin_l/tt/tt_swin_attention.py
@@ -1,0 +1,202 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+TTNN Shifted Window Attention for Swin-L backbone.
+Adapted from models/experimental/swin_s/tt/tt_shifted_window_attention.py.
+Initial version: correctness-first (no hardcoded sharding configs).
+"""
+
+import ttnn
+
+
+def roll(tensor, shifts, dims):
+    """Cyclic shift via slice + concat (same as Swin-S)."""
+    if isinstance(shifts, int):
+        shifts = (shifts,)
+    if isinstance(dims, int):
+        dims = (dims,)
+    assert len(shifts) == len(dims)
+    result = tensor
+    shape = result.shape
+    num_dims = len(shape)
+
+    for shift, dim in zip(shifts, dims):
+        shift %= shape[dim]
+        if shift == 0:
+            continue
+        start_left = [0] * num_dims
+        end_left = list(shape)
+        start_right = [0] * num_dims
+        end_right = list(shape)
+        start_left[dim] = shape[dim] - shift
+        end_right[dim] = shape[dim] - shift
+
+        left_part = ttnn.slice(
+            result,
+            slice_start=start_left,
+            slice_end=end_left,
+            slice_step=[1] * num_dims,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        )
+        right_part = ttnn.slice(
+            result,
+            slice_start=start_right,
+            slice_end=end_right,
+            slice_step=[1] * num_dims,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        )
+        result = ttnn.concat([left_part, right_part], dim, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+    return result
+
+
+class TtSwinAttention:
+    """Shifted window multi-head self-attention (TTNN)."""
+
+    def __init__(self, device, parameters, dim, window_size, shift_size, num_heads, attn_mask=None):
+        self.device = device
+        self.parameters = parameters
+        self.dim = dim
+        self.window_size = list(window_size) if not isinstance(window_size, list) else window_size
+        self.shift_size = list(shift_size) if not isinstance(shift_size, list) else shift_size
+        self.num_heads = num_heads
+        self.attn_mask = attn_mask
+
+    def __call__(self, input_tensor):
+        relative_position_bias = self.parameters["relative_position_bias"]
+
+        B, H, W, C = input_tensor.shape
+        pad_r = (self.window_size[1] - W % self.window_size[1]) % self.window_size[1]
+        pad_b = (self.window_size[0] - H % self.window_size[0]) % self.window_size[0]
+        pad_values = (B, H + pad_b, W + pad_r, C)
+        input_tensor = ttnn.pad(input_tensor, pad_values, [0, 0, 0, 0], 0)
+        _, pad_H, pad_W, _ = input_tensor.shape
+
+        shift_size = self.shift_size.copy()
+        if self.window_size[0] >= pad_H:
+            shift_size[0] = 0
+        if self.window_size[1] >= pad_W:
+            shift_size[1] = 0
+
+        # cyclic shift
+        if sum(shift_size) > 0:
+            input_tensor = roll(input_tensor, (-shift_size[0], -shift_size[1]), [1, 2])
+
+        # partition windows
+        num_windows = (pad_H // self.window_size[0]) * (pad_W // self.window_size[1])
+        input_tensor = ttnn.reshape(
+            input_tensor,
+            (
+                B,
+                pad_H // self.window_size[0],
+                self.window_size[0],
+                pad_W // self.window_size[1],
+                self.window_size[1],
+                C,
+            ),
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        )
+        input_tensor = ttnn.permute(input_tensor, (0, 1, 3, 2, 4, 5), memory_config=ttnn.DRAM_MEMORY_CONFIG)
+        input_tensor = ttnn.reshape(
+            input_tensor,
+            (B * num_windows, self.window_size[0] * self.window_size[1], C),
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        )
+
+        # QKV projection
+        input_tensor = ttnn.to_layout(input_tensor, ttnn.TILE_LAYOUT, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+        qkv = ttnn.linear(
+            input_tensor,
+            self.parameters["qkv"]["weight"],
+            bias=self.parameters["qkv"]["bias"],
+            compute_kernel_config=ttnn.WormholeComputeKernelConfig(math_fidelity=ttnn.MathFidelity.LoFi),
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        )
+        qkv = ttnn.to_layout(qkv, layout=ttnn.ROW_MAJOR_LAYOUT, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+        seq_len = input_tensor.shape[1]
+        head_dim = C // self.num_heads
+        qkv = ttnn.reshape(qkv, (B * num_windows, seq_len, 3, self.num_heads, head_dim))
+        qkv = ttnn.permute(qkv, (2, 0, 3, 1, 4), memory_config=ttnn.DRAM_MEMORY_CONFIG)
+        ttnn.deallocate(input_tensor)
+
+        q = qkv[0]
+        k = qkv[1]
+        v = qkv[2]
+        q = ttnn.squeeze(q, 0)
+        k = ttnn.squeeze(k, 0)
+        v = ttnn.squeeze(v, 0)
+
+        # scaled dot-product attention
+        q = q * (head_dim**-0.5)
+        k = ttnn.permute(k, (0, 1, 3, 2), memory_config=ttnn.DRAM_MEMORY_CONFIG)
+        q = ttnn.to_layout(q, ttnn.TILE_LAYOUT, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+        k = ttnn.to_layout(k, ttnn.TILE_LAYOUT, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+        attn = ttnn.matmul(
+            q,
+            k,
+            compute_kernel_config=ttnn.WormholeComputeKernelConfig(math_fidelity=ttnn.MathFidelity.LoFi),
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        )
+        ttnn.deallocate(qkv)
+        ttnn.deallocate(q)
+        ttnn.deallocate(k)
+
+        # relative position bias
+        attn = ttnn.add(attn, relative_position_bias, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+
+        # attention mask for shifted windows
+        if sum(shift_size) > 0 and self.attn_mask is not None:
+            attn = attn + self.attn_mask
+            attn = ttnn.to_layout(attn, layout=ttnn.ROW_MAJOR_LAYOUT, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+            attn = ttnn.reshape(attn, (-1, self.num_heads, seq_len, seq_len))
+            attn = ttnn.to_layout(attn, layout=ttnn.TILE_LAYOUT, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+
+        attn = ttnn.softmax(attn, dim=-1, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+
+        v = ttnn.to_layout(v, ttnn.TILE_LAYOUT, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+        output = ttnn.matmul(
+            attn,
+            v,
+            compute_kernel_config=ttnn.WormholeComputeKernelConfig(math_fidelity=ttnn.MathFidelity.LoFi),
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        )
+        ttnn.deallocate(v)
+        ttnn.deallocate(attn)
+
+        output = ttnn.permute(output, (0, 2, 1, 3), memory_config=ttnn.DRAM_MEMORY_CONFIG)
+        output = ttnn.to_layout(output, layout=ttnn.ROW_MAJOR_LAYOUT, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+        output = ttnn.reshape(output, (B * num_windows, seq_len, C))
+
+        # output projection
+        output = ttnn.to_layout(output, ttnn.TILE_LAYOUT, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+        output = ttnn.linear(
+            output,
+            self.parameters["proj"]["weight"],
+            bias=self.parameters["proj"]["bias"],
+            compute_kernel_config=ttnn.WormholeComputeKernelConfig(math_fidelity=ttnn.MathFidelity.LoFi),
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        )
+
+        # reverse windows
+        output = ttnn.to_layout(output, layout=ttnn.ROW_MAJOR_LAYOUT, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+        output = ttnn.reshape(
+            output,
+            (
+                B,
+                pad_H // self.window_size[0],
+                pad_W // self.window_size[1],
+                self.window_size[0],
+                self.window_size[1],
+                C,
+            ),
+        )
+        output = ttnn.permute(output, (0, 1, 3, 2, 4, 5), memory_config=ttnn.DRAM_MEMORY_CONFIG)
+        output = ttnn.reshape(output, (B, pad_H, pad_W, C))
+
+        # reverse cyclic shift
+        if sum(shift_size) > 0:
+            output = roll(output, (shift_size[0], shift_size[1]), [1, 2])
+
+        # unpad
+        output = output[:, :H, :W, :]
+        return output

--- a/models/experimental/swin_l/tt/tt_swin_block.py
+++ b/models/experimental/swin_l/tt/tt_swin_block.py
@@ -1,0 +1,49 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+TTNN Swin Transformer block for Swin-L backbone.
+Adapted from models/experimental/swin_s/tt/tt_swin_transformer_block.py.
+"""
+
+import ttnn
+from models.experimental.swin_l.tt.tt_swin_attention import TtSwinAttention
+from models.experimental.swin_l.tt.tt_swin_mlp import TtSwinMLP
+
+
+class TtSwinBlock:
+    """Pre-norm Swin Transformer block: LN -> Attention -> residual -> LN -> MLP -> residual."""
+
+    def __init__(self, device, parameters, dim, num_heads, window_size, shift_size, mlp_ratio=4.0, attn_mask=None):
+        self.device = device
+        self.parameters = parameters
+        self.attn = TtSwinAttention(
+            device, parameters["attn"], dim, window_size, shift_size, num_heads, attn_mask=attn_mask
+        )
+        self.mlp = TtSwinMLP(device, parameters["mlp"], dim, mlp_ratio=mlp_ratio)
+
+    def __call__(self, input_tensor):
+        # LN1 -> Attention
+        norm1 = ttnn.layer_norm(
+            input_tensor,
+            weight=self.parameters["norm1"]["weight"],
+            bias=self.parameters["norm1"]["bias"],
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        )
+        attn_out = self.attn(norm1)
+        output = input_tensor + attn_out
+        ttnn.deallocate(norm1)
+
+        # LN2 -> MLP
+        norm2 = ttnn.layer_norm(
+            output,
+            weight=self.parameters["norm2"]["weight"],
+            bias=self.parameters["norm2"]["bias"],
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        )
+        ttnn.deallocate(attn_out)
+        mlp_out = self.mlp(norm2)
+        output = output + mlp_out
+        ttnn.deallocate(norm2)
+        ttnn.deallocate(mlp_out)
+        return output

--- a/models/experimental/swin_l/tt/tt_swin_mlp.py
+++ b/models/experimental/swin_l/tt/tt_swin_mlp.py
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+TTNN MLP for Swin-L blocks.
+Adapted from models/experimental/swin_s/tt/tt_mlp.py.
+Initial version: generic (no hardcoded sharding configs).
+"""
+
+import ttnn
+
+
+class TtSwinMLP:
+    """Two-layer MLP with GELU activation."""
+
+    def __init__(self, device, parameters, dim, mlp_ratio=4.0):
+        self.device = device
+        self.parameters = parameters
+        self.hidden_dim = int(dim * mlp_ratio)
+        self.dim = dim
+
+    def __call__(self, input_tensor):
+        # fc1 + GELU
+        output = ttnn.linear(
+            input_tensor,
+            self.parameters["fc1"]["weight"],
+            bias=self.parameters["fc1"]["bias"],
+            activation="gelu",
+            compute_kernel_config=ttnn.WormholeComputeKernelConfig(math_fidelity=ttnn.MathFidelity.LoFi),
+            core_grid=ttnn.CoreGrid(y=8, x=8),
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        )
+        output = ttnn.to_memory_config(output, ttnn.DRAM_MEMORY_CONFIG, dtype=ttnn.bfloat16)
+
+        # fc2
+        output = ttnn.linear(
+            output,
+            self.parameters["fc2"]["weight"],
+            bias=self.parameters["fc2"]["bias"],
+            compute_kernel_config=ttnn.WormholeComputeKernelConfig(math_fidelity=ttnn.MathFidelity.LoFi),
+            core_grid=ttnn.CoreGrid(y=8, x=8),
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        )
+        output = ttnn.to_memory_config(output, ttnn.DRAM_MEMORY_CONFIG, dtype=ttnn.bfloat16)
+        return output

--- a/models/experimental/swin_l/tt/tt_swin_patch_merge.py
+++ b/models/experimental/swin_l/tt/tt_swin_patch_merge.py
@@ -1,0 +1,54 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+TTNN Patch Merging (downsampling) for Swin-L backbone.
+Adapted from models/experimental/swin_s/tt/tt_patchmerging.py.
+Initial version: generic (no hardcoded sharding configs).
+"""
+
+import ttnn
+
+
+class TtSwinPatchMerge:
+    """Patch merging: 2x2 spatial downsample -> concat -> LN -> linear (4C -> 2C)."""
+
+    def __init__(self, device, parameters, dim):
+        self.device = device
+        self.parameters = parameters
+        self.dim = dim
+
+    def __call__(self, input_tensor):
+        B, H, W, C = input_tensor.shape
+        # Pad odd spatial dims to even (mmdet PatchMerging does the same)
+        pad_h = H % 2
+        pad_w = W % 2
+        if pad_h or pad_w:
+            input_tensor = ttnn.pad(input_tensor, (B, H + pad_h, W + pad_w, C), [0, 0, 0, 0], 0.0)
+        x0 = input_tensor[..., 0::2, 0::2, :]
+        x1 = input_tensor[..., 1::2, 0::2, :]
+        x2 = input_tensor[..., 0::2, 1::2, :]
+        x3 = input_tensor[..., 1::2, 1::2, :]
+        output = ttnn.concat([x0, x1, x2, x3], -1, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+        ttnn.deallocate(x0)
+        ttnn.deallocate(x1)
+        ttnn.deallocate(x2)
+        ttnn.deallocate(x3)
+
+        output = ttnn.to_layout(output, layout=ttnn.TILE_LAYOUT, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+        output = ttnn.layer_norm(
+            output,
+            weight=self.parameters["norm"]["weight"],
+            bias=self.parameters["norm"]["bias"],
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        )
+        output = ttnn.linear(
+            output,
+            self.parameters["reduction"]["weight"],
+            dtype=ttnn.bfloat16,
+            compute_kernel_config=ttnn.WormholeComputeKernelConfig(math_fidelity=ttnn.MathFidelity.LoFi),
+            core_grid=ttnn.CoreGrid(y=8, x=8),
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        )
+        output = ttnn.to_memory_config(output, ttnn.DRAM_MEMORY_CONFIG, dtype=ttnn.bfloat16)
+        return output


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Provide context for the problem.

### What's changed
Describe the approach used to solve the problem.
Summarize the changes made and its impact.

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=tvardhineni/swin_L_bringup)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:tvardhineni/swin_L_bringup)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=tvardhineni/swin_L_bringup)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:tvardhineni/swin_L_bringup)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=tvardhineni/swin_L_bringup)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:tvardhineni/swin_L_bringup)
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=tvardhineni/swin_L_bringup)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:tvardhineni/swin_L_bringup)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=tvardhineni/swin_L_bringup)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:tvardhineni/swin_L_bringup)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=tvardhineni/swin_L_bringup)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:tvardhineni/swin_L_bringup)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
