### PR TITLE
Non-causal SDPA data movement improvements

### DIFF
--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/dataflow_common.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/dataflow_common.hpp
@@ -659,8 +659,9 @@ void generate_noncausal_padded_mask(uint32_t Sq_chunk_t, uint32_t Sk_chunk_t, ui
     int zero_tile_idx = -1;
     int inf_tile_idx = -1;
     int vertical_tile_idx = -1;
-    const uint32_t unpadded_Sk_in_chunk =
-        unpadded_Sk % (Sk_chunk_t * tt::constants::TILE_WIDTH);  // TODO: constant for tile width
+    const uint32_t raw_mod = unpadded_Sk % (Sk_chunk_t * tt::constants::TILE_WIDTH);
+    // When raw_mod == 0, the last K chunk is fully valid (no padding) — treat as full chunk size
+    const uint32_t unpadded_Sk_in_chunk = (raw_mod == 0) ? (Sk_chunk_t * tt::constants::TILE_WIDTH) : raw_mod;
     uint32_t unpad_tile_col_in_chunk = unpadded_Sk_in_chunk / tt::constants::TILE_WIDTH;
     uint32_t unpad_col_in_tile = unpadded_Sk_in_chunk % tt::constants::TILE_WIDTH;
 

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/reader_interleaved.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/reader_interleaved.cpp
@@ -22,30 +22,28 @@ FORCE_INLINE uint32_t read_chunk_for_forwarding(
     const uint32_t num_tiles = dst_rows * dst_cols;
     cb_reserve_back(cb_id, num_tiles);
     const uint32_t base_write_ptr = get_write_ptr(cb_id);
-    {
-        const uint32_t outer_ptr_stride = transpose ? tile_bytes : dst_cols * tile_bytes;
-        const uint32_t inner_ptr_stride = transpose ? tile_bytes * dst_rows : tile_bytes;
+    const uint32_t outer_ptr_stride = transpose ? tile_bytes : dst_cols * tile_bytes;
+    const uint32_t inner_ptr_stride = transpose ? tile_bytes * dst_rows : tile_bytes;
 
-        uint32_t tile_id = start_tile_id;
-        for (uint32_t row = 0; row < src_rows; ++row) {
-            uint32_t write_ptr = base_write_ptr + row * outer_ptr_stride;
-            for (uint32_t col = 0; col < src_cols; ++col) {
-                noc_async_read_tile(tile_id++, reader, write_ptr);
-                write_ptr += inner_ptr_stride;
-            }
-            tile_id += skip_src_cols;
+    uint32_t tile_id = start_tile_id;
+    for (uint32_t row = 0; row < src_rows; ++row) {
+        uint32_t write_ptr = base_write_ptr + row * outer_ptr_stride;
+        for (uint32_t col = 0; col < src_cols; ++col) {
+            noc_async_read_tile(tile_id++, reader, write_ptr);
+            write_ptr += inner_ptr_stride;
         }
-        for (uint32_t row = 0; row < dst_rows; ++row) {
-            for (uint32_t col = 0; col < dst_cols; ++col) {
-                if (row < src_rows && col < src_cols) {
-                    continue;
-                }
-                uint32_t tile_idx = transpose ? col * dst_rows + row : row * dst_cols + col;
-                fill_tile_zeros<tile_bytes, false>(cb_id, tile_idx);
-            }
-        }
-        noc_async_read_barrier();
+        tile_id += skip_src_cols;
     }
+    for (uint32_t row = 0; row < dst_rows; ++row) {
+        for (uint32_t col = 0; col < dst_cols; ++col) {
+            if (row < src_rows && col < src_cols) {
+                continue;
+            }
+            uint32_t tile_idx = transpose ? col * dst_rows + row : row * dst_cols + col;
+            fill_tile_zeros<tile_bytes, false>(cb_id, tile_idx);
+        }
+    }
+    noc_async_read_barrier();
     cb_push_back(cb_id, num_tiles);
     return base_write_ptr;
 }
@@ -250,7 +248,6 @@ void kernel_main() {
 
     volatile tt_l1_ptr uint32_t* page_table_ptr;
 
-    uint32_t barrier_count = 0;
     uint32_t chunked_q_chunk_offset = 0;
     if constexpr (is_chunked) {
         if (chunk_start_idx_addr != 0) {
@@ -411,53 +408,49 @@ void kernel_main() {
                         // K: either read locally (injector or not participant) or receive from previous core
                         uint32_t cb_k_start_address = 0;
 
-                        {
-                            if (should_receive) {
-                                // Receive forwarded K chunk from previous core
-                                cb_reserve_back(cb_k_in, k_chunk_tiles);
-                                {
-                                    cb_k_start_address = get_write_ptr(cb_k_in);
-                                    noc_semaphore_set(receiver_semaphore_addr_ptr, INVALID);
-                                    noc_semaphore_inc(sender_semaphore_noc_addr, 1);
-                                    noc_semaphore_wait(receiver_semaphore_addr_ptr, VALID);
-                                }
-                                cb_push_back(cb_k_in, k_chunk_tiles);
+                        if (should_receive) {
+                            // Receive forwarded K chunk from previous core
+                            cb_reserve_back(cb_k_in, k_chunk_tiles);
+                            cb_k_start_address = get_write_ptr(cb_k_in);
+                            noc_semaphore_set(receiver_semaphore_addr_ptr, INVALID);
+                            noc_semaphore_inc(sender_semaphore_noc_addr, 1);
+                            noc_semaphore_wait(receiver_semaphore_addr_ptr, VALID);
+                            cb_push_back(cb_k_in, k_chunk_tiles);
+                        } else {
+                            // Read K chunk from DRAM
+                            if constexpr (is_chunked) {
+                                // Use page table to read K chunk (forwarding not supported for paged mode)
+                                const uint32_t k_chunk_start_row_num = k_chunk * Sk_chunk_t;
+                                read_paged_chunk_with_padding<NKH, block_size_t, DHt>(
+                                    k_reader,
+                                    cb_k_in,
+                                    k_head,
+                                    k_chunk_start_row_num,
+                                    kv_row_tile_count,
+                                    DHt,
+                                    Sk_chunk_t,
+                                    DHt,
+                                    k_tile_bytes,
+                                    barrier_threshold,
+                                    page_table_ptr,
+                                    true  // transpose=true for K reads
+                                );
                             } else {
-                                // Read K chunk from DRAM
-                                if constexpr (is_chunked) {
-                                    // Use page table to read K chunk (forwarding not supported for paged mode)
-                                    const uint32_t k_chunk_start_row_num = k_chunk * Sk_chunk_t;
-                                    read_paged_chunk_with_padding<NKH, block_size_t, DHt>(
+                                if (should_forward) {
+                                    cb_k_start_address = read_chunk_for_forwarding<k_tile_bytes, true>(
+                                        k_reader, cb_k_in, k_start_tile_id, kv_row_tile_count, DHt, Sk_chunk_t, DHt);
+                                } else {
+                                    read_chunk_with_padding<k_tile_bytes>(
                                         k_reader,
                                         cb_k_in,
-                                        k_head,
-                                        k_chunk_start_row_num,
+                                        k_start_tile_id,
                                         kv_row_tile_count,
                                         DHt,
                                         Sk_chunk_t,
                                         DHt,
-                                        k_tile_bytes,
                                         barrier_threshold,
-                                        page_table_ptr,
                                         true  // transpose=true for K reads
                                     );
-                                } else {
-                                    if (should_forward) {
-                                        cb_k_start_address = read_chunk_for_forwarding<k_tile_bytes, true>(
-                                            k_reader, cb_k_in, k_start_tile_id, kv_row_tile_count, DHt, Sk_chunk_t, DHt);
-                                    } else {
-                                        read_chunk_with_padding<k_tile_bytes>(
-                                            k_reader,
-                                            cb_k_in,
-                                            k_start_tile_id,
-                                            kv_row_tile_count,
-                                            DHt,
-                                            Sk_chunk_t,
-                                            DHt,
-                                            barrier_threshold,
-                                            true  // transpose=true for K reads
-                                        );
-                                    }
                                 }
                             }
                         }
@@ -467,28 +460,22 @@ void kernel_main() {
                         // The companion must be issued immediately after the linked write —
                         // any noc_async_read_barrier() between them deadlocks (the read barrier
                         // blocks while a linked write awaits its companion).
-                        {
-                            if (should_forward) {
-                                noc_semaphore_wait(sender_semaphore_addr_ptr, sender_wait_count);
-                                {
-                                    noc_semaphore_set(sender_semaphore_addr_ptr, 0);
-                                    if constexpr (mcast_enabled) {
-                                        uint64_t k_mcast_addr = mcast_base_noc_addr | cb_k_start_address;
-                                        noc_async_write_multicast(
-                                            cb_k_start_address,
-                                            k_mcast_addr,
-                                            k_chunk_tiles * k_tile_bytes,
-                                            mcast_num_dests,
-                                            true /* linked: semaphore mcast follows */);
-                                        noc_semaphore_set_multicast(
-                                            valid_semaphore_addr, mcast_sem_noc_addr, mcast_num_dests);
-                                    } else {
-                                        uint64_t k_unicast_data_addr =
-                                            get_noc_addr(next_physical_x, next_physical_y, cb_k_start_address);
-                                        noc_async_write(
-                                            cb_k_start_address, k_unicast_data_addr, k_chunk_tiles * k_tile_bytes);
-                                    }
-                                }
+                        if (should_forward) {
+                            noc_semaphore_wait(sender_semaphore_addr_ptr, sender_wait_count);
+                            noc_semaphore_set(sender_semaphore_addr_ptr, 0);
+                            if constexpr (mcast_enabled) {
+                                uint64_t k_mcast_addr = mcast_base_noc_addr | cb_k_start_address;
+                                noc_async_write_multicast(
+                                    cb_k_start_address,
+                                    k_mcast_addr,
+                                    k_chunk_tiles * k_tile_bytes,
+                                    mcast_num_dests,
+                                    true /* linked: semaphore mcast follows */);
+                                noc_semaphore_set_multicast(valid_semaphore_addr, mcast_sem_noc_addr, mcast_num_dests);
+                            } else {
+                                uint64_t k_unicast_data_addr =
+                                    get_noc_addr(next_physical_x, next_physical_y, cb_k_start_address);
+                                noc_async_write(cb_k_start_address, k_unicast_data_addr, k_chunk_tiles * k_tile_bytes);
                             }
                         }
 
@@ -496,7 +483,7 @@ void kernel_main() {
                         if constexpr (use_provided_mask) {
                             cb_reserve_back(cb_mask_in, mask_chunk_tiles);
                             uint32_t mask_write_ptr = get_write_ptr(cb_mask_in);
-                            barrier_count = 0;
+                            uint32_t barrier_count = 0;
 
                             uint32_t mask_row_start = mask_batch_offset + q_chunk * Sq_chunk_t * valid_Skt;
                             if constexpr (!broadcast_provided_mask_heads) {
@@ -533,12 +520,10 @@ void kernel_main() {
 
                         // Complete K forward: flush write and signal receiver(s)
                         // (mcast path already completed above — companion sent with linked write)
-                        {
-                            if (should_forward) {
-                                if constexpr (!mcast_enabled) {
-                                    noc_async_writes_flushed();
-                                    noc_semaphore_set_remote(valid_semaphore_addr, receiver_semaphore_noc_addr);
-                                }
+                        if (should_forward) {
+                            if constexpr (!mcast_enabled) {
+                                noc_async_writes_flushed();
+                                noc_semaphore_set_remote(valid_semaphore_addr, receiver_semaphore_noc_addr);
                             }
                         }
 

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/reader_interleaved.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/reader_interleaved.cpp
@@ -78,14 +78,15 @@ void kernel_main() {
     constexpr uint32_t use_attention_sink = get_compile_time_arg_val(23) == 1;
     constexpr uint32_t use_mla = get_compile_time_arg_val(24) == 1;
     constexpr uint32_t mla_kv_overlap = get_compile_time_arg_val(25) == 1;
+    constexpr uint32_t qk_subblock_h = get_compile_time_arg_val(26);
 
     // Semaphore IDs for KV chain forwarding (non-causal only, but always present in compile args)
-    constexpr uint32_t sender_semaphore_id = get_compile_time_arg_val(26);
-    constexpr uint32_t receiver_semaphore_id = get_compile_time_arg_val(27);
-    constexpr uint32_t valid_semaphore_id = get_compile_time_arg_val(28);
-    constexpr bool mcast_enabled = get_compile_time_arg_val(29) == 1;
+    constexpr uint32_t sender_semaphore_id = get_compile_time_arg_val(27);
+    constexpr uint32_t receiver_semaphore_id = get_compile_time_arg_val(28);
+    constexpr uint32_t valid_semaphore_id = get_compile_time_arg_val(29);
+    constexpr bool mcast_enabled = get_compile_time_arg_val(30) == 1;
 
-    constexpr auto q_args = TensorAccessorArgs<30>();
+    constexpr auto q_args = TensorAccessorArgs<31>();
     constexpr auto k_args = TensorAccessorArgs<q_args.next_compile_time_args_offset()>();
     constexpr auto v_args = TensorAccessorArgs<k_args.next_compile_time_args_offset()>();
     constexpr auto mask_args = TensorAccessorArgs<v_args.next_compile_time_args_offset()>();
@@ -220,6 +221,8 @@ void kernel_main() {
 
     constexpr uint32_t q_heads_per_k = NQH / NKH;
     constexpr uint32_t q_heads_per_v = NQH / NVH;
+    constexpr uint32_t q_num_subblocks = Sq_chunk_t / qk_subblock_h;
+    constexpr bool use_q_subblock_push = (q_num_subblocks > 1);
 
     constexpr uint32_t barrier_threshold = get_barrier_read_threshold<q_tile_bytes, num_cores>();
 
@@ -357,9 +360,22 @@ void kernel_main() {
                     const uint32_t q_row_start_tile = std::min(q_chunk * Sq_chunk_t, valid_Sqt);
                     const uint32_t q_row_end_tile = std::min(q_row_start_tile + Sq_chunk_t, valid_Sqt);
                     const uint32_t q_row_tile_count = q_row_end_tile - q_row_start_tile;
-                    const uint32_t q_tile_id = q_tile_shape.id_of(nb, nq, read_offset + q_row_start_tile, 0);
-                    read_chunk_with_padding<q_tile_bytes>(
-                        q_reader, cb_q_in, q_tile_id, q_row_tile_count, DHt, Sq_chunk_t, DHt, barrier_threshold);
+                    uint32_t q_read_tile_id = q_tile_shape.id_of(nb, nq, read_offset + q_row_start_tile, 0);
+
+                    // Q read is deferred into the K loop (k_chunk==0) for subblock interleaving.
+                    // When use_q_subblock_push is false, Q is read in full before the K loop (original behavior).
+                    if constexpr (!use_q_subblock_push) {
+                        read_chunk_with_padding<q_tile_bytes>(
+                            q_reader,
+                            cb_q_in,
+                            q_read_tile_id,
+                            q_row_tile_count,
+                            DHt,
+                            Sq_chunk_t,
+                            DHt,
+                            barrier_threshold);
+                    }
+
                     q_chunk = chunked_q_chunk_offset + q_chunk;
                     uint32_t q_low_idx =
                         q_chunk * Sq_chunk_t;  // This is the sequence index of the first tile of this chunk
@@ -522,6 +538,30 @@ void kernel_main() {
                                 } else {
                                     noc_async_writes_flushed();
                                     noc_semaphore_set_remote(valid_semaphore_addr, receiver_semaphore_noc_addr);
+                                }
+                            }
+                        }
+
+                        // Q subblock push: K is fully forwarded, now push Q one subblock at
+                        // a time. Compute waits for K first (cb_wait_front(cb_k_in, K*N)),
+                        // then waits for Q subblocks incrementally (accumulating cb_wait_front).
+                        // Each push unblocks the next QK subblock computation.
+                        // Placed after K forward complete so no outstanding NOC writes remain
+                        // (noc_async_read_barrier inside read_q_subblock deadlocks on BH
+                        // when NOC writes are in-flight).
+                        if constexpr (use_q_subblock_push) {
+                            if (k_chunk == 0) {
+                                for (uint32_t q_sub = 0; q_sub < q_num_subblocks; ++q_sub) {
+                                    read_q_subblock<q_tile_bytes>(
+                                        q_reader,
+                                        cb_q_in,
+                                        q_read_tile_id,
+                                        q_sub * qk_subblock_h,
+                                        qk_subblock_h,
+                                        q_row_tile_count,
+                                        DHt,
+                                        DHt,
+                                        barrier_threshold);
                                 }
                             }
                         }

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/reader_interleaved.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/reader_interleaved.cpp
@@ -23,7 +23,6 @@ FORCE_INLINE uint32_t read_chunk_for_forwarding(
     cb_reserve_back(cb_id, num_tiles);
     const uint32_t base_write_ptr = get_write_ptr(cb_id);
     {
-        // DeviceZoneScopedN("READ_CHUNK_FOR_FORWARDING");
         const uint32_t outer_ptr_stride = transpose ? tile_bytes : dst_cols * tile_bytes;
         const uint32_t inner_ptr_stride = transpose ? tile_bytes * dst_rows : tile_bytes;
 
@@ -135,6 +134,7 @@ void kernel_main() {
     uint32_t next_physical_y = 0;
     uint32_t next_core_q_chunks = 0;
     uint32_t mcast_num_dests = 0;
+    uint32_t mcast_sender_wait = 0;
     uint64_t mcast_base_noc_addr = 0;
 
     // Initialize semaphore addresses and NOC addresses for chain forwarding
@@ -161,6 +161,7 @@ void kernel_main() {
         next_physical_y = get_arg_val<uint32_t>(argidx++);
         next_core_q_chunks = get_arg_val<uint32_t>(argidx++);
         mcast_num_dests = get_arg_val<uint32_t>(argidx++);
+        mcast_sender_wait = get_arg_val<uint32_t>(argidx++);
 
         if (is_chain_participant) {
             const uint32_t sender_semaphore_addr = get_semaphore(sender_semaphore_id);
@@ -186,7 +187,7 @@ void kernel_main() {
                         next_physical_y,
                         0);  // addr=0; will OR in actual L1 addr at use site
                     mcast_sem_noc_addr = mcast_base_noc_addr | receiver_semaphore_l1_addr;
-                    sender_wait_count = mcast_num_dests;
+                    sender_wait_count = mcast_sender_wait;
                 }
             } else {
                 sender_semaphore_noc_addr = get_noc_addr(prev_physical_x, prev_physical_y, sender_semaphore_addr);
@@ -415,7 +416,6 @@ void kernel_main() {
                                 // Receive forwarded K chunk from previous core
                                 cb_reserve_back(cb_k_in, k_chunk_tiles);
                                 {
-                                    // DeviceZoneScopedN("K RECEIVE");
                                     cb_k_start_address = get_write_ptr(cb_k_in);
                                     noc_semaphore_set(receiver_semaphore_addr_ptr, INVALID);
                                     noc_semaphore_inc(sender_semaphore_noc_addr, 1);
@@ -467,7 +467,6 @@ void kernel_main() {
                             if (should_forward) {
                                 noc_semaphore_wait(sender_semaphore_addr_ptr, sender_wait_count);
                                 {
-                                    // DeviceZoneScopedN("K_forward_initiate");
                                     noc_semaphore_set(sender_semaphore_addr_ptr, 0);
                                     if constexpr (mcast_enabled) {
                                         uint64_t k_mcast_addr = mcast_base_noc_addr | cb_k_start_address;
@@ -530,9 +529,6 @@ void kernel_main() {
                         {
                             if (should_forward) {
                                 if constexpr (mcast_enabled) {
-#ifdef ARCH_BLACKHOLE
-                                    noc_async_writes_flushed();
-#endif
                                     noc_semaphore_set_multicast(
                                         valid_semaphore_addr, mcast_sem_noc_addr, mcast_num_dests);
                                 } else {
@@ -636,9 +632,6 @@ void kernel_main() {
                                     v_chunk_tiles * v_tile_bytes,
                                     mcast_num_dests,
                                     true /* linked: semaphore mcast follows */);
-#ifdef ARCH_BLACKHOLE
-                                noc_async_writes_flushed();
-#endif
                                 noc_semaphore_set_multicast(valid_semaphore_addr, mcast_sem_noc_addr, mcast_num_dests);
                             } else {
                                 uint64_t v_unicast_data_addr =

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/reader_interleaved.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/reader_interleaved.cpp
@@ -463,6 +463,10 @@ void kernel_main() {
                         }
 
                         // Forward K chunk to next core(s): initiate async write (NOC write channel)
+                        // For mcast: send linked data + companion semaphore back-to-back.
+                        // The companion must be issued immediately after the linked write —
+                        // any noc_async_read_barrier() between them deadlocks (the read barrier
+                        // blocks while a linked write awaits its companion).
                         {
                             if (should_forward) {
                                 noc_semaphore_wait(sender_semaphore_addr_ptr, sender_wait_count);
@@ -476,6 +480,8 @@ void kernel_main() {
                                             k_chunk_tiles * k_tile_bytes,
                                             mcast_num_dests,
                                             true /* linked: semaphore mcast follows */);
+                                        noc_semaphore_set_multicast(
+                                            valid_semaphore_addr, mcast_sem_noc_addr, mcast_num_dests);
                                     } else {
                                         uint64_t k_unicast_data_addr =
                                             get_noc_addr(next_physical_x, next_physical_y, cb_k_start_address);
@@ -486,7 +492,7 @@ void kernel_main() {
                             }
                         }
 
-                        // Mask read uses NOC read channel — overlaps with in-flight K write
+                        // Mask read — safe after linked write pair is complete
                         if constexpr (use_provided_mask) {
                             cb_reserve_back(cb_mask_in, mask_chunk_tiles);
                             uint32_t mask_write_ptr = get_write_ptr(cb_mask_in);
@@ -526,12 +532,10 @@ void kernel_main() {
                         }
 
                         // Complete K forward: flush write and signal receiver(s)
+                        // (mcast path already completed above — companion sent with linked write)
                         {
                             if (should_forward) {
-                                if constexpr (mcast_enabled) {
-                                    noc_semaphore_set_multicast(
-                                        valid_semaphore_addr, mcast_sem_noc_addr, mcast_num_dests);
-                                } else {
+                                if constexpr (!mcast_enabled) {
                                     noc_async_writes_flushed();
                                     noc_semaphore_set_remote(valid_semaphore_addr, receiver_semaphore_noc_addr);
                                 }

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/reader_interleaved.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/reader_interleaved.cpp
@@ -22,29 +22,31 @@ FORCE_INLINE uint32_t read_chunk_for_forwarding(
     const uint32_t num_tiles = dst_rows * dst_cols;
     cb_reserve_back(cb_id, num_tiles);
     const uint32_t base_write_ptr = get_write_ptr(cb_id);
+    {
+        // DeviceZoneScopedN("READ_CHUNK_FOR_FORWARDING");
+        const uint32_t outer_ptr_stride = transpose ? tile_bytes : dst_cols * tile_bytes;
+        const uint32_t inner_ptr_stride = transpose ? tile_bytes * dst_rows : tile_bytes;
 
-    const uint32_t outer_ptr_stride = transpose ? tile_bytes : dst_cols * tile_bytes;
-    const uint32_t inner_ptr_stride = transpose ? tile_bytes * dst_rows : tile_bytes;
-
-    uint32_t tile_id = start_tile_id;
-    for (uint32_t row = 0; row < src_rows; ++row) {
-        uint32_t write_ptr = base_write_ptr + row * outer_ptr_stride;
-        for (uint32_t col = 0; col < src_cols; ++col) {
-            noc_async_read_tile(tile_id++, reader, write_ptr);
-            write_ptr += inner_ptr_stride;
-        }
-        tile_id += skip_src_cols;
-    }
-    for (uint32_t row = 0; row < dst_rows; ++row) {
-        for (uint32_t col = 0; col < dst_cols; ++col) {
-            if (row < src_rows && col < src_cols) {
-                continue;
+        uint32_t tile_id = start_tile_id;
+        for (uint32_t row = 0; row < src_rows; ++row) {
+            uint32_t write_ptr = base_write_ptr + row * outer_ptr_stride;
+            for (uint32_t col = 0; col < src_cols; ++col) {
+                noc_async_read_tile(tile_id++, reader, write_ptr);
+                write_ptr += inner_ptr_stride;
             }
-            uint32_t tile_idx = transpose ? col * dst_rows + row : row * dst_cols + col;
-            fill_tile_zeros<tile_bytes, false>(cb_id, tile_idx);
+            tile_id += skip_src_cols;
         }
+        for (uint32_t row = 0; row < dst_rows; ++row) {
+            for (uint32_t col = 0; col < dst_cols; ++col) {
+                if (row < src_rows && col < src_cols) {
+                    continue;
+                }
+                uint32_t tile_idx = transpose ? col * dst_rows + row : row * dst_cols + col;
+                fill_tile_zeros<tile_bytes, false>(cb_id, tile_idx);
+            }
+        }
+        noc_async_read_barrier();
     }
-    noc_async_read_barrier();
     cb_push_back(cb_id, num_tiles);
     return base_write_ptr;
 }
@@ -81,8 +83,9 @@ void kernel_main() {
     constexpr uint32_t sender_semaphore_id = get_compile_time_arg_val(26);
     constexpr uint32_t receiver_semaphore_id = get_compile_time_arg_val(27);
     constexpr uint32_t valid_semaphore_id = get_compile_time_arg_val(28);
+    constexpr bool mcast_enabled = get_compile_time_arg_val(29) == 1;
 
-    constexpr auto q_args = TensorAccessorArgs<29>();
+    constexpr auto q_args = TensorAccessorArgs<30>();
     constexpr auto k_args = TensorAccessorArgs<q_args.next_compile_time_args_offset()>();
     constexpr auto v_args = TensorAccessorArgs<k_args.next_compile_time_args_offset()>();
     constexpr auto mask_args = TensorAccessorArgs<v_args.next_compile_time_args_offset()>();
@@ -125,13 +128,13 @@ void kernel_main() {
     uint32_t is_sink = 0;
     uint32_t chain_batch = 0;
     uint32_t chain_head = 0;
-    uint32_t chain_q_chunk_start = 0;
-    uint32_t chain_q_chunk_count = 0;
     uint32_t prev_physical_x = 0;
     uint32_t prev_physical_y = 0;
     uint32_t next_physical_x = 0;
     uint32_t next_physical_y = 0;
     uint32_t next_core_q_chunks = 0;
+    uint32_t mcast_num_dests = 0;
+    uint64_t mcast_base_noc_addr = 0;
 
     // Initialize semaphore addresses and NOC addresses for chain forwarding
     volatile tt_l1_ptr uint32_t* sender_semaphore_addr_ptr = nullptr;
@@ -140,6 +143,9 @@ void kernel_main() {
     uint64_t sender_semaphore_noc_addr = 0;
     uint64_t receiver_semaphore_noc_addr = 0;
     uint32_t valid_semaphore_addr = 0;
+    uint32_t receiver_semaphore_l1_addr = 0;
+    uint64_t mcast_sem_noc_addr = 0;
+    uint32_t sender_wait_count = 1;
 
     if constexpr (!is_causal) {
         is_chain_participant = get_arg_val<uint32_t>(argidx++);
@@ -147,18 +153,19 @@ void kernel_main() {
         is_sink = get_arg_val<uint32_t>(argidx++);
         chain_batch = get_arg_val<uint32_t>(argidx++);
         chain_head = get_arg_val<uint32_t>(argidx++);
-        chain_q_chunk_start = get_arg_val<uint32_t>(argidx++);
-        chain_q_chunk_count = get_arg_val<uint32_t>(argidx++);
+        argidx += 2;  // skip chain_q_chunk_start, chain_q_chunk_count (host-only metadata)
         prev_physical_x = get_arg_val<uint32_t>(argidx++);
         prev_physical_y = get_arg_val<uint32_t>(argidx++);
         next_physical_x = get_arg_val<uint32_t>(argidx++);
         next_physical_y = get_arg_val<uint32_t>(argidx++);
         next_core_q_chunks = get_arg_val<uint32_t>(argidx++);
+        mcast_num_dests = get_arg_val<uint32_t>(argidx++);
 
         if (is_chain_participant) {
             const uint32_t sender_semaphore_addr = get_semaphore(sender_semaphore_id);
             const uint32_t receiver_semaphore_addr = get_semaphore(receiver_semaphore_id);
             valid_semaphore_addr = get_semaphore(valid_semaphore_id);
+            receiver_semaphore_l1_addr = receiver_semaphore_addr;
 
             sender_semaphore_addr_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(sender_semaphore_addr);
             receiver_semaphore_addr_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(receiver_semaphore_addr);
@@ -166,8 +173,24 @@ void kernel_main() {
 
             *valid_semaphore_addr_ptr = VALID;
 
-            sender_semaphore_noc_addr = get_noc_addr(prev_physical_x, prev_physical_y, sender_semaphore_addr);
-            receiver_semaphore_noc_addr = get_noc_addr(next_physical_x, next_physical_y, receiver_semaphore_addr);
+            if constexpr (mcast_enabled) {
+                // All chains use mcast (all-or-nothing compile-time decision)
+                sender_semaphore_noc_addr = get_noc_addr(prev_physical_x, prev_physical_y, sender_semaphore_addr);
+                if (is_injector) {
+                    // prev_physical = mcast_start (first receiver), next_physical = mcast_end (last receiver)
+                    mcast_base_noc_addr = get_noc_multicast_addr(
+                        prev_physical_x,
+                        prev_physical_y,
+                        next_physical_x,
+                        next_physical_y,
+                        0);  // addr=0; will OR in actual L1 addr at use site
+                    mcast_sem_noc_addr = mcast_base_noc_addr | receiver_semaphore_l1_addr;
+                    sender_wait_count = mcast_num_dests;
+                }
+            } else {
+                sender_semaphore_noc_addr = get_noc_addr(prev_physical_x, prev_physical_y, sender_semaphore_addr);
+                receiver_semaphore_noc_addr = get_noc_addr(next_physical_x, next_physical_y, receiver_semaphore_addr);
+            }
         }
     }
 
@@ -189,7 +212,6 @@ void kernel_main() {
     constexpr uint32_t cb_id_chunk_start_idx_compute = tt::CBIndex::c_8;
     constexpr uint32_t cb_id_chunk_start_idx_writer = tt::CBIndex::c_9;
 
-    constexpr uint32_t onetile = 1;
     constexpr uint32_t q_tile_bytes = get_tile_size(cb_q_in);
     constexpr uint32_t k_tile_bytes = get_tile_size(cb_k_in);
     constexpr uint32_t v_tile_bytes = get_tile_size(cb_v_in);
@@ -224,8 +246,6 @@ void kernel_main() {
 
     volatile tt_l1_ptr uint32_t* page_table_ptr;
 
-    uint32_t v_tile_id = 0;
-    uint32_t mask_tile_id = 0;
     uint32_t barrier_count = 0;
     uint32_t chunked_q_chunk_offset = 0;
     if constexpr (is_chunked) {
@@ -353,11 +373,18 @@ void kernel_main() {
                     const uint32_t k_head = nq / q_heads_per_k;
                     const uint32_t v_head = nq / q_heads_per_v;
 
+                    // Chain forwarding conditions are loop-invariant — compute once
+                    bool should_forward = false;
+                    bool should_receive = false;
+                    if constexpr (!is_causal) {
+                        should_forward = is_chain_participant && !is_sink && (nb == chain_batch && nq == chain_head) &&
+                                         (q_iter < next_core_q_chunks);
+                        should_receive =
+                            is_chain_participant && !is_injector && (nb == chain_batch && nq == chain_head);
+                    }
+
                     // loop while k_low < q_high
                     for (uint32_t k_chunk = 0; (k_chunk * Sk_chunk_t) < q_high_idx; ++k_chunk) {
-                        const uint32_t k_low_idx = k_chunk * Sk_chunk_t;
-                        const uint32_t k_high_idx = k_low_idx + Sk_chunk_t;
-
                         const uint32_t kv_row_start_tile = std::min(k_chunk * Sk_chunk_t, valid_Skt_bound);
                         const uint32_t kv_row_end_tile = std::min(kv_row_start_tile + Sk_chunk_t, valid_Skt_bound);
                         const uint32_t kv_row_tile_count = kv_row_end_tile - kv_row_start_tile;
@@ -366,70 +393,82 @@ void kernel_main() {
 
                         // K: either read locally (injector or not participant) or receive from previous core
                         uint32_t cb_k_start_address = 0;
-                        bool should_forward_k = false;
-                        bool should_receive_k = false;
 
-                        if constexpr (!is_causal) {
-                            should_forward_k = is_chain_participant && !is_sink &&
-                                               (nb == chain_batch && nq == chain_head) && (q_iter < next_core_q_chunks);
-                            should_receive_k =
-                                is_chain_participant && !is_injector && (nb == chain_batch && nq == chain_head);
-                        }
-
-                        if (should_receive_k) {
-                            // Receive forwarded K chunk from previous core
-                            cb_reserve_back(cb_k_in, k_chunk_tiles);
-                            cb_k_start_address = get_write_ptr(cb_k_in);
-                            noc_semaphore_set(receiver_semaphore_addr_ptr, INVALID);
-                            noc_semaphore_inc(sender_semaphore_noc_addr, 1);
-                            noc_semaphore_wait(receiver_semaphore_addr_ptr, VALID);
-                            cb_push_back(cb_k_in, k_chunk_tiles);
-                        } else {
-                            // Read K chunk from DRAM
-                            if constexpr (is_chunked) {
-                                // Use page table to read K chunk (forwarding not supported for paged mode)
-                                const uint32_t k_chunk_start_row_num = k_chunk * Sk_chunk_t;
-                                read_paged_chunk_with_padding<NKH, block_size_t, DHt>(
-                                    k_reader,
-                                    cb_k_in,
-                                    k_head,
-                                    k_chunk_start_row_num,
-                                    kv_row_tile_count,
-                                    DHt,
-                                    Sk_chunk_t,
-                                    DHt,
-                                    k_tile_bytes,
-                                    barrier_threshold,
-                                    page_table_ptr,
-                                    true  // transpose=true for K reads
-                                );
+                        {
+                            if (should_receive) {
+                                // Receive forwarded K chunk from previous core
+                                cb_reserve_back(cb_k_in, k_chunk_tiles);
+                                {
+                                    // DeviceZoneScopedN("K RECEIVE");
+                                    cb_k_start_address = get_write_ptr(cb_k_in);
+                                    noc_semaphore_set(receiver_semaphore_addr_ptr, INVALID);
+                                    noc_semaphore_inc(sender_semaphore_noc_addr, 1);
+                                    noc_semaphore_wait(receiver_semaphore_addr_ptr, VALID);
+                                }
+                                cb_push_back(cb_k_in, k_chunk_tiles);
                             } else {
-                                if (should_forward_k) {
-                                    cb_k_start_address = read_chunk_for_forwarding<k_tile_bytes, true>(
-                                        k_reader, cb_k_in, k_start_tile_id, kv_row_tile_count, DHt, Sk_chunk_t, DHt);
-                                } else {
-                                    read_chunk_with_padding<k_tile_bytes>(
+                                // Read K chunk from DRAM
+                                if constexpr (is_chunked) {
+                                    // Use page table to read K chunk (forwarding not supported for paged mode)
+                                    const uint32_t k_chunk_start_row_num = k_chunk * Sk_chunk_t;
+                                    read_paged_chunk_with_padding<NKH, block_size_t, DHt>(
                                         k_reader,
                                         cb_k_in,
-                                        k_start_tile_id,
+                                        k_head,
+                                        k_chunk_start_row_num,
                                         kv_row_tile_count,
                                         DHt,
                                         Sk_chunk_t,
                                         DHt,
+                                        k_tile_bytes,
                                         barrier_threshold,
+                                        page_table_ptr,
                                         true  // transpose=true for K reads
                                     );
+                                } else {
+                                    if (should_forward) {
+                                        cb_k_start_address = read_chunk_for_forwarding<k_tile_bytes, true>(
+                                            k_reader, cb_k_in, k_start_tile_id, kv_row_tile_count, DHt, Sk_chunk_t, DHt);
+                                    } else {
+                                        read_chunk_with_padding<k_tile_bytes>(
+                                            k_reader,
+                                            cb_k_in,
+                                            k_start_tile_id,
+                                            kv_row_tile_count,
+                                            DHt,
+                                            Sk_chunk_t,
+                                            DHt,
+                                            barrier_threshold,
+                                            true  // transpose=true for K reads
+                                        );
+                                    }
                                 }
                             }
                         }
 
-                        // Forward K chunk to next core: initiate async write (NOC write channel)
-                        if (should_forward_k) {
-                            noc_semaphore_wait(sender_semaphore_addr_ptr, 1);
-                            noc_semaphore_set(sender_semaphore_addr_ptr, 0);
-                            uint64_t k_unicast_data_addr =
-                                get_noc_addr(next_physical_x, next_physical_y, cb_k_start_address);
-                            noc_async_write(cb_k_start_address, k_unicast_data_addr, k_chunk_tiles * k_tile_bytes);
+                        // Forward K chunk to next core(s): initiate async write (NOC write channel)
+                        {
+                            if (should_forward) {
+                                noc_semaphore_wait(sender_semaphore_addr_ptr, sender_wait_count);
+                                {
+                                    // DeviceZoneScopedN("K_forward_initiate");
+                                    noc_semaphore_set(sender_semaphore_addr_ptr, 0);
+                                    if constexpr (mcast_enabled) {
+                                        uint64_t k_mcast_addr = mcast_base_noc_addr | cb_k_start_address;
+                                        noc_async_write_multicast(
+                                            cb_k_start_address,
+                                            k_mcast_addr,
+                                            k_chunk_tiles * k_tile_bytes,
+                                            mcast_num_dests,
+                                            true /* linked: semaphore mcast follows */);
+                                    } else {
+                                        uint64_t k_unicast_data_addr =
+                                            get_noc_addr(next_physical_x, next_physical_y, cb_k_start_address);
+                                        noc_async_write(
+                                            cb_k_start_address, k_unicast_data_addr, k_chunk_tiles * k_tile_bytes);
+                                    }
+                                }
+                            }
                         }
 
                         // Mask read uses NOC read channel — overlaps with in-flight K write
@@ -471,25 +510,26 @@ void kernel_main() {
                             cb_push_back(cb_mask_in, mask_chunk_tiles);
                         }
 
-                        // Complete K forward: flush write and signal receiver
-                        if (should_forward_k) {
-                            noc_async_writes_flushed();
-                            noc_semaphore_set_remote(valid_semaphore_addr, receiver_semaphore_noc_addr);
+                        // Complete K forward: flush write and signal receiver(s)
+                        {
+                            if (should_forward) {
+                                if constexpr (mcast_enabled) {
+#ifdef ARCH_BLACKHOLE
+                                    noc_async_writes_flushed();
+#endif
+                                    noc_semaphore_set_multicast(
+                                        valid_semaphore_addr, mcast_sem_noc_addr, mcast_num_dests);
+                                } else {
+                                    noc_async_writes_flushed();
+                                    noc_semaphore_set_remote(valid_semaphore_addr, receiver_semaphore_noc_addr);
+                                }
+                            }
                         }
 
                         // V: either read locally (injector or not participant) or receive from previous core
                         uint32_t cb_v_start_address = 0;
-                        bool should_forward_v = false;
-                        bool should_receive_v = false;
 
-                        if constexpr (!is_causal) {
-                            should_forward_v = is_chain_participant && !is_sink &&
-                                               (nb == chain_batch && nq == chain_head) && (q_iter < next_core_q_chunks);
-                            should_receive_v =
-                                is_chain_participant && !is_injector && (nb == chain_batch && nq == chain_head);
-                        }
-
-                        if (should_receive_v) {
+                        if (should_receive) {
                             // Receive forwarded V chunk from previous core
                             cb_reserve_back(cb_v_in, v_chunk_tiles);
                             cb_v_start_address = get_write_ptr(cb_v_in);
@@ -518,7 +558,7 @@ void kernel_main() {
                                     false,
                                     skip_src_cols);
                             } else {
-                                if (should_forward_v) {
+                                if (should_forward) {
                                     cb_v_start_address = read_chunk_for_forwarding<v_tile_bytes, false>(
                                         v_reader,
                                         cb_v_in,
@@ -544,15 +584,29 @@ void kernel_main() {
                             }
                         }
 
-                        // Forward V chunk to next core if applicable
-                        if (should_forward_v) {
-                            noc_semaphore_wait(sender_semaphore_addr_ptr, 1);
+                        // Forward V chunk to next core(s) if applicable
+                        if (should_forward) {
+                            noc_semaphore_wait(sender_semaphore_addr_ptr, sender_wait_count);
                             noc_semaphore_set(sender_semaphore_addr_ptr, 0);
-                            uint64_t v_unicast_data_addr =
-                                get_noc_addr(next_physical_x, next_physical_y, cb_v_start_address);
-                            noc_async_write(cb_v_start_address, v_unicast_data_addr, v_chunk_tiles * v_tile_bytes);
-                            noc_async_writes_flushed();
-                            noc_semaphore_set_remote(valid_semaphore_addr, receiver_semaphore_noc_addr);
+                            if constexpr (mcast_enabled) {
+                                uint64_t v_mcast_addr = mcast_base_noc_addr | cb_v_start_address;
+                                noc_async_write_multicast(
+                                    cb_v_start_address,
+                                    v_mcast_addr,
+                                    v_chunk_tiles * v_tile_bytes,
+                                    mcast_num_dests,
+                                    true /* linked: semaphore mcast follows */);
+#ifdef ARCH_BLACKHOLE
+                                noc_async_writes_flushed();
+#endif
+                                noc_semaphore_set_multicast(valid_semaphore_addr, mcast_sem_noc_addr, mcast_num_dests);
+                            } else {
+                                uint64_t v_unicast_data_addr =
+                                    get_noc_addr(next_physical_x, next_physical_y, cb_v_start_address);
+                                noc_async_write(cb_v_start_address, v_unicast_data_addr, v_chunk_tiles * v_tile_bytes);
+                                noc_async_writes_flushed();
+                                noc_semaphore_set_remote(valid_semaphore_addr, receiver_semaphore_noc_addr);
+                            }
                         }
                     }
                 }

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_distributed_sdpa_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_distributed_sdpa_program_factory.cpp
@@ -224,14 +224,16 @@ RingDistributedSdpaMeshWorkloadFactory::cached_program_t RingDistributedSdpaMesh
         (uint32_t)is_chunked,  //(uint32_t)is_chunked,
         block_size_t,
         page_table_stick_size,
-        0,  // use_attention_sink
-        0,  // use_mla
-        0   // mla_kv_overlap
+        0,                 // use_attention_sink
+        0,                 // use_mla
+        0,                 // mla_kv_overlap
+        qk_out_subblock_h  // qk_subblock_h
     };
-    // Semaphore placeholders (not used in ring, but kernel expects them at indices 23-25)
+    // Semaphore placeholders (not used in ring, but kernel expects them at indices 27-30)
     reader_compile_time_args.push_back(0);  // sender_semaphore_id
     reader_compile_time_args.push_back(0);  // receiver_semaphore_id
     reader_compile_time_args.push_back(0);  // valid_semaphore_id
+    reader_compile_time_args.push_back(0);  // mcast_enabled
 
     TensorAccessorArgs(input_tensor_q.buffer()).append_to(reader_compile_time_args);
     TensorAccessorArgs(input_tensor_k.buffer()).append_to(reader_compile_time_args);

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sdpa_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sdpa_program_factory.cpp
@@ -51,6 +51,8 @@ struct CoreChainInfo {
     CoreCoord prev_physical = CoreCoord{0, 0};
     CoreCoord next_physical = CoreCoord{0, 0};
     uint32_t next_core_q_chunks = 0;
+    bool use_mcast = false;
+    uint32_t mcast_num_dests = 0;  // receiver count (chain_size - 1), injector only
 };
 
 SDPAProgramFactory::cached_program_t SDPAProgramFactory::create(
@@ -396,6 +398,7 @@ SDPAProgramFactory::cached_program_t SDPAProgramFactory::create(
     reader_compile_time_args.push_back(0);  // sender_semaphore_id placeholder
     reader_compile_time_args.push_back(0);  // receiver_semaphore_id placeholder
     reader_compile_time_args.push_back(0);  // valid_semaphore_id placeholder
+    reader_compile_time_args.push_back(0);  // mcast_enabled placeholder
 
     TensorAccessorArgs(input_tensor_q.buffer()).append_to(reader_compile_time_args);
     TensorAccessorArgs(input_tensor_k.buffer()).append_to(reader_compile_time_args);
@@ -508,28 +511,8 @@ SDPAProgramFactory::cached_program_t SDPAProgramFactory::create(
 
     log_debug(tt::LogOp, "BALANCED_Q_PARALLEL: {}", balanced_q_parallel);
 
-    auto reader_kernels_id = CreateKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/reader_interleaved.cpp",
-        core_grid,
-        tt::tt_metal::ReaderDataMovementConfig(reader_compile_time_args, defines));
-
-    auto writer_kernels_id = CreateKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/writer_interleaved.cpp",
-        core_grid,
-        tt::tt_metal::WriterDataMovementConfig(writer_compile_time_args, defines));
-
-    auto compute_kernels_id = CreateKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/sdpa.cpp",
-        core_grid,
-        tt::tt_metal::ComputeConfig{
-            .math_fidelity = math_fidelity,
-            .fp32_dest_acc_en = fp32_dest_acc_en,
-            .math_approx_mode = math_approx_mode,
-            .compile_args = compute_compile_time_args,
-            .defines = defines});
+    // NOTE: CreateKernel calls are deferred until after chain construction so that
+    // the mcast_enabled compile-time arg can be determined first.
 
     // Create circular buffers
 
@@ -689,6 +672,7 @@ SDPAProgramFactory::cached_program_t SDPAProgramFactory::create(
     std::vector<CoreChainInfo> core_chain_info(num_cores);
     const uint32_t total_heads = B * NQH;
     std::vector<std::vector<HeadSegmentRef>> head_segments;
+    uint32_t mcast_chains = 0;
 
     if (!is_causal && !is_chunked) {
         head_segments.resize(total_heads);
@@ -891,7 +875,150 @@ SDPAProgramFactory::cached_program_t SDPAProgramFactory::create(
             "Chain construction complete: {} chains built, {} skipped due to conflicts",
             chains_built,
             chains_skipped);
+
+        // Third pass: Check multicast eligibility — all-or-nothing policy.
+        // First, check if ALL multi-core chains are eligible. Only if every chain
+        // qualifies do we configure mcast (compile-time decision for the kernel).
+        struct McastCandidate {
+            std::vector<uint32_t> core_indices;
+            uint32_t ref_q_chunks;
+        };
+        std::vector<McastCandidate> candidates;
+        bool all_eligible = true;
+        uint32_t total_multi_core_chains = 0;
+
+        for (uint32_t head_id = 0; head_id < head_segments.size(); ++head_id) {
+            auto& segments = head_segments[head_id];
+            if (segments.size() < 2) {
+                continue;
+            }
+
+            // Collect chain core indices that actually participate in this head's chain
+            std::vector<uint32_t> chain_core_indices;
+            for (const auto& seg : segments) {
+                if (seg.core_idx < core_chain_info.size() && core_chain_info[seg.core_idx].participates &&
+                    core_chain_info[seg.core_idx].batch == (head_id / NQH) &&
+                    core_chain_info[seg.core_idx].head == (head_id % NQH)) {
+                    chain_core_indices.push_back(seg.core_idx);
+                }
+            }
+
+            if (chain_core_indices.size() < 2) {
+                continue;
+            }
+
+            total_multi_core_chains++;
+
+            // Check eligibility condition 1: All physical cores share the same Y coordinate
+            const uint32_t ref_y = core_work[chain_core_indices[0]].physical_core.y;
+            bool same_row = true;
+            for (size_t ci = 1; ci < chain_core_indices.size(); ++ci) {
+                if (core_work[chain_core_indices[ci]].physical_core.y != ref_y) {
+                    same_row = false;
+                    break;
+                }
+            }
+
+            if (!same_row) {
+                all_eligible = false;
+                log_debug(tt::LogOp, "Head {}: mcast ineligible - cores span multiple rows", head_id);
+                break;
+            }
+
+            // Note: Physical X contiguity is NOT required. Harvested (non-worker) cores
+            // in the multicast rectangle safely discard the data.
+
+            // Check eligibility condition 2: All chain cores have equal q_chunk_count
+            const uint32_t ref_q_chunks = core_chain_info[chain_core_indices[0]].q_chunk_count;
+            bool equal_q_chunks = true;
+            for (size_t ci = 1; ci < chain_core_indices.size(); ++ci) {
+                if (core_chain_info[chain_core_indices[ci]].q_chunk_count != ref_q_chunks) {
+                    equal_q_chunks = false;
+                    break;
+                }
+            }
+
+            if (!equal_q_chunks) {
+                all_eligible = false;
+                log_debug(tt::LogOp, "Head {}: mcast ineligible - unequal q_chunk_count across chain", head_id);
+                break;
+            }
+
+            candidates.push_back(McastCandidate{std::move(chain_core_indices), ref_q_chunks});
+        }
+
+        // Only configure mcast if ALL multi-core chains are eligible (all-or-nothing)
+        if (all_eligible && !candidates.empty()) {
+            mcast_chains = candidates.size();
+            for (const auto& cand : candidates) {
+                const uint32_t injector_idx = cand.core_indices[0];
+                const uint32_t chain_size = cand.core_indices.size();
+                const uint32_t num_receivers = chain_size - 1;
+
+                const CoreCoord first_receiver_phys = core_work[cand.core_indices[1]].physical_core;
+                const CoreCoord last_receiver_phys = core_work[cand.core_indices[chain_size - 1]].physical_core;
+
+                // Configure injector
+                auto& injector_chain = core_chain_info[injector_idx];
+                injector_chain.use_mcast = true;
+                injector_chain.prev_physical = first_receiver_phys;  // mcast rect start
+                injector_chain.next_physical = last_receiver_phys;   // mcast rect end
+                injector_chain.mcast_num_dests = num_receivers;
+                injector_chain.next_core_q_chunks = cand.ref_q_chunks;
+
+                // Configure receivers
+                for (size_t ci = 1; ci < cand.core_indices.size(); ++ci) {
+                    auto& receiver_chain = core_chain_info[cand.core_indices[ci]];
+                    receiver_chain.use_mcast = true;
+                    receiver_chain.prev_physical = core_work[injector_idx].physical_core;
+                    receiver_chain.is_sink = true;
+                }
+
+                log_debug(
+                    tt::LogOp,
+                    "Head: mcast enabled - {} receivers, injector core {} -> rect ({},{}) to ({},{})",
+                    num_receivers,
+                    injector_idx,
+                    first_receiver_phys.x,
+                    first_receiver_phys.y,
+                    last_receiver_phys.x,
+                    last_receiver_phys.y);
+            }
+        }
+
+        log_info(
+            tt::LogOp,
+            "Multicast eligibility: {}/{} chains using mcast (all-or-nothing)",
+            mcast_chains,
+            total_multi_core_chains);
     }
+
+    // Update mcast_enabled compile-time arg now that chain construction is complete
+    reader_compile_time_args[sem_args_offset + 3] = (mcast_chains > 0) ? 1 : 0;
+
+    // Create kernels (deferred until after chain construction for mcast_enabled flag)
+    auto reader_kernels_id = CreateKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/reader_interleaved.cpp",
+        core_grid,
+        tt::tt_metal::ReaderDataMovementConfig(reader_compile_time_args, defines));
+
+    auto writer_kernels_id = CreateKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/writer_interleaved.cpp",
+        core_grid,
+        tt::tt_metal::WriterDataMovementConfig(writer_compile_time_args, defines));
+
+    auto compute_kernels_id = CreateKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/sdpa.cpp",
+        core_grid,
+        tt::tt_metal::ComputeConfig{
+            .math_fidelity = math_fidelity,
+            .fp32_dest_acc_en = fp32_dest_acc_en,
+            .math_approx_mode = math_approx_mode,
+            .compile_args = compute_compile_time_args,
+            .defines = defines});
 
     // Set reader rt args
     for (uint32_t i = 0; i < num_cores; ++i) {
@@ -960,6 +1087,7 @@ SDPAProgramFactory::cached_program_t SDPAProgramFactory::create(
             reader_args.push_back(static_cast<uint32_t>(chain.next_physical.x));
             reader_args.push_back(static_cast<uint32_t>(chain.next_physical.y));
             reader_args.push_back(chain.next_core_q_chunks);
+            reader_args.push_back(chain.mcast_num_dests);
         }
 
         SetRuntimeArgs(program, reader_kernels_id, core, reader_args);

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sdpa_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sdpa_program_factory.cpp
@@ -390,7 +390,8 @@ SDPAProgramFactory::cached_program_t SDPAProgramFactory::create(
                                                       page_table_stick_size,
                                                       (std::uint32_t)use_attention_sink,
                                                       (std::uint32_t)use_mla,
-                                                      (std::uint32_t)mla_kv_overlap};
+                                                      (std::uint32_t)mla_kv_overlap,
+                                                      qk_out_subblock_h};
 
     // Placeholder semaphore IDs for KV chain forwarding (will be filled later if enabled)
     // Add these BEFORE TensorAccessorArgs to keep indexing consistent with kernel expectations

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sdpa_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sdpa_program_factory.cpp
@@ -951,21 +951,9 @@ SDPAProgramFactory::cached_program_t SDPAProgramFactory::create(
             // Note: Physical X contiguity is NOT required. Harvested (non-worker) cores
             // in the multicast rectangle safely discard the data.
 
-            // Check eligibility condition 2: All chain cores have equal q_chunk_count
+            // equal q_chunk_count is already guaranteed by the second pass chain construction
+            // filter (cores with mismatched q_chunk_count are excluded from chain_order).
             const uint32_t ref_q_chunks = core_chain_info[chain_core_indices[0]].q_chunk_count;
-            bool equal_q_chunks = true;
-            for (size_t ci = 1; ci < chain_core_indices.size(); ++ci) {
-                if (core_chain_info[chain_core_indices[ci]].q_chunk_count != ref_q_chunks) {
-                    equal_q_chunks = false;
-                    break;
-                }
-            }
-
-            if (!equal_q_chunks) {
-                all_eligible = false;
-                log_debug(tt::LogOp, "Head {}: mcast ineligible - unequal q_chunk_count across chain", head_id);
-                break;
-            }
 
             candidates.push_back(McastCandidate{std::move(chain_core_indices), ref_q_chunks});
         }
@@ -1022,6 +1010,8 @@ SDPAProgramFactory::cached_program_t SDPAProgramFactory::create(
                     auto& receiver_chain = core_chain_info[ci];
                     receiver_chain.use_mcast = true;
                     receiver_chain.prev_physical = core_work[injector_idx].physical_core;
+                    receiver_chain.next_physical = CoreCoord{0, 0};
+                    receiver_chain.next_core_q_chunks = 0;
                     receiver_chain.is_sink = true;
                 }
 

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sdpa_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sdpa_program_factory.cpp
@@ -52,7 +52,8 @@ struct CoreChainInfo {
     CoreCoord next_physical = CoreCoord{0, 0};
     uint32_t next_core_q_chunks = 0;
     bool use_mcast = false;
-    uint32_t mcast_num_dests = 0;  // receiver count (chain_size - 1), injector only
+    uint32_t mcast_num_dests = 0;    // num_dests for mcast API (includes self if injector inside rect)
+    uint32_t mcast_sender_wait = 0;  // number of actual receivers that signal back (always chain_size - 1)
 };
 
 SDPAProgramFactory::cached_program_t SDPAProgramFactory::create(
@@ -743,23 +744,23 @@ SDPAProgramFactory::cached_program_t SDPAProgramFactory::create(
                 continue;  // No chain needed for single core
             }
 
-            // Find first core with single head segment as chain start (injector)
+            // Find chain start (injector), rotating preferred position per head to
+            // spread injectors across different physical columns for DRAM BW.
+            const std::size_t preferred_start = head_id % segments.size();
             std::optional<std::size_t> chain_start_idx;
-            for (std::size_t idx = 0; idx + 1 < segments.size(); ++idx) {
+
+            // First pass: prefer cores handling only one head segment
+            for (std::size_t offset = 0; offset < segments.size(); ++offset) {
+                std::size_t idx = (preferred_start + offset) % segments.size();
                 const auto& seg = segments[idx];
                 const auto& work = core_work[seg.core_idx];
 
-                // Skip cores that don't handle this head
                 if (seg.head_work_index >= work.head_work.size()) {
                     continue;
                 }
-
-                // Check if this core already participates in a chain (conflict detection)
                 if (core_chain_info[seg.core_idx].participates) {
-                    continue;  // Skip - already in a chain
+                    continue;
                 }
-
-                // Prefer cores handling only one head segment
                 if (work.head_work.size() == 1) {
                     chain_start_idx = idx;
                     break;
@@ -768,7 +769,8 @@ SDPAProgramFactory::cached_program_t SDPAProgramFactory::create(
 
             // If no single-segment core found, try any core not in a chain
             if (!chain_start_idx.has_value()) {
-                for (std::size_t idx = 0; idx + 1 < segments.size(); ++idx) {
+                for (std::size_t offset = 0; offset < segments.size(); ++offset) {
+                    std::size_t idx = (preferred_start + offset) % segments.size();
                     const auto& seg = segments[idx];
                     if (!core_chain_info[seg.core_idx].participates) {
                         chain_start_idx = idx;
@@ -803,7 +805,14 @@ SDPAProgramFactory::cached_program_t SDPAProgramFactory::create(
                 segments.size(),
                 start);
 
-            for (std::size_t idx = start; idx < segments.size(); ++idx) {
+            // Build chain in wrap order: start, start+1, ..., N-1, 0, 1, ..., start-1
+            // Exclude segments with different q_chunk_count than the injector (uneven tail).
+            std::vector<std::size_t> chain_order;
+            const auto& start_seg = segments[start];
+            const uint32_t ref_q_count =
+                core_work[start_seg.core_idx].head_work[start_seg.head_work_index].q_chunk_count;
+            for (std::size_t step = 0; step < segments.size(); ++step) {
+                std::size_t idx = (start + step) % segments.size();
                 const auto& seg = segments[idx];
                 const uint32_t core_idx = seg.core_idx;
 
@@ -811,19 +820,31 @@ SDPAProgramFactory::cached_program_t SDPAProgramFactory::create(
                     continue;
                 }
 
-                const auto& hw = core_work[core_idx].head_work[seg.head_work_index];
-                auto& chain = core_chain_info[core_idx];
-
-                // Check for conflict (core already in a different chain)
-                if (chain.participates) {
+                if (core_chain_info[core_idx].participates) {
                     log_debug(
                         tt::LogOp,
                         "WARNING: Core {} already participates in chain (batch={}, head={}), skipping rest",
                         core_idx,
-                        chain.batch,
-                        chain.head);
+                        core_chain_info[core_idx].batch,
+                        core_chain_info[core_idx].head);
                     break;
                 }
+
+                // Skip cores with different q_chunk_count (e.g. uneven tail)
+                const auto& hw = core_work[core_idx].head_work[seg.head_work_index];
+                if (hw.q_chunk_count != ref_q_count) {
+                    continue;
+                }
+
+                chain_order.push_back(idx);
+            }
+
+            for (std::size_t pos = 0; pos < chain_order.size(); ++pos) {
+                const std::size_t idx = chain_order[pos];
+                const auto& seg = segments[idx];
+                const uint32_t core_idx = seg.core_idx;
+                const auto& hw = core_work[core_idx].head_work[seg.head_work_index];
+                auto& chain = core_chain_info[core_idx];
 
                 chain.participates = true;
                 chain.batch = hw.batch;
@@ -831,28 +852,29 @@ SDPAProgramFactory::cached_program_t SDPAProgramFactory::create(
                 chain.q_chunk_start = hw.q_chunk_start;
                 chain.q_chunk_count = hw.q_chunk_count;
 
-                if (idx == start) {
+                if (pos == 0) {
                     chain.is_injector = true;
                 }
-                if (idx == segments.size() - 1) {
+                if (pos == chain_order.size() - 1) {
                     chain.is_sink = true;
                 }
 
-                // Set prev core coordinates
-                if (idx > start) {
-                    const uint32_t prev_core_idx = segments[idx - 1].core_idx;
+                // Set prev core coordinates (previous in wrap order)
+                if (pos > 0) {
+                    const uint32_t prev_core_idx = segments[chain_order[pos - 1]].core_idx;
                     if (prev_core_idx < core_work.size()) {
                         chain.prev_physical = core_work[prev_core_idx].physical_core;
                     }
                 }
 
-                // Set next core coordinates and q_chunk count
-                if (idx + 1 < segments.size()) {
-                    const uint32_t next_core_idx = segments[idx + 1].core_idx;
+                // Set next core coordinates and q_chunk count (next in wrap order)
+                if (pos + 1 < chain_order.size()) {
+                    const std::size_t next_idx = chain_order[pos + 1];
+                    const uint32_t next_core_idx = segments[next_idx].core_idx;
                     if (next_core_idx < core_work.size() &&
-                        segments[idx + 1].head_work_index < core_work[next_core_idx].head_work.size()) {
+                        segments[next_idx].head_work_index < core_work[next_core_idx].head_work.size()) {
                         chain.next_physical = core_work[next_core_idx].physical_core;
-                        const auto& next_hw = core_work[next_core_idx].head_work[segments[idx + 1].head_work_index];
+                        const auto& next_hw = core_work[next_core_idx].head_work[segments[next_idx].head_work_index];
                         chain.next_core_q_chunks = next_hw.q_chunk_count;
                     }
                 }
@@ -952,24 +974,52 @@ SDPAProgramFactory::cached_program_t SDPAProgramFactory::create(
         if (all_eligible && !candidates.empty()) {
             mcast_chains = candidates.size();
             for (const auto& cand : candidates) {
-                const uint32_t injector_idx = cand.core_indices[0];
                 const uint32_t chain_size = cand.core_indices.size();
                 const uint32_t num_receivers = chain_size - 1;
 
-                const CoreCoord first_receiver_phys = core_work[cand.core_indices[1]].physical_core;
-                const CoreCoord last_receiver_phys = core_work[cand.core_indices[chain_size - 1]].physical_core;
+                // Find the injector (may not be at index 0 due to rotation)
+                uint32_t injector_idx = cand.core_indices[0];
+                for (const auto& ci : cand.core_indices) {
+                    if (core_chain_info[ci].is_injector) {
+                        injector_idx = ci;
+                        break;
+                    }
+                }
+
+                // Mcast rect covers the full row (min to max physical X across all chain cores).
+                // The mcast API excludes the source from destinations automatically.
+                uint32_t min_x = core_work[cand.core_indices[0]].physical_core.x;
+                uint32_t max_x = min_x;
+                for (size_t ci = 1; ci < cand.core_indices.size(); ++ci) {
+                    uint32_t x = core_work[cand.core_indices[ci]].physical_core.x;
+                    min_x = std::min(min_x, x);
+                    max_x = std::max(max_x, x);
+                }
+                const uint32_t injector_y = core_work[injector_idx].physical_core.y;
+                const CoreCoord rect_start = CoreCoord{min_x, injector_y};
+                const CoreCoord rect_end = CoreCoord{max_x, injector_y};
+
+                // When the injector is geometrically inside the mcast rect (not at min or max X),
+                // the hardware counts it as a destination slot, so num_dests must include it.
+                const uint32_t injector_x = core_work[injector_idx].physical_core.x;
+                const bool injector_inside_rect = (injector_x > min_x && injector_x < max_x);
+                const uint32_t mcast_num_dests = injector_inside_rect ? chain_size : num_receivers;
 
                 // Configure injector
                 auto& injector_chain = core_chain_info[injector_idx];
                 injector_chain.use_mcast = true;
-                injector_chain.prev_physical = first_receiver_phys;  // mcast rect start
-                injector_chain.next_physical = last_receiver_phys;   // mcast rect end
-                injector_chain.mcast_num_dests = num_receivers;
+                injector_chain.prev_physical = rect_start;  // mcast rect start
+                injector_chain.next_physical = rect_end;    // mcast rect end
+                injector_chain.mcast_num_dests = mcast_num_dests;
+                injector_chain.mcast_sender_wait = num_receivers;
                 injector_chain.next_core_q_chunks = cand.ref_q_chunks;
 
-                // Configure receivers
-                for (size_t ci = 1; ci < cand.core_indices.size(); ++ci) {
-                    auto& receiver_chain = core_chain_info[cand.core_indices[ci]];
+                // Configure receivers (all non-injector cores)
+                for (const auto& ci : cand.core_indices) {
+                    if (ci == injector_idx) {
+                        continue;
+                    }
+                    auto& receiver_chain = core_chain_info[ci];
                     receiver_chain.use_mcast = true;
                     receiver_chain.prev_physical = core_work[injector_idx].physical_core;
                     receiver_chain.is_sink = true;
@@ -977,13 +1027,16 @@ SDPAProgramFactory::cached_program_t SDPAProgramFactory::create(
 
                 log_debug(
                     tt::LogOp,
-                    "Head: mcast enabled - {} receivers, injector core {} -> rect ({},{}) to ({},{})",
+                    "Head: mcast enabled - {} receivers, injector core {} (phys_x={}), num_dests={} -> rect ({},{}) to "
+                    "({},{})",
                     num_receivers,
                     injector_idx,
-                    first_receiver_phys.x,
-                    first_receiver_phys.y,
-                    last_receiver_phys.x,
-                    last_receiver_phys.y);
+                    core_work[injector_idx].physical_core.x,
+                    mcast_num_dests,
+                    rect_start.x,
+                    rect_start.y,
+                    rect_end.x,
+                    rect_end.y);
             }
         }
 
@@ -1089,6 +1142,7 @@ SDPAProgramFactory::cached_program_t SDPAProgramFactory::create(
             reader_args.push_back(static_cast<uint32_t>(chain.next_physical.y));
             reader_args.push_back(chain.next_core_q_chunks);
             reader_args.push_back(chain.mcast_num_dests);
+            reader_args.push_back(chain.mcast_sender_wait);
         }
 
         SetRuntimeArgs(program, reader_kernels_id, core, reader_args);


### PR DESCRIPTION
**1.** On the first iteration of `q_chunk`, push `q_chunk` across multiple iterations aligned to matmul subblock granularity requirements, rather than pushing once upfront.

**2.** Use multicast (mcast) in the special case where the cluster of Tensix cores processing the same sequence length forms a contiguous rectangle (or a single row), replacing per-core unicasts with a single mcast transaction.

**3.** Ensure that "injector cores" responsible for downloading K/V tensors from DRAM are not co-located in a single column, which would create a degenerate access pattern and bottleneck DRAM download bandwidth.
### Checklist

These will push FPU utilisation on WAN 2.2 SDPA shapes up to 3%

APC WH
https://github.com/tenstorrent/tt-metal/actions/runs/22143967767
APC BH
https://github.com/tenstorrent/tt-metal/actions/runs/22143977306
Nightly L2 SDPA
https://github.com/tenstorrent/tt-metal/actions/runs/22143369331