### PR TITLE
Fix docker image ubuntu python versions

### DIFF
--- a/.github/workflows/build-all-docker-images.yaml
+++ b/.github/workflows/build-all-docker-images.yaml
@@ -186,9 +186,7 @@ jobs:
           file: dockerfile/Dockerfile
           target: ci-build
           tags: ${{ needs.check-images.outputs.ubuntu-2204-ci-build-tag }}
-          build-args: |
-            UBUNTU_VERSION=22.04
-            PYTHON_VERSION=3.10
+          build-args: UBUNTU_VERSION=22.04
           cache-to: type=inline
           pull: true
           outputs: |
@@ -201,9 +199,7 @@ jobs:
           file: dockerfile/Dockerfile
           target: ci-test
           tags: ${{ needs.check-images.outputs.ubuntu-2204-ci-test-tag }}
-          build-args: |
-            UBUNTU_VERSION=22.04
-            PYTHON_VERSION=3.10
+          build-args: UBUNTU_VERSION=22.04
           cache-to: type=inline
           pull: true
           outputs: |
@@ -216,9 +212,7 @@ jobs:
           file: dockerfile/Dockerfile
           target: dev
           tags: ${{ needs.check-images.outputs.ubuntu-2204-dev-tag }}
-          build-args: |
-            UBUNTU_VERSION=22.04
-            PYTHON_VERSION=3.10
+          build-args: UBUNTU_VERSION=22.04
           cache-to: type=inline
           pull: true
           outputs: |
@@ -231,9 +225,7 @@ jobs:
           file: dockerfile/Dockerfile.basic-dev
           target: base
           tags: ${{ needs.check-images.outputs.ubuntu-2204-basic-dev-tag }}
-          build-args: |
-            UBUNTU_VERSION=22.04
-            PYTHON_VERSION=3.10
+          build-args: UBUNTU_VERSION=22.04
           cache-to: type=inline
           pull: true
           outputs: |
@@ -246,9 +238,7 @@ jobs:
           file: dockerfile/Dockerfile.basic-dev
           target: basic-ttnn-runtime
           tags: ${{ needs.check-images.outputs.ubuntu-2204-basic-ttnn-runtime-tag }}
-          build-args: |
-            UBUNTU_VERSION=22.04
-            PYTHON_VERSION=3.10
+          build-args: UBUNTU_VERSION=22.04
           cache-to: type=inline
           pull: true
           outputs: |
@@ -280,9 +270,7 @@ jobs:
           file: dockerfile/Dockerfile
           target: ci-build
           tags: ${{ needs.check-images.outputs.ubuntu-2404-ci-build-tag }}
-          build-args: |
-            UBUNTU_VERSION=24.04
-            PYTHON_VERSION=3.12
+          build-args: UBUNTU_VERSION=24.04
           cache-to: type=inline
           pull: true
           outputs: |
@@ -295,9 +283,7 @@ jobs:
           file: dockerfile/Dockerfile
           target: ci-test
           tags: ${{ needs.check-images.outputs.ubuntu-2404-ci-test-tag }}
-          build-args: |
-            UBUNTU_VERSION=24.04
-            PYTHON_VERSION=3.12
+          build-args: UBUNTU_VERSION=24.04
           cache-to: type=inline
           pull: true
           outputs: |
@@ -310,9 +296,7 @@ jobs:
           file: dockerfile/Dockerfile
           target: dev
           tags: ${{ needs.check-images.outputs.ubuntu-2404-dev-tag }}
-          build-args: |
-            UBUNTU_VERSION=24.04
-            PYTHON_VERSION=3.12
+          build-args: UBUNTU_VERSION=24.04
           cache-to: type=inline
           pull: true
           outputs: |
@@ -325,9 +309,7 @@ jobs:
           file: dockerfile/Dockerfile.basic-dev
           target: base
           tags: ${{ needs.check-images.outputs.ubuntu-2404-basic-dev-tag }}
-          build-args: |
-            UBUNTU_VERSION=24.04
-            PYTHON_VERSION=3.12
+          build-args: UBUNTU_VERSION=24.04
           cache-to: type=inline
           pull: true
           outputs: |
