### PR TITLE
Enable weights cache reuse across different replication factors

### DIFF
--- a/tests/ttnn/unit_tests/base_functionality/test_multi_device.py
+++ b/tests/ttnn/unit_tests/base_functionality/test_multi_device.py
@@ -799,3 +799,84 @@ def test_multihost_sanity(mesh_device):
     torch_loop_back_tensor = ttnn.to_torch(ttnn_loop_back_tensor, mesh_composer=ConcatMeshToTensor(mesh_device, dim=3))
 
     assert_with_pcc(torch_gelu, torch_loop_back_tensor, pcc=0.9999)
+
+
+def test_dump_load_partial_replicate_roundtrip(mesh_device):
+    """Dump/load a [R, S(-1)] tensor — transparent topology-portable caching.
+    No special mapper or fingerprint needed; to_flatbuffer collapses replicate axes automatically."""
+    num_cols = mesh_device.shape[1]
+    shard_size = 32
+    torch_tensor = torch.rand((1, 1, 32, shard_size * num_cols), dtype=torch.bfloat16)
+
+    config = ttnn.MeshMapperConfig(
+        placements=[ttnn.PlacementReplicate(), ttnn.PlacementShard(-1)],
+    )
+    mapper = ttnn.create_mesh_mapper(mesh_device, config)
+    host_tensor = ttnn.from_torch(
+        torch_tensor,
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        mesh_mapper=mapper,
+    )
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        cache_path = f"{tmpdir}/test_cache.tensorbin"
+        ttnn.dump_tensor(cache_path, host_tensor)
+
+        loaded = ttnn.load_tensor(cache_path, device=mesh_device)
+
+        # Verify each shard matches expected slice
+        shards = ttnn.get_device_tensors(loaded)
+        assert len(shards) == mesh_device.get_num_devices()
+
+        for col in range(num_cols):
+            shard_torch = ttnn.to_torch(shards[col])
+            expected = torch_tensor[..., col * shard_size : (col + 1) * shard_size]
+            assert_with_pcc(shard_torch, expected, pcc=0.9999)
+
+
+@pytest.mark.parametrize(
+    "mesh_device",
+    [pytest.param((2, 2), id="2x2_grid"), pytest.param((2, 4), id="2x4_grid")],
+    indirect=True,
+)
+def test_topology_portable_cross_mesh_roundtrip(mesh_device):
+    """Verify a [R, S(-1)] tensor dumped on NxM loads correctly on a 1xM submesh.
+
+    Demonstrates topology portability: the replicate axis changes from N to 1
+    while the shard axis (M) stays the same. The serialized file stores only
+    the M unique shard entries (replicate axis collapsed), so it is loadable
+    on any mesh whose column count matches.
+    """
+    num_rows = mesh_device.shape[0]
+    num_cols = mesh_device.shape[1]
+    shard_size = 32
+    torch_tensor = torch.rand((1, 1, 32, shard_size * num_cols), dtype=torch.bfloat16)
+
+    # Distribute as [R, S(-1)] on the full mesh (replicate axis = num_rows).
+    config = ttnn.MeshMapperConfig(
+        placements=[ttnn.PlacementReplicate(), ttnn.PlacementShard(-1)],
+    )
+    mapper = ttnn.create_mesh_mapper(mesh_device, config)
+    host_tensor = ttnn.from_torch(
+        torch_tensor,
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        mesh_mapper=mapper,
+    )
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        cache_path = f"{tmpdir}/cross_mesh.tensorbin"
+        ttnn.dump_tensor(cache_path, host_tensor)
+
+        # Load on a 1xM submesh — replicate axis shrinks from N to 1.
+        submesh = mesh_device.create_submesh(ttnn.MeshShape(1, num_cols))
+        loaded = ttnn.load_tensor(cache_path, device=submesh)
+
+        shards = ttnn.get_device_tensors(loaded)
+        assert len(shards) == num_cols
+
+        for col in range(num_cols):
+            shard_torch = ttnn.to_torch(shards[col])
+            expected = torch_tensor[..., col * shard_size : (col + 1) * shard_size]
+            assert_with_pcc(shard_torch, expected, pcc=0.9999)

