### PR TITLE
Sraizada/gpt oss swiglu

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/experimental/test_moe.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/test_moe.py
@@ -16,7 +16,9 @@ from tracy.process_model_log import (
     run_device_profiler,
 )
 
-PCC_THRESHOLD = 0.988
+# SwiGLU achieves ~0.985 PCC (vs SiLU's ~0.989) due to additional multiplicative
+# terms amplifying Bfp4_b weight quantization error. This is inherent to the formula.
+PCC_THRESHOLD = 0.984
 
 # Some cores have more tiles than others, but they are sprinkled around the ring for boundary alignment.
 FULL_CORES = {0, 1, 8, 9}
@@ -496,13 +498,19 @@ def run_test_moe(device, M, K, N, E, L, check_accuracy, dump_outputs):
             # Use first 2*M rows of input (one copy of the original replicated input)
             torch_input_ref = torch_input[:, 0, ...]
 
-            # Compute gate activations for each expert
+            # Compute gate and up projections for each expert
             # (L, E, M, K) @ (L, E, K, N) -> (L, E, M, N)
-            torch_w0_output_ref = torch_input_ref @ torch_w0
-            torch_silu_output_ref = torch.nn.functional.silu(torch_w0_output_ref)
-            # (L, E, M, K) @ (L, E, K, N) -> (L, E, M, N)
-            torch_w1_output_ref = torch_input_ref @ torch_w1
-            torch_intermediate_ref = torch_silu_output_ref * torch_w1_output_ref  # (L, E, M, N)
+            torch_w0_output_ref = torch_input_ref @ torch_w0  # gate
+            torch_w1_output_ref = torch_input_ref @ torch_w1  # up
+
+            # GPT-OSS SwiGLU: (clamp(up)+1) * clamp(gate) * sigmoid(alpha * clamp(gate))
+            alpha = 1.702
+            clamp_limit = 7.0
+            gate = torch.clamp(torch_w0_output_ref, max=clamp_limit)
+            up = torch.clamp(torch_w1_output_ref, min=-clamp_limit, max=clamp_limit)
+            up_plus_1 = up + 1.0
+            glu = gate * torch.sigmoid(alpha * gate)
+            torch_intermediate_ref = up_plus_1 * glu  # (L, E, M, N)
 
             # (L, E, M, N) @ (L, E, N, K) -> (L, E, M, K)
             torch_output_ref = torch_intermediate_ref @ torch_w2
@@ -518,12 +526,17 @@ def run_test_moe(device, M, K, N, E, L, check_accuracy, dump_outputs):
     if dump_outputs:
         torch.set_printoptions(profile="full")
         var2filename = {
-            torch_w0_output_ref: f"torch_w0_output_ref.txt",
-            torch_w1_output_ref: f"torch_w1_output_ref.txt",
-            torch_intermediate_ref: f"torch_intermediate_ref.txt",
-            torch_output_ref: f"torch_output_ref.txt",
             tt_to_torch_outputs: f"tt_output_act.txt",
         }
+        if check_accuracy:
+            var2filename.update(
+                {
+                    torch_w0_output_ref: f"torch_w0_output_ref.txt",
+                    torch_w1_output_ref: f"torch_w1_output_ref.txt",
+                    torch_intermediate_ref: f"torch_intermediate_ref.txt",
+                    torch_output_ref: f"torch_output_ref.txt",
+                }
+            )
 
         for var, filename in var2filename.items():
             with open(filename, "w") as f:

--- a/tests/ttnn/nightly/unit_tests/operations/experimental/test_moe.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/test_moe.py
@@ -39,25 +39,6 @@ def create_torch_input(L, in0_num_cores, E, M, K):
     Returns:
         torch_input: Tensor of shape (L, in0_num_cores, 2, M, K)
     """
-    # torch_input = torch.empty((L, in0_num_cores, E, M, K), dtype=torch.bfloat16)
-    # le_val = 1
-    # for layer in range(L):
-    #     for expert in range(E):
-    #         for k_chunk_id in range(K // 32):
-    #             k_start, k_end = k_chunk_id * 32, k_chunk_id * 32 + 32
-    #             chunk_value = le_val * 0.001 * k_chunk_id
-    #             torch_input[layer, :, expert, :, k_start:k_end] = chunk_value
-    #         le_val *= -1
-    # torch_input = 0.25 * 0.25 *torch.ones((L, in0_num_cores, E, M, K), dtype=torch.bfloat16)
-    # torch_input = torch.empty((L, in0_num_cores, E, M, K), dtype=torch.bfloat16)
-    # k_half = K // 2
-    # # Interleave the positive and negatives
-    # for i in range(K):
-    #     if i % 2 == 0:
-    #         torch_input[..., i] = 0.25
-    #     else:
-    #         torch_input[..., i] = -0.25
-    # torch_input = (1 / 1024) * torch.ones((L, in0_num_cores, 2, M, K), dtype=torch.bfloat16)
     torch_input = torch.rand((L, 2, M, K), dtype=torch.bfloat16) - 0.5
     torch_input = torch_input.unsqueeze(1).repeat(1, in0_num_cores, 1, 1, 1)
     return torch_input
@@ -76,19 +57,6 @@ def create_torch_w0(L, E, K, N):
     Returns:
         torch_w0: Tensor of shape (L, E, K, N)
     """
-    # torch_w0 = torch.empty((L, E, K, N), dtype=torch.bfloat16)
-    # le_val = 1
-    # for l in range(L):
-    #     for e in range(E):
-    #         for k_chunk in range(K // 32):
-    #             k_start, k_end = k_chunk * 32, k_chunk * 32 + 32
-    #             k_val = k_chunk * 0.001
-    #             for n_chunk in range(N // 32):
-    #                 n_start, n_end = n_chunk * 32, n_chunk * 32 + 32
-    #                 n_val = n_chunk
-    #                 torch_w0[l, e, k_start:k_end, n_start:n_end] = (n_val + k_val) * le_val
-    #         le_val *= -1
-
     torch_w0 = torch.rand((L, E, K, N), dtype=torch.bfloat16) - 0.5
     return torch_w0
 
