### PR TITLE
SDPA decode bug fixes

### DIFF
--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/dataflow/dataflow_common.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/dataflow/dataflow_common.hpp
@@ -354,6 +354,38 @@ void generate_sliding_window_mask(uint32_t k_num_chunks, uint32_t Sk_chunk_t, ui
     cb_push_back(cb_mask_in, total_read_tiles);
 }
 
+/*
+ * Generate a block padding mask for paged attention when block_size < TILE_HEIGHT.
+ * In QK tiles, K sequence positions are along the column dimension. Columns [0, block_size)
+ * get mask=0 (valid), columns [block_size, 32) get mask=-inf (padding).
+ * This mask is pushed once and reused (without popping) by the compute kernel for every K chunk.
+ */
+template <uint32_t cb_block_pad_mask, uint32_t PNHt>
+void generate_block_padding_mask(uint32_t Sk_chunk_t, uint32_t block_size) {
+    uint32_t total_tiles = PNHt * Sk_chunk_t;
+    constexpr uint32_t tile_bytes = get_tile_size(cb_block_pad_mask);
+    constexpr uint32_t NEG_INF = 0xFF80FF80;
+
+    cb_reserve_back(cb_block_pad_mask, total_tiles);
+
+    for (uint32_t i = 0; i < Sk_chunk_t; ++i) {
+        // fill_tile_partial: columns [0, block_size-1] = 0, columns [block_size, 31] = -inf
+        fill_tile_partial<tile_bytes>(cb_block_pad_mask, i, block_size - 1, NEG_INF);
+
+        // Copy to all heads
+        uint64_t noc_read_addr_base = get_noc_addr(get_read_ptr(cb_block_pad_mask));
+        uint32_t write_ptr_base = get_read_ptr(cb_block_pad_mask);
+        for (uint32_t j = 1; j < PNHt; ++j) {
+            copy_tile<tile_bytes>(noc_read_addr_base, write_ptr_base, i, j * Sk_chunk_t + i);
+            if (j == PNHt - 1) {
+                noc_async_read_barrier();
+            }
+        }
+    }
+
+    cb_push_back(cb_block_pad_mask, total_tiles);
+}
+
 /******************************************************************************
  *                   Writer Kernel Specific Functions                         *
  ******************************************************************************/

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/dataflow/dataflow_common.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/dataflow/dataflow_common.hpp
@@ -196,7 +196,10 @@ uint32_t read_mask_chunk(
     }
     noc_async_read_barrier();
     cb_push_back(cb_mask_in, mask_chunk_tiles);
-    mask_start_tile_id += mask_chunk_tiles;
+    // Advance by Sk_chunk_t (column stride), NOT mask_chunk_tiles (PNHt * Sk_chunk_t).
+    // The mask tensor has shape (PNHt, St) with row stride PSt. Each chunk advances
+    // Sk_chunk_t columns. Using mask_chunk_tiles would over-advance when PNHt > 1.
+    mask_start_tile_id += Sk_chunk_t;
     return mask_start_tile_id;
 }
 


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/37927)

### Problem description

Fixes SDPA mask offset bug for PNHt>1 and paged decode bug for block_size=16.

## Issue 1: Non-Causal Mask Read Offset
Non-causal mask read offset was incorrectly advanced by `mask_chunk_tiles (= PNHt * Sk_chunk_t)` for `PNHt > 1` (when `q_chunk_size == head_size`).

The mask tensor shape `(PNHt, St)` has row stride `PSt`, so column advance per chunk should be `Sk_chunk_t`, not `PNHt * Sk_chunk_t`. This skipped `(PNHt-1)` chunks worth of mask columns, causing garbage output.

Affected cases: `PNHt > 1` with non-causal attention (causal uses on-chip masks). Typical `d=128` has `PNHt=1`; `d=64` with `nh=64` gives `PNHt=2`.

## Issue 2: Paged SDPA Decode for Small Block Size
For `block_size=16 < TILE_HEIGHT=32`, K/V tiles have 16 valid rows + 16 zero-padded rows. Two bugs occurred:

- **Wrong tile count**: `cur_pos` mapped to too few tiles. Fix: Convert to padded space as `(cur_pos / block_size) * TILE_HEIGHT + (cur_pos % block_size)` (causal mode only; non-causal already padded).

- **Softmax dilution**: Padded rows contributed `exp(0)` weight. Fix: Persistent block padding mask (`-inf` for pads) added to QK per chunk via `add_block_inplace<false>`.

## Verification
Nightly L2 SDPA tests passed green: https://github.com/tenstorrent/tt-metal/actions/runs/22068801673

(Single-card) Demo tests 
https://github.com/tenstorrent/tt-metal/actions/runs/22218651881

