### PR TITLE
Create view MeshBuffer in tensor::view and store root MeshBuffer in DeviceStorage

### DIFF
--- a/ttnn/api/ttnn/tensor/storage.hpp
+++ b/ttnn/api/ttnn/tensor/storage.hpp
@@ -39,14 +39,20 @@ private:
 struct DeviceStorage {
     std::vector<distributed::MeshCoordinate> coords;
     std::shared_ptr<distributed::MeshBuffer> mesh_buffer;
+    // Workaround for managing view MeshBuffer; expected to be refactored in #38093
+    std::shared_ptr<distributed::MeshBuffer> root_mesh_buffer;
 
     DeviceStorage() = default;
     DeviceStorage(
-        std::shared_ptr<distributed::MeshBuffer> mesh_buffer_, std::vector<distributed::MeshCoordinate> coords_);
+        std::shared_ptr<distributed::MeshBuffer> mesh_buffer_,
+        std::vector<distributed::MeshCoordinate> coords_,
+        std::shared_ptr<distributed::MeshBuffer> root_buffer_ = nullptr);
 
     Buffer* get_buffer() const;
     std::shared_ptr<distributed::MeshBuffer> get_mesh_buffer() const;
-
+    const std::shared_ptr<distributed::MeshBuffer>& get_root_mesh_buffer() const;
+    void deallocate_root_mesh_buffer();
+    void reset_root_mesh_buffer();
     static constexpr auto attribute_names = std::forward_as_tuple();
     auto attribute_values() const { return std::forward_as_tuple(); }
 

