### PR TITLE
Fix tools test: update watcher assert string to match uppercase BRISC

### DIFF
--- a/tests/scripts/run_tools_tests.sh
+++ b/tests/scripts/run_tools_tests.sh
@@ -16,7 +16,7 @@ if [[ -z "$TT_METAL_SLOW_DISPATCH_MODE" ]] ; then
     ./build/tools/watcher_dump -d=0 -w &> tmp.log || { echo "Above failure is expected."; }
 
     # Verify the error we expect showed up in the program output.
-    grep "brisc tripped an assert" tmp.log > /dev/null || { echo "Error: couldn't find expected string in command output:" ; cat tmp.log; exit 1; }
+    grep "BRISC tripped an assert" tmp.log > /dev/null || { echo "Error: couldn't find expected string in command output:" ; cat tmp.log; exit 1; }
     echo "Watcher dump all data test - Pass"
 
     # Check that stack dumping is working

--- a/tests/scripts/run_tools_tests.sh
+++ b/tests/scripts/run_tools_tests.sh
@@ -22,7 +22,7 @@ if [[ -z "$TT_METAL_SLOW_DISPATCH_MODE" ]] ; then
     # Check that stack dumping is working
     ./build/test/tt_metal/unit_tests_debug_tools --gtest_filter=*TestWatcherRingBufferBrisc
     ./build/tools/watcher_dump -d=0 -w
-    grep "brisc highest stack usage:" generated/watcher/watcher.log > /dev/null || { echo "Error: couldn't find stack usage in watcher log after dump." ; exit 1; }
+    grep "BRISC highest stack usage:" generated/watcher/watcher.log > /dev/null || { echo "Error: couldn't find stack usage in watcher log after dump." ; exit 1; }
     echo "Watcher stack usage test - Pass"
 
     # Remove created files.


### PR DESCRIPTION
### Ticket
N/A

### Problem description
The `cpp-unit-tests (wormhole_b0, N150) / tools wormhole_b0 N150` job on Nightly tt-metal L2 tests is failing. The watcher dump output now uses uppercase `BRISC` (e.g. `BRISC tripped an assert`) but the test script was still grepping for the old lowercase `brisc tripped an assert`, causing the assertion check to fail.

### What's changed
Updated the expected grep string in `tests/scripts/run_tools_tests.sh` from `"brisc tripped an assert"` to `"BRISC tripped an assert"` to match the current watcher dump output format.

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=jbauman/fixtoolstest)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:jbauman/fixtoolstest)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=jbauman/fixtoolstest)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:jbauman/fixtoolstest)
- [x] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=jbauman/fixtoolstest)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jbauman/fixtoolstest)
- [x] New/Existing tests provide coverage for changes
