### PR TITLE
Fix remaining broken imports after SDPA test migration (#37713)

### DIFF
--- a/models/demos/llama3_70b_galaxy/tests/unit_tests/test_llama_ops.py
+++ b/models/demos/llama3_70b_galaxy/tests/unit_tests/test_llama_ops.py
@@ -16,7 +16,7 @@ from tests.ttnn.unit_tests.operations.fused.test_distributed_layernorm_sharded i
     compute_pre_allgather_stats,
     compute_post_allgather_output,
 )
-from tests.tt_eager.python_api_testing.unit_testing.misc.test_scaled_dot_product_attention_decode import (
+from tests.ttnn.unit_tests.operations.sdpa.sdpa_test_utils import (
     run_test_sdpa_decode_paged_attention_single_iter,
 )
 from tests.tt_eager.python_api_testing.unit_testing.misc.test_nlp_create_qkv_heads_decode import (

--- a/models/demos/llama3_70b_galaxy/tests/unit_tests/test_qwen_ops.py
+++ b/models/demos/llama3_70b_galaxy/tests/unit_tests/test_qwen_ops.py
@@ -16,7 +16,7 @@ from tests.ttnn.unit_tests.operations.fused.test_distributed_layernorm_sharded i
     compute_pre_allgather_stats,
     compute_post_allgather_output,
 )
-from tests.tt_eager.python_api_testing.unit_testing.misc.test_scaled_dot_product_attention_decode import (
+from tests.ttnn.unit_tests.operations.sdpa.sdpa_test_utils import (
     run_test_sdpa_decode_paged_attention_single_iter,
 )
 from tests.tt_eager.python_api_testing.unit_testing.misc.test_nlp_create_qkv_heads_decode import (

--- a/models/tt_dit/tests/unit/test_ring_joint_attention.py
+++ b/models/tt_dit/tests/unit/test_ring_joint_attention.py
@@ -11,7 +11,7 @@ from tracy.process_model_log import post_process_ops_log, run_device_profiler
 import ttnn
 from models.tt_dit.utils.padding import get_padded_vision_seq_len
 from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import comp_pcc
-from tests.tt_eager.python_api_testing.unit_testing.misc.test_scaled_dot_product_attention import fa_rand
+from tests.ttnn.unit_tests.operations.sdpa.sdpa_test_utils import fa_rand
 
 
 def torch_sdpa(q, k, v, joint_q, joint_k, joint_v, num_devices):

--- a/tests/sweep_framework/sweeps/model_traced/scaled_dot_product_attention_decode_model_traced.py
+++ b/tests/sweep_framework/sweeps/model_traced/scaled_dot_product_attention_decode_model_traced.py
@@ -8,7 +8,7 @@ from tests.ttnn.utils_for_testing import check_with_pcc, start_measuring_time, s
 from tests.sweep_framework.master_config_loader import MasterConfigLoader
 
 # Import helper functions from unit test
-from tests.tt_eager.python_api_testing.unit_testing.misc.test_scaled_dot_product_attention_decode import (
+from tests.ttnn.unit_tests.operations.sdpa.sdpa_test_utils import (
     nearest_n,
     nearest_pow_2,
     fa_rand,


### PR DESCRIPTION
Regression introduced in 89175b6e79d (#37713) which moved SDPA test files from tests/tt_eager/.../misc/ to tests/ttnn/unit_tests/operations/sdpa/. Four files were not updated and still imported from the deleted paths, causing ModuleNotFoundError during pytest collection.

Failing CI: https://github.com/tenstorrent/tt-metal/actions/runs/22121588688/job/63943103183
  - Galaxy CCL tests fail at collection of tests/nightly/tg/ccl/test_ring_joint_attention.py

Files fixed:
- models/tt_dit/tests/unit/test_ring_joint_attention.py: fa_rand from test_scaled_dot_product_attention
- tests/sweep_framework/sweeps/model_traced/scaled_dot_product_attention_decode_model_traced.py: nearest_n, nearest_pow_2, fa_rand, get_chunk_size from test_scaled_dot_product_attention_decode
- models/demos/llama3_70b_galaxy/tests/unit_tests/test_llama_ops.py: run_test_sdpa_decode_paged_attention_single_iter from test_scaled_dot_product_attention_decode
- models/demos/llama3_70b_galaxy/tests/unit_tests/test_qwen_ops.py: run_test_sdpa_decode_paged_attention_single_iter from test_scaled_dot_product_attention_decode

All imports updated to point to the new location: sdpa_test_utils.py

Similar fix was applied to test_deepseek_mla_ops.py in 694c6efbf72 (#37919).

Galaxy e2e tests run:
https://github.com/tenstorrent/tt-metal/actions/runs/22173578815
