### PR TITLE
Add L1/L2 cache flush/invalidate support for Quasar DM cores

### DIFF
--- a/tests/tt_metal/tt_metal/data_movement/quasar_cache/kernels/l1_dcache_test.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/quasar_cache/kernels/l1_dcache_test.cpp
@@ -55,5 +55,9 @@ void kernel_main() {
             invalidate_l1_dcache(0);  // 0 = entire cache
             flush_l2_cache_range(base_addr, num_words * sizeof(uint32_t));
             break;
+
+        default:
+            ASSERT(false);
+            while (1);
     }
 }

--- a/tests/tt_metal/tt_metal/data_movement/quasar_cache/kernels/l1_dcache_test.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/quasar_cache/kernels/l1_dcache_test.cpp
@@ -18,7 +18,7 @@ void kernel_main() {
     uint32_t num_words = get_common_arg_val<uint32_t>(1);
 
     // Write values to cacheable addresses (goes through L1 D$ -> L2)
-    volatile uint32_t* ptr = (volatile uint32_t*)base_addr;
+    volatile uint32_t* ptr = (volatile uint32_t*)(uintptr_t)base_addr;
     for (uint32_t i = 0; i < num_words; i++) {
         ptr[i] = value + i;
     }

--- a/tests/tt_metal/tt_metal/data_movement/quasar_cache/kernels/l1_dcache_test.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/quasar_cache/kernels/l1_dcache_test.cpp
@@ -6,12 +6,14 @@
 // Tests flush and invalidate operations with two-stage verification.
 
 #include "api/dataflow/dataflow_api.h"
+#include "dev_mem_map.h"
 #include "risc_common.h"
 
 void kernel_main() {
     // Runtime args
     uint32_t base_addr = get_arg_val<uint32_t>(0);
-    uint32_t test_mode = get_arg_val<uint32_t>(1);  // 0=flush_line, 1=flush_full, 2=invalidate_line, 3=invalidate_full
+    // 0=flush_line, 1=flush_full, 2=invalidate_line, 3=invalidate_full, 4=invalidate_fresh_read
+    uint32_t test_mode = get_arg_val<uint32_t>(1);
 
     // Common args
     uint32_t value = get_common_arg_val<uint32_t>(0);
@@ -55,6 +57,31 @@ void kernel_main() {
             invalidate_l1_dcache(0);  // 0 = entire cache
             flush_l2_cache_range(base_addr, num_words * sizeof(uint32_t));
             break;
+
+        case 4: {
+            // Test that invalidation causes fresh read from memory:
+            // 1. Read from cacheable address (caches in L1 D$)
+            // 2. Write new value via uncached address (directly to TL1)
+            // 3. Invalidate L1 D$ and L2 lines
+            // 4. Read again - should get new value from TL1
+            uint32_t uncached_addr = base_addr + MEM_L1_UNCACHED_BASE;
+            volatile uint32_t* uncached_ptr = (volatile uint32_t*)(uintptr_t)uncached_addr;
+
+            for (uint32_t i = 0; i < num_words; i++) {
+                // Read to cache the old value (host pre-populated)
+                volatile uint32_t cached_val = ptr[i];
+                (void)cached_val;
+
+                // Write new value directly to TL1 via uncached alias
+                uncached_ptr[i] = value + i;
+
+                // Invalidate both L1 D$ and L2 to ensure fresh read from TL1
+                invalidate_l1_dcache(base_addr + i * sizeof(uint32_t));
+                invalidate_l2_cache_line(base_addr + i * sizeof(uint32_t));
+            }
+            // Now when host reads, it should see the new values
+            break;
+        }
 
         default:
             ASSERT(false);

--- a/tests/tt_metal/tt_metal/data_movement/quasar_cache/kernels/l1_dcache_test.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/quasar_cache/kernels/l1_dcache_test.cpp
@@ -1,0 +1,59 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Kernel for testing L1 data cache operations on Quasar DM cores.
+// Tests flush and invalidate operations with two-stage verification.
+
+#include "api/dataflow/dataflow_api.h"
+#include "risc_common.h"
+
+void kernel_main() {
+    // Runtime args
+    uint32_t base_addr = get_arg_val<uint32_t>(0);
+    uint32_t test_mode = get_arg_val<uint32_t>(1);  // 0=flush_line, 1=flush_full, 2=invalidate_line, 3=invalidate_full
+
+    // Common args
+    uint32_t value = get_common_arg_val<uint32_t>(0);
+    uint32_t num_words = get_common_arg_val<uint32_t>(1);
+
+    // Write values to cacheable addresses (goes through L1 D$ -> L2)
+    volatile uint32_t* ptr = (volatile uint32_t*)base_addr;
+    for (uint32_t i = 0; i < num_words; i++) {
+        ptr[i] = value + i;
+    }
+
+    switch (test_mode) {
+        case 0:
+            // Flush L1 D$ line(s) to L2, then flush L2 to TL1
+            for (uint32_t i = 0; i < num_words; i++) {
+                flush_l1_dcache(base_addr + i * sizeof(uint32_t));
+            }
+            // Now flush L2 to make data visible to host
+            flush_l2_cache_range(base_addr, num_words * sizeof(uint32_t));
+            break;
+
+        case 1:
+            // Flush entire L1 D$ to L2, then flush L2 to TL1
+            flush_l1_dcache(0);  // 0 = entire cache
+            flush_l2_cache_range(base_addr, num_words * sizeof(uint32_t));
+            break;
+
+        case 2:
+            // Invalidate L1 D$ line(s) WITHOUT writeback, then flush L2
+            // Since L1 didn't write back, L2 should have stale/no data
+            // This tests that invalidate does NOT write back
+            for (uint32_t i = 0; i < num_words; i++) {
+                invalidate_l1_dcache(base_addr + i * sizeof(uint32_t));
+            }
+            // Flush L2 - should NOT contain the new values since L1 didn't write back
+            flush_l2_cache_range(base_addr, num_words * sizeof(uint32_t));
+            break;
+
+        case 3:
+            // Invalidate entire L1 D$ WITHOUT writeback, then flush L2
+            invalidate_l1_dcache(0);  // 0 = entire cache
+            flush_l2_cache_range(base_addr, num_words * sizeof(uint32_t));
+            break;
+    }
+}

--- a/tests/tt_metal/tt_metal/data_movement/quasar_cache/kernels/l2_flush_test.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/quasar_cache/kernels/l2_flush_test.cpp
@@ -1,0 +1,43 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Kernel for testing L2 cache flush operations on Quasar DM cores.
+// Writes values to cacheable memory and flushes using various L2 flush functions.
+
+#include "api/dataflow/dataflow_api.h"
+#include "risc_common.h"
+
+void kernel_main() {
+    // Runtime args
+    uint32_t base_addr = get_arg_val<uint32_t>(0);
+    uint32_t test_mode = get_arg_val<uint32_t>(1);  // 0=line, 1=range, 2=full
+
+    // Common args
+    uint32_t value = get_common_arg_val<uint32_t>(0);
+    uint32_t num_words = get_common_arg_val<uint32_t>(1);
+
+    // Write values to cacheable addresses
+    volatile uint32_t* ptr = (volatile uint32_t*)base_addr;
+    for (uint32_t i = 0; i < num_words; i++) {
+        ptr[i] = value + i;
+    }
+
+    // Flush based on test mode
+    switch (test_mode) {
+        case 0:
+            // Single line flush - flush each cache line individually
+            for (uint32_t i = 0; i < num_words; i++) {
+                flush_l2_cache_line(base_addr + i * sizeof(uint32_t));
+            }
+            break;
+        case 1:
+            // Range flush
+            flush_l2_cache_range(base_addr, num_words * sizeof(uint32_t));
+            break;
+        case 2:
+            // Full cache flush
+            flush_l2_cache_full();
+            break;
+    }
+}

--- a/tests/tt_metal/tt_metal/data_movement/quasar_cache/kernels/l2_flush_test.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/quasar_cache/kernels/l2_flush_test.cpp
@@ -7,12 +7,14 @@
 
 #include "api/dataflow/dataflow_api.h"
 #include "api/debug/dprint.h"
+#include "dev_mem_map.h"
 #include "risc_common.h"
 
 void kernel_main() {
     // Runtime args
     uint32_t base_addr = get_arg_val<uint32_t>(0);
-    uint32_t test_mode = get_arg_val<uint32_t>(1);  // 0=flush_line, 1=flush_range, 2=flush_full, 3=invalidate_line
+    // 0=flush_line, 1=flush_range, 2=flush_full, 3=invalidate_line, 4=invalidate_fresh_read
+    uint32_t test_mode = get_arg_val<uint32_t>(1);
 
     // Common args
     uint32_t value = get_common_arg_val<uint32_t>(0);
@@ -51,6 +53,31 @@ void kernel_main() {
                 invalidate_l2_cache_line(base_addr + i * sizeof(uint32_t));
             }
             break;
+
+        case 4: {
+            // Test that invalidation causes fresh read from TL1:
+            // 1. Read from cacheable address (caches in L2)
+            // 2. Write new value via uncached address (directly to TL1)
+            // 3. Invalidate L2 line
+            // 4. Read again - should get new value
+            uint32_t uncached_addr = base_addr + MEM_L1_UNCACHED_BASE;
+            volatile uint32_t* uncached_ptr = (volatile uint32_t*)(uintptr_t)uncached_addr;
+
+            for (uint32_t i = 0; i < num_words; i++) {
+                // Read to cache the old value (host pre-populated)
+                volatile uint32_t cached_val = ptr[i];
+                (void)cached_val;
+
+                // Write new value directly to TL1 via uncached alias
+                uncached_ptr[i] = value + i;
+
+                // Invalidate the L2 cache line
+                invalidate_l2_cache_line(base_addr + i * sizeof(uint32_t));
+            }
+            // Now when host reads, it should see the new values
+            // (they were written via uncached path, L2 was invalidated so no stale data)
+            break;
+        }
 
         default:
             ASSERT(false);

--- a/tests/tt_metal/tt_metal/data_movement/quasar_cache/kernels/l2_flush_test.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/quasar_cache/kernels/l2_flush_test.cpp
@@ -6,6 +6,7 @@
 // Writes values to cacheable memory and flushes using various L2 flush functions.
 
 #include "api/dataflow/dataflow_api.h"
+#include "api/debug/dprint.h"
 #include "risc_common.h"
 
 void kernel_main() {
@@ -17,11 +18,15 @@ void kernel_main() {
     uint32_t value = get_common_arg_val<uint32_t>(0);
     uint32_t num_words = get_common_arg_val<uint32_t>(1);
 
+    DPRINT << "START mode=" << test_mode << " words=" << num_words << ENDL();
+
     // Write values to cacheable addresses
     volatile uint32_t* ptr = (volatile uint32_t*)(uintptr_t)base_addr;
     for (uint32_t i = 0; i < num_words; i++) {
         ptr[i] = value + i;
     }
+
+    DPRINT << "WRITES DONE" << ENDL();
 
     // Flush based on test mode
     switch (test_mode) {
@@ -40,4 +45,6 @@ void kernel_main() {
             flush_l2_cache_full();
             break;
     }
+
+    DPRINT << "FLUSH DONE" << ENDL();
 }

--- a/tests/tt_metal/tt_metal/data_movement/quasar_cache/kernels/l2_flush_test.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/quasar_cache/kernels/l2_flush_test.cpp
@@ -2,8 +2,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-// Kernel for testing L2 cache flush operations on Quasar DM cores.
-// Writes values to cacheable memory and flushes using various L2 flush functions.
+// Kernel for testing L2 cache operations on Quasar DM cores.
+// Writes values to cacheable memory and flushes/invalidates using various L2 functions.
 
 #include "api/dataflow/dataflow_api.h"
 #include "api/debug/dprint.h"
@@ -12,7 +12,7 @@
 void kernel_main() {
     // Runtime args
     uint32_t base_addr = get_arg_val<uint32_t>(0);
-    uint32_t test_mode = get_arg_val<uint32_t>(1);  // 0=line, 1=range, 2=full
+    uint32_t test_mode = get_arg_val<uint32_t>(1);  // 0=flush_line, 1=flush_range, 2=flush_full, 3=invalidate_line
 
     // Common args
     uint32_t value = get_common_arg_val<uint32_t>(0);
@@ -28,7 +28,7 @@ void kernel_main() {
 
     DPRINT << "WRITES DONE" << ENDL();
 
-    // Flush based on test mode
+    // Flush/invalidate based on test mode
     switch (test_mode) {
         case 0:
             // Single line flush - flush each cache line individually
@@ -44,7 +44,14 @@ void kernel_main() {
             // Full cache flush
             flush_l2_cache_full();
             break;
+        case 3:
+            // Invalidate line - flush L1 to L2, then invalidate L2 (no writeback to TL1)
+            flush_l1_dcache(0);  // Flush L1 D$ to L2
+            for (uint32_t i = 0; i < num_words; i++) {
+                invalidate_l2_cache_line(base_addr + i * sizeof(uint32_t));
+            }
+            break;
     }
 
-    DPRINT << "FLUSH DONE" << ENDL();
+    DPRINT << "DONE" << ENDL();
 }

--- a/tests/tt_metal/tt_metal/data_movement/quasar_cache/kernels/l2_flush_test.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/quasar_cache/kernels/l2_flush_test.cpp
@@ -18,7 +18,7 @@ void kernel_main() {
     uint32_t num_words = get_common_arg_val<uint32_t>(1);
 
     // Write values to cacheable addresses
-    volatile uint32_t* ptr = (volatile uint32_t*)base_addr;
+    volatile uint32_t* ptr = (volatile uint32_t*)(uintptr_t)base_addr;
     for (uint32_t i = 0; i < num_words; i++) {
         ptr[i] = value + i;
     }

--- a/tests/tt_metal/tt_metal/data_movement/quasar_cache/kernels/l2_flush_test.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/quasar_cache/kernels/l2_flush_test.cpp
@@ -51,6 +51,10 @@ void kernel_main() {
                 invalidate_l2_cache_line(base_addr + i * sizeof(uint32_t));
             }
             break;
+
+        default:
+            ASSERT(false);
+            while (1);
     }
 
     DPRINT << "DONE" << ENDL();

--- a/tests/tt_metal/tt_metal/data_movement/quasar_cache/quasar_dm_cache_management.md
+++ b/tests/tt_metal/tt_metal/data_movement/quasar_cache/quasar_dm_cache_management.md
@@ -6,37 +6,38 @@
 ## Cache Hierarchy
 
 ```
-┌─────────────────────────────────────────────────────────────┐
-│                      Quasar DM Core                         │
-│  ┌─────────────────────────────────────────────────────────┐│
-│  │                    RV64 Core                            ││
-│  └─────────────────────────────────────────────────────────┘│
-│                    │                │                       │
-│                    ▼                ▼                       │
-│            ┌───────────┐    ┌───────────┐                   │
-│            │  L1 D$    │    │  L1 I$    │                   │
-│            │  4 KB (?) │    │   ? (?)   │                   │
-│            └─────┬─────┘    └───────────┘                   │
-│                  │                                          │
-│                  ▼                                          │
-│         ┌────────────────┐                                  │
-│         │      L2        │  ◄── 8 banks, 8 ways, 32 sets    │
-│         │    128 KB      │      64B cache line              │
-│         └────────┬───────┘                                  │
-└──────────────────┼──────────────────────────────────────────┘
-                   │
-                   ▼
-         ┌────────────────┐
-         │      TL1       │  (Tensix L1 / Shared Node SRAM)
-         │   Node Memory  │
-         └────────────────┘
+┌─────────────────────────────────────────────────────────────────────────────┐
+│                            Quasar DM Cores (x8)                             │
+│                                                                             │
+│  ┌────────────┐  ┌────────────┐  ┌────────────┐            ┌────────────┐   │
+│  │ DM Core 0  │  │ DM Core 1  │  │ DM Core 2  │    ...     │ DM Core 7  │   │
+│  │            │  │            │  │            │            │            │   │
+│  │ L1D$ 4K 2W │  │ L1D$ 4K 2W │  │ L1D$ 4K 2W │            │ L1D$ 4K 2W │   │
+│  │ L1I$ 4K 2W │  │ L1I$ 4K 2W │  │ L1I$ 4K 2W │            │ L1I$ 4K 2W │   │
+│  └─────┬──────┘  └─────┬──────┘  └─────┬──────┘            └─────┬──────┘   │
+│        │               │               │                         │          │
+│        └───────────────┴───────────────┴────────── ... ──────────┘          │
+│                                   │                                         │
+│                                   ▼                                         │
+│                       ┌───────────────────┐                                 │
+│                       │   L2 (shared)     │  128 KB, 4-way associative      │
+│                       │                   │  64B cache line                 │
+│                       └─────────┬─────────┘                                 │
+└─────────────────────────────────┼───────────────────────────────────────────┘
+                                  │
+                                  ▼
+                       ┌───────────────────┐
+                       │       TL1         │  (Tensix L1 / Shared Node SRAM)
+                       │   Node Memory     │
+                       └───────────────────┘
 ```
 
 **Key points:**
-- L1 D$ is **inclusive** of L2 (flushing L1 writes to L2, not directly to TL1) — per code comments
-- L1 I$ is separate (instruction cache), size unknown
-- L2 is shared across 8 DM cores in a cluster (?) — per code comments
+- L1 D$: 4KB, 2-way, write-back, private per core
+- L1 I$: 4KB, 2-way, private per core
+- L2: 128KB, 4-way, write-back, shared between all 8 DM cores
 - TL1 is the backing memory visible to NoC/DMA
+- Address 0-4MB is cacheable, 4-8MB aliases to same range but uncached ("write around")
 
 ---
 
@@ -50,7 +51,8 @@
 | `flush_l2_cache_line(addr)` | Single 64B line | L2 → TL1 | Tested |
 | `flush_l2_cache_range(addr, size)` | Address range | L2 → TL1 (loops over lines) | Tested |
 | `flush_l2_cache_full()` | Entire 128KB | L2 → TL1 | Tested |
-| `invalidate_l2_cache(hartid)` | Entire 128KB | Discard L2 (requires all 8 cores?) | Not tested |
+| `invalidate_l2_cache_line(addr)` | Single 64B line | Discard L2 line (no writeback) | Tested |
+| `invalidate_l2_cache(hartid)` | Entire 128KB | Discard L2 (requires all DM cores?) | Not tested |
 
 ---
 
@@ -108,7 +110,7 @@ void invalidate_l1_icache();  // Uses FENCE.I instruction
 
 No flush exists — I$ is read-only from CPU perspective.
 
-**L1 I$ size:** Unknown
+**L1 I$ size:** 4KB
 
 ### L2 Cache
 
@@ -122,13 +124,17 @@ void flush_l2_cache_range(uint32_t start_addr, uint32_t size);
 // Entire 128KB cache
 void flush_l2_cache_full();
 
-// Invalidate - per code comments, requires coordination across all 8 DM cores
+// Invalidate single line (no writeback)
+void invalidate_l2_cache_line(uint32_t addr);
+
+// Invalidate entire L2 - requires coordination across all DM cores
 void invalidate_l2_cache(uint32_t hartid);
 ```
 
 **Implementation:** Memory-mapped registers in cache controller
 - `L2_FLUSH_ADDR`: Write address to flush that line
-- `L2_FULL_INVALIDATE_ADDR`: Bitmask register for core synchronization (?)
+- `L2_INVALIDATE_ADDR`: Write address to invalidate that line
+- `L2_FULL_INVALIDATE_ADDR`: Bitmask register for full cache invalidation
 
 ---
 
@@ -212,13 +218,13 @@ flush_l2_cache_line(0x20010);  // Flushes line containing 0x20010
 ```cpp
 // Only running on core 0
 invalidate_l2_cache(0);  // May deadlock or cause undefined behavior (?)
-// Per code comments, hardware waits for all 8 cores to signal
+// Per code comments, hardware waits for all DM cores to signal
 ```
 
 **Possible workaround (unverified):**
 ```cpp
 volatile uint64_t* inv_reg = (volatile uint64_t*)L2_FULL_INVALIDATE_ADDR;
-*inv_reg = 0xFF;  // Signal all 8 cores at once (?)
+*inv_reg = 0xFF;  // Signal all DM cores at once (?)
 while (*inv_reg != 0);
 ```
 
@@ -229,11 +235,8 @@ while (*inv_reg != 0);
 From `overlay_addresses.h` (verified):
 
 ```cpp
-#define L2_CACHE_LINE_SIZE  64      // bytes
-#define L2_CACHE_NUM_SETS   32
-#define L2_CACHE_NUM_WAYS   8
-#define L2_CACHE_NUM_BANKS  8
-#define L2_CACHE_SIZE       131072  // 128 KB (8 * 8 * 32 * 64)
+#define L2_CACHE_LINE_SIZE  64          // bytes
+#define L2_CACHE_SIZE       (128 * 1024) // 128 KB, 4-way associative
 ```
 
 L1 D$ size: 4 KB — per SiFive X280 documentation (?)
@@ -252,6 +255,7 @@ L1 D$ size: 4 KB — per SiFive X280 documentation (?)
 | `flush_l2_cache_line(addr)` | Yes | `QuasarL2CacheFlush.FlushLine` |
 | `flush_l2_cache_range(...)` | Yes | `QuasarL2CacheFlush.FlushRange` |
 | `flush_l2_cache_full()` | Yes | `QuasarL2CacheFlush.FlushFull` |
+| `invalidate_l2_cache_line(addr)` | Yes | `QuasarL2CacheFlush.InvalidateLine` |
 | `invalidate_l2_cache(hartid)` | No | — (requires multi-core coordination) |
 
 ---

--- a/tests/tt_metal/tt_metal/data_movement/quasar_cache/quasar_dm_cache_management.md
+++ b/tests/tt_metal/tt_metal/data_movement/quasar_cache/quasar_dm_cache_management.md
@@ -20,7 +20,7 @@
 │                                   │                                         │
 │                                   ▼                                         │
 │                       ┌───────────────────┐                                 │
-│                       │   L2 (shared)     │  128 KB, 4-way associative      │
+│                       │   L2$ (shared)    │  128 KB, 4-way associative      │
 │                       │                   │  64B cache line                 │
 │                       └─────────┬─────────┘                                 │
 └─────────────────────────────────┼───────────────────────────────────────────┘
@@ -36,6 +36,7 @@
 - L1 D$: 4KB, 2-way, write-back, private per core
 - L1 I$: 4KB, 2-way, private per core
 - L2: 128KB, 4-way, write-back, shared between all 8 DM cores
+- **L1 and L2 are coherent** — L2 flush probes L1 D$ for dirty data before writing to TL1
 - TL1 is the backing memory visible to NoC/DMA
 - Address 0-4MB is cacheable, 4-8MB aliases to same range but uncached ("write around")
 
@@ -48,9 +49,9 @@
 | `flush_l1_dcache(addr)` | Single line or full | L1 D$ → L2 (writeback + invalidate) | Tested |
 | `invalidate_l1_dcache(addr)` | Single line or full | Discard L1 D$ line (no writeback) | Tested |
 | `invalidate_l1_icache()` | Full only | Discard L1 I$ (for code changes) | Not tested |
-| `flush_l2_cache_line(addr)` | Single 64B line | L2 → TL1 | Tested |
+| `flush_l2_cache_line(addr)` | Single 64B line | L2 → TL1 (probes L1 D$ first) | Tested |
 | `flush_l2_cache_range(addr, size)` | Address range | L2 → TL1 (loops over lines) | Tested |
-| `flush_l2_cache_full()` | Entire 128KB | L2 → TL1 | Tested |
+| `flush_l2_cache_full()` | Entire 128KB | L2 → TL1 (probes L1 D$ first) | Tested |
 | `invalidate_l2_cache_line(addr)` | Single 64B line | Discard L2 line (no writeback) | Tested |
 | `invalidate_l2_cache(hartid)` | Entire 128KB | Discard L2 (requires all DM cores?) | Not tested |
 
@@ -116,16 +117,16 @@ No flush exists — I$ is read-only from CPU perspective.
 
 ```cpp
 // Single line (64 bytes)
-void flush_l2_cache_line(uint32_t addr);
+void flush_l2_cache_line(uintptr_t addr);
 
 // Range (automatically aligns to 64B boundaries)
-void flush_l2_cache_range(uint32_t start_addr, uint32_t size);
+void flush_l2_cache_range(uintptr_t start_addr, size_t size);
 
 // Entire 128KB cache
 void flush_l2_cache_full();
 
 // Invalidate single line (no writeback)
-void invalidate_l2_cache_line(uint32_t addr);
+void invalidate_l2_cache_line(uintptr_t addr);
 
 // Invalidate entire L2 - requires coordination across all DM cores
 void invalidate_l2_cache(uint32_t hartid);
@@ -140,7 +141,7 @@ void invalidate_l2_cache(uint32_t hartid);
 
 ## Code Examples
 
-### Correct: Full path flush (L1 → L2 → TL1)
+### Correct: Flush to TL1 (L2 probes L1 automatically)
 
 ```cpp
 // Write data
@@ -149,21 +150,19 @@ for (int i = 0; i < 16; i++) {
     ptr[i] = data[i];
 }
 
-// Flush through entire hierarchy
-flush_l1_dcache(0);                                    // L1 D$ → L2 (entire cache)
-flush_l2_cache_range(0x20000, 16 * sizeof(uint32_t));  // L2 → TL1
+// Flush to TL1 - L2 flush automatically probes L1 D$ for dirty data
+flush_l2_cache_range(0x20000, 16 * sizeof(uint32_t));
 // Data now visible in TL1
 ```
 
-### Correct: Line-by-line flush
+### Correct: Single line flush
 
 ```cpp
-uint32_t addr = 0x20000;
+uintptr_t addr = 0x20000;
 volatile uint32_t* ptr = (volatile uint32_t*)addr;
 *ptr = 0xDEADBEEF;
 
-flush_l1_dcache(addr);       // Flush this specific L1 line to L2
-flush_l2_cache_line(addr);   // Flush this specific L2 line to TL1
+flush_l2_cache_line(addr);   // Probes L1 D$, then flushes L2 line to TL1
 ```
 
 ### Correct: Invalidate I$ after loading new code
@@ -177,18 +176,6 @@ invalidate_l1_icache();  // Clear stale instructions
 ---
 
 ## Bad Usage Examples
-
-### BAD: Forgetting L1 flush
-
-```cpp
-volatile uint32_t* ptr = (volatile uint32_t*)0x20000;
-*ptr = 0xDEADBEEF;
-
-flush_l2_cache_line(0x20000);  // WRONG: Data may still be in L1 D$!
-// TL1 may get stale data (whatever was in L2)
-```
-
-**Fix:** Flush L1 first, then L2.
 
 ### BAD: Invalidate when you meant flush
 

--- a/tests/tt_metal/tt_metal/data_movement/quasar_cache/quasar_dm_cache_management.md
+++ b/tests/tt_metal/tt_metal/data_movement/quasar_cache/quasar_dm_cache_management.md
@@ -1,0 +1,264 @@
+# Quasar DM Core Cache Management
+
+> **Note:** This document is based on implementation work and hardware documentation.
+> Items marked with **(?)** need verification. Please fact-check before relying on details.
+
+## Cache Hierarchy
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                      Quasar DM Core                         │
+│  ┌─────────────────────────────────────────────────────────┐│
+│  │                    RV64 Core                            ││
+│  └─────────────────────────────────────────────────────────┘│
+│                    │                │                       │
+│                    ▼                ▼                       │
+│            ┌───────────┐    ┌───────────┐                   │
+│            │  L1 D$    │    │  L1 I$    │                   │
+│            │  4 KB (?) │    │   ? (?)   │                   │
+│            └─────┬─────┘    └───────────┘                   │
+│                  │                                          │
+│                  ▼                                          │
+│         ┌────────────────┐                                  │
+│         │      L2        │  ◄── 8 banks, 8 ways, 32 sets    │
+│         │    128 KB      │      64B cache line              │
+│         └────────┬───────┘                                  │
+└──────────────────┼──────────────────────────────────────────┘
+                   │
+                   ▼
+         ┌────────────────┐
+         │      TL1       │  (Tensix L1 / Shared Node SRAM)
+         │   Node Memory  │
+         └────────────────┘
+```
+
+**Key points:**
+- L1 D$ is **inclusive** of L2 (flushing L1 writes to L2, not directly to TL1) — per code comments
+- L1 I$ is separate (instruction cache), size unknown
+- L2 is shared across 8 DM cores in a cluster (?) — per code comments
+- TL1 is the backing memory visible to NoC/DMA
+
+---
+
+## Operations Summary
+
+| Function | Scope | What it does | Verified |
+|----------|-------|--------------|----------|
+| `flush_l1_dcache(addr)` | Single line or full | L1 D$ → L2 (writeback + invalidate) | Tested |
+| `invalidate_l1_dcache(addr)` | Single line or full | Discard L1 D$ line (no writeback) | Tested |
+| `invalidate_l1_icache()` | Full only | Discard L1 I$ (for code changes) | Not tested |
+| `flush_l2_cache_line(addr)` | Single 64B line | L2 → TL1 | Tested |
+| `flush_l2_cache_range(addr, size)` | Address range | L2 → TL1 (loops over lines) | Tested |
+| `flush_l2_cache_full()` | Entire 128KB | L2 → TL1 | Tested |
+| `invalidate_l2_cache(hartid)` | Entire 128KB | Discard L2 (requires all 8 cores?) | Not tested |
+
+---
+
+## Flush vs Invalidate
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                         FLUSH                               │
+│   Writes dirty data to next level, then invalidates line(?) │
+│                                                             │
+│   Cache ──(write dirty)──► Next Level                       │
+│          then discard(?)                                    │
+│                                                             │
+│   Use: Before someone else needs to read your data          │
+└─────────────────────────────────────────────────────────────┘
+
+┌─────────────────────────────────────────────────────────────┐
+│                       INVALIDATE                            │
+│   Discards line immediately, dirty data is LOST             │
+│                                                             │
+│   Cache ──(discard)──► /dev/null                            │
+│                                                             │
+│   Use: When cached data is stale and you need fresh read    │
+│   DANGER: If line is dirty, modifications are lost!         │
+└─────────────────────────────────────────────────────────────┘
+```
+
+**(?)** Whether flush also invalidates the line, or just writes back and keeps it cached, is unclear from documentation. SiFive docs suggest CFLUSH.D.L1 does both writeback + invalidate.
+
+---
+
+## API Details
+
+### L1 Data Cache
+
+```cpp
+// Flush single line (addr != 0) or entire cache (addr == 0)
+void flush_l1_dcache(uintptr_t addr);
+
+// Invalidate single line (addr != 0) or entire cache (addr == 0)
+void invalidate_l1_dcache(uintptr_t addr);
+```
+
+**Implementation:** Custom RISC-V instructions (SiFive/rocket-chip heritage — per code comments)
+- `CFLUSH.D.L1` (simm12 = -0x40): flush + invalidate
+- `CDISCARD.D.L1` (simm12 = -0x3E): invalidate only
+
+**L1 D$ size:** 4 KB — sourced from SiFive X280 documentation, not directly verified on Quasar
+
+### L1 Instruction Cache
+
+```cpp
+void invalidate_l1_icache();  // Uses FENCE.I instruction
+```
+
+No flush exists — I$ is read-only from CPU perspective.
+
+**L1 I$ size:** Unknown
+
+### L2 Cache
+
+```cpp
+// Single line (64 bytes)
+void flush_l2_cache_line(uint32_t addr);
+
+// Range (automatically aligns to 64B boundaries)
+void flush_l2_cache_range(uint32_t start_addr, uint32_t size);
+
+// Entire 128KB cache
+void flush_l2_cache_full();
+
+// Invalidate - per code comments, requires coordination across all 8 DM cores
+void invalidate_l2_cache(uint32_t hartid);
+```
+
+**Implementation:** Memory-mapped registers in cache controller
+- `L2_FLUSH_ADDR`: Write address to flush that line
+- `L2_FULL_INVALIDATE_ADDR`: Bitmask register for core synchronization (?)
+
+---
+
+## Code Examples
+
+### Correct: Full path flush (L1 → L2 → TL1)
+
+```cpp
+// Write data
+volatile uint32_t* ptr = (volatile uint32_t*)0x20000;
+for (int i = 0; i < 16; i++) {
+    ptr[i] = data[i];
+}
+
+// Flush through entire hierarchy
+flush_l1_dcache(0);                                    // L1 D$ → L2 (entire cache)
+flush_l2_cache_range(0x20000, 16 * sizeof(uint32_t));  // L2 → TL1
+// Data now visible in TL1
+```
+
+### Correct: Line-by-line flush
+
+```cpp
+uint32_t addr = 0x20000;
+volatile uint32_t* ptr = (volatile uint32_t*)addr;
+*ptr = 0xDEADBEEF;
+
+flush_l1_dcache(addr);       // Flush this specific L1 line to L2
+flush_l2_cache_line(addr);   // Flush this specific L2 line to TL1
+```
+
+### Correct: Invalidate I$ after loading new code
+
+```cpp
+// New code was written to instruction memory (by overlay load, etc.)
+invalidate_l1_icache();  // Clear stale instructions
+// Safe to jump to new code now
+```
+
+---
+
+## Bad Usage Examples
+
+### BAD: Forgetting L1 flush
+
+```cpp
+volatile uint32_t* ptr = (volatile uint32_t*)0x20000;
+*ptr = 0xDEADBEEF;
+
+flush_l2_cache_line(0x20000);  // WRONG: Data may still be in L1 D$!
+// TL1 may get stale data (whatever was in L2)
+```
+
+**Fix:** Flush L1 first, then L2.
+
+### BAD: Invalidate when you meant flush
+
+```cpp
+volatile uint32_t* ptr = (volatile uint32_t*)0x20000;
+*ptr = 0xDEADBEEF;
+
+invalidate_l1_dcache(0x20000);  // WRONG: Data is LOST!
+flush_l2_cache_line(0x20000);
+// 0xDEADBEEF never reaches TL1
+```
+
+**Fix:** Use `flush_l1_dcache` to preserve data.
+
+### BAD: Unaligned range assumption
+
+```cpp
+// Data at 0x20010 (not 64B aligned)
+flush_l2_cache_line(0x20010);  // Flushes line containing 0x20010
+// This works, but be aware: likely flushes 0x20000-0x2003F (entire 64B line)
+```
+
+**Note:** `flush_l2_cache_range` handles alignment automatically.
+
+### BAD: Single-core L2 invalidate (?)
+
+```cpp
+// Only running on core 0
+invalidate_l2_cache(0);  // May deadlock or cause undefined behavior (?)
+// Per code comments, hardware waits for all 8 cores to signal
+```
+
+**Possible workaround (unverified):**
+```cpp
+volatile uint64_t* inv_reg = (volatile uint64_t*)L2_FULL_INVALIDATE_ADDR;
+*inv_reg = 0xFF;  // Signal all 8 cores at once (?)
+while (*inv_reg != 0);
+```
+
+---
+
+## Constants
+
+From `overlay_addresses.h` (verified):
+
+```cpp
+#define L2_CACHE_LINE_SIZE  64      // bytes
+#define L2_CACHE_NUM_SETS   32
+#define L2_CACHE_NUM_WAYS   8
+#define L2_CACHE_NUM_BANKS  8
+#define L2_CACHE_SIZE       131072  // 128 KB (8 * 8 * 32 * 64)
+```
+
+L1 D$ size: 4 KB — per SiFive X280 documentation (?)
+
+---
+
+## Test Coverage
+
+| Operation | Tested | Test Name |
+|-----------|--------|-----------|
+| `flush_l1_dcache(addr)` | Yes | `QuasarL1DCacheOps.FlushLine` |
+| `flush_l1_dcache(0)` | Yes | `QuasarL1DCacheOps.FlushFull` |
+| `invalidate_l1_dcache(addr)` | Yes | `QuasarL1DCacheOps.InvalidateLine` |
+| `invalidate_l1_dcache(0)` | Yes | `QuasarL1DCacheOps.InvalidateFull` |
+| `invalidate_l1_icache()` | No | — |
+| `flush_l2_cache_line(addr)` | Yes | `QuasarL2CacheFlush.FlushLine` |
+| `flush_l2_cache_range(...)` | Yes | `QuasarL2CacheFlush.FlushRange` |
+| `flush_l2_cache_full()` | Yes | `QuasarL2CacheFlush.FlushFull` |
+| `invalidate_l2_cache(hartid)` | No | — (requires multi-core coordination) |
+
+---
+
+## References
+
+- SiFive X280 Core Manual, sections 3.4.2, 6.1.1, 6.1.2 — referenced in code comments
+- Chipyard rocket-chip — referenced as basis for Quasar DM cores in code comments
+- `tt_metal/hw/inc/internal/tt-2xx/risc_common.h` — implementation
+- `tt_metal/hw/inc/internal/tt-2xx/quasar/overlay/overlay_addresses.h` — L2 constants

--- a/tests/tt_metal/tt_metal/data_movement/quasar_cache/test_quasar_cache.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/quasar_cache/test_quasar_cache.cpp
@@ -60,7 +60,7 @@ bool run_l2_flush_test(
         program,
         "tests/tt_metal/tt_metal/data_movement/quasar_cache/kernels/l2_flush_test.cpp",
         core,
-        experimental::quasar::QuasarDataMovementConfig{.num_processors_per_cluster = 1});
+        experimental::quasar::QuasarDataMovementConfig{.num_threads_per_cluster = 1});
 
     // Set runtime args
     SetRuntimeArgs(program, kernel, core, {config.base_addr, config.test_mode});
@@ -124,7 +124,7 @@ bool run_l1_dcache_test(
         program,
         "tests/tt_metal/tt_metal/data_movement/quasar_cache/kernels/l1_dcache_test.cpp",
         core,
-        experimental::quasar::QuasarDataMovementConfig{.num_processors_per_cluster = 1});
+        experimental::quasar::QuasarDataMovementConfig{.num_threads_per_cluster = 1});
 
     // Set runtime args
     SetRuntimeArgs(program, kernel, core, {config.base_addr, config.test_mode});

--- a/tests/tt_metal/tt_metal/data_movement/quasar_cache/test_quasar_cache.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/quasar_cache/test_quasar_cache.cpp
@@ -221,6 +221,23 @@ TEST_F(QuasarL2CacheFlush, InvalidateLine) {
     EXPECT_TRUE(unit_tests::dm::quasar_cache::run_l2_flush_test(devices_[0], config));
 }
 
+TEST_F(QuasarL2CacheFlush, InvalidateFreshRead) {
+    if (unit_tests::dm::quasar_cache::should_skip_test()) {
+        GTEST_SKIP() << "Test requires Quasar simulator";
+    }
+
+    // Test that invalidation causes fresh read from TL1:
+    // Kernel reads (caches), writes new value via uncached path, invalidates, host verifies new value
+    unit_tests::dm::quasar_cache::L2FlushTestConfig config = {
+        .base_addr = 100 * 1024,
+        .num_words = 16,
+        .value = 0xFE5A0000,
+        .test_mode = 4,  // invalidate fresh read
+        .expect_new_values = true  // After invalidation, new values written via uncached path should be visible
+    };
+    EXPECT_TRUE(unit_tests::dm::quasar_cache::run_l2_flush_test(devices_[0], config));
+}
+
 // =============================================================================
 // Test Suite: L1 Data Cache Operations
 // =============================================================================
@@ -285,6 +302,23 @@ TEST_F(QuasarL1DCacheOps, InvalidateFull) {
         .value = 0x44440000,
         .test_mode = 3,  // invalidate full
         .expect_new_values = false  // should see old values
+    };
+    EXPECT_TRUE(unit_tests::dm::quasar_cache::run_l1_dcache_test(devices_[0], config));
+}
+
+TEST_F(QuasarL1DCacheOps, InvalidateFreshRead) {
+    if (unit_tests::dm::quasar_cache::should_skip_test()) {
+        GTEST_SKIP() << "Test requires Quasar simulator";
+    }
+
+    // Test that invalidation causes fresh read from TL1:
+    // Kernel reads (caches), writes new value via uncached path, invalidates L1+L2, host verifies new value
+    unit_tests::dm::quasar_cache::L1DCacheTestConfig config = {
+        .base_addr = 100 * 1024,
+        .num_words = 16,
+        .value = 0xFE5B0000,
+        .test_mode = 4,  // invalidate fresh read
+        .expect_new_values = true  // After invalidation, new values written via uncached path should be visible
     };
     EXPECT_TRUE(unit_tests::dm::quasar_cache::run_l1_dcache_test(devices_[0], config));
 }

--- a/tests/tt_metal/tt_metal/data_movement/quasar_cache/test_quasar_cache.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/quasar_cache/test_quasar_cache.cpp
@@ -25,10 +25,7 @@ bool should_skip_test() {
         return true;
     }
     char* env_var = std::getenv("TT_METAL_SIMULATOR");
-    if (env_var == nullptr) {
-        return true;
-    }
-    return false;
+    return env_var == nullptr;
 }
 
 // =============================================================================
@@ -39,7 +36,8 @@ struct L2FlushTestConfig {
     uint32_t base_addr;
     uint32_t num_words;
     uint32_t value;
-    uint32_t test_mode;  // 0=line, 1=range, 2=full
+    uint32_t test_mode;  // 0=flush_line, 1=flush_range, 2=flush_full, 3=invalidate_line
+    bool expect_new_values = true;  // true for flush tests, false for invalidate tests
 };
 
 bool run_l2_flush_test(
@@ -49,8 +47,10 @@ bool run_l2_flush_test(
     IDevice* device = mesh_device->get_devices()[0];
     constexpr CoreCoord core = {0, 0};
 
-    // Initialize memory to zero
-    std::vector<uint32_t> init_data(config.num_words, 0);
+    // For invalidate tests, pre-populate with known "old" values
+    // that should persist after invalidation (since invalidate doesn't write back)
+    uint32_t old_value = 0xDEADBEEF;
+    std::vector<uint32_t> init_data(config.num_words, config.expect_new_values ? 0 : old_value);
     tt_metal::detail::WriteToDeviceL1(device, core, config.base_addr, init_data);
 
     // Create program with Quasar DM kernel
@@ -81,7 +81,7 @@ bool run_l2_flush_test(
 
     bool pass = true;
     for (uint32_t i = 0; i < config.num_words; i++) {
-        uint32_t expected = config.value + i;
+        uint32_t expected = config.expect_new_values ? (config.value + i) : old_value;
         if (output_data[i] != expected) {
             log_error(tt::LogTest, "Mismatch at index {}: expected 0x{:08x}, got 0x{:08x}",
                       i, expected, output_data[i]);
@@ -202,6 +202,21 @@ TEST_F(QuasarL2CacheFlush, FlushFull) {
         .num_words = 64,
         .value = 0x55550000,
         .test_mode = 2  // full flush
+    };
+    EXPECT_TRUE(unit_tests::dm::quasar_cache::run_l2_flush_test(devices_[0], config));
+}
+
+TEST_F(QuasarL2CacheFlush, InvalidateLine) {
+    if (unit_tests::dm::quasar_cache::should_skip_test()) {
+        GTEST_SKIP() << "Test requires Quasar simulator";
+    }
+
+    unit_tests::dm::quasar_cache::L2FlushTestConfig config = {
+        .base_addr = 100 * 1024,
+        .num_words = 16,
+        .value = 0x99990000,
+        .test_mode = 3,  // invalidate line
+        .expect_new_values = false  // Invalidate doesn't write back, so old values should remain
     };
     EXPECT_TRUE(unit_tests::dm::quasar_cache::run_l2_flush_test(devices_[0], config));
 }

--- a/tests/tt_metal/tt_metal/data_movement/quasar_cache/test_quasar_cache.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/quasar_cache/test_quasar_cache.cpp
@@ -1,0 +1,277 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Tests for Quasar DM core cache management functions.
+// These tests verify L1 D$ and L2 cache flush/invalidate operations.
+
+#include <tt-logger/tt-logger.hpp>
+#include "device_fixture.hpp"
+#include "dm_common.hpp"
+#include <tt-metalium/distributed.hpp>
+#include <tt-metalium/experimental/host_api.hpp>
+
+namespace tt::tt_metal {
+
+using namespace std;
+using namespace tt::test_utils;
+
+namespace unit_tests::dm::quasar_cache {
+
+// Skip test if not running on Quasar with simulator
+bool should_skip_test() {
+    const auto arch = tt::get_arch_from_string(tt::test_utils::get_umd_arch_name());
+    if (arch != tt::ARCH::QUASAR) {
+        return true;
+    }
+    char* env_var = std::getenv("TT_METAL_SIMULATOR");
+    if (env_var == nullptr) {
+        return true;
+    }
+    return false;
+}
+
+// =============================================================================
+// L2 Cache Flush Tests
+// =============================================================================
+
+struct L2FlushTestConfig {
+    uint32_t base_addr;
+    uint32_t num_words;
+    uint32_t value;
+    uint32_t test_mode;  // 0=line, 1=range, 2=full
+};
+
+bool run_l2_flush_test(
+    const std::shared_ptr<distributed::MeshDevice>& mesh_device,
+    const L2FlushTestConfig& config) {
+
+    IDevice* device = mesh_device->get_devices()[0];
+    constexpr CoreCoord core = {0, 0};
+
+    // Initialize memory to zero
+    std::vector<uint32_t> init_data(config.num_words, 0);
+    tt_metal::detail::WriteToDeviceL1(device, core, config.base_addr, init_data);
+
+    // Create program with Quasar DM kernel
+    Program program = CreateProgram();
+
+    KernelHandle kernel = experimental::quasar::CreateKernel(
+        program,
+        "tests/tt_metal/tt_metal/data_movement/quasar_cache/kernels/l2_flush_test.cpp",
+        core,
+        experimental::quasar::QuasarDataMovementConfig{.num_processors_per_cluster = 1});
+
+    // Set runtime args
+    SetRuntimeArgs(program, kernel, core, {config.base_addr, config.test_mode});
+    SetCommonRuntimeArgs(program, kernel, {config.value, config.num_words});
+
+    // Execute
+    distributed::MeshWorkload workload;
+    distributed::MeshCoordinateRange device_range(mesh_device->shape());
+    workload.add_program(device_range, std::move(program));
+
+    distributed::MeshCommandQueue& cq = mesh_device->mesh_command_queue();
+    distributed::EnqueueMeshWorkload(cq, workload, true);
+
+    // Read back and verify
+    std::vector<uint32_t> output_data;
+    tt_metal::detail::ReadFromDeviceL1(
+        device, core, config.base_addr, config.num_words * sizeof(uint32_t), output_data);
+
+    bool pass = true;
+    for (uint32_t i = 0; i < config.num_words; i++) {
+        uint32_t expected = config.value + i;
+        if (output_data[i] != expected) {
+            log_error(tt::LogTest, "Mismatch at index {}: expected 0x{:08x}, got 0x{:08x}",
+                      i, expected, output_data[i]);
+            pass = false;
+        }
+    }
+
+    return pass;
+}
+
+// =============================================================================
+// L1 D$ Tests
+// =============================================================================
+
+struct L1DCacheTestConfig {
+    uint32_t base_addr;
+    uint32_t num_words;
+    uint32_t value;
+    uint32_t test_mode;  // 0=flush_line, 1=flush_full, 2=invalidate_line, 3=invalidate_full
+    bool expect_new_values;  // true for flush tests, false for invalidate tests
+};
+
+bool run_l1_dcache_test(
+    const std::shared_ptr<distributed::MeshDevice>& mesh_device,
+    const L1DCacheTestConfig& config) {
+
+    IDevice* device = mesh_device->get_devices()[0];
+    constexpr CoreCoord core = {0, 0};
+
+    // For invalidate tests, we need to pre-populate with known "old" values
+    // that should persist after invalidation (since invalidate doesn't write back)
+    uint32_t old_value = 0xDEADBEEF;
+    std::vector<uint32_t> init_data(config.num_words, old_value);
+    tt_metal::detail::WriteToDeviceL1(device, core, config.base_addr, init_data);
+
+    // Create program with Quasar DM kernel
+    Program program = CreateProgram();
+
+    KernelHandle kernel = experimental::quasar::CreateKernel(
+        program,
+        "tests/tt_metal/tt_metal/data_movement/quasar_cache/kernels/l1_dcache_test.cpp",
+        core,
+        experimental::quasar::QuasarDataMovementConfig{.num_processors_per_cluster = 1});
+
+    // Set runtime args
+    SetRuntimeArgs(program, kernel, core, {config.base_addr, config.test_mode});
+    SetCommonRuntimeArgs(program, kernel, {config.value, config.num_words});
+
+    // Execute
+    distributed::MeshWorkload workload;
+    distributed::MeshCoordinateRange device_range(mesh_device->shape());
+    workload.add_program(device_range, std::move(program));
+
+    distributed::MeshCommandQueue& cq = mesh_device->mesh_command_queue();
+    distributed::EnqueueMeshWorkload(cq, workload, true);
+
+    // Read back and verify
+    std::vector<uint32_t> output_data;
+    tt_metal::detail::ReadFromDeviceL1(
+        device, core, config.base_addr, config.num_words * sizeof(uint32_t), output_data);
+
+    bool pass = true;
+    for (uint32_t i = 0; i < config.num_words; i++) {
+        uint32_t expected = config.expect_new_values ? (config.value + i) : old_value;
+        if (output_data[i] != expected) {
+            log_error(tt::LogTest, "Mismatch at index {}: expected 0x{:08x}, got 0x{:08x}",
+                      i, expected, output_data[i]);
+            pass = false;
+        }
+    }
+
+    return pass;
+}
+
+}  // namespace unit_tests::dm::quasar_cache
+
+// =============================================================================
+// Test Suite: L2 Cache Flush Operations
+// =============================================================================
+
+class QuasarL2CacheFlush : public MeshDeviceSingleCardFixture {};
+
+TEST_F(QuasarL2CacheFlush, FlushLine) {
+    if (unit_tests::dm::quasar_cache::should_skip_test()) {
+        GTEST_SKIP() << "Test requires Quasar simulator";
+    }
+
+    unit_tests::dm::quasar_cache::L2FlushTestConfig config = {
+        .base_addr = 100 * 1024,
+        .num_words = 16,
+        .value = 0x12340000,
+        .test_mode = 0  // line flush
+    };
+    EXPECT_TRUE(unit_tests::dm::quasar_cache::run_l2_flush_test(devices_[0], config));
+}
+
+TEST_F(QuasarL2CacheFlush, FlushRange) {
+    if (unit_tests::dm::quasar_cache::should_skip_test()) {
+        GTEST_SKIP() << "Test requires Quasar simulator";
+    }
+
+    unit_tests::dm::quasar_cache::L2FlushTestConfig config = {
+        .base_addr = 100 * 1024,
+        .num_words = 256,  // Multiple cache lines
+        .value = 0xABCD0000,
+        .test_mode = 1  // range flush
+    };
+    EXPECT_TRUE(unit_tests::dm::quasar_cache::run_l2_flush_test(devices_[0], config));
+}
+
+TEST_F(QuasarL2CacheFlush, FlushFull) {
+    if (unit_tests::dm::quasar_cache::should_skip_test()) {
+        GTEST_SKIP() << "Test requires Quasar simulator";
+    }
+
+    unit_tests::dm::quasar_cache::L2FlushTestConfig config = {
+        .base_addr = 100 * 1024,
+        .num_words = 64,
+        .value = 0x55550000,
+        .test_mode = 2  // full flush
+    };
+    EXPECT_TRUE(unit_tests::dm::quasar_cache::run_l2_flush_test(devices_[0], config));
+}
+
+// =============================================================================
+// Test Suite: L1 Data Cache Operations
+// =============================================================================
+
+class QuasarL1DCacheOps : public MeshDeviceSingleCardFixture {};
+
+TEST_F(QuasarL1DCacheOps, FlushLine) {
+    if (unit_tests::dm::quasar_cache::should_skip_test()) {
+        GTEST_SKIP() << "Test requires Quasar simulator";
+    }
+
+    unit_tests::dm::quasar_cache::L1DCacheTestConfig config = {
+        .base_addr = 100 * 1024,
+        .num_words = 16,
+        .value = 0x11110000,
+        .test_mode = 0,  // flush line
+        .expect_new_values = true
+    };
+    EXPECT_TRUE(unit_tests::dm::quasar_cache::run_l1_dcache_test(devices_[0], config));
+}
+
+TEST_F(QuasarL1DCacheOps, FlushFull) {
+    if (unit_tests::dm::quasar_cache::should_skip_test()) {
+        GTEST_SKIP() << "Test requires Quasar simulator";
+    }
+
+    unit_tests::dm::quasar_cache::L1DCacheTestConfig config = {
+        .base_addr = 100 * 1024,
+        .num_words = 16,
+        .value = 0x22220000,
+        .test_mode = 1,  // flush full
+        .expect_new_values = true
+    };
+    EXPECT_TRUE(unit_tests::dm::quasar_cache::run_l1_dcache_test(devices_[0], config));
+}
+
+TEST_F(QuasarL1DCacheOps, InvalidateLine) {
+    if (unit_tests::dm::quasar_cache::should_skip_test()) {
+        GTEST_SKIP() << "Test requires Quasar simulator";
+    }
+
+    // Invalidate should NOT write back - old values should persist
+    unit_tests::dm::quasar_cache::L1DCacheTestConfig config = {
+        .base_addr = 100 * 1024,
+        .num_words = 16,
+        .value = 0x33330000,
+        .test_mode = 2,  // invalidate line
+        .expect_new_values = false  // should see old values
+    };
+    EXPECT_TRUE(unit_tests::dm::quasar_cache::run_l1_dcache_test(devices_[0], config));
+}
+
+TEST_F(QuasarL1DCacheOps, InvalidateFull) {
+    if (unit_tests::dm::quasar_cache::should_skip_test()) {
+        GTEST_SKIP() << "Test requires Quasar simulator";
+    }
+
+    // Invalidate should NOT write back - old values should persist
+    unit_tests::dm::quasar_cache::L1DCacheTestConfig config = {
+        .base_addr = 100 * 1024,
+        .num_words = 16,
+        .value = 0x44440000,
+        .test_mode = 3,  // invalidate full
+        .expect_new_values = false  // should see old values
+    };
+    EXPECT_TRUE(unit_tests::dm::quasar_cache::run_l1_dcache_test(devices_[0], config));
+}
+
+}  // namespace tt::tt_metal

--- a/tests/tt_metal/tt_metal/data_movement/quasar_cache/test_quasar_cache.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/quasar_cache/test_quasar_cache.cpp
@@ -159,12 +159,12 @@ bool run_l1_dcache_test(
 }  // namespace unit_tests::dm::quasar_cache
 
 // =============================================================================
-// Test Suite: L2 Cache Flush Operations
+// Test Suite: L2 Cache Operations
 // =============================================================================
 
-class QuasarL2CacheFlush : public MeshDeviceSingleCardFixture {};
+class QuasarL2CacheOps : public MeshDeviceSingleCardFixture {};
 
-TEST_F(QuasarL2CacheFlush, FlushLine) {
+TEST_F(QuasarL2CacheOps, FlushLine) {
     if (unit_tests::dm::quasar_cache::should_skip_test()) {
         GTEST_SKIP() << "Test requires Quasar simulator";
     }
@@ -178,7 +178,7 @@ TEST_F(QuasarL2CacheFlush, FlushLine) {
     EXPECT_TRUE(unit_tests::dm::quasar_cache::run_l2_flush_test(devices_[0], config));
 }
 
-TEST_F(QuasarL2CacheFlush, FlushRange) {
+TEST_F(QuasarL2CacheOps, FlushRange) {
     if (unit_tests::dm::quasar_cache::should_skip_test()) {
         GTEST_SKIP() << "Test requires Quasar simulator";
     }
@@ -192,7 +192,7 @@ TEST_F(QuasarL2CacheFlush, FlushRange) {
     EXPECT_TRUE(unit_tests::dm::quasar_cache::run_l2_flush_test(devices_[0], config));
 }
 
-TEST_F(QuasarL2CacheFlush, FlushFull) {
+TEST_F(QuasarL2CacheOps, FlushFull) {
     if (unit_tests::dm::quasar_cache::should_skip_test()) {
         GTEST_SKIP() << "Test requires Quasar simulator";
     }
@@ -206,7 +206,7 @@ TEST_F(QuasarL2CacheFlush, FlushFull) {
     EXPECT_TRUE(unit_tests::dm::quasar_cache::run_l2_flush_test(devices_[0], config));
 }
 
-TEST_F(QuasarL2CacheFlush, InvalidateLine) {
+TEST_F(QuasarL2CacheOps, InvalidateLine) {
     if (unit_tests::dm::quasar_cache::should_skip_test()) {
         GTEST_SKIP() << "Test requires Quasar simulator";
     }
@@ -221,7 +221,7 @@ TEST_F(QuasarL2CacheFlush, InvalidateLine) {
     EXPECT_TRUE(unit_tests::dm::quasar_cache::run_l2_flush_test(devices_[0], config));
 }
 
-TEST_F(QuasarL2CacheFlush, InvalidateFreshRead) {
+TEST_F(QuasarL2CacheOps, InvalidateFreshRead) {
     if (unit_tests::dm::quasar_cache::should_skip_test()) {
         GTEST_SKIP() << "Test requires Quasar simulator";
     }

--- a/tests/tt_metal/tt_metal/data_movement/quasar_cache/test_quasar_cache.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/quasar_cache/test_quasar_cache.cpp
@@ -185,7 +185,7 @@ TEST_F(QuasarL2CacheFlush, FlushRange) {
 
     unit_tests::dm::quasar_cache::L2FlushTestConfig config = {
         .base_addr = 100 * 1024,
-        .num_words = 256,  // Multiple cache lines
+        .num_words = 64,  // Multiple cache lines (4 lines worth)
         .value = 0xABCD0000,
         .test_mode = 1  // range flush
     };

--- a/tests/tt_metal/tt_metal/data_movement/sources.cmake
+++ b/tests/tt_metal/tt_metal/data_movement/sources.cmake
@@ -30,4 +30,5 @@ set(UNIT_TESTS_DATA_MOVEMENT_SRC
     noc_api_latency/test_noc_api_latency.cpp
     noc_estimator_tests/test_noc_estimator.cpp
     dram_neighbour/test_dram_neighbour.cpp
+    quasar_cache/test_quasar_cache.cpp
 )

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/simple_l1_write.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/simple_l1_write.cpp
@@ -4,12 +4,15 @@
 
 #include "api/dataflow/dataflow_api.h"
 #include "api/debug/dprint.h"
+#include "risc_common.h"
 
 void kernel_main() {
     uintptr_t dst_addr = get_arg_val<uint32_t>(0);
     uint32_t value = get_common_arg_val<uint32_t>(0);
-    uint32_t buffer_size = get_named_ct_arg("buffer_size");
-    DPRINT << "buffer_size: " << buffer_size << ENDL();
-    *((uint32_t*)(dst_addr + MEM_L1_UNCACHED_BASE)) =
-        value;  // use cache write-around for now, in the future use cache flush
+
+    // Write to cacheable L1 address
+    *((volatile uint32_t*)dst_addr) = value;
+
+    // Flush the cache line to TL1 (node memory) so host can read it
+    flush_l2_cache_line(dst_addr);
 }

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/simple_l1_write.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/simple_l1_write.cpp
@@ -4,6 +4,7 @@
 
 #include "api/dataflow/dataflow_api.h"
 #include "api/debug/dprint.h"
+#include "experimental/core_local_mem.h"
 #include "risc_common.h"
 
 void kernel_main() {
@@ -11,7 +12,8 @@ void kernel_main() {
     uint32_t value = get_common_arg_val<uint32_t>(0);
 
     // Write to cacheable L1 address
-    *((volatile uint32_t*)dst_addr) = value;
+    experimental::CoreLocalMem<uint32_t> buffer(dst_addr);
+    buffer[0] = value;
 
     // Flush the cache line to TL1 (node memory) so host can read it
     flush_l2_cache_line(dst_addr);

--- a/tt_metal/hw/inc/internal/tt-2xx/quasar/overlay/overlay_addresses.h
+++ b/tt_metal/hw/inc/internal/tt-2xx/quasar/overlay/overlay_addresses.h
@@ -14,20 +14,33 @@
 #define MEM_PORT_NONCACHEABLE_BASE_ADDR (uint64_t)MEMORY_PORT_NONCACHEABLE_MEM_PORT_MEM_BASE_ADDR
 #define PERIPH_PORT_BASE_ADDR (uint64_t)TT_CLUSTER_CTRL_REG_MAP_BASE_ADDR
 
-// L2 Cache Controller Flush Registers
+// =============================================================================
+// L2 Cache Controller Registers
+// =============================================================================
 //
-// The two flush registers use DIFFERENT address encodings:
-//   - FLUSH64 (0x04010200): Takes the raw byte address
+// L2 is a 128KB inclusive write-back cache shared by 8 DM cores.
+// Config register (0x04010000) encodes: 8 banks x 8 ways x 32 sets x 64B = 128KB
+//
+// Flush registers (DIFFERENT address encodings):
+//   - FLUSH64 (0x04010200): Takes raw byte address
 //   - FLUSH32 (0x04010240): Takes (byte_address >> 4)
 //
-// Example: To flush cache line containing address 0x19000:
-//   FLUSH64: write 0x19000
-//   FLUSH32: write 0x1900  (0x19000 >> 4)
+// Full invalidation register (0x04010300):
+//   - Each core writes its bit (1 << hartid) to signal ready
+//   - HW starts wipe when all 8 bits are set
+//   - HW clears register to 0 when complete
+//   - Cores poll until they read 0, then invalidate their own L1 caches
 //
 #define L2_FLUSH_ADDR (uint64_t)TT_CACHE_CONTROLLER_FLUSH64_REG_ADDR
 #define L2_FLUSH32_ADDR (uint64_t)TT_CACHE_CONTROLLER_FLUSH32_REG_ADDR  // NOTE: takes (addr >> 4)
-#define L2_INVALIDATE_ADDR (uint64_t)TT_CACHE_CONTROLLER_INVALIDATE64_REG_ADDR  // NOT implemented in HW
-#define L2_FULL_INVALIDATE_ADDR (uint64_t)TT_CACHE_CONTROLLER_FULLINVALIDATE_REG_ADDR  // NOT implemented in HW
+#define L2_FULL_INVALIDATE_ADDR (uint64_t)TT_CACHE_CONTROLLER_FULLINVALIDATE_REG_ADDR
+
+// L2 cache geometry (derived from TT_CACHE_CONTROLLER_CONFIGURATION_REG_DEFAULT = 0x06050808)
+#define L2_CACHE_LINE_SIZE 64                               // 2^6 bytes (LGBLOCKBYTES=6)
+#define L2_CACHE_NUM_SETS 32                                // 2^5 sets (LGSETS=5)
+#define L2_CACHE_NUM_WAYS 8                                 // WAYS field
+#define L2_CACHE_NUM_BANKS 8                                // BANKS field
+#define L2_CACHE_SIZE (L2_CACHE_NUM_BANKS * L2_CACHE_NUM_WAYS * L2_CACHE_NUM_SETS * L2_CACHE_LINE_SIZE)  // 128KB
 
 #define WRITE_REG32(addr, val) ((*((volatile uint32_t*)(uintptr_t)(addr))) = (val))
 #define READ_REG32(addr) (*((volatile uint32_t*)(uintptr_t)(addr)))

--- a/tt_metal/hw/inc/internal/tt-2xx/quasar/overlay/overlay_addresses.h
+++ b/tt_metal/hw/inc/internal/tt-2xx/quasar/overlay/overlay_addresses.h
@@ -13,9 +13,21 @@
 #define MEM_PORT_CACHEABLE_BASE_ADDR (uint64_t)MEMORY_PORT_CACHEABLE_MEM_PORT_MEM_BASE_ADDR
 #define MEM_PORT_NONCACHEABLE_BASE_ADDR (uint64_t)MEMORY_PORT_NONCACHEABLE_MEM_PORT_MEM_BASE_ADDR
 #define PERIPH_PORT_BASE_ADDR (uint64_t)TT_CLUSTER_CTRL_REG_MAP_BASE_ADDR
+
+// L2 Cache Controller Flush Registers
+//
+// The two flush registers use DIFFERENT address encodings:
+//   - FLUSH64 (0x04010200): Takes the raw byte address
+//   - FLUSH32 (0x04010240): Takes (byte_address >> 4)
+//
+// Example: To flush cache line containing address 0x19000:
+//   FLUSH64: write 0x19000
+//   FLUSH32: write 0x1900  (0x19000 >> 4)
+//
 #define L2_FLUSH_ADDR (uint64_t)TT_CACHE_CONTROLLER_FLUSH64_REG_ADDR
-#define L2_INVALIDATE_ADDR (uint64_t)TT_CACHE_CONTROLLER_INVALIDATE64_REG_ADDR
-#define L2_FULL_INVALIDATE_ADDR (uint64_t)TT_CACHE_CONTROLLER_FULLINVALIDATE_REG_ADDR
+#define L2_FLUSH32_ADDR (uint64_t)TT_CACHE_CONTROLLER_FLUSH32_REG_ADDR  // NOTE: takes (addr >> 4)
+#define L2_INVALIDATE_ADDR (uint64_t)TT_CACHE_CONTROLLER_INVALIDATE64_REG_ADDR  // NOT implemented in HW
+#define L2_FULL_INVALIDATE_ADDR (uint64_t)TT_CACHE_CONTROLLER_FULLINVALIDATE_REG_ADDR  // NOT implemented in HW
 
 #define WRITE_REG32(addr, val) ((*((volatile uint32_t*)(uintptr_t)(addr))) = (val))
 #define READ_REG32(addr) (*((volatile uint32_t*)(uintptr_t)(addr)))

--- a/tt_metal/hw/inc/internal/tt-2xx/quasar/overlay/overlay_addresses.h
+++ b/tt_metal/hw/inc/internal/tt-2xx/quasar/overlay/overlay_addresses.h
@@ -18,8 +18,7 @@
 // L2 Cache Controller Registers
 // =============================================================================
 //
-// L2 is a 128KB inclusive write-back cache shared by 8 DM cores.
-// Config register (0x04010000) encodes: 8 banks x 8 ways x 32 sets x 64B = 128KB
+// L2 is a 128KB, 4-way associative, write-back cache shared between 8 DM cores.
 //
 // Flush registers (DIFFERENT address encodings):
 //   - FLUSH64 (0x04010200): Takes raw byte address
@@ -27,20 +26,18 @@
 //
 // Full invalidation register (0x04010300):
 //   - Each core writes its bit (1 << hartid) to signal ready
-//   - HW starts wipe when all 8 bits are set
+//   - HW starts wipe when all core bits are set
 //   - HW clears register to 0 when complete
 //   - Cores poll until they read 0, then invalidate their own L1 caches
 //
 #define L2_FLUSH_ADDR (uint64_t)TT_CACHE_CONTROLLER_FLUSH64_REG_ADDR
 #define L2_FLUSH32_ADDR (uint64_t)TT_CACHE_CONTROLLER_FLUSH32_REG_ADDR  // NOTE: takes (addr >> 4)
+#define L2_INVALIDATE_ADDR (uint64_t)TT_CACHE_CONTROLLER_INVALIDATE64_REG_ADDR
 #define L2_FULL_INVALIDATE_ADDR (uint64_t)TT_CACHE_CONTROLLER_FULLINVALIDATE_REG_ADDR
 
-// L2 cache geometry (derived from TT_CACHE_CONTROLLER_CONFIGURATION_REG_DEFAULT = 0x06050808)
-#define L2_CACHE_LINE_SIZE 64                               // 2^6 bytes (LGBLOCKBYTES=6)
-#define L2_CACHE_NUM_SETS 32                                // 2^5 sets (LGSETS=5)
-#define L2_CACHE_NUM_WAYS 8                                 // WAYS field
-#define L2_CACHE_NUM_BANKS 8                                // BANKS field
-#define L2_CACHE_SIZE (L2_CACHE_NUM_BANKS * L2_CACHE_NUM_WAYS * L2_CACHE_NUM_SETS * L2_CACHE_LINE_SIZE)  // 128KB
+// L2 cache geometry: 128KB, 4-way associative, 64B lines
+#define L2_CACHE_LINE_SIZE 64
+#define L2_CACHE_SIZE (128 * 1024)
 
 #define WRITE_REG32(addr, val) ((*((volatile uint32_t*)(uintptr_t)(addr))) = (val))
 #define READ_REG32(addr) (*((volatile uint32_t*)(uintptr_t)(addr)))

--- a/tt_metal/hw/inc/internal/tt-2xx/risc_common.h
+++ b/tt_metal/hw/inc/internal/tt-2xx/risc_common.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/tt_metal/hw/inc/internal/tt-2xx/risc_common.h
+++ b/tt_metal/hw/inc/internal/tt-2xx/risc_common.h
@@ -162,7 +162,7 @@ inline __attribute__((always_inline)) void invalidate_l1_cache() {
 }
 #endif  // !ARCH_QUASAR
 
-#if defined(ARCH_QUASAR)
+#if defined(ARCH_QUASAR) && defined(COMPILE_FOR_DM)
 // =============================================================================
 // Quasar DM Core Cache Management
 // =============================================================================
@@ -178,7 +178,7 @@ inline __attribute__((always_inline)) void invalidate_l1_cache() {
 // Key points:
 //   - Writes go through L1 D$ and L2 before reaching TL1
 //   - Flush is required for data to be visible to other agents
-//   - L1 D$ is inclusive of L2 (flushing L1 writes back to L2, not TL1)
+//   - L1 and L2 are coherent: L2 flush probes L1 D$ for dirty data before writing to TL1
 //
 // References:
 //   - SiFive X280 Core Manual, sections 3.4.2, 6.1.1, 6.1.2 (CFLUSH.D.L1, CDISCARD.D.L1)
@@ -234,7 +234,8 @@ inline __attribute__((always_inline)) void invalidate_l1_icache() {
 // See overlay_addresses.h for register definitions and geometry.
 
 // Flush a single 64B cache line from L2 to TL1 (node memory).
-inline __attribute__((always_inline)) void flush_l2_cache_line(uint32_t addr) {
+// Probes L1 D$ for dirty data before flushing - no need to flush L1 first.
+inline __attribute__((always_inline)) void flush_l2_cache_line(uintptr_t addr) {
     __asm__ __volatile__("fence" ::: "memory");
     volatile uint64_t* flush_reg = (volatile uint64_t*)L2_FLUSH_ADDR;
     *flush_reg = (uint64_t)addr;
@@ -243,7 +244,7 @@ inline __attribute__((always_inline)) void flush_l2_cache_line(uint32_t addr) {
 
 // Invalidate a single 64B cache line from L2 without writeback.
 // Discards dirty data - use only when data is known to be stale.
-inline __attribute__((always_inline)) void invalidate_l2_cache_line(uint32_t addr) {
+inline __attribute__((always_inline)) void invalidate_l2_cache_line(uintptr_t addr) {
     __asm__ __volatile__("fence" ::: "memory");
     volatile uint64_t* inv_reg = (volatile uint64_t*)L2_INVALIDATE_ADDR;
     *inv_reg = (uint64_t)addr;
@@ -252,11 +253,11 @@ inline __attribute__((always_inline)) void invalidate_l2_cache_line(uint32_t add
 
 // Flush a range of addresses from L2 to TL1.
 // Flushes all cache lines covering [start_addr, start_addr + size).
-inline __attribute__((always_inline)) void flush_l2_cache_range(uint32_t start_addr, uint32_t size) {
-    uint32_t aligned_start = start_addr & ~(uint32_t)63;  // align to 64B
-    uint32_t end_addr = start_addr + size;
+inline __attribute__((always_inline)) void flush_l2_cache_range(uintptr_t start_addr, size_t size) {
+    uintptr_t aligned_start = start_addr & ~(uintptr_t)63;  // align to 64B
+    uintptr_t end_addr = start_addr + size;
 
-    for (uint32_t addr = aligned_start; addr < end_addr; addr += 64) {
+    for (uintptr_t addr = aligned_start; addr < end_addr; addr += 64) {
         flush_l2_cache_line(addr);
     }
 }
@@ -289,8 +290,9 @@ inline void invalidate_l2_cache(uint32_t hartid) {
 
 // Invalidate entire L1 cache (D$ + I$) on this core.
 // Provided for API compatibility with previous architectures.
+// Uses flush (not invalidate) for D$ since older architectures had write-through caches.
 inline void invalidate_l1_cache() {
-    invalidate_l1_dcache(0);
+    flush_l1_dcache(0);
     invalidate_l1_icache();
 }
 
@@ -305,7 +307,14 @@ inline void invalidate_cache_all(uint32_t hartid) {
     invalidate_l1_cache();
 }
 
-#endif  // ARCH_QUASAR
+#endif  // ARCH_QUASAR && COMPILE_FOR_DM
+
+// Fallback for Quasar non-DM cores (TRISC) - no cache management needed
+#if defined(ARCH_QUASAR) && !defined(COMPILE_FOR_DM)
+inline __attribute__((always_inline)) void invalidate_l1_cache() {
+    // No-op for non-DM cores on Quasar
+}
+#endif  // ARCH_QUASAR && !COMPILE_FOR_DM
 
 template <bool enable = true>
 inline __attribute__((always_inline)) void set_l1_data_cache() {

--- a/tt_metal/hw/inc/internal/tt-2xx/risc_common.h
+++ b/tt_metal/hw/inc/internal/tt-2xx/risc_common.h
@@ -161,46 +161,150 @@ inline __attribute__((always_inline)) void invalidate_l1_cache() {
 }
 
 #if defined(ARCH_QUASAR)
-// Quasar L2 Cache Management
-// DM cores have an L2 cache between the core and TL1 (node memory).
-// Writes to cacheable addresses (< MEM_L1_SIZE) go through L2.
-// Flush is required for data to be visible to other agents (host, other cores).
+// =============================================================================
+// Quasar DM Core Cache Management
+// =============================================================================
 //
-// Cache line size: 64 bytes
-// Flush registers:
-//   FLUSH64 (0x04010200): Takes raw byte address
-//   FLUSH32 (0x04010240): Takes (address >> 4)
+// Cache hierarchy (per DM core):
+//   L1 D$ : 4KB write-back, 64B lines, private per core
+//   L1 I$ : instruction cache, private per core
+//   L2    : 128KB write-back, 64B lines, inclusive, shared by 8 DM cores
+//   TL1   : Tensix L1 (node memory), visible to host and other cores
 //
-// Note: L2 invalidation is NOT supported per HW.
+// Data path: Core -> L1 D$ -> L2 -> TL1
+//
+// Key points:
+//   - Writes go through L1 D$ and L2 before reaching TL1
+//   - Flush is required for data to be visible to other agents
+//   - L1 D$ is inclusive of L2 (flushing L1 writes back to L2, not TL1)
+//
+// References:
+//   - SiFive X280 Core Manual, sections 3.4.2, 6.1.1, 6.1.2 (CFLUSH.D.L1, CDISCARD.D.L1)
+//   - Chipyard rocket-chip (basis for Quasar DM cores)
+//   - overlay/software/metal_lib/freedom-metal/src/cache.c (reference implementation)
+//
+// =============================================================================
 
 #include "internal/tt-2xx/quasar/overlay/overlay_addresses.h"
 
-// Flush a single cache line from L2 to TL1 (node memory).
-// Includes fence instructions for proper memory ordering.
+// -----------------------------------------------------------------------------
+// L1 Data Cache Operations
+// -----------------------------------------------------------------------------
+// Uses custom RISC-V instructions from SiFive/rocket-chip.
+// Instruction encoding: I-type with opcode=0x73, funct3=0, rd=x0
+//   CFLUSH.D.L1:   simm12 = -0x40 (0xFC0), flushes line to L2 + invalidates
+//   CDISCARD.D.L1: simm12 = -0x3E (0xFC2), invalidates line without writeback
+// If rs1=x0, operates on entire 4KB L1 D$.
+
+// Flush L1 D$ line (or entire cache if addr=0) to L2.
+// Writes back dirty data to L2 and invalidates the line.
+inline __attribute__((always_inline)) void flush_l1_dcache(uintptr_t addr) {
+    if (addr) {
+        // .insn i opcode, funct3, rd, rs1, simm12
+        __asm__ __volatile__(".insn i 0x73, 0, x0, %0, -0x40" :: "r"(addr) : "memory");
+    } else {
+        // rs1=x0: flush entire L1 D$ (encoded as .word for x0 case)
+        __asm__ __volatile__(".word 0xfc000073" ::: "memory");
+    }
+    __asm__ __volatile__("fence" ::: "memory");
+}
+
+// Invalidate L1 D$ line (or entire cache if addr=0) without writeback.
+// Discards dirty data - use only when data is known to be stale.
+inline __attribute__((always_inline)) void invalidate_l1_dcache(uintptr_t addr) {
+    if (addr) {
+        __asm__ __volatile__(".insn i 0x73, 0, x0, %0, -0x3E" :: "r"(addr) : "memory");
+    } else {
+        // rs1=x0: invalidate entire L1 D$
+        __asm__ __volatile__(".word 0xfc200073" ::: "memory");
+    }
+    __asm__ __volatile__("fence" ::: "memory");
+}
+
+// -----------------------------------------------------------------------------
+// L1 Instruction Cache Operations
+// -----------------------------------------------------------------------------
+
+// Invalidate entire L1 I$ using FENCE.I instruction.
+// Required after modifying instruction memory before jumping to new code.
+inline __attribute__((always_inline)) void invalidate_l1_icache() {
+    __asm__ __volatile__("fence.i" ::: "memory");
+}
+
+// -----------------------------------------------------------------------------
+// L2 Cache Operations
+// -----------------------------------------------------------------------------
+// L2 is controlled via memory-mapped registers in the cache controller.
+// See overlay_addresses.h for register definitions and geometry.
+
+// Flush a single 64B cache line from L2 to TL1 (node memory).
 inline __attribute__((always_inline)) void flush_l2_cache_line(uint32_t addr) {
-    asm volatile("fence" ::: "memory");
+    __asm__ __volatile__("fence" ::: "memory");
     volatile uint64_t* flush_reg = (volatile uint64_t*)L2_FLUSH_ADDR;
     *flush_reg = (uint64_t)addr;
-    asm volatile("fence" ::: "memory");
+    __asm__ __volatile__("fence" ::: "memory");
 }
 
 // Flush a range of addresses from L2 to TL1.
 // Flushes all cache lines covering [start_addr, start_addr + size).
 inline __attribute__((always_inline)) void flush_l2_cache_range(uint32_t start_addr, uint32_t size) {
-    constexpr uint32_t CACHE_LINE_SIZE = 64;
-    constexpr uint32_t CACHE_LINE_MASK = ~(CACHE_LINE_SIZE - 1);
+    constexpr uint32_t LINE_MASK = ~(L2_CACHE_LINE_SIZE - 1);
 
-    asm volatile("fence" ::: "memory");
+    __asm__ __volatile__("fence" ::: "memory");
 
     volatile uint64_t* flush_reg = (volatile uint64_t*)L2_FLUSH_ADDR;
-    uint32_t aligned_start = start_addr & CACHE_LINE_MASK;
+    uint32_t aligned_start = start_addr & LINE_MASK;
     uint32_t end_addr = start_addr + size;
 
-    for (uint32_t addr = aligned_start; addr < end_addr; addr += CACHE_LINE_SIZE) {
+    for (uint32_t addr = aligned_start; addr < end_addr; addr += L2_CACHE_LINE_SIZE) {
         *flush_reg = (uint64_t)addr;
     }
 
-    asm volatile("fence" ::: "memory");
+    __asm__ __volatile__("fence" ::: "memory");
+}
+
+// Flush entire L2 cache (128KB) to TL1.
+// Iterates FLUSH64 over all possible cache line addresses.
+inline void flush_l2_cache_full() {
+    __asm__ __volatile__("fence" ::: "memory");
+
+    volatile uint64_t* flush_reg = (volatile uint64_t*)L2_FLUSH_ADDR;
+    for (uint32_t addr = 0; addr < L2_CACHE_SIZE; addr += L2_CACHE_LINE_SIZE) {
+        *flush_reg = (uint64_t)addr;
+    }
+
+    __asm__ __volatile__("fence" ::: "memory");
+}
+
+// Coordinated L2 invalidation across all 8 DM cores.
+// Each core signals ready by writing its bit, then polls until HW clears register.
+// Call from all 8 cores, or write other cores' bits if only one core is active.
+inline void invalidate_l2_cache(uint32_t hartid) {
+    volatile uint64_t* inv_reg = (volatile uint64_t*)L2_FULL_INVALIDATE_ADDR;
+    *inv_reg = (uint64_t)(1 << hartid);
+    while (*inv_reg != 0);  // Wait for HW to complete and clear
+}
+
+// -----------------------------------------------------------------------------
+// Combined Cache Operations
+// -----------------------------------------------------------------------------
+
+// Invalidate entire L1 cache (D$ + I$) on this core.
+// Provided for API compatibility with previous architectures.
+inline void invalidate_l1_cache() {
+    invalidate_l1_dcache(0);
+    invalidate_l1_icache();
+}
+
+// Invalidate entire cache hierarchy: L2 + L1 D$ + L1 I$.
+// Must be called from all 8 DM cores for proper synchronization.
+// After return, all caches are cold and will fetch fresh data from TL1.
+inline void invalidate_cache_all(uint32_t hartid) {
+    // 1. Coordinate L2 wipe across all cores
+    invalidate_l2_cache(hartid);
+
+    // 2. Invalidate local L1 (D$ + I$)
+    invalidate_l1_cache();
 }
 
 #endif  // ARCH_QUASAR

--- a/tt_metal/hw/inc/internal/tt-2xx/risc_common.h
+++ b/tt_metal/hw/inc/internal/tt-2xx/risc_common.h
@@ -160,6 +160,51 @@ inline __attribute__((always_inline)) void invalidate_l1_cache() {
 #endif
 }
 
+#if defined(ARCH_QUASAR)
+// Quasar L2 Cache Management
+// DM cores have an L2 cache between the core and TL1 (node memory).
+// Writes to cacheable addresses (< MEM_L1_SIZE) go through L2.
+// Flush is required for data to be visible to other agents (host, other cores).
+//
+// Cache line size: 64 bytes
+// Flush registers:
+//   FLUSH64 (0x04010200): Takes raw byte address
+//   FLUSH32 (0x04010240): Takes (address >> 4)
+//
+// Note: L2 invalidation is NOT supported per HW.
+
+#include "internal/tt-2xx/quasar/overlay/overlay_addresses.h"
+
+// Flush a single cache line from L2 to TL1 (node memory).
+// Includes fence instructions for proper memory ordering.
+inline __attribute__((always_inline)) void flush_l2_cache_line(uint32_t addr) {
+    asm volatile("fence" ::: "memory");
+    volatile uint64_t* flush_reg = (volatile uint64_t*)L2_FLUSH_ADDR;
+    *flush_reg = (uint64_t)addr;
+    asm volatile("fence" ::: "memory");
+}
+
+// Flush a range of addresses from L2 to TL1.
+// Flushes all cache lines covering [start_addr, start_addr + size).
+inline __attribute__((always_inline)) void flush_l2_cache_range(uint32_t start_addr, uint32_t size) {
+    constexpr uint32_t CACHE_LINE_SIZE = 64;
+    constexpr uint32_t CACHE_LINE_MASK = ~(CACHE_LINE_SIZE - 1);
+
+    asm volatile("fence" ::: "memory");
+
+    volatile uint64_t* flush_reg = (volatile uint64_t*)L2_FLUSH_ADDR;
+    uint32_t aligned_start = start_addr & CACHE_LINE_MASK;
+    uint32_t end_addr = start_addr + size;
+
+    for (uint32_t addr = aligned_start; addr < end_addr; addr += CACHE_LINE_SIZE) {
+        *flush_reg = (uint64_t)addr;
+    }
+
+    asm volatile("fence" ::: "memory");
+}
+
+#endif  // ARCH_QUASAR
+
 template <bool enable = true>
 inline __attribute__((always_inline)) void set_l1_data_cache() {
 #if defined(ARCH_BLACKHOLE)

--- a/tt_metal/hw/inc/internal/tt-2xx/risc_common.h
+++ b/tt_metal/hw/inc/internal/tt-2xx/risc_common.h
@@ -154,11 +154,13 @@ inline uint32_t special_mult(uint32_t a, uint32_t special_b) {
 // MMU or range registers).
 //  Writing an address on one proc and reading it from another proc only requires the reader to invalidate.
 //  Need to invalidate any address written by noc that may have been previously read by riscv
+#if !defined(ARCH_QUASAR)
 inline __attribute__((always_inline)) void invalidate_l1_cache() {
 #if defined(ARCH_BLACKHOLE)
     asm("fence");
 #endif
 }
+#endif  // !ARCH_QUASAR
 
 #if defined(ARCH_QUASAR)
 // =============================================================================

--- a/tt_metal/hw/inc/internal/tt-2xx/risc_common.h
+++ b/tt_metal/hw/inc/internal/tt-2xx/risc_common.h
@@ -250,19 +250,12 @@ inline __attribute__((always_inline)) void flush_l2_cache_line(uint32_t addr) {
 // Flush a range of addresses from L2 to TL1.
 // Flushes all cache lines covering [start_addr, start_addr + size).
 inline __attribute__((always_inline)) void flush_l2_cache_range(uint32_t start_addr, uint32_t size) {
-    constexpr uint32_t LINE_MASK = ~(L2_CACHE_LINE_SIZE - 1);
-
-    __asm__ __volatile__("fence" ::: "memory");
-
-    volatile uint64_t* flush_reg = (volatile uint64_t*)L2_FLUSH_ADDR;
-    uint32_t aligned_start = start_addr & LINE_MASK;
+    uint32_t aligned_start = start_addr & ~(uint32_t)63;  // align to 64B
     uint32_t end_addr = start_addr + size;
 
-    for (uint32_t addr = aligned_start; addr < end_addr; addr += L2_CACHE_LINE_SIZE) {
-        *flush_reg = (uint64_t)addr;
+    for (uint32_t addr = aligned_start; addr < end_addr; addr += 64) {
+        flush_l2_cache_line(addr);
     }
-
-    __asm__ __volatile__("fence" ::: "memory");
 }
 
 // Flush entire L2 cache (128KB) to TL1.

--- a/tt_metal/hw/inc/internal/tt-2xx/risc_common.h
+++ b/tt_metal/hw/inc/internal/tt-2xx/risc_common.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -168,9 +168,9 @@ inline __attribute__((always_inline)) void invalidate_l1_cache() {
 // =============================================================================
 //
 // Cache hierarchy (per DM core):
-//   L1 D$ : 4KB write-back, 64B lines, private per core
-//   L1 I$ : instruction cache, private per core
-//   L2    : 128KB write-back, 64B lines, inclusive, shared by 8 DM cores
+//   L1 D$ : 4KB write-back, 2-way, 64B lines, private per core
+//   L1 I$ : 4KB, 2-way, private per core
+//   L2    : 128KB write-back, 4-way, 64B lines, shared between DM cores
 //   TL1   : Tensix L1 (node memory), visible to host and other cores
 //
 // Data path: Core -> L1 D$ -> L2 -> TL1
@@ -192,21 +192,16 @@ inline __attribute__((always_inline)) void invalidate_l1_cache() {
 // -----------------------------------------------------------------------------
 // L1 Data Cache Operations
 // -----------------------------------------------------------------------------
-// Uses custom RISC-V instructions from SiFive/rocket-chip.
-// Instruction encoding: I-type with opcode=0x73, funct3=0, rd=x0
-//   CFLUSH.D.L1:   simm12 = -0x40 (0xFC0), flushes line to L2 + invalidates
-//   CDISCARD.D.L1: simm12 = -0x3E (0xFC2), invalidates line without writeback
-// If rs1=x0, operates on entire 4KB L1 D$.
+// Uses tt.cache.cflush.d.l1 and tt.cache.cdiscard.d.l1 instructions.
+// If rs1=x0, operates on entire L1 D$.
 
 // Flush L1 D$ line (or entire cache if addr=0) to L2.
 // Writes back dirty data to L2 and invalidates the line.
 inline __attribute__((always_inline)) void flush_l1_dcache(uintptr_t addr) {
     if (addr) {
-        // .insn i opcode, funct3, rd, rs1, simm12
-        __asm__ __volatile__(".insn i 0x73, 0, x0, %0, -0x40" :: "r"(addr) : "memory");
+        __asm__ __volatile__("tt.cache.cflush.d.l1 %0" :: "r"(addr) : "memory");
     } else {
-        // rs1=x0: flush entire L1 D$ (encoded as .word for x0 case)
-        __asm__ __volatile__(".word 0xfc000073" ::: "memory");
+        __asm__ __volatile__("tt.cache.cflush.d.l1 x0" ::: "memory");
     }
     __asm__ __volatile__("fence" ::: "memory");
 }
@@ -215,10 +210,9 @@ inline __attribute__((always_inline)) void flush_l1_dcache(uintptr_t addr) {
 // Discards dirty data - use only when data is known to be stale.
 inline __attribute__((always_inline)) void invalidate_l1_dcache(uintptr_t addr) {
     if (addr) {
-        __asm__ __volatile__(".insn i 0x73, 0, x0, %0, -0x3E" :: "r"(addr) : "memory");
+        __asm__ __volatile__("tt.cache.cdiscard.d.l1 %0" :: "r"(addr) : "memory");
     } else {
-        // rs1=x0: invalidate entire L1 D$
-        __asm__ __volatile__(".word 0xfc200073" ::: "memory");
+        __asm__ __volatile__("tt.cache.cdiscard.d.l1 x0" ::: "memory");
     }
     __asm__ __volatile__("fence" ::: "memory");
 }
@@ -247,6 +241,15 @@ inline __attribute__((always_inline)) void flush_l2_cache_line(uint32_t addr) {
     __asm__ __volatile__("fence" ::: "memory");
 }
 
+// Invalidate a single 64B cache line from L2 without writeback.
+// Discards dirty data - use only when data is known to be stale.
+inline __attribute__((always_inline)) void invalidate_l2_cache_line(uint32_t addr) {
+    __asm__ __volatile__("fence" ::: "memory");
+    volatile uint64_t* inv_reg = (volatile uint64_t*)L2_INVALIDATE_ADDR;
+    *inv_reg = (uint64_t)addr;
+    __asm__ __volatile__("fence" ::: "memory");
+}
+
 // Flush a range of addresses from L2 to TL1.
 // Flushes all cache lines covering [start_addr, start_addr + size).
 inline __attribute__((always_inline)) void flush_l2_cache_range(uint32_t start_addr, uint32_t size) {
@@ -258,22 +261,22 @@ inline __attribute__((always_inline)) void flush_l2_cache_range(uint32_t start_a
     }
 }
 
-// Flush entire L2 cache (128KB) to TL1.
-// Iterates FLUSH64 over all possible cache line addresses.
+// Flush entire L2 cache to TL1.
+// Iterates FLUSH64 over all cacheable TL1 addresses (4MB).
 inline void flush_l2_cache_full() {
     __asm__ __volatile__("fence" ::: "memory");
 
     volatile uint64_t* flush_reg = (volatile uint64_t*)L2_FLUSH_ADDR;
-    for (uint32_t addr = 0; addr < L2_CACHE_SIZE; addr += L2_CACHE_LINE_SIZE) {
+    for (uint32_t addr = 0; addr < MEMORY_PORT_CACHEABLE_MEM_PORT_MEM_SIZE; addr += L2_CACHE_LINE_SIZE) {
         *flush_reg = (uint64_t)addr;
     }
 
     __asm__ __volatile__("fence" ::: "memory");
 }
 
-// Coordinated L2 invalidation across all 8 DM cores.
+// Coordinated L2 invalidation across all DM cores.
 // Each core signals ready by writing its bit, then polls until HW clears register.
-// Call from all 8 cores, or write other cores' bits if only one core is active.
+// Call from all DM cores, or write other cores' bits if only one core is active.
 inline void invalidate_l2_cache(uint32_t hartid) {
     volatile uint64_t* inv_reg = (volatile uint64_t*)L2_FULL_INVALIDATE_ADDR;
     *inv_reg = (uint64_t)(1 << hartid);
@@ -292,7 +295,7 @@ inline void invalidate_l1_cache() {
 }
 
 // Invalidate entire cache hierarchy: L2 + L1 D$ + L1 I$.
-// Must be called from all 8 DM cores for proper synchronization.
+// Must be called from all DM cores for proper synchronization.
 // After return, all caches are cold and will fetch fresh data from TL1.
 inline void invalidate_cache_all(uint32_t hartid) {
     // 1. Coordinate L2 wipe across all cores


### PR DESCRIPTION
### Ticket

N/A

### Problem description
Quasar DM cores have an L2 cache between the core and TL1 (node memory). Writes to cacheable addresses stay in L2 and are not visible to host or other cores without explicit flush.

### What's changed

  - Added flush_l2_cache_line() and flush_l2_cache_range() functions in risc_common.h for Quasar
  - Documented FLUSH64/FLUSH32 register address encodings in overlay_addresses.h (FLUSH64 takes raw byte address, FLUSH32 takes addr >> 4)
  - Updated simple_l1_write.cpp test to use cache flush instead of bypassing cache via MEM_L1_UNCACHED_BASE


### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=prybicki/flush-qsr-dm-l2)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:prybicki/flush-qsr-dm-l2)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=prybicki/flush-qsr-dm-l2)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:prybicki/flush-qsr-dm-l2)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=prybicki/flush-qsr-dm-l2)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:prybicki/flush-qsr-dm-l2)
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=prybicki/flush-qsr-dm-l2)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:prybicki/flush-qsr-dm-l2)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=prybicki/flush-qsr-dm-l2)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:prybicki/flush-qsr-dm-l2)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=prybicki/flush-qsr-dm-l2)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:prybicki/flush-qsr-dm-l2)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
