### PR TITLE
Esmal/prepare weights md

### DIFF
--- a/models/demos/deepseek_v3_b1/DEEPSEEK_PREPARE_WEIGHTS_DESIGN_DOC.md
+++ b/models/demos/deepseek_v3_b1/DEEPSEEK_PREPARE_WEIGHTS_DESIGN_DOC.md
@@ -125,6 +125,33 @@ So: **full HF tensors → prepare_weights (transform only) → blitz (shard to d
 | shared_gate_proj / shared_up_proj | (7168, 2048) | (7168, 256) per device |
 | q_a_proj, kv_a_proj, gate_mm, norms | — | Replicated (full shape per device) |
 
+### 5.4 How HF weights map onto MoE and MLP implementation
+
+DeepSeek V3 has **two layer types**: the first few layers are **dense** (one MLP, no routing); the rest are **MoE** (router + shared expert + 32 routed experts). The table below maps HF state-dict keys to what **prepare_weights** produces and which **fused ops** in this directory consume them.
+
+**Layer types in HF:**
+
+- **Dense layers** (e.g. `i = 0, 1, 2`): `model.layers.{i}.mlp` has a single “expert” with `gate_proj`, `up_proj`, `down_proj` (no `gate`, no `shared_experts`, no `experts`).
+- **MoE layers** (e.g. `i = 3..60`): `model.layers.{i}.mlp` has `gate` (router), `shared_experts.gate_proj/up_proj/down_proj`, and `experts.{0..31}.gate_proj/up_proj/down_proj`.
+
+**Implementation in this directory:**
+
+| HF concept | HF keys (under `model.layers.{i}.`) | prepare_weights / blitz | Fused op that uses it |
+|------------|-------------------------------------|--------------------------|------------------------|
+| **Attention** (all layers) | self_attn.q_a_proj, q_b_proj, kv_a_proj_with_mqa, kv_b_proj, o_proj + norms | Yes → OverlappedTensors in q_ab_kv_a, kv_b12, o_proj_gate_mm_norms | Pre-SDPA, Post-SDPA (not covered in this table in detail). |
+| **Router** (MoE only) | mlp.gate.weight | Yes → gate_mm in o_proj_gate_mm_norms | **MoeOp**: gate matmul (step 2); expects gate_mm on L1. |
+| **Shared expert gate/up** (MoE only) | mlp.shared_experts.gate_proj.weight, up_proj.weight | Yes → gate_up fusion (shared_gate_proj, shared_up_proj) | **SharedExpertOp**: fused gate/up matmul (steps 2–4); reads gate_up L1 buffer. |
+| **Shared expert down** (MoE only) | mlp.shared_experts.down_proj.weight | Yes → plain tensor shared_down_proj (TP-sharded) | **SharedExpertOp** + **DownProj**: down_proj matmul (step 7); reads shared_down_proj. |
+| **Dense MLP** (dense layers only) | mlp.gate_proj, mlp.up_proj, mlp.down_proj | **No** (Phase 2) | **MlpOp** (test_mlp.py): one “expert” gate/up/down; today tests use synthetic weights, not HF. |
+| **Routed experts** (MoE only) | mlp.experts.{e}.gate_proj, up_proj, down_proj (e=0..31) | **No** (Phase 3) | **MoeOp** (MoeRoutedExpertOp): gate_proj, up_proj, down_proj per expert from **DRAM**; today tests use create_expert_matmul_tensors (synthetic). |
+
+**Summary:**
+
+- **Dense layers:** HF has one set of `mlp.gate_proj`, `mlp.up_proj`, `mlp.down_proj`. The **MlpOp** path (test_mlp.py) implements that single-expert MLP; **prepare_weights** does not yet load these three (Phase 2).
+- **MoE layers:** HF has (1) router `mlp.gate`, (2) shared expert `mlp.shared_experts.{gate,up,down}_proj`, (3) 32 routed experts `mlp.experts.{e}.{gate,up,down}_proj`. We **do** load (1) and (2) via prepare_weights → gate_mm, gate_up fusion, and shared_down_proj. The **MoeOp** uses gate_mm and the **SharedExpertOp** uses gate_up + shared_down_proj. Routed expert weights (3) are **not** in prepare_weights yet; the MoE op expects them in DRAM (e.g. from create_expert_matmul_tensors in tests).
+
+So: **HF dense MLP** → MlpOp (one gate/up/down); **HF MoE** → MoeOp (router + SharedExpertOp for shared expert + DRAM experts for routed). prepare_weights currently feeds only attention + router + shared expert; dense MLP and routed experts are future work.
+
 ---
 
 ## 6. kv_b_proj Split

--- a/models/demos/deepseek_v3_b1/DEEPSEEK_PREPARE_WEIGHTS_DESIGN_DOC.md
+++ b/models/demos/deepseek_v3_b1/DEEPSEEK_PREPARE_WEIGHTS_DESIGN_DOC.md
@@ -1,0 +1,267 @@
+# DeepSeek V3 Prepare Weights — Design Document
+
+Design doc for the **prepare_weights** feature: building device-resident, fused (blitz decode) weights from a HuggingFace-style state dict. Update this doc as the feature evolves.
+
+---
+
+## 1. Motivation
+
+- **Decouple weight preparation from the model class.** The host-side `DeepSeekV3` class in `model.py` handles H2D/D2H sockets and prefill/decode orchestration. Weight loading and fusion should live in a separate, reusable path so that:
+  - We can load and fuse weights once (e.g., at startup or from a checkpoint) and pass a single `DeepSeekV3Weights` object into the model.
+  - The same pipeline can be tested with synthetic state dicts or real checkpoints without tying either to the socket I/O layer.
+
+- **Reuse the blitz decode fusion pipeline.** `blitz_decode_weights.py` already fuses multiple weight tensors into shared L1 buffers (weight overlapping) to reduce fragmentation and buffer count. We want a single entry point that:
+  - Takes a standard state dict (e.g., from HuggingFace).
+  - Applies the correct key mapping, transposes, and any splits (e.g., `kv_b_proj` → `kv_b1` / `kv_b2`).
+  - Calls `BlitzDecodeWeights` for every layer and returns a typed container (`DeepSeekV3Weights`) that the rest of the stack can consume.
+
+- **Support both dense and MoE layers.** DeepSeek V3 has 61 layers: the first 3 are dense (standard MLP), the remaining 58 are MoE (routing gate + shared expert + routed experts). The prepared type is a union so call sites can use `isinstance(layer, DeepSeekV3MoELayerWeights)` and access `gate_mm`, `shared_gate_proj`, `shared_up_proj` only when present.
+
+---
+
+## 2. Architecture Overview
+
+```
+┌─────────────────────────────────────────────────────────────────────────┐
+│  state_dict (HF convention)                                              │
+│  model.layers.{i}.self_attn.*, model.layers.{i}.mlp.*, ...              │
+└─────────────────────────────────────────────────────────────────────────┘
+                                      │
+                                      ▼
+┌─────────────────────────────────────────────────────────────────────────┐
+│  prepare_weights(state_dict, device, num_layers=61,                     │
+│                   first_k_dense_replace=3)                               │
+│  - Key mapping & transpose (HF → blitz K,N convention)                   │
+│  - _split_kv_b_proj(kv_b_proj) → kv_b1, kv_b2                            │
+│  - Per layer: BlitzDecodeWeights.get_tt_*() fusion calls                 │
+└─────────────────────────────────────────────────────────────────────────┘
+                                      │
+                                      ▼
+┌─────────────────────────────────────────────────────────────────────────┐
+│  DeepSeekV3Weights                                                       │
+│  .layers: list[DeepSeekV3DenseLayerWeights | DeepSeekV3MoELayerWeights]  │
+│  Each layer holds OverlappedTensor views into fused device buffers.      │
+└─────────────────────────────────────────────────────────────────────────┘
+                                      │
+                                      ▼
+┌─────────────────────────────────────────────────────────────────────────┐
+│  DeepSeekV3(..., weights: DeepSeekV3Weights)  [future]                   │
+│  Fused ops (Pre-SDPA, Post-SDPA, MoE, …) read from OverlappedTensors    │
+│  via fused_tensor + byte_offset + core_range_set.                        │
+└─────────────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## 3. Files and Roles
+
+| File | Role |
+|------|------|
+| **prepare_weights.py** | Entry point and types. Defines `prepare_weights()`, `DeepSeekV3Weights`, `DeepSeekV3DenseLayerWeights`, `DeepSeekV3MoELayerWeights`, and helpers (`_key`, `_split_kv_b_proj`). Imports `BlitzDecodeWeights` and `OverlappedTensor` from `blitz_decode_weights`. |
+| **blitz_decode_weights.py** | Weight overlapping (fusion) implementation. Exposes `BlitzDecodeWeights` and configs; `get_tt_o_proj_and_gate_mm_weights(..., gate_mm_weights=None)` supports dense layers when `gate_mm_weights` is omitted. |
+| **model.py** | Host I/O and prefill/decode orchestration. Intended to accept an optional `DeepSeekV3Weights` once the real decoder pipeline is wired; no weight loading in this doc’s scope. |
+| **tests/unit_tests/test_prepare_weights.py** | Unit tests: random-weight state dicts for one dense and one MoE layer, plus a skip-marked placeholder for real checkpoint tests. |
+
+---
+
+## 4. Data Types
+
+### 4.1 Layer weight containers
+
+- **DeepSeekV3DenseLayerWeights**  
+  Used for layers `0 .. first_k_dense_replace - 1`. Contains:
+  - Attention: `q_a_proj`, `q_b_proj`, `kv_a_proj`, `kv_b1_proj`, `kv_b2_proj`
+  - Output + norms: `o_proj`, `attn_norm`, `q_norm`, `kv_norm`, `ffn_norm`  
+  No `gate_mm` or shared expert (dense layers use a standard MLP, not MoE).
+
+- **DeepSeekV3MoELayerWeights**  
+  Used for layers `first_k_dense_replace .. num_layers - 1`. Same as dense plus:
+  - `gate_mm` (routing gate)
+  - `shared_gate_proj`, `shared_up_proj` (shared expert gate/up)
+
+- **DeepSeekV3LayerWeights**  
+  Type alias: `DeepSeekV3DenseLayerWeights | DeepSeekV3MoELayerWeights`.
+
+- **DeepSeekV3Weights**  
+  Top-level container: `layers: list[DeepSeekV3LayerWeights]`.
+
+All weight fields are **OverlappedTensor** views (see `blitz_decode_weights.py`): they reference a shared `fused_tensor` and carry `tensor_shape`, `shard_shape`, `core_range_set`, `dtype`, `tile_shape`, and `byte_offset` so kernels can address each sub-weight inside the fused L1 buffer.
+
+### 4.2 Blitz fusion groups (reference)
+
+| Fusion method | Outputs | Notes |
+|---------------|--------|--------|
+| `get_tt_q_ab_proj_and_kv_a_proj_weights` | q_a_proj, q_b_proj, kv_a_proj | WIDTH_SHARDED; q_a packed, q_b shuffled for Qnope/Qrope, kv_a shard-reordered. |
+| `get_tt_o_proj_and_gate_mm_weights` | o_proj, [gate_mm], attn_norm, q_norm, kv_norm, ffn_norm | gate_mm optional for dense; UINT32 raw container. |
+| `get_tt_kv_b12_proj_weights` | kv_b1_proj, kv_b2_proj | HEIGHT_SHARDED. |
+| `get_tt_gate_up_proj_weights` | shared_gate_proj, shared_up_proj | HEIGHT_SHARDED, block-sharded; MoE only. |
+
+---
+
+## 5. State Dict Convention and Transformations
+
+We assume keys under `model.layers.{layer_idx}.` as follows. Linear weights are stored in HF as `(out_features, in_features)`; we transpose to `(K, N)` for blitz.
+
+| Blitz / prepare_weights | HF state_dict key (under `model.layers.{i}.`) | Shape (HF) | Transform |
+|------------------------|------------------------------------------------|------------|-----------|
+| q_a_proj               | self_attn.q_a_proj.weight                      | (1536, 7168) | .T → (7168, 1536) |
+| q_b_proj               | self_attn.q_b_proj.weight                      | (12288, 1536) | .T → (1536, 12288) |
+| kv_a_proj              | self_attn.kv_a_proj_with_mqa.weight            | (576, 7168)  | .T → (7168, 576) |
+| kv_b1, kv_b2           | self_attn.kv_b_proj.weight                     | (16384, 512) | See §6; **kv_b1 not transposed**, kv_b2 transposed |
+| o_proj                 | self_attn.o_proj.weight                        | (7168, 8192) | .T → (8192, 7168) |
+| gate_mm                | mlp.gate.weight                                | (256, 7168)  | .T → (7168, 256); MoE only |
+| attn_norm              | input_layernorm.weight                         | (7168,)      | unsqueeze(0) → (1, 7168) |
+| q_norm                 | self_attn.q_a_layernorm.weight                  | (1536,)      | unsqueeze(0) → (1, 1536) |
+| kv_norm                | self_attn.kv_a_layernorm.weight                 | (512,)       | unsqueeze(0) → (1, 512) |
+| ffn_norm               | post_attention_layernorm.weight                 | (7168,)      | unsqueeze(0) → (1, 7168) |
+| shared_gate_proj       | mlp.shared_experts.gate_proj.weight             | (256, 7168)  | .T → (7168, 256); MoE only |
+| shared_up_proj         | mlp.shared_experts.up_proj.weight               | (256, 7168)  | .T → (7168, 256); MoE only |
+
+---
+
+## 6. kv_b_proj Split
+
+HuggingFace stores a single `kv_b_proj`; the blitz pipeline expects two matrices. **All linear weights are transposed for blitz except kv_b1.**
+
+- **kv_b1_proj:** (8192, 512) — 64 heads × 128 (qk_nope head dim), HEIGHT_SHARDED on the Qnope grid. **Not transposed**: use HF slice as (8192, 512).
+- **kv_b2_proj:** (512, 8192) — 64 heads × 128 (v head dim); **transposed** from HF (8192, 512) to (512, 8192). Blitz then reshapes for HEIGHT_SHARDED placement.
+
+Constants: `num_heads=64`, `qk_nope_head_dim=128`, `v_head_dim=128`, `kv_lora_rank=512`, so HF shape is `(num_heads * 256, 512) = (16384, 512)`.
+
+**Algorithm (`_split_kv_b_proj`):**
+
+1. Reshape (16384, 512) to (64, 256, 512) — (num_heads, head_dim, kv_lora_rank).
+2. kv_b1: slice `[:, :128, :]` → (64, 128, 512); reshape to (8192, 512). **No transpose.**
+3. kv_b2: slice `[:, 128:, :]` → (64, 128, 512); reshape to (8192, 512); then `.T` → (512, 8192).
+
+This aligns with `models/demos/deepseek_v3/tt/mla/mla1d.py` (wkv_b1 / wkv_b2) and keeps b1 in (out, in) and b2 in (K, N) for blitz.
+
+---
+
+## 7. Dense vs MoE and Optional gate_mm
+
+- **Dense layers** (`i < first_k_dense_replace`): No `mlp.gate` or `mlp.shared_experts.*`. We call `get_tt_o_proj_and_gate_mm_weights(o_proj, None, attn_norm, q_norm, kv_norm, ffn_norm)` so that the 8 gate_mm cores are omitted from the fused buffer; the returned list has 5 elements (no gate_mm OverlappedTensor). We do not call `get_tt_gate_up_proj_weights`.
+
+- **MoE layers** (`i >= first_k_dense_replace`): We pass `gate_mm` and call `get_tt_gate_up_proj_weights(shared_gate, shared_up)`; the layer is stored as `DeepSeekV3MoELayerWeights` with all fields populated.
+
+---
+
+## 8. Testing
+
+- **test_prepare_dense_layer(device)**  
+  Builds a synthetic state dict for a single dense layer (random bfloat16), calls `prepare_weights(..., num_layers=1, first_k_dense_replace=1)`, and asserts type and `tensor_shape` for all fields. Skips if device grid is smaller than 12×10.
+
+- **test_prepare_moe_layer(device)**  
+  Same idea for two layers (one dense, one MoE); asserts the second layer is `DeepSeekV3MoELayerWeights` and checks shapes including `gate_mm`, `shared_gate_proj`, `shared_up_proj`.
+
+- **test_prepare_real_weights(device)**  
+  Placeholder: `@pytest.mark.skip` with a note that real checkpoint testing will be added later.
+
+---
+
+## 9. Multi-device and full-pipeline extension (blitz_decode_weights)
+
+The current blitz decode weights path is built around a **single logical device** (one chip). The full decoder pipeline (Pre-SDPA, Flash MLA, Post-SDPA, MoE, etc.) is written to run on a **MeshDevice**: fused ops take mesh tensors and use `ttnn.get_device_tensors(...)` to get one tensor per device, then launch per-device work with CCL for cross-device sync. To support that pipeline end-to-end, blitz_decode_weights will need to be extended as follows.
+
+### 9.1 Current behavior (single device)
+
+- **BlitzDecodeWeights** takes a single `device` and stores it as `self._device`.
+- **Grid validation** uses `self._device.compute_with_storage_grid_size()` and asserts the grid is at least as large as the core ranges in each overlap config (e.g. 12×10 for q_ab + kv_a). This is the **per-device** grid.
+- **Placement** uses `ttnn.from_torch(..., device=self._device, mesh_mapper=ttnn.ReplicateTensorToMesh(self._device))`. So:
+  - If `device` is a **single Device**: one fused tensor is created on that device; core ranges (0,0)–(11,7), etc. are that device’s logical cores.
+  - If `device` is a **MeshDevice**: `ReplicateTensorToMesh` replicates the same tensor to **every** device in the mesh. Each device gets the same logical core layout and the same weight data. Fused ops that call `get_device_tensors(weight_mesh)` then get one weight tensor per device, which is what they use today (e.g. `matmul_weights_tensors_per_device[device_idx]`). So **replicated** weights on a mesh already match how the fused ops consume weights.
+
+So today:
+
+- **Single device:** fully supported; all fusion groups live on that device.
+- **Mesh with replication:** supported in principle (pass a MeshDevice; each chip gets a full copy of the fused weights). Not yet exercised in tests; grid validation is still per-device and must hold on every device in the mesh.
+
+What is **not** supported today:
+
+- **Pipeline parallelism:** each device only holds weights for “its” layers (e.g. device 0: layers 0–15, device 1: layers 16–31). That would require preparing weights per stage and using a mesh mapper (or separate calls) so each device only gets the tensors for its layer range, instead of replicating the full model.
+- **Tensor parallelism:** sharding a single layer’s weights across multiple devices (e.g. splitting q_a_proj along K or N across 4 chips). Core ranges and shard specs are currently single-device; supporting this would mean defining per-device core ranges and a mesh mapper that shards the weight tensor across devices (e.g. `ShardTensorToMesh` on a dimension), and ensuring fused ops and CCL (e.g. all-reduce after matmul) are aware of the sharding.
+
+### 9.2 Extensions needed for the full decoder pipeline
+
+1. **Explicit MeshDevice support and testing**
+   - When `device` is a MeshDevice, keep using `ReplicateTensorToMesh(self._device)` so each device gets a full copy.
+   - Ensure grid validation uses the per-device grid (same as today) and that every device in the mesh has a large enough grid (e.g. 12×10). If the API returns a single grid for the mesh, validate that grid; otherwise validate per device if the runtime exposes it.
+   - Add a test that builds weights with a small mesh (e.g. 2×1) and runs at least one fused op (e.g. Pre-SDPA) to confirm replicated weights work with `get_device_tensors`.
+
+2. **Pipeline parallelism (layers split across devices)**
+   - **Option A:** `prepare_weights` (or a variant) accepts a **stage_id** and **num_stages** and only produces weights for layers in that stage (e.g. stage 0: layers 0–15, stage 1: 16–31). Each stage is prepared with `BlitzDecodeWeights(single_device)` for that device, and the runner only passes that stage’s `DeepSeekV3Weights` to the device. No change to BlitzDecodeWeights internals; only the orchestration (who calls prepare_weights and with which layers) changes.
+   - **Option B:** `prepare_weights` takes a MeshDevice and a “layer → device” mapping and uses a mesh mapper that places each layer’s fused tensors only on the assigned device (e.g. no replication of other layers). That would require a custom mesh mapper or multiple `from_torch` calls per layer with device placement constrained to one mesh coordinate.
+
+3. **Tensor parallelism (weight sharding across devices)**
+   - Today each fusion group (q_ab+kv_a, o_proj+gate_mm+norms, kv_b1+kv_b2, gate+up) is a single logical tensor sharded over cores on **one** device. To shard a group across devices (e.g. q_a_proj rows split across 4 devices), we’d need:
+     - A **mesh mapper** that shards the fused tensor along the chosen dimension across mesh devices (e.g. `ShardTensorToMesh` on a logical dimension that corresponds to “which device”).
+     - **Per-device core ranges** so that each device’s shard is placed on the right cores locally, and the overall ShardSpec / memory config describes the cross-device sharding.
+     - Fused ops (and possibly kernels) to be aware of sharded weights: e.g. matmul with sharded weights followed by an all-reduce or other CCL. This is a larger change and may require new op variants or config flags.
+
+4. **Full decoder weight coverage**
+   - Blitz currently fuses only a subset of decoder weights (q_a/q_b/kv_a, o_proj+gate_mm+norms, kv_b1/kv_b2, shared expert gate/up). The full pipeline also uses (and may want to fuse or overlap):
+     - **down_proj** (and expert down_projs in MoE).
+     - **Expert weights** (gate_proj, up_proj, down_proj per expert).
+     - **Embedding** and **lm_head** (if they are to live on device and be overlapped with other buffers).
+   - Extending blitz for these would mean new overlap configs and new `get_tt_*` methods (and corresponding updates to `prepare_weights` and the layer weight dataclasses), following the same pattern: define core ranges and shard layout, then stitch or pack into a single buffer per core (or per device in a multi-device setup).
+
+### 9.3 Summary
+
+| Scenario | Today | Extension |
+|----------|--------|-----------|
+| Single device | Supported | — |
+| Mesh, replicated weights (full model on each device) | Supported in principle | Validate + test with MeshDevice |
+| Pipeline parallelism (layers per device) | Not supported | prepare_weights per stage or layer→device mapping + mapper |
+| Tensor parallelism (weight shard across devices) | Not supported | ShardTensorToMesh + per-device core ranges + op/CL support |
+| Full decoder (down_proj, experts, embed, lm_head) | Partial (only current fusion groups) | New overlap configs and get_tt_* in blitz_decode_weights |
+
+---
+
+## 10. Adapting prepare_weights to branch `bliu/deepseek`
+
+On branch **bliu/deepseek**, `BlitzDecodeWeights` adds **tensor parallelism (TP)** and renames configs. Below is what must change in **prepare_weights.py** when that branch is used.
+
+### 10.1 HF state dict is unchanged; TP/DP are TTNN placement only
+
+The HuggingFace state dict and checkpoint stay the same regardless of TP/DP. We always load **full-model** weights (e.g. q_b (1536, 12288), o_proj (8192, 7168), etc.). The **TP/DP factors** (e.g. mla_tp=2, moe_tp=8 on a 4×2 mesh) refer to how the **TTNN tensors** (the fused device buffers) are **sharded across the decoder mesh** — i.e. a runtime/placement concern, not a different checkpoint layout. So **prepare_weights** always passes the same shapes to blitz (the full-model shapes derived from the HF state dict). BlitzDecodeWeights is responsible for slicing/sharding those full-model tensors and placing them on the mesh when the device is multi-device.
+
+### 10.2 Branch changes in blitz_decode_weights.py
+
+- **Config renames:** `QAB_KVA_PROJ_OverlapConfig` → `QAB_KVA_PROJ_SingleDeviceOverlapSpec`, and similarly for the other three (constants use `*_SINGLE_DEVICE_OVERLAP_SPEC`). Logic is equivalent; only names differ.
+- **BlitzDecodeWeights.__init__:** Sets `self.mla_tp` and `self.moe_tp` from the device (single device → 1/1; 4×2 mesh → 2/8). These drive how the **output** TTNN tensors are sharded (e.g. `ShardTensor2dMesh`), not the **input** shapes from the caller.
+- **Intended input shapes (full-model from HF):** Callers (e.g. prepare_weights) always pass **full-model** weights: q_b (1536, 12288), o_proj (8192, 7168), kv_b1 (8192, 512), kv_b2 (512, 8192), gate/up (7168, 256). When the device is a mesh, blitz should **accept these same shapes**, slice them per TP index internally, and produce the sharded mesh tensor. (Note: the current branch code may still expect TP-concatenated shapes like (1536, 12288×mla_tp); aligning with “HF stays the same” would mean changing blitz to accept (1536, 12288) and do the slicing inside.)
+- **Dense layers:** On the branch, `get_tt_o_proj_and_gate_mm_weights` **requires** `gate_mm_weights` (no `None`). So either the branch adds optional `gate_mm` for dense, or prepare_weights passes a dummy (e.g. zeros) of shape (7168, 256) for dense layers.
+- **GATE_UP:** `GATE_UP_PROJ_SingleDeviceOverlapSpec` uses different core range groupings and `reshuffle_block_to_height_sharded(weights, core_range_set)`; no change to prepare_weights call signature for gate/up.
+
+### 10.3 Required changes in prepare_weights.py
+
+Because **HF stays the same** and TP/DP only affect how TTNN tensors are sharded on the mesh, prepare_weights continues to load the same state dict and pass **the same full-model shapes** to BlitzDecodeWeights for both single-device and 4×2 mesh:
+
+- **No TP-concatenation in prepare_weights.** We do not build (1536, 12288×mla_tp) or (7168, 256×moe_tp); we always pass (1536, 12288), (7168, 256), etc. from the HF state dict (after transpose/split as today). Blitz is responsible for sharding those full-model tensors across the mesh when the device is multi-device.
+
+- **Dense layers and gate_mm:** If the branch does not support `gate_mm_weights=None`, then for dense layers either add optional `gate_mm` on the branch, or in prepare_weights pass a zero tensor of shape (7168, 256) when `i < first_k_dense_replace`.
+
+- **Branch blitz alignment:** If the current branch API still expects TP-concatenated input shapes (e.g. q_b (1536, 12288×mla_tp)), then the branch should be updated to accept full-model shapes and perform the TP slicing internally, so that prepare_weights can remain agnostic of mla_tp/moe_tp and always pass HF-derived shapes.
+
+### 10.4 Summary
+
+- **HF state dict:** Unchanged; single full-model checkpoint.
+- **prepare_weights:** Always passes full-model shapes (same as today); no mesh- or TP-specific logic.
+- **BlitzDecodeWeights:** Uses mla_tp/moe_tp to shard the **output** TTNN tensors across the 4×2 decoder mesh; should accept the **same** full-model input shapes and do any per-TP slicing internally.
+
+---
+
+## 11. Future Work / Open Points
+
+- **Integrate with DeepSeekV3:** Pass `DeepSeekV3Weights` into `DeepSeekV3.__init__` and wire OverlappedTensors to Pre-SDPA, Post-SDPA, MoE, and shared expert ops (each op already takes `ttnn.Tensor`; kernels use `byte_offset` where the fused buffer is a raw container).
+- **Real checkpoint test:** Implement `test_prepare_real_weights` using a real HuggingFace checkpoint (or a small fixture) and validate numerical consistency or golden outputs.
+- **Config-driven constants:** Move `num_layers`, `first_k_dense_replace`, and kv_b split constants (e.g. `_NUM_HEADS`) into a small config or the existing DeepSeek V3 config so they stay in sync with the reference model.
+- **Lazy / on-demand loading:** If needed, consider a variant that prepares weights for a subset of layers or streams from checkpoint instead of loading the full state dict up front.
+
+---
+
+## 12. Changelog
+
+- **Initial:** Added prepare_weights API, DeepSeekV3Weights / Dense / MoE types, state dict mapping, kv_b split, optional gate_mm in blitz_decode_weights, and unit tests with random weights plus placeholder for real weights.
+- **Multi-device / full pipeline:** Added §9 (Multi-device and full-pipeline extension): current single-device assumption, MeshDevice + replication behavior, and required extensions for pipeline parallelism, tensor parallelism, and full decoder weight coverage.
+- **bliu/deepseek branch:** Added §10 (Adapting prepare_weights to branch bliu/deepseek): TP-aware shapes, mla_tp/moe_tp, and required prepare_weights.py changes for single-device vs 4×2 mesh.

--- a/models/demos/deepseek_v3_b1/DEEPSEEK_PREPARE_WEIGHTS_DESIGN_DOC.md
+++ b/models/demos/deepseek_v3_b1/DEEPSEEK_PREPARE_WEIGHTS_DESIGN_DOC.md
@@ -181,7 +181,241 @@ Pipeline parallelism (layers split across devices) and further tensor parallelis
 
 ---
 
-## 11. Future Work / Open Points
+## 11. Serialization and Deserialization
+
+### 11.1 Motivation
+
+`prepare_weights` is expensive: it transposes, splits, fuses, and shards every layer through blitz. For production we want to run it **once offline** and serialize the result so that at model runtime we can load pre-prepared weights directly onto the device(s) without re-doing the fusion. The runtime path should be: **load manifest → load fused tensors → reconstruct `DeepSeekV3Weights` → run model**.
+
+### 11.2 Serialization primitives
+
+- **`ttnn.dump_tensor(file_name, tensor)`** — saves a `ttnn.Tensor` to `.tensorbin` (FlatBuffer metadata + binary data). Works for host and device tensors.
+- **`ttnn.load_tensor(file_name, device=device)`** — loads a `.tensorbin` and optionally places on device/mesh.
+
+### 11.3 Key insight: fused tensors are shared
+
+Each fusion group (q_ab+kv_a, o_proj+gate_mm+norms, kv_b12, gate_up) produces **one fused `ttnn.Tensor`** in L1 that multiple `OverlappedTensor` views reference via `byte_offset`. For example, q_a_proj, q_b_proj, and kv_a_proj all point to the same fused buffer with different `byte_offset`, `tensor_shape`, `shard_shape`, etc.
+
+So we serialize **one `.tensorbin` per fusion group per layer**, not one per OverlappedTensor field. For 61 layers this gives:
+
+| Layer type | Fusion groups | Files per layer |
+|-----------|---------------|-----------------|
+| Dense (0–2) | q_ab_kv_a, o_proj_gate_mm_norms, kv_b12 | 3 |
+| MoE (3–60) | q_ab_kv_a, o_proj_gate_mm_norms, kv_b12, gate_up | 4 |
+
+Total: 3×3 + 58×4 = **241 `.tensorbin` files** + 241 sidecar `.json` files.
+
+### 11.4 Directory layout
+
+There is **no top-level manifest**. Each layer directory is fully independent and can be prepared, regenerated, or loaded in isolation. Each layer has a `manifest.json` with layer-level metadata and all fusion group field metadata, plus one `.tensorbin` per fusion group.
+
+```
+<weights_dir>/
+  layer_000/                            # dense layer — independently loadable
+    manifest.json                       # layer metadata + all field metadata
+    q_ab_kv_a.tensorbin
+    o_proj_gate_mm_norms.tensorbin
+    kv_b12.tensorbin
+  layer_001/
+    manifest.json
+    ...
+  layer_003/                            # MoE layer
+    manifest.json
+    q_ab_kv_a.tensorbin
+    o_proj_gate_mm_norms.tensorbin
+    kv_b12.tensorbin
+    gate_up.tensorbin                   # MoE only
+  ...
+  layer_060/
+    manifest.json
+    ...
+```
+
+**Why no top-level manifest:**
+- Each layer is fully independent — can be regenerated without touching other layers.
+- Parallel writes: different processes prepare different layers with no coordination.
+- Per-layer loading: pipeline parallelism loads only its layers by directory name.
+- No single point of failure; adding or replacing a layer is just replacing its directory.
+
+### 11.5 Per-layer manifest (`layer_NNN/manifest.json`)
+
+Each layer's manifest contains both global metadata (for validation and self-description) and all fusion group field metadata (for reconstructing OverlappedTensors).
+
+```json
+{
+  "version": 1,
+  "created_time": "2026-02-20T15:30:00Z",
+  "hf_model_name": "deepseek-ai/DeepSeek-V3",
+  "hf_state_dict_name": "model-00001-of-000XX.safetensors",
+  "device_mesh_shape": [4, 2],
+  "layer_idx": 0,
+  "layer_type": "dense",
+  "fusion_groups": {
+    "q_ab_kv_a": {
+      "tensorbin": "q_ab_kv_a.tensorbin",
+      "fields": {
+        "q_a_proj": {
+          "tensor_shape": [7168, 1536],
+          "shard_shape": [7168, 16],
+          "core_range_set": [[[0, 0], [11, 7]]],
+          "dtype": "BFLOAT8_B",
+          "tile_shape": [32, 32],
+          "byte_offset": 0
+        },
+        "q_b_proj": {
+          "tensor_shape": [1536, 24576],
+          "shard_shape": [1536, 256],
+          "core_range_set": [[[0, 0], [11, 7]]],
+          "dtype": "BFLOAT8_B",
+          "tile_shape": [32, 32],
+          "byte_offset": 57344
+        },
+        "kv_a_proj": {
+          "tensor_shape": [7168, 576],
+          "shard_shape": [7168, 72],
+          "core_range_set": [[[0, 0], [0, 7]]],
+          "dtype": "BFLOAT8_B",
+          "tile_shape": [32, 32],
+          "byte_offset": 0
+        }
+      }
+    },
+    "o_proj_gate_mm_norms": {
+      "tensorbin": "o_proj_gate_mm_norms.tensorbin",
+      "fields": {
+        "o_proj": { "..." : "..." },
+        "gate_mm": { "..." : "..." },
+        "attn_norm": { "..." : "..." },
+        "q_norm": { "..." : "..." },
+        "kv_norm": { "..." : "..." },
+        "ffn_norm": { "..." : "..." }
+      }
+    },
+    "kv_b12": {
+      "tensorbin": "kv_b12.tensorbin",
+      "fields": {
+        "kv_b1_proj": { "..." : "..." },
+        "kv_b2_proj": { "..." : "..." }
+      }
+    }
+  }
+}
+```
+
+MoE layers include an additional `"gate_up"` fusion group with `shared_gate_proj` and `shared_up_proj`.
+
+**Manifest fields:**
+
+| Field | Purpose |
+|-------|---------|
+| `version` | Schema version for forward compatibility. |
+| `created_time` | ISO-8601 timestamp of when this layer was prepared. |
+| `hf_model_name` | HF model identifier (e.g. `deepseek-ai/DeepSeek-V3`). |
+| `hf_state_dict_name` | Name/pattern of the HF checkpoint files used as input. |
+| `device_mesh_shape` | Mesh shape weights were prepared for (e.g. `[4, 2]`). |
+| `layer_idx` | Layer index in the model. |
+| `layer_type` | `"dense"` or `"moe"`. |
+| Per-field: `tensor_shape`, `shard_shape`, `core_range_set`, `dtype`, `tile_shape`, `byte_offset` | Everything needed to reconstruct an `OverlappedTensor` from its fused tensor. |
+
+### 11.6 API
+
+**Per-layer (primary):** Serialization is defined per layer. Use these for single-layer save/load, incremental or parallel preparation, and replacing one layer.
+
+```python
+def save_layer(
+    layer: DeepSeekV3LayerWeights,
+    path: str | Path,
+    layer_idx: int,
+    *,
+    hf_model_name: str,
+    hf_state_dict_name: str,
+    device_mesh_shape: tuple[int, int] = (1, 1),
+) -> None:
+    """Serialize one layer to <path>/layer_{layer_idx:03d}/."""
+
+def load_layer(
+    path: str | Path,
+    device,
+    layer_idx: int,
+) -> DeepSeekV3DenseLayerWeights | DeepSeekV3MoELayerWeights:
+    """Deserialize one layer from <path>/layer_{layer_idx:03d}/."""
+```
+
+**Full-model (convenience):** Thin wrappers for “save/load all layers”.
+
+```python
+def save_weights(weights, path, *, hf_model_name, hf_state_dict_name, device_mesh_shape=(1,1)) -> None:
+    """Loop over weights.layers and call save_layer for each."""
+
+def load_weights(path, device, num_layers: int = 61) -> DeepSeekV3Weights:
+    """Load layer_000/ .. layer_{num_layers-1}/ via load_layer; return DeepSeekV3Weights(layers=...)."""
+```
+
+Layer type (dense vs MoE) comes from each layer’s manifest; `load_weights` does not take `first_k_dense_replace`.
+
+### 11.7 Serialization algorithm (`save_layer`)
+
+1. Create `path` and `path/layer_{layer_idx:03d}/`.
+2. Collect all `OverlappedTensor` fields from the layer; group by `id(field.fused_tensor)`.
+3. For each unique fused tensor: determine group name, call `ttnn.dump_tensor(layer_dir / f"{group_name}.tensorbin", fused_tensor)`, record per-field metadata.
+4. Write `layer_dir / manifest.json` with layer metadata + all fusion group field metadata.
+
+`save_weights` is a loop: `for i, layer in enumerate(weights.layers): save_layer(layer, path, i, ...)`.
+
+### 11.8 Deserialization algorithm (`load_layer`)
+
+1. Read `{path}/layer_{layer_idx:03d}/manifest.json`. Validate version.
+2. For each fusion group: load fused tensor with `ttnn.load_tensor(..., device=device)`, reconstruct each field’s `OverlappedTensor` from metadata.
+3. Build and return one `DeepSeekV3DenseLayerWeights` or `DeepSeekV3MoELayerWeights` (from manifest `layer_type`).
+
+`load_weights` is: `layers = [load_layer(path, device, i) for i in range(num_layers)]`; return `DeepSeekV3Weights(layers=layers)`.
+
+### 11.9 core_range_set serialization
+
+`ttnn.CoreRangeSet` is serialized as a list of `[[start_x, start_y], [end_x, end_y]]` pairs. On deserialization, reconstruct via `ttnn.CoreRangeSet([ttnn.CoreRange(ttnn.CoreCoord(sx, sy), ttnn.CoreCoord(ex, ey)) for (sx, sy), (ex, ey) in ...])`.
+
+### 11.10 Compatibility and validation
+
+- **Mesh shape mismatch:** Each layer manifest contains `device_mesh_shape`. If it doesn't match the runtime device, the loader can raise an error.
+- **Version check:** Loader rejects manifests with `version` > supported.
+- **Independent regeneration:** To re-prepare a single layer, delete its `layer_NNN/` directory and call `save_layer(layer, path, idx, ...)` for that layer only.
+- **Per-layer loading:** Pipeline parallelism calls `load_layer(path, device, i)` only for its assigned layer indices.
+
+### 11.11 Testing
+
+**test_save_load_dense_layer_single_layer(device, tmp_path):**
+
+1. Build one dense layer with `prepare_weights` (synthetic state dict, per-device shapes).
+2. Call `save_layer(weights.layers[0], tmp_path, 0, hf_model_name=..., hf_state_dict_name=...)`.
+3. Verify on disk: `tmp_path/layer_000/manifest.json` and 3 `.tensorbin` files.
+4. Call `deallocate_weights(weights)` then `layer = load_layer(tmp_path, device, 0)`.
+5. Assert `isinstance(layer, DeepSeekV3DenseLayerWeights)` and that every OverlappedTensor field matches original (tensor_shape, shard_shape, dtype, tile_shape, byte_offset, core_range_set); same fusion group must share `id(fused_tensor)`.
+
+**test_save_load_moe_layer_single_layer(device, tmp_path):**
+
+Same pattern for one MoE layer: `save_layer` then `load_layer`; verify 4 tensorbins and `DeepSeekV3MoELayerWeights` with gate_mm, shared_gate_proj, shared_up_proj.
+
+Both tests use `tmp_path` and skip unless slow dispatch + grid >= 12×10 (MoE also requires ≥128 cores).
+
+### 11.12 End-to-end flow
+
+```
+[Offline / one-time]
+  HF checkpoint --> prepare_weights(state_dict, device) --> DeepSeekV3Weights
+                                                                  |
+                                                          save_weights(weights, path)
+                                                                  |
+                                                                  v
+                                              <weights_dir>/layer_NNN/manifest.json
+                                              <weights_dir>/layer_NNN/{group}.tensorbin
+
+[Runtime / every startup]
+  load_weights(path, device) --> DeepSeekV3Weights --> model forward pass
+```
+
+---
+
+## 12. Future Work / Open Points
 
 - **Integrate with DeepSeekV3:** Pass `DeepSeekV3Weights` into the model and wire OverlappedTensors to Pre-SDPA, Post-SDPA, MoE, shared expert ops.
 - **Real checkpoint test:** Implement `test_prepare_real_weights` with a real HF checkpoint; validate shapes and optionally numerical consistency.
@@ -190,8 +424,10 @@ Pipeline parallelism (layers split across devices) and further tensor parallelis
 
 ---
 
-## 12. Changelog
+## 13. Changelog
 
 - **Initial:** prepare_weights API, DeepSeekV3Weights / Dense / MoE types, state dict mapping, kv_b split, unit tests, placeholder for real weights.
 - **Multi-device / blitz sharding:** Documented flow: full HF tensors → prepare_weights (transform only) → blitz (shard to device/mesh). Removed TP expansion from prepare_weights; blitz does all sharding. Tests: single-device use per-device slice, 4×2 use full logical.
 - **Design doc refactor:** Cleaned stale “current blitz assumes” and “expand for TP” wording; centered doc on full HF → prepare_weights → blitz sharding; simplified §5 (one table for full logical, one for per-device after sharding), §6 (kv_b supports both 16384 and 32768), §8 (test descriptions), §9–§10 (sharding model and integration).
+
+- **Serialization / deserialization plan (§11):** Added design for `save_weights` / `load_weights`: one `.tensorbin` per fusion group per layer + `manifest.json` with OverlappedTensor metadata, enabling offline weight preparation and fast runtime loading.

--- a/models/demos/deepseek_v3_b1/DEEPSEEK_PREPARE_WEIGHTS_DESIGN_DOC.md
+++ b/models/demos/deepseek_v3_b1/DEEPSEEK_PREPARE_WEIGHTS_DESIGN_DOC.md
@@ -58,7 +58,7 @@ Design doc for the **prepare_weights** feature: building device-resident, fused 
 | File | Role |
 |------|------|
 | **prepare_weights.py** | Entry point and types. Defines `prepare_weights()`, `DeepSeekV3Weights`, `DeepSeekV3DenseLayerWeights`, `DeepSeekV3MoELayerWeights`, and helpers (`_key`, `_split_kv_b_proj`). Imports `BlitzDecodeWeights` and `OverlappedTensor` from `blitz_decode_weights`. |
-| **blitz_decode_weights.py** | Weight overlapping (fusion) implementation. Exposes `BlitzDecodeWeights` and configs; `get_tt_o_proj_and_gate_mm_weights(..., gate_mm_weights=None)` supports dense layers when `gate_mm_weights` is omitted. |
+| **blitz_decode_weights.py** | Weight overlapping (fusion) implementation (bliu/deepseek). Exposes `BlitzDecodeWeights` and configs; `get_tt_o_proj_and_gate_mm_weights(..., gate_mm_weights)` requires a tensor (dense layers pass a dummy zeros (7168, 256)); always returns six OverlappedTensors. |
 | **model.py** | Host I/O and prefill/decode orchestration. Intended to accept an optional `DeepSeekV3Weights` once the real decoder pipeline is wired; no weight loading in this doc’s scope. |
 | **tests/unit_tests/test_prepare_weights.py** | Unit tests: random-weight state dicts for one dense and one MoE layer, plus a skip-marked placeholder for real checkpoint tests. |
 
@@ -92,7 +92,7 @@ All weight fields are **OverlappedTensor** views (see `blitz_decode_weights.py`)
 | Fusion method | Outputs | Notes |
 |---------------|--------|--------|
 | `get_tt_q_ab_proj_and_kv_a_proj_weights` | q_a_proj, q_b_proj, kv_a_proj | WIDTH_SHARDED; q_a packed, q_b shuffled for Qnope/Qrope, kv_a shard-reordered. |
-| `get_tt_o_proj_and_gate_mm_weights` | o_proj, [gate_mm], attn_norm, q_norm, kv_norm, ffn_norm | gate_mm optional for dense; UINT32 raw container. |
+| `get_tt_o_proj_and_gate_mm_weights` | o_proj, gate_mm, attn_norm, q_norm, kv_norm, ffn_norm | gate_mm always required (dense layers pass dummy zeros); always six outputs; UINT32 raw container. |
 | `get_tt_kv_b12_proj_weights` | kv_b1_proj, kv_b2_proj | HEIGHT_SHARDED. |
 | `get_tt_gate_up_proj_weights` | shared_gate_proj, shared_up_proj | HEIGHT_SHARDED, block-sharded; MoE only. |
 
@@ -138,11 +138,11 @@ This aligns with `models/demos/deepseek_v3/tt/mla/mla1d.py` (wkv_b1 / wkv_b2) an
 
 ---
 
-## 7. Dense vs MoE and Optional gate_mm
+## 7. Dense vs MoE and gate_mm (bliu/deepseek)
 
-- **Dense layers** (`i < first_k_dense_replace`): No `mlp.gate` or `mlp.shared_experts.*`. We call `get_tt_o_proj_and_gate_mm_weights(o_proj, None, attn_norm, q_norm, kv_norm, ffn_norm)` so that the 8 gate_mm cores are omitted from the fused buffer; the returned list has 5 elements (no gate_mm OverlappedTensor). We do not call `get_tt_gate_up_proj_weights`.
+- **Dense layers** (`i < first_k_dense_replace`): No `mlp.gate` or `mlp.shared_experts.*` in the state dict. We create a **dummy** gate_mm tensor `torch.zeros(7168, 256, dtype=torch.bfloat16, device=...)` and call `get_tt_o_proj_and_gate_mm_weights(o_proj, gate_mm_dummy, attn_norm, q_norm, kv_norm, ffn_norm)`. The method always returns six OverlappedTensors; we unpack all six and build `DeepSeekV3DenseLayerWeights` using only `o_proj_ot`, `attn_norm_ot`, `q_norm_ot`, `kv_norm_ot`, `ffn_norm_ot` (we ignore `gate_mm_ot`). We do not call `get_tt_gate_up_proj_weights`.
 
-- **MoE layers** (`i >= first_k_dense_replace`): We pass `gate_mm` and call `get_tt_gate_up_proj_weights(shared_gate, shared_up)`; the layer is stored as `DeepSeekV3MoELayerWeights` with all fields populated.
+- **MoE layers** (`i >= first_k_dense_replace`): We pass the real `gate_mm` from the state dict and call `get_tt_gate_up_proj_weights(shared_gate, shared_up)`; the layer is stored as `DeepSeekV3MoELayerWeights` with all fields populated.
 
 ---
 
@@ -217,37 +217,33 @@ What is **not** supported today:
 
 ---
 
-## 10. Adapting prepare_weights to branch `bliu/deepseek`
+## 10. Integration with bliu/deepseek (current)
 
-On branch **bliu/deepseek**, `BlitzDecodeWeights` adds **tensor parallelism (TP)** and renames configs. Below is what must change in **prepare_weights.py** when that branch is used.
+**prepare_weights** is integrated with the **bliu/deepseek** blitz decode path. `BlitzDecodeWeights` uses tensor parallelism (TP) and single-device overlap specs; prepare_weights passes full-model shapes and uses a dummy gate_mm for dense layers.
 
-### 10.1 HF state dict is unchanged; TP/DP are TTNN placement only
+### 10.1 HF state dict; TP/DP are TTNN placement only
 
-The HuggingFace state dict and checkpoint stay the same regardless of TP/DP. We always load **full-model** weights (e.g. q_b (1536, 12288), o_proj (8192, 7168), etc.). The **TP/DP factors** (e.g. mla_tp=2, moe_tp=8 on a 4×2 mesh) refer to how the **TTNN tensors** (the fused device buffers) are **sharded across the decoder mesh** — i.e. a runtime/placement concern, not a different checkpoint layout. So **prepare_weights** always passes the same shapes to blitz (the full-model shapes derived from the HF state dict). BlitzDecodeWeights is responsible for slicing/sharding those full-model tensors and placing them on the mesh when the device is multi-device.
+The HuggingFace state dict and checkpoint are unchanged. We always load **full-model** weights (e.g. q_b (1536, 12288), o_proj (8192, 7168), etc.). The **TP/DP factors** (e.g. mla_tp=2, moe_tp=8 on a 4×2 mesh) refer to how the **TTNN tensors** (the fused device buffers) are **sharded across the decoder mesh** — a runtime/placement concern. **prepare_weights** always passes the same full-model shapes to blitz; BlitzDecodeWeights is responsible for slicing/sharding and placement when the device is multi-device.
 
-### 10.2 Branch changes in blitz_decode_weights.py
+### 10.2 blitz_decode_weights.py (bliu/deepseek)
 
-- **Config renames:** `QAB_KVA_PROJ_OverlapConfig` → `QAB_KVA_PROJ_SingleDeviceOverlapSpec`, and similarly for the other three (constants use `*_SINGLE_DEVICE_OVERLAP_SPEC`). Logic is equivalent; only names differ.
-- **BlitzDecodeWeights.__init__:** Sets `self.mla_tp` and `self.moe_tp` from the device (single device → 1/1; 4×2 mesh → 2/8). These drive how the **output** TTNN tensors are sharded (e.g. `ShardTensor2dMesh`), not the **input** shapes from the caller.
-- **Intended input shapes (full-model from HF):** Callers (e.g. prepare_weights) always pass **full-model** weights: q_b (1536, 12288), o_proj (8192, 7168), kv_b1 (8192, 512), kv_b2 (512, 8192), gate/up (7168, 256). When the device is a mesh, blitz should **accept these same shapes**, slice them per TP index internally, and produce the sharded mesh tensor. (Note: the current branch code may still expect TP-concatenated shapes like (1536, 12288×mla_tp); aligning with “HF stays the same” would mean changing blitz to accept (1536, 12288) and do the slicing inside.)
-- **Dense layers:** On the branch, `get_tt_o_proj_and_gate_mm_weights` **requires** `gate_mm_weights` (no `None`). So either the branch adds optional `gate_mm` for dense, or prepare_weights passes a dummy (e.g. zeros) of shape (7168, 256) for dense layers.
-- **GATE_UP:** `GATE_UP_PROJ_SingleDeviceOverlapSpec` uses different core range groupings and `reshuffle_block_to_height_sharded(weights, core_range_set)`; no change to prepare_weights call signature for gate/up.
+- **Config names:** Overlap configs use `*_SINGLE_DEVICE_OVERLAP_SPEC` (e.g. `QAB_KVA_PROJ_SingleDeviceOverlapSpec`, `O_PROJ_GATE_MM_RMSNORM_GAMMA_SINGLE_DEVICE_OVERLAP_SPEC`).
+- **BlitzDecodeWeights:** Sets `self.mla_tp` and `self.moe_tp` from the device; these drive how **output** TTNN tensors are sharded, not the **input** shapes from the caller.
+- **Input shapes:** prepare_weights passes **full-model** weights (e.g. o_proj (8192, 7168) for single-device; for TP, blitz expects (8192×mla_tp, 7168) per its config). Gate_mm is (7168, 256).
+- **gate_mm required:** `get_tt_o_proj_and_gate_mm_weights(..., gate_mm_weights)` takes a **required** `torch.Tensor` (no `None`). It always returns six OverlappedTensors: o_proj, gate_mm, attn_norm, q_norm, kv_norm, ffn_norm.
+- **GATE_UP:** `get_tt_gate_up_proj_weights(shared_gate, shared_up)` unchanged from prepare_weights' perspective.
 
-### 10.3 Required changes in prepare_weights.py
+### 10.3 prepare_weights.py behavior
 
-Because **HF stays the same** and TP/DP only affect how TTNN tensors are sharded on the mesh, prepare_weights continues to load the same state dict and pass **the same full-model shapes** to BlitzDecodeWeights for both single-device and 4×2 mesh:
-
-- **No TP-concatenation in prepare_weights.** We do not build (1536, 12288×mla_tp) or (7168, 256×moe_tp); we always pass (1536, 12288), (7168, 256), etc. from the HF state dict (after transpose/split as today). Blitz is responsible for sharding those full-model tensors across the mesh when the device is multi-device.
-
-- **Dense layers and gate_mm:** If the branch does not support `gate_mm_weights=None`, then for dense layers either add optional `gate_mm` on the branch, or in prepare_weights pass a zero tensor of shape (7168, 256) when `i < first_k_dense_replace`.
-
-- **Branch blitz alignment:** If the current branch API still expects TP-concatenated input shapes (e.g. q_b (1536, 12288×mla_tp)), then the branch should be updated to accept full-model shapes and perform the TP slicing internally, so that prepare_weights can remain agnostic of mla_tp/moe_tp and always pass HF-derived shapes.
+- **Full-model shapes:** No TP-concatenation in prepare_weights; we pass HF-derived shapes (after transpose/split). Blitz handles per-TP slicing when the device is a mesh.
+- **Dense layers:** For `i < first_k_dense_replace` we pass a **dummy** gate_mm: `torch.zeros(7168, 256, dtype=torch.bfloat16, device=...)`. We unpack all six elements from `get_tt_o_proj_and_gate_mm_weights` and ignore `gate_mm_ot` when building `DeepSeekV3DenseLayerWeights`.
+- **MoE layers:** We pass the real `gate_mm` from the state dict and unpack the same six elements; all six are used in `DeepSeekV3MoELayerWeights`.
 
 ### 10.4 Summary
 
 - **HF state dict:** Unchanged; single full-model checkpoint.
-- **prepare_weights:** Always passes full-model shapes (same as today); no mesh- or TP-specific logic.
-- **BlitzDecodeWeights:** Uses mla_tp/moe_tp to shard the **output** TTNN tensors across the 4×2 decoder mesh; should accept the **same** full-model input shapes and do any per-TP slicing internally.
+- **prepare_weights:** Passes full-model shapes; dense layers use a dummy (7168, 256) gate_mm and ignore the gate_mm OverlappedTensor in the dense layer container.
+- **BlitzDecodeWeights (bliu/deepseek):** Requires gate_mm; always returns six sub-tensors from `get_tt_o_proj_and_gate_mm_weights`; uses mla_tp/moe_tp for output sharding on the mesh.
 
 ---
 
@@ -265,3 +261,4 @@ Because **HF stays the same** and TP/DP only affect how TTNN tensors are sharded
 - **Initial:** Added prepare_weights API, DeepSeekV3Weights / Dense / MoE types, state dict mapping, kv_b split, optional gate_mm in blitz_decode_weights, and unit tests with random weights plus placeholder for real weights.
 - **Multi-device / full pipeline:** Added §9 (Multi-device and full-pipeline extension): current single-device assumption, MeshDevice + replication behavior, and required extensions for pipeline parallelism, tensor parallelism, and full decoder weight coverage.
 - **bliu/deepseek branch:** Added §10 (Adapting prepare_weights to branch bliu/deepseek): TP-aware shapes, mla_tp/moe_tp, and required prepare_weights.py changes for single-device vs 4×2 mesh.
+- **bliu/deepseek integrated:** prepare_weights now targets bliu/deepseek blitz path. gate_mm is required in `get_tt_o_proj_and_gate_mm_weights`; dense layers pass a dummy zeros (7168, 256) and unpack six elements (gate_mm_ot ignored for DenseLayerWeights). §3, §4.2, §7, and §10 updated to describe current behavior.

--- a/models/demos/deepseek_v3_b1/DEEPSEEK_PREPARE_WEIGHTS_DESIGN_DOC.md
+++ b/models/demos/deepseek_v3_b1/DEEPSEEK_PREPARE_WEIGHTS_DESIGN_DOC.md
@@ -1,21 +1,16 @@
 # DeepSeek V3 Prepare Weights — Design Document
 
-Design doc for the **prepare_weights** feature: building device-resident, fused (blitz decode) weights from a HuggingFace-style state dict. Update this doc as the feature evolves.
+Design doc for the **prepare_weights** feature: building device-resident, fused (blitz decode) weights from a HuggingFace-style state dict. The intended flow is: **load full HF tensors → prepare_weights (key mapping, transpose, split) → blitz_decode_weights (shard onto single device or across mesh)**. Update this doc as the feature evolves.
 
 ---
 
 ## 1. Motivation
 
-- **Decouple weight preparation from the model class.** The host-side `DeepSeekV3` class in `model.py` handles H2D/D2H sockets and prefill/decode orchestration. Weight loading and fusion should live in a separate, reusable path so that:
-  - We can load and fuse weights once (e.g., at startup or from a checkpoint) and pass a single `DeepSeekV3Weights` object into the model.
-  - The same pipeline can be tested with synthetic state dicts or real checkpoints without tying either to the socket I/O layer.
+- **Decouple weight preparation from the model class.** Weight loading and fusion live in a separate, reusable path so we can load and fuse once (e.g. at startup) and pass a single `DeepSeekV3Weights` into the model, and test with synthetic or real checkpoints without tying to socket I/O.
 
-- **Reuse the blitz decode fusion pipeline.** `blitz_decode_weights.py` already fuses multiple weight tensors into shared L1 buffers (weight overlapping) to reduce fragmentation and buffer count. We want a single entry point that:
-  - Takes a standard state dict (e.g., from HuggingFace).
-  - Applies the correct key mapping, transposes, and any splits (e.g., `kv_b_proj` → `kv_b1` / `kv_b2`).
-  - Calls `BlitzDecodeWeights` for every layer and returns a typed container (`DeepSeekV3Weights`) that the rest of the stack can consume.
+- **Single pipeline from full HF to sharded device weights.** We take **full HuggingFace state dict tensors** (logical model shapes), run **prepare_weights** for key mapping, transposes, and splits (e.g. `kv_b_proj` → `kv_b1` / `kv_b2`), then **blitz_decode_weights** fuses and **shards** them onto the target device(s). On a single device, blitz produces one shard per layer; on a mesh (e.g. 4×2), blitz shards across the mesh (MLA-TP along 2, MoE shared TP=8, etc.). No expansion or pre-slicing in prepare_weights for mesh—blitz does all sharding.
 
-- **Support both dense and MoE layers.** DeepSeek V3 has 61 layers: the first 3 are dense (standard MLP), the remaining 58 are MoE (routing gate + shared expert + routed experts). The prepared type is a union so call sites can use `isinstance(layer, DeepSeekV3MoELayerWeights)` and access `gate_mm`, `shared_gate_proj`, `shared_up_proj` only when present.
+- **Support both dense and MoE layers.** DeepSeek V3 has 61 layers: first 3 dense, remaining 58 MoE. The prepared type is a union so call sites can use `isinstance(layer, DeepSeekV3MoELayerWeights)` and access MoE-only fields when present.
 
 ---
 
@@ -23,17 +18,26 @@ Design doc for the **prepare_weights** feature: building device-resident, fused 
 
 ```
 ┌─────────────────────────────────────────────────────────────────────────┐
-│  state_dict (HF convention)                                              │
+│  state_dict (HF convention, full logical shapes)                        │
 │  model.layers.{i}.self_attn.*, model.layers.{i}.mlp.*, ...              │
+│  e.g. q_b (24576, 1536), o_proj (7168, 16384), kv_b (32768, 512), ...   │
 └─────────────────────────────────────────────────────────────────────────┘
                                       │
                                       ▼
 ┌─────────────────────────────────────────────────────────────────────────┐
-│  prepare_weights(state_dict, device, num_layers=61,                     │
-│                   first_k_dense_replace=3)                               │
-│  - Key mapping & transpose (HF → blitz K,N convention)                   │
-│  - _split_kv_b_proj(kv_b_proj) → kv_b1, kv_b2                            │
-│  - Per layer: BlitzDecodeWeights.get_tt_*() fusion calls                 │
+│  prepare_weights(state_dict, device, num_layers, first_k_dense_replace)  │
+│  • Key mapping & transpose (HF → blitz K,N convention)                   │
+│  • _split_kv_b_proj(kv_b_proj) → kv_b1, kv_b2                            │
+│  • No expansion: pass full logical tensors through                       │
+└─────────────────────────────────────────────────────────────────────────┘
+                                      │
+                                      ▼
+┌─────────────────────────────────────────────────────────────────────────┐
+│  BlitzDecodeWeights(device)                                              │
+│  • Fuses groups into shared L1 (q_ab+kv_a, o_proj+gate_mm+norms,          │
+│    kv_b1+kv_b2, shared gate/up)                                          │
+│  • Shards full logical tensors: single device = one shard;               │
+│    mesh (e.g. 4×2) = MLA-TP=2, MoE shared TP=8, etc.                     │
 └─────────────────────────────────────────────────────────────────────────┘
                                       │
                                       ▼
@@ -41,13 +45,6 @@ Design doc for the **prepare_weights** feature: building device-resident, fused 
 │  DeepSeekV3Weights                                                       │
 │  .layers: list[DeepSeekV3DenseLayerWeights | DeepSeekV3MoELayerWeights]  │
 │  Each layer holds OverlappedTensor views into fused device buffers.      │
-└─────────────────────────────────────────────────────────────────────────┘
-                                      │
-                                      ▼
-┌─────────────────────────────────────────────────────────────────────────┐
-│  DeepSeekV3(..., weights: DeepSeekV3Weights)  [future]                   │
-│  Fused ops (Pre-SDPA, Post-SDPA, MoE, …) read from OverlappedTensors    │
-│  via fused_tensor + byte_offset + core_range_set.                        │
 └─────────────────────────────────────────────────────────────────────────┘
 ```
 
@@ -57,10 +54,10 @@ Design doc for the **prepare_weights** feature: building device-resident, fused 
 
 | File | Role |
 |------|------|
-| **prepare_weights.py** | Entry point and types. Defines `prepare_weights()`, `DeepSeekV3Weights`, `DeepSeekV3DenseLayerWeights`, `DeepSeekV3MoELayerWeights`, and helpers (`_key`, `_split_kv_b_proj`). Imports `BlitzDecodeWeights` and `OverlappedTensor` from `blitz_decode_weights`. |
-| **blitz_decode_weights.py** | Weight overlapping (fusion) implementation (bliu/deepseek). Exposes `BlitzDecodeWeights` and configs; `get_tt_o_proj_and_gate_mm_weights(..., gate_mm_weights)` requires a tensor (dense layers pass a dummy zeros (7168, 256)); always returns six OverlappedTensors. |
-| **model.py** | Host I/O and prefill/decode orchestration. Intended to accept an optional `DeepSeekV3Weights` once the real decoder pipeline is wired; no weight loading in this doc’s scope. |
-| **tests/unit_tests/test_prepare_weights.py** | Unit tests: random-weight state dicts for one dense and one MoE layer, plus a skip-marked placeholder for real checkpoint tests. |
+| **prepare_weights.py** | Entry point and types. `prepare_weights()` takes a state dict and device; does key mapping, transpose, and `_split_kv_b_proj`; calls `BlitzDecodeWeights` per layer. No TP expansion—caller passes full logical (mesh) or per-device slice (single-device tests). Defines `DeepSeekV3Weights`, `DeepSeekV3DenseLayerWeights`, `DeepSeekV3MoELayerWeights`. |
+| **blitz_decode_weights.py** | Weight fusion and **sharding**. Fuses weight groups into shared L1; when device is a mesh, shards full logical tensors across the mesh (mla_tp, moe_tp). Exposes `BlitzDecodeWeights`, `OverlappedTensor`; `get_tt_o_proj_and_gate_mm_weights` requires a gate_mm tensor (dense layers pass dummy zeros). |
+| **model.py** | Host I/O and prefill/decode orchestration; intended to accept optional `DeepSeekV3Weights`. |
+| **tests/unit_tests/test_prepare_weights.py** | Unit tests: synthetic state dicts with **full logical HF shapes** for 4×2 mesh tests, and **per-device slice shapes** for single-device tests; verifies prepare_weights + blitz produce correct types and shapes. |
 
 ---
 
@@ -68,197 +65,133 @@ Design doc for the **prepare_weights** feature: building device-resident, fused 
 
 ### 4.1 Layer weight containers
 
-- **DeepSeekV3DenseLayerWeights**  
-  Used for layers `0 .. first_k_dense_replace - 1`. Contains:
-  - Attention: `q_a_proj`, `q_b_proj`, `kv_a_proj`, `kv_b1_proj`, `kv_b2_proj`
-  - Output + norms: `o_proj`, `attn_norm`, `q_norm`, `kv_norm`, `ffn_norm`  
-  No `gate_mm` or shared expert (dense layers use a standard MLP, not MoE).
+- **DeepSeekV3DenseLayerWeights** — Layers `0 .. first_k_dense_replace - 1`. Attention: `q_a_proj`, `q_b_proj`, `kv_a_proj`, `kv_b1_proj`, `kv_b2_proj`; output + norms: `o_proj`, `attn_norm`, `q_norm`, `kv_norm`, `ffn_norm`. No gate_mm or shared expert.
 
-- **DeepSeekV3MoELayerWeights**  
-  Used for layers `first_k_dense_replace .. num_layers - 1`. Same as dense plus:
-  - `gate_mm` (routing gate)
-  - `shared_gate_proj`, `shared_up_proj` (shared expert gate/up)
+- **DeepSeekV3MoELayerWeights** — Layers `first_k_dense_replace .. num_layers - 1`. Same as dense plus `gate_mm`, `shared_gate_proj`, `shared_up_proj`.
 
-- **DeepSeekV3LayerWeights**  
-  Type alias: `DeepSeekV3DenseLayerWeights | DeepSeekV3MoELayerWeights`.
+- **DeepSeekV3Weights** — `layers: list[DeepSeekV3LayerWeights]` where `DeepSeekV3LayerWeights = DeepSeekV3DenseLayerWeights | DeepSeekV3MoELayerWeights`.
 
-- **DeepSeekV3Weights**  
-  Top-level container: `layers: list[DeepSeekV3LayerWeights]`.
-
-All weight fields are **OverlappedTensor** views (see `blitz_decode_weights.py`): they reference a shared `fused_tensor` and carry `tensor_shape`, `shard_shape`, `core_range_set`, `dtype`, `tile_shape`, and `byte_offset` so kernels can address each sub-weight inside the fused L1 buffer.
+All weight fields are **OverlappedTensor** views (see blitz_decode_weights): `tensor_shape`, `shard_shape`, `core_range_set`, `dtype`, `tile_shape`, `byte_offset` into a shared fused L1 buffer.
 
 ### 4.2 Blitz fusion groups (reference)
 
 | Fusion method | Outputs | Notes |
 |---------------|--------|--------|
-| `get_tt_q_ab_proj_and_kv_a_proj_weights` | q_a_proj, q_b_proj, kv_a_proj | WIDTH_SHARDED; q_a packed, q_b shuffled for Qnope/Qrope, kv_a shard-reordered. |
-| `get_tt_o_proj_and_gate_mm_weights` | o_proj, gate_mm, attn_norm, q_norm, kv_norm, ffn_norm | gate_mm always required (dense layers pass dummy zeros); always six outputs; UINT32 raw container. |
+| `get_tt_q_ab_proj_and_kv_a_proj_weights` | q_a_proj, q_b_proj, kv_a_proj | WIDTH_SHARDED; q_b shuffled for Qnope/Qrope. |
+| `get_tt_o_proj_and_gate_mm_weights` | o_proj, gate_mm, attn_norm, q_norm, kv_norm, ffn_norm | gate_mm required (dense: dummy zeros); six outputs. |
 | `get_tt_kv_b12_proj_weights` | kv_b1_proj, kv_b2_proj | HEIGHT_SHARDED. |
-| `get_tt_gate_up_proj_weights` | shared_gate_proj, shared_up_proj | HEIGHT_SHARDED, block-sharded; MoE only. |
+| `get_tt_gate_up_proj_weights` | shared_gate_proj, shared_up_proj | HEIGHT_SHARDED; MoE only. |
 
 ---
 
-## 5. State Dict Convention and Transformations
+## 5. State Dict Convention and Sharding Model
 
-We assume keys under `model.layers.{layer_idx}.` as follows. Linear weights are stored in HF as `(out_features, in_features)`; we transpose to `(K, N)` for blitz.
+**Design principle:** We load **full HuggingFace tensors** (logical model shapes). **prepare_weights** only transforms (transpose, split); it does not expand or slice for TP. **blitz_decode_weights** receives full logical shapes and **shards** them onto one device or across the mesh.
 
-| Blitz / prepare_weights | HF state_dict key (under `model.layers.{i}.`) | Shape (HF) | Transform |
-|------------------------|------------------------------------------------|------------|-----------|
-| q_a_proj               | self_attn.q_a_proj.weight                      | (1536, 7168) | .T → (7168, 1536) |
-| q_b_proj               | self_attn.q_b_proj.weight                      | (12288, 1536) | .T → (1536, 12288) |
-| kv_a_proj              | self_attn.kv_a_proj_with_mqa.weight            | (576, 7168)  | .T → (7168, 576) |
-| kv_b1, kv_b2           | self_attn.kv_b_proj.weight                     | (16384, 512) | See §6; **kv_b1 not transposed**, kv_b2 transposed |
-| o_proj                 | self_attn.o_proj.weight                        | (7168, 8192) | .T → (8192, 7168) |
-| gate_mm                | mlp.gate.weight                                | (256, 7168)  | .T → (7168, 256); MoE only |
-| attn_norm              | input_layernorm.weight                         | (7168,)      | unsqueeze(0) → (1, 7168) |
-| q_norm                 | self_attn.q_a_layernorm.weight                  | (1536,)      | unsqueeze(0) → (1, 1536) |
-| kv_norm                | self_attn.kv_a_layernorm.weight                 | (512,)       | unsqueeze(0) → (1, 512) |
-| ffn_norm               | post_attention_layernorm.weight                 | (7168,)      | unsqueeze(0) → (1, 7168) |
-| shared_gate_proj       | mlp.shared_experts.gate_proj.weight             | (256, 7168)  | .T → (7168, 256); MoE only |
-| shared_up_proj         | mlp.shared_experts.up_proj.weight               | (256, 7168)  | .T → (7168, 256); MoE only |
+### 5.1 HF shapes (full logical)
+
+Real HuggingFace checkpoints use these **full logical** shapes (one row per weight). Linear weights are `(out_features, in_features)`.
+
+| Weight | HF key (under `model.layers.{i}.`) | HF shape (full logical) | After prepare_weights (.T / split) |
+|--------|-------------------------------------|--------------------------|------------------------------------|
+| q_a_proj | self_attn.q_a_proj.weight | (1536, 7168) | (7168, 1536) |
+| q_b_proj | self_attn.q_b_proj.weight | **(24576, 1536)** | (1536, 24576) |
+| kv_a_proj | self_attn.kv_a_proj_with_mqa.weight | (576, 7168) | (7168, 576) |
+| kv_b_proj | self_attn.kv_b_proj.weight | **(32768, 512)** | split → kv_b1 (16384, 512), kv_b2 (512, 16384) |
+| o_proj | self_attn.o_proj.weight | **(7168, 16384)** | (16384, 7168) |
+| gate_mm | mlp.gate.weight | (256, 7168) | (7168, 256); MoE only |
+| attn_norm | input_layernorm.weight | (7168,) | (1, 7168) |
+| q_norm | self_attn.q_a_layernorm.weight | (1536,) | (1, 1536) |
+| kv_norm | self_attn.kv_a_layernorm.weight | (512,) | (1, 512) |
+| ffn_norm | post_attention_layernorm.weight | (7168,) | (1, 7168) |
+| shared_gate_proj | mlp.shared_experts.gate_proj.weight | **(2048, 7168)** | (7168, 2048); MoE only |
+| shared_up_proj | mlp.shared_experts.up_proj.weight | **(2048, 7168)** | (7168, 2048); MoE only |
+
+### 5.2 Who shards what
+
+- **Single device:** Caller may pass either (a) full logical state dict, or (b) a **per-device slice** (e.g. q_b (12288, 1536), o_proj (7168, 8192), kv_b (16384, 512), shared (256, 7168)) for testing. blitz then places that single shard on the device. Tests use (b) for single-device and (a) for 4×2.
+- **Mesh (e.g. 4×2):** Caller passes **full logical** state dict. prepare_weights passes it through unchanged (after transpose/split). blitz_decode_weights shards: MLA-TP=2 (q_b, o_proj, kv_b1, kv_b2), MoE shared TP=8 (shared_gate_proj, shared_up_proj), rest replicated.
+
+So: **full HF tensors → prepare_weights (transform only) → blitz (shard to device/mesh).**
+
+### 5.3 Per-device logical shapes (after blitz sharding, 4×2)
+
+| Weight | Full logical (post prepare_weights) | Per-device logical (4×2, MLA-TP=2, MoE-TP=8) |
+|--------|--------------------------------------|-----------------------------------------------|
+| q_b_proj | (1536, 24576) | (1536, 12288) per device |
+| o_proj | (16384, 7168) | (8192, 7168) per device |
+| kv_b1_proj | (16384, 512) | (8192, 512) per device |
+| kv_b2_proj | (512, 16384) | (512, 8192) per device |
+| shared_gate_proj / shared_up_proj | (7168, 2048) | (7168, 256) per device |
+| q_a_proj, kv_a_proj, gate_mm, norms | — | Replicated (full shape per device) |
 
 ---
 
 ## 6. kv_b_proj Split
 
-HuggingFace stores a single `kv_b_proj`; the blitz pipeline expects two matrices. **All linear weights are transposed for blitz except kv_b1.**
+HF stores one `kv_b_proj`; blitz expects two matrices. **prepare_weights** splits via `_split_kv_b_proj`.
 
-- **kv_b1_proj:** (8192, 512) — 64 heads × 128 (qk_nope head dim), HEIGHT_SHARDED on the Qnope grid. **Not transposed**: use HF slice as (8192, 512).
-- **kv_b2_proj:** (512, 8192) — 64 heads × 128 (v head dim); **transposed** from HF (8192, 512) to (512, 8192). Blitz then reshapes for HEIGHT_SHARDED placement.
+- **Supported HF shapes:** (16384, 512) per-device and (32768, 512) full logical. `out_features = num_heads * 256` (256 = qk_nope_head_dim + v_head_dim).
+- **Algorithm:** `num_heads = out_features // 256`; reshape to `(num_heads, 256, 512)`; first 128 dims → kv_b1 (no transpose); last 128 → reshape then `.T` → kv_b2.
+- **Result:** (16384, 512) → kv_b1 (8192, 512), kv_b2 (512, 8192); (32768, 512) → kv_b1 (16384, 512), kv_b2 (512, 16384).
 
-Constants: `num_heads=64`, `qk_nope_head_dim=128`, `v_head_dim=128`, `kv_lora_rank=512`, so HF shape is `(num_heads * 256, 512) = (16384, 512)`.
-
-**Algorithm (`_split_kv_b_proj`):**
-
-1. Reshape (16384, 512) to (64, 256, 512) — (num_heads, head_dim, kv_lora_rank).
-2. kv_b1: slice `[:, :128, :]` → (64, 128, 512); reshape to (8192, 512). **No transpose.**
-3. kv_b2: slice `[:, 128:, :]` → (64, 128, 512); reshape to (8192, 512); then `.T` → (512, 8192).
-
-This aligns with `models/demos/deepseek_v3/tt/mla/mla1d.py` (wkv_b1 / wkv_b2) and keeps b1 in (out, in) and b2 in (K, N) for blitz.
+Constants: `qk_nope_head_dim=128`, `v_head_dim=128`, `kv_lora_rank=512`.
 
 ---
 
-## 7. Dense vs MoE and gate_mm (bliu/deepseek)
+## 7. Dense vs MoE and gate_mm
 
-- **Dense layers** (`i < first_k_dense_replace`): No `mlp.gate` or `mlp.shared_experts.*` in the state dict. We create a **dummy** gate_mm tensor `torch.zeros(7168, 256, dtype=torch.bfloat16, device=...)` and call `get_tt_o_proj_and_gate_mm_weights(o_proj, gate_mm_dummy, attn_norm, q_norm, kv_norm, ffn_norm)`. The method always returns six OverlappedTensors; we unpack all six and build `DeepSeekV3DenseLayerWeights` using only `o_proj_ot`, `attn_norm_ot`, `q_norm_ot`, `kv_norm_ot`, `ffn_norm_ot` (we ignore `gate_mm_ot`). We do not call `get_tt_gate_up_proj_weights`.
+- **Dense layers** (`i < first_k_dense_replace`): No `mlp.gate` or `mlp.shared_experts.*` in the state dict. We pass a **dummy** gate_mm `torch.zeros(7168, 256, dtype=torch.bfloat16, device=...)` to `get_tt_o_proj_and_gate_mm_weights` and ignore the returned gate_mm OverlappedTensor when building `DeepSeekV3DenseLayerWeights`. We do not call `get_tt_gate_up_proj_weights`.
 
-- **MoE layers** (`i >= first_k_dense_replace`): We pass the real `gate_mm` from the state dict and call `get_tt_gate_up_proj_weights(shared_gate, shared_up)`; the layer is stored as `DeepSeekV3MoELayerWeights` with all fields populated.
+- **MoE layers** (`i >= first_k_dense_replace`): Real `gate_mm` and `shared_gate_proj` / `shared_up_proj` from the state dict; all six o_proj+gate_mm+norms and both shared expert OverlappedTensors are stored in `DeepSeekV3MoELayerWeights`.
 
 ---
 
 ## 8. Testing
 
-- **test_prepare_dense_layer(device)**  
-  Builds a synthetic state dict for a single dense layer (random bfloat16), calls `prepare_weights(..., num_layers=1, first_k_dense_replace=1)`, and asserts type and `tensor_shape` for all fields. Skips if device grid is smaller than 12×10.
+- **test_prepare_dense_layer_single_layer(device)** — Synthetic state dict with **per-device** shapes (e.g. q_b (12288, 1536), o_proj (7168, 8192)); one dense layer; asserts type and tensor_shape. Skips if not slow dispatch or grid < 12×10.
 
-- **test_prepare_moe_layer(device)**  
-  Same idea for two layers (one dense, one MoE); asserts the second layer is `DeepSeekV3MoELayerWeights` and checks shapes including `gate_mm`, `shared_gate_proj`, `shared_up_proj`.
+- **test_prepare_moe_layer_single_layer(device)** — Same for one MoE layer (per-device shapes); asserts MoE fields and shared_gate_proj / shared_up_proj tensor_shape (7168, 256). Skips as above and if grid would require >120 compute banks for GATE_UP.
 
-- **test_prepare_real_weights(device)**  
-  Placeholder: `@pytest.mark.skip` with a note that real checkpoint testing will be added later.
+- **test_prepare_dense_layer_single_layer_4x2(bh_2d_mesh_device)** — **Full logical** state dict (q_b (24576, 1536), o_proj (7168, 16384), kv_b (32768, 512)); 4×2 mesh; one dense layer. Verifies prepare_weights + blitz shard correctly.
 
----
+- **test_prepare_moe_layer_single_layer_4x2(bh_2d_mesh_device)** — Full logical state dict including shared (2048, 7168); one MoE layer on 4×2. Same sharding checks.
 
-## 9. Multi-device and full-pipeline extension (blitz_decode_weights)
-
-The current blitz decode weights path is built around a **single logical device** (one chip). The full decoder pipeline (Pre-SDPA, Flash MLA, Post-SDPA, MoE, etc.) is written to run on a **MeshDevice**: fused ops take mesh tensors and use `ttnn.get_device_tensors(...)` to get one tensor per device, then launch per-device work with CCL for cross-device sync. To support that pipeline end-to-end, blitz_decode_weights will need to be extended as follows.
-
-### 9.1 Current behavior (single device)
-
-- **BlitzDecodeWeights** takes a single `device` and stores it as `self._device`.
-- **Grid validation** uses `self._device.compute_with_storage_grid_size()` and asserts the grid is at least as large as the core ranges in each overlap config (e.g. 12×10 for q_ab + kv_a). This is the **per-device** grid.
-- **Placement** uses `ttnn.from_torch(..., device=self._device, mesh_mapper=ttnn.ReplicateTensorToMesh(self._device))`. So:
-  - If `device` is a **single Device**: one fused tensor is created on that device; core ranges (0,0)–(11,7), etc. are that device’s logical cores.
-  - If `device` is a **MeshDevice**: `ReplicateTensorToMesh` replicates the same tensor to **every** device in the mesh. Each device gets the same logical core layout and the same weight data. Fused ops that call `get_device_tensors(weight_mesh)` then get one weight tensor per device, which is what they use today (e.g. `matmul_weights_tensors_per_device[device_idx]`). So **replicated** weights on a mesh already match how the fused ops consume weights.
-
-So today:
-
-- **Single device:** fully supported; all fusion groups live on that device.
-- **Mesh with replication:** supported in principle (pass a MeshDevice; each chip gets a full copy of the fused weights). Not yet exercised in tests; grid validation is still per-device and must hold on every device in the mesh.
-
-What is **not** supported today:
-
-- **Pipeline parallelism:** each device only holds weights for “its” layers (e.g. device 0: layers 0–15, device 1: layers 16–31). That would require preparing weights per stage and using a mesh mapper (or separate calls) so each device only gets the tensors for its layer range, instead of replicating the full model.
-- **Tensor parallelism:** sharding a single layer’s weights across multiple devices (e.g. splitting q_a_proj along K or N across 4 chips). Core ranges and shard specs are currently single-device; supporting this would mean defining per-device core ranges and a mesh mapper that shards the weight tensor across devices (e.g. `ShardTensorToMesh` on a dimension), and ensuring fused ops and CCL (e.g. all-reduce after matmul) are aware of the sharding.
-
-### 9.2 Extensions needed for the full decoder pipeline
-
-1. **Explicit MeshDevice support and testing**
-   - When `device` is a MeshDevice, keep using `ReplicateTensorToMesh(self._device)` so each device gets a full copy.
-   - Ensure grid validation uses the per-device grid (same as today) and that every device in the mesh has a large enough grid (e.g. 12×10). If the API returns a single grid for the mesh, validate that grid; otherwise validate per device if the runtime exposes it.
-   - Add a test that builds weights with a small mesh (e.g. 2×1) and runs at least one fused op (e.g. Pre-SDPA) to confirm replicated weights work with `get_device_tensors`.
-
-2. **Pipeline parallelism (layers split across devices)**
-   - **Option A:** `prepare_weights` (or a variant) accepts a **stage_id** and **num_stages** and only produces weights for layers in that stage (e.g. stage 0: layers 0–15, stage 1: 16–31). Each stage is prepared with `BlitzDecodeWeights(single_device)` for that device, and the runner only passes that stage’s `DeepSeekV3Weights` to the device. No change to BlitzDecodeWeights internals; only the orchestration (who calls prepare_weights and with which layers) changes.
-   - **Option B:** `prepare_weights` takes a MeshDevice and a “layer → device” mapping and uses a mesh mapper that places each layer’s fused tensors only on the assigned device (e.g. no replication of other layers). That would require a custom mesh mapper or multiple `from_torch` calls per layer with device placement constrained to one mesh coordinate.
-
-3. **Tensor parallelism (weight sharding across devices)**
-   - Today each fusion group (q_ab+kv_a, o_proj+gate_mm+norms, kv_b1+kv_b2, gate+up) is a single logical tensor sharded over cores on **one** device. To shard a group across devices (e.g. q_a_proj rows split across 4 devices), we’d need:
-     - A **mesh mapper** that shards the fused tensor along the chosen dimension across mesh devices (e.g. `ShardTensorToMesh` on a logical dimension that corresponds to “which device”).
-     - **Per-device core ranges** so that each device’s shard is placed on the right cores locally, and the overall ShardSpec / memory config describes the cross-device sharding.
-     - Fused ops (and possibly kernels) to be aware of sharded weights: e.g. matmul with sharded weights followed by an all-reduce or other CCL. This is a larger change and may require new op variants or config flags.
-
-4. **Full decoder weight coverage**
-   - Blitz currently fuses only a subset of decoder weights (q_a/q_b/kv_a, o_proj+gate_mm+norms, kv_b1/kv_b2, shared expert gate/up). The full pipeline also uses (and may want to fuse or overlap):
-     - **down_proj** (and expert down_projs in MoE).
-     - **Expert weights** (gate_proj, up_proj, down_proj per expert).
-     - **Embedding** and **lm_head** (if they are to live on device and be overlapped with other buffers).
-   - Extending blitz for these would mean new overlap configs and new `get_tt_*` methods (and corresponding updates to `prepare_weights` and the layer weight dataclasses), following the same pattern: define core ranges and shard layout, then stitch or pack into a single buffer per core (or per device in a multi-device setup).
-
-### 9.3 Summary
-
-| Scenario | Today | Extension |
-|----------|--------|-----------|
-| Single device | Supported | — |
-| Mesh, replicated weights (full model on each device) | Supported in principle | Validate + test with MeshDevice |
-| Pipeline parallelism (layers per device) | Not supported | prepare_weights per stage or layer→device mapping + mapper |
-| Tensor parallelism (weight shard across devices) | Not supported | ShardTensorToMesh + per-device core ranges + op/CL support |
-| Full decoder (down_proj, experts, embed, lm_head) | Partial (only current fusion groups) | New overlap configs and get_tt_* in blitz_decode_weights |
+- **test_prepare_real_weights** — Placeholder for real checkpoint testing.
 
 ---
 
-## 10. Integration with bliu/deepseek (current)
+## 9. Multi-Device Sharding (blitz_decode_weights)
 
-**prepare_weights** is integrated with the **bliu/deepseek** blitz decode path. `BlitzDecodeWeights` uses tensor parallelism (TP) and single-device overlap specs; prepare_weights passes full-model shapes and uses a dummy gate_mm for dense layers.
+**BlitzDecodeWeights** is responsible for sharding full logical tensors onto the device or mesh.
 
-### 10.1 HF state dict; TP/DP are TTNN placement only
+- **Single device:** One `device`; blitz expects either full logical or a single shard (e.g. from tests). Fused tensors are placed on that device’s grid (e.g. 12×10 minimum).
 
-The HuggingFace state dict and checkpoint are unchanged. We always load **full-model** weights (e.g. q_b (1536, 12288), o_proj (8192, 7168), etc.). The **TP/DP factors** (e.g. mla_tp=2, moe_tp=8 on a 4×2 mesh) refer to how the **TTNN tensors** (the fused device buffers) are **sharded across the decoder mesh** — a runtime/placement concern. **prepare_weights** always passes the same full-model shapes to blitz; BlitzDecodeWeights is responsible for slicing/sharding and placement when the device is multi-device.
+- **Mesh (e.g. 4×2):** `BlitzDecodeWeights(device)` with a MeshDevice sets `mla_tp=2`, `moe_tp=8`. It expects **full logical** input shapes (e.g. q_b (1536, 24576), o_proj (16384, 7168)). It uses mesh mappers to shard: MLA weights (q_b, o_proj, kv_b1, kv_b2) along TP dimension 2; MoE shared expert (gate_proj, up_proj) across all 8 devices (TP=8); q_a, kv_a, gate_mm, norms replicated. No expansion in prepare_weights—blitz does all sharding.
 
-### 10.2 blitz_decode_weights.py (bliu/deepseek)
+Pipeline parallelism (layers split across devices) and further tensor parallelism variants are out of scope for this doc; see code and overlap specs in blitz_decode_weights.
 
-- **Config names:** Overlap configs use `*_SINGLE_DEVICE_OVERLAP_SPEC` (e.g. `QAB_KVA_PROJ_SingleDeviceOverlapSpec`, `O_PROJ_GATE_MM_RMSNORM_GAMMA_SINGLE_DEVICE_OVERLAP_SPEC`).
-- **BlitzDecodeWeights:** Sets `self.mla_tp` and `self.moe_tp` from the device; these drive how **output** TTNN tensors are sharded, not the **input** shapes from the caller.
-- **Input shapes:** prepare_weights passes **full-model** weights (e.g. o_proj (8192, 7168) for single-device; for TP, blitz expects (8192×mla_tp, 7168) per its config). Gate_mm is (7168, 256).
-- **gate_mm required:** `get_tt_o_proj_and_gate_mm_weights(..., gate_mm_weights)` takes a **required** `torch.Tensor` (no `None`). It always returns six OverlappedTensors: o_proj, gate_mm, attn_norm, q_norm, kv_norm, ffn_norm.
-- **GATE_UP:** `get_tt_gate_up_proj_weights(shared_gate, shared_up)` unchanged from prepare_weights' perspective.
+---
 
-### 10.3 prepare_weights.py behavior
+## 10. Integration Summary
 
-- **Full-model shapes:** No TP-concatenation in prepare_weights; we pass HF-derived shapes (after transpose/split). Blitz handles per-TP slicing when the device is a mesh.
-- **Dense layers:** For `i < first_k_dense_replace` we pass a **dummy** gate_mm: `torch.zeros(7168, 256, dtype=torch.bfloat16, device=...)`. We unpack all six elements from `get_tt_o_proj_and_gate_mm_weights` and ignore `gate_mm_ot` when building `DeepSeekV3DenseLayerWeights`.
-- **MoE layers:** We pass the real `gate_mm` from the state dict and unpack the same six elements; all six are used in `DeepSeekV3MoELayerWeights`.
-
-### 10.4 Summary
-
-- **HF state dict:** Unchanged; single full-model checkpoint.
-- **prepare_weights:** Passes full-model shapes; dense layers use a dummy (7168, 256) gate_mm and ignore the gate_mm OverlappedTensor in the dense layer container.
-- **BlitzDecodeWeights (bliu/deepseek):** Requires gate_mm; always returns six sub-tensors from `get_tt_o_proj_and_gate_mm_weights`; uses mla_tp/moe_tp for output sharding on the mesh.
+- **HF state dict:** Full logical shapes (see §5.1). Single checkpoint; no pre-slicing by the loader.
+- **prepare_weights:** Key mapping, transpose, `_split_kv_b_proj`. Passes tensors through to blitz **without** TP expansion. Single-device tests may use per-device slice state dicts; mesh tests use full logical.
+- **blitz_decode_weights:** Fuses weight groups and **shards** full logical tensors: single device = one shard, mesh = MLA-TP=2, MoE shared TP=8. Requires gate_mm in `get_tt_o_proj_and_gate_mm_weights` (dense: dummy zeros). Returns OverlappedTensors used by the fused decode ops.
 
 ---
 
 ## 11. Future Work / Open Points
 
-- **Integrate with DeepSeekV3:** Pass `DeepSeekV3Weights` into `DeepSeekV3.__init__` and wire OverlappedTensors to Pre-SDPA, Post-SDPA, MoE, and shared expert ops (each op already takes `ttnn.Tensor`; kernels use `byte_offset` where the fused buffer is a raw container).
-- **Real checkpoint test:** Implement `test_prepare_real_weights` using a real HuggingFace checkpoint (or a small fixture) and validate numerical consistency or golden outputs.
-- **Config-driven constants:** Move `num_layers`, `first_k_dense_replace`, and kv_b split constants (e.g. `_NUM_HEADS`) into a small config or the existing DeepSeek V3 config so they stay in sync with the reference model.
-- **Lazy / on-demand loading:** If needed, consider a variant that prepares weights for a subset of layers or streams from checkpoint instead of loading the full state dict up front.
+- **Integrate with DeepSeekV3:** Pass `DeepSeekV3Weights` into the model and wire OverlappedTensors to Pre-SDPA, Post-SDPA, MoE, shared expert ops.
+- **Real checkpoint test:** Implement `test_prepare_real_weights` with a real HF checkpoint; validate shapes and optionally numerical consistency.
+- **Config-driven constants:** Move `num_layers`, `first_k_dense_replace`, and kv_b split constants into a small config to stay in sync with the reference model.
+- **Lazy / on-demand loading:** Optionally prepare weights for a subset of layers or stream from checkpoint.
 
 ---
 
 ## 12. Changelog
 
-- **Initial:** Added prepare_weights API, DeepSeekV3Weights / Dense / MoE types, state dict mapping, kv_b split, optional gate_mm in blitz_decode_weights, and unit tests with random weights plus placeholder for real weights.
-- **Multi-device / full pipeline:** Added §9 (Multi-device and full-pipeline extension): current single-device assumption, MeshDevice + replication behavior, and required extensions for pipeline parallelism, tensor parallelism, and full decoder weight coverage.
-- **bliu/deepseek branch:** Added §10 (Adapting prepare_weights to branch bliu/deepseek): TP-aware shapes, mla_tp/moe_tp, and required prepare_weights.py changes for single-device vs 4×2 mesh.
-- **bliu/deepseek integrated:** prepare_weights now targets bliu/deepseek blitz path. gate_mm is required in `get_tt_o_proj_and_gate_mm_weights`; dense layers pass a dummy zeros (7168, 256) and unpack six elements (gate_mm_ot ignored for DenseLayerWeights). §3, §4.2, §7, and §10 updated to describe current behavior.
+- **Initial:** prepare_weights API, DeepSeekV3Weights / Dense / MoE types, state dict mapping, kv_b split, unit tests, placeholder for real weights.
+- **Multi-device / blitz sharding:** Documented flow: full HF tensors → prepare_weights (transform only) → blitz (shard to device/mesh). Removed TP expansion from prepare_weights; blitz does all sharding. Tests: single-device use per-device slice, 4×2 use full logical.
+- **Design doc refactor:** Cleaned stale “current blitz assumes” and “expand for TP” wording; centered doc on full HF → prepare_weights → blitz sharding; simplified §5 (one table for full logical, one for per-device after sharding), §6 (kv_b supports both 16384 and 32768), §8 (test descriptions), §9–§10 (sharding model and integration).

--- a/models/demos/deepseek_v3_b1/blitz_decode_weights.py
+++ b/models/demos/deepseek_v3_b1/blitz_decode_weights.py
@@ -765,34 +765,13 @@ class BlitzDecodeWeights:
         """Fuse o_proj, gate_mm, and 4 RMSNorm gammas into one WIDTH_SHARDED tensor.
 
         The fused buffer is a UINT32 raw-byte container where each core's
-        shard is zero-padded to the same maximum byte size.  The six
-        sub-tensors use three distinct formats:
+        shard is zero-padded to the same maximum byte size.  There are always
+        six sub-tensors.
 
         * **o_proj** — BFP8 (32×32 tiles) on 112 cores.
         * **gate_mm** — BFP16 (32×32 tiles) on 8 cores.
-        * **attn_norm, q_norm, ffn_norm** — BFP16
-          (1×32 tiles) back-to-back on core (12, 9).
+        * **attn_norm, q_norm, ffn_norm** — BFP16 (1×32 tiles) back-to-back on core (12, 9).
         * **kv_norm** — BFP16 (1×32 tiles) on dedicated core (0, 8).
-
-        Layout::
-
-            -- o_proj region: 112 cores --
-            o_proj (8192, 7168) as bfloat8_b
-              shard (8192, 64) = 512 tiles × 1088 B = 557 056 B
-
-            -- gate_mm region: 8 cores (col 12, rows 0-7) --
-            gate_mm (7168, 256) as bfloat16
-              shard (7168, 32) = 224 tiles × 2048 B = 458 752 B
-
-            -- gamma core: 1 core (12, 9) --
-            attn_norm (1, 7168)   @ offset 0      → 14 336 B
-            q_norm (1, 1536)  @ offset 14 336  →  3 072 B
-            ffn_norm (1, 7168) @ offset 17 408 → 14 336 B
-
-            -- kv_norm core: 1 core (0, 8) --
-            kv_norm (1, 512) @ offset 0 → 1 024 B
-
-            combined: 122 cores, shard = max_shard_bytes
 
         Args:
             o_proj_weights:     Raw o_proj tensor, shape
@@ -805,10 +784,8 @@ class BlitzDecodeWeights:
             ffn_norm:  MoE pre-MLP RMSNorm gamma, shape (1, 7168).
 
         Returns:
-            A list of six :class:`OverlappedTensor` views
-            ``[o_proj, gate_mm, attn_norm, q_norm,
-            kv_norm, ffn_norm]`` sharing the same
-            underlying fused device buffer.
+            List of six OverlappedTensors
+            ``[o_proj, gate_mm, attn_norm, q_norm, kv_norm, ffn_norm]``.
         """
         cfg = O_PROJ_GATE_MM_RMSNORM_GAMMA_SINGLE_DEVICE_OVERLAP_SPEC
         mla_tp = self.mla_tp
@@ -894,12 +871,13 @@ class BlitzDecodeWeights:
         else:
             combined = torch.cat([t.reshape(1, -1) for t in per_tp_raw], dim=1)
 
-        combined_crs = ttnn.CoreRangeSet(
+        combined_crs_ranges = (
             list(cfg.o_proj_core_range_set.ranges())
             + list(cfg.gate_mm_core_range_set.ranges())
             + list(cfg.gamma_core_range_set.ranges())
             + list(cfg.kv_norm_core_range_set.ranges())
         )
+        combined_crs = ttnn.CoreRangeSet(combined_crs_ranges)
         shard_spec = ttnn.ShardSpec(
             combined_crs,
             (1, uint32_per_shard),
@@ -930,7 +908,7 @@ class BlitzDecodeWeights:
         tile_32x32 = (cfg.tile_h, cfg.tile_w)
         tile_1x32 = (cfg.gamma_tile_h, cfg.gamma_tile_w)
 
-        return [
+        result: list[OverlappedTensor] = [
             OverlappedTensor(
                 fused_tensor=fused,
                 tensor_shape=cfg.o_proj_shape,
@@ -940,6 +918,8 @@ class BlitzDecodeWeights:
                 tile_shape=tile_32x32,
                 byte_offset=0,
             ),
+        ]
+        result.append(
             OverlappedTensor(
                 fused_tensor=fused,
                 tensor_shape=cfg.gate_mm_shape,
@@ -948,44 +928,49 @@ class BlitzDecodeWeights:
                 dtype=ttnn.bfloat16,
                 tile_shape=tile_32x32,
                 byte_offset=0,
-            ),
-            OverlappedTensor(
-                fused_tensor=fused,
-                tensor_shape=cfg.attn_norm_shape,
-                shard_shape=cfg.attn_norm_shape,
-                core_range_set=cfg.gamma_core_range_set,
-                dtype=ttnn.bfloat16,
-                tile_shape=tile_1x32,
-                byte_offset=cfg.attn_norm_byte_offset,
-            ),
-            OverlappedTensor(
-                fused_tensor=fused,
-                tensor_shape=cfg.q_norm_shape,
-                shard_shape=cfg.q_norm_shape,
-                core_range_set=cfg.gamma_core_range_set,
-                dtype=ttnn.bfloat16,
-                tile_shape=tile_1x32,
-                byte_offset=cfg.q_norm_byte_offset,
-            ),
-            OverlappedTensor(
-                fused_tensor=fused,
-                tensor_shape=cfg.kv_norm_shape,
-                shard_shape=cfg.kv_norm_shape,
-                core_range_set=cfg.kv_norm_core_range_set,
-                dtype=ttnn.bfloat16,
-                tile_shape=tile_1x32,
-                byte_offset=cfg.kv_norm_byte_offset,
-            ),
-            OverlappedTensor(
-                fused_tensor=fused,
-                tensor_shape=cfg.ffn_norm_shape,
-                shard_shape=cfg.ffn_norm_shape,
-                core_range_set=cfg.gamma_core_range_set,
-                dtype=ttnn.bfloat16,
-                tile_shape=tile_1x32,
-                byte_offset=cfg.ffn_norm_byte_offset,
-            ),
-        ]
+            )
+        )
+        result.extend(
+            [
+                OverlappedTensor(
+                    fused_tensor=fused,
+                    tensor_shape=cfg.attn_norm_shape,
+                    shard_shape=cfg.attn_norm_shape,
+                    core_range_set=cfg.gamma_core_range_set,
+                    dtype=ttnn.bfloat16,
+                    tile_shape=tile_1x32,
+                    byte_offset=cfg.attn_norm_byte_offset,
+                ),
+                OverlappedTensor(
+                    fused_tensor=fused,
+                    tensor_shape=cfg.q_norm_shape,
+                    shard_shape=cfg.q_norm_shape,
+                    core_range_set=cfg.gamma_core_range_set,
+                    dtype=ttnn.bfloat16,
+                    tile_shape=tile_1x32,
+                    byte_offset=cfg.q_norm_byte_offset,
+                ),
+                OverlappedTensor(
+                    fused_tensor=fused,
+                    tensor_shape=cfg.kv_norm_shape,
+                    shard_shape=cfg.kv_norm_shape,
+                    core_range_set=cfg.kv_norm_core_range_set,
+                    dtype=ttnn.bfloat16,
+                    tile_shape=tile_1x32,
+                    byte_offset=cfg.kv_norm_byte_offset,
+                ),
+                OverlappedTensor(
+                    fused_tensor=fused,
+                    tensor_shape=cfg.ffn_norm_shape,
+                    shard_shape=cfg.ffn_norm_shape,
+                    core_range_set=cfg.gamma_core_range_set,
+                    dtype=ttnn.bfloat16,
+                    tile_shape=tile_1x32,
+                    byte_offset=cfg.ffn_norm_byte_offset,
+                ),
+            ]
+        )
+        return result
 
     def get_tt_kv_b12_proj_weights(
         self,

--- a/models/demos/deepseek_v3_b1/blitz_decode_weights.py
+++ b/models/demos/deepseek_v3_b1/blitz_decode_weights.py
@@ -80,7 +80,7 @@ def shuffle_weights_for_interleaved_qnope_qrope(
 
 
 @dataclass(frozen=True)
-class QAB_KVA_PROJ_OverlapConfig:
+class QAB_KVA_PROJ_SingleDeviceOverlapSpec:
     """Configuration for the q_a / q_b / kv_a weight overlap.
 
     Shape tuples follow (height, width) convention.  All shapes describe
@@ -162,6 +162,26 @@ class QAB_KVA_PROJ_OverlapConfig:
             heads_per_row=self.heads_per_row,
         )
 
+    def get_q_b_slice(self, q_b_proj_weights: torch.Tensor, tp_idx: int, mla_tp: int) -> torch.Tensor:
+        """Extract the per-device q_b_proj slice for a given TP index.
+
+        The full q_b_proj tensor is laid out as ``[all_qnope | all_qrope]``
+        across ``mla_tp`` devices.  This method splits qnope and qrope,
+        takes the ``tp_idx``-th chunk of each, and stitches them into the
+        single-device ``(K, qnope_dim + qrope_dim)`` slice.
+        """
+        per_tp_qnope_dim = self.num_qnope_heads * self.qnope_head_dim
+        per_tp_qrope_dim = self.num_qrope_heads * self.qrope_head_dim
+        total_qnope_dim = mla_tp * per_tp_qnope_dim
+
+        full_qnope = q_b_proj_weights[:, :total_qnope_dim]
+        full_qrope = q_b_proj_weights[:, total_qnope_dim:]
+
+        tp_qnope = full_qnope[:, tp_idx * per_tp_qnope_dim : (tp_idx + 1) * per_tp_qnope_dim]
+        tp_qrope = full_qrope[:, tp_idx * per_tp_qrope_dim : (tp_idx + 1) * per_tp_qrope_dim]
+
+        return torch.cat([tp_qnope, tp_qrope], dim=1)
+
     def shuffle_kv_a(self, weights: torch.Tensor) -> torch.Tensor:
         """Reorder kv_a_proj shards for the KV cache branch core layout."""
         kv_h, kv_w = weights.shape
@@ -170,11 +190,11 @@ class QAB_KVA_PROJ_OverlapConfig:
         return shards[:, list(self.kv_a_proj_shard_order), :].reshape(kv_h, kv_w)
 
 
-QAB_KVA_PROJ_OVERLAP_CFG = QAB_KVA_PROJ_OverlapConfig()
+QAB_KVA_PROJ_SINGLE_DEVICE_OVERLAP_SPEC = QAB_KVA_PROJ_SingleDeviceOverlapSpec()
 
 
 @dataclass(frozen=True)
-class O_PROJ_GATE_MM_RMSNORM_GAMMA_OverlapConfig:
+class O_PROJ_GATE_MM_RMSNORM_GAMMA_SingleDeviceOverlapSpec:
     """Configuration for the o_proj / gate_mm / rmsnorm-gamma weight overlap.
 
     Fuses the following into a single WIDTH_SHARDED raw buffer:
@@ -315,11 +335,11 @@ class O_PROJ_GATE_MM_RMSNORM_GAMMA_OverlapConfig:
         )
 
 
-O_PROJ_GATE_MM_RMSNORM_GAMMA_OVERLAP_CFG = O_PROJ_GATE_MM_RMSNORM_GAMMA_OverlapConfig()
+O_PROJ_GATE_MM_RMSNORM_GAMMA_SINGLE_DEVICE_OVERLAP_SPEC = O_PROJ_GATE_MM_RMSNORM_GAMMA_SingleDeviceOverlapSpec()
 
 
 @dataclass(frozen=True)
-class KVB12_PROJ_OverlapConfig:
+class KVB12_PROJ_SingleDeviceOverlapSpec:
     """Configuration for the kv_b1 / kv_b2 weight overlap.
 
     Stitches ``kv_b1_proj (8192, 512)`` onto 64 cores and
@@ -388,11 +408,11 @@ class KVB12_PROJ_OverlapConfig:
         return weights.reshape(kv_dim, n_cores, head_dim).permute(1, 2, 0).reshape(-1, kv_dim).contiguous()
 
 
-KVB12_PROJ_OVERLAP_CFG = KVB12_PROJ_OverlapConfig()
+KVB12_PROJ_SINGLE_DEVICE_OVERLAP_SPEC = KVB12_PROJ_SingleDeviceOverlapSpec()
 
 
 @dataclass(frozen=True)
-class GATE_UP_PROJ_OverlapConfig:
+class GATE_UP_PROJ_SingleDeviceOverlapSpec:
     """Configuration for the gate / up projection weight overlap.
 
     Both tensors share the raw shape ``(K_gate, K_down) = (7168, 256)``
@@ -415,25 +435,23 @@ class GATE_UP_PROJ_OverlapConfig:
     Shape tuples follow (height, width) convention.
     """
 
-    # Core range sets — gate (A) and up (B) grids
+    # Core range sets — gate (A) and up (B) grids, stored as contiguous column chunks
     gate_core_range_set: ttnn.CoreRangeSet = field(
         default_factory=lambda: ttnn.CoreRangeSet(
             {
-                ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(3, 3)),  # 16 cores
-                ttnn.CoreRange(ttnn.CoreCoord(7, 0), ttnn.CoreCoord(9, 3)),  # 12 cores
-                ttnn.CoreRange(ttnn.CoreCoord(0, 4), ttnn.CoreCoord(2, 9)),  # 18 cores
-                ttnn.CoreRange(ttnn.CoreCoord(7, 4), ttnn.CoreCoord(9, 9)),  # 18 cores
+                ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(2, 9)),  # 30 cores  cols 0-2
+                ttnn.CoreRange(ttnn.CoreCoord(3, 0), ttnn.CoreCoord(3, 3)),  #  4 cores  col 3 top
+                ttnn.CoreRange(ttnn.CoreCoord(7, 0), ttnn.CoreCoord(9, 9)),  # 30 cores  cols 7-9
             }
         )
     )
     up_core_range_set: ttnn.CoreRangeSet = field(
         default_factory=lambda: ttnn.CoreRangeSet(
             {
-                ttnn.CoreRange(ttnn.CoreCoord(4, 0), ttnn.CoreCoord(6, 3)),  # 12 cores
-                ttnn.CoreRange(ttnn.CoreCoord(10, 0), ttnn.CoreCoord(12, 3)),  # 12 cores
-                ttnn.CoreRange(ttnn.CoreCoord(3, 4), ttnn.CoreCoord(6, 9)),  # 24 cores
-                ttnn.CoreRange(ttnn.CoreCoord(10, 4), ttnn.CoreCoord(12, 7)),  # 12 cores
-                ttnn.CoreRange(ttnn.CoreCoord(10, 8), ttnn.CoreCoord(11, 9)),  # 4 cores
+                ttnn.CoreRange(ttnn.CoreCoord(3, 4), ttnn.CoreCoord(3, 9)),  #  6 cores  col 3 bottom
+                ttnn.CoreRange(ttnn.CoreCoord(4, 0), ttnn.CoreCoord(6, 9)),  # 30 cores  cols 4-6
+                ttnn.CoreRange(ttnn.CoreCoord(10, 0), ttnn.CoreCoord(11, 9)),  # 20 cores  cols 10-11
+                ttnn.CoreRange(ttnn.CoreCoord(12, 0), ttnn.CoreCoord(12, 7)),  #  8 cores  col 12
             }
         )
     )
@@ -476,22 +494,51 @@ class GATE_UP_PROJ_OverlapConfig:
     def max_shard_bytes(self) -> int:
         return self.shard_bytes
 
-    def reshuffle_block_to_height_sharded(self, weights: torch.Tensor) -> torch.Tensor:
+    @staticmethod
+    def _crs_shard_permutation(core_range_set: ttnn.CoreRangeSet) -> tuple[int, ...]:
+        """Compute shard permutation from CoreRangeSet enumeration to row-major order.
+
+        HEIGHT_SHARDED places shard *j* on the *j*-th core in CoreRangeSet
+        enumeration order.  The kernel (SharedExpertOp) assigns
+        ``(k_idx, n_idx)`` to each core based on global row-major order
+        (y then x).  This method returns a permutation *P* such that
+        ``stacked[j] = block_shards[P[j]]`` places the correct shard on
+        each physical core.
+        """
+        crs_cores = []
+        for cr in core_range_set.ranges():
+            for y in range(cr.start.y, cr.end.y + 1):
+                for x in range(cr.start.x, cr.end.x + 1):
+                    crs_cores.append((x, y))
+        sorted_cores = sorted(crs_cores, key=lambda c: (c[1], c[0]))
+        core_to_sorted_idx = {c: i for i, c in enumerate(sorted_cores)}
+        return tuple(core_to_sorted_idx[c] for c in crs_cores)
+
+    def reshuffle_block_to_height_sharded(
+        self, weights: torch.Tensor, core_range_set: ttnn.CoreRangeSet
+    ) -> torch.Tensor:
         """Reorder a (K, N) weight matrix into stacked HEIGHT_SHARDED form.
 
-        ``(K, N) -> (k_parallel, sh, n_parallel, sw)
-        -> permute (k_parallel, n_parallel, sh, sw) -> reshape (-1, sw)``
+        The block decomposition splits ``(K, N)`` into
+        ``(k_parallel, n_parallel)`` shards of shape ``(sh, sw)``.
+        The shards are then permuted so that HEIGHT_SHARDED placement on
+        ``core_range_set`` puts each shard on the physical core expected
+        by the compute kernel (which assigns shards in global row-major
+        core order).
 
         Returns:
             Tensor of shape :attr:`stacked_shape`.
         """
         sh, sw = self.shard_shape
-        return (
-            weights.reshape(self.k_parallel, sh, self.n_parallel, sw).permute(0, 2, 1, 3).reshape(-1, sw).contiguous()
+        num_shards = self.k_parallel * self.n_parallel
+        block_shards = (
+            weights.reshape(self.k_parallel, sh, self.n_parallel, sw).permute(0, 2, 1, 3).reshape(num_shards, sh, sw)
         )
+        perm = self._crs_shard_permutation(core_range_set)
+        return block_shards[list(perm)].reshape(-1, sw).contiguous()
 
 
-GATE_UP_PROJ_OVERLAP_CFG = GATE_UP_PROJ_OverlapConfig()
+GATE_UP_PROJ_SINGLE_DEVICE_OVERLAP_SPEC = GATE_UP_PROJ_SingleDeviceOverlapSpec()
 
 
 @dataclass
@@ -527,6 +574,19 @@ class BlitzDecodeWeights:
     def __init__(self, device) -> None:
         self._device = device
 
+        num_devices = device.get_num_devices()
+        if num_devices == 1:
+            self.mla_tp = 1
+            self.moe_tp = 1
+        else:
+            mesh_shape = (device.shape[0], device.shape[1])
+            assert mesh_shape == (
+                4,
+                2,
+            ), f"Only single-device or 4x2 mesh supported, got {mesh_shape[0]}x{mesh_shape[1]}"
+            self.mla_tp = 2
+            self.moe_tp = 8
+
     # ------------------------------------------------------------------
     # Public API
     # ------------------------------------------------------------------
@@ -536,7 +596,6 @@ class BlitzDecodeWeights:
         q_a_proj_weights: torch.Tensor,
         q_b_proj_weights: torch.Tensor,
         kv_a_proj_weights: torch.Tensor,
-        cfg: QAB_KVA_PROJ_OverlapConfig | None = None,
     ) -> list[OverlappedTensor]:
         """Fuse q_a_proj, q_b_proj, and kv_a_proj into one WIDTH_SHARDED tensor.
 
@@ -550,43 +609,29 @@ class BlitzDecodeWeights:
           the top region.
 
         For multi-device (4x2 mesh, TP=2) the q_b_proj weights span all
-        TP devices (width ``tp * per_device_width``).  Per-TP slices are
+        TP devices (width ``mla_tp * per_device_width``).  Per-TP slices are
         shuffled independently and stitched with the (replicated)
         q_a_proj into separate per-TP fused tensors, which are
         concatenated along width and distributed via
         ``ShardTensor2dMesh`` across mesh columns.  q_a_proj and
         kv_a_proj are replicated on every device.
 
-        TP is inferred from the device topology: single-device -> TP=1,
-        4x2 mesh -> TP=2.
+        MLA TP is inferred from the device topology: single-device ->
+        mla_tp=1, 4x2 mesh -> mla_tp=2.
 
         Args:
             q_a_proj_weights: Raw q_a_proj tensor, shape ``(7168, 1536)``.
             q_b_proj_weights: Raw (unshuffled) q_b_proj tensor, shape
-                ``(1536, 12288 * tp)``.
+                ``(1536, 12288 * mla_tp)``.
             kv_a_proj_weights: Raw kv_a_proj tensor, shape ``(7168, 576)``.
-            cfg: Overlap configuration.  Defaults to the module-level
-                ``QAB_KVA_PROJ_OVERLAP_CFG`` singleton.
 
         Returns:
             A list of three :class:`OverlappedTensor` views
             ``[q_a_proj, q_b_proj, kv_a_proj]`` that share the same
             underlying fused device buffer.
         """
-        if cfg is None:
-            cfg = QAB_KVA_PROJ_OVERLAP_CFG
-
-        # -- Infer TP from device topology --------------------------------
-        num_devices = self._device.get_num_devices()
-        if num_devices == 1:
-            tp = 1
-        else:
-            mesh_shape = (self._device.shape[0], self._device.shape[1])
-            assert mesh_shape == (
-                4,
-                2,
-            ), f"Only single-device or 4x2 mesh supported, got {mesh_shape[0]}x{mesh_shape[1]}"
-            tp = mesh_shape[1]
+        cfg = QAB_KVA_PROJ_SINGLE_DEVICE_OVERLAP_SPEC
+        mla_tp = self.mla_tp
 
         # -- Validate device grid ----------------------------------------
         device_grid = self._device.compute_with_storage_grid_size()
@@ -601,7 +646,7 @@ class BlitzDecodeWeights:
         assert (
             q_a_proj_weights.shape == cfg.q_a_proj_shape
         ), f"q_a_proj_weights must be {cfg.q_a_proj_shape}, got {tuple(q_a_proj_weights.shape)}"
-        expected_q_b_shape = (cfg.q_b_proj_shape[0], cfg.q_b_proj_shape[1] * tp)
+        expected_q_b_shape = (cfg.q_b_proj_shape[0], cfg.q_b_proj_shape[1] * mla_tp)
         assert (
             tuple(q_b_proj_weights.shape) == expected_q_b_shape
         ), f"q_b_proj_weights must be {expected_q_b_shape}, got {tuple(q_b_proj_weights.shape)}"
@@ -619,10 +664,9 @@ class BlitzDecodeWeights:
         q_ab_num_cores = cfg.q_ab_core_range_set.num_cores()
 
         # -- Step 3: build per-TP fused tensors -------------------------
-        per_device_q_b_w = cfg.q_b_proj_shape[1]
         per_tp_combined = []
-        for tp_idx in range(tp):
-            q_b_slice = q_b_proj_weights[:, tp_idx * per_device_q_b_w : (tp_idx + 1) * per_device_q_b_w]
+        for tp_idx in range(mla_tp):
+            q_b_slice = cfg.get_q_b_slice(q_b_proj_weights, tp_idx, mla_tp)
             shuffled = cfg.shuffle_q_b(q_b_slice)
 
             q_ab_fused, q_ab_shard_shape = BlitzDecodeWeights._stitch_width_sharded(packed, shuffled, q_ab_num_cores)
@@ -641,7 +685,7 @@ class BlitzDecodeWeights:
             assert combined_tp.shape == (fused_shard_h, target_w * total_cores)
             per_tp_combined.append(combined_tp)
 
-        combined = torch.cat(per_tp_combined, dim=1) if tp > 1 else per_tp_combined[0]
+        combined = torch.cat(per_tp_combined, dim=1) if mla_tp > 1 else per_tp_combined[0]
 
         # -- Step 4: place on device as WIDTH_SHARDED -------------------
         shard_spec = ttnn.ShardSpec(
@@ -655,7 +699,7 @@ class BlitzDecodeWeights:
             shard_spec,
         )
 
-        if tp == 1:
+        if mla_tp == 1:
             mesh_mapper = ttnn.ReplicateTensorToMesh(self._device)
         else:
             mesh_shape = (self._device.shape[0], self._device.shape[1])
@@ -751,8 +795,10 @@ class BlitzDecodeWeights:
             combined: 122 cores, shard = max_shard_bytes
 
         Args:
-            o_proj_weights:     Raw o_proj tensor, shape (8192, 7168).
+            o_proj_weights:     Raw o_proj tensor, shape
+                ``(8192 * mla_tp, 7168)``.  TP-sharded on the inner dim.
             gate_mm_weights:    Raw gate_mm tensor, shape (7168, 256).
+                Replicated across TP devices.
             attn_norm:      Pre-SDPA attention-input RMSNorm gamma, shape (1, 7168).
             q_norm:     Pre-SDPA post-matmul1 RMSNorm gamma, shape (1, 1536).
             kv_norm:  Pre-SDPA KV-cache-branch RMSNorm gamma, shape (1, 512).
@@ -764,12 +810,14 @@ class BlitzDecodeWeights:
             kv_norm, ffn_norm]`` sharing the same
             underlying fused device buffer.
         """
-        cfg = O_PROJ_GATE_MM_RMSNORM_GAMMA_OVERLAP_CFG
+        cfg = O_PROJ_GATE_MM_RMSNORM_GAMMA_SINGLE_DEVICE_OVERLAP_SPEC
+        mla_tp = self.mla_tp
 
         # -- Validate shapes --------------------------------------------
+        expected_o_proj_shape = (cfg.o_proj_shape[0] * mla_tp, cfg.o_proj_shape[1])
         assert (
-            o_proj_weights.shape == cfg.o_proj_shape
-        ), f"o_proj must be {cfg.o_proj_shape}, got {tuple(o_proj_weights.shape)}"
+            tuple(o_proj_weights.shape) == expected_o_proj_shape
+        ), f"o_proj must be {expected_o_proj_shape}, got {tuple(o_proj_weights.shape)}"
         assert (
             gate_mm_weights.shape == cfg.gate_mm_shape
         ), f"gate_mm must be {cfg.gate_mm_shape}, got {tuple(gate_mm_weights.shape)}"
@@ -791,24 +839,16 @@ class BlitzDecodeWeights:
         max_shard_bytes = cfg.max_shard_bytes
         assert max_shard_bytes % 4 == 0, "shard bytes must be UINT32-aligned"
 
-        # -- Pack shards ------------------------------------------------
-        packed = bytearray()
-
-        # o_proj shards (BFP8_b) — 112 cores
-        for i in range(o_num_cores):
-            shard_data = o_proj_weights[:, i * o_shard_w : (i + 1) * o_shard_w].contiguous()
-            shard_raw = BlitzDecodeWeights._tilize_and_pack_bfp8(shard_data, cfg.tile_h, cfg.tile_w)
-            assert len(shard_raw) == cfg.o_proj_shard_bytes
-            packed.extend(shard_raw)
-            packed.extend(b"\x00" * (max_shard_bytes - cfg.o_proj_shard_bytes))
+        # -- Pack shared portion (gate_mm + gammas, replicated) ----------
+        shared_packed = bytearray()
 
         # gate_mm shards (bfloat16) — 8 cores
         for i in range(g_num_cores):
             shard_data = gate_mm_weights[:, i * g_shard_w : (i + 1) * g_shard_w].contiguous()
             shard_raw = BlitzDecodeWeights._tilize_and_pack_bfloat16(shard_data, cfg.tile_h, cfg.tile_w)
             assert len(shard_raw) == cfg.gate_mm_shard_bytes
-            packed.extend(shard_raw)
-            packed.extend(b"\x00" * (max_shard_bytes - cfg.gate_mm_shard_bytes))
+            shared_packed.extend(shard_raw)
+            shared_packed.extend(b"\x00" * (max_shard_bytes - cfg.gate_mm_shard_bytes))
 
         # Gamma core (12, 9) — attn_norm + q_norm + ffn_norm
         gamma_shard = bytearray(max_shard_bytes)
@@ -822,20 +862,37 @@ class BlitzDecodeWeights:
             assert len(raw) == expected_bytes
             gamma_shard[offset : offset + len(raw)] = raw
             offset += len(raw)
-        packed.extend(gamma_shard)
+        shared_packed.extend(gamma_shard)
 
         # kv_norm core (0, 8) — dedicated core
         kv_norm_shard = bytearray(max_shard_bytes)
         kv_norm_raw = BlitzDecodeWeights._pack_bfloat16_1x32(kv_norm)
         assert len(kv_norm_raw) == cfg.kv_norm_bytes
         kv_norm_shard[: len(kv_norm_raw)] = kv_norm_raw
-        packed.extend(kv_norm_shard)
+        shared_packed.extend(kv_norm_shard)
 
-        # -- Build UINT32 tensor on device ------------------------------
+        # -- Pack per-TP o_proj shards and combine -----------------------
         total_cores = o_num_cores + g_num_cores + 2  # +1 gamma core, +1 kv_norm core
         uint32_per_shard = max_shard_bytes // 4
+        per_device_o_h = cfg.o_proj_shape[0]
 
-        raw_data = torch.frombuffer(bytes(packed), dtype=torch.int32).clone()
+        per_tp_raw = []
+        for tp_idx in range(mla_tp):
+            o_proj_slice = o_proj_weights[tp_idx * per_device_o_h : (tp_idx + 1) * per_device_o_h, :]
+            o_packed = bytearray()
+            for i in range(o_num_cores):
+                shard_data = o_proj_slice[:, i * o_shard_w : (i + 1) * o_shard_w].contiguous()
+                shard_raw = BlitzDecodeWeights._tilize_and_pack_bfp8(shard_data, cfg.tile_h, cfg.tile_w)
+                assert len(shard_raw) == cfg.o_proj_shard_bytes
+                o_packed.extend(shard_raw)
+                o_packed.extend(b"\x00" * (max_shard_bytes - cfg.o_proj_shard_bytes))
+            per_tp_raw.append(torch.frombuffer(bytes(o_packed + shared_packed), dtype=torch.int32).clone())
+
+        # -- Build UINT32 tensor on device ------------------------------
+        if mla_tp == 1:
+            combined = per_tp_raw[0].reshape(1, uint32_per_shard * total_cores)
+        else:
+            combined = torch.cat([t.reshape(1, -1) for t in per_tp_raw], dim=1)
 
         combined_crs = ttnn.CoreRangeSet(
             list(cfg.o_proj_core_range_set.ranges())
@@ -854,13 +911,19 @@ class BlitzDecodeWeights:
             shard_spec,
         )
 
+        if mla_tp == 1:
+            mesh_mapper = ttnn.ReplicateTensorToMesh(self._device)
+        else:
+            mesh_shape = (self._device.shape[0], self._device.shape[1])
+            mesh_mapper = ttnn.ShardTensor2dMesh(self._device, mesh_shape=mesh_shape, dims=(None, 1))
+
         fused = ttnn.from_torch(
-            raw_data.reshape(1, uint32_per_shard * total_cores),
+            combined,
             dtype=ttnn.uint32,
             layout=ttnn.ROW_MAJOR_LAYOUT,
             device=self._device,
             memory_config=mem_config,
-            mesh_mapper=ttnn.ReplicateTensorToMesh(self._device),
+            mesh_mapper=mesh_mapper,
         )
 
         # -- Build OverlappedTensor views --------------------------------
@@ -946,24 +1009,38 @@ class BlitzDecodeWeights:
             combined: 128 cores, HEIGHT_SHARDED, shard (128, 512)
 
         Args:
-            kv_b1_proj_weights: shape (8192, 512).
-            kv_b2_proj_weights: shape (512, 8192).
+            kv_b1_proj_weights: shape ``(8192 * mla_tp, 512)``.
+                TP-sharded on the heads dim.
+            kv_b2_proj_weights: shape ``(512, 8192 * mla_tp)``.
+                TP-sharded on the heads dim.
 
         Returns:
             ``[kv_b1_proj, kv_b2_proj]`` as :class:`OverlappedTensor`
             views sharing the same fused device buffer.
         """
-        cfg = KVB12_PROJ_OVERLAP_CFG
+        cfg = KVB12_PROJ_SINGLE_DEVICE_OVERLAP_SPEC
+        mla_tp = self.mla_tp
 
+        expected_b1_shape = (cfg.kv_b1_proj_shape[0] * mla_tp, cfg.kv_b1_proj_shape[1])
         assert (
-            tuple(kv_b1_proj_weights.shape) == cfg.kv_b1_proj_shape
-        ), f"kv_b1 expected {cfg.kv_b1_proj_shape}, got {tuple(kv_b1_proj_weights.shape)}"
+            tuple(kv_b1_proj_weights.shape) == expected_b1_shape
+        ), f"kv_b1 expected {expected_b1_shape}, got {tuple(kv_b1_proj_weights.shape)}"
+        expected_b2_shape = (cfg.kv_b2_proj_shape[0], cfg.kv_b2_proj_shape[1] * mla_tp)
         assert (
-            tuple(kv_b2_proj_weights.shape) == cfg.kv_b2_proj_shape
-        ), f"kv_b2 expected {cfg.kv_b2_proj_shape}, got {tuple(kv_b2_proj_weights.shape)}"
+            tuple(kv_b2_proj_weights.shape) == expected_b2_shape
+        ), f"kv_b2 expected {expected_b2_shape}, got {tuple(kv_b2_proj_weights.shape)}"
 
-        kv_b2_physical = cfg.shuffle_kv_b2(kv_b2_proj_weights)
-        combined = torch.cat([kv_b1_proj_weights, kv_b2_physical], dim=0)
+        per_device_b1_h = cfg.kv_b1_proj_shape[0]
+        per_device_b2_w = cfg.kv_b2_proj_shape[1]
+
+        per_tp_combined = []
+        for tp_idx in range(mla_tp):
+            b1_slice = kv_b1_proj_weights[tp_idx * per_device_b1_h : (tp_idx + 1) * per_device_b1_h, :]
+            b2_slice = kv_b2_proj_weights[:, tp_idx * per_device_b2_w : (tp_idx + 1) * per_device_b2_w]
+            b2_physical = cfg.shuffle_kv_b2(b2_slice)
+            per_tp_combined.append(torch.cat([b1_slice, b2_physical], dim=0))
+
+        combined = torch.cat(per_tp_combined, dim=0) if mla_tp > 1 else per_tp_combined[0]
 
         # -- Place on device as HEIGHT_SHARDED --------------------------
         combined_crs = ttnn.CoreRangeSet(
@@ -981,13 +1058,19 @@ class BlitzDecodeWeights:
             shard_spec,
         )
 
+        if mla_tp == 1:
+            mesh_mapper = ttnn.ReplicateTensorToMesh(self._device)
+        else:
+            mesh_shape = (self._device.shape[0], self._device.shape[1])
+            mesh_mapper = ttnn.ShardTensor2dMesh(self._device, mesh_shape=mesh_shape, dims=(None, 0))
+
         fused = ttnn.from_torch(
             combined,
             dtype=ttnn.bfloat8_b,
             layout=ttnn.TILE_LAYOUT,
             device=self._device,
             memory_config=mem_config,
-            mesh_mapper=ttnn.ReplicateTensorToMesh(self._device),
+            mesh_mapper=mesh_mapper,
         )
 
         # -- Build OverlappedTensor views --------------------------------
@@ -1033,7 +1116,10 @@ class BlitzDecodeWeights:
         BFP4 with identical shard shapes, so ``ttnn.from_torch`` handles
         the conversion directly (no raw byte packing needed).
 
-        Layout::
+        With ``moe_tp > 1`` the outer (N) dimension is TP-sharded across
+        all devices.  Each device receives its per-TP slice (7168, 256).
+
+        Per-device layout::
 
             -- gate region: 64 A cores (non-rectangular) --
             gate_proj (7168, 256) as bfloat4_b, block-sharded
@@ -1046,28 +1132,39 @@ class BlitzDecodeWeights:
             combined: 128 cores, HEIGHT_SHARDED (114688, 32)
 
         Args:
-            gate_proj_weights: Raw gate tensor, shape (7168, 256).
-            up_proj_weights:   Raw up tensor, shape (7168, 256).
+            gate_proj_weights: Raw gate tensor, shape
+                ``(7168, 256 * moe_tp)``.  TP-sharded on the outer dim.
+            up_proj_weights:   Raw up tensor, shape
+                ``(7168, 256 * moe_tp)``.  TP-sharded on the outer dim.
 
         Returns:
             A list of two :class:`OverlappedTensor` views
             ``[gate_proj, up_proj]`` that share the same underlying fused
             device buffer.
         """
-        cfg = GATE_UP_PROJ_OVERLAP_CFG
+        cfg = GATE_UP_PROJ_SINGLE_DEVICE_OVERLAP_SPEC
+        moe_tp = self.moe_tp
 
         # -- Validate shapes --------------------------------------------
+        expected_gate_shape = (cfg.gate_proj_shape[0], cfg.gate_proj_shape[1] * moe_tp)
         assert (
-            gate_proj_weights.shape == cfg.gate_proj_shape
-        ), f"gate_proj must be {cfg.gate_proj_shape}, got {tuple(gate_proj_weights.shape)}"
+            tuple(gate_proj_weights.shape) == expected_gate_shape
+        ), f"gate_proj must be {expected_gate_shape}, got {tuple(gate_proj_weights.shape)}"
+        expected_up_shape = (cfg.up_proj_shape[0], cfg.up_proj_shape[1] * moe_tp)
         assert (
-            up_proj_weights.shape == cfg.up_proj_shape
-        ), f"up_proj must be {cfg.up_proj_shape}, got {tuple(up_proj_weights.shape)}"
+            tuple(up_proj_weights.shape) == expected_up_shape
+        ), f"up_proj must be {expected_up_shape}, got {tuple(up_proj_weights.shape)}"
 
-        # -- Stack block-shards and concatenate -------------------------
-        gate_stacked = cfg.reshuffle_block_to_height_sharded(gate_proj_weights)
-        up_stacked = cfg.reshuffle_block_to_height_sharded(up_proj_weights)
-        combined = torch.cat([gate_stacked, up_stacked], dim=0)
+        # -- Stack block-shards per TP and concatenate -------------------
+        per_device_n = cfg.gate_proj_shape[1]
+
+        per_tp_combined = []
+        for tp_idx in range(moe_tp):
+            gate_slice = gate_proj_weights[:, tp_idx * per_device_n : (tp_idx + 1) * per_device_n]
+            up_slice = up_proj_weights[:, tp_idx * per_device_n : (tp_idx + 1) * per_device_n]
+            gate_stacked = cfg.reshuffle_block_to_height_sharded(gate_slice, cfg.gate_core_range_set)
+            up_stacked = cfg.reshuffle_block_to_height_sharded(up_slice, cfg.up_core_range_set)
+            per_tp_combined.append(torch.cat([gate_stacked, up_stacked], dim=0))
 
         # -- Place on device as HEIGHT_SHARDED --------------------------
         combined_crs = ttnn.CoreRangeSet(list(cfg.gate_core_range_set.ranges()) + list(cfg.up_core_range_set.ranges()))
@@ -1083,24 +1180,36 @@ class BlitzDecodeWeights:
             shard_spec,
         )
 
+        if moe_tp == 1:
+            combined = per_tp_combined[0]
+            mesh_mapper = ttnn.ReplicateTensorToMesh(self._device)
+        else:
+            mesh_rows = self._device.shape[0]
+            mesh_cols = self._device.shape[1]
+            rows = []
+            for r in range(mesh_rows):
+                rows.append(torch.cat(per_tp_combined[r * mesh_cols : (r + 1) * mesh_cols], dim=1))
+            combined = torch.cat(rows, dim=0)
+            mesh_shape = (mesh_rows, mesh_cols)
+            mesh_mapper = ttnn.ShardTensor2dMesh(self._device, mesh_shape=mesh_shape, dims=(0, 1))
+
         fused = ttnn.from_torch(
             combined,
             dtype=ttnn.bfloat4_b,
             layout=ttnn.TILE_LAYOUT,
             device=self._device,
             memory_config=mem_config,
-            mesh_mapper=ttnn.ReplicateTensorToMesh(self._device),
+            mesh_mapper=mesh_mapper,
         )
 
         # -- Build OverlappedTensor views --------------------------------
         tile = fused.get_tile()
         ts = tuple(tile.tile_shape)
