### PR TITLE
Fix TensixTestL1ToPCIeAt16BAlignedAddress race condition

### DIFF
--- a/tests/tt_metal/tt_metal/device/test_device.cpp
+++ b/tests/tt_metal/tt_metal/device/test_device.cpp
@@ -324,7 +324,7 @@ TEST_F(MeshDeviceFixture, TensixTestL1ToPCIeAt16BAlignedAddress) {
             .noc = NOC::RISCV_0_default,
             .compile_args = {base_l1_src_address, base_pcie_dst_address, num_16b_writes}});
 
-    distributed::EnqueueMeshWorkload(cq, workload, false);
+    distributed::EnqueueMeshWorkload(cq, workload, true);
 
     std::vector<uint32_t> result(size_bytes / sizeof(uint32_t));
     ChipId mmio_device_id =


### PR DESCRIPTION
### Ticket
N/A

### Problem description
`MeshDeviceFixture.TensixTestL1ToPCIeAt16BAlignedAddress` started failing on CI after #37705 ("H<->D Ops for Blitz + Changes to support Async Slow Dispatch").

That PR changed `SDMeshCommandQueue::enqueue_mesh_workload` so that `blocking=false` actually becomes non-blocking. Previously the `blocking` parameter was ignored and `WaitProgramDone` was always called.

The test passes `blocking=false` to `EnqueueMeshWorkload`, then immediately reads PCIe sysmem directly via the cluster API (bypassing the command queue). Since the read doesn't go through the mesh command queue, the lazy `wait_for_cores_idle()` never fires, and the kernel's NOC writes to PCIe may not have completed — a race condition causing data miscompares.

### What's changed
Pass `blocking=true` to `EnqueueMeshWorkload` in `TensixTestL1ToPCIeAt16BAlignedAddress`, since the test needs the program to complete before reading back data via `read_sysmem`.

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=jbauman/fixpcietest)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:jbauman/fixpcietest)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=jbauman/fixpcietest)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:jbauman/fixpcietest)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=jbauman/fixpcietest)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jbauman/fixpcietest)
- [x] New/Existing tests provide coverage for changes