@@ -106,19 +74,6 @@ def create_torch_w1(L, E, K, N):
     Returns:
         torch_w1: Tensor of shape (L, E, K, N)
     """
-    # torch_w1 = torch.empty((L, E, K, N), dtype=torch.bfloat16)
-    # le_val = -1
-    # for l in range(L):
-    #     for e in range(E):
-    #         for k_chunk in range(K // 32):
-    #             k_start, k_end = k_chunk * 32, k_chunk * 32 + 32
-    #             k_val = k_chunk * 0.001
-    #             for n_chunk in range(N // 32):
-    #                 n_start, n_end = n_chunk * 32, n_chunk * 32 + 32
-    #                 n_val = n_chunk
-    #                 torch_w1[l, e, k_start:k_end, n_start:n_end] = (n_val + k_val) * le_val
-    #         le_val *= -1
-
     torch_w1 = torch.rand((L, E, K, N), dtype=torch.bfloat16) - 0.5
     return torch_w1
 
@@ -136,18 +91,6 @@ def create_torch_w2(L, E, N, K):
     Returns:
         torch_w2: Tensor of shape (L, E, N, K)
     """
-    # torch_w2 = torch.empty((L, E, N, K), dtype=torch.bfloat16)
-    # le_val = 1
-    # for l in range(L):
-    #     for e in range(E):
-    #         for n_chunk in range(N // 32):
-    #             n_start, n_end = n_chunk * 32, n_chunk * 32 + 32
-    #             n_val = 0.001 * n_chunk
-    #             for k_chunk in range(K // 32):
-    #                 k_start, k_end = k_chunk * 32, k_chunk * 32 + 32
-    #                 k_val = k_chunk
-    #                 torch_w2[l, e, n_start:n_end, k_start:k_end] = (n_val + k_val) * le_val
-    #         le_val *= -1
     torch_w2 = torch.rand((L, E, N, K), dtype=torch.bfloat16) - 0.5
     return torch_w2
 

