### PR TITLE
#37716: Fix block-sharded conv2d producing wrong results with dilation > 1

### DIFF
--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/conv_reader_common.hpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/conv_reader_common.hpp
@@ -434,9 +434,6 @@ FORCE_INLINE void read_activation_data(
                         conv_act_c_read_bytes,
                         coalesced_read_bytes,
                         stride_h_bytes);
-                    if constexpr (act_block_w_extra_align_bytes) {
-                        l1_write_addr_act += act_block_w_extra_align_bytes;
-                    }
                 } else {
                     read_dilated_channels<weight_size_h, weight_size_w>(
                         l1_write_addr_act,
@@ -445,6 +442,9 @@ FORCE_INLINE void read_activation_data(
                         conv_act_c_read_bytes,
                         stride_h_bytes,
                         stride_w_bytes);
+                }
+                if constexpr (act_block_w_extra_align_bytes) {
+                    l1_write_addr_act += act_block_w_extra_align_bytes;
                 }
             }
         }


### PR DESCRIPTION
The non-sliced read_activation_data path (used by block-sharded conv) was missing act_block_w_extra_align_bytes advancement after read_dilated_channels. The dilation==1 path (read_channels) had this alignment, but the dilation>1 path did not.

When channels_per_shard * kernel_width is not tile-aligned (e.g. 16 channels * 3 taps = 48, padded to 64), each activation row needs 16 elements of padding. Without it, every row after the first was written at the wrong CB offset, causing the tilizer to read misaligned data.

The fix moves the alignment outside the dilation_w==1 / else branch so it applies unconditionally to both paths.

Closes #37716

### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/37716)

Nightly L2 for convs
https://github.com/tenstorrent/tt-metal/actions/runs/22064122538
