### PR TITLE
[GPT-OSS] b=1 improve ccl times

### DIFF
--- a/models/demos/gpt_oss/tt/experts/decode.py
+++ b/models/demos/gpt_oss/tt/experts/decode.py
@@ -146,7 +146,11 @@ def decode_forward(
     if tp > 1:
         # Note: apply_tensor_parallel_allreduce already handles deallocating the input tensor
         next_states = apply_tensor_parallel_allreduce(
-            next_states, mesh_config, mesh_device, ccl_manager, activation_dtype, seq_len, tp
+            next_states,
+            mesh_config,
+            mesh_device,
+            seq_len,
+            ccl_manager,
         )
 
     # Final reshape

--- a/models/demos/gpt_oss/tt/experts/prefill.py
+++ b/models/demos/gpt_oss/tt/experts/prefill.py
@@ -273,10 +273,8 @@ def prefill_forward(
             next_states,
             mesh_config,
             mesh_device,
-            ccl_manager,
-            activation_dtype,
             seq_len_global,
-            tp,
+            ccl_manager,
         )
 
     # Sequence parallel all-gather


### PR DESCRIPTION
### Problem description
reduce_scatter was doing a load of padding for reduce_scatter+all_gather all_reduce which was slowing perf 

### What's changed
Use ttnn.all_reduce for ep/tp/sp CCLs in low-latency experts. Improve perf:
- 1x8 
  - 120b decode 10.72 tsu ->  14.73 tsu (38% ⬆️ ✅ )
  - 20b decode 16.2 tsu -> 22.27 tsu (38% ⬆️ ✅ )
  - 120b prefill 1220 TTFT -> 1119.7ms (8.3% ⬇️ ✅  )
  - 20b prefill 286ms TTFT -> 238.54ms (17% ⬇️ ✅ )
- 4x8
  - 120b decode 9.16 tsu -> 14.96 tsu (63% ⬆️ ✅  )
  - 20b decode 13.2 tsu -> 22.35 tsu (69% ⬆️ ✅ )
  - 120b prefill 628ms TTFT -> 541.36ms  (14% ⬇️ ✅  )
  - 20b prefill 286ms TTFT -> 243.71ms (15% ⬇️ ✅ )

### Checklist

- [ ] [![(Galaxy) demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml/badge.svg?branch=handrews/gpt-oss-b1-ccl)](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml?query=branch:handrews/gpt-oss-b1-ccl)
- [ ] [![(Galaxy) unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-unit-tests.yaml/badge.svg?branch=handrews/gpt-oss-b1-ccl)](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-unit-tests.yaml?query=branch:handrews/gpt-oss-b1-ccl)
- [ ] [![(T3000) demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml/badge.svg?branch=handrews/gpt-oss-b1-ccl)](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml?query=branch:handrews/gpt-oss-b1-ccl)
- [ ] [![(T3000) unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml/badge.svg?branch=handrews/gpt-oss-b1-ccl)](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml?query=branch:handrews/gpt-oss-b1-ccl)
