### PR TITLE
Allow creating global semaphores without initial value and with pre-allocated mesh buffer

### DIFF
--- a/tt_metal/api/tt-metalium/experimental/forge_backdoor/global_semaphore.hpp
+++ b/tt_metal/api/tt-metalium/experimental/forge_backdoor/global_semaphore.hpp
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
 #include <tt-metalium/global_semaphore.hpp>
 
 namespace tt::tt_metal::experimental {

--- a/tt_metal/api/tt-metalium/experimental/forge_backdoor/global_semaphore.hpp
+++ b/tt_metal/api/tt-metalium/experimental/forge_backdoor/global_semaphore.hpp
@@ -1,0 +1,26 @@
+#include <tt-metalium/global_semaphore.hpp>
+
+namespace tt::tt_metal::experimental {
+// clang-format off
+/**
+ * Experimental API for creating a global semaphore at a specific address.
+ * and with optional initial value used by tt-mlir.
+ *
+ * Return value: GlobalSemaphore
+ *
+ * | Argument       | Description                                            | Type                                                      | Valid Range  | Required |
+ * |----------------|--------------------------------------------------------|-----------------------------------------------------------|--------------|----------|
+ * | device         | The device to create the semaphore on                  | IDevice*                                                  |              | Yes      |
+ * | cores          | Range of the Tensix co-ordinates using the semaphore   | const CoreRangeSet &                                      |              | Yes      |
+ * | initial_value  | Initial value of the semaphore                         | uint32_t                                                  |              | Yes      |
+ * | buffer_type    | Buffer type to store the semaphore                     | BufferType                                                | L1 types     | No       |
+ * | address        | Address of the semaphore to create                     | uint64_t                                                  |              | Yes      |
+ */
+// clang-format on
+GlobalSemaphore CreateGlobalSemaphore(
+    IDevice* device,
+    const CoreRangeSet& cores,
+    std::optional<uint32_t> initial_value,
+    BufferType buffer_type,
+    uint64_t address);
+}  // namespace tt::tt_metal::experimental

--- a/tt_metal/api/tt-metalium/global_semaphore.hpp
+++ b/tt_metal/api/tt-metalium/global_semaphore.hpp
@@ -21,6 +21,7 @@ class IDevice;
 class GlobalSemaphore;
 
 namespace experimental {
+// TODO: Move to impl when this class is PIMPLed
 GlobalSemaphore CreateGlobalSemaphore(
     IDevice* device,
     const CoreRangeSet& cores,
@@ -57,6 +58,7 @@ public:
 
 private:
     // private constructor used by experimental API
+    // TODO: Move to impl when this class is PIMPLed
     GlobalSemaphore(
         IDevice* device,
         const CoreRangeSet& cores,

--- a/tt_metal/api/tt-metalium/global_semaphore.hpp
+++ b/tt_metal/api/tt-metalium/global_semaphore.hpp
@@ -15,8 +15,19 @@
 #include <tt-metalium/hal_types.hpp>
 #include <tt-metalium/mesh_buffer.hpp>
 
+// forward declarations
 namespace tt::tt_metal {
 class IDevice;
+class GlobalSemaphore;
+
+namespace experimental {
+GlobalSemaphore CreateGlobalSemaphore(
+    IDevice* device,
+    const CoreRangeSet& cores,
+    std::optional<uint32_t> initial_value,
+    BufferType buffer_type,
+    uint64_t address);
+}  // namespace experimental
 }  // namespace tt::tt_metal
 
 namespace tt::tt_metal {
@@ -45,13 +56,29 @@ public:
     auto attribute_values() const { return std::make_tuple(this->cores_, this->buffer_.get_buffer()->buffer_type()); }
 
 private:
-    void setup_buffer(uint32_t initial_value, BufferType buffer_type);
+    // private constructor used by experimental API
+    GlobalSemaphore(
+        IDevice* device,
+        const CoreRangeSet& cores,
+        std::optional<uint32_t> initial_value,
+        BufferType buffer_type,
+        uint64_t address);
+
+    void setup_buffer(
+        std::optional<uint32_t> initial_value, BufferType buffer_type, std::optional<uint64_t> address = std::nullopt);
 
     // GlobalSemaphore is implemented as a wrapper around a sharded buffer
     // This can be updated in the future to be its own container with optimized dispatch functions
     distributed::AnyBuffer buffer_;
     IDevice* device_;
     CoreRangeSet cores_;
+
+    friend GlobalSemaphore experimental::CreateGlobalSemaphore(
+        IDevice* device,
+        const CoreRangeSet& cores,
+        std::optional<uint32_t> initial_value,
+        BufferType buffer_type,
+        uint64_t address);
 };
 
 }  // namespace tt::tt_metal

--- a/tt_metal/tt_metal.cpp
+++ b/tt_metal/tt_metal.cpp
@@ -1396,6 +1396,17 @@ GlobalSemaphore CreateGlobalSemaphore(
     return GlobalSemaphore(device, std::move(cores), initial_value, buffer_type);
 }
 
+namespace experimental {
+GlobalSemaphore CreateGlobalSemaphore(
+    IDevice* device,
+    const CoreRangeSet& cores,
+    std::optional<uint32_t> initial_value,
+    BufferType buffer_type,
+    uint64_t address) {
+    return GlobalSemaphore(device, cores, initial_value, buffer_type, address);
+}
+}  // namespace experimental
+
 std::shared_ptr<Buffer> CreateBuffer(const InterleavedBufferConfig& config) {
     return Buffer::create(config.device, config.size, config.page_size, config.buffer_type);
 }


### PR DESCRIPTION
### Ticket
Link to Github Issue: https://github.com/tenstorrent/tt-mlir/issues/6766

### Problem description/What's changed
These changes are needed for tt-mlir, specifically for the d2m compiler. We want to be able to create global semaphores upfront without initializing them until they are needed in an op. The d2m compiler also does buffer allocation on its own so we need to support creating global semaphores from a pre-allocated buffer.

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=snadeem/global_semaphores)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:snadeem/global_semaphores)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=snadeem/global_semaphores)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:snadeem/global_semaphores)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=snadeem/global_semaphores)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:snadeem/global_semaphores)
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=snadeem/global_semaphores)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:snadeem/global_semaphores)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=snadeem/global_semaphores)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:snadeem/global_semaphores)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=snadeem/global_semaphores)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:snadeem/global_semaphores)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
