### PR TITLE
Move cb ids to CTAs for blitz RMSNorm

### DIFF
--- a/models/demos/deepseek_v3_b1/fused_ops/broadcast_rms/kernels/broadcast_rms_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/fused_ops/broadcast_rms/kernels/broadcast_rms_kernel.cpp
@@ -103,12 +103,12 @@ void kernel_main() {
     using RMSNormCTArgs = deepseek_b1_ops::RMSNorm::ComputeCTArgs<
         get_named_compile_time_arg_val("rmsnorm_fp32_acc") == 1,
         get_named_compile_time_arg_val("rmsnorm_num_tiles"),
-        get_named_compile_time_arg_val("rmsnorm_rsqrt_fast_approx") == 1>;
-
-    deepseek_b1_ops::RMSNorm::ComputeArgs rms_args{
+        get_named_compile_time_arg_val("rmsnorm_rsqrt_fast_approx") == 1,
         get_named_compile_time_arg_val("rmsnorm_input_cb"),
         get_named_compile_time_arg_val("rmsnorm_gamma_cb"),
-        get_named_compile_time_arg_val("rmsnorm_output_cb"),
+        get_named_compile_time_arg_val("rmsnorm_output_cb")>;
+
+    deepseek_b1_ops::RMSNorm::ComputeArgs rms_args{
         get_common_arg_val<uint32_t>(0),  // epsilon (common runtime arg 0)
         get_common_arg_val<float>(1),     // scalar (1/N)
     };

--- a/models/demos/deepseek_v3_b1/fused_ops/kv_cache_branch/kernels/kv_cache_branch_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/fused_ops/kv_cache_branch/kernels/kv_cache_branch_kernel.cpp
@@ -126,13 +126,13 @@ void kernel_main() {
     using KV_RMSNormCTArgs = deepseek_b1_ops::RMSNorm::ComputeCTArgs<
         get_named_compile_time_arg_val("rmsnorm_fp32_acc") == 1,
         get_named_compile_time_arg_val("kv_rmsnorm_num_tiles"),
-        get_named_compile_time_arg_val("rmsnorm_rsqrt_fast_approx") == 1>;
+        get_named_compile_time_arg_val("rmsnorm_rsqrt_fast_approx") == 1,
+        get_named_compile_time_arg_val("kv_rmsnorm_input_cb"),
+        get_named_compile_time_arg_val("kv_rmsnorm_gamma_cb"),
+        get_named_compile_time_arg_val("kv_rmsnorm_output_cb")>;
 
     // RMSNorm compute runtime args
     deepseek_b1_ops::RMSNorm::ComputeArgs kv_rmsnorm_args{
-        get_named_compile_time_arg_val("kv_rmsnorm_input_cb"),
-        get_named_compile_time_arg_val("kv_rmsnorm_gamma_cb"),
-        get_named_compile_time_arg_val("kv_rmsnorm_output_cb"),
         get_common_arg_val<uint32_t>(0),  // epsilon
         get_common_arg_val<float>(1),     // scalar (1/sqrt(512))
     };

--- a/models/demos/deepseek_v3_b1/fused_ops/mlp/mlp_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/fused_ops/mlp/mlp_kernel.cpp
@@ -584,13 +584,13 @@ void kernel_main() {
             using RMSNormCTArgs = deepseek_b1_ops::RMSNorm::ComputeCTArgs<
                 get_named_compile_time_arg_val("rmsnorm_fp32_acc") == 1,
                 get_named_compile_time_arg_val("rmsnorm_num_tiles"),
-                get_named_compile_time_arg_val("rmsnorm_rsqrt_fast_approx") == 1>;
-            deepseek_b1_ops::RMSNorm::ComputeArgs rmsnorm_args{
+                get_named_compile_time_arg_val("rmsnorm_rsqrt_fast_approx") == 1,
                 get_named_compile_time_arg_val("rmsnorm_input_cb"),  // residual_mcast_src_cb
                 get_named_compile_time_arg_val("rmsnorm_gamma_cb"),
-                get_named_compile_time_arg_val("rmsnorm_output_cb"),  // rmsnorm_output_cb
-                get_common_arg_val<uint32_t>(0),                      // epsilon
-                get_common_arg_val<float>(1),                         // scalar (1/sqrt(numel))
+                get_named_compile_time_arg_val("rmsnorm_output_cb")>;  // rmsnorm_output_cb>;
+            deepseek_b1_ops::RMSNorm::ComputeArgs rmsnorm_args{
+                get_common_arg_val<uint32_t>(0),  // epsilon
+                get_common_arg_val<float>(1),     // scalar (1/sqrt(numel))
             };
         } routed;
 

--- a/models/demos/deepseek_v3_b1/fused_ops/mlp/mlp_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/fused_ops/mlp/mlp_kernel.cpp
@@ -587,7 +587,7 @@ void kernel_main() {
                 get_named_compile_time_arg_val("rmsnorm_rsqrt_fast_approx") == 1,
                 get_named_compile_time_arg_val("rmsnorm_input_cb"),  // residual_mcast_src_cb
                 get_named_compile_time_arg_val("rmsnorm_gamma_cb"),
-                get_named_compile_time_arg_val("rmsnorm_output_cb")>;  // rmsnorm_output_cb>;
+                get_named_compile_time_arg_val("rmsnorm_output_cb")>;  // rmsnorm_output_cb
             deepseek_b1_ops::RMSNorm::ComputeArgs rmsnorm_args{
                 get_common_arg_val<uint32_t>(0),  // epsilon
                 get_common_arg_val<float>(1),     // scalar (1/sqrt(numel))

--- a/models/demos/deepseek_v3_b1/fused_ops/moe/moe_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/fused_ops/moe/moe_kernel.cpp
@@ -709,13 +709,13 @@ void kernel_main() {
             using RMSNormCTArgs = deepseek_b1_ops::RMSNorm::ComputeCTArgs<
                 get_named_compile_time_arg_val("rmsnorm_fp32_acc") == 1,
                 get_named_compile_time_arg_val("rmsnorm_num_tiles"),
-                get_named_compile_time_arg_val("rmsnorm_rsqrt_fast_approx") == 1>;
-            deepseek_b1_ops::RMSNorm::ComputeArgs rmsnorm_args{
+                get_named_compile_time_arg_val("rmsnorm_rsqrt_fast_approx") == 1,
                 get_named_compile_time_arg_val("rmsnorm_input_cb"),  // residual_mcast_src_cb
                 get_named_compile_time_arg_val("rmsnorm_gamma_cb"),
-                get_named_compile_time_arg_val("rmsnorm_output_cb"),  // rmsnorm_output_cb
-                get_common_arg_val<uint32_t>(0),                      // epsilon
-                get_common_arg_val<float>(1),                         // scalar (1/sqrt(numel))
+                get_named_compile_time_arg_val("rmsnorm_output_cb")>;  // rmsnorm_output_cb>;
+            deepseek_b1_ops::RMSNorm::ComputeArgs rmsnorm_args{
+                get_common_arg_val<uint32_t>(0),  // epsilon
+                get_common_arg_val<float>(1),     // scalar (1/sqrt(numel))
             };
         } routed;
 

--- a/models/demos/deepseek_v3_b1/fused_ops/moe/moe_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/fused_ops/moe/moe_kernel.cpp
@@ -712,7 +712,7 @@ void kernel_main() {
                 get_named_compile_time_arg_val("rmsnorm_rsqrt_fast_approx") == 1,
                 get_named_compile_time_arg_val("rmsnorm_input_cb"),  // residual_mcast_src_cb
                 get_named_compile_time_arg_val("rmsnorm_gamma_cb"),
-                get_named_compile_time_arg_val("rmsnorm_output_cb")>;  // rmsnorm_output_cb>;
+                get_named_compile_time_arg_val("rmsnorm_output_cb")>;  // rmsnorm_output_cb
             deepseek_b1_ops::RMSNorm::ComputeArgs rmsnorm_args{
                 get_common_arg_val<uint32_t>(0),  // epsilon
                 get_common_arg_val<float>(1),     // scalar (1/sqrt(numel))

--- a/models/demos/deepseek_v3_b1/fused_ops/pre_sdpa/kernels/pre_sdpa_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/fused_ops/pre_sdpa/kernels/pre_sdpa_kernel.cpp
@@ -416,9 +416,9 @@ void kernel_main() {
         get_named_compile_time_arg_val("rmsnorm_fp32_acc") == 1,
         get_named_compile_time_arg_val("rmsnorm2_num_tiles"),
         get_named_compile_time_arg_val("rmsnorm_rsqrt_fast_approx") == 1,
-        get_named_compile_time_arg_val("rmsnorm_input_cb"),
-        get_named_compile_time_arg_val("rmsnorm_gamma_cb"),
-        get_named_compile_time_arg_val("rmsnorm_output_cb")>;
+        get_named_compile_time_arg_val("rmsnorm2_input_cb"),
+        get_named_compile_time_arg_val("rmsnorm2_gamma_cb"),
+        get_named_compile_time_arg_val("rmsnorm2_output_cb")>;
     using McastCTArgs = deepseek_b1_ops::Mcast::ComputeCTArgs;
 
     // RMSNorm compute runtime args
@@ -462,11 +462,8 @@ void kernel_main() {
 
     // RMSNorm2 compute args (separate CBs with exact sizes for testing)
     deepseek_b1_ops::RMSNorm::ComputeArgs rmsnorm2_args{
-        get_named_compile_time_arg_val("rmsnorm2_input_cb"),   // separate input CB (3 tiles of 16x32)
-        get_named_compile_time_arg_val("rmsnorm2_gamma_cb"),   // new gamma for 1536 elements
-        get_named_compile_time_arg_val("rmsnorm2_output_cb"),  // separate output CB (3 tiles of 16x32)
-        get_common_arg_val<uint32_t>(0),                       // epsilon (same as rmsnorm1)
-        get_common_arg_val<float>(2),                          // scalar (1/sqrt(1536))
+        get_common_arg_val<uint32_t>(0),  // epsilon (same as rmsnorm1)
+        get_common_arg_val<float>(2),     // scalar (1/sqrt(1536))
     };
 
     // Matmul2 CTArgs type alias (out_w is compile-time for TRISC)

--- a/models/demos/deepseek_v3_b1/fused_ops/pre_sdpa/kernels/pre_sdpa_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/fused_ops/pre_sdpa/kernels/pre_sdpa_kernel.cpp
@@ -408,18 +408,21 @@ void kernel_main() {
     using RMSNormCTArgs = deepseek_b1_ops::RMSNorm::ComputeCTArgs<
         get_named_compile_time_arg_val("rmsnorm_fp32_acc") == 1,
         get_named_compile_time_arg_val("rmsnorm_num_tiles"),
-        get_named_compile_time_arg_val("rmsnorm_rsqrt_fast_approx") == 1>;
+        get_named_compile_time_arg_val("rmsnorm_rsqrt_fast_approx") == 1,
+        get_named_compile_time_arg_val("rmsnorm_input_cb"),
+        get_named_compile_time_arg_val("rmsnorm_gamma_cb"),
+        get_named_compile_time_arg_val("rmsnorm_output_cb")>;
     using RMSNorm2CTArgs = deepseek_b1_ops::RMSNorm::ComputeCTArgs<
         get_named_compile_time_arg_val("rmsnorm_fp32_acc") == 1,
         get_named_compile_time_arg_val("rmsnorm2_num_tiles"),
-        get_named_compile_time_arg_val("rmsnorm_rsqrt_fast_approx") == 1>;
+        get_named_compile_time_arg_val("rmsnorm_rsqrt_fast_approx") == 1,
+        get_named_compile_time_arg_val("rmsnorm_input_cb"),
+        get_named_compile_time_arg_val("rmsnorm_gamma_cb"),
+        get_named_compile_time_arg_val("rmsnorm_output_cb")>;
     using McastCTArgs = deepseek_b1_ops::Mcast::ComputeCTArgs;
 
     // RMSNorm compute runtime args
     deepseek_b1_ops::RMSNorm::ComputeArgs rmsnorm_args{
-        get_named_compile_time_arg_val("rmsnorm_input_cb"),
-        get_named_compile_time_arg_val("rmsnorm_gamma_cb"),
-        get_named_compile_time_arg_val("rmsnorm_output_cb"),
         get_common_arg_val<uint32_t>(0),  // epsilon
         get_common_arg_val<float>(1),     // scalar (1/sqrt(7168))
     };
@@ -536,13 +539,13 @@ void kernel_main() {
     using KV_RMSNormCTArgs = deepseek_b1_ops::RMSNorm::ComputeCTArgs<
         get_named_compile_time_arg_val("rmsnorm_fp32_acc") == 1,
         get_named_compile_time_arg_val("kv_rmsnorm_num_tiles"),
-        get_named_compile_time_arg_val("rmsnorm_rsqrt_fast_approx") == 1>;
+        get_named_compile_time_arg_val("rmsnorm_rsqrt_fast_approx") == 1,
+        get_named_compile_time_arg_val("kv_rmsnorm_input_cb"),
+        get_named_compile_time_arg_val("kv_rmsnorm_gamma_cb"),
+        get_named_compile_time_arg_val("kv_rmsnorm_output_cb")>;
 
     // RMSNorm compute runtime args
     deepseek_b1_ops::RMSNorm::ComputeArgs kv_rmsnorm_args{
-        get_named_compile_time_arg_val("kv_rmsnorm_input_cb"),
-        get_named_compile_time_arg_val("kv_rmsnorm_gamma_cb"),
-        get_named_compile_time_arg_val("kv_rmsnorm_output_cb"),
         get_common_arg_val<uint32_t>(0),  // epsilon
         get_common_arg_val<float>(3),     // kv_scalar (1/sqrt(512))
     };

--- a/models/demos/deepseek_v3_b1/micro_ops/rmsnorm/kernels/rmsnorm_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/micro_ops/rmsnorm/kernels/rmsnorm_kernel.cpp
@@ -47,22 +47,22 @@ void kernel_main() {
     deepseek_b1_ops::RMSNorm::WriterArgs rmsnorm_args{};
 
 #elif defined(COMPILE_FOR_TRISC)
-    // CTArgs type alias (required for Op template)
-    using RMSNormCTArgs = deepseek_b1_ops::RMSNorm::ComputeCTArgs<
-        get_named_compile_time_arg_val("rmsnorm_fp32_acc") == 1,
-        get_named_compile_time_arg_val("rmsnorm_num_tiles"),
-        get_named_compile_time_arg_val("rmsnorm_rsqrt_fast_approx") == 1>;
-
     // Named compile-time args
     constexpr uint32_t input_cb = get_named_compile_time_arg_val("rmsnorm_input_cb");
     constexpr uint32_t gamma_cb = get_named_compile_time_arg_val("rmsnorm_gamma_cb");
     constexpr uint32_t output_cb = get_named_compile_time_arg_val("rmsnorm_output_cb");
 
+    // CTArgs type alias (required for Op template)
+    using RMSNormCTArgs = deepseek_b1_ops::RMSNorm::ComputeCTArgs<
+        get_named_compile_time_arg_val("rmsnorm_fp32_acc") == 1,
+        get_named_compile_time_arg_val("rmsnorm_num_tiles"),
+        get_named_compile_time_arg_val("rmsnorm_rsqrt_fast_approx") == 1,
+        input_cb,
+        gamma_cb,
+        output_cb>;
+
     // Compute args
     deepseek_b1_ops::RMSNorm::ComputeArgs rmsnorm_args{
-        .input_cb = input_cb,
-        .gamma_cb = gamma_cb,
-        .output_cb = output_cb,
         .epsilon = get_common_arg_val<uint32_t>(0),  // epsilon
         .scalar = get_common_arg_val<float>(1),      // scalar (1/sqrt(num_elements))
     };


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
RMSNorm has a dependency of knowing num_faces at compile time. We were previously passing CB ids as compile time args, but storing it in a runtime struct. Compiler was generally able to resolve this properly at compile time, but now when running with profiler, this doesn't seem to get resolved at compile time and ends up failing.

### What's changed
Store the compile time CB ids in the CTA struct instead of the RTA struct.

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=aho/rms-cta)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:aho/rms-cta)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=aho/rms-cta)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:aho/rms-cta)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=aho/rms-cta)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:aho/rms-cta)
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=aho/rms-cta)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:aho/rms-cta)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=aho/rms-cta)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:aho/rms-cta)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=aho/rms-cta)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:aho/rms-cta)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
