### PR TITLE
Disable SD 1.4 on BH P150 Model perf pipeline

### DIFF
--- a/.github/workflows/perf-models-impl.yaml
+++ b/.github/workflows/perf-models-impl.yaml
@@ -94,7 +94,8 @@ jobs:
         uses: tenstorrent/tt-metal/.github/actions/single-card-perf-test@main
         with:
           commands: pytest models/demos/vision/generative/stable_diffusion/${{ matrix.test-info.arch == 'blackhole' && 'blackhole' || 'wormhole' }}/tests -m models_performance_bare_metal
-        if: ${{ !cancelled() && matrix.test-info.model-group == 'cnn_javelin' && (inputs.model == 'all' || inputs.model == 'stable_diffusion') }}
+        # Disabled on blackhole until the test is fixed; issue #37617
+        if: ${{ !cancelled() && matrix.test-info.model-group == 'cnn_javelin' && matrix.test-info.arch != 'blackhole' && (inputs.model == 'all' || inputs.model == 'stable_diffusion') }}
       # Disabled until the test is fixed; issue #35263
       # - name: Run sentence_bert model_perf test
       #   timeout-minutes: ${{ matrix.test-info.timeout }}


### PR DESCRIPTION
### Ticket
#37617

### Problem description
The test was reenabled yesterday, however, we still have a hang in p150. The initial issue was timeout, however we also have an actual hang. The hang happens only if we run SD after Unet in the pipeline, which is why it was not reproduced yesterday - I ran the pipeline with SD selected only. Disabling to avoid affecting other tests that run afterwards.

### Checklist
https://github.com/tenstorrent/tt-metal/actions/runs/22222328705 ✅ 