### PR TITLE
Nostojic/call warmup metal same as vllm

### DIFF
--- a/models/common/demos/llama31_8B_demo.py
+++ b/models/common/demos/llama31_8B_demo.py
@@ -602,7 +602,7 @@ def test_mlp1d_llama_demo(
     )
     generator.warmup_model_decode(
         kv_cache=tt_kv_cache_list,
-        enable_trace=not measure_accuracy,
+        enable_trace=True,
         max_batch_size=batch_size,
         num_blocks=paged_attention_config.max_num_blocks,
         can_sample_on_device=generator.metal_supports_on_device_sampling(),
@@ -610,16 +610,15 @@ def test_mlp1d_llama_demo(
     )
 
     # --- Prefill Phase ---
-    if not generator.already_warmed_up_prefill:
-        logger.info("Starting prefill warmup...")
-        profiler.start("compile_prefill")
-        logits = generator.prefill_forward_text(
-            input_tokens_prefill_pt,
-            page_table=page_table,
-            kv_cache=tt_kv_cache_list,
-            prompt_lens=decoding_pos,
-        )
-        profiler.end("compile_prefill")
+    logger.info("Starting prefill warmup...")
+    profiler.start("compile_prefill")
+    logits = generator.prefill_forward_text(
+        input_tokens_prefill_pt,
+        page_table=page_table,
+        kv_cache=tt_kv_cache_list,
+        prompt_lens=decoding_pos,
+    )
+    profiler.end("compile_prefill")
 
     logger.info("Starting prefill inference...")
     profiler.start("inference_prefill")

--- a/models/common/demos/llama31_8B_demo.py
+++ b/models/common/demos/llama31_8B_demo.py
@@ -593,16 +593,33 @@ def test_mlp1d_llama_demo(
     # Create generator
     generator = Generator(model_list, model_args_list, mesh_device, tokenizer=tokenizer)
 
-    # --- Prefill Phase ---
-    logger.info("Starting prefill warmup...")
-    profiler.start("compile_prefill")
-    logits = generator.prefill_forward_text(
-        input_tokens_prefill_pt,
-        page_table=page_table,
+    # warmup the model
+    generator.warmup_model_prefill(
         kv_cache=tt_kv_cache_list,
-        prompt_lens=decoding_pos,
+        enable_trace=True,
+        can_sample_on_device=generator.metal_supports_on_device_sampling(),
+        non_greedy_decoding_on_device=generator.metal_supports_on_device_sampling(),
     )
-    profiler.end("compile_prefill")
+    generator.warmup_model_decode(
+        kv_cache=tt_kv_cache_list,
+        enable_trace=not measure_accuracy,
+        max_batch_size=batch_size,
+        num_blocks=paged_attention_config.max_num_blocks,
+        can_sample_on_device=generator.metal_supports_on_device_sampling(),
+        non_greedy_decoding_on_device=generator.metal_supports_on_device_sampling(),
+    )
+
+    # --- Prefill Phase ---
+    if not generator.already_warmed_up_prefill:
+        logger.info("Starting prefill warmup...")
+        profiler.start("compile_prefill")
+        logits = generator.prefill_forward_text(
+            input_tokens_prefill_pt,
+            page_table=page_table,
+            kv_cache=tt_kv_cache_list,
+            prompt_lens=decoding_pos,
+        )
+        profiler.end("compile_prefill")
 
     logger.info("Starting prefill inference...")
     profiler.start("inference_prefill")

--- a/models/common/warmup/warmup_utils.py
+++ b/models/common/warmup/warmup_utils.py
@@ -22,7 +22,6 @@ class WarmupForwardMixin:
     - self.decode_forward(): method to perform decode forward pass
     """
 
-
     def _create_sampling_params(self, can_sample_on_device, non_greedy_decoding_on_device, batch_size):
         """
         non_greedy_decoding_on_device: when True, device supports non-greedy sampling (temperature,
@@ -76,7 +75,8 @@ class WarmupForwardMixin:
     def _create_decode_warmup_inputs(self, max_batch_size, num_blocks):
         tokens = torch.zeros(max_batch_size, 1, dtype=torch.int32)
         start_pos = torch.zeros(max_batch_size, dtype=torch.int32)
-        page_table = torch.zeros(max_batch_size, num_blocks, dtype=torch.int32)
+        # None is passed from tests if paged attention is not enabled
+        page_table = torch.zeros(max_batch_size, num_blocks, dtype=torch.int32) if num_blocks is not None else None
         return tokens, start_pos, page_table
 
     def warmup_model_decode(
@@ -100,7 +100,7 @@ class WarmupForwardMixin:
         logger.info("Starting decode warmup")
         logger.info(f"Tokens shape: {tokens.shape}")
         logger.info(f"Start pos shape: {start_pos.shape}")
-        logger.info(f"Page table shape: {page_table.shape}")
+        logger.info(f"Page table shape: {page_table.shape if page_table is not None else 'None'}")
 
         for param in sampling_params:
             logger.info(f"Warming up decode for sampling params: {param}")

--- a/models/common/warmup/warmup_utils.py
+++ b/models/common/warmup/warmup_utils.py
@@ -22,7 +22,8 @@ class WarmupForwardMixin:
     - self.decode_forward(): method to perform decode forward pass
     """
 
-    def _create_sampling_params(self, can_sample_on_device, non_greedy_decoding_on_device, max_batch_size, mode):
+
+    def _create_sampling_params(self, can_sample_on_device, non_greedy_decoding_on_device, batch_size):
         """
         non_greedy_decoding_on_device: when True, device supports non-greedy sampling (temperature,
         top_k, top_p, presence/frequency/repetition penalties, log_probs); warmup then includes
@@ -38,15 +39,15 @@ class WarmupForwardMixin:
                 presence_penalty, frequency_penalty, repetition_penalty = None, None, None
 
                 if penalties:
-                    presence_penalty = [1.2] * max_batch_size if mode == "decode" else 1.2
-                    frequency_penalty = [1.2] * max_batch_size if mode == "decode" else 1.2
-                    repetition_penalty = [1.5] * max_batch_size if mode == "decode" else 1.5
+                    presence_penalty = [1.2] * batch_size
+                    frequency_penalty = [1.2] * batch_size
+                    repetition_penalty = [1.5] * batch_size
 
-                enable_log_probs = [log_probs] * max_batch_size if mode == "decode" else log_probs
+                enable_log_probs = [log_probs] * batch_size
 
-                temperature = [1.0] * max_batch_size if mode == "decode" else 1.0
-                top_k = [10] * max_batch_size if mode == "decode" else 10
-                top_p = [0.9] * max_batch_size if mode == "decode" else 0.9
+                temperature = [1.0] * batch_size
+                top_k = [10] * batch_size
+                top_p = [0.9] * batch_size
 
                 sampling_configs.append(
                     SamplingParams(
@@ -62,9 +63,9 @@ class WarmupForwardMixin:
 
         sampling_configs.append(
             SamplingParams(
-                temperature=[0.0] * max_batch_size if mode == "decode" else 0.0,
-                top_k=[1] * max_batch_size if mode == "decode" else 1,
-                top_p=[1.0] * max_batch_size if mode == "decode" else 1.0,
+                temperature=[0.0] * batch_size,
+                top_k=[1] * batch_size,
+                top_p=[1.0] * batch_size,
             )
         )
 
@@ -91,7 +92,7 @@ class WarmupForwardMixin:
         This function is called by vLLM
         """
         sampling_params = self._create_sampling_params(
-            can_sample_on_device, non_greedy_decoding_on_device, max_batch_size, mode="decode"
+            can_sample_on_device, non_greedy_decoding_on_device, max_batch_size
         )
 
         tokens, start_pos, page_table = self._create_decode_warmup_inputs(max_batch_size, num_blocks)

--- a/models/demos/deepseek_v3/tt/generator.py
+++ b/models/demos/deepseek_v3/tt/generator.py
@@ -27,7 +27,6 @@ from models.perf.benchmarking_utils import BenchmarkProfiler
 
 MAX_SEQ_LEN = 2048
 
-
 def _strip_model_prefix(state_dict: dict[str, torch.Tensor]) -> dict[str, torch.Tensor]:
     """Return a copy of the HF state_dict with leading 'model.' stripped.
 

--- a/models/demos/gpt_oss/demo/text_demo.py
+++ b/models/demos/gpt_oss/demo/text_demo.py
@@ -909,19 +909,18 @@ def test_gpt_oss_demo(
 
         else:
             # Standard sequential prefill (batch_size < num_rows)
-            if not generator.already_warmed_up_prefill:
-                logger.info("Starting prefill warmup...")
-                profiler.start(f"compile_prefill", iteration=batch_idx)
-                generator.prefill_forward_text(
-                    input_tokens_prefill_pt[:1],
-                    page_table=page_table,
-                    kv_cache=tt_kv_cache,
-                    prompt_lens=decoding_pos,
-                    enable_trace=enable_prefill_trace,
-                    warmup_prefill=False,
-                )
-                profiler.end(f"compile_prefill", iteration=batch_idx)
-                logger.info("Finished prefill warmup")
+            logger.info("Starting prefill warmup...")
+            profiler.start(f"compile_prefill", iteration=batch_idx)
+            generator.prefill_forward_text(
+                input_tokens_prefill_pt[:1],
+                page_table=page_table,
+                kv_cache=tt_kv_cache,
+                prompt_lens=decoding_pos,
+                enable_trace=enable_prefill_trace,
+                warmup_prefill=False,
+            )
+            profiler.end(f"compile_prefill", iteration=batch_idx)
+            logger.info("Finished prefill warmup")
 
             logger.info(f"Starting prefill...")
             profiler.start(f"inference_prefill", iteration=batch_idx)

--- a/models/demos/gpt_oss/demo/text_demo.py
+++ b/models/demos/gpt_oss/demo/text_demo.py
@@ -432,6 +432,22 @@ def test_gpt_oss_demo(
     # Create generator (match tt-transformers pattern)
     generator = Generator(model, model_args, mesh_device, processor=processor, tokenizer=tokenizer)
 
+    # warmup the model
+    generator.warmup_model_prefill(
+        kv_cache=tt_kv_cache,
+        enable_trace=enable_prefill_trace,
+        can_sample_on_device=generator.metal_supports_on_device_sampling(),
+        non_greedy_decoding_on_device=generator.metal_supports_on_device_sampling(),
+    )
+    generator.warmup_model_decode(
+        kv_cache=tt_kv_cache,
+        enable_trace=enable_decode_trace,
+        max_batch_size=global_batch_size,
+        num_blocks=paged_attention_config.max_num_blocks,
+        can_sample_on_device=generator.metal_supports_on_device_sampling(),
+        non_greedy_decoding_on_device=generator.metal_supports_on_device_sampling(),
+    )
+
     profiler.end(f"generator_setup", iteration=batch_idx)
 
     # Prepare input prompts
@@ -893,18 +909,19 @@ def test_gpt_oss_demo(
 
         else:
             # Standard sequential prefill (batch_size < num_rows)
-            logger.info("Starting prefill warmup...")
-            profiler.start(f"compile_prefill", iteration=batch_idx)
-            generator.prefill_forward_text(
-                input_tokens_prefill_pt[:1],
-                page_table=page_table,
-                kv_cache=tt_kv_cache,
-                prompt_lens=decoding_pos,
-                enable_trace=enable_prefill_trace,
-                warmup_prefill=False,
-            )
-            profiler.end(f"compile_prefill", iteration=batch_idx)
-            logger.info("Finished prefill warmup")
+            if not generator.already_warmed_up_prefill:
+                logger.info("Starting prefill warmup...")
+                profiler.start(f"compile_prefill", iteration=batch_idx)
+                generator.prefill_forward_text(
+                    input_tokens_prefill_pt[:1],
+                    page_table=page_table,
+                    kv_cache=tt_kv_cache,
+                    prompt_lens=decoding_pos,
+                    enable_trace=enable_prefill_trace,
+                    warmup_prefill=False,
+                )
+                profiler.end(f"compile_prefill", iteration=batch_idx)
+                logger.info("Finished prefill warmup")
 
             logger.info(f"Starting prefill...")
             profiler.start(f"inference_prefill", iteration=batch_idx)

--- a/models/demos/gpt_oss/tests/accuracy/test_model.py
+++ b/models/demos/gpt_oss/tests/accuracy/test_model.py
@@ -373,6 +373,22 @@ def test_full_model_accuracy(mesh_device, mesh_shape, device_params, reset_seeds
 
     generator = Generator(model, model_args, setup["mesh_device"], processor=processor, tokenizer=tokenizer)
 
+    # warmup the model
+    generator.warmup_model_prefill(
+        kv_cache=tt_kv_cache,
+        enable_trace=True,
+        can_sample_on_device=generator.metal_supports_on_device_sampling(),
+        non_greedy_decoding_on_device=generator.metal_supports_on_device_sampling(),
+    )
+    generator.warmup_model_decode(
+        kv_cache=tt_kv_cache,
+        enable_trace=False,
+        max_batch_size=global_batch_size,
+        num_blocks=paged_attention_config.max_num_blocks,
+        can_sample_on_device=generator.metal_supports_on_device_sampling(),
+        non_greedy_decoding_on_device=generator.metal_supports_on_device_sampling(),
+    )
+
     # Test accuracy
     top1_acc, top5_acc = run_accuracy(
         generator,

--- a/models/demos/gpt_oss/tests/accuracy/test_model.py
+++ b/models/demos/gpt_oss/tests/accuracy/test_model.py
@@ -376,15 +376,15 @@ def test_full_model_accuracy(mesh_device, mesh_shape, device_params, reset_seeds
     # warmup the model
     generator.warmup_model_prefill(
         kv_cache=tt_kv_cache,
-        enable_trace=True,
+        enable_trace=False,  # No paged attention
         can_sample_on_device=generator.metal_supports_on_device_sampling(),
         non_greedy_decoding_on_device=generator.metal_supports_on_device_sampling(),
     )
     generator.warmup_model_decode(
         kv_cache=tt_kv_cache,
-        enable_trace=False,
+        enable_trace=False,  # No paged attention
         max_batch_size=global_batch_size,
-        num_blocks=paged_attention_config.max_num_blocks,
+        num_blocks=None,  # No paged attention
         can_sample_on_device=generator.metal_supports_on_device_sampling(),
         non_greedy_decoding_on_device=generator.metal_supports_on_device_sampling(),
     )

--- a/models/demos/llama3_70b_galaxy/demo/text_demo.py
+++ b/models/demos/llama3_70b_galaxy/demo/text_demo.py
@@ -761,16 +761,16 @@ def test_demo_text(
     # warmup the model
     generator.warmup_model_prefill(
         kv_cache=tt_kv_cache,
-        enable_trace=prefill_enable_trace,
+        enable_trace=True if paged_attention else False,
         can_sample_on_device=generator.metal_supports_on_device_sampling(),
         non_greedy_decoding_on_device=generator.metal_supports_on_device_sampling(),
     )
 
     generator.warmup_model_decode(
         kv_cache=tt_kv_cache,
-        enable_trace=True,
-        max_batch_size=batch_size,
-        num_blocks=page_params["page_max_num_blocks"],
+        enable_trace=True if paged_attention else False,
+        max_batch_size=32,
+        num_blocks=page_params["page_max_num_blocks"] if paged_attention else None,
         can_sample_on_device=generator.metal_supports_on_device_sampling(),
         non_greedy_decoding_on_device=generator.metal_supports_on_device_sampling(),
     )
@@ -869,26 +869,25 @@ def test_demo_text(
             enable_log_probs=log_probs,
         )
         if batch_idx == 0:
-            if not generator.prefill_traces_warmup:
-                logger.info("Starting prefill warmup...")
-                profiler.start(f"compile_prefill", iteration=batch_idx)
-                try:
-                    # We run prefill warm up for all supported sequence lengths once on 1 user
-                    tt_out_logits_all_users = torch.zeros(batch_size, 1, 131072) if pcc_check else None
-                    toks = generator.prefill_forward_text(
-                        input_tokens_prefill_pt,
-                        page_table=page_table,
-                        kv_cache=tt_kv_cache,
-                        prompt_lens=decoding_pos,
-                        enable_trace=prefill_enable_trace,
-                        tt_out_logits_all_users=tt_out_logits_all_users,
-                        sampling_params=device_sampling_params,
-                    )
-                except Exception as e:
-                    logger.error(f"Error during prefill warmup: {str(e)}")
-                    raise e
-                profiler.end(f"compile_prefill", iteration=batch_idx)
-                logger.info("Finished prefill warmup")
+            logger.info("Starting prefill warmup...")
+            profiler.start(f"compile_prefill", iteration=batch_idx)
+            try:
+                # We run prefill warm up for all supported sequence lengths once on 1 user
+                tt_out_logits_all_users = torch.zeros(batch_size, 1, 131072) if pcc_check else None
+                toks = generator.prefill_forward_text(
+                    input_tokens_prefill_pt,
+                    page_table=page_table,
+                    kv_cache=tt_kv_cache,
+                    prompt_lens=decoding_pos,
+                    enable_trace=prefill_enable_trace,
+                    tt_out_logits_all_users=tt_out_logits_all_users,
+                    sampling_params=device_sampling_params,
+                )
+            except Exception as e:
+                logger.error(f"Error during prefill warmup: {str(e)}")
+                raise e
+            profiler.end(f"compile_prefill", iteration=batch_idx)
+            logger.info("Finished prefill warmup")
         logger.info(f"Starting prefill...")
 
         profiler.start(f"inference_prefill", iteration=batch_idx)

--- a/models/demos/llama3_70b_galaxy/demo/text_demo.py
+++ b/models/demos/llama3_70b_galaxy/demo/text_demo.py
@@ -758,6 +758,23 @@ def test_demo_text(
     tokenizer = model_args.tokenizer
     generator = Generator(model, model_args, mesh_device, tokenizer=tokenizer)
 
+    # warmup the model
+    generator.warmup_model_prefill(
+        kv_cache=tt_kv_cache,
+        enable_trace=prefill_enable_trace,
+        can_sample_on_device=generator.metal_supports_on_device_sampling(),
+        non_greedy_decoding_on_device=generator.metal_supports_on_device_sampling(),
+    )
+
+    generator.warmup_model_decode(
+        kv_cache=tt_kv_cache,
+        enable_trace=True,
+        max_batch_size=batch_size,
+        num_blocks=page_params["page_max_num_blocks"],
+        can_sample_on_device=generator.metal_supports_on_device_sampling(),
+        non_greedy_decoding_on_device=generator.metal_supports_on_device_sampling(),
+    )
+
     num_tokens_generated_decode = []
 
     logger.info("Starting inference...")
@@ -852,25 +869,26 @@ def test_demo_text(
             enable_log_probs=log_probs,
         )
         if batch_idx == 0:
-            logger.info("Starting prefill warmup...")
-            profiler.start(f"compile_prefill", iteration=batch_idx)
-            try:
-                # We run prefill warm up for all supported sequence lengths once on 1 user
-                tt_out_logits_all_users = torch.zeros(batch_size, 1, 131072) if pcc_check else None
-                toks = generator.prefill_forward_text(
-                    input_tokens_prefill_pt,
-                    page_table=page_table,
-                    kv_cache=tt_kv_cache,
-                    prompt_lens=decoding_pos,
-                    enable_trace=prefill_enable_trace,
-                    tt_out_logits_all_users=tt_out_logits_all_users,
-                    sampling_params=device_sampling_params,
-                )
-            except Exception as e:
-                logger.error(f"Error during prefill warmup: {str(e)}")
-                raise e
-            profiler.end(f"compile_prefill", iteration=batch_idx)
-            logger.info("Finished prefill warmup")
+            if not generator.prefill_traces_warmup:
+                logger.info("Starting prefill warmup...")
+                profiler.start(f"compile_prefill", iteration=batch_idx)
+                try:
+                    # We run prefill warm up for all supported sequence lengths once on 1 user
+                    tt_out_logits_all_users = torch.zeros(batch_size, 1, 131072) if pcc_check else None
+                    toks = generator.prefill_forward_text(
+                        input_tokens_prefill_pt,
+                        page_table=page_table,
+                        kv_cache=tt_kv_cache,
+                        prompt_lens=decoding_pos,
+                        enable_trace=prefill_enable_trace,
+                        tt_out_logits_all_users=tt_out_logits_all_users,
+                        sampling_params=device_sampling_params,
+                    )
+                except Exception as e:
+                    logger.error(f"Error during prefill warmup: {str(e)}")
+                    raise e
+                profiler.end(f"compile_prefill", iteration=batch_idx)
+                logger.info("Finished prefill warmup")
         logger.info(f"Starting prefill...")
 
         profiler.start(f"inference_prefill", iteration=batch_idx)

--- a/models/demos/llama3_70b_galaxy/demo/text_qwen_demo.py
+++ b/models/demos/llama3_70b_galaxy/demo/text_qwen_demo.py
@@ -593,7 +593,7 @@ def test_qwen_demo_text(
     generator.warmup_model_decode(
         kv_cache=tt_kv_cache,
         enable_trace=True,
-        max_batch_size=batch_size,
+        max_batch_size=32,
         num_blocks=page_params["page_max_num_blocks"],
         can_sample_on_device=generator.metal_supports_on_device_sampling(),
         non_greedy_decoding_on_device=generator.metal_supports_on_device_sampling(),
@@ -679,27 +679,26 @@ def test_qwen_demo_text(
             temperature=sampling_params["temperature"], top_k=32, top_p=sampling_params["top_p"]
         )
         if batch_idx == 0:
-            if not generator.prefill_traces_warmup:
-                logger.info("Starting prefill warmup...")
-                profiler.start(f"compile_prefill", iteration=batch_idx)
-                try:
-                    tt_out_logits_all_users = (
-                        torch.zeros(batch_size, 1, model_args.padded_vocab_size) if pcc_check else None
-                    )
-                    toks = generator.prefill_forward_text(
-                        input_tokens_prefill_pt,  # Just warmup prefill for 1 user
-                        page_table=page_table,
-                        kv_cache=tt_kv_cache,
-                        prompt_lens=decoding_pos,
-                        enable_trace=prefill_enable_trace,
-                        tt_out_logits_all_users=tt_out_logits_all_users,
-                        sampling_params=device_sampling_params,
-                    )
-                except Exception as e:
-                    logger.error(f"Error during prefill warmup: {str(e)}")
-                    raise e
-                profiler.end(f"compile_prefill", iteration=batch_idx)
-                logger.info("Finished prefill warmup")
+            logger.info("Starting prefill warmup...")
+            profiler.start(f"compile_prefill", iteration=batch_idx)
+            try:
+                tt_out_logits_all_users = (
+                    torch.zeros(batch_size, 1, model_args.padded_vocab_size) if pcc_check else None
+                )
+                toks = generator.prefill_forward_text(
+                    input_tokens_prefill_pt,  # Just warmup prefill for 1 user
+                    page_table=page_table,
+                    kv_cache=tt_kv_cache,
+                    prompt_lens=decoding_pos,
+                    enable_trace=prefill_enable_trace,
+                    tt_out_logits_all_users=tt_out_logits_all_users,
+                    sampling_params=device_sampling_params,
+                )
+            except Exception as e:
+                logger.error(f"Error during prefill warmup: {str(e)}")
+                raise e
+            profiler.end(f"compile_prefill", iteration=batch_idx)
+            logger.info("Finished prefill warmup")
 
         logger.info(f"Starting prefill...")
 

--- a/models/demos/llama3_70b_galaxy/demo/text_qwen_demo.py
+++ b/models/demos/llama3_70b_galaxy/demo/text_qwen_demo.py
@@ -582,6 +582,23 @@ def test_qwen_demo_text(
     tokenizer = AutoTokenizer.from_pretrained(model_args.TOKENIZER_PATH)
     generator = Generator(model, model_args, mesh_device, tokenizer=tokenizer)
 
+    # warmup the model
+    generator.warmup_model_prefill(
+        kv_cache=tt_kv_cache,
+        enable_trace=prefill_enable_trace,
+        can_sample_on_device=generator.metal_supports_on_device_sampling(),
+        non_greedy_decoding_on_device=generator.metal_supports_on_device_sampling(),
+    )
+
+    generator.warmup_model_decode(
+        kv_cache=tt_kv_cache,
+        enable_trace=True,
+        max_batch_size=batch_size,
+        num_blocks=page_params["page_max_num_blocks"],
+        can_sample_on_device=generator.metal_supports_on_device_sampling(),
+        non_greedy_decoding_on_device=generator.metal_supports_on_device_sampling(),
+    )
+
     num_tokens_generated_decode = []
 
     logger.info("Starting inference...")
@@ -662,26 +679,27 @@ def test_qwen_demo_text(
             temperature=sampling_params["temperature"], top_k=32, top_p=sampling_params["top_p"]
         )
         if batch_idx == 0:
-            logger.info("Starting prefill warmup...")
-            profiler.start(f"compile_prefill", iteration=batch_idx)
-            try:
-                tt_out_logits_all_users = (
-                    torch.zeros(batch_size, 1, model_args.padded_vocab_size) if pcc_check else None
-                )
-                toks = generator.prefill_forward_text(
-                    input_tokens_prefill_pt,  # Just warmup prefill for 1 user
-                    page_table=page_table,
-                    kv_cache=tt_kv_cache,
-                    prompt_lens=decoding_pos,
-                    enable_trace=prefill_enable_trace,
-                    tt_out_logits_all_users=tt_out_logits_all_users,
-                    sampling_params=device_sampling_params,
-                )
-            except Exception as e:
-                logger.error(f"Error during prefill warmup: {str(e)}")
-                raise e
-            profiler.end(f"compile_prefill", iteration=batch_idx)
-            logger.info("Finished prefill warmup")
+            if not generator.prefill_traces_warmup:
+                logger.info("Starting prefill warmup...")
+                profiler.start(f"compile_prefill", iteration=batch_idx)
+                try:
+                    tt_out_logits_all_users = (
+                        torch.zeros(batch_size, 1, model_args.padded_vocab_size) if pcc_check else None
+                    )
+                    toks = generator.prefill_forward_text(
+                        input_tokens_prefill_pt,  # Just warmup prefill for 1 user
+                        page_table=page_table,
+                        kv_cache=tt_kv_cache,
+                        prompt_lens=decoding_pos,
+                        enable_trace=prefill_enable_trace,
+                        tt_out_logits_all_users=tt_out_logits_all_users,
+                        sampling_params=device_sampling_params,
+                    )
+                except Exception as e:
+                    logger.error(f"Error during prefill warmup: {str(e)}")
+                    raise e
+                profiler.end(f"compile_prefill", iteration=batch_idx)
+                logger.info("Finished prefill warmup")
 
         logger.info(f"Starting prefill...")
 

--- a/models/demos/llama3_70b_galaxy/tt/generator.py
+++ b/models/demos/llama3_70b_galaxy/tt/generator.py
@@ -86,6 +86,12 @@ class Generator(WarmupForwardMixin):
         self.enable_split_sampling = True
         self.model.enable_internal_trace = self.enable_split_sampling
 
+    def metal_supports_on_device_sampling(self):
+        return (
+            getattr(self.model, "_supports_on_device_sampling", False)
+            and getattr(self.model, "sampling", None) is not None
+        )
+
     def warmup_prefill_traces(
         self,
         tokens: torch.Tensor,
@@ -99,6 +105,9 @@ class Generator(WarmupForwardMixin):
     ):
         # Avoids an infinite loop
         self.prefill_traces_warmup = True
+
+        # Check if model supports on-device sampling and non-greedy decoding (same as tt_transformers)
+        sampling_on_device_enabled = self.metal_supports_on_device_sampling()
 
         self.model.switch_mode("prefill")
         logger.info("Warming up prefill traces for all supported sequence lengths")
@@ -127,6 +136,13 @@ class Generator(WarmupForwardMixin):
                 warmup_tokens = torch.zeros(batch, supported_length, dtype=torch.long)
                 warmup_prompt_lens = torch.tensor([supported_length] * batch, dtype=torch.long)
                 warmup_empty_slots = list(range(batch))
+
+                sampling_params = self._create_sampling_params(
+                    can_sample_on_device=sampling_on_device_enabled,
+                    non_greedy_decoding_on_device=sampling_on_device_enabled,
+                    batch_size=batch,
+                )
+
                 self.prefill_forward_text(
                     warmup_tokens,
                     warmup_page_table,

--- a/models/demos/llama3_70b_galaxy/tt/llama_model.py
+++ b/models/demos/llama3_70b_galaxy/tt/llama_model.py
@@ -187,8 +187,10 @@ class TtTransformer(LightweightModule):
                 mesh_device=self.mesh_device,
                 tt_ccl=self.tt_ccl,
             )
+            self._supports_on_device_sampling = True
         else:
             self.tt_ccl = self.tt_ccl_decode
+            self._supports_on_device_sampling = False
 
     def prepare_prefill_inputs_host(
         self, tokens, user_id=0, page_table=None, chunk_page_table=None, tt_rot_mats_prefill=None, batch_size=1

--- a/models/demos/multimodal/gemma3/demo/text_demo.py
+++ b/models/demos/multimodal/gemma3/demo/text_demo.py
@@ -844,15 +844,15 @@ def test_demo_text(
     # warmup the model
     generator.warmup_model_prefill(
         kv_cache=tt_kv_cache,
-        enable_trace=enable_trace,
+        enable_trace=True if paged_attention else False,
         can_sample_on_device=generator.metal_supports_on_device_sampling(),
         non_greedy_decoding_on_device=generator.metal_supports_on_device_sampling(),
     )
     generator.warmup_model_decode(
         kv_cache=tt_kv_cache,
-        enable_trace=enable_trace,
+        enable_trace=True if paged_attention else False,
         max_batch_size=global_batch_size,
-        num_blocks=page_params["page_max_num_blocks"],
+        num_blocks=page_params["page_max_num_blocks_per_dp"] if paged_attention else None,
         can_sample_on_device=generator.metal_supports_on_device_sampling(),
         non_greedy_decoding_on_device=generator.metal_supports_on_device_sampling(),
     )
@@ -904,17 +904,16 @@ def test_demo_text(
 
         input_tokens_prefill_pt = torch.stack(input_tokens_prefill_pt).view(global_batch_size, -1)
 
-        if not generator.already_warmed_up_prefill:
-            logger.info("Starting prefill warmup...")
-            profiler.start(f"compile_prefill", iteration=batch_idx)
-            logits = generator.prefill_forward_text(
-                input_tokens_prefill_pt,  # Prefill warmup for all users, in case some users have different seqlens than others
-                page_table=page_table,
-                kv_cache=tt_kv_cache,
-                prompt_lens=decoding_pos,
-            )
-            profiler.end(f"compile_prefill", iteration=batch_idx)
-            logger.info("Finished prefill warmup")
+        logger.info("Starting prefill warmup...")
+        profiler.start(f"compile_prefill", iteration=batch_idx)
+        logits = generator.prefill_forward_text(
+            input_tokens_prefill_pt,  # Prefill warmup for all users, in case some users have different seqlens than others
+            page_table=page_table,
+            kv_cache=tt_kv_cache,
+            prompt_lens=decoding_pos,
+        )
+        profiler.end(f"compile_prefill", iteration=batch_idx)
+        logger.info("Finished prefill warmup")
 
         logger.info(f"Starting prefill...")
         profiler.start(f"inference_prefill", iteration=batch_idx)

--- a/models/demos/multimodal/gemma3/demo/text_demo.py
+++ b/models/demos/multimodal/gemma3/demo/text_demo.py
@@ -841,6 +841,22 @@ def test_demo_text(
 
     generator = Generator(model, model_args, mesh_device, tokenizer=tokenizer)
 
+    # warmup the model
+    generator.warmup_model_prefill(
+        kv_cache=tt_kv_cache,
+        enable_trace=enable_trace,
+        can_sample_on_device=generator.metal_supports_on_device_sampling(),
+        non_greedy_decoding_on_device=generator.metal_supports_on_device_sampling(),
+    )
+    generator.warmup_model_decode(
+        kv_cache=tt_kv_cache,
+        enable_trace=enable_trace,
+        max_batch_size=global_batch_size,
+        num_blocks=page_params["page_max_num_blocks"],
+        can_sample_on_device=generator.metal_supports_on_device_sampling(),
+        non_greedy_decoding_on_device=generator.metal_supports_on_device_sampling(),
+    )
+
     if token_accuracy:
         input_prompts[0] = token_acc.prepare_ref_tokens(tokenizer)
 
@@ -888,16 +904,17 @@ def test_demo_text(
 
         input_tokens_prefill_pt = torch.stack(input_tokens_prefill_pt).view(global_batch_size, -1)
 
-        logger.info("Starting prefill warmup...")
-        profiler.start(f"compile_prefill", iteration=batch_idx)
-        logits = generator.prefill_forward_text(
-            input_tokens_prefill_pt,  # Prefill warmup for all users, in case some users have different seqlens than others
-            page_table=page_table,
-            kv_cache=tt_kv_cache,
-            prompt_lens=decoding_pos,
-        )
-        profiler.end(f"compile_prefill", iteration=batch_idx)
-        logger.info("Finished prefill warmup")
+        if not generator.already_warmed_up_prefill:
+            logger.info("Starting prefill warmup...")
+            profiler.start(f"compile_prefill", iteration=batch_idx)
+            logits = generator.prefill_forward_text(
+                input_tokens_prefill_pt,  # Prefill warmup for all users, in case some users have different seqlens than others
+                page_table=page_table,
+                kv_cache=tt_kv_cache,
+                prompt_lens=decoding_pos,
+            )
+            profiler.end(f"compile_prefill", iteration=batch_idx)
+            logger.info("Finished prefill warmup")
 
         logger.info(f"Starting prefill...")
         profiler.start(f"inference_prefill", iteration=batch_idx)

--- a/models/demos/multimodal/gemma3/demo/vision_demo.py
+++ b/models/demos/multimodal/gemma3/demo/vision_demo.py
@@ -247,7 +247,7 @@ def test_multimodal_demo_text(
     )
 
     generator = Generator(model, model_args, mesh_device)
-    # add vision warmup calls when vision warmup is implemented
+    # call warmup_model_prefill and warmup_model_decode when vision warmup is implemented
 
     xattn_caches = [None for i, model in enumerate(generator.model)]
 

--- a/models/demos/multimodal/gemma3/demo/vision_demo.py
+++ b/models/demos/multimodal/gemma3/demo/vision_demo.py
@@ -247,6 +247,7 @@ def test_multimodal_demo_text(
     )
 
     generator = Generator(model, model_args, mesh_device)
+    # add vision warmup calls when vision warmup is implemented
 
     xattn_caches = [None for i, model in enumerate(generator.model)]
 

--- a/models/demos/qwen25_vl/demo/demo.py
+++ b/models/demos/qwen25_vl/demo/demo.py
@@ -367,15 +367,15 @@ def test_demo(
     # warmup the model
     generator.warmup_model_prefill(
         kv_cache=tt_kv_cache,
-        enable_trace=enable_trace,
+        enable_trace=True if paged_attention else False,
         can_sample_on_device=generator.metal_supports_on_device_sampling(),
         non_greedy_decoding_on_device=generator.metal_supports_on_device_sampling(),
     )
     generator.warmup_model_decode(
         kv_cache=tt_kv_cache,
-        enable_trace=enable_trace,
+        enable_trace=True if paged_attention else False,
         max_batch_size=batch_size,
-        num_blocks=page_params["page_max_num_blocks"],
+        num_blocks=page_params["page_max_num_blocks"] if paged_attention else None,
         can_sample_on_device=generator.metal_supports_on_device_sampling(),
         non_greedy_decoding_on_device=generator.metal_supports_on_device_sampling(),
     )
@@ -469,19 +469,18 @@ def test_demo(
         )
         profiler.end(f"preprocess_prefill_inputs", iteration=batch_idx)
 
-        if not generator.already_warmed_up_prefill:
-            logger.info("Starting prefill warmup...")
-            profiler.start(f"compile_prefill", iteration=batch_idx)
-            # [INFO] prefill_forward_text is read-only of the cos/sin matrices
-            logits = generator.prefill_forward_text(
-                input_prefill_pt[0].unsqueeze(0),  # Just warmup prefill for 1 user
-                rot_mats=(cos, sin),
-                page_table=page_table,
-                kv_cache=tt_kv_cache,
-                prompt_lens=decoding_pos,
-            )
-            profiler.end(f"compile_prefill", iteration=batch_idx)
-            logger.info("Finished prefill warmup")
+        logger.info("Starting prefill warmup...")
+        profiler.start(f"compile_prefill", iteration=batch_idx)
+        # [INFO] prefill_forward_text is read-only of the cos/sin matrices
+        logits = generator.prefill_forward_text(
+            input_prefill_pt[0].unsqueeze(0),  # Just warmup prefill for 1 user
+            rot_mats=(cos, sin),
+            page_table=page_table,
+            kv_cache=tt_kv_cache,
+            prompt_lens=decoding_pos,
+        )
+        profiler.end(f"compile_prefill", iteration=batch_idx)
+        logger.info("Finished prefill warmup")
 
         logger.info(f"Starting prefill...")
         profiler.start(f"inference_prefill", iteration=batch_idx)

--- a/models/demos/qwen25_vl/demo/demo.py
+++ b/models/demos/qwen25_vl/demo/demo.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+models / demos / qwen25_vl / demo / demo.py  # SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 # SPDX-License-Identifier: Apache-2.0
 
 import json
@@ -364,6 +364,22 @@ def test_demo(
     model_args.use_qk_fused = False
     generator = Generator(model, model_args, mesh_device, processor=processor, tokenizer=tokenizer)
 
+    # warmup the model
+    generator.warmup_model_prefill(
+        kv_cache=tt_kv_cache,
+        enable_trace=enable_trace,
+        can_sample_on_device=generator.metal_supports_on_device_sampling(),
+        non_greedy_decoding_on_device=generator.metal_supports_on_device_sampling(),
+    )
+    generator.warmup_model_decode(
+        kv_cache=tt_kv_cache,
+        enable_trace=enable_trace,
+        max_batch_size=batch_size,
+        num_blocks=page_params["page_max_num_blocks"],
+        can_sample_on_device=generator.metal_supports_on_device_sampling(),
+        non_greedy_decoding_on_device=generator.metal_supports_on_device_sampling(),
+    )
+
     # Load vision model and processor
     # reduce the number of layers to 1 for fast ci runs (also useful for debugging)
     from transformers import logging as transformers_logging
@@ -453,18 +469,19 @@ def test_demo(
         )
         profiler.end(f"preprocess_prefill_inputs", iteration=batch_idx)
 
-        logger.info("Starting prefill warmup...")
-        profiler.start(f"compile_prefill", iteration=batch_idx)
-        # [INFO] prefill_forward_text is read-only of the cos/sin matrices
-        logits = generator.prefill_forward_text(
-            input_prefill_pt[0].unsqueeze(0),  # Just warmup prefill for 1 user
-            rot_mats=(cos, sin),
-            page_table=page_table,
-            kv_cache=tt_kv_cache,
-            prompt_lens=decoding_pos,
-        )
-        profiler.end(f"compile_prefill", iteration=batch_idx)
-        logger.info("Finished prefill warmup")
+        if not generator.already_warmed_up_prefill:
+            logger.info("Starting prefill warmup...")
+            profiler.start(f"compile_prefill", iteration=batch_idx)
+            # [INFO] prefill_forward_text is read-only of the cos/sin matrices
+            logits = generator.prefill_forward_text(
+                input_prefill_pt[0].unsqueeze(0),  # Just warmup prefill for 1 user
+                rot_mats=(cos, sin),
+                page_table=page_table,
+                kv_cache=tt_kv_cache,
+                prompt_lens=decoding_pos,
+            )
+            profiler.end(f"compile_prefill", iteration=batch_idx)
+            logger.info("Finished prefill warmup")
 
         logger.info(f"Starting prefill...")
         profiler.start(f"inference_prefill", iteration=batch_idx)

--- a/models/demos/qwen3_vl/demo/demo.py
+++ b/models/demos/qwen3_vl/demo/demo.py
@@ -361,6 +361,23 @@ def test_demo(
     model_args.use_qk_fused = False
     generator = Generator(model, model_args, mesh_device, processor=processor, tokenizer=tokenizer)
 
+    # warmup the model
+    generator.warmup_model_prefill(
+        kv_cache=tt_kv_cache,
+        enable_trace=True,
+        can_sample_on_device=generator.metal_supports_on_device_sampling(),
+        non_greedy_decoding_on_device=generator.metal_supports_on_device_sampling(),
+    )
+
+    generator.warmup_model_decode(
+        kv_cache=tt_kv_cache,
+        enable_trace=True,
+        max_batch_size=batch_size,
+        num_blocks=page_params["page_max_num_blocks"],
+        can_sample_on_device=generator.metal_supports_on_device_sampling(),
+        non_greedy_decoding_on_device=generator.metal_supports_on_device_sampling(),
+    )
+
     # Load vision model and processor
     # reduce the number of layers to 1 for fast ci runs (also useful for debugging)
     from transformers import logging as transformers_logging

--- a/models/demos/qwen3_vl/demo/demo.py
+++ b/models/demos/qwen3_vl/demo/demo.py
@@ -364,16 +364,16 @@ def test_demo(
     # warmup the model
     generator.warmup_model_prefill(
         kv_cache=tt_kv_cache,
-        enable_trace=True,
+        enable_trace=True if paged_attention else False,
         can_sample_on_device=generator.metal_supports_on_device_sampling(),
         non_greedy_decoding_on_device=generator.metal_supports_on_device_sampling(),
     )
 
     generator.warmup_model_decode(
         kv_cache=tt_kv_cache,
-        enable_trace=True,
+        enable_trace=True if paged_attention else False,
         max_batch_size=batch_size,
-        num_blocks=page_params["page_max_num_blocks"],
+        num_blocks=page_params["page_max_num_blocks"] if paged_attention else None,
         can_sample_on_device=generator.metal_supports_on_device_sampling(),
         non_greedy_decoding_on_device=generator.metal_supports_on_device_sampling(),
     )

--- a/models/demos/qwen3_vl/tt/generator.py
+++ b/models/demos/qwen3_vl/tt/generator.py
@@ -44,6 +44,9 @@ class Generator(WarmupForwardMixin):
     def processor(self):
         return self._ttt_generator.processor
 
+    def metal_supports_on_device_sampling(self):
+        return self._ttt_generator.metal_supports_on_device_sampling()
+
     def prefill_forward_text(
         self,
         tokens: torch.Tensor,

--- a/models/demos/tg/llama3_70b/demo/demo.py
+++ b/models/demos/tg/llama3_70b/demo/demo.py
@@ -103,6 +103,7 @@ def demo_warmup(args):
     data_args = replace(args.data, max_output_tokens=2)
 
     generator = build_generator(model_args, tt_args)
+    # ovde se init generator
     # Load the model and tokenizer
     model, tokenizer = generator.model, generator.tokenizer
 
@@ -147,7 +148,7 @@ def run_demo(args):
                 logger.info(f"Loaded {len(ground_truth_outputs)} ground truth outputs")
 
     generator = build_generator(model_args, tt_args)
-
+    # ovde se init generator
     # Load the model and tokenizer
     model, tokenizer = generator.model, generator.tokenizer
 

--- a/models/demos/tg/llama3_70b/demo/demo.py
+++ b/models/demos/tg/llama3_70b/demo/demo.py
@@ -103,7 +103,7 @@ def demo_warmup(args):
     data_args = replace(args.data, max_output_tokens=2)
 
     generator = build_generator(model_args, tt_args)
-    # ovde se init generator
+
     # Load the model and tokenizer
     model, tokenizer = generator.model, generator.tokenizer
 
@@ -148,7 +148,7 @@ def run_demo(args):
                 logger.info(f"Loaded {len(ground_truth_outputs)} ground truth outputs")
 
     generator = build_generator(model_args, tt_args)
-    # ovde se init generator
+
     # Load the model and tokenizer
     model, tokenizer = generator.model, generator.tokenizer
 

--- a/models/experimental/gemma3_4b/tests/vision_tests/test_end2end.py
+++ b/models/experimental/gemma3_4b/tests/vision_tests/test_end2end.py
@@ -154,6 +154,22 @@ def generate(model, processed_inputs, model_args, page_table=None, paged_attenti
     # Setup KV cache (exactly like test_end2end.py)
     tt_kv_cache = [[l.attention.layer_past for l in model.layers]] if paged_attention_config else None
 
+    # warmup the model
+    generator.warmup_model_prefill(
+        kv_cache=tt_kv_cache,
+        enable_trace=True if paged_attention_config else False,
+        can_sample_on_device=generator.metal_supports_on_device_sampling(),
+        non_greedy_decoding_on_device=generator.metal_supports_on_device_sampling(),
+    )
+    generator.warmup_model_decode(
+        kv_cache=tt_kv_cache,
+        enable_trace=True if paged_attention_config else False,
+        max_batch_size=model_args.max_batch_size,
+        num_blocks=paged_attention_config.max_num_blocks,
+        can_sample_on_device=generator.metal_supports_on_device_sampling(),
+        non_greedy_decoding_on_device=generator.metal_supports_on_device_sampling(),
+    )
+
     # # Text generation setup (exactly like test_end2end.py)
     input_tokens_prefill = input_ids
     batch_size = input_tokens_prefill.shape[0]

--- a/models/experimental/mistral_24b/tests/pipeline_tests/test_end2end.py
+++ b/models/experimental/mistral_24b/tests/pipeline_tests/test_end2end.py
@@ -232,7 +232,24 @@ def run_generation_exactly_like_test_end2end(
 
     logger.info("Running Vision Model...")
     generator = Generator([text_model], [model_args], vision_model.mesh_device, tokenizer=model_args.tokenizer)
+
     tt_kv_cache = [[l.attention.layer_past for l in text_model.layers]] if paged_attention_config else None
+
+    # warmup the model
+    generator.warmup_model_prefill(
+        kv_cache=tt_kv_cache,
+        enable_trace=True if paged_attention_config else False,
+        can_sample_on_device=generator.metal_supports_on_device_sampling(),
+        non_greedy_decoding_on_device=generator.metal_supports_on_device_sampling(),
+    )
+    generator.warmup_model_decode(
+        kv_cache=tt_kv_cache,
+        enable_trace=True if paged_attention_config else False,
+        max_batch_size=model_args.max_batch_size,
+        num_blocks=paged_attention_config.max_num_blocks,
+        can_sample_on_device=generator.metal_supports_on_device_sampling(),
+        non_greedy_decoding_on_device=generator.metal_supports_on_device_sampling(),
+    )
 
     input_tokens_prefill = input_ids
     batch_size = input_tokens_prefill.shape[0]

--- a/models/tt_transformers/demo/multimodal_demo_chat.py
+++ b/models/tt_transformers/demo/multimodal_demo_chat.py
@@ -65,7 +65,7 @@ def test_multimodal_demo_chat(
         processor = AutoProcessor.from_pretrained(ckpt_dir)
         tokenizer = processor.tokenizer
         generator = Generator([model], [model_args], mesh_device, processor=processor, tokenizer=tokenizer)
-        # ovde se init generator
+        # call warmup_model_prefill and warmup_model_decode when vision warmup is implemented
 
     # image understanding
     dialogs = []

--- a/models/tt_transformers/demo/multimodal_demo_chat.py
+++ b/models/tt_transformers/demo/multimodal_demo_chat.py
@@ -65,6 +65,7 @@ def test_multimodal_demo_chat(
         processor = AutoProcessor.from_pretrained(ckpt_dir)
         tokenizer = processor.tokenizer
         generator = Generator([model], [model_args], mesh_device, processor=processor, tokenizer=tokenizer)
+        # ovde se init generator
 
     # image understanding
     dialogs = []

--- a/models/tt_transformers/demo/multimodal_demo_text.py
+++ b/models/tt_transformers/demo/multimodal_demo_text.py
@@ -72,6 +72,7 @@ def test_multimodal_demo_text(
         processor = AutoProcessor.from_pretrained(ckpt_dir, local_files_only=is_ci_env)
         tokenizer = processor.tokenizer
         generator = Generator([model], [model_args], mesh_device, preprocessor=processor, tokenizer=tokenizer)
+        # ovde se init generator
 
     with open(IMG_PATH / "dog.jpg", "rb") as f:
         img = PIL_Image.open(f).convert("RGB")

--- a/models/tt_transformers/demo/multimodal_demo_text.py
+++ b/models/tt_transformers/demo/multimodal_demo_text.py
@@ -72,7 +72,7 @@ def test_multimodal_demo_text(
         processor = AutoProcessor.from_pretrained(ckpt_dir, local_files_only=is_ci_env)
         tokenizer = processor.tokenizer
         generator = Generator([model], [model_args], mesh_device, preprocessor=processor, tokenizer=tokenizer)
-        # ovde se init generator
+        # call warmup_model_prefill and warmup_model_decode when vision warmup is implemented
 
     with open(IMG_PATH / "dog.jpg", "rb") as f:
         img = PIL_Image.open(f).convert("RGB")

--- a/models/tt_transformers/demo/simple_text_demo.py
+++ b/models/tt_transformers/demo/simple_text_demo.py
@@ -957,7 +957,7 @@ def test_demo_text(
     generator = Generator(model, model_args, mesh_device, processor=processor, tokenizer=tokenizer)
 
     # warmup the model
-    """generator.warmup_model_prefill(
+    generator.warmup_model_prefill(
         kv_cache=tt_kv_cache,
         enable_trace=True if paged_attention else False,
         can_sample_on_device=generator.metal_supports_on_device_sampling(),
@@ -967,10 +967,10 @@ def test_demo_text(
         kv_cache=tt_kv_cache,
         enable_trace=True if paged_attention else False,
         max_batch_size=batch_size,
-        num_blocks=page_params["page_max_num_blocks"],
+        num_blocks=page_params["page_max_num_blocks"] if paged_attention else None,
         can_sample_on_device=generator.metal_supports_on_device_sampling(),
         non_greedy_decoding_on_device=generator.metal_supports_on_device_sampling(),
-    )"""
+    )
 
     if token_accuracy:
         input_prompts[0] = token_acc.prepare_ref_tokens(tokenizer)

--- a/models/tt_transformers/demo/simple_text_demo.py
+++ b/models/tt_transformers/demo/simple_text_demo.py
@@ -957,7 +957,7 @@ def test_demo_text(
     generator = Generator(model, model_args, mesh_device, processor=processor, tokenizer=tokenizer)
 
     # warmup the model
-    generator.warmup_model_prefill(
+    """generator.warmup_model_prefill(
         kv_cache=tt_kv_cache,
         enable_trace=True if paged_attention else False,
         can_sample_on_device=generator.metal_supports_on_device_sampling(),
@@ -970,7 +970,7 @@ def test_demo_text(
         num_blocks=page_params["page_max_num_blocks"],
         can_sample_on_device=generator.metal_supports_on_device_sampling(),
         non_greedy_decoding_on_device=generator.metal_supports_on_device_sampling(),
-    )
+    )"""
 
     if token_accuracy:
         input_prompts[0] = token_acc.prepare_ref_tokens(tokenizer)

--- a/models/tt_transformers/demo/simple_text_demo.py
+++ b/models/tt_transformers/demo/simple_text_demo.py
@@ -956,6 +956,22 @@ def test_demo_text(
 
     generator = Generator(model, model_args, mesh_device, processor=processor, tokenizer=tokenizer)
 
+    # warmup the model
+    generator.warmup_model_prefill(
+        kv_cache=tt_kv_cache,
+        enable_trace=True if paged_attention else False,
+        can_sample_on_device=generator.metal_supports_on_device_sampling(),
+        non_greedy_decoding_on_device=generator.metal_supports_on_device_sampling(),
+    )
+    generator.warmup_model_decode(
+        kv_cache=tt_kv_cache,
+        enable_trace=True if paged_attention else False,
+        max_batch_size=batch_size,
+        num_blocks=page_params["page_max_num_blocks"],
+        can_sample_on_device=generator.metal_supports_on_device_sampling(),
+        non_greedy_decoding_on_device=generator.metal_supports_on_device_sampling(),
+    )
+
     if token_accuracy:
         input_prompts[0] = token_acc.prepare_ref_tokens(tokenizer)
 

--- a/models/tt_transformers/demo/simple_vision_demo.py
+++ b/models/tt_transformers/demo/simple_vision_demo.py
@@ -328,6 +328,7 @@ def test_multimodal_demo_text(
     processor = AutoProcessor.from_pretrained(ckpt_dir, local_files_only=is_ci_env)
     tokenizer = processor.tokenizer
     generator = Generator(model, model_args, mesh_device, processor=processor, tokenizer=tokenizer)
+    # call warmup_model_prefill and warmup_model_decode when vision warmup is implemented
 
     xattn_caches = [model.setup_cache(model_args[i].max_batch_size) for i, model in enumerate(generator.model)]
 

--- a/models/tt_transformers/tests/mixtral/test_mixtral_model_prefill.py
+++ b/models/tt_transformers/tests/mixtral/test_mixtral_model_prefill.py
@@ -154,14 +154,6 @@ def test_model_inference(
         can_sample_on_device=generator.metal_supports_on_device_sampling(),
         non_greedy_decoding_on_device=generator.metal_supports_on_device_sampling(),
     )
-    generator.warmup_model_decode(
-        kv_cache=[tt_kv_cache],
-        enable_trace=True if paged_attention else False,
-        max_batch_size=batch_size,
-        num_blocks=page_params["page_max_num_blocks"],
-        can_sample_on_device=generator.metal_supports_on_device_sampling(),
-        non_greedy_decoding_on_device=generator.metal_supports_on_device_sampling(),
-    )
 
     logger.info("Finished loading TT model.")
 

--- a/models/tt_transformers/tests/mixtral/test_mixtral_model_prefill.py
+++ b/models/tt_transformers/tests/mixtral/test_mixtral_model_prefill.py
@@ -146,6 +146,23 @@ def test_model_inference(
 
     tokenizer = model_args.tokenizer
     generator = Generator([tt_model], [model_args], mesh_device, tokenizer=tokenizer)
+
+    # warmup the model
+    generator.warmup_model_prefill(
+        kv_cache=[tt_kv_cache],
+        enable_trace=True if paged_attention else False,
+        can_sample_on_device=generator.metal_supports_on_device_sampling(),
+        non_greedy_decoding_on_device=generator.metal_supports_on_device_sampling(),
+    )
+    generator.warmup_model_decode(
+        kv_cache=[tt_kv_cache],
+        enable_trace=True if paged_attention else False,
+        max_batch_size=batch_size,
+        num_blocks=page_params["page_max_num_blocks"],
+        can_sample_on_device=generator.metal_supports_on_device_sampling(),
+        non_greedy_decoding_on_device=generator.metal_supports_on_device_sampling(),
+    )
+
     logger.info("Finished loading TT model.")
 
     # Create page table if paged attention is enabled

--- a/models/tt_transformers/tests/test_chunked_generation.py
+++ b/models/tt_transformers/tests/test_chunked_generation.py
@@ -135,6 +135,23 @@ def test_chunked_prefill_single_user(
     pt_prefill_input = embd(pt_prefill_input).view(batch_size, seq_len, -1)
 
     tt_kv_cache = [l.attention.layer_past for l in tt_model.layers]
+
+    # warmup the model
+    generator.warmup_model_prefill(
+        kv_cache=tt_kv_cache,
+        enable_trace=True,
+        can_sample_on_device=generator.metal_supports_on_device_sampling(),
+        non_greedy_decoding_on_device=generator.metal_supports_on_device_sampling(),
+    )
+    generator.warmup_model_decode(
+        kv_cache=tt_kv_cache,
+        enable_trace=True,
+        max_batch_size=batch_size,
+        num_blocks=page_params["page_max_num_blocks"],
+        can_sample_on_device=generator.metal_supports_on_device_sampling(),
+        non_greedy_decoding_on_device=generator.metal_supports_on_device_sampling(),
+    )
+
     # Slice out relevant part of page table
     block_size = get_block_size(tt_kv_cache)
     num_blocks = num_blocks_in_seq(seq_len, block_size)

--- a/models/tt_transformers/tests/test_chunked_generation.py
+++ b/models/tt_transformers/tests/test_chunked_generation.py
@@ -138,16 +138,16 @@ def test_chunked_prefill_single_user(
 
     # warmup the model
     generator.warmup_model_prefill(
-        kv_cache=tt_kv_cache,
-        enable_trace=True,
+        kv_cache=[tt_kv_cache],
+        enable_trace=True if paged_attention else False,
         can_sample_on_device=generator.metal_supports_on_device_sampling(),
         non_greedy_decoding_on_device=generator.metal_supports_on_device_sampling(),
     )
     generator.warmup_model_decode(
-        kv_cache=tt_kv_cache,
-        enable_trace=True,
+        kv_cache=[tt_kv_cache],
+        enable_trace=True if paged_attention else False,
         max_batch_size=batch_size,
-        num_blocks=page_params["page_max_num_blocks"],
+        num_blocks=page_params["page_max_num_blocks"] if paged_attention else None,
         can_sample_on_device=generator.metal_supports_on_device_sampling(),
         non_greedy_decoding_on_device=generator.metal_supports_on_device_sampling(),
     )

--- a/models/tt_transformers/tests/test_model_prefill.py
+++ b/models/tt_transformers/tests/test_model_prefill.py
@@ -170,16 +170,16 @@ def test_model_inference(
     generator = Generator([tt_model], [model_args], mesh_device, processor=processor, tokenizer=tokenizer)
 
     generator.warmup_model_prefill(
-        kv_cache=tt_kv_cache,
-        enable_trace=True if paged_attention_config else False,
+        kv_cache=[tt_kv_cache],
+        enable_trace=True if paged_attention else False,
         can_sample_on_device=generator.metal_supports_on_device_sampling(),
         non_greedy_decoding_on_device=generator.metal_supports_on_device_sampling(),
     )
     generator.warmup_model_decode(
-        kv_cache=tt_kv_cache,
-        enable_trace=True if paged_attention_config else False,
+        kv_cache=[tt_kv_cache],
+        enable_trace=True if paged_attention else False,
         max_batch_size=batch_size,
-        num_blocks=paged_attention_config.max_num_blocks,
+        num_blocks=paged_attention_config.max_num_blocks if paged_attention else None,
         can_sample_on_device=generator.metal_supports_on_device_sampling(),
         non_greedy_decoding_on_device=generator.metal_supports_on_device_sampling(),
     )

--- a/models/tt_transformers/tests/test_model_prefill.py
+++ b/models/tt_transformers/tests/test_model_prefill.py
@@ -168,6 +168,22 @@ def test_model_inference(
     processor = model_args.processor
     tokenizer = model_args.tokenizer
     generator = Generator([tt_model], [model_args], mesh_device, processor=processor, tokenizer=tokenizer)
+
+    generator.warmup_model_prefill(
+        kv_cache=tt_kv_cache,
+        enable_trace=True if paged_attention_config else False,
+        can_sample_on_device=generator.metal_supports_on_device_sampling(),
+        non_greedy_decoding_on_device=generator.metal_supports_on_device_sampling(),
+    )
+    generator.warmup_model_decode(
+        kv_cache=tt_kv_cache,
+        enable_trace=True if paged_attention_config else False,
+        max_batch_size=batch_size,
+        num_blocks=paged_attention_config.max_num_blocks,
+        can_sample_on_device=generator.metal_supports_on_device_sampling(),
+        non_greedy_decoding_on_device=generator.metal_supports_on_device_sampling(),
+    )
+
     logger.info("Finished loading TT model.")
 
     # Create page table if paged attention is enabled

--- a/models/tt_transformers/tt/generator.py
+++ b/models/tt_transformers/tt/generator.py
@@ -137,24 +137,16 @@ class Generator(WarmupForwardMixin):
             if sampling_module is not None:
                 sampling_module.enable_internal_trace = enabled
 
-
     def metal_supports_on_device_sampling(self):
         return (
             getattr(self.model[0], "_supports_on_device_sampling", False)
             and getattr(self.model[0], "sampling", None) is not None
         )
-    
+
     def warmup_model_prefill(self, kv_cache, enable_trace, can_sample_on_device, non_greedy_decoding_on_device):
         if self.already_warmed_up_prefill:
             return
         self.already_warmed_up_prefill = True
-
-        sampling_params = self._create_sampling_params(
-            can_sample_on_device,
-            non_greedy_decoding_on_device,
-            None,
-            mode="prefill",
-        )
 
         sequence_lengths_to_warmup = self.model_args[0].get_warmup_prefill_supported_seq_lens()
 

--- a/models/tt_transformers/tt/generator.py
+++ b/models/tt_transformers/tt/generator.py
@@ -137,6 +137,13 @@ class Generator(WarmupForwardMixin):
             if sampling_module is not None:
                 sampling_module.enable_internal_trace = enabled
 
+
+    def metal_supports_on_device_sampling(self):
+        return (
+            getattr(self.model[0], "_supports_on_device_sampling", False)
+            and getattr(self.model[0], "sampling", None) is not None
+        )
+    
     def warmup_model_prefill(self, kv_cache, enable_trace, can_sample_on_device, non_greedy_decoding_on_device):
         if self.already_warmed_up_prefill:
             return
@@ -161,41 +168,55 @@ class Generator(WarmupForwardMixin):
                 ):
                     continue
 
-                warmup_tokens = torch.zeros(1, supported_length, dtype=torch.long)
-                warmup_prompt_lens = torch.tensor([supported_length], dtype=torch.long)
-                warmup_empty_slots = list(range(1))
+                for batch_size in [1, 32]:
+                    if batch_size == 32:
+                        logger.warning("Batched prefill in TTT is not supported")
+                        continue
 
-                logger.info(f"Warming up prefill for sequence length: {supported_length}")
-
-                page_table_warmup = None
-                # second check is some tests set the kv_cache to [None] instead of None
-                if kv_cache is not None and kv_cache[model_id] is not None:
-                    block_size = get_block_size(kv_cache[model_id])
-                    num_blocks = num_blocks_in_seq(supported_length, block_size)
-                    page_table_warmup = torch.zeros(1, num_blocks, dtype=torch.int32)
-
-                # chunked prefill not supported without paged attention
-                if page_table_warmup is None and max_prefill_chunk_size_cutoff(
-                    supported_length, self.model_args[0].max_prefill_chunk_size
-                ):
-                    logger.warning(
-                        "Skipping warmup for sequence lengths after: {supported_length} because they are greater than the max prefill chunk size and paged attention is disabled"
-                    )
-                    break
-                for param in sampling_params:
                     logger.info(
-                        f"Warming up prefill for sequence length: {supported_length} with sampling params: {param}"
+                        f"Warming up prefill for sequence length: {supported_length} for batch size: {batch_size}"
                     )
-                    self.prefill_forward_text(
-                        warmup_tokens,
-                        page_table_warmup,
-                        kv_cache,
-                        warmup_prompt_lens,
-                        warmup_empty_slots,
-                        enable_trace,
-                        model_id,
-                        param,
+
+                    warmup_tokens = torch.zeros(batch_size, supported_length, dtype=torch.long)
+                    warmup_prompt_lens = torch.tensor([supported_length] * batch_size, dtype=torch.long)
+                    warmup_empty_slots = list(range(batch_size))
+
+                    page_table_warmup = None
+                    # second check is some tests set the kv_cache to [None] instead of None
+                    if kv_cache is not None and kv_cache[model_id] is not None:
+                        block_size = get_block_size(kv_cache[model_id])
+                        num_blocks = num_blocks_in_seq(supported_length, block_size)
+                        page_table_warmup = torch.zeros(batch_size, num_blocks, dtype=torch.int32)
+
+                    # chunked prefill not supported without paged attention
+                    if page_table_warmup is None and max_prefill_chunk_size_cutoff(
+                        supported_length, self.model_args[0].max_prefill_chunk_size
+                    ):
+                        logger.warning(
+                            "Skipping warmup for sequence lengths after: {supported_length} because they are greater than the max prefill chunk size and paged attention is disabled"
+                        )
+                        break
+
+                    sampling_params = self._create_sampling_params(
+                        can_sample_on_device=can_sample_on_device,
+                        non_greedy_decoding_on_device=non_greedy_decoding_on_device,
+                        batch_size=batch_size,
                     )
+
+                    for param in sampling_params:
+                        logger.info(
+                            f"Warming up prefill for sequence length: {supported_length} with sampling params: {param}"
+                        )
+                        self.prefill_forward_text(
+                            warmup_tokens,
+                            page_table_warmup,
+                            kv_cache,
+                            warmup_prompt_lens,
+                            warmup_empty_slots,
+                            enable_trace,
+                            model_id,
+                            param,
+                        )
 
     def _capture_trace_prefill(
         self,
@@ -319,11 +340,13 @@ class Generator(WarmupForwardMixin):
 
         # we need this here becuase of tt-metal tests
         if warmup_prefill:
-            sampling_on_device_enabled = (
-                getattr(self.model[0], "_supports_on_device_sampling", False)
-                and getattr(self.model[0], "sampling", None) is not None
+            sampling_on_device_enabled = self.metal_supports_on_device_sampling()
+            self.warmup_model_prefill(
+                kv_cache=kv_cache,
+                enable_trace=enable_trace,
+                can_sample_on_device=sampling_on_device_enabled,
+                non_greedy_decoding_on_device=sampling_on_device_enabled,
             )
-            self.warmup_model_prefill(kv_cache, enable_trace, sampling_on_device_enabled, sampling_on_device_enabled)
 
         batch_size, batch_seq_len = tokens.shape
         max_batch_size_per_model = self.model_args[0].max_batch_size
@@ -363,12 +386,8 @@ class Generator(WarmupForwardMixin):
                 seq_len - num_cached_tokens
             )  # Without the cached tokens, then padded
             local_kwargs = kwargs.copy()  # Avoid modifying original kwargs
-            local_kwargs["global_user_id"] = user_id  # Pass global user_id for row-sharded page table targeting
-            sampling_enabled = (
-                sampling_on_device_requested
-                and getattr(self.model[model_id], "_supports_on_device_sampling", False)
-                and getattr(self.model[model_id], "sampling", None) is not None
-            )
+            local_kwargs["global_user_id"] = user_id
+            sampling_enabled = sampling_on_device_requested and self.metal_supports_on_device_sampling()
 
             logger.info(f"Prefilling User {user_id + 1} up to {seq_len} tokens")
 

--- a/needed_tests.md
+++ b/needed_tests.md
@@ -180,24 +180,18 @@ run manually or added to a pipeline before merging.
 
 ## Summary Table
 
-| Changed File | CI Workflow | In Pipeline? |
+| Test / Job | Files Covered | In Pipeline? |
 |---|---|---|
-| common/demos/llama31_8B_demo.py | t3000-e2e-tests-impl.yaml | ✅ |
-| demos/gpt_oss/demo/text_demo.py | t3000-demo-tests-impl.yaml + galaxy | ✅ |
-| demos/gpt_oss/tests/accuracy/test_model.py | t3000-demo-tests-impl.yaml + galaxy | ✅ |
-| demos/llama3_70b_galaxy/demo/text_demo.py | galaxy-unit-tests-impl.yaml | ✅ |
-| demos/llama3_70b_galaxy/demo/text_qwen_demo.py | galaxy-unit-tests-impl.yaml | ✅ |
-| demos/multimodal/gemma3/demo/text_demo.py | t3000-demo-tests-impl.yaml + single-card | ✅ |
-| demos/multimodal/gemma3/demo/vision_demo.py | t3000-demo-tests-impl.yaml + single-card | ✅ |
-| demos/qwen25_vl/demo/demo.py | t3000-demo-tests-impl.yaml + single-card | ✅ |
-| demos/qwen3_vl/demo/demo.py | t3000-demo-tests-impl.yaml | ✅ |
-| demos/tg/llama3_70b/demo/demo.py | galaxy-unit-tests-impl.yaml | ✅ (placeholder only) |
-| tt_transformers/demo/simple_text_demo.py | t3000-demo + single-card + galaxy | ✅ |
-| tt_transformers/demo/simple_vision_demo.py | t3000-demo-tests-impl.yaml | ✅ |
-| tt_transformers/demo/multimodal_demo_chat.py | None | ❌ not in pipeline |
-| tt_transformers/demo/multimodal_demo_text.py | None | ❌ not in pipeline |
-| tt_transformers/tests/test_model_prefill.py | t3000-integration-tests-impl.yaml | ✅ |
-| tt_transformers/tests/test_chunked_generation.py | t3000-integration-tests-impl.yaml | ✅ |
-| tt_transformers/tests/mixtral/test_mixtral_model_prefill.py | t3000-unit-tests-impl.yaml | ✅ |
-| experimental/gemma3_4b/tests/vision_tests/test_end2end.py | None | ❌ not in pipeline |
-| experimental/mistral_24b/tests/pipeline_tests/test_end2end.py | None | ❌ not in pipeline |
+| `models_tttv2_llama31_8B_tests` | `common/demos/llama31_8B_demo.py` | ✅ |
+| `t3k_gpt_oss_tests` + Galaxy GPT-OSS | `demos/gpt_oss/demo/text_demo.py`<br>`demos/gpt_oss/tests/accuracy/test_model.py` | ✅ |
+| Galaxy llama3_70b tests | `demos/llama3_70b_galaxy/demo/text_demo.py`<br>`demos/llama3_70b_galaxy/demo/text_qwen_demo.py` | ✅ |
+| `t3k_gemma3_tests` + N300 single-card | `demos/multimodal/gemma3/demo/text_demo.py`<br>`demos/multimodal/gemma3/demo/vision_demo.py` | ✅ |
+| `t3k_qwen25_vl_tests` + N150/N300 single-card | `demos/qwen25_vl/demo/demo.py` | ✅ |
+| `t3k_qwen3_vl_tests` | `demos/qwen3_vl/demo/demo.py` | ✅ |
+| Galaxy demo (placeholder only) | `demos/tg/llama3_70b/demo/demo.py` | ✅ (placeholder only) |
+| t3k/single-card/galaxy demo tests (various) | `tt_transformers/demo/simple_text_demo.py` | ✅ |
+| `t3k_llama3_vision_tests` / `t3k_llama3_90b_vision_tests` | `tt_transformers/demo/simple_vision_demo.py` | ✅ |
+| t3000-integration tests | `tt_transformers/tests/test_model_prefill.py`<br>`tt_transformers/tests/test_chunked_generation.py` | ✅ |
+| `t3k_mixtral_tests` | `tt_transformers/tests/mixtral/test_mixtral_model_prefill.py` | ✅ |
+| ❌ Not in any pipeline | `tt_transformers/demo/multimodal_demo_chat.py`<br>`tt_transformers/demo/multimodal_demo_text.py` | ❌ |
+| ❌ Not in any pipeline | `experimental/gemma3_4b/tests/vision_tests/test_end2end.py`<br>`experimental/mistral_24b/tests/pipeline_tests/test_end2end.py` | ❌ |

--- a/needed_tests.md
+++ b/needed_tests.md
@@ -1,0 +1,203 @@
+# Needed CI Tests for PR #38139
+# Warmup calls in metal tests (same as vLLM)
+
+---
+
+## models/common/demos/llama31_8B_demo.py
+
+**CI Workflow:** `t3000-e2e-tests-impl.yaml`
+**Pipeline config:** `tests/pipeline_reorg/t3k_e2e_tests.yaml`
+**Job name:** `models_tttv2_llama31_8B_tests`
+
+```
+MESH_DEVICE=T3K HF_HUB_OFFLINE=1 HF_HOME=/mnt/MLPerf/huggingface \
+HF_MODEL=meta-llama/Llama-3.1-8B-Instruct \
+TT_CACHE_PATH=/mnt/MLPerf/huggingface/tt_cache/meta-llama--Llama-3.1-8B-Instruct \
+pytest --tb=short models/common/demos/llama31_8B_demo.py
+```
+
+---
+
+## models/demos/gpt_oss/demo/text_demo.py
+## models/demos/gpt_oss/tests/accuracy/test_model.py
+
+**CI Workflow:** `t3000-demo-tests-impl.yaml` (T3K) + `galaxy-unit-tests-impl.yaml` (Galaxy)
+**Pipeline configs:** `tests/pipeline_reorg/t3k_demo_tests.yaml`, `tests/pipeline_reorg/galaxy_demo_tests.yaml`
+**Shell script:** `tests/scripts/t3000/run_t3000_demo_tests.sh` → `run_t3000_gpt_oss_tests`
+**Job names:** `t3k_gpt_oss_tests` (T3K), Galaxy GPT-OSS job (Galaxy)
+
+T3K (1x8):
+```
+pytest models/demos/gpt_oss/demo/text_demo.py -k "1x8" --timeout 1000
+pytest models/demos/gpt_oss/tests/accuracy/test_model.py -k "1x8" --timeout 900
+```
+Galaxy (4x8):
+```
+pytest models/demos/gpt_oss/demo/text_demo.py -k "4x8" --timeout 1000
+pytest models/demos/gpt_oss/tests/accuracy/test_model.py -k "4x8" --timeout 900
+```
+
+---
+
+## models/demos/llama3_70b_galaxy/demo/text_demo.py
+## models/demos/llama3_70b_galaxy/demo/text_qwen_demo.py
+
+**CI Workflow:** `galaxy-unit-tests-impl.yaml`
+**Pipeline config:** `tests/pipeline_reorg/galaxy_demo_tests.yaml`
+
+```
+pytest models/demos/llama3_70b_galaxy/demo/text_demo.py -k "repeat" --timeout 1000
+pytest models/demos/llama3_70b_galaxy/demo/text_demo.py -k "pcc-80L" --timeout 1000
+pytest models/demos/llama3_70b_galaxy/demo/text_demo.py -k "batch-32-non-uniform-sampling" --timeout 500
+pytest models/demos/llama3_70b_galaxy/demo/text_qwen_demo.py -k "batch-32" --timeout 1000
+pytest models/demos/llama3_70b_galaxy/demo/text_qwen_demo.py -k "repeat2" --timeout 1000
+pytest models/demos/llama3_70b_galaxy/demo/text_qwen_demo.py -k "long-8k-b1" --timeout 1000
+```
+
+---
+
+## models/demos/multimodal/gemma3/demo/text_demo.py
+## models/demos/multimodal/gemma3/demo/vision_demo.py
+
+**CI Workflow:** `t3000-demo-tests-impl.yaml` (T3K) + `single-card-demo-tests-impl.yaml` (N300)
+**Pipeline config:** `tests/pipeline_reorg/t3k_demo_tests.yaml`
+**Shell script:** `tests/scripts/t3000/run_t3000_demo_tests.sh` → `run_t3000_gemma3_tests`
+**Job names:** `t3k_gemma3_tests` (T3K), `gemma3` N300 (single-card)
+
+```
+pytest models/demos/multimodal/gemma3/demo/text_demo.py -k "performance and ci-1"
+pytest models/demos/multimodal/gemma3/demo/vision_demo.py -k "performance and batch1-multi-image-trace"
+```
+
+---
+
+## models/demos/qwen25_vl/demo/demo.py
+
+**CI Workflow:** `t3000-demo-tests-impl.yaml` (T3K) + `single-card-demo-tests-impl.yaml` (N150/N300)
+**Pipeline config:** `tests/pipeline_reorg/t3k_demo_tests.yaml`
+**Shell script:** `tests/scripts/t3000/run_t3000_demo_tests.sh` → `run_t3000_qwen25_vl_tests`
+**Job names:** `t3k_qwen25_vl_tests` (T3K), `qwen25_vl` N150/N300 (single-card)
+
+```
+pytest models/demos/qwen25_vl/demo/demo.py --timeout 900
+```
+
+---
+
+## models/demos/qwen3_vl/demo/demo.py
+
+**CI Workflow:** `t3000-demo-tests-impl.yaml`
+**Pipeline config:** `tests/pipeline_reorg/t3k_demo_tests.yaml`
+**Shell script:** `tests/scripts/t3000/run_t3000_demo_tests.sh` → `run_t3000_qwen3_vl_tests`
+**Job name:** `t3k_qwen3_vl_tests`
+
+```
+pytest models/demos/qwen3_vl/demo/demo.py --timeout 600
+```
+
+---
+
+## models/demos/tg/llama3_70b/demo/demo.py
+
+**CI Workflow:** `galaxy-unit-tests-impl.yaml`
+**Pipeline config:** `tests/pipeline_reorg/galaxy_demo_tests.yaml`
+**Note:** Only has `# ovde se init generator` placeholder comment added — old Llama generator,
+not WarmupForwardMixin. Real warmup handled internally by `demo_warmup()`. Low priority.
+
+---
+
+## models/tt_transformers/demo/simple_text_demo.py
+
+**CI Workflows:** `t3000-demo-tests-impl.yaml` (T3K) + `single-card-demo-tests-impl.yaml` (N150/N300)
+             + `galaxy-unit-tests-impl.yaml` (Galaxy)
+**Shell scripts:** `run_t3000_demo_tests.sh` + `run_single_card_demo_tests.sh`
+**Functions:** `run_t3000_llama3_tests`, `run_t3000_llama3_70b_tests`, `run_t3000_qwen25_tests`,
+              `run_t3000_mistral_tests`, `run_t3000_mixtral_tests`, `run_llama3_func`, `run_llama3_perf`
+
+This file is exercised by virtually every model's demo test — running any of the
+t3k_demo_tests or single-card demo tests will cover it.
+
+---
+
+## models/tt_transformers/demo/simple_vision_demo.py
+
+**CI Workflow:** `t3000-demo-tests-impl.yaml`
+**Shell script:** `tests/scripts/t3000/run_t3000_demo_tests.sh` → `run_t3000_llama3_vision_tests`
+**Job names:** `t3k_llama3_vision_tests`, `t3k_llama3_90b_vision_tests`
+
+```
+pytest models/tt_transformers/demo/simple_vision_demo.py -k "not batch1-notrace"
+pytest models/tt_transformers/demo/simple_vision_demo.py -k "batch1-trace"
+```
+
+---
+
+## models/tt_transformers/demo/multimodal_demo_chat.py
+## models/tt_transformers/demo/multimodal_demo_text.py
+
+**CI Workflow:** NOT IN ANY CI PIPELINE
+**Note:** Only has `# ovde se init generator` placeholder — vision warmup not yet implemented.
+No CI pipeline references found. No action needed until vision warmup is implemented.
+
+---
+
+## models/tt_transformers/tests/test_model_prefill.py
+## models/tt_transformers/tests/test_chunked_generation.py
+
+**CI Workflow:** `t3000-integration-tests-impl.yaml`
+**Shell script:** `tests/scripts/t3000/run_t3000_integration_tests.sh`
+**Functions:** `run_t3000_llama3_tests`, `run_t3000_llama3_70b_tests`, `run_t3000_llama3_90b_tests`
+
+```
+pytest models/tt_transformers/tests/test_model_prefill.py
+pytest models/tt_transformers/tests/test_chunked_generation.py
+```
+
+---
+
+## models/tt_transformers/tests/mixtral/test_mixtral_model_prefill.py
+
+**CI Workflow:** `t3000-unit-tests-impl.yaml`
+**Shell script:** `tests/scripts/t3000/run_t3000_unit_tests.sh` → `run_t3000_mixtral_tests`
+**Job name:** `t3k_mixtral_tests`
+
+```
+HF_MODEL=$mixtral8x7 TT_CACHE_PATH=$tt_cache_mixtral8x7 CI=true \
+pytest models/tt_transformers/tests/mixtral/test_mixtral_model_prefill.py::test_model_inference[wormhole_b0-device_params0-1layer-performance-max128k-4k-page_params0-paged_attention-8] --timeout=720
+```
+
+---
+
+## models/experimental/gemma3_4b/tests/vision_tests/test_end2end.py
+## models/experimental/mistral_24b/tests/pipeline_tests/test_end2end.py
+
+**CI Workflow:** NOT IN ANY CI PIPELINE
+**Note:** These files are new and have no CI pipeline references anywhere in
+.github/workflows/ or tests/pipeline_reorg/ or tests/scripts/. They need to be
+run manually or added to a pipeline before merging.
+
+---
+
+## Summary Table
+
+| Changed File | CI Workflow | In Pipeline? |
+|---|---|---|
+| common/demos/llama31_8B_demo.py | t3000-e2e-tests-impl.yaml | ✅ |
+| demos/gpt_oss/demo/text_demo.py | t3000-demo-tests-impl.yaml + galaxy | ✅ |
+| demos/gpt_oss/tests/accuracy/test_model.py | t3000-demo-tests-impl.yaml + galaxy | ✅ |
+| demos/llama3_70b_galaxy/demo/text_demo.py | galaxy-unit-tests-impl.yaml | ✅ |
+| demos/llama3_70b_galaxy/demo/text_qwen_demo.py | galaxy-unit-tests-impl.yaml | ✅ |
+| demos/multimodal/gemma3/demo/text_demo.py | t3000-demo-tests-impl.yaml + single-card | ✅ |
+| demos/multimodal/gemma3/demo/vision_demo.py | t3000-demo-tests-impl.yaml + single-card | ✅ |
+| demos/qwen25_vl/demo/demo.py | t3000-demo-tests-impl.yaml + single-card | ✅ |
+| demos/qwen3_vl/demo/demo.py | t3000-demo-tests-impl.yaml | ✅ |
+| demos/tg/llama3_70b/demo/demo.py | galaxy-unit-tests-impl.yaml | ✅ (placeholder only) |
+| tt_transformers/demo/simple_text_demo.py | t3000-demo + single-card + galaxy | ✅ |
+| tt_transformers/demo/simple_vision_demo.py | t3000-demo-tests-impl.yaml | ✅ |
+| tt_transformers/demo/multimodal_demo_chat.py | None | ❌ not in pipeline |
+| tt_transformers/demo/multimodal_demo_text.py | None | ❌ not in pipeline |
+| tt_transformers/tests/test_model_prefill.py | t3000-integration-tests-impl.yaml | ✅ |
+| tt_transformers/tests/test_chunked_generation.py | t3000-integration-tests-impl.yaml | ✅ |
+| tt_transformers/tests/mixtral/test_mixtral_model_prefill.py | t3000-unit-tests-impl.yaml | ✅ |
+| experimental/gemma3_4b/tests/vision_tests/test_end2end.py | None | ❌ not in pipeline |
+| experimental/mistral_24b/tests/pipeline_tests/test_end2end.py | None | ❌ not in pipeline |


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Provide context for the problem.

### What's changed
Describe the approach used to solve the problem.
Summarize the changes made and its impact.

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=nostojic/call_warmup_metal_same_as_vllm)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:nostojic/call_warmup_metal_same_as_vllm)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=nostojic/call_warmup_metal_same_as_vllm)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:nostojic/call_warmup_metal_same_as_vllm)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nostojic/call_warmup_metal_same_as_vllm)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nostojic/call_warmup_metal_same_as_vllm)
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nostojic/call_warmup_metal_same_as_vllm)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nostojic/call_warmup_metal_same_as_vllm)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nostojic/call_warmup_metal_same_as_vllm)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nostojic/call_warmup_metal_same_as_vllm)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nostojic/call_warmup_metal_same_as_vllm)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nostojic/call_warmup_metal_same_as_vllm)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
