### PR TITLE
Re-enable SD 1.4 on Model perf BH pipeline

### DIFF
--- a/.github/workflows/perf-models-impl.yaml
+++ b/.github/workflows/perf-models-impl.yaml
@@ -95,7 +95,7 @@ jobs:
         with:
           commands: pytest models/demos/vision/generative/stable_diffusion/${{ matrix.test-info.arch == 'blackhole' && 'blackhole' || 'wormhole' }}/tests -m models_performance_bare_metal --timeout=480
         # Disabled on blackhole until the test is fixed; issue #37617
-        if: ${{ !cancelled() && matrix.test-info.model-group == 'cnn_javelin' && matrix.test-info.arch != 'blackhole' && (inputs.model == 'all' || inputs.model == 'stable_diffusion') }}
+        if: ${{ !cancelled() && matrix.test-info.model-group == 'cnn_javelin' && (inputs.model == 'all' || inputs.model == 'stable_diffusion') }}
       # Disabled until the test is fixed; issue #35263
       # - name: Run sentence_bert model_perf test
       #   timeout-minutes: ${{ matrix.test-info.timeout }}

--- a/.github/workflows/perf-models-impl.yaml
+++ b/.github/workflows/perf-models-impl.yaml
@@ -93,8 +93,7 @@ jobs:
         timeout-minutes: ${{ matrix.test-info.timeout }}
         uses: tenstorrent/tt-metal/.github/actions/single-card-perf-test@main
         with:
-          commands: pytest models/demos/vision/generative/stable_diffusion/${{ matrix.test-info.arch == 'blackhole' && 'blackhole' || 'wormhole' }}/tests -m models_performance_bare_metal --timeout=480
-        # Disabled on blackhole until the test is fixed; issue #37617
+          commands: pytest models/demos/vision/generative/stable_diffusion/${{ matrix.test-info.arch == 'blackhole' && 'blackhole' || 'wormhole' }}/tests -m models_performance_bare_metal
         if: ${{ !cancelled() && matrix.test-info.model-group == 'cnn_javelin' && (inputs.model == 'all' || inputs.model == 'stable_diffusion') }}
       # Disabled until the test is fixed; issue #35263
       # - name: Run sentence_bert model_perf test

--- a/models/demos/vision/generative/stable_diffusion/wormhole/sd_helper_funcs.py
+++ b/models/demos/vision/generative/stable_diffusion/wormhole/sd_helper_funcs.py
@@ -179,8 +179,17 @@ def run(
     # scale and decode the image latents with vae
     latents = 1 / 0.18215 * ttnn_latents
 
-    ttnn_output = ttnn.permute(latents, [0, 2, 3, 1])
-    ttnn_output = tt_vae.decode(ttnn_output)
+    # Deallocate L1 tensors from the last denoising iteration before VAE
+    ttnn_latent_model_input.deallocate(True)
+    ttnn_output.deallocate(True)
+    noise_pred.deallocate(True)
+    ttnn_latents.deallocate(True)
+    for e in ttnn_scheduler.ets:
+        e.deallocate(True)
+    ttnn_scheduler.ets.clear()
+
+    latents = ttnn.permute(latents, [0, 2, 3, 1])
+    ttnn_output = tt_vae.decode(latents)
     ttnn_output = ttnn.reshape(ttnn_output, [1, 512, 512, ttnn_output.shape[3]])
     return ttnn.permute(ttnn_output, [0, 3, 1, 2])
 

--- a/models/demos/vision/generative/stable_diffusion/wormhole/sd_helper_funcs.py
+++ b/models/demos/vision/generative/stable_diffusion/wormhole/sd_helper_funcs.py
@@ -182,7 +182,6 @@ def run(
     # Deallocate L1 tensors from the last denoising iteration before VAE
     ttnn_latent_model_input.deallocate(True)
     ttnn_output.deallocate(True)
-    noise_pred.deallocate(True)
     ttnn_latents.deallocate(True)
     for e in ttnn_scheduler.ets:
         e.deallocate(True)

--- a/models/demos/vision/generative/stable_diffusion/wormhole/tests/test_perf.py
+++ b/models/demos/vision/generative/stable_diffusion/wormhole/tests/test_perf.py
@@ -253,7 +253,7 @@ def test_stable_diffusion_vae_trace(device, is_ci_env, is_ci_v2_env, model_locat
 @pytest.mark.parametrize(
     "batch_size, num_inference_steps, expected_compile_time, expected_inference_time",
     [
-        (1, 50, 3600, 4.45) if is_wormhole_b0() else (1, 50, 3600, 2.7),  # Wormhole B0 vs Blackhole performance
+        (1, 50, 3600, 4.5) if is_wormhole_b0() else (1, 50, 3600, 2.8),  # Wormhole B0 vs Blackhole performance
     ],
 )
 def test_stable_diffusion_perf(

--- a/models/demos/vision/generative/stable_diffusion/wormhole/tests/test_perf.py
+++ b/models/demos/vision/generative/stable_diffusion/wormhole/tests/test_perf.py
@@ -245,6 +245,7 @@ def test_stable_diffusion_vae_trace(device, is_ci_env, is_ci_v2_env, model_locat
     ), f"Inference time with trace is {inference_time}s, while expected time is {expected_inference_time}s"
 
 
+@pytest.mark.timeout(500)
 @pytest.mark.models_performance_bare_metal
 @pytest.mark.parametrize(
     "device_params", [{"l1_small_size": SD_L1_SMALL_SIZE, "trace_region_size": SD_TRACE_REGION_SIZE}], indirect=True
@@ -252,7 +253,7 @@ def test_stable_diffusion_vae_trace(device, is_ci_env, is_ci_v2_env, model_locat
 @pytest.mark.parametrize(
     "batch_size, num_inference_steps, expected_compile_time, expected_inference_time",
     [
-        (1, 50, 3600, 5.0) if is_wormhole_b0() else (1, 50, 3600, 3.15),  # Wormhole B0 vs Blackhole performance
+        (1, 50, 3600, 4.45) if is_wormhole_b0() else (1, 50, 3600, 2.7),  # Wormhole B0 vs Blackhole performance
     ],
 )
 def test_stable_diffusion_perf(


### PR DESCRIPTION
### Ticket
#37617

### Problem description & changes
SD 1.4 was removed from Model perf pipeline because it timeouted. In the meanwhile new fw rollout landed for BH that harvests 2 columns from p150. 

I increased the timeout and this resulted in L1 OOM error on perf test running Unet2d and VAE components together. This is fixed by deallocating tensors that stayed in memory after Unet2d component is done, although they were not needed anymore.

The targets for both WH and BH were very loose so we didn't see any perf hit from losing 2 columns, so I updated them. It is possible that the targets were loose because we had different behavior in different machines in the past, I will monitor if new tagrets become too tight now and adjust if needed.

### Checklist

- Model perf: https://github.com/tenstorrent/tt-metal/actions/runs/22183475821 ✅ 