### PR TITLE
SDXL Relax unet PCC thresholds

### DIFF
--- a/models/experimental/stable_diffusion_xl_base/tests/pcc/test_module_tt_unet.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/pcc/test_module_tt_unet.py
@@ -159,7 +159,7 @@ def run_unet_model(
 
     ttnn.ReadDeviceProfiler(device)
 
-    _, pcc_message = assert_with_pcc(torch_output_tensor, output_tensor, 0.997)
+    _, pcc_message = assert_with_pcc(torch_output_tensor, output_tensor, 0.9969)
     logger.info(f"PCC of first iteration is: {pcc_message}")
 
     for _ in range(iterations - 1):

--- a/models/experimental/stable_diffusion_xl_base/tests/pcc/test_unet_loop.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/pcc/test_unet_loop.py
@@ -26,7 +26,7 @@ import matplotlib.pyplot as plt
 from models.common.utility_functions import is_wormhole_b0
 
 # TODO: test 20 instead of 10 unet iterations
-UNET_LOOP_PCC = {"10": 0.92, "50": 0.92}
+UNET_LOOP_PCC = {"10": 0.91, "50": 0.92}
 
 
 @torch.no_grad()

--- a/models/experimental/stable_diffusion_xl_base/tests/pcc/test_unet_loop.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/pcc/test_unet_loop.py
@@ -26,7 +26,7 @@ import matplotlib.pyplot as plt
 from models.common.utility_functions import is_wormhole_b0
 
 # TODO: test 20 instead of 10 unet iterations
-UNET_LOOP_PCC = {"10": 0.90, "50": 0.92}
+UNET_LOOP_PCC = {"10": 0.91, "50": 0.92}
 
 
 @torch.no_grad()

--- a/models/experimental/stable_diffusion_xl_base/tests/pcc/test_unet_loop.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/pcc/test_unet_loop.py
@@ -26,7 +26,7 @@ import matplotlib.pyplot as plt
 from models.common.utility_functions import is_wormhole_b0
 
 # TODO: test 20 instead of 10 unet iterations
-UNET_LOOP_PCC = {"10": 0.91, "50": 0.92}
+UNET_LOOP_PCC = {"10": 0.90, "50": 0.92}
 
 
 @torch.no_grad()


### PR DESCRIPTION
### Problem description
Une iter and unet loop 10 iter is failing in Metal CI after:  Improve precision, range, and performance of sin/cos/tan. (#37714), as this is change is valid we need to relax thresholds for these tests

### What's changed
Lower UNet loop final-iteration PCC threshold for 10 denoising steps (0.92 → 0.90).
Slightly relax the first-iteration UNet module PCC threshold (0.997 → 0.9969)

### Checklist

- [ ] (Single-card) [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/runs/22233340815) ⚠️fail - but same error is on main - (pcc part passes)
- [ ] (Single-card) [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/runs/22233323227) passes (`github/actions/upload-artifact-with-job-uuid` is failing - it is not relevant) ⚠️
- [x] [Nightly tt-metal L2 tests](https://github.com/tenstorrent/tt-metal/actions/runs/22230764857)

