### PR TITLE
Enable column-major CCL allocation for ring joint attention and change SDPA grid in Wan2.2

### DIFF
--- a/models/tt_dit/models/transformers/wan2_2/attention_wan.py
+++ b/models/tt_dit/models/transformers/wan2_2/attention_wan.py
@@ -120,7 +120,7 @@ class WanAttention(Module):
             exp_approx_mode=False,  # NOTE: False is more correct
         )
 
-        self.sdpa_worker_grid = (full_grid.x, full_grid.y - 1)
+        self.sdpa_worker_grid = (full_grid.x - 1, full_grid.y)  # Reserve last column for CCL
         ring_sdpa_chunk_size = self.sdpa_chunk_size_map.get(
             (
                 is_blackhole(),
@@ -348,7 +348,7 @@ class WanAttention(Module):
                     mesh_device=self.mesh_device,
                     topology=ttnn.Topology.Linear,  # RJA always uses Linear topology
                     subdevice_id=self.ccl_manager.ccl_sub_device_id,
-                    ccl_core_grid_offset=(0, self.sdpa_worker_grid[1]),
+                    ccl_core_grid_offset=(self.sdpa_worker_grid[0], 0),  # Place CCL in last column
                 )
             else:
                 spatial_BHNE = ttnn.transformer.scaled_dot_product_attention(

--- a/models/tt_dit/models/transformers/wan2_2/attention_wan.py
+++ b/models/tt_dit/models/transformers/wan2_2/attention_wan.py
@@ -349,6 +349,7 @@ class WanAttention(Module):
                     topology=ttnn.Topology.Linear,  # RJA always uses Linear topology
                     subdevice_id=self.ccl_manager.ccl_sub_device_id,
                     ccl_core_grid_offset=(self.sdpa_worker_grid[0], 0),  # Place CCL in last column
+                    use_column_major_ccl=True,  # WAN2.2 specific: use column-major CCL allocation
                 )
             else:
                 spatial_BHNE = ttnn.transformer.scaled_dot_product_attention(

--- a/ttnn/cpp/ttnn/operations/ccl/ccl_common.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/ccl_common.cpp
@@ -335,7 +335,8 @@ std::tuple<CoreRangeSet, std::vector<CoreCoord>> choose_worker_cores(
     IDevice* device,
     const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id,
     const CoreCoord core_grid_offset,
-    const std::optional<CoreRangeSet>& sub_core_grid) {
+    const std::optional<CoreRangeSet>& sub_core_grid,
+    CoreAllocationStrategy strategy) {
     std::tuple<CoreRangeSet, std::vector<CoreCoord>> result;
     CoreRangeSet sender_worker_core_range;
     const size_t num_workers_preferred = num_workers_per_link * num_links;
@@ -359,19 +360,39 @@ std::tuple<CoreRangeSet, std::vector<CoreCoord>> choose_worker_cores(
     for (const auto& cr : available_cores.ranges()) {
         auto start = cr.start_coord;
         auto end = cr.end_coord;
-        for (size_t y = start.y; y <= end.y; y++) {
+
+        if (strategy == CoreAllocationStrategy::COL_MAJOR) {
+            // Column-major allocation: fill columns first (outer loop x, inner loop y)
             for (size_t x = start.x; x <= end.x; x++) {
-                sender_worker_core_range = sender_worker_core_range.merge(CoreRangeSet(CoreRange(
-                    CoreCoord(x + core_grid_offset.x, y + core_grid_offset.y),
-                    CoreCoord(x + core_grid_offset.x, y + core_grid_offset.y))));
+                for (size_t y = start.y; y <= end.y; y++) {
+                    sender_worker_core_range = sender_worker_core_range.merge(CoreRangeSet(CoreRange(
+                        CoreCoord(x + core_grid_offset.x, y + core_grid_offset.y),
+                        CoreCoord(x + core_grid_offset.x, y + core_grid_offset.y))));
+                    if (sender_worker_core_range.num_cores() == num_workers_preferred) {
+                        break;
+                    }
+                }
                 if (sender_worker_core_range.num_cores() == num_workers_preferred) {
                     break;
                 }
             }
-            if (sender_worker_core_range.num_cores() == num_workers_preferred) {
-                break;
+        } else {
+            // Row-major allocation: fill rows first (outer loop y, inner loop x) - default behavior
+            for (size_t y = start.y; y <= end.y; y++) {
+                for (size_t x = start.x; x <= end.x; x++) {
+                    sender_worker_core_range = sender_worker_core_range.merge(CoreRangeSet(CoreRange(
+                        CoreCoord(x + core_grid_offset.x, y + core_grid_offset.y),
+                        CoreCoord(x + core_grid_offset.x, y + core_grid_offset.y))));
+                    if (sender_worker_core_range.num_cores() == num_workers_preferred) {
+                        break;
+                    }
+                }
+                if (sender_worker_core_range.num_cores() == num_workers_preferred) {
+                    break;
+                }
             }
         }
+
         if (sender_worker_core_range.num_cores() == num_workers_preferred) {
             break;
         }

--- a/ttnn/cpp/ttnn/operations/ccl/ccl_common.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/ccl_common.hpp
@@ -79,13 +79,19 @@ std::vector<IDevice*> get_active_physical_devices(const Tensor& tensor);
 // to run a CCL over the unit-meshes.
 std::vector<IDevice*> get_active_physical_devices(const std::vector<Tensor>& tensor_shards);
 
+enum class CoreAllocationStrategy {
+    ROW_MAJOR,
+    COL_MAJOR,
+};
+
 std::tuple<CoreRangeSet, std::vector<CoreCoord>> choose_worker_cores(
     size_t num_links,
     size_t num_workers_per_link,
     IDevice* device,
     const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id,
     CoreCoord core_grid_offset = CoreCoord(0, 0),
-    const std::optional<CoreRangeSet>& sub_core_grid = std::nullopt);
+    const std::optional<CoreRangeSet>& sub_core_grid = std::nullopt,
+    CoreAllocationStrategy strategy = CoreAllocationStrategy::ROW_MAJOR);
 
 class EriscDatamoverBuilder;
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/ring_attention_all_gather_async_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/ring_attention_all_gather_async_device_operation_types.hpp
@@ -33,6 +33,7 @@ struct RingAttentionAllGatherAsyncParams {
     std::vector<GlobalSemaphore> semaphore;
     std::optional<tt::tt_metal::SubDeviceId> sub_device_id;
     std::optional<uint32_t> cluster_axis;
+    ttnn::ccl::CoreAllocationStrategy core_allocation_strategy = ttnn::ccl::CoreAllocationStrategy::ROW_MAJOR;
 };
 
 struct RingAttentionAllGatherAsyncInputs {

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/ring_attention_all_gather_async_multi_core_with_workers_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/ring_attention_all_gather_async_multi_core_with_workers_program_factory.cpp
@@ -147,7 +147,8 @@ ring_attention_all_gather_async_multi_core_with_workers_helper(
     const std::vector<GlobalSemaphore>& semaphore,
     const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id,
     std::optional<ttnn::experimental::ccl::AllGatherFusedOpSignaler>& fused_op_signaler,
-    const CoreCoord core_grid_offset) {
+    const CoreCoord core_grid_offset,
+    ttnn::ccl::CoreAllocationStrategy core_allocation_strategy) {
     auto* mesh_device = input_tensor[0].device();
     [[maybe_unused]] const bool is_first_chip = ring_index == 0;
     [[maybe_unused]] const bool is_last_chip = ring_index == ring_size - 1;
@@ -190,7 +191,7 @@ ring_attention_all_gather_async_multi_core_with_workers_helper(
         sub_device_id,
         core_grid_offset,
         std::nullopt,
-        ttnn::ccl::CoreAllocationStrategy::COL_MAJOR);
+        core_allocation_strategy);
 
     std::set<CoreRange> sender_forward_core_ranges;
     std::set<CoreRange> sender_backward_core_ranges;

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/ring_attention_all_gather_async_multi_core_with_workers_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/ring_attention_all_gather_async_multi_core_with_workers_program_factory.cpp
@@ -183,8 +183,14 @@ ring_attention_all_gather_async_multi_core_with_workers_helper(
     // Get worker cores
     // 2 sender (forward/backward, each with a reader/writer)
     uint32_t num_senders_per_link = 2;
-    const auto [sender_worker_core_range, sender_worker_cores] =
-        ttnn::ccl::choose_worker_cores(num_links, num_senders_per_link, mesh_device, sub_device_id, core_grid_offset);
+    const auto [sender_worker_core_range, sender_worker_cores] = ttnn::ccl::choose_worker_cores(
+        num_links,
+        num_senders_per_link,
+        mesh_device,
+        sub_device_id,
+        core_grid_offset,
+        std::nullopt,
+        ttnn::ccl::CoreAllocationStrategy::COL_MAJOR);
 
     std::set<CoreRange> sender_forward_core_ranges;
     std::set<CoreRange> sender_backward_core_ranges;

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/ring_attention_all_gather_async_multi_core_with_workers_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/ring_attention_all_gather_async_multi_core_with_workers_program_factory.hpp
@@ -77,7 +77,8 @@ ring_attention_all_gather_async_multi_core_with_workers_helper(
     const std::vector<GlobalSemaphore>& semaphore,
     const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id,
     std::optional<ttnn::experimental::ccl::AllGatherFusedOpSignaler>& fused_op_signaler,
-    CoreCoord core_grid_offset = CoreCoord(0, 0));
+    CoreCoord core_grid_offset = CoreCoord(0, 0),
+    ttnn::ccl::CoreAllocationStrategy core_allocation_strategy = ttnn::ccl::CoreAllocationStrategy::ROW_MAJOR);
 
 void ring_attention_all_gather_async_multicore_with_workers_override_runtime_arguments(
     const RingAttentionAllGatherAsyncMultiCoreWithWorkersSharedVariables& shared_variables,

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_device_operation.cpp
@@ -49,7 +49,7 @@ void RingJointSDPADeviceOperation::validate_on_program_cache_miss(
     // Check that SDPA coregrid does not overlap with AllGather coregrid
     TT_FATAL(args.program_config.has_value(), "Program config must be provided");
     TT_FATAL(
-        args.ccl_core_grid_offset.y >= args.program_config.value().compute_with_storage_grid_size.y,
+        args.ccl_core_grid_offset.x >= args.program_config.value().compute_with_storage_grid_size.x,
         "SDPA coregrid overlaps with AllGather coregrid");
 
     // Validate joint strategy is 'rear'

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_device_operation.cpp
@@ -48,9 +48,16 @@ void RingJointSDPADeviceOperation::validate_on_program_cache_miss(
 
     // Check that SDPA coregrid does not overlap with AllGather coregrid
     TT_FATAL(args.program_config.has_value(), "Program config must be provided");
-    TT_FATAL(
-        args.ccl_core_grid_offset.x >= args.program_config.value().compute_with_storage_grid_size.x,
-        "SDPA coregrid overlaps with AllGather coregrid");
+    const auto strategy = args.all_gather_operation_attributes.core_allocation_strategy;
+    if (strategy == ttnn::ccl::CoreAllocationStrategy::COL_MAJOR) {
+        TT_FATAL(
+            args.ccl_core_grid_offset.x >= args.program_config.value().compute_with_storage_grid_size.x,
+            "SDPA coregrid overlaps with AllGather coregrid (column-major)");
+    } else {
+        TT_FATAL(
+            args.ccl_core_grid_offset.y >= args.program_config.value().compute_with_storage_grid_size.y,
+            "SDPA coregrid overlaps with AllGather coregrid (row-major)");
+    }
 
     // Validate joint strategy is 'rear'
     TT_FATAL(args.joint_strategy == "rear", "Joint strategy must be 'rear'. Got: {}", args.joint_strategy);
@@ -294,7 +301,8 @@ RingJointSDPAResult ring_joint_scaled_dot_product_attention(
     const CoreCoord ccl_core_grid_offset,
     std::optional<tt::tt_metal::SubDeviceId> subdevice_id,
     const std::optional<float> scale,
-    const std::optional<DeviceComputeKernelConfig> compute_kernel_config) {
+    const std::optional<DeviceComputeKernelConfig> compute_kernel_config,
+    const ttnn::ccl::CoreAllocationStrategy core_allocation_strategy) {
     using OperationType = ttnn::prim::RingJointSDPADeviceOperation;
 
     auto kernel_config_val = init_device_compute_kernel_config(
@@ -328,7 +336,8 @@ RingJointSDPAResult ring_joint_scaled_dot_product_attention(
         topology,
         multi_device_global_semaphore,
         subdevice_id,
-        cluster_axis};
+        cluster_axis,
+        core_allocation_strategy};
     auto all_gather_tensor_args = ttnn::experimental::prim::RingAttentionAllGatherAsyncInputs{
         {input_tensor_k, input_tensor_v}, {persistent_output_buffer_k, persistent_output_buffer_v}};
 

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_device_operation.hpp
@@ -48,6 +48,7 @@ RingJointSDPAResult ring_joint_scaled_dot_product_attention(
     CoreCoord ccl_core_grid_offset,
     std::optional<tt::tt_metal::SubDeviceId> subdevice_id = std::nullopt,
     std::optional<float> scale = std::nullopt,
-    std::optional<DeviceComputeKernelConfig> compute_kernel_config = std::nullopt);
+    std::optional<DeviceComputeKernelConfig> compute_kernel_config = std::nullopt,
+    ttnn::ccl::CoreAllocationStrategy core_allocation_strategy = ttnn::ccl::CoreAllocationStrategy::ROW_MAJOR);
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_program_factory.cpp
@@ -877,7 +877,8 @@ RingJointSDPAProgramFactory::cached_program_t RingJointSDPAProgramFactory::creat
         args.all_gather_operation_attributes.semaphore,
         args.all_gather_operation_attributes.sub_device_id,
         all_gather_fused_op_signaler,
-        args.ccl_core_grid_offset);
+        args.ccl_core_grid_offset,
+        args.all_gather_operation_attributes.core_allocation_strategy);
 
     return cached_program_t{
         std::move(program),

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/sdpa.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/sdpa.cpp
@@ -170,7 +170,8 @@ std::tuple<ttnn::Tensor, ttnn::Tensor, ttnn::Tensor> ExecuteRingJointAttention::
     std::optional<tt::tt_metal::SubDeviceId> subdevice_id,
     const CoreCoord ccl_core_grid_offset,
     std::optional<float> scale,
-    std::optional<DeviceComputeKernelConfig> compute_kernel_config) {
+    std::optional<DeviceComputeKernelConfig> compute_kernel_config,
+    ttnn::ccl::CoreAllocationStrategy core_allocation_strategy) {
     auto output_tensors = ttnn::prim::ring_joint_scaled_dot_product_attention(
         input_tensor_q,
         input_tensor_k,  // AllGather input
@@ -192,7 +193,8 @@ std::tuple<ttnn::Tensor, ttnn::Tensor, ttnn::Tensor> ExecuteRingJointAttention::
         ccl_core_grid_offset,
         subdevice_id,
         scale,
-        compute_kernel_config);
+        compute_kernel_config,
+        core_allocation_strategy);
     return {output_tensors.output, output_tensors.joint_output, output_tensors.lse_output};
 }
 

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/sdpa.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/sdpa.hpp
@@ -8,6 +8,7 @@
 #include "ttnn/decorators.hpp"
 #include "ttnn/operations/transformer/sdpa_config.hpp"
 #include "ttnn/operations/ccl/ccl_host_types.hpp"
+#include "ttnn/operations/ccl/ccl_common.hpp"
 
 namespace ttnn {
 namespace operations::transformer {
@@ -91,7 +92,8 @@ struct ExecuteRingJointAttention {
         std::optional<tt::tt_metal::SubDeviceId> subdevice_id,
         CoreCoord ccl_core_grid_offset,
         std::optional<float> scale = std::nullopt,
-        std::optional<DeviceComputeKernelConfig> compute_kernel_config = std::nullopt);
+        std::optional<DeviceComputeKernelConfig> compute_kernel_config = std::nullopt,
+        ttnn::ccl::CoreAllocationStrategy core_allocation_strategy = ttnn::ccl::CoreAllocationStrategy::ROW_MAJOR);
 };
 
 struct ExecuteFlashMLAPrefill {

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/sdpa_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/sdpa_nanobind.cpp
@@ -17,6 +17,7 @@
 #include "sdpa.hpp"
 #include "ttnn-nanobind/decorators.hpp"
 #include "ttnn/operations/ccl/ccl_host_types.hpp"
+#include "ttnn/operations/ccl/ccl_common.hpp"
 
 namespace ttnn::operations::transformer {
 
@@ -310,6 +311,9 @@ void bind_sdpa(nb::module_& mod) {
             topology (ttnn.ccl.Topology): Communication topology (Ring or Linear).
             subdevice_id (Optional[tt.tt_metal.SubDeviceId]): Sub-device identifier. Defaults to None.
             ccl_core_grid_offset (ttnn.CoreCoord): Core grid offset for CCL operations.
+            use_column_major_ccl (bool, optional): If True, allocate CCL worker cores in column-major order.
+                This places CCL workers in a column (useful when reserving the last column for CCL).
+                If False (default), uses row-major allocation. Defaults to False.
 
         Returns:
             (ttnn.Tensor, ttnn.Tensor, ttnn.Tensor):
@@ -346,7 +350,10 @@ void bind_sdpa(nb::module_& mod) {
                const MeshDevice& mesh_device,
                ttnn::ccl::Topology topology,
                std::optional<tt::tt_metal::SubDeviceId> subdevice_id,
-               CoreCoord ccl_core_grid_offset) {
+               CoreCoord ccl_core_grid_offset,
+               bool use_column_major_ccl) {
+                auto strategy = use_column_major_ccl ? ttnn::ccl::CoreAllocationStrategy::COL_MAJOR
+                                                     : ttnn::ccl::CoreAllocationStrategy::ROW_MAJOR;
                 auto outputs = self(
                     input_tensor_q,
                     input_tensor_k,
@@ -368,7 +375,8 @@ void bind_sdpa(nb::module_& mod) {
                     subdevice_id,
                     ccl_core_grid_offset,
                     scale,
-                    compute_kernel_config);
+                    compute_kernel_config,
+                    strategy);
                 return outputs;
             },
             nb::arg("input_tensor_q").noconvert(),
@@ -392,7 +400,8 @@ void bind_sdpa(nb::module_& mod) {
             nb::arg("mesh_device"),
             nb::arg("topology"),
             nb::arg("subdevice_id") = nb::none(),
-            nb::arg("ccl_core_grid_offset")});
+            nb::arg("ccl_core_grid_offset"),
+            nb::arg("use_column_major_ccl") = false});
 
     const auto* mla_doc =
         R"doc(


### PR DESCRIPTION
### Ticket
N/A

### Problem description
Currently, the last row of the Tensix grid is reserved for CCLs in Wan2.2 ring-joint SDPA.

On Blackhole, we have 10 rows available, and it would be beneficial to keep all 10 rows for compute, since Wan2.2 in the Galaxy+ setup uses 10 heads per ring.

The goal of this change is to move CCL cores from the last row to the last column, freeing all rows for SDPA compute.

### What's changed
- Added support for column-major strategy for CCL worker distribution

- Enabled column-major strategy in ring-joint SDPA

- Updated SDPA and CCL grid configurations in Wan2.2

### Checklist

- [x] APC https://github.com/tenstorrent/tt-metal/actions/runs/22452337786
- [x] BHPC https://github.com/tenstorrent/tt-metal/actions/runs/22452362255
- [x] (Galaxy) demo tests Wan2.2 https://github.com/tenstorrent/tt-metal/actions/runs/22452390444
- [x] (Blackhole) Demo tests Wan2.2 https://github.com/tenstorrent/tt-metal/actions/runs/22452419042
- [x] (Galaxy) e2e tests https://github.com/tenstorrent/tt-metal/actions/runs/22452443589 (same tests fail on main)
