### PR TITLE
Fix CB wrapping blocking writer test hang (wrong TRISC core)

### DIFF
--- a/tests/tt_metal/tt_metal/test_kernels/misc/circular_buffer/cb_wrapping_test_blocking_writer.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/misc/circular_buffer/cb_wrapping_test_blocking_writer.cpp
@@ -111,7 +111,7 @@ void core_agnostic_main() {
 
 void kernel_main() {
 #ifdef COMPILE_FOR_TRISC
-#ifdef TRISC_UNPACK
+#ifdef TRISC_PACK
     core_agnostic_main();
 #endif
 #else


### PR DESCRIPTION
### Ticket
Fixes hang in `MeshDeviceFixture.TensixTestCircularBufferWrappingBlockingToWriter` introduced by #37147.

### Problem description
Commit 9639e5ad781 ("Use up-to-date main() declaration in all kernels & docs", #37147) migrated the CB wrapping blocking writer test kernel from the old `namespace NAMESPACE { void MAIN { ... } }` pattern to `void kernel_main() { ... }`, but incorrectly changed the TRISC guard from `TRISC_PACK` to `TRISC_UNPACK`.

The writer kernel calls `cb_reserve_back`/`cb_push_back` which are gated by the `PACK()` macro — they only execute on `TRISC_PACK`. On `TRISC_UNPACK` these are no-ops, so the writer pushes nothing into the circular buffer and the reader hangs forever in `cb_wait_front`.

### What's changed
Changed the guard in `cb_wrapping_test_blocking_writer.cpp` `kernel_main()` from `TRISC_UNPACK` back to `TRISC_PACK` so that the CB write operations actually execute.

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=jbauman/fixwrappingblockingtest)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:jbauman/fixwrappingblockingtest)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=jbauman/fixwrappingblockingtest)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:jbauman/fixwrappingblockingtest)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=jbauman/fixwrappingblockingtest)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jbauman/fixwrappingblockingtest)
- [x] New/Existing tests provide coverage for changes
