### PR TITLE
[QSR]: Integrating DFBs into datacopy and bmm tests 

### DIFF
--- a/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer.cpp
+++ b/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer.cpp
@@ -95,6 +95,14 @@ void run_single_dfb_program(
     experimental::dfb::DataflowBufferConfig& dfb_config,
     DFBPorCType producer_type,
     DFBPorCType consumer_type) {
+
+    if (dfb_config.num_producers > 1 and producer_type == DFBPorCType::TENSIX) {
+        GTEST_SKIP() << "Skipping DFB test until api to init kernels on multiple tensix is available";
+    }
+    if (dfb_config.num_consumers > 1 and consumer_type == DFBPorCType::TENSIX) {
+        GTEST_SKIP() << "Skipping DFB test until api to init kernels on multiple tensix is available";
+    }
+
     TT_FATAL(
         !(producer_type == DFBPorCType::TENSIX && consumer_type == DFBPorCType::TENSIX),
         "Both producer and consumer cannot be Tensix. At least one must be a DM kernel for NOC transfers.");

--- a/tests/tt_metal/tt_metal/test_kernels/compute/bmm.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/bmm.cpp
@@ -5,7 +5,11 @@
 #include <cstdint>
 #include "api/compute/tile_move_copy.h"
 #include "api/compute/matmul.h"
+#ifdef ARCH_QUASAR
+#include "experimental/dataflow_buffer.h"
+#else
 #include "experimental/circular_buffer.h"
+#endif
 
 using std::uint32_t;
 
@@ -22,11 +26,19 @@ void kernel_main() {
     uint32_t Kt = get_compile_time_arg_val(2);
     uint32_t Nt = get_compile_time_arg_val(3);
 
+#ifdef ARCH_QUASAR
+    experimental::DataflowBuffer dfb0(0);
+    experimental::DataflowBuffer dfb1(1);
+    experimental::DataflowBuffer dfb_out(2);
+
+    mm_init(dfb0.get_id(), dfb1.get_id(), dfb_out.get_id());
+#else
     experimental::CircularBuffer cb0(tt::CBIndex::c_0);
     experimental::CircularBuffer cb1(tt::CBIndex::c_1);
     experimental::CircularBuffer cb16(tt::CBIndex::c_16);
 
     mm_init(tt::CBIndex::c_0, tt::CBIndex::c_1, tt::CBIndex::c_16);
+#endif
 
     // the simplest possible version of outer product blocked matmul
     // the reader is expected to read the A's and B's tile rows and tile columns for each output tile
@@ -36,6 +48,15 @@ void kernel_main() {
             {
                 acquire_dst();
                 for (uint32_t kt = 0; kt < Kt; kt++) {
+#ifdef ARCH_QUASAR
+                    dfb0.wait_front(onetile);
+                    dfb1.wait_front(onetile);
+
+                    matmul_tiles(dfb0.get_id(), dfb1.get_id(), 0, 0, 0);
+
+                    dfb0.pop_front(onetile);
+                    dfb1.pop_front(onetile);
+#else
                     cb0.wait_front(onetile);
                     cb1.wait_front(onetile);
 
@@ -43,11 +64,19 @@ void kernel_main() {
 
                     cb0.pop_front(onetile);
                     cb1.pop_front(onetile);
+#endif
                 }
 
-                cb16.reserve_back(onetile);
-                pack_tile(0, tt::CBIndex::c_16);
-                cb16.push_back(onetile);
+
+#ifdef ARCH_QUASAR
+                    dfb_out.reserve_back(onetile);
+                    pack_tile(0, dfb_out.get_id());
+                    dfb_out.push_back(onetile);
+#else
+                    cb16.reserve_back(onetile);
+                    pack_tile(0, tt::CBIndex::c_16);
+                    cb16.push_back(onetile);
+#endif
 
                 release_dst();
             }

--- a/tests/tt_metal/tt_metal/test_kernels/compute/eltwise_copy.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/eltwise_copy.cpp
@@ -7,18 +7,36 @@
 #include "api/compute/common.h"
 #include "api/compute/tile_move_copy.h"
 #include "api/compute/eltwise_unary/eltwise_unary.h"
+#ifdef ARCH_QUASAR
+#include "experimental/dataflow_buffer.h"
+#else
 #include "experimental/circular_buffer.h"
+#endif
 
 void kernel_main() {
     uint32_t per_core_tile_cnt = get_compile_time_arg_val(0);
 
+#ifdef ARCH_QUASAR
+    experimental::DataflowBuffer dfb_in(0);
+    experimental::DataflowBuffer dfb_out(1);
+    unary_op_init_common(dfb_in.get_id(), dfb_out.get_id());
+#else
     experimental::CircularBuffer cb0(tt::CBIndex::c_0);
     experimental::CircularBuffer cb16(tt::CBIndex::c_16);
-
     unary_op_init_common(tt::CBIndex::c_0, tt::CBIndex::c_16);
+#endif
+
     for (uint32_t b = 0; b < per_core_tile_cnt; ++b) {
         acquire_dst();
 
+#ifdef ARCH_QUASAR
+        dfb_in.wait_front(1);
+        dfb_out.reserve_back(1);
+        copy_tile(dfb_in.get_id(), 0, 0);
+        pack_tile(0, dfb_out.get_id());
+        dfb_in.pop_front(1);
+        dfb_out.push_back(1);
+#else
         // Pop tile after tile, copy to DST and pack
         cb0.wait_front(1);
         cb16.reserve_back(1);
@@ -28,6 +46,7 @@ void kernel_main() {
 
         cb0.pop_front(1);
         cb16.push_back(1);
+#endif
 
         release_dst();
     }

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/dram/direct_reader_unary.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/dram/direct_reader_unary.cpp
@@ -5,6 +5,11 @@
 #include <stdint.h>
 
 #include "api/dataflow/dataflow_api.h"
+#ifdef ARCH_QUASAR
+#include "experimental/dataflow_buffer.h"
+#include "experimental/endpoints.h"
+#include "experimental/noc.h"
+#endif
 
 void kernel_main() {
     const uint32_t cb_id = get_compile_time_arg_val(0);
@@ -12,8 +17,26 @@ void kernel_main() {
     uint32_t src_bank_id = get_arg_val<uint32_t>(1);
     uint32_t num_tiles = get_arg_val<uint32_t>(2);
 
-    // ublocks size defined in tiles
     constexpr uint32_t ublock_size_tiles = 1;
+
+#ifdef ARCH_QUASAR
+    experimental::DataflowBuffer dfb(cb_id);
+    constexpr experimental::AllocatorBankType bank_type = experimental::AllocatorBankType::DRAM;
+    experimental::AllocatorBank<bank_type> src_dram;
+    experimental::Noc noc;
+
+    uint32_t ublock_size_bytes = dfb.get_entry_size();
+
+    for (uint32_t i = 0; i < num_tiles; i += ublock_size_tiles) {
+        dfb.reserve_back(ublock_size_tiles);
+        noc.async_read(src_dram, dfb, ublock_size_bytes, {.bank_id = src_bank_id, .addr = src_addr}, {});
+        noc.async_read_barrier();
+        dfb.push_back(ublock_size_tiles);
+        src_addr += ublock_size_bytes;
+    }
+
+#else
+    // ublocks size defined in tiles
     uint32_t ublock_size_bytes = get_tile_size(cb_id) * ublock_size_tiles;
 
     // read a ublock of tiles from src to CB, and then push the ublock to unpacker
@@ -29,4 +52,5 @@ void kernel_main() {
         cb_push_back(cb_id, ublock_size_tiles);
         src_addr += ublock_size_bytes;
     }
+#endif
 }

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/dram/direct_writer_unary.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/dram/direct_writer_unary.cpp
@@ -3,6 +3,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "api/dataflow/dataflow_api.h"
+#ifdef ARCH_QUASAR
+#include "experimental/dataflow_buffer.h"
+#include "experimental/endpoints.h"
+#include "experimental/noc.h"
+#endif
 
 void kernel_main() {
     const uint32_t cb_id = get_compile_time_arg_val(0);
@@ -10,9 +15,32 @@ void kernel_main() {
     uint32_t dst_bank_id = get_arg_val<uint32_t>(1);
     uint32_t num_tiles = get_arg_val<uint32_t>(2);
 
+    uint32_t ublock_size_tiles = 1;
+
+#ifdef ARCH_QUASAR
+    experimental::DataflowBuffer dfb(cb_id);
+    constexpr experimental::AllocatorBankType bank_type = experimental::AllocatorBankType::DRAM;
+    experimental::AllocatorBank<bank_type> dst_dram;
+    experimental::Noc noc;
+
+    uint32_t ublock_size_bytes = dfb.get_entry_size();
+
+    volatile tt_l1_ptr uint32_t* debug_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(763520);
+
+    for (uint32_t i = 0; i < num_tiles; i += ublock_size_tiles) {
+        dfb.wait_front(ublock_size_tiles);
+
+        DPRINT << "Debug pointer value: " << *debug_ptr << ENDL();
+
+        noc.async_write(dfb, dst_dram, ublock_size_bytes, {}, {.bank_id = dst_bank_id, .addr = dst_addr});
+        noc.async_write_barrier();
+
+        dfb.pop_front(ublock_size_tiles);
+        dst_addr += ublock_size_bytes;
+    }
+#else
     // single-tile ublocks
     uint32_t ublock_size_bytes = get_tile_size(cb_id);
-    uint32_t ublock_size_tiles = 1;
 
     for (uint32_t i = 0; i < num_tiles; i += ublock_size_tiles) {
          uint64_t dst_noc_addr = get_noc_addr_from_bank_id<true>(dst_bank_id, dst_addr);
@@ -26,4 +54,5 @@ void kernel_main() {
         cb_pop_front(cb_id, ublock_size_tiles);
         dst_addr += ublock_size_bytes;
     }
+#endif
 }

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_unpack_AB_matmul_api.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_unpack_AB_matmul_api.h
@@ -5,6 +5,7 @@
 #pragma once
 #include "llk_unpack_matmul.h"
 #include "llk_unpack_common_api.h"
+#include "experimental/dataflow_buffer.h"
 
 /*************************************************************************
  * LLK UNPACK AB MATMUL
@@ -72,8 +73,8 @@ inline void llk_unpack_AB_matmul(
     const std::uint32_t operandA_id = get_operand_id(operandA);
     const std::uint32_t operandB_id = get_operand_id(operandB);
 
-    const std::uint32_t l1_tile_idx_0 = get_local_cb_interface(operandA_id).fifo_rd_tile_idx + tile_index_a;
-    const std::uint32_t l1_tile_idx_1 = get_local_cb_interface(operandB_id).fifo_rd_tile_idx + tile_index_b;
+    const std::uint32_t l1_tile_idx_0 = g_dfb_interface[operandA_id].rd_entry_idx + tile_index_a;
+    const std::uint32_t l1_tile_idx_1 = g_dfb_interface[operandB_id].rd_entry_idx + tile_index_b;
 
     WAYPOINT("UPMW");
     _llk_unpack_matmul_(ct_dim, rt_dim, kt_dim, l1_tile_idx_0, l1_tile_idx_1);

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_unpack_A_api.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_unpack_A_api.h
@@ -5,6 +5,7 @@
 #pragma once
 #include "llk_unpack_unary_operand.h"
 #include "llk_unpack_common_api.h"
+#include "experimental/dataflow_buffer.h"
 
 /*************************************************************************
  * LLK UNPACK A
@@ -32,15 +33,15 @@ inline void llk_unpack_A_init(const std::uint32_t operand) {
  *
  * @brief Unpacks a single operand, unpacker0 is used
  *
- * @param operand: The input operand circular buffer
+ * @param operand: The logical dataflow buffer id
  * @param tile_index: The index in the input CB to read from
  *
  * This function unpacks a single operand from the input circular buffer to srcA/dest register.
  */
 inline void llk_unpack_A(const std::uint32_t operand, const std::uint32_t tile_index) {
     const std::uint32_t operand_id = get_operand_id(operand);
-    // Use fifo_rd_tile_idx: number of tiles the read pointer has advanced from CB base
-    const std::uint32_t l1_tile_index = get_local_cb_interface(operand_id).fifo_rd_tile_idx + tile_index;
+    // Use fifo_rd_tile_idx: number of tiles the read pointer has advanced from DFB base
+    const std::uint32_t l1_tile_index = g_dfb_interface[operand_id].rd_entry_idx + tile_index;
 
     WAYPOINT("UPAW");
     _llk_unpack_unary_operand_<p_unpacr::UNP_A>(l1_tile_index);

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_unpack_common_api.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_unpack_common_api.h
@@ -13,6 +13,7 @@
 #include "llk_io.h"
 #include "llk_operands.h"
 #include "llk_unpack_common.h"
+#include "experimental/dataflow_buffer.h"
 
 /*************************************************************************
  * LLK UNPACK COMMON
@@ -28,7 +29,7 @@ inline void llk_unpack_hw_configure(const std::uint32_t unpA_operand, const std:
     const std::uint32_t unpA_operand_id = get_operand_id(unpA_operand);
     const std::uint32_t unpB_operand_id = get_operand_id(unpB_operand);
 
-    // Program buffer descriptors for all 32 circular buffers
+    // Program buffer descriptors for all 32 dataflow buffers, i is the logical dfb id
     for (std::uint32_t i = 0; i < NUM_CIRCULAR_BUFFERS; ++i) {
         const DataFormat l1_data_format = static_cast<DataFormat>(unpack_src_format[i]);
 
@@ -36,8 +37,9 @@ inline void llk_unpack_hw_configure(const std::uint32_t unpA_operand, const std:
             continue;
         }
 
+        // TODO: with multiple TCs are there multiple descriptors?
         buffer_descriptor_u bd_val = {0};
-        bd_val.f.l1_addr_16B = get_local_cb_interface(i).fifo_limit - get_local_cb_interface(i).fifo_size;
+        bd_val.f.l1_addr_16B = g_dfb_interface[i].tc_slots[0].base_addr;
         bd_val.f.format = static_cast<std::uint8_t>(l1_data_format);
         bd_val.f.x_dim = unpack_tile_face_r_dim[i];
         bd_val.f.y_dim = ckernel::trisc::FACE_C_DIM;

--- a/tt_metal/hw/ckernels/quasar/metal/llk_io/llk_io_unpack.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_io/llk_io_unpack.h
@@ -6,39 +6,47 @@
 
 #include "tools/profiler/kernel_profiler.hpp"
 #include "ckernel.h"
+#include "ckernel_trisc_common.h"
 #include "internal/circular_buffer_interface.h"
+#include "internal/dataflow_buffer_init.h"
 
 /**
- * @brief  Wait for num_tiles available in the incoming circular buffer
- * @param cb_id: Circular Buffer ID, values = [0-31]
- * @param num_tiles: Number of tiles to wait for in circular buffer
+ * @brief  Wait for num_tiles available in the incoming dataflow buffer
+ * @param dfb_id: Dataflow Buffer ID, values = [0-31]
+ * @param num_tiles: Number of tiles to wait for in dataflow buffer
  */
-inline void llk_wait_tiles(const std::int32_t cb_id, const std::uint32_t num_tiles) {
-    TT_WAIT_TILES(ckernel::p_stall::STALL_UNPACK, num_tiles, cb_id);
+inline void llk_wait_tiles(const std::int32_t dfb_id, const std::uint32_t num_tiles) {
+    experimental::LocalDFBInterface& local_dfb_interface = g_dfb_interface[dfb_id];
+    uint32_t tc_id = experimental::get_counter_id(local_dfb_interface.tc_slots[local_dfb_interface.tc_idx].packed_tile_counter);
+
+    TT_WAIT_TILES(ckernel::p_stall::STALL_UNPACK, num_tiles, tc_id);
 }
 
 /**
  * @brief Pop num_tiles tiles from the incoming stream, increment read pointer
- * @param cb_id: Circular Buffer ID, values = [0-31]
- * @param num_tiles: Number of tiles to wait for in circular buffer
+ * @param dfb_id: Dataflow Buffer ID, values = [0-31]
+ * @param num_tiles: Number of tiles to wait for in dataflow buffer
  */
 template <std::uint8_t UNPACK_SEL = 0x3>
-inline void llk_pop_tiles(const std::int32_t cb_id, const std::int32_t num_tiles) {
+inline void llk_pop_tiles(const std::int32_t dfb_id, const std::int32_t num_tiles) {
+    experimental::LocalDFBInterface& local_dfb_interface = g_dfb_interface[dfb_id];
+    uint32_t tc_id = experimental::get_counter_id(local_dfb_interface.tc_slots[local_dfb_interface.tc_idx].packed_tile_counter);
+
     // Wait until selected unpackers are reading from L1
-    TT_POP_TILES(UNPACK_SEL, num_tiles, cb_id);
+    TT_POP_TILES(UNPACK_SEL, num_tiles, tc_id);
 
-    // Independent software tracking and tile tracking is used
-    // Not the right approach; it will be fixed when moving to DFBs
-    // Update the CB buffer information
-    const std::uint32_t num_words = num_tiles * get_local_cb_interface(cb_id).fifo_page_size;
+    // Update the DFB buffer information
+    const std::uint32_t num_words = num_tiles * local_dfb_interface.stride_size;
 
-    get_local_cb_interface(cb_id).tiles_acked += num_tiles;
-    get_local_cb_interface(cb_id).fifo_rd_ptr += num_words;
-    get_local_cb_interface(cb_id).fifo_rd_tile_idx += num_tiles;
-
-    // Reset fifo_rd_tile_idx when fifo_rd_ptr reaches limit (back to beginning of CB)
-    if (get_local_cb_interface(cb_id).fifo_rd_ptr >= get_local_cb_interface(cb_id).fifo_limit) {
-        get_local_cb_interface(cb_id).fifo_rd_ptr -= get_local_cb_interface(cb_id).fifo_size;
-        get_local_cb_interface(cb_id).fifo_rd_tile_idx = 0;
+    local_dfb_interface.tc_slots[local_dfb_interface.tc_idx].rd_ptr += num_words;
+    local_dfb_interface.rd_entry_idx += num_tiles;
+    if (local_dfb_interface.tc_slots[local_dfb_interface.tc_idx].rd_ptr == local_dfb_interface.tc_slots[local_dfb_interface.tc_idx].limit) {
+        local_dfb_interface.tc_slots[local_dfb_interface.tc_idx].rd_ptr = local_dfb_interface.tc_slots[local_dfb_interface.tc_idx].base_addr;
+        // rd_entry_idx is a global index, not per-tc for a given DFB. Only reset it when we reached the limit for the entire buffer, not just for the current tc.
+        if (local_dfb_interface.tc_idx == local_dfb_interface.num_tcs_to_rr - 1) {
+            local_dfb_interface.rd_entry_idx = 0;
+        }
     }
+
+    local_dfb_interface.tc_idx = (local_dfb_interface.tc_idx + 1) % local_dfb_interface.num_tcs_to_rr;
 }

--- a/tt_metal/hw/firmware/src/tt-2xx/trisc.cc
+++ b/tt_metal/hw/firmware/src/tt-2xx/trisc.cc
@@ -17,11 +17,9 @@
 #include "api/debug/dprint.h"
 #include "internal/debug/stack_usage.h"
 #include "api/debug/ring_buffer.h"
-#if !defined(UCK_CHLKC_MATH)
-#include "internal/circular_buffer_interface.h"
-#include "internal/circular_buffer_init.h"
-#endif
+#if defined(UCK_CHLKC_UNPACK) || defined(UCK_CHLKC_PACK)
 #include "internal/dataflow_buffer_init.h"
+#endif
 #include "tt-metalium/circular_buffer_constants.h"
 // clang-format on
 
@@ -42,7 +40,9 @@ uint8_t my_logical_y_ __attribute__((used));
 uint8_t my_relative_x_ __attribute__((used));
 uint8_t my_relative_y_ __attribute__((used));
 
+#if defined(UCK_CHLKC_UNPACK) || defined(UCK_CHLKC_PACK)
 thread_local ::experimental::LocalDFBInterface g_dfb_interface[experimental::NUM_DFBS] __attribute__((used));
+#endif
 
 namespace ckernel {
 
@@ -135,23 +135,13 @@ extern "C" uint32_t _start1() {
 
         uint32_t kernel_config_base = launch_msg->kernel_config.kernel_config_base[ProgrammableCoreType::TENSIX];
 
-#if !defined(UCK_CHLKC_MATH)
-        // uint32_t tt_l1_ptr* cb_l1_base =
-        //     (uint32_t tt_l1_ptr*)(kernel_config_base + launch_msg->kernel_config.local_cb_offset);
-        // uint32_t local_cb_mask = launch_msg->kernel_config.local_cb_mask;
-        // setup_local_cb_read_write_interfaces<cb_init_read, cb_init_write, cb_init_write>(cb_l1_base, 0,
-        // local_cb_mask);
 
-        // cb_l1_base = (uint32_t tt_l1_ptr*)(kernel_config_base + launch_msg->kernel_config.remote_cb_offset);
-        // uint32_t end_cb_index = launch_msg->kernel_config.min_remote_cb_start_index;
-        // // NOC argument is unused
-        // experimental::setup_remote_cb_interfaces<false>(cb_l1_base, end_cb_index, 0, 0, 0, 0);
-#endif
-
+#if defined(UCK_CHLKC_UNPACK) || defined(UCK_CHLKC_PACK)
         uint32_t tt_l1_ptr* dfb_l1_base = (uint32_t tt_l1_ptr*)(MEM_L1_UNCACHED_BASE + kernel_config_base +
                                                                 launch_msg->kernel_config.local_cb_offset);
         uint32_t num_local_dfbs = launch_msg->kernel_config.local_cb_mask;
         experimental::setup_local_dfb_interfaces(dfb_l1_base, num_local_dfbs);
+#endif
 
         rta_l1_base =
             (uint32_t tt_l1_ptr*)(kernel_config_base + launch_msg->kernel_config.rta_offset[hartid].rta_offset);

--- a/tt_metal/hw/inc/experimental/dataflow_buffer.h
+++ b/tt_metal/hw/inc/experimental/dataflow_buffer.h
@@ -14,8 +14,13 @@
 #include "internal/tt-2xx/quasar/overlay/llk_intf_api.hpp"
 #include "experimental/noc.h"
 #else
-#include "api/compute/common_globals.h"
 #include "ckernel_trisc_common.h"
+#ifdef UCK_CHLKC_PACK
+#include "llk_io_pack.h"
+#endif
+#ifdef UCK_CHLKC_UNPACK
+#include "llk_io_unpack.h"
+#endif
 #endif
 
 #include "experimental/lock.h"
@@ -24,116 +29,115 @@ namespace experimental {
 
 class DataflowBuffer {
 public:
-    DataflowBuffer(uint16_t logical_dfb_id) : logical_dfb_id_(logical_dfb_id) {
-        LocalDFBInterface& local_dfb_interface = g_dfb_interface[logical_dfb_id];
-        PackedTileCounter packed_tc = local_dfb_interface.packed_tile_counter[0];
-        uint8_t tc_id = get_counter_id(packed_tc);
-        uint8_t tensix_id = get_tensix_id(packed_tc);
-    }
+    DataflowBuffer(uint16_t logical_dfb_id) : local_dfb_interface_(g_dfb_interface[logical_dfb_id]), logical_dfb_id_(logical_dfb_id) {}
 
-    uint32_t get_entry_size() const { return g_dfb_interface[logical_dfb_id_].entry_size; }
+    uint16_t get_id() const { return logical_dfb_id_; }
+
+    uint32_t get_entry_size() const { return local_dfb_interface_.entry_size; }
 
     // Explicit sync APIs
     void reserve_back(uint16_t num_entries) {
         ASSERT(num_entries == 1);
-        PackedTileCounter packed_tc = g_dfb_interface[logical_dfb_id_].packed_tile_counter[counter_idx_];
+        PackedTileCounter packed_tc = local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].packed_tile_counter;
         uint8_t tc_id = get_counter_id(packed_tc);
-#ifdef COMPILE_FOR_TRISC
-        // PACK({DPRINT << "reserve_back: tc_id: " << static_cast<uint32_t>(tc_id) << " capacity: " << static_cast<uint32_t>(tile_counters[tc_id].f.buf_capacity) << ENDL();})
-        PACK({
-            uint16_t entries_freed;
-            do {
-                entries_freed = tile_counters[tc_id].f.acked;
-            } while (entries_freed < num_entries);
-        })
-#else
+#if defined(COMPILE_FOR_TRISC) && defined(UCK_CHLKC_PACK)
+        llk_wait_for_free_tiles(logical_dfb_id_, num_entries);
+        // DPRINT << "reserve_back: tc_id: " << static_cast<uint32_t>(tc_id) << " acked: " << static_cast<uint32_t>(tile_counters[tc_id].f.acked) << ENDL();
+        // PACK({
+        //     uint16_t entries_freed;
+        //     do {
+        //         entries_freed = tile_counters[tc_id].f.acked;
+        //     } while (entries_freed < num_entries);
+        // })
+#elif !defined(COMPILE_FOR_TRISC)
         uint8_t tensix_id = get_tensix_id(packed_tc);
         while (llk_intf_get_free_space(tensix_id, tc_id) < num_entries);
+        // DPRINT << "reserve_back: tc_id: " << static_cast<uint32_t>(tc_id) << " free space: " << static_cast<uint32_t>(llk_intf_get_free_space(tensix_id, tc_id)) << ENDL();
 #endif
     }
 
     void push_back(uint16_t num_entries) {
         ASSERT(num_entries == 1);
-        LocalDFBInterface& local_dfb_interface = g_dfb_interface[logical_dfb_id_];
-        PackedTileCounter packed_tc = local_dfb_interface.packed_tile_counter[counter_idx_];
+        PackedTileCounter packed_tc = local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].packed_tile_counter;
         uint8_t tc_id = get_counter_id(packed_tc);
-#ifdef COMPILE_FOR_TRISC
-        // PACK({DPRINT << "push_bak: tc_id: " << static_cast<uint32_t>(tc_id) << " posted: " << static_cast<uint32_t>(tile_counters[tc_id].f.posted) << ENDL();})
-        PACK({
-            tile_counters[tc_id].f.posted = num_entries;
-            local_dfb_interface.wr_ptr[counter_idx_] += (num_entries * local_dfb_interface.stride_size);
-            // DPRINT << "push_back: updated wr_ptr: " << local_dfb_interface.wr_ptr[counter_idx_] << ENDL();
-            if (local_dfb_interface.wr_ptr[counter_idx_] == local_dfb_interface.limit[counter_idx_]) {
-                local_dfb_interface.wr_ptr[counter_idx_] = local_dfb_interface.base_addr[counter_idx_];
-            }
+#if defined(COMPILE_FOR_TRISC) && defined(UCK_CHLKC_PACK)
+        llk_push_tiles(logical_dfb_id_, num_entries);
+        // DPRINT << "push_bak: tc_id: " << static_cast<uint32_t>(tc_id) << " posted: " << static_cast<uint32_t>(tile_counters[tc_id].f.posted) << ENDL();
+        // PACK({
+        //     tile_counters[tc_id].f.posted = num_entries;
+        //     local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].wr_ptr += (num_entries * local_dfb_interface_.stride_size);
+        //     if (local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].wr_ptr == local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].limit) {
+        //         local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].wr_ptr = local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].base_addr;
+        //     }
 
-            counter_idx_ = (counter_idx_ + 1) % local_dfb_interface.num_tcs_to_rr;
-            // DPRINT << "push_back: updated counter_idx: " << (uint32_t)counter_idx_ << ENDL();
-        })
-#else
+        //     local_dfb_interface_.tc_idx = (local_dfb_interface_.tc_idx + 1) % local_dfb_interface_.num_tcs_to_rr;
+        // })
+#elif !defined(COMPILE_FOR_TRISC)
         uint8_t tensix_id = get_tensix_id(packed_tc);
         llk_intf_inc_posted(tensix_id, tc_id, num_entries);
         // DPRINT << "push_back: tensix_id: " << static_cast<uint32_t>(tensix_id) << " tc_id: " << static_cast<uint32_t>(tc_id) << " capacity: "
         //         << static_cast<uint32_t>(llk_intf_get_capacity(tensix_id, tc_id))
         //         << " posted: " << static_cast<uint32_t>(llk_intf_get_posted(tensix_id, tc_id)) << ENDL();
 
-        local_dfb_interface.wr_ptr[counter_idx_] += (num_entries * local_dfb_interface.stride_size);
-        if (local_dfb_interface.wr_ptr[counter_idx_] == local_dfb_interface.limit[counter_idx_]) {
-            local_dfb_interface.wr_ptr[counter_idx_] = local_dfb_interface.base_addr[counter_idx_];
+        local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].wr_ptr += (num_entries * local_dfb_interface_.stride_size);
+        if (local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].wr_ptr == local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].limit) {
+            local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].wr_ptr = local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].base_addr;
         }
 
-        counter_idx_ = (counter_idx_ + 1) % local_dfb_interface.num_tcs_to_rr;
+        local_dfb_interface_.tc_idx = (local_dfb_interface_.tc_idx + 1) % local_dfb_interface_.num_tcs_to_rr;
 #endif
     }
 
     void wait_front(uint16_t num_entries) {
         ASSERT(num_entries == 1);
-        PackedTileCounter packed_tc = g_dfb_interface[logical_dfb_id_].packed_tile_counter[counter_idx_];
+        PackedTileCounter packed_tc = local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].packed_tile_counter;
         uint8_t tc_id = get_counter_id(packed_tc);
-#ifdef COMPILE_FOR_TRISC
-        // UNPACK({DPRINT << "wait_front: tc_id: " << static_cast<uint32_t>(tc_id) << " capacity: " << static_cast<uint32_t>(tile_counters[tc_id].f.buf_capacity) << ENDL();})
-        UNPACK({
-            uint16_t entries_received;
-            do {
-                entries_received = tile_counters[tc_id].f.posted;
-            } while (entries_received < num_entries);
-        })
-#else
+#if defined(COMPILE_FOR_TRISC) && defined(UCK_CHLKC_UNPACK)
+        llk_wait_tiles(logical_dfb_id_, num_entries);
+        // DPRINT << "wait_front: tc_id: " << static_cast<uint32_t>(tc_id)
+        //        << " capacity: " << static_cast<uint32_t>(tile_counters[tc_id].f.buf_capacity)
+        //        << " posted: " << static_cast<uint32_t>(tile_counters[tc_id].f.posted) << ENDL();
+
+        // UNPACK({
+        //     uint16_t entries_received;
+        //     do {
+        //         entries_received = tile_counters[tc_id].f.posted;
+        //     } while (entries_received < num_entries);
+        // })
+#elif !defined(COMPILE_FOR_TRISC)
         uint8_t tensix_id = get_tensix_id(packed_tc);
+        while (llk_intf_get_occupancy(tensix_id, tc_id) < num_entries);
         // DPRINT << "wait_front: tensix_id: " << static_cast<uint32_t>(tensix_id)
         //        << " capacity: " << static_cast<uint32_t>(llk_intf_get_capacity(tensix_id, tc_id))
         //        << " tc_id: " << static_cast<uint32_t>(tc_id)
         //        << " occupancy: " << static_cast<uint32_t>(llk_intf_get_occupancy(tensix_id, tc_id)) << ENDL();
-        while (llk_intf_get_occupancy(tensix_id, tc_id) < num_entries);
 #endif
     }
 
     void pop_front(uint16_t num_entries) {
         ASSERT(num_entries == 1);
-        LocalDFBInterface& local_dfb_interface = g_dfb_interface[logical_dfb_id_];
-        PackedTileCounter packed_tc = local_dfb_interface.packed_tile_counter[counter_idx_];
+        PackedTileCounter packed_tc = local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].packed_tile_counter;
         uint8_t tc_id = get_counter_id(packed_tc);
-#ifdef COMPILE_FOR_TRISC
-        UNPACK({
-            tile_counters[tc_id].f.acked = num_entries;
-            local_dfb_interface.rd_ptr[counter_idx_] += (num_entries * local_dfb_interface.stride_size);
-            // DPRINT << "pop_front: updated rd_ptr: " << local_dfb_interface.rd_ptr[counter_idx_] << ENDL();
-            if (local_dfb_interface.rd_ptr[counter_idx_] == local_dfb_interface.limit[counter_idx_]) {
-                local_dfb_interface.rd_ptr[counter_idx_] = local_dfb_interface.base_addr[counter_idx_];
-            }
-            counter_idx_ = (counter_idx_ + 1) % local_dfb_interface.num_tcs_to_rr;
-            // DPRINT << "pop_front: updated counter_idx: " << (uint32_t)counter_idx_ << ENDL();
-        })
-#else
+#if defined(COMPILE_FOR_TRISC) && defined(UCK_CHLKC_UNPACK)
+        llk_pop_tiles(logical_dfb_id_, num_entries);
+        // DPRINT << "pop_front: tc_id: " << static_cast<uint32_t>(tc_id) << " acked: " << static_cast<uint32_t>(tile_counters[tc_id].f.acked) << ENDL();
+        // UNPACK({
+        //     tile_counters[tc_id].f.acked = num_entries;
+        //     local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].rd_ptr += (num_entries * local_dfb_interface_.stride_size);
+        //     if (local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].rd_ptr == local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].limit) {
+        //         local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].rd_ptr = local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].base_addr;
+        //     }
+        //     local_dfb_interface_.tc_idx = (local_dfb_interface_.tc_idx + 1) % local_dfb_interface_.num_tcs_to_rr;
+        // })
+#elif !defined(COMPILE_FOR_TRISC)
         uint8_t tensix_id = get_tensix_id(packed_tc);
         llk_intf_inc_acked(tensix_id, tc_id, num_entries);
-        local_dfb_interface.rd_ptr[counter_idx_] += (num_entries * local_dfb_interface.stride_size);
-        // DPRINT << "pop_front: updated rd_ptr: " << local_dfb_interface.rd_ptr[counter_idx_] << ENDL();
-        if (local_dfb_interface.rd_ptr[counter_idx_] == local_dfb_interface.limit[counter_idx_]) {
-            local_dfb_interface.rd_ptr[counter_idx_] = local_dfb_interface.base_addr[counter_idx_];
+        local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].rd_ptr += (num_entries * local_dfb_interface_.stride_size);
+        if (local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].rd_ptr == local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].limit) {
+            local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].rd_ptr = local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].base_addr;
         }
-        counter_idx_ = (counter_idx_ + 1) % local_dfb_interface.num_tcs_to_rr;
-        // DPRINT << "pop_front: updated counter_idx: " << (uint32_t)counter_idx_ << ENDL();
+        local_dfb_interface_.tc_idx = (local_dfb_interface_.tc_idx + 1) % local_dfb_interface_.num_tcs_to_rr;
+        // DPRINT << "pop_front: free spae: " << (uint32_t)llk_intf_get_free_space(tensix_id, tc_id) << ENDL();
 #endif
     }
     // Explicit sync APIs end
@@ -148,16 +152,15 @@ public:
     // TC)
     // also that there are no interrupts remaining...
     void finish() {
-        LocalDFBInterface& local_dfb_interface = g_dfb_interface[logical_dfb_id_];
         bool all_acked = false;
         while (!all_acked) {
             all_acked = true;
-            for (uint8_t i = 0; i < local_dfb_interface.num_tcs_to_rr; i++) {
-                PackedTileCounter packed_tc = local_dfb_interface.packed_tile_counter[i];
+            for (uint8_t i = 0; i < local_dfb_interface_.num_tcs_to_rr; i++) {
+                PackedTileCounter packed_tc = local_dfb_interface_.tc_slots[i].packed_tile_counter;
                 uint8_t tc_id = get_counter_id(packed_tc);
-#ifdef COMPILE_FOR_TRISC
-                UNPACK({ all_acked = all_acked && (tile_counters[tc_id].f.posted == 0); })
-#else
+#if defined(COMPILE_FOR_TRISC) && defined(UCK_CHLKC_UNPACK)
+                all_acked = all_acked && (ckernel::trisc::tile_counters[tc_id].f.posted == 0);
+#elif !defined(COMPILE_FOR_TRISC)
                 uint8_t tensix_id = get_tensix_id(packed_tc);
                 all_acked &=
                     (fast_llk_intf_read_acked(tensix_id, tc_id) == fast_llk_intf_read_posted(tensix_id, tc_id));
@@ -168,14 +171,12 @@ public:
 
     uint32_t get_write_ptr() const {
         // return byte address (wr_ptr is 16B address on Gen1XX)
-        uint32_t wr_ptr_bytes = g_dfb_interface[logical_dfb_id_].wr_ptr[counter_idx_];
-        return wr_ptr_bytes;
+        return local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].wr_ptr;
     }
 
     uint32_t get_read_ptr() const {
         // return byte address (rd_ptr is 16B address on Gen1XX)
-        uint32_t rd_ptr_bytes = g_dfb_interface[logical_dfb_id_].rd_ptr[counter_idx_];
-        return rd_ptr_bytes;
+        return local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].rd_ptr;
     }
 
     [[nodiscard]] auto scoped_lock() {
@@ -188,12 +189,12 @@ private:
         // TODO: Unregister with the debugger
     }
 
-    uint16_t logical_dfb_id_;
-    uint8_t counter_idx_ = 0;
+    LocalDFBInterface& local_dfb_interface_;
 
+    uint16_t logical_dfb_id_;
+    uint32_t txn_id_loop_cnt_ = 0;  // try to remove this
     // TODO: update txn id isr handling
     uint8_t txn_id_index_ = 0;
-    uint32_t txn_id_loop_cnt_ = 0;  // try to remove this
 };
 
 #ifndef COMPILE_FOR_TRISC

--- a/tt_metal/hw/inc/internal/dataflow_buffer_interface.h
+++ b/tt_metal/hw/inc/internal/dataflow_buffer_interface.h
@@ -113,46 +113,43 @@ struct dfb_initializer_intra_tensix_t {  // 24 bytes
     uint8_t tensix_mask;
 } __attribute__((packed));
 
+// Per–tile-counter slot
+struct DFBTCSlot {
+    uint32_t rd_ptr;
+    uint32_t wr_ptr;
+    uint32_t base_addr;
+    uint32_t limit;
+    PackedTileCounter packed_tile_counter;
+} __attribute__((packed));
+
 // on WH/BH arrays will be sized to 1
 struct LocalDFBInterface {
-    uint32_t rd_ptr[MAX_NUM_TILE_COUNTERS_TO_RR];
-    uint32_t wr_ptr[MAX_NUM_TILE_COUNTERS_TO_RR];
-    uint32_t base_addr[MAX_NUM_TILE_COUNTERS_TO_RR];
-    uint32_t limit[MAX_NUM_TILE_COUNTERS_TO_RR];
+    DFBTCSlot tc_slots[MAX_NUM_TILE_COUNTERS_TO_RR];
 
     uint32_t entry_size;   // shared across riscs so can be factored out and put into sep initialization struct
     uint32_t stride_size;  // shared across riscs so can be factored out and put into sep initialization struct
 
-    PackedTileCounter packed_tile_counter[MAX_NUM_TILE_COUNTERS_TO_RR];
+    // Entry indices tracking how many entries from DFB base the rd/wr pointers are
+    uint32_t rd_entry_idx;
+    uint32_t wr_entry_idx;
+    uint32_t wr_entry_ptr;
+
     uint8_t txn_ids[NUM_TXN_IDS];  // shared across riscs so can be factored out and put into sep initialization struct
     uint8_t
         num_entries_per_txn_id;  // shared across riscs so can be factored out and put into sep initialization struct
     uint8_t num_entries_per_txn_id_per_tc;  // shared across riscs so can be factored out and put into sep
                                             // initialization struct
-    uint8_t remapper_pair_index;
     uint8_t num_tcs_to_rr;
     uint8_t num_txn_ids;  // shared across riscs so can be factored out and put into sep initialization struct
+    uint8_t tc_idx;
 
-    uint8_t padding[3];
 
-    // #ifndef ARCH_QUASAR
-    //     // used by packer for in-order packing ... is this still needed on Quasar?
-    //     uint32_t wr_tile_ptr;
-
-    //     // Save a cycle during init by writing 0 to the uint32 below
-    //     union {
-    //         uint32_t tiles_acked_received_init;
-    //         struct {
-    //             uint16_t tiles_acked;
-    //             uint16_t tiles_received;
-    //         };
-    //     };
-    // #endif
 } __attribute__((packed));
 
+static_assert(sizeof(DFBTCSlot) == 17, "DFBTCSlot size is incorrect");
 static_assert(sizeof(dfb_initializer_t) == 24, "dfb_initializer_t size is incorrect");
 static_assert(sizeof(dfb_initializer_per_risc_t) == 44, "dfb_initializer_per_risc_t size is incorrect");
 static_assert(sizeof(dfb_initializer_intra_tensix_t) == 24, "dfb_initializer_intra_tensix_t size is incorrect");
-static_assert(sizeof(LocalDFBInterface) == 88, "LocalDFBInterface size is incorrect");
+static_assert(sizeof(LocalDFBInterface) == 97, "LocalDFBInterface size is incorrect");
 
 }  // namespace experimental

--- a/tt_metal/impl/dataflow_buffer/dataflow_buffer.cpp
+++ b/tt_metal/impl/dataflow_buffer/dataflow_buffer.cpp
@@ -42,7 +42,7 @@ void BindDataflowBufferToProducerConsumerKernels(Program& program, uint32_t dfb_
     TT_FATAL(producer_kernel != nullptr, "Producer kernel not found");
     TT_FATAL(consumer_kernel != nullptr, "Consumer kernel not found");
 
-    if (auto compute_producer = std::dynamic_pointer_cast<ComputeKernel>(producer_kernel)) {
+    if (auto compute_producer = std::dynamic_pointer_cast<experimental::quasar::QuasarComputeKernel>(producer_kernel)) {
         TT_FATAL(dfb->config.num_producers == 1, "Only one Tensix is supported for now");
         dfb->config.producer_risc_mask = ::experimental::TENSIX_RISC_OFFSET;
     } else if (auto dm_producer = std::dynamic_pointer_cast<experimental::quasar::QuasarDataMovementKernel>(producer_kernel)) {
@@ -54,7 +54,7 @@ void BindDataflowBufferToProducerConsumerKernels(Program& program, uint32_t dfb_
         TT_FATAL(false, "Unsupported kernel type");
     }
 
-    if (auto compute_consumer = std::dynamic_pointer_cast<ComputeKernel>(consumer_kernel)) {
+    if (auto compute_consumer = std::dynamic_pointer_cast<experimental::quasar::QuasarComputeKernel>(consumer_kernel)) {
         TT_FATAL(dfb->config.num_consumers == 1, "Only one Tensix is supported for now");
         dfb->config.consumer_risc_mask = ::experimental::TENSIX_RISC_OFFSET;
     } else if (auto dm_consumer = std::dynamic_pointer_cast<experimental::quasar::QuasarDataMovementKernel>(consumer_kernel)) {
@@ -366,6 +366,7 @@ uint32_t ProgramImpl::add_dataflow_buffer(const CoreRangeSet& core_range_set, co
     TT_FATAL(config.num_entries > 0, "Num entries must be > 0");
 
     TT_FATAL(config.pap != ::experimental::AccessPattern::BLOCKED, "Blocked producer pattern not supported");
+
     TT_FATAL(!config.enable_implicit_sync, "Implicit sync not supported yet");
     TT_FATAL(
         core_range_set.num_cores() == 1,


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/38044

### What's changed
Uplifting datacopy and bmm tests to use DFB interfaces rather than CBs. 

Note there will be some modifications in initializing buffer descriptors when there are multiple tensix producers/consumers. This will be done in a separate pr that has focused tests on these cases 

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=abhullar/integrate-dfb)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:abhullar/integrate-dfb)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=abhullar/integrate-dfb)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:abhullar/integrate-dfb)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=abhullar/integrate-dfb)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:abhullar/integrate-dfb)
- [ ] New/Existing tests provide coverage for changes