### PR TITLE
Allow setup/teardown of fast-dispatch mode from Python

### DIFF
--- a/tests/ttnn/unit_tests/base_functionality/test_device.py
+++ b/tests/ttnn/unit_tests/base_functionality/test_device.py
@@ -2,7 +2,6 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
-import os
 import pytest
 
 import ttnn

--- a/tests/ttnn/unit_tests/base_functionality/test_device.py
+++ b/tests/ttnn/unit_tests/base_functionality/test_device.py
@@ -64,8 +64,16 @@ def test_worker_l1_fail(device, layout, dtype):
         )
 
 
-def test_dispatch_context_init_and_terminate(mesh_device):
-    if os.environ.get("TT_METAL_SLOW_DISPATCH_MODE") != "1":
-        pytest.skip("Test requires Slow Dispatch mode (TT_METAL_SLOW_DISPATCH_MODE=1)")
-    ttnn.device.initialize_fast_dispatch(mesh_device)
-    ttnn.device.terminate_fast_dispatch(mesh_device)
+@pytest.mark.requires_fast_runtime_mode_off
+@pytest.mark.parametrize("layout", [ttnn.TILE_LAYOUT])
+@pytest.mark.parametrize("dtype", [ttnn.bfloat16])
+def test_dispatch_context_init_and_terminate(mesh_device, dtype, layout):
+    tensor = torch.rand((1, 1, 32, 1024), dtype=torch.bfloat16)
+    core_grid = ttnn.CoreGrid(y=1, x=1)
+    memory_config = ttnn.create_sharded_memory_config(tensor.shape, core_grid, ttnn.ShardStrategy.BLOCK)
+    ttnn_tensor = ttnn.from_torch(tensor, dtype=dtype, layout=layout)
+
+    with ttnn.device.setup_fast_dispatch(mesh_device):
+        ttnn_tensor = ttnn.to_device(ttnn_tensor, mesh_device, memory_config=memory_config).cpu()
+
+    assert ttnn_tensor.shape == tensor.shape

--- a/tests/ttnn/unit_tests/base_functionality/test_device.py
+++ b/tests/ttnn/unit_tests/base_functionality/test_device.py
@@ -2,6 +2,7 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
+import os
 import pytest
 
 import ttnn
@@ -61,3 +62,10 @@ def test_worker_l1_fail(device, layout, dtype):
             device,
             memory_config=memory_config,
         )
+
+
+def test_dispatch_context_init_and_terminate(mesh_device):
+    if os.environ.get("TT_METAL_SLOW_DISPATCH_MODE") != "1":
+        pytest.skip("Test requires Slow Dispatch mode (TT_METAL_SLOW_DISPATCH_MODE=1)")
+    ttnn.device.initialize_fast_dispatch(mesh_device)
+    ttnn.device.terminate_fast_dispatch(mesh_device)

--- a/tt_metal/distributed/dispatch_context.cpp
+++ b/tt_metal/distributed/dispatch_context.cpp
@@ -54,7 +54,6 @@ void DispatchContext::initialize_fast_dispatch(distributed::MeshDevice* mesh_dev
     }
     // Query the number of command queues requested
     device_manager->initialize_dispatch_firmware(/*force_recreate_topology=*/true);
-    tt::tt_metal::MetalContext::instance().rtoptions().set_fast_dispatch(fast_dispatch_enabled_);
 
     auto& mesh_device_impl = mesh_device->impl();
     mesh_device_impl.mesh_command_queues_.clear();

