### PR TITLE
[llama3_70b_galaxy] return logprobs for prefill output token

### DIFF
--- a/models/demos/llama3_70b_galaxy/demo/text_demo.py
+++ b/models/demos/llama3_70b_galaxy/demo/text_demo.py
@@ -917,7 +917,9 @@ def test_demo_text(
             # Once updated, include the modified target file in your PR. The model code owners will then review and approve the changes.
             # If no changes to the model are expected from the PR, but targets differ, further investigation is needed to understand the root cause.
 
-        # Save prefill token
+        # Save prefill token (unpack tuple when device sampling returns logprobs)
+        if isinstance(toks, tuple):
+            toks = toks[0]
         prefilled_token = toks.view(-1, 1)
         profiler.end(f"inference_prefill", iteration=batch_idx)
         logger.info(f"Prefill finished")

--- a/models/demos/llama3_70b_galaxy/demo/text_qwen_demo.py
+++ b/models/demos/llama3_70b_galaxy/demo/text_qwen_demo.py
@@ -729,7 +729,9 @@ def test_qwen_demo_text(
             # Once updated, include the modified target file in your PR. The model code owners will then review and approve the changes.
             # If no changes to the model are expected from the PR, but targets differ, further investigation is needed to understand the root cause.
 
-        # Save prefill token
+        # Save prefill token (unpack tuple when device sampling returns logprobs)
+        if isinstance(toks, tuple):
+            toks = toks[0]
         prefilled_token = toks.view(-1, 1)
         profiler.end(f"inference_prefill", iteration=batch_idx)
         logger.info(f"Prefill finished")

--- a/models/demos/llama3_70b_galaxy/tt/generator.py
+++ b/models/demos/llama3_70b_galaxy/tt/generator.py
@@ -298,6 +298,7 @@ class Generator(WarmupForwardMixin):
                 else:
                     # Single user: logits list has 1 entry, copy into persistent buffer
                     ttnn.copy(input_a=tt_logits_list[0], input_b=self.tt_logits_accumulated[user_id])
+        prefill_log_probs = None
         # On-device sampling for prefill
         if do_device_sampling:
             padded_batch = 32
@@ -366,7 +367,16 @@ class Generator(WarmupForwardMixin):
 
             # sampled_tokens has 32 entries ordered by slot.
             sampled_tensor = sampled_tokens[0, 0, 0, :]  # Shape: [32]
-            output_toks = sampled_tensor[empty_slots].reshape(batch, 1, 1)
+            output_toks = sampled_tensor[empty_slots]  # Shape: [batch]
+
+            if tt_log_probs is not None:
+                tt_lp = tt_log_probs
+                if isinstance(tt_lp, tuple):
+                    tt_lp = tt_lp[0]
+                if isinstance(tt_lp, list):
+                    tt_lp = tt_lp[0]
+                log_probs_torch = ttnn.to_torch(ttnn.get_device_tensors(tt_lp)[0])
+                prefill_log_probs = log_probs_torch[0, 0, 0, :][empty_slots]
 
         if return_logits:
             # TODO: the current solution runs the argmax even if we are returning logits
@@ -377,6 +387,8 @@ class Generator(WarmupForwardMixin):
             return tt_out_logits_all_users
 
         logger.info(f"Finished prefill for all users up to {batch_seq_len} tokens, Starting decode...")
+        if prefill_log_probs is not None:
+            return output_toks, prefill_log_probs
         return output_toks
 
     def prefill_forward_single_user_text(

--- a/models/demos/llama3_70b_galaxy/tt/generator.py
+++ b/models/demos/llama3_70b_galaxy/tt/generator.py
@@ -177,7 +177,7 @@ class Generator(WarmupForwardMixin):
 
         kv_cache = kv_cache[0]
         batch, batch_seq_len = tokens.shape
-        output_toks = torch.zeros(batch, 1, 1)
+        output_toks = torch.zeros(batch)
         prompt_lens = prompt_lens if prompt_lens is not None else torch.tensor([batch_seq_len] * batch)
         if not isinstance(prompt_lens, list):
             prompt_lens = prompt_lens.tolist()
@@ -282,7 +282,7 @@ class Generator(WarmupForwardMixin):
                 if use_batched_prefill:
                     # reverse the reordering of the tokens when empty_slots are not sequential (from vllm)
                     tt_tok_tensor = torch.stack(tt_tok, dim=0)
-                    output_toks = tt_tok_tensor[empty_slots].reshape(batch, 1, 1)
+                    output_toks = tt_tok_tensor[empty_slots].reshape(batch)
                 else:
                     output_toks[id] = tt_tok
 
@@ -367,14 +367,10 @@ class Generator(WarmupForwardMixin):
 
             # sampled_tokens has 32 entries ordered by slot.
             sampled_tensor = sampled_tokens[0, 0, 0, :]  # Shape: [32]
-            output_toks = sampled_tensor[empty_slots]  # Shape: [batch]
+            output_toks = sampled_tensor[empty_slots]
 
             if tt_log_probs is not None:
                 tt_lp = tt_log_probs
-                if isinstance(tt_lp, tuple):
-                    tt_lp = tt_lp[0]
-                if isinstance(tt_lp, list):
-                    tt_lp = tt_lp[0]
                 log_probs_torch = ttnn.to_torch(ttnn.get_device_tensors(tt_lp)[0])
                 prefill_log_probs = log_probs_torch[0, 0, 0, :][empty_slots]
 


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/38073

### Problem description
Logprobs are not properly returned from the generator when performing device sampling in prefill.

### What's changed
Return logprobs instead of discarding in generators
Insert discard in demos
### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=tcheda/llama_prefill_logprobs)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:tcheda/llama_prefill_logprobs)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=tcheda/llama_prefill_logprobs)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:tcheda/llama_prefill_logprobs)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=tcheda/llama_prefill_logprobs)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:tcheda/llama_prefill_logprobs)
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=tcheda/llama_prefill_logprobs)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:tcheda/llama_prefill_logprobs)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=tcheda/llama_prefill_logprobs)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:tcheda/llama_prefill_logprobs)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=tcheda/llama_prefill_logprobs)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:tcheda/llama_prefill_logprobs)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [x] other selection - specify runs
