### PR TITLE
Bliu/main

### DIFF
--- a/models/demos/deepseek_v3_b1/blitz_decode_weights.py
+++ b/models/demos/deepseek_v3_b1/blitz_decode_weights.py
@@ -80,7 +80,7 @@ def shuffle_weights_for_interleaved_qnope_qrope(
 
 
 @dataclass(frozen=True)
-class QAB_KVA_PROJ_OverlapConfig:
+class QAB_KVA_PROJ_SingleDeviceOverlapSpec:
     """Configuration for the q_a / q_b / kv_a weight overlap.
 
     Shape tuples follow (height, width) convention.  All shapes describe
@@ -162,6 +162,26 @@ class QAB_KVA_PROJ_OverlapConfig:
             heads_per_row=self.heads_per_row,
         )
 
+    def get_q_b_slice(self, q_b_proj_weights: torch.Tensor, tp_idx: int, mla_tp: int) -> torch.Tensor:
+        """Extract the per-device q_b_proj slice for a given TP index.
+
+        The full q_b_proj tensor is laid out as ``[all_qnope | all_qrope]``
+        across ``mla_tp`` devices.  This method splits qnope and qrope,
+        takes the ``tp_idx``-th chunk of each, and stitches them into the
+        single-device ``(K, qnope_dim + qrope_dim)`` slice.
+        """
+        per_tp_qnope_dim = self.num_qnope_heads * self.qnope_head_dim
+        per_tp_qrope_dim = self.num_qrope_heads * self.qrope_head_dim
+        total_qnope_dim = mla_tp * per_tp_qnope_dim
+
+        full_qnope = q_b_proj_weights[:, :total_qnope_dim]
+        full_qrope = q_b_proj_weights[:, total_qnope_dim:]
+
+        tp_qnope = full_qnope[:, tp_idx * per_tp_qnope_dim : (tp_idx + 1) * per_tp_qnope_dim]
+        tp_qrope = full_qrope[:, tp_idx * per_tp_qrope_dim : (tp_idx + 1) * per_tp_qrope_dim]
+
+        return torch.cat([tp_qnope, tp_qrope], dim=1)
+
     def shuffle_kv_a(self, weights: torch.Tensor) -> torch.Tensor:
         """Reorder kv_a_proj shards for the KV cache branch core layout."""
         kv_h, kv_w = weights.shape
@@ -170,11 +190,11 @@ class QAB_KVA_PROJ_OverlapConfig:
         return shards[:, list(self.kv_a_proj_shard_order), :].reshape(kv_h, kv_w)
 
 
-QAB_KVA_PROJ_OVERLAP_CFG = QAB_KVA_PROJ_OverlapConfig()
+QAB_KVA_PROJ_SINGLE_DEVICE_OVERLAP_SPEC = QAB_KVA_PROJ_SingleDeviceOverlapSpec()
 
 
 @dataclass(frozen=True)
-class O_PROJ_GATE_MM_RMSNORM_GAMMA_OverlapConfig:
+class O_PROJ_GATE_MM_RMSNORM_GAMMA_SingleDeviceOverlapSpec:
     """Configuration for the o_proj / gate_mm / rmsnorm-gamma weight overlap.
 
     Fuses the following into a single WIDTH_SHARDED raw buffer:
@@ -315,11 +335,11 @@ class O_PROJ_GATE_MM_RMSNORM_GAMMA_OverlapConfig:
         )
 
 
-O_PROJ_GATE_MM_RMSNORM_GAMMA_OVERLAP_CFG = O_PROJ_GATE_MM_RMSNORM_GAMMA_OverlapConfig()
+O_PROJ_GATE_MM_RMSNORM_GAMMA_SINGLE_DEVICE_OVERLAP_SPEC = O_PROJ_GATE_MM_RMSNORM_GAMMA_SingleDeviceOverlapSpec()
 
 
 @dataclass(frozen=True)
-class KVB12_PROJ_OverlapConfig:
+class KVB12_PROJ_SingleDeviceOverlapSpec:
     """Configuration for the kv_b1 / kv_b2 weight overlap.
 
     Stitches ``kv_b1_proj (8192, 512)`` onto 64 cores and
@@ -388,11 +408,11 @@ class KVB12_PROJ_OverlapConfig:
         return weights.reshape(kv_dim, n_cores, head_dim).permute(1, 2, 0).reshape(-1, kv_dim).contiguous()
 
 
-KVB12_PROJ_OVERLAP_CFG = KVB12_PROJ_OverlapConfig()
+KVB12_PROJ_SINGLE_DEVICE_OVERLAP_SPEC = KVB12_PROJ_SingleDeviceOverlapSpec()
 
 
 @dataclass(frozen=True)
-class GATE_UP_PROJ_OverlapConfig:
+class GATE_UP_PROJ_SingleDeviceOverlapSpec:
     """Configuration for the gate / up projection weight overlap.
 
     Both tensors share the raw shape ``(K_gate, K_down) = (7168, 256)``
@@ -415,25 +435,23 @@ class GATE_UP_PROJ_OverlapConfig:
     Shape tuples follow (height, width) convention.
     """
 
-    # Core range sets — gate (A) and up (B) grids
+    # Core range sets — gate (A) and up (B) grids, stored as contiguous column chunks
     gate_core_range_set: ttnn.CoreRangeSet = field(
         default_factory=lambda: ttnn.CoreRangeSet(
             {
-                ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(3, 3)),  # 16 cores
-                ttnn.CoreRange(ttnn.CoreCoord(7, 0), ttnn.CoreCoord(9, 3)),  # 12 cores
-                ttnn.CoreRange(ttnn.CoreCoord(0, 4), ttnn.CoreCoord(2, 9)),  # 18 cores
-                ttnn.CoreRange(ttnn.CoreCoord(7, 4), ttnn.CoreCoord(9, 9)),  # 18 cores
+                ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(2, 9)),  # 30 cores  cols 0-2
+                ttnn.CoreRange(ttnn.CoreCoord(3, 0), ttnn.CoreCoord(3, 3)),  #  4 cores  col 3 top
+                ttnn.CoreRange(ttnn.CoreCoord(7, 0), ttnn.CoreCoord(9, 9)),  # 30 cores  cols 7-9
             }
         )
     )
     up_core_range_set: ttnn.CoreRangeSet = field(
         default_factory=lambda: ttnn.CoreRangeSet(
             {
-                ttnn.CoreRange(ttnn.CoreCoord(4, 0), ttnn.CoreCoord(6, 3)),  # 12 cores
-                ttnn.CoreRange(ttnn.CoreCoord(10, 0), ttnn.CoreCoord(12, 3)),  # 12 cores
-                ttnn.CoreRange(ttnn.CoreCoord(3, 4), ttnn.CoreCoord(6, 9)),  # 24 cores
-                ttnn.CoreRange(ttnn.CoreCoord(10, 4), ttnn.CoreCoord(12, 7)),  # 12 cores
-                ttnn.CoreRange(ttnn.CoreCoord(10, 8), ttnn.CoreCoord(11, 9)),  # 4 cores
+                ttnn.CoreRange(ttnn.CoreCoord(3, 4), ttnn.CoreCoord(3, 9)),  #  6 cores  col 3 bottom
+                ttnn.CoreRange(ttnn.CoreCoord(4, 0), ttnn.CoreCoord(6, 9)),  # 30 cores  cols 4-6
+                ttnn.CoreRange(ttnn.CoreCoord(10, 0), ttnn.CoreCoord(11, 9)),  # 20 cores  cols 10-11
+                ttnn.CoreRange(ttnn.CoreCoord(12, 0), ttnn.CoreCoord(12, 7)),  #  8 cores  col 12
             }
         )
     )
@@ -476,22 +494,95 @@ class GATE_UP_PROJ_OverlapConfig:
     def max_shard_bytes(self) -> int:
         return self.shard_bytes
 
-    def reshuffle_block_to_height_sharded(self, weights: torch.Tensor) -> torch.Tensor:
+    @staticmethod
+    def _crs_shard_permutation(core_range_set: ttnn.CoreRangeSet) -> tuple[int, ...]:
+        """Compute shard permutation from CoreRangeSet enumeration to row-major order.
+
+        HEIGHT_SHARDED places shard *j* on the *j*-th core in CoreRangeSet
+        enumeration order.  The kernel (SharedExpertOp) assigns
+        ``(k_idx, n_idx)`` to each core based on global row-major order
+        (y then x).  This method returns a permutation *P* such that
+        ``stacked[j] = block_shards[P[j]]`` places the correct shard on
+        each physical core.
+        """
+        crs_cores = []
+        for cr in core_range_set.ranges():
+            for y in range(cr.start.y, cr.end.y + 1):
+                for x in range(cr.start.x, cr.end.x + 1):
+                    crs_cores.append((x, y))
+        sorted_cores = sorted(crs_cores, key=lambda c: (c[1], c[0]))
+        core_to_sorted_idx = {c: i for i, c in enumerate(sorted_cores)}
+        return tuple(core_to_sorted_idx[c] for c in crs_cores)
+
+    def reshuffle_block_to_height_sharded(
+        self, weights: torch.Tensor, core_range_set: ttnn.CoreRangeSet
+    ) -> torch.Tensor:
         """Reorder a (K, N) weight matrix into stacked HEIGHT_SHARDED form.
 
-        ``(K, N) -> (k_parallel, sh, n_parallel, sw)
-        -> permute (k_parallel, n_parallel, sh, sw) -> reshape (-1, sw)``
+        The block decomposition splits ``(K, N)`` into
+        ``(k_parallel, n_parallel)`` shards of shape ``(sh, sw)``.
+        The shards are then permuted so that HEIGHT_SHARDED placement on
+        ``core_range_set`` puts each shard on the physical core expected
+        by the compute kernel (which assigns shards in global row-major
+        core order).
 
         Returns:
             Tensor of shape :attr:`stacked_shape`.
         """
         sh, sw = self.shard_shape
-        return (
-            weights.reshape(self.k_parallel, sh, self.n_parallel, sw).permute(0, 2, 1, 3).reshape(-1, sw).contiguous()
+        num_shards = self.k_parallel * self.n_parallel
+        block_shards = (
+            weights.reshape(self.k_parallel, sh, self.n_parallel, sw).permute(0, 2, 1, 3).reshape(num_shards, sh, sw)
         )
+        perm = self._crs_shard_permutation(core_range_set)
+        return block_shards[list(perm)].reshape(-1, sw).contiguous()
 
 
-GATE_UP_PROJ_OVERLAP_CFG = GATE_UP_PROJ_OverlapConfig()
+GATE_UP_PROJ_SINGLE_DEVICE_OVERLAP_SPEC = GATE_UP_PROJ_SingleDeviceOverlapSpec()
+
+
+@dataclass(frozen=True)
+class DOWN_PROJ_SingleDeviceSpec:
+    """Configuration for the down projection weight layout.
+
+    Down-proj weights are WIDTH_SHARDED on 112 matmul cores from the
+    13x10 device grid, excluding 8 DRAM workers, 9 phantom cores
+    (col 12, rows 0-8), and 1 mcast/gather core (12,9).
+
+    Per-device layout::
+
+        down_proj (256, 7168) WIDTH_SHARDED on 112 cores
+          shard (256, 64)
+    """
+
+    DRAM_WORKER_POSITIONS: frozenset = frozenset({(0, 0), (0, 3), (0, 7), (0, 9), (7, 1), (7, 4), (7, 6), (7, 9)})
+    GRID_X: int = 13
+    GRID_Y: int = 10
+    NUM_MATMUL_CORES: int = 112
+
+    def build_matmul_core_grid(self) -> ttnn.CoreRangeSet:
+        """Build CoreRangeSet for the 112 matmul cores."""
+        excluded = self.DRAM_WORKER_POSITIONS | {(12, row) for row in range(self.GRID_Y)}
+        all_cores = [
+            (col, row) for row in range(self.GRID_Y) for col in range(self.GRID_X) if (col, row) not in excluded
+        ]
+        assert len(all_cores) == self.NUM_MATMUL_CORES
+        core_ranges = []
+        for row in range(self.GRID_Y):
+            row_cores = sorted(c for c, r in all_cores if r == row)
+            if not row_cores:
+                continue
+            seg_start = prev_col = row_cores[0]
+            for col in row_cores[1:]:
+                if col != prev_col + 1:
+                    core_ranges.append(ttnn.CoreRange(ttnn.CoreCoord(seg_start, row), ttnn.CoreCoord(prev_col, row)))
+                    seg_start = col
+                prev_col = col
+            core_ranges.append(ttnn.CoreRange(ttnn.CoreCoord(seg_start, row), ttnn.CoreCoord(prev_col, row)))
+        return ttnn.CoreRangeSet(core_ranges)
+
+
+DOWN_PROJ_SINGLE_DEVICE_SPEC = DOWN_PROJ_SingleDeviceSpec()
 
 
 @dataclass
@@ -527,8 +618,21 @@ class BlitzDecodeWeights:
     def __init__(self, device) -> None:
         self._device = device
 
+        num_devices = device.get_num_devices()
+        if num_devices == 1:
+            self.mla_tp = 1
+            self.moe_tp = 1
+        else:
+            mesh_shape = (device.shape[0], device.shape[1])
+            assert mesh_shape == (
+                4,
+                2,
+            ), f"Only single-device or 4x2 mesh supported, got {mesh_shape[0]}x{mesh_shape[1]}"
+            self.mla_tp = 2
+            self.moe_tp = 8
+
     # ------------------------------------------------------------------
-    # Public API
+    # MLA weight loading
     # ------------------------------------------------------------------
 
     def get_tt_q_ab_proj_and_kv_a_proj_weights(
@@ -536,7 +640,6 @@ class BlitzDecodeWeights:
         q_a_proj_weights: torch.Tensor,
         q_b_proj_weights: torch.Tensor,
         kv_a_proj_weights: torch.Tensor,
-        cfg: QAB_KVA_PROJ_OverlapConfig | None = None,
     ) -> list[OverlappedTensor]:
         """Fuse q_a_proj, q_b_proj, and kv_a_proj into one WIDTH_SHARDED tensor.
 
@@ -550,43 +653,29 @@ class BlitzDecodeWeights:
           the top region.
 
         For multi-device (4x2 mesh, TP=2) the q_b_proj weights span all
-        TP devices (width ``tp * per_device_width``).  Per-TP slices are
+        TP devices (width ``mla_tp * per_device_width``).  Per-TP slices are
         shuffled independently and stitched with the (replicated)
         q_a_proj into separate per-TP fused tensors, which are
         concatenated along width and distributed via
         ``ShardTensor2dMesh`` across mesh columns.  q_a_proj and
         kv_a_proj are replicated on every device.
 
-        TP is inferred from the device topology: single-device -> TP=1,
-        4x2 mesh -> TP=2.
+        MLA TP is inferred from the device topology: single-device ->
+        mla_tp=1, 4x2 mesh -> mla_tp=2.
 
         Args:
             q_a_proj_weights: Raw q_a_proj tensor, shape ``(7168, 1536)``.
             q_b_proj_weights: Raw (unshuffled) q_b_proj tensor, shape
-                ``(1536, 12288 * tp)``.
+                ``(1536, 12288 * mla_tp)``.
             kv_a_proj_weights: Raw kv_a_proj tensor, shape ``(7168, 576)``.
-            cfg: Overlap configuration.  Defaults to the module-level
-                ``QAB_KVA_PROJ_OVERLAP_CFG`` singleton.
 
         Returns:
             A list of three :class:`OverlappedTensor` views
             ``[q_a_proj, q_b_proj, kv_a_proj]`` that share the same
             underlying fused device buffer.
         """
-        if cfg is None:
-            cfg = QAB_KVA_PROJ_OVERLAP_CFG
-
-        # -- Infer TP from device topology --------------------------------
-        num_devices = self._device.get_num_devices()
-        if num_devices == 1:
-            tp = 1
-        else:
-            mesh_shape = (self._device.shape[0], self._device.shape[1])
-            assert mesh_shape == (
-                4,
-                2,
-            ), f"Only single-device or 4x2 mesh supported, got {mesh_shape[0]}x{mesh_shape[1]}"
-            tp = mesh_shape[1]
+        cfg = QAB_KVA_PROJ_SINGLE_DEVICE_OVERLAP_SPEC
+        mla_tp = self.mla_tp
 
         # -- Validate device grid ----------------------------------------
         device_grid = self._device.compute_with_storage_grid_size()
@@ -601,7 +690,7 @@ class BlitzDecodeWeights:
         assert (
             q_a_proj_weights.shape == cfg.q_a_proj_shape
         ), f"q_a_proj_weights must be {cfg.q_a_proj_shape}, got {tuple(q_a_proj_weights.shape)}"
-        expected_q_b_shape = (cfg.q_b_proj_shape[0], cfg.q_b_proj_shape[1] * tp)
+        expected_q_b_shape = (cfg.q_b_proj_shape[0], cfg.q_b_proj_shape[1] * mla_tp)
         assert (
             tuple(q_b_proj_weights.shape) == expected_q_b_shape
         ), f"q_b_proj_weights must be {expected_q_b_shape}, got {tuple(q_b_proj_weights.shape)}"
@@ -619,10 +708,9 @@ class BlitzDecodeWeights:
         q_ab_num_cores = cfg.q_ab_core_range_set.num_cores()
 
         # -- Step 3: build per-TP fused tensors -------------------------
-        per_device_q_b_w = cfg.q_b_proj_shape[1]
         per_tp_combined = []
-        for tp_idx in range(tp):
-            q_b_slice = q_b_proj_weights[:, tp_idx * per_device_q_b_w : (tp_idx + 1) * per_device_q_b_w]
+        for tp_idx in range(mla_tp):
+            q_b_slice = cfg.get_q_b_slice(q_b_proj_weights, tp_idx, mla_tp)
             shuffled = cfg.shuffle_q_b(q_b_slice)
 
             q_ab_fused, q_ab_shard_shape = BlitzDecodeWeights._stitch_width_sharded(packed, shuffled, q_ab_num_cores)
@@ -641,7 +729,7 @@ class BlitzDecodeWeights:
             assert combined_tp.shape == (fused_shard_h, target_w * total_cores)
             per_tp_combined.append(combined_tp)
 
-        combined = torch.cat(per_tp_combined, dim=1) if tp > 1 else per_tp_combined[0]
+        combined = torch.cat(per_tp_combined, dim=1) if mla_tp > 1 else per_tp_combined[0]
 
         # -- Step 4: place on device as WIDTH_SHARDED -------------------
         shard_spec = ttnn.ShardSpec(
@@ -655,7 +743,7 @@ class BlitzDecodeWeights:
             shard_spec,
         )
 
-        if tp == 1:
+        if mla_tp == 1:
             mesh_mapper = ttnn.ReplicateTensorToMesh(self._device)
         else:
             mesh_shape = (self._device.shape[0], self._device.shape[1])
@@ -751,8 +839,10 @@ class BlitzDecodeWeights:
             combined: 122 cores, shard = max_shard_bytes
 
         Args:
-            o_proj_weights:     Raw o_proj tensor, shape (8192, 7168).
+            o_proj_weights:     Raw o_proj tensor, shape
+                ``(8192 * mla_tp, 7168)``.  TP-sharded on the inner dim.
             gate_mm_weights:    Raw gate_mm tensor, shape (7168, 256).
+                Replicated across TP devices.
             attn_norm:      Pre-SDPA attention-input RMSNorm gamma, shape (1, 7168).
             q_norm:     Pre-SDPA post-matmul1 RMSNorm gamma, shape (1, 1536).
             kv_norm:  Pre-SDPA KV-cache-branch RMSNorm gamma, shape (1, 512).
@@ -764,12 +854,14 @@ class BlitzDecodeWeights:
             kv_norm, ffn_norm]`` sharing the same
             underlying fused device buffer.
         """
-        cfg = O_PROJ_GATE_MM_RMSNORM_GAMMA_OVERLAP_CFG
+        cfg = O_PROJ_GATE_MM_RMSNORM_GAMMA_SINGLE_DEVICE_OVERLAP_SPEC
+        mla_tp = self.mla_tp
 
         # -- Validate shapes --------------------------------------------
+        expected_o_proj_shape = (cfg.o_proj_shape[0] * mla_tp, cfg.o_proj_shape[1])
         assert (
-            o_proj_weights.shape == cfg.o_proj_shape
-        ), f"o_proj must be {cfg.o_proj_shape}, got {tuple(o_proj_weights.shape)}"
+            tuple(o_proj_weights.shape) == expected_o_proj_shape
+        ), f"o_proj must be {expected_o_proj_shape}, got {tuple(o_proj_weights.shape)}"
         assert (
             gate_mm_weights.shape == cfg.gate_mm_shape
         ), f"gate_mm must be {cfg.gate_mm_shape}, got {tuple(gate_mm_weights.shape)}"
@@ -791,24 +883,16 @@ class BlitzDecodeWeights:
         max_shard_bytes = cfg.max_shard_bytes
         assert max_shard_bytes % 4 == 0, "shard bytes must be UINT32-aligned"
 
-        # -- Pack shards ------------------------------------------------
-        packed = bytearray()
-
-        # o_proj shards (BFP8_b) — 112 cores
-        for i in range(o_num_cores):
-            shard_data = o_proj_weights[:, i * o_shard_w : (i + 1) * o_shard_w].contiguous()
-            shard_raw = BlitzDecodeWeights._tilize_and_pack_bfp8(shard_data, cfg.tile_h, cfg.tile_w)
-            assert len(shard_raw) == cfg.o_proj_shard_bytes
-            packed.extend(shard_raw)
-            packed.extend(b"\x00" * (max_shard_bytes - cfg.o_proj_shard_bytes))
+        # -- Pack shared portion (gate_mm + gammas, replicated) ----------
+        shared_packed = bytearray()
 
         # gate_mm shards (bfloat16) — 8 cores
         for i in range(g_num_cores):
             shard_data = gate_mm_weights[:, i * g_shard_w : (i + 1) * g_shard_w].contiguous()
             shard_raw = BlitzDecodeWeights._tilize_and_pack_bfloat16(shard_data, cfg.tile_h, cfg.tile_w)
             assert len(shard_raw) == cfg.gate_mm_shard_bytes
-            packed.extend(shard_raw)
-            packed.extend(b"\x00" * (max_shard_bytes - cfg.gate_mm_shard_bytes))
+            shared_packed.extend(shard_raw)
+            shared_packed.extend(b"\x00" * (max_shard_bytes - cfg.gate_mm_shard_bytes))
 
         # Gamma core (12, 9) — attn_norm + q_norm + ffn_norm
         gamma_shard = bytearray(max_shard_bytes)
@@ -822,20 +906,37 @@ class BlitzDecodeWeights:
             assert len(raw) == expected_bytes
             gamma_shard[offset : offset + len(raw)] = raw
             offset += len(raw)
-        packed.extend(gamma_shard)
+        shared_packed.extend(gamma_shard)
 
         # kv_norm core (0, 8) — dedicated core
         kv_norm_shard = bytearray(max_shard_bytes)
         kv_norm_raw = BlitzDecodeWeights._pack_bfloat16_1x32(kv_norm)
         assert len(kv_norm_raw) == cfg.kv_norm_bytes
         kv_norm_shard[: len(kv_norm_raw)] = kv_norm_raw
-        packed.extend(kv_norm_shard)
+        shared_packed.extend(kv_norm_shard)
 
-        # -- Build UINT32 tensor on device ------------------------------
+        # -- Pack per-TP o_proj shards and combine -----------------------
         total_cores = o_num_cores + g_num_cores + 2  # +1 gamma core, +1 kv_norm core
         uint32_per_shard = max_shard_bytes // 4
+        per_device_o_h = cfg.o_proj_shape[0]
 
-        raw_data = torch.frombuffer(bytes(packed), dtype=torch.int32).clone()
+        per_tp_raw = []
+        for tp_idx in range(mla_tp):
+            o_proj_slice = o_proj_weights[tp_idx * per_device_o_h : (tp_idx + 1) * per_device_o_h, :]
+            o_packed = bytearray()
+            for i in range(o_num_cores):
+                shard_data = o_proj_slice[:, i * o_shard_w : (i + 1) * o_shard_w].contiguous()
+                shard_raw = BlitzDecodeWeights._tilize_and_pack_bfp8(shard_data, cfg.tile_h, cfg.tile_w)
+                assert len(shard_raw) == cfg.o_proj_shard_bytes
+                o_packed.extend(shard_raw)
+                o_packed.extend(b"\x00" * (max_shard_bytes - cfg.o_proj_shard_bytes))
+            per_tp_raw.append(torch.frombuffer(bytes(o_packed + shared_packed), dtype=torch.int32).clone())
+
+        # -- Build UINT32 tensor on device ------------------------------
+        if mla_tp == 1:
+            combined = per_tp_raw[0].reshape(1, uint32_per_shard * total_cores)
+        else:
+            combined = torch.cat([t.reshape(1, -1) for t in per_tp_raw], dim=1)
 
         combined_crs = ttnn.CoreRangeSet(
             list(cfg.o_proj_core_range_set.ranges())
@@ -854,13 +955,19 @@ class BlitzDecodeWeights:
             shard_spec,
         )
 
