### PR TITLE
Increase stable diffusion demo test timeout to 600s

### DIFF
--- a/tests/scripts/single_card/run_single_card_demo_tests.sh
+++ b/tests/scripts/single_card/run_single_card_demo_tests.sh
@@ -228,7 +228,7 @@ run_efficientnet_b0_func(){
 
 run_stable_diffusion_func() {
 
-  $PYTEST_CMD --input-path="models/demos/vision/generative/stable_diffusion/wormhole/demo/input_data.json" models/demos/vision/generative/stable_diffusion/wormhole/demo/demo.py::test_demo
+  $PYTEST_CMD --timeout 600 --input-path="models/demos/vision/generative/stable_diffusion/wormhole/demo/input_data.json" models/demos/vision/generative/stable_diffusion/wormhole/demo/demo.py::test_demo
 
 }
 


### PR DESCRIPTION
The stable_diffusion-N150-func CI job was failing due to the default 300s pytest timeout being insufficient for 10 prompts x 50 inference steps at 512x512 resolution. Align with the 600s timeout already used by related stable diffusion tests and other long-running demo tests.

(Single-card) Demo tests
https://github.com/tenstorrent/tt-metal/actions/runs/22219047289