--- a/tests/ttnn/nightly/unit_tests/operations/experimental/test_swiglu.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/test_swiglu.py
@@ -1,0 +1,193 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Standalone SwiGLU activation correctness test for GPT-OSS MoE.
+
+Tests the SwiGLU activation formula:
+    gate_clamped = clamp(gate, max=7.0)
+    up_clamped   = clamp(up, min=-7.0, max=7.0)
+    result       = (up_clamped + 1) * gate_clamped * sigmoid(alpha * gate_clamped)
+
+where alpha = 1.702.
+
+This test validates:
+1. The PyTorch reference implementation is correct
+2. The TT device implementation matches the reference (via the full MOE op)
+"""
+
+import itertools
+import math
+import pytest
+import torch
+import ttnn
+from loguru import logger
+
+from models.common.utility_functions import comp_pcc
+
+
+# ---------------------------------------------------------------------------
+# Reference implementation
+# ---------------------------------------------------------------------------
+def swiglu_reference(gate, up, alpha=1.702, clamp_limit=7.0):
+    """
+    PyTorch reference for GPT-OSS SwiGLU.
+
+    Args:
+        gate: Gate projection output (W0 @ input)
+        up: Up projection output (W1 @ input)
+        alpha: Sigmoid scaling factor (default: 1.702 for GPT-OSS)
+        clamp_limit: Symmetric clamp bound (default: 7.0 for GPT-OSS)
+
+    Returns:
+        SwiGLU activated tensor
+    """
+    gate = torch.clamp(gate, max=clamp_limit)
+    up = torch.clamp(up, min=-clamp_limit, max=clamp_limit)
+    up_plus_1 = up + 1.0
+    glu = gate * torch.sigmoid(alpha * gate)
+    return up_plus_1 * glu
+
+
+# ---------------------------------------------------------------------------
+# Pure PyTorch reference tests (no hardware needed)
+# ---------------------------------------------------------------------------
+class TestSwiGLUReference:
+    """Tests for the PyTorch SwiGLU reference implementation."""
+
+    def test_basic_values(self):
+        """SwiGLU with known values."""
+        gate = torch.tensor([0.0, 1.0, -1.0, 0.5], dtype=torch.float32)
+        up = torch.tensor([0.0, 1.0, -1.0, 0.5], dtype=torch.float32)
+        result = swiglu_reference(gate, up)
+
+        # gate=0: clamp(0)=0, sigmoid(0)=0.5, 0*0.5=0, (up+1)*0 = 0
+        assert result[0].item() == pytest.approx(0.0, abs=1e-6)
+
+        # gate=1: clamp(1)=1, sigmoid(1.702)~0.846, 1*0.846=0.846, (1+1)*0.846 = 1.692
+        expected_1 = 2.0 * 1.0 * torch.sigmoid(torch.tensor(1.702)).item()
+        assert result[1].item() == pytest.approx(expected_1, rel=1e-4)
+
+    def test_clamping_gate(self):
+        """Gate values above clamp_limit should be clamped."""
+        gate = torch.tensor([10.0, 7.0, 6.9], dtype=torch.float32)
+        up = torch.tensor([0.0, 0.0, 0.0], dtype=torch.float32)  # up+1 = 1
+
+        result = swiglu_reference(gate, up)
+
+        # gate=10 clamped to 7, gate=7 stays, gate=6.9 stays
+        # up=0 -> up+1 = 1 -> result = gate_clamped * sigmoid(alpha * gate_clamped)
+        r_7 = 7.0 * torch.sigmoid(torch.tensor(1.702 * 7.0)).item()
+        r_69 = 6.9 * torch.sigmoid(torch.tensor(1.702 * 6.9)).item()
+
+        assert result[0].item() == pytest.approx(r_7, rel=1e-4), "gate=10 should be clamped to 7"
+        assert result[1].item() == pytest.approx(r_7, rel=1e-4), "gate=7 should stay at 7"
+        assert result[2].item() == pytest.approx(r_69, rel=1e-4), "gate=6.9 should stay at 6.9"
+
+    def test_clamping_up(self):
+        """Up values should be clamped symmetrically."""
+        gate = torch.tensor([1.0, 1.0, 1.0, 1.0], dtype=torch.float32)
+        up = torch.tensor([10.0, -10.0, 7.0, -7.0], dtype=torch.float32)
+
+        result = swiglu_reference(gate, up)
+
+        g = 1.0 * torch.sigmoid(torch.tensor(1.702)).item()  # gate part
+        # up=10 clamped to 7 -> (7+1)*g = 8*g
+        # up=-10 clamped to -7 -> (-7+1)*g = -6*g
+        # up=7 -> (7+1)*g = 8*g
+        # up=-7 -> (-7+1)*g = -6*g
+        assert result[0].item() == pytest.approx(8.0 * g, rel=1e-4)
+        assert result[1].item() == pytest.approx(-6.0 * g, rel=1e-4)
+        assert result[2].item() == pytest.approx(8.0 * g, rel=1e-4)
+        assert result[3].item() == pytest.approx(-6.0 * g, rel=1e-4)
+
+    def test_bfloat16_range(self):
+        """SwiGLU should work with bfloat16 typical values."""
+        torch.manual_seed(42)
+        gate = torch.randn(1, 1, 32, 32, dtype=torch.bfloat16)
+        up = torch.randn(1, 1, 32, 32, dtype=torch.bfloat16)
+
+        result = swiglu_reference(gate.float(), up.float())
+        result_bf16 = swiglu_reference(gate, up)
+
+        # Check PCC between float32 and bfloat16 computation
+        pcc = comp_pcc(result.bfloat16(), result_bf16)[0]
+        assert pcc, f"BF16 PCC too low: {pcc}"
+
+    def test_shape_preservation(self):
+        """Output shape should match input shapes."""
+        for shape in [(1, 1, 32, 32), (2, 4, 32, 64), (1, 1, 32, 2048)]:
+            gate = torch.randn(shape, dtype=torch.float32)
+            up = torch.randn(shape, dtype=torch.float32)
+            result = swiglu_reference(gate, up)
+            assert result.shape == gate.shape, f"Shape mismatch for {shape}"
+
+    def test_vs_silu(self):
+        """SwiGLU with alpha=1, no clamp, and up=0 should NOT equal SiLU (different formula)."""
+        x = torch.randn(32, dtype=torch.float32)
+
+        # SiLU: x * sigmoid(x)
+        silu_result = torch.nn.functional.silu(x)
+
+        # SwiGLU with alpha=1, no clamp, up=0: (0+1) * x * sigmoid(1*x) = x * sigmoid(x)
+        swiglu_result = swiglu_reference(x, torch.zeros_like(x), alpha=1.0, clamp_limit=float("inf"))
+
+        # These SHOULD be equal when alpha=1, up=0, no clamp
+        assert torch.allclose(silu_result, swiglu_result, atol=1e-6), "SwiGLU(alpha=1, up=0) should equal SiLU"
+
+
+# ---------------------------------------------------------------------------
+# Integration test: run through the MOE op on device
+# ---------------------------------------------------------------------------
+# This imports the MOE test infrastructure and runs a minimal config
+# to verify the SwiGLU activation on actual hardware.
+import sys
+import os
+
+sys.path.insert(0, os.path.dirname(__file__))
+from test_moe import run_test_moe
+
+PCC_THRESHOLD = 0.95  # Relaxed threshold for initial bring-up
+
+
+@pytest.mark.parametrize(
+    "device_params",
+    [
+        pytest.param(
+            {
+                "dispatch_core_axis": ttnn.DispatchCoreAxis.ROW,
+            },
+            id="dispatch_row",
+        )
+    ],
+    indirect=True,
+)
+@pytest.mark.parametrize(
+    "M, K, N, E, L",
+    [(32, 7168, 2048, 2, 1)],
+    ids=["M=32-K=7168-N=2048-E=2-L=1"],
+)
+def test_swiglu_via_moe(device, M, K, N, E, L):
+    """
+    Test SwiGLU activation by running it through the full MOE kernel.
+
+    Uses the MOE test infrastructure with check_accuracy=True to verify
+    that the SwiGLU output matches the PyTorch reference.
+    """
+    accuracy_metrics = run_test_moe(
+        device,
+        M,
+        K,
+        N,
+        E,
+        L,
+        check_accuracy=True,
+        dump_outputs=False,
+    )
+
+    for (layer_id, expert_id), metrics in accuracy_metrics.items():
+        pcc_value = metrics.get("pcc", 0.0)
+        logger.info(f"Layer {layer_id}, Expert {expert_id}: PCC = {pcc_value:.6f}")
+        assert (
+            pcc_value >= PCC_THRESHOLD
+        ), f"PCC too low for layer {layer_id}, expert {expert_id}: {pcc_value:.6f} < {PCC_THRESHOLD}"

--- a/tests/ttnn/nightly/unit_tests/operations/experimental/test_swiglu.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/test_swiglu.py
@@ -2,22 +2,18 @@
 # SPDX-License-Identifier: Apache-2.0
 
 """
-Standalone SwiGLU activation correctness test for GPT-OSS MoE.
+Standalone SwiGLU SFPU accuracy test.
 
-Tests the SwiGLU activation formula:
+Tests the SwiGLU activation kernel in isolation, without matmul or weight
+quantization, by feeding bf16 gate/up tiles directly through the SFPU and
+comparing against a PyTorch reference.
+
+Formula:
     gate_clamped = clamp(gate, max=7.0)
     up_clamped   = clamp(up, min=-7.0, max=7.0)