--- a/tests/ttnn/unit_tests/gtests/tensor/test_distributed_tensor.cpp
+++ b/tests/ttnn/unit_tests/gtests/tensor/test_distributed_tensor.cpp
@@ -490,4 +490,49 @@ TEST_F(TensorDistribution2x4Test, NdMapperShard3D) {
     EXPECT_THAT(aggregated_tensor.to_vector<float>(), Pointwise(FloatEq(), expected_data));
 }
 
+TEST_F(TensorDistribution2x4Test, PartialReplicationExpansion) {
+    // Create a reduced [1,4] tensor with [R, S(-1)], then expand to [2,4] mesh.
+    constexpr int kNumCols = 4;
+    std::vector<float> test_data;
+    for (int i = 0; i < kNumCols; i++) {
+        test_data.insert(test_data.end(), {i * 1.F, i * 2.F, i * 3.F});
+    }
+    Tensor input_tensor =
+        Tensor::from_vector(test_data, get_tensor_spec(ttnn::Shape{1, 1, kNumCols, 3}, DataType::FLOAT32));
+
+    // Create a reduced mapper with [R, S(-1)] and mesh_shape_override = [1,4]
+    // (replicate axis collapsed to 1)
+    const auto reduced_config = MeshMapperConfig{
+        .placements = {MeshMapperConfig::Replicate{}, MeshMapperConfig::Shard{2}},
+        .mesh_shape_override = MeshShape(1, kNumCols),
+    };
+    auto mapper = create_mesh_mapper(*mesh_device_, reduced_config);
+    Tensor reduced_tensor = distribute_tensor(input_tensor, *mapper);
+
+    // Verify reduced tensor has [1,4] distribution shape
+    EXPECT_EQ(reduced_tensor.tensor_topology().distribution_shape(), MeshShape(1, kNumCols));
+
+    // Send to device — this should trigger partial expansion from [1,4] to [2,4]
+    Tensor device_tensor = reduced_tensor.to_device(mesh_device_.get());
+
+    // Verify the expanded tensor has the full mesh topology
+    const auto& expanded_topology = device_tensor.tensor_topology();
+    EXPECT_EQ(expanded_topology.distribution_shape(), mesh_device_->shape());
+
+    // Verify we have 8 device tensors (2x4 mesh)
+    std::vector<Tensor> device_tensors = get_device_tensors(device_tensor);
+    EXPECT_EQ(device_tensors.size(), mesh_device_->num_devices());
+
+    // Verify data: each column should have the same data in both rows (replicated)
+    for (int col = 0; col < kNumCols; col++) {
+        auto row0_data = device_tensors[col].to_vector<float>();             // row 0, col `col`
+        auto row1_data = device_tensors[kNumCols + col].to_vector<float>();  // row 1, col `col`
+        EXPECT_THAT(row0_data, Pointwise(FloatEq(), row1_data))
+            << "Row 0 and Row 1 should have identical data at column " << col;
+        // Also verify the data matches the original shard
+        std::vector<float> expected = {col * 1.F, col * 2.F, col * 3.F};
+        EXPECT_THAT(row0_data, Pointwise(FloatEq(), expected));
+    }
+}
+
 }  // namespace ttnn::distributed::test

--- a/tests/ttnn/unit_tests/gtests/tensor/test_tensor_serialization.cpp
+++ b/tests/ttnn/unit_tests/gtests/tensor/test_tensor_serialization.cpp
@@ -333,16 +333,21 @@ TEST_F(TensorSerializationFlatbuffer2x4Test, PartiallyReplicatedRoundtrip) {
     EXPECT_EQ(loaded_tensor.layout(), sharded_tensor.layout());
     EXPECT_TRUE(loaded_tensor.storage_type() == StorageType::HOST);
 
+    // After collapsing replicate axes, the loaded tensor has [2,1] distribution shape
+    // with only 2 unique shards (one per row), instead of the original 8.
+    EXPECT_EQ(loaded_tensor.tensor_topology().distribution_shape(), MeshShape(kNumRows, 1));
+
     std::vector<Tensor> original_device_tensors = ttnn::distributed::get_device_tensors(sharded_tensor);
     std::vector<Tensor> loaded_device_tensors = ttnn::distributed::get_device_tensors(loaded_tensor);
 
-    ASSERT_THAT(loaded_device_tensors, SizeIs(original_device_tensors.size()));
+    ASSERT_THAT(loaded_device_tensors, SizeIs(kNumRows));
 
-    for (size_t i = 0; i < original_device_tensors.size(); i++) {
+    // Each loaded shard should match the corresponding row from the original.
+    for (int row = 0; row < kNumRows; row++) {
         EXPECT_THAT(
-            loaded_device_tensors[i].to_vector<float>(),
-            Pointwise(FloatEq(), original_device_tensors[i].to_vector<float>()));
-        EXPECT_EQ(loaded_device_tensors[i].logical_shape(), original_device_tensors[i].logical_shape());
+            loaded_device_tensors[row].to_vector<float>(),
+            Pointwise(FloatEq(), original_device_tensors[row * kNumCols].to_vector<float>()));
+        EXPECT_EQ(loaded_device_tensors[row].logical_shape(), original_device_tensors[row * kNumCols].logical_shape());
     }
 }
 