+        if mla_tp == 1:
+            mesh_mapper = ttnn.ReplicateTensorToMesh(self._device)
+        else:
+            mesh_shape = (self._device.shape[0], self._device.shape[1])
+            mesh_mapper = ttnn.ShardTensor2dMesh(self._device, mesh_shape=mesh_shape, dims=(None, 1))
+
         fused = ttnn.from_torch(
-            raw_data.reshape(1, uint32_per_shard * total_cores),
+            combined,
             dtype=ttnn.uint32,
             layout=ttnn.ROW_MAJOR_LAYOUT,
             device=self._device,
             memory_config=mem_config,
-            mesh_mapper=ttnn.ReplicateTensorToMesh(self._device),
+            mesh_mapper=mesh_mapper,
         )
 
         # -- Build OverlappedTensor views --------------------------------
@@ -946,24 +1053,38 @@ class BlitzDecodeWeights:
             combined: 128 cores, HEIGHT_SHARDED, shard (128, 512)
 
         Args:
-            kv_b1_proj_weights: shape (8192, 512).
-            kv_b2_proj_weights: shape (512, 8192).
+            kv_b1_proj_weights: shape ``(8192 * mla_tp, 512)``.
+                TP-sharded on the heads dim.
+            kv_b2_proj_weights: shape ``(512, 8192 * mla_tp)``.
+                TP-sharded on the heads dim.
 
         Returns:
             ``[kv_b1_proj, kv_b2_proj]`` as :class:`OverlappedTensor`
             views sharing the same fused device buffer.
         """
-        cfg = KVB12_PROJ_OVERLAP_CFG
+        cfg = KVB12_PROJ_SINGLE_DEVICE_OVERLAP_SPEC
+        mla_tp = self.mla_tp
 
+        expected_b1_shape = (cfg.kv_b1_proj_shape[0] * mla_tp, cfg.kv_b1_proj_shape[1])
         assert (
-            tuple(kv_b1_proj_weights.shape) == cfg.kv_b1_proj_shape
-        ), f"kv_b1 expected {cfg.kv_b1_proj_shape}, got {tuple(kv_b1_proj_weights.shape)}"
+            tuple(kv_b1_proj_weights.shape) == expected_b1_shape
+        ), f"kv_b1 expected {expected_b1_shape}, got {tuple(kv_b1_proj_weights.shape)}"
+        expected_b2_shape = (cfg.kv_b2_proj_shape[0], cfg.kv_b2_proj_shape[1] * mla_tp)
         assert (
-            tuple(kv_b2_proj_weights.shape) == cfg.kv_b2_proj_shape
-        ), f"kv_b2 expected {cfg.kv_b2_proj_shape}, got {tuple(kv_b2_proj_weights.shape)}"
+            tuple(kv_b2_proj_weights.shape) == expected_b2_shape
+        ), f"kv_b2 expected {expected_b2_shape}, got {tuple(kv_b2_proj_weights.shape)}"
 
-        kv_b2_physical = cfg.shuffle_kv_b2(kv_b2_proj_weights)
-        combined = torch.cat([kv_b1_proj_weights, kv_b2_physical], dim=0)
+        per_device_b1_h = cfg.kv_b1_proj_shape[0]
+        per_device_b2_w = cfg.kv_b2_proj_shape[1]
+
+        per_tp_combined = []
+        for tp_idx in range(mla_tp):
+            b1_slice = kv_b1_proj_weights[tp_idx * per_device_b1_h : (tp_idx + 1) * per_device_b1_h, :]
+            b2_slice = kv_b2_proj_weights[:, tp_idx * per_device_b2_w : (tp_idx + 1) * per_device_b2_w]
+            b2_physical = cfg.shuffle_kv_b2(b2_slice)
+            per_tp_combined.append(torch.cat([b1_slice, b2_physical], dim=0))
+
+        combined = torch.cat(per_tp_combined, dim=0) if mla_tp > 1 else per_tp_combined[0]
 
         # -- Place on device as HEIGHT_SHARDED --------------------------
         combined_crs = ttnn.CoreRangeSet(
@@ -981,13 +1102,19 @@ class BlitzDecodeWeights:
             shard_spec,
         )
 
+        if mla_tp == 1:
+            mesh_mapper = ttnn.ReplicateTensorToMesh(self._device)
+        else:
+            mesh_shape = (self._device.shape[0], self._device.shape[1])
+            mesh_mapper = ttnn.ShardTensor2dMesh(self._device, mesh_shape=mesh_shape, dims=(None, 0))
+
         fused = ttnn.from_torch(
             combined,
             dtype=ttnn.bfloat8_b,
             layout=ttnn.TILE_LAYOUT,
             device=self._device,
             memory_config=mem_config,
-            mesh_mapper=ttnn.ReplicateTensorToMesh(self._device),
+            mesh_mapper=mesh_mapper,
         )
 
         # -- Build OverlappedTensor views --------------------------------
@@ -1017,23 +1144,29 @@ class BlitzDecodeWeights:
             ),
         ]
 
-    def get_tt_gate_up_proj_weights(
+    # ------------------------------------------------------------------
+    # MOE weight loading
+    # ------------------------------------------------------------------
+
+    def get_tt_moe_shared_expert_weights(
         self,
         gate_proj_weights: torch.Tensor,
         up_proj_weights: torch.Tensor,
-    ) -> list[OverlappedTensor]:
-        """Fuse gate_proj and up_proj into one HEIGHT_SHARDED tensor.
+        down_proj_weights: torch.Tensor,
+    ) -> tuple[OverlappedTensor, OverlappedTensor, ttnn.Tensor]:
+        """Create all shared-expert weight tensors in one call.
 
-        Both tensors are block-sharded: the K dimension is split among
-        ``k_parallel`` partitions and the N dimension among ``n_parallel``
-        partitions, yielding 64 shards of ``(896, 32)`` per weight.
+        **Gate / Up projections** are block-sharded and fused into a single
+        HEIGHT_SHARDED L1 tensor.  Gate weights live on the A compute cores,
+        up weights on the B compute cores.  Both are BFP4 with shard shape
+        ``(896, 32)`` across 64 cores each (128 total).
 
-        Gate weights live on the A compute cores, up weights on the B
-        compute cores of the shared-expert dual-matmul layout.  Both are
-        BFP4 with identical shard shapes, so ``ttnn.from_torch`` handles
-        the conversion directly (no raw byte packing needed).
+        **Down projection** is WIDTH_SHARDED on 112 matmul cores as BFP4.
 
-        Layout::
+        With ``moe_tp > 1`` the outer (N) dimension of gate/up and the inner
+        (K) dimension of down are TP-sharded across devices.
+
+        Per-device layout::
 
             -- gate region: 64 A cores (non-rectangular) --
             gate_proj (7168, 256) as bfloat4_b, block-sharded
@@ -1043,84 +1176,404 @@ class BlitzDecodeWeights:
             up_proj (7168, 256) as bfloat4_b, block-sharded
               stacked (57344, 32), shard (896, 32)
 
-            combined: 128 cores, HEIGHT_SHARDED (114688, 32)
+            gate+up combined: 128 cores, HEIGHT_SHARDED (114688, 32)
+
+            down_proj (256, 7168) as bfloat4_b, WIDTH_SHARDED on 112 cores
+              shard (256, 64)
 
         Args:
-            gate_proj_weights: Raw gate tensor, shape (7168, 256).
-            up_proj_weights:   Raw up tensor, shape (7168, 256).
+            gate_proj_weights: Raw gate tensor, shape
+                ``(7168, 256 * moe_tp)``.  TP-sharded on the outer dim.
+            up_proj_weights: Raw up tensor, shape
+                ``(7168, 256 * moe_tp)``.  TP-sharded on the outer dim.
+            down_proj_weights: Raw down_proj tensor, shape
+                ``(256 * moe_tp, 7168)``.  TP-sharded on the inner dim.
 
         Returns:
-            A list of two :class:`OverlappedTensor` views
-            ``[gate_proj, up_proj]`` that share the same underlying fused
-            device buffer.
+            ``(gate_proj, up_proj, down_proj)`` where the first two are
+            :class:`OverlappedTensor` views sharing a fused buffer and the
+            third is a standalone ``ttnn.Tensor``.
         """
-        cfg = GATE_UP_PROJ_OVERLAP_CFG
+        moe_tp = self.moe_tp
 
-        # -- Validate shapes --------------------------------------------
+        # ==================================================================
+        # Gate + Up (fused HEIGHT_SHARDED in L1)
+        # ==================================================================
+        cfg = GATE_UP_PROJ_SINGLE_DEVICE_OVERLAP_SPEC
+
+        expected_gate_shape = (cfg.gate_proj_shape[0], cfg.gate_proj_shape[1] * moe_tp)
         assert (
-            gate_proj_weights.shape == cfg.gate_proj_shape
-        ), f"gate_proj must be {cfg.gate_proj_shape}, got {tuple(gate_proj_weights.shape)}"
+            tuple(gate_proj_weights.shape) == expected_gate_shape
+        ), f"gate_proj must be {expected_gate_shape}, got {tuple(gate_proj_weights.shape)}"
+        expected_up_shape = (cfg.up_proj_shape[0], cfg.up_proj_shape[1] * moe_tp)
         assert (
-            up_proj_weights.shape == cfg.up_proj_shape
-        ), f"up_proj must be {cfg.up_proj_shape}, got {tuple(up_proj_weights.shape)}"
+            tuple(up_proj_weights.shape) == expected_up_shape
+        ), f"up_proj must be {expected_up_shape}, got {tuple(up_proj_weights.shape)}"
 
-        # -- Stack block-shards and concatenate -------------------------
-        gate_stacked = cfg.reshuffle_block_to_height_sharded(gate_proj_weights)
-        up_stacked = cfg.reshuffle_block_to_height_sharded(up_proj_weights)
-        combined = torch.cat([gate_stacked, up_stacked], dim=0)
+        per_device_n = cfg.gate_proj_shape[1]
+        gu_per_tp = []
+        for tp_idx in range(moe_tp):
+            gate_slice = gate_proj_weights[:, tp_idx * per_device_n : (tp_idx + 1) * per_device_n]
+            up_slice = up_proj_weights[:, tp_idx * per_device_n : (tp_idx + 1) * per_device_n]
+            gate_stacked = cfg.reshuffle_block_to_height_sharded(gate_slice, cfg.gate_core_range_set)
+            up_stacked = cfg.reshuffle_block_to_height_sharded(up_slice, cfg.up_core_range_set)
+            gu_per_tp.append(torch.cat([gate_stacked, up_stacked], dim=0))
 
-        # -- Place on device as HEIGHT_SHARDED --------------------------
         combined_crs = ttnn.CoreRangeSet(list(cfg.gate_core_range_set.ranges()) + list(cfg.up_core_range_set.ranges()))
         sh, sw = cfg.shard_shape
-        shard_spec = ttnn.ShardSpec(
-            combined_crs,
-            (sh, sw),
-            ttnn.ShardOrientation.ROW_MAJOR,
-        )
-        mem_config = ttnn.MemoryConfig(
-            ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
-            ttnn.BufferType.L1,
-            shard_spec,
-        )
+        gu_shard_spec = ttnn.ShardSpec(combined_crs, (sh, sw), ttnn.ShardOrientation.ROW_MAJOR)
+        gu_mem = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, gu_shard_spec)
+
+        if moe_tp == 1:
+            gu_combined = gu_per_tp[0]
+            gu_mapper = ttnn.ReplicateTensorToMesh(self._device)
+        else:
+            mesh_rows = self._device.shape[0]
+            mesh_cols = self._device.shape[1]
+            rows = []
+            for r in range(mesh_rows):
+                rows.append(torch.cat(gu_per_tp[r * mesh_cols : (r + 1) * mesh_cols], dim=1))
+            gu_combined = torch.cat(rows, dim=0)
+            gu_mapper = ttnn.ShardTensor2dMesh(self._device, mesh_shape=(mesh_rows, mesh_cols), dims=(0, 1))
 
         fused = ttnn.from_torch(
-            combined,
+            gu_combined,
             dtype=ttnn.bfloat4_b,
             layout=ttnn.TILE_LAYOUT,
             device=self._device,
-            memory_config=mem_config,
-            mesh_mapper=ttnn.ReplicateTensorToMesh(self._device),
+            memory_config=gu_mem,
+            mesh_mapper=gu_mapper,
         )
 
-        # -- Build OverlappedTensor views --------------------------------
         tile = fused.get_tile()
         ts = tuple(tile.tile_shape)
-        stacked = cfg.stacked_shape
+        gate_ov = OverlappedTensor(
+            fused_tensor=fused,
+            tensor_shape=cfg.gate_proj_shape,
+            shard_shape=cfg.shard_shape,
+            core_range_set=cfg.gate_core_range_set,
+            dtype=ttnn.bfloat4_b,
+            tile_shape=ts,
+            byte_offset=0,
+        )
+        up_ov = OverlappedTensor(
+            fused_tensor=fused,
+            tensor_shape=cfg.up_proj_shape,
+            shard_shape=cfg.shard_shape,
+            core_range_set=cfg.up_core_range_set,
+            dtype=ttnn.bfloat4_b,
+            tile_shape=ts,
+            byte_offset=0,
+        )
 
-        return [
-            OverlappedTensor(
-                fused_tensor=fused,
-                tensor_shape=stacked,
-                shard_shape=cfg.shard_shape,
-                core_range_set=cfg.gate_core_range_set,
+        # ==================================================================
+        # Down (WIDTH_SHARDED in L1 on 112 matmul cores)
+        # ==================================================================
+        dp_spec = DOWN_PROJ_SINGLE_DEVICE_SPEC
+        K_down_per_device = 256
+        N_per_core = 64
+        N_down = N_per_core * dp_spec.NUM_MATMUL_CORES  # 7168
+
+        expected_down_shape = (K_down_per_device * moe_tp, N_down)
+        assert (
+            tuple(down_proj_weights.shape) == expected_down_shape
+        ), f"down_proj_weights must be {expected_down_shape}, got {tuple(down_proj_weights.shape)}"
+
+        matmul_core_grid = dp_spec.build_matmul_core_grid()
+
+        if moe_tp == 1:
+            dp_combined = down_proj_weights
+            dp_mapper = ttnn.ReplicateTensorToMesh(self._device)
+        else:
+            mesh_rows = self._device.shape[0]
+            mesh_cols = self._device.shape[1]
+            dp_combined = (
+                down_proj_weights.reshape(mesh_rows, mesh_cols, K_down_per_device, N_down)
+                .permute(0, 2, 1, 3)
+                .reshape(mesh_rows * K_down_per_device, mesh_cols * N_down)
+            )
+            dp_mapper = ttnn.ShardTensor2dMesh(self._device, mesh_shape=(mesh_rows, mesh_cols), dims=(0, 1))
+
+        dp_shard_spec = ttnn.ShardSpec(
+            matmul_core_grid, (K_down_per_device, N_per_core), ttnn.ShardOrientation.ROW_MAJOR
+        )
+        dp_mem = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.WIDTH_SHARDED, ttnn.BufferType.L1, dp_shard_spec)
+
+        down_tensor = ttnn.from_torch(
+            dp_combined,
+            dtype=ttnn.bfloat4_b,
+            layout=ttnn.TILE_LAYOUT,
+            device=self._device,
+            memory_config=dp_mem,
+            tile=ttnn.Tile([32, 32]),
+            mesh_mapper=dp_mapper,
+        )
+
+        return gate_ov, up_ov, down_tensor
+
+    def get_tt_moe_routed_expert_weights(
+        self,
+        gate_proj_weights: torch.Tensor,
+        up_proj_weights: torch.Tensor,
+        down_proj_weights: torch.Tensor,
+    ) -> tuple[list[ttnn.Tensor], list[ttnn.Tensor], list[ttnn.Tensor]]:
+        """Create DRAM WIDTH_SHARDED expert weight tensors for routed MoE.
+
+        Each expert projection is uploaded as a separate WIDTH_SHARDED tensor
+        across all DRAM banks as ``bfloat4_b``.  Tiles within each bank's
+        shard are reordered from row-major to column-major so that K tiles
+        stream contiguously.
+
+        Weights are replicated across all devices in a multi-device mesh.
+
+        Per-expert device layout::
+
+            gate_proj_i  (K, N_padded)  WIDTH_SHARDED in DRAM
+            up_proj_i    (K, N_padded)  WIDTH_SHARDED in DRAM
+            down_proj_i  (K_down, N_down_padded)  WIDTH_SHARDED in DRAM
+
+        Args:
+            gate_proj_weights: Stacked gate expert weights, shape
+                ``(num_experts, K, N)``.
+            up_proj_weights: Stacked up expert weights, shape
+                ``(num_experts, K, N)``.
+            down_proj_weights: Stacked down expert weights, shape
+                ``(num_experts, K_down, N_down)``.
+
+        Returns:
+            ``(gate_expert_tensors, up_expert_tensors, down_expert_tensors)``
+            — three lists of device-resident ttnn.Tensors, one per expert.
+            The first tensor in each list can be used as the base address for
+            the op; all tensors must be kept alive to prevent deallocation.
+        """
+        device = self._device
+        tile_w = 32
+        num_banks = device.dram_grid_size().x
+        mesh_mapper = ttnn.ReplicateTensorToMesh(device)
+
+        def upload(expert_weights: torch.Tensor) -> list[ttnn.Tensor]:
+            num_experts, K, N = expert_weights.shape
+            N_padded = ((N + num_banks * tile_w - 1) // (num_banks * tile_w)) * (num_banks * tile_w)
+            per_core_N = N_padded // num_banks
+
+            dram_grid = ttnn.CoreRangeSet(
+                {
+                    ttnn.CoreRange(
+                        ttnn.CoreCoord(0, 0),
+                        ttnn.CoreCoord(device.dram_grid_size().x - 1, device.dram_grid_size().y - 1),
+                    )
+                }
+            )
+            shard_spec = ttnn.ShardSpec(dram_grid, [K, per_core_N], ttnn.ShardOrientation.ROW_MAJOR)
+            mem_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.WIDTH_SHARDED, ttnn.BufferType.DRAM, shard_spec)
+
+            tensors = []
+            for i in range(num_experts):
+                w = expert_weights[i]
+                if N_padded != N:
+                    w = torch.nn.functional.pad(w, (0, N_padded - N))
+
+                w_shuffled = self._shuffle_dram_tiles(w.unsqueeze(0), tile_w, num_banks)
+                w_shuffled = w_shuffled.reshape(1, 1, K, N_padded)
+
+                tensors.append(
+                    ttnn.from_torch(
+                        w_shuffled.contiguous(),
+                        dtype=ttnn.bfloat4_b,
+                        layout=ttnn.TILE_LAYOUT,
+                        device=device,
+                        memory_config=mem_config,
+                        mesh_mapper=mesh_mapper,
+                    )
+                )
+            return tensors
+
+        return upload(gate_proj_weights), upload(up_proj_weights), upload(down_proj_weights)
+
+    # ------------------------------------------------------------------
+    # MLP weight loading
+    # ------------------------------------------------------------------
+
+    def get_tt_mlp_shared_expert_weights(
+        self,
+        gate_proj_weights: torch.Tensor,
+        up_proj_weights: torch.Tensor,
+        down_proj_weights: torch.Tensor,
+    ) -> tuple[OverlappedTensor, OverlappedTensor, ttnn.Tensor | None]:
+        """Create MLP shared-expert weights (SRAM) from full projection tensors.
+
+        The full MLP projections contain ``9`` experts of width
+        2048.  The first 2048 columns (gate/up) or rows (down) form the
+        shared expert, which is TP-sharded across devices and placed in L1
+        identically to the MoE shared expert.
+
+        Args:
+            gate_proj_weights: Full gate tensor ``(7168, 18432)``.
+            up_proj_weights: Full up tensor ``(7168, 18432)``.
+            down_proj_weights: Full down tensor ``(18432, 7168)``.
+
+        Returns:
+            Same as :meth:`get_tt_moe_shared_expert_weights`.
+        """
+        shared_n = 2048
+        return self.get_tt_moe_shared_expert_weights(
+            gate_proj_weights[:, :shared_n],
+            up_proj_weights[:, :shared_n],
+            down_proj_weights[:shared_n, :],
+        )
+
+    def get_tt_mlp_routed_expert_weights(
+        self,
+        gate_proj_weights: torch.Tensor,
+        up_proj_weights: torch.Tensor,
+        down_proj_weights: torch.Tensor,
+    ) -> tuple[ttnn.Tensor, ttnn.Tensor, ttnn.Tensor]:
+        """Create MLP per-device routed expert weights (DRAM).
+
+        After the shared expert (first 2048), the remaining ``8 * 2048``
+        columns (gate/up) or rows (down) are split into 8 routed experts,
+        one per device.  Each expert is WIDTH_SHARDED in DRAM across all
+        banks on its assigned device.
+
+        Per-device layout::
+
+            gate_proj  (7168, N_padded)  WIDTH_SHARDED in DRAM
+            up_proj    (7168, N_padded)  WIDTH_SHARDED in DRAM
+            down_proj  (2048, N_padded)  WIDTH_SHARDED in DRAM
+
+        Args:
+            gate_proj_weights: Full gate tensor ``(7168, 18432)``.
+            up_proj_weights: Full up tensor ``(7168, 18432)``.
+            down_proj_weights: Full down tensor ``(18432, 7168)``.
+
+        Returns:
+            ``(gate_tensor, up_tensor, down_tensor)`` — one device-resident
+            ``ttnn.Tensor`` per projection, each containing the single
+            routed expert assigned to that device.
+        """
+        shared_n = 2048
+        num_routed = 8
+        expert_n = 2048
+
+        K_gate = gate_proj_weights.shape[0]  # 7168
+        N_down = down_proj_weights.shape[1]  # 7168
+
+        gate_experts = (
+            gate_proj_weights[:, shared_n:].reshape(K_gate, num_routed, expert_n).permute(1, 0, 2).contiguous()
+        )  # (8, 7168, 2048)
+        up_experts = (
+            up_proj_weights[:, shared_n:].reshape(K_gate, num_routed, expert_n).permute(1, 0, 2).contiguous()
+        )  # (8, 7168, 2048)
+        down_experts = (
+            down_proj_weights[shared_n:, :].reshape(num_routed, expert_n, N_down).contiguous()
+        )  # (8, 2048, 7168)
+
+        device = self._device
+        tile_w = 32
+        num_banks = device.dram_grid_size().x
+        mesh_rows = device.shape[0]
+        mesh_cols = device.shape[1]
+
+        def upload(experts: torch.Tensor) -> ttnn.Tensor:
+            n_exp, K, N = experts.shape
+            N_padded = ((N + num_banks * tile_w - 1) // (num_banks * tile_w)) * (num_banks * tile_w)
+            per_core_N = N_padded // num_banks
+
+            processed = []
+            for i in range(n_exp):
+                w = experts[i]
+                if N_padded != N:
+                    w = torch.nn.functional.pad(w, (0, N_padded - N))
+                w_shuffled = self._shuffle_dram_tiles(w.unsqueeze(0), tile_w, num_banks)
+                processed.append(w_shuffled.reshape(K, N_padded))
+
+            stacked = torch.stack(processed).reshape(mesh_rows, mesh_cols, K, N_padded)
+
+            dram_grid = ttnn.CoreRangeSet(
+                {
+                    ttnn.CoreRange(
+                        ttnn.CoreCoord(0, 0),
+                        ttnn.CoreCoord(device.dram_grid_size().x - 1, device.dram_grid_size().y - 1),
+                    )
+                }
+            )
+            shard_spec = ttnn.ShardSpec(dram_grid, [K, per_core_N], ttnn.ShardOrientation.ROW_MAJOR)
+            mem_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.WIDTH_SHARDED, ttnn.BufferType.DRAM, shard_spec)
+
+            return ttnn.from_torch(
+                stacked.contiguous(),
                 dtype=ttnn.bfloat4_b,
-                tile_shape=ts,
-                byte_offset=0,
-            ),
-            OverlappedTensor(
-                fused_tensor=fused,
-                tensor_shape=stacked,
-                shard_shape=cfg.shard_shape,
-                core_range_set=cfg.up_core_range_set,
-                dtype=ttnn.bfloat4_b,
-                tile_shape=ts,
-                byte_offset=0,
-            ),
-        ]
+                layout=ttnn.TILE_LAYOUT,
+                device=device,
+                memory_config=mem_config,
+                mesh_mapper=ttnn.ShardTensor2dMesh(device, mesh_shape=(mesh_rows, mesh_cols), dims=(0, 1)),
+            )
+
+        return upload(gate_experts), upload(up_experts), upload(down_experts)
 
     # ------------------------------------------------------------------
     # Internal helpers
     # ------------------------------------------------------------------
+
+    @staticmethod
+    def _shuffle_dram_tiles(tensor: torch.Tensor, tile_size: int, num_banks: int) -> torch.Tensor:
+        """Reorder tiles within each DRAM bank shard from row-major to column-major.
+
+        WIDTH_SHARDED DRAM layout stores tiles row-major, but the streaming
+        matmul kernel expects K tiles contiguous for each N column.  This
+        function transposes the tile order within each shard so that the
+        kernel can linearly read K tiles at a time.
+
+        Args:
+            tensor: ``[*, K, N]`` tensor (supports batch dimensions).
+            tile_size: Tile dimension (square tiles assumed).
+            num_banks: Number of DRAM banks (shards).
+
+        Returns:
+            Same-shape tensor with tiles rearranged per shard.
+        """
+        orig_shape = tensor.shape
+        K, N = orig_shape[-2], orig_shape[-1]
+
+        lcm = tile_size * num_banks
+        n_padded = ((N + lcm - 1) // lcm) * lcm
+        needs_padding = n_padded != N
+
+        tensor = tensor.reshape(-1, K, N)
+        batch_size = tensor.shape[0]
+
+        if needs_padding:
+            tensor = torch.nn.functional.pad(tensor, (0, n_padded - N))
+
+        K_tiles = K // tile_size
+        per_N = n_padded // num_banks
+        per_N_tiles = per_N // tile_size
+        num_tiles_per_shard = K_tiles * per_N_tiles
+
+        tensor = tensor.reshape(batch_size, K, num_banks, per_N)
+        tensor = tensor.permute(0, 2, 1, 3).contiguous()
+        shards = tensor.reshape(-1, K, per_N)
+
+        tiles = shards.reshape(-1, K_tiles, tile_size, per_N_tiles, tile_size)
+        tiles = tiles.permute(0, 1, 3, 2, 4).contiguous()
+        tiles = tiles.reshape(-1, num_tiles_per_shard, tile_size, tile_size)
+
+        i = torch.arange(num_tiles_per_shard, device=tensor.device)
+        source_idx = (i % K_tiles) * per_N_tiles + (i // K_tiles)
+        shuffled_tiles = tiles[:, source_idx, :, :]
+
+        shuffled_tiles = shuffled_tiles.reshape(-1, K_tiles, per_N_tiles, tile_size, tile_size)
+        shuffled_tiles = shuffled_tiles.permute(0, 1, 3, 2, 4).contiguous()
+        shuffled_shards = shuffled_tiles.reshape(-1, K, per_N)
+
+        shuffled = shuffled_shards.reshape(batch_size, num_banks, K, per_N)
+        shuffled = shuffled.permute(0, 2, 1, 3).contiguous()
+        shuffled = shuffled.reshape(batch_size, K, n_padded)
+
+        if needs_padding:
+            shuffled = shuffled[:, :, :N]
+
+        return shuffled.reshape(*orig_shape)
 
     @staticmethod
     def _tilize_and_pack_bfp8(data_2d: torch.Tensor, tile_h: int = 32, tile_w: int = 32) -> bytes:

--- a/models/demos/deepseek_v3_b1/blitz_decode_weights.py
+++ b/models/demos/deepseek_v3_b1/blitz_decode_weights.py
@@ -19,6 +19,7 @@ from dataclasses import dataclass, field
 
 import numpy as np
 import torch
+from loguru import logger
 
 import ttnn
 
@@ -1386,6 +1387,8 @@ class BlitzDecodeWeights:
                         mesh_mapper=mesh_mapper,
                     )
                 )
+                if (i + 1) % 32 == 0:
+                    logger.info(f"  Uploaded {i + 1}/{num_experts} experts")
             return tensors
 
         return upload(gate_proj_weights), upload(up_proj_weights), upload(down_proj_weights)

--- a/models/demos/deepseek_v3_b1/fused_ops/broadcast_rms/kernels/broadcast_rms_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/fused_ops/broadcast_rms/kernels/broadcast_rms_kernel.cpp
@@ -103,6 +103,7 @@ void kernel_main() {
     deepseek_b1_ops::RMSNorm::ComputeArgs rms_args{
         get_common_arg_val<uint32_t>(0),  // epsilon (common runtime arg 0)
         get_common_arg_val<float>(1),     // scalar (1/N)
+        get_common_arg_val<uint32_t>(2),  // gamma_address
     };
 
 #if !defined(SKIP_CCL)

--- a/models/demos/deepseek_v3_b1/fused_ops/broadcast_rms/op.py
+++ b/models/demos/deepseek_v3_b1/fused_ops/broadcast_rms/op.py
@@ -313,7 +313,7 @@ class BroadcastRMSNorm:
                     brisc_named_compile_time_args=brisc_named_compile_time_args,
                     trisc_named_compile_time_args=trisc_named_compile_time_args,
                     ncrisc_common_runtime_args=writer_common_rt_args,
-                    trisc_common_runtime_args=[epsilon_packed, scalar_packed],
+                    trisc_common_runtime_args=[epsilon_packed, scalar_packed, gamma_tensor.buffer_address()],
                     trisc_compute_config=ttnn.ComputeConfigDescriptor(
                         math_fidelity=ttnn.MathFidelity.LoFi,
                         math_approx_mode=False,

--- a/models/demos/deepseek_v3_b1/fused_ops/down_proj/kernels/down_proj_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/fused_ops/down_proj/kernels/down_proj_kernel.cpp
@@ -169,6 +169,7 @@ void kernel_main() {
         get_named_compile_time_arg_val("matmul_in1"),
         get_named_compile_time_arg_val("matmul_out"),
         get_named_compile_time_arg_val("matmul_k_num_tiles"),
+        get_named_compile_time_arg_val("matmul_in1_address"),
     };
 
     // Gather compute args (no-op for TRISC)

--- a/models/demos/deepseek_v3_b1/fused_ops/down_proj/op.py
+++ b/models/demos/deepseek_v3_b1/fused_ops/down_proj/op.py
@@ -347,6 +347,7 @@ class DownProj:
             ("matmul_out", matmul_out_cb),
             ("matmul_k_num_tiles", k_num_tiles),
             ("matmul_out_w_per_core", out_w_per_core),
+            ("matmul_in1_address", weights_tensor.buffer_address()),
             # Residual add step
             ("residual_add_in0", matmul_out_cb),
             ("residual_add_in1", residual_add_mcast_dst_cb),

--- a/models/demos/deepseek_v3_b1/fused_ops/gated_local_reduce_down_proj/kernels/gated_local_reduce_down_proj_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/fused_ops/gated_local_reduce_down_proj/kernels/gated_local_reduce_down_proj_kernel.cpp
@@ -251,6 +251,7 @@ void kernel_main() {
         get_named_compile_time_arg_val("matmul_in1"),
         get_named_compile_time_arg_val("matmul_out"),
         get_named_compile_time_arg_val("matmul_k_num_tiles"),
+        get_named_compile_time_arg_val("matmul_in1_address"),
     };
 
     // Output gather compute args (no-op)

--- a/models/demos/deepseek_v3_b1/fused_ops/gated_local_reduce_down_proj/op.py
+++ b/models/demos/deepseek_v3_b1/fused_ops/gated_local_reduce_down_proj/op.py
@@ -512,6 +512,7 @@ class GatedLocalReduceDownProjOp:
             ("matmul_out", ctx.matmul_out_cb),
             ("matmul_k_num_tiles", ctx.k_num_tiles),
             ("matmul_out_w_per_core", ctx.out_w_per_core),
+            ("matmul_in1_address", ctx.weights_tensor.buffer_address()),
             # Residual add step
             ("residual_add_in0", ctx.matmul_out_cb),
             ("residual_add_in1", ctx.residual_add_mcast_dst_cb),

--- a/models/demos/deepseek_v3_b1/fused_ops/kv_cache_branch/kernels/kv_cache_branch_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/fused_ops/kv_cache_branch/kernels/kv_cache_branch_kernel.cpp
@@ -117,6 +117,7 @@ void kernel_main() {
         get_named_compile_time_arg_val("dkv_matmul_in1"),
         get_named_compile_time_arg_val("dkv_matmul_out"),
         get_named_compile_time_arg_val("dkv_matmul_k_num_tiles"),
+        get_named_compile_time_arg_val("dkv_matmul_in1_address"),
     };
 
     // Gather compute args (no-op for TRISC)
@@ -135,6 +136,7 @@ void kernel_main() {
     deepseek_b1_ops::RMSNorm::ComputeArgs kv_rmsnorm_args{
         get_common_arg_val<uint32_t>(0),  // epsilon
         get_common_arg_val<float>(1),     // scalar (1/sqrt(512))
+        get_common_arg_val<uint32_t>(2),  // gamma_address
     };
 
     using K_RopeCTArgs = deepseek_b1_ops::Rope::

--- a/models/demos/deepseek_v3_b1/fused_ops/kv_cache_branch/op.py
+++ b/models/demos/deepseek_v3_b1/fused_ops/kv_cache_branch/op.py
@@ -166,6 +166,7 @@ class KVCacheBranch:
             ("dkv_matmul_out", dkv_matmul_output_cb),
             ("dkv_matmul_k_num_tiles", dkv_matmul_k_num_tiles),
             ("dkv_matmul_out_w_per_core", dkv_matmul_out_w),
+            ("dkv_matmul_in1_address", dkv_matmul_weights_tensor.buffer_address()),
         ]
 
         # KV RMSNorm
@@ -450,6 +451,7 @@ class KVCacheBranch:
             trisc_common_runtime_args=[
                 epsilon_packed,
                 kv_scalar_packed,
+                gamma_tensor.buffer_address(),
             ],
             trisc_compute_config=ttnn.ComputeConfigDescriptor(
                 math_fidelity=ttnn.MathFidelity.LoFi,

--- a/models/demos/deepseek_v3_b1/fused_ops/lm_head_sampling/kernels/lm_head_sampling_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/fused_ops/lm_head_sampling/kernels/lm_head_sampling_kernel.cpp
@@ -173,6 +173,7 @@ void kernel_main() {
         .in1 = in1_cb,
         .out = out_cb,
         .k_num_tiles = num_tiles_k,
+        .in1_address = get_named_compile_time_arg_val("matmul_in1_address"),
     };
     // Full init, CBs don't matter
     compute_kernel_hw_startup(0, 0, 0);

--- a/models/demos/deepseek_v3_b1/fused_ops/lm_head_sampling/op.py
+++ b/models/demos/deepseek_v3_b1/fused_ops/lm_head_sampling/op.py
@@ -337,6 +337,7 @@ class LMHeadSampling:
                     ("matmul_out", matmul_out_cb),
                     ("matmul_k_num_tiles", num_tiles_k),
                     ("matmul_out_w", out_w_per_core),
+                    ("matmul_in1_address", vocab_tensor_device.buffer_address()),
                 ]
 
                 # ================================================================

--- a/models/demos/deepseek_v3_b1/fused_ops/mlp/mlp_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/fused_ops/mlp/mlp_kernel.cpp
@@ -658,6 +658,7 @@ void kernel_main() {
             deepseek_b1_ops::RMSNorm::ComputeArgs rmsnorm_args{
                 get_common_arg_val<uint32_t>(get_named_compile_time_arg_val("rmsnorm_trisc_common_rt_arg_base") + 0),
                 get_common_arg_val<float>(get_named_compile_time_arg_val("rmsnorm_trisc_common_rt_arg_base") + 1),
+                get_common_arg_val<uint32_t>(get_named_compile_time_arg_val("rmsnorm_trisc_common_rt_arg_base") + 2),
             };
 
 #ifdef ENABLE_REDUCE_TO_ONE
@@ -688,6 +689,7 @@ void kernel_main() {
                 get_named_compile_time_arg_val("shared_gu_k_offset"),
                 get_named_compile_time_arg_val("shared_gu_k_per_core"),
                 get_named_compile_time_arg_val("shared_gu_act_total_tiles"),
+                get_named_compile_time_arg_val("shared_gu_weights_address"),
             };
 
             // Gather (compute — no-op for TRISC)
@@ -717,6 +719,7 @@ void kernel_main() {
                 get_named_compile_time_arg_val("shared_down_matmul_in1"),
                 get_named_compile_time_arg_val("shared_down_matmul_out"),
                 get_named_compile_time_arg_val("shared_down_matmul_k_num_tiles"),
+                get_named_compile_time_arg_val("shared_down_matmul_in1_address"),
             };
 
             // Residual Add (compute)

--- a/models/demos/deepseek_v3_b1/fused_ops/mlp/op.py
+++ b/models/demos/deepseek_v3_b1/fused_ops/mlp/op.py
@@ -1159,7 +1159,8 @@ class MlpOp:
         rmsnorm_gamma_tensor,
         # Shared expert tensors
         shared_residual_mcast_src_tensor,
-        shared_gate_up_weights_tensor,
+        shared_gate_weights_overlapped,
+        shared_up_weights_overlapped,
         shared_residual_mcast_dst_tensor,
         shared_down_mcast_dst_tensor,
         shared_down_weights_tensor,
@@ -1242,7 +1243,8 @@ class MlpOp:
 
         shared_ctx = MoeSharedExpertOp._setup_dimensions(
             device=routed_ctx.device,
-            shared_gate_up_weights_tensor=shared_gate_up_weights_tensor,
+            shared_gate_weights_overlapped=shared_gate_weights_overlapped,
+            shared_up_weights_overlapped=shared_up_weights_overlapped,
             shared_down_mcast_dst_tensor=shared_down_mcast_dst_tensor,
             shared_down_weights_tensor=shared_down_weights_tensor,
             shared_output_tensor=shared_output_tensor,
@@ -1349,7 +1351,7 @@ class MlpOp:
             rmsnorm_gamma_tensor,
             # Shared expert tensors
             shared_residual_mcast_src_tensor,
-            shared_gate_up_weights_tensor,
+            shared_gate_weights_overlapped.fused_tensor,
             shared_ag_gather_dst_tensor,
             shared_bg_gather_dst_tensor,
             shared_residual_mcast_dst_tensor,

--- a/models/demos/deepseek_v3_b1/fused_ops/mlp/op.py
+++ b/models/demos/deepseek_v3_b1/fused_ops/mlp/op.py
@@ -126,6 +126,7 @@ class _MlpRoutedExpertContext:
     rmsnorm_gamma_cb_descriptor: Any
     rmsnorm_epsilon_packed: int
     rmsnorm_scalar_packed: int
+    rmsnorm_gamma_address: int
     rmsnorm_num_tiles: int
     rmsnorm_gamma_num_pages: int
 
@@ -703,6 +704,7 @@ class MlpRoutedExpertOp:
             rmsnorm_gamma_cb_descriptor=rmsnorm_gamma_cb_descriptor,
             rmsnorm_epsilon_packed=rmsnorm_epsilon_packed,
             rmsnorm_scalar_packed=rmsnorm_scalar_packed,
+            rmsnorm_gamma_address=rmsnorm_gamma_tensor.buffer_address(),
             rmsnorm_num_tiles=rmsnorm_num_tiles,
             rmsnorm_gamma_num_pages=rmsnorm_gamma_num_pages,
             # Per-core values
@@ -1664,6 +1666,7 @@ class MlpOp:
                     trisc_common_runtime_args=[
                         routed_ctx.rmsnorm_epsilon_packed,
                         routed_ctx.rmsnorm_scalar_packed,
+                        routed_ctx.rmsnorm_gamma_address,
                     ],
                     trisc_compute_config=ttnn.ComputeConfigDescriptor(
                         math_fidelity=ttnn.MathFidelity.LoFi,

--- a/models/demos/deepseek_v3_b1/fused_ops/moe/moe_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/fused_ops/moe/moe_kernel.cpp
@@ -675,6 +675,7 @@ void kernel_main() {
                 get_named_compile_time_arg_val("gate_mm_in1"),
                 get_named_compile_time_arg_val("gate_mm_out"),
                 get_named_compile_time_arg_val("gate_mm_k_num_tiles"),
+                get_named_compile_time_arg_val("gate_mm_in1_address"),
             };
 
             // Gather (compute — no-op)
@@ -783,6 +784,7 @@ void kernel_main() {
             deepseek_b1_ops::RMSNorm::ComputeArgs rmsnorm_args{
                 get_common_arg_val<uint32_t>(get_named_compile_time_arg_val("rmsnorm_trisc_common_rt_arg_base") + 0),
                 get_common_arg_val<float>(get_named_compile_time_arg_val("rmsnorm_trisc_common_rt_arg_base") + 1),
+                get_common_arg_val<uint32_t>(get_named_compile_time_arg_val("rmsnorm_trisc_common_rt_arg_base") + 2),
             };
 
 #ifdef ENABLE_REDUCE_TO_ONE
@@ -813,6 +815,7 @@ void kernel_main() {
                 get_named_compile_time_arg_val("shared_gu_k_offset"),
                 get_named_compile_time_arg_val("shared_gu_k_per_core"),
                 get_named_compile_time_arg_val("shared_gu_act_total_tiles"),
+                get_named_compile_time_arg_val("shared_gu_weights_address"),
             };
 
             // Gather (compute — no-op for TRISC)
@@ -842,6 +845,7 @@ void kernel_main() {
                 get_named_compile_time_arg_val("shared_down_matmul_in1"),
                 get_named_compile_time_arg_val("shared_down_matmul_out"),
                 get_named_compile_time_arg_val("shared_down_matmul_k_num_tiles"),
+                get_named_compile_time_arg_val("shared_down_matmul_in1_address"),
             };
 
             // Residual Add (compute)

--- a/models/demos/deepseek_v3_b1/fused_ops/moe/op.py
+++ b/models/demos/deepseek_v3_b1/fused_ops/moe/op.py
@@ -143,6 +143,7 @@ class _MoeRoutedExpertContext:
     rmsnorm_gamma_cb_descriptor: Any
     rmsnorm_epsilon_packed: int
     rmsnorm_scalar_packed: int
+    rmsnorm_gamma_address: int
     rmsnorm_num_tiles: int
     rmsnorm_gamma_num_pages: int
 
@@ -1279,6 +1280,7 @@ class MoeRoutedExpertOp:
             rmsnorm_gamma_cb_descriptor=rmsnorm_gamma_cb_descriptor,
             rmsnorm_epsilon_packed=rmsnorm_epsilon_packed,
             rmsnorm_scalar_packed=rmsnorm_scalar_packed,
+            rmsnorm_gamma_address=rmsnorm_gamma_tensor.buffer_address(),
             rmsnorm_num_tiles=rmsnorm_num_tiles,
             rmsnorm_gamma_num_pages=rmsnorm_gamma_num_pages,
             # Per-core values
@@ -1516,6 +1518,7 @@ class MoeRoutedExpertOp:
             ("gate_mm_k_num_tiles", ctx.gate_mm_params["k_num_tiles"]),
             ("gate_mm_out_w", ctx.gate_mm_params["out_w"]),
             ("gate_mm_fused_activation", ctx.gate_mm_params["fused_activation"]),
+            ("gate_mm_in1_address", ctx.gate_mm_params["in1_buf_addr"]),
             # Gate compute
             ("gate_input_cb", ctx.gate_params["input_cb"]),
             ("gate_bias_cb", ctx.gate_params["bias_cb"]),
@@ -1777,6 +1780,7 @@ class MoeSharedExpertOp:
             "weights_num_pages": weights_num_pages,
             "cb_weights_descriptor": cb_weights_descriptor,
             "cb_out_descriptor": cb_out_descriptor,
+            "weights_buf_addr": weights_tensor.buffer_address(),
         }
 
     @staticmethod
@@ -2394,6 +2398,7 @@ class MoeSharedExpertOp:
             ("shared_gu_out_cb", shared_ctx.gu_out_cb),
             ("shared_gu_k_per_core", shared_ctx.gu_matmul_params["k_per_core"]),
             ("shared_gu_act_total_tiles", shared_ctx.gu_matmul_params["act_total_tiles"]),
+            ("shared_gu_weights_address", shared_ctx.gu_matmul_params["weights_buf_addr"]),
             # Gated reduce
             ("shared_gated_reduce_group1_cb", shared_ctx.group1_cb),
             ("shared_gated_reduce_group2_cb", shared_ctx.group2_cb),
@@ -2407,6 +2412,7 @@ class MoeSharedExpertOp:
             ("shared_down_matmul_out", shared_ctx.down_matmul_params["out_cb"]),
             ("shared_down_matmul_k_num_tiles", shared_ctx.down_matmul_params["k_num_tiles"]),
             ("shared_down_matmul_out_w_per_core", shared_ctx.down_matmul_params["out_w"]),
+            ("shared_down_matmul_in1_address", shared_ctx.down_matmul_params["in1_buf_addr"]),
             # Residual add
             ("shared_residual_add_in0", shared_ctx.down_matmul_params["out_cb"]),  # matmul output
             ("shared_residual_add_in1", shared_ctx.residual_cb),  # residual (pre-loaded bias)
@@ -2783,6 +2789,8 @@ class MoeOp:
             # CB descriptors
             "weights_cb_descriptor": weights_cb_descriptor,
             "output_cb_descriptor": output_cb_descriptor,
+            # Weight buffer address for overlapped tensor support
+            "in1_buf_addr": weights_tensor.buffer_address(),
         }
 
     @staticmethod
@@ -3441,6 +3449,7 @@ class MoeOp:
                     trisc_common_runtime_args=[
                         routed_ctx.rmsnorm_epsilon_packed,
                         routed_ctx.rmsnorm_scalar_packed,
+                        routed_ctx.rmsnorm_gamma_address,
                     ],
                     trisc_compute_config=ttnn.ComputeConfigDescriptor(
                         math_fidelity=ttnn.MathFidelity.LoFi,

--- a/models/demos/deepseek_v3_b1/fused_ops/moe_routed_expert/moe_routed_expert_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/fused_ops/moe_routed_expert/moe_routed_expert_kernel.cpp
@@ -475,6 +475,7 @@ void kernel_main() {
         get_named_compile_time_arg_val("gate_mm_in1"),
         get_named_compile_time_arg_val("gate_mm_out"),
         get_named_compile_time_arg_val("gate_mm_k_num_tiles"),
+        get_named_compile_time_arg_val("gate_mm_in1_address"),
     };
 
     // ------------------------------------------------------------------------

--- a/models/demos/deepseek_v3_b1/fused_ops/moe_routed_expert/op.py
+++ b/models/demos/deepseek_v3_b1/fused_ops/moe_routed_expert/op.py
@@ -484,6 +484,8 @@ def setup_sram_matmul(
         # CB descriptors
         "weights_cb_descriptor": weights_cb_descriptor,
         "output_cb_descriptor": output_cb_descriptor,
+        # Weight buffer address for overlapped tensor support
+        "in1_buf_addr": weights_tensor.buffer_address(),
     }
 
 
@@ -1506,6 +1508,7 @@ class MoeRoutedExpert:
             ("gate_mm_k_num_tiles", gate_mm_params["k_num_tiles"]),
             ("gate_mm_out_w", gate_mm_params["out_w"]),
             ("gate_mm_fused_activation", gate_mm_params["fused_activation"]),
+            ("gate_mm_in1_address", gate_mm_params["in1_buf_addr"]),
             # Gate compute args (sender core)
             ("gate_input_cb", gate_params["input_cb"]),
             ("gate_bias_cb", gate_params["bias_cb"]),

--- a/models/demos/deepseek_v3_b1/fused_ops/post_sdpa/kernels/post_sdpa_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/fused_ops/post_sdpa/kernels/post_sdpa_kernel.cpp
@@ -290,6 +290,7 @@ void kernel_main() {
         get_named_compile_time_arg_val("matmul1_in1"),
         get_named_compile_time_arg_val("matmul1_out"),
         get_named_compile_time_arg_val("matmul1_k_num_tiles"),
+        get_named_compile_time_arg_val("matmul1_in1_address"),
     };
 
     // Gather1 compute args (no-op)
@@ -307,6 +308,7 @@ void kernel_main() {
         get_named_compile_time_arg_val("matmul2_in1"),
         get_named_compile_time_arg_val("matmul2_out"),
         get_named_compile_time_arg_val("matmul2_k_num_tiles"),
+        get_named_compile_time_arg_val("matmul2_in1_address"),
     };
 
     // Gather2 compute args (no-op)

--- a/models/demos/deepseek_v3_b1/fused_ops/post_sdpa/op.py
+++ b/models/demos/deepseek_v3_b1/fused_ops/post_sdpa/op.py
@@ -711,12 +711,14 @@ class PostSDPA:
                     ("matmul1_out", matmul1_out_cb),
                     ("matmul1_k_num_tiles", matmul1_k_num_tiles),
                     ("matmul1_out_w_per_core", matmul1_out_w_per_core),
+                    ("matmul1_in1_address", weights1_tensor.buffer_address()),
                     # Matmul2
                     ("matmul2_in0", matmul2_in0_cb),
                     ("matmul2_in1", matmul2_in1_cb),
                     ("matmul2_out", matmul2_out_cb),
                     ("matmul2_k_num_tiles", matmul2_k_num_tiles),
                     ("matmul2_out_w_per_core", matmul2_out_w_per_core),
+                    ("matmul2_in1_address", weights2_tensor.buffer_address()),
                     # CCL receiver compute (reduction)
                     ("ccl_receiver_cb_in0", ccl_remote_data_cb),
                     ("ccl_receiver_cb_in1", gather2_dst_cb),  # Local data

--- a/models/demos/deepseek_v3_b1/fused_ops/pre_sdpa/kernels/pre_sdpa_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/fused_ops/pre_sdpa/kernels/pre_sdpa_kernel.cpp
@@ -417,6 +417,7 @@ void kernel_main() {
     deepseek_b1_ops::RMSNorm::ComputeArgs rmsnorm_args{
         get_common_arg_val<uint32_t>(0),  // epsilon
         get_common_arg_val<float>(1),     // scalar (1/sqrt(7168))
+        get_common_arg_val<uint32_t>(7),  // gamma_address
     };
 
     // Mcast compute args (no-op for TRISC)
@@ -443,6 +444,7 @@ void kernel_main() {
         k_offset,
         get_named_compile_time_arg_val("matmul_k_per_core"),
         get_named_compile_time_arg_val("matmul_act_total_tiles"),
+        get_named_compile_time_arg_val("matmul_in1_address"),
     };
 
     // Gather reduce compute args
@@ -456,6 +458,7 @@ void kernel_main() {
     deepseek_b1_ops::RMSNorm::ComputeArgs rmsnorm2_args{
         get_common_arg_val<uint32_t>(0),  // epsilon (same as rmsnorm1)
         get_common_arg_val<float>(2),     // scalar (1/sqrt(1536))
+        get_common_arg_val<uint32_t>(8),  // gamma_address
     };
 
     // Matmul2 CTArgs type alias (out_w is compile-time for TRISC)
@@ -468,6 +471,7 @@ void kernel_main() {
         get_named_compile_time_arg_val("matmul2_in1"),
         get_named_compile_time_arg_val("matmul2_out"),
         get_named_compile_time_arg_val("matmul2_k_num_tiles"),
+        get_named_compile_time_arg_val("matmul2_in1_address"),
     };
 
     // Mcast2 compute args (no-op for TRISC)
@@ -483,6 +487,7 @@ void kernel_main() {
         get_named_compile_time_arg_val("matmul3_in1"),
         get_named_compile_time_arg_val("matmul3_out"),
         get_named_compile_time_arg_val("matmul3_k_num_tiles"),
+        get_named_compile_time_arg_val("matmul3_in1_address"),
     };
 
     // Qrope CTArgs type alias
@@ -519,6 +524,7 @@ void kernel_main() {
         get_named_compile_time_arg_val("dkv_matmul_in1"),
         get_named_compile_time_arg_val("dkv_matmul_out"),
         get_named_compile_time_arg_val("dkv_matmul_k_num_tiles"),
+        get_named_compile_time_arg_val("dkv_matmul_in1_address"),
     };
 
     // Gather compute args (no-op for TRISC)
@@ -537,6 +543,7 @@ void kernel_main() {
     deepseek_b1_ops::RMSNorm::ComputeArgs kv_rmsnorm_args{
         get_common_arg_val<uint32_t>(0),  // epsilon
         get_common_arg_val<float>(3),     // kv_scalar (1/sqrt(512))
+        get_common_arg_val<uint32_t>(9),  // gamma_address
     };
 
     using K_RopeCTArgs = deepseek_b1_ops::Rope::

--- a/models/demos/deepseek_v3_b1/fused_ops/pre_sdpa/kernels/pre_sdpa_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/fused_ops/pre_sdpa/kernels/pre_sdpa_kernel.cpp
@@ -590,20 +590,11 @@ void kernel_main() {
         unified_kernels::setup_sharded_buffer(rmsnorm2_gamma_cb, rmsnorm2_num_tiles);
     }
     if constexpr (Core::is_matmul_core) {
-        // Matmul weights
+        // Fused weights CB: one setup for both matmul1 (q_a) and matmul2 (q_b) on q_ab cores
         constexpr uint32_t matmul_in1 = get_named_compile_time_arg_val("matmul_in1");
-        constexpr uint32_t matmul_k_num_tiles = get_named_compile_time_arg_val("matmul_k_per_core");
-        constexpr uint32_t matmul_out_w_per_core = get_named_compile_time_arg_val("matmul_out_w_per_core");
-        unified_kernels::setup_sharded_buffer(matmul_in1, matmul_k_num_tiles * matmul_out_w_per_core);
-    }
-    if constexpr (Core::is_matmul2_core) {
-        // Matmul2 CB indices and parameters from named compile-time args
-        constexpr uint32_t matmul2_in1 = get_named_compile_time_arg_val("matmul2_in1");
-        constexpr uint32_t matmul2_k_num_tiles = get_named_compile_time_arg_val("matmul2_k_num_tiles");
-        constexpr uint32_t matmul2_out_w_per_core = get_named_compile_time_arg_val("matmul2_out_w_per_core");
-
-        // Matmul2 weights (on all cores in main grid, 4 tiles per core)
-        unified_kernels::setup_sharded_buffer(matmul2_in1, matmul2_k_num_tiles * matmul2_out_w_per_core);
+        constexpr uint32_t fused_weights_tiles_per_core =
+            get_named_compile_time_arg_val("fused_weights_tiles_per_core");
+        unified_kernels::setup_sharded_buffer(matmul_in1, fused_weights_tiles_per_core);
     }
     if constexpr (Core::is_qnope_core) {
         // Matmul3 CB indices and parameters from named compile-time args
@@ -632,11 +623,11 @@ void kernel_main() {
     }
 
     if constexpr (Core::is_dkv_matmul_core) {
-        // Matmul weights (in1)
+        // Fused weights CB: setup on kv_a cores (same CB as matmul1/matmul2 on q_ab cores)
         constexpr uint32_t dkv_matmul_in1 = get_named_compile_time_arg_val("dkv_matmul_in1");
-        constexpr uint32_t dkv_matmul_out_w_per_core = get_named_compile_time_arg_val("dkv_matmul_out_w_per_core");
-        constexpr uint32_t dkv_matmul_k_num_tiles = get_named_compile_time_arg_val("dkv_matmul_k_num_tiles");
-        unified_kernels::setup_sharded_buffer(dkv_matmul_in1, dkv_matmul_k_num_tiles * dkv_matmul_out_w_per_core);
+        constexpr uint32_t fused_weights_tiles_per_core =
+            get_named_compile_time_arg_val("fused_weights_tiles_per_core");
+        unified_kernels::setup_sharded_buffer(dkv_matmul_in1, fused_weights_tiles_per_core);
     }
 
     if constexpr (Core::is_kv_rmsnorm_core) {

--- a/models/demos/deepseek_v3_b1/fused_ops/pre_sdpa/op.py
+++ b/models/demos/deepseek_v3_b1/fused_ops/pre_sdpa/op.py
@@ -1707,9 +1707,12 @@ class PreSDPA:
                     scalar_packed,  # idx 1
                     scalar2_packed,  # idx 2
                     kv_scalar_packed,  # idx 3
-                    kv_cache_input_cb,
-                    kv_cache_output_cb,
-                    kv_cache_intermed_cb,
+                    kv_cache_input_cb,  # idx 4
+                    kv_cache_output_cb,  # idx 5
+                    kv_cache_intermed_cb,  # idx 6
+                    gamma_tensor_device.buffer_address(),  # idx 7: rmsnorm gamma_address
+                    rmsnorm2_gamma_tensor_device.buffer_address(),  # idx 8: rmsnorm2 gamma_address
+                    dkv_rmsnorm_gamma_tensor_device.buffer_address(),  # idx 9: kv_rmsnorm gamma_address
                 ]
 
                 unified_kernel = UnifiedKernelDescriptor(
@@ -1760,6 +1763,7 @@ class PreSDPA:
                     + matmul2_trisc_named_compile_time_args
                     + [("matmul2_in1_address", matmul2_weights_addr)]
                     + matmul3_trisc_named_compile_time_args
+                    + [("matmul3_in1_address", matmul3_weights_tensor_device.buffer_address())]
                     + qrope_trisc_named_compile_time_args
                     + create_q_heads_trisc_named_compile_time_args
                     + dkv_matmul_trisc_named_compile_time_args

--- a/models/demos/deepseek_v3_b1/fused_ops/pre_sdpa/op.py
+++ b/models/demos/deepseek_v3_b1/fused_ops/pre_sdpa/op.py
@@ -7,6 +7,7 @@ import math
 import torch
 
 import ttnn
+from models.demos.deepseek_v3_b1.blitz_decode_weights import OverlappedTensor
 from models.demos.deepseek_v3_b1.unified_kernel_descriptor import (
     PerCoreRuntimeArgsDescriptor,
     UnifiedCompileTimeCoreDescriptor,
@@ -148,16 +149,16 @@ class PreSDPA:
         input_tensor_mesh,
         intermediate_tensor_mesh,
         gamma_tensor,
-        matmul_weights_tensor,
+        matmul_weights_ot: OverlappedTensor,
         rmsnorm2_gamma_tensor,
-        matmul2_weights_tensor,
+        matmul2_weights_ot: OverlappedTensor,
         matmul3_weights_tensor,
         qrope_sin_tensor,
         qrope_cos_tensor,
         trans_mat_tensor,
         krope_cos_tensor,
         krope_sin_tensor,
-        dkv_matmul_weights_tensor,
+        dkv_matmul_weights_ot: OverlappedTensor,
         dkv_rmsnorm_gamma_tensor,
         kv_cache_tensor,
         position_id,
@@ -181,9 +182,9 @@ class PreSDPA:
             input_tensor_mesh: Input mesh tensor (must be sharded on single core per device)
             intermediate_tensor_mesh: Intermediate mesh tensor for CCL broadcast destination
             gamma_tensor: Gamma/weight tensor (must be sharded, same shape as input)
-            matmul_weights_tensor: Matmul weights tensor (must be width sharded)
+            matmul_weights_ot: OverlappedTensor for q_a_proj (packed matmul1 weights)
             rmsnorm2_gamma_tensor: Gamma tensor for second RMSNorm (1536 elements = 3 tiles of 16x32)
-            matmul2_weights_tensor: Matmul2 weights tensor (width sharded, shuffled for interleaved output)
+            matmul2_weights_ot: OverlappedTensor for q_b_proj (shuffled matmul2 weights)
             matmul3_weights_tensor: Matmul3 weights tensor (height sharded on Qnope grid, [128, 512] per core)
             qrope_sin_tensor: Sin tensor (sharded tensor for QRoPE)
             qrope_cos_tensor: Cos tensor (sharded tensor for QRoPE)
@@ -211,13 +212,15 @@ class PreSDPA:
         mesh_rows = mesh_shape[0]
         mesh_cols = mesh_shape[1]
 
+        # The 3 weight OverlappedTensors share one fused device tensor
+        fused_weights_tensor = matmul_weights_ot.fused_tensor
+
         # Get per-device tensors
         input_tensors_per_device = ttnn.get_device_tensors(input_tensor_mesh)
         intermediate_tensors_per_device = ttnn.get_device_tensors(intermediate_tensor_mesh)
         gamma_tensors_per_device = ttnn.get_device_tensors(gamma_tensor)
-        matmul_weights_tensors_per_device = ttnn.get_device_tensors(matmul_weights_tensor)
+        fused_weights_tensors_per_device = ttnn.get_device_tensors(fused_weights_tensor)
         rmsnorm2_gamma_tensors_per_device = ttnn.get_device_tensors(rmsnorm2_gamma_tensor)
-        matmul2_weights_tensors_per_device = ttnn.get_device_tensors(matmul2_weights_tensor)
         matmul3_weights_tensors_per_device = ttnn.get_device_tensors(matmul3_weights_tensor)
         qrope_sin_tensors_per_device = ttnn.get_device_tensors(qrope_sin_tensor)
         qrope_cos_tensors_per_device = ttnn.get_device_tensors(qrope_cos_tensor)
@@ -225,7 +228,6 @@ class PreSDPA:
         krope_cos_tensors_per_device = ttnn.get_device_tensors(krope_cos_tensor)
         krope_sin_tensors_per_device = ttnn.get_device_tensors(krope_sin_tensor)
         output_tensors_per_device = ttnn.get_device_tensors(output_tensor)
-        dkv_matmul_weights_tensors_per_device = ttnn.get_device_tensors(dkv_matmul_weights_tensor)
         dkv_rmsnorm_gamma_tensors_per_device = ttnn.get_device_tensors(dkv_rmsnorm_gamma_tensor)
         kv_cache_tensors_per_device = ttnn.get_device_tensors(kv_cache_tensor)
         sdpa_out_interm_buffers_per_device = ttnn.get_device_tensors(sdpa_out_interm_buffer)
@@ -291,39 +293,19 @@ class PreSDPA:
             [ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(device_grid_size.x - 1, device_grid_size.y - 1))]
         )
 
-        # Matmul1 grid from weight shard spec (single packed weight tensor)
-        matmul_weights_sample = matmul_weights_tensors_per_device[0]
-        matmul_weights_memory_config = matmul_weights_sample.memory_config()
-        matmul_weights_core_grid = matmul_weights_memory_config.shard_spec.grid
-        if len(list(matmul_weights_core_grid.ranges())) != 1:
-            raise ValueError("matmul weights core grid must be a single rectangular range for packed K-split")
-        if matmul_weights_memory_config.shard_spec.orientation != ttnn.ShardOrientation.ROW_MAJOR:
-            raise ValueError("matmul weights shard orientation must be ROW_MAJOR for packed K-split")
+        # Matmul1 grid from OverlappedTensor metadata (q_a_proj packed)
+        matmul_weights_core_grid = matmul_weights_ot.core_range_set
         matmul_bbox = matmul_weights_core_grid.bounding_box()
         matmul_grid_size = matmul_bbox.grid_size()
         matmul_num_cores = matmul_grid_size.x * matmul_grid_size.y
-        if matmul_weights_core_grid.num_cores() != matmul_num_cores:
-            raise ValueError("matmul core grid must be a single rectangular range for this packed K-split path")
-        if matmul_num_cores % 2 != 0:
-            raise ValueError(f"matmul core grid must have an even number of cores, got {matmul_num_cores}")
-        if matmul_num_cores != 96:
-            raise ValueError(f"matmul core grid must have 96 cores for this K-split path, got {matmul_num_cores}")
         matmul_half_num_cores = matmul_num_cores // 2
+        matmul_weights_shard_width = matmul_weights_ot.shard_shape[1]
+        matmul_out_w = matmul_weights_shard_width // matmul_weights_ot.tile_shape[1]
 
-        # Calculate per-core width in tiles for matmul1 (from shard spec)
-        matmul_weights_tile = matmul_weights_sample.get_tile()
-        matmul_weights_shard_shape = matmul_weights_memory_config.shard_spec.shape
-        matmul_weights_shard_width = matmul_weights_shard_shape[1]  # Width dimension
-        matmul_out_w = matmul_weights_shard_width // matmul_weights_tile.tile_shape[1]  # Per-core width in tiles
-
-        # Calculate per-core width in tiles for matmul2 (from shard spec)
-        matmul2_weights_sample = matmul2_weights_tensors_per_device[0]
-        matmul2_weights_memory_config = matmul2_weights_sample.memory_config()
-        matmul2_weights_core_grid = matmul2_weights_memory_config.shard_spec.grid
-        matmul2_weights_tile = matmul2_weights_sample.get_tile()
-        matmul2_weights_shard_shape = matmul2_weights_memory_config.shard_spec.shape
-        matmul2_weights_shard_width = matmul2_weights_shard_shape[1]  # Width dimension
-        matmul2_out_w = matmul2_weights_shard_width // matmul2_weights_tile.tile_shape[1]  # Per-core width in tiles
+        # Matmul2 grid from OverlappedTensor metadata (q_b_proj shuffled)
+        matmul2_weights_core_grid = matmul2_weights_ot.core_range_set
+        matmul2_weights_shard_width = matmul2_weights_ot.shard_shape[1]
+        matmul2_out_w = matmul2_weights_shard_width // matmul2_weights_ot.tile_shape[1]
 
         # Extract matmul3 weights core grid (for inferring QNOPE grid dimensions)
         matmul3_weights_sample = matmul3_weights_tensors_per_device[0]
@@ -421,20 +403,10 @@ class PreSDPA:
         QNOPE_COLS = 8  # Number of QNOPE sender columns
         QROPE_COLS = 4  # Number of QROPE sender columns
 
-        # KV Cache Branch grid configuration
-        # DKV Matmul (9x2)
-        dkv_matmul_weights_sample = dkv_matmul_weights_tensors_per_device[0]
-        dkv_matmul_weights_memory_config = dkv_matmul_weights_sample.memory_config()
-        dkv_matmul_weights_core_grid = dkv_matmul_weights_memory_config.shard_spec.grid
-
-        # Calculate per-core width in tiles for matmul (from shard spec)
-        # Get shard width directly from shard_spec and divide by tile width from tensor
-        dkv_matmul_weights_tile = dkv_matmul_weights_sample.get_tile()
-        dkv_matmul_weights_shard_shape = dkv_matmul_weights_memory_config.shard_spec.shape
-        dkv_matmul_weights_shard_width = dkv_matmul_weights_shard_shape[1]  # Width dimension
-        dkv_matmul_out_w = (
-            dkv_matmul_weights_shard_width // dkv_matmul_weights_tile.tile_shape[1]
-        )  # Per-core width in tiles
+        # KV Cache Branch grid from OverlappedTensor metadata (kv_a_proj)
+        dkv_matmul_weights_core_grid = dkv_matmul_weights_ot.core_range_set
+        dkv_matmul_weights_shard_width = dkv_matmul_weights_ot.shard_shape[1]
+        dkv_matmul_out_w = dkv_matmul_weights_shard_width // dkv_matmul_weights_ot.tile_shape[1]
 
         # ========================================================================
         # Mcast grid configuration (decoupled from matmul weights tensor)
@@ -501,8 +473,12 @@ class PreSDPA:
         input_cb = 0
         gamma_cb = 1
         rmsnorm_output_cb = 2
+        # Fused weights CB: single CB for q_a (matmul1), q_b (matmul2), kv_a (dkv_matmul)
+        fused_weights_cb = 3
+        matmul_weights_cb = fused_weights_cb
+        matmul2_weights_cb = fused_weights_cb
+        dkv_matmul_weights_cb = fused_weights_cb
         # Matmul1 + gather-reduce + RMSNorm2 path
-        matmul_weights_cb = 3
         matmul_output_cb = 4
         matmul_input_cb = 5
         rmsnorm2_gamma_cb = 6  # Gamma for second RMSNorm (1536 elements = 3 tiles of 16x32)
@@ -511,7 +487,6 @@ class PreSDPA:
         rmsnorm2_output_cb = 9  # Output CB for RMSNorm2
         # Matmul2 + Matmul3 + QRoPE/CreateQHeads path
         matmul2_input_cb = 10  # Input CB for second matmul (1x1536 with 1x32 tiles)
-        matmul2_weights_cb = 11  # Weights CB for second matmul (width sharded, 4 tiles per core)
         matmul2_output_cb = 12  # Output CB for second matmul ([64, 1, 128] + [64, 1, 64])
         matmul3_weights_cb = 13  # Weights CB for third matmul (height sharded on Qnope grid)
         matmul3_output_cb = 14  # Output CB for third matmul (Qnope final output)
@@ -524,7 +499,6 @@ class PreSDPA:
         qrope_cos_interm_cb = 21  # Cos intermediate CB for RoPE
         qrope_sin_interm_cb = 22  # Sin intermediate CB for RoPE
         # KV cache branch
-        dkv_matmul_weights_cb = 23  # DKV Matmul weights CB
         dkv_matmul_output_cb = 24  # DKV Matmul output CB, 64 bytes (1 tile per core for rope input)
         kv_rmsnorm_input_cb = 25  # Input CB for KV Cache Branch RMSNorm
         kv_rmsnorm_gamma_cb = 26  # Gamma CB for KV Cache Branch RMSNorm
@@ -537,6 +511,13 @@ class PreSDPA:
         kv_cache_output_cb = 32  # Output CB for KV Cache Branch
         kv_cache_intermed_cb = 33  # Intermed CB for KV Cache Branch
         kv_cache_input_cb = 34  # Input CB for KV Cache Branch
+
+        # Fused weights: total tiles per core (from fused tensor shard)
+        fused_shard_shape = fused_weights_tensor.memory_config().shard_spec.shape
+        fused_tile = fused_weights_tensor.get_tile()
+        fused_tiles_per_core = (fused_shard_shape[0] // fused_tile.tile_shape[0]) * (
+            fused_shard_shape[1] // fused_tile.tile_shape[1]
+        )
 
         # RMSNorm2 parameters (for 1536 element input using 16x32 tiles)
         rmsnorm2_numel = 1536
@@ -615,6 +596,7 @@ class PreSDPA:
             ("matmul_in1", matmul_weights_cb),
             ("matmul_k_per_core", matmul_k_per_core),
             ("matmul_out_w_per_core", matmul_out_w),
+            ("fused_weights_tiles_per_core", fused_tiles_per_core),
         ]
         # BRISC: out
         matmul_brisc_named_compile_time_args = [
@@ -1069,21 +1051,24 @@ class PreSDPA:
                 input_tensor_device = input_tensors_per_device[device_idx]
                 intermediate_tensor_device = intermediate_tensors_per_device[device_idx]
                 gamma_tensor_device = gamma_tensors_per_device[device_idx]
-                matmul_weights_tensor_device = matmul_weights_tensors_per_device[device_idx]
+                fused_weights_tensor_device = fused_weights_tensors_per_device[device_idx]
                 rmsnorm2_gamma_tensor_device = rmsnorm2_gamma_tensors_per_device[device_idx]
-                matmul2_weights_tensor_device = matmul2_weights_tensors_per_device[device_idx]
                 matmul3_weights_tensor_device = matmul3_weights_tensors_per_device[device_idx]
                 qrope_cos_tensor_device = qrope_cos_tensors_per_device[device_idx]
                 qrope_sin_tensor_device = qrope_sin_tensors_per_device[device_idx]
                 trans_mat_tensor_device = trans_mat_tensors_per_device[device_idx]
                 output_tensor_device = output_tensors_per_device[device_idx]
-                dkv_matmul_weights_tensor_device = dkv_matmul_weights_tensors_per_device[device_idx]
                 dkv_rmsnorm_gamma_tensor_device = dkv_rmsnorm_gamma_tensors_per_device[device_idx]
                 krope_cos_tensor_device = krope_cos_tensors_per_device[device_idx]
                 krope_sin_tensor_device = krope_sin_tensors_per_device[device_idx]
                 kv_cache_tensor_device = kv_cache_tensors_per_device[device_idx]
                 sdpa_kv_cache_buffer_device = sdpa_kv_cache_buffers_per_device[device_idx]
                 sdpa_out_interm_buffer_device = sdpa_out_interm_buffers_per_device[device_idx]
+
+                fused_base_addr = fused_weights_tensor_device.buffer_address()
+                matmul_weights_addr = fused_base_addr + matmul_weights_ot.byte_offset
+                matmul2_weights_addr = fused_base_addr + matmul2_weights_ot.byte_offset
+                dkv_matmul_weights_addr = fused_base_addr + dkv_matmul_weights_ot.byte_offset
 
                 # Get worker core from per-device input tensor shard grid
                 device_local = input_tensor_device.device()
@@ -1195,9 +1180,9 @@ class PreSDPA:
                     )
                 ]
 
-                # CB: Matmul weights (created from sharded tensor)
-                matmul_weights_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(
-                    matmul_weights_cb, matmul_weights_tensor_device
+                # CB: Fused weights (single CB for matmul1/matmul2/dkv_matmul, backed by fused tensor)
+                fused_weights_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(
+                    fused_weights_cb, fused_weights_tensor_device
                 )
 
                 # CB: Matmul input buffer (1x32 tiles, receives mcast data)
@@ -1325,11 +1310,6 @@ class PreSDPA:
                     )
                 ]
                 sdpa_out_interm_running_offset += matmul2_input_cb_descriptor.total_size  # +3072 B
-
-                # CB: Matmul2 weights (created from sharded tensor, 4 tiles per core)
-                matmul2_weights_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(
-                    matmul2_weights_cb, matmul2_weights_tensor_device
-                )
 
                 # CB 12: Matmul2 output buffer — overlap with sdpa_out_interm L1 buffer
                 # at offset 12352 B. This CB is consumed before SDPA runs.
@@ -1493,11 +1473,6 @@ class PreSDPA:
                 # Only allocated on receiver cores (SDPA Input grid) - senders no longer write here
                 create_q_heads_out_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(
                     create_q_heads_out_cb, output_tensor_device
-                )
-
-                # CB: DKV Matmul weights buffer
-                dkv_matmul_weights_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(
-                    dkv_matmul_weights_cb, dkv_matmul_weights_tensor_device
                 )
 
                 # CB 24: DKV Matmul output — overlap with sdpa_out_interm L1 buffer
@@ -1779,13 +1754,16 @@ class PreSDPA:
                     trisc_named_compile_time_args=bcast_trisc_named_compile_time_args
                     + rmsnorm_compute_named_compile_time_args
                     + matmul_trisc_named_compile_time_args
+                    + [("matmul_in1_address", matmul_weights_addr)]
                     + gather_reduce_trisc_named_compile_time_args
                     + rmsnorm2_trisc_named_compile_time_args
                     + matmul2_trisc_named_compile_time_args
+                    + [("matmul2_in1_address", matmul2_weights_addr)]
                     + matmul3_trisc_named_compile_time_args
                     + qrope_trisc_named_compile_time_args
                     + create_q_heads_trisc_named_compile_time_args
                     + dkv_matmul_trisc_named_compile_time_args
+                    + [("dkv_matmul_in1_address", dkv_matmul_weights_addr)]
                     + kv_rmsnorm_trisc_named_compile_time_args
                     + krope_trisc_named_compile_time_args
                     + kv_cache_trisc_named_compile_time_args,
@@ -1880,7 +1858,7 @@ class PreSDPA:
                     in_cb_descriptor,
                     gamma_cb_descriptor,
                     rmsnorm_output_cb_descriptor,
-                    matmul_weights_cb_descriptor,
+                    fused_weights_cb_descriptor,  # CB 3: Fused weights (matmul1 + matmul2 + dkv_matmul)
                     matmul_output_cb_descriptor,
                     matmul_input_cb_descriptor,
                     rmsnorm2_gamma_cb_descriptor,  # CB 6: RMSNorm2 gamma
@@ -1888,7 +1866,6 @@ class PreSDPA:
                     gather_reduce_half1_scratch_cb_descriptor,  # CB 8: gather_reduce half1 scratch
                     rmsnorm2_output_cb_descriptor,  # CB 9: RMSNorm2 output
                     matmul2_input_cb_descriptor,  # CB 10: Matmul2 input
-                    matmul2_weights_cb_descriptor,  # CB 11: Matmul2 weights
                     matmul2_output_cb_descriptor,  # CB 12: Matmul2 output (intermediate)
                     matmul3_weights_cb_descriptor,  # CB 13: Matmul3 weights
                     matmul3_output_cb_descriptor,  # CB 14: Matmul3 output (Qnope final)
@@ -1900,7 +1877,6 @@ class PreSDPA:
                     qrope_rotated_input_interm_cb_descriptor,  # CB 20: Rotated input intermediate
                     qrope_cos_interm_cb_descriptor,  # CB 21: Cos intermediate
                     qrope_sin_interm_cb_descriptor,  # CB 22: Sin intermediate
-                    dkv_matmul_weights_cb_descriptor,  # CB 23: DKV Matmul weights
                     dkv_matmul_output_cb_descriptor,  # CB 24: DKV Matmul output
                     kv_rmsnorm_input_cb_descriptor,  # CB 25: KV RMSNorm input
                     kv_rmsnorm_gamma_cb_descriptor,  # CB 26: KV RMSNorm gamma
@@ -1953,16 +1929,14 @@ class PreSDPA:
                 input_tensor_mesh,
                 intermediate_tensor_mesh,
                 gamma_tensor,
-                matmul_weights_tensor,
+                fused_weights_tensor,
                 rmsnorm2_gamma_tensor,
-                matmul2_weights_tensor,
                 matmul3_weights_tensor,
                 qrope_sin_tensor,
                 qrope_cos_tensor,
                 trans_mat_tensor,
                 krope_cos_tensor,
                 krope_sin_tensor,
-                dkv_matmul_weights_tensor,
                 dkv_rmsnorm_gamma_tensor,
                 kv_cache_tensor,
                 sdpa_kv_cache_buffer,

--- a/models/demos/deepseek_v3_b1/fused_ops/shared_expert/kernels/shared_expert_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/fused_ops/shared_expert/kernels/shared_expert_kernel.cpp
@@ -308,6 +308,7 @@ void kernel_main() {
         get_named_compile_time_arg_val("gu_k_offset"),
         get_named_compile_time_arg_val("gu_k_per_core"),
         get_named_compile_time_arg_val("gu_act_total_tiles"),
+        get_named_compile_time_arg_val("gu_weights_address"),
     };
 
     // Down proj matmul CTArgs
@@ -318,6 +319,7 @@ void kernel_main() {
         get_named_compile_time_arg_val("matmul_in1"),
         get_named_compile_time_arg_val("matmul_out"),
         get_named_compile_time_arg_val("matmul_k_num_tiles"),
+        get_named_compile_time_arg_val("matmul_in1_address"),
     };
 
     // Output gather compute args (no-op)

--- a/models/demos/deepseek_v3_b1/fused_ops/shared_expert/op.py
+++ b/models/demos/deepseek_v3_b1/fused_ops/shared_expert/op.py
@@ -116,6 +116,10 @@ class _SharedExpertContext:
     gu_weights_cb: int
     gu_out_cb: int
 
+    # Weight buffer addresses for overlapped tensor support
+    gu_weights_address: int
+    down_weights_address: int
+
     # Derived sizes
     act_mcast_data_size_bytes: int
     act_mcast_is_part_of_receiver_grid: bool
@@ -443,6 +447,8 @@ class SharedExpertOp:
             residual_add_out_cb=residual_add_out_cb,
             gu_weights_cb=gu_weights_cb,
             gu_out_cb=gu_out_cb,
+            gu_weights_address=gate_up_weights_tensor.buffer_address(),
+            down_weights_address=down_weights_tensor.buffer_address(),
             act_mcast_data_size_bytes=act_mcast_data_size_bytes,
             act_mcast_is_part_of_receiver_grid=act_mcast_is_part_of_receiver_grid,
             mcast_data_size_bytes=mcast_data_size_bytes,
@@ -606,6 +612,7 @@ class SharedExpertOp:
             ("gu_out_cb", ctx.gu_out_cb),
             ("gu_k_per_core", ctx.k_per_core),
             ("gu_act_total_tiles", ctx.K_gate_tiles),
+            ("gu_weights_address", ctx.gu_weights_address),
             # Gated reduce
             ("gated_reduce_group1_cb", ctx.group1_cb),
             ("gated_reduce_group2_cb", ctx.group2_cb),
@@ -619,6 +626,7 @@ class SharedExpertOp:
             ("matmul_out", ctx.matmul_out_cb),
             ("matmul_k_num_tiles", ctx.K_down_tiles),
             ("matmul_out_w_per_core", ctx.out_w_per_core),
+            ("matmul_in1_address", ctx.down_weights_address),
             # Residual add step
             ("residual_add_in0", ctx.matmul_out_cb),
             ("residual_add_in1", ctx.residual_mcast_dst_cb),

--- a/models/demos/deepseek_v3_b1/micro_ops/kn_sliced_matmul/kernels/kn_sliced_matmul_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/micro_ops/kn_sliced_matmul/kernels/kn_sliced_matmul_kernel.cpp
@@ -42,6 +42,7 @@ void kernel_main() {
         get_named_compile_time_arg_val("k_offset"),
         get_named_compile_time_arg_val("k_per_core"),
         get_named_compile_time_arg_val("act_total_tiles"),
+        get_named_compile_time_arg_val("weights_address"),
     };
     deepseek_b1_ops::KNSlicedMatmul::Op<KNSlicedMatmulCTArgs, true, /*pop_act=*/true, /*pop_weights=*/false> matmul;
     // Full init, CBs don't matter

--- a/models/demos/deepseek_v3_b1/micro_ops/kn_sliced_matmul/op.py
+++ b/models/demos/deepseek_v3_b1/micro_ops/kn_sliced_matmul/op.py
@@ -73,6 +73,7 @@ class KNSlicedMatmulOp:
             ("k_per_core", k_per_core),
             ("act_total_tiles", act_total_tiles),
             ("out_w", out_w),
+            ("weights_address", weights_tensor.buffer_address()),
         ]
 
         per_core_descs = []

--- a/models/demos/deepseek_v3_b1/micro_ops/matmul/kernels/matmul_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/micro_ops/matmul/kernels/matmul_kernel.cpp
@@ -67,6 +67,7 @@ void kernel_main() {
         .in1 = in1_cb,
         .out = out_cb,
         .k_num_tiles = num_tiles_k,
+        .in1_address = get_named_compile_time_arg_val("matmul_in1_address"),
     };
     // Full init, CBs don't matter
     compute_kernel_hw_startup(0, 0, 0);

--- a/models/demos/deepseek_v3_b1/micro_ops/matmul/op.py
+++ b/models/demos/deepseek_v3_b1/micro_ops/matmul/op.py
@@ -166,6 +166,7 @@ class Matmul:
             ("matmul_out_w", out_w),
             ("matmul_transpose", transpose),
             ("matmul_fused_activation", fused_activation_val),
+            ("matmul_in1_address", input_b.buffer_address()),
         ]
 
         # Unified kernel descriptor

--- a/models/demos/deepseek_v3_b1/micro_ops/rmsnorm/kernels/rmsnorm_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/micro_ops/rmsnorm/kernels/rmsnorm_kernel.cpp
@@ -65,6 +65,7 @@ void kernel_main() {
     deepseek_b1_ops::RMSNorm::ComputeArgs rmsnorm_args{
         .epsilon = get_common_arg_val<uint32_t>(0),  // epsilon
         .scalar = get_common_arg_val<float>(1),      // scalar (1/sqrt(num_elements))
+        .gamma_address = get_common_arg_val<uint32_t>(2),
     };
     // Full init, CBs don't matter
     compute_kernel_hw_startup(0, 0, 0);

--- a/models/demos/deepseek_v3_b1/micro_ops/rmsnorm/op.py
+++ b/models/demos/deepseek_v3_b1/micro_ops/rmsnorm/op.py
@@ -153,7 +153,7 @@ class RMSNormSingleCore:
             ncrisc_named_compile_time_args=ncrisc_named_compile_time_args,
             brisc_named_compile_time_args=[],
             trisc_named_compile_time_args=trisc_named_compile_time_args,
-            trisc_common_runtime_args=[epsilon_packed, scalar_packed],
+            trisc_common_runtime_args=[epsilon_packed, scalar_packed, gamma_tensor.buffer_address()],
             trisc_compute_config=ttnn.ComputeConfigDescriptor(
                 math_fidelity=ttnn.MathFidelity.LoFi,
                 math_approx_mode=False,

--- a/models/demos/deepseek_v3_b1/tests/blitz_weights_tests/test_blitz_decode_weights.py
+++ b/models/demos/deepseek_v3_b1/tests/blitz_weights_tests/test_blitz_decode_weights.py
@@ -28,7 +28,7 @@ against a dtype round-tripped reference):
   - kv_b1_proj (HEIGHT_SHARDED, BFP8)
   - kv_b2_proj (HEIGHT_SHARDED, BFP8)
 
-Tests both constituents of get_tt_gate_up_proj_weights
+Tests both constituents of get_tt_moe_shared_expert_weights
 (using CopyToOutput to extract each sub-tensor, then verifying
 against a dtype round-tripped reference):
   - gate_proj (block-sharded HEIGHT_SHARDED, BFP4)
@@ -41,10 +41,10 @@ from loguru import logger
 
 import ttnn
 from models.demos.deepseek_v3_b1.blitz_decode_weights import (
-    GATE_UP_PROJ_OVERLAP_CFG,
-    KVB12_PROJ_OVERLAP_CFG,
-    O_PROJ_GATE_MM_RMSNORM_GAMMA_OVERLAP_CFG,
-    QAB_KVA_PROJ_OVERLAP_CFG,
+    GATE_UP_PROJ_SINGLE_DEVICE_OVERLAP_SPEC,
+    KVB12_PROJ_SINGLE_DEVICE_OVERLAP_SPEC,
+    O_PROJ_GATE_MM_RMSNORM_GAMMA_SINGLE_DEVICE_OVERLAP_SPEC,
+    QAB_KVA_PROJ_SINGLE_DEVICE_OVERLAP_SPEC,
     BlitzDecodeWeights,
 )
 from models.demos.deepseek_v3_b1.tests.blitz_weights_tests.op import CopyToOutput
@@ -143,29 +143,43 @@ def test_q_ab_proj_kv_a_proj_overlap(bh_2d_mesh_device, mesh_rows, mesh_cols):
     each sub-tensor with CopyToOutput and checks it against an
     independently preprocessed + bfp8 round-tripped reference.
 
-    For multi-device (4x2 mesh), TP=2 across mesh columns:
-    q_b_proj is sharded, q_a_proj and kv_a_proj are replicated.
+    For multi-device (4x2 mesh), mla_tp=2 across mesh columns:
+    q_b_proj is TP-sharded on the width, q_a_proj and kv_a_proj are replicated.
+
+    Per-device layout::
+
+        q_a_proj (7168, 1536) packed to (3584, 3072) as bfloat8_b
+          WIDTH_SHARDED on 96 cores (12x8), shard (3584, 32)
+
+        q_b_proj (1536, 12288) as bfloat8_b
+          WIDTH_SHARDED on 96 cores (12x8), shard (1536, 128)
+
+        kv_a_proj (7168, 576) as bfloat8_b, shard-reordered
+          WIDTH_SHARDED on 18 cores (9x2), shard (7168, 32)
     """
     num_devices = mesh_rows * mesh_cols
     if bh_2d_mesh_device.shape[0] * bh_2d_mesh_device.shape[1] < num_devices:
         pytest.skip("Test requires more devices than are available on this platform")
 
     submesh = bh_2d_mesh_device.create_submesh(ttnn.MeshShape((mesh_rows, mesh_cols)))
-    tp = mesh_cols
-    cfg = QAB_KVA_PROJ_OVERLAP_CFG
+    mla_tp = mesh_cols
+    cfg = QAB_KVA_PROJ_SINGLE_DEVICE_OVERLAP_SPEC
 
     torch.manual_seed(42)
     q_a_raw = torch.randn(cfg.q_a_proj_shape, dtype=torch.bfloat16)
-    q_b_raw = torch.randn(cfg.q_b_proj_shape[0], cfg.q_b_proj_shape[1] * tp, dtype=torch.bfloat16)
+    q_b_raw = torch.randn(cfg.q_b_proj_shape[0], cfg.q_b_proj_shape[1] * mla_tp, dtype=torch.bfloat16)
     kv_raw = torch.randn(cfg.kv_a_proj_shape, dtype=torch.bfloat16)
 
     bdw = BlitzDecodeWeights(submesh)
+    logger.info("Building fused q_ab_proj + kv_a_proj weights ...")
     q_a, q_b, kv = bdw.get_tt_q_ab_proj_and_kv_a_proj_weights(q_a_raw, q_b_raw, kv_raw)
 
     replicate = ttnn.ReplicateTensorToMesh(submesh)
     composer = ttnn.ConcatMeshToTensor(submesh, dim=0)
+    single_device = submesh.create_submesh(ttnn.MeshShape((1, 1)))
 
     # -- Extract all three sub-tensors while fused buffer is alive -----------
+    logger.info("Extracting q_a_proj from fused buffer ...")
     q_a_out = _create_output_device_tensor(
         *q_a.tensor_shape, q_a.core_range_set, submesh, dtype=q_a.dtype, mesh_mapper=replicate
     )
@@ -173,6 +187,7 @@ def test_q_ab_proj_kv_a_proj_overlap(bh_2d_mesh_device, mesh_rows, mesh_cols):
     q_a_result = ttnn.to_torch(q_a_out, mesh_composer=composer)
     ttnn.deallocate(q_a_out)
 
+    logger.info("Extracting q_b_proj from fused buffer ...")
     q_b_out = _create_output_device_tensor(
         *q_b.tensor_shape, q_b.core_range_set, submesh, dtype=q_b.dtype, mesh_mapper=replicate
     )
@@ -180,6 +195,7 @@ def test_q_ab_proj_kv_a_proj_overlap(bh_2d_mesh_device, mesh_rows, mesh_cols):
     q_b_result = ttnn.to_torch(q_b_out, mesh_composer=composer)
     ttnn.deallocate(q_b_out)
 
+    logger.info("Extracting kv_a_proj from fused buffer ...")
     kv_out = _create_output_device_tensor(
         *kv.tensor_shape, kv.core_range_set, submesh, dtype=kv.dtype, mesh_mapper=replicate
     )
@@ -189,50 +205,46 @@ def test_q_ab_proj_kv_a_proj_overlap(bh_2d_mesh_device, mesh_rows, mesh_cols):
 
     ttnn.deallocate(q_a.fused_tensor)
 
-    # -- Build references (bfp8 round-trip) after fused buffer is freed ------
-    # q_a and kv_a are replicated: build a single reference and check all devices.
+    # -- Build references (bfp8 round-trip on single device) -----------------
+    logger.info("Building q_a_proj round-trip reference ...")
     q_a_ref = _get_roundtrip_reference(
         cfg.shuffle_q_a(q_a_raw),
         q_a.core_range_set,
-        submesh,
+        single_device,
         dtype=q_a.dtype,
-        mesh_mapper=replicate,
-        mesh_composer=composer,
     )
+    logger.info("Building kv_a_proj round-trip reference ...")
     kv_ref = _get_roundtrip_reference(
         cfg.shuffle_kv_a(kv_raw),
         kv.core_range_set,
-        submesh,
+        single_device,
         dtype=kv.dtype,
-        mesh_mapper=replicate,
-        mesh_composer=composer,
     )
 
-    # q_b is TP-sharded: build per-TP references.
-    per_device_q_b_w = cfg.q_b_proj_shape[1]
+    logger.info("Building q_b_proj per-TP round-trip references ...")
     q_b_tp_refs = []
-    for tp_idx in range(tp):
-        q_b_slice = q_b_raw[:, tp_idx * per_device_q_b_w : (tp_idx + 1) * per_device_q_b_w]
+    for tp_idx in range(mla_tp):
+        q_b_slice = cfg.get_q_b_slice(q_b_raw, tp_idx, mla_tp)
         ref = _get_roundtrip_reference(
             cfg.shuffle_q_b(q_b_slice),
             q_b.core_range_set,
-            submesh,
+            single_device,
             dtype=q_b.dtype,
-            mesh_mapper=replicate,
-            mesh_composer=composer,
         )
-        q_b_tp_refs.append(ref[: q_b.tensor_shape[0]])
+        q_b_tp_refs.append(ref)
+
+    ttnn.close_mesh_device(single_device)
 
     q_a_h = q_a.tensor_shape[0]
     q_b_h = q_b.tensor_shape[0]
     kv_h = kv.tensor_shape[0]
 
+    logger.info("Verifying per-device results ...")
     for device_idx in range(num_devices):
         tp_group = device_idx % mesh_cols
 
         q_a_slice = q_a_result[device_idx * q_a_h : (device_idx + 1) * q_a_h]
-        q_a_ref_slice = q_a_ref[device_idx * q_a_h : (device_idx + 1) * q_a_h]
-        assert torch.equal(q_a_slice, q_a_ref_slice), f"q_a_proj mismatch on device {device_idx}"
+        assert torch.equal(q_a_slice, q_a_ref), f"q_a_proj mismatch on device {device_idx}"
 
         q_b_slice = q_b_result[device_idx * q_b_h : (device_idx + 1) * q_b_h]
         assert torch.equal(
@@ -240,31 +252,59 @@ def test_q_ab_proj_kv_a_proj_overlap(bh_2d_mesh_device, mesh_rows, mesh_cols):
         ), f"q_b_proj mismatch on device {device_idx} (TP={tp_group})"
 
         kv_slice = kv_result[device_idx * kv_h : (device_idx + 1) * kv_h]
-        kv_ref_slice = kv_ref[device_idx * kv_h : (device_idx + 1) * kv_h]
-        assert torch.equal(kv_slice, kv_ref_slice), f"kv_a_proj mismatch on device {device_idx}"
+        assert torch.equal(kv_slice, kv_ref), f"kv_a_proj mismatch on device {device_idx}"
 
         logger.info(f"Device {device_idx} (TP={tp_group}): q_a_proj, q_b_proj, kv_a_proj overlap passed")
 
 
-def test_o_proj_gate_mm_rmsnorm_gamma_overlap(device):
+@pytest.mark.parametrize("mesh_rows, mesh_cols", [(4, 2), (1, 1)])
+@pytest.mark.parametrize(
+    "device_params",
+    [{"fabric_config": ttnn.FabricConfig.FABRIC_2D}],
+    indirect=True,
+)
+def test_o_proj_gate_mm_rmsnorm_gamma_overlap(bh_2d_mesh_device, mesh_rows, mesh_cols):
     """Verify all constituents of the o_proj + gate_mm + rmsnorm gamma overlap.
 
     Creates the fused tensor once via BlitzDecodeWeights, then extracts
     each sub-tensor with CopyToOutput and checks it against an
     independently preprocessed + dtype round-tripped reference.
+
+    For multi-device (4x2 mesh), mla_tp=2 across mesh columns:
+    o_proj is TP-sharded on the inner dim (8192), everything else is replicated.
+
+    Per-device layout::
+
+        o_proj (8192, 7168) as bfloat8_b
+          WIDTH_SHARDED on 112 cores, shard (8192, 64)
+
+        gate_mm (7168, 256) as bfloat16
+          WIDTH_SHARDED on 8 cores, shard (7168, 32)
+
+        attn_norm (1, 7168) as bfloat16, 1x32 tiles, on core (12, 9)
+        q_norm   (1, 1536) as bfloat16, 1x32 tiles, on core (12, 9)
+        kv_norm  (1, 512)  as bfloat16, 1x32 tiles, on core (0, 8)
+        ffn_norm (1, 7168) as bfloat16, 1x32 tiles, on core (12, 9)
     """
-    cfg = O_PROJ_GATE_MM_RMSNORM_GAMMA_OVERLAP_CFG
+    num_devices = mesh_rows * mesh_cols
+    if bh_2d_mesh_device.shape[0] * bh_2d_mesh_device.shape[1] < num_devices:
+        pytest.skip("Test requires more devices than are available on this platform")
+
+    submesh = bh_2d_mesh_device.create_submesh(ttnn.MeshShape((mesh_rows, mesh_cols)))
+    mla_tp = mesh_cols
+    cfg = O_PROJ_GATE_MM_RMSNORM_GAMMA_SINGLE_DEVICE_OVERLAP_SPEC
     tile_1x32 = ttnn.Tile([1, 32])
 
     torch.manual_seed(42)
-    o_proj_raw = torch.randn(cfg.o_proj_shape, dtype=torch.bfloat16)
+    o_proj_raw = torch.randn(cfg.o_proj_shape[0] * mla_tp, cfg.o_proj_shape[1], dtype=torch.bfloat16)
     gate_mm_raw = torch.randn(cfg.gate_mm_shape, dtype=torch.bfloat16)
     attn_norm_raw = torch.randn(cfg.attn_norm_shape, dtype=torch.bfloat16)
     q_norm_raw = torch.randn(cfg.q_norm_shape, dtype=torch.bfloat16)
     kv_norm_raw = torch.randn(cfg.kv_norm_shape, dtype=torch.bfloat16)
     ffn_norm_raw = torch.randn(cfg.ffn_norm_shape, dtype=torch.bfloat16)
 
-    bdw = BlitzDecodeWeights(device)
+    bdw = BlitzDecodeWeights(submesh)
+    logger.info("Building fused o_proj + gate_mm + rmsnorm gamma weights ...")
     o_proj, gate_mm, attn_norm_g, q_norm_g, kv_norm_g, ffn_norm_g = bdw.get_tt_o_proj_and_gate_mm_weights(
         o_proj_raw,
         gate_mm_raw,
@@ -274,16 +314,26 @@ def test_o_proj_gate_mm_rmsnorm_gamma_overlap(device):
         ffn_norm_raw,
     )
 
+    replicate = ttnn.ReplicateTensorToMesh(submesh)
+    composer = ttnn.ConcatMeshToTensor(submesh, dim=0)
+    single_device = submesh.create_submesh(ttnn.MeshShape((1, 1)))
+
     # -- Extract o_proj (BFP8) while fused buffer is alive -------------------
-    o_out = _create_output_device_tensor(*o_proj.tensor_shape, o_proj.core_range_set, device, dtype=o_proj.dtype)
+    logger.info("Extracting o_proj from fused buffer ...")
+    o_out = _create_output_device_tensor(
+        *o_proj.tensor_shape, o_proj.core_range_set, submesh, dtype=o_proj.dtype, mesh_mapper=replicate
+    )
     o_out = CopyToOutput.op(o_proj.fused_tensor, o_out, byte_offset=o_proj.byte_offset)
-    o_result = ttnn.to_torch(o_out)
+    o_result = ttnn.to_torch(o_out, mesh_composer=composer)
     ttnn.deallocate(o_out)
 
     # -- Extract gate_mm (BFP16) while fused buffer is alive -----------------
-    g_out = _create_output_device_tensor(*gate_mm.tensor_shape, gate_mm.core_range_set, device, dtype=gate_mm.dtype)
+    logger.info("Extracting gate_mm from fused buffer ...")
+    g_out = _create_output_device_tensor(
+        *gate_mm.tensor_shape, gate_mm.core_range_set, submesh, dtype=gate_mm.dtype, mesh_mapper=replicate
+    )
     g_out = CopyToOutput.op(gate_mm.fused_tensor, g_out, byte_offset=gate_mm.byte_offset)
-    g_result = ttnn.to_torch(g_out)
+    g_result = ttnn.to_torch(g_out, mesh_composer=composer)
     ttnn.deallocate(g_out)
 
     # -- Extract gammas (BFP16 1x32 tiles) while fused buffer is alive ------
@@ -297,176 +347,332 @@ def test_o_proj_gate_mm_rmsnorm_gamma_overlap(device):
         out = _create_output_device_tensor(
             *ov.tensor_shape,
             ov.core_range_set,
-            device,
+            submesh,
             dtype=ov.dtype,
             sharding=ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
             tile=tile_1x32,
+            mesh_mapper=replicate,
         )
+        logger.info(f"Extracting {name} from fused buffer ...")
         out = CopyToOutput.op(ov.fused_tensor, out, byte_offset=ov.byte_offset)
-        gamma_results[name] = ttnn.to_torch(out)
+        gamma_results[name] = ttnn.to_torch(out, mesh_composer=composer)
         ttnn.deallocate(out)
 
     ttnn.deallocate(o_proj.fused_tensor)
 
-    # -- Build references (dtype round-trip) after fused buffer is freed -----
-    o_ref = _get_roundtrip_reference(o_proj_raw, o_proj.core_range_set, device, dtype=o_proj.dtype)
-    assert torch.equal(o_result, o_ref), "o_proj overlap has mismatch"
-    logger.info("o_proj overlap comparison passed")
+    # -- Build references (dtype round-trip on single device) ----------------
+    logger.info("Building o_proj per-TP round-trip references ...")
+    per_device_o_h = cfg.o_proj_shape[0]
+    o_tp_refs = []
+    for tp_idx in range(mla_tp):
+        o_slice = o_proj_raw[tp_idx * per_device_o_h : (tp_idx + 1) * per_device_o_h, :]
+        ref = _get_roundtrip_reference(
+            o_slice,
+            o_proj.core_range_set,
+            single_device,
+            dtype=o_proj.dtype,
+        )
+        o_tp_refs.append(ref)
 
-    g_ref = _get_roundtrip_reference(gate_mm_raw, gate_mm.core_range_set, device, dtype=gate_mm.dtype)
-    assert torch.equal(g_result, g_ref), "gate_mm overlap has mismatch"
-    logger.info("gate_mm overlap comparison passed")
+    logger.info("Building gate_mm round-trip reference ...")
+    g_ref = _get_roundtrip_reference(
+        gate_mm_raw,
+        gate_mm.core_range_set,
+        single_device,
+        dtype=gate_mm.dtype,
+    )
 
+    gamma_refs = {}
     for name, raw, ov in [
         ("attn_norm", attn_norm_raw, attn_norm_g),
         ("q_norm", q_norm_raw, q_norm_g),
         ("kv_norm", kv_norm_raw, kv_norm_g),
         ("ffn_norm", ffn_norm_raw, ffn_norm_g),
     ]:
-        ref = _get_roundtrip_reference(
+        logger.info(f"Building {name} round-trip reference ...")
+        gamma_refs[name] = _get_roundtrip_reference(
             raw,
             ov.core_range_set,
-            device,
+            single_device,
             dtype=ov.dtype,
             sharding=ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
             tile=tile_1x32,
         )
-        assert torch.equal(gamma_results[name], ref), f"{name} overlap has mismatch"
-        logger.info(f"{name} overlap comparison passed")
+
+    ttnn.close_mesh_device(single_device)
+
+    o_h = o_proj.tensor_shape[0]
+    g_h = gate_mm.tensor_shape[0]
+
+    logger.info("Verifying per-device results ...")
+    for device_idx in range(num_devices):
+        tp_group = device_idx % mesh_cols
+
+        o_slice = o_result[device_idx * o_h : (device_idx + 1) * o_h]
+        assert torch.equal(o_slice, o_tp_refs[tp_group]), f"o_proj mismatch on device {device_idx} (TP={tp_group})"
+
+        g_slice = g_result[device_idx * g_h : (device_idx + 1) * g_h]
+        assert torch.equal(g_slice, g_ref), f"gate_mm mismatch on device {device_idx}"
+
+        for name in ["attn_norm", "q_norm", "kv_norm", "ffn_norm"]:
+            gamma_h = gamma_results[name].shape[0] // num_devices
+            gamma_slice = gamma_results[name][device_idx * gamma_h : (device_idx + 1) * gamma_h]
+            assert torch.equal(gamma_slice, gamma_refs[name]), f"{name} mismatch on device {device_idx}"
+
+        logger.info(f"Device {device_idx} (TP={tp_group}): o_proj, gate_mm, gammas overlap passed")
 
 
-def test_kv_b12_proj_overlap(device):
+@pytest.mark.parametrize("mesh_rows, mesh_cols", [(4, 2), (1, 1)])
+@pytest.mark.parametrize(
+    "device_params",
+    [{"fabric_config": ttnn.FabricConfig.FABRIC_2D}],
+    indirect=True,
+)
+def test_kv_b12_proj_overlap(bh_2d_mesh_device, mesh_rows, mesh_cols):
     """Verify both constituents of the kv_b1 + kv_b2 overlap.
 
     Creates the fused tensor once via BlitzDecodeWeights, then extracts
     each sub-tensor with CopyToOutput and checks it against an
     independently preprocessed + bfp8 round-tripped reference.
 
-    kv_b1_proj (8192, 512) is HEIGHT_SHARDED on the 8x8 Qnope grid.
-    kv_b2_proj (512, 8192) is pre-transposed, reshaped internally to
-    (8192, 512) and HEIGHT_SHARDED on the remaining 64 cores.
+    For multi-device (4x2 mesh), mla_tp=2 across mesh columns:
+    kv_b1_proj is TP-sharded on height (8192), kv_b2_proj on width (8192).
+
+    Per-device layout::
+
+        kv_b1_proj (8192, 512) as bfloat8_b
+          HEIGHT_SHARDED on 64 cores (8x8 Qnope grid), shard (128, 512)
+
+        kv_b2_proj (512, 8192) pre-transposed to (8192, 512) as bfloat8_b
+          HEIGHT_SHARDED on 64 cores, shard (128, 512)
+
+    For multi-device (4x2 mesh), mla_tp=2 across mesh columns:
+    both tensors are TP-sharded on the 8192 (heads) dim.
     """
-    cfg = KVB12_PROJ_OVERLAP_CFG
+    num_devices = mesh_rows * mesh_cols
+    if bh_2d_mesh_device.shape[0] * bh_2d_mesh_device.shape[1] < num_devices:
+        pytest.skip("Test requires more devices than are available on this platform")
+
+    submesh = bh_2d_mesh_device.create_submesh(ttnn.MeshShape((mesh_rows, mesh_cols)))
+    mla_tp = mesh_cols
+    cfg = KVB12_PROJ_SINGLE_DEVICE_OVERLAP_SPEC
 
     torch.manual_seed(42)
-    kv_b1_raw = torch.randn(*cfg.kv_b1_proj_shape, dtype=torch.bfloat16)
-    kv_b2_raw = torch.randn(*cfg.kv_b2_proj_shape, dtype=torch.bfloat16)
+    kv_b1_raw = torch.randn(cfg.kv_b1_proj_shape[0] * mla_tp, cfg.kv_b1_proj_shape[1], dtype=torch.bfloat16)
+    kv_b2_raw = torch.randn(cfg.kv_b2_proj_shape[0], cfg.kv_b2_proj_shape[1] * mla_tp, dtype=torch.bfloat16)
 
-    bdw = BlitzDecodeWeights(device)
+    bdw = BlitzDecodeWeights(submesh)
+    logger.info("Building fused kv_b1 + kv_b2 weights ...")
     kv_b1, kv_b2 = bdw.get_tt_kv_b12_proj_weights(kv_b1_raw, kv_b2_raw)
 
-    kv_b2_physical = cfg.shuffle_kv_b2(kv_b2_raw)
+    replicate = ttnn.ReplicateTensorToMesh(submesh)
+    composer = ttnn.ConcatMeshToTensor(submesh, dim=0)
+    single_device = submesh.create_submesh(ttnn.MeshShape((1, 1)))
 
     # -- Extract kv_b1 (HEIGHT_SHARDED, BFP8) while fused buffer is alive ----
+    logger.info("Extracting kv_b1_proj from fused buffer ...")
     kv_b1_out = _create_output_device_tensor(
         *kv_b1.tensor_shape,
         kv_b1.core_range_set,
-        device,
+        submesh,
         dtype=kv_b1.dtype,
         sharding=ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+        mesh_mapper=replicate,
     )
     kv_b1_out = CopyToOutput.op(kv_b1.fused_tensor, kv_b1_out, byte_offset=kv_b1.byte_offset)
-    kv_b1_result = ttnn.to_torch(kv_b1_out)
+    kv_b1_result = ttnn.to_torch(kv_b1_out, mesh_composer=composer)
     ttnn.deallocate(kv_b1_out)
 
     # -- Extract kv_b2 (HEIGHT_SHARDED, BFP8) while fused buffer is alive -----
+    logger.info("Extracting kv_b2_proj from fused buffer ...")
     kv_b2_out = _create_output_device_tensor(
         *cfg.kv_b1_proj_shape,
         kv_b2.core_range_set,
-        device,
+        submesh,
         dtype=kv_b2.dtype,
         sharding=ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+        mesh_mapper=replicate,
     )
     kv_b2_out = CopyToOutput.op(kv_b2.fused_tensor, kv_b2_out, byte_offset=kv_b2.byte_offset)
-    kv_b2_result = ttnn.to_torch(kv_b2_out)
+    kv_b2_result = ttnn.to_torch(kv_b2_out, mesh_composer=composer)
     ttnn.deallocate(kv_b2_out)
 
     ttnn.deallocate(kv_b1.fused_tensor)
 
-    # -- Build references (bfp8 round-trip) after fused buffer is freed ------
-    kv_b1_ref = _get_roundtrip_reference(
-        kv_b1_raw,
-        kv_b1.core_range_set,
-        device,
-        dtype=kv_b1.dtype,
-        sharding=ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
-    )
-    assert torch.equal(kv_b1_result, kv_b1_ref), "kv_b1_proj overlap has mismatch"
-    logger.info("kv_b1_proj overlap comparison passed")
+    # -- Build per-TP references (bfp8 round-trip on single device) ----------
+    per_device_b1_h = cfg.kv_b1_proj_shape[0]
+    per_device_b2_w = cfg.kv_b2_proj_shape[1]
 
-    kv_b2_ref = _get_roundtrip_reference(
-        kv_b2_physical,
-        kv_b2.core_range_set,
-        device,
-        dtype=kv_b2.dtype,
-        sharding=ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
-    )
-    assert torch.equal(kv_b2_result, kv_b2_ref), "kv_b2_proj overlap has mismatch"
-    logger.info("kv_b2_proj overlap comparison passed")
+    kv_b1_tp_refs = []
+    kv_b2_tp_refs = []
+    for tp_idx in range(mla_tp):
+        logger.info(f"Building kv_b1_proj round-trip reference (TP={tp_idx}) ...")
+        b1_slice = kv_b1_raw[tp_idx * per_device_b1_h : (tp_idx + 1) * per_device_b1_h, :]
+        ref = _get_roundtrip_reference(
+            b1_slice,
+            kv_b1.core_range_set,
+            single_device,
+            dtype=kv_b1.dtype,
+            sharding=ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+        )
+        kv_b1_tp_refs.append(ref)
+
+        logger.info(f"Building kv_b2_proj round-trip reference (TP={tp_idx}) ...")
+        b2_slice = kv_b2_raw[:, tp_idx * per_device_b2_w : (tp_idx + 1) * per_device_b2_w]
+        b2_physical = cfg.shuffle_kv_b2(b2_slice)
+        ref = _get_roundtrip_reference(
+            b2_physical,
+            kv_b2.core_range_set,
+            single_device,
+            dtype=kv_b2.dtype,
+            sharding=ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+        )
+        kv_b2_tp_refs.append(ref)
+
+    ttnn.close_mesh_device(single_device)
+
+    kv_b1_h = kv_b1.tensor_shape[0]
+
+    logger.info("Verifying per-device results ...")
+    for device_idx in range(num_devices):
+        tp_group = device_idx % mesh_cols
+
+        b1_slice = kv_b1_result[device_idx * kv_b1_h : (device_idx + 1) * kv_b1_h]
+        assert torch.equal(
+            b1_slice, kv_b1_tp_refs[tp_group]
+        ), f"kv_b1_proj mismatch on device {device_idx} (TP={tp_group})"
+
+        b2_slice = kv_b2_result[device_idx * kv_b1_h : (device_idx + 1) * kv_b1_h]
+        assert torch.equal(
+            b2_slice, kv_b2_tp_refs[tp_group]
+        ), f"kv_b2_proj mismatch on device {device_idx} (TP={tp_group})"
+
+        logger.info(f"Device {device_idx} (TP={tp_group}): kv_b1_proj, kv_b2_proj overlap passed")
 
 
-def test_gate_up_proj_overlap(device):
+@pytest.mark.parametrize("mesh_rows, mesh_cols", [(4, 2), (1, 1)])
+@pytest.mark.parametrize(
+    "device_params",
+    [{"fabric_config": ttnn.FabricConfig.FABRIC_2D}],
+    indirect=True,
+)
+def test_gate_up_proj_overlap(bh_2d_mesh_device, mesh_rows, mesh_cols):
     """Verify both constituents of the gate + up projection overlap.
 
     Creates the fused tensor once via BlitzDecodeWeights, then extracts
     each sub-tensor with CopyToOutput and checks it against an
     independently preprocessed + bfp4 round-tripped reference.
 
-    Both gate_proj and up_proj are block-sharded (stacked HEIGHT_SHARDED)
-    on 64 non-rectangular compute cores each.
+    For multi-device (4x2 mesh), moe_tp=8 across all devices:
+    both gate_proj and up_proj are TP-sharded on the outer dim (N=2048,
+    per-device N=256).
+
+    Per-device layout::
+
+        gate_proj (7168, 256) as bfloat4_b, block-sharded
+          stacked (57344, 32), shard (896, 32), 64 A cores
+
+        up_proj (7168, 256) as bfloat4_b, block-sharded
+          stacked (57344, 32), shard (896, 32), 64 B cores
+
+        combined: 128 cores, HEIGHT_SHARDED (114688, 32)
     """
-    cfg = GATE_UP_PROJ_OVERLAP_CFG
+    num_devices = mesh_rows * mesh_cols
+    if bh_2d_mesh_device.shape[0] * bh_2d_mesh_device.shape[1] < num_devices:
+        pytest.skip("Test requires more devices than are available on this platform")
+
+    submesh = bh_2d_mesh_device.create_submesh(ttnn.MeshShape((mesh_rows, mesh_cols)))
+    moe_tp = num_devices
+    cfg = GATE_UP_PROJ_SINGLE_DEVICE_OVERLAP_SPEC
 
     torch.manual_seed(42)
-    gate_raw = torch.randn(cfg.gate_proj_shape, dtype=torch.bfloat16)
-    up_raw = torch.randn(cfg.up_proj_shape, dtype=torch.bfloat16)
+    gate_raw = torch.randn(cfg.gate_proj_shape[0], cfg.gate_proj_shape[1] * moe_tp, dtype=torch.bfloat16)
+    up_raw = torch.randn(cfg.up_proj_shape[0], cfg.up_proj_shape[1] * moe_tp, dtype=torch.bfloat16)
+    down_raw = torch.randn(256 * moe_tp, 7168, dtype=torch.bfloat16)
 
-    bdw = BlitzDecodeWeights(device)
-    gate, up = bdw.get_tt_gate_up_proj_weights(gate_raw, up_raw)
+    replicate = ttnn.ReplicateTensorToMesh(submesh)
+    composer = ttnn.ConcatMeshToTensor(submesh, dim=0)
+    single_device = submesh.create_submesh(ttnn.MeshShape((1, 1)))
+
+    bdw = BlitzDecodeWeights(submesh)
+    logger.info("Building fused gate + up proj weights ...")
+    gate, up, _ = bdw.get_tt_moe_shared_expert_weights(gate_raw, up_raw, down_raw)
 
     # -- Extract gate (block-sharded BFP4) while fused buffer is alive -------
+    logger.info("Extracting gate_proj from fused buffer ...")
     gate_out = _create_output_device_tensor(
-        *gate.tensor_shape,
+        *cfg.stacked_shape,
         gate.core_range_set,
-        device,
+        submesh,
         dtype=gate.dtype,
         sharding=ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+        mesh_mapper=replicate,
     )
     gate_out = CopyToOutput.op(gate.fused_tensor, gate_out, byte_offset=gate.byte_offset)
-    gate_result = ttnn.to_torch(gate_out)
+    gate_result = ttnn.to_torch(gate_out, mesh_composer=composer)
     ttnn.deallocate(gate_out)
 
     # -- Extract up (block-sharded BFP4) while fused buffer is alive ---------
+    logger.info("Extracting up_proj from fused buffer ...")
     up_out = _create_output_device_tensor(
-        *up.tensor_shape,
+        *cfg.stacked_shape,
         up.core_range_set,
-        device,
+        submesh,
         dtype=up.dtype,
         sharding=ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+        mesh_mapper=replicate,
     )
     up_out = CopyToOutput.op(up.fused_tensor, up_out, byte_offset=up.byte_offset)
-    up_result = ttnn.to_torch(up_out)
+    up_result = ttnn.to_torch(up_out, mesh_composer=composer)
     ttnn.deallocate(up_out)
 
     ttnn.deallocate(gate.fused_tensor)
 
-    # -- Build references (bfp4 round-trip) after fused buffer is freed ------
-    gate_ref = _get_roundtrip_reference(
-        cfg.reshuffle_block_to_height_sharded(gate_raw),
-        gate.core_range_set,
-        device,
-        dtype=gate.dtype,
-        sharding=ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
-    )
-    assert torch.equal(gate_result, gate_ref), "gate_proj overlap has mismatch"
-    logger.info("gate_proj overlap comparison passed")
+    # -- Build per-TP references (bfp4 round-trip on single device) ----------
+    per_device_n = cfg.gate_proj_shape[1]
 
-    up_ref = _get_roundtrip_reference(
-        cfg.reshuffle_block_to_height_sharded(up_raw),
-        up.core_range_set,
-        device,
-        dtype=up.dtype,
-        sharding=ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
-    )
-    assert torch.equal(up_result, up_ref), "up_proj overlap has mismatch"
-    logger.info("up_proj overlap comparison passed")
+    logger.info("Building per-TP gate_proj round-trip references ...")
+    gate_tp_refs = []
+    for tp_idx in range(moe_tp):
+        gate_slice = gate_raw[:, tp_idx * per_device_n : (tp_idx + 1) * per_device_n]
+        ref = _get_roundtrip_reference(
+            cfg.reshuffle_block_to_height_sharded(gate_slice, cfg.gate_core_range_set),
+            gate.core_range_set,
+            single_device,
+            dtype=gate.dtype,
+            sharding=ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+        )
+        gate_tp_refs.append(ref)
+
+    logger.info("Building per-TP up_proj round-trip references ...")
+    up_tp_refs = []
+    for tp_idx in range(moe_tp):
+        up_slice = up_raw[:, tp_idx * per_device_n : (tp_idx + 1) * per_device_n]
+        ref = _get_roundtrip_reference(
+            cfg.reshuffle_block_to_height_sharded(up_slice, cfg.up_core_range_set),
+            up.core_range_set,
+            single_device,
+            dtype=up.dtype,
+            sharding=ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+        )
+        up_tp_refs.append(ref)
+
+    ttnn.close_mesh_device(single_device)
+
+    # -- Verify per-device ---------------------------------------------------
+    gate_h = cfg.stacked_shape[0]
+    up_h = cfg.stacked_shape[0]
+
+    logger.info("Verifying per-device results ...")
+    for device_idx in range(num_devices):
+        tp_group = device_idx
+
+        gate_slice = gate_result[device_idx * gate_h : (device_idx + 1) * gate_h]
+        assert torch.equal(
+            gate_slice, gate_tp_refs[tp_group]
+        ), f"gate_proj mismatch on device {device_idx} (TP={tp_group})"
+
+        up_slice = up_result[device_idx * up_h : (device_idx + 1) * up_h]
+        assert torch.equal(up_slice, up_tp_refs[tp_group]), f"up_proj mismatch on device {device_idx} (TP={tp_group})"
+
+        logger.info(f"Device {device_idx} (TP={tp_group}): gate_proj, up_proj overlap passed")

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_mlp.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_mlp.py
@@ -18,9 +18,9 @@ from loguru import logger
 
 import ttnn
 from models.common.utility_functions import comp_pcc, skip_for_wormhole_b0
+from models.demos.deepseek_v3_b1.blitz_decode_weights import BlitzDecodeWeights
 from models.demos.deepseek_v3_b1.fused_ops.mlp.op import MlpOp
 from models.demos.deepseek_v3_b1.tests.unit_tests.test_moe import (
-    create_expert_matmul_tensors,
     create_shared_expert_tensors,
     extract_routed_expert_output,
 )
@@ -156,49 +156,59 @@ def create_mlp_tensors(device, mesh_mapper=None):
         **from_torch_kwargs,
     )
 
-    # ── Expert weight tensors (num_experts=1 for MLP) ──
-    (
-        gate_proj_weights,
-        gate_proj_output,
-        expert_weights_dict,
-        gate_proj_expert_tensors,
-    ) = create_expert_matmul_tensors(
-        device=device,
-        K=gate_proj_K,
-        N=gate_proj_N,
-        num_experts=num_experts,
-        compute_core_grid=gate_proj_core_ranges,
-        num_cores=num_gate_proj_cores,
-        tile_h=M,
-        tile_w=32,
-        dtype=ttnn.bfloat4_b,
-        seed=0,
-        mesh_mapper=mesh_mapper,
-    )
-
-    # up_proj matmul tensors
-    (
-        up_proj_weights,
-        up_proj_mm_out_tensor,
-        up_proj_weights_dict,
-        up_proj_expert_tensors,
-    ) = create_expert_matmul_tensors(
-        device=device,
-        K=gate_proj_K,
-        N=gate_proj_N,
-        num_experts=num_experts,
-        compute_core_grid=gate_proj_core_ranges,
-        num_cores=num_gate_proj_cores,
-        tile_h=M,
-        tile_w=32,
-        dtype=ttnn.bfloat4_b,
-        seed=256,
-        mesh_mapper=mesh_mapper,
-    )
-
-    # Fused output tensor
+    # ── Compute dimensions for expert DRAM matmul ──
     num_banks = device.dram_grid_size().x
-    gate_proj_N_padded = ((gate_proj_N + num_banks * 32 - 1) // (num_banks * 32)) * (num_banks * 32)
+    tile_w = 32
+    gate_proj_N_padded = ((gate_proj_N + num_banks * tile_w - 1) // (num_banks * tile_w)) * (num_banks * tile_w)
+    down_proj_K = gate_proj_N
+    down_proj_N = K
+    down_proj_N_padded = ((down_proj_N + num_banks * tile_w - 1) // (num_banks * tile_w)) * (num_banks * tile_w)
+    per_core_gate_N = gate_proj_N_padded // num_banks
+    per_core_down_proj_N = down_proj_N_padded // num_banks
+
+    # ── Generate expert weights for validation ──
+    def _gen_experts(num_exp, K_dim, N_padded, seed):
+        stacked = torch.zeros(num_exp, K_dim, N_padded, dtype=torch.bfloat16)
+        validation = {}
+        for i in range(num_exp):
+            torch.manual_seed(seed + i)
+            w = torch.randn(1, 1, K_dim, N_padded).clamp(-2, 2).bfloat16()
+            validation[i] = w.clone()
+            stacked[i] = w.reshape(K_dim, N_padded)
+        return stacked, validation
+
+    gate_stacked, expert_weights_dict = _gen_experts(num_experts, gate_proj_K, gate_proj_N_padded, seed=0)
+    up_stacked, up_proj_weights_dict = _gen_experts(num_experts, gate_proj_K, gate_proj_N_padded, seed=256)
+    down_stacked, down_proj_weights_dict = _gen_experts(num_experts, down_proj_K, down_proj_N_padded, seed=512)
+
+    # ── Upload expert weights via BlitzDecodeWeights ──
+    bdw = BlitzDecodeWeights(device)
+    gate_proj_expert_tensors, up_proj_expert_tensors, down_proj_expert_tensors = bdw.get_tt_moe_routed_expert_weights(
+        gate_stacked, up_stacked, down_stacked
+    )
+    gate_proj_weights = gate_proj_expert_tensors[0]
+    up_proj_weights = up_proj_expert_tensors[0]
+    down_proj_weights = down_proj_expert_tensors[0]
+
+    # ── Create matmul output tensors (WIDTH_SHARDED in L1) ──
+    def _create_dram_mm_output(N_pad, per_core_N_val):
+        out_tile = ttnn.Tile([M, tile_w])
+        out_shard = ttnn.ShardSpec(gate_proj_core_ranges, [M, per_core_N_val], ttnn.ShardOrientation.ROW_MAJOR)
+        out_mem = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.WIDTH_SHARDED, ttnn.BufferType.L1, out_shard)
+        return ttnn.from_torch(
+            torch.zeros(1, 1, M, N_pad).bfloat16(),
+            dtype=ttnn.bfloat16,
+            layout=ttnn.TILE_LAYOUT,
+            device=device,
+            memory_config=out_mem,
+            tile=out_tile,
+            **from_torch_kwargs,
+        )
+
+    gate_proj_output = _create_dram_mm_output(gate_proj_N_padded, per_core_gate_N)
+    up_proj_mm_out_tensor = _create_dram_mm_output(gate_proj_N_padded, per_core_gate_N)
+
+    # Fused output tensor (same layout as gate/up output)
     fused_output_tensor = ttnn.from_torch(
         torch.zeros([1, 1, M, gate_proj_N_padded]).bfloat16().float(),
         dtype=ttnn.bfloat16,
@@ -209,10 +219,7 @@ def create_mlp_tensors(device, mesh_mapper=None):
         **from_torch_kwargs,
     )
 
-    # down_proj tensors
-    down_proj_K = gate_proj_N
-    down_proj_N = K
-
+    # down_proj intermediate tensors
     down_proj_gather_shard_spec = ttnn.ShardSpec(
         input_core_grid,
         (M, gate_proj_N_padded),
@@ -249,29 +256,7 @@ def create_mlp_tensors(device, mesh_mapper=None):
         **from_torch_kwargs,
     )
 
-    # down_proj expert weights and output
-    (
-        down_proj_weights,
-        down_proj_output,
-        down_proj_weights_dict,
-        down_proj_expert_tensors,
-    ) = create_expert_matmul_tensors(
-        device=device,
-        K=down_proj_K,
-        N=down_proj_N,
-        num_experts=num_experts,
-        compute_core_grid=gate_proj_core_ranges,
-        num_cores=num_gate_proj_cores,
-        tile_h=M,
-        tile_w=32,
-        dtype=ttnn.bfloat4_b,
-        seed=512,
-        mesh_mapper=mesh_mapper,
-    )
-
-    # Final output tensor
-    down_proj_N_padded = ((down_proj_N + num_banks * 32 - 1) // (num_banks * 32)) * (num_banks * 32)
-    per_core_down_proj_N = down_proj_N_padded // num_banks
+    down_proj_output = _create_dram_mm_output(down_proj_N_padded, per_core_down_proj_N)
 
     final_output_width_per_core = 32 * 32
     final_output_total_width = final_output_width_per_core * num_gate_proj_cores

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_mlp.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_mlp.py
@@ -397,7 +397,8 @@ def test_mlp_fused(device):
         rmsnorm_gamma_tensor=r["ttnn_rmsnorm_gamma"],
         # Shared expert tensors
         shared_residual_mcast_src_tensor=r["ttnn_residual_mcast_src"],
-        shared_gate_up_weights_tensor=s["ttnn_gate_up_weights"],
+        shared_gate_weights_overlapped=s["shared_gate_weights_overlapped"],
+        shared_up_weights_overlapped=s["shared_up_weights_overlapped"],
         shared_residual_mcast_dst_tensor=r["ttnn_residual_mcast_dst"],
         shared_down_mcast_dst_tensor=s["ttnn_down_mcast_dst"],
         shared_down_weights_tensor=s["ttnn_down_weights"],
@@ -571,7 +572,8 @@ def test_mlp_fused_with_reduce(bh_2d_mesh_device):
         rmsnorm_gamma_tensor=r["ttnn_rmsnorm_gamma"],
         # Shared expert tensors
         shared_residual_mcast_src_tensor=r["ttnn_residual_mcast_src"],
-        shared_gate_up_weights_tensor=s["ttnn_gate_up_weights"],
+        shared_gate_weights_overlapped=s["shared_gate_weights_overlapped"],
+        shared_up_weights_overlapped=s["shared_up_weights_overlapped"],
         shared_residual_mcast_dst_tensor=r["ttnn_residual_mcast_dst"],
         shared_down_mcast_dst_tensor=s["ttnn_down_mcast_dst"],
         shared_down_weights_tensor=s["ttnn_down_weights"],

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_mlp.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_mlp.py
@@ -599,21 +599,29 @@ def test_mlp_fused_with_reduce(bh_2d_mesh_device):
     logger.info(f"Fused MLP with reduce: {num_iterations} iterations completed")
 
     # ── Verify results ──
-    # Compute golden for a single device (all devices run identical MLP, no routing)
-    torch_expected_single = MlpOp.golden(
-        r["torch_input"],
-        shared_gate_weights=s["torch_gate_weights"],
-        shared_up_weights=s["torch_up_weights"],
-        shared_down_weights=s["torch_down_weights"],
-        gate_proj_weights=r["expert_weights_dict"][0],
-        up_proj_weights=r["up_proj_weights_dict"][0],
-        down_proj_weights=r["down_proj_weights_dict"][0],
-        rmsnorm_gamma=r["torch_rmsnorm_gamma"],
-        rmsnorm_epsilon=1e-6,
-    )
+    # Compute per-device golden with per-device TP shards of shared expert weights
+    K_down = s["K_down"]
+    expected_final_outputs = []
+    for device_idx in range(num_devices):
+        shared_gate_shard = s["torch_gate_weights"][:, device_idx * K_down : (device_idx + 1) * K_down]
+        shared_up_shard = s["torch_up_weights"][:, device_idx * K_down : (device_idx + 1) * K_down]
+        shared_down_shard = s["torch_down_weights"][device_idx * K_down : (device_idx + 1) * K_down, :]
 
-    # Expected reduce output = sum of all 8 identical device outputs
-    expected_reduce_output = torch_expected_single * num_devices
+        device_expected = MlpOp.golden(
+            r["torch_input"],
+            shared_gate_weights=shared_gate_shard,
+            shared_up_weights=shared_up_shard,
+            shared_down_weights=shared_down_shard,
+            gate_proj_weights=r["expert_weights_dict"][0],
+            up_proj_weights=r["up_proj_weights_dict"][0],
+            down_proj_weights=r["down_proj_weights_dict"][0],
+            rmsnorm_gamma=r["torch_rmsnorm_gamma"],
+            rmsnorm_epsilon=1e-6,
+        )
+        expected_final_outputs.append(device_expected)
+
+    # Expected reduce output = sum of all per-device outputs (each with unique TP shard)
+    expected_reduce_output = sum(expected_final_outputs)
 
     # Get actual reduce output from ROOT1 device
     reduce_output_torch = ttnn.to_torch(

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_moe.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_moe.py
@@ -86,8 +86,7 @@ def create_shared_expert_tensors(device, M, K_gate, mcast_grid, mesh_mapper=None
     gate_full = torch_gate_weights.repeat(1, moe_tp) if moe_tp > 1 else torch_gate_weights
     up_full = torch_up_weights.repeat(1, moe_tp) if moe_tp > 1 else torch_up_weights
     down_full = torch_down_weights.repeat(moe_tp, 1) if moe_tp > 1 else torch_down_weights
-    gate_ov, _up_ov, ttnn_down_weights = bdw.get_tt_moe_shared_expert_weights(gate_full, up_full, down_full)
-    ttnn_gate_up_weights = gate_ov.fused_tensor
+    gate_ov, up_ov, ttnn_down_weights = bdw.get_tt_moe_shared_expert_weights(gate_full, up_full, down_full)
 
     # ── Output ──
     out_shard = ttnn.ShardSpec(sender_core_grid, (M, N), ttnn.ShardOrientation.ROW_MAJOR)
@@ -241,7 +240,8 @@ def create_shared_expert_tensors(device, M, K_gate, mcast_grid, mesh_mapper=None
     return {
         # TTNN tensors
         "ttnn_activation": ttnn_activation,
-        "ttnn_gate_up_weights": ttnn_gate_up_weights,
+        "shared_gate_weights_overlapped": gate_ov,
+        "shared_up_weights_overlapped": up_ov,
         "ttnn_down_weights": ttnn_down_weights,
         "ttnn_output": ttnn_output,
         "ttnn_down_mcast_dst": ttnn_down_mcast_dst,
@@ -888,7 +888,8 @@ def test_moe_fused(device, use_hardcoded_expert_index):
         rmsnorm_gamma_tensor=r["ttnn_rmsnorm_gamma"],
         # Shared expert tensors
         shared_residual_mcast_src_tensor=r["ttnn_residual_mcast_src"],
-        shared_gate_up_weights_tensor=s["ttnn_gate_up_weights"],
+        shared_gate_weights_overlapped=s["shared_gate_weights_overlapped"],
+        shared_up_weights_overlapped=s["shared_up_weights_overlapped"],
         shared_residual_mcast_dst_tensor=r["ttnn_residual_mcast_dst"],
         shared_down_mcast_dst_tensor=s["ttnn_down_mcast_dst"],
         shared_down_weights_tensor=s["ttnn_down_weights"],
@@ -1094,7 +1095,8 @@ def test_moe_fused_with_reduce(bh_2d_mesh_device, use_hardcoded_expert_index):
         rmsnorm_gamma_tensor=r["ttnn_rmsnorm_gamma"],
         # Shared expert tensors
         shared_residual_mcast_src_tensor=r["ttnn_residual_mcast_src"],
-        shared_gate_up_weights_tensor=s["ttnn_gate_up_weights"],
+        shared_gate_weights_overlapped=s["shared_gate_weights_overlapped"],
+        shared_up_weights_overlapped=s["shared_up_weights_overlapped"],
         shared_residual_mcast_dst_tensor=r["ttnn_residual_mcast_dst"],
         shared_down_mcast_dst_tensor=s["ttnn_down_mcast_dst"],
         shared_down_weights_tensor=s["ttnn_down_weights"],

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_moe.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_moe.py
@@ -18,104 +18,10 @@ from loguru import logger
 
 import ttnn
 from models.common.utility_functions import comp_pcc, skip_for_wormhole_b0
+from models.demos.deepseek_v3_b1.blitz_decode_weights import BlitzDecodeWeights
 from models.demos.deepseek_v3_b1.fused_ops.down_proj.op import DownProj
 from models.demos.deepseek_v3_b1.fused_ops.moe.op import MoeOp
 from models.demos.deepseek_v3_b1.fused_ops.shared_expert.op import SharedExpertOp
-from models.demos.deepseek_v3_b1.tests.unit_tests.test_dram_streaming_matmul import shuffle_tensor_tiles
-
-
-# ============================================================================
-# Helper: create DRAM streaming expert weight tensors
-# ============================================================================
-def create_expert_matmul_tensors(
-    device,
-    K,
-    N,
-    num_experts,
-    compute_core_grid,
-    num_cores,
-    tile_h=1,
-    tile_w=32,
-    dtype=ttnn.bfloat4_b,
-    seed=0,
-    mesh_mapper=None,
-):
-    """
-    Create DRAM streaming matmul weight and output tensors.
-
-    Returns:
-        Tuple of:
-        - weights_tensor: First expert tensor (kernel uses base addr + offset for others)
-        - output_tensor: Output tensor for matmul result
-        - expert_weights_for_validation: Dict of expert weights for golden validation
-        - expert_tensors: List of all expert tensors (must be kept alive to prevent deallocation)
-    """
-    num_banks = device.dram_grid_size().x
-
-    # Pad N to be divisible by num_banks * tile_w
-    N_padded = ((N + num_banks * tile_w - 1) // (num_banks * tile_w)) * (num_banks * tile_w)
-    per_core_N = N_padded // num_banks
-
-    logger.info(f"DRAM MM: K={K}, N={N}, N_padded={N_padded}, per_core_N={per_core_N}, num_experts={num_experts}")
-
-    # DRAM shard spec for weights
-    in1_shard_shape = [K, per_core_N]
-    in1_shard_grid = ttnn.CoreCoord(device.dram_grid_size().x - 1, device.dram_grid_size().y - 1)
-    in1_shard_grid = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), in1_shard_grid)})
-    in1_shard_spec = ttnn.ShardSpec(in1_shard_grid, in1_shard_shape, ttnn.ShardOrientation.ROW_MAJOR)
-    in1_memory_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.WIDTH_SHARDED, ttnn.BufferType.DRAM, in1_shard_spec)
-
-    # Upload experts as separate contiguous tensors
-    logger.info(f"Uploading {num_experts} experts as separate contiguous tensors...")
-    expert_tensors = []
-    expert_weights_for_validation = {}
-
-    for expert_idx in range(num_experts):
-        torch.manual_seed(seed + expert_idx)
-        expert_weights = torch.randn(1, 1, K, N_padded).clamp(-2, 2).bfloat16()
-
-        expert_weights_for_validation[expert_idx] = expert_weights.clone()
-
-        expert_shuffled = shuffle_tensor_tiles(expert_weights.reshape(1, K, N_padded), tile_w, num_banks)
-        expert_shuffled = expert_shuffled.reshape(1, 1, K, N_padded)
-
-        expert_t = ttnn.from_torch(
-            expert_shuffled.contiguous(),
-            dtype=dtype,
-            layout=ttnn.TILE_LAYOUT,
-            device=device,
-            memory_config=in1_memory_config,
-            mesh_mapper=mesh_mapper,
-        )
-        expert_tensors.append(expert_t)
-
-        del expert_shuffled
-
-        if (expert_idx + 1) % 32 == 0:
-            logger.info(f"  Uploaded {expert_idx + 1}/{num_experts} experts")
-
-    logger.info(f"All experts uploaded.")
-
-    # Use first expert tensor for the op
-    weights_tensor = expert_tensors[0]
-
-    # Output tensor - WIDTH_SHARDED in L1
-    out_tile = ttnn.Tile([tile_h, tile_w])
-    out_shard_shape = [tile_h, per_core_N]
-    out_shard_spec = ttnn.ShardSpec(compute_core_grid, out_shard_shape, ttnn.ShardOrientation.ROW_MAJOR)
-    out_memory_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.WIDTH_SHARDED, ttnn.BufferType.L1, out_shard_spec)
-
-    output_tensor = ttnn.from_torch(
-        torch.zeros(1, 1, tile_h, N_padded).bfloat16(),
-        dtype=ttnn.bfloat16,
-        layout=ttnn.TILE_LAYOUT,
-        device=device,
-        memory_config=out_memory_config,
-        tile=out_tile,
-        mesh_mapper=mesh_mapper,
-    )
-
-    return weights_tensor, output_tensor, expert_weights_for_validation, expert_tensors
 
 
 # ============================================================================
@@ -140,16 +46,12 @@ def create_shared_expert_tensors(device, M, K_gate, mcast_grid, mesh_mapper=None
     K_down = n_parallel * 32  # 256
     N_per_core = 64
     N = N_per_core * DownProj.NUM_MATMUL_CORES  # 7168
-    k_per_core = (K_gate // 32) // k_parallel
-    weights_dtype = ttnn.bfloat8_b
 
     a_tile = ttnn.Tile([M, 32])
-    b_tile = ttnn.Tile([32, 32])
     out_tile = ttnn.Tile([M, 32])
 
     # Core grids
-    a_cores_list, b_cores_list = SharedExpertOp.build_ab_grids()
-    compute_cores_list = a_cores_list + b_cores_list
+    compute_cores_list = sum(SharedExpertOp.build_ab_grids(), [])
     mcast_gather_core = DownProj.MCAST_GATHER_CORE
     sender_core_grid = ttnn.CoreRangeSet([ttnn.CoreRange(mcast_gather_core, mcast_gather_core)])
     matmul_core_grid = DownProj.build_matmul_core_grid()
@@ -177,49 +79,15 @@ def create_shared_expert_tensors(device, M, K_gate, mcast_grid, mesh_mapper=None
         **from_torch_kwargs,
     )
 
-    # ── Gate/Up weights (stacked, HEIGHT_SHARDED on 128 compute cores) ──
-    weight_shards = []
-    for i in range(len(a_cores_list)):
-        k_idx = i // n_parallel
-        n_idx = i % n_parallel
-        k_start = k_idx * k_per_core * 32
-        k_end = k_start + k_per_core * 32
-        n_start, n_end = n_idx * 32, (n_idx + 1) * 32
-        weight_shards.append(torch_gate_weights[k_start:k_end, n_start:n_end])
-    for i in range(len(b_cores_list)):
-        k_idx = i // n_parallel
-        n_idx = i % n_parallel
-        k_start = k_idx * k_per_core * 32
-        k_end = k_start + k_per_core * 32
-        n_start, n_end = n_idx * 32, (n_idx + 1) * 32
-        weight_shards.append(torch_up_weights[k_start:k_end, n_start:n_end])
-    torch_gate_up_stacked = torch.cat(weight_shards, dim=0)
-
     compute_core_grid = ttnn.CoreRangeSet([ttnn.CoreRange(c, c) for c in compute_cores_list])
-    gu_shard = ttnn.ShardSpec(compute_core_grid, (k_per_core * 32, 32), ttnn.ShardOrientation.ROW_MAJOR)
-    gu_mem = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, gu_shard)
-    ttnn_gate_up_weights = ttnn.from_torch(
-        torch_gate_up_stacked,
-        dtype=weights_dtype,
-        layout=ttnn.TILE_LAYOUT,
-        device=device,
-        memory_config=gu_mem,
-        tile=b_tile,
-        **from_torch_kwargs,
-    )
 
-    # ── Down proj weights ──
-    down_shard = ttnn.ShardSpec(matmul_core_grid, (K_down, N_per_core), ttnn.ShardOrientation.ROW_MAJOR)
-    down_mem = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.WIDTH_SHARDED, ttnn.BufferType.L1, down_shard)
-    ttnn_down_weights = ttnn.from_torch(
-        torch_down_weights,
-        dtype=weights_dtype,
-        layout=ttnn.TILE_LAYOUT,
-        device=device,
-        memory_config=down_mem,
-        tile=b_tile,
-        **from_torch_kwargs,
-    )
+    bdw = BlitzDecodeWeights(device)
+    moe_tp = bdw.moe_tp
+    gate_full = torch_gate_weights.repeat(1, moe_tp) if moe_tp > 1 else torch_gate_weights
+    up_full = torch_up_weights.repeat(1, moe_tp) if moe_tp > 1 else torch_up_weights
+    down_full = torch_down_weights.repeat(moe_tp, 1) if moe_tp > 1 else torch_down_weights
+    gate_ov, _up_ov, ttnn_down_weights = bdw.get_tt_moe_shared_expert_weights(gate_full, up_full, down_full)
+    ttnn_gate_up_weights = gate_ov.fused_tensor
 
     # ── Output ──
     out_shard = ttnn.ShardSpec(sender_core_grid, (M, N), ttnn.ShardOrientation.ROW_MAJOR)
@@ -695,48 +563,60 @@ def create_routed_expert_tensors(device, use_hardcoded_expert_index, mesh_mapper
         **from_torch_kwargs,
     )
 
-    (
-        gate_proj_weights,
-        gate_proj_output,
-        expert_weights_dict,
-        gate_proj_expert_tensors,
-    ) = create_expert_matmul_tensors(
-        device=device,
-        K=gate_proj_K,
-        N=gate_proj_N,
-        num_experts=num_experts,
-        compute_core_grid=gate_proj_core_ranges,
-        num_cores=num_gate_proj_cores,
-        tile_h=M,
-        tile_w=32,
-        dtype=ttnn.bfloat4_b,
-        seed=0,
-        mesh_mapper=mesh_mapper,
-    )
-
-    # up_proj matmul tensors
-    (
-        up_proj_weights,
-        up_proj_mm_out_tensor,
-        up_proj_weights_dict,
-        up_proj_expert_tensors,
-    ) = create_expert_matmul_tensors(
-        device=device,
-        K=gate_proj_K,
-        N=gate_proj_N,
-        num_experts=num_experts,
-        compute_core_grid=gate_proj_core_ranges,
-        num_cores=num_gate_proj_cores,
-        tile_h=M,
-        tile_w=32,
-        dtype=ttnn.bfloat4_b,
-        seed=256,
-        mesh_mapper=mesh_mapper,
-    )
-
-    # Fused output tensor
+    # ── Compute dimensions for expert DRAM matmul ──
     num_banks = device.dram_grid_size().x
-    gate_proj_N_padded = ((gate_proj_N + num_banks * 32 - 1) // (num_banks * 32)) * (num_banks * 32)
+    tile_w = 32
+    gate_proj_N_padded = ((gate_proj_N + num_banks * tile_w - 1) // (num_banks * tile_w)) * (num_banks * tile_w)
+    down_proj_K = gate_proj_N
+    down_proj_N = K
+    down_proj_N_padded = ((down_proj_N + num_banks * tile_w - 1) // (num_banks * tile_w)) * (num_banks * tile_w)
+    per_core_gate_N = gate_proj_N_padded // num_banks
+
+    # ── Generate expert weights for validation ──
+    def _gen_experts(num_exp, K_dim, N_padded, seed):
+        stacked = torch.zeros(num_exp, K_dim, N_padded, dtype=torch.bfloat16)
+        validation = {}
+        for i in range(num_exp):
+            torch.manual_seed(seed + i)
+            w = torch.randn(1, 1, K_dim, N_padded).clamp(-2, 2).bfloat16()
+            validation[i] = w.clone()
+            stacked[i] = w.reshape(K_dim, N_padded)
+            if (i + 1) % 32 == 0:
+                logger.info(f"  Generated {i + 1}/{num_exp} experts (seed={seed})")
+        return stacked, validation
+
+    gate_stacked, expert_weights_dict = _gen_experts(num_experts, gate_proj_K, gate_proj_N_padded, seed=0)
+    up_stacked, up_proj_weights_dict = _gen_experts(num_experts, gate_proj_K, gate_proj_N_padded, seed=256)
+    down_stacked, down_proj_weights_dict = _gen_experts(num_experts, down_proj_K, down_proj_N_padded, seed=512)
+
+    # ── Upload expert weights via BlitzDecodeWeights ──
+    bdw = BlitzDecodeWeights(device)
+    gate_proj_expert_tensors, up_proj_expert_tensors, down_proj_expert_tensors = bdw.get_tt_moe_routed_expert_weights(
+        gate_stacked, up_stacked, down_stacked
+    )
+    gate_proj_weights = gate_proj_expert_tensors[0]
+    up_proj_weights = up_proj_expert_tensors[0]
+    down_proj_weights = down_proj_expert_tensors[0]
+
+    # ── Create matmul output tensors (WIDTH_SHARDED in L1) ──
+    def _create_dram_mm_output(N_pad, per_core_N_val):
+        out_tile = ttnn.Tile([M, tile_w])
+        out_shard = ttnn.ShardSpec(gate_proj_core_ranges, [M, per_core_N_val], ttnn.ShardOrientation.ROW_MAJOR)
+        out_mem = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.WIDTH_SHARDED, ttnn.BufferType.L1, out_shard)
+        return ttnn.from_torch(
+            torch.zeros(1, 1, M, N_pad).bfloat16(),
+            dtype=ttnn.bfloat16,
+            layout=ttnn.TILE_LAYOUT,
+            device=device,
+            memory_config=out_mem,
+            tile=out_tile,
+            **from_torch_kwargs,
+        )
+
+    gate_proj_output = _create_dram_mm_output(gate_proj_N_padded, per_core_gate_N)
+    up_proj_mm_out_tensor = _create_dram_mm_output(gate_proj_N_padded, per_core_gate_N)
+
+    # Fused output tensor (same layout as gate/up output)
     fused_output_tensor = ttnn.from_torch(
         torch.zeros([1, 1, M, gate_proj_N_padded]).bfloat16().float(),
         dtype=ttnn.bfloat16,
@@ -747,10 +627,7 @@ def create_routed_expert_tensors(device, use_hardcoded_expert_index, mesh_mapper
         **from_torch_kwargs,
     )
 
-    # down_proj tensors
-    down_proj_K = gate_proj_N
-    down_proj_N = K
-
+    # down_proj intermediate tensors
     down_proj_gather_shard_spec = ttnn.ShardSpec(
         input_core_grid,
         (M, gate_proj_N_padded),
@@ -787,30 +664,10 @@ def create_routed_expert_tensors(device, use_hardcoded_expert_index, mesh_mapper
         **from_torch_kwargs,
     )
 
-    # down_proj expert weights and output
-    (
-        down_proj_weights,
-        down_proj_output,
-        down_proj_weights_dict,
-        down_proj_expert_tensors,
-    ) = create_expert_matmul_tensors(
-        device=device,
-        K=down_proj_K,
-        N=down_proj_N,
-        num_experts=num_experts,
-        compute_core_grid=gate_proj_core_ranges,
-        num_cores=num_gate_proj_cores,
-        tile_h=M,
-        tile_w=32,
-        dtype=ttnn.bfloat4_b,
-        seed=512,
-        mesh_mapper=mesh_mapper,
-    )
+    per_core_down_proj_N = down_proj_N_padded // num_banks
+    down_proj_output = _create_dram_mm_output(down_proj_N_padded, per_core_down_proj_N)
 
     # fused_add tensor
-    down_proj_N_padded = ((down_proj_N + num_banks * 32 - 1) // (num_banks * 32)) * (num_banks * 32)
-    per_core_down_proj_N = down_proj_N_padded // num_banks
-
     torch.manual_seed(1024)
     fused_add_torch = torch.randn([1, 1, 1, down_proj_N_padded]).bfloat16().float()
 

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_moe.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_moe.py
@@ -56,12 +56,16 @@ def create_shared_expert_tensors(device, M, K_gate, mcast_grid, mesh_mapper=None
     sender_core_grid = ttnn.CoreRangeSet([ttnn.CoreRange(mcast_gather_core, mcast_gather_core)])
     matmul_core_grid = DownProj.build_matmul_core_grid()
 
-    # Create torch data
+    # Create torch data — generate full TP-width weights with unique data per shard
+    bdw = BlitzDecodeWeights(device)
+    moe_tp = bdw.moe_tp
+    K_down_full = K_down * moe_tp
+
     torch.manual_seed(100)  # Different seed from routed expert
     torch_activation = torch.randn((M, K_gate), dtype=torch.bfloat16)
-    torch_gate_weights = torch.randn((K_gate, K_down), dtype=torch.bfloat16)
-    torch_up_weights = torch.randn((K_gate, K_down), dtype=torch.bfloat16)
-    torch_down_weights = torch.randn((K_down, N), dtype=torch.bfloat16)
+    torch_gate_weights = torch.randn((K_gate, K_down_full), dtype=torch.bfloat16)
+    torch_up_weights = torch.randn((K_gate, K_down_full), dtype=torch.bfloat16)
+    torch_down_weights = torch.randn((K_down_full, N), dtype=torch.bfloat16)
     torch_bias = torch.randn((M, N), dtype=torch.bfloat16)
 
     from_torch_kwargs = {"mesh_mapper": mesh_mapper} if mesh_mapper else {}
@@ -81,12 +85,9 @@ def create_shared_expert_tensors(device, M, K_gate, mcast_grid, mesh_mapper=None
 
     compute_core_grid = ttnn.CoreRangeSet([ttnn.CoreRange(c, c) for c in compute_cores_list])
 
-    bdw = BlitzDecodeWeights(device)
-    moe_tp = bdw.moe_tp
-    gate_full = torch_gate_weights.repeat(1, moe_tp) if moe_tp > 1 else torch_gate_weights
-    up_full = torch_up_weights.repeat(1, moe_tp) if moe_tp > 1 else torch_up_weights
-    down_full = torch_down_weights.repeat(moe_tp, 1) if moe_tp > 1 else torch_down_weights
-    gate_ov, up_ov, ttnn_down_weights = bdw.get_tt_moe_shared_expert_weights(gate_full, up_full, down_full)
+    gate_ov, up_ov, ttnn_down_weights = bdw.get_tt_moe_shared_expert_weights(
+        torch_gate_weights, torch_up_weights, torch_down_weights
+    )
 
     # ── Output ──
     out_shard = ttnn.ShardSpec(sender_core_grid, (M, N), ttnn.ShardOrientation.ROW_MAJOR)
@@ -249,6 +250,8 @@ def create_shared_expert_tensors(device, M, K_gate, mcast_grid, mesh_mapper=None
         # Params
         "k_parallel": k_parallel,
         "n_parallel": n_parallel,
+        "moe_tp": moe_tp,
+        "K_down": K_down,
         # Tensor-backed CB tensors
         "ttnn_ag_gather_dst": ttnn_ag_gather_dst,
         "ttnn_bg_gather_dst": ttnn_bg_gather_dst,
@@ -1129,6 +1132,8 @@ def test_moe_fused_with_reduce(bh_2d_mesh_device, use_hardcoded_expert_index):
 
     # Compute expected output for each device, then sum
     # Each device uses a different hardcoded expert index (chip_id)
+    # and a different TP shard of shared expert weights
+    K_down = s["K_down"]
     expected_final_outputs = []
     for device_idx in range(num_devices):
         chip_id = device_idx
@@ -1140,13 +1145,17 @@ def test_moe_fused_with_reduce(bh_2d_mesh_device, use_hardcoded_expert_index):
             actual_expert_idx = int(device_gate_indices[0].flatten()[chip_id].item())
             actual_expert_scale = device_gate_scores[0].flatten()[chip_id].float()
 
+        shared_gate_shard = s["torch_gate_weights"][:, device_idx * K_down : (device_idx + 1) * K_down]
+        shared_up_shard = s["torch_up_weights"][:, device_idx * K_down : (device_idx + 1) * K_down]
+        shared_down_shard = s["torch_down_weights"][device_idx * K_down : (device_idx + 1) * K_down, :]
+
         _, _, torch_expected_final = MoeOp.golden(
             r["torch_input"],
             r["torch_gate_mm_weights"],
             r["torch_bias"],
-            shared_gate_weights=s["torch_gate_weights"],
-            shared_up_weights=s["torch_up_weights"],
-            shared_down_weights=s["torch_down_weights"],
+            shared_gate_weights=shared_gate_shard,
+            shared_up_weights=shared_up_shard,
+            shared_down_weights=shared_down_shard,
             gate_proj_weights_dict=r["expert_weights_dict"],
             up_proj_weights_dict=r["up_proj_weights_dict"],
             down_proj_weights_dict=r["down_proj_weights_dict"],

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_pre_sdpa.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_pre_sdpa.py
@@ -17,7 +17,7 @@ from loguru import logger
 import ttnn
 from models.common.utility_functions import comp_pcc
 from models.demos.deepseek_v3.tt.rope import get_rot_transformation_mat
-from models.demos.deepseek_v3_b1.blitz_decode_weights import shuffle_weights_for_interleaved_qnope_qrope
+from models.demos.deepseek_v3_b1.blitz_decode_weights import BlitzDecodeWeights
 from models.demos.deepseek_v3_b1.fused_ops.pre_sdpa.op import PreSDPA
 from models.demos.deepseek_v3_b1.micro_ops.flash_mla.op import FlashMLADecode
 
@@ -247,15 +247,10 @@ def test_pre_sdpa(
     torch_input = torch.randn(shape, dtype=torch.bfloat16)
     torch_gamma = torch.randn(shape, dtype=torch.bfloat16)
     torch_matmul_weights = torch.randn(matmul_weights_shape, dtype=torch.bfloat16)
-    matmul_h, matmul_w = matmul_weights_shape
-    # Pack [H, W] -> [H/2, 2W] by pairing each row i from K-half0 and K-half1 as [half0_i | half1_i].
-    torch_matmul_weights_packed = (
-        torch_matmul_weights.reshape(2, matmul_h // 2, matmul_w).permute(1, 0, 2).reshape(matmul_h // 2, 2 * matmul_w)
-    )
     torch_rmsnorm2_gamma = torch.randn((1, rmsnorm2_width), dtype=torch.bfloat16)
 
     # Matmul2 weights - full tensor with layout [all_qnope | all_qrope] for num_tp * 64 heads.
-    # Golden receives this directly; per-TP slices are extracted for shuffling + mesh distribution.
+    # Golden receives this directly; BlitzDecodeWeights handles packing/shuffling for device.
     total_qnope_heads = num_tp * NUM_QNOPE_HEADS
     total_qrope_heads = num_tp * NUM_QROPE_HEADS
     total_qnope_dim = total_qnope_heads * QNOPE_HEAD_DIM
@@ -263,28 +258,6 @@ def test_pre_sdpa(
     torch_matmul2_weights_full_unshuffled = torch.randn(
         (matmul2_weights_shape[0], total_qnope_dim + total_qrope_dim), dtype=torch.bfloat16
     )
-
-    per_tp_qnope_dim = NUM_QNOPE_HEADS * QNOPE_HEAD_DIM
-    per_tp_qrope_dim = NUM_QROPE_HEADS * QROPE_HEAD_DIM
-    full_qnope = torch_matmul2_weights_full_unshuffled[:, :total_qnope_dim]
-    full_qrope = torch_matmul2_weights_full_unshuffled[:, total_qnope_dim:]
-
-    matmul2_tp_slices_shuffled = []
-    for tp in range(num_tp):
-        tp_qnope = full_qnope[:, tp * per_tp_qnope_dim : (tp + 1) * per_tp_qnope_dim]
-        tp_qrope = full_qrope[:, tp * per_tp_qrope_dim : (tp + 1) * per_tp_qrope_dim]
-        tp_unshuffled = torch.cat([tp_qnope, tp_qrope], dim=1)
-        shuffled = shuffle_weights_for_interleaved_qnope_qrope(
-            tp_unshuffled,
-            num_qnope_heads=NUM_QNOPE_HEADS,
-            num_qrope_heads=NUM_QROPE_HEADS,
-            qnope_head_dim=QNOPE_HEAD_DIM,
-            qrope_head_dim=QROPE_HEAD_DIM,
-            heads_per_row=HEADS_PER_ROW,
-        )
-        matmul2_tp_slices_shuffled.append(shuffled)
-
-    torch_matmul2_weights_shuffled = torch.cat(matmul2_tp_slices_shuffled, dim=1)
 
     # Matmul3 weights - [num_tp * num_qnope_heads, qnope_head_dim, qnope_out_dim] for golden
     # Each TP slice of 64 heads is height-sharded on 64 cores per device.
@@ -372,57 +345,20 @@ def test_pre_sdpa(
         mesh_mapper=ttnn.ReplicateTensorToMesh(submesh),
     )
 
-    # Matmul1 packed weights tensor
-    # Pack [7168, 1536] -> [3584, 3072] by concatenating K-halves across width.
-    # Width-shard over full 96-core grid, giving per-core shard [3584, 32].
-    matmul_grid_x = 12
-    matmul_grid_y = 8
-    matmul_grid = ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(matmul_grid_x - 1, matmul_grid_y - 1))
-    num_matmul_cores = matmul_grid_x * matmul_grid_y
-    # WIDTH_SHARDED requires shard height == tensor height.
-    # Packed tensor is [3584, 3072], so per-core shard is [3584, 32].
-    matmul_packed_shard_shape = (
-        matmul_weights_shape[0] // 2,
-        (matmul_weights_shape[1] * 2) // num_matmul_cores,
-    )
-    matmul_packed_shard_spec = ttnn.ShardSpec(
-        ttnn.CoreRangeSet({matmul_grid}),
-        matmul_packed_shard_shape,
-        ttnn.ShardOrientation.ROW_MAJOR,
-    )
-    matmul_packed_mem_config = ttnn.MemoryConfig(
-        ttnn.TensorMemoryLayout.WIDTH_SHARDED, ttnn.BufferType.L1, matmul_packed_shard_spec
-    )
+    # Fused q_a_proj + q_b_proj + kv_a_proj weights via BlitzDecodeWeights.
+    # The raw torch_matmul_weights (q_a_proj) and torch_matmul2_weights_full_unshuffled (q_b_proj)
+    # are kept for golden; torch_dkv_matmul_weights (kv_a_proj) is created here and also used for golden.
+    torch_dkv_matmul_weights = torch.randn(dkv_matmul_weights_shape, dtype=torch.bfloat16)
 
-    ttnn_matmul_weights = ttnn.from_torch(
-        torch_matmul_weights_packed,
-        dtype=ttnn.bfloat8_b,
-        layout=ttnn.TILE_LAYOUT,
-        device=submesh,
-        memory_config=matmul_packed_mem_config,
-        mesh_mapper=ttnn.ReplicateTensorToMesh(submesh),
-    )
-
-    # Matmul2 weights tensor (shuffled) - width sharded on 8x12 grid
-    matmul2_grid = ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(matmul2_grid_x - 1, matmul2_grid_y - 1))
-    matmul2_num_cores = matmul2_grid_x * matmul2_grid_y
-    matmul2_shard_shape = (matmul2_weights_shape[0], matmul2_weights_shape[1] // matmul2_num_cores)
-    matmul2_shard_spec = ttnn.ShardSpec(
-        ttnn.CoreRangeSet({matmul2_grid}),
-        matmul2_shard_shape,
-        ttnn.ShardOrientation.ROW_MAJOR,
-    )
-    matmul2_mem_config = ttnn.MemoryConfig(
-        ttnn.TensorMemoryLayout.WIDTH_SHARDED, ttnn.BufferType.L1, matmul2_shard_spec
-    )
-
-    ttnn_matmul2_weights = ttnn.from_torch(
-        torch_matmul2_weights_shuffled,
-        dtype=ttnn.bfloat8_b,
-        layout=ttnn.TILE_LAYOUT,
-        device=submesh,
-        memory_config=matmul2_mem_config,
-        mesh_mapper=ttnn.ShardTensor2dMesh(submesh, mesh_shape=(mesh_rows, mesh_cols), dims=(None, 1)),
+    blitz_weights = BlitzDecodeWeights(submesh)
+    (
+        ttnn_q_a_proj_overlapped,
+        ttnn_q_b_proj_overlapped,
+        ttnn_kv_a_proj_overlapped,
+    ) = blitz_weights.get_tt_q_ab_proj_and_kv_a_proj_weights(
+        torch_matmul_weights,
+        torch_matmul2_weights_full_unshuffled,
+        torch_dkv_matmul_weights,
     )
 
     # RMSNorm2 gamma tensor
@@ -579,36 +515,7 @@ def test_pre_sdpa(
         mesh_mapper=ttnn.ReplicateTensorToMesh(submesh),
     )
 
-    # KV Cache Branch
-    torch_dkv_matmul_weights = torch.randn(dkv_matmul_weights_shape, dtype=torch.bfloat16)
-    num_shards = kv_cache_branch_crs.num_cores()
-    shard_width = dkv_matmul_weights_shape[1] // num_shards
-    # new_shard_order = [0, 15, 1, 14, 2, 13, 3, 12, 4, 11, 5, 10, 6, 9, 7, 8, 16, 17]
-    new_shard_order = [0, 1, 2, 3, 4, 5, 6, 7, 16, 8, 9, 10, 11, 12, 13, 14, 15, 17]
-    torch_dkv_matmul_weights_shards = torch_dkv_matmul_weights.reshape(
-        dkv_matmul_weights_shape[0], num_shards, shard_width
-    )
-    torch_dkv_matmul_weights_shuffled = torch_dkv_matmul_weights_shards[:, new_shard_order, :].reshape(
-        dkv_matmul_weights_shape[0], dkv_matmul_weights_shape[1]
-    )
-    dkv_matmul_weights_shard_spec = ttnn.ShardSpec(
-        kv_cache_branch_crs,
-        (dkv_matmul_weights_shape[0], shard_width),
-        ttnn.ShardOrientation.ROW_MAJOR,
-    )
-
-    dkv_matmul_weights_mem_config = ttnn.MemoryConfig(
-        ttnn.TensorMemoryLayout.WIDTH_SHARDED, ttnn.BufferType.L1, dkv_matmul_weights_shard_spec
-    )
-    ttnn_dkv_matmul_weights = ttnn.from_torch(
-        torch_dkv_matmul_weights_shuffled,
-        dtype=ttnn.bfloat8_b,
-        layout=ttnn.TILE_LAYOUT,
-        device=submesh,
-        memory_config=dkv_matmul_weights_mem_config,
-        mesh_mapper=ttnn.ReplicateTensorToMesh(submesh),
-    )
-
+    # KV Cache Branch (torch_dkv_matmul_weights created above with BlitzDecodeWeights)
     torch_dkv_rmsnorm_gamma = torch.randn((1, KNOPE_DIM), dtype=torch.bfloat16)
     dkv_rmsnorm_gamma_shard_spec = ttnn.ShardSpec(
         kv_cache_branch_rms_crs,
@@ -715,16 +622,16 @@ def test_pre_sdpa(
             input_tensor_mesh,
             intermediate_tensor_mesh,
             ttnn_gamma,
-            ttnn_matmul_weights,
+            ttnn_q_a_proj_overlapped,
             ttnn_rmsnorm2_gamma,
-            ttnn_matmul2_weights,
+            ttnn_q_b_proj_overlapped,
             ttnn_matmul3_weights,
             ttnn_qrope_sin,
             ttnn_qrope_cos,
             ttnn_trans_mat,
             ttnn_krope_cos,
             ttnn_krope_sin,
-            ttnn_dkv_matmul_weights,
+            ttnn_kv_a_proj_overlapped,
             ttnn_dkv_rmsnorm_gamma,
             ttnn_kv_cache,
             position_ids,

--- a/models/demos/deepseek_v3_b1/unified_kernels/kernel_utils.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/kernel_utils.hpp
@@ -66,3 +66,14 @@ FORCE_INLINE void setup_sharded_buffer(uint32_t cb_id, uint32_t num_tiles) {
 #endif
 
 }  // namespace unified_kernels
+
+// ============================================================================
+// CB pointer manipulation (TRISC only)
+// ============================================================================
+
+#if defined(COMPILE_FOR_TRISC)
+FORCE_INLINE void set_local_cb_rd_ptr(uint32_t cb_id, uint32_t byte_address) {
+    LocalCBInterface& local_cb = get_local_cb_interface(cb_id);
+    local_cb.fifo_rd_ptr = byte_address / L1_ALIGNMENT;
+}
+#endif

--- a/models/demos/deepseek_v3_b1/unified_kernels/kn_sliced_matmul.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/kn_sliced_matmul.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "kernel_op_api.hpp"
+#include "kernel_utils.hpp"
 
 #if defined(COMPILE_FOR_BRISC)
 #include "api/dataflow/dataflow_api.h"
@@ -72,6 +73,7 @@ struct KNSlicedMatmul {
         uint32_t k_offset;         // tile offset into act_cb
         uint32_t k_per_core;       // K tiles this core processes
         uint32_t act_total_tiles;  // total tiles in act_cb (for wait/pop)
+        uint32_t weights_address = 0;
     };
 
     using RTArgs = unified_kernels::SelectByRISCV<ReaderArgs, WriterArgs, ComputeArgs>;
@@ -114,6 +116,10 @@ struct KNSlicedMatmul {
             // Wait for all activation tiles and weight tiles
             cb_wait_front(args.act_cb, args.act_total_tiles);
             cb_wait_front(args.weights_cb, args.k_per_core);
+
+            if (args.weights_address != 0) {
+                UNPACK(({ set_local_cb_rd_ptr(args.weights_cb, args.weights_address); }));
+            }
 
             // Reserve output tile
             cb_reserve_back(args.out_cb, out_w);

--- a/models/demos/deepseek_v3_b1/unified_kernels/matmul.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/matmul.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "kernel_op_api.hpp"
+#include "kernel_utils.hpp"
 
 #if defined(COMPILE_FOR_BRISC)
 #include "api/dataflow/dataflow_api.h"
@@ -81,6 +82,7 @@ struct Matmul {
         uint32_t in1;
         uint32_t out;
         uint32_t k_num_tiles;
+        uint32_t in1_address = 0;
     };
 
     using RTArgs = unified_kernels::SelectByRISCV<ReaderArgs, WriterArgs, ComputeArgs>;
@@ -122,6 +124,10 @@ struct Matmul {
             // in1 has num_tiles * out_w tiles (K tiles for each output column)
             cb_wait_front(args.in0, args.k_num_tiles);
             cb_wait_front(args.in1, args.k_num_tiles * out_w);
+
+            if (args.in1_address != 0) {
+                UNPACK(({ set_local_cb_rd_ptr(args.in1, args.in1_address); }));
+            }
 
             // Reserve output tiles
             cb_reserve_back(args.out, out_w);

--- a/models/demos/deepseek_v3_b1/unified_kernels/rmsnorm.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/rmsnorm.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "kernel_op_api.hpp"
+#include "kernel_utils.hpp"
 
 #if defined(COMPILE_FOR_BRISC)
 #include "api/dataflow/dataflow_api.h"
@@ -81,6 +82,7 @@ struct RMSNorm {
     struct ComputeArgs {
         uint32_t epsilon;
         float scalar;
+        uint32_t gamma_address = 0;
     };
 
     using RTArgs = unified_kernels::SelectByRISCV<ReaderArgs, WriterArgs, ComputeArgs>;
@@ -105,6 +107,10 @@ struct RMSNorm {
             // ================================================================
             // Init block done only once
             cb_wait_front(CTArgs::gamma_cb, CTArgs::num_tiles);  // we don't pop, only wait once and reuse
+
+            if (args.gamma_address != 0) {
+                UNPACK(({ set_local_cb_rd_ptr(CTArgs::gamma_cb, args.gamma_address); }));
+            }
 
             compute_rmsnorm(args);
 #endif


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Provide context for the problem.

### What's changed
Describe the approach used to solve the problem.
Summarize the changes made and its impact.

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=bliu/main)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:bliu/main)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=bliu/main)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:bliu/main)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=bliu/main)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:bliu/main)
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=bliu/main)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:bliu/main)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=bliu/main)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:bliu/main)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=bliu/main)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:bliu/main)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
