### PR TITLE
#35719: Add int32 support for addcmul

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_ternary.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_ternary.py
@@ -266,18 +266,26 @@ def test_addcmul(device, torch_dtype, ttnn_dtype, value, in_data1_shape, in_data
     assert_with_ulp(output_tensor, golden_tensor)
 
 
-def test_addcmul_with_int32_inputs(device):
-    in_data1 = torch.randint(0, 100, (1, 1, 32, 32), dtype=torch.int32)
-    in_data2 = torch.randint(0, 100, (1, 1, 32, 32), dtype=torch.int32)
-    in_data3 = torch.randint(0, 100, (1, 1, 32, 32), dtype=torch.int32)
-    value = 1
+@pytest.mark.parametrize(
+    "in_data1_shape, in_data2_shape, in_data3_shape",
+    [
+        ((1, 1, 32, 32), (1, 1, 32, 32), (1, 1, 32, 32)),
+        ((1, 1, 1, 1024), (1, 1, 1024, 1024), (1, 1, 1, 1024)),
+        ((1, 1, 1024, 1), (1, 1, 1024, 1024), (1, 1, 1024, 1)),
+        ((1, 1, 1, 1), (1, 1, 1024, 1024), (1, 1, 1, 1)),
+    ],
+)
+def test_addcmul_with_int32_inputs(device, in_data1_shape, in_data2_shape, in_data3_shape):
+    in_data1 = torch.randint(-100, 100, in_data1_shape, dtype=torch.int32)
+    in_data2 = torch.randint(-100, 100, in_data2_shape, dtype=torch.int32)
+    in_data3 = torch.randint(-100, 100, in_data3_shape, dtype=torch.int32)
+    value = 6
     input_tensor1 = ttnn.from_torch(in_data1, dtype=ttnn.int32, layout=ttnn.TILE_LAYOUT, device=device)
     input_tensor2 = ttnn.from_torch(in_data2, dtype=ttnn.int32, layout=ttnn.TILE_LAYOUT, device=device)
     input_tensor3 = ttnn.from_torch(in_data3, dtype=ttnn.int32, layout=ttnn.TILE_LAYOUT, device=device)
 
     output_tensor = ttnn.addcmul(input_tensor1, input_tensor2, input_tensor3, value=value)
     output_tensor = ttnn.to_torch(output_tensor)
-
     golden_fn = ttnn.get_golden_function(ttnn.addcmul)
     golden_tensor = golden_fn(in_data1, in_data2, in_data3, value=value)
 

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/common/ternary_op_types.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/common/ternary_op_types.hpp
@@ -13,6 +13,9 @@ namespace ttnn::operations::ternary {
 // Supports float, int, and Tensor types
 using TensorScalarVariant = std::variant<float, int, Tensor>;
 
+// Scalar variant for addcmul(float, int32, uint32)
+using ScalarVariant = std::variant<float, int32_t, uint32_t>;
+
 // Ternary operation types
 enum class TernaryOpType {
     WHERE,    // conditional selection: out = predicate ? value_true : value_false

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/compute/ternary_addcmul_int_sfpu.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/compute/ternary_addcmul_int_sfpu.cpp
@@ -1,0 +1,65 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+
+#include "api/compute/eltwise_unary/eltwise_unary.h"
+#include "api/compute/tile_move_copy.h"
+#include "api/compute/eltwise_unary/fill.h"
+#include "api/compute/mul_int_sfpu.h"
+#include "api/compute/add_int_sfpu.h"
+
+void kernel_main() {
+    uint32_t num_tiles = get_arg_val<uint32_t>(0);
+    uint32_t scalar_arg = get_arg_val<uint32_t>(3);
+    constexpr uint32_t num_tiles_per_cycle = get_compile_time_arg_val(0);  // set to 1
+
+    constexpr auto cb_in0 = tt::CBIndex::c_0;  // input_a
+    constexpr auto cb_in1 = tt::CBIndex::c_1;  // input_b
+    constexpr auto cb_in2 = tt::CBIndex::c_2;  // input_c
+    constexpr auto cb_out = tt::CBIndex::c_3;
+
+    unary_op_init_common(cb_in0, cb_out);
+
+    for (uint32_t tile_id = 0; tile_id < num_tiles; ++tile_id) {
+        cb_wait_front(cb_in0, num_tiles_per_cycle);
+        cb_wait_front(cb_in1, num_tiles_per_cycle);
+        cb_wait_front(cb_in2, num_tiles_per_cycle);
+
+        cb_reserve_back(cb_out, num_tiles_per_cycle);
+
+        tile_regs_acquire();
+
+        copy_tile_init(cb_in0);
+        copy_tile(cb_in0, 0 /*in_tile_index*/, 0 /*dst_tile_index*/);
+
+        copy_tile_init(cb_in1);
+        copy_tile(cb_in1, 0 /*in_tile_index*/, 1 /*dst_tile_index*/);
+
+        copy_tile_init(cb_in2);
+        copy_tile(cb_in2, 0 /*in_tile_index*/, 2 /*dst_tile_index*/);
+
+        fill_tile_init();
+        fill_tile_int<DataFormat::Int32>(3, scalar_arg);
+
+        mul_int_tile_init<DataFormat::Int32>();
+        mul_int_tile<DataFormat::Int32>(3, 1, 3);
+        mul_int_tile<DataFormat::Int32>(3, 2, 2);
+
+        add_int_tile_init();
+        add_int_tile<DataFormat::Int32>(0, 2, 0);
+
+        tile_regs_commit();
+        tile_regs_wait();
+
+        pack_tile(0, cb_out);
+
+        tile_regs_release();
+
+        cb_push_back(cb_out, num_tiles_per_cycle);
+        cb_pop_front(cb_in0, num_tiles_per_cycle);
+        cb_pop_front(cb_in1, num_tiles_per_cycle);
+        cb_pop_front(cb_in2, num_tiles_per_cycle);
+    }
+}

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/compute/ternary_addcmul_int_sfpu_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/compute/ternary_addcmul_int_sfpu_bcast.cpp
@@ -1,0 +1,134 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+
+#include "api/compute/eltwise_unary/eltwise_unary.h"
+#include "api/compute/tile_move_copy.h"
+#include "api/compute/eltwise_unary/fill.h"
+#include "api/compute/mul_int_sfpu.h"
+#include "api/compute/add_int_sfpu.h"
+
+ALWI void process_tile(
+    tt::CBIndex cb_in0,
+    tt::CBIndex cb_in1,
+    tt::CBIndex cb_in2,
+    tt::CBIndex cb_out,
+    uint32_t freq,
+    uint32_t tile_start,
+    uint32_t num_tiles_per_cycle,
+    uint32_t scalar_arg) {
+    using namespace ckernel;
+
+    // 3-tensor broadcast-aware synchronization - wait for broadcast CBs outside loop
+#if BCAST_A
+    cb_wait_front(cb_in0, num_tiles_per_cycle);  // input_a is broadcast
+#endif
+#if BCAST_B
+    cb_wait_front(cb_in1, num_tiles_per_cycle);  // input_b is broadcast
+#endif
+#if BCAST_C
+    cb_wait_front(cb_in2, num_tiles_per_cycle);  // input_c is broadcast
+#endif
+
+    for (uint32_t j = tile_start; j < freq; ++j) {
+        // Wait for non-broadcast CBs inside loop
+#if !BCAST_A
+        cb_wait_front(cb_in0, num_tiles_per_cycle);
+#endif
+#if !BCAST_B
+        cb_wait_front(cb_in1, num_tiles_per_cycle);
+#endif
+#if !BCAST_C
+        cb_wait_front(cb_in2, num_tiles_per_cycle);
+#endif
+
+        cb_reserve_back(cb_out, num_tiles_per_cycle);
+
+        tile_regs_acquire();
+
+        // Load all three inputs into DST registers
+        copy_tile_init(cb_in0);
+        copy_tile(cb_in0, 0 /*in_tile_index*/, 0 /*dst_tile_index*/);
+
+        copy_tile_init(cb_in1);
+        copy_tile(cb_in1, 0 /*in_tile_index*/, 1 /*dst_tile_index*/);
+
+        copy_tile_init(cb_in2);
+        copy_tile(cb_in2, 0 /*in_tile_index*/, 2 /*dst_tile_index*/);
+
+        fill_tile_init();
+        fill_tile_int<DataFormat::Int32>(3, scalar_arg);
+
+        mul_int_tile_init<DataFormat::Int32>();
+        mul_int_tile<DataFormat::Int32>(3, 1, 3);
+        mul_int_tile<DataFormat::Int32>(3, 2, 2);
+
+        add_int_tile_init();
+        add_int_tile<DataFormat::Int32>(0, 2, 0);
+
+        tile_regs_commit();
+        tile_regs_wait();
+
+        // Pack the result from DST[0] to output
+        pack_tile(0, cb_out);
+
+        tile_regs_release();
+
+        cb_push_back(cb_out, num_tiles_per_cycle);
+
+        // Pop non-broadcast CBs inside loop
+#if !BCAST_A
+        cb_pop_front(cb_in0, num_tiles_per_cycle);
+#endif
+#if !BCAST_B
+        cb_pop_front(cb_in1, num_tiles_per_cycle);
+#endif
+#if !BCAST_C
+        cb_pop_front(cb_in2, num_tiles_per_cycle);
+#endif
+    }
+
+    // Pop broadcast CBs outside loop
+#if BCAST_A
+    cb_pop_front(cb_in0, num_tiles_per_cycle);
+#endif
+#if BCAST_B
+    cb_pop_front(cb_in1, num_tiles_per_cycle);
+#endif
+#if BCAST_C
+    cb_pop_front(cb_in2, num_tiles_per_cycle);
+#endif
+}
+
+void kernel_main() {
+    uint32_t num_tiles = get_arg_val<uint32_t>(0);
+    uint32_t tile_freq = get_arg_val<uint32_t>(1);
+    uint32_t tile_start = get_arg_val<uint32_t>(2);
+    uint32_t scalar_arg = get_arg_val<uint32_t>(3);
+
+    constexpr uint32_t num_tiles_per_cycle = get_compile_time_arg_val(0);
+
+    if (num_tiles == 0) {
+        return;
+    }
+
+    constexpr auto cb_in0 = tt::CBIndex::c_0;  // input_a
+    constexpr auto cb_in1 = tt::CBIndex::c_1;  // input_b
+    constexpr auto cb_in2 = tt::CBIndex::c_2;  // input_c
+    constexpr auto cb_out = tt::CBIndex::c_3;  // output
+
+    unary_op_init_common(cb_in0, cb_out);
+
+    uint32_t complete_iterations = (num_tiles + tile_start) / tile_freq;
+    uint32_t remaining_iterations = (num_tiles + tile_start) % tile_freq;
+
+    for (uint32_t i = 0; i < complete_iterations; ++i, tile_start = 0) {
+        process_tile(cb_in0, cb_in1, cb_in2, cb_out, tile_freq, tile_start, num_tiles_per_cycle, scalar_arg);
+    }
+
+    if (remaining_iterations > 0) {
+        process_tile(cb_in0, cb_in1, cb_in2, cb_out, remaining_iterations, tile_start, num_tiles_per_cycle, scalar_arg);
+    }
+}

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/device/ternary_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/device/ternary_device_operation.cpp
@@ -618,7 +618,7 @@ ttnn::operations::ternary::TernaryDeviceOperation::tensor_return_value_t ternary
     const Tensor& input_a,
     const Tensor& input_b,
     const Tensor& input_c,
-    float scalar,
+    ttnn::operations::ternary::ScalarVariant scalar,
     const std::optional<const DataType>& output_dtype,
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<Tensor>& optional_output_tensor,
@@ -649,7 +649,7 @@ ttnn::operations::ternary::TernaryDeviceOperation::tensor_return_value_t ternary
         .dtype = output_dtype.value_or(input_b.dtype()),
         .compute_kernel_config = std::nullopt,
         .sub_core_grids = sub_core_grids,
-        .scalar_input_a = scalar,  // Reuse scalar_input_a for ADDCMUL/ADDCDIV scalar value
+        .scalar_input_a = scalar,
         .scalar_input_b = std::nullopt,
     };
 
@@ -692,7 +692,7 @@ ttnn::operations::ternary::TernaryDeviceOperation::tensor_return_value_t ternary
         .dtype = output_dtype.value_or(input_b.dtype()),
         .compute_kernel_config = std::nullopt,
         .sub_core_grids = sub_core_grids,
-        .scalar_input_b = scalar_c,
+        .scalar_input_b = ttnn::operations::ternary::ScalarVariant(scalar_c),
     };
 
     OperationType::tensor_args_t args{
@@ -734,7 +734,7 @@ ttnn::operations::ternary::TernaryDeviceOperation::tensor_return_value_t ternary
         .dtype = output_dtype.value_or(input_c.dtype()),
         .compute_kernel_config = std::nullopt,
         .sub_core_grids = sub_core_grids,
-        .scalar_input_a = scalar_b,
+        .scalar_input_a = ttnn::operations::ternary::ScalarVariant(scalar_b),
     };
 
     OperationType::tensor_args_t args{

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/device/ternary_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/device/ternary_device_operation.hpp
@@ -26,9 +26,8 @@ struct TernaryDeviceOperation {
         std::optional<DeviceComputeKernelConfig> compute_kernel_config;
         std::optional<CoreRangeSet> sub_core_grids;
 
-        // Scalar values for TTS/TST/TSS variants
-        std::optional<float> scalar_input_a;  // For TST/TSS, and for ADDCMUL scalar value
-        std::optional<float> scalar_input_b;  // For TTS/TSS
+        std::optional<ScalarVariant> scalar_input_a;
+        std::optional<ScalarVariant> scalar_input_b;
 
         tt::stl::hash::hash_t to_hash() const;
 
@@ -90,7 +89,7 @@ ttnn::operations::ternary::TernaryDeviceOperation::tensor_return_value_t ternary
     const Tensor& input_a,
     const Tensor& input_b,
     const Tensor& input_c,
-    float scalar,
+    ttnn::operations::ternary::ScalarVariant scalar,
     const std::optional<const DataType>& output_dtype = std::nullopt,
     const std::optional<MemoryConfig>& memory_config = std::nullopt,
     const std::optional<Tensor>& optional_output_tensor = std::nullopt,

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/device/ternary_op_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/device/ternary_op_utils.hpp
@@ -54,7 +54,9 @@ struct TernaryKernelConfig {
 
 std::string get_kernel_file_path(KernelName kernel_name, bool is_fpu = false);
 
-uint32_t pack_scalar_runtime_arg(float scalar, DataType dtype);
+std::string override_addcmul_compute_kernel(KernelName kernel_name);
+
+uint32_t pack_scalar_runtime_arg(ScalarVariant scalar, DataType dtype);
 
 std::map<std::string, std::string> make_dataflow_defines(
     DataType dtype, DataType b_dtype, std::optional<DataType> c_dtype = std::nullopt);  // for binary & ternary variant

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/device/ternary_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/device/ternary_program_factory.cpp
@@ -1185,8 +1185,11 @@ TernaryDeviceOperation::TernaryProgramFactory::cached_program_t TernaryDeviceOpe
         .compile_args = compute_kernel_args,
         .defines = kernel_defines};
 
-    auto compute_kernel_id =
-        tt_metal::CreateKernel(program, get_kernel_file_path(compute_kernel, is_fpu), all_device_cores, compute_config);
+    std::string compute_kernel_path = (operation_attributes.ternary_op_type == TernaryOpType::ADDCMUL &&
+                                       operation_attributes.dtype == DataType::INT32)
+                                          ? override_addcmul_compute_kernel(compute_kernel)
+                                          : get_kernel_file_path(compute_kernel, is_fpu);
+    auto compute_kernel_id = tt_metal::CreateKernel(program, compute_kernel_path, all_device_cores, compute_config);
 
     auto set_runtime_args = [](Program& program, KernelHandle kernel_id, CoreCoord core, auto&& args) {
         tt_metal::SetRuntimeArgs(program, kernel_id, core, args);

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/ternary.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/ternary.hpp
@@ -41,7 +41,7 @@ struct AddcmulOperation {
         const Tensor& input_a,
         const Tensor& input_b,
         const Tensor& input_c,
-        float value = 1.0f,
+        ScalarVariant value = 1.0f,
         const std::optional<MemoryConfig>& memory_config = std::nullopt,
         const std::optional<Tensor>& output = std::nullopt);
 };


### PR DESCRIPTION
### Ticket
Link to Github Issue #35719

### Problem description
Addcmul uses composite version for int32.

### What's changed

- Added int32 support for addcmul in HLK.
- Introduced separate int32 kernels, since the existing addcmul compute kernels (ternary_addc_ops_sfpu.cpp, ternary_addc_ops_sfpu_bcast.cpp) are designed around float/bfloat tile ops; dedicated int32 kernels ensure clarity and correctness.
- Added scalar variant support so that scalar values now support both float and integer types.

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=mouliraj/int32_addcmul)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:mouliraj/int32_addcmul)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=mouliraj/int32_addcmul)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:mouliraj/int32_addcmul)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mouliraj/int32_addcmul)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mouliraj/int32_addcmul)