### PR TITLE
Validate circular buffer core ranges against device compute grid

### DIFF
--- a/tests/tt_metal/tt_metal/api/circular_buffer/test_CircularBuffer_creation.cpp
+++ b/tests/tt_metal/tt_metal/api/circular_buffer/test_CircularBuffer_creation.cpp
@@ -177,4 +177,29 @@ TEST_F(MeshDeviceFixture, TensixTestCreateCircularBufferWithTooManyPages) {
     EXPECT_ANY_THROW(CreateCircularBuffer(program, cr_set, config));
 }
 
+TEST_F(MeshDeviceFixture, TensixTestCreateCircularBufferOnOutOfRangeCores) {
+    for (unsigned int id = 0; id < num_devices_; id++) {
+        auto& cq = devices_.at(id)->mesh_command_queue();
+        distributed::MeshWorkload workload;
+        auto zero_coord = distributed::MeshCoordinate(0, 0);
+        auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
+        Program program;
+        workload.add_program(device_range, std::move(program));
+        auto& program_ = workload.get_programs().at(device_range);
+
+        auto grid_size = devices_.at(id)->compute_with_storage_grid_size();
+        // Extend one column beyond the compute grid into dispatch core territory
+        CoreRange cr({0, 0}, {grid_size.x, grid_size.y - 1});
+        CoreRangeSet cr_set({cr});
+
+        CBConfig cb_config;
+        CircularBufferConfig config =
+            CircularBufferConfig(cb_config.page_size, {{0, cb_config.data_format}})
+                .set_page_size(0, cb_config.page_size);
+        CreateCircularBuffer(program_, cr_set, config);
+
+        EXPECT_ANY_THROW(distributed::EnqueueMeshWorkload(cq, workload, false));
+    }
+}
+
 }  // end namespace basic_tests::circular_buffer

--- a/tests/tt_metal/tt_metal/api/circular_buffer/test_CircularBuffer_creation.cpp
+++ b/tests/tt_metal/tt_metal/api/circular_buffer/test_CircularBuffer_creation.cpp
@@ -193,9 +193,8 @@ TEST_F(MeshDeviceFixture, TensixTestCreateCircularBufferOnOutOfRangeCores) {
         CoreRangeSet cr_set({cr});
 
         CBConfig cb_config;
-        CircularBufferConfig config =
-            CircularBufferConfig(cb_config.page_size, {{0, cb_config.data_format}})
-                .set_page_size(0, cb_config.page_size);
+        CircularBufferConfig config = CircularBufferConfig(cb_config.page_size, {{0, cb_config.data_format}})
+                                          .set_page_size(0, cb_config.page_size);
         CreateCircularBuffer(program_, cr_set, config);
 
         EXPECT_ANY_THROW(distributed::EnqueueMeshWorkload(cq, workload, false));

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_dispatch.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_dispatch.cpp
@@ -445,4 +445,28 @@ TEST_F(MeshDispatchFixture, TensixCircularBufferInitFunction) {
     }
 }
 
+TEST_F(MeshDispatchFixture, TensixTestCreateCircularBufferOnOutOfRangeCores) {
+    for (auto& device : devices_) {
+        auto& cq = device->mesh_command_queue();
+        distributed::MeshWorkload workload;
+        auto zero_coord = distributed::MeshCoordinate(0, 0);
+        auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
+        Program program;
+        workload.add_program(device_range, std::move(program));
+        auto& program_ = workload.get_programs().at(device_range);
+
+        auto grid_size = device->compute_with_storage_grid_size();
+        CoreRange cr({0, 0}, {grid_size.x, grid_size.y - 1});
+        CoreRangeSet cr_set({cr});
+
+        uint32_t page_size = tt::tile_size(tt::DataFormat::Float16_b);
+        CircularBufferConfig config =
+            CircularBufferConfig(page_size, {{0, tt::DataFormat::Float16_b}})
+                .set_page_size(0, page_size);
+        CreateCircularBuffer(program_, cr_set, config);
+
+        EXPECT_ANY_THROW(distributed::EnqueueMeshWorkload(cq, workload, false));
+    }
+}
+
 }  // namespace tt::tt_metal

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_dispatch.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_dispatch.cpp
@@ -461,8 +461,7 @@ TEST_F(MeshDispatchFixture, TensixTestCreateCircularBufferOnOutOfRangeCores) {
 
         uint32_t page_size = tt::tile_size(tt::DataFormat::Float16_b);
         CircularBufferConfig config =
-            CircularBufferConfig(page_size, {{0, tt::DataFormat::Float16_b}})
-                .set_page_size(0, page_size);
+            CircularBufferConfig(page_size, {{0, tt::DataFormat::Float16_b}}).set_page_size(0, page_size);
         CreateCircularBuffer(program_, cr_set, config);
 
         EXPECT_ANY_THROW(distributed::EnqueueMeshWorkload(cq, workload, false));

--- a/tt_metal/distributed/mesh_workload.cpp
+++ b/tt_metal/distributed/mesh_workload.cpp
@@ -98,6 +98,7 @@ void MeshWorkloadImpl::compile_program(const MeshCoordinateRange& device_range, 
     auto& program = programs_.at(device_range);
     program.impl().compile(mesh_device);
     program.impl().allocate_circular_buffers(mesh_device);
+    program.impl().validate_circular_buffer_core_ranges(mesh_device);
     program.impl().validate_circular_buffer_region(mesh_device);
     program.impl().allocate_dataflow_buffers(mesh_device);
     program.impl().validate_dataflow_buffer_region(mesh_device);

--- a/tt_metal/impl/program/program.cpp
+++ b/tt_metal/impl/program/program.cpp
@@ -951,6 +951,21 @@ void detail::ProgramImpl::validate_circular_buffer_region(const IDevice* device)
     }
 }
 
