### PR TITLE
#38022: add ttnn reduction tests to l2 nightly

### DIFF
--- a/.github/workflows/tt-metal-l2-nightly-impl.yaml
+++ b/.github/workflows/tt-metal-l2-nightly-impl.yaml
@@ -38,6 +38,10 @@ on:
         required: false
         type: boolean
         default: true
+      run_reduction_tests:
+        required: false
+        type: boolean
+        default: true
       run_experimental_tests:
         required: false
         type: boolean
@@ -284,6 +288,58 @@ jobs:
       - name: ttnn nightly fused tests
         timeout-minutes: ${{ inputs.timeout }}
         run: pytest tests/ttnn/nightly/unit_tests/operations/fused -xv -m "not disable_fast_runtime_mode" --timeout=${{ env.TEST_BUDGET_SECONDS }}
+      - uses: tenstorrent/tt-metal/.github/actions/upload-artifact-with-job-uuid@main
+        timeout-minutes: 15
+        if: ${{ !cancelled() }}
+        with:
+          prefix: "test_reports_"
+      - uses: tenstorrent/tt-metal/.github/actions/slack-report@main
+        # Only notify during failed scheduled runs
+        if: ${{ failure() && github.event_name == 'schedule' }}
+        with:
+          slack_webhook_url: ${{ secrets.SLACK_METAL_INFRA_PIPELINE_STATUS_ALERT }}
+          owner: U06Q7ESTFEV # Borys Bradel
+      - uses: tenstorrent/tt-metal/.github/actions/cleanup@main
+        if: always()
+
+  ttnn-reduction-tests:
+    if: ${{ inputs.run_reduction_tests }}
+    container:
+      image: ${{ inputs.docker-image || 'docker-image-unresolved!' }}
+      env:
+        PYTHONPATH: /work
+        LD_LIBRARY_PATH: /work/build/lib
+        ARCH_NAME: ${{ inputs.arch }}
+        LOGURU_LEVEL: INFO
+      volumes:
+        - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
+        - /dev/hugepages-1G:/dev/hugepages-1G
+      options: "--device /dev/tenstorrent -v /mnt/MLPerf:/mnt/MLPerf:ro"
+    defaults:
+      run:
+        shell: bash
+        working-directory: /work # https://github.com/actions/runner/issues/878
+    name: ttnn nightly reduction tests ${{ inputs.arch }} ${{ inputs.runner-label }}
+    runs-on: >-
+      ${{
+        ((inputs.runner-label == 'P150b') && format('tt-ubuntu-2204-{0}-stable', inputs.runner-label))
+        || fromJSON(format('["{0}", "in-service"]', inputs.runner-label))
+      }}
+    steps:
+      - name: 🧬 Checkout Repository
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          path: docker-job
+      - name: ⬇️  Setup Job
+        uses: ./docker-job/.github/actions/setup-job
+        timeout-minutes: 15
+        with:
+          build-artifact-name: ${{ inputs.build-artifact-name }}
+          wheel-artifact-name: ${{ inputs.wheel-artifact-name }}
+      - name: ttnn nightly reduction tests
+        timeout-minutes: ${{ inputs.timeout }}
+        run: pytest tests/ttnn/nightly/unit_tests/operations/reduction -xv -m "not disable_fast_runtime_mode" --timeout=${{ env.TEST_BUDGET_SECONDS }}
       - uses: tenstorrent/tt-metal/.github/actions/upload-artifact-with-job-uuid@main
         timeout-minutes: 15
         if: ${{ !cancelled() }}

--- a/.github/workflows/tt-metal-l2-nightly.yaml
+++ b/.github/workflows/tt-metal-l2-nightly.yaml
@@ -61,7 +61,7 @@ on:
         type: boolean
         default: false
       additional_test_categories:
-        description: 'Additional test categories to run (comma-separated, e.g., conv,pool,sdxl,train,sdpa,eltwise,matmul,experimental,docs_examples,ops_docs_check,misc,moreh,fused,data_movement,transformers)'
+        description: 'Additional test categories to run (comma-separated, e.g., conv,pool,sdxl,train,sdpa,eltwise,matmul,experimental,docs_examples,ops_docs_check,misc,moreh,fused,reduction,data_movement,transformers)'
         required: false
         type: string
         default: ''
@@ -265,6 +265,7 @@ jobs:
       run_moreh_tests: ${{ github.event_name == 'schedule' || contains(format(',{0},', inputs.additional_test_categories), ',moreh,') }}
       run_data_movement_tests: ${{ github.event_name == 'schedule' || contains(format(',{0},', inputs.additional_test_categories), ',data_movement,') }}
       run_fused_tests: ${{ github.event_name == 'schedule' || contains(format(',{0},', inputs.additional_test_categories), ',fused,') }}