-    result       = (up_clamped + 1) * gate_clamped * sigmoid(alpha * gate_clamped)
-
-where alpha = 1.702.
-
-This test validates:
-1. The PyTorch reference implementation is correct
-2. The TT device implementation matches the reference (via the full MOE op)
+    result       = (up_clamped + 1) * gate_clamped * sigmoid(1.702 * gate_clamped)
 """
 
-import itertools
-import math
 import pytest
 import torch
 import ttnn
@@ -27,167 +23,197 @@ from models.common.utility_functions import comp_pcc
 
 
 # ---------------------------------------------------------------------------
-# Reference implementation
+# Reference
 # ---------------------------------------------------------------------------
 def swiglu_reference(gate, up, alpha=1.702, clamp_limit=7.0):
-    """
-    PyTorch reference for GPT-OSS SwiGLU.
-
-    Args:
-        gate: Gate projection output (W0 @ input)
-        up: Up projection output (W1 @ input)
-        alpha: Sigmoid scaling factor (default: 1.702 for GPT-OSS)
-        clamp_limit: Symmetric clamp bound (default: 7.0 for GPT-OSS)
-
-    Returns:
-        SwiGLU activated tensor
-    """
     gate = torch.clamp(gate, max=clamp_limit)
     up = torch.clamp(up, min=-clamp_limit, max=clamp_limit)
-    up_plus_1 = up + 1.0
-    glu = gate * torch.sigmoid(alpha * gate)
-    return up_plus_1 * glu
+    return (up + 1.0) * gate * torch.sigmoid(alpha * gate)
 
 
 # ---------------------------------------------------------------------------
-# Pure PyTorch reference tests (no hardware needed)
+# Standalone SFPU test via generic_op
 # ---------------------------------------------------------------------------
-class TestSwiGLUReference:
-    """Tests for the PyTorch SwiGLU reference implementation."""
+# Inline reader kernel: reads gate tiles into CB0 and up tiles into CB1
+# from two DRAM-interleaved tensors.
+BINARY_READER_SOURCE = r"""
+#include "api/dataflow/dataflow_api.h"
 
-    def test_basic_values(self):
-        """SwiGLU with known values."""
-        gate = torch.tensor([0.0, 1.0, -1.0, 0.5], dtype=torch.float32)
-        up = torch.tensor([0.0, 1.0, -1.0, 0.5], dtype=torch.float32)
-        result = swiglu_reference(gate, up)
+void kernel_main() {
+    const uint32_t gate_addr = get_arg_val<uint32_t>(0);
+    const uint32_t up_addr   = get_arg_val<uint32_t>(1);
+    const uint32_t num_tiles = get_arg_val<uint32_t>(2);
+    const uint32_t start_id  = get_arg_val<uint32_t>(3);
 
-        # gate=0: clamp(0)=0, sigmoid(0)=0.5, 0*0.5=0, (up+1)*0 = 0
-        assert result[0].item() == pytest.approx(0.0, abs=1e-6)
+    constexpr auto gate_args = TensorAccessorArgs<0>();
+    constexpr auto up_args   = TensorAccessorArgs<gate_args.next_compile_time_args_offset()>();
 
-        # gate=1: clamp(1)=1, sigmoid(1.702)~0.846, 1*0.846=0.846, (1+1)*0.846 = 1.692
-        expected_1 = 2.0 * 1.0 * torch.sigmoid(torch.tensor(1.702)).item()
-        assert result[1].item() == pytest.approx(expected_1, rel=1e-4)
+    constexpr uint32_t cb_gate = 0;
+    constexpr uint32_t cb_up   = 1;
 
-    def test_clamping_gate(self):
-        """Gate values above clamp_limit should be clamped."""
-        gate = torch.tensor([10.0, 7.0, 6.9], dtype=torch.float32)
-        up = torch.tensor([0.0, 0.0, 0.0], dtype=torch.float32)  # up+1 = 1
+    const uint32_t gate_page_bytes = get_tile_size(cb_gate);
+    const uint32_t up_page_bytes   = get_tile_size(cb_up);
 
-        result = swiglu_reference(gate, up)
+    const auto gate_s = TensorAccessor(gate_args, gate_addr, gate_page_bytes);
+    const auto up_s   = TensorAccessor(up_args,   up_addr,   up_page_bytes);
 
-        # gate=10 clamped to 7, gate=7 stays, gate=6.9 stays
-        # up=0 -> up+1 = 1 -> result = gate_clamped * sigmoid(alpha * gate_clamped)
-        r_7 = 7.0 * torch.sigmoid(torch.tensor(1.702 * 7.0)).item()
-        r_69 = 6.9 * torch.sigmoid(torch.tensor(1.702 * 6.9)).item()
+    uint32_t end_id = start_id + num_tiles;
+    for (uint32_t i = start_id; i < end_id; ++i) {
+        cb_reserve_back(cb_gate, 1);
+        noc_async_read_page(i, gate_s, get_write_ptr(cb_gate));
+        noc_async_read_barrier();
+        cb_push_back(cb_gate, 1);
 
-        assert result[0].item() == pytest.approx(r_7, rel=1e-4), "gate=10 should be clamped to 7"
-        assert result[1].item() == pytest.approx(r_7, rel=1e-4), "gate=7 should stay at 7"
-        assert result[2].item() == pytest.approx(r_69, rel=1e-4), "gate=6.9 should stay at 6.9"
+        cb_reserve_back(cb_up, 1);
+        noc_async_read_page(i, up_s, get_write_ptr(cb_up));
+        noc_async_read_barrier();
+        cb_push_back(cb_up, 1);
+    }
+}
+"""
 
-    def test_clamping_up(self):
-        """Up values should be clamped symmetrically."""
-        gate = torch.tensor([1.0, 1.0, 1.0, 1.0], dtype=torch.float32)
-        up = torch.tensor([10.0, -10.0, 7.0, -7.0], dtype=torch.float32)
+# Path to the compute kernel (lives next to swiglu_sfpu.h so the include resolves)
+COMPUTE_KERNEL_PATH = "ttnn/cpp/ttnn/operations/experimental/moe/device/kernels/test_swiglu_compute.cpp"
 
-        result = swiglu_reference(gate, up)
+# Reuse the standard unary writer
+WRITER_KERNEL_PATH = (
+    "ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/writer_unary_interleaved_start_id.cpp"
+)
 
-        g = 1.0 * torch.sigmoid(torch.tensor(1.702)).item()  # gate part
-        # up=10 clamped to 7 -> (7+1)*g = 8*g
-        # up=-10 clamped to -7 -> (-7+1)*g = -6*g
-        # up=7 -> (7+1)*g = 8*g
-        # up=-7 -> (-7+1)*g = -6*g
-        assert result[0].item() == pytest.approx(8.0 * g, rel=1e-4)
-        assert result[1].item() == pytest.approx(-6.0 * g, rel=1e-4)
-        assert result[2].item() == pytest.approx(8.0 * g, rel=1e-4)
-        assert result[3].item() == pytest.approx(-6.0 * g, rel=1e-4)
-
-    def test_bfloat16_range(self):
-        """SwiGLU should work with bfloat16 typical values."""
-        torch.manual_seed(42)
-        gate = torch.randn(1, 1, 32, 32, dtype=torch.bfloat16)
-        up = torch.randn(1, 1, 32, 32, dtype=torch.bfloat16)
-
-        result = swiglu_reference(gate.float(), up.float())
-        result_bf16 = swiglu_reference(gate, up)
-
-        # Check PCC between float32 and bfloat16 computation
-        pcc = comp_pcc(result.bfloat16(), result_bf16)[0]
-        assert pcc, f"BF16 PCC too low: {pcc}"
-
-    def test_shape_preservation(self):
-        """Output shape should match input shapes."""
-        for shape in [(1, 1, 32, 32), (2, 4, 32, 64), (1, 1, 32, 2048)]:
-            gate = torch.randn(shape, dtype=torch.float32)
-            up = torch.randn(shape, dtype=torch.float32)
-            result = swiglu_reference(gate, up)
-            assert result.shape == gate.shape, f"Shape mismatch for {shape}"
-
-    def test_vs_silu(self):
-        """SwiGLU with alpha=1, no clamp, and up=0 should NOT equal SiLU (different formula)."""
-        x = torch.randn(32, dtype=torch.float32)
-
-        # SiLU: x * sigmoid(x)
-        silu_result = torch.nn.functional.silu(x)
-
-        # SwiGLU with alpha=1, no clamp, up=0: (0+1) * x * sigmoid(1*x) = x * sigmoid(x)
-        swiglu_result = swiglu_reference(x, torch.zeros_like(x), alpha=1.0, clamp_limit=float("inf"))
-
-        # These SHOULD be equal when alpha=1, up=0, no clamp
-        assert torch.allclose(silu_result, swiglu_result, atol=1e-6), "SwiGLU(alpha=1, up=0) should equal SiLU"
+# bf16 tile page size
+BF16_TILE_PAGE_SIZE = 2 * 1024  # 32 x 32 x 2 bytes
 
 
-# ---------------------------------------------------------------------------
-# Integration test: run through the MOE op on device
-# ---------------------------------------------------------------------------
-# This imports the MOE test infrastructure and runs a minimal config
-# to verify the SwiGLU activation on actual hardware.
-import sys
-import os
+def run_swiglu_sfpu_test(device, num_tiles):
+    """
+    Run the SwiGLU SFPU in isolation on device and compare against PyTorch.
 
