### PR TITLE
[skip ci] Fix Slack message size limits and add workflow inputs

### DIFF
--- a/.github/actions/slack-report-analyze-workflow-data/action.yaml
+++ b/.github/actions/slack-report-analyze-workflow-data/action.yaml
@@ -20,16 +20,31 @@ outputs:
 runs:
   using: "composite"
   steps:
+    - name: Write inputs to temp files (avoid env var size limits)
+      id: write-inputs
+      shell: bash
+      run: |
+        REGRESSED_FILE="${RUNNER_TEMP}/regressed_raw.json"
+        cat > "$REGRESSED_FILE" << '__REGRESSED_JSON_EOF__'
+        ${{ inputs.regressed_workflows }}
+        __REGRESSED_JSON_EOF__
+        echo "regressed_file=$REGRESSED_FILE" >> "$GITHUB_OUTPUT"
+
+        ALERT_FILE="${RUNNER_TEMP}/alert_raw.txt"
+        cat > "$ALERT_FILE" << '__ALERT_TEXT_EOF__'
+        ${{ inputs.alert_all_message }}
+        __ALERT_TEXT_EOF__
+        echo "alert_file=$ALERT_FILE" >> "$GITHUB_OUTPUT"
+
     - name: Build Slack message from regressions
       id: build
       shell: bash
       env:
-        ALERT_RAW: ${{ inputs.alert_all_message }}
-        REGRESSED_RAW: ${{ inputs.regressed_workflows }}
+        REGRESSED_FILE: ${{ steps.write-inputs.outputs.regressed_file }}
+        ALERT_FILE: ${{ steps.write-inputs.outputs.alert_file }}
       run: |
         set -euo pipefail
-        tmp_file="$(mktemp)"
-        printf '%s' "$REGRESSED_RAW" > "$tmp_file"
+        tmp_file="$REGRESSED_FILE"
         if ! jq -e . "$tmp_file" >/dev/null 2>&1; then
           echo "⚠️ Failed to parse regression list JSON. Skipping Slack notification."
           echo "has_regressions=false" >> "$GITHUB_OUTPUT"
@@ -236,8 +251,8 @@ runs:
         # The alert message format is: "*Alerts: failing workflows on main*\n• Workflow Name <url|open> mentions jobs"
         # We count lines starting with "• " to get the total number of failing workflows
         FAILING_WORKFLOWS_COUNT_MESSAGE=""
+        ALERT_RAW="$(cat "$ALERT_FILE" 2>/dev/null || true)"
         if [ -n "${ALERT_RAW:-}" ]; then
-          # Decode the alert message and count workflow lines
           decoded_alert=$(printf '%b' "$ALERT_RAW")
           total_failing_count=$(echo "$decoded_alert" | grep -E '^• ' | wc -l | tr -d ' ')
 
@@ -425,12 +440,17 @@ runs:
             echo "Body block text length: $body_text_length characters (limit: 3000)"
 
             if [ "$body_text_length" -gt 3000 ]; then
-              echo "⚠️ ERROR: Body text length ($body_text_length) exceeds Slack's 3000 char limit!"
-              echo "This message will fail. Skipping to prevent API error."
-              echo "Cleaning up oversized payload file: $payload_file"
-              rm -f "$payload_file" || echo "⚠️ Failed to remove payload file: $payload_file"
-              SEND_ERRORS=$((SEND_ERRORS + 1))
-              continue
+              echo "⚠️ WARNING: Body text ($body_text_length chars) exceeds Slack's 3000 char limit. Truncating..."
+              truncated_text="${body_text:0:2950}"$'\n'"_(message truncated due to size limit)_"
+              PAYLOAD=$(echo "$PAYLOAD" | jq -c --arg trunc "$truncated_text" \
+                '.blocks[1].text.text = $trunc' 2>/dev/null || echo "")
+              if [ -z "$PAYLOAD" ]; then
+                echo "⚠️ Failed to truncate payload for chunk $((i + 1))"
+                SEND_ERRORS=$((SEND_ERRORS + 1))
+                continue
+              fi
+              echo "$PAYLOAD" > "$payload_file"
+              echo "Truncated body to $(printf '%s' "$truncated_text" | wc -c) characters"
             fi
 
             # Build request body with channel and optional thread_ts

--- a/.github/actions/slack-report-analyze-workflow-data/action.yaml
+++ b/.github/actions/slack-report-analyze-workflow-data/action.yaml
@@ -24,13 +24,13 @@ runs:
       id: write-inputs
       shell: bash
       run: |
-        REGRESSED_FILE="${RUNNER_TEMP}/regressed_raw.json"
+        REGRESSED_FILE="$(mktemp "${RUNNER_TEMP}/regressed_raw.XXXXXX.json")"
         cat > "$REGRESSED_FILE" << '__REGRESSED_JSON_EOF__'
         ${{ inputs.regressed_workflows }}
         __REGRESSED_JSON_EOF__
         echo "regressed_file=$REGRESSED_FILE" >> "$GITHUB_OUTPUT"
 
