### PR TITLE
Lpremovic/odd width custom mm

### DIFF
--- a/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_math_custom_mm_api.h
+++ b/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_math_custom_mm_api.h
@@ -13,7 +13,7 @@
  * in0 tile shape: [{1, 2, 4, 8}, 32]
  * in1 tile shape: [32, 32]
  * rt_dim: 1
- * ct_dim: {1, 2, 4, 6, 8, 10, 12, 14, 16}
+ * ct_dim: {1, 2, 3, 4, 5, 6, 8, 10, 12, 14, 16}
  * kt_dim: even number from 2 to 256 (inclusive)
  * fidelity: LoFi only
  * throttle: not supported

--- a/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_AB_custom_mm_api.h
+++ b/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_AB_custom_mm_api.h
@@ -13,7 +13,7 @@
  * in0 tile shape: [{1, 2, 4, 8}, 32]
  * in1 tile shape: [32, 32]
  * rt_dim: 1
- * ct_dim: {1, 2, 4, 6, 8, 10, 12, 14, 16}
+ * ct_dim: {1, 2, 3, 4, 5, 6, 8, 10, 12, 14, 16}
  * kt_dim: even number from 2 to 256 (inclusive)
  * fidelity: LoFi only
  * throttle: not supported

--- a/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/include/compute_kernel_api/custom_mm.h
+++ b/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/include/compute_kernel_api/custom_mm.h
@@ -22,22 +22,22 @@ namespace ckernel {
  * in0 tile shape: [{1, 2, 4, 8}, 32]
  * in1 tile shape: [32, 32]
  * rt_dim: 1
- * ct_dim: {1, 2, 4, 6, 8, 10, 12, 14, 16}
+ * ct_dim: {1, 2, 3, 4, 5, 6, 8, 10, 12, 14, 16}
  * kt_dim: even number from 2 to 256 (inclusive)
  * fidelity: LoFi only
  * throttle: not supported
  *
  * Return value: None
  *
- * | Argument       | Description                                                                            | Type     | Valid Range                     | Required              |
- * |----------------|----------------------------------------------------------------------------------------|----------|---------------------------------|-----------------------|
- * | transpose      | The transpose flag for performing transpose operation on in1                           | bool     | true/false                      | False (default false) |
- * | split_acc      | Whether to accumulate partials within a single tile in different dest locations        | bool     | true/false                      | False (default false) |
- * | dense_packing  | Whether to pack consecutive tiles 32 rows apart (instead of 64, doubles dest capacity) | bool     | true/false                      | False (default false) |
- * | in0_cb_id      | The identifier of the first input circular buffer (CB)                                 | uint32_t | 0 to 31                         | True                  |
- * | in1_cb_id      | The identifier of the second input circular buffer (CB)                                | uint32_t | 0 to 31                         | True                  |
- * | out_cb_id      | The identifier of the output circular buffer (CB)                                      | uint32_t | 0 to 31                         | True                  |
- * | ct_dim         | The width of the output matrix in tiles                                                | uint32_t | {1, 2, 4, 6, 8, 10, 12, 14, 16} | False (default 1)     |
+ * | Argument       | Description                                                                            | Type     | Valid Range                           | Required              |
+ * |----------------|----------------------------------------------------------------------------------------|----------|---------------------------------------|-----------------------|
+ * | transpose      | The transpose flag for performing transpose operation on in1                           | bool     | true/false                            | False (default false) |
+ * | split_acc      | Whether to accumulate partials within a single tile in different dest locations        | bool     | true/false                            | False (default false) |
+ * | dense_packing  | Whether to pack consecutive tiles 32 rows apart (instead of 64, doubles dest capacity) | bool     | true/false                            | False (default false) |
+ * | in0_cb_id      | The identifier of the first input circular buffer (CB)                                 | uint32_t | 0 to 31                               | True                  |
+ * | in1_cb_id      | The identifier of the second input circular buffer (CB)                                | uint32_t | 0 to 31                               | True                  |
+ * | out_cb_id      | The identifier of the output circular buffer (CB)                                      | uint32_t | 0 to 31                               | True                  |
+ * | ct_dim         | The width of the output matrix in tiles                                                | uint32_t | {1, 2, 3, 4, 5, 6, 8, 10, 12, 14, 16} | False (default 1)     |
  */
 // clang-format on
 template <bool transpose = false, bool split_acc = false, bool dense_packing = false, bool fp32_dest_acc_en = DST_ACCUM_MODE>
@@ -73,22 +73,22 @@ ALWI void custom_mm_block_init(
  * in0 tile shape: [{1, 2, 4, 8}, 32]
  * in1 tile shape: [32, 32]
  * rt_dim: 1
- * ct_dim: {1, 2, 4, 6, 8, 10, 12, 14, 16}
+ * ct_dim: {1, 2, 3, 4, 5, 6, 8, 10, 12, 14, 16}
  * kt_dim: even number from 2 to 256 (inclusive)
  * fidelity: LoFi only
  * throttle: not supported
  *
  * Return value: None
  *
- * | Argument       | Description                                                                            | Type     | Valid Range                     | Required              |
- * |----------------|----------------------------------------------------------------------------------------|----------|---------------------------------|-----------------------|
- * | transpose      | The transpose flag for performing transpose operation on in1                           | bool     | true/false                      | False (default false) |
- * | split_acc      | Whether to accumulate partials within a single tile in different dest locations        | bool     | true/false                      | False (default false) |
- * | dense_packing  | Whether to pack consecutive tiles 32 rows apart (instead of 64, doubles dest capacity) | bool     | true/false                      | False (default false) |
- * | in0_cb_id      | The identifier of the first input circular buffer (CB)                                 | uint32_t | 0 to 31                         | True                  |
- * | in1_cb_id      | The identifier of the second input circular buffer (CB)                                | uint32_t | 0 to 31                         | True                  |
- * | out_cb_id      | The identifier of the output circular buffer (CB)                                      | uint32_t | 0 to 31                         | True                  |
- * | ct_dim         | The width of the output matrix in tiles                                                | uint32_t | {1, 2, 4, 6, 8, 10, 12, 14, 16} | False (default 1)     |
+ * | Argument       | Description                                                                            | Type     | Valid Range                           | Required              |
+ * |----------------|----------------------------------------------------------------------------------------|----------|---------------------------------------|-----------------------|
+ * | transpose      | The transpose flag for performing transpose operation on in1                           | bool     | true/false                            | False (default false) |
+ * | split_acc      | Whether to accumulate partials within a single tile in different dest locations        | bool     | true/false                            | False (default false) |
+ * | dense_packing  | Whether to pack consecutive tiles 32 rows apart (instead of 64, doubles dest capacity) | bool     | true/false                            | False (default false) |
+ * | in0_cb_id      | The identifier of the first input circular buffer (CB)                                 | uint32_t | 0 to 31                               | True                  |
+ * | in1_cb_id      | The identifier of the second input circular buffer (CB)                                | uint32_t | 0 to 31                               | True                  |
+ * | out_cb_id      | The identifier of the output circular buffer (CB)                                      | uint32_t | 0 to 31                               | True                  |
+ * | ct_dim         | The width of the output matrix in tiles                                                | uint32_t | {1, 2, 3, 4, 5, 6, 8, 10, 12, 14, 16} | False (default 1)     |
  */
 // clang-format on
 template <bool transpose = false, bool split_acc = false, bool dense_packing = false>
@@ -120,7 +120,7 @@ ALWI void custom_mm_block_init_short(
  * in0 tile shape: [{1, 2, 4, 8}, 32]
  * in1 tile shape: [32, 32]
  * rt_dim: 1
- * ct_dim: {1, 2, 4, 6, 8, 10, 12, 14, 16}
+ * ct_dim: {1, 2, 3, 4, 5, 6, 8, 10, 12, 14, 16}
  * kt_dim: even number from 2 to 256 (inclusive)
  * fidelity: LoFi only
  * throttle: not supported
@@ -137,7 +137,7 @@ ALWI void custom_mm_block_init_short(
  * | in1_tile_index  | The index of the tile in block B from the second input CB                                                       | uint32_t | Must be less than the size of the CB             | True                  |
  * | dst_index       | The index of the tile in DST REG to which the result C will be written                                          | uint32_t | Must be less than the acquired size of DST REG   | True                  |
  * | kt_dim          | The inner dimension in tiles                                                                                    | uint32_t | Must be an even number from 2 to 256 (inclusive) | True                  |
- * | ct_dim          | The width of the output matrix in tiles                                                                         | uint32_t | {1, 2, 4, 6, 8, 10, 12, 14, 16}                  | False (default 1)     |
+ * | ct_dim          | The width of the output matrix in tiles                                                                         | uint32_t | {1, 2, 3, 4, 5, 6, 8, 10, 12, 14, 16}            | False (default 1)     |
  */
 // clang-format on
 template <bool finalize = true, bool read_transposed = false>
@@ -165,7 +165,7 @@ ALWI void custom_mm_block(
  * in0 tile shape: [{1, 2, 4, 8}, 32]
  * in1 tile shape: [32, 32]
  * rt_dim: 1
- * ct_dim: {1, 2, 4, 6, 8, 10, 12, 14, 16}
+ * ct_dim: {1, 2, 3, 4, 5, 6, 8, 10, 12, 14, 16}
  * kt_dim: even number from 2 to 256 (inclusive)
  * fidelity: LoFi only
  * throttle: not supported
@@ -180,7 +180,7 @@ ALWI void custom_mm_block(
  * | in0_tile_index  | The index of the tile in block A from the first input CB                                                        | uint32_t | Must be less than the size of the CB             | True                  |
  * | in1_tile_index  | The index of the tile in block B from the second input CB                                                       | uint32_t | Must be less than the size of the CB             | True                  |
  * | kt_dim          | The inner dimension in tiles                                                                                    | uint32_t | Must be an even number from 2 to 256 (inclusive) | True                  |
- * | ct_dim          | The width of the output matrix in tiles                                                                         | uint32_t | {1, 2, 4, 6, 8, 10, 12, 14, 16}                  | False (default 1)     |
+ * | ct_dim          | The width of the output matrix in tiles                                                                         | uint32_t | {1, 2, 3, 4, 5, 6, 8, 10, 12, 14, 16}            | False (default 1)     |
  */
 // clang-format on
 template <bool read_transposed = false>
@@ -206,7 +206,7 @@ ALWI void custom_mm_block_unpack(
  * in0 tile shape: [{1, 2, 4, 8}, 32]
  * in1 tile shape: [32, 32]
  * rt_dim: 1
- * ct_dim: {1, 2, 4, 6, 8, 10, 12, 14, 16}
+ * ct_dim: {1, 2, 3, 4, 5, 6, 8, 10, 12, 14, 16}
  * kt_dim: even number from 2 to 256 (inclusive)
  * fidelity: LoFi only
  * throttle: not supported
@@ -220,7 +220,7 @@ ALWI void custom_mm_block_unpack(
  * | in1_cb_id       | The identifier of the second input circular buffer (CB)                                                        | uint32_t | 0 to 31                                          | True                  |
  * | dst_index       | The index of the tile in DST REG to which the result C will be written                                         | uint32_t | Must be less than the acquired size of DST REG   | True                  |
  * | kt_dim          | The inner dimension in tiles                                                                                   | uint32_t | Must be an even number from 2 to 256 (inclusive) | True                  |
- * | ct_dim          | The width of the output matrix in tiles                                                                        | uint32_t | {1, 2, 4, 6, 8, 10, 12, 14, 16}                  | False (default 1)     |
+ * | ct_dim          | The width of the output matrix in tiles                                                                        | uint32_t | {1, 2, 3, 4, 5, 6, 8, 10, 12, 14, 16}            | False (default 1)     |
  */
 // clang-format on
 template <bool finalize = true>

--- a/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/third_party/tt_llk/tt_llk_blackhole/llk_lib/llk_math_custom_mm.h
+++ b/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/third_party/tt_llk/tt_llk_blackhole/llk_lib/llk_math_custom_mm.h
@@ -21,7 +21,7 @@ using namespace ckernel::math;
 // in0 tile shape: [{1, 2, 4, 8}, 32]
 // in1 tile shape: [32, 32]
 // rt_dim: 1
-// ct_dim: {1, 2, 4, 6, 8, 10, 12, 14, 16}
+// ct_dim: {1, 2, 3, 4, 5, 6, 8, 10, 12, 14, 16}
 // kt_dim: even number from 2 to 256 (inclusive)
 // fidelity: LoFi only
 // throttle: not supported

--- a/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/third_party/tt_llk/tt_llk_blackhole/llk_lib/llk_unpack_AB_custom_mm.h
+++ b/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/third_party/tt_llk/tt_llk_blackhole/llk_lib/llk_unpack_AB_custom_mm.h
@@ -21,7 +21,7 @@ using namespace ckernel::unpacker;
 // in0 tile shape: [{1, 2, 4, 8}, 32]
 // in1 tile shape: [32, 32]
 // rt_dim: 1
-// ct_dim: {1, 2, 4, 6, 8, 10, 12, 14, 16}
+// ct_dim: {1, 2, 3, 4, 5, 6, 8, 10, 12, 14, 16}
 // kt_dim: even number from 2 to 256 (inclusive)
 // fidelity: LoFi only
 // throttle: not supported
@@ -126,36 +126,36 @@ inline void _llk_unpack_AB_custom_mm_mop_config_(const std::uint32_t ct_dim) {
         }
     });
 
-    // When ct_dim == 1 we alternate between full sequences for both contexts kt_dim times in total
-    // When ct_dim > 1 we start with full context 0 and then alternate between reuse contexts 1 and 0 ct_dim - 1 times
-    // Since if ct_dim > 1 it must be even full sequence always lands on context 0
-    // thus instruction sequence is same for each kt_dim
-    // Mop is configured such that it always covers two iterations of the inner dim loop,
-    // this has two benefits:
-    // With the max number of mop iterations (128) we can cover up to 256 kt_dim, which is the max supported by this API
-    // There is no need to have different templates for contexts 0 and 1 since they are always executed as a pair
-    // In order to be able to usefully issue up to 128 mop iterations we are limited to only using 0s in zmask
+    // Mop is configured to always cover two iterations of the inner dim loop, providing two benefits:
+    // 1. With max mop iterations (128) we can cover up to 256 kt_dim (max supported by this API)
+    // 2. No need for different templates for contexts 0 and 1 since they're always executed as a pair
+    // To usefully issue up to 128 mop iterations we're limited to only using 0s in zmask
     // (not using SKIP_A/B instructions) since iterations beyond 32 always use 0s for zmask
-    // In ct_dim == 1 case we enable unpackB and two instructions we issue per iteration are replays for
-    // full context 0 and full context 1
-    // In ct_dim > 1 case we enable unpackHalo and thus have 4 instructions to execute two inner dim iterations,
-    // meaning 2 instructions per inner dim
-    // This is achieved with really long replay sequences that each cover half of the ct_dim iterations
-    // First half is:
-    // full context 0, {reuse context 1, reuse context 0} (ct_dim / 4) - 1 times, [reuse context 1] if ct_dim > 2
-    // Since our replay is organized like:
-    // full context 0, reuse context 1, {reuse context 0, reuse context 1} 4 times (which fills all 32 instructions)
-    // We just pick first ct_dim / 2 sequences (each sequence is 3 instructions plus first full one is
-    // 2 additional instructions, thus getting the equation which calculates first half of the replay length)
-    // Similarly second half is just {reuse context 0, reuse context 1} ct_dim / 4 times,
-    // which is just picking ct_dim / 2 sequences starting from the first reuse context 0 sequence
-    // (each sequence is 3 instructions so replay length calculation is simpler)
-    // To be sure that everything fits, for max ct_dim of 16, second half has to issue 4 pairs of sequences
-    // which is exactly what we recorded at the end
-    // First sequence already has the first pair as full context 0 and reuse context 1
-    // so it needs only 3 additional pair which are covered by the 4 pairs required for the second half
-    // Special case is ct_dim == 2 where first half is just full context 0
-    // and second half is just reuse context 1 thus having an earlier starting index
+    //
+    // Replay buffer layout:
+    // Odd ct_dim (1, 3, 5) uses 28 instructions:
+    //   0-4: full ctx0, 5-9: full ctx1, 10-27: {reuse ctx0, reuse ctx1} x 3 pairs
+    // Even ct_dim (2, 4, 6, 8, 10, 12, 14, 16) uses 32 instructions:
+    //   0-4: full ctx0, 5-7: reuse ctx1, 8-31: {reuse ctx0, reuse ctx1} x 4 pairs
+    //
+    // Desired instruction sequences per mop iteration (covering 2 inner dim loops):
+    // ct_dim == 1: full ctx0, full ctx1
+    // ct_dim == 2: full ctx0, reuse ctx1, full ctx0, reuse ctx1
+    // Odd ct_dim (3, 5): full ctx0, {reuse ctx1, reuse ctx0} x ((ct_dim-1)/2) times,
+    //                    full ctx1, {reuse ctx0, reuse ctx1} x ((ct_dim-1)/2) times
+    // Even ct_dim (4, 6, 8, 10, 12, 14, 16): full ctx0, reuse ctx1, {reuse ctx0, reuse ctx1} x ((ct_dim/2)-1) times,
+    //                                        full ctx0, reuse ctx1, {reuse ctx0, reuse ctx1} x ((ct_dim/2)-1) times
+    //
+    // Mop template parameter assignment (breaking sequences into replay parts):
+    // ct_dim == 1: A0=ctx0_full, B=ctx1_full (uses unpackB)
+    // ct_dim == 2: A0=ct_dim_2,  B=ct_dim_2 (uses unpackB)
+    //              ct_dim_2 captures: full ctx0, reuse ctx1
+    // Odd ct_dim (3, 5): A0=ctx0_full, A1=ctx1_r_tail, A2=ctx1_full, A3=ctx0_r_tail (uses unpackHalo)
+    //                    ctx1_r_tail captures: {reuse ctx1, reuse ctx0} x ((ct_dim-1)/2) times
+    //                    ctx0_r_tail captures: {reuse ctx0, reuse ctx1} x ((ct_dim-1)/2) times
+    // Even ct_dim: A0=first_half, A1=second_half, A2=first_half, A3=second_half (uses unpackHalo)
+    //              first_half captures: full ctx0, reuse ctx1, {reuse ctx0, reuse ctx1} x ((ct_dim/2)-1) times
+    //              second_half captures: {reuse ctx0, reuse ctx1} x (ct_dim/2) times
 
     const std::uint32_t ctx0_full = lltt::replay_insn(0, 5);
     const std::uint32_t ctx1_full = lltt::replay_insn(5, 5);
@@ -276,6 +276,7 @@ inline void _llk_unpack_AB_custom_mm_(
             block_start_address += block_increment;
             semaphore_post(semaphore::UNPACK_SYNC);
             address_a += inner_increment;
+
             block_start_address = address_a;
 #pragma GCC unroll 8
             for (std::uint32_t ct = 0; ct + 1 < ct_dim; ct += 2) {

--- a/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/third_party/tt_llk/tt_llk_blackhole/llk_lib/llk_unpack_AB_custom_mm.h
+++ b/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/third_party/tt_llk/tt_llk_blackhole/llk_lib/llk_unpack_AB_custom_mm.h
@@ -27,7 +27,7 @@ using namespace ckernel::unpacker;
 // throttle: not supported
 
 inline void _llk_unpack_AB_custom_mm_mop_config_(const std::uint32_t ct_dim) {
-    const std::uint32_t replay_buf_prog_len = ct_dim == 1 ? 10 : 32;
+    const std::uint32_t replay_buf_prog_len = ct_dim % 2 == 1 ? 28 : 32;
 
     load_replay_buf(0, replay_buf_prog_len, [ct_dim] {
         // === Context 0 full ===
@@ -56,7 +56,7 @@ inline void _llk_unpack_AB_custom_mm_mop_config_(const std::uint32_t ct_dim) {
         // Signal context done
         t6_semaphore_get(semaphore::UNPACK_SYNC);
 
-        if (ct_dim == 1) {
+        if (ct_dim % 2 == 1) {
             // === Context 1 full ===
             // Wait for context available
             t6_semaphore_wait_on_zero<p_stall::STALL_UNPACK>(semaphore::UNPACK_SYNC);
@@ -82,27 +82,47 @@ inline void _llk_unpack_AB_custom_mm_mop_config_(const std::uint32_t ct_dim) {
             // Signal context done
             t6_semaphore_get(semaphore::UNPACK_SYNC);
 
-            for (std::uint32_t i = 0; i < 4; i++) {
-                // === Context 0 reuse ===
-                // Wait for context available
-                t6_semaphore_wait_on_zero<p_stall::STALL_UNPACK>(semaphore::UNPACK_SYNC);
+            // === Context 0 reuse ===
+            // Wait for context available
+            t6_semaphore_wait_on_zero<p_stall::STALL_UNPACK>(semaphore::UNPACK_SYNC);
 
-                // Unpack SrcA (in1, full tile, uses contexts to manipulate L1 address)
-                TTI_UNPACR_COMMON_EXPLICIT_CONTEXT(SrcA, 0b00000000, 0, 1);  // Also set dvalid
+            // Unpack SrcA (in1, full tile, uses contexts to manipulate L1 address)
+            TTI_UNPACR_COMMON_EXPLICIT_CONTEXT(SrcA, 0b00000000, 0, 1);  // Also set dvalid
 
-                // Signal context done
-                t6_semaphore_get(semaphore::UNPACK_SYNC);
+            // Signal context done
+            t6_semaphore_get(semaphore::UNPACK_SYNC);
 
-                // === Context 1 reuse ===
-                // Wait for context available
-                t6_semaphore_wait_on_zero<p_stall::STALL_UNPACK>(semaphore::UNPACK_SYNC);
+            // === Context 1 reuse ===
+            // Wait for context available
+            t6_semaphore_wait_on_zero<p_stall::STALL_UNPACK>(semaphore::UNPACK_SYNC);
 
-                // Unpack SrcA (in1, full tile, uses contexts to manipulate L1 address)
-                TTI_UNPACR_COMMON_EXPLICIT_CONTEXT(SrcA, 0b00000000, 1, 1);  // Also set dvalid
+            // Unpack SrcA (in1, full tile, uses contexts to manipulate L1 address)
+            TTI_UNPACR_COMMON_EXPLICIT_CONTEXT(SrcA, 0b00000000, 1, 1);  // Also set dvalid
 
-                // Signal context done
-                t6_semaphore_get(semaphore::UNPACK_SYNC);
-            }
+            // Signal context done
+            t6_semaphore_get(semaphore::UNPACK_SYNC);
+        }
+
+        for (std::uint32_t i = 0; i < 3; i++) {
+            // === Context 0 reuse ===
+            // Wait for context available
+            t6_semaphore_wait_on_zero<p_stall::STALL_UNPACK>(semaphore::UNPACK_SYNC);
+
+            // Unpack SrcA (in1, full tile, uses contexts to manipulate L1 address)
+            TTI_UNPACR_COMMON_EXPLICIT_CONTEXT(SrcA, 0b00000000, 0, 1);  // Also set dvalid
+
+            // Signal context done
+            t6_semaphore_get(semaphore::UNPACK_SYNC);
+
+            // === Context 1 reuse ===
+            // Wait for context available
+            t6_semaphore_wait_on_zero<p_stall::STALL_UNPACK>(semaphore::UNPACK_SYNC);
+
+            // Unpack SrcA (in1, full tile, uses contexts to manipulate L1 address)
+            TTI_UNPACR_COMMON_EXPLICIT_CONTEXT(SrcA, 0b00000000, 1, 1);  // Also set dvalid
+
+            // Signal context done
+            t6_semaphore_get(semaphore::UNPACK_SYNC);
         }
     });
 
@@ -139,19 +159,23 @@ inline void _llk_unpack_AB_custom_mm_mop_config_(const std::uint32_t ct_dim) {
 
     const std::uint32_t ctx0_full = lltt::replay_insn(0, 5);
     const std::uint32_t ctx1_full = lltt::replay_insn(5, 5);
+    const std::uint32_t ct_dim_2 = lltt::replay_insn(0, 8);
+    const std::uint32_t ctx1_r_tail = lltt::replay_insn(13, (ct_dim - 1) * 3);
+    const std::uint32_t ctx0_r_tail = lltt::replay_insn(10, (ct_dim - 1) * 3);
     const std::uint32_t first_half = lltt::replay_insn(0, 2 + (ct_dim / 2) * 3);
-    const std::uint32_t second_half = lltt::replay_insn(ct_dim == 2 ? 5 : 8, (ct_dim / 2) * 3);
+    const std::uint32_t second_half = lltt::replay_insn(8, (ct_dim / 2) * 3);
+    const std::uint32_t even_A0 = ct_dim == 2 ? ct_dim_2 : first_half;
 
     ckernel_unpack_template tmp = ckernel_unpack_template(
-        ct_dim == 1,                           // Use UNPACR_B and SKIP_B instructions?
-        ct_dim != 1,                           // Use UNPACR_A1/2/3 instructions?
-        ct_dim == 1 ? ctx0_full : first_half,  // A0
-        ct_dim == 1 ? 0 : second_half,         // A1
-        ct_dim == 1 ? 0 : first_half,          // A2
-        ct_dim == 1 ? 0 : second_half,         // A3
-        0,                                     // Skip A
-        ct_dim == 1 ? ctx1_full : 0,           // B
-        0                                      // Skip B
+        ct_dim <= 2,                                  // Use UNPACR_B and SKIP_B instructions?
+        ct_dim > 2,                                   // Use UNPACR_A1/2/3 instructions?
+        ct_dim % 2 == 1 ? ctx0_full : even_A0,        // A0
+        ct_dim % 2 == 1 ? ctx1_r_tail : second_half,  // A1
+        ct_dim % 2 == 1 ? ctx1_full : first_half,     // A2
+        ct_dim % 2 == 1 ? ctx0_r_tail : second_half,  // A3
+        0,                                            // Skip A
+        ct_dim == 1 ? ctx1_full : ct_dim_2,           // B
+        0                                             // Skip B
     );
 
     tmp.program();
@@ -217,7 +241,7 @@ inline void _llk_unpack_AB_custom_mm_(
             address_a += inner_increment;
             semaphore_post(semaphore::UNPACK_SYNC);
         }
-    } else {
+    } else if (ct_dim % 2 == 0) {
         for (std::uint32_t k = 0; k < kt_dim; k++) {
             std::uint32_t block_start_address = address_a;
 #pragma GCC unroll 8
@@ -231,6 +255,43 @@ inline void _llk_unpack_AB_custom_mm_(
                 block_start_address += block_increment;
                 semaphore_post(semaphore::UNPACK_SYNC);
             }
+            address_a += inner_increment;
+        }
+    } else {
+        for (std::uint32_t k = 0; k < kt_dim; k += 2) {
+            std::uint32_t block_start_address = address_a;
+#pragma GCC unroll 8
+            for (std::uint32_t ct = 0; ct + 1 < ct_dim; ct += 2) {
+                wait_for_next_context(2);
+                cfg[THCON_SEC0_REG3_Base_address_ADDR32] = block_start_address;
+                block_start_address += block_increment;
+                semaphore_post(semaphore::UNPACK_SYNC);
+                wait_for_next_context(2);
+                cfg[THCON_SEC0_REG3_Base_cntx1_address_ADDR32] = block_start_address;
+                block_start_address += block_increment;
+                semaphore_post(semaphore::UNPACK_SYNC);
+            }
+            wait_for_next_context(2);
+            cfg[THCON_SEC0_REG3_Base_address_ADDR32] = block_start_address;
+            block_start_address += block_increment;
+            semaphore_post(semaphore::UNPACK_SYNC);
+            address_a += inner_increment;
+            block_start_address = address_a;
+#pragma GCC unroll 8
+            for (std::uint32_t ct = 0; ct + 1 < ct_dim; ct += 2) {
+                wait_for_next_context(2);
+                cfg[THCON_SEC0_REG3_Base_cntx1_address_ADDR32] = block_start_address;
+                block_start_address += block_increment;
+                semaphore_post(semaphore::UNPACK_SYNC);
+                wait_for_next_context(2);
+                cfg[THCON_SEC0_REG3_Base_address_ADDR32] = block_start_address;
+                block_start_address += block_increment;
+                semaphore_post(semaphore::UNPACK_SYNC);
+            }
+            wait_for_next_context(2);
+            cfg[THCON_SEC0_REG3_Base_cntx1_address_ADDR32] = block_start_address;
+            block_start_address += block_increment;
+            semaphore_post(semaphore::UNPACK_SYNC);
             address_a += inner_increment;
         }
     }

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_matmul.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_matmul.py
@@ -60,6 +60,8 @@ from models.demos.deepseek_v3_b1.micro_ops.matmul.op import Matmul
         (1, 7168, 32, ttnn.bfloat16, ttnn.bfloat16, False, "sigmoid", True),  # Router gate + sigmoid with FP32 acc
         # SiLU activation test (similar to MoE gate projection)
         (1, 7168, 32, ttnn.bfloat16, ttnn.bfloat4_b, False, "silu", False),  # Gate proj + silu
+        # Tail MMs
+        (1, 7168, 160, ttnn.bfloat16, ttnn.bfloat4_b, False, None, False),  # LM Head
     ],
 )
 def test_matmul_single_core(device, M, K, N, in0_dtype, in1_dtype, transpose, fused_activation, fp32_dest_acc_en):


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/35997

### Problem description
The custom matrix multiplication (custom_mm) kernel API only supported specific ct_dim (column tile dimension) values: {1, 2, 4, 6, 8, 10, 12, 14, 16}. This restriction prevented using the custom_mm kernel for certain matrix dimensions, specifically odd widths like 3, 5, and non-standard widths like 160 that are needed for operations such as language model head projections (7168 x 160).

### What's changed
Extended the custom_mm kernel API to support odd ct_dim values by modifying the replay buffer logic and instruction sequencing:

- **Replay buffer optimization**: Updated instruction layout to handle odd ct_dim values (3, 5) with 28-instruction sequences vs 32 for even values
- **Context switching logic**: Refactored context alternation to properly handle odd ct_dim with dedicated code paths for odd/even cases
- **Mop template assignment**: Restructured replay instruction sequences to support alternating full/reuse context patterns for odd widths
- **Documentation**: Updated API documentation in custom_mm.h and all LLK headers to reflect new supported ct_dim range: {1, 2, 3, 4, 5, 6, 8, 10, 12, 14, 16}
- **Test coverage**: Added test case for 7168 x 160 matmul (tail MM for LM head)

The changes are localized to the deepseek_v3_b1 kernel includes, specifically the unpack and math LLK libraries for the custom_mm operation.

**Impact**: Enables custom_mm kernel usage for previously unsupported matrix dimensions, improving flexibility for model operations requiring odd or non-standard widths.

### Checklist

- [x] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=lpremovic/odd_width_custom_mm)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:lpremovic/odd_width_custom_mm) (Fails on main too)
- [x] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=lpremovic/odd_width_custom_mm)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:lpremovic/odd_width_custom_mm)
- [N/A] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=lpremovic/odd_width_custom_mm)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:lpremovic/odd_width_custom_mm)
- [x] New/Existing tests provide coverage for changes


#### Model tests

[N/A]