--- a/ttnn/core/tensor/storage.cpp
+++ b/ttnn/core/tensor/storage.cpp
@@ -25,8 +25,10 @@ HostStorage HostStorage::transform(const std::function<HostBuffer(const HostBuff
 }
 
 DeviceStorage::DeviceStorage(
-    std::shared_ptr<distributed::MeshBuffer> mesh_buffer_, std::vector<distributed::MeshCoordinate> coords_) :
-    coords(std::move(coords_)), mesh_buffer(std::move(mesh_buffer_)) {}
+    std::shared_ptr<distributed::MeshBuffer> mesh_buffer_,
+    std::vector<distributed::MeshCoordinate> coords_,
+    std::shared_ptr<distributed::MeshBuffer> root_buffer_) :
+    coords(std::move(coords_)), mesh_buffer(std::move(mesh_buffer_)), root_mesh_buffer(std::move(root_buffer_)) {}
 
 Buffer* DeviceStorage::get_buffer() const {
     if (this->mesh_buffer != nullptr) {
@@ -38,6 +40,26 @@ Buffer* DeviceStorage::get_buffer() const {
 std::shared_ptr<distributed::MeshBuffer> DeviceStorage::get_mesh_buffer() const {
     TT_FATAL(mesh_buffer != nullptr, "Buffer is not allocated");
     return mesh_buffer;
+}
+
+const std::shared_ptr<distributed::MeshBuffer>& DeviceStorage::get_root_mesh_buffer() const {
+    return root_mesh_buffer ? root_mesh_buffer : mesh_buffer;
+}
+
+void DeviceStorage::deallocate_root_mesh_buffer() {
+    if (root_mesh_buffer) {
+        root_mesh_buffer->deallocate();
+    } else {
+        mesh_buffer->deallocate();
+    }
+}
+
+void DeviceStorage::reset_root_mesh_buffer() {
+    if (root_mesh_buffer) {
+        root_mesh_buffer.reset();
+    } else {
+        mesh_buffer.reset();
+    }
 }
 
 bool DeviceStorage::is_allocated() const { return this->mesh_buffer != nullptr && this->mesh_buffer->is_allocated(); }

--- a/ttnn/core/tensor/tensor.cpp
+++ b/ttnn/core/tensor/tensor.cpp
@@ -135,10 +135,10 @@ void Tensor::deallocate_impl(bool force) {
             tt::stl::overloaded{
                 [](HostStorage&) {},
                 [this, force, &can_deallocate](DeviceStorage& storage) {
-                    if (can_deallocate(storage.mesh_buffer, force)) {
-                        storage.mesh_buffer->deallocate();
+                    if (can_deallocate(storage.get_root_mesh_buffer(), force)) {
+                        storage.deallocate_root_mesh_buffer();
                     }
-                    storage.mesh_buffer.reset();
+                    storage.reset_root_mesh_buffer();
                 }},
             this->tensor_attributes->get_storage());
     }

--- a/ttnn/core/tensor/tensor_ops.cpp
+++ b/ttnn/core/tensor/tensor_ops.cpp
@@ -249,24 +249,33 @@ Tensor view(const Tensor& input_tensor, const Shape& new_logical_shape, const Sh
     tt::tt_metal::GraphTracker::instance().track_function_start(
         "Tensor::reshape", input_tensor, new_logical_shape, new_padded_shape);
 
-    auto infer_output_memory_config = [](const MemoryConfig& input_memory_config,
-                                         const tt::tt_metal::Shape& output_padded_shape) -> MemoryConfig {
-        if (input_memory_config.memory_layout() == TensorMemoryLayout::HEIGHT_SHARDED) {
-            auto shard_spec = input_memory_config.shard_spec().value();
-            auto shard_volume = shard_spec.numel();
-            shard_spec.shape[1] = output_padded_shape[-1];  // update output shard to match new shard width
-            shard_spec.shape[0] = shard_volume / shard_spec.shape[1];
-            return MemoryConfig{input_memory_config.memory_layout(), input_memory_config.buffer_type(), shard_spec};
-        }
-        return input_memory_config;
-    };
-
     // Just edit shape if shape has a 0 dimension
     if (input_tensor.logical_volume() == 0) {
         TT_FATAL(new_logical_shape.volume() == 0, "Tensor volume is 0, but shape's volume is not");
     }
+    bool is_row_major = input_tensor.layout() == Layout::ROW_MAJOR;
+    bool changing_last_dim = new_padded_shape[-1] != input_tensor.padded_shape()[-1];
+    const auto& input_memory_config = input_tensor.memory_config();
+    TT_FATAL(
+        !input_memory_config.is_sharded() || !changing_last_dim ||
+            input_memory_config.shard_spec()->shape[1] == input_tensor.padded_shape()[-1],
+        "Changing the last dimension of a sharded tensor is not supported unless the shard width matches the input "
+        "last dimension. "
+        "Input shape: {}, New shape: {}, Shard width: {}",
+        input_tensor.padded_shape(),
+        new_padded_shape,
+        input_memory_config.shard_spec()->shape[1]);
 
-    const auto output_memory_config = infer_output_memory_config(input_tensor.memory_config(), new_padded_shape);
+    auto output_memory_config = input_memory_config;
+    if (is_row_major && input_memory_config.is_sharded() && changing_last_dim) {
+        auto shard_spec = input_memory_config.shard_spec().value();
+        auto shard_volume = shard_spec.numel();
+        shard_spec.shape[1] = new_padded_shape[-1];  // update output shard to match new shard width
+        shard_spec.shape[0] = shard_volume / shard_spec.shape[1];
+        output_memory_config =
+            MemoryConfig{input_memory_config.memory_layout(), input_memory_config.buffer_type(), shard_spec};
+    }
+
     auto new_spec = tt::tt_metal::TensorSpec(
         new_logical_shape,
         TensorLayout::fromPaddedShape(
@@ -275,66 +284,58 @@ Tensor view(const Tensor& input_tensor, const Shape& new_logical_shape, const Sh
             output_memory_config,
             new_logical_shape,
             new_padded_shape));
-
     // TODO (#25340): Review tensor topology logic for reshape
     auto output = std::visit(
-        [&input_tensor, &new_spec, &new_logical_shape, &new_padded_shape](auto&& storage) -> Tensor {
+        [&input_tensor, &new_spec, &new_logical_shape, &new_padded_shape, &output_memory_config, &changing_last_dim](
+            auto&& storage) -> Tensor {
             using T = std::decay_t<decltype(storage)>;
             const auto& tensor = input_tensor;
 
             if constexpr (std::is_same_v<T, tt::tt_metal::DeviceStorage>) {
                 auto device_storage = std::get<tt::tt_metal::DeviceStorage>(tensor.storage());
-                if (input_tensor.layout() != Layout::ROW_MAJOR) {
+                if (tensor.layout() != Layout::ROW_MAJOR || !changing_last_dim) {
                     return Tensor(std::move(device_storage), new_spec, tensor.tensor_topology());
                 }
-                if (tensor.memory_config().memory_layout() != TensorMemoryLayout::HEIGHT_SHARDED) {
+                if (!tensor.memory_config().is_sharded()) {
                     auto* device_buffer = device_storage.get_buffer();
-                    const auto& tensor_spec = tensor.tensor_spec();
-                    auto page_size_bytes = tensor_spec.compute_page_size_bytes();
+                    auto page_size_bytes = new_spec.compute_page_size_bytes();
                     device_buffer->set_page_size(page_size_bytes);
                     return Tensor(std::move(device_storage), new_spec, tensor.tensor_topology());
                 }
 
-                auto* device_buffer = device_storage.get_buffer();
-                tt::tt_metal::ShardSpecBuffer shard_spec_buffer = device_buffer->shard_spec();
+                tt::tt_metal::ShardSpec new_shard_spec = output_memory_config.shard_spec().value();
+                std::array<uint32_t, 2> shard_page_shape = {1, new_shard_spec.shape[1]};
+                std::array<uint32_t, 2> tensor2d_shape_in_pages = {
+                    new_spec.physical_shape().height() / shard_page_shape[0],
+                    new_spec.physical_shape().width() / shard_page_shape[1]};
+                tt::tt_metal::ShardSpecBuffer new_shard_spec_buffer =
+                    tt::tt_metal::ShardSpecBuffer(new_shard_spec, shard_page_shape, tensor2d_shape_in_pages);
 
-                auto shard_spec = shard_spec_buffer.tensor_shard_spec;
-                auto shard_shape = shard_spec.shape;
+                tt::tt_metal::Shape tensor_shape_pages(tensor2d_shape_in_pages);
+                tt::tt_metal::Shape shard_shape_pages(new_shard_spec_buffer.shape_in_pages());
+                tt::tt_metal::BufferDistributionSpec new_buffer_dist_spec = tt::tt_metal::BufferDistributionSpec(
+                    tensor_shape_pages, shard_shape_pages, new_shard_spec.grid, new_shard_spec.orientation);
 
-                uint32_t mul_div;
-                if (new_logical_shape[-1] == 0 || shard_shape[1] == 0) {
-                    mul_div = 0;
-                } else {
-                    mul_div = new_logical_shape[-1] > shard_shape[1] ? (new_logical_shape[-1] / shard_shape[1])
-                                                                     : (shard_shape[1] / new_logical_shape[-1]);
-                }
+                auto device_local_config = device_storage.mesh_buffer->device_local_config();
+                auto& sharding_args = device_local_config.sharding_args;
+                tt::tt_metal::BufferShardingArgs new_sharding_args(
+                    new_buffer_dist_spec, new_shard_spec_buffer, sharding_args.buffer_layout());
 
-                shard_spec.shape[0] =
-                    new_logical_shape[-1] > shard_shape[1] ? shard_shape[0] / mul_div : shard_shape[0] * mul_div;
-                shard_spec.shape[1] = new_logical_shape[-1];
+                tt::tt_metal::distributed::DeviceLocalBufferConfig new_device_config = {
+                    .page_size = new_spec.compute_page_size_bytes(),
+                    .buffer_type = device_local_config.buffer_type,
+                    .sharding_args = new_sharding_args,
+                    .bottom_up = device_local_config.bottom_up};
 
-                MemoryConfig mem_config = input_tensor.memory_config().with_shard_spec(shard_spec);
+                auto view_mesh_buffer = tt::tt_metal::distributed::MeshBuffer::create(
+                    device_storage.mesh_buffer->global_config(),
+                    new_device_config,
+                    device_storage.mesh_buffer->device(),
+                    device_storage.mesh_buffer->address());
+                tt::tt_metal::DeviceStorage view_storage(
+                    view_mesh_buffer, device_storage.coords, device_storage.get_root_mesh_buffer());
 
-                auto upd_spec = tt::tt_metal::TensorSpec(
-                    new_logical_shape,
-                    TensorLayout::fromPaddedShape(
-                        input_tensor.dtype(),
-                        input_tensor.tensor_spec().page_config(),
-                        mem_config,
-                        new_logical_shape,
-                        new_padded_shape));
-
-                shard_spec_buffer.page_shape = {1, new_logical_shape[-1]};
-                shard_spec_buffer.tensor2d_shape_in_pages = {
-                    upd_spec.physical_shape().height() / shard_spec_buffer.page_shape[0],
-                    upd_spec.physical_shape().width() / shard_spec_buffer.page_shape[1]};
-                shard_spec_buffer.set_shard_spec(shard_spec);
-                device_buffer->set_shard_spec(shard_spec_buffer);
-
-                auto page_size_bytes = upd_spec.compute_page_size_bytes();
-                device_buffer->set_page_size(page_size_bytes);
-
-                return Tensor(std::move(device_storage), upd_spec, tensor.tensor_topology());
+                return Tensor(view_storage, new_spec, tensor.tensor_topology());
 
             } else if constexpr (std::is_same_v<T, tt::tt_metal::HostStorage>) {
                 return Tensor(tensor.storage(), new_spec, tensor.tensor_topology());


### PR DESCRIPTION
### Problem description
The current view operation for row-major layout changes the shared MeshBuffer from the input and also uses wrong parameters. As a result, it can break the input tensor, and if the next operation uses TensorAccessor, it can lead to a hang or wrong results.

### What's changed
Now the view operation creates a new MeshBuffer (view on the original) with correct sharding arguments. Additionally, to support this, storage now stores a pointer to the root MeshBuffer to correctly manage this resource. This is a current work-around which is expected to be removed in https://github.com/tenstorrent/tt-metal/issues/38093

### Checklist

- [x] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=itaraban/try-fix-view)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:itaraban/try-fix-view)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=itaraban/try-fix-view)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:itaraban/try-fix-view)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=itaraban/try-fix-view)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:itaraban/try-fix-view)
