### PR TITLE
Ridvan/group placement

### DIFF
--- a/tests/tt_metal/tt_fabric/fabric_router/test_physical_grouping_descriptor.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_router/test_physical_grouping_descriptor.cpp
@@ -494,10 +494,12 @@ TEST(PhysicalGroupingDescriptorTests, HasGroupingReturnsTrueForExistingGrouping)
     )proto");
     ;
 
-    PhysicalGroupingDescriptor desc(text_proto);
-    EXPECT_TRUE(desc.has_grouping("meshes"));
-    EXPECT_TRUE(desc.has_grouping("pods"));
-    EXPECT_FALSE(desc.has_grouping("nonexistent"));
+    EXPECT_NO_THROW({
+        PhysicalGroupingDescriptor desc(text_proto);
+        EXPECT_TRUE(desc.has_grouping("meshes"));
+        EXPECT_TRUE(desc.has_grouping("pods"));
+        EXPECT_FALSE(desc.has_grouping("nonexistent"));
+    });
 }
 
 TEST(PhysicalGroupingDescriptorTests, GetGroupingsByNameReturnsAllDefinitions) {

--- a/tests/tt_metal/tt_fabric/fabric_router/test_physical_grouping_descriptor.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_router/test_physical_grouping_descriptor.cpp
@@ -418,25 +418,213 @@ TEST(PhysicalGroupingDescriptorTests, ValidationFailsWhenCircularDependency) {
 TEST(PhysicalGroupingDescriptorTests, DuplicateNamesAreUniquified) {
     const std::string text_proto = wrap_with_required_groupings(R"proto(
         groupings {
-          name: "duplicate_name"
+          name: "tray_1_a"
+          preset_type: TRAY_1
+          instances:
+          [ { id: 0 asic_location: ASIC_LOCATION_1 }]
+        }
+        groupings {
+          name: "tray_1_b"
+          preset_type: TRAY_1
+          instances:
+          [ { id: 0 asic_location: ASIC_LOCATION_1 }]
+        }
+        groupings {
+          name: "tray_2"
+          preset_type: TRAY_2
+          instances:
+          [ { id: 0 asic_location: ASIC_LOCATION_1 }]
+        }
+        groupings {
+          name: "tray_3"
+          preset_type: TRAY_3
+          instances:
+          [ { id: 0 asic_location: ASIC_LOCATION_1 }]
+        }
+        groupings {
+          name: "tray_4"
+          preset_type: TRAY_4
+          instances:
+          [ { id: 0 asic_location: ASIC_LOCATION_1 }]
+        }
+        groupings {
+          name: "hosts_1"
+          custom_type: "hosts"
+          instances:
+          [ {
+            id: 0
+            grouping_ref { preset_type: TRAY_1 }
+          }]
+        }
+        groupings {
+          name: "meshes_1"
+          custom_type: "meshes"
+          instances:
+          [ {
+            id: 0
+            grouping_ref { custom_type: "hosts" }
+          }]
+        }
+    )proto";
+
+    EXPECT_THAT(
+        ([&]() { PhysicalGroupingDescriptor desc(text_proto); }),
+        ::testing::ThrowsMessage<std::runtime_error>(
+            ::testing::HasSubstr("Exactly one grouping with preset_type 'TRAY_1' is required but 2 are defined")));
+}
+
+TEST(PhysicalGroupingDescriptorTests, ValidationFailsWhenDuplicateHosts) {
+    const std::string text_proto = R"proto(
+        groupings {
+          name: "tray_1"
+          preset_type: TRAY_1
+          instances:
+          [ { id: 0 asic_location: ASIC_LOCATION_1 }]
+        }
+        groupings {
+          name: "tray_2"
+          preset_type: TRAY_2
+          instances:
+          [ { id: 0 asic_location: ASIC_LOCATION_1 }]
+        }
+        groupings {
+          name: "tray_3"
+          preset_type: TRAY_3
+          instances:
+          [ { id: 0 asic_location: ASIC_LOCATION_1 }]
+        }
+        groupings {
+          name: "tray_4"
+          preset_type: TRAY_4
+          instances:
+          [ { id: 0 asic_location: ASIC_LOCATION_1 }]
+        }
+        groupings {
+          name: "hosts_1"
+          custom_type: "hosts"
+          instances:
+          [ {
+            id: 0
+            grouping_ref { preset_type: TRAY_1 }
+          }]
+        }
+        groupings {
+          name: "hosts_2"
+          custom_type: "hosts"
+          instances:
+          [ {
+            id: 0
+            grouping_ref { preset_type: TRAY_1 }
+          }]
+        }
+        groupings {
+          name: "meshes_1"
+          custom_type: "meshes"
+          instances:
+          [ {
+            id: 0
+            grouping_ref { custom_type: "hosts" }
+          }]
+        }
+    )proto";
+
+    EXPECT_THAT(
+        ([&]() { PhysicalGroupingDescriptor desc(text_proto); }),
+        ::testing::ThrowsMessage<std::runtime_error>(
+            ::testing::HasSubstr("Exactly one grouping with custom_type 'hosts' is required but 2 are defined")));
+}
+
+TEST(PhysicalGroupingDescriptorTests, ValidationFailsWhenNoLeafGroupingUsesASICLocations) {
+    // This test is no longer valid because TRAY_1-4 are required and must use ASIC locations,
+    // making them leaf groupings. The validation "at least one leaf grouping must use ASIC locations"
+    // is always satisfied when TRAY_1-4 are present. This test is skipped.
+    GTEST_SKIP() << "Test invalidated: TRAY_1-4 are required and use ASIC locations, so leaf grouping requirement is "
+                    "always satisfied";
+}
+
+TEST(PhysicalGroupingDescriptorTests, ValidationFailsWhenNonLeafGroupingUsesASICLocations) {
+    // Test that a non-leaf grouping (one with grouping references) cannot also use ASIC locations
+    const std::string text_proto = get_required_groupings() + R"proto(
+        groupings {
+          name: "meshes_required"
           custom_type: "meshes"
           instances:
           [ { id: 0 asic_location: ASIC_LOCATION_1 }]
         }
         groupings {
-          name: "duplicate_name"
+          name: "pods_bad"
           custom_type: "pods"
           instances:
           [ {
             id: 0
             grouping_ref { custom_type: "meshes" }
           }
-            , {
-              id: 1
-              grouping_ref { custom_type: "meshes" }
-            }]
-          all_to_all {}
+            , { id: 1 asic_location: ASIC_LOCATION_2 }]
         }
+    )proto");
+    ;
+
+    EXPECT_THAT(
+        ([&]() { PhysicalGroupingDescriptor desc(text_proto); }),
+        ::testing::ThrowsMessage<std::runtime_error>(
+            ::testing::HasSubstr("uses ASIC locations but also has grouping references")));
+}
+
+TEST(PhysicalGroupingDescriptorTests, ValidationFailsWhenCircularDependency) {
+    // Create a cycle: pods -> clusters -> pods
+    const std::string text_proto = get_required_groupings() + R"proto(
+        groupings {
+          name: "meshes_required"
+          custom_type: "meshes"
+          instances:
+          [ { id: 0 asic_location: ASIC_LOCATION_1 }]
+        }
+        groupings {
+          name: "pods_cycle"
+          custom_type: "pods"
+          instances:
+          [ {
+            id: 0
+            grouping_ref { custom_type: "clusters" }
+          }]
+        }
+        groupings {
+          name: "clusters_cycle"
+          custom_type: "clusters"
+          instances:
+          [ {
+            id: 0
+            grouping_ref { custom_type: "pods" }
+          }]
+        }
+    )proto";
+
+    EXPECT_THAT(
+        ([&]() { PhysicalGroupingDescriptor desc(text_proto); }),
+        ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr("Circular dependencies detected")));
+}
+
+TEST(PhysicalGroupingDescriptorTests, DuplicateNamesAreUniquified) {
+    const std::string text_proto = wrap_with_required_groupings(R"proto(groupings {
+                                                                          name: "duplicate_name"
+                                                                          custom_type: "meshes"
+                                                                          instances:
+                                                                          [ { id: 0 asic_location: ASIC_LOCATION_1 }]
+                                                                        }
+                                                                        groupings {
+                                                                          name: "duplicate_name"
+                                                                          custom_type: "pods"
+                                                                          instances:
+                                                                          [ {
+                                                                            id: 0
+                                                                            grouping_ref { custom_type: "meshes" }
+                                                                          }
+                                                                            , {
+                                                                              id: 1
+                                                                              grouping_ref { custom_type: "meshes" }
+                                                                            }]
+                                                                          all_to_all {}
+                                                                        }
     )proto");
     ;
 

