### PR TITLE
Fix SDPA reduce_c C++ unit test compilation after granularity refactor

### DIFF
--- a/tests/tt_metal/tt_metal/test_kernels/misc/sdpa/reduce_block_max_row/compute.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/misc/sdpa/reduce_block_max_row/compute.cpp
@@ -41,7 +41,6 @@ void kernel_main() {
     cb_wait_front(qk_im_cb, num_tiles);
     cb_reserve_back(out_max_cb, rows);
 
-    binary_max_tile_init();
     constexpr uint32_t reduce_dst_idx = 0;
     constexpr uint32_t prev_max_dst_idx = 1;
 
@@ -54,6 +53,7 @@ void kernel_main() {
         if (do_eltwise) {
             copy_tile_to_dst_init_short(prev_max_cb);
             copy_tile(prev_max_cb, i, prev_max_dst_idx);
+            binary_max_tile_init();
             binary_max_tile(reduce_dst_idx, prev_max_dst_idx, reduce_dst_idx);
         }
 

--- a/tests/tt_metal/tt_metal/test_sdpa_reduce_c.cpp
+++ b/tests/tt_metal/tt_metal/test_sdpa_reduce_c.cpp
@@ -216,19 +216,8 @@ static bool test_sdpa_reduce_c(
         k_chunk_size,
         static_cast<uint32_t>(do_eltwise_max ? 1 : 0)};
     std::map<std::string, std::string> compute_defines;
-    // unnecessary defines
-    compute_defines["SUB_EXP_GRANULARITY"] = "0";
-    compute_defines["LOG2_SUB_EXP_GRANULARITY"] = "0";
-    compute_defines["STATS_GRANULARITY"] = "0";
-    compute_defines["LOG2_STATS_GRANULARITY"] = "0";
-    compute_defines["MUL_BCAST_GRANULARITY"] = "0";
-    compute_defines["LOG2_MUL_BCAST_GRANULARITY"] = "0";
-    compute_defines["DHT_GRANULARITY"] = "0";
-    compute_defines["LOG2_DHT_GRANULARITY"] = "0";
     compute_defines["EXP_APPROX_MODE"] = "0";
-    // For this testing, use granularity of 1
     compute_defines["REDUCE_GRANULARITY"] = "1";
-    compute_defines["LOG2_REDUCE_GRANULARITY"] = "0";
 
     tt_metal::CreateKernel(
         program,


### PR DESCRIPTION
Regression from e7596662e56b ("Remove granularity compile-time defines from SDPA compute kernel") which removed the granularity defines from the SDPA compute kernel but did not update the C++ unit test that was still passing the now-removed defines, causing compilation failures.

Resolves: https://github.com/tenstorrent/tt-metal/issues/38039
Broken pipeline: https://github.com/tenstorrent/tt-metal/actions/runs/22129032505/job/63965579936

Nightly L2 run with cpp unit tests
https://github.com/tenstorrent/tt-metal/actions/runs/22179356662

Nightly L2 run with cpp unit tests (take two)
https://github.com/tenstorrent/tt-metal/actions/runs/22220080182