### PR TITLE
dispatch: split cq_prefetch into reader (BRISC) and writer (NCRISC) kernels

### DIFF
--- a/tests/scripts/run_cpp_fd2_tests.sh
+++ b/tests/scripts/run_cpp_fd2_tests.sh
@@ -23,6 +23,10 @@ run_test_with_watcher() {
 
     run_test "./build/test/tt_metal/perf_microbenchmark/dispatch/test_prefetcher"
 
+    echo "Running test_prefetcher with split prefetcher..";
+
+    run_test "env TT_METAL_SPLIT_PREFETCHER=1 ./build/test/tt_metal/perf_microbenchmark/dispatch/test_prefetcher --gtest_filter=*SplitPrefetcherJitCompile*"
+
     #############################################
     # TEST_DISPATCHER TESTS                     #
     #############################################

--- a/tests/scripts/run_cpp_fd2_tests.sh
+++ b/tests/scripts/run_cpp_fd2_tests.sh
@@ -3,14 +3,16 @@
 set -eo pipefail
 
 run_test() {
-    echo $1
-    $1
+    printf '%q ' "$@"
+    echo
+    "$@"
     echo
 };
 
 run_test_with_watcher() {
-    echo $1
-    TT_METAL_WATCHER=1 TT_METAL_WATCHER_NOINLINE=1 $1
+    printf '%q ' "$@"
+    echo
+    TT_METAL_WATCHER=1 TT_METAL_WATCHER_NOINLINE=1 "$@"
     echo
 };
 # Unset the variable for these tests
@@ -25,7 +27,11 @@ run_test_with_watcher() {
 
     echo "Running test_prefetcher with split prefetcher..";
 
-    run_test "env TT_METAL_SPLIT_PREFETCHER=1 ./build/test/tt_metal/perf_microbenchmark/dispatch/test_prefetcher --gtest_filter=*SplitPrefetcherJitCompile*"
+    run_test \
+        env \
+        TT_METAL_SPLIT_PREFETCHER=1 \
+        ./build/test/tt_metal/perf_microbenchmark/dispatch/test_prefetcher \
+        '--gtest_filter=*SplitPrefetcherJitCompile*'
 
     #############################################
     # TEST_DISPATCHER TESTS                     #

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
@@ -3057,3 +3057,16 @@ INSTANTIATE_TEST_SUITE_P(
     });
 
 }  // namespace tt::tt_metal::tt_dispatch_tests::prefetcher_tests
+
+namespace tt::tt_metal {
+
+// Verifies that the JIT-compiled dispatch kernels (including cq_prefetch_reader.cpp
+// when TT_METAL_SPLIT_PREFETCHER=1 is set) compile without errors.
+// Run with: TT_METAL_SPLIT_PREFETCHER=1 <binary> --gtest_filter=*SplitPrefetcherJitCompile*
+TEST_F(GenericMeshDeviceFixture, SplitPrefetcherJitCompile) {
+    // No work needed: SetUp() initialises the device, which triggers JIT compilation
+    // of all fast-dispatch kernels.  TearDown() closes it.  A compile failure in any
+    // kernel (e.g. cq_prefetch_reader.cpp) will cause SetUp() to abort.
+}
+
+}  // namespace tt::tt_metal

--- a/tt_metal/impl/dispatch/dispatch_core_common.hpp
+++ b/tt_metal/impl/dispatch/dispatch_core_common.hpp
@@ -23,8 +23,9 @@ enum DispatchWorkerType : uint32_t {
     DISPATCH_H = 6,
     DISPATCH_D = 7,
     DISPATCH_S = 8,
-    FABRIC_MUX = 17,         // Downstream from MMIO to remote mux. Tunnel index is required.
-    RETURN_FABRIC_MUX = 18,  // Upstream from remote to MMIO mux. Tunnel index will be determined from the device id.
+    FABRIC_MUX = 17,          // Downstream from MMIO to remote mux. Tunnel index is required.
+    RETURN_FABRIC_MUX = 18,   // Upstream from remote to MMIO mux. Tunnel index will be determined from the device id.
+    PREFETCH_HD_WRITER = 19,  // Writer stub that runs on NCRISC of the same core as PREFETCH_HD (on BRISC).
     COUNT,
 };
 

--- a/tt_metal/impl/dispatch/kernel_config/fd_kernel.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/fd_kernel.cpp
@@ -17,6 +17,7 @@
 #include "hal_types.hpp"
 #include "kernel_types.hpp"
 #include "prefetch.hpp"
+#include "prefetch_writer.hpp"
 #include "impl/context/context_descriptor.hpp"
 // #include "impl/context/metal_context.hpp"
 #include "kernels/kernel.hpp"
