### PR TITLE
Add position tracking to mla

### DIFF
--- a/models/demos/deepseek_v3_b1/fused_ops/kv_cache_branch/kernels/kv_cache_branch_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/fused_ops/kv_cache_branch/kernels/kv_cache_branch_kernel.cpp
@@ -60,18 +60,26 @@ void kernel_main() {
     // kv cache rmsnorm reader args
     deepseek_b1_ops::RMSNorm::ReaderArgs kv_rmsnorm_args{};
 
-    using K_RopeCTArgs =
-        deepseek_b1_ops::Rope::ReaderCTArgs<get_named_compile_time_arg_val("Wt"), get_named_compile_time_arg_val("Ht")>;
+    using K_RopeCTArgs = deepseek_b1_ops::Rope::ReaderCTArgs<
+        get_named_compile_time_arg_val("Wt"),
+        get_named_compile_time_arg_val("Ht"),
+        get_named_compile_time_arg_val("cos_sin_page_size"),
+        get_named_compile_time_arg_val("bank_id")>;
     constexpr uint32_t k_rope_input_cb = get_named_compile_time_arg_val("in_cb");
     constexpr uint32_t cos_cb = get_named_compile_time_arg_val("cos_cb");
     constexpr uint32_t sin_cb = get_named_compile_time_arg_val("sin_cb");
+    constexpr uint32_t cos_tensor_address = get_named_compile_time_arg_val("cos_tensor_address");
+    constexpr uint32_t sin_tensor_address = get_named_compile_time_arg_val("sin_tensor_address");
+    constexpr uint32_t position_ids_tensor_address = get_named_compile_time_arg_val("position_ids_tensor_address");
     constexpr uint32_t trans_mat_cb = get_named_compile_time_arg_val("trans_mat_cb");
 
-    // Reader args: CB indices for sharded input signaling
     deepseek_b1_ops::Rope::ReaderArgs k_rope_args{
         .in_cb = k_rope_input_cb,
         .cos_cb = cos_cb,
         .sin_cb = sin_cb,
+        .cos_tensor_address = cos_tensor_address,
+        .sin_tensor_address = sin_tensor_address,
+        .position_ids_tensor_address = position_ids_tensor_address,
         .trans_mat_cb = trans_mat_cb,
     };
 
@@ -184,12 +192,7 @@ void kernel_main() {
         unified_kernels::setup_sharded_buffer(kv_rmsnorm_gamma_cb, kv_rmsnorm_num_tiles);
     }
     if constexpr (Core::is_krope_core) {
-        constexpr uint32_t cos_cb = get_named_compile_time_arg_val("cos_cb");
-        constexpr uint32_t sin_cb = get_named_compile_time_arg_val("sin_cb");
         constexpr uint32_t trans_mat_cb = get_named_compile_time_arg_val("trans_mat_cb");
-        constexpr uint32_t Wt = get_named_compile_time_arg_val("Wt");
-        unified_kernels::setup_sharded_buffer(cos_cb, Wt);
-        unified_kernels::setup_sharded_buffer(sin_cb, Wt);
         unified_kernels::setup_sharded_buffer(trans_mat_cb, 1);
     }
 #endif

--- a/models/demos/deepseek_v3_b1/fused_ops/kv_cache_branch/kernels/kv_cache_branch_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/fused_ops/kv_cache_branch/kernels/kv_cache_branch_kernel.cpp
@@ -240,7 +240,10 @@ void kernel_main() {
     DeviceZoneScopedN("KV_CACHE_UPDATE");
     // Get runtime args: buffer address and starting tile ID
     uint32_t kv_cache_buffer_addr = get_common_arg_val<uint32_t>(0);
-    uint32_t kv_cache_start_tile_id = get_common_arg_val<uint32_t>(1);
+    uint32_t position_ids_addr = get_common_arg_val<uint32_t>(1);
+
+    volatile tt_l1_ptr uint32_t* position_ids_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(position_ids_addr);
+    uint32_t kv_cache_start_tile_id = position_ids_ptr[0];
 
     // Create TensorAccessor for DRAM interleaved tensor
     auto kv_cache_addr_gen = TensorAccessor(

--- a/models/demos/deepseek_v3_b1/fused_ops/kv_cache_branch/kernels/kv_cache_branch_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/fused_ops/kv_cache_branch/kernels/kv_cache_branch_kernel.cpp
@@ -64,7 +64,8 @@ void kernel_main() {
         get_named_compile_time_arg_val("Wt"),
         get_named_compile_time_arg_val("Ht"),
         get_named_compile_time_arg_val("cos_sin_page_size"),
-        get_named_compile_time_arg_val("bank_id")>;
+        get_named_compile_time_arg_val("total_Wt"),
+        get_named_compile_time_arg_val("start_tile_offset")>;
     constexpr uint32_t k_rope_input_cb = get_named_compile_time_arg_val("in_cb");
     constexpr uint32_t cos_cb = get_named_compile_time_arg_val("cos_cb");
     constexpr uint32_t sin_cb = get_named_compile_time_arg_val("sin_cb");

--- a/models/demos/deepseek_v3_b1/fused_ops/kv_cache_branch/op.py
+++ b/models/demos/deepseek_v3_b1/fused_ops/kv_cache_branch/op.py
@@ -263,13 +263,17 @@ class KVCacheBranch:
         cos_tensor_address = cos_tensor.buffer_address()
         sin_tensor_address = sin_tensor.buffer_address()
 
+        krope_Wt = 1
+        krope_Ht = 1
+        num_rope_cores = krope_core_grid.num_cores()
+        total_Wt = krope_Wt * num_rope_cores
         rope_cores = ttnn.corerange_to_cores(krope_core_grid)
-        bank_id_core_values = [(core, idx) for idx, core in enumerate(rope_cores)]
+        start_tile_offset_core_values = [(core, idx * krope_Wt) for idx, core in enumerate(rope_cores)]
 
         krope_brisc_named_compile_time_args = [
             ("k_rope_output_cb", k_rope_output_cb),
-            ("Wt", 1),  # Needed for KV Cache update
-            ("Ht", 1),  # Needed for KV Cache update
+            ("Wt", krope_Wt),
+            ("Ht", krope_Ht),
         ]
         krope_ncrisc_named_compile_time_args = [
             ("in_cb", dkv_matmul_output_cb),
@@ -279,9 +283,10 @@ class KVCacheBranch:
             ("sin_tensor_address", sin_tensor_address),
             ("position_ids_tensor_address", position_ids_tensor_addr),
             ("trans_mat_cb", trans_mat_cb),
-            ("Wt", 1),
-            ("Ht", 1),
+            ("Wt", krope_Wt),
+            ("Ht", krope_Ht),
             ("cos_sin_page_size", rope_tile_size),
+            ("total_Wt", total_Wt),
         ]
         krope_trisc_named_compile_time_args = [
             ("in_cb", dkv_matmul_output_cb),
@@ -292,8 +297,8 @@ class KVCacheBranch:
             ("cos_interm_cb", cos_interm_cb),
             ("sin_interm_cb", sin_interm_cb),
             ("out_cb", k_rope_output_cb),
-            ("Wt", 1),
-            ("Ht", 1),
+            ("Wt", krope_Wt),
+            ("Ht", krope_Ht),
         ]
 
         # Create tile descriptor for proper tile dimensions
@@ -520,8 +525,8 @@ class KVCacheBranch:
             ],
             per_core_compile_time_descriptors=[
                 PerCoreCompileTimeDescriptor(
-                    named_compile_time_arg="bank_id",
-                    core_values=bank_id_core_values,
+                    named_compile_time_arg="start_tile_offset",
+                    core_values=start_tile_offset_core_values,
                     other_value=0,
                 ),
             ],

--- a/models/demos/deepseek_v3_b1/fused_ops/kv_cache_branch/op.py
+++ b/models/demos/deepseek_v3_b1/fused_ops/kv_cache_branch/op.py
@@ -68,7 +68,7 @@ class KVCacheBranch:
         trans_mat_tensor,
         output_tensor,
         kv_cache_tensor,
-        kv_cache_write_index,
+        position_ids_tensor,
         epsilon=1e-6,
         fp32_dest_acc_en=False,
     ):
@@ -82,7 +82,7 @@ class KVCacheBranch:
             cos_tensor: Cos tensor (must be sharded)
             sin_tensor: Sin tensor (must be sharded)
             kv_cache_tensor: Optional KV cache tensor in DRAM (interleaved) to write results to
-            kv_cache_write_index: Sequence position index to write to in KV cache
+            position_ids_tensor: Sequence position index to write to in KV cache
             epsilon: Epsilon for RMSNorm
             fp32_dest_acc_en: Whether to enable FP32 accumulation in compute kernel
 
@@ -125,6 +125,7 @@ class KVCacheBranch:
         # KV Cache tensor setup
         # Tile size is now derived from output CB in kernel using get_tile_size()
         kv_cache_buffer_addr = kv_cache_tensor.buffer_address()
+        position_ids_tensor_addr = position_ids_tensor.buffer_address()
         kv_cache_tile = kv_cache_tensor.get_tile()
         # Calculate starting tile ID based on write index
         # KV cache shape is [1, 1, seq_len, kv_dim], tiles are [32, 32]
@@ -439,7 +440,7 @@ class KVCacheBranch:
             # BRISC common runtime args: KV cache buffer address and write position
             brisc_common_runtime_args=[
                 kv_cache_buffer_addr,
-                kv_cache_write_index,
+                position_ids_tensor_addr,
             ],
             # TRISC named compile-time args
             trisc_named_compile_time_args=kv_rmsnorm_trisc_named_compile_time_args

--- a/models/demos/deepseek_v3_b1/fused_ops/kv_cache_branch/op.py
+++ b/models/demos/deepseek_v3_b1/fused_ops/kv_cache_branch/op.py
@@ -9,6 +9,7 @@ import torch
 import ttnn
 from models.demos.deepseek_v3_b1.micro_ops.rope.op import RopeSingleCore
 from models.demos.deepseek_v3_b1.unified_kernel_descriptor import (
+    PerCoreCompileTimeDescriptor,
     UnifiedCompileTimeCoreDescriptor,
     UnifiedKernelDescriptor,
 )
@@ -134,8 +135,8 @@ class KVCacheBranch:
         # CONSOLIDATE!!!!!!!!!
         # Tile sizes: 1x32 = 64 bytes (BF16), 16x32 = 1024 bytes (BF16), 32x32 = 2048 bytes (BF16)
 
-        cos_cb = 0  # 1x32 tile, 64 bytes (sharded, Wt tiles per core)
-        sin_cb = 1  # 1x32 tile, 64 bytes (sharded, Wt tiles per core)
+        cos_cb = 0  # tile (NCRISC reads from DRAM)
+        sin_cb = 1  # tile (NCRISC reads from DRAM)
         trans_mat_cb = 2  # 1x32 tile, 64 bytes (sharded, 1 tile per core) - actually 32x32 for matmul
         rotated_input_interm_cb = 3  # 1x32 tile, 64 bytes (Wt tiles, intermediate)
         cos_interm_cb = 4  # 1x32 tile, 64 bytes (Wt tiles, intermediate)
@@ -200,7 +201,8 @@ class KVCacheBranch:
         # Sender runs on NCRISC (NOC_0 default), Receiver runs on BRISC (NOC_1 default)
         # ========================================================================
         dkv_gather_receiver_core = gamma_tensor.memory_config().shard_spec.grid.ranges()[0].start
-        dkv_gather_sender_grid = dkv_matmul_weights_core_grid.subtract(cos_tensor.memory_config().shard_spec.grid)
+        krope_core_grid = trans_mat_tensor.memory_config().shard_spec.grid
+        dkv_gather_sender_grid = dkv_matmul_weights_core_grid.subtract(krope_core_grid)
 
         # Get NOC coordinates for gather destination (receiver core)
         dkv_gather_dest_noc_core = device.worker_core_from_logical_core(dkv_gather_receiver_core)
@@ -256,6 +258,14 @@ class KVCacheBranch:
         ]
 
         # ROPE
+        rope_tile = cos_tensor.get_tile()
+        rope_tile_size = rope_tile.get_tile_size(data_format)
+        cos_tensor_address = cos_tensor.buffer_address()
+        sin_tensor_address = sin_tensor.buffer_address()
+
+        rope_cores = ttnn.corerange_to_cores(krope_core_grid)
+        bank_id_core_values = [(core, idx) for idx, core in enumerate(rope_cores)]
+
         krope_brisc_named_compile_time_args = [
             ("k_rope_output_cb", k_rope_output_cb),
             ("Wt", 1),  # Needed for KV Cache update
@@ -265,9 +275,13 @@ class KVCacheBranch:
             ("in_cb", dkv_matmul_output_cb),
             ("cos_cb", cos_cb),
             ("sin_cb", sin_cb),
+            ("cos_tensor_address", cos_tensor_address),
+            ("sin_tensor_address", sin_tensor_address),
+            ("position_ids_tensor_address", position_ids_tensor_addr),
             ("trans_mat_cb", trans_mat_cb),
             ("Wt", 1),
             ("Ht", 1),
+            ("cos_sin_page_size", rope_tile_size),
         ]
         krope_trisc_named_compile_time_args = [
             ("in_cb", dkv_matmul_output_cb),
@@ -346,11 +360,30 @@ class KVCacheBranch:
 
         krope_tile_size = TILE_1x32.get_tile_size(data_format)
         krope_tile_descriptor = ttnn.TileDescriptor(TILE_1x32)
-        krope_core_grid = cos_tensor.memory_config().shard_spec.grid
-        # CB X: Cos (sharded tensor)
-        cos_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(cos_cb, cos_tensor)
-        # CB X: Sin (sharded tensor)
-        sin_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(sin_cb, sin_tensor)
+
+        rope_tile_descriptor = ttnn.TileDescriptor(rope_tile)
+        cos_cb_format = ttnn.CBFormatDescriptor(
+            buffer_index=cos_cb,
+            data_format=data_format,
+            page_size=rope_tile_size,
+            tile=rope_tile_descriptor,
+        )
+        cos_cb_descriptor = ttnn.CBDescriptor(
+            total_size=1 * rope_tile_size,
+            core_ranges=krope_core_grid,
+            format_descriptors=[cos_cb_format],
+        )
+        sin_cb_format = ttnn.CBFormatDescriptor(
+            buffer_index=sin_cb,
+            data_format=data_format,
+            page_size=rope_tile_size,
+            tile=rope_tile_descriptor,
+        )
+        sin_cb_descriptor = ttnn.CBDescriptor(
+            total_size=1 * rope_tile_size,
+            core_ranges=krope_core_grid,
+            format_descriptors=[sin_cb_format],
+        )
         # CB X: Trans_mat (sharded tensor)
         trans_mat_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(trans_mat_cb, trans_mat_tensor)
 
@@ -480,8 +513,15 @@ class KVCacheBranch:
                 ),
                 UnifiedCompileTimeCoreDescriptor(
                     named_compile_time_arg="is_krope_core",
-                    core_range=krope_core_grid,  # TODO: could be wrong if shared cos tensor with q rope
+                    core_range=krope_core_grid,
                     value=1,
+                    other_value=0,
+                ),
+            ],
+            per_core_compile_time_descriptors=[
+                PerCoreCompileTimeDescriptor(
+                    named_compile_time_arg="bank_id",
+                    core_values=bank_id_core_values,
                     other_value=0,
                 ),
             ],
