### PR TITLE
Fix forward_prefill calls in Galaxy MLP prefill tests

### DIFF
--- a/models/demos/llama3_70b_galaxy/tests/unit_tests/test_llama_mlp_prefill.py
+++ b/models/demos/llama3_70b_galaxy/tests/unit_tests/test_llama_mlp_prefill.py
@@ -95,7 +95,7 @@ def test_llama_mlp_inference(seq_len, batch_size, mesh_device, reset_seeds, ensu
             layout=ttnn.TILE_LAYOUT,
         )
         logger.info("Run Llama_MLP")
-        tt_output = tt_model.forward_prefill(tt_input, mode)
+        tt_output = tt_model.forward_prefill(tt_input, batch_size)
 
         tt_output_torch = ttnn.to_torch(
             tt_output,

--- a/models/demos/llama3_70b_galaxy/tests/unit_tests/test_qwen_mlp_prefill.py
+++ b/models/demos/llama3_70b_galaxy/tests/unit_tests/test_qwen_mlp_prefill.py
@@ -108,7 +108,7 @@ def test_qwen_mlp_inference_prefill(seq_len, batch_size, mesh_device, reset_seed
             layout=ttnn.TILE_LAYOUT,
         )
         logger.info("Run Qwen_MLP")
-        tt_output = tt_model.forward_prefill(tt_input, mode)
+        tt_output = tt_model.forward_prefill(tt_input, batch_size)
 
         tt_output_torch = ttnn.to_torch(
             tt_output,


### PR DESCRIPTION
## Summary
- `test_llama_mlp_prefill.py` and `test_qwen_mlp_prefill.py` were calling `forward_prefill(tt_input, mode)` where `mode` is a string like `"prefill"`, but the function signature expects `batch_size` (int) as the second argument.
- This caused `TypeError: '>' not supported between instances of 'str' and 'int'` at the `batch_size > 1` comparison in `llama_mlp.py`.
- Fixed by passing `batch_size` instead of `mode`.

## Test plan
- [ ] Run `test_llama_mlp_prefill.py` on Galaxy to verify no TypeError (https://github.com/tenstorrent/tt-metal/actions/runs/22152149508/job/64047093407)

🤖 Generated with [Claude Code](https://claude.com/claude-code)