### PR TITLE
Fix race in Blitz Flash MLA

### DIFF
--- a/models/demos/deepseek_v3_b1/micro_ops/flash_mla/kernels/dataflow/writer_decode_all.cpp
+++ b/models/demos/deepseek_v3_b1/micro_ops/flash_mla/kernels/dataflow/writer_decode_all.cpp
@@ -210,7 +210,7 @@ void kernel_main() {
                 cb_pop_front(cb_out_o, out_chunk_tiles);
                 // Atomic barrier sure guarantee writes are completed
                 noc_async_atomic_barrier();
-                return;
+                break;
 
             } else if (role_code == 2) {
                 // RECEIVER

--- a/models/demos/deepseek_v3_b1/micro_ops/flash_mla/kernels/dataflow/writer_decode_all.cpp
+++ b/models/demos/deepseek_v3_b1/micro_ops/flash_mla/kernels/dataflow/writer_decode_all.cpp
@@ -96,8 +96,10 @@ void kernel_main() {
             reinterpret_cast<volatile tt_l1_ptr uint32_t*>(ncrisc_brisc_sync_addr);
         volatile tt_l1_ptr uint32_t* ncrisc_brisc_sync_next_ptr =
             reinterpret_cast<volatile tt_l1_ptr uint32_t*>(ncrisc_brisc_sync_addr + 4);
-        volatile tt_l1_ptr uint32_t* k_write_ptr_shared =
+        volatile tt_l1_ptr uint32_t* k_write_curr_ptr_shared =
             reinterpret_cast<volatile tt_l1_ptr uint32_t*>(ncrisc_brisc_sync_addr + 8);
+        volatile tt_l1_ptr uint32_t* k_write_next_ptr_shared =
+            reinterpret_cast<volatile tt_l1_ptr uint32_t*>(ncrisc_brisc_sync_addr + 12);
 
         // Receiver ready semaphore: wait for all receivers to reserve CB before multicast
         // This ensures consistent write addresses across cores for double-buffer safety
@@ -121,7 +123,7 @@ void kernel_main() {
             // Wait for NCRISC to have first page ready
             noc_semaphore_wait_min(ncrisc_brisc_sync_curr_ptr, 1);
             invalidate_l1_cache();
-            uint32_t page_addr = *k_write_ptr_shared;
+            uint32_t page_addr = *k_write_curr_ptr_shared;
 
             uint64_t mcast_dest_addr = mcast_noc_addr | page_addr;
 
@@ -147,6 +149,7 @@ void kernel_main() {
             noc_async_writes_flushed(MCAST_NOC);
             *ncrisc_brisc_sync_curr_ptr = 0;
             std::swap(ncrisc_brisc_sync_curr_ptr, ncrisc_brisc_sync_next_ptr);
+            std::swap(k_write_curr_ptr_shared, k_write_next_ptr_shared);
         }
         noc_async_write_barrier(MCAST_NOC);
     }


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Recent changes introduced using two ncrisc_brisc_sync_ptrs. This allows us to start fetching the next chunk from dram without waiting for the current mcast to finish being sent out from the core. However, we were still only using one k_write_ptr_shared, which resulted in a race where the reader risc could modify it before the writer risc read the correct ptr value.

### What's changed
Use two k_write_ptr_shared and only update the current one once mcast has signalled it is done.

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=aho/sdpa-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:aho/sdpa-fix)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=aho/sdpa-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:aho/sdpa-fix)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=aho/sdpa-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:aho/sdpa-fix)
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=aho/sdpa-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:aho/sdpa-fix)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=aho/sdpa-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:aho/sdpa-fix)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=aho/sdpa-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:aho/sdpa-fix)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
