### PR TITLE
Added DeepSeek quad cache generation CI pipeline

### DIFF
--- a/.github/workflows/multi-host-deepseekv3.yaml
+++ b/.github/workflows/multi-host-deepseekv3.yaml
@@ -93,6 +93,7 @@ jobs:
             -e TT_METAL_HOME=${{ github.workspace }}
             -e ARCH_NAME=wormhole_b0
             -e TT_METAL_ENABLE_ERISC_IRAM="1"
+            -e GITHUB_RUN_ID=${{ github.run_id }}
             -e _DEEPSEEK_V3_CACHE_DIR=${{ inputs.cache-dir }}
             -e _DEEPSEEK_V3_OVERRIDE_NUM_LAYERS=${{ inputs.override-num-layers }}
             -v /etc/mpirun:/etc/mpirun:ro

--- a/.github/workflows/multi-host-deepseekv3.yaml
+++ b/.github/workflows/multi-host-deepseekv3.yaml
@@ -1,41 +1,19 @@
-name: DeepSeek V3 Multi-Host Tests
+name: DeepSeek V3 Multi-Host Cache Generation
 on:
+  # schedule:
+    # - cron: '0 13 * * 6'  # Every Saturday at 13:00 UTC
   workflow_dispatch:
     inputs:
-      setup:
-        description: 'Galaxy setup to test'
+      cache-dir:
+        description: 'Destination cache directory'
         required: true
-        type: choice
-        default: both
-        options:
-          - dual
-          - quad
-          - both
-      deepseekv3_unit_tests:
-        description: 'Run DeepSeek V3 unit tests'
+        type: string
+        default: '/mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528-Cache/CI'
+      override-num-layers:
+        description: 'Optional: override the number of layers in the model'
         required: false
-        default: false
-        type: boolean
-      deepseekv3_module_tests:
-        description: 'Run DeepSeek V3 module tests'
-        required: false
-        default: false
-        type: boolean
-      teacher_forced:
-        description: 'Run teacher forced accuracy test'
-        required: false
-        default: false
-        type: boolean
-      demo:
-        description: 'Run demo test'
-        required: false
-        default: false
-        type: boolean
-      demo_stress:
-        description: 'Run demo stress test'
-        required: false
-        default: false
-        type: boolean
+        type: string
+        default: ''
       platform:
         required: false
         type: choice
@@ -61,7 +39,7 @@ on:
         default: false
         description: "Enable Link Time Optimization (LTO)"
 
-run-name: "DeepSeek V3 – ${{ inputs.setup }} [${{ inputs.deepseekv3_unit_tests && 'unit ' || '' }}${{ inputs.deepseekv3_module_tests && 'module ' || '' }}${{ inputs.teacher_forced && 'tf ' || '' }}${{ inputs.demo && 'demo ' || '' }}${{ inputs.demo_stress && 'stress' || '' }}]"
+run-name: "DeepSeek V3 Cache Generation - quad"
 
 jobs:
   build-artifact:
@@ -75,8 +53,7 @@ jobs:
       enable-lto: ${{ inputs.enable-lto || false }}
       build-wheel: true
 
-  deepseekv3-tests:
-    if: ${{ inputs.deepseekv3_unit_tests || inputs.deepseekv3_module_tests || inputs.teacher_forced || inputs.demo || inputs.demo_stress }}
+  deepseek-cache-generation:
     runs-on:
       - multi-host-glx-4x
       - arch-wormhole_b0
@@ -104,11 +81,9 @@ jobs:
         id: capture-home
         run: echo "home=${HOME}" >> $GITHUB_OUTPUT
 
-      # ── DeepSeek V3 unit tests ──────────────────────────────────────────
-      - name: Run dual DeepSeek V3 unit tests
-        if: ${{ inputs.deepseekv3_unit_tests && (inputs.setup == 'dual' || inputs.setup == 'both') }}
+      - name: Generate quad DeepSeek V3 TT-NN cache
         uses: ./.github/actions/docker-run
-        timeout-minutes: 60
+        timeout-minutes: 480
         with:
           docker_image: ${{ needs.build-artifact.outputs.dev-docker-image }}
           docker_password: ${{ secrets.GITHUB_TOKEN }}
@@ -118,7 +93,8 @@ jobs:
             -e TT_METAL_HOME=${{ github.workspace }}
             -e ARCH_NAME=wormhole_b0
             -e TT_METAL_ENABLE_ERISC_IRAM="1"
-            -e GTEST_OUTPUT="xml:${{ github.workspace }}/generated/test_reports/"
+            -e _DEEPSEEK_V3_CACHE_DIR=${{ inputs.cache-dir }}
+            -e _DEEPSEEK_V3_OVERRIDE_NUM_LAYERS=${{ inputs.override-num-layers }}
             -v /etc/mpirun:/etc/mpirun:ro
             -v ${{ steps.capture-home.outputs.home }}/.ssh:${{ steps.capture-home.outputs.home }}/.ssh:ro
             --device /dev/tenstorrent
@@ -126,285 +102,5 @@ jobs:
             --hostname=mpirun-host
           install_wheel: true
           run_args: |
