### PR TITLE
Implement DeepSeekV3 B1 TTNN weight serialization/deserialization

### DIFF
--- a/models/demos/deepseek_v3_b1/prepare_weights.py
+++ b/models/demos/deepseek_v3_b1/prepare_weights.py
@@ -1,0 +1,1091 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Prepare DeepSeek V3 fused (blitz decode) weights from a state dict.
+
+Takes full HuggingFace state dict tensors (full logical shapes for the target
+mesh), applies key mapping, transpose, and kv_b split, then passes to
+BlitzDecodeWeights which fuses and shards onto the mesh.
+
+Supports save_weights / load_weights for offline preparation and runtime load.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from dataclasses import dataclass, fields
+from datetime import datetime, timezone
+from pathlib import Path
+
+import torch
+from loguru import logger
+
+import ttnn
+from models.demos.deepseek_v3_b1.blitz_decode_weights import BlitzDecodeWeights, OverlappedTensor
+
+# Serialization: manifest version and dtype name mapping
+_MANIFEST_VERSION = 1
+_DTYPE_TO_STR = {
+    ttnn.DataType.BFLOAT4_B: "BFLOAT4_B",
+    ttnn.DataType.BFLOAT8_B: "BFLOAT8_B",
+    ttnn.DataType.UINT32: "UINT32",
+    ttnn.DataType.BFLOAT16: "BFLOAT16",
+}
+_STR_TO_DTYPE = {v: k for k, v in _DTYPE_TO_STR.items()}
+
+# Fusion group name per field (for grouping by fused_tensor)
+_FIELD_TO_FUSION_GROUP: dict[str, str] = {
+    "q_a_proj": "q_ab_kv_a",
+    "q_b_proj": "q_ab_kv_a",
+    "kv_a_proj": "q_ab_kv_a",
+    "o_proj": "o_proj_gate_mm_norms",
+    "gate_mm": "o_proj_gate_mm_norms",
+    "attn_norm": "o_proj_gate_mm_norms",
+    "q_norm": "o_proj_gate_mm_norms",
+    "kv_norm": "o_proj_gate_mm_norms",
+    "ffn_norm": "o_proj_gate_mm_norms",
+    "kv_b1_proj": "kv_b12",
+    "kv_b2_proj": "kv_b12",
+    "shared_gate_proj": "gate_up",
+    "shared_up_proj": "gate_up",
+}
+
+
+@dataclass
+class AttentionWeights:
+    """Attention fusion groups: q_ab_kv_a + kv_b12 + o_proj_gate_mm_norms."""
+
+    q_a_proj: OverlappedTensor
+    q_b_proj: OverlappedTensor
+    kv_a_proj: OverlappedTensor
+    o_proj: OverlappedTensor
+    gate_mm: OverlappedTensor | None  # None for dense layers
+    attn_norm: OverlappedTensor
+    q_norm: OverlappedTensor
+    kv_norm: OverlappedTensor
+    ffn_norm: OverlappedTensor
+    kv_b1_proj: OverlappedTensor
+    kv_b2_proj: OverlappedTensor
+
+
+@dataclass
+class SharedExpertWeights:
+    """Shared expert gate_up fusion group + standalone shared_down_proj."""
+
+    shared_gate_proj: OverlappedTensor
+    shared_up_proj: OverlappedTensor
+    shared_down_proj: ttnn.Tensor
+
+
+@dataclass
+class DenseRoutedExpertWeights:
+    """Routed expert weights for dense layers (single tensor per proj)."""
+
+    routed_gate_proj: ttnn.Tensor
+    routed_up_proj: ttnn.Tensor
+    routed_down_proj: ttnn.Tensor
+
+
+@dataclass
+class MoERoutedExpertWeights:
+    """Routed expert weights for MoE layers (list of tensors, one per expert)."""
+
+    routed_gate_proj: list[ttnn.Tensor]
+    routed_up_proj: list[ttnn.Tensor]
+    routed_down_proj: list[ttnn.Tensor]
+
+
+@dataclass
+class DeepSeekV3DenseLayerWeights:
+    """Weights for a dense layer (0..first_k_dense_replace-1).
+
+    Has the 3 attention fusion groups and o_proj + norms (no gate_mm).
+    """
+
+    # From get_tt_q_ab_proj_and_kv_a_proj_weights
+    q_a_proj: OverlappedTensor
+    q_b_proj: OverlappedTensor
+    kv_a_proj: OverlappedTensor
+
+    # From get_tt_o_proj_and_gate_mm_weights (no gate_mm for dense)
+    o_proj: OverlappedTensor
+    attn_norm: OverlappedTensor
+    q_norm: OverlappedTensor
+    kv_norm: OverlappedTensor
+    ffn_norm: OverlappedTensor
+
+    # From get_tt_kv_b12_proj_weights
+    kv_b1_proj: OverlappedTensor
+    kv_b2_proj: OverlappedTensor
+
+    # From get_tt_mlp_shared_expert_weights
+    shared_gate_proj: OverlappedTensor
+    shared_up_proj: OverlappedTensor
+    shared_down_proj: ttnn.Tensor
+
+    # From get_tt_mlp_routed_expert_weights (1 DRAM expert per device)
+    routed_gate_proj: ttnn.Tensor
+    routed_up_proj: ttnn.Tensor
+    routed_down_proj: ttnn.Tensor
+
+
+@dataclass
+class DeepSeekV3MoELayerWeights:
+    """Weights for an MoE layer (first_k_dense_replace..num_layers-1).
+
+    Extends dense with gate_mm and shared expert projections.
+    """
+
+    # From get_tt_q_ab_proj_and_kv_a_proj_weights
+    q_a_proj: OverlappedTensor
+    q_b_proj: OverlappedTensor
+    kv_a_proj: OverlappedTensor
+
+    # From get_tt_o_proj_and_gate_mm_weights (includes gate_mm)
+    o_proj: OverlappedTensor
+    gate_mm: OverlappedTensor
+    attn_norm: OverlappedTensor
+    q_norm: OverlappedTensor
+    kv_norm: OverlappedTensor
+    ffn_norm: OverlappedTensor
+
+    # From get_tt_kv_b12_proj_weights
+    kv_b1_proj: OverlappedTensor
+    kv_b2_proj: OverlappedTensor
+
+    # From get_tt_moe_shared_expert_weights (replaces get_tt_gate_up_proj_weights)
+    shared_gate_proj: OverlappedTensor
+    shared_up_proj: OverlappedTensor
+    shared_down_proj: ttnn.Tensor
+
+    # From get_tt_moe_routed_expert_weights (256 DRAM experts)
+    routed_gate_proj: list[ttnn.Tensor]
+    routed_up_proj: list[ttnn.Tensor]
+    routed_down_proj: list[ttnn.Tensor]
+
+
+DeepSeekV3LayerWeights = DeepSeekV3DenseLayerWeights | DeepSeekV3MoELayerWeights
+
+
+@dataclass
+class DeepSeekV3Weights:
+    """Container for all prepared (fused) layer weights."""
+
+    layers: list[DeepSeekV3LayerWeights]
+
+
+# Constants for kv_b_proj split (HF stores one matrix; we split into kv_b1 and kv_b2).
+_NUM_HEADS = 64
+# MoE routed experts (DeepSeek V3 config: n_routed_experts=256).
+NUM_ROUTED_EXPERTS = 256
+_QK_NOPE_HEAD_DIM = 128
+_V_HEAD_DIM = 128
+_KV_LORA_RANK = 512
+_KV_B_PROJ_HEAD_DIM = _QK_NOPE_HEAD_DIM + _V_HEAD_DIM  # 256
+
+
+def _key(layer_idx: int, suffix: str) -> str:
+    """State dict key under model.layers.{layer_idx}."""
+    return f"model.layers.{layer_idx}.{suffix}"
+
+
+def _split_kv_b_proj(kv_b_proj: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+    """Split HF kv_b_proj (out_features, in_features) into kv_b1 and kv_b2.
+
+    Expects full logical shape (32768, 512) for 4x2 mesh.
+    out_features = num_heads * (qk_nope_head_dim + v_head_dim) = num_heads * 256.
+    Reshape to (num_heads, 256, 512); first 128 dims are k (b1), last 128 are v (b2).
+    Only kv_b2 is transposed for blitz.
+    """
+    out_features, kv_lora_rank = kv_b_proj.shape
+    assert kv_lora_rank == _KV_LORA_RANK
+    num_heads = out_features // _KV_B_PROJ_HEAD_DIM
+    w = kv_b_proj.reshape(num_heads, _KV_B_PROJ_HEAD_DIM, _KV_LORA_RANK).contiguous()
+    kv_b1 = w[:, :_QK_NOPE_HEAD_DIM, :].reshape(-1, _KV_LORA_RANK)
+    kv_b2 = w[:, _QK_NOPE_HEAD_DIM:, :].reshape(-1, _KV_LORA_RANK).T.contiguous()
+    return kv_b1, kv_b2
+
+
+def _get_layer_raw_tensors(
+    state_dict: dict[str, torch.Tensor], layer_idx: int
+) -> tuple[
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+]:
+    """Extract and transform raw tensors for one layer from the state dict.
+
+    Expects full logical HF shapes. We transpose HF
+    (out_features, in_features) to (K, N); norms unsqueeze(0) to
+    (1, W); kv_b_proj is split into kv_b1 and kv_b2 (see _split_kv_b_proj).
+
+    Transformation (HF full logical -> transform -> passed to BlitzDecodeWeights):
+
+        Weight        | HF key (under model.layers.{i}.)     | HF shape      | Transform   | To blitz
+        --------------|-------------------------------------|---------------|-------------|------------------
+        q_b_proj      | self_attn.q_b_proj.weight            | (24576, 1536) | .T          | (1536, 24576)
+        o_proj        | self_attn.o_proj.weight              | (7168, 16384) | .T          | (16384, 7168)
+        kv_b_proj     | self_attn.kv_b_proj.weight           | (32768, 512)  | split       | kv_b1, kv_b2
+        q_a_proj      | self_attn.q_a_proj.weight            | (1536, 7168)  | .T          | (7168, 1536)
+        kv_a_proj     | self_attn.kv_a_proj_with_mqa.weight  | (576, 7168)   | .T          | (7168, 576)
+        norms         | input_layernorm, q_a_layernorm, etc. | (7168,), …    | unsqueeze(0)| (1, 7168), …
+
+    MoE-only (gate_mm, shared_gate_proj, shared_up_proj) are read in
+    prepare_moe_decoder_layer_weights.
+
+    Returns:
+        (q_a, q_b, kv_a, kv_b1, kv_b2, o_proj, attn_norm, q_norm, kv_norm, ffn_norm).
+    """
+    q_a = state_dict[_key(layer_idx, "self_attn.q_a_proj.weight")].T.contiguous()
+    q_b = state_dict[_key(layer_idx, "self_attn.q_b_proj.weight")].T.contiguous()
+    kv_a = state_dict[_key(layer_idx, "self_attn.kv_a_proj_with_mqa.weight")].T.contiguous()
+    kv_b1, kv_b2 = _split_kv_b_proj(state_dict[_key(layer_idx, "self_attn.kv_b_proj.weight")])
+    o_proj = state_dict[_key(layer_idx, "self_attn.o_proj.weight")].T.contiguous()
+
+    attn_norm = state_dict[_key(layer_idx, "input_layernorm.weight")].unsqueeze(0)
+    q_norm = state_dict[_key(layer_idx, "self_attn.q_a_layernorm.weight")].unsqueeze(0)
+    kv_norm = state_dict[_key(layer_idx, "self_attn.kv_a_layernorm.weight")].unsqueeze(0)
+    ffn_norm = state_dict[_key(layer_idx, "post_attention_layernorm.weight")].unsqueeze(0)
+
+    return q_a, q_b, kv_a, kv_b1, kv_b2, o_proj, attn_norm, q_norm, kv_norm, ffn_norm
+
+
+def prepare_attention_weights(
+    bdw: BlitzDecodeWeights,
+    state_dict: dict[str, torch.Tensor],
+    layer_idx: int,
+    *,
+    is_moe: bool,
+) -> AttentionWeights:
+    """Prepare attention fusion groups for one layer (q_ab_kv_a, kv_b12, o_proj_gate_mm_norms)."""
+    logger.debug("Loading raw tensors from state dict for layer {}", layer_idx)
+    t0 = time.perf_counter()
+    q_a, q_b, kv_a, kv_b1, kv_b2, o_proj, attn_norm, q_norm, kv_norm, ffn_norm = _get_layer_raw_tensors(
+        state_dict, layer_idx
+    )
+    logger.debug("  load raw tensors: {:.3f}s", time.perf_counter() - t0)
+    logger.debug("Converting attention fusion groups for layer {} (q_ab_kv_a, kv_b12, o_proj_gate_mm_norms)", layer_idx)
+    t0 = time.perf_counter()
+    q_a_proj, q_b_proj, kv_a_proj = bdw.get_tt_q_ab_proj_and_kv_a_proj_weights(q_a, q_b, kv_a, move_to_device=False)
+    kv_b1_proj, kv_b2_proj = bdw.get_tt_kv_b12_proj_weights(kv_b1, kv_b2, move_to_device=False)
+    logger.debug("  convert q_ab_kv_a + kv_b12: {:.3f}s", time.perf_counter() - t0)
+
+    if is_moe:
+        gate_mm = state_dict[_key(layer_idx, "mlp.gate.weight")].T.contiguous()
+        o_norms = bdw.get_tt_o_proj_and_gate_mm_weights(
+            o_proj, gate_mm, attn_norm, q_norm, kv_norm, ffn_norm, move_to_device=False
+        )
+        o_proj_ot, gate_mm_ot, attn_norm_ot, q_norm_ot, kv_norm_ot, ffn_norm_ot = o_norms
+        logger.debug("  convert o_proj_gate_mm_norms (MoE): {:.3f}s", time.perf_counter() - t0)
+        return AttentionWeights(
+            q_a_proj=q_a_proj,
+            q_b_proj=q_b_proj,
+            kv_a_proj=kv_a_proj,
+            o_proj=o_proj_ot,
+            gate_mm=gate_mm_ot,
+            attn_norm=attn_norm_ot,
+            q_norm=q_norm_ot,
+            kv_norm=kv_norm_ot,
+            ffn_norm=ffn_norm_ot,
+            kv_b1_proj=kv_b1_proj,
+            kv_b2_proj=kv_b2_proj,
+        )
+    else:
+        gate_mm_dummy = torch.zeros(7168, 256, dtype=torch.bfloat16, device=next(iter(state_dict.values())).device)
+        o_norms = bdw.get_tt_o_proj_and_gate_mm_weights(
+            o_proj, gate_mm_dummy, attn_norm, q_norm, kv_norm, ffn_norm, move_to_device=False
+        )
+        o_proj_ot, _gate_mm_ot, attn_norm_ot, q_norm_ot, kv_norm_ot, ffn_norm_ot = o_norms
+        logger.debug("  convert o_proj_gate_mm_norms (dense): {:.3f}s", time.perf_counter() - t0)
+        return AttentionWeights(
+            q_a_proj=q_a_proj,
+            q_b_proj=q_b_proj,
+            kv_a_proj=kv_a_proj,
+            o_proj=o_proj_ot,
+            gate_mm=None,
+            attn_norm=attn_norm_ot,
+            q_norm=q_norm_ot,
+            kv_norm=kv_norm_ot,
+            ffn_norm=ffn_norm_ot,
+            kv_b1_proj=kv_b1_proj,
+            kv_b2_proj=kv_b2_proj,
+        )
+
+
+def prepare_shared_expert_weights(
+    bdw: BlitzDecodeWeights,
+    state_dict: dict[str, torch.Tensor],
+    layer_idx: int,
+    *,
+    is_moe: bool,
+) -> SharedExpertWeights:
+    """Prepare shared expert weights (gate_up fusion group + shared_down_proj) for one layer."""
+    logger.debug("Converting shared expert weights for layer {} (is_moe={})", layer_idx, is_moe)
+    t0 = time.perf_counter()
+    if is_moe:
+        shared_gate = state_dict[_key(layer_idx, "mlp.shared_experts.gate_proj.weight")].T.contiguous()
+        shared_up = state_dict[_key(layer_idx, "mlp.shared_experts.up_proj.weight")].T.contiguous()
+        shared_down = state_dict[_key(layer_idx, "mlp.shared_experts.down_proj.weight")].T.contiguous()
+        shared_gate_proj, shared_up_proj, shared_down_proj = bdw.get_tt_moe_shared_expert_weights(
+            shared_gate, shared_up, shared_down, move_to_device=False
+        )
+    else:
+        mlp_gate = state_dict[_key(layer_idx, "mlp.gate_proj.weight")].T.contiguous()
+        mlp_up = state_dict[_key(layer_idx, "mlp.up_proj.weight")].T.contiguous()
+        mlp_down = state_dict[_key(layer_idx, "mlp.down_proj.weight")].T.contiguous()
+        shared_gate_proj, shared_up_proj, shared_down_proj = bdw.get_tt_mlp_shared_expert_weights(
+            mlp_gate, mlp_up, mlp_down, move_to_device=False
+        )
+    logger.debug("  shared expert weights done in {:.3f}s", time.perf_counter() - t0)
+    return SharedExpertWeights(
+        shared_gate_proj=shared_gate_proj,
+        shared_up_proj=shared_up_proj,
+        shared_down_proj=shared_down_proj,
+    )
+
+
+def prepare_routed_expert_weights(
+    bdw: BlitzDecodeWeights,
+    state_dict: dict[str, torch.Tensor],
+    layer_idx: int,
+    *,
+    is_moe: bool,
+    num_routed_experts: int = NUM_ROUTED_EXPERTS,
+) -> DenseRoutedExpertWeights | MoERoutedExpertWeights:
+    """Prepare routed expert weights for one layer (dense: single MLP; MoE: num_routed_experts experts)."""
+    if is_moe:
+        logger.info(
+            "Loading and converting {} routed experts for layer {} (this may be slow)...",
+            num_routed_experts,
+            layer_idx,
+        )
+        t0 = time.perf_counter()
+        gate_list = []
+        up_list = []
+        down_list = []
+        for e in range(num_routed_experts):
+            if e > 0 and e % 64 == 0:
+                logger.debug("  loaded experts 0..{} from state dict", e - 1)
+            gate_list.append(state_dict[_key(layer_idx, f"mlp.experts.{e}.gate_proj.weight")].T.contiguous())
+            up_list.append(state_dict[_key(layer_idx, f"mlp.experts.{e}.up_proj.weight")].T.contiguous())
+            down_list.append(state_dict[_key(layer_idx, f"mlp.experts.{e}.down_proj.weight")].T.contiguous())
+        load_elapsed = time.perf_counter() - t0
+        logger.info("  loaded {} experts from state dict in {:.3f}s", num_routed_experts, load_elapsed)
+        logger.debug("Converting routed experts to device format (blitz)...")
+        t0 = time.perf_counter()
+        gate_stacked = torch.stack(gate_list, dim=0)
+        up_stacked = torch.stack(up_list, dim=0)
+        down_stacked = torch.stack(down_list, dim=0)
+        routed_gate_proj, routed_up_proj, routed_down_proj = bdw.get_tt_moe_routed_expert_weights(
+            gate_stacked, up_stacked, down_stacked, move_to_device=False
+        )
+        logger.info("  converted routed experts in {:.3f}s", time.perf_counter() - t0)
+        return MoERoutedExpertWeights(
+            routed_gate_proj=routed_gate_proj,
+            routed_up_proj=routed_up_proj,
+            routed_down_proj=routed_down_proj,
+        )
+    else:
+        mlp_gate = state_dict[_key(layer_idx, "mlp.gate_proj.weight")].T.contiguous()
+        mlp_up = state_dict[_key(layer_idx, "mlp.up_proj.weight")].T.contiguous()
+        mlp_down = state_dict[_key(layer_idx, "mlp.down_proj.weight")].T.contiguous()
+        routed_gate_proj, routed_up_proj, routed_down_proj = bdw.get_tt_mlp_routed_expert_weights(
+            mlp_gate, mlp_up, mlp_down, move_to_device=False
+        )
+        return DenseRoutedExpertWeights(
+            routed_gate_proj=routed_gate_proj,
+            routed_up_proj=routed_up_proj,
+            routed_down_proj=routed_down_proj,
+        )
+
+
+def prepare_dense_decoder_layer_weights(
+    bdw: BlitzDecodeWeights,
+    state_dict: dict[str, torch.Tensor],
+    layer_idx: int,
+) -> DeepSeekV3DenseLayerWeights:
+    """Prepare fused weights for a single dense decoder layer."""
+    logger.info("Preparing dense layer {}...", layer_idx)
+    t0 = time.perf_counter()
+    attn = prepare_attention_weights(bdw, state_dict, layer_idx, is_moe=False)
+    shared = prepare_shared_expert_weights(bdw, state_dict, layer_idx, is_moe=False)
+    routed = prepare_routed_expert_weights(bdw, state_dict, layer_idx, is_moe=False)
+    assert isinstance(routed, DenseRoutedExpertWeights)
+    return DeepSeekV3DenseLayerWeights(
+        q_a_proj=attn.q_a_proj,
+        q_b_proj=attn.q_b_proj,
+        kv_a_proj=attn.kv_a_proj,
+        o_proj=attn.o_proj,
+        attn_norm=attn.attn_norm,
+        q_norm=attn.q_norm,
+        kv_norm=attn.kv_norm,
+        ffn_norm=attn.ffn_norm,
+        kv_b1_proj=attn.kv_b1_proj,
+        kv_b2_proj=attn.kv_b2_proj,
+        shared_gate_proj=shared.shared_gate_proj,
+        shared_up_proj=shared.shared_up_proj,
+        shared_down_proj=shared.shared_down_proj,
+        routed_gate_proj=routed.routed_gate_proj,
+        routed_up_proj=routed.routed_up_proj,
+        routed_down_proj=routed.routed_down_proj,
+    )
+    logger.info("  dense layer {} done in {:.3f}s", layer_idx, time.perf_counter() - t0)
+
+
+def prepare_moe_decoder_layer_weights(
+    bdw: BlitzDecodeWeights,
+    state_dict: dict[str, torch.Tensor],
+    layer_idx: int,
+    *,
+    num_routed_experts: int = NUM_ROUTED_EXPERTS,
+) -> DeepSeekV3MoELayerWeights:
+    """Prepare fused weights for a single MoE decoder layer."""
+    logger.info("Preparing MoE layer {}...", layer_idx)
+    t0 = time.perf_counter()
+    attn = prepare_attention_weights(bdw, state_dict, layer_idx, is_moe=True)
+    shared = prepare_shared_expert_weights(bdw, state_dict, layer_idx, is_moe=True)
+    routed = prepare_routed_expert_weights(
+        bdw, state_dict, layer_idx, is_moe=True, num_routed_experts=num_routed_experts
+    )
+    assert isinstance(attn.gate_mm, OverlappedTensor)
+    assert isinstance(routed, MoERoutedExpertWeights)
+    return DeepSeekV3MoELayerWeights(
+        q_a_proj=attn.q_a_proj,
+        q_b_proj=attn.q_b_proj,
+        kv_a_proj=attn.kv_a_proj,
+        o_proj=attn.o_proj,
+        gate_mm=attn.gate_mm,
+        attn_norm=attn.attn_norm,
+        q_norm=attn.q_norm,
+        kv_norm=attn.kv_norm,
+        ffn_norm=attn.ffn_norm,
+        kv_b1_proj=attn.kv_b1_proj,
+        kv_b2_proj=attn.kv_b2_proj,
+        shared_gate_proj=shared.shared_gate_proj,
+        shared_up_proj=shared.shared_up_proj,
+        shared_down_proj=shared.shared_down_proj,
+        routed_gate_proj=routed.routed_gate_proj,
+        routed_up_proj=routed.routed_up_proj,
+        routed_down_proj=routed.routed_down_proj,
+    )
+    logger.info("  MoE layer {} done in {:.3f}s", layer_idx, time.perf_counter() - t0)
+
+
+def prepare_weights(
+    state_dict: dict[str, torch.Tensor],
+    device,
+    num_layers: int = 61,
+    first_k_dense_replace: int = 3,
+    num_routed_experts: int = NUM_ROUTED_EXPERTS,
+) -> DeepSeekV3Weights:
+    """Build fused weights from a HuggingFace-style state dict.
+
+    State dict should use full logical HF shapes when device is a mesh (e.g. 4x2);
+    internally we shard them across the mesh.
+
+    Args:
+        state_dict: Weights keyed by model.layers.{i}.self_attn.*, model.layers.{i}.mlp.*, etc.
+        device: MeshDevice to place weights on.
+        num_layers: Total number of layers (default 61).
+        first_k_dense_replace: Number of dense layers before MoE (default 3).
+        num_routed_experts: Number of MoE routed experts per layer (default NUM_ROUTED_EXPERTS).
+
+    Returns:
+        DeepSeekV3Weights with one entry per layer; dense vs MoE type by layer index.
+    """
+    logger.info(
+        "Preparing full model weights ({} layers, dense 0..{}, MoE {}..{})...",
+        num_layers,
+        first_k_dense_replace - 1,
+        first_k_dense_replace,
+        num_layers - 1,
+    )
+    total_t0 = time.perf_counter()
+    bdw = BlitzDecodeWeights(device)
+    layers: list[DeepSeekV3LayerWeights] = []
+
+    for i in range(num_layers):
+        is_moe = i >= first_k_dense_replace
+        if is_moe:
+            layers.append(prepare_moe_decoder_layer_weights(bdw, state_dict, i, num_routed_experts=num_routed_experts))
+        else:
+            layers.append(prepare_dense_decoder_layer_weights(bdw, state_dict, i))
+
+    logger.info("All {} layers prepared in {:.3f}s", num_layers, time.perf_counter() - total_t0)
+    return DeepSeekV3Weights(layers=layers)
+
+
+def _deallocate_tt_tensor(t: ttnn.Tensor, seen: set[int]) -> None:
+    """Deallocate a single ttnn.Tensor if not already deallocated (by id)."""
+    fid = id(t)
+    if fid not in seen:
+        seen.add(fid)
+        ttnn.deallocate(t, force=True)
+
+
+def deallocate_weights(weights: DeepSeekV3Weights) -> None:
+    """Release device memory for all fused tensors in prepared weights.
+
+    Call this before loading a new set of weights onto the same device to avoid
+    OOM (the original and loaded weights would otherwise both reside on device).
+    """
+    seen: set[int] = set()
+    for layer in weights.layers:
+        for _name, ot in _layer_overlapped_tensor_fields(layer):
+            fid = id(ot.fused_tensor)
+            if fid not in seen:
+                seen.add(fid)
+                ttnn.deallocate(ot.fused_tensor, force=True)
+        if hasattr(layer, "shared_down_proj"):
+            _deallocate_tt_tensor(getattr(layer, "shared_down_proj"), seen)
+        if isinstance(layer, DeepSeekV3MoELayerWeights):
+            for t in layer.routed_gate_proj:
+                _deallocate_tt_tensor(t, seen)
+            for t in layer.routed_up_proj:
+                _deallocate_tt_tensor(t, seen)
+            for t in layer.routed_down_proj:
+                _deallocate_tt_tensor(t, seen)
+        else:
+            assert isinstance(layer, DeepSeekV3DenseLayerWeights)
+            _deallocate_tt_tensor(layer.routed_gate_proj, seen)
+            _deallocate_tt_tensor(layer.routed_up_proj, seen)
+            _deallocate_tt_tensor(layer.routed_down_proj, seen)
+
+
+def _core_range_set_to_list(crs: ttnn.CoreRangeSet) -> list[list[list[int]]]:
+    """Serialize CoreRangeSet to JSON-serializable list of [[sx, sy], [ex, ey]]."""
+    result = []
+    for r in crs.ranges():
+        start, end = r.start, r.end
+        result.append([[start.x, start.y], [end.x, end.y]])
+    return result
+
+
+def _core_range_set_from_list(lst: list[list[list[int]]]) -> ttnn.CoreRangeSet:
+    """Deserialize list of [[sx, sy], [ex, ey]] to CoreRangeSet."""
+    ranges = [
+        ttnn.CoreRange(
+            ttnn.CoreCoord(pair[0][0], pair[0][1]),
+            ttnn.CoreCoord(pair[1][0], pair[1][1]),
+        )
+        for pair in lst
+    ]
+    return ttnn.CoreRangeSet(ranges)
+
+
+def _overlapped_tensor_to_json(ot: OverlappedTensor) -> dict:
+    """Serialize one OverlappedTensor's metadata to a JSON-serializable dict."""
+    dtype_str = _DTYPE_TO_STR.get(ot.dtype)
+    if dtype_str is None:
+        dtype_str = str(ot.dtype)
+    return {
+        "tensor_shape": list(ot.tensor_shape),
+        "shard_shape": list(ot.shard_shape),
+        "core_range_set": _core_range_set_to_list(ot.core_range_set),
+        "dtype": dtype_str,
+        "tile_shape": list(ot.tile_shape),
+        "byte_offset": ot.byte_offset,
+    }
+
+
+def _overlapped_tensor_from_dict(
+    fused_tensor: ttnn.Tensor,
+    d: dict,
+) -> OverlappedTensor:
+    """Reconstruct one OverlappedTensor from loaded fused tensor and manifest dict."""
+    dtype = _STR_TO_DTYPE.get(d["dtype"])
+    if dtype is None:
+        raise ValueError(f"Unknown dtype in manifest: {d['dtype']}")
+    return OverlappedTensor(
+        fused_tensor=fused_tensor,
+        tensor_shape=tuple(d["tensor_shape"]),
+        shard_shape=tuple(d["shard_shape"]),
+        core_range_set=_core_range_set_from_list(d["core_range_set"]),
+        dtype=dtype,
+        tile_shape=tuple(d["tile_shape"]),
+        byte_offset=d["byte_offset"],
+    )
+
+
+def _layer_overlapped_tensor_fields(
+    layer: DeepSeekV3LayerWeights,
+) -> list[tuple[str, OverlappedTensor]]:
+    """Return (field_name, OverlappedTensor) for every OverlappedTensor field on the layer."""
+    out = []
+    for f in fields(layer):
+        val = getattr(layer, f.name)
+        if isinstance(val, OverlappedTensor):
+            out.append((f.name, val))
+    return out
+
+
+def _read_or_create_manifest(
+    layer_dir: Path,
+    layer_idx: int,
+    is_moe: bool,
+    *,
+    hf_model_name: str = "",
+    hf_state_dict_name: str = "",
+    device_mesh_shape: tuple[int, int] = (1, 1),
+) -> dict:
+    """Read existing manifest or create a new one for incremental save. Caller merges and writes back."""
+    manifest_path = layer_dir / "manifest.json"
+    if manifest_path.exists():
+        with open(manifest_path) as f:
+            return json.load(f)
+    created = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    manifest = {
+        "version": _MANIFEST_VERSION,
+        "created_time": created,
+        "hf_model_name": hf_model_name,
+        "hf_state_dict_name": hf_state_dict_name,
+        "device_mesh_shape": list(device_mesh_shape),
+        "layer_idx": layer_idx,
+        "layer_type": "moe" if is_moe else "dense",
+        "fusion_groups": {},
+        "standalone_tensors": {},
+    }
+    if is_moe:
+        manifest["routed_experts"] = {"num_experts": NUM_ROUTED_EXPERTS}
+    else:
+        manifest["routed_mlp"] = True
+    return manifest
+
+
+def _dump_overlapped_fusion_groups(
+    layer_dir: Path,
+    field_tuples: list[tuple[str, OverlappedTensor]],
+) -> dict:
+    """Dump fused tensors for the given (field_name, OverlappedTensor) pairs; return fusion_groups dict."""
+    by_fused: dict[int, list[tuple[str, OverlappedTensor]]] = {}
+    for name, ot in field_tuples:
+        fid = id(ot.fused_tensor)
+        if fid not in by_fused:
+            by_fused[fid] = []
+        by_fused[fid].append((name, ot))
+    fusion_groups: dict[str, dict] = {}
+    for fid, group_fields in by_fused.items():
+        group_name = _FIELD_TO_FUSION_GROUP.get(group_fields[0][0])
+        if group_name is None:
+            raise KeyError(f"Unknown field for fusion group: {group_fields[0][0]}")
+        tensorbin_name = f"{group_name}.tensorbin"
+        ttnn.dump_tensor(layer_dir / tensorbin_name, group_fields[0][1].fused_tensor)
+        fusion_groups[group_name] = {
+            "tensorbin": tensorbin_name,
+            "fields": {name: _overlapped_tensor_to_json(ot) for name, ot in group_fields},
+        }
+    return fusion_groups
+
+
+def save_attention_weights(
+    attn: AttentionWeights,
+    path: str | Path,
+    layer_idx: int,
+    *,
+    is_moe: bool,
+    hf_model_name: str = "",
+    hf_state_dict_name: str = "",
+    device_mesh_shape: tuple[int, int] = (1, 1),
+) -> None:
+    """Save attention fusion groups to layer dir; merge into existing manifest if present."""
+    logger.debug("Saving attention weights for layer {}...", layer_idx)
+    t0 = time.perf_counter()
+    path = Path(path)
+    path.mkdir(parents=True, exist_ok=True)
+    layer_dir = path / f"layer_{layer_idx:03d}"
+    layer_dir.mkdir(parents=True, exist_ok=True)
+    manifest = _read_or_create_manifest(
+        layer_dir,
+        layer_idx,
+        is_moe,
+        hf_model_name=hf_model_name,
+        hf_state_dict_name=hf_state_dict_name,
+        device_mesh_shape=device_mesh_shape,
+    )
+    field_tuples: list[tuple[str, OverlappedTensor]] = [
+        ("q_a_proj", attn.q_a_proj),
+        ("q_b_proj", attn.q_b_proj),
+        ("kv_a_proj", attn.kv_a_proj),
+        ("o_proj", attn.o_proj),
+        ("attn_norm", attn.attn_norm),
+        ("q_norm", attn.q_norm),
+        ("kv_norm", attn.kv_norm),
+        ("ffn_norm", attn.ffn_norm),
+        ("kv_b1_proj", attn.kv_b1_proj),
+        ("kv_b2_proj", attn.kv_b2_proj),
+    ]
+    if attn.gate_mm is not None:
+        field_tuples.append(("gate_mm", attn.gate_mm))
+    new_groups = _dump_overlapped_fusion_groups(layer_dir, field_tuples)
+    manifest.setdefault("fusion_groups", {}).update(new_groups)
+    with open(layer_dir / "manifest.json", "w") as f:
+        json.dump(manifest, f, indent=2)
+    logger.debug("  save_attention_weights: {:.3f}s", time.perf_counter() - t0)
+
+
+def save_shared_expert_weights(
+    shared: SharedExpertWeights,
+    path: str | Path,
+    layer_idx: int,
+    *,
+    is_moe: bool,
+    hf_model_name: str = "",
+    hf_state_dict_name: str = "",
+    device_mesh_shape: tuple[int, int] = (1, 1),
+) -> None:
+    """Save shared expert gate_up and shared_down_proj to layer dir; merge into existing manifest if present."""
+    logger.debug("Saving shared expert weights for layer {}...", layer_idx)
+    t0 = time.perf_counter()
+    path = Path(path)
+    path.mkdir(parents=True, exist_ok=True)
+    layer_dir = path / f"layer_{layer_idx:03d}"
+    layer_dir.mkdir(parents=True, exist_ok=True)
+    manifest = _read_or_create_manifest(
+        layer_dir,
+        layer_idx,
+        is_moe,
+        hf_model_name=hf_model_name,
+        hf_state_dict_name=hf_state_dict_name,
+        device_mesh_shape=device_mesh_shape,
+    )
+    new_groups = _dump_overlapped_fusion_groups(
+        layer_dir,
+        [
+            ("shared_gate_proj", shared.shared_gate_proj),
+            ("shared_up_proj", shared.shared_up_proj),
+        ],
+    )
+    manifest.setdefault("fusion_groups", {}).update(new_groups)
+    name = "shared_down_proj.tensorbin"
+    ttnn.dump_tensor(layer_dir / name, shared.shared_down_proj)
+    manifest.setdefault("standalone_tensors", {})["shared_down_proj"] = name
+    with open(layer_dir / "manifest.json", "w") as f:
+        json.dump(manifest, f, indent=2)
+    logger.debug("  save_shared_expert_weights: {:.3f}s", time.perf_counter() - t0)
+
+
+def save_routed_expert_weights(
+    routed: DenseRoutedExpertWeights | MoERoutedExpertWeights,
+    path: str | Path,
+    layer_idx: int,
+    *,
+    is_moe: bool,
+    hf_model_name: str = "",
+    hf_state_dict_name: str = "",
+    device_mesh_shape: tuple[int, int] = (1, 1),
+) -> None:
+    """Save routed expert weights to layer dir; merge into existing manifest if present."""
+    path = Path(path)
+    path.mkdir(parents=True, exist_ok=True)
+    layer_dir = path / f"layer_{layer_idx:03d}"
+    layer_dir.mkdir(parents=True, exist_ok=True)
+    manifest = _read_or_create_manifest(
+        layer_dir,
+        layer_idx,
+        is_moe,
+        hf_model_name=hf_model_name,
+        hf_state_dict_name=hf_state_dict_name,
+        device_mesh_shape=device_mesh_shape,
+    )
+    standalone = manifest.setdefault("standalone_tensors", {})
+    if is_moe:
+        assert isinstance(routed, MoERoutedExpertWeights)
+        num_experts = len(routed.routed_gate_proj)
+        manifest["routed_experts"] = {"num_experts": num_experts}
+        logger.info("Saving {} routed experts for layer {} to disk (this may be slow)...", num_experts, layer_idx)
+        t0 = time.perf_counter()
+        experts_dir = layer_dir / "experts"
+        experts_dir.mkdir(parents=True, exist_ok=True)
+        for e in range(num_experts):
+            if e > 0 and e % 64 == 0:
+                logger.debug("  saved experts 0..{}", e - 1)
+            expert_dir = experts_dir / f"e_{e:03d}"
+            expert_dir.mkdir(parents=True, exist_ok=True)
+            ttnn.dump_tensor(expert_dir / "gate_proj.tensorbin", routed.routed_gate_proj[e])
+            ttnn.dump_tensor(expert_dir / "up_proj.tensorbin", routed.routed_up_proj[e])
+            ttnn.dump_tensor(expert_dir / "down_proj.tensorbin", routed.routed_down_proj[e])
+        logger.info("  saved {} routed experts in {:.3f}s", num_experts, time.perf_counter() - t0)
+    else:
+        assert isinstance(routed, DenseRoutedExpertWeights)
+        logger.debug("Saving dense routed MLP for layer {}...", layer_idx)
+        ttnn.dump_tensor(layer_dir / "routed_gate_proj.tensorbin", routed.routed_gate_proj)
+        ttnn.dump_tensor(layer_dir / "routed_up_proj.tensorbin", routed.routed_up_proj)
+        ttnn.dump_tensor(layer_dir / "routed_down_proj.tensorbin", routed.routed_down_proj)
+        standalone["routed_gate_proj"] = "routed_gate_proj.tensorbin"
+        standalone["routed_up_proj"] = "routed_up_proj.tensorbin"
+        standalone["routed_down_proj"] = "routed_down_proj.tensorbin"
+    with open(layer_dir / "manifest.json", "w") as f:
+        json.dump(manifest, f, indent=2)
+
+
+def save_layer(
+    layer: DeepSeekV3LayerWeights,
+    path: str | Path,
+    layer_idx: int,
+    *,
+    hf_model_name: str,
+    hf_state_dict_name: str,
+    device_mesh_shape: tuple[int, int] = (1, 1),
+) -> None:
+    """Serialize a single layer to <path>/layer_{layer_idx:03d}/.
+
+    Creates one directory with manifest.json and per-fusion-group .tensorbin files.
+    Caller must provide hf_model_name and hf_state_dict_name for the manifest.
+    """
+    path = Path(path)
+    layer_dir = path / f"layer_{layer_idx:03d}"
+    logger.info(f"Saving layer {layer_idx} to {layer_dir}...")
+    is_moe = isinstance(layer, DeepSeekV3MoELayerWeights)
+    save_layer_t0 = time.perf_counter()
+    attn = AttentionWeights(
+        q_a_proj=layer.q_a_proj,
+        q_b_proj=layer.q_b_proj,
+        kv_a_proj=layer.kv_a_proj,
+        o_proj=layer.o_proj,
+        gate_mm=getattr(layer, "gate_mm", None),
+        attn_norm=layer.attn_norm,
+        q_norm=layer.q_norm,
+        kv_norm=layer.kv_norm,
+        ffn_norm=layer.ffn_norm,
+        kv_b1_proj=layer.kv_b1_proj,
+        kv_b2_proj=layer.kv_b2_proj,
+    )
+    shared = SharedExpertWeights(
+        shared_gate_proj=layer.shared_gate_proj,
+        shared_up_proj=layer.shared_up_proj,
+        shared_down_proj=layer.shared_down_proj,
+    )
+    if is_moe:
+        routed = MoERoutedExpertWeights(
+            routed_gate_proj=layer.routed_gate_proj,
+            routed_up_proj=layer.routed_up_proj,
+            routed_down_proj=layer.routed_down_proj,
+        )
+    else:
+        routed = DenseRoutedExpertWeights(
+            routed_gate_proj=layer.routed_gate_proj,
+            routed_up_proj=layer.routed_up_proj,
+            routed_down_proj=layer.routed_down_proj,
+        )
+    save_attention_weights(
+        attn,
+        path,
+        layer_idx,
+        is_moe=is_moe,
+        hf_model_name=hf_model_name,
+        hf_state_dict_name=hf_state_dict_name,
+        device_mesh_shape=device_mesh_shape,
+    )
+    save_shared_expert_weights(
+        shared,
+        path,
+        layer_idx,
+        is_moe=is_moe,
+        hf_model_name=hf_model_name,
+        hf_state_dict_name=hf_state_dict_name,
+        device_mesh_shape=device_mesh_shape,
+    )
+    save_routed_expert_weights(
+        routed,
+        path,
+        layer_idx,
+        is_moe=is_moe,
+        hf_model_name=hf_model_name,
+        hf_state_dict_name=hf_state_dict_name,
+        device_mesh_shape=device_mesh_shape,
+    )
+    logger.info(f"  save_layer total: {time.perf_counter() - save_layer_t0:.3f}s")
+
+
+def load_layer(
+    path: str | Path,
+    device,
+    layer_idx: int,
+) -> DeepSeekV3LayerWeights:
+    """Deserialize a single layer from <path>/layer_{layer_idx:03d}/."""
+    path = Path(path)
+    layer_dir = path / f"layer_{layer_idx:03d}"
+    manifest_path = layer_dir / "manifest.json"
+    if not manifest_path.exists():
+        raise FileNotFoundError(f"Missing manifest: {manifest_path}")
+
+    with open(manifest_path) as f:
+        manifest = json.load(f)
+
+    if manifest.get("version", 0) > _MANIFEST_VERSION:
+        raise ValueError(f"Unsupported manifest version: {manifest.get('version')}")
+
+    layer_type = manifest["layer_type"]
+    fusion_groups = manifest["fusion_groups"]
+    load_t0 = time.perf_counter()
+    logger.info("Loading layer {} ({}) from disk...", layer_idx, layer_type)
+
+    if layer_type == "dense":
+        q_ab = fusion_groups["q_ab_kv_a"]
+        fused_q = ttnn.load_tensor(layer_dir / q_ab["tensorbin"], device=device)
+        q_a_proj = _overlapped_tensor_from_dict(fused_q, q_ab["fields"]["q_a_proj"])
+        q_b_proj = _overlapped_tensor_from_dict(fused_q, q_ab["fields"]["q_b_proj"])
+        kv_a_proj = _overlapped_tensor_from_dict(fused_q, q_ab["fields"]["kv_a_proj"])
+
+        o_grp = fusion_groups["o_proj_gate_mm_norms"]
+        fused_o = ttnn.load_tensor(layer_dir / o_grp["tensorbin"], device=device)
+        o_proj = _overlapped_tensor_from_dict(fused_o, o_grp["fields"]["o_proj"])
+        attn_norm = _overlapped_tensor_from_dict(fused_o, o_grp["fields"]["attn_norm"])
+        q_norm = _overlapped_tensor_from_dict(fused_o, o_grp["fields"]["q_norm"])
+        kv_norm = _overlapped_tensor_from_dict(fused_o, o_grp["fields"]["kv_norm"])
+        ffn_norm = _overlapped_tensor_from_dict(fused_o, o_grp["fields"]["ffn_norm"])
+
+        kv_grp = fusion_groups["kv_b12"]
+        fused_kv = ttnn.load_tensor(layer_dir / kv_grp["tensorbin"], device=device)
+        kv_b1_proj = _overlapped_tensor_from_dict(fused_kv, kv_grp["fields"]["kv_b1_proj"])
+        kv_b2_proj = _overlapped_tensor_from_dict(fused_kv, kv_grp["fields"]["kv_b2_proj"])
+
+        gu_grp = fusion_groups["gate_up"]
+        fused_gu = ttnn.load_tensor(layer_dir / gu_grp["tensorbin"], device=device)
+        shared_gate_proj = _overlapped_tensor_from_dict(fused_gu, gu_grp["fields"]["shared_gate_proj"])
+        shared_up_proj = _overlapped_tensor_from_dict(fused_gu, gu_grp["fields"]["shared_up_proj"])
+
+        standalone = manifest.get("standalone_tensors", {})
+        shared_down_proj = ttnn.load_tensor(layer_dir / standalone["shared_down_proj"], device=device)
+        routed_gate_proj = ttnn.load_tensor(layer_dir / standalone["routed_gate_proj"], device=device)
+        routed_up_proj = ttnn.load_tensor(layer_dir / standalone["routed_up_proj"], device=device)
+        routed_down_proj = ttnn.load_tensor(layer_dir / standalone["routed_down_proj"], device=device)
+        logger.info("  layer {} loaded in {:.3f}s", layer_idx, time.perf_counter() - load_t0)
+
+        return DeepSeekV3DenseLayerWeights(
+            q_a_proj=q_a_proj,
+            q_b_proj=q_b_proj,
+            kv_a_proj=kv_a_proj,
+            o_proj=o_proj,
+            attn_norm=attn_norm,
+            q_norm=q_norm,
+            kv_norm=kv_norm,
+            ffn_norm=ffn_norm,
+            kv_b1_proj=kv_b1_proj,
+            kv_b2_proj=kv_b2_proj,
+            shared_gate_proj=shared_gate_proj,
+            shared_up_proj=shared_up_proj,
+            shared_down_proj=shared_down_proj,
+            routed_gate_proj=routed_gate_proj,
+            routed_up_proj=routed_up_proj,
+            routed_down_proj=routed_down_proj,
+        )
+    else:
+        q_ab = fusion_groups["q_ab_kv_a"]
+        fused_q = ttnn.load_tensor(layer_dir / q_ab["tensorbin"], device=device)
+        q_a_proj = _overlapped_tensor_from_dict(fused_q, q_ab["fields"]["q_a_proj"])
+        q_b_proj = _overlapped_tensor_from_dict(fused_q, q_ab["fields"]["q_b_proj"])
+        kv_a_proj = _overlapped_tensor_from_dict(fused_q, q_ab["fields"]["kv_a_proj"])
+
+        o_grp = fusion_groups["o_proj_gate_mm_norms"]
+        fused_o = ttnn.load_tensor(layer_dir / o_grp["tensorbin"], device=device)
+        o_proj = _overlapped_tensor_from_dict(fused_o, o_grp["fields"]["o_proj"])
+        gate_mm = _overlapped_tensor_from_dict(fused_o, o_grp["fields"]["gate_mm"])
+        attn_norm = _overlapped_tensor_from_dict(fused_o, o_grp["fields"]["attn_norm"])
+        q_norm = _overlapped_tensor_from_dict(fused_o, o_grp["fields"]["q_norm"])
+        kv_norm = _overlapped_tensor_from_dict(fused_o, o_grp["fields"]["kv_norm"])
+        ffn_norm = _overlapped_tensor_from_dict(fused_o, o_grp["fields"]["ffn_norm"])
+
+        kv_grp = fusion_groups["kv_b12"]
+        fused_kv = ttnn.load_tensor(layer_dir / kv_grp["tensorbin"], device=device)
+        kv_b1_proj = _overlapped_tensor_from_dict(fused_kv, kv_grp["fields"]["kv_b1_proj"])
+        kv_b2_proj = _overlapped_tensor_from_dict(fused_kv, kv_grp["fields"]["kv_b2_proj"])
+
+        gu_grp = fusion_groups["gate_up"]
+        fused_gu = ttnn.load_tensor(layer_dir / gu_grp["tensorbin"], device=device)
+        shared_gate_proj = _overlapped_tensor_from_dict(fused_gu, gu_grp["fields"]["shared_gate_proj"])
+        shared_up_proj = _overlapped_tensor_from_dict(fused_gu, gu_grp["fields"]["shared_up_proj"])
+
+        standalone = manifest.get("standalone_tensors", {})
+        shared_down_proj = ttnn.load_tensor(layer_dir / standalone["shared_down_proj"], device=device)
+        num_experts = manifest.get("routed_experts", {}).get("num_experts", NUM_ROUTED_EXPERTS)
+        logger.info("  loading {} routed experts from disk (this may be slow)...", num_experts)
+        experts_t0 = time.perf_counter()
+        experts_dir = layer_dir / "experts"
+        routed_gate_proj = []
+        routed_up_proj = []
+        routed_down_proj = []
+        for e in range(num_experts):
+            if e > 0 and e % 64 == 0:
+                logger.debug("  loaded experts 0..{}", e - 1)
+            expert_dir = experts_dir / f"e_{e:03d}"
+            routed_gate_proj.append(ttnn.load_tensor(expert_dir / "gate_proj.tensorbin", device=device))
+            routed_up_proj.append(ttnn.load_tensor(expert_dir / "up_proj.tensorbin", device=device))
+            routed_down_proj.append(ttnn.load_tensor(expert_dir / "down_proj.tensorbin", device=device))
+        logger.info(
+            "  layer {} loaded in {:.3f}s (routed experts: {:.3f}s)",
+            layer_idx,
+            time.perf_counter() - load_t0,
+            time.perf_counter() - experts_t0,
+        )
+
+        return DeepSeekV3MoELayerWeights(
+            q_a_proj=q_a_proj,
+            q_b_proj=q_b_proj,
+            kv_a_proj=kv_a_proj,
+            o_proj=o_proj,
+            gate_mm=gate_mm,
+            attn_norm=attn_norm,
+            q_norm=q_norm,
+            kv_norm=kv_norm,
+            ffn_norm=ffn_norm,
+            kv_b1_proj=kv_b1_proj,
+            kv_b2_proj=kv_b2_proj,
+            shared_gate_proj=shared_gate_proj,
+            shared_up_proj=shared_up_proj,
+            shared_down_proj=shared_down_proj,
+            routed_gate_proj=routed_gate_proj,
+            routed_up_proj=routed_up_proj,
+            routed_down_proj=routed_down_proj,
+        )
+
+
+def save_weights(
+    weights: DeepSeekV3Weights,
+    path: str | Path,
+    *,
+    hf_model_name: str,
+    hf_state_dict_name: str,
+    device_mesh_shape: tuple[int, int] = (1, 1),
+) -> None:
+    """Serialize all layers to disk. Convenience wrapper around save_layer."""
+    path = Path(path)
+    num_layers = len(weights.layers)
+    logger.info("Saving all {} layers to {}...", num_layers, path)
+    total_t0 = time.perf_counter()
+    for layer_idx, layer in enumerate(weights.layers):
+        save_layer(
+            layer,
+            path,
+            layer_idx,
+            hf_model_name=hf_model_name,
+            hf_state_dict_name=hf_state_dict_name,
+            device_mesh_shape=device_mesh_shape,
+        )
+    logger.info("All {} layers saved in {:.3f}s", num_layers, time.perf_counter() - total_t0)
+
+
+def load_weights(
+    path: str | Path,
+    device,
+    num_layers: int = 61,
+) -> DeepSeekV3Weights:
+    """Deserialize layers from disk. Convenience wrapper: load_layer for each index."""
+    path = Path(path)
+    if not path.is_dir():
+        raise FileNotFoundError(f"Weights path is not a directory: {path}")
+    logger.info("Loading all {} layers from {}...", num_layers, path)
+    total_t0 = time.perf_counter()
+    layers = [load_layer(path, device, i) for i in range(num_layers)]
+    logger.info("All {} layers loaded in {:.3f}s", num_layers, time.perf_counter() - total_t0)
+    return DeepSeekV3Weights(layers=layers)

--- a/models/demos/deepseek_v3_b1/scripts/generate_cache.py
+++ b/models/demos/deepseek_v3_b1/scripts/generate_cache.py
@@ -1,0 +1,608 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Generate weight cache for a single DeepSeek V3 layer from HuggingFace safetensors.
+
+Modes:
+  dense   - Full dense layer (layers 0-2). Requires slow dispatch.
+  moe     - Attention + shared experts only (layers 3-60). Requires slow dispatch.
+  experts - Routed experts only (layers 3-60). Can run in fast dispatch.
+
+Usage:
+  python generate_cache.py --model-path /path/to/DeepSeek-V3 --output-path /path/to/cache --layer-num 0 --type dense
+  python generate_cache.py --model-path /path/to/DeepSeek-V3 --output-path /path/to/cache --layer-num 4 --type moe
+  python generate_cache.py --model-path /path/to/DeepSeek-V3 --output-path /path/to/cache --layer-num 4 --type experts
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import time
+from pathlib import Path
+
+from loguru import logger
+
+import ttnn
+
+# Same mesh device setup as test_prepare_weights.py (bh_2d_mesh_device fixture).
+from conftest import bh_2d_mesh_device_context
+from models.common.utility_functions import is_slow_dispatch
+from models.demos.deepseek_v3.utils.lazy_state_dict import LazyStateDict
+from models.demos.deepseek_v3_b1.blitz_decode_weights import BlitzDecodeWeights
+from models.demos.deepseek_v3_b1.prepare_weights import (
+    NUM_ROUTED_EXPERTS,
+    DeepSeekV3DenseLayerWeights,
+    DeepSeekV3MoELayerWeights,
+    load_layer,
+    prepare_attention_weights,
+    prepare_dense_decoder_layer_weights,
+    prepare_routed_expert_weights,
+    prepare_shared_expert_weights,
+    save_attention_weights,
+    save_layer,
+    save_routed_expert_weights,
+    save_shared_expert_weights,
+)
+
+NUM_LAYERS = 61
+FIRST_K_DENSE_REPLACE = 3
+DEVICE_MESH_SHAPE = (4, 2)
+MANIFEST_VERSION = 1
+HF_MODEL_NAME = "deepseek-ai/DeepSeek-V3"
+HF_STATE_DICT_NAME = "lazy"
+
+# Fusion group tensorbin names written by save_attention_weights / save_shared_expert_weights (moe mode)
+MOE_FUSION_FILES = (
+    "q_ab_kv_a.tensorbin",
+    "o_proj_gate_mm_norms.tensorbin",
+    "kv_b12.tensorbin",
+    "gate_up.tensorbin",
+)
+
+# Expected tensor_topology() placements for 4x2 mesh (mla_tp=2, moe_tp=8); used by verify device load.
+_PLACEMENTS_SHARD_NONE_1 = [ttnn.PlacementReplicate(), ttnn.PlacementShard(1)]  # q_ab_kv_a, o_proj_gate_mm_norms
+_PLACEMENTS_SHARD_NONE_0 = [ttnn.PlacementReplicate(), ttnn.PlacementShard(0)]  # kv_b12
+_PLACEMENTS_SHARD_0_1 = [ttnn.PlacementShard(0), ttnn.PlacementShard(1)]  # gate_up, shared_down_proj, dense routed
+_PLACEMENTS_REPLICATE = [ttnn.PlacementReplicate()]  # MoE routed experts (per expert)
+
+
+def _create_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Generate weight cache for a single DeepSeek V3 layer from HuggingFace weights.",
+    )
+    parser.add_argument(
+        "--model-path",
+        type=Path,
+        default=None,
+        help="Local directory containing model.safetensors.index.json and shard files (required for generate; optional for --verify)",
+    )
+    parser.add_argument(
+        "--output-path",
+        type=Path,
+        required=True,
+        help="Directory to write cache (layer_NNN subdirs created inside)",
+    )
+    parser.add_argument(
+        "--layer-num",
+        type=int,
+        required=True,
+        help="Layer index (0-60)",
+    )
+    parser.add_argument(
+        "--type",
+        dest="mode",
+        choices=("dense", "moe", "experts"),
+        required=True,
+        help="Cache type: dense (layers 0-2), moe (attn+shared for 3-60), experts (routed only for 3-60)",
+    )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Overwrite existing cache files for this layer/mode",
+    )
+    parser.add_argument(
+        "--verify",
+        action="store_true",
+        help="Verify existing cache (manifest + files, optional device load) instead of generating",
+    )
+    return parser
+
+
+def _validate_args(args: argparse.Namespace) -> None:
+    """Validate arguments and exit with message on failure."""
+    layer_num = args.layer_num
+    mode = args.mode
+    output_path = args.output_path.resolve()
+
+    if layer_num < 0 or layer_num >= NUM_LAYERS:
+        logger.error("layer-num must be in [0, {}], got {}", NUM_LAYERS - 1, layer_num)
+        sys.exit(1)
+
+    if mode == "dense":
+        if layer_num >= FIRST_K_DENSE_REPLACE:
+            logger.error(
+                "type=dense requires layer-num < {} (dense layers are 0-{}), got {}",
+                FIRST_K_DENSE_REPLACE,
+                FIRST_K_DENSE_REPLACE - 1,
+                layer_num,
+            )
+            sys.exit(1)
+    else:
+        if layer_num < FIRST_K_DENSE_REPLACE:
+            logger.error(
+                "type={} requires layer-num >= {} (MoE layers are {}-{}), got {}",
+                mode,
+                FIRST_K_DENSE_REPLACE,
+                FIRST_K_DENSE_REPLACE,
+                NUM_LAYERS - 1,
+                layer_num,
+            )
+            sys.exit(1)
+
+    if args.verify:
+        # Verify mode: no model-path; require output_path and that layer dir exists
+        if not output_path.exists():
+            logger.error("output-path must exist for verify: {}", output_path)
+            sys.exit(1)
+        layer_dir = output_path / f"layer_{layer_num:03d}"
+        if not layer_dir.is_dir():
+            logger.error("Layer directory must exist for verify: {}", layer_dir)
+            sys.exit(1)
+        manifest_path = layer_dir / "manifest.json"
+        if not manifest_path.is_file():
+            logger.error("manifest.json not found for verify: {}", manifest_path)
+            sys.exit(1)
+        return
+
+    # Generate mode: require model-path and index
+    if args.model_path is None:
+        logger.error("--model-path is required for generate (omit --verify to generate)")
+        sys.exit(1)
+    model_path = args.model_path.resolve()
+    index_path = model_path / "model.safetensors.index.json"
+    if not index_path.is_file():
+        logger.error("model-path must contain model.safetensors.index.json; not found at {}", index_path)
+        sys.exit(1)
+
+    if not output_path.parent.exists():
+        logger.error("output-path parent must exist: {}", output_path.parent)
+        sys.exit(1)
+
+    if not args.force:
+        layer_dir = output_path / f"layer_{layer_num:03d}"
+        if mode == "dense":
+            manifest = layer_dir / "manifest.json"
+            if manifest.exists():
+                logger.error(
+                    "Layer {} cache already exists (manifest.json). Use --force to overwrite.",
+                    layer_num,
+                )
+                sys.exit(1)
+        elif mode == "moe":
+            for name in MOE_FUSION_FILES:
+                f = layer_dir / name
+                if f.exists():
+                    logger.error(
+                        "Layer {} already has {} (moe cache). Use --force to overwrite.",
+                        layer_num,
+                        name,
+                    )
+                    sys.exit(1)
+        else:
+            experts_dir = layer_dir / "experts"
+            if experts_dir.exists():
+                logger.error(
+                    "Layer {} already has experts/ directory. Use --force to overwrite.",
+                    layer_num,
+                )
+                sys.exit(1)
+
+    # Dispatch mode: dense and moe require slow dispatch; experts can use either, warn if slow
+    if mode in ("dense", "moe"):
+        if not is_slow_dispatch():
+            logger.warning(
+                "type={} requires slow dispatch mode. Set TT_METAL_SLOW_DISPATCH_MODE=1 and rerun.",
+                mode,
+            )
+    else:
+        assert mode == "experts"
+        if is_slow_dispatch():
+            logger.warning(
+                "experts mode can run in fast dispatch; you have TT_METAL_SLOW_DISPATCH_MODE=1 set (slow dispatch)."
+            )
+
+
+def _check_file(path: Path, layer_dir: Path) -> bool:
+    """Return True if path exists and has size > 0. path can be relative to layer_dir or absolute."""
+    if not path.is_absolute():
+        path = layer_dir / path
+    if not path.exists():
+        logger.error("File missing or not readable: {}", path)
+        return False
+    if path.stat().st_size == 0:
+        logger.error("File empty: {}", path)
+        return False
+    return True
+
+
+def _check_on_device(tensor: ttnn.Tensor, name: str) -> bool:
+    """Return True if tensor is on device (4x2 grid)."""
+    if tensor.storage_type() != ttnn.StorageType.DEVICE:
+        logger.error("{}: expected storage DEVICE, got {}", name, tensor.storage_type())
+        return False
+    return True
+
+
+def _check_topology(
+    tensor: ttnn.Tensor,
+    expected_placements: list,
+    name: str,
+) -> bool:
+    """Return True if tensor_topology().placements() matches expected for 4x2."""
+    actual = list(tensor.tensor_topology().placements())
+    if len(actual) != len(expected_placements):
+        logger.error(
+            "{}: expected {} placements, got {}",
+            name,
+            len(expected_placements),
+            len(actual),
+        )
+        return False
+    for a, e in zip(actual, expected_placements):
+        if type(a) != type(e):
+            logger.error("{}: placement type mismatch: {} vs {}", name, type(a).__name__, type(e).__name__)
+            return False
+        if isinstance(e, ttnn.PlacementShard) and a.dim != e.dim:
+            logger.error("{}: shard dim mismatch: {} vs {}", name, a.dim, e.dim)
+            return False
+    return True
+
+
+def _verify_layer_on_4x2_grid(
+    loaded: DeepSeekV3DenseLayerWeights | DeepSeekV3MoELayerWeights,
+) -> bool:
+    """Verify all tensors are on device and have correct tensor_topology() for 4x2 mesh. Returns False on first failure."""
+    seen_fused: set[int] = set()
+    # q_ab_kv_a
+    if not _check_on_device(loaded.q_a_proj.fused_tensor, "q_a_proj.fused_tensor"):
+        return False
+    fid = id(loaded.q_a_proj.fused_tensor)
+    if fid not in seen_fused:
+        seen_fused.add(fid)
+        if not _check_topology(loaded.q_a_proj.fused_tensor, _PLACEMENTS_SHARD_NONE_1, "q_ab_kv_a"):
+            return False
+    # o_proj_gate_mm_norms
+    if not _check_on_device(loaded.o_proj.fused_tensor, "o_proj.fused_tensor"):
+        return False
+    fid = id(loaded.o_proj.fused_tensor)
+    if fid not in seen_fused:
+        seen_fused.add(fid)
+        if not _check_topology(loaded.o_proj.fused_tensor, _PLACEMENTS_SHARD_NONE_1, "o_proj_gate_mm_norms"):
+            return False
+    # kv_b12
+    if not _check_on_device(loaded.kv_b1_proj.fused_tensor, "kv_b1_proj.fused_tensor"):
+        return False
+    fid = id(loaded.kv_b1_proj.fused_tensor)
+    if fid not in seen_fused:
+        seen_fused.add(fid)
+        if not _check_topology(loaded.kv_b1_proj.fused_tensor, _PLACEMENTS_SHARD_NONE_0, "kv_b12"):
+            return False
+    # gate_up
+    if not _check_on_device(loaded.shared_gate_proj.fused_tensor, "shared_gate_proj.fused_tensor"):
+        return False
+    fid = id(loaded.shared_gate_proj.fused_tensor)
+    if fid not in seen_fused:
+        seen_fused.add(fid)
+        if not _check_topology(loaded.shared_gate_proj.fused_tensor, _PLACEMENTS_SHARD_0_1, "gate_up"):
+            return False
+    # shared_down_proj
+    if not _check_on_device(loaded.shared_down_proj, "shared_down_proj"):
+        return False
+    if not _check_topology(loaded.shared_down_proj, _PLACEMENTS_SHARD_0_1, "shared_down_proj"):
+        return False
+    # Routed experts
+    if isinstance(loaded, DeepSeekV3DenseLayerWeights):
+        if not _check_on_device(loaded.routed_gate_proj, "routed_gate_proj"):
+            return False
+        if not _check_on_device(loaded.routed_up_proj, "routed_up_proj"):
+            return False
+        if not _check_on_device(loaded.routed_down_proj, "routed_down_proj"):
+            return False
+        if not _check_topology(loaded.routed_gate_proj, _PLACEMENTS_SHARD_0_1, "routed_gate_proj"):
+            return False
+        if not _check_topology(loaded.routed_up_proj, _PLACEMENTS_SHARD_0_1, "routed_up_proj"):
+            return False
+        if not _check_topology(loaded.routed_down_proj, _PLACEMENTS_SHARD_0_1, "routed_down_proj"):
+            return False
+    else:
+        assert isinstance(loaded, DeepSeekV3MoELayerWeights)
+        for e in range(len(loaded.routed_gate_proj)):
+            if not _check_on_device(loaded.routed_gate_proj[e], f"routed_gate_proj[{e}]"):
+                return False
+            if not _check_on_device(loaded.routed_up_proj[e], f"routed_up_proj[{e}]"):
+                return False
+            if not _check_on_device(loaded.routed_down_proj[e], f"routed_down_proj[{e}]"):
+                return False
+            if not _check_topology(loaded.routed_gate_proj[e], _PLACEMENTS_REPLICATE, f"routed_gate_proj[{e}]"):
+                return False
+            if not _check_topology(loaded.routed_up_proj[e], _PLACEMENTS_REPLICATE, f"routed_up_proj[{e}]"):
+                return False
+            if not _check_topology(loaded.routed_down_proj[e], _PLACEMENTS_REPLICATE, f"routed_down_proj[{e}]"):
+                return False
+    return True
+
+
+def _verify_cache(output_path: Path, layer_num: int, mode: str) -> bool:
+    """Verify existing cache: manifest, file existence, and optionally load to device. Returns True if all checks pass."""
+    layer_dir = output_path / f"layer_{layer_num:03d}"
+    manifest_path = layer_dir / "manifest.json"
+    logger.info("Verifying layer {} (mode={})...", layer_num, mode)
+
+    # 1. Manifest checks
+    try:
+        with open(manifest_path) as f:
+            manifest = json.load(f)
+    except (OSError, json.JSONDecodeError) as e:
+        logger.error("Failed to load manifest: {}", e)
+        return False
+    version = manifest.get("version", 0)
+    if version > MANIFEST_VERSION:
+        logger.error("Unsupported manifest version {} (max {})", version, MANIFEST_VERSION)
+        return False
+    logger.info("Manifest OK (version={})", version)
+    layer_type = manifest.get("layer_type")
+    if mode == "dense":
+        if layer_type != "dense":
+            logger.error("Expected layer_type 'dense', got '{}'", layer_type)
+            return False
+    else:
+        if layer_type != "moe":
+            logger.error("Expected layer_type 'moe' for mode {}, got '{}'", mode, layer_type)
+            return False
+
+    fusion_groups = manifest.get("fusion_groups", {})
+    standalone_tensors = manifest.get("standalone_tensors", {})
+
+    # 2. File-existence checks by mode
+    if mode == "dense":
+        required_fusion = ("q_ab_kv_a", "o_proj_gate_mm_norms", "kv_b12", "gate_up")
+        for name in required_fusion:
+            if name not in fusion_groups:
+                logger.error("Missing fusion_groups['{}']", name)
+                return False
+            grp = fusion_groups[name]
+            tensorbin = grp.get("tensorbin")
+            if not tensorbin or not _check_file(Path(tensorbin), layer_dir):
+                return False
+        required_standalone = ("shared_down_proj", "routed_gate_proj", "routed_up_proj", "routed_down_proj")
+        for name in required_standalone:
+            if name not in standalone_tensors:
+                logger.error("Missing standalone_tensors['{}']", name)
+                return False
+            if not _check_file(Path(standalone_tensors[name]), layer_dir):
+                return False
+        logger.info("All dense layer files present")
+    elif mode == "moe":
+        for name in ("q_ab_kv_a", "o_proj_gate_mm_norms", "kv_b12", "gate_up"):
+            if name not in fusion_groups:
+                logger.error("Missing fusion_groups['{}']", name)
+                return False
+            if not _check_file(Path(fusion_groups[name]["tensorbin"]), layer_dir):
+                return False
+        if "shared_down_proj" not in standalone_tensors:
+            logger.error("Missing standalone_tensors['shared_down_proj']")
+            return False
+        if not _check_file(Path(standalone_tensors["shared_down_proj"]), layer_dir):
+            return False
+        logger.info("All moe (attn+shared) files present")
+    else:
+        assert mode == "experts"
+        routed = manifest.get("routed_experts", {})
+        num_experts = routed.get("num_experts", 0)
+        if num_experts != NUM_ROUTED_EXPERTS:
+            logger.error("Expected routed_experts.num_experts={}, got {}", NUM_ROUTED_EXPERTS, num_experts)
+            return False
+        experts_dir = layer_dir / "experts"
+        if not experts_dir.is_dir():
+            logger.error("experts/ directory missing: {}", experts_dir)
+            return False
+        for e in range(NUM_ROUTED_EXPERTS):
+            expert_dir = experts_dir / f"e_{e:03d}"
+            if not expert_dir.is_dir():
+                logger.error("Expert dir missing: {}", expert_dir)
+                return False
+            for fname in ("gate_proj.tensorbin", "up_proj.tensorbin", "down_proj.tensorbin"):
+                if not _check_file(expert_dir / fname, layer_dir):
+                    return False
+        logger.info("All {} expert files present", NUM_ROUTED_EXPERTS)
+
+    # 3. Optional device load when cache is a complete layer
+    full_layer = False
+    if mode == "dense":
+        full_layer = True
+    elif mode == "moe":
+        experts_dir = layer_dir / "experts"
+        if experts_dir.is_dir():
+            n = sum(1 for _ in experts_dir.iterdir() if _.is_dir())
+            if n >= NUM_ROUTED_EXPERTS:
+                full_layer = True
+
+    if full_layer:
+        logger.info("Cache is complete layer; loading to device for sanity check...")
+        if not os.environ.get("TT_METAL_FABRIC_ROUTER_SYNC_TIMEOUT_MS"):
+            os.environ["TT_METAL_FABRIC_ROUTER_SYNC_TIMEOUT_MS"] = "30000"
+        device_params = {"fabric_config": ttnn.FabricConfig.FABRIC_2D}
+        try:
+            with bh_2d_mesh_device_context(device_params) as mesh_device:
+                submesh = mesh_device.create_submesh(ttnn.MeshShape(*DEVICE_MESH_SHAPE))
+                loaded = load_layer(output_path, submesh, layer_num)
+            if manifest.get("layer_type") == "dense":
+                if not isinstance(loaded, DeepSeekV3DenseLayerWeights):
+                    logger.error("Expected DeepSeekV3DenseLayerWeights, got {}", type(loaded).__name__)
+                    return False
+                # One shape check from manifest
+                expected_shape = tuple(fusion_groups["q_ab_kv_a"]["fields"]["q_a_proj"]["tensor_shape"])
+                if loaded.q_a_proj.tensor_shape != expected_shape:
+                    logger.error(
+                        "q_a_proj shape mismatch: expected {}, got {}",
+                        expected_shape,
+                        loaded.q_a_proj.tensor_shape,
+                    )
+                    return False
+            else:
+                if not isinstance(loaded, DeepSeekV3MoELayerWeights):
+                    logger.error("Expected DeepSeekV3MoELayerWeights, got {}", type(loaded).__name__)
+                    return False
+                expected_shape = tuple(fusion_groups["q_ab_kv_a"]["fields"]["q_a_proj"]["tensor_shape"])
+                if loaded.q_a_proj.tensor_shape != expected_shape:
+                    logger.error(
+                        "q_a_proj shape mismatch: expected {}, got {}",
+                        expected_shape,
+                        loaded.q_a_proj.tensor_shape,
+                    )
+                    return False
+            # Verify tensors are on 4x2 grid with correct topology
+            if not _verify_layer_on_4x2_grid(loaded):
+                logger.error("4x2 grid / tensor_topology() verification failed")
+                return False
+            logger.info("Device load OK (type, shape, on-device, and topology checks passed)")
+        except Exception as e:
+            logger.error("Device load failed: {}", e)
+            return False
+    else:
+        logger.info("Cache is partial (moe-only or experts-only); skipping device load")
+
+    logger.info("Verify OK")
+    return True
+
+
+def main() -> int:
+    parser = _create_parser()
+    args = parser.parse_args()
+    _validate_args(args)
+
+    layer_num = args.layer_num
+    mode = args.mode
+    output_path = args.output_path.resolve()
+
+    if args.verify:
+        ok = _verify_cache(output_path, layer_num, mode)
+        return 0 if ok else 1
+
+    model_path = args.model_path.resolve()
+    output_path.mkdir(parents=True, exist_ok=True)
+
+    total_t0 = time.perf_counter()
+
+    logger.info(
+        "Generating cache: mode={}, layer_num={}, model_path={}, output_path={}",
+        mode,
+        layer_num,
+        model_path,
+        output_path,
+    )
+
+    t0 = time.perf_counter()
+    with LazyStateDict(model_path) as state_dict:
+        logger.info("LazyStateDict initialized in {:.3f}s", time.perf_counter() - t0)
+
+        # Same initialization as bh_2d_mesh_device fixture (conftest.bh_2d_mesh_device_context).
+        if not os.environ.get("TT_METAL_FABRIC_ROUTER_SYNC_TIMEOUT_MS"):
+            os.environ["TT_METAL_FABRIC_ROUTER_SYNC_TIMEOUT_MS"] = "30000"
+            logger.info("Set TT_METAL_FABRIC_ROUTER_SYNC_TIMEOUT_MS=30000 (fabric init may be slow)")
+        device_params = {"fabric_config": ttnn.FabricConfig.FABRIC_2D}
+        logger.info("Opening 4x2 mesh device (via bh_2d_mesh_device_context)...")
+        t0 = time.perf_counter()
+        with bh_2d_mesh_device_context(device_params) as mesh_device:
+            logger.info("Mesh device opened in {:.3f}s", time.perf_counter() - t0)
+
+            submesh = mesh_device.create_submesh(ttnn.MeshShape(*DEVICE_MESH_SHAPE))
+            logger.info("Creating BlitzDecodeWeights on 4x2 submesh...")
+            bdw = BlitzDecodeWeights(submesh)
+
+            manifest_kw = dict(
+                hf_model_name=HF_MODEL_NAME,
+                hf_state_dict_name=HF_STATE_DICT_NAME,
+                device_mesh_shape=DEVICE_MESH_SHAPE,
+            )
+
+            if mode == "dense":
+                logger.info("Preparing dense decoder layer weights...")
+                t0 = time.perf_counter()
+                layer = prepare_dense_decoder_layer_weights(bdw, state_dict, layer_num)
+                logger.info("prepare_dense_decoder_layer_weights took {:.3f}s", time.perf_counter() - t0)
+                logger.info("Saving dense layer to disk...")
+                t0 = time.perf_counter()
+                save_layer(
+                    layer,
+                    output_path,
+                    layer_num,
+                    hf_model_name=manifest_kw["hf_model_name"],
+                    hf_state_dict_name=manifest_kw["hf_state_dict_name"],
+                    device_mesh_shape=manifest_kw["device_mesh_shape"],
+                )
+                logger.info("save_layer took {:.3f}s", time.perf_counter() - t0)
+            elif mode == "moe":
+                logger.info("Preparing attention weights (MoE)...")
+                t0 = time.perf_counter()
+                attn = prepare_attention_weights(bdw, state_dict, layer_num, is_moe=True)
+                logger.info("prepare_attention_weights took {:.3f}s", time.perf_counter() - t0)
+                logger.info("Saving attention weights...")
+                t0 = time.perf_counter()
+                save_attention_weights(
+                    attn,
+                    output_path,
+                    layer_num,
+                    is_moe=True,
+                    **manifest_kw,
+                )
+                logger.info("save_attention_weights took {:.3f}s", time.perf_counter() - t0)
+                logger.info("Preparing shared expert weights...")
+                t0 = time.perf_counter()
+                shared = prepare_shared_expert_weights(bdw, state_dict, layer_num, is_moe=True)
+                logger.info("prepare_shared_expert_weights took {:.3f}s", time.perf_counter() - t0)
+                logger.info("Saving shared expert weights...")
+                t0 = time.perf_counter()
+                save_shared_expert_weights(
+                    shared,
+                    output_path,
+                    layer_num,
+                    is_moe=True,
+                    **manifest_kw,
+                )
+                logger.info("save_shared_expert_weights took {:.3f}s", time.perf_counter() - t0)
+            else:
+                assert mode == "experts"
+                logger.info("Preparing routed expert weights (num_routed_experts={})...", NUM_ROUTED_EXPERTS)
+                t0 = time.perf_counter()
+                routed = prepare_routed_expert_weights(
+                    bdw,
+                    state_dict,
+                    layer_num,
+                    is_moe=True,
+                    num_routed_experts=NUM_ROUTED_EXPERTS,
+                )
+                logger.info("prepare_routed_expert_weights took {:.3f}s", time.perf_counter() - t0)
+                logger.info("Saving routed expert weights...")
+                t0 = time.perf_counter()
+                save_routed_expert_weights(
+                    routed,
+                    output_path,
+                    layer_num,
+                    is_moe=True,
+                    **manifest_kw,
+                )
+                logger.info("save_routed_expert_weights took {:.3f}s", time.perf_counter() - t0)
+
+    elapsed = time.perf_counter() - total_t0
+    logger.info("Cache generation complete for layer {} (mode={}) in {:.3f}s", layer_num, mode, elapsed)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_prepare_weights.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_prepare_weights.py
@@ -1,0 +1,892 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Tests for prepare_weights: building DeepSeekV3Weights from a state dict (4x2 mesh only).
+
+- test_prepare_dense_layer_single_layer_4x2 / test_prepare_moe_layer_single_layer_4x2: one layer on 4x2 mesh.
+- test_save_load_dense_layer_single_layer_4x2 / test_save_load_moe_layer_single_layer_4x2: save then load one layer on 4x2 submesh.
+- test_load_4_layers_across_4_submeshes_4x2: prepare each of 4 layers on a different 4x2 submesh, save, then load each on same submesh (32 devices).
+- test_prepare_attention_weights_*_4x2, test_prepare_shared_expert_weights_*_4x2, test_prepare_routed_expert_weights_*_4x2: per-group prepare on 4x2 mesh.
+- test_incremental_save_load_dense_4x2 / test_incremental_save_load_moe_4x2: incremental save then load on 4x2 mesh.
+- test_dump_load_routed_expert_weights_4x2: dump/load routed expert weights on 4x2 mesh.
+"""
+
+import time
+
+import pytest
+import torch
+from loguru import logger
+
+import ttnn
+from models.common.utility_functions import is_slow_dispatch
+from models.demos.deepseek_v3_b1.blitz_decode_weights import BlitzDecodeWeights, OverlappedTensor
+from models.demos.deepseek_v3_b1.prepare_weights import (
+    AttentionWeights,
+    DeepSeekV3DenseLayerWeights,
+    DeepSeekV3MoELayerWeights,
+    DenseRoutedExpertWeights,
+    MoERoutedExpertWeights,
+    SharedExpertWeights,
+    deallocate_weights,
+    load_layer,
+    prepare_attention_weights,
+    prepare_routed_expert_weights,
+    prepare_shared_expert_weights,
+    prepare_weights,
+    save_attention_weights,
+    save_layer,
+    save_routed_expert_weights,
+    save_shared_expert_weights,
+)
+
+
+def _core_range_set_to_tuples(crs):
+    """Normalize CoreRangeSet to comparable list of tuples for assertion."""
+    return sorted(((r.start.x, r.start.y), (r.end.x, r.end.y)) for r in crs.ranges())
+
+
+def _assert_overlapped_tensors_match(a: OverlappedTensor, b: OverlappedTensor) -> None:
+    """Assert two OverlappedTensors have matching metadata (not fused_tensor identity)."""
+    assert a.tensor_shape == b.tensor_shape
+    assert a.shard_shape == b.shard_shape
+    assert a.dtype == b.dtype
+    assert a.tile_shape == b.tile_shape
+    assert a.byte_offset == b.byte_offset
+    assert _core_range_set_to_tuples(a.core_range_set) == _core_range_set_to_tuples(b.core_range_set)
+
+
+def _assert_on_device(tensor: ttnn.Tensor) -> None:
+    """Assert the tensor storage type is DEVICE."""
+    assert tensor.storage_type() == ttnn.StorageType.DEVICE, f"Expected DEVICE storage, got {tensor.storage_type()}"
+
+
+def _assert_topology(tensor: ttnn.Tensor, expected_placements: list) -> None:
+    """Assert the tensor topology placements match expected."""
+    actual = list(tensor.tensor_topology().placements())
+    assert len(actual) == len(expected_placements), f"Expected {len(expected_placements)} placements, got {len(actual)}"
+    for a, e in zip(actual, expected_placements):
+        assert type(a) == type(e), f"Placement type mismatch: {a} vs {e}"
+        if isinstance(e, ttnn.PlacementShard):
+            assert a.dim == e.dim, f"Shard dim mismatch: {a.dim} vs {e.dim}"
+
+
+def _skip_unless_4x2_mesh(bh_2d_mesh_device):
+    """Skip test if mesh device does not have enough devices for a 4x2 submesh."""
+    if bh_2d_mesh_device.shape[0] * bh_2d_mesh_device.shape[1] < 8:
+        pytest.skip("Test requires 8 devices (4x2 mesh)")
+
+
+# Expected placements for 4x2 mesh (mla_tp=2, moe_tp=8)
+_PLACEMENTS_SHARD_NONE_1 = [ttnn.PlacementReplicate(), ttnn.PlacementShard(1)]
+_PLACEMENTS_SHARD_NONE_0 = [ttnn.PlacementReplicate(), ttnn.PlacementShard(0)]
+_PLACEMENTS_SHARD_0_1 = [ttnn.PlacementShard(0), ttnn.PlacementShard(1)]
+_PLACEMENTS_REPLICATE = [ttnn.PlacementReplicate()]
+
+
+def _assert_layer_on_device_with_topology(
+    layer: DeepSeekV3DenseLayerWeights | DeepSeekV3MoELayerWeights,
+) -> None:
+    """Assert all tensors in a loaded layer are on device and have correct topology for 4x2 mesh."""
+    seen_fused: set[int] = set()
+    # Check fusion groups via one representative OverlappedTensor per group
+    # q_ab_kv_a
+    _assert_on_device(layer.q_a_proj.fused_tensor)
+    fid = id(layer.q_a_proj.fused_tensor)
+    if fid not in seen_fused:
+        seen_fused.add(fid)
+        _assert_topology(layer.q_a_proj.fused_tensor, _PLACEMENTS_SHARD_NONE_1)
+    # o_proj_gate_mm_norms
+    _assert_on_device(layer.o_proj.fused_tensor)
+    fid = id(layer.o_proj.fused_tensor)
+    if fid not in seen_fused:
+        seen_fused.add(fid)
+        _assert_topology(layer.o_proj.fused_tensor, _PLACEMENTS_SHARD_NONE_1)
+    # kv_b12
+    _assert_on_device(layer.kv_b1_proj.fused_tensor)
+    fid = id(layer.kv_b1_proj.fused_tensor)
+    if fid not in seen_fused:
+        seen_fused.add(fid)
+        _assert_topology(layer.kv_b1_proj.fused_tensor, _PLACEMENTS_SHARD_NONE_0)
+    # gate_up
+    _assert_on_device(layer.shared_gate_proj.fused_tensor)
+    fid = id(layer.shared_gate_proj.fused_tensor)
+    if fid not in seen_fused:
+        seen_fused.add(fid)
+        _assert_topology(layer.shared_gate_proj.fused_tensor, _PLACEMENTS_SHARD_0_1)
+    # Standalone: shared_down_proj
+    _assert_on_device(layer.shared_down_proj)
+    _assert_topology(layer.shared_down_proj, _PLACEMENTS_SHARD_0_1)
+    # Routed experts
+    if isinstance(layer, DeepSeekV3DenseLayerWeights):
+        _assert_on_device(layer.routed_gate_proj)
+        _assert_on_device(layer.routed_up_proj)
+        _assert_on_device(layer.routed_down_proj)
+        _assert_topology(layer.routed_gate_proj, _PLACEMENTS_SHARD_0_1)
+        _assert_topology(layer.routed_up_proj, _PLACEMENTS_SHARD_0_1)
+        _assert_topology(layer.routed_down_proj, _PLACEMENTS_SHARD_0_1)
+    else:
+        assert isinstance(layer, DeepSeekV3MoELayerWeights)
+        for e in range(len(layer.routed_gate_proj)):
+            _assert_on_device(layer.routed_gate_proj[e])
+            _assert_on_device(layer.routed_up_proj[e])
+            _assert_on_device(layer.routed_down_proj[e])
+            _assert_topology(layer.routed_gate_proj[e], _PLACEMENTS_REPLICATE)
+            _assert_topology(layer.routed_up_proj[e], _PLACEMENTS_REPLICATE)
+            _assert_topology(layer.routed_down_proj[e], _PLACEMENTS_REPLICATE)
+
+
+# HF state dict shapes (out_features, in_features) for linears; full logical for 4x2 mesh. See DEEPSEEK_PREPARE_WEIGHTS_DESIGN_DOC.md §5.
+HF_Q_B_FULL_LOGICAL = (24576, 1536)
+HF_O_PROJ_FULL_LOGICAL = (7168, 16384)
+HF_KV_B_FULL_LOGICAL = (32768, 512)
+HF_SHARED_GATE_UP_FULL_LOGICAL = (2048, 7168)
+
+# Don't use all the experts in tests to avoid taking too long
+NUM_ROUTED_EXPERTS = 4
+
+
+def _layer_state_dict(
+    layer_idx: int,
+    *,
+    is_moe: bool,
+    seed: int = 42,
+) -> dict[str, torch.Tensor]:
+    """Build a minimal state_dict for one layer (HF key convention, random weights).
+
+    Uses full logical shapes for 4x2 mesh; prepare_weights passes them to blitz, which shards across the mesh.
+    """
+    g = torch.Generator().manual_seed(seed)
+    q_b_hf = HF_Q_B_FULL_LOGICAL
+    o_proj_hf = HF_O_PROJ_FULL_LOGICAL
+    kv_b_hf = HF_KV_B_FULL_LOGICAL
+    shared_hf = HF_SHARED_GATE_UP_FULL_LOGICAL
+
+    state = {
+        f"model.layers.{layer_idx}.self_attn.q_a_proj.weight": torch.randn(
+            1536, 7168, generator=g, dtype=torch.bfloat16
+        ),
+        f"model.layers.{layer_idx}.self_attn.q_b_proj.weight": torch.randn(*q_b_hf, generator=g, dtype=torch.bfloat16),
+        f"model.layers.{layer_idx}.self_attn.kv_a_proj_with_mqa.weight": torch.randn(
+            576, 7168, generator=g, dtype=torch.bfloat16
+        ),
+        f"model.layers.{layer_idx}.self_attn.kv_b_proj.weight": torch.randn(
+            *kv_b_hf, generator=g, dtype=torch.bfloat16
+        ),
+        f"model.layers.{layer_idx}.self_attn.o_proj.weight": torch.randn(*o_proj_hf, generator=g, dtype=torch.bfloat16),
+        f"model.layers.{layer_idx}.input_layernorm.weight": torch.randn(7168, generator=g, dtype=torch.bfloat16),
+        f"model.layers.{layer_idx}.self_attn.q_a_layernorm.weight": torch.randn(
+            1536, generator=g, dtype=torch.bfloat16
+        ),
+        f"model.layers.{layer_idx}.self_attn.kv_a_layernorm.weight": torch.randn(
+            512, generator=g, dtype=torch.bfloat16
+        ),
+        f"model.layers.{layer_idx}.post_attention_layernorm.weight": torch.randn(
+            7168, generator=g, dtype=torch.bfloat16
+        ),
+    }
+    if is_moe:
+        state[f"model.layers.{layer_idx}.mlp.gate.weight"] = torch.randn(256, 7168, generator=g, dtype=torch.bfloat16)
+        state[f"model.layers.{layer_idx}.mlp.shared_experts.gate_proj.weight"] = torch.randn(
+            *shared_hf, generator=g, dtype=torch.bfloat16
+        )
+        state[f"model.layers.{layer_idx}.mlp.shared_experts.up_proj.weight"] = torch.randn(
+            *shared_hf, generator=g, dtype=torch.bfloat16
+        )
+        # shared down: HF (7168, 2048*tp) full logical
+        shared_down_rows = 7168
+        shared_down_cols = shared_hf[0]  # 2048 for 4x2
+        state[f"model.layers.{layer_idx}.mlp.shared_experts.down_proj.weight"] = torch.randn(
+            shared_down_rows, shared_down_cols, generator=g, dtype=torch.bfloat16
+        )
+        for e in range(NUM_ROUTED_EXPERTS):
+            state[f"model.layers.{layer_idx}.mlp.experts.{e}.gate_proj.weight"] = torch.randn(
+                2048, 7168, generator=g, dtype=torch.bfloat16
+            )
+            state[f"model.layers.{layer_idx}.mlp.experts.{e}.up_proj.weight"] = torch.randn(
+                2048, 7168, generator=g, dtype=torch.bfloat16
+            )
+            state[f"model.layers.{layer_idx}.mlp.experts.{e}.down_proj.weight"] = torch.randn(
+                7168, 2048, generator=g, dtype=torch.bfloat16
+            )
+    else:
+        # Dense MLP: HF (out, in) gate/up (18432, 7168), down (7168, 18432)
+        state[f"model.layers.{layer_idx}.mlp.gate_proj.weight"] = torch.randn(
+            18432, 7168, generator=g, dtype=torch.bfloat16
+        )
+        state[f"model.layers.{layer_idx}.mlp.up_proj.weight"] = torch.randn(
+            18432, 7168, generator=g, dtype=torch.bfloat16
+        )
+        state[f"model.layers.{layer_idx}.mlp.down_proj.weight"] = torch.randn(
+            7168, 18432, generator=g, dtype=torch.bfloat16
+        )
+    return state
+
+
+@pytest.mark.parametrize(
+    "device_params",
+    [{"fabric_config": ttnn.FabricConfig.FABRIC_2D}],
+    indirect=True,
+)
+def test_prepare_attention_weights_dense_4x2(bh_2d_mesh_device):
+    """Prepare attention weights only for a dense layer on 4x2 mesh; verify shapes and fusion group sharing."""
+    _skip_unless_4x2_mesh(bh_2d_mesh_device)
+    submesh = bh_2d_mesh_device.create_submesh(ttnn.MeshShape((4, 2)))
+    state = _layer_state_dict(0, is_moe=False)
+    bdw = BlitzDecodeWeights(submesh)
+    attn = prepare_attention_weights(bdw, state, 0, is_moe=False)
+    assert attn.gate_mm is None
+    assert attn.q_a_proj.tensor_shape == (3584, 3072)
+    assert attn.q_b_proj.tensor_shape == (1536, 12288)
+    assert attn.kv_a_proj.tensor_shape == (7168, 576)
+    assert attn.o_proj.tensor_shape == (8192, 7168)
+    assert attn.attn_norm.tensor_shape == (1, 7168)
+    assert attn.kv_b1_proj.tensor_shape == (8192, 512)
+    assert attn.kv_b2_proj.tensor_shape == (512, 8192)
+
+
+@pytest.mark.parametrize(
+    "device_params",
+    [{"fabric_config": ttnn.FabricConfig.FABRIC_2D}],
+    indirect=True,
+)
+def test_prepare_attention_weights_moe_4x2(bh_2d_mesh_device):
+    """Prepare attention weights only for an MoE layer on 4x2 mesh; verify shapes and gate_mm present."""
+    _skip_unless_4x2_mesh(bh_2d_mesh_device)
+    submesh = bh_2d_mesh_device.create_submesh(ttnn.MeshShape((4, 2)))
+    state = _layer_state_dict(0, is_moe=True, seed=43)
+    bdw = BlitzDecodeWeights(submesh)
+    attn = prepare_attention_weights(bdw, state, 0, is_moe=True)
+    assert attn.gate_mm is not None
+    assert attn.gate_mm.tensor_shape == (7168, 256)
+    assert attn.q_a_proj.tensor_shape == (3584, 3072)
+    assert attn.o_proj.tensor_shape == (8192, 7168)
+
+
+@pytest.mark.parametrize(
+    "device_params",
+    [{"fabric_config": ttnn.FabricConfig.FABRIC_2D}],
+    indirect=True,
+)
+def test_prepare_shared_expert_weights_dense_4x2(bh_2d_mesh_device):
+    """Prepare shared expert weights only for a dense layer on 4x2 mesh; verify shapes."""
+    _skip_unless_4x2_mesh(bh_2d_mesh_device)
+    submesh = bh_2d_mesh_device.create_submesh(ttnn.MeshShape((4, 2)))
+    state = _layer_state_dict(0, is_moe=False)
+    bdw = BlitzDecodeWeights(submesh)
+    shared = prepare_shared_expert_weights(bdw, state, 0, is_moe=False)
+    assert shared.shared_gate_proj.tensor_shape is not None
+    assert shared.shared_up_proj.tensor_shape is not None
+    assert shared.shared_down_proj.shape is not None
+
+
+@pytest.mark.parametrize(
+    "device_params",
+    [{"fabric_config": ttnn.FabricConfig.FABRIC_2D}],
+    indirect=True,
+)
+def test_prepare_shared_expert_weights_moe_4x2(bh_2d_mesh_device):
+    """Prepare shared expert weights only for an MoE layer on 4x2 mesh; verify shapes."""
+    _skip_unless_4x2_mesh(bh_2d_mesh_device)
+    submesh = bh_2d_mesh_device.create_submesh(ttnn.MeshShape((4, 2)))
+    state = _layer_state_dict(0, is_moe=True, seed=43)
+    bdw = BlitzDecodeWeights(submesh)
+    shared = prepare_shared_expert_weights(bdw, state, 0, is_moe=True)
+    assert shared.shared_gate_proj.tensor_shape == (7168, 256)
+    assert shared.shared_up_proj.tensor_shape == (7168, 256)
+    assert shared.shared_down_proj.shape is not None
+
+
+@pytest.mark.parametrize(
+    "device_params",
+    [{"fabric_config": ttnn.FabricConfig.FABRIC_2D}],
+    indirect=True,
+)
+def test_prepare_routed_expert_weights_dense_4x2(bh_2d_mesh_device):
+    """Prepare routed expert weights only for a dense layer on 4x2 mesh; verify shapes."""
+    _skip_unless_4x2_mesh(bh_2d_mesh_device)
+    submesh = bh_2d_mesh_device.create_submesh(ttnn.MeshShape((4, 2)))
+    state = _layer_state_dict(0, is_moe=False)
+    bdw = BlitzDecodeWeights(submesh)
+    routed = prepare_routed_expert_weights(bdw, state, 0, is_moe=False)
+    assert isinstance(routed, DenseRoutedExpertWeights)
+    assert routed.routed_gate_proj.shape is not None
+    assert routed.routed_up_proj.shape is not None
+    assert routed.routed_down_proj.shape is not None
+
+
+@pytest.mark.parametrize(
+    "device_params",
+    [{"fabric_config": ttnn.FabricConfig.FABRIC_2D}],
+    indirect=True,
+)
+def test_prepare_routed_expert_weights_moe_4x2(bh_2d_mesh_device):
+    """Prepare routed expert weights only for an MoE layer on 4x2 mesh; verify shapes and expert count."""
+    _skip_unless_4x2_mesh(bh_2d_mesh_device)
+    submesh = bh_2d_mesh_device.create_submesh(ttnn.MeshShape((4, 2)))
+    state = _layer_state_dict(0, is_moe=True, seed=43)
+    bdw = BlitzDecodeWeights(submesh)
+    routed = prepare_routed_expert_weights(bdw, state, 0, is_moe=True, num_routed_experts=NUM_ROUTED_EXPERTS)
+    assert isinstance(routed, MoERoutedExpertWeights)
+    assert len(routed.routed_gate_proj) == NUM_ROUTED_EXPERTS
+    assert len(routed.routed_up_proj) == NUM_ROUTED_EXPERTS
+    assert len(routed.routed_down_proj) == NUM_ROUTED_EXPERTS
+
+
+@pytest.mark.parametrize(
+    "device_params",
+    [{"fabric_config": ttnn.FabricConfig.FABRIC_2D}],
+    indirect=True,
+)
+def test_incremental_save_load_dense_4x2(bh_2d_mesh_device, tmp_path):
+    """Save dense layer on 4x2 via separate save_attention_weights, save_shared_expert_weights, save_routed_expert_weights; load_layer and verify."""
+    _skip_unless_4x2_mesh(bh_2d_mesh_device)
+    if not is_slow_dispatch():
+        pytest.skip("load_layer requires slow dispatch")
+    submesh = bh_2d_mesh_device.create_submesh(ttnn.MeshShape((4, 2)))
+    state = _layer_state_dict(0, is_moe=False)
+    weights = prepare_weights(state, submesh, num_layers=1, first_k_dense_replace=1)
+    layer = weights.layers[0]
+    assert isinstance(layer, DeepSeekV3DenseLayerWeights)
+    attn = AttentionWeights(
+        q_a_proj=layer.q_a_proj,
+        q_b_proj=layer.q_b_proj,
+        kv_a_proj=layer.kv_a_proj,
+        o_proj=layer.o_proj,
+        gate_mm=None,
+        attn_norm=layer.attn_norm,
+        q_norm=layer.q_norm,
+        kv_norm=layer.kv_norm,
+        ffn_norm=layer.ffn_norm,
+        kv_b1_proj=layer.kv_b1_proj,
+        kv_b2_proj=layer.kv_b2_proj,
+    )
+    shared = SharedExpertWeights(
+        shared_gate_proj=layer.shared_gate_proj,
+        shared_up_proj=layer.shared_up_proj,
+        shared_down_proj=layer.shared_down_proj,
+    )
+    routed = DenseRoutedExpertWeights(
+        routed_gate_proj=layer.routed_gate_proj,
+        routed_up_proj=layer.routed_up_proj,
+        routed_down_proj=layer.routed_down_proj,
+    )
+    manifest_kw = dict(
+        hf_model_name="test-incremental-dense-4x2",
+        hf_state_dict_name="test-incremental-dense.safetensors",
+        device_mesh_shape=(4, 2),
+    )
+    save_attention_weights(attn, tmp_path, 0, is_moe=False, **manifest_kw)
+    save_shared_expert_weights(shared, tmp_path, 0, is_moe=False, **manifest_kw)
+    save_routed_expert_weights(routed, tmp_path, 0, is_moe=False, **manifest_kw)
+    expected_routed_shape = layer.routed_gate_proj.shape
+    deallocate_weights(weights)
+    loaded = load_layer(tmp_path, submesh, 0)
+    assert isinstance(loaded, DeepSeekV3DenseLayerWeights)
+    _assert_overlapped_tensors_match(layer.q_a_proj, loaded.q_a_proj)
+    _assert_overlapped_tensors_match(layer.shared_gate_proj, loaded.shared_gate_proj)
+    assert loaded.routed_gate_proj.shape == expected_routed_shape
+    _assert_layer_on_device_with_topology(loaded)
+
+
+@pytest.mark.parametrize(
+    "device_params",
+    [{"fabric_config": ttnn.FabricConfig.FABRIC_2D}],
+    indirect=True,
+)
+def test_incremental_save_load_moe_4x2(bh_2d_mesh_device, tmp_path):
+    """Save MoE layer on 4x2 via separate save_attention_weights, save_shared_expert_weights, save_routed_expert_weights; load_layer and verify."""
+    _skip_unless_4x2_mesh(bh_2d_mesh_device)
+    if not is_slow_dispatch():
+        pytest.skip("load_layer requires slow dispatch")
+    submesh = bh_2d_mesh_device.create_submesh(ttnn.MeshShape((4, 2)))
+    state = _layer_state_dict(0, is_moe=True, seed=43)
+    weights = prepare_weights(
+        state,
+        submesh,
+        num_layers=1,
+        first_k_dense_replace=0,
+        num_routed_experts=NUM_ROUTED_EXPERTS,
+    )
+    layer = weights.layers[0]
+    assert isinstance(layer, DeepSeekV3MoELayerWeights)
+    attn = AttentionWeights(
+        q_a_proj=layer.q_a_proj,
+        q_b_proj=layer.q_b_proj,
+        kv_a_proj=layer.kv_a_proj,
+        o_proj=layer.o_proj,
+        gate_mm=layer.gate_mm,
+        attn_norm=layer.attn_norm,
+        q_norm=layer.q_norm,
+        kv_norm=layer.kv_norm,
+        ffn_norm=layer.ffn_norm,
+        kv_b1_proj=layer.kv_b1_proj,
+        kv_b2_proj=layer.kv_b2_proj,
+    )
+    shared = SharedExpertWeights(
+        shared_gate_proj=layer.shared_gate_proj,
+        shared_up_proj=layer.shared_up_proj,
+        shared_down_proj=layer.shared_down_proj,
+    )
+    routed = MoERoutedExpertWeights(
+        routed_gate_proj=layer.routed_gate_proj,
+        routed_up_proj=layer.routed_up_proj,
+        routed_down_proj=layer.routed_down_proj,
+    )
+    manifest_kw = dict(
+        hf_model_name="test-incremental-moe-4x2",
+        hf_state_dict_name="test-incremental-moe.safetensors",
+        device_mesh_shape=(4, 2),
+    )
+    save_attention_weights(attn, tmp_path, 0, is_moe=True, **manifest_kw)
+    save_shared_expert_weights(shared, tmp_path, 0, is_moe=True, **manifest_kw)
+    save_routed_expert_weights(routed, tmp_path, 0, is_moe=True, **manifest_kw)
+    expected_routed_expert_shape = layer.routed_gate_proj[0].shape
+    deallocate_weights(weights)
+    loaded = load_layer(tmp_path, submesh, 0)
+    assert isinstance(loaded, DeepSeekV3MoELayerWeights)
+    _assert_overlapped_tensors_match(layer.gate_mm, loaded.gate_mm)
+    _assert_overlapped_tensors_match(layer.shared_gate_proj, loaded.shared_gate_proj)
+    assert len(loaded.routed_gate_proj) == NUM_ROUTED_EXPERTS
+    assert loaded.routed_gate_proj[0].shape == expected_routed_expert_shape
+    _assert_layer_on_device_with_topology(loaded)
+
+
+def _moe_routed_expert_stacked_tensors(seed: int = 43):
+    """Build (num_experts, K, N) stacked gate/up and (num_experts, K_down, N_down) down for get_tt_moe_routed_expert_weights."""
+    g = torch.Generator().manual_seed(seed)
+    # MoE expert shapes: gate/up (K=7168, N=2048), down (2048, 7168)
+    gate_stacked = torch.randn(NUM_ROUTED_EXPERTS, 7168, 2048, generator=g, dtype=torch.bfloat16)
+    up_stacked = torch.randn(NUM_ROUTED_EXPERTS, 7168, 2048, generator=g, dtype=torch.bfloat16)
+    down_stacked = torch.randn(NUM_ROUTED_EXPERTS, 2048, 7168, generator=g, dtype=torch.bfloat16)
+    return gate_stacked, up_stacked, down_stacked
+
+
+@pytest.mark.parametrize(
+    "device_params",
+    [{"fabric_config": ttnn.FabricConfig.FABRIC_2D}],
+    indirect=True,
+)
+def test_dump_load_routed_expert_weights_4x2(bh_2d_mesh_device, tmp_path):
+    """Test dump/load round-trip for MoE routed expert weights on 4x2 mesh. Uses BlitzDecodeWeights directly so it can run in slow dispatch."""
+    _skip_unless_4x2_mesh(bh_2d_mesh_device)
+    submesh = bh_2d_mesh_device.create_submesh(ttnn.MeshShape((4, 2)))
+
+    gate_stacked, up_stacked, down_stacked = _moe_routed_expert_stacked_tensors(seed=43)
+    bdw = BlitzDecodeWeights(submesh)
+    routed_gate_proj, routed_up_proj, routed_down_proj = bdw.get_tt_moe_routed_expert_weights(
+        gate_stacked, up_stacked, down_stacked
+    )
+
+    # Capture shapes before dump
+    expected_gate_shapes = [routed_gate_proj[e].shape for e in range(NUM_ROUTED_EXPERTS)]
+    expected_up_shapes = [routed_up_proj[e].shape for e in range(NUM_ROUTED_EXPERTS)]
+    expected_down_shapes = [routed_down_proj[e].shape for e in range(NUM_ROUTED_EXPERTS)]
+
+    # Dump only routed experts (same layout as save_layer for MoE)
+    layer_dir = tmp_path / "layer_000"
+    experts_dir = layer_dir / "experts"
+    experts_dir.mkdir(parents=True, exist_ok=True)
+    for e in range(NUM_ROUTED_EXPERTS):
+        expert_dir = experts_dir / f"e_{e:03d}"
+        expert_dir.mkdir(parents=True, exist_ok=True)
+        ttnn.dump_tensor(expert_dir / "gate_proj.tensorbin", routed_gate_proj[e])
+        ttnn.dump_tensor(expert_dir / "up_proj.tensorbin", routed_up_proj[e])
+        ttnn.dump_tensor(expert_dir / "down_proj.tensorbin", routed_down_proj[e])
+
+    # Allow original tensors to be freed; load back onto the same submesh
+    del routed_gate_proj, routed_up_proj, routed_down_proj
+    routed_gate_proj = []
+    routed_up_proj = []
+    routed_down_proj = []
+    logger.info("Loading routed experts back onto the same submesh...")
+    t0 = time.perf_counter()
+    for e in range(NUM_ROUTED_EXPERTS):
+        expert_dir = experts_dir / f"e_{e:03d}"
+        routed_gate_proj.append(ttnn.load_tensor(expert_dir / "gate_proj.tensorbin", device=submesh))
+        routed_up_proj.append(ttnn.load_tensor(expert_dir / "up_proj.tensorbin", device=submesh))
+        routed_down_proj.append(ttnn.load_tensor(expert_dir / "down_proj.tensorbin", device=submesh))
+    elapsed = time.perf_counter() - t0
+    logger.info("Loaded routed experts back onto the same submesh in {:.3f}s", elapsed)
+
+    assert len(routed_gate_proj) == NUM_ROUTED_EXPERTS
+    assert len(routed_up_proj) == NUM_ROUTED_EXPERTS
+    assert len(routed_down_proj) == NUM_ROUTED_EXPERTS
+    for e in range(NUM_ROUTED_EXPERTS):
+        assert routed_gate_proj[e].shape == expected_gate_shapes[e]
+        assert routed_up_proj[e].shape == expected_up_shapes[e]
+        assert routed_down_proj[e].shape == expected_down_shapes[e]
+        _assert_on_device(routed_gate_proj[e])
+        _assert_on_device(routed_up_proj[e])
+        _assert_on_device(routed_down_proj[e])
+        _assert_topology(routed_gate_proj[e], _PLACEMENTS_REPLICATE)
+        _assert_topology(routed_up_proj[e], _PLACEMENTS_REPLICATE)
+        _assert_topology(routed_down_proj[e], _PLACEMENTS_REPLICATE)
+
+
+@pytest.mark.parametrize(
+    "device_params",
+    [{"fabric_config": ttnn.FabricConfig.FABRIC_2D}],
+    indirect=True,
+)
+def test_prepare_dense_layer_single_layer_4x2(bh_2d_mesh_device):
+    """Build one dense layer on 4x2 mesh; verify type and shapes (MLA TP=2)."""
+    _skip_unless_4x2_mesh(bh_2d_mesh_device)
+    submesh = bh_2d_mesh_device.create_submesh(ttnn.MeshShape((4, 2)))
+    state = _layer_state_dict(0, is_moe=False)
+    t0 = time.perf_counter()
+    weights = prepare_weights(
+        state,
+        submesh,
+        num_layers=1,
+        first_k_dense_replace=1,
+    )
+    elapsed = time.perf_counter() - t0
+    logger.info("prepare_weights (1 dense layer, 4x2 mesh): {:.3f} s", elapsed)
+    assert len(weights.layers) == 1
+    layer = weights.layers[0]
+    assert isinstance(layer, DeepSeekV3DenseLayerWeights)
+    assert layer.q_a_proj.tensor_shape == (3584, 3072)
+    assert layer.q_b_proj.tensor_shape == (1536, 12288)
+    assert layer.kv_a_proj.tensor_shape == (7168, 576)
+    assert layer.o_proj.tensor_shape == (8192, 7168)
+    assert layer.attn_norm.tensor_shape == (1, 7168)
+    assert layer.q_norm.tensor_shape == (1, 1536)
+    assert layer.kv_norm.tensor_shape == (1, 512)
+    assert layer.ffn_norm.tensor_shape == (1, 7168)
+    assert layer.kv_b1_proj.tensor_shape == (8192, 512)
+    assert layer.kv_b2_proj.tensor_shape == (512, 8192)
+    assert hasattr(layer, "shared_gate_proj") and layer.shared_gate_proj is not None
+    assert hasattr(layer, "shared_up_proj") and layer.shared_up_proj is not None
+    assert hasattr(layer, "routed_gate_proj") and layer.routed_gate_proj is not None
+    assert hasattr(layer, "routed_up_proj") and layer.routed_up_proj is not None
+    assert hasattr(layer, "routed_down_proj") and layer.routed_down_proj is not None
+
+
+@pytest.mark.parametrize(
+    "device_params",
+    [{"fabric_config": ttnn.FabricConfig.FABRIC_2D}],
+    indirect=True,
+)
+def test_save_load_dense_layer_single_layer_4x2(bh_2d_mesh_device, tmp_path):
+    """Save one dense layer (4x2 submesh) to disk, load it back, assert metadata and fused-tensor sharing."""
+    _skip_unless_4x2_mesh(bh_2d_mesh_device)
+    if not is_slow_dispatch():
+        pytest.skip("load_layer requires slow dispatch")
+    submesh = bh_2d_mesh_device.create_submesh(ttnn.MeshShape((4, 2)))
+
+    state = _layer_state_dict(0, is_moe=False)
+    t0 = time.perf_counter()
+    weights = prepare_weights(state, submesh, num_layers=1, first_k_dense_replace=1)
+    elapsed = time.perf_counter() - t0
+    logger.info("prepare_weights (1 dense layer, 4x2 mesh): {:.3f} s", elapsed)
+    assert len(weights.layers) == 1
+    orig = weights.layers[0]
+    assert isinstance(orig, DeepSeekV3DenseLayerWeights)
+    assert orig.q_a_proj.tensor_shape == (3584, 3072)
+    assert orig.q_b_proj.tensor_shape == (1536, 12288)
+    assert orig.kv_a_proj.tensor_shape == (7168, 576)
+    assert orig.o_proj.tensor_shape == (8192, 7168)
+    assert orig.attn_norm.tensor_shape == (1, 7168)
+    assert orig.q_norm.tensor_shape == (1, 1536)
+    assert orig.kv_norm.tensor_shape == (1, 512)
+    assert orig.ffn_norm.tensor_shape == (1, 7168)
+    assert orig.kv_b1_proj.tensor_shape == (8192, 512)
+    assert orig.kv_b2_proj.tensor_shape == (512, 8192)
+    assert hasattr(orig, "shared_gate_proj") and orig.shared_gate_proj is not None
+    assert hasattr(orig, "shared_up_proj") and orig.shared_up_proj is not None
+    assert hasattr(orig, "routed_gate_proj") and orig.routed_gate_proj is not None
+    assert hasattr(orig, "routed_up_proj") and orig.routed_up_proj is not None
+    assert hasattr(orig, "routed_down_proj") and orig.routed_down_proj is not None
+    # Early access to q_ab_kv_a fused_tensor (same as first tensor touched in save_layer)
+    logger.info("Early access: touching q_ab_kv_a fused_tensor (orig.q_a_proj.fused_tensor)...")
+    q_ab_kv_a_fused = orig.q_a_proj.fused_tensor
+    _ = q_ab_kv_a_fused.shape
+    logger.info("Early access: got shape {}", q_ab_kv_a_fused.shape)
+    save_layer(
+        orig,
+        tmp_path,
+        0,
+        hf_model_name="test-dense-model-4x2",
+        hf_state_dict_name="test-dense-state-dict.safetensors",
+        device_mesh_shape=(4, 2),
+    )
+
+    assert (tmp_path / "layer_000" / "manifest.json").exists()
+    layer_dir = tmp_path / "layer_000"
+    assert (layer_dir / "q_ab_kv_a.tensorbin").exists()
+    assert (layer_dir / "o_proj_gate_mm_norms.tensorbin").exists()
+    assert (layer_dir / "kv_b12.tensorbin").exists()
+    assert (layer_dir / "gate_up.tensorbin").exists()
+    assert (layer_dir / "routed_gate_proj.tensorbin").exists()
+    assert (layer_dir / "routed_up_proj.tensorbin").exists()
+    assert (layer_dir / "routed_down_proj.tensorbin").exists()
+
+    deallocate_weights(weights)
+    t0 = time.perf_counter()
+    layer = load_layer(tmp_path, submesh, 0)
+    elapsed = time.perf_counter() - t0
+    logger.info("load_layer (dense, 4x2 submesh): {:.3f} s", elapsed)
+    assert isinstance(layer, DeepSeekV3DenseLayerWeights)
+
+    _assert_overlapped_tensors_match(orig.q_a_proj, layer.q_a_proj)
+    _assert_overlapped_tensors_match(orig.q_b_proj, layer.q_b_proj)
+    _assert_overlapped_tensors_match(orig.kv_a_proj, layer.kv_a_proj)
+    _assert_overlapped_tensors_match(orig.o_proj, layer.o_proj)
+    _assert_overlapped_tensors_match(orig.attn_norm, layer.attn_norm)
+    _assert_overlapped_tensors_match(orig.q_norm, layer.q_norm)
+    _assert_overlapped_tensors_match(orig.kv_norm, layer.kv_norm)
+    _assert_overlapped_tensors_match(orig.ffn_norm, layer.ffn_norm)
+    _assert_overlapped_tensors_match(orig.kv_b1_proj, layer.kv_b1_proj)
+    _assert_overlapped_tensors_match(orig.kv_b2_proj, layer.kv_b2_proj)
+    _assert_overlapped_tensors_match(orig.shared_gate_proj, layer.shared_gate_proj)
+    _assert_overlapped_tensors_match(orig.shared_up_proj, layer.shared_up_proj)
+    assert layer.routed_gate_proj.shape == orig.routed_gate_proj.shape
+    assert layer.routed_up_proj.shape == orig.routed_up_proj.shape
+    assert layer.routed_down_proj.shape == orig.routed_down_proj.shape
+
+    assert id(layer.q_a_proj.fused_tensor) == id(layer.q_b_proj.fused_tensor)
+    assert id(layer.q_b_proj.fused_tensor) == id(layer.kv_a_proj.fused_tensor)
+    assert id(layer.o_proj.fused_tensor) == id(layer.attn_norm.fused_tensor)
+    assert id(layer.kv_b1_proj.fused_tensor) == id(layer.kv_b2_proj.fused_tensor)
+    assert id(layer.shared_gate_proj.fused_tensor) == id(layer.shared_up_proj.fused_tensor)
+    _assert_layer_on_device_with_topology(layer)
+
+
+@pytest.mark.parametrize(
+    "device_params",
+    [{"fabric_config": ttnn.FabricConfig.FABRIC_2D}],
+    indirect=True,
+)
+def test_prepare_moe_layer_single_layer_4x2(bh_2d_mesh_device):
+    """Build one MoE layer on 4x2 mesh; verify type and shapes (MLA TP=2, MoE TP=8)."""
+    _skip_unless_4x2_mesh(bh_2d_mesh_device)
+    submesh = bh_2d_mesh_device.create_submesh(ttnn.MeshShape((4, 2)))
+    state = _layer_state_dict(0, is_moe=True, seed=43)
+    logger.info(f"State dict prepared")
+    t0 = time.perf_counter()
+    logger.info(f"Preparing weights...")
+    weights = prepare_weights(
+        state,
+        submesh,
+        num_layers=1,
+        first_k_dense_replace=0,
+        num_routed_experts=NUM_ROUTED_EXPERTS,
+    )
+    logger.info(f"Weights prepared")
+    elapsed = time.perf_counter() - t0
+    logger.info("prepare_weights (1 MoE layer, 4x2 mesh): {:.3f} s", elapsed)
+    assert len(weights.layers) == 1
+    layer = weights.layers[0]
+    assert isinstance(layer, DeepSeekV3MoELayerWeights)
+    assert layer.q_a_proj.tensor_shape == (3584, 3072)
+    assert layer.q_b_proj.tensor_shape == (1536, 12288)
+    assert layer.kv_a_proj.tensor_shape == (7168, 576)
+    assert layer.o_proj.tensor_shape == (8192, 7168)
+    assert layer.gate_mm.tensor_shape == (7168, 256)
+    assert layer.attn_norm.tensor_shape == (1, 7168)
+    assert layer.q_norm.tensor_shape == (1, 1536)
+    assert layer.kv_norm.tensor_shape == (1, 512)
+    assert layer.ffn_norm.tensor_shape == (1, 7168)
+    assert layer.kv_b1_proj.tensor_shape == (8192, 512)
+    assert layer.kv_b2_proj.tensor_shape == (512, 8192)
+    assert layer.shared_gate_proj.tensor_shape == (7168, 256)
+    assert layer.shared_up_proj.tensor_shape == (7168, 256)
+    assert hasattr(layer, "shared_down_proj")
+    assert len(layer.routed_gate_proj) == NUM_ROUTED_EXPERTS
+    assert len(layer.routed_up_proj) == NUM_ROUTED_EXPERTS
+    assert len(layer.routed_down_proj) == NUM_ROUTED_EXPERTS
+
+
+@pytest.mark.parametrize(
+    "device_params",
+    [{"fabric_config": ttnn.FabricConfig.FABRIC_2D}],
+    indirect=True,
+)
+def test_save_load_moe_layer_single_layer_4x2(bh_2d_mesh_device, tmp_path):
+    """Save one MoE layer (4x2 submesh) to disk, load it back, assert metadata and fused-tensor sharing."""
+    _skip_unless_4x2_mesh(bh_2d_mesh_device)
+    if not is_slow_dispatch():
+        pytest.skip("load_layer requires slow dispatch")
+    submesh = bh_2d_mesh_device.create_submesh(ttnn.MeshShape((4, 2)))
+
+    state = _layer_state_dict(0, is_moe=True, seed=43)
+    t0 = time.perf_counter()
+    weights = prepare_weights(
+        state,
+        submesh,
+        num_layers=1,
+        first_k_dense_replace=0,
+        num_routed_experts=NUM_ROUTED_EXPERTS,
+    )
+    elapsed = time.perf_counter() - t0
+    logger.info("prepare_weights (1 MoE layer, 4x2 mesh): {:.3f} s", elapsed)
+    assert len(weights.layers) == 1
+    orig = weights.layers[0]
+    assert isinstance(orig, DeepSeekV3MoELayerWeights)
+    assert orig.q_a_proj.tensor_shape == (3584, 3072)
+    assert orig.q_b_proj.tensor_shape == (1536, 12288)
+    assert orig.kv_a_proj.tensor_shape == (7168, 576)
+    assert orig.o_proj.tensor_shape == (8192, 7168)
+    assert orig.gate_mm.tensor_shape == (7168, 256)
+    assert orig.attn_norm.tensor_shape == (1, 7168)
+    assert orig.q_norm.tensor_shape == (1, 1536)
+    assert orig.kv_norm.tensor_shape == (1, 512)
+    assert orig.ffn_norm.tensor_shape == (1, 7168)
+    assert orig.kv_b1_proj.tensor_shape == (8192, 512)
+    assert orig.kv_b2_proj.tensor_shape == (512, 8192)
+    assert orig.shared_gate_proj.tensor_shape == (7168, 256)
+    assert orig.shared_up_proj.tensor_shape == (7168, 256)
+    assert hasattr(orig, "shared_down_proj")
+    assert len(orig.routed_gate_proj) == NUM_ROUTED_EXPERTS
+    assert len(orig.routed_up_proj) == NUM_ROUTED_EXPERTS
+    assert len(orig.routed_down_proj) == NUM_ROUTED_EXPERTS
+    # Early access to q_ab_kv_a fused_tensor (same as first tensor touched in save_layer)
+    logger.info("Early access: touching q_ab_kv_a fused_tensor (orig.q_a_proj.fused_tensor)...")
+    q_ab_kv_a_fused = orig.q_a_proj.fused_tensor
+    _ = q_ab_kv_a_fused.shape
+    logger.info("Early access: got shape {}", q_ab_kv_a_fused.shape)
+    save_layer(
+        orig,
+        tmp_path,
+        0,
+        hf_model_name="test-moe-model-4x2",
+        hf_state_dict_name="test-moe-state-dict.safetensors",
+        device_mesh_shape=(4, 2),
+    )
+
+    assert (tmp_path / "layer_000" / "manifest.json").exists()
+    layer_dir = tmp_path / "layer_000"
+    assert (layer_dir / "gate_up.tensorbin").exists()
+    assert (layer_dir / "shared_down_proj.tensorbin").exists()
+    experts_dir = layer_dir / "experts"
+    for e in range(NUM_ROUTED_EXPERTS):
+        expert_dir = experts_dir / f"e_{e:03d}"
+        assert (expert_dir / "gate_proj.tensorbin").exists()
+        assert (expert_dir / "up_proj.tensorbin").exists()
+        assert (expert_dir / "down_proj.tensorbin").exists()
+
+    deallocate_weights(weights)
+    t0 = time.perf_counter()
+    layer = load_layer(tmp_path, submesh, 0)
+    elapsed = time.perf_counter() - t0
+    logger.info("load_layer (moe, 4x2 submesh): {:.3f} s", elapsed)
+    assert isinstance(layer, DeepSeekV3MoELayerWeights)
+
+    _assert_overlapped_tensors_match(orig.q_a_proj, layer.q_a_proj)
+    _assert_overlapped_tensors_match(orig.q_b_proj, layer.q_b_proj)
+    _assert_overlapped_tensors_match(orig.kv_a_proj, layer.kv_a_proj)
+    _assert_overlapped_tensors_match(orig.o_proj, layer.o_proj)
+    _assert_overlapped_tensors_match(orig.gate_mm, layer.gate_mm)
+    _assert_overlapped_tensors_match(orig.attn_norm, layer.attn_norm)
+    _assert_overlapped_tensors_match(orig.q_norm, layer.q_norm)
+    _assert_overlapped_tensors_match(orig.kv_norm, layer.kv_norm)
+    _assert_overlapped_tensors_match(orig.ffn_norm, layer.ffn_norm)
+    _assert_overlapped_tensors_match(orig.kv_b1_proj, layer.kv_b1_proj)
+    _assert_overlapped_tensors_match(orig.kv_b2_proj, layer.kv_b2_proj)
+    _assert_overlapped_tensors_match(orig.shared_gate_proj, layer.shared_gate_proj)
+    _assert_overlapped_tensors_match(orig.shared_up_proj, layer.shared_up_proj)
+    assert layer.shared_down_proj.shape == orig.shared_down_proj.shape
+    assert len(layer.routed_gate_proj) == NUM_ROUTED_EXPERTS
+    assert len(layer.routed_up_proj) == NUM_ROUTED_EXPERTS
+    assert len(layer.routed_down_proj) == NUM_ROUTED_EXPERTS
+    for e in range(NUM_ROUTED_EXPERTS):
+        assert layer.routed_gate_proj[e].shape == orig.routed_gate_proj[e].shape
+        assert layer.routed_up_proj[e].shape == orig.routed_up_proj[e].shape
+        assert layer.routed_down_proj[e].shape == orig.routed_down_proj[e].shape
+
+    assert id(layer.shared_gate_proj.fused_tensor) == id(layer.shared_up_proj.fused_tensor)
+    _assert_layer_on_device_with_topology(layer)
+
+
+@pytest.mark.skip(reason="Too slow for CI; use for manual multi-submesh validation")
+@pytest.mark.parametrize(
+    "device_params",
+    [{"fabric_config": ttnn.FabricConfig.FABRIC_2D}],
+    indirect=True,
+)
+def test_load_4_layers_across_4_submeshes_4x2(bh_2d_mesh_device, tmp_path):
+    """Prepare each of 4 layers on a different 4x2 submesh, save them, then load each on the same submesh.
+
+    Uses create_submeshes to get 4 disjoint (4x2) submeshes; requires 32 devices.
+    Each layer is prepared on its own submesh to avoid OOM. Layers 0,1,2 are dense, layer 3 is MoE.
+    """
+    if not is_slow_dispatch():
+        pytest.skip("load_layer requires slow dispatch")
+    num_submeshes = 4
+    devices_per_submesh = 4 * 2
+    num_devices_required = num_submeshes * devices_per_submesh  # 32
+    if bh_2d_mesh_device.shape[0] * bh_2d_mesh_device.shape[1] < num_devices_required:
+        pytest.skip(
+            f"Test requires {num_devices_required} devices (4 submeshes x 4x2), "
+            f"mesh has {bh_2d_mesh_device.shape[0] * bh_2d_mesh_device.shape[1]}"
+        )
+    submeshes = bh_2d_mesh_device.create_submeshes(ttnn.MeshShape((4, 2)))
+    assert len(submeshes) >= num_submeshes, f"Expected at least {num_submeshes} submeshes"
+    submesh0 = submeshes[0]
+
+    num_layers = 4
+    first_k_dense_replace = 3  # layers 0,1,2 dense; layer 3 MoE
+    for layer_idx in range(num_layers):
+        is_moe = layer_idx >= first_k_dense_replace
+        submesh = submeshes[layer_idx]
+        state = _layer_state_dict(
+            layer_idx,
+            is_moe=is_moe,
+            seed=42 + layer_idx,
+        )
+        # prepare_weights always looks up model.layers.0.* when num_layers=1; remap keys
+        state_for_prepare = {k.replace(f"model.layers.{layer_idx}.", "model.layers.0."): v for k, v in state.items()}
+        # first_k_dense_replace so the single layer (index 0) is dense or MoE
+        first_k = 1 if layer_idx < first_k_dense_replace else 0
+        t0 = time.perf_counter()
+        weights = prepare_weights(
+            state_for_prepare,
+            submesh,
+            num_layers=1,
+            first_k_dense_replace=first_k,
+            num_routed_experts=NUM_ROUTED_EXPERTS,
+        )
+        elapsed = time.perf_counter() - t0
+        logger.info(
+            "prepare_weights (layer %d, %s, on submesh %d): {:.3f} s",
+            layer_idx,
+            "moe" if is_moe else "dense",
+            layer_idx,
+            elapsed,
+        )
+        assert len(weights.layers) == 1
+        save_layer(
+            weights.layers[0],
+            tmp_path,
+            layer_idx,
+            hf_model_name="test-4layer-model",
+            hf_state_dict_name="test-4layer-state-dict.safetensors",
+            device_mesh_shape=(4, 2),
+        )
+        deallocate_weights(weights)
+
+    loaded = []
+    t0 = time.time()
+    for layer_idx in range(num_layers):
+        submesh = submeshes[layer_idx]
+        layer = load_layer(tmp_path, submesh, layer_idx)
+        loaded.append(layer)
+    elapsed = time.time() - t0
+    logger.info(f"load_layer (4 layers, 4x2 submesh): {elapsed:.3f} s")
+
+    assert isinstance(loaded[0], DeepSeekV3DenseLayerWeights)
+    assert isinstance(loaded[1], DeepSeekV3DenseLayerWeights)
+    assert isinstance(loaded[2], DeepSeekV3DenseLayerWeights)
+    assert isinstance(loaded[3], DeepSeekV3MoELayerWeights)
+    for i in range(3):
+        assert hasattr(loaded[i], "shared_gate_proj") and loaded[i].shared_gate_proj is not None
+        assert hasattr(loaded[i], "routed_gate_proj") and loaded[i].routed_gate_proj is not None
+        assert loaded[i].routed_gate_proj.shape is not None
+    assert len(loaded[3].routed_gate_proj) == NUM_ROUTED_EXPERTS
+    assert len(loaded[3].routed_up_proj) == NUM_ROUTED_EXPERTS
+    assert len(loaded[3].routed_down_proj) == NUM_ROUTED_EXPERTS
+    assert loaded[3].shared_down_proj is not None
+    for i in range(num_layers):
+        _assert_layer_on_device_with_topology(loaded[i])


### PR DESCRIPTION
### Ticket
- https://github.com/tenstorrent/tt-metal/issues/38229

### What's Changed
This PR implements the weight preprocessing, serialization, deserialization, and caching pipeline for the DeepSeekV3 B1 model. 

We use the `BlitzDecodeWeights` utility to covert synthetic and/or HF tensors into TTNN tensors that can be used by the B1 fused decoder layers.

This PR includes a caching API in `prepare_weights.py` with corresponding tests in `test_prepare_weights.py`. 

The `generate_cache.py` script can be used to generate a layer of the cache with the following command:

```
python models/demos/deepseek_v3_b1/scripts/generate_cache.py --model-path /mnt/models/deepseek-ai/DeepSeek-R1-0528-dequantized --output-path /tmp/output/ --layer-num 3 --type moe
```

Currently, cache generation can be done using FD (since we never actually send tensors to device), but cache loading requires SD, unless youn are loading the routed experts. 

### Checklist

- [x] [APC](https://github.com/tenstorrent/tt-metal/actions/runs/22312177678)
- [x] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=esmal/weights)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:esmal/weights)
