### PR TITLE
[Deepseek Blitz] Socket integration with bcast

### DIFF
--- a/models/demos/deepseek_v3_b1/fused_ops/broadcast_rms/kernels/broadcast_rms_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/fused_ops/broadcast_rms/kernels/broadcast_rms_kernel.cpp
@@ -8,7 +8,7 @@
 
 #include "../../../unified_kernels/kernel_op_api.hpp"
 #include "../../../unified_kernels/kernel_utils.hpp"
-#if !defined(SKIP_CCL)
+#if !defined(SKIP_CCL) || defined(ENABLE_SOCKET_READER)
 #include "../../../unified_kernels/broadcast.hpp"
 #endif
 #include "../../../unified_kernels/rmsnorm.hpp"
@@ -71,15 +71,18 @@ void kernel_main() {
 // -----------------------
 #if defined(COMPILE_FOR_BRISC)
 
-#if !defined(SKIP_CCL)
+#if !defined(SKIP_CCL) || defined(ENABLE_SOCKET_READER)
     using BcastCTArgs = deepseek_b1_ops::Broadcast::ReaderCTArgs<
         get_named_compile_time_arg_val("cb0_id"),
         get_named_compile_time_arg_val("num_pages_to_read"),
-        get_named_compile_time_arg_val("is_sender")>;
+        get_named_compile_time_arg_val("is_sender"),
+        get_named_compile_time_arg_val("use_socket")>;
 
-    deepseek_b1_ops::Broadcast::ReaderArgs bcast_args{};
-
-    bcast_args = deepseek_b1_ops::Broadcast::ReaderArgs{};
+    deepseek_b1_ops::Broadcast::ReaderArgs bcast_args{
+        get_common_arg_val<uint32_t>(0),  // socket_config_addr
+        get_common_arg_val<uint32_t>(1),  // socket_page_size
+        get_common_arg_val<uint32_t>(2),  // socket_num_pages
+    };
 #endif
 
     using RMSNormCTArgs = deepseek_b1_ops::RMSNorm::WriterCTArgs;
@@ -115,19 +118,24 @@ void kernel_main() {
 
 #endif
 
-    // CCL Broadcast
-#if !defined(SKIP_CCL)
+    // CCL Broadcast (also runs in socket-reader mode with skip_ccl)
+#if !defined(SKIP_CCL) || defined(ENABLE_SOCKET_READER)
     deepseek_b1_ops::Broadcast::Op<BcastCTArgs, true> bcast;
     bcast(bcast_args);
 #endif
 
 #if defined(COMPILE_FOR_NCRISC)
+    constexpr bool use_socket = get_named_compile_time_arg_val("use_socket") == 1;
     constexpr uint32_t gamma_cb = get_named_compile_time_arg_val("gamma_cb");
     constexpr uint32_t rmsnorm_num_tiles = get_named_compile_time_arg_val("rmsnorm_num_tiles");
 
     if constexpr (skip_ccl) {
-        constexpr uint32_t rmsnorm_input_cb = get_named_compile_time_arg_val("rmsnorm_input_cb");
-        unified_kernels::setup_sharded_buffer(rmsnorm_input_cb, rmsnorm_num_tiles);
+        // In socket mode BRISC signals rmsnorm_input_cb readiness via cb_push_back after socket recv;
+        // NCRISC must not call setup_sharded_buffer on it or it will double-signal the CB.
+        if constexpr (!use_socket) {
+            constexpr uint32_t rmsnorm_input_cb = get_named_compile_time_arg_val("rmsnorm_input_cb");
+            unified_kernels::setup_sharded_buffer(rmsnorm_input_cb, rmsnorm_num_tiles);
+        }
         unified_kernels::setup_sharded_buffer(gamma_cb, rmsnorm_num_tiles);
     } else {
         constexpr uint32_t intermediate_cb = get_named_compile_time_arg_val("intermediate_cb");

--- a/models/demos/deepseek_v3_b1/fused_ops/broadcast_rms/kernels/broadcast_rms_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/fused_ops/broadcast_rms/kernels/broadcast_rms_kernel.cpp
@@ -118,8 +118,9 @@ void kernel_main() {
 
 #endif
 
-    // CCL Broadcast (also runs in socket-reader mode with skip_ccl)
-#if !defined(SKIP_CCL) || defined(ENABLE_SOCKET_READER)
+    // CCL Broadcast: runs on all cores in normal mode.
+    // In socket-reader + skip_ccl mode, only BRISC executes this path (socket recv via broadcast reader).
+#if !defined(SKIP_CCL) || (defined(ENABLE_SOCKET_READER) && defined(COMPILE_FOR_BRISC))
     deepseek_b1_ops::Broadcast::Op<BcastCTArgs, true> bcast;
     bcast(bcast_args);
 #endif

--- a/models/demos/deepseek_v3_b1/fused_ops/broadcast_rms/op.py
+++ b/models/demos/deepseek_v3_b1/fused_ops/broadcast_rms/op.py
@@ -202,10 +202,29 @@ class BroadcastRMSNorm:
                 range_hops_backward = num_targets_backward
 
                 use_socket = socket is not None and is_sender
-                # In skip_ccl+socket mode, BRISC fills pkt_cb from socket; TRISC reads pkt_cb.
-                # In all other modes, TRISC reads input_cb (backed by intermediate or input tensor).
-                rmsnorm_input_source_cb = pkt_cb if (skip_ccl and use_socket) else input_cb
                 num_pages_to_read = input_num_pages
+
+                # CB roles:
+                #   input_cb (0): RMSNorm input — always read by TRISC; has explicit page_size=2048 override.
+                #   pkt_cb   (1): Broadcast staging — used by NCRISC/BRISC in CCL mode only.
+                #
+                # Who delivers data into input_cb depends on mode:
+                #   CCL         (skip_ccl=False):           NCRISC signals it (intermediate_cb) after broadcast
+                #   local       (skip_ccl=True, no socket): NCRISC signals it directly
+                #   socket recv (skip_ccl=True, socket):    BRISC writes received payload here
+                #
+                # BRISC's broadcast CB:
+                #   CCL mode:    pkt_cb   (dummy-signal to NCRISC that source data is ready to broadcast)
+                #   socket mode: input_cb (BRISC writes received payload here; TRISC reads via page_size=2048)
+                #   local mode:  idle     (BRISC does nothing; value unused)
+                if not skip_ccl:
+                    brisc_bcast_cb = pkt_cb
+                elif use_socket:
+                    brisc_bcast_cb = input_cb
+                else:
+                    brisc_bcast_cb = 0  # BRISC idle in local skip_ccl mode
+
+                brisc_is_active = not skip_ccl or use_socket
 
                 ncrisc_named_compile_time_args = [
                     ("skip_ccl", 1 if skip_ccl else 0),
@@ -225,23 +244,21 @@ class BroadcastRMSNorm:
                     ("range_hops_forward", range_hops_forward if not skip_ccl else 0),
                     ("start_distance_in_hops_backward", start_distance_backward if not skip_ccl else 0),
                     ("range_hops_backward", range_hops_backward if not skip_ccl else 0),
-                    ("rmsnorm_input_cb", rmsnorm_input_source_cb),
+                    ("rmsnorm_input_cb", input_cb),
                     ("rmsnorm_num_tiles", num_tiles),
                     ("intermediate_cb", input_cb if not skip_ccl else pkt_cb),
                     ("gamma_cb", gamma_cb),
                 ]
 
-                # BRISC reader is active when CCL is enabled OR when socket delivers data in skip_ccl mode
-                brisc_reader_active = not skip_ccl or use_socket
                 brisc_named_compile_time_args = [
                     ("skip_ccl", 1 if skip_ccl else 0),
-                    ("cb0_id", pkt_cb if brisc_reader_active else 0),
-                    ("num_pages_to_read", num_pages_to_read if brisc_reader_active else 0),
-                    ("is_sender", int(is_sender) if brisc_reader_active else 0),
+                    ("cb0_id", brisc_bcast_cb),
+                    ("num_pages_to_read", num_pages_to_read if brisc_is_active else 0),
+                    ("is_sender", int(is_sender) if brisc_is_active else 0),
                     ("use_socket", 1 if use_socket else 0),
                 ]
 
-                # Socket runtime args for BRISC reader (zeros for non-socket cores)
+                # Socket runtime args for BRISC (zeros when not using socket)
                 brisc_common_runtime_args = [
                     int(socket.get_config_buffer_address()) if use_socket else 0,  # socket_config_addr
                     int(socket_page_size) if use_socket else 0,  # socket_page_size
@@ -251,7 +268,7 @@ class BroadcastRMSNorm:
                 # Named compile-time args for TRISC (rmsnorm compute)
                 trisc_named_compile_time_args = [
                     ("skip_ccl", 1 if skip_ccl else 0),
-                    ("rmsnorm_input_cb", rmsnorm_input_source_cb),
+                    ("rmsnorm_input_cb", input_cb),
                     ("rmsnorm_gamma_cb", gamma_cb),
                     ("rmsnorm_output_cb", output_cb),
                     ("rmsnorm_fp32_acc", 1 if fp32_dest_acc_en else 0),

--- a/models/demos/deepseek_v3_b1/fused_ops/broadcast_rms/op.py
+++ b/models/demos/deepseek_v3_b1/fused_ops/broadcast_rms/op.py
@@ -6,6 +6,7 @@ import math
 import torch
 
 import ttnn
+from models.demos.deepseek_v3_b1.micro_ops.host_io.utils import dtype_size
 from models.demos.deepseek_v3_b1.unified_kernel_descriptor import PerCoreRuntimeArgsDescriptor, UnifiedKernelDescriptor
 from models.demos.deepseek_v3_b1.utils import float_to_uint32
 
@@ -51,6 +52,7 @@ class BroadcastRMSNorm:
         fp32_dest_acc_en=False,
         rsqrt_fast_approx=False,
         skip_ccl=False,
+        socket=None,
     ):
         """
         Execute fused Broadcast+RMSNorm operation.
@@ -86,23 +88,32 @@ class BroadcastRMSNorm:
             barrier_sem_addr = ttnn.get_global_semaphore_address(barrier_semaphore)
             secondary_sync_sem_addr = ttnn.get_global_semaphore_address(secondary_sync_semaphore)
 
-        # Calculate packet size and page info
-        packet_size_bytes = 14336  # 14 KB packets for (1, 7168) input
-
         # Get tile info from input tensor (use a sample device tensor)
         input_tensor_sample = input_tensors_per_device[0]
         tile = input_tensor_sample.tile
         tile_height, tile_width = tile.tile_shape
 
+        input_shape = input_tensor_sample.shape
         dtype = input_tensor_sample.dtype
-        element_size = 2
+        element_size = dtype_size(dtype)
         tile_id_start = 0
 
         # bcast cb info
-        input_shape = input_tensor_sample.shape
+        payload_size_bytes = input_shape[0] * input_shape[1] * element_size
+        packet_size_bytes = payload_size_bytes
         page_size_bytes = 32 * 32 * element_size  # interpret it as 32x32 tile to use the same cb as rmsnorm
-        input_num_pages = input_shape[0] * input_shape[1] * element_size // page_size_bytes
+        assert (
+            payload_size_bytes % page_size_bytes == 0
+        ), f"payload_size_bytes {payload_size_bytes} must be a multiple of page_size_bytes {page_size_bytes}"
+        input_num_pages = payload_size_bytes // page_size_bytes
         num_pages_per_packet = packet_size_bytes // page_size_bytes
+
+        socket_page_size = packet_size_bytes
+        assert socket_page_size % 16 == 0, f"socket_page_size {socket_page_size} must be 16-byte aligned"
+        assert socket_page_size == input_num_pages * page_size_bytes, (
+            f"single-shot requires socket_page_size {socket_page_size} == full payload "
+            f"{input_num_pages} * {page_size_bytes}"
+        )
 
         # CB indices for rms norm
         input_cb = 0
@@ -145,13 +156,12 @@ class BroadcastRMSNorm:
             for col in range(mesh_cols):
                 coord = ttnn.MeshCoordinate(row, col)
 
-                # CCL role calculation (only matters if not skipping CCL)
+                # CCL role calculation
+                is_sender = (row == sender_row) and (col == sender_col)
                 if skip_ccl:
-                    is_sender = False
                     is_secondary_sender = False
                     is_receiver = False
                 else:
-                    is_sender = (row == sender_row) and (col == sender_col)
                     is_secondary_sender = (
                         secondary_cluster_axis is not None and (row == sender_row) and (col != sender_col)
                     )
@@ -191,11 +201,15 @@ class BroadcastRMSNorm:
                 start_distance_backward = 1 if num_targets_backward > 0 else 0
                 range_hops_backward = num_targets_backward
 
-                rmsnorm_input_source_cb = input_cb
+                use_socket = socket is not None and is_sender
+                # In skip_ccl+socket mode, BRISC fills pkt_cb from socket; TRISC reads pkt_cb.
+                # In all other modes, TRISC reads input_cb (backed by intermediate or input tensor).
+                rmsnorm_input_source_cb = pkt_cb if (skip_ccl and use_socket) else input_cb
                 num_pages_to_read = input_num_pages
 
                 ncrisc_named_compile_time_args = [
                     ("skip_ccl", 1 if skip_ccl else 0),
+                    ("use_socket", 1 if use_socket else 0),
                     # CCL broadcast writer args (dummy values when skip_ccl)
                     ("cb0_id", pkt_cb if not skip_ccl else 0),
                     ("num_pages_to_read", num_pages_to_read if not skip_ccl else 0),
@@ -217,11 +231,21 @@ class BroadcastRMSNorm:
                     ("gamma_cb", gamma_cb),
                 ]
 
+                # BRISC reader is active when CCL is enabled OR when socket delivers data in skip_ccl mode
+                brisc_reader_active = not skip_ccl or use_socket
                 brisc_named_compile_time_args = [
                     ("skip_ccl", 1 if skip_ccl else 0),
-                    ("cb0_id", pkt_cb if not skip_ccl else 0),
-                    ("num_pages_to_read", num_pages_to_read if not skip_ccl else 0),
-                    ("is_sender", int(is_sender) if not skip_ccl else 0),
+                    ("cb0_id", pkt_cb if brisc_reader_active else 0),
+                    ("num_pages_to_read", num_pages_to_read if brisc_reader_active else 0),
+                    ("is_sender", int(is_sender) if brisc_reader_active else 0),
+                    ("use_socket", 1 if use_socket else 0),
+                ]
+
+                # Socket runtime args for BRISC reader (zeros for non-socket cores)
+                brisc_common_runtime_args = [
+                    int(socket.get_config_buffer_address()) if use_socket else 0,  # socket_config_addr
+                    int(socket_page_size) if use_socket else 0,  # socket_page_size
+                    1 if use_socket else 0,  # socket_num_pages (single-shot)
                 ]
 
                 # Named compile-time args for TRISC (rmsnorm compute)
@@ -303,7 +327,11 @@ class BroadcastRMSNorm:
                 out_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(output_cb, output_tensor)
                 out_cb_descriptor.format_descriptors[0].tile = tile_descriptor
                 out_cb_descriptor.format_descriptors[0].page_size = cb_page_size
-                kernel_defines = [("SKIP_CCL", "1")] if skip_ccl else []
+                kernel_defines = []
+                if skip_ccl:
+                    kernel_defines.append(("SKIP_CCL", "1"))
+                if use_socket:
+                    kernel_defines.append(("ENABLE_SOCKET_READER", "1"))
 
                 # Unified kernel descriptor for fused op
                 unified_kernel = UnifiedKernelDescriptor(
@@ -313,6 +341,7 @@ class BroadcastRMSNorm:
                     brisc_named_compile_time_args=brisc_named_compile_time_args,
                     trisc_named_compile_time_args=trisc_named_compile_time_args,
                     ncrisc_common_runtime_args=writer_common_rt_args,
+                    brisc_common_runtime_args=brisc_common_runtime_args,
                     trisc_common_runtime_args=[epsilon_packed, scalar_packed],
                     trisc_compute_config=ttnn.ComputeConfigDescriptor(
                         math_fidelity=ttnn.MathFidelity.LoFi,

--- a/models/demos/deepseek_v3_b1/micro_ops/host_io/op.py
+++ b/models/demos/deepseek_v3_b1/micro_ops/host_io/op.py
@@ -48,6 +48,8 @@ class HostInterface:
         d2h_upstream_core=ttnn.MeshCoreCoord(ttnn.MeshCoordinate(0, 0), ttnn.CoreCoord(0, 0)),
         embedding_tensor=None,
         loopback_mode=False,
+        embedding_cb_index=None,
+        fabric_packet_header_cb_index=None,
     ):
         self.h2d_socket = h2d_socket
         self.d2h_socket = d2h_socket
@@ -139,9 +141,11 @@ class HostInterface:
             ), f"Expected embedding tensor to be DRAM interleaved with page size {self.embedding_page_size} bytes for shape {self.embedding_tensor.shape}"
             # Tensor is DRAM interleaved, and row major. Page size is inner dim stride.
             self.embedding_page_size = self.embedding_tensor.shape[3] * dtype_size(self.embedding_tensor.dtype)
-            self.embedding_cb_index = 2
+            self.embedding_cb_index = 2 if embedding_cb_index is None else embedding_cb_index
 
-        self.fabric_packet_header_cb_index = 1
+        self.fabric_packet_header_cb_index = (
+            1 if fabric_packet_header_cb_index is None else fabric_packet_header_cb_index
+        )
         self.num_fwd_links = 2
         self.num_bwd_links = 1
 

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_broadcast_rms_single_device.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_broadcast_rms_single_device.py
@@ -13,8 +13,11 @@ import torch
 from loguru import logger
 
 import ttnn
-from models.common.utility_functions import comp_pcc
+from models.common.utility_functions import comp_pcc, is_slow_dispatch
 from models.demos.deepseek_v3_b1.fused_ops.broadcast_rms.op import BroadcastRMSNorm
+from models.demos.deepseek_v3_b1.micro_ops.d2d_exchange.op import SocketInterface
+from models.demos.deepseek_v3_b1.micro_ops.host_io.op import HostInterface
+from models.demos.deepseek_v3_b1.micro_ops.host_io.utils import dtype_size
 
 
 @pytest.mark.parametrize(
@@ -28,6 +31,7 @@ from models.demos.deepseek_v3_b1.fused_ops.broadcast_rms.op import BroadcastRMSN
 @pytest.mark.parametrize("epsilon", [1e-6])
 @pytest.mark.parametrize("fp32_dest_acc_en", [False])
 @pytest.mark.parametrize("mesh_device", [(1, 1)], indirect=True)
+@pytest.mark.parametrize("use_socket", [True, False])
 def test_broadcast_rms_single_device(
     mesh_device,
     output_shape,
@@ -37,15 +41,28 @@ def test_broadcast_rms_single_device(
     input_dtype,
     epsilon,
     fp32_dest_acc_en,
+    use_socket,
 ):
     """
     Test fused Broadcast+RMSNorm op on a single device with skip_ccl=True for Debugging purpose.
 
     """
-    logger.info(f"Testing BroadcastRMSNorm (skip_ccl=True) with shape={output_shape}, epsilon={epsilon}")
+
+    if use_socket:
+        if not is_slow_dispatch():
+            pytest.skip("Skipping test in fast dispatch mode")
+
+        ttnn.enable_asynchronous_slow_dispatch(mesh_device)
+
+    compute_grid_size = mesh_device.compute_with_storage_grid_size()
+    bcast_core = ttnn.CoreCoord(0, 0)
+    pipeline_core = ttnn.CoreCoord(0, 1)
+    intermed_core_0 = ttnn.CoreCoord(0, 2)
+    intermed_core_1 = ttnn.CoreCoord(0, 3)
+    d2h_upstream_core = ttnn.CoreCoord(0, 4)
 
     # Set up sharded memory config (single core shard)
-    input_shard_grid = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(0, 0))})
+    input_shard_grid = ttnn.CoreRangeSet({ttnn.CoreRange(bcast_core, bcast_core)})
     input_shard_spec = ttnn.ShardSpec(
         input_shard_grid,
         input_shard_shape,
@@ -106,6 +123,65 @@ def test_broadcast_rms_single_device(
     # Compute expected output using PyTorch reference
     torch_expected = BroadcastRMSNorm.golden(torch_input, torch_gamma, epsilon=epsilon)
 
+    host_io = None
+    recv_socket = None
+    h2d_socket = None
+    if use_socket:
+        element_size = dtype_size(input_dtype)
+        socket_page_size = output_shape[0] * output_shape[1] * element_size
+        token_page_size = 64
+
+        sender_tensor_4d = torch_input.reshape(1, 1, 1, output_shape[1])
+        embedding_tensor = ttnn.from_torch(
+            sender_tensor_4d,
+            dtype=input_dtype,
+            layout=ttnn.ROW_MAJOR_LAYOUT,
+            device=mesh_device,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device),
+        )
+
+        device_coord = ttnn.MeshCoordinate(0, 0)
+        pipeline_mesh_core = ttnn.MeshCoreCoord(device_coord, pipeline_core)
+        intermed_mesh_core_0 = ttnn.MeshCoreCoord(device_coord, intermed_core_0)
+        intermed_mesh_core_1 = ttnn.MeshCoreCoord(device_coord, intermed_core_1)
+        bcast_mesh_core = ttnn.MeshCoreCoord(device_coord, bcast_core)
+        d2h_upstream_mesh_core = ttnn.MeshCoreCoord(device_coord, d2h_upstream_core)
+
+        h2d_socket = ttnn.H2DSocket(
+            mesh_device, pipeline_mesh_core, ttnn.BufferType.L1, token_page_size * 2, ttnn.H2DMode.HOST_PUSH
+        )
+        d2h_socket = ttnn.D2HSocket(mesh_device, pipeline_mesh_core, socket_page_size)
+
+        host_io = HostInterface(
+            h2d_socket,
+            d2h_socket,
+            token_page_size,
+            socket_page_size,
+            core_to_core_socket_buffer_size=socket_page_size,
+            h2d_downstream_core=intermed_mesh_core_0,
+            d2h_upstream_core=d2h_upstream_mesh_core,
+            embedding_tensor=embedding_tensor,
+            loopback_mode=False,
+            embedding_cb_index=4,
+        )
+
+        socket_interface_1 = SocketInterface(
+            socket_page_size,
+            socket_page_size,
+            socket_page_size,
+            intermed_mesh_core_0,
+            intermed_mesh_core_1,
+            upstream_socket=host_io.get_downstream_socket(),
+            downstream_core_coord=bcast_mesh_core,
+            mesh_device=mesh_device,
+        )
+
+        recv_socket = socket_interface_1.get_downstream_socket()
+
+        host_io.run()
+        socket_interface_1.run()
+
     # Run fused operation with skip_ccl=True (single-device mode)
     logger.info("Running fused Broadcast+RMSNorm with skip_ccl=True")
     sender_coord = ttnn.MeshCoordinate(0, 0)  # Ignored when skip_ccl=True
@@ -120,9 +196,19 @@ def test_broadcast_rms_single_device(
         skip_ccl=True,
         epsilon=epsilon,
         fp32_dest_acc_en=fp32_dest_acc_en,
+        socket=recv_socket if use_socket else None,
     )
 
-    ttnn.synchronize_device(mesh_device)
+    if use_socket:
+        token_size_datums = token_page_size // 4
+        torch_token = torch.zeros(1, token_size_datums, dtype=torch.uint32)
+        torch_token[0, 0] = 0
+        token_tensor = ttnn.from_torch(torch_token, dtype=ttnn.uint32, layout=ttnn.ROW_MAJOR_LAYOUT)
+        h2d_socket.write_tensor(token_tensor)
+        host_io.terminate(False)
+        socket_interface_1.terminate(True)
+    else:
+        ttnn.synchronize_device(mesh_device)
 
     # Convert result back to torch
     output_tensor_torch = ttnn.to_torch(result, mesh_composer=ttnn.ConcatMeshToTensor(mesh_device, dim=0))


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Provide context for the problem.

### What's changed
Describe the approach used to solve the problem.
Summarize the changes made and its impact.

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=aagarwal/pipeline-integ-w-broadcast-2)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:aagarwal/pipeline-integ-w-broadcast-2)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=aagarwal/pipeline-integ-w-broadcast-2)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:aagarwal/pipeline-integ-w-broadcast-2)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=aagarwal/pipeline-integ-w-broadcast-2)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:aagarwal/pipeline-integ-w-broadcast-2)
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=aagarwal/pipeline-integ-w-broadcast-2)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:aagarwal/pipeline-integ-w-broadcast-2)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=aagarwal/pipeline-integ-w-broadcast-2)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:aagarwal/pipeline-integ-w-broadcast-2)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=aagarwal/pipeline-integ-w-broadcast-2)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:aagarwal/pipeline-integ-w-broadcast-2)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