-            eval "$(./tests/scripts/multihost/setup_shared_venv.sh --activate)"
-            ./tests/scripts/multihost/run_quad_galaxy_tests.sh dual_deepseekv3_unit_tests
-
-      - name: Run quad DeepSeek V3 unit tests
-        if: ${{ inputs.deepseekv3_unit_tests && (inputs.setup == 'quad' || inputs.setup == 'both') }}
-        uses: ./.github/actions/docker-run
-        timeout-minutes: 60
-        with:
-          docker_image: ${{ needs.build-artifact.outputs.dev-docker-image }}
-          docker_password: ${{ secrets.GITHUB_TOKEN }}
-          docker_opts: |
-            -e LD_LIBRARY_PATH=${{ github.workspace }}/build/lib
-            -e PYTHONPATH=${{ github.workspace }}
-            -e TT_METAL_HOME=${{ github.workspace }}
-            -e ARCH_NAME=wormhole_b0
-            -e TT_METAL_ENABLE_ERISC_IRAM="1"
-            -e GTEST_OUTPUT="xml:${{ github.workspace }}/generated/test_reports/"
-            -v /etc/mpirun:/etc/mpirun:ro
-            -v ${{ steps.capture-home.outputs.home }}/.ssh:${{ steps.capture-home.outputs.home }}/.ssh:ro
-            --device /dev/tenstorrent
-            --pid=host
-            --hostname=mpirun-host
-          install_wheel: true
-          run_args: |
-            eval "$(./tests/scripts/multihost/setup_shared_venv.sh --activate)"
-            ./tests/scripts/multihost/run_quad_galaxy_tests.sh quad_deepseekv3_unit_tests
-
-      # ── DeepSeek V3 module tests ────────────────────────────────────────
-      - name: Run dual DeepSeek V3 module tests
-        if: ${{ inputs.deepseekv3_module_tests && (inputs.setup == 'dual' || inputs.setup == 'both') }}
-        uses: ./.github/actions/docker-run
-        timeout-minutes: 150
-        with:
-          docker_image: ${{ needs.build-artifact.outputs.dev-docker-image }}
-          docker_password: ${{ secrets.GITHUB_TOKEN }}
-          docker_opts: |
-            -e LD_LIBRARY_PATH=${{ github.workspace }}/build/lib
-            -e PYTHONPATH=${{ github.workspace }}
-            -e TT_METAL_HOME=${{ github.workspace }}
-            -e ARCH_NAME=wormhole_b0
-            -e TT_METAL_ENABLE_ERISC_IRAM="1"
-            -e GTEST_OUTPUT="xml:${{ github.workspace }}/generated/test_reports/"
-            -v /etc/mpirun:/etc/mpirun:ro
-            -v ${{ steps.capture-home.outputs.home }}/.ssh:${{ steps.capture-home.outputs.home }}/.ssh:ro
-            --device /dev/tenstorrent
-            --pid=host
-            --hostname=mpirun-host
-          install_wheel: true
-          run_args: |
-            eval "$(./tests/scripts/multihost/setup_shared_venv.sh --activate)"
-            ./tests/scripts/multihost/run_quad_galaxy_tests.sh dual_deepseekv3_module_tests
-
-      - name: Run quad DeepSeek V3 module tests
-        if: ${{ inputs.deepseekv3_module_tests && (inputs.setup == 'quad' || inputs.setup == 'both') }}
-        uses: ./.github/actions/docker-run
-        timeout-minutes: 150
-        with:
-          docker_image: ${{ needs.build-artifact.outputs.dev-docker-image }}
-          docker_password: ${{ secrets.GITHUB_TOKEN }}
-          docker_opts: |
-            -e LD_LIBRARY_PATH=${{ github.workspace }}/build/lib
-            -e PYTHONPATH=${{ github.workspace }}
-            -e TT_METAL_HOME=${{ github.workspace }}
-            -e ARCH_NAME=wormhole_b0
-            -e TT_METAL_ENABLE_ERISC_IRAM="1"
-            -e GTEST_OUTPUT="xml:${{ github.workspace }}/generated/test_reports/"
-            -v /etc/mpirun:/etc/mpirun:ro
-            -v ${{ steps.capture-home.outputs.home }}/.ssh:${{ steps.capture-home.outputs.home }}/.ssh:ro
-            --device /dev/tenstorrent
-            --pid=host
-            --hostname=mpirun-host
-          install_wheel: true
-          run_args: |
-            eval "$(./tests/scripts/multihost/setup_shared_venv.sh --activate)"
-            ./tests/scripts/multihost/run_quad_galaxy_tests.sh quad_deepseekv3_module_tests
-
-      # ── Teacher forced accuracy tests ───────────────────────────────────
-      - name: Run dual teacher forced accuracy test
-        if: ${{ inputs.teacher_forced && (inputs.setup == 'dual' || inputs.setup == 'both') }}
-        uses: ./.github/actions/docker-run
-        timeout-minutes: 60
-        with:
-          docker_image: ${{ needs.build-artifact.outputs.dev-docker-image }}
-          docker_password: ${{ secrets.GITHUB_TOKEN }}
-          docker_opts: |
-            -e LD_LIBRARY_PATH=${{ github.workspace }}/build/lib
-            -e PYTHONPATH=${{ github.workspace }}
-            -e TT_METAL_HOME=${{ github.workspace }}
-            -e ARCH_NAME=wormhole_b0
-            -e TT_METAL_ENABLE_ERISC_IRAM="1"
-            -e GTEST_OUTPUT="xml:${{ github.workspace }}/generated/test_reports/"
-            -v /etc/mpirun:/etc/mpirun:ro
-            -v ${{ steps.capture-home.outputs.home }}/.ssh:${{ steps.capture-home.outputs.home }}/.ssh:ro
-            --device /dev/tenstorrent
-            --pid=host
-            --hostname=mpirun-host
-          install_wheel: true
-          run_args: |
-            eval "$(./tests/scripts/multihost/setup_shared_venv.sh --activate)"
-            ./tests/scripts/multihost/run_quad_galaxy_tests.sh dual_teacher_forced
-
-      - name: Upload dual teacher forced accuracy artifacts
-        if: ${{ always() && inputs.teacher_forced && (inputs.setup == 'dual' || inputs.setup == 'both') }}
-        uses: actions/upload-artifact@v4
-        with:
-          name: dual-teacher-forced-accuracy-${{ github.run_id }}
-          path: |
-            generated/artifacts/dual_teacher_forced_accuracy.txt
-            generated/artifacts/dual_teacher_forced_output.log
-          if-no-files-found: warn
-
-      - name: Run quad teacher forced accuracy test
-        if: ${{ inputs.teacher_forced && (inputs.setup == 'quad' || inputs.setup == 'both') }}
-        uses: ./.github/actions/docker-run
-        timeout-minutes: 60
-        with:
-          docker_image: ${{ needs.build-artifact.outputs.dev-docker-image }}
-          docker_password: ${{ secrets.GITHUB_TOKEN }}
-          docker_opts: |
-            -e LD_LIBRARY_PATH=${{ github.workspace }}/build/lib
-            -e PYTHONPATH=${{ github.workspace }}
-            -e TT_METAL_HOME=${{ github.workspace }}
-            -e ARCH_NAME=wormhole_b0
-            -e TT_METAL_ENABLE_ERISC_IRAM="1"
-            -e GTEST_OUTPUT="xml:${{ github.workspace }}/generated/test_reports/"
-            -v /etc/mpirun:/etc/mpirun:ro
-            -v ${{ steps.capture-home.outputs.home }}/.ssh:${{ steps.capture-home.outputs.home }}/.ssh:ro
-            --device /dev/tenstorrent
-            --pid=host
-            --hostname=mpirun-host
-          install_wheel: true
-          run_args: |
-            eval "$(./tests/scripts/multihost/setup_shared_venv.sh --activate)"
-            ./tests/scripts/multihost/run_quad_galaxy_tests.sh quad_teacher_forced
-
-      - name: Upload quad teacher forced accuracy artifacts
-        if: ${{ always() && inputs.teacher_forced && (inputs.setup == 'quad' || inputs.setup == 'both') }}
-        uses: actions/upload-artifact@v4
-        with:
-          name: quad-teacher-forced-accuracy-${{ github.run_id }}
-          path: |
-            generated/artifacts/quad_teacher_forced_accuracy.txt
-            generated/artifacts/quad_teacher_forced_output.log
-          if-no-files-found: warn
-
-      # ── Demo tests ──────────────────────────────────────────────────────
-      - name: Run dual demo test (256 prompts, 1 batch)
-        if: ${{ inputs.demo && (inputs.setup == 'dual' || inputs.setup == 'both') }}
-        uses: ./.github/actions/docker-run
-        timeout-minutes: 40
-        with:
-          docker_image: ${{ needs.build-artifact.outputs.dev-docker-image }}
-          docker_password: ${{ secrets.GITHUB_TOKEN }}
-          docker_opts: |
-            -e LD_LIBRARY_PATH=${{ github.workspace }}/build/lib
-            -e PYTHONPATH=${{ github.workspace }}
-            -e TT_METAL_HOME=${{ github.workspace }}
-            -e ARCH_NAME=wormhole_b0
-            -e TT_METAL_ENABLE_ERISC_IRAM="1"
-            -e GTEST_OUTPUT="xml:${{ github.workspace }}/generated/test_reports/"
-            -v /etc/mpirun:/etc/mpirun:ro
-            -v ${{ steps.capture-home.outputs.home }}/.ssh:${{ steps.capture-home.outputs.home }}/.ssh:ro
-            --device /dev/tenstorrent
-            --pid=host
-            --hostname=mpirun-host
-          install_wheel: true
-          run_args: |
-            eval "$(./tests/scripts/multihost/setup_shared_venv.sh --activate)"
-            ./tests/scripts/multihost/run_quad_galaxy_tests.sh dual_demo
-
-      - name: Upload dual demo output artifacts
-        if: ${{ always() && inputs.demo && (inputs.setup == 'dual' || inputs.setup == 'both') }}
-        uses: actions/upload-artifact@v4
-        with:
-          name: dual-demo-output-${{ github.run_id }}
-          path: |
-            generated/artifacts/dual_demo_output.log
-            generated/artifacts/dual_demo_full_results.json
-          if-no-files-found: warn
-
-      - name: Run quad demo test (512 prompts, 1 batch)
-        if: ${{ inputs.demo && (inputs.setup == 'quad' || inputs.setup == 'both') }}
-        uses: ./.github/actions/docker-run
-        timeout-minutes: 60
-        with:
-          docker_image: ${{ needs.build-artifact.outputs.dev-docker-image }}
-          docker_password: ${{ secrets.GITHUB_TOKEN }}
-          docker_opts: |
-            -e LD_LIBRARY_PATH=${{ github.workspace }}/build/lib
-            -e PYTHONPATH=${{ github.workspace }}
-            -e TT_METAL_HOME=${{ github.workspace }}
-            -e ARCH_NAME=wormhole_b0
-            -e TT_METAL_ENABLE_ERISC_IRAM="1"
-            -e GTEST_OUTPUT="xml:${{ github.workspace }}/generated/test_reports/"
-            -v /etc/mpirun:/etc/mpirun:ro
-            -v ${{ steps.capture-home.outputs.home }}/.ssh:${{ steps.capture-home.outputs.home }}/.ssh:ro
-            --device /dev/tenstorrent
-            --pid=host
-            --hostname=mpirun-host
-          install_wheel: true
-          run_args: |
-            eval "$(./tests/scripts/multihost/setup_shared_venv.sh --activate)"
-            ./tests/scripts/multihost/run_quad_galaxy_tests.sh quad_demo
-
-      - name: Upload quad demo output artifacts
-        if: ${{ always() && inputs.demo && (inputs.setup == 'quad' || inputs.setup == 'both') }}
-        uses: actions/upload-artifact@v4
-        with:
-          name: quad-demo-output-${{ github.run_id }}
-          path: |
-            generated/artifacts/quad_demo_output.log
-            generated/artifacts/quad_demo_full_results.json
-          if-no-files-found: warn
-
-      # ── Demo stress tests ───────────────────────────────────────────────
-      - name: Run dual demo stress test (56 prompts, 20 batches)
-        if: ${{ inputs.demo_stress && (inputs.setup == 'dual' || inputs.setup == 'both') }}
-        uses: ./.github/actions/docker-run
-        timeout-minutes: 90
-        with:
-          docker_image: ${{ needs.build-artifact.outputs.dev-docker-image }}
-          docker_password: ${{ secrets.GITHUB_TOKEN }}
-          docker_opts: |
-            -e LD_LIBRARY_PATH=${{ github.workspace }}/build/lib
-            -e PYTHONPATH=${{ github.workspace }}
-            -e TT_METAL_HOME=${{ github.workspace }}
-            -e ARCH_NAME=wormhole_b0
-            -e TT_METAL_ENABLE_ERISC_IRAM="1"
-            -e GTEST_OUTPUT="xml:${{ github.workspace }}/generated/test_reports/"
-            -v /etc/mpirun:/etc/mpirun:ro
-            -v ${{ steps.capture-home.outputs.home }}/.ssh:${{ steps.capture-home.outputs.home }}/.ssh:ro
-            --device /dev/tenstorrent
-            --pid=host
-            --hostname=mpirun-host
-          install_wheel: true
-          run_args: |
-            eval "$(./tests/scripts/multihost/setup_shared_venv.sh --activate)"
-            ./tests/scripts/multihost/run_quad_galaxy_tests.sh dual_demo_stress
-
-      - name: Upload dual demo stress output artifacts
-        if: ${{ always() && inputs.demo_stress && (inputs.setup == 'dual' || inputs.setup == 'both') }}
-        uses: actions/upload-artifact@v4
-        with:
-          name: dual-demo-stress-output-${{ github.run_id }}
-          path: |
-            generated/artifacts/dual_demo_stress_output.log
-            generated/artifacts/dual_demo_stress_results.json
-          if-no-files-found: warn
-
-      - name: Run quad demo stress test (56 prompts, 20 batches)
-        if: ${{ inputs.demo_stress && (inputs.setup == 'quad' || inputs.setup == 'both') }}
-        uses: ./.github/actions/docker-run
-        timeout-minutes: 90
-        with:
-          docker_image: ${{ needs.build-artifact.outputs.dev-docker-image }}
-          docker_password: ${{ secrets.GITHUB_TOKEN }}
-          docker_opts: |
-            -e LD_LIBRARY_PATH=${{ github.workspace }}/build/lib
-            -e PYTHONPATH=${{ github.workspace }}
-            -e TT_METAL_HOME=${{ github.workspace }}
-            -e ARCH_NAME=wormhole_b0
-            -e TT_METAL_ENABLE_ERISC_IRAM="1"
-            -e GTEST_OUTPUT="xml:${{ github.workspace }}/generated/test_reports/"
-            -v /etc/mpirun:/etc/mpirun:ro
-            -v ${{ steps.capture-home.outputs.home }}/.ssh:${{ steps.capture-home.outputs.home }}/.ssh:ro
-            --device /dev/tenstorrent
-            --pid=host
-            --hostname=mpirun-host
-          install_wheel: true
-          run_args: |
-            eval "$(./tests/scripts/multihost/setup_shared_venv.sh --activate)"
-            ./tests/scripts/multihost/run_quad_galaxy_tests.sh quad_demo_stress
-
-      - name: Upload quad demo stress output artifacts
-        if: ${{ always() && inputs.demo_stress && (inputs.setup == 'quad' || inputs.setup == 'both') }}
-        uses: actions/upload-artifact@v4
-        with:
-          name: quad-demo-stress-output-${{ github.run_id }}
-          path: |
-            generated/artifacts/quad_demo_stress_output.log
-            generated/artifacts/quad_demo_stress_results.json
-          if-no-files-found: warn
+            ./tests/scripts/multihost/setup_shared_venv.sh
+            ./tests/scripts/multihost/run_quad_galaxy_tests.sh quad_cache_gen