@@ -373,6 +378,65 @@ TEST_F(TensorSerializationFlatbuffer2x4Test, FullyReplicatedRoundtrip) {
 
     EXPECT_EQ(loaded_tensor.tensor_topology().distribution_shape(), expected_shape);
     EXPECT_EQ(loaded_tensor.tensor_topology().placements(), expected_placements);
+}
+
+TEST_F(TensorSerializationFlatbuffer2x4Test, TopologyPortablePartialReplicateRoundtrip) {
+    TemporaryFile test_file("topology_portable_partial_replicate.tensorbin");
+    constexpr int kNumRows = 2;
+    constexpr int kNumCols = 4;
+    constexpr int kNumElements = 1024;
+    const int num_devices = kNumRows * kNumCols;
+
+    std::vector<float> test_data;
+    for (int i = 0; i < num_devices; i++) {
+        std::generate_n(std::back_inserter(test_data), kNumElements, [i]() { return i * 1.0f; });
+    }
+
+    Tensor input_tensor = Tensor::from_vector(
+        test_data, get_tensor_spec(ttnn::Shape{1, kNumRows, kNumCols, kNumElements}, DataType::FLOAT32));
+
+    // [R, S(2)] — replicate along rows, shard along columns.
+    auto mapper = ttnn::distributed::create_mesh_mapper(
+        *mesh_device_,
+        ttnn::distributed::MeshMapperConfig{
+            .placements =
+                {ttnn::distributed::MeshMapperConfig::Replicate{}, ttnn::distributed::MeshMapperConfig::Shard{2}},
+        });
+
+    Tensor sharded_tensor = ttnn::distributed::distribute_tensor(input_tensor, *mapper);
+    EXPECT_TRUE(sharded_tensor.storage_type() == StorageType::HOST);
+
+    dump_tensor_flatbuffer(test_file.string(), sharded_tensor);
+
+    // Verify the loaded host tensor has reduced distribution shape [1,4] with 4 unique shards.
+    Tensor loaded_tensor = load_tensor_flatbuffer(test_file.string());
+    EXPECT_EQ(loaded_tensor.tensor_topology().distribution_shape(), MeshShape(1, kNumCols));
+
+    std::vector<Tensor> loaded_device_tensors = ttnn::distributed::get_device_tensors(loaded_tensor);
+    ASSERT_THAT(loaded_device_tensors, SizeIs(kNumCols));
+
+    // Verify data of each unique shard matches the corresponding column from the original.
+    std::vector<Tensor> original_device_tensors = ttnn::distributed::get_device_tensors(sharded_tensor);
+    for (int col = 0; col < kNumCols; col++) {
+        EXPECT_THAT(
+            loaded_device_tensors[col].to_vector<float>(),
+            Pointwise(FloatEq(), original_device_tensors[col].to_vector<float>()));
+    }
+
+    // Load with device — should expand replicate axes to fill 2x4 mesh.
+    Tensor device_tensor = load_tensor_flatbuffer(test_file.string(), mesh_device_.get());
+    EXPECT_TRUE(device_tensor.storage_type() == StorageType::DEVICE);
+
+    std::vector<Tensor> expanded_device_tensors = ttnn::distributed::get_device_tensors(device_tensor);
+    ASSERT_THAT(expanded_device_tensors, SizeIs(num_devices));
+
+    // Verify replicated rows have matching data.
+    for (int col = 0; col < kNumCols; col++) {
+        auto row0_data = expanded_device_tensors[col].to_vector<float>();
+        auto row1_data = expanded_device_tensors[kNumCols + col].to_vector<float>();
+        EXPECT_THAT(row0_data, Pointwise(FloatEq(), row1_data))
+            << "Row 0 and Row 1 should have identical data at column " << col;
+    }
 }
 
 }  // namespace