@@ -512,12 +552,11 @@ class KVCacheBranch:
         )
 
         # Execute generic op
+        # cos_tensor and sin_tensor are accessed by DRAM address, not as io tensors
         io_tensors = [
             input_tensor,
             dkv_matmul_weights_tensor,
             gamma_tensor,
-            cos_tensor,
-            sin_tensor,
             trans_mat_tensor,
             kv_cache_tensor,
             output_tensor,

--- a/models/demos/deepseek_v3_b1/fused_ops/pre_sdpa/kernels/pre_sdpa_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/fused_ops/pre_sdpa/kernels/pre_sdpa_kernel.cpp
@@ -167,7 +167,8 @@ void kernel_main() {
         get_named_compile_time_arg_val("qrope_Wt"),
         get_named_compile_time_arg_val("qrope_Ht"),
         get_named_compile_time_arg_val("qrope_cos_sin_page_size"),
-        get_named_compile_time_arg_val("qrope_bank_id")>;
+        get_named_compile_time_arg_val("qrope_total_Wt"),
+        get_named_compile_time_arg_val("qrope_start_tile_offset")>;
 
     deepseek_b1_ops::Rope::ReaderArgs qrope_args{
         .in_cb = get_named_compile_time_arg_val("qrope_in_cb"),
@@ -241,7 +242,8 @@ void kernel_main() {
         get_named_compile_time_arg_val("krope_Wt"),
         get_named_compile_time_arg_val("krope_Ht"),
         get_named_compile_time_arg_val("krope_cos_sin_page_size"),
-        get_named_compile_time_arg_val("krope_bank_id")>;
+        get_named_compile_time_arg_val("krope_total_Wt"),
+        get_named_compile_time_arg_val("krope_start_tile_offset")>;
 
     deepseek_b1_ops::Rope::ReaderArgs krope_args{
         .in_cb = get_named_compile_time_arg_val("krope_in_cb"),

--- a/models/demos/deepseek_v3_b1/fused_ops/pre_sdpa/kernels/pre_sdpa_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/fused_ops/pre_sdpa/kernels/pre_sdpa_kernel.cpp
@@ -163,11 +163,21 @@ void kernel_main() {
     deepseek_b1_ops::Matmul::ReaderArgs matmul3_args{};
 
     // Qrope CTArgs type alias (NCRISC uses ReaderCTArgs)
-    using QRopeCTArgs = deepseek_b1_ops::Rope::
-        ReaderCTArgs<get_named_compile_time_arg_val("qrope_Wt"), get_named_compile_time_arg_val("qrope_Ht")>;
+    using QRopeCTArgs = deepseek_b1_ops::Rope::ReaderCTArgs<
+        get_named_compile_time_arg_val("qrope_Wt"),
+        get_named_compile_time_arg_val("qrope_Ht"),
+        get_named_compile_time_arg_val("qrope_cos_sin_page_size"),
+        get_named_compile_time_arg_val("qrope_bank_id")>;
 
-    // Qrope reader args (NCRISC is no-op)
-    deepseek_b1_ops::Rope::ReaderArgs qrope_args{};
+    deepseek_b1_ops::Rope::ReaderArgs qrope_args{
+        .in_cb = get_named_compile_time_arg_val("qrope_in_cb"),
+        .cos_cb = get_named_compile_time_arg_val("qrope_cos_cb"),
+        .sin_cb = get_named_compile_time_arg_val("qrope_sin_cb"),
+        .cos_tensor_address = get_named_compile_time_arg_val("qrope_cos_tensor_address"),
+        .sin_tensor_address = get_named_compile_time_arg_val("qrope_sin_tensor_address"),
+        .position_ids_tensor_address = get_named_compile_time_arg_val("qrope_position_ids_tensor_address"),
+        .trans_mat_cb = get_named_compile_time_arg_val("qrope_trans_mat_cb"),
+    };
 
     // NCRISC: Sender args for QNOPE/QROPE cores
     // Senders write to intermediate CB, then compute tilizes to output CB
@@ -227,15 +237,21 @@ void kernel_main() {
     // kv cache rmsnorm reader args
     deepseek_b1_ops::RMSNorm::ReaderArgs kv_rmsnorm_args{};
 
-    using K_RopeCTArgs = deepseek_b1_ops::Rope::
-        ReaderCTArgs<get_named_compile_time_arg_val("krope_Wt"), get_named_compile_time_arg_val("krope_Ht")>;
-    constexpr uint32_t krope_input_cb = get_named_compile_time_arg_val("krope_in_cb");
-    constexpr uint32_t krope_cos_cb = get_named_compile_time_arg_val("krope_cos_cb");
-    constexpr uint32_t krope_sin_cb = get_named_compile_time_arg_val("krope_sin_cb");
-    constexpr uint32_t krope_trans_mat_cb = get_named_compile_time_arg_val("krope_trans_mat_cb");
+    using K_RopeCTArgs = deepseek_b1_ops::Rope::ReaderCTArgs<
+        get_named_compile_time_arg_val("krope_Wt"),
+        get_named_compile_time_arg_val("krope_Ht"),
+        get_named_compile_time_arg_val("krope_cos_sin_page_size"),
+        get_named_compile_time_arg_val("krope_bank_id")>;
 
-    // Reader args: CB indices for sharded input signaling
-    deepseek_b1_ops::Rope::ReaderArgs krope_args{};
+    deepseek_b1_ops::Rope::ReaderArgs krope_args{
+        .in_cb = get_named_compile_time_arg_val("krope_in_cb"),
+        .cos_cb = get_named_compile_time_arg_val("krope_cos_cb"),
+        .sin_cb = get_named_compile_time_arg_val("krope_sin_cb"),
+        .cos_tensor_address = get_named_compile_time_arg_val("krope_cos_tensor_address"),
+        .sin_tensor_address = get_named_compile_time_arg_val("krope_sin_tensor_address"),
+        .position_ids_tensor_address = get_named_compile_time_arg_val("krope_position_ids_tensor_address"),
+        .trans_mat_cb = get_named_compile_time_arg_val("krope_trans_mat_cb"),
+    };
 
     deepseek_b1_ops::KVCacheUpdate::ReaderArgs kv_cache_update_args{};
 // ============================================================================
@@ -616,19 +632,8 @@ void kernel_main() {
     }
 
     if constexpr (Core::is_qrope_core) {
-        // Qrope CB indices and parameters from named compile-time args
-        constexpr uint32_t qrope_cos_cb = get_named_compile_time_arg_val("qrope_cos_cb");
-        constexpr uint32_t qrope_sin_cb = get_named_compile_time_arg_val("qrope_sin_cb");
         constexpr uint32_t qrope_trans_mat_cb = get_named_compile_time_arg_val("qrope_trans_mat_cb");
-        constexpr uint32_t Wt = get_named_compile_time_arg_val("qrope_Wt");
-
-        // NOTE: Do NOT setup qrope input CB (matmul2_output_cb) as sharded buffer!
-        // The input to RoPE comes from matmul2 compute output, NOT from a sharded tensor.
-        // Calling setup_sharded_buffer on it would fill the CB and block matmul2's cb_reserve_back.
-        // Only setup the actual sharded tensor CBs (cos, sin, trans_mat).
-        unified_kernels::setup_sharded_buffer(qrope_cos_cb, Wt);
-        unified_kernels::setup_sharded_buffer(qrope_sin_cb, Wt);
-        unified_kernels::setup_sharded_buffer(qrope_trans_mat_cb, 1);  // trans_mat is 1 tile (32x32)
+        unified_kernels::setup_sharded_buffer(qrope_trans_mat_cb, 1);
     }
 
     if constexpr (Core::is_dkv_matmul_core) {
@@ -647,12 +652,7 @@ void kernel_main() {
     }
 
     if constexpr (Core::is_krope_core) {
-        constexpr uint32_t krope_cos_cb = get_named_compile_time_arg_val("krope_cos_cb");
-        constexpr uint32_t krope_sin_cb = get_named_compile_time_arg_val("krope_sin_cb");
         constexpr uint32_t krope_trans_mat_cb = get_named_compile_time_arg_val("krope_trans_mat_cb");
-        constexpr uint32_t krope_Wt = get_named_compile_time_arg_val("krope_Wt");
-        unified_kernels::setup_sharded_buffer(krope_cos_cb, krope_Wt);
-        unified_kernels::setup_sharded_buffer(krope_sin_cb, krope_Wt);
         unified_kernels::setup_sharded_buffer(krope_trans_mat_cb, 1);
     }
 #endif

--- a/models/demos/deepseek_v3_b1/fused_ops/pre_sdpa/op.py
+++ b/models/demos/deepseek_v3_b1/fused_ops/pre_sdpa/op.py
@@ -188,6 +188,7 @@ class PreSDPA:
             qrope_sin_tensor: Sin tensor (sharded tensor for QRoPE)
             qrope_cos_tensor: Cos tensor (sharded tensor for QRoPE)
             trans_mat_tensor: Trans_mat tensor (sharded tensor for RoPE)
+            position_ids_tensor: Position IDs tensor (sharded tensor for RoPE)
             output_tensor: Output tensor for pre-SDPA (sharded on SDPA grid, [8, 576] per core = 8 interleaved heads)
             sender_coord: Tuple (row, col) of sender device in mesh
             semaphores: List of global semaphores [out_ready, barrier, secondary_sync] for CCL

--- a/models/demos/deepseek_v3_b1/fused_ops/pre_sdpa/op.py
+++ b/models/demos/deepseek_v3_b1/fused_ops/pre_sdpa/op.py
@@ -8,6 +8,7 @@ import torch
 
 import ttnn
 from models.demos.deepseek_v3_b1.unified_kernel_descriptor import (
+    PerCoreCompileTimeDescriptor,
     PerCoreRuntimeArgsDescriptor,
     UnifiedCompileTimeCoreDescriptor,
     UnifiedKernelDescriptor,
@@ -161,6 +162,7 @@ class PreSDPA:
         dkv_rmsnorm_gamma_tensor,
         kv_cache_tensor,
         position_id,
+        position_ids_tensor,
         output_tensor,
         sdpa_kv_cache_buffer,
         sdpa_out_interm_buffer,
@@ -225,6 +227,7 @@ class PreSDPA:
         trans_mat_tensors_per_device = ttnn.get_device_tensors(trans_mat_tensor)
         krope_cos_tensors_per_device = ttnn.get_device_tensors(krope_cos_tensor)
         krope_sin_tensors_per_device = ttnn.get_device_tensors(krope_sin_tensor)
+        position_ids_tensors_per_device = ttnn.get_device_tensors(position_ids_tensor)
         output_tensors_per_device = ttnn.get_device_tensors(output_tensor)
         dkv_matmul_weights_tensors_per_device = ttnn.get_device_tensors(dkv_matmul_weights_tensor)
         dkv_rmsnorm_gamma_tensors_per_device = ttnn.get_device_tensors(dkv_rmsnorm_gamma_tensor)
@@ -703,14 +706,15 @@ class PreSDPA:
         qrope_num_heads_per_core = 2  # Each qrope core processes 2 heads
 
         # RoPE compile-time args (only on Qrope cores)
-        # NCRISC: in_cb, cos_cb, sin_cb, trans_mat_cb, Wt, Ht
+        qrope_rope_tile_size = TILE_1x32.get_tile_size(data_format)
         qrope_ncrisc_named_compile_time_args = [
-            ("qrope_in_cb", matmul2_output_cb),  # Input from matmul2 output
+            ("qrope_in_cb", matmul2_output_cb),
             ("qrope_cos_cb", qrope_cos_cb),
             ("qrope_sin_cb", qrope_sin_cb),
             ("qrope_trans_mat_cb", qrope_trans_mat_cb),
             ("qrope_Wt", qrope_head_dim_per_core_t),
             ("qrope_Ht", qrope_num_heads_per_core),
+            ("qrope_cos_sin_page_size", qrope_rope_tile_size),
         ]
         # BRISC: no-op (empty args)
         qrope_brisc_named_compile_time_args = []
@@ -996,6 +1000,7 @@ class PreSDPA:
         ]
 
         # KV Cache Branch: RoPE
+        krope_rope_tile_size = TILE_1x32.get_tile_size(data_format)
         krope_ncrisc_named_compile_time_args = [
             ("krope_output_cb", krope_output_cb),
             ("krope_in_cb", dkv_matmul_output_cb),
@@ -1004,6 +1009,7 @@ class PreSDPA:
             ("krope_trans_mat_cb", qrope_trans_mat_cb),
             ("krope_Wt", 1),
             ("krope_Ht", 1),
+            ("krope_cos_sin_page_size", krope_rope_tile_size),
         ]
         krope_trisc_named_compile_time_args = [
             ("krope_in_cb", dkv_matmul_output_cb),
@@ -1082,6 +1088,7 @@ class PreSDPA:
                 dkv_rmsnorm_gamma_tensor_device = dkv_rmsnorm_gamma_tensors_per_device[device_idx]
                 krope_cos_tensor_device = krope_cos_tensors_per_device[device_idx]
                 krope_sin_tensor_device = krope_sin_tensors_per_device[device_idx]
+                position_ids_tensor_device = position_ids_tensors_per_device[device_idx]
                 kv_cache_tensor_device = kv_cache_tensors_per_device[device_idx]
                 sdpa_kv_cache_buffer_device = sdpa_kv_cache_buffers_per_device[device_idx]
                 sdpa_out_interm_buffer_device = sdpa_out_interm_buffers_per_device[device_idx]
@@ -1398,11 +1405,32 @@ class PreSDPA:
                 ]
                 sdpa_out_interm_running_offset += qrope_output_cb_descriptor.total_size  # +256 B
 
-                # CB 17: Cos (sharded tensor)
-                qrope_cos_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(qrope_cos_cb, qrope_cos_tensor_device)
+                # CB 17: Cos (DRAM, read by NCRISC)
+                qrope_rope_tile_descriptor = ttnn.TileDescriptor(TILE_1x32)
+                qrope_cos_cb_format = ttnn.CBFormatDescriptor(
+                    buffer_index=qrope_cos_cb,
+                    data_format=data_format,
+                    page_size=qrope_rope_tile_size,
+                    tile=qrope_rope_tile_descriptor,
+                )
+                qrope_cos_cb_descriptor = ttnn.CBDescriptor(
+                    total_size=qrope_head_dim_per_core_t * qrope_rope_tile_size,
+                    core_ranges=qrope_grid,
+                    format_descriptors=[qrope_cos_cb_format],
+                )
 
-                # CB 18: Sin (sharded tensor)
-                qrope_sin_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(qrope_sin_cb, qrope_sin_tensor_device)
+                # CB 18: Sin (DRAM, read by NCRISC)
+                qrope_sin_cb_format = ttnn.CBFormatDescriptor(
+                    buffer_index=qrope_sin_cb,
+                    data_format=data_format,
+                    page_size=qrope_rope_tile_size,
+                    tile=qrope_rope_tile_descriptor,
+                )
+                qrope_sin_cb_descriptor = ttnn.CBDescriptor(
+                    total_size=qrope_head_dim_per_core_t * qrope_rope_tile_size,
+                    core_ranges=qrope_grid,
+                    format_descriptors=[qrope_sin_cb_format],
+                )
 
                 # CB 19: Trans_mat (sharded tensor)
                 qrope_trans_mat_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(
@@ -1566,10 +1594,31 @@ class PreSDPA:
                 ]
                 sdpa_out_interm_running_offset += kv_rmsnorm_output_cb_descriptor.total_size  # +1024 B
 
-                # CB: Cos (sharded tensor)
-                krope_cos_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(krope_cos_cb, krope_cos_tensor_device)
-                # CB: Sin (sharded tensor)
-                krope_sin_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(krope_sin_cb, krope_sin_tensor_device)
+                # CB 29: Cos (DRAM, read by NCRISC)
+                krope_rope_tile_descriptor = ttnn.TileDescriptor(TILE_1x32)
+                krope_cos_cb_format = ttnn.CBFormatDescriptor(
+                    buffer_index=krope_cos_cb,
+                    data_format=data_format,
+                    page_size=krope_rope_tile_size,
+                    tile=krope_rope_tile_descriptor,
+                )
+                krope_cos_cb_descriptor = ttnn.CBDescriptor(
+                    total_size=1 * krope_rope_tile_size,
+                    core_ranges=krope_grid,
+                    format_descriptors=[krope_cos_cb_format],
+                )
+                # CB 30: Sin (DRAM, read by NCRISC)
+                krope_sin_cb_format = ttnn.CBFormatDescriptor(
+                    buffer_index=krope_sin_cb,
+                    data_format=data_format,
+                    page_size=krope_rope_tile_size,
+                    tile=krope_rope_tile_descriptor,
+                )
+                krope_sin_cb_descriptor = ttnn.CBDescriptor(
+                    total_size=1 * krope_rope_tile_size,
+                    core_ranges=krope_grid,
+                    format_descriptors=[krope_sin_cb_format],
+                )
 
                 # CB 28: KRoPE output — overlap with sdpa_out_interm L1 buffer
                 # at offset 16384 B. This CB is consumed before SDPA runs.
@@ -1738,12 +1787,37 @@ class PreSDPA:
                     kv_cache_intermed_cb,
                 ]
 
+                # RoPE DRAM address args (per-device)
+                qrope_cos_tensor_address = qrope_cos_tensor_device.buffer_address()
+                qrope_sin_tensor_address = qrope_sin_tensor_device.buffer_address()
+                krope_cos_tensor_address = krope_cos_tensor_device.buffer_address()
+                krope_sin_tensor_address = krope_sin_tensor_device.buffer_address()
+                position_ids_tensor_addr = position_ids_tensor_device.buffer_address()
+
+                qrope_ncrisc_addr_args = [
+                    ("qrope_cos_tensor_address", qrope_cos_tensor_address),
+                    ("qrope_sin_tensor_address", qrope_sin_tensor_address),
+                    ("qrope_position_ids_tensor_address", position_ids_tensor_addr),
+                ]
+                krope_ncrisc_addr_args = [
+                    ("krope_cos_tensor_address", krope_cos_tensor_address),
+                    ("krope_sin_tensor_address", krope_sin_tensor_address),
+                    ("krope_position_ids_tensor_address", position_ids_tensor_addr),
+                ]
+
+                # Per-core bank_id for QRoPE (all cores use bank 0 since DRAM has 1 bank)
+                qrope_cores = ttnn.corerange_to_cores(qrope_grid)
+                qrope_bank_id_core_values = [(core, 0) for core in qrope_cores]
+
+                # Per-core bank_id for KRoPE (2 cores, each maps to a DRAM bank)
+                krope_cores = ttnn.corerange_to_cores(krope_grid)
+                krope_bank_id_core_values = [(core, idx) for idx, core in enumerate(krope_cores)]
+
                 unified_kernel = UnifiedKernelDescriptor(
                     kernel_source="models/demos/deepseek_v3_b1/fused_ops/pre_sdpa/kernels/pre_sdpa_kernel.cpp",
                     core_ranges=full_device_grid,
                     ncrisc_compile_time_args=ncrisc_compile_time_args,
                     brisc_compile_time_args=brisc_compile_time_args,
-                    # NCRISC named compile-time args: bcast reader + rmsnorm reader + mcast receiver + matmul + gather_reduce sender + rmsnorm2 + matmul2 + mcast2 + matmul3 + unicast receiver + dkv_matmul + dkv_gather_sender + kv_rmsnorm
                     ncrisc_named_compile_time_args=bcast_ncrisc_named_compile_time_args
                     + rmsnorm_reader_named_compile_time_args
                     + mcast_receiver_named_compile_time_args
@@ -1754,11 +1828,13 @@ class PreSDPA:
                     + mcast2_ncrisc_named_compile_time_args
                     + matmul3_ncrisc_named_compile_time_args
                     + qrope_ncrisc_named_compile_time_args
+                    + qrope_ncrisc_addr_args
                     + create_q_heads_ncrisc_named_compile_time_args
                     + dkv_matmul_ncrisc_named_compile_time_args
                     + kv_rmsnorm_ncrisc_named_compile_time_args
                     + dkv_gather_sender_named_compile_time_args
-                    + krope_ncrisc_named_compile_time_args,
+                    + krope_ncrisc_named_compile_time_args
+                    + krope_ncrisc_addr_args,
                     # NCRISC common runtime args:
                     ncrisc_common_runtime_args=ncrisc_bcast_common_args,
                     # BRISC named compile-time args: bcast + rmsnorm reader (for gamma setup) + mcast sender + matmul + gather_reduce receiver + matmul2 + mcast2 + matmul3 + qrope + create_q_heads + dkv_matmul + dkv_gather_receiver + kv_rmsnorm
@@ -1866,6 +1942,18 @@ class PreSDPA:
                             other_value=0,
                         ),
                     ],
+                    per_core_compile_time_descriptors=[
+                        PerCoreCompileTimeDescriptor(
+                            named_compile_time_arg="qrope_bank_id",
+                            core_values=qrope_bank_id_core_values,
+                            other_value=0,
+                        ),
+                        PerCoreCompileTimeDescriptor(
+                            named_compile_time_arg="krope_bank_id",
+                            core_values=krope_bank_id_core_values,
+                            other_value=0,
+                        ),
+                    ],
                     # Per-core runtime args for fabric (BRISC only, on worker_core)
                     # Initialize empty args that will be populated by setup_routing_plane_connection
                     per_core_runtime_args_descriptor=PerCoreRuntimeArgsDescriptor(
@@ -1895,8 +1983,8 @@ class PreSDPA:
                     matmul3_output_cb_descriptor,  # CB 14: Matmul3 output (Qnope final)
                     qrope_output_cb_descriptor,  # CB 15: Qrope output (RoPE output)
                     create_q_heads_out_cb_descriptor,  # CB 16: CreateQHeads output (tilized, linked to tensor)
-                    qrope_cos_cb_descriptor,  # CB 17: Cos (sharded tensor)
-                    qrope_sin_cb_descriptor,  # CB 18: Sin (sharded tensor)
+                    qrope_cos_cb_descriptor,  # CB 17: Cos (DRAM, read by NCRISC)
+                    qrope_sin_cb_descriptor,  # CB 18: Sin (DRAM, read by NCRISC)
                     qrope_trans_mat_cb_descriptor,  # CB 19: Trans_mat (sharded tensor)
                     qrope_rotated_input_interm_cb_descriptor,  # CB 20: Rotated input intermediate
                     qrope_cos_interm_cb_descriptor,  # CB 21: Cos intermediate
@@ -1907,8 +1995,8 @@ class PreSDPA:
                     kv_rmsnorm_gamma_cb_descriptor,  # CB 26: KV RMSNorm gamma
                     kv_rmsnorm_output_cb_descriptor,  # CB 27: KV RMSNorm output
                     krope_output_cb_descriptor,  # CB 28: KV Cache Branch RoPE output
-                    krope_cos_cb_descriptor,  # CB 29: Cos (sharded tensor)
-                    krope_sin_cb_descriptor,  # CB 30: Sin (sharded tensor)
+                    krope_cos_cb_descriptor,  # CB 29: Cos (DRAM, read by NCRISC)
+                    krope_sin_cb_descriptor,  # CB 30: Sin (DRAM, read by NCRISC)
                     create_q_heads_interm_cb_descriptor,  # CB 31: CreateQHeads intermediate (row-major)
                     kv_cache_output_cb_descriptor,  # CB 32: KV Cache output
                     kv_cache_intermed_cb_descriptor,  # CB 33: KV Cache intermed
@@ -1958,11 +2046,12 @@ class PreSDPA:
                 rmsnorm2_gamma_tensor,
                 matmul2_weights_tensor,
                 matmul3_weights_tensor,
-                qrope_sin_tensor,
-                qrope_cos_tensor,
                 trans_mat_tensor,
+                qrope_cos_tensor,
+                qrope_sin_tensor,
                 krope_cos_tensor,
                 krope_sin_tensor,
+                position_ids_tensor,
                 dkv_matmul_weights_tensor,
                 dkv_rmsnorm_gamma_tensor,
                 kv_cache_tensor,

--- a/models/demos/deepseek_v3_b1/fused_ops/pre_sdpa/op.py
+++ b/models/demos/deepseek_v3_b1/fused_ops/pre_sdpa/op.py
@@ -707,6 +707,7 @@ class PreSDPA:
 
         # RoPE compile-time args (only on Qrope cores)
         qrope_rope_tile_size = TILE_1x32.get_tile_size(data_format)
+        qrope_total_Wt = qrope_head_dim_per_core_t  # all cores read full head_dim, so total_Wt = Wt
         qrope_ncrisc_named_compile_time_args = [
             ("qrope_in_cb", matmul2_output_cb),
             ("qrope_cos_cb", qrope_cos_cb),
@@ -715,6 +716,7 @@ class PreSDPA:
             ("qrope_Wt", qrope_head_dim_per_core_t),
             ("qrope_Ht", qrope_num_heads_per_core),
             ("qrope_cos_sin_page_size", qrope_rope_tile_size),
+            ("qrope_total_Wt", qrope_total_Wt),
         ]
         # BRISC: no-op (empty args)
         qrope_brisc_named_compile_time_args = []
@@ -1001,15 +1003,20 @@ class PreSDPA:
 
         # KV Cache Branch: RoPE
         krope_rope_tile_size = TILE_1x32.get_tile_size(data_format)
+        krope_Wt = 1
+        krope_Ht = 1
+        num_krope_cores = krope_grid.num_cores()
+        krope_total_Wt = krope_Wt * num_krope_cores
         krope_ncrisc_named_compile_time_args = [
             ("krope_output_cb", krope_output_cb),
             ("krope_in_cb", dkv_matmul_output_cb),
             ("krope_cos_cb", krope_cos_cb),
             ("krope_sin_cb", krope_sin_cb),
             ("krope_trans_mat_cb", qrope_trans_mat_cb),
-            ("krope_Wt", 1),
-            ("krope_Ht", 1),
+            ("krope_Wt", krope_Wt),
+            ("krope_Ht", krope_Ht),
             ("krope_cos_sin_page_size", krope_rope_tile_size),
+            ("krope_total_Wt", krope_total_Wt),
         ]
         krope_trisc_named_compile_time_args = [
             ("krope_in_cb", dkv_matmul_output_cb),
@@ -1020,8 +1027,8 @@ class PreSDPA:
             ("krope_cos_interm_cb", qrope_cos_interm_cb),
             ("krope_sin_interm_cb", qrope_sin_interm_cb),
             ("krope_output_cb", krope_output_cb),
-            ("krope_Wt", 1),
-            ("krope_Ht", 1),
+            ("krope_Wt", krope_Wt),
+            ("krope_Ht", krope_Ht),
         ]
 
         # KVCacheUpdate CB indices and krope_Wt passed as runtime args (ReaderArgs/WriterArgs/ComputeArgs)
@@ -1603,7 +1610,7 @@ class PreSDPA:
                     tile=krope_rope_tile_descriptor,
                 )
                 krope_cos_cb_descriptor = ttnn.CBDescriptor(
-                    total_size=1 * krope_rope_tile_size,
+                    total_size=krope_Wt * krope_rope_tile_size,
                     core_ranges=krope_grid,
                     format_descriptors=[krope_cos_cb_format],
                 )
@@ -1615,7 +1622,7 @@ class PreSDPA:
                     tile=krope_rope_tile_descriptor,
                 )
                 krope_sin_cb_descriptor = ttnn.CBDescriptor(
-                    total_size=1 * krope_rope_tile_size,
+                    total_size=krope_Wt * krope_rope_tile_size,
                     core_ranges=krope_grid,
                     format_descriptors=[krope_sin_cb_format],
                 )
@@ -1805,13 +1812,13 @@ class PreSDPA:
                     ("krope_position_ids_tensor_address", position_ids_tensor_addr),
                 ]
 
-                # Per-core bank_id for QRoPE (all cores use bank 0 since DRAM has 1 bank)
+                # Per-core start_tile_offset for QRoPE (all cores read full head_dim, offset=0)
                 qrope_cores = ttnn.corerange_to_cores(qrope_grid)
-                qrope_bank_id_core_values = [(core, 0) for core in qrope_cores]
+                qrope_start_tile_offset_core_values = [(core, 0) for core in qrope_cores]
 
-                # Per-core bank_id for KRoPE (2 cores, each maps to a DRAM bank)
+                # Per-core start_tile_offset for KRoPE (2 cores, each reads its width slice)
                 krope_cores = ttnn.corerange_to_cores(krope_grid)
-                krope_bank_id_core_values = [(core, idx) for idx, core in enumerate(krope_cores)]
+                krope_start_tile_offset_core_values = [(core, idx * krope_Wt) for idx, core in enumerate(krope_cores)]
 
                 unified_kernel = UnifiedKernelDescriptor(
                     kernel_source="models/demos/deepseek_v3_b1/fused_ops/pre_sdpa/kernels/pre_sdpa_kernel.cpp",
@@ -1944,13 +1951,13 @@ class PreSDPA:
                     ],
                     per_core_compile_time_descriptors=[
                         PerCoreCompileTimeDescriptor(
-                            named_compile_time_arg="qrope_bank_id",
-                            core_values=qrope_bank_id_core_values,
+                            named_compile_time_arg="qrope_start_tile_offset",
+                            core_values=qrope_start_tile_offset_core_values,
                             other_value=0,
                         ),
                         PerCoreCompileTimeDescriptor(
-                            named_compile_time_arg="krope_bank_id",
-                            core_values=krope_bank_id_core_values,
+                            named_compile_time_arg="krope_start_tile_offset",
+                            core_values=krope_start_tile_offset_core_values,
                             other_value=0,
                         ),
                     ],

--- a/models/demos/deepseek_v3_b1/micro_ops/rope/kernels/rope_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/micro_ops/rope/kernels/rope_kernel.cpp
@@ -25,11 +25,11 @@ void kernel_main() {
 // Define args per RISC (different compile-time arg layout per processor)
 // ============================================================================
 #if defined(COMPILE_FOR_NCRISC)
-    // CTArgs type alias (required for Op template)
     constexpr uint32_t Wt = get_named_compile_time_arg_val("Wt");
     constexpr uint32_t Ht = get_named_compile_time_arg_val("Ht");
     constexpr uint32_t cos_sin_page_size = get_named_compile_time_arg_val("cos_sin_page_size");
-    using RopeCTArgs = deepseek_b1_ops::Rope::ReaderCTArgs<Wt, Ht, cos_sin_page_size>;
+    constexpr uint32_t bank_id = get_named_compile_time_arg_val("bank_id");
+    using RopeCTArgs = deepseek_b1_ops::Rope::ReaderCTArgs<Wt, Ht, cos_sin_page_size, bank_id>;
 
     constexpr uint32_t in_cb = get_named_compile_time_arg_val("in_cb");
     constexpr uint32_t cos_cb = get_named_compile_time_arg_val("cos_cb");
@@ -38,15 +38,9 @@ void kernel_main() {
     constexpr uint32_t sin_tensor_address = get_named_compile_time_arg_val("sin_tensor_address");
     constexpr uint32_t position_ids_tensor_address = get_named_compile_time_arg_val("position_ids_tensor_address");
     constexpr uint32_t trans_mat_cb = get_named_compile_time_arg_val("trans_mat_cb");
-    constexpr uint32_t grid_start_x = get_named_compile_time_arg_val("grid_start_x");
-    constexpr uint32_t grid_start_y = get_named_compile_time_arg_val("grid_start_y");
-    constexpr uint32_t grid_end_x = get_named_compile_time_arg_val("grid_end_x");
-    constexpr uint32_t grid_end_y = get_named_compile_time_arg_val("grid_end_y");
 
     unified_kernels::setup_sharded_buffer(in_cb, Wt);
     unified_kernels::setup_sharded_buffer(trans_mat_cb, 1);
-
-    uint32_t core_index = unified_kernels::linear_id_in_grid<true>(grid_start_x, grid_start_y, grid_end_x, grid_end_y);
 
     deepseek_b1_ops::Rope::ReaderArgs rope_args{
         .in_cb = in_cb,
@@ -56,7 +50,6 @@ void kernel_main() {
         .sin_tensor_address = sin_tensor_address,
         .position_ids_tensor_address = position_ids_tensor_address,
         .trans_mat_cb = trans_mat_cb,
-        .cos_sin_start_page = core_index * Wt,
     };
 
 #elif defined(COMPILE_FOR_BRISC)

--- a/models/demos/deepseek_v3_b1/micro_ops/rope/kernels/rope_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/micro_ops/rope/kernels/rope_kernel.cpp
@@ -28,25 +28,35 @@ void kernel_main() {
     // CTArgs type alias (required for Op template)
     constexpr uint32_t Wt = get_named_compile_time_arg_val("Wt");
     constexpr uint32_t Ht = get_named_compile_time_arg_val("Ht");
-    using RopeCTArgs = deepseek_b1_ops::Rope::ReaderCTArgs<Wt, Ht>;
+    constexpr uint32_t cos_sin_page_size = get_named_compile_time_arg_val("cos_sin_page_size");
+    using RopeCTArgs = deepseek_b1_ops::Rope::ReaderCTArgs<Wt, Ht, cos_sin_page_size>;
 
     constexpr uint32_t in_cb = get_named_compile_time_arg_val("in_cb");
     constexpr uint32_t cos_cb = get_named_compile_time_arg_val("cos_cb");
     constexpr uint32_t sin_cb = get_named_compile_time_arg_val("sin_cb");
+    constexpr uint32_t cos_tensor_address = get_named_compile_time_arg_val("cos_tensor_address");
+    constexpr uint32_t sin_tensor_address = get_named_compile_time_arg_val("sin_tensor_address");
+    constexpr uint32_t position_ids_tensor_address = get_named_compile_time_arg_val("position_ids_tensor_address");
     constexpr uint32_t trans_mat_cb = get_named_compile_time_arg_val("trans_mat_cb");
-    // Setup sharded buffers: input CB contains Ht * Wt tiles total (consumed in Ht iterations),
-    // sin/cos CBs contain Wt tiles each (reused for all Ht heads)
+    constexpr uint32_t grid_start_x = get_named_compile_time_arg_val("grid_start_x");
+    constexpr uint32_t grid_start_y = get_named_compile_time_arg_val("grid_start_y");
+    constexpr uint32_t grid_end_x = get_named_compile_time_arg_val("grid_end_x");
+    constexpr uint32_t grid_end_y = get_named_compile_time_arg_val("grid_end_y");
+
     unified_kernels::setup_sharded_buffer(in_cb, Wt);
-    unified_kernels::setup_sharded_buffer(cos_cb, Wt);
-    unified_kernels::setup_sharded_buffer(sin_cb, Wt);
     unified_kernels::setup_sharded_buffer(trans_mat_cb, 1);
 
-    // Reader args: CB indices for sharded input signaling
+    uint32_t core_index = unified_kernels::linear_id_in_grid<true>(grid_start_x, grid_start_y, grid_end_x, grid_end_y);
+
     deepseek_b1_ops::Rope::ReaderArgs rope_args{
         .in_cb = in_cb,
         .cos_cb = cos_cb,
         .sin_cb = sin_cb,
+        .cos_tensor_address = cos_tensor_address,
+        .sin_tensor_address = sin_tensor_address,
+        .position_ids_tensor_address = position_ids_tensor_address,
         .trans_mat_cb = trans_mat_cb,
+        .cos_sin_start_page = core_index * Wt,
     };
 
 #elif defined(COMPILE_FOR_BRISC)

--- a/models/demos/deepseek_v3_b1/micro_ops/rope/kernels/rope_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/micro_ops/rope/kernels/rope_kernel.cpp
@@ -28,8 +28,9 @@ void kernel_main() {
     constexpr uint32_t Wt = get_named_compile_time_arg_val("Wt");
     constexpr uint32_t Ht = get_named_compile_time_arg_val("Ht");
     constexpr uint32_t cos_sin_page_size = get_named_compile_time_arg_val("cos_sin_page_size");
-    constexpr uint32_t bank_id = get_named_compile_time_arg_val("bank_id");
-    using RopeCTArgs = deepseek_b1_ops::Rope::ReaderCTArgs<Wt, Ht, cos_sin_page_size, bank_id>;
+    constexpr uint32_t total_Wt = get_named_compile_time_arg_val("total_Wt");
+    constexpr uint32_t start_tile_offset = get_named_compile_time_arg_val("start_tile_offset");
+    using RopeCTArgs = deepseek_b1_ops::Rope::ReaderCTArgs<Wt, Ht, cos_sin_page_size, total_Wt, start_tile_offset>;
 
     constexpr uint32_t in_cb = get_named_compile_time_arg_val("in_cb");
     constexpr uint32_t cos_cb = get_named_compile_time_arg_val("cos_cb");

--- a/models/demos/deepseek_v3_b1/micro_ops/rope/op.py
+++ b/models/demos/deepseek_v3_b1/micro_ops/rope/op.py
@@ -22,6 +22,7 @@ import torch
 
 import ttnn
 from models.demos.deepseek_v3_b1.unified_kernel_descriptor import (
+    PerCoreCompileTimeDescriptor,
     UnifiedCompileTimeCoreDescriptor,
     UnifiedKernelDescriptor,
 )
@@ -144,7 +145,7 @@ class RopeSingleCore:
         # CB 0: Input (sharded tensor)
         input_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(input_cb, input_tensor)
 
-        # CB 1: Cos (sharded tensor)
+        # CB 1: Cos (same tile format as input for broadcast compatibility)
         cos_format = ttnn.CBFormatDescriptor(
             buffer_index=cos_cb,
             data_format=data_format,
@@ -157,7 +158,7 @@ class RopeSingleCore:
             format_descriptors=[cos_format],
         )
 
-        # CB 2: Sin (sharded tensor)
+        # CB 2: Sin (same tile format as input for broadcast compatibility)
         sin_format = ttnn.CBFormatDescriptor(
             buffer_index=sin_cb,
             data_format=data_format,
@@ -219,9 +220,6 @@ class RopeSingleCore:
         # Unified Kernel Descriptor (handles NCRISC, BRISC, TRISC)
         # ========================================================================
 
-        # Grid bounds for per-core page offset computation
-        bbox = core_grid.bounding_box()
-
         # Named compile-time args for NCRISC
         ncrisc_named_compile_time_args = [
             ("in_cb", input_cb),
@@ -234,11 +232,11 @@ class RopeSingleCore:
             ("cos_sin_page_size", tile_size),
             ("Wt", head_dim_per_core_t),
             ("Ht", 1),
-            ("grid_start_x", bbox.start.x),
-            ("grid_start_y", bbox.start.y),
-            ("grid_end_x", bbox.end.x),
-            ("grid_end_y", bbox.end.y),
         ]
+
+        # Per-core bank_id: each compute core reads from its assigned DRAM bank
+        all_cores = ttnn.corerange_to_cores(core_grid)
+        bank_id_core_values = [(core, idx) for idx, core in enumerate(all_cores)]
 
         # Named compile-time args for BRISC (empty - no-op)
         brisc_named_compile_time_args = []
@@ -275,6 +273,13 @@ class RopeSingleCore:
                     named_compile_time_arg="is_active_core",
                     core_range=core_grid,
                     value=1,
+                    other_value=0,
+                ),
+            ],
+            per_core_compile_time_descriptors=[
+                PerCoreCompileTimeDescriptor(
+                    named_compile_time_arg="bank_id",
+                    core_values=bank_id_core_values,
                     other_value=0,
                 ),
             ],

--- a/models/demos/deepseek_v3_b1/micro_ops/rope/op.py
+++ b/models/demos/deepseek_v3_b1/micro_ops/rope/op.py
@@ -221,6 +221,9 @@ class RopeSingleCore:
         # ========================================================================
 
         # Named compile-time args for NCRISC
+        num_cores = core_grid.num_cores()
+        total_Wt = head_dim_per_core_t * num_cores
+
         ncrisc_named_compile_time_args = [
             ("in_cb", input_cb),
             ("cos_tensor_address", cos_tensor.buffer_address()),
@@ -232,11 +235,12 @@ class RopeSingleCore:
             ("cos_sin_page_size", tile_size),
             ("Wt", head_dim_per_core_t),
             ("Ht", 1),
+            ("total_Wt", total_Wt),
         ]
 
-        # Per-core bank_id: each compute core reads from its assigned DRAM bank
+        # Per-core start_tile_offset: each core reads its width slice from DRAM
         all_cores = ttnn.corerange_to_cores(core_grid)
-        bank_id_core_values = [(core, idx) for idx, core in enumerate(all_cores)]
+        start_tile_offset_core_values = [(core, idx * head_dim_per_core_t) for idx, core in enumerate(all_cores)]
 
         # Named compile-time args for BRISC (empty - no-op)
         brisc_named_compile_time_args = []
@@ -278,8 +282,8 @@ class RopeSingleCore:
             ],
             per_core_compile_time_descriptors=[
                 PerCoreCompileTimeDescriptor(
-                    named_compile_time_arg="bank_id",
-                    core_values=bank_id_core_values,
+                    named_compile_time_arg="start_tile_offset",
+                    core_values=start_tile_offset_core_values,
                     other_value=0,
                 ),
             ],

--- a/models/demos/deepseek_v3_b1/micro_ops/rope/op.py
+++ b/models/demos/deepseek_v3_b1/micro_ops/rope/op.py
@@ -82,6 +82,7 @@ class RopeSingleCore:
         cos_tensor,
         sin_tensor,
         trans_mat_tensor,
+        position_ids_tensor,
         output_tensor,
         fp32_dest_acc_en=False,
     ):
@@ -144,10 +145,30 @@ class RopeSingleCore:
         input_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(input_cb, input_tensor)
 
         # CB 1: Cos (sharded tensor)
-        cos_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(cos_cb, cos_tensor)
+        cos_format = ttnn.CBFormatDescriptor(
+            buffer_index=cos_cb,
+            data_format=data_format,
+            page_size=tile_size,
+            tile=tile_descriptor,
+        )
+        cos_cb_descriptor = ttnn.CBDescriptor(
+            total_size=head_dim_per_core_t * tile_size,
+            core_ranges=core_grid,
+            format_descriptors=[cos_format],
+        )
 
         # CB 2: Sin (sharded tensor)
-        sin_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(sin_cb, sin_tensor)
+        sin_format = ttnn.CBFormatDescriptor(
+            buffer_index=sin_cb,
+            data_format=data_format,
+            page_size=tile_size,
+            tile=tile_descriptor,
+        )
+        sin_cb_descriptor = ttnn.CBDescriptor(
+            total_size=head_dim_per_core_t * tile_size,
+            core_ranges=core_grid,
+            format_descriptors=[sin_format],
+        )
 
         # CB 3: Trans_mat (sharded tensor)
         trans_mat_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(trans_mat_cb, trans_mat_tensor)
@@ -198,14 +219,25 @@ class RopeSingleCore:
         # Unified Kernel Descriptor (handles NCRISC, BRISC, TRISC)
         # ========================================================================
 
+        # Grid bounds for per-core page offset computation
+        bbox = core_grid.bounding_box()
+
         # Named compile-time args for NCRISC
         ncrisc_named_compile_time_args = [
             ("in_cb", input_cb),
+            ("cos_tensor_address", cos_tensor.buffer_address()),
+            ("sin_tensor_address", sin_tensor.buffer_address()),
+            ("position_ids_tensor_address", position_ids_tensor.buffer_address()),
             ("cos_cb", cos_cb),
             ("sin_cb", sin_cb),
             ("trans_mat_cb", trans_mat_cb),
+            ("cos_sin_page_size", tile_size),
             ("Wt", head_dim_per_core_t),
             ("Ht", 1),
+            ("grid_start_x", bbox.start.x),
+            ("grid_start_y", bbox.start.y),
+            ("grid_end_x", bbox.end.x),
+            ("grid_end_y", bbox.end.y),
         ]
 
         # Named compile-time args for BRISC (empty - no-op)

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_kv_cache_branch.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_kv_cache_branch.py
@@ -172,25 +172,30 @@ def test_kv_cache_branch(device, epsilon, use_fp32, position_id):
     )
 
     # ROPE
-    # Cos/sin indexed by position: [1, batch, 1, head_dim]
-    # Shape stays [1, 1, 1, head_dim] - broadcast multiply will use row 0
     rope_tile = ttnn.Tile((rope_num_heads, ttnn.TILE_SIZE))
     trans_tile = ttnn.Tile((ttnn.TILE_SIZE, ttnn.TILE_SIZE))
-    cos_selected = torch_cos[position_ids].unsqueeze(0).unsqueeze(2)
-    sin_selected = torch_sin[position_ids].unsqueeze(0).unsqueeze(2)
 
-    # Use same tiny tile as input - data in row 0, rows 1+ are padding
+    # Full cos/sin cache in DRAM WIDTH_SHARDED: [1, 1, max_seq_len * rope_num_heads, rope_head_dim]
+    # Each position's cos/sin row is repeated rope_num_heads times to match tile height.
+    # Kernel indexes by position_id at runtime.
+    num_rope_cores = rope_crs.num_cores()
+    cos_repeated = torch_cos.unsqueeze(1).expand(-1, rope_num_heads, -1).reshape(-1, rope_head_dim)
+    sin_repeated = torch_sin.unsqueeze(1).expand(-1, rope_num_heads, -1).reshape(-1, rope_head_dim)
+    cos_full = cos_repeated.unsqueeze(0).unsqueeze(0)  # [1, 1, max_seq_len * rope_num_heads, rope_head_dim]
+    sin_full = sin_repeated.unsqueeze(0).unsqueeze(0)
+
+    dram_shard_grid = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(num_rope_cores - 1, 0))})
     cos_sin_shard_spec = ttnn.ShardSpec(
-        rope_crs,
-        (rope_num_heads, rope_head_dim // 2),
+        dram_shard_grid,
+        (max_seq_len * rope_num_heads, rope_head_dim // num_rope_cores),
         ttnn.ShardOrientation.ROW_MAJOR,
     )
     cos_sin_mem_config = ttnn.MemoryConfig(
-        ttnn.TensorMemoryLayout.WIDTH_SHARDED, ttnn.BufferType.L1, cos_sin_shard_spec
+        ttnn.TensorMemoryLayout.WIDTH_SHARDED, ttnn.BufferType.DRAM, cos_sin_shard_spec
     )
 
     tt_cos = ttnn.from_torch(
-        cos_selected,
+        cos_full,
         dtype=ttnn.bfloat16,
         layout=ttnn.TILE_LAYOUT,
         device=device,
@@ -198,7 +203,7 @@ def test_kv_cache_branch(device, epsilon, use_fp32, position_id):
         tile=rope_tile,
     )
     tt_sin = ttnn.from_torch(
-        sin_selected,
+        sin_full,
         dtype=ttnn.bfloat16,
         layout=ttnn.TILE_LAYOUT,
         device=device,

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_kv_cache_branch.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_kv_cache_branch.py
@@ -175,24 +175,16 @@ def test_kv_cache_branch(device, epsilon, use_fp32, position_id):
     rope_tile = ttnn.Tile((rope_num_heads, ttnn.TILE_SIZE))
     trans_tile = ttnn.Tile((ttnn.TILE_SIZE, ttnn.TILE_SIZE))
 
-    # Full cos/sin cache in DRAM WIDTH_SHARDED: [1, 1, max_seq_len * rope_num_heads, rope_head_dim]
+    # Full cos/sin cache in DRAM INTERLEAVED: [1, 1, max_seq_len * rope_num_heads, rope_head_dim]
     # Each position's cos/sin row is repeated rope_num_heads times to match tile height.
-    # Kernel indexes by position_id at runtime.
+    # Kernel indexes by position_id at runtime via TensorAccessor.
     num_rope_cores = rope_crs.num_cores()
     cos_repeated = torch_cos.unsqueeze(1).expand(-1, rope_num_heads, -1).reshape(-1, rope_head_dim)
     sin_repeated = torch_sin.unsqueeze(1).expand(-1, rope_num_heads, -1).reshape(-1, rope_head_dim)
     cos_full = cos_repeated.unsqueeze(0).unsqueeze(0)  # [1, 1, max_seq_len * rope_num_heads, rope_head_dim]
     sin_full = sin_repeated.unsqueeze(0).unsqueeze(0)
 
-    dram_shard_grid = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(num_rope_cores - 1, 0))})
-    cos_sin_shard_spec = ttnn.ShardSpec(
-        dram_shard_grid,
-        (max_seq_len * rope_num_heads, rope_head_dim // num_rope_cores),
-        ttnn.ShardOrientation.ROW_MAJOR,
-    )
-    cos_sin_mem_config = ttnn.MemoryConfig(
-        ttnn.TensorMemoryLayout.WIDTH_SHARDED, ttnn.BufferType.DRAM, cos_sin_shard_spec
-    )
+    cos_sin_mem_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.DRAM)
 
     tt_cos = ttnn.from_torch(
         cos_full,

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_kv_cache_branch.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_kv_cache_branch.py
@@ -280,6 +280,23 @@ def test_kv_cache_branch(device, epsilon, use_fp32, position_id):
         tile=tile,
     )
 
+    position_replicated = torch.full((device_grid_size.x * device_grid_size.y, 1), position_id, dtype=torch.int32)
+    pos_core_grid = ttnn.CoreRangeSet(
+        [ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(device_grid_size.x - 1, device_grid_size.y - 1))]
+    )
+    pos_mem_config = ttnn.MemoryConfig(
+        ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+        ttnn.BufferType.L1,
+        ttnn.ShardSpec(pos_core_grid, (1, 1), ttnn.ShardOrientation.ROW_MAJOR),
+    )
+    ttnn_position_ids = ttnn.from_torch(
+        position_replicated,
+        dtype=ttnn.int32,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        device=device,
+        memory_config=pos_mem_config,
+    )
+
     logger.info(f"Created KV cache tensor in DRAM with shape {kv_cache_shape}")
 
     logger.info(f"Created tensors sharded on single core with shard shape {output_shard_shape}")
@@ -294,7 +311,7 @@ def test_kv_cache_branch(device, epsilon, use_fp32, position_id):
         tt_trans_replicated,
         ttnn_output,
         ttnn_kv_cache,
-        kv_cache_write_index=position_id,  # Which sequence position to write to
+        position_ids_tensor=ttnn_position_ids,  # Current decode position, used as DRAM page ID for KV cache write
     )
 
     logger.info("Running KV cache branch golden reference...")

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_pre_sdpa.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_pre_sdpa.py
@@ -509,23 +509,12 @@ def test_pre_sdpa(
         ttnn.CoreCoord(QNOPE_GRID_COLS, 0), ttnn.CoreCoord(QNOPE_GRID_COLS + QROPE_GRID_COLS - 1, matmul2_grid_y - 1)
     )
 
