### PR TITLE
increase timeouts for longer deepseek tests

### DIFF
--- a/models/demos/deepseek_v3/demo/test_demo.py
+++ b/models/demos/deepseek_v3/demo/test_demo.py
@@ -36,7 +36,7 @@ CACHE_DIR = Path(os.getenv("DEEPSEEK_V3_CACHE", "/mnt/MLPerf/tt_dnn-models/deeps
             "dual_demo_full_results",
             False,
             id="dual_full_demo",
-            marks=pytest.mark.requires_device(["DUAL"]),
+            marks=[pytest.mark.requires_device(["DUAL"]), pytest.mark.timeout(2400)],
         ),
         pytest.param(
             56,
@@ -47,7 +47,7 @@ CACHE_DIR = Path(os.getenv("DEEPSEEK_V3_CACHE", "/mnt/MLPerf/tt_dnn-models/deeps
             "dual_demo_stress_results",
             False,
             id="dual_stress_demo",
-            marks=pytest.mark.requires_device(["DUAL"]),
+            marks=[pytest.mark.requires_device(["DUAL"]), pytest.mark.timeout(5400)],
         ),
         pytest.param(
             512,
@@ -58,7 +58,7 @@ CACHE_DIR = Path(os.getenv("DEEPSEEK_V3_CACHE", "/mnt/MLPerf/tt_dnn-models/deeps
             "quad_demo_full_results",
             False,
             id="quad_full_demo",
-            marks=pytest.mark.requires_device(["QUAD"]),
+            marks=[pytest.mark.requires_device(["QUAD"]), pytest.mark.timeout(3600)],
         ),
         pytest.param(
             56,
@@ -69,7 +69,7 @@ CACHE_DIR = Path(os.getenv("DEEPSEEK_V3_CACHE", "/mnt/MLPerf/tt_dnn-models/deeps
             "quad_demo_stress_results",
             False,
             id="quad_stress_demo",
-            marks=pytest.mark.requires_device(["QUAD"]),
+            marks=[pytest.mark.requires_device(["QUAD"]), pytest.mark.timeout(5400)],
         ),
         pytest.param(
             1,

--- a/models/demos/deepseek_v3/demo/test_demo_teacher_forced.py
+++ b/models/demos/deepseek_v3/demo/test_demo_teacher_forced.py
@@ -32,6 +32,7 @@ CACHE_DIR = Path(
 REFERENCE_FILE = Path(__file__).with_name("gpqa_diamond_racemic.refpt")
 
 
+@pytest.mark.timeout(3600)
 @pytest.mark.parametrize("reference_file", [REFERENCE_FILE])
 @pytest.mark.parametrize("max_new_tokens", [128, 2048, 8192], ids=["128", "2048", "8192"])
 def test_demo_teacher_forcing_accuracy(reference_file: Path, max_new_tokens: int, is_ci_env: bool):


### PR DESCRIPTION

This PR increases test timeouts for DeepSeek V3 demo tests to accommodate longer-running test scenarios. The timeout values are appropriately sized based on test complexity, with stress tests (20 repeat batches) receiving higher timeouts (5400s) than full demo tests.

Changes:

Added 1-hour timeout to teacher forcing accuracy tests
Added timeouts ranging from 40-90 minutes to DUAL and QUAD device demo tests
Modified pytest marks syntax to use list format when combining multiple marks