### PR TITLE
Add DeepSeekV3 B1 demo CLI script

### DIFF
--- a/models/demos/deepseek_v3_b1/demo/README.md
+++ b/models/demos/deepseek_v3_b1/demo/README.md
@@ -1,0 +1,21 @@
+# DeepSeek V3 B1 Demo CLI
+
+This folder contains a CLI for running the current DeepSeek V3 B1 demo.
+
+The demo runs prefill + decode over `DeepSeekV3` sockets and streams decoded text to stdout.
+
+## Requirements
+
+Assuming your environment is configured correctly:
+
+1. Enable slow dispatch mode:
+
+```bash
+export TT_METAL_SLOW_DISPATCH_MODE=1
+```
+
+2. Run the demo:
+
+```bash
+python -m models.demos.deepseek_v3_b1.demo.cli --prompt "Once upon a time" --max-new-tokens 128
+```

--- a/models/demos/deepseek_v3_b1/demo/cli.py
+++ b/models/demos/deepseek_v3_b1/demo/cli.py
@@ -1,0 +1,157 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import argparse
+import sys
+from typing import TextIO
+
+import torch
+from transformers import AutoTokenizer
+
+import ttnn
+from models.common.utility_functions import is_slow_dispatch
+from models.demos.deepseek_v3_b1.demo.runner import GenerationResult, run_generation
+from models.demos.deepseek_v3_b1.model import TOKEN_ID_BYTES, DeepSeekV3, page_size_bytes, to_padded_input
+
+DEFAULT_TOKENIZER = "deepseek-ai/DeepSeek-V3"
+
+
+def create_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser("DeepSeek-V3-B1 Demo on TT-NN")
+    parser.add_argument("--prompt", type=str, default="", help="Prompt text")
+    parser.add_argument("--max-new-tokens", type=int, default=128, help="Number of decode steps to run")
+    parser.add_argument(
+        "--tokenizer",
+        type=str,
+        default=DEFAULT_TOKENIZER,
+        help="HF tokenizer id or local tokenizer path",
+    )
+    parser.add_argument(
+        "--loopback-mode",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Use HostInterface loopback path (recommended for current B1 bring-up)",
+    )
+    parser.add_argument("--mesh-height", type=int, default=1, help="Mesh height for open_mesh_device")
+    parser.add_argument("--mesh-width", type=int, default=1, help="Mesh width for open_mesh_device")
+    return parser
+
+
+def load_tokenizer(tokenizer_name_or_path: str):
+    return AutoTokenizer.from_pretrained(tokenizer_name_or_path, trust_remote_code=True)
+
+
+def create_deepseek_v3(
+    mesh_device: ttnn.MeshDevice,
+    *,
+    batch_size: int = 1,
+    loopback_mode: bool = True,
+) -> DeepSeekV3:
+    fifo_size = page_size_bytes(batch_size)
+    socket_core = ttnn.MeshCoreCoord(ttnn.MeshCoordinate(0, 0), ttnn.CoreCoord(0, 0))
+    h2d_socket_prefill = ttnn.H2DSocket(
+        mesh_device,
+        socket_core,
+        ttnn.BufferType.L1,
+        fifo_size,
+        ttnn.H2DMode.DEVICE_PULL,
+    )
+    h2d_socket_decode = ttnn.H2DSocket(
+        mesh_device,
+        socket_core,
+        ttnn.BufferType.L1,
+        fifo_size,
+        ttnn.H2DMode.HOST_PUSH,
+    )
+    d2h_socket = ttnn.D2HSocket(mesh_device, socket_core, fifo_size)
+    return DeepSeekV3(
+        h2d_socket_prefill=h2d_socket_prefill,
+        h2d_socket_decode=h2d_socket_decode,
+        d2h_socket=d2h_socket,
+        batch_size=batch_size,
+        loopback_mode=loopback_mode,
+    )
+
+
+def make_padded_input_tensor(token_id: int, *, batch_size: int, page_size_datums: int) -> ttnn.Tensor:
+    torch_token = torch.full((batch_size, 1), int(token_id), dtype=torch.int32)
+    return to_padded_input(torch_token, batch_size=batch_size, page_size_datums=page_size_datums)
+
+
+def extract_token_id_from_output(output_tensor: ttnn.Tensor) -> int:
+    torch_output = ttnn.to_torch(output_tensor).reshape(-1)
+    return int(torch_output[0].item())
+
+
+def run_demo(
+    *,
+    prompt: str,
+    max_new_tokens: int,
+    tokenizer_name_or_path: str,
+    loopback_mode: bool,
+    mesh_height: int,
+    mesh_width: int,
+    output_stream: TextIO,
+) -> GenerationResult:
+    if not is_slow_dispatch():
+        raise RuntimeError(
+            "DeepSeek V3 B1 demo requires slow dispatch mode. Set TT_METAL_SLOW_DISPATCH_MODE=1 and rerun."
+        )
+
+    tokenizer = load_tokenizer(tokenizer_name_or_path)
+    page_size_datums = page_size_bytes(1) // TOKEN_ID_BYTES
+    is_first_decode_chunk = True
+
+    def write_text(text: str) -> None:
+        nonlocal is_first_decode_chunk
+        if is_first_decode_chunk:
+            if prompt:
+                output_stream.write(prompt)
+            is_first_decode_chunk = False
+        output_stream.write(text)
+        output_stream.flush()
+
+    mesh_device: ttnn.MeshDevice | None = None
+    try:
+        mesh_device = ttnn.open_mesh_device(mesh_shape=ttnn.MeshShape(mesh_height, mesh_width))
+        model = create_deepseek_v3(mesh_device=mesh_device, batch_size=1, loopback_mode=loopback_mode)
+        return run_generation(
+            model=model,
+            tokenizer=tokenizer,
+            prompt=prompt,
+            max_new_tokens=max_new_tokens,
+            make_input_tensor=lambda token_id: make_padded_input_tensor(
+                token_id,
+                batch_size=1,
+                page_size_datums=page_size_datums,
+            ),
+            extract_token_id=extract_token_id_from_output,
+            write_text=write_text,
+        )
+    finally:
+        if mesh_device is not None:
+            ttnn.close_mesh_device(mesh_device)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = create_parser()
+    args = parser.parse_args(argv)
+
+    run_demo(
+        prompt=args.prompt,
+        max_new_tokens=args.max_new_tokens,
+        tokenizer_name_or_path=args.tokenizer,
+        loopback_mode=args.loopback_mode,
+        mesh_height=args.mesh_height,
+        mesh_width=args.mesh_width,
+        output_stream=sys.stdout,
+    )
+    print(file=sys.stdout, flush=True)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/models/demos/deepseek_v3_b1/demo/cli.py
+++ b/models/demos/deepseek_v3_b1/demo/cli.py
@@ -8,13 +8,12 @@ import argparse
 import sys
 from typing import TextIO
 