-    # QRoPE cos/sin: WIDTH_SHARDED DRAM on 1 bank (all qrope cores read full head_dim)
+    # QRoPE cos/sin: DRAM INTERLEAVED (all qrope cores read full head_dim)
     # Shape: [1, 1, max_seq_len, qrope_head_dim]
     qrope_cos_full = torch_cos.unsqueeze(0).unsqueeze(0)  # [1, 1, max_seq_len, 64]
     qrope_sin_full = torch_sin.unsqueeze(0).unsqueeze(0)  # [1, 1, max_seq_len, 64]
 
-    qrope_dram_num_banks = 1
-    qrope_dram_shard_grid = ttnn.CoreRangeSet(
-        {ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(qrope_dram_num_banks - 1, 0))}
-    )
-    qrope_dram_shard_spec = ttnn.ShardSpec(
-        qrope_dram_shard_grid,
-        (max_seq_len, QROPE_HEAD_DIM // qrope_dram_num_banks),
-        ttnn.ShardOrientation.ROW_MAJOR,
-    )
-    qrope_dram_mem_config = ttnn.MemoryConfig(
-        ttnn.TensorMemoryLayout.WIDTH_SHARDED, ttnn.BufferType.DRAM, qrope_dram_shard_spec
-    )
+    qrope_dram_mem_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.DRAM)
 
     ttnn_qrope_cos = ttnn.from_torch(
         qrope_cos_full,
@@ -622,22 +611,12 @@ def test_pre_sdpa(
         mesh_mapper=ttnn.ReplicateTensorToMesh(submesh),
     )
 
-    # KRoPE cos/sin: WIDTH_SHARDED DRAM on 2 banks (matching 2 krope cores)
+    # KRoPE cos/sin: DRAM INTERLEAVED (each krope core reads its width slice)
     krope_num_cores = kv_cache_branch_rope_crs.num_cores()
     krope_cos_full = torch_cos.unsqueeze(0).unsqueeze(0)  # [1, 1, max_seq_len, 64]
     krope_sin_full = torch_sin.unsqueeze(0).unsqueeze(0)  # [1, 1, max_seq_len, 64]
 
-    krope_dram_shard_grid = ttnn.CoreRangeSet(
-        {ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(krope_num_cores - 1, 0))}
-    )
-    krope_dram_shard_spec = ttnn.ShardSpec(
-        krope_dram_shard_grid,
-        (max_seq_len, KROPE_DIM // krope_num_cores),
-        ttnn.ShardOrientation.ROW_MAJOR,
-    )
-    krope_dram_mem_config = ttnn.MemoryConfig(
-        ttnn.TensorMemoryLayout.WIDTH_SHARDED, ttnn.BufferType.DRAM, krope_dram_shard_spec
-    )
+    krope_dram_mem_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.DRAM)
 
     ttnn_krope_cos = ttnn.from_torch(
         krope_cos_full,

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_pre_sdpa.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_pre_sdpa.py
@@ -504,52 +504,45 @@ def test_pre_sdpa(
         mesh_mapper=ttnn.ReplicateTensorToMesh(submesh),
     )
 
-    # RoPE tensors - sharded on Qrope grid (4x8 = 32 cores)
+    # RoPE tensors
     qrope_grid = ttnn.CoreRange(
         ttnn.CoreCoord(QNOPE_GRID_COLS, 0), ttnn.CoreCoord(QNOPE_GRID_COLS + QROPE_GRID_COLS - 1, matmul2_grid_y - 1)
     )
 
-    # For decode mode, cos/sin are indexed by position: [1, batch, 1, head_dim]
-    # Shape: [1, 1, 1, qrope_head_dim] - broadcast multiply will use row 0
+    # QRoPE cos/sin: WIDTH_SHARDED DRAM on 1 bank (all qrope cores read full head_dim)
+    # Shape: [1, 1, max_seq_len, qrope_head_dim]
+    qrope_cos_full = torch_cos.unsqueeze(0).unsqueeze(0)  # [1, 1, max_seq_len, 64]
+    qrope_sin_full = torch_sin.unsqueeze(0).unsqueeze(0)  # [1, 1, max_seq_len, 64]
 
-    # Cos/Sin sharding: HEIGHT_SHARDED on qrope grid
-    # Each core gets full head_dim (since cos/sin are reused for all heads on that core)
-    # Shape per core: (1, qrope_head_dim) = (1, 64)
-    # Shared with KV Cache branch, double check if modifying these tensors
-    cos_selected = torch_cos[position_ids].unsqueeze(0).unsqueeze(2)  # [1, batch, 1, qrope_head_dim] = [1, 1, 1, 64]
-    sin_selected = torch_sin[position_ids].unsqueeze(0).unsqueeze(2)  # [1, batch, 1, qrope_head_dim] = [1, 1, 1, 64]
-
-    qrope_cos_sin_shard_shape = (1, QROPE_HEAD_DIM)  # [1, 64] per core
-    qrope_cos_sin_shard_spec = ttnn.ShardSpec(
-        ttnn.CoreRangeSet({qrope_grid}),
-        qrope_cos_sin_shard_shape,
+    qrope_dram_num_banks = 1
+    qrope_dram_shard_grid = ttnn.CoreRangeSet(
+        {ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(qrope_dram_num_banks - 1, 0))}
+    )
+    qrope_dram_shard_spec = ttnn.ShardSpec(
+        qrope_dram_shard_grid,
+        (max_seq_len, QROPE_HEAD_DIM // qrope_dram_num_banks),
         ttnn.ShardOrientation.ROW_MAJOR,
     )
-    qrope_cos_sin_mem_config = ttnn.MemoryConfig(
-        ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, qrope_cos_sin_shard_spec
+    qrope_dram_mem_config = ttnn.MemoryConfig(
+        ttnn.TensorMemoryLayout.WIDTH_SHARDED, ttnn.BufferType.DRAM, qrope_dram_shard_spec
     )
 
-    # Repeat cos/sin for all qrope cores: [1, 1, num_cores, qrope_head_dim]
-    # Each core gets the same cos/sin (reused for its 2 heads)
-    cos_replicated = cos_selected.repeat(1, 1, qrope_num_cores, 1)  # [1, 1, 32, 64]
-    sin_replicated = sin_selected.repeat(1, 1, qrope_num_cores, 1)  # [1, 1, 32, 64]
-
     ttnn_qrope_cos = ttnn.from_torch(
-        cos_replicated,
+        qrope_cos_full,
         dtype=ttnn.bfloat16,
         layout=ttnn.TILE_LAYOUT,
         device=submesh,
-        memory_config=qrope_cos_sin_mem_config,
+        memory_config=qrope_dram_mem_config,
         tile=tile,
         mesh_mapper=ttnn.ReplicateTensorToMesh(submesh),
     )
 
     ttnn_qrope_sin = ttnn.from_torch(
-        sin_replicated,
+        qrope_sin_full,
         dtype=ttnn.bfloat16,
         layout=ttnn.TILE_LAYOUT,
         device=submesh,
-        memory_config=qrope_cos_sin_mem_config,
+        memory_config=qrope_dram_mem_config,
         tile=tile,
         mesh_mapper=ttnn.ReplicateTensorToMesh(submesh),
     )
@@ -629,31 +622,38 @@ def test_pre_sdpa(
         mesh_mapper=ttnn.ReplicateTensorToMesh(submesh),
     )
 
-    krope_num_heads = 1
-    krope_cos_sin_shard_spec = ttnn.ShardSpec(
-        kv_cache_branch_rope_crs,
-        (krope_num_heads, KROPE_DIM // 2),
+    # KRoPE cos/sin: WIDTH_SHARDED DRAM on 2 banks (matching 2 krope cores)
+    krope_num_cores = kv_cache_branch_rope_crs.num_cores()
+    krope_cos_full = torch_cos.unsqueeze(0).unsqueeze(0)  # [1, 1, max_seq_len, 64]
+    krope_sin_full = torch_sin.unsqueeze(0).unsqueeze(0)  # [1, 1, max_seq_len, 64]
+
+    krope_dram_shard_grid = ttnn.CoreRangeSet(
+        {ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(krope_num_cores - 1, 0))}
+    )
+    krope_dram_shard_spec = ttnn.ShardSpec(
+        krope_dram_shard_grid,
+        (max_seq_len, KROPE_DIM // krope_num_cores),
         ttnn.ShardOrientation.ROW_MAJOR,
     )
-    krope_cos_sin_mem_config = ttnn.MemoryConfig(
-        ttnn.TensorMemoryLayout.WIDTH_SHARDED, ttnn.BufferType.L1, krope_cos_sin_shard_spec
+    krope_dram_mem_config = ttnn.MemoryConfig(
+        ttnn.TensorMemoryLayout.WIDTH_SHARDED, ttnn.BufferType.DRAM, krope_dram_shard_spec
     )
 
     ttnn_krope_cos = ttnn.from_torch(
-        cos_selected,
+        krope_cos_full,
         dtype=ttnn.bfloat16,
         layout=ttnn.TILE_LAYOUT,
         device=submesh,
-        memory_config=krope_cos_sin_mem_config,
+        memory_config=krope_dram_mem_config,
         tile=tile,
         mesh_mapper=ttnn.ReplicateTensorToMesh(submesh),
     )
     ttnn_krope_sin = ttnn.from_torch(
-        sin_selected,
+        krope_sin_full,
         dtype=ttnn.bfloat16,
         layout=ttnn.TILE_LAYOUT,
         device=submesh,
-        memory_config=krope_cos_sin_mem_config,
+        memory_config=krope_dram_mem_config,
         tile=tile,
         mesh_mapper=ttnn.ReplicateTensorToMesh(submesh),
     )
@@ -745,7 +745,8 @@ def test_pre_sdpa(
             ttnn_dkv_matmul_weights,
             ttnn_dkv_rmsnorm_gamma,
             ttnn_kv_cache,
-            position_ids,
+            position_id,
+            ttnn_position_ids,
             ttnn_sdpa_input_output,
             sdpa_kv_cache_buffer,
             sdpa_out_interm_buffer,

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_pre_sdpa.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_pre_sdpa.py
@@ -658,6 +658,24 @@ def test_pre_sdpa(
         mesh_mapper=ttnn.ReplicateTensorToMesh(submesh),
     )
 
+    position_replicated = torch.full((device_grid_size.x * device_grid_size.y, 1), position_id, dtype=torch.int32)
+    pos_core_grid = ttnn.CoreRangeSet(
+        [ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(device_grid_size.x - 1, device_grid_size.y - 1))]
+    )
+    pos_mem_config = ttnn.MemoryConfig(
+        ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+        ttnn.BufferType.L1,
+        ttnn.ShardSpec(pos_core_grid, (1, 1), ttnn.ShardOrientation.ROW_MAJOR),
+    )
+    ttnn_position_ids = ttnn.from_torch(
+        position_replicated,
+        dtype=ttnn.int32,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        device=submesh,
+        memory_config=pos_mem_config,
+        mesh_mapper=ttnn.ReplicateTensorToMesh(submesh),
+    )
+
     num_cores = device_grid_size.x * device_grid_size.y
     available_cores = ttnn.num_cores_to_corerangeset(num_cores, device_grid_size, row_wise=True)
     out_ready_semaphore = ttnn.create_global_semaphore(submesh, available_cores, 0)

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_rope.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_rope.py
@@ -93,16 +93,27 @@ def test_rope_decode(device, batch, num_heads, head_dim, position_id, grid_size,
         tile=tiny_tile,
     )
 
-    # For decode mode, cos/sin are indexed by position: [1, batch, 1, head_dim]
-    # Shape stays [1, 1, 1, head_dim] - broadcast multiply will use row 0
-    cos_selected = cos[position_ids].unsqueeze(0).unsqueeze(2)  # [1, batch, 1, head_dim]
-    sin_selected = sin[position_ids].unsqueeze(0).unsqueeze(2)  # [1, batch, 1, head_dim]
+    # Full cos/sin cache in DRAM WIDTH_SHARDED: [1, 1, max_seq_len * num_heads, head_dim]
+    # Each position's cos/sin row is repeated num_heads times to match the input tile height.
+    # Kernel indexes by position_id at runtime.
+    cos_repeated = cos.unsqueeze(1).expand(-1, num_heads, -1).reshape(-1, head_dim)
+    sin_repeated = sin.unsqueeze(1).expand(-1, num_heads, -1).reshape(-1, head_dim)
+    cos_full = cos_repeated.unsqueeze(0).unsqueeze(0)  # [1, 1, max_seq_len * num_heads, head_dim]
+    sin_full = sin_repeated.unsqueeze(0).unsqueeze(0)
 
-    # Cos/sin stored in DRAM interleaved - NCRISC will DMA-read into CBs
-    cos_sin_mem_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.DRAM)
+    num_cores = core_grid.num_cores()
+    dram_shard_grid = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(num_cores - 1, 0))})
+    cos_sin_shard_spec = ttnn.ShardSpec(
+        dram_shard_grid,
+        (max_seq_len * num_heads, head_dim // num_cores),
+        ttnn.ShardOrientation.ROW_MAJOR,
+    )
+    cos_sin_mem_config = ttnn.MemoryConfig(
+        ttnn.TensorMemoryLayout.WIDTH_SHARDED, ttnn.BufferType.DRAM, cos_sin_shard_spec
+    )
 
     tt_cos = ttnn.from_torch(
-        cos_selected,
+        cos_full,
         dtype=ttnn.bfloat16,
         layout=ttnn.TILE_LAYOUT,
         device=device,
@@ -110,7 +121,7 @@ def test_rope_decode(device, batch, num_heads, head_dim, position_id, grid_size,
         tile=tiny_tile,
     )
     tt_sin = ttnn.from_torch(
-        sin_selected,
+        sin_full,
         dtype=ttnn.bfloat16,
         layout=ttnn.TILE_LAYOUT,
         device=device,
@@ -141,7 +152,7 @@ def test_rope_decode(device, batch, num_heads, head_dim, position_id, grid_size,
     )
 
     device_grid_size = device.compute_with_storage_grid_size()
-    position_replicated = torch.full((device_grid_size.x * device_grid_size.y, 1), 0, dtype=torch.int32)
+    position_replicated = torch.full((device_grid_size.x * device_grid_size.y, 1), position_id, dtype=torch.int32)
     pos_core_grid = ttnn.CoreRangeSet(
         [ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(device_grid_size.x - 1, device_grid_size.y - 1))]
     )
@@ -272,16 +283,25 @@ def test_rope_decode_yarn(device, batch, num_heads, head_dim, position_id, pcc):
         tile=tiny_tile,
     )
 
-    # Cos/sin indexed by position: [1, batch, 1, head_dim]
-    # Shape stays [1, 1, 1, head_dim] - broadcast multiply will use row 0
-    cos_selected = cos[position_ids].unsqueeze(0).unsqueeze(2)
-    sin_selected = sin[position_ids].unsqueeze(0).unsqueeze(2)
+    # Full cos/sin cache in DRAM WIDTH_SHARDED: [1, batch, max_seq_len * num_heads, head_dim]
+    cos_repeated = cos.unsqueeze(1).expand(-1, num_heads, -1).reshape(-1, head_dim)
+    sin_repeated = sin.unsqueeze(1).expand(-1, num_heads, -1).reshape(-1, head_dim)
+    cos_full = cos_repeated.unsqueeze(0).unsqueeze(0)
+    sin_full = sin_repeated.unsqueeze(0).unsqueeze(0)
 
-    # Cos/sin stored in DRAM interleaved - NCRISC will DMA-read into CBs
-    cos_sin_mem_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.DRAM)
+    num_cores = core_grid.num_cores()
+    dram_shard_grid = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(num_cores - 1, 0))})
+    cos_sin_shard_spec = ttnn.ShardSpec(
+        dram_shard_grid,
+        (max_seq_len * num_heads, head_dim // num_cores),
+        ttnn.ShardOrientation.ROW_MAJOR,
+    )
+    cos_sin_mem_config = ttnn.MemoryConfig(
+        ttnn.TensorMemoryLayout.WIDTH_SHARDED, ttnn.BufferType.DRAM, cos_sin_shard_spec
+    )
 
     tt_cos = ttnn.from_torch(
-        cos_selected,
+        cos_full,
         dtype=ttnn.bfloat16,
         layout=ttnn.TILE_LAYOUT,
         device=device,
@@ -289,7 +309,7 @@ def test_rope_decode_yarn(device, batch, num_heads, head_dim, position_id, pcc):
         tile=tiny_tile,
     )
     tt_sin = ttnn.from_torch(
-        sin_selected,
+        sin_full,
         dtype=ttnn.bfloat16,
         layout=ttnn.TILE_LAYOUT,
         device=device,
@@ -318,7 +338,7 @@ def test_rope_decode_yarn(device, batch, num_heads, head_dim, position_id, pcc):
         tile=trans_tile,
     )
     device_grid_size = device.compute_with_storage_grid_size()
-    position_replicated = torch.full((device_grid_size.x * device_grid_size.y, 1), 0, dtype=torch.int32)
+    position_replicated = torch.full((device_grid_size.x * device_grid_size.y, 1), position_id, dtype=torch.int32)
     pos_core_grid = ttnn.CoreRangeSet(
         [ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(device_grid_size.x - 1, device_grid_size.y - 1))]
     )

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_rope.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_rope.py
@@ -93,24 +93,15 @@ def test_rope_decode(device, batch, num_heads, head_dim, position_id, grid_size,
         tile=tiny_tile,
     )
 
-    # Full cos/sin cache in DRAM WIDTH_SHARDED: [1, 1, max_seq_len * num_heads, head_dim]
+    # Full cos/sin cache in DRAM INTERLEAVED: [1, 1, max_seq_len * num_heads, head_dim]
     # Each position's cos/sin row is repeated num_heads times to match the input tile height.
-    # Kernel indexes by position_id at runtime.
+    # Kernel indexes by position_id at runtime via TensorAccessor.
     cos_repeated = cos.unsqueeze(1).expand(-1, num_heads, -1).reshape(-1, head_dim)
     sin_repeated = sin.unsqueeze(1).expand(-1, num_heads, -1).reshape(-1, head_dim)
     cos_full = cos_repeated.unsqueeze(0).unsqueeze(0)  # [1, 1, max_seq_len * num_heads, head_dim]
     sin_full = sin_repeated.unsqueeze(0).unsqueeze(0)
 
-    num_cores = core_grid.num_cores()
-    dram_shard_grid = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(num_cores - 1, 0))})
-    cos_sin_shard_spec = ttnn.ShardSpec(
-        dram_shard_grid,
-        (max_seq_len * num_heads, head_dim // num_cores),
-        ttnn.ShardOrientation.ROW_MAJOR,
-    )
-    cos_sin_mem_config = ttnn.MemoryConfig(
-        ttnn.TensorMemoryLayout.WIDTH_SHARDED, ttnn.BufferType.DRAM, cos_sin_shard_spec
-    )
+    cos_sin_mem_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.DRAM)
 
     tt_cos = ttnn.from_torch(
         cos_full,
@@ -283,22 +274,13 @@ def test_rope_decode_yarn(device, batch, num_heads, head_dim, position_id, pcc):
         tile=tiny_tile,
     )
 
-    # Full cos/sin cache in DRAM WIDTH_SHARDED: [1, batch, max_seq_len * num_heads, head_dim]
+    # Full cos/sin cache in DRAM INTERLEAVED: [1, batch, max_seq_len * num_heads, head_dim]
     cos_repeated = cos.unsqueeze(1).expand(-1, num_heads, -1).reshape(-1, head_dim)
     sin_repeated = sin.unsqueeze(1).expand(-1, num_heads, -1).reshape(-1, head_dim)
     cos_full = cos_repeated.unsqueeze(0).unsqueeze(0)
     sin_full = sin_repeated.unsqueeze(0).unsqueeze(0)
 
-    num_cores = core_grid.num_cores()
-    dram_shard_grid = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(num_cores - 1, 0))})
-    cos_sin_shard_spec = ttnn.ShardSpec(
-        dram_shard_grid,
-        (max_seq_len * num_heads, head_dim // num_cores),
-        ttnn.ShardOrientation.ROW_MAJOR,
-    )
-    cos_sin_mem_config = ttnn.MemoryConfig(
-        ttnn.TensorMemoryLayout.WIDTH_SHARDED, ttnn.BufferType.DRAM, cos_sin_shard_spec
-    )
+    cos_sin_mem_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.DRAM)
 
     tt_cos = ttnn.from_torch(
         cos_full,

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_rope.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_rope.py
@@ -98,16 +98,8 @@ def test_rope_decode(device, batch, num_heads, head_dim, position_id, grid_size,
     cos_selected = cos[position_ids].unsqueeze(0).unsqueeze(2)  # [1, batch, 1, head_dim]
     sin_selected = sin[position_ids].unsqueeze(0).unsqueeze(2)  # [1, batch, 1, head_dim]
 
-    # Use same tiny tile as input - data in row 0, rows 1+ are padding
-    # Broadcast multiply reads row 0 and broadcasts to all rows
-    cos_sin_shard_spec = ttnn.ShardSpec(
-        core_grid,
-        (num_heads, head_dim // (core_grid.num_cores())),
-        ttnn.ShardOrientation.ROW_MAJOR,
-    )
-    cos_sin_mem_config = ttnn.MemoryConfig(
-        ttnn.TensorMemoryLayout.WIDTH_SHARDED, ttnn.BufferType.L1, cos_sin_shard_spec
-    )
+    # Cos/sin stored in DRAM interleaved - NCRISC will DMA-read into CBs
+    cos_sin_mem_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.DRAM)
 
     tt_cos = ttnn.from_torch(
         cos_selected,
@@ -148,6 +140,24 @@ def test_rope_decode(device, batch, num_heads, head_dim, position_id, grid_size,
         tile=trans_tile,
     )
 
+    device_grid_size = device.compute_with_storage_grid_size()
+    position_replicated = torch.full((device_grid_size.x * device_grid_size.y, 1), 0, dtype=torch.int32)
+    pos_core_grid = ttnn.CoreRangeSet(
+        [ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(device_grid_size.x - 1, device_grid_size.y - 1))]
+    )
+    pos_mem_config = ttnn.MemoryConfig(
+        ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+        ttnn.BufferType.L1,
+        ttnn.ShardSpec(pos_core_grid, (1, 1), ttnn.ShardOrientation.ROW_MAJOR),
+    )
+    ttnn_position_ids = ttnn.from_torch(
+        position_replicated,
+        dtype=ttnn.int32,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        device=device,
+        memory_config=pos_mem_config,
+    )
+
     # Create output tensor with same sharded memory config and tiny tile as input
     torch_output_zeros = torch.zeros_like(x_ttnn, dtype=torch.bfloat16)
     tt_out = ttnn.from_torch(
@@ -165,6 +175,7 @@ def test_rope_decode(device, batch, num_heads, head_dim, position_id, grid_size,
         tt_cos,
         tt_sin,
         tt_trans_replicated,
+        ttnn_position_ids,
         tt_out,
     )
 
@@ -266,15 +277,8 @@ def test_rope_decode_yarn(device, batch, num_heads, head_dim, position_id, pcc):
     cos_selected = cos[position_ids].unsqueeze(0).unsqueeze(2)
     sin_selected = sin[position_ids].unsqueeze(0).unsqueeze(2)
 
-    # Use same tiny tile as input - data in row 0, rows 1+ are padding
-    cos_sin_shard_spec = ttnn.ShardSpec(
-        core_grid,
-        (num_heads, head_dim),
-        ttnn.ShardOrientation.ROW_MAJOR,
-    )
-    cos_sin_mem_config = ttnn.MemoryConfig(
-        ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, cos_sin_shard_spec
-    )
+    # Cos/sin stored in DRAM interleaved - NCRISC will DMA-read into CBs
+    cos_sin_mem_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.DRAM)
 
     tt_cos = ttnn.from_torch(
         cos_selected,
@@ -313,6 +317,23 @@ def test_rope_decode_yarn(device, batch, num_heads, head_dim, position_id, pcc):
         memory_config=trans_mem_config,
         tile=trans_tile,
     )
+    device_grid_size = device.compute_with_storage_grid_size()
+    position_replicated = torch.full((device_grid_size.x * device_grid_size.y, 1), 0, dtype=torch.int32)
+    pos_core_grid = ttnn.CoreRangeSet(
+        [ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(device_grid_size.x - 1, device_grid_size.y - 1))]
+    )
+    pos_mem_config = ttnn.MemoryConfig(
+        ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+        ttnn.BufferType.L1,
+        ttnn.ShardSpec(pos_core_grid, (1, 1), ttnn.ShardOrientation.ROW_MAJOR),
+    )
+    ttnn_position_ids = ttnn.from_torch(
+        position_replicated,
+        dtype=ttnn.int32,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        device=device,
+        memory_config=pos_mem_config,
+    )
 
     # Create output tensor with same sharded memory config and tiny tile as input
     torch_output_zeros = torch.zeros_like(x_ttnn, dtype=torch.bfloat16)
@@ -331,6 +352,7 @@ def test_rope_decode_yarn(device, batch, num_heads, head_dim, position_id, pcc):
         tt_cos,
         tt_sin,
         tt_trans,
+        ttnn_position_ids,
         tt_out,
     )
 