-sys.path.insert(0, os.path.dirname(__file__))
-from test_moe import run_test_moe
+    Creates bf16 gate and up tensors, feeds them through the standalone
+    SwiGLU compute kernel (no matmul, no weight quantization), and checks
+    PCC against the reference.
+    """
+    shape = [1, num_tiles, 32, 32]
 
-PCC_THRESHOLD = 0.95  # Relaxed threshold for initial bring-up
+    # Create random bf16 inputs in a range that exercises clamping
+    torch.manual_seed(42)
+    torch_gate = (torch.randn(shape) * 4.0).to(torch.bfloat16)  # some values > 7
+    torch_up = (torch.randn(shape) * 4.0).to(torch.bfloat16)  # some values outside [-7, 7]
+
+    # PyTorch reference (in float32 for precision)
+    torch_ref = swiglu_reference(torch_gate.float(), torch_up.float())
+
+    # Send to device
+    dram_config = ttnn.DRAM_MEMORY_CONFIG
+    gate_tensor = ttnn.from_torch(
+        torch_gate, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device, memory_config=dram_config
+    )
+    up_tensor = ttnn.from_torch(
+        torch_up, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device, memory_config=dram_config
+    )
+    output_tensor = ttnn.allocate_tensor_on_device(
+        ttnn.Shape(shape), ttnn.bfloat16, ttnn.TILE_LAYOUT, device, dram_config
+    )
+
+    # ---- Core grid: single core for simplicity ----
+    core = ttnn.CoreCoord(0, 0)
+    core_range = ttnn.CoreRangeSet([ttnn.CoreRange(core, core)])
+
+    # ---- Circular buffers ----
+    cb_total_size = 2 * BF16_TILE_PAGE_SIZE  # double buffer
+
+    gate_cb_format = ttnn.CBFormatDescriptor(buffer_index=0, data_format=ttnn.bfloat16, page_size=BF16_TILE_PAGE_SIZE)
+    up_cb_format = ttnn.CBFormatDescriptor(buffer_index=1, data_format=ttnn.bfloat16, page_size=BF16_TILE_PAGE_SIZE)
+    out_cb_format = ttnn.CBFormatDescriptor(buffer_index=16, data_format=ttnn.bfloat16, page_size=BF16_TILE_PAGE_SIZE)
+
+    gate_cb = ttnn.CBDescriptor(total_size=cb_total_size, core_ranges=core_range, format_descriptors=[gate_cb_format])
+    up_cb = ttnn.CBDescriptor(total_size=cb_total_size, core_ranges=core_range, format_descriptors=[up_cb_format])
+    out_cb = ttnn.CBDescriptor(total_size=cb_total_size, core_ranges=core_range, format_descriptors=[out_cb_format])
+
+    # ---- Reader kernel (inline source, reads two tensors) ----
+    gate_cta = list(ttnn.TensorAccessorArgs(gate_tensor).get_compile_time_args())
+    up_cta = list(ttnn.TensorAccessorArgs(up_tensor).get_compile_time_args())
+    reader_compile_time_args = gate_cta + up_cta
+
+    reader_rt_args = ttnn.RuntimeArgs()
+    reader_rt_args[0][0] = [gate_tensor.buffer_address(), up_tensor.buffer_address(), num_tiles, 0]
+
+    reader_kernel = ttnn.KernelDescriptor(
+        kernel_source=BINARY_READER_SOURCE,
+        source_type=ttnn.KernelDescriptor.SourceType.SOURCE_CODE,
+        core_ranges=core_range,
+        compile_time_args=reader_compile_time_args,
+        runtime_args=reader_rt_args,
+        config=ttnn.ReaderConfigDescriptor(),
+    )
+
+    # ---- Writer kernel (reuse standard unary writer) ----
+    writer_compile_time_args = [16]  # output CB index
+    writer_compile_time_args.extend(list(ttnn.TensorAccessorArgs(output_tensor).get_compile_time_args()))
+
+    writer_rt_args = ttnn.RuntimeArgs()
+    writer_rt_args[0][0] = [output_tensor.buffer_address(), num_tiles, 0]
+
+    writer_kernel = ttnn.KernelDescriptor(
+        kernel_source=WRITER_KERNEL_PATH,
+        source_type=ttnn.KernelDescriptor.SourceType.FILE_PATH,
+        core_ranges=core_range,
+        compile_time_args=writer_compile_time_args,
+        runtime_args=writer_rt_args,
+        config=ttnn.WriterConfigDescriptor(),
+    )
+
+    # ---- Compute kernel (SwiGLU SFPU) ----
+    compute_kernel = ttnn.KernelDescriptor(
+        kernel_source=COMPUTE_KERNEL_PATH,
+        source_type=ttnn.KernelDescriptor.SourceType.FILE_PATH,
+        core_ranges=core_range,
+        compile_time_args=[num_tiles],
+        defines=[],
+        runtime_args=[],
+        config=ttnn.ComputeConfigDescriptor(math_approx_mode=True),
+    )
+
+    # ---- Program descriptor ----
+    program = ttnn.ProgramDescriptor(
+        kernels=[reader_kernel, writer_kernel, compute_kernel],
+        semaphores=[],
+        cbs=[gate_cb, up_cb, out_cb],
+    )
+
+    # ---- Execute ----
+    io_tensors = [gate_tensor, up_tensor, output_tensor]
+    result = ttnn.generic_op(io_tensors, program)
+
+    # ---- Compare ----
+    torch_output = ttnn.to_torch(result)
+
+    passing, pcc_value = comp_pcc(torch_ref, torch_output)
+
+    return passing, pcc_value
+
+
+PCC_THRESHOLD = 0.999  # High threshold: no weight quantization error
 
 
 @pytest.mark.parametrize(
     "device_params",
     [
         pytest.param(
-            {
-                "dispatch_core_axis": ttnn.DispatchCoreAxis.ROW,
-            },
+            {"dispatch_core_axis": ttnn.DispatchCoreAxis.ROW},
             id="dispatch_row",
         )
     ],
     indirect=True,
 )
-@pytest.mark.parametrize(
-    "M, K, N, E, L",
-    [(32, 7168, 2048, 2, 1)],
-    ids=["M=32-K=7168-N=2048-E=2-L=1"],
-)
-def test_swiglu_via_moe(device, M, K, N, E, L):
+@pytest.mark.parametrize("num_tiles", [1, 4, 16], ids=["1tile", "4tiles", "16tiles"])
+def test_swiglu_sfpu(device, num_tiles):
     """
