### PR TITLE
Remove unnecessary assert in update kv cache

### DIFF
--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_update_cache.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_update_cache.py
@@ -21,13 +21,7 @@ from models.common.utility_functions import skip_for_blackhole
 class TestUpdateCache:
     @pytest.mark.parametrize("seq_len", [32, 512, 2048, 4096])
     def test_fill_cache(self, seq_len, head_dim, max_seq_len, num_users, num_heads, in_sharded, input_dtype, device):
-        if not in_sharded and num_heads > 1 and seq_len == 2048:
-            pytest.skip(
-                "For interleaved, each core can only have 1 tile along seq_len if num_heads > 1, so there is a restriction on max seq_len!"
-            )
-
         cache_dtype = input_dtype
-
         input_shape = [1, num_heads, seq_len, head_dim]
         cache_shape = [num_users, num_heads, max_seq_len, head_dim]
         cache = torch.randn(cache_shape).bfloat16().float()

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_update_cache.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_update_cache.py
@@ -13,13 +13,13 @@ from models.common.utility_functions import skip_for_blackhole
 
 @skip_for_blackhole("Mismatching on BH, see #12349")
 @pytest.mark.parametrize("head_dim", [64])
-@pytest.mark.parametrize("max_seq_len", [2048])
+@pytest.mark.parametrize("max_seq_len", [4096])
 @pytest.mark.parametrize("num_users", [8, 16, 32, 64])
-@pytest.mark.parametrize("num_heads", [1, 2])
+@pytest.mark.parametrize("num_heads", [1, 2, 8])
 @pytest.mark.parametrize("in_sharded", [True, False])
 @pytest.mark.parametrize("input_dtype", [ttnn.bfloat16, ttnn.bfloat8_b])
 class TestUpdateCache:
-    @pytest.mark.parametrize("seq_len", [32, 512, 2048])
+    @pytest.mark.parametrize("seq_len", [32, 512, 2048, 4096])
     def test_fill_cache(self, seq_len, head_dim, max_seq_len, num_users, num_heads, in_sharded, input_dtype, device):
         if not in_sharded and num_heads > 1 and seq_len == 2048:
             pytest.skip(

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_update_cache.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_update_cache.py
@@ -145,11 +145,6 @@ class TestUpdateCacheFP32:
     def test_fill_cache_fp32(
         self, seq_len, head_dim, max_seq_len, num_users, num_heads, in_sharded, input_dtype, device
     ):
-        if not in_sharded and num_heads > 1 and seq_len == 1024:
-            pytest.skip(
-                "For interleaved, each core can only have 1 tile along seq_len if num_heads > 1, so there is a restriction on max seq_len!"
-            )
-
         cache_dtype = input_dtype
 
         input_shape = [1, num_heads, seq_len, head_dim]

--- a/ttnn/cpp/ttnn/operations/kv_cache/device/update_cache_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/kv_cache/device/update_cache_device_operation.cpp
@@ -64,23 +64,6 @@ void UpdateKVCacheOperation::validate_on_program_cache_miss(
         // TODO: If we want to support mixed precision like decode, we need to add simple compute kernel for conversion
         TT_FATAL(input_tensor.dtype() == cache_tensor.dtype(), "Input and cache tensors must have same dtype!");
 
-        // TODO: For interleaved, assume each core handles 1 tile of seq_len if kv_heads > 1
-        // For 56 cores and 2 heads, this effectively caps max seq len at 56 / 2 * 32 = 896
-        // Can generalize interleaved to infer and check arbitrary number of tiles along seq_len per core; or, add more
-        // robust logic in reader/writer loops to handle generic blocking of work For sharded, we infer number of tiles
-        // each core handles from shard so no issues there
-        if (input_tensor.memory_config().memory_layout() == TensorMemoryLayout::INTERLEAVED and
-            input_tensor.padded_shape()[1] > 1) {
-            const uint32_t num_blocks_of_work =
-                input_tensor.padded_shape()[1] * input_tensor.padded_shape()[-2] / TILE_HEIGHT;
-            const auto compute_with_storage_grid_size = input_tensor.device()->compute_with_storage_grid_size();
-            TT_FATAL(
-                (num_blocks_of_work <= compute_with_storage_grid_size.x * compute_with_storage_grid_size.y),
-                "Number of work blocks ({}) must be <= total grid size ({})",
-                num_blocks_of_work,
-                compute_with_storage_grid_size.x * compute_with_storage_grid_size.y);
-        }
-
         if (input_tensor.is_sharded()) {
             TT_FATAL(
                 input_tensor.memory_config().memory_layout() != TensorMemoryLayout::WIDTH_SHARDED,


### PR DESCRIPTION
### Problem description
Update cache fails with an assert when amount of work is greater than core grid, due to the assumption that one core can only do one time. But the program factory and kernels supports more than one tile per kernel.

### What's changed
Removed assert. 

### Checklist

- [x] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=smanoj/remove_update_cache_assert)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:smanoj/remove_update_cache_assert)
- [x] New/Existing tests provide coverage for changes

