### PR TITLE
Optimize DeepSeekV3 weight dequantization

### DIFF
--- a/models/demos/deepseek_v3/tests/test_dequantize.py
+++ b/models/demos/deepseek_v3/tests/test_dequantize.py
@@ -11,6 +11,7 @@ from models.demos.deepseek_v3.utils.dequantize import dequantize_tensor
 
 
 def _reference_dequantize(tensor: torch.Tensor, inv_scale: torch.Tensor, block_shape: tuple[int, ...]) -> torch.Tensor:
+    """Naive reference implementation of dequantization that uses `repeat_interleave`"""
     expanded = inv_scale
     for dim, block_dim in enumerate(block_shape):
         expanded = expanded.repeat_interleave(block_dim, dim=dim)
@@ -30,11 +31,11 @@ def _reference_dequantize(tensor: torch.Tensor, inv_scale: torch.Tensor, block_s
 def test_dequantize_tensor_matches_reference(
     shape: tuple[int, ...], block_shape: tuple[int, ...], input_dtype: torch.dtype
 ):
-    torch.manual_seed(sum(shape) + sum(block_shape) + int(input_dtype == torch.bfloat16))
+    torch.manual_seed(1234)
     inv_shape = tuple(math.ceil(shape[i] / block_shape[i]) for i in range(len(shape)))
 
-    quantized = torch.randn(shape, dtype=torch.float32).to(input_dtype)
-    inv_scale = torch.randn(inv_shape, dtype=torch.float32)
+    quantized = torch.rand(shape, dtype=torch.float32).to(input_dtype)
+    inv_scale = torch.rand(inv_shape, dtype=torch.float32)
 
     expected = _reference_dequantize(quantized, inv_scale, block_shape)
     actual = dequantize_tensor(quantized, inv_scale, block_shape)

--- a/models/demos/deepseek_v3/tests/test_dequantize.py
+++ b/models/demos/deepseek_v3/tests/test_dequantize.py
@@ -1,0 +1,51 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import math
+
+import pytest
+import torch
+
+from models.demos.deepseek_v3.utils.dequantize import dequantize_tensor
+
+
+def _reference_dequantize(tensor: torch.Tensor, inv_scale: torch.Tensor, block_shape: tuple[int, ...]) -> torch.Tensor:
+    expanded = inv_scale
+    for dim, block_dim in enumerate(block_shape):
+        expanded = expanded.repeat_interleave(block_dim, dim=dim)
+    slices = tuple(slice(0, size) for size in tensor.shape)
+    return tensor.float() * expanded[slices].float()
+
+
+@pytest.mark.parametrize(
+    "shape,block_shape,input_dtype",
+    [
+        ((130, 257), (128, 128), torch.float8_e4m3fn),  # non-divisible in both dims
+        ((512, 1024), (128, 128), torch.float8_e4m3fn),  # exactly divisible
+        ((63, 65), (32, 32), torch.float8_e4m3fn),  # small non-divisible
+        ((5, 7, 9), (2, 3, 4), torch.float8_e4m3fn),  # rank-3 coverage
+    ],
+)
+def test_dequantize_tensor_matches_reference(
+    shape: tuple[int, ...], block_shape: tuple[int, ...], input_dtype: torch.dtype
+):
+    torch.manual_seed(sum(shape) + sum(block_shape) + int(input_dtype == torch.bfloat16))
+    inv_shape = tuple(math.ceil(shape[i] / block_shape[i]) for i in range(len(shape)))
+
+    quantized = torch.randn(shape, dtype=torch.float32).to(input_dtype)
+    inv_scale = torch.randn(inv_shape, dtype=torch.float32)
+
+    expected = _reference_dequantize(quantized, inv_scale, block_shape)
+    actual = dequantize_tensor(quantized, inv_scale, block_shape)
+
+    assert actual.dtype == torch.float32
+    assert torch.allclose(actual, expected, atol=1e-6, rtol=1e-6)
+
+
+def test_dequantize_tensor_rejects_invalid_rank():
+    quantized = torch.randn((2, 3), dtype=torch.float32).to(torch.float8_e4m3fn)
+    inv_scale = torch.randn((1,), dtype=torch.float32)
+
+    with pytest.raises(ValueError, match="same ndim"):
+        dequantize_tensor(quantized, inv_scale, (2, 2))

--- a/models/demos/deepseek_v3/tests/test_dequantize.py
+++ b/models/demos/deepseek_v3/tests/test_dequantize.py
@@ -44,6 +44,53 @@ def test_dequantize_tensor_matches_reference(
     assert torch.allclose(actual, expected, atol=1e-6, rtol=1e-6)
 
 
+def test_dequantize_tensor_does_not_mutate_float32_input():
+    torch.manual_seed(2026)
+
+    tensor = torch.randn((8, 257, 259), dtype=torch.float32)
+    tensor_before = tensor.clone()
+    scale = torch.rand((8, 3, 3), dtype=torch.float32) + 0.1
+
+    _ = dequantize_tensor(tensor, scale, (1, 128, 128))
+
+    assert torch.equal(tensor, tensor_before)
+
+
+def test_dequantize_tensor_matches_reference_in_experts_weight_loading_flow():
+    torch.manual_seed(1337)
+
+    num_experts = 8
+    weight_shape = (257, 259)
+    block_shape = (128, 128)
+    block_shape_with_expert_dim = (1, *block_shape)
+    scale_shape = tuple(math.ceil(weight_shape[i] / block_shape[i]) for i in range(len(weight_shape)))
+
+    expert_weights = [torch.randn(weight_shape, dtype=torch.float32) for _ in range(num_experts)]
+    quant_scales = [torch.rand(scale_shape, dtype=torch.float32) + 0.1 for _ in range(num_experts)]
+
+    # This mirrors add_inv_scale_to_state_dict's quantization path in module tests.
+    quantized_old = [
+        _reference_dequantize(weight.clone(), scale, block_shape).to(torch.float8_e4m3fn)
+        for weight, scale in zip(expert_weights, quant_scales, strict=True)
+    ]
+    quantized_new = [
+        dequantize_tensor(weight.clone(), scale, block_shape).to(torch.float8_e4m3fn)
+        for weight, scale in zip(expert_weights, quant_scales, strict=True)
+    ]
+    inv_scales = [1.0 / scale for scale in quant_scales]
+
+    quantized_old_stacked = torch.stack(quantized_old)
+    quantized_new_stacked = torch.stack(quantized_new)
+    inv_scales_stacked = torch.stack(inv_scales)
+
+    # This mirrors Experts.convert_weights dequantization path.
+    loaded_old = _reference_dequantize(quantized_old_stacked, inv_scales_stacked, block_shape_with_expert_dim)
+    loaded_new = dequantize_tensor(quantized_new_stacked, inv_scales_stacked, block_shape_with_expert_dim)
+
+    assert torch.equal(quantized_new_stacked, quantized_old_stacked)
+    assert torch.allclose(loaded_new, loaded_old, atol=1e-6, rtol=1e-6)
+
+
 def test_dequantize_tensor_rejects_invalid_rank():
     quantized = torch.randn((2, 3), dtype=torch.float32).to(torch.float8_e4m3fn)
     inv_scale = torch.randn((1,), dtype=torch.float32)

--- a/models/demos/deepseek_v3/utils/config_helpers.py
+++ b/models/demos/deepseek_v3/utils/config_helpers.py
@@ -15,6 +15,7 @@ from loguru import logger
 
 import ttnn
 from models.demos.deepseek_v3.utils.config_dataclass import SavedWeight
+from models.demos.deepseek_v3.utils.dequantize import dequantize_tensor
 from models.demos.deepseek_v3.utils.lazy_state_dict import LazyStateDict
 
 # Constants
@@ -494,11 +495,7 @@ def dequantize(tensor: torch.Tensor, inv_scale: torch.Tensor, block_shape: Seque
     assert len(block_shape) == tensor.ndim and all(
         inv_scale.shape[i] * block_shape[i] >= tensor.shape[i] for i in range(tensor.ndim)
     )
-    for i, block_dim in enumerate(block_shape):
-        inv_scale = inv_scale.repeat_interleave(block_dim, dim=i)
-    tensor = tensor.float() * inv_scale[tuple(slice(0, s) for s in tensor.shape)].float()
-    del inv_scale
-    return tensor
+    return dequantize_tensor(tensor, inv_scale, block_shape)
 
 
 def get_state_dicts(

--- a/models/demos/deepseek_v3/utils/dequantize.py
+++ b/models/demos/deepseek_v3/utils/dequantize.py
@@ -13,8 +13,15 @@ def dequantize_tensor(tensor: torch.Tensor, inv_scale: torch.Tensor, block_shape
     """
     Dequantize a tensor using block-wise inverse scales.
 
-    This implementation avoids materializing a fully expanded inverse-scale tensor
-    via repeat_interleave and instead applies scales with broadcasted block views.
+    Performance notes:
+    - Avoids `repeat_interleave` over `inv_scale`, which would materialize a huge
+      expanded scale tensor and significantly increase peak memory.
+    - Uses reshape+broadcast to apply scales per block, so scale expansion stays
+      virtual and the only dense payload is the output tensor itself.
+    - Uses in-place multiply on a view (`mul_`) to reduce temporary allocations
+      and memory bandwidth pressure.
+    - Pads only when needed for non-divisible shapes, then slices back to the
+      original shape.
     """
     if tensor.ndim != inv_scale.ndim:
         raise ValueError(f"Tensor and inverse scale must have same ndim, got {tensor.ndim} and {inv_scale.ndim}")
@@ -34,6 +41,8 @@ def dequantize_tensor(tensor: torch.Tensor, inv_scale: torch.Tensor, block_shape
 
     out = tensor.float()
     if padded_shape != original_shape:
+        # Only allocate a padded buffer when block coverage extends past the
+        # original tensor shape (tail blocks on non-divisible dimensions).
         padded = torch.zeros(padded_shape, dtype=out.dtype)
         padded[original_slices] = out
         out = padded
@@ -45,6 +54,8 @@ def dequantize_tensor(tensor: torch.Tensor, inv_scale: torch.Tensor, block_shape
         interleaved_shape.extend([blocks, block_dim])
         scale_broadcast_shape.extend([blocks, 1])
 
+    # Reshape into [blocks, block_size, ...] and apply broadcasted scales in
+    # place, avoiding explicit per-element scale expansion.
     out_view = out.reshape(*interleaved_shape)
     out_view.mul_(inv_scale.float().reshape(*scale_broadcast_shape))
     out = out_view.reshape(*padded_shape)

--- a/models/demos/deepseek_v3/utils/dequantize.py
+++ b/models/demos/deepseek_v3/utils/dequantize.py
@@ -39,10 +39,15 @@ def dequantize_tensor(tensor: torch.Tensor, inv_scale: torch.Tensor, block_shape
     padded_shape = tuple(inv_scale.shape[i] * block_shape[i] for i in range(tensor.ndim))
     original_slices = tuple(slice(0, size) for size in original_shape)
 
+    # When input is already float32, `tensor.float()` may alias the original storage. We clone in
+    # that case before in-place math to avoid mutating caller-owned tensors (this impacted DeepSeek
+    # module tests that pass tensors from `reference_model.state_dict()`).
     out = tensor.float()
+    out = out.clone() if out.data_ptr() == tensor.data_ptr() else out
+
+    # Only allocate a padded buffer when block coverage extends past the
+    # original tensor shape (tail blocks on non-divisible dimensions).
     if padded_shape != original_shape:
-        # Only allocate a padded buffer when block coverage extends past the
-        # original tensor shape (tail blocks on non-divisible dimensions).
         padded = torch.zeros(padded_shape, dtype=out.dtype)
         padded[original_slices] = out
         out = padded

--- a/models/demos/deepseek_v3/utils/dequantize.py
+++ b/models/demos/deepseek_v3/utils/dequantize.py
@@ -1,0 +1,51 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from typing import Sequence
+
+import torch
+
+
+def dequantize_tensor(tensor: torch.Tensor, inv_scale: torch.Tensor, block_shape: Sequence[int]) -> torch.Tensor:
+    """
+    Dequantize a tensor using block-wise inverse scales.
+
+    This implementation avoids materializing a fully expanded inverse-scale tensor
+    via repeat_interleave and instead applies scales with broadcasted block views.
+    """
+    if tensor.ndim != inv_scale.ndim:
+        raise ValueError(f"Tensor and inverse scale must have same ndim, got {tensor.ndim} and {inv_scale.ndim}")
+    if len(block_shape) != tensor.ndim:
+        raise ValueError(
+            f"Block shape rank mismatch, got len(block_shape)={len(block_shape)} and tensor.ndim={tensor.ndim}"
+        )
+    if any(inv_scale.shape[i] * block_shape[i] < tensor.shape[i] for i in range(tensor.ndim)):
+        raise ValueError(
+            "Inverse scale shape does not cover tensor shape: "
+            f"tensor={tuple(tensor.shape)}, inv_scale={tuple(inv_scale.shape)}, block_shape={tuple(block_shape)}"
+        )
+
+    original_shape = tuple(tensor.shape)
+    padded_shape = tuple(inv_scale.shape[i] * block_shape[i] for i in range(tensor.ndim))
+    original_slices = tuple(slice(0, size) for size in original_shape)
+
+    out = tensor.float()
+    if padded_shape != original_shape:
+        padded = torch.zeros(padded_shape, dtype=out.dtype)
+        padded[original_slices] = out
+        out = padded
+
+    interleaved_shape: list[int] = []
+    scale_broadcast_shape: list[int] = []
+    for dim, block_dim in enumerate(block_shape):
+        blocks = inv_scale.shape[dim]
+        interleaved_shape.extend([blocks, block_dim])
+        scale_broadcast_shape.extend([blocks, 1])
+
+    out_view = out.reshape(*interleaved_shape)
+    out_view.mul_(inv_scale.float().reshape(*scale_broadcast_shape))
+    out = out_view.reshape(*padded_shape)
+    return out[original_slices]


### PR DESCRIPTION
## Summary

This PR optimizes DeepSeek V3 weight dequantization by replacing the `repeat_interleave`-based implementation with a reshape+broadcast implementation that avoids materializing expanded scale tensors.

Measured performance improvement is roughly 2.1x faster on DeepSeekV3 weight tensors. Peak memory consumption is around 2x less.

## Motivation

The previous dequantization path expanded `inv_scale` across full tensor shape, which is expensive in both memory and runtime for large checkpoint tensors. This change keeps scale expansion virtual and applies scaling blockwise in place.

## Changes

  - Added a dequantization utility:
    - `models/demos/deepseek_v3/utils/dequantize.py`
    - New `dequantize_tensor(tensor, inv_scale, block_shape)` implementation using:
      - shape validation
      - optional padding for non-divisible block tails
      - reshape-based block view
      - broadcasted in-place multiply (`mul_`)
  - Switched DeepSeek config helper dequantization so that `dequantize(...)` now delegates to `dequantize_tensor(...)`
  - Added unit tests
    - `models/demos/deepseek_v3/tests/test_dequantize.py`
    - Validates parity vs naive reference implementation across:
      - divisible and non-divisible shapes
      - rank-2 and rank-3 tensors
      - FP8 input tensors
    - Adds negative test for invalid rank mismatch

### Checklist

- [x] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=esmal/dequantize)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:esmal/dequantize)
- [x] [DeepSeekV3 unit tests](https://github.com/tenstorrent/tt-metal/actions/runs/22189950609)
- [ ] [DeepSeekV3 TG demo tests](https://github.com/tenstorrent/tt-metal/actions/runs/22186453635)