@@ -340,9 +322,7 @@ jobs:
           file: dockerfile/Dockerfile.basic-dev
           target: basic-ttnn-runtime
           tags: ${{ needs.check-images.outputs.ubuntu-2404-basic-ttnn-runtime-tag }}
-          build-args: |
-            UBUNTU_VERSION=24.04
-            PYTHON_VERSION=3.12
+          build-args: UBUNTU_VERSION=24.04
           cache-to: type=inline
           pull: true
           outputs: |

--- a/.github/workflows/build-all-docker-images.yaml
+++ b/.github/workflows/build-all-docker-images.yaml
@@ -186,7 +186,9 @@ jobs:
           file: dockerfile/Dockerfile
           target: ci-build
           tags: ${{ needs.check-images.outputs.ubuntu-2204-ci-build-tag }}
-          build-args: UBUNTU_VERSION=22.04
+          build-args: |
+            UBUNTU_VERSION=22.04
+            PYTHON_VERSION=3.10
           cache-to: type=inline
           pull: true
           outputs: |
@@ -199,7 +201,9 @@ jobs:
           file: dockerfile/Dockerfile
           target: ci-test
           tags: ${{ needs.check-images.outputs.ubuntu-2204-ci-test-tag }}
-          build-args: UBUNTU_VERSION=22.04
+          build-args: |
+            UBUNTU_VERSION=22.04
+            PYTHON_VERSION=3.10
           cache-to: type=inline
           pull: true
           outputs: |
@@ -212,7 +216,9 @@ jobs:
           file: dockerfile/Dockerfile
           target: dev
           tags: ${{ needs.check-images.outputs.ubuntu-2204-dev-tag }}
-          build-args: UBUNTU_VERSION=22.04
+          build-args: |
+            UBUNTU_VERSION=22.04
+            PYTHON_VERSION=3.10
           cache-to: type=inline
           pull: true
           outputs: |
@@ -225,7 +231,9 @@ jobs:
           file: dockerfile/Dockerfile.basic-dev
           target: base
           tags: ${{ needs.check-images.outputs.ubuntu-2204-basic-dev-tag }}
-          build-args: UBUNTU_VERSION=22.04
+          build-args: |
+            UBUNTU_VERSION=22.04
+            PYTHON_VERSION=3.10
           cache-to: type=inline
           pull: true
           outputs: |
@@ -238,7 +246,9 @@ jobs:
           file: dockerfile/Dockerfile.basic-dev
           target: basic-ttnn-runtime
           tags: ${{ needs.check-images.outputs.ubuntu-2204-basic-ttnn-runtime-tag }}
-          build-args: UBUNTU_VERSION=22.04
+          build-args: |
+            UBUNTU_VERSION=22.04
+            PYTHON_VERSION=3.10
           cache-to: type=inline
           pull: true
           outputs: |
@@ -270,7 +280,9 @@ jobs:
           file: dockerfile/Dockerfile
           target: ci-build
           tags: ${{ needs.check-images.outputs.ubuntu-2404-ci-build-tag }}
-          build-args: UBUNTU_VERSION=24.04
+          build-args: |
+            UBUNTU_VERSION=24.04
+            PYTHON_VERSION=3.12
           cache-to: type=inline
           pull: true
           outputs: |
@@ -283,7 +295,9 @@ jobs:
           file: dockerfile/Dockerfile
           target: ci-test
           tags: ${{ needs.check-images.outputs.ubuntu-2404-ci-test-tag }}
-          build-args: UBUNTU_VERSION=24.04
+          build-args: |
+            UBUNTU_VERSION=24.04
+            PYTHON_VERSION=3.12
           cache-to: type=inline
           pull: true
           outputs: |
@@ -296,7 +310,9 @@ jobs:
           file: dockerfile/Dockerfile
           target: dev
           tags: ${{ needs.check-images.outputs.ubuntu-2404-dev-tag }}
-          build-args: UBUNTU_VERSION=24.04
+          build-args: |
+            UBUNTU_VERSION=24.04
+            PYTHON_VERSION=3.12
           cache-to: type=inline
           pull: true
           outputs: |