--- a/.github/workflows/multi-host-deepseekv3.yaml
+++ b/.github/workflows/multi-host-deepseekv3.yaml
@@ -1,19 +1,41 @@
-name: DeepSeek V3 Multi-Host Cache Generation
+name: DeepSeek V3 Multi-Host Tests
 on:
-  # schedule:
-    # - cron: '0 13 * * 6'  # Every Saturday at 13:00 UTC
   workflow_dispatch:
     inputs:
-      cache-dir:
-        description: 'Destination cache directory'
+      setup:
+        description: 'Galaxy setup to test'
         required: true
-        type: string
-        default: '/mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528-Cache/CI'
-      override-num-layers:
-        description: 'Optional: override the number of layers in the model'
+        type: choice
+        default: both
+        options:
+          - dual
+          - quad
+          - both
+      deepseekv3_unit_tests:
+        description: 'Run DeepSeek V3 unit tests'
         required: false
-        type: string
-        default: ''
+        default: false
+        type: boolean
+      deepseekv3_module_tests:
+        description: 'Run DeepSeek V3 module tests'
+        required: false
+        default: false
+        type: boolean
+      teacher_forced:
+        description: 'Run teacher forced accuracy test'
+        required: false
+        default: false
+        type: boolean
+      demo:
+        description: 'Run demo test'
+        required: false
+        default: false
+        type: boolean
+      demo_stress:
+        description: 'Run demo stress test'
+        required: false
+        default: false
+        type: boolean
       platform:
         required: false
         type: choice
@@ -39,7 +61,7 @@ on:
         default: false
         description: "Enable Link Time Optimization (LTO)"
 
-run-name: "DeepSeek V3 Cache Generation - quad"
+run-name: "DeepSeek V3 – ${{ inputs.setup }} [${{ inputs.deepseekv3_unit_tests && 'unit ' || '' }}${{ inputs.deepseekv3_module_tests && 'module ' || '' }}${{ inputs.teacher_forced && 'tf ' || '' }}${{ inputs.demo && 'demo ' || '' }}${{ inputs.demo_stress && 'stress' || '' }}]"
 
 jobs:
   build-artifact:
@@ -53,7 +75,8 @@ jobs:
       enable-lto: ${{ inputs.enable-lto || false }}
       build-wheel: true
 
-  deepseek-cache-generation:
+  deepseekv3-tests:
+    if: ${{ inputs.deepseekv3_unit_tests || inputs.deepseekv3_module_tests || inputs.teacher_forced || inputs.demo || inputs.demo_stress }}
     runs-on:
       - multi-host-glx-4x
       - arch-wormhole_b0
@@ -81,9 +104,11 @@ jobs:
         id: capture-home
         run: echo "home=${HOME}" >> $GITHUB_OUTPUT
 
-      - name: Generate quad DeepSeek V3 TT-NN cache
+      # ── DeepSeek V3 unit tests ──────────────────────────────────────────
+      - name: Run dual DeepSeek V3 unit tests
+        if: ${{ inputs.deepseekv3_unit_tests && (inputs.setup == 'dual' || inputs.setup == 'both') }}
         uses: ./.github/actions/docker-run
