### PR TITLE
Move SystemMesh from singleton to MetalContext ownership

### DIFF
--- a/tests/tt_metal/distributed/multiprocess/test_sanity.cpp
+++ b/tests/tt_metal/distributed/multiprocess/test_sanity.cpp
@@ -100,9 +100,9 @@ TEST(BigMeshDualRankTest, LocalRankBinding) {
 TEST_P(BigMeshDualRankMeshShapeSweepFixture, MeshDeviceValidation) { EXPECT_EQ(mesh_device_->shape(), GetParam()); }
 
 TEST_F(BigMeshDualRankTest2x4, SystemMeshValidation) {
-    ASSERT_NO_THROW({ SystemMesh::instance(); });
+    ASSERT_NO_THROW({ MetalContext::instance().get_system_mesh(); });
 
-    const auto& system_mesh = SystemMesh::instance();
+    const auto& system_mesh = MetalContext::instance().get_system_mesh();
     EXPECT_EQ(system_mesh.local_shape(), MeshShape(2, 2));
 
     auto mapped_devices = system_mesh.get_mapped_devices(MeshShape(2, 4));

--- a/tests/tt_metal/distributed/test_dispatch_context.cpp
+++ b/tests/tt_metal/distributed/test_dispatch_context.cpp
@@ -36,7 +36,7 @@ TEST(DispatchContext, TestWritesAndWorkloads) {
     if (rt_options.get_fast_dispatch()) {
         GTEST_SKIP() << "This test can only be run with Slow Dispatch mode.";
     }
-    const MeshShape system_shape = tt::tt_metal::distributed::SystemMesh::instance().shape();
+    const MeshShape system_shape = MetalContext::instance().get_system_mesh().shape();
     auto mesh_device_ = MeshDevice::create(MeshDeviceConfig(system_shape));
 
     // Terminating without initializing should throw
@@ -102,7 +102,7 @@ TEST(DispatchContext, SdEnableFdDisableFdThenL1Buffer) {
     if (rt_options.get_fast_dispatch()) {
         GTEST_SKIP() << "This test can only be run with Slow Dispatch mode.";
     }
-    const MeshShape system_shape = tt::tt_metal::distributed::SystemMesh::instance().shape();
+    const MeshShape system_shape = MetalContext::instance().get_system_mesh().shape();
     auto mesh_device_ = MeshDevice::create(MeshDeviceConfig(system_shape));
 
     const auto& cluster = MetalContext::instance().get_cluster();

--- a/tests/tt_metal/distributed/test_mesh_device.cpp
+++ b/tests/tt_metal/distributed/test_mesh_device.cpp
@@ -21,6 +21,7 @@
 #include <tt-metalium/mesh_device_view.hpp>
 #include <tt-metalium/shape_base.hpp>
 #include <tt-metalium/system_mesh.hpp>
+#include "impl/context/metal_context.hpp"
 #include "tests/tt_metal/tt_metal/common/multi_device_fixture.hpp"
 #include <tt-metalium/experimental/fabric/control_plane.hpp>
 #include <tt-metalium/experimental/device.hpp>
@@ -47,7 +48,7 @@ using MeshDevice2x4Test = MeshDevice2x4Fixture;
 using MeshDeviceTest = GenericMeshDeviceFixture;
 
 TEST_F(MeshDevice2x4Test, SystemMeshTearDownWithoutClose) {
-    auto& sys = SystemMesh::instance();
+    auto& sys = MetalContext::instance().get_system_mesh();
 
     const auto system_shape = sys.shape();
     ASSERT_EQ(system_shape.dims(), 2);

--- a/tests/tt_metal/distributed/test_mesh_device_reshape.cpp
+++ b/tests/tt_metal/distributed/test_mesh_device_reshape.cpp
@@ -4,7 +4,6 @@
 
 #include <gtest/gtest.h>
 #include <cstdlib>
-#include <tt_stl/indestructible.hpp>
 #include <algorithm>
 #include <cstddef>
 #include <memory>
@@ -23,6 +22,7 @@
 #include <tt-metalium/mesh_device.hpp>
 #include <tt-metalium/system_mesh.hpp>
 #include <tt-metalium/maybe_remote.hpp>
+#include "impl/context/metal_context.hpp"
 #include "tests/tt_metal/tt_metal/common/multi_device_fixture.hpp"
 #include "tests/tt_metal/test_utils/env_vars.hpp"
 #include <tt-metalium/tt_backend_api_types.hpp>
@@ -56,7 +56,7 @@ TEST_P(MeshConfigurationTest, MeshConfigurations) { EXPECT_EQ(mesh_device_->shap
 TEST_P(MeshConfigurationTest, GetMappedDevices) {
     const auto& shape = GetParam();
 
-    auto& system_mesh = SystemMesh::instance();
+    auto& system_mesh = MetalContext::instance().get_system_mesh();
     EXPECT_THAT(system_mesh.get_mapped_devices(shape).device_ids, SizeIs(shape.mesh_size()));
     EXPECT_THAT(system_mesh.get_mapped_devices(shape).fabric_node_ids, SizeIs(shape.mesh_size()));
 }
@@ -118,7 +118,7 @@ public:
 };
 
 TEST_F(MeshDevice1x8ReshapeTest, InvalidRequestedShape) {
-    auto& system_mesh = tt::tt_metal::distributed::SystemMesh::instance();
+    auto& system_mesh = tt::tt_metal::MetalContext::instance().get_system_mesh();
 
     // Shape too big.
     EXPECT_ANY_THROW(system_mesh.get_mapped_devices(MeshShape(9)));

--- a/tests/tt_metal/tt_fabric/common/test_fabric_edm_common.hpp
+++ b/tests/tt_metal/tt_fabric/common/test_fabric_edm_common.hpp
@@ -71,7 +71,7 @@ public:
     std::shared_ptr<MeshDevice> mesh_device_;
 
     // Gets the appropriate mesh shape based on device configuration
-    MeshShape GetDeterminedMeshShape() const { return SystemMesh::instance().shape(); }
+    MeshShape GetDeterminedMeshShape() const { return MetalContext::instance().get_system_mesh().shape(); }
 
     // Validates environment and hardware for tests
     void ValidateEnvironment() {

--- a/tests/tt_metal/tt_metal/api/distribution_spec/test_buffer_distribution_spec.cpp
+++ b/tests/tt_metal/tt_metal/api/distribution_spec/test_buffer_distribution_spec.cpp
@@ -31,7 +31,7 @@ protected:
             return;
         }
 
-        const auto system_mesh_shape = tt::tt_metal::distributed::SystemMesh::instance().shape();
+        const auto system_mesh_shape = tt::tt_metal::MetalContext::instance().get_system_mesh().shape();
         auto core_type = tt::tt_metal::DispatchCoreType::WORKER;
 
         mesh_device_ = tt::tt_metal::distributed::MeshDevice::create(

--- a/tests/tt_metal/tt_metal/common/multi_device_fixture.hpp
+++ b/tests/tt_metal/tt_metal/common/multi_device_fixture.hpp
@@ -127,7 +127,7 @@ protected:
                 *config_.arch);
         }
 
-        const auto system_mesh_shape = tt::tt_metal::distributed::SystemMesh::instance().shape();
+        const auto system_mesh_shape = tt::tt_metal::MetalContext::instance().get_system_mesh().shape();
         if (config_.mesh_shape.has_value() && config_.mesh_shape->mesh_size() > system_mesh_shape.mesh_size()) {
             GTEST_SKIP() << fmt::format(
                 "Skipping MeshDevice test suite on a machine with SystemMesh {} that is smaller than the requested "

--- a/tt_metal/api/tt-metalium/system_mesh.hpp
+++ b/tt_metal/api/tt-metalium/system_mesh.hpp
@@ -4,7 +4,6 @@
 
 #pragma once
 
-#include <tt_stl/indestructible.hpp>
 #include <memory>
 #include <optional>
 #include <vector>
@@ -12,6 +11,10 @@
 #include <tt-metalium/mesh_coord.hpp>
 #include <tt-metalium/maybe_remote.hpp>
 #include <tt-metalium/experimental/fabric/routing_table_generator.hpp>
+
+namespace tt::tt_fabric {
+class ControlPlane;
+}  // namespace tt::tt_fabric
 
 namespace tt::tt_metal::distributed {
 
@@ -23,11 +26,13 @@ private:
     class Impl;  // Forward declaration only
 
     std::unique_ptr<Impl> pimpl_;
-    SystemMesh();
-
-    friend class tt::stl::Indestructible<SystemMesh>;
 
 public:
+    explicit SystemMesh(const tt::tt_fabric::ControlPlane& control_plane);
+    ~SystemMesh();
+
+    // Convenience accessor — delegates to MetalContext::instance().get_system_mesh().
+    // Retained because MetalContext is not part of the public API.
     static SystemMesh& instance();
     SystemMesh(const SystemMesh&) = delete;
     SystemMesh& operator=(const SystemMesh&) = delete;

--- a/tt_metal/api/tt-metalium/system_mesh.hpp
+++ b/tt_metal/api/tt-metalium/system_mesh.hpp
@@ -16,6 +16,10 @@ namespace tt::tt_fabric {
 class ControlPlane;
 }  // namespace tt::tt_fabric
 
+namespace tt::tt_metal {
+class MetalContext;
+}  // namespace tt::tt_metal
+
 namespace tt::tt_metal::distributed {
 
 // SystemMesh creates a virtualization over the physical devices in the system.
@@ -23,14 +27,16 @@ namespace tt::tt_metal::distributed {
 // It serves as a query interface between the logical coordinates to physical device IDs.
 class SystemMesh {
 private:
+    friend class tt::tt_metal::MetalContext;
+
     class Impl;  // Forward declaration only
 
     std::unique_ptr<Impl> pimpl_;
 
-public:
     explicit SystemMesh(const tt::tt_fabric::ControlPlane& control_plane);
-    ~SystemMesh();
 
+public:
+    ~SystemMesh();
     // Convenience accessor — delegates to MetalContext::instance().get_system_mesh().
     // Retained because MetalContext is not part of the public API.
     static SystemMesh& instance();

--- a/tt_metal/distributed/system_mesh_translation_map.cpp
+++ b/tt_metal/distributed/system_mesh_translation_map.cpp
@@ -4,64 +4,56 @@
 
 #include "tt_metal/distributed/system_mesh_translation_map.hpp"
 
-#include <optional>
 #include <unordered_set>
-#include <utility>
 #include <vector>
 
 #include <tt_stl/assert.hpp>
 #include <tt-metalium/experimental/fabric/control_plane.hpp>
-#include <tt_stl/indestructible.hpp>
 #include <tt-logger/tt-logger.hpp>
 #include "mesh_coord.hpp"
-#include "impl/context/metal_context.hpp"
 #include <umd/device/types/cluster_descriptor_types.hpp>
 
 namespace tt::tt_metal::distributed {
 
-const MeshContainer<PhysicalMeshCoordinate>& get_system_mesh_coordinate_translation_map() {
-    static tt::stl::Indestructible<MeshContainer<PhysicalMeshCoordinate>> kTranslationMap([]() {
-        const auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
+MeshContainer<PhysicalMeshCoordinate> get_system_mesh_coordinate_translation_map(
+    const tt::tt_fabric::ControlPlane& control_plane) {
+    const auto mesh_ids = control_plane.get_user_physical_mesh_ids();
+    TT_FATAL(!mesh_ids.empty(), "There are no user physical meshes in the system found by control plane.");
 
-        const auto mesh_ids = control_plane.get_user_physical_mesh_ids();
-        TT_FATAL(!mesh_ids.empty(), "There are no user physical meshes in the system found by control plane.");
+    if (mesh_ids.size() > 1) {
+        log_warning(LogMetal, "Only one user physical mesh is supported, using the first one");
+    }
 
-        if (mesh_ids.size() > 1) {
-            log_warning(LogMetal, "Only one user physical mesh is supported, using the first one");
-        }
+    const auto mesh_id = mesh_ids.front();
+    const auto local_mesh_shape = control_plane.get_physical_mesh_shape(mesh_id, tt::tt_fabric::MeshScope::LOCAL);
+    const auto local_coord_range = control_plane.get_coord_range(mesh_id, tt::tt_fabric::MeshScope::LOCAL);
 
-        const auto mesh_id = mesh_ids.front();
-        const auto local_mesh_shape = control_plane.get_physical_mesh_shape(mesh_id, tt::tt_fabric::MeshScope::LOCAL);
-        const auto local_coord_range = control_plane.get_coord_range(mesh_id, tt::tt_fabric::MeshScope::LOCAL);
+    // Validate that the physical chip ids are unique.
+    std::unordered_set<ChipId> unique_chip_ids;
 
-        // Validate that the physical chip ids are unique.
-        std::unordered_set<ChipId> unique_chip_ids;
+    std::vector<PhysicalMeshCoordinate> physical_coordinates;
+    physical_coordinates.reserve(local_mesh_shape.mesh_size());
 
-        std::vector<PhysicalMeshCoordinate> physical_coordinates;
-        physical_coordinates.reserve(local_mesh_shape.mesh_size());
-
-        for (const auto& coord : local_coord_range) {
-            const auto logical_chip_id =
-                coord.to_linear_index(control_plane.get_physical_mesh_shape(mesh_id, tt::tt_fabric::MeshScope::GLOBAL));
-            // Query the control plane to get the physical chip id from logical chip id
-            const auto physical_chip_id = control_plane.get_physical_chip_id_from_fabric_node_id(
-                tt::tt_fabric::FabricNodeId(mesh_id, logical_chip_id));
-            TT_FATAL(
-                unique_chip_ids.insert(physical_chip_id).second,
-                "Found duplicate physical chip id: {}, mesh id: {}",
-                physical_chip_id,
-                mesh_id);
-            log_debug(LogDistributed, "Adding logical->physical coordinate: {}, {}", logical_chip_id, physical_chip_id);
-            physical_coordinates.push_back(PhysicalMeshCoordinate(mesh_id, /*chip_id=*/physical_chip_id));
-        }
-        log_debug(
-            LogDistributed,
-            "SystemMesh local shape: {}, physical coordinates count: {}",
-            local_mesh_shape,
-            physical_coordinates.size());
-        return MeshContainer<PhysicalMeshCoordinate>(local_mesh_shape, std::move(physical_coordinates));
-    }());
-    return kTranslationMap.get();
+    for (const auto& coord : local_coord_range) {
+        const auto logical_chip_id =
+            coord.to_linear_index(control_plane.get_physical_mesh_shape(mesh_id, tt::tt_fabric::MeshScope::GLOBAL));
+        // Query the control plane to get the physical chip id from logical chip id
+        const auto physical_chip_id = control_plane.get_physical_chip_id_from_fabric_node_id(
+            tt::tt_fabric::FabricNodeId(mesh_id, logical_chip_id));
+        TT_FATAL(
+            unique_chip_ids.insert(physical_chip_id).second,
+            "Found duplicate physical chip id: {}, mesh id: {}",
+            physical_chip_id,
+            mesh_id);
+        log_debug(LogDistributed, "Adding logical->physical coordinate: {}, {}", logical_chip_id, physical_chip_id);
+        physical_coordinates.push_back(PhysicalMeshCoordinate(mesh_id, /*chip_id=*/physical_chip_id));
+    }
+    log_debug(
+        LogDistributed,
+        "SystemMesh local shape: {}, physical coordinates count: {}",
+        local_mesh_shape,
+        physical_coordinates.size());
+    return MeshContainer<PhysicalMeshCoordinate>(local_mesh_shape, std::move(physical_coordinates));
 }
 
 }  // namespace tt::tt_metal::distributed

--- a/tt_metal/distributed/system_mesh_translation_map.hpp
+++ b/tt_metal/distributed/system_mesh_translation_map.hpp
@@ -9,6 +9,10 @@
 #include <stdint.h>
 #include <tuple>
 
+namespace tt::tt_fabric {
+class ControlPlane;
+}  // namespace tt::tt_fabric
+
 namespace tt::tt_metal::distributed {
 template <typename T>
 class MeshContainer;
@@ -37,6 +41,7 @@ private:
 };
 
 // Returns a map of all physical mesh coordinates in the system.
-const MeshContainer<PhysicalMeshCoordinate>& get_system_mesh_coordinate_translation_map();
+MeshContainer<PhysicalMeshCoordinate> get_system_mesh_coordinate_translation_map(
+    const tt::tt_fabric::ControlPlane& control_plane);
 
 }  // namespace tt::tt_metal::distributed

--- a/tt_metal/impl/context/metal_context.cpp
+++ b/tt_metal/impl/context/metal_context.cpp
@@ -44,6 +44,7 @@
 #include "device/device_manager.hpp"
 #include <distributed_context.hpp>
 #include <experimental/fabric/fabric.hpp>
+#include <system_mesh.hpp>
 
 #include <tt_metal.hpp>
 #include <umd/device/types/cluster_descriptor_types.hpp>
@@ -405,6 +406,7 @@ void MetalContext::teardown() {
     // Deinitialize inspector
     inspector_data_.reset();
 
+    system_mesh_.reset();
     control_plane_.reset();
 
     noc_debug_state_.reset();
@@ -537,6 +539,7 @@ void MetalContext::reinitialize_for_real_hardware() {
 
 void MetalContext::teardown_base_objects() {
     // Teardown in backward order of dependencies to avoid dereferencing uninitialized objects
+    system_mesh_.reset();
     control_plane_.reset();
     distributed_context_.reset();
     // Destroy inspector before cluster to prevent RPC handlers from accessing destroyed cluster
@@ -777,6 +780,17 @@ tt::tt_fabric::ControlPlane& MetalContext::get_control_plane() {
     return *control_plane_;
 }
 
+distributed::SystemMesh& MetalContext::get_system_mesh() {
+    std::lock_guard<std::mutex> lock(control_plane_mutex_);
+    if (!system_mesh_) {
+        if (!control_plane_) {
+            this->initialize_control_plane_impl();
+        }
+        system_mesh_ = std::make_unique<distributed::SystemMesh>(*control_plane_);
+    }
+    return *system_mesh_;
+}
+
 void MetalContext::set_custom_fabric_topology(
     const std::string& mesh_graph_desc_file,
     const std::map<tt_fabric::FabricNodeId, ChipId>& logical_mesh_chip_id_to_physical_chip_id_mapping) {
@@ -793,7 +807,8 @@ void MetalContext::set_default_fabric_topology() {
     TT_FATAL(
         !device_manager_->is_initialized() || device_manager_->get_all_active_devices().empty(),
         "Modifying control plane requires no devices to be active");
-    // Reset the control plane, since it was initialized with custom parameters.
+    // Reset the system mesh and control plane, since they were initialized with custom parameters.
+    system_mesh_.reset();
     control_plane_.reset();
     // Set the mesh graph descriptor file to the default value and clear the custom FabricNodeId to physical chip
     // mapping.
@@ -900,6 +915,7 @@ void MetalContext::set_fabric_config(
             "Fabric config changed from {} to {}, reinitializing control plane",
             this->get_control_plane().get_fabric_config(),
             this->fabric_config_);
+        system_mesh_.reset();
         this->initialize_control_plane_impl();
     }
 }

--- a/tt_metal/impl/context/metal_context.cpp
+++ b/tt_metal/impl/context/metal_context.cpp
@@ -786,7 +786,7 @@ distributed::SystemMesh& MetalContext::get_system_mesh() {
         if (!control_plane_) {
             this->initialize_control_plane_impl();
         }
-        system_mesh_ = std::make_unique<distributed::SystemMesh>(*control_plane_);
+        system_mesh_ = std::unique_ptr<distributed::SystemMesh>(new distributed::SystemMesh(*control_plane_));
     }
     return *system_mesh_;
 }

--- a/tt_metal/impl/context/metal_context.hpp
+++ b/tt_metal/impl/context/metal_context.hpp
@@ -16,6 +16,10 @@ namespace tt::tt_fabric {
 class ControlPlane;
 }  // namespace tt::tt_fabric
 
+namespace tt::tt_metal::distributed {
+class SystemMesh;
+}  // namespace tt::tt_metal::distributed
+
 namespace tt {
 class Cluster;
 }  // namespace tt
@@ -110,6 +114,9 @@ public:
     // Control plane accessors
     void initialize_control_plane();
     tt::tt_fabric::ControlPlane& get_control_plane();
+
+    // System mesh accessor — lazily initialized, reset when control plane is reset.
+    distributed::SystemMesh& get_system_mesh();
     void set_custom_fabric_topology(
         const std::string& mesh_graph_desc_file,
         const std::map<tt_fabric::FabricNodeId, ChipId>& logical_mesh_chip_id_to_physical_chip_id_mapping);
@@ -253,6 +260,7 @@ private:
 
     std::array<std::unique_ptr<DispatchMemMap>, static_cast<size_t>(CoreType::COUNT)> dispatch_mem_map_;
     std::unique_ptr<tt::tt_fabric::ControlPlane> control_plane_;
+    std::unique_ptr<distributed::SystemMesh> system_mesh_;
     tt_fabric::FabricConfig fabric_config_ = tt_fabric::FabricConfig::DISABLED;
     tt_fabric::FabricTensixConfig fabric_tensix_config_ = tt_fabric::FabricTensixConfig::DISABLED;
     tt_fabric::FabricUDMMode fabric_udm_mode_ = tt_fabric::FabricUDMMode::DISABLED;


### PR DESCRIPTION
### Ticket
N/A

### Problem description
SystemMesh was a global singleton (Indestructible<SystemMesh>) that could not be reset when ControlPlane was reconstructed, leading to stale state after topology changes. Move ownership to MetalContext so SystemMesh is invalidated whenever ControlPlane is reset.

### What's changed
- Make SystemMesh accept ControlPlane& in constructor instead of fetching it internally from MetalContext
- Convert get_system_mesh_coordinate_translation_map() from a cached singleton to a parameterized function accepting ControlPlane&
- Add get_system_mesh() accessor to MetalContext with lazy initialization protected by control_plane_mutex_
- Reset system_mesh_ before control_plane_ at all 4 reset sites (teardown, teardown_base_objects, set_default_fabric_topology, set_fabric_config)
- Keep SystemMesh::instance() as a public convenience that delegates to MetalContext for code outside the metal library (ttnn bindings, etc.)
- Update call sites in mesh_device.cpp and tests to use MetalContext::instance().get_system_mesh() where MetalContext is accessible

### Checklist

- [x] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=jchu/system-mesh)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:jchu/system-mesh)
https://github.com/tenstorrent/tt-metal/actions/runs/22330635075
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=jchu/system-mesh)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:jchu/system-mesh)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=jchu/system-mesh)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jchu/system-mesh)
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=jchu/system-mesh)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:jchu/system-mesh)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=jchu/system-mesh)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:jchu/system-mesh)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=jchu/system-mesh)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:jchu/system-mesh)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs