### PR TITLE
Disabling n300 and enabling more verbose output in triage tests

### DIFF
--- a/.github/workflows/merge-gate.yaml
+++ b/.github/workflows/merge-gate.yaml
@@ -395,7 +395,6 @@ jobs:
       matrix:
         platform: [
           "N150",
-          "N300",
           "P150b",
         ]
     uses: ./.github/workflows/triage.yaml

--- a/.github/workflows/triage.yaml
+++ b/.github/workflows/triage.yaml
@@ -73,7 +73,7 @@ jobs:
         run: |
             mkdir -p generated/test_reports
             uv pip install -r tools/triage/requirements.txt
-            TT_METAL_RESET_DEVICE_AFTER_HANG=1 pytest ./tools/tests/triage/
+            TT_METAL_RESET_DEVICE_AFTER_HANG=1 pytest -v ./tools/tests/triage/
       - uses: tenstorrent/tt-metal/.github/actions/slack-report@main
         if: ${{ failure() }}
         with:


### PR DESCRIPTION
Disabling triage tests on n300 in CI due to ND failure (ex. https://github.com/tenstorrent/tt-metal/actions/runs/22206189167).

Also enabling verbose output when running triage tests in CI.