@@ -309,7 +325,9 @@ jobs:
           file: dockerfile/Dockerfile.basic-dev
           target: base
           tags: ${{ needs.check-images.outputs.ubuntu-2404-basic-dev-tag }}
-          build-args: UBUNTU_VERSION=24.04
+          build-args: |
+            UBUNTU_VERSION=24.04
+            PYTHON_VERSION=3.12
           cache-to: type=inline
           pull: true
           outputs: |
@@ -322,7 +340,9 @@ jobs:
           file: dockerfile/Dockerfile.basic-dev
           target: basic-ttnn-runtime
           tags: ${{ needs.check-images.outputs.ubuntu-2404-basic-ttnn-runtime-tag }}
-          build-args: UBUNTU_VERSION=24.04
+          build-args: |
+            UBUNTU_VERSION=24.04
+            PYTHON_VERSION=3.12
           cache-to: type=inline
           pull: true
           outputs: |

--- a/dockerfile/Dockerfile
+++ b/dockerfile/Dockerfile
@@ -4,6 +4,9 @@
 
 # Global build arguments (defined before FROM to be available in all stages)
 ARG UBUNTU_VERSION=22.04
+# PYTHON_VERSION must match the Ubuntu version:
+# Ubuntu 22.04 -> Python 3.10
+# Ubuntu 24.04 -> Python 3.12
 ARG PYTHON_VERSION=3.10
 
 FROM ghcr.io/astral-sh/uv@sha256:9a23023be68b2ed09750ae636228e903a54a05ea56ed03a934d00fe9fbeded4b AS uv-layer

--- a/dockerfile/Dockerfile
+++ b/dockerfile/Dockerfile
@@ -4,15 +4,16 @@
 
 # Global build arguments (defined before FROM to be available in all stages)
 ARG UBUNTU_VERSION=22.04
-# PYTHON_VERSION must match the Ubuntu version:
+# PYTHON_VERSION can be explicitly set or auto-detected from UBUNTU_VERSION:
 # Ubuntu 22.04 -> Python 3.10
 # Ubuntu 24.04 -> Python 3.12
-ARG PYTHON_VERSION=3.10
+ARG PYTHON_VERSION=""
 
 FROM ghcr.io/astral-sh/uv@sha256:9a23023be68b2ed09750ae636228e903a54a05ea56ed03a934d00fe9fbeded4b AS uv-layer
 
 FROM mirror.gcr.io/ubuntu:${UBUNTU_VERSION} AS base
 
+ARG UBUNTU_VERSION
 ARG PYTHON_VERSION
 
 ENV DEBIAN_FRONTEND=noninteractive
@@ -24,7 +25,19 @@ COPY --from=uv-layer /uv /uvx /usr/local/bin/
 # shared path. When the venv is copied to NFS for multi-host use, the Python interpreter
 # must be reachable from all nodes. See scripts/install-uv.sh post-install message.
 ENV UV_PYTHON_INSTALL_DIR="/usr/local/share/uv"
-RUN umask 000 && uv python install "$PYTHON_VERSION"
+
+# Auto-detect Python version from Ubuntu version if not explicitly provided
+RUN set -e; \
+    DETECTED_PYTHON_VERSION="${PYTHON_VERSION}"; \
+    if [ -z "${DETECTED_PYTHON_VERSION}" ]; then \
+    if [ "${UBUNTU_VERSION}" = "24.04" ]; then \
+    DETECTED_PYTHON_VERSION="3.12"; \
+    else \
+    DETECTED_PYTHON_VERSION="3.10"; \
+    fi; \
+    fi; \
+    echo "Installing Python ${DETECTED_PYTHON_VERSION} for Ubuntu ${UBUNTU_VERSION}"; \
+    umask 000 && uv python install "${DETECTED_PYTHON_VERSION}"
 
 # Install runtime deps
 COPY /install_dependencies.sh /opt/tt_metal_infra/scripts/docker/install_dependencies.sh

--- a/dockerfile/Dockerfile.basic-dev
+++ b/dockerfile/Dockerfile.basic-dev
@@ -1,11 +1,15 @@
 ARG UBUNTU_VERSION=22.04
