### PR TITLE
#36397 [GPT-OSS] low latency enabling prefill up to 32k

### DIFF
--- a/models/demos/gpt_oss/demo/text_demo.py
+++ b/models/demos/gpt_oss/demo/text_demo.py
@@ -401,8 +401,6 @@ def test_gpt_oss_demo(
         pytest.skip(
             f"Batch size = 128 demo skipped for mesh shape f{mesh_shape}. Only single user demo is supported for single row meshes."
         )
-    if mesh_shape[0] > 1 and (batch_size * data_parallel) == 1:
-        pytest.skip("For 4x8 mesh, batch * DP should be greater than 1.")
 
     if os.environ.get("CI", None) and long_context_mode:
         pytest.skip(f"Long-context mode skipped for CI environment.")
@@ -1047,7 +1045,7 @@ def test_gpt_oss_demo(
                 if len(prompt) > 200
                 else prompt
             )
-            user_label = f"USER {i} (row {i // users_per_row})" if long_context_mode else f"USER {i}"
+            user_label = f"USER {i} (row {i // max(users_per_row,1)})" if long_context_mode else f"USER {i}"
             logger.info(
                 f"\n==REPEAT BATCH {batch_idx}\n=={user_label} - PROMPT\n{short_prompt} \n=={user_label} - OUTPUT\n{text_after_prompt.strip()}\n"
             )

--- a/models/demos/gpt_oss/demo/text_demo.py
+++ b/models/demos/gpt_oss/demo/text_demo.py
@@ -297,7 +297,7 @@ def prepare_gpt_oss_generator_args(
             True,  # enable_decode_trace
             True,  # enable_prefill_trace
             False,  # users_row_sharded
-            True,  # long_context_mode
+            False,  # long_context_mode
             False,  # stop_at_eos
         ),
         (
@@ -312,7 +312,7 @@ def prepare_gpt_oss_generator_args(
             True,  # enable_decode_trace
             True,  # enable_prefill_trace
             False,  # users_row_sharded
-            True,  # long_context_mode
+            False,  # long_context_mode
             False,  # stop_at_eos
         ),
         (
@@ -327,7 +327,7 @@ def prepare_gpt_oss_generator_args(
             True,  # enable_decode_trace
             True,  # enable_prefill_trace
             False,  # users_row_sharded
-            True,  # long_context_mode
+            False,  # long_context_mode
             False,  # stop_at_eos
         ),
         # (
@@ -367,7 +367,7 @@ def prepare_gpt_oss_generator_args(
         "prefill_4k",
         "batch128",
         "long_context_128k",
-        "long_context_short_prefill_long_decode"
+        "long_context_short_prefill_long_decode",
         "prefill_8k",
         "prefill_16k",
         "prefill_32k",
@@ -401,6 +401,8 @@ def test_gpt_oss_demo(
         pytest.skip(
             f"Batch size = 128 demo skipped for mesh shape f{mesh_shape}. Only single user demo is supported for single row meshes."
         )
+    if long_context_mode:
+        assert batch_size >= mesh_shape[0], "Long-context mode requires batch_size >= number of mesh rows"
 
     if os.environ.get("CI", None) and long_context_mode:
         pytest.skip(f"Long-context mode skipped for CI environment.")

--- a/models/demos/gpt_oss/demo/text_demo.py
+++ b/models/demos/gpt_oss/demo/text_demo.py
@@ -178,6 +178,7 @@ def prepare_gpt_oss_generator_args(
     return model_args, model, page_table, tt_kv_cache, tokenizer, processor, paged_attention_config
 
 
+@pytest.mark.timeout(1200)
 @pytest.mark.parametrize(
     "mesh_shape",
     [
@@ -293,10 +294,11 @@ def prepare_gpt_oss_generator_args(
             200,  # max_generated_tokens
             {"page_block_size": 64, "page_max_num_blocks_per_dp": 128 * 1024 // 64},  # page_params
             {"temperature": 0, "top_p": 0.08},  # sampling_params (greedy decoding)
-            False,  # enable_decode_trace
-            False,  # enable_prefill_trace
+            True,  # enable_decode_trace
+            True,  # enable_prefill_trace
             False,  # users_row_sharded
-            False,  # long_context_mode
+            True,  # long_context_mode
+            False,  # stop_at_eos
         ),
         (
             "models/tt_transformers/demo/sample_prompts/input_data_long_16k.json",  # input_prompts
@@ -305,12 +307,13 @@ def prepare_gpt_oss_generator_args(
             1,  # repeat_batches
             16 * 1024,  # max_seq_len
             200,  # max_generated_tokens
-            {"page_block_size": 64, "page_max_num_blocks_per_dp": 256 * 1024 // 64},  # page_params
+            {"page_block_size": 64, "page_max_num_blocks_per_dp": 128 * 1024 // 64},  # page_params
             {"temperature": 0, "top_p": 0.08},  # sampling_params (greedy decoding)
-            False,  # enable_decode_trace
-            False,  # enable_prefill_trace
+            True,  # enable_decode_trace
+            True,  # enable_prefill_trace
             False,  # users_row_sharded
-            False,  # long_context_mode
+            True,  # long_context_mode
+            False,  # stop_at_eos
         ),
         # (
         #     "models/tt_transformers/demo/sample_prompts/input_data_long_32k.json",  # input_prompts
@@ -319,8 +322,13 @@ def prepare_gpt_oss_generator_args(
         #     1,  # repeat_batches
         #     32 * 1024,  # max_seq_len
         #     200,  # max_generated_tokens
-        #     {"page_block_size": 64, "page_max_num_blocks_per_dp": 4 * 1024 // 64},  # page_params
+        #     {"page_block_size": 64, "page_max_num_blocks_per_dp":  128 * 1024 // 64},  # page_params
         #     {"temperature": 0, "top_p": 0.08},  # sampling_params (greedy decoding)
+        #     True,  # enable_decode_trace
+        #     True,  # enable_prefill_trace
+        #     False,  # users_row_sharded
+        #     True,  # long_context_mode
+        #     False,  # stop_at_eos
         # ),
         # (
         #     "models/tt_transformers/demo/sample_prompts/input_data_long_64k.json",  # input_prompts
@@ -329,18 +337,13 @@ def prepare_gpt_oss_generator_args(
         #     1,  # repeat_batches
         #     64 * 1024,  # max_seq_len
         #     200,  # max_generated_tokens
-        #     {"page_block_size": 64, "page_max_num_blocks_per_dp": 4 * 1024 // 64},  # page_params
-        #     {"temperature": 0, "top_p": 0.08},  # sampling_params (greedy decoding)
-        # ),
-        # (
-        #     "models/tt_transformers/demo/sample_prompts/input_data_long_128k.json",  # input_prompts
-        #     1,  # data_parallel
-        #     1,  # batch_size
-        #     1,  # repeat_batches
-        #     128 * 1024,  # max_seq_len
-        #     200,  # max_generated_tokens
-        #     {"page_block_size": 64, "page_max_num_blocks_per_dp": 4 * 1024 // 64},  # page_params
-        #     {"temperature": 0, "top_p": 0.08},  # sampling_params (greedy decoding)
+        #     {"page_block_size": 64, "page_max_num_blocks_per_dp": 128 * 1024 // 64},  # page_params
+        #     {"temperature": 0, "top_p": 0.08},  # sampling_params (greedy decoding),
+        #     True,  # enable_decode_trace
+        #     True,  # enable_prefill_trace
+        #     False,  # users_row_sharded
+        #     True,  # long_context_mode
+        #     False,  # stop_at_eos
         # ),
     ],
     ids=[
@@ -352,9 +355,9 @@ def prepare_gpt_oss_generator_args(
         "long_context_short_prefill_long_decode"
         "prefill_8k",
         "prefill_16k",
-        # "prefill_32k",
-        # "prefill_64k",
-        # "prefill_128k",
+        "prefill_32k",
+        # "prefill_64k", OOM error
+        # "prefill_128k", OOM error
     ],
 )
 @parametrize_mesh_with_fabric()
@@ -383,6 +386,9 @@ def test_gpt_oss_demo(
         pytest.skip(
             f"Batch size = 128 demo skipped for mesh shape f{mesh_shape}. Only single user demo is supported for single row meshes."
         )
+    if mesh_shape[0] > 1 and (batch_size * data_parallel) == 1:
+        pytest.skip("For 4x8 mesh, batch * DP should be greater than 1.")
+
     if os.environ.get("CI", None) and long_context_mode:
         pytest.skip(f"Long-context mode skipped for CI environment.")
     mesh_device = mesh_device.create_submesh(ttnn.MeshShape(mesh_shape))

--- a/models/demos/gpt_oss/demo/text_demo.py
+++ b/models/demos/gpt_oss/demo/text_demo.py
@@ -315,15 +315,30 @@ def prepare_gpt_oss_generator_args(
             True,  # long_context_mode
             False,  # stop_at_eos
         ),
+        (
+            "models/tt_transformers/demo/sample_prompts/input_data_long_32k.json",  # input_prompts
+            1,  # data_parallel
+            1,  # batch_size
+            1,  # repeat_batches
+            32 * 1024,  # max_seq_len
+            200,  # max_generated_tokens
+            {"page_block_size": 64, "page_max_num_blocks_per_dp": 128 * 1024 // 64},  # page_params
+            {"temperature": 0, "top_p": 0.08},  # sampling_params (greedy decoding)
+            True,  # enable_decode_trace
+            True,  # enable_prefill_trace
+            False,  # users_row_sharded
+            True,  # long_context_mode
+            False,  # stop_at_eos
+        ),
         # (
-        #     "models/tt_transformers/demo/sample_prompts/input_data_long_32k.json",  # input_prompts
+        #     "models/tt_transformers/demo/sample_prompts/input_data_long_64k.json",  # input_prompts
         #     1,  # data_parallel
         #     1,  # batch_size
         #     1,  # repeat_batches
-        #     32 * 1024,  # max_seq_len
+        #     64 * 1024,  # max_seq_len
         #     200,  # max_generated_tokens
-        #     {"page_block_size": 64, "page_max_num_blocks_per_dp":  128 * 1024 // 64},  # page_params
-        #     {"temperature": 0, "top_p": 0.08},  # sampling_params (greedy decoding)
+        #     {"page_block_size": 64, "page_max_num_blocks_per_dp": 64 * 1024 // 64},  # page_params
+        #     {"temperature": 0, "top_p": 0.08},  # sampling_params (greedy decoding),
         #     True,  # enable_decode_trace
         #     True,  # enable_prefill_trace
         #     False,  # users_row_sharded
@@ -331,11 +346,11 @@ def prepare_gpt_oss_generator_args(
         #     False,  # stop_at_eos
         # ),
         # (
-        #     "models/tt_transformers/demo/sample_prompts/input_data_long_64k.json",  # input_prompts
+        #     "models/tt_transformers/demo/sample_prompts/input_data_long_128k.json",  # input_prompts
         #     1,  # data_parallel
         #     1,  # batch_size
         #     1,  # repeat_batches
-        #     64 * 1024,  # max_seq_len
+        #     128 * 1024,  # max_seq_len
         #     200,  # max_generated_tokens
         #     {"page_block_size": 64, "page_max_num_blocks_per_dp": 128 * 1024 // 64},  # page_params
         #     {"temperature": 0, "top_p": 0.08},  # sampling_params (greedy decoding),
@@ -356,8 +371,8 @@ def prepare_gpt_oss_generator_args(
         "prefill_8k",
         "prefill_16k",
         "prefill_32k",
-        # "prefill_64k", OOM error
-        # "prefill_128k", OOM error
+        # "prefill_64k", #OOM error
+        # "prefill_128k", #OOM error
     ],
 )
 @parametrize_mesh_with_fabric()

--- a/models/demos/gpt_oss/demo/text_demo.py
+++ b/models/demos/gpt_oss/demo/text_demo.py
@@ -124,6 +124,7 @@ def prepare_gpt_oss_generator_args(
     for submesh in submesh_devices:
         # Use GPT-OSS create_tt_model directly!
         use_throughput = mesh_device.shape[0] > 1 and global_batch_size > 1
+        logger.info(f"Creating GPT-OSS model for submesh {submesh} with throughput experts: {use_throughput}")
         model_args_i, model_i, tt_kv_cache_i, state_dict = create_tt_model(
             submesh,
             max_batch_size=global_batch_size // data_parallel,
@@ -282,27 +283,35 @@ def prepare_gpt_oss_generator_args(
             True,  # users_row_sharded
             True,  # long_context_mode - single user per row gets all page blocks
             False,  # stop_at_eos
-        )
-        # (
-        #     "models/tt_transformers/demo/sample_prompts/input_data_long_8k.json",  # input_prompts
-        #     1,  # data_parallel
-        #     1,  # batch_size
-        #     1,  # repeat_batches
-        #     8 * 1024,  # max_seq_len
-        #     200,  # max_generated_tokens
-        #     {"page_block_size": 64, "page_max_num_blocks_per_dp": 4 * 1024 // 64},  # page_params
-        #     {"temperature": 0, "top_p": 0.08},  # sampling_params (greedy decoding)
-        # ),
-        # (
-        #     "models/tt_transformers/demo/sample_prompts/input_data_long_16k.json",  # input_prompts
-        #     1,  # data_parallel
-        #     1,  # batch_size
-        #     1,  # repeat_batches
-        #     16 * 1024,  # max_seq_len
-        #     200,  # max_generated_tokens
-        #     {"page_block_size": 64, "page_max_num_blocks_per_dp": 4 * 1024 // 64},  # page_params
-        #     {"temperature": 0, "top_p": 0.08},  # sampling_params (greedy decoding)
-        # ),
+        ),
+        (
+            "models/tt_transformers/demo/sample_prompts/input_data_long_8k.json",  # input_prompts
+            1,  # data_parallel
+            1,  # batch_size
+            1,  # repeat_batches
+            8 * 1024,  # max_seq_len
+            200,  # max_generated_tokens
+            {"page_block_size": 64, "page_max_num_blocks_per_dp": 128 * 1024 // 64},  # page_params
+            {"temperature": 0, "top_p": 0.08},  # sampling_params (greedy decoding)
+            False,  # enable_decode_trace
+            False,  # enable_prefill_trace
+            False,  # users_row_sharded
+            False,  # long_context_mode
+        ),
+        (
+            "models/tt_transformers/demo/sample_prompts/input_data_long_16k.json",  # input_prompts
+            1,  # data_parallel
+            1,  # batch_size
+            1,  # repeat_batches
+            16 * 1024,  # max_seq_len
+            200,  # max_generated_tokens
+            {"page_block_size": 64, "page_max_num_blocks_per_dp": 256 * 1024 // 64},  # page_params
+            {"temperature": 0, "top_p": 0.08},  # sampling_params (greedy decoding)
+            False,  # enable_decode_trace
+            False,  # enable_prefill_trace
+            False,  # users_row_sharded
+            False,  # long_context_mode
+        ),
         # (
         #     "models/tt_transformers/demo/sample_prompts/input_data_long_32k.json",  # input_prompts
         #     1,  # data_parallel
@@ -341,8 +350,8 @@ def prepare_gpt_oss_generator_args(
         "batch128",
         "long_context_128k",
         "long_context_short_prefill_long_decode"
-        # "prefill_8k",
-        # "prefill_16k",
+        "prefill_8k",
+        "prefill_16k",
         # "prefill_32k",
         # "prefill_64k",
         # "prefill_128k",


### PR DESCRIPTION
### Problem description
GPT OSS hangs with seqlen 8k, as the page table size was too small. The test was disabled.

### What's changed
Enabled the 4k seqlen demo test.

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:{{branch_name}})
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:{{branch_name}})
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:{{branch_name}})
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:{{branch_name}})
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:{{branch_name}})
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:{{branch_name}})
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