-    Test SwiGLU activation by running it through the full MOE kernel.
+    Test SwiGLU SFPU in isolation.
 
-    Uses the MOE test infrastructure with check_accuracy=True to verify
-    that the SwiGLU output matches the PyTorch reference.
+    Feeds bf16 gate/up tiles directly through the SFPU kernel (no matmul,
+    no weight quantization) and compares against PyTorch reference.
+    Expects PCC > 0.999 since the only error source is bf16 SFPU precision.
     """
-    accuracy_metrics = run_test_moe(
-        device,
-        M,
-        K,
-        N,
-        E,
-        L,
-        check_accuracy=True,
-        dump_outputs=False,
-    )
-
-    for (layer_id, expert_id), metrics in accuracy_metrics.items():
-        pcc_value = metrics.get("pcc", 0.0)
-        logger.info(f"Layer {layer_id}, Expert {expert_id}: PCC = {pcc_value:.6f}")
-        assert (
-            pcc_value >= PCC_THRESHOLD
-        ), f"PCC too low for layer {layer_id}, expert {expert_id}: {pcc_value:.6f} < {PCC_THRESHOLD}"
+    passing, pcc_value = run_swiglu_sfpu_test(device, num_tiles)
+    logger.info(f"SwiGLU SFPU standalone ({num_tiles} tiles): PCC = {pcc_value}")
+    assert pcc_value >= PCC_THRESHOLD, f"PCC {pcc_value} < {PCC_THRESHOLD}"

--- a/ttnn/cpp/ttnn/operations/experimental/moe/device/kernels/compute.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/moe/device/kernels/compute.cpp
@@ -11,9 +11,7 @@
 
 // Need these headers for running SFPU on PACK thread
 #ifdef TRISC_PACK
-#include "ckernel_sfpu_exp.h"
-#include "llk_math_eltwise_unary_sfpu_silu.h"
-#include "llk_math_eltwise_binary_sfpu_binop.h"
+#include "swiglu_sfpu.h"
 #endif
 
 void kernel_main() {
@@ -104,8 +102,8 @@ void kernel_main() {
     // Initialize matmul for W0
     mm_block_init(cb_s2c_in, cb_r2c_w0_w1, cb_s2c_in2, /*transpose=*/false, /*ct_dim=*/4, /*rt_dim=*/1, /*kt_dim=*/1);
 
-    // Initialize SFPU for SILU and eltwise multiply
-    PACK((llk_math_eltwise_unary_sfpu_silu_init<true>()));
+    // Initialize SFPU for GPT-OSS SwiGLU activation
+    PACK((llk_math_eltwise_binary_sfpu_swiglu_init<true>()));
 
     //-------------------------------------------------------------------------
     // Expert loop
@@ -151,13 +149,12 @@ void kernel_main() {
             PACK(TT_SETC16(DEST_TARGET_REG_CFG_MATH_Offset_ADDR32, ckernel::packer::get_packer_dest_offset()));
 
             //---------------------------------------------------------------------
-            // Apply SILU activation and then eltwise multiply
+            // Apply GPT-OSS SwiGLU activation
+            // SwiGLU: (clamp(up)+1) * clamp(gate) * sigmoid(alpha * clamp(gate))
+            // Dest layout: [gate0, up0, gate1, up1] at tile indices [0, 1, 2, 3]
             //---------------------------------------------------------------------
-            PACK((llk_math_eltwise_unary_sfpu_silu<true, false>(0)));
-            PACK((llk_math_eltwise_unary_sfpu_silu<true, false>(2)));
-
-            PACK((llk_math_eltwise_binary_sfpu_binop<true, ckernel::BinaryOp::MUL>(0, 1, 0)));
-            PACK((llk_math_eltwise_binary_sfpu_binop<true, ckernel::BinaryOp::MUL>(2, 3, 2)));
+            PACK((llk_math_eltwise_binary_sfpu_swiglu<true, false>(0, 1, 0)));
+            PACK((llk_math_eltwise_binary_sfpu_swiglu<true, false>(2, 3, 2)));
 
             PACK(TTI_STALLWAIT(p_stall::STALL_PACK, p_stall::WAIT_SFPU));
 

--- a/ttnn/cpp/ttnn/operations/experimental/moe/device/kernels/swiglu_sfpu.h
+++ b/ttnn/cpp/ttnn/operations/experimental/moe/device/kernels/swiglu_sfpu.h
@@ -1,0 +1,136 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+//=============================================================================
+// GPT-OSS SwiGLU Activation for SFPU (runs on PACK thread)
+//
+// Formula:
+//   gate_clamped = clamp(gate, max=clamp_limit)
+//   up_clamped   = clamp(up, min=-clamp_limit, max=clamp_limit)
+//   result       = (up_clamped + 1) * gate_clamped * sigmoid(alpha * gate_clamped)
+//
+// Usage:
+//   // With default GPT-OSS config (alpha=1.702, clamp_limit=7.0):
+//   PACK((llk_math_eltwise_binary_sfpu_swiglu_init<true>()));
+//   PACK((llk_math_eltwise_binary_sfpu_swiglu<true, false>(gate, up, out)));
+//
+//   // With custom config:
+//   struct MyConfig { static constexpr float alpha = 1.0f; static constexpr float clamp_limit = 5.0f; };
+//   PACK((llk_math_eltwise_binary_sfpu_swiglu_init<true>()));
+//   PACK((llk_math_eltwise_binary_sfpu_swiglu<true, false, MyConfig>(gate, up, out)));
+//
+// This header is designed to be reusable across different models.
+// Include it from a compute kernel that runs SFPU on the PACK thread.
+//=============================================================================
+
+#ifdef TRISC_PACK
+
+#include "ckernel_sfpu_exp.h"
+#include "ckernel_sfpu_recip.h"
+#include "llk_math_eltwise_binary_sfpu_init.h"
+#include "llk_math_eltwise_binary_sfpu_params.h"
+
+namespace ckernel::sfpu {
+
+//-----------------------------------------------------------------------------
+// Configuration structs - add new models here
+//-----------------------------------------------------------------------------
+struct SwiGLUConfigGPTOSS {
+    static constexpr float alpha = 1.702f;
+    static constexpr float clamp_limit = 7.0f;
+};
+
+//-----------------------------------------------------------------------------
+// Sigmoid: sigmoid(x) = 1 / (1 + exp(-x))
+// Precision level matches dest accumulation mode.
+//-----------------------------------------------------------------------------
+template <bool is_fp32_dest_acc_en>
+sfpi_inline sfpi::vFloat _swiglu_sigmoid_(sfpi::vFloat x) {
+    sfpi::vFloat exp_neg_x;
+    if constexpr (is_fp32_dest_acc_en) {
+        exp_neg_x = _sfpu_exp_improved_<true>(-x);
+    } else {
+        exp_neg_x = _sfpu_exp_21f_<true>(-x);
+    }
+    sfpi::vFloat denominator = sfpi::vConst1 + exp_neg_x;
+    if constexpr (is_fp32_dest_acc_en) {
+        return _sfpu_reciprocal_<2>(denominator);
+    } else {
+        return _sfpu_reciprocal_<1>(denominator);
+    }
+}
+
+//-----------------------------------------------------------------------------
+// Core SwiGLU computation
+//-----------------------------------------------------------------------------
+template <bool is_fp32_dest_acc_en, int ITERATIONS = 8, class Config = SwiGLUConfigGPTOSS>
+inline void calculate_swiglu(const uint gate_tile_idx, const uint up_tile_idx, const uint out_tile_idx) {
+    constexpr float alpha = Config::alpha;
+    constexpr float clamp_limit = Config::clamp_limit;
+
+    constexpr uint dst_tile_size = 32;  // 32 rows per tile in SFPU addressing
+
+    for (int d = 0; d < ITERATIONS; d++) {
+        sfpi::vFloat gate = sfpi::dst_reg[gate_tile_idx * dst_tile_size];
+        sfpi::vFloat up = sfpi::dst_reg[up_tile_idx * dst_tile_size];
+
+        // Clamp gate: clamp(gate, max=clamp_limit)
+        v_if(gate > clamp_limit) { gate = clamp_limit; }
+        v_endif;
+
+        // Clamp up: clamp(up, min=-clamp_limit, max=clamp_limit)
+        v_if(up > clamp_limit) { up = clamp_limit; }
+        v_endif;
+        v_if(up < -clamp_limit) { up = -clamp_limit; }
+        v_endif;
+
+        // up = up + 1
+        up = up + sfpi::vConst1;
+
+        // sigmoid(alpha * gate)
+        sfpi::vFloat alpha_gate = gate * alpha;
+        sfpi::vFloat sig = _swiglu_sigmoid_<is_fp32_dest_acc_en>(alpha_gate);
+
+        // result = (up + 1) * gate * sigmoid(alpha * gate)
+        // Compute gate*sig first (bounded range, similar to SiLU), then multiply by up.
+        sfpi::vFloat glu = gate * sig;
+        sfpi::vFloat result = up * glu;
+
+        // Round to bf16 if not in fp32 dest accumulation mode
+        if constexpr (!is_fp32_dest_acc_en) {
+            result = sfpi::reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(result, 0));
+        }
+
+        sfpi::dst_reg[out_tile_idx * dst_tile_size] = result;
+        sfpi::dst_reg++;
+    }
+}
+
+template <bool APPROXIMATION_MODE>
+inline void swiglu_init() {
+    // SwiGLU uses sigmoid internally, which needs reciprocal table init.
+    _init_reciprocal_<false, false>();
+}
+
+}  // namespace ckernel::sfpu
+
+namespace ckernel {
+
+template <bool APPROXIMATE>
+inline void llk_math_eltwise_binary_sfpu_swiglu_init() {
+    llk_math_eltwise_binary_sfpu_init<SfpuType::unused, APPROXIMATE>(ckernel::sfpu::swiglu_init<APPROXIMATE>);
+}
+
+template <bool APPROXIMATE, bool is_fp32_dest_acc_en = false, class Config = ckernel::sfpu::SwiGLUConfigGPTOSS>
+inline void llk_math_eltwise_binary_sfpu_swiglu(
+    uint gate_tile, uint32_t up_tile, uint32_t out_tile, int vector_mode = VectorMode::RC) {
+    _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
+        ckernel::sfpu::calculate_swiglu<is_fp32_dest_acc_en, 8, Config>, gate_tile, up_tile, out_tile, vector_mode);
+}
+
+}  // namespace ckernel
+
+#endif  // TRISC_PACK

--- a/ttnn/cpp/ttnn/operations/experimental/moe/device/kernels/swiglu_sfpu.h
+++ b/ttnn/cpp/ttnn/operations/experimental/moe/device/kernels/swiglu_sfpu.h
@@ -23,10 +23,10 @@
 //   PACK((llk_math_eltwise_binary_sfpu_swiglu<true, false, MyConfig>(gate, up, out)));
 //
 // This header is designed to be reusable across different models.
-// Include it from a compute kernel that runs SFPU on the PACK thread.
+// Include it from a compute kernel that runs SFPU on the PACK or MATH thread.
 //=============================================================================
 
-#ifdef TRISC_PACK
+#if defined(TRISC_PACK) || defined(TRISC_MATH)
 
 #include "ckernel_sfpu_exp.h"
 #include "ckernel_sfpu_recip.h"
@@ -133,4 +133,4 @@ inline void llk_math_eltwise_binary_sfpu_swiglu(
 
 }  // namespace ckernel
 
-#endif  // TRISC_PACK
+#endif  // TRISC_PACK || TRISC_MATH

--- a/ttnn/cpp/ttnn/operations/experimental/moe/device/kernels/test_swiglu_compute.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/moe/device/kernels/test_swiglu_compute.cpp
@@ -1,0 +1,56 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Standalone SwiGLU SFPU test kernel.
+//
+// Reads gate tiles from CB0 and up tiles from CB1, runs SwiGLU SFPU on the
+// MATH thread, and packs the result to CB16.
+
+#include "compute_kernel_api/common.h"
+#include "compute_kernel_api/tile_move_copy.h"
+#include "compute_kernel_api/eltwise_unary/eltwise_unary.h"
+
+#include "swiglu_sfpu.h"
+
+void kernel_main() {
+    constexpr uint32_t num_tiles = get_compile_time_arg_val(0);
+
+    constexpr auto cb_gate = tt::CBIndex::c_0;
+    constexpr auto cb_up = tt::CBIndex::c_1;
+    constexpr auto cb_out = tt::CBIndex::c_16;
+
+    // Init unpacker AND packer (init_sfpu configures both)
+    init_sfpu(cb_gate, cb_out);
+
+    // Init binary SFPU for SwiGLU
+    MATH((llk_math_eltwise_binary_sfpu_swiglu_init<true>()));
+
+    for (uint32_t t = 0; t < num_tiles; t++) {
+        tile_regs_acquire();
+
+        cb_wait_front(cb_gate, 1);
+        cb_wait_front(cb_up, 1);
+
+        // Copy gate tile from CB0 to dest[0]
+        copy_tile(cb_gate, 0, 0);
+
+        // Copy up tile from CB1 to dest[1]
+        copy_tile(cb_up, 0, 1);
+
+        // Run SwiGLU on MATH thread: result -> dest[0]
+        MATH((llk_math_eltwise_binary_sfpu_swiglu<true, false>(0, 1, 0)));
+
+        tile_regs_commit();
+        tile_regs_wait();
+
+        cb_reserve_back(cb_out, 1);
+        pack_tile(0, cb_out);
+        cb_push_back(cb_out, 1);
+
+        tile_regs_release();
+
+        cb_pop_front(cb_gate, 1);
+        cb_pop_front(cb_up, 1);
+    }
+}


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Provide context for the problem.

### What's changed
Describe the approach used to solve the problem.
Summarize the changes made and its impact.

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=sraizada/gpt-oss-swiglu)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:sraizada/gpt-oss-swiglu)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=sraizada/gpt-oss-swiglu)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:sraizada/gpt-oss-swiglu)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=sraizada/gpt-oss-swiglu)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:sraizada/gpt-oss-swiglu)
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=sraizada/gpt-oss-swiglu)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:sraizada/gpt-oss-swiglu)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=sraizada/gpt-oss-swiglu)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:sraizada/gpt-oss-swiglu)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=sraizada/gpt-oss-swiglu)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:sraizada/gpt-oss-swiglu)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
