### PR TITLE
Decouple FDKernels from MetalContext

### DIFF
--- a/tt_metal/fabric/fabric_builder.cpp
+++ b/tt_metal/fabric/fabric_builder.cpp
@@ -35,6 +35,7 @@ FabricBuilder::FabricBuilder(
 void FabricBuilder::discover_channels() {
     const auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
     const bool is_2D_routing = fabric_context_.is_2D_routing_enabled();
+    bool is_galaxy_cluster = tt_metal::MetalContext::instance().get_cluster().is_galaxy_cluster();
 
     auto is_dispatch_link = [&](chan_id_t eth_chan, uint32_t dispatch_link_idx) {
         auto link_idx = control_plane.get_routing_plane_id(local_node_, eth_chan);
@@ -68,8 +69,8 @@ void FabricBuilder::discover_channels() {
         channels_by_direction_[direction] = active_eth_chans;
 
         // Identify and cache dispatch links
-        uint32_t dispatch_link_idx =
-            tt::tt_metal::RelayMux::get_dispatch_link_index(local_node_, neighbor_fabric_node_id, device_);
+        uint32_t dispatch_link_idx = tt::tt_metal::RelayMux::get_dispatch_link_index(
+            control_plane, is_galaxy_cluster, local_node_, neighbor_fabric_node_id, device_);
         for (const auto& eth_chan : active_eth_chans) {
             if (is_dispatch_link(eth_chan, dispatch_link_idx)) {
                 dispatch_links_.insert(eth_chan);

--- a/tt_metal/fabric/fabric_tensix_builder.cpp
+++ b/tt_metal/fabric/fabric_tensix_builder.cpp
@@ -44,6 +44,7 @@ void FabricTensixDatamoverConfig::find_min_max_eth_channels(const std::vector<tt
 
     auto device_id = all_active_devices.front()->id();
     const auto& control_plane = tt_metal::MetalContext::instance().get_control_plane();
+    bool is_galaxy_cluster = tt_metal::MetalContext::instance().get_cluster().is_galaxy_cluster();
     has_dispatch_tunnel_ = device_has_dispatch_tunnel(device_id);
 
     for (const auto& device : all_active_devices) {
@@ -75,8 +76,8 @@ void FabricTensixDatamoverConfig::find_min_max_eth_channels(const std::vector<tt
         std::vector<chan_id_t> non_dispatch_active_channels;
         std::set<routing_plane_id_t> non_dispatch_routing_planes;
         for (const auto& [direction, remote_fabric_node_id] : chip_neighbors) {
-            dispatch_link_idx_ =
-                tt_metal::RelayMux::get_dispatch_link_index(fabric_node_id, remote_fabric_node_id, device);
+            dispatch_link_idx_ = tt_metal::RelayMux::get_dispatch_link_index(
+                control_plane, is_galaxy_cluster, fabric_node_id, remote_fabric_node_id, device);
 
             for (const auto& eth_chan : active_fabric_eth_channels[direction]) {
                 auto link_idx = control_plane.get_routing_plane_id(fabric_node_id, eth_chan);

--- a/tt_metal/impl/context/context_descriptor.hpp
+++ b/tt_metal/impl/context/context_descriptor.hpp
@@ -25,6 +25,10 @@ namespace tt::tt_metal {
 class Hal;
 class MetalContext;
 class DeviceManager;
+class dispatch_core_manager;
+class DispatchQueryManager;
+class DispatchMemMap;
+class DPrintServer;
 
 class ContextDescriptor {
 public:
@@ -55,6 +59,31 @@ public:
         fabric_udm_mode_(fabric_udm_mode),
         fabric_manager_(fabric_manager),
         router_config_(router_config) {}
+
+    const Hal& hal() const { return *hal_; }
+    Cluster& cluster() const { return *cluster_; }
+    const llrt::RunTimeOptions& rtoptions() const { return *rtoptions_; }
+
+    int num_cqs() const { return num_cqs_; }
+    int l1_small_size() const { return l1_small_size_; }
+    int trace_region_size() const { return trace_region_size_; }
+    int worker_l1_size() const { return worker_l1_size_; }
+    const DispatchCoreConfig& dispatch_core_config() const { return dispatch_core_config_; }
+    bool is_mock_device() const { return !mock_cluster_desc_path_.empty(); }
+    std::string_view mock_cluster_desc_path() const { return mock_cluster_desc_path_; }
+    const tt::stl::Span<const std::uint32_t>& l1_bank_remap() const { return l1_bank_remap_; }
+
+    tt::tt_fabric::FabricConfig fabric_config() const { return fabric_config_; }
+    tt::tt_fabric::FabricReliabilityMode reliability_mode() const { return reliability_mode_; }
+    std::optional<uint8_t> num_routing_planes() const { return num_routing_planes_; }
+    tt::tt_fabric::FabricTensixConfig fabric_tensix_config() const { return fabric_tensix_config_; }
+    tt::tt_fabric::FabricUDMMode fabric_udm_mode() const { return fabric_udm_mode_; }
+    tt::tt_fabric::FabricManagerMode fabric_manager() const { return fabric_manager_; }
+    const tt::tt_fabric::FabricRouterConfig& router_config() const { return router_config_; }
+
+private:
+    friend class MetalContext;
+    friend class DeviceManager;
 
     // Intended for internal use by MetalContext to pass in HAL/Cluster/RuntimeOptions dependencies for init
     ContextDescriptor(
@@ -92,31 +121,6 @@ public:
         router_config_(router_config) {}
 
     ContextDescriptor() = default;
-
-    const Hal& hal() const { return *hal_; }
-    Cluster& cluster() const { return *cluster_; }
-    const llrt::RunTimeOptions& rtoptions() const { return *rtoptions_; }
-
-    int num_cqs() const { return num_cqs_; }
-    int l1_small_size() const { return l1_small_size_; }
-    int trace_region_size() const { return trace_region_size_; }
-    int worker_l1_size() const { return worker_l1_size_; }
-    const DispatchCoreConfig& dispatch_core_config() const { return dispatch_core_config_; }
-    bool is_mock_device() const { return !mock_cluster_desc_path_.empty(); }
-    std::string_view mock_cluster_desc_path() const { return mock_cluster_desc_path_; }
-    const tt::stl::Span<const std::uint32_t>& l1_bank_remap() const { return l1_bank_remap_; }
-
-    tt::tt_fabric::FabricConfig fabric_config() const { return fabric_config_; }
-    tt::tt_fabric::FabricReliabilityMode reliability_mode() const { return reliability_mode_; }
-    std::optional<uint8_t> num_routing_planes() const { return num_routing_planes_; }
-    tt::tt_fabric::FabricTensixConfig fabric_tensix_config() const { return fabric_tensix_config_; }
-    tt::tt_fabric::FabricUDMMode fabric_udm_mode() const { return fabric_udm_mode_; }
-    tt::tt_fabric::FabricManagerMode fabric_manager() const { return fabric_manager_; }
-    const tt::tt_fabric::FabricRouterConfig& router_config() const { return router_config_; }
-
-private:
-    friend class MetalContext;
-    friend class DeviceManager;
 
     // Dependencies
     const Hal* hal_ = nullptr;

--- a/tt_metal/impl/context/context_descriptor.hpp
+++ b/tt_metal/impl/context/context_descriptor.hpp
@@ -25,10 +25,6 @@ namespace tt::tt_metal {
 class Hal;
 class MetalContext;
 class DeviceManager;
-class dispatch_core_manager;
-class DispatchQueryManager;
-class DispatchMemMap;
-class DPrintServer;
 
 class ContextDescriptor {
 public:

--- a/tt_metal/impl/context/metal_context.cpp
+++ b/tt_metal/impl/context/metal_context.cpp
@@ -939,7 +939,7 @@ tt_fabric::FabricManagerMode MetalContext::get_fabric_manager() const { return f
 
 std::shared_ptr<ContextDescriptor> MetalContext::create_context_descriptor(
     int num_hw_cqs, size_t l1_small_size, size_t trace_region_size, size_t worker_l1_size) {
-    return std::make_shared<ContextDescriptor>(
+    return std::shared_ptr<ContextDescriptor>(new ContextDescriptor(
         *hal_,
         *cluster_,
         rtoptions_,
@@ -955,7 +955,7 @@ std::shared_ptr<ContextDescriptor> MetalContext::create_context_descriptor(
         worker_l1_size,
         dispatch_core_config_,
         l1_bank_remap_,
-        rtoptions_.get_mock_cluster_desc_path());
+        rtoptions_.get_mock_cluster_desc_path()));
 }
 
 void MetalContext::construct_control_plane(const std::filesystem::path& mesh_graph_desc_path) {

--- a/tt_metal/impl/device/firmware/dispatch_kernel_initializer.cpp
+++ b/tt_metal/impl/device/firmware/dispatch_kernel_initializer.cpp
@@ -27,9 +27,28 @@ void wait_until_cores_done(
 namespace tt::tt_metal {
 
 DispatchKernelInitializer::DispatchKernelInitializer(
-    std::shared_ptr<const ContextDescriptor> descriptor, dispatch_core_manager& dispatch_core_manager) :
-    FirmwareInitializer(std::move(descriptor)), dispatch_core_manager_(dispatch_core_manager) {
-    dispatch_topology_ = std::make_unique<tt::tt_metal::DispatchTopology>(*descriptor_, dispatch_core_manager_);
+    std::shared_ptr<const ContextDescriptor> descriptor,
+    dispatch_core_manager& dispatch_core_manager,
+    DeviceManager* device_manager,
+    const GetControlPlaneFn& get_control_plane,
+    const GetDispatchQueryManagerFn& get_dispatch_query_manager,
+    const GetMaxNumEthCoresFn& get_max_num_eth_cores,
+    const GetReadsDispatchCoresFn& get_reads_dispatch_cores) :
+    FirmwareInitializer(std::move(descriptor)),
+    dispatch_core_manager_(dispatch_core_manager),
+    device_manager_(device_manager),
+    get_control_plane_(get_control_plane),
+    get_dispatch_query_manager_(get_dispatch_query_manager),
+    get_max_num_eth_cores_(get_max_num_eth_cores),
+    get_reads_dispatch_cores_(get_reads_dispatch_cores) {
+    dispatch_topology_ = std::make_unique<tt::tt_metal::DispatchTopology>(
+        *descriptor_,
+        dispatch_core_manager_,
+        device_manager_,
+        get_control_plane_,
+        get_dispatch_query_manager_,
+        get_max_num_eth_cores_,
+        get_reads_dispatch_cores_);
 }
 
 void DispatchKernelInitializer::populate_fd_kernels_only(const std::vector<Device*>& devices) {

--- a/tt_metal/impl/device/firmware/dispatch_kernel_initializer.hpp
+++ b/tt_metal/impl/device/firmware/dispatch_kernel_initializer.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "dispatch/dispatch_mem_map.hpp"
+#include "dispatch/kernel_config/fd_kernel.hpp"
 #include "dispatch/topology.hpp"
 #include "firmware_initializer.hpp"
 
@@ -15,7 +16,13 @@ public:
     static constexpr InitializerKey key = InitializerKey::Dispatch;
 
     DispatchKernelInitializer(
-        std::shared_ptr<const ContextDescriptor> descriptor, dispatch_core_manager& dispatch_core_manager);
+        std::shared_ptr<const ContextDescriptor> descriptor,
+        dispatch_core_manager& dispatch_core_manager,
+        DeviceManager* device_manager,
+        const GetControlPlaneFn& get_control_plane = {},
+        const GetDispatchQueryManagerFn& get_dispatch_query_manager = {},
+        const GetMaxNumEthCoresFn& get_max_num_eth_cores = {},
+        const GetReadsDispatchCoresFn& get_reads_dispatch_cores = {});
 
     void init(const std::vector<Device*>& devices, const std::unordered_set<InitializerKey>& init_done) override;
     void configure() override;
@@ -46,6 +53,11 @@ private:
     std::unique_ptr<tt::tt_metal::DispatchTopology> dispatch_topology_;
     std::array<std::unique_ptr<DispatchMemMap>, static_cast<size_t>(CoreType::COUNT)> dispatch_mem_map_;
     dispatch_core_manager& dispatch_core_manager_;
+    DeviceManager* device_manager_ = nullptr;
+    GetControlPlaneFn get_control_plane_;
+    GetDispatchQueryManagerFn get_dispatch_query_manager_;
+    GetMaxNumEthCoresFn get_max_num_eth_cores_;
+    GetReadsDispatchCoresFn get_reads_dispatch_cores_;
 };
 
 }  // namespace tt::tt_metal

--- a/tt_metal/impl/dispatch/kernel_config/dispatch.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/dispatch.cpp
@@ -55,10 +55,10 @@ DispatchKernel::DispatchKernel(
         noc_selection,
         descriptor,
         dispatch_core_manager,
-        std::move(get_control_plane),
-        std::move(get_dispatch_query_manager),
-        std::move(get_max_num_eth_cores),
-        std::move(get_reads_dispatch_cores)) {
+        get_control_plane,
+        get_dispatch_query_manager,
+        get_max_num_eth_cores,
+        get_reads_dispatch_cores) {
     TT_FATAL(
         noc_selection.downstream_noc == tt_metal::k_dispatch_downstream_noc,
         "Invalid downstream NOC specified for Dispatcher kernel");

--- a/tt_metal/impl/dispatch/kernel_config/dispatch.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/dispatch.cpp
@@ -21,7 +21,7 @@
 #include "dispatch_s.hpp"
 #include "hal_types.hpp"
 #include "prefetch.hpp"
-#include "context/metal_context.hpp"
+#include "context/context_descriptor.hpp"
 #include "debug/inspector/inspector.hpp"
 #include <umd/device/types/xy_pair.hpp>
 #include "dispatch/system_memory_manager.hpp"
@@ -40,9 +40,25 @@ DispatchKernel::DispatchKernel(
     uint8_t cq_id,
     noc_selection_t noc_selection,
     bool h_variant,
-    bool d_variant) :
-    FDKernel(node_id, device_id, servicing_device_id, cq_id, noc_selection) {
-    auto& core_manager = MetalContext::instance().get_dispatch_core_manager();  // Not thread safe
+    bool d_variant,
+    const ContextDescriptor& descriptor,
+    dispatch_core_manager& dispatch_core_manager,
+    const GetControlPlaneFn& get_control_plane,
+    const GetDispatchQueryManagerFn& get_dispatch_query_manager,
+    const GetMaxNumEthCoresFn& get_max_num_eth_cores,
+    const GetReadsDispatchCoresFn& get_reads_dispatch_cores) :
+    FDKernel(
+        node_id,
+        device_id,
+        servicing_device_id,
+        cq_id,
+        noc_selection,
+        descriptor,
+        dispatch_core_manager,
+        std::move(get_control_plane),
+        std::move(get_dispatch_query_manager),
+        std::move(get_max_num_eth_cores),
+        std::move(get_reads_dispatch_cores)) {
     TT_FATAL(
         noc_selection.downstream_noc == tt_metal::k_dispatch_downstream_noc,
         "Invalid downstream NOC specified for Dispatcher kernel");
@@ -51,18 +67,18 @@ DispatchKernel::DispatchKernel(
         "Dispatcher kernel cannot have identical upstream and downstream NOCs.");
     static_config_.is_h_variant = h_variant;
     static_config_.is_d_variant = d_variant;
-    uint16_t channel = MetalContext::instance().get_cluster().get_assigned_channel_for_device(device_id);
+    uint16_t channel = descriptor.cluster().get_assigned_channel_for_device(device_id);
 
     DispatchWorkerType type = DISPATCH;
     if (h_variant && d_variant) {
-        this->logical_core_ = core_manager.dispatcher_core(device_id, channel, cq_id);
+        this->logical_core_ = dispatch_core_manager.dispatcher_core(device_id, channel, cq_id);
         type = DISPATCH_HD;
     } else if (h_variant) {
-        channel = MetalContext::instance().get_cluster().get_assigned_channel_for_device(servicing_device_id);
-        this->logical_core_ = core_manager.dispatcher_core(servicing_device_id, channel, cq_id);
+        channel = descriptor.cluster().get_assigned_channel_for_device(servicing_device_id);
+        this->logical_core_ = dispatch_core_manager.dispatcher_core(servicing_device_id, channel, cq_id);
         type = DISPATCH_H;
     } else if (d_variant) {
-        this->logical_core_ = core_manager.dispatcher_d_core(device_id, channel, cq_id);
+        this->logical_core_ = dispatch_core_manager.dispatcher_d_core(device_id, channel, cq_id);
         type = DISPATCH_D;
     }
     this->kernel_type_ = FDKernelType::DISPATCH;
@@ -72,9 +88,9 @@ DispatchKernel::DispatchKernel(
 }
 
 void DispatchKernel::GenerateStaticConfigs() {
-    uint16_t channel = MetalContext::instance().get_cluster().get_assigned_channel_for_device(device_->id());
+    uint16_t channel = descriptor_.cluster().get_assigned_channel_for_device(device_->id());
     uint8_t cq_id_ = this->cq_id_;
-    const auto& my_dispatch_constants = MetalContext::instance().dispatch_mem_map(GetCoreType());
+    const auto& my_dispatch_constants = *dispatch_mem_map_[enchantum::to_underlying(GetCoreType())].get();
 
     // May be zero if not using dispatch on fabric
     static_config_.fabric_header_rb_base =
@@ -114,14 +130,12 @@ void DispatchKernel::GenerateStaticConfigs() {
         static_config_.max_num_worker_sems = DispatchSettings::DISPATCH_MESSAGE_ENTRIES;
         static_config_.max_num_go_signal_noc_data_entries = DispatchSettings::DISPATCH_GO_SIGNAL_NOC_DATA_ENTRIES;
         static_config_.mcast_go_signal_addr =
-            MetalContext::instance().hal().get_dev_addr(HalProgrammableCoreType::TENSIX, HalL1MemAddrType::GO_MSG);
+            descriptor_.hal().get_dev_addr(HalProgrammableCoreType::TENSIX, HalL1MemAddrType::GO_MSG);
         static_config_.unicast_go_signal_addr =
-            (MetalContext::instance().hal().get_programmable_core_type_index(HalProgrammableCoreType::ACTIVE_ETH) != -1)
-                ? MetalContext::instance().hal().get_dev_addr(
-                      HalProgrammableCoreType::ACTIVE_ETH, HalL1MemAddrType::GO_MSG)
+            (descriptor_.hal().get_programmable_core_type_index(HalProgrammableCoreType::ACTIVE_ETH) != -1)
+                ? descriptor_.hal().get_dev_addr(HalProgrammableCoreType::ACTIVE_ETH, HalL1MemAddrType::GO_MSG)
                 : 0;
-        static_config_.distributed_dispatcher =
-            MetalContext::instance().get_dispatch_query_manager().distributed_dispatcher();
+        static_config_.distributed_dispatcher = get_dispatch_query_manager_ref().distributed_dispatcher();
         static_config_.first_stream_used = my_dispatch_constants.get_dispatch_stream_index(0);
 
         static_config_.host_completion_q_wr_ptr =
@@ -134,7 +148,7 @@ void DispatchKernel::GenerateStaticConfigs() {
             my_dispatch_constants.get_device_command_queue_addr(CommandQueueDeviceAddrType::DISPATCH_PROGRESS);
     } else if (static_config_.is_h_variant.value()) {
         // DISPATCH_H services a remote chip, and so has a different channel
-        channel = MetalContext::instance().get_cluster().get_assigned_channel_for_device(servicing_device_id_);
+        channel = descriptor_.cluster().get_assigned_channel_for_device(servicing_device_id_);
         uint32_t cq_start = my_dispatch_constants.get_host_command_queue_addr(CommandQueueHostAddrType::UNRESERVED);
         uint32_t cq_size = device_->sysmem_manager().get_cq_size();
         uint32_t command_queue_start_addr = get_absolute_cq_offset(channel, cq_id_, cq_size);
@@ -198,14 +212,12 @@ void DispatchKernel::GenerateStaticConfigs() {
         static_config_.max_num_worker_sems = DispatchSettings::DISPATCH_MESSAGE_ENTRIES;
         static_config_.max_num_go_signal_noc_data_entries = DispatchSettings::DISPATCH_GO_SIGNAL_NOC_DATA_ENTRIES;
         static_config_.mcast_go_signal_addr =
-            MetalContext::instance().hal().get_dev_addr(HalProgrammableCoreType::TENSIX, HalL1MemAddrType::GO_MSG);
+            descriptor_.hal().get_dev_addr(HalProgrammableCoreType::TENSIX, HalL1MemAddrType::GO_MSG);
         static_config_.unicast_go_signal_addr =
-            (MetalContext::instance().hal().get_programmable_core_type_index(HalProgrammableCoreType::ACTIVE_ETH) != -1)
-                ? MetalContext::instance().hal().get_dev_addr(
-                      HalProgrammableCoreType::ACTIVE_ETH, HalL1MemAddrType::GO_MSG)
+            (descriptor_.hal().get_programmable_core_type_index(HalProgrammableCoreType::ACTIVE_ETH) != -1)
+                ? descriptor_.hal().get_dev_addr(HalProgrammableCoreType::ACTIVE_ETH, HalL1MemAddrType::GO_MSG)
                 : 0;
-        static_config_.distributed_dispatcher =
-            MetalContext::instance().get_dispatch_query_manager().distributed_dispatcher();
+        static_config_.distributed_dispatcher = get_dispatch_query_manager_ref().distributed_dispatcher();
         static_config_.first_stream_used = my_dispatch_constants.get_dispatch_stream_index(0);
 
         static_config_.host_completion_q_wr_ptr =
@@ -222,8 +234,7 @@ void DispatchKernel::GenerateStaticConfigs() {
 
     if (!is_hd()) {
         create_edm_connection_sems(edm_connection_attributes_);
-        const auto& fabric_context = MetalContext::instance().get_control_plane().get_fabric_context();
-        static_config_.is_2d_fabric = fabric_context.is_2D_routing_enabled();
+        static_config_.is_2d_fabric = tt::tt_fabric::is_2d_fabric_config(get_control_plane_ref().get_fabric_config());
     } else {
         static_config_.is_2d_fabric = false;
     }
@@ -259,14 +270,14 @@ void DispatchKernel::GenerateDependentConfigs() {
             dependent_config_.prefetch_h_local_downstream_sem_addr = 0;
         } else {
             dependent_config_.split_prefetch = true;
-            dependent_config_.prefetch_h_noc_xy = MetalContext::instance().hal().noc_xy_encoding(
+            dependent_config_.prefetch_h_noc_xy = descriptor_.hal().noc_xy_encoding(
                 prefetch_kernel->GetVirtualCore().x, prefetch_kernel->GetVirtualCore().y);
             dependent_config_.prefetch_h_local_downstream_sem_addr =
                 prefetch_kernel->GetStaticConfig().my_downstream_cb_sem_id;
         }
 
         // Downstream
-        if (MetalContext::instance().get_dispatch_query_manager().dispatch_s_enabled()) {
+        if (get_dispatch_query_manager_ref().dispatch_s_enabled()) {
             TT_ASSERT(downstream_kernels_.size() == 1);
             auto* dispatch_s_kernel = dynamic_cast<DispatchSKernel*>(downstream_kernels_[0]);
             TT_ASSERT(dispatch_s_kernel);
@@ -291,8 +302,9 @@ void DispatchKernel::GenerateDependentConfigs() {
             dependent_config_.upstream_logical_core = dispatch_d->GetLogicalCore();
             dependent_config_.upstream_dispatch_cb_sem_id = dispatch_d->GetStaticConfig().my_downstream_cb_sem_id;
             dependent_config_.upstream_sync_sem = 0;  // Unused
-            dependent_config_.num_hops = tt_metal::get_num_hops(device_id_, dispatch_d->GetDeviceId());
-            assemble_2d_fabric_packet_header_args(this->dependent_config_, GetDeviceId(), dispatch_d->GetDeviceId());
+            dependent_config_.num_hops = tt_metal::get_num_hops(descriptor_, device_id_, dispatch_d->GetDeviceId());
+            assemble_2d_fabric_packet_header_args(
+                this->dependent_config_, GetDeviceId(), dispatch_d->GetDeviceId(), get_control_plane_ref());
         } else {
             TT_FATAL(false, "Unimplemented path");
         }
@@ -308,7 +320,7 @@ void DispatchKernel::GenerateDependentConfigs() {
                 TT_ASSERT(prefetch_h_kernel && prefetch_h_kernel->GetStaticConfig().is_h_variant.value());
                 TT_ASSERT(!found_prefetch_h, "DISPATCH_H has multiple downstream PREFETCH_H kernels.");
                 found_prefetch_h = true;
-                dependent_config_.prefetch_h_noc_xy = MetalContext::instance().hal().noc_xy_encoding(
+                dependent_config_.prefetch_h_noc_xy = descriptor_.hal().noc_xy_encoding(
                     prefetch_h_kernel->GetVirtualCore().x, prefetch_h_kernel->GetVirtualCore().y);
                 dependent_config_.prefetch_h_local_downstream_sem_addr =
                     prefetch_h_kernel->GetStaticConfig().my_downstream_cb_sem_id;
@@ -351,7 +363,7 @@ void DispatchKernel::GenerateDependentConfigs() {
             dependent_config_.prefetch_h_local_downstream_sem_addr = 0;
         } else {
             dependent_config_.split_prefetch = true;
-            dependent_config_.prefetch_h_noc_xy = MetalContext::instance().hal().noc_xy_encoding(
+            dependent_config_.prefetch_h_noc_xy = descriptor_.hal().noc_xy_encoding(
                 prefetch_kernel->GetVirtualCore().x, prefetch_kernel->GetVirtualCore().y);
             dependent_config_.prefetch_h_local_downstream_sem_addr =
                 prefetch_kernel->GetStaticConfig().my_downstream_cb_sem_id;
@@ -376,9 +388,10 @@ void DispatchKernel::GenerateDependentConfigs() {
                 dependent_config_.downstream_cb_size = dispatch_h_kernel->GetDispatchBufferSize();
                 dependent_config_.downstream_cb_base = dispatch_h_kernel->GetStaticConfig().dispatch_cb_base;
                 dependent_config_.downstream_cb_sem_id = dispatch_h_kernel->GetStaticConfig().my_dispatch_cb_sem_id;
-                dependent_config_.num_hops = tt_metal::get_num_hops(dispatch_h_kernel->GetDeviceId(), device_id_);
+                dependent_config_.num_hops =
+                    tt_metal::get_num_hops(descriptor_, dispatch_h_kernel->GetDeviceId(), device_id_);
                 assemble_2d_fabric_packet_header_args(
-                    this->dependent_config_, GetDeviceId(), dispatch_h_kernel->GetDeviceId());
+                    this->dependent_config_, GetDeviceId(), dispatch_h_kernel->GetDeviceId(), get_control_plane_ref());
                 found_dispatch_h = true;
             } else if (auto* relay_mux = dynamic_cast<RelayMux*>(ds_kernel)) {
                 TT_ASSERT(!found_relay_mux, "DISPATCH_D has multiple downstream RELAY_MUX kernels.");
@@ -394,7 +407,7 @@ void DispatchKernel::GenerateDependentConfigs() {
         }
 
         TT_FATAL(
-            !MetalContext::instance().get_dispatch_query_manager().dispatch_s_enabled() || found_dispatch_s,
+            !get_dispatch_query_manager_ref().dispatch_s_enabled() || found_dispatch_s,
             "dispatch_d is missing dispatch_s downstream");
         TT_FATAL(found_dispatch_h, "Path not implemented for dispatch_d. dispatch_h in downstream is required");
 
@@ -414,13 +427,9 @@ void DispatchKernel::CreateKernel() {
     // num_physical_ethernet_cores is the number of actual available ethernet cores on the current device.
     // virtualize_num_eth_cores is set if the number of virtual cores is greater than the number of actual
     // ethernet cores in the chip.
-    uint32_t num_virtual_active_eth_cores =
-        MetalContext::instance().device_manager()->get_max_num_eth_cores_across_all_devices();
+    uint32_t num_virtual_active_eth_cores = get_max_num_eth_cores();
     uint32_t num_physical_active_eth_cores =
-        MetalContext::instance()
-            .get_control_plane()
-            .get_active_ethernet_cores(device_->id(), /*skip_reserved_tunnel_cores*/ true)
-            .size();
+        get_control_plane_ref().get_active_ethernet_cores(device_->id(), /*skip_reserved_tunnel_cores*/ true).size();
     bool virtualize_num_eth_cores = num_virtual_active_eth_cores > num_physical_active_eth_cores;
 
     const auto& compute_grid_size = device_->compute_with_storage_grid_size();
@@ -431,12 +440,13 @@ void DispatchKernel::CreateKernel() {
 
     std::vector<uint32_t> compile_args = {};
 
-    auto my_virtual_core = get_virtual_core_coord(logical_core_, GetCoreType());
-    auto upstream_virtual_core = get_virtual_core_coord(dependent_config_.upstream_logical_core.value(), GetCoreType());
+    auto my_virtual_core = get_virtual_core_coord(descriptor_, logical_core_, GetCoreType());
+    auto upstream_virtual_core =
+        get_virtual_core_coord(descriptor_, dependent_config_.upstream_logical_core.value(), GetCoreType());
     auto downstream_virtual_core =
-        get_virtual_core_coord(dependent_config_.downstream_logical_core.value(), GetCoreType());
+        get_virtual_core_coord(descriptor_, dependent_config_.downstream_logical_core.value(), GetCoreType());
     auto downstream_s_virtual_core =
-        get_virtual_core_coord(dependent_config_.downstream_s_logical_core.value(), GetCoreType());
+        get_virtual_core_coord(descriptor_, dependent_config_.downstream_s_logical_core.value(), GetCoreType());
 
     auto my_virtual_noc_coords = device_->virtual_noc0_coordinate(noc_selection_.non_dispatch_noc, my_virtual_core);
     auto upstream_virtual_noc_coords =
@@ -551,7 +561,7 @@ void DispatchKernel::CreateKernel() {
 void DispatchKernel::ConfigureCore() {
     // For all dispatchers, need to clear the dispatch message
     std::vector<uint32_t> zero = {0x0};
-    const auto& my_dispatch_constants = MetalContext::instance().dispatch_mem_map(GetCoreType());
+    const auto& my_dispatch_constants = *this->dispatch_mem_map_[enchantum::to_underlying(GetCoreType())].get();
     uint32_t dispatch_s_sync_sem_base_addr =
         my_dispatch_constants.get_device_command_queue_addr(CommandQueueDeviceAddrType::DISPATCH_S_SYNC_SEM);
     for (uint32_t i = 0; i < DispatchSettings::DISPATCH_MESSAGE_ENTRIES; i++) {

--- a/tt_metal/impl/dispatch/kernel_config/dispatch.hpp
+++ b/tt_metal/impl/dispatch/kernel_config/dispatch.hpp
@@ -12,7 +12,7 @@
 #include "dispatch/kernel_config/relay_mux.hpp"
 #include "fd_kernel.hpp"
 #include <tt-metalium/experimental/fabric/mesh_graph.hpp>
-#include "impl/context/metal_context.hpp"
+#include "impl/context/context_descriptor.hpp"
 #include "tt_metal/impl/dispatch/topology.hpp"
 #include <umd/device/types/xy_pair.hpp>
 
@@ -99,7 +99,13 @@ public:
         uint8_t cq_id,
         noc_selection_t noc_selection,
         bool h_variant,
-        bool d_variant);
+        bool d_variant,
+        const ContextDescriptor& descriptor,
+        dispatch_core_manager& dispatch_core_manager,
+        const GetControlPlaneFn& get_control_plane = {},
+        const GetDispatchQueryManagerFn& get_dispatch_query_manager = {},
+        const GetMaxNumEthCoresFn& get_max_num_eth_cores = {},
+        const GetReadsDispatchCoresFn& get_reads_dispatch_cores = {});
 
     void CreateKernel() override;
 

--- a/tt_metal/impl/dispatch/kernel_config/dispatch_s.hpp
+++ b/tt_metal/impl/dispatch/kernel_config/dispatch_s.hpp
@@ -6,7 +6,7 @@
 #include <optional>
 
 #include "fd_kernel.hpp"
-#include "impl/context/metal_context.hpp"
+#include "impl/context/context_descriptor.hpp"
 #include <umd/device/types/xy_pair.hpp>
 
 namespace tt::tt_metal {
@@ -35,7 +35,17 @@ struct dispatch_s_dependent_config_t {
 class DispatchSKernel : public FDKernel {
 public:
     DispatchSKernel(
-        int node_id, ChipId device_id, ChipId servicing_device_id, uint8_t cq_id, noc_selection_t noc_selection);
+        int node_id,
+        ChipId device_id,
+        ChipId servicing_device_id,
+        uint8_t cq_id,
+        noc_selection_t noc_selection,
+        const ContextDescriptor& descriptor,
+        dispatch_core_manager& dispatch_core_manager,
+        const GetControlPlaneFn& get_control_plane = {},
+        const GetDispatchQueryManagerFn& get_dispatch_query_manager = {},
+        const GetMaxNumEthCoresFn& get_max_num_eth_cores = {},
+        const GetReadsDispatchCoresFn& get_reads_dispatch_cores = {});
 
     void CreateKernel() override;
     void GenerateStaticConfigs() override;

--- a/tt_metal/impl/dispatch/kernel_config/fd_kernel.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/fd_kernel.cpp
@@ -4,6 +4,7 @@
 
 #include "fd_kernel.hpp"
 
+#include <tt-metalium/experimental/fabric/control_plane.hpp>
 #include <host_api.hpp>
 #include <utility>
 #include <variant>
@@ -17,16 +18,15 @@
 #include "hal_types.hpp"
 #include "kernel_types.hpp"
 #include "prefetch.hpp"
-#include "impl/context/metal_context.hpp"
+#include "impl/context/context_descriptor.hpp"
 #include <umd/device/types/core_coordinates.hpp>
 #include <impl/debug/dprint_server.hpp>
 
 using namespace tt::tt_metal;
 
-ChipId FDKernel::GetUpstreamDeviceId(ChipId device_id) {
-    ChipId mmio_device_id = tt::tt_metal::MetalContext::instance().get_cluster().get_associated_mmio_device(device_id);
-    for (auto tunnel :
-         tt::tt_metal::MetalContext::instance().get_cluster().get_tunnels_from_mmio_device(mmio_device_id)) {
+ChipId FDKernel::GetUpstreamDeviceId(const ContextDescriptor& descriptor, ChipId device_id) {
+    ChipId mmio_device_id = descriptor.cluster().get_associated_mmio_device(device_id);
+    for (auto tunnel : descriptor.cluster().get_tunnels_from_mmio_device(mmio_device_id)) {
         for (int idx = 0; idx < tunnel.size(); idx++) {
             if (tunnel[idx] == device_id) {
                 // MMIO device doesn't have an upsream, just return itself
@@ -38,9 +38,9 @@ ChipId FDKernel::GetUpstreamDeviceId(ChipId device_id) {
     return device_id;
 }
 
-ChipId FDKernel::GetDownstreamDeviceId(ChipId device_id, int tunnel) {
-    ChipId mmio_device_id = tt::tt_metal::MetalContext::instance().get_cluster().get_associated_mmio_device(device_id);
-    auto tunnels = tt::tt_metal::MetalContext::instance().get_cluster().get_tunnels_from_mmio_device(mmio_device_id);
+ChipId FDKernel::GetDownstreamDeviceId(const ContextDescriptor& descriptor, ChipId device_id, int tunnel) {
+    ChipId mmio_device_id = descriptor.cluster().get_associated_mmio_device(device_id);
+    auto tunnels = descriptor.cluster().get_tunnels_from_mmio_device(mmio_device_id);
     if (tunnel < -1 || tunnel >= static_cast<int>(tunnels.size())) {
         TT_THROW("Tunnel {} is out of range. {} tunnels exist", tunnel, tunnels.size());
     }
@@ -63,10 +63,9 @@ ChipId FDKernel::GetDownstreamDeviceId(ChipId device_id, int tunnel) {
     return device_id;
 }
 
-uint32_t FDKernel::GetTunnelStop(ChipId device_id) {
-    ChipId mmio_device_id = tt::tt_metal::MetalContext::instance().get_cluster().get_associated_mmio_device(device_id);
-    for (auto tunnel :
-         tt::tt_metal::MetalContext::instance().get_cluster().get_tunnels_from_mmio_device(mmio_device_id)) {
+uint32_t FDKernel::GetTunnelStop(const ContextDescriptor& descriptor, ChipId device_id) {
+    ChipId mmio_device_id = descriptor.cluster().get_associated_mmio_device(device_id);
+    for (auto tunnel : descriptor.cluster().get_tunnels_from_mmio_device(mmio_device_id)) {
         for (uint32_t idx = 0; idx < tunnel.size(); idx++) {
             if (tunnel[idx] == device_id) {
                 return idx;
@@ -77,6 +76,21 @@ uint32_t FDKernel::GetTunnelStop(ChipId device_id) {
     return 0;
 }
 
+tt::tt_fabric::ControlPlane& FDKernel::get_control_plane_ref() const {
+    TT_ASSERT(static_cast<bool>(get_control_plane_), "Control plane accessor not set (required when fabric is used)");
+    return get_control_plane_();
+}
+
+const DispatchQueryManager& FDKernel::get_dispatch_query_manager_ref() const {
+    TT_ASSERT(static_cast<bool>(get_dispatch_query_manager_), "Dispatch query manager accessor not set");
+    return get_dispatch_query_manager_();
+}
+
+uint32_t FDKernel::get_max_num_eth_cores() const {
+    TT_ASSERT(static_cast<bool>(get_max_num_eth_cores_), "Max num eth cores accessor not set");
+    return get_max_num_eth_cores_();
+}
+
 FDKernel* FDKernel::Generate(
     int node_id,
     ChipId device_id,
@@ -84,52 +98,169 @@ FDKernel* FDKernel::Generate(
     uint8_t cq_id,
     noc_selection_t noc_selection,
     DispatchWorkerType type,
-    int tunnel_index) {
+    const ContextDescriptor& descriptor,
+    dispatch_core_manager& dispatch_core_manager,
+    int tunnel_index,
+    const GetControlPlaneFn& get_control_plane,
+    const GetDispatchQueryManagerFn& get_dispatch_query_manager,
+    const GetMaxNumEthCoresFn& get_max_num_eth_cores,
+    const GetReadsDispatchCoresFn& get_reads_dispatch_cores) {
     switch (type) {
         case PREFETCH_HD:
-            return new PrefetchKernel(node_id, device_id, servicing_device_id, cq_id, noc_selection, true, true);
+            return new PrefetchKernel(
+                node_id,
+                device_id,
+                servicing_device_id,
+                cq_id,
+                noc_selection,
+                true,
+                true,
+                descriptor,
+                dispatch_core_manager,
+                get_control_plane,
+                get_dispatch_query_manager,
+                get_max_num_eth_cores,
+                get_reads_dispatch_cores);
         case PREFETCH_H:
-            return new PrefetchKernel(node_id, device_id, servicing_device_id, cq_id, noc_selection, true, false);
+            return new PrefetchKernel(
+                node_id,
+                device_id,
+                servicing_device_id,
+                cq_id,
+                noc_selection,
+                true,
+                false,
+                descriptor,
+                dispatch_core_manager,
+                get_control_plane,
+                get_dispatch_query_manager,
+                get_max_num_eth_cores,
+                get_reads_dispatch_cores);
         case PREFETCH_D:
-            return new PrefetchKernel(node_id, device_id, servicing_device_id, cq_id, noc_selection, false, true);
+            return new PrefetchKernel(
+                node_id,
+                device_id,
+                servicing_device_id,
+                cq_id,
+                noc_selection,
+                false,
+                true,
+                descriptor,
+                dispatch_core_manager,
+                get_control_plane,
+                get_dispatch_query_manager,
+                get_max_num_eth_cores,
+                get_reads_dispatch_cores);
         case DISPATCH_HD:
-            return new DispatchKernel(node_id, device_id, servicing_device_id, cq_id, noc_selection, true, true);
+            return new DispatchKernel(
+                node_id,
+                device_id,
+                servicing_device_id,
+                cq_id,
+                noc_selection,
+                true,
+                true,
+                descriptor,
+                dispatch_core_manager,
+                get_control_plane,
+                get_dispatch_query_manager,
+                get_max_num_eth_cores,
+                get_reads_dispatch_cores);
         case DISPATCH_H:
-            return new DispatchKernel(node_id, device_id, servicing_device_id, cq_id, noc_selection, true, false);
+            return new DispatchKernel(
+                node_id,
+                device_id,
+                servicing_device_id,
+                cq_id,
+                noc_selection,
+                true,
+                false,
+                descriptor,
+                dispatch_core_manager,
+                get_control_plane,
+                get_dispatch_query_manager,
+                get_max_num_eth_cores,
+                get_reads_dispatch_cores);
         case DISPATCH_D:
-            return new DispatchKernel(node_id, device_id, servicing_device_id, cq_id, noc_selection, false, true);
-        case DISPATCH_S: return new DispatchSKernel(node_id, device_id, servicing_device_id, cq_id, noc_selection);
+            return new DispatchKernel(
+                node_id,
+                device_id,
+                servicing_device_id,
+                cq_id,
+                noc_selection,
+                false,
+                true,
+                descriptor,
+                dispatch_core_manager,
+                get_control_plane,
+                get_dispatch_query_manager,
+                get_max_num_eth_cores,
+                get_reads_dispatch_cores);
+        case DISPATCH_S:
+            return new DispatchSKernel(
+                node_id,
+                device_id,
+                servicing_device_id,
+                cq_id,
+                noc_selection,
+                descriptor,
+                dispatch_core_manager,
+                get_control_plane,
+                get_dispatch_query_manager,
+                get_max_num_eth_cores,
+                get_reads_dispatch_cores);
         case FABRIC_MUX:
             return new tt::tt_metal::RelayMux(
-                node_id, device_id, servicing_device_id, cq_id, noc_selection, false, tunnel_index);
+                node_id,
+                device_id,
+                servicing_device_id,
+                cq_id,
+                noc_selection,
+                false,
+                tunnel_index,
+                descriptor,
+                dispatch_core_manager,
+                get_control_plane,
+                get_reads_dispatch_cores);
         case RETURN_FABRIC_MUX:
             return new tt::tt_metal::RelayMux(
-                node_id, device_id, servicing_device_id, cq_id, noc_selection, true, tunnel_index);
+                node_id,
+                device_id,
+                servicing_device_id,
+                cq_id,
+                noc_selection,
+                true,
+                tunnel_index,
+                descriptor,
+                dispatch_core_manager,
+                get_control_plane,
+                get_reads_dispatch_cores);
         default: TT_FATAL(false, "Unrecognized dispatch kernel type: {}.", type); return nullptr;
     }
 }
 
-uint32_t FDKernel::get_programmable_core_type_index(CoreType dispatch_core_type, bool is_active_eth_core) {
+uint32_t FDKernel::get_programmable_core_type_index(
+    const ContextDescriptor& descriptor, CoreType dispatch_core_type, bool is_active_eth_core) {
     // TODO(#22895): Too many core types. Consolidate programmable_core_type_index with ProgrammableCoreType and
     // CoreType
     uint32_t programmable_core_type_index;
     if (dispatch_core_type == CoreType::WORKER) {
         programmable_core_type_index =
-            MetalContext::instance().hal().get_programmable_core_type_index(HalProgrammableCoreType::TENSIX);
+            descriptor.hal().get_programmable_core_type_index(HalProgrammableCoreType::TENSIX);
     } else if (is_active_eth_core) {
         programmable_core_type_index =
-            MetalContext::instance().hal().get_programmable_core_type_index(HalProgrammableCoreType::ACTIVE_ETH);
+            descriptor.hal().get_programmable_core_type_index(HalProgrammableCoreType::ACTIVE_ETH);
     } else {
         programmable_core_type_index =
-            MetalContext::instance().hal().get_programmable_core_type_index(HalProgrammableCoreType::IDLE_ETH);
+            descriptor.hal().get_programmable_core_type_index(HalProgrammableCoreType::IDLE_ETH);
     }
 
     return programmable_core_type_index;
 }
 
-CoreCoord FDKernel::get_virtual_core_coord(const tt_cxy_pair& logical_cxy, const CoreType& core_type) {
-    const auto& cluster = tt::tt_metal::MetalContext::instance().get_cluster();
-    return cluster.get_virtual_coordinate_from_logical_coordinates(logical_cxy, core_type);
+CoreCoord FDKernel::get_virtual_core_coord(
+    const ContextDescriptor& descriptor, const tt_cxy_pair& logical_cxy, const CoreType& core_type) {
+    return descriptor.cluster().get_virtual_coordinate_from_logical_coordinates(logical_cxy, core_type);
 }
 
 KernelHandle FDKernel::configure_kernel_variant(
@@ -140,7 +271,8 @@ KernelHandle FDKernel::configure_kernel_variant(
     bool send_to_brisc,
     bool force_watcher_no_inline,
     KernelBuildOptLevel opt_level) {
-    uint32_t programmable_core_type_index = get_programmable_core_type_index(GetCoreType(), is_active_eth_core);
+    uint32_t programmable_core_type_index =
+        get_programmable_core_type_index(descriptor_, GetCoreType(), is_active_eth_core);
 
     std::map<std::string, std::string> defines = {
         {"DISPATCH_KERNEL", "1"},
@@ -149,16 +281,15 @@ KernelHandle FDKernel::configure_kernel_variant(
     if (force_watcher_no_inline) {
         defines.insert({"WATCHER_NOINLINE", std::to_string(force_watcher_no_inline)});
     }
-    auto& rt_options = tt::tt_metal::MetalContext::instance().rtoptions();
+    const auto& rt_options = descriptor_.rtoptions();
     if (rt_options.watcher_dispatch_disabled()) {
         defines["FORCE_WATCHER_OFF"] = "1";
     }
-    if (!(MetalContext::instance().dprint_server() and
-          MetalContext::instance().dprint_server()->reads_dispatch_cores(device_->id()))) {
+    if (!(get_reads_dispatch_cores_ && get_reads_dispatch_cores_(device_->id()))) {
         defines["FORCE_DPRINT_OFF"] = "1";
     }
     defines.insert(defines_in.begin(), defines_in.end());
-    if (MetalContext::instance().get_cluster().is_galaxy_cluster()) {
+    if (descriptor_.cluster().is_galaxy_cluster()) {
         // TG specific fabric routing
         // TODO: https://github.com/tenstorrent/tt-metal/issues/24413
         defines["GALAXY_CLUSTER"] = "1";

--- a/tt_metal/impl/dispatch/kernel_config/fd_kernel.hpp
+++ b/tt_metal/impl/dispatch/kernel_config/fd_kernel.hpp
@@ -6,20 +6,23 @@
 
 #include <tt-metalium/program.hpp>
 #include <tt-metalium/kernel_types.hpp>
-#include <stdint.h>
+#include <cstdint>
+#include <functional>
 #include <map>
 #include <string>
 #include <vector>
 
 #include <tt_stl/assert.hpp>
 #include "core_coord.hpp"
-#include "impl/context/metal_context.hpp"
+#include "impl/context/context_descriptor.hpp"
 #include "impl/dispatch/dispatch_core_common.hpp"
 #include <umd/device/types/xy_pair.hpp>
 #include <umd/device/types/core_coordinates.hpp>
 #include <tt_stl/tt_stl/reflection.hpp>
 #include <impl/dispatch/dispatch_core_manager.hpp>
+#include <impl/dispatch/dispatch_query_manager.hpp>
 #include <llrt/tt_cluster.hpp>
+#include <impl/dispatch/dispatch_mem_map.hpp>
 
 namespace tt::tt_metal {
 
@@ -79,16 +82,45 @@ static std::vector<std::string> dispatch_kernel_file_names = {
     ""                                                             // COUNT
 };
 
+// Use getters because they may be recreated between calls to Generate() and ConfigureCore()
+// E.g., Changing fabric mode from Disabled to Enabled constructs a new control plane
+using GetControlPlaneFn = std::function<tt::tt_fabric::ControlPlane&()>;
+using GetDispatchQueryManagerFn = std::function<const DispatchQueryManager&()>;
+using GetMaxNumEthCoresFn = std::function<uint32_t()>;
+using GetReadsDispatchCoresFn = std::function<bool(ChipId)>;
+
 // Top-level class describing a Fast Dispatch Kernel (kernel running on a specific core). All FD kernels should inherit
 // from this class and implement the virtual functions as required.
 class FDKernel {
 public:
-    FDKernel(int node_id, ChipId device_id, ChipId servicing_device_id, uint8_t cq_id, noc_selection_t noc_selection) :
+    FDKernel(
+        int node_id,
+        ChipId device_id,
+        ChipId servicing_device_id,
+        uint8_t cq_id,
+        noc_selection_t noc_selection,
+        const ContextDescriptor& descriptor,
+        dispatch_core_manager& dispatch_core_manager,
+        const GetControlPlaneFn& get_control_plane = {},
+        const GetDispatchQueryManagerFn& get_dispatch_query_manager = {},
+        const GetMaxNumEthCoresFn& get_max_num_eth_cores = {},
+        const GetReadsDispatchCoresFn& get_reads_dispatch_cores = {}) :
         device_id_(device_id),
         servicing_device_id_(servicing_device_id),
         node_id_(node_id),
         cq_id_(cq_id),
-        noc_selection_(noc_selection) {}
+        noc_selection_(noc_selection),
+        descriptor_(descriptor),
+        dispatch_core_manager_(dispatch_core_manager),
+        get_control_plane_(std::move(get_control_plane)),
+        get_dispatch_query_manager_(std::move(get_dispatch_query_manager)),
+        get_max_num_eth_cores_(std::move(get_max_num_eth_cores)),
+        get_reads_dispatch_cores_(std::move(get_reads_dispatch_cores)) {
+        dispatch_mem_map_[enchantum::to_underlying(CoreType::WORKER)] =
+            std::make_unique<tt::tt_metal::DispatchMemMap>(CoreType::WORKER, descriptor.num_cqs());
+        dispatch_mem_map_[enchantum::to_underlying(CoreType::ETH)] =
+            std::make_unique<tt::tt_metal::DispatchMemMap>(CoreType::ETH, descriptor.num_cqs());
+    }
     virtual ~FDKernel() = default;
 
     // Populate the static configs for this kernel (ones that do not depend on configs from other kernels), including
@@ -118,29 +150,34 @@ public:
         uint8_t cq_id,
         noc_selection_t noc_selection,
         tt::tt_metal::DispatchWorkerType type,
-        int tunnel_index = -1);
+        const ContextDescriptor& descriptor,
+        dispatch_core_manager& dispatch_core_manager,
+        int tunnel_index = -1,
+        const GetControlPlaneFn& get_control_plane = {},
+        const GetDispatchQueryManagerFn& get_dispatch_query_manager = {},
+        const GetMaxNumEthCoresFn& get_max_num_eth_cores = {},
+        const GetReadsDispatchCoresFn& get_reads_dispatch_cores = {});
 
     // Translate DispatchCoreType to programmable core type index
-    static uint32_t get_programmable_core_type_index(CoreType dispatch_core_type, bool is_active_eth_core = false);
+    static uint32_t get_programmable_core_type_index(
+        const ContextDescriptor& descriptor, CoreType dispatch_core_type, bool is_active_eth_core = false);
 
     // Translate core coord using the chip_id from the logical_cxy
     //
     // IDevice::virtual_core_from_logical_core uses the chip_id of the device instance whereas this function uses the
     // chip_id specified in the logical coordinate.
-    static CoreCoord get_virtual_core_coord(const tt_cxy_pair& logical_cxy, const CoreType& core_type);
+    static CoreCoord get_virtual_core_coord(
+        const ContextDescriptor& descriptor, const tt_cxy_pair& logical_cxy, const CoreType& core_type);
 
     // Register another kernel as upstream/downstream of this one
     void AddUpstreamKernel(FDKernel* upstream) { upstream_kernels_.push_back(upstream); }
     void AddDownstreamKernel(FDKernel* downstream) { downstream_kernels_.push_back(downstream); }
 
-    virtual CoreType GetCoreType() const {
-        return tt::tt_metal::MetalContext::instance().get_dispatch_core_manager().get_dispatch_core_type();
-    }
+    virtual CoreType GetCoreType() const { return dispatch_core_manager_.get_dispatch_core_type(); }
     FDKernelType GetKernelType() const { return kernel_type_; }
     tt_cxy_pair GetLogicalCore() const { return logical_core_; }
     tt_cxy_pair GetVirtualCore() const {
-        return tt::tt_metal::MetalContext::instance().get_cluster().get_virtual_coordinate_from_logical_coordinates(
-            logical_core_, GetCoreType());
+        return descriptor_.cluster().get_virtual_coordinate_from_logical_coordinates(logical_core_, GetCoreType());
     }
     ChipId GetDeviceId() const { return device_id_; }  // Since this->device may not exist yet
     int GetNodeId() const { return node_id_; }
@@ -151,6 +188,10 @@ public:
     int GetDownstreamPort(FDKernel* other) const { return GetPort(other, this->downstream_kernels_); }
     void AddDevice(tt::tt_metal::IDevice* device) { device_ = device; }
     void AddProgram(tt::tt_metal::Program* program) { program_ = program; }
+
+    tt::tt_fabric::ControlPlane& get_control_plane_ref() const;
+    const DispatchQueryManager& get_dispatch_query_manager_ref() const;
+    uint32_t get_max_num_eth_cores() const;
 
 protected:
     // Attributes for an EDM client to connect to the router
@@ -179,11 +220,11 @@ protected:
     }
 
     // Helper function to get upstream device in the tunnel from current device, not valid for mmio
-    static ChipId GetUpstreamDeviceId(ChipId device_id);
+    static ChipId GetUpstreamDeviceId(const ContextDescriptor& descriptor, ChipId device_id);
     // Helper function to get downstream device in the tunnel from current device
-    static ChipId GetDownstreamDeviceId(ChipId device_id, int tunnel = -1);
+    static ChipId GetDownstreamDeviceId(const ContextDescriptor& descriptor, ChipId device_id, int tunnel = -1);
     // Helper function to get the tunnel stop index of current device
-    static uint32_t GetTunnelStop(ChipId device_id);
+    static uint32_t GetTunnelStop(const ContextDescriptor& descriptor, ChipId device_id);
     // Create and populate semaphores for the EDM connection
     void create_edm_connection_sems(FDKernelEdmConnectionAttributes& attributes);
     IDevice* device_ = nullptr;  // Set at configuration time by AddDeviceAndProgram()
@@ -201,6 +242,13 @@ protected:
     std::vector<FDKernel*> downstream_kernels_;
 
     std::vector<uint32_t> runtime_args_;
+    const ContextDescriptor& descriptor_;
+    dispatch_core_manager& dispatch_core_manager_;
+    GetControlPlaneFn get_control_plane_;
+    GetDispatchQueryManagerFn get_dispatch_query_manager_;
+    GetMaxNumEthCoresFn get_max_num_eth_cores_;
+    GetReadsDispatchCoresFn get_reads_dispatch_cores_;
+    std::array<std::unique_ptr<DispatchMemMap>, static_cast<size_t>(CoreType::COUNT)> dispatch_mem_map_;
 };
 
 }  // namespace tt::tt_metal

--- a/tt_metal/impl/dispatch/kernel_config/fd_kernel.hpp
+++ b/tt_metal/impl/dispatch/kernel_config/fd_kernel.hpp
@@ -112,10 +112,10 @@ public:
         noc_selection_(noc_selection),
         descriptor_(descriptor),
         dispatch_core_manager_(dispatch_core_manager),
-        get_control_plane_(std::move(get_control_plane)),
-        get_dispatch_query_manager_(std::move(get_dispatch_query_manager)),
-        get_max_num_eth_cores_(std::move(get_max_num_eth_cores)),
-        get_reads_dispatch_cores_(std::move(get_reads_dispatch_cores)) {
+        get_control_plane_(get_control_plane),
+        get_dispatch_query_manager_(get_dispatch_query_manager),
+        get_max_num_eth_cores_(get_max_num_eth_cores),
+        get_reads_dispatch_cores_(get_reads_dispatch_cores) {
         dispatch_mem_map_[enchantum::to_underlying(CoreType::WORKER)] =
             std::make_unique<tt::tt_metal::DispatchMemMap>(CoreType::WORKER, descriptor.num_cqs());
         dispatch_mem_map_[enchantum::to_underlying(CoreType::ETH)] =

--- a/tt_metal/impl/dispatch/kernel_config/prefetch.hpp
+++ b/tt_metal/impl/dispatch/kernel_config/prefetch.hpp
@@ -10,7 +10,7 @@
 #include "core_coord.hpp"
 #include "fd_kernel.hpp"
 #include <tt-metalium/experimental/fabric/mesh_graph.hpp>
-#include "impl/context/metal_context.hpp"
+#include "impl/context/context_descriptor.hpp"
 #include <umd/device/types/xy_pair.hpp>
 #include <umd/device/types/cluster_descriptor_types.hpp>
 #include "dispatch/kernel_config/relay_mux.hpp"
@@ -97,7 +97,13 @@ public:
         uint8_t cq_id,
         noc_selection_t noc_selection,
         bool h_variant,
-        bool d_variant);
+        bool d_variant,
+        const ContextDescriptor& descriptor,
+        dispatch_core_manager& dispatch_core_manager,
+        const GetControlPlaneFn& get_control_plane = {},
+        const GetDispatchQueryManagerFn& get_dispatch_query_manager = {},
+        const GetMaxNumEthCoresFn& get_max_num_eth_cores = {},
+        const GetReadsDispatchCoresFn& get_reads_dispatch_cores = {});
 
     void CreateKernel() override;
 

--- a/tt_metal/impl/dispatch/topology.cpp
+++ b/tt_metal/impl/dispatch/topology.cpp
@@ -4,7 +4,6 @@
 
 #include "topology.hpp"
 
-#include "context/metal_context.hpp"
 #include "device/device_manager.hpp"
 #include <host_api.hpp>
 #include <enchantum/enchantum.hpp>
@@ -392,8 +391,21 @@ static const std::vector<DispatchKernelNode> galaxy_nine_chip_arch_2cq_fabric = 
 };
 // clang-format on
 
-DispatchTopology::DispatchTopology(const ContextDescriptor& descriptor, dispatch_core_manager& dispatch_core_manager) :
-    descriptor_(descriptor), dispatch_core_manager_(dispatch_core_manager) {
+DispatchTopology::DispatchTopology(
+    const ContextDescriptor& descriptor,
+    dispatch_core_manager& dispatch_core_manager,
+    DeviceManager* device_manager,
+    const GetControlPlaneFn& get_control_plane,
+    const GetDispatchQueryManagerFn& get_dispatch_query_manager,
+    const GetMaxNumEthCoresFn& get_max_num_eth_cores,
+    const GetReadsDispatchCoresFn& get_reads_dispatch_cores) :
+    descriptor_(descriptor),
+    dispatch_core_manager_(dispatch_core_manager),
+    device_manager_(device_manager),
+    get_control_plane_(get_control_plane),
+    get_dispatch_query_manager_(get_dispatch_query_manager),
+    get_max_num_eth_cores_(get_max_num_eth_cores),
+    get_reads_dispatch_cores_(get_reads_dispatch_cores) {
     command_queue_compile_group_ = std::make_unique<detail::ProgramCompileGroup>();
     dispatch_mem_map_[enchantum::to_underlying(CoreType::WORKER)] =
         std::make_unique<DispatchMemMap>(CoreType::WORKER, descriptor_.num_cqs());
@@ -583,7 +595,13 @@ void DispatchTopology::populate_fd_kernels(const std::vector<DispatchKernelNode>
             node.cq_id,
             node.noc_selection,
             node.kernel_type,
-            node.tunnel_index));
+            descriptor_,
+            dispatch_core_manager_,
+            node.tunnel_index,
+            get_control_plane_,
+            get_dispatch_query_manager_,
+            get_max_num_eth_cores_,
+            get_reads_dispatch_cores_));
         if (descriptor_.cluster().get_associated_mmio_device(node.device_id) == node.device_id) {
             mmio_device_ids.insert(node.device_id);
         }
@@ -738,14 +756,14 @@ void DispatchTopology::configure_dispatch_cores(Device* device) {
     std::vector<uint32_t> zero = {0x0};
 
     // Need to set up for all devices serviced by an mmio chip
+    TT_ASSERT(device_manager_ != nullptr, "DeviceManager required for configure_dispatch_cores");
     if (device->is_mmio_capable()) {
         for (ChipId serviced_device_id : descriptor_.cluster().get_devices_controlled_by_mmio_device(device->id())) {
             uint16_t channel = descriptor_.cluster().get_assigned_channel_for_device(serviced_device_id);
             for (uint8_t cq_id = 0; cq_id < device->num_hw_cqs(); cq_id++) {
                 tt_cxy_pair completion_q_writer_location =
                     this->dispatch_core_manager_.completion_queue_writer_core(serviced_device_id, channel, cq_id);
-                IDevice* mmio_device =
-                    MetalContext::instance().device_manager()->get_active_device(completion_q_writer_location.chip);
+                IDevice* mmio_device = device_manager_->get_active_device(completion_q_writer_location.chip);
                 uint32_t completion_q_wr_ptr =
                     my_dispatch_constants.get_device_command_queue_addr(CommandQueueDeviceAddrType::COMPLETION_Q_WR);
                 uint32_t completion_q_rd_ptr =

--- a/tt_metal/impl/dispatch/topology.cpp
+++ b/tt_metal/impl/dispatch/topology.cpp
@@ -444,9 +444,8 @@ std::vector<DispatchKernelNode> DispatchTopology::generate_nodes(
     auto populate_single_device = [&]() {
         if (num_hw_cqs == 1) {
             return single_chip_arch_1cq;
-        }  // TODO: determine whether dispatch_s is inserted at this level, instead of inside
-           // Device::dispatch_s_enabled().
-        if (this->dispatch_core_manager_.get_dispatch_core_type() == CoreType::WORKER) {
+        }
+        if (this->get_dispatch_query_manager_().dispatch_s_enabled()) {
             return single_chip_arch_2cq_dispatch_s;
         }
         return single_chip_arch_2cq;

--- a/tt_metal/impl/dispatch/topology.hpp
+++ b/tt_metal/impl/dispatch/topology.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <device.hpp>
+#include <functional>
 #include <memory>
 #include <set>
 #include <unordered_map>
@@ -18,6 +19,10 @@
 #include "tt_metal/impl/dispatch/kernel_config/fd_kernel.hpp"
 #include "tt_metal/impl/dispatch/dispatch_core_common.hpp"
 #include "tt_metal/impl/context/context_descriptor.hpp"
+
+namespace tt::tt_fabric {
+class ControlPlane;
+}
 
 namespace tt {
 class Cluster;
@@ -53,7 +58,14 @@ struct DispatchKernelNode {
 
 class DispatchTopology {
 public:
-    explicit DispatchTopology(const ContextDescriptor& descriptor, dispatch_core_manager& dispatch_core_manager);
+    explicit DispatchTopology(
+        const ContextDescriptor& descriptor,
+        dispatch_core_manager& dispatch_core_manager,
+        DeviceManager* device_manager,
+        const GetControlPlaneFn& get_control_plane = {},
+        const GetDispatchQueryManagerFn& get_dispatch_query_manager = {},
+        const GetMaxNumEthCoresFn& get_max_num_eth_cores = {},
+        const GetReadsDispatchCoresFn& get_reads_dispatch_cores = {});
     ~DispatchTopology();
 
     void populate_fd_kernels(const std::vector<Device*>& devices, uint32_t num_hw_cqs);
@@ -77,6 +89,11 @@ private:
 
     const ContextDescriptor& descriptor_;
     dispatch_core_manager& dispatch_core_manager_;
+    DeviceManager* device_manager_;
+    GetControlPlaneFn get_control_plane_;
+    GetDispatchQueryManagerFn get_dispatch_query_manager_;
+    GetMaxNumEthCoresFn get_max_num_eth_cores_;
+    GetReadsDispatchCoresFn get_reads_dispatch_cores_;
     std::unique_ptr<DispatchMemMap> dispatch_mem_map_[enchantum::to_underlying(CoreType::COUNT)];
     std::vector<FDKernel*> node_id_to_kernel_;
     std::unique_ptr<detail::ProgramCompileGroup> command_queue_compile_group_;


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/37247

### Problem description
- Decouple dispatch init from MetalContext. It just needs Cluster, Hal, Rtoptions.

### What's changed
- Remove MetalContext::instance() calls from the FDKernels and provide the necessary information for init using the `ContextDescriptor`
- This removes the circular dependency with MetalContext and the dispatch init data flow. It looks like this now. A ContextDescriptor is passed from MetalContext to each child
```
MetalContext -> DeviceManager -> DispatchKernelInitializer -> DispatchTopology
```
- Make the `ContextDescriptor` constructor with (Hal, RuntimeOptions, Cluster) params private as this overload should only be used by MetalContext/DeviceManager.

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=nhuang/decouple-fd-kernel)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:nhuang/decouple-fd-kernel)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=nhuang/decouple-fd-kernel)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:nhuang/decouple-fd-kernel)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nhuang/decouple-fd-kernel)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nhuang/decouple-fd-kernel)
- [ ] New/Existing tests provide coverage for changes

Multi Host
https://github.com/tenstorrent/tt-metal/actions/runs/22243695442

#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nhuang/decouple-fd-kernel)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nhuang/decouple-fd-kernel)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nhuang/decouple-fd-kernel)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nhuang/decouple-fd-kernel)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nhuang/decouple-fd-kernel)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nhuang/decouple-fd-kernel)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
