### PR TITLE
[GPT-OSS] b=1 prefill tracing

### DIFF
--- a/models/demos/gpt_oss/demo/text_demo.py
+++ b/models/demos/gpt_oss/demo/text_demo.py
@@ -201,7 +201,7 @@ def prepare_gpt_oss_generator_args(
             {"page_block_size": 64, "page_max_num_blocks_per_dp": 4 * 1024 // 64},  # page_params
             {"temperature": 0, "top_p": 0.08},  # sampling_params (greedy decoding),
             True,  # enable_decode_trace
-            False,  # enable_prefill_trace
+            True,  # enable_prefill_trace
             False,  # users_row_sharded
             False,  # long_context_mode
             True,  # stop_at_eos
@@ -216,7 +216,7 @@ def prepare_gpt_oss_generator_args(
             {"page_block_size": 64, "page_max_num_blocks_per_dp": 4 * 1024 // 64},  # page_params
             {"temperature": 0, "top_p": 0.08},  # sampling_params (greedy decoding)
             True,  # enable_decode_trace
-            False,  # enable_prefill_trace
+            True,  # enable_prefill_trace
             False,  # users_row_sharded
             False,  # long_context_mode
             True,  # stop_at_eos
@@ -231,7 +231,7 @@ def prepare_gpt_oss_generator_args(
             {"page_block_size": 64, "page_max_num_blocks_per_dp": 4 * 1024 // 64},  # page_params
             {"temperature": 0, "top_p": 0.08},  # sampling_params (greedy decoding)
             True,  # enable_decode_trace
-            False,  # enable_prefill_trace
+            True,  # enable_prefill_trace
             False,  # users_row_sharded
             False,  # long_context_mode
             True,  # stop_at_eos

--- a/models/demos/gpt_oss/tt/experts/operations.py
+++ b/models/demos/gpt_oss/tt/experts/operations.py
@@ -91,10 +91,6 @@ def apply_tensor_parallel_allreduce(tensor, mesh_config, mesh_device, seq_len, c
     Returns:
         Allreduced tensor
     """
-    # Synchronize for prefill
-    if seq_len > 1:
-        ttnn.synchronize_device(mesh_device)  # ✅ Use explicit mesh_device
-
     tensor_allreduced = ttnn.all_reduce(
         tensor, num_links=ccl_manager.num_links, topology=ttnn.Topology.Ring, cluster_axis=mesh_config.tp_axis
     )

--- a/models/demos/gpt_oss/tt/experts/prefill.py
+++ b/models/demos/gpt_oss/tt/experts/prefill.py
@@ -243,7 +243,6 @@ def prefill_forward(
     ep, sp, tp = mode_config.ep, mode_config.sp, mode_config.tp
 
     # Reshard for sequence parallelism if needed
-    breakpoint()
     if sp > 1:
         hidden_states, routing_weights = _reshard_for_sequence_parallel(
             hidden_states, routing_weights, mesh_config, ccl_manager

--- a/models/demos/gpt_oss/tt/experts/prefill.py
+++ b/models/demos/gpt_oss/tt/experts/prefill.py
@@ -18,27 +18,42 @@ from .operations import (
 from .weights import ExpertWeights
 
 
-def _reshard_for_sequence_parallel(hidden_states, routing_weights, mesh_device):
-    """Reshard tensors for sequence parallel processing."""
-    hidden_states_torch = ttnn.to_torch(ttnn.get_device_tensors(hidden_states)[0])
-    routing_weights_torch = ttnn.to_torch(ttnn.get_device_tensors(routing_weights)[0])
-    hidden_states.deallocate(True)
-    routing_weights.deallocate(True)
+def _reshard_for_sequence_parallel(hidden_states, routing_weights, mesh_config, ccl_manager):
+    """
+    Convert replicated prefill inputs to SP row-sharded tensors using device-side CCL.
 
-    routing_weights = ttnn.from_torch(
-        routing_weights_torch,
-        device=mesh_device,
-        layout=ttnn.TILE_LAYOUT,
-        mesh_mapper=ttnn.ShardTensor2dMesh(dims=(-2, None), mesh_shape=mesh_device.shape, mesh_device=mesh_device),
+    This avoids host reads (`to_torch/get_device_tensors`) so it is trace-capture safe.
+    The input tensors are replicated across rows, so reduce-scatter sums identical values.
+    We rescale by 1/sp to recover the original values after sharding.
+    """
+    sp = mesh_config.get_config(Mode.PREFILL).sp
+    if sp <= 1:
+        return hidden_states, routing_weights
+
+    cluster_axis = mesh_config.sp_axis
+    scale = 1.0 / sp
+
+    hidden_states_sharded = ttnn.reduce_scatter(
+        hidden_states,
+        dim=2,  # sequence dimension for hidden states: [1, B, S, H]
+        cluster_axis=cluster_axis,
+        memory_config=hidden_states.memory_config(),
+        topology=ccl_manager.topology,
+        num_links=ccl_manager.num_links,
     )
-    hidden_states = ttnn.from_torch(
-        hidden_states_torch,
-        device=mesh_device,
-        layout=ttnn.TILE_LAYOUT,
-        mesh_mapper=ttnn.ShardTensor2dMesh(dims=(-2, None), mesh_shape=mesh_device.shape, mesh_device=mesh_device),
+    routing_weights_sharded = ttnn.reduce_scatter(
+        routing_weights,
+        dim=0,  # sequence dimension for routing weights: [S, E]
+        cluster_axis=cluster_axis,
+        memory_config=routing_weights.memory_config(),
+        topology=ccl_manager.topology,
+        num_links=ccl_manager.num_links,
     )
 
-    return hidden_states, routing_weights
+    hidden_states_sharded = ttnn.mul(hidden_states_sharded, scale, output_tensor=hidden_states_sharded)
+    routing_weights_sharded = ttnn.mul(routing_weights_sharded, scale, output_tensor=routing_weights_sharded)
+
+    return hidden_states_sharded, routing_weights_sharded
 
 
 def _process_prefill_chunk(
@@ -228,8 +243,11 @@ def prefill_forward(
     ep, sp, tp = mode_config.ep, mode_config.sp, mode_config.tp
 
     # Reshard for sequence parallelism if needed
+    breakpoint()
     if sp > 1:
-        hidden_states, routing_weights = _reshard_for_sequence_parallel(hidden_states, routing_weights, mesh_device)
+        hidden_states, routing_weights = _reshard_for_sequence_parallel(
+            hidden_states, routing_weights, mesh_config, ccl_manager
+        )
 
     # Chunk processing for very long sequences
     chunk_size = program_config.sequence_chunk_size

--- a/models/demos/gpt_oss/tt/model_config.py
+++ b/models/demos/gpt_oss/tt/model_config.py
@@ -172,6 +172,9 @@ class ModelArgs:
 
         # TODO: If no specific sequence lengths are listed for a model and device, the default one will be used (from the default_supported_seq_lens dictionary)
         model_specific_supported_seq_lens = {
+            "gpt-oss-120b": {
+                "TG": [128],
+            }
             # exmaple : #base_model_name : {device_name : [sequence_lengths]}
         }
 

--- a/models/demos/gpt_oss/tt/model_config.py
+++ b/models/demos/gpt_oss/tt/model_config.py
@@ -173,6 +173,7 @@ class ModelArgs:
         # TODO: If no specific sequence lengths are listed for a model and device, the default one will be used (from the default_supported_seq_lens dictionary)
         model_specific_supported_seq_lens = {
             "gpt-oss-120b": {
+                "T3K": [128],
                 "TG": [128],
             }
             # exmaple : #base_model_name : {device_name : [sequence_lengths]}


### PR DESCRIPTION
### Problem description
Prefill tracing was disabled for b=1 GPT-OSS

### What's changed
Add support for prefill tracing 

- 1x8 
  - 120b prefill 1119.7ms TTFT -> 1068.3ms(5% ⬇️ ✅  )
  - 20b prefill 238.54ms TTFT -> 218.55ms (8.4% ⬇️ ✅ )
- 4x8
  - 120b prefill 541.36ms TTFT -> 310.65ms (43% ⬇️ ✅  )
  - 20b prefill 243.71ms TTFT -> 204.13 (16% ⬇️ ✅ )

### Checklist

- [ ] [![(Galaxy) demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml/badge.svg?branch=handrews/gpt-oss-b1-prefill-trace)](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml?query=branch:handrews/gpt-oss-b1-prefill-trace)
- [ ] [![(Galaxy) unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-unit-tests.yaml/badge.svg?branch=handrews/gpt-oss-b1-prefill-trace)](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-unit-tests.yaml?query=branch:handrews/gpt-oss-b1-prefill-trace)
- [ ] [![(T3000) demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml/badge.svg?branch=handrews/gpt-oss-b1-prefill-trace)](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml?query=branch:handrews/gpt-oss-b1-prefill-trace)
- [ ] [![(T3000) unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml/badge.svg?branch=handrews/gpt-oss-b1-prefill-trace)](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml?query=branch:handrews/gpt-oss-b1-prefill-trace)