-ARG PYTHON_VERSION=3.10
+# PYTHON_VERSION can be explicitly set or auto-detected from UBUNTU_VERSION:
+# Ubuntu 22.04 -> Python 3.10
+# Ubuntu 24.04 -> Python 3.12
+ARG PYTHON_VERSION=""
 
 FROM ghcr.io/astral-sh/uv@sha256:9a23023be68b2ed09750ae636228e903a54a05ea56ed03a934d00fe9fbeded4b AS uv-layer
 
 FROM mirror.gcr.io/ubuntu:${UBUNTU_VERSION} AS base
 # Re-declare ARG make it available in the build stage
 ARG UBUNTU_VERSION
+ARG PYTHON_VERSION
 
 # Install basic tools to build
 RUN apt-get update && apt-get install -y \
@@ -21,7 +25,7 @@ RUN apt-get update && apt-get install -y \
 RUN set -eux; \
     apt-get update && \
     apt-get install -y -f \
-        wget ca-certificates && \
+    wget ca-certificates && \
     TMP_DIR="$(mktemp -d)" && \
     DEB_URL="https://github.com/tenstorrent/ompi/releases/download/v5.0.7/openmpi-ulfm_5.0.7-1_amd64.deb" && \
     wget -qO "$TMP_DIR/ompi.deb" "$DEB_URL" && \
@@ -33,13 +37,27 @@ RUN set -eux; \
 
 FROM base AS basic-ttnn-runtime
 
+ARG UBUNTU_VERSION
 ARG PYTHON_VERSION
 
 # Install uv with version pinning (centralized in install-uv.sh)
 COPY --from=uv-layer /uv /uvx /usr/local/bin/
 
 ENV UV_PYTHON_INSTALL_DIR="/usr/local/share/uv"
-RUN umask 000 && uv python install "$PYTHON_VERSION"
+
+# Auto-detect Python version from Ubuntu version if not explicitly provided
+RUN set -e; \
+    DETECTED_PYTHON_VERSION="${PYTHON_VERSION}"; \
+    if [ -z "${DETECTED_PYTHON_VERSION}" ]; then \
+    if [ "${UBUNTU_VERSION}" = "24.04" ]; then \
+    DETECTED_PYTHON_VERSION="3.12"; \
+    else \
+    DETECTED_PYTHON_VERSION="3.10"; \
+    fi; \
+    fi; \
+    echo "Installing Python ${DETECTED_PYTHON_VERSION} for Ubuntu ${UBUNTU_VERSION}"; \
+    umask 000 && uv python install "${DETECTED_PYTHON_VERSION}"; \
+    echo "${DETECTED_PYTHON_VERSION}" > /tmp/python_version
 
 # Install basic runtime dependencies
 RUN apt-get update && apt-get install -y \
@@ -62,7 +80,8 @@ ENV PYTHON_ENV_DIR=/opt/venv
 # SECURITY NOTE: This enables any user in the container to modify the Python environment.
 # This is acceptable for single-user containers but should be reconsidered for multi-tenant
 # or security-sensitive deployments. Consider using user-specific venvs in those cases.
-RUN umask 000 && uv venv --python "$PYTHON_VERSION" --link-mode copy --managed-python --relocatable "$PYTHON_ENV_DIR"
+RUN DETECTED_PYTHON_VERSION=$(cat /tmp/python_version) && \
+    umask 000 && uv venv --python "$DETECTED_PYTHON_VERSION" --link-mode copy --managed-python --relocatable "$PYTHON_ENV_DIR"
 
 # Ensure the virtual environment is used for all Python-related commands
 ENV PATH="$PYTHON_ENV_DIR/bin:$PATH"


### PR DESCRIPTION
### Problem description
Currently python wheel can't be installed on Ubuntu 24.04 because we are installing there only python 3.10

### What's changed
With setting ubuntu version we need to set python version to go with it

### Checklist

- [x] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=dpopov-fix-docker-ubuntu-python-versions)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:dpopov-fix-docker-ubuntu-python-versions)
