### PR TITLE
add initial support for fabric profile guided channel removal

### DIFF
--- a/.github/workflows/blackhole-multi-card-unit-tests-impl.yaml
+++ b/.github/workflows/blackhole-multi-card-unit-tests-impl.yaml
@@ -80,7 +80,7 @@ jobs:
             test-type: fast
           - name: fabric and ttnn UDM unit tests
             cmd: |
-              ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="*Fabric2DUDMModeFixture.*"
+              ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="*Fabric2DUDMModeFixture.*:*ChannelTrimming*"
               ./build/test/ttnn/unit_tests_ttnn_udm
             timeout: 20
             test-type: slow

--- a/.github/workflows/tm-fabric-tests-impl.yaml
+++ b/.github/workflows/tm-fabric-tests-impl.yaml
@@ -304,6 +304,7 @@ jobs:
             cmd: |
               ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="Fabric2DUDMModeFixture.*"
               ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="NightlyFabric2DUDMModeFixture.*"
+              ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="*ChannelTrimming*"
             timeout: 15
           - name: ttnn UDM unit tests
             cmd: ./build/test/ttnn/unit_tests_ttnn_udm

--- a/tests/tt_metal/tt_fabric/fabric_router/test_channel_trimming_capture.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_router/test_channel_trimming_capture.cpp
@@ -1,0 +1,1139 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Channel Trimming Capture Integration Tests
+ *
+ * Tests the host-side integration for channel trimming resource usage capture:
+ * - Runtime option plumbing (rtoptions → L1 allocation → named CT args)
+ * - L1 buffer allocation in FabricEriscDatamoverConfig
+ * - FabricRouterDiagnosticBufferMap via FabricBuilderContext
+ * - FabricDatapathUsageL1Results struct correctness
+ *
+ * Device-level tests that launch sender/receiver kernels, send traffic through
+ * the fabric, and read back FabricDatapathUsageL1Results from eth core L1.
+ * Tests use mesh coordinates (FabricNodeId) to select devices and the connection
+ * API (get_forwarding_link_indices + append_fabric_connection_rt_args) for routing.
+ */
+
+#include <gtest/gtest.h>
+#include <algorithm>
+#include <chrono>
+#include <cstdint>
+#include <cstring>
+#include <filesystem>
+#include <vector>
+
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/tt_metal.hpp>
+#include <tt-metalium/hal.hpp>
+#include <tt-metalium/allocator.hpp>
+#include <tt-metalium/core_coord.hpp>
+#include <tt-metalium/mesh_coord.hpp>
+#include <tt-metalium/experimental/fabric/fabric.hpp>
+#include <tt-metalium/experimental/fabric/mesh_graph.hpp>
+#include "impl/context/metal_context.hpp"
+#include "tt_metal/fabric/erisc_datamover_builder.hpp"
+#include "tt_metal/fabric/fabric_builder_context.hpp"
+#include "tt_metal/fabric/fabric_context.hpp"
+#include "tt_metal/fabric/fabric_host_utils.hpp"
+#include "tt_metal/fabric/hw/inc/edm_fabric/fabric_trimming_types.hpp"
+#include "tt_metal/fabric/hw/inc/tt_fabric_status.h"
+#include "tt_metal/fabric/builder/fabric_builder_config.hpp"
+#include <tt-metalium/experimental/fabric/control_plane.hpp>
+#include <llrt/tt_cluster.hpp>
+
+#include "tt_metal/fabric/channel_trimming_export.hpp"
+#include "tt_metal/fabric/channel_trimming_import.hpp"
+
+#include "fabric_fixture.hpp"
+
+namespace tt::tt_fabric::fabric_router_tests {
+
+// ============================================================================
+// Type alias for the capture results struct used throughout these tests
+// ============================================================================
+using CaptureResults = FabricDatapathUsageL1Results<true, builder_config::num_max_receiver_channels, builder_config::num_max_sender_channels>;
+
+// ============================================================================
+// Helper: Result of reading capture data from a single ETH core
+// ============================================================================
+struct EthCoreCaptureResult {
+    ChipId physical_chip_id;
+    CoreCoord logical_eth_core;
+    chan_id_t channel_id;
+    CaptureResults capture;
+};
+
+// ============================================================================
+// Helper: Read capture data from all active ETH cores on a device
+// ============================================================================
+std::vector<EthCoreCaptureResult> read_capture_from_all_eth_cores(
+    BaseFabricFixture* fixture, ChipId physical_chip_id) {
+    const auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
+    const auto& builder_ctx = control_plane.get_fabric_context().get_builder_context();
+    auto buffer_map = builder_ctx.get_telemetry_and_metadata_buffer_map();
+
+    TT_FATAL(
+        buffer_map.channel_trimming_capture.is_enabled(),
+        "Channel trimming capture is not enabled — cannot read capture data");
+
+    size_t capture_addr = buffer_map.channel_trimming_capture.l1_address;
+    size_t capture_size = buffer_map.channel_trimming_capture.size_bytes;
+
+    const auto logical_cores = control_plane.get_active_ethernet_cores(physical_chip_id);
+    const auto& cluster = tt::tt_metal::MetalContext::instance().get_cluster();
+    const auto& chan_map = cluster.get_soc_desc(physical_chip_id).logical_eth_core_to_chan_map;
+
+    const auto& device = fixture->get_device(physical_chip_id);
+
+    std::vector<EthCoreCaptureResult> results;
+    results.reserve(logical_cores.size());
+
+    for (const auto& logical_core : logical_cores) {
+        auto chan_it = chan_map.find(logical_core);
+        if (chan_it == chan_map.end()) {
+            continue;
+        }
+        chan_id_t channel_id = static_cast<chan_id_t>(chan_it->second);
+
+        std::vector<uint32_t> raw_data;
+        tt_metal::detail::ReadFromDeviceL1(
+            device->get_devices()[0], logical_core, capture_addr, capture_size, raw_data, CoreType::ETH);
+
+        CaptureResults capture{};
+        std::memcpy(&capture, raw_data.data(), std::min(capture_size, raw_data.size() * sizeof(uint32_t)));
+
+        results.push_back(EthCoreCaptureResult{physical_chip_id, logical_core, channel_id, capture});
+    }
+
+    return results;
+}
+
+// ============================================================================
+// Helper: Run the real exporter, import the YAML back, and verify that
+// every capture read from L1 matches the imported data.
+// ============================================================================
+void verify_capture_roundtrip(const std::vector<EthCoreCaptureResult>& pre_export_captures) {
+    if (pre_export_captures.empty()) {
+        return;
+    }
+
+    // Run the real exporter (writes to {logs_dir}/generated/reports/channel_trimming_capture.yaml)
+    export_channel_trimming_capture();
+
+    // Determine the output path
+    const auto& rtoptions = tt::tt_metal::MetalContext::instance().rtoptions();
+    auto yaml_path =
+        std::filesystem::path(rtoptions.get_logs_dir()) / "generated" / "reports" / "channel_trimming_capture.yaml";
+    ASSERT_TRUE(std::filesystem::exists(yaml_path)) << "Export YAML not found: " << yaml_path;
+
+    // Import back
+    auto imported = load_channel_trimming_overrides(yaml_path.string());
+
+    // Compare: for each pre-export capture, the imported entry must match
+    for (const auto& cap : pre_export_captures) {
+        uint64_t key = make_override_key(cap.physical_chip_id, cap.channel_id);
+        ASSERT_TRUE(imported.contains(key))
+            << "Missing imported entry for chip=" << cap.physical_chip_id
+            << " eth_chan=" << static_cast<int>(cap.channel_id);
+        EXPECT_EQ(imported.at(key), cap.capture)
+            << "Roundtrip mismatch for chip=" << cap.physical_chip_id
+            << " eth_chan=" << static_cast<int>(cap.channel_id);
+    }
+}
+
+// ============================================================================
+// Helper: Result of running unicast traffic
+// ============================================================================
+struct UnicastTrafficResult {
+    ChipId src_physical_device_id;
+    ChipId dst_physical_device_id;
+    FabricNodeId src_fabric_node_id;
+    FabricNodeId dst_fabric_node_id;
+    chan_id_t edm_port;
+    bool skipped;
+};
+
+// ============================================================================
+// Helper: Run unicast traffic between two fabric nodes using the connection API
+// Follows the run_unicast_test_bw_chips pattern from test_basic_1d_fabric.cpp
+// ============================================================================
+UnicastTrafficResult run_unicast_traffic_bw_nodes(
+    BaseFabricFixture* fixture,
+    FabricNodeId src_fabric_node_id,
+    FabricNodeId dst_fabric_node_id,
+    uint32_t num_hops,
+    uint32_t num_packets = 10) {
+    CoreCoord sender_logical_core = {0, 0};
+    CoreCoord receiver_logical_core = {1, 0};
+
+    const auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
+
+    ChipId src_physical = control_plane.get_physical_chip_id_from_fabric_node_id(src_fabric_node_id);
+    ChipId dst_physical = control_plane.get_physical_chip_id_from_fabric_node_id(dst_fabric_node_id);
+
+    // For multi-hop in 1D mode, append_fabric_connection_rt_args only works for direct
+    // neighbors. Determine the first-hop neighbor and use it for the connection setup.
+    // The sender kernel uses num_hops/dst_chip_id runtime args to forward further.
+    auto forwarding_dir_opt = control_plane.get_forwarding_direction(src_fabric_node_id, dst_fabric_node_id);
+    if (!forwarding_dir_opt.has_value()) {
+        return UnicastTrafficResult{{}, {}, FabricNodeId(MeshId{0}, 0), FabricNodeId(MeshId{0}, 0), 0, true};
+    }
+
+    // The connection destination is the first-hop neighbor (which equals dst for 1-hop)
+    FabricNodeId connection_dst = dst_fabric_node_id;
+    if (num_hops > 1) {
+        auto first_hop_neighbors =
+            control_plane.get_intra_chip_neighbors(src_fabric_node_id, *forwarding_dir_opt);
+        if (first_hop_neighbors.empty()) {
+            return UnicastTrafficResult{{}, {}, FabricNodeId(MeshId{0}, 0), FabricNodeId(MeshId{0}, 0), 0, true};
+        }
+        connection_dst = FabricNodeId(src_fabric_node_id.mesh_id, first_hop_neighbors[0]);
+    }
+
+    const auto& available_links = get_forwarding_link_indices(src_fabric_node_id, connection_dst);
+    if (available_links.empty()) {
+        return UnicastTrafficResult{{}, {}, FabricNodeId(MeshId{0}, 0), FabricNodeId(MeshId{0}, 0), 0, true};
+    }
+    uint32_t link_idx = available_links[0];
+
+    auto dir_eth_chans =
+        control_plane.get_active_fabric_eth_channels_in_direction(src_fabric_node_id, *forwarding_dir_opt);
+    chan_id_t edm_port = dir_eth_chans[link_idx];
+
+    auto sender_device = fixture->get_device(src_physical);
+    auto receiver_device = fixture->get_device(dst_physical);
+    CoreCoord receiver_virtual_core = receiver_device->worker_core_from_logical_core(receiver_logical_core);
+
+    const auto topology = control_plane.get_fabric_context().get_fabric_topology();
+    uint32_t is_2d_fabric = topology == Topology::Mesh;
+
+    auto worker_mem_map = BaseFabricFixture::generate_worker_mem_map(sender_device, topology);
+    auto mesh_shape = control_plane.get_physical_mesh_shape(src_fabric_node_id.mesh_id);
+    uint32_t time_seed = std::chrono::system_clock::now().time_since_epoch().count();
+
+    std::vector<uint32_t> compile_time_args = {
+        worker_mem_map.test_results_address,
+        worker_mem_map.test_results_size_bytes,
+        worker_mem_map.target_address,
+        0 /* use_dram_dst */,
+        is_2d_fabric,
+        0 /* is_chip_multicast */,
+        0 /* additional_dir */};
+
+    std::map<std::string, std::string> defines = {};
+    if (is_2d_fabric) {
+        defines["FABRIC_2D"] = "";
+    }
+
+    // Create sender program
+    auto sender_program = tt_metal::CreateProgram();
+    auto sender_kernel = tt_metal::CreateKernel(
+        sender_program,
+        "tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/tt_fabric_1d_tx.cpp",
+        {sender_logical_core},
+        tt_metal::DataMovementConfig{
+            .processor = tt_metal::DataMovementProcessor::RISCV_0,
+            .noc = tt_metal::NOC::RISCV_0_default,
+            .compile_args = compile_time_args,
+            .defines = defines});
+
+    std::vector<uint32_t> sender_runtime_args = {
+        worker_mem_map.source_l1_buffer_address,
+        worker_mem_map.packet_payload_size_bytes,
+        num_packets,
+        time_seed,
+        receiver_virtual_core.x,
+        receiver_virtual_core.y,
+        mesh_shape[1],
+        src_fabric_node_id.chip_id,
+        num_hops,
+        1 /* fwd_range */,
+        dst_fabric_node_id.chip_id,
+        *dst_fabric_node_id.mesh_id};
+
+    // Use connection API to append EDM connection args (to first-hop neighbor)
+    append_fabric_connection_rt_args(
+        src_fabric_node_id,
+        connection_dst,
+        link_idx,
+        sender_program,
+        sender_logical_core,
+        sender_runtime_args);
+
+    tt_metal::SetRuntimeArgs(sender_program, sender_kernel, sender_logical_core, sender_runtime_args);
+
+    // Create receiver program
+    std::vector<uint32_t> receiver_runtime_args = {worker_mem_map.packet_payload_size_bytes, num_packets, time_seed};
+
+    auto receiver_program = tt_metal::CreateProgram();
+    auto receiver_kernel = tt_metal::CreateKernel(
+        receiver_program,
+        "tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/tt_fabric_1d_rx.cpp",
+        {receiver_logical_core},
+        tt_metal::DataMovementConfig{
+            .processor = tt_metal::DataMovementProcessor::RISCV_0,
+            .noc = tt_metal::NOC::RISCV_0_default,
+            .compile_args = compile_time_args});
+
+    tt_metal::SetRuntimeArgs(receiver_program, receiver_kernel, receiver_logical_core, receiver_runtime_args);
+
+    // Launch and wait
+    fixture->RunProgramNonblocking(receiver_device, receiver_program);
+    fixture->RunProgramNonblocking(sender_device, sender_program);
+    fixture->WaitForSingleProgramDone(sender_device, sender_program);
+    fixture->WaitForSingleProgramDone(receiver_device, receiver_program);
+
+    // Validate sender/receiver status
+    std::vector<uint32_t> sender_status;
+    std::vector<uint32_t> receiver_status;
+
+    tt_metal::detail::ReadFromDeviceL1(
+        sender_device->get_devices()[0],
+        sender_logical_core,
+        worker_mem_map.test_results_address,
+        worker_mem_map.test_results_size_bytes,
+        sender_status,
+        CoreType::WORKER);
+
+    tt_metal::detail::ReadFromDeviceL1(
+        receiver_device->get_devices()[0],
+        receiver_logical_core,
+        worker_mem_map.test_results_address,
+        worker_mem_map.test_results_size_bytes,
+        receiver_status,
+        CoreType::WORKER);
+
+    EXPECT_EQ(sender_status[TT_FABRIC_STATUS_INDEX], TT_FABRIC_STATUS_PASS);
+    EXPECT_EQ(receiver_status[TT_FABRIC_STATUS_INDEX], TT_FABRIC_STATUS_PASS);
+
+    return UnicastTrafficResult{
+        src_physical, dst_physical, src_fabric_node_id, dst_fabric_node_id, edm_port, false};
+}
+
+// ============================================================================
+// Helper: Walk the mesh to find a neighbor pair with the specified hop count.
+// Scans all mesh positions and all directions (E/W/N/S) to find a source with
+// at least `num_hops` neighbors. Returns the chain of nodes along the path.
+// ============================================================================
+struct MeshPathResult {
+    FabricNodeId src_node;
+    FabricNodeId dst_node;
+    std::vector<FabricNodeId> path;  // src, hop1, hop2, ..., dst
+    RoutingDirection direction;
+    bool found;
+};
+
+MeshPathResult find_mesh_path_with_hops(uint32_t num_hops) {
+    const auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
+    auto mesh_shape = control_plane.get_physical_mesh_shape(MeshId{0});
+    uint32_t num_chips = mesh_shape.mesh_size();
+
+    // For each candidate source, try to find a destination `num_hops` away by following
+    // the routing path hop-by-hop. Each hop may use a different direction (e.g., on a 2x2
+    // mesh in 1D mode, the chain snakes E→S→W).
+    for (uint32_t src_id = 0; src_id < num_chips; src_id++) {
+        for (uint32_t dst_id = 0; dst_id < num_chips; dst_id++) {
+            if (src_id == dst_id) {
+                continue;
+            }
+            FabricNodeId src_node(MeshId{0}, src_id);
+            FabricNodeId dst_node(MeshId{0}, dst_id);
+
+            // Walk the forwarding path from src toward dst, hop by hop
+            std::vector<FabricNodeId> path;
+            path.push_back(src_node);
+            FabricNodeId current = src_node;
+            bool valid = true;
+
+            for (uint32_t hop = 0; hop < num_hops; hop++) {
+                auto fwd_dir = control_plane.get_forwarding_direction(current, dst_node);
+                if (!fwd_dir.has_value()) {
+                    valid = false;
+                    break;
+                }
+                auto neighbors = control_plane.get_intra_chip_neighbors(current, *fwd_dir);
+                if (neighbors.empty()) {
+                    valid = false;
+                    break;
+                }
+                current = FabricNodeId(MeshId{0}, neighbors[0]);
+                path.push_back(current);
+            }
+
+            if (valid && path.size() == num_hops + 1 && current == dst_node) {
+                // Use the first hop's direction as the overall direction for logging
+                auto first_dir = control_plane.get_forwarding_direction(src_node, dst_node);
+                return MeshPathResult{
+                    src_node, dst_node, path, first_dir.value_or(RoutingDirection::E), true};
+            }
+        }
+    }
+
+    return MeshPathResult{FabricNodeId(MeshId{0}, 0), FabricNodeId(MeshId{0}, 0), {}, RoutingDirection::E, false};
+}
+
+// ============================================================================
+// Helper: Find a src/dst pair where src has a forwarding channel in target_direction
+// Uses mesh coordinates to scan all positions.
+// ============================================================================
+bool find_pair_for_direction(
+    RoutingDirection target_direction,
+    FabricNodeId& src_node,
+    FabricNodeId& dst_node) {
+    const auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
+    auto mesh_shape = control_plane.get_physical_mesh_shape(MeshId{0});
+    uint32_t num_chips = mesh_shape.mesh_size();
+
+    for (uint32_t i = 0; i < num_chips; i++) {
+        FabricNodeId candidate(MeshId{0}, i);
+        auto neighbors = control_plane.get_intra_chip_neighbors(candidate, target_direction);
+        if (neighbors.empty()) {
+            continue;
+        }
+
+        FabricNodeId neighbor_node(MeshId{0}, neighbors[0]);
+        auto links = get_forwarding_link_indices(candidate, neighbor_node);
+        if (links.empty()) {
+            continue;
+        }
+
+        src_node = candidate;
+        dst_node = neighbor_node;
+        return true;
+    }
+
+    return false;
+}
+
+// ============================================================================
+// Fixture: Fabric1D with channel trimming capture enabled before fabric setup
+// ============================================================================
+class Fabric1DChannelTrimmingFixture : public BaseFabricFixture {
+protected:
+    static void SetUpTestSuite() {
+        tt::tt_metal::MetalContext::instance().rtoptions().set_enable_channel_trimming_capture(true);
+        BaseFabricFixture::DoSetUpTestSuite(tt::tt_fabric::FabricConfig::FABRIC_1D);
+    }
+
+    static void TearDownTestSuite() {
+        BaseFabricFixture::DoTearDownTestSuite();
+        tt::tt_metal::MetalContext::instance().rtoptions().set_enable_channel_trimming_capture(false);
+    }
+
+    void SetUp() override {
+        if (arch_ != tt::ARCH::BLACKHOLE) {
+            GTEST_SKIP() << "Channel trimming tests require Blackhole architecture";
+        }
+        if (tt::tt_metal::GetNumAvailableDevices() < 4) {
+            GTEST_SKIP() << "Channel trimming tests require at least 4 devices";
+        }
+        BaseFabricFixture::SetUp();
+    }
+};
+
+// ============================================================================
+// Tests using Fabric1DChannelTrimmingFixture (capture enabled at fabric setup)
+// ============================================================================
+
+// Test: Runtime option is enabled as set by the fixture
+TEST_F(Fabric1DChannelTrimmingFixture, RuntimeOptionEnabled) {
+    auto& rtoptions = tt::tt_metal::MetalContext::instance().rtoptions();
+    EXPECT_TRUE(rtoptions.get_enable_channel_trimming_capture());
+}
+
+// Test: Config allocates L1 buffer when capture is enabled
+TEST_F(Fabric1DChannelTrimmingFixture, ConfigAllocatesL1Buffer) {
+    const auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
+    const auto& config = control_plane.get_fabric_context().get_builder_context().get_fabric_router_config();
+
+    EXPECT_NE(config.datapath_usage_l1_address, 0u);
+    EXPECT_GT(config.datapath_usage_buffer_size, 0u);
+    EXPECT_EQ(config.datapath_usage_buffer_size,
+              sizeof(CaptureResults));
+}
+
+// Test: L1 allocation placed before handshake address
+TEST_F(Fabric1DChannelTrimmingFixture, L1AllocationOrdering) {
+    const auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
+    const auto& config = control_plane.get_fabric_context().get_builder_context().get_fabric_router_config();
+
+    // Capture buffer + its size should not exceed the handshake address
+    size_t capture_end = config.datapath_usage_l1_address + config.datapath_usage_buffer_size;
+    EXPECT_LE(capture_end, config.handshake_addr);
+}
+
+// Test: DiagnosticBufferMap shows channel_trimming_capture enabled via FabricBuilderContext
+TEST_F(Fabric1DChannelTrimmingFixture, DiagnosticBufferMapViaBuilderContext) {
+    const auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
+    const auto& builder_ctx = control_plane.get_fabric_context().get_builder_context();
+    auto buffer_map = builder_ctx.get_telemetry_and_metadata_buffer_map();
+
+    EXPECT_TRUE(buffer_map.channel_trimming_capture.is_enabled());
+    EXPECT_NE(buffer_map.channel_trimming_capture.l1_address, 0u);
+    EXPECT_GT(buffer_map.channel_trimming_capture.size_bytes, 0u);
+    EXPECT_EQ(buffer_map.channel_trimming_capture.size_bytes,
+              sizeof(CaptureResults));
+}
+
+// Test: DiagnosticBufferMap regions are non-overlapping and ordered
+TEST_F(Fabric1DChannelTrimmingFixture, DiagnosticBufferMapRegionsNonOverlapping) {
+    const auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
+    const auto& builder_ctx = control_plane.get_fabric_context().get_builder_context();
+    auto buffer_map = builder_ctx.get_telemetry_and_metadata_buffer_map();
+
+    // Collect all enabled regions
+    std::vector<std::pair<size_t, size_t>> regions;  // (address, end)
+    if (buffer_map.perf_telemetry.is_enabled()) {
+        regions.emplace_back(
+            buffer_map.perf_telemetry.l1_address,
+            buffer_map.perf_telemetry.l1_address + buffer_map.perf_telemetry.size_bytes);
+    }
+    if (buffer_map.code_profiling.is_enabled()) {
+        regions.emplace_back(
+            buffer_map.code_profiling.l1_address,
+            buffer_map.code_profiling.l1_address + buffer_map.code_profiling.size_bytes);
+    }
+    if (buffer_map.channel_trimming_capture.is_enabled()) {
+        regions.emplace_back(
+            buffer_map.channel_trimming_capture.l1_address,
+            buffer_map.channel_trimming_capture.l1_address + buffer_map.channel_trimming_capture.size_bytes);
+    }
+
+    // Verify no overlaps: sort by address and check each end <= next start
+    std::sort(regions.begin(), regions.end());
+    for (size_t i = 1; i < regions.size(); i++) {
+        EXPECT_LE(regions[i - 1].second, regions[i].first)
+            << "Diagnostic buffer regions overlap at index " << i;
+    }
+}
+
+// ============================================================================
+// Tests using Fabric1DFixture (capture disabled — tests disabled path and
+// pure struct logic that don't need the runtime option set at setup time)
+// ============================================================================
+
+// Test: Runtime option getter/setter interface
+TEST_F(Fabric1DFixture, ChannelTrimmingCapture_RuntimeOptionGetterSetter) {
+    auto& rtoptions = tt::tt_metal::MetalContext::instance().rtoptions();
+    bool original = rtoptions.get_enable_channel_trimming_capture();
+
+    rtoptions.set_enable_channel_trimming_capture(true);
+    EXPECT_TRUE(rtoptions.get_enable_channel_trimming_capture());
+    rtoptions.set_enable_channel_trimming_capture(false);
+    EXPECT_FALSE(rtoptions.get_enable_channel_trimming_capture());
+
+    rtoptions.set_enable_channel_trimming_capture(original);
+}
+
+// Test: DiagnosticBufferMap shows channel_trimming_capture disabled when not enabled at setup
+TEST_F(Fabric1DFixture, ChannelTrimmingCapture_DiagnosticBufferMapDisabled) {
+    const auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
+    const auto& builder_ctx = control_plane.get_fabric_context().get_builder_context();
+    auto buffer_map = builder_ctx.get_telemetry_and_metadata_buffer_map();
+
+    EXPECT_FALSE(buffer_map.channel_trimming_capture.is_enabled());
+    EXPECT_EQ(buffer_map.channel_trimming_capture.l1_address, 0u);
+    EXPECT_EQ(buffer_map.channel_trimming_capture.size_bytes, 0u);
+}
+
+// Test: Config does NOT allocate L1 buffer when capture is disabled
+TEST_F(Fabric1DFixture, ChannelTrimmingCapture_ConfigNoAllocWhenDisabled) {
+    const auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
+    const auto& config = control_plane.get_fabric_context().get_builder_context().get_fabric_router_config();
+
+    // Fabric1DFixture does not enable channel trimming capture, so the config should not allocate
+    EXPECT_EQ(config.datapath_usage_l1_address, 0u);
+    EXPECT_EQ(config.datapath_usage_buffer_size, 0u);
+}
+
+// ============================================================================
+// Fixture: Fabric2D with channel trimming capture enabled before fabric setup
+// ============================================================================
+class Fabric2DChannelTrimmingFixture : public BaseFabricFixture {
+protected:
+    static void SetUpTestSuite() {
+        tt::tt_metal::MetalContext::instance().rtoptions().set_enable_channel_trimming_capture(true);
+        BaseFabricFixture::DoSetUpTestSuite(tt::tt_fabric::FabricConfig::FABRIC_2D);
+    }
+
+    static void TearDownTestSuite() {
+        BaseFabricFixture::DoTearDownTestSuite();
+        tt::tt_metal::MetalContext::instance().rtoptions().set_enable_channel_trimming_capture(false);
+    }
+
+    void SetUp() override {
+        if (arch_ != tt::ARCH::BLACKHOLE) {
+            GTEST_SKIP() << "Channel trimming tests require Blackhole architecture";
+        }
+        if (tt::tt_metal::GetNumAvailableDevices() < 4) {
+            GTEST_SKIP() << "Channel trimming tests require at least 4 devices";
+        }
+        BaseFabricFixture::SetUp();
+    }
+};
+
+// ============================================================================
+// Device-Level Tests: Fabric1DChannelTrimmingFixture
+// ============================================================================
+
+// Test 1: 1-hop unicast — verify both source and destination routers recorded traffic
+TEST_F(Fabric1DChannelTrimmingFixture, UnicastSenderAndReceiverChannelUsed) {
+    // Use mesh coordinates to find a 1-hop neighbor pair (any direction on the chain)
+    auto path_result = find_mesh_path_with_hops(1);
+    if (!path_result.found) {
+        GTEST_SKIP() << "No 1-hop neighbor pair found on the mesh";
+    }
+
+    log_info(
+        tt::LogTest,
+        "1-hop test: src mesh chip_id={} -> dst mesh chip_id={} in direction {}",
+        path_result.src_node.chip_id,
+        path_result.dst_node.chip_id,
+        static_cast<int>(path_result.direction));
+
+    auto result = run_unicast_traffic_bw_nodes(this, path_result.src_node, path_result.dst_node, 1);
+    if (result.skipped) {
+        GTEST_SKIP() << "No forwarding links between selected nodes";
+    }
+
+    // Source router: the eth core matching edm_port should show sender channel activity
+    auto src_captures = read_capture_from_all_eth_cores(this, result.src_physical_device_id);
+    int num_routers_with_sender_activity = 0;
+    for (const auto& cap : src_captures) {
+        if (cap.capture.sender_channel_used_bitfield_by_vc != 0) {
+            num_routers_with_sender_activity++;
+            // Sender channel validation on sender chip
+            EXPECT_EQ(cap.capture.sender_channel_used_bitfield_by_vc, 1)
+                << "Source router eth core (chan " << static_cast<int>(cap.channel_id)
+                << ") should only show channel 0 (worker channel) activity";
+            // Receiver channel validation on sender chip — no inbound traffic
+            EXPECT_EQ(cap.capture.receiver_channel_data_forwarded_bitfield_by_vc, 0)
+                << "Source router eth core (chan " << static_cast<int>(cap.channel_id)
+                << ") should not show receiver channel forwarding activity since traffic is one-way";
+            // NocSendType validation — source doesn't deliver locally
+            for (size_t vc = 0; vc < 2; vc++) {
+                EXPECT_EQ(cap.capture.used_noc_send_type_by_vc_bitfield[vc], 0)
+                    << "Source router eth core (chan " << static_cast<int>(cap.channel_id)
+                    << ") should not show NocSendType activity on VC " << vc << " since traffic is one-way outbound";
+                EXPECT_EQ(cap.capture.sender_channel_forwarded_to_bitfield_by_vc[vc], 0)
+                    << "Source router eth core (chan " << static_cast<int>(cap.channel_id)
+                    << ") should not show forwarding-to on VC " << vc << " since traffic originates here (not forwarded from receiver)";
+            }
+
+        }
+    }
+    EXPECT_TRUE(num_routers_with_sender_activity == 1);
+
+    // Destination router: the inbound eth core should show full receiver state
+    auto dst_captures = read_capture_from_all_eth_cores(this, result.dst_physical_device_id);
+    bool found_receiver_forwarding = false;
+    int num_routers_with_receiver_activity = 0;
+    for (const auto& cap : dst_captures) {
+        if (cap.capture.receiver_channel_data_forwarded_bitfield_by_vc != 0) {
+            num_routers_with_receiver_activity++;
+            // Receiver channel validation on destination chip
+            EXPECT_NE(cap.capture.receiver_channel_data_forwarded_bitfield_by_vc, 0)
+                << "Destination router eth core (chan " << static_cast<int>(cap.channel_id)
+                << ") should show receiver channel forwarding activity";
+            // NocSendType validation — destination delivers packets locally via noc
+
+            EXPECT_TRUE(cap.capture.used_noc_send_type_by_vc_bitfield[0] != 0)
+                << "Destination router eth core (chan " << static_cast<int>(cap.channel_id)
+                << ") receiver channel 0 should show NocSendType activity since it delivers packets locally";
+            EXPECT_TRUE(cap.capture.used_noc_send_type_by_vc_bitfield[1] == 0)
+                << "Destination router eth core (chan " << static_cast<int>(cap.channel_id)
+                << ") receiver channel 1 should NOT show NocSendType activity since it delivers packets locally";
+            // Sender channel validation — destination is 1-hop endpoint, should NOT forward
+            EXPECT_EQ(cap.capture.sender_channel_used_bitfield_by_vc, 0)
+                << "Destination router eth core (chan " << static_cast<int>(cap.channel_id)
+                << ") should not show sender channel activity since it is the 1-hop endpoint";
+
+            EXPECT_EQ(cap.capture.sender_channel_forwarded_to_bitfield_by_vc[0], 0)
+                << "Destination router eth core (chan " << static_cast<int>(cap.channel_id)
+                << ") receiver channel 0 should record forwarding to sender channel 1 (bit 1)";
+            EXPECT_EQ(cap.capture.sender_channel_forwarded_to_bitfield_by_vc[1], 0)
+                << "Destination router eth core (chan " << static_cast<int>(cap.channel_id)
+                << ") VC 1 should not show forwarding-to (no VC1 traffic in 1D)";
+
+            found_receiver_forwarding = true;
+        }
+    }
+    EXPECT_EQ(num_routers_with_receiver_activity, 1);
+    EXPECT_TRUE(found_receiver_forwarding) << "Expected at least one eth core on destination to show receiver "
+                                              "channel data forwarding activity";
+
+    // Roundtrip: export to YAML → import → compare
+    auto all_captures = src_captures;
+    all_captures.insert(all_captures.end(), dst_captures.begin(), dst_captures.end());
+    verify_capture_roundtrip(all_captures);
+}
+
+// Test 2: 2-hop unicast — verify intermediate router forwarding
+TEST_F(Fabric1DChannelTrimmingFixture, UnicastMultiHopForwarding) {
+    // Use mesh coordinates to find a 2-hop path (scans all positions and directions)
+    auto path_result = find_mesh_path_with_hops(2);
+    if (!path_result.found) {
+        GTEST_SKIP() << "No 2-hop path found on the mesh (need >=3 devices in some direction)";
+    }
+
+    log_info(
+        tt::LogTest,
+        "2-hop test: src mesh chip_id={} -> intermediate chip_id={} -> dst mesh chip_id={} in direction {}",
+        path_result.path[0].chip_id,
+        path_result.path[1].chip_id,
+        path_result.path[2].chip_id,
+        static_cast<int>(path_result.direction));
+
+    auto result = run_unicast_traffic_bw_nodes(this, path_result.src_node, path_result.dst_node, 2);
+    if (result.skipped) {
+        GTEST_SKIP() << "No forwarding links between selected nodes";
+    }
+
+    // Get the intermediate device's physical chip ID
+    const auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
+    FabricNodeId intermediate_node = path_result.path[1];
+    ChipId intermediate_physical = control_plane.get_physical_chip_id_from_fabric_node_id(intermediate_node);
+
+    ASSERT_NE(intermediate_physical, result.dst_physical_device_id)
+        << "Intermediate should differ from destination in a 2-hop route";
+
+    // --- Source router validation ---
+    auto src_captures = read_capture_from_all_eth_cores(this, result.src_physical_device_id);
+    int num_routers_with_sender_activity = 0;
+    for (const auto& cap : src_captures) {
+        if (cap.channel_id == result.edm_port) {
+            num_routers_with_sender_activity++;
+            // Sender channel validation — source originates traffic
+            EXPECT_EQ(cap.capture.sender_channel_used_bitfield_by_vc, 1)
+                << "Source router eth core (chan " << static_cast<int>(cap.channel_id)
+                << ") should only show channel 0 (worker channel) activity";
+            // Receiver channel validation — source has no inbound traffic
+            EXPECT_EQ(cap.capture.receiver_channel_data_forwarded_bitfield_by_vc, 0)
+                << "Source router eth core (chan " << static_cast<int>(cap.channel_id)
+                << ") should not show receiver forwarding (traffic originates here)";
+            for (size_t vc = 0; vc < 2; vc++) {
+                EXPECT_EQ(cap.capture.used_noc_send_type_by_vc_bitfield[vc], 0)
+                    << "Source router eth core (chan " << static_cast<int>(cap.channel_id)
+                    << ") should not show NocSendType on VC " << vc << " (outbound only)";
+                EXPECT_EQ(cap.capture.sender_channel_forwarded_to_bitfield_by_vc[vc], 0)
+                    << "Source router eth core (chan " << static_cast<int>(cap.channel_id)
+                    << ") should not show forwarding-to on VC " << vc << " (traffic originates here)";
+            }
+        }
+    }
+    EXPECT_TRUE(num_routers_with_sender_activity == 1) << "Expected to find exactly one router with sender activity on source device's edm_port";
+
+    // --- Intermediate router validation ---
+    auto intermediate_captures = read_capture_from_all_eth_cores(this, intermediate_physical);
+    int num_routers_with_intermediate_sender_activity = 0;
+    int num_routers_with_intermediate_receiver_activity = 0;
+    bool sender_and_receiver_channels_active_on_different_routers = true;
+    for (const auto& cap : intermediate_captures) {
+        if (cap.capture.sender_channel_used_bitfield_by_vc != 0) {
+            num_routers_with_intermediate_sender_activity++;
+            // Intermediate forwards outbound — sender channel should be forwarding channel, not worker
+            EXPECT_EQ(cap.capture.sender_channel_used_bitfield_by_vc & 1u, 0)
+                << "Intermediate router eth core (chan " << static_cast<int>(cap.channel_id)
+                << ") should NOT show worker channel (bit 0) activity — it only forwards";
+            // NocSendType should be zero — intermediate doesn't deliver locally
+            for (size_t vc = 0; vc < 2; vc++) {
+                EXPECT_EQ(cap.capture.used_noc_send_type_by_vc_bitfield[vc], 0)
+                    << "Intermediate router eth core (chan " << static_cast<int>(cap.channel_id)
+                    << ") should not show NocSendType on VC " << vc << " (forwarding only, no local delivery)";
+            }
+        }
+        if (cap.capture.receiver_channel_data_forwarded_bitfield_by_vc != 0) {
+            num_routers_with_intermediate_receiver_activity++;
+            // Intermediate receives and forwards — forwarding relationship should be recorded
+            EXPECT_NE(cap.capture.sender_channel_forwarded_to_bitfield_by_vc[0], 0)
+                << "Intermediate router eth core (chan " << static_cast<int>(cap.channel_id)
+                << ") VC0 should show forwarding-to (receiver forwards to sender channel)";
+        }
+        sender_and_receiver_channels_active_on_different_routers = sender_and_receiver_channels_active_on_different_routers &&
+            !((cap.capture.receiver_channel_data_forwarded_bitfield_by_vc != 0) && (cap.capture.sender_channel_used_bitfield_by_vc != 0));
+    }
+    EXPECT_TRUE(num_routers_with_intermediate_sender_activity == 1) << "Expected to find exactly one router with sender activity on intermediate device";
+    EXPECT_TRUE(num_routers_with_intermediate_receiver_activity == 1) << "Expected to find exactly one router with receiver activity on intermediate device";
+    EXPECT_TRUE(sender_and_receiver_channels_active_on_different_routers) << "Sender and receiver channels should be active on different routers";
+
+    // --- Destination router validation ---
+    auto dst_captures = read_capture_from_all_eth_cores(this, result.dst_physical_device_id);
+    int num_routers_with_dst_receiver_activity = 0;
+    for (const auto& cap : dst_captures) {
+        if (cap.capture.receiver_channel_data_forwarded_bitfield_by_vc != 0) {
+            num_routers_with_dst_receiver_activity++;
+            // Receiver channel validation — destination receives and delivers locally
+            EXPECT_NE(cap.capture.receiver_channel_data_forwarded_bitfield_by_vc, 0)
+                << "Destination router eth core (chan " << static_cast<int>(cap.channel_id)
+                << ") should show receiver channel forwarding activity";
+            // NocSendType validation — delivers locally
+            bool has_noc_send_type = false;
+            for (size_t vc = 0; vc < 2; vc++) {
+                if (cap.capture.used_noc_send_type_by_vc_bitfield[vc] != 0) {
+                    has_noc_send_type = true;
+                }
+            }
+            EXPECT_TRUE(has_noc_send_type)
+                << "Destination router eth core (chan " << static_cast<int>(cap.channel_id)
+                << ") should show NocSendType activity (local delivery)";
+            // Sender channel validation — destination is endpoint, no sender transmission
+            EXPECT_EQ(cap.capture.sender_channel_used_bitfield_by_vc, 0)
+                << "Destination router eth core (chan " << static_cast<int>(cap.channel_id)
+                << ") should not show sender channel activity (2-hop endpoint)";
+
+            EXPECT_EQ(cap.capture.sender_channel_forwarded_to_bitfield_by_vc[0], 0)
+                << "Destination router eth core (chan " << static_cast<int>(cap.channel_id)
+                << ") receiver channel 0 should record forwarding to sender channel 1 (bit 1)";
+            EXPECT_EQ(cap.capture.sender_channel_forwarded_to_bitfield_by_vc[1], 0)
+                << "Destination router eth core (chan " << static_cast<int>(cap.channel_id)
+                << ") VC1 should not show forwarding-to (no VC1 traffic in 1D)";
+        }
+    }
+    EXPECT_TRUE(num_routers_with_dst_receiver_activity == 1) << "Expected to find exactly one router with receiver activity on destination device";
+
+    // Roundtrip: export to YAML → import → compare
+    auto all_captures = src_captures;
+    all_captures.insert(all_captures.end(), intermediate_captures.begin(), intermediate_captures.end());
+    all_captures.insert(all_captures.end(), dst_captures.begin(), dst_captures.end());
+    verify_capture_roundtrip(all_captures);
+}
+
+// Test 3: 1-hop unicast — verify min/max packet size tracking
+TEST_F(Fabric1DChannelTrimmingFixture, UnicastPacketSizeTracking) {
+    auto path_result = find_mesh_path_with_hops(1);
+    if (!path_result.found) {
+        GTEST_SKIP() << "No 1-hop neighbor pair found on the mesh";
+    }
+
+    auto result = run_unicast_traffic_bw_nodes(this, path_result.src_node, path_result.dst_node, 1, /*num_packets=*/10);
+    if (result.skipped) {
+        GTEST_SKIP() << "No forwarding links between selected nodes";
+    }
+
+    // --- Source router: packet size tracking ---
+    auto src_captures = read_capture_from_all_eth_cores(this, result.src_physical_device_id);
+
+    for (const auto& cap : src_captures) {
+        if (cap.channel_id != result.edm_port) {
+            continue;
+        }
+
+        uint16_t used_bitfield = cap.capture.sender_channel_used_bitfield_by_vc;
+        ASSERT_NE(used_bitfield, 0) << "Expected sender channel activity on edm_port "
+                                    << static_cast<int>(result.edm_port);
+        EXPECT_EQ(used_bitfield, 1)
+            << "Source should only show channel 0 (worker channel) activity";
+
+        // Full state: source is outbound only
+        EXPECT_EQ(cap.capture.receiver_channel_data_forwarded_bitfield_by_vc, 0)
+            << "Source router should not show receiver forwarding (1-hop outbound)";
+        for (size_t vc = 0; vc < 2; vc++) {
+            EXPECT_EQ(cap.capture.used_noc_send_type_by_vc_bitfield[vc], 0)
+                << "Source router should not show NocSendType on VC " << vc << " (outbound only)";
+            EXPECT_EQ(cap.capture.sender_channel_forwarded_to_bitfield_by_vc[vc], 0)
+                << "Source router should not show forwarding-to on VC " << vc << " (traffic originates here)";
+        }
+
+        // Check each sender channel that has its bit set — packet size invariants
+        for (size_t ch = 0; ch < builder_config::num_max_sender_channels; ch++) {
+            if (!(used_bitfield & (1u << ch))) {
+                continue;
+            }
+            uint16_t min_pkt = cap.capture.sender_channel_min_packet_size_seen_bytes_by_vc[ch];
+            uint16_t max_pkt = cap.capture.sender_channel_max_packet_size_seen_bytes_by_vc[ch];
+
+            EXPECT_NE(min_pkt, 0xFFFF)
+                << "Sender channel " << ch << ": min_packet_size should be updated from sentinel 0xFFFF";
+            EXPECT_NE(max_pkt, 0u) << "Sender channel " << ch << ": max_packet_size should be updated from 0";
+            EXPECT_LE(min_pkt, max_pkt)
+                << "Sender channel " << ch << ": min_packet_size (" << min_pkt
+                << ") should be <= max_packet_size (" << max_pkt << ")";
+        }
+        break;
+    }
+
+    // --- Destination router: full state validation ---
+    auto dst_captures = read_capture_from_all_eth_cores(this, result.dst_physical_device_id);
+    bool found_dst_receiver = false;
+    for (const auto& cap : dst_captures) {
+        if (cap.capture.receiver_channel_data_forwarded_bitfield_by_vc != 0) {
+            // Receiver delivers locally
+            bool has_noc_send_type = false;
+            for (size_t vc = 0; vc < 2; vc++) {
+                if (cap.capture.used_noc_send_type_by_vc_bitfield[vc] != 0) {
+                    has_noc_send_type = true;
+                }
+            }
+            EXPECT_TRUE(has_noc_send_type)
+                << "Destination router eth core (chan " << static_cast<int>(cap.channel_id)
+                << ") should show NocSendType activity (local delivery)";
+            // Endpoint — no sender transmission
+            EXPECT_EQ(cap.capture.sender_channel_used_bitfield_by_vc, 0)
+                << "Destination router eth core (chan " << static_cast<int>(cap.channel_id)
+                << ") should not show sender channel activity (endpoint)";
+            // In 1D, the receiver channel always records its forwarding path to sender channel 1
+            EXPECT_EQ(cap.capture.sender_channel_forwarded_to_bitfield_by_vc[0], 0)
+                << "Destination router eth core (chan " << static_cast<int>(cap.channel_id)
+                << ") receiver channel 0 should record forwarding to sender channel 1 (bit 1)";
+            EXPECT_EQ(cap.capture.sender_channel_forwarded_to_bitfield_by_vc[1], 0)
+                << "Destination router eth core (chan " << static_cast<int>(cap.channel_id)
+                << ") VC1 should not show forwarding-to (no VC1 traffic in 1D)";
+            found_dst_receiver = true;
+        }
+    }
+    EXPECT_TRUE(found_dst_receiver)
+        << "Destination router should show receiver channel forwarding activity";
+
+    // Roundtrip: export to YAML → import → compare
+    auto all_captures = src_captures;
+    all_captures.insert(all_captures.end(), dst_captures.begin(), dst_captures.end());
+    verify_capture_roundtrip(all_captures);
+}
+
+// ============================================================================
+// Device-Level Tests: Fabric2DChannelTrimmingFixture
+// ============================================================================
+
+// Test 4: Exercise each directional channel (E/W/N/S)
+TEST_F(Fabric2DChannelTrimmingFixture, DirectionalChannelLiveness) {
+    std::vector<RoutingDirection> directions = {
+        RoutingDirection::E, RoutingDirection::W, RoutingDirection::N, RoutingDirection::S};
+    std::vector<RoutingDirection> exercised_directions;
+
+    for (auto direction : directions) {
+        FabricNodeId src_node(MeshId{0}, 0);
+        FabricNodeId dst_node(MeshId{0}, 0);
+
+        if (!find_pair_for_direction(direction, src_node, dst_node)) {
+            log_info(
+                tt::LogTest,
+                "No device pair found for direction {} — skipping this direction",
+                static_cast<int>(direction));
+            continue;
+        }
+
+        auto result = run_unicast_traffic_bw_nodes(this, src_node, dst_node, 1, /*num_packets=*/10);
+        if (result.skipped) {
+            log_info(
+                tt::LogTest,
+                "Traffic run skipped for direction {} — no forwarding links",
+                static_cast<int>(direction));
+            continue;
+        }
+
+        // --- Source device: validate sender channel activity on the edm_port ---
+        // NOTE: We only check positive conditions (sender was used). Negative conditions
+        // (receiver/noc_send_type should be zero) are unreliable because the firmware only
+        // resets capture data at kernel_main() startup, and across loop iterations the same
+        // device may play different roles (source vs destination), accumulating stale data.
+        auto src_captures = read_capture_from_all_eth_cores(this, result.src_physical_device_id);
+        bool found_sender = false;
+        for (const auto& cap : src_captures) {
+            if (cap.channel_id == result.edm_port) {
+                EXPECT_NE(cap.capture.sender_channel_used_bitfield_by_vc, 0)
+                    << "Source router eth core (chan " << static_cast<int>(cap.channel_id)
+                    << ", direction " << static_cast<int>(direction) << ") should show sender channel activity";
+                // Worker channel (bit 0) should be set
+                EXPECT_NE(cap.capture.sender_channel_used_bitfield_by_vc & 1, 0)
+                    << "Source router eth core (chan " << static_cast<int>(cap.channel_id)
+                    << ", direction " << static_cast<int>(direction) << ") should show worker channel (0) activity";
+                found_sender = true;
+            }
+        }
+
+        // --- Destination device: validate receiver channel activity ---
+        // NOTE: In 2D, sender_channel_forwarded_to_bitfield_by_vc[0] is 0 at the terminal
+        // destination because hop_cmd_to_sender_channel_mask masks out my_direction,
+        // resulting in fwd_mask=0. Also, sender_channel_used may be non-zero if this
+        // router also forwards in other directions. We only check positive conditions.
+        auto dst_captures = read_capture_from_all_eth_cores(this, result.dst_physical_device_id);
+        bool found_receiver = false;
+        for (const auto& cap : dst_captures) {
+            if (cap.capture.receiver_channel_data_forwarded_bitfield_by_vc != 0) {
+                bool has_noc_send_type = false;
+                for (size_t vc = 0; vc < 2; vc++) {
+                    if (cap.capture.used_noc_send_type_by_vc_bitfield[vc] != 0) {
+                        has_noc_send_type = true;
+                    }
+                }
+                EXPECT_TRUE(has_noc_send_type)
+                    << "Destination router eth core (chan " << static_cast<int>(cap.channel_id)
+                    << ", direction " << static_cast<int>(direction)
+                    << ") should show NocSendType activity (local delivery)";
+                found_receiver = true;
+            }
+        }
+
+        if (found_sender && found_receiver) {
+            exercised_directions.push_back(direction);
+            log_info(
+                tt::LogTest,
+                "Direction {} successfully exercised (src mesh chip_id={}, dst mesh chip_id={})",
+                static_cast<int>(direction),
+                src_node.chip_id,
+                dst_node.chip_id);
+
+            // Roundtrip: export to YAML → import → compare
+            auto all_captures = src_captures;
+            all_captures.insert(all_captures.end(), dst_captures.begin(), dst_captures.end());
+            verify_capture_roundtrip(all_captures);
+        }
+    }
+
+    // On any multi-device system, at least 2 directions should be exercisable
+    EXPECT_GE(exercised_directions.size(), 2u)
+        << "Expected at least 2 directions to be exercised; only got " << exercised_directions.size();
+}
+
+// Test 5: Verify forwarding relationships in 2D (sender_channel_forwarded_to_bitfield)
+TEST_F(Fabric2DChannelTrimmingFixture, DirectionalChannelForwardedTo) {
+    const auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
+    auto mesh_shape = control_plane.get_physical_mesh_shape(MeshId{0});
+    uint32_t num_chips = mesh_shape.mesh_size();
+
+    if (num_chips < 4) {
+        GTEST_SKIP() << "Need at least 4 devices for multi-hop 2D routing test";
+    }
+
+    // Try to find two devices that are not direct neighbors (want multi-hop)
+    FabricNodeId src_node(MeshId{0}, 0);
+    FabricNodeId dst_node(MeshId{0}, 0);
+    bool found_pair = false;
+
+    for (uint32_t i = 0; i < num_chips && !found_pair; i++) {
+        FabricNodeId candidate_src(MeshId{0}, i);
+
+        for (uint32_t j = 0; j < num_chips; j++) {
+            if (i == j) {
+                continue;
+            }
+            FabricNodeId candidate_dst(MeshId{0}, j);
+
+            auto links = get_forwarding_link_indices(candidate_src, candidate_dst);
+            if (links.empty()) {
+                continue;
+            }
+
+            // Check this isn't a direct neighbor (want multi-hop)
+            // get_intra_chip_neighbors returns mesh chip_ids, so compare against j (mesh chip_id)
+            bool is_direct_neighbor = false;
+            for (auto dir :
+                 {RoutingDirection::E, RoutingDirection::W, RoutingDirection::N, RoutingDirection::S}) {
+                auto neighbors = control_plane.get_intra_chip_neighbors(candidate_src, dir);
+                for (auto n : neighbors) {
+                    if (n == j) {
+                        is_direct_neighbor = true;
+                        break;
+                    }
+                }
+                if (is_direct_neighbor) {
+                    break;
+                }
+            }
+
+            if (!is_direct_neighbor) {
+                src_node = candidate_src;
+                dst_node = candidate_dst;
+                found_pair = true;
+                break;
+            }
+        }
+    }
+
+    if (!found_pair) {
+        // Fall back to any src/dst pair with forwarding links
+        for (uint32_t i = 0; i < num_chips && !found_pair; i++) {
+            for (uint32_t j = 0; j < num_chips; j++) {
+                if (i == j) {
+                    continue;
+                }
+                FabricNodeId candidate_src(MeshId{0}, i);
+                FabricNodeId candidate_dst(MeshId{0}, j);
+                auto links = get_forwarding_link_indices(candidate_src, candidate_dst);
+                if (!links.empty()) {
+                    src_node = candidate_src;
+                    dst_node = candidate_dst;
+                    found_pair = true;
+                    break;
+                }
+            }
+        }
+    }
+
+    if (!found_pair) {
+        GTEST_SKIP() << "No valid src/dst pair with forwarding links found";
+    }
+
+    auto result = run_unicast_traffic_bw_nodes(this, src_node, dst_node, 1, /*num_packets=*/10);
+    if (result.skipped) {
+        GTEST_SKIP() << "No forwarding channels between selected src/dst pair";
+    }
+
+    // --- Source device: validate sender channel activity ---
+    auto src_captures = read_capture_from_all_eth_cores(this, result.src_physical_device_id);
+    bool found_src_sender = false;
+    bool found_forwarded_to = false;
+    for (const auto& cap : src_captures) {
+        if (cap.channel_id == result.edm_port) {
+            EXPECT_NE(cap.capture.sender_channel_used_bitfield_by_vc, 0)
+                << "Source router eth core (chan " << static_cast<int>(cap.channel_id)
+                << ") should show sender channel activity";
+            EXPECT_NE(cap.capture.sender_channel_used_bitfield_by_vc & 1, 0)
+                << "Source router eth core (chan " << static_cast<int>(cap.channel_id)
+                << ") should show worker channel (0) activity";
+            found_src_sender = true;
+        }
+
+        // Check forwarded_to on any eth core (for multi-hop intermediate routers on src device)
+        for (size_t vc = 0; vc < 2; vc++) {
+            if (cap.capture.sender_channel_forwarded_to_bitfield_by_vc[vc] != 0) {
+                found_forwarded_to = true;
+                log_info(
+                    tt::LogTest,
+                    "Source chip {} eth core chan {}: sender_channel_forwarded_to_bitfield_by_vc[{}] = 0x{:04x}",
+                    cap.physical_chip_id,
+                    static_cast<int>(cap.channel_id),
+                    vc,
+                    cap.capture.sender_channel_forwarded_to_bitfield_by_vc[vc]);
+            }
+        }
+    }
+    EXPECT_TRUE(found_src_sender)
+        << "Expected to find sender activity on source device's edm_port " << static_cast<int>(result.edm_port);
+
+    // --- Destination device: validate receiver channel activity ---
+    // NOTE: In 2D, forwarded_to[0] is 0 at the terminal destination because
+    // hop_cmd_to_sender_channel_mask masks out my_direction (local write).
+    // sender_channel_used may also be non-zero if this router forwards in other directions.
+    auto dst_captures = read_capture_from_all_eth_cores(this, result.dst_physical_device_id);
+    bool found_receiver_forwarding = false;
+    for (const auto& cap : dst_captures) {
+        if (cap.capture.receiver_channel_data_forwarded_bitfield_by_vc != 0) {
+            bool has_noc_send_type = false;
+            for (size_t vc = 0; vc < 2; vc++) {
+                if (cap.capture.used_noc_send_type_by_vc_bitfield[vc] != 0) {
+                    has_noc_send_type = true;
+                }
+            }
+            EXPECT_TRUE(has_noc_send_type)
+                << "Destination router eth core (chan " << static_cast<int>(cap.channel_id)
+                << ") should show NocSendType activity (local delivery)";
+            found_receiver_forwarding = true;
+        }
+    }
+
+    // At least one of forwarded_to or receiver forwarding should be set
+    EXPECT_TRUE(found_forwarded_to || found_receiver_forwarding)
+        << "Expected forwarding relationship to be recorded either as sender_channel_forwarded_to on source "
+           "or receiver_channel_data_forwarded on destination";
+
+    // Roundtrip: export to YAML → import → compare
+    auto all_captures = src_captures;
+    all_captures.insert(all_captures.end(), dst_captures.begin(), dst_captures.end());
+    verify_capture_roundtrip(all_captures);
+}
+
+}  // namespace tt::tt_fabric::fabric_router_tests

