### PR TITLE
Revert "Enabling blackhole triage CI (#38005)"

### DIFF
--- a/.github/workflows/merge-gate.yaml
+++ b/.github/workflows/merge-gate.yaml
@@ -396,7 +396,6 @@ jobs:
         platform: [
           "N150",
           "N300",
-          "P150b",
         ]
     uses: ./.github/workflows/triage.yaml
     with:


### PR DESCRIPTION
Reverted enabling triage CI on blackhole since it keep failing in merge gate workflow.