+void detail::ProgramImpl::validate_circular_buffer_core_ranges(const IDevice* device) {
+    auto grid_size = device->compute_with_storage_grid_size();
+    for (const auto& cb : circular_buffers_) {
+        for (const auto& cr : cb->core_ranges().ranges()) {
+            TT_FATAL(
+                cr.end_coord.x < grid_size.x && cr.end_coord.y < grid_size.y,
+                "Circular buffer core range {} in program {} exceeds device compute grid ({}x{})",
+                cr.str(),
+                this->id,
+                grid_size.x,
+                grid_size.y);
+        }
+    }
+}
+
 void detail::ProgramImpl::init_semaphores(
     const IDevice& device, const CoreCoord& logical_core, uint32_t programmable_core_type_index) const {
     const auto& hal = MetalContext::instance().hal();

--- a/tt_metal/impl/program/program_impl.hpp
+++ b/tt_metal/impl/program/program_impl.hpp
@@ -280,6 +280,8 @@ public:
     // Ensures that statically allocated circular buffers do not grow into L1 buffer space
     void validate_circular_buffer_region(const IDevice* device);
     void validate_dataflow_buffer_region(const IDevice* device);
+    // Ensures that circular buffer core ranges are within the device compute grid
+    void validate_circular_buffer_core_ranges(const IDevice* device);
 
     KernelHandle add_kernel(const std::shared_ptr<Kernel>& kernel, const HalProgrammableCoreType& core_type);
 

--- a/tt_metal/tt_metal.cpp
+++ b/tt_metal/tt_metal.cpp
@@ -816,6 +816,7 @@ bool ConfigureDeviceWithProgram(IDevice* device, Program& program, bool force_sl
     auto device_id = device->id();
 
     program.impl().allocate_circular_buffers(device);
+    program.impl().validate_circular_buffer_core_ranges(device);
     program.impl().validate_circular_buffer_region(device);
     program.impl().allocate_dataflow_buffers(device);
     program.impl().validate_dataflow_buffer_region(device);


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/38033

### Problem description
Programs that create circular buffers on cores outside the device's compute grid (e.g. on dispatch cores) cause silent hangs in the dispatcher's write barrier. This was discovered via the `BM_pgm_dispatch/all_processors_all_cores_1cb` benchmark on blackhole, where a hardcoded core grid exceeded the actual device grid, writing CB config to dispatch cores and causing a hang.

### What's changed
Added `ProgramImpl::validate_circular_buffer_core_ranges()` which checks that all circular buffer core ranges fall within `device->compute_with_storage_grid_size()`. This validation is called:
- In `ConfigureDeviceWithProgram()` (slow dispatch path)
- In `MeshWorkloadImpl::compile_program()` (fast dispatch path)

This turns a silent hang into an immediate `TT_FATAL` with a clear error message.

**New tests:**
- `MeshDeviceFixture.TensixTestCreateCircularBufferOnOutOfRangeCores` in `unit_tests_api` (slow dispatch CI)
- `MeshDispatchFixture.TensixTestCreateCircularBufferOnOutOfRangeCores` in `unit_tests_dispatch` (fast dispatch CI)

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=jbauman/validatecbcores)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:jbauman/validatecbcores)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=jbauman/validatecbcores)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:jbauman/validatecbcores)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=jbauman/validatecbcores)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jbauman/validatecbcores)
- [x] New/Existing tests provide coverage for changes

#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=jbauman/validatecbcores)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:jbauman/validatecbcores)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=jbauman/validatecbcores)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:jbauman/validatecbcores)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=jbauman/validatecbcores)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:jbauman/validatecbcores)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

Made with [Cursor](https://cursor.com)