### PR TITLE
PDL perf bump

### DIFF
--- a/models/experimental/panoptic_deeplab/tests/test_device_perf_pdl.py
+++ b/models/experimental/panoptic_deeplab/tests/test_device_perf_pdl.py
@@ -54,7 +54,7 @@ def test_device_perf_pdl_20_cores(
     [
         (
             "pytest models/experimental/panoptic_deeplab/tests/pcc/test_tt_model.py::test_model_panoptic_deeplab -k panoptic_deeplab_110_cores",
-            6_412_537,
+            6_342_574,
             PANOPTIC_DEEPLAB,
             PANOPTIC_DEEPLAB,
             1,
@@ -64,7 +64,7 @@ def test_device_perf_pdl_20_cores(
         ),
         (
             "pytest models/experimental/panoptic_deeplab/tests/pcc/test_tt_model.py::test_model_panoptic_deeplab -k deeplab_v3_plus_110_cores",
-            4_252_383,
+            4_182_858,
             DEEPLAB_V3_PLUS,
             DEEPLAB_V3_PLUS,
             1,


### PR DESCRIPTION
### Problem description
[(Single-card) Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/runs/22185771518/job/64159910983#step:27:869) for PDL started failing after
this commit https://github.com/tenstorrent/tt-metal/commit/6ba707026ea8287aa0e546544633a4a7750c0212 . Perf time on DeepLabV3+ improved from `4_224_090` to `4_187_816` which violated 1.5% margin. PDL also improved `6_399_642` -> `6_335_498`.

### What's changed
Perf times changed in `models/experimental/panoptic_deeplab/tests/test_device_perf_pdl.py`.

### Checklist

- [ ] [![(Single-card) Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml/badge.svg?branch=nmilicevic/pdl-bump-perf)](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml?query=branch:nmilicevic/pdl-bump-perf)