+      run_reduction_tests: ${{ github.event_name == 'schedule' || contains(format(',{0},', inputs.additional_test_categories), ',reduction,') }}
       run_misc_tests: ${{ github.event_name == 'schedule' || contains(format(',{0},', inputs.additional_test_categories), ',misc,') }}
   ttnn-ops-docs-check:
     needs: [build-artifact, generate-arch-matrix]

--- a/tests/ttnn/nightly/unit_tests/operations/reduction/test_prod_all.py
+++ b/tests/ttnn/nightly/unit_tests/operations/reduction/test_prod_all.py
@@ -8,7 +8,7 @@ from loguru import logger
 from functools import partial
 
 import ttnn
-from models.common.utility_functions import comp_allclose_and_pcc, skip_for_blackhole
+from models.common.utility_functions import comp_allclose_and_pcc
 
 from tests.tt_eager.python_api_testing.sweep_tests import (
     comparison_funcs,
@@ -33,7 +33,6 @@ def get_tensors(input_shape, output_shape, device):
     return tt_input, tt_output, torch_input
 
 
-@skip_for_blackhole("Hangs on Blackhole, see #12349")
 @pytest.mark.parametrize(
     "shapes",
     (

--- a/tests/ttnn/nightly/unit_tests/operations/reduction/test_sum.py
+++ b/tests/ttnn/nightly/unit_tests/operations/reduction/test_sum.py
@@ -6,8 +6,6 @@ import torch
 import pytest
 import ttnn
 
-from models.common.utility_functions import skip_for_blackhole
-
 
 @pytest.mark.parametrize(
     "shape_dim",
@@ -39,7 +37,6 @@ def test_sum_for_dim_hw(device, shape_dim):
     assert torch.equal(tt_dev[0, 0, 0, 0], torch.Tensor([value]).bfloat16()[0])
 
 
-@skip_for_blackhole("Mismatching on BH, see #12349")
 @pytest.mark.parametrize(
     "shape",
     (


### PR DESCRIPTION
### Ticket
Link to Github Issue #38022

### Problem description
A test was added to tests/ttnn/nightly/unit_tests/operations/reduction without adding that directory to the L2 nightly workflow.

### What's changed
Add that directory to the L2 nightly workflow.

Also, checked that skipped tests now pass and enabled them:
```
PASSED tests/ttnn/nightly/unit_tests/operations/reduction/test_prod_all.py::test_prod[shapes=[1, 1, 32, 32]]
PASSED tests/ttnn/nightly/unit_tests/operations/reduction/test_prod_all.py::test_prod[shapes=[1, 4, 32, 32]]
PASSED tests/ttnn/nightly/unit_tests/operations/reduction/test_prod_all.py::test_prod[shapes=[2, 2, 32, 32]]
PASSED tests/ttnn/nightly/unit_tests/operations/reduction/test_prod_all.py::test_prod[shapes=[16, 16]]
================================================================ 4 passed, 1 warning in 1.66s ================================================================
```
and
```
PASSED tests/ttnn/nightly/unit_tests/operations/reduction/test_sum.py::test_sum_for_dim_hw[shape_dim=((1, 1, 32, 32), 3)]
PASSED tests/ttnn/nightly/unit_tests/operations/reduction/test_sum.py::test_sum_for_dim_hw[shape_dim=((1, 1, 32, 32), 2)]
PASSED tests/ttnn/nightly/unit_tests/operations/reduction/test_sum.py::test_sum_for_dim_hw[shape_dim=((32, 32, 32, 32), 1)]
PASSED tests/ttnn/nightly/unit_tests/operations/reduction/test_sum.py::test_sum_for_dim_hw[shape_dim=((32, 32, 32, 32), 0)]
PASSED tests/ttnn/nightly/unit_tests/operations/reduction/test_sum.py::test_sum_global[shape=(1, 1, 32, 32)0]
PASSED tests/ttnn/nightly/unit_tests/operations/reduction/test_sum.py::test_sum_global[shape=(1, 1, 32, 32)1]
PASSED tests/ttnn/nightly/unit_tests/operations/reduction/test_sum.py::test_sum_global[shape=(32, 32, 32, 32)0]
PASSED tests/ttnn/nightly/unit_tests/operations/reduction/test_sum.py::test_sum_global[shape=(32, 32, 32, 32)1]
================================================================ 8 passed, 1 warning in 1.49s ================================================================
```

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=bbradel-38022_l2red)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:bbradel-38022_l2red)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=bbradel-38022_l2red)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:bbradel-38022_l2red)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=bbradel-38022_l2red)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:bbradel-38022_l2red)
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=bbradel-38022_l2red)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:bbradel-38022_l2red)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=bbradel-38022_l2red)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:bbradel-38022_l2red)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=bbradel-38022_l2red)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:bbradel-38022_l2red)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