@@ -199,6 +200,19 @@ FDKernel* FDKernel::Generate(
                 get_reads_dispatch_cores);
         case DISPATCH_S:
             return new DispatchSKernel(
+                node_id,
+                device_id,
+                servicing_device_id,
+                cq_id,
+                noc_selection,
+                descriptor,
+                dispatch_core_manager,
+                get_control_plane,
+                get_dispatch_query_manager,
+                get_max_num_eth_cores,
+                get_reads_dispatch_cores);
+        case PREFETCH_HD_WRITER:
+            return new PrefetchWriterKernel(
                 node_id,
                 device_id,
                 servicing_device_id,

--- a/tt_metal/impl/dispatch/kernel_config/fd_kernel.hpp
+++ b/tt_metal/impl/dispatch/kernel_config/fd_kernel.hpp
@@ -79,6 +79,7 @@ static std::vector<std::string> dispatch_kernel_file_names = {
     "tt_metal/impl/dispatch/kernels/vc_packet_router.cpp",         // PACKET_ROUTER_DEMUX
     "tt_metal/fabric/impl/kernels/tt_fabric_mux.cpp",              // FABRIC_MUX
     "tt_metal/fabric/impl/kernels/tt_fabric_mux.cpp",              // FABRIC_RETURN_MUX
+    "tt_metal/impl/dispatch/kernels/cq_prefetch_writer.cpp",       // PREFETCH_HD_WRITER
     ""                                                             // COUNT
 };
 

--- a/tt_metal/impl/dispatch/kernel_config/prefetch.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/prefetch.cpp
@@ -541,10 +541,19 @@ void PrefetchKernel::CreateKernel() {
     defines["OFFSETOF_TO_DEV_ID"] = std::to_string(static_config_.offsetof_to_dev_id.value_or(0));
     defines["OFFSETOF_ROUTER_DIRECTION"] = std::to_string(static_config_.offsetof_router_direction.value_or(0));
 
+    // Stash defines for use by PrefetchWriterKernel (same-core NCRISC stub).
+    kernel_defines_ = defines;
+
+    // When the split-prefetcher mode is active, load the reader-only kernel on BRISC so that the
+    // companion PrefetchWriterKernel can occupy NCRISC of the same core.
+    const bool use_split = is_hd() && MetalContext::instance().rtoptions().get_split_prefetcher();
+    const std::string kernel_path =
+        use_split ? "tt_metal/impl/dispatch/kernels/cq_prefetch_reader.cpp" : dispatch_kernel_file_names[PREFETCH];
+
     // Compile at Os on IERISC to fit in code region.
     auto optimization_level = (GetCoreType() == CoreType::WORKER) ? KernelBuildOptLevel::O2 : KernelBuildOptLevel::Os;
     configure_kernel_variant(
-        dispatch_kernel_file_names[PREFETCH],
+        kernel_path,
         {},
         defines,
         false,

--- a/tt_metal/impl/dispatch/kernel_config/prefetch.hpp
+++ b/tt_metal/impl/dispatch/kernel_config/prefetch.hpp
@@ -5,7 +5,9 @@
 #pragma once
 
 #include <stdint.h>
+#include <map>
 #include <optional>
+#include <string>
 
 #include "core_coord.hpp"
 #include "fd_kernel.hpp"
@@ -117,10 +119,15 @@ public:
 
     const prefetch_static_config_t& GetStaticConfig() { return static_config_; }
 
+    // Returns the compile-time defines map built during CreateKernel(). Used by PrefetchWriterKernel
+    // to compile the writer stub with the same define set as the reader.
+    const std::map<std::string, std::string>& GetDefines() const { return kernel_defines_; }
+
 private:
     prefetch_static_config_t static_config_;
     prefetch_dependent_config_t dependent_config_;
     FDKernelEdmConnectionAttributes edm_connection_attributes_;
+    std::map<std::string, std::string> kernel_defines_;
 
     bool is_hd() const { return static_config_.is_h_variant.value() && static_config_.is_d_variant.value(); }
 };

--- a/tt_metal/impl/dispatch/kernel_config/prefetch_writer.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/prefetch_writer.cpp
@@ -1,0 +1,69 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "prefetch_writer.hpp"
+
+#include <host_api.hpp>
+#include <tt_metal.hpp>
+#include <map>
+#include <string>
+
+#include <tt_stl/assert.hpp>
+#include "device.hpp"
+#include "dispatch/kernel_config/fd_kernel.hpp"
+#include "dispatch/dispatch_settings.hpp"
+#include "dispatch_core_common.hpp"
+#include "hal_types.hpp"
+#include "prefetch.hpp"
+#include "impl/context/metal_context.hpp"
+#include <umd/device/types/core_coordinates.hpp>
+#include <umd/device/types/xy_pair.hpp>
+#include <impl/dispatch/dispatch_mem_map.hpp>
+
+using namespace tt::tt_metal;
+
+PrefetchWriterKernel::PrefetchWriterKernel(
+    int node_id, ChipId device_id, ChipId servicing_device_id, uint8_t cq_id, noc_selection_t noc_selection) :
+    FDKernel(node_id, device_id, servicing_device_id, cq_id, noc_selection) {
+    uint16_t channel = MetalContext::instance().get_cluster().get_assigned_channel_for_device(device_id);
+    // Runs on the same physical core as the upstream PrefetchKernel (BRISC). Core is set in
+    // GenerateStaticConfigs() once the upstream kernel is known.
+    this->logical_core_ =
+        MetalContext::instance().get_dispatch_core_manager().prefetcher_core(device_id, channel, cq_id);
+    this->kernel_type_ = FDKernelType::DISPATCH;
+}
+
+void PrefetchWriterKernel::GenerateStaticConfigs() {
+    // The writer stub has no independent static config: it shares the core and all defines
+    // with the upstream PrefetchKernel. Nothing to do here.
+}
+
+void PrefetchWriterKernel::GenerateDependentConfigs() {
+    TT_ASSERT(upstream_kernels_.size() == 1);
+    auto* prefetch_kernel = dynamic_cast<PrefetchKernel*>(upstream_kernels_[0]);
+    TT_ASSERT(prefetch_kernel, "PrefetchWriterKernel upstream must be a PrefetchKernel");
+    // Confirm we are on the same core.
+    TT_ASSERT(
+        logical_core_ == prefetch_kernel->GetLogicalCore(),
+        "PrefetchWriterKernel must be on the same core as its upstream PrefetchKernel");
+}
+
+void PrefetchWriterKernel::CreateKernel() {
+    TT_ASSERT(upstream_kernels_.size() == 1);
+    auto* prefetch_kernel = dynamic_cast<PrefetchKernel*>(upstream_kernels_[0]);
+    TT_ASSERT(prefetch_kernel, "PrefetchWriterKernel upstream must be a PrefetchKernel");
+
+    // Use the same defines as the reader so both kernels compile with an identical config set.
+    auto defines = prefetch_kernel->GetDefines();
+
+    auto optimization_level = (GetCoreType() == CoreType::WORKER) ? KernelBuildOptLevel::O2 : KernelBuildOptLevel::Os;
+    configure_kernel_variant(
+        dispatch_kernel_file_names[PREFETCH_HD_WRITER],
+        {},
+        defines,
+        false,
+        false,  // send_to_brisc=false => NCRISC (RISCV_1)
+        false,
+        optimization_level);
+}

--- a/tt_metal/impl/dispatch/kernel_config/prefetch_writer.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/prefetch_writer.cpp
@@ -7,6 +7,7 @@
 #include <host_api.hpp>
 #include <tt_metal.hpp>
 #include <map>
+#include <utility>
 
 #include <tt_stl/assert.hpp>
 #include "dispatch/kernel_config/fd_kernel.hpp"
@@ -44,8 +45,8 @@ PrefetchWriterKernel::PrefetchWriterKernel(
         get_max_num_eth_cores,
         get_reads_dispatch_cores) {
     uint16_t channel = descriptor.cluster().get_assigned_channel_for_device(device_id);
-    // Runs on the same physical core as the upstream PrefetchKernel (BRISC). Core is set in
-    // GenerateStaticConfigs() once the upstream kernel is known.
+    // Runs on the same physical core as the upstream PrefetchKernel (BRISC). The core is selected here
+    // via the dispatch core manager and is verified against the upstream kernel in GenerateDependentConfigs().
     this->logical_core_ = dispatch_core_manager.prefetcher_core(device_id, channel, cq_id);
     this->kernel_type_ = FDKernelType::DISPATCH;
 }
@@ -77,7 +78,7 @@ void PrefetchWriterKernel::CreateKernel() {
     configure_kernel_variant(
         dispatch_kernel_file_names[PREFETCH_HD_WRITER],
         {},
-        defines,
+        std::move(defines),
         false,
         false,  // send_to_brisc=false => NCRISC (RISCV_1)
         false,

--- a/tt_metal/impl/dispatch/kernel_config/prefetch_writer.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/prefetch_writer.cpp
@@ -7,14 +7,10 @@
 #include <host_api.hpp>
 #include <tt_metal.hpp>
 #include <map>
-#include <string>
 
 #include <tt_stl/assert.hpp>
-#include "device.hpp"
 #include "dispatch/kernel_config/fd_kernel.hpp"
 #include "dispatch/dispatch_settings.hpp"
-#include "dispatch_core_common.hpp"
-#include "hal_types.hpp"
 #include "prefetch.hpp"
 #include "impl/context/metal_context.hpp"
 #include <umd/device/types/core_coordinates.hpp>
@@ -24,13 +20,33 @@
 using namespace tt::tt_metal;
 
 PrefetchWriterKernel::PrefetchWriterKernel(
-    int node_id, ChipId device_id, ChipId servicing_device_id, uint8_t cq_id, noc_selection_t noc_selection) :
-    FDKernel(node_id, device_id, servicing_device_id, cq_id, noc_selection) {
-    uint16_t channel = MetalContext::instance().get_cluster().get_assigned_channel_for_device(device_id);
+    int node_id,
+    ChipId device_id,
+    ChipId servicing_device_id,
+    uint8_t cq_id,
+    noc_selection_t noc_selection,
+    const ContextDescriptor& descriptor,
+    dispatch_core_manager& dispatch_core_manager,
+    const GetControlPlaneFn& get_control_plane,
+    const GetDispatchQueryManagerFn& get_dispatch_query_manager,
+    const GetMaxNumEthCoresFn& get_max_num_eth_cores,
+    const GetReadsDispatchCoresFn& get_reads_dispatch_cores) :
+    FDKernel(
+        node_id,
+        device_id,
+        servicing_device_id,
+        cq_id,
+        noc_selection,
+        descriptor,
+        dispatch_core_manager,
+        get_control_plane,
+        get_dispatch_query_manager,
+        get_max_num_eth_cores,
+        get_reads_dispatch_cores) {
+    uint16_t channel = descriptor.cluster().get_assigned_channel_for_device(device_id);
     // Runs on the same physical core as the upstream PrefetchKernel (BRISC). Core is set in
     // GenerateStaticConfigs() once the upstream kernel is known.
-    this->logical_core_ =
-        MetalContext::instance().get_dispatch_core_manager().prefetcher_core(device_id, channel, cq_id);
+    this->logical_core_ = dispatch_core_manager.prefetcher_core(device_id, channel, cq_id);
     this->kernel_type_ = FDKernelType::DISPATCH;
 }
 

--- a/tt_metal/impl/dispatch/kernel_config/prefetch_writer.hpp
+++ b/tt_metal/impl/dispatch/kernel_config/prefetch_writer.hpp
@@ -1,0 +1,28 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <stdint.h>
+
+#include "fd_kernel.hpp"
+#include "impl/context/metal_context.hpp"
+#include <umd/device/types/xy_pair.hpp>
+
+namespace tt::tt_metal {
+
+// PrefetchWriterKernel runs on NCRISC of the same Tensix core as PrefetchKernel (BRISC).
+// It receives the identical set of compile-time defines as the reader so that both kernels
+// share the same configuration space. Currently a stub intended for future write-path work.
+class PrefetchWriterKernel : public FDKernel {
+public:
+    PrefetchWriterKernel(
+        int node_id, ChipId device_id, ChipId servicing_device_id, uint8_t cq_id, noc_selection_t noc_selection);
+
+    void CreateKernel() override;
+    void GenerateStaticConfigs() override;
+    void GenerateDependentConfigs() override;
+};
+
+}  // namespace tt::tt_metal

--- a/tt_metal/impl/dispatch/kernel_config/prefetch_writer.hpp
+++ b/tt_metal/impl/dispatch/kernel_config/prefetch_writer.hpp
@@ -18,7 +18,17 @@ namespace tt::tt_metal {
 class PrefetchWriterKernel : public FDKernel {
 public:
     PrefetchWriterKernel(
-        int node_id, ChipId device_id, ChipId servicing_device_id, uint8_t cq_id, noc_selection_t noc_selection);
+        int node_id,
+        ChipId device_id,
+        ChipId servicing_device_id,
+        uint8_t cq_id,
+        noc_selection_t noc_selection,
+        const ContextDescriptor& descriptor,
+        dispatch_core_manager& dispatch_core_manager,
+        const GetControlPlaneFn& get_control_plane,
+        const GetDispatchQueryManagerFn& get_dispatch_query_manager,
+        const GetMaxNumEthCoresFn& get_max_num_eth_cores,
+        const GetReadsDispatchCoresFn& get_reads_dispatch_cores);
 
     void CreateKernel() override;
     void GenerateStaticConfigs() override;

--- a/tt_metal/impl/dispatch/kernels/cq_prefetch_reader.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_prefetch_reader.cpp
@@ -23,7 +23,7 @@
 #include "api/debug/dprint.h"
 #include "noc/noc_parameters.h"  // PCIE_ALIGNMENT
 
-constexpr uint32_t CQ_PREFETCH_CMD_BARE_MIN_SIZE = PCIE_ALIGNMENT;  // for NOC PCIe alignemnt
+constexpr uint32_t CQ_PREFETCH_CMD_BARE_MIN_SIZE = PCIE_ALIGNMENT;  // for NOC PCIe alignment
 static_assert(sizeof(CQPrefetchCmd) <= CQ_PREFETCH_CMD_BARE_MIN_SIZE);
 static_assert(sizeof(CQPrefetchCmdLarge) <= CQ_PREFETCH_CMD_BARE_MIN_SIZE);
 struct CQPrefetchHToPrefetchDHeader_s {
@@ -1052,19 +1052,17 @@ void kernel_main() {
     to_dev_id = get_arg_val<uint32_t>(OFFSETOF_TO_DEV_ID);
     router_direction = get_arg_val<uint32_t>(OFFSETOF_ROUTER_DIRECTION);
 
+    static_assert(is_d_variant, "cq_prefetch_reader only supports _hd and _d variants; _h is excluded");
     if (is_h_variant and is_d_variant) {
         kernel_main_hd();
-    } else if (is_d_variant) {
-        kernel_main_d();
     } else {
-        ASSERT(0);
+        kernel_main_d();
     }
     IDLE_ERISC_RETURN();
 
-    // The reader stub never writes pages to the downstream CB (all relay functions are
-    // stubbed), so the CBWriter's page accounting is always at its initial state and
-    // wait_all_pages would hang waiting for credits that never arrive.  Skip it here;
-    // the writer (NCRISC) sends the terminate directly to the dispatcher instead.
+    // Termination is driven out-of-band by the writer (NCRISC) which sends
+    // CQ_DISPATCH_CMD_TERMINATE directly to the dispatchers. The normal
+    // wait_all_pages() drain is therefore skipped here.
 
     noc_async_full_barrier();
 

--- a/tt_metal/impl/dispatch/kernels/cq_prefetch_reader.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_prefetch_reader.cpp
@@ -19,9 +19,13 @@
 #include "internal/dataflow/dataflow_api_addrgen.h"
 #include "tt_metal/impl/dispatch/kernels/cq_commands.hpp"
 #include "tt_metal/impl/dispatch/kernels/cq_common.hpp"
+#include "tt_metal/impl/dispatch/kernels/cq_prefetch.hpp"
 #include "tt_metal/impl/dispatch/kernels/cq_relay.hpp"
 #include "api/debug/dprint.h"
 #include "noc/noc_parameters.h"  // PCIE_ALIGNMENT
+
+#include <array>
+#include <cstdint>
 
 constexpr uint32_t CQ_PREFETCH_CMD_BARE_MIN_SIZE = PCIE_ALIGNMENT;  // for NOC PCIe alignment
 static_assert(sizeof(CQPrefetchCmd) <= CQ_PREFETCH_CMD_BARE_MIN_SIZE);
@@ -244,7 +248,7 @@ CQRelayClient<fabric_mux_num_buffers_per_channel, fabric_mux_channel_buffer_size
     relay_client;
 
 // Feature to stall the prefetcher, mainly for ExecBuf impl which reuses CmdDataQ
-static enum StallState { STALL_NEXT = 2, STALLED = 1, NOT_STALLED = 0 } stall_state = NOT_STALLED;
+static enum class StallState : uint32_t { STALLED = 1U, NOT_STALLED = 0U } stall_state = StallState::NOT_STALLED;
 
 static_assert((downstream_cb_base & (downstream_cb_page_size - 1)) == 0);
 
@@ -288,34 +292,41 @@ FORCE_INLINE void write_downstream(
     local_downstream_data_ptr += length;
 }
 
-// If prefetcher must stall after this fetch, wait for data to come back, and move to stalled state.
-FORCE_INLINE void barrier_and_stall(uint32_t& pending_read_size, uint32_t& fence, uint32_t& cmd_ptr) {
-    noc_async_read_barrier();
-    if (fence < cmd_ptr) {
-        cmd_ptr = fence;
-    }
-    fence += pending_read_size;
-    pending_read_size = 0;
-    stall_state = STALLED;
-}
-
 template <uint32_t preamble_size>
 FORCE_INLINE uint32_t read_from_pcie(
     volatile tt_l1_ptr prefetch_q_entry_type*& prefetch_q_rd_ptr,
     uint32_t& fence,
     uint32_t& pcie_read_ptr,
-    uint32_t cmd_ptr,
-    uint32_t size) {
-    uint32_t pending_read_size = 0;
+    const uint32_t cmd_ptr,
+    const uint32_t size,
+    const uint32_t trid,
+    const bool queue_empty) {
+    uint32_t pending_read_size = 0U;
+
     // Wrap cmddat_q
-    if (fence + size + preamble_size > cmddat_q_end) {
-        // only wrap if there are no commands ready, otherwise we'll leave some on the floor
-        // TODO: does this matter for perf?
-        if (cmd_ptr != fence) {
-            // No pending reads, since the location of fence cannot be moved due to unread commands
-            // in the cmddat_q -> reads cannot be issued to fill the queue.
+    const uint32_t needed_bytes = size + preamble_size;
+    // If cmd_ptr == fence, the ring is either EMPTY or FULL. The caller must disambiguate via `queue_empty`.
+    if ((cmd_ptr == fence) && !queue_empty) {
+        return pending_read_size;
+    }
+
+    if (cmd_ptr > fence) {
+        // Producer has wrapped behind consumer: free space is the contiguous region [fence .. cmd_ptr).
+        // Ensure we don't overwrite unread commands.
+        const uint32_t available_bytes = cmd_ptr - fence;
+        if (needed_bytes > available_bytes) {
             return pending_read_size;
         }
+    } else if (fence + needed_bytes > cmddat_q_end) {
+        // Not enough space at the end. Wrap to the beginning if there is sufficient free space.
+        // If the ring is empty (no committed/unread commands and no reads in flight), we can always reset to the base
+        // and use the full contiguous buffer space.
+        const uint32_t available_bytes_at_beginning =
+            queue_empty ? (cmddat_q_end - cmddat_q_base) : (cmd_ptr - cmddat_q_base);
+        if (needed_bytes > available_bytes_at_beginning) {
+            return pending_read_size;
+        }
+
         fence = cmddat_q_base;
     }
 
@@ -324,132 +335,193 @@ FORCE_INLINE uint32_t read_from_pcie(
         pcie_read_ptr = pcie_base;
     }
 
-    uint64_t host_src_addr = pcie_noc_xy | pcie_read_ptr;
-    // DPRINT << "read_from_pcie: " << fence + preamble_size << " " << pcie_read_ptr << ENDL();
-    noc_async_read(host_src_addr, fence + preamble_size, size);
-    pending_read_size = size + preamble_size;
+    const uint64_t host_src_addr = pcie_noc_xy | pcie_read_ptr;
+    const uint32_t dst_addr = fence + preamble_size;
+    noc_async_read_set_trid(trid);
+    noc_async_read(host_src_addr, dst_addr, size);
+    // Avoid leaking this trid to unrelated reads.
+    noc_async_read_set_trid(0U);
+    pending_read_size = needed_bytes;
     pcie_read_ptr += size;
 
-    *prefetch_q_rd_ptr = 0;
+    *prefetch_q_rd_ptr = 0U;
 
     // Tell host we read
-    *(volatile tt_l1_ptr uint32_t*)prefetch_q_rd_ptr_addr = (uint32_t)prefetch_q_rd_ptr;
-    *(volatile tt_l1_ptr uint32_t*)prefetch_q_pcie_rd_ptr_addr = (uint32_t)pcie_read_ptr;
+    *reinterpret_cast<volatile tt_l1_ptr uint32_t*>(prefetch_q_rd_ptr_addr) =
+        reinterpret_cast<uintptr_t>(prefetch_q_rd_ptr);
+    *reinterpret_cast<volatile tt_l1_ptr uint32_t*>(prefetch_q_pcie_rd_ptr_addr) = pcie_read_ptr;
 
-    prefetch_q_rd_ptr++;
+    ++prefetch_q_rd_ptr;
 
     // Wrap prefetch_q
-    if ((uint32_t)prefetch_q_rd_ptr == prefetch_q_end) {
-        prefetch_q_rd_ptr = (volatile tt_l1_ptr prefetch_q_entry_type*)prefetch_q_base;
+    if (reinterpret_cast<uintptr_t>(prefetch_q_rd_ptr) == prefetch_q_end) {
+        prefetch_q_rd_ptr = reinterpret_cast<volatile tt_l1_ptr prefetch_q_entry_type*>(prefetch_q_base);
     }
     return pending_read_size;
 }
 
-// This routine can be called in 8 states based on the boolean values cmd_ready, prefetch_q_ready, read_pending:
-//  - !cmd_ready, !prefetch_q_ready, !read_pending: stall on prefetch_q, issue read, read barrier
-//  - !cmd_ready, !prefetch_q_ready,  read pending: read barrier (and re-evaluate prefetch_q_ready)
-//  - !cmd_ready,  prefetch_q_ready, !read_pending: issue read, read barrier
-//  - !cmd_ready,  prefetch_q_ready,  read_pending: read barrier, issue read
-//  -  cmd_ready, !prefetch_q_ready, !read_pending: exit
-//  -  cmd_ready, !prefetch_q_ready,  read_pending: exit (no barrier yet)
-//  -  cmd_ready,  prefetch_q_ready, !read_pending: issue read
-//  -  cmd_ready,  prefetch_q_ready,  read_pending: exit (don't add latency to the in flight request)
-//
-// With WH tagging of reads:
-// open question: should fetcher loop on prefetch_q_ready issuing reads until !prefetch_q_ready
-//  - !cmd_ready, !prefetch_q_ready, !read_pending: stall on prefetch_q, issue read, read barrier
-//  - !cmd_ready, !prefetch_q_ready,  read pending: read barrier on oldest tag
-//  - !cmd_ready,  prefetch_q_ready, !read_pending: issue read, read barrier
-//  - !cmd_ready,  prefetch_q_ready,  read_pending: issue read, read barrier on oldest tag
-//  -  cmd_ready, !prefetch_q_ready, !read_pending: exit
-//  -  cmd_ready, !prefetch_q_ready,  read_pending: exit (no barrier yet)
-//  -  cmd_ready,  prefetch_q_ready, !read_pending: issue and tag read
-//  -  cmd_ready,  prefetch_q_ready,  read_pending: issue and tag read
 template <uint32_t preamble_size>
 void fetch_q_get_cmds(uint32_t& fence, uint32_t& cmd_ptr, uint32_t& pcie_read_ptr) {
-    static uint32_t pending_read_size = 0;
+    static constexpr uint32_t INFLIGHT_MASK = tt::tt_metal::PrefetchConstants::PREFETCH_MAX_OUTSTANDING_PCIE_READS - 1U;
+    enum class InflightFlags : uint32_t { NOSTALL = 0x0U, STALL_AFTER = 0x1U };
+    struct InflightRead {
+        uint32_t read_start;     // where the read's preamble begins (payload at read_start + preamble)
+        uint32_t trid;           // NoC transaction ID
+        uint32_t reserved_size;  // payload + preamble (bytes to advance committed fence)
+        InflightFlags flags;     // inflight flags
+    };
+
+    // Circular queue: only head + count are needed; tail is derived.
+    static std::array<InflightRead, tt::tt_metal::PrefetchConstants::PREFETCH_MAX_OUTSTANDING_PCIE_READS> inflight;
+    static uint32_t inflight_count = 0U;
+    static uint32_t inflight_head = 0U;
+
+    // Reserve trid 0/1 for other traffic (0 is the default; 1 is used by exec_buf DRAM reads).
+    // Keep TRIDs unique across in-flight reads so retirement barriers only wait for the oldest read.
+    static constexpr uint32_t MIN_TRID = 2U;
+    static constexpr std::array<uint32_t, tt::tt_metal::PrefetchConstants::PREFETCH_MAX_OUTSTANDING_PCIE_READS>
+        PREFETCH_TRIDS = {{
+            MIN_TRID,
+            MIN_TRID + 1U,
+            MIN_TRID + 2U,
+            MIN_TRID + 3U,
+        }};
+    static_assert((PREFETCH_TRIDS.size() & (PREFETCH_TRIDS.size() - 1U)) == 0U);  // power-of-two for masking
+    static_assert(tt::tt_metal::PrefetchConstants::PREFETCH_MAX_OUTSTANDING_PCIE_READS <= PREFETCH_TRIDS.size());
+
+    static uint32_t next_trid_idx = 0U;
+
+    // End of reserved (possibly-not-yet-committed) region in cmddat_q for issued reads.
+    // `fence` remains the committed boundary used for cmd_ready checks.
+    static uint32_t issue_fence = cmddat_q_base;
     static volatile tt_l1_ptr prefetch_q_entry_type* prefetch_q_rd_ptr =
         (volatile tt_l1_ptr prefetch_q_entry_type*)prefetch_q_base;
-    constexpr uint32_t prefetch_q_msb_mask = 1u << (sizeof(prefetch_q_entry_type) * CHAR_BIT - 1);
+    static constexpr uint32_t prefetch_q_msb_mask = 1u << (sizeof(prefetch_q_entry_type) * CHAR_BIT - 1U);
 
-    if (stall_state == STALLED) {
-        ASSERT(pending_read_size == 0);  // Before stalling, fetch must have been completed.
+    if (stall_state == StallState::STALLED) {
+        ASSERT(inflight_count == 0U);  // Before stalling, all reads must have been completed.
+        ASSERT(issue_fence == fence);
         return;
     }
 
-    // DPRINT << "fetch_q_get_cmds: " << cmd_ptr << " " << fence << ENDL();
+    // If the committed fence wrapped behind cmd_ptr (e.g., after retiring a wrapped read), cmd_ptr may still be in the
+    // old (high) region because it only advances when consuming commands. Numerically fence < cmd_ptr.
+    // Snap cmd_ptr to fence so the committed unread region [cmd_ptr, fence) remains contiguous/correct.
     if (fence < cmd_ptr) {
         cmd_ptr = fence;
     }
 
-    bool cmd_ready = (cmd_ptr != fence);
+    while (true) {
+        // At this point cmd_ptr <= fence and the contiguous set of commands from cmd_ptr to fence are valid, because
+        // neither cmd_ptr nor fence will be wrapped. Whenever wrapping of fence happens, cmd_ptr will also be wrapped.
+        // So if cmd_ptr == fence, then there are no ready commands. This is different from issue_fence, which may wrap
+        // earlier.
+        const bool cmd_ready = (cmd_ptr != fence);
 
-    uint32_t prefetch_q_rd_ptr_local = *prefetch_q_rd_ptr;
-    uint32_t fetch_size = (prefetch_q_rd_ptr_local & ~prefetch_q_msb_mask) << prefetch_q_log_minsize;
-    bool stall_flag = (prefetch_q_rd_ptr_local & prefetch_q_msb_mask) != 0;
-    stall_state = static_cast<StallState>(stall_flag << 1);  // NOT_STALLED -> STALL_NEXT if stall_flag is set
+        // If a stall-after read is already in-flight, we must not consume/issue beyond it.
+        bool has_pending_stall_after = false;
+        if (inflight_count != 0U) {
+            const uint32_t inflight_last = (inflight_head + inflight_count - 1U) & INFLIGHT_MASK;
+            has_pending_stall_after = (inflight[inflight_last].flags == InflightFlags::STALL_AFTER);
+        }
 
-    if (fetch_size != 0 && pending_read_size == 0) {
-        pending_read_size = read_from_pcie<preamble_size>(prefetch_q_rd_ptr, fence, pcie_read_ptr, cmd_ptr, fetch_size);
-        if (stall_state == STALL_NEXT && pending_read_size != 0) {
-            // No pending reads -> stall_state can be set to STALLED, since the read to the cmd
-            // that initiated the stall has been issued.
-            // exec_buf is the first command being fetched and should be offset
-            // by preamble size. After ensuring that the exec_buf command has been read (barrier),
-            // exit.
-            barrier_and_stall(pending_read_size, fence, cmd_ptr);  // STALL_NEXT -> STALLED
+        // Fast path: when commands are ready and we cannot issue any more reads, return immediately.
+        // (Avoids extra volatile PrefetchQ polling / decode on the steady-state path.)
+        if (cmd_ready && (has_pending_stall_after ||
+                          (inflight_count == tt::tt_metal::PrefetchConstants::PREFETCH_MAX_OUTSTANDING_PCIE_READS))) {
             return;
         }
-    }
-    if (!cmd_ready) {
-        if (pending_read_size != 0) {
-            noc_async_read_barrier();
-            // wrap the cmddat_q
-            if (fence < cmd_ptr) {
-                cmd_ptr = fence;
-            }
 
-            fence += pending_read_size;
-            pending_read_size = 0;
+        // Local helper for reading the current prefetch_q entry.
+        uint32_t prefetch_q_rd_ptr_local = *prefetch_q_rd_ptr;
+        uint32_t fetch_size = (prefetch_q_rd_ptr_local & ~prefetch_q_msb_mask) << prefetch_q_log_minsize;
+        bool stall_flag = (prefetch_q_rd_ptr_local & prefetch_q_msb_mask) != 0U;
 
-            // After the stall, re-check the host
-            prefetch_q_rd_ptr_local = *prefetch_q_rd_ptr;
-            fetch_size = (prefetch_q_rd_ptr_local & ~prefetch_q_msb_mask) << prefetch_q_log_minsize;
+        // Issue tagged reads (up to MAX_OUTSTANDING_READS) whenever host has work and there is capacity.
+        // Stop once we encounter a stall_flag entry (do not prefetch beyond it).
+        if (!has_pending_stall_after) {
+            while ((fetch_size != 0U) &&
+                   (inflight_count < tt::tt_metal::PrefetchConstants::PREFETCH_MAX_OUTSTANDING_PCIE_READS)) {
+                const uint32_t this_trid = PREFETCH_TRIDS[next_trid_idx];
+                uint32_t total_size = 0U;
+                const uint32_t idx = (inflight_head + inflight_count) & INFLIGHT_MASK;
+                const bool queue_empty = (inflight_count == 0U) && !cmd_ready;
 
-            if (fetch_size != 0) {
-                stall_flag = (prefetch_q_rd_ptr_local & prefetch_q_msb_mask) != 0;
-                stall_state =
-                    static_cast<StallState>(stall_flag << 1);  // NOT_STALLED -> STALL_NEXT if stall_flag is set
+                total_size = read_from_pcie<preamble_size>(
+                    prefetch_q_rd_ptr, issue_fence, pcie_read_ptr, cmd_ptr, fetch_size, this_trid, queue_empty);
 
-                if (stall_state == STALL_NEXT) {
-                    // If the prefetcher state reached here, it is issuing a read to the same "slot", since for exec_buf
-                    // commands we will insert a read barrier. Hence, the exec_buf command will be concatenated to a
-                    // previous command, and should not be offset by preamble size.
-                    pending_read_size = read_from_pcie<0>(prefetch_q_rd_ptr, fence, pcie_read_ptr, cmd_ptr, fetch_size);
-                    if (pending_read_size != 0) {
-                        // if pending_read_size == 0 read_from_pcie early exited, due to a wrap, i.e. the exec_buf cmd
-                        // is at a wrapped location, and a read to it could not be issued, since there are existing
-                        // commands in the cmddat_q. Only move the stall_state to stalled if the read to the cmd that
-                        // initiated the stall was issued
-                        barrier_and_stall(pending_read_size, fence, cmd_ptr);  // STALL_NEXT -> STALLED
-                    }
-                } else {
-                    pending_read_size =
-                        read_from_pcie<preamble_size>(prefetch_q_rd_ptr, fence, pcie_read_ptr, cmd_ptr, fetch_size);
+                if (total_size == 0U) {
+                    // Could not issue due to cmddat_q wrap restriction. Do not consume host entry; retry later.
+                    break;
                 }
+
+                // `issue_fence` may have been wrapped inside read_from_pcie before issuing the read.
+                const uint32_t read_fence = issue_fence;
+
+                inflight[idx].read_start = read_fence;
+                inflight[idx].trid = this_trid;
+                inflight[idx].reserved_size = total_size;
+                inflight[idx].flags = stall_flag ? InflightFlags::STALL_AFTER : InflightFlags::NOSTALL;
+                ++inflight_count;
+
+                // Advance reservation pointer for the next issue.
+                issue_fence += total_size;
+
+                // Cycle through PREFETCH_TRIDS.
+                next_trid_idx = (next_trid_idx + 1U) & (static_cast<uint32_t>(PREFETCH_TRIDS.size()) - 1U);
+
+                // Stop issuing reads beyond a stall entry. We'll stall when this read is retired.
+                if (stall_flag) {
+                    break;
+                }
+
+                // Refresh host state for potential next issue.
+                prefetch_q_rd_ptr_local = *prefetch_q_rd_ptr;
+                fetch_size = (prefetch_q_rd_ptr_local & ~prefetch_q_msb_mask) << prefetch_q_log_minsize;
+                stall_flag = (prefetch_q_rd_ptr_local & prefetch_q_msb_mask) != 0U;
             }
-        } else {
-            // By here, prefetch_q_ready must be false
-            // Nothing to fetch, nothing pending, nothing available, stall on host
-            WAYPOINT("HQW");
-            uint32_t heartbeat = 0;
-            while ((fetch_size = *prefetch_q_rd_ptr) == 0) {
-                invalidate_l1_cache();
-                IDLE_ERISC_HEARTBEAT_AND_RETURN(heartbeat);
-            }
-            fetch_q_get_cmds<preamble_size>(fence, cmd_ptr, pcie_read_ptr);
-            WAYPOINT("HQD");
         }
+
+        // If no commands are ready, retire the oldest in-flight read to advance the committed fence.
+        // This preserves correctness: the main loop expects data to be present after fetch_q_get_cmds returns.
+        if (!cmd_ready) {
+            if (inflight_count != 0U) {
+                const uint32_t idx = inflight_head;
+
+                noc_async_read_barrier_with_trid(inflight[idx].trid);
+
+                cmd_ptr = inflight[idx].read_start;
+                fence = inflight[idx].read_start + inflight[idx].reserved_size;
+
+                inflight_head = (inflight_head + 1U) & INFLIGHT_MASK;
+                --inflight_count;
+
+                // If this was a stall-after read, transition to STALLED now (exec_buf is next).
+                if (inflight[idx].flags == InflightFlags::STALL_AFTER) {
+                    ASSERT(inflight_count == 0U);
+                    ASSERT(issue_fence == fence);
+                    stall_state = StallState::STALLED;
+                    return;
+                }
+
+                // We just advanced the committed fence (made commands available). Restart the loop so we can
+                // opportunistically top up the in-flight window using the unified issue logic, without duplicating a
+                // separate "re-check" issue path.
+                continue;
+            } else {
+                // Nothing to fetch, nothing pending, nothing available, stall on host
+                WAYPOINT("HQW");
+                uint32_t heartbeat = 0U;
+                while ((fetch_size = *prefetch_q_rd_ptr) == 0U) {
+                    invalidate_l1_cache();
+                    IDLE_ERISC_HEARTBEAT_AND_RETURN(heartbeat);
+                }
+                // Host has work now; restart without recursion.
+                continue;
+            }
+        }
+
+        return;
     }
 }
 
@@ -733,10 +805,10 @@ bool process_cmd(
             // DPRINT << "exec buf: " << cmd_ptr << ENDL();
             ASSERT(!exec_buf);
             if (is_h_variant) {
-                ASSERT(stall_state == STALLED);  // ExecBuf must be preceded by a prefetcher stall
+                ASSERT(stall_state == StallState::STALLED);  // ExecBuf must be preceded by a prefetcher stall
             }
             stride = process_exec_buf_cmd(cmd_ptr, downstream_data_ptr, l1_cache, exec_buf_state);
-            stall_state = NOT_STALLED;  // Stall is no longer required after ExecBuf finished.
+            stall_state = StallState::NOT_STALLED;  // Stall is no longer required after ExecBuf finished.
             break;
 
         case CQ_PREFETCH_CMD_EXEC_BUF_END:

--- a/tt_metal/impl/dispatch/kernels/cq_prefetch_reader.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_prefetch_reader.cpp
@@ -136,7 +136,8 @@ constexpr uint8_t my_noc_index = NOC_INDEX;
 constexpr uint32_t my_noc_xy = uint32_t(NOC_XY_ENCODING(MY_NOC_X, MY_NOC_Y));
 constexpr uint32_t upstream_noc_xy = uint32_t(NOC_XY_ENCODING(UPSTREAM_NOC_X, UPSTREAM_NOC_Y));
 constexpr uint32_t downstream_noc_xy = uint32_t(NOC_XY_ENCODING(DOWNSTREAM_NOC_X, DOWNSTREAM_NOC_Y));
-constexpr uint32_t dispatch_s_noc_xy = uint32_t(NOC_XY_ENCODING(DOWNSTREAM_SUBORDINATE_NOC_X, DOWNSTREAM_SUBORDINATE_NOC_Y));
+constexpr uint32_t dispatch_s_noc_xy =
+    uint32_t(NOC_XY_ENCODING(DOWNSTREAM_SUBORDINATE_NOC_X, DOWNSTREAM_SUBORDINATE_NOC_Y));
 constexpr uint64_t pcie_noc_xy =
     uint64_t(NOC_XY_PCIE_ENCODING(NOC_X_PHYS_COORD(PCIE_NOC_X), NOC_Y_PHYS_COORD(PCIE_NOC_Y)));
 constexpr uint32_t downstream_cb_page_size = 1 << downstream_cb_log_page_size;
@@ -424,19 +425,17 @@ void fetch_q_get_cmds(uint32_t& fence, uint32_t& cmd_ptr, uint32_t& pcie_read_pt
                     // If the prefetcher state reached here, it is issuing a read to the same "slot", since for exec_buf
                     // commands we will insert a read barrier. Hence, the exec_buf command will be concatenated to a
                     // previous command, and should not be offset by preamble size.
-                    pending_read_size = read_from_pcie<0>(
-                        prefetch_q_rd_ptr, fence, pcie_read_ptr, cmd_ptr, fetch_size);
+                    pending_read_size = read_from_pcie<0>(prefetch_q_rd_ptr, fence, pcie_read_ptr, cmd_ptr, fetch_size);
                     if (pending_read_size != 0) {
                         // if pending_read_size == 0 read_from_pcie early exited, due to a wrap, i.e. the exec_buf cmd
                         // is at a wrapped location, and a read to it could not be issued, since there are existing
                         // commands in the cmddat_q. Only move the stall_state to stalled if the read to the cmd that
                         // initiated the stall was issued
-                        barrier_and_stall(
-                            pending_read_size, fence, cmd_ptr);  // STALL_NEXT -> STALLED
+                        barrier_and_stall(pending_read_size, fence, cmd_ptr);  // STALL_NEXT -> STALLED
                     }
                 } else {
-                    pending_read_size = read_from_pcie<preamble_size>(
-                        prefetch_q_rd_ptr, fence, pcie_read_ptr, cmd_ptr, fetch_size);
+                    pending_read_size =
+                        read_from_pcie<preamble_size>(prefetch_q_rd_ptr, fence, pcie_read_ptr, cmd_ptr, fetch_size);
                 }
             }
         } else {
@@ -538,8 +537,7 @@ uint32_t process_relay_paged_cmd(uint32_t cmd_ptr, uint32_t& downstream__data_pt
 }
 
 // Similar to relay_paged, this iterates and aggregates reads from multiple embedded relay_paged cmds
-void process_relay_paged_packed_sub_cmds(uint32_t total_length, uint32_t* l1_cache) {
-}
+void process_relay_paged_packed_sub_cmds(uint32_t total_length, uint32_t* l1_cache) {}
 
 template <bool cmddat_wrap_enable>
 uint32_t process_relay_paged_packed_cmd(uint32_t cmd_ptr, uint32_t& downstream__data_ptr, uint32_t* l1_cache) {
@@ -581,13 +579,10 @@ uint32_t process_relay_linear_cmd(uint32_t cmd_ptr, uint32_t& downstream_data_pt
     return CQ_PREFETCH_CMD_BARE_MIN_SIZE;
 }
 
-uint32_t process_stall(uint32_t cmd_ptr) {
-    return CQ_PREFETCH_CMD_BARE_MIN_SIZE;
-}
+uint32_t process_stall(uint32_t cmd_ptr) { return CQ_PREFETCH_CMD_BARE_MIN_SIZE; }
 
 // This function reads data from the DRAM and populates the cmddat_q l1 buffer.
-void paged_read_into_cmddat_q(uint32_t& cmd_ptr, PrefetchExecBufState& exec_buf_state) {
-}
+void paged_read_into_cmddat_q(uint32_t& cmd_ptr, PrefetchExecBufState& exec_buf_state) {}
 
 // processes the relay_inline cmd from an exec_buf
 // Separate implementation that fetches more data from exec buf when cmd has been split
@@ -632,12 +627,9 @@ uint32_t process_paged_to_ringbuffer_cmd(uint32_t cmd_ptr, uint32_t& downstream_
     return CQ_PREFETCH_CMD_BARE_MIN_SIZE;
 }
 
-uint32_t process_set_ringbuffer_offset(uint32_t cmd_ptr) {
-    return CQ_PREFETCH_CMD_BARE_MIN_SIZE;
-}
+uint32_t process_set_ringbuffer_offset(uint32_t cmd_ptr) { return CQ_PREFETCH_CMD_BARE_MIN_SIZE; }
 
-void process_relay_ringbuffer_sub_cmds(uint32_t count, uint32_t* l1_cache) {
-}
+void process_relay_ringbuffer_sub_cmds(uint32_t count, uint32_t* l1_cache) {}
 
 template <bool cmddat_wrap_enable>
 uint32_t process_relay_ringbuffer_cmd(uint32_t cmd_ptr, uint32_t& downstream__data_ptr, uint32_t* l1_cache) {
@@ -652,8 +644,7 @@ static uint32_t process_exec_buf_relay_ringbuffer_cmd(
     return cmd->relay_ringbuffer.stride;
 }
 
-void process_relay_linear_packed_sub_cmds(uint32_t noc_xy_addr, uint32_t total_length, uint32_t* l1_cache) {
-}
+void process_relay_linear_packed_sub_cmds(uint32_t noc_xy_addr, uint32_t total_length, uint32_t* l1_cache) {}
 
 template <bool cmddat_wrap_enable>
 uint32_t process_relay_linear_packed_cmd(uint32_t cmd_ptr, uint32_t& downstream_data_ptr, uint32_t* l1_cache) {
@@ -1045,7 +1036,6 @@ void kernel_main_hd() {
         done = process_cmd<false, false>(cmd_ptr, downstream_data_ptr, stride, l1_cache, exec_buf_state);
         cmd_ptr += stride;
     }
-
 }
 
 void kernel_main() {

--- a/tt_metal/impl/dispatch/kernels/cq_prefetch_reader.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_prefetch_reader.cpp
@@ -1045,6 +1045,7 @@ void kernel_main_hd() {
         done = process_cmd<false, false>(cmd_ptr, downstream_data_ptr, stride, l1_cache, exec_buf_state);
         cmd_ptr += stride;
     }
+
 }
 
 void kernel_main() {
@@ -1070,8 +1071,10 @@ void kernel_main() {
     }
     IDLE_ERISC_RETURN();
 
-    // Confirm expected number of pages, spinning here is a leak
-    DispatchRelayInlineState::cb_writer.wait_all_pages(downstream_cb_pages);
+    // The reader stub never writes pages to the downstream CB (all relay functions are
+    // stubbed), so the CBWriter's page accounting is always at its initial state and
+    // wait_all_pages would hang waiting for credits that never arrive.  Skip it here;
+    // the writer (NCRISC) sends the terminate directly to the dispatcher instead.
 
     noc_async_full_barrier();
 

--- a/tt_metal/impl/dispatch/kernels/cq_prefetch_reader.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_prefetch_reader.cpp
@@ -2,12 +2,11 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-// Prefetch kernel
-//  - 3 flavors: _hd (host and dram), _h (host only), _d (DRAM only)
-//  - fetches commands from host (if applicable), executes
-//  - uses HostQ for host handshaking, ComDatQ for commands (from host),
-//    double buffered ScratchBuf for out of band data (e.g., from DRAM)
-//  - syncs w/ dispatcher via 2 semaphores, page_ready, page_done
+// Prefetch reader kernel (split-prefetcher BRISC half)
+//  - Handles the _hd and _d variants; _h variant is excluded (reader-only role)
+//  - Reads commands from host / upstream and processes them; write-path work will move to
+//    cq_prefetch_writer.cpp (NCRISC) in future iterations
+//  - Command-implementing functions are currently stubbed; their bodies will migrate to the writer
 //
 // Write cmd buf allocation:
 //  - BRISC_WR_CMD_BUF: writes to downstream_noc_xy
@@ -224,8 +223,6 @@ struct PrefetchExecBufState {
     uint32_t read_ptr;
     uint32_t prefetch_length;
 };
-
-uint32_t process_relay_linear_h_cmd(uint32_t cmd_ptr, uint32_t& downstream_data_ptr);
 
 // Global Variables
 static uint32_t pcie_read_ptr = pcie_base;
@@ -465,39 +462,6 @@ uint32_t process_debug_cmd(uint32_t cmd_ptr) {
 template <bool cmddat_wrap_enable, typename RelayInlineState>
 static uint32_t process_relay_inline_cmd(uint32_t cmd_ptr, uint32_t& local_downstream_data_ptr) {
     volatile CQPrefetchCmd tt_l1_ptr* cmd = (volatile CQPrefetchCmd tt_l1_ptr*)cmd_ptr;
-    uint32_t length = cmd->relay_inline.length;
-    uint32_t data_ptr = cmd_ptr + sizeof(CQPrefetchCmd);
-
-    uint32_t npages =
-        (length + RelayInlineState::downstream_page_size - 1) >> RelayInlineState::downstream_log_page_size;
-
-    // Assume the downstream buffer is big relative to cmddat command size that we can
-    // grab what we need in one chunk
-    RelayInlineState::cb_writer.acquire_pages(npages);
-
-    uint32_t remaining = cmddat_q_end - data_ptr;
-    if (cmddat_wrap_enable && length > remaining) {
-        // wrap cmddat
-        write_downstream<RelayInlineState::downstream_cb_base_addr, RelayInlineState::downstream_write_cmd_buf>(
-            data_ptr,
-            local_downstream_data_ptr,
-            remaining,
-            RelayInlineState::downstream_cb_end_addr,
-            RelayInlineState::downstream_noc_encoding);
-        length -= remaining;
-        data_ptr = cmddat_q_base;
-    }
-
-    write_downstream<RelayInlineState::downstream_cb_base_addr, RelayInlineState::downstream_write_cmd_buf>(
-        data_ptr,
-        local_downstream_data_ptr,
-        length,
-        RelayInlineState::downstream_cb_end_addr,
-        RelayInlineState::downstream_noc_encoding);
-
-    local_downstream_data_ptr = round_up_pow2(local_downstream_data_ptr, RelayInlineState::downstream_page_size);
-    noc_async_writes_flushed();
-    RelayInlineState::cb_writer.release_pages(npages, local_downstream_data_ptr);
     return cmd->relay_inline.stride;
 }
 
@@ -508,25 +472,6 @@ static uint32_t process_relay_inline_cmd(uint32_t cmd_ptr, uint32_t& local_downs
 template <bool cmddat_wrap_enable>
 static uint32_t process_relay_inline_noflush_cmd(uint32_t cmd_ptr, uint32_t& dispatch_data_ptr) {
     volatile CQPrefetchCmd tt_l1_ptr* cmd = (volatile CQPrefetchCmd tt_l1_ptr*)cmd_ptr;
-
-    uint32_t length = cmd->relay_inline.length;
-    uint32_t data_ptr = cmd_ptr + sizeof(CQPrefetchCmd);
-
-    DispatchRelayInlineState::cb_writer.acquire_pages(1);
-    if (dispatch_data_ptr == downstream_cb_end) {
-        dispatch_data_ptr = downstream_cb_base;
-    }
-    uint32_t remaining = cmddat_q_end - data_ptr;
-    if (cmddat_wrap_enable && length > remaining) {
-        // wrap cmddat
-        noc_async_write(data_ptr, get_noc_addr_helper(downstream_noc_xy, dispatch_data_ptr), remaining);
-        dispatch_data_ptr += remaining;
-        length -= remaining;
-        data_ptr = cmddat_q_base;
-    }
-    noc_async_write(data_ptr, get_noc_addr_helper(downstream_noc_xy, dispatch_data_ptr), length);
-    dispatch_data_ptr += length;
-
     return cmd->relay_inline.stride;
 }
 
@@ -583,368 +528,23 @@ uint32_t process_relay_paged_cmd_large(
     uint32_t page_size,
     uint32_t pages,
     uint32_t length_adjust) {
-#if ENABLE_PREFETCH_DPRINTS
-    DPRINT << "relay_paged_cmd_large: " << page_size << " " << pages << " " << length_adjust << ENDL();
-#endif
-
-    auto addr_gen = TensorAccessor(tensor_accessor::make_interleaved_dspec<is_dram>(), base_addr, page_size);
-
-    // First step - read into DB0
-    uint32_t scratch_read_addr = scratch_db_top[0];
-    uint64_t noc_addr = addr_gen.get_noc_addr(page_id);
-    uint64_t write_length = (uint64_t)pages * page_size - length_adjust;
-    uint64_t read_length;
-    uint32_t amt_read;
-    if (scratch_db_half_size >= write_length) {
-        amt_read = write_length;
-        read_length = 0;
-    } else {
-        amt_read = scratch_db_half_size;
-        read_length = write_length - amt_read;
-    }
-    noc_async_read(noc_addr, scratch_read_addr, amt_read);
-    uint32_t page_length = page_size - amt_read;
-    uint32_t page_offset = amt_read;
-
-    // Second step - read into DB[x], write from DB[x], toggle x, iterate
-    // Writes are fast, reads are slow
-    uint32_t db_toggle = 0;
-    uint32_t scratch_write_addr;
-
-    noc_async_read_barrier();
-    while (read_length != 0) {
-        // This ensures that writes from prior iteration are done
-        // TODO(pgk); we can do better on WH w/ tagging
-        noc_async_writes_flushed();
-
-        db_toggle ^= 1;
-        scratch_read_addr = scratch_db_top[db_toggle];
-        scratch_write_addr = scratch_db_top[db_toggle ^ 1];
-
-        uint32_t amt_to_write = amt_read;
-        uint64_t noc_addr = addr_gen.get_noc_addr(page_id, page_offset);
-        if (page_length <= scratch_db_half_size) {
-            noc_async_read(noc_addr, scratch_read_addr, page_length);
-            page_id++;
-            page_offset = 0;
-            amt_read = page_length;
-            page_length = page_size;
-
-            if (amt_read < scratch_db_half_size && read_length > amt_read) {
-                noc_addr = addr_gen.get_noc_addr(page_id, 0);
-                uint32_t amt_to_read = scratch_db_half_size - amt_read;
-                noc_async_read(noc_addr, scratch_read_addr + amt_read, amt_to_read);
-                page_length -= amt_to_read;
-                amt_read = scratch_db_half_size;
-                page_offset = amt_to_read;
-            }
-        } else {
-            noc_async_read(noc_addr, scratch_read_addr, scratch_db_half_size);
-            page_length -= scratch_db_half_size;
-            page_offset += scratch_db_half_size;
-            amt_read = scratch_db_half_size;
-        }
-
-        // Third step - write from DB
-        if (write_length < amt_to_write) {
-            amt_to_write = write_length;
-            read_length = 0;
-        } else {
-            read_length -= amt_read;
-        }
-
-        write_length -= amt_to_write;
-        uint32_t npages = write_pages_to_dispatcher<0, false>(downstream_data_ptr, scratch_write_addr, amt_to_write);
-        DispatchRelayInlineState::cb_writer.release_pages(npages, downstream_data_ptr, /*round_to_page_size*/ true);
-
-        // TODO(pgk); we can do better on WH w/ tagging
-        noc_async_read_barrier();
-    }
-
-    // Third step - write from DB
-    if (write_length > 0) {
-        scratch_write_addr = scratch_db_top[db_toggle];
-        uint32_t amt_to_write = write_length;
-        uint32_t npages = write_pages_to_dispatcher<1, true>(downstream_data_ptr, scratch_write_addr, amt_to_write);
-
-        downstream_data_ptr = round_up_pow2(downstream_data_ptr, downstream_cb_page_size);
-        // One page was acquired w/ the cmd in CMD_RELAY_INLINE_NOFLUSH with 16 bytes written
-        DispatchRelayInlineState::cb_writer.release_pages(npages + 1, downstream_data_ptr);
-    } else {
-        downstream_data_ptr = round_up_pow2(downstream_data_ptr, downstream_cb_page_size);
-        DispatchRelayInlineState::cb_writer.release_pages(1, downstream_data_ptr);
-    }
-
     return CQ_PREFETCH_CMD_BARE_MIN_SIZE;
 }
 
 // This fn prefetches data from DRAM memory and writes data to the dispatch core.
-// Reading from DRAM has the following characteristics:
-//  - latency is moderately high ~400 cycles on WH
-//  - DRAM bw is ~maximized when page size reaches 2K
-//  - for kernel dispatch, it is expected that page sizes will often be <2K
-//  - for buffer writing, page sizes will vary
-//  - writing to dispatcher works best with 4K pages (2K pages cover overhead, 4K gives perf cushion)
-//  - writing a 4K page takes ~32*4=128 cycles
-//  - writing 4 4K pages is 512 cycles, close to parity w/ the latency of DRAM
-//  - to hide the latency (~12% overhead), assume we need to read ~32 pages=128K, double buffered
-//  - in other words, we'll never achieve high efficiency and always be (somewhat) latency bound
-// Algorithm does:
-//  - read a batch from DRAM
-//  - loop: read a batch from DRAM while sending to dispatcher
-//  - send a batch to dispatcher
-// The size of the first read should be based on latency.  With small page sizes
-// bandwidth will be low and we'll be DRAM bound (send to dispatcher is ~free).
-// With larger pages we'll get closer to a bandwidth match
-// The dispatch buffer is a ring buffer.
 template <bool is_dram>
 uint32_t process_relay_paged_cmd(uint32_t cmd_ptr, uint32_t& downstream__data_ptr, uint32_t page_id) {
-    // This ensures that a previous cmd using the scratch buf has finished
-    noc_async_writes_flushed();
-
-    volatile CQPrefetchCmd tt_l1_ptr* cmd = (volatile CQPrefetchCmd tt_l1_ptr*)cmd_ptr;
-    uint32_t base_addr = cmd->relay_paged.base_addr;
-    uint32_t page_size = cmd->relay_paged.page_size;
-    uint32_t pages = cmd->relay_paged.pages;
-    uint16_t length_adjust = cmd->relay_paged.is_dram_and_length_adjust & CQ_PREFETCH_RELAY_PAGED_LENGTH_ADJUST_MASK;
-
-    if (page_size > scratch_db_half_size) {
-        return process_relay_paged_cmd_large<is_dram>(
-            cmd_ptr, downstream_data_ptr, page_id, base_addr, page_size, pages, length_adjust);
-    }
-
-    auto addr_gen = TensorAccessor(tensor_accessor::make_interleaved_dspec<is_dram>(), base_addr, page_size);
-
-    // First step - read into DB0
-    uint64_t read_wlength = (uint64_t)pages * page_size;
-    uint32_t scratch_read_addr = scratch_db_top[0];
-    uint32_t amt_to_read = (scratch_db_half_size > read_wlength) ? read_wlength : scratch_db_half_size;
-    uint32_t amt_read = 0;
-    while (amt_to_read >= page_size) {
-        uint64_t noc_addr = addr_gen.get_noc_addr(page_id);
-        noc_async_read(noc_addr, scratch_read_addr, page_size);
-        scratch_read_addr += page_size;
-        page_id++;
-        amt_to_read -= page_size;
-        amt_read += page_size;
-    }
-    // The fences are to prevent any compiler reordering of instructions around the division. The latency of the
-    // division is hidden by the latency of the noc_async_read_barrier().
-    std::atomic_signal_fence(std::memory_order_acq_rel);
-    const uint32_t max_batch_size = read_wlength > std::numeric_limits<uint32_t>::max()
-                                        ? (std::numeric_limits<uint32_t>::max() / page_size) * page_size
-                                        : read_wlength;
-    std::atomic_signal_fence(std::memory_order_acq_rel);
-    noc_async_read_barrier();
-
-    // Second step - read into DB[x], write from DB[x], toggle x, iterate
-    // Writes are fast, reads are slow
-    uint32_t db_toggle = 0;
-    uint32_t scratch_write_addr;
-    read_wlength -= amt_read;
-    while (read_wlength != 0) {
-        uint32_t read_length = (read_wlength > max_batch_size) ? max_batch_size : static_cast<uint32_t>(read_wlength);
-        read_wlength -= read_length;
-        while (read_length != 0) {
-            // This ensures that writes from prior iteration are done
-            // TODO(pgk); we can do better on WH w/ tagging
-            noc_async_writes_flushed();
-
-            db_toggle ^= 1;
-            scratch_read_addr = scratch_db_top[db_toggle];
-            scratch_write_addr = scratch_db_top[db_toggle ^ 1];
-
-            uint32_t amt_to_write = amt_read;
-            amt_to_read = (scratch_db_half_size > read_length) ? read_length : scratch_db_half_size;
-            amt_read = 0;
-            while (amt_to_read >= page_size) {
-                uint64_t noc_addr = addr_gen.get_noc_addr(page_id);
-                noc_async_read(noc_addr, scratch_read_addr, page_size);
-                scratch_read_addr += page_size;
-                page_id++;
-                amt_to_read -= page_size;
-                amt_read += page_size;
-            }
-
-            // Third step - write from DB
-            uint32_t npages =
-                write_pages_to_dispatcher<0, false>(downstream_data_ptr, scratch_write_addr, amt_to_write);
-            DispatchRelayInlineState::cb_writer.release_pages(npages, downstream_data_ptr, /*round_to_page_size*/ true);
-
-            read_length -= amt_read;
-
-            // TODO(pgk); we can do better on WH w/ tagging
-            noc_async_read_barrier();
-        }
-    }
-
-    // Third step - write from DB
-    // Note that we may write less than full pages despite reading full pages based on length_adjust
-    // Expectation is that the gain from reading less is small to 0, revisit as needed
-    ASSERT(length_adjust < page_size);
-    scratch_write_addr = scratch_db_top[db_toggle];
-    uint32_t amt_to_write = amt_read - length_adjust;
-    uint32_t npages = write_pages_to_dispatcher<1, true>(downstream_data_ptr, scratch_write_addr, amt_to_write);
-
-    downstream_data_ptr = round_up_pow2(downstream_data_ptr, downstream_cb_page_size);
-
-    // One page was acquired w/ the cmd in CMD_RELAY_INLINE_NOFLUSH with 16 bytes written
-    DispatchRelayInlineState::cb_writer.release_pages(npages + 1, downstream_data_ptr);
-
     return CQ_PREFETCH_CMD_BARE_MIN_SIZE;
 }
 
-// Similar to relay_paged, this iterates and aggregates reads from multiple
-// embedded relay_paged cmds
+// Similar to relay_paged, this iterates and aggregates reads from multiple embedded relay_paged cmds
 void process_relay_paged_packed_sub_cmds(uint32_t total_length, uint32_t* l1_cache) {
-    // This ensures that a previous cmd using the scratch buf has finished
-    noc_async_writes_flushed();
-
-    // First step - read multiple sub_cmds worth into DB0
-    CQPrefetchRelayPagedPackedSubCmd tt_l1_ptr* sub_cmd = (CQPrefetchRelayPagedPackedSubCmd tt_l1_ptr*)(l1_cache);
-    uint32_t read_length = sub_cmd->length;
-    ASSERT(read_length <= scratch_db_half_size);
-    uint32_t amt_to_read = (scratch_db_half_size > total_length) ? total_length : scratch_db_half_size;
-    uint32_t amt_read = 0;
-    uint32_t scratch_read_addr = scratch_db_top[0];
-
-    while (read_length <= amt_to_read) {
-        uint32_t page_id = sub_cmd->start_page;
-        uint32_t log_page_size = sub_cmd->log_page_size;
-        uint32_t base_addr = sub_cmd->base_addr;
-        sub_cmd++;
-
-        uint32_t page_size = 1 << log_page_size;
-        InterleavedPow2AddrGen<true> addr_gen{.bank_base_address = base_addr, .log_base_2_of_page_size = log_page_size};
-
-        uint32_t amt_to_read2 =
-            (scratch_db_half_size - amt_read > read_length) ? read_length : scratch_db_half_size - amt_read;
-        uint32_t amt_read2 = 0;
-        while (amt_read2 < amt_to_read2) {
-            uint64_t noc_addr = addr_gen.get_noc_addr(page_id);
-            uint32_t read_size = (amt_to_read2 - amt_read2 >= page_size) ? page_size : amt_to_read2 - amt_read2;
-            noc_async_read(noc_addr, scratch_read_addr, read_size);
-            scratch_read_addr += read_size;
-            page_id++;
-            amt_read2 += read_size;
-        }
-
-        amt_read += amt_read2;
-        amt_to_read -= amt_read2;
-
-        // note: below can walk off the end of the sub_cmds
-        // this is ok as we store a sentinel non-zero value
-        read_length = sub_cmd->length;
-        ASSERT(read_length <= scratch_db_half_size || total_length == amt_read);
-    }
-    noc_async_read_barrier();
-
-    // Second step - read into DB[x], write from DB[x], toggle x, iterate
-    // Writes are fast, reads are slow
-    uint32_t db_toggle = 0;
-    uint32_t scratch_write_addr;
-    total_length -= amt_read;
-    while (total_length != 0) {
-        // This ensures that writes from prior iteration are done
-        // TODO(pgk); we can do better on WH w/ tagging
-        noc_async_writes_flushed();
-
-        db_toggle ^= 1;
-        scratch_read_addr = scratch_db_top[db_toggle];
-        scratch_write_addr = scratch_db_top[db_toggle ^ 1];
-
-        uint32_t amt_to_write = amt_read;
-        amt_read = 0;
-        amt_to_read = (scratch_db_half_size > total_length) ? total_length : scratch_db_half_size;
-        while (read_length <= amt_to_read) {
-            uint32_t page_id = sub_cmd->start_page;
-            uint32_t log_page_size = sub_cmd->log_page_size;
-            uint32_t base_addr = sub_cmd->base_addr;
-            sub_cmd++;
-
-            uint32_t page_size = 1 << log_page_size;
-            InterleavedPow2AddrGen<true> addr_gen{
-                .bank_base_address = base_addr, .log_base_2_of_page_size = log_page_size};
-
-            uint32_t amt_to_read2 =
-                (scratch_db_half_size - amt_read > read_length) ? read_length : scratch_db_half_size - amt_read;
-            uint32_t amt_read2 = 0;
-            while (amt_read2 < amt_to_read2) {
-                uint64_t noc_addr = addr_gen.get_noc_addr(page_id);
-                uint32_t read_size = (amt_to_read2 - amt_read2 >= page_size) ? page_size : amt_to_read2 - amt_read2;
-                noc_async_read(noc_addr, scratch_read_addr, read_size);
-                scratch_read_addr += read_size;
-                page_id++;
-                amt_read2 += read_size;
-            }
-
-            amt_read += amt_read2;
-            amt_to_read -= amt_read2;
-
-            // note: below can walk off the end of the sub_cmds
-            // this is ok as we store a sentinel non-zero value
-            read_length = sub_cmd->length;
-            ASSERT(read_length <= scratch_db_half_size || total_length == amt_read);
-        }
-
-        // Third step - write from DB
-        uint32_t npages = write_pages_to_dispatcher<0, false>(downstream_data_ptr, scratch_write_addr, amt_to_write);
-        DispatchRelayInlineState::cb_writer.release_pages(npages, downstream_data_ptr, /*round_to_page_size*/ true);
-
-        total_length -= amt_read;
-
-        // TODO(pgk); we can do better on WH w/ tagging
-        noc_async_read_barrier();
-    }
-
-    // Third step - write from DB
-    scratch_write_addr = scratch_db_top[db_toggle];
-    uint32_t amt_to_write = amt_read;
-    uint32_t npages = write_pages_to_dispatcher<1, true>(downstream_data_ptr, scratch_write_addr, amt_to_write);
-
-    downstream_data_ptr = round_up_pow2(downstream_data_ptr, downstream_cb_page_size);
-
-    // One page was acquired w/ the cmd in CMD_RELAY_INLINE_NOFLUSH with 16 bytes written
-    DispatchRelayInlineState::cb_writer.release_pages(npages + 1, downstream_data_ptr);
 }
 
 template <bool cmddat_wrap_enable>
 uint32_t process_relay_paged_packed_cmd(uint32_t cmd_ptr, uint32_t& downstream__data_ptr, uint32_t* l1_cache) {
     volatile CQPrefetchCmd tt_l1_ptr* cmd = (volatile CQPrefetchCmd tt_l1_ptr*)cmd_ptr;
-    uint32_t total_length = cmd->relay_paged_packed.total_length;
-    uint32_t sub_cmds_length = cmd->relay_paged_packed.count * sizeof(CQPrefetchRelayPagedPackedSubCmd);
-    uint32_t stride = cmd->relay_paged_packed.stride;
-    ASSERT(total_length > 0);
-    // DPRINT << "paged_packed: " << total_length << " " << cmd->relay_paged_packed.stride << ENDL();
-
-    uint32_t data_ptr = cmd_ptr + sizeof(CQPrefetchCmd);
-    uint32_t remaining = cmddat_q_end - data_ptr;
-    uint32_t* l1_cache_pos = l1_cache;
-    if (cmddat_wrap_enable && sub_cmds_length > remaining) {
-        // wrap cmddat
-        uint32_t amt = remaining / sizeof(uint32_t);
-        careful_copy_from_l1_to_local_cache<l1_to_local_cache_copy_chunk, l1_cache_elements_rounded>(
-            (volatile uint32_t tt_l1_ptr*)(data_ptr), amt, l1_cache_pos);
-        sub_cmds_length -= remaining;
-        data_ptr = cmddat_q_base;
-        l1_cache_pos += amt;
-    }
-
-    uint32_t amt = sub_cmds_length / sizeof(uint32_t);
-    // Check that the final write does not overflow the L1 cache and corrupt the stack
-    // End address of final write is: curr_offset_into_cache + write_size_rounded_up_to_copy_chunk
-    ASSERT(
-        (uint32_t)(l1_cache_pos +
-                   ((amt + l1_to_local_cache_copy_chunk - 1) / l1_to_local_cache_copy_chunk) *
-                       l1_to_local_cache_copy_chunk -
-                   l1_cache) < l1_cache_elements_rounded);
-    careful_copy_from_l1_to_local_cache<l1_to_local_cache_copy_chunk, l1_cache_elements_rounded>(
-        (volatile uint32_t tt_l1_ptr*)(data_ptr), amt, l1_cache_pos);
-    // Store a sentinal non 0 value at the end to save a test/branch in read path
-    ((CQPrefetchRelayPagedPackedSubCmd*)&l1_cache_pos[amt])->length = 1;
-
-    process_relay_paged_packed_sub_cmds(total_length, l1_cache);
-    return stride;
+    return cmd->relay_paged_packed.stride;
 }
 
 template <bool set_src_noc_addr = false>
@@ -978,309 +578,32 @@ void noc_read_64bit_any_len(uint32_t src_noc_addr, uint64_t src_addr, uint32_t d
 }
 
 uint32_t process_relay_linear_cmd(uint32_t cmd_ptr, uint32_t& downstream_data_ptr) {
-    // This ensures that a previous cmd using the scratch buf has finished
-    noc_async_writes_flushed();
-
-    volatile CQPrefetchCmdLarge tt_l1_ptr* cmd = (volatile CQPrefetchCmdLarge tt_l1_ptr*)cmd_ptr;
-    uint32_t noc_xy_addr = cmd->relay_linear.noc_xy_addr;
-    uint64_t read_addr = cmd->relay_linear.addr;
-    uint64_t wlength = cmd->relay_linear.length;
-    // DPRINT << "relay_linear: " << cmd_ptr << " " << wlength << " " << read_addr << " " << noc_xy_addr << ENDL();
-
-    // First step - read into DB0
-    uint32_t scratch_read_addr = scratch_db_top[0];
-    uint32_t amt_to_read = (scratch_db_half_size > wlength) ? wlength : scratch_db_half_size;
-    noc_read_64bit_any_len<true>(noc_xy_addr, read_addr, scratch_read_addr, amt_to_read);
-
-    read_addr += amt_to_read;
-    wlength -= amt_to_read;
-    noc_async_read_barrier();
-
-    // Second step - read into DB[x], write from DB[x], toggle x, iterate
-    // Writes are fast, reads are slow
-    uint32_t db_toggle = 0;
-    uint32_t scratch_write_addr;
-    constexpr uint32_t max_batch_size = ~(scratch_db_half_size - 1);
-    while (wlength != 0) {
-        uint32_t read_length = (wlength > max_batch_size) ? max_batch_size : wlength;
-        wlength -= read_length;
-        while (read_length != 0) {
-            // This ensures that writes from prior iteration are done
-            // TODO(pgk); we can do better on WH w/ tagging
-            noc_async_writes_flushed();
-
-            db_toggle ^= 1;
-            scratch_read_addr = scratch_db_top[db_toggle];
-            scratch_write_addr = scratch_db_top[db_toggle ^ 1];
-
-            uint32_t amt_to_write = amt_to_read;
-            amt_to_read = (scratch_db_half_size > read_length) ? read_length : scratch_db_half_size;
-            noc_read_64bit_any_len<false>(noc_xy_addr, read_addr, scratch_read_addr, amt_to_read);
-            read_addr += amt_to_read;
-
-            // Third step - write from DB
-            uint32_t npages =
-                write_pages_to_dispatcher<0, false>(downstream_data_ptr, scratch_write_addr, amt_to_write);
-
-            DispatchRelayInlineState::cb_writer.release_pages(npages, downstream_data_ptr, /*round_to_page_size*/ true);
-
-            read_length -= amt_to_read;
-
-            // TODO(pgk); we can do better on WH w/ tagging
-            noc_async_read_barrier();
-        }
-    }
-
-    // Third step - write from DB
-    scratch_write_addr = scratch_db_top[db_toggle];
-    uint32_t amt_to_write = amt_to_read;
-    uint32_t npages = write_pages_to_dispatcher<1, true>(downstream_data_ptr, scratch_write_addr, amt_to_write);
-
-    downstream_data_ptr = round_up_pow2(downstream_data_ptr, downstream_cb_page_size);
-
-    // One page was acquired w/ the cmd in CMD_RELAY_INLINE_NOFLUSH
-    DispatchRelayInlineState::cb_writer.release_pages(npages + 1, downstream_data_ptr);
-
     return CQ_PREFETCH_CMD_BARE_MIN_SIZE;
 }
 
 uint32_t process_stall(uint32_t cmd_ptr) {
-    static uint32_t count = 0;
-
-    count++;
-
-    WAYPOINT("PSW");
-    volatile tt_l1_ptr uint32_t* sem_addr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_semaphore<fd_core_type>(my_downstream_sync_sem_id));
-    uint32_t heartbeat = 0;
-    do {
-        invalidate_l1_cache();
-        IDLE_ERISC_HEARTBEAT_AND_RETURN(heartbeat, CQ_PREFETCH_CMD_BARE_MIN_SIZE);
-    } while (*sem_addr != count);
-    WAYPOINT("PSD");
-
     return CQ_PREFETCH_CMD_BARE_MIN_SIZE;
 }
 
 // This function reads data from the DRAM and populates the cmddat_q l1 buffer.
-// It starts by fetching initial chunk of 16KB from DRAM and then prefetches
-// the rest and returns to have the initial cmddat_q to be processed.
-// All fetching from DRAM stops at the end of cmddat_q until the cmddat_q are
-// processed.  Then it repeats again. Note: exec_buf_state struct must be
-// initialized to start using this function.
 void paged_read_into_cmddat_q(uint32_t& cmd_ptr, PrefetchExecBufState& exec_buf_state) {
-    uint32_t page_id = exec_buf_state.page_id;
-    uint32_t base_addr = exec_buf_state.base_addr;
-    uint32_t log_page_size = exec_buf_state.log_page_size;
-    uint32_t page_size = 1 << log_page_size;
-    uint32_t pages = exec_buf_state.pages;
-    uint32_t read_ptr = exec_buf_state.read_ptr;
-    constexpr uint32_t INITIAL_FETCH_SIZE = 16 * 1024;                           // 16KB (OPTIMIZE HERE)
-    constexpr uint32_t PREFETCH_FETCH_SIZE = cmddat_q_size - INITIAL_FETCH_SIZE;  // the rest
-
-    // To handle cmddat_q that are non multiples of page_size
-    uint32_t trace_q_end = cmddat_q_base + (((cmddat_q_end - cmddat_q_base) >> log_page_size) << log_page_size);
-
-    // This function also resets the cmd_ptr when it is at the end of cmddat_q.
-    // That is the only thing related to cmd_ptr in this function.
-    if (cmd_ptr == trace_q_end) {
-        cmd_ptr = cmddat_q_base;
-    }
-
-    auto addr_gen = TensorAccessor(tensor_accessor::make_interleaved_dspec</*is_dram=*/true>(), base_addr, page_size);
-    // set transaction ID to 1 for all read
-    noc_async_read_set_trid(1);
-    ASSERT(page_size <= NOC_MAX_BURST_SIZE);
-    // Initialize the read size for all later commands.
-    noc_read_with_state<DM_DEDICATED_NOC, read_cmd_buf, CQ_NOC_sndL, CQ_NOC_send, CQ_NOC_WAIT>(0, 0, 0, page_size);
-
-    // initial read
-    if (exec_buf_state.prefetch_length == 0) {
-        uint32_t initial_read_pages = INITIAL_FETCH_SIZE >> log_page_size;
-        uint32_t initial_pages_at_once = (initial_read_pages > pages) ? pages : initial_read_pages;
-        uint32_t initial_read_length = initial_pages_at_once << log_page_size;
-        pages -= initial_pages_at_once;
-
-        while (initial_pages_at_once != 0) {
-            uint32_t pages_to_read = noc_available_transactions(noc_index, 1);
-            if (pages_to_read > initial_pages_at_once) {
-                pages_to_read = initial_pages_at_once;
-            }
-            initial_pages_at_once -= pages_to_read;
-            while (pages_to_read != 0) {
-                uint64_t noc_addr = addr_gen.get_noc_addr(page_id);
-                noc_read_with_state<DM_DEDICATED_NOC, read_cmd_buf, CQ_NOC_SNDl, CQ_NOC_SEND, CQ_NOC_WAIT>(
-                    noc_index, noc_addr, read_ptr, 0);
-                read_ptr += page_size;
-                page_id++;
-                pages_to_read--;
-            }
-        }
-        noc_async_read_barrier_with_trid(1);
-        // update length always after barrier to make sure data in cmddat_q
-        exec_buf_state.page_id = page_id;
-        exec_buf_state.pages = pages;
-        exec_buf_state.length += initial_read_length;
-        exec_buf_state.read_ptr = read_ptr;
-    } else {
-        ASSERT(exec_buf_state.length == 0);
-        // add barrier to wait for prefetch noc read to complete
-        noc_async_read_barrier_with_trid(1);
-        // update always after barrier to make sure data in cmddat_q
-        exec_buf_state.length += exec_buf_state.prefetch_length;
-        exec_buf_state.prefetch_length = 0;
-    }
-
-    // prefetch only when there are still pages to prefetch
-    if (exec_buf_state.pages > 0) {
-        // wrap around to prefetch from beginning again
-        uint32_t max_prefetch_size = PREFETCH_FETCH_SIZE;
-        if (read_ptr == trace_q_end) {
-            max_prefetch_size = INITIAL_FETCH_SIZE;
-            read_ptr = cmddat_q_base;
-        }
-        uint32_t prefetch_read_pages = max_prefetch_size >> log_page_size;
-        uint32_t prefetch_pages_at_once = (prefetch_read_pages > pages) ? pages : prefetch_read_pages;
-        uint32_t prefetch_read_length = prefetch_pages_at_once << log_page_size;
-        pages -= prefetch_pages_at_once;
-
-        while (prefetch_pages_at_once != 0) {
-            uint32_t pages_to_read = noc_available_transactions(noc_index, 1);
-            if (pages_to_read > prefetch_pages_at_once) {
-                pages_to_read = prefetch_pages_at_once;
-            }
-            prefetch_pages_at_once -= pages_to_read;
-            while (pages_to_read != 0) {
-                uint64_t noc_addr = addr_gen.get_noc_addr(page_id);
-                noc_read_with_state<DM_DEDICATED_NOC, read_cmd_buf, CQ_NOC_SNDl, CQ_NOC_SEND, CQ_NOC_WAIT>(
-                    noc_index, noc_addr, read_ptr, 0);
-                read_ptr += page_size;
-                page_id++;
-                pages_to_read--;
-            }
-        }
-        // update length always after barrier to make sure data in cmddat_q
-        exec_buf_state.page_id = page_id;
-        exec_buf_state.pages = pages;
-        exec_buf_state.prefetch_length = prefetch_read_length;
-        exec_buf_state.read_ptr = read_ptr;
-    }
-
-    // set transaction ID to 0 for other noc read to not use transaction id 1
-    // to remove unnecessary barrier delay
-    noc_async_read_set_trid(0);
-    // Ensure reads receive the updated data.
-    invalidate_l1_cache();
 }
 
 // processes the relay_inline cmd from an exec_buf
-// ie, reads the data from dram and relays it on
 // Separate implementation that fetches more data from exec buf when cmd has been split
 template <typename RelayInlineState>
 FORCE_INLINE static uint32_t process_exec_buf_relay_inline_cmd(
     uint32_t& cmd_ptr, uint32_t& local_downstream_data_ptr, PrefetchExecBufState& exec_buf_state) {
     volatile CQPrefetchCmd tt_l1_ptr* cmd = (volatile CQPrefetchCmd tt_l1_ptr*)cmd_ptr;
-    uint8_t dispatcher_type = cmd->relay_inline.dispatcher_type;
-    uint32_t length = cmd->relay_inline.length;
-    uint32_t data_ptr = cmd_ptr + sizeof(CQPrefetchCmd);
-
-    // DPRINT << "relay_inline_exec_buf_cmd:" << length << ENDL();
-    uint32_t npages =
-        (length + RelayInlineState::downstream_page_size - 1) >> RelayInlineState::downstream_log_page_size;
-    static_assert(
-        &RelayInlineState::cb_writer.additional_count == &DispatchRelayInlineState::cb_writer.additional_count ||
-        &RelayInlineState::cb_writer.additional_count == &DispatchSRelayInlineState::cb_writer.additional_count);
-
-    // Assume the downstream buffer is big relative to cmddat command size that we can
-    // grab what we need in one chunk
-    RelayInlineState::cb_writer.acquire_pages(npages);
-    uint32_t stride = cmd->relay_inline.stride;
-    uint32_t remaining_stride = exec_buf_state.length;
-    uint32_t remaining = exec_buf_state.length - sizeof(CQPrefetchCmd);
-    while (length > remaining) {
-        // wrap cmddat
-        write_downstream<RelayInlineState::downstream_cb_base_addr, RelayInlineState::downstream_write_cmd_buf>(
-            data_ptr,
-            local_downstream_data_ptr,
-            remaining,
-            RelayInlineState::downstream_cb_end_addr,
-            RelayInlineState::downstream_noc_encoding);
-        length -= remaining;
-        stride -= remaining_stride;
-        exec_buf_state.length = 0;
-        cmd_ptr += remaining_stride;
-
-        // fetch more
-        noc_async_writes_flushed(RelayInlineState::downstream_noc_index);
-        paged_read_into_cmddat_q(cmd_ptr, exec_buf_state);
-        data_ptr = cmd_ptr;
-        remaining = exec_buf_state.length;
-        remaining_stride = exec_buf_state.length;
-    }
-    write_downstream<RelayInlineState::downstream_cb_base_addr, RelayInlineState::downstream_write_cmd_buf>(
-        data_ptr,
-        local_downstream_data_ptr,
-        length,
-        RelayInlineState::downstream_cb_end_addr,
-        RelayInlineState::downstream_noc_encoding);
-    local_downstream_data_ptr = round_up_pow2(local_downstream_data_ptr, RelayInlineState::downstream_page_size);
-    noc_async_writes_flushed(RelayInlineState::downstream_noc_index);
-    RelayInlineState::cb_writer.release_pages(npages, local_downstream_data_ptr);
-
-    return stride;
+    return cmd->relay_inline.stride;
 }
 
 // This version of inline sends inline data to the dispatcher but doesn't flush the page to the dispatcher
-// This is used to assemble dispatcher commands when data comes out of band, eg, reading from DRAM
-// That means this command is stateful, incorrect use will be...bad
-// NOTE: this routine assumes we're sending a command header and that is LESS THAN A PAGE
 // Separate implementation that fetches more data from exec buf when cmd has been split
 static uint32_t process_exec_buf_relay_inline_noflush_cmd(
     uint32_t& cmd_ptr, uint32_t& dispatch_data_ptr, PrefetchExecBufState& exec_buf_state) {
     volatile CQPrefetchCmd tt_l1_ptr* cmd = (volatile CQPrefetchCmd tt_l1_ptr*)cmd_ptr;
-
-    uint32_t length = cmd->relay_inline.length;
-    uint32_t data_ptr = cmd_ptr + sizeof(CQPrefetchCmd);
-
-    uint32_t stride = cmd->relay_inline.stride;
-
-    DispatchRelayInlineState::cb_writer.acquire_pages(1);
-    if (dispatch_data_ptr == downstream_cb_end) {
-        dispatch_data_ptr = downstream_cb_base;
-    }
-    uint32_t remaining_stride = exec_buf_state.length;
-    uint32_t remaining = exec_buf_state.length - sizeof(CQPrefetchCmd);
-    while (length > remaining) {
-        // wrap cmddat
-#if defined(FABRIC_RELAY)
-        noc_async_write(data_ptr, get_noc_addr_helper(downstream_noc_xy, dispatch_data_ptr), remaining);
-#else
-        cq_noc_async_write_with_state_any_len<true, true>(
-            data_ptr, get_noc_addr_helper(downstream_noc_xy, dispatch_data_ptr), remaining);
-#endif
-        dispatch_data_ptr += remaining;
-        length -= remaining;
-        stride -= remaining_stride;
-        exec_buf_state.length = 0;
-        cmd_ptr += remaining_stride;
-
-        // fetch more
-        noc_async_writes_flushed();
-        paged_read_into_cmddat_q(cmd_ptr, exec_buf_state);
-        data_ptr = cmd_ptr;
-        remaining = exec_buf_state.length;
-        remaining_stride = exec_buf_state.length;
-    }
-
-#if defined(FABRIC_RELAY)
-    noc_async_write(data_ptr, get_noc_addr_helper(downstream_noc_xy, dispatch_data_ptr), length);
-#else
-    cq_noc_async_write_with_state_any_len<true, true>(
-        data_ptr, get_noc_addr_helper(downstream_noc_xy, dispatch_data_ptr), length);
-#endif
-    dispatch_data_ptr += length;
-
-    return stride;
+    return cmd->relay_inline.stride;
 }
 
 template <uint32_t cmd_header_size = sizeof(CQPrefetchCmd)>
@@ -1290,375 +613,59 @@ void* copy_into_l1_cache(
     uint32_t* l1_cache,
     PrefetchExecBufState& exec_buf_state,
     uint32_t& stride) {
-    uint32_t remaining_stride = exec_buf_state.length;
-    uint32_t remaining = (exec_buf_state.length - cmd_header_size);
-    volatile uint32_t tt_l1_ptr* l1_ptr = (volatile uint32_t tt_l1_ptr*)(cmd_ptr + cmd_header_size);
-    uint32_t* l1_cache_pos = l1_cache;
-    while (sub_cmds_length > remaining) {
-        uint32_t amt = remaining / sizeof(uint32_t);
-        careful_copy_from_l1_to_local_cache<l1_to_local_cache_copy_chunk, l1_cache_elements_rounded>(
-            l1_ptr, amt, l1_cache_pos);
-
-        l1_cache_pos += amt;
-        sub_cmds_length -= remaining;
-        stride -= remaining_stride;
-        exec_buf_state.length = 0;
-        cmd_ptr += remaining_stride;
-        paged_read_into_cmddat_q(cmd_ptr, exec_buf_state);
-        l1_ptr = (volatile uint32_t tt_l1_ptr*)(cmd_ptr);
-        remaining = exec_buf_state.length;
-        remaining_stride = exec_buf_state.length;
-    }
-    uint32_t amt = sub_cmds_length / sizeof(uint32_t);
-    // Check that the final write does not overflow the L1 cache and corrupt the stack.
-    // End address of final write is: curr_offset_into_cache + write_size_rounded_up_to_copy_chunk
-    ASSERT(
-        (uint32_t)(l1_cache_pos +
-                   ((amt + l1_to_local_cache_copy_chunk - 1) / l1_to_local_cache_copy_chunk) *
-                       l1_to_local_cache_copy_chunk -
-                   l1_cache) < l1_cache_elements_rounded);
-    careful_copy_from_l1_to_local_cache<l1_to_local_cache_copy_chunk, l1_cache_elements_rounded>(
-        l1_ptr, amt, l1_cache_pos);
-
-    // Return a pointer to right after the last copy
-    return &l1_cache_pos[amt];
+    return nullptr;
 }
 
 // Separate implementation that fetches more data from exec buf when cmd has been split
 static uint32_t process_exec_buf_relay_paged_packed_cmd(
     uint32_t& cmd_ptr, uint32_t& downstream__data_ptr, uint32_t* l1_cache, PrefetchExecBufState& exec_buf_state) {
     volatile CQPrefetchCmd tt_l1_ptr* cmd = (volatile CQPrefetchCmd tt_l1_ptr*)cmd_ptr;
-    uint32_t total_length = cmd->relay_paged_packed.total_length;
-    uint32_t sub_cmds_length = cmd->relay_paged_packed.count * sizeof(CQPrefetchRelayPagedPackedSubCmd);
-    uint32_t stride = cmd->relay_paged_packed.stride;
-    ASSERT(total_length > 0);
-    // DPRINT << "paged_packed: " << total_length << " " << cmd->relay_paged_packed.stride << ENDL();
-
-    void* end = copy_into_l1_cache(cmd_ptr, sub_cmds_length, l1_cache, exec_buf_state, stride);
-
-    // Store a sentinal non 0 value at the end to save a test/branch in read path
-    ((CQPrefetchRelayPagedPackedSubCmd*)end)->length = 1;
-
-    process_relay_paged_packed_sub_cmds(total_length, l1_cache);
-    return stride;
+    return cmd->relay_paged_packed.stride;
 }
 
 uint32_t process_exec_buf_cmd(
     uint32_t cmd_ptr_outer, uint32_t& downstream_data_ptr, uint32_t* l1_cache, PrefetchExecBufState& exec_buf_state) {
-    // dispatch on eth cores is memory constrained, so exec_buf re-uses the cmddat_q
-    // prefetch_h stalls upon issuing an exec_buf to prevent conflicting use of the cmddat_q,
-    // the exec_buf contains the release commands
-    volatile CQPrefetchCmd tt_l1_ptr* cmd = (volatile CQPrefetchCmd tt_l1_ptr*)cmd_ptr_outer;
-
-    // setup exec_buf_state the first time
-    exec_buf_state.page_id = 0;
-    exec_buf_state.base_addr = cmd->exec_buf.base_addr;
-    exec_buf_state.log_page_size = cmd->exec_buf.log_page_size;
-    exec_buf_state.pages = cmd->exec_buf.pages;
-    exec_buf_state.length = 0;
-    exec_buf_state.read_ptr = cmddat_q_base;
-    exec_buf_state.prefetch_length = 0;
-    uint32_t cmd_ptr = cmddat_q_base;
-
-    bool done = false;
-    while (!done) {
-        paged_read_into_cmddat_q(cmd_ptr, exec_buf_state);
-
-        while (exec_buf_state.length > 0) {
-            uint32_t stride;
-            done = process_cmd<false, true>(cmd_ptr, downstream_data_ptr, stride, l1_cache, exec_buf_state);
-
-            if (done) {
-                break;
-            }
-
-            exec_buf_state.length -= stride;
-            cmd_ptr += stride;
-        }
-    }
-
     return CQ_PREFETCH_CMD_BARE_MIN_SIZE;
 }
 
 uint32_t process_paged_to_ringbuffer_cmd(uint32_t cmd_ptr, uint32_t& downstream__data_ptr) {
-    // This ensures that a previous cmd using the ringbuffer have completed.
-    noc_async_writes_flushed();
-
-    volatile CQPrefetchCmd tt_l1_ptr* cmd = (volatile CQPrefetchCmd tt_l1_ptr*)cmd_ptr;
-    uint32_t start_page = cmd->paged_to_ringbuffer.start_page;
-    uint32_t base_addr = cmd->paged_to_ringbuffer.base_addr;
-    uint8_t log2_page_size = cmd->paged_to_ringbuffer.log2_page_size;
-    uint32_t page_size = 1 << log2_page_size;
-    uint32_t length = cmd->paged_to_ringbuffer.length;
-    uint8_t flags = cmd->paged_to_ringbuffer.flags;
-    uint32_t wp_update_offset = cmd->paged_to_ringbuffer.wp_offset_update;
-
-    ASSERT(length <= wp_update_offset);
-
-    if (flags & CQ_PREFETCH_PAGED_TO_RING_BUFFER_FLAG_RESET_TO_START) {
-        ringbuffer_wp = scratch_db_base;
-    }
-
-    ASSERT(length % DRAM_ALIGNMENT == 0);
-    ASSERT(wp_update_offset + ringbuffer_wp <= ringbuffer_end);
-
-    ringbuffer_offset = ringbuffer_wp - scratch_db_base;
-
-    const bool is_dram = true;
-    InterleavedPow2AddrGen<is_dram> addr_gen{.bank_base_address = base_addr, .log_base_2_of_page_size = log2_page_size};
-
-    uint32_t scratch_read_addr = ringbuffer_wp;
-    uint32_t page_id = start_page;
-    while (length >= page_size) {
-        uint64_t noc_addr = addr_gen.get_noc_addr(page_id);
-        noc_async_read(noc_addr, scratch_read_addr, page_size);
-        scratch_read_addr += page_size;
-        page_id++;
-        length -= page_size;
-    }
-    if (length > 0) {
-        uint64_t noc_addr = addr_gen.get_noc_addr(page_id);
-        noc_async_read(noc_addr, scratch_read_addr, length);
-        scratch_read_addr += length;
-    }
-
-    ringbuffer_wp += wp_update_offset;
-
-    // The consumer will perform a read barrier.
-
     return CQ_PREFETCH_CMD_BARE_MIN_SIZE;
 }
 
 uint32_t process_set_ringbuffer_offset(uint32_t cmd_ptr) {
-    volatile CQPrefetchCmd tt_l1_ptr* cmd = (volatile CQPrefetchCmd tt_l1_ptr*)cmd_ptr;
-    uint32_t offset = cmd->set_ringbuffer_offset.offset;
-
-    if (cmd->set_ringbuffer_offset.update_wp) {
-        ringbuffer_wp = scratch_db_base + offset;
-        ASSERT(ringbuffer_wp <= ringbuffer_end);
-    } else {
-        ringbuffer_offset = offset;
-    }
-
     return CQ_PREFETCH_CMD_BARE_MIN_SIZE;
 }
 
 void process_relay_ringbuffer_sub_cmds(uint32_t count, uint32_t* l1_cache) {
-    CQPrefetchRelayRingbufferSubCmd tt_l1_ptr* sub_cmd = (CQPrefetchRelayRingbufferSubCmd tt_l1_ptr*)(l1_cache);
-    ASSERT(count > 0);
-
-    noc_async_read_barrier();
-    uint32_t ringbuffer_start = ringbuffer_offset + scratch_db_base;
-
-    for (uint32_t i = 0; i < count - 1; i++) {
-        uint32_t start = ringbuffer_start + sub_cmd->start;
-        uint32_t length = sub_cmd->length;
-
-        uint32_t npages = write_pages_to_dispatcher<0, false>(downstream_data_ptr, start, length);
-
-        DispatchRelayInlineState::cb_writer.release_pages(npages, downstream_data_ptr, /*round_to_page_size*/ true);
-        sub_cmd++;
-    }
-    uint32_t start = ringbuffer_start + sub_cmd->start;
-    uint32_t length = sub_cmd->length;
-    uint32_t npages = write_pages_to_dispatcher<1, false>(downstream_data_ptr, start, length);
-
-    // One page was acquired w/ the cmd in CMD_RELAY_INLINE_NOFLUSH with 16 bytes written
-    downstream_data_ptr = round_up_pow2(downstream_data_ptr, downstream_cb_page_size);
-    DispatchRelayInlineState::cb_writer.release_pages(npages + 1, downstream_data_ptr);
 }
 
 template <bool cmddat_wrap_enable>
 uint32_t process_relay_ringbuffer_cmd(uint32_t cmd_ptr, uint32_t& downstream__data_ptr, uint32_t* l1_cache) {
     volatile CQPrefetchCmd tt_l1_ptr* cmd = (volatile CQPrefetchCmd tt_l1_ptr*)cmd_ptr;
-    uint32_t count = cmd->relay_ringbuffer.count;
-    uint32_t sub_cmds_length = count * sizeof(CQPrefetchRelayRingbufferSubCmd);
-    uint32_t stride = cmd->relay_ringbuffer.stride;
-    // DPRINT << "relay_ringbuffer: " << count << " " << cmd->relay_ringbuffer.stride << ENDL();
-
-    uint32_t data_ptr = cmd_ptr + sizeof(CQPrefetchCmd);
-    uint32_t remaining = cmddat_q_end - data_ptr;
-    uint32_t* l1_cache_pos = l1_cache;
-    if (cmddat_wrap_enable && sub_cmds_length > remaining) {
-        // wrap cmddat
-        uint32_t amt = remaining / sizeof(uint32_t);
-        careful_copy_from_l1_to_local_cache<l1_to_local_cache_copy_chunk, l1_cache_elements_rounded>(
-            (volatile uint32_t tt_l1_ptr*)(data_ptr), amt, l1_cache_pos);
-        sub_cmds_length -= remaining;
-        data_ptr = cmddat_q_base;
-        l1_cache_pos += amt;
-    }
-
-    uint32_t amt = sub_cmds_length / sizeof(uint32_t);
-    // Check that the final write does not overflow the L1 cache and corrupt the stack
-    // End address of final write is: curr_offset_into_cache + write_size_rounded_up_to_copy_chunk
-    ASSERT(
-        (uint32_t)(l1_cache_pos +
-                   ((amt + l1_to_local_cache_copy_chunk - 1) / l1_to_local_cache_copy_chunk) *
-                       l1_to_local_cache_copy_chunk -
-                   l1_cache) < l1_cache_elements_rounded);
-    careful_copy_from_l1_to_local_cache<l1_to_local_cache_copy_chunk, l1_cache_elements_rounded>(
-        (volatile uint32_t tt_l1_ptr*)(data_ptr), amt, l1_cache_pos);
-
-    process_relay_ringbuffer_sub_cmds(count, l1_cache);
-    return stride;
+    return cmd->relay_ringbuffer.stride;
 }
 
 // Separate implementation that fetches more data from exec buf when cmd has been split
 static uint32_t process_exec_buf_relay_ringbuffer_cmd(
     uint32_t& cmd_ptr, uint32_t& downstream__data_ptr, uint32_t* l1_cache, PrefetchExecBufState& exec_buf_state) {
     volatile CQPrefetchCmd tt_l1_ptr* cmd = (volatile CQPrefetchCmd tt_l1_ptr*)cmd_ptr;
-    uint32_t count = cmd->relay_ringbuffer.count;
-    uint32_t sub_cmds_length = count * sizeof(CQPrefetchRelayRingbufferSubCmd);
-    uint32_t stride = cmd->relay_ringbuffer.stride;
-
-    copy_into_l1_cache(cmd_ptr, sub_cmds_length, l1_cache, exec_buf_state, stride);
-
-    process_relay_ringbuffer_sub_cmds(count, l1_cache);
-    return stride;
+    return cmd->relay_ringbuffer.stride;
 }
 
 void process_relay_linear_packed_sub_cmds(uint32_t noc_xy_addr, uint32_t total_length, uint32_t* l1_cache) {
-    // This ensures that a previous cmd using the scratch buf has finished
-    noc_async_writes_flushed();
-
-    // First step - read multiple sub_cmds worth into DB0
-    CQPrefetchRelayLinearPackedSubCmd tt_l1_ptr* sub_cmd = (CQPrefetchRelayLinearPackedSubCmd tt_l1_ptr*)(l1_cache);
-    uint64_t current_addr = sub_cmd->addr;
-    uint32_t current_length = sub_cmd->length;
-    uint32_t amt_to_read = (scratch_db_half_size > total_length) ? total_length : scratch_db_half_size;
-    uint32_t amt_read = 0;
-    uint32_t scratch_read_addr = scratch_db_top[0];
-
-    while (amt_read < amt_to_read) {
-        uint32_t amt_to_read2 =
-            (scratch_db_half_size - amt_read > current_length) ? current_length : scratch_db_half_size - amt_read;
-        noc_read_64bit_any_len<true>(noc_xy_addr, current_addr, scratch_read_addr, amt_to_read2);
-        scratch_read_addr += amt_to_read2;
-        amt_read += amt_to_read2;
-        current_addr += amt_to_read2;
-        current_length -= amt_to_read2;
-
-        // If we've consumed the current sub-command, move to the next one
-        if (current_length == 0) {
-            sub_cmd++;
-            current_addr = sub_cmd->addr;
-            current_length = sub_cmd->length;
-        }
-    }
-    noc_async_read_barrier();
-
-    // Second step - read into DB[x], write from DB[x], toggle x, iterate
-    // Writes are fast, reads are slow
-    uint32_t db_toggle = 0;
-    uint32_t scratch_write_addr;
-    total_length -= amt_read;
-    while (total_length != 0) {
-        // This ensures that writes from prior iteration are done
-        // TODO(pgk); we can do better on WH w/ tagging
-        noc_async_writes_flushed();
-
-        db_toggle ^= 1;
-        scratch_read_addr = scratch_db_top[db_toggle];
-        scratch_write_addr = scratch_db_top[db_toggle ^ 1];
-
-        uint32_t amt_to_write = amt_read;
-        amt_read = 0;
-        amt_to_read = (scratch_db_half_size > total_length) ? total_length : scratch_db_half_size;
-        while (amt_read < amt_to_read) {
-            uint32_t amt_to_read2 =
-                (scratch_db_half_size - amt_read > current_length) ? current_length : scratch_db_half_size - amt_read;
-            noc_read_64bit_any_len<false>(noc_xy_addr, current_addr, scratch_read_addr, amt_to_read2);
-            scratch_read_addr += amt_to_read2;
-            amt_read += amt_to_read2;
-            current_addr += amt_to_read2;
-            current_length -= amt_to_read2;
-
-            // If we've consumed the current sub-command, move to the next one
-            if (current_length == 0) {
-                sub_cmd++;
-                current_addr = sub_cmd->addr;
-                current_length = sub_cmd->length;
-            }
-        }
-
-        // Third step - write from DB
-        uint32_t npages = write_pages_to_dispatcher<0, false>(downstream_data_ptr, scratch_write_addr, amt_to_write);
-        DispatchRelayInlineState::cb_writer.release_pages(npages, downstream_data_ptr, /*round_to_page_size*/ true);
-
-        total_length -= amt_read;
-
-        // TODO(pgk); we can do better on WH w/ tagging
-        noc_async_read_barrier();
-    }
-
-    // Third step - write from DB
-    scratch_write_addr = scratch_db_top[db_toggle];
-    uint32_t amt_to_write = amt_read;
-    uint32_t npages = write_pages_to_dispatcher<1, true>(downstream_data_ptr, scratch_write_addr, amt_to_write);
-
-    downstream_data_ptr = round_up_pow2(downstream_data_ptr, downstream_cb_page_size);
-
-    // One page was acquired w/ the cmd in CMD_RELAY_INLINE_NOFLUSH with 16 bytes written
-    DispatchRelayInlineState::cb_writer.release_pages(npages + 1, downstream_data_ptr);
 }
 
 template <bool cmddat_wrap_enable>
 uint32_t process_relay_linear_packed_cmd(uint32_t cmd_ptr, uint32_t& downstream_data_ptr, uint32_t* l1_cache) {
     volatile CQPrefetchCmd tt_l1_ptr* cmd = (volatile CQPrefetchCmd tt_l1_ptr*)cmd_ptr;
-    uint32_t noc_xy_addr = cmd->relay_linear_packed.noc_xy_addr;
-    uint32_t total_length = cmd->relay_linear_packed.total_length;
-    uint32_t sub_cmds_length = cmd->relay_linear_packed.count * sizeof(CQPrefetchRelayLinearPackedSubCmd);
-    uint32_t stride = cmd->relay_linear_packed.stride;
-    ASSERT(total_length > 0);
-    // DPRINT << "linear_packed: " << total_length << " " << cmd->relay_linear_packed.stride << ENDL();
-
-    uint32_t data_ptr = cmd_ptr + sizeof(CQPrefetchCmd);
-    uint32_t remaining = cmddat_q_end - data_ptr;
-    uint32_t* l1_cache_pos = l1_cache;
-    if (cmddat_wrap_enable && sub_cmds_length > remaining) {
-        // wrap cmddat
-        uint32_t amt = remaining / sizeof(uint32_t);
-        careful_copy_from_l1_to_local_cache<l1_to_local_cache_copy_chunk, l1_cache_elements_rounded>(
-            (volatile uint32_t tt_l1_ptr*)(data_ptr), amt, l1_cache_pos);
-        sub_cmds_length -= remaining;
-        data_ptr = cmddat_q_base;
-        l1_cache_pos += amt;
-    }
-
-    uint32_t amt = sub_cmds_length / sizeof(uint32_t);
-    // Check that the final write does not overflow the L1 cache and corrupt the stack
-    // End address of final write is: curr_offset_into_cache + write_size_rounded_up_to_copy_chunk
-    ASSERT(
-        (uint32_t)(l1_cache_pos +
-                   ((amt + l1_to_local_cache_copy_chunk - 1) / l1_to_local_cache_copy_chunk) *
-                       l1_to_local_cache_copy_chunk -
-                   l1_cache) < l1_cache_elements_rounded);
-    careful_copy_from_l1_to_local_cache<l1_to_local_cache_copy_chunk, l1_cache_elements_rounded>(
-        (volatile uint32_t tt_l1_ptr*)(data_ptr), amt, l1_cache_pos);
-    // Store a sentinal non 0 value at the end to save a test/branch in read path
-    ((CQPrefetchRelayLinearPackedSubCmd*)&l1_cache_pos[amt])->length = 1;
-
-    process_relay_linear_packed_sub_cmds(noc_xy_addr, total_length, l1_cache);
-    return stride;
+    return cmd->relay_linear_packed.stride;
 }
 
 // Separate implementation that fetches more data from exec buf when cmd has been split
 static uint32_t process_exec_buf_relay_linear_packed_cmd(
     uint32_t& cmd_ptr, uint32_t& downstream_data_ptr, uint32_t* l1_cache, PrefetchExecBufState& exec_buf_state) {
     volatile CQPrefetchCmd tt_l1_ptr* cmd = (volatile CQPrefetchCmd tt_l1_ptr*)cmd_ptr;
-    uint32_t noc_xy_addr = cmd->relay_linear_packed.noc_xy_addr;
-    uint32_t total_length = cmd->relay_linear_packed.total_length;
-    uint32_t sub_cmds_length = cmd->relay_linear_packed.count * sizeof(CQPrefetchRelayLinearPackedSubCmd);
-    uint32_t stride = cmd->relay_linear_packed.stride;
-
-    void* end = copy_into_l1_cache(cmd_ptr, sub_cmds_length, l1_cache, exec_buf_state, stride);
-
-    // Store a sentinal non 0 value at the end to save a test/branch in read path
-    ((CQPrefetchRelayLinearPackedSubCmd*)end)->length = 1;
-
-    process_relay_linear_packed_sub_cmds(noc_xy_addr, total_length, l1_cache);
-    return stride;
+    return cmd->relay_linear_packed.stride;
 }
 
 template <bool cmddat_wrap_enable, bool exec_buf>
@@ -1813,271 +820,6 @@ bool process_cmd(
     return done;
 }
 
-/* Relay linear bytes to dispatch_hd or dispatch_d via prefetch_d. test_for_nonzero is an optimization that can be false
- * if amt_to_write >= downstream_cb_page_size. For simplicity this code will always acquire the exact number of pages
- * needed, unlike write_pages_to_dispatcher which may acquire an extra page if we hit an exact page boundary. */
-template <bool test_for_nonzero>
-static void relay_linear_to_downstream(
-    uint32_t& downstream_data_ptr, uint32_t scratch_write_addr, uint32_t amt_to_write) {
-    // Unlike in write_pages_to_dispatcher we always round npages down, so if downstream_data_ptr is at the start of a
-    // page, that means page_residual_space is 0. This is why the logic is different from write_pages_to_dispatcher.
-    uint32_t page_residual_space = -downstream_data_ptr & (downstream_cb_page_size - 1);
-
-    // Following is fine if downstream cb block is bigger than scratch and there are at least a couple of them
-    uint32_t npages = (amt_to_write - page_residual_space + downstream_cb_page_size - 1) / downstream_cb_page_size;
-    if (!test_for_nonzero || (npages != 0)) {
-        DispatchRelayInlineState::cb_writer.acquire_pages(npages);
-    }
-    uint64_t noc_addr;
-    if (downstream_data_ptr == downstream_cb_end) {
-        downstream_data_ptr = downstream_cb_base;
-    } else if (downstream_data_ptr + amt_to_write > downstream_cb_end) {  // wrap
-        uint32_t last_chunk_size = downstream_cb_end - downstream_data_ptr;
-        noc_addr = get_noc_addr_helper(downstream_noc_xy, downstream_data_ptr);
-        relay_client.write_any_len<my_noc_index, true, NCRISC_WR_CMD_BUF>(
-            scratch_write_addr, noc_addr, last_chunk_size);
-        downstream_data_ptr = downstream_cb_base;
-        scratch_write_addr += last_chunk_size;
-        amt_to_write -= last_chunk_size;
-    }
-    noc_addr = get_noc_addr_helper(downstream_noc_xy, downstream_data_ptr);
-    relay_client
-        .write_atomic_inc_any_len<my_noc_index, downstream_noc_xy, downstream_cb_sem_id, true, NCRISC_WR_CMD_BUF>(
-            scratch_write_addr, noc_addr, amt_to_write, npages);
-    downstream_data_ptr += amt_to_write;
-}
-
-// Used in prefetch_h upstream of a CQ_PREFETCH_CMD_RELAY_LINEAR_H command.
-uint32_t process_relay_linear_h_cmd(uint32_t cmd_ptr, uint32_t& downstream_data_ptr) {
-    volatile CQPrefetchCmdLarge tt_l1_ptr* cmd = nullptr;
-    cmd = (volatile CQPrefetchCmdLarge tt_l1_ptr*)(cmd_ptr + sizeof(CQPrefetchHToPrefetchDHeader));
-    uint64_t wlength = cmd->relay_linear_h.length;
-    uint32_t scratch_read_addr = scratch_db_top[0];
-    constexpr uint32_t start_offset = sizeof(CQPrefetchHToPrefetchDHeader);
-    // kernel_h must relay user data from pinned buffer to downstream (kernel_d's cmddatq)
-    volatile tt_l1_ptr CQPrefetchHToPrefetchDHeader* dptr =
-        (volatile tt_l1_ptr CQPrefetchHToPrefetchDHeader*)scratch_read_addr;
-    dptr->header.length = wlength + sizeof(CQPrefetchHToPrefetchDHeader);
-    dptr->header.raw_copy = true;
-    scratch_read_addr += sizeof(CQPrefetchHToPrefetchDHeader);
-
-    uint32_t noc_xy_addr = cmd->relay_linear_h.noc_xy_addr;
-    uint64_t read_addr = cmd->relay_linear_h.addr;
-
-    // DPRINT << "relay_linear_h: cmd_ptr:0x" << HEX() << (uint32_t)cmd_ptr << ", length:0x " << wlength << ", addr:0x"
-    // << read_addr << ", nocxy:0x" << noc_xy_addr << ", downstream_data_ptr:0x" << downstream_data_ptr << DEC() <<
-    // ENDL();
-
-    // First step - read into DB0
-    uint32_t amt_to_read =
-        (scratch_db_half_size - start_offset > wlength) ? wlength : scratch_db_half_size - start_offset;
-    noc_read_64bit_any_len<true>(noc_xy_addr, read_addr, scratch_read_addr, amt_to_read);
-
-    read_addr += amt_to_read;
-    wlength -= amt_to_read;
-    noc_async_read_barrier();
-
-    // Second step - read into DB[x], write from DB[x], toggle x, iterate
-    // Writes are fast, reads are slow
-    uint32_t scratch_write_start_addr = scratch_db_top[0];
-    uint32_t scratch_read_start_addr = scratch_db_top[1];
-    // Add back start_offset to amt_to_read to ensure all bytes from scratch_db are transferred
-    amt_to_read += start_offset;
-    // Calculate the largest multiple of scratch_db_half_size that can fit in a uint32_t. This allows most of the math
-    // to be done in 32 bits.
-    constexpr uint32_t max_batch_size = ~(scratch_db_half_size - 1);
-    while (wlength != 0) {
-        uint32_t read_length = (wlength > max_batch_size) ? max_batch_size : wlength;
-        wlength -= read_length;
-        while (read_length != 0) {
-            // This ensures that writes from prior iteration are done
-            noc_async_writes_flushed();
-
-            uint32_t scratch_read_addr = scratch_read_start_addr;
-            uint32_t scratch_write_addr = scratch_write_start_addr;
-            std::swap(scratch_read_start_addr, scratch_write_start_addr);
-
-            uint32_t amt_to_write = amt_to_read;
-            amt_to_read = (scratch_db_half_size > read_length) ? read_length : scratch_db_half_size;
-            noc_read_64bit_any_len<false>(noc_xy_addr, read_addr, scratch_read_addr, amt_to_read);
-            read_addr += amt_to_read;
-
-            // Third step - write from DB. amt_to_write is greater than a page, so we don't need to test for nonzero.
-            relay_linear_to_downstream<false>(downstream_data_ptr, scratch_write_addr, amt_to_write);
-            read_length -= amt_to_read;
-
-            // TODO(pgk); we can do better on WH w/ tagging
-            noc_async_read_barrier();
-        }
-    }
-
-    // Third step - write from DB
-    uint32_t amt_to_write = amt_to_read;
-    relay_linear_to_downstream<true>(downstream_data_ptr, scratch_write_start_addr, amt_to_write);
-    downstream_data_ptr = round_up_pow2(downstream_data_ptr, downstream_cb_page_size);
-
-    // RelayLinearH is a large command.
-    return 2 * CQ_PREFETCH_CMD_BARE_MIN_SIZE;
-}
-
-// Used in prefetch_h upstream of a CQ_PREFETCH_CMD_RELAY_LINEAR_PACKED_H command.
-// Combines packed linear reads (multiple sub-commands) with H-variant relay to remote device.
-uint32_t process_relay_linear_packed_h_cmd(uint32_t cmd_ptr, uint32_t& downstream_data_ptr, uint32_t* l1_cache) {
-    volatile CQPrefetchCmd tt_l1_ptr* cmd =
-        (volatile CQPrefetchCmd tt_l1_ptr*)(cmd_ptr + sizeof(CQPrefetchHToPrefetchDHeader));
-    uint32_t noc_xy_addr = cmd->relay_linear_packed.noc_xy_addr;
-    uint32_t total_length = cmd->relay_linear_packed.total_length;
-    uint32_t sub_cmds_length = cmd->relay_linear_packed.count * sizeof(CQPrefetchRelayLinearPackedSubCmd);
-    uint32_t stride = cmd->relay_linear_packed.stride;
-    ASSERT(total_length > 0);
-
-    // Copy sub-commands into L1 cache (same pattern as process_relay_linear_packed_cmd)
-    uint32_t data_ptr = cmd_ptr + sizeof(CQPrefetchHToPrefetchDHeader) + sizeof(CQPrefetchCmd);
-    uint32_t amt = sub_cmds_length / sizeof(uint32_t);
-    careful_copy_from_l1_to_local_cache<l1_to_local_cache_copy_chunk, l1_cache_elements_rounded>(
-        (volatile uint32_t tt_l1_ptr*)(data_ptr), amt, l1_cache);
-
-    // Setup scratch buffer for relay
-    uint32_t scratch_read_addr = scratch_db_top[0];
-    constexpr uint32_t start_offset = sizeof(CQPrefetchHToPrefetchDHeader);
-    // kernel_h must relay user data to downstream (kernel_d's cmddatq)
-    volatile tt_l1_ptr CQPrefetchHToPrefetchDHeader* dptr =
-        (volatile tt_l1_ptr CQPrefetchHToPrefetchDHeader*)scratch_read_addr;
-    dptr->header.length = total_length + sizeof(CQPrefetchHToPrefetchDHeader);
-    dptr->header.raw_copy = true;
-    scratch_read_addr += sizeof(CQPrefetchHToPrefetchDHeader);
-
-    // Initialize the src NoC address once, since all sub-commands will use the same address.
-    noc_read_with_state<DM_DEDICATED_NOC, read_cmd_buf, CQ_NOC_sNdl, CQ_NOC_send, CQ_NOC_WAIT>(
-        noc_index, noc_xy_addr, 0, 0, 0);
-
-    // First step - read multiple sub_cmds worth into DB0
-    CQPrefetchRelayLinearPackedSubCmd tt_l1_ptr* sub_cmd = (CQPrefetchRelayLinearPackedSubCmd tt_l1_ptr*)(l1_cache);
-    uint64_t current_addr = sub_cmd->addr;
-    uint32_t current_length = sub_cmd->length;
-    // Total amount to read into the scratch db half from all sub-commands (that fit)
-    uint32_t amt_to_read_to_scratch_db =
-        (scratch_db_half_size - start_offset > total_length) ? total_length : scratch_db_half_size - start_offset;
-
-    uint32_t amt_read = amt_to_read_to_scratch_db;
-
-    auto fill_scratch_db = [&]() {
-        while (amt_to_read_to_scratch_db > 0) {
-            uint32_t amt_to_read_sub_cmd =
-                amt_to_read_to_scratch_db > current_length ? current_length : amt_to_read_to_scratch_db;
-            noc_read_64bit_any_len<false>(noc_xy_addr, current_addr, scratch_read_addr, amt_to_read_sub_cmd);
-            scratch_read_addr += amt_to_read_sub_cmd;
-
-            amt_to_read_to_scratch_db -= amt_to_read_sub_cmd;
-            current_addr += amt_to_read_sub_cmd;
-            current_length -= amt_to_read_sub_cmd;
-
-            // If we've consumed the current sub-command, move to the next one
-            if (current_length == 0) {
-                sub_cmd++;
-                current_addr = sub_cmd->addr;
-                current_length = sub_cmd->length;
-            }
-        }
-    };
-
-    fill_scratch_db();
-    noc_async_read_barrier();
-
-    // Second step - read into DB[x], write from DB[x], toggle x, iterate
-    // Writes are fast, reads are slow
-    uint32_t scratch_write_start_addr = scratch_db_top[0];
-    uint32_t scratch_read_start_addr = scratch_db_top[1];
-    uint32_t read_length = total_length - amt_read;
-    // Add back start_offset to amt_read to ensure all bytes from scratch_db are transferred
-    amt_read += start_offset;
-
-    while (read_length != 0) {
-        // This ensures that writes from prior iteration are done
-        noc_async_writes_flushed();
-
-        scratch_read_addr = scratch_read_start_addr;
-        uint32_t scratch_write_addr = scratch_write_start_addr;
-        std::swap(scratch_read_start_addr, scratch_write_start_addr);
-
-        uint32_t amt_to_write = amt_read;
-        amt_to_read_to_scratch_db = (scratch_db_half_size > read_length) ? read_length : scratch_db_half_size;
-        amt_read = amt_to_read_to_scratch_db;
-        fill_scratch_db();
-
-        // Third step - write from DB. amt_to_write is greater than a page, so we don't need to test for nonzero.
-        relay_linear_to_downstream<false>(downstream_data_ptr, scratch_write_addr, amt_to_write);
-        read_length -= amt_read;
-
-        // TODO(pgk); we can do better on WH w/ tagging
-        noc_async_read_barrier();
-    }
-
-    // Third step - write from DB
-    uint32_t amt_to_write = amt_read;
-    relay_linear_to_downstream<true>(downstream_data_ptr, scratch_write_start_addr, amt_to_write);
-    downstream_data_ptr = round_up_pow2(downstream_data_ptr, downstream_cb_page_size);
-
-    return stride + sizeof(CQPrefetchHToPrefetchDHeader);
-}
-
-// This function is only valid when called on the H variant
-// It expects the NoC async write state to be initialized to point to the downstream
-static uint32_t process_relay_inline_all(uint32_t data_ptr, uint32_t fence, bool is_exec_buf) {
-    uint32_t length = fence - data_ptr;
-    // Downstream doesn't have FetchQ to tell it how much data to process
-    // This packet header just contains the length
-    volatile tt_l1_ptr CQPrefetchHToPrefetchDHeader* dptr = (volatile tt_l1_ptr CQPrefetchHToPrefetchDHeader*)data_ptr;
-    dptr->header.length = length;
-    dptr->header.raw_copy = false;
-
-    uint32_t npages = (length + downstream_cb_page_size - 1) >> downstream_cb_log_page_size;
-
-    // Assume the dispatch buffer is big relative to cmddat command size that we can
-    // grab what we need in one chunk
-    DispatchRelayInlineState::cb_writer.acquire_pages(npages);
-    if (is_exec_buf) {
-        // swipe all the downstream page credits from ourselves...
-        // prefetch_h stalls sending commands to prefetch_d until notified by dispatch_d that the exec_buf is done
-        // exec_buf completing on dispatch_h will free the pages and allow sending again
-        DispatchRelayInlineState::cb_writer.additional_count -= downstream_cb_pages;
-
-        // OK to continue prefetching once the page credits are returned
-        stall_state = NOT_STALLED;
-    }
-
-    // Write sizes below may exceed NOC_MAX_BURST_SIZE so we use the any_len version
-    // Amount to write depends on how much free space
-    uint32_t downstream_pages_left = (downstream_cb_end - downstream_data_ptr) >> downstream_cb_log_page_size;
-    if (downstream_pages_left >= npages) {
-        // WAIT is not needed here because previous writes were flushed at the end of the loop in the caller (kernel_h)
-        relay_client
-            .write_atomic_inc_any_len<my_noc_index, downstream_noc_xy, downstream_cb_sem_id, false, NCRISC_WR_CMD_BUF>(
-                data_ptr, get_noc_addr_helper(downstream_noc_xy, downstream_data_ptr), length, npages);
-        downstream_data_ptr += npages * downstream_cb_page_size;
-    } else {
-        uint32_t tail_pages = npages - downstream_pages_left;
-        uint32_t available = downstream_pages_left * downstream_cb_page_size;
-        if (available > 0) {
-            relay_client.write_any_len<my_noc_index, false, NCRISC_WR_CMD_BUF, true>(
-                data_ptr, get_noc_addr_helper(downstream_noc_xy, downstream_data_ptr), available);
-            data_ptr += available;
-            length -= available;
-        }
-
-        // Remainder
-        // WAIT is needed here because previously "if (available > 0)" then it used the write buf which may still be
-        // busy at this point
-        relay_client
-            .write_atomic_inc_any_len<my_noc_index, downstream_noc_xy, downstream_cb_sem_id, true, NCRISC_WR_CMD_BUF>(
-                data_ptr, get_noc_addr_helper(downstream_noc_xy, downstream_cb_base), length, npages);
-
-        downstream_data_ptr = downstream_cb_base + tail_pages * downstream_cb_page_size;
-    }
-
-    return fence;
-}
-
 // We require that all data for a single fetch is available before processing commands. We can't use a normal
 // CBReaderWithReleasePolicy because that always releases pages when advancing between blocks,
 // which would cause problems if the data spans multiple blocks.
@@ -2194,62 +936,6 @@ inline uint32_t relay_cb_get_cmds(uint32_t& data_ptr, uint32_t& downstream_data_
 
             data_ptr += sizeof(CQPrefetchHToPrefetchDHeader);
             return length - sizeof(CQPrefetchHToPrefetchDHeader);
-        }
-    }
-}
-
-void kernel_main_h() {
-    uint32_t cmd_ptr = cmddat_q_base;
-    uint32_t fence = cmddat_q_base;
-    bool done = false;
-    uint32_t heartbeat = 0;
-    uint32_t l1_cache[l1_cache_elements_rounded];
-
-    // Fetch q uses read buf. Write buf for process_relay_inline_all/process_relay_linear_h_cmd can be setup once
-    relay_client.init<
-        my_noc_index,
-        fabric_mux_x,
-        fabric_mux_y,
-        worker_credits_stream_id,
-        fabric_mux_channel_base_address,
-        fabric_mux_connection_handshake_address,
-        fabric_mux_connection_info_address,
-        fabric_mux_buffer_index_address,
-        fabric_worker_flow_control_sem,
-        fabric_worker_teardown_sem,
-        fabric_worker_buffer_index_sem,
-        fabric_mux_status_address,
-        my_fabric_sync_status_addr,
-        to_mesh_id,
-        ew_dim,
-        fabric_header_rb_base,
-        num_hops,
-        NCRISC_WR_CMD_BUF>(get_noc_addr_helper(downstream_noc_xy, 0), my_dev_id, to_dev_id, router_direction);
-
-    while (!done) {
-        fetch_q_get_cmds<sizeof(CQPrefetchHToPrefetchDHeader)>(fence, cmd_ptr, pcie_read_ptr);
-
-        IDLE_ERISC_HEARTBEAT_AND_RETURN(heartbeat);
-
-        volatile CQPrefetchCmd tt_l1_ptr* cmd =
-            (volatile CQPrefetchCmd tt_l1_ptr*)(cmd_ptr + sizeof(CQPrefetchHToPrefetchDHeader));
-        uint32_t cmd_id = cmd->base.cmd_id;
-        // Infer that an exec_buf command is to be executed based on the stall state.
-        bool is_exec_buf = (stall_state == STALLED);
-        if (cmd_id == CQ_PREFETCH_CMD_RELAY_LINEAR_H) {
-            cmd_ptr += process_relay_linear_h_cmd(cmd_ptr, downstream_data_ptr);
-        } else if (cmd_id == CQ_PREFETCH_CMD_RELAY_LINEAR_PACKED_H) {
-            cmd_ptr += process_relay_linear_packed_h_cmd(cmd_ptr, downstream_data_ptr, l1_cache);
-        } else {
-            cmd_ptr = process_relay_inline_all(cmd_ptr, fence, is_exec_buf);
-        }
-        noc_async_writes_flushed();
-
-        // Note: one fetch_q entry can contain multiple commands
-        // The code below assumes these commands arrive individually, packing them would require parsing all cmds
-        if (cmd_id == CQ_PREFETCH_CMD_TERMINATE) {
-            // DPRINT << "prefetch terminating_10" << ENDL();
-            done = true;
         }
     }
 }
@@ -2377,8 +1063,6 @@ void kernel_main() {
 
     if (is_h_variant and is_d_variant) {
         kernel_main_hd();
-    } else if (is_h_variant) {
-        kernel_main_h();
     } else if (is_d_variant) {
         kernel_main_d();
     } else {

--- a/tt_metal/impl/dispatch/kernels/cq_prefetch_reader.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_prefetch_reader.cpp
@@ -1,0 +1,2396 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Prefetch kernel
+//  - 3 flavors: _hd (host and dram), _h (host only), _d (DRAM only)
+//  - fetches commands from host (if applicable), executes
+//  - uses HostQ for host handshaking, ComDatQ for commands (from host),
+//    double buffered ScratchBuf for out of band data (e.g., from DRAM)
+//  - syncs w/ dispatcher via 2 semaphores, page_ready, page_done
+//
+// Write cmd buf allocation:
+//  - BRISC_WR_CMD_BUF: writes to downstream_noc_xy
+//  - BRISC_WR_REG_CMD_BUF: small writes to dispatch_s_noc_xy. not much traffic on this path.
+//
+//  Using the normal NoC APIs for writes and/or inline_dw_writes are not allowed on this kernel.
+//
+
+#include "api/dataflow/dataflow_api.h"
+#include "internal/dataflow/dataflow_api_addrgen.h"
+#include "tt_metal/impl/dispatch/kernels/cq_commands.hpp"
+#include "tt_metal/impl/dispatch/kernels/cq_common.hpp"
+#include "tt_metal/impl/dispatch/kernels/cq_relay.hpp"
+#include "api/debug/dprint.h"
+#include "noc/noc_parameters.h"  // PCIE_ALIGNMENT
+
+constexpr uint32_t CQ_PREFETCH_CMD_BARE_MIN_SIZE = PCIE_ALIGNMENT;  // for NOC PCIe alignemnt
+static_assert(sizeof(CQPrefetchCmd) <= CQ_PREFETCH_CMD_BARE_MIN_SIZE);
+static_assert(sizeof(CQPrefetchCmdLarge) <= CQ_PREFETCH_CMD_BARE_MIN_SIZE);
+struct CQPrefetchHToPrefetchDHeader_s {
+    uint64_t length;
+    uint8_t raw_copy;  // If true, copy the data directly to the downstream.
+};
+union CQPrefetchHToPrefetchDHeader {
+    CQPrefetchHToPrefetchDHeader_s header;
+    unsigned char padding[CQ_PREFETCH_CMD_BARE_MIN_SIZE];
+};
+static_assert((sizeof(CQPrefetchHToPrefetchDHeader) & (CQ_PREFETCH_CMD_BARE_MIN_SIZE - 1)) == 0);
+
+using prefetch_q_entry_type = uint16_t;
+
+// Use named defines instead of get_compile_time_arg_val indices
+constexpr uint32_t downstream_cb_base = DOWNSTREAM_CB_BASE;
+constexpr uint32_t downstream_cb_log_page_size = DOWNSTREAM_CB_LOG_PAGE_SIZE;
+constexpr uint32_t downstream_cb_pages = DOWNSTREAM_CB_PAGES;
+constexpr uint32_t my_downstream_cb_sem_id = MY_DOWNSTREAM_CB_SEM_ID;
+constexpr uint32_t downstream_cb_sem_id = DOWNSTREAM_CB_SEM_ID;
+
+// unused for prefetch_d
+constexpr uint32_t pcie_base = PCIE_BASE;
+constexpr uint32_t pcie_size = PCIE_SIZE;
+constexpr uint32_t prefetch_q_base = PREFETCH_Q_BASE;
+constexpr uint32_t prefetch_q_size = PREFETCH_Q_SIZE;
+constexpr uint32_t prefetch_q_rd_ptr_addr = PREFETCH_Q_RD_PTR_ADDR;
+constexpr uint32_t prefetch_q_pcie_rd_ptr_addr = PREFETCH_Q_PCIE_RD_PTR_ADDR;
+
+constexpr uint32_t cmddat_q_base = CMDDAT_Q_BASE;
+constexpr uint32_t cmddat_q_size = CMDDAT_Q_SIZE;
+
+// unused for prefetch_h
+constexpr uint32_t scratch_db_base = SCRATCH_DB_BASE;
+constexpr uint32_t scratch_db_size = SCRATCH_DB_SIZE;
+constexpr uint32_t my_downstream_sync_sem_id = DOWNSTREAM_SYNC_SEM_ID;
+
+// prefetch_d specific
+constexpr uint32_t cmddat_q_pages = CMDDAT_Q_PAGES;
+constexpr uint32_t my_upstream_cb_sem_id = MY_UPSTREAM_CB_SEM_ID;
+constexpr uint32_t upstream_cb_sem_id = UPSTREAM_CB_SEM_ID;
+constexpr uint32_t cmddat_q_log_page_size = CMDDAT_Q_LOG_PAGE_SIZE;
+constexpr uint32_t cmddat_q_blocks = CMDDAT_Q_BLOCKS;
+
+// used for prefetch_d <--> dispatch_s data path
+constexpr uint32_t dispatch_s_buffer_base = DISPATCH_S_BUFFER_BASE;
+constexpr uint32_t my_dispatch_s_cb_sem_id = MY_DISPATCH_S_CB_SEM_ID;
+constexpr uint32_t downstream_dispatch_s_cb_sem_id = DOWNSTREAM_DISPATCH_S_CB_SEM_ID;
+constexpr uint32_t dispatch_s_buffer_size = DISPATCH_S_BUFFER_SIZE;
+constexpr uint32_t dispatch_s_cb_log_page_size = DISPATCH_S_CB_LOG_PAGE_SIZE;
+
+constexpr uint32_t ringbuffer_size = RINGBUFFER_SIZE;
+
+// fabric mux connection
+constexpr uint32_t fabric_header_rb_base = FABRIC_HEADER_RB_BASE;
+constexpr uint32_t fabric_header_rb_entries = FABRIC_HEADER_RB_ENTRIES;
+constexpr uint32_t my_fabric_sync_status_addr = MY_FABRIC_SYNC_STATUS_ADDR;
+
+constexpr uint8_t fabric_mux_x = FABRIC_MUX_X;
+constexpr uint8_t fabric_mux_y = FABRIC_MUX_Y;
+constexpr uint8_t fabric_mux_num_buffers_per_channel = FABRIC_MUX_NUM_BUFFERS_PER_CHANNEL;
+constexpr size_t fabric_mux_channel_buffer_size_bytes = FABRIC_MUX_CHANNEL_BUFFER_SIZE_BYTES;
+constexpr size_t fabric_mux_channel_base_address = FABRIC_MUX_CHANNEL_BASE_ADDRESS;
+constexpr size_t fabric_mux_connection_info_address = FABRIC_MUX_CONNECTION_INFO_ADDRESS;
+constexpr size_t fabric_mux_connection_handshake_address = FABRIC_MUX_CONNECTION_HANDSHAKE_ADDRESS;
+constexpr size_t fabric_mux_flow_control_address = FABRIC_MUX_FLOW_CONTROL_ADDRESS;
+constexpr size_t fabric_mux_buffer_index_address = FABRIC_MUX_BUFFER_INDEX_ADDRESS;
+constexpr size_t fabric_mux_status_address = FABRIC_MUX_STATUS_ADDRESS;
+constexpr size_t fabric_mux_termination_signal_address = FABRIC_MUX_TERMINATION_SIGNAL_ADDRESS;
+constexpr size_t worker_credits_stream_id = WORKER_CREDITS_STREAM_ID;
+
+constexpr size_t fabric_worker_flow_control_sem = FABRIC_WORKER_FLOW_CONTROL_SEM;
+constexpr size_t fabric_worker_teardown_sem = FABRIC_WORKER_TEARDOWN_SEM;
+constexpr size_t fabric_worker_buffer_index_sem = FABRIC_WORKER_BUFFER_INDEX_SEM;
+
+constexpr uint8_t num_hops = NUM_HOPS;
+
+constexpr uint32_t ew_dim = EW_DIM;
+constexpr uint32_t to_mesh_id = TO_MESH_ID;
+
+constexpr bool is_2d_fabric = FABRIC_2D;
+
+constexpr uint32_t is_d_variant = IS_D_VARIANT;
+constexpr uint32_t is_h_variant = IS_H_VARIANT;
+
+constexpr uint32_t prefetch_q_end = prefetch_q_base + prefetch_q_size;
+constexpr uint32_t cmddat_q_end = cmddat_q_base + cmddat_q_size;
+constexpr uint32_t scratch_db_end = scratch_db_base + scratch_db_size;
+constexpr uint32_t ringbuffer_end = scratch_db_base + ringbuffer_size;
+
+// hd and h: fetch_q, cmddat_q, scratch_db
+static_assert(
+    !(is_h_variant) || (prefetch_q_base >= cmddat_q_end || cmddat_q_base >= prefetch_q_end),
+    "prefetch_q and cmddat_q overlap");
+
+static_assert(
+    !(is_h_variant) || (prefetch_q_base >= scratch_db_end || scratch_db_base >= prefetch_q_end),
+    "prefetch_q and scratch_db overlap");
+
+static_assert(
+    !(is_h_variant) || (scratch_db_base >= cmddat_q_end || cmddat_q_base >= scratch_db_end),
+    "cmddat_q and scratch_db overlap");
+
+// d: cmddat_q, scratch_db
+static_assert(
+    !(is_d_variant && !is_h_variant) || (scratch_db_base >= cmddat_q_end || cmddat_q_base >= scratch_db_end),
+    "cmddat_q and scratch_db overlap");
+
+constexpr uint8_t my_noc_index = NOC_INDEX;
+constexpr uint32_t my_noc_xy = uint32_t(NOC_XY_ENCODING(MY_NOC_X, MY_NOC_Y));
+constexpr uint32_t upstream_noc_xy = uint32_t(NOC_XY_ENCODING(UPSTREAM_NOC_X, UPSTREAM_NOC_Y));
+constexpr uint32_t downstream_noc_xy = uint32_t(NOC_XY_ENCODING(DOWNSTREAM_NOC_X, DOWNSTREAM_NOC_Y));
+constexpr uint32_t dispatch_s_noc_xy = uint32_t(NOC_XY_ENCODING(DOWNSTREAM_SUBORDINATE_NOC_X, DOWNSTREAM_SUBORDINATE_NOC_Y));
+constexpr uint64_t pcie_noc_xy =
+    uint64_t(NOC_XY_PCIE_ENCODING(NOC_X_PHYS_COORD(PCIE_NOC_X), NOC_Y_PHYS_COORD(PCIE_NOC_Y)));
+constexpr uint32_t downstream_cb_page_size = 1 << downstream_cb_log_page_size;
+constexpr uint32_t dispatch_s_cb_page_size = 1 << dispatch_s_cb_log_page_size;
+constexpr uint32_t downstream_cb_end = downstream_cb_base + (1 << downstream_cb_log_page_size) * downstream_cb_pages;
+constexpr uint32_t dispatch_s_buffer_end = dispatch_s_buffer_base + dispatch_s_buffer_size;
+constexpr uint32_t cmddat_q_page_size = 1 << cmddat_q_log_page_size;
+
+constexpr uint32_t scratch_db_half_size = scratch_db_size / 2;
+constexpr uint32_t scratch_db_base0 = scratch_db_base;
+constexpr uint32_t scratch_db_base1 = scratch_db_base + scratch_db_half_size;
+
+constexpr uint32_t prefetch_q_log_minsize = 4;
+
+const uint32_t scratch_db_top[2] = {scratch_db_base0, scratch_db_base1};
+
+constexpr uint32_t cmddat_q_pages_per_block = cmddat_q_pages / cmddat_q_blocks;
+
+// Currently capping the same as dispatch
+constexpr uint32_t max_read_packed_cmd =
+    CQ_PREFETCH_CMD_RELAY_PAGED_PACKED_MAX_SUB_CMDS * sizeof(CQPrefetchRelayPagedPackedSubCmd) / sizeof(uint32_t);
+constexpr uint32_t l1_cache_elements = max_read_packed_cmd + 1;  // +1 for sentinel value
+constexpr uint32_t l1_cache_elements_rounded =
+    ((l1_cache_elements + l1_to_local_cache_copy_chunk - 1) / l1_to_local_cache_copy_chunk) *
+        l1_to_local_cache_copy_chunk +
+    (l1_to_local_cache_copy_chunk - 1);
+
+static_assert(
+    CQ_PREFETCH_CMD_RELAY_RINGBUFFER_MAX_SUB_CMDS * sizeof(CQPrefetchRelayRingbufferSubCmd) / sizeof(uint32_t) <
+        l1_cache_elements_rounded,
+    "CQ_PREFETCH_CMD_RELAY_RINGBUFFER_MAX_SUB_CMDS is too large for l1_cache_elements_rounded");
+
+// Define these constexpr structs for a cleaner interface for process_relay_inline_cmd and
+// process_exec_buf_relay_inline_cmd while ensuring that state for dispatch_master and dispatch_subordinate is passed in
+// during compile time.
+struct DispatchRelayInlineState {
+    static constexpr uint32_t my_downstream_cb_sem = my_downstream_cb_sem_id;
+    static constexpr uint32_t downstream_cb_sem = downstream_cb_sem_id;
+    static constexpr uint32_t downstream_noc_encoding = downstream_noc_xy;
+    static constexpr uint32_t downstream_page_size = downstream_cb_page_size;
+    static constexpr uint32_t downstream_log_page_size = downstream_cb_log_page_size;
+    static constexpr uint32_t downstream_cb_base_addr = downstream_cb_base;
+    static constexpr uint32_t downstream_cb_end_addr = downstream_cb_end;
+    static constexpr uint32_t downstream_write_cmd_buf = BRISC_WR_CMD_BUF;
+    static constexpr uint32_t downstream_noc_index = my_noc_index;
+    static inline CBWriter<
+        my_downstream_cb_sem,
+        my_noc_index,
+        downstream_noc_xy,
+        downstream_cb_sem,
+        downstream_cb_base,
+        downstream_cb_end,
+        downstream_cb_page_size>
+        cb_writer{};
+};
+
+struct DispatchSRelayInlineState {
+    static constexpr uint32_t my_downstream_cb_sem = my_dispatch_s_cb_sem_id;
+    static constexpr uint32_t downstream_cb_sem = downstream_dispatch_s_cb_sem_id;
+    static constexpr uint32_t downstream_noc_encoding = dispatch_s_noc_xy;
+    static constexpr uint32_t downstream_page_size = dispatch_s_cb_page_size;
+    static constexpr uint32_t downstream_log_page_size = dispatch_s_cb_log_page_size;
+    static constexpr uint32_t downstream_cb_base_addr = dispatch_s_buffer_base;
+    static constexpr uint32_t downstream_cb_end_addr = dispatch_s_buffer_end;
+    static constexpr uint32_t downstream_write_cmd_buf = BRISC_WR_REG_CMD_BUF;
+    static constexpr uint32_t downstream_noc_index = my_noc_index;
+    static inline CBWriter<
+        my_dispatch_s_cb_sem_id,
+        my_noc_index,
+        dispatch_s_noc_xy,
+        downstream_dispatch_s_cb_sem_id,
+        dispatch_s_buffer_base,
+        dispatch_s_buffer_end,
+        dispatch_s_cb_page_size>
+        cb_writer{};
+};
+
+struct PrefetchExecBufState {
+    uint32_t page_id;
+    uint32_t base_addr;
+    uint32_t log_page_size;
+    uint32_t pages;
+    uint32_t length;
+    uint32_t read_ptr;
+    uint32_t prefetch_length;
+};
+
+uint32_t process_relay_linear_h_cmd(uint32_t cmd_ptr, uint32_t& downstream_data_ptr);
+
+// Global Variables
+static uint32_t pcie_read_ptr = pcie_base;
+static uint32_t downstream_data_ptr = downstream_cb_base;
+static uint32_t downstream_data_ptr_s = dispatch_s_buffer_base;
+static uint32_t block_next_start_addr[cmddat_q_blocks];
+static uint32_t rd_block_idx = 0;
+static uint32_t upstream_total_acquired_page_count = 0;
+static uint32_t ringbuffer_wp = scratch_db_base;
+static uint32_t ringbuffer_offset = 0;
+
+// Runtime args
+static uint32_t my_dev_id;
+static uint32_t to_dev_id;
+static uint32_t router_direction;
+
+CQRelayClient<fabric_mux_num_buffers_per_channel, fabric_mux_channel_buffer_size_bytes, fabric_header_rb_base>
+    relay_client;
+
+// Feature to stall the prefetcher, mainly for ExecBuf impl which reuses CmdDataQ
+static enum StallState { STALL_NEXT = 2, STALLED = 1, NOT_STALLED = 0 } stall_state = NOT_STALLED;
+
+static_assert((downstream_cb_base & (downstream_cb_page_size - 1)) == 0);
+
+template <bool cmddat_wrap_enable, bool exec_buf>
+bool process_cmd(
+    uint32_t& cmd_ptr,
+    uint32_t& downstream_data_ptr,
+    uint32_t& stride,
+    uint32_t* l1_cache,
+    PrefetchExecBufState& exec_buf_state);
+
+template <uint32_t downstream_cb_base_addr, uint32_t downstream_cmd_buf>
+FORCE_INLINE void write_downstream(
+    uint32_t& data_ptr,
+    uint32_t& local_downstream_data_ptr,
+    uint32_t length,
+    uint32_t downstream_end,
+    uint32_t downstream_noc_encoding = downstream_noc_xy) {
+    uint32_t remaining = downstream_end - local_downstream_data_ptr;
+    if (length > remaining) {
+        if (remaining > 0) {
+#if defined(FABRIC_RELAY)
+            noc_async_write(
+                data_ptr, get_noc_addr_helper(downstream_noc_encoding, local_downstream_data_ptr), remaining);
+#else
+            cq_noc_async_write_with_state_any_len<true, true, CQNocWait::CQ_NOC_WAIT, downstream_cmd_buf>(
+                data_ptr, get_noc_addr_helper(downstream_noc_encoding, local_downstream_data_ptr), remaining);
+#endif
+            data_ptr += remaining;
+            length -= remaining;
+        }
+        local_downstream_data_ptr = downstream_cb_base_addr;
+    }
+
+#if defined(FABRIC_RELAY)
+    noc_async_write(data_ptr, get_noc_addr_helper(downstream_noc_encoding, local_downstream_data_ptr), length);
+#else
+    cq_noc_async_write_with_state_any_len<true, true, CQNocWait::CQ_NOC_WAIT, downstream_cmd_buf>(
+        data_ptr, get_noc_addr_helper(downstream_noc_encoding, local_downstream_data_ptr), length);
+#endif
+    local_downstream_data_ptr += length;
+}
+
+// If prefetcher must stall after this fetch, wait for data to come back, and move to stalled state.
+FORCE_INLINE void barrier_and_stall(uint32_t& pending_read_size, uint32_t& fence, uint32_t& cmd_ptr) {
+    noc_async_read_barrier();
+    if (fence < cmd_ptr) {
+        cmd_ptr = fence;
+    }
+    fence += pending_read_size;
+    pending_read_size = 0;
+    stall_state = STALLED;
+}
+
+template <uint32_t preamble_size>
+FORCE_INLINE uint32_t read_from_pcie(
+    volatile tt_l1_ptr prefetch_q_entry_type*& prefetch_q_rd_ptr,
+    uint32_t& fence,
+    uint32_t& pcie_read_ptr,
+    uint32_t cmd_ptr,
+    uint32_t size) {
+    uint32_t pending_read_size = 0;
+    // Wrap cmddat_q
+    if (fence + size + preamble_size > cmddat_q_end) {
+        // only wrap if there are no commands ready, otherwise we'll leave some on the floor
+        // TODO: does this matter for perf?
+        if (cmd_ptr != fence) {
+            // No pending reads, since the location of fence cannot be moved due to unread commands
+            // in the cmddat_q -> reads cannot be issued to fill the queue.
+            return pending_read_size;
+        }
+        fence = cmddat_q_base;
+    }
+
+    // Wrap pcie/hugepage
+    if (pcie_read_ptr + size > pcie_base + pcie_size) {
+        pcie_read_ptr = pcie_base;
+    }
+
+    uint64_t host_src_addr = pcie_noc_xy | pcie_read_ptr;
+    // DPRINT << "read_from_pcie: " << fence + preamble_size << " " << pcie_read_ptr << ENDL();
+    noc_async_read(host_src_addr, fence + preamble_size, size);
+    pending_read_size = size + preamble_size;
+    pcie_read_ptr += size;
+
+    *prefetch_q_rd_ptr = 0;
+
+    // Tell host we read
+    *(volatile tt_l1_ptr uint32_t*)prefetch_q_rd_ptr_addr = (uint32_t)prefetch_q_rd_ptr;
+    *(volatile tt_l1_ptr uint32_t*)prefetch_q_pcie_rd_ptr_addr = (uint32_t)pcie_read_ptr;
+
+    prefetch_q_rd_ptr++;
+
+    // Wrap prefetch_q
+    if ((uint32_t)prefetch_q_rd_ptr == prefetch_q_end) {
+        prefetch_q_rd_ptr = (volatile tt_l1_ptr prefetch_q_entry_type*)prefetch_q_base;
+    }
+    return pending_read_size;
+}
+
+// This routine can be called in 8 states based on the boolean values cmd_ready, prefetch_q_ready, read_pending:
+//  - !cmd_ready, !prefetch_q_ready, !read_pending: stall on prefetch_q, issue read, read barrier
+//  - !cmd_ready, !prefetch_q_ready,  read pending: read barrier (and re-evaluate prefetch_q_ready)
+//  - !cmd_ready,  prefetch_q_ready, !read_pending: issue read, read barrier
+//  - !cmd_ready,  prefetch_q_ready,  read_pending: read barrier, issue read
+//  -  cmd_ready, !prefetch_q_ready, !read_pending: exit
+//  -  cmd_ready, !prefetch_q_ready,  read_pending: exit (no barrier yet)
+//  -  cmd_ready,  prefetch_q_ready, !read_pending: issue read
+//  -  cmd_ready,  prefetch_q_ready,  read_pending: exit (don't add latency to the in flight request)
+//
+// With WH tagging of reads:
+// open question: should fetcher loop on prefetch_q_ready issuing reads until !prefetch_q_ready
+//  - !cmd_ready, !prefetch_q_ready, !read_pending: stall on prefetch_q, issue read, read barrier
+//  - !cmd_ready, !prefetch_q_ready,  read pending: read barrier on oldest tag
+//  - !cmd_ready,  prefetch_q_ready, !read_pending: issue read, read barrier
+//  - !cmd_ready,  prefetch_q_ready,  read_pending: issue read, read barrier on oldest tag
+//  -  cmd_ready, !prefetch_q_ready, !read_pending: exit
+//  -  cmd_ready, !prefetch_q_ready,  read_pending: exit (no barrier yet)
+//  -  cmd_ready,  prefetch_q_ready, !read_pending: issue and tag read
+//  -  cmd_ready,  prefetch_q_ready,  read_pending: issue and tag read
+template <uint32_t preamble_size>
+void fetch_q_get_cmds(uint32_t& fence, uint32_t& cmd_ptr, uint32_t& pcie_read_ptr) {
+    static uint32_t pending_read_size = 0;
+    static volatile tt_l1_ptr prefetch_q_entry_type* prefetch_q_rd_ptr =
+        (volatile tt_l1_ptr prefetch_q_entry_type*)prefetch_q_base;
+    constexpr uint32_t prefetch_q_msb_mask = 1u << (sizeof(prefetch_q_entry_type) * CHAR_BIT - 1);
+
+    if (stall_state == STALLED) {
+        ASSERT(pending_read_size == 0);  // Before stalling, fetch must have been completed.
+        return;
+    }
+
+    // DPRINT << "fetch_q_get_cmds: " << cmd_ptr << " " << fence << ENDL();
+    if (fence < cmd_ptr) {
+        cmd_ptr = fence;
+    }
+
+    bool cmd_ready = (cmd_ptr != fence);
+
+    uint32_t prefetch_q_rd_ptr_local = *prefetch_q_rd_ptr;
+    uint32_t fetch_size = (prefetch_q_rd_ptr_local & ~prefetch_q_msb_mask) << prefetch_q_log_minsize;
+    bool stall_flag = (prefetch_q_rd_ptr_local & prefetch_q_msb_mask) != 0;
+    stall_state = static_cast<StallState>(stall_flag << 1);  // NOT_STALLED -> STALL_NEXT if stall_flag is set
+
+    if (fetch_size != 0 && pending_read_size == 0) {
+        pending_read_size = read_from_pcie<preamble_size>(prefetch_q_rd_ptr, fence, pcie_read_ptr, cmd_ptr, fetch_size);
+        if (stall_state == STALL_NEXT && pending_read_size != 0) {
+            // No pending reads -> stall_state can be set to STALLED, since the read to the cmd
+            // that initiated the stall has been issued.
+            // exec_buf is the first command being fetched and should be offset
+            // by preamble size. After ensuring that the exec_buf command has been read (barrier),
+            // exit.
+            barrier_and_stall(pending_read_size, fence, cmd_ptr);  // STALL_NEXT -> STALLED
+            return;
+        }
+    }
+    if (!cmd_ready) {
+        if (pending_read_size != 0) {
+            noc_async_read_barrier();
+            // wrap the cmddat_q
+            if (fence < cmd_ptr) {
+                cmd_ptr = fence;
+            }
+
+            fence += pending_read_size;
+            pending_read_size = 0;
+
+            // After the stall, re-check the host
+            prefetch_q_rd_ptr_local = *prefetch_q_rd_ptr;
+            fetch_size = (prefetch_q_rd_ptr_local & ~prefetch_q_msb_mask) << prefetch_q_log_minsize;
+
+            if (fetch_size != 0) {
+                stall_flag = (prefetch_q_rd_ptr_local & prefetch_q_msb_mask) != 0;
+                stall_state =
+                    static_cast<StallState>(stall_flag << 1);  // NOT_STALLED -> STALL_NEXT if stall_flag is set
+
+                if (stall_state == STALL_NEXT) {
+                    // If the prefetcher state reached here, it is issuing a read to the same "slot", since for exec_buf
+                    // commands we will insert a read barrier. Hence, the exec_buf command will be concatenated to a
+                    // previous command, and should not be offset by preamble size.
+                    pending_read_size = read_from_pcie<0>(
+                        prefetch_q_rd_ptr, fence, pcie_read_ptr, cmd_ptr, fetch_size);
+                    if (pending_read_size != 0) {
+                        // if pending_read_size == 0 read_from_pcie early exited, due to a wrap, i.e. the exec_buf cmd
+                        // is at a wrapped location, and a read to it could not be issued, since there are existing
+                        // commands in the cmddat_q. Only move the stall_state to stalled if the read to the cmd that
+                        // initiated the stall was issued
+                        barrier_and_stall(
+                            pending_read_size, fence, cmd_ptr);  // STALL_NEXT -> STALLED
+                    }
+                } else {
+                    pending_read_size = read_from_pcie<preamble_size>(
+                        prefetch_q_rd_ptr, fence, pcie_read_ptr, cmd_ptr, fetch_size);
+                }
+            }
+        } else {
+            // By here, prefetch_q_ready must be false
+            // Nothing to fetch, nothing pending, nothing available, stall on host
+            WAYPOINT("HQW");
+            uint32_t heartbeat = 0;
+            while ((fetch_size = *prefetch_q_rd_ptr) == 0) {
+                invalidate_l1_cache();
+                IDLE_ERISC_HEARTBEAT_AND_RETURN(heartbeat);
+            }
+            fetch_q_get_cmds<preamble_size>(fence, cmd_ptr, pcie_read_ptr);
+            WAYPOINT("HQD");
+        }
+    }
+}
+
+uint32_t process_debug_cmd(uint32_t cmd_ptr) {
+    volatile CQPrefetchCmd tt_l1_ptr* cmd = (volatile CQPrefetchCmd tt_l1_ptr*)cmd_ptr;
+    return cmd->debug.stride;
+}
+
+template <bool cmddat_wrap_enable, typename RelayInlineState>
+static uint32_t process_relay_inline_cmd(uint32_t cmd_ptr, uint32_t& local_downstream_data_ptr) {
+    volatile CQPrefetchCmd tt_l1_ptr* cmd = (volatile CQPrefetchCmd tt_l1_ptr*)cmd_ptr;
+    uint32_t length = cmd->relay_inline.length;
+    uint32_t data_ptr = cmd_ptr + sizeof(CQPrefetchCmd);
+
+    uint32_t npages =
+        (length + RelayInlineState::downstream_page_size - 1) >> RelayInlineState::downstream_log_page_size;
+
+    // Assume the downstream buffer is big relative to cmddat command size that we can
+    // grab what we need in one chunk
+    RelayInlineState::cb_writer.acquire_pages(npages);
+
+    uint32_t remaining = cmddat_q_end - data_ptr;
+    if (cmddat_wrap_enable && length > remaining) {
+        // wrap cmddat
+        write_downstream<RelayInlineState::downstream_cb_base_addr, RelayInlineState::downstream_write_cmd_buf>(
+            data_ptr,
+            local_downstream_data_ptr,
+            remaining,
+            RelayInlineState::downstream_cb_end_addr,
+            RelayInlineState::downstream_noc_encoding);
+        length -= remaining;
+        data_ptr = cmddat_q_base;
+    }
+
+    write_downstream<RelayInlineState::downstream_cb_base_addr, RelayInlineState::downstream_write_cmd_buf>(
+        data_ptr,
+        local_downstream_data_ptr,
+        length,
+        RelayInlineState::downstream_cb_end_addr,
+        RelayInlineState::downstream_noc_encoding);
+
+    local_downstream_data_ptr = round_up_pow2(local_downstream_data_ptr, RelayInlineState::downstream_page_size);
+    noc_async_writes_flushed();
+    RelayInlineState::cb_writer.release_pages(npages, local_downstream_data_ptr);
+    return cmd->relay_inline.stride;
+}
+
+// This version of inline sends inline data to the dispatcher but doesn't flush the page to the dispatcher
+// This is used to assemble dispatcher commands when data comes out of band, eg, reading from DRAM
+// That means this command is stateful, incorrect use will be...bad
+// NOTE: this routine assumes we're sending a command header and that is LESS THAN A PAGE
+template <bool cmddat_wrap_enable>
+static uint32_t process_relay_inline_noflush_cmd(uint32_t cmd_ptr, uint32_t& dispatch_data_ptr) {
+    volatile CQPrefetchCmd tt_l1_ptr* cmd = (volatile CQPrefetchCmd tt_l1_ptr*)cmd_ptr;
+
+    uint32_t length = cmd->relay_inline.length;
+    uint32_t data_ptr = cmd_ptr + sizeof(CQPrefetchCmd);
+
+    DispatchRelayInlineState::cb_writer.acquire_pages(1);
+    if (dispatch_data_ptr == downstream_cb_end) {
+        dispatch_data_ptr = downstream_cb_base;
+    }
+    uint32_t remaining = cmddat_q_end - data_ptr;
+    if (cmddat_wrap_enable && length > remaining) {
+        // wrap cmddat
+        noc_async_write(data_ptr, get_noc_addr_helper(downstream_noc_xy, dispatch_data_ptr), remaining);
+        dispatch_data_ptr += remaining;
+        length -= remaining;
+        data_ptr = cmddat_q_base;
+    }
+    noc_async_write(data_ptr, get_noc_addr_helper(downstream_noc_xy, dispatch_data_ptr), length);
+    dispatch_data_ptr += length;
+
+    return cmd->relay_inline.stride;
+}
+
+// The hard problem here is: when an xfer lands exactly at a page boundary, who is responsible for getting the next
+// page? For inner loop, call N grabs page N+1.  No client should ever hit this as inline_noflush puts 16 bytes at the
+// top of the first page At the end, do not grab page N+1
+template <int32_t round, bool test_for_nonzero>
+static uint32_t write_pages_to_dispatcher(
+    uint32_t& downstream_data_ptr, uint32_t scratch_write_addr, uint32_t amt_to_write) {
+    uint32_t page_residual_space = downstream_cb_page_size - (downstream_data_ptr & (downstream_cb_page_size - 1));
+    uint32_t npages = (amt_to_write - page_residual_space + downstream_cb_page_size - round) / downstream_cb_page_size;
+
+    // Grabbing all pages at once is ok if scratch_size < 3 * downstream_cb_block_size
+    // test_for_nonzero is an optimization: inner loops moving lots of pages don't bother
+    if (!test_for_nonzero || npages != 0) {
+        DispatchRelayInlineState::cb_writer.acquire_pages(npages);
+    }
+
+    uint64_t noc_addr;
+    if (downstream_data_ptr == downstream_cb_end) {
+        downstream_data_ptr = downstream_cb_base;
+    } else if (downstream_data_ptr + amt_to_write > downstream_cb_end) {  // wrap
+        uint32_t last_chunk_size = downstream_cb_end - downstream_data_ptr;
+        noc_addr = get_noc_addr_helper(downstream_noc_xy, downstream_data_ptr);
+#if defined(FABRIC_RELAY)
+        noc_async_write(scratch_write_addr, noc_addr, last_chunk_size);
+#else
+        cq_noc_async_write_with_state_any_len<true, true>(scratch_write_addr, noc_addr, last_chunk_size);
+#endif
+        downstream_data_ptr = downstream_cb_base;
+        scratch_write_addr += last_chunk_size;
+        amt_to_write -= last_chunk_size;
+    }
+    noc_addr = get_noc_addr_helper(downstream_noc_xy, downstream_data_ptr);
+
+#if defined(FABRIC_RELAY)
+    noc_async_write(scratch_write_addr, noc_addr, amt_to_write);
+#else
+    cq_noc_async_write_with_state_any_len<true, true>(scratch_write_addr, noc_addr, amt_to_write);
+#endif
+    downstream_data_ptr += amt_to_write;
+
+    return npages;
+}
+
+// This isn't the right way to handle large pages, but expedient for now
+// In the future, break them down into smaller pages...
+template <bool is_dram>
+uint32_t process_relay_paged_cmd_large(
+    uint32_t cmd_ptr,
+    uint32_t& downstream__data_ptr,
+    uint32_t page_id,
+    uint32_t base_addr,
+    uint32_t page_size,
+    uint32_t pages,
+    uint32_t length_adjust) {
+#if ENABLE_PREFETCH_DPRINTS
+    DPRINT << "relay_paged_cmd_large: " << page_size << " " << pages << " " << length_adjust << ENDL();
+#endif
+
+    auto addr_gen = TensorAccessor(tensor_accessor::make_interleaved_dspec<is_dram>(), base_addr, page_size);
+
+    // First step - read into DB0
+    uint32_t scratch_read_addr = scratch_db_top[0];
+    uint64_t noc_addr = addr_gen.get_noc_addr(page_id);
+    uint64_t write_length = (uint64_t)pages * page_size - length_adjust;
+    uint64_t read_length;
+    uint32_t amt_read;
+    if (scratch_db_half_size >= write_length) {
+        amt_read = write_length;
+        read_length = 0;
+    } else {
+        amt_read = scratch_db_half_size;
+        read_length = write_length - amt_read;
+    }
+    noc_async_read(noc_addr, scratch_read_addr, amt_read);
+    uint32_t page_length = page_size - amt_read;
+    uint32_t page_offset = amt_read;
+
+    // Second step - read into DB[x], write from DB[x], toggle x, iterate
+    // Writes are fast, reads are slow
+    uint32_t db_toggle = 0;
+    uint32_t scratch_write_addr;
+
+    noc_async_read_barrier();
+    while (read_length != 0) {
+        // This ensures that writes from prior iteration are done
+        // TODO(pgk); we can do better on WH w/ tagging
+        noc_async_writes_flushed();
+
+        db_toggle ^= 1;
+        scratch_read_addr = scratch_db_top[db_toggle];
+        scratch_write_addr = scratch_db_top[db_toggle ^ 1];
+
+        uint32_t amt_to_write = amt_read;
+        uint64_t noc_addr = addr_gen.get_noc_addr(page_id, page_offset);
+        if (page_length <= scratch_db_half_size) {
+            noc_async_read(noc_addr, scratch_read_addr, page_length);
+            page_id++;
+            page_offset = 0;
+            amt_read = page_length;
+            page_length = page_size;
+
+            if (amt_read < scratch_db_half_size && read_length > amt_read) {
+                noc_addr = addr_gen.get_noc_addr(page_id, 0);
+                uint32_t amt_to_read = scratch_db_half_size - amt_read;
+                noc_async_read(noc_addr, scratch_read_addr + amt_read, amt_to_read);
+                page_length -= amt_to_read;
+                amt_read = scratch_db_half_size;
+                page_offset = amt_to_read;
+            }
+        } else {
+            noc_async_read(noc_addr, scratch_read_addr, scratch_db_half_size);
+            page_length -= scratch_db_half_size;
+            page_offset += scratch_db_half_size;
+            amt_read = scratch_db_half_size;
+        }
+
+        // Third step - write from DB
+        if (write_length < amt_to_write) {
+            amt_to_write = write_length;
+            read_length = 0;
+        } else {
+            read_length -= amt_read;
+        }
+
+        write_length -= amt_to_write;
+        uint32_t npages = write_pages_to_dispatcher<0, false>(downstream_data_ptr, scratch_write_addr, amt_to_write);
+        DispatchRelayInlineState::cb_writer.release_pages(npages, downstream_data_ptr, /*round_to_page_size*/ true);
+
+        // TODO(pgk); we can do better on WH w/ tagging
+        noc_async_read_barrier();
+    }
+
+    // Third step - write from DB
+    if (write_length > 0) {
+        scratch_write_addr = scratch_db_top[db_toggle];
+        uint32_t amt_to_write = write_length;
+        uint32_t npages = write_pages_to_dispatcher<1, true>(downstream_data_ptr, scratch_write_addr, amt_to_write);
+
+        downstream_data_ptr = round_up_pow2(downstream_data_ptr, downstream_cb_page_size);
+        // One page was acquired w/ the cmd in CMD_RELAY_INLINE_NOFLUSH with 16 bytes written
+        DispatchRelayInlineState::cb_writer.release_pages(npages + 1, downstream_data_ptr);
+    } else {
+        downstream_data_ptr = round_up_pow2(downstream_data_ptr, downstream_cb_page_size);
+        DispatchRelayInlineState::cb_writer.release_pages(1, downstream_data_ptr);
+    }
+
+    return CQ_PREFETCH_CMD_BARE_MIN_SIZE;
+}
+
+// This fn prefetches data from DRAM memory and writes data to the dispatch core.
+// Reading from DRAM has the following characteristics:
+//  - latency is moderately high ~400 cycles on WH
+//  - DRAM bw is ~maximized when page size reaches 2K
+//  - for kernel dispatch, it is expected that page sizes will often be <2K
+//  - for buffer writing, page sizes will vary
+//  - writing to dispatcher works best with 4K pages (2K pages cover overhead, 4K gives perf cushion)
+//  - writing a 4K page takes ~32*4=128 cycles
+//  - writing 4 4K pages is 512 cycles, close to parity w/ the latency of DRAM
+//  - to hide the latency (~12% overhead), assume we need to read ~32 pages=128K, double buffered
+//  - in other words, we'll never achieve high efficiency and always be (somewhat) latency bound
+// Algorithm does:
+//  - read a batch from DRAM
+//  - loop: read a batch from DRAM while sending to dispatcher
+//  - send a batch to dispatcher
+// The size of the first read should be based on latency.  With small page sizes
+// bandwidth will be low and we'll be DRAM bound (send to dispatcher is ~free).
+// With larger pages we'll get closer to a bandwidth match
+// The dispatch buffer is a ring buffer.
+template <bool is_dram>
+uint32_t process_relay_paged_cmd(uint32_t cmd_ptr, uint32_t& downstream__data_ptr, uint32_t page_id) {
+    // This ensures that a previous cmd using the scratch buf has finished
+    noc_async_writes_flushed();
+
+    volatile CQPrefetchCmd tt_l1_ptr* cmd = (volatile CQPrefetchCmd tt_l1_ptr*)cmd_ptr;
+    uint32_t base_addr = cmd->relay_paged.base_addr;
+    uint32_t page_size = cmd->relay_paged.page_size;
+    uint32_t pages = cmd->relay_paged.pages;
+    uint16_t length_adjust = cmd->relay_paged.is_dram_and_length_adjust & CQ_PREFETCH_RELAY_PAGED_LENGTH_ADJUST_MASK;
+
+    if (page_size > scratch_db_half_size) {
+        return process_relay_paged_cmd_large<is_dram>(
+            cmd_ptr, downstream_data_ptr, page_id, base_addr, page_size, pages, length_adjust);
+    }
+
+    auto addr_gen = TensorAccessor(tensor_accessor::make_interleaved_dspec<is_dram>(), base_addr, page_size);
+
+    // First step - read into DB0
+    uint64_t read_wlength = (uint64_t)pages * page_size;
+    uint32_t scratch_read_addr = scratch_db_top[0];
+    uint32_t amt_to_read = (scratch_db_half_size > read_wlength) ? read_wlength : scratch_db_half_size;
+    uint32_t amt_read = 0;
+    while (amt_to_read >= page_size) {
+        uint64_t noc_addr = addr_gen.get_noc_addr(page_id);
+        noc_async_read(noc_addr, scratch_read_addr, page_size);
+        scratch_read_addr += page_size;
+        page_id++;
+        amt_to_read -= page_size;
+        amt_read += page_size;
+    }
+    // The fences are to prevent any compiler reordering of instructions around the division. The latency of the
+    // division is hidden by the latency of the noc_async_read_barrier().
+    std::atomic_signal_fence(std::memory_order_acq_rel);
+    const uint32_t max_batch_size = read_wlength > std::numeric_limits<uint32_t>::max()
+                                        ? (std::numeric_limits<uint32_t>::max() / page_size) * page_size
+                                        : read_wlength;
+    std::atomic_signal_fence(std::memory_order_acq_rel);
+    noc_async_read_barrier();
+
+    // Second step - read into DB[x], write from DB[x], toggle x, iterate
+    // Writes are fast, reads are slow
+    uint32_t db_toggle = 0;
+    uint32_t scratch_write_addr;
+    read_wlength -= amt_read;
+    while (read_wlength != 0) {
+        uint32_t read_length = (read_wlength > max_batch_size) ? max_batch_size : static_cast<uint32_t>(read_wlength);
+        read_wlength -= read_length;
+        while (read_length != 0) {
+            // This ensures that writes from prior iteration are done
+            // TODO(pgk); we can do better on WH w/ tagging
+            noc_async_writes_flushed();
+
+            db_toggle ^= 1;
+            scratch_read_addr = scratch_db_top[db_toggle];
+            scratch_write_addr = scratch_db_top[db_toggle ^ 1];
+
+            uint32_t amt_to_write = amt_read;
+            amt_to_read = (scratch_db_half_size > read_length) ? read_length : scratch_db_half_size;
+            amt_read = 0;
+            while (amt_to_read >= page_size) {
+                uint64_t noc_addr = addr_gen.get_noc_addr(page_id);
+                noc_async_read(noc_addr, scratch_read_addr, page_size);
+                scratch_read_addr += page_size;
+                page_id++;
+                amt_to_read -= page_size;
+                amt_read += page_size;
+            }
+
+            // Third step - write from DB
+            uint32_t npages =
+                write_pages_to_dispatcher<0, false>(downstream_data_ptr, scratch_write_addr, amt_to_write);
+            DispatchRelayInlineState::cb_writer.release_pages(npages, downstream_data_ptr, /*round_to_page_size*/ true);
+
+            read_length -= amt_read;
+
+            // TODO(pgk); we can do better on WH w/ tagging
+            noc_async_read_barrier();
+        }
+    }
+
+    // Third step - write from DB
+    // Note that we may write less than full pages despite reading full pages based on length_adjust
+    // Expectation is that the gain from reading less is small to 0, revisit as needed
+    ASSERT(length_adjust < page_size);
+    scratch_write_addr = scratch_db_top[db_toggle];
+    uint32_t amt_to_write = amt_read - length_adjust;
+    uint32_t npages = write_pages_to_dispatcher<1, true>(downstream_data_ptr, scratch_write_addr, amt_to_write);
+
+    downstream_data_ptr = round_up_pow2(downstream_data_ptr, downstream_cb_page_size);
+
+    // One page was acquired w/ the cmd in CMD_RELAY_INLINE_NOFLUSH with 16 bytes written
+    DispatchRelayInlineState::cb_writer.release_pages(npages + 1, downstream_data_ptr);
+
+    return CQ_PREFETCH_CMD_BARE_MIN_SIZE;
+}
+
+// Similar to relay_paged, this iterates and aggregates reads from multiple
+// embedded relay_paged cmds
+void process_relay_paged_packed_sub_cmds(uint32_t total_length, uint32_t* l1_cache) {
+    // This ensures that a previous cmd using the scratch buf has finished
+    noc_async_writes_flushed();
+
+    // First step - read multiple sub_cmds worth into DB0
+    CQPrefetchRelayPagedPackedSubCmd tt_l1_ptr* sub_cmd = (CQPrefetchRelayPagedPackedSubCmd tt_l1_ptr*)(l1_cache);
+    uint32_t read_length = sub_cmd->length;
+    ASSERT(read_length <= scratch_db_half_size);
+    uint32_t amt_to_read = (scratch_db_half_size > total_length) ? total_length : scratch_db_half_size;
+    uint32_t amt_read = 0;
+    uint32_t scratch_read_addr = scratch_db_top[0];
+
+    while (read_length <= amt_to_read) {
+        uint32_t page_id = sub_cmd->start_page;
+        uint32_t log_page_size = sub_cmd->log_page_size;
+        uint32_t base_addr = sub_cmd->base_addr;
+        sub_cmd++;
+
+        uint32_t page_size = 1 << log_page_size;
+        InterleavedPow2AddrGen<true> addr_gen{.bank_base_address = base_addr, .log_base_2_of_page_size = log_page_size};
+
+        uint32_t amt_to_read2 =
+            (scratch_db_half_size - amt_read > read_length) ? read_length : scratch_db_half_size - amt_read;
+        uint32_t amt_read2 = 0;
+        while (amt_read2 < amt_to_read2) {
+            uint64_t noc_addr = addr_gen.get_noc_addr(page_id);
+            uint32_t read_size = (amt_to_read2 - amt_read2 >= page_size) ? page_size : amt_to_read2 - amt_read2;
+            noc_async_read(noc_addr, scratch_read_addr, read_size);
+            scratch_read_addr += read_size;
+            page_id++;
+            amt_read2 += read_size;
+        }
+
+        amt_read += amt_read2;
+        amt_to_read -= amt_read2;
+
+        // note: below can walk off the end of the sub_cmds
+        // this is ok as we store a sentinel non-zero value
+        read_length = sub_cmd->length;
+        ASSERT(read_length <= scratch_db_half_size || total_length == amt_read);
+    }
+    noc_async_read_barrier();
+
+    // Second step - read into DB[x], write from DB[x], toggle x, iterate
+    // Writes are fast, reads are slow
+    uint32_t db_toggle = 0;
+    uint32_t scratch_write_addr;
+    total_length -= amt_read;
+    while (total_length != 0) {
+        // This ensures that writes from prior iteration are done
+        // TODO(pgk); we can do better on WH w/ tagging
+        noc_async_writes_flushed();
+
+        db_toggle ^= 1;
+        scratch_read_addr = scratch_db_top[db_toggle];
+        scratch_write_addr = scratch_db_top[db_toggle ^ 1];
+
+        uint32_t amt_to_write = amt_read;
+        amt_read = 0;
+        amt_to_read = (scratch_db_half_size > total_length) ? total_length : scratch_db_half_size;
+        while (read_length <= amt_to_read) {
+            uint32_t page_id = sub_cmd->start_page;
+            uint32_t log_page_size = sub_cmd->log_page_size;
+            uint32_t base_addr = sub_cmd->base_addr;
+            sub_cmd++;
+
+            uint32_t page_size = 1 << log_page_size;
+            InterleavedPow2AddrGen<true> addr_gen{
+                .bank_base_address = base_addr, .log_base_2_of_page_size = log_page_size};
+
+            uint32_t amt_to_read2 =
+                (scratch_db_half_size - amt_read > read_length) ? read_length : scratch_db_half_size - amt_read;
+            uint32_t amt_read2 = 0;
+            while (amt_read2 < amt_to_read2) {
+                uint64_t noc_addr = addr_gen.get_noc_addr(page_id);
+                uint32_t read_size = (amt_to_read2 - amt_read2 >= page_size) ? page_size : amt_to_read2 - amt_read2;
+                noc_async_read(noc_addr, scratch_read_addr, read_size);
+                scratch_read_addr += read_size;
+                page_id++;
+                amt_read2 += read_size;
+            }
+
+            amt_read += amt_read2;
+            amt_to_read -= amt_read2;
+
+            // note: below can walk off the end of the sub_cmds
+            // this is ok as we store a sentinel non-zero value
+            read_length = sub_cmd->length;
+            ASSERT(read_length <= scratch_db_half_size || total_length == amt_read);
+        }
+
+        // Third step - write from DB
+        uint32_t npages = write_pages_to_dispatcher<0, false>(downstream_data_ptr, scratch_write_addr, amt_to_write);
+        DispatchRelayInlineState::cb_writer.release_pages(npages, downstream_data_ptr, /*round_to_page_size*/ true);
+
+        total_length -= amt_read;
+
+        // TODO(pgk); we can do better on WH w/ tagging
+        noc_async_read_barrier();
+    }
+
+    // Third step - write from DB
+    scratch_write_addr = scratch_db_top[db_toggle];
+    uint32_t amt_to_write = amt_read;
+    uint32_t npages = write_pages_to_dispatcher<1, true>(downstream_data_ptr, scratch_write_addr, amt_to_write);
+
+    downstream_data_ptr = round_up_pow2(downstream_data_ptr, downstream_cb_page_size);
+
+    // One page was acquired w/ the cmd in CMD_RELAY_INLINE_NOFLUSH with 16 bytes written
+    DispatchRelayInlineState::cb_writer.release_pages(npages + 1, downstream_data_ptr);
+}
+
+template <bool cmddat_wrap_enable>
+uint32_t process_relay_paged_packed_cmd(uint32_t cmd_ptr, uint32_t& downstream__data_ptr, uint32_t* l1_cache) {
+    volatile CQPrefetchCmd tt_l1_ptr* cmd = (volatile CQPrefetchCmd tt_l1_ptr*)cmd_ptr;
+    uint32_t total_length = cmd->relay_paged_packed.total_length;
+    uint32_t sub_cmds_length = cmd->relay_paged_packed.count * sizeof(CQPrefetchRelayPagedPackedSubCmd);
+    uint32_t stride = cmd->relay_paged_packed.stride;
+    ASSERT(total_length > 0);
+    // DPRINT << "paged_packed: " << total_length << " " << cmd->relay_paged_packed.stride << ENDL();
+
+    uint32_t data_ptr = cmd_ptr + sizeof(CQPrefetchCmd);
+    uint32_t remaining = cmddat_q_end - data_ptr;
+    uint32_t* l1_cache_pos = l1_cache;
+    if (cmddat_wrap_enable && sub_cmds_length > remaining) {
+        // wrap cmddat
+        uint32_t amt = remaining / sizeof(uint32_t);
+        careful_copy_from_l1_to_local_cache<l1_to_local_cache_copy_chunk, l1_cache_elements_rounded>(
+            (volatile uint32_t tt_l1_ptr*)(data_ptr), amt, l1_cache_pos);
+        sub_cmds_length -= remaining;
+        data_ptr = cmddat_q_base;
+        l1_cache_pos += amt;
+    }
+
+    uint32_t amt = sub_cmds_length / sizeof(uint32_t);
+    // Check that the final write does not overflow the L1 cache and corrupt the stack
+    // End address of final write is: curr_offset_into_cache + write_size_rounded_up_to_copy_chunk
+    ASSERT(
+        (uint32_t)(l1_cache_pos +
+                   ((amt + l1_to_local_cache_copy_chunk - 1) / l1_to_local_cache_copy_chunk) *
+                       l1_to_local_cache_copy_chunk -
+                   l1_cache) < l1_cache_elements_rounded);
+    careful_copy_from_l1_to_local_cache<l1_to_local_cache_copy_chunk, l1_cache_elements_rounded>(
+        (volatile uint32_t tt_l1_ptr*)(data_ptr), amt, l1_cache_pos);
+    // Store a sentinal non 0 value at the end to save a test/branch in read path
+    ((CQPrefetchRelayPagedPackedSubCmd*)&l1_cache_pos[amt])->length = 1;
+
+    process_relay_paged_packed_sub_cmds(total_length, l1_cache);
+    return stride;
+}
+
+template <bool set_src_noc_addr = false>
+void noc_read_64bit_any_len(uint32_t src_noc_addr, uint64_t src_addr, uint32_t dst_addr, uint32_t size) {
+    // noc_read_state_init is unnecessary.
+    if constexpr (set_src_noc_addr) {
+        noc_read_with_state<DM_DEDICATED_NOC, read_cmd_buf, CQ_NOC_sNdL, CQ_NOC_send, CQ_NOC_WAIT>(
+            noc_index, src_noc_addr, 0, 0, 0);
+    } else {
+        // wait on command buf to be ready before issuing new programming
+        noc_read_with_state<DM_DEDICATED_NOC, read_cmd_buf, CQ_NOC_sndl, CQ_NOC_send, CQ_NOC_WAIT>(
+            noc_index, 0, 0, 0, 0);
+    }
+    if (size > NOC_MAX_BURST_SIZE) {
+        // Set length to max burst size.
+        noc_read_with_state<DM_DEDICATED_NOC, read_cmd_buf, CQ_NOC_sndL, CQ_NOC_send, CQ_NOC_wait>(
+            noc_index, 0, 0, 0, NOC_MAX_BURST_SIZE);
+        while (size > NOC_MAX_BURST_SIZE) {
+            noc_read_with_state<DM_DEDICATED_NOC, read_cmd_buf, CQ_NOC_SnDl, CQ_NOC_SEND, CQ_NOC_wait>(
+                noc_index, 0, src_addr, dst_addr, 0);
+            src_addr += NOC_MAX_BURST_SIZE;
+            dst_addr += NOC_MAX_BURST_SIZE;
+            size -= NOC_MAX_BURST_SIZE;
+            // Do a wait before either the next iteration or the final read.
+            noc_read_with_state<DM_DEDICATED_NOC, read_cmd_buf, CQ_NOC_sndl, CQ_NOC_send, CQ_NOC_WAIT>(
+                noc_index, 0, 0, 0, 0);
+        }
+    }
+    noc_read_with_state<DM_DEDICATED_NOC, read_cmd_buf, CQ_NOC_SnDL, CQ_NOC_SEND, CQ_NOC_wait>(
+        noc_index, 0, src_addr, dst_addr, size);
+}
+
+uint32_t process_relay_linear_cmd(uint32_t cmd_ptr, uint32_t& downstream_data_ptr) {
+    // This ensures that a previous cmd using the scratch buf has finished
+    noc_async_writes_flushed();
+
+    volatile CQPrefetchCmdLarge tt_l1_ptr* cmd = (volatile CQPrefetchCmdLarge tt_l1_ptr*)cmd_ptr;
+    uint32_t noc_xy_addr = cmd->relay_linear.noc_xy_addr;
+    uint64_t read_addr = cmd->relay_linear.addr;
+    uint64_t wlength = cmd->relay_linear.length;
+    // DPRINT << "relay_linear: " << cmd_ptr << " " << wlength << " " << read_addr << " " << noc_xy_addr << ENDL();
+
+    // First step - read into DB0
+    uint32_t scratch_read_addr = scratch_db_top[0];
+    uint32_t amt_to_read = (scratch_db_half_size > wlength) ? wlength : scratch_db_half_size;
+    noc_read_64bit_any_len<true>(noc_xy_addr, read_addr, scratch_read_addr, amt_to_read);
+
+    read_addr += amt_to_read;
+    wlength -= amt_to_read;
+    noc_async_read_barrier();
+
+    // Second step - read into DB[x], write from DB[x], toggle x, iterate
+    // Writes are fast, reads are slow
+    uint32_t db_toggle = 0;
+    uint32_t scratch_write_addr;
+    constexpr uint32_t max_batch_size = ~(scratch_db_half_size - 1);
+    while (wlength != 0) {
+        uint32_t read_length = (wlength > max_batch_size) ? max_batch_size : wlength;
+        wlength -= read_length;
+        while (read_length != 0) {
+            // This ensures that writes from prior iteration are done
+            // TODO(pgk); we can do better on WH w/ tagging
+            noc_async_writes_flushed();
+
+            db_toggle ^= 1;
+            scratch_read_addr = scratch_db_top[db_toggle];
+            scratch_write_addr = scratch_db_top[db_toggle ^ 1];
+
+            uint32_t amt_to_write = amt_to_read;
+            amt_to_read = (scratch_db_half_size > read_length) ? read_length : scratch_db_half_size;
+            noc_read_64bit_any_len<false>(noc_xy_addr, read_addr, scratch_read_addr, amt_to_read);
+            read_addr += amt_to_read;
+
+            // Third step - write from DB
+            uint32_t npages =
+                write_pages_to_dispatcher<0, false>(downstream_data_ptr, scratch_write_addr, amt_to_write);
+
+            DispatchRelayInlineState::cb_writer.release_pages(npages, downstream_data_ptr, /*round_to_page_size*/ true);
+
+            read_length -= amt_to_read;
+
+            // TODO(pgk); we can do better on WH w/ tagging
+            noc_async_read_barrier();
+        }
+    }
+
+    // Third step - write from DB
+    scratch_write_addr = scratch_db_top[db_toggle];
+    uint32_t amt_to_write = amt_to_read;
+    uint32_t npages = write_pages_to_dispatcher<1, true>(downstream_data_ptr, scratch_write_addr, amt_to_write);
+
+    downstream_data_ptr = round_up_pow2(downstream_data_ptr, downstream_cb_page_size);
+
+    // One page was acquired w/ the cmd in CMD_RELAY_INLINE_NOFLUSH
+    DispatchRelayInlineState::cb_writer.release_pages(npages + 1, downstream_data_ptr);
+
+    return CQ_PREFETCH_CMD_BARE_MIN_SIZE;
+}
+
+uint32_t process_stall(uint32_t cmd_ptr) {
+    static uint32_t count = 0;
+
+    count++;
+
+    WAYPOINT("PSW");
+    volatile tt_l1_ptr uint32_t* sem_addr =
+        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_semaphore<fd_core_type>(my_downstream_sync_sem_id));
+    uint32_t heartbeat = 0;
+    do {
+        invalidate_l1_cache();
+        IDLE_ERISC_HEARTBEAT_AND_RETURN(heartbeat, CQ_PREFETCH_CMD_BARE_MIN_SIZE);
+    } while (*sem_addr != count);
+    WAYPOINT("PSD");
+
+    return CQ_PREFETCH_CMD_BARE_MIN_SIZE;
+}
+
+// This function reads data from the DRAM and populates the cmddat_q l1 buffer.
+// It starts by fetching initial chunk of 16KB from DRAM and then prefetches
+// the rest and returns to have the initial cmddat_q to be processed.
+// All fetching from DRAM stops at the end of cmddat_q until the cmddat_q are
+// processed.  Then it repeats again. Note: exec_buf_state struct must be
+// initialized to start using this function.
+void paged_read_into_cmddat_q(uint32_t& cmd_ptr, PrefetchExecBufState& exec_buf_state) {
+    uint32_t page_id = exec_buf_state.page_id;
+    uint32_t base_addr = exec_buf_state.base_addr;
+    uint32_t log_page_size = exec_buf_state.log_page_size;
+    uint32_t page_size = 1 << log_page_size;
+    uint32_t pages = exec_buf_state.pages;
+    uint32_t read_ptr = exec_buf_state.read_ptr;
+    constexpr uint32_t INITIAL_FETCH_SIZE = 16 * 1024;                           // 16KB (OPTIMIZE HERE)
+    constexpr uint32_t PREFETCH_FETCH_SIZE = cmddat_q_size - INITIAL_FETCH_SIZE;  // the rest
+
+    // To handle cmddat_q that are non multiples of page_size
+    uint32_t trace_q_end = cmddat_q_base + (((cmddat_q_end - cmddat_q_base) >> log_page_size) << log_page_size);
+
+    // This function also resets the cmd_ptr when it is at the end of cmddat_q.
+    // That is the only thing related to cmd_ptr in this function.
+    if (cmd_ptr == trace_q_end) {
+        cmd_ptr = cmddat_q_base;
+    }
+
+    auto addr_gen = TensorAccessor(tensor_accessor::make_interleaved_dspec</*is_dram=*/true>(), base_addr, page_size);
+    // set transaction ID to 1 for all read
+    noc_async_read_set_trid(1);
+    ASSERT(page_size <= NOC_MAX_BURST_SIZE);
+    // Initialize the read size for all later commands.
+    noc_read_with_state<DM_DEDICATED_NOC, read_cmd_buf, CQ_NOC_sndL, CQ_NOC_send, CQ_NOC_WAIT>(0, 0, 0, page_size);
+
+    // initial read
+    if (exec_buf_state.prefetch_length == 0) {
+        uint32_t initial_read_pages = INITIAL_FETCH_SIZE >> log_page_size;
+        uint32_t initial_pages_at_once = (initial_read_pages > pages) ? pages : initial_read_pages;
+        uint32_t initial_read_length = initial_pages_at_once << log_page_size;
+        pages -= initial_pages_at_once;
+
+        while (initial_pages_at_once != 0) {
+            uint32_t pages_to_read = noc_available_transactions(noc_index, 1);
+            if (pages_to_read > initial_pages_at_once) {
+                pages_to_read = initial_pages_at_once;
+            }
+            initial_pages_at_once -= pages_to_read;
+            while (pages_to_read != 0) {
+                uint64_t noc_addr = addr_gen.get_noc_addr(page_id);
+                noc_read_with_state<DM_DEDICATED_NOC, read_cmd_buf, CQ_NOC_SNDl, CQ_NOC_SEND, CQ_NOC_WAIT>(
+                    noc_index, noc_addr, read_ptr, 0);
+                read_ptr += page_size;
+                page_id++;
+                pages_to_read--;
+            }
+        }
+        noc_async_read_barrier_with_trid(1);
+        // update length always after barrier to make sure data in cmddat_q
+        exec_buf_state.page_id = page_id;
+        exec_buf_state.pages = pages;
+        exec_buf_state.length += initial_read_length;
+        exec_buf_state.read_ptr = read_ptr;
+    } else {
+        ASSERT(exec_buf_state.length == 0);
+        // add barrier to wait for prefetch noc read to complete
+        noc_async_read_barrier_with_trid(1);
+        // update always after barrier to make sure data in cmddat_q
+        exec_buf_state.length += exec_buf_state.prefetch_length;
+        exec_buf_state.prefetch_length = 0;
+    }
+
+    // prefetch only when there are still pages to prefetch
+    if (exec_buf_state.pages > 0) {
+        // wrap around to prefetch from beginning again
+        uint32_t max_prefetch_size = PREFETCH_FETCH_SIZE;
+        if (read_ptr == trace_q_end) {
+            max_prefetch_size = INITIAL_FETCH_SIZE;
+            read_ptr = cmddat_q_base;
+        }
+        uint32_t prefetch_read_pages = max_prefetch_size >> log_page_size;
+        uint32_t prefetch_pages_at_once = (prefetch_read_pages > pages) ? pages : prefetch_read_pages;
+        uint32_t prefetch_read_length = prefetch_pages_at_once << log_page_size;
+        pages -= prefetch_pages_at_once;
+
+        while (prefetch_pages_at_once != 0) {
+            uint32_t pages_to_read = noc_available_transactions(noc_index, 1);
+            if (pages_to_read > prefetch_pages_at_once) {
+                pages_to_read = prefetch_pages_at_once;
+            }
+            prefetch_pages_at_once -= pages_to_read;
+            while (pages_to_read != 0) {
+                uint64_t noc_addr = addr_gen.get_noc_addr(page_id);
+                noc_read_with_state<DM_DEDICATED_NOC, read_cmd_buf, CQ_NOC_SNDl, CQ_NOC_SEND, CQ_NOC_WAIT>(
+                    noc_index, noc_addr, read_ptr, 0);
+                read_ptr += page_size;
+                page_id++;
+                pages_to_read--;
+            }
+        }
+        // update length always after barrier to make sure data in cmddat_q
+        exec_buf_state.page_id = page_id;
+        exec_buf_state.pages = pages;
+        exec_buf_state.prefetch_length = prefetch_read_length;
+        exec_buf_state.read_ptr = read_ptr;
+    }
+
+    // set transaction ID to 0 for other noc read to not use transaction id 1
+    // to remove unnecessary barrier delay
+    noc_async_read_set_trid(0);
+    // Ensure reads receive the updated data.
+    invalidate_l1_cache();
+}
+
+// processes the relay_inline cmd from an exec_buf
+// ie, reads the data from dram and relays it on
+// Separate implementation that fetches more data from exec buf when cmd has been split
+template <typename RelayInlineState>
+FORCE_INLINE static uint32_t process_exec_buf_relay_inline_cmd(
+    uint32_t& cmd_ptr, uint32_t& local_downstream_data_ptr, PrefetchExecBufState& exec_buf_state) {
+    volatile CQPrefetchCmd tt_l1_ptr* cmd = (volatile CQPrefetchCmd tt_l1_ptr*)cmd_ptr;
+    uint8_t dispatcher_type = cmd->relay_inline.dispatcher_type;
+    uint32_t length = cmd->relay_inline.length;
+    uint32_t data_ptr = cmd_ptr + sizeof(CQPrefetchCmd);
+
+    // DPRINT << "relay_inline_exec_buf_cmd:" << length << ENDL();
+    uint32_t npages =
+        (length + RelayInlineState::downstream_page_size - 1) >> RelayInlineState::downstream_log_page_size;
+    static_assert(
+        &RelayInlineState::cb_writer.additional_count == &DispatchRelayInlineState::cb_writer.additional_count ||
+        &RelayInlineState::cb_writer.additional_count == &DispatchSRelayInlineState::cb_writer.additional_count);
+
+    // Assume the downstream buffer is big relative to cmddat command size that we can
+    // grab what we need in one chunk
+    RelayInlineState::cb_writer.acquire_pages(npages);
+    uint32_t stride = cmd->relay_inline.stride;
+    uint32_t remaining_stride = exec_buf_state.length;
+    uint32_t remaining = exec_buf_state.length - sizeof(CQPrefetchCmd);
+    while (length > remaining) {
+        // wrap cmddat
+        write_downstream<RelayInlineState::downstream_cb_base_addr, RelayInlineState::downstream_write_cmd_buf>(
+            data_ptr,
+            local_downstream_data_ptr,
+            remaining,
+            RelayInlineState::downstream_cb_end_addr,
+            RelayInlineState::downstream_noc_encoding);
+        length -= remaining;
+        stride -= remaining_stride;
+        exec_buf_state.length = 0;
+        cmd_ptr += remaining_stride;
+
+        // fetch more
+        noc_async_writes_flushed(RelayInlineState::downstream_noc_index);
+        paged_read_into_cmddat_q(cmd_ptr, exec_buf_state);
+        data_ptr = cmd_ptr;
+        remaining = exec_buf_state.length;
+        remaining_stride = exec_buf_state.length;
+    }
+    write_downstream<RelayInlineState::downstream_cb_base_addr, RelayInlineState::downstream_write_cmd_buf>(
+        data_ptr,
+        local_downstream_data_ptr,
+        length,
+        RelayInlineState::downstream_cb_end_addr,
+        RelayInlineState::downstream_noc_encoding);
+    local_downstream_data_ptr = round_up_pow2(local_downstream_data_ptr, RelayInlineState::downstream_page_size);
+    noc_async_writes_flushed(RelayInlineState::downstream_noc_index);
+    RelayInlineState::cb_writer.release_pages(npages, local_downstream_data_ptr);
+
+    return stride;
+}
+
+// This version of inline sends inline data to the dispatcher but doesn't flush the page to the dispatcher
+// This is used to assemble dispatcher commands when data comes out of band, eg, reading from DRAM
+// That means this command is stateful, incorrect use will be...bad
+// NOTE: this routine assumes we're sending a command header and that is LESS THAN A PAGE
+// Separate implementation that fetches more data from exec buf when cmd has been split
+static uint32_t process_exec_buf_relay_inline_noflush_cmd(
+    uint32_t& cmd_ptr, uint32_t& dispatch_data_ptr, PrefetchExecBufState& exec_buf_state) {
+    volatile CQPrefetchCmd tt_l1_ptr* cmd = (volatile CQPrefetchCmd tt_l1_ptr*)cmd_ptr;
+
+    uint32_t length = cmd->relay_inline.length;
+    uint32_t data_ptr = cmd_ptr + sizeof(CQPrefetchCmd);
+
+    uint32_t stride = cmd->relay_inline.stride;
+
+    DispatchRelayInlineState::cb_writer.acquire_pages(1);
+    if (dispatch_data_ptr == downstream_cb_end) {
+        dispatch_data_ptr = downstream_cb_base;
+    }
+    uint32_t remaining_stride = exec_buf_state.length;
+    uint32_t remaining = exec_buf_state.length - sizeof(CQPrefetchCmd);
+    while (length > remaining) {
+        // wrap cmddat
+#if defined(FABRIC_RELAY)
+        noc_async_write(data_ptr, get_noc_addr_helper(downstream_noc_xy, dispatch_data_ptr), remaining);
+#else
+        cq_noc_async_write_with_state_any_len<true, true>(
+            data_ptr, get_noc_addr_helper(downstream_noc_xy, dispatch_data_ptr), remaining);
+#endif
+        dispatch_data_ptr += remaining;
+        length -= remaining;
+        stride -= remaining_stride;
+        exec_buf_state.length = 0;
+        cmd_ptr += remaining_stride;
+
+        // fetch more
+        noc_async_writes_flushed();
+        paged_read_into_cmddat_q(cmd_ptr, exec_buf_state);
+        data_ptr = cmd_ptr;
+        remaining = exec_buf_state.length;
+        remaining_stride = exec_buf_state.length;
+    }
+
+#if defined(FABRIC_RELAY)
+    noc_async_write(data_ptr, get_noc_addr_helper(downstream_noc_xy, dispatch_data_ptr), length);
+#else
+    cq_noc_async_write_with_state_any_len<true, true>(
+        data_ptr, get_noc_addr_helper(downstream_noc_xy, dispatch_data_ptr), length);
+#endif
+    dispatch_data_ptr += length;
+
+    return stride;
+}
+
+template <uint32_t cmd_header_size = sizeof(CQPrefetchCmd)>
+void* copy_into_l1_cache(
+    uint32_t& cmd_ptr,
+    uint32_t sub_cmds_length,
+    uint32_t* l1_cache,
+    PrefetchExecBufState& exec_buf_state,
+    uint32_t& stride) {
+    uint32_t remaining_stride = exec_buf_state.length;
+    uint32_t remaining = (exec_buf_state.length - cmd_header_size);
+    volatile uint32_t tt_l1_ptr* l1_ptr = (volatile uint32_t tt_l1_ptr*)(cmd_ptr + cmd_header_size);
+    uint32_t* l1_cache_pos = l1_cache;
+    while (sub_cmds_length > remaining) {
+        uint32_t amt = remaining / sizeof(uint32_t);
+        careful_copy_from_l1_to_local_cache<l1_to_local_cache_copy_chunk, l1_cache_elements_rounded>(
+            l1_ptr, amt, l1_cache_pos);
+
+        l1_cache_pos += amt;
+        sub_cmds_length -= remaining;
+        stride -= remaining_stride;
+        exec_buf_state.length = 0;
+        cmd_ptr += remaining_stride;
+        paged_read_into_cmddat_q(cmd_ptr, exec_buf_state);
+        l1_ptr = (volatile uint32_t tt_l1_ptr*)(cmd_ptr);
+        remaining = exec_buf_state.length;
+        remaining_stride = exec_buf_state.length;
+    }
+    uint32_t amt = sub_cmds_length / sizeof(uint32_t);
+    // Check that the final write does not overflow the L1 cache and corrupt the stack.
+    // End address of final write is: curr_offset_into_cache + write_size_rounded_up_to_copy_chunk
+    ASSERT(
+        (uint32_t)(l1_cache_pos +
+                   ((amt + l1_to_local_cache_copy_chunk - 1) / l1_to_local_cache_copy_chunk) *
+                       l1_to_local_cache_copy_chunk -
+                   l1_cache) < l1_cache_elements_rounded);
+    careful_copy_from_l1_to_local_cache<l1_to_local_cache_copy_chunk, l1_cache_elements_rounded>(
+        l1_ptr, amt, l1_cache_pos);
+
+    // Return a pointer to right after the last copy
+    return &l1_cache_pos[amt];
+}
+
+// Separate implementation that fetches more data from exec buf when cmd has been split
+static uint32_t process_exec_buf_relay_paged_packed_cmd(
+    uint32_t& cmd_ptr, uint32_t& downstream__data_ptr, uint32_t* l1_cache, PrefetchExecBufState& exec_buf_state) {
+    volatile CQPrefetchCmd tt_l1_ptr* cmd = (volatile CQPrefetchCmd tt_l1_ptr*)cmd_ptr;
+    uint32_t total_length = cmd->relay_paged_packed.total_length;
+    uint32_t sub_cmds_length = cmd->relay_paged_packed.count * sizeof(CQPrefetchRelayPagedPackedSubCmd);
+    uint32_t stride = cmd->relay_paged_packed.stride;
+    ASSERT(total_length > 0);
+    // DPRINT << "paged_packed: " << total_length << " " << cmd->relay_paged_packed.stride << ENDL();
+
+    void* end = copy_into_l1_cache(cmd_ptr, sub_cmds_length, l1_cache, exec_buf_state, stride);
+
+    // Store a sentinal non 0 value at the end to save a test/branch in read path
+    ((CQPrefetchRelayPagedPackedSubCmd*)end)->length = 1;
+
+    process_relay_paged_packed_sub_cmds(total_length, l1_cache);
+    return stride;
+}
+
+uint32_t process_exec_buf_cmd(
+    uint32_t cmd_ptr_outer, uint32_t& downstream_data_ptr, uint32_t* l1_cache, PrefetchExecBufState& exec_buf_state) {
+    // dispatch on eth cores is memory constrained, so exec_buf re-uses the cmddat_q
+    // prefetch_h stalls upon issuing an exec_buf to prevent conflicting use of the cmddat_q,
+    // the exec_buf contains the release commands
+    volatile CQPrefetchCmd tt_l1_ptr* cmd = (volatile CQPrefetchCmd tt_l1_ptr*)cmd_ptr_outer;
+
+    // setup exec_buf_state the first time
+    exec_buf_state.page_id = 0;
+    exec_buf_state.base_addr = cmd->exec_buf.base_addr;
+    exec_buf_state.log_page_size = cmd->exec_buf.log_page_size;
+    exec_buf_state.pages = cmd->exec_buf.pages;
+    exec_buf_state.length = 0;
+    exec_buf_state.read_ptr = cmddat_q_base;
+    exec_buf_state.prefetch_length = 0;
+    uint32_t cmd_ptr = cmddat_q_base;
+
+    bool done = false;
+    while (!done) {
+        paged_read_into_cmddat_q(cmd_ptr, exec_buf_state);
+
+        while (exec_buf_state.length > 0) {
+            uint32_t stride;
+            done = process_cmd<false, true>(cmd_ptr, downstream_data_ptr, stride, l1_cache, exec_buf_state);
+
+            if (done) {
+                break;
+            }
+
+            exec_buf_state.length -= stride;
+            cmd_ptr += stride;
+        }
+    }
+
+    return CQ_PREFETCH_CMD_BARE_MIN_SIZE;
+}
+
+uint32_t process_paged_to_ringbuffer_cmd(uint32_t cmd_ptr, uint32_t& downstream__data_ptr) {
+    // This ensures that a previous cmd using the ringbuffer have completed.
+    noc_async_writes_flushed();
+
+    volatile CQPrefetchCmd tt_l1_ptr* cmd = (volatile CQPrefetchCmd tt_l1_ptr*)cmd_ptr;
+    uint32_t start_page = cmd->paged_to_ringbuffer.start_page;
+    uint32_t base_addr = cmd->paged_to_ringbuffer.base_addr;
+    uint8_t log2_page_size = cmd->paged_to_ringbuffer.log2_page_size;
+    uint32_t page_size = 1 << log2_page_size;
+    uint32_t length = cmd->paged_to_ringbuffer.length;
+    uint8_t flags = cmd->paged_to_ringbuffer.flags;
+    uint32_t wp_update_offset = cmd->paged_to_ringbuffer.wp_offset_update;
+
+    ASSERT(length <= wp_update_offset);
+
+    if (flags & CQ_PREFETCH_PAGED_TO_RING_BUFFER_FLAG_RESET_TO_START) {
+        ringbuffer_wp = scratch_db_base;
+    }
+
+    ASSERT(length % DRAM_ALIGNMENT == 0);
+    ASSERT(wp_update_offset + ringbuffer_wp <= ringbuffer_end);
+
+    ringbuffer_offset = ringbuffer_wp - scratch_db_base;
+
+    const bool is_dram = true;
+    InterleavedPow2AddrGen<is_dram> addr_gen{.bank_base_address = base_addr, .log_base_2_of_page_size = log2_page_size};
+
+    uint32_t scratch_read_addr = ringbuffer_wp;
+    uint32_t page_id = start_page;
+    while (length >= page_size) {
+        uint64_t noc_addr = addr_gen.get_noc_addr(page_id);
+        noc_async_read(noc_addr, scratch_read_addr, page_size);
+        scratch_read_addr += page_size;
+        page_id++;
+        length -= page_size;
+    }
+    if (length > 0) {
+        uint64_t noc_addr = addr_gen.get_noc_addr(page_id);
+        noc_async_read(noc_addr, scratch_read_addr, length);
+        scratch_read_addr += length;
+    }
+
+    ringbuffer_wp += wp_update_offset;
+
+    // The consumer will perform a read barrier.
+
+    return CQ_PREFETCH_CMD_BARE_MIN_SIZE;
+}
+
+uint32_t process_set_ringbuffer_offset(uint32_t cmd_ptr) {
+    volatile CQPrefetchCmd tt_l1_ptr* cmd = (volatile CQPrefetchCmd tt_l1_ptr*)cmd_ptr;
+    uint32_t offset = cmd->set_ringbuffer_offset.offset;
+
+    if (cmd->set_ringbuffer_offset.update_wp) {
+        ringbuffer_wp = scratch_db_base + offset;
+        ASSERT(ringbuffer_wp <= ringbuffer_end);
+    } else {
+        ringbuffer_offset = offset;
+    }
+
+    return CQ_PREFETCH_CMD_BARE_MIN_SIZE;
+}
+
+void process_relay_ringbuffer_sub_cmds(uint32_t count, uint32_t* l1_cache) {
+    CQPrefetchRelayRingbufferSubCmd tt_l1_ptr* sub_cmd = (CQPrefetchRelayRingbufferSubCmd tt_l1_ptr*)(l1_cache);
+    ASSERT(count > 0);
+
+    noc_async_read_barrier();
+    uint32_t ringbuffer_start = ringbuffer_offset + scratch_db_base;
+
+    for (uint32_t i = 0; i < count - 1; i++) {
+        uint32_t start = ringbuffer_start + sub_cmd->start;
+        uint32_t length = sub_cmd->length;
+
+        uint32_t npages = write_pages_to_dispatcher<0, false>(downstream_data_ptr, start, length);
+
+        DispatchRelayInlineState::cb_writer.release_pages(npages, downstream_data_ptr, /*round_to_page_size*/ true);
+        sub_cmd++;
+    }
+    uint32_t start = ringbuffer_start + sub_cmd->start;
+    uint32_t length = sub_cmd->length;
+    uint32_t npages = write_pages_to_dispatcher<1, false>(downstream_data_ptr, start, length);
+
+    // One page was acquired w/ the cmd in CMD_RELAY_INLINE_NOFLUSH with 16 bytes written
+    downstream_data_ptr = round_up_pow2(downstream_data_ptr, downstream_cb_page_size);
+    DispatchRelayInlineState::cb_writer.release_pages(npages + 1, downstream_data_ptr);
+}
+
+template <bool cmddat_wrap_enable>
+uint32_t process_relay_ringbuffer_cmd(uint32_t cmd_ptr, uint32_t& downstream__data_ptr, uint32_t* l1_cache) {
+    volatile CQPrefetchCmd tt_l1_ptr* cmd = (volatile CQPrefetchCmd tt_l1_ptr*)cmd_ptr;
+    uint32_t count = cmd->relay_ringbuffer.count;
+    uint32_t sub_cmds_length = count * sizeof(CQPrefetchRelayRingbufferSubCmd);
+    uint32_t stride = cmd->relay_ringbuffer.stride;
+    // DPRINT << "relay_ringbuffer: " << count << " " << cmd->relay_ringbuffer.stride << ENDL();
+
+    uint32_t data_ptr = cmd_ptr + sizeof(CQPrefetchCmd);
+    uint32_t remaining = cmddat_q_end - data_ptr;
+    uint32_t* l1_cache_pos = l1_cache;
+    if (cmddat_wrap_enable && sub_cmds_length > remaining) {
+        // wrap cmddat
+        uint32_t amt = remaining / sizeof(uint32_t);
+        careful_copy_from_l1_to_local_cache<l1_to_local_cache_copy_chunk, l1_cache_elements_rounded>(
+            (volatile uint32_t tt_l1_ptr*)(data_ptr), amt, l1_cache_pos);
+        sub_cmds_length -= remaining;
+        data_ptr = cmddat_q_base;
+        l1_cache_pos += amt;
+    }
+
+    uint32_t amt = sub_cmds_length / sizeof(uint32_t);
+    // Check that the final write does not overflow the L1 cache and corrupt the stack
+    // End address of final write is: curr_offset_into_cache + write_size_rounded_up_to_copy_chunk
+    ASSERT(
+        (uint32_t)(l1_cache_pos +
+                   ((amt + l1_to_local_cache_copy_chunk - 1) / l1_to_local_cache_copy_chunk) *
+                       l1_to_local_cache_copy_chunk -
+                   l1_cache) < l1_cache_elements_rounded);
+    careful_copy_from_l1_to_local_cache<l1_to_local_cache_copy_chunk, l1_cache_elements_rounded>(
+        (volatile uint32_t tt_l1_ptr*)(data_ptr), amt, l1_cache_pos);
+
+    process_relay_ringbuffer_sub_cmds(count, l1_cache);
+    return stride;
+}
+
+// Separate implementation that fetches more data from exec buf when cmd has been split
+static uint32_t process_exec_buf_relay_ringbuffer_cmd(
+    uint32_t& cmd_ptr, uint32_t& downstream__data_ptr, uint32_t* l1_cache, PrefetchExecBufState& exec_buf_state) {
+    volatile CQPrefetchCmd tt_l1_ptr* cmd = (volatile CQPrefetchCmd tt_l1_ptr*)cmd_ptr;
+    uint32_t count = cmd->relay_ringbuffer.count;
+    uint32_t sub_cmds_length = count * sizeof(CQPrefetchRelayRingbufferSubCmd);
+    uint32_t stride = cmd->relay_ringbuffer.stride;
+
+    copy_into_l1_cache(cmd_ptr, sub_cmds_length, l1_cache, exec_buf_state, stride);
+
+    process_relay_ringbuffer_sub_cmds(count, l1_cache);
+    return stride;
+}
+
+void process_relay_linear_packed_sub_cmds(uint32_t noc_xy_addr, uint32_t total_length, uint32_t* l1_cache) {
+    // This ensures that a previous cmd using the scratch buf has finished
+    noc_async_writes_flushed();
+
+    // First step - read multiple sub_cmds worth into DB0
+    CQPrefetchRelayLinearPackedSubCmd tt_l1_ptr* sub_cmd = (CQPrefetchRelayLinearPackedSubCmd tt_l1_ptr*)(l1_cache);
+    uint64_t current_addr = sub_cmd->addr;
+    uint32_t current_length = sub_cmd->length;
+    uint32_t amt_to_read = (scratch_db_half_size > total_length) ? total_length : scratch_db_half_size;
+    uint32_t amt_read = 0;
+    uint32_t scratch_read_addr = scratch_db_top[0];
+
+    while (amt_read < amt_to_read) {
+        uint32_t amt_to_read2 =
+            (scratch_db_half_size - amt_read > current_length) ? current_length : scratch_db_half_size - amt_read;
+        noc_read_64bit_any_len<true>(noc_xy_addr, current_addr, scratch_read_addr, amt_to_read2);
+        scratch_read_addr += amt_to_read2;
+        amt_read += amt_to_read2;
+        current_addr += amt_to_read2;
+        current_length -= amt_to_read2;
+
+        // If we've consumed the current sub-command, move to the next one
+        if (current_length == 0) {
+            sub_cmd++;
+            current_addr = sub_cmd->addr;
+            current_length = sub_cmd->length;
+        }
+    }
+    noc_async_read_barrier();
+
+    // Second step - read into DB[x], write from DB[x], toggle x, iterate
+    // Writes are fast, reads are slow
+    uint32_t db_toggle = 0;
+    uint32_t scratch_write_addr;
+    total_length -= amt_read;
+    while (total_length != 0) {
+        // This ensures that writes from prior iteration are done
+        // TODO(pgk); we can do better on WH w/ tagging
+        noc_async_writes_flushed();
+
+        db_toggle ^= 1;
+        scratch_read_addr = scratch_db_top[db_toggle];
+        scratch_write_addr = scratch_db_top[db_toggle ^ 1];
+
+        uint32_t amt_to_write = amt_read;
+        amt_read = 0;
+        amt_to_read = (scratch_db_half_size > total_length) ? total_length : scratch_db_half_size;
+        while (amt_read < amt_to_read) {
+            uint32_t amt_to_read2 =
+                (scratch_db_half_size - amt_read > current_length) ? current_length : scratch_db_half_size - amt_read;
+            noc_read_64bit_any_len<false>(noc_xy_addr, current_addr, scratch_read_addr, amt_to_read2);
+            scratch_read_addr += amt_to_read2;
+            amt_read += amt_to_read2;
+            current_addr += amt_to_read2;
+            current_length -= amt_to_read2;
+
+            // If we've consumed the current sub-command, move to the next one
+            if (current_length == 0) {
+                sub_cmd++;
+                current_addr = sub_cmd->addr;
+                current_length = sub_cmd->length;
+            }
+        }
+
+        // Third step - write from DB
+        uint32_t npages = write_pages_to_dispatcher<0, false>(downstream_data_ptr, scratch_write_addr, amt_to_write);
+        DispatchRelayInlineState::cb_writer.release_pages(npages, downstream_data_ptr, /*round_to_page_size*/ true);
+
+        total_length -= amt_read;
+
+        // TODO(pgk); we can do better on WH w/ tagging
+        noc_async_read_barrier();
+    }
+
+    // Third step - write from DB
+    scratch_write_addr = scratch_db_top[db_toggle];
+    uint32_t amt_to_write = amt_read;
+    uint32_t npages = write_pages_to_dispatcher<1, true>(downstream_data_ptr, scratch_write_addr, amt_to_write);
+
+    downstream_data_ptr = round_up_pow2(downstream_data_ptr, downstream_cb_page_size);
+
+    // One page was acquired w/ the cmd in CMD_RELAY_INLINE_NOFLUSH with 16 bytes written
+    DispatchRelayInlineState::cb_writer.release_pages(npages + 1, downstream_data_ptr);
+}
+
+template <bool cmddat_wrap_enable>
+uint32_t process_relay_linear_packed_cmd(uint32_t cmd_ptr, uint32_t& downstream_data_ptr, uint32_t* l1_cache) {
+    volatile CQPrefetchCmd tt_l1_ptr* cmd = (volatile CQPrefetchCmd tt_l1_ptr*)cmd_ptr;
+    uint32_t noc_xy_addr = cmd->relay_linear_packed.noc_xy_addr;
+    uint32_t total_length = cmd->relay_linear_packed.total_length;
+    uint32_t sub_cmds_length = cmd->relay_linear_packed.count * sizeof(CQPrefetchRelayLinearPackedSubCmd);
+    uint32_t stride = cmd->relay_linear_packed.stride;
+    ASSERT(total_length > 0);
+    // DPRINT << "linear_packed: " << total_length << " " << cmd->relay_linear_packed.stride << ENDL();
+
+    uint32_t data_ptr = cmd_ptr + sizeof(CQPrefetchCmd);
+    uint32_t remaining = cmddat_q_end - data_ptr;
+    uint32_t* l1_cache_pos = l1_cache;
+    if (cmddat_wrap_enable && sub_cmds_length > remaining) {
+        // wrap cmddat
+        uint32_t amt = remaining / sizeof(uint32_t);
+        careful_copy_from_l1_to_local_cache<l1_to_local_cache_copy_chunk, l1_cache_elements_rounded>(
+            (volatile uint32_t tt_l1_ptr*)(data_ptr), amt, l1_cache_pos);
+        sub_cmds_length -= remaining;
+        data_ptr = cmddat_q_base;
+        l1_cache_pos += amt;
+    }
+
+    uint32_t amt = sub_cmds_length / sizeof(uint32_t);
+    // Check that the final write does not overflow the L1 cache and corrupt the stack
+    // End address of final write is: curr_offset_into_cache + write_size_rounded_up_to_copy_chunk
+    ASSERT(
+        (uint32_t)(l1_cache_pos +
+                   ((amt + l1_to_local_cache_copy_chunk - 1) / l1_to_local_cache_copy_chunk) *
+                       l1_to_local_cache_copy_chunk -
+                   l1_cache) < l1_cache_elements_rounded);
+    careful_copy_from_l1_to_local_cache<l1_to_local_cache_copy_chunk, l1_cache_elements_rounded>(
+        (volatile uint32_t tt_l1_ptr*)(data_ptr), amt, l1_cache_pos);
+    // Store a sentinal non 0 value at the end to save a test/branch in read path
+    ((CQPrefetchRelayLinearPackedSubCmd*)&l1_cache_pos[amt])->length = 1;
+
+    process_relay_linear_packed_sub_cmds(noc_xy_addr, total_length, l1_cache);
+    return stride;
+}
+
+// Separate implementation that fetches more data from exec buf when cmd has been split
+static uint32_t process_exec_buf_relay_linear_packed_cmd(
+    uint32_t& cmd_ptr, uint32_t& downstream_data_ptr, uint32_t* l1_cache, PrefetchExecBufState& exec_buf_state) {
+    volatile CQPrefetchCmd tt_l1_ptr* cmd = (volatile CQPrefetchCmd tt_l1_ptr*)cmd_ptr;
+    uint32_t noc_xy_addr = cmd->relay_linear_packed.noc_xy_addr;
+    uint32_t total_length = cmd->relay_linear_packed.total_length;
+    uint32_t sub_cmds_length = cmd->relay_linear_packed.count * sizeof(CQPrefetchRelayLinearPackedSubCmd);
+    uint32_t stride = cmd->relay_linear_packed.stride;
+
+    void* end = copy_into_l1_cache(cmd_ptr, sub_cmds_length, l1_cache, exec_buf_state, stride);
+
+    // Store a sentinal non 0 value at the end to save a test/branch in read path
+    ((CQPrefetchRelayLinearPackedSubCmd*)end)->length = 1;
+
+    process_relay_linear_packed_sub_cmds(noc_xy_addr, total_length, l1_cache);
+    return stride;
+}
+
+template <bool cmddat_wrap_enable, bool exec_buf>
+bool process_cmd(
+    uint32_t& cmd_ptr,
+    uint32_t& downstream_data_ptr,
+    uint32_t& stride,
+    uint32_t* l1_cache,
+    PrefetchExecBufState& exec_buf_state) {
+    volatile CQPrefetchCmd tt_l1_ptr* cmd = (volatile CQPrefetchCmd tt_l1_ptr*)cmd_ptr;
+    bool done = false;
+
+    switch (cmd->base.cmd_id) {
+        case CQ_PREFETCH_CMD_RELAY_LINEAR:
+            // DPRINT << "relay linear: " << cmd_ptr << ENDL();
+            stride = process_relay_linear_cmd(cmd_ptr, downstream_data_ptr);
+            break;
+
+        case CQ_PREFETCH_CMD_RELAY_PAGED:
+            // DPRINT << "relay paged: " << cmd_ptr << ENDL();
+            {
+                uint32_t is_dram_and_length_adjust = cmd->relay_paged.is_dram_and_length_adjust;
+                uint32_t is_dram = is_dram_and_length_adjust & (1 << CQ_PREFETCH_RELAY_PAGED_IS_DRAM_SHIFT);
+                uint32_t start_page = cmd->relay_paged.start_page;
+                if (is_dram) {
+                    stride = process_relay_paged_cmd<true>(cmd_ptr, downstream_data_ptr, start_page);
+                } else {
+                    stride = process_relay_paged_cmd<false>(cmd_ptr, downstream_data_ptr, start_page);
+                }
+            }
+            break;
+
+        case CQ_PREFETCH_CMD_RELAY_PAGED_PACKED:
+            // DPRINT << "relay paged packed" << ENDL();
+            if (exec_buf) {
+                stride =
+                    process_exec_buf_relay_paged_packed_cmd(cmd_ptr, downstream_data_ptr, l1_cache, exec_buf_state);
+            } else {
+                stride = process_relay_paged_packed_cmd<cmddat_wrap_enable>(cmd_ptr, downstream_data_ptr, l1_cache);
+            }
+            break;
+
+        case CQ_PREFETCH_CMD_RELAY_INLINE:
+            // DPRINT << "relay inline" << ENDL();
+            if constexpr (exec_buf) {
+                if (cmd->relay_inline.dispatcher_type == DispatcherSelect::DISPATCH_MASTER) {
+                    stride = process_exec_buf_relay_inline_cmd<DispatchRelayInlineState>(
+                        cmd_ptr, downstream_data_ptr, exec_buf_state);
+                } else {
+                    stride = process_exec_buf_relay_inline_cmd<DispatchSRelayInlineState>(
+                        cmd_ptr, downstream_data_ptr_s, exec_buf_state);
+                }
+            } else {
+                if (cmd->relay_inline.dispatcher_type == DispatcherSelect::DISPATCH_MASTER) {
+                    stride = process_relay_inline_cmd<cmddat_wrap_enable, DispatchRelayInlineState>(
+                        cmd_ptr, downstream_data_ptr);
+                } else {
+                    stride = process_relay_inline_cmd<cmddat_wrap_enable, DispatchSRelayInlineState>(
+                        cmd_ptr, downstream_data_ptr_s);
+                }
+            }
+            break;
+
+        case CQ_PREFETCH_CMD_RELAY_INLINE_NOFLUSH:
+            // DPRINT << "inline no flush" << ENDL();
+            if (exec_buf) {
+                stride = process_exec_buf_relay_inline_noflush_cmd(cmd_ptr, downstream_data_ptr, exec_buf_state);
+            } else {
+                stride = process_relay_inline_noflush_cmd<cmddat_wrap_enable>(cmd_ptr, downstream_data_ptr);
+            }
+            break;
+
+        case CQ_PREFETCH_CMD_EXEC_BUF:
+            // DPRINT << "exec buf: " << cmd_ptr << ENDL();
+            ASSERT(!exec_buf);
+            if (is_h_variant) {
+                ASSERT(stall_state == STALLED);  // ExecBuf must be preceded by a prefetcher stall
+            }
+            stride = process_exec_buf_cmd(cmd_ptr, downstream_data_ptr, l1_cache, exec_buf_state);
+            stall_state = NOT_STALLED;  // Stall is no longer required after ExecBuf finished.
+            break;
+
+        case CQ_PREFETCH_CMD_EXEC_BUF_END:
+            // DPRINT << "exec buf end: " << cmd_ptr << ENDL();
+            ASSERT(exec_buf);
+            stride = process_exec_buf_relay_inline_cmd<DispatchRelayInlineState>(
+                cmd_ptr, downstream_data_ptr, exec_buf_state);
+            done = true;
+            break;
+
+        case CQ_PREFETCH_CMD_STALL:
+            // DPRINT << "stall" << ENDL();
+            stride = process_stall(cmd_ptr);
+            break;
+
+        case CQ_PREFETCH_CMD_DEBUG:
+            // DPRINT << "debug" << ENDL();
+            //  Splitting debug cmds not implemented for exec_bufs (yet)
+            if (exec_buf) {
+                ASSERT(0);
+            }
+            stride = process_debug_cmd(cmd_ptr);
+            break;
+
+        case CQ_PREFETCH_CMD_TERMINATE:
+            // DPRINT << "prefetch terminating_" << is_h_variant << is_d_variant << ENDL();
+            ASSERT(!exec_buf);
+            done = true;
+            break;
+
+        case CQ_PREFETCH_CMD_PAGED_TO_RINGBUFFER:
+            // DPRINT << "paged to ringbuffer" << ENDL();
+            stride = process_paged_to_ringbuffer_cmd(cmd_ptr, downstream_data_ptr);
+            break;
+
+        case CQ_PREFETCH_CMD_SET_RINGBUFFER_OFFSET:
+            // DPRINT << "set ringbuffer offset" << ENDL();
+            stride = process_set_ringbuffer_offset(cmd_ptr);
+            break;
+
+        case CQ_PREFETCH_CMD_RELAY_RINGBUFFER:
+            // DPRINT << "relay ringbuffer" << ENDL();
+            if (exec_buf) {
+                stride = process_exec_buf_relay_ringbuffer_cmd(cmd_ptr, downstream_data_ptr, l1_cache, exec_buf_state);
+            } else {
+                stride = process_relay_ringbuffer_cmd<cmddat_wrap_enable>(cmd_ptr, downstream_data_ptr, l1_cache);
+            }
+            break;
+
+        case CQ_PREFETCH_CMD_RELAY_LINEAR_PACKED:
+            // DPRINT << "relay linear packed" << ENDL();
+            if (exec_buf) {
+                stride =
+                    process_exec_buf_relay_linear_packed_cmd(cmd_ptr, downstream_data_ptr, l1_cache, exec_buf_state);
+            } else {
+                stride = process_relay_linear_packed_cmd<cmddat_wrap_enable>(cmd_ptr, downstream_data_ptr, l1_cache);
+            }
+            break;
+
+        default:
+            //  DPRINT << "prefetch invalid command:" << (uint32_t)cmd->base.cmd_id << " " << cmd_ptr << " " <<
+            //                           cmddat_q_base << ENDL();
+            //  DPRINT << HEX() << *(uint32_t*)cmd_ptr << ENDL();
+            //  DPRINT << HEX() << *((uint32_t*)cmd_ptr+1) << ENDL();
+            //  DPRINT << HEX() << *((uint32_t*)cmd_ptr+2) << ENDL();
+            //  DPRINT << HEX() << *((uint32_t*)cmd_ptr+3) << ENDL();
+            //  DPRINT << HEX() << *((uint32_t*)cmd_ptr+4) << ENDL();
+            WAYPOINT("!CMD");
+            ASSERT(0);
+    }
+
+    return done;
+}
+
+/* Relay linear bytes to dispatch_hd or dispatch_d via prefetch_d. test_for_nonzero is an optimization that can be false
+ * if amt_to_write >= downstream_cb_page_size. For simplicity this code will always acquire the exact number of pages
+ * needed, unlike write_pages_to_dispatcher which may acquire an extra page if we hit an exact page boundary. */
+template <bool test_for_nonzero>
+static void relay_linear_to_downstream(
+    uint32_t& downstream_data_ptr, uint32_t scratch_write_addr, uint32_t amt_to_write) {
+    // Unlike in write_pages_to_dispatcher we always round npages down, so if downstream_data_ptr is at the start of a
+    // page, that means page_residual_space is 0. This is why the logic is different from write_pages_to_dispatcher.
+    uint32_t page_residual_space = -downstream_data_ptr & (downstream_cb_page_size - 1);
+
+    // Following is fine if downstream cb block is bigger than scratch and there are at least a couple of them
+    uint32_t npages = (amt_to_write - page_residual_space + downstream_cb_page_size - 1) / downstream_cb_page_size;
+    if (!test_for_nonzero || (npages != 0)) {
+        DispatchRelayInlineState::cb_writer.acquire_pages(npages);
+    }
+    uint64_t noc_addr;
+    if (downstream_data_ptr == downstream_cb_end) {
+        downstream_data_ptr = downstream_cb_base;
+    } else if (downstream_data_ptr + amt_to_write > downstream_cb_end) {  // wrap
+        uint32_t last_chunk_size = downstream_cb_end - downstream_data_ptr;
+        noc_addr = get_noc_addr_helper(downstream_noc_xy, downstream_data_ptr);
+        relay_client.write_any_len<my_noc_index, true, NCRISC_WR_CMD_BUF>(
+            scratch_write_addr, noc_addr, last_chunk_size);
+        downstream_data_ptr = downstream_cb_base;
+        scratch_write_addr += last_chunk_size;
+        amt_to_write -= last_chunk_size;
+    }
+    noc_addr = get_noc_addr_helper(downstream_noc_xy, downstream_data_ptr);
+    relay_client
+        .write_atomic_inc_any_len<my_noc_index, downstream_noc_xy, downstream_cb_sem_id, true, NCRISC_WR_CMD_BUF>(
+            scratch_write_addr, noc_addr, amt_to_write, npages);
+    downstream_data_ptr += amt_to_write;
+}
+
+// Used in prefetch_h upstream of a CQ_PREFETCH_CMD_RELAY_LINEAR_H command.
+uint32_t process_relay_linear_h_cmd(uint32_t cmd_ptr, uint32_t& downstream_data_ptr) {
+    volatile CQPrefetchCmdLarge tt_l1_ptr* cmd = nullptr;
+    cmd = (volatile CQPrefetchCmdLarge tt_l1_ptr*)(cmd_ptr + sizeof(CQPrefetchHToPrefetchDHeader));
+    uint64_t wlength = cmd->relay_linear_h.length;
+    uint32_t scratch_read_addr = scratch_db_top[0];
+    constexpr uint32_t start_offset = sizeof(CQPrefetchHToPrefetchDHeader);
+    // kernel_h must relay user data from pinned buffer to downstream (kernel_d's cmddatq)
+    volatile tt_l1_ptr CQPrefetchHToPrefetchDHeader* dptr =
+        (volatile tt_l1_ptr CQPrefetchHToPrefetchDHeader*)scratch_read_addr;
+    dptr->header.length = wlength + sizeof(CQPrefetchHToPrefetchDHeader);
+    dptr->header.raw_copy = true;
+    scratch_read_addr += sizeof(CQPrefetchHToPrefetchDHeader);
+
+    uint32_t noc_xy_addr = cmd->relay_linear_h.noc_xy_addr;
+    uint64_t read_addr = cmd->relay_linear_h.addr;
+
+    // DPRINT << "relay_linear_h: cmd_ptr:0x" << HEX() << (uint32_t)cmd_ptr << ", length:0x " << wlength << ", addr:0x"
+    // << read_addr << ", nocxy:0x" << noc_xy_addr << ", downstream_data_ptr:0x" << downstream_data_ptr << DEC() <<
+    // ENDL();
+
+    // First step - read into DB0
+    uint32_t amt_to_read =
+        (scratch_db_half_size - start_offset > wlength) ? wlength : scratch_db_half_size - start_offset;
+    noc_read_64bit_any_len<true>(noc_xy_addr, read_addr, scratch_read_addr, amt_to_read);
+
+    read_addr += amt_to_read;
+    wlength -= amt_to_read;
+    noc_async_read_barrier();
+
+    // Second step - read into DB[x], write from DB[x], toggle x, iterate
+    // Writes are fast, reads are slow
+    uint32_t scratch_write_start_addr = scratch_db_top[0];
+    uint32_t scratch_read_start_addr = scratch_db_top[1];
+    // Add back start_offset to amt_to_read to ensure all bytes from scratch_db are transferred
+    amt_to_read += start_offset;
+    // Calculate the largest multiple of scratch_db_half_size that can fit in a uint32_t. This allows most of the math
+    // to be done in 32 bits.
+    constexpr uint32_t max_batch_size = ~(scratch_db_half_size - 1);
+    while (wlength != 0) {
+        uint32_t read_length = (wlength > max_batch_size) ? max_batch_size : wlength;
+        wlength -= read_length;
+        while (read_length != 0) {
+            // This ensures that writes from prior iteration are done
+            noc_async_writes_flushed();
+
+            uint32_t scratch_read_addr = scratch_read_start_addr;
+            uint32_t scratch_write_addr = scratch_write_start_addr;
+            std::swap(scratch_read_start_addr, scratch_write_start_addr);
+
+            uint32_t amt_to_write = amt_to_read;
+            amt_to_read = (scratch_db_half_size > read_length) ? read_length : scratch_db_half_size;
+            noc_read_64bit_any_len<false>(noc_xy_addr, read_addr, scratch_read_addr, amt_to_read);
+            read_addr += amt_to_read;
+
+            // Third step - write from DB. amt_to_write is greater than a page, so we don't need to test for nonzero.
+            relay_linear_to_downstream<false>(downstream_data_ptr, scratch_write_addr, amt_to_write);
+            read_length -= amt_to_read;
+
+            // TODO(pgk); we can do better on WH w/ tagging
+            noc_async_read_barrier();
+        }
+    }
+
+    // Third step - write from DB
+    uint32_t amt_to_write = amt_to_read;
+    relay_linear_to_downstream<true>(downstream_data_ptr, scratch_write_start_addr, amt_to_write);
+    downstream_data_ptr = round_up_pow2(downstream_data_ptr, downstream_cb_page_size);
+
+    // RelayLinearH is a large command.
+    return 2 * CQ_PREFETCH_CMD_BARE_MIN_SIZE;
+}
+
+// Used in prefetch_h upstream of a CQ_PREFETCH_CMD_RELAY_LINEAR_PACKED_H command.
+// Combines packed linear reads (multiple sub-commands) with H-variant relay to remote device.
+uint32_t process_relay_linear_packed_h_cmd(uint32_t cmd_ptr, uint32_t& downstream_data_ptr, uint32_t* l1_cache) {
+    volatile CQPrefetchCmd tt_l1_ptr* cmd =
+        (volatile CQPrefetchCmd tt_l1_ptr*)(cmd_ptr + sizeof(CQPrefetchHToPrefetchDHeader));
+    uint32_t noc_xy_addr = cmd->relay_linear_packed.noc_xy_addr;
+    uint32_t total_length = cmd->relay_linear_packed.total_length;
+    uint32_t sub_cmds_length = cmd->relay_linear_packed.count * sizeof(CQPrefetchRelayLinearPackedSubCmd);
+    uint32_t stride = cmd->relay_linear_packed.stride;
+    ASSERT(total_length > 0);
+
+    // Copy sub-commands into L1 cache (same pattern as process_relay_linear_packed_cmd)
+    uint32_t data_ptr = cmd_ptr + sizeof(CQPrefetchHToPrefetchDHeader) + sizeof(CQPrefetchCmd);
+    uint32_t amt = sub_cmds_length / sizeof(uint32_t);
+    careful_copy_from_l1_to_local_cache<l1_to_local_cache_copy_chunk, l1_cache_elements_rounded>(
+        (volatile uint32_t tt_l1_ptr*)(data_ptr), amt, l1_cache);
+
+    // Setup scratch buffer for relay
+    uint32_t scratch_read_addr = scratch_db_top[0];
+    constexpr uint32_t start_offset = sizeof(CQPrefetchHToPrefetchDHeader);
+    // kernel_h must relay user data to downstream (kernel_d's cmddatq)
+    volatile tt_l1_ptr CQPrefetchHToPrefetchDHeader* dptr =
+        (volatile tt_l1_ptr CQPrefetchHToPrefetchDHeader*)scratch_read_addr;
+    dptr->header.length = total_length + sizeof(CQPrefetchHToPrefetchDHeader);
+    dptr->header.raw_copy = true;
+    scratch_read_addr += sizeof(CQPrefetchHToPrefetchDHeader);
+
+    // Initialize the src NoC address once, since all sub-commands will use the same address.
+    noc_read_with_state<DM_DEDICATED_NOC, read_cmd_buf, CQ_NOC_sNdl, CQ_NOC_send, CQ_NOC_WAIT>(
+        noc_index, noc_xy_addr, 0, 0, 0);
+
+    // First step - read multiple sub_cmds worth into DB0
+    CQPrefetchRelayLinearPackedSubCmd tt_l1_ptr* sub_cmd = (CQPrefetchRelayLinearPackedSubCmd tt_l1_ptr*)(l1_cache);
+    uint64_t current_addr = sub_cmd->addr;
+    uint32_t current_length = sub_cmd->length;
+    // Total amount to read into the scratch db half from all sub-commands (that fit)
+    uint32_t amt_to_read_to_scratch_db =
+        (scratch_db_half_size - start_offset > total_length) ? total_length : scratch_db_half_size - start_offset;
+
+    uint32_t amt_read = amt_to_read_to_scratch_db;
+
+    auto fill_scratch_db = [&]() {
+        while (amt_to_read_to_scratch_db > 0) {
+            uint32_t amt_to_read_sub_cmd =
+                amt_to_read_to_scratch_db > current_length ? current_length : amt_to_read_to_scratch_db;
+            noc_read_64bit_any_len<false>(noc_xy_addr, current_addr, scratch_read_addr, amt_to_read_sub_cmd);
+            scratch_read_addr += amt_to_read_sub_cmd;
+
+            amt_to_read_to_scratch_db -= amt_to_read_sub_cmd;
+            current_addr += amt_to_read_sub_cmd;
+            current_length -= amt_to_read_sub_cmd;
+
+            // If we've consumed the current sub-command, move to the next one
+            if (current_length == 0) {
+                sub_cmd++;
+                current_addr = sub_cmd->addr;
+                current_length = sub_cmd->length;
+            }
+        }
+    };
+
+    fill_scratch_db();
+    noc_async_read_barrier();
+
+    // Second step - read into DB[x], write from DB[x], toggle x, iterate
+    // Writes are fast, reads are slow
+    uint32_t scratch_write_start_addr = scratch_db_top[0];
+    uint32_t scratch_read_start_addr = scratch_db_top[1];
+    uint32_t read_length = total_length - amt_read;
+    // Add back start_offset to amt_read to ensure all bytes from scratch_db are transferred
+    amt_read += start_offset;
+
+    while (read_length != 0) {
+        // This ensures that writes from prior iteration are done
+        noc_async_writes_flushed();
+
+        scratch_read_addr = scratch_read_start_addr;
+        uint32_t scratch_write_addr = scratch_write_start_addr;
+        std::swap(scratch_read_start_addr, scratch_write_start_addr);
+
+        uint32_t amt_to_write = amt_read;
+        amt_to_read_to_scratch_db = (scratch_db_half_size > read_length) ? read_length : scratch_db_half_size;
+        amt_read = amt_to_read_to_scratch_db;
+        fill_scratch_db();
+
+        // Third step - write from DB. amt_to_write is greater than a page, so we don't need to test for nonzero.
+        relay_linear_to_downstream<false>(downstream_data_ptr, scratch_write_addr, amt_to_write);
+        read_length -= amt_read;
+
+        // TODO(pgk); we can do better on WH w/ tagging
+        noc_async_read_barrier();
+    }
+
+    // Third step - write from DB
+    uint32_t amt_to_write = amt_read;
+    relay_linear_to_downstream<true>(downstream_data_ptr, scratch_write_start_addr, amt_to_write);
+    downstream_data_ptr = round_up_pow2(downstream_data_ptr, downstream_cb_page_size);
+
+    return stride + sizeof(CQPrefetchHToPrefetchDHeader);
+}
+
+// This function is only valid when called on the H variant
+// It expects the NoC async write state to be initialized to point to the downstream
+static uint32_t process_relay_inline_all(uint32_t data_ptr, uint32_t fence, bool is_exec_buf) {
+    uint32_t length = fence - data_ptr;
+    // Downstream doesn't have FetchQ to tell it how much data to process
+    // This packet header just contains the length
+    volatile tt_l1_ptr CQPrefetchHToPrefetchDHeader* dptr = (volatile tt_l1_ptr CQPrefetchHToPrefetchDHeader*)data_ptr;
+    dptr->header.length = length;
+    dptr->header.raw_copy = false;
+
+    uint32_t npages = (length + downstream_cb_page_size - 1) >> downstream_cb_log_page_size;
+
+    // Assume the dispatch buffer is big relative to cmddat command size that we can
+    // grab what we need in one chunk
+    DispatchRelayInlineState::cb_writer.acquire_pages(npages);
+    if (is_exec_buf) {
+        // swipe all the downstream page credits from ourselves...
+        // prefetch_h stalls sending commands to prefetch_d until notified by dispatch_d that the exec_buf is done
+        // exec_buf completing on dispatch_h will free the pages and allow sending again
+        DispatchRelayInlineState::cb_writer.additional_count -= downstream_cb_pages;
+
+        // OK to continue prefetching once the page credits are returned
+        stall_state = NOT_STALLED;
+    }
+
+    // Write sizes below may exceed NOC_MAX_BURST_SIZE so we use the any_len version
+    // Amount to write depends on how much free space
+    uint32_t downstream_pages_left = (downstream_cb_end - downstream_data_ptr) >> downstream_cb_log_page_size;
+    if (downstream_pages_left >= npages) {
+        // WAIT is not needed here because previous writes were flushed at the end of the loop in the caller (kernel_h)
+        relay_client
+            .write_atomic_inc_any_len<my_noc_index, downstream_noc_xy, downstream_cb_sem_id, false, NCRISC_WR_CMD_BUF>(
+                data_ptr, get_noc_addr_helper(downstream_noc_xy, downstream_data_ptr), length, npages);
+        downstream_data_ptr += npages * downstream_cb_page_size;
+    } else {
+        uint32_t tail_pages = npages - downstream_pages_left;
+        uint32_t available = downstream_pages_left * downstream_cb_page_size;
+        if (available > 0) {
+            relay_client.write_any_len<my_noc_index, false, NCRISC_WR_CMD_BUF, true>(
+                data_ptr, get_noc_addr_helper(downstream_noc_xy, downstream_data_ptr), available);
+            data_ptr += available;
+            length -= available;
+        }
+
+        // Remainder
+        // WAIT is needed here because previously "if (available > 0)" then it used the write buf which may still be
+        // busy at this point
+        relay_client
+            .write_atomic_inc_any_len<my_noc_index, downstream_noc_xy, downstream_cb_sem_id, true, NCRISC_WR_CMD_BUF>(
+                data_ptr, get_noc_addr_helper(downstream_noc_xy, downstream_cb_base), length, npages);
+
+        downstream_data_ptr = downstream_cb_base + tail_pages * downstream_cb_page_size;
+    }
+
+    return fence;
+}
+
+// We require that all data for a single fetch is available before processing commands. We can't use a normal
+// CBReaderWithReleasePolicy because that always releases pages when advancing between blocks,
+// which would cause problems if the data spans multiple blocks.
+CBReaderWithManualRelease<
+    my_upstream_cb_sem_id,
+    cmddat_q_log_page_size,
+    cmddat_q_blocks,
+    cmddat_q_pages_per_block,
+    cmddat_q_base,
+    cmddat_q_end>
+    h_cmddat_q_reader;
+
+// Used in prefetch_d downstream of a CQ_PREFETCH_CMD_RELAY_LINEAR_H command.
+inline void relay_raw_data_to_downstream(uint32_t& data_ptr, uint64_t wlength, uint32_t& local_downstream_data_ptr) {
+    // In initial return, we return the header bytes as well
+    uint32_t initial_data_to_return = sizeof(CQPrefetchHToPrefetchDHeader);
+    data_ptr += sizeof(CQPrefetchHToPrefetchDHeader);
+    wlength -= sizeof(CQPrefetchHToPrefetchDHeader);
+    // Stream data to downstream as it arrives. Acquire upstream pages incrementally.
+    while (wlength > 0) {
+        // Ensure at least one upstream page is available
+        uint32_t available_data = h_cmddat_q_reader.wait_for_available_data(data_ptr);
+
+        uint32_t can_read_now = available_data;
+        if (can_read_now > wlength) {
+            can_read_now = wlength;
+        }
+
+        // Decide whether this is the final chunk
+        bool is_final_chunk = (can_read_now == wlength);
+
+        uint32_t npages;
+        if (is_final_chunk) {
+            npages = write_pages_to_dispatcher<1, true>(local_downstream_data_ptr, data_ptr, can_read_now);
+        } else {
+            npages = write_pages_to_dispatcher<0, false>(local_downstream_data_ptr, data_ptr, can_read_now);
+        }
+
+        // Release pages consumed by this chunk
+        if (npages != 0) {
+            DispatchRelayInlineState::cb_writer.release_pages(npages, local_downstream_data_ptr, true);
+        }
+
+        // Advance pointers and wlength
+        h_cmddat_q_reader.consumed_data(data_ptr, can_read_now);
+        wlength -= can_read_now;
+
+        // Release upstream pages so prefetch_h can make more available. Ensure to flush the writes just made to prevent
+        // data race.
+        noc_async_writes_flushed();
+        // wait_for_available_data always returns up to a page boundary, so the rounding only matters on the final chunk
+        // and lets us return the final bytes in the page early.
+        uint32_t pages_to_free =
+            (can_read_now + initial_data_to_return + cmddat_q_page_size - 1) >> cmddat_q_log_page_size;
+        initial_data_to_return = 0;
+        uint32_t watcher_data_ptr = data_ptr;
+#if ASSERT_ENABLED
+        if (wlength == 0) {
+            // This normally happens after the end of the loop, but do it early here so we don't hit assertions. Data
+            // until the end of the page isn't used.
+            watcher_data_ptr = round_up_pow2(watcher_data_ptr, cmddat_q_page_size);
+        }
+#endif
+        // data_ptr may not be page-aligned mid-stream, so allow it to be up to one page ahead
+        relay_client.release_pages<
+            my_noc_index,
+            upstream_noc_xy,
+            upstream_cb_sem_id,
+            cmddat_q_base,
+            cmddat_q_end,
+            cmddat_q_page_size>(pages_to_free, watcher_data_ptr);
+    }
+    local_downstream_data_ptr =
+        round_up_pow2(local_downstream_data_ptr, DispatchRelayInlineState::downstream_page_size);
+    // Release an extra page to account for the dispatch command (via CQ_PREFETCH_CMD_RELAY_INLINE_NOFLUSH) that would
+    // have headed the first relayed segment
+    DispatchRelayInlineState::cb_writer.release_pages(1, local_downstream_data_ptr);
+    // Round upstream pointer to next cmddat page boundary for next command
+    data_ptr = round_up_pow2(data_ptr, cmddat_q_page_size);
+}
+
+// Gets cmds from upstream prefetch_h
+// Note the prefetch_h uses the HostQ and grabs whole commands
+// Shared command processor assumes whole commands are present, really
+// just matters for the inline command which could be re-implemented
+// This grabs whole (possibly sets of if multiple in a page) commands.
+// In the case raw_copy is set in the header, that data will be copied to the downstream, and this function will loop
+// until commands are received.
+inline uint32_t relay_cb_get_cmds(uint32_t& data_ptr, uint32_t& downstream_data_ptr) {
+    while (true) {
+        // DPRINT << "get_commands: data_ptr:0x" << HEX() << data_ptr << ", fence:0x" << fence << ",
+        // downstream_data_ptr:0x" << downstream_data_ptr << ENDL();
+        h_cmddat_q_reader.wait_for_available_data(data_ptr);
+
+        volatile tt_l1_ptr CQPrefetchHToPrefetchDHeader* cmd_ptr =
+            (volatile tt_l1_ptr CQPrefetchHToPrefetchDHeader*)data_ptr;
+
+        if (cmd_ptr->header.raw_copy) {
+            uint64_t wlength = cmd_ptr->header.length;
+            relay_raw_data_to_downstream(data_ptr, wlength, downstream_data_ptr);
+        } else {
+            uint32_t length = cmd_ptr->header.length;
+            // Ensure the entire command payload is present before returning
+            uint32_t pages_ready = h_cmddat_q_reader.available_bytes(data_ptr) >> cmddat_q_log_page_size;
+            uint32_t pages_needed = (length + cmddat_q_page_size - 1) >> cmddat_q_log_page_size;
+            int32_t pages_pending = pages_needed - pages_ready;
+            int32_t npages = 0;
+
+            uint32_t dummy_data_ptr = data_ptr;
+            while (npages < pages_pending) {
+                npages += h_cmddat_q_reader.get_cb_page(dummy_data_ptr);
+                IDLE_ERISC_RETURN(length - sizeof(CQPrefetchHToPrefetchDHeader));
+            }
+
+            data_ptr += sizeof(CQPrefetchHToPrefetchDHeader);
+            return length - sizeof(CQPrefetchHToPrefetchDHeader);
+        }
+    }
+}
+
+void kernel_main_h() {
+    uint32_t cmd_ptr = cmddat_q_base;
+    uint32_t fence = cmddat_q_base;
+    bool done = false;
+    uint32_t heartbeat = 0;
+    uint32_t l1_cache[l1_cache_elements_rounded];
+
+    // Fetch q uses read buf. Write buf for process_relay_inline_all/process_relay_linear_h_cmd can be setup once
+    relay_client.init<
+        my_noc_index,
+        fabric_mux_x,
+        fabric_mux_y,
+        worker_credits_stream_id,
+        fabric_mux_channel_base_address,
+        fabric_mux_connection_handshake_address,
+        fabric_mux_connection_info_address,
+        fabric_mux_buffer_index_address,
+        fabric_worker_flow_control_sem,
+        fabric_worker_teardown_sem,
+        fabric_worker_buffer_index_sem,
+        fabric_mux_status_address,
+        my_fabric_sync_status_addr,
+        to_mesh_id,
+        ew_dim,
+        fabric_header_rb_base,
+        num_hops,
+        NCRISC_WR_CMD_BUF>(get_noc_addr_helper(downstream_noc_xy, 0), my_dev_id, to_dev_id, router_direction);
+
+    while (!done) {
+        fetch_q_get_cmds<sizeof(CQPrefetchHToPrefetchDHeader)>(fence, cmd_ptr, pcie_read_ptr);
+
+        IDLE_ERISC_HEARTBEAT_AND_RETURN(heartbeat);
+
+        volatile CQPrefetchCmd tt_l1_ptr* cmd =
+            (volatile CQPrefetchCmd tt_l1_ptr*)(cmd_ptr + sizeof(CQPrefetchHToPrefetchDHeader));
+        uint32_t cmd_id = cmd->base.cmd_id;
+        // Infer that an exec_buf command is to be executed based on the stall state.
+        bool is_exec_buf = (stall_state == STALLED);
+        if (cmd_id == CQ_PREFETCH_CMD_RELAY_LINEAR_H) {
+            cmd_ptr += process_relay_linear_h_cmd(cmd_ptr, downstream_data_ptr);
+        } else if (cmd_id == CQ_PREFETCH_CMD_RELAY_LINEAR_PACKED_H) {
+            cmd_ptr += process_relay_linear_packed_h_cmd(cmd_ptr, downstream_data_ptr, l1_cache);
+        } else {
+            cmd_ptr = process_relay_inline_all(cmd_ptr, fence, is_exec_buf);
+        }
+        noc_async_writes_flushed();
+
+        // Note: one fetch_q entry can contain multiple commands
+        // The code below assumes these commands arrive individually, packing them would require parsing all cmds
+        if (cmd_id == CQ_PREFETCH_CMD_TERMINATE) {
+            // DPRINT << "prefetch terminating_10" << ENDL();
+            done = true;
+        }
+    }
+}
+
+void kernel_main_d() {
+    PrefetchExecBufState exec_buf_state;
+
+    h_cmddat_q_reader.init();
+    uint32_t cmd_ptr = cmddat_q_base;
+
+    bool done = false;
+    uint32_t heartbeat = 0;
+    uint32_t l1_cache[l1_cache_elements_rounded];
+
+    // Cmdbuf allocation is not defined yet for fabric so we can't use stateful APIs on Dispatch D
+#if defined(FABRIC_RELAY)
+    relay_client.init<
+        my_noc_index,
+        fabric_mux_x,
+        fabric_mux_y,
+        worker_credits_stream_id,
+        fabric_mux_channel_base_address,
+        fabric_mux_connection_handshake_address,
+        fabric_mux_connection_info_address,
+        fabric_mux_buffer_index_address,
+        fabric_worker_flow_control_sem,
+        fabric_worker_teardown_sem,
+        fabric_worker_buffer_index_sem,
+        fabric_mux_status_address,
+        my_fabric_sync_status_addr,
+        to_mesh_id,
+        ew_dim,
+        fabric_header_rb_base,
+        num_hops,
+        NCRISC_WR_CMD_BUF>(get_noc_addr_helper(downstream_noc_xy, 0), my_dev_id, to_dev_id, router_direction);
+#else
+    cq_noc_async_write_init_state<CQ_NOC_sNdl, false, false, DispatchRelayInlineState::downstream_write_cmd_buf>(
+        0, get_noc_addr_helper(downstream_noc_xy, downstream_data_ptr), 0, my_noc_index);
+    cq_noc_async_write_init_state<CQ_NOC_sNdl, false, false, DispatchSRelayInlineState::downstream_write_cmd_buf>(
+        0, get_noc_addr_helper(dispatch_s_noc_xy, downstream_data_ptr_s), 0, my_noc_index);
+#endif
+
+    // Initialize cmd_ptr tracking for release_pages synchronization assertions
+    relay_client.init_cmd_ptr_tracking<cmddat_q_base>();
+
+    while (!done) {
+        // cmds come in packed batches based on HostQ reads in prefetch_h
+        // once a packed batch ends, we need to jump to the next page
+        uint32_t length = relay_cb_get_cmds(cmd_ptr, downstream_data_ptr);
+
+        IDLE_ERISC_HEARTBEAT_AND_RETURN(heartbeat);
+
+        uint32_t amt_processed = 0;
+        while (length > amt_processed) {
+            uint32_t stride;
+            done = process_cmd<true, false>(cmd_ptr, downstream_data_ptr, stride, l1_cache, exec_buf_state);
+            amt_processed += stride;
+
+            h_cmddat_q_reader.consumed_data(cmd_ptr, stride);
+        }
+
+        // TODO: evaluate less costly free pattern (blocks?)
+        uint32_t total_length = length + sizeof(CQPrefetchHToPrefetchDHeader);
+        uint32_t pages_to_free = (total_length + cmddat_q_page_size - 1) >> cmddat_q_log_page_size;
+        // Ensure all writes that consumed this payload have completed before releasing upstream pages
+        noc_async_writes_flushed();
+
+        // Move to next page
+        cmd_ptr = round_up_pow2(cmd_ptr, cmddat_q_page_size);
+        relay_client.release_pages<
+            my_noc_index,
+            upstream_noc_xy,
+            upstream_cb_sem_id,
+            cmddat_q_base,
+            cmddat_q_end,
+            cmddat_q_page_size>(pages_to_free, cmd_ptr);
+    }
+
+    // Set upstream semaphore MSB to signal completion and path teardown
+    // in case prefetch_d is connected to a depacketizing stage.
+    relay_client.teardown<my_noc_index, upstream_noc_xy, upstream_cb_sem_id>();
+}
+
+void kernel_main_hd() {
+    uint32_t cmd_ptr = cmddat_q_base;
+    uint32_t fence = cmddat_q_base;
+    bool done = false;
+    uint32_t heartbeat = 0;
+    uint32_t l1_cache[l1_cache_elements_rounded];
+    PrefetchExecBufState exec_buf_state;
+
+    cq_noc_async_write_init_state<CQ_NOC_sNdl, false, false, DispatchRelayInlineState::downstream_write_cmd_buf>(
+        0, get_noc_addr_helper(downstream_noc_xy, downstream_data_ptr), 0);
+    cq_noc_async_write_init_state<CQ_NOC_sNdl, false, false, DispatchSRelayInlineState::downstream_write_cmd_buf>(
+        0, get_noc_addr_helper(dispatch_s_noc_xy, downstream_data_ptr_s), 0);
+
+    while (!done) {
+        DeviceZoneScopedN("CQ-PREFETCH");
+        constexpr uint32_t preamble_size = 0;
+        fetch_q_get_cmds<preamble_size>(fence, cmd_ptr, pcie_read_ptr);
+
+        IDLE_ERISC_HEARTBEAT_AND_RETURN(heartbeat);
+
+        volatile CQPrefetchCmd tt_l1_ptr* cmd = (volatile CQPrefetchCmd tt_l1_ptr*)cmd_ptr;
+
+        uint32_t stride;
+        done = process_cmd<false, false>(cmd_ptr, downstream_data_ptr, stride, l1_cache, exec_buf_state);
+        cmd_ptr += stride;
+    }
+}
+
+void kernel_main() {
+    set_l1_data_cache<true>();
+#if defined(FABRIC_RELAY)
+    DPRINT << "prefetcher_" << is_h_variant << is_d_variant << ": start (fabric relay. 2d = " << (uint32_t)is_2d_fabric
+           << ")" << ENDL();
+#else
+    DPRINT << "prefetcher_" << is_h_variant << is_d_variant << ": start" << ENDL();
+#endif
+
+    // Get runtime args
+    my_dev_id = get_arg_val<uint32_t>(OFFSETOF_MY_DEV_ID);
+    to_dev_id = get_arg_val<uint32_t>(OFFSETOF_TO_DEV_ID);
+    router_direction = get_arg_val<uint32_t>(OFFSETOF_ROUTER_DIRECTION);
+
+    if (is_h_variant and is_d_variant) {
+        kernel_main_hd();
+    } else if (is_h_variant) {
+        kernel_main_h();
+    } else if (is_d_variant) {
+        kernel_main_d();
+    } else {
+        ASSERT(0);
+    }
+    IDLE_ERISC_RETURN();
+
+    // Confirm expected number of pages, spinning here is a leak
+    DispatchRelayInlineState::cb_writer.wait_all_pages(downstream_cb_pages);
+
+    noc_async_full_barrier();
+
+    DPRINT << "prefetcher_" << is_h_variant << is_d_variant << ": out" << ENDL();
+    set_l1_data_cache<false>();
+}

--- a/tt_metal/impl/dispatch/kernels/cq_prefetch_writer.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_prefetch_writer.cpp
@@ -18,7 +18,8 @@
 // Constants used to interact with the downstream dispatchers.
 // fd_core_type is already defined in cq_common.hpp.
 constexpr uint32_t downstream_noc_xy = uint32_t(NOC_XY_ENCODING(DOWNSTREAM_NOC_X, DOWNSTREAM_NOC_Y));
-constexpr uint32_t dispatch_s_noc_xy = uint32_t(NOC_XY_ENCODING(DOWNSTREAM_SUBORDINATE_NOC_X, DOWNSTREAM_SUBORDINATE_NOC_Y));
+constexpr uint32_t dispatch_s_noc_xy =
+    uint32_t(NOC_XY_ENCODING(DOWNSTREAM_SUBORDINATE_NOC_X, DOWNSTREAM_SUBORDINATE_NOC_Y));
 constexpr uint32_t downstream_cb_base = DOWNSTREAM_CB_BASE;
 constexpr uint32_t dispatch_s_buffer_base = DISPATCH_S_BUFFER_BASE;
 constexpr uint32_t scratch_db_base = SCRATCH_DB_BASE;
@@ -78,24 +79,17 @@ void kernel_main() {
     // dispatcher's CB, then signal each dispatcher via its semaphore.
     // No synchronisation with the reader (BRISC) is needed at this stub stage.
 
-    volatile tt_l1_ptr CQDispatchCmd* local_cmd =
-        reinterpret_cast<volatile tt_l1_ptr CQDispatchCmd*>(scratch_db_base);
+    volatile tt_l1_ptr CQDispatchCmd* local_cmd = reinterpret_cast<volatile tt_l1_ptr CQDispatchCmd*>(scratch_db_base);
     local_cmd->base.cmd_id = CQ_DISPATCH_CMD_TERMINATE;
 
     // --- Regular dispatcher ---
-    noc_async_write(
-        scratch_db_base,
-        get_noc_addr_helper(downstream_noc_xy, downstream_cb_base),
-        sizeof(CQDispatchCmd));
+    noc_async_write(scratch_db_base, get_noc_addr_helper(downstream_noc_xy, downstream_cb_base), sizeof(CQDispatchCmd));
     noc_async_writes_flushed();
-    noc_semaphore_inc(
-        get_noc_addr_helper(downstream_noc_xy, get_semaphore<fd_core_type>(downstream_cb_sem_id)), 1);
+    noc_semaphore_inc(get_noc_addr_helper(downstream_noc_xy, get_semaphore<fd_core_type>(downstream_cb_sem_id)), 1);
 
     // --- Subordinate dispatcher (dispatch_s) ---
     noc_async_write(
-        scratch_db_base,
-        get_noc_addr_helper(dispatch_s_noc_xy, dispatch_s_buffer_base),
-        sizeof(CQDispatchCmd));
+        scratch_db_base, get_noc_addr_helper(dispatch_s_noc_xy, dispatch_s_buffer_base), sizeof(CQDispatchCmd));
     noc_async_writes_flushed();
     noc_semaphore_inc(
         get_noc_addr_helper(dispatch_s_noc_xy, get_semaphore<fd_core_type>(downstream_dispatch_s_cb_sem_id)), 1);

--- a/tt_metal/impl/dispatch/kernels/cq_prefetch_writer.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_prefetch_writer.cpp
@@ -15,13 +15,21 @@
 #include "tt_metal/impl/dispatch/kernels/cq_relay.hpp"
 #include "api/debug/dprint.h"
 
-// Reference all defines to ensure they are valid and the kernel compiles with the
-// same define set as cq_prefetch_reader.cpp.
-[[maybe_unused]] constexpr uint32_t pw_downstream_cb_base = DOWNSTREAM_CB_BASE;
+// Constants used to interact with the downstream dispatchers.
+// fd_core_type is already defined in cq_common.hpp.
+constexpr uint32_t downstream_noc_xy = uint32_t(NOC_XY_ENCODING(DOWNSTREAM_NOC_X, DOWNSTREAM_NOC_Y));
+constexpr uint32_t dispatch_s_noc_xy = uint32_t(NOC_XY_ENCODING(DOWNSTREAM_SUBORDINATE_NOC_X, DOWNSTREAM_SUBORDINATE_NOC_Y));
+constexpr uint32_t downstream_cb_base = DOWNSTREAM_CB_BASE;
+constexpr uint32_t dispatch_s_buffer_base = DISPATCH_S_BUFFER_BASE;
+constexpr uint32_t scratch_db_base = SCRATCH_DB_BASE;
+constexpr uint32_t downstream_cb_sem_id = DOWNSTREAM_CB_SEM_ID;
+constexpr uint32_t downstream_dispatch_s_cb_sem_id = DOWNSTREAM_DISPATCH_S_CB_SEM_ID;
+
+// Reference remaining defines to keep the compilation set consistent with cq_prefetch_reader.cpp.
+[[maybe_unused]] constexpr uint32_t pw_my_downstream_cb_sem_id = MY_DOWNSTREAM_CB_SEM_ID;
+[[maybe_unused]] constexpr uint32_t pw_my_dispatch_s_cb_sem_id = MY_DISPATCH_S_CB_SEM_ID;
 [[maybe_unused]] constexpr uint32_t pw_downstream_cb_log_page_size = DOWNSTREAM_CB_LOG_PAGE_SIZE;
 [[maybe_unused]] constexpr uint32_t pw_downstream_cb_pages = DOWNSTREAM_CB_PAGES;
-[[maybe_unused]] constexpr uint32_t pw_my_downstream_cb_sem_id = MY_DOWNSTREAM_CB_SEM_ID;
-[[maybe_unused]] constexpr uint32_t pw_downstream_cb_sem_id = DOWNSTREAM_CB_SEM_ID;
 [[maybe_unused]] constexpr uint32_t pw_pcie_base = PCIE_BASE;
 [[maybe_unused]] constexpr uint32_t pw_pcie_size = PCIE_SIZE;
 [[maybe_unused]] constexpr uint32_t pw_prefetch_q_base = PREFETCH_Q_BASE;
@@ -30,7 +38,6 @@
 [[maybe_unused]] constexpr uint32_t pw_prefetch_q_pcie_rd_ptr_addr = PREFETCH_Q_PCIE_RD_PTR_ADDR;
 [[maybe_unused]] constexpr uint32_t pw_cmddat_q_base = CMDDAT_Q_BASE;
 [[maybe_unused]] constexpr uint32_t pw_cmddat_q_size = CMDDAT_Q_SIZE;
-[[maybe_unused]] constexpr uint32_t pw_scratch_db_base = SCRATCH_DB_BASE;
 [[maybe_unused]] constexpr uint32_t pw_scratch_db_size = SCRATCH_DB_SIZE;
 [[maybe_unused]] constexpr uint32_t pw_downstream_sync_sem_id = DOWNSTREAM_SYNC_SEM_ID;
 [[maybe_unused]] constexpr uint32_t pw_cmddat_q_pages = CMDDAT_Q_PAGES;
@@ -38,9 +45,6 @@
 [[maybe_unused]] constexpr uint32_t pw_upstream_cb_sem_id = UPSTREAM_CB_SEM_ID;
 [[maybe_unused]] constexpr uint32_t pw_cmddat_q_log_page_size = CMDDAT_Q_LOG_PAGE_SIZE;
 [[maybe_unused]] constexpr uint32_t pw_cmddat_q_blocks = CMDDAT_Q_BLOCKS;
-[[maybe_unused]] constexpr uint32_t pw_dispatch_s_buffer_base = DISPATCH_S_BUFFER_BASE;
-[[maybe_unused]] constexpr uint32_t pw_my_dispatch_s_cb_sem_id = MY_DISPATCH_S_CB_SEM_ID;
-[[maybe_unused]] constexpr uint32_t pw_downstream_dispatch_s_cb_sem_id = DOWNSTREAM_DISPATCH_S_CB_SEM_ID;
 [[maybe_unused]] constexpr uint32_t pw_dispatch_s_buffer_size = DISPATCH_S_BUFFER_SIZE;
 [[maybe_unused]] constexpr uint32_t pw_dispatch_s_cb_log_page_size = DISPATCH_S_CB_LOG_PAGE_SIZE;
 [[maybe_unused]] constexpr uint32_t pw_ringbuffer_size = RINGBUFFER_SIZE;
@@ -70,6 +74,29 @@
 [[maybe_unused]] constexpr uint32_t pw_is_h_variant = IS_H_VARIANT;
 
 void kernel_main() {
-    DPRINT << "prefetch_writer: start" << ENDL();
-    DPRINT << "prefetch_writer: out" << ENDL();
+    // Build a TERMINATE command in local L1 (scratch), NOC-write it to each downstream
+    // dispatcher's CB, then signal each dispatcher via its semaphore.
+    // No synchronisation with the reader (BRISC) is needed at this stub stage.
+
+    volatile tt_l1_ptr CQDispatchCmd* local_cmd =
+        reinterpret_cast<volatile tt_l1_ptr CQDispatchCmd*>(scratch_db_base);
+    local_cmd->base.cmd_id = CQ_DISPATCH_CMD_TERMINATE;
+
+    // --- Regular dispatcher ---
+    noc_async_write(
+        scratch_db_base,
+        get_noc_addr_helper(downstream_noc_xy, downstream_cb_base),
+        sizeof(CQDispatchCmd));
+    noc_async_writes_flushed();
+    noc_semaphore_inc(
+        get_noc_addr_helper(downstream_noc_xy, get_semaphore<fd_core_type>(downstream_cb_sem_id)), 1);
+
+    // --- Subordinate dispatcher (dispatch_s) ---
+    noc_async_write(
+        scratch_db_base,
+        get_noc_addr_helper(dispatch_s_noc_xy, dispatch_s_buffer_base),
+        sizeof(CQDispatchCmd));
+    noc_async_writes_flushed();
+    noc_semaphore_inc(
+        get_noc_addr_helper(dispatch_s_noc_xy, get_semaphore<fd_core_type>(downstream_dispatch_s_cb_sem_id)), 1);
 }

--- a/tt_metal/impl/dispatch/kernels/cq_prefetch_writer.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_prefetch_writer.cpp
@@ -1,0 +1,75 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Prefetch writer stub kernel
+//  - Intended to run on NCRISC of the same core as the prefetch reader (BRISC)
+//  - Currently a stub; future work will move write operations here from the reader
+//
+// This kernel receives the same compile-time defines as cq_prefetch_reader.cpp so that
+// both kernels share a single compilation unit configuration.
+
+#include "api/dataflow/dataflow_api.h"
+#include "tt_metal/impl/dispatch/kernels/cq_commands.hpp"
+#include "tt_metal/impl/dispatch/kernels/cq_common.hpp"
+#include "tt_metal/impl/dispatch/kernels/cq_relay.hpp"
+#include "api/debug/dprint.h"
+
+// Reference all defines to ensure they are valid and the kernel compiles with the
+// same define set as cq_prefetch_reader.cpp.
+[[maybe_unused]] constexpr uint32_t pw_downstream_cb_base = DOWNSTREAM_CB_BASE;
+[[maybe_unused]] constexpr uint32_t pw_downstream_cb_log_page_size = DOWNSTREAM_CB_LOG_PAGE_SIZE;
+[[maybe_unused]] constexpr uint32_t pw_downstream_cb_pages = DOWNSTREAM_CB_PAGES;
+[[maybe_unused]] constexpr uint32_t pw_my_downstream_cb_sem_id = MY_DOWNSTREAM_CB_SEM_ID;
+[[maybe_unused]] constexpr uint32_t pw_downstream_cb_sem_id = DOWNSTREAM_CB_SEM_ID;
+[[maybe_unused]] constexpr uint32_t pw_pcie_base = PCIE_BASE;
+[[maybe_unused]] constexpr uint32_t pw_pcie_size = PCIE_SIZE;
+[[maybe_unused]] constexpr uint32_t pw_prefetch_q_base = PREFETCH_Q_BASE;
+[[maybe_unused]] constexpr uint32_t pw_prefetch_q_size = PREFETCH_Q_SIZE;
+[[maybe_unused]] constexpr uint32_t pw_prefetch_q_rd_ptr_addr = PREFETCH_Q_RD_PTR_ADDR;
+[[maybe_unused]] constexpr uint32_t pw_prefetch_q_pcie_rd_ptr_addr = PREFETCH_Q_PCIE_RD_PTR_ADDR;
+[[maybe_unused]] constexpr uint32_t pw_cmddat_q_base = CMDDAT_Q_BASE;
+[[maybe_unused]] constexpr uint32_t pw_cmddat_q_size = CMDDAT_Q_SIZE;
+[[maybe_unused]] constexpr uint32_t pw_scratch_db_base = SCRATCH_DB_BASE;
+[[maybe_unused]] constexpr uint32_t pw_scratch_db_size = SCRATCH_DB_SIZE;
+[[maybe_unused]] constexpr uint32_t pw_downstream_sync_sem_id = DOWNSTREAM_SYNC_SEM_ID;
+[[maybe_unused]] constexpr uint32_t pw_cmddat_q_pages = CMDDAT_Q_PAGES;
+[[maybe_unused]] constexpr uint32_t pw_my_upstream_cb_sem_id = MY_UPSTREAM_CB_SEM_ID;
+[[maybe_unused]] constexpr uint32_t pw_upstream_cb_sem_id = UPSTREAM_CB_SEM_ID;
+[[maybe_unused]] constexpr uint32_t pw_cmddat_q_log_page_size = CMDDAT_Q_LOG_PAGE_SIZE;
+[[maybe_unused]] constexpr uint32_t pw_cmddat_q_blocks = CMDDAT_Q_BLOCKS;
+[[maybe_unused]] constexpr uint32_t pw_dispatch_s_buffer_base = DISPATCH_S_BUFFER_BASE;
+[[maybe_unused]] constexpr uint32_t pw_my_dispatch_s_cb_sem_id = MY_DISPATCH_S_CB_SEM_ID;
+[[maybe_unused]] constexpr uint32_t pw_downstream_dispatch_s_cb_sem_id = DOWNSTREAM_DISPATCH_S_CB_SEM_ID;
+[[maybe_unused]] constexpr uint32_t pw_dispatch_s_buffer_size = DISPATCH_S_BUFFER_SIZE;
+[[maybe_unused]] constexpr uint32_t pw_dispatch_s_cb_log_page_size = DISPATCH_S_CB_LOG_PAGE_SIZE;
+[[maybe_unused]] constexpr uint32_t pw_ringbuffer_size = RINGBUFFER_SIZE;
+[[maybe_unused]] constexpr uint32_t pw_fabric_header_rb_base = FABRIC_HEADER_RB_BASE;
+[[maybe_unused]] constexpr uint32_t pw_fabric_header_rb_entries = FABRIC_HEADER_RB_ENTRIES;
+[[maybe_unused]] constexpr uint32_t pw_my_fabric_sync_status_addr = MY_FABRIC_SYNC_STATUS_ADDR;
+[[maybe_unused]] constexpr uint8_t pw_fabric_mux_x = FABRIC_MUX_X;
+[[maybe_unused]] constexpr uint8_t pw_fabric_mux_y = FABRIC_MUX_Y;
+[[maybe_unused]] constexpr uint8_t pw_fabric_mux_num_buffers_per_channel = FABRIC_MUX_NUM_BUFFERS_PER_CHANNEL;
+[[maybe_unused]] constexpr size_t pw_fabric_mux_channel_buffer_size_bytes = FABRIC_MUX_CHANNEL_BUFFER_SIZE_BYTES;
+[[maybe_unused]] constexpr size_t pw_fabric_mux_channel_base_address = FABRIC_MUX_CHANNEL_BASE_ADDRESS;
+[[maybe_unused]] constexpr size_t pw_fabric_mux_connection_info_address = FABRIC_MUX_CONNECTION_INFO_ADDRESS;
+[[maybe_unused]] constexpr size_t pw_fabric_mux_connection_handshake_address = FABRIC_MUX_CONNECTION_HANDSHAKE_ADDRESS;
+[[maybe_unused]] constexpr size_t pw_fabric_mux_flow_control_address = FABRIC_MUX_FLOW_CONTROL_ADDRESS;
+[[maybe_unused]] constexpr size_t pw_fabric_mux_buffer_index_address = FABRIC_MUX_BUFFER_INDEX_ADDRESS;
+[[maybe_unused]] constexpr size_t pw_fabric_mux_status_address = FABRIC_MUX_STATUS_ADDRESS;
+[[maybe_unused]] constexpr size_t pw_fabric_mux_termination_signal_address = FABRIC_MUX_TERMINATION_SIGNAL_ADDRESS;
+[[maybe_unused]] constexpr size_t pw_worker_credits_stream_id = WORKER_CREDITS_STREAM_ID;
+[[maybe_unused]] constexpr size_t pw_fabric_worker_flow_control_sem = FABRIC_WORKER_FLOW_CONTROL_SEM;
+[[maybe_unused]] constexpr size_t pw_fabric_worker_teardown_sem = FABRIC_WORKER_TEARDOWN_SEM;
+[[maybe_unused]] constexpr size_t pw_fabric_worker_buffer_index_sem = FABRIC_WORKER_BUFFER_INDEX_SEM;
+[[maybe_unused]] constexpr uint8_t pw_num_hops = NUM_HOPS;
+[[maybe_unused]] constexpr uint32_t pw_ew_dim = EW_DIM;
+[[maybe_unused]] constexpr uint32_t pw_to_mesh_id = TO_MESH_ID;
+[[maybe_unused]] constexpr bool pw_is_2d_fabric = FABRIC_2D;
+[[maybe_unused]] constexpr uint32_t pw_is_d_variant = IS_D_VARIANT;
+[[maybe_unused]] constexpr uint32_t pw_is_h_variant = IS_H_VARIANT;
+
+void kernel_main() {
+    DPRINT << "prefetch_writer: start" << ENDL();
+    DPRINT << "prefetch_writer: out" << ENDL();
+}

--- a/tt_metal/impl/dispatch/topology.cpp
+++ b/tt_metal/impl/dispatch/topology.cpp
@@ -104,6 +104,23 @@ constexpr noc_selection_t k_dispatcher_s_noc = {
 static_assert(k_dispatcher_noc.non_dispatch_noc != k_dispatcher_s_noc.non_dispatch_noc);
 
 //
+// Prefetch writer NOC selections.
+//
+// The writer stub runs on NCRISC of the same Tensix core as the prefetch reader (BRISC).
+// Both RISCs use stateful NoC APIs, so they must use different NOCs to avoid corrupting
+// each other's in-flight request counts.  The reader uses NOC_0; the writer uses NOC_1.
+//
+constexpr noc_selection_t k_prefetcher_writer_noc = {
+    .non_dispatch_noc = NOC::NOC_1,
+    .upstream_noc = NOC::NOC_1,
+    .downstream_noc = NOC::NOC_1,
+};
+
+// Must be on different NOCs because PrefetchKernel (reader) and PrefetchWriterKernel may run on the same
+// core. They are using stateful APIs. Running on the same NOC will mess up requests sent/to free count.
+static_assert(k_prefetcher_noc.non_dispatch_noc != k_prefetcher_writer_noc.non_dispatch_noc);
+
+//
 // Fabric MUX NOC selections
 //
 // Must be NoC0
@@ -558,6 +575,29 @@ std::vector<DispatchKernelNode> DispatchTopology::generate_nodes(
                 index_offset += nodes_for_one_mmio.size();
             }
         }
+    }
+
+    // When the split-prefetcher env var is set, append a PREFETCH_HD_WRITER node for every
+    // PREFETCH_HD node.  The writer runs on NCRISC of the same core.  Its only upstream link
+    // is the reader (so it can retrieve the reader's defines in CreateKernel()).
+    if (MetalContext::instance().rtoptions().get_split_prefetcher()) {
+        std::vector<DispatchKernelNode> writer_nodes;
+        for (const auto& node : nodes) {
+            if (node.kernel_type == PREFETCH_HD) {
+                int writer_id = static_cast<int>(nodes.size()) + static_cast<int>(writer_nodes.size());
+                DispatchKernelNode writer_node;
+                writer_node.id = writer_id;
+                writer_node.device_id = node.device_id;
+                writer_node.servicing_device_id = node.servicing_device_id;
+                writer_node.cq_id = node.cq_id;
+                writer_node.kernel_type = PREFETCH_HD_WRITER;
+                writer_node.upstream_ids = {node.id, x, x, x};
+                writer_node.downstream_ids = {x, x, x, x};
+                writer_node.noc_selection = k_prefetcher_writer_noc;
+                writer_nodes.push_back(writer_node);
+            }
+        }
+        nodes.insert(nodes.end(), writer_nodes.begin(), writer_nodes.end());
     }
 
     return nodes;

--- a/tt_metal/impl/sources.cmake
+++ b/tt_metal/impl/sources.cmake
@@ -71,6 +71,7 @@ set(IMPL_SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/dispatch/topology.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/dispatch/kernel_config/fd_kernel.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/dispatch/kernel_config/prefetch.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/dispatch/kernel_config/prefetch_writer.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/dispatch/kernel_config/dispatch.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/dispatch/kernel_config/dispatch_s.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/dispatch/kernel_config/relay_mux.cpp

--- a/tt_metal/llrt/rtoptions.cpp
+++ b/tt_metal/llrt/rtoptions.cpp
@@ -104,6 +104,7 @@ enum class EnvVarID {
     TT_METAL_USE_MGD_2_0,                      // Use mesh graph descriptor 2.0
     TT_METAL_FORCE_JIT_COMPILE,                // Force JIT compilation
     TT_METAL_DISABLE_SFPLOADMACRO,             // Disable use of SFPLOADMACRO instructions
+    TT_METAL_SPLIT_PREFETCHER,              // Split prefetch_hd into reader (BRISC) + writer stub (NCRISC)
 
     // ========================================
     // PROFILING & PERFORMANCE
@@ -677,6 +678,12 @@ void RunTimeOptions::HandleEnvVar(EnvVarID id, const char* value) {
         // Default: 0 (use SFPLOADMACRO instructions)
         // Usage: export TT_METAL_DISABLE_SFPLOADMACRO=1
         case EnvVarID::TT_METAL_DISABLE_SFPLOADMACRO: this->disable_sfploadmacro = is_env_enabled(value); break;
+
+        // TT_METAL_SPLIT_PREFETCHER
+        // Split the prefetch_hd kernel into a reader (BRISC) and a writer stub (NCRISC) on the same core.
+        // Default: false (single prefetch_hd kernel on BRISC)
+        // Usage: export TT_METAL_SPLIT_PREFETCHER=1
+        case EnvVarID::TT_METAL_SPLIT_PREFETCHER: this->split_prefetcher = true; break;
 
         // ========================================
         // PROFILING & PERFORMANCE

--- a/tt_metal/llrt/rtoptions.cpp
+++ b/tt_metal/llrt/rtoptions.cpp
@@ -683,7 +683,7 @@ void RunTimeOptions::HandleEnvVar(EnvVarID id, const char* value) {
         // Split the prefetch_hd kernel into a reader (BRISC) and a writer stub (NCRISC) on the same core.
         // Default: false (single prefetch_hd kernel on BRISC)
         // Usage: export TT_METAL_SPLIT_PREFETCHER=1
-        case EnvVarID::TT_METAL_SPLIT_PREFETCHER: this->split_prefetcher = true; break;
+        case EnvVarID::TT_METAL_SPLIT_PREFETCHER: this->split_prefetcher = is_env_enabled(value); break;
 
         // ========================================
         // PROFILING & PERFORMANCE

--- a/tt_metal/llrt/rtoptions.cpp
+++ b/tt_metal/llrt/rtoptions.cpp
@@ -104,7 +104,7 @@ enum class EnvVarID {
     TT_METAL_USE_MGD_2_0,                      // Use mesh graph descriptor 2.0
     TT_METAL_FORCE_JIT_COMPILE,                // Force JIT compilation
     TT_METAL_DISABLE_SFPLOADMACRO,             // Disable use of SFPLOADMACRO instructions
-    TT_METAL_SPLIT_PREFETCHER,              // Split prefetch_hd into reader (BRISC) + writer stub (NCRISC)
+    TT_METAL_SPLIT_PREFETCHER,                 // Split prefetch_hd into reader (BRISC) + writer stub (NCRISC)
 
     // ========================================
     // PROFILING & PERFORMANCE

--- a/tt_metal/llrt/rtoptions.hpp
+++ b/tt_metal/llrt/rtoptions.hpp
@@ -236,6 +236,8 @@ class RunTimeOptions {
 
     bool fast_dispatch = true;
 
+    bool split_prefetcher = false;
+
     bool skip_eth_cores_with_retrain = false;
 
     // Relaxed ordering on BH allows loads to bypass stores when going to separate addresses
@@ -619,6 +621,7 @@ public:
 
     void set_fast_dispatch(bool enable) { fast_dispatch = enable; }
 
+    bool get_split_prefetcher() const { return split_prefetcher; }
     bool get_skip_eth_cores_with_retrain() const { return skip_eth_cores_with_retrain; }
 
     uint32_t get_arc_debug_buffer_size() const { return arc_debug_buffer_size; }

--- a/tt_metal/sources.cmake
+++ b/tt_metal/sources.cmake
@@ -165,6 +165,8 @@ set(JITAPI_FILES
     impl/dispatch/kernels/cq_dispatch.cpp
     impl/dispatch/kernels/cq_dispatch_subordinate.cpp
     impl/dispatch/kernels/cq_prefetch.cpp
+    impl/dispatch/kernels/cq_prefetch_reader.cpp
+    impl/dispatch/kernels/cq_prefetch_writer.cpp
     fabric/impl/kernels/edm_fabric/fabric_erisc_router.cpp
     fabric/impl/kernels/tt_fabric_mux.cpp
     kernels/compute/blank.cpp


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
The `cq_prefetch` kernel currently runs entirely on BRISC, combining both the command-fetch/relay logic and the write-to-dispatcher path on a single RISC-V processor. Splitting these responsibilities across BRISC and NCRISC on the same Tensix core is a prerequisite for further dispatch pipeline parallelism and throughput improvements.

### What's changed

**New kernels:**
- `tt_metal/impl/dispatch/kernels/cq_prefetch_reader.cpp`: BRISC half of the split prefetcher. Derived from `cq_prefetch.cpp` with the `prefetch_h`-only variant removed and command-relay function bodies stubbed out (signatures retained; bodies will migrate to the writer in follow-up work).
- `tt_metal/impl/dispatch/kernels/cq_prefetch_writer.cpp`: NCRISC stub. Receives the same compile-time defines as the reader. Currently sends `CQ_DISPATCH_CMD_TERMINATE` to both the regular dispatcher and `dispatch_s` on startup, allowing clean device teardown while the relay logic is being migrated.

**Runtime opt-in via environment variable:**
- `TT_METAL_SPLIT_PREFETCHER=1` activates the split kernels in place of the existing `prefetch_hd` kernel. Without the variable the behaviour is unchanged.
- Added `rtoptions` plumbing (`is_split_prefetcher()`) and topology/kernel-config wiring to load the reader on BRISC (NOC 0) and the writer on NCRISC (NOC 1) of the same core.

**Test:**
- Added `GenericMeshDeviceFixture.SplitPrefetcherJitCompile` to `test_prefetcher.cpp`: creates a device (triggering JIT compilation of the split kernels) and tears it down cleanly.
- Added the new test to `tests/scripts/run_cpp_fd2_tests.sh` (run with `TT_METAL_SPLIT_PREFETCHER=1`).

**Verified:** all 29 existing `test_prefetcher` tests, 1 new split-prefetcher test, and 18 `test_dispatcher` tests pass via `run_cpp_fd2_tests.sh`.

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=jbauman/startsplitprefetcher)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:jbauman/startsplitprefetcher)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=jbauman/startsplitprefetcher)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:jbauman/startsplitprefetcher)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=jbauman/startsplitprefetcher)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jbauman/startsplitprefetcher)
- [x] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=jbauman/startsplitprefetcher)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:jbauman/startsplitprefetcher)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=jbauman/startsplitprefetcher)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:jbauman/startsplitprefetcher)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=jbauman/startsplitprefetcher)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:jbauman/startsplitprefetcher)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