--- a/ttnn/core/distributed/distributed_nanobind.cpp
+++ b/ttnn/core/distributed/distributed_nanobind.cpp
@@ -644,11 +644,18 @@ void py_module(nb::module_& mod) {
                col_dim Optional[int]: The column dimension to shard / replicate over.
                mesh_shape_override Optional[MeshShape]: If provided, overrides distribution shape of the mesh device.
                )doc")
-        .def("__repr__", [](const MeshMapperConfig& config) {
-            std::ostringstream str;
-            str << config;
-            return str.str();
-        });
+        .def(
+            "__repr__",
+            [](const MeshMapperConfig& config) {
+                std::ostringstream str;
+                str << config;
+                return str.str();
+            })
+        .def_ro(
+            "placements",
+            &MeshMapperConfig::placements,
+            R"doc(Returns the list of placements (PlacementReplicate or PlacementShard).)doc")
+        .def_ro("mesh_shape_override", &MeshMapperConfig::mesh_shape_override);
     auto py_mesh_composer_config = static_cast<nb::class_<MeshComposerConfig>>(mod.attr("MeshComposerConfig"));
     py_mesh_composer_config
         .def(

--- a/ttnn/core/distributed/distributed_tensor.cpp
+++ b/ttnn/core/distributed/distributed_tensor.cpp
@@ -2,6 +2,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <sstream>
+
 #include <tt_stl/assert.hpp>
 #include <tt-metalium/distributed_host_buffer.hpp>
 #include <tt-metalium/shape.hpp>

--- a/ttnn/core/tensor/flatbuffer/tensor_flatbuffer.cpp
+++ b/ttnn/core/tensor/flatbuffer/tensor_flatbuffer.cpp
@@ -25,6 +25,7 @@
 #include <vector>
 #include <cstdint>
 #include <unordered_map>
+#include <algorithm>
 
 namespace ttnn {
 namespace {
@@ -165,29 +166,102 @@ flatbuffers::Offset<ttnn::flatbuffer::Tensor> to_flatbuffer(
     auto tensor_spec_offset = ttnn::to_flatbuffer(tensor.tensor_spec(), builder);
 
     const auto& host_storage = tensor.host_storage();
+    const auto& topology = tensor.tensor_topology();
+    const auto& placements = topology.placements();
+    const auto& dist_shape = topology.distribution_shape();
 
+    // Determine if we should collapse replicate axes in the stored representation.
+    // This makes the serialized file topology-portable: a tensor with [R, S(-1)] on a 2x4 mesh
+    // is stored as [1,4] with 4 shards, loadable on any mesh with 4+ columns.
+    // Condition: buffer dimensionality must match placements (excludes 1D overrides on ND meshes).
+    const bool collapse_replicates =
+        host_storage.buffer().shape().dims() == placements.size() &&
+        std::any_of(placements.begin(), placements.end(), [](const auto& p) {
+            return std::holds_alternative<tt::tt_metal::distributed::MeshMapperConfig::Replicate>(p);
+        });
+
+    // Build shard entries: pairs of (physical_coord_for_data_lookup, coord_to_store).
+    struct ShardEntry {
+        tt::tt_metal::distributed::MeshCoordinate phys_coord;
+        tt::tt_metal::distributed::MeshCoordinate stored_coord;
+    };
+    std::vector<ShardEntry> shard_entries;
+
+    tt::tt_metal::distributed::MeshShape stored_mesh_shape = host_storage.buffer().shape();
+
+    if (collapse_replicates) {
+        // Compute reduced mesh shape: replicate axes collapse to 1, shard axes keep their size.
+        std::vector<uint32_t> reduced_dims;
+        for (size_t i = 0; i < placements.size(); i++) {
+            reduced_dims.push_back(
+                std::holds_alternative<tt::tt_metal::distributed::MeshMapperConfig::Replicate>(placements[i])
+                    ? 1
+                    : dist_shape[i]);
+        }
+        stored_mesh_shape = tt::tt_metal::distributed::MeshShape(reduced_dims);
+
+        // Walk distribution coords in lockstep with topology mesh_coords.
+        // Keep only the canonical representative for each projected coord
+        // (the one where all replicate-axis components are 0).
+        const auto& mesh_coords = topology.mesh_coords();
+        size_t coord_idx = 0;
+        for (const auto& dist_coord : tt::tt_metal::distributed::MeshCoordinateRange(dist_shape)) {
+            if (coord_idx >= mesh_coords.size()) {
+                break;
+            }
+            const auto& phys_coord = mesh_coords[coord_idx++];
+
+            // Skip non-canonical entries: any replicate-axis component > 0 means this is a replica.
+            bool is_canonical = true;
+            for (size_t i = 0; i < dist_coord.dims(); i++) {
+                if (std::holds_alternative<tt::tt_metal::distributed::MeshMapperConfig::Replicate>(placements[i]) &&
+                    dist_coord[i] != 0) {
+                    is_canonical = false;
+                    break;
+                }
+            }
+            if (!is_canonical) {
+                continue;
+            }
+
+            // For canonical entries, the distribution coord already has replicate axes at 0,
+            // so it serves directly as the stored coord in the reduced space.
+            std::vector<uint32_t> projected;
+            for (size_t i = 0; i < dist_coord.dims(); i++) {
+                projected.push_back(dist_coord[i]);
+            }
+            shard_entries.push_back({phys_coord, tt::tt_metal::distributed::MeshCoordinate(projected)});
+        }
+    } else {
+        // No reduction: store all populated shard coords as-is.
+        for (const auto& coord : host_storage.buffer().shard_coords()) {
+            if (host_storage.buffer().get_shard(coord).has_value()) {
+                shard_entries.push_back({coord, coord});
+            }
+        }
+    }
+
+    // Create shard flatbuffer entries.
     std::vector<flatbuffers::Offset<ttnn::flatbuffer::TensorShard>> shards_vector;
-    // Used to deduplicate buffer addresses for replicated tensor data.
     std::unordered_map<const std::byte*, uint64_t> buffer_to_offset;
     uint64_t next_buffer_offset = 0;
-    for (const auto& coord : host_storage.buffer().shard_coords()) {
-        // Iterate over local populated shards.
-        if (const auto& buffer = host_storage.buffer().get_shard(coord); buffer.has_value()) {
+    std::vector<tt::tt_metal::distributed::MeshCoordinate> stored_coords;
+
+    for (const auto& [phys_coord, stored_coord] : shard_entries) {
+        if (const auto& buffer = host_storage.buffer().get_shard(phys_coord); buffer.has_value()) {
             const auto* buffer_address = buffer->view_bytes().data();
             const std::size_t buffer_size = buffer->view_bytes().size();
 
             uint64_t shard_buffer_offset = next_buffer_offset;
             if (auto [it, inserted] = buffer_to_offset.try_emplace(buffer_address, shard_buffer_offset); inserted) {
-                // Encountered a new buffer, add it to the buffers vector.
                 next_buffer_offset += buffer_size;
                 buffers.push_back(*buffer);
             } else {
-                // Point to the existing buffer.
                 shard_buffer_offset = it->second;
             }
 
             auto inline_storage = ttnn::flatbuffer::InlineFileStorage(shard_buffer_offset, buffer_size);
-            auto mesh_coord_offset = to_flatbuffer(coord, builder);
+            auto mesh_coord_offset = to_flatbuffer(stored_coord, builder);
 
             auto shard_offset = ttnn::flatbuffer::CreateTensorShard(
                 builder,
@@ -196,13 +270,17 @@ flatbuffers::Offset<ttnn::flatbuffer::Tensor> to_flatbuffer(
                 mesh_coord_offset);
 
             shards_vector.push_back(shard_offset);
+            stored_coords.push_back(stored_coord);
         }
     }
     auto shards = builder.CreateVector(shards_vector);
 
-    auto mesh_shape_offset = to_flatbuffer(host_storage.buffer().shape(), builder);
+    auto mesh_shape_offset = to_flatbuffer(stored_mesh_shape, builder);
 
-    auto topology_offset = to_flatbuffer(tensor.tensor_topology(), builder);
+    // Store reduced topology if replicates were collapsed, otherwise store the original.
+    auto stored_topology =
+        collapse_replicates ? tt::tt_metal::TensorTopology(stored_mesh_shape, placements, stored_coords) : topology;
+    auto topology_offset = to_flatbuffer(stored_topology, builder);
 
     auto tensor_offset =
         ttnn::flatbuffer::CreateTensor(builder, tensor_spec_offset, mesh_shape_offset, shards, topology_offset);

--- a/ttnn/core/tensor/tensor_impl.cpp
+++ b/ttnn/core/tensor/tensor_impl.cpp
@@ -624,6 +624,51 @@ std::pair<DeviceStorage, TensorTopology> to_device_mesh_buffer(
             replicate_to_mesh_buffer(*device_buffer, mesh_buffer, tensor_spec, cq_id),
             TensorTopology::create_fully_replicated_tensor_topology(mesh_device_shape)};
     }
+
+    // Partial expansion: e.g. [1,2] host → [2,2] mesh for [R, S(-1)] config.
+    // Can we expand host_storage_shape to mesh_device_shape by replicating size-1 axes?
+    auto can_expand_to_mesh = [&]() {
+        if (host_storage_shape == mesh_device_shape ||
+            host_storage_shape.dims() != mesh_device_shape.dims() ||
+            host_storage_shape.dims() != tensor_topology.placements().size()) {
+            return false;
+        }
+        const auto& placements = tensor_topology.placements();
+        for (size_t i = 0; i < host_storage_shape.dims(); ++i) {
+            if (host_storage_shape[i] == mesh_device_shape[i]) {
+                continue;
+            }
+            if (host_storage_shape[i] == 1 &&
+                std::holds_alternative<distributed::MeshMapperConfig::Replicate>(placements[i])) {
+                continue;
+            }
+            return false;
+        }
+        return true;
+    };
+
+    if (can_expand_to_mesh()) {
+        // Build expanded DistributedHostBuffer by replicating along Replicate axes.
+        auto expanded_buffer = DistributedHostBuffer::create(mesh_device_shape);
+        std::vector<distributed::MeshCoordinate> coords;
+        for (const auto& device_coord : distributed::MeshCoordinateRange(mesh_device_shape)) {
+            // Map device coord to source coord: collapse replicate axes to 0
+            std::vector<uint32_t> source_coords;
+            for (size_t i = 0; i < device_coord.dims(); ++i) {
+                source_coords.push_back(host_storage_shape[i] == 1 ? 0 : device_coord[i]);
+            }
+            distributed::MeshCoordinate source_coord(source_coords);
+            auto source_shard = host_storage.buffer().get_shard(source_coord);
+            if (source_shard.has_value()) {
+                expanded_buffer.emplace_shard(device_coord, [&source_shard]() { return *source_shard; });
+            }
+            coords.push_back(device_coord);
+        }
+
+        auto expanded_topology = TensorTopology(mesh_device_shape, tensor_topology.placements(), coords);
+        return {write_to_mesh_buffer(expanded_buffer, mesh_buffer, cq_id), expanded_topology};
+    }
+
     TT_FATAL(
         host_storage_shape == mesh_device_shape,
         "Distributed host buffer has different shape {} than the mesh device {}",


### PR DESCRIPTION
### Ticket
N/A

### Problem description
@kpaigwar originally brought up an issue about whether tensor caches could be used for 8x8-mesh to 8x16 mesh if we are just replicating to a larger mesh. Right now, users need to regenerate the entire weights tensor cache which can be pretty time-consuming for large models.

### What's changed
Users will now be able to re-use the same tensor weight caches across variable replication factors. For example,

Tests:
- C++ gtests for partial replication expansion and serialization roundtrips (partially replicated, fully replicated, cross-topology)
- Python integration tests for transparent dump/load and cross-mesh portability (dump on NxM, load on 1xM submesh)

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=jchu/distributed-infra)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:jchu/distributed-infra)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=jchu/distributed-infra)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:jchu/distributed-infra)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=jchu/distributed-infra)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jchu/distributed-infra)
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=jchu/distributed-infra)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:jchu/distributed-infra)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=jchu/distributed-infra)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:jchu/distributed-infra)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=jchu/distributed-infra)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:jchu/distributed-infra)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