--- a/tests/tt_metal/tt_fabric/physical_groupings/triple_16x8_quad_bh_galaxy_physical_groupings.textproto
+++ b/tests/tt_metal/tt_fabric/physical_groupings/triple_16x8_quad_bh_galaxy_physical_groupings.textproto
@@ -133,6 +133,15 @@ groupings {
   }
 }
 
+# Custom hosts grouping (required)
+groupings {
+  name: "hosts_custom"
+  custom_type: "hosts"
+  instances: [
+    { id: 0 grouping_ref { preset_type: TRAY_1 } }
+  ]
+}
+
 # MESH preset groupings for different mesh sizes to cover all MGD cases
 
 # MESH: 1 tray (8 ASICs)
@@ -174,6 +183,19 @@ groupings {
   instances: [
     { id: 0 grouping_ref { preset_type: TRAY_4 } },
     { id: 1 grouping_ref { preset_type: TRAY_3 } }
+  ]
+  row_major_mesh {
+    dims: [2, 1]
+  }
+}
+
+# MESH: 2 trays (16 ASICs)
+groupings {
+  name: "4x4_Mesh"
+  preset_type: MESH
+  instances: [
+    { id: 0 grouping_ref { preset_type: TRAY_3 } },
+    { id: 1 grouping_ref { preset_type: TRAY_4 } }
   ]
   row_major_mesh {
     dims: [2, 1]

--- a/tt_metal/api/tt-metalium/experimental/fabric/physical_grouping_descriptor.hpp
+++ b/tt_metal/api/tt-metalium/experimental/fabric/physical_grouping_descriptor.hpp
@@ -113,6 +113,11 @@ public:
         const tt::tt_metal::PhysicalSystemDescriptor& physical_system_descriptor,
         std::vector<std::string>* errors_out = nullptr);
 
+    // Same as above but populates errors_out when validation fails (for testing/inspection)
+    bool validate_preformed_groups_from_physical_system_descriptor(
+        const tt::tt_metal::PhysicalSystemDescriptor& physical_system_descriptor,
+        std::vector<std::string>* errors_out) const;
+
     // Node metadata for flattened mesh nodes
     // Generic enough to be used throughout the flattened mesh representation
     struct FlattenedMeshNodeInfo {

--- a/tt_metal/api/tt-metalium/experimental/fabric/physical_grouping_descriptor.hpp
+++ b/tt_metal/api/tt-metalium/experimental/fabric/physical_grouping_descriptor.hpp
@@ -132,6 +132,9 @@ public:
     // Returns graph with FlattenedMeshNodeInfo as node type
     AdjacencyGraph<FlattenedMeshNodeInfo> build_flattened_adjacency_mesh(const GroupingInfo& grouping) const;
 
+    // Build flattened adjacency graph forming one uniform mesh
+    AdjacencyGraph<uint32_t> build_flattened_adjacency_mesh(const GroupingInfo& grouping) const;
+
 private:
     // Data members
     std::shared_ptr<const proto::PhysicalGroupings> proto_;

--- a/tt_metal/fabric/physical_grouping_descriptor.cpp
+++ b/tt_metal/fabric/physical_grouping_descriptor.cpp
@@ -2349,6 +2349,11 @@ bool PhysicalGroupingDescriptor::validate_grouping_with_psd(
     return errors.empty();
 }
 
+bool PhysicalGroupingDescriptor::validate_preformed_groups_from_physical_system_descriptor(
+    const tt::tt_metal::PhysicalSystemDescriptor& physical_system_descriptor) const {
+    return validate_preformed_groups_from_physical_system_descriptor(physical_system_descriptor, nullptr);
+}
+
 // Stream operator for FlattenedMeshNodeInfo (required by topology solver)
 std::ostream& operator<<(std::ostream& os, const PhysicalGroupingDescriptor::FlattenedMeshNodeInfo& node_info) {
     os << "FlattenedMeshNodeInfo{unique_id=" << node_info.unique_id;

--- a/tt_metal/fabric/topology_solver_internal.tpp
+++ b/tt_metal/fabric/topology_solver_internal.tpp
@@ -1022,6 +1022,7 @@ bool DFSSearchEngine<TargetNode, GlobalNode>::search(
     state_ = SearchState();
     state_.mapping.resize(graph_data.n_target, -1);
     state_.used.resize(graph_data.n_global, false);
+    quiet_mode_ = quiet_mode;
 
     // Log node degrees and degree histograms at the start of mapping
     // Build degree histograms for more descriptive logging


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Provide context for the problem.

### What's changed
Describe the approach used to solve the problem.
Summarize the changes made and its impact.

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=ridvan/group-placement)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:ridvan/group-placement)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ridvan/group-placement)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ridvan/group-placement)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ridvan/group-placement)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ridvan/group-placement)
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ridvan/group-placement)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ridvan/group-placement)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ridvan/group-placement)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ridvan/group-placement)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ridvan/group-placement)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ridvan/group-placement)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
