### PR TITLE
#36378: Disable L1 accumulation in DRAM-sharded matmul when FP32 dest is active

### DIFF
--- a/models/tt_transformers/tests/test_attention.py
+++ b/models/tt_transformers/tests/test_attention.py
@@ -70,7 +70,7 @@ def test_attention_inference(
 ):
     mode = Mode.DECODE
     dtype = ttnn.bfloat8_b
-    pcc = 0.986  # pcc reduced from .99 while investigating issue #36378
+    pcc = 0.99
     llama90b_hf_rope_pcc = 0.97
     num_tensors = 2
     prefetcher = Prefetcher(mesh_device, num_tensors=num_tensors, num_layers=1) if use_prefetcher else None

--- a/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_mcast_dram_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_mcast_dram_sharded_program_factory.cpp
@@ -179,8 +179,11 @@ create_program_dram_sharded(
 
     uint32_t num_blocks = K / in0_block_w;
     // Only enable packer l1 accumulation when there are spills, otherwise
-    // unnecessary overhead for reconfigs are added
-    bool packer_l1_acc_en = packer_l1_acc && num_blocks > 1;
+    // unnecessary overhead for reconfigs are added.
+    // L1 accumulation is disabled when fp32_dest_acc_en is true due to a known
+    // packer pipeline limitation where format conversion order conflicts with
+    // accumulation when FP32 dest registers are active (see issue #28800).
+    bool packer_l1_acc_en = packer_l1_acc && num_blocks > 1 && !fp32_dest_acc_en;
 
     // if fp32 enabled then we pack fp32 in l1, if not, then we pack fp16 in l1
     tt::DataFormat interm0_data_format = packer_l1_acc_en


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/36378

### Problem description
PR #36177 removed a stale override that forced `interm0_data_format` to `Float16_b` in the DRAM-sharded matmul program factory (`matmul_multicore_reuse_mcast_dram_sharded_program_factory.cpp`). With the override removed, the intermediate circular buffer correctly uses `Float32` when `fp32_dest_acc_en` is set. However, this exposed a known hardware limitation (#28800) where L1 packer accumulation conflicts with FP32 destination registers — the packer pipeline's format conversion ordering is incompatible with accumulation when FP32 dest registers are active.

This caused PCC to drop from ~0.999 to ~0.986 in the Llama-3.2-90B attention decode test on T3K, falling below the 0.99 threshold. The test threshold was temporarily lowered to 0.986 as a workaround.

### What's changed
- **`matmul_multicore_reuse_mcast_dram_sharded_program_factory.cpp`**: Added `&& !fp32_dest_acc_en` guard to the `packer_l1_acc_en` flag. When FP32 destination accumulation is enabled, L1 packer accumulation is now disabled to avoid the known pipeline conflict. This is consistent with the pattern already used in other matmul program factories (e.g., `matmul_multicore_reuse_mcast_1d_program_factory.cpp`).
- **`test_attention.py`**: Restored the PCC threshold from the temporary 0.986 back to 0.99, since the fix recovers PCC to ~0.999.

**Verification**: All 15 tests in the t3k Llama-3.2-90B unit test suite pass (attention, decoder, MLP, LM head, RMS norm, embedding) with zero regressions.

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=gchoudhary/36378-disable-L1-accumulation-due-to-known-hardware-limitation)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:gchoudhary/36378-disable-L1-accumulation-due-to-known-hardware-limitation)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=gchoudhary/36378-disable-L1-accumulation-due-to-known-hardware-limitation)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:gchoudhary/36378-disable-L1-accumulation-due-to-known-hardware-limitation)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=gchoudhary/36378-disable-L1-accumulation-due-to-known-hardware-limitation)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:gchoudhary/36378-disable-L1-accumulation-due-to-known-hardware-limitation)
- [x] New/Existing tests provide coverage for changes

#### Model tests

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=gchoudhary/36378-disable-L1-accumulation-due-to-known-hardware-limitation)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:gchoudhary/36378-disable-L1-accumulation-due-to-known-hardware-limitation)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)

Made with [Cursor](https://cursor.com)