### PR TITLE
Switch broadcast noc usage

### DIFF
--- a/models/demos/deepseek_v3_b1/fused_ops/broadcast_rms/kernels/broadcast_rms_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/fused_ops/broadcast_rms/kernels/broadcast_rms_kernel.cpp
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 // Fused Broadcast + RMSNorm unified kernel
-// - NCRISC: Broadcast reader + RMSNorm reader
-// - BRISC: Broadcast writer
+// - NCRISC: Broadcast writer + RMSNorm setup
+// - BRISC: Broadcast reader
 // - TRISC: RMSNorm compute
 
 #include "../../../unified_kernels/kernel_op_api.hpp"
@@ -13,7 +13,7 @@
 #endif
 #include "../../../unified_kernels/rmsnorm.hpp"
 
-#if defined(COMPILE_FOR_NRISC)
+#if defined(COMPILE_FOR_BRISC)
 #include "ttnn/cpp/ttnn/kernel/dataflow/generate_reduce_scaler.hpp"
 #endif
 
@@ -21,31 +21,9 @@ void kernel_main() {
     constexpr bool skip_ccl = get_named_compile_time_arg_val("skip_ccl") == 1;
 
 // -----------------------
-// NCRISC: Broadcast reader + RMSNorm reader
+// NCRISC: Broadcast writer
 // -----------------------
 #if defined(COMPILE_FOR_NCRISC)
-
-#if !defined(SKIP_CCL)
-    using BcastCTArgs = deepseek_b1_ops::Broadcast::ReaderCTArgs<
-        get_named_compile_time_arg_val("cb0_id"),
-        get_named_compile_time_arg_val("num_pages_to_read"),
-        get_named_compile_time_arg_val("is_sender")>;
-
-    // Only read broadcast runtime args if CCL is enabled
-    deepseek_b1_ops::Broadcast::ReaderArgs bcast_args{};
-
-    bcast_args = deepseek_b1_ops::Broadcast::ReaderArgs{};
-#endif
-
-    using RMSNormCTArgs = deepseek_b1_ops::RMSNorm::ReaderCTArgs;
-
-    // RMSNorm reader runtime args
-    deepseek_b1_ops::RMSNorm::ReaderArgs rms_args{};
-
-// -----------------------
-// BRISC: Broadcast writer
-// -----------------------
-#elif defined(COMPILE_FOR_BRISC)
 #if !defined(SKIP_CCL)
     using BcastCTArgs = deepseek_b1_ops::Broadcast::WriterCTArgs<
         get_named_compile_time_arg_val("cb0_id"),
@@ -81,14 +59,38 @@ void kernel_main() {
         get_common_arg_val<uint32_t>(12),  // num_connections
     };
 #endif
+    using RMSNormCTArgs = deepseek_b1_ops::RMSNorm::ReaderCTArgs;
 
-        using RMSNormCTArgs = deepseek_b1_ops::RMSNorm::WriterCTArgs;
-        deepseek_b1_ops::RMSNorm::WriterArgs rms_args{};
+    // RMSNorm reader runtime args
+    deepseek_b1_ops::RMSNorm::ReaderArgs rms_args{};
+
+#endif
+
+// -----------------------
+// BRISC: Broadcast reader
+// -----------------------
+#if defined(COMPILE_FOR_BRISC)
+
+#if !defined(SKIP_CCL)
+    using BcastCTArgs = deepseek_b1_ops::Broadcast::ReaderCTArgs<
+        get_named_compile_time_arg_val("cb0_id"),
+        get_named_compile_time_arg_val("num_pages_to_read"),
+        get_named_compile_time_arg_val("is_sender")>;
+
+    deepseek_b1_ops::Broadcast::ReaderArgs bcast_args{};
+
+    bcast_args = deepseek_b1_ops::Broadcast::ReaderArgs{};
+#endif
+
+    using RMSNormCTArgs = deepseek_b1_ops::RMSNorm::WriterCTArgs;
+    deepseek_b1_ops::RMSNorm::WriterArgs rms_args{};
+
+#endif
 
 // -----------------------
 // TRISC: RMSNorm compute
 // -----------------------
-#elif defined(COMPILE_FOR_TRISC)
+#if defined(COMPILE_FOR_TRISC)
 
     using RMSNormCTArgs = deepseek_b1_ops::RMSNorm::ComputeCTArgs<
         get_named_compile_time_arg_val("rmsnorm_fp32_acc") == 1,
@@ -120,29 +122,17 @@ void kernel_main() {
 #endif
 
 #if defined(COMPILE_FOR_NCRISC)
-    if constexpr (skip_ccl) {
-        // Single-device: setup sharded buffer for input
-        constexpr uint32_t rmsnorm_input_cb = get_named_compile_time_arg_val("rmsnorm_input_cb");
-        constexpr uint32_t rmsnorm_num_tiles = get_named_compile_time_arg_val("rmsnorm_num_tiles");
-        unified_kernels::setup_sharded_buffer(rmsnorm_input_cb, rmsnorm_num_tiles);
-    }
-#endif
-
-#if defined(COMPILE_FOR_BRISC)
-    constexpr uint32_t intermediate_cb = get_named_compile_time_arg_val("intermediate_cb");
     constexpr uint32_t gamma_cb = get_named_compile_time_arg_val("gamma_cb");
-    constexpr uint32_t num_tiles = get_named_compile_time_arg_val("num_tiles");
+    constexpr uint32_t rmsnorm_num_tiles = get_named_compile_time_arg_val("rmsnorm_num_tiles");
 
     if constexpr (skip_ccl) {
-        // Single-device: only setup gamma buffer
-        cb_reserve_back(gamma_cb, num_tiles);
-        cb_push_back(gamma_cb, num_tiles);
+        constexpr uint32_t rmsnorm_input_cb = get_named_compile_time_arg_val("rmsnorm_input_cb");
+        unified_kernels::setup_sharded_buffer(rmsnorm_input_cb, rmsnorm_num_tiles);
+        unified_kernels::setup_sharded_buffer(gamma_cb, rmsnorm_num_tiles);
     } else {
-        // Multi-device: setup intermediate (broadcast output) and gamma buffers
-        cb_reserve_back(intermediate_cb, num_tiles);
-        cb_push_back(intermediate_cb, num_tiles);
-        cb_reserve_back(gamma_cb, num_tiles);
-        cb_push_back(gamma_cb, num_tiles);
+        constexpr uint32_t intermediate_cb = get_named_compile_time_arg_val("intermediate_cb");
+        unified_kernels::setup_sharded_buffer(intermediate_cb, rmsnorm_num_tiles);
+        unified_kernels::setup_sharded_buffer(gamma_cb, rmsnorm_num_tiles);
     }
 #endif
 

--- a/models/demos/deepseek_v3_b1/fused_ops/broadcast_rms/kernels/broadcast_rms_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/fused_ops/broadcast_rms/kernels/broadcast_rms_kernel.cpp
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 // Fused Broadcast + RMSNorm unified kernel
-// - NCRISC: Broadcast writer + RMSNorm setup
+// - NCRISC: Broadcast writer + RMSNorm reader
 // - BRISC: Broadcast reader
 // - TRISC: RMSNorm compute
 

--- a/models/demos/deepseek_v3_b1/fused_ops/broadcast_rms/kernels/broadcast_rms_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/fused_ops/broadcast_rms/kernels/broadcast_rms_kernel.cpp
@@ -28,21 +28,13 @@ void kernel_main() {
 #if !defined(SKIP_CCL)
     using BcastCTArgs = deepseek_b1_ops::Broadcast::ReaderCTArgs<
         get_named_compile_time_arg_val("cb0_id"),
-        get_named_compile_time_arg_val("packet_size_in_pages"),
-        get_named_compile_time_arg_val("tensor0_page_size"),
-        get_named_compile_time_arg_val("is_sender"),
-        get_named_compile_time_arg_val("core_noc_x"),
-        get_named_compile_time_arg_val("core_noc_y"),
-        get_named_compile_time_arg_val("is_secondary_sender")>;
+        get_named_compile_time_arg_val("num_pages_to_read"),
+        get_named_compile_time_arg_val("is_sender")>;
 
     // Only read broadcast runtime args if CCL is enabled
     deepseek_b1_ops::Broadcast::ReaderArgs bcast_args{};
 
-    bcast_args = deepseek_b1_ops::Broadcast::ReaderArgs{
-        get_common_arg_val<uint32_t>(0),  // tensor_address0
-        get_common_arg_val<uint32_t>(1),  // tile_id_start
-        get_common_arg_val<uint32_t>(2),  // tile_id_end
-    };
+    bcast_args = deepseek_b1_ops::Broadcast::ReaderArgs{};
 #endif
 
     using RMSNormCTArgs = deepseek_b1_ops::RMSNorm::ReaderCTArgs;
@@ -57,7 +49,7 @@ void kernel_main() {
 #if !defined(SKIP_CCL)
     using BcastCTArgs = deepseek_b1_ops::Broadcast::WriterCTArgs<
         get_named_compile_time_arg_val("cb0_id"),
-        get_named_compile_time_arg_val("packet_size_in_pages"),
+        get_named_compile_time_arg_val("num_pages_to_read"),
         get_named_compile_time_arg_val("tensor0_page_size"),
         get_named_compile_time_arg_val("num_targets_forward_direction"),
         get_named_compile_time_arg_val("num_targets_backward_direction"),
@@ -76,19 +68,17 @@ void kernel_main() {
     bcast_args = deepseek_b1_ops::Broadcast::WriterArgs{
         get_common_arg_val<uint32_t>(0),   // tensor_address0
         get_common_arg_val<uint32_t>(1),   // out_ready_sem_bank_addr
-        get_common_arg_val<uint32_t>(2),   // tile_id_start
-        get_common_arg_val<uint32_t>(3),   // tile_id_end
-        get_common_arg_val<uint32_t>(4),   // wait_output_semaphore
-        get_common_arg_val<uint32_t>(5),   // reset_global_semaphore
-        get_common_arg_val<uint32_t>(6),   // out_ready_sem_noc0_x
-        get_common_arg_val<uint32_t>(7),   // out_ready_sem_noc0_y
-        get_common_arg_val<uint32_t>(8),   // out_ready_sem_wait_value
-        get_common_arg_val<uint32_t>(9),   // barrier_sem
-        get_common_arg_val<uint32_t>(10),  // barrier_sem_noc0_x
-        get_common_arg_val<uint32_t>(11),  // barrier_sem_noc0_y
-        get_common_arg_val<uint32_t>(12),  // ring_index
-        get_common_arg_val<uint32_t>(13),  // secondary_sync_sem
-        get_common_arg_val<uint32_t>(14),  // num_connections
+        get_common_arg_val<uint32_t>(2),   // wait_output_semaphore
+        get_common_arg_val<uint32_t>(3),   // reset_global_semaphore
+        get_common_arg_val<uint32_t>(4),   // out_ready_sem_noc0_x
+        get_common_arg_val<uint32_t>(5),   // out_ready_sem_noc0_y
+        get_common_arg_val<uint32_t>(6),   // out_ready_sem_wait_value
+        get_common_arg_val<uint32_t>(7),   // barrier_sem
+        get_common_arg_val<uint32_t>(8),   // barrier_sem_noc0_x
+        get_common_arg_val<uint32_t>(9),   // barrier_sem_noc0_y
+        get_common_arg_val<uint32_t>(10),  // ring_index
+        get_common_arg_val<uint32_t>(11),  // secondary_sync_sem
+        get_common_arg_val<uint32_t>(12),  // num_connections
     };
 #endif
 

--- a/models/demos/deepseek_v3_b1/fused_ops/broadcast_rms/op.py
+++ b/models/demos/deepseek_v3_b1/fused_ops/broadcast_rms/op.py
@@ -192,17 +192,14 @@ class BroadcastRMSNorm:
                 range_hops_backward = num_targets_backward
 
                 rmsnorm_input_source_cb = input_cb
+                num_pages_to_read = input_num_pages
 
                 ncrisc_named_compile_time_args = [
                     ("skip_ccl", 1 if skip_ccl else 0),
                     # CCL broadcast reader args (dummy values when skip_ccl)
                     ("cb0_id", pkt_cb if not skip_ccl else 0),
-                    ("packet_size_in_pages", num_pages_per_packet if not skip_ccl else 0),
-                    ("tensor0_page_size", page_size_bytes if not skip_ccl else 0),
+                    ("num_pages_to_read", num_pages_to_read if not skip_ccl else 0),
                     ("is_sender", int(is_sender) if not skip_ccl else 0),
-                    ("core_noc_x", core_noc_x if not skip_ccl else 0),
-                    ("core_noc_y", core_noc_y if not skip_ccl else 0),
-                    ("is_secondary_sender", int(is_secondary_sender) if not skip_ccl else 0),
                     ("rmsnorm_input_cb", rmsnorm_input_source_cb),
                     ("rmsnorm_num_tiles", num_tiles),
                 ]
@@ -211,7 +208,7 @@ class BroadcastRMSNorm:
                     ("skip_ccl", 1 if skip_ccl else 0),
                     # CCL broadcast writer args (dummy values when skip_ccl)
                     ("cb0_id", pkt_cb if not skip_ccl else 0),
-                    ("packet_size_in_pages", num_pages_per_packet if not skip_ccl else 0),
+                    ("num_pages_to_read", num_pages_to_read if not skip_ccl else 0),
                     ("tensor0_page_size", page_size_bytes if not skip_ccl else 0),
                     ("num_targets_forward_direction", num_targets_forward if not skip_ccl else 0),
                     ("num_targets_backward_direction", num_targets_backward if not skip_ccl else 0),
@@ -264,13 +261,6 @@ class BroadcastRMSNorm:
                         dst_nodes.append(mesh_device.get_fabric_node_id(secondary_coord))
                     num_connections = len(dst_nodes)
 
-                # Common runtime args for reader (broadcast args shared across cores)
-                reader_common_rt_args = [
-                    int(input_tensor_device.buffer_address()),  # tensor_address0
-                    tile_id_start,  # tile_id_start
-                    input_num_pages,  # tile_id_end
-                ]
-
                 # Common runtime args for writer (broadcast args shared across cores)
                 writer_common_rt_args = []
                 if not skip_ccl:
@@ -282,8 +272,6 @@ class BroadcastRMSNorm:
                     writer_common_rt_args = [
                         int(intermediate_tensor_device.buffer_address()),  # tensor_address0
                         int(out_ready_sem_addr),  # out_ready_sem_bank_addr
-                        tile_id_start,  # tile_id_start
-                        input_num_pages,  # tile_id_end
                         int(wait_output_semaphore),  # wait_output_semaphore
                         int(reset_global_semaphore),  # reset_global_semaphore
                         core_noc_x,  # out_ready_sem_noc0_x (drain_sync_core)
@@ -308,18 +296,8 @@ class BroadcastRMSNorm:
                 in_cb_descriptor.format_descriptors[0].tile = tile_descriptor
                 in_cb_descriptor.format_descriptors[0].page_size = cb_page_size
 
-                # CB 2: packet buffer
-                pkt_cb_format = ttnn.CBFormatDescriptor(
-                    buffer_index=pkt_cb,
-                    data_format=data_format,
-                    page_size=cb_page_size,
-                    tile=tile_descriptor,
-                )
-                pkt_cb_descriptor = ttnn.CBDescriptor(
-                    total_size=num_tiles * cb_page_size,
-                    core_ranges=worker_core_set,
-                    format_descriptors=[pkt_cb_format],
-                )
+                # CB 2: ccl buffer
+                pkt_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(pkt_cb, input_tensor_mesh)
 
                 # CB 3: Gamma (created from sharded gamma tensor)
                 gamma_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(gamma_cb, gamma_tensor)
@@ -339,7 +317,6 @@ class BroadcastRMSNorm:
                     ncrisc_named_compile_time_args=ncrisc_named_compile_time_args,
                     brisc_named_compile_time_args=brisc_named_compile_time_args,
                     trisc_named_compile_time_args=trisc_named_compile_time_args,
-                    ncrisc_common_runtime_args=reader_common_rt_args,
                     brisc_common_runtime_args=writer_common_rt_args,
                     trisc_common_runtime_args=[epsilon_packed, scalar_packed],
                     trisc_compute_config=ttnn.ComputeConfigDescriptor(

--- a/models/demos/deepseek_v3_b1/fused_ops/broadcast_rms/op.py
+++ b/models/demos/deepseek_v3_b1/fused_ops/broadcast_rms/op.py
@@ -196,16 +196,6 @@ class BroadcastRMSNorm:
 
                 ncrisc_named_compile_time_args = [
                     ("skip_ccl", 1 if skip_ccl else 0),
-                    # CCL broadcast reader args (dummy values when skip_ccl)
-                    ("cb0_id", pkt_cb if not skip_ccl else 0),
-                    ("num_pages_to_read", num_pages_to_read if not skip_ccl else 0),
-                    ("is_sender", int(is_sender) if not skip_ccl else 0),
-                    ("rmsnorm_input_cb", rmsnorm_input_source_cb),
-                    ("rmsnorm_num_tiles", num_tiles),
-                ]
-
-                brisc_named_compile_time_args = [
-                    ("skip_ccl", 1 if skip_ccl else 0),
                     # CCL broadcast writer args (dummy values when skip_ccl)
                     ("cb0_id", pkt_cb if not skip_ccl else 0),
                     ("num_pages_to_read", num_pages_to_read if not skip_ccl else 0),
@@ -221,12 +211,17 @@ class BroadcastRMSNorm:
                     ("range_hops_forward", range_hops_forward if not skip_ccl else 0),
                     ("start_distance_in_hops_backward", start_distance_backward if not skip_ccl else 0),
                     ("range_hops_backward", range_hops_backward if not skip_ccl else 0),
-                    # RMSNorm/common args (always valid)
-                    # In multi-device mode, intermediate_cb = input_cb (CB 0) because broadcast
-                    # writes to CB 0 which is backed by intermediate_tensor_mesh
+                    ("rmsnorm_input_cb", rmsnorm_input_source_cb),
+                    ("rmsnorm_num_tiles", num_tiles),
                     ("intermediate_cb", input_cb if not skip_ccl else pkt_cb),
                     ("gamma_cb", gamma_cb),
-                    ("num_tiles", num_tiles),
+                ]
+
+                brisc_named_compile_time_args = [
+                    ("skip_ccl", 1 if skip_ccl else 0),
+                    ("cb0_id", pkt_cb if not skip_ccl else 0),
+                    ("num_pages_to_read", num_pages_to_read if not skip_ccl else 0),
+                    ("is_sender", int(is_sender) if not skip_ccl else 0),
                 ]
 
                 # Named compile-time args for TRISC (rmsnorm compute)
@@ -317,7 +312,7 @@ class BroadcastRMSNorm:
                     ncrisc_named_compile_time_args=ncrisc_named_compile_time_args,
                     brisc_named_compile_time_args=brisc_named_compile_time_args,
                     trisc_named_compile_time_args=trisc_named_compile_time_args,
-                    brisc_common_runtime_args=writer_common_rt_args,
+                    ncrisc_common_runtime_args=writer_common_rt_args,
                     trisc_common_runtime_args=[epsilon_packed, scalar_packed],
                     trisc_compute_config=ttnn.ComputeConfigDescriptor(
                         math_fidelity=ttnn.MathFidelity.LoFi,
@@ -328,7 +323,7 @@ class BroadcastRMSNorm:
                     defines=kernel_defines,
                     # Per-core runtime args: empty for BRISC (fabric args appended later)
                     per_core_runtime_args_descriptor=PerCoreRuntimeArgsDescriptor(
-                        brisc_args=[(worker_core, [])],  # Fabric args appended after program creation
+                        ncrisc_args=[(worker_core, [])],  # Fabric args appended after program creation
                     ),
                 )
 
@@ -344,13 +339,13 @@ class BroadcastRMSNorm:
                     semaphores=[],
                 )
 
-                # Append fabric connection args to BRISC kernel if needed (CCL mode only)
+                # Append fabric connection args to NCRISC kernel if needed (CCL mode only)
                 # Runtime args are already initialized by UnifiedKernelDescriptor via per_core_runtime_args_descriptors
                 if not skip_ccl and num_connections > 0:
-                    # writer kernel is index 1 in the unified kernel descriptor list
-                    writer_rt_args_ref = program.kernels[1].runtime_args[worker_core.x][worker_core.y]
+                    # NCRISC writer kernel is index 0 in the unified kernel descriptor list
+                    writer_rt_args_ref = program.kernels[0].runtime_args[worker_core.x][worker_core.y]
                     fabric_args = ttnn.setup_routing_plane_connection(
-                        fabric_node_id, dst_nodes, [0], program, 1, worker_core  # kernel_idx (writer kernel)
+                        fabric_node_id, dst_nodes, [0], program, 0, worker_core
                     )
                     writer_rt_args_ref.extend(fabric_args)
 

--- a/models/demos/deepseek_v3_b1/fused_ops/pre_sdpa/kernels/pre_sdpa_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/fused_ops/pre_sdpa/kernels/pre_sdpa_kernel.cpp
@@ -69,15 +69,42 @@ void kernel_main() {
 #if defined(COMPILE_FOR_NCRISC)
     // CTArgs type aliases (required for Op templates)
     // CCL Broadcast CTArgs type alias
-    using BcastCTArgs = deepseek_b1_ops::Broadcast::ReaderCTArgs<
+
+    // CCL Broadcast CTArgs type alias
+    using BcastCTArgs = deepseek_b1_ops::Broadcast::WriterCTArgs<
         get_named_compile_time_arg_val("bcast_cb0_id"),
         get_named_compile_time_arg_val("bcast_num_pages_to_read"),
-        get_named_compile_time_arg_val("bcast_is_sender")>;
+        get_named_compile_time_arg_val("bcast_tensor0_page_size"),
+        get_named_compile_time_arg_val("bcast_num_targets_forward_direction"),
+        get_named_compile_time_arg_val("bcast_num_targets_backward_direction"),
+        get_named_compile_time_arg_val("bcast_is_sender"),
+        get_named_compile_time_arg_val("bcast_core_noc_x"),
+        get_named_compile_time_arg_val("bcast_core_noc_y"),
+        get_named_compile_time_arg_val("bcast_is_secondary_sender"),
+        get_named_compile_time_arg_val("bcast_has_secondary_target"),
+        get_named_compile_time_arg_val("bcast_start_distance_in_hops_forward"),
+        get_named_compile_time_arg_val("bcast_range_hops_forward"),
+        get_named_compile_time_arg_val("bcast_start_distance_in_hops_backward"),
+        get_named_compile_time_arg_val("bcast_range_hops_backward")>;
 
-    // CCL Broadcast reader runtime args (only populated when not skip_ccl)
-    deepseek_b1_ops::Broadcast::ReaderArgs bcast_args{};
+    // CCL Broadcast writer runtime args (only populated when not skip_ccl)
+    deepseek_b1_ops::Broadcast::WriterArgs bcast_args{};
     if constexpr (!Core::skip_ccl) {
-        bcast_args = deepseek_b1_ops::Broadcast::ReaderArgs{};
+        bcast_args = deepseek_b1_ops::Broadcast::WriterArgs{
+            get_common_arg_val<uint32_t>(0),   // tensor_address0
+            get_common_arg_val<uint32_t>(1),   // out_ready_sem_bank_addr
+            get_common_arg_val<uint32_t>(2),   // wait_output_semaphore
+            get_common_arg_val<uint32_t>(3),   // reset_global_semaphore
+            get_common_arg_val<uint32_t>(4),   // out_ready_sem_noc0_x
+            get_common_arg_val<uint32_t>(5),   // out_ready_sem_noc0_y
+            get_common_arg_val<uint32_t>(6),   // out_ready_sem_wait_value
+            get_common_arg_val<uint32_t>(7),   // barrier_sem
+            get_common_arg_val<uint32_t>(8),   // barrier_sem_noc0_x
+            get_common_arg_val<uint32_t>(9),   // barrier_sem_noc0_y
+            get_common_arg_val<uint32_t>(10),  // ring_index
+            get_common_arg_val<uint32_t>(11),  // secondary_sync_sem
+            get_common_arg_val<uint32_t>(12),  // num_connections (computed from len(dst_nodes))
+        };
     }
 
     using RMSNormCTArgs = deepseek_b1_ops::RMSNorm::ReaderCTArgs;
@@ -218,42 +245,17 @@ void kernel_main() {
 // ============================================================================
 #elif defined(COMPILE_FOR_BRISC)
 
-    // CCL Broadcast CTArgs type alias
-    using BcastCTArgs = deepseek_b1_ops::Broadcast::WriterCTArgs<
+    using BcastCTArgs = deepseek_b1_ops::Broadcast::ReaderCTArgs<
         get_named_compile_time_arg_val("bcast_cb0_id"),
         get_named_compile_time_arg_val("bcast_num_pages_to_read"),
-        get_named_compile_time_arg_val("bcast_tensor0_page_size"),
-        get_named_compile_time_arg_val("bcast_num_targets_forward_direction"),
-        get_named_compile_time_arg_val("bcast_num_targets_backward_direction"),
-        get_named_compile_time_arg_val("bcast_is_sender"),
-        get_named_compile_time_arg_val("bcast_core_noc_x"),
-        get_named_compile_time_arg_val("bcast_core_noc_y"),
-        get_named_compile_time_arg_val("bcast_is_secondary_sender"),
-        get_named_compile_time_arg_val("bcast_has_secondary_target"),
-        get_named_compile_time_arg_val("bcast_start_distance_in_hops_forward"),
-        get_named_compile_time_arg_val("bcast_range_hops_forward"),
-        get_named_compile_time_arg_val("bcast_start_distance_in_hops_backward"),
-        get_named_compile_time_arg_val("bcast_range_hops_backward")>;
+        get_named_compile_time_arg_val("bcast_is_sender")>;
 
-    // CCL Broadcast writer runtime args (only populated when not skip_ccl)
-    deepseek_b1_ops::Broadcast::WriterArgs bcast_args{};
+    // CCL Broadcast reader runtime args (only populated when not skip_ccl)
+    deepseek_b1_ops::Broadcast::ReaderArgs bcast_args{};
     if constexpr (!Core::skip_ccl) {
-        bcast_args = deepseek_b1_ops::Broadcast::WriterArgs{
-            get_common_arg_val<uint32_t>(0),   // tensor_address0
-            get_common_arg_val<uint32_t>(1),   // out_ready_sem_bank_addr
-            get_common_arg_val<uint32_t>(2),   // wait_output_semaphore
-            get_common_arg_val<uint32_t>(3),   // reset_global_semaphore
-            get_common_arg_val<uint32_t>(4),   // out_ready_sem_noc0_x
-            get_common_arg_val<uint32_t>(5),   // out_ready_sem_noc0_y
-            get_common_arg_val<uint32_t>(6),   // out_ready_sem_wait_value
-            get_common_arg_val<uint32_t>(7),   // barrier_sem
-            get_common_arg_val<uint32_t>(8),   // barrier_sem_noc0_x
-            get_common_arg_val<uint32_t>(9),   // barrier_sem_noc0_y
-            get_common_arg_val<uint32_t>(10),  // ring_index
-            get_common_arg_val<uint32_t>(11),  // secondary_sync_sem
-            get_common_arg_val<uint32_t>(12),  // num_connections (computed from len(dst_nodes))
-        };
+        bcast_args = deepseek_b1_ops::Broadcast::ReaderArgs{};
     }
+
     // CTArgs type aliases (required for Op templates)
     using RMSNormCTArgs = deepseek_b1_ops::RMSNorm::WriterCTArgs;
     using RMSNorm2CTArgs = deepseek_b1_ops::RMSNorm::WriterCTArgs;  // BRISC is no-op
@@ -574,7 +576,7 @@ void kernel_main() {
 
 #if defined(COMPILE_FOR_NCRISC)
     // Setup sharded persistent buffers
-    if constexpr (Core::is_input_core && !Core::skip_ccl) {
+    if constexpr (Core::is_input_core) {
         // Multi-device mode: NCRISC sets up gamma buffers while BRISC handles CCL
         // RMSNorm gamma buffer
         constexpr uint32_t rmsnorm_input_cb = get_named_compile_time_arg_val("rmsnorm_input_cb");
@@ -667,23 +669,7 @@ void kernel_main() {
     }
 
 #if defined(COMPILE_FOR_NCRISC)
-    if constexpr (Core::is_input_core && Core::skip_ccl) {
-        // Single-device mode: NCRISC sets up ALL sharded buffers (input + gamma + gamma2)
-        // This matches the reference kernel behavior
-        constexpr uint32_t rmsnorm_input_cb = get_named_compile_time_arg_val("rmsnorm_input_cb");
-        constexpr uint32_t rmsnorm_gamma_cb = get_named_compile_time_arg_val("rmsnorm_gamma_cb");
-        constexpr uint32_t rmsnorm_num_tiles = get_named_compile_time_arg_val("rmsnorm_num_tiles");
-        constexpr uint32_t rmsnorm2_gamma_cb = get_named_compile_time_arg_val("rmsnorm2_gamma_cb");
-        constexpr uint32_t rmsnorm2_num_tiles = get_named_compile_time_arg_val("rmsnorm2_num_tiles");
-
-        unified_kernels::setup_sharded_buffer(rmsnorm_input_cb, rmsnorm_num_tiles);
-        unified_kernels::setup_sharded_buffer(rmsnorm_gamma_cb, rmsnorm_num_tiles);
-        unified_kernels::setup_sharded_buffer(rmsnorm2_gamma_cb, rmsnorm2_num_tiles);
-    }
-#endif
-
-#if defined(COMPILE_FOR_BRISC)
-    if constexpr (Core::is_input_core && !Core::skip_ccl) {
+    if constexpr (Core::is_input_core) {
         // Multi-device mode only: BRISC sets up intermediate (broadcast output) buffer
         // Gamma CBs are already set up by NCRISC via setup_sharded_buffer
         constexpr uint32_t rmsnorm_input_cb = get_named_compile_time_arg_val("rmsnorm_input_cb");

--- a/models/demos/deepseek_v3_b1/fused_ops/pre_sdpa/kernels/pre_sdpa_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/fused_ops/pre_sdpa/kernels/pre_sdpa_kernel.cpp
@@ -69,8 +69,6 @@ void kernel_main() {
 #if defined(COMPILE_FOR_NCRISC)
     // CTArgs type aliases (required for Op templates)
     // CCL Broadcast CTArgs type alias
-
-    // CCL Broadcast CTArgs type alias
     using BcastCTArgs = deepseek_b1_ops::Broadcast::WriterCTArgs<
         get_named_compile_time_arg_val("bcast_cb0_id"),
         get_named_compile_time_arg_val("bcast_num_pages_to_read"),
@@ -89,6 +87,7 @@ void kernel_main() {
 
     // CCL Broadcast writer runtime args (only populated when not skip_ccl)
     deepseek_b1_ops::Broadcast::WriterArgs bcast_args{};
+
     if constexpr (!Core::skip_ccl) {
         bcast_args = deepseek_b1_ops::Broadcast::WriterArgs{
             get_common_arg_val<uint32_t>(0),   // tensor_address0
@@ -245,6 +244,7 @@ void kernel_main() {
 // ============================================================================
 #elif defined(COMPILE_FOR_BRISC)
 
+    // CCL Broadcast CTArgs type alias
     using BcastCTArgs = deepseek_b1_ops::Broadcast::ReaderCTArgs<
         get_named_compile_time_arg_val("bcast_cb0_id"),
         get_named_compile_time_arg_val("bcast_num_pages_to_read"),
@@ -252,10 +252,10 @@ void kernel_main() {
 
     // CCL Broadcast reader runtime args (only populated when not skip_ccl)
     deepseek_b1_ops::Broadcast::ReaderArgs bcast_args{};
+
     if constexpr (!Core::skip_ccl) {
         bcast_args = deepseek_b1_ops::Broadcast::ReaderArgs{};
     }
-
     // CTArgs type aliases (required for Op templates)
     using RMSNormCTArgs = deepseek_b1_ops::RMSNorm::WriterCTArgs;
     using RMSNorm2CTArgs = deepseek_b1_ops::RMSNorm::WriterCTArgs;  // BRISC is no-op
@@ -377,8 +377,8 @@ void kernel_main() {
     deepseek_b1_ops::Rope::WriterArgs krope_args{};
 
     deepseek_b1_ops::KVCacheUpdate::WriterArgs kv_cache_update_args{
-        .kv_cache_buffer_base_addr = get_common_arg_val<uint32_t>(15),
-        .position_id = get_common_arg_val<uint32_t>(16),
+        .kv_cache_buffer_base_addr = get_common_arg_val<uint32_t>(0),
+        .position_id = get_common_arg_val<uint32_t>(1),
         .kv_cache_input_cb = get_named_compile_time_arg_val("kv_cache_input_cb"),
         .kv_cache_intermed_cb = get_named_compile_time_arg_val("kv_cache_intermed_cb"),
         .kv_cache_output_cb = get_named_compile_time_arg_val("kv_cache_output_cb"),
@@ -670,7 +670,6 @@ void kernel_main() {
 
 #if defined(COMPILE_FOR_NCRISC)
     if constexpr (Core::is_input_core) {
-        // Multi-device mode only: BRISC sets up intermediate (broadcast output) buffer
         // Gamma CBs are already set up by NCRISC via setup_sharded_buffer
         constexpr uint32_t rmsnorm_input_cb = get_named_compile_time_arg_val("rmsnorm_input_cb");
         constexpr uint32_t rmsnorm_num_tiles = get_named_compile_time_arg_val("rmsnorm_num_tiles");

--- a/models/demos/deepseek_v3_b1/fused_ops/pre_sdpa/kernels/pre_sdpa_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/fused_ops/pre_sdpa/kernels/pre_sdpa_kernel.cpp
@@ -71,21 +71,13 @@ void kernel_main() {
     // CCL Broadcast CTArgs type alias
     using BcastCTArgs = deepseek_b1_ops::Broadcast::ReaderCTArgs<
         get_named_compile_time_arg_val("bcast_cb0_id"),
-        get_named_compile_time_arg_val("bcast_packet_size_in_pages"),
-        get_named_compile_time_arg_val("bcast_tensor0_page_size"),
-        get_named_compile_time_arg_val("bcast_is_sender"),
-        get_named_compile_time_arg_val("bcast_core_noc_x"),
-        get_named_compile_time_arg_val("bcast_core_noc_y"),
-        get_named_compile_time_arg_val("bcast_is_secondary_sender")>;
+        get_named_compile_time_arg_val("bcast_num_pages_to_read"),
+        get_named_compile_time_arg_val("bcast_is_sender")>;
 
     // CCL Broadcast reader runtime args (only populated when not skip_ccl)
     deepseek_b1_ops::Broadcast::ReaderArgs bcast_args{};
     if constexpr (!Core::skip_ccl) {
-        bcast_args = deepseek_b1_ops::Broadcast::ReaderArgs{
-            get_common_arg_val<uint32_t>(0),  // tensor_address0
-            get_common_arg_val<uint32_t>(1),  // tile_id_start
-            get_common_arg_val<uint32_t>(2),  // tile_id_end
-        };
+        bcast_args = deepseek_b1_ops::Broadcast::ReaderArgs{};
     }
 
     using RMSNormCTArgs = deepseek_b1_ops::RMSNorm::ReaderCTArgs;
@@ -229,7 +221,7 @@ void kernel_main() {
     // CCL Broadcast CTArgs type alias
     using BcastCTArgs = deepseek_b1_ops::Broadcast::WriterCTArgs<
         get_named_compile_time_arg_val("bcast_cb0_id"),
-        get_named_compile_time_arg_val("bcast_packet_size_in_pages"),
+        get_named_compile_time_arg_val("bcast_num_pages_to_read"),
         get_named_compile_time_arg_val("bcast_tensor0_page_size"),
         get_named_compile_time_arg_val("bcast_num_targets_forward_direction"),
         get_named_compile_time_arg_val("bcast_num_targets_backward_direction"),
@@ -249,19 +241,17 @@ void kernel_main() {
         bcast_args = deepseek_b1_ops::Broadcast::WriterArgs{
             get_common_arg_val<uint32_t>(0),   // tensor_address0
             get_common_arg_val<uint32_t>(1),   // out_ready_sem_bank_addr
-            get_common_arg_val<uint32_t>(2),   // tile_id_start
-            get_common_arg_val<uint32_t>(3),   // tile_id_end
-            get_common_arg_val<uint32_t>(4),   // wait_output_semaphore
-            get_common_arg_val<uint32_t>(5),   // reset_global_semaphore
-            get_common_arg_val<uint32_t>(6),   // out_ready_sem_noc0_x
-            get_common_arg_val<uint32_t>(7),   // out_ready_sem_noc0_y
-            get_common_arg_val<uint32_t>(8),   // out_ready_sem_wait_value
-            get_common_arg_val<uint32_t>(9),   // barrier_sem
-            get_common_arg_val<uint32_t>(10),  // barrier_sem_noc0_x
-            get_common_arg_val<uint32_t>(11),  // barrier_sem_noc0_y
-            get_common_arg_val<uint32_t>(12),  // ring_index
-            get_common_arg_val<uint32_t>(13),  // secondary_sync_sem
-            get_common_arg_val<uint32_t>(14),  // num_connections (computed from len(dst_nodes))
+            get_common_arg_val<uint32_t>(2),   // wait_output_semaphore
+            get_common_arg_val<uint32_t>(3),   // reset_global_semaphore
+            get_common_arg_val<uint32_t>(4),   // out_ready_sem_noc0_x
+            get_common_arg_val<uint32_t>(5),   // out_ready_sem_noc0_y
+            get_common_arg_val<uint32_t>(6),   // out_ready_sem_wait_value
+            get_common_arg_val<uint32_t>(7),   // barrier_sem
+            get_common_arg_val<uint32_t>(8),   // barrier_sem_noc0_x
+            get_common_arg_val<uint32_t>(9),   // barrier_sem_noc0_y
+            get_common_arg_val<uint32_t>(10),  // ring_index
+            get_common_arg_val<uint32_t>(11),  // secondary_sync_sem
+            get_common_arg_val<uint32_t>(12),  // num_connections (computed from len(dst_nodes))
         };
     }
     // CTArgs type aliases (required for Op templates)

--- a/models/demos/deepseek_v3_b1/fused_ops/pre_sdpa/op.py
+++ b/models/demos/deepseek_v3_b1/fused_ops/pre_sdpa/op.py
@@ -1114,6 +1114,7 @@ class PreSDPA:
                 range_hops_forward = num_targets_forward
                 start_distance_backward = 1 if num_targets_backward > 0 else 0
                 range_hops_backward = num_targets_backward
+                bcast_num_pages_to_read = bcast_num_pages
 
                 # ================================================================
                 # CCL Broadcast compile-time args (per-device)
@@ -1121,18 +1122,14 @@ class PreSDPA:
                 bcast_ncrisc_named_compile_time_args = [
                     ("skip_ccl", 1 if skip_ccl else 0),
                     ("bcast_cb0_id", bcast_pkt_cb if not skip_ccl else 0),
-                    ("bcast_packet_size_in_pages", num_pages_per_packet if not skip_ccl else 0),
-                    ("bcast_tensor0_page_size", bcast_page_size_bytes if not skip_ccl else 0),
+                    ("bcast_num_pages_to_read", bcast_num_pages_to_read if not skip_ccl else 0),
                     ("bcast_is_sender", int(is_sender) if not skip_ccl else 0),
-                    ("bcast_core_noc_x", core_noc_x if not skip_ccl else 0),
-                    ("bcast_core_noc_y", core_noc_y if not skip_ccl else 0),
-                    ("bcast_is_secondary_sender", int(is_secondary_sender) if not skip_ccl else 0),
                 ]
 
                 bcast_brisc_named_compile_time_args = [
                     ("skip_ccl", 1 if skip_ccl else 0),
                     ("bcast_cb0_id", bcast_pkt_cb if not skip_ccl else 0),
-                    ("bcast_packet_size_in_pages", num_pages_per_packet if not skip_ccl else 0),
+                    ("bcast_num_pages_to_read", bcast_num_pages_to_read if not skip_ccl else 0),
                     ("bcast_tensor0_page_size", bcast_page_size_bytes if not skip_ccl else 0),
                     ("bcast_num_targets_forward_direction", num_targets_forward if not skip_ccl else 0),
                     ("bcast_num_targets_backward_direction", num_targets_backward if not skip_ccl else 0),
@@ -1160,6 +1157,9 @@ class PreSDPA:
                 # Update the tile descriptor in the format descriptor
                 in_cb_descriptor.format_descriptors[0].tile = tile_descriptor
                 in_cb_descriptor.format_descriptors[0].page_size = cb_page_size
+
+                # CB: CCL broadcast buffer
+                bcast_pkt_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(bcast_pkt_cb, input_tensor_device)
 
                 # CB: Gamma (created from sharded tensor)
                 gamma_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(gamma_cb, gamma_tensor_device)
@@ -1697,8 +1697,7 @@ class PreSDPA:
                 # ================================================================
                 if skip_ccl:
                     # Single-device mode: empty broadcast args
-                    ncrisc_bcast_common_args = [0, 0, 0]  # tensor_address0, tile_id_start, tile_id_end
-                    brisc_bcast_common_args = [0] * 15
+                    brisc_bcast_common_args = [0] * 13
                     dst_nodes = []
                     fabric_node_id = None
                 else:
@@ -1727,17 +1726,9 @@ class PreSDPA:
 
                     num_connections = len(dst_nodes)
 
-                    ncrisc_bcast_common_args = [
-                        int(input_tensor_device.buffer_address()),  # tensor_address0
-                        tile_id_start,  # tile_id_start
-                        bcast_num_pages,  # tile_id_end
-                    ]
-
                     brisc_bcast_common_args = [
                         int(intermediate_tensor_device.buffer_address()),  # tensor_address0
                         int(out_ready_sem_addr),  # out_ready_sem_bank_addr
-                        tile_id_start,  # tile_id_start
-                        bcast_num_pages,  # tile_id_end
                         int(wait_output_semaphore),
                         int(reset_global_semaphore),
                         core_noc_x,  # out_ready_sem_noc0_x
@@ -1783,8 +1774,6 @@ class PreSDPA:
                     + kv_rmsnorm_ncrisc_named_compile_time_args
                     + dkv_gather_sender_named_compile_time_args
                     + krope_ncrisc_named_compile_time_args,
-                    # NCRISC common runtime args:
-                    ncrisc_common_runtime_args=ncrisc_bcast_common_args,
                     # BRISC named compile-time args: bcast + rmsnorm reader (for gamma setup) + mcast sender + matmul + gather_reduce receiver + matmul2 + mcast2 + matmul3 + qrope + create_q_heads + dkv_matmul + dkv_gather_receiver + kv_rmsnorm
                     brisc_named_compile_time_args=bcast_brisc_named_compile_time_args
                     + rmsnorm_reader_named_compile_time_args

--- a/models/demos/deepseek_v3_b1/fused_ops/pre_sdpa/op.py
+++ b/models/demos/deepseek_v3_b1/fused_ops/pre_sdpa/op.py
@@ -1119,14 +1119,14 @@ class PreSDPA:
                 # ================================================================
                 # CCL Broadcast compile-time args (per-device)
                 # ================================================================
-                bcast_ncrisc_named_compile_time_args = [
+                bcast_brisc_named_compile_time_args = [
                     ("skip_ccl", 1 if skip_ccl else 0),
                     ("bcast_cb0_id", bcast_pkt_cb if not skip_ccl else 0),
                     ("bcast_num_pages_to_read", bcast_num_pages_to_read if not skip_ccl else 0),
                     ("bcast_is_sender", int(is_sender) if not skip_ccl else 0),
                 ]
 
-                bcast_brisc_named_compile_time_args = [
+                bcast_ncrisc_named_compile_time_args = [
                     ("skip_ccl", 1 if skip_ccl else 0),
                     ("bcast_cb0_id", bcast_pkt_cb if not skip_ccl else 0),
                     ("bcast_num_pages_to_read", bcast_num_pages_to_read if not skip_ccl else 0),
@@ -1726,7 +1726,7 @@ class PreSDPA:
 
                     num_connections = len(dst_nodes)
 
-                    brisc_bcast_common_args = [
+                    ncrisc_bcast_common_args = [
                         int(intermediate_tensor_device.buffer_address()),  # tensor_address0
                         int(out_ready_sem_addr),  # out_ready_sem_bank_addr
                         int(wait_output_semaphore),
@@ -1776,7 +1776,6 @@ class PreSDPA:
                     + krope_ncrisc_named_compile_time_args,
                     # BRISC named compile-time args: bcast + rmsnorm reader (for gamma setup) + mcast sender + matmul + gather_reduce receiver + matmul2 + mcast2 + matmul3 + qrope + create_q_heads + dkv_matmul + dkv_gather_receiver + kv_rmsnorm
                     brisc_named_compile_time_args=bcast_brisc_named_compile_time_args
-                    + rmsnorm_reader_named_compile_time_args
                     + mcast_sender_named_compile_time_args
                     + matmul_brisc_named_compile_time_args
                     + gather_reduce_receiver_named_compile_time_args
@@ -1789,8 +1788,8 @@ class PreSDPA:
                     + kv_rmsnorm_brisc_named_compile_time_args
                     + kv_cache_brisc_named_compile_time_args,
                     # BRISC common runtime args: bcast args
-                    brisc_common_runtime_args=brisc_bcast_common_args
-                    + [int(kv_cache_tensor_device.buffer_address()), position_id],
+                    brisc_common_runtime_args=[int(kv_cache_tensor_device.buffer_address()), position_id],
+                    ncrisc_common_runtime_args=ncrisc_bcast_common_args,
                     # TRISC named compile-time args: rmsnorm compute + matmul + gather-reduce + rmsnorm2 + matmul2 + matmul3 + qrope + create_q_heads + dkv_matmul + kv_rmsnorm + krope
                     trisc_named_compile_time_args=bcast_trisc_named_compile_time_args
                     + rmsnorm_compute_named_compile_time_args
@@ -1884,7 +1883,7 @@ class PreSDPA:
                     # Per-core runtime args for fabric (BRISC only, on worker_core)
                     # Initialize empty args that will be populated by setup_routing_plane_connection
                     per_core_runtime_args_descriptor=PerCoreRuntimeArgsDescriptor(
-                        brisc_args=[(worker_core, [])],  # Fabric args appended after program creation
+                        ncrisc_args=[(worker_core, [])],  # Fabric args appended after program creation
                     ),
                     noc_mode=noc_mode,
                 )
@@ -1948,12 +1947,11 @@ class PreSDPA:
                 if not skip_ccl and num_connections > 0:
                     # Find the BRISC (writer) kernel whose core_ranges includes worker_core
                     for idx, kernel in enumerate(program.kernels):
-                        if kernel.core_ranges.contains(worker_core) and (
-                            isinstance(kernel.config, ttnn.WriterConfigDescriptor)
+                        if kernel.core_ranges.contains(worker_core) and isinstance(
+                            kernel.config, ttnn.ReaderConfigDescriptor)
                             or (
                                 isinstance(kernel.config, ttnn.DataMovementConfigDescriptor)
-                                and kernel.config.processor == ttnn.DataMovementProcessor.RISCV_0
-                            )
+                                and kernel.config.processor == ttnn.DataMovementProcessor.RISCV_1
                         ):
                             writer_rt_args_ref = kernel.runtime_args[worker_core.x][worker_core.y]
                             fabric_args = ttnn.setup_routing_plane_connection(

--- a/models/demos/deepseek_v3_b1/fused_ops/pre_sdpa/op.py
+++ b/models/demos/deepseek_v3_b1/fused_ops/pre_sdpa/op.py
@@ -1158,9 +1158,6 @@ class PreSDPA:
                 in_cb_descriptor.format_descriptors[0].tile = tile_descriptor
                 in_cb_descriptor.format_descriptors[0].page_size = cb_page_size
 
-                # CB: CCL broadcast buffer
-                bcast_pkt_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(bcast_pkt_cb, input_tensor_device)
-
                 # CB: Gamma (created from sharded tensor)
                 gamma_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(gamma_cb, gamma_tensor_device)
                 # Update the tile descriptor in the format descriptor
@@ -1179,20 +1176,7 @@ class PreSDPA:
                 sdpa_kv_cache_running_offset = 0
 
                 # CB: CCL broadcast packet buffer
-                bcast_pkt_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(
-                    bcast_pkt_cb,
-                    sdpa_kv_cache_buffer_device,
-                    address_offset=sdpa_kv_cache_running_offset,
-                    total_size=num_tiles * cb_page_size,
-                )
-                bcast_pkt_cb_descriptor.format_descriptors = [
-                    ttnn.CBFormatDescriptor(
-                        buffer_index=bcast_pkt_cb,
-                        data_format=data_format,
-                        page_size=cb_page_size,
-                        tile=tile_descriptor,
-                    )
-                ]
+                bcast_pkt_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(bcast_pkt_cb, input_tensor_device)
                 sdpa_kv_cache_running_offset += bcast_pkt_cb_descriptor.total_size
 
                 # CB: RMSNorm output buffer
@@ -1697,7 +1681,7 @@ class PreSDPA:
                 # ================================================================
                 if skip_ccl:
                     # Single-device mode: empty broadcast args
-                    brisc_bcast_common_args = [0] * 13
+                    ncrisc_bcast_common_args = [0] * 13
                     dst_nodes = []
                     fabric_node_id = None
                 else:
@@ -1774,6 +1758,8 @@ class PreSDPA:
                     + kv_rmsnorm_ncrisc_named_compile_time_args
                     + dkv_gather_sender_named_compile_time_args
                     + krope_ncrisc_named_compile_time_args,
+                    # NCRISC common runtime args:
+                    ncrisc_common_runtime_args=ncrisc_bcast_common_args,
                     # BRISC named compile-time args: bcast + rmsnorm reader (for gamma setup) + mcast sender + matmul + gather_reduce receiver + matmul2 + mcast2 + matmul3 + qrope + create_q_heads + dkv_matmul + dkv_gather_receiver + kv_rmsnorm
                     brisc_named_compile_time_args=bcast_brisc_named_compile_time_args
                     + mcast_sender_named_compile_time_args
@@ -1789,7 +1775,6 @@ class PreSDPA:
                     + kv_cache_brisc_named_compile_time_args,
                     # BRISC common runtime args: bcast args
                     brisc_common_runtime_args=[int(kv_cache_tensor_device.buffer_address()), position_id],
-                    ncrisc_common_runtime_args=ncrisc_bcast_common_args,
                     # TRISC named compile-time args: rmsnorm compute + matmul + gather-reduce + rmsnorm2 + matmul2 + matmul3 + qrope + create_q_heads + dkv_matmul + kv_rmsnorm + krope
                     trisc_named_compile_time_args=bcast_trisc_named_compile_time_args
                     + rmsnorm_compute_named_compile_time_args
@@ -1947,11 +1932,12 @@ class PreSDPA:
                 if not skip_ccl and num_connections > 0:
                     # Find the BRISC (writer) kernel whose core_ranges includes worker_core
                     for idx, kernel in enumerate(program.kernels):
-                        if kernel.core_ranges.contains(worker_core) and isinstance(
-                            kernel.config, ttnn.ReaderConfigDescriptor)
+                        if kernel.core_ranges.contains(worker_core) and (
+                            isinstance(kernel.config, ttnn.ReaderConfigDescriptor)
                             or (
                                 isinstance(kernel.config, ttnn.DataMovementConfigDescriptor)
                                 and kernel.config.processor == ttnn.DataMovementProcessor.RISCV_1
+                            )
                         ):
                             writer_rt_args_ref = kernel.runtime_args[worker_core.x][worker_core.y]
                             fabric_args = ttnn.setup_routing_plane_connection(

--- a/models/demos/deepseek_v3_b1/micro_ops/ccl_broadcast/kernels/ccl_broadcast_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/micro_ops/ccl_broadcast/kernels/ccl_broadcast_kernel.cpp
@@ -17,25 +17,17 @@ void kernel_main() {
     // Reader CTArgs
     using BcastCTArgs = Broadcast::ReaderCTArgs<
         get_named_compile_time_arg_val("cb0_id"),
-        get_named_compile_time_arg_val("packet_size_in_pages"),
-        get_named_compile_time_arg_val("tensor0_page_size"),
-        get_named_compile_time_arg_val("is_sender"),
-        get_named_compile_time_arg_val("core_noc_x"),
-        get_named_compile_time_arg_val("core_noc_y"),
-        get_named_compile_time_arg_val("is_secondary_sender")>;
+        get_named_compile_time_arg_val("num_pages_to_read"),
+        get_named_compile_time_arg_val("is_sender")>;
 
     // Runtime args:
-    Broadcast::ReaderArgs bcast_args{
-        get_common_arg_val<uint32_t>(0),  // tensor_address0
-        get_common_arg_val<uint32_t>(1),  // tile_id_start
-        get_common_arg_val<uint32_t>(2),  // tile_id_end
-    };
+    Broadcast::ReaderArgs bcast_args{};
 
 #elif defined(COMPILE_FOR_BRISC)
     // Writer CTArgs
     using BcastCTArgs = Broadcast::WriterCTArgs<
         get_named_compile_time_arg_val("cb0_id"),
-        get_named_compile_time_arg_val("packet_size_in_pages"),
+        get_named_compile_time_arg_val("num_pages_to_read"),
         get_named_compile_time_arg_val("tensor0_page_size"),
         get_named_compile_time_arg_val("num_targets_forward_direction"),
         get_named_compile_time_arg_val("num_targets_backward_direction"),
@@ -53,19 +45,17 @@ void kernel_main() {
     Broadcast::WriterArgs bcast_args{
         get_common_arg_val<uint32_t>(0),   // tensor_address0
         get_common_arg_val<uint32_t>(1),   // out_ready_sem_bank_addr
-        get_common_arg_val<uint32_t>(2),   // tile_id_start
-        get_common_arg_val<uint32_t>(3),   // tile_id_end
-        get_common_arg_val<uint32_t>(4),   // wait_output_semaphore
-        get_common_arg_val<uint32_t>(5),   // reset_global_semaphore
-        get_common_arg_val<uint32_t>(6),   // out_ready_sem_noc0_x
-        get_common_arg_val<uint32_t>(7),   // out_ready_sem_noc0_y
-        get_common_arg_val<uint32_t>(8),   // out_ready_sem_wait_value
-        get_common_arg_val<uint32_t>(9),   // barrier_sem
-        get_common_arg_val<uint32_t>(10),  // barrier_sem_noc0_x
-        get_common_arg_val<uint32_t>(11),  // barrier_sem_noc0_y
-        get_common_arg_val<uint32_t>(12),  // ring_index
-        get_common_arg_val<uint32_t>(13),  // secondary_sync_sem
-        get_common_arg_val<uint32_t>(14),  // num_connections
+        get_common_arg_val<uint32_t>(2),   // wait_output_semaphore
+        get_common_arg_val<uint32_t>(3),   // reset_global_semaphore
+        get_common_arg_val<uint32_t>(4),   // out_ready_sem_noc0_x
+        get_common_arg_val<uint32_t>(5),   // out_ready_sem_noc0_y
+        get_common_arg_val<uint32_t>(6),   // out_ready_sem_wait_value
+        get_common_arg_val<uint32_t>(7),   // barrier_sem
+        get_common_arg_val<uint32_t>(8),   // barrier_sem_noc0_x
+        get_common_arg_val<uint32_t>(9),   // barrier_sem_noc0_y
+        get_common_arg_val<uint32_t>(10),  // ring_index
+        get_common_arg_val<uint32_t>(11),  // secondary_sync_sem
+        get_common_arg_val<uint32_t>(12),  // num_connections
     };
 
 #elif defined(COMPILE_FOR_TRISC)

--- a/models/demos/deepseek_v3_b1/micro_ops/ccl_broadcast/kernels/ccl_broadcast_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/micro_ops/ccl_broadcast/kernels/ccl_broadcast_kernel.cpp
@@ -14,16 +14,6 @@ void kernel_main() {
     using Broadcast = deepseek_b1_ops::Broadcast;
 
 #if defined(COMPILE_FOR_NCRISC)
-    // Reader CTArgs
-    using BcastCTArgs = Broadcast::ReaderCTArgs<
-        get_named_compile_time_arg_val("cb0_id"),
-        get_named_compile_time_arg_val("num_pages_to_read"),
-        get_named_compile_time_arg_val("is_sender")>;
-
-    // Runtime args:
-    Broadcast::ReaderArgs bcast_args{};
-
-#elif defined(COMPILE_FOR_BRISC)
     // Writer CTArgs
     using BcastCTArgs = Broadcast::WriterCTArgs<
         get_named_compile_time_arg_val("cb0_id"),
@@ -57,6 +47,16 @@ void kernel_main() {
         get_common_arg_val<uint32_t>(11),  // secondary_sync_sem
         get_common_arg_val<uint32_t>(12),  // num_connections
     };
+
+#elif defined(COMPILE_FOR_BRISC)
+    // Reader CTArgs
+    using BcastCTArgs = Broadcast::ReaderCTArgs<
+        get_named_compile_time_arg_val("cb0_id"),
+        get_named_compile_time_arg_val("num_pages_to_read"),
+        get_named_compile_time_arg_val("is_sender")>;
+
+    // Runtime args:
+    Broadcast::ReaderArgs bcast_args{};
 
 #elif defined(COMPILE_FOR_TRISC)
     // TRISC: Compute args unused for broadcast

--- a/models/demos/deepseek_v3_b1/micro_ops/ccl_broadcast/op.py
+++ b/models/demos/deepseek_v3_b1/micro_ops/ccl_broadcast/op.py
@@ -232,10 +232,10 @@ class DeepseekMinimalBroadcast:
                     core_ranges=worker_core_set,
                     ncrisc_named_compile_time_args=union_named_compile_time_args,
                     brisc_named_compile_time_args=union_named_compile_time_args,
-                    brisc_common_runtime_args=writer_common_rt_args,
-                    # Per-core runtime args: empty for BRISC (fabric args appended later)
+                    ncrisc_common_runtime_args=writer_common_rt_args,
+                    # Per-core runtime args: empty for NCRISC (fabric args appended later)
                     per_core_runtime_args_descriptor=PerCoreRuntimeArgsDescriptor(
-                        brisc_args=[(worker_core, [])],  # Fabric args appended after program creation
+                        ncrisc_args=[(worker_core, [])],  # Fabric args appended after program creation
                     ),
                 )
 
@@ -246,16 +246,16 @@ class DeepseekMinimalBroadcast:
                     cbs=[cb_desc],
                 )
 
-                # Append fabric connection args to BRISC kernel if needed
+                # Append fabric connection args to NCRISC kernel if needed
                 # Runtime args are already initialized by UnifiedKernelDescriptor via per_core_runtime_args_descriptors
                 if num_connections > 0:
-                    writer_rt_args_ref = program.kernels[1].runtime_args[worker_core.x][worker_core.y]
+                    writer_rt_args_ref = program.kernels[0].runtime_args[worker_core.x][worker_core.y]
                     fabric_args = ttnn.setup_routing_plane_connection(
                         fabric_node_id,
                         dst_nodes,
                         [0],
                         program,
-                        1,  # kernel_idx (writer kernel)
+                        0,  # kernel_idx (writer kernel)
                         worker_core,
                     )
                     writer_rt_args_ref.extend(fabric_args)

--- a/models/demos/deepseek_v3_b1/micro_ops/ccl_broadcast/op.py
+++ b/models/demos/deepseek_v3_b1/micro_ops/ccl_broadcast/op.py
@@ -149,22 +149,19 @@ class DeepseekMinimalBroadcast:
                 range_hops_forward = num_targets_forward
                 start_distance_backward = 1 if num_targets_backward > 0 else 0
                 range_hops_backward = num_targets_backward
+                num_pages_to_read = input_num_pages
 
                 # Reader named compile-time args
                 reader_named_compile_time_args = [
                     ("cb0_id", src0_cb_index),
-                    ("packet_size_in_pages", num_pages_per_packet),
-                    ("tensor0_page_size", page_size_bytes),
+                    ("num_pages_to_read", num_pages_to_read),
                     ("is_sender", 1 if is_sender else 0),
-                    ("core_noc_x", core_noc_x),
-                    ("core_noc_y", core_noc_y),
-                    ("is_secondary_sender", 1 if is_secondary_sender else 0),
                 ]
 
                 # Writer named compile-time args
                 writer_named_compile_time_args = [
                     ("cb0_id", src0_cb_index),
-                    ("packet_size_in_pages", num_pages_per_packet),
+                    ("num_pages_to_read", num_pages_to_read),
                     ("tensor0_page_size", page_size_bytes),
                     ("num_targets_forward_direction", num_targets_forward),
                     ("num_targets_backward_direction", num_targets_backward),
@@ -206,13 +203,6 @@ class DeepseekMinimalBroadcast:
 
                 num_connections = len(dst_nodes)
 
-                # Common runtime args for reader
-                reader_common_rt_args = [
-                    int(input_tensor_device.buffer_address()),  # tensor_address0
-                    0,  # tile_id_start
-                    input_num_pages,  # tile_id_end
-                ]
-
                 # Writer runtime args - moved to common args since CCL only uses one core
                 wait_output_semaphore = is_secondary_sender or is_receiver
                 reset_global_semaphore = is_secondary_sender or is_receiver
@@ -221,8 +211,6 @@ class DeepseekMinimalBroadcast:
                 writer_common_rt_args = [
                     int(output_tensor_device.buffer_address()),  # tensor_address0
                     int(out_ready_sem_addr),  # out_ready_sem_bank_addr
-                    0,  # tile_id_start
-                    input_num_pages,  # tile_id_end
                     int(wait_output_semaphore),  # wait_output_semaphore
                     int(reset_global_semaphore),  # reset_global_semaphore
                     core_noc_x,  # out_ready_sem_noc0_x (drain_sync_core)
@@ -237,24 +225,13 @@ class DeepseekMinimalBroadcast:
                 ]
 
                 # Create CB config
-                cb_config = ttnn.CBFormatDescriptor(
-                    buffer_index=src0_cb_index,
-                    data_format=dtype,
-                    page_size=page_size_bytes,
-                )
-                cb_desc = ttnn.CBDescriptor(
-                    total_size=num_pages_per_packet * page_size_bytes,
-                    core_ranges=worker_core_set,
-                    format_descriptors=[cb_config],
-                )
-
+                cb_desc = ttnn.cb_descriptor_from_sharded_tensor(src0_cb_index, input_tensor_device)
                 # Create unified kernel descriptor for CCL broadcast
                 unified_kernel = UnifiedKernelDescriptor(
                     kernel_source=ccl_kernel_path,
                     core_ranges=worker_core_set,
                     ncrisc_named_compile_time_args=union_named_compile_time_args,
                     brisc_named_compile_time_args=union_named_compile_time_args,
-                    ncrisc_common_runtime_args=reader_common_rt_args,
                     brisc_common_runtime_args=writer_common_rt_args,
                     # Per-core runtime args: empty for BRISC (fabric args appended later)
                     per_core_runtime_args_descriptor=PerCoreRuntimeArgsDescriptor(

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_pre_sdpa.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_pre_sdpa.py
@@ -52,7 +52,7 @@ def create_fabric_router_config(max_payload_size):
     ],
     indirect=True,
 )
-@pytest.mark.parametrize("noc_mode", [ttnn.NOC_MODE.DM_DEDICATED_NOC, ttnn.NOC_MODE.DM_DYNAMIC_NOC])
+@pytest.mark.parametrize("noc_mode", [ttnn.NOC_MODE.DM_DEDICATED_NOC])
 def test_pre_sdpa(
     bh_2d_mesh_device,
     mesh_rows,

--- a/models/demos/deepseek_v3_b1/unified_kernels/broadcast.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/broadcast.hpp
@@ -41,33 +41,18 @@ struct Broadcast {
     // ========================================================================
     // Runtime args structs - different layout per RISC
     // ========================================================================
-    template <
-        uint32_t cb0Id,
-        uint32_t packetSizeInPages,
-        uint32_t tensorPageSize,
-        uint32_t isSender,
-        uint32_t coreNocX,
-        uint32_t coreNocY,
-        uint32_t isSecondarySender>
+    template <uint32_t cb0Id, uint32_t NumPagesToRead, uint32_t isSender>
     struct ReaderCTArgs {
         static constexpr uint32_t cb0_id = cb0Id;
-        static constexpr uint32_t packet_size_in_pages = packetSizeInPages;
-        static constexpr uint32_t tensor0_page_size = tensorPageSize;
+        static constexpr uint32_t num_pages_to_read = NumPagesToRead;
         static constexpr uint32_t is_sender = isSender;
-        static constexpr uint32_t core_noc_x = coreNocX;
-        static constexpr uint32_t core_noc_y = coreNocY;
-        static constexpr uint32_t is_secondary_sender = isSecondarySender;
     };
 
-    struct ReaderArgs {
-        uint32_t tensor_address0;
-        uint32_t tile_id_start;
-        uint32_t tile_id_end;
-    };
+    struct ReaderArgs {};
 
     template <
         uint32_t cb0Id,
-        uint32_t packetSizeInPages,
+        uint32_t NumPagesToRead,
         uint32_t tensorPageSize,
         uint32_t numTargetsForwardDirection,
         uint32_t numTargetsBackwardDirection,
@@ -82,7 +67,7 @@ struct Broadcast {
         uint32_t rangeHopsBackward>
     struct WriterCTArgs {
         static constexpr uint32_t cb0_id = cb0Id;
-        static constexpr uint32_t packet_size_in_pages = packetSizeInPages;
+        static constexpr uint32_t num_pages_to_read = NumPagesToRead;
         static constexpr uint32_t tensor0_page_size = tensorPageSize;
         static constexpr uint32_t num_targets_forward_direction = numTargetsForwardDirection;
         static constexpr uint32_t num_targets_backward_direction = numTargetsBackwardDirection;
@@ -99,8 +84,6 @@ struct Broadcast {
     struct WriterArgs {
         uint32_t tensor_address0;
         uint32_t out_ready_sem_bank_addr;
-        uint32_t tile_id_start;
-        uint32_t tile_id_end;
         uint32_t wait_output_semaphore;
         uint32_t reset_global_semaphore;
         uint32_t out_ready_sem_noc0_x;
@@ -137,15 +120,8 @@ struct Broadcast {
             // ================================================================
             if constexpr (IsWorkerCore) {
                 if (CTArgs::is_sender) {
-                    uint32_t num_pages_to_read =
-                        std::min(args.tile_id_end - args.tile_id_start, CTArgs::packet_size_in_pages);
-                    cb_reserve_back(CTArgs::cb0_id, num_pages_to_read);
-                    const uint32_t l1_write_addr = get_write_ptr(CTArgs::cb0_id);
-                    uint64_t base_src_addr = get_noc_addr(CTArgs::core_noc_x, CTArgs::core_noc_y, args.tensor_address0);
-                    uint64_t read_addr = base_src_addr + (args.tile_id_start * CTArgs::tensor0_page_size);
-                    noc_async_read(read_addr, l1_write_addr, num_pages_to_read * CTArgs::tensor0_page_size);
-                    noc_async_read_barrier();
-                    cb_push_back(CTArgs::cb0_id, num_pages_to_read);
+                    cb_reserve_back(CTArgs::cb0_id, CTArgs::num_pages_to_read);
+                    cb_push_back(CTArgs::cb0_id, CTArgs::num_pages_to_read);
                 }
             }
 #elif defined(COMPILE_FOR_BRISC)
@@ -196,13 +172,10 @@ struct Broadcast {
                     safe_get_noc_addr(args.barrier_sem_noc0_x, args.barrier_sem_noc0_y, args.secondary_sync_sem, 0);
 
                 if (CTArgs::is_sender) {
-                    uint32_t num_pages_to_read =
-                        std::min(args.tile_id_end - args.tile_id_start, CTArgs::packet_size_in_pages);
-                    cb_wait_front(CTArgs::cb0_id, num_pages_to_read);
+                    cb_wait_front(CTArgs::cb0_id, CTArgs::num_pages_to_read);
                     size_t l1_read_addr = get_read_ptr(CTArgs::cb0_id);
                     uint64_t dst_noc_addr =
                         get_noc_addr(CTArgs::core_noc_x, CTArgs::core_noc_y, args.tensor_address0, 0);
-                    dst_noc_addr += args.tile_id_start * CTArgs::tensor0_page_size;
 
                     uint64_t out_ready_sem_noc_addr_in_pkt = safe_get_noc_addr(
                         args.out_ready_sem_noc0_x, args.out_ready_sem_noc0_y, args.out_ready_sem_bank_addr, 0);
@@ -221,7 +194,7 @@ struct Broadcast {
                             &secondary_slot.sender,
                             secondary_header,
                             l1_read_addr,
-                            CTArgs::tensor0_page_size * num_pages_to_read,
+                            CTArgs::tensor0_page_size * CTArgs::num_pages_to_read,
                             tt::tt_fabric::NocUnicastAtomicIncFusedCommandHeader{
                                 dst_noc_addr, out_ready_sem_noc_addr_in_pkt, 1, true},
                             1);  // 1 hop to secondary sender
@@ -234,9 +207,9 @@ struct Broadcast {
                         l1_read_addr,
                         tt::tt_fabric::NocUnicastAtomicIncFusedCommandHeader{
                             dst_noc_addr, out_ready_sem_noc_addr_in_pkt, 1, true},
-                        CTArgs::tensor0_page_size * num_pages_to_read);
+                        CTArgs::tensor0_page_size * CTArgs::num_pages_to_read);
 
-                    noc_async_write(l1_read_addr, dst_noc_addr, CTArgs::tensor0_page_size * num_pages_to_read);
+                    noc_async_write(l1_read_addr, dst_noc_addr, CTArgs::tensor0_page_size * CTArgs::num_pages_to_read);
 
                     // increment locally
                     uint64_t out_ready_sem_noc_addr = safe_get_noc_addr(
@@ -256,7 +229,7 @@ struct Broadcast {
                             reinterpret_cast<volatile tt_l1_ptr uint32_t*>(args.out_ready_sem_bank_addr), 0);
                     }
                     noc_async_writes_flushed();
-                    cb_pop_front(CTArgs::cb0_id, num_pages_to_read);
+                    cb_pop_front(CTArgs::cb0_id, CTArgs::num_pages_to_read);
 
                 } else if constexpr (CTArgs::is_secondary_sender) {
                     // Secondary sender: wait for data from primary sender, then broadcast along primary axis
@@ -274,11 +247,8 @@ struct Broadcast {
                     }
 
                     // broadcast the received data along the primary axis
-                    uint32_t num_pages_to_read =
-                        std::min(args.tile_id_end - args.tile_id_start, CTArgs::packet_size_in_pages);
                     uint64_t src_noc_addr =
                         get_noc_addr(CTArgs::core_noc_x, CTArgs::core_noc_y, args.tensor_address0, 0);
-                    src_noc_addr += args.tile_id_start * CTArgs::tensor0_page_size;
 
                     // Mcast the data along primary axis
                     uint64_t out_ready_sem_noc_addr_in_pkt = safe_get_noc_addr(
@@ -289,10 +259,10 @@ struct Broadcast {
                         UnicastFusedAtomicIncUpdateMask::PayloadSize>(
                         fabric_connection,
                         fused_route_id,
-                        static_cast<size_t>(args.tensor_address0 + args.tile_id_start * CTArgs::tensor0_page_size),
+                        static_cast<size_t>(args.tensor_address0),
                         tt::tt_fabric::NocUnicastAtomicIncFusedCommandHeader{
                             src_noc_addr, out_ready_sem_noc_addr_in_pkt, 1, true},
-                        CTArgs::tensor0_page_size * num_pages_to_read);
+                        CTArgs::tensor0_page_size * CTArgs::num_pages_to_read);
                     noc_async_writes_flushed();
 
                 } else {

--- a/models/demos/deepseek_v3_b1/unified_kernels/broadcast.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/broadcast.hpp
@@ -6,7 +6,7 @@
 #include "kernel_op_api.hpp"
 #include "kernel_utils.hpp"
 
-#if defined(COMPILE_FOR_BRISC)
+#if defined(COMPILE_FOR_NCRISC)
 #include "api/dataflow/dataflow_api.h"
 #include "tt_metal/fabric/hw/inc/edm_fabric/fabric_connection_manager.hpp"
 #include "tt_metal/fabric/hw/inc/noc_addr.h"
@@ -24,7 +24,7 @@
 using address_t = uint32_t;
 using namespace tt::tt_fabric::linear::experimental;
 
-#elif defined(COMPILE_FOR_NCRISC)
+#elif defined(COMPILE_FOR_BRISC)
 #include "api/dataflow/dataflow_api.h"
 #include <cstdint>
 #include <utility>
@@ -101,7 +101,7 @@ struct Broadcast {
     struct ComputeArgs {};
     struct ComputeCTArgs {};
 
-    using RTArgs = unified_kernels::SelectByRISCV<ReaderArgs, WriterArgs, ComputeArgs>;
+    using RTArgs = unified_kernels::SelectByRISCV<WriterArgs, ReaderArgs, ComputeArgs>;
 
     template <typename CTArgs, bool IsWorkerCore>
     class Op {
@@ -114,9 +114,9 @@ struct Broadcast {
 
     private:
         void impl([[maybe_unused]] const RTArgs& args) {
-#if defined(COMPILE_FOR_NCRISC)
+#if defined(COMPILE_FOR_BRISC)
             // ================================================================
-            // NRISC - bcast reader
+            // BRISC - bcast reader
             // ================================================================
             if constexpr (IsWorkerCore) {
                 if (CTArgs::is_sender) {
@@ -124,9 +124,10 @@ struct Broadcast {
                     cb_push_back(CTArgs::cb0_id, CTArgs::num_pages_to_read);
                 }
             }
-#elif defined(COMPILE_FOR_BRISC)
+
+#elif defined(COMPILE_FOR_NCRISC)
             // ================================================================
-            // BRISC - Bcast writer
+            // NCRISC - bcast writer
             // ================================================================
             if constexpr (IsWorkerCore) {
                 constexpr uint32_t num_primary_connections = (CTArgs::start_distance_in_hops_forward > 0 ? 1 : 0) +


### PR DESCRIPTION
### Ticket
Link to Github Issue 

### Problem description
In the initial implementation, broadcast op had the writer running on brisc (noc 1) which causes a conflict with mcast op in pre sdpa for blitz

### What's changed
- Switch noc usage between reader and writer for broadcast op to ensure that there isn't any noc transaction happening on noc 1 and avoid the conflict with mcast op
- Apply the changes to all the ops that are running ccl broadcast

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:{{branch_name}})
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:{{branch_name}})
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:{{branch_name}})
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:{{branch_name}})
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:{{branch_name}})
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:{{branch_name}})
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
