### PR TITLE
Enhance validation for device-only tensor slicing

### DIFF
--- a/ttnn/cpp/ttnn/operations/data_movement/slice/slice.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/slice.cpp
@@ -235,6 +235,11 @@ ttnn::Tensor SliceOperation::invoke(
         }
     }
 
+    // slice_dim and num_devices must be provided for device-only tensor args slice
+    if (slice_dim.has_value() && num_devices.has_value()) {
+        use_device_only_path = false;
+    }
+
     // Validate tensors are on device for both paths
     TT_FATAL(
         input_tensor.storage_type() == StorageType::DEVICE, "Input tensor must be on device for tensor args slice");
@@ -244,10 +249,6 @@ ttnn::Tensor SliceOperation::invoke(
 
     if (use_device_only_path) {
         // Validate required parameters for device-only path
-        TT_FATAL(
-            slice_dim.has_value() && num_devices.has_value(),
-            "slice_dim and num_devices must be provided for device-only tensor args slice");
-
         TT_FATAL(
             output_tensor_start.storage_type() == StorageType::DEVICE,
             "Start tensor must be on device for tensor args slice");

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/slice.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/slice.cpp
@@ -236,7 +236,7 @@ ttnn::Tensor SliceOperation::invoke(
     }
 
     // slice_dim and num_devices must be provided for device-only tensor args slice
-    if (slice_dim.has_value() && num_devices.has_value()) {
+    if (!slice_dim.has_value() || !num_devices.has_value()) {
         use_device_only_path = false;
     }
 


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/34687

### Problem description
When running Llama DoRA (JAX) from `tt-blacksmith`:
```
python "blacksmith/experiments/jax/llama_dora/test_llama_fine_tuning_jax.py" --config "blacksmith/experiments/jax/llama_dora/test_llama_fine_tuning_jax.yaml" --test-config "tests/configs/test_training_fast.yaml"
```
we encountered an error:
```
TT_FATAL: slice_dim and num_devices must be provided for device-only tensor args slice (assert.hpp:104)
```

### What's changed
This PR aims to return the fallback mechanism in case either of `slice_dim` and `num_devices` are missing, and flip the `use_device_only_path` to `false`.

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=agobeljicTT/use_device_only_path_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:agobeljicTT/use_device_only_path_fix)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=agobeljicTT/use_device_only_path_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:agobeljicTT/use_device_only_path_fix)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=agobeljicTT/use_device_only_path_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:agobeljicTT/use_device_only_path_fix)
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=agobeljicTT/use_device_only_path_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:agobeljicTT/use_device_only_path_fix)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=agobeljicTT/use_device_only_path_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:agobeljicTT/use_device_only_path_fix)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=agobeljicTT/use_device_only_path_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:agobeljicTT/use_device_only_path_fix)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
