### PR TITLE
[tt-train] softmax_backward kernel implementation

### DIFF
--- a/tt-train/sources/ttml/CMakeLists.txt
+++ b/tt-train/sources/ttml/CMakeLists.txt
@@ -61,6 +61,7 @@ set(SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/ops/reshape_op.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/ops/rmsnorm_op.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/ops/rope_op.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/ops/softmax_backward_op.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/ops/scaled_dot_product_attention.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/ops/swiglu_op.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/ops/unary_ops.cpp
@@ -120,6 +121,10 @@ set(METAL_OPS_FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/metal/ops/softmax/softmax.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/metal/ops/softmax/device/softmax_device_operation.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/metal/ops/softmax/device/softmax_program_factory.cpp
+    # Softmax Backward
+    ${CMAKE_CURRENT_SOURCE_DIR}/metal/ops/softmax_backward/softmax_backward.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/metal/ops/softmax_backward/device/softmax_backward_device_operation.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/metal/ops/softmax_backward/device/softmax_backward_program_factory.cpp
     # ProfilerNoOp
     ${CMAKE_CURRENT_SOURCE_DIR}/metal/ops/profiler_no_op/profiler_no_op.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/metal/ops/profiler_no_op/device/profiler_no_op_device_operation.cpp

--- a/tt-train/sources/ttml/metal/common/compute_utils.hpp
+++ b/tt-train/sources/ttml/metal/common/compute_utils.hpp
@@ -45,6 +45,15 @@ inline void zero_dst_reg(const uint32_t i) {
     fill_tile(i, zero);
 }
 
+// Create and push a zero tile to the specified circular buffer
+inline void push_zero_tile(const uint32_t cb_id) {
+    constexpr uint32_t DST_REG_ID = 0;
+    tile_regs_acquire();
+    zero_dst_reg(DST_REG_ID);
+    tile_regs_commit();
+    pack_and_push(DST_REG_ID, cb_id);
+}
+
 inline void pack_and_push_two_blocks(uint32_t cb_output_1, uint32_t cb_output_2, uint32_t block_size) {
     // NOTE:
     // Packs two blocks from consecutive registers to two output circular buffers.

--- a/tt-train/sources/ttml/metal/common/dataflow_utils.hpp
+++ b/tt-train/sources/ttml/metal/common/dataflow_utils.hpp
@@ -6,18 +6,23 @@
 
 #include <cstdint>
 #include <cstring>
+#include <tt-metalium/constants.hpp>
 
 #include "api/dataflow/dataflow_api.h"
 #include "api/debug/dprint.h"
 #include "api/debug/dprint_pages.h"
 
-constexpr uint32_t TILE_WIDTH = 32U;
-constexpr uint32_t TILE_HEIGHT = 32U;
-constexpr uint32_t FACE_WIDTH = 16U;
-constexpr uint32_t FACE_HEIGHT = 16U;
 constexpr uint32_t onetile = 1U;
 
+// IEEE 754 bit representations for compile-time template parameters
+constexpr uint32_t FP32_ONE_BITS = 0x3F800000;    // 1.0f
+constexpr uint32_t FP32_ZERO_BITS = 0x00000000;   // 0.0f
+constexpr uint16_t BF16_ONE_BITS = 0x3F80;        // 1.0 in bfloat16
+constexpr uint16_t BF16_ZERO_BITS = 0x0000;       // 0.0 in bfloat16
+constexpr uint32_t BF16_ONE_PACKED = 0x3f803f80;  // BF16(1.0) packed twice into u32
+
 inline uint32_t get_tilized_idx(uint32_t h, uint32_t w) {
+    using namespace tt::constants;
     // Get local coordinates within the tile
     uint32_t local_row = h % TILE_HEIGHT;
     uint32_t local_col = w % TILE_WIDTH;
@@ -127,10 +132,6 @@ inline void generate_matmul_row_reduce_tile(uint32_t cb_id) {
 
     cb_reserve_back(cb_id, onetile);
 
-    // IEEE 754 bit representations for compile-time template parameters
-    constexpr uint32_t FP32_ONE_BITS = 0x3F800000;  // 1.0f
-    constexpr uint16_t BF16_ONE_BITS = 0x3F80;      // 1.0 in bfloat16
-
     switch (data_format) {
         case DataFormat::Float32: fill_matmul_row_reduce_tile<uint32_t, FP32_ONE_BITS>(cb_id); break;
         case DataFormat::Int32:
@@ -150,6 +151,7 @@ inline void generate_matmul_row_reduce_tile(uint32_t cb_id) {
 // This creates a triangular pattern within the 32x32 tile for causal attention.
 template <typename T, T one_value, T zero_value>
 inline void fill_causal_mask_tile(uint32_t cb_id) {
+    using namespace tt::constants;
     T* tile_ptr = reinterpret_cast<T*>(get_write_ptr(cb_id));
 
     for (uint32_t face = 0; face < 4; ++face) {
@@ -173,12 +175,6 @@ inline void generate_causal_mask_tile(uint32_t cb_id) {
     const DataFormat data_format = get_dataformat(cb_id);
 
     cb_reserve_back(cb_id, onetile);
-
-    // IEEE 754 bit representations for compile-time template parameters
-    constexpr uint32_t FP32_ONE_BITS = 0x3F800000;   // 1.0f
-    constexpr uint32_t FP32_ZERO_BITS = 0x00000000;  // 0.0f
-    constexpr uint16_t BF16_ONE_BITS = 0x3F80;       // 1.0 in bfloat16
-    constexpr uint16_t BF16_ZERO_BITS = 0x0000;      // 0.0 in bfloat16
 
     switch (data_format) {
         case DataFormat::Float32: fill_causal_mask_tile<uint32_t, FP32_ONE_BITS, FP32_ZERO_BITS>(cb_id); break;

--- a/tt-train/sources/ttml/metal/common/dataflow_utils.hpp
+++ b/tt-train/sources/ttml/metal/common/dataflow_utils.hpp
@@ -98,6 +98,21 @@ void generate_bcast_scalar_bfloat16(uint32_t cb_id, uint32_t packed_scalar) {
     cb_push_back(cb_id, onetile);
 }
 
+// Zero-fills already-reserved tile slots in a CB (e.g. tail padding so compute always sees block_size tiles).
+inline void fill_reserved_tiles_with_zero(uint32_t cb_id, uint32_t start_slot, uint32_t num_slots, uint32_t tile_size) {
+    if (num_slots == 0) {
+        return;
+    }
+    uint32_t l1_base = get_write_ptr(cb_id) + start_slot * tile_size;
+    const uint32_t num_u32_per_tile = tile_size / sizeof(uint32_t);
+    for (uint32_t s = 0; s < num_slots; ++s) {
+        volatile tt_l1_ptr uint32_t* ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(l1_base + s * tile_size);
+        for (uint32_t i = 0; i < num_u32_per_tile; ++i) {
+            ptr[i] = 0;
+        }
+    }
+}
+
 // Fills a tile (32x32 bfloat16 values) with a single bfloat16 value.
 // This avoids writing 1024 individual 16-bit values by packing them into 512 32-bit writes.
 void generate_tile_with_bfloat16_value(uint32_t cb_id, uint16_t bf16_value) {

--- a/tt-train/sources/ttml/metal/operations.hpp
+++ b/tt-train/sources/ttml/metal/operations.hpp
@@ -15,6 +15,7 @@
 #include "ops/sdpa_fw/sdpa_fw.hpp"
 #include "ops/silu_bw/silu_bw.hpp"
 #include "ops/softmax/softmax.hpp"
+#include "ops/softmax_backward/softmax_backward.hpp"
 #include "ops/swiglu_fw/swiglu_fw.hpp"
 #include "optimizers/adamw/adamw.hpp"
 #include "optimizers/sgd_fused/sgd_fused.hpp"

--- a/tt-train/sources/ttml/metal/ops/cross_entropy_bw/device/kernels/dataflow/writer_cross_entropy_bw_interleaved_start_id.cpp
+++ b/tt-train/sources/ttml/metal/ops/cross_entropy_bw/device/kernels/dataflow/writer_cross_entropy_bw_interleaved_start_id.cpp
@@ -10,6 +10,7 @@
 #include "tt-train/sources/ttml/metal/common/dataflow_utils.hpp"
 
 void kernel_main() {
+    using namespace tt::constants;
     uint32_t runtime_args_counter = 0;
     uint32_t output_addr = get_arg_val<uint32_t>(runtime_args_counter++);
     uint32_t num_rows_to_process = get_arg_val<uint32_t>(runtime_args_counter++);

--- a/tt-train/sources/ttml/metal/ops/cross_entropy_fw/device/kernels/dataflow/reader_cross_entropy_fw_interleaved_start_id.cpp
+++ b/tt-train/sources/ttml/metal/ops/cross_entropy_fw/device/kernels/dataflow/reader_cross_entropy_fw_interleaved_start_id.cpp
@@ -10,6 +10,7 @@
 #include "tt-train/sources/ttml/metal/common/dataflow_utils.hpp"
 
 void kernel_main() {
+    using namespace tt::constants;
     uint32_t runtime_args_counter = 0U;
     uint32_t input_address = get_arg_val<uint32_t>(runtime_args_counter++);        // input buffer address
     uint32_t target_address = get_arg_val<uint32_t>(runtime_args_counter++);       // target buffer address

--- a/tt-train/sources/ttml/metal/ops/softmax_backward/device/kernels/compute/softmax_backward_kernel.cpp
+++ b/tt-train/sources/ttml/metal/ops/softmax_backward/device/kernels/compute/softmax_backward_kernel.cpp
@@ -1,0 +1,176 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "api/compute/bcast.h"
+#include "api/compute/common.h"
+#include "api/compute/eltwise_binary.h"
+#include "api/compute/eltwise_unary/fill.h"
+#include "api/compute/matmul.h"
+#include "api/compute/tile_move_copy.h"
+#include "tt-train/sources/ttml/metal/common/compute_utils.hpp"
+
+constexpr uint32_t DST_REG_ID = 0;
+constexpr uint32_t ONE_TILE = 1;
+
+// Caller is responsible for waiting cb_wait_front(icb_ones, onetile);
+ALWI void reduce_tile_to_cb(uint32_t icb0, uint32_t icb_ones, uint32_t ocb, uint32_t size) {
+    tile_regs_acquire();
+
+    // Initialize matmul - will accumulate across all tiles
+    mm_init(icb0, icb_ones, ocb, /*transpose*/ 0);
+
+    for (uint32_t x = 0; x < size; ++x) {
+        cb_wait_front(icb0, x + 1);  // must be a cumulative wait for correctness
+
+        // Multiply tile x with ones vector and accumulate to dst0
+        // false = no transpose, enables accumulation behavior
+        matmul_tiles(icb0, icb_ones, x, 0, DST_REG_ID);
+    }
+
+    tile_regs_commit();
+    pack_and_push(DST_REG_ID, ocb);
+}
+
+// Multiply two tiles from CBs
+// Note: caller must ensure tiles are available via cb_wait_front before calling
+ALWI void elementwise_multiply(uint32_t src0_cb_id, uint32_t src1_cb_id, uint32_t out_cb_id, uint32_t block_size) {
+    mul_tiles_init(src0_cb_id, src1_cb_id);
+    for (uint32_t i = 0; i < block_size; ++i) {
+        tile_regs_acquire();
+        mul_tiles(src0_cb_id, src1_cb_id, i, i, DST_REG_ID);
+        tile_regs_commit();
+        pack_and_push(DST_REG_ID, out_cb_id);
+    }
+}
+
+// Add a new value to an accumulator and replace the accumulator with the result
+// Reads from accum_cb and addend_cb, pops both, then pushes result back to accum_cb
+ALWI void accumulate(uint32_t accum_cb_id, uint32_t addend_cb_id) {
+    // Wait for both inputs
+    cb_wait_front(accum_cb_id, ONE_TILE);
+    cb_wait_front(addend_cb_id, ONE_TILE);
+
+    // Add them together
+    add_tiles_init(accum_cb_id, addend_cb_id);
+    tile_regs_acquire();
+    add_tiles(accum_cb_id, addend_cb_id, 0, 0, DST_REG_ID);
+    tile_regs_commit();
+    tile_regs_wait();
+
+    // Pop old values
+    cb_pop_front(accum_cb_id, ONE_TILE);
+    cb_pop_front(addend_cb_id, ONE_TILE);
+
+    // Write updated sum back to accumulator CB
+    pack_and_push(DST_REG_ID, accum_cb_id);
+}
+
+// Fused subtract and multiply: output = y * (grad - sum)
+// Reuses DST register to eliminate intermediate CB write/read
+ALWI void fused_sub_mul(
+    uint32_t y_cb_id,           // y (softmax output)
+    uint32_t grad_cb_id,        // grad (upstream gradient)
+    uint32_t sum_reduce_cb_id,  // sum(y * grad) - broadcasted scalar
+    uint32_t out_cb_id,         // output
+    uint32_t y_tile_idx,
+    uint32_t grad_tile_idx) {
+    tile_regs_acquire();
+
+    // Step 1: Compute grad - sum(y * grad) and store in DST[0]
+    sub_bcast_cols_init_short(grad_cb_id, sum_reduce_cb_id);
+    sub_tiles_bcast<BROADCAST_TYPE>(grad_cb_id, sum_reduce_cb_id, grad_tile_idx, 0, DST_REG_ID);
+
+    // Step 2: Multiply y * DST[0], reusing the DST register
+    binary_dest_reuse_tiles_init<ELWMUL, EltwiseBinaryReuseDestType::DEST_TO_SRCA>(y_cb_id);
+    binary_dest_reuse_tiles<ELWMUL, EltwiseBinaryReuseDestType::DEST_TO_SRCA>(y_cb_id, y_tile_idx, DST_REG_ID);
+
+    tile_regs_commit();
+    pack_and_push(DST_REG_ID, out_cb_id);
+}
+
+void kernel_main() {
+    // Compile time args
+    constexpr uint32_t y_cb_id = get_compile_time_arg_val(0);            // softmax_output (y)
+    constexpr uint32_t grad_cb_id = get_compile_time_arg_val(1);         // upstream_grad (grad)
+    constexpr uint32_t out_cb_id = get_compile_time_arg_val(2);          // output
+    constexpr uint32_t mul_cb_id = get_compile_time_arg_val(3);          // y * grad
+    constexpr uint32_t sum_reduce_cb_id = get_compile_time_arg_val(4);   // sum(y * grad) - accumulated
+    constexpr uint32_t ones_cb_id = get_compile_time_arg_val(5);         // ones vector for matmul reduction
+    constexpr uint32_t block_sum_cb_id = get_compile_time_arg_val(6);    // block sum temporary
+    constexpr uint32_t num_tiles_per_row = get_compile_time_arg_val(7);  // width in tiles
+    constexpr uint32_t tiles_per_block = get_compile_time_arg_val(8);  // block size - must match reader/writer kernels
+    constexpr bool full_row_in_l1 = (num_tiles_per_row == tiles_per_block);  // skip second read when full row fits
+
+    // Runtime args
+    const uint32_t num_rows = get_arg_val<uint32_t>(0);  // Number of rows to process
+
+    // Initialize compute operations
+    binary_op_init_common(y_cb_id, grad_cb_id, out_cb_id);
+
+    // Two-pass streaming algorithm for minimal L1 memory
+    for (uint32_t row = 0; row < num_rows; ++row) {
+        // === PASS 1: Streaming reduction to compute sum(y * grad) ===
+        cb_wait_front(ones_cb_id, ONE_TILE);
+
+        // Initialize accumulator with a zero tile
+        push_zero_tile(sum_reduce_cb_id);
+
+        // Process in blocks: compute products, then accumulate each block
+        for (uint32_t block_start = 0; block_start < num_tiles_per_row; block_start += tiles_per_block) {
+            const uint32_t current_block_size = std::min(tiles_per_block, num_tiles_per_row - block_start);
+
+            // Wait for this block from reader
+            cb_wait_front(y_cb_id, current_block_size);
+            cb_wait_front(grad_cb_id, current_block_size);
+
+            // Step 1a: Compute y * grad for all tiles in this block (elementwise multiplication)
+            elementwise_multiply(y_cb_id, grad_cb_id, mul_cb_id, current_block_size);
+
+            // Step 1b: Reduce this block to a single sum tile using matmul with ones
+            // Write block sum to temporary CB
+            reduce_tile_to_cb(mul_cb_id, ones_cb_id, block_sum_cb_id, current_block_size);
+
+            // Step 1c: Add block sum to running total
+            // accumulated_sum = accumulated_sum + block_sum
+            accumulate(sum_reduce_cb_id, block_sum_cb_id);
+
+            // Pop this block
+            cb_pop_front(mul_cb_id, current_block_size);
+            if constexpr (!full_row_in_l1) {
+                cb_pop_front(y_cb_id, current_block_size);
+                cb_pop_front(grad_cb_id, current_block_size);
+            }
+        }
+
+        // === PASS 2: Compute final output (reuse data when full row in L1, else fresh read) ===
+        cb_wait_front(sum_reduce_cb_id, ONE_TILE);
+
+        for (uint32_t block_start = 0; block_start < num_tiles_per_row; block_start += tiles_per_block) {
+            const uint32_t current_block_size = std::min(tiles_per_block, num_tiles_per_row - block_start);
+
+            if constexpr (!full_row_in_l1) {
+                // Wait for fresh block from reader (pass 2 read)
+                cb_wait_front(y_cb_id, current_block_size);
+                cb_wait_front(grad_cb_id, current_block_size);
+            }
+
+            // Process each tile: compute y * (grad - sum)
+            for (uint32_t i = 0; i < current_block_size; ++i) {
+                fused_sub_mul(
+                    y_cb_id,           // y
+                    grad_cb_id,        // grad
+                    sum_reduce_cb_id,  // sum(y * grad)
+                    out_cb_id,         // output
+                    i,                 // y tile index (relative to block)
+                    i);                // grad tile index (relative to block)
+            }
+
+            cb_pop_front(y_cb_id, current_block_size);
+            cb_pop_front(grad_cb_id, current_block_size);
+        }
+
+        // Pop sum for this row
+        cb_pop_front(sum_reduce_cb_id, ONE_TILE);
+    }
+}

--- a/tt-train/sources/ttml/metal/ops/softmax_backward/device/kernels/compute/softmax_backward_kernel.cpp
+++ b/tt-train/sources/ttml/metal/ops/softmax_backward/device/kernels/compute/softmax_backward_kernel.cpp
@@ -5,24 +5,21 @@
 #include "api/compute/bcast.h"
 #include "api/compute/common.h"
 #include "api/compute/eltwise_binary.h"
-#include "api/compute/eltwise_unary/fill.h"
 #include "api/compute/matmul.h"
-#include "api/compute/tile_move_copy.h"
 #include "tt-train/sources/ttml/metal/common/compute_utils.hpp"
 
 constexpr uint32_t DST_REG_ID = 0;
 constexpr uint32_t ONE_TILE = 1;
 
 // Caller is responsible for waiting cb_wait_front(icb_ones, onetile);
-ALWI void reduce_tile_to_cb(uint32_t icb0, uint32_t icb_ones, uint32_t ocb, uint32_t size) {
+ALWI void reduce_tile_to_cb(uint32_t icb0, uint32_t icb_ones, uint32_t ocb, uint32_t num_tiles) {
     tile_regs_acquire();
 
     // Initialize matmul - will accumulate across all tiles
     mm_init(icb0, icb_ones, ocb, /*transpose*/ 0);
 
-    for (uint32_t x = 0; x < size; ++x) {
-        cb_wait_front(icb0, x + 1);  // must be a cumulative wait for correctness
-
+    cb_wait_front(icb0, num_tiles);
+    for (uint32_t x = 0; x < num_tiles; ++x) {
         // Multiply tile x with ones vector and accumulate to dst0
         // false = no transpose, enables accumulation behavior
         matmul_tiles(icb0, icb_ones, x, 0, DST_REG_ID);
@@ -32,16 +29,30 @@ ALWI void reduce_tile_to_cb(uint32_t icb0, uint32_t icb_ones, uint32_t ocb, uint
     pack_and_push(DST_REG_ID, ocb);
 }
 
-// Multiply two tiles from CBs
-// Note: caller must ensure tiles are available via cb_wait_front before calling
-ALWI void elementwise_multiply(uint32_t src0_cb_id, uint32_t src1_cb_id, uint32_t out_cb_id, uint32_t block_size) {
+// Multiply tiles from two CBs; FullRowInL1 chooses row (per-tile pack) vs block (batch pack) code path.
+template <bool FullRowInL1>
+ALWI void elementwise_multiply(uint32_t src0_cb_id, uint32_t src1_cb_id, uint32_t out_cb_id, uint32_t size);
+
+template <>
+ALWI void elementwise_multiply<true>(uint32_t src0_cb_id, uint32_t src1_cb_id, uint32_t out_cb_id, uint32_t size) {
     mul_tiles_init(src0_cb_id, src1_cb_id);
-    for (uint32_t i = 0; i < block_size; ++i) {
+    for (uint32_t i = 0; i < size; ++i) {
         tile_regs_acquire();
         mul_tiles(src0_cb_id, src1_cb_id, i, i, DST_REG_ID);
         tile_regs_commit();
         pack_and_push(DST_REG_ID, out_cb_id);
     }
+}
+
+template <>
+ALWI void elementwise_multiply<false>(uint32_t src0_cb_id, uint32_t src1_cb_id, uint32_t out_cb_id, uint32_t size) {
+    mul_tiles_init(src0_cb_id, src1_cb_id);
+    tile_regs_acquire();
+    for (uint32_t i = 0; i < size; ++i) {
+        mul_tiles(src0_cb_id, src1_cb_id, i, i, i);
+    }
+    tile_regs_commit();
+    pack_and_push_block(out_cb_id, size);
 }
 
 // Add a new value to an accumulator and replace the accumulator with the result
@@ -107,6 +118,7 @@ void kernel_main() {
 
     // Initialize compute operations
     binary_op_init_common(y_cb_id, grad_cb_id, out_cb_id);
+    cb_wait_front(ones_cb_id, ONE_TILE);
 
     // Two-pass streaming algorithm for minimal L1 memory
     for (uint32_t row = 0; row < num_rows; ++row) {
@@ -118,28 +130,24 @@ void kernel_main() {
 
         // Process in blocks: compute products, then accumulate each block
         for (uint32_t block_start = 0; block_start < num_tiles_per_row; block_start += tiles_per_block) {
-            const uint32_t current_block_size = std::min(tiles_per_block, num_tiles_per_row - block_start);
+            cb_wait_front(y_cb_id, tiles_per_block);
+            cb_wait_front(grad_cb_id, tiles_per_block);
 
-            // Wait for this block from reader
-            cb_wait_front(y_cb_id, current_block_size);
-            cb_wait_front(grad_cb_id, current_block_size);
+            // Step 1a: Compute y * grad for all tiles in this block (padding slots are 0*0=0)
+            elementwise_multiply<full_row_in_l1>(y_cb_id, grad_cb_id, mul_cb_id, tiles_per_block);
 
-            // Step 1a: Compute y * grad for all tiles in this block (elementwise multiplication)
-            elementwise_multiply(y_cb_id, grad_cb_id, mul_cb_id, current_block_size);
-
-            // Step 1b: Reduce this block to a single sum tile using matmul with ones
-            // Write block sum to temporary CB
-            reduce_tile_to_cb(mul_cb_id, ones_cb_id, block_sum_cb_id, current_block_size);
+            // Step 1b: Reduce this block to a single sum tile (padding tiles add 0 to sum)
+            reduce_tile_to_cb(mul_cb_id, ones_cb_id, block_sum_cb_id, tiles_per_block);
 
             // Step 1c: Add block sum to running total
             // accumulated_sum = accumulated_sum + block_sum
             accumulate(sum_reduce_cb_id, block_sum_cb_id);
 
             // Pop this block
-            cb_pop_front(mul_cb_id, current_block_size);
+            cb_pop_front(mul_cb_id, tiles_per_block);
             if constexpr (!full_row_in_l1) {
-                cb_pop_front(y_cb_id, current_block_size);
-                cb_pop_front(grad_cb_id, current_block_size);
+                cb_pop_front(y_cb_id, tiles_per_block);
+                cb_pop_front(grad_cb_id, tiles_per_block);
             }
         }
 
@@ -147,16 +155,13 @@ void kernel_main() {
         cb_wait_front(sum_reduce_cb_id, ONE_TILE);
 
         for (uint32_t block_start = 0; block_start < num_tiles_per_row; block_start += tiles_per_block) {
-            const uint32_t current_block_size = std::min(tiles_per_block, num_tiles_per_row - block_start);
-
             if constexpr (!full_row_in_l1) {
-                // Wait for fresh block from reader (pass 2 read)
-                cb_wait_front(y_cb_id, current_block_size);
-                cb_wait_front(grad_cb_id, current_block_size);
+                cb_wait_front(y_cb_id, tiles_per_block);
+                cb_wait_front(grad_cb_id, tiles_per_block);
             }
 
             // Process each tile: compute y * (grad - sum)
-            for (uint32_t i = 0; i < current_block_size; ++i) {
+            for (uint32_t i = 0; i < tiles_per_block; ++i) {
                 fused_sub_mul(
                     y_cb_id,           // y
                     grad_cb_id,        // grad
@@ -166,8 +171,8 @@ void kernel_main() {
                     i);                // grad tile index (relative to block)
             }
 
-            cb_pop_front(y_cb_id, current_block_size);
-            cb_pop_front(grad_cb_id, current_block_size);
+            cb_pop_front(y_cb_id, tiles_per_block);
+            cb_pop_front(grad_cb_id, tiles_per_block);
         }
 
         // Pop sum for this row

--- a/tt-train/sources/ttml/metal/ops/softmax_backward/device/kernels/dataflow/reader_softmax_backward.cpp
+++ b/tt-train/sources/ttml/metal/ops/softmax_backward/device/kernels/dataflow/reader_softmax_backward.cpp
@@ -1,0 +1,92 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+
+#include "api/dataflow/dataflow_api.h"
+#include "tt-train/sources/ttml/metal/common/dataflow_utils.hpp"
+#include "ttnn/kernel/dataflow/generate_mm_scaler.hpp"
+#include "ttnn/operations/kernel_helper_functions/pad_tile.hpp"
+
+void kernel_main() {
+    // Compile time args
+    constexpr uint32_t src0_cb_id = get_compile_time_arg_val(0);  // softmax_output
+    constexpr uint32_t src1_cb_id = get_compile_time_arg_val(1);  // upstream_grad
+    constexpr uint32_t ones_cb_id = get_compile_time_arg_val(2);  // ones vector for matmul reduction
+    constexpr uint32_t num_tiles_per_row = get_compile_time_arg_val(3);
+    constexpr uint32_t tiles_per_block = get_compile_time_arg_val(4);  // block size - must match compute/writer kernels
+    constexpr uint32_t mask_w = get_compile_time_arg_val(5);           // padding mask width (0 if no padding)
+    // Set up tensor accessors
+    constexpr auto softmax_output_args = TensorAccessorArgs<6>();
+    constexpr auto upstream_grad_args = TensorAccessorArgs<7>();
+
+    // Common runtime args (shared across all cores)
+    const uint32_t softmax_output_addr = get_common_arg_val<uint32_t>(0);
+    const uint32_t upstream_grad_addr = get_common_arg_val<uint32_t>(1);
+
+    // Per-core runtime args: work assignment for this core (supports arbitrary CoreRangeSet)
+    const uint32_t start_row = get_arg_val<uint32_t>(0);
+    const uint32_t num_rows = get_arg_val<uint32_t>(1);
+
+    // Get tile sizes
+    const uint32_t src0_tile_size = get_tile_size(src0_cb_id);
+    const uint32_t src1_tile_size = get_tile_size(src1_cb_id);
+
+    // Create tensor accessors
+    const auto softmax_output_accessor = TensorAccessor(softmax_output_args, softmax_output_addr, src0_tile_size);
+    const auto upstream_grad_accessor = TensorAccessor(upstream_grad_args, upstream_grad_addr, src1_tile_size);
+
+    // Generate a column vector of ones for matmul-based reduction (BF16 only)
+    generate_mm_scaler(ones_cb_id, BF16_ONE_PACKED);
+
+    // When full row fits in L1 (num_tiles_per_row == tiles_per_block), read once; else stream and read twice
+    constexpr bool full_row_in_l1 = (num_tiles_per_row == tiles_per_block);
+    constexpr uint32_t num_passes = full_row_in_l1 ? 1 : 2;
+
+    for (uint32_t row_idx = 0; row_idx < num_rows; ++row_idx) {
+        const uint32_t row_start_tile = (start_row + row_idx) * num_tiles_per_row;
+
+        for (uint32_t pass = 0; pass < num_passes; ++pass) {
+            for (uint32_t block_start = 0; block_start < num_tiles_per_row; block_start += tiles_per_block) {
+                const uint32_t current_block_size = std::min(tiles_per_block, num_tiles_per_row - block_start);
+
+                cb_reserve_back(src0_cb_id, current_block_size);
+                const uint32_t l1_write_addr_src0 = get_write_ptr(src0_cb_id);
+
+                cb_reserve_back(src1_cb_id, current_block_size);
+                const uint32_t l1_write_addr_src1 = get_write_ptr(src1_cb_id);
+
+                for (uint32_t i = 0; i < current_block_size; ++i) {
+                    const uint32_t curr_tile = row_start_tile + block_start + i;
+
+                    noc_async_read_page(curr_tile, softmax_output_accessor, l1_write_addr_src0 + i * src0_tile_size);
+                    noc_async_read_page(curr_tile, upstream_grad_accessor, l1_write_addr_src1 + i * src1_tile_size);
+                }
+
+                // Wait for all tiles in block to be read before masking
+                noc_async_read_barrier();
+
+                // Mask padded region in last tile of the row by replacing padded values with 0.0 (BF16 only)
+                if constexpr (mask_w > 0) {
+                    const uint32_t last_tile_idx_in_block = current_block_size - 1;
+                    const uint32_t global_last_tile_idx = block_start + current_block_size - 1;
+                    const bool block_contains_last_tile = (global_last_tile_idx == num_tiles_per_row - 1);
+
+                    if (block_contains_last_tile) {
+                        // Zero-fill padding in last tile (width-only; full tile height 32)
+                        fill_pad_tile<uint16_t, mask_w, 32>(
+                            l1_write_addr_src0 + last_tile_idx_in_block * src0_tile_size,
+                            static_cast<uint16_t>(BF16_ZERO_BITS));
+                        fill_pad_tile<uint16_t, mask_w, 32>(
+                            l1_write_addr_src1 + last_tile_idx_in_block * src1_tile_size,
+                            static_cast<uint16_t>(BF16_ZERO_BITS));
+                    }
+                }
+
+                cb_push_back(src0_cb_id, current_block_size);
+                cb_push_back(src1_cb_id, current_block_size);
+            }
+        }
+    }
+}

--- a/tt-train/sources/ttml/metal/ops/softmax_backward/device/kernels/dataflow/reader_softmax_backward.cpp
+++ b/tt-train/sources/ttml/metal/ops/softmax_backward/device/kernels/dataflow/reader_softmax_backward.cpp
@@ -51,30 +51,33 @@ void kernel_main() {
             for (uint32_t block_start = 0; block_start < num_tiles_per_row; block_start += tiles_per_block) {
                 const uint32_t current_block_size = std::min(tiles_per_block, num_tiles_per_row - block_start);
 
-                cb_reserve_back(src0_cb_id, current_block_size);
-                const uint32_t l1_write_addr_src0 = get_write_ptr(src0_cb_id);
+                const uint32_t block_start_tile = row_start_tile + block_start;
 
-                cb_reserve_back(src1_cb_id, current_block_size);
-                const uint32_t l1_write_addr_src1 = get_write_ptr(src1_cb_id);
+                // CB API requires the same tile count in all cb_* calls (must divide CB size).
+                // Always reserve/push tiles_per_block; only current_block_size tiles are read from DRAM.
+                read_tiles_by_row</* UseBarrier = */ false>(
+                    src0_cb_id,
+                    softmax_output_accessor,
+                    block_start_tile,
+                    current_block_size,
+                    src0_tile_size,
+                    tiles_per_block);
+                read_tiles_by_row</* UseBarrier = */ false>(
+                    src1_cb_id,
+                    upstream_grad_accessor,
+                    block_start_tile,
+                    current_block_size,
+                    src1_tile_size,
+                    tiles_per_block);
 
-                for (uint32_t i = 0; i < current_block_size; ++i) {
-                    const uint32_t curr_tile = row_start_tile + block_start + i;
-
-                    noc_async_read_page(curr_tile, softmax_output_accessor, l1_write_addr_src0 + i * src0_tile_size);
-                    noc_async_read_page(curr_tile, upstream_grad_accessor, l1_write_addr_src1 + i * src1_tile_size);
-                }
-
-                // Wait for all tiles in block to be read before masking
                 noc_async_read_barrier();
 
-                // Mask padded region in last tile of the row by replacing padded values with 0.0 (BF16 only)
                 if constexpr (mask_w > 0) {
-                    const uint32_t last_tile_idx_in_block = current_block_size - 1;
                     const uint32_t global_last_tile_idx = block_start + current_block_size - 1;
-                    const bool block_contains_last_tile = (global_last_tile_idx == num_tiles_per_row - 1);
-
-                    if (block_contains_last_tile) {
-                        // Zero-fill padding in last tile (width-only; full tile height 32)
+                    if (global_last_tile_idx == num_tiles_per_row - 1) {
+                        const uint32_t last_tile_idx_in_block = current_block_size - 1;
+                        const uint32_t l1_write_addr_src0 = get_write_ptr(src0_cb_id);
+                        const uint32_t l1_write_addr_src1 = get_write_ptr(src1_cb_id);
                         fill_pad_tile<uint16_t, mask_w, 32>(
                             l1_write_addr_src0 + last_tile_idx_in_block * src0_tile_size,
                             static_cast<uint16_t>(BF16_ZERO_BITS));
@@ -84,8 +87,15 @@ void kernel_main() {
                     }
                 }
 
-                cb_push_back(src0_cb_id, current_block_size);
-                cb_push_back(src1_cb_id, current_block_size);
+                // Zero-fill tail padding so compute always sees tiles_per_block tiles (no padding logic in compute).
+                if (current_block_size < tiles_per_block) {
+                    const uint32_t pad_slots = tiles_per_block - current_block_size;
+                    fill_reserved_tiles_with_zero(src0_cb_id, current_block_size, pad_slots, src0_tile_size);
+                    fill_reserved_tiles_with_zero(src1_cb_id, current_block_size, pad_slots, src1_tile_size);
+                }
+
+                cb_push_back(src0_cb_id, tiles_per_block);
+                cb_push_back(src1_cb_id, tiles_per_block);
             }
         }
     }

--- a/tt-train/sources/ttml/metal/ops/softmax_backward/device/kernels/dataflow/writer_softmax_backward.cpp
+++ b/tt-train/sources/ttml/metal/ops/softmax_backward/device/kernels/dataflow/writer_softmax_backward.cpp
@@ -1,0 +1,50 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+
+#include "api/dataflow/dataflow_api.h"
+#include "tt-train/sources/ttml/metal/common/dataflow_utils.hpp"
+
+void kernel_main() {
+    // Compile time args
+    constexpr uint32_t out_cb_id = get_compile_time_arg_val(0);
+    constexpr uint32_t num_tiles_per_row = get_compile_time_arg_val(1);
+    constexpr uint32_t tiles_per_block = get_compile_time_arg_val(2);
+
+    // Set up tensor accessor
+    constexpr auto output_args = TensorAccessorArgs<3>();
+
+    // Common runtime args (shared across all cores)
+    const uint32_t output_addr = get_common_arg_val<uint32_t>(0);
+
+    // Per-core runtime args: work assignment for this core (supports arbitrary CoreRangeSet)
+    const uint32_t start_row = get_arg_val<uint32_t>(0);
+    const uint32_t num_rows = get_arg_val<uint32_t>(1);
+
+    // Get tile size
+    const uint32_t out_tile_size = get_tile_size(out_cb_id);
+
+    // Create tensor accessor
+    const auto output_accessor = TensorAccessor(output_args, output_addr, out_tile_size);
+
+    // Write output rows in blocks
+    for (uint32_t row_idx = 0; row_idx < num_rows; ++row_idx) {
+        const uint32_t row_start_tile = (start_row + row_idx) * num_tiles_per_row;
+
+        // Process tiles in blocks within each row
+        for (uint32_t block_start = 0; block_start < num_tiles_per_row; block_start += tiles_per_block) {
+            // Calculate block size (handle remainder)
+            const uint32_t current_block_size = std::min(tiles_per_block, num_tiles_per_row - block_start);
+
+            write_tiles_by_row(
+                out_cb_id,
+                output_accessor,
+                row_start_tile + block_start,
+                current_block_size,
+                out_tile_size,
+                current_block_size);
+        }
+    }
+}

--- a/tt-train/sources/ttml/metal/ops/softmax_backward/device/kernels/dataflow/writer_softmax_backward.cpp
+++ b/tt-train/sources/ttml/metal/ops/softmax_backward/device/kernels/dataflow/writer_softmax_backward.cpp
@@ -35,16 +35,15 @@ void kernel_main() {
 
         // Process tiles in blocks within each row
         for (uint32_t block_start = 0; block_start < num_tiles_per_row; block_start += tiles_per_block) {
-            // Calculate block size (handle remainder)
             const uint32_t current_block_size = std::min(tiles_per_block, num_tiles_per_row - block_start);
 
             write_tiles_by_row(
                 out_cb_id,
                 output_accessor,
                 row_start_tile + block_start,
-                current_block_size,
+                current_block_size,  // num_tiles_to_write to DRAM
                 out_tile_size,
-                current_block_size);
+                tiles_per_block);  // num_tiles_to_pop (fixed for CB API)
         }
     }
 }

--- a/tt-train/sources/ttml/metal/ops/softmax_backward/device/softmax_backward_device_operation.cpp
+++ b/tt-train/sources/ttml/metal/ops/softmax_backward/device/softmax_backward_device_operation.cpp
@@ -1,0 +1,82 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "softmax_backward_device_operation.hpp"
+
+#include "tt_stl/assert.hpp"
+#include "ttnn/device_operation.hpp"
+#include "ttnn/tensor/tensor.hpp"
+#include "ttnn/types.hpp"
+
+using namespace tt::tt_metal;
+
+namespace ttml::metal::ops::softmax_backward::device {
+
+void SoftmaxBackwardDeviceOperation::validate_on_program_cache_miss(
+    const operation_attributes_t& attributes, const tensor_args_t& tensor_args) {
+    const auto& softmax_output = tensor_args.softmax_output;
+    const auto& upstream_grad = tensor_args.upstream_grad;
+    TT_FATAL(
+        softmax_output.logical_shape() == upstream_grad.logical_shape(),
+        "Softmax output and upstream gradient tensors must have the same shape");
+    TT_FATAL(softmax_output.dtype() == DataType::BFLOAT16, "Softmax backward only supports BFLOAT16");
+    TT_FATAL(
+        upstream_grad.dtype() == softmax_output.dtype(),
+        "Softmax output and upstream gradient must have the same dtype");
+    TT_FATAL(softmax_output.layout() == Layout::TILE, "Softmax backward requires TILE layout");
+    TT_FATAL(upstream_grad.layout() == Layout::TILE, "Softmax backward requires TILE layout");
+    const auto rank = softmax_output.logical_shape().rank();
+    TT_FATAL(
+        attributes.dim == rank - 1,
+        "Currently only supporting softmax_backward on last dimension (got dim={}, rank={})",
+        attributes.dim,
+        rank);
+}
+
+SoftmaxBackwardDeviceOperation::spec_return_value_t SoftmaxBackwardDeviceOperation::compute_output_specs(
+    const operation_attributes_t& /*operation_attributes*/, const tensor_args_t& tensor_args) {
+    const auto& input_tensor = tensor_args.softmax_output;
+    return {
+        input_tensor.logical_shape(),
+        tt::tt_metal::TensorLayout(
+            input_tensor.dtype(), tt::tt_metal::PageConfig(input_tensor.layout()), input_tensor.memory_config())};
+}
+
+SoftmaxBackwardDeviceOperation::tensor_return_value_t SoftmaxBackwardDeviceOperation::create_output_tensors(
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
+    auto output_spec = compute_output_specs(operation_attributes, tensor_args);
+    return create_device_tensor(output_spec, tensor_args.softmax_output.device());
+}
+
+tt::tt_metal::operation::OpPerformanceModelGeneral<SoftmaxBackwardDeviceOperation::tensor_return_value_t>
+SoftmaxBackwardDeviceOperation::create_op_performance_model(
+    const operation_attributes_t& /*operation_attributes*/,
+    const tensor_args_t& tensor_args,
+    tensor_return_value_t& tensor_return_value) {
+    const auto& softmax_output = tensor_args.softmax_output;
+    const auto& upstream_grad = tensor_args.upstream_grad;
+    const auto& output_tensor = tensor_return_value;
+    // Placeholder; tt-train build does not depend on ttnn data_movement common_tm_bw_model.
+    constexpr int ideal_dev_clock_cycles = 0;
+    tt::tt_metal::operation::OpPerformanceModelGeneral<tensor_return_value_t> result(
+        {softmax_output, upstream_grad}, output_tensor, ideal_dev_clock_cycles);
+    return result;
+}
+
+}  // namespace ttml::metal::ops::softmax_backward::device
+
+namespace ttnn::prim {
+
+ttnn::Tensor ttml_softmax_backward(
+    const ttnn::Tensor& softmax_output,
+    const ttnn::Tensor& upstream_grad,
+    uint32_t dim,
+    const std::optional<tt::tt_metal::CoreRangeSet>& sub_core_grids) {
+    using OperationType = ttml::metal::ops::softmax_backward::device::SoftmaxBackwardDeviceOperation;
+    auto operation_attributes = OperationType::operation_attributes_t{dim, sub_core_grids};
+    auto tensor_args = OperationType::tensor_args_t{softmax_output, upstream_grad};
+    return ttnn::device_operation::launch<OperationType>(operation_attributes, tensor_args);
+}
+
+}  // namespace ttnn::prim

--- a/tt-train/sources/ttml/metal/ops/softmax_backward/device/softmax_backward_device_operation.hpp
+++ b/tt-train/sources/ttml/metal/ops/softmax_backward/device/softmax_backward_device_operation.hpp
@@ -1,0 +1,38 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <variant>
+
+#include "softmax_backward_device_operation_types.hpp"
+#include "softmax_backward_program_factory.hpp"
+
+namespace ttml::metal::ops::softmax_backward::device {
+
+struct SoftmaxBackwardDeviceOperation {
+    using operation_attributes_t = SoftmaxBackwardParams;
+    using tensor_args_t = SoftmaxBackwardInputs;
+    using spec_return_value_t = ttml::metal::ops::softmax_backward::device::spec_return_value_t;
+    using tensor_return_value_t = ttml::metal::ops::softmax_backward::device::tensor_return_value_t;
+    using program_factory_t = std::variant<SoftmaxBackwardFactory>;
+
+    static void validate_on_program_cache_miss(const operation_attributes_t&, const tensor_args_t&);
+    static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
+    static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
+    static tt::tt_metal::operation::OpPerformanceModelGeneral<tensor_return_value_t> create_op_performance_model(
+        const operation_attributes_t&, const tensor_args_t&, tensor_return_value_t&);
+};
+
+}  // namespace ttml::metal::ops::softmax_backward::device
+
+namespace ttnn::prim {
+
+ttnn::Tensor ttml_softmax_backward(
+    const ttnn::Tensor& softmax_output,
+    const ttnn::Tensor& upstream_grad,
+    uint32_t dim,
+    const std::optional<tt::tt_metal::CoreRangeSet>& sub_core_grids = std::nullopt);
+
+}  // namespace ttnn::prim

--- a/tt-train/sources/ttml/metal/ops/softmax_backward/device/softmax_backward_device_operation_types.hpp
+++ b/tt-train/sources/ttml/metal/ops/softmax_backward/device/softmax_backward_device_operation_types.hpp
@@ -1,0 +1,33 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+#include <optional>
+#include <tt-metalium/core_coord.hpp>
+#include <tt-metalium/kernel_types.hpp>
+#include <ttnn/tensor/tensor.hpp>
+
+namespace ttml::metal::ops::softmax_backward::device {
+
+struct SoftmaxBackwardParams {
+    uint32_t dim;
+    std::optional<tt::tt_metal::CoreRangeSet> sub_core_grids;
+};
+
+struct SoftmaxBackwardInputs {
+    ttnn::Tensor softmax_output;
+    ttnn::Tensor upstream_grad;
+};
+
+using spec_return_value_t = ttnn::TensorSpec;
+using tensor_return_value_t = ttnn::Tensor;
+
+struct shared_variables_t {
+    tt::tt_metal::KernelHandle unary_reader_kernel_id;
+    tt::tt_metal::KernelHandle unary_writer_kernel_id;
+};
+
+}  // namespace ttml::metal::ops::softmax_backward::device

--- a/tt-train/sources/ttml/metal/ops/softmax_backward/device/softmax_backward_program_factory.cpp
+++ b/tt-train/sources/ttml/metal/ops/softmax_backward/device/softmax_backward_program_factory.cpp
@@ -1,0 +1,292 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "softmax_backward_program_factory.hpp"
+
+#include <algorithm>
+#include <cstdint>
+#include <optional>
+#include <tt-logger/tt-logger.hpp>
+#include <tt-metalium/constants.hpp>
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/kernel_types.hpp>
+#include <tt-metalium/math.hpp>
+#include <tt-metalium/tensor_accessor_args.hpp>
+#include <tt-metalium/tt_backend_api_types.hpp>
+#include <utility>
+#include <vector>
+
+#include "hostdevcommon/kernel_structs.h"
+
+using namespace tt;
+using namespace tt::tt_metal;
+
+namespace {
+
+constexpr uint32_t src0_cb_index = tt::CBIndex::c_0;         // softmax_output
+constexpr uint32_t src1_cb_index = tt::CBIndex::c_1;         // upstream_grad
+constexpr uint32_t ones_cb_index = tt::CBIndex::c_2;         // ones vector for matmul reduction
+constexpr uint32_t out_cb_index = tt::CBIndex::c_7;          // output
+constexpr uint32_t ygrad_cb_index = tt::CBIndex::c_13;       // y * grad
+constexpr uint32_t sum_reduce_cb_index = tt::CBIndex::c_14;  // sum(y * grad) - accumulated
+constexpr uint32_t block_sum_cb_index = tt::CBIndex::c_15;   // block sum temporary
+
+constexpr const char* const kReaderPath =
+    "tt-train/sources/ttml/metal/ops/softmax_backward/device/kernels/dataflow/reader_softmax_backward.cpp";
+constexpr const char* const kWriterPath =
+    "tt-train/sources/ttml/metal/ops/softmax_backward/device/kernels/dataflow/writer_softmax_backward.cpp";
+constexpr const char* const kComputePath =
+    "tt-train/sources/ttml/metal/ops/softmax_backward/device/kernels/compute/softmax_backward_kernel.cpp";
+
+struct CoreRowAssignment {
+    CoreCoord core;
+    uint32_t start_row;
+    uint32_t num_rows;
+};
+
+static std::vector<CoreCoord> get_worker_cores_in_order(
+    const std::optional<CoreRangeSet>& sub_core_grids, const tt::tt_metal::IDevice* device) {
+    if (sub_core_grids.has_value()) {
+        const CoreRangeSet& sub = *sub_core_grids;
+        std::vector<CoreCoord> cores;
+        cores.reserve(sub.num_cores());
+        for (const CoreRange& range : sub.ranges()) {
+            for (CoreCoord core : range) {
+                cores.push_back(core);
+            }
+        }
+        return cores;
+    }
+    const CoreCoord grid_size = device->compute_with_storage_grid_size();
+    std::vector<CoreCoord> cores;
+    cores.reserve(grid_size.x * grid_size.y);
+    for (uint32_t x = 0; x < grid_size.x; ++x) {
+        for (uint32_t y = 0; y < grid_size.y; ++y) {
+            cores.emplace_back(x, y);
+        }
+    }
+    return cores;
+}
+
+static void assign_rows_to_cores(
+    const std::vector<CoreCoord>& cores_in_order,
+    uint32_t num_rows,
+    std::vector<CoreRange>& worker_core_ranges,
+    std::vector<CoreRowAssignment>& core_row_assignments) {
+    const uint32_t num_cores = static_cast<uint32_t>(cores_in_order.size());
+    if (num_cores == 0)
+        return;
+    const uint32_t rows_per_core = tt::div_up(num_rows, num_cores);
+    for (uint32_t core_idx = 0; core_idx < num_cores; ++core_idx) {
+        const uint32_t start_row = core_idx * rows_per_core;
+        if (start_row >= num_rows)
+            continue;
+        const uint32_t end_row = std::min(start_row + rows_per_core, num_rows);
+        const uint32_t num_rows_this_core = end_row - start_row;
+        if (num_rows_this_core == 0)
+            continue;
+        const CoreCoord& core = cores_in_order[core_idx];
+        worker_core_ranges.push_back(CoreRange(core, core));
+        core_row_assignments.push_back({core, start_row, num_rows_this_core});
+    }
+}
+
+}  // namespace
+
+namespace ttml::metal::ops::softmax_backward::device {
+
+struct KernelMode {
+    uint32_t buffering_multiplier;
+    uint32_t required_memory_bytes;
+    uint32_t tiles_per_block;
+};
+
+static KernelMode get_kernel_mode(uint32_t width_tiles, uint32_t tile_size, const tt::tt_metal::IDevice* device) {
+    const uint32_t available_L1_in_bytes =
+        device->l1_size_per_core() - device->allocator()->get_base_allocator_addr(tt::tt_metal::HalMemType::L1);
+    const uint32_t memory_needed =
+        (width_tiles * tile_size) * 4U + (1U * tile_size) * 2U;  // src0, src1, out, ygrad; sum_reduce, ones
+    const uint32_t tiles_per_block = (memory_needed < available_L1_in_bytes) ? width_tiles : 1U;
+    const uint32_t buffering_multiplier = (memory_needed * 2U > available_L1_in_bytes) ? 1U : 2U;
+    return {buffering_multiplier, memory_needed, tiles_per_block};
+}
+
+static void get_tensor_properties(
+    const ttnn::Tensor& softmax_output,
+    const SoftmaxBackwardParams& operation_attributes,
+    uint32_t& num_rows,
+    uint32_t& width_tiles,
+    uint32_t& mask_w,
+    tt::DataFormat& input_data_format,
+    tt::DataFormat& output_data_format,
+    tt::DataFormat& intermed_data_format,
+    uint32_t& input_tile_size,
+    uint32_t& output_tile_size,
+    uint32_t& intermed_tile_size,
+    const ttnn::Tensor& tensor_return_value) {
+    const uint32_t dim = operation_attributes.dim;
+    TT_FATAL(
+        dim == softmax_output.logical_shape().rank() - 1 || dim == static_cast<uint32_t>(-1),
+        "Currently only supporting softmax_backward on last dimension");
+    const uint32_t height = softmax_output.logical_shape()[-2];
+    const uint32_t width = softmax_output.logical_shape()[-1];
+    const auto tile = softmax_output.tensor_spec().tile();
+    const uint32_t tile_height = tile.get_height();
+    const uint32_t tile_width = tile.get_width();
+    const uint32_t height_tiles = height / tile_height;
+    width_tiles = tt::div_up(width, tile_width);
+    const uint32_t logical_width = softmax_output.logical_shape()[-1];
+    mask_w = logical_width % tile_width;
+    const uint64_t num_outer_dims = softmax_output.physical_volume() / height / width;
+    num_rows = num_outer_dims * height_tiles;
+    input_data_format = datatype_to_dataformat_converter(softmax_output.dtype());
+    output_data_format = datatype_to_dataformat_converter(tensor_return_value.dtype());
+    intermed_data_format = tt::DataFormat::Float16_b;
+    input_tile_size = tile_size(input_data_format);
+    output_tile_size = tile_size(output_data_format);
+    intermed_tile_size = tile_size(intermed_data_format);
+}
+
+static tt::tt_metal::ComputeConfig precise(
+    std::vector<uint32_t> compile_time_args, std::map<std::string, std::string> defines) {
+    tt::tt_metal::ComputeConfig config;
+    config.fp32_dest_acc_en = true;
+    config.math_approx_mode = false;
+    config.math_fidelity = MathFidelity::HiFi4;
+    config.compile_args = std::move(compile_time_args);
+    config.defines = std::move(defines);
+    return config;
+}
+
+SoftmaxBackwardFactory::cached_program_t SoftmaxBackwardFactory::create(
+    const SoftmaxBackwardParams& operation_attributes,
+    const SoftmaxBackwardInputs& tensor_args,
+    ttnn::Tensor& tensor_return_value) {
+    const ttnn::Tensor& softmax_output = tensor_args.softmax_output;
+    const ttnn::Tensor& upstream_grad = tensor_args.upstream_grad;
+    auto* device = softmax_output.device();
+    Program program = CreateProgram();
+
+    uint32_t num_rows, width_tiles, mask_w;
+    DataFormat input_data_format, output_data_format, intermed_data_format;
+    uint32_t input_tile_size, output_tile_size, intermed_tile_size;
+    get_tensor_properties(
+        softmax_output,
+        operation_attributes,
+        num_rows,
+        width_tiles,
+        mask_w,
+        input_data_format,
+        output_data_format,
+        intermed_data_format,
+        input_tile_size,
+        output_tile_size,
+        intermed_tile_size,
+        tensor_return_value);
+
+    const auto [buffering_multiplier, required_memory_bytes, tiles_per_block] =
+        get_kernel_mode(width_tiles, intermed_tile_size, device);
+
+    log_debug(
+        tt::LogOp,
+        "SoftmaxBackward: Using {} kernel | Shape: {}x{} tiles | Estimated L1: {} KB",
+        tiles_per_block == width_tiles ? "NON-STREAMING" : "STREAMING",
+        num_rows,
+        width_tiles,
+        required_memory_bytes / 1024);
+
+    // Collect worker cores in deterministic order and assign rows to each.
+    std::vector<CoreRange> worker_core_ranges;
+    std::vector<CoreRowAssignment> core_row_assignments;
+    const std::vector<CoreCoord> cores_in_order =
+        get_worker_cores_in_order(operation_attributes.sub_core_grids, device);
+    assign_rows_to_cores(cores_in_order, num_rows, worker_core_ranges, core_row_assignments);
+    TT_FATAL(!worker_core_ranges.empty(), "SoftmaxBackward: no cores have work");
+    const CoreRangeSet worker_cores(worker_core_ranges);
+
+    const uint32_t block_cb_size_in0 = buffering_multiplier * tiles_per_block * input_tile_size;
+    const uint32_t block_cb_size_out = buffering_multiplier * tiles_per_block * output_tile_size;
+    const uint32_t block_cb_size_intermed0 = buffering_multiplier * tiles_per_block * intermed_tile_size;
+
+    auto c_in0_config = CircularBufferConfig(block_cb_size_in0, {{src0_cb_index, input_data_format}})
+                            .set_page_size(src0_cb_index, input_tile_size);
+    CreateCircularBuffer(program, worker_cores, c_in0_config);
+    auto c_in1_config = CircularBufferConfig(block_cb_size_in0, {{src1_cb_index, input_data_format}})
+                            .set_page_size(src1_cb_index, input_tile_size);
+    CreateCircularBuffer(program, worker_cores, c_in1_config);
+    auto c_scaler_config = CircularBufferConfig(intermed_tile_size, {{ones_cb_index, intermed_data_format}})
+                               .set_page_size(ones_cb_index, intermed_tile_size);
+    CreateCircularBuffer(program, worker_cores, c_scaler_config);
+    auto c_out_config = CircularBufferConfig(block_cb_size_out, {{out_cb_index, output_data_format}})
+                            .set_page_size(out_cb_index, output_tile_size);
+    CreateCircularBuffer(program, worker_cores, c_out_config);
+    auto c_ygrad_config = CircularBufferConfig(block_cb_size_intermed0, {{ygrad_cb_index, intermed_data_format}})
+                              .set_page_size(ygrad_cb_index, intermed_tile_size);
+    CreateCircularBuffer(program, worker_cores, c_ygrad_config);
+    auto c_sum_reduce_config = CircularBufferConfig(intermed_tile_size, {{sum_reduce_cb_index, intermed_data_format}})
+                                   .set_page_size(sum_reduce_cb_index, intermed_tile_size);
+    CreateCircularBuffer(program, worker_cores, c_sum_reduce_config);
+    auto c_block_sum_config = CircularBufferConfig(intermed_tile_size, {{block_sum_cb_index, intermed_data_format}})
+                                  .set_page_size(block_sum_cb_index, intermed_tile_size);
+    CreateCircularBuffer(program, worker_cores, c_block_sum_config);
+
+    std::vector<uint32_t> reader_compile_time_args = {
+        src0_cb_index, src1_cb_index, ones_cb_index, width_tiles, tiles_per_block, mask_w};
+    TensorAccessorArgs(softmax_output.buffer()).append_to(reader_compile_time_args);
+    TensorAccessorArgs(upstream_grad.buffer()).append_to(reader_compile_time_args);
+
+    std::vector<uint32_t> writer_compile_time_args = {out_cb_index, width_tiles, tiles_per_block};
+    TensorAccessorArgs(tensor_return_value.buffer()).append_to(writer_compile_time_args);
+
+    const std::vector<uint32_t> compute_compile_time_args = {
+        src0_cb_index,
+        src1_cb_index,
+        out_cb_index,
+        ygrad_cb_index,
+        sum_reduce_cb_index,
+        ones_cb_index,
+        block_sum_cb_index,
+        width_tiles,
+        tiles_per_block};
+
+    std::map<std::string, std::string> compute_defines = {{"BROADCAST_TYPE", "BroadcastType::COL"}};
+    const ComputeConfig wconf = precise(compute_compile_time_args, compute_defines);
+
+    auto reader_kernel_id =
+        CreateKernel(program, kReaderPath, worker_cores, ReaderDataMovementConfig(reader_compile_time_args));
+    auto writer_kernel_id =
+        CreateKernel(program, kWriterPath, worker_cores, WriterDataMovementConfig(writer_compile_time_args));
+    auto compute_kernel_id = CreateKernel(program, kComputePath, worker_cores, wconf);
+
+    SetCommonRuntimeArgs(
+        program, reader_kernel_id, {softmax_output.buffer()->address(), upstream_grad.buffer()->address()});
+    SetCommonRuntimeArgs(program, writer_kernel_id, {tensor_return_value.buffer()->address()});
+    for (const CoreRowAssignment& a : core_row_assignments) {
+        SetRuntimeArgs(program, reader_kernel_id, a.core, {a.start_row, a.num_rows});
+        SetRuntimeArgs(program, writer_kernel_id, a.core, {a.start_row, a.num_rows});
+        SetRuntimeArgs(program, compute_kernel_id, a.core, {a.num_rows});
+    }
+
+    return {
+        std::move(program), {.unary_reader_kernel_id = reader_kernel_id, .unary_writer_kernel_id = writer_kernel_id}};
+}
+
+void SoftmaxBackwardFactory::override_runtime_arguments(
+    cached_program_t& cached_program,
+    const SoftmaxBackwardParams& /*operation_attributes*/,
+    const SoftmaxBackwardInputs& tensor_args,
+    ttnn::Tensor& tensor_return_value) {
+    const Program& program = cached_program.program;
+    const KernelHandle& reader_kernel_id = cached_program.shared_variables.unary_reader_kernel_id;
+    const KernelHandle& writer_kernel_id = cached_program.shared_variables.unary_writer_kernel_id;
+    const ttnn::Tensor& softmax_output = tensor_args.softmax_output;
+    const ttnn::Tensor& upstream_grad = tensor_args.upstream_grad;
+    RuntimeArgsData& reader_common_args = GetCommonRuntimeArgs(program, reader_kernel_id);
+    reader_common_args[0] = softmax_output.buffer()->address();
+    reader_common_args[1] = upstream_grad.buffer()->address();
+    RuntimeArgsData& writer_common_args = GetCommonRuntimeArgs(program, writer_kernel_id);
+    writer_common_args[0] = tensor_return_value.buffer()->address();
+}
+
+}  // namespace ttml::metal::ops::softmax_backward::device

--- a/tt-train/sources/ttml/metal/ops/softmax_backward/device/softmax_backward_program_factory.cpp
+++ b/tt-train/sources/ttml/metal/ops/softmax_backward/device/softmax_backward_program_factory.cpp
@@ -102,14 +102,20 @@ struct KernelMode {
     uint32_t tiles_per_block;
 };
 
+static constexpr uint32_t memory_estimator(uint32_t width_tiles, uint32_t tile_size) {
+    return (width_tiles * tile_size) * 4U + (1U * tile_size) * 2U;  // src0, src1, out, ygrad; sum_reduce, ones
+}
+
 static KernelMode get_kernel_mode(uint32_t width_tiles, uint32_t tile_size, const tt::tt_metal::IDevice* device) {
     const uint32_t available_L1_in_bytes =
         device->l1_size_per_core() - device->allocator()->get_base_allocator_addr(tt::tt_metal::HalMemType::L1);
-    const uint32_t memory_needed =
-        (width_tiles * tile_size) * 4U + (1U * tile_size) * 2U;  // src0, src1, out, ygrad; sum_reduce, ones
-    const uint32_t tiles_per_block = (memory_needed < available_L1_in_bytes) ? width_tiles : 1U;
-    const uint32_t buffering_multiplier = (memory_needed * 2U > available_L1_in_bytes) ? 1U : 2U;
-    return {buffering_multiplier, memory_needed, tiles_per_block};
+    const uint32_t full_row_memory_needed = memory_estimator(width_tiles, tile_size);
+    const uint32_t tiles_per_block = (full_row_memory_needed < available_L1_in_bytes) ? width_tiles : 4U;
+    const uint32_t new_estimation_memory_needed = memory_estimator(tiles_per_block, tile_size);
+    // Double buffering when total L1 with 2x fits: for streaming (small blocks) and for short rows (e.g. 6000x5).
+    // Long full rows (e.g. 127 tiles) get 1x so we stay under L1.
+    const uint32_t buffering_multiplier = (new_estimation_memory_needed * 2U <= available_L1_in_bytes) ? 2U : 1U;
+    return {buffering_multiplier, new_estimation_memory_needed, tiles_per_block};
 }
 
 static void get_tensor_properties(
@@ -190,10 +196,11 @@ SoftmaxBackwardFactory::cached_program_t SoftmaxBackwardFactory::create(
 
     log_debug(
         tt::LogOp,
-        "SoftmaxBackward: Using {} kernel | Shape: {}x{} tiles | Estimated L1: {} KB",
+        "SoftmaxBackward: Using {} kernel | Shape: {}x{} tiles | {}x buffering | Estimated L1: {} KB",
         tiles_per_block == width_tiles ? "NON-STREAMING" : "STREAMING",
         num_rows,
         width_tiles,
+        buffering_multiplier,
         required_memory_bytes / 1024);
 
     // Collect worker cores in deterministic order and assign rows to each.

--- a/tt-train/sources/ttml/metal/ops/softmax_backward/device/softmax_backward_program_factory.hpp
+++ b/tt-train/sources/ttml/metal/ops/softmax_backward/device/softmax_backward_program_factory.hpp
@@ -1,0 +1,30 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <tt-metalium/kernel_types.hpp>
+#include <ttnn/device_operation.hpp>
+
+#include "softmax_backward_device_operation_types.hpp"
+
+namespace ttml::metal::ops::softmax_backward::device {
+
+struct SoftmaxBackwardFactory {
+    using shared_variables_t = ttml::metal::ops::softmax_backward::device::shared_variables_t;
+    using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
+
+    static cached_program_t create(
+        const SoftmaxBackwardParams& operation_attributes,
+        const SoftmaxBackwardInputs& tensor_args,
+        ttnn::Tensor& tensor_return_value);
+
+    static void override_runtime_arguments(
+        cached_program_t& cached_program,
+        const SoftmaxBackwardParams& operation_attributes,
+        const SoftmaxBackwardInputs& tensor_args,
+        ttnn::Tensor& tensor_return_value);
+};
+
+}  // namespace ttml::metal::ops::softmax_backward::device

--- a/tt-train/sources/ttml/metal/ops/softmax_backward/softmax_backward.cpp
+++ b/tt-train/sources/ttml/metal/ops/softmax_backward/softmax_backward.cpp
@@ -1,0 +1,29 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "softmax_backward.hpp"
+
+#include <tt_stl/assert.hpp>
+
+#include "device/softmax_backward_device_operation.hpp"
+
+namespace ttml::metal {
+
+ttnn::Tensor softmax_backward(
+    const ttnn::Tensor& softmax_output,
+    const ttnn::Tensor& grad,
+    int32_t dim,
+    const std::optional<tt::tt_metal::CoreRangeSet>& sub_core_grids) {
+    const auto rank = static_cast<int32_t>(softmax_output.logical_shape().rank());
+    int32_t normalized_dim = dim >= 0 ? dim : rank + dim;
+    TT_FATAL(
+        normalized_dim >= 0 && normalized_dim < rank,
+        "Dimension {} is out of bounds for tensor with rank {}",
+        dim,
+        rank);
+    return ttnn::prim::ttml_softmax_backward(
+        softmax_output, grad, static_cast<uint32_t>(normalized_dim), sub_core_grids);
+}
+
+}  // namespace ttml::metal

--- a/tt-train/sources/ttml/metal/ops/softmax_backward/softmax_backward.hpp
+++ b/tt-train/sources/ttml/metal/ops/softmax_backward/softmax_backward.hpp
@@ -1,0 +1,21 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <optional>
+#include <tt-metalium/core_coord.hpp>
+
+#include "ttnn/tensor/tensor.hpp"
+
+namespace ttml::metal {
+
+/** Softmax backward: output = y * (grad - sum(y * grad, dim, keepdim=True)). Supports last dimension only. */
+ttnn::Tensor softmax_backward(
+    const ttnn::Tensor& softmax_output,
+    const ttnn::Tensor& grad,
+    int32_t dim,
+    const std::optional<tt::tt_metal::CoreRangeSet>& sub_core_grids = std::nullopt);
+
+}  // namespace ttml::metal

--- a/tt-train/sources/ttml/ops/softmax_backward_op.cpp
+++ b/tt-train/sources/ttml/ops/softmax_backward_op.cpp
@@ -1,0 +1,21 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ops/softmax_backward_op.hpp"
+
+#include "autograd/tensor.hpp"
+#include "metal/operations.hpp"
+
+namespace ttml::ops {
+
+autograd::TensorPtr softmax_backward(
+    const autograd::TensorPtr& softmax_output,
+    const autograd::TensorPtr& grad,
+    int dim,
+    std::optional<tt::tt_metal::CoreRangeSet> sub_core_grids) {
+    auto result = ttml::metal::softmax_backward(softmax_output->get_value(), grad->get_value(), dim, sub_core_grids);
+    return autograd::create_tensor(result);
+}
+
+}  // namespace ttml::ops

--- a/tt-train/sources/ttml/ops/softmax_backward_op.hpp
+++ b/tt-train/sources/ttml/ops/softmax_backward_op.hpp
@@ -1,0 +1,37 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <optional>
+#include <tt-metalium/core_coord.hpp>
+
+#include "autograd/tensor.hpp"
+
+namespace ttml::ops {
+
+/** Computes the gradient of softmax: output = y * (grad - sum(y * grad, dim, keepdim=True)).
+ * Uses the tt-metal softmax backward kernel. Supports the last dimension only.
+ *
+ * @param softmax_output The softmax output tensor (y) from the forward pass.
+ * @param grad Upstream gradient with respect to y.
+ * @param dim Dimension along which softmax was applied in the forward pass (e.g. -1 for last dim).
+ * @param sub_core_grids Optional. Restricts which device cores run this op. When std::nullopt
+ *        (default), the full compute grid is used. When set, only cores in the given CoreRangeSet
+ *        are used; work (tile rows) is split across them in a deterministic order. Useful for:
+ *        - Reserving part of the grid for other ops.
+ *        - Non-rectangular or disjoint core sets (e.g. L-shapes, or several CoreRanges).
+ *        The set can be a single CoreRange, multiple CoreRanges (e.g. from a vector), or any
+ *        CoreRangeSet. Row distribution order: ranges are traversed in order; within each
+ *        CoreRange, cores are traversed row-major (x then y). All cores in the set must be valid
+ *        for the device. Pass std::nullopt to use the full device grid.
+ * @return autograd::TensorPtr holding the gradient with respect to the pre-softmax logits.
+ */
+autograd::TensorPtr softmax_backward(
+    const autograd::TensorPtr& softmax_output,
+    const autograd::TensorPtr& grad,
+    int dim,
+    std::optional<tt::tt_metal::CoreRangeSet> sub_core_grids = std::nullopt);
+
+}  // namespace ttml::ops

--- a/tt-train/tests/CMakeLists.txt
+++ b/tt-train/tests/CMakeLists.txt
@@ -55,6 +55,7 @@ set(SOURCES
     ops/unary_ops_test.cpp
     ops/embedding_op_test.cpp
     ops/softmax_test.cpp
+    ops/softmax_backward_op_test.cpp
     ops/silu_op_test.cpp
     ops/sdpa_fw_op_test.cpp
     ops/sdpa_bw_op_test.cpp

--- a/tt-train/tests/ops/softmax_backward_op_test.cpp
+++ b/tt-train/tests/ops/softmax_backward_op_test.cpp
@@ -1,0 +1,321 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <gtest/gtest.h>
+
+#include <array>
+#include <core/ttnn_all_includes.hpp>
+#include <optional>
+#include <string_view>
+#include <tt-metalium/core_coord.hpp>
+#include <vector>
+#include <xtensor-blas/xlinalg.hpp>
+
+#include "autograd/auto_context.hpp"
+#include "core/random.hpp"
+#include "core/tt_tensor_utils.hpp"
+#include "metal/operations.hpp"
+
+namespace {
+
+struct SoftmaxBackwardCase {
+    const char* name;
+    uint32_t n;
+    uint32_t c;
+    uint32_t h;
+    uint32_t w;
+    int32_t dim;
+    float atol;
+    float rtol;
+    float grad_min;
+    float grad_max;
+};
+
+struct DTypeParam {
+    const char* name;
+    ttnn::DataType dtype;
+    bool is_supported;
+};
+
+constexpr uint32_t kSuiteSeed = 42U;
+
+uint32_t make_case_seed(const SoftmaxBackwardCase& test_case, uint32_t salt) {
+    // Small deterministic hash for stable test data generation regardless of execution order.
+    uint32_t hash = 2166136261U ^ (kSuiteSeed + salt);
+    auto mix = [&hash](uint32_t value) {
+        hash ^= value + 0x9e3779b9U + (hash << 6U) + (hash >> 2U);
+        hash *= 16777619U;
+    };
+    for (unsigned char ch : std::string_view(test_case.name)) {
+        hash ^= static_cast<uint32_t>(ch);
+        hash *= 16777619U;
+    }
+    mix(test_case.n);
+    mix(test_case.c);
+    mix(test_case.h);
+    mix(test_case.w);
+    mix(static_cast<uint32_t>(test_case.dim));
+    return hash;
+}
+
+xt::xarray<float> xt_softmax(const xt::xarray<float>& input, uint32_t dim = 3U) {
+    xt::xarray<float> max_value = xt::amax(input, dim, xt::keep_dims);
+    xt::xarray<float> shifted_input = input - max_value;
+    xt::xarray<float> exp_shifted_input = xt::exp(shifted_input);
+    xt::xarray<float> exp_sum = xt::sum(exp_shifted_input, dim, xt::keep_dims);
+    return exp_shifted_input / exp_sum;
+}
+
+xt::xarray<float> reference_softmax_backward(const xt::xarray<float>& y, const xt::xarray<float>& grad, uint32_t dim) {
+    xt::xarray<float> dot = xt::sum(y * grad, {dim}, xt::keep_dims);
+    return y * (grad - dot);
+}
+
+ttnn::Tensor to_device_tensor(
+    const xt::xarray<float>& host_tensor, ttnn::distributed::MeshDevice* device, ttnn::DataType dtype) {
+    switch (dtype) {
+        case ttnn::DataType::BFLOAT16:
+            return ttml::core::from_xtensor<float, ttnn::DataType::BFLOAT16>(host_tensor, device);
+        case ttnn::DataType::FLOAT32:
+            return ttml::core::from_xtensor<float, ttnn::DataType::FLOAT32>(host_tensor, device);
+        default: TT_THROW("Unsupported dtype in softmax backward test");
+    }
+}
+
+void run_softmax_backward_case(
+    const SoftmaxBackwardCase& test_case,
+    const DTypeParam& dtype_param,
+    ttnn::distributed::MeshDevice* device,
+    std::optional<tt::tt_metal::CoreRangeSet> sub_core_grids = std::nullopt) {
+    using namespace ttml;
+
+    xt::xarray<float> logits_tensor = xt::empty<float>({test_case.n, test_case.c, test_case.h, test_case.w});
+    xt::xarray<float> grad_tensor = xt::empty<float>({test_case.n, test_case.c, test_case.h, test_case.w});
+
+    const uint32_t logits_seed = make_case_seed(test_case, 0xA5A5A5A5U);
+    const uint32_t grad_seed = make_case_seed(test_case, 0x5A5A5A5AU);
+    ttml::core::parallel_generate(
+        std::span{logits_tensor.data(), logits_tensor.size()},
+        []() { return std::uniform_real_distribution<float>(-10.0F, 10.0F); },
+        logits_seed);
+    const float grad_min = test_case.grad_min;
+    const float grad_max = test_case.grad_max;
+    ttml::core::parallel_generate(
+        std::span{grad_tensor.data(), grad_tensor.size()},
+        [grad_min, grad_max]() { return std::uniform_real_distribution<float>(grad_min, grad_max); },
+        grad_seed);
+
+    const int32_t rank = 4;
+    const int32_t normalized_dim = test_case.dim >= 0 ? test_case.dim : rank + test_case.dim;
+    const uint32_t dim_u32 = static_cast<uint32_t>(normalized_dim);
+
+    auto y_tensor = xt_softmax(logits_tensor, dim_u32);
+    auto y_tt = to_device_tensor(y_tensor, device, dtype_param.dtype);
+    auto grad_tt = to_device_tensor(grad_tensor, device, dtype_param.dtype);
+
+    if (!dtype_param.is_supported) {
+        EXPECT_ANY_THROW((void)ttml::metal::softmax_backward(y_tt, grad_tt, test_case.dim))
+            << "case=" << test_case.name << ", dtype=" << dtype_param.name;
+        return;
+    }
+
+    ttnn::Tensor result_tt = sub_core_grids.has_value()
+                                 ? ttml::metal::softmax_backward(y_tt, grad_tt, test_case.dim, *sub_core_grids)
+                                 : ttml::metal::softmax_backward(y_tt, grad_tt, test_case.dim);
+    auto result_xtensor = core::to_xtensor(result_tt);
+
+    auto expected = reference_softmax_backward(core::to_xtensor(y_tt), core::to_xtensor(grad_tt), dim_u32);
+    const auto max_abs_diff = xt::amax(xt::abs(result_xtensor - expected))();
+    EXPECT_TRUE(xt::allclose(result_xtensor, expected, test_case.rtol, test_case.atol))
+        << "case=" << test_case.name << ", max_abs_diff=" << max_abs_diff << ", atol=" << test_case.atol
+        << ", rtol=" << test_case.rtol;
+}
+
+}  // namespace
+
+class SoftmaxBackwardOpTest : public ::testing::Test {
+protected:
+    static ttnn::distributed::MeshDevice* s_device;
+
+    static void SetUpTestSuite() {
+        ttml::autograd::ctx().open_device();
+        ttml::autograd::ctx().set_seed(kSuiteSeed);
+        s_device = &ttml::autograd::ctx().get_device();
+    }
+
+    static void TearDownTestSuite() {
+        ttml::autograd::ctx().close_device();
+        s_device = nullptr;
+    }
+};
+
+ttnn::distributed::MeshDevice* SoftmaxBackwardOpTest::s_device = nullptr;
+
+class SoftmaxBackwardOpTypedTest : public SoftmaxBackwardOpTest, public ::testing::WithParamInterface<DTypeParam> {};
+
+#define SOFTMAX_BW_SKIP_IF_UNSUPPORTED(description)                                                       \
+    do {                                                                                                  \
+        if (!GetParam().is_supported) {                                                                   \
+            GTEST_SKIP() << "Skipping " << (description) << " for unsupported dtype " << GetParam().name; \
+            return;                                                                                       \
+        }                                                                                                 \
+    } while (0)
+
+TEST_P(SoftmaxBackwardOpTypedTest, SoftmaxBackward_LastDim_1Tile) {
+    SOFTMAX_BW_SKIP_IF_UNSUPPORTED("1-tile last-dim");
+    constexpr SoftmaxBackwardCase test_case{
+        .name = "1tile_last_dim",
+        .n = 1,
+        .c = 1,
+        .h = 32,
+        .w = 32,
+        .dim = 3,
+        .atol = 2.5e-2F,
+        .rtol = 2.5e-2F,
+        .grad_min = -10.0F,
+        .grad_max = 10.0F,
+    };
+    run_softmax_backward_case(test_case, GetParam(), s_device);
+}
+
+TEST_P(SoftmaxBackwardOpTypedTest, SoftmaxBackward_SubCoreGrid_Rectangular) {
+    SOFTMAX_BW_SKIP_IF_UNSUPPORTED("sub-core-grid rectangular");
+    // Rectangular sub-grid: 2x2 cores starting at (0,0). Requires device with at least 2x2 compute grid.
+    const tt::tt_metal::CoreRange sub_range(tt::tt_metal::CoreCoord(0, 0), tt::tt_metal::CoreCoord(1, 1));
+    const tt::tt_metal::CoreRangeSet sub_core_grids(sub_range);
+    constexpr SoftmaxBackwardCase test_case{
+        .name = "sub_grid_2x2",
+        .n = 23,
+        .c = 1,
+        .h = 32,
+        .w = 64,
+        .dim = 3,
+        .atol = 1e-2F,
+        .rtol = 1e-2F,
+        .grad_min = -10.0F,
+        .grad_max = 10.0F,
+    };
+    run_softmax_backward_case(test_case, GetParam(), s_device, sub_core_grids);
+}
+
+TEST_P(SoftmaxBackwardOpTypedTest, SoftmaxBackward_SubCoreGrid_NonRectangular) {
+    SOFTMAX_BW_SKIP_IF_UNSUPPORTED("sub-core-grid non-rectangular");
+    // Non-rectangular (L-shaped) sub-grid
+    std::vector<tt::tt_metal::CoreRange> ranges = {
+        tt::tt_metal::CoreRange(tt::tt_metal::CoreCoord(0, 0), tt::tt_metal::CoreCoord(2, 0)),  // row y=0
+        tt::tt_metal::CoreRange(tt::tt_metal::CoreCoord(2, 1), tt::tt_metal::CoreCoord(2, 1)),  // (0,1) only
+    };
+    const tt::tt_metal::CoreRangeSet sub_core_grids(std::move(ranges));
+    constexpr SoftmaxBackwardCase test_case{
+        .name = "sub_grid_L_shape",
+        .n = 13,
+        .c = 1,
+        .h = 32,
+        .w = 512,
+        .dim = 3,
+        .atol = 1e-2F,
+        .rtol = 1e-2F,
+        .grad_min = -10.0F,
+        .grad_max = 10.0F,
+    };
+    run_softmax_backward_case(test_case, GetParam(), s_device, sub_core_grids);
+}
+
+TEST_P(SoftmaxBackwardOpTypedTest, SoftmaxBackward_LongRows) {
+    SOFTMAX_BW_SKIP_IF_UNSUPPORTED("long-row shape");
+    constexpr std::array<SoftmaxBackwardCase, 2> cases = {{
+        {"long_rows_streaming_300_tiles", 1, 5, 32, 300 * 32 + 3, -1, 6e-2F, 6e-2F, -10.0F, 10.0F},
+        {"long_rows_streaming_639_tiles", 1, 1, 32, 639 * 32, -1, 6e-2F, 6e-2F, -10.0F, 10.0F},
+    }};
+    for (const auto& test_case : cases) {
+        SCOPED_TRACE(test_case.name);
+        run_softmax_backward_case(test_case, GetParam(), s_device);
+    }
+}
+
+TEST_P(SoftmaxBackwardOpTypedTest, SoftmaxBackward_ManyShortRows) {
+    SOFTMAX_BW_SKIP_IF_UNSUPPORTED("many-short-rows shape");
+    constexpr SoftmaxBackwardCase test_case{
+        .name = "many_short_rows_non_streaming_5_tiles",
+        .n = 1,
+        .c = 30,
+        .h = 6400,
+        .w = 5 * 32,
+        .dim = -1,
+        .atol = 6e-2F,
+        .rtol = 6e-2F,
+        .grad_min = -10.0F,
+        .grad_max = 10.0F,
+    };
+    run_softmax_backward_case(test_case, GetParam(), s_device);
+}
+
+// Type A - first face must be padded
+// Type B - first face is full, second face is empty
+// Type C - first face is full, second face must be padded
+
+TEST_P(SoftmaxBackwardOpTypedTest, SoftmaxBackward_Padding_NonStreaming) {
+    SOFTMAX_BW_SKIP_IF_UNSUPPORTED("padded non-streaming shape");
+    constexpr std::array<SoftmaxBackwardCase, 3> cases = {{
+        {"padded_non_streaming_type_a", 1, 1, 128, 14 * 32 + 2, -1, 6e-2F, 6e-2F, -10.0F, 10.0F},
+        {"padded_non_streaming_type_b", 2, 1, 256, 14 * 32 + 16, 3, 6e-2F, 6e-2F, -10.0F, 10.0F},
+        {"padded_non_streaming_type_c", 2, 1, 128, 14 * 32 + 18, 3, 6e-2F, 6e-2F, -10.0F, 10.0F},
+    }};
+    for (const auto& test_case : cases) {
+        SCOPED_TRACE(test_case.name);
+        run_softmax_backward_case(test_case, GetParam(), s_device);
+    }
+}
+
+TEST_P(SoftmaxBackwardOpTypedTest, SoftmaxBackward_Padding_Streaming) {
+    SOFTMAX_BW_SKIP_IF_UNSUPPORTED("padded streaming shape");
+    constexpr std::array<SoftmaxBackwardCase, 3> cases = {{
+        {"padded_streaming_type_a", 1, 5, 32, 300 * 32 + 3, -1, 6e-2F, 6e-2F, -10.0F, 10.0F},
+        {"padded_streaming_type_b", 7, 1, 64, 300 * 32 + 16, 3, 6e-2F, 6e-2F, -10.0F, 10.0F},
+        {"padded_streaming_type_c", 3, 1, 32, 300 * 32 + 19, 3, 6e-2F, 6e-2F, -10.0F, 10.0F},
+    }};
+    for (const auto& test_case : cases) {
+        SCOPED_TRACE(test_case.name);
+        run_softmax_backward_case(test_case, GetParam(), s_device);
+    }
+}
+
+TEST_P(SoftmaxBackwardOpTypedTest, SoftmaxBackward_WidthBoundaryStreamingSwitch) {
+    SOFTMAX_BW_SKIP_IF_UNSUPPORTED("boundary shape");
+    constexpr std::array<SoftmaxBackwardCase, 5> cases = {{
+        {"boundary_63_tiles", 1, 2, 32, 63 * 32, -1, 6e-2F, 6e-2F, -10.0F, 10.0F},
+        {"boundary_64_tiles", 1, 3, 32, 64 * 32, -1, 6e-2F, 6e-2F, -10.0F, 10.0F},
+        {"boundary_65_tiles", 1, 4, 32, 65 * 32, -1, 6e-2F, 6e-2F, -10.0F, 10.0F},
+        {"boundary_127_tiles", 1, 1, 32, 127 * 32, -1, 6e-2F, 6e-2F, -10.0F, 10.0F},
+        {"boundary_128_tiles", 3, 1, 32, 128 * 32, -1, 7e-2F, 7e-2F, -10.0F, 10.0F},
+    }};
+    for (const auto& test_case : cases) {
+        SCOPED_TRACE(test_case.name);
+        run_softmax_backward_case(test_case, GetParam(), s_device);
+    }
+}
+
+// 16384 rows by 64 tiles each
+// Test takes around 105 seconds on BH
+TEST_P(SoftmaxBackwardOpTypedTest, NIGHTLY_SoftmaxBackward_llama8b) {
+    SOFTMAX_BW_SKIP_IF_UNSUPPORTED("llama shape");
+    constexpr std::array<SoftmaxBackwardCase, 1> cases = {{
+        {"llama8b_b1", 8, 32, 2048, 2048, 3, 1e-2F, 1e-2F, -10.0F, 10.0F},
+    }};
+    for (const auto& test_case : cases) {
+        SCOPED_TRACE(test_case.name);
+        run_softmax_backward_case(test_case, GetParam(), s_device);
+    }
+}
+
+constexpr std::array<DTypeParam, 2> kDTypeParams = {{
+    {"bf16", ttnn::DataType::BFLOAT16, true},
+    {"fp32", ttnn::DataType::FLOAT32, false},
+}};
+
+INSTANTIATE_TEST_SUITE_P(
+    SoftmaxBackward,
+    SoftmaxBackwardOpTypedTest,
+    ::testing::ValuesIn(kDTypeParams),
+    [](const ::testing::TestParamInfo<SoftmaxBackwardOpTypedTest::ParamType>& info) { return info.param.name; });

--- a/tt-train/tests/ops/softmax_backward_op_test.cpp
+++ b/tt-train/tests/ops/softmax_backward_op_test.cpp
@@ -72,11 +72,23 @@ xt::xarray<float> reference_softmax_backward(const xt::xarray<float>& y, const x
     return y * (grad - dot);
 }
 
+// Converts float xtensor to bfloat16 so from_xtensor<bfloat16, BFLOAT16> is used; that path does
+// tilization on host (to_layout TILE then to_device), avoiding device tilize.
+static xt::xarray<bfloat16> to_bf16_xtensor(const xt::xarray<float>& src) {
+    xt::xarray<bfloat16> out = xt::empty<bfloat16>(src.shape());
+    for (size_t i = 0; i < src.size(); ++i) {
+        out.data()[i] = bfloat16(src.data()[i]);
+    }
+    return out;
+}
+
 ttnn::Tensor to_device_tensor(
     const xt::xarray<float>& host_tensor, ttnn::distributed::MeshDevice* device, ttnn::DataType dtype) {
     switch (dtype) {
-        case ttnn::DataType::BFLOAT16:
-            return ttml::core::from_xtensor<float, ttnn::DataType::BFLOAT16>(host_tensor, device);
+        case ttnn::DataType::BFLOAT16: {
+            auto bf16_host = to_bf16_xtensor(host_tensor);
+            return ttml::core::from_xtensor<bfloat16, ttnn::DataType::BFLOAT16>(bf16_host, device);
+        }
         case ttnn::DataType::FLOAT32:
             return ttml::core::from_xtensor<float, ttnn::DataType::FLOAT32>(host_tensor, device);
         default: TT_THROW("Unsupported dtype in softmax backward test");
@@ -171,8 +183,8 @@ TEST_P(SoftmaxBackwardOpTypedTest, SoftmaxBackward_LastDim_1Tile) {
         .h = 32,
         .w = 32,
         .dim = 3,
-        .atol = 2.5e-2F,
-        .rtol = 2.5e-2F,
+        .atol = 2e-2F,
+        .rtol = 2e-2F,
         .grad_min = -10.0F,
         .grad_max = 10.0F,
     };
@@ -222,11 +234,11 @@ TEST_P(SoftmaxBackwardOpTypedTest, SoftmaxBackward_SubCoreGrid_NonRectangular) {
     run_softmax_backward_case(test_case, GetParam(), s_device, sub_core_grids);
 }
 
-TEST_P(SoftmaxBackwardOpTypedTest, SoftmaxBackward_LongRows) {
+TEST_P(SoftmaxBackwardOpTypedTest, NIGHTLY_SoftmaxBackward_LongRows) {
     SOFTMAX_BW_SKIP_IF_UNSUPPORTED("long-row shape");
     constexpr std::array<SoftmaxBackwardCase, 2> cases = {{
-        {"long_rows_streaming_300_tiles", 1, 5, 32, 300 * 32 + 3, -1, 6e-2F, 6e-2F, -10.0F, 10.0F},
-        {"long_rows_streaming_639_tiles", 1, 1, 32, 639 * 32, -1, 6e-2F, 6e-2F, -10.0F, 10.0F},
+        {"long_rows_streaming_300_tiles", 1, 5, 32, 300 * 32, 3, 1e-2F, 1e-2F, -10.0F, 10.0F},
+        {"long_rows_streaming_639_tiles", 1, 1, 32, 639 * 32, -1, 1e-2F, 1e-2F, -10.0F, 10.0F},
     }};
     for (const auto& test_case : cases) {
         SCOPED_TRACE(test_case.name);
@@ -234,7 +246,7 @@ TEST_P(SoftmaxBackwardOpTypedTest, SoftmaxBackward_LongRows) {
     }
 }
 
-TEST_P(SoftmaxBackwardOpTypedTest, SoftmaxBackward_ManyShortRows) {
+TEST_P(SoftmaxBackwardOpTypedTest, NIGHTLY_SoftmaxBackward_ManyShortRows) {
     SOFTMAX_BW_SKIP_IF_UNSUPPORTED("many-short-rows shape");
     constexpr SoftmaxBackwardCase test_case{
         .name = "many_short_rows_non_streaming_5_tiles",
@@ -243,8 +255,8 @@ TEST_P(SoftmaxBackwardOpTypedTest, SoftmaxBackward_ManyShortRows) {
         .h = 6400,
         .w = 5 * 32,
         .dim = -1,
-        .atol = 6e-2F,
-        .rtol = 6e-2F,
+        .atol = 2.5e-2F,
+        .rtol = 2.5e-2F,
         .grad_min = -10.0F,
         .grad_max = 10.0F,
     };
@@ -255,12 +267,12 @@ TEST_P(SoftmaxBackwardOpTypedTest, SoftmaxBackward_ManyShortRows) {
 // Type B - first face is full, second face is empty
 // Type C - first face is full, second face must be padded
 
-TEST_P(SoftmaxBackwardOpTypedTest, SoftmaxBackward_Padding_NonStreaming) {
+TEST_P(SoftmaxBackwardOpTypedTest, NIGHTLY_SoftmaxBackward_Padding_NonStreaming) {
     SOFTMAX_BW_SKIP_IF_UNSUPPORTED("padded non-streaming shape");
     constexpr std::array<SoftmaxBackwardCase, 3> cases = {{
-        {"padded_non_streaming_type_a", 1, 1, 128, 14 * 32 + 2, -1, 6e-2F, 6e-2F, -10.0F, 10.0F},
-        {"padded_non_streaming_type_b", 2, 1, 256, 14 * 32 + 16, 3, 6e-2F, 6e-2F, -10.0F, 10.0F},
-        {"padded_non_streaming_type_c", 2, 1, 128, 14 * 32 + 18, 3, 6e-2F, 6e-2F, -10.0F, 10.0F},
+        {"padded_non_streaming_type_a", 1, 1, 128, 14 * 32 + 2, -1, 1e-2F, 1e-2F, -10.0F, 10.0F},
+        {"padded_non_streaming_type_b", 2, 1, 256, 14 * 32 + 16, 3, 1e-2F, 1e-2F, -10.0F, 10.0F},
+        {"padded_non_streaming_type_c", 2, 1, 128, 14 * 32 + 18, 3, 1e-2F, 1e-2F, -10.0F, 10.0F},
     }};
     for (const auto& test_case : cases) {
         SCOPED_TRACE(test_case.name);
@@ -268,12 +280,12 @@ TEST_P(SoftmaxBackwardOpTypedTest, SoftmaxBackward_Padding_NonStreaming) {
     }
 }
 
-TEST_P(SoftmaxBackwardOpTypedTest, SoftmaxBackward_Padding_Streaming) {
+TEST_P(SoftmaxBackwardOpTypedTest, NIGHTLY_SoftmaxBackward_Padding_Streaming) {
     SOFTMAX_BW_SKIP_IF_UNSUPPORTED("padded streaming shape");
     constexpr std::array<SoftmaxBackwardCase, 3> cases = {{
-        {"padded_streaming_type_a", 1, 5, 32, 300 * 32 + 3, -1, 6e-2F, 6e-2F, -10.0F, 10.0F},
-        {"padded_streaming_type_b", 7, 1, 64, 300 * 32 + 16, 3, 6e-2F, 6e-2F, -10.0F, 10.0F},
-        {"padded_streaming_type_c", 3, 1, 32, 300 * 32 + 19, 3, 6e-2F, 6e-2F, -10.0F, 10.0F},
+        {"padded_streaming_type_a", 1, 5, 32, 300 * 32 + 3, -1, 1e-2F, 1e-2F, -10.0F, 10.0F},
+        {"padded_streaming_type_b", 7, 1, 64, 300 * 32 + 16, 3, 1e-2F, 1e-2F, -10.0F, 10.0F},
+        {"padded_streaming_type_c", 3, 1, 32, 300 * 32 + 19, 3, 1e-2F, 1e-2F, -10.0F, 10.0F},
     }};
     for (const auto& test_case : cases) {
         SCOPED_TRACE(test_case.name);
@@ -281,14 +293,14 @@ TEST_P(SoftmaxBackwardOpTypedTest, SoftmaxBackward_Padding_Streaming) {
     }
 }
 
-TEST_P(SoftmaxBackwardOpTypedTest, SoftmaxBackward_WidthBoundaryStreamingSwitch) {
+TEST_P(SoftmaxBackwardOpTypedTest, NIGHTLY_SoftmaxBackward_WidthBoundaryStreamingSwitch) {
     SOFTMAX_BW_SKIP_IF_UNSUPPORTED("boundary shape");
     constexpr std::array<SoftmaxBackwardCase, 5> cases = {{
-        {"boundary_63_tiles", 1, 2, 32, 63 * 32, -1, 6e-2F, 6e-2F, -10.0F, 10.0F},
-        {"boundary_64_tiles", 1, 3, 32, 64 * 32, -1, 6e-2F, 6e-2F, -10.0F, 10.0F},
-        {"boundary_65_tiles", 1, 4, 32, 65 * 32, -1, 6e-2F, 6e-2F, -10.0F, 10.0F},
-        {"boundary_127_tiles", 1, 1, 32, 127 * 32, -1, 6e-2F, 6e-2F, -10.0F, 10.0F},
-        {"boundary_128_tiles", 3, 1, 32, 128 * 32, -1, 7e-2F, 7e-2F, -10.0F, 10.0F},
+        {"boundary_63_tiles", 1, 2, 32, 63 * 32, -1, 1e-2F, 1e-2F, -10.0F, 10.0F},
+        {"boundary_64_tiles", 1, 3, 32, 64 * 32, -1, 1e-2F, 1e-2F, -10.0F, 10.0F},
+        {"boundary_65_tiles", 1, 4, 32, 65 * 32, -1, 1e-2F, 1e-2F, -10.0F, 10.0F},
+        {"boundary_127_tiles", 1, 1, 32, 127 * 32, -1, 1e-2F, 1e-2F, -10.0F, 10.0F},
+        {"boundary_128_tiles", 3, 1, 32, 128 * 32, -1, 1e-2F, 1e-2F, -10.0F, 10.0F},
     }};
     for (const auto& test_case : cases) {
         SCOPED_TRACE(test_case.name);


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/27796)

### Problem description
This is the second attempt to merge https://github.com/tenstorrent/tt-metal/pull/31580
Previous one broke APC, because constants TILE_HW, TILE_WIDTH, and TILE_HEIGHT were removed from `dataflow_utils.hpp` in favor of `tt-metalium/constants.hpp`, but cross_entropy kernels were not updated.
This PR contains original commit as is + small fix for cross_entropy.

### Checklist

- [x] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=vlad/softmax_backward_2)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:vlad/softmax_backward_2)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=vlad/softmax_backward_2)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:vlad/softmax_backward_2) failure seems unrelated
    https://github.com/tenstorrent/tt-metal/actions/runs/22433408489/job/64957816360 - failure on main
    https://github.com/tenstorrent/tt-metal/actions/runs/22436012348/job/64982659741 - failure on my branch
```
FAILED models/demos/deepseek_v3_b1/tests/unit_tests/test_pre_sdpa.py::test_pre_sdpa[blackhole-True-NOC_MODE.DM_DYNAMIC_NOC-device_params0-127-1-1-1-1-0-True-1e-06-1-0] - RuntimeError: TT_FATAL @ /project/tt_metal/impl/allocator/bank_manager.cpp:403: num_shards.value() <= num_compute_banks
info:
Expected number of shards 128 to be less than or equal to total number of L1 banks 120 in compute cores
```
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=vlad/softmax_backward_2)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:vlad/softmax_backward_2)
- [x] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=vlad/softmax_backward_2)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:vlad/softmax_backward_2)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=vlad/softmax_backward_2)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:vlad/softmax_backward_2)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=vlad/softmax_backward_2)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:vlad/softmax_backward_2)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