-        stacked = cfg.stacked_shape
 
         return [
             OverlappedTensor(
                 fused_tensor=fused,
-                tensor_shape=stacked,
+                tensor_shape=cfg.gate_proj_shape,
                 shard_shape=cfg.shard_shape,
                 core_range_set=cfg.gate_core_range_set,
                 dtype=ttnn.bfloat4_b,
@@ -1109,7 +1218,7 @@ class BlitzDecodeWeights:
             ),
             OverlappedTensor(
                 fused_tensor=fused,
-                tensor_shape=stacked,
+                tensor_shape=cfg.up_proj_shape,
                 shard_shape=cfg.shard_shape,
                 core_range_set=cfg.up_core_range_set,
                 dtype=ttnn.bfloat4_b,

--- a/models/demos/deepseek_v3_b1/prepare_weights.py
+++ b/models/demos/deepseek_v3_b1/prepare_weights.py
@@ -15,10 +15,7 @@ from dataclasses import dataclass
 
 import torch
 
-from models.demos.deepseek_v3_b1.blitz_decode_weights import (
-    BlitzDecodeWeights,
-    OverlappedTensor,
-)
+from models.demos.deepseek_v3_b1.blitz_decode_weights import BlitzDecodeWeights, OverlappedTensor
 
 
 @dataclass
@@ -98,30 +95,60 @@ def _key(layer_idx: int, suffix: str) -> str:
 
 
 def _split_kv_b_proj(kv_b_proj: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
-    """Split HF kv_b_proj (out_features, in_features) into kv_b1 (8192, 512) and kv_b2 (512, 8192).
+    """Split HF kv_b_proj (out_features, in_features) into kv_b1 and kv_b2.
 
-    HF shape: (num_heads * (qk_nope_head_dim + v_head_dim), kv_lora_rank) = (16384, 512).
-    Reshape to (64, 256, 512); first 128 of the 256 dim are k (b1), last 128 are v (b2).
-    Only kv_b2 is transposed for blitz; kv_b1 is used as (8192, 512).
+    Supports per-device (16384, 512) and full logical (32768, 512).
+    out_features = num_heads * (qk_nope_head_dim + v_head_dim) = num_heads * 256.
+    Reshape to (num_heads, 256, 512); first 128 dims are k (b1), last 128 are v (b2).
+    Only kv_b2 is transposed for blitz.
     """
-    # (16384, 512) -> (64, 256, 512); same layout as reference mla1d (num_heads, head_dim, kv_lora_rank)
-    w = kv_b_proj.reshape(_NUM_HEADS, _KV_B_PROJ_HEAD_DIM, _KV_LORA_RANK).contiguous()
-    # kv_b1: (64, 128, 512) -> (8192, 512); no transpose (blitz expects (8192, 512))
-    kv_b1 = w[:, : _QK_NOPE_HEAD_DIM, :].reshape(-1, _KV_LORA_RANK)
-    # kv_b2: (64, 128, 512) -> (8192, 512) then transpose -> (512, 8192) for blitz
-    kv_b2 = w[:, _QK_NOPE_HEAD_DIM :, :].reshape(-1, _KV_LORA_RANK).T.contiguous()
+    out_features, kv_lora_rank = kv_b_proj.shape
+    assert kv_lora_rank == _KV_LORA_RANK
+    num_heads = out_features // _KV_B_PROJ_HEAD_DIM
+    w = kv_b_proj.reshape(num_heads, _KV_B_PROJ_HEAD_DIM, _KV_LORA_RANK).contiguous()
+    kv_b1 = w[:, :_QK_NOPE_HEAD_DIM, :].reshape(-1, _KV_LORA_RANK)
+    kv_b2 = w[:, _QK_NOPE_HEAD_DIM:, :].reshape(-1, _KV_LORA_RANK).T.contiguous()
     return kv_b1, kv_b2
 
 
 def _get_layer_raw_tensors(
     state_dict: dict[str, torch.Tensor], layer_idx: int
 ) -> tuple[
-    torch.Tensor, torch.Tensor, torch.Tensor,
-    torch.Tensor, torch.Tensor,
     torch.Tensor,
-    torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
 ]:
     """Extract and transform raw tensors for one layer from the state dict.
+
+    HuggingFace linear weights are stored as (out_features, in_features). We
+    transpose to (K, N) for blitz_decode_weights so matmul uses input @ weight.
+    Norms are 1D in HF; we unsqueeze(0) to get (1, W). For kv_b_proj we split
+    into kv_b1 and kv_b2; only kv_b2 is transposed (see _split_kv_b_proj).
+
+    Transformation summary (HF shape -> transform -> blitz shape):
+
+        Weight          | HF key (under model.layers.{i}.)           | HF shape    | Transform           | Blitz shape
+        ----------------|------------------------------------------|-------------|---------------------|-------------
+        q_a_proj        | self_attn.q_a_proj.weight                  | (1536,7168) | .T                  | (7168, 1536)
+        q_b_proj        | self_attn.q_b_proj.weight                 | (12288,1536)| .T                  | (1536, 12288)
+        kv_a_proj       | self_attn.kv_a_proj_with_mqa.weight       | (576, 7168) | .T                  | (7168, 576)
+        kv_b1_proj      | self_attn.kv_b_proj.weight (split)       | (16384,512) | split, no transpose | (8192, 512)
+        kv_b2_proj       | self_attn.kv_b_proj.weight (split)       | (16384,512) | split + .T          | (512, 8192)
+        o_proj           | self_attn.o_proj.weight                   | (7168,8192) | .T                  | (8192, 7168)
+        attn_norm        | input_layernorm.weight                    | (7168,)     | unsqueeze(0)        | (1, 7168)
+        q_norm           | self_attn.q_a_layernorm.weight             | (1536,)     | unsqueeze(0)        | (1, 1536)
+        kv_norm          | self_attn.kv_a_layernorm.weight            | (512,)      | unsqueeze(0)        | (1, 512)
+        ffn_norm         | post_attention_layernorm.weight            | (7168,)     | unsqueeze(0)        | (1, 7168)
+
+    MoE-only weights (gate_mm, shared_gate_proj, shared_up_proj) are read and
+    transposed in prepare_moe_decoder_layer_weights, not here.
 
     Returns:
         (q_a, q_b, kv_a, kv_b1, kv_b2, o_proj, attn_norm, q_norm, kv_norm, ffn_norm).
@@ -149,16 +176,12 @@ def prepare_dense_decoder_layer_weights(
     q_a, q_b, kv_a, kv_b1, kv_b2, o_proj, attn_norm, q_norm, kv_norm, ffn_norm = _get_layer_raw_tensors(
         state_dict, layer_idx
     )
-
+    # Single device: state dict is per-device slice. Multi device: full logical; blitz shards internally. No expansion.
     q_a_proj, q_b_proj, kv_a_proj = bdw.get_tt_q_ab_proj_and_kv_a_proj_weights(q_a, q_b, kv_a)
     kv_b1_proj, kv_b2_proj = bdw.get_tt_kv_b12_proj_weights(kv_b1, kv_b2)
 
-    gate_mm_dummy = torch.zeros(
-        7168, 256, dtype=torch.bfloat16, device=next(iter(state_dict.values())).device
-    )
-    o_norms = bdw.get_tt_o_proj_and_gate_mm_weights(
-        o_proj, gate_mm_dummy, attn_norm, q_norm, kv_norm, ffn_norm
-    )
+    gate_mm_dummy = torch.zeros(7168, 256, dtype=torch.bfloat16, device=next(iter(state_dict.values())).device)
+    o_norms = bdw.get_tt_o_proj_and_gate_mm_weights(o_proj, gate_mm_dummy, attn_norm, q_norm, kv_norm, ffn_norm)
     o_proj_ot, _gate_mm_ot, attn_norm_ot, q_norm_ot, kv_norm_ot, ffn_norm_ot = o_norms
 
     return DeepSeekV3DenseLayerWeights(
@@ -184,7 +207,7 @@ def prepare_moe_decoder_layer_weights(
     q_a, q_b, kv_a, kv_b1, kv_b2, o_proj, attn_norm, q_norm, kv_norm, ffn_norm = _get_layer_raw_tensors(
         state_dict, layer_idx
     )
-
+    # Single device: per-device slice. Multi device: full logical; blitz shards. No expansion.
     q_a_proj, q_b_proj, kv_a_proj = bdw.get_tt_q_ab_proj_and_kv_a_proj_weights(q_a, q_b, kv_a)
     kv_b1_proj, kv_b2_proj = bdw.get_tt_kv_b12_proj_weights(kv_b1, kv_b2)
 
@@ -192,9 +215,7 @@ def prepare_moe_decoder_layer_weights(
     shared_gate = state_dict[_key(layer_idx, "mlp.shared_experts.gate_proj.weight")].T.contiguous()
     shared_up = state_dict[_key(layer_idx, "mlp.shared_experts.up_proj.weight")].T.contiguous()
 
-    o_norms = bdw.get_tt_o_proj_and_gate_mm_weights(
-        o_proj, gate_mm, attn_norm, q_norm, kv_norm, ffn_norm
-    )
+    o_norms = bdw.get_tt_o_proj_and_gate_mm_weights(o_proj, gate_mm, attn_norm, q_norm, kv_norm, ffn_norm)
     o_proj_ot, gate_mm_ot, attn_norm_ot, q_norm_ot, kv_norm_ot, ffn_norm_ot = o_norms
     shared_gate_proj, shared_up_proj = bdw.get_tt_gate_up_proj_weights(shared_gate, shared_up)
 

--- a/models/demos/deepseek_v3_b1/prepare_weights.py
+++ b/models/demos/deepseek_v3_b1/prepare_weights.py
@@ -20,6 +20,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 import torch
+from loguru import logger
 
 import ttnn
 from models.demos.deepseek_v3_b1.blitz_decode_weights import BlitzDecodeWeights, OverlappedTensor
@@ -313,11 +314,6 @@ def deallocate_weights(weights: DeepSeekV3Weights) -> None:
                 ttnn.deallocate(ot.fused_tensor, force=True)
 
 
-# ---------------------------------------------------------------------------
-# Serialization (save_weights / load_weights)
-# ---------------------------------------------------------------------------
-
-
 def _core_range_set_to_list(crs: ttnn.CoreRangeSet) -> list[list[list[int]]]:
     """Serialize CoreRangeSet to JSON-serializable list of [[sx, sy], [ex, ey]]."""
     result = []
@@ -399,9 +395,13 @@ def save_layer(
     Creates one directory with manifest.json and per-fusion-group .tensorbin files.
     Caller must provide hf_model_name and hf_state_dict_name for the manifest.
     """
+    logger.info(f"Saving layer {layer_idx} to {path}...")
+
     path = Path(path)
     path.mkdir(parents=True, exist_ok=True)
     layer_dir = path / f"layer_{layer_idx:03d}"
+    logger.info(f"Saving layer {layer_idx} to {layer_dir}...")
+
     layer_dir.mkdir(parents=True, exist_ok=True)
     created = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
 
@@ -413,17 +413,23 @@ def save_layer(
             by_fused[fid] = []
         by_fused[fid].append((name, ot))
 
+    logger.info(f"Creating fusion groups for layer {layer_idx}...")
     fusion_groups: dict[str, dict] = {}
     for fid, group_fields in by_fused.items():
         group_name = _FIELD_TO_FUSION_GROUP.get(group_fields[0][0])
         if group_name is None:
             raise KeyError(f"Unknown field for fusion group: {group_fields[0][0]}")
         tensorbin_name = f"{group_name}.tensorbin"
+
+        logger.info(f"Saving {tensorbin_name}...")
         ttnn.dump_tensor(layer_dir / tensorbin_name, group_fields[0][1].fused_tensor)
+        logger.info(f"Saved {tensorbin_name} to {layer_dir / tensorbin_name}...")
+
         fusion_groups[group_name] = {
             "tensorbin": tensorbin_name,
             "fields": {name: _overlapped_tensor_to_json(ot) for name, ot in group_fields},
         }
+    logger.info(f"Created fusion groups for layer {layer_idx}...")
 
     is_moe = isinstance(layer, DeepSeekV3MoELayerWeights)
     manifest = {
@@ -462,6 +468,7 @@ def load_layer(
     fusion_groups = manifest["fusion_groups"]
 
     if layer_type == "dense":
+        logger.info(f"Loading all dense tensors for layer {layer_idx}...")
         q_ab = fusion_groups["q_ab_kv_a"]
         fused_q = ttnn.load_tensor(layer_dir / q_ab["tensorbin"], device=device)
         q_a_proj = _overlapped_tensor_from_dict(fused_q, q_ab["fields"]["q_a_proj"])
@@ -480,6 +487,7 @@ def load_layer(
         fused_kv = ttnn.load_tensor(layer_dir / kv_grp["tensorbin"], device=device)
         kv_b1_proj = _overlapped_tensor_from_dict(fused_kv, kv_grp["fields"]["kv_b1_proj"])
         kv_b2_proj = _overlapped_tensor_from_dict(fused_kv, kv_grp["fields"]["kv_b2_proj"])
+        logger.info(f"Loaded all dense tensors for layer {layer_idx}...")
 
         return DeepSeekV3DenseLayerWeights(
             q_a_proj=q_a_proj,
@@ -494,6 +502,7 @@ def load_layer(
             kv_b2_proj=kv_b2_proj,
         )
     else:
+        logger.info(f"Loading all dense tensors for layer {layer_idx}...")
         q_ab = fusion_groups["q_ab_kv_a"]
         fused_q = ttnn.load_tensor(layer_dir / q_ab["tensorbin"], device=device)
         q_a_proj = _overlapped_tensor_from_dict(fused_q, q_ab["fields"]["q_a_proj"])
@@ -518,6 +527,7 @@ def load_layer(
         fused_gu = ttnn.load_tensor(layer_dir / gu_grp["tensorbin"], device=device)
         shared_gate_proj = _overlapped_tensor_from_dict(fused_gu, gu_grp["fields"]["shared_gate_proj"])
         shared_up_proj = _overlapped_tensor_from_dict(fused_gu, gu_grp["fields"]["shared_up_proj"])
+        logger.info(f"Loaded all MoE tensors for layer {layer_idx}...")
 
         return DeepSeekV3MoELayerWeights(
             q_a_proj=q_a_proj,

--- a/models/demos/deepseek_v3_b1/prepare_weights.py
+++ b/models/demos/deepseek_v3_b1/prepare_weights.py
@@ -113,6 +113,108 @@ def _split_kv_b_proj(kv_b_proj: torch.Tensor) -> tuple[torch.Tensor, torch.Tenso
     return kv_b1, kv_b2
 
 
+def _get_layer_raw_tensors(
+    state_dict: dict[str, torch.Tensor], layer_idx: int
+) -> tuple[
+    torch.Tensor, torch.Tensor, torch.Tensor,
+    torch.Tensor, torch.Tensor,
+    torch.Tensor,
+    torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor,
+]:
+    """Extract and transform raw tensors for one layer from the state dict.
+
+    Returns:
+        (q_a, q_b, kv_a, kv_b1, kv_b2, o_proj, attn_norm, q_norm, kv_norm, ffn_norm).
+    """
+    q_a = state_dict[_key(layer_idx, "self_attn.q_a_proj.weight")].T.contiguous()
+    q_b = state_dict[_key(layer_idx, "self_attn.q_b_proj.weight")].T.contiguous()
+    kv_a = state_dict[_key(layer_idx, "self_attn.kv_a_proj_with_mqa.weight")].T.contiguous()
+    kv_b1, kv_b2 = _split_kv_b_proj(state_dict[_key(layer_idx, "self_attn.kv_b_proj.weight")])
+    o_proj = state_dict[_key(layer_idx, "self_attn.o_proj.weight")].T.contiguous()
+
+    attn_norm = state_dict[_key(layer_idx, "input_layernorm.weight")].unsqueeze(0)
+    q_norm = state_dict[_key(layer_idx, "self_attn.q_a_layernorm.weight")].unsqueeze(0)
+    kv_norm = state_dict[_key(layer_idx, "self_attn.kv_a_layernorm.weight")].unsqueeze(0)
+    ffn_norm = state_dict[_key(layer_idx, "post_attention_layernorm.weight")].unsqueeze(0)
+
+    return q_a, q_b, kv_a, kv_b1, kv_b2, o_proj, attn_norm, q_norm, kv_norm, ffn_norm
+
+
+def prepare_dense_decoder_layer_weights(
+    bdw: BlitzDecodeWeights,
+    state_dict: dict[str, torch.Tensor],
+    layer_idx: int,
+) -> DeepSeekV3DenseLayerWeights:
+    """Prepare fused weights for a single dense decoder layer."""
+    q_a, q_b, kv_a, kv_b1, kv_b2, o_proj, attn_norm, q_norm, kv_norm, ffn_norm = _get_layer_raw_tensors(
+        state_dict, layer_idx
+    )
+
+    q_a_proj, q_b_proj, kv_a_proj = bdw.get_tt_q_ab_proj_and_kv_a_proj_weights(q_a, q_b, kv_a)
+    kv_b1_proj, kv_b2_proj = bdw.get_tt_kv_b12_proj_weights(kv_b1, kv_b2)
+
+    gate_mm_dummy = torch.zeros(
+        7168, 256, dtype=torch.bfloat16, device=next(iter(state_dict.values())).device
+    )
+    o_norms = bdw.get_tt_o_proj_and_gate_mm_weights(
+        o_proj, gate_mm_dummy, attn_norm, q_norm, kv_norm, ffn_norm
+    )
+    o_proj_ot, _gate_mm_ot, attn_norm_ot, q_norm_ot, kv_norm_ot, ffn_norm_ot = o_norms
+
+    return DeepSeekV3DenseLayerWeights(
+        q_a_proj=q_a_proj,
+        q_b_proj=q_b_proj,
+        kv_a_proj=kv_a_proj,
+        o_proj=o_proj_ot,
+        attn_norm=attn_norm_ot,
+        q_norm=q_norm_ot,
+        kv_norm=kv_norm_ot,
+        ffn_norm=ffn_norm_ot,
+        kv_b1_proj=kv_b1_proj,
+        kv_b2_proj=kv_b2_proj,
+    )
+
+
+def prepare_moe_decoder_layer_weights(
+    bdw: BlitzDecodeWeights,
+    state_dict: dict[str, torch.Tensor],
+    layer_idx: int,
+) -> DeepSeekV3MoELayerWeights:
+    """Prepare fused weights for a single MoE decoder layer."""
+    q_a, q_b, kv_a, kv_b1, kv_b2, o_proj, attn_norm, q_norm, kv_norm, ffn_norm = _get_layer_raw_tensors(
+        state_dict, layer_idx
+    )
+
+    q_a_proj, q_b_proj, kv_a_proj = bdw.get_tt_q_ab_proj_and_kv_a_proj_weights(q_a, q_b, kv_a)
+    kv_b1_proj, kv_b2_proj = bdw.get_tt_kv_b12_proj_weights(kv_b1, kv_b2)
+
+    gate_mm = state_dict[_key(layer_idx, "mlp.gate.weight")].T.contiguous()
+    shared_gate = state_dict[_key(layer_idx, "mlp.shared_experts.gate_proj.weight")].T.contiguous()
+    shared_up = state_dict[_key(layer_idx, "mlp.shared_experts.up_proj.weight")].T.contiguous()
+
+    o_norms = bdw.get_tt_o_proj_and_gate_mm_weights(
+        o_proj, gate_mm, attn_norm, q_norm, kv_norm, ffn_norm
+    )
+    o_proj_ot, gate_mm_ot, attn_norm_ot, q_norm_ot, kv_norm_ot, ffn_norm_ot = o_norms
+    shared_gate_proj, shared_up_proj = bdw.get_tt_gate_up_proj_weights(shared_gate, shared_up)
+
+    return DeepSeekV3MoELayerWeights(
+        q_a_proj=q_a_proj,
+        q_b_proj=q_b_proj,
+        kv_a_proj=kv_a_proj,
+        o_proj=o_proj_ot,
+        gate_mm=gate_mm_ot,
+        attn_norm=attn_norm_ot,
+        q_norm=q_norm_ot,
+        kv_norm=kv_norm_ot,
+        ffn_norm=ffn_norm_ot,
+        kv_b1_proj=kv_b1_proj,
+        kv_b2_proj=kv_b2_proj,
+        shared_gate_proj=shared_gate_proj,
+        shared_up_proj=shared_up_proj,
+    )
+
+
 def prepare_weights(
     state_dict: dict[str, torch.Tensor],
     device,
@@ -134,77 +236,10 @@ def prepare_weights(
     layers: list[DeepSeekV3LayerWeights] = []
 
     for i in range(num_layers):
-        prefix = f"model.layers.{i}."
-
-        # Linear weights: HF (out_features, in_features) -> (K, N) for blitz. All transposed except kv_b1.
-        q_a = state_dict[_key(i, "self_attn.q_a_proj.weight")].T.contiguous()
-        q_b = state_dict[_key(i, "self_attn.q_b_proj.weight")].T.contiguous()
-        kv_a = state_dict[_key(i, "self_attn.kv_a_proj_with_mqa.weight")].T.contiguous()
-        kv_b1, kv_b2 = _split_kv_b_proj(state_dict[_key(i, "self_attn.kv_b_proj.weight")])  # b1 no transpose, b2 transposed inside
-        o_proj = state_dict[_key(i, "self_attn.o_proj.weight")].T.contiguous()
-
-        # Norms: (C,) -> (1, C)
-        attn_norm = state_dict[_key(i, "input_layernorm.weight")].unsqueeze(0)
-        q_norm = state_dict[_key(i, "self_attn.q_a_layernorm.weight")].unsqueeze(0)
-        kv_norm = state_dict[_key(i, "self_attn.kv_a_layernorm.weight")].unsqueeze(0)
-        ffn_norm = state_dict[_key(i, "post_attention_layernorm.weight")].unsqueeze(0)
-
-        q_ab_kv_a = bdw.get_tt_q_ab_proj_and_kv_a_proj_weights(q_a, q_b, kv_a)
-        q_a_proj, q_b_proj, kv_a_proj = q_ab_kv_a
-
-        kv_b12 = bdw.get_tt_kv_b12_proj_weights(kv_b1, kv_b2)
-        kv_b1_proj, kv_b2_proj = kv_b12
-
-        if i < first_k_dense_replace:
-            gate_mm_dummy = torch.zeros(
-                7168, 256, dtype=torch.bfloat16, device=next(iter(state_dict.values())).device
-            )
-            o_norms = bdw.get_tt_o_proj_and_gate_mm_weights(
-                o_proj, gate_mm_dummy, attn_norm, q_norm, kv_norm, ffn_norm
-            )
-            o_proj_ot, gate_mm_ot, attn_norm_ot, q_norm_ot, kv_norm_ot, ffn_norm_ot = o_norms
-            layers.append(
-                DeepSeekV3DenseLayerWeights(
-                    q_a_proj=q_a_proj,
-                    q_b_proj=q_b_proj,
-                    kv_a_proj=kv_a_proj,
-                    o_proj=o_proj_ot,
-                    attn_norm=attn_norm_ot,
-                    q_norm=q_norm_ot,
-                    kv_norm=kv_norm_ot,
-                    ffn_norm=ffn_norm_ot,
-                    kv_b1_proj=kv_b1_proj,
-                    kv_b2_proj=kv_b2_proj,
-                )
-            )
+        is_moe = i >= first_k_dense_replace
+        if is_moe:
+            layers.append(prepare_moe_decoder_layer_weights(bdw, state_dict, i))
         else:
-            gate_mm = state_dict[_key(i, "mlp.gate.weight")].T.contiguous()
-            shared_gate = state_dict[_key(i, "mlp.shared_experts.gate_proj.weight")].T.contiguous()
-            shared_up = state_dict[_key(i, "mlp.shared_experts.up_proj.weight")].T.contiguous()
-
-            o_norms = bdw.get_tt_o_proj_and_gate_mm_weights(
-                o_proj, gate_mm, attn_norm, q_norm, kv_norm, ffn_norm
-            )
-            o_proj_ot, gate_mm_ot, attn_norm_ot, q_norm_ot, kv_norm_ot, ffn_norm_ot = o_norms
-            gate_up = bdw.get_tt_gate_up_proj_weights(shared_gate, shared_up)
-            shared_gate_proj, shared_up_proj = gate_up
-
-            layers.append(
-                DeepSeekV3MoELayerWeights(
-                    q_a_proj=q_a_proj,
-                    q_b_proj=q_b_proj,
-                    kv_a_proj=kv_a_proj,
-                    o_proj=o_proj_ot,
-                    gate_mm=gate_mm_ot,
-                    attn_norm=attn_norm_ot,
-                    q_norm=q_norm_ot,
-                    kv_norm=kv_norm_ot,
-                    ffn_norm=ffn_norm_ot,
-                    kv_b1_proj=kv_b1_proj,
-                    kv_b2_proj=kv_b2_proj,
-                    shared_gate_proj=shared_gate_proj,
-                    shared_up_proj=shared_up_proj,
-                )
-            )
+            layers.append(prepare_dense_decoder_layer_weights(bdw, state_dict, i))
 
     return DeepSeekV3Weights(layers=layers)

--- a/models/demos/deepseek_v3_b1/prepare_weights.py
+++ b/models/demos/deepseek_v3_b1/prepare_weights.py
@@ -1,0 +1,210 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Prepare DeepSeek V3 fused (blitz decode) weights from a state dict.
+
+Provides prepare_weights(state_dict, device, ...) -> DeepSeekV3Weights and
+dataclasses for dense vs MoE layer weight containers.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import torch
+
+from models.demos.deepseek_v3_b1.blitz_decode_weights import (
+    BlitzDecodeWeights,
+    OverlappedTensor,
+)
+
+
+@dataclass
+class DeepSeekV3DenseLayerWeights:
+    """Weights for a dense layer (0..first_k_dense_replace-1).
+
+    Has the 3 attention fusion groups and o_proj + norms (no gate_mm).
+    """
+
+    # From get_tt_q_ab_proj_and_kv_a_proj_weights
+    q_a_proj: OverlappedTensor
+    q_b_proj: OverlappedTensor
+    kv_a_proj: OverlappedTensor
+
+    # From get_tt_o_proj_and_gate_mm_weights (no gate_mm for dense)
+    o_proj: OverlappedTensor
+    attn_norm: OverlappedTensor
+    q_norm: OverlappedTensor
+    kv_norm: OverlappedTensor
+    ffn_norm: OverlappedTensor
+
+    # From get_tt_kv_b12_proj_weights
+    kv_b1_proj: OverlappedTensor
+    kv_b2_proj: OverlappedTensor
+
+
+@dataclass
+class DeepSeekV3MoELayerWeights:
+    """Weights for an MoE layer (first_k_dense_replace..num_layers-1).
+
+    Extends dense with gate_mm and shared expert projections.
+    """
+
+    # From get_tt_q_ab_proj_and_kv_a_proj_weights
+    q_a_proj: OverlappedTensor
+    q_b_proj: OverlappedTensor
+    kv_a_proj: OverlappedTensor
+
+    # From get_tt_o_proj_and_gate_mm_weights (includes gate_mm)
+    o_proj: OverlappedTensor
+    gate_mm: OverlappedTensor
+    attn_norm: OverlappedTensor
+    q_norm: OverlappedTensor
+    kv_norm: OverlappedTensor
+    ffn_norm: OverlappedTensor
+
+    # From get_tt_kv_b12_proj_weights
+    kv_b1_proj: OverlappedTensor
+    kv_b2_proj: OverlappedTensor
+
+    # From get_tt_gate_up_proj_weights (shared expert)
+    shared_gate_proj: OverlappedTensor
+    shared_up_proj: OverlappedTensor
+
+
+DeepSeekV3LayerWeights = DeepSeekV3DenseLayerWeights | DeepSeekV3MoELayerWeights
+
+
+@dataclass
+class DeepSeekV3Weights:
+    """Container for all prepared (fused) layer weights."""
+
+    layers: list[DeepSeekV3LayerWeights]
+
+
+# Constants for kv_b_proj split (HF stores one matrix; we split into kv_b1 and kv_b2).
+_NUM_HEADS = 64
+_QK_NOPE_HEAD_DIM = 128
+_V_HEAD_DIM = 128
+_KV_LORA_RANK = 512
+_KV_B_PROJ_HEAD_DIM = _QK_NOPE_HEAD_DIM + _V_HEAD_DIM  # 256
+
+
+def _key(layer_idx: int, suffix: str) -> str:
+    """State dict key under model.layers.{layer_idx}."""
+    return f"model.layers.{layer_idx}.{suffix}"
+
+
+def _split_kv_b_proj(kv_b_proj: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+    """Split HF kv_b_proj (out_features, in_features) into kv_b1 (8192, 512) and kv_b2 (512, 8192).
+
+    HF shape: (num_heads * (qk_nope_head_dim + v_head_dim), kv_lora_rank) = (16384, 512).
+    Reshape to (64, 256, 512); first 128 of the 256 dim are k (b1), last 128 are v (b2).
+    Only kv_b2 is transposed for blitz; kv_b1 is used as (8192, 512).
+    """
+    # (16384, 512) -> (64, 256, 512); same layout as reference mla1d (num_heads, head_dim, kv_lora_rank)
+    w = kv_b_proj.reshape(_NUM_HEADS, _KV_B_PROJ_HEAD_DIM, _KV_LORA_RANK).contiguous()
+    # kv_b1: (64, 128, 512) -> (8192, 512); no transpose (blitz expects (8192, 512))
+    kv_b1 = w[:, : _QK_NOPE_HEAD_DIM, :].reshape(-1, _KV_LORA_RANK)
+    # kv_b2: (64, 128, 512) -> (8192, 512) then transpose -> (512, 8192) for blitz
+    kv_b2 = w[:, _QK_NOPE_HEAD_DIM :, :].reshape(-1, _KV_LORA_RANK).T.contiguous()
+    return kv_b1, kv_b2
+
+
+def prepare_weights(
+    state_dict: dict[str, torch.Tensor],
+    device,
+    num_layers: int = 61,
+    first_k_dense_replace: int = 3,
+) -> DeepSeekV3Weights:
+    """Build fused (blitz decode) weights from a HuggingFace-style state dict.
+
+    Args:
+        state_dict: Weights keyed by model.layers.{i}.self_attn.*, model.layers.{i}.mlp.*, etc.
+        device: ttnn device (or MeshDevice) to place tensors on.
+        num_layers: Total number of layers (default 61).
+        first_k_dense_replace: Number of dense layers before MoE (default 3).
+
+    Returns:
+        DeepSeekV3Weights with one entry per layer; dense vs MoE type by layer index.
+    """
+    bdw = BlitzDecodeWeights(device)
+    layers: list[DeepSeekV3LayerWeights] = []
+
+    for i in range(num_layers):
+        prefix = f"model.layers.{i}."
+
+        # Linear weights: HF (out_features, in_features) -> (K, N) for blitz. All transposed except kv_b1.
+        q_a = state_dict[_key(i, "self_attn.q_a_proj.weight")].T.contiguous()
+        q_b = state_dict[_key(i, "self_attn.q_b_proj.weight")].T.contiguous()
+        kv_a = state_dict[_key(i, "self_attn.kv_a_proj_with_mqa.weight")].T.contiguous()
+        kv_b1, kv_b2 = _split_kv_b_proj(state_dict[_key(i, "self_attn.kv_b_proj.weight")])  # b1 no transpose, b2 transposed inside
+        o_proj = state_dict[_key(i, "self_attn.o_proj.weight")].T.contiguous()
+
+        # Norms: (C,) -> (1, C)
+        attn_norm = state_dict[_key(i, "input_layernorm.weight")].unsqueeze(0)
+        q_norm = state_dict[_key(i, "self_attn.q_a_layernorm.weight")].unsqueeze(0)
+        kv_norm = state_dict[_key(i, "self_attn.kv_a_layernorm.weight")].unsqueeze(0)
+        ffn_norm = state_dict[_key(i, "post_attention_layernorm.weight")].unsqueeze(0)
+
+        q_ab_kv_a = bdw.get_tt_q_ab_proj_and_kv_a_proj_weights(q_a, q_b, kv_a)
+        q_a_proj, q_b_proj, kv_a_proj = q_ab_kv_a
+
+        kv_b12 = bdw.get_tt_kv_b12_proj_weights(kv_b1, kv_b2)
+        kv_b1_proj, kv_b2_proj = kv_b12
+
+        if i < first_k_dense_replace:
+            gate_mm_dummy = torch.zeros(
+                7168, 256, dtype=torch.bfloat16, device=next(iter(state_dict.values())).device
+            )
+            o_norms = bdw.get_tt_o_proj_and_gate_mm_weights(
+                o_proj, gate_mm_dummy, attn_norm, q_norm, kv_norm, ffn_norm
+            )
+            o_proj_ot, gate_mm_ot, attn_norm_ot, q_norm_ot, kv_norm_ot, ffn_norm_ot = o_norms
+            layers.append(
+                DeepSeekV3DenseLayerWeights(
+                    q_a_proj=q_a_proj,
+                    q_b_proj=q_b_proj,
+                    kv_a_proj=kv_a_proj,
+                    o_proj=o_proj_ot,
+                    attn_norm=attn_norm_ot,
+                    q_norm=q_norm_ot,
+                    kv_norm=kv_norm_ot,
+                    ffn_norm=ffn_norm_ot,
+                    kv_b1_proj=kv_b1_proj,
+                    kv_b2_proj=kv_b2_proj,
+                )
+            )
+        else:
+            gate_mm = state_dict[_key(i, "mlp.gate.weight")].T.contiguous()
+            shared_gate = state_dict[_key(i, "mlp.shared_experts.gate_proj.weight")].T.contiguous()
+            shared_up = state_dict[_key(i, "mlp.shared_experts.up_proj.weight")].T.contiguous()
+
+            o_norms = bdw.get_tt_o_proj_and_gate_mm_weights(
+                o_proj, gate_mm, attn_norm, q_norm, kv_norm, ffn_norm
+            )
+            o_proj_ot, gate_mm_ot, attn_norm_ot, q_norm_ot, kv_norm_ot, ffn_norm_ot = o_norms
+            gate_up = bdw.get_tt_gate_up_proj_weights(shared_gate, shared_up)
+            shared_gate_proj, shared_up_proj = gate_up
+
+            layers.append(
+                DeepSeekV3MoELayerWeights(
+                    q_a_proj=q_a_proj,
+                    q_b_proj=q_b_proj,
+                    kv_a_proj=kv_a_proj,
+                    o_proj=o_proj_ot,
+                    gate_mm=gate_mm_ot,
+                    attn_norm=attn_norm_ot,
+                    q_norm=q_norm_ot,
+                    kv_norm=kv_norm_ot,
+                    ffn_norm=ffn_norm_ot,
+                    kv_b1_proj=kv_b1_proj,
+                    kv_b2_proj=kv_b2_proj,
+                    shared_gate_proj=shared_gate_proj,
+                    shared_up_proj=shared_up_proj,
+                )
+            )
+
+    return DeepSeekV3Weights(layers=layers)

--- a/models/demos/deepseek_v3_b1/prepare_weights.py
+++ b/models/demos/deepseek_v3_b1/prepare_weights.py
@@ -8,15 +8,48 @@ Prepare DeepSeek V3 fused (blitz decode) weights from a state dict.
 Takes full HuggingFace state dict tensors (or per-device slice for single-device
 tests), applies key mapping, transpose, and kv_b split, then passes to
 BlitzDecodeWeights which fuses and shards onto the device or mesh.
+
+Supports save_weights / load_weights for offline preparation and runtime load.
 """
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+import json
+from dataclasses import dataclass, fields
+from datetime import datetime, timezone
+from pathlib import Path
 
 import torch
 
+import ttnn
 from models.demos.deepseek_v3_b1.blitz_decode_weights import BlitzDecodeWeights, OverlappedTensor
+
+# Serialization: manifest version and dtype name mapping
+_MANIFEST_VERSION = 1
+_DTYPE_TO_STR = {
+    ttnn.DataType.BFLOAT4_B: "BFLOAT4_B",
+    ttnn.DataType.BFLOAT8_B: "BFLOAT8_B",
+    ttnn.DataType.UINT32: "UINT32",
+    ttnn.DataType.BFLOAT16: "BFLOAT16",
+}
+_STR_TO_DTYPE = {v: k for k, v in _DTYPE_TO_STR.items()}
+
+# Fusion group name per field (for grouping by fused_tensor)
+_FIELD_TO_FUSION_GROUP: dict[str, str] = {
+    "q_a_proj": "q_ab_kv_a",
+    "q_b_proj": "q_ab_kv_a",
+    "kv_a_proj": "q_ab_kv_a",
+    "o_proj": "o_proj_gate_mm_norms",
+    "gate_mm": "o_proj_gate_mm_norms",
+    "attn_norm": "o_proj_gate_mm_norms",
+    "q_norm": "o_proj_gate_mm_norms",
+    "kv_norm": "o_proj_gate_mm_norms",
+    "ffn_norm": "o_proj_gate_mm_norms",
+    "kv_b1_proj": "kv_b12",
+    "kv_b2_proj": "kv_b12",
+    "shared_gate_proj": "gate_up",
+    "shared_up_proj": "gate_up",
+}
 
 
 @dataclass
@@ -262,4 +295,276 @@ def prepare_weights(
         else:
             layers.append(prepare_dense_decoder_layer_weights(bdw, state_dict, i))
 
+    return DeepSeekV3Weights(layers=layers)
+
+
+def deallocate_weights(weights: DeepSeekV3Weights) -> None:
+    """Release device memory for all fused tensors in prepared weights.
+
+    Call this before loading a new set of weights onto the same device to avoid
+    OOM (the original and loaded weights would otherwise both reside on device).
+    """
+    seen: set[int] = set()
+    for layer in weights.layers:
+        for _name, ot in _layer_overlapped_tensor_fields(layer):
+            fid = id(ot.fused_tensor)
+            if fid not in seen:
+                seen.add(fid)
+                ttnn.deallocate(ot.fused_tensor, force=True)
+
+
+# ---------------------------------------------------------------------------
+# Serialization (save_weights / load_weights)
+# ---------------------------------------------------------------------------
+
+
+def _core_range_set_to_list(crs: ttnn.CoreRangeSet) -> list[list[list[int]]]:
+    """Serialize CoreRangeSet to JSON-serializable list of [[sx, sy], [ex, ey]]."""
+    result = []
+    for r in crs.ranges():
+        start, end = r.start, r.end
+        result.append([[start.x, start.y], [end.x, end.y]])
+    return result
+
+
+def _core_range_set_from_list(lst: list[list[list[int]]]) -> ttnn.CoreRangeSet:
+    """Deserialize list of [[sx, sy], [ex, ey]] to CoreRangeSet."""
+    ranges = [
+        ttnn.CoreRange(
+            ttnn.CoreCoord(pair[0][0], pair[0][1]),
+            ttnn.CoreCoord(pair[1][0], pair[1][1]),
+        )
+        for pair in lst
+    ]
+    return ttnn.CoreRangeSet(ranges)
+
+
+def _overlapped_tensor_to_json(ot: OverlappedTensor) -> dict:
+    """Serialize one OverlappedTensor's metadata to a JSON-serializable dict."""
+    dtype_str = _DTYPE_TO_STR.get(ot.dtype)
+    if dtype_str is None:
+        dtype_str = str(ot.dtype)
+    return {
+        "tensor_shape": list(ot.tensor_shape),
+        "shard_shape": list(ot.shard_shape),
+        "core_range_set": _core_range_set_to_list(ot.core_range_set),
+        "dtype": dtype_str,
+        "tile_shape": list(ot.tile_shape),
+        "byte_offset": ot.byte_offset,
+    }
+
+
+def _overlapped_tensor_from_dict(
+    fused_tensor: ttnn.Tensor,
+    d: dict,
+) -> OverlappedTensor:
+    """Reconstruct one OverlappedTensor from loaded fused tensor and manifest dict."""
+    dtype = _STR_TO_DTYPE.get(d["dtype"])
+    if dtype is None:
+        raise ValueError(f"Unknown dtype in manifest: {d['dtype']}")
+    return OverlappedTensor(
+        fused_tensor=fused_tensor,
+        tensor_shape=tuple(d["tensor_shape"]),
+        shard_shape=tuple(d["shard_shape"]),
+        core_range_set=_core_range_set_from_list(d["core_range_set"]),
+        dtype=dtype,
+        tile_shape=tuple(d["tile_shape"]),
+        byte_offset=d["byte_offset"],
+    )
+
+
+def _layer_overlapped_tensor_fields(
+    layer: DeepSeekV3LayerWeights,
+) -> list[tuple[str, OverlappedTensor]]:
+    """Return (field_name, OverlappedTensor) for every OverlappedTensor field on the layer."""
+    out = []
+    for f in fields(layer):
+        val = getattr(layer, f.name)
+        if isinstance(val, OverlappedTensor):
+            out.append((f.name, val))
+    return out
+
+
+def save_layer(
+    layer: DeepSeekV3LayerWeights,
+    path: str | Path,
+    layer_idx: int,
+    *,
+    hf_model_name: str,
+    hf_state_dict_name: str,
+    device_mesh_shape: tuple[int, int] = (1, 1),
+) -> None:
+    """Serialize a single layer to <path>/layer_{layer_idx:03d}/.
+
+    Creates one directory with manifest.json and per-fusion-group .tensorbin files.
+    Caller must provide hf_model_name and hf_state_dict_name for the manifest.
+    """
+    path = Path(path)
+    path.mkdir(parents=True, exist_ok=True)
+    layer_dir = path / f"layer_{layer_idx:03d}"
+    layer_dir.mkdir(parents=True, exist_ok=True)
+    created = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    fields_list = _layer_overlapped_tensor_fields(layer)
+    by_fused: dict[int, list[tuple[str, OverlappedTensor]]] = {}
+    for name, ot in fields_list:
+        fid = id(ot.fused_tensor)
+        if fid not in by_fused:
+            by_fused[fid] = []
+        by_fused[fid].append((name, ot))
+
+    fusion_groups: dict[str, dict] = {}
+    for fid, group_fields in by_fused.items():
+        group_name = _FIELD_TO_FUSION_GROUP.get(group_fields[0][0])
+        if group_name is None:
+            raise KeyError(f"Unknown field for fusion group: {group_fields[0][0]}")
+        tensorbin_name = f"{group_name}.tensorbin"
+        ttnn.dump_tensor(layer_dir / tensorbin_name, group_fields[0][1].fused_tensor)
+        fusion_groups[group_name] = {
+            "tensorbin": tensorbin_name,
+            "fields": {name: _overlapped_tensor_to_json(ot) for name, ot in group_fields},
+        }
+
+    is_moe = isinstance(layer, DeepSeekV3MoELayerWeights)
+    manifest = {
+        "version": _MANIFEST_VERSION,
+        "created_time": created,
+        "hf_model_name": hf_model_name,
+        "hf_state_dict_name": hf_state_dict_name,
+        "device_mesh_shape": list(device_mesh_shape),
+        "layer_idx": layer_idx,
+        "layer_type": "moe" if is_moe else "dense",
+        "fusion_groups": fusion_groups,
+    }
+    with open(layer_dir / "manifest.json", "w") as f:
+        json.dump(manifest, f, indent=2)
+
+
+def load_layer(
+    path: str | Path,
+    device,
+    layer_idx: int,
+) -> DeepSeekV3LayerWeights:
+    """Deserialize a single layer from <path>/layer_{layer_idx:03d}/."""
+    path = Path(path)
+    layer_dir = path / f"layer_{layer_idx:03d}"
+    manifest_path = layer_dir / "manifest.json"
+    if not manifest_path.exists():
+        raise FileNotFoundError(f"Missing manifest: {manifest_path}")
+
+    with open(manifest_path) as f:
+        manifest = json.load(f)
+
+    if manifest.get("version", 0) > _MANIFEST_VERSION:
+        raise ValueError(f"Unsupported manifest version: {manifest.get('version')}")
+
+    layer_type = manifest["layer_type"]
+    fusion_groups = manifest["fusion_groups"]
+
+    if layer_type == "dense":
+        q_ab = fusion_groups["q_ab_kv_a"]
+        fused_q = ttnn.load_tensor(layer_dir / q_ab["tensorbin"], device=device)
+        q_a_proj = _overlapped_tensor_from_dict(fused_q, q_ab["fields"]["q_a_proj"])
+        q_b_proj = _overlapped_tensor_from_dict(fused_q, q_ab["fields"]["q_b_proj"])
+        kv_a_proj = _overlapped_tensor_from_dict(fused_q, q_ab["fields"]["kv_a_proj"])
+
+        o_grp = fusion_groups["o_proj_gate_mm_norms"]
+        fused_o = ttnn.load_tensor(layer_dir / o_grp["tensorbin"], device=device)
+        o_proj = _overlapped_tensor_from_dict(fused_o, o_grp["fields"]["o_proj"])
+        attn_norm = _overlapped_tensor_from_dict(fused_o, o_grp["fields"]["attn_norm"])
+        q_norm = _overlapped_tensor_from_dict(fused_o, o_grp["fields"]["q_norm"])
+        kv_norm = _overlapped_tensor_from_dict(fused_o, o_grp["fields"]["kv_norm"])
+        ffn_norm = _overlapped_tensor_from_dict(fused_o, o_grp["fields"]["ffn_norm"])
+
+        kv_grp = fusion_groups["kv_b12"]
+        fused_kv = ttnn.load_tensor(layer_dir / kv_grp["tensorbin"], device=device)
+        kv_b1_proj = _overlapped_tensor_from_dict(fused_kv, kv_grp["fields"]["kv_b1_proj"])
+        kv_b2_proj = _overlapped_tensor_from_dict(fused_kv, kv_grp["fields"]["kv_b2_proj"])
+
+        return DeepSeekV3DenseLayerWeights(
+            q_a_proj=q_a_proj,
+            q_b_proj=q_b_proj,
+            kv_a_proj=kv_a_proj,
+            o_proj=o_proj,
+            attn_norm=attn_norm,
+            q_norm=q_norm,
+            kv_norm=kv_norm,
+            ffn_norm=ffn_norm,
+            kv_b1_proj=kv_b1_proj,
+            kv_b2_proj=kv_b2_proj,
+        )
+    else:
+        q_ab = fusion_groups["q_ab_kv_a"]
+        fused_q = ttnn.load_tensor(layer_dir / q_ab["tensorbin"], device=device)
+        q_a_proj = _overlapped_tensor_from_dict(fused_q, q_ab["fields"]["q_a_proj"])
+        q_b_proj = _overlapped_tensor_from_dict(fused_q, q_ab["fields"]["q_b_proj"])
+        kv_a_proj = _overlapped_tensor_from_dict(fused_q, q_ab["fields"]["kv_a_proj"])
+
+        o_grp = fusion_groups["o_proj_gate_mm_norms"]
+        fused_o = ttnn.load_tensor(layer_dir / o_grp["tensorbin"], device=device)
+        o_proj = _overlapped_tensor_from_dict(fused_o, o_grp["fields"]["o_proj"])
+        gate_mm = _overlapped_tensor_from_dict(fused_o, o_grp["fields"]["gate_mm"])
+        attn_norm = _overlapped_tensor_from_dict(fused_o, o_grp["fields"]["attn_norm"])
+        q_norm = _overlapped_tensor_from_dict(fused_o, o_grp["fields"]["q_norm"])
+        kv_norm = _overlapped_tensor_from_dict(fused_o, o_grp["fields"]["kv_norm"])
+        ffn_norm = _overlapped_tensor_from_dict(fused_o, o_grp["fields"]["ffn_norm"])
+
+        kv_grp = fusion_groups["kv_b12"]
+        fused_kv = ttnn.load_tensor(layer_dir / kv_grp["tensorbin"], device=device)
+        kv_b1_proj = _overlapped_tensor_from_dict(fused_kv, kv_grp["fields"]["kv_b1_proj"])
+        kv_b2_proj = _overlapped_tensor_from_dict(fused_kv, kv_grp["fields"]["kv_b2_proj"])
+
+        gu_grp = fusion_groups["gate_up"]
+        fused_gu = ttnn.load_tensor(layer_dir / gu_grp["tensorbin"], device=device)
+        shared_gate_proj = _overlapped_tensor_from_dict(fused_gu, gu_grp["fields"]["shared_gate_proj"])
+        shared_up_proj = _overlapped_tensor_from_dict(fused_gu, gu_grp["fields"]["shared_up_proj"])
+
+        return DeepSeekV3MoELayerWeights(
+            q_a_proj=q_a_proj,
+            q_b_proj=q_b_proj,
+            kv_a_proj=kv_a_proj,
+            o_proj=o_proj,
+            gate_mm=gate_mm,
+            attn_norm=attn_norm,
+            q_norm=q_norm,
+            kv_norm=kv_norm,
+            ffn_norm=ffn_norm,
+            kv_b1_proj=kv_b1_proj,
+            kv_b2_proj=kv_b2_proj,
+            shared_gate_proj=shared_gate_proj,
+            shared_up_proj=shared_up_proj,
+        )
+
+
+def save_weights(
+    weights: DeepSeekV3Weights,
+    path: str | Path,
+    *,
+    hf_model_name: str,
+    hf_state_dict_name: str,
+    device_mesh_shape: tuple[int, int] = (1, 1),
+) -> None:
+    """Serialize all layers to disk. Convenience wrapper around save_layer."""
+    path = Path(path)
+    for layer_idx, layer in enumerate(weights.layers):
+        save_layer(
+            layer,
+            path,
+            layer_idx,
+            hf_model_name=hf_model_name,
+            hf_state_dict_name=hf_state_dict_name,
+            device_mesh_shape=device_mesh_shape,
+        )
+
+
+def load_weights(
+    path: str | Path,
+    device,
+    num_layers: int = 61,
+) -> DeepSeekV3Weights:
+    """Deserialize layers from disk. Convenience wrapper: load_layer for each index."""
+    path = Path(path)
+    if not path.is_dir():
+        raise FileNotFoundError(f"Weights path is not a directory: {path}")
+    layers = [load_layer(path, device, i) for i in range(num_layers)]
     return DeepSeekV3Weights(layers=layers)

--- a/models/demos/deepseek_v3_b1/prepare_weights.py
+++ b/models/demos/deepseek_v3_b1/prepare_weights.py
@@ -5,8 +5,9 @@
 """
 Prepare DeepSeek V3 fused (blitz decode) weights from a state dict.
 
-Provides prepare_weights(state_dict, device, ...) -> DeepSeekV3Weights and
-dataclasses for dense vs MoE layer weight containers.
+Takes full HuggingFace state dict tensors (or per-device slice for single-device
+tests), applies key mapping, transpose, and kv_b split, then passes to
+BlitzDecodeWeights which fuses and shards onto the device or mesh.
 """
 
 from __future__ import annotations
@@ -127,28 +128,23 @@ def _get_layer_raw_tensors(
 ]:
     """Extract and transform raw tensors for one layer from the state dict.
 
-    HuggingFace linear weights are stored as (out_features, in_features). We
-    transpose to (K, N) for blitz_decode_weights so matmul uses input @ weight.
-    Norms are 1D in HF; we unsqueeze(0) to get (1, W). For kv_b_proj we split
-    into kv_b1 and kv_b2; only kv_b2 is transposed (see _split_kv_b_proj).
+    Expects full logical HF shapes. We transpose HF
+    (out_features, in_features) to (K, N); norms unsqueeze(0) to
+    (1, W); kv_b_proj is split into kv_b1 and kv_b2 (see _split_kv_b_proj).
 
-    Transformation summary (HF shape -> transform -> blitz shape):
+    Transformation (HF full logical -> transform -> passed to BlitzDecodeWeights):
 
-        Weight          | HF key (under model.layers.{i}.)           | HF shape    | Transform           | Blitz shape
-        ----------------|------------------------------------------|-------------|---------------------|-------------
-        q_a_proj        | self_attn.q_a_proj.weight                  | (1536,7168) | .T                  | (7168, 1536)
-        q_b_proj        | self_attn.q_b_proj.weight                 | (12288,1536)| .T                  | (1536, 12288)
-        kv_a_proj       | self_attn.kv_a_proj_with_mqa.weight       | (576, 7168) | .T                  | (7168, 576)
-        kv_b1_proj      | self_attn.kv_b_proj.weight (split)       | (16384,512) | split, no transpose | (8192, 512)
-        kv_b2_proj       | self_attn.kv_b_proj.weight (split)       | (16384,512) | split + .T          | (512, 8192)
-        o_proj           | self_attn.o_proj.weight                   | (7168,8192) | .T                  | (8192, 7168)
-        attn_norm        | input_layernorm.weight                    | (7168,)     | unsqueeze(0)        | (1, 7168)
-        q_norm           | self_attn.q_a_layernorm.weight             | (1536,)     | unsqueeze(0)        | (1, 1536)
-        kv_norm          | self_attn.kv_a_layernorm.weight            | (512,)      | unsqueeze(0)        | (1, 512)
-        ffn_norm         | post_attention_layernorm.weight            | (7168,)     | unsqueeze(0)        | (1, 7168)
+        Weight        | HF key (under model.layers.{i}.)     | HF shape      | Transform   | To blitz
+        --------------|-------------------------------------|---------------|-------------|------------------
+        q_b_proj      | self_attn.q_b_proj.weight            | (24576, 1536) | .T          | (1536, 24576)
+        o_proj        | self_attn.o_proj.weight              | (7168, 16384) | .T          | (16384, 7168)
+        kv_b_proj     | self_attn.kv_b_proj.weight           | (32768, 512)  | split       | kv_b1, kv_b2
+        q_a_proj      | self_attn.q_a_proj.weight            | (1536, 7168)  | .T          | (7168, 1536)
+        kv_a_proj     | self_attn.kv_a_proj_with_mqa.weight  | (576, 7168)   | .T          | (7168, 576)
+        norms         | input_layernorm, q_a_layernorm, etc. | (7168,), …    | unsqueeze(0)| (1, 7168), …
 
-    MoE-only weights (gate_mm, shared_gate_proj, shared_up_proj) are read and
-    transposed in prepare_moe_decoder_layer_weights, not here.
+    MoE-only (gate_mm, shared_gate_proj, shared_up_proj) are read in
+    prepare_moe_decoder_layer_weights.
 
     Returns:
         (q_a, q_b, kv_a, kv_b1, kv_b2, o_proj, attn_norm, q_norm, kv_norm, ffn_norm).
@@ -180,6 +176,7 @@ def prepare_dense_decoder_layer_weights(
     q_a_proj, q_b_proj, kv_a_proj = bdw.get_tt_q_ab_proj_and_kv_a_proj_weights(q_a, q_b, kv_a)
     kv_b1_proj, kv_b2_proj = bdw.get_tt_kv_b12_proj_weights(kv_b1, kv_b2)
 
+    # TODO: replace with actual gate_mm when available.
     gate_mm_dummy = torch.zeros(7168, 256, dtype=torch.bfloat16, device=next(iter(state_dict.values())).device)
     o_norms = bdw.get_tt_o_proj_and_gate_mm_weights(o_proj, gate_mm_dummy, attn_norm, q_norm, kv_norm, ffn_norm)
     o_proj_ot, _gate_mm_ot, attn_norm_ot, q_norm_ot, kv_norm_ot, ffn_norm_ot = o_norms
@@ -207,7 +204,6 @@ def prepare_moe_decoder_layer_weights(
     q_a, q_b, kv_a, kv_b1, kv_b2, o_proj, attn_norm, q_norm, kv_norm, ffn_norm = _get_layer_raw_tensors(
         state_dict, layer_idx
     )
-    # Single device: per-device slice. Multi device: full logical; blitz shards. No expansion.
     q_a_proj, q_b_proj, kv_a_proj = bdw.get_tt_q_ab_proj_and_kv_a_proj_weights(q_a, q_b, kv_a)
     kv_b1_proj, kv_b2_proj = bdw.get_tt_kv_b12_proj_weights(kv_b1, kv_b2)
 
@@ -242,11 +238,14 @@ def prepare_weights(
     num_layers: int = 61,
     first_k_dense_replace: int = 3,
 ) -> DeepSeekV3Weights:
-    """Build fused (blitz decode) weights from a HuggingFace-style state dict.
+    """Build fused weights from a HuggingFace-style state dict.
+
+    State dict should use full logical HF shapes when device is a mesh (e.g. 4x2);
+    internally we shard them across the mesh.
 
     Args:
         state_dict: Weights keyed by model.layers.{i}.self_attn.*, model.layers.{i}.mlp.*, etc.
-        device: ttnn device (or MeshDevice) to place tensors on.
+        device: MeshDevice to place weights on.
         num_layers: Total number of layers (default 61).
         first_k_dense_replace: Number of dense layers before MoE (default 3).
 

--- a/models/demos/deepseek_v3_b1/tests/blitz_weights_tests/test_blitz_decode_weights.py
+++ b/models/demos/deepseek_v3_b1/tests/blitz_weights_tests/test_blitz_decode_weights.py
@@ -41,10 +41,10 @@ from loguru import logger
 
 import ttnn
 from models.demos.deepseek_v3_b1.blitz_decode_weights import (
-    GATE_UP_PROJ_OVERLAP_CFG,
-    KVB12_PROJ_OVERLAP_CFG,
-    O_PROJ_GATE_MM_RMSNORM_GAMMA_OVERLAP_CFG,
-    QAB_KVA_PROJ_OVERLAP_CFG,
+    GATE_UP_PROJ_SINGLE_DEVICE_OVERLAP_SPEC,
+    KVB12_PROJ_SINGLE_DEVICE_OVERLAP_SPEC,
+    O_PROJ_GATE_MM_RMSNORM_GAMMA_SINGLE_DEVICE_OVERLAP_SPEC,
+    QAB_KVA_PROJ_SINGLE_DEVICE_OVERLAP_SPEC,
     BlitzDecodeWeights,
 )
 from models.demos.deepseek_v3_b1.tests.blitz_weights_tests.op import CopyToOutput
@@ -143,29 +143,43 @@ def test_q_ab_proj_kv_a_proj_overlap(bh_2d_mesh_device, mesh_rows, mesh_cols):
     each sub-tensor with CopyToOutput and checks it against an
     independently preprocessed + bfp8 round-tripped reference.
 
-    For multi-device (4x2 mesh), TP=2 across mesh columns:
-    q_b_proj is sharded, q_a_proj and kv_a_proj are replicated.
+    For multi-device (4x2 mesh), mla_tp=2 across mesh columns:
+    q_b_proj is TP-sharded on the width, q_a_proj and kv_a_proj are replicated.
+
+    Per-device layout::
+
+        q_a_proj (7168, 1536) packed to (3584, 3072) as bfloat8_b
+          WIDTH_SHARDED on 96 cores (12x8), shard (3584, 32)
+
+        q_b_proj (1536, 12288) as bfloat8_b
+          WIDTH_SHARDED on 96 cores (12x8), shard (1536, 128)
+
+        kv_a_proj (7168, 576) as bfloat8_b, shard-reordered
+          WIDTH_SHARDED on 18 cores (9x2), shard (7168, 32)
     """
     num_devices = mesh_rows * mesh_cols
     if bh_2d_mesh_device.shape[0] * bh_2d_mesh_device.shape[1] < num_devices:
         pytest.skip("Test requires more devices than are available on this platform")
 
     submesh = bh_2d_mesh_device.create_submesh(ttnn.MeshShape((mesh_rows, mesh_cols)))
-    tp = mesh_cols
-    cfg = QAB_KVA_PROJ_OVERLAP_CFG
+    mla_tp = mesh_cols
+    cfg = QAB_KVA_PROJ_SINGLE_DEVICE_OVERLAP_SPEC
 
     torch.manual_seed(42)
     q_a_raw = torch.randn(cfg.q_a_proj_shape, dtype=torch.bfloat16)
-    q_b_raw = torch.randn(cfg.q_b_proj_shape[0], cfg.q_b_proj_shape[1] * tp, dtype=torch.bfloat16)
+    q_b_raw = torch.randn(cfg.q_b_proj_shape[0], cfg.q_b_proj_shape[1] * mla_tp, dtype=torch.bfloat16)
     kv_raw = torch.randn(cfg.kv_a_proj_shape, dtype=torch.bfloat16)
 
     bdw = BlitzDecodeWeights(submesh)
+    logger.info("Building fused q_ab_proj + kv_a_proj weights ...")
     q_a, q_b, kv = bdw.get_tt_q_ab_proj_and_kv_a_proj_weights(q_a_raw, q_b_raw, kv_raw)
 
     replicate = ttnn.ReplicateTensorToMesh(submesh)
     composer = ttnn.ConcatMeshToTensor(submesh, dim=0)
+    single_device = submesh.create_submesh(ttnn.MeshShape((1, 1)))
 
     # -- Extract all three sub-tensors while fused buffer is alive -----------
+    logger.info("Extracting q_a_proj from fused buffer ...")
     q_a_out = _create_output_device_tensor(
         *q_a.tensor_shape, q_a.core_range_set, submesh, dtype=q_a.dtype, mesh_mapper=replicate
     )
@@ -173,6 +187,7 @@ def test_q_ab_proj_kv_a_proj_overlap(bh_2d_mesh_device, mesh_rows, mesh_cols):
     q_a_result = ttnn.to_torch(q_a_out, mesh_composer=composer)
     ttnn.deallocate(q_a_out)
 
+    logger.info("Extracting q_b_proj from fused buffer ...")
     q_b_out = _create_output_device_tensor(
         *q_b.tensor_shape, q_b.core_range_set, submesh, dtype=q_b.dtype, mesh_mapper=replicate
     )
@@ -180,6 +195,7 @@ def test_q_ab_proj_kv_a_proj_overlap(bh_2d_mesh_device, mesh_rows, mesh_cols):
     q_b_result = ttnn.to_torch(q_b_out, mesh_composer=composer)
     ttnn.deallocate(q_b_out)
 
+    logger.info("Extracting kv_a_proj from fused buffer ...")
     kv_out = _create_output_device_tensor(
         *kv.tensor_shape, kv.core_range_set, submesh, dtype=kv.dtype, mesh_mapper=replicate
     )
@@ -189,50 +205,44 @@ def test_q_ab_proj_kv_a_proj_overlap(bh_2d_mesh_device, mesh_rows, mesh_cols):
 
     ttnn.deallocate(q_a.fused_tensor)
 
-    # -- Build references (bfp8 round-trip) after fused buffer is freed ------
-    # q_a and kv_a are replicated: build a single reference and check all devices.
+    # -- Build references (bfp8 round-trip on single device) -----------------
+    logger.info("Building q_a_proj round-trip reference ...")
     q_a_ref = _get_roundtrip_reference(
         cfg.shuffle_q_a(q_a_raw),
         q_a.core_range_set,
-        submesh,
+        single_device,
         dtype=q_a.dtype,
-        mesh_mapper=replicate,
-        mesh_composer=composer,
     )
+    logger.info("Building kv_a_proj round-trip reference ...")
     kv_ref = _get_roundtrip_reference(
         cfg.shuffle_kv_a(kv_raw),
         kv.core_range_set,
-        submesh,
+        single_device,
         dtype=kv.dtype,
-        mesh_mapper=replicate,
-        mesh_composer=composer,
     )
 
-    # q_b is TP-sharded: build per-TP references.
-    per_device_q_b_w = cfg.q_b_proj_shape[1]
+    logger.info("Building q_b_proj per-TP round-trip references ...")
     q_b_tp_refs = []
-    for tp_idx in range(tp):
-        q_b_slice = q_b_raw[:, tp_idx * per_device_q_b_w : (tp_idx + 1) * per_device_q_b_w]
+    for tp_idx in range(mla_tp):
+        q_b_slice = cfg.get_q_b_slice(q_b_raw, tp_idx, mla_tp)
         ref = _get_roundtrip_reference(
             cfg.shuffle_q_b(q_b_slice),
             q_b.core_range_set,
-            submesh,
+            single_device,
             dtype=q_b.dtype,
-            mesh_mapper=replicate,
-            mesh_composer=composer,
         )
-        q_b_tp_refs.append(ref[: q_b.tensor_shape[0]])
+        q_b_tp_refs.append(ref)
 
     q_a_h = q_a.tensor_shape[0]
     q_b_h = q_b.tensor_shape[0]
     kv_h = kv.tensor_shape[0]
 
+    logger.info("Verifying per-device results ...")
     for device_idx in range(num_devices):
         tp_group = device_idx % mesh_cols
 
         q_a_slice = q_a_result[device_idx * q_a_h : (device_idx + 1) * q_a_h]
-        q_a_ref_slice = q_a_ref[device_idx * q_a_h : (device_idx + 1) * q_a_h]
-        assert torch.equal(q_a_slice, q_a_ref_slice), f"q_a_proj mismatch on device {device_idx}"
+        assert torch.equal(q_a_slice, q_a_ref), f"q_a_proj mismatch on device {device_idx}"
 
         q_b_slice = q_b_result[device_idx * q_b_h : (device_idx + 1) * q_b_h]
         assert torch.equal(
@@ -240,31 +250,59 @@ def test_q_ab_proj_kv_a_proj_overlap(bh_2d_mesh_device, mesh_rows, mesh_cols):
         ), f"q_b_proj mismatch on device {device_idx} (TP={tp_group})"
 
         kv_slice = kv_result[device_idx * kv_h : (device_idx + 1) * kv_h]
-        kv_ref_slice = kv_ref[device_idx * kv_h : (device_idx + 1) * kv_h]
-        assert torch.equal(kv_slice, kv_ref_slice), f"kv_a_proj mismatch on device {device_idx}"
+        assert torch.equal(kv_slice, kv_ref), f"kv_a_proj mismatch on device {device_idx}"
 
         logger.info(f"Device {device_idx} (TP={tp_group}): q_a_proj, q_b_proj, kv_a_proj overlap passed")
 
 
-def test_o_proj_gate_mm_rmsnorm_gamma_overlap(device):
+@pytest.mark.parametrize("mesh_rows, mesh_cols", [(4, 2), (1, 1)])
+@pytest.mark.parametrize(
+    "device_params",
+    [{"fabric_config": ttnn.FabricConfig.FABRIC_2D}],
+    indirect=True,
+)
+def test_o_proj_gate_mm_rmsnorm_gamma_overlap(bh_2d_mesh_device, mesh_rows, mesh_cols):
     """Verify all constituents of the o_proj + gate_mm + rmsnorm gamma overlap.
 
     Creates the fused tensor once via BlitzDecodeWeights, then extracts
     each sub-tensor with CopyToOutput and checks it against an
     independently preprocessed + dtype round-tripped reference.
+
+    For multi-device (4x2 mesh), mla_tp=2 across mesh columns:
+    o_proj is TP-sharded on the inner dim (8192), everything else is replicated.
+
+    Per-device layout::
+
+        o_proj (8192, 7168) as bfloat8_b
+          WIDTH_SHARDED on 112 cores, shard (8192, 64)
+
+        gate_mm (7168, 256) as bfloat16
+          WIDTH_SHARDED on 8 cores, shard (7168, 32)
+
+        attn_norm (1, 7168) as bfloat16, 1x32 tiles, on core (12, 9)
+        q_norm   (1, 1536) as bfloat16, 1x32 tiles, on core (12, 9)
+        kv_norm  (1, 512)  as bfloat16, 1x32 tiles, on core (0, 8)
+        ffn_norm (1, 7168) as bfloat16, 1x32 tiles, on core (12, 9)
     """
-    cfg = O_PROJ_GATE_MM_RMSNORM_GAMMA_OVERLAP_CFG
+    num_devices = mesh_rows * mesh_cols
+    if bh_2d_mesh_device.shape[0] * bh_2d_mesh_device.shape[1] < num_devices:
+        pytest.skip("Test requires more devices than are available on this platform")
+
+    submesh = bh_2d_mesh_device.create_submesh(ttnn.MeshShape((mesh_rows, mesh_cols)))
+    mla_tp = mesh_cols
+    cfg = O_PROJ_GATE_MM_RMSNORM_GAMMA_SINGLE_DEVICE_OVERLAP_SPEC
     tile_1x32 = ttnn.Tile([1, 32])
 
     torch.manual_seed(42)
-    o_proj_raw = torch.randn(cfg.o_proj_shape, dtype=torch.bfloat16)
+    o_proj_raw = torch.randn(cfg.o_proj_shape[0] * mla_tp, cfg.o_proj_shape[1], dtype=torch.bfloat16)
     gate_mm_raw = torch.randn(cfg.gate_mm_shape, dtype=torch.bfloat16)
     attn_norm_raw = torch.randn(cfg.attn_norm_shape, dtype=torch.bfloat16)
     q_norm_raw = torch.randn(cfg.q_norm_shape, dtype=torch.bfloat16)
     kv_norm_raw = torch.randn(cfg.kv_norm_shape, dtype=torch.bfloat16)
     ffn_norm_raw = torch.randn(cfg.ffn_norm_shape, dtype=torch.bfloat16)
 
-    bdw = BlitzDecodeWeights(device)
+    bdw = BlitzDecodeWeights(submesh)
+    logger.info("Building fused o_proj + gate_mm + rmsnorm gamma weights ...")
     o_proj, gate_mm, attn_norm_g, q_norm_g, kv_norm_g, ffn_norm_g = bdw.get_tt_o_proj_and_gate_mm_weights(
         o_proj_raw,
         gate_mm_raw,
@@ -274,16 +312,26 @@ def test_o_proj_gate_mm_rmsnorm_gamma_overlap(device):
         ffn_norm_raw,
     )
 
+    replicate = ttnn.ReplicateTensorToMesh(submesh)
+    composer = ttnn.ConcatMeshToTensor(submesh, dim=0)
+    single_device = submesh.create_submesh(ttnn.MeshShape((1, 1)))
+
     # -- Extract o_proj (BFP8) while fused buffer is alive -------------------
-    o_out = _create_output_device_tensor(*o_proj.tensor_shape, o_proj.core_range_set, device, dtype=o_proj.dtype)
+    logger.info("Extracting o_proj from fused buffer ...")
+    o_out = _create_output_device_tensor(
+        *o_proj.tensor_shape, o_proj.core_range_set, submesh, dtype=o_proj.dtype, mesh_mapper=replicate
+    )
     o_out = CopyToOutput.op(o_proj.fused_tensor, o_out, byte_offset=o_proj.byte_offset)
-    o_result = ttnn.to_torch(o_out)
+    o_result = ttnn.to_torch(o_out, mesh_composer=composer)
     ttnn.deallocate(o_out)
 
     # -- Extract gate_mm (BFP16) while fused buffer is alive -----------------
-    g_out = _create_output_device_tensor(*gate_mm.tensor_shape, gate_mm.core_range_set, device, dtype=gate_mm.dtype)
+    logger.info("Extracting gate_mm from fused buffer ...")
+    g_out = _create_output_device_tensor(
+        *gate_mm.tensor_shape, gate_mm.core_range_set, submesh, dtype=gate_mm.dtype, mesh_mapper=replicate
+    )
     g_out = CopyToOutput.op(gate_mm.fused_tensor, g_out, byte_offset=gate_mm.byte_offset)
-    g_result = ttnn.to_torch(g_out)
+    g_result = ttnn.to_torch(g_out, mesh_composer=composer)
     ttnn.deallocate(g_out)
 
     # -- Extract gammas (BFP16 1x32 tiles) while fused buffer is alive ------
@@ -297,176 +345,325 @@ def test_o_proj_gate_mm_rmsnorm_gamma_overlap(device):
         out = _create_output_device_tensor(
             *ov.tensor_shape,
             ov.core_range_set,
-            device,
+            submesh,
             dtype=ov.dtype,
             sharding=ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
             tile=tile_1x32,
+            mesh_mapper=replicate,
         )
+        logger.info(f"Extracting {name} from fused buffer ...")
         out = CopyToOutput.op(ov.fused_tensor, out, byte_offset=ov.byte_offset)
-        gamma_results[name] = ttnn.to_torch(out)
+        gamma_results[name] = ttnn.to_torch(out, mesh_composer=composer)
         ttnn.deallocate(out)
 
     ttnn.deallocate(o_proj.fused_tensor)
 
-    # -- Build references (dtype round-trip) after fused buffer is freed -----
-    o_ref = _get_roundtrip_reference(o_proj_raw, o_proj.core_range_set, device, dtype=o_proj.dtype)
-    assert torch.equal(o_result, o_ref), "o_proj overlap has mismatch"
-    logger.info("o_proj overlap comparison passed")
+    # -- Build references (dtype round-trip on single device) ----------------
+    logger.info("Building o_proj per-TP round-trip references ...")
+    per_device_o_h = cfg.o_proj_shape[0]
+    o_tp_refs = []
+    for tp_idx in range(mla_tp):
+        o_slice = o_proj_raw[tp_idx * per_device_o_h : (tp_idx + 1) * per_device_o_h, :]
+        ref = _get_roundtrip_reference(
+            o_slice,
+            o_proj.core_range_set,
+            single_device,
+            dtype=o_proj.dtype,
+        )
+        o_tp_refs.append(ref)
 
-    g_ref = _get_roundtrip_reference(gate_mm_raw, gate_mm.core_range_set, device, dtype=gate_mm.dtype)
-    assert torch.equal(g_result, g_ref), "gate_mm overlap has mismatch"
-    logger.info("gate_mm overlap comparison passed")
+    logger.info("Building gate_mm round-trip reference ...")
+    g_ref = _get_roundtrip_reference(
+        gate_mm_raw,
+        gate_mm.core_range_set,
+        single_device,
+        dtype=gate_mm.dtype,
+    )
 
+    gamma_refs = {}
     for name, raw, ov in [
         ("attn_norm", attn_norm_raw, attn_norm_g),
         ("q_norm", q_norm_raw, q_norm_g),
         ("kv_norm", kv_norm_raw, kv_norm_g),
         ("ffn_norm", ffn_norm_raw, ffn_norm_g),
     ]:
-        ref = _get_roundtrip_reference(
+        logger.info(f"Building {name} round-trip reference ...")
+        gamma_refs[name] = _get_roundtrip_reference(
             raw,
             ov.core_range_set,
-            device,
+            single_device,
             dtype=ov.dtype,
             sharding=ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
             tile=tile_1x32,
         )
-        assert torch.equal(gamma_results[name], ref), f"{name} overlap has mismatch"
-        logger.info(f"{name} overlap comparison passed")
+
+    o_h = o_proj.tensor_shape[0]
+    g_h = gate_mm.tensor_shape[0]
+
+    logger.info("Verifying per-device results ...")
+    for device_idx in range(num_devices):
+        tp_group = device_idx % mesh_cols
+
+        o_slice = o_result[device_idx * o_h : (device_idx + 1) * o_h]
+        assert torch.equal(o_slice, o_tp_refs[tp_group]), f"o_proj mismatch on device {device_idx} (TP={tp_group})"
+
+        g_slice = g_result[device_idx * g_h : (device_idx + 1) * g_h]
+        assert torch.equal(g_slice, g_ref), f"gate_mm mismatch on device {device_idx}"
+
+        for name in ["attn_norm", "q_norm", "kv_norm", "ffn_norm"]:
+            gamma_h = gamma_results[name].shape[0] // num_devices
+            gamma_slice = gamma_results[name][device_idx * gamma_h : (device_idx + 1) * gamma_h]
+            assert torch.equal(gamma_slice, gamma_refs[name]), f"{name} mismatch on device {device_idx}"
+
+        logger.info(f"Device {device_idx} (TP={tp_group}): o_proj, gate_mm, gammas overlap passed")
 
 
-def test_kv_b12_proj_overlap(device):
+@pytest.mark.parametrize("mesh_rows, mesh_cols", [(4, 2), (1, 1)])
+@pytest.mark.parametrize(
+    "device_params",
+    [{"fabric_config": ttnn.FabricConfig.FABRIC_2D}],
+    indirect=True,
+)
+def test_kv_b12_proj_overlap(bh_2d_mesh_device, mesh_rows, mesh_cols):
     """Verify both constituents of the kv_b1 + kv_b2 overlap.
 
     Creates the fused tensor once via BlitzDecodeWeights, then extracts
     each sub-tensor with CopyToOutput and checks it against an
     independently preprocessed + bfp8 round-tripped reference.
 
-    kv_b1_proj (8192, 512) is HEIGHT_SHARDED on the 8x8 Qnope grid.
-    kv_b2_proj (512, 8192) is pre-transposed, reshaped internally to
-    (8192, 512) and HEIGHT_SHARDED on the remaining 64 cores.
+    For multi-device (4x2 mesh), mla_tp=2 across mesh columns:
+    kv_b1_proj is TP-sharded on height (8192), kv_b2_proj on width (8192).
+
+    Per-device layout::
+
+        kv_b1_proj (8192, 512) as bfloat8_b
+          HEIGHT_SHARDED on 64 cores (8x8 Qnope grid), shard (128, 512)
+
+        kv_b2_proj (512, 8192) pre-transposed to (8192, 512) as bfloat8_b
+          HEIGHT_SHARDED on 64 cores, shard (128, 512)
+
+    For multi-device (4x2 mesh), mla_tp=2 across mesh columns:
+    both tensors are TP-sharded on the 8192 (heads) dim.
     """
-    cfg = KVB12_PROJ_OVERLAP_CFG
+    num_devices = mesh_rows * mesh_cols
+    if bh_2d_mesh_device.shape[0] * bh_2d_mesh_device.shape[1] < num_devices:
+        pytest.skip("Test requires more devices than are available on this platform")
+
+    submesh = bh_2d_mesh_device.create_submesh(ttnn.MeshShape((mesh_rows, mesh_cols)))
+    mla_tp = mesh_cols
+    cfg = KVB12_PROJ_SINGLE_DEVICE_OVERLAP_SPEC
 
     torch.manual_seed(42)
-    kv_b1_raw = torch.randn(*cfg.kv_b1_proj_shape, dtype=torch.bfloat16)
-    kv_b2_raw = torch.randn(*cfg.kv_b2_proj_shape, dtype=torch.bfloat16)
+    kv_b1_raw = torch.randn(cfg.kv_b1_proj_shape[0] * mla_tp, cfg.kv_b1_proj_shape[1], dtype=torch.bfloat16)
+    kv_b2_raw = torch.randn(cfg.kv_b2_proj_shape[0], cfg.kv_b2_proj_shape[1] * mla_tp, dtype=torch.bfloat16)
 
-    bdw = BlitzDecodeWeights(device)
+    bdw = BlitzDecodeWeights(submesh)
+    logger.info("Building fused kv_b1 + kv_b2 weights ...")
     kv_b1, kv_b2 = bdw.get_tt_kv_b12_proj_weights(kv_b1_raw, kv_b2_raw)
 
-    kv_b2_physical = cfg.shuffle_kv_b2(kv_b2_raw)
+    replicate = ttnn.ReplicateTensorToMesh(submesh)
+    composer = ttnn.ConcatMeshToTensor(submesh, dim=0)
+    single_device = submesh.create_submesh(ttnn.MeshShape((1, 1)))
 
     # -- Extract kv_b1 (HEIGHT_SHARDED, BFP8) while fused buffer is alive ----
+    logger.info("Extracting kv_b1_proj from fused buffer ...")
     kv_b1_out = _create_output_device_tensor(
         *kv_b1.tensor_shape,
         kv_b1.core_range_set,
-        device,
+        submesh,
         dtype=kv_b1.dtype,
         sharding=ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+        mesh_mapper=replicate,
     )
     kv_b1_out = CopyToOutput.op(kv_b1.fused_tensor, kv_b1_out, byte_offset=kv_b1.byte_offset)
-    kv_b1_result = ttnn.to_torch(kv_b1_out)
+    kv_b1_result = ttnn.to_torch(kv_b1_out, mesh_composer=composer)
     ttnn.deallocate(kv_b1_out)
 
     # -- Extract kv_b2 (HEIGHT_SHARDED, BFP8) while fused buffer is alive -----
+    logger.info("Extracting kv_b2_proj from fused buffer ...")
     kv_b2_out = _create_output_device_tensor(
         *cfg.kv_b1_proj_shape,
         kv_b2.core_range_set,
-        device,
+        submesh,
         dtype=kv_b2.dtype,
         sharding=ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+        mesh_mapper=replicate,
     )
     kv_b2_out = CopyToOutput.op(kv_b2.fused_tensor, kv_b2_out, byte_offset=kv_b2.byte_offset)
-    kv_b2_result = ttnn.to_torch(kv_b2_out)
+    kv_b2_result = ttnn.to_torch(kv_b2_out, mesh_composer=composer)
     ttnn.deallocate(kv_b2_out)
 
     ttnn.deallocate(kv_b1.fused_tensor)
 
-    # -- Build references (bfp8 round-trip) after fused buffer is freed ------
-    kv_b1_ref = _get_roundtrip_reference(
-        kv_b1_raw,
-        kv_b1.core_range_set,
-        device,
-        dtype=kv_b1.dtype,
-        sharding=ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
-    )
-    assert torch.equal(kv_b1_result, kv_b1_ref), "kv_b1_proj overlap has mismatch"
-    logger.info("kv_b1_proj overlap comparison passed")
+    # -- Build per-TP references (bfp8 round-trip on single device) ----------
+    per_device_b1_h = cfg.kv_b1_proj_shape[0]
+    per_device_b2_w = cfg.kv_b2_proj_shape[1]
 
-    kv_b2_ref = _get_roundtrip_reference(
-        kv_b2_physical,
-        kv_b2.core_range_set,
-        device,
-        dtype=kv_b2.dtype,
-        sharding=ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
-    )
-    assert torch.equal(kv_b2_result, kv_b2_ref), "kv_b2_proj overlap has mismatch"
-    logger.info("kv_b2_proj overlap comparison passed")
+    kv_b1_tp_refs = []
+    kv_b2_tp_refs = []
+    for tp_idx in range(mla_tp):
+        logger.info(f"Building kv_b1_proj round-trip reference (TP={tp_idx}) ...")
+        b1_slice = kv_b1_raw[tp_idx * per_device_b1_h : (tp_idx + 1) * per_device_b1_h, :]
+        ref = _get_roundtrip_reference(
+            b1_slice,
+            kv_b1.core_range_set,
+            single_device,
+            dtype=kv_b1.dtype,
+            sharding=ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+        )
+        kv_b1_tp_refs.append(ref)
+
+        logger.info(f"Building kv_b2_proj round-trip reference (TP={tp_idx}) ...")
+        b2_slice = kv_b2_raw[:, tp_idx * per_device_b2_w : (tp_idx + 1) * per_device_b2_w]
+        b2_physical = cfg.shuffle_kv_b2(b2_slice)
+        ref = _get_roundtrip_reference(
+            b2_physical,
+            kv_b2.core_range_set,
+            single_device,
+            dtype=kv_b2.dtype,
+            sharding=ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+        )
+        kv_b2_tp_refs.append(ref)
+
+    kv_b1_h = kv_b1.tensor_shape[0]
+
+    logger.info("Verifying per-device results ...")
+    for device_idx in range(num_devices):
+        tp_group = device_idx % mesh_cols
+
+        b1_slice = kv_b1_result[device_idx * kv_b1_h : (device_idx + 1) * kv_b1_h]
+        assert torch.equal(
+            b1_slice, kv_b1_tp_refs[tp_group]
+        ), f"kv_b1_proj mismatch on device {device_idx} (TP={tp_group})"
+
+        b2_slice = kv_b2_result[device_idx * kv_b1_h : (device_idx + 1) * kv_b1_h]
+        assert torch.equal(
+            b2_slice, kv_b2_tp_refs[tp_group]
+        ), f"kv_b2_proj mismatch on device {device_idx} (TP={tp_group})"
+
+        logger.info(f"Device {device_idx} (TP={tp_group}): kv_b1_proj, kv_b2_proj overlap passed")
 
 
-def test_gate_up_proj_overlap(device):
+@pytest.mark.parametrize("mesh_rows, mesh_cols", [(4, 2), (1, 1)])
+@pytest.mark.parametrize(
+    "device_params",
+    [{"fabric_config": ttnn.FabricConfig.FABRIC_2D}],
+    indirect=True,
+)
+def test_gate_up_proj_overlap(bh_2d_mesh_device, mesh_rows, mesh_cols):
     """Verify both constituents of the gate + up projection overlap.
 
     Creates the fused tensor once via BlitzDecodeWeights, then extracts
     each sub-tensor with CopyToOutput and checks it against an
     independently preprocessed + bfp4 round-tripped reference.
 
-    Both gate_proj and up_proj are block-sharded (stacked HEIGHT_SHARDED)
-    on 64 non-rectangular compute cores each.
+    For multi-device (4x2 mesh), moe_tp=8 across all devices:
+    both gate_proj and up_proj are TP-sharded on the outer dim (N=2048,
+    per-device N=256).
+
+    Per-device layout::
+
+        gate_proj (7168, 256) as bfloat4_b, block-sharded
+          stacked (57344, 32), shard (896, 32), 64 A cores
+
+        up_proj (7168, 256) as bfloat4_b, block-sharded
+          stacked (57344, 32), shard (896, 32), 64 B cores
+
+        combined: 128 cores, HEIGHT_SHARDED (114688, 32)
     """
-    cfg = GATE_UP_PROJ_OVERLAP_CFG
+    num_devices = mesh_rows * mesh_cols
+    if bh_2d_mesh_device.shape[0] * bh_2d_mesh_device.shape[1] < num_devices:
+        pytest.skip("Test requires more devices than are available on this platform")
+
+    submesh = bh_2d_mesh_device.create_submesh(ttnn.MeshShape((mesh_rows, mesh_cols)))
+    moe_tp = num_devices
+    cfg = GATE_UP_PROJ_SINGLE_DEVICE_OVERLAP_SPEC
 
     torch.manual_seed(42)
-    gate_raw = torch.randn(cfg.gate_proj_shape, dtype=torch.bfloat16)
-    up_raw = torch.randn(cfg.up_proj_shape, dtype=torch.bfloat16)
+    gate_raw = torch.randn(cfg.gate_proj_shape[0], cfg.gate_proj_shape[1] * moe_tp, dtype=torch.bfloat16)
+    up_raw = torch.randn(cfg.up_proj_shape[0], cfg.up_proj_shape[1] * moe_tp, dtype=torch.bfloat16)
 
-    bdw = BlitzDecodeWeights(device)
+    replicate = ttnn.ReplicateTensorToMesh(submesh)
+    composer = ttnn.ConcatMeshToTensor(submesh, dim=0)
+    single_device = submesh.create_submesh(ttnn.MeshShape((1, 1)))
+
+    bdw = BlitzDecodeWeights(submesh)
+    logger.info("Building fused gate + up proj weights ...")
     gate, up = bdw.get_tt_gate_up_proj_weights(gate_raw, up_raw)
 
     # -- Extract gate (block-sharded BFP4) while fused buffer is alive -------
+    logger.info("Extracting gate_proj from fused buffer ...")
     gate_out = _create_output_device_tensor(
-        *gate.tensor_shape,
+        *cfg.stacked_shape,
         gate.core_range_set,
-        device,
+        submesh,
         dtype=gate.dtype,
         sharding=ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+        mesh_mapper=replicate,
     )
     gate_out = CopyToOutput.op(gate.fused_tensor, gate_out, byte_offset=gate.byte_offset)
-    gate_result = ttnn.to_torch(gate_out)
+    gate_result = ttnn.to_torch(gate_out, mesh_composer=composer)
     ttnn.deallocate(gate_out)
 
     # -- Extract up (block-sharded BFP4) while fused buffer is alive ---------
+    logger.info("Extracting up_proj from fused buffer ...")
     up_out = _create_output_device_tensor(
-        *up.tensor_shape,
+        *cfg.stacked_shape,
         up.core_range_set,
-        device,
+        submesh,
         dtype=up.dtype,
         sharding=ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+        mesh_mapper=replicate,
     )
     up_out = CopyToOutput.op(up.fused_tensor, up_out, byte_offset=up.byte_offset)
-    up_result = ttnn.to_torch(up_out)
+    up_result = ttnn.to_torch(up_out, mesh_composer=composer)
     ttnn.deallocate(up_out)
 
     ttnn.deallocate(gate.fused_tensor)
 
-    # -- Build references (bfp4 round-trip) after fused buffer is freed ------
-    gate_ref = _get_roundtrip_reference(
-        cfg.reshuffle_block_to_height_sharded(gate_raw),
-        gate.core_range_set,
-        device,
-        dtype=gate.dtype,
-        sharding=ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
-    )
-    assert torch.equal(gate_result, gate_ref), "gate_proj overlap has mismatch"
-    logger.info("gate_proj overlap comparison passed")
+    # -- Build per-TP references (bfp4 round-trip on single device) ----------
+    per_device_n = cfg.gate_proj_shape[1]
 
-    up_ref = _get_roundtrip_reference(
-        cfg.reshuffle_block_to_height_sharded(up_raw),
-        up.core_range_set,
-        device,
-        dtype=up.dtype,
-        sharding=ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
-    )
-    assert torch.equal(up_result, up_ref), "up_proj overlap has mismatch"
-    logger.info("up_proj overlap comparison passed")
+    logger.info("Building per-TP gate_proj round-trip references ...")
+    gate_tp_refs = []
+    for tp_idx in range(moe_tp):
+        gate_slice = gate_raw[:, tp_idx * per_device_n : (tp_idx + 1) * per_device_n]
+        ref = _get_roundtrip_reference(
+            cfg.reshuffle_block_to_height_sharded(gate_slice, cfg.gate_core_range_set),
+            gate.core_range_set,
+            single_device,
+            dtype=gate.dtype,
+            sharding=ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+        )
+        gate_tp_refs.append(ref)
+
+    logger.info("Building per-TP up_proj round-trip references ...")
+    up_tp_refs = []
+    for tp_idx in range(moe_tp):
+        up_slice = up_raw[:, tp_idx * per_device_n : (tp_idx + 1) * per_device_n]
+        ref = _get_roundtrip_reference(
+            cfg.reshuffle_block_to_height_sharded(up_slice, cfg.up_core_range_set),
+            up.core_range_set,
+            single_device,
+            dtype=up.dtype,
+            sharding=ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+        )
+        up_tp_refs.append(ref)
+
+    # -- Verify per-device ---------------------------------------------------
+    gate_h = cfg.stacked_shape[0]
+    up_h = cfg.stacked_shape[0]
+
+    logger.info("Verifying per-device results ...")
+    for device_idx in range(num_devices):
+        tp_group = device_idx
+
+        gate_slice = gate_result[device_idx * gate_h : (device_idx + 1) * gate_h]
+        assert torch.equal(
+            gate_slice, gate_tp_refs[tp_group]
+        ), f"gate_proj mismatch on device {device_idx} (TP={tp_group})"
+
+        up_slice = up_result[device_idx * up_h : (device_idx + 1) * up_h]
+        assert torch.equal(up_slice, up_tp_refs[tp_group]), f"up_proj mismatch on device {device_idx} (TP={tp_group})"
+
+        logger.info(f"Device {device_idx} (TP={tp_group}): gate_proj, up_proj overlap passed")

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_prepare_weights.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_prepare_weights.py
@@ -10,6 +10,7 @@ Tests for prepare_weights: building DeepSeekV3Weights from a state dict.
 - test_save_load_dense_layer_single_layer / test_save_load_moe_layer_single_layer: save then load one layer.
 - test_prepare_dense_layer_single_layer_4x2: one dense layer on 4x2 mesh.
 - test_prepare_moe_layer_single_layer_4x2: one MoE layer on 4x2 mesh.
+- test_save_load_dense_layer_single_layer_4x2: save then load one dense layer on 4x2 submesh.
 - test_save_load_moe_layer_single_layer_4x2: save then load one MoE layer on 4x2 submesh.
 """
 
@@ -330,6 +331,65 @@ def test_prepare_dense_layer_single_layer_4x2(bh_2d_mesh_device):
     assert layer.ffn_norm.tensor_shape == (1, 7168)
     assert layer.kv_b1_proj.tensor_shape == (8192, 512)
     assert layer.kv_b2_proj.tensor_shape == (512, 8192)
+
+
+@pytest.mark.parametrize(
+    "device_params",
+    [{"fabric_config": ttnn.FabricConfig.FABRIC_2D}],
+    indirect=True,
+)
+def test_save_load_dense_layer_single_layer_4x2(bh_2d_mesh_device, tmp_path):
+    """Save one dense layer (4x2 submesh) to disk, load it back, assert metadata and fused-tensor sharing."""
+    if not is_slow_dispatch():
+        pytest.skip("prepare_weights tests require slow dispatch mode (TT_METAL_SLOW_DISPATCH_MODE=1)")
+    num_devices = 4 * 2
+    if bh_2d_mesh_device.shape[0] * bh_2d_mesh_device.shape[1] < num_devices:
+        pytest.skip("Test requires 8 devices (4x2 mesh)")
+    submesh = bh_2d_mesh_device.create_submesh(ttnn.MeshShape((4, 2)))
+    device_grid = submesh.compute_with_storage_grid_size()
+    if device_grid.x < 12 or device_grid.y < 10:
+        pytest.skip(f"Per-device grid {device_grid.x}x{device_grid.y} too small for blitz decode (need 12x10+)")
+
+    state = _layer_state_dict(0, is_moe=False, for_multi_device=True)
+    weights = prepare_weights(state, submesh, num_layers=1, first_k_dense_replace=1)
+    orig = weights.layers[0]
+    save_layer(
+        orig,
+        tmp_path,
+        0,
+        hf_model_name="test-dense-model-4x2",
+        hf_state_dict_name="test-dense-state-dict.safetensors",
+        device_mesh_shape=(4, 2),
+    )
+
+    assert (tmp_path / "layer_000" / "manifest.json").exists()
+    layer_dir = tmp_path / "layer_000"
+    assert (layer_dir / "q_ab_kv_a.tensorbin").exists()
+    assert (layer_dir / "o_proj_gate_mm_norms.tensorbin").exists()
+    assert (layer_dir / "kv_b12.tensorbin").exists()
+
+    deallocate_weights(weights)
+    t0 = time.perf_counter()
+    layer = load_layer(tmp_path, submesh, 0)
+    elapsed = time.perf_counter() - t0
+    logger.info("load_layer (dense, 4x2 submesh): {:.3f} s", elapsed)
+    assert isinstance(layer, DeepSeekV3DenseLayerWeights)
+
+    _assert_overlapped_tensors_match(orig.q_a_proj, layer.q_a_proj)
+    _assert_overlapped_tensors_match(orig.q_b_proj, layer.q_b_proj)
+    _assert_overlapped_tensors_match(orig.kv_a_proj, layer.kv_a_proj)
+    _assert_overlapped_tensors_match(orig.o_proj, layer.o_proj)
+    _assert_overlapped_tensors_match(orig.attn_norm, layer.attn_norm)
+    _assert_overlapped_tensors_match(orig.q_norm, layer.q_norm)
+    _assert_overlapped_tensors_match(orig.kv_norm, layer.kv_norm)
+    _assert_overlapped_tensors_match(orig.ffn_norm, layer.ffn_norm)
+    _assert_overlapped_tensors_match(orig.kv_b1_proj, layer.kv_b1_proj)
+    _assert_overlapped_tensors_match(orig.kv_b2_proj, layer.kv_b2_proj)
+
+    assert id(layer.q_a_proj.fused_tensor) == id(layer.q_b_proj.fused_tensor)
+    assert id(layer.q_b_proj.fused_tensor) == id(layer.kv_a_proj.fused_tensor)
+    assert id(layer.o_proj.fused_tensor) == id(layer.attn_norm.fused_tensor)
+    assert id(layer.kv_b1_proj.fused_tensor) == id(layer.kv_b2_proj.fused_tensor)
 
 
 @pytest.mark.parametrize(

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_prepare_weights.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_prepare_weights.py
@@ -5,55 +5,111 @@
 """
 Tests for prepare_weights: building DeepSeekV3Weights from a state dict.
 
-- test_prepare_dense_layer: one dense layer with random weights.
-- test_prepare_moe_layer: one MoE layer with random weights.
+- test_prepare_dense_layer_single_layer: one dense layer with random weights.
+- test_prepare_moe_layer_single_layer: one MoE layer with random weights.
+- test_prepare_dense_layer_single_layer_4x2: one dense layer on 4x2 mesh.
+- test_prepare_moe_layer_single_layer_4x2: one MoE layer on 4x2 mesh.
 - test_prepare_real_weights: placeholder for future real checkpoint testing.
 """
 
+import time
+
 import pytest
 import torch
+from loguru import logger
 
+import ttnn
+from models.common.utility_functions import is_slow_dispatch
 from models.demos.deepseek_v3_b1.prepare_weights import (
     DeepSeekV3DenseLayerWeights,
     DeepSeekV3MoELayerWeights,
     prepare_weights,
 )
 
+# HF state dict shapes (out_features, in_features) for linears; see DEEPSEEK_PREPARE_WEIGHTS_DESIGN_DOC.md §5.
+# Per-device = one shard for single-device; blitz expects these when device is single.
+# Full logical = full model; pass to prepare_weights when device is 4x2 mesh; blitz shards internally.
+HF_Q_B_PER_DEVICE = (12288, 1536)
+HF_Q_B_FULL_LOGICAL = (24576, 1536)
+HF_O_PROJ_PER_DEVICE = (7168, 8192)
+HF_O_PROJ_FULL_LOGICAL = (7168, 16384)
+HF_KV_B_PER_DEVICE = (16384, 512)
+HF_KV_B_FULL_LOGICAL = (32768, 512)
+HF_SHARED_GATE_UP_PER_DEVICE = (256, 7168)
+HF_SHARED_GATE_UP_FULL_LOGICAL = (2048, 7168)
 
-def _layer_state_dict(layer_idx: int, *, is_moe: bool, seed: int = 42) -> dict[str, torch.Tensor]:
-    """Build a minimal state_dict for a single layer (HF key convention, random weights)."""
+
+def _layer_state_dict(
+    layer_idx: int,
+    *,
+    is_moe: bool,
+    for_multi_device: bool = False,
+    seed: int = 42,
+) -> dict[str, torch.Tensor]:
+    """Build a minimal state_dict for one layer (HF key convention, random weights).
+
+    For single device: use for_multi_device=False so tensors are per-device shards
+    (sliced from full logical); prepare_weights uses them as-is.
+    For 4x2 mesh: use for_multi_device=True so tensors are full logical shapes;
+    prepare_weights passes them to blitz, which shards across the mesh.
+    """
     g = torch.Generator().manual_seed(seed)
-    # HF linear weights are (out_features, in_features)
+    q_b_hf = HF_Q_B_FULL_LOGICAL if for_multi_device else HF_Q_B_PER_DEVICE
+    o_proj_hf = HF_O_PROJ_FULL_LOGICAL if for_multi_device else HF_O_PROJ_PER_DEVICE
+    kv_b_hf = HF_KV_B_FULL_LOGICAL if for_multi_device else HF_KV_B_PER_DEVICE
+    shared_hf = HF_SHARED_GATE_UP_FULL_LOGICAL if for_multi_device else HF_SHARED_GATE_UP_PER_DEVICE
+
     state = {
-        f"model.layers.{layer_idx}.self_attn.q_a_proj.weight": torch.randn(1536, 7168, generator=g, dtype=torch.bfloat16),
-        f"model.layers.{layer_idx}.self_attn.q_b_proj.weight": torch.randn(12288, 1536, generator=g, dtype=torch.bfloat16),
-        f"model.layers.{layer_idx}.self_attn.kv_a_proj_with_mqa.weight": torch.randn(576, 7168, generator=g, dtype=torch.bfloat16),
-        f"model.layers.{layer_idx}.self_attn.kv_b_proj.weight": torch.randn(16384, 512, generator=g, dtype=torch.bfloat16),
-        f"model.layers.{layer_idx}.self_attn.o_proj.weight": torch.randn(7168, 8192, generator=g, dtype=torch.bfloat16),
+        f"model.layers.{layer_idx}.self_attn.q_a_proj.weight": torch.randn(
+            1536, 7168, generator=g, dtype=torch.bfloat16
+        ),
+        f"model.layers.{layer_idx}.self_attn.q_b_proj.weight": torch.randn(*q_b_hf, generator=g, dtype=torch.bfloat16),
+        f"model.layers.{layer_idx}.self_attn.kv_a_proj_with_mqa.weight": torch.randn(
+            576, 7168, generator=g, dtype=torch.bfloat16
+        ),
+        f"model.layers.{layer_idx}.self_attn.kv_b_proj.weight": torch.randn(
+            *kv_b_hf, generator=g, dtype=torch.bfloat16
+        ),
+        f"model.layers.{layer_idx}.self_attn.o_proj.weight": torch.randn(*o_proj_hf, generator=g, dtype=torch.bfloat16),
         f"model.layers.{layer_idx}.input_layernorm.weight": torch.randn(7168, generator=g, dtype=torch.bfloat16),
-        f"model.layers.{layer_idx}.self_attn.q_a_layernorm.weight": torch.randn(1536, generator=g, dtype=torch.bfloat16),
-        f"model.layers.{layer_idx}.self_attn.kv_a_layernorm.weight": torch.randn(512, generator=g, dtype=torch.bfloat16),
-        f"model.layers.{layer_idx}.post_attention_layernorm.weight": torch.randn(7168, generator=g, dtype=torch.bfloat16),
+        f"model.layers.{layer_idx}.self_attn.q_a_layernorm.weight": torch.randn(
+            1536, generator=g, dtype=torch.bfloat16
+        ),
+        f"model.layers.{layer_idx}.self_attn.kv_a_layernorm.weight": torch.randn(
+            512, generator=g, dtype=torch.bfloat16
+        ),
+        f"model.layers.{layer_idx}.post_attention_layernorm.weight": torch.randn(
+            7168, generator=g, dtype=torch.bfloat16
+        ),
     }
     if is_moe:
         state[f"model.layers.{layer_idx}.mlp.gate.weight"] = torch.randn(256, 7168, generator=g, dtype=torch.bfloat16)
-        state[f"model.layers.{layer_idx}.mlp.shared_experts.gate_proj.weight"] = torch.randn(256, 7168, generator=g, dtype=torch.bfloat16)
-        state[f"model.layers.{layer_idx}.mlp.shared_experts.up_proj.weight"] = torch.randn(256, 7168, generator=g, dtype=torch.bfloat16)
+        state[f"model.layers.{layer_idx}.mlp.shared_experts.gate_proj.weight"] = torch.randn(
+            *shared_hf, generator=g, dtype=torch.bfloat16
+        )
+        state[f"model.layers.{layer_idx}.mlp.shared_experts.up_proj.weight"] = torch.randn(
+            *shared_hf, generator=g, dtype=torch.bfloat16
+        )
     return state
 
 
-def test_prepare_dense_layer(device):
+def test_prepare_dense_layer_single_layer(device):
     """Build a single dense layer with random weights; verify type and shapes."""
+    if not is_slow_dispatch():
+        pytest.skip("prepare_weights tests require slow dispatch mode (TT_METAL_SLOW_DISPATCH_MODE=1)")
     device_grid = device.compute_with_storage_grid_size()
     if device_grid.x < 12 or device_grid.y < 10:
         pytest.skip(f"Device grid {device_grid.x}x{device_grid.y} too small for blitz decode (need 12x10+)")
     state = _layer_state_dict(0, is_moe=False)
+    t0 = time.perf_counter()
     weights = prepare_weights(
         state,
         device,
         num_layers=1,
         first_k_dense_replace=1,
     )
+    elapsed = time.perf_counter() - t0
+    logger.info("prepare_weights (1 dense layer): {:.3f} s", elapsed)
     assert len(weights.layers) == 1
     layer = weights.layers[0]
     assert isinstance(layer, DeepSeekV3DenseLayerWeights)
@@ -70,21 +126,32 @@ def test_prepare_dense_layer(device):
     assert layer.kv_b2_proj.tensor_shape == (512, 8192)
 
 
-def test_prepare_moe_layer(device):
-    """Build one dense and one MoE layer with random weights; verify MoE type and shapes."""
+def test_prepare_moe_layer_single_layer(device):
+    """Build a single MoE layer with random weights; verify type and shapes.
+
+    We prepare only one layer to avoid L1 OOM (two full blitz layers exceed
+    device L1 capacity on current hardware).
+    """
+    if not is_slow_dispatch():
+        pytest.skip("prepare_weights tests require slow dispatch mode (TT_METAL_SLOW_DISPATCH_MODE=1)")
     device_grid = device.compute_with_storage_grid_size()
     if device_grid.x < 12 or device_grid.y < 10:
         pytest.skip(f"Device grid {device_grid.x}x{device_grid.y} too small for blitz decode (need 12x10+)")
-    state = _layer_state_dict(0, is_moe=False, seed=42) | _layer_state_dict(1, is_moe=True, seed=43)
+    num_cores = device_grid.x * device_grid.y
+    if num_cores < 128:
+        pytest.skip(f"Device has {num_cores} compute cores; GATE_UP overlap spec requires 128 cores (13x10 grid)")
+    state = _layer_state_dict(0, is_moe=True, seed=43)
+    t0 = time.perf_counter()
     weights = prepare_weights(
         state,
         device,
-        num_layers=2,
-        first_k_dense_replace=1,
+        num_layers=1,
+        first_k_dense_replace=0,
     )
-    assert len(weights.layers) == 2
-    assert isinstance(weights.layers[0], DeepSeekV3DenseLayerWeights)
-    layer = weights.layers[1]
+    elapsed = time.perf_counter() - t0
+    logger.info("prepare_weights (1 MoE layer): {:.3f} s", elapsed)
+    assert len(weights.layers) == 1
+    layer = weights.layers[0]
     assert isinstance(layer, DeepSeekV3MoELayerWeights)
 
     assert layer.q_a_proj.tensor_shape == (3584, 3072)
@@ -98,8 +165,100 @@ def test_prepare_moe_layer(device):
     assert layer.ffn_norm.tensor_shape == (1, 7168)
     assert layer.kv_b1_proj.tensor_shape == (8192, 512)
     assert layer.kv_b2_proj.tensor_shape == (512, 8192)
-    assert layer.shared_gate_proj.tensor_shape == (57344, 32)  # stacked
-    assert layer.shared_up_proj.tensor_shape == (57344, 32)
+    # tensor_shape is logical (unsharded); gate/up are HEIGHT_SHARDED as (57344, 32) on device
+    assert layer.shared_gate_proj.tensor_shape == (7168, 256)
+    assert layer.shared_up_proj.tensor_shape == (7168, 256)
+
+
+# ---------------------------------------------------------------------------
+# Multi-device (4x2 grid) tests
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize(
+    "device_params",
+    [{"fabric_config": ttnn.FabricConfig.FABRIC_2D}],
+    indirect=True,
+)
+def test_prepare_dense_layer_single_layer_4x2(bh_2d_mesh_device):
+    """Build one dense layer on 4x2 mesh; verify type and shapes (MLA TP=2)."""
+    if not is_slow_dispatch():
+        pytest.skip("prepare_weights tests require slow dispatch mode (TT_METAL_SLOW_DISPATCH_MODE=1)")
+    num_devices = 4 * 2
+    if bh_2d_mesh_device.shape[0] * bh_2d_mesh_device.shape[1] < num_devices:
+        pytest.skip("Test requires 8 devices (4x2 mesh)")
+    submesh = bh_2d_mesh_device.create_submesh(ttnn.MeshShape((4, 2)))
+    device_grid = submesh.compute_with_storage_grid_size()
+    if device_grid.x < 12 or device_grid.y < 10:
+        pytest.skip(f"Per-device grid {device_grid.x}x{device_grid.y} too small for blitz decode (need 12x10+)")
+    state = _layer_state_dict(0, is_moe=False, for_multi_device=True)
+    t0 = time.perf_counter()
+    weights = prepare_weights(
+        state,
+        submesh,
+        num_layers=1,
+        first_k_dense_replace=1,
+    )
+    elapsed = time.perf_counter() - t0
+    logger.info("prepare_weights (1 dense layer, 4x2 mesh): {:.3f} s", elapsed)
+    assert len(weights.layers) == 1
+    layer = weights.layers[0]
+    assert isinstance(layer, DeepSeekV3DenseLayerWeights)
+    assert layer.q_a_proj.tensor_shape == (3584, 3072)
+    assert layer.q_b_proj.tensor_shape == (1536, 12288)
+    assert layer.kv_a_proj.tensor_shape == (7168, 576)
+    assert layer.o_proj.tensor_shape == (8192, 7168)
+    assert layer.attn_norm.tensor_shape == (1, 7168)
+    assert layer.q_norm.tensor_shape == (1, 1536)
+    assert layer.kv_norm.tensor_shape == (1, 512)
+    assert layer.ffn_norm.tensor_shape == (1, 7168)
+    assert layer.kv_b1_proj.tensor_shape == (8192, 512)
+    assert layer.kv_b2_proj.tensor_shape == (512, 8192)
+
+
+@pytest.mark.parametrize(
+    "device_params",
+    [{"fabric_config": ttnn.FabricConfig.FABRIC_2D}],
+    indirect=True,
+)
+def test_prepare_moe_layer_single_layer_4x2(bh_2d_mesh_device):
+    """Build one MoE layer on 4x2 mesh; verify type and shapes (MLA TP=2, MoE TP=8)."""
+    if not is_slow_dispatch():
+        pytest.skip("prepare_weights tests require slow dispatch mode (TT_METAL_SLOW_DISPATCH_MODE=1)")
+    num_devices = 4 * 2
+    if bh_2d_mesh_device.shape[0] * bh_2d_mesh_device.shape[1] < num_devices:
+        pytest.skip("Test requires 8 devices (4x2 mesh)")
+    submesh = bh_2d_mesh_device.create_submesh(ttnn.MeshShape((4, 2)))
+    device_grid = submesh.compute_with_storage_grid_size()
+    if device_grid.x < 12 or device_grid.y < 10:
+        pytest.skip(f"Per-device grid {device_grid.x}x{device_grid.y} too small for blitz decode (need 12x10+)")
+    num_cores = device_grid.x * device_grid.y
+    if num_cores < 128:
+        pytest.skip(f"Per-device has {num_cores} compute cores; GATE_UP overlap spec requires 128 cores (13x10 grid)")
+    state = _layer_state_dict(0, is_moe=True, for_multi_device=True, seed=43)
+    t0 = time.perf_counter()
+    weights = prepare_weights(
+        state,
+        submesh,
+        num_layers=1,
+        first_k_dense_replace=0,
+    )
+    elapsed = time.perf_counter() - t0
+    logger.info("prepare_weights (1 MoE layer, 4x2 mesh): {:.3f} s", elapsed)
+    assert len(weights.layers) == 1
+    layer = weights.layers[0]
+    assert isinstance(layer, DeepSeekV3MoELayerWeights)
+    assert layer.q_a_proj.tensor_shape == (3584, 3072)
+    assert layer.q_b_proj.tensor_shape == (1536, 12288)
+    assert layer.kv_a_proj.tensor_shape == (7168, 576)
+    assert layer.o_proj.tensor_shape == (8192, 7168)
+    assert layer.gate_mm.tensor_shape == (7168, 256)
+    assert layer.attn_norm.tensor_shape == (1, 7168)
+    assert layer.q_norm.tensor_shape == (1, 1536)
+    assert layer.kv_norm.tensor_shape == (1, 512)
+    assert layer.ffn_norm.tensor_shape == (1, 7168)
+    assert layer.kv_b1_proj.tensor_shape == (8192, 512)
+    assert layer.kv_b2_proj.tensor_shape == (512, 8192)
+    assert layer.shared_gate_proj.tensor_shape == (7168, 256)
+    assert layer.shared_up_proj.tensor_shape == (7168, 256)
 
 
 @pytest.mark.skip(reason="Future: run with real HF checkpoint; not implemented yet.")

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_prepare_weights.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_prepare_weights.py
@@ -20,11 +20,31 @@ from loguru import logger
 
 import ttnn
 from models.common.utility_functions import is_slow_dispatch
+from models.demos.deepseek_v3_b1.blitz_decode_weights import OverlappedTensor
 from models.demos.deepseek_v3_b1.prepare_weights import (
     DeepSeekV3DenseLayerWeights,
     DeepSeekV3MoELayerWeights,
+    deallocate_weights,
+    load_layer,
     prepare_weights,
+    save_layer,
 )
+
+
+def _core_range_set_to_tuples(crs):
+    """Normalize CoreRangeSet to comparable list of tuples for assertion."""
+    return sorted(((r.start.x, r.start.y), (r.end.x, r.end.y)) for r in crs.ranges())
+
+
+def _assert_overlapped_tensors_match(a: OverlappedTensor, b: OverlappedTensor) -> None:
+    """Assert two OverlappedTensors have matching metadata (not fused_tensor identity)."""
+    assert a.tensor_shape == b.tensor_shape
+    assert a.shard_shape == b.shard_shape
+    assert a.dtype == b.dtype
+    assert a.tile_shape == b.tile_shape
+    assert a.byte_offset == b.byte_offset
+    assert _core_range_set_to_tuples(a.core_range_set) == _core_range_set_to_tuples(b.core_range_set)
+
 
 # HF state dict shapes (out_features, in_features) for linears; see DEEPSEEK_PREPARE_WEIGHTS_DESIGN_DOC.md §5.
 # Per-device = one shard for single-device; blitz expects these when device is single.
@@ -170,9 +190,100 @@ def test_prepare_moe_layer_single_layer(device):
     assert layer.shared_up_proj.tensor_shape == (7168, 256)
 
 
-# ---------------------------------------------------------------------------
-# Multi-device (4x2 grid) tests
-# ---------------------------------------------------------------------------
+def test_save_load_dense_layer_single_layer(device, tmp_path):
+    """Save one dense layer to disk, load it back, assert metadata and fused-tensor sharing."""
+    if not is_slow_dispatch():
+        pytest.skip("prepare_weights tests require slow dispatch mode (TT_METAL_SLOW_DISPATCH_MODE=1)")
+    device_grid = device.compute_with_storage_grid_size()
+    if device_grid.x < 12 or device_grid.y < 10:
+        pytest.skip(f"Device grid {device_grid.x}x{device_grid.y} too small for blitz decode (need 12x10+)")
+
+    state = _layer_state_dict(0, is_moe=False)
+    weights = prepare_weights(state, device, num_layers=1, first_k_dense_replace=1)
+    save_layer(
+        weights.layers[0],
+        tmp_path,
+        0,
+        hf_model_name="test-dense-model",
+        hf_state_dict_name="test-dense-state-dict.safetensors",
+    )
+
+    assert (tmp_path / "layer_000" / "manifest.json").exists()
+    layer_dir = tmp_path / "layer_000"
+    assert (layer_dir / "q_ab_kv_a.tensorbin").exists()
+    assert (layer_dir / "o_proj_gate_mm_norms.tensorbin").exists()
+    assert (layer_dir / "kv_b12.tensorbin").exists()
+
+    deallocate_weights(weights)
+    layer = load_layer(tmp_path, device, 0)
+    orig = weights.layers[0]
+    assert isinstance(layer, DeepSeekV3DenseLayerWeights)
+
+    _assert_overlapped_tensors_match(orig.q_a_proj, layer.q_a_proj)
+    _assert_overlapped_tensors_match(orig.q_b_proj, layer.q_b_proj)
+    _assert_overlapped_tensors_match(orig.kv_a_proj, layer.kv_a_proj)
+    _assert_overlapped_tensors_match(orig.o_proj, layer.o_proj)
+    _assert_overlapped_tensors_match(orig.attn_norm, layer.attn_norm)
+    _assert_overlapped_tensors_match(orig.q_norm, layer.q_norm)
+    _assert_overlapped_tensors_match(orig.kv_norm, layer.kv_norm)
+    _assert_overlapped_tensors_match(orig.ffn_norm, layer.ffn_norm)
+    _assert_overlapped_tensors_match(orig.kv_b1_proj, layer.kv_b1_proj)
+    _assert_overlapped_tensors_match(orig.kv_b2_proj, layer.kv_b2_proj)
+
+    # Same fusion group must share fused_tensor
+    assert id(layer.q_a_proj.fused_tensor) == id(layer.q_b_proj.fused_tensor)
+    assert id(layer.q_b_proj.fused_tensor) == id(layer.kv_a_proj.fused_tensor)
+    assert id(layer.o_proj.fused_tensor) == id(layer.attn_norm.fused_tensor)
+    assert id(layer.kv_b1_proj.fused_tensor) == id(layer.kv_b2_proj.fused_tensor)
+
+
+def test_save_load_moe_layer_single_layer(device, tmp_path):
+    """Save one MoE layer to disk, load it back, assert metadata and fused-tensor sharing."""
+    if not is_slow_dispatch():
+        pytest.skip("prepare_weights tests require slow dispatch mode (TT_METAL_SLOW_DISPATCH_MODE=1)")
+    device_grid = device.compute_with_storage_grid_size()
+    if device_grid.x < 12 or device_grid.y < 10:
+        pytest.skip(f"Device grid {device_grid.x}x{device_grid.y} too small for blitz decode (need 12x10+)")
+    num_cores = device_grid.x * device_grid.y
+    if num_cores < 128:
+        pytest.skip(f"Device has {num_cores} compute cores; GATE_UP overlap spec requires 128 cores")
+
+    state = _layer_state_dict(0, is_moe=True, seed=43)
+    weights = prepare_weights(state, device, num_layers=1, first_k_dense_replace=0)
+    save_layer(
+        weights.layers[0],
+        tmp_path,
+        0,
+        hf_model_name="test-moe-model",
+        hf_state_dict_name="test-moe-state-dict.safetensors",
+    )
+
+    assert (tmp_path / "layer_000" / "manifest.json").exists()
+    layer_dir = tmp_path / "layer_000"
+    assert (layer_dir / "gate_up.tensorbin").exists()
+
+    deallocate_weights(weights)
+    layer = load_layer(tmp_path, device, 0)
+    orig = weights.layers[0]
+    assert isinstance(layer, DeepSeekV3MoELayerWeights)
+
+    _assert_overlapped_tensors_match(orig.q_a_proj, layer.q_a_proj)
+    _assert_overlapped_tensors_match(orig.q_b_proj, layer.q_b_proj)
+    _assert_overlapped_tensors_match(orig.kv_a_proj, layer.kv_a_proj)
+    _assert_overlapped_tensors_match(orig.o_proj, layer.o_proj)
+    _assert_overlapped_tensors_match(orig.gate_mm, layer.gate_mm)
+    _assert_overlapped_tensors_match(orig.attn_norm, layer.attn_norm)
+    _assert_overlapped_tensors_match(orig.q_norm, layer.q_norm)
+    _assert_overlapped_tensors_match(orig.kv_norm, layer.kv_norm)
+    _assert_overlapped_tensors_match(orig.ffn_norm, layer.ffn_norm)
+    _assert_overlapped_tensors_match(orig.kv_b1_proj, layer.kv_b1_proj)
+    _assert_overlapped_tensors_match(orig.kv_b2_proj, layer.kv_b2_proj)
+    _assert_overlapped_tensors_match(orig.shared_gate_proj, layer.shared_gate_proj)
+    _assert_overlapped_tensors_match(orig.shared_up_proj, layer.shared_up_proj)
+
+    assert id(layer.shared_gate_proj.fused_tensor) == id(layer.shared_up_proj.fused_tensor)
+
+
 @pytest.mark.parametrize(
     "device_params",
     [{"fabric_config": ttnn.FabricConfig.FABRIC_2D}],

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_prepare_weights.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_prepare_weights.py
@@ -7,9 +7,10 @@ Tests for prepare_weights: building DeepSeekV3Weights from a state dict.
 
 - test_prepare_dense_layer_single_layer: one dense layer with random weights.
 - test_prepare_moe_layer_single_layer: one MoE layer with random weights.
+- test_save_load_dense_layer_single_layer / test_save_load_moe_layer_single_layer: save then load one layer.
 - test_prepare_dense_layer_single_layer_4x2: one dense layer on 4x2 mesh.
 - test_prepare_moe_layer_single_layer_4x2: one MoE layer on 4x2 mesh.
-- test_prepare_real_weights: placeholder for future real checkpoint testing.
+- test_save_load_moe_layer_single_layer_4x2: save then load one MoE layer on 4x2 submesh.
 """
 
 import time
@@ -215,7 +216,10 @@ def test_save_load_dense_layer_single_layer(device, tmp_path):
     assert (layer_dir / "kv_b12.tensorbin").exists()
 
     deallocate_weights(weights)
+    t0 = time.perf_counter()
     layer = load_layer(tmp_path, device, 0)
+    elapsed = time.perf_counter() - t0
+    logger.info("load_layer (dense, single device): {:.3f} s", elapsed)
     orig = weights.layers[0]
     assert isinstance(layer, DeepSeekV3DenseLayerWeights)
 
@@ -263,7 +267,10 @@ def test_save_load_moe_layer_single_layer(device, tmp_path):
     assert (layer_dir / "gate_up.tensorbin").exists()
 
     deallocate_weights(weights)
+    t0 = time.perf_counter()
     layer = load_layer(tmp_path, device, 0)
+    elapsed = time.perf_counter() - t0
+    logger.info("load_layer (moe, single device): {:.3f} s", elapsed)
     orig = weights.layers[0]
     assert isinstance(layer, DeepSeekV3MoELayerWeights)
 
@@ -372,7 +379,68 @@ def test_prepare_moe_layer_single_layer_4x2(bh_2d_mesh_device):
     assert layer.shared_up_proj.tensor_shape == (7168, 256)
 
 
-@pytest.mark.skip(reason="Future: run with real HF checkpoint; not implemented yet.")
-def test_prepare_real_weights(device):
-    """Placeholder for testing prepare_weights with real model weights."""
-    pytest.fail("Real-weight test not implemented yet.")
+@pytest.mark.parametrize(
+    "device_params",
+    [{"fabric_config": ttnn.FabricConfig.FABRIC_2D}],
+    indirect=True,
+)
+def test_save_load_moe_layer_single_layer_4x2(bh_2d_mesh_device, tmp_path):
+    """Save one MoE layer (4x2 submesh) to disk, load it back, assert metadata and fused-tensor sharing."""
+    if not is_slow_dispatch():
+        pytest.skip("prepare_weights tests require slow dispatch mode (TT_METAL_SLOW_DISPATCH_MODE=1)")
+    num_devices = 4 * 2
+    if bh_2d_mesh_device.shape[0] * bh_2d_mesh_device.shape[1] < num_devices:
+        pytest.skip("Test requires 8 devices (4x2 mesh)")
+    submesh = bh_2d_mesh_device.create_submesh(ttnn.MeshShape((4, 2)))
+    device_grid = submesh.compute_with_storage_grid_size()
+    if device_grid.x < 12 or device_grid.y < 10:
+        pytest.skip(f"Per-device grid {device_grid.x}x{device_grid.y} too small for blitz decode (need 12x10+)")
+    num_cores = device_grid.x * device_grid.y
+    if num_cores < 128:
+        pytest.skip(f"Per-device has {num_cores} compute cores; GATE_UP overlap spec requires 128 cores")
+
+    state = _layer_state_dict(0, is_moe=True, for_multi_device=True, seed=43)
+    weights = prepare_weights(state, submesh, num_layers=1, first_k_dense_replace=0)
+    orig = weights.layers[0]
+    save_layer(
+        orig,
+        tmp_path,
+        0,
+        hf_model_name="test-moe-model-4x2",
+        hf_state_dict_name="test-moe-state-dict.safetensors",
+        device_mesh_shape=(4, 2),
+    )
+
+    assert (tmp_path / "layer_000" / "manifest.json").exists()
+    layer_dir = tmp_path / "layer_000"
+    assert (layer_dir / "gate_up.tensorbin").exists()
+    orig_shared_down_shape = getattr(orig, "shared_down_proj", None)
+    if orig_shared_down_shape is not None:
+        orig_shared_down_shape = orig_shared_down_shape.shape
+        assert (layer_dir / "shared_down_proj.tensorbin").exists()
+
+    deallocate_weights(weights)
+    t0 = time.perf_counter()
+    layer = load_layer(tmp_path, submesh, 0)
+    elapsed = time.perf_counter() - t0
+    logger.info("load_layer (moe, 4x2 submesh): {:.3f} s", elapsed)
+    assert isinstance(layer, DeepSeekV3MoELayerWeights)
+
+    _assert_overlapped_tensors_match(orig.q_a_proj, layer.q_a_proj)
+    _assert_overlapped_tensors_match(orig.q_b_proj, layer.q_b_proj)
+    _assert_overlapped_tensors_match(orig.kv_a_proj, layer.kv_a_proj)
+    _assert_overlapped_tensors_match(orig.o_proj, layer.o_proj)
+    _assert_overlapped_tensors_match(orig.gate_mm, layer.gate_mm)
+    _assert_overlapped_tensors_match(orig.attn_norm, layer.attn_norm)
+    _assert_overlapped_tensors_match(orig.q_norm, layer.q_norm)
+    _assert_overlapped_tensors_match(orig.kv_norm, layer.kv_norm)
+    _assert_overlapped_tensors_match(orig.ffn_norm, layer.ffn_norm)
+    _assert_overlapped_tensors_match(orig.kv_b1_proj, layer.kv_b1_proj)
+    _assert_overlapped_tensors_match(orig.kv_b2_proj, layer.kv_b2_proj)
+    _assert_overlapped_tensors_match(orig.shared_gate_proj, layer.shared_gate_proj)
+    _assert_overlapped_tensors_match(orig.shared_up_proj, layer.shared_up_proj)
+
+    assert id(layer.shared_gate_proj.fused_tensor) == id(layer.shared_up_proj.fused_tensor)
+    if orig_shared_down_shape is not None:
+        assert getattr(layer, "shared_down_proj", None) is not None
+        assert layer.shared_down_proj.shape == orig_shared_down_shape

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_prepare_weights.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_prepare_weights.py
@@ -12,6 +12,7 @@ Tests for prepare_weights: building DeepSeekV3Weights from a state dict.
 - test_prepare_moe_layer_single_layer_4x2: one MoE layer on 4x2 mesh.
 - test_save_load_dense_layer_single_layer_4x2: save then load one dense layer on 4x2 submesh.
 - test_save_load_moe_layer_single_layer_4x2: save then load one MoE layer on 4x2 submesh.
+- test_load_4_layers_across_4_submeshes_4x2: prepare each of 4 layers on a different 4x2 submesh, save, then load each on same submesh (32 devices).
 """
 
 import time
@@ -504,3 +505,92 @@ def test_save_load_moe_layer_single_layer_4x2(bh_2d_mesh_device, tmp_path):
     if orig_shared_down_shape is not None:
         assert getattr(layer, "shared_down_proj", None) is not None
         assert layer.shared_down_proj.shape == orig_shared_down_shape
+
+
+@pytest.mark.parametrize(
+    "device_params",
+    [{"fabric_config": ttnn.FabricConfig.FABRIC_2D}],
+    indirect=True,
+)
+def test_load_4_layers_across_4_submeshes_4x2(bh_2d_mesh_device, tmp_path):
+    """Prepare each of 4 layers on a different 4x2 submesh, save them, then load each on the same submesh.
+
+    Uses create_submeshes to get 4 disjoint (4x2) submeshes; requires 32 devices.
+    Each layer is prepared on its own submesh to avoid OOM. Layers 0,1,2 are dense, layer 3 is MoE.
+    """
+
+    tmp_path = "/tmp/test-cache/"
+    if not is_slow_dispatch():
+        pytest.skip("prepare_weights tests require slow dispatch mode (TT_METAL_SLOW_DISPATCH_MODE=1)")
+    num_submeshes = 4
+    devices_per_submesh = 4 * 2
+    num_devices_required = num_submeshes * devices_per_submesh  # 32
+    if bh_2d_mesh_device.shape[0] * bh_2d_mesh_device.shape[1] < num_devices_required:
+        pytest.skip(
+            f"Test requires {num_devices_required} devices (4 submeshes x 4x2), "
+            f"mesh has {bh_2d_mesh_device.shape[0] * bh_2d_mesh_device.shape[1]}"
+        )
+    submeshes = bh_2d_mesh_device.create_submeshes(ttnn.MeshShape((4, 2)))
+    assert len(submeshes) >= num_submeshes, f"Expected at least {num_submeshes} submeshes"
+    submesh0 = submeshes[0]
+    device_grid = submesh0.compute_with_storage_grid_size()
+    if device_grid.x < 12 or device_grid.y < 10:
+        pytest.skip(f"Per-device grid {device_grid.x}x{device_grid.y} too small for blitz decode (need 12x10+)")
+    num_cores = device_grid.x * device_grid.y
+    if num_cores < 128:
+        pytest.skip(f"Per-device has {num_cores} compute cores; GATE_UP overlap spec requires 128 cores")
+
+    num_layers = 4
+    first_k_dense_replace = 3  # layers 0,1,2 dense; layer 3 MoE
+    for layer_idx in range(num_layers):
+        is_moe = layer_idx >= first_k_dense_replace
+        submesh = submeshes[layer_idx]
+        state = _layer_state_dict(
+            layer_idx,
+            is_moe=is_moe,
+            for_multi_device=True,
+            seed=42 + layer_idx,
+        )
+        # prepare_weights always looks up model.layers.0.* when num_layers=1; remap keys
+        state_for_prepare = {k.replace(f"model.layers.{layer_idx}.", "model.layers.0."): v for k, v in state.items()}
+        # first_k_dense_replace so the single layer (index 0) is dense or MoE
+        first_k = 1 if layer_idx < first_k_dense_replace else 0
+        t0 = time.perf_counter()
+        weights = prepare_weights(
+            state_for_prepare,
+            submesh,
+            num_layers=1,
+            first_k_dense_replace=first_k,
+        )
+        elapsed = time.perf_counter() - t0
+        logger.info(
+            "prepare_weights (layer %d, %s, on submesh %d): {:.3f} s",
+            layer_idx,
+            "moe" if is_moe else "dense",
+            layer_idx,
+            elapsed,
+        )
+        assert len(weights.layers) == 1
+        save_layer(
+            weights.layers[0],
+            tmp_path,
+            layer_idx,
+            hf_model_name="test-4layer-model",
+            hf_state_dict_name="test-4layer-state-dict.safetensors",
+            device_mesh_shape=(4, 2),
+        )
+        deallocate_weights(weights)
+
+    loaded = []
+    t0 = time.time()
+    for layer_idx in range(num_layers):
+        submesh = submeshes[layer_idx]
+        layer = load_layer(tmp_path, submesh, layer_idx)
+        loaded.append(layer)
+    elapsed = time.time() - t0
+    logger.info(f"load_layer (4 layers, 4x2 submesh): {elapsed:.3f} s")
+
+    assert isinstance(loaded[0], DeepSeekV3DenseLayerWeights)
+    assert isinstance(loaded[1], DeepSeekV3DenseLayerWeights)
+    assert isinstance(loaded[2], DeepSeekV3DenseLayerWeights)
+    assert isinstance(loaded[3], DeepSeekV3MoELayerWeights)

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_prepare_weights.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_prepare_weights.py
@@ -1,0 +1,108 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Tests for prepare_weights: building DeepSeekV3Weights from a state dict.
+
+- test_prepare_dense_layer: one dense layer with random weights.
+- test_prepare_moe_layer: one MoE layer with random weights.
+- test_prepare_real_weights: placeholder for future real checkpoint testing.
+"""
+
+import pytest
+import torch
+
+from models.demos.deepseek_v3_b1.prepare_weights import (
+    DeepSeekV3DenseLayerWeights,
+    DeepSeekV3MoELayerWeights,
+    prepare_weights,
+)
+
+
+def _layer_state_dict(layer_idx: int, *, is_moe: bool, seed: int = 42) -> dict[str, torch.Tensor]:
+    """Build a minimal state_dict for a single layer (HF key convention, random weights)."""
+    g = torch.Generator().manual_seed(seed)
+    # HF linear weights are (out_features, in_features)
+    state = {
+        f"model.layers.{layer_idx}.self_attn.q_a_proj.weight": torch.randn(1536, 7168, generator=g, dtype=torch.bfloat16),
+        f"model.layers.{layer_idx}.self_attn.q_b_proj.weight": torch.randn(12288, 1536, generator=g, dtype=torch.bfloat16),
+        f"model.layers.{layer_idx}.self_attn.kv_a_proj_with_mqa.weight": torch.randn(576, 7168, generator=g, dtype=torch.bfloat16),
+        f"model.layers.{layer_idx}.self_attn.kv_b_proj.weight": torch.randn(16384, 512, generator=g, dtype=torch.bfloat16),
+        f"model.layers.{layer_idx}.self_attn.o_proj.weight": torch.randn(7168, 8192, generator=g, dtype=torch.bfloat16),
+        f"model.layers.{layer_idx}.input_layernorm.weight": torch.randn(7168, generator=g, dtype=torch.bfloat16),
+        f"model.layers.{layer_idx}.self_attn.q_a_layernorm.weight": torch.randn(1536, generator=g, dtype=torch.bfloat16),
+        f"model.layers.{layer_idx}.self_attn.kv_a_layernorm.weight": torch.randn(512, generator=g, dtype=torch.bfloat16),
+        f"model.layers.{layer_idx}.post_attention_layernorm.weight": torch.randn(7168, generator=g, dtype=torch.bfloat16),
+    }
+    if is_moe:
+        state[f"model.layers.{layer_idx}.mlp.gate.weight"] = torch.randn(256, 7168, generator=g, dtype=torch.bfloat16)
+        state[f"model.layers.{layer_idx}.mlp.shared_experts.gate_proj.weight"] = torch.randn(256, 7168, generator=g, dtype=torch.bfloat16)
+        state[f"model.layers.{layer_idx}.mlp.shared_experts.up_proj.weight"] = torch.randn(256, 7168, generator=g, dtype=torch.bfloat16)
+    return state
+
+
+def test_prepare_dense_layer(device):
+    """Build a single dense layer with random weights; verify type and shapes."""
+    device_grid = device.compute_with_storage_grid_size()
+    if device_grid.x < 12 or device_grid.y < 10:
+        pytest.skip(f"Device grid {device_grid.x}x{device_grid.y} too small for blitz decode (need 12x10+)")
+    state = _layer_state_dict(0, is_moe=False)
+    weights = prepare_weights(
+        state,
+        device,
+        num_layers=1,
+        first_k_dense_replace=1,
+    )
+    assert len(weights.layers) == 1
+    layer = weights.layers[0]
+    assert isinstance(layer, DeepSeekV3DenseLayerWeights)
+
+    assert layer.q_a_proj.tensor_shape == (3584, 3072)  # packed
+    assert layer.q_b_proj.tensor_shape == (1536, 12288)
+    assert layer.kv_a_proj.tensor_shape == (7168, 576)
+    assert layer.o_proj.tensor_shape == (8192, 7168)
+    assert layer.attn_norm.tensor_shape == (1, 7168)
+    assert layer.q_norm.tensor_shape == (1, 1536)
+    assert layer.kv_norm.tensor_shape == (1, 512)
+    assert layer.ffn_norm.tensor_shape == (1, 7168)
+    assert layer.kv_b1_proj.tensor_shape == (8192, 512)
+    assert layer.kv_b2_proj.tensor_shape == (512, 8192)
+
+
+def test_prepare_moe_layer(device):
+    """Build one dense and one MoE layer with random weights; verify MoE type and shapes."""
+    device_grid = device.compute_with_storage_grid_size()
+    if device_grid.x < 12 or device_grid.y < 10:
+        pytest.skip(f"Device grid {device_grid.x}x{device_grid.y} too small for blitz decode (need 12x10+)")
+    state = _layer_state_dict(0, is_moe=False, seed=42) | _layer_state_dict(1, is_moe=True, seed=43)
+    weights = prepare_weights(
+        state,
+        device,
+        num_layers=2,
+        first_k_dense_replace=1,
+    )
+    assert len(weights.layers) == 2
+    assert isinstance(weights.layers[0], DeepSeekV3DenseLayerWeights)
+    layer = weights.layers[1]
+    assert isinstance(layer, DeepSeekV3MoELayerWeights)
+
+    assert layer.q_a_proj.tensor_shape == (3584, 3072)
+    assert layer.q_b_proj.tensor_shape == (1536, 12288)
+    assert layer.kv_a_proj.tensor_shape == (7168, 576)
+    assert layer.o_proj.tensor_shape == (8192, 7168)
+    assert layer.gate_mm.tensor_shape == (7168, 256)
+    assert layer.attn_norm.tensor_shape == (1, 7168)
+    assert layer.q_norm.tensor_shape == (1, 1536)
+    assert layer.kv_norm.tensor_shape == (1, 512)
+    assert layer.ffn_norm.tensor_shape == (1, 7168)
+    assert layer.kv_b1_proj.tensor_shape == (8192, 512)
+    assert layer.kv_b2_proj.tensor_shape == (512, 8192)
+    assert layer.shared_gate_proj.tensor_shape == (57344, 32)  # stacked
+    assert layer.shared_up_proj.tensor_shape == (57344, 32)
+
+
+@pytest.mark.skip(reason="Future: run with real HF checkpoint; not implemented yet.")
+def test_prepare_real_weights(device):
+    """Placeholder for testing prepare_weights with real model weights."""
+    pytest.fail("Real-weight test not implemented yet.")

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_shared_expert.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_shared_expert.py
@@ -17,6 +17,7 @@ from loguru import logger
 
 import ttnn
 from models.common.utility_functions import comp_pcc
+from models.demos.deepseek_v3_b1.blitz_decode_weights import GATE_UP_PROJ_SINGLE_DEVICE_OVERLAP_SPEC
 from models.demos.deepseek_v3_b1.fused_ops.down_proj.op import DownProj
 from models.demos.deepseek_v3_b1.fused_ops.shared_expert.op import SharedExpertOp
 
@@ -67,8 +68,9 @@ def test_shared_expert(device, K_gate, N_per_core, weights_dtype):
     # ========================================================================
     # Core grids
     # ========================================================================
-    a_cores_list, b_cores_list = SharedExpertOp.build_ab_grids()
-    compute_cores_list = a_cores_list + b_cores_list  # 128 compute cores
+    gate_up_cfg = GATE_UP_PROJ_SINGLE_DEVICE_OVERLAP_SPEC
+    gate_crs = gate_up_cfg.gate_core_range_set
+    up_crs = gate_up_cfg.up_core_range_set
 
     mcast_gather_core = DownProj.MCAST_GATHER_CORE
     sender_core_grid = ttnn.CoreRangeSet([ttnn.CoreRange(mcast_gather_core, mcast_gather_core)])
@@ -115,34 +117,31 @@ def test_shared_expert(device, K_gate, N_per_core, weights_dtype):
     # Gate/Up weights: stacked, HEIGHT_SHARDED on 128 compute cores
     # Each core gets [k_per_core, 32] weight shard
     # A cores get gate weight shards, B cores get up weight shards
-    # Row order must match compute_cores_list = a_cores + b_cores
+    # Shard order follows CoreRangeSet enumeration of gate + up ranges
     # ========================================================================
-    # Build weight tensor with shards ordered by compute core list
-    weight_shards = []
-    for i, core in enumerate(a_cores_list):
-        # A core i: k_idx = i // n_parallel, n_idx = i % n_parallel
-        k_idx = i // n_parallel
-        n_idx = i % n_parallel
-        k_start = k_idx * k_per_core * 32
-        k_end = k_start + k_per_core * 32
-        n_start = n_idx * 32
-        n_end = n_start + 32
-        weight_shards.append(torch_gate_weights[k_start:k_end, n_start:n_end])
+    num_gate_cores = gate_crs.num_cores()
+    num_up_cores = up_crs.num_cores()
 
-    for i, core in enumerate(b_cores_list):
-        k_idx = i // n_parallel
-        n_idx = i % n_parallel
-        k_start = k_idx * k_per_core * 32
-        k_end = k_start + k_per_core * 32
-        n_start = n_idx * 32
-        n_end = n_start + 32
-        weight_shards.append(torch_up_weights[k_start:k_end, n_start:n_end])
+    def _build_shards(weights, num_cores, crs):
+        """Build weight shards in CRS enumeration order for HEIGHT_SHARDED placement."""
+        shards_rowmajor = []
+        for i in range(num_cores):
+            k_idx = i // n_parallel
+            n_idx = i % n_parallel
+            k_start = k_idx * k_per_core * 32
+            k_end = k_start + k_per_core * 32
+            n_start = n_idx * 32
+            n_end = n_start + 32
+            shards_rowmajor.append(weights[k_start:k_end, n_start:n_end])
+        perm = type(gate_up_cfg)._crs_shard_permutation(crs)
+        return [shards_rowmajor[p] for p in perm]
 
-    # Stack all shards: [128 * k_per_core, 32]
-    torch_gate_up_stacked = torch.cat(weight_shards, dim=0)
+    gate_shards = _build_shards(torch_gate_weights, num_gate_cores, gate_crs)
+    up_shards = _build_shards(torch_up_weights, num_up_cores, up_crs)
+    torch_gate_up_stacked = torch.cat(gate_shards + up_shards, dim=0)
     logger.info(f"Gate/Up weights stacked shape: {torch_gate_up_stacked.shape}")
 
-    compute_core_grid = ttnn.CoreRangeSet([ttnn.CoreRange(c, c) for c in compute_cores_list])
+    compute_core_grid = ttnn.CoreRangeSet(list(gate_crs.ranges()) + list(up_crs.ranges()))
     gu_shard_spec = ttnn.ShardSpec(compute_core_grid, (k_per_core * 32, 32), ttnn.ShardOrientation.ROW_MAJOR)
     gu_mem = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, gu_shard_spec)
 


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Provide context for the problem.

### What's changed
Describe the approach used to solve the problem.
Summarize the changes made and its impact.

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=esmal/prepare-weights-md)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:esmal/prepare-weights-md)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=esmal/prepare-weights-md)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:esmal/prepare-weights-md)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=esmal/prepare-weights-md)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:esmal/prepare-weights-md)
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=esmal/prepare-weights-md)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:esmal/prepare-weights-md)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=esmal/prepare-weights-md)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:esmal/prepare-weights-md)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=esmal/prepare-weights-md)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:esmal/prepare-weights-md)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
