### PR TITLE
refresh ethernet microbenchmarks

### DIFF
--- a/tests/tt_metal/microbenchmarks/conftest.py
+++ b/tests/tt_metal/microbenchmarks/conftest.py
@@ -8,3 +8,9 @@ def pytest_addoption(parser):
     parser.addoption("--num-iterations", action="store", type=int, help="Number of iterations to run each test config")
     parser.addoption("--num-packets", action="store", type=int, help="Number of packets to send during each iteration")
     parser.addoption("--packet-size", action="store", type=int, help="Packet size in bytes")
+    parser.addoption(
+        "--extended",
+        action="store_true",
+        default=False,
+        help="Run extended/exhaustive sweep tests (skipped by default)",
+    )

--- a/tests/tt_metal/microbenchmarks/ethernet/conftest.py
+++ b/tests/tt_metal/microbenchmarks/ethernet/conftest.py
@@ -18,3 +18,12 @@ def pytest_addoption(parser):
 def pytest_configure(config):
     config.addinivalue_line("markers", "ubench_quick_tests: quick tests for fast iteration")
     config.addinivalue_line("markers", "sanity_6u: quick subset of 6u applicable tests")
+    config.addinivalue_line("markers", "extended: extended/exhaustive sweep tests (require --extended flag)")
+
+
+def pytest_collection_modifyitems(config, items):
+    if not config.getoption("--extended"):
+        skip_extended = pytest.mark.skip(reason="extended sweep test — pass --extended to run")
+        for item in items:
+            if "extended" in item.keywords:
+                item.add_marker(skip_extended)

--- a/tests/tt_metal/microbenchmarks/ethernet/test_all_ethernet_links_bandwidth.py
+++ b/tests/tt_metal/microbenchmarks/ethernet/test_all_ethernet_links_bandwidth.py
@@ -2,16 +2,18 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import atexit
 import os
+import shutil
+from collections import defaultdict
 
 from loguru import logger
-import pytest
 from tests.tt_metal.microbenchmarks.ethernet.test_all_ethernet_links_common import (
     process_profile_results,
     write_results_to_csv,
 )
 
-from models.common.utility_functions import is_single_chip
+# from models.common.utility_functions import is_single_chip
 
 from tracy.common import PROFILER_LOGS_DIR, PROFILER_DEVICE_SIDE_LOG
 
@@ -22,85 +24,136 @@ FILE_NAME = PROFILER_LOGS_DIR / "test_all_ethernet_links_bandwidth.csv"
 if os.path.exists(FILE_NAME):
     os.remove(FILE_NAME)
 
+# Accumulate BW results per test function for summary tables
+# Key: test_name -> {(packet_size, channel_count): avg_bw}
+_bw_summary = defaultdict(dict)
+_atexit_registered = False
 