--- a/tests/tt_metal/tt_fabric/fabric_router/test_channel_trimming_capture.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_router/test_channel_trimming_capture.cpp
@@ -581,12 +581,12 @@ TEST_F(Fabric1DChannelTrimmingFixture, DiagnosticBufferMapRegionsNonOverlapping)
 }
 
 // ============================================================================
-// Tests using Fabric1DFixture (capture disabled — tests disabled path and
+// Tests using Fabric1DChannelTrimmingFixture (capture disabled — tests disabled path and
 // pure struct logic that don't need the runtime option set at setup time)
 // ============================================================================
 
 // Test: Runtime option getter/setter interface
-TEST_F(Fabric1DFixture, ChannelTrimmingCapture_RuntimeOptionGetterSetter) {
+TEST_F(Fabric1DChannelTrimmingFixture, ChannelTrimmingCapture_RuntimeOptionGetterSetter) {
     auto& rtoptions = tt::tt_metal::MetalContext::instance().rtoptions();
     bool original = rtoptions.get_enable_channel_trimming_capture();
 
@@ -599,7 +599,7 @@ TEST_F(Fabric1DFixture, ChannelTrimmingCapture_RuntimeOptionGetterSetter) {
 }
 
 // Test: DiagnosticBufferMap shows channel_trimming_capture disabled when not enabled at setup
-TEST_F(Fabric1DFixture, ChannelTrimmingCapture_DiagnosticBufferMapDisabled) {
+TEST_F(Fabric1DChannelTrimmingFixture, ChannelTrimmingCapture_DiagnosticBufferMapDisabled) {
     const auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
     const auto& builder_ctx = control_plane.get_fabric_context().get_builder_context();
     auto buffer_map = builder_ctx.get_telemetry_and_metadata_buffer_map();
@@ -610,11 +610,11 @@ TEST_F(Fabric1DFixture, ChannelTrimmingCapture_DiagnosticBufferMapDisabled) {
 }
 
 // Test: Config does NOT allocate L1 buffer when capture is disabled
-TEST_F(Fabric1DFixture, ChannelTrimmingCapture_ConfigNoAllocWhenDisabled) {
+TEST_F(Fabric1DChannelTrimmingFixture, ChannelTrimmingCapture_ConfigNoAllocWhenDisabled) {
     const auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
     const auto& config = control_plane.get_fabric_context().get_builder_context().get_fabric_router_config();
 
-    // Fabric1DFixture does not enable channel trimming capture, so the config should not allocate
+    // Fabric1DChannelTrimmingFixture does not enable channel trimming capture, so the config should not allocate
     EXPECT_EQ(config.datapath_usage_l1_address, 0u);
     EXPECT_EQ(config.datapath_usage_buffer_size, 0u);
 }

--- a/tests/tt_metal/tt_fabric/fabric_router/test_channel_trimming_capture.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_router/test_channel_trimming_capture.cpp
@@ -103,7 +103,7 @@ std::vector<EthCoreCaptureResult> read_capture_from_all_eth_cores(
             device->get_devices()[0], logical_core, capture_addr, capture_size, raw_data, CoreType::ETH);
 
         CaptureResults capture{};
-        std::memcpy(&capture, raw_data.data(), std::min(capture_size, raw_data.size() * sizeof(uint32_t)));
+        std::memcpy(static_cast<void*>(&capture), raw_data.data(), std::min(capture_size, raw_data.size() * sizeof(uint32_t)));
 
         results.push_back(EthCoreCaptureResult{physical_chip_id, logical_core, channel_id, capture});
     }

--- a/tests/tt_metal/tt_fabric/fabric_router/test_channel_trimming_capture.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_router/test_channel_trimming_capture.cpp
@@ -112,6 +112,49 @@ std::vector<EthCoreCaptureResult> read_capture_from_all_eth_cores(
 }
 
 // ============================================================================
+// Helper: Clear capture buffers on all active ETH cores for a device.
+// Writes a zeroed CaptureResults struct (with min_packet_size sentinel 0xFFFF)
+// to each core's L1 capture address, matching the device-side reset() behavior.
+// ============================================================================
+void clear_capture_on_device(BaseFabricFixture* fixture, ChipId physical_chip_id) {
+    const auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
+    const auto& builder_ctx = control_plane.get_fabric_context().get_builder_context();
+    auto buffer_map = builder_ctx.get_telemetry_and_metadata_buffer_map();
+    if (!buffer_map.channel_trimming_capture.is_enabled()) {
+        return;
+    }
+
+    size_t capture_addr = buffer_map.channel_trimming_capture.l1_address;
+    size_t capture_size = buffer_map.channel_trimming_capture.size_bytes;
+
+    // Build a reset capture struct matching device-side reset()
+    CaptureResults reset_data{};
+    reset_data.sender_channel_min_packet_size_seen_bytes_by_vc.fill(0xFFFF);
+
+    std::vector<uint32_t> raw(capture_size / sizeof(uint32_t), 0);
+    std::memcpy(raw.data(), &reset_data, std::min(capture_size, sizeof(reset_data)));
+
+    const auto logical_cores = control_plane.get_active_ethernet_cores(physical_chip_id);
+    const auto& device = fixture->get_device(physical_chip_id);
+    for (const auto& logical_core : logical_cores) {
+        tt_metal::detail::WriteToDeviceL1(
+            device->get_devices()[0], logical_core, capture_addr, raw, CoreType::ETH);
+    }
+}
+
+// ============================================================================
+// Helper: Clear capture buffers on ALL devices in the mesh.
+// ============================================================================
+void clear_all_capture_buffers(BaseFabricFixture* fixture) {
+    const auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
+    auto mesh_shape = control_plane.get_physical_mesh_shape(MeshId{0});
+    for (uint32_t i = 0; i < mesh_shape.mesh_size(); i++) {
+        ChipId phys = control_plane.get_physical_chip_id_from_fabric_node_id(FabricNodeId(MeshId{0}, i));
+        clear_capture_on_device(fixture, phys);
+    }
+}
+
+// ============================================================================
 // Helper: Run the real exporter, import the YAML back, and verify that
 // every capture read from L1 matches the imported data.
 // ============================================================================
@@ -326,53 +369,71 @@ struct MeshPathResult {
     bool found;
 };
 
-MeshPathResult find_mesh_path_with_hops(uint32_t num_hops) {
+MeshPathResult find_1d_path_with_hops(uint32_t num_hops) {
+    // Walk the 1D chain from chip 0 using get_forwarding_direction to determine
+    // the actual forward direction at each hop. In 1D mode, get_forwarding_link_indices
+    // returns links for ANY destination (all traffic goes "forward"), so we can't use
+    // it to distinguish neighbors. Instead, we ask for the forwarding direction towards
+    // an unvisited chip, then get the neighbor in that direction.
     const auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
     auto mesh_shape = control_plane.get_physical_mesh_shape(MeshId{0});
     uint32_t num_chips = mesh_shape.mesh_size();
 
-    // For each candidate source, try to find a destination `num_hops` away by following
-    // the routing path hop-by-hop. Each hop may use a different direction (e.g., on a 2x2
-    // mesh in 1D mode, the chain snakes E→S→W).
-    for (uint32_t src_id = 0; src_id < num_chips; src_id++) {
-        for (uint32_t dst_id = 0; dst_id < num_chips; dst_id++) {
-            if (src_id == dst_id) {
-                continue;
-            }
-            FabricNodeId src_node(MeshId{0}, src_id);
-            FabricNodeId dst_node(MeshId{0}, dst_id);
+    FabricNodeId current(MeshId{0}, 0);
+    std::vector<FabricNodeId> path = {current};
 
-            // Walk the forwarding path from src toward dst, hop by hop
-            std::vector<FabricNodeId> path;
-            path.push_back(src_node);
-            FabricNodeId current = src_node;
-            bool valid = true;
-
-            for (uint32_t hop = 0; hop < num_hops; hop++) {
-                auto fwd_dir = control_plane.get_forwarding_direction(current, dst_node);
-                if (!fwd_dir.has_value()) {
-                    valid = false;
-                    break;
-                }
-                auto neighbors = control_plane.get_intra_chip_neighbors(current, *fwd_dir);
-                if (neighbors.empty()) {
-                    valid = false;
-                    break;
-                }
-                current = FabricNodeId(MeshId{0}, neighbors[0]);
-                path.push_back(current);
-            }
-
-            if (valid && path.size() == num_hops + 1 && current == dst_node) {
-                // Use the first hop's direction as the overall direction for logging
-                auto first_dir = control_plane.get_forwarding_direction(src_node, dst_node);
-                return MeshPathResult{
-                    src_node, dst_node, path, first_dir.value_or(RoutingDirection::E), true};
+    for (uint32_t hop = 0; hop < num_hops; hop++) {
+        // Find the furthest unvisited chip to use as a forwarding target.
+        // Using the LAST unvisited chip avoids picking a direct neighbor, which would
+        // cause get_forwarding_direction to return the 2D shortest-path direction
+        // instead of the 1D chain forward direction.
+        FabricNodeId target(MeshId{0}, 0);
+        bool found_target = false;
+        for (int i = num_chips - 1; i >= 0; i--) {
+            bool visited = std::any_of(path.begin(), path.end(), [&](const FabricNodeId& n) {
+                return n.chip_id == static_cast<uint32_t>(i);
+            });
+            if (!visited) {
+                target = FabricNodeId(MeshId{0}, static_cast<uint32_t>(i));
+                found_target = true;
+                break;
             }
         }
+        if (!found_target) {
+            log_warning(tt::LogTest, "find_1d_path_with_hops: no unvisited chip at hop {}", hop);
+            return MeshPathResult{current, current, {}, RoutingDirection::E, false};
+        }
+
+        // Get the forward direction from current towards the target
+        auto fwd_dir = control_plane.get_forwarding_direction(current, target);
+        if (!fwd_dir.has_value()) {
+            log_warning(
+                tt::LogTest,
+                "find_1d_path_with_hops: no forwarding direction from chip_id={} to chip_id={} at hop {}",
+                current.chip_id,
+                target.chip_id,
+                hop);
+            return MeshPathResult{current, current, {}, RoutingDirection::E, false};
+        }
+
+        // Get the actual neighbor in the forward direction
+        auto neighbors = control_plane.get_intra_chip_neighbors(current, *fwd_dir);
+        if (neighbors.empty()) {
+            log_warning(
+                tt::LogTest,
+                "find_1d_path_with_hops: no neighbor in direction {} from chip_id={} at hop {}",
+                static_cast<int>(*fwd_dir),
+                current.chip_id,
+                hop);
+            return MeshPathResult{current, current, {}, RoutingDirection::E, false};
+        }
+
+        FabricNodeId next(current.mesh_id, neighbors[0]);
+        path.push_back(next);
+        current = next;
     }
 
-    return MeshPathResult{FabricNodeId(MeshId{0}, 0), FabricNodeId(MeshId{0}, 0), {}, RoutingDirection::E, false};
+    return MeshPathResult{path.front(), path.back(), path, RoutingDirection::E, true};
 }
 
 // ============================================================================
@@ -581,8 +642,10 @@ protected:
 
 // Test 1: 1-hop unicast — verify both source and destination routers recorded traffic
 TEST_F(Fabric1DChannelTrimmingFixture, UnicastSenderAndReceiverChannelUsed) {
+    clear_all_capture_buffers(this);
+
     // Use mesh coordinates to find a 1-hop neighbor pair (any direction on the chain)
-    auto path_result = find_mesh_path_with_hops(1);
+    auto path_result = find_1d_path_with_hops(1);
     if (!path_result.found) {
         GTEST_SKIP() << "No 1-hop neighbor pair found on the mesh";
     }
@@ -653,10 +716,10 @@ TEST_F(Fabric1DChannelTrimmingFixture, UnicastSenderAndReceiverChannelUsed) {
 
             EXPECT_EQ(cap.capture.sender_channel_forwarded_to_bitfield_by_vc[0], 0)
                 << "Destination router eth core (chan " << static_cast<int>(cap.channel_id)
-                << ") receiver channel 0 should record forwarding to sender channel 1 (bit 1)";
+                << ") VC0 should not show forwarding-to on 1-hop endpoint";
             EXPECT_EQ(cap.capture.sender_channel_forwarded_to_bitfield_by_vc[1], 0)
                 << "Destination router eth core (chan " << static_cast<int>(cap.channel_id)
-                << ") VC 1 should not show forwarding-to (no VC1 traffic in 1D)";
+                << ") VC1 should not show forwarding-to (no VC1 traffic in 1D)";
 
             found_receiver_forwarding = true;
         }
@@ -673,8 +736,10 @@ TEST_F(Fabric1DChannelTrimmingFixture, UnicastSenderAndReceiverChannelUsed) {
 
 // Test 2: 2-hop unicast — verify intermediate router forwarding
 TEST_F(Fabric1DChannelTrimmingFixture, UnicastMultiHopForwarding) {
+    clear_all_capture_buffers(this);
+
     // Use mesh coordinates to find a 2-hop path (scans all positions and directions)
-    auto path_result = find_mesh_path_with_hops(2);
+    auto path_result = find_1d_path_with_hops(2);
     if (!path_result.found) {
         GTEST_SKIP() << "No 2-hop path found on the mesh (need >=3 devices in some direction)";
     }
@@ -755,8 +820,8 @@ TEST_F(Fabric1DChannelTrimmingFixture, UnicastMultiHopForwarding) {
         sender_and_receiver_channels_active_on_different_routers = sender_and_receiver_channels_active_on_different_routers &&
             !((cap.capture.receiver_channel_data_forwarded_bitfield_by_vc != 0) && (cap.capture.sender_channel_used_bitfield_by_vc != 0));
     }
-    EXPECT_TRUE(num_routers_with_intermediate_sender_activity == 1) << "Expected to find exactly one router with sender activity on intermediate device";
-    EXPECT_TRUE(num_routers_with_intermediate_receiver_activity == 1) << "Expected to find exactly one router with receiver activity on intermediate device";
+    EXPECT_EQ(num_routers_with_intermediate_sender_activity, 1) << "Expected to find exactly one router with sender activity on intermediate device";
+    EXPECT_EQ(num_routers_with_intermediate_receiver_activity, 1) << "Expected to find exactly one router with receiver activity on intermediate device";
     EXPECT_TRUE(sender_and_receiver_channels_active_on_different_routers) << "Sender and receiver channels should be active on different routers";
 
     // --- Destination router validation ---
@@ -786,7 +851,7 @@ TEST_F(Fabric1DChannelTrimmingFixture, UnicastMultiHopForwarding) {
 
             EXPECT_EQ(cap.capture.sender_channel_forwarded_to_bitfield_by_vc[0], 0)
                 << "Destination router eth core (chan " << static_cast<int>(cap.channel_id)
-                << ") receiver channel 0 should record forwarding to sender channel 1 (bit 1)";
+                << ") VC0 should not show forwarding-to on 2-hop endpoint";
             EXPECT_EQ(cap.capture.sender_channel_forwarded_to_bitfield_by_vc[1], 0)
                 << "Destination router eth core (chan " << static_cast<int>(cap.channel_id)
                 << ") VC1 should not show forwarding-to (no VC1 traffic in 1D)";
@@ -803,12 +868,14 @@ TEST_F(Fabric1DChannelTrimmingFixture, UnicastMultiHopForwarding) {
 
 // Test 3: 1-hop unicast — verify min/max packet size tracking
 TEST_F(Fabric1DChannelTrimmingFixture, UnicastPacketSizeTracking) {
-    auto path_result = find_mesh_path_with_hops(1);
+    clear_all_capture_buffers(this);
+
+    auto path_result = find_1d_path_with_hops(1);
     if (!path_result.found) {
         GTEST_SKIP() << "No 1-hop neighbor pair found on the mesh";
     }
 
-    auto result = run_unicast_traffic_bw_nodes(this, path_result.src_node, path_result.dst_node, 1, /*num_packets=*/10);
+    auto result = run_unicast_traffic_bw_nodes(this, path_result.src_node, path_result.dst_node, 1);
     if (result.skipped) {
         GTEST_SKIP() << "No forwarding links between selected nodes";
     }
@@ -870,14 +937,13 @@ TEST_F(Fabric1DChannelTrimmingFixture, UnicastPacketSizeTracking) {
             EXPECT_TRUE(has_noc_send_type)
                 << "Destination router eth core (chan " << static_cast<int>(cap.channel_id)
                 << ") should show NocSendType activity (local delivery)";
-            // Endpoint — no sender transmission
+            // Endpoint — no sender transmission (receiver delivers locally, doesn't originate traffic)
             EXPECT_EQ(cap.capture.sender_channel_used_bitfield_by_vc, 0)
                 << "Destination router eth core (chan " << static_cast<int>(cap.channel_id)
                 << ") should not show sender channel activity (endpoint)";
-            // In 1D, the receiver channel always records its forwarding path to sender channel 1
             EXPECT_EQ(cap.capture.sender_channel_forwarded_to_bitfield_by_vc[0], 0)
                 << "Destination router eth core (chan " << static_cast<int>(cap.channel_id)
-                << ") receiver channel 0 should record forwarding to sender channel 1 (bit 1)";
+                << ") VC0 should not show forwarding-to on 1-hop endpoint";
             EXPECT_EQ(cap.capture.sender_channel_forwarded_to_bitfield_by_vc[1], 0)
                 << "Destination router eth core (chan " << static_cast<int>(cap.channel_id)
                 << ") VC1 should not show forwarding-to (no VC1 traffic in 1D)";
@@ -899,6 +965,8 @@ TEST_F(Fabric1DChannelTrimmingFixture, UnicastPacketSizeTracking) {
 
 // Test 4: Exercise each directional channel (E/W/N/S)
 TEST_F(Fabric2DChannelTrimmingFixture, DirectionalChannelLiveness) {
+    clear_all_capture_buffers(this);
+
     std::vector<RoutingDirection> directions = {
         RoutingDirection::E, RoutingDirection::W, RoutingDirection::N, RoutingDirection::S};
     std::vector<RoutingDirection> exercised_directions;
@@ -990,6 +1058,8 @@ TEST_F(Fabric2DChannelTrimmingFixture, DirectionalChannelLiveness) {
 
 // Test 5: Verify forwarding relationships in 2D (sender_channel_forwarded_to_bitfield)
 TEST_F(Fabric2DChannelTrimmingFixture, DirectionalChannelForwardedTo) {
+    clear_all_capture_buffers(this);
+
     const auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
     auto mesh_shape = control_plane.get_physical_mesh_shape(MeshId{0});
     uint32_t num_chips = mesh_shape.mesh_size();

--- a/tests/tt_metal/tt_fabric/fabric_router/test_channel_trimming_capture.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_router/test_channel_trimming_capture.cpp
@@ -475,24 +475,33 @@ bool find_pair_for_direction(
 class Fabric1DChannelTrimmingFixture : public BaseFabricFixture {
 protected:
     static void SetUpTestSuite() {
+        if (tt::get_arch_from_string(tt::test_utils::get_umd_arch_name()) != tt::ARCH::BLACKHOLE) {
+            should_skip_ = true;
+            return;
+        }
+        if (tt::tt_metal::GetNumAvailableDevices() < 4) {
+            should_skip_ = true;
+            return;
+        }
         tt::tt_metal::MetalContext::instance().rtoptions().set_enable_channel_trimming_capture(true);
         BaseFabricFixture::DoSetUpTestSuite(tt::tt_fabric::FabricConfig::FABRIC_1D);
     }
 
     static void TearDownTestSuite() {
-        BaseFabricFixture::DoTearDownTestSuite();
-        tt::tt_metal::MetalContext::instance().rtoptions().set_enable_channel_trimming_capture(false);
+        if (!should_skip_) {
+            BaseFabricFixture::DoTearDownTestSuite();
+            tt::tt_metal::MetalContext::instance().rtoptions().set_enable_channel_trimming_capture(false);
+        }
     }
 
     void SetUp() override {
-        if (arch_ != tt::ARCH::BLACKHOLE) {
-            GTEST_SKIP() << "Channel trimming tests require Blackhole architecture";
-        }
-        if (tt::tt_metal::GetNumAvailableDevices() < 4) {
-            GTEST_SKIP() << "Channel trimming tests require at least 4 devices";
+        if (should_skip_) {
+            GTEST_SKIP() << "Channel trimming tests require Blackhole architecture with at least 4 devices";
         }
         BaseFabricFixture::SetUp();
     }
+
+    inline static bool should_skip_ = false;
 };
 
 // ============================================================================
@@ -616,24 +625,33 @@ TEST_F(Fabric1DFixture, ChannelTrimmingCapture_ConfigNoAllocWhenDisabled) {
 class Fabric2DChannelTrimmingFixture : public BaseFabricFixture {
 protected:
     static void SetUpTestSuite() {
+        if (tt::get_arch_from_string(tt::test_utils::get_umd_arch_name()) != tt::ARCH::BLACKHOLE) {
+            should_skip_ = true;
+            return;
+        }
+        if (tt::tt_metal::GetNumAvailableDevices() < 4) {
+            should_skip_ = true;
+            return;
+        }
         tt::tt_metal::MetalContext::instance().rtoptions().set_enable_channel_trimming_capture(true);
         BaseFabricFixture::DoSetUpTestSuite(tt::tt_fabric::FabricConfig::FABRIC_2D);
     }
 
     static void TearDownTestSuite() {
-        BaseFabricFixture::DoTearDownTestSuite();
-        tt::tt_metal::MetalContext::instance().rtoptions().set_enable_channel_trimming_capture(false);
+        if (!should_skip_) {
+            BaseFabricFixture::DoTearDownTestSuite();
+            tt::tt_metal::MetalContext::instance().rtoptions().set_enable_channel_trimming_capture(false);
+        }
     }
 
     void SetUp() override {
-        if (arch_ != tt::ARCH::BLACKHOLE) {
-            GTEST_SKIP() << "Channel trimming tests require Blackhole architecture";
-        }
-        if (tt::tt_metal::GetNumAvailableDevices() < 4) {
-            GTEST_SKIP() << "Channel trimming tests require at least 4 devices";
+        if (should_skip_) {
+            GTEST_SKIP() << "Channel trimming tests require Blackhole architecture with at least 4 devices";
         }
         BaseFabricFixture::SetUp();
     }
+
+    inline static bool should_skip_ = false;
 };
 
 // ============================================================================

--- a/tests/tt_metal/tt_fabric/fabric_router/test_channel_trimming_capture.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_router/test_channel_trimming_capture.cpp
@@ -598,27 +598,6 @@ TEST_F(Fabric1DChannelTrimmingFixture, ChannelTrimmingCapture_RuntimeOptionGette
     rtoptions.set_enable_channel_trimming_capture(original);
 }
 
-// Test: DiagnosticBufferMap shows channel_trimming_capture disabled when not enabled at setup
-TEST_F(Fabric1DChannelTrimmingFixture, ChannelTrimmingCapture_DiagnosticBufferMapDisabled) {
-    const auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
-    const auto& builder_ctx = control_plane.get_fabric_context().get_builder_context();
-    auto buffer_map = builder_ctx.get_telemetry_and_metadata_buffer_map();
-
-    EXPECT_FALSE(buffer_map.channel_trimming_capture.is_enabled());
-    EXPECT_EQ(buffer_map.channel_trimming_capture.l1_address, 0u);
-    EXPECT_EQ(buffer_map.channel_trimming_capture.size_bytes, 0u);
-}
-
-// Test: Config does NOT allocate L1 buffer when capture is disabled
-TEST_F(Fabric1DChannelTrimmingFixture, ChannelTrimmingCapture_ConfigNoAllocWhenDisabled) {
-    const auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
-    const auto& config = control_plane.get_fabric_context().get_builder_context().get_fabric_router_config();
-
-    // Fabric1DChannelTrimmingFixture does not enable channel trimming capture, so the config should not allocate
-    EXPECT_EQ(config.datapath_usage_l1_address, 0u);
-    EXPECT_EQ(config.datapath_usage_buffer_size, 0u);
-}
-
 // ============================================================================
 // Fixture: Fabric2D with channel trimming capture enabled before fabric setup
 // ============================================================================

--- a/tests/tt_metal/tt_fabric/sources.cmake
+++ b/tests/tt_metal/tt_fabric/sources.cmake
@@ -23,6 +23,7 @@ set(UNIT_TESTS_FABRIC_SRC
     fabric_router/test_z_router_integration.cpp
     fabric_router/test_z_router_device_detection.cpp
     fabric_router/test_fabric_topology_helpers.cpp
+    fabric_router/test_channel_trimming_capture.cpp
     fabric_data_movement/test_basic_fabric_apis.cpp
     fabric_data_movement/test_basic_1d_fabric.cpp
     fabric_data_movement/test_basic_fabric_mux.cpp

--- a/tt_metal/fabric/CMakeLists.txt
+++ b/tt_metal/fabric/CMakeLists.txt
@@ -55,6 +55,8 @@ target_sources(
         builder/multi_pool_channel_allocator.cpp
         builder/connection_registry.cpp
         builder/router_connection_mapping.cpp
+        channel_trimming_export.cpp
+        channel_trimming_import.cpp
         fabric.cpp
         fabric_init.cpp
         fabric_host_utils.cpp

--- a/tt_metal/fabric/ccl/ccl_common.cpp
+++ b/tt_metal/fabric/ccl/ccl_common.cpp
@@ -26,15 +26,18 @@ tt::tt_metal::KernelHandle generate_edm_kernel_impl(
 
     std::vector<uint32_t> const edm_kernel_rt_args = edm_builder.get_runtime_args();
     // Ethernet Kernels
-    const std::vector<uint32_t> eth_sender_ct_args = edm_builder.get_compile_time_args((uint32_t)risc_id);
+    auto [eth_sender_ct_args, named_ct_args] = edm_builder.get_compile_time_args((uint32_t)risc_id);
     log_trace(tt::LogFabric, "EDM core (x={},y={}):", eth_core.x, eth_core.y);
     log_trace(tt::LogFabric, "CT ARGS:");
     for ([[maybe_unused]] const auto& s : eth_sender_ct_args) {
         log_trace(tt::LogFabric, "\t{}", s);
     }
 
-    auto kernel_config =
-        tt::tt_metal::EthernetConfig{.noc = noc_id, .processor = risc_id, .compile_args = eth_sender_ct_args};
+    auto kernel_config = tt::tt_metal::EthernetConfig{
+        .noc = noc_id,
+        .processor = risc_id,
+        .compile_args = eth_sender_ct_args,
+        .named_compile_args = named_ct_args};
     if (opt_level.has_value()) {
         kernel_config.opt_level = opt_level.value();
     }

--- a/tt_metal/fabric/channel_trimming_export.cpp
+++ b/tt_metal/fabric/channel_trimming_export.cpp
@@ -1,0 +1,281 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Exports per-router channel trimming capture data as YAML.
+//
+// Output schema:
+//
+//   channel_trimming_capture:
+//     chip_<id>:
+//       eth_channel_<id>:
+//         direction: <EAST|WEST|NORTH|SOUTH|Z>
+//         sender_channel_used_bitfield: 0x001F        # bit per sender channel, set if used
+//         sender_channels:                             # details for each used sender channel
+//           - id: 0
+//             min_packet_size_bytes: 128
+//             max_packet_size_bytes: 4096
+//             forwarded_from_receiver_vcs: [0, 1]      # VCs that forwarded to this sender
+//         sender_channel_forwarded_to_by_vc:           # per-VC bitfield of which sender channels received forwards
+//           - vc: 0
+//             bitfield: 0x001F
+//           - vc: 1
+//             bitfield: 0x0000
+//         receiver_channel_data_forwarded_bitfield: 0x0003  # bit per receiver channel, set if forwarded data
+//         noc_send_types_by_vc:                        # per-VC bitfield of NOC send types observed
+//           - vc: 0
+//             types: [NOC_UNICAST_WRITE, NOC_UNICAST_INLINE_WRITE]
+//           - vc: 1
+//             types: []
+
+#include "channel_trimming_export.hpp"
+
+#include <cstring>
+#include <filesystem>
+#include <fstream>
+#include <vector>
+
+#include <fmt/format.h>
+#include <tt-logger/tt-logger.hpp>
+#include <yaml-cpp/yaml.h>
+
+#include "tt_metal/api/tt-metalium/experimental/fabric/control_plane.hpp"
+#include "tt_metal/fabric/builder/fabric_builder_config.hpp"
+#include "tt_metal/fabric/fabric_builder_context.hpp"
+#include "tt_metal/fabric/fabric_context.hpp"
+#include "tt_metal/fabric/fabric_edm_packet_header.hpp"
+#include "tt_metal/fabric/hw/inc/edm_fabric/fabric_trimming_types.hpp"
+#include "tt_metal/impl/context/metal_context.hpp"
+#include "tt_metal/llrt/rtoptions.hpp"
+#include "tt_metal/llrt/tt_cluster.hpp"
+#include "hostdevcommon/fabric_common.h"
+
+#include "umd/device/types/core_coordinates.hpp"
+
+namespace tt::tt_fabric {
+
+namespace {
+
+using CaptureResults =
+    FabricDatapathUsageL1Results<true, builder_config::MAX_NUM_VCS, builder_config::num_max_sender_channels>;
+
+const char* noc_send_type_to_string(uint8_t type) {
+    switch (type) {
+        case NocSendType::NOC_UNICAST_WRITE: return "NOC_UNICAST_WRITE";
+        case NocSendType::NOC_UNICAST_INLINE_WRITE: return "NOC_UNICAST_INLINE_WRITE";
+        case NocSendType::NOC_UNICAST_ATOMIC_INC: return "NOC_UNICAST_ATOMIC_INC";
+        case NocSendType::NOC_FUSED_UNICAST_ATOMIC_INC: return "NOC_FUSED_UNICAST_ATOMIC_INC";
+        case NocSendType::NOC_UNICAST_SCATTER_WRITE: return "NOC_UNICAST_SCATTER_WRITE";
+        case NocSendType::NOC_MULTICAST_WRITE: return "NOC_MULTICAST_WRITE";
+        case NocSendType::NOC_MULTICAST_ATOMIC_INC: return "NOC_MULTICAST_ATOMIC_INC";
+        case NocSendType::NOC_UNICAST_READ: return "NOC_UNICAST_READ";
+        default: return "UNKNOWN";
+    }
+}
+
+const char* direction_to_string(eth_chan_directions dir) {
+    switch (dir) {
+        case eth_chan_directions::EAST: return "EAST";
+        case eth_chan_directions::WEST: return "WEST";
+        case eth_chan_directions::NORTH: return "NORTH";
+        case eth_chan_directions::SOUTH: return "SOUTH";
+        case eth_chan_directions::Z: return "Z";
+        default: return "UNKNOWN";
+    }
+}
+
+void emit_sender_channels(
+    YAML::Emitter& emitter,
+    const CaptureResults& capture) {
+    uint16_t used_bitfield = capture.sender_channel_used_bitfield_by_vc;
+    emitter << YAML::Key << "sender_channel_used_bitfield" << YAML::Value
+            << fmt::format("0x{:04X}", used_bitfield);
+
+    emitter << YAML::Key << "sender_channels" << YAML::Value << YAML::BeginSeq;
+    for (size_t ch = 0; ch < builder_config::num_max_sender_channels; ch++) {
+        if (!(used_bitfield & (1u << ch))) {
+            continue;
+        }
+        emitter << YAML::BeginMap;
+        emitter << YAML::Key << "id" << YAML::Value << ch;
+        emitter << YAML::Key << "min_packet_size_bytes" << YAML::Value
+                << capture.sender_channel_min_packet_size_seen_bytes_by_vc[ch];
+        emitter << YAML::Key << "max_packet_size_bytes" << YAML::Value
+                << capture.sender_channel_max_packet_size_seen_bytes_by_vc[ch];
+
+        // Collect VCs that forward to this sender channel
+        std::vector<size_t> forwarded_from_vcs;
+        for (size_t vc = 0; vc < builder_config::MAX_NUM_VCS; vc++) {
+            if (capture.sender_channel_forwarded_to_bitfield_by_vc[vc] & (1u << ch)) {
+                forwarded_from_vcs.push_back(vc);
+            }
+        }
+        emitter << YAML::Key << "forwarded_from_receiver_vcs" << YAML::Value;
+        emitter << YAML::Flow << YAML::BeginSeq;
+        for (auto vc : forwarded_from_vcs) {
+            emitter << vc;
+        }
+        emitter << YAML::EndSeq;
+
+        emitter << YAML::EndMap;
+    }
+    emitter << YAML::EndSeq;
+}
+
+void emit_sender_forwarded_to_bitfields(
+    YAML::Emitter& emitter,
+    const CaptureResults& capture) {
+    emitter << YAML::Key << "sender_channel_forwarded_to_by_vc" << YAML::Value << YAML::BeginSeq;
+    for (size_t vc = 0; vc < builder_config::MAX_NUM_VCS; vc++) {
+        emitter << YAML::BeginMap;
+        emitter << YAML::Key << "vc" << YAML::Value << vc;
+        emitter << YAML::Key << "bitfield" << YAML::Value
+                << fmt::format("0x{:04X}", capture.sender_channel_forwarded_to_bitfield_by_vc[vc]);
+        emitter << YAML::EndMap;
+    }
+    emitter << YAML::EndSeq;
+}
+
+void emit_receiver_channels(
+    YAML::Emitter& emitter,
+    const CaptureResults& capture) {
+    uint16_t fwd_bitfield = capture.receiver_channel_data_forwarded_bitfield_by_vc;
+    emitter << YAML::Key << "receiver_channel_data_forwarded_bitfield" << YAML::Value
+            << fmt::format("0x{:04X}", fwd_bitfield);
+}
+
+void emit_noc_send_types(
+    YAML::Emitter& emitter,
+    const CaptureResults& capture) {
+    emitter << YAML::Key << "noc_send_types_by_vc" << YAML::Value << YAML::BeginSeq;
+    for (size_t vc = 0; vc < builder_config::MAX_NUM_VCS; vc++) {
+        emitter << YAML::BeginMap;
+        emitter << YAML::Key << "vc" << YAML::Value << vc;
+
+        uint16_t type_bitfield = capture.used_noc_send_type_by_vc_bitfield[vc];
+        emitter << YAML::Key << "types" << YAML::Value;
+        emitter << YAML::Flow << YAML::BeginSeq;
+        for (uint8_t t = 0; t <= NocSendType::NOC_UNICAST_READ; t++) {
+            if (type_bitfield & (1u << t)) {
+                emitter << noc_send_type_to_string(t);
+            }
+        }
+        emitter << YAML::EndSeq;
+
+        emitter << YAML::EndMap;
+    }
+    emitter << YAML::EndSeq;
+}
+
+void emit_capture_channel_yaml(YAML::Emitter& emitter, const CaptureResults& capture, const char* direction) {
+    emitter << YAML::Key << "direction" << YAML::Value << direction;
+    emit_sender_channels(emitter, capture);
+    emit_sender_forwarded_to_bitfields(emitter, capture);
+    emit_receiver_channels(emitter, capture);
+    emit_noc_send_types(emitter, capture);
+}
+
+}  // namespace
+
+void export_channel_trimming_capture() {
+    auto& metal_ctx = tt::tt_metal::MetalContext::instance();
+    const auto& rtoptions = metal_ctx.rtoptions();
+
+    // Guard: capture must be enabled via runtime option
+    if (!rtoptions.get_enable_channel_trimming_capture()) {
+        return;
+    }
+
+    auto& cluster = metal_ctx.get_cluster();
+
+    // Guard: skip on Mock devices
+    if (cluster.get_target_device_type() == tt::TargetDevice::Mock) {
+        return;
+    }
+
+    auto& control_plane = metal_ctx.get_control_plane();
+
+    // Guard: capture buffer must be allocated
+    const auto& builder_ctx = control_plane.get_fabric_context().get_builder_context();
+    auto buffer_map = builder_ctx.get_telemetry_and_metadata_buffer_map();
+    if (!buffer_map.channel_trimming_capture.is_enabled()) {
+        return;
+    }
+
+    size_t capture_addr = buffer_map.channel_trimming_capture.l1_address;
+    size_t capture_size = buffer_map.channel_trimming_capture.size_bytes;
+
+    auto all_chips = cluster.all_chip_ids();
+
+    YAML::Emitter emitter;
+    emitter << YAML::BeginMap;
+    emitter << YAML::Key << "channel_trimming_capture" << YAML::Value << YAML::BeginMap;
+
+    auto& umd_cluster = const_cast<tt::umd::Cluster&>(*cluster.get_driver());
+
+    for (ChipId chip_id : all_chips) {
+        FabricNodeId fabric_node_id = control_plane.get_fabric_node_id_from_physical_chip_id(chip_id);
+
+        const auto logical_cores = control_plane.get_active_ethernet_cores(chip_id);
+        if (logical_cores.empty()) {
+            continue;
+        }
+
+        const auto& chan_map = cluster.get_soc_desc(chip_id).logical_eth_core_to_chan_map;
+
+        // Collect cores that have a valid channel mapping before emitting
+        std::vector<std::pair<CoreCoord, chan_id_t>> mapped_cores;
+        for (const auto& logical_core : logical_cores) {
+            auto chan_it = chan_map.find(logical_core);
+            if (chan_it != chan_map.end()) {
+                mapped_cores.emplace_back(logical_core, static_cast<chan_id_t>(chan_it->second));
+            }
+        }
+        if (mapped_cores.empty()) {
+            continue;
+        }
+
+        cluster.l1_barrier(chip_id);
+
+        emitter << YAML::Key << fmt::format("chip_{}", chip_id) << YAML::Value << YAML::BeginMap;
+
+        for (const auto& [logical_core, channel_id] : mapped_cores) {
+            eth_chan_directions direction = control_plane.get_eth_chan_direction(fabric_node_id, channel_id);
+
+            const auto& soc_desc = umd_cluster.get_soc_descriptor(chip_id);
+            tt::umd::CoreCoord eth_core = soc_desc.get_eth_core_for_channel(channel_id, tt::CoordSystem::LOGICAL);
+
+            std::vector<std::byte> buffer(capture_size);
+            umd_cluster.read_from_device(buffer.data(), chip_id, eth_core, capture_addr, capture_size);
+
+            CaptureResults capture{};
+            std::memcpy(&capture, buffer.data(), std::min(capture_size, sizeof(CaptureResults)));
+
+            emitter << YAML::Key << fmt::format("eth_channel_{}", channel_id) << YAML::Value << YAML::BeginMap;
+            emit_capture_channel_yaml(emitter, capture, direction_to_string(direction));
+            emitter << YAML::EndMap;
+        }
+
+        emitter << YAML::EndMap;
+    }
+
+    emitter << YAML::EndMap;
+    emitter << YAML::EndMap;
+
+    // Write to file
+    std::filesystem::path output_path =
+        std::filesystem::path(rtoptions.get_logs_dir()) / "generated" / "reports" / "channel_trimming_capture.yaml";
+    std::filesystem::create_directories(output_path.parent_path());
+
+    std::ofstream out_file(output_path);
+    if (!out_file.is_open()) {
+        log_warning(tt::LogFabric, "Failed to open output file for channel trimming capture: {}", output_path.string());
+        return;
+    }
+    out_file << emitter.c_str();
+    out_file.close();
+
+    log_info(tt::LogFabric, "Channel trimming capture data written to: {}", output_path.string());
+}
+
+}  // namespace tt::tt_fabric

--- a/tt_metal/fabric/channel_trimming_export.hpp
+++ b/tt_metal/fabric/channel_trimming_export.hpp
@@ -1,0 +1,13 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+namespace tt::tt_fabric {
+
+// Entry point: checks all guards internally (runtime option, Mock device, buffer enabled).
+// Safe to call unconditionally — returns immediately if capture is not active.
+void export_channel_trimming_capture();
+
+}  // namespace tt::tt_fabric

--- a/tt_metal/fabric/channel_trimming_import.cpp
+++ b/tt_metal/fabric/channel_trimming_import.cpp
@@ -1,0 +1,215 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "channel_trimming_import.hpp"
+
+#include <limits>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include <tt-logger/tt-logger.hpp>
+#include <tt_stl/assert.hpp>
+#include <yaml-cpp/yaml.h>
+
+#include "tt_metal/fabric/fabric_edm_packet_header.hpp"  // NocSendType
+
+namespace tt::tt_fabric {
+
+namespace {
+
+// Parse "chip_N" → N
+ChipId parse_chip_key(const std::string& key) {
+    constexpr auto prefix = std::string_view("chip_");
+    TT_FATAL(
+        key.size() > prefix.size() && key.substr(0, prefix.size()) == prefix,
+        "Invalid chip key in trimming profile: '{}'",
+        key);
+    return static_cast<ChipId>(std::stoi(key.substr(prefix.size())));
+}
+
+// Parse "eth_channel_N" → N
+chan_id_t parse_eth_channel_key(const std::string& key) {
+    constexpr auto prefix = std::string_view("eth_channel_");
+    TT_FATAL(
+        key.size() > prefix.size() && key.substr(0, prefix.size()) == prefix,
+        "Invalid eth channel key in trimming profile: '{}'",
+        key);
+    return static_cast<chan_id_t>(std::stoi(key.substr(prefix.size())));
+}
+
+// Parse hex string like "0x001F" → uint16_t
+uint16_t parse_hex_bitfield(const std::string& str) {
+    return static_cast<uint16_t>(std::stoul(str, nullptr, 16));
+}
+
+// Map NocSendType string name back to its enum value.
+// Returns -1 if the string is not recognized.
+int parse_noc_send_type(const std::string& name) {
+    if (name == "NOC_UNICAST_WRITE") {
+        return NocSendType::NOC_UNICAST_WRITE;
+    }
+    if (name == "NOC_UNICAST_INLINE_WRITE") {
+        return NocSendType::NOC_UNICAST_INLINE_WRITE;
+    }
+    if (name == "NOC_UNICAST_ATOMIC_INC") {
+        return NocSendType::NOC_UNICAST_ATOMIC_INC;
+    }
+    if (name == "NOC_FUSED_UNICAST_ATOMIC_INC") {
+        return NocSendType::NOC_FUSED_UNICAST_ATOMIC_INC;
+    }
+    if (name == "NOC_UNICAST_SCATTER_WRITE") {
+        return NocSendType::NOC_UNICAST_SCATTER_WRITE;
+    }
+    if (name == "NOC_MULTICAST_WRITE") {
+        return NocSendType::NOC_MULTICAST_WRITE;
+    }
+    if (name == "NOC_MULTICAST_ATOMIC_INC") {
+        return NocSendType::NOC_MULTICAST_ATOMIC_INC;
+    }
+    if (name == "NOC_UNICAST_READ") {
+        return NocSendType::NOC_UNICAST_READ;
+    }
+    return -1;
+}
+
+// Import sender_channels sequence into the entry's per-channel arrays and forwarded-to bitfields.
+void import_sender_channels(const YAML::Node& chan_data, ChannelTrimmingOverrides& entry) {
+    if (!chan_data["sender_channels"]) {
+        return;
+    }
+    for (const auto& sc : chan_data["sender_channels"]) {
+        size_t ch = sc["id"].as<size_t>();
+        if (ch >= entry.sender_channel_min_packet_size_seen_bytes_by_vc.size()) {
+            continue;
+        }
+        if (sc["min_packet_size_bytes"]) {
+            entry.sender_channel_min_packet_size_seen_bytes_by_vc[ch] = sc["min_packet_size_bytes"].as<uint16_t>();
+        }
+        if (sc["max_packet_size_bytes"]) {
+            entry.sender_channel_max_packet_size_seen_bytes_by_vc[ch] = sc["max_packet_size_bytes"].as<uint16_t>();
+        }
+        if (sc["forwarded_from_receiver_vcs"]) {
+            for (const auto& vc_node : sc["forwarded_from_receiver_vcs"]) {
+                size_t vc = vc_node.as<size_t>();
+                if (vc < entry.sender_channel_forwarded_to_bitfield_by_vc.size()) {
+                    entry.sender_channel_forwarded_to_bitfield_by_vc[vc] |= (1u << ch);
+                }
+            }
+        }
+    }
+}
+
+// Import sender_channel_forwarded_to_by_vc sequence into per-vc forwarding bitfields.
+void import_sender_forwarded_to_bitfields(const YAML::Node& chan_data, ChannelTrimmingOverrides& entry) {
+    if (!chan_data["sender_channel_forwarded_to_by_vc"]) {
+        return;
+    }
+    for (const auto& vc_entry : chan_data["sender_channel_forwarded_to_by_vc"]) {
+        size_t vc = vc_entry["vc"].as<size_t>();
+        if (vc >= entry.sender_channel_forwarded_to_bitfield_by_vc.size()) {
+            continue;
+        }
+        if (vc_entry["bitfield"]) {
+            entry.sender_channel_forwarded_to_bitfield_by_vc[vc] =
+                parse_hex_bitfield(vc_entry["bitfield"].as<std::string>());
+        }
+    }
+}
+
+// Import noc_send_types_by_vc sequence into the entry's per-vc noc send type bitfields.
+void import_noc_send_types(const YAML::Node& chan_data, ChannelTrimmingOverrides& entry) {
+    if (!chan_data["noc_send_types_by_vc"]) {
+        return;
+    }
+    for (const auto& vc_entry : chan_data["noc_send_types_by_vc"]) {
+        size_t vc = vc_entry["vc"].as<size_t>();
+        if (vc >= entry.used_noc_send_type_by_vc_bitfield.size()) {
+            continue;
+        }
+        if (vc_entry["types"]) {
+            for (const auto& type_node : vc_entry["types"]) {
+                int type_val = parse_noc_send_type(type_node.as<std::string>());
+                if (type_val >= 0) {
+                    entry.used_noc_send_type_by_vc_bitfield[vc] |= (1u << type_val);
+                }
+            }
+        }
+    }
+}
+
+// Collect all scalar keys from a YAML map node into a vector.
+// Must be done before any operator[] lookups on the map's children, because
+// yaml-cpp's operator[] mutates the underlying node (inserting null entries)
+// which corrupts in-progress iteration.
+std::vector<std::string> collect_map_keys(const YAML::Node& map_node) {
+    std::vector<std::string> keys;
+    for (auto it = map_node.begin(); it != map_node.end(); ++it) {
+        if (it->first.IsScalar()) {
+            keys.push_back(it->first.as<std::string>());
+        }
+    }
+    return keys;
+}
+
+}  // namespace
+
+ChannelTrimmingOverrideMap load_channel_trimming_overrides(const std::string& yaml_path) {
+    log_info(tt::LogFabric, "Loading channel trimming profile from: {}", yaml_path);
+
+    YAML::Node root = YAML::LoadFile(yaml_path);
+    TT_FATAL(
+        root["channel_trimming_capture"],
+        "Trimming profile YAML missing 'channel_trimming_capture' root key: {}",
+        yaml_path);
+
+    ChannelTrimmingOverrideMap overrides;
+    const auto& capture = root["channel_trimming_capture"];
+
+    auto chip_keys = collect_map_keys(capture);
+    for (const auto& chip_key : chip_keys) {
+        ChipId chip_id = parse_chip_key(chip_key);
+        const auto& channels = capture[chip_key];
+
+        auto chan_keys = collect_map_keys(channels);
+        for (const auto& chan_key : chan_keys) {
+            chan_id_t eth_chan = parse_eth_channel_key(chan_key);
+            const auto& chan_data = channels[chan_key];
+
+            ChannelTrimmingOverrides entry;
+            // Match device-side initialization: min packet size starts at max sentinel
+            entry.sender_channel_min_packet_size_seen_bytes_by_vc.fill(std::numeric_limits<uint16_t>::max());
+
+            if (chan_data["sender_channel_used_bitfield"]) {
+                entry.sender_channel_used_bitfield_by_vc =
+                    parse_hex_bitfield(chan_data["sender_channel_used_bitfield"].as<std::string>());
+            }
+
+            if (chan_data["receiver_channel_data_forwarded_bitfield"]) {
+                entry.receiver_channel_data_forwarded_bitfield_by_vc =
+                    parse_hex_bitfield(chan_data["receiver_channel_data_forwarded_bitfield"].as<std::string>());
+            }
+
+            import_sender_channels(chan_data, entry);
+            import_sender_forwarded_to_bitfields(chan_data, entry);
+            import_noc_send_types(chan_data, entry);
+
+            uint64_t key = make_override_key(chip_id, eth_chan);
+            overrides[key] = entry;
+
+            log_debug(
+                tt::LogFabric,
+                "  chip={} eth_chan={}: sender_used=0x{:04X} rx_fwd=0x{:04X}",
+                chip_id,
+                eth_chan,
+                entry.sender_channel_used_bitfield_by_vc,
+                entry.receiver_channel_data_forwarded_bitfield_by_vc);
+        }
+    }
+
+    log_info(tt::LogFabric, "Loaded {} channel trimming overrides from profile", overrides.size());
+    return overrides;
+}
+
+}  // namespace tt::tt_fabric

--- a/tt_metal/fabric/channel_trimming_import.hpp
+++ b/tt_metal/fabric/channel_trimming_import.hpp
@@ -1,0 +1,33 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include <unordered_map>
+
+#include <umd/device/types/cluster_descriptor_types.hpp>  // ChipId
+#include <hostdevcommon/fabric_common.h>                   // chan_id_t
+
+#include "tt_metal/fabric/builder/fabric_builder_config.hpp"
+#include "tt_metal/fabric/hw/inc/edm_fabric/fabric_trimming_types.hpp"
+
+namespace tt::tt_fabric {
+
+// Reuse the capture data structure for import overrides so export and import are consistent.
+using ChannelTrimmingOverrides =
+    FabricDatapathUsageL1Results<true, builder_config::MAX_NUM_VCS, builder_config::num_max_sender_channels>;
+
+// Key: pack(chip_id, eth_channel_id) → overrides
+using ChannelTrimmingOverrideMap = std::unordered_map<uint64_t, ChannelTrimmingOverrides>;
+
+inline uint64_t make_override_key(ChipId chip_id, chan_id_t eth_chan) {
+    return (static_cast<uint64_t>(static_cast<uint32_t>(chip_id)) << 32) | eth_chan;
+}
+
+// Parse a previously exported channel trimming capture YAML and return per-router overrides.
+ChannelTrimmingOverrideMap load_channel_trimming_overrides(const std::string& yaml_path);
+
+}  // namespace tt::tt_fabric

--- a/tt_metal/fabric/fabric_builder_context.hpp
+++ b/tt_metal/fabric/fabric_builder_context.hpp
@@ -9,6 +9,7 @@
 #include <umd/device/types/cluster_descriptor_types.hpp>  // ChipId
 #include "erisc_datamover_builder.hpp"
 #include "tt_metal/fabric/fabric_tensix_builder.hpp"
+#include "tt_metal/fabric/channel_trimming_import.hpp"
 #include <vector>
 #include <memory>
 #include <array>
@@ -154,6 +155,19 @@ public:
     std::optional<std::pair<uint32_t, EDMStatus>> get_fabric_router_ready_address_and_signal() const;
     std::pair<uint32_t, uint32_t> get_fabric_router_termination_address_and_signal() const;
 
+    // ============ Diagnostic Buffer Map ============
+    /** Returns the diagnostic buffer locations for all routers.
+     *  The layout is identical across all router cores in the fabric. */
+    FabricRouterDiagnosticBufferMap get_telemetry_and_metadata_buffer_map() const {
+        TT_FATAL(router_config_ != nullptr, "Error, fabric router config is uninitialized");
+        return router_config_->get_telemetry_and_metadata_buffer_map();
+    }
+
+    // ============ Channel Trimming Overrides ============
+    const std::optional<ChannelTrimmingOverrideMap>& get_channel_trimming_overrides() const {
+        return channel_trimming_overrides_;
+    }
+
     // ============ Intermesh VC Configuration ============
     const IntermeshVCConfig& get_intermesh_vc_config() const { return intermesh_vc_config_; }
     bool requires_intermesh_vc() const { return intermesh_vc_config_.requires_vc1; }
@@ -167,6 +181,9 @@ private:
     friend class FabricContext;
 
     const FabricContext& fabric_context_;
+
+    // Channel trimming overrides loaded from profile YAML (if specified)
+    std::optional<ChannelTrimmingOverrideMap> channel_trimming_overrides_;
 
     IntermeshVCConfig intermesh_vc_config_;
 

--- a/tt_metal/fabric/hw/inc/edm_fabric/fabric_edm_packet_transmission.hpp
+++ b/tt_metal/fabric/hw/inc/edm_fabric/fabric_edm_packet_transmission.hpp
@@ -139,6 +139,7 @@ FORCE_INLINE
     constexpr bool update_counter = false;
 
     tt::tt_fabric::NocSendType noc_send_type = header.noc_send_type;
+    channel_trimming_usage_recorder.set_noc_send_type_used(rx_channel_id, noc_send_type);
     if (noc_send_type > tt::tt_fabric::NocSendType::NOC_SEND_TYPE_LAST) {
         __builtin_unreachable();
     }

--- a/tt_metal/fabric/hw/inc/edm_fabric/fabric_erisc_router_ct_args.hpp
+++ b/tt_metal/fabric/hw/inc/edm_fabric/fabric_erisc_router_ct_args.hpp
@@ -9,6 +9,7 @@
 
 #include "tt_metal/fabric/hw/inc/edm_fabric/compile_time_arg_tmp.hpp"
 #include "tt_metal/fabric/hw/inc/edm_fabric/fabric_router_elastic_channels_ct_args.hpp"
+#include "tt_metal/fabric/hw/inc/edm_fabric/fabric_trimming.hpp"
 #include "tt_metal/fabric/hw/inc/edm_fabric/telemetry/fabric_bandwidth_telemetry.hpp"
 #include "tt_metal/fabric/hw/inc/edm_fabric/telemetry/fabric_code_profiling.hpp"
 #include "tt_metal/fabric/hw/inc/edm_fabric/fabric_static_channels_ct_args.hpp"
@@ -690,3 +691,26 @@ constexpr std::array<size_t, NUM_RECEIVER_CHANNELS> REMOTE_RECEIVER_NUM_BUFFERS_
     NUM_RECEIVER_CHANNELS>();
 
 }  // namespace tt::tt_fabric
+
+//-------------------------------- Channel Trimming --------------------------------//
+// channel trimming is a feature that allows the router to trim channels that are not used.
+// this is useful for reducing the amount of compute needed by the router.
+
+// RX channel forwarding disable flags (from imported trimming profile)
+constexpr bool disable_rx_ch0_forwarding = get_named_compile_time_arg_val("DISABLE_RX_CH0_FORWARDING") != 0;
+constexpr bool disable_rx_ch1_forwarding = get_named_compile_time_arg_val("DISABLE_RX_CH1_FORWARDING") != 0;
+constexpr std::array<bool, MAX_NUM_RECEIVER_CHANNELS> is_receiver_channel_forwarding_disabled = {
+    disable_rx_ch0_forwarding,
+    disable_rx_ch1_forwarding
+};
+
+
+constexpr bool ENABLE_CHANNEL_TRIMMING_RESOURCE_USAGE_CAPTURE = get_named_compile_time_arg_val("ENABLE_CHANNEL_TRIMMING_RESOURCE_USAGE_CAPTURE");
+constexpr size_t RESOURCE_USAGE_CAPTURE_OUTPUT_L1_ADDRESS = ENABLE_CHANNEL_TRIMMING_RESOURCE_USAGE_CAPTURE ? get_named_compile_time_arg_val("RESOURCE_USAGE_CAPTURE_OUTPUT_L1_ADDRESS") : 0;
+
+using ChannelTrimmingUsagePtr = tt::tt_fabric::FabricDatapathUsageL1Ptr<
+    ENABLE_CHANNEL_TRIMMING_RESOURCE_USAGE_CAPTURE,
+    RESOURCE_USAGE_CAPTURE_OUTPUT_L1_ADDRESS,
+    MAX_NUM_RECEIVER_CHANNELS,
+    MAX_NUM_SENDER_CHANNELS>;
+constexpr ChannelTrimmingUsagePtr channel_trimming_usage_recorder{};

--- a/tt_metal/fabric/hw/inc/edm_fabric/fabric_trimming.hpp
+++ b/tt_metal/fabric/hw/inc/edm_fabric/fabric_trimming.hpp
@@ -1,0 +1,83 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+// Device-only header: FabricDatapathUsageL1Ptr wraps an L1 pointer to
+// FabricDatapathUsageL1Results and provides the recording API.
+// The core data structure is defined in fabric_trimming_types.hpp (host+device).
+
+#include "tt_metal/fabric/hw/inc/edm_fabric/fabric_trimming_types.hpp"
+#include "tt_metal/fabric/fabric_edm_packet_header.hpp"  // for NocSendType
+
+#include "internal/risc_attribs.h"
+
+#include <limits>
+
+namespace tt::tt_fabric {
+
+// ============================================================================
+// FabricDatapathUsageL1Ptr — compile-time L1 pointer wrapper
+// ============================================================================
+
+// Primary template — enabled implementation
+template <bool ENABLED, size_t L1_ADDR, size_t NUM_VC = 2, size_t MAX_NUM_SENDER_CHANNELS = 9>
+struct FabricDatapathUsageL1Ptr {
+    using ResultsType = FabricDatapathUsageL1Results<true, NUM_VC, MAX_NUM_SENDER_CHANNELS>;
+    FORCE_INLINE ResultsType* get() const { return reinterpret_cast<ResultsType*>(L1_ADDR); }
+
+    FORCE_INLINE void reset() const {
+        auto* r = get();
+        r->sender_channel_min_packet_size_seen_bytes_by_vc.fill(std::numeric_limits<uint16_t>::max());
+        r->sender_channel_max_packet_size_seen_bytes_by_vc.fill(0);
+        r->sender_channel_used_bitfield_by_vc = 0;
+        r->sender_channel_forwarded_to_bitfield_by_vc.fill(0);
+        r->receiver_channel_data_forwarded_bitfield_by_vc = 0;
+        r->used_noc_send_type_by_vc_bitfield.fill(0);
+    }
+
+    FORCE_INLINE void set_sender_channel_used(size_t sender_channel_id) const {
+        get()->sender_channel_used_bitfield_by_vc |= (1 << sender_channel_id);
+    }
+
+    FORCE_INLINE void set_receiver_channel_data_forwarded(size_t receiver_channel_id) const {
+        get()->receiver_channel_data_forwarded_bitfield_by_vc |= (1 << receiver_channel_id);
+    }
+
+    FORCE_INLINE void update_sender_channel_packet_size(size_t sender_channel_id, uint16_t packet_size_bytes) const {
+        auto* r = get();
+        if (packet_size_bytes < r->sender_channel_min_packet_size_seen_bytes_by_vc[sender_channel_id]) {
+            r->sender_channel_min_packet_size_seen_bytes_by_vc[sender_channel_id] = packet_size_bytes;
+        }
+        if (packet_size_bytes > r->sender_channel_max_packet_size_seen_bytes_by_vc[sender_channel_id]) {
+            r->sender_channel_max_packet_size_seen_bytes_by_vc[sender_channel_id] = packet_size_bytes;
+        }
+    }
+
+    FORCE_INLINE void set_sender_channel_forwarded_to(size_t vc_id, size_t sender_channel_id) const {
+        get()->sender_channel_forwarded_to_bitfield_by_vc[vc_id] |= (1 << sender_channel_id);
+    }
+
+    FORCE_INLINE void merge_sender_channel_forwarded_to(size_t vc_id, uint16_t mask) const {
+        get()->sender_channel_forwarded_to_bitfield_by_vc[vc_id] |= mask;
+    }
+
+    FORCE_INLINE void set_noc_send_type_used(size_t vc_id, NocSendType noc_send_type) const {
+        get()->used_noc_send_type_by_vc_bitfield[vc_id] |= (1 << static_cast<uint8_t>(noc_send_type));
+    }
+};
+
+// Disabled specialization — all no-ops
+template <size_t L1_ADDR, size_t NUM_VC, size_t MAX_NUM_SENDER_CHANNELS>
+struct FabricDatapathUsageL1Ptr<false, L1_ADDR, NUM_VC, MAX_NUM_SENDER_CHANNELS> {
+    FORCE_INLINE void reset() const {}
+    FORCE_INLINE void set_sender_channel_used(size_t) const {}
+    FORCE_INLINE void set_receiver_channel_data_forwarded(size_t) const {}
+    FORCE_INLINE void update_sender_channel_packet_size(size_t, uint16_t) const {}
+    FORCE_INLINE void set_sender_channel_forwarded_to(size_t, size_t) const {}
+    FORCE_INLINE void merge_sender_channel_forwarded_to(size_t, uint16_t) const {}
+    FORCE_INLINE void set_noc_send_type_used(size_t, NocSendType) const {}
+};
+
+}  // namespace tt::tt_fabric

--- a/tt_metal/fabric/hw/inc/edm_fabric/fabric_trimming_types.hpp
+++ b/tt_metal/fabric/hw/inc/edm_fabric/fabric_trimming_types.hpp
@@ -1,0 +1,64 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+// Host+device compatible header: data layout and query accessors for datapath usage capture.
+// No device-specific includes.
+// Mutation helpers (set/update) are free functions in fabric_trimming.hpp (device-only).
+
+#include <array>
+#include <cstdint>
+#include <cstddef>
+
+namespace tt::tt_fabric {
+
+// Primary template - enabled implementation (full data storage)
+template <bool ENABLED, size_t NUM_VC = 2, size_t MAX_NUM_SENDER_CHANNELS = 9>
+struct FabricDatapathUsageL1Results {
+    using SenderChannelUsedBitfield = uint16_t;
+    using ReceiverChannelDataForwardedBitfield = uint16_t;
+    using NocSendTypeBitfield = uint16_t;
+
+    // Record the max and min packet size seen by each sender channel
+    std::array<uint16_t, MAX_NUM_SENDER_CHANNELS> sender_channel_min_packet_size_seen_bytes_by_vc = {};
+    std::array<uint16_t, MAX_NUM_SENDER_CHANNELS> sender_channel_max_packet_size_seen_bytes_by_vc = {};
+
+    // A bit is set high if the sender channel with ID matching that bit (offset) processed any traffic
+    SenderChannelUsedBitfield sender_channel_used_bitfield_by_vc = {};
+
+    // A bit is set high if the sender channel on this VC is forwarded to the receiver channel with ID matching
+    // that bit (offset). Used only for validation after readback.
+    std::array<SenderChannelUsedBitfield, NUM_VC> sender_channel_forwarded_to_bitfield_by_vc = {};
+
+    // A bit is set high if the receiver channel with ID matching that bit (offset) has forwarded any traffic
+    ReceiverChannelDataForwardedBitfield receiver_channel_data_forwarded_bitfield_by_vc = {};
+
+    // A bit is set high if the receiver channel on this VC forwards a noc message of that type
+    std::array<NocSendTypeBitfield, NUM_VC> used_noc_send_type_by_vc_bitfield = {};
+
+    // Query accessors
+    bool is_sender_channel_used(size_t sender_channel_id) const {
+        return (sender_channel_used_bitfield_by_vc & (1u << sender_channel_id)) != 0;
+    }
+    bool is_receiver_channel_data_forwarded(size_t receiver_channel_id) const {
+        return (receiver_channel_data_forwarded_bitfield_by_vc & (1u << receiver_channel_id)) != 0;
+    }
+
+    bool operator==(const FabricDatapathUsageL1Results& other) const {
+        return sender_channel_min_packet_size_seen_bytes_by_vc == other.sender_channel_min_packet_size_seen_bytes_by_vc &&
+               sender_channel_max_packet_size_seen_bytes_by_vc == other.sender_channel_max_packet_size_seen_bytes_by_vc &&
+               sender_channel_used_bitfield_by_vc == other.sender_channel_used_bitfield_by_vc &&
+               sender_channel_forwarded_to_bitfield_by_vc == other.sender_channel_forwarded_to_bitfield_by_vc &&
+               receiver_channel_data_forwarded_bitfield_by_vc == other.receiver_channel_data_forwarded_bitfield_by_vc &&
+               used_noc_send_type_by_vc_bitfield == other.used_noc_send_type_by_vc_bitfield;
+    }
+    bool operator!=(const FabricDatapathUsageL1Results& other) const { return !(*this == other); }
+};
+
+// Specialization for disabled implementation - zero overhead, no storage
+template <size_t NUM_VC, size_t MAX_NUM_SENDER_CHANNELS>
+struct FabricDatapathUsageL1Results<false, NUM_VC, MAX_NUM_SENDER_CHANNELS> {};
+
+}  // namespace tt::tt_fabric

--- a/tt_metal/fabric/impl/kernels/edm_fabric/fabric_erisc_router.cpp
+++ b/tt_metal/fabric/impl/kernels/edm_fabric/fabric_erisc_router.cpp
@@ -855,6 +855,7 @@ FORCE_INLINE void receiver_forward_packet(
         if (not_last_destination_device) {
             forward_payload_to_downstream_edm<enable_deadlock_avoidance, ENABLE_STATEFUL_NOC_APIS>(
                 packet_start, payload_size_bytes, cached_routing_fields, downstream_edm_interface, transaction_id);
+            channel_trimming_usage_recorder.set_sender_channel_forwarded_to(rx_channel_id, 1);
         }
         if (start_distance_is_terminal_value) {
             execute_chip_unicast_to_local_chip(packet_start, payload_size_bytes, transaction_id, rx_channel_id);

--- a/tt_metal/fabric/impl/kernels/edm_fabric/fabric_erisc_router.cpp
+++ b/tt_metal/fabric/impl/kernels/edm_fabric/fabric_erisc_router.cpp
@@ -488,6 +488,23 @@ FORCE_INLINE constexpr size_t map_downstream_direction_to_compact_index(eth_chan
     return direction_to_compact_index_map[my_direction][downstream_direction];
 }
 
+// Convert a hop_cmd direction bitmask into a sender channel bitmask using dense channel packing.
+// Each direction bit maps to a compact_index via map_downstream_direction_to_compact_index,
+// and the corresponding sender channel is compact_index + 1 (channel 0 is always worker).
+// my_direction is masked out since it represents a local write, not a forwarding channel.
+FORCE_INLINE uint16_t hop_cmd_to_sender_channel_mask(uint32_t hop_cmd) {
+    uint32_t fwd_directions = hop_cmd & ~(1u << my_direction);
+    uint16_t fwd_mask = 0;
+    constexpr size_t num_directions = z_router_enabled ? eth_chan_directions::COUNT : eth_chan_directions::COUNT - 1;
+    for (uint32_t dir = 0; dir < num_directions && fwd_directions; dir++) {
+        if (fwd_directions & (1u << dir)) {
+            size_t compact_idx = map_downstream_direction_to_compact_index(static_cast<eth_chan_directions>(dir));
+            fwd_mask |= static_cast<uint16_t>(1u << (compact_idx + 1));
+        }
+    }
+    return fwd_mask;
+}
+
 static constexpr std::array<bool, MAX_NUM_SENDER_CHANNELS_VC0> sender_channels_turn_status =
     get_sender_channel_turn_statuses();
 
@@ -574,6 +591,11 @@ FORCE_INLINE void send_next_data(
 
     volatile auto* pkt_header = reinterpret_cast<volatile PACKET_HEADER_TYPE*>(src_addr);
     size_t const payload_size_bytes = pkt_header->get_payload_size_including_header();
+
+    channel_trimming_usage_recorder.set_sender_channel_used(sender_channel_index);
+    channel_trimming_usage_recorder.update_sender_channel_packet_size(
+        sender_channel_index,
+        static_cast<uint16_t>(pkt_header->payload_size_bytes));
 
     auto const dest_addr = outbound_to_receiver_channel_pointers.remote_receiver_channel_address_ptr;
 
@@ -847,11 +869,18 @@ FORCE_INLINE void receiver_forward_packet(
             case LowLatencyFields::FORWARD_ONLY:
                 forward_payload_to_downstream_edm<enable_deadlock_avoidance, ENABLE_STATEFUL_NOC_APIS>(
                     packet_start, payload_size_bytes, cached_routing_fields, downstream_edm_interface, transaction_id);
+
+                // In 1D, the forwarding sender channel is always sender channel 1
+                // (channel 0 is worker, channel 1 receives forwarded traffic from upstream)
+                channel_trimming_usage_recorder.set_sender_channel_forwarded_to(rx_channel_id, 1);
                 break;
             case LowLatencyFields::WRITE_AND_FORWARD:
                 forward_payload_to_downstream_edm<enable_deadlock_avoidance, ENABLE_STATEFUL_NOC_APIS>(
                     packet_start, payload_size_bytes, cached_routing_fields, downstream_edm_interface, transaction_id);
                 execute_chip_unicast_to_local_chip(packet_start, payload_size_bytes, transaction_id, rx_channel_id);
+                // In 1D, the forwarding sender channel is always sender channel 1
+                // (channel 0 is worker, channel 1 receives forwarded traffic from upstream)
+                channel_trimming_usage_recorder.set_sender_channel_forwarded_to(rx_channel_id, 1);
                 break;
             default: {
                 ASSERT(false);
@@ -1336,6 +1365,9 @@ FORCE_INLINE
             break;
         default: __builtin_unreachable();
     }
+
+    channel_trimming_usage_recorder.merge_sender_channel_forwarded_to(
+        rx_channel_id, hop_cmd_to_sender_channel_mask(hop_cmd));
 }
 #endif
 
@@ -1734,6 +1766,43 @@ FORCE_INLINE
 
 template <
     uint8_t receiver_channel,
+    bool forwarding_disabled,
+    size_t DOWNSTREAM_EDM_SIZE,
+    typename WriteTridTracker,
+    typename DownstreamSenderT,
+    typename LocalRelayInterfaceT>
+FORCE_INLINE void receiver_channel_forward_if_enabled(
+    WriteTridTracker& receiver_channel_trid_tracker,
+    tt::tt_fabric::BufferIndex receiver_buffer_index,
+    tt_l1_ptr PACKET_HEADER_TYPE* packet_header,
+    ROUTING_FIELDS_TYPE cached_routing_fields,
+    std::array<DownstreamSenderT, DOWNSTREAM_EDM_SIZE>& downstream_edm_interfaces,
+    LocalRelayInterfaceT& local_relay_interface,
+    uint32_t hop_cmd) {
+    if constexpr (!forwarding_disabled) {
+        uint8_t trid = receiver_channel_trid_tracker.update_buffer_slot_to_next_trid_and_advance_trid_counter(
+            receiver_buffer_index);
+        if constexpr (is_2d_fabric) {
+#if defined(FABRIC_2D)
+            receiver_forward_packet<receiver_channel, DOWNSTREAM_EDM_SIZE>(
+                packet_header,
+                cached_routing_fields,
+                downstream_edm_interfaces,
+                local_relay_interface,
+                trid,
+                hop_cmd);
+#endif
+        } else {
+#ifndef FABRIC_2D
+            receiver_forward_packet<receiver_channel>(
+                packet_header, cached_routing_fields, downstream_edm_interfaces[0], trid);
+#endif
+        }
+    }
+}
+
+template <
+    uint8_t receiver_channel,
     uint8_t to_receiver_pkts_sent_id,
     bool enable_first_level_ack,
     size_t DOWNSTREAM_EDM_SIZE,
@@ -1852,24 +1921,18 @@ FORCE_INLINE bool run_receiver_channel_step_impl(
             if constexpr (FABRIC_TELEMETRY_BANDWIDTH) {
                 update_bw_counters(packet_header, local_fabric_telemetry);
             }
-            uint8_t trid = receiver_channel_trid_tracker.update_buffer_slot_to_next_trid_and_advance_trid_counter(
-                receiver_buffer_index);
-            if constexpr (is_2d_fabric) {
-#if defined(FABRIC_2D)
-                receiver_forward_packet<receiver_channel, DOWNSTREAM_EDM_SIZE>(
-                    packet_header,
-                    cached_routing_fields,
-                    downstream_edm_interfaces,
-                    local_relay_interface,
-                    trid,
-                    hop_cmd);
-#endif
-            } else {
-#ifndef FABRIC_2D
-                receiver_forward_packet<receiver_channel>(
-                    packet_header, cached_routing_fields, downstream_edm_interfaces[0], trid);
-#endif
-            }
+            channel_trimming_usage_recorder.set_receiver_channel_data_forwarded(receiver_channel);
+            receiver_channel_forward_if_enabled<
+                receiver_channel,
+                is_receiver_channel_forwarding_disabled[receiver_channel],
+                DOWNSTREAM_EDM_SIZE>(
+                receiver_channel_trid_tracker,
+                receiver_buffer_index,
+                packet_header,
+                cached_routing_fields,
+                downstream_edm_interfaces,
+                local_relay_interface,
+                hop_cmd);
             wr_sent_counter.increment();
             // decrement the to_receiver_pkts_sent_id stream register by 1 since current packet has been processed.
             if constexpr (!enable_first_level_ack) {
@@ -2710,6 +2773,10 @@ void initialize_fabric_telemetry() {
 }
 
 void kernel_main() {
+    if constexpr (ENABLE_CHANNEL_TRIMMING_RESOURCE_USAGE_CAPTURE) {
+        channel_trimming_usage_recorder.reset();
+    }
+
 #if !defined(FABRIC_2D_VC1_ACTIVE)
     POSTCODE(tt::tt_fabric::EDMStatus::INITIALIZATION_STARTED);
 #endif

--- a/tt_metal/impl/context/metal_context.cpp
+++ b/tt_metal/impl/context/metal_context.cpp
@@ -19,6 +19,7 @@
 #include "firmware_capability.hpp"
 #include "hal.hpp"
 #include "hal_types.hpp"
+#include "fabric/channel_trimming_export.hpp"
 #include "fabric/fabric_host_utils.hpp"
 #include "allocator/allocator.hpp"
 #include "allocator/l1_banking_allocator.hpp"
@@ -833,6 +834,14 @@ void MetalContext::set_fabric_config(
     // Changes to fabric force a re-init. TODO: We should supply the fabric config in the same way as the dispatch
     // config, not through this function exposed in the detail API.
     force_reinit_ = true;
+
+    // Export channel trimming capture data before fabric config changes.
+    // Must happen while fabric_config_ is still active and fabric context is alive.
+    bool is_tearing_down_fabric = fabric_config == tt_fabric::FabricConfig::DISABLED &&
+        this->fabric_config_ != tt_fabric::FabricConfig::DISABLED;
+    if (is_tearing_down_fabric) {
+        tt::tt_fabric::export_channel_trimming_capture();
+    }
 
     if (this->fabric_config_ == tt_fabric::FabricConfig::DISABLED ||
         fabric_config == tt_fabric::FabricConfig::DISABLED) {

--- a/tt_metal/llrt/rtoptions.cpp
+++ b/tt_metal/llrt/rtoptions.cpp
@@ -87,6 +87,8 @@ enum class EnvVarID {
     TT_METAL_FABRIC_BW_TELEMETRY,           // Enable fabric bandwidth telemetry
     TT_METAL_FABRIC_TELEMETRY,              // Enable fabric telemetry
     TT_FABRIC_PROFILE_RX_CH_FWD,            // Enable fabric RX channel forwarding profiling
+    TT_METAL_ENABLE_CHANNEL_TRIMMING_CAPTURE, // Enable channel trimming resource usage capture
+    TT_METAL_FABRIC_TRIMMING_PROFILE,         // Path to channel trimming profile YAML for import
     TT_METAL_FORCE_REINIT,                  // Force context reinitialization
     TT_METAL_DISABLE_FABRIC_TWO_ERISC,      // Disable fabric 2-ERISC mode
     TT_METAL_LOG_KERNELS_COMPILE_COMMANDS,  // Log kernel compilation commands
@@ -548,6 +550,21 @@ void RunTimeOptions::HandleEnvVar(EnvVarID id, const char* value) {
         // Default: false
         // Usage: export TT_FABRIC_PROFILE_RX_CH_FWD=1
         case EnvVarID::TT_FABRIC_PROFILE_RX_CH_FWD: this->fabric_profiling_settings.enable_rx_ch_fwd = true; break;
+
+        // TT_METAL_ENABLE_CHANNEL_TRIMMING_CAPTURE
+        // Enables channel trimming resource usage capture on fabric routers.
+        // Default: false
+        // Usage: export TT_METAL_ENABLE_CHANNEL_TRIMMING_CAPTURE=1
+        case EnvVarID::TT_METAL_ENABLE_CHANNEL_TRIMMING_CAPTURE: this->enable_channel_trimming_capture = true; break;
+
+        // TT_METAL_FABRIC_TRIMMING_PROFILE
+        // Path to a previously captured channel trimming YAML file. When set, fabric router
+        // construction uses the captured profile to disable unused sender/receiver channels.
+        // Default: empty (no profile import)
+        // Usage: export TT_METAL_FABRIC_TRIMMING_PROFILE=/path/to/channel_trimming_capture.yaml
+        case EnvVarID::TT_METAL_FABRIC_TRIMMING_PROFILE:
+            this->fabric_trimming_profile_path = std::string(value);
+            break;
 
         // RELIABILITY_MODE
         // Sets the fabric reliability mode (STRICT, RELAXED, or DYNAMIC).

--- a/tt_metal/llrt/rtoptions.hpp
+++ b/tt_metal/llrt/rtoptions.hpp
@@ -269,6 +269,12 @@ class RunTimeOptions {
     // Enable fabric performance telemetry
     bool enable_fabric_bw_telemetry = false;
 
+    // Enable channel trimming resource usage capture
+    bool enable_channel_trimming_capture = false;
+
+    // Path to channel trimming profile YAML for import-driven router construction
+    std::string fabric_trimming_profile_path;
+
     // Enable fabric telemetry
     bool enable_fabric_telemetry = false;
     FabricTelemetrySettings fabric_telemetry_settings;
@@ -645,6 +651,14 @@ public:
     void set_enable_fabric_code_profiling_rx_ch_fwd(bool enable) {
         fabric_profiling_settings.enable_rx_ch_fwd = enable;
     }
+
+    // If true, enables channel trimming resource usage capture on fabric routers
+    bool get_enable_channel_trimming_capture() const { return enable_channel_trimming_capture; }
+    void set_enable_channel_trimming_capture(bool enable) { enable_channel_trimming_capture = enable; }
+
+    // Channel trimming profile import path
+    bool has_fabric_trimming_profile() const { return !fabric_trimming_profile_path.empty(); }
+    const std::string& get_fabric_trimming_profile_path() const { return fabric_trimming_profile_path; }
 
     // Reliability mode override accessor
     std::optional<tt::tt_fabric::FabricReliabilityMode> get_reliability_mode() const { return reliability_mode; }


### PR DESCRIPTION
Adding initial capture support for the fabric channel trimming feature. This includes. export and import support for fabric router resource usage. This information is used to on subsequent runs to launch a cut down or streamline fabric router, on a per router basis. 

For example, if you are running a workload with a 2-D fabric and and channel trimming capture is enabled, and the workload happens to only use neighbour exchange patterns than the router could disable/not instantiate all non-worker centre channels, as well as compile away the receiver packet forward logic

# How it works
There are two phases to this features analogous to how the trace feature works; although mechanically the implementation and delivery mechanisms are quite different. There is a capture phase and a replay/import phase. 

Export (capture on-device data to YAML): `TT_METAL_ENABLE_CHANNEL_TRIMMING_CAPTURE=1`

Import (load YAML to drive router construction): `TT_METAL_FABRIC_TRIMMING_PROFILE=/path/to/channel_trimming_capture.yaml `

Note that the above two options are mutually exclusive.

## Capture Phase
Each fabric router is instrumented with a FabricDatapathUsageL1Results struct in ETH core L1. During operation, the router records which sender/receiver channels were active, packet size ranges, forwarding bitfields, and NOC send types per VC. On fabric teardown (close_devices()), if capture is enabled, the host reads back all L1 structs and serializes them as a human-readable YAML report.

Output path: `{logs_dir}/generated/reports/channel_trimming_capture.yaml`.

##  Import Phase
When TT_METAL_FABRIC_TRIMMING_PROFILE is set, the YAML is parsed during FabricBuilderContext construction (before any routers are built). For each router being constructed, the builder looks up overrides by (chip_id, eth_channel) and applies them:

- Sender channels: unused channels have is_sender_channel_serviced set to false — the router skips them entirely (constexpr dead-code elimination)
- Receiver channels: unused channels have is_receiver_channel_serviced set to false, plus per-channel named compile args (DISABLE_RX_CH0_FORWARDING, DISABLE_RX_CH1_FORWARDING) compile away the packet forwarding logic

# Testing                                                                                                                                                                                                                
- New unit tests in test_channel_trimming_capture.cpp covering export serialization, YAML import/parsing, and override application to router builders
- Existing fabric tests pass unchanged (both features are off by default — guarded by env vars)
- Manual validation: run any fabric workload with capture enabled, then re-run with the generated YAML as the trimming profile

# YAML Schema

```
channel_trimming_capture:                                                                                                                                                                                                                                      
  chip_<id>:                                                                                                                                                                                                                                                   
    eth_channel_<id>:                                                                                                                                                                                                                                          
      direction: <EAST|WEST|NORTH|SOUTH|Z>                                                                                                                                                                                                                     
      sender_channel_used_bitfield: 0x001F        # bit per sender channel, set if used                                                                                                                                                                        
      sender_channels:                             # details for each used sender channel                                                                                                                                                                      
        - id: 0                                                                                                                                                                                                                                                
          min_packet_size_bytes: 128                                                                                                                                                                                                                           
          max_packet_size_bytes: 4096                                                                                                                                                                                                                          
          forwarded_from_receiver_vcs: [0, 1]      # VCs that forwarded to this sender                                                                                                                                                                         
      sender_channel_forwarded_to_by_vc:           # per-VC bitfield of which sender channels received forwards                                                                                                                                                
        - vc: 0                                                                                                                                                                                                                                                
          bitfield: 0x001F                                                                                                                                                                                                                                     
        - vc: 1                                                                                                                                                                                                                                                
          bitfield: 0x0000                                                                                                                                                                                                                                     
      receiver_channel_data_forwarded_bitfield: 0x0003  # bit per receiver channel, set if forwarded data                                                                                                                                                      
      noc_send_types_by_vc:                        # per-VC bitfield of NOC send types observed                                                                                                                                                                
        - vc: 0                                                                                                                                                                                                                                                
          types: [NOC_UNICAST_WRITE, NOC_UNICAST_INLINE_WRITE]                                                                                                                                                                                                 
        - vc: 1                                                                                                                                                                                                                                                
          types: []   
```

### Ticket
https://github.com/tenstorrent/tt-metal/issues/38027

### Checklist

- [x] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=snijjar/fabric-channel-trimming-profile-extraction)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:snijjar/fabric-channel-trimming-profile-extraction): same failures reproducible on main
- [x] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=snijjar/fabric-channel-trimming-profile-extraction)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:snijjar/fabric-channel-trimming-profile-extraction): Same failure on main: https://github.com/tenstorrent/tt-metal/actions/runs/22212164557/job/64249018243

- [x] BH Nightly: https://github.com/tenstorrent/tt-metal/actions/runs/22226900326 - same failure as above
- [x] Fabric Test Suite: https://github.com/tenstorrent/tt-metal/actions/runs/22210232461
  - only failures were deleted tests, didn't want to rerun and waste resources