--- a/tt_metal/impl/device/device_manager.cpp
+++ b/tt_metal/impl/device/device_manager.cpp
@@ -503,6 +503,24 @@ void DeviceManager::initialize_dispatch_firmware(bool force_recreate_topology) {
     init_done_.erase(DispatchKernelInitializer::key);
     if (force_recreate_topology) {
         reset_dispatch_topology();
+        // Recreate the initializer after reset (it was erased so that topology can be recreated for FD).
+        auto dispatch_kernel_initializer = std::make_unique<DispatchKernelInitializer>(
+            descriptor_,
+            MetalContext::instance().get_dispatch_core_manager(),
+            this,
+            []() -> tt::tt_fabric::ControlPlane& { return MetalContext::instance().get_control_plane(); },
+            []() -> const tt::tt_metal::DispatchQueryManager& {
+                return MetalContext::instance().get_dispatch_query_manager();
+            },
+            [this]() { return static_cast<uint32_t>(this->get_max_num_eth_cores_across_all_devices()); },
+            [](ChipId id) {
+                auto& s = MetalContext::instance().dprint_server();
+                return s && s.get() && s->reads_dispatch_cores(id);
+            });
+        if (!active_devices.empty()) {
+            dispatch_kernel_initializer->populate_fd_kernels_only(active_devices);
+        }
+        initializers_[DispatchKernelInitializer::key] = std::move(dispatch_kernel_initializer);
     }
     initializers_[DispatchKernelInitializer::key]->init(active_devices, init_done_);
     initializers_[DispatchKernelInitializer::key]->configure();

--- a/tt_metal/impl/device/device_manager.cpp
+++ b/tt_metal/impl/device/device_manager.cpp
@@ -503,7 +503,8 @@ void DeviceManager::initialize_dispatch_firmware(bool force_recreate_topology) {
     init_done_.erase(DispatchKernelInitializer::key);
     if (force_recreate_topology) {
         reset_dispatch_topology();
-        // Recreate the initializer after reset (it was erased so that topology can be recreated for FD).
+        // Create the initializer from scratch if this is the first time FD is being dynamically initialized.
+        // Or recreate the initializer after reset (it was erased so that topology can be recreated for FD).
         auto dispatch_kernel_initializer = std::make_unique<DispatchKernelInitializer>(
             descriptor_,
             MetalContext::instance().get_dispatch_core_manager(),

--- a/ttnn/cpp/ttnn-nanobind/device.cpp
+++ b/ttnn/cpp/ttnn-nanobind/device.cpp
@@ -367,6 +367,26 @@ void device_module(nb::module_& m_device) {
             >>> import ttnn
             >>> ttnn.device.ClearKernelCache()
     )doc");
+    m_device.def(
+        "initialize_fast_dispatch",
+        [](MeshDevice* device) { tt::tt_metal::experimental::DispatchContext::get().initialize_fast_dispatch(device); },
+        nb::arg("device").noconvert(),
+        R"doc(
+        Dynamically enable Fast Dispatch on a MeshDevice that was opened in Slow Dispatch mode.
+
+        Args:
+            device (ttnn.Device): The mesh device to enable Fast Dispatch on.
+    )doc");
+    m_device.def(
+        "terminate_fast_dispatch",
+        [](MeshDevice* device) { tt::tt_metal::experimental::DispatchContext::get().terminate_fast_dispatch(device); },
+        nb::arg("device").noconvert(),
+        R"doc(
+        Disable Fast Dispatch on a MeshDevice, returning it to Slow Dispatch mode.
+
+        Args:
+            device (ttnn.Device): The mesh device to disable Fast Dispatch on.
+    )doc");
     m_device.def("EnableMemoryReports", &tt::tt_metal::detail::EnableMemoryReports, R"doc(
         Enables tt-metal to generate reports of memory allocation statistics
     )doc");

--- a/ttnn/ttnn/device.py
+++ b/ttnn/ttnn/device.py
@@ -210,6 +210,9 @@ EnableMemoryReports = ttnn._ttnn.device.EnableMemoryReports
 DisableMemoryReports = ttnn._ttnn.device.DisableMemoryReports
 DeallocateBuffers = ttnn._ttnn.device.deallocate_buffers
 
+initialize_fast_dispatch = ttnn._ttnn.device.initialize_fast_dispatch
+terminate_fast_dispatch = ttnn._ttnn.device.terminate_fast_dispatch
+
 
 @contextlib.contextmanager
 def manage_device(device_id: int) -> "ttnn.device.Device":

--- a/ttnn/ttnn/device.py
+++ b/ttnn/ttnn/device.py
@@ -210,9 +210,6 @@ EnableMemoryReports = ttnn._ttnn.device.EnableMemoryReports
 DisableMemoryReports = ttnn._ttnn.device.DisableMemoryReports
 DeallocateBuffers = ttnn._ttnn.device.deallocate_buffers
 
-initialize_fast_dispatch = ttnn._ttnn.device.initialize_fast_dispatch
-terminate_fast_dispatch = ttnn._ttnn.device.terminate_fast_dispatch
-
 
 @contextlib.contextmanager
 def manage_device(device_id: int) -> "ttnn.device.Device":
@@ -237,6 +234,37 @@ def manage_device(device_id: int) -> "ttnn.device.Device":
         yield device
     finally:
         close_device(device)
+
+
+initialize_fast_dispatch = ttnn._ttnn.device.initialize_fast_dispatch
+terminate_fast_dispatch = ttnn._ttnn.device.terminate_fast_dispatch
+
+
+@contextlib.contextmanager
+def setup_fast_dispatch(device):
+    """
+    Context manager that enables Fast Dispatch for the duration of the block.
+    The device must have been opened in Slow Dispatch mode (e.g. TT_METAL_SLOW_DISPATCH_MODE=1).
+    On exit, Fast Dispatch is terminated and the device returns to Slow Dispatch.
+
+    Args:
+        device: The device to enable Fast Dispatch on.
+
+    Yields:
+        None: Use the device inside the block; it is in Fast Dispatch mode.
+
+    Example:
+        >>> mesh_device = ttnn.open_mesh_device(ttnn.MeshShape(1, 1))
+        >>> with ttnn.device.setup_fast_dispatch(mesh_device):
+        ...     # issue writes or other FD operations
+        ...     pass
+        >>> # FD terminated; device is back in Slow Dispatch
+    """
+    initialize_fast_dispatch(device)
+    try:
+        yield
+    finally:
+        terminate_fast_dispatch(device)
 
 
 def dump_device_memory_state(device, prefix=""):


### PR DESCRIPTION
### Summary
This change allows for users to switch between slow and fast dispatch in Python by binding the underlying fast-dispatch setup/teardown. This also includes a fix for a regression affecting the setup/teardown that was introduced in https://github.com/tenstorrent/tt-metal/commit/cbcf0caab6254ff08de3ff4d353f324d5573e623.

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=esmal/toggle-fd)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:esmal/toggle-fd)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=esmal/toggle-fd)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:esmal/toggle-fd)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=esmal/toggle-fd)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:esmal/toggle-fd)
- [x] New/Existing tests provide coverage for changes