--- a/models/demos/deepseek_v3_b1/unified_kernels/rope.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/rope.hpp
@@ -16,6 +16,7 @@
 #include "api/compute/eltwise_binary.h"
 #include "api/compute/tile_move_copy.h"
 #include "api/compute/reg_api.h"
+#include "api/debug/dprint.h"
 #endif
 
 namespace deepseek_b1_ops {
@@ -37,10 +38,11 @@ struct Rope {
     // ========================================================================
 
     // Reader CTArgs (NCRISC): Wt and Ht for sharded input signaling
-    template <uint32_t Wt_, uint32_t Ht_>
+    template <uint32_t Wt_, uint32_t Ht_, uint32_t CosSinPageSize_ = 64>
     struct ReaderCTArgs {
         static constexpr uint32_t Wt = Wt_;  // head_dim in tiles
         static constexpr uint32_t Ht = Ht_;  // num_heads per core
+        static constexpr uint32_t cos_sin_page_size = CosSinPageSize_;
     };
 
     // Writer CTArgs (BRISC): none
@@ -62,7 +64,11 @@ struct Rope {
         uint32_t in_cb;
         uint32_t cos_cb;
         uint32_t sin_cb;
+        uint32_t cos_tensor_address;
+        uint32_t sin_tensor_address;
+        uint32_t position_ids_tensor_address;
         uint32_t trans_mat_cb;
+        uint32_t cos_sin_start_page;
     };
 
     // Writer args (BRISC): none
@@ -96,6 +102,47 @@ struct Rope {
 
     private:
         void impl(const RTArgs& args) {
+#if defined(COMPILE_FOR_NCRISC)
+
+            volatile tt_l1_ptr uint32_t* position_ids_ptr =
+                reinterpret_cast<volatile tt_l1_ptr uint32_t*>(args.position_ids_tensor_address);
+            uint32_t position_id = position_ids_ptr[0];
+
+            DPRINT << "position_ideolo: " << position_id << ENDL();
+
+            constexpr uint32_t Wt = CTArgs::Wt;
+            constexpr uint32_t page_size = CTArgs::cos_sin_page_size;
+            const uint32_t start_page = args.cos_sin_start_page;
+
+            auto cos_accessor =
+                TensorAccessor(tensor_accessor::make_interleaved_dspec<true>(), args.cos_tensor_address, page_size);
+
+            cb_reserve_back(args.cos_cb, Wt);
+            uint32_t l1_write_addr = get_write_ptr(args.cos_cb);
+
+            for (uint32_t page_id = 0; page_id < Wt; page_id++) {
+                uint64_t noc_addr = cos_accessor.get_noc_addr(Wt * position_id + start_page + page_id);
+                noc_async_read(noc_addr, l1_write_addr, page_size);
+                l1_write_addr += page_size;
+            }
+            noc_async_read_barrier();
+            cb_push_back(args.cos_cb, Wt);
+
+            auto sin_accessor =
+                TensorAccessor(tensor_accessor::make_interleaved_dspec<true>(), args.sin_tensor_address, page_size);
+
+            cb_reserve_back(args.sin_cb, Wt);
+            l1_write_addr = get_write_ptr(args.sin_cb);
+
+            for (uint32_t page_id = 0; page_id < Wt; page_id++) {
+                uint64_t noc_addr = sin_accessor.get_noc_addr(Wt * position_id + start_page + page_id);
+                noc_async_read(noc_addr, l1_write_addr, page_size);
+                l1_write_addr += page_size;
+            }
+            noc_async_read_barrier();
+            cb_push_back(args.sin_cb, Wt);
+
+#endif
 #if defined(COMPILE_FOR_TRISC)
             constexpr uint32_t Wt = CTArgs::Wt;
             constexpr uint32_t Ht = CTArgs::Ht;

--- a/models/demos/deepseek_v3_b1/unified_kernels/rope.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/rope.hpp
@@ -36,13 +36,19 @@ struct Rope {
     // Compile-time args structs - different layout per RISC
     // ========================================================================
 
-    // Reader CTArgs (NCRISC): Wt and Ht for sharded input signaling
-    template <uint32_t Wt_, uint32_t Ht_, uint32_t CosSinPageSize_ = 64, uint32_t BankId_ = 0>
+    // Reader CTArgs (NCRISC): Wt/Ht for dimensions, TotalWt/StartTileOffset for DRAM interleaved addressing
+    template <
+        uint32_t Wt_,
+        uint32_t Ht_,
+        uint32_t CosSinPageSize_ = 64,
+        uint32_t TotalWt_ = 2,
+        uint32_t StartTileOffset_ = 0>
     struct ReaderCTArgs {
         static constexpr uint32_t Wt = Wt_;  // head_dim in tiles (per core)
         static constexpr uint32_t Ht = Ht_;  // num_heads per core
         static constexpr uint32_t cos_sin_page_size = CosSinPageSize_;
-        static constexpr uint32_t bank_id = BankId_;
+        static constexpr uint32_t total_Wt = TotalWt_;                   // total width tiles per row in DRAM tensor
+        static constexpr uint32_t start_tile_offset = StartTileOffset_;  // this core's first tile in row
     };
 
     // Writer CTArgs (BRISC): none
@@ -109,27 +115,30 @@ struct Rope {
 
             constexpr uint32_t Wt = CTArgs::Wt;
             constexpr uint32_t page_size = CTArgs::cos_sin_page_size;
-            constexpr uint32_t bank_id = CTArgs::bank_id;
+            constexpr uint32_t total_Wt = CTArgs::total_Wt;
+            constexpr uint32_t start_tile_offset = CTArgs::start_tile_offset;
 
-            // Cos/sin are WIDTH_SHARDED in DRAM: each bank holds [max_seq_len, Wt] tiles.
-            // Row position_id starts at byte offset position_id * Wt * page_size within the bank.
-            uint32_t row_offset = position_id * Wt * page_size;
+            // Cos/sin are INTERLEAVED in DRAM. Each row has total_Wt tiles.
+            // This core reads Wt tiles starting at start_tile_offset within the row.
+            uint32_t start_page = position_id * total_Wt + start_tile_offset;
 
-            uint64_t cos_base = get_noc_addr_from_bank_id<true>(bank_id, args.cos_tensor_address);
+            auto cos_accessor = TensorAccessor(
+                tensor_accessor::make_interleaved_dspec</*is_dram=*/true>(), args.cos_tensor_address, page_size);
             cb_reserve_back(args.cos_cb, Wt);
             uint32_t l1_write_addr = get_write_ptr(args.cos_cb);
             for (uint32_t i = 0; i < Wt; i++) {
-                noc_async_read(cos_base + row_offset + i * page_size, l1_write_addr, page_size);
+                noc_async_read_page(start_page + i, cos_accessor, l1_write_addr);
                 l1_write_addr += page_size;
             }
             noc_async_read_barrier();
             cb_push_back(args.cos_cb, Wt);
 
-            uint64_t sin_base = get_noc_addr_from_bank_id<true>(bank_id, args.sin_tensor_address);
+            auto sin_accessor = TensorAccessor(
+                tensor_accessor::make_interleaved_dspec</*is_dram=*/true>(), args.sin_tensor_address, page_size);
             cb_reserve_back(args.sin_cb, Wt);
             l1_write_addr = get_write_ptr(args.sin_cb);
             for (uint32_t i = 0; i < Wt; i++) {
-                noc_async_read(sin_base + row_offset + i * page_size, l1_write_addr, page_size);
+                noc_async_read_page(start_page + i, sin_accessor, l1_write_addr);
                 l1_write_addr += page_size;
             }
             noc_async_read_barrier();

--- a/models/demos/deepseek_v3_b1/unified_kernels/rope.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/rope.hpp
@@ -16,7 +16,6 @@
 #include "api/compute/eltwise_binary.h"
 #include "api/compute/tile_move_copy.h"
 #include "api/compute/reg_api.h"
-#include "api/debug/dprint.h"
 #endif
 
 namespace deepseek_b1_ops {
@@ -38,11 +37,12 @@ struct Rope {
     // ========================================================================
 
     // Reader CTArgs (NCRISC): Wt and Ht for sharded input signaling
-    template <uint32_t Wt_, uint32_t Ht_, uint32_t CosSinPageSize_ = 64>
+    template <uint32_t Wt_, uint32_t Ht_, uint32_t CosSinPageSize_ = 64, uint32_t BankId_ = 0>
     struct ReaderCTArgs {
-        static constexpr uint32_t Wt = Wt_;  // head_dim in tiles
+        static constexpr uint32_t Wt = Wt_;  // head_dim in tiles (per core)
         static constexpr uint32_t Ht = Ht_;  // num_heads per core
         static constexpr uint32_t cos_sin_page_size = CosSinPageSize_;
+        static constexpr uint32_t bank_id = BankId_;
     };
 
     // Writer CTArgs (BRISC): none
@@ -68,7 +68,6 @@ struct Rope {
         uint32_t sin_tensor_address;
         uint32_t position_ids_tensor_address;
         uint32_t trans_mat_cb;
-        uint32_t cos_sin_start_page;
     };
 
     // Writer args (BRISC): none
@@ -108,35 +107,29 @@ struct Rope {
                 reinterpret_cast<volatile tt_l1_ptr uint32_t*>(args.position_ids_tensor_address);
             uint32_t position_id = position_ids_ptr[0];
 
-            DPRINT << "position_ideolo: " << position_id << ENDL();
-
             constexpr uint32_t Wt = CTArgs::Wt;
             constexpr uint32_t page_size = CTArgs::cos_sin_page_size;
-            const uint32_t start_page = args.cos_sin_start_page;
+            constexpr uint32_t bank_id = CTArgs::bank_id;
 
-            auto cos_accessor =
-                TensorAccessor(tensor_accessor::make_interleaved_dspec<true>(), args.cos_tensor_address, page_size);
+            // Cos/sin are WIDTH_SHARDED in DRAM: each bank holds [max_seq_len, Wt] tiles.
+            // Row position_id starts at byte offset position_id * Wt * page_size within the bank.
+            uint32_t row_offset = position_id * Wt * page_size;
 
+            uint64_t cos_base = get_noc_addr_from_bank_id<true>(bank_id, args.cos_tensor_address);
             cb_reserve_back(args.cos_cb, Wt);
             uint32_t l1_write_addr = get_write_ptr(args.cos_cb);
-
-            for (uint32_t page_id = 0; page_id < Wt; page_id++) {
-                uint64_t noc_addr = cos_accessor.get_noc_addr(Wt * position_id + start_page + page_id);
-                noc_async_read(noc_addr, l1_write_addr, page_size);
+            for (uint32_t i = 0; i < Wt; i++) {
+                noc_async_read(cos_base + row_offset + i * page_size, l1_write_addr, page_size);
                 l1_write_addr += page_size;
             }
             noc_async_read_barrier();
             cb_push_back(args.cos_cb, Wt);
 
-            auto sin_accessor =
-                TensorAccessor(tensor_accessor::make_interleaved_dspec<true>(), args.sin_tensor_address, page_size);
-
+            uint64_t sin_base = get_noc_addr_from_bank_id<true>(bank_id, args.sin_tensor_address);
             cb_reserve_back(args.sin_cb, Wt);
             l1_write_addr = get_write_ptr(args.sin_cb);
-
-            for (uint32_t page_id = 0; page_id < Wt; page_id++) {
-                uint64_t noc_addr = sin_accessor.get_noc_addr(Wt * position_id + start_page + page_id);
-                noc_async_read(noc_addr, l1_write_addr, page_size);
+            for (uint32_t i = 0; i < Wt; i++) {
+                noc_async_read(sin_base + row_offset + i * page_size, l1_write_addr, page_size);
                 l1_write_addr += page_size;
             }
             noc_async_read_barrier();


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Need to change position id to be read from L1, and update sin and cos to be read from a dram tensor.

### What's changed
Switch to a position id tensor and read from an interleaved dram tensor for sin and cos in pre-sdpa.

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=kwerblinski/37665-add_position_tracking_to_MLA)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:kwerblinski/37665-add_position_tracking_to_MLA)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=kwerblinski/37665-add_position_tracking_to_MLA)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:kwerblinski/37665-add_position_tracking_to_MLA)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=kwerblinski/37665-add_position_tracking_to_MLA)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:kwerblinski/37665-add_position_tracking_to_MLA)
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=kwerblinski/37665-add_position_tracking_to_MLA)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:kwerblinski/37665-add_position_tracking_to_MLA)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=kwerblinski/37665-add_position_tracking_to_MLA)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:kwerblinski/37665-add_position_tracking_to_MLA)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=kwerblinski/37665-add_position_tracking_to_MLA)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:kwerblinski/37665-add_position_tracking_to_MLA)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