-import torch
 from transformers import AutoTokenizer
 
 import ttnn
 from models.common.utility_functions import is_slow_dispatch
 from models.demos.deepseek_v3_b1.demo.runner import GenerationResult, run_generation
-from models.demos.deepseek_v3_b1.model import TOKEN_ID_BYTES, DeepSeekV3, page_size_bytes, to_padded_input
+from models.demos.deepseek_v3_b1.demo.runtime import TokenCodec, create_model
 
 DEFAULT_TOKENIZER = "deepseek-ai/DeepSeek-V3"
 
@@ -44,48 +43,6 @@ def load_tokenizer(tokenizer_name_or_path: str):
     return AutoTokenizer.from_pretrained(tokenizer_name_or_path, trust_remote_code=True)
 
 
-def create_deepseek_v3(
-    mesh_device: ttnn.MeshDevice,
-    *,
-    batch_size: int = 1,
-    loopback_mode: bool = True,
-) -> DeepSeekV3:
-    fifo_size = page_size_bytes(batch_size)
-    socket_core = ttnn.MeshCoreCoord(ttnn.MeshCoordinate(0, 0), ttnn.CoreCoord(0, 0))
-    h2d_socket_prefill = ttnn.H2DSocket(
-        mesh_device,
-        socket_core,
-        ttnn.BufferType.L1,
-        fifo_size,
-        ttnn.H2DMode.DEVICE_PULL,
-    )
-    h2d_socket_decode = ttnn.H2DSocket(
-        mesh_device,
-        socket_core,
-        ttnn.BufferType.L1,
-        fifo_size,
-        ttnn.H2DMode.HOST_PUSH,
-    )
-    d2h_socket = ttnn.D2HSocket(mesh_device, socket_core, fifo_size)
-    return DeepSeekV3(
-        h2d_socket_prefill=h2d_socket_prefill,
-        h2d_socket_decode=h2d_socket_decode,
-        d2h_socket=d2h_socket,
-        batch_size=batch_size,
-        loopback_mode=loopback_mode,
-    )
-
-
-def make_padded_input_tensor(token_id: int, *, batch_size: int, page_size_datums: int) -> ttnn.Tensor:
-    torch_token = torch.full((batch_size, 1), int(token_id), dtype=torch.int32)
-    return to_padded_input(torch_token, batch_size=batch_size, page_size_datums=page_size_datums)
-
-
-def extract_token_id_from_output(output_tensor: ttnn.Tensor) -> int:
-    torch_output = ttnn.to_torch(output_tensor).reshape(-1)
-    return int(torch_output[0].item())
-
-
 def run_demo(
     *,
     prompt: str,
@@ -102,7 +59,7 @@ def run_demo(
         )
 
     tokenizer = load_tokenizer(tokenizer_name_or_path)
-    page_size_datums = page_size_bytes(1) // TOKEN_ID_BYTES
+    token_codec = TokenCodec(batch_size=1)
     is_first_decode_chunk = True
 
     def write_text(text: str) -> None:
@@ -117,18 +74,14 @@ def run_demo(
     mesh_device: ttnn.MeshDevice | None = None
     try:
         mesh_device = ttnn.open_mesh_device(mesh_shape=ttnn.MeshShape(mesh_height, mesh_width))
-        model = create_deepseek_v3(mesh_device=mesh_device, batch_size=1, loopback_mode=loopback_mode)
+        model = create_model(mesh_device=mesh_device, batch_size=1, loopback_mode=loopback_mode)
         return run_generation(
             model=model,
             tokenizer=tokenizer,
             prompt=prompt,
             max_new_tokens=max_new_tokens,
-            make_input_tensor=lambda token_id: make_padded_input_tensor(
-                token_id,
-                batch_size=1,
-                page_size_datums=page_size_datums,
-            ),
-            extract_token_id=extract_token_id_from_output,
+            make_input_tensor=token_codec.make_input,
+            extract_token_id=token_codec.extract_token_id,
             write_text=write_text,
         )
     finally:

--- a/models/demos/deepseek_v3_b1/demo/runner.py
+++ b/models/demos/deepseek_v3_b1/demo/runner.py
@@ -1,0 +1,101 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Callable, Protocol
+
+
+class ModelLike(Protocol):
+    def start(self) -> None:
+        ...
+
+    def prefill(self, prompt_tokens: list[Any]) -> Any:
+        ...
+
+    def decode_step(self, input_tensor: Any) -> Any:
+        ...
+
+    def stop(self) -> None:
+        ...
+
+
+@dataclass(frozen=True)
+class GenerationResult:
+    prompt_token_ids: list[int]
+    generated_token_ids: list[int]
+    generated_text: str
+
+
+def tokenize_prompt(tokenizer: Any, prompt: str) -> list[int]:
+    if hasattr(tokenizer, "encode"):
+        token_ids = tokenizer.encode(prompt, add_special_tokens=True)
+    else:
+        encoded = tokenizer(prompt, add_special_tokens=True, return_attention_mask=False)
+        token_ids = encoded["input_ids"] if isinstance(encoded, dict) else encoded.input_ids
+    if len(token_ids) > 0 and isinstance(token_ids[0], list):
+        token_ids = token_ids[0]
+    return [int(token_id) for token_id in token_ids]
+
+
+def ensure_non_empty_prompt_tokens(prompt_token_ids: list[int], bos_token_id: int | None) -> list[int]:
+    if len(prompt_token_ids) > 0:
+        return prompt_token_ids
+    if bos_token_id is None:
+        raise ValueError("Prompt tokenization produced zero tokens and tokenizer has no bos_token_id fallback.")
+    return [int(bos_token_id)]
+
+
+def run_generation(
+    *,
+    model: ModelLike,
+    tokenizer: Any,
+    prompt: str,
+    max_new_tokens: int,
+    make_input_tensor: Callable[[int], Any],
+    extract_token_id: Callable[[Any], int],
+    write_text: Callable[[str], None] | None = None,
+    on_before_decode: Callable[[], None] | None = None,
+) -> GenerationResult:
+    if max_new_tokens < 0:
+        raise ValueError(f"max_new_tokens must be >= 0, got {max_new_tokens}")
+
+    write_text = write_text or (lambda _: None)
+    on_before_decode = on_before_decode or (lambda: None)
+    prompt_token_ids = ensure_non_empty_prompt_tokens(
+        tokenize_prompt(tokenizer, prompt),
+        getattr(tokenizer, "bos_token_id", None),
+    )
+    prefill_inputs = [make_input_tensor(token_id) for token_id in prompt_token_ids]
+
+    started = False
+    try:
+        model.start()
+        started = True
+
+        last_prefill_output = model.prefill(prefill_inputs)
+        next_token_id = extract_token_id(last_prefill_output)
+        on_before_decode()
+
+        generated_token_ids: list[int] = []
+        generated_chunks: list[str] = []
+        for _ in range(max_new_tokens):
+            decode_input = make_input_tensor(next_token_id)
+            decode_output = model.decode_step(decode_input)
+            next_token_id = extract_token_id(decode_output)
+
+            generated_token_ids.append(next_token_id)
+            chunk = tokenizer.decode([next_token_id], skip_special_tokens=False)
+            generated_chunks.append(chunk)
+            write_text(chunk)
+
+        return GenerationResult(
+            prompt_token_ids=prompt_token_ids,
+            generated_token_ids=generated_token_ids,
+            generated_text="".join(generated_chunks),
+        )
+    finally:
+        if started:
+            model.stop()

--- a/models/demos/deepseek_v3_b1/demo/runtime.py
+++ b/models/demos/deepseek_v3_b1/demo/runtime.py
@@ -1,0 +1,61 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import torch
+
+import ttnn
+from models.demos.deepseek_v3_b1.model import TOKEN_ID_BYTES, DeepSeekV3, page_size_bytes, to_padded_input
+
+
+def create_model(
+    mesh_device: ttnn.MeshDevice,
+    *,
+    batch_size: int = 1,
+    loopback_mode: bool = True,
+) -> DeepSeekV3:
+    fifo_size = page_size_bytes(batch_size)
+    socket_core = ttnn.MeshCoreCoord(ttnn.MeshCoordinate(0, 0), ttnn.CoreCoord(0, 0))
+    h2d_socket_prefill = ttnn.H2DSocket(
+        mesh_device,
+        socket_core,
+        ttnn.BufferType.L1,
+        fifo_size,
+        ttnn.H2DMode.DEVICE_PULL,
+    )
+    h2d_socket_decode = ttnn.H2DSocket(
+        mesh_device,
+        socket_core,
+        ttnn.BufferType.L1,
+        fifo_size,
+        ttnn.H2DMode.HOST_PUSH,
+    )
+    d2h_socket = ttnn.D2HSocket(mesh_device, socket_core, fifo_size)
+    return DeepSeekV3(
+        h2d_socket_prefill=h2d_socket_prefill,
+        h2d_socket_decode=h2d_socket_decode,
+        d2h_socket=d2h_socket,
+        batch_size=batch_size,
+        loopback_mode=loopback_mode,
+    )
+
+
+class TokenCodec:
+    def __init__(self, *, batch_size: int) -> None:
+        self.batch_size = int(batch_size)
+        if self.batch_size <= 0:
+            raise ValueError(f"batch_size must be > 0, got {batch_size}")
+        self.page_size_datums = page_size_bytes(self.batch_size) // TOKEN_ID_BYTES
+
+    def make_input(self, token_id: int) -> ttnn.Tensor:
+        torch_token = torch.full((self.batch_size, 1), int(token_id), dtype=torch.int32)
+        return to_padded_input(torch_token, batch_size=self.batch_size, page_size_datums=self.page_size_datums)
+
+    def make_prefill_inputs(self, token_ids: list[int]) -> list[ttnn.Tensor]:
+        return [self.make_input(token_id) for token_id in token_ids]
+
+    def extract_token_id(self, output_tensor: ttnn.Tensor) -> int:
+        torch_output = ttnn.to_torch(output_tensor).reshape(-1)
+        return int(torch_output[0].item())

--- a/models/demos/deepseek_v3_b1/model.py
+++ b/models/demos/deepseek_v3_b1/model.py
@@ -1,0 +1,229 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+DeepSeek V3 B1 model (host interface).
+
+Orchestrates prefill (token-by-token prompt processing) and autoregressive decode
+over the socket interface. Uses HostInterface in loopback mode as a mock decoder
+until the real decoder pipeline is composed from Pre-SDPA, Flash MLA, Post-SDPA, MoE.
+
+Algorithm (prefill-by-decode then generation):
+  - Prefill: for i = 0..S-1, call with input_ids = x[i] (B, 1); device uses/updates
+    cache; ignore logits for i < S-1. prefill() returns the last step output (logits
+    in real decoder) so caller can sample y0.
+  - Start generation: last_logits = prefill(prompt_tokens); y0 = sample(last_logits).
+  - Generation loop: for t = 0,1,..., feed y[t] (B, 1) via decode_step(), get logits,
+    sample y[t+1], repeat.
+
+Input tensor shape (H2D):
+  - Only (B, 1) is supported: one token per batch element per step. The embedding layer
+    runs on device; the host sends token IDs (int32). Payload size is B * TOKEN_ID_BYTES.
+
+Interface vs real decoder:
+  - One H2D write and one D2H read per step. The real decoder will also need per-step
+    position (cur_pos_tensor / kv_cache_write_index); the engine tracks position for
+    when the protocol is extended.
+"""
+
+import torch
+from loguru import logger
+
+import ttnn
+from models.demos.deepseek_v3_b1.micro_ops.host_io.op import HostInterface
+
+# Token IDs are int32 over the socket; payload size per step is B * TOKEN_ID_BYTES.
+TOKEN_ID_BYTES: int = 4
+
+# Socket page_size must be PCIe-aligned (see h2d_socket.cpp). Use 64 to work across devices.
+PCIE_PAGE_ALIGNMENT_BYTES: int = 64
+
+
+def align_up(value: int, alignment: int) -> int:
+    """Round value up to the next multiple of alignment."""
+    return (value + alignment - 1) // alignment * alignment
+
+
+def page_size_bytes(batch_size: int) -> int:
+    """PCIe-aligned page (and FIFO) size in bytes for (B, 1) token IDs. Use for socket creation."""
+    return align_up(batch_size * TOKEN_ID_BYTES, PCIE_PAGE_ALIGNMENT_BYTES)
+
+
+def create_output_buffer(page_size_datums: int) -> ttnn.Tensor:
+    """Allocate a host output tensor (1, page_size_datums) int32 for socket read_tensor."""
+    torch_output = torch.zeros(1, page_size_datums, dtype=torch.int32)
+    return ttnn.from_torch(torch_output, dtype=ttnn.uint32, layout=ttnn.ROW_MAJOR_LAYOUT)
+
+
+def to_padded_input(
+    token: torch.Tensor | ttnn.Tensor,
+    batch_size: int,
+    page_size_datums: int,
+) -> ttnn.Tensor:
+    """Copy (B, 1) token into a PCIe-aligned padded buffer for write_tensor."""
+    if isinstance(token, ttnn.Tensor):
+        token = ttnn.to_torch(token)
+    torch_padded = torch.zeros(1, page_size_datums, dtype=torch.int32)
+    torch_padded[0, :batch_size] = token.flatten()[:batch_size]
+    return ttnn.from_torch(torch_padded, dtype=ttnn.uint32, layout=ttnn.ROW_MAJOR_LAYOUT)
+
+
+class DeepSeekV3:
+    """
+    Host-side model interface for prefill and decode over H2D/D2H sockets.
+    Tracks position for compatibility with the real decoder (position_ids, kv_cache_write_index).
+
+    Prefill uses DEVICE_PULL H2D; decode uses HOST_PUSH H2D. Two HostInterface programs
+    run one at a time on the same core; the first decode_step() transitions from prefill
+    to decode host I/O.
+    """
+
+    def __init__(
+        self,
+        h2d_socket_prefill: ttnn.H2DSocket,
+        h2d_socket_decode: ttnn.H2DSocket,
+        d2h_socket: ttnn.D2HSocket,
+        batch_size: int = 1,
+        loopback_mode: bool = False,
+    ) -> None:
+        """
+        Args:
+            h2d_socket_prefill: H2D socket for prefill; must use DEVICE_PULL mode.
+            h2d_socket_decode: H2D socket for decode; must use HOST_PUSH mode.
+            d2h_socket: D2H socket for device-to-host (shared by prefill and decode).
+            batch_size: Batch size B. Current implementation supports only B=1;
+                payload size is B * TOKEN_ID_BYTES (int32).
+            loopback_mode: If True, host I/O uses circular buffers for H2D/D2H loopback
+                If False, host I/O forwards to downstream/upstream cores via D2D sockets.
+
+        Sockets must be created with FIFO size equal to page_size_bytes(batch_size).
+        """
+        if batch_size != 1:
+            raise ValueError(f"DeepSeekV3 currently supports only batch_size=1, got {batch_size}")
+        if h2d_socket_prefill.get_h2d_mode() != ttnn.H2DMode.DEVICE_PULL:
+            raise ValueError(
+                "h2d_socket_prefill must use H2DMode.DEVICE_PULL, got " f"{h2d_socket_prefill.get_h2d_mode()}"
+            )
+        if h2d_socket_decode.get_h2d_mode() != ttnn.H2DMode.HOST_PUSH:
+            raise ValueError("h2d_socket_decode must use H2DMode.HOST_PUSH, got " f"{h2d_socket_decode.get_h2d_mode()}")
+
+        self.h2d_socket_prefill = h2d_socket_prefill
+        self.h2d_socket_decode = h2d_socket_decode
+        self.d2h_socket = d2h_socket
+        self.batch_size = batch_size
+        payload_bytes: int = batch_size * TOKEN_ID_BYTES
+        logger.debug(f"Payload bytes: {payload_bytes} bytes")
+        self._tensor_size_bytes: int = align_up(payload_bytes, PCIE_PAGE_ALIGNMENT_BYTES)
+        self._page_size_datums: int = self._tensor_size_bytes // TOKEN_ID_BYTES
+
+        logger.debug(f"Creating DeepSeekV3 model with batch size {batch_size}")
+        logger.debug(
+            f"Creating host I/O for prefill and decode with aligned page size {self._tensor_size_bytes} bytes (payload size is {payload_bytes} bytes)"
+        )
+
+        self._host_io_prefill: HostInterface = HostInterface(
+            h2d_socket_prefill,
+            d2h_socket,
+            self._tensor_size_bytes,
+            self._tensor_size_bytes,
+            core_to_core_socket_buffer_size=self._tensor_size_bytes,
+            loopback_mode=loopback_mode,
+        )
+        self._host_io_decode: HostInterface = HostInterface(
+            h2d_socket_decode,
+            d2h_socket,
+            self._tensor_size_bytes,
+            self._tensor_size_bytes,
+            core_to_core_socket_buffer_size=self._tensor_size_bytes,
+            loopback_mode=loopback_mode,
+        )
+        self._prefill_active: bool = False
+        self._decode_active: bool = False
+        self._position: int = 0
+        self._output_buffer: ttnn.Tensor = create_output_buffer(self._page_size_datums)
+
+    def start(self) -> None:
+        """Launch the prefill mock decoder program (DEVICE_PULL H2D) on device."""
+        self._host_io_prefill.run()
+        self._prefill_active = True
+        self._decode_active = False
+
+    def _switch_to_decode(self) -> None:
+        """One-time transition: terminate prefill host I/O, launch decode host I/O (HOST_PUSH)."""
+        if self._decode_active:
+            return
+        if self._prefill_active:
+            logger.debug(f"Terminating prefill host I/O")
+            self._host_io_prefill.terminate()
+            self._prefill_active = False
+        logger.debug(f"Switching to decode host I/O")
+        self._host_io_decode.run()
+        self._decode_active = True
+
+    def prefill(self, prompt_tokens: list[ttnn.Tensor]) -> ttnn.Tensor:
+        """
+        Prefill-by-decode: for i = 0..S-1, send input_ids = x[i], get logits
+        (and device updates cache). Outputs for i < S-1 are discarded. Returns the
+        last step output so the caller can sample y0 (first generated token).
+
+        Args:
+            prompt_tokens: List of ttnn.Tensor, each already padded for the socket
+                (PCIe-aligned, size in bytes equal to page_size_bytes(batch_size)).
+                Caller is responsible for padding; use to_padded_input() if needed.
+
+        Returns:
+            Last step output tensor; valid data is first batch_size elements (logits
+            (B, V) in real decoder). None if prompt_tokens is empty. Caller uses this
+            to sample(logits) -> y0 for the generation loop.
+        """
+        if len(prompt_tokens) == 0:
+            raise ValueError("Expected at least one prompt token")
+
+        last_output: ttnn.Tensor | None = None
+        for token in prompt_tokens:
+            self.h2d_socket_prefill.write_tensor(token)
+            self.d2h_socket.read_tensor(self._output_buffer)
+            last_output = self._output_buffer
+            self._position += 1
+        assert last_output is not None, "Last output tensor is None"
+        return last_output
+
+    def decode_step(self, input_tensor: ttnn.Tensor) -> ttnn.Tensor:
+        """
+        Single decode step: send input via H2D, receive output via D2H.
+        On first call, transitions from prefill host I/O to decode host I/O (HOST_PUSH).
+        Returns the output tensor. Increments position.
+
+        Args:
+            input_tensor: Token IDs (B, 1), torch or ttnn.
+
+        Returns:
+            Output tensor; valid data is first batch_size elements. In loopback mode
+            that matches the input.
+        """
+        assert len(input_tensor.shape) == 2, f"Input tensor shape must be (B, 1), got {input_tensor.shape}"
+        assert (
+            input_tensor.shape[0] == self.batch_size
+        ), f"Input tensor batch size must be {self.batch_size}, got {input_tensor.shape[0]}"
+
+        self._switch_to_decode()
+        padded_input = to_padded_input(input_tensor, self.batch_size, self._page_size_datums)
+        self.h2d_socket_decode.write_tensor(padded_input)
+        self.d2h_socket.read_tensor(self._output_buffer)
+        self._position += 1
+        return self._output_buffer
+
+    @property
+    def position(self) -> int:
+        """Current sequence position (number of tokens processed so far)."""
+        return self._position
+
+    def stop(self) -> None:
+        """Clean shutdown of whichever mock decoder (prefill or decode) is active."""
+        if self._prefill_active:
+            self._host_io_prefill.terminate()
+            self._prefill_active = False
+        if self._decode_active:
+            self._host_io_decode.terminate()
+            self._decode_active = False

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_demo.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_demo.py
@@ -1,0 +1,185 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import pytest
+
+from models.demos.deepseek_v3_b1.demo.runner import run_generation
+
+
+class FakeTokenizer:
+    def __init__(self, *, prompt_tokens: list[int], bos_token_id: int | None = 1):
+        self._prompt_tokens = prompt_tokens
+        self.bos_token_id = bos_token_id
+
+    def encode(self, text: str, add_special_tokens: bool = True) -> list[int]:
+        del text, add_special_tokens
+        return list(self._prompt_tokens)
+
+    def decode(self, token_ids: list[int], skip_special_tokens: bool = False) -> str:
+        del skip_special_tokens
+        return f"<{token_ids[0]}>"
+
+
+class FakeModel:
+    def __init__(self, decode_outputs: list[int]):
+        self._decode_outputs = list(decode_outputs)
+        self.started = False
+        self.stopped = False
+        self.prefill_inputs: list[int] = []
+        self.decode_inputs: list[int] = []
+
+    def start(self) -> None:
+        self.started = True
+
+    def prefill(self, prompt_tokens: list[int]) -> int:
+        self.prefill_inputs = list(prompt_tokens)
+        return prompt_tokens[-1]
+
+    def decode_step(self, input_tensor: int) -> int:
+        self.decode_inputs.append(input_tensor)
+        return self._decode_outputs.pop(0)
+
+    def stop(self) -> None:
+        self.stopped = True
+
+
+def test_run_generation_streams_decode_text_and_tracks_token_flow():
+    tokenizer = FakeTokenizer(prompt_tokens=[11, 12], bos_token_id=1)
+    model = FakeModel(decode_outputs=[101, 102, 103])
+    streamed_chunks: list[str] = []
+
+    result = run_generation(
+        model=model,
+        tokenizer=tokenizer,
+        prompt="hello",
+        max_new_tokens=3,
+        make_input_tensor=lambda token_id: token_id,
+        extract_token_id=lambda output: output,
+        write_text=streamed_chunks.append,
+    )
+
+    assert model.started
+    assert model.stopped
+    assert model.prefill_inputs == [11, 12]
+    assert model.decode_inputs == [12, 101, 102]
+    assert result.prompt_token_ids == [11, 12]
+    assert result.generated_token_ids == [101, 102, 103]
+    assert result.generated_text == "<101><102><103>"
+    assert "".join(streamed_chunks) == "<101><102><103>"
+
+
+def test_run_generation_uses_bos_for_empty_prompt():
+    tokenizer = FakeTokenizer(prompt_tokens=[], bos_token_id=7)
+    model = FakeModel(decode_outputs=[8, 9])
+
+    result = run_generation(
+        model=model,
+        tokenizer=tokenizer,
+        prompt="",
+        max_new_tokens=2,
+        make_input_tensor=lambda token_id: token_id,
+        extract_token_id=lambda output: output,
+    )
+
+    assert model.prefill_inputs == [7]
+    assert model.decode_inputs == [7, 8]
+    assert result.prompt_token_ids == [7]
+    assert result.generated_token_ids == [8, 9]
+
+
+def test_run_generation_stops_model_if_decode_raises():
+    tokenizer = FakeTokenizer(prompt_tokens=[3], bos_token_id=1)
+
+    class FailingModel(FakeModel):
+        def decode_step(self, input_tensor: int) -> int:
+            super().decode_step(input_tensor)
+            raise RuntimeError("decode failed")
+
+    model = FailingModel(decode_outputs=[4])
+
+    with pytest.raises(RuntimeError, match="decode failed"):
+        run_generation(
+            model=model,
+            tokenizer=tokenizer,
+            prompt="x",
+            max_new_tokens=1,
+            make_input_tensor=lambda token_id: token_id,
+            extract_token_id=lambda output: output,
+        )
+
+    assert model.started
+    assert model.stopped
+
+
+def test_run_generation_rejects_negative_max_new_tokens():
+    tokenizer = FakeTokenizer(prompt_tokens=[1], bos_token_id=1)
+    model = FakeModel(decode_outputs=[])
+
+    with pytest.raises(ValueError, match="max_new_tokens must be >= 0"):
+        run_generation(
+            model=model,
+            tokenizer=tokenizer,
+            prompt="x",
+            max_new_tokens=-1,
+            make_input_tensor=lambda token_id: token_id,
+            extract_token_id=lambda output: output,
+        )
+
+    assert not model.started
+    assert not model.stopped
+
+
+class _LoopbackTokenizer:
+    bos_token_id = 1
+
+    def encode(self, text: str, add_special_tokens: bool = True) -> list[int]:
+        del text, add_special_tokens
+        return [self.bos_token_id]
+
+    def decode(self, token_ids: list[int], skip_special_tokens: bool = False) -> str:
+        del token_ids, skip_special_tokens
+        return ""
+
+
+@pytest.mark.slow
+@pytest.mark.skip_post_commit
+@pytest.mark.timeout(3600)
+def test_demo_decode_stress_64k_tokens(mesh_device) -> None:
+    from models.common.utility_functions import is_slow_dispatch
+    from models.demos.deepseek_v3_b1.demo.cli import (
+        create_deepseek_v3,
+        extract_token_id_from_output,
+        make_padded_input_tensor,
+    )
+    from models.demos.deepseek_v3_b1.model import TOKEN_ID_BYTES, page_size_bytes
+
+    if not is_slow_dispatch():
+        pytest.skip("Skipping stress test in fast dispatch mode")
+
+    max_new_tokens = 65536
+    batch_size = 1
+    tokenizer = _LoopbackTokenizer()
+    page_size_datums = page_size_bytes(batch_size) // TOKEN_ID_BYTES
+    model = create_deepseek_v3(mesh_device=mesh_device, batch_size=batch_size, loopback_mode=True)
+
+    result = run_generation(
+        model=model,
+        tokenizer=tokenizer,
+        prompt="",
+        max_new_tokens=max_new_tokens,
+        make_input_tensor=lambda token_id: make_padded_input_tensor(
+            token_id,
+            batch_size=batch_size,
+            page_size_datums=page_size_datums,
+        ),
+        extract_token_id=extract_token_id_from_output,
+        write_text=lambda _: None,
+    )
+
+    assert len(result.generated_token_ids) == max_new_tokens
+    assert result.generated_token_ids[0] == tokenizer.bos_token_id
+    assert result.generated_token_ids[-1] == tokenizer.bos_token_id
+    assert model.position == 1 + max_new_tokens

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_demo.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_demo.py
@@ -149,12 +149,7 @@ class _LoopbackTokenizer:
 @pytest.mark.timeout(3600)
 def test_demo_decode_stress_64k_tokens(mesh_device) -> None:
     from models.common.utility_functions import is_slow_dispatch
-    from models.demos.deepseek_v3_b1.demo.cli import (
-        create_deepseek_v3,
-        extract_token_id_from_output,
-        make_padded_input_tensor,
-    )
-    from models.demos.deepseek_v3_b1.model import TOKEN_ID_BYTES, page_size_bytes
+    from models.demos.deepseek_v3_b1.demo.runtime import TokenCodec, create_model
 
     if not is_slow_dispatch():
         pytest.skip("Skipping stress test in fast dispatch mode")
@@ -162,20 +157,16 @@ def test_demo_decode_stress_64k_tokens(mesh_device) -> None:
     max_new_tokens = 65536
     batch_size = 1
     tokenizer = _LoopbackTokenizer()
-    page_size_datums = page_size_bytes(batch_size) // TOKEN_ID_BYTES
-    model = create_deepseek_v3(mesh_device=mesh_device, batch_size=batch_size, loopback_mode=True)
+    token_codec = TokenCodec(batch_size=batch_size)
+    model = create_model(mesh_device=mesh_device, batch_size=batch_size, loopback_mode=True)
 
     result = run_generation(
         model=model,
         tokenizer=tokenizer,
         prompt="",
         max_new_tokens=max_new_tokens,
-        make_input_tensor=lambda token_id: make_padded_input_tensor(
-            token_id,
-            batch_size=batch_size,
-            page_size_datums=page_size_datums,
-        ),
-        extract_token_id=extract_token_id_from_output,
+        make_input_tensor=token_codec.make_input,
+        extract_token_id=token_codec.extract_token_id,
         write_text=lambda _: None,
     )
 

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_model.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_model.py
@@ -1,0 +1,88 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Tests for DeepSeek V3 B1 model (prefill harness and decode flow).
+
+Uses HostInterface in loopback mode as a mock decoder; validates prefill
+(token-by-token with outputs discarded) and autoregressive decode (input → output).
+"""
+
+from __future__ import annotations
+
+import pytest
+import torch
+from loguru import logger
+
+import ttnn
+from models.common.utility_functions import is_slow_dispatch
+from models.demos.deepseek_v3_b1.model import TOKEN_ID_BYTES, DeepSeekV3, page_size_bytes, to_padded_input
+
+
+@pytest.mark.parametrize("loopback_mode", [True, False])
+@pytest.mark.parametrize("batch_size", [1])
+@pytest.mark.parametrize("prompt_length", [1, 8, 64, 128])
+@pytest.mark.parametrize("num_decode_steps", [1, 16, 32])
+def test_prefill_and_decode(
+    mesh_device: ttnn.MeshDevice,
+    loopback_mode: bool,
+    batch_size: int,
+    prompt_length: int,
+    num_decode_steps: int,
+) -> None:
+    if not is_slow_dispatch():
+        pytest.skip("Skipping test in fast dispatch mode")
+    if not loopback_mode:
+        pytest.skip("Non-loopback mode is not currently supported")
+
+    fifo_size = page_size_bytes(batch_size)
+
+    device_coord: ttnn.MeshCoordinate = ttnn.MeshCoordinate(0, 0)
+    core_coord: ttnn.CoreCoord = ttnn.CoreCoord(0, 0)
+    socket_core: ttnn.MeshCoreCoord = ttnn.MeshCoreCoord(device_coord, core_coord)
+
+    logger.info("Creating sockets and DeepSeekV3 model (prefill=DEVICE_PULL, decode=HOST_PUSH)")
+    h2d_socket_prefill = ttnn.H2DSocket(
+        mesh_device, socket_core, ttnn.BufferType.L1, fifo_size, ttnn.H2DMode.DEVICE_PULL
+    )
+    h2d_socket_decode = ttnn.H2DSocket(mesh_device, socket_core, ttnn.BufferType.L1, fifo_size, ttnn.H2DMode.HOST_PUSH)
+    d2h_socket = ttnn.D2HSocket(mesh_device, socket_core, fifo_size)
+    model = DeepSeekV3(h2d_socket_prefill, h2d_socket_decode, d2h_socket, batch_size, loopback_mode=loopback_mode)
+    model.start()
+
+    logger.info(f"B={batch_size}, prefill {prompt_length} tokens, then {num_decode_steps} decode steps")
+
+    # Phase 1: Prefill - list of padded ttnn.Tensor tokens
+    page_size_datums = page_size_bytes(batch_size) // TOKEN_ID_BYTES
+    prompt_tokens: list[ttnn.Tensor] = [
+        to_padded_input(
+            torch.full((batch_size, 1), i, dtype=torch.int32),
+            batch_size,
+            page_size_datums,
+        )
+        for i in range(prompt_length)
+    ]
+    model.prefill(prompt_tokens)
+    assert model.position == prompt_length, f"Position after prefill: expected {prompt_length}, got {model.position}"
+
+    # Phase 2: Decode - each step (B, 1) in, (B, 1) out; loopback => output == input
+    for step in range(num_decode_steps):
+        token_id = prompt_length + step
+        torch_input = torch.full((batch_size, 1), token_id, dtype=torch.int32)
+        input_tensor = ttnn.from_torch(torch_input, dtype=ttnn.uint32, layout=ttnn.ROW_MAJOR_LAYOUT)
+        output_tensor = model.decode_step(input_tensor)
+        result_torch = ttnn.to_torch(output_tensor)
+
+        # Output is padded to PCIe alignment; valid data is first batch_size elements
+        result_valid = result_torch.reshape(-1)[:batch_size].reshape(batch_size, 1)
+        assert torch.equal(
+            torch_input, result_valid
+        ), f"Decode step {step} loopback mismatch: expected {torch_input}, got {result_valid}"
+
+    assert (
+        model.position == prompt_length + num_decode_steps
+    ), f"Position after decode: expected {prompt_length + num_decode_steps}, got {model.position}"
+
+    model.stop()
+    logger.info("Prefill and decode test passed")

--- a/ttnn/cpp/ttnn-nanobind/mesh_socket.cpp
+++ b/ttnn/cpp/ttnn-nanobind/mesh_socket.cpp
@@ -128,6 +128,15 @@ void py_module_types(nb::module_& mod) {
                 Note:
                     Sockets should typically be created in pairs using create_socket_pair()
                     rather than using this constructor directly.
+            )doc")
+        .def(
+            "get_config_buffer_address",
+            [](const tt::tt_metal::distributed::MeshSocket& socket) {
+                return static_cast<uint32_t>(socket.get_config_buffer()->address());
+            },
+            R"doc(
+                Returns the L1 address of the socket configuration buffer on the device.
+                This address is passed to device kernels to access socket metadata.
             )doc");
 }
 


### PR DESCRIPTION
### Ticket
- https://github.com/tenstorrent/tt-metal/issues/37977

### Summary

Adds a demo CLI script for the DeepSeekV3 B1 model. Currently, this demo internally uses the `HostInterface` with loopback interface to mock the true decoder implementation while it is still being integrated.  This change also adds unit tests for the demo script that will run in BH APC. 

### Checklist

- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/22143264726)