### PR TITLE
add escape paths for potential infinite loops in fabric init

### DIFF
--- a/tt_metal/fabric/fabric_builder_context.cpp
+++ b/tt_metal/fabric/fabric_builder_context.cpp
@@ -194,7 +194,9 @@ chan_id_t FabricBuilderContext::get_fabric_master_router_chan(ChipId chip_id) co
 
 std::vector<size_t> FabricBuilderContext::get_fabric_router_addresses_to_clear() const {
     std::vector<size_t> addresses_to_clear = {
-        router_config_->edm_local_sync_address, router_config_->edm_local_tensix_sync_address};
+        router_config_->edm_local_sync_address,
+        router_config_->edm_local_tensix_sync_address,
+        router_config_->termination_signal_address};
 
     if (router_config_->sender_txq_id != router_config_->receiver_txq_id) {
         addresses_to_clear.push_back(router_config_->to_sender_channel_remote_ack_counters_base_addr);

--- a/tt_metal/fabric/hw/inc/edm_fabric/edm_handshake.hpp
+++ b/tt_metal/fabric/hw/inc/edm_fabric/edm_handshake.hpp
@@ -83,10 +83,9 @@ FORCE_INLINE void sender_side_handshake(
     while (handshake_info->local_value != MAGIC_HANDSHAKE_VALUE) {
         if (count == HS_CONTEXT_SWITCH_TIMEOUT) {
             count = 0;
-#ifndef ARCH_WORMHOLE
-            static_assert(PHYSICAL_AERISC_ID == 0, "run_routing() is only safe from ERISC0");
-#endif
+#if defined(ARCH_WORMHOLE) || (defined(PHYSICAL_AERISC_ID) && PHYSICAL_AERISC_ID == 0)
             run_routing();
+#endif
         } else {
             count++;
             internal_::eth_send_packet(0, scratch_addr, local_val_addr, 1);
@@ -108,10 +107,9 @@ FORCE_INLINE void receiver_side_handshake(
     while (handshake_info->local_value != MAGIC_HANDSHAKE_VALUE) {
         if (count == HS_CONTEXT_SWITCH_TIMEOUT) {
             count = 0;
-#ifndef ARCH_WORMHOLE
-            static_assert(PHYSICAL_AERISC_ID == 0, "run_routing() is only safe from ERISC0");
-#endif
+#if defined(ARCH_WORMHOLE) || (defined(PHYSICAL_AERISC_ID) && PHYSICAL_AERISC_ID == 0)
             run_routing();
+#endif
         } else {
             count++;
         }

--- a/tt_metal/fabric/hw/inc/edm_fabric/edm_handshake.hpp
+++ b/tt_metal/fabric/hw/inc/edm_fabric/edm_handshake.hpp
@@ -55,7 +55,7 @@ struct handshake_info_t {
     uint32_t scratch[4];         // Bytes 16-31: TODO: Can be removed if we use a stream register for handshaking.
 };
 
-__attribute__((optimize("Os"))) FORCE_INLINE volatile tt_l1_ptr handshake_info_t* init_handshake_info(
+FORCE_INLINE volatile tt_l1_ptr handshake_info_t* init_handshake_info(
     uint32_t handshake_register_address, uint16_t my_mesh_id, uint8_t my_device_id) {
     volatile tt_l1_ptr handshake_info_t* handshake_info =
         reinterpret_cast<volatile tt_l1_ptr handshake_info_t*>(handshake_register_address);
@@ -70,7 +70,7 @@ __attribute__((optimize("Os"))) FORCE_INLINE volatile tt_l1_ptr handshake_info_t
     return handshake_info;
 }
 
-__attribute__((optimize("Os"))) FORCE_INLINE void sender_side_handshake(
+FORCE_INLINE void sender_side_handshake(
     uint32_t handshake_register_address,
     uint16_t my_mesh_id,
     uint8_t my_device_id,
@@ -92,7 +92,7 @@ __attribute__((optimize("Os"))) FORCE_INLINE void sender_side_handshake(
     }
 }
 
-__attribute__((optimize("Os"))) FORCE_INLINE void receiver_side_handshake(
+FORCE_INLINE void receiver_side_handshake(
     uint32_t handshake_register_address,
     uint16_t my_mesh_id,
     uint8_t my_device_id,

--- a/tt_metal/fabric/hw/inc/edm_fabric/edm_handshake.hpp
+++ b/tt_metal/fabric/hw/inc/edm_fabric/edm_handshake.hpp
@@ -56,7 +56,7 @@ struct handshake_info_t {
     uint32_t scratch[4];         // Bytes 16-31: TODO: Can be removed if we use a stream register for handshaking.
 };
 
-FORCE_INLINE volatile tt_l1_ptr handshake_info_t* init_handshake_info(
+__attribute__((optimize("Os"))) FORCE_INLINE volatile tt_l1_ptr handshake_info_t* init_handshake_info(
     uint32_t handshake_register_address, uint16_t my_mesh_id, uint8_t my_device_id) {
     volatile tt_l1_ptr handshake_info_t* handshake_info =
         reinterpret_cast<volatile tt_l1_ptr handshake_info_t*>(handshake_register_address);
@@ -72,7 +72,7 @@ FORCE_INLINE volatile tt_l1_ptr handshake_info_t* init_handshake_info(
 }
 
 template <bool RISC_CPU_DATA_CACHE_ENABLED>
-FORCE_INLINE void sender_side_handshake(
+__attribute__((optimize("Os"))) FORCE_INLINE void sender_side_handshake(
     uint32_t handshake_register_address,
     uint16_t my_mesh_id,
     uint8_t my_device_id,
@@ -97,7 +97,7 @@ FORCE_INLINE void sender_side_handshake(
 }
 
 template <bool RISC_CPU_DATA_CACHE_ENABLED>
-FORCE_INLINE void receiver_side_handshake(
+__attribute__((optimize("Os"))) FORCE_INLINE void receiver_side_handshake(
     uint32_t handshake_register_address,
     uint16_t my_mesh_id,
     uint8_t my_device_id,

--- a/tt_metal/fabric/hw/inc/edm_fabric/edm_handshake.hpp
+++ b/tt_metal/fabric/hw/inc/edm_fabric/edm_handshake.hpp
@@ -41,7 +41,6 @@ namespace handshake {
  */
 
 static constexpr uint32_t A_LONG_TIMEOUT_BEFORE_CONTEXT_SWITCH = 1000000000;
-static constexpr uint32_t CONTEXT_SWITCH_TIMEOUT_SHORT = 100000;
 static constexpr uint32_t MAGIC_HANDSHAKE_VALUE = 0xAA;
 
 // Data-Structure used for EDM to EDM Handshaking.

--- a/tt_metal/fabric/hw/inc/edm_fabric/edm_handshake.hpp
+++ b/tt_metal/fabric/hw/inc/edm_fabric/edm_handshake.hpp
@@ -84,7 +84,9 @@ FORCE_INLINE void sender_side_handshake(
     while (handshake_info->local_value != MAGIC_HANDSHAKE_VALUE) {
         if (count == HS_CONTEXT_SWITCH_TIMEOUT) {
             count = 0;
+#ifndef ARCH_WORMHOLE
             static_assert(PHYSICAL_AERISC_ID == 0, "run_routing() is only safe from ERISC0");
+#endif
             run_routing();
         } else {
             count++;
@@ -107,7 +109,9 @@ FORCE_INLINE void receiver_side_handshake(
     while (handshake_info->local_value != MAGIC_HANDSHAKE_VALUE) {
         if (count == HS_CONTEXT_SWITCH_TIMEOUT) {
             count = 0;
+#ifndef ARCH_WORMHOLE
             static_assert(PHYSICAL_AERISC_ID == 0, "run_routing() is only safe from ERISC0");
+#endif
             run_routing();
         } else {
             count++;

--- a/tt_metal/fabric/hw/inc/edm_fabric/edm_handshake.hpp
+++ b/tt_metal/fabric/hw/inc/edm_fabric/edm_handshake.hpp
@@ -7,6 +7,7 @@
 #include <cstdint>
 #include "internal/ethernet/dataflow_api.h"
 #include "hostdevcommon/fabric_common.h"
+#include "tt_metal/fabric/hw/inc/tt_fabric_utils.h"
 
 namespace erisc {
 namespace datamover {
@@ -70,17 +71,20 @@ FORCE_INLINE volatile tt_l1_ptr handshake_info_t* init_handshake_info(
     return handshake_info;
 }
 
+template <bool RISC_CPU_DATA_CACHE_ENABLED>
 FORCE_INLINE void sender_side_handshake(
     uint32_t handshake_register_address,
     uint16_t my_mesh_id,
     uint8_t my_device_id,
+    volatile tt::tt_fabric::TerminationSignal* termination_signal_ptr,
     size_t HS_CONTEXT_SWITCH_TIMEOUT = A_LONG_TIMEOUT_BEFORE_CONTEXT_SWITCH) {
     volatile tt_l1_ptr handshake_info_t* handshake_info =
         init_handshake_info(handshake_register_address, my_mesh_id, my_device_id);
     uint32_t local_val_addr = ((uint32_t)(&handshake_info->local_value)) / tt::tt_fabric::PACKET_WORD_SIZE_BYTES;
     uint32_t scratch_addr = ((uint32_t)(&handshake_info->scratch)) / tt::tt_fabric::PACKET_WORD_SIZE_BYTES;
     uint32_t count = 0;
-    while (handshake_info->local_value != MAGIC_HANDSHAKE_VALUE) {
+    while (handshake_info->local_value != MAGIC_HANDSHAKE_VALUE &&
+           !tt::tt_fabric::got_immediate_termination_signal<RISC_CPU_DATA_CACHE_ENABLED>(termination_signal_ptr)) {
         if (count == HS_CONTEXT_SWITCH_TIMEOUT) {
             count = 0;
             run_routing();
@@ -92,17 +96,20 @@ FORCE_INLINE void sender_side_handshake(
     }
 }
 
+template <bool RISC_CPU_DATA_CACHE_ENABLED>
 FORCE_INLINE void receiver_side_handshake(
     uint32_t handshake_register_address,
     uint16_t my_mesh_id,
     uint8_t my_device_id,
+    volatile tt::tt_fabric::TerminationSignal* termination_signal_ptr,
     size_t HS_CONTEXT_SWITCH_TIMEOUT = A_LONG_TIMEOUT_BEFORE_CONTEXT_SWITCH) {
     volatile tt_l1_ptr handshake_info_t* handshake_info =
         init_handshake_info(handshake_register_address, my_mesh_id, my_device_id);
     uint32_t local_val_addr = ((uint32_t)(&handshake_info->local_value)) / tt::tt_fabric::PACKET_WORD_SIZE_BYTES;
     uint32_t scratch_addr = ((uint32_t)(&handshake_info->scratch)) / tt::tt_fabric::PACKET_WORD_SIZE_BYTES;
     uint32_t count = 0;
-    while (handshake_info->local_value != MAGIC_HANDSHAKE_VALUE) {
+    while (handshake_info->local_value != MAGIC_HANDSHAKE_VALUE &&
+           !tt::tt_fabric::got_immediate_termination_signal<RISC_CPU_DATA_CACHE_ENABLED>(termination_signal_ptr)) {
         if (count == HS_CONTEXT_SWITCH_TIMEOUT) {
             count = 0;
             run_routing();
@@ -111,7 +118,9 @@ FORCE_INLINE void receiver_side_handshake(
         }
         invalidate_l1_cache();
     }
-    internal_::eth_send_packet(0, scratch_addr, local_val_addr, 1);
+    if (!tt::tt_fabric::got_immediate_termination_signal<RISC_CPU_DATA_CACHE_ENABLED>(termination_signal_ptr)) {
+        internal_::eth_send_packet(0, scratch_addr, local_val_addr, 1);
+    }
 }
 
 namespace deprecated {

--- a/tt_metal/fabric/hw/inc/edm_fabric/edm_handshake.hpp
+++ b/tt_metal/fabric/hw/inc/edm_fabric/edm_handshake.hpp
@@ -41,6 +41,7 @@ namespace handshake {
  */
 
 static constexpr uint32_t A_LONG_TIMEOUT_BEFORE_CONTEXT_SWITCH = 1000000000;
+static constexpr uint32_t CONTEXT_SWITCH_TIMEOUT_SHORT = 100000;
 static constexpr uint32_t MAGIC_HANDSHAKE_VALUE = 0xAA;
 
 // Data-Structure used for EDM to EDM Handshaking.
@@ -83,6 +84,7 @@ FORCE_INLINE void sender_side_handshake(
     while (handshake_info->local_value != MAGIC_HANDSHAKE_VALUE) {
         if (count == HS_CONTEXT_SWITCH_TIMEOUT) {
             count = 0;
+            static_assert(PHYSICAL_AERISC_ID == 0, "run_routing() is only safe from ERISC0");
             run_routing();
         } else {
             count++;
@@ -105,6 +107,7 @@ FORCE_INLINE void receiver_side_handshake(
     while (handshake_info->local_value != MAGIC_HANDSHAKE_VALUE) {
         if (count == HS_CONTEXT_SWITCH_TIMEOUT) {
             count = 0;
+            static_assert(PHYSICAL_AERISC_ID == 0, "run_routing() is only safe from ERISC0");
             run_routing();
         } else {
             count++;

--- a/tt_metal/fabric/hw/inc/edm_fabric/edm_handshake.hpp
+++ b/tt_metal/fabric/hw/inc/edm_fabric/edm_handshake.hpp
@@ -7,7 +7,6 @@
 #include <cstdint>
 #include "internal/ethernet/dataflow_api.h"
 #include "hostdevcommon/fabric_common.h"
-#include "tt_metal/fabric/hw/inc/tt_fabric_utils.h"
 
 namespace erisc {
 namespace datamover {
@@ -71,20 +70,17 @@ __attribute__((optimize("Os"))) FORCE_INLINE volatile tt_l1_ptr handshake_info_t
     return handshake_info;
 }
 
-template <bool RISC_CPU_DATA_CACHE_ENABLED>
 __attribute__((optimize("Os"))) FORCE_INLINE void sender_side_handshake(
     uint32_t handshake_register_address,
     uint16_t my_mesh_id,
     uint8_t my_device_id,
-    volatile tt::tt_fabric::TerminationSignal* termination_signal_ptr,
     size_t HS_CONTEXT_SWITCH_TIMEOUT = A_LONG_TIMEOUT_BEFORE_CONTEXT_SWITCH) {
     volatile tt_l1_ptr handshake_info_t* handshake_info =
         init_handshake_info(handshake_register_address, my_mesh_id, my_device_id);
     uint32_t local_val_addr = ((uint32_t)(&handshake_info->local_value)) / tt::tt_fabric::PACKET_WORD_SIZE_BYTES;
     uint32_t scratch_addr = ((uint32_t)(&handshake_info->scratch)) / tt::tt_fabric::PACKET_WORD_SIZE_BYTES;
     uint32_t count = 0;
-    while (handshake_info->local_value != MAGIC_HANDSHAKE_VALUE &&
-           !tt::tt_fabric::got_immediate_termination_signal<RISC_CPU_DATA_CACHE_ENABLED>(termination_signal_ptr)) {
+    while (handshake_info->local_value != MAGIC_HANDSHAKE_VALUE) {
         if (count == HS_CONTEXT_SWITCH_TIMEOUT) {
             count = 0;
             run_routing();
@@ -96,20 +92,17 @@ __attribute__((optimize("Os"))) FORCE_INLINE void sender_side_handshake(
     }
 }
 
-template <bool RISC_CPU_DATA_CACHE_ENABLED>
 __attribute__((optimize("Os"))) FORCE_INLINE void receiver_side_handshake(
     uint32_t handshake_register_address,
     uint16_t my_mesh_id,
     uint8_t my_device_id,
-    volatile tt::tt_fabric::TerminationSignal* termination_signal_ptr,
     size_t HS_CONTEXT_SWITCH_TIMEOUT = A_LONG_TIMEOUT_BEFORE_CONTEXT_SWITCH) {
     volatile tt_l1_ptr handshake_info_t* handshake_info =
         init_handshake_info(handshake_register_address, my_mesh_id, my_device_id);
     uint32_t local_val_addr = ((uint32_t)(&handshake_info->local_value)) / tt::tt_fabric::PACKET_WORD_SIZE_BYTES;
     uint32_t scratch_addr = ((uint32_t)(&handshake_info->scratch)) / tt::tt_fabric::PACKET_WORD_SIZE_BYTES;
     uint32_t count = 0;
-    while (handshake_info->local_value != MAGIC_HANDSHAKE_VALUE &&
-           !tt::tt_fabric::got_immediate_termination_signal<RISC_CPU_DATA_CACHE_ENABLED>(termination_signal_ptr)) {
+    while (handshake_info->local_value != MAGIC_HANDSHAKE_VALUE) {
         if (count == HS_CONTEXT_SWITCH_TIMEOUT) {
             count = 0;
             run_routing();
@@ -118,9 +111,7 @@ __attribute__((optimize("Os"))) FORCE_INLINE void receiver_side_handshake(
         }
         invalidate_l1_cache();
     }
-    if (!tt::tt_fabric::got_immediate_termination_signal<RISC_CPU_DATA_CACHE_ENABLED>(termination_signal_ptr)) {
-        internal_::eth_send_packet(0, scratch_addr, local_val_addr, 1);
-    }
+    internal_::eth_send_packet(0, scratch_addr, local_val_addr, 1);
 }
 
 namespace deprecated {

--- a/tt_metal/fabric/hw/inc/edm_fabric/fabric_router_eth_handshake.hpp
+++ b/tt_metal/fabric/hw/inc/edm_fabric/fabric_router_eth_handshake.hpp
@@ -30,8 +30,11 @@ __attribute__((optimize("Os"))) FORCE_INLINE void fabric_sender_side_handshake(
     uint32_t local_val_addr = ((uint32_t)(&handshake_info->local_value)) / tt::tt_fabric::PACKET_WORD_SIZE_BYTES;
     uint32_t scratch_addr = ((uint32_t)(&handshake_info->scratch)) / tt::tt_fabric::PACKET_WORD_SIZE_BYTES;
     uint32_t count = 0;
-    while (handshake_info->local_value != MAGIC_HANDSHAKE_VALUE &&
-           !tt::tt_fabric::got_immediate_termination_signal<RISC_CPU_DATA_CACHE_ENABLED>(termination_signal_ptr)) {
+    while (handshake_info->local_value != MAGIC_HANDSHAKE_VALUE
+#ifndef ARCH_WORMHOLE
+           && !tt::tt_fabric::got_immediate_termination_signal<RISC_CPU_DATA_CACHE_ENABLED>(termination_signal_ptr)
+#endif
+    ) {
         if (count == HS_CONTEXT_SWITCH_TIMEOUT) {
             count = 0;
             run_routing();
@@ -55,8 +58,11 @@ __attribute__((optimize("Os"))) FORCE_INLINE void fabric_receiver_side_handshake
     uint32_t local_val_addr = ((uint32_t)(&handshake_info->local_value)) / tt::tt_fabric::PACKET_WORD_SIZE_BYTES;
     uint32_t scratch_addr = ((uint32_t)(&handshake_info->scratch)) / tt::tt_fabric::PACKET_WORD_SIZE_BYTES;
     uint32_t count = 0;
-    while (handshake_info->local_value != MAGIC_HANDSHAKE_VALUE &&
-           !tt::tt_fabric::got_immediate_termination_signal<RISC_CPU_DATA_CACHE_ENABLED>(termination_signal_ptr)) {
+    while (handshake_info->local_value != MAGIC_HANDSHAKE_VALUE
+#ifndef ARCH_WORMHOLE
+           && !tt::tt_fabric::got_immediate_termination_signal<RISC_CPU_DATA_CACHE_ENABLED>(termination_signal_ptr)
+#endif
+    ) {
         if (count == HS_CONTEXT_SWITCH_TIMEOUT) {
             count = 0;
             run_routing();
@@ -65,9 +71,13 @@ __attribute__((optimize("Os"))) FORCE_INLINE void fabric_receiver_side_handshake
         }
         invalidate_l1_cache();
     }
+#ifndef ARCH_WORMHOLE
     if (!tt::tt_fabric::got_immediate_termination_signal<RISC_CPU_DATA_CACHE_ENABLED>(termination_signal_ptr)) {
         internal_::eth_send_packet(0, scratch_addr, local_val_addr, 1);
     }
+#else
+    internal_::eth_send_packet(0, scratch_addr, local_val_addr, 1);
+#endif
 }
 
 }  // namespace handshake

--- a/tt_metal/fabric/hw/inc/edm_fabric/fabric_router_eth_handshake.hpp
+++ b/tt_metal/fabric/hw/inc/edm_fabric/fabric_router_eth_handshake.hpp
@@ -37,10 +37,10 @@ FORCE_INLINE void fabric_sender_side_handshake(
     ) {
         if (count == HS_CONTEXT_SWITCH_TIMEOUT) {
             count = 0;
-#ifndef ARCH_WORMHOLE
-            static_assert(PHYSICAL_AERISC_ID == 0, "run_routing() is only safe from ERISC0");
-#endif
+
+#if (defined(COMPILE_FOR_AERISC) && (PHYSICAL_AERISC_ID == 0)) || !defined(ARCH_BLACKHOLE)
             run_routing();
+#endif
         } else {
             count++;
             internal_::eth_send_packet(0, scratch_addr, local_val_addr, 1);
@@ -68,10 +68,10 @@ FORCE_INLINE void fabric_receiver_side_handshake(
     ) {
         if (count == HS_CONTEXT_SWITCH_TIMEOUT) {
             count = 0;
-#ifndef ARCH_WORMHOLE
-            static_assert(PHYSICAL_AERISC_ID == 0, "run_routing() is only safe from ERISC0");
-#endif
+
+#if (defined(COMPILE_FOR_AERISC) && (PHYSICAL_AERISC_ID == 0)) || !defined(ARCH_BLACKHOLE)
             run_routing();
+#endif
         } else {
             count++;
         }

--- a/tt_metal/fabric/hw/inc/edm_fabric/fabric_router_eth_handshake.hpp
+++ b/tt_metal/fabric/hw/inc/edm_fabric/fabric_router_eth_handshake.hpp
@@ -37,6 +37,7 @@ FORCE_INLINE void fabric_sender_side_handshake(
     ) {
         if (count == HS_CONTEXT_SWITCH_TIMEOUT) {
             count = 0;
+            static_assert(PHYSICAL_AERISC_ID == 0, "run_routing() is only safe from ERISC0");
             run_routing();
         } else {
             count++;
@@ -65,6 +66,7 @@ FORCE_INLINE void fabric_receiver_side_handshake(
     ) {
         if (count == HS_CONTEXT_SWITCH_TIMEOUT) {
             count = 0;
+            static_assert(PHYSICAL_AERISC_ID == 0, "run_routing() is only safe from ERISC0");
             run_routing();
         } else {
             count++;

--- a/tt_metal/fabric/hw/inc/edm_fabric/fabric_router_eth_handshake.hpp
+++ b/tt_metal/fabric/hw/inc/edm_fabric/fabric_router_eth_handshake.hpp
@@ -19,7 +19,7 @@ namespace handshake {
  */
 
 template <bool RISC_CPU_DATA_CACHE_ENABLED>
-__attribute__((optimize("Os"))) FORCE_INLINE void fabric_sender_side_handshake(
+FORCE_INLINE void fabric_sender_side_handshake(
     uint32_t handshake_register_address,
     uint16_t my_mesh_id,
     uint8_t my_device_id,
@@ -47,7 +47,7 @@ __attribute__((optimize("Os"))) FORCE_INLINE void fabric_sender_side_handshake(
 }
 
 template <bool RISC_CPU_DATA_CACHE_ENABLED>
-__attribute__((optimize("Os"))) FORCE_INLINE void fabric_receiver_side_handshake(
+FORCE_INLINE void fabric_receiver_side_handshake(
     uint32_t handshake_register_address,
     uint16_t my_mesh_id,
     uint8_t my_device_id,

--- a/tt_metal/fabric/hw/inc/edm_fabric/fabric_router_eth_handshake.hpp
+++ b/tt_metal/fabric/hw/inc/edm_fabric/fabric_router_eth_handshake.hpp
@@ -37,7 +37,9 @@ FORCE_INLINE void fabric_sender_side_handshake(
     ) {
         if (count == HS_CONTEXT_SWITCH_TIMEOUT) {
             count = 0;
+#ifndef ARCH_WORMHOLE
             static_assert(PHYSICAL_AERISC_ID == 0, "run_routing() is only safe from ERISC0");
+#endif
             run_routing();
         } else {
             count++;
@@ -66,7 +68,9 @@ FORCE_INLINE void fabric_receiver_side_handshake(
     ) {
         if (count == HS_CONTEXT_SWITCH_TIMEOUT) {
             count = 0;
+#ifndef ARCH_WORMHOLE
             static_assert(PHYSICAL_AERISC_ID == 0, "run_routing() is only safe from ERISC0");
+#endif
             run_routing();
         } else {
             count++;

--- a/tt_metal/fabric/hw/inc/edm_fabric/fabric_router_eth_handshake.hpp
+++ b/tt_metal/fabric/hw/inc/edm_fabric/fabric_router_eth_handshake.hpp
@@ -1,0 +1,75 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "tt_metal/fabric/hw/inc/edm_fabric/edm_handshake.hpp"
+#include "tt_metal/fabric/hw/inc/tt_fabric_utils.h"
+
+namespace erisc {
+namespace datamover {
+namespace handshake {
+
+/*
+ * Fabric-specific handshake functions with termination signal support.
+ * These extend the base EDM handshake with the ability to exit early
+ * when the host requests immediate termination, enabling graceful
+ * recovery during fabric init/teardown.
+ */
+
+template <bool RISC_CPU_DATA_CACHE_ENABLED>
+__attribute__((optimize("Os"))) FORCE_INLINE void fabric_sender_side_handshake(
+    uint32_t handshake_register_address,
+    uint16_t my_mesh_id,
+    uint8_t my_device_id,
+    volatile tt::tt_fabric::TerminationSignal* termination_signal_ptr,
+    size_t HS_CONTEXT_SWITCH_TIMEOUT = A_LONG_TIMEOUT_BEFORE_CONTEXT_SWITCH) {
+    volatile tt_l1_ptr handshake_info_t* handshake_info =
+        init_handshake_info(handshake_register_address, my_mesh_id, my_device_id);
+    uint32_t local_val_addr = ((uint32_t)(&handshake_info->local_value)) / tt::tt_fabric::PACKET_WORD_SIZE_BYTES;
+    uint32_t scratch_addr = ((uint32_t)(&handshake_info->scratch)) / tt::tt_fabric::PACKET_WORD_SIZE_BYTES;
+    uint32_t count = 0;
+    while (handshake_info->local_value != MAGIC_HANDSHAKE_VALUE &&
+           !tt::tt_fabric::got_immediate_termination_signal<RISC_CPU_DATA_CACHE_ENABLED>(termination_signal_ptr)) {
+        if (count == HS_CONTEXT_SWITCH_TIMEOUT) {
+            count = 0;
+            run_routing();
+        } else {
+            count++;
+            internal_::eth_send_packet(0, scratch_addr, local_val_addr, 1);
+        }
+        invalidate_l1_cache();
+    }
+}
+
+template <bool RISC_CPU_DATA_CACHE_ENABLED>
+__attribute__((optimize("Os"))) FORCE_INLINE void fabric_receiver_side_handshake(
+    uint32_t handshake_register_address,
+    uint16_t my_mesh_id,
+    uint8_t my_device_id,
+    volatile tt::tt_fabric::TerminationSignal* termination_signal_ptr,
+    size_t HS_CONTEXT_SWITCH_TIMEOUT = A_LONG_TIMEOUT_BEFORE_CONTEXT_SWITCH) {
+    volatile tt_l1_ptr handshake_info_t* handshake_info =
+        init_handshake_info(handshake_register_address, my_mesh_id, my_device_id);
+    uint32_t local_val_addr = ((uint32_t)(&handshake_info->local_value)) / tt::tt_fabric::PACKET_WORD_SIZE_BYTES;
+    uint32_t scratch_addr = ((uint32_t)(&handshake_info->scratch)) / tt::tt_fabric::PACKET_WORD_SIZE_BYTES;
+    uint32_t count = 0;
+    while (handshake_info->local_value != MAGIC_HANDSHAKE_VALUE &&
+           !tt::tt_fabric::got_immediate_termination_signal<RISC_CPU_DATA_CACHE_ENABLED>(termination_signal_ptr)) {
+        if (count == HS_CONTEXT_SWITCH_TIMEOUT) {
+            count = 0;
+            run_routing();
+        } else {
+            count++;
+        }
+        invalidate_l1_cache();
+    }
+    if (!tt::tt_fabric::got_immediate_termination_signal<RISC_CPU_DATA_CACHE_ENABLED>(termination_signal_ptr)) {
+        internal_::eth_send_packet(0, scratch_addr, local_val_addr, 1);
+    }
+}
+
+}  // namespace handshake
+}  // namespace datamover
+}  // namespace erisc

--- a/tt_metal/fabric/hw/inc/tt_fabric_utils.h
+++ b/tt_metal/fabric/hw/inc/tt_fabric_utils.h
@@ -71,7 +71,7 @@ FORCE_INLINE void check_worker_connections(
 
 // !!!FORCE_INLINE could potentially cause stack corruption as seen in the past
 template <bool RISC_CPU_DATA_CACHE_ENABLED>
-__attribute__((optimize("Os"))) inline void wait_for_notification(
+inline void wait_for_notification(
     uint32_t address, uint32_t value, volatile tt::tt_fabric::TerminationSignal* termination_signal_ptr) {
     volatile tt_l1_ptr uint32_t* poll_addr = (volatile tt_l1_ptr uint32_t*)address;
     while (*poll_addr != value
@@ -86,7 +86,7 @@ __attribute__((optimize("Os"))) inline void wait_for_notification(
 }
 
 // !!!FORCE_INLINE could potentially cause stack corruption as seen in the past
-__attribute__((optimize("Os"))) inline void notify_master_router(uint32_t master_eth_chan, uint32_t address) {
+inline void notify_master_router(uint32_t master_eth_chan, uint32_t address) {
     // send semaphore increment to master router on this device.
     // semaphore notifies all other routers that this router has completed
     // startup handshake with its ethernet peer.
@@ -106,7 +106,7 @@ __attribute__((optimize("Os"))) inline void notify_master_router(uint32_t master
 // !!!FORCE_INLINE could potentially cause stack corruption as seen in the past
 // exclude_eth_chan is normally used for master ethernet channel to avoid sending notification to itself
 // but still can send to itself if the eth core has multiple risc cores (like Blackhole)
-__attribute__((optimize("Os"))) inline void notify_subordinate_routers(
+inline void notify_subordinate_routers(
     uint32_t router_eth_chans_mask, uint32_t exclude_eth_chan, uint32_t address, uint32_t notification) {
     uint32_t remaining_cores = router_eth_chans_mask;
     constexpr uint32_t num_routers = sizeof(eth_chan_to_noc_xy[0]) / sizeof(eth_chan_to_noc_xy[0][0]);

--- a/tt_metal/fabric/hw/inc/tt_fabric_utils.h
+++ b/tt_metal/fabric/hw/inc/tt_fabric_utils.h
@@ -81,7 +81,9 @@ inline void wait_for_notification(
     ) {
         router_invalidate_l1_cache<RISC_CPU_DATA_CACHE_ENABLED>();
         // context switch while waiting to allow slow dispatch traffic to go through
+#ifndef ARCH_WORMHOLE
         static_assert(PHYSICAL_AERISC_ID == 0, "run_routing() is only safe from ERISC0");
+#endif
         run_routing();
     }
 }

--- a/tt_metal/fabric/hw/inc/tt_fabric_utils.h
+++ b/tt_metal/fabric/hw/inc/tt_fabric_utils.h
@@ -74,8 +74,11 @@ template <bool RISC_CPU_DATA_CACHE_ENABLED>
 __attribute__((optimize("Os"))) inline void wait_for_notification(
     uint32_t address, uint32_t value, volatile tt::tt_fabric::TerminationSignal* termination_signal_ptr) {
     volatile tt_l1_ptr uint32_t* poll_addr = (volatile tt_l1_ptr uint32_t*)address;
-    while (*poll_addr != value &&
-           !got_immediate_termination_signal<RISC_CPU_DATA_CACHE_ENABLED>(termination_signal_ptr)) {
+    while (*poll_addr != value
+#ifndef ARCH_WORMHOLE
+           && !got_immediate_termination_signal<RISC_CPU_DATA_CACHE_ENABLED>(termination_signal_ptr)
+#endif
+    ) {
         router_invalidate_l1_cache<RISC_CPU_DATA_CACHE_ENABLED>();
         // context switch while waiting to allow slow dispatch traffic to go through
         run_routing();

--- a/tt_metal/fabric/hw/inc/tt_fabric_utils.h
+++ b/tt_metal/fabric/hw/inc/tt_fabric_utils.h
@@ -71,7 +71,7 @@ FORCE_INLINE void check_worker_connections(
 
 // !!!FORCE_INLINE could potentially cause stack corruption as seen in the past
 template <bool RISC_CPU_DATA_CACHE_ENABLED>
-inline void wait_for_notification(
+__attribute__((optimize("Os"))) inline void wait_for_notification(
     uint32_t address, uint32_t value, volatile tt::tt_fabric::TerminationSignal* termination_signal_ptr) {
     volatile tt_l1_ptr uint32_t* poll_addr = (volatile tt_l1_ptr uint32_t*)address;
     while (*poll_addr != value &&
@@ -83,7 +83,7 @@ inline void wait_for_notification(
 }
 
 // !!!FORCE_INLINE could potentially cause stack corruption as seen in the past
-inline void notify_master_router(uint32_t master_eth_chan, uint32_t address) {
+__attribute__((optimize("Os"))) inline void notify_master_router(uint32_t master_eth_chan, uint32_t address) {
     // send semaphore increment to master router on this device.
     // semaphore notifies all other routers that this router has completed
     // startup handshake with its ethernet peer.
@@ -103,7 +103,7 @@ inline void notify_master_router(uint32_t master_eth_chan, uint32_t address) {
 // !!!FORCE_INLINE could potentially cause stack corruption as seen in the past
 // exclude_eth_chan is normally used for master ethernet channel to avoid sending notification to itself
 // but still can send to itself if the eth core has multiple risc cores (like Blackhole)
-inline void notify_subordinate_routers(
+__attribute__((optimize("Os"))) inline void notify_subordinate_routers(
     uint32_t router_eth_chans_mask, uint32_t exclude_eth_chan, uint32_t address, uint32_t notification) {
     uint32_t remaining_cores = router_eth_chans_mask;
     constexpr uint32_t num_routers = sizeof(eth_chan_to_noc_xy[0]) / sizeof(eth_chan_to_noc_xy[0][0]);

--- a/tt_metal/fabric/hw/inc/tt_fabric_utils.h
+++ b/tt_metal/fabric/hw/inc/tt_fabric_utils.h
@@ -81,10 +81,10 @@ inline void wait_for_notification(
     ) {
         router_invalidate_l1_cache<RISC_CPU_DATA_CACHE_ENABLED>();
         // context switch while waiting to allow slow dispatch traffic to go through
-#ifndef ARCH_WORMHOLE
-        static_assert(PHYSICAL_AERISC_ID == 0, "run_routing() is only safe from ERISC0");
-#endif
+
+#if (defined(COMPILE_FOR_AERISC) && (PHYSICAL_AERISC_ID == 0)) || !defined(ARCH_BLACKHOLE)
         run_routing();
+#endif
     }
 }
 

--- a/tt_metal/fabric/hw/inc/tt_fabric_utils.h
+++ b/tt_metal/fabric/hw/inc/tt_fabric_utils.h
@@ -81,6 +81,7 @@ inline void wait_for_notification(
     ) {
         router_invalidate_l1_cache<RISC_CPU_DATA_CACHE_ENABLED>();
         // context switch while waiting to allow slow dispatch traffic to go through
+        static_assert(PHYSICAL_AERISC_ID == 0, "run_routing() is only safe from ERISC0");
         run_routing();
     }
 }

--- a/tt_metal/fabric/hw/inc/tt_fabric_utils.h
+++ b/tt_metal/fabric/hw/inc/tt_fabric_utils.h
@@ -71,9 +71,11 @@ FORCE_INLINE void check_worker_connections(
 
 // !!!FORCE_INLINE could potentially cause stack corruption as seen in the past
 template <bool RISC_CPU_DATA_CACHE_ENABLED>
-inline void wait_for_notification(uint32_t address, uint32_t value) {
+inline void wait_for_notification(
+    uint32_t address, uint32_t value, volatile tt::tt_fabric::TerminationSignal* termination_signal_ptr) {
     volatile tt_l1_ptr uint32_t* poll_addr = (volatile tt_l1_ptr uint32_t*)address;
-    while (*poll_addr != value) {
+    while (*poll_addr != value &&
+           !got_immediate_termination_signal<RISC_CPU_DATA_CACHE_ENABLED>(termination_signal_ptr)) {
         router_invalidate_l1_cache<RISC_CPU_DATA_CACHE_ENABLED>();
         // context switch while waiting to allow slow dispatch traffic to go through
         run_routing();

--- a/tt_metal/fabric/impl/kernels/edm_fabric/fabric_erisc_router.cpp
+++ b/tt_metal/fabric/impl/kernels/edm_fabric/fabric_erisc_router.cpp
@@ -2679,6 +2679,9 @@ void
         if (!sender_ch_live_check_skip[sender_channel_idx]) {
             return;
         }
+        static_constexpr(
+            !sender_ch_live_check_skip[sender_channel_idx] || MY_ERISC_ID == 0,
+            "run_routing() is only safe from ERISC0");
         uint32_t count = 0;
         while (!connect_is_requested(*interface.connection_live_semaphore)
 #ifndef ARCH_WORMHOLE
@@ -2688,7 +2691,6 @@ void
             router_invalidate_l1_cache<ENABLE_RISC_CPU_DATA_CACHE>();
 #ifndef ARCH_WORMHOLE
             if constexpr (MY_ERISC_ID == 0) {
-                static_assert(PHYSICAL_AERISC_ID == 0, "run_routing() is only safe from ERISC0");
                 if (count++ == CONTEXT_SWITCH_TIMEOUT_SHORT) {
                     count = 0;
                     run_routing();

--- a/tt_metal/fabric/impl/kernels/edm_fabric/fabric_erisc_router.cpp
+++ b/tt_metal/fabric/impl/kernels/edm_fabric/fabric_erisc_router.cpp
@@ -2805,6 +2805,11 @@ void populate_local_sender_channel_free_slots_stream_id_ordered_map(
 
 constexpr bool IS_TEARDOWN_MASTER() { return MY_ERISC_ID == 0; }
 
+// Note: No termination check is added here intentionally. Both local ERISCs share
+// the same termination signal, so both will see it and exit their respective wait
+// loops naturally. Adding a termination check here would be unsafe — if one ERISC
+// broke out of the sync early and skipped its scratch register write, the other
+// could spin forever waiting for a value that never arrives.
 void wait_for_other_local_erisc() {
     constexpr uint32_t multi_erisc_sync_start_value = 0x0fed;
     constexpr uint32_t multi_erisc_sync_step2_value = 0x1bad;

--- a/tt_metal/fabric/impl/kernels/edm_fabric/fabric_erisc_router.cpp
+++ b/tt_metal/fabric/impl/kernels/edm_fabric/fabric_erisc_router.cpp
@@ -2679,9 +2679,6 @@ void
         if (!sender_ch_live_check_skip[sender_channel_idx]) {
             return;
         }
-        static_constexpr(
-            !sender_ch_live_check_skip[sender_channel_idx] || MY_ERISC_ID == 0,
-            "run_routing() is only safe from ERISC0");
         uint32_t count = 0;
         while (!connect_is_requested(*interface.connection_live_semaphore)
 #ifndef ARCH_WORMHOLE

--- a/tt_metal/fabric/impl/kernels/edm_fabric/fabric_erisc_router.cpp
+++ b/tt_metal/fabric/impl/kernels/edm_fabric/fabric_erisc_router.cpp
@@ -1379,7 +1379,7 @@ FORCE_INLINE
 #endif
 
 template <typename EdmChannelWorkerIFs>
-FORCE_INLINE void establish_edm_connection(
+__attribute__((optimize("Os"))) FORCE_INLINE void establish_edm_connection(
     EdmChannelWorkerIFs& local_sender_channel_worker_interface, uint32_t stream_id) {
     local_sender_channel_worker_interface.template cache_producer_noc_addr<ENABLE_RISC_CPU_DATA_CACHE, USE_DYNAMIC_CREDIT_ADDR>();
 }
@@ -2024,7 +2024,7 @@ FORCE_INLINE bool run_receiver_channel_step(
 template<
     typename OutboundReceiverChannelPointers,
     typename RemoteEthReceiverChannels>
-FORCE_INLINE void configure_outbound_to_receiver_channel_pointers(
+__attribute__((optimize("Os"))) FORCE_INLINE void configure_outbound_to_receiver_channel_pointers(
     OutboundReceiverChannelPointers& outbound_to_receiver_channel_pointers,
     RemoteEthReceiverChannels& remote_receiver_channels) {
     static_assert(OutboundReceiverChannelPointers::N == RemoteEthReceiverChannels::num_channels);
@@ -2669,6 +2669,7 @@ FORCE_INLINE void run_fabric_edm_main_loop(
 }
 
 template <typename EdmChannelWorkerIFs, size_t NUM_SENDER_CHANNELS>
+__attribute__((optimize("Os")))
 void
 #ifdef FABRIC_2D
     __attribute__((noinline))
@@ -2727,7 +2728,7 @@ constexpr size_t get_credits_init_val() {
 // SFINAE helper to initialize a single sender channel worker interface
 // Only enabled when I < NUM_SENDER_CHANNELS
 template <size_t I, size_t NUM_SENDER_CHANNELS, typename EdmChannelWorkerIFs>
-FORCE_INLINE typename std::enable_if<(I < NUM_SENDER_CHANNELS), void>::type init_sender_channel_worker_interface(
+__attribute__((optimize("Os"))) FORCE_INLINE typename std::enable_if<(I < NUM_SENDER_CHANNELS), void>::type init_sender_channel_worker_interface(
     std::array<size_t, NUM_SENDER_CHANNELS>& local_sender_connection_live_semaphore_addresses,
     std::array<size_t, NUM_SENDER_CHANNELS>& local_sender_connection_info_addresses,
     EdmChannelWorkerIFs& local_sender_channel_worker_interfaces) {
@@ -2753,6 +2754,7 @@ typename std::enable_if<(I >= NUM_SENDER_CHANNELS), void>::type init_sender_chan
 }
 
 template <size_t NUM_SENDER_CHANNELS, typename EdmChannelWorkerIFs>
+__attribute__((optimize("Os")))
 void
 #ifdef FABRIC_2D
     __attribute__((noinline))
@@ -2795,7 +2797,7 @@ void
 
 // copy the sender_channel_free_slots_stream_ids (in L1) to local memory for performance.
 template <size_t NUM_SENDER_CHANNELS>
-void populate_local_sender_channel_free_slots_stream_id_ordered_map(
+__attribute__((optimize("Os"))) void populate_local_sender_channel_free_slots_stream_id_ordered_map(
     uint32_t has_downstream_edm_vc0_buffer_connection,
     std::array<uint32_t, NUM_SENDER_CHANNELS>& local_sender_channel_free_slots_stream_ids) {
     for (size_t i = 0; i < NUM_SENDER_CHANNELS; i++) {
@@ -2810,7 +2812,7 @@ constexpr bool IS_TEARDOWN_MASTER() { return MY_ERISC_ID == 0; }
 // loops naturally. Adding a termination check here would be unsafe — if one ERISC
 // broke out of the sync early and skipped its scratch register write, the other
 // could spin forever waiting for a value that never arrives.
-void wait_for_other_local_erisc() {
+__attribute__((optimize("Os"))) void wait_for_other_local_erisc() {
     constexpr uint32_t multi_erisc_sync_start_value = 0x0fed;
     constexpr uint32_t multi_erisc_sync_step2_value = 0x1bad;
     if constexpr (IS_TEARDOWN_MASTER()) {
@@ -2829,7 +2831,7 @@ void wait_for_other_local_erisc() {
     }
 }
 
-FORCE_INLINE void teardown(
+__attribute__((optimize("Os"))) void teardown(
     volatile tt_l1_ptr tt::tt_fabric::TerminationSignal* termination_signal_ptr,
     volatile tt_l1_ptr tt::tt_fabric::EDMStatus* edm_status_ptr,
     WriteTransactionIdTracker<
@@ -2910,7 +2912,7 @@ FORCE_INLINE void teardown(
     }
 }
 
-void initialize_state_for_txq1_active_mode() {
+__attribute__((optimize("Os"))) void initialize_state_for_txq1_active_mode() {
     eth_enable_packet_mode(receiver_txq_id);
     for (size_t i = 0; i < NUM_RECEIVER_CHANNELS; i++) {
         reinterpret_cast<volatile uint32_t*>(local_receiver_ack_counters_base_address)[i] = 0;
@@ -2918,7 +2920,7 @@ void initialize_state_for_txq1_active_mode() {
     }
     eth_txq_reg_write(receiver_txq_id, ETH_TXQ_DATA_PACKET_ACCEPT_AHEAD, DEFAULT_NUM_ETH_TXQ_DATA_PACKET_ACCEPT_AHEAD);
 }
-void initialize_state_for_txq1_active_mode_sender_side() {
+__attribute__((optimize("Os"))) void initialize_state_for_txq1_active_mode_sender_side() {
     for (size_t i = 0; i < NUM_SENDER_CHANNELS; i++) {
         reinterpret_cast<volatile uint32_t*>(to_sender_remote_ack_counters_base_address)[i] = 0;
         reinterpret_cast<volatile uint32_t*>(to_sender_remote_completion_counters_base_address)[i] = 0;
@@ -2927,7 +2929,7 @@ void initialize_state_for_txq1_active_mode_sender_side() {
 
 // Initialize fabric telemetry structure in L1
 // This must be called early in kernel_main to ensure telemetry is properly initialized
-void initialize_fabric_telemetry() {
+__attribute__((optimize("Os"))) void initialize_fabric_telemetry() {
     // Get pointer to telemetry structure in L1
     volatile tt_l1_ptr FabricTelemetry* fabric_telemetry =
         reinterpret_cast<volatile tt_l1_ptr FabricTelemetry*>(eth_l1_mem::address_map::AERISC_FABRIC_TELEMETRY_ADDR);

--- a/tt_metal/fabric/impl/kernels/edm_fabric/fabric_erisc_router.cpp
+++ b/tt_metal/fabric/impl/kernels/edm_fabric/fabric_erisc_router.cpp
@@ -2666,6 +2666,7 @@ FORCE_INLINE void run_fabric_edm_main_loop(
     }
 }
 
+static constexpr uint32_t CONTEXT_SWITCH_TIMEOUT_SHORT = 100000;
 template <typename EdmChannelWorkerIFs, size_t NUM_SENDER_CHANNELS>
 void
 #ifdef FABRIC_2D

--- a/tt_metal/fabric/impl/kernels/edm_fabric/fabric_erisc_router.cpp
+++ b/tt_metal/fabric/impl/kernels/edm_fabric/fabric_erisc_router.cpp
@@ -2172,7 +2172,6 @@ FORCE_INLINE void run_fabric_edm_main_loop(
     using FabricTelemetryT = FabricTelemetry;
     FabricTelemetryT local_fabric_telemetry{};
     auto fabric_telemetry = reinterpret_cast<volatile FabricTelemetryT*>(MEM_AERISC_FABRIC_TELEMETRY_BASE);
-    *termination_signal_ptr = tt::tt_fabric::TerminationSignal::KEEP_RUNNING;
 
     const auto* routing_table_l1 = reinterpret_cast<tt_l1_ptr tt::tt_fabric::routing_l1_info_t*>(ROUTING_TABLE_BASE);
     auto* state_manager_l1 = const_cast<tt_l1_ptr RouterStateManager*>(&routing_table_l1->state_manager);
@@ -2676,13 +2675,16 @@ void
 #endif
     wait_for_static_connection_to_ready(
         EdmChannelWorkerIFs& local_sender_channel_worker_interfaces,
-        std::array<uint32_t, NUM_SENDER_CHANNELS>& local_sender_channel_free_slots_stream_ids) {
+        std::array<uint32_t, NUM_SENDER_CHANNELS>& local_sender_channel_free_slots_stream_ids,
+        volatile tt::tt_fabric::TerminationSignal* termination_signal_ptr) {
     auto establish_static_connection_from_receiver_side = [&](auto& interface, size_t sender_channel_idx) {
         if (!sender_ch_live_check_skip[sender_channel_idx]) {
             return;
         }
-        while (!connect_is_requested(*interface.connection_live_semaphore)) {
+        while (!connect_is_requested(*interface.connection_live_semaphore) &&
+               !got_immediate_termination_signal<ENABLE_RISC_CPU_DATA_CACHE>(termination_signal_ptr)) {
             router_invalidate_l1_cache<ENABLE_RISC_CPU_DATA_CACHE>();
+            run_routing();
         }
         establish_edm_connection(interface, local_sender_channel_free_slots_stream_ids[sender_channel_idx]);
     };
@@ -3504,16 +3506,18 @@ void kernel_main() {
     }
     if constexpr (enable_ethernet_handshake) {
         if constexpr (is_handshake_sender) {
-            erisc::datamover::handshake::sender_side_handshake(
+            erisc::datamover::handshake::sender_side_handshake<ENABLE_RISC_CPU_DATA_CACHE>(
                 handshake_addr,
                 routing_table_l1->my_mesh_id,
                 routing_table_l1->my_device_id,
+                termination_signal_ptr,
                 DEFAULT_HANDSHAKE_CONTEXT_SWITCH_TIMEOUT);
         } else {
-            erisc::datamover::handshake::receiver_side_handshake(
+            erisc::datamover::handshake::receiver_side_handshake<ENABLE_RISC_CPU_DATA_CACHE>(
                 handshake_addr,
                 routing_table_l1->my_mesh_id,
                 routing_table_l1->my_device_id,
+                termination_signal_ptr,
                 DEFAULT_HANDSHAKE_CONTEXT_SWITCH_TIMEOUT);
         }
 
@@ -3533,7 +3537,8 @@ void kernel_main() {
 
         if constexpr (wait_for_host_signal) {
             if constexpr (is_local_handshake_master) {
-                wait_for_notification<ENABLE_RISC_CPU_DATA_CACHE>((uint32_t)edm_local_sync_ptr, num_local_edms - 1);
+                wait_for_notification<ENABLE_RISC_CPU_DATA_CACHE>(
+                    (uint32_t)edm_local_sync_ptr, num_local_edms - 1, termination_signal_ptr);
                 // This master sends notification to self for multi risc in single eth core case,
                 // This still send to self even though with single risc core case, but no side effects
                 constexpr uint32_t exclude_eth_chan = std::numeric_limits<uint32_t>::max();
@@ -3541,7 +3546,8 @@ void kernel_main() {
                     edm_channels_mask, exclude_eth_chan, (uint32_t)edm_local_sync_ptr, num_local_edms);
             } else {
                 notify_master_router(local_handshake_master_eth_chan, (uint32_t)edm_local_sync_ptr);
-                wait_for_notification<ENABLE_RISC_CPU_DATA_CACHE>((uint32_t)edm_local_sync_ptr, num_local_edms);
+                wait_for_notification<ENABLE_RISC_CPU_DATA_CACHE>(
+                    (uint32_t)edm_local_sync_ptr, num_local_edms, termination_signal_ptr);
             }
 
             *edm_status_ptr = tt::tt_fabric::EDMStatus::LOCAL_HANDSHAKE_COMPLETE;
@@ -3550,7 +3556,8 @@ void kernel_main() {
             // 2. All risc cores in master eth core receive signal from host and exits from this wait
             //    Other subordinate risc cores wait for this signal
             // 4. The other subordinate risc cores receive the READY_FOR_TRAFFIC signal and exit from this wait
-            wait_for_notification<ENABLE_RISC_CPU_DATA_CACHE>((uint32_t)edm_status_ptr, tt::tt_fabric::EDMStatus::READY_FOR_TRAFFIC);
+            wait_for_notification<ENABLE_RISC_CPU_DATA_CACHE>(
+                (uint32_t)edm_status_ptr, tt::tt_fabric::EDMStatus::READY_FOR_TRAFFIC, termination_signal_ptr);
 
             if constexpr (is_local_handshake_master) {
                 // 3. Only master risc core notifies all subordinate risc cores (except subordinate riscs in master eth
@@ -3573,7 +3580,8 @@ void kernel_main() {
     // if enable the tensix extension, then before open downstream connection, need to wait for downstream tensix ready
     // for connection.
     if constexpr (num_ds_or_local_tensix_connections) {
-        wait_for_notification<ENABLE_RISC_CPU_DATA_CACHE>((uint32_t)edm_local_tensix_sync_ptr_addr, num_ds_or_local_tensix_connections);
+        wait_for_notification<ENABLE_RISC_CPU_DATA_CACHE>(
+            (uint32_t)edm_local_tensix_sync_ptr_addr, num_ds_or_local_tensix_connections, termination_signal_ptr);
     }
 
     if constexpr (is_2d_fabric) {
@@ -3683,7 +3691,7 @@ void kernel_main() {
 
     WAYPOINT("FSCW");
     wait_for_static_connection_to_ready(
-        local_sender_channel_worker_interfaces, local_sender_channel_free_slots_stream_ids);
+        local_sender_channel_worker_interfaces, local_sender_channel_free_slots_stream_ids, termination_signal_ptr);
     WAYPOINT("FSCD");
 
     if constexpr (NUM_ACTIVE_ERISCS > 1) {

--- a/tt_metal/fabric/impl/kernels/edm_fabric/fabric_erisc_router.cpp
+++ b/tt_metal/fabric/impl/kernels/edm_fabric/fabric_erisc_router.cpp
@@ -1379,7 +1379,7 @@ FORCE_INLINE
 #endif
 
 template <typename EdmChannelWorkerIFs>
-__attribute__((optimize("Os"))) FORCE_INLINE void establish_edm_connection(
+FORCE_INLINE void establish_edm_connection(
     EdmChannelWorkerIFs& local_sender_channel_worker_interface, uint32_t stream_id) {
     local_sender_channel_worker_interface.template cache_producer_noc_addr<ENABLE_RISC_CPU_DATA_CACHE, USE_DYNAMIC_CREDIT_ADDR>();
 }
@@ -2021,10 +2021,8 @@ FORCE_INLINE bool run_receiver_channel_step(
     return false;
 }
 
-template<
-    typename OutboundReceiverChannelPointers,
-    typename RemoteEthReceiverChannels>
-__attribute__((optimize("Os"))) FORCE_INLINE void configure_outbound_to_receiver_channel_pointers(
+template <typename OutboundReceiverChannelPointers, typename RemoteEthReceiverChannels>
+FORCE_INLINE void configure_outbound_to_receiver_channel_pointers(
     OutboundReceiverChannelPointers& outbound_to_receiver_channel_pointers,
     RemoteEthReceiverChannels& remote_receiver_channels) {
     static_assert(OutboundReceiverChannelPointers::N == RemoteEthReceiverChannels::num_channels);
@@ -2669,7 +2667,6 @@ FORCE_INLINE void run_fabric_edm_main_loop(
 }
 
 template <typename EdmChannelWorkerIFs, size_t NUM_SENDER_CHANNELS>
-__attribute__((optimize("Os")))
 void
 #ifdef FABRIC_2D
     __attribute__((noinline))
@@ -2733,7 +2730,7 @@ constexpr size_t get_credits_init_val() {
 // SFINAE helper to initialize a single sender channel worker interface
 // Only enabled when I < NUM_SENDER_CHANNELS
 template <size_t I, size_t NUM_SENDER_CHANNELS, typename EdmChannelWorkerIFs>
-__attribute__((optimize("Os"))) FORCE_INLINE typename std::enable_if<(I < NUM_SENDER_CHANNELS), void>::type init_sender_channel_worker_interface(
+FORCE_INLINE typename std::enable_if<(I < NUM_SENDER_CHANNELS), void>::type init_sender_channel_worker_interface(
     std::array<size_t, NUM_SENDER_CHANNELS>& local_sender_connection_live_semaphore_addresses,
     std::array<size_t, NUM_SENDER_CHANNELS>& local_sender_connection_info_addresses,
     EdmChannelWorkerIFs& local_sender_channel_worker_interfaces) {
@@ -2802,7 +2799,7 @@ void
 
 // copy the sender_channel_free_slots_stream_ids (in L1) to local memory for performance.
 template <size_t NUM_SENDER_CHANNELS>
-__attribute__((optimize("Os"))) void populate_local_sender_channel_free_slots_stream_id_ordered_map(
+void populate_local_sender_channel_free_slots_stream_id_ordered_map(
     uint32_t has_downstream_edm_vc0_buffer_connection,
     std::array<uint32_t, NUM_SENDER_CHANNELS>& local_sender_channel_free_slots_stream_ids) {
     for (size_t i = 0; i < NUM_SENDER_CHANNELS; i++) {
@@ -2934,7 +2931,7 @@ __attribute__((optimize("Os"))) void initialize_state_for_txq1_active_mode_sende
 
 // Initialize fabric telemetry structure in L1
 // This must be called early in kernel_main to ensure telemetry is properly initialized
-__attribute__((optimize("Os"))) void initialize_fabric_telemetry() {
+void initialize_fabric_telemetry() {
     // Get pointer to telemetry structure in L1
     volatile tt_l1_ptr FabricTelemetry* fabric_telemetry =
         reinterpret_cast<volatile tt_l1_ptr FabricTelemetry*>(eth_l1_mem::address_map::AERISC_FABRIC_TELEMETRY_ADDR);

--- a/tt_metal/fabric/impl/kernels/edm_fabric/fabric_erisc_router.cpp
+++ b/tt_metal/fabric/impl/kernels/edm_fabric/fabric_erisc_router.cpp
@@ -2682,10 +2682,15 @@ void
         if (!sender_ch_live_check_skip[sender_channel_idx]) {
             return;
         }
-        while (!connect_is_requested(*interface.connection_live_semaphore) &&
-               !got_immediate_termination_signal<ENABLE_RISC_CPU_DATA_CACHE>(termination_signal_ptr)) {
+        while (!connect_is_requested(*interface.connection_live_semaphore)
+#ifndef ARCH_WORMHOLE
+               && !got_immediate_termination_signal<ENABLE_RISC_CPU_DATA_CACHE>(termination_signal_ptr)
+#endif
+        ) {
             router_invalidate_l1_cache<ENABLE_RISC_CPU_DATA_CACHE>();
+#ifndef ARCH_WORMHOLE
             run_routing();
+#endif
         }
         establish_edm_connection(interface, local_sender_channel_free_slots_stream_ids[sender_channel_idx]);
     };

--- a/tt_metal/fabric/impl/kernels/edm_fabric/fabric_erisc_router.cpp
+++ b/tt_metal/fabric/impl/kernels/edm_fabric/fabric_erisc_router.cpp
@@ -11,7 +11,7 @@
 #include <tt-metalium/experimental/fabric/fabric_edm_types.hpp>
 
 #include "tt_metal/fabric/hw/inc/edm_fabric/fabric_erisc_router_ct_args.hpp"
-#include "tt_metal/fabric/hw/inc/edm_fabric/edm_handshake.hpp"
+#include "tt_metal/fabric/hw/inc/edm_fabric/fabric_router_eth_handshake.hpp"
 #include "tt_metal/fabric/hw/inc/edm_fabric/fabric_router_adapter.hpp"
 #include "tt_metal/fabric/hw/inc/edm_fabric/fabric_edm_packet_header_validate.hpp"
 #include "tt_metal/fabric/hw/inc/edm_fabric/fabric_edm_packet_transmission.hpp"
@@ -3513,14 +3513,14 @@ void kernel_main() {
     }
     if constexpr (enable_ethernet_handshake) {
         if constexpr (is_handshake_sender) {
-            erisc::datamover::handshake::sender_side_handshake<ENABLE_RISC_CPU_DATA_CACHE>(
+            erisc::datamover::handshake::fabric_sender_side_handshake<ENABLE_RISC_CPU_DATA_CACHE>(
                 handshake_addr,
                 routing_table_l1->my_mesh_id,
                 routing_table_l1->my_device_id,
                 termination_signal_ptr,
                 DEFAULT_HANDSHAKE_CONTEXT_SWITCH_TIMEOUT);
         } else {
-            erisc::datamover::handshake::receiver_side_handshake<ENABLE_RISC_CPU_DATA_CACHE>(
+            erisc::datamover::handshake::fabric_receiver_side_handshake<ENABLE_RISC_CPU_DATA_CACHE>(
                 handshake_addr,
                 routing_table_l1->my_mesh_id,
                 routing_table_l1->my_device_id,

--- a/tt_metal/fabric/impl/kernels/edm_fabric/fabric_erisc_router.cpp
+++ b/tt_metal/fabric/impl/kernels/edm_fabric/fabric_erisc_router.cpp
@@ -2679,6 +2679,7 @@ void
         if (!sender_ch_live_check_skip[sender_channel_idx]) {
             return;
         }
+        uint32_t count = 0;
         while (!connect_is_requested(*interface.connection_live_semaphore)
 #ifndef ARCH_WORMHOLE
                && !got_immediate_termination_signal<ENABLE_RISC_CPU_DATA_CACHE>(termination_signal_ptr)
@@ -2686,7 +2687,13 @@ void
         ) {
             router_invalidate_l1_cache<ENABLE_RISC_CPU_DATA_CACHE>();
 #ifndef ARCH_WORMHOLE
-            run_routing();
+            if constexpr (MY_ERISC_ID == 0) {
+                static_assert(PHYSICAL_AERISC_ID == 0, "run_routing() is only safe from ERISC0");
+                if (count++ == CONTEXT_SWITCH_TIMEOUT_SHORT) {
+                    count = 0;
+                    run_routing();
+                }
+            }
 #endif
         }
         establish_edm_connection(interface, local_sender_channel_free_slots_stream_ids[sender_channel_idx]);

--- a/tt_metal/fabric/impl/kernels/edm_fabric/fabric_router_mux_extension.cpp
+++ b/tt_metal/fabric/impl/kernels/edm_fabric/fabric_router_mux_extension.cpp
@@ -116,6 +116,7 @@ void wait_for_static_connection_to_ready(
     tt::tt_fabric::FabricMuxStaticSizedChannelWorkerInterface<NUM_BUFFERS>& worker_interface,
     volatile tt::tt_fabric::TerminationSignal* termination_signal_ptr) {
     while (!connect_is_requested(*worker_interface.connection_live_semaphore) &&
+        // set dcache enabled true (conservatively) - since we're in init code, the perf penalty is inconsequential
            !got_immediate_termination_signal<ENABLE_RISC_CPU_DATA_CACHE>(termination_signal_ptr)) {
         invalidate_l1_cache();
     }

--- a/tt_metal/fabric/impl/kernels/edm_fabric/fabric_router_mux_extension.cpp
+++ b/tt_metal/fabric/impl/kernels/edm_fabric/fabric_router_mux_extension.cpp
@@ -115,9 +115,12 @@ template <uint8_t NUM_BUFFERS>
 void wait_for_static_connection_to_ready(
     tt::tt_fabric::FabricMuxStaticSizedChannelWorkerInterface<NUM_BUFFERS>& worker_interface,
     volatile tt::tt_fabric::TerminationSignal* termination_signal_ptr) {
-    while (!connect_is_requested(*worker_interface.connection_live_semaphore) &&
-        // set dcache enabled true (conservatively) - since we're in init code, the perf penalty is inconsequential
-           !got_immediate_termination_signal<ENABLE_RISC_CPU_DATA_CACHE>(termination_signal_ptr)) {
+    while (!connect_is_requested(*worker_interface.connection_live_semaphore)
+    // set dcache enabled true (conservatively) - since we're in init code, the perf penalty is inconsequential
+#ifndef ARCH_WORMHOLE
+           && !got_immediate_termination_signal<ENABLE_RISC_CPU_DATA_CACHE>(termination_signal_ptr)
+#endif
+    ) {
         invalidate_l1_cache();
     }
 

--- a/tt_metal/fabric/impl/kernels/edm_fabric/fabric_router_mux_extension.cpp
+++ b/tt_metal/fabric/impl/kernels/edm_fabric/fabric_router_mux_extension.cpp
@@ -113,8 +113,10 @@ using FabricMuxToEdmSender = WorkerToFabricEdmSenderImpl<false, NUM_EDM_BUFFERS>
 
 template <uint8_t NUM_BUFFERS>
 void wait_for_static_connection_to_ready(
-    tt::tt_fabric::FabricMuxStaticSizedChannelWorkerInterface<NUM_BUFFERS>& worker_interface) {
-    while (!connect_is_requested(*worker_interface.connection_live_semaphore)) {
+    tt::tt_fabric::FabricMuxStaticSizedChannelWorkerInterface<NUM_BUFFERS>& worker_interface,
+    volatile tt::tt_fabric::TerminationSignal* termination_signal_ptr) {
+    while (!connect_is_requested(*worker_interface.connection_live_semaphore) &&
+           !got_immediate_termination_signal<ENABLE_RISC_CPU_DATA_CACHE>(termination_signal_ptr)) {
         invalidate_l1_cache();
     }
 
@@ -337,13 +339,13 @@ void kernel_main() {
     // Wait for persistent channels to be ready
     for (uint32_t i = 0; i < NUM_WORKER_CHANNELS; i++) {
         if (worker_is_persistent[i] == 1) {
-            wait_for_static_connection_to_ready<NUM_BUFFERS_WORKER>(worker_channel_interfaces[i]);
+            wait_for_static_connection_to_ready<NUM_BUFFERS_WORKER>(worker_channel_interfaces[i], termination_signal_ptr);
         }
     }
 
     for (uint32_t i = 0; i < NUM_ROUTER_CHANNELS; i++) {
         if (router_is_persistent[i] == 1) {
-            wait_for_static_connection_to_ready<NUM_BUFFERS_ROUTER>(router_channel_interfaces[i]);
+            wait_for_static_connection_to_ready<NUM_BUFFERS_ROUTER>(router_channel_interfaces[i], termination_signal_ptr);
         }
     }
 

--- a/tt_metal/fabric/impl/kernels/edm_fabric/fabric_router_relay_extension.cpp
+++ b/tt_metal/fabric/impl/kernels/edm_fabric/fabric_router_relay_extension.cpp
@@ -140,16 +140,23 @@ constexpr bool ENABLE_RISC_CPU_DATA_CACHE = true;
 
 template <uint8_t NUM_BUFFERS>
 void wait_for_static_connection_to_ready(
-    tt::tt_fabric::FabricRelayStaticSizedChannelWorkerInterface<NUM_BUFFERS>& worker_interface) {
-    while (!connect_is_requested(*worker_interface.connection_live_semaphore)) {
+    tt::tt_fabric::FabricRelayStaticSizedChannelWorkerInterface<NUM_BUFFERS>& worker_interface,
+    volatile tt::tt_fabric::TerminationSignal* termination_signal_ptr) {
+    while (!connect_is_requested(*worker_interface.connection_live_semaphore) &&
+           !got_immediate_termination_signal<ENABLE_RISC_CPU_DATA_CACHE>(termination_signal_ptr)) {
         invalidate_l1_cache();
+        run_routing();
     }
 
     worker_interface.template cache_producer_noc_addr<ENABLE_RISC_CPU_DATA_CACHE>();
 }
 
 FORCE_INLINE void wait_for_mux_endpoint_ready(
-    uint8_t mux_noc_x, uint8_t mux_noc_y, size_t mux_status_address, uint32_t mux_status_readback_address) {
+    uint8_t mux_noc_x,
+    uint8_t mux_noc_y,
+    size_t mux_status_address,
+    uint32_t mux_status_readback_address,
+    volatile tt::tt_fabric::TerminationSignal* termination_signal_ptr) {
     uint64_t noc_addr = get_noc_addr(mux_noc_x, mux_noc_y, mux_status_address);
     auto ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(mux_status_readback_address);
 
@@ -158,7 +165,8 @@ FORCE_INLINE void wait_for_mux_endpoint_ready(
         noc_async_read_one_packet(noc_addr, mux_status_readback_address, 4);
         noc_async_read_barrier();
         invalidate_l1_cache();
-    } while (ptr[0] != tt::tt_fabric::FabricMuxStatus::READY_FOR_TRAFFIC);
+    } while (ptr[0] != tt::tt_fabric::FabricMuxStatus::READY_FOR_TRAFFIC &&
+             !got_immediate_termination_signal<ENABLE_RISC_CPU_DATA_CACHE>(termination_signal_ptr));
 }
 
 template <uint8_t NUM_BUFFERS>
@@ -534,7 +542,8 @@ void kernel_main() {
 
     // before connecting to mux, wait for mux status to turn into READY_FOR_TRAFFIC
     volatile auto mux_status_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(mux_status_address);
-    while (*mux_status_ptr != tt::tt_fabric::FabricMuxStatus::READY_FOR_TRAFFIC) {
+    while (*mux_status_ptr != tt::tt_fabric::FabricMuxStatus::READY_FOR_TRAFFIC &&
+           !got_immediate_termination_signal<ENABLE_RISC_CPU_DATA_CACHE>(termination_signal_ptr)) {
         invalidate_l1_cache();
     }
 
@@ -545,7 +554,8 @@ void kernel_main() {
                 mux_connections[i].edm_noc_x,
                 mux_connections[i].edm_noc_y,
                 mux_status_address,
-                downstream_mux_status_readback_address);
+                downstream_mux_status_readback_address,
+                termination_signal_ptr);
         }
     }
 
@@ -560,7 +570,7 @@ void kernel_main() {
     auto noc_addr = get_noc_addr(router_noc_x, router_noc_y, fabric_router_sync_address);
     noc_semaphore_inc(noc_addr, 1);
 
-    wait_for_static_connection_to_ready<NUM_BUFFERS>(worker_interface);
+    wait_for_static_connection_to_ready<NUM_BUFFERS>(worker_interface, termination_signal_ptr);
 
     status_ptr[0] = tt::tt_fabric::FabricRelayStatus::READY_FOR_TRAFFIC;
 

--- a/tt_metal/fabric/impl/kernels/edm_fabric/fabric_router_relay_extension.cpp
+++ b/tt_metal/fabric/impl/kernels/edm_fabric/fabric_router_relay_extension.cpp
@@ -139,7 +139,7 @@ constexpr uint32_t DOWNSTREAM_WS_MUX_IDX = 2;
 constexpr bool ENABLE_RISC_CPU_DATA_CACHE = true;
 
 template <uint8_t NUM_BUFFERS>
-void wait_for_static_connection_to_ready(
+__attribute__((optimize("Os"))) void wait_for_static_connection_to_ready(
     tt::tt_fabric::FabricRelayStaticSizedChannelWorkerInterface<NUM_BUFFERS>& worker_interface,
     volatile tt::tt_fabric::TerminationSignal* termination_signal_ptr) {
     while (!connect_is_requested(*worker_interface.connection_live_semaphore) &&
@@ -151,7 +151,7 @@ void wait_for_static_connection_to_ready(
     worker_interface.template cache_producer_noc_addr<ENABLE_RISC_CPU_DATA_CACHE>();
 }
 
-FORCE_INLINE void wait_for_mux_endpoint_ready(
+__attribute__((optimize("Os"))) FORCE_INLINE void wait_for_mux_endpoint_ready(
     uint8_t mux_noc_x,
     uint8_t mux_noc_y,
     size_t mux_status_address,
@@ -170,7 +170,7 @@ FORCE_INLINE void wait_for_mux_endpoint_ready(
 }
 
 template <uint8_t NUM_BUFFERS>
-void setup_channel(
+__attribute__((optimize("Os"))) void setup_channel(
     tt::tt_fabric::FabricRelayChannelBuffer<NUM_BUFFERS>* channel_ptr,
     tt::tt_fabric::FabricRelayStaticSizedChannelWorkerInterface<NUM_BUFFERS>* worker_interface_ptr,
     bool& channel_connection_established,

--- a/tt_metal/fabric/impl/kernels/edm_fabric/fabric_router_relay_extension.cpp
+++ b/tt_metal/fabric/impl/kernels/edm_fabric/fabric_router_relay_extension.cpp
@@ -142,8 +142,11 @@ template <uint8_t NUM_BUFFERS>
 __attribute__((optimize("Os"))) void wait_for_static_connection_to_ready(
     tt::tt_fabric::FabricRelayStaticSizedChannelWorkerInterface<NUM_BUFFERS>& worker_interface,
     volatile tt::tt_fabric::TerminationSignal* termination_signal_ptr) {
-    while (!connect_is_requested(*worker_interface.connection_live_semaphore) &&
-           !got_immediate_termination_signal<ENABLE_RISC_CPU_DATA_CACHE>(termination_signal_ptr)) {
+    while (!connect_is_requested(*worker_interface.connection_live_semaphore)
+#ifndef ARCH_WORMHOLE
+           && !got_immediate_termination_signal<ENABLE_RISC_CPU_DATA_CACHE>(termination_signal_ptr)
+#endif
+    ) {
         invalidate_l1_cache();
         run_routing();
     }
@@ -165,8 +168,11 @@ __attribute__((optimize("Os"))) FORCE_INLINE void wait_for_mux_endpoint_ready(
         noc_async_read_one_packet(noc_addr, mux_status_readback_address, 4);
         noc_async_read_barrier();
         invalidate_l1_cache();
-    } while (ptr[0] != tt::tt_fabric::FabricMuxStatus::READY_FOR_TRAFFIC &&
-             !got_immediate_termination_signal<ENABLE_RISC_CPU_DATA_CACHE>(termination_signal_ptr));
+    } while (ptr[0] != tt::tt_fabric::FabricMuxStatus::READY_FOR_TRAFFIC
+#ifndef ARCH_WORMHOLE
+             && !got_immediate_termination_signal<ENABLE_RISC_CPU_DATA_CACHE>(termination_signal_ptr)
+#endif
+    );
 }
 
 template <uint8_t NUM_BUFFERS>
@@ -542,8 +548,11 @@ void kernel_main() {
 
     // before connecting to mux, wait for mux status to turn into READY_FOR_TRAFFIC
     volatile auto mux_status_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(mux_status_address);
-    while (*mux_status_ptr != tt::tt_fabric::FabricMuxStatus::READY_FOR_TRAFFIC &&
-           !got_immediate_termination_signal<ENABLE_RISC_CPU_DATA_CACHE>(termination_signal_ptr)) {
+    while (*mux_status_ptr != tt::tt_fabric::FabricMuxStatus::READY_FOR_TRAFFIC
+#ifndef ARCH_WORMHOLE
+           && !got_immediate_termination_signal<ENABLE_RISC_CPU_DATA_CACHE>(termination_signal_ptr)
+#endif
+    ) {
         invalidate_l1_cache();
     }
 

--- a/tt_metal/fabric/impl/kernels/edm_fabric/fabric_router_relay_extension.cpp
+++ b/tt_metal/fabric/impl/kernels/edm_fabric/fabric_router_relay_extension.cpp
@@ -176,7 +176,7 @@ __attribute__((optimize("Os"))) FORCE_INLINE void wait_for_mux_endpoint_ready(
 }
 
 template <uint8_t NUM_BUFFERS>
-__attribute__((optimize("Os"))) void setup_channel(
+void setup_channel(
     tt::tt_fabric::FabricRelayChannelBuffer<NUM_BUFFERS>* channel_ptr,
     tt::tt_fabric::FabricRelayStaticSizedChannelWorkerInterface<NUM_BUFFERS>* worker_interface_ptr,
     bool& channel_connection_established,

--- a/tt_metal/fabric/impl/kernels/edm_fabric/fabric_router_relay_extension.cpp
+++ b/tt_metal/fabric/impl/kernels/edm_fabric/fabric_router_relay_extension.cpp
@@ -139,7 +139,7 @@ constexpr uint32_t DOWNSTREAM_WS_MUX_IDX = 2;
 constexpr bool ENABLE_RISC_CPU_DATA_CACHE = true;
 
 template <uint8_t NUM_BUFFERS>
-__attribute__((optimize("Os"))) void wait_for_static_connection_to_ready(
+void wait_for_static_connection_to_ready(
     tt::tt_fabric::FabricRelayStaticSizedChannelWorkerInterface<NUM_BUFFERS>& worker_interface,
     volatile tt::tt_fabric::TerminationSignal* termination_signal_ptr) {
     while (!connect_is_requested(*worker_interface.connection_live_semaphore)
@@ -148,13 +148,12 @@ __attribute__((optimize("Os"))) void wait_for_static_connection_to_ready(
 #endif
     ) {
         invalidate_l1_cache();
-        run_routing();
     }
 
     worker_interface.template cache_producer_noc_addr<ENABLE_RISC_CPU_DATA_CACHE>();
 }
 
-__attribute__((optimize("Os"))) FORCE_INLINE void wait_for_mux_endpoint_ready(
+FORCE_INLINE void wait_for_mux_endpoint_ready(
     uint8_t mux_noc_x,
     uint8_t mux_noc_y,
     size_t mux_status_address,

--- a/tt_metal/fabric/impl/kernels/edm_fabric/fabric_router_udm_mux_extension.cpp
+++ b/tt_metal/fabric/impl/kernels/edm_fabric/fabric_router_udm_mux_extension.cpp
@@ -178,7 +178,8 @@ void wait_for_static_connection_to_ready(
     tt::tt_fabric::FabricMuxStaticSizedChannelWorkerInterface<NUM_BUFFERS>& worker_interface,
     volatile tt::tt_fabric::TerminationSignal* termination_signal_ptr) {
     while (!connect_is_requested(*worker_interface.connection_live_semaphore) &&
-           !got_immediate_termination_signal<ENABLE_RISC_CPU_DATA_CACHE>(termination_signal_ptr)) {
+            // set dcache enabled true (conservatively) - since we're in init code, the perf penalty is inconsequential
+           !got_immediate_termination_signal<true>(termination_signal_ptr)) {
         invalidate_l1_cache();
     }
 

--- a/tt_metal/fabric/impl/kernels/edm_fabric/fabric_router_udm_mux_extension.cpp
+++ b/tt_metal/fabric/impl/kernels/edm_fabric/fabric_router_udm_mux_extension.cpp
@@ -175,8 +175,10 @@ static_assert(noc_index == 0, "Mux kernel requires noc_index to be 0 so relay ke
 
 template <uint8_t NUM_BUFFERS>
 void wait_for_static_connection_to_ready(
-    tt::tt_fabric::FabricMuxStaticSizedChannelWorkerInterface<NUM_BUFFERS>& worker_interface) {
-    while (!connect_is_requested(*worker_interface.connection_live_semaphore)) {
+    tt::tt_fabric::FabricMuxStaticSizedChannelWorkerInterface<NUM_BUFFERS>& worker_interface,
+    volatile tt::tt_fabric::TerminationSignal* termination_signal_ptr) {
+    while (!connect_is_requested(*worker_interface.connection_live_semaphore) &&
+           !got_immediate_termination_signal<ENABLE_RISC_CPU_DATA_CACHE>(termination_signal_ptr)) {
         invalidate_l1_cache();
     }
 
@@ -509,19 +511,19 @@ void kernel_main() {
     // Wait for persistent channels to be ready
     for (uint32_t i = 0; i < NUM_WORKER_CHANNELS; i++) {
         if (worker_is_persistent[i] == 1) {
-            wait_for_static_connection_to_ready<NUM_BUFFERS_WORKER>(worker_channel_interfaces[i]);
+            wait_for_static_connection_to_ready<NUM_BUFFERS_WORKER>(worker_channel_interfaces[i], termination_signal_ptr);
         }
     }
 
     for (uint32_t i = 0; i < NUM_RELAY_TO_MUX_CHANNELS; i++) {
         if (relay_to_mux_is_persistent[i] == 1) {
-            wait_for_static_connection_to_ready<NUM_BUFFERS_RELAY_TO_MUX>(relay_to_mux_channel_interfaces[i]);
+            wait_for_static_connection_to_ready<NUM_BUFFERS_RELAY_TO_MUX>(relay_to_mux_channel_interfaces[i], termination_signal_ptr);
         }
     }
 
     for (uint32_t i = 0; i < NUM_MUX_TO_MUX_CHANNELS; i++) {
         if (mux_to_mux_is_persistent[i] == 1) {
-            wait_for_static_connection_to_ready<NUM_BUFFERS_MUX_TO_MUX>(mux_to_mux_channel_interfaces[i]);
+            wait_for_static_connection_to_ready<NUM_BUFFERS_MUX_TO_MUX>(mux_to_mux_channel_interfaces[i], termination_signal_ptr);
         }
     }
 

--- a/tt_metal/fabric/impl/kernels/edm_fabric/fabric_router_udm_mux_extension.cpp
+++ b/tt_metal/fabric/impl/kernels/edm_fabric/fabric_router_udm_mux_extension.cpp
@@ -177,9 +177,12 @@ template <uint8_t NUM_BUFFERS>
 void wait_for_static_connection_to_ready(
     tt::tt_fabric::FabricMuxStaticSizedChannelWorkerInterface<NUM_BUFFERS>& worker_interface,
     volatile tt::tt_fabric::TerminationSignal* termination_signal_ptr) {
-    while (!connect_is_requested(*worker_interface.connection_live_semaphore) &&
-            // set dcache enabled true (conservatively) - since we're in init code, the perf penalty is inconsequential
-           !got_immediate_termination_signal<true>(termination_signal_ptr)) {
+    while (!connect_is_requested(*worker_interface.connection_live_semaphore)
+    // set dcache enabled true (conservatively) - since we're in init code, the perf penalty is inconsequential
+#ifndef ARCH_WORMHOLE
+           && !got_immediate_termination_signal<true>(termination_signal_ptr)
+#endif
+    ) {
         invalidate_l1_cache();
     }
 

--- a/tt_metal/fabric/sources.cmake
+++ b/tt_metal/fabric/sources.cmake
@@ -10,6 +10,7 @@ set(FABRIC_JIT_API_HEADERS
     hw/inc/edm_fabric/fabric_connection_manager.hpp
     hw/inc/edm_fabric/fabric_edm_packet_header_validate.hpp
     hw/inc/edm_fabric/fabric_edm_packet_transmission.hpp
+    hw/inc/edm_fabric/fabric_router_eth_handshake.hpp
     hw/inc/edm_fabric/fabric_txq_setup.h
     hw/inc/edm_fabric/fabric_erisc_datamover_channels.hpp
     hw/inc/fabric_direction_table_interface.h


### PR DESCRIPTION
these infinite loops can hit if a series of unfortunate events trigger. This gives us an out to recover without board reset.

Additionally, resolved a subtle bug with how we init the termination signal on router; it's now initialized and written 1-way by host. The router treats it as read-only.

### Ticket
Closes #35609

### Checklist

- [x] [![sanity-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=snijjar/add-fabric-init-escape-paths-issue-35609)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:snijjar/add-fabric-init-escape-paths-issue-35609)
- [x] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=snijjar/add-fabric-init-escape-paths-issue-35609)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:snijjar/add-fabric-init-escape-paths-issue-35609)
- [x] [![tm-fabric-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tm-fabric-tests.yaml/badge.svg?branch=snijjar/add-fabric-init-escape-paths-issue-35609)](https://github.com/tenstorrent/tt-metal/actions/workflows/tm-fabric-tests.yaml?query=branch:snijjar/add-fabric-init-escape-paths-issue-35609) - same failures as [on main](https://github.com/tenstorrent/tt-metal/actions/runs/23598758766)