-        timeout-minutes: 480
+        timeout-minutes: 60
         with:
           docker_image: ${{ needs.build-artifact.outputs.dev-docker-image }}
           docker_password: ${{ secrets.GITHUB_TOKEN }}
@@ -93,9 +118,7 @@ jobs:
             -e TT_METAL_HOME=${{ github.workspace }}
             -e ARCH_NAME=wormhole_b0
             -e TT_METAL_ENABLE_ERISC_IRAM="1"
-            -e GITHUB_RUN_ID=${{ github.run_id }}
-            -e _DEEPSEEK_V3_CACHE_DIR=${{ inputs.cache-dir }}
-            -e _DEEPSEEK_V3_OVERRIDE_NUM_LAYERS=${{ inputs.override-num-layers }}
+            -e GTEST_OUTPUT="xml:${{ github.workspace }}/generated/test_reports/"
             -v /etc/mpirun:/etc/mpirun:ro
             -v ${{ steps.capture-home.outputs.home }}/.ssh:${{ steps.capture-home.outputs.home }}/.ssh:ro
             --device /dev/tenstorrent
@@ -103,5 +126,285 @@ jobs:
             --hostname=mpirun-host
           install_wheel: true
           run_args: |
-            ./tests/scripts/multihost/setup_shared_venv.sh
-            ./tests/scripts/multihost/run_quad_galaxy_tests.sh quad_cache_gen
+            eval "$(./tests/scripts/multihost/setup_shared_venv.sh --activate)"
+            ./tests/scripts/multihost/run_quad_galaxy_tests.sh dual_deepseekv3_unit_tests
+
+      - name: Run quad DeepSeek V3 unit tests
+        if: ${{ inputs.deepseekv3_unit_tests && (inputs.setup == 'quad' || inputs.setup == 'both') }}
+        uses: ./.github/actions/docker-run
+        timeout-minutes: 60
+        with:
+          docker_image: ${{ needs.build-artifact.outputs.dev-docker-image }}
+          docker_password: ${{ secrets.GITHUB_TOKEN }}
+          docker_opts: |
+            -e LD_LIBRARY_PATH=${{ github.workspace }}/build/lib
+            -e PYTHONPATH=${{ github.workspace }}
+            -e TT_METAL_HOME=${{ github.workspace }}
+            -e ARCH_NAME=wormhole_b0
+            -e TT_METAL_ENABLE_ERISC_IRAM="1"
+            -e GTEST_OUTPUT="xml:${{ github.workspace }}/generated/test_reports/"
+            -v /etc/mpirun:/etc/mpirun:ro
+            -v ${{ steps.capture-home.outputs.home }}/.ssh:${{ steps.capture-home.outputs.home }}/.ssh:ro
+            --device /dev/tenstorrent
+            --pid=host
+            --hostname=mpirun-host
+          install_wheel: true
+          run_args: |
+            eval "$(./tests/scripts/multihost/setup_shared_venv.sh --activate)"
+            ./tests/scripts/multihost/run_quad_galaxy_tests.sh quad_deepseekv3_unit_tests
+
+      # ── DeepSeek V3 module tests ────────────────────────────────────────
+      - name: Run dual DeepSeek V3 module tests
+        if: ${{ inputs.deepseekv3_module_tests && (inputs.setup == 'dual' || inputs.setup == 'both') }}
+        uses: ./.github/actions/docker-run
+        timeout-minutes: 150
+        with:
+          docker_image: ${{ needs.build-artifact.outputs.dev-docker-image }}
+          docker_password: ${{ secrets.GITHUB_TOKEN }}
+          docker_opts: |
+            -e LD_LIBRARY_PATH=${{ github.workspace }}/build/lib
+            -e PYTHONPATH=${{ github.workspace }}
+            -e TT_METAL_HOME=${{ github.workspace }}
+            -e ARCH_NAME=wormhole_b0
+            -e TT_METAL_ENABLE_ERISC_IRAM="1"
+            -e GTEST_OUTPUT="xml:${{ github.workspace }}/generated/test_reports/"
+            -v /etc/mpirun:/etc/mpirun:ro
+            -v ${{ steps.capture-home.outputs.home }}/.ssh:${{ steps.capture-home.outputs.home }}/.ssh:ro
+            --device /dev/tenstorrent
+            --pid=host
+            --hostname=mpirun-host
+          install_wheel: true
+          run_args: |
+            eval "$(./tests/scripts/multihost/setup_shared_venv.sh --activate)"
+            ./tests/scripts/multihost/run_quad_galaxy_tests.sh dual_deepseekv3_module_tests
+
+      - name: Run quad DeepSeek V3 module tests
+        if: ${{ inputs.deepseekv3_module_tests && (inputs.setup == 'quad' || inputs.setup == 'both') }}
+        uses: ./.github/actions/docker-run
+        timeout-minutes: 150
+        with:
+          docker_image: ${{ needs.build-artifact.outputs.dev-docker-image }}
+          docker_password: ${{ secrets.GITHUB_TOKEN }}
+          docker_opts: |
+            -e LD_LIBRARY_PATH=${{ github.workspace }}/build/lib
+            -e PYTHONPATH=${{ github.workspace }}
+            -e TT_METAL_HOME=${{ github.workspace }}
+            -e ARCH_NAME=wormhole_b0
+            -e TT_METAL_ENABLE_ERISC_IRAM="1"
+            -e GTEST_OUTPUT="xml:${{ github.workspace }}/generated/test_reports/"
+            -v /etc/mpirun:/etc/mpirun:ro
+            -v ${{ steps.capture-home.outputs.home }}/.ssh:${{ steps.capture-home.outputs.home }}/.ssh:ro
+            --device /dev/tenstorrent
+            --pid=host
+            --hostname=mpirun-host
+          install_wheel: true
+          run_args: |
+            eval "$(./tests/scripts/multihost/setup_shared_venv.sh --activate)"
+            ./tests/scripts/multihost/run_quad_galaxy_tests.sh quad_deepseekv3_module_tests
+
+      # ── Teacher forced accuracy tests ───────────────────────────────────
+      - name: Run dual teacher forced accuracy test
+        if: ${{ inputs.teacher_forced && (inputs.setup == 'dual' || inputs.setup == 'both') }}
+        uses: ./.github/actions/docker-run
+        timeout-minutes: 60
+        with:
+          docker_image: ${{ needs.build-artifact.outputs.dev-docker-image }}
+          docker_password: ${{ secrets.GITHUB_TOKEN }}
+          docker_opts: |
+            -e LD_LIBRARY_PATH=${{ github.workspace }}/build/lib
+            -e PYTHONPATH=${{ github.workspace }}
+            -e TT_METAL_HOME=${{ github.workspace }}
+            -e ARCH_NAME=wormhole_b0
+            -e TT_METAL_ENABLE_ERISC_IRAM="1"
+            -e GTEST_OUTPUT="xml:${{ github.workspace }}/generated/test_reports/"
+            -v /etc/mpirun:/etc/mpirun:ro
+            -v ${{ steps.capture-home.outputs.home }}/.ssh:${{ steps.capture-home.outputs.home }}/.ssh:ro
+            --device /dev/tenstorrent
+            --pid=host
+            --hostname=mpirun-host
+          install_wheel: true
+          run_args: |
+            eval "$(./tests/scripts/multihost/setup_shared_venv.sh --activate)"
+            ./tests/scripts/multihost/run_quad_galaxy_tests.sh dual_teacher_forced
+
+      - name: Upload dual teacher forced accuracy artifacts
+        if: ${{ always() && inputs.teacher_forced && (inputs.setup == 'dual' || inputs.setup == 'both') }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: dual-teacher-forced-accuracy-${{ github.run_id }}
+          path: |
+            generated/artifacts/dual_teacher_forced_accuracy.txt
+            generated/artifacts/dual_teacher_forced_output.log
+          if-no-files-found: warn
+
+      - name: Run quad teacher forced accuracy test
+        if: ${{ inputs.teacher_forced && (inputs.setup == 'quad' || inputs.setup == 'both') }}
+        uses: ./.github/actions/docker-run
+        timeout-minutes: 60
+        with:
+          docker_image: ${{ needs.build-artifact.outputs.dev-docker-image }}
+          docker_password: ${{ secrets.GITHUB_TOKEN }}
+          docker_opts: |
+            -e LD_LIBRARY_PATH=${{ github.workspace }}/build/lib
+            -e PYTHONPATH=${{ github.workspace }}
+            -e TT_METAL_HOME=${{ github.workspace }}
+            -e ARCH_NAME=wormhole_b0
+            -e TT_METAL_ENABLE_ERISC_IRAM="1"
+            -e GTEST_OUTPUT="xml:${{ github.workspace }}/generated/test_reports/"
+            -v /etc/mpirun:/etc/mpirun:ro
+            -v ${{ steps.capture-home.outputs.home }}/.ssh:${{ steps.capture-home.outputs.home }}/.ssh:ro
+            --device /dev/tenstorrent
+            --pid=host
+            --hostname=mpirun-host
+          install_wheel: true
+          run_args: |
+            eval "$(./tests/scripts/multihost/setup_shared_venv.sh --activate)"
+            ./tests/scripts/multihost/run_quad_galaxy_tests.sh quad_teacher_forced
+
+      - name: Upload quad teacher forced accuracy artifacts
+        if: ${{ always() && inputs.teacher_forced && (inputs.setup == 'quad' || inputs.setup == 'both') }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: quad-teacher-forced-accuracy-${{ github.run_id }}
+          path: |
+            generated/artifacts/quad_teacher_forced_accuracy.txt
+            generated/artifacts/quad_teacher_forced_output.log
+          if-no-files-found: warn
+
+      # ── Demo tests ──────────────────────────────────────────────────────
+      - name: Run dual demo test (256 prompts, 1 batch)
+        if: ${{ inputs.demo && (inputs.setup == 'dual' || inputs.setup == 'both') }}
+        uses: ./.github/actions/docker-run
+        timeout-minutes: 40
+        with:
+          docker_image: ${{ needs.build-artifact.outputs.dev-docker-image }}
+          docker_password: ${{ secrets.GITHUB_TOKEN }}
+          docker_opts: |
+            -e LD_LIBRARY_PATH=${{ github.workspace }}/build/lib
+            -e PYTHONPATH=${{ github.workspace }}
+            -e TT_METAL_HOME=${{ github.workspace }}
+            -e ARCH_NAME=wormhole_b0
+            -e TT_METAL_ENABLE_ERISC_IRAM="1"
+            -e GTEST_OUTPUT="xml:${{ github.workspace }}/generated/test_reports/"
+            -v /etc/mpirun:/etc/mpirun:ro
+            -v ${{ steps.capture-home.outputs.home }}/.ssh:${{ steps.capture-home.outputs.home }}/.ssh:ro
+            --device /dev/tenstorrent
+            --pid=host
+            --hostname=mpirun-host
+          install_wheel: true
+          run_args: |
+            eval "$(./tests/scripts/multihost/setup_shared_venv.sh --activate)"
+            ./tests/scripts/multihost/run_quad_galaxy_tests.sh dual_demo
+
+      - name: Upload dual demo output artifacts
+        if: ${{ always() && inputs.demo && (inputs.setup == 'dual' || inputs.setup == 'both') }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: dual-demo-output-${{ github.run_id }}
+          path: |
+            generated/artifacts/dual_demo_output.log
+            generated/artifacts/dual_demo_full_results.json
+          if-no-files-found: warn
+
+      - name: Run quad demo test (512 prompts, 1 batch)
+        if: ${{ inputs.demo && (inputs.setup == 'quad' || inputs.setup == 'both') }}
+        uses: ./.github/actions/docker-run
+        timeout-minutes: 60
+        with:
+          docker_image: ${{ needs.build-artifact.outputs.dev-docker-image }}
+          docker_password: ${{ secrets.GITHUB_TOKEN }}
+          docker_opts: |
+            -e LD_LIBRARY_PATH=${{ github.workspace }}/build/lib
+            -e PYTHONPATH=${{ github.workspace }}
+            -e TT_METAL_HOME=${{ github.workspace }}
+            -e ARCH_NAME=wormhole_b0
+            -e TT_METAL_ENABLE_ERISC_IRAM="1"
+            -e GTEST_OUTPUT="xml:${{ github.workspace }}/generated/test_reports/"
+            -v /etc/mpirun:/etc/mpirun:ro
+            -v ${{ steps.capture-home.outputs.home }}/.ssh:${{ steps.capture-home.outputs.home }}/.ssh:ro
+            --device /dev/tenstorrent
+            --pid=host
+            --hostname=mpirun-host
+          install_wheel: true
+          run_args: |
+            eval "$(./tests/scripts/multihost/setup_shared_venv.sh --activate)"
+            ./tests/scripts/multihost/run_quad_galaxy_tests.sh quad_demo
+
+      - name: Upload quad demo output artifacts
+        if: ${{ always() && inputs.demo && (inputs.setup == 'quad' || inputs.setup == 'both') }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: quad-demo-output-${{ github.run_id }}
+          path: |
+            generated/artifacts/quad_demo_output.log
+            generated/artifacts/quad_demo_full_results.json
+          if-no-files-found: warn
+
+      # ── Demo stress tests ───────────────────────────────────────────────
+      - name: Run dual demo stress test (56 prompts, 20 batches)
+        if: ${{ inputs.demo_stress && (inputs.setup == 'dual' || inputs.setup == 'both') }}
+        uses: ./.github/actions/docker-run
+        timeout-minutes: 90
+        with:
+          docker_image: ${{ needs.build-artifact.outputs.dev-docker-image }}
+          docker_password: ${{ secrets.GITHUB_TOKEN }}
+          docker_opts: |
+            -e LD_LIBRARY_PATH=${{ github.workspace }}/build/lib
+            -e PYTHONPATH=${{ github.workspace }}
+            -e TT_METAL_HOME=${{ github.workspace }}
+            -e ARCH_NAME=wormhole_b0
+            -e TT_METAL_ENABLE_ERISC_IRAM="1"
+            -e GTEST_OUTPUT="xml:${{ github.workspace }}/generated/test_reports/"
+            -v /etc/mpirun:/etc/mpirun:ro
+            -v ${{ steps.capture-home.outputs.home }}/.ssh:${{ steps.capture-home.outputs.home }}/.ssh:ro
+            --device /dev/tenstorrent
+            --pid=host
+            --hostname=mpirun-host
+          install_wheel: true
+          run_args: |
+            eval "$(./tests/scripts/multihost/setup_shared_venv.sh --activate)"
+            ./tests/scripts/multihost/run_quad_galaxy_tests.sh dual_demo_stress
+
+      - name: Upload dual demo stress output artifacts
+        if: ${{ always() && inputs.demo_stress && (inputs.setup == 'dual' || inputs.setup == 'both') }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: dual-demo-stress-output-${{ github.run_id }}
+          path: |
+            generated/artifacts/dual_demo_stress_output.log
+            generated/artifacts/dual_demo_stress_results.json
+          if-no-files-found: warn
+
+      - name: Run quad demo stress test (56 prompts, 20 batches)
+        if: ${{ inputs.demo_stress && (inputs.setup == 'quad' || inputs.setup == 'both') }}
+        uses: ./.github/actions/docker-run
+        timeout-minutes: 90
+        with:
+          docker_image: ${{ needs.build-artifact.outputs.dev-docker-image }}
+          docker_password: ${{ secrets.GITHUB_TOKEN }}
+          docker_opts: |
+            -e LD_LIBRARY_PATH=${{ github.workspace }}/build/lib
+            -e PYTHONPATH=${{ github.workspace }}
+            -e TT_METAL_HOME=${{ github.workspace }}
+            -e ARCH_NAME=wormhole_b0
+            -e TT_METAL_ENABLE_ERISC_IRAM="1"
+            -e GTEST_OUTPUT="xml:${{ github.workspace }}/generated/test_reports/"
+            -v /etc/mpirun:/etc/mpirun:ro
+            -v ${{ steps.capture-home.outputs.home }}/.ssh:${{ steps.capture-home.outputs.home }}/.ssh:ro
+            --device /dev/tenstorrent
+            --pid=host
+            --hostname=mpirun-host
+          install_wheel: true
+          run_args: |
+            eval "$(./tests/scripts/multihost/setup_shared_venv.sh --activate)"
+            ./tests/scripts/multihost/run_quad_galaxy_tests.sh quad_demo_stress
+
+      - name: Upload quad demo stress output artifacts
+        if: ${{ always() && inputs.demo_stress && (inputs.setup == 'quad' || inputs.setup == 'both') }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: quad-demo-stress-output-${{ github.run_id }}
+          path: |
+            generated/artifacts/quad_demo_stress_output.log
+            generated/artifacts/quad_demo_stress_results.json
+          if-no-files-found: warn

--- a/.github/workflows/multi-host-deepseekv3_cache_gen.yaml
+++ b/.github/workflows/multi-host-deepseekv3_cache_gen.yaml
@@ -39,7 +39,7 @@ on:
         default: false
         description: "Enable Link Time Optimization (LTO)"
 
-run-name: "DeepSeek V3 Cache Generation - quad"
+run-name: "DeepSeek V3 Cache Generation - quad ${{ inputs.override-num-layers || 'all' }}"
 
 jobs:
   build-artifact:

--- a/.github/workflows/multi-host-deepseekv3_cache_gen.yaml
+++ b/.github/workflows/multi-host-deepseekv3_cache_gen.yaml
@@ -38,6 +38,8 @@ on:
         type: boolean
         default: false
         description: "Enable Link Time Optimization (LTO)"
+  push:
+    branches: ["mtsishkouski/38198-deepseek-cache-re-gen-pipeline-4x"]
 
 run-name: "DeepSeek V3 Cache Generation - quad"
 

--- a/.github/workflows/multi-host-deepseekv3_cache_gen.yaml
+++ b/.github/workflows/multi-host-deepseekv3_cache_gen.yaml
@@ -93,6 +93,7 @@ jobs:
             -e TT_METAL_HOME=${{ github.workspace }}
             -e ARCH_NAME=wormhole_b0
             -e TT_METAL_ENABLE_ERISC_IRAM="1"
+            -e GITHUB_RUN_ID=${{ github.run_id }}
             -e _DEEPSEEK_V3_CACHE_DIR=${{ inputs.cache-dir }}
             -e _DEEPSEEK_V3_OVERRIDE_NUM_LAYERS=${{ inputs.override-num-layers }}
             -v /etc/mpirun:/etc/mpirun:ro

--- a/.github/workflows/multi-host-deepseekv3_cache_gen.yaml
+++ b/.github/workflows/multi-host-deepseekv3_cache_gen.yaml
@@ -1,0 +1,106 @@
+name: DeepSeek V3 Cache Generation
+on:
+  # schedule:
+    # - cron: '0 13 * * 6'  # Every Saturday at 13:00 UTC
+  workflow_dispatch:
+    inputs:
+      cache-dir:
+        description: 'Destination cache directory'
+        required: true
+        type: string
+      override-num-layers:
+        description: 'Optional: override the number of layers in the model'
+        required: false
+        type: string
+        default: ''
+      platform:
+        required: false
+        type: choice
+        default: "Ubuntu 22.04"
+        options:
+          - "Ubuntu 22.04"
+          - "Ubuntu 24.04"
+        description: "Platform to build and test"
+      build-type:
+        required: false
+        type: choice
+        default: Release
+        options:
+          - Release
+          - Debug
+          - RelWithDebInfo
+          - ASan
+          - TSan
+        description: "Build type configuration"
+      enable-lto:
+        required: false
+        type: boolean
+        default: false
+        description: "Enable Link Time Optimization (LTO)"
+
+run-name: "DeepSeek V3 Cache Generation - quad"
+
+jobs:
+  build-artifact:
+    uses: ./.github/workflows/build-artifact.yaml
+    permissions:
+      packages: write
+    secrets: inherit
+    with:
+      build-type: ${{ inputs.build-type || 'Release' }}
+      platform: ${{ inputs.platform || 'Ubuntu 22.04' }}
+      enable-lto: ${{ inputs.enable-lto || false }}
+      build-wheel: true
+
+  deepseek-cache-generation:
+    runs-on:
+      - multi-host-glx-4x
+      - arch-wormhole_b0
+      - bare-metal
+      - in-service
+    needs: build-artifact
+    steps:
+      - name: ⬇️ Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - name: ⬇️ Download Build
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0
+        timeout-minutes: 10
+        with:
+          name: ${{ needs.build-artifact.outputs.build-artifact-name }}
+      - name: Extract files
+        run: tar --zstd -xvf ttm_any.tar.zst
+      - name: ⬇️ Download Wheel
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0
+        timeout-minutes: 10
+        with:
+          name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
+      - name: Capture runner's home directory
+        id: capture-home
+        run: echo "home=${HOME}" >> $GITHUB_OUTPUT
+
+      - name: Generate quad DeepSeek V3 TT-NN cache
+        uses: ./.github/actions/docker-run
+        timeout-minutes: 480
+        with:
+          docker_image: ${{ needs.build-artifact.outputs.dev-docker-image }}
+          docker_password: ${{ secrets.GITHUB_TOKEN }}
+          docker_opts: |
+            -e LD_LIBRARY_PATH=${{ github.workspace }}/build/lib
+            -e PYTHONPATH=${{ github.workspace }}
+            -e TT_METAL_HOME=${{ github.workspace }}
+            -e ARCH_NAME=wormhole_b0
+            -e TT_METAL_ENABLE_ERISC_IRAM="1"
+            -e _DEEPSEEK_V3_CACHE_DIR=${{ inputs.cache-dir }}
+            -e _DEEPSEEK_V3_OVERRIDE_NUM_LAYERS=${{ inputs.override-num-layers }}
+            -v /etc/mpirun:/etc/mpirun:ro
+            -v ${{ steps.capture-home.outputs.home }}/.ssh:${{ steps.capture-home.outputs.home }}/.ssh:ro
+            # -v /mnt/MLPerf:/mnt/MLPerf
+            --device /dev/tenstorrent
+            --pid=host
+            --hostname=mpirun-host
+          install_wheel: true
+          run_args: |
+            ./tests/scripts/multihost/setup_shared_venv.sh
+            ./tests/scripts/multihost/run_quad_galaxy_tests.sh quad_cache_gen

--- a/.github/workflows/multi-host-deepseekv3_cache_gen.yaml
+++ b/.github/workflows/multi-host-deepseekv3_cache_gen.yaml
@@ -38,8 +38,6 @@ on:
         type: boolean
         default: false
         description: "Enable Link Time Optimization (LTO)"
-  push:
-    branches: ["mtsishkouski/38198-deepseek-cache-re-gen-pipeline-4x"]
 
 run-name: "DeepSeek V3 Cache Generation - quad"
 

--- a/.github/workflows/multi-host-deepseekv3_cache_gen.yaml
+++ b/.github/workflows/multi-host-deepseekv3_cache_gen.yaml
@@ -1,7 +1,7 @@
 name: DeepSeek V3 Multi-Host Cache Generation
 on:
   # schedule:
-    # - cron: '0 13 * * 6'  # Every Saturday at 13:00 UTC
+  #   - cron: '0 4 * * 0'  # Every Sunday at 04:00 UTC
   workflow_dispatch:
     inputs:
       cache-dir:

--- a/.github/workflows/multi-host-deepseekv3_cache_gen.yaml
+++ b/.github/workflows/multi-host-deepseekv3_cache_gen.yaml
@@ -1,4 +1,4 @@
-name: DeepSeek V3 Cache Generation
+name: DeepSeek V3 Multi-Host Cache Generation
 on:
   # schedule:
     # - cron: '0 13 * * 6'  # Every Saturday at 13:00 UTC
@@ -8,6 +8,7 @@ on:
         description: 'Destination cache directory'
         required: true
         type: string
+        default: '/mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528-Cache/CI'
       override-num-layers:
         description: 'Optional: override the number of layers in the model'
         required: false
@@ -96,7 +97,6 @@ jobs:
             -e _DEEPSEEK_V3_OVERRIDE_NUM_LAYERS=${{ inputs.override-num-layers }}
             -v /etc/mpirun:/etc/mpirun:ro
             -v ${{ steps.capture-home.outputs.home }}/.ssh:${{ steps.capture-home.outputs.home }}/.ssh:ro
-            # -v /mnt/MLPerf:/mnt/MLPerf
             --device /dev/tenstorrent
             --pid=host
             --hostname=mpirun-host

--- a/models/demos/deepseek_v3/scripts/generate_ds_cache.py
+++ b/models/demos/deepseek_v3/scripts/generate_ds_cache.py
@@ -49,7 +49,6 @@ def move_cache(temp_cache_dir: Path, cache_dir: Path, archive_dir: Optional[Path
             # moves from cache_dir to archive_dir
             archive_dst = archive_dir / timestamp / rel
             archive_dst.parent.mkdir(parents=True, exist_ok=True)
-            logger.info(f"Archiving '{dst}' -> '{archive_dst}'")
             shutil.move(str(dst), str(archive_dst))
 
         # moves from temp_cache_dir to cache_dir
@@ -106,7 +105,7 @@ def main() -> None:
         logger.info("Waiting for all hosts to finish cache generation and validation before moving files")
         ttnn.distributed_context_barrier()
 
-    if not ttnn.distributed_context_is_initialized() or ttnn.distributed_context_get_rank() == 0:
+    if (not ttnn.distributed_context_is_initialized()) or (int(ttnn.distributed_context_get_rank()) == 0):
         move_cache(temp_cache_dir, cache_dir, archive_dir)
 
     logger.info("Cache generation complete.")

--- a/models/demos/deepseek_v3/scripts/generate_ds_cache.py
+++ b/models/demos/deepseek_v3/scripts/generate_ds_cache.py
@@ -85,6 +85,7 @@ def main() -> None:
     logger.info(f"Opening mesh device with shape {mesh_shape}")
     mesh_device = ttnn.open_mesh_device(mesh_shape=mesh_shape)
 
+    cache_gen_error = None
     try:
         logger.info(f"Generating cache in {temp_cache_dir}")
         gen = DeepseekGenerator(
@@ -94,6 +95,9 @@ def main() -> None:
             override_num_layers=args.override_num_layers,
         )
         logger.info(f"Cache was generated in {temp_cache_dir}")
+    except Exception as e:
+        cache_gen_error = e
+        logger.error(f"Cache generation failed on this host: {e}")
     finally:
         ttnn.synchronize_device(mesh_device)
         for submesh in mesh_device.get_submeshes():
@@ -102,8 +106,13 @@ def main() -> None:
         ttnn.set_fabric_config(ttnn.FabricConfig.DISABLED)
 
     if ttnn.distributed_context_is_initialized():
-        logger.info("Waiting for all hosts to finish cache generation and validation before moving files")
+        # Always reach the barrier regardless of success/failure so no host hangs
+        # waiting for a peer that already exited with an error.
+        logger.info("Waiting for all hosts to finish cache generation before moving files")
         ttnn.distributed_context_barrier()
+
+    if cache_gen_error is not None:
+        raise cache_gen_error
 
     if (not ttnn.distributed_context_is_initialized()) or (int(ttnn.distributed_context_get_rank()) == 0):
         move_cache(temp_cache_dir, cache_dir, archive_dir)

--- a/models/demos/deepseek_v3/scripts/generate_ds_cache.py
+++ b/models/demos/deepseek_v3/scripts/generate_ds_cache.py
@@ -1,0 +1,113 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import argparse
+import os
+import shutil
+import tempfile
+from datetime import datetime
+from pathlib import Path
+from typing import Optional
+
+from loguru import logger
+
+import ttnn
+from models.demos.deepseek_v3.tt.generator import DeepseekGenerator
+from models.demos.deepseek_v3.utils.test_utils import system_name_to_mesh_shape
+
+optimal_topology = (
+    ttnn.FabricConfig.FABRIC_1D_RING if (os.getenv("USE_TORUS_MODE") is not None) else ttnn.FabricConfig.FABRIC_1D
+)
+
+
+def create_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser("Generate DeepSeek-V3 TT-NN cache")
+    p.add_argument("--model-path", type=str, required=True, help="Path to local HF DeepSeek-V3 model (safetensors)")
+    p.add_argument("--cache-dir", type=str, required=True, help="Destination cache directory")
+    p.add_argument("--temp-cache-dir", type=str, required=True, help="Destination cache directory")
+    p.add_argument(
+        "--archive-dir",
+        type=str,
+        help="Directory to archive overwritten cache files into a timestamped subdirectory. "
+        "If not provided, existing files in cache-dir will be overwritten without backup.",
+    )
+    p.add_argument("--override-num-layers", type=int, help="Override the number of layers in the model.")
+    return p
+
+
+def move_cache(temp_cache_dir: Path, cache_dir: Path, archive_dir: Optional[Path]):
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+
+    logger.info(f"Moving generated cache from '{temp_cache_dir}' to '{cache_dir}'")
+    for src in temp_cache_dir.rglob("*"):
+        if not src.is_file():
+            continue
+        rel = src.relative_to(temp_cache_dir)
+        dst = cache_dir / rel
+        if dst.exists() and archive_dir is not None:
+            # moves from cache_dir to archive_dir
+            archive_dst = archive_dir / timestamp / rel
+            archive_dst.parent.mkdir(parents=True, exist_ok=True)
+            logger.info(f"Archiving '{dst}' -> '{archive_dst}'")
+            shutil.move(str(dst), str(archive_dst))
+
+        # moves from temp_cache_dir to cache_dir
+        dst.parent.mkdir(parents=True, exist_ok=True)
+        shutil.move(str(src), str(dst))
+
+
+def main() -> None:
+    args = create_parser().parse_args()
+
+    model_path = Path(args.model_path)
+    cache_dir = Path(args.cache_dir)
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    temp_cache_dir = Path(args.temp_cache_dir)
+    temp_cache_dir.mkdir(parents=True, exist_ok=True)
+    archive_dir = Path(args.archive_dir) if args.archive_dir is not None else None
+
+    if archive_dir is None:
+        logger.warning(
+            "No --archive-dir specified. Any existing files in cache-dir that conflict with "
+            "newly generated cache files will be overwritten and lost."
+        )
+
+    requested_system_name = os.getenv("MESH_DEVICE")
+    if requested_system_name is None:
+        raise ValueError("Environment variable $MESH_DEVICE is not set. Please set it to DUAL, QUAD, or TG.")
+    mesh_shape = system_name_to_mesh_shape(requested_system_name.upper())
+    logger.info(f"Selected MESH_DEVICE: '{requested_system_name}' - mesh shape will be set to: {mesh_shape}")
+    fabric_config = optimal_topology
+    logger.info(f"Setting fabric config to {fabric_config} for demo run")
+    ttnn.set_fabric_config(fabric_config, ttnn.FabricReliabilityMode.RELAXED_INIT)
+
+    logger.info(f"Opening mesh device with shape {mesh_shape}")
+    mesh_device = ttnn.open_mesh_device(mesh_shape=mesh_shape)
+
+    with tempfile.TemporaryDirectory(dir=str(cache_dir)) as _tmp:
+        temp_cache_dir = Path(_tmp)
+        try:
+            logger.info(f"Generating cache in {temp_cache_dir}")
+            gen = DeepseekGenerator(
+                mesh_device=mesh_device,
+                model_path=model_path,
+                cache_dir=temp_cache_dir,
+                override_num_layers=args.override_num_layers,
+            )
+            logger.info(f"Cache was generated in {temp_cache_dir}")
+        finally:
+            ttnn.synchronize_device(mesh_device)
+            for submesh in mesh_device.get_submeshes():
+                ttnn.close_mesh_device(submesh)
+            ttnn.close_mesh_device(mesh_device)
+            ttnn.set_fabric_config(ttnn.FabricConfig.DISABLED)
+
+        move_cache(temp_cache_dir, cache_dir, archive_dir)
+
+    logger.info("Cache generation complete.")
+
+
+if __name__ == "__main__":
+    main()

--- a/models/demos/deepseek_v3/scripts/generate_ds_cache.py
+++ b/models/demos/deepseek_v3/scripts/generate_ds_cache.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 import argparse
 import os
 import shutil
-import tempfile
 from datetime import datetime
 from pathlib import Path
 from typing import Optional
@@ -26,7 +25,7 @@ def create_parser() -> argparse.ArgumentParser:
     p = argparse.ArgumentParser("Generate DeepSeek-V3 TT-NN cache")
     p.add_argument("--model-path", type=str, required=True, help="Path to local HF DeepSeek-V3 model (safetensors)")
     p.add_argument("--cache-dir", type=str, required=True, help="Destination cache directory")
-    p.add_argument("--temp-cache-dir", type=str, required=True, help="Destination cache directory")
+    p.add_argument("--temp-cache-dir", type=str, required=True, help="Temporary cache directory to be written to")
     p.add_argument(
         "--archive-dir",
         type=str,
@@ -56,6 +55,7 @@ def move_cache(temp_cache_dir: Path, cache_dir: Path, archive_dir: Optional[Path
         # moves from temp_cache_dir to cache_dir
         dst.parent.mkdir(parents=True, exist_ok=True)
         shutil.move(str(src), str(dst))
+    shutil.rmtree(str(temp_cache_dir))
 
 
 def main() -> None:
@@ -86,24 +86,27 @@ def main() -> None:
     logger.info(f"Opening mesh device with shape {mesh_shape}")
     mesh_device = ttnn.open_mesh_device(mesh_shape=mesh_shape)
 
-    with tempfile.TemporaryDirectory(dir=str(cache_dir)) as _tmp:
-        temp_cache_dir = Path(_tmp)
-        try:
-            logger.info(f"Generating cache in {temp_cache_dir}")
-            gen = DeepseekGenerator(
-                mesh_device=mesh_device,
-                model_path=model_path,
-                cache_dir=temp_cache_dir,
-                override_num_layers=args.override_num_layers,
-            )
-            logger.info(f"Cache was generated in {temp_cache_dir}")
-        finally:
-            ttnn.synchronize_device(mesh_device)
-            for submesh in mesh_device.get_submeshes():
-                ttnn.close_mesh_device(submesh)
-            ttnn.close_mesh_device(mesh_device)
-            ttnn.set_fabric_config(ttnn.FabricConfig.DISABLED)
+    try:
+        logger.info(f"Generating cache in {temp_cache_dir}")
+        gen = DeepseekGenerator(
+            mesh_device=mesh_device,
+            model_path=model_path,
+            cache_dir=temp_cache_dir,
+            override_num_layers=args.override_num_layers,
+        )
+        logger.info(f"Cache was generated in {temp_cache_dir}")
+    finally:
+        ttnn.synchronize_device(mesh_device)
+        for submesh in mesh_device.get_submeshes():
+            ttnn.close_mesh_device(submesh)
+        ttnn.close_mesh_device(mesh_device)
+        ttnn.set_fabric_config(ttnn.FabricConfig.DISABLED)
 
+    if ttnn.distributed_context_is_initialized():
+        logger.info("Waiting for all hosts to finish cache generation and validation before moving files")
+        ttnn.distributed_context_barrier()
+
+    if not ttnn.distributed_context_is_initialized() or ttnn.distributed_context_get_rank() == 0:
         move_cache(temp_cache_dir, cache_dir, archive_dir)
 
     logger.info("Cache generation complete.")

--- a/tests/scripts/multihost/run_quad_galaxy_tests.sh
+++ b/tests/scripts/multihost/run_quad_galaxy_tests.sh
@@ -245,6 +245,40 @@ run_quad_demo_stress_test() {
 }
 
 ###############################################################################
+# Cache generation
+###############################################################################
+
+run_quad_cache_gen() {
+    fail=0
+    setup_quad_galaxy_env
+
+    local model_path="${DEEPSEEK_V3_HF_MODEL}"
+    local cache_dir="${_DEEPSEEK_V3_CACHE_DIR}"
+    local temp_cache_dir="/mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528-Cache/temp"
+    local archive_dir="/mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528-Cache-Archive"
+    local num_layers="${_DEEPSEEK_V3_OVERRIDE_NUM_LAYERS:-}"
+
+    if [[ -z "$cache_dir" ]]; then
+        echo "Error: _DEEPSEEK_V3_CACHE_DIR must be set" >&2
+        exit 1
+    fi
+
+    local cmd="python models/demos/deepseek_v3/scripts/generate_ds_cache.py \
+        --model-path ${model_path} \
+        --cache-dir ${cache_dir} \
+        --temp-cache-dir ${temp_cache_dir} \
+        --archive-dir ${archive_dir}"
+
+    [[ -n "$num_layers" ]] && cmd="$cmd --override-num-layers ${num_layers}"
+
+    _run_deepseekv3_tt bash -c "$cmd" ; fail+=$?
+
+    if [[ $fail -ne 0 ]]; then
+        exit 1
+    fi
+}
+
+###############################################################################
 # Composite runners
 ###############################################################################
 
@@ -341,12 +375,15 @@ main() {
         "quad_deepseekv3_integration_tests")
             run_quad_deepseekv3_integration_tests
             ;;
+        "quad_cache_gen")
+            run_quad_cache_gen
+            ;;
         "all")
             run_quad_galaxy_tests
             ;;
         *)
             echo "Unknown test function: $test_function" 1>&2
-            echo "Available options: unit_tests, dual_deepseekv3_unit_tests, quad_deepseekv3_unit_tests, dual_deepseekv3_module_tests, quad_deepseekv3_module_tests, dual_teacher_forced, quad_teacher_forced, dual_demo, quad_demo, dual_demo_stress, quad_demo_stress, dual_deepseekv3_integration_tests, quad_deepseekv3_integration_tests, all" 1>&2
+            echo "Available options: unit_tests, dual_deepseekv3_unit_tests, quad_deepseekv3_unit_tests, dual_deepseekv3_module_tests, quad_deepseekv3_module_tests, dual_teacher_forced, quad_teacher_forced, dual_demo, quad_demo, dual_demo_stress, quad_demo_stress, dual_deepseekv3_integration_tests, quad_deepseekv3_integration_tests, quad_cache_gen, all" 1>&2
             exit 1
             ;;
     esac

--- a/tests/scripts/multihost/run_quad_galaxy_tests.sh
+++ b/tests/scripts/multihost/run_quad_galaxy_tests.sh
@@ -254,7 +254,7 @@ run_quad_cache_gen() {
 
     local model_path="${DEEPSEEK_V3_HF_MODEL}"
     local cache_dir="${_DEEPSEEK_V3_CACHE_DIR}"
-    local temp_cache_dir="/mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528-Cache/temp"
+    local temp_cache_dir="/mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528-Cache/temp/${GITHUB_RUN_ID:-local}"
     local archive_dir="/mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528-Cache-Archive"
     local num_layers="${_DEEPSEEK_V3_OVERRIDE_NUM_LAYERS:-}"
 


### PR DESCRIPTION
### Ticket
Closes #38198 

### Problem description
Add CI pipeline to generate DeepSeek quad cache since quad machines with mounted /mnt/MLPeft won't be accessible by the team

### What's changed
Created script which generates DeepSeek cache. Features:

- takes `--archive-dir` as an input to move old cache here (datetime subdir would be created automatically)
- takes `--override-num-layers` as an input to be able to generate cache for 1,5,61 or any number of layers
- if generation is unsuccessful, all the generated weights will be in `--temp-cache-dir/$GITHUB_RUN_ID`, otherwise it'll be deleted

Created CI pipeline which calls the scripts above.

### Checklist

- [ ] [CI run](https://github.com/tenstorrent/tt-metal/actions/runs/22228831562) - In progress