### PR TITLE
Resubmit: Add check for proper configuration of unpacker and packer during init and block

### DIFF
--- a/tests/tt_metal/tt_metal/test_kernels/compute/reconfig.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/reconfig.cpp
@@ -58,9 +58,6 @@ void kernel_main() {
 
         // -------------------- Addition with acc -----------------------------
 
-        // Init like CB_0 is in A and CB_1 is in B
-        add_tiles_init(cb_in0, cb_in1, true);
-
         // Reconfigure UNPACK for correct source formats, tests reconfig calls
 #if (EXPLICIT_RECONFIG == 1)
 #if (SPLIT_SRC_RECONFIG == 1)
@@ -81,6 +78,9 @@ void kernel_main() {
         reconfig_data_format(cb_in1, cb_in0);
 #endif  // SPLIT_SRC_RECONFIG
 #endif  // EXPLICIT_RECONFIG
+
+        // Init like CB_0 is in A and CB_1 is in B
+        add_tiles_init(cb_in1, cb_in0, true);
 
         for (uint32_t i = 0; i < ublock_size_tiles; ++i) {
             add_tiles(cb_in1, cb_in0, i, i, i);

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_AB_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_AB_api.h
@@ -27,6 +27,18 @@ inline void llk_unpack_AB_init(
     const bool narrow_tile =
         get_operand_narrow_tile(operandA_id);  // if narrow tile read face 0 twice for row broadcast
 
+    LLK_ASSERT(
+        (are_unpacker_AB_configured_correctly(
+            unpack_src_format[operandA_id],
+            unpack_dst_format[operandA_id],
+            unpack_src_format[get_operand_id(operandB)],
+            unpack_dst_format[get_operand_id(operandB)],
+            face_r_dim,
+            get_operand_face_r_dim(get_operand_id(operandB)),
+            num_faces,
+            get_operand_num_faces(get_operand_id(operandB)))),
+        "");
+
     _llk_unpack_AB_init_<BType>(face_r_dim, num_faces, narrow_tile, transpose);
 }
 
@@ -45,6 +57,18 @@ inline void llk_unpack_AB(
     std::uint32_t base_address_b = get_local_cb_interface(operandB_id).fifo_rd_ptr - 1;
     std::uint32_t offset_address_b = get_local_cb_interface(operandB_id).fifo_page_size * tile_index_b;
     std::uint32_t address_b = base_address_b + offset_address_b;
+
+    LLK_ASSERT(
+        (are_unpacker_AB_configured_correctly(
+            unpack_src_format[operandA_id],
+            unpack_dst_format[operandA_id],
+            unpack_src_format[operandB_id],
+            unpack_dst_format[operandB_id],
+            get_operand_face_r_dim(operandA_id),
+            get_operand_face_r_dim(operandB_id),
+            get_operand_num_faces(operandA_id),
+            get_operand_num_faces(operandB_id))),
+        "");
 
     // For row broadcast with non-zero row index, adjust address to point to the desired row
     if constexpr (BType == BroadcastType::ROW) {

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_AB_matmul_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_AB_matmul_api.h
@@ -40,6 +40,18 @@ __attribute__((always_inline)) inline void llk_unpack_AB_matmul_init(
     const uint32_t unpB_num_faces =
         partial_face_b ? 1 : get_operand_num_faces(operandB_id);  // if partial face -> unpack face by face
 
+    LLK_ASSERT(
+        (are_unpacker_AB_configured_correctly(
+            unpack_src_format[operandA_id],
+            unpack_dst_format[operandA_id],
+            unpack_src_format[operandB_id],
+            unpack_dst_format[operandB_id],
+            unpA_face_r_dim,
+            unpB_face_r_dim,
+            unpA_num_faces,
+            unpB_num_faces)),
+        "");
+
     _llk_unpack_AB_matmul_init_(
         transpose,
         ct_dim,
@@ -78,6 +90,18 @@ inline void llk_unpack_AB_matmul(
 
     std::uint32_t tile_size_a = get_local_cb_interface(operandA_id).fifo_page_size;
     std::uint32_t tile_size_b = get_local_cb_interface(operandB_id).fifo_page_size;
+
+    LLK_ASSERT(
+        (are_unpacker_AB_configured_correctly(
+            unpack_src_format[operandB_id],
+            unpack_dst_format[operandB_id],
+            unpack_src_format[operandA_id],
+            unpack_dst_format[operandA_id],
+            get_operand_face_r_dim(operandB_id),
+            get_operand_face_r_dim(operandA_id),
+            partial_face_a ? 1 : get_operand_num_faces(operandB_id),
+            partial_face_b ? 1 : get_operand_num_faces(operandA_id))),
+        "");
 
     WAYPOINT("UPMW");
     _llk_unpack_AB_matmul_(

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_A_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_A_api.h
@@ -46,6 +46,11 @@ inline void llk_unpack_A_init(
         llk_unpack_dbg_feature_disable();
     }
 
+    LLK_ASSERT(
+        (is_unpacker_A_configured_correctly<UnpackerProgramType::ProgramByTile>(
+            operand_unpack_src_format, operand_unpack_dst_format, face_r_dim, num_faces)),
+        "");
+
     _llk_unpack_A_init_<BType, acc_to_dest, binary_reuse_dest, unpack_to_dest>(
         transpose_of_faces,
         within_face_16x16_transpose,
@@ -65,6 +70,14 @@ inline void llk_unpack_A(const std::uint32_t operand, const std::uint32_t tile_i
     std::uint32_t base_address = get_local_cb_interface(operand_id).fifo_rd_ptr - 1;
     std::uint32_t offset_address = get_local_cb_interface(operand_id).fifo_page_size * tile_index;
     std::uint32_t address = base_address + offset_address;
+
+    LLK_ASSERT(
+        (is_unpacker_A_configured_correctly<UnpackerProgramType::ProgramByTile>(
+            unpack_src_format[operand_id],
+            unpack_dst_format[operand_id],
+            get_operand_face_r_dim(operand_id),
+            get_operand_num_faces(operand_id))),
+        "");
 
     WAYPOINT("UPAW");
     _llk_unpack_A_<BType, acc_to_dest, binary_reuse_dest, unpack_to_dest>(

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_tilize_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_tilize_api.h
@@ -82,12 +82,23 @@ inline void llk_unpack_tilizeA_B_init(
     const std::uint32_t unpA_face_r_dim = FACE_R_DIM,
     const std::uint32_t unpB_face_r_dim = FACE_R_DIM) {
 
-    const std::uint32_t operand_id = get_operand_id(operandA);
-    const bool narrow_tile = get_operand_narrow_tile(operand_id);
+    const std::uint32_t operandA_id = get_operand_id(operandA);
+    const bool narrow_tile = get_operand_narrow_tile(operandA_id);
+
+    LLK_ASSERT((are_unpacker_AB_configured_correctly<UnpackerProgramType::ProgramByFace>(
+        unpack_src_format[operandA_id],
+        unpack_dst_format[operandA_id],
+        unpack_src_format[get_operand_id(operandB)],
+        unpack_dst_format[get_operand_id(operandB)],
+        unpA_face_r_dim,
+        unpB_face_r_dim),
+        num_faces,
+        get_operand_num_faces(get_operand_id(operandB))),
+    "");
 
     _llk_unpack_tilizeA_B_init_<neginf_srcA, reload_srcB, zero_srcA, zero_srcA_reduce>(
-        unpack_src_format[operand_id],
-        unpack_dst_format[operand_id],
+        unpack_src_format[operandA_id],
+        unpack_dst_format[operandA_id],
         narrow_tile,
         ct_dim,
         num_faces,
@@ -120,6 +131,17 @@ inline void llk_unpack_tilizeA_B(
         get_local_cb_interface(operandB_id).fifo_rd_ptr - 1;  // Remove header size added by descriptor
     const std::uint32_t offset_address_b = tile_index_b * get_local_cb_interface(operandB_id).fifo_page_size;
     const std::uint32_t address_b = base_address_b + offset_address_b;
+
+    LLK_ASSERT((are_unpacker_AB_configured_correctly<UnpackerProgramType::ProgramByFace>(
+        unpack_src_format[operandA_id],
+        unpack_dst_format[operandA_id],
+        unpack_src_format[operandB_id],
+        unpack_dst_format[operandB_id],
+        face_r_dim,
+        get_operand_face_r_dim(operandB_id),
+        num_faces,
+        get_operand_num_faces(operandB_id))),
+    "");
 
     WAYPOINT("UPTW");
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_pack_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_pack_api.h
@@ -104,6 +104,11 @@ inline void llk_pack_init(const std::uint32_t pack_output = 16) {
     const bool partial_face = get_output_partial_face(output_id);
     const bool narrow_tile = get_output_narrow_tile(output_id);
 
+    LLK_ASSERT(
+        (are_packers_configured_correctly<PackerProgramType::ProgramByFace>(
+            pack_src_format[output_id], pack_dst_format[output_id], face_r_dim)),
+        "");
+
     _llk_pack_init_<untilize, zero_output>(
         pack_dst_format[output_id], pack_src_format[output_id], face_r_dim, num_faces, partial_face, narrow_tile);
 }
@@ -153,6 +158,11 @@ inline void llk_pack(std::uint32_t tile_index, std::uint32_t output, std::uint32
 
     std::uint32_t pack_tile_addr = get_output_tile_address<out_of_order_output, untilize>(output_id, output_tile_index);
 
+    LLK_ASSERT(
+        (are_packers_configured_correctly<PackerProgramType::ProgramByFace>(
+            pack_src_format[output_id], pack_dst_format[output_id], get_output_face_r_dim(output_id))),
+        "");
+
     _llk_pack_<DST_SYNC_MODE, is_fp32_dest_acc_en, untilize>(tile_index, pack_tile_addr);
 }
 
@@ -171,6 +181,11 @@ inline void llk_pack_untilize_init(
     std::uint32_t output, const std::uint32_t face_r_dim = FACE_R_DIM, const std::uint32_t num_faces = 4) {
     static_assert(dense == false, "Dense is only supported on BH");
     const std::uint32_t output_id = get_output_id(output);
+
+    LLK_ASSERT(
+        (are_packers_configured_correctly<PackerProgramType::ProgramByFace>(
+            pack_src_format[output_id], pack_dst_format[output_id], face_r_dim)),
+        "");
 
     _llk_pack_untilize_init_<block_ct_dim, full_ct_dim, diagonal, narrow_row, row_num_datums>(
         pack_dst_format[output_id], face_r_dim, num_faces);
@@ -201,6 +216,11 @@ inline void llk_pack_untilize(
             16;
 
     for (std::uint32_t block_rt = 0; block_rt < block_rt_dim; block_rt++) {
+        LLK_ASSERT(
+            (are_packers_configured_correctly<PackerProgramType::ProgramByFace>(
+                pack_src_format[output_id], pack_dst_format[output_id], face_r_dim)),
+            "");
+
         _llk_pack_untilize_<block_ct_dim, full_ct_dim, diagonal, narrow_row, row_num_datums, tile_dst_ct_offset>(
             pack_tile_addr,
             pack_dst_format[output_id],
@@ -224,6 +244,11 @@ inline void llk_matmul_pack(
 
         std::uint32_t pack_tile_addr =
             get_output_tile_address<out_of_order_output, untilize>(output_id, output_tile_index);
+
+        LLK_ASSERT(
+            (are_packers_configured_correctly<PackerProgramType::ProgramByFace>(
+                pack_src_format[output_id], pack_dst_format[output_id], get_output_face_r_dim(output_id))),
+            "");
 
         _llk_pack_<DST_SYNC_MODE, is_fp32_dest_acc_en, untilize>(tile_index, pack_tile_addr);
     }
@@ -263,6 +288,14 @@ inline void llk_pack_rows(
 
     const std::uint8_t output_id = get_output_id(output);
     const std::uint32_t pack_addr = get_output_tile_address<true, false>(output_id, output_index);
+
+    // Pack rows uses pack_reads_per_xy_plane=1 (set in _llk_pack_rows_init_) for row packing,
+    // which differs from standard tile face_r_dim. Use ProgramByTile to skip face_r_dim check.
+    LLK_ASSERT(
+        (are_packers_configured_correctly<PackerProgramType::ProgramByTile>(
+            pack_src_format[output_id], pack_dst_format[output_id])),
+        "");
+
     _llk_pack_rows_(dst_index, pack_addr);
 }
 
@@ -286,6 +319,12 @@ inline void llk_pack_fast_tilize_init(
 
     const uint32_t use_32bit_dest =
         pack_src_format[input_id] == (uint)DataFormat::Float32 || pack_src_format[input_id] == (uint)DataFormat::Tf32;
+
+    LLK_ASSERT(
+        (are_packers_configured_correctly<PackerProgramType::ProgramByTile>(
+            pack_src_format[input_id], pack_dst_format[output_id])),
+        "");
+
     _llk_pack_fast_tilize_init_<DST_SYNC_MODE>(use_32bit_dest, pack_dst_format[output_id], unit_dim, num_faces);
 }
 
@@ -313,6 +352,11 @@ inline void llk_pack_fast_tilize_block(
     const std::uint32_t num_faces = get_output_num_faces(output_id);
 
     const std::uint32_t pack_tile_addr = get_output_tile_address<true, false>(output_id, output_tile_index);
+
+    LLK_ASSERT(
+        (are_packers_configured_correctly<PackerProgramType::ProgramByTile>(
+            pack_src_format[output_id], pack_dst_format[output_id])),
+        "");
 
     _llk_pack_fast_tilize_block_(tile_index, pack_tile_addr, unit_dim, num_units, num_faces);
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_AB_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_AB_api.h
@@ -27,6 +27,18 @@ inline void llk_unpack_AB_init(
     const bool narrow_tile =
         get_operand_narrow_tile(operandA_id);  // if narrow tile read face 0 twice for row broadcast
 
+    LLK_ASSERT(
+        (are_unpacker_AB_configured_correctly(
+            unpack_src_format[operandA_id],
+            unpack_dst_format[operandA_id],
+            unpack_src_format[get_operand_id(operandB)],
+            unpack_dst_format[get_operand_id(operandB)],
+            face_r_dim,
+            get_operand_face_r_dim(get_operand_id(operandB)),
+            num_faces,
+            get_operand_num_faces(get_operand_id(operandB)))),
+        "");
+
     _llk_unpack_AB_init_<BType>(face_r_dim, num_faces, narrow_tile, transpose);
 }
 
@@ -45,6 +57,18 @@ inline void llk_unpack_AB(
     std::uint32_t base_address_b = get_local_cb_interface(operandB_id).fifo_rd_ptr - 1;
     std::uint32_t offset_address_b = get_local_cb_interface(operandB_id).fifo_page_size * tile_index_b;
     std::uint32_t address_b = base_address_b + offset_address_b;
+
+    LLK_ASSERT(
+        (are_unpacker_AB_configured_correctly(
+            unpack_src_format[operandA_id],
+            unpack_dst_format[operandA_id],
+            unpack_src_format[operandB_id],
+            unpack_dst_format[operandB_id],
+            get_operand_face_r_dim(operandA_id),
+            get_operand_face_r_dim(operandB_id),
+            get_operand_num_faces(operandA_id),
+            get_operand_num_faces(operandB_id))),
+        "");
 
     // For row broadcast with non-zero row index, adjust address to point to the desired row
     if constexpr (BType == BroadcastType::ROW) {

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_AB_matmul_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_AB_matmul_api.h
@@ -40,6 +40,18 @@ __attribute__((always_inline)) inline void llk_unpack_AB_matmul_init(
     const uint32_t unpB_num_faces =
         partial_face_b ? 1 : get_operand_num_faces(operandB_id);  // if partial face -> unpack face by face
 
+    LLK_ASSERT(
+        (are_unpacker_AB_configured_correctly(
+            unpack_src_format[operandA_id],
+            unpack_dst_format[operandA_id],
+            unpack_src_format[operandB_id],
+            unpack_dst_format[operandB_id],
+            unpA_face_r_dim,
+            unpB_face_r_dim,
+            unpA_num_faces,
+            unpB_num_faces)),
+        "");
+
     _llk_unpack_AB_matmul_init_(
         transpose,
         ct_dim,
@@ -77,6 +89,18 @@ inline void llk_unpack_AB_matmul(
     std::uint32_t base_address_b = get_local_cb_interface(operandB_id).fifo_rd_ptr - 1;
     std::uint32_t tile_size_a = get_local_cb_interface(operandA_id).fifo_page_size;
     std::uint32_t tile_size_b = get_local_cb_interface(operandB_id).fifo_page_size;
+
+    LLK_ASSERT(
+        (are_unpacker_AB_configured_correctly(
+            unpack_src_format[operandB_id],
+            unpack_dst_format[operandB_id],
+            unpack_src_format[operandA_id],
+            unpack_dst_format[operandA_id],
+            get_operand_face_r_dim(operandB_id),
+            get_operand_face_r_dim(operandA_id),
+            partial_face_a ? 1 : get_operand_num_faces(operandB_id),
+            partial_face_b ? 1 : get_operand_num_faces(operandA_id))),
+        "");
 
     WAYPOINT("UPMW");
     _llk_unpack_AB_matmul_(

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_A_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_A_api.h
@@ -46,6 +46,11 @@ inline void llk_unpack_A_init(
         llk_unpack_dbg_feature_disable();
     }
 
+    LLK_ASSERT(
+        (is_unpacker_A_configured_correctly<UnpackerProgramType::ProgramByTile>(
+            operand_unpack_src_format, operand_unpack_dst_format, face_r_dim, num_faces)),
+        "");
+
     _llk_unpack_A_init_<BType, acc_to_dest, binary_reuse_dest, unpack_to_dest>(
         transpose_of_faces,
         within_face_16x16_transpose,
@@ -65,6 +70,14 @@ inline void llk_unpack_A(const std::uint32_t operand, const std::uint32_t tile_i
     std::uint32_t base_address = get_local_cb_interface(operand_id).fifo_rd_ptr - 1;
     std::uint32_t offset_address = get_local_cb_interface(operand_id).fifo_page_size * tile_index;
     std::uint32_t address = base_address + offset_address;
+
+    LLK_ASSERT(
+        (is_unpacker_A_configured_correctly<UnpackerProgramType::ProgramByTile>(
+            unpack_src_format[operand_id],
+            unpack_dst_format[operand_id],
+            get_operand_face_r_dim(operand_id),
+            get_operand_num_faces(operand_id))),
+        "");
 
     WAYPOINT("UPAW");
     _llk_unpack_A_<BType, acc_to_dest, binary_reuse_dest, unpack_to_dest>(

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_tilize_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_tilize_api.h
@@ -89,20 +89,31 @@ inline void llk_unpack_tilizeA_B_init(
     const std::uint32_t num_faces = 4,
     const std::uint32_t unpA_face_r_dim = FACE_R_DIM,
     const std::uint32_t unpB_face_r_dim = FACE_R_DIM) {
-    const std::uint32_t operand_id =
-        get_operand_id(operandA);  // Use operandA to get operand_id tile dims must be the same for both operands
+    const std::uint32_t operandA_id = get_operand_id(operandA);
+    // Use operandA to get operand_id tile dims must be the same for both operands
     // const std::uint32_t face_r_dim = get_operand_face_r_dim(operand_id);
-    const bool narrow_tile = get_operand_narrow_tile(operand_id);
+    const bool narrow_tile = get_operand_narrow_tile(operandA_id);
+
+    LLK_ASSERT(
+        (are_unpacker_AB_configured_correctly<UnpackerProgramType::ProgramByFace>(
+            unpack_src_format[operandA_id],
+            unpack_dst_format[operandA_id],
+            unpack_src_format[get_operand_id(operandB)],
+            unpack_dst_format[get_operand_id(operandB)],
+            unpA_face_r_dim,
+            unpB_face_r_dim,
+            num_faces,
+            get_operand_num_faces(get_operand_id(operandB)))),
+        "");
 
     _llk_unpack_tilizeA_B_init_<neginf_srcA, reload_srcB, zero_srcA, zero_srcA_reduce>(
-        unpack_src_format[operand_id],
-        unpack_dst_format[operand_id],
+        unpack_src_format[operandA_id],
+        unpack_dst_format[operandA_id],
         narrow_tile,
         ct_dim,
         num_faces,
         unpA_face_r_dim,
-        unpB_face_r_dim
-    );
+        unpB_face_r_dim);
 }
 
 template <bool zero_srcA = false>
@@ -127,6 +138,18 @@ inline void llk_unpack_tilizeA_B(
         get_local_cb_interface(operandB_id).fifo_rd_ptr - 1;  // Remove header size added by descriptor
     std::uint32_t offset_address_b = tile_index_b * get_local_cb_interface(operandB_id).fifo_page_size;
     std::uint32_t address_b = base_address_b + offset_address_b;
+
+    LLK_ASSERT(
+        (are_unpacker_AB_configured_correctly<UnpackerProgramType::ProgramByFace>(
+            unpack_src_format[operandA_id],
+            unpack_dst_format[operandA_id],
+            unpack_src_format[operandB_id],
+            unpack_dst_format[operandB_id],
+            face_r_dim,
+            get_operand_face_r_dim(operandB_id),
+            num_faces,
+            get_operand_num_faces(operandB_id))),
+        "");
 
     WAYPOINT("UPTW");
     _llk_unpack_tilizeA_B_<zero_srcA>(

--- a/tt_metal/hw/inc/api/compute/compute_kernel_hw_startup.h
+++ b/tt_metal/hw/inc/api/compute/compute_kernel_hw_startup.h
@@ -45,8 +45,8 @@ ALWI void compute_kernel_hw_startup(uint32_t icb0, uint32_t icb1, uint32_t ocb) 
     MATH((llk_math_pack_sync_init<DST_ACCUM_MODE>()));
     MATH((llk_math_hw_configure<DST_ACCUM_MODE>(icb0, icb1)));
 
-    PACK((llk_pack_init<false /*untilize*/, false /*zero_output*/, false /*tilize*/>(ocb)));
     PACK((llk_pack_hw_configure<DST_ACCUM_MODE>(ocb)));
+    PACK((llk_pack_init<false /*untilize*/, false /*zero_output*/, false /*tilize*/>(ocb)));
     PACK((llk_pack_dest_init<DST_ACCUM_MODE, false /*untilize*/>(ocb)));
 
     ComputeKernelSentinel::instance().set_srca(icb0).set_srcb(icb1).set_pack(ocb);

--- a/tt_metal/hw/inc/api/compute/pack_untilize.h
+++ b/tt_metal/hw/inc/api/compute/pack_untilize.h
@@ -230,6 +230,10 @@ ALWI void pack_untilize_dest(
 // clang-format on
 ALWI void pack_untilize_uninit(uint32_t ocb) {
     PACK((llk_init_packer_dest_offset_registers<false>()));
+
+    // Reconfigure data format to match the initial configuration, before calling init.
+    // Init is called to ensure special untilize init overrides are cleaned up.
+    PACK((llk_pack_reconfig_data_format<DST_ACCUM_MODE>(ocb)));
     PACK((llk_pack_init(ocb)));
 
 #ifdef ARCH_BLACKHOLE


### PR DESCRIPTION
### Ticket
#38328 

### Problem description
This is a resubmit of PR: https://github.com/tenstorrent/tt-metal/pull/37265
All the relevant description can be seen in the original PR.
The original PR was reverted in PR: https://github.com/tenstorrent/tt-metal/pull/38100

The original PR got reverted as it broke several tests which verified DRAM memory usage and performances. The reason for these breaks was that even when disabled, LLK_ASSERT still required calculating condition. However, the reason why this was so visible to break the test was the condition itself - calling several new methods (unused before) and performing compute heavy calculations). The fix for this issue is in this PR: https://github.com/tenstorrent/tt-llk/pull/1314
Now, when disabled, LLK_ASSERT will still require compile time syntax checks, but it won't perform runtime calculations.

The original PR first had both WH and BH asserts added, then there was another blocker with few registers in tt-sim not readable for BH. Therefore, the original PR was merged with WH changes only. Since tt-sim related blocker is resolved, both WH and BH changes are part of this resubmit PR.

### What's changed
Added asserts for verifying unpacker and packer hw configurations are properly set prior to init/block execution
Changed is implementation of LLK_ASSERT when disabled, so that it does not introduce overheads in runtime.

APC run:
https://github.com/tenstorrent/tt-metal/actions/runs/22230990922

### Checklist

- [x] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=ndivnic/resubmit_verify_unpack_pack_configs)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:ndivnic/resubmit_verify_unpack_pack_configs)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ndivnic/resubmit_verify_unpack_pack_configs)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ndivnic/resubmit_verify_unpack_pack_configs)
- [x] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ndivnic/resubmit_verify_unpack_pack_configs)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ndivnic/resubmit_verify_unpack_pack_configs)
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [x] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ndivnic/resubmit_verify_unpack_pack_configs)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ndivnic/resubmit_verify_unpack_pack_configs)
  - [x] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [x] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [x] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ndivnic/resubmit_verify_unpack_pack_configs)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ndivnic/resubmit_verify_unpack_pack_configs)
  - [x] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [x] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ndivnic/resubmit_verify_unpack_pack_configs)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ndivnic/resubmit_verify_unpack_pack_configs)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