-def run_erisc_write_worker_bw(
+
+def _print_summary_tables():
+    for test_name in sorted(_bw_summary.keys()):
+        results = _bw_summary[test_name]
+        if not results:
+            continue
+        packet_sizes = sorted(set(ps for ps, _ in results.keys()))
+        channel_counts = sorted(set(cc for _, cc in results.keys()))
+
+        col_w = 10
+        header = f"{'pkt_size':>{col_w}}" + "".join(f"{cc:>{col_w}}" for cc in channel_counts)
+        sep = "-" * len(header)
+
+        logger.info(f"\n{'=' * len(header)}")
+        logger.info(f"{test_name} — BW (GB/s)  rows=packet_size  cols=channel_count")
+        logger.info(f"{'=' * len(header)}")
+        logger.info(header)
+        logger.info(sep)
+        for ps in packet_sizes:
+            row = f"{ps:>{col_w}}"
+            for cc in channel_counts:
+                val = results.get((ps, cc))
+                row += f"{val:>{col_w}.2f}" if val is not None else f"{'---':>{col_w}}"
+            logger.info(row)
+    logger.info("")
+
+
+def run_erisc_write_worker_bw_batch(
     benchmark_type,
     num_packets,
-    packet_size,
-    channel_count,
+    packet_sizes,
+    channel_counts,
     disable_trid,
     num_iterations,
     packet_size_to_expected_bw,
     request,
 ):
-    os.system(f"rm -rf {os.environ['TT_METAL_HOME']}/generated/profiler/.logs/profile_log_device.csv")
+    # Clean up old config-specific profiler files
+    for f in PROFILER_LOGS_DIR.glob("profile_log_device_ps*_ch*.csv"):
+        os.remove(f)
 
     num_iterations = request.config.getoption("--num-iterations") or num_iterations
     num_packets = request.config.getoption("--num-packets") or num_packets
-    packet_size = request.config.getoption("--packet-size") or packet_size
+    ps_override = request.config.getoption("--packet-size")
+    if ps_override:
+        packet_sizes = [ps_override]
 
     test_latency = 0
 
-    ARCH_NAME = os.getenv("ARCH_NAME")
-    cmd = f"TT_METAL_DEVICE_PROFILER=1 \
-            {os.environ['TT_METAL_HOME']}/build/test/tt_metal/perf_microbenchmark/ethernet/test_all_ethernet_links \
-                {benchmark_type} \
-                {num_packets} \
-                {packet_size} \
-                {channel_count} \
-                {test_latency} \
-                {disable_trid} \
-                {num_iterations}"
+    ps_csv = ",".join(str(p) for p in packet_sizes)
+    cc_csv = ",".join(str(c) for c in channel_counts)
+
+    cmd = (
+        f"TT_METAL_DEVICE_PROFILER=1 TT_METAL_PROFILER_MID_RUN_DUMP=1"
+        f" {os.environ['TT_METAL_HOME']}/build/test/tt_metal/perf_microbenchmark/ethernet/test_all_ethernet_links"
+        f" {benchmark_type}"
+        f" {num_packets}"
+        f" {ps_csv}"
+        f" {cc_csv}"
+        f" {test_latency}"
+        f" {disable_trid}"
+        f" {num_iterations}"
+    )
     rc = os.system(cmd)
     if rc != 0:
         logger.info("Error in running the test")
         assert False
 
-    process_profile_results(packet_size, num_packets, channel_count, benchmark_type, test_latency, num_iterations)
-    avg_bw = write_results_to_csv(FILE_NAME, test_latency)
-    logger.info(f"Sender bandwidth (GB/s) {avg_bw}")
-    if ARCH_NAME in packet_size_to_expected_bw:
-        expected_bw_for_arch = packet_size_to_expected_bw[ARCH_NAME]
-        if packet_size in expected_bw_for_arch:
-            expected_bw = expected_bw_for_arch[packet_size]
-            expected_bw_lower_bound = expected_bw - 0.5
-            expected_bw_upper_bound = expected_bw + 0.5
-            assert expected_bw_lower_bound <= avg_bw <= expected_bw_upper_bound
+    global _atexit_registered
+    test_name = request.node.name
+    if not _atexit_registered:
+        atexit.register(_print_summary_tables)
+        _atexit_registered = True
+
+    ARCH_NAME = os.getenv("ARCH_NAME")
+
+    # Process each config's profiler file
+    for ps in packet_sizes:
+        for cc in channel_counts:
+            config_file = PROFILER_LOGS_DIR / f"profile_log_device_ps{ps}_ch{cc}.csv"
+            if not config_file.exists():
+                logger.warning(f"Missing profiler file for ps={ps}, ch={cc}: {config_file}")
+                continue
+            shutil.copy(config_file, profiler_log_path)
+            process_profile_results(ps, num_packets, cc, benchmark_type, test_latency, num_iterations)
+            avg_bw = write_results_to_csv(FILE_NAME, test_latency)
+            logger.info(f"packet_size={ps} channel_count={cc} => BW (GB/s) {avg_bw}")
+
+            _bw_summary[test_name][(ps, cc)] = avg_bw
+
+            if ARCH_NAME in packet_size_to_expected_bw:
+                expected_bw_for_arch = packet_size_to_expected_bw[ARCH_NAME]
+                if ps in expected_bw_for_arch:
+                    expected_bw = expected_bw_for_arch[ps]
+                    expected_bw_lower_bound = expected_bw - 0.5
+                    expected_bw_upper_bound = expected_bw + 0.5
+                    assert expected_bw_lower_bound <= avg_bw <= expected_bw_upper_bound, (
+                        f"BW {avg_bw} outside expected range [{expected_bw_lower_bound}, {expected_bw_upper_bound}] "
+                        f"for packet_size={ps}, channel_count={cc}"
+                    )
 
 
 ##################################### No Worker BW test #######################################################
 # uni-direction test for eth-sender <---> eth-receiver
-@pytest.mark.skipif(is_single_chip(), reason="Unsupported on single chip systems")
-@pytest.mark.parametrize("num_packets", [256])
-@pytest.mark.parametrize("channel_count", [16])
-@pytest.mark.parametrize("num_iterations", [1])
-@pytest.mark.parametrize("packet_size", [16, 128, 256, 512, 1024, 2048, 4096, 8192])
-def test_erisc_bw_uni_dir(num_packets, packet_size, channel_count, num_iterations, request):
+# @pytest.mark.skipif(is_single_chip(), reason="Unsupported on single chip systems")
+def test_erisc_bw_uni_dir(request):
     packet_size_to_expected_bw = {
         "wormhole_b0": {16: 0.28, 128: 2.25, 256: 4.39, 512: 8.35, 1024: 11.74, 2048: 11.84, 4096: 12.04, 8192: 12.07},
         "blackhole": {16: 0.11, 128: 0.97, 256: 1.88, 512: 3.65, 1024: 7.27, 2048: 12.97, 4096: 19.71, 8192: 24.16},
     }
-    benchmark_type_id = 0
-    disable_trid = 0  # don't care in this case
-    run_erisc_write_worker_bw(
-        benchmark_type_id,
-        num_packets,
-        packet_size,
-        channel_count,
-        disable_trid,
-        num_iterations,
-        packet_size_to_expected_bw,
-        request,
+    run_erisc_write_worker_bw_batch(
+        benchmark_type=0,
+        num_packets=256,
+        packet_sizes=[16, 128, 256, 512, 1024, 2048, 4096, 8192],
+        channel_counts=[4, 8, 12, 16, 20, 24, 28, 32],
+        disable_trid=0,
+        num_iterations=1,
+        packet_size_to_expected_bw=packet_size_to_expected_bw,
+        request=request,
     )
 
 
 # bi-direction test for eth-sender <---> eth-receiver
-@pytest.mark.skipif(is_single_chip(), reason="Unsupported on single chip systems")
-@pytest.mark.parametrize("num_packets", [1000])
-@pytest.mark.parametrize("channel_count", [16])
-@pytest.mark.parametrize("num_iterations", [1])
-@pytest.mark.parametrize("packet_size", [16, 128, 256, 512, 1024, 2048, 4096])
-def test_erisc_bw_bi_dir(num_packets, packet_size, channel_count, num_iterations, request):
+# @pytest.mark.skipif(is_single_chip(), reason="Unsupported on single chip systems")
+def test_erisc_bw_bi_dir(request):
     packet_size_to_expected_bw = {
         "wormhole_b0": {
             16: 0.19,
@@ -121,109 +174,96 @@ def test_erisc_bw_bi_dir(num_packets, packet_size, channel_count, num_iterations
             4096: 18.75,
         },
     }
-    benchmark_type_id = 1
-    disable_trid = 0  # don't care in this case
-    run_erisc_write_worker_bw(
-        benchmark_type_id,
-        num_packets,
-        packet_size,
-        channel_count,
-        disable_trid,
-        num_iterations,
-        packet_size_to_expected_bw,
-        request,
+    run_erisc_write_worker_bw_batch(
+        benchmark_type=1,
+        num_packets=1000,
+        packet_sizes=[16, 128, 256, 512, 1024, 2048, 4096],
+        channel_counts=[4, 8, 12, 16, 20, 24, 28, 32],
+        disable_trid=0,
+        num_iterations=1,
+        packet_size_to_expected_bw=packet_size_to_expected_bw,
+        request=request,
     )
 
 
 ##################################### BW test #######################################################
 # uni-direction test for eth-sender <---> eth-receiver ---> worker
-@pytest.mark.skipif(is_single_chip(), reason="Unsupported on single chip systems")
-@pytest.mark.parametrize("num_packets", [256])
-@pytest.mark.parametrize("channel_count", [16])
-@pytest.mark.parametrize("disable_trid", [0])
-@pytest.mark.parametrize("num_iterations", [1])
-@pytest.mark.parametrize("packet_size", [16, 128, 256, 512, 1024, 2048, 4096, 8192])
-def test_erisc_write_worker_bw_uni_dir(num_packets, packet_size, channel_count, disable_trid, num_iterations, request):
+# @pytest.mark.skipif(is_single_chip(), reason="Unsupported on single chip systems")
+def test_erisc_write_worker_bw_uni_dir(request):
     packet_size_to_expected_bw = {
         "wormhole_b0": {16: 0.21, 128: 1.72, 256: 3.44, 512: 6.89, 1024: 11.73, 2048: 11.83, 4096: 12.04, 8192: 12.07},
         "blackhole": {16: 0.11, 128: 0.84, 256: 1.61, 512: 3.41, 1024: 6.52, 2048: 11.70, 4096: 19.10, 8192: 23.97},
     }
-    benchmark_type_id = 2
-    run_erisc_write_worker_bw(
-        benchmark_type_id,
-        num_packets,
-        packet_size,
-        channel_count,
-        disable_trid,
-        num_iterations,
-        packet_size_to_expected_bw,
-        request,
+    run_erisc_write_worker_bw_batch(
+        benchmark_type=2,
+        num_packets=256,
+        packet_sizes=[16, 128, 256, 512, 1024, 2048, 4096, 8192],
+        channel_counts=[4, 8, 12, 16, 20, 24, 28, 32],
+        disable_trid=0,
+        num_iterations=1,
+        packet_size_to_expected_bw=packet_size_to_expected_bw,
+        request=request,
     )
 
 
 # bi-direction test for eth-sender <---> eth-receiver ---> worker
-@pytest.mark.skipif(is_single_chip(), reason="Unsupported on single chip systems")
-@pytest.mark.parametrize("num_packets", [1000])
-@pytest.mark.parametrize("channel_count", [16])
-@pytest.mark.parametrize("disable_trid", [0])
-@pytest.mark.parametrize("num_iterations", [1])
-@pytest.mark.parametrize("packet_size", [16, 128, 256, 512, 1024, 2048, 4096])
-def test_erisc_write_worker_bw_bi_dir(num_packets, packet_size, channel_count, disable_trid, num_iterations, request):
+# @pytest.mark.skipif(is_single_chip(), reason="Unsupported on single chip systems")
+def test_erisc_write_worker_bw_bi_dir(request):
     packet_size_to_expected_bw = {
         "wormhole_b0": {16: 0.13, 128: 1.03, 256: 2.08, 512: 4.15, 1024: 7.81, 2048: 11.40, 4096: 11.82},
         "blackhole": {16: 0.16, 128: 1.35, 256: 2.69, 512: 5.39, 1024: 10.79, 2048: 21.47, 4096: 18.70},
     }
-    benchmark_type_id = 3
-    run_erisc_write_worker_bw(
-        benchmark_type_id,
-        num_packets,
-        packet_size,
-        channel_count,
-        disable_trid,
-        num_iterations,
-        packet_size_to_expected_bw,
-        request,
+    run_erisc_write_worker_bw_batch(
+        benchmark_type=3,
+        num_packets=1000,
+        packet_sizes=[16, 128, 256, 512, 1024, 2048, 4096],
+        channel_counts=[4, 8, 12, 16, 20, 24, 28, 32],
+        disable_trid=0,
+        num_iterations=1,
+        packet_size_to_expected_bw=packet_size_to_expected_bw,
+        request=request,
+    )
+
+
+##################################### Dual-ERISC Bi-Directional BW test (BH only) ####################################
+# bi-direction test using ERISC_0 as sender and ERISC_1 as receiver per eth core
+def test_erisc_bw_dual_erisc_bi_dir(request):
+    packet_size_to_expected_bw = {}  # no expected values yet, establish baseline
+    run_erisc_write_worker_bw_batch(
+        benchmark_type=9,  # DualEriscBiDir
+        num_packets=1000,
+        packet_sizes=[16, 128, 256, 512, 1024, 2048, 4096],
+        channel_counts=[4, 8, 12, 16, 20, 24, 28, 32],
+        disable_trid=0,
+        num_iterations=1,
+        packet_size_to_expected_bw=packet_size_to_expected_bw,
+        request=request,
     )
 
 
 ##################################### No Transaction ID BW test #######################################################
 # uni-direction test for eth-sender <---> eth-receiver ---> worker
-@pytest.mark.skipif(is_single_chip(), reason="Unsupported on single chip systems")
-@pytest.mark.parametrize("num_packets", [256])
-@pytest.mark.parametrize("channel_count", [16])
-@pytest.mark.parametrize("disable_trid", [1])
-@pytest.mark.parametrize("num_iterations", [1])
-@pytest.mark.parametrize("packet_size", [16, 128, 256, 512, 1024, 2048, 4096, 8192])
-def test_erisc_write_worker_bw_uni_dir_no_trid(
-    num_packets, packet_size, channel_count, disable_trid, num_iterations, request
-):
+# @pytest.mark.skipif(is_single_chip(), reason="Unsupported on single chip systems")
+def test_erisc_write_worker_bw_uni_dir_no_trid(request):
     packet_size_to_expected_bw = {
         "wormhole_b0": {16: 0.18, 128: 1.71, 256: 3.81, 512: 7.72, 1024: 11.32, 2048: 11.83, 4096: 12.04, 8192: 12.07},
         "blackhole": {16: 0.11, 128: 0.90, 256: 1.82, 512: 3.71, 1024: 7.37, 2048: 12.62, 4096: 20.04, 8192: 24.09},
     }
-    benchmark_type_id = 2
-    run_erisc_write_worker_bw(
-        benchmark_type_id,
-        num_packets,
-        packet_size,
-        channel_count,
-        disable_trid,
-        num_iterations,
-        packet_size_to_expected_bw,
-        request,
+    run_erisc_write_worker_bw_batch(
+        benchmark_type=2,
+        num_packets=256,
+        packet_sizes=[16, 128, 256, 512, 1024, 2048, 4096, 8192],
+        channel_counts=[4, 8, 12, 16, 20, 24, 28, 32],
+        disable_trid=1,
+        num_iterations=1,
+        packet_size_to_expected_bw=packet_size_to_expected_bw,
+        request=request,
     )
 
 
 # bi-direction test for eth-sender <---> eth-receiver ---> worker
-@pytest.mark.skipif(is_single_chip(), reason="Unsupported on single chip systems")
-@pytest.mark.parametrize("num_packets", [1000])
-@pytest.mark.parametrize("channel_count", [16])
-@pytest.mark.parametrize("disable_trid", [1])
-@pytest.mark.parametrize("num_iterations", [1])
-@pytest.mark.parametrize("packet_size", [16, 128, 256, 512, 1024, 2048, 4096])
-def test_erisc_write_worker_bw_bi_dir_no_trid(
-    num_packets, packet_size, channel_count, disable_trid, num_iterations, request
-):
+# @pytest.mark.skipif(is_single_chip(), reason="Unsupported on single chip systems")
+def test_erisc_write_worker_bw_bi_dir_no_trid(request):
     packet_size_to_expected_bw = {
         "wormhole_b0": {
             16: 0.10,
@@ -244,14 +284,13 @@ def test_erisc_write_worker_bw_bi_dir_no_trid(
             4096: 19.02,
         },
     }
-    benchmark_type_id = 3
-    run_erisc_write_worker_bw(
-        benchmark_type_id,
-        num_packets,
-        packet_size,
-        channel_count,
-        disable_trid,
-        num_iterations,
-        packet_size_to_expected_bw,
-        request,
+    run_erisc_write_worker_bw_batch(
+        benchmark_type=3,
+        num_packets=1000,
+        packet_sizes=[16, 128, 256, 512, 1024, 2048, 4096],
+        channel_counts=[4, 8, 12, 16, 20, 24, 28, 32],
+        disable_trid=1,
+        num_iterations=1,
+        packet_size_to_expected_bw=packet_size_to_expected_bw,
+        request=request,
     )

--- a/tests/tt_metal/microbenchmarks/ethernet/test_all_ethernet_links_bandwidth.py
+++ b/tests/tt_metal/microbenchmarks/ethernet/test_all_ethernet_links_bandwidth.py
@@ -27,7 +27,6 @@ if os.path.exists(FILE_NAME):
 # Accumulate BW results per test function for summary tables
 # Key: test_name -> {(packet_size, channel_count): avg_bw}
 _bw_summary = defaultdict(dict)
-_atexit_registered = False
 
 
 def _print_summary_tables():
@@ -98,11 +97,9 @@ def run_erisc_write_worker_bw_batch(
         logger.info("Error in running the test")
         assert False
 
-    global _atexit_registered
     test_name = request.node.name
-    if not _atexit_registered:
+    if not _bw_summary:
         atexit.register(_print_summary_tables)
-        _atexit_registered = True
 
     ARCH_NAME = os.getenv("ARCH_NAME")
 

--- a/tests/tt_metal/microbenchmarks/ethernet/test_all_ethernet_links_bandwidth.py
+++ b/tests/tt_metal/microbenchmarks/ethernet/test_all_ethernet_links_bandwidth.py
@@ -81,8 +81,9 @@ def run_erisc_write_worker_bw_batch(
     ps_csv = ",".join(str(p) for p in packet_sizes)
     cc_csv = ",".join(str(c) for c in channel_counts)
 
+    profiler_env = "TT_METAL_DEVICE_PROFILER=1 TT_METAL_PROFILER_MID_RUN_DUMP=1"
     cmd = (
-        f"TT_METAL_DEVICE_PROFILER=1 TT_METAL_PROFILER_MID_RUN_DUMP=1"
+        f"{profiler_env}"
         f" {os.environ['TT_METAL_HOME']}/build/test/tt_metal/perf_microbenchmark/ethernet/test_all_ethernet_links"
         f" {benchmark_type}"
         f" {num_packets}"

--- a/tests/tt_metal/microbenchmarks/ethernet/test_all_ethernet_links_latency.py
+++ b/tests/tt_metal/microbenchmarks/ethernet/test_all_ethernet_links_latency.py
@@ -11,7 +11,7 @@ from tests.tt_metal.microbenchmarks.ethernet.test_all_ethernet_links_common impo
     write_results_to_csv,
 )
 
-from models.common.utility_functions import is_single_chip
+# from models.common.utility_functions import is_single_chip
 
 from tracy.common import PROFILER_LOGS_DIR, PROFILER_DEVICE_SIDE_LOG
 
@@ -71,11 +71,11 @@ def run_erisc_write_worker_latency(
 
 
 # uni-direction test for eth-sender <---> eth-receiver
-@pytest.mark.skipif(is_single_chip(), reason="Unsupported on single chip systems")
+# @pytest.mark.skipif(is_single_chip(), reason="Unsupported on single chip systems")
 @pytest.mark.parametrize("num_packets", [1])
-@pytest.mark.parametrize("channel_count", [16])
+@pytest.mark.parametrize("channel_count", [2])  # 6])
 @pytest.mark.parametrize("num_iterations", [1])
-@pytest.mark.parametrize("packet_size", [16, 128, 256, 512, 1024, 2048, 4096, 8192])
+@pytest.mark.parametrize("packet_size", [16])  # , 128, 256, 512, 1024, 2048, 4096, 8192])
 def test_erisc_latency_uni_dir(num_packets, packet_size, channel_count, num_iterations, request):
     packet_size_to_expected_latency = {
         "wormhole_b0": {
@@ -104,12 +104,12 @@ def test_erisc_latency_uni_dir(num_packets, packet_size, channel_count, num_iter
 
 
 # uni-direction test for eth-sender <---> eth-receiver ---> worker
-@pytest.mark.skipif(is_single_chip(), reason="Unsupported on single chip systems")
+# @pytest.mark.skipif(is_single_chip(), reason="Unsupported on single chip systems")
 @pytest.mark.parametrize("num_packets", [1])
-@pytest.mark.parametrize("channel_count", [16])
+@pytest.mark.parametrize("channel_count", [2])  # 6])
 @pytest.mark.parametrize("disable_trid", [0])
 @pytest.mark.parametrize("num_iterations", [1])
-@pytest.mark.parametrize("packet_size", [16, 128, 256, 512, 1024, 2048, 4096, 8192])
+@pytest.mark.parametrize("packet_size", [16])  # , 128, 256, 512, 1024, 2048, 4096, 8192])
 def test_erisc_write_worker_latency_uni_dir(
     num_packets, packet_size, channel_count, disable_trid, num_iterations, request
 ):
@@ -126,6 +126,27 @@ def test_erisc_write_worker_latency_uni_dir(
         }
     }
     benchmark_type_id = 2
+    run_erisc_write_worker_latency(
+        benchmark_type_id,
+        num_packets,
+        packet_size,
+        channel_count,
+        disable_trid,
+        num_iterations,
+        packet_size_to_expected_latency,
+        request,
+    )
+
+
+# full round-trip: tensix -> eth -> eth -> tensix -> eth -> eth -> tensix
+@pytest.mark.parametrize("num_packets", [100])
+@pytest.mark.parametrize("channel_count", [2])
+@pytest.mark.parametrize("num_iterations", [1])
+@pytest.mark.parametrize("packet_size", [16, 128, 256, 512, 1024, 2048, 4096, 8192])
+def test_tensix_eth_eth_tensix_latency_uni_dir(num_packets, packet_size, channel_count, num_iterations, request):
+    packet_size_to_expected_latency = {}
+    benchmark_type_id = 8
+    disable_trid = 0
     run_erisc_write_worker_latency(
         benchmark_type_id,
         num_packets,

--- a/tests/tt_metal/microbenchmarks/ethernet/test_all_ethernet_links_latency.py
+++ b/tests/tt_metal/microbenchmarks/ethernet/test_all_ethernet_links_latency.py
@@ -320,6 +320,50 @@ def run_sender_sweep(
     return all_results
 
 
+def run_receiver_sweep(
+    benchmark_type,
+    num_packets,
+    packet_size,
+    channel_count,
+    disable_trid,
+    num_iterations,
+    noc_index,
+    receiver_noc_index,
+    request,
+):
+    """Sweep receiver cores (sender fixed at closest to eth). One table of receiver core latencies."""
+    num_iterations = request.config.getoption("--num-iterations") or num_iterations
+    num_packets = request.config.getoption("--num-packets") or num_packets
+    packet_size = request.config.getoption("--packet-size") or packet_size
+
+    _run_sweep_binary(
+        benchmark_type,
+        num_packets,
+        packet_size,
+        channel_count,
+        disable_trid,
+        num_iterations,
+        3,
+        noc_index,
+        receiver_noc_index,
+    )
+
+    all_results = _parse_sweep_results(packet_size, channel_count, benchmark_type, num_packets, 1, num_iterations)
+
+    # For sweep_cores=3, sender is fixed — all entries have the same single sender.
+    # Flatten: {(rx, ry): latency}
+    flat_results = {}
+    fixed_sender = None
+    for sender_core, receiver_map in all_results.items():
+        fixed_sender = sender_core
+        for receiver_core, latency in receiver_map.items():
+            flat_results[receiver_core] = latency
+    if flat_results:
+        _print_receiver_sweep_table(flat_results, packet_size, noc_index, receiver_noc_index, fixed_sender)
+
+    return all_results
+
+
 def run_extended_sweep(
     benchmark_type,
     num_packets,
@@ -357,15 +401,14 @@ def run_extended_sweep(
     return all_results
 
 
-# Default: sweep sender cores, receiver fixed closest to eth, one table per NOC config
+# Default: sweep sender cores, receiver fixed closest to eth
+# ETH is locked to NOC_0, tensix uses NOC_1 (opposite)
 @pytest.mark.parametrize("packet_size", [16, 256, 1024, 4096])
-@pytest.mark.parametrize("noc_index", [0, 1])
-def test_erisc_write_worker_latency_core_sweep(packet_size, noc_index, request):
+def test_erisc_write_worker_latency_core_sweep(packet_size, request):
     """Sweep sender cores with receiver fixed at closest-to-eth core.
 
-    Receiver tensix uses NOC1 (opposite of receiver eth which is on NOC0).
-    The receiver tensix is picked "below" the eth core (closest on NOC0),
-    so its return path on NOC1 (upward) is also minimal.
+    ETH kernels are locked to NOC_0 (ERISC constraint). Tensix kernels should use
+    NOC_1 (opposite) so eth→tensix and tensix→eth writes travel in opposite directions.
     """
     run_sender_sweep(
         benchmark_type=8,  # TensixEthEthTensixUniDir
@@ -374,13 +417,31 @@ def test_erisc_write_worker_latency_core_sweep(packet_size, noc_index, request):
         channel_count=2,
         disable_trid=0,
         num_iterations=1,
-        noc_index=noc_index,
-        receiver_noc_index=1,  # opposite of receiver eth (NOC0)
+        noc_index=1,  # tensix uses NOC_1 (opposite of eth NOC_0)
+        receiver_noc_index=1,  # both tensix on NOC_1
+        request=request,
+    )
+
+
+# Sweep receiver cores, sender fixed at closest to eth
+@pytest.mark.parametrize("packet_size", [16, 256, 1024, 4096])
+def test_erisc_write_worker_latency_receiver_sweep(packet_size, request):
+    """Sweep receiver cores with sender fixed at closest-to-eth core."""
+    run_receiver_sweep(
+        benchmark_type=8,  # TensixEthEthTensixUniDir
+        num_packets=100,
+        packet_size=packet_size,
+        channel_count=2,
+        disable_trid=0,
+        num_iterations=1,
+        noc_index=1,  # tensix uses NOC_1 (opposite of eth NOC_0)
+        receiver_noc_index=1,  # both tensix on NOC_1
         request=request,
     )
 
 
 # Extended: sweep both sender and receiver cores independently
+@pytest.mark.extended
 @pytest.mark.parametrize("packet_size", [16, 4096])
 @pytest.mark.parametrize("noc_index", [0, 1])
 @pytest.mark.parametrize("receiver_noc_index", [0, 1])

--- a/tests/tt_metal/microbenchmarks/ethernet/test_all_ethernet_links_latency.py
+++ b/tests/tt_metal/microbenchmarks/ethernet/test_all_ethernet_links_latency.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import os
+import shutil
 
 from loguru import logger
 import pytest
@@ -156,4 +157,243 @@ def test_tensix_eth_eth_tensix_latency_uni_dir(num_packets, packet_size, channel
         num_iterations,
         packet_size_to_expected_latency,
         request,
+    )
+
+
+##################################### Core Sweep Latency test ################################################
+
+
+def _print_sender_sweep_table(results, packet_size, sender_noc, receiver_noc, receiver_core):
+    """Print a heatmap table of sender core sweep results (receiver fixed)."""
+    if not results:
+        logger.warning("No core sweep results to display")
+        return
+    max_x = max(x for x, _ in results.keys())
+    max_y = max(y for _, y in results.keys())
+    col_w = 8
+    yx_label = "y\\x"
+    header = f"{yx_label:>{col_w}}" + "".join(f"{x:>{col_w}}" for x in range(max_x + 1))
+    logger.info(
+        f"\nSender Core Sweep Latency (ns) — packet_size={packet_size}, "
+        f"sender_noc=NOC{sender_noc}, receiver_noc=NOC{receiver_noc}, "
+        f"receiver_tensix=({receiver_core[0]},{receiver_core[1]})"
+    )
+    logger.info(header)
+    logger.info("-" * len(header))
+    for y in range(max_y + 1):
+        row = f"{y:>{col_w}}"
+        for x in range(max_x + 1):
+            val = results.get((x, y))
+            row += f"{val:>{col_w}.0f}" if val is not None else f"{'---':>{col_w}}"
+        logger.info(row)
+
+
+def _print_receiver_sweep_table(results, packet_size, sender_noc, receiver_noc, sender_core):
+    """Print a heatmap table of receiver core sweep results (sender fixed)."""
+    if not results:
+        return
+    max_x = max(x for x, _ in results.keys())
+    max_y = max(y for _, y in results.keys())
+    col_w = 8
+    yx_label = "y\\x"
+    header = f"{yx_label:>{col_w}}" + "".join(f"{x:>{col_w}}" for x in range(max_x + 1))
+    logger.info(
+        f"\nReceiver Core Sweep Latency (ns) — packet_size={packet_size}, "
+        f"sender_noc=NOC{sender_noc}, receiver_noc=NOC{receiver_noc}, "
+        f"sender_tensix=({sender_core[0]},{sender_core[1]})"
+    )
+    logger.info(header)
+    logger.info("-" * len(header))
+    for y in range(max_y + 1):
+        row = f"{y:>{col_w}}"
+        for x in range(max_x + 1):
+            val = results.get((x, y))
+            row += f"{val:>{col_w}.0f}" if val is not None else f"{'---':>{col_w}}"
+        logger.info(row)
+
+
+def _parse_sweep_results(packet_size, channel_count, benchmark_type, num_packets, test_latency, num_iterations):
+    """Parse profiler CSVs with _s{sx}_{sy}_r{rx}_{ry} naming into nested dict."""
+    # Returns {(sx, sy): {(rx, ry): avg_latency_ns}}
+    all_results = {}
+    for config_file in sorted(
+        PROFILER_LOGS_DIR.glob(f"profile_log_device_ps{packet_size}_ch{channel_count}_s*_r*.csv")
+    ):
+        name = config_file.stem
+        # e.g. "profile_log_device_ps16_ch2_s3_5_r7_2"
+        s_part = name.split("_s")[1]  # "3_5_r7_2"
+        s_coords, r_part = s_part.split("_r")  # "3_5", "7_2"
+        sx, sy = int(s_coords.split("_")[0]), int(s_coords.split("_")[1])
+        rx, ry = int(r_part.split("_")[0]), int(r_part.split("_")[1])
+
+        shutil.copy(config_file, profiler_log_path)
+        process_profile_results(packet_size, num_packets, channel_count, benchmark_type, test_latency, num_iterations)
+        avg_latency = write_results_to_csv(FILE_NAME, test_latency)
+
+        if (sx, sy) not in all_results:
+            all_results[(sx, sy)] = {}
+        all_results[(sx, sy)][(rx, ry)] = avg_latency
+
+    return all_results
+
+
+def _run_sweep_binary(
+    benchmark_type,
+    num_packets,
+    packet_size,
+    channel_count,
+    disable_trid,
+    num_iterations,
+    sweep_cores,
+    noc_index,
+    receiver_noc_index,
+):
+    """Run the C++ test binary with sweep parameters."""
+    # Clean old per-core profiler files
+    for f in PROFILER_LOGS_DIR.glob("profile_log_device_ps*_ch*_s*_r*.csv"):
+        os.remove(f)
+
+    test_latency = 1
+    cmd = (
+        f"TT_METAL_DEVICE_PROFILER=1 TT_METAL_PROFILER_MID_RUN_DUMP=1"
+        f" {os.environ['TT_METAL_HOME']}/build/test/tt_metal/perf_microbenchmark/ethernet/test_all_ethernet_links"
+        f" {benchmark_type}"
+        f" {num_packets}"
+        f" {packet_size}"
+        f" {channel_count}"
+        f" {test_latency}"
+        f" {disable_trid}"
+        f" {num_iterations}"
+        f" {sweep_cores}"
+        f" {noc_index}"
+        f" {receiver_noc_index}"
+    )
+    rc = os.system(cmd)
+    assert rc == 0, "Test binary failed"
+
+
+def run_sender_sweep(
+    benchmark_type,
+    num_packets,
+    packet_size,
+    channel_count,
+    disable_trid,
+    num_iterations,
+    noc_index,
+    receiver_noc_index,
+    request,
+):
+    """Sweep sender cores (receiver fixed at closest to eth). One table per NOC config."""
+    num_iterations = request.config.getoption("--num-iterations") or num_iterations
+    num_packets = request.config.getoption("--num-packets") or num_packets
+    packet_size = request.config.getoption("--packet-size") or packet_size
+
+    _run_sweep_binary(
+        benchmark_type,
+        num_packets,
+        packet_size,
+        channel_count,
+        disable_trid,
+        num_iterations,
+        1,
+        noc_index,
+        receiver_noc_index,
+    )
+
+    all_results = _parse_sweep_results(packet_size, channel_count, benchmark_type, num_packets, 1, num_iterations)
+
+    # For sweep_cores=1, receiver is fixed — all sender entries have the same single receiver.
+    # Print one flat table of sender core latencies.
+    for sender_core in sorted(all_results.keys()):
+        for receiver_core, latency in all_results[sender_core].items():
+            pass  # just get the receiver_core (same for all)
+    # Flatten: {(sx, sy): latency}
+    flat_results = {}
+    fixed_receiver = None
+    for sender_core, receiver_map in all_results.items():
+        for receiver_core, latency in receiver_map.items():
+            flat_results[sender_core] = latency
+            fixed_receiver = receiver_core
+    if flat_results:
+        _print_sender_sweep_table(flat_results, packet_size, noc_index, receiver_noc_index, fixed_receiver)
+
+    return all_results
+
+
+def run_extended_sweep(
+    benchmark_type,
+    num_packets,
+    packet_size,
+    channel_count,
+    disable_trid,
+    num_iterations,
+    noc_index,
+    receiver_noc_index,
+    request,
+):
+    """Sweep both sender and receiver cores (N^2). One table per sender core."""
+    num_iterations = request.config.getoption("--num-iterations") or num_iterations
+    num_packets = request.config.getoption("--num-packets") or num_packets
+    packet_size = request.config.getoption("--packet-size") or packet_size
+
+    _run_sweep_binary(
+        benchmark_type,
+        num_packets,
+        packet_size,
+        channel_count,
+        disable_trid,
+        num_iterations,
+        2,
+        noc_index,
+        receiver_noc_index,
+    )
+
+    all_results = _parse_sweep_results(packet_size, channel_count, benchmark_type, num_packets, 1, num_iterations)
+
+    # Print one table per sender core
+    for sender_core in sorted(all_results.keys()):
+        _print_receiver_sweep_table(all_results[sender_core], packet_size, noc_index, receiver_noc_index, sender_core)
+
+    return all_results
+
+
+# Default: sweep sender cores, receiver fixed closest to eth, one table per NOC config
+@pytest.mark.parametrize("packet_size", [16, 256, 1024, 4096])
+@pytest.mark.parametrize("noc_index", [0, 1])
+def test_erisc_write_worker_latency_core_sweep(packet_size, noc_index, request):
+    """Sweep sender cores with receiver fixed at closest-to-eth core.
+
+    Receiver tensix uses NOC1 (opposite of receiver eth which is on NOC0).
+    The receiver tensix is picked "below" the eth core (closest on NOC0),
+    so its return path on NOC1 (upward) is also minimal.
+    """
+    run_sender_sweep(
+        benchmark_type=8,  # TensixEthEthTensixUniDir
+        num_packets=100,
+        packet_size=packet_size,
+        channel_count=2,
+        disable_trid=0,
+        num_iterations=1,
+        noc_index=noc_index,
+        receiver_noc_index=1,  # opposite of receiver eth (NOC0)
+        request=request,
+    )
+
+
+# Extended: sweep both sender and receiver cores independently
+@pytest.mark.parametrize("packet_size", [16, 4096])
+@pytest.mark.parametrize("noc_index", [0, 1])
+@pytest.mark.parametrize("receiver_noc_index", [0, 1])
+def test_erisc_write_worker_latency_extended_sweep(packet_size, noc_index, receiver_noc_index, request):
+    """Sweep both sender and receiver cores (N^2) with configurable NOCs."""
+    run_extended_sweep(
+        benchmark_type=8,  # TensixEthEthTensixUniDir
+        num_packets=100,
+        packet_size=packet_size,
+        channel_count=2,
+        disable_trid=0,
+        num_iterations=1,
+        noc_index=noc_index,
+        receiver_noc_index=receiver_noc_index,
+        request=request,
     )

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/ethernet/test_all_ethernet_links.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/ethernet/test_all_ethernet_links.cpp
@@ -130,7 +130,8 @@ private:
     std::map<ChipId, tt_metal::IDevice*> devices_map;
 
 public:
-    ConnectedDevicesHelper(BenchmarkType benchmark_type) {
+    ConnectedDevicesHelper(
+        BenchmarkType benchmark_type, uint32_t sender_noc_index = 1, uint32_t receiver_noc_index = 1) {
         this->arch = tt::get_arch_from_string(tt::test_utils::get_umd_arch_name());
 
         this->num_devices = tt::tt_metal::GetNumAvailableDevices();
@@ -150,7 +151,7 @@ public:
             this->devices.push_back(device);
         }
 
-        this->initialize_sender_receiver_pairs(benchmark_type);
+        this->initialize_sender_receiver_pairs(benchmark_type, sender_noc_index, receiver_noc_index);
         device_open_ = true;
     }
 
@@ -239,7 +240,8 @@ public:
     }
 
 private:
-    std::optional<CoreCoord> assign_tensix(BenchmarkType benchmark_type, const tt_cxy_pair& logical_eth_core) {
+    std::optional<CoreCoord> assign_tensix(
+        BenchmarkType benchmark_type, const tt_cxy_pair& logical_eth_core, uint32_t tensix_noc_index = 1) {
         if (benchmark_type != BenchmarkType::EthEthTensixUniDir and
             benchmark_type != BenchmarkType::EthEthTensixBiDir and
             benchmark_type != BenchmarkType::TensixEthEthTensixUniDir) {
@@ -253,15 +255,34 @@ private:
 
         const std::vector<tt::umd::CoreCoord>& tensix_cores = soc_d.get_cores(CoreType::TENSIX, CoordSystem::NOC0);
 
+        // Pick the tensix core in the same x-column as the eth core.
+        // Eth is at NOC y=1, tensix cores at y=2..11.
+        //
+        // NOC_1 goes upward (-y): top row (y=2) is 1 hop from eth → forward iteration picks y=2.
+        // NOC_0 goes downward (+y): bottom row (y=11) wraps around to eth → reverse iteration picks y=11.
         std::optional<CoreCoord> closest_phys_tensix = std::nullopt;
-        for (auto phys_tensix : tensix_cores) {
-            if (assigned_phys_tensix.contains(phys_tensix)) {
-                continue;
+        if (tensix_noc_index == 0) {
+            // NOC_0: reverse iterate to pick bottom row (highest y) — closest via +y wrap
+            for (auto it = tensix_cores.rbegin(); it != tensix_cores.rend(); ++it) {
+                auto phys_tensix = *it;
+                if (assigned_phys_tensix.contains(phys_tensix)) {
+                    continue;
+                }
+                if (phys_tensix.x == physical_eth_core.x and phys_tensix.y > physical_eth_core.y) {
+                    closest_phys_tensix = phys_tensix;
+                    break;
+                }
             }
-            // TODO: uplift this for BH col harvesting when that is enabled
-            if (phys_tensix.x == physical_eth_core.x and phys_tensix.y > physical_eth_core.y) {
-                closest_phys_tensix = phys_tensix;
-                break;
+        } else {
+            // NOC_1: forward iterate to pick top row (lowest y) — closest via -y direction
+            for (auto phys_tensix : tensix_cores) {
+                if (assigned_phys_tensix.contains(phys_tensix)) {
+                    continue;
+                }
+                if (phys_tensix.x == physical_eth_core.x and phys_tensix.y > physical_eth_core.y) {
+                    closest_phys_tensix = phys_tensix;
+                    break;
+                }
             }
         }
         TT_FATAL(
@@ -307,7 +328,8 @@ private:
         return tt_metal::distributed::MeshBuffer::create(global_buffer_config, device_local_config, device);
     }
 
-    void initialize_sender_receiver_pairs(BenchmarkType benchmark_type) {
+    void initialize_sender_receiver_pairs(
+        BenchmarkType benchmark_type, uint32_t sender_noc_index = 1, uint32_t receiver_noc_index = 1) {
         // chip id -> active eth ch on chip -> (connected chip, remote active eth ch)
         auto all_eth_connections = tt::tt_metal::MetalContext::instance().get_cluster().get_ethernet_connections();
 
@@ -384,8 +406,8 @@ private:
                     tt::tt_metal::MetalContext::instance().get_cluster().get_connected_ethernet_core(
                         std::make_tuple(sender_chip_id, logical_active_eth));
                 auto receiver_eth = tt_cxy_pair(std::get<0>(receiver_eth_tuple), std::get<1>(receiver_eth_tuple));
-                auto sender_tensix = assign_tensix(benchmark_type, sender_eth);
-                auto receiver_tensix = assign_tensix(benchmark_type, receiver_eth);
+                auto sender_tensix = assign_tensix(benchmark_type, sender_eth, sender_noc_index);
+                auto receiver_tensix = assign_tensix(benchmark_type, receiver_eth, receiver_noc_index);
                 this->unique_links.insert(SenderReceiverPair{
                     .sender = sender_eth,
                     .receiver = receiver_eth,
@@ -406,7 +428,6 @@ std::vector<tt_metal::Program> build(const ConnectedDevicesHelper& device_helper
     std::map<ChipId, size_t> chip_to_index;
     for (size_t i = 0; i < device_helper.devices.size(); i++) {
         chip_to_index[device_helper.devices[i]->get_devices()[0]->id()] = i;
-        log_info(tt::LogTest, "Device {} index {}", device_helper.devices[i]->get_devices()[0]->id(), i);
     }
 
     uint32_t measurement_type = (uint32_t)(params.test_latency ? MeasurementType::Latency : MeasurementType::Bandwidth);
@@ -559,16 +580,17 @@ std::vector<tt_metal::Program> build(const ConnectedDevicesHelper& device_helper
 
         // Create Tensix DataMovement kernels for TensixEthEthTensixUniDir
         if (params.benchmark_type == BenchmarkType::TensixEthEthTensixUniDir && link.sender_tensix.has_value()) {
+            auto* raw_sender_device = sender_device->get_devices()[0];
             uint32_t eth_unreserved_base = tt_metal::MetalContext::instance().hal().get_dev_addr(
                 tt_metal::HalProgrammableCoreType::ACTIVE_ETH, tt_metal::HalL1MemAddrType::UNRESERVED);
             uint32_t eth_slot_addr = eth_unreserved_base + sizeof(eth_buffer_slot_sync_t);
             uint32_t push_counter_addr = eth_slot_addr + params.packet_size;
 
-            // Sender tensix: virtual coords of sender eth core
-            auto virtual_sender_eth =
-                sender_device->virtual_core_from_logical_core(CoreCoord(link.sender.x, link.sender.y), CoreType::ETH);
-            // Receiver tensix: virtual coords of receiver eth core
-            auto virtual_receiver_eth = receiver_device->virtual_core_from_logical_core(
+            // Get virtual eth coords for the tensix kernel runtime args
+            auto* raw_receiver_device = receiver_device->get_devices()[0];
+            auto virtual_sender_eth = raw_sender_device->virtual_core_from_logical_core(
+                CoreCoord(link.sender.x, link.sender.y), CoreType::ETH);
+            auto virtual_receiver_eth = raw_receiver_device->virtual_core_from_logical_core(
                 CoreCoord(link.receiver.x, link.receiver.y), CoreType::ETH);
 
             // Tensix buffer layout: [landing_buffer(msg_size)][tensix_sem(4B)][pad(12B)][test_data(msg_size)]
@@ -946,11 +968,13 @@ void run(
                     double cycles_to_ns = 1000.0 / 1350.0;
                     log_info(
                         tt::LogTest,
-                        "Timestamps: sender_tensix=({},{}), num_iters={}, "
+                        "Timestamps: sender_tensix=({},{}), receiver_tensix=({},{}), num_iters={}, "
                         "mean={:.1f} cycles ({:.1f} ns), min={} cycles ({:.1f} ns), "
                         "max={} cycles ({:.1f} ns), stddev={:.1f} cycles",
                         link.sender_tensix.value().x,
                         link.sender_tensix.value().y,
+                        link.receiver_tensix.value().x,
+                        link.receiver_tensix.value().y,
                         num_timed,
                         mean,
                         mean * cycles_to_ns,
@@ -1012,7 +1036,8 @@ int main(int argc, char** argv) {
     uint32_t num_iterations = std::stoi(argv[arg_idx++]);
 
     // Optional trailing args: sweep_cores, noc_index, receiver_noc_index
-    // sweep_cores: 0=no sweep, 1=sweep sender (receiver fixed closest), 2=sweep both
+    // sweep_cores: 0=no sweep, 1=sweep sender (receiver fixed closest),
+    //              2=sweep both, 3=sweep receiver (sender fixed closest)
     uint32_t sweep_cores = (arg_idx < (std::size_t)argc) ? std::stoi(argv[arg_idx++]) : 0;
     uint32_t noc_index = (arg_idx < (std::size_t)argc) ? std::stoi(argv[arg_idx++]) : 0;
     uint32_t receiver_noc_index = (arg_idx < (std::size_t)argc) ? std::stoi(argv[arg_idx++]) : 0;
@@ -1023,7 +1048,7 @@ int main(int argc, char** argv) {
     }
 
     log_info(tt::LogTest, "Setting up test fixture");
-    ConnectedDevicesHelper device_helper(benchmark_type_enum.value());
+    ConnectedDevicesHelper device_helper(benchmark_type_enum.value(), noc_index, receiver_noc_index);
     log_info(tt::LogTest, "Done setting up test fixture");
     if (device_helper.num_devices < 2) {
         log_info(tt::LogTest, "Need at least 2 devices to run this test");
@@ -1034,6 +1059,7 @@ int main(int argc, char** argv) {
     //   sweep_cores=0: no sweep, single run with assign_tensix defaults
     //   sweep_cores=1: sweep sender_tensix only, receiver_tensix fixed at closest-to-eth
     //   sweep_cores=2: sweep sender_tensix × receiver_tensix (N^2)
+    //   sweep_cores=3: sweep receiver_tensix only, sender_tensix fixed at closest-to-eth
     std::vector<CoreCoord> all_cores;
     std::vector<CoreCoord> sender_cores_to_test;
     std::vector<CoreCoord> receiver_cores_to_test;
@@ -1044,7 +1070,9 @@ int main(int argc, char** argv) {
 
         auto& link = *device_helper.unique_links.begin();
         TT_FATAL(link.receiver_tensix.has_value(), "Expected receiver_tensix to be assigned for sweep mode");
+        TT_FATAL(link.sender_tensix.has_value(), "Expected sender_tensix to be assigned for sweep mode");
         fixed_receiver_core = link.receiver_tensix.value();
+        CoreCoord fixed_sender_core = link.sender_tensix.value();
 
         auto grid_size = device_helper.devices[0]->compute_with_storage_grid_size();
         for (uint32_t y = 0; y < grid_size.y; y++) {
@@ -1053,9 +1081,9 @@ int main(int argc, char** argv) {
             }
         }
 
-        sender_cores_to_test = all_cores;
         if (sweep_cores == 1) {
-            // Receiver fixed at closest core to eth
+            // Sweep sender, receiver fixed at closest core to eth
+            sender_cores_to_test = all_cores;
             receiver_cores_to_test.push_back(fixed_receiver_core);
             log_info(
                 tt::LogTest,
@@ -1068,8 +1096,9 @@ int main(int argc, char** argv) {
                 fixed_receiver_core.x,
                 fixed_receiver_core.y,
                 sender_cores_to_test.size());
-        } else {
+        } else if (sweep_cores == 2) {
             // Extended: sweep both
+            sender_cores_to_test = all_cores;
             receiver_cores_to_test = all_cores;
             log_info(
                 tt::LogTest,
@@ -1079,6 +1108,21 @@ int main(int argc, char** argv) {
                 noc_index,
                 receiver_noc_index,
                 sender_cores_to_test.size() * receiver_cores_to_test.size());
+        } else if (sweep_cores == 3) {
+            // Sweep receiver, sender fixed at closest core to eth
+            sender_cores_to_test.push_back(fixed_sender_core);
+            receiver_cores_to_test = all_cores;
+            log_info(
+                tt::LogTest,
+                "Receiver sweep: grid {}x{}, sender_noc={}, receiver_noc={}, "
+                "fixed sender_tensix=({},{}), {} iterations",
+                grid_size.x,
+                grid_size.y,
+                noc_index,
+                receiver_noc_index,
+                fixed_sender_core.x,
+                fixed_sender_core.y,
+                receiver_cores_to_test.size());
         }
     } else {
         sender_cores_to_test.push_back(CoreCoord(0, 0));
@@ -1094,6 +1138,70 @@ int main(int argc, char** argv) {
     std::filesystem::remove(profiler_dir / "new_zone_src_locations.log");
 
     bool success = true;
+
+    // Print full test configuration
+    {
+        auto& link = *device_helper.unique_links.begin();
+        auto sender_noc_str = noc_index == 0 ? "NOC_0" : "NOC_1";
+        auto receiver_noc_str = receiver_noc_index == 0 ? "NOC_0" : "NOC_1";
+        log_info(tt::LogTest, "=== Test Configuration ===");
+        log_info(
+            tt::LogTest,
+            "  benchmark_type={} ({})",
+            (int)benchmark_type_enum.value(),
+            enchantum::to_string(benchmark_type_enum.value()));
+        log_info(
+            tt::LogTest,
+            "  num_packets={}, packet_size(s)={}, channel_count(s)={}, num_iterations={}",
+            num_packets,
+            packet_sizes[0],
+            channel_counts[0],
+            num_iterations);
+        log_info(
+            tt::LogTest,
+            "  sender_tensix_noc={}, receiver_tensix_noc={}, eth_noc=NOC_0 (locked)",
+            sender_noc_str,
+            receiver_noc_str);
+        log_info(
+            tt::LogTest, "  sweep_cores={}, test_latency={}, disable_trid={}", sweep_cores, test_latency, disable_trid);
+        if (link.sender_tensix.has_value()) {
+            log_info(
+                tt::LogTest,
+                "  sender: chip={} eth=({},{}), tensix=({},{})",
+                link.sender.chip,
+                link.sender.x,
+                link.sender.y,
+                link.sender_tensix.value().x,
+                link.sender_tensix.value().y);
+        } else {
+            log_info(
+                tt::LogTest,
+                "  sender: chip={} eth=({},{}), tensix=N/A",
+                link.sender.chip,
+                link.sender.x,
+                link.sender.y);
+        }
+        if (link.receiver_tensix.has_value()) {
+            log_info(
+                tt::LogTest,
+                "  receiver: chip={} eth=({},{}), tensix=({},{})",
+                link.receiver.chip,
+                link.receiver.x,
+                link.receiver.y,
+                link.receiver_tensix.value().x,
+                link.receiver_tensix.value().y);
+        } else {
+            log_info(
+                tt::LogTest,
+                "  receiver: chip={} eth=({},{}), tensix=N/A",
+                link.receiver.chip,
+                link.receiver.x,
+                link.receiver.y);
+        }
+        log_info(tt::LogTest, "  num_links={}", device_helper.unique_links.size());
+        log_info(tt::LogTest, "==========================");
+    }
+
     log_info(tt::LogTest, "STARTING");
     try {
         for (auto packet_size : packet_sizes) {

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/ethernet/test_all_ethernet_links.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/ethernet/test_all_ethernet_links.cpp
@@ -4,6 +4,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <algorithm>
+#include <cmath>
 #include <tuple>
 #include <map>
 #include <set>
@@ -53,6 +54,9 @@ struct TestParams {
     bool test_latency;
     bool disable_trid;
     uint32_t num_iterations;
+    uint32_t sweep_cores = 0;         // 0 = no sweep, 1 = sweep sender only, 2 = sweep both
+    uint32_t noc_index = 0;           // sender tensix NOC: 0 = NOC_0, 1 = NOC_1
+    uint32_t receiver_noc_index = 0;  // receiver tensix NOC: 0 = NOC_0, 1 = NOC_1
 };
 
 struct LinkStats {
@@ -172,7 +176,43 @@ public:
     size_t num_devices;
     std::set<SenderReceiverPair> unique_links;
 
+    void reassign_sender_tensix(CoreCoord logical_core) {
+        for (auto& link : unique_links) {
+            const_cast<SenderReceiverPair&>(link).sender_tensix = logical_core;
+        }
+    }
+
+    void reassign_receiver_tensix(CoreCoord logical_core) {
+        for (auto& link : unique_links) {
+            const_cast<SenderReceiverPair&>(link).receiver_tensix = logical_core;
+        }
+    }
+
+    // Reduce to a single representative link for core sweep mode.
+    // Multiple links on the same chip can't share a tensix core (CreateKernel overlap).
+    void select_single_link() {
+        if (unique_links.size() > 1) {
+            auto first = *unique_links.begin();
+            unique_links.clear();
+            unique_links.insert(first);
+            log_info(
+                tt::LogTest,
+                "Core sweep: using single link — sender chip {} eth ({},{}), receiver chip {} eth ({},{})",
+                first.sender.chip,
+                first.sender.x,
+                first.sender.y,
+                first.receiver.chip,
+                first.receiver.x,
+                first.receiver.y);
+        }
+    }
+
     void allocate_buffers(const TestParams& params) {
+        // For TensixEthEthTensixUniDir sender, allocate extra space for per-iteration timestamps
+        uint32_t sender_extra = 0;
+        if (params.benchmark_type == BenchmarkType::TensixEthEthTensixUniDir && params.num_packets > 1) {
+            sender_extra = (params.num_packets - 1) * sizeof(uint32_t);
+        }
         for (const auto& link : unique_links) {
             if (!link.sender_tensix.has_value()) {
                 continue;
@@ -181,7 +221,8 @@ public:
                 find_device_with_id(devices, link.sender.chip),
                 link.sender_tensix.value(),
                 params.packet_size,
-                params.benchmark_type);
+                params.benchmark_type,
+                sender_extra);
             link.receiver_buffer = create_tensix_buffer(
                 find_device_with_id(devices, link.receiver.chip),
                 link.receiver_tensix.value(),
@@ -239,11 +280,12 @@ private:
         tt_metal::distributed::MeshDevice* device,
         CoreCoord logical_tensix,
         uint32_t packet_size,
-        BenchmarkType benchmark_type) {
+        BenchmarkType benchmark_type,
+        uint32_t extra_bytes = 0) {
         // TensixEthEthTensixUniDir needs: landing_buffer(msg_size) + sem(4B) + pad(12B) + test_data(msg_size)
         uint32_t buffer_size = packet_size;
         if (benchmark_type == BenchmarkType::TensixEthEthTensixUniDir) {
-            buffer_size = 2 * packet_size + 16;
+            buffer_size = 2 * packet_size + 16 + extra_bytes;
         }
 
         tt_metal::ShardSpecBuffer shard_spec = tt_metal::ShardSpecBuffer(
@@ -370,6 +412,9 @@ std::vector<tt_metal::Program> build(const ConnectedDevicesHelper& device_helper
     uint32_t measurement_type = (uint32_t)(params.test_latency ? MeasurementType::Latency : MeasurementType::Bandwidth);
     uint32_t benchmark_type_val = enchantum::to_underlying(params.benchmark_type);
 
+    auto sender_noc_select = params.noc_index == 0 ? tt_metal::NOC::NOC_0 : tt_metal::NOC::NOC_1;
+    auto receiver_noc_select = params.receiver_noc_index == 0 ? tt_metal::NOC::NOC_0 : tt_metal::NOC::NOC_1;
+
     // eth core ct args
     const std::vector<uint32_t>& eth_ct_args = {
         benchmark_type_val, measurement_type, params.num_buffer_slots, uint32_t(params.disable_trid)};
@@ -439,6 +484,7 @@ std::vector<tt_metal::Program> build(const ConnectedDevicesHelper& device_helper
             // --- Sender chip: ERISC_0 = forward sender (region A), ERISC_1 = reverse receiver (region B) ---
             auto sender_fwd_rt_args = eth_sender_rt_args;
             sender_fwd_rt_args.push_back(0);  // buffer_offset = 0 (region A)
+            sender_fwd_rt_args.push_back(1);  // is_handshake_sender = true
             auto sender_fwd_kernel = tt_metal::CreateKernel(
                 sender_program,
                 sender_kernel_path,
@@ -469,6 +515,7 @@ std::vector<tt_metal::Program> build(const ConnectedDevicesHelper& device_helper
             sender_rev_rt_args[sender_rev_rt_args.size() - 2] = receiver_encoding;
             sender_rev_rt_args[sender_rev_rt_args.size() - 1] = sender_encoding;
             sender_rev_rt_args.push_back(buf_region_size);  // buffer_offset (region B)
+            sender_rev_rt_args.push_back(0);                // is_handshake_sender = false (receiver side of handshake)
             auto sender_rev_kernel = tt_metal::CreateKernel(
                 receiver_program,
                 sender_kernel_path,
@@ -536,11 +583,12 @@ std::vector<tt_metal::Program> build(const ConnectedDevicesHelper& device_helper
                 link.sender_tensix.value(),
                 tt_metal::DataMovementConfig{
                     .processor = tt_metal::DataMovementProcessor::RISCV_0,
-                    .noc = tt_metal::NOC::RISCV_0_default,
+                    .noc = sender_noc_select,
                     .compile_args = {1}});
             // RT args: eth_noc_x, eth_noc_y, eth_slot_addr, eth_push_counter_addr,
             //          local_sem_addr, local_data_addr, num_messages, message_size,
-            //          sender_encoding, receiver_encoding
+            //          sender_encoding, receiver_encoding, timestamp_buf_addr
+            uint32_t timestamp_buf_addr = link.sender_buffer->address() + 2 * params.packet_size + 16;
             tt_metal::SetRuntimeArgs(
                 sender_program,
                 sender_tensix_kernel,
@@ -554,7 +602,8 @@ std::vector<tt_metal::Program> build(const ConnectedDevicesHelper& device_helper
                  params.num_packets,
                  params.packet_size,
                  sender_encoding,
-                 receiver_encoding});
+                 receiver_encoding,
+                 timestamp_buf_addr});
 
             // Receiver tensix kernel (echo): is_initiator = 0
             auto receiver_tensix_kernel = tt_metal::CreateKernel(
@@ -564,7 +613,7 @@ std::vector<tt_metal::Program> build(const ConnectedDevicesHelper& device_helper
                 link.receiver_tensix.value(),
                 tt_metal::DataMovementConfig{
                     .processor = tt_metal::DataMovementProcessor::RISCV_0,
-                    .noc = tt_metal::NOC::RISCV_0_default,
+                    .noc = receiver_noc_select,
                     .compile_args = {0}});
             tt_metal::SetRuntimeArgs(
                 receiver_program,
@@ -864,6 +913,67 @@ void run(
                     link.sender_buffer->address());
                 bool pass = golden_vec == result_vec;
                 TT_FATAL(pass, "TensixEthEthTensixUniDir validation failed on sender tensix landing buffer");
+
+                // Read per-iteration timestamps from sender tensix L1
+                if (params.num_packets > 1) {
+                    uint32_t num_timed = params.num_packets - 1;  // warmup excluded
+                    uint32_t ts_buf_addr = link.sender_buffer->address() + 2 * params.packet_size + 16;
+                    std::vector<uint32_t> timestamps(num_timed, 0);
+                    tt::tt_metal::MetalContext::instance().get_cluster().read_core(
+                        timestamps.data(),
+                        num_timed * sizeof(uint32_t),
+                        tt_cxy_pair(link.sender.chip, virtual_tensix),
+                        ts_buf_addr);
+
+                    // Compute stats
+                    uint64_t sum = 0;
+                    uint32_t min_val = UINT32_MAX;
+                    uint32_t max_val = 0;
+                    for (uint32_t i = 0; i < num_timed; i++) {
+                        sum += timestamps[i];
+                        min_val = std::min(min_val, timestamps[i]);
+                        max_val = std::max(max_val, timestamps[i]);
+                    }
+                    double mean = static_cast<double>(sum) / num_timed;
+                    double var = 0;
+                    for (uint32_t i = 0; i < num_timed; i++) {
+                        double diff = timestamps[i] - mean;
+                        var += diff * diff;
+                    }
+                    double stddev = std::sqrt(var / num_timed);
+
+                    // BH clock is 1350 MHz -> 1 cycle = 1/1.35 ns ≈ 0.7407 ns
+                    double cycles_to_ns = 1000.0 / 1350.0;
+                    log_info(
+                        tt::LogTest,
+                        "Timestamps: sender_tensix=({},{}), num_iters={}, "
+                        "mean={:.1f} cycles ({:.1f} ns), min={} cycles ({:.1f} ns), "
+                        "max={} cycles ({:.1f} ns), stddev={:.1f} cycles",
+                        link.sender_tensix.value().x,
+                        link.sender_tensix.value().y,
+                        num_timed,
+                        mean,
+                        mean * cycles_to_ns,
+                        min_val,
+                        min_val * cycles_to_ns,
+                        max_val,
+                        max_val * cycles_to_ns,
+                        stddev);
+
+                    // Print first few individual timestamps for inspection
+                    uint32_t print_count = std::min(num_timed, 10u);
+                    std::string ts_str;
+                    for (uint32_t i = 0; i < print_count; i++) {
+                        if (i > 0) {
+                            ts_str += ", ";
+                        }
+                        ts_str += std::to_string(timestamps[i]);
+                    }
+                    if (num_timed > print_count) {
+                        ts_str += ", ...";
+                    }
+                    log_info(tt::LogTest, "  Per-iteration cycles: [{}]", ts_str);
+                }
             } break;
             case BenchmarkType::DualEriscBiDir: {
                 validation(device_helper, link, params.packet_size, true);
@@ -883,7 +993,7 @@ std::vector<uint32_t> parse_csv_u32(const char* s) {
     return result;
 }
 
-int main(int /*argc*/, char** argv) {
+int main(int argc, char** argv) {
     std::size_t arg_idx = 1;
     uint32_t benchmark_type = (uint32_t)std::stoi(argv[arg_idx++]);
 
@@ -901,6 +1011,12 @@ int main(int /*argc*/, char** argv) {
     bool disable_trid = std::stoi(argv[arg_idx++]);
     uint32_t num_iterations = std::stoi(argv[arg_idx++]);
 
+    // Optional trailing args: sweep_cores, noc_index, receiver_noc_index
+    // sweep_cores: 0=no sweep, 1=sweep sender (receiver fixed closest), 2=sweep both
+    uint32_t sweep_cores = (arg_idx < (std::size_t)argc) ? std::stoi(argv[arg_idx++]) : 0;
+    uint32_t noc_index = (arg_idx < (std::size_t)argc) ? std::stoi(argv[arg_idx++]) : 0;
+    uint32_t receiver_noc_index = (arg_idx < (std::size_t)argc) ? std::stoi(argv[arg_idx++]) : 0;
+
     if (benchmark_type_enum.value() == BenchmarkType::DualEriscBiDir) {
         auto arch = tt::get_arch_from_string(tt::test_utils::get_umd_arch_name());
         TT_FATAL(arch == tt::ARCH::BLACKHOLE, "DualEriscBiDir mode requires Blackhole (2 ERISCs per eth core)");
@@ -914,48 +1030,135 @@ int main(int /*argc*/, char** argv) {
         return 0;
     }
 
+    // Build core lists for sweep modes:
+    //   sweep_cores=0: no sweep, single run with assign_tensix defaults
+    //   sweep_cores=1: sweep sender_tensix only, receiver_tensix fixed at closest-to-eth
+    //   sweep_cores=2: sweep sender_tensix × receiver_tensix (N^2)
+    std::vector<CoreCoord> all_cores;
+    std::vector<CoreCoord> sender_cores_to_test;
+    std::vector<CoreCoord> receiver_cores_to_test;
+    CoreCoord fixed_receiver_core(0, 0);
+
+    if (sweep_cores > 0) {
+        device_helper.select_single_link();
+
+        auto& link = *device_helper.unique_links.begin();
+        TT_FATAL(link.receiver_tensix.has_value(), "Expected receiver_tensix to be assigned for sweep mode");
+        fixed_receiver_core = link.receiver_tensix.value();
+
+        auto grid_size = device_helper.devices[0]->compute_with_storage_grid_size();
+        for (uint32_t y = 0; y < grid_size.y; y++) {
+            for (uint32_t x = 0; x < grid_size.x; x++) {
+                all_cores.push_back(CoreCoord(x, y));
+            }
+        }
+
+        sender_cores_to_test = all_cores;
+        if (sweep_cores == 1) {
+            // Receiver fixed at closest core to eth
+            receiver_cores_to_test.push_back(fixed_receiver_core);
+            log_info(
+                tt::LogTest,
+                "Sender sweep: grid {}x{}, sender_noc={}, receiver_noc={}, "
+                "fixed receiver_tensix=({},{}), {} iterations",
+                grid_size.x,
+                grid_size.y,
+                noc_index,
+                receiver_noc_index,
+                fixed_receiver_core.x,
+                fixed_receiver_core.y,
+                sender_cores_to_test.size());
+        } else {
+            // Extended: sweep both
+            receiver_cores_to_test = all_cores;
+            log_info(
+                tt::LogTest,
+                "Extended sweep: grid {}x{}, sender_noc={}, receiver_noc={}, {} iterations",
+                grid_size.x,
+                grid_size.y,
+                noc_index,
+                receiver_noc_index,
+                sender_cores_to_test.size() * receiver_cores_to_test.size());
+        }
+    } else {
+        sender_cores_to_test.push_back(CoreCoord(0, 0));
+        receiver_cores_to_test.push_back(CoreCoord(0, 0));
+    }
+
     std::filesystem::path profiler_dir = std::filesystem::path(tt::tt_metal::get_profiler_logs_dir());
     std::filesystem::path profiler_log = profiler_dir / DEVICE_SIDE_LOG;
+
+    // Clear persistent zone source location logs to prevent 16-bit hash collisions
+    // from entries accumulated across previous runs
+    std::filesystem::remove(profiler_dir / "zone_src_locations.log");
+    std::filesystem::remove(profiler_dir / "new_zone_src_locations.log");
 
     bool success = true;
     log_info(tt::LogTest, "STARTING");
     try {
         for (auto packet_size : packet_sizes) {
             for (auto num_buffer_slots : channel_counts) {
-                TestParams params{
-                    .benchmark_type = benchmark_type_enum.value(),
-                    .num_packets = num_packets,
-                    .packet_size = packet_size,
-                    .num_buffer_slots = num_buffer_slots,
-                    .test_latency = test_latency,
-                    .disable_trid = disable_trid,
-                    .num_iterations = num_iterations};
+                size_t total_iterations = sender_cores_to_test.size() * receiver_cores_to_test.size();
+                size_t iteration = 0;
+                for (auto& sender_core : sender_cores_to_test) {
+                    for (auto& receiver_core : receiver_cores_to_test) {
+                        iteration++;
 
-                log_info(
-                    tt::LogTest,
-                    "benchmark type: {}, measurement type: {}, num_packets: {}, packet_size: {} B, num_buffer_slots: "
-                    "{}",
-                    enchantum::to_string(benchmark_type_enum.value()),
-                    enchantum::to_string(test_latency ? MeasurementType::Latency : MeasurementType::Bandwidth),
-                    num_packets,
-                    packet_size,
-                    num_buffer_slots);
+                        if (sweep_cores > 0) {
+                            device_helper.reassign_sender_tensix(sender_core);
+                            device_helper.reassign_receiver_tensix(receiver_core);
+                            log_info(
+                                tt::LogTest,
+                                "Core sweep: sender_tensix=({}, {}), receiver_tensix=({}, {}), {}/{}",
+                                sender_core.x,
+                                sender_core.y,
+                                receiver_core.x,
+                                receiver_core.y,
+                                iteration,
+                                total_iterations);
+                        }
 
-                // Clear profiler CSV before this sub-run (it appends)
-                std::filesystem::remove(profiler_log);
+                        TestParams params{
+                            .benchmark_type = benchmark_type_enum.value(),
+                            .num_packets = num_packets,
+                            .packet_size = packet_size,
+                            .num_buffer_slots = num_buffer_slots,
+                            .test_latency = test_latency,
+                            .disable_trid = disable_trid,
+                            .num_iterations = num_iterations,
+                            .sweep_cores = sweep_cores,
+                            .noc_index = noc_index,
+                            .receiver_noc_index = receiver_noc_index};
 
-                device_helper.allocate_buffers(params);
-                auto programs = build(device_helper, params);
-                run(device_helper, programs, params);
+                        // Clear profiler CSV before this sub-run (it appends)
+                        std::filesystem::remove(profiler_log);
 
-                // Rename profiler CSV to config-specific name
-                auto config_log =
-                    profiler_dir / fmt::format("profile_log_device_ps{}_ch{}.csv", packet_size, num_buffer_slots);
-                if (std::filesystem::exists(profiler_log)) {
-                    std::filesystem::rename(profiler_log, config_log);
+                        device_helper.allocate_buffers(params);
+                        auto programs = build(device_helper, params);
+                        run(device_helper, programs, params);
+
+                        // Rename profiler CSV: include sender and receiver coords when sweeping
+                        std::filesystem::path config_log;
+                        if (sweep_cores > 0) {
+                            config_log = profiler_dir / fmt::format(
+                                                            "profile_log_device_ps{}_ch{}_s{}_{}_r{}_{}.csv",
+                                                            packet_size,
+                                                            num_buffer_slots,
+                                                            sender_core.x,
+                                                            sender_core.y,
+                                                            receiver_core.x,
+                                                            receiver_core.y);
+                        } else {
+                            config_log = profiler_dir /
+                                         fmt::format("profile_log_device_ps{}_ch{}.csv", packet_size, num_buffer_slots);
+                        }
+                        if (std::filesystem::exists(profiler_log)) {
+                            std::filesystem::rename(profiler_log, config_log);
+                        }
+
+                        device_helper.clear_buffers();
+                    }
                 }
-
-                device_helper.clear_buffers();
             }
         }
     } catch (std::exception& e) {

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/ethernet/test_all_ethernet_links.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/ethernet/test_all_ethernet_links.cpp
@@ -10,7 +10,9 @@
 #include <vector>
 #include <queue>
 #include <optional>
+#include <filesystem>
 #include <fstream>
+#include <sstream>
 
 #include <umd/device/types/arch.hpp>
 #include <tt-metalium/mesh_device.hpp>
@@ -73,8 +75,8 @@ struct SenderReceiverPair {
     std::optional<CoreCoord> sender_tensix = std::nullopt;
     std::optional<CoreCoord> receiver_tensix = std::nullopt;
 
-    std::shared_ptr<tt_metal::distributed::MeshBuffer> sender_buffer = nullptr;
-    std::shared_ptr<tt_metal::distributed::MeshBuffer> receiver_buffer = nullptr;
+    mutable std::shared_ptr<tt_metal::distributed::MeshBuffer> sender_buffer = nullptr;
+    mutable std::shared_ptr<tt_metal::distributed::MeshBuffer> receiver_buffer = nullptr;
 
     bool operator==(const SenderReceiverPair& other) const {
         bool same_s_r = sender.chip == other.sender.chip && sender.x == other.sender.x && sender.y == other.sender.y &&
@@ -124,7 +126,7 @@ private:
     std::map<ChipId, tt_metal::IDevice*> devices_map;
 
 public:
-    ConnectedDevicesHelper(const TestParams& params) {
+    ConnectedDevicesHelper(BenchmarkType benchmark_type) {
         this->arch = tt::get_arch_from_string(tt::test_utils::get_umd_arch_name());
 
         this->num_devices = tt::tt_metal::GetNumAvailableDevices();
@@ -144,7 +146,7 @@ public:
             this->devices.push_back(device);
         }
 
-        this->initialize_sender_receiver_pairs(params);
+        this->initialize_sender_receiver_pairs(benchmark_type);
         device_open_ = true;
     }
 
@@ -170,16 +172,39 @@ public:
     size_t num_devices;
     std::set<SenderReceiverPair> unique_links;
 
-private:
-    // NOLINTBEGIN(readability-make-member-function-const)
-    std::pair<std::optional<CoreCoord>, std::shared_ptr<tt_metal::distributed::MeshBuffer>>
-    assign_tensix_and_allocate_buffer(const TestParams& params, const tt_cxy_pair& logical_eth_core) {
-        if (params.benchmark_type != BenchmarkType::EthEthTensixUniDir and
-            params.benchmark_type != BenchmarkType::EthEthTensixBiDir) {
-            return {std::nullopt, nullptr};
+    void allocate_buffers(const TestParams& params) {
+        for (const auto& link : unique_links) {
+            if (!link.sender_tensix.has_value()) {
+                continue;
+            }
+            link.sender_buffer = create_tensix_buffer(
+                find_device_with_id(devices, link.sender.chip),
+                link.sender_tensix.value(),
+                params.packet_size,
+                params.benchmark_type);
+            link.receiver_buffer = create_tensix_buffer(
+                find_device_with_id(devices, link.receiver.chip),
+                link.receiver_tensix.value(),
+                params.packet_size,
+                params.benchmark_type);
         }
-        static std::unordered_map<ChipId, std::unordered_set<CoreCoord>> assigned_tensix_per_chip;
-        auto& assigned_phys_tensix = assigned_tensix_per_chip[logical_eth_core.chip];
+    }
+
+    void clear_buffers() {
+        for (const auto& link : unique_links) {
+            link.sender_buffer = nullptr;
+            link.receiver_buffer = nullptr;
+        }
+    }
+
+private:
+    std::optional<CoreCoord> assign_tensix(BenchmarkType benchmark_type, const tt_cxy_pair& logical_eth_core) {
+        if (benchmark_type != BenchmarkType::EthEthTensixUniDir and
+            benchmark_type != BenchmarkType::EthEthTensixBiDir and
+            benchmark_type != BenchmarkType::TensixEthEthTensixUniDir) {
+            return std::nullopt;
+        }
+        auto& assigned_phys_tensix = assigned_tensix_per_chip_[logical_eth_core.chip];
         const auto& soc_d = tt::tt_metal::MetalContext::instance().get_cluster().get_soc_desc(logical_eth_core.chip);
 
         auto physical_eth_core =
@@ -207,30 +232,40 @@ private:
         auto logical_tensix = soc_d.translate_coord_to(
             {closest_phys_tensix.value(), CoreType::TENSIX, CoordSystem::NOC0}, CoordSystem::LOGICAL);
 
+        return logical_tensix;
+    }
+
+    static std::shared_ptr<tt_metal::distributed::MeshBuffer> create_tensix_buffer(
+        tt_metal::distributed::MeshDevice* device,
+        CoreCoord logical_tensix,
+        uint32_t packet_size,
+        BenchmarkType benchmark_type) {
+        // TensixEthEthTensixUniDir needs: landing_buffer(msg_size) + sem(4B) + pad(12B) + test_data(msg_size)
+        uint32_t buffer_size = packet_size;
+        if (benchmark_type == BenchmarkType::TensixEthEthTensixUniDir) {
+            buffer_size = 2 * packet_size + 16;
+        }
+
         tt_metal::ShardSpecBuffer shard_spec = tt_metal::ShardSpecBuffer(
             CoreRangeSet(std::set<CoreRange>({CoreRange(logical_tensix)})),
-            {1, params.packet_size},
+            {1, buffer_size},
             tt_metal::ShardOrientation::ROW_MAJOR,
-            {1, params.packet_size},
-            {1, params.packet_size});
+            {1, buffer_size},
+            {1, buffer_size});
 
         tt_metal::distributed::DeviceLocalBufferConfig device_local_config{
-            .page_size = params.packet_size,
+            .page_size = buffer_size,
             .buffer_type = tt_metal::BufferType::L1,
             .sharding_args = tt_metal::BufferShardingArgs(shard_spec, tt_metal::TensorMemoryLayout::HEIGHT_SHARDED),
             .bottom_up = false};
 
         tt_metal::distributed::ReplicatedBufferConfig global_buffer_config{
-            .size = params.packet_size,
+            .size = buffer_size,
         };
-        auto* device = find_device_with_id(this->devices, logical_eth_core.chip);
-        auto buffer = tt_metal::distributed::MeshBuffer::create(global_buffer_config, device_local_config, device);
-
-        return std::make_pair(logical_tensix, std::move(buffer));
+        return tt_metal::distributed::MeshBuffer::create(global_buffer_config, device_local_config, device);
     }
-    // NOLINTEND(readability-make-member-function-const)
 
-    void initialize_sender_receiver_pairs(const TestParams& params) {
+    void initialize_sender_receiver_pairs(BenchmarkType benchmark_type) {
         // chip id -> active eth ch on chip -> (connected chip, remote active eth ch)
         auto all_eth_connections = tt::tt_metal::MetalContext::instance().get_cluster().get_ethernet_connections();
 
@@ -307,20 +342,18 @@ private:
                     tt::tt_metal::MetalContext::instance().get_cluster().get_connected_ethernet_core(
                         std::make_tuple(sender_chip_id, logical_active_eth));
                 auto receiver_eth = tt_cxy_pair(std::get<0>(receiver_eth_tuple), std::get<1>(receiver_eth_tuple));
-                const auto& [sender_tensix, sender_buffer] = assign_tensix_and_allocate_buffer(params, sender_eth);
-                const auto& [receiver_tensix, receiver_buffer] =
-                    assign_tensix_and_allocate_buffer(params, receiver_eth);
+                auto sender_tensix = assign_tensix(benchmark_type, sender_eth);
+                auto receiver_tensix = assign_tensix(benchmark_type, receiver_eth);
                 this->unique_links.insert(SenderReceiverPair{
                     .sender = sender_eth,
                     .receiver = receiver_eth,
                     .sender_tensix = sender_tensix,
-                    .receiver_tensix = receiver_tensix,
-                    .sender_buffer = sender_buffer,
-                    .receiver_buffer = receiver_buffer});
+                    .receiver_tensix = receiver_tensix});
             }
         }
     }
 
+    std::unordered_map<ChipId, std::unordered_set<CoreCoord>> assigned_tensix_per_chip_;
     bool device_open_ = false;
 };
 // NOLINTEND(cppcoreguidelines-prefer-member-initializer)
@@ -389,23 +422,163 @@ std::vector<tt_metal::Program> build(const ConnectedDevicesHelper& device_helper
         eth_sender_rt_args[eth_sender_rt_args.size() - 2] = sender_encoding;
         eth_sender_rt_args[eth_sender_rt_args.size() - 1] = receiver_encoding;
 
-        auto sender_kernel = tt_metal::CreateKernel(
-            sender_program,
+        const std::string sender_kernel_path =
             "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/erisc/"
-            "ethernet_write_worker_latency_ubench_sender.cpp",
-            CoreCoord(link.sender.x, link.sender.y),
-            tt_metal::EthernetConfig{.noc = tt_metal::NOC::RISCV_0_default, .compile_args = eth_ct_args});
-        tt_metal::SetRuntimeArgs(
-            sender_program, sender_kernel, CoreCoord(link.sender.x, link.sender.y), eth_sender_rt_args);
+            "ethernet_write_worker_latency_ubench_sender.cpp";
+        const std::string receiver_kernel_path =
+            "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/erisc/"
+            "ethernet_write_worker_latency_ubench_receiver.cpp";
 
-        auto receiver_kernel = tt_metal::CreateKernel(
-            receiver_program,
-            "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/erisc/"
-            "ethernet_write_worker_latency_ubench_receiver.cpp",
-            CoreCoord(link.receiver.x, link.receiver.y),
-            tt_metal::EthernetConfig{.noc = tt_metal::NOC::RISCV_0_default, .compile_args = eth_ct_args});
-        tt_metal::SetRuntimeArgs(
-            receiver_program, receiver_kernel, CoreCoord(link.receiver.x, link.receiver.y), eth_receiver_rt_args);
+        if (params.benchmark_type == BenchmarkType::DualEriscBiDir) {
+            // Dual-ERISC bi-directional: ERISC_0 = sender, ERISC_1 = receiver on each eth core.
+            // Memory layout: [sync_struct(16B)][region_A: N * msg_size][region_B: N * msg_size]
+            // Sender chip: ERISC_0 offset=0 (region A sends), ERISC_1 offset=buf_region_size (region B receives)
+            // Receiver chip: ERISC_0 offset=buf_region_size (region B sends), ERISC_1 offset=0 (region A receives)
+            uint32_t buf_region_size = params.num_buffer_slots * params.packet_size;
+
+            // --- Sender chip: ERISC_0 = forward sender (region A), ERISC_1 = reverse receiver (region B) ---
+            auto sender_fwd_rt_args = eth_sender_rt_args;
+            sender_fwd_rt_args.push_back(0);  // buffer_offset = 0 (region A)
+            auto sender_fwd_kernel = tt_metal::CreateKernel(
+                sender_program,
+                sender_kernel_path,
+                CoreCoord(link.sender.x, link.sender.y),
+                tt_metal::EthernetConfig{
+                    .noc = tt_metal::NOC::NOC_0,
+                    .processor = tt_metal::DataMovementProcessor::RISCV_0,
+                    .compile_args = eth_ct_args});
+            tt_metal::SetRuntimeArgs(
+                sender_program, sender_fwd_kernel, CoreCoord(link.sender.x, link.sender.y), sender_fwd_rt_args);
+
+            auto recv_rev_rt_args = eth_receiver_rt_args;
+            recv_rev_rt_args.push_back(buf_region_size);  // buffer_offset (region B)
+            auto recv_rev_kernel = tt_metal::CreateKernel(
+                sender_program,
+                receiver_kernel_path,
+                CoreCoord(link.sender.x, link.sender.y),
+                tt_metal::EthernetConfig{
+                    .noc = tt_metal::NOC::NOC_1,
+                    .processor = tt_metal::DataMovementProcessor::RISCV_1,
+                    .compile_args = eth_ct_args});
+            tt_metal::SetRuntimeArgs(
+                sender_program, recv_rev_kernel, CoreCoord(link.sender.x, link.sender.y), recv_rev_rt_args);
+
+            // --- Receiver chip: ERISC_0 = reverse sender (region B), ERISC_1 = forward receiver (region A) ---
+            // Reverse sender uses swapped encoding (receiver's perspective as sender)
+            auto sender_rev_rt_args = eth_sender_rt_args;
+            sender_rev_rt_args[sender_rev_rt_args.size() - 2] = receiver_encoding;
+            sender_rev_rt_args[sender_rev_rt_args.size() - 1] = sender_encoding;
+            sender_rev_rt_args.push_back(buf_region_size);  // buffer_offset (region B)
+            auto sender_rev_kernel = tt_metal::CreateKernel(
+                receiver_program,
+                sender_kernel_path,
+                CoreCoord(link.receiver.x, link.receiver.y),
+                tt_metal::EthernetConfig{
+                    .noc = tt_metal::NOC::NOC_0,
+                    .processor = tt_metal::DataMovementProcessor::RISCV_0,
+                    .compile_args = eth_ct_args});
+            tt_metal::SetRuntimeArgs(
+                receiver_program, sender_rev_kernel, CoreCoord(link.receiver.x, link.receiver.y), sender_rev_rt_args);
+
+            auto recv_fwd_rt_args = eth_receiver_rt_args;
+            recv_fwd_rt_args.push_back(0);  // buffer_offset = 0 (region A)
+            auto recv_fwd_kernel = tt_metal::CreateKernel(
+                receiver_program,
+                receiver_kernel_path,
+                CoreCoord(link.receiver.x, link.receiver.y),
+                tt_metal::EthernetConfig{
+                    .noc = tt_metal::NOC::NOC_1,
+                    .processor = tt_metal::DataMovementProcessor::RISCV_1,
+                    .compile_args = eth_ct_args});
+            tt_metal::SetRuntimeArgs(
+                receiver_program, recv_fwd_kernel, CoreCoord(link.receiver.x, link.receiver.y), recv_fwd_rt_args);
+        } else {
+            auto sender_kernel = tt_metal::CreateKernel(
+                sender_program,
+                sender_kernel_path,
+                CoreCoord(link.sender.x, link.sender.y),
+                tt_metal::EthernetConfig{.noc = tt_metal::NOC::RISCV_0_default, .compile_args = eth_ct_args});
+            tt_metal::SetRuntimeArgs(
+                sender_program, sender_kernel, CoreCoord(link.sender.x, link.sender.y), eth_sender_rt_args);
+
+            auto receiver_kernel = tt_metal::CreateKernel(
+                receiver_program,
+                receiver_kernel_path,
+                CoreCoord(link.receiver.x, link.receiver.y),
+                tt_metal::EthernetConfig{.noc = tt_metal::NOC::RISCV_0_default, .compile_args = eth_ct_args});
+            tt_metal::SetRuntimeArgs(
+                receiver_program, receiver_kernel, CoreCoord(link.receiver.x, link.receiver.y), eth_receiver_rt_args);
+        }
+
+        // Create Tensix DataMovement kernels for TensixEthEthTensixUniDir
+        if (params.benchmark_type == BenchmarkType::TensixEthEthTensixUniDir && link.sender_tensix.has_value()) {
+            uint32_t eth_unreserved_base = tt_metal::MetalContext::instance().hal().get_dev_addr(
+                tt_metal::HalProgrammableCoreType::ACTIVE_ETH, tt_metal::HalL1MemAddrType::UNRESERVED);
+            uint32_t eth_slot_addr = eth_unreserved_base + sizeof(eth_buffer_slot_sync_t);
+            uint32_t push_counter_addr = eth_slot_addr + params.packet_size;
+
+            // Sender tensix: virtual coords of sender eth core
+            auto virtual_sender_eth =
+                sender_device->virtual_core_from_logical_core(CoreCoord(link.sender.x, link.sender.y), CoreType::ETH);
+            // Receiver tensix: virtual coords of receiver eth core
+            auto virtual_receiver_eth = receiver_device->virtual_core_from_logical_core(
+                CoreCoord(link.receiver.x, link.receiver.y), CoreType::ETH);
+
+            // Tensix buffer layout: [landing_buffer(msg_size)][tensix_sem(4B)][pad(12B)][test_data(msg_size)]
+            uint32_t sender_tensix_sem_addr = link.sender_buffer->address() + params.packet_size;
+            uint32_t receiver_tensix_sem_addr = link.receiver_buffer->address() + params.packet_size;
+
+            // Sender tensix kernel (initiator): is_initiator = 1
+            auto sender_tensix_kernel = tt_metal::CreateKernel(
+                sender_program,
+                "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/erisc/"
+                "tensix_eth_datacopy_worker.cpp",
+                link.sender_tensix.value(),
+                tt_metal::DataMovementConfig{
+                    .processor = tt_metal::DataMovementProcessor::RISCV_0,
+                    .noc = tt_metal::NOC::RISCV_0_default,
+                    .compile_args = {1}});
+            // RT args: eth_noc_x, eth_noc_y, eth_slot_addr, eth_push_counter_addr,
+            //          local_sem_addr, local_data_addr, num_messages, message_size,
+            //          sender_encoding, receiver_encoding
+            tt_metal::SetRuntimeArgs(
+                sender_program,
+                sender_tensix_kernel,
+                link.sender_tensix.value(),
+                {virtual_sender_eth.x,
+                 virtual_sender_eth.y,
+                 eth_slot_addr,
+                 push_counter_addr,
+                 sender_tensix_sem_addr,
+                 link.sender_buffer->address(),
+                 params.num_packets,
+                 params.packet_size,
+                 sender_encoding,
+                 receiver_encoding});
+
+            // Receiver tensix kernel (echo): is_initiator = 0
+            auto receiver_tensix_kernel = tt_metal::CreateKernel(
+                receiver_program,
+                "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/erisc/"
+                "tensix_eth_datacopy_worker.cpp",
+                link.receiver_tensix.value(),
+                tt_metal::DataMovementConfig{
+                    .processor = tt_metal::DataMovementProcessor::RISCV_0,
+                    .noc = tt_metal::NOC::RISCV_0_default,
+                    .compile_args = {0}});
+            tt_metal::SetRuntimeArgs(
+                receiver_program,
+                receiver_tensix_kernel,
+                link.receiver_tensix.value(),
+                {virtual_receiver_eth.x,
+                 virtual_receiver_eth.y,
+                 eth_slot_addr,
+                 push_counter_addr,
+                 receiver_tensix_sem_addr,
+                 link.receiver_buffer->address(),
+                 params.num_packets,
+                 params.packet_size});
+        }
     }
 
     // Compile all programs
@@ -645,8 +818,11 @@ void run(
     }
 
     for (const auto& link : device_helper.unique_links) {
-        // Only read profiler results from sender
+        // Read profiler results from sender (and also receiver for DualEriscBiDir since both have sender kernels)
         tt_metal::ReadMeshDeviceProfilerResults(*find_device_with_id(device_helper.devices, link.sender.chip));
+        if (params.benchmark_type == BenchmarkType::DualEriscBiDir) {
+            tt_metal::ReadMeshDeviceProfilerResults(*find_device_with_id(device_helper.devices, link.receiver.chip));
+        }
 
         switch (params.benchmark_type) {
             case BenchmarkType::EthOnlyUniDir:
@@ -671,9 +847,40 @@ void run(
                     validation(device_helper, link, params.packet_size, false, true);
                 }
             } break;
+            case BenchmarkType::TensixEthEthTensixUniDir: {
+                // Validate that sender tensix landing_buffer has the echoed iota pattern
+                TT_FATAL(link.sender_buffer != nullptr, "Expected sender tensix to have allocated buffer");
+                // Read directly from sender tensix L1 (landing_buffer is at offset 0 in the MeshBuffer)
+                auto* device = find_device_with_id(device_helper.devices, link.sender.chip);
+                auto virtual_tensix =
+                    device->virtual_core_from_logical_core(link.sender_tensix.value(), CoreType::WORKER);
+                std::vector<uint8_t> golden_vec(params.packet_size);
+                std::iota(std::begin(golden_vec), std::end(golden_vec), 0);
+                std::vector<uint8_t> result_vec(params.packet_size, 0);
+                tt::tt_metal::MetalContext::instance().get_cluster().read_core(
+                    result_vec.data(),
+                    params.packet_size,
+                    tt_cxy_pair(link.sender.chip, virtual_tensix),
+                    link.sender_buffer->address());
+                bool pass = golden_vec == result_vec;
+                TT_FATAL(pass, "TensixEthEthTensixUniDir validation failed on sender tensix landing buffer");
+            } break;
+            case BenchmarkType::DualEriscBiDir: {
+                validation(device_helper, link, params.packet_size, true);
+            } break;
             default: break;
         }
     }
+}
+
+std::vector<uint32_t> parse_csv_u32(const char* s) {
+    std::vector<uint32_t> result;
+    std::stringstream ss(s);
+    std::string token;
+    while (std::getline(ss, token, ',')) {
+        result.push_back(std::stoul(token));
+    }
+    return result;
 }
 
 int main(int /*argc*/, char** argv) {
@@ -686,48 +893,71 @@ int main(int /*argc*/, char** argv) {
         "Unsupported benchmark {} specified, check BenchmarkType enum for supported values",
         benchmark_type);
 
-    std::size_t num_packets = std::stoi(argv[arg_idx++]);
-    std::size_t packet_size = std::stoi(argv[arg_idx++]);
-    std::size_t num_buffer_slots = std::stoi(argv[arg_idx++]);
+    uint32_t num_packets = std::stoi(argv[arg_idx++]);
+    auto packet_sizes = parse_csv_u32(argv[arg_idx++]);
+    auto channel_counts = parse_csv_u32(argv[arg_idx++]);
 
     bool test_latency = std::stoi(argv[arg_idx++]);
     bool disable_trid = std::stoi(argv[arg_idx++]);
     uint32_t num_iterations = std::stoi(argv[arg_idx++]);
 
-    TestParams params{
-        .benchmark_type = benchmark_type_enum.value(),
-        .num_packets = num_packets,
-        .packet_size = packet_size,
-        .num_buffer_slots = num_buffer_slots,
-        .test_latency = test_latency,
-        .disable_trid = disable_trid,
-        .num_iterations = num_iterations};
+    if (benchmark_type_enum.value() == BenchmarkType::DualEriscBiDir) {
+        auto arch = tt::get_arch_from_string(tt::test_utils::get_umd_arch_name());
+        TT_FATAL(arch == tt::ARCH::BLACKHOLE, "DualEriscBiDir mode requires Blackhole (2 ERISCs per eth core)");
+    }
 
     log_info(tt::LogTest, "Setting up test fixture");
-    ConnectedDevicesHelper device_helper(params);
+    ConnectedDevicesHelper device_helper(benchmark_type_enum.value());
     log_info(tt::LogTest, "Done setting up test fixture");
     if (device_helper.num_devices < 2) {
         log_info(tt::LogTest, "Need at least 2 devices to run this test");
         return 0;
     }
 
-    // Add more configurations here until proper argc parsing added
-    bool success = false;
-    success = true;
+    std::filesystem::path profiler_dir = std::filesystem::path(tt::tt_metal::get_profiler_logs_dir());
+    std::filesystem::path profiler_log = profiler_dir / DEVICE_SIDE_LOG;
+
+    bool success = true;
     log_info(tt::LogTest, "STARTING");
     try {
-        log_info(
-            tt::LogTest,
-            "benchmark type: {}, measurement type: {}, num_packets: {}, packet_size: {} B, num_buffer_slots: {}",
-            enchantum::to_string(benchmark_type_enum.value()),
-            enchantum::to_string(test_latency ? MeasurementType::Latency : MeasurementType::Bandwidth),
-            num_packets,
-            packet_size,
-            num_buffer_slots);
+        for (auto packet_size : packet_sizes) {
+            for (auto num_buffer_slots : channel_counts) {
+                TestParams params{
+                    .benchmark_type = benchmark_type_enum.value(),
+                    .num_packets = num_packets,
+                    .packet_size = packet_size,
+                    .num_buffer_slots = num_buffer_slots,
+                    .test_latency = test_latency,
+                    .disable_trid = disable_trid,
+                    .num_iterations = num_iterations};
 
-        auto programs = build(device_helper, params);
-        run(device_helper, programs, params);
+                log_info(
+                    tt::LogTest,
+                    "benchmark type: {}, measurement type: {}, num_packets: {}, packet_size: {} B, num_buffer_slots: "
+                    "{}",
+                    enchantum::to_string(benchmark_type_enum.value()),
+                    enchantum::to_string(test_latency ? MeasurementType::Latency : MeasurementType::Bandwidth),
+                    num_packets,
+                    packet_size,
+                    num_buffer_slots);
 
+                // Clear profiler CSV before this sub-run (it appends)
+                std::filesystem::remove(profiler_log);
+
+                device_helper.allocate_buffers(params);
+                auto programs = build(device_helper, params);
+                run(device_helper, programs, params);
+
+                // Rename profiler CSV to config-specific name
+                auto config_log =
+                    profiler_dir / fmt::format("profile_log_device_ps{}_ch{}.csv", packet_size, num_buffer_slots);
+                if (std::filesystem::exists(profiler_log)) {
+                    std::filesystem::rename(profiler_log, config_log);
+                }
+
+                device_helper.clear_buffers();
+            }
+        }
     } catch (std::exception& e) {
         log_error(tt::LogTest, "Caught exception: {}", e.what());
         device_helper.TearDown();

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/noc/test_noc_hop_latency.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/noc/test_noc_hop_latency.cpp
@@ -1,0 +1,578 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// NOC hop latency microbenchmark.
+// Measures round-trip semaphore ping-pong latency to characterize per-hop NOC latency.
+//
+// Modes:
+//   0 = tensix-tensix: fix sender at (0,0), sweep responder across all tensix cores
+//   1 = eth-sender:    fix sender on eth core, sweep responder across all tensix cores
+//   2 = eth-receiver:  sweep sender across all tensix cores, fix responder on eth core
+//
+// Usage: test_noc_hop_latency [num_iterations] [num_warmup] [noc_index] [mode]
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <cstdlib>
+#include <fstream>
+#include <iomanip>
+#include <iostream>
+#include <map>
+#include <string>
+#include <vector>
+
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/tt_metal.hpp>
+#include <tt-metalium/core_coord.hpp>
+#include <tt-metalium/kernel_types.hpp>
+#include <tt-metalium/tt_metal_profiler.hpp>
+#include <tt-logger/tt-logger.hpp>
+#include "impl/context/metal_context.hpp"
+#include <tt-metalium/experimental/fabric/control_plane.hpp>
+#include <llrt/tt_cluster.hpp>
+
+using namespace tt;
+
+struct PingResult {
+    double mean_cycles;  // total round-trip
+    double min_cycles;
+    double max_cycles;
+    double stddev_cycles;
+    double mean_issue;  // noc_semaphore_inc issue time
+    double mean_poll;   // poll wait time
+    double stddev_issue;
+    double stddev_poll;
+    uint32_t manhattan_distance;
+    std::vector<uint32_t> raw_issue;  // per-iteration issue cycles
+    std::vector<uint32_t> raw_poll;   // per-iteration poll cycles
+};
+
+struct CoreSpec {
+    CoreCoord logical;
+    CoreType type;  // WORKER or ETH
+};
+
+PingResult run_ping_pong(
+    tt_metal::IDevice* device,
+    CoreSpec sender,
+    CoreSpec responder,
+    uint32_t num_iterations,
+    uint32_t num_warmup,
+    tt_metal::NOC sender_noc,
+    uint32_t noc_index,
+    CoreCoord noc_grid_size) {
+    tt_metal::Program program = tt_metal::CreateProgram();
+
+    auto sender_virtual = device->virtual_core_from_logical_core(sender.logical, sender.type);
+    auto responder_virtual = device->virtual_core_from_logical_core(responder.logical, responder.type);
+
+    // L1 addresses: eth uses HAL unreserved base, tensix uses high L1 (safe region above kernel data)
+    uint32_t eth_unreserved = tt_metal::MetalContext::instance().hal().get_dev_addr(
+        tt_metal::HalProgrammableCoreType::ACTIVE_ETH, tt_metal::HalL1MemAddrType::UNRESERVED);
+    constexpr uint32_t tensix_sem_base = 150 * 1024;  // 150KB — well above kernel config/stack
+
+    // 16-byte aligned addresses for NOC semaphore operations
+    auto align16 = [](uint32_t addr) { return (addr + 15) & ~15u; };
+
+    // Sender addresses
+    uint32_t sender_base = (sender.type == CoreType::ETH) ? eth_unreserved : tensix_sem_base;
+    uint32_t sender_sem_addr = align16(sender_base);
+    uint32_t timestamp_buf_addr = align16(sender_sem_addr + 16);  // semaphore is 4 bytes, pad to 16
+    // Ready semaphore: used when responder is eth so sender waits for eth to be ready
+    // Place after timestamp buffer (2 * num_iterations * 4 bytes)
+    uint32_t ready_sem_addr = (responder.type == CoreType::ETH)
+                                  ? align16(timestamp_buf_addr + 2 * num_iterations * sizeof(uint32_t))
+                                  : 0;  // 0 = no handshake
+
+    // Responder addresses
+    uint32_t responder_base = (responder.type == CoreType::ETH) ? eth_unreserved : tensix_sem_base;
+    uint32_t responder_sem_addr = align16(responder_base);
+
+    // Sender NOC: on BH, ERISC0 is locked to NOC0
+    tt_metal::NOC actual_sender_noc = sender_noc;
+    if (sender.type == CoreType::ETH) {
+        actual_sender_noc = tt_metal::NOC::NOC_0;
+    }
+
+    // Responder uses opposite NOC so both directions traverse the same physical path
+    // Exception: ERISC0 on BH is locked to NOC0
+    tt_metal::NOC responder_noc;
+    if (responder.type == CoreType::ETH) {
+        responder_noc = tt_metal::NOC::NOC_0;
+    } else {
+        responder_noc = (actual_sender_noc == tt_metal::NOC::NOC_0) ? tt_metal::NOC::NOC_1 : tt_metal::NOC::NOC_0;
+    }
+
+    // Sender kernel
+    tt_metal::KernelHandle sender_kernel;
+    if (sender.type == CoreType::ETH) {
+        sender_kernel = tt_metal::CreateKernel(
+            program,
+            "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/noc/noc_latency_ping_sender.cpp",
+            sender.logical,
+            tt_metal::EthernetConfig{.noc = tt_metal::NOC::RISCV_0_default, .compile_args = {}});
+    } else {
+        sender_kernel = tt_metal::CreateKernel(
+            program,
+            "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/noc/noc_latency_ping_sender.cpp",
+            sender.logical,
+            tt_metal::DataMovementConfig{
+                .processor = tt_metal::DataMovementProcessor::RISCV_0, .noc = actual_sender_noc});
+    }
+    tt_metal::SetRuntimeArgs(
+        program,
+        sender_kernel,
+        sender.logical,
+        {responder_virtual.x,
+         responder_virtual.y,
+         responder_sem_addr,
+         sender_sem_addr,
+         timestamp_buf_addr,
+         num_iterations,
+         num_warmup,
+         ready_sem_addr});
+
+    // Responder kernel
+    uint32_t total_pings = num_warmup + num_iterations;
+    if (responder.type == CoreType::ETH) {
+        auto responder_kernel = tt_metal::CreateKernel(
+            program,
+            "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/noc/noc_latency_ping_responder.cpp",
+            responder.logical,
+            tt_metal::EthernetConfig{.noc = tt_metal::NOC::RISCV_0_default, .compile_args = {}});
+        tt_metal::SetRuntimeArgs(
+            program,
+            responder_kernel,
+            responder.logical,
+            {sender_virtual.x, sender_virtual.y, sender_sem_addr, responder_sem_addr, total_pings, ready_sem_addr});
+    } else {
+        auto responder_kernel = tt_metal::CreateKernel(
+            program,
+            "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/noc/noc_latency_ping_responder.cpp",
+            responder.logical,
+            tt_metal::DataMovementConfig{.processor = tt_metal::DataMovementProcessor::RISCV_0, .noc = responder_noc});
+        tt_metal::SetRuntimeArgs(
+            program,
+            responder_kernel,
+            responder.logical,
+            {sender_virtual.x, sender_virtual.y, sender_sem_addr, responder_sem_addr, total_pings, 0u});
+    }
+
+    tt_metal::detail::CompileProgram(device, program);
+    tt_metal::detail::LaunchProgram(device, program);
+
+    // Read timestamps from sender L1 — pairs of [issue_time, poll_time]
+    std::vector<uint32_t> timestamps(2 * num_iterations, 0);
+    tt::tt_metal::MetalContext::instance().get_cluster().read_core(
+        timestamps.data(),
+        2 * num_iterations * sizeof(uint32_t),
+        tt_cxy_pair(device->id(), sender_virtual),
+        timestamp_buf_addr);
+
+    // Compute stats for total, issue, and poll phases
+    uint64_t sum_total = 0, sum_issue = 0, sum_poll = 0;
+    uint32_t min_val = UINT32_MAX, max_val = 0;
+    for (uint32_t i = 0; i < num_iterations; i++) {
+        uint32_t issue = timestamps[2 * i];
+        uint32_t poll = timestamps[2 * i + 1];
+        uint32_t total = issue + poll;
+        sum_total += total;
+        sum_issue += issue;
+        sum_poll += poll;
+        min_val = std::min(min_val, total);
+        max_val = std::max(max_val, total);
+    }
+    double mean_total = static_cast<double>(sum_total) / num_iterations;
+    double mean_issue = static_cast<double>(sum_issue) / num_iterations;
+    double mean_poll = static_cast<double>(sum_poll) / num_iterations;
+
+    double var_total = 0, var_issue = 0, var_poll = 0;
+    for (uint32_t i = 0; i < num_iterations; i++) {
+        uint32_t issue = timestamps[2 * i];
+        uint32_t poll = timestamps[2 * i + 1];
+        uint32_t total = issue + poll;
+        var_total += (total - mean_total) * (total - mean_total);
+        var_issue += (issue - mean_issue) * (issue - mean_issue);
+        var_poll += (poll - mean_poll) * (poll - mean_poll);
+    }
+    double stddev_total = std::sqrt(var_total / num_iterations);
+    double stddev_issue = std::sqrt(var_issue / num_iterations);
+    double stddev_poll = std::sqrt(var_poll / num_iterations);
+
+    // Manhattan distance using physical NOC0 coordinates (not virtual/translated)
+    // Virtual coords for eth are in translated space (x=20+, y=25) which doesn't reflect actual hop count.
+    // Physical NOC0 coords are within the 17x12 grid and give correct Manhattan distance.
+    const metal_SocDescriptor& soc_desc =
+        tt::tt_metal::MetalContext::instance().get_cluster().get_soc_desc(device->id());
+    CoreCoord sender_phys = soc_desc.get_physical_core_from_logical_core(sender.logical, sender.type);
+    CoreCoord responder_phys = soc_desc.get_physical_core_from_logical_core(responder.logical, responder.type);
+
+    uint32_t abs_dx =
+        (sender_phys.x > responder_phys.x) ? (sender_phys.x - responder_phys.x) : (responder_phys.x - sender_phys.x);
+    uint32_t abs_dy =
+        (sender_phys.y > responder_phys.y) ? (sender_phys.y - responder_phys.y) : (responder_phys.y - sender_phys.y);
+    uint32_t dx, dy;
+    if (noc_index == 0) {
+        dx = abs_dx;
+        dy = abs_dy;
+    } else {
+        // NOC1 routes the opposite way around the torus grid
+        dx = noc_grid_size.x - abs_dx;
+        dy = noc_grid_size.y - abs_dy;
+    }
+
+    // Store raw per-iteration samples
+    std::vector<uint32_t> raw_issue(num_iterations), raw_poll(num_iterations);
+    for (uint32_t i = 0; i < num_iterations; i++) {
+        raw_issue[i] = timestamps[2 * i];
+        raw_poll[i] = timestamps[2 * i + 1];
+    }
+
+    return PingResult{
+        .mean_cycles = mean_total,
+        .min_cycles = static_cast<double>(min_val),
+        .max_cycles = static_cast<double>(max_val),
+        .stddev_cycles = stddev_total,
+        .mean_issue = mean_issue,
+        .mean_poll = mean_poll,
+        .stddev_issue = stddev_issue,
+        .stddev_poll = stddev_poll,
+        .manhattan_distance = dx + dy,
+        .raw_issue = std::move(raw_issue),
+        .raw_poll = std::move(raw_poll)};
+}
+
+void print_results(
+    const std::map<std::pair<uint32_t, uint32_t>, PingResult>& results,
+    CoreCoord grid_size,
+    const std::string& title,
+    uint32_t noc_index) {
+    double cycles_to_ns = 1000.0 / 1350.0;  // BH: 1350 MHz
+    int col_w = 9;
+
+    log_info(tt::LogTest, "\n=== {} (NOC{}) ===", title, noc_index);
+    std::ostringstream header;
+    std::string yx_label = "y\\x";
+    header << std::setw(col_w) << yx_label;
+    for (uint32_t x = 0; x < grid_size.x; x++) {
+        header << std::setw(col_w) << x;
+    }
+    log_info(tt::LogTest, "{}", header.str());
+
+    for (uint32_t y = 0; y < grid_size.y; y++) {
+        std::ostringstream row;
+        row << std::setw(col_w) << y;
+        for (uint32_t x = 0; x < grid_size.x; x++) {
+            auto it = results.find({x, y});
+            if (it != results.end()) {
+                row << std::setw(col_w) << std::fixed << std::setprecision(0) << it->second.mean_cycles;
+            } else {
+                row << std::setw(col_w) << "---";
+            }
+        }
+        log_info(tt::LogTest, "{}", row.str());
+    }
+
+    // Distance summary with issue/poll breakdown
+    struct DistStats {
+        std::vector<double> totals;
+        std::vector<double> issues;
+        std::vector<double> polls;
+    };
+    std::map<uint32_t, DistStats> dist_to_stats;
+    for (const auto& [coord, result] : results) {
+        auto& ds = dist_to_stats[result.manhattan_distance];
+        ds.totals.push_back(result.mean_cycles);
+        ds.issues.push_back(result.mean_issue);
+        ds.polls.push_back(result.mean_poll);
+    }
+    log_info(tt::LogTest, "\n--- Distance summary ---");
+    log_info(
+        tt::LogTest,
+        "{:>6} {:>10} {:>10} {:>10} {:>10} {:>10} {:>8}",
+        "dist",
+        "total",
+        "issue",
+        "poll",
+        "min",
+        "max",
+        "count");
+    for (const auto& [dist, ds] : dist_to_stats) {
+        double sum_t = 0, sum_i = 0, sum_p = 0, min_v = 1e9, max_v = 0;
+        for (size_t j = 0; j < ds.totals.size(); j++) {
+            sum_t += ds.totals[j];
+            sum_i += ds.issues[j];
+            sum_p += ds.polls[j];
+            min_v = std::min(min_v, ds.totals[j]);
+            max_v = std::max(max_v, ds.totals[j]);
+        }
+        double n = ds.totals.size();
+        log_info(
+            tt::LogTest,
+            "{:>6} {:>10.1f} {:>10.1f} {:>10.1f} {:>10.1f} {:>10.1f} {:>8}",
+            dist,
+            sum_t / n,
+            sum_i / n,
+            sum_p / n,
+            min_v,
+            max_v,
+            (int)n);
+    }
+
+    // Linear regression
+    double sum_d = 0, sum_l = 0, sum_dl = 0, sum_dd = 0;
+    uint32_t n = 0;
+    for (auto& [coord, result] : results) {
+        double d = result.manhattan_distance;
+        double l = result.mean_cycles;
+        sum_d += d;
+        sum_l += l;
+        sum_dl += d * l;
+        sum_dd += d * d;
+        n++;
+    }
+    if (n > 1) {
+        double mean_d = sum_d / n;
+        double mean_l = sum_l / n;
+        double b = (sum_dl - n * mean_d * mean_l) / (sum_dd - n * mean_d * mean_d);
+        double a = mean_l - b * mean_d;
+        log_info(tt::LogTest, "\n--- Linear fit: round_trip = {:.1f} + {:.2f} * distance ---", a, b);
+        log_info(tt::LogTest, "  Fixed overhead (one-way): {:.1f} cycles ({:.1f} ns)", a / 2, a / 2 * cycles_to_ns);
+        log_info(tt::LogTest, "  Per-hop cost (one-way):   {:.2f} cycles ({:.2f} ns)", b / 2, b / 2 * cycles_to_ns);
+    }
+}
+
+void dump_raw_csv(
+    const std::map<std::pair<uint32_t, uint32_t>, PingResult>& results,
+    const std::string& sender_label,
+    uint32_t num_iterations,
+    uint32_t noc_index,
+    uint32_t mode,
+    const std::string& csv_path) {
+    std::ofstream csv(csv_path);
+    // Header
+    csv << "src,dst_x,dst_y,distance,iteration,issue_cycles,poll_cycles,total_cycles\n";
+
+    for (const auto& [coord, result] : results) {
+        auto [dx, dy] = coord;
+        for (uint32_t i = 0; i < num_iterations; i++) {
+            uint32_t issue = result.raw_issue[i];
+            uint32_t poll = result.raw_poll[i];
+            csv << sender_label << "," << dx << "," << dy << "," << result.manhattan_distance << "," << i << ","
+                << issue << "," << poll << "," << (issue + poll) << "\n";
+        }
+    }
+    log_info(tt::LogTest, "Raw CSV written to: {}", csv_path);
+}
+
+int main(int argc, char** argv) {
+    uint32_t num_iterations = (argc > 1) ? std::stoi(argv[1]) : 100;
+    uint32_t num_warmup = (argc > 2) ? std::stoi(argv[2]) : 10;
+    uint32_t noc_index = (argc > 3) ? std::stoi(argv[3]) : 0;
+    uint32_t mode = (argc > 4) ? std::stoi(argv[4]) : 0;
+
+    auto noc_select = noc_index == 0 ? tt_metal::NOC::NOC_0 : tt_metal::NOC::NOC_1;
+
+    const char* mode_names[] = {"tensix-tensix", "eth-sender", "eth-receiver"};
+    log_info(
+        tt::LogTest,
+        "NOC Hop Latency Benchmark: {} iterations, {} warmup, NOC{}, mode={} ({})",
+        num_iterations,
+        num_warmup,
+        noc_index,
+        mode,
+        mode_names[mode]);
+
+    // For eth modes, open all devices so the active eth cores can complete FW handshake
+    size_t num_devices = tt::tt_metal::GetNumAvailableDevices();
+    std::vector<tt_metal::IDevice*> all_devices;
+    if (mode > 0 && num_devices > 1) {
+        for (size_t i = 0; i < num_devices; i++) {
+            all_devices.push_back(tt_metal::CreateDevice(i));
+        }
+    } else {
+        all_devices.push_back(tt_metal::CreateDevice(0));
+    }
+    tt_metal::IDevice* device = all_devices[0];
+
+    auto grid_size = device->compute_with_storage_grid_size();
+    auto noc_grid_size = device->grid_size();  // Full NOC torus grid dimensions
+    log_info(
+        tt::LogTest,
+        "Worker grid: {}x{}, NOC grid: {}x{}, {} devices opened",
+        grid_size.x,
+        grid_size.y,
+        noc_grid_size.x,
+        noc_grid_size.y,
+        all_devices.size());
+
+    // Get active eth cores for modes 1 and 2
+    std::vector<CoreCoord> eth_cores;
+    if (mode > 0) {
+        bool slow_dispatch = (getenv("TT_METAL_SLOW_DISPATCH_MODE") != nullptr);
+        auto active_eth_cores = tt::tt_metal::MetalContext::instance().get_control_plane().get_active_ethernet_cores(
+            device->id(), !slow_dispatch);
+        TT_FATAL(!active_eth_cores.empty(), "No active ethernet cores found on device 0");
+        for (const auto& ec : active_eth_cores) {
+            eth_cores.push_back(ec);
+        }
+        log_info(tt::LogTest, "Found {} active ethernet cores", eth_cores.size());
+        for (const auto& ec : eth_cores) {
+            auto ev = device->virtual_core_from_logical_core(ec, CoreType::ETH);
+            log_info(tt::LogTest, "  eth logical=({},{}), virtual=({},{})", ec.x, ec.y, ev.x, ev.y);
+        }
+    }
+
+    if (mode == 0) {
+        // Tensix-tensix: fix sender at (0,0), sweep responder
+        std::map<std::pair<uint32_t, uint32_t>, PingResult> results;
+        CoreSpec sender{CoreCoord(0, 0), CoreType::WORKER};
+        for (uint32_t ry = 0; ry < grid_size.y; ry++) {
+            for (uint32_t rx = 0; rx < grid_size.x; rx++) {
+                CoreCoord responder_logical(rx, ry);
+                if (responder_logical == sender.logical) {
+                    continue;
+                }
+
+                CoreSpec responder{responder_logical, CoreType::WORKER};
+                auto result = run_ping_pong(
+                    device, sender, responder, num_iterations, num_warmup, noc_select, noc_index, noc_grid_size);
+                results[{rx, ry}] = result;
+
+                log_info(
+                    tt::LogTest,
+                    "  T({},{}) -> T({},{}): dist={}, total={:.1f} cyc, issue={:.1f} (sd={:.1f}), poll={:.1f} "
+                    "(sd={:.1f})",
+                    0,
+                    0,
+                    rx,
+                    ry,
+                    result.manhattan_distance,
+                    result.mean_cycles,
+                    result.mean_issue,
+                    result.stddev_issue,
+                    result.mean_poll,
+                    result.stddev_poll);
+            }
+        }
+        print_results(results, grid_size, "Tensix-Tensix round-trip (cycles), sender=T(0,0)", noc_index);
+        dump_raw_csv(
+            results,
+            "T(0;0)",
+            num_iterations,
+            noc_index,
+            mode,
+            fmt::format("noc_hop_latency_mode{}_noc{}.csv", mode, noc_index));
+
+    } else if (mode == 1) {
+        // Eth-sender: sweep ALL active eth cores as sender, each sweeping all tensix responders
+        for (const auto& eth_logical : eth_cores) {
+            std::map<std::pair<uint32_t, uint32_t>, PingResult> results;
+            CoreSpec sender{eth_logical, CoreType::ETH};
+            auto eth_virtual = device->virtual_core_from_logical_core(eth_logical, CoreType::ETH);
+            log_info(
+                tt::LogTest,
+                "\n>>> Eth sender: logical=({},{}), virtual=({},{})",
+                eth_logical.x,
+                eth_logical.y,
+                eth_virtual.x,
+                eth_virtual.y);
+
+            for (uint32_t ry = 0; ry < grid_size.y; ry++) {
+                for (uint32_t rx = 0; rx < grid_size.x; rx++) {
+                    CoreSpec responder{CoreCoord(rx, ry), CoreType::WORKER};
+                    auto result = run_ping_pong(
+                        device, sender, responder, num_iterations, num_warmup, noc_select, noc_index, noc_grid_size);
+                    results[{rx, ry}] = result;
+
+                    log_info(
+                        tt::LogTest,
+                        "  E({},{}) -> T({},{}): dist={}, total={:.1f} cyc, issue={:.1f} (sd={:.1f}), poll={:.1f} "
+                        "(sd={:.1f})",
+                        eth_logical.x,
+                        eth_logical.y,
+                        rx,
+                        ry,
+                        result.manhattan_distance,
+                        result.mean_cycles,
+                        result.mean_issue,
+                        result.stddev_issue,
+                        result.mean_poll,
+                        result.stddev_poll);
+                }
+            }
+            print_results(
+                results,
+                grid_size,
+                fmt::format("Eth-Sender round-trip (cycles), sender=E({},{})", eth_logical.x, eth_logical.y),
+                noc_index);
+            dump_raw_csv(
+                results,
+                fmt::format("E({};{})", eth_logical.x, eth_logical.y),
+                num_iterations,
+                noc_index,
+                mode,
+                fmt::format(
+                    "noc_hop_latency_mode{}_noc{}_eth{}_{}.csv", mode, noc_index, eth_logical.x, eth_logical.y));
+        }
+
+    } else if (mode == 2) {
+        // Eth-receiver: sweep ALL active eth cores as responder, each with all tensix senders
+        for (const auto& eth_logical : eth_cores) {
+            std::map<std::pair<uint32_t, uint32_t>, PingResult> results;
+            CoreSpec responder{eth_logical, CoreType::ETH};
+            auto eth_virtual = device->virtual_core_from_logical_core(eth_logical, CoreType::ETH);
+            log_info(
+                tt::LogTest,
+                "\n>>> Eth responder: logical=({},{}), virtual=({},{})",
+                eth_logical.x,
+                eth_logical.y,
+                eth_virtual.x,
+                eth_virtual.y);
+
+            for (uint32_t ry = 0; ry < grid_size.y; ry++) {
+                for (uint32_t rx = 0; rx < grid_size.x; rx++) {
+                    CoreSpec sender{CoreCoord(rx, ry), CoreType::WORKER};
+                    auto result = run_ping_pong(
+                        device, sender, responder, num_iterations, num_warmup, noc_select, noc_index, noc_grid_size);
+                    results[{rx, ry}] = result;
+
+                    log_info(
+                        tt::LogTest,
+                        "  T({},{}) -> E({},{}): dist={}, total={:.1f} cyc, issue={:.1f} (sd={:.1f}), poll={:.1f} "
+                        "(sd={:.1f})",
+                        rx,
+                        ry,
+                        eth_logical.x,
+                        eth_logical.y,
+                        result.manhattan_distance,
+                        result.mean_cycles,
+                        result.mean_issue,
+                        result.stddev_issue,
+                        result.mean_poll,
+                        result.stddev_poll);
+                }
+            }
+            print_results(
+                results,
+                grid_size,
+                fmt::format("Eth-Receiver round-trip (cycles), responder=E({},{})", eth_logical.x, eth_logical.y),
+                noc_index);
+            dump_raw_csv(
+                results,
+                fmt::format("E({};{})", eth_logical.x, eth_logical.y),
+                num_iterations,
+                noc_index,
+                mode,
+                fmt::format(
+                    "noc_hop_latency_mode{}_noc{}_eth{}_{}.csv", mode, noc_index, eth_logical.x, eth_logical.y));
+        }
+    }
+
+    for (auto* d : all_devices) {
+        tt_metal::CloseDevice(d);
+    }
+    return 0;
+}

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/noc/test_noc_hop_latency.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/noc/test_noc_hop_latency.cpp
@@ -90,18 +90,28 @@ PingResult run_ping_pong(
     uint32_t responder_base = (responder.type == CoreType::ETH) ? eth_unreserved : tensix_sem_base;
     uint32_t responder_sem_addr = align16(responder_base);
 
-    // Sender NOC: on BH, ERISC0 is locked to NOC0
+    // NOC selection: sender and responder must use OPPOSITE NOCs so both legs
+    // of the round-trip take the short path (same direction on the torus).
+    // If both use the same NOC, the round-trip distance is always the full torus
+    // circumference regardless of position (forward + return = grid_width).
+    //
+    // On BH, ERISC0 is locked to NOC0, so:
+    //   - When sender is ETH: sender=NOC0, responder=NOC1
+    //   - When responder is ETH: responder=NOC0, sender=NOC1
+    //   - When both are tensix: sender=user-selected, responder=opposite
     tt_metal::NOC actual_sender_noc = sender_noc;
-    if (sender.type == CoreType::ETH) {
-        actual_sender_noc = tt_metal::NOC::NOC_0;
-    }
-
-    // Responder uses opposite NOC so both directions traverse the same physical path
-    // Exception: ERISC0 on BH is locked to NOC0
     tt_metal::NOC responder_noc;
-    if (responder.type == CoreType::ETH) {
+
+    if (sender.type == CoreType::ETH) {
+        // ERISC sender locked to NOC0, tensix responder uses NOC1
+        actual_sender_noc = tt_metal::NOC::NOC_0;
+        responder_noc = tt_metal::NOC::NOC_1;
+    } else if (responder.type == CoreType::ETH) {
+        // ERISC responder locked to NOC0, tensix sender uses NOC1
+        actual_sender_noc = tt_metal::NOC::NOC_1;
         responder_noc = tt_metal::NOC::NOC_0;
     } else {
+        // Both tensix: use user-selected NOC for sender, opposite for responder
         responder_noc = (actual_sender_noc == tt_metal::NOC::NOC_0) ? tt_metal::NOC::NOC_1 : tt_metal::NOC::NOC_0;
     }
 
@@ -209,18 +219,21 @@ PingResult run_ping_pong(
     CoreCoord sender_phys = soc_desc.get_physical_core_from_logical_core(sender.logical, sender.type);
     CoreCoord responder_phys = soc_desc.get_physical_core_from_logical_core(responder.logical, responder.type);
 
-    uint32_t abs_dx =
-        (sender_phys.x > responder_phys.x) ? (sender_phys.x - responder_phys.x) : (responder_phys.x - sender_phys.x);
-    uint32_t abs_dy =
-        (sender_phys.y > responder_phys.y) ? (sender_phys.y - responder_phys.y) : (responder_phys.y - sender_phys.y);
+    // With sender and responder on opposite NOCs, both legs of the round-trip traverse
+    // the same number of hops in the same direction. The one-way hop count is the
+    // directional distance for the sender's NOC.
+    //
+    // NOC_0 goes rightward/downward: distance(A→B) = (B - A + G) mod G
+    // NOC_1 goes leftward/upward:    distance(A→B) = (A - B + G) mod G
+    //
+    // The round-trip = 2 × one_way_directional_hops.
     uint32_t dx, dy;
-    if (noc_index == 0) {
-        dx = abs_dx;
-        dy = abs_dy;
+    if (actual_sender_noc == tt_metal::NOC::NOC_0) {
+        dx = (responder_phys.x - sender_phys.x + noc_grid_size.x) % noc_grid_size.x;
+        dy = (responder_phys.y - sender_phys.y + noc_grid_size.y) % noc_grid_size.y;
     } else {
-        // NOC1 routes the opposite way around the torus grid
-        dx = noc_grid_size.x - abs_dx;
-        dy = noc_grid_size.y - abs_dy;
+        dx = (sender_phys.x - responder_phys.x + noc_grid_size.x) % noc_grid_size.x;
+        dy = (sender_phys.y - responder_phys.y + noc_grid_size.y) % noc_grid_size.y;
     }
 
     // Store raw per-iteration samples

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/noc/test_noc_overhead.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/noc/test_noc_overhead.cpp
@@ -1,0 +1,194 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Host driver for NOC overhead microbenchmark.
+// Deploys noc_overhead_ubench kernel on a tensix or eth core and reads back per-operation cycle costs.
+//
+// Usage: test_noc_overhead [num_iterations] [use_eth] [eth_core_idx]
+//   num_iterations: number of iterations per test (default 1000)
+//   use_eth:        0 = tensix core (0,0), 1 = first active eth core (default 0)
+//   eth_core_idx:   which active eth core to use when use_eth=1 (default 0)
+
+#include <cstdint>
+#include <cstdlib>
+#include <iomanip>
+#include <iostream>
+#include <string>
+#include <vector>
+
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/tt_metal.hpp>
+#include <tt-metalium/core_coord.hpp>
+#include <tt-metalium/kernel_types.hpp>
+#include <tt-metalium/tt_metal_profiler.hpp>
+#include <tt-logger/tt-logger.hpp>
+#include "impl/context/metal_context.hpp"
+#include <llrt/tt_cluster.hpp>
+#include <tt-metalium/experimental/fabric/control_plane.hpp>
+
+using namespace tt;
+
+static const char* TEST_NAMES[] = {
+    "fence (invalidate_l1_cache)",
+    "wall clock read (TS overhead)",
+    "NOC_STATUS_READ: NIU_MST_RD_RESP_RECEIVED",
+    "NOC_STATUS_READ: NIU_MST_NONPOSTED_WR_REQ_SENT",
+    "NOC_STATUS_READ: NIU_MST_WR_ACK_RECEIVED",
+    "NOC_STATUS_READ: NIU_MST_ATOMIC_RESP_RECEIVED",
+    "NOC_STATUS_READ: NIU_MST_POSTED_WR_REQ_SENT",
+    "L1 read: noc_reads_num_issued",
+    "ncrisc_noc_reads_flushed (MMIO+L1+cmp)",
+    "ncrisc_noc_nonposted_atomics_flushed",
+    "noc_async_full_barrier (nothing outstanding)",
+    "noc_semaphore_inc (issue only, to self)",
+    "noc_semaphore_inc + flush (full round-trip to self)",
+    "volatile L1 read (sem poll, single read)",
+};
+constexpr uint32_t NUM_TESTS = 14;
+
+void print_results(const std::vector<uint32_t>& results, uint32_t num_iterations, const std::string& core_label) {
+    log_info(tt::LogTest, "\n=== Results for {} ===", core_label);
+    log_info(tt::LogTest, "{:>4} {:>8} {:>8} {:>8} {:>10}  {}", "ID", "Min", "Max", "Mean", "Sum", "Test");
+    log_info(tt::LogTest, "{}", std::string(80, '-'));
+
+    for (uint32_t t = 0; t < NUM_TESTS; t++) {
+        uint32_t test_id = results[t * 5 + 0];
+        uint32_t min_val = results[t * 5 + 1];
+        uint32_t max_val = results[t * 5 + 2];
+        uint32_t sum_lo = results[t * 5 + 3];
+        uint32_t sum_hi = results[t * 5 + 4];
+        uint64_t sum = (static_cast<uint64_t>(sum_hi) << 32) | sum_lo;
+        double mean = static_cast<double>(sum) / num_iterations;
+
+        log_info(
+            tt::LogTest, "{:>4} {:>8} {:>8} {:>8.1f} {:>10}  {}", test_id, min_val, max_val, mean, sum, TEST_NAMES[t]);
+    }
+
+    uint64_t ts_sum = (static_cast<uint64_t>(results[1 * 5 + 4]) << 32) | results[1 * 5 + 3];
+    double ts_overhead = static_cast<double>(ts_sum) / num_iterations;
+
+    log_info(tt::LogTest, "\n--- Adjusted costs (subtracting TS overhead of {:.1f} cycles) ---", ts_overhead);
+    log_info(tt::LogTest, "{:>4} {:>8}  {}", "ID", "Adj.Mean", "Test");
+    log_info(tt::LogTest, "{}", std::string(60, '-'));
+    for (uint32_t t = 0; t < NUM_TESTS; t++) {
+        uint32_t sum_lo = results[t * 5 + 3];
+        uint32_t sum_hi = results[t * 5 + 4];
+        uint64_t sum = (static_cast<uint64_t>(sum_hi) << 32) | sum_lo;
+        double mean = static_cast<double>(sum) / num_iterations;
+        double adjusted = mean - ts_overhead;
+
+        log_info(tt::LogTest, "{:>4} {:>8.1f}  {}", t, adjusted, TEST_NAMES[t]);
+    }
+}
+
+int main(int argc, char** argv) {
+    uint32_t num_iterations = (argc > 1) ? std::stoi(argv[1]) : 1000;
+    uint32_t use_eth = (argc > 2) ? std::stoi(argv[2]) : 0;
+    uint32_t eth_core_idx = (argc > 3) ? std::stoi(argv[3]) : 0;
+
+    // For eth mode, open all devices so active eth cores can complete FW handshake
+    size_t num_devices = tt::tt_metal::GetNumAvailableDevices();
+    std::vector<tt_metal::IDevice*> all_devices;
+    if (use_eth && num_devices > 1) {
+        for (size_t i = 0; i < num_devices; i++) {
+            all_devices.push_back(tt_metal::CreateDevice(i));
+        }
+    } else {
+        all_devices.push_back(tt_metal::CreateDevice(0));
+    }
+    tt_metal::IDevice* device = all_devices[0];
+
+    constexpr uint32_t result_words = NUM_TESTS * 5;
+
+    if (!use_eth) {
+        // Tensix mode
+        CoreCoord logical_core(0, 0);
+        auto virtual_core = device->virtual_core_from_logical_core(logical_core, CoreType::WORKER);
+        log_info(
+            tt::LogTest,
+            "NOC Overhead Benchmark: {} iterations on Tensix (0,0) virtual=({},{})",
+            num_iterations,
+            virtual_core.x,
+            virtual_core.y);
+
+        constexpr uint32_t l1_base = 150 * 1024;
+        uint32_t sem_addr = (l1_base + 15) & ~15u;
+        uint32_t ts_buf_addr = (sem_addr + 16 + 15) & ~15u;
+
+        tt_metal::Program program = tt_metal::CreateProgram();
+        auto kernel = tt_metal::CreateKernel(
+            program,
+            "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/noc/noc_overhead_ubench.cpp",
+            logical_core,
+            tt_metal::DataMovementConfig{
+                .processor = tt_metal::DataMovementProcessor::RISCV_0, .noc = tt_metal::NOC::NOC_0});
+
+        tt_metal::SetRuntimeArgs(
+            program, kernel, logical_core, {ts_buf_addr, num_iterations, virtual_core.x, virtual_core.y, sem_addr});
+
+        tt_metal::detail::CompileProgram(device, program);
+        tt_metal::detail::LaunchProgram(device, program);
+
+        std::vector<uint32_t> results(result_words, 0);
+        tt::tt_metal::MetalContext::instance().get_cluster().read_core(
+            results.data(), result_words * sizeof(uint32_t), tt_cxy_pair(device->id(), virtual_core), ts_buf_addr);
+
+        print_results(
+            results, num_iterations, fmt::format("Tensix (0,0) virt=({},{})", virtual_core.x, virtual_core.y));
+
+    } else {
+        // Eth mode
+        bool slow_dispatch = (getenv("TT_METAL_SLOW_DISPATCH_MODE") != nullptr);
+        auto active_eth_cores = tt::tt_metal::MetalContext::instance().get_control_plane().get_active_ethernet_cores(
+            device->id(), !slow_dispatch);
+        TT_FATAL(!active_eth_cores.empty(), "No active ethernet cores found");
+
+        std::vector<CoreCoord> eth_cores(active_eth_cores.begin(), active_eth_cores.end());
+        TT_FATAL(
+            eth_core_idx < eth_cores.size(), "eth_core_idx {} >= {} active eth cores", eth_core_idx, eth_cores.size());
+
+        CoreCoord eth_logical = eth_cores[eth_core_idx];
+        auto eth_virtual = device->virtual_core_from_logical_core(eth_logical, CoreType::ETH);
+        log_info(
+            tt::LogTest,
+            "NOC Overhead Benchmark: {} iterations on ETH({},{}) virtual=({},{})",
+            num_iterations,
+            eth_logical.x,
+            eth_logical.y,
+            eth_virtual.x,
+            eth_virtual.y);
+
+        uint32_t eth_unreserved = tt_metal::MetalContext::instance().hal().get_dev_addr(
+            tt_metal::HalProgrammableCoreType::ACTIVE_ETH, tt_metal::HalL1MemAddrType::UNRESERVED);
+        uint32_t sem_addr = (eth_unreserved + 15) & ~15u;
+        uint32_t ts_buf_addr = (sem_addr + 16 + 15) & ~15u;
+
+        tt_metal::Program program = tt_metal::CreateProgram();
+        auto kernel = tt_metal::CreateKernel(
+            program,
+            "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/noc/noc_overhead_ubench.cpp",
+            eth_logical,
+            tt_metal::EthernetConfig{.noc = tt_metal::NOC::RISCV_0_default, .compile_args = {}});
+
+        tt_metal::SetRuntimeArgs(
+            program, kernel, eth_logical, {ts_buf_addr, num_iterations, eth_virtual.x, eth_virtual.y, sem_addr});
+
+        tt_metal::detail::CompileProgram(device, program);
+        tt_metal::detail::LaunchProgram(device, program);
+
+        std::vector<uint32_t> results(result_words, 0);
+        tt::tt_metal::MetalContext::instance().get_cluster().read_core(
+            results.data(), result_words * sizeof(uint32_t), tt_cxy_pair(device->id(), eth_virtual), ts_buf_addr);
+
+        print_results(
+            results,
+            num_iterations,
+            fmt::format("ETH({},{}) virt=({},{})", eth_logical.x, eth_logical.y, eth_virtual.x, eth_virtual.y));
+    }
+
+    for (auto* d : all_devices) {
+        tt_metal::CloseDevice(d);
+    }
+    return 0;
+}

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/sources.cmake
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/sources.cmake
@@ -10,6 +10,7 @@ set(PERF_MICROBENCH_TESTS_SRCS
     routing/test_tt_fabric_mux_bandwidth.cpp
     routing/test_tt_fabric.cpp
     noc/test_noc_unicast_vs_multicast_to_single_core_latency.cpp
+    noc/test_noc_hop_latency.cpp
     tensix/test_gathering.cpp
     old/matmul/matmul_global_l1.cpp
     old/matmul/matmul_local_l1.cpp

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/erisc/eth_ubenchmark_types.hpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/erisc/eth_ubenchmark_types.hpp
@@ -17,6 +17,8 @@ enum BenchmarkType : uint8_t {
     EthMcastTensix = 5,
     EthToLocalEth = 6,
     EthToLocalEthAndMcastTensix = 7,
+    TensixEthEthTensixUniDir = 8,
+    DualEriscBiDir = 9,
 };
 
 enum MeasurementType : uint8_t { Latency = 0, Bandwidth = 1 };

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/erisc/ethernet_ping_latency_ubench_receiver.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/erisc/ethernet_ping_latency_ubench_receiver.cpp
@@ -89,6 +89,7 @@ FORCE_INLINE void run_loop_iteration(
 
 static constexpr uint32_t MAX_CHANNELS = 8;
 void kernel_main() {
+    set_l1_data_cache<false>();
     uint32_t arg_idx = 0;
     const uint32_t handshake_addr = get_arg_val<uint32_t>(arg_idx++);
     const uint32_t num_messages = get_arg_val<uint32_t>(arg_idx++);

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/erisc/ethernet_ping_latency_ubench_sender.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/erisc/ethernet_ping_latency_ubench_sender.cpp
@@ -88,6 +88,7 @@ FORCE_INLINE void run_loop_iteration(
 }
 
 void kernel_main() {
+    set_l1_data_cache<false>();
     uint32_t arg_idx = 0;
     const uint32_t handshake_addr = get_arg_val<uint32_t>(arg_idx++);
     const uint32_t num_messages = get_arg_val<uint32_t>(arg_idx++);
@@ -117,10 +118,6 @@ void kernel_main() {
     // This ensures registers are initialized before the remote side can access them
     init_ptr_val<SENDER_CREDIT_STREAM_ID>(0);
 
-    // Avoids hang in issue https://github.com/tenstorrent/tt-metal/issues/9963
-    for (uint32_t i = 0; i < 2000000000; i++) {
-        asm volatile("nop");
-    }
     eth_setup_handshake(handshake_addr, true);
 
     // Track expected credits for stream register checking

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/erisc/ethernet_write_worker_latency_ubench_common.hpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/erisc/ethernet_write_worker_latency_ubench_common.hpp
@@ -4,6 +4,7 @@
 
 #include <cstdint>
 #include <array>
+#include <algorithm>
 #include "eth_l1_address_map.h"
 #include "api/dataflow/dataflow_api.h"
 #include "internal/ethernet/dataflow_api.h"
@@ -11,8 +12,16 @@
 #include "api/debug/dprint.h"
 #include "eth_ubenchmark_types.hpp"
 #include "risc_common.h"
+#include "tt_metal/fabric/hw/inc/edm_fabric/fabric_stream_regs.hpp"
 
 // #define ENABLE_DEBUG 1
+
+// Overlay stream register IDs for flow control.
+// Each core has these as LOCAL registers; the remote peer writes to them via eth_write_remote_reg.
+// Stream 0: incremented remotely by peer when it sends a data packet to us
+// Stream 1: incremented remotely by peer when it acks/completes processing of our sent packet
+constexpr uint8_t STREAM_ID_PACKETS_FROM_REMOTE = 0;
+constexpr uint8_t STREAM_ID_ACKS_FROM_REMOTE = 1;
 
 FORCE_INLINE void eth_setup_handshake(std::uint32_t handshake_register_address, bool is_sender) {
     if (is_sender) {
@@ -31,7 +40,7 @@ FORCE_INLINE void switch_context_if_debug() {
 }
 
 template <typename T>
-bool is_power_of_two(T val) {
+constexpr bool is_power_of_two(T val) {
     return (val & (val - 1)) == T(0);
 }
 
@@ -40,27 +49,24 @@ bool is_power_of_two(T val) {
 constexpr BenchmarkType benchmark_type = static_cast<BenchmarkType>(get_compile_time_arg_val(0));
 constexpr MeasurementType measurement_type = static_cast<MeasurementType>(get_compile_time_arg_val(1));
 constexpr uint32_t NUM_BUFFER_SLOTS = get_compile_time_arg_val(2);
-constexpr uint32_t MAX_NUM_TRANSACTION_ID =
-    NUM_BUFFER_SLOTS / 2;  // the algorithm only works for NUM_BUFFER_SLOTS divisible by MAX_NUM_TRANSACTION_ID
+constexpr uint32_t MAX_NUM_TRANSACTION_ID = std::min<uint32_t>(
+    NUM_BUFFER_SLOTS / 2, 8);  // the algorithm only works for NUM_BUFFER_SLOTS divisible by MAX_NUM_TRANSACTION_ID
 constexpr uint32_t disable_trid = get_compile_time_arg_val(3);
+
+// Initialize overlay stream registers for flow control.
+// Must be called BEFORE handshake to ensure registers are ready before the remote peer starts.
+FORCE_INLINE void init_flow_control_registers() {
+    init_ptr_val<STREAM_ID_PACKETS_FROM_REMOTE>(0);
+    init_ptr_val<STREAM_ID_ACKS_FROM_REMOTE>(0);
+}
 
 // ******************************* Sender APIs ***************************************************
 
 FORCE_INLINE uint32_t setup_sender_buffer(
-    std::array<uint32_t, NUM_BUFFER_SLOTS>& buffer_slot_addrs,
-    std::array<volatile eth_buffer_slot_sync_t*, NUM_BUFFER_SLOTS>& buffer_slot_sync_addrs,
-    uint32_t buffer_slot_addr,
-    uint32_t message_size) {
+    std::array<uint32_t, NUM_BUFFER_SLOTS>& buffer_slot_addrs, uint32_t buffer_slot_addr, uint32_t message_size) {
     for (uint8_t i = 0; i < NUM_BUFFER_SLOTS; i++) {
         buffer_slot_addrs[i] = buffer_slot_addr;
         buffer_slot_addr += message_size;
-        buffer_slot_sync_addrs[i] = reinterpret_cast<volatile eth_buffer_slot_sync_t*>(buffer_slot_addr);
-        buffer_slot_addr += sizeof(eth_buffer_slot_sync_t);
-    }
-
-    // reset bytes_sent to 1s so first iter it will block on receiver ack
-    for (uint32_t i = 0; i < NUM_BUFFER_SLOTS; i++) {
-        buffer_slot_sync_addrs[i]->bytes_sent = 1;
     }
 
     // assemble a packet filled with values
@@ -71,137 +77,85 @@ FORCE_INLINE uint32_t setup_sender_buffer(
         }
     }
 
-    uint32_t buffer_end_addr = buffer_slot_addr;
-    return buffer_end_addr;
+    return buffer_slot_addr;
 }
 
-FORCE_INLINE uint32_t advance_buffer_slot_ptr(uint32_t curr_ptr) { return (curr_ptr + 1) % NUM_BUFFER_SLOTS; }
-
-FORCE_INLINE void write_receiver(
-    uint32_t buffer_slot_addr, volatile eth_buffer_slot_sync_t* buffer_slot_sync_addr, uint32_t full_payload_size) {
-    buffer_slot_sync_addr->bytes_sent = 1;
-
-    while (eth_txq_is_busy()) {
-        switch_context_if_debug();
-    }
-
-    eth_send_bytes_over_channel_payload_only_unsafe_one_packet(buffer_slot_addr, buffer_slot_addr, full_payload_size);
-}
-
-FORCE_INLINE bool has_receiver_ack(volatile eth_buffer_slot_sync_t* buffer_slot_sync_addr) {
-    invalidate_l1_cache();
-    return buffer_slot_sync_addr->bytes_sent == 0;
-}
-
-FORCE_INLINE void check_buffer_full_and_send_packet(
-    const std::array<uint32_t, NUM_BUFFER_SLOTS>& buffer_slot_addrs,
-    const std::array<volatile eth_buffer_slot_sync_t*, NUM_BUFFER_SLOTS>& buffer_slot_sync_addrs,
-    uint32_t read_ptr,
-    uint32_t& write_ptr,
-    uint64_t full_payload_size,
-    uint32_t& num_messages_send) {
-    uint32_t next_write_ptr = advance_buffer_slot_ptr(write_ptr);
-    bool buffer_not_full = next_write_ptr != read_ptr;
-
-    if (buffer_not_full && num_messages_send != 0) {
-        write_receiver(buffer_slot_addrs[write_ptr], buffer_slot_sync_addrs[write_ptr], full_payload_size);
-
-        write_ptr = next_write_ptr;
-        num_messages_send--;
-    }
-}
-
-FORCE_INLINE void check_receiver_done(
-    const std::array<volatile eth_buffer_slot_sync_t*, NUM_BUFFER_SLOTS>& buffer_slot_sync_addrs,
-    uint32_t& read_ptr,
-    uint32_t& num_messages_ack) {
-    if (has_receiver_ack(buffer_slot_sync_addrs[read_ptr])) {
-        uint32_t next_read_ptr = advance_buffer_slot_ptr(read_ptr);
-
-        buffer_slot_sync_addrs[read_ptr]->bytes_sent = 1;
-        read_ptr = next_read_ptr;
-        num_messages_ack++;
+template <uint32_t NUM_BUFFER_SLOTS>
+FORCE_INLINE uint32_t advance_buffer_slot_ptr(uint32_t curr_ptr) {
+    if constexpr (is_power_of_two(NUM_BUFFER_SLOTS)) {
+        return (curr_ptr + 1) & (NUM_BUFFER_SLOTS - 1);
+    } else if constexpr (NUM_BUFFER_SLOTS == 2) {
+        return 1 - curr_ptr;
+    } else {
+        return curr_ptr == NUM_BUFFER_SLOTS - 1 ? 0 : curr_ptr + 1;
     }
 }
 
 FORCE_INLINE void update_sender_state(
     const std::array<uint32_t, NUM_BUFFER_SLOTS>& buffer_slot_addrs,
-    const std::array<volatile eth_buffer_slot_sync_t*, NUM_BUFFER_SLOTS>& buffer_slot_sync_addrs,
-    uint32_t full_payload_size,
+    uint32_t message_size,
     uint32_t& num_messages_ack,
     uint32_t& num_messages_send,
     uint32_t& buffer_read_ptr,
     uint32_t& buffer_write_ptr) {
-    // Check if current buffer slot is ready and send packet to receiver
-    check_buffer_full_and_send_packet(
-        buffer_slot_addrs,
-        buffer_slot_sync_addrs,
-        buffer_read_ptr,
-        buffer_write_ptr,
-        full_payload_size,
-        num_messages_send);
-    // Check if the write for trid is done, and ack sender if the current buffer slot is done
-    check_receiver_done(buffer_slot_sync_addrs, buffer_read_ptr, num_messages_ack);
+    // Try to send a packet if buffer has space and we have messages to send
+    uint32_t next_write_ptr = advance_buffer_slot_ptr<NUM_BUFFER_SLOTS>(buffer_write_ptr);
+    bool buffer_not_full = next_write_ptr != buffer_read_ptr;
+
+    if (buffer_not_full && num_messages_send != 0 && !eth_txq_is_busy()) {
+        // Send data payload to remote (lands at same L1 address on peer)
+        internal_::eth_send_packet_bytes_unsafe(
+            0, buffer_slot_addrs[buffer_write_ptr], buffer_slot_addrs[buffer_write_ptr], message_size);
+        // Wait for data send to complete, then notify receiver via stream register
+        while (eth_txq_is_busy()) {
+            switch_context_if_debug();
+        }
+        remote_update_ptr_val<STREAM_ID_PACKETS_FROM_REMOTE, 0>(1);
+
+        buffer_write_ptr = next_write_ptr;
+        num_messages_send--;
+    }
+
+    // Check for acks from receiver via stream register
+    int32_t new_acks = get_ptr_val<STREAM_ID_ACKS_FROM_REMOTE>();
+    if (new_acks > 0) {
+        increment_local_update_ptr_val<STREAM_ID_ACKS_FROM_REMOTE>(-new_acks);
+        for (int32_t i = 0; i < new_acks; i++) {
+            buffer_read_ptr = advance_buffer_slot_ptr<NUM_BUFFER_SLOTS>(buffer_read_ptr);
+        }
+        num_messages_ack += new_acks;
+    }
 }
 
 // ******************************* Receiver APIs *************************************************
 
 FORCE_INLINE uint32_t setup_receiver_buffer(
-    std::array<uint32_t, NUM_BUFFER_SLOTS>& buffer_slot_addrs,
-    std::array<volatile eth_buffer_slot_sync_t*, NUM_BUFFER_SLOTS>& buffer_slot_sync_addrs,
-    uint32_t buffer_slot_addr,
-    uint32_t message_size) {
+    std::array<uint32_t, NUM_BUFFER_SLOTS>& buffer_slot_addrs, uint32_t buffer_slot_addr, uint32_t message_size) {
     for (uint8_t i = 0; i < NUM_BUFFER_SLOTS; i++) {
         buffer_slot_addrs[i] = buffer_slot_addr;
         buffer_slot_addr += message_size;
-        buffer_slot_sync_addrs[i] = reinterpret_cast<volatile eth_buffer_slot_sync_t*>(buffer_slot_addr);
-        buffer_slot_sync_addrs[i]->bytes_sent = 0;
-        buffer_slot_sync_addrs[i]->receiver_ack = 0;
-        buffer_slot_addr += sizeof(eth_buffer_slot_sync_t);
     }
 
-    uint32_t buffer_end_addr = buffer_slot_addr;
-    return buffer_end_addr;
+    return buffer_slot_addr;
 }
 
-FORCE_INLINE uint32_t get_buffer_slot_trid(uint32_t curr_ptr) { return curr_ptr % MAX_NUM_TRANSACTION_ID + 1; }
-
-FORCE_INLINE bool has_incoming_packet(volatile eth_buffer_slot_sync_t* buffer_slot_sync_addr) {
-    invalidate_l1_cache();
-    return buffer_slot_sync_addr->bytes_sent != 0;
+template <uint32_t MAX_NUM_TRANSACTION_ID>
+FORCE_INLINE uint32_t get_buffer_slot_trid(uint32_t curr_ptr) {
+    if constexpr (is_power_of_two(MAX_NUM_TRANSACTION_ID)) {
+        return (curr_ptr + 1) & (MAX_NUM_TRANSACTION_ID - 1);
+    } else if constexpr (MAX_NUM_TRANSACTION_ID == 2) {
+        return 1 - curr_ptr;
+    } else {
+        return curr_ptr == MAX_NUM_TRANSACTION_ID - 1 ? 0 : curr_ptr + 1;
+    }
 }
 
 FORCE_INLINE bool write_worker_done(uint32_t trid) {
     return ncrisc_noc_nonposted_write_with_transaction_id_sent(noc_index, trid);
 }
 
-FORCE_INLINE void ack_complete(
-    uint32_t buffer_slot_addr, volatile eth_buffer_slot_sync_t* buffer_slot_sync_addr, uint32_t full_payload_size) {
-    buffer_slot_sync_addr->bytes_sent = 0;
-
-    while (eth_txq_is_busy()) {
-        switch_context_if_debug();
-    }
-
-    if constexpr (measurement_type == MeasurementType::Latency) {
-        // Send pack entire packet so measurement from sender -> receiver -> sender is symmetric
-        eth_send_bytes_over_channel_payload_only_unsafe_one_packet(
-            buffer_slot_addr, buffer_slot_addr, full_payload_size);
-    } else {
-        eth_send_bytes_over_channel_payload_only_unsafe_one_packet(
-            reinterpret_cast<uint32_t>(buffer_slot_sync_addr),
-            reinterpret_cast<uint32_t>(buffer_slot_sync_addr),
-            sizeof(eth_buffer_slot_sync_t));
-    }
-}
-
 FORCE_INLINE void write_worker(
-    uint32_t buffer_slot_addr,
-    volatile eth_buffer_slot_sync_t* buffer_slot_sync_addr,
-    uint64_t worker_noc_addr,
-    uint32_t message_size,
-    uint32_t curr_trid_to_write) {
-    // write to local
+    uint32_t buffer_slot_addr, uint64_t worker_noc_addr, uint32_t message_size, uint32_t curr_trid_to_write) {
 #ifdef DISABLE_TRID
     noc_async_write(buffer_slot_addr, worker_noc_addr, message_size);
     noc_async_writes_flushed();
@@ -209,87 +163,60 @@ FORCE_INLINE void write_worker(
     noc_async_write_one_packet_with_trid_with_state<false, false>(
         buffer_slot_addr, worker_noc_addr, message_size, curr_trid_to_write);
 #endif
-    // reset sync
-    buffer_slot_sync_addr->bytes_sent = 0;
-}
-
-template <bool write_to_worker>
-FORCE_INLINE void check_incoming_packet_and_write_worker(
-    const std::array<uint32_t, NUM_BUFFER_SLOTS>& buffer_slot_addrs,
-    const std::array<volatile eth_buffer_slot_sync_t*, NUM_BUFFER_SLOTS>& buffer_slot_sync_addrs,
-    uint32_t read_ptr,
-    uint32_t& write_ptr,
-    uint64_t worker_noc_addr,
-    uint32_t message_size) {
-    uint32_t next_write_ptr = advance_buffer_slot_ptr(write_ptr);
-    bool buffer_not_full = next_write_ptr != read_ptr;
-
-    if (buffer_not_full && has_incoming_packet(buffer_slot_sync_addrs[write_ptr])) {
-        if constexpr (write_to_worker) {
-            uint32_t curr_trid = get_buffer_slot_trid(write_ptr);
-            write_worker(
-                buffer_slot_addrs[write_ptr],
-                buffer_slot_sync_addrs[write_ptr],
-                worker_noc_addr,
-                message_size,
-                curr_trid);
-        }
-        write_ptr = next_write_ptr;
-    }
-}
-
-template <bool write_to_worker>
-FORCE_INLINE void check_write_worker_done_and_send_ack(
-    const std::array<uint32_t, NUM_BUFFER_SLOTS>& buffer_slot_addrs,
-    const std::array<volatile eth_buffer_slot_sync_t*, NUM_BUFFER_SLOTS>& buffer_slot_sync_addrs,
-    uint32_t full_payload_size,
-    uint32_t& read_ptr,
-    uint32_t write_ptr,
-    uint32_t& num_messages_ack) {
-    bool buffer_not_empty = read_ptr != write_ptr;
-
-    bool send_ack_condition = buffer_not_empty;
-    if constexpr (write_to_worker and !disable_trid) {
-        uint32_t curr_trid = get_buffer_slot_trid(read_ptr);
-        send_ack_condition = send_ack_condition && write_worker_done(curr_trid);
-    }
-    if (send_ack_condition) {
-        // DPRINT << "read_ptr " << read_ptr << ENDL();
-        ack_complete(buffer_slot_addrs[read_ptr], buffer_slot_sync_addrs[read_ptr], full_payload_size);
-        read_ptr = advance_buffer_slot_ptr(read_ptr);
-        num_messages_ack++;
-    }
 }
 
 template <bool write_to_worker>
 FORCE_INLINE void update_receiver_state(
     const std::array<uint32_t, NUM_BUFFER_SLOTS>& buffer_slot_addrs,
-    const std::array<volatile eth_buffer_slot_sync_t*, NUM_BUFFER_SLOTS>& buffer_slot_sync_addrs,
     uint64_t worker_noc_addr,
     uint32_t message_size,
-    uint32_t full_payload_size,
     uint32_t& num_messages_ack,
     uint32_t& buffer_read_ptr,
     uint32_t& buffer_write_ptr) {
-    // Check if there's an incoming packet for current buffer slot and write to worker if there's new packet
-    check_incoming_packet_and_write_worker<write_to_worker>(
-        buffer_slot_addrs, buffer_slot_sync_addrs, buffer_read_ptr, buffer_write_ptr, worker_noc_addr, message_size);
-    // Check if the write for trid is done, and ack sender if the current buffer slot is done
-    check_write_worker_done_and_send_ack<write_to_worker>(
-        buffer_slot_addrs,
-        buffer_slot_sync_addrs,
-        full_payload_size,
-        buffer_read_ptr,
-        buffer_write_ptr,
-        num_messages_ack);
+    // Check for incoming packets via stream register
+    uint32_t next_write_ptr = advance_buffer_slot_ptr<NUM_BUFFER_SLOTS>(buffer_write_ptr);
+    bool buffer_not_full = next_write_ptr != buffer_read_ptr;
+
+    if (buffer_not_full && get_ptr_val<STREAM_ID_PACKETS_FROM_REMOTE>() > 0) {
+        increment_local_update_ptr_val<STREAM_ID_PACKETS_FROM_REMOTE>(-1);
+        if constexpr (write_to_worker) {
+            uint32_t curr_trid = get_buffer_slot_trid<MAX_NUM_TRANSACTION_ID>(buffer_write_ptr);
+            write_worker(buffer_slot_addrs[buffer_write_ptr], worker_noc_addr, message_size, curr_trid);
+        }
+        buffer_write_ptr = next_write_ptr;
+    }
+
+    // Send ack when processing is complete
+    bool buffer_not_empty = buffer_read_ptr != buffer_write_ptr;
+    bool send_ack_condition = buffer_not_empty;
+    if constexpr (write_to_worker and !disable_trid) {
+        uint32_t curr_trid = get_buffer_slot_trid<MAX_NUM_TRANSACTION_ID>(buffer_read_ptr);
+        send_ack_condition = send_ack_condition && write_worker_done(curr_trid);
+    }
+    if (send_ack_condition) {
+        if constexpr (measurement_type == MeasurementType::Latency) {
+            // Send data back for symmetric round-trip measurement
+            while (eth_txq_is_busy()) {
+                switch_context_if_debug();
+            }
+            internal_::eth_send_packet_bytes_unsafe(
+                0, buffer_slot_addrs[buffer_read_ptr], buffer_slot_addrs[buffer_read_ptr], message_size);
+        }
+        // Send ack via stream register
+        while (eth_txq_is_busy()) {
+            switch_context_if_debug();
+        }
+        remote_update_ptr_val<STREAM_ID_ACKS_FROM_REMOTE, 0>(1);
+
+        buffer_read_ptr = advance_buffer_slot_ptr<NUM_BUFFER_SLOTS>(buffer_read_ptr);
+        num_messages_ack++;
+    }
 }
 
 template <bool write_to_worker>
 FORCE_INLINE void receiver_uni_dir(
     const std::array<uint32_t, NUM_BUFFER_SLOTS>& receiver_buffer_slot_addrs,
-    const std::array<volatile eth_buffer_slot_sync_t*, NUM_BUFFER_SLOTS>& receiver_buffer_slot_sync_addrs,
     uint32_t message_size,
-    uint32_t full_payload_size,
     uint32_t num_messages,
     uint64_t worker_noc_addr) {
     uint32_t total_msgs;
@@ -312,10 +239,8 @@ FORCE_INLINE void receiver_uni_dir(
     while (receiver_num_messages_ack < total_msgs) {
         update_receiver_state<write_to_worker>(
             receiver_buffer_slot_addrs,
-            receiver_buffer_slot_sync_addrs,
             worker_noc_addr,
             message_size,
-            full_payload_size,
             receiver_num_messages_ack,
             receiver_buffer_read_ptr,
             receiver_buffer_write_ptr);
@@ -325,14 +250,103 @@ FORCE_INLINE void receiver_uni_dir(
     }
 }
 
+// ******************************* Tensix-Eth-Eth-Tensix Sender/Receiver APIs ***********************
+
+// Sender eth loop for TensixEthEthTensixUniDir benchmark.
+// Sender eth spins on push_counter from local tensix, sends over ethernet, waits for ack,
+// then writes returning echo data to local tensix and signals tensix_sem.
+FORCE_INLINE void tensix_eth_sender_loop(
+    uint32_t data_slot_addr,
+    uint32_t push_counter_addr,
+    uint64_t tensix_landing_noc_addr,
+    uint64_t tensix_sem_noc_addr,
+    uint32_t message_size,
+    uint32_t num_messages) {
+    volatile tt_l1_ptr uint32_t* push_counter = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(push_counter_addr);
+
+    // Signal tensix that eth is ready (handshake complete, push_counter initialized)
+    noc_semaphore_inc(tensix_sem_noc_addr, 1);
+
+    for (uint32_t i = 0; i < num_messages; i++) {
+        // Wait for local tensix to push data into our slot
+        invalidate_l1_cache();
+        while (*push_counter == 0) {
+            invalidate_l1_cache();
+        }
+        *push_counter = 0;
+
+        // Send data over ethernet to remote eth peer
+        internal_::eth_send_packet_bytes_unsafe(0, data_slot_addr, data_slot_addr, message_size);
+        while (eth_txq_is_busy()) {
+            switch_context_if_debug();
+        }
+        // Notify remote eth that a packet arrived
+        remote_update_ptr_val<STREAM_ID_PACKETS_FROM_REMOTE, 0>(1);
+
+        // Wait for ack (echo data returned from remote)
+        while (get_ptr_val<STREAM_ID_ACKS_FROM_REMOTE>() == 0) {
+            switch_context_if_debug();
+        }
+        increment_local_update_ptr_val<STREAM_ID_ACKS_FROM_REMOTE>(-1);
+
+        // Write echo data from our slot to local tensix landing buffer
+        noc_async_write(data_slot_addr, tensix_landing_noc_addr, message_size);
+
+        // Signal local tensix that data is ready (NOC ordering guarantees data arrives first)
+        noc_semaphore_inc(tensix_sem_noc_addr, 1);
+    }
+}
+
+// Receiver eth loop for TensixEthEthTensixUniDir benchmark.
+// Receiver eth spins on overlay reg for incoming packet, writes to local tensix, signals tensix_sem,
+// then waits for tensix to echo data back, sends echo over ethernet, and acks sender.
+FORCE_INLINE void tensix_eth_receiver_loop(
+    uint32_t data_slot_addr,
+    uint32_t push_counter_addr,
+    uint64_t tensix_landing_noc_addr,
+    uint64_t tensix_sem_noc_addr,
+    uint32_t message_size,
+    uint32_t num_messages) {
+    volatile tt_l1_ptr uint32_t* push_counter = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(push_counter_addr);
+
+    // Signal tensix that eth is ready (handshake complete, push_counter initialized)
+    noc_semaphore_inc(tensix_sem_noc_addr, 1);
+
+    for (uint32_t i = 0; i < num_messages; i++) {
+        // Wait for incoming packet from remote eth (sender)
+        while (get_ptr_val<STREAM_ID_PACKETS_FROM_REMOTE>() == 0) {
+            switch_context_if_debug();
+        }
+        increment_local_update_ptr_val<STREAM_ID_PACKETS_FROM_REMOTE>(-1);
+
+        // Write received data to local tensix landing buffer
+        noc_async_write(data_slot_addr, tensix_landing_noc_addr, message_size);
+
+        // Signal local tensix that data is ready (NOC ordering guarantees data arrives first)
+        noc_semaphore_inc(tensix_sem_noc_addr, 1);
+
+        // Wait for local tensix to push echo data back into our slot
+        invalidate_l1_cache();
+        while (*push_counter == 0) {
+            invalidate_l1_cache();
+        }
+        *push_counter = 0;
+
+        // Send echo data back over ethernet to sender eth
+        internal_::eth_send_packet_bytes_unsafe(0, data_slot_addr, data_slot_addr, message_size);
+        while (eth_txq_is_busy()) {
+            switch_context_if_debug();
+        }
+        // Ack the sender eth
+        remote_update_ptr_val<STREAM_ID_ACKS_FROM_REMOTE, 0>(1);
+    }
+}
+
 // same as below so merge
 template <bool write_to_worker>
 FORCE_INLINE void send_receiver_bi_dir(
     const std::array<uint32_t, NUM_BUFFER_SLOTS>& sender_buffer_slot_addrs,
-    const std::array<volatile eth_buffer_slot_sync_t*, NUM_BUFFER_SLOTS>& sender_buffer_slot_sync_addrs,
     const std::array<uint32_t, NUM_BUFFER_SLOTS>& receiver_buffer_slot_addrs,
-    const std::array<volatile eth_buffer_slot_sync_t*, NUM_BUFFER_SLOTS>& receiver_buffer_slot_sync_addrs,
-    uint32_t full_payload_size,
     uint32_t message_size,
     uint32_t num_messages,
     uint64_t worker_noc_addr) {
@@ -366,8 +380,7 @@ FORCE_INLINE void send_receiver_bi_dir(
     while (num_messages_ack < total_msgs) {
         update_sender_state(
             sender_buffer_slot_addrs,
-            sender_buffer_slot_sync_addrs,
-            full_payload_size,
+            message_size,
             num_messages_ack,
             sender_num_messages_send,
             sender_buffer_read_ptr,
@@ -375,10 +388,8 @@ FORCE_INLINE void send_receiver_bi_dir(
 
         update_receiver_state<write_to_worker>(
             receiver_buffer_slot_addrs,
-            receiver_buffer_slot_sync_addrs,
             worker_noc_addr,
             message_size,
-            full_payload_size,
             num_messages_ack,
             receiver_buffer_read_ptr,
             receiver_buffer_write_ptr);

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/erisc/ethernet_write_worker_latency_ubench_common.hpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/erisc/ethernet_write_worker_latency_ubench_common.hpp
@@ -165,7 +165,7 @@ FORCE_INLINE void write_worker(
 #endif
 }
 
-template <bool write_to_worker>
+template <bool write_to_worker, uint32_t txq_id = 0>
 FORCE_INLINE void update_receiver_state(
     const std::array<uint32_t, NUM_BUFFER_SLOTS>& buffer_slot_addrs,
     uint64_t worker_noc_addr,
@@ -196,24 +196,24 @@ FORCE_INLINE void update_receiver_state(
     if (send_ack_condition) {
         if constexpr (measurement_type == MeasurementType::Latency) {
             // Send data back for symmetric round-trip measurement
-            while (eth_txq_is_busy()) {
+            while (internal_::eth_txq_is_busy(txq_id)) {
                 switch_context_if_debug();
             }
             internal_::eth_send_packet_bytes_unsafe(
-                0, buffer_slot_addrs[buffer_read_ptr], buffer_slot_addrs[buffer_read_ptr], message_size);
+                txq_id, buffer_slot_addrs[buffer_read_ptr], buffer_slot_addrs[buffer_read_ptr], message_size);
         }
         // Send ack via stream register
-        while (eth_txq_is_busy()) {
+        while (internal_::eth_txq_is_busy(txq_id)) {
             switch_context_if_debug();
         }
-        remote_update_ptr_val<STREAM_ID_ACKS_FROM_REMOTE, 0>(1);
+        remote_update_ptr_val<STREAM_ID_ACKS_FROM_REMOTE, txq_id>(1);
 
         buffer_read_ptr = advance_buffer_slot_ptr<NUM_BUFFER_SLOTS>(buffer_read_ptr);
         num_messages_ack++;
     }
 }
 
-template <bool write_to_worker>
+template <bool write_to_worker, uint32_t txq_id = 0>
 FORCE_INLINE void receiver_uni_dir(
     const std::array<uint32_t, NUM_BUFFER_SLOTS>& receiver_buffer_slot_addrs,
     uint32_t message_size,
@@ -237,7 +237,7 @@ FORCE_INLINE void receiver_uni_dir(
     }
 
     while (receiver_num_messages_ack < total_msgs) {
-        update_receiver_state<write_to_worker>(
+        update_receiver_state<write_to_worker, txq_id>(
             receiver_buffer_slot_addrs,
             worker_noc_addr,
             message_size,
@@ -246,6 +246,149 @@ FORCE_INLINE void receiver_uni_dir(
             receiver_buffer_write_ptr);
 
         // not called in normal execution mode
+        switch_context_if_debug();
+    }
+}
+
+// ******************************* Dual-ERISC Sender/Receiver APIs *********************************
+// For DualEriscBiDir mode: ERISC_0 (sender) uses TXQ0 for data + notifications (stream reg writes).
+// ERISC_1 (receiver) uses TXQ1 for acks as DATA packets (register writes via TXQ1 don't work).
+// Sender polls an L1 ack counter instead of stream registers for acks.
+
+// Sender loop for DualEriscBiDir: uses L1 ack counter instead of stream register acks
+FORCE_INLINE void dual_erisc_send_uni_dir(
+    const std::array<uint32_t, NUM_BUFFER_SLOTS>& buffer_slot_addrs,
+    uint32_t message_size,
+    uint32_t num_messages,
+    volatile tt_l1_ptr uint32_t* ack_counter) {
+    uint32_t total_msgs;
+    if constexpr (measurement_type == MeasurementType::Latency) {
+        total_msgs = num_messages;
+    } else {
+        total_msgs = num_messages * NUM_BUFFER_SLOTS;
+    }
+
+    uint32_t sender_buffer_read_ptr = 0;
+    uint32_t sender_buffer_write_ptr = 0;
+    uint32_t sender_num_messages_ack = 0;
+    uint32_t sender_num_messages_send = total_msgs;
+    uint32_t last_seen_ack = 0;
+
+    while (sender_num_messages_ack < total_msgs) {
+        // Try to send a packet if buffer has space and we have messages to send
+        uint32_t next_write_ptr = advance_buffer_slot_ptr<NUM_BUFFER_SLOTS>(sender_buffer_write_ptr);
+        bool buffer_not_full = next_write_ptr != sender_buffer_read_ptr;
+
+        if (buffer_not_full && sender_num_messages_send != 0 && !eth_txq_is_busy()) {
+            internal_::eth_send_packet_bytes_unsafe(
+                0,
+                buffer_slot_addrs[sender_buffer_write_ptr],
+                buffer_slot_addrs[sender_buffer_write_ptr],
+                message_size);
+            while (eth_txq_is_busy()) {
+                switch_context_if_debug();
+            }
+            remote_update_ptr_val<STREAM_ID_PACKETS_FROM_REMOTE, 0>(1);
+            sender_buffer_write_ptr = next_write_ptr;
+            sender_num_messages_send--;
+        }
+
+        // Check for acks via L1 counter (written by remote ERISC_1 via TXQ1 data packet)
+        invalidate_l1_cache();
+        uint32_t current_ack = *ack_counter;
+        if (current_ack > last_seen_ack) {
+            uint32_t new_acks = current_ack - last_seen_ack;
+            last_seen_ack = current_ack;
+            for (uint32_t i = 0; i < new_acks; i++) {
+                sender_buffer_read_ptr = advance_buffer_slot_ptr<NUM_BUFFER_SLOTS>(sender_buffer_read_ptr);
+            }
+            sender_num_messages_ack += new_acks;
+        }
+
+        switch_context_if_debug();
+    }
+}
+
+// Receiver loop for DualEriscBiDir: sends acks as data packets via TXQ1
+// ack_counter_addr: the REMOTE sender's L1 address where it polls for acks (destination of TXQ1 data send)
+// outgoing_ack_addr: LOCAL L1 address used as source for TXQ1 data send (must not conflict with sender's ack poll)
+template <bool write_to_worker>
+FORCE_INLINE void dual_erisc_receiver_uni_dir(
+    const std::array<uint32_t, NUM_BUFFER_SLOTS>& receiver_buffer_slot_addrs,
+    uint32_t message_size,
+    uint32_t num_messages,
+    uint64_t worker_noc_addr,
+    uint32_t remote_ack_dest_addr,
+    uint32_t local_ack_src_addr) {
+    uint32_t total_msgs;
+    if constexpr (measurement_type == MeasurementType::Latency) {
+        total_msgs = num_messages;
+    } else {
+        total_msgs = num_messages * NUM_BUFFER_SLOTS;
+    }
+
+    uint32_t receiver_buffer_read_ptr = 0;
+    uint32_t receiver_buffer_write_ptr = 0;
+    uint32_t receiver_num_messages_ack = 0;
+
+    // Local ack counter: incremented each time we ack, then sent to remote sender via TXQ1.
+    // Uses a SEPARATE L1 address from the incoming ack counter to avoid conflicting with
+    // the local sender (ERISC_0) which polls ack_counter_addr for ITS incoming acks.
+    volatile tt_l1_ptr uint32_t* local_ack = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(local_ack_src_addr);
+    *local_ack = 0;
+
+    if constexpr (write_to_worker) {
+        noc_async_write_one_packet_with_trid_set_state(worker_noc_addr);
+    }
+
+    while (receiver_num_messages_ack < total_msgs) {
+        // Check for incoming packets via stream register
+        uint32_t next_write_ptr = advance_buffer_slot_ptr<NUM_BUFFER_SLOTS>(receiver_buffer_write_ptr);
+        bool buffer_not_full = next_write_ptr != receiver_buffer_read_ptr;
+
+        if (buffer_not_full && get_ptr_val<STREAM_ID_PACKETS_FROM_REMOTE>() > 0) {
+            increment_local_update_ptr_val<STREAM_ID_PACKETS_FROM_REMOTE>(-1);
+            if constexpr (write_to_worker) {
+                uint32_t curr_trid = get_buffer_slot_trid<MAX_NUM_TRANSACTION_ID>(receiver_buffer_write_ptr);
+                write_worker(
+                    receiver_buffer_slot_addrs[receiver_buffer_write_ptr], worker_noc_addr, message_size, curr_trid);
+            }
+            receiver_buffer_write_ptr = next_write_ptr;
+        }
+
+        // Send ack when processing is complete
+        bool buffer_not_empty = receiver_buffer_read_ptr != receiver_buffer_write_ptr;
+        bool send_ack_condition = buffer_not_empty;
+        if constexpr (write_to_worker and !disable_trid) {
+            uint32_t curr_trid = get_buffer_slot_trid<MAX_NUM_TRANSACTION_ID>(receiver_buffer_read_ptr);
+            send_ack_condition = send_ack_condition && write_worker_done(curr_trid);
+        }
+        if (send_ack_condition) {
+            if constexpr (measurement_type == MeasurementType::Latency) {
+                // Send data back for symmetric round-trip measurement
+                while (internal_::eth_txq_is_busy(1)) {
+                    switch_context_if_debug();
+                }
+                internal_::eth_send_packet_bytes_unsafe(
+                    1,
+                    receiver_buffer_slot_addrs[receiver_buffer_read_ptr],
+                    receiver_buffer_slot_addrs[receiver_buffer_read_ptr],
+                    message_size);
+            }
+            // Increment local ack counter and send to remote sender via TXQ1 data packet.
+            // IMPORTANT: Wait for TXQ1 to finish previous DMA BEFORE writing new ack value to L1,
+            // otherwise we corrupt in-flight DMA source data.
+            receiver_num_messages_ack++;
+            while (internal_::eth_txq_is_busy(1)) {
+                switch_context_if_debug();
+            }
+            *local_ack = receiver_num_messages_ack;
+            // Send from local_ack_src_addr to remote's ack_counter_addr (incoming ack location)
+            internal_::eth_send_packet_bytes_unsafe(1, local_ack_src_addr, remote_ack_dest_addr, 16);
+
+            receiver_buffer_read_ptr = advance_buffer_slot_ptr<NUM_BUFFER_SLOTS>(receiver_buffer_read_ptr);
+        }
+
         switch_context_if_debug();
     }
 }

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/erisc/ethernet_write_worker_latency_ubench_receiver.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/erisc/ethernet_write_worker_latency_ubench_receiver.cpp
@@ -13,79 +13,76 @@ void kernel_main() {
     const uint32_t worker_noc_y = get_arg_val<uint32_t>(arg_idx++);
     const uint32_t worker_buffer_addr = get_arg_val<uint32_t>(arg_idx++);
 
+    uint32_t buffer_offset = 0;
+    if constexpr (benchmark_type == BenchmarkType::DualEriscBiDir) {
+        buffer_offset = get_arg_val<uint32_t>(arg_idx++);
+    }
+
     ASSERT(is_power_of_two(NUM_BUFFER_SLOTS));
 
-    const uint32_t full_payload_size = message_size + sizeof(eth_buffer_slot_sync_t);
-    const uint32_t full_payload_size_eth_words = full_payload_size >> 4;
-
-    uint32_t buffer_start_addr = handshake_addr + sizeof(eth_buffer_slot_sync_t);
+    uint32_t buffer_start_addr = handshake_addr + sizeof(eth_buffer_slot_sync_t) + buffer_offset;
 
     std::array<uint32_t, NUM_BUFFER_SLOTS> receiver_buffer_slot_addrs;
-    std::array<volatile eth_buffer_slot_sync_t*, NUM_BUFFER_SLOTS> receiver_buffer_slot_sync_addrs;
-    buffer_start_addr = setup_receiver_buffer(
-        receiver_buffer_slot_addrs, receiver_buffer_slot_sync_addrs, buffer_start_addr, message_size);
+    buffer_start_addr = setup_receiver_buffer(receiver_buffer_slot_addrs, buffer_start_addr, message_size);
 
     // Only used for bi-directional cases
     std::array<uint32_t, NUM_BUFFER_SLOTS> sender_buffer_slot_addrs;
-    std::array<volatile eth_buffer_slot_sync_t*, NUM_BUFFER_SLOTS> sender_buffer_slot_sync_addrs;
     if constexpr (benchmark_type == BenchmarkType::EthOnlyBiDir or benchmark_type == BenchmarkType::EthEthTensixBiDir) {
-        setup_sender_buffer(sender_buffer_slot_addrs, sender_buffer_slot_sync_addrs, buffer_start_addr, message_size);
+        setup_sender_buffer(sender_buffer_slot_addrs, buffer_start_addr, message_size);
     }
 
-    // Avoids hang in issue https://github.com/tenstorrent/tt-metal/issues/9963
-    for (uint32_t i = 0; i < 2000000000; i++) {
-        asm volatile("nop");
+    // For TensixEthEthTensixUniDir, initialize push_counter before handshake
+    if constexpr (benchmark_type == BenchmarkType::TensixEthEthTensixUniDir) {
+        uint32_t push_counter_addr = handshake_addr + sizeof(eth_buffer_slot_sync_t) + message_size;
+        volatile tt_l1_ptr uint32_t* push_counter = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(push_counter_addr);
+        *push_counter = 0;
     }
+
+    // Initialize overlay registers BEFORE handshake
+    init_flow_control_registers();
 
     uint64_t worker_noc_addr = get_noc_addr(worker_noc_x, worker_noc_y, worker_buffer_addr);
 
-    eth_setup_handshake(handshake_addr, false);
+    if constexpr (benchmark_type != BenchmarkType::DualEriscBiDir) {
+        eth_setup_handshake(handshake_addr, false);
+    }
 
     switch (benchmark_type) {
         case EthOnlyUniDir: {
             DeviceZoneScopedN("MAIN-TEST-BODY");
-            receiver_uni_dir<false>(
-                receiver_buffer_slot_addrs,
-                receiver_buffer_slot_sync_addrs,
-                message_size,
-                full_payload_size,
-                num_messages,
-                worker_noc_addr);
+            receiver_uni_dir<false>(receiver_buffer_slot_addrs, message_size, num_messages, worker_noc_addr);
         } break;
         case EthOnlyBiDir: {
             DeviceZoneScopedN("MAIN-TEST-BODY");
             send_receiver_bi_dir<false>(
-                sender_buffer_slot_addrs,
-                sender_buffer_slot_sync_addrs,
-                receiver_buffer_slot_addrs,
-                receiver_buffer_slot_sync_addrs,
-                full_payload_size,
-                message_size,
-                num_messages,
-                worker_noc_addr);
+                sender_buffer_slot_addrs, receiver_buffer_slot_addrs, message_size, num_messages, worker_noc_addr);
         } break;
         case EthEthTensixUniDir: {
             DeviceZoneScopedN("MAIN-TEST-BODY");
-            receiver_uni_dir<true>(
-                receiver_buffer_slot_addrs,
-                receiver_buffer_slot_sync_addrs,
-                message_size,
-                full_payload_size,
-                num_messages,
-                worker_noc_addr);
+            receiver_uni_dir<true>(receiver_buffer_slot_addrs, message_size, num_messages, worker_noc_addr);
         } break;
         case EthEthTensixBiDir: {
             DeviceZoneScopedN("MAIN-TEST-BODY");
             send_receiver_bi_dir<true>(
-                sender_buffer_slot_addrs,
-                sender_buffer_slot_sync_addrs,
-                receiver_buffer_slot_addrs,
-                receiver_buffer_slot_sync_addrs,
-                full_payload_size,
-                message_size,
-                num_messages,
-                worker_noc_addr);
+                sender_buffer_slot_addrs, receiver_buffer_slot_addrs, message_size, num_messages, worker_noc_addr);
 
+        } break;
+        case TensixEthEthTensixUniDir: {
+            uint32_t push_counter_addr = handshake_addr + sizeof(eth_buffer_slot_sync_t) + message_size;
+            uint64_t tensix_landing_noc_addr = get_noc_addr(worker_noc_x, worker_noc_y, worker_buffer_addr);
+            uint64_t tensix_sem_noc_addr = get_noc_addr(worker_noc_x, worker_noc_y, worker_buffer_addr + message_size);
+
+            DeviceZoneScopedN("MAIN-TEST-BODY");
+            tensix_eth_receiver_loop(
+                receiver_buffer_slot_addrs[0],
+                push_counter_addr,
+                tensix_landing_noc_addr,
+                tensix_sem_noc_addr,
+                message_size,
+                num_messages);
+        } break;
+        case DualEriscBiDir: {
+            receiver_uni_dir<false>(receiver_buffer_slot_addrs, message_size, num_messages, worker_noc_addr);
         } break;
         case TensixPushEth: {
             ASSERT(0);

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/erisc/ethernet_write_worker_latency_ubench_receiver.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/erisc/ethernet_write_worker_latency_ubench_receiver.cpp
@@ -39,13 +39,14 @@ void kernel_main() {
     }
 
     // Initialize overlay registers BEFORE handshake
-    init_flow_control_registers();
-
-    uint64_t worker_noc_addr = get_noc_addr(worker_noc_x, worker_noc_y, worker_buffer_addr);
-
+    // For DualEriscBiDir, ERISC_0 (sender kernel) initializes registers and does handshake.
+    // ERISC_1 (this kernel) skips both to avoid register reset races.
     if constexpr (benchmark_type != BenchmarkType::DualEriscBiDir) {
+        init_flow_control_registers();
         eth_setup_handshake(handshake_addr, false);
     }
+
+    uint64_t worker_noc_addr = get_noc_addr(worker_noc_x, worker_noc_y, worker_buffer_addr);
 
     switch (benchmark_type) {
         case EthOnlyUniDir: {
@@ -82,7 +83,20 @@ void kernel_main() {
                 num_messages);
         } break;
         case DualEriscBiDir: {
-            receiver_uni_dir<false>(receiver_buffer_slot_addrs, message_size, num_messages, worker_noc_addr);
+            // Memory layout after buffers: [incoming_ack(16B)][outgoing_ack(16B)]
+            // incoming_ack_addr: polled by ERISC_0 sender for acks (written by REMOTE ERISC_1 via TXQ1)
+            // outgoing_ack_addr: written by THIS ERISC_1, sent to REMOTE's incoming_ack_addr via TXQ1
+            uint32_t remote_ack_dest_addr = handshake_addr + sizeof(eth_buffer_slot_sync_t) +
+                                            2 * NUM_BUFFER_SLOTS * message_size;  // remote sender's incoming ack addr
+            uint32_t local_ack_src_addr = remote_ack_dest_addr + 16;              // our outgoing ack source
+
+            dual_erisc_receiver_uni_dir<false>(
+                receiver_buffer_slot_addrs,
+                message_size,
+                num_messages,
+                worker_noc_addr,
+                remote_ack_dest_addr,
+                local_ack_src_addr);
         } break;
         case TensixPushEth: {
             ASSERT(0);

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/erisc/ethernet_write_worker_latency_ubench_sender.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/erisc/ethernet_write_worker_latency_ubench_sender.cpp
@@ -5,10 +5,7 @@
 #include "ethernet_write_worker_latency_ubench_common.hpp"
 
 FORCE_INLINE void send_uni_dir(
-    const std::array<uint32_t, NUM_BUFFER_SLOTS>& buffer_slot_addrs,
-    const std::array<volatile eth_buffer_slot_sync_t*, NUM_BUFFER_SLOTS>& buffer_slot_sync_addrs,
-    uint32_t full_payload_size,
-    uint32_t num_messages) {
+    const std::array<uint32_t, NUM_BUFFER_SLOTS>& buffer_slot_addrs, uint32_t message_size, uint32_t num_messages) {
     uint32_t total_msgs;
     if constexpr (measurement_type == MeasurementType::Latency) {
         total_msgs = num_messages;
@@ -26,8 +23,7 @@ FORCE_INLINE void send_uni_dir(
     while (sender_num_messages_ack < total_msgs) {
         update_sender_state(
             buffer_slot_addrs,
-            buffer_slot_sync_addrs,
-            full_payload_size,
+            message_size,
             sender_num_messages_ack,
             sender_num_messages_send,
             sender_buffer_read_ptr,
@@ -51,70 +47,78 @@ void kernel_main() {
 
     const uint64_t sender_receiver_encoding = ((uint64_t)sender_encoding << 32) | receiver_encoding;
 
+    uint32_t buffer_offset = 0;
+    if constexpr (benchmark_type == BenchmarkType::DualEriscBiDir) {
+        buffer_offset = get_arg_val<uint32_t>(arg_idx++);
+    }
+
     ASSERT(is_power_of_two(NUM_BUFFER_SLOTS));
 
-    const uint32_t full_payload_size = message_size + sizeof(eth_buffer_slot_sync_t);
-    const uint32_t full_payload_size_eth_words = full_payload_size >> 4;
-
-    uint32_t buffer_start_addr = handshake_addr + sizeof(eth_buffer_slot_sync_t);
+    uint32_t buffer_start_addr = handshake_addr + sizeof(eth_buffer_slot_sync_t) + buffer_offset;
 
     std::array<uint32_t, NUM_BUFFER_SLOTS> sender_buffer_slot_addrs;
-    std::array<volatile eth_buffer_slot_sync_t*, NUM_BUFFER_SLOTS> sender_buffer_slot_sync_addrs;
-    buffer_start_addr =
-        setup_sender_buffer(sender_buffer_slot_addrs, sender_buffer_slot_sync_addrs, buffer_start_addr, message_size);
+    buffer_start_addr = setup_sender_buffer(sender_buffer_slot_addrs, buffer_start_addr, message_size);
 
     // Only used for bi-directional cases
     std::array<uint32_t, NUM_BUFFER_SLOTS> receiver_buffer_slot_addrs;
-    std::array<volatile eth_buffer_slot_sync_t*, NUM_BUFFER_SLOTS> receiver_buffer_slot_sync_addrs;
     if constexpr (benchmark_type == BenchmarkType::EthOnlyBiDir or benchmark_type == BenchmarkType::EthEthTensixBiDir) {
-        setup_receiver_buffer(
-            receiver_buffer_slot_addrs, receiver_buffer_slot_sync_addrs, buffer_start_addr, message_size);
+        setup_receiver_buffer(receiver_buffer_slot_addrs, buffer_start_addr, message_size);
     }
 
-    // Avoids hang in issue https://github.com/tenstorrent/tt-metal/issues/9963
-    for (uint32_t i = 0; i < 2000000000; i++) {
-        asm volatile("nop");
+    // For TensixEthEthTensixUniDir, initialize push_counter before handshake
+    if constexpr (benchmark_type == BenchmarkType::TensixEthEthTensixUniDir) {
+        uint32_t push_counter_addr = handshake_addr + sizeof(eth_buffer_slot_sync_t) + message_size;
+        volatile tt_l1_ptr uint32_t* push_counter = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(push_counter_addr);
+        *push_counter = 0;
     }
+
+    // Initialize overlay registers BEFORE handshake
+    init_flow_control_registers();
 
     eth_setup_handshake(handshake_addr, true);
 
     uint64_t worker_noc_addr = get_noc_addr(worker_noc_x, worker_noc_y, worker_buffer_addr);
 
-    // Log sender/receiver tt_cxy_pair
-    DeviceTimestampedData("SR_ENCODE", sender_receiver_encoding);
+    // Log sender/receiver tt_cxy_pair (not for TensixEthEthTensixUniDir — profiling done on tensix)
+    if constexpr (benchmark_type != BenchmarkType::TensixEthEthTensixUniDir) {
+        DeviceTimestampedData("SR_ENCODE", sender_receiver_encoding);
+    }
 
     switch (benchmark_type) {
         case EthOnlyUniDir: {
             DeviceZoneScopedN("MAIN-TEST-BODY");
-            send_uni_dir(sender_buffer_slot_addrs, sender_buffer_slot_sync_addrs, full_payload_size, num_messages);
+            send_uni_dir(sender_buffer_slot_addrs, message_size, num_messages);
         } break;
         case EthOnlyBiDir: {
             DeviceZoneScopedN("MAIN-TEST-BODY");
             send_receiver_bi_dir<false>(
-                sender_buffer_slot_addrs,
-                sender_buffer_slot_sync_addrs,
-                receiver_buffer_slot_addrs,
-                receiver_buffer_slot_sync_addrs,
-                full_payload_size,
-                message_size,
-                num_messages,
-                worker_noc_addr);
+                sender_buffer_slot_addrs, receiver_buffer_slot_addrs, message_size, num_messages, worker_noc_addr);
         } break;
         case EthEthTensixUniDir: {
             DeviceZoneScopedN("MAIN-TEST-BODY");
-            send_uni_dir(sender_buffer_slot_addrs, sender_buffer_slot_sync_addrs, full_payload_size, num_messages);
+            send_uni_dir(sender_buffer_slot_addrs, message_size, num_messages);
         } break;
         case EthEthTensixBiDir: {
             DeviceZoneScopedN("MAIN-TEST-BODY");
             send_receiver_bi_dir<true>(
-                sender_buffer_slot_addrs,
-                sender_buffer_slot_sync_addrs,
-                receiver_buffer_slot_addrs,
-                receiver_buffer_slot_sync_addrs,
-                full_payload_size,
+                sender_buffer_slot_addrs, receiver_buffer_slot_addrs, message_size, num_messages, worker_noc_addr);
+        } break;
+        case TensixEthEthTensixUniDir: {
+            uint32_t push_counter_addr = handshake_addr + sizeof(eth_buffer_slot_sync_t) + message_size;
+            uint64_t tensix_landing_noc_addr = get_noc_addr(worker_noc_x, worker_noc_y, worker_buffer_addr);
+            uint64_t tensix_sem_noc_addr = get_noc_addr(worker_noc_x, worker_noc_y, worker_buffer_addr + message_size);
+
+            tensix_eth_sender_loop(
+                sender_buffer_slot_addrs[0],
+                push_counter_addr,
+                tensix_landing_noc_addr,
+                tensix_sem_noc_addr,
                 message_size,
-                num_messages,
-                worker_noc_addr);
+                num_messages);
+        } break;
+        case DualEriscBiDir: {
+            DeviceZoneScopedN("MAIN-TEST-BODY");
+            send_uni_dir(sender_buffer_slot_addrs, message_size, num_messages);
         } break;
         case TensixPushEth: {
             ASSERT(0);

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/erisc/ethernet_write_worker_latency_ubench_sender.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/erisc/ethernet_write_worker_latency_ubench_sender.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "ethernet_write_worker_latency_ubench_common.hpp"
+#include "tt_metal/fabric/hw/inc/edm_fabric/fabric_txq_setup.h"
 
 FORCE_INLINE void send_uni_dir(
     const std::array<uint32_t, NUM_BUFFER_SLOTS>& buffer_slot_addrs, uint32_t message_size, uint32_t num_messages) {
@@ -48,8 +49,10 @@ void kernel_main() {
     const uint64_t sender_receiver_encoding = ((uint64_t)sender_encoding << 32) | receiver_encoding;
 
     uint32_t buffer_offset = 0;
+    uint32_t is_handshake_sender = 1;
     if constexpr (benchmark_type == BenchmarkType::DualEriscBiDir) {
         buffer_offset = get_arg_val<uint32_t>(arg_idx++);
+        is_handshake_sender = get_arg_val<uint32_t>(arg_idx++);
     }
 
     ASSERT(is_power_of_two(NUM_BUFFER_SLOTS));
@@ -75,7 +78,14 @@ void kernel_main() {
     // Initialize overlay registers BEFORE handshake
     init_flow_control_registers();
 
-    eth_setup_handshake(handshake_addr, true);
+    eth_setup_handshake(handshake_addr, is_handshake_sender != 0);
+
+    // Enable dual TX queue mode for DualEriscBiDir AFTER handshake:
+    // eth_enable_packet_mode changes TXQ0 behavior (enables packet resend mode)
+    // which may interfere with the legacy eth_send_bytes used by the handshake.
+    if constexpr (benchmark_type == BenchmarkType::DualEriscBiDir) {
+        eth_enable_packet_mode(1);
+    }
 
     uint64_t worker_noc_addr = get_noc_addr(worker_noc_x, worker_noc_y, worker_buffer_addr);
 
@@ -117,8 +127,14 @@ void kernel_main() {
                 num_messages);
         } break;
         case DualEriscBiDir: {
+            // Ack counter lives after both buffer regions in L1
+            uint32_t ack_counter_addr =
+                handshake_addr + sizeof(eth_buffer_slot_sync_t) + 2 * NUM_BUFFER_SLOTS * message_size;
+            volatile tt_l1_ptr uint32_t* ack_counter = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(ack_counter_addr);
+            *ack_counter = 0;
+
             DeviceZoneScopedN("MAIN-TEST-BODY");
-            send_uni_dir(sender_buffer_slot_addrs, message_size, num_messages);
+            dual_erisc_send_uni_dir(sender_buffer_slot_addrs, message_size, num_messages, ack_counter);
         } break;
         case TensixPushEth: {
             ASSERT(0);

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/erisc/tensix_eth_datacopy_worker.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/erisc/tensix_eth_datacopy_worker.cpp
@@ -1,0 +1,118 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Tensix DataMovement kernel for TensixEthEthTensixUniDir benchmark.
+// Compile-time arg is_initiator selects between initiator (sender tensix) and echo (receiver tensix) modes.
+//
+// Initiator mode: fills test_data with iota pattern, writes to eth slot, signals eth push_counter,
+//                 then spins on local tensix_sem for round-trip completion.
+//                 Per-iteration cycle deltas are stored in an L1 timestamp buffer for host readback.
+// Echo mode:      spins on local tensix_sem for incoming data, copies landing_buffer to eth slot,
+//                 signals eth push_counter.
+
+#include <cstdint>
+#include "api/dataflow/dataflow_api.h"
+#include "risc_common.h"
+
+void kernel_main() {
+    constexpr bool is_initiator = get_compile_time_arg_val(0) != 0;
+
+    uint32_t arg_idx = 0;
+    const uint32_t eth_noc_x = get_arg_val<uint32_t>(arg_idx++);
+    const uint32_t eth_noc_y = get_arg_val<uint32_t>(arg_idx++);
+    const uint32_t eth_slot_addr = get_arg_val<uint32_t>(arg_idx++);
+    const uint32_t eth_push_counter_addr = get_arg_val<uint32_t>(arg_idx++);
+    const uint32_t local_sem_addr = get_arg_val<uint32_t>(arg_idx++);
+    const uint32_t local_data_addr = get_arg_val<uint32_t>(arg_idx++);
+    const uint32_t num_messages = get_arg_val<uint32_t>(arg_idx++);
+    const uint32_t message_size = get_arg_val<uint32_t>(arg_idx++);
+
+    volatile tt_l1_ptr uint32_t* tensix_sem = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(local_sem_addr);
+    // Initialize semaphore to 0 before starting
+    *tensix_sem = 0;
+
+    uint64_t eth_slot_noc_addr = get_noc_addr(eth_noc_x, eth_noc_y, eth_slot_addr);
+    uint64_t eth_push_counter_noc_addr = get_noc_addr(eth_noc_x, eth_noc_y, eth_push_counter_addr);
+
+    // Wait for eth kernel to signal that it's ready (handshake complete, push_counter initialized)
+    while (*tensix_sem == 0) {
+    }
+    *tensix_sem = 0;
+
+    if constexpr (is_initiator) {
+        // Read sender/receiver encoding for profiler link identification
+        const uint32_t sender_encoding = get_arg_val<uint32_t>(arg_idx++);
+        const uint32_t receiver_encoding = get_arg_val<uint32_t>(arg_idx++);
+        const uint32_t timestamp_buf_addr = get_arg_val<uint32_t>(arg_idx++);
+        const uint64_t sender_receiver_encoding = ((uint64_t)sender_encoding << 32) | receiver_encoding;
+        DeviceTimestampedData("SR_ENCODE", sender_receiver_encoding);
+
+        // Timestamp buffer: per-iteration cycle deltas stored as uint32_t
+        volatile tt_l1_ptr uint32_t* ts_buf = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(timestamp_buf_addr);
+
+        // Fill test_data buffer with iota pattern
+        // test_data is at local_data_addr + message_size + 16 (after landing_buffer + sem + padding)
+        uint32_t test_data_addr = local_data_addr + message_size + 16;
+        tt_l1_ptr uint8_t* test_data = reinterpret_cast<tt_l1_ptr uint8_t*>(test_data_addr);
+        for (uint32_t j = 0; j < message_size; j++) {
+            test_data[j] = j;
+        }
+
+        // Warmup iteration (not timed)
+        noc_async_write(test_data_addr, eth_slot_noc_addr, message_size);
+        noc_semaphore_inc(eth_push_counter_noc_addr, 1);
+        while (*tensix_sem == 0) {
+        }
+        *tensix_sem = 0;
+
+        {
+            DeviceZoneScopedN("MAIN-TEST-BODY");
+            for (uint32_t i = 0; i < num_messages - 1; i++) {
+                // Read wall clock BEFORE this iteration
+                uint32_t t0 = reg_read(RISCV_DEBUG_REG_WALL_CLOCK_L);
+
+                // Write test_data to eth slot
+                noc_async_write(test_data_addr, eth_slot_noc_addr, message_size);
+
+                // Signal eth that data is ready (NOC ordering guarantees data arrives first)
+                noc_semaphore_inc(eth_push_counter_noc_addr, 1);
+
+                // Wait for round-trip completion (eth writes echo to our landing_buffer)
+                while (*tensix_sem == 0) {
+                }
+                *tensix_sem = 0;
+
+                // Read wall clock AFTER this iteration
+                uint32_t t1 = reg_read(RISCV_DEBUG_REG_WALL_CLOCK_L);
+                ts_buf[i] = t1 - t0;
+            }
+        }
+    } else {
+        // Echo mode: landing_buffer is at local_data_addr (offset 0)
+        uint32_t landing_buffer_addr = local_data_addr;
+        // Wait for eth to deliver incoming data to our landing_buffer
+        while (*tensix_sem == 0) {
+        }
+        *tensix_sem = 0;
+
+        // Echo: copy landing_buffer to eth slot
+        noc_async_write(landing_buffer_addr, eth_slot_noc_addr, message_size);
+
+        // Signal eth that echo data is ready (NOC ordering guarantees data arrives first)
+        noc_semaphore_inc(eth_push_counter_noc_addr, 1);
+
+        for (uint32_t i = 0; i < num_messages - 1; i++) {
+            // Wait for eth to deliver incoming data to our landing_buffer
+            while (*tensix_sem == 0) {
+            }
+            *tensix_sem = 0;
+
+            // Echo: copy landing_buffer to eth slot
+            noc_async_write(landing_buffer_addr, eth_slot_noc_addr, message_size);
+
+            // Signal eth that echo data is ready (NOC ordering guarantees data arrives first)
+            noc_semaphore_inc(eth_push_counter_noc_addr, 1);
+        }
+    }
+}

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/erisc/tensix_eth_datacopy_worker.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/erisc/tensix_eth_datacopy_worker.cpp
@@ -16,6 +16,8 @@
 #include "risc_common.h"
 
 void kernel_main() {
+    set_l1_data_cache<false>();
+
     constexpr bool is_initiator = get_compile_time_arg_val(0) != 0;
 
     uint32_t arg_idx = 0;

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/noc/noc_latency_ping_responder.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/noc/noc_latency_ping_responder.cpp
@@ -20,7 +20,7 @@ void kernel_main() {
 
     volatile tt_l1_ptr uint32_t* local_sem = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(local_sem_addr);
 
-    *local_sem = 0;
+    noc_semaphore_set(local_sem, 0);
 
     // If sender_ready_sem_addr is nonzero, signal the sender that we're ready
     if (sender_ready_sem_addr != 0) {

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/noc/noc_latency_ping_responder.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/noc/noc_latency_ping_responder.cpp
@@ -1,0 +1,38 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Responder kernel for NOC hop latency ping-pong benchmark.
+// Waits for sender to inc our semaphore, then incs sender's semaphore back.
+
+#include <cstdint>
+#include "api/dataflow/dataflow_api.h"
+
+void kernel_main() {
+    set_l1_data_cache<false>();
+    uint32_t arg_idx = 0;
+    const uint32_t sender_noc_x = get_arg_val<uint32_t>(arg_idx++);
+    const uint32_t sender_noc_y = get_arg_val<uint32_t>(arg_idx++);
+    const uint32_t sender_sem_addr = get_arg_val<uint32_t>(arg_idx++);
+    const uint32_t local_sem_addr = get_arg_val<uint32_t>(arg_idx++);
+    const uint32_t total_pings = get_arg_val<uint32_t>(arg_idx++);
+    const uint32_t sender_ready_sem_addr = get_arg_val<uint32_t>(arg_idx++);
+
+    volatile tt_l1_ptr uint32_t* local_sem = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(local_sem_addr);
+
+    *local_sem = 0;
+
+    // If sender_ready_sem_addr is nonzero, signal the sender that we're ready
+    if (sender_ready_sem_addr != 0) {
+        uint64_t sender_ready_noc_addr = get_noc_addr(sender_noc_x, sender_noc_y, sender_ready_sem_addr);
+        noc_semaphore_inc(sender_ready_noc_addr, 1);
+    }
+
+    uint64_t sender_sem_noc_addr = get_noc_addr(sender_noc_x, sender_noc_y, sender_sem_addr);
+
+    for (uint32_t i = 0; i < total_pings; i++) {
+        noc_semaphore_wait(local_sem, 1);
+        noc_semaphore_set(local_sem, 0);
+        noc_semaphore_inc(sender_sem_noc_addr, 1);
+    }
+}

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/noc/noc_latency_ping_sender.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/noc/noc_latency_ping_sender.cpp
@@ -1,0 +1,64 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Sender kernel for NOC hop latency ping-pong benchmark.
+// Sends a semaphore inc to responder, waits for responder to inc our semaphore back.
+// Records per-iteration wall clock cycle deltas in an L1 timestamp buffer.
+
+#include <cstdint>
+#include "api/dataflow/dataflow_api.h"
+#include "risc_common.h"
+
+// risc_common.h has get_timestamp() but we just use reg_read directly for both ERISC and tensix
+
+void kernel_main() {
+    set_l1_data_cache<false>();
+    uint32_t arg_idx = 0;
+    const uint32_t responder_noc_x = get_arg_val<uint32_t>(arg_idx++);
+    const uint32_t responder_noc_y = get_arg_val<uint32_t>(arg_idx++);
+    const uint32_t responder_sem_addr = get_arg_val<uint32_t>(arg_idx++);
+    const uint32_t local_sem_addr = get_arg_val<uint32_t>(arg_idx++);
+    const uint32_t timestamp_buf_addr = get_arg_val<uint32_t>(arg_idx++);
+    const uint32_t num_iterations = get_arg_val<uint32_t>(arg_idx++);
+    const uint32_t num_warmup = get_arg_val<uint32_t>(arg_idx++);
+    const uint32_t ready_sem_addr = get_arg_val<uint32_t>(arg_idx++);
+
+    volatile tt_l1_ptr uint32_t* local_sem = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(local_sem_addr);
+    volatile tt_l1_ptr uint32_t* ts_buf = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(timestamp_buf_addr);
+
+    *local_sem = 0;
+
+    // If ready_sem_addr is nonzero, wait for responder to signal it's ready
+    if (ready_sem_addr != 0) {
+        volatile tt_l1_ptr uint32_t* ready_sem = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(ready_sem_addr);
+        *ready_sem = 0;
+        while (*ready_sem == 0) {
+        }
+    }
+
+    uint64_t responder_sem_noc_addr = get_noc_addr(responder_noc_x, responder_noc_y, responder_sem_addr);
+
+    // Warmup iterations (not timed)
+    for (uint32_t i = 0; i < num_warmup; i++) {
+        noc_semaphore_inc(responder_sem_noc_addr, 1);
+        while (*local_sem == 0) {
+        }
+        *local_sem = 0;
+    }
+
+    // Timed iterations — store [issue_time, poll_time] pairs
+    for (uint32_t i = 0; i < num_iterations; i++) {
+        uint32_t t0 = reg_read(RISCV_DEBUG_REG_WALL_CLOCK_L);
+
+        noc_semaphore_inc(responder_sem_noc_addr, 1);
+        uint32_t seminc_issue_end = reg_read(RISCV_DEBUG_REG_WALL_CLOCK_L);
+
+        noc_semaphore_wait(local_sem, 1);
+        uint32_t t1 = reg_read(RISCV_DEBUG_REG_WALL_CLOCK_L);
+        noc_semaphore_set(local_sem, 0);
+
+        ts_buf[2 * i] = seminc_issue_end - t0;      // issue time (noc_semaphore_inc call)
+        ts_buf[2 * i + 1] = t1 - seminc_issue_end;  // poll time (pure wait for response)
+    }
+}

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/noc/noc_latency_ping_sender.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/noc/noc_latency_ping_sender.cpp
@@ -32,9 +32,8 @@ void kernel_main() {
     // If ready_sem_addr is nonzero, wait for responder to signal it's ready
     if (ready_sem_addr != 0) {
         volatile tt_l1_ptr uint32_t* ready_sem = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(ready_sem_addr);
-        *ready_sem = 0;
-        while (*ready_sem == 0) {
-        }
+        noc_semaphore_set(ready_sem, 0);
+        noc_semaphore_wait(ready_sem, 1);
     }
 
     uint64_t responder_sem_noc_addr = get_noc_addr(responder_noc_x, responder_noc_y, responder_sem_addr);
@@ -42,9 +41,8 @@ void kernel_main() {
     // Warmup iterations (not timed)
     for (uint32_t i = 0; i < num_warmup; i++) {
         noc_semaphore_inc(responder_sem_noc_addr, 1);
-        while (*local_sem == 0) {
-        }
-        *local_sem = 0;
+        noc_semaphore_wait(local_sem, 1);
+        noc_semaphore_set(local_sem, 0);
     }
 
     // Timed iterations — store [issue_time, poll_time] pairs

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/noc/noc_overhead_ubench.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/noc/noc_overhead_ubench.cpp
@@ -1,0 +1,203 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Microbenchmark to measure cycle cost of individual NOC operations:
+//   - fence (invalidate_l1_cache)
+//   - NOC status register read (NOC_STATUS_READ_REG)
+//   - L1 software counter read
+//   - noc_semaphore_inc (forced non-posted atomic on BH)
+//   - noc_semaphore_wait (single iteration, sem already set)
+//   - full barrier (noc_async_full_barrier) with nothing outstanding
+//   - ncrisc_noc_nonposted_atomics_flushed check
+//   - Each individual barrier sub-check
+//
+// Results written to L1 timestamp buffer as pairs of [op_id, cycles].
+
+#include <cstdint>
+#include "api/dataflow/dataflow_api.h"
+#include "risc_common.h"
+#include "noc_nonblocking_api.h"
+
+#define TS() reg_read(RISCV_DEBUG_REG_WALL_CLOCK_L)
+
+void kernel_main() {
+    set_l1_data_cache<false>();
+
+    uint32_t arg_idx = 0;
+    const uint32_t timestamp_buf_addr = get_arg_val<uint32_t>(arg_idx++);
+    const uint32_t num_iterations = get_arg_val<uint32_t>(arg_idx++);
+    const uint32_t target_noc_x = get_arg_val<uint32_t>(arg_idx++);
+    const uint32_t target_noc_y = get_arg_val<uint32_t>(arg_idx++);
+    const uint32_t target_sem_addr = get_arg_val<uint32_t>(arg_idx++);
+
+    volatile tt_l1_ptr uint32_t* ts_buf = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(timestamp_buf_addr);
+
+    // Number of tests
+    constexpr uint32_t NUM_TESTS = 14;
+    // Layout: [test_id(0), min(1), max(2), sum_lo(3), sum_hi(4)] x NUM_TESTS = 70 words header
+    // Then raw samples follow if needed
+    constexpr uint32_t HEADER_WORDS = NUM_TESTS * 5;
+
+    // Initialize header
+    for (uint32_t t = 0; t < NUM_TESTS; t++) {
+        ts_buf[t * 5 + 0] = t;           // test_id
+        ts_buf[t * 5 + 1] = 0xFFFFFFFF;  // min
+        ts_buf[t * 5 + 2] = 0;           // max
+        ts_buf[t * 5 + 3] = 0;           // sum_lo
+        ts_buf[t * 5 + 4] = 0;           // sum_hi
+    }
+
+    auto record = [&](uint32_t test_id, uint32_t cycles) {
+        uint32_t base = test_id * 5;
+        if (cycles < ts_buf[base + 1]) {
+            ts_buf[base + 1] = cycles;
+        }
+        if (cycles > ts_buf[base + 2]) {
+            ts_buf[base + 2] = cycles;
+        }
+        uint32_t old_lo = ts_buf[base + 3];
+        ts_buf[base + 3] = old_lo + cycles;
+        if (ts_buf[base + 3] < old_lo) {
+            ts_buf[base + 4]++;  // carry
+        }
+    };
+
+    uint64_t target_noc_addr = get_noc_addr(target_noc_x, target_noc_y, target_sem_addr);
+
+    // ---- Test 0: fence (invalidate_l1_cache) ----
+    for (uint32_t i = 0; i < num_iterations; i++) {
+        uint32_t t0 = TS();
+        invalidate_l1_cache();
+        uint32_t t1 = TS();
+        record(0, t1 - t0);
+    }
+
+    // ---- Test 1: wall clock read (baseline for timestamp overhead) ----
+    for (uint32_t i = 0; i < num_iterations; i++) {
+        uint32_t t0 = TS();
+        uint32_t t1 = TS();
+        record(1, t1 - t0);
+    }
+
+    // ---- Test 2: NOC_STATUS_READ_REG - NIU_MST_RD_RESP_RECEIVED ----
+    for (uint32_t i = 0; i < num_iterations; i++) {
+        uint32_t t0 = TS();
+        volatile uint32_t x = NOC_STATUS_READ_REG(noc_index, NIU_MST_RD_RESP_RECEIVED);
+        uint32_t t1 = TS();
+        record(2, t1 - t0);
+        (void)x;
+    }
+
+    // ---- Test 3: NOC_STATUS_READ_REG - NIU_MST_NONPOSTED_WR_REQ_SENT ----
+    for (uint32_t i = 0; i < num_iterations; i++) {
+        uint32_t t0 = TS();
+        volatile uint32_t x = NOC_STATUS_READ_REG(noc_index, NIU_MST_NONPOSTED_WR_REQ_SENT);
+        uint32_t t1 = TS();
+        record(3, t1 - t0);
+        (void)x;
+    }
+
+    // ---- Test 4: NOC_STATUS_READ_REG - NIU_MST_WR_ACK_RECEIVED ----
+    for (uint32_t i = 0; i < num_iterations; i++) {
+        uint32_t t0 = TS();
+        volatile uint32_t x = NOC_STATUS_READ_REG(noc_index, NIU_MST_WR_ACK_RECEIVED);
+        uint32_t t1 = TS();
+        record(4, t1 - t0);
+        (void)x;
+    }
+
+    // ---- Test 5: NOC_STATUS_READ_REG - NIU_MST_ATOMIC_RESP_RECEIVED ----
+    for (uint32_t i = 0; i < num_iterations; i++) {
+        uint32_t t0 = TS();
+        volatile uint32_t x = NOC_STATUS_READ_REG(noc_index, NIU_MST_ATOMIC_RESP_RECEIVED);
+        uint32_t t1 = TS();
+        record(5, t1 - t0);
+        (void)x;
+    }
+
+    // ---- Test 6: NOC_STATUS_READ_REG - NIU_MST_POSTED_WR_REQ_SENT ----
+    for (uint32_t i = 0; i < num_iterations; i++) {
+        uint32_t t0 = TS();
+        volatile uint32_t x = NOC_STATUS_READ_REG(noc_index, NIU_MST_POSTED_WR_REQ_SENT);
+        uint32_t t1 = TS();
+        record(6, t1 - t0);
+        (void)x;
+    }
+
+    // ---- Test 7: L1 read of software counter (noc_reads_num_issued) ----
+    for (uint32_t i = 0; i < num_iterations; i++) {
+        uint32_t t0 = TS();
+        volatile uint32_t x = noc_reads_num_issued[noc_index];
+        uint32_t t1 = TS();
+        record(7, t1 - t0);
+        (void)x;
+    }
+
+    // ---- Test 8: ncrisc_noc_reads_flushed (MMIO read + L1 read + compare) ----
+    for (uint32_t i = 0; i < num_iterations; i++) {
+        uint32_t t0 = TS();
+        volatile bool x = ncrisc_noc_reads_flushed(noc_index);
+        uint32_t t1 = TS();
+        record(8, t1 - t0);
+        (void)x;
+    }
+
+    // ---- Test 9: ncrisc_noc_nonposted_atomics_flushed ----
+    for (uint32_t i = 0; i < num_iterations; i++) {
+        uint32_t t0 = TS();
+        volatile bool x = ncrisc_noc_nonposted_atomics_flushed(noc_index);
+        uint32_t t1 = TS();
+        record(9, t1 - t0);
+        (void)x;
+    }
+
+    // ---- Test 10: noc_async_full_barrier (nothing outstanding) ----
+    for (uint32_t i = 0; i < num_iterations; i++) {
+        uint32_t t0 = TS();
+        noc_async_full_barrier();
+        uint32_t t1 = TS();
+        record(10, t1 - t0);
+    }
+
+    // ---- Test 11: noc_semaphore_inc (to self, forced non-posted on BH) ----
+    // Target a local sem so the atomic completes quickly
+    volatile tt_l1_ptr uint32_t* local_dummy = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(target_sem_addr);
+    *local_dummy = 0;
+    uint64_t self_noc_addr = get_noc_addr(
+        NOC_XY_ENCODING(my_x[noc_index], my_y[noc_index]) >> NOC_ADDR_NODE_ID_BITS,
+        NOC_XY_ENCODING(my_x[noc_index], my_y[noc_index]) & ((1 << NOC_ADDR_NODE_ID_BITS) - 1),
+        target_sem_addr);
+    // Actually, just use get_noc_addr with my_x/my_y directly
+    // Warmup to get counters in steady state
+    noc_semaphore_inc(target_noc_addr, 1);
+    while (!ncrisc_noc_nonposted_atomics_flushed(noc_index));
+
+    for (uint32_t i = 0; i < num_iterations; i++) {
+        uint32_t t0 = TS();
+        noc_semaphore_inc(target_noc_addr, 1);
+        uint32_t t1 = TS();
+        record(11, t1 - t0);
+        // Wait for atomic to complete before next iteration
+        while (!ncrisc_noc_nonposted_atomics_flushed(noc_index));
+    }
+
+    // ---- Test 12: noc_semaphore_inc + wait for atomic flush (full round-trip to target) ----
+    for (uint32_t i = 0; i < num_iterations; i++) {
+        uint32_t t0 = TS();
+        noc_semaphore_inc(target_noc_addr, 1);
+        while (!ncrisc_noc_nonposted_atomics_flushed(noc_index));
+        uint32_t t1 = TS();
+        record(12, t1 - t0);
+    }
+
+    // ---- Test 13: volatile L1 read (semaphore poll, single read, no fence) ----
+    *local_dummy = 1;  // pre-set so we don't block
+    for (uint32_t i = 0; i < num_iterations; i++) {
+        uint32_t t0 = TS();
+        volatile uint32_t x = *local_dummy;
+        uint32_t t1 = TS();
+        record(13, t1 - t0);
+        (void)x;
+    }
+}


### PR DESCRIPTION
## Summary                                                                                                                                                                            
- Extend raw ethernet microbenchmarks with worker-to-worker round-trip latency (type 8: TensixEthEthTensixUniDir), worker core sweep modes, and per-core NOC selection             
- Add standalone NOC hop latency microbenchmark (test_noc_hop_latency) measuring single-write latency across all worker/eth core pairs with 2D distance heatmaps                   
- Add --extended pytest flag to gate exhaustive N^2 sweep tests that take a long time to run

New benchmark: TensixEthEthTensixUniDir (type 8)
Full worker-to-worker round-trip over ethernet: tensix → eth → [link] → eth → tensix → eth → [link] → eth → tensix. Per-iteration cycle timestamps are captured on the initiator tensix core and read back by the host, giving precise round-trip latency without profiler overhead.

Worker core sweep modes for the ethernet benchmark:
- sweep_cores=1: Sweep sender core across the full compute grid, receiver fixed at closest-to-eth
- sweep_cores=3: Sweep receiver core, sender fixed at closest-to-eth
- sweep_cores=2: Sweep both sender × receiver (N^2) — gated behind --extended
- sweep_cores=0: Both sender and receiver at closest-to-eth (single point)

NOC-aware core placement: assign_tensix() picks the closest core to eth based on which NOC the tensix kernel uses — top row for NOC_1 (shortest -y path), bottom row for NOC_0 (shortest +y wrap path).

New standalone NOC hop latency test (test_noc_hop_latency): Measures single noc_async_write latency from a fixed source to every destination core. Modes: worker→worker, eth→worker, worker→eth. Outputs 2D latency grids and per-distance summaries with linear regression fits.

## Tests

  - Build: ninja -C build test/tt_metal/perf_microbenchmark/ethernet/test_all_ethernet_links test/tt_metal/perf_microbenchmark/noc/test_noc_hop_latency
  - Existing eth-only latency tests still pass (backward compatible, no new CLI args needed)
  - Sender core sweep produces a 2D latency grid showing NOC distance effects
  - Receiver core sweep produces an equivalent grid
  - Closest-to-closest gives a single latency measurement
  - Extended sweep tests are skipped without --extended flag

 ## Usage examples

### --- Ethernet worker-to-worker latency ---

- Sender core sweep (receiver at closest-to-eth), packet_size=16, both tensix on NOC_1
  TT_METAL_HOME=$PWD pytest tests/tt_metal/microbenchmarks/ethernet/test_all_ethernet_links_latency.py \
    -k "test_erisc_write_worker_latency_core_sweep[16]" -s

-  Receiver core sweep (sender at closest-to-eth), packet_size=16
  TT_METAL_HOME=$PWD pytest tests/tt_metal/microbenchmarks/ethernet/test_all_ethernet_links_latency.py \
    -k "test_erisc_write_worker_latency_receiver_sweep[16]" -s

-  Single point: closest sender to closest receiver, all packet sizes
  TT_METAL_HOME=$PWD pytest tests/tt_metal/microbenchmarks/ethernet/test_all_ethernet_links_latency.py \
    -k "test_tensix_eth_eth_tensix_latency_uni_dir" -s

- Extended N^2 sweep (requires --extended flag, takes ~30 min)
  TT_METAL_HOME=$PWD pytest tests/tt_metal/microbenchmarks/ethernet/test_all_ethernet_links_latency.py \
    -k "test_erisc_write_worker_latency_extended_sweep" --extended -s

- Direct C++ binary: sender sweep, 100 packets, ps=16, 2 channels, NOC_1/NOC_1
  TT_METAL_HOME=$PWD TT_METAL_DEVICE_PROFILER=1 TT_METAL_PROFILER_MID_RUN_DUMP=1 \
    build/test/tt_metal/perf_microbenchmark/ethernet/test_all_ethernet_links \
    8 100 16 2 1 0 1 1 1 1
  - #args: type packets pkt_size channels latency trid iters sweep_cores sender_noc receiver_noc

  ### --- NOC hop latency ---

- Worker→Worker sweep, NOC_0, 100 iterations, 10 warmup
  TT_METAL_HOME=$PWD TT_METAL_SLOW_DISPATCH_MODE=1 \
    build/test/tt_metal/perf_microbenchmark/noc/test_noc_hop_latency 100 10 0 0
  - #args: iterations warmup noc_index mode(0=w2w, 1=eth2w, 2=w2eth)

 - Eth→Worker sweep, NOC_0
  TT_METAL_HOME=$PWD TT_METAL_SLOW_DISPATCH_MODE=1 \
    build/test/tt_metal/perf_microbenchmark/noc/test_noc_hop_latency 100 10 0 1


### Ticket
Link to Github Issue

### Problem description
Provide context for the problem.

### What's changed
Describe the approach used to solve the problem.
Summarize the changes made and its impact.

### Checklist

- [x] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:{{branch_name}}): https://github.com/tenstorrent/tt-metal/actions/runs/22158930587
- [ ] Metal Microbenchmark: https://github.com/tenstorrent/tt-metal/actions/runs/22158938429
- [ ] 
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:{{branch_name}})
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:{{branch_name}})
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:{{branch_name}})
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:{{branch_name}})
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:{{branch_name}})
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