-        ALERT_FILE="${RUNNER_TEMP}/alert_raw.txt"
+        ALERT_FILE="$(mktemp "${RUNNER_TEMP}/alert_raw.XXXXXX.txt")"
         cat > "$ALERT_FILE" << '__ALERT_TEXT_EOF__'
         ${{ inputs.alert_all_message }}
         __ALERT_TEXT_EOF__
@@ -441,7 +441,7 @@ runs:
 
             if [ "$body_text_length" -gt 3000 ]; then
               echo "⚠️ WARNING: Body text ($body_text_length chars) exceeds Slack's 3000 char limit. Truncating..."
-              truncated_text="${body_text:0:2950}"$'\n'"_(message truncated due to size limit)_"
+              truncated_text=$(printf '%s' "$body_text" | jq -R -r '.[0:2950] + "\n_(message truncated due to size limit)_"')
               PAYLOAD=$(echo "$PAYLOAD" | jq -c --arg trunc "$truncated_text" \
                 '.blocks[1].text.text = $trunc' 2>/dev/null || echo "")
               if [ -z "$PAYLOAD" ]; then

--- a/.github/workflows/aggregate-workflow-data.yaml
+++ b/.github/workflows/aggregate-workflow-data.yaml
@@ -285,7 +285,7 @@ jobs:
 
   trigger-auto-triage:
     needs: [analyze-data, handle-failures]
-    if: ${{ always() && (github.event.inputs.run-auto-triage || 'true') == 'true' && needs.analyze-data.result == 'success' && fromJson(needs.analyze-data.outputs.regressed_workflows) != '[]' }}
+    if: ${{ always() && fromJson(github.event.inputs.run-auto-triage || 'true') && needs.analyze-data.result == 'success' && fromJson(needs.analyze-data.outputs.regressed_workflows) != '[]' }}
     runs-on: ubuntu-latest
     permissions:
       actions: write

--- a/.github/workflows/aggregate-workflow-data.yaml
+++ b/.github/workflows/aggregate-workflow-data.yaml
@@ -21,6 +21,10 @@ on:
         required: false
         type: boolean
         default: true
+      slack-channel-id:
+        description: 'Slack channel ID to post notifications to'
+        required: false
+        type: string
 
 jobs:
   fetch-data:
@@ -273,7 +277,7 @@ jobs:
         id: slack-report
         uses: ./.github/actions/slack-report-analyze-workflow-data
         with:
-          channel_id: ${{ secrets.SLACK_METAL_INFRA_CHANNEL_ID }}
+          channel_id: ${{ github.event.inputs.slack-channel-id || secrets.SLACK_METAL_INFRA_CHANNEL_ID }}
           regressed_workflows: ${{ needs.analyze-data.outputs.regressed_workflows }}
           alert_all_message: ${{ needs.analyze-data.outputs.alert_all_message }}
         env:
@@ -300,6 +304,6 @@ jobs:
           regressed_workflows: ${{ needs.analyze-data.outputs.regressed_workflows }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           slack_ts: ${{ needs.handle-failures.outputs.slack_ts }}
-          slack_channel_id: ${{ secrets.SLACK_METAL_INFRA_CHANNEL_ID }}
+          slack_channel_id: ${{ github.event.inputs.slack-channel-id || secrets.SLACK_METAL_INFRA_CHANNEL_ID }}
           slack_bot_token: ${{ secrets.SLACK_BOT_TOKEN }}
           send-slack-message: true

--- a/.github/workflows/aggregate-workflow-data.yaml
+++ b/.github/workflows/aggregate-workflow-data.yaml
@@ -16,6 +16,11 @@ on:
         required: false
         type: boolean
         default: false
+      run-auto-triage:
+        description: 'Run auto-triage for regressed jobs'
+        required: false
+        type: boolean
+        default: true
 
 jobs:
   fetch-data:
@@ -276,7 +281,7 @@ jobs:
 
   trigger-auto-triage:
     needs: [analyze-data, handle-failures]
-    if: ${{ always() && needs.analyze-data.result == 'success' && fromJson(needs.analyze-data.outputs.regressed_workflows) != '[]' }}
+    if: ${{ always() && (github.event.inputs.run-auto-triage || 'true') == 'true' && needs.analyze-data.result == 'success' && fromJson(needs.analyze-data.outputs.regressed_workflows) != '[]' }}
     runs-on: ubuntu-latest
     permissions:
       actions: write


### PR DESCRIPTION
## Summary
Fixes the aggregate workflow data Slack reporting when regression data is too large (causing "Argument list too long" errors) and adds configurable inputs.

## Changes
1. **Slack message size fix**: Write large inputs (regressed_workflows, alert_all_message) to temp files via heredoc instead of passing as environment variables. The bash process was hitting OS ARG_MAX limits before chunking logic could run.
2. **Truncation fallback**: When a chunk still exceeds Slack's 3000-char block limit, truncate with a note instead of skipping the message entirely.
3. **New workflow inputs** (workflow_dispatch):
   - `run-auto-triage`: Enable/disable auto-triage for regressed jobs (default: true)
   - `slack-channel-id`: Override Slack channel for notifications (default: uses SLACK_METAL_INFRA_CHANNEL_ID secret)

## Proof it works
Workflow run showing successful execution end-to-end: https://github.com/tenstorrent/tt-metal/actions/runs/22189862210

Made with [Cursor](https://cursor.com)