### PR TITLE
Adapt fused MoE kernel from DeepSeek to GPT-OSS dimensions

### DIFF
--- a/docs/moe_gpt_gpt_oss_integration.md
+++ b/docs/moe_gpt_gpt_oss_integration.md
@@ -1,0 +1,220 @@
+# GPT-OSS Fused MoE Compute Kernel (`moe_gpt`) — Integration Guide
+
+## Overview
+
+This document describes the fused MoE compute kernel adapted from DeepSeek for GPT-OSS.
+The kernel performs the full expert computation (W0/W1 matmul → SwiGLU activation → ring
+All-to-All → W2 matmul) in a single fused operation across 12 cores on a single chip.
+
+The next step is integrating this kernel with `all_to_all_dispatch` and `all_to_all_combine`
+ops to run the full multi-chip GPT-OSS MoE layer.
+
+## GPT-OSS vs DeepSeek Dimensions
+
+| Parameter | DeepSeek | GPT-OSS |
+|---|---|---|
+| hidden_dim (K) | 7168 | 2880 |
+| intermediate_dim (N) | 2048 | 2880 |
+| experts per device (E) | 2 | 4 |
+| K tiles (K/32) | 224 | 90 |
+| N tiles (N/32) | 64 | 90 |
+| W0/W1 shape per expert | [7168, 2048] | [2880, 2880] |
+| W2 shape per expert | [2048, 7168] | [2880, 2880] |
+
+Key difference: GPT-OSS has **symmetric** weight matrices (K == N == 2880), so W0/W1
+and W2 have identical tile distributions across cores.
+
+## Architecture
+
+### Kernel Structure (3 RISC-V cores per Tensix)
+
+1. **dm0** (BRISC/RISCV_1, NOC_0): Reads W0/W1 and W2 weights from DRAM.
+   Triple-buffered pipeline with transaction IDs.
+
+2. **dm1** (NCRISC/RISCV_0, NOC_1): Handles ring All-to-All data movement.
+   Sends intermediate results to neighbor cores via NOC1 posted writes.
+   Uses semaphore-based signaling for synchronization.
+
+3. **compute** (TRISC): Performs matmul + SwiGLU activation + matmul.
+   - Phase 1: `input @ [W0, W1]` → SwiGLU activation → intermediate result
+   - Phase 2: `intermediate @ W2` → output (written in-place to input buffer)
+
+### Ring All-to-All (A2A)
+
+- 12 cores form a ring ordered by physical NOC1 coordinates (descending y, descending x)
+- Each core computes its local intermediate result, then rotates it around the ring
+- 2 A2A iterations × 12 steps = 24 rotations per expert
+- 2 NOC packets per step (4 tiles × 2048 bytes = 8192 bytes each)
+- 6-buffer cycling scheme (buffers 0..5) with 5 steps of slack before overwrite
+- Semaphore-based synchronization: predecessor writes semaphore value to signal data readiness
+
+### Activation: SwiGLU
+
+```
+gate_clamped = clamp(gate, max=7.0)
+up_clamped   = clamp(up, min=-7.0, max=7.0)
+result       = (up_clamped + 1) * gate_clamped * sigmoid(1.702 * gate_clamped)
+```
+
+Implemented as an SFPU kernel running on the PACK thread (`swiglu_sfpu.h`).
+
+## Key Constants (moe_gpt_ring_common.h)
+
+| Constant | Value | Derivation |
+|---|---|---|
+| NUM_CORES | 12 | DRAM banks on Wormhole |
+| NUM_W0_W1_TILES_H | 90 | K/32 = 2880/32 |
+| NUM_W2_TILES_H | 90 | N/32 = 2880/32 |
+| W0_W1_TILES_PER_TXN | 10 | Largest factor of 90 fitting 8KB NOC packet |
+| W2_TILES_PER_TXN | 10 | Same |
+| IN2_TILES_PER_STEP | 8 | max(tiles per core) = max(7,8) |
+| NUM_A2A_ITERS | 2 | max(W2_TILES_PER_CORE) / 4 = 8/4 |
+| W2_BLOCKS_PER_EXPERT | 36 | w2_blocks_per_four_mm2_tile × NUM_A2A_ITERS = 18×2 |
+
+Tile distribution across 12 cores (90/12 = 7.5):
+- Cores {0,1,4,5,8,9}: 8 tiles (FULL_CORES)
+- Cores {2,3,6,7,10,11}: 7 tiles (PAD_CORES)
+
+This distribution applies to BOTH W0/W1 width and W2 width since K == N.
+
+## Performance
+
+| Metric | Value |
+|---|---|
+| Total kernel time (4 experts) | 272.7 μs |
+| Per expert | 68.2 μs |
+| DRAM data per core per expert | 1.24 MB |
+| DRAM theoretical minimum | 51.8 μs/expert |
+| DRAM BW utilization | 76% |
+| Accuracy (PCC) | ~0.990 (threshold 0.984) |
+
+## File Inventory
+
+### Kernel files (`ttnn/cpp/ttnn/operations/experimental/moe_gpt/device/kernels/`)
+
+| File | Description |
+|---|---|
+| `moe_gpt_ring_common.h` | Dimension constants, tile distribution lookup tables |
+| `compute.cpp` | Matmul + SwiGLU + matmul compute kernel |
+| `dm0.cpp` | DRAM weight reader (BRISC, NOC_0) |
+| `dm1.cpp` | Ring A2A data movement (NCRISC, NOC_1) |
+| `swiglu_sfpu.h` | SwiGLU SFPU implementation (from `origin/sraizada/gpt-oss-swiglu`) |
+
+### Host files (`ttnn/cpp/ttnn/operations/experimental/moe_gpt/device/`)
+
+| File | Description |
+|---|---|
+| `moe_gpt_program_factory.cpp` | CB allocation, kernel creation, runtime args setup |
+
+### Test files
+
+| File | Description |
+|---|---|
+| `tests/ttnn/nightly/unit_tests/operations/experimental/test_moe_gpt.py` | Full test with tensor preparation and accuracy checks |
+| `run_moe_gpt_test.py` | Standalone test runner (bypasses conftest.py hook issue) |
+| `run_moe_gpt_profile.py` | Tracy profiling script |
+
+## Weight Tensor DRAM Layout
+
+### W0/W1 (interleaved)
+
+Shape per DRAM bank: `(L, E, groups_per_core, K, 4×TILE_SIZE)` in tiles.
+
+- `groups_per_core = 4` (8 max tiles / 2 per group)
+- Each group contains 2 paired column tiles: [w0_col_i, w1_col_i, w0_col_j, w1_col_j]
+- DRAM stride between experts: `w0_w1_total_size_per_expert = 2 × 90 × 8 × 576 bytes`
+- Cores with 7 tiles have their 8th tile padded with zeros
+
+### W2
+
+Shape per DRAM bank: `(L, E, 2, N, 4×TILE_SIZE)` in tiles.
+
+- 2 groups of 4 output tiles each (8 max tiles / 4 per group)
+- N tiles are reordered per core to match ring A2A rotation order
+- DRAM stride: `w2_total_size_per_expert = 90 × 8 × 576 bytes`
+- Cores with 7 tiles have group 2 padded to 4 tiles
+
+### Input/Output (sharded L1)
+
+Shape: `(num_cores, E, M, K)` with `shard_shape = (E×M, K) = (128, 2880)`.
+
+- HEIGHT_SHARDED in L1, one shard per core
+- Output is written in-place to the input tensor
+- Each expert's result occupies `NUM_W0_W1_TILES_H = 90` tile rows
+
+## Circular Buffer Layout
+
+| CB | Index | Format | Tiles | Bytes | Purpose |
+|---|---|---|---|---|---|
+| cb_r2c_w0 | c_0 | Bfp4_b | 60 | 34,560 | Triple-buffered weight read (aliased as cb_r2c_w2) |
+| cb_s2c_in | c_1 | Float16_b | 360 | 737,280 | Sharded input (aliased as cb_c2s_out for output) |
+| cb_c2w_rdy | c_2 | Float32 | 1 | 4 | Compute→dm1 ready signal |
+| cb_w2c_rdy | c_3 | Float32 | 1 | 4 | dm1→compute ready signal |
+| cb_s2c_in2 | c_4 | Float16_b | 48 | 98,304 | A2A intermediate data (6 buffers × 8 tiles) |
+
+Total L1 per core: ~530 KB (fits in 1.2 MB L1).
+
+## Known Issues and Design Decisions
+
+### Semaphore Reset for Program Caching
+
+The ring semaphore must be explicitly reset to 0 at the start of dm1's `kernel_main()`:
+```cpp
+noc_semaphore_set(my_semaphore_ptr, 0);
+uint32_t semaphore_value = 0;
+```
+Without this, cached program invocations inherit stale semaphore values and deadlock
+intermittently. This was the root cause of 3/20 failure rate before the fix.
+
+### Cross-Expert Boundary Barrier
+
+After each expert's ring loop completes, dm1 waits for the predecessor's final A2A write
+(which targets buf 0) before signaling compute to proceed with the next expert's SwiGLU.
+This prevents the next expert's output from overwriting buf 0 while the predecessor is
+still writing to it.
+
+### Double Flush in dm1
+
+There are two `noc_async_posted_writes_flushed()` calls per A2A step:
+1. After data packets, before semaphore write — **required** (data must land before signal)
+2. After semaphore write — potentially removable for optimization
+
+### conftest.py Hook Issue
+
+The root `conftest.py` has a broken `pytest_handlecrashitem` hook that prevents pytest
+from running. Workaround: use standalone scripts (`run_moe_gpt_test.py`, `run_moe_gpt_profile.py`)
+that import the test functions directly.
+
+## Integration with all_to_all_dispatch / all_to_all_combine
+
+### Expected Data Flow (Multi-Chip)
+
+```
+all_to_all_dispatch  →  moe_gpt (fused expert compute)  →  all_to_all_combine
+[distribute tokens]     [W0/W1 → SwiGLU → A2A → W2]       [gather results]
+```
+
+### Input Contract
+
+`moe_gpt` expects:
+- **input**: HEIGHT_SHARDED L1 tensor, shape `(num_cores, E, M, K)`, dtype Float16_b
+- **w0_w1**: HEIGHT_SHARDED DRAM tensor, prepared by `prepare_w0_w1_tensor()`
+- **w2**: HEIGHT_SHARDED DRAM tensor, prepared by `prepare_w2_tensor()`
+- **output**: Same tensor as input (in-place)
+
+### Output Contract
+
+- Output is written in-place to the input tensor
+- Shape: `(num_cores, E, M, K_padded)` where K_padded = max_tiles_per_core × 32
+- Use `prepare_output_tensor()` to extract valid tiles per core
+
+### Build System
+
+**MUST build with `./build_metal.sh`**, not `cmake --build build`.
+
+### Profiling
+
+```bash
+source python_env/bin/activate
+python -m tracy -v -r -p -o <output_dir> -a device_kernel_duration -- run_moe_gpt_profile.py
+```

--- a/run_moe_gpt_profile.py
+++ b/run_moe_gpt_profile.py
@@ -1,0 +1,20 @@
+"""Quick profiling script for moe_gpt - run under tracy."""
+import sys
+import ttnn
+import torch
+
+sys.path.insert(0, "/localdev/handrews/tt-metal")
+from tests.ttnn.nightly.unit_tests.operations.experimental.test_moe_gpt import run_test_moe_gpt
+
+device = ttnn.open_device(
+    device_id=0,
+    dispatch_core_config=ttnn.DispatchCoreConfig(ttnn.DispatchCoreType.WORKER, ttnn.DispatchCoreAxis.ROW),
+)
+
+metrics = run_test_moe_gpt(device, M=32, K=2880, N=2880, E=4, L=1, check_accuracy=True, dump_outputs=False)
+
+pccs = [m["pcc"] for m in metrics.values()]
+status = "PASS" if all(p > 0.984 for p in pccs) else "FAIL"
+print(f"Result: {status} | " + " ".join(f"E{i}={p:.4f}" for i, p in enumerate(pccs)))
+
+ttnn.close_device(device)

--- a/run_moe_gpt_test.py
+++ b/run_moe_gpt_test.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+"""Standalone script to run moe_gpt test, bypassing conftest.py hook issue."""
+import ttnn
+
+device = ttnn.open_device(device_id=0)
+
+from tests.ttnn.nightly.unit_tests.operations.experimental.test_moe_gpt import run_test_moe_gpt
+
+accuracy_metrics = run_test_moe_gpt(device, M=32, K=2880, N=2880, E=4, L=1, check_accuracy=True, dump_outputs=False)
+
+passing = True
+for (layer_id, expert_id), metrics in accuracy_metrics.items():
+    pcc = metrics["pcc"]
+    status = "PASS" if pcc >= 0.984 else "FAIL"
+    if status == "FAIL":
+        passing = False
+    print(f"  Layer {layer_id}, Expert {expert_id}: PCC={pcc:.6f} [{status}]")
+
+print(f"\nOverall: {'PASS' if passing else 'FAIL'}")
+
+ttnn.close_device(device)

--- a/tests/ttnn/nightly/unit_tests/operations/experimental/test_moe_gpt.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/test_moe_gpt.py
@@ -1,0 +1,600 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Test for GPT-OSS fused MOE compute kernel (moe_gpt).
+
+Dimensions:
+  M = 32 (sequence length / tokens)
+  K = 2880 (hidden_size) -> 90 tiles
+  N = 2880 (intermediate_size) -> 90 tiles
+  E = 4 (experts per device)
+  L = 1 (layers)
+
+W0/W1: [K, N] = [90, 90] tiles, distributed as 7-8 tiles/core (90/12 = 7.5)
+W2:    [N, K] = [90, 90] tiles, distributed as 7-8 tiles/core (90/12 = 7.5)
+
+Both W0/W1 and W2 have the same distribution since K == N == 2880.
+
+Activation: SwiGLU
+  gate_clamped = clamp(gate, max=7.0)
+  up_clamped   = clamp(up, min=-7.0, max=7.0)
+  result       = (up_clamped + 1) * gate_clamped * sigmoid(1.702 * gate_clamped)
+"""
+
+import itertools
+import math
+import pytest
+import torch
+import ttnn
+from loguru import logger
+
+from models.common.utility_functions import comp_pcc, comp_allclose
+
+from tracy.process_model_log import (
+    get_latest_ops_log_filename,
+    run_device_profiler,
+)
+
+PCC_THRESHOLD = 0.984
+
+# GPT-OSS: Both W0/W1 and W2 distribute 90 tiles across 12 cores (7.5 per core)
+# Boundary-optimized: pairs at [0,1], [4,5], [8,9] get 8 tiles (FULL)
+FULL_CORES = {0, 1, 4, 5, 8, 9}
+PAD_CORES = {2, 3, 6, 7, 10, 11}
+
+# Max tiles per core for W0/W1 (padded)
+MAX_W0_W1_TILES_PER_CORE = 8
+
+
+def tiles_for_core(ring_pos):
+    """Return the number of valid tiles for a core at a given ring position."""
+    return 7 if ring_pos in PAD_CORES else 8
+
+
+def create_torch_input(L, in0_num_cores, E, M, K):
+    """
+    Create torch input tensor with random values.
+
+    Returns:
+        torch_input: Tensor of shape (L, in0_num_cores, E, M, K)
+    """
+    torch_input = torch.rand((L, E, M, K), dtype=torch.bfloat16) - 0.5
+    torch_input = torch_input.unsqueeze(1).repeat(1, in0_num_cores, 1, 1, 1)
+    return torch_input
+
+
+def create_torch_w0(L, E, K, N):
+    """Create torch w0 weight tensor of shape (L, E, K, N)."""
+    return torch.rand((L, E, K, N), dtype=torch.bfloat16) - 0.5
+
+
+def create_torch_w1(L, E, K, N):
+    """Create torch w1 weight tensor of shape (L, E, K, N)."""
+    return torch.rand((L, E, K, N), dtype=torch.bfloat16) - 0.5
+
+
+def create_torch_w2(L, E, N, K):
+    """Create torch w2 weight tensor of shape (L, E, N, K)."""
+    return torch.rand((L, E, N, K), dtype=torch.bfloat16) - 0.5
+
+
+def prepare_w0_w1_tensor(torch_w0, torch_w1, L, E, K, N, ring2cores):
+    """
+    Prepare the w0_w1 tensor by interleaving chunks of w0 and w1 width-wise.
+
+    GPT-OSS: 7-8 tiles/core (90/12 = 7.5), padded to 8.
+    Each core's shard has 4 groups of 2 paired tiles.
+
+    Args:
+        torch_w0: Weight tensor of shape (L, E, K, N)
+        torch_w1: Weight tensor of shape (L, E, K, N)
+        L: Number of layers
+        E: Number of experts
+        K: Input dimension (2880)
+        N: Output dimension (2880)
+        ring2cores: Dictionary mapping ring position to (core_coord, dram_bank_id, pad_flag)
+
+    Returns:
+        torch_w0_w1_paired: Interleaved tensor of shape (12, L, E, 4, K, 128)
+    """
+    num_cores = len(ring2cores)
+    Nt = N // ttnn.TILE_SIZE  # 2880 / 32 = 90 tiles per tensor
+
+    # Reshape to expose chunks: (L, E, K, N) -> (L, E, K, Nt, TILE_SIZE)
+    w0_chunks = torch_w0.view(L, E, K, Nt, ttnn.TILE_SIZE)
+    w1_chunks = torch_w1.view(L, E, K, Nt, ttnn.TILE_SIZE)
+
+    # Stack w0 and w1 chunks together: (L, E, K, Nt, 2, TILE_SIZE)
+    # This puts w0_chunk_i and w1_chunk_i adjacent to each other
+    stacked = torch.stack([w0_chunks, w1_chunks], dim=4)
+
+    # Reshape to interleave: (L, E, K, Nt, 2 * TILE_SIZE) = (L, E, K, 90, 64)
+    torch_w0_w1_interleaved = stacked.view(L, E, K, Nt, 2 * ttnn.TILE_SIZE)
+
+    # Permute to move Nt before K: (L, E, Nt, K, 2*TILE)
+    torch_w0_w1_permuted = torch_w0_w1_interleaved.permute(0, 1, 3, 2, 4)
+
+    # Split into per-core shards with padding for cores with 7 tiles
+    each_shard = []
+    start_tile = 0
+    for ring_pos in range(num_cores):
+        num_tiles = tiles_for_core(ring_pos)
+        shard = torch_w0_w1_permuted[:, :, start_tile : start_tile + num_tiles, :, :]
+        start_tile += num_tiles
+
+        # Pad to MAX_W0_W1_TILES_PER_CORE if needed
+        if num_tiles < MAX_W0_W1_TILES_PER_CORE:
+            pad_tiles = MAX_W0_W1_TILES_PER_CORE - num_tiles
+            padding = torch.zeros(L, E, pad_tiles, K, 2 * ttnn.TILE_SIZE, dtype=torch_w0.dtype)
+            shard = torch.cat([shard, padding], dim=2)
+
+        each_shard.append(shard)
+
+    # (L, E, 12*8, K, 64) = (L, E, 96, K, 64)
+    torch_w0_w1_reordered = torch.cat(each_shard, dim=2)
+    groups_per_core = MAX_W0_W1_TILES_PER_CORE // 2  # 4
+
+    # (L, E, 12, 8, K, 64) -> (12, L, E, 8, K, 64)
+    all_groups_per_bank = torch_w0_w1_reordered.view(L, E, num_cores, MAX_W0_W1_TILES_PER_CORE, K, 2 * ttnn.TILE_SIZE)
+    all_groups_per_bank = all_groups_per_bank.permute(2, 0, 1, 3, 4, 5)
+
+    # Pair 2 tiles into groups of 4 tiles wide (matching kernel matmul_block ct_dim=4):
+    # (12, L, E, 8, K, 64) -> (12, L, E, 4, 2, K, 64) -> (12, L, E, 4, K, 2, 64) -> (12, L, E, 4, K, 128)
+    torch_w0_w1_pair_2_tiles = all_groups_per_bank.view(num_cores, L, E, groups_per_core, 2, K, 2 * ttnn.TILE_SIZE)
+    torch_w0_w1_pair_2_tiles = torch_w0_w1_pair_2_tiles.permute(0, 1, 2, 3, 5, 4, 6)
+    torch_w0_w1_paired = torch_w0_w1_pair_2_tiles.reshape(num_cores, L, E, groups_per_core, K, 4 * ttnn.TILE_SIZE)
+
+    return torch_w0_w1_paired
+
+
+def prepare_w2_tensor(torch_w2, L, E, N, K, ring2cores):
+    """
+    Prepare the w2 tensor by padding and reordering tiles.
+
+    GPT-OSS: W2 is [N, K] = [2880, 2880], distributed as 7-8 K-tiles per core.
+    Grouped into ceil(max_tiles/4) = 2 groups of 4 tiles each.
+
+    Args:
+        torch_w2: Weight tensor of shape (L, E, N, K)
+        L: Number of layers
+        E: Number of experts
+        N: Intermediate dimension (2880)
+        K: Output dimension (2880)
+        ring2cores: Dictionary mapping ring position to (core_coord, dram_bank_id, pad_flag)
+
+    Returns:
+        torch_w2_reordered: Reordered tensor of shape (12, L, E, 2, N, 128)
+    """
+    num_cores = len(ring2cores)
+    each_shard = []
+
+    start_col = 0
+    for ring_pos in range(num_cores):
+        (_, _, pad_flag) = ring2cores[ring_pos]
+
+        if pad_flag:
+            # Pad cores: 7 tiles -> 1 group of 4 + 1 group of 3 + 1 pad
+            each_shard.append(torch_w2[:, :, :, start_col : start_col + 4 * ttnn.TILE_SIZE])
+            start_col += 4 * ttnn.TILE_SIZE
+            each_shard.append(torch_w2[:, :, :, start_col : start_col + 3 * ttnn.TILE_SIZE])
+            start_col += 3 * ttnn.TILE_SIZE
+            # Pad the last group to 4 tiles
+            each_shard.append(torch.zeros(L, E, N, 1 * ttnn.TILE_SIZE, dtype=torch_w2.dtype))
+        else:
+            # Full cores: 8 tiles -> 2 groups of 4 tiles each, no padding
+            each_shard.append(torch_w2[:, :, :, start_col : start_col + 4 * ttnn.TILE_SIZE])
+            start_col += 4 * ttnn.TILE_SIZE
+            each_shard.append(torch_w2[:, :, :, start_col : start_col + 4 * ttnn.TILE_SIZE])
+            start_col += 4 * ttnn.TILE_SIZE
+
+    torch_w2_reordered = torch.cat(each_shard, dim=-1)  # (L, E, N, 12 * 8 * 32)
+    all_groups_per_bank = torch_w2_reordered.view(L, E, N, num_cores, 2, 4 * ttnn.TILE_SIZE)
+
+    # (L, E, N, 12, 2, 128) -> (12, L, E, 2, N, 128)
+    all_groups_per_bank = all_groups_per_bank.permute(3, 0, 1, 4, 2, 5)
+
+    # Group N in terms of tiles for ring reordering
+    Nt = N // ttnn.TILE_SIZE  # 90
+    N_grouped = all_groups_per_bank.view(
+        num_cores, L, E, 2, Nt, ttnn.TILE_SIZE, 4 * ttnn.TILE_SIZE
+    )  # (12, L, E, 2, 90, 32, 128)
+
+    # Figure out the order of N tiles based on the ring position.
+    # Each core's intermediate tiles come from different source cores in the ring.
+    core_chunk_order = torch.tensor(list(reversed(range(num_cores)))).roll(1)
+
+    # Chunk sizes per source core: 7 or 8 tiles
+    chunk_sizes = [tiles_for_core(i) for i in range(num_cores)]
+    chunk_start_positions = torch.cat(
+        [torch.zeros(1, dtype=torch.int32), torch.cumsum(torch.tensor(chunk_sizes, dtype=torch.int32), dim=0)]
+    )
+
+    each_shard = []
+    for core_id in range(num_cores):
+        each_chunk = []
+        for chunk_id in core_chunk_order:
+            start_pos = chunk_start_positions[chunk_id]
+            end_pos = chunk_start_positions[chunk_id + 1]
+            this_chunk = N_grouped[core_id, :, :, :, start_pos:end_pos, :, :]
+            each_chunk.append(this_chunk)
+        each_shard.append(torch.cat(each_chunk, dim=3))
+
+        core_chunk_order = core_chunk_order.roll(1)
+
+    N_reordered = torch.stack(each_shard).view(num_cores, L, E, 2, -1, 4 * ttnn.TILE_SIZE)
+
+    # GPT-OSS: N=2880, Nt=90. 90/10=9 exact, no padding needed.
+    return N_reordered
+
+
+def prepare_output_tensor(tt_output, E, M, K, ring2cores):
+    """
+    Prepare the output tensor by extracting valid tiles per core.
+
+    GPT-OSS: W2 output has K/32 = 90 tiles total across 12 cores.
+    Cores with 8 tiles produce 8*32 = 256 elements of K.
+    Cores with 7 tiles produce 7*32 = 224 elements of K.
+
+    Args:
+        tt_output: Tensor of shape (num_cores, E, M, K_padded)
+        E: Number of experts
+        M: Number of input features
+        K: Number of output features (2880)
+        ring2cores: Dictionary mapping ring position to (core_coord, dram_bank_id, pad_flag)
+
+    Returns:
+        torch_output: Tensor of shape (E, M, K)
+    """
+    each_shard = []
+
+    for ring_pos in range(len(ring2cores)):
+        (_, _, pad_flag) = ring2cores[ring_pos]
+        # Full cores (8 tiles) -> 8*32=256 elements; Pad cores (7 tiles) -> 7*32=224 elements
+        # But output is stored with max padding = 8*32 per core
+        num_tiles = 7 if pad_flag else 8
+        each_shard.append(tt_output[ring_pos, :, :, : num_tiles * ttnn.TILE_SIZE])
+
+    result = torch.cat(each_shard, dim=-1)
+    assert result.shape == (E, M, K), f"Expected shape {(E, M, K)}, got {result.shape}"
+    return result
+
+
+def get_accuracy_metrics(torch_output, tt_output):
+    _pcc_passed, pcc_val = comp_pcc(torch_output, tt_output)
+    std = torch_output.std().item()
+    relative_rmse_val = (torch.nn.functional.mse_loss(torch_output, tt_output).sqrt().item() / std) if std != 0 else 0.0
+    allclose_passed, allclose_val = comp_allclose(torch_output, tt_output)
+    return {
+        "pcc": pcc_val,
+        "relative_rmse": relative_rmse_val,
+        "allclose": allclose_passed,
+        "allclose_val": allclose_val,
+    }
+
+
+def swiglu_reference(gate, up, alpha=1.702, clamp_limit=7.0):
+    """
+    GPT-OSS SwiGLU activation reference.
+
+    Args:
+        gate: Tensor from W0 matmul
+        up: Tensor from W1 matmul
+
+    Returns:
+        result = (clamp(up, -7, 7) + 1) * clamp(gate, max=7) * sigmoid(1.702 * clamp(gate, max=7))
+    """
+    gate_c = torch.clamp(gate, max=clamp_limit)
+    up_c = torch.clamp(up, min=-clamp_limit, max=clamp_limit)
+    return (up_c + 1.0) * gate_c * torch.sigmoid(alpha * gate_c)
+
+
+def run_test_moe_gpt(device, M, K, N, E, L, check_accuracy, dump_outputs):
+    logger.info(
+        f"Running test_moe_gpt with M={M}, K={K}, N={N}, E={E}, L={L}, "
+        f"check_accuracy={check_accuracy}, dump_outputs={dump_outputs}"
+    )
+
+    # --------------------------------------------------------------------------
+    # Shard grid
+    # --------------------------------------------------------------------------
+    in0_core_coords = ttnn.device.get_optimal_dram_bank_to_logical_worker_assignment(device, 0)
+    core2dram = {}
+    for dram_bank_id, core_coords in enumerate(in0_core_coords):
+        core2dram[core_coords] = dram_bank_id
+
+    in0_num_cores = len(in0_core_coords)
+
+    # Make a new list of core coords sorted in decreasing order by y then x (ring order)
+    in0_core_coords_sorted = sorted(in0_core_coords, key=lambda x: (x.y, x.x), reverse=True)
+
+    ring2cores = {}
+    for ring_pos, core_coord in enumerate(in0_core_coords_sorted):
+        # key: ring_pos, value: (core_coord, dram_bank_id, pad_flag)
+        # pad_flag: 1 for cores with 7 tiles, 0 for cores with 8 tiles
+        ring2cores[ring_pos] = (core_coord, core2dram[core_coord], 1 if ring_pos in PAD_CORES else 0)
+
+    in0_core_range = [ttnn.CoreRange(ring2cores[i][0], ring2cores[i][0]) for i in range(in0_num_cores)]
+    in0_core_range_set = ttnn.CoreRangeSet(in0_core_range)
+
+    # --------------------------------------------------------------------------
+    # Constants
+    # --------------------------------------------------------------------------
+    in0_dtype = ttnn.bfloat16
+    w0_dtype = ttnn.bfloat4_b
+    num_dram_banks = 12
+
+    dram_core_coords = [ttnn.CoreCoord(ring2cores[i][1], 0) for i in range(in0_num_cores)]
+    dram_core_range = [ttnn.CoreRange(dram_core_coord, dram_core_coord) for dram_core_coord in dram_core_coords]
+    dram_core_range_set = ttnn.CoreRangeSet(dram_core_range)
+
+    # --------------------------------------------------------------------------
+    # Tensor shapes and memory configurations
+    # --------------------------------------------------------------------------
+    input_shape = (in0_num_cores, E, M, K)
+
+    in0_shard_spec = ttnn.ShardSpec(
+        grid=in0_core_range_set,
+        shard_shape=(E * M, K),
+        shard_orientation=ttnn.ShardOrientation.ROW_MAJOR,
+    )
+
+    input_sharded_mem_config = ttnn.MemoryConfig(
+        ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, in0_shard_spec
+    )
+
+    # ------------------------------------------------------------------------
+    # Create DRAM shard spec for w0_w1
+    # GPT-OSS: (12, L, E, 4, K, 128) -> shard per bank = L * E * 4 * K height, 128 width
+    # 4 groups (8 max tiles / 2 per group), K=2880 height, 128 = 4 tiles width
+    # ------------------------------------------------------------------------
+    groups_per_core = MAX_W0_W1_TILES_PER_CORE // 2  # 4
+    w0_w1_shard_height = L * E * groups_per_core * K
+    w0_w1_shard_width = 4 * ttnn.TILE_SIZE
+
+    w0_w1_shard_spec = ttnn.ShardSpec(
+        dram_core_range_set, (w0_w1_shard_height, w0_w1_shard_width), ttnn.ShardOrientation.ROW_MAJOR
+    )
+
+    w0_w1_mem_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.DRAM, w0_w1_shard_spec)
+
+    # ------------------------------------------------------------------------
+    # Create DRAM shard spec for w2
+    # GPT-OSS: (12, L, E, 2, N, 128) -> shard per bank = L * E * 2 * N height, 128 width
+    # 2 groups, N=2880 height, 128 = 4 tiles width
+    # 90/10 = 9 exact, no N-dimension padding needed.
+    # ------------------------------------------------------------------------
+    w2_shard_height = L * E * 2 * N
+    w2_shard_width = 4 * ttnn.TILE_SIZE
+
+    w2_shard_spec = ttnn.ShardSpec(
+        dram_core_range_set, (w2_shard_height, w2_shard_width), ttnn.ShardOrientation.ROW_MAJOR
+    )
+
+    w2_mem_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.DRAM, w2_shard_spec)
+
+    # --------------------------------------------------------------------------
+    # Prepare the tensors
+    # --------------------------------------------------------------------------
+    if check_accuracy:
+        torch_input = create_torch_input(L, in0_num_cores, E, M, K)
+        torch_w0 = create_torch_w0(L, E, K, N)
+        torch_w1 = create_torch_w1(L, E, K, N)
+        torch_w2 = create_torch_w2(L, E, N, K)
+
+        # Prepare w0_w1 tensor (interleaved, and reordered)
+        torch_w0_w1_reordered = prepare_w0_w1_tensor(torch_w0, torch_w1, L, E, K, N, ring2cores)
+
+        tt_w0_w1 = ttnn.from_torch(
+            torch_w0_w1_reordered,
+            dtype=w0_dtype,
+            device=device,
+            layout=ttnn.TILE_LAYOUT,
+            memory_config=w0_w1_mem_config,
+        )
+
+        # Prepare w2 tensor (padded and reordered)
+        torch_w2_reordered = prepare_w2_tensor(torch_w2, L, E, N, K, ring2cores)
+
+        tt_w2 = ttnn.from_torch(
+            torch_w2_reordered, dtype=w0_dtype, device=device, layout=ttnn.TILE_LAYOUT, memory_config=w2_mem_config
+        )
+    else:
+        tt_input = ttnn.empty(
+            input_shape,
+            dtype=in0_dtype,
+            device=device,
+            layout=ttnn.TILE_LAYOUT,
+            memory_config=input_sharded_mem_config,
+        )
+        tt_w0_w1 = ttnn.empty(
+            [num_dram_banks] + w0_w1_shard_spec.shape,
+            dtype=w0_dtype,
+            device=device,
+            layout=ttnn.TILE_LAYOUT,
+            memory_config=w0_w1_mem_config,
+        )
+        tt_w2 = ttnn.empty(
+            [num_dram_banks] + w2_shard_spec.shape,
+            dtype=w0_dtype,
+            device=device,
+            layout=ttnn.TILE_LAYOUT,
+            memory_config=w2_mem_config,
+        )
+
+    # --------------------------------------------------------------------------
+    # Run the operation
+    # --------------------------------------------------------------------------
+    all_outputs = []
+    all_accuracy_metrics = {}
+
+    for layer_id in range(L):
+        if check_accuracy:
+            tt_input = ttnn.from_torch(
+                torch_input[layer_id],
+                dtype=in0_dtype,
+                device=device,
+                layout=ttnn.TILE_LAYOUT,
+                memory_config=input_sharded_mem_config,
+            )
+
+        _tt_output = ttnn.experimental.moe_gpt(
+            tt_input,
+            w0_w1_tensor=tt_w0_w1,
+            w2_tensor=tt_w2,
+            output_tensor=tt_input,
+            num_experts=E,
+            layer_id=layer_id,
+        )
+
+        # Output is produced in-place on the input tensor
+        tt_raw_output = ttnn.to_torch(tt_input)
+        tt_to_torch_output = prepare_output_tensor(tt_raw_output, E, M, K, ring2cores)
+        all_outputs.append(tt_to_torch_output)
+
+    tt_to_torch_outputs = torch.stack(all_outputs)
+
+    if check_accuracy:
+        with torch.no_grad():
+            # Reference calculation using SwiGLU
+            torch_input_ref = torch_input[:, 0, ...]  # (L, E, M, K)
+
+            # W0 and W1 projections
+            # (L, E, M, K) @ (L, E, K, N) -> (L, E, M, N)
+            torch_w0_output_ref = torch_input_ref @ torch_w0
+            torch_w1_output_ref = torch_input_ref @ torch_w1
+
+            # SwiGLU activation: gate=W0 output, up=W1 output
+            torch_intermediate_ref = swiglu_reference(torch_w0_output_ref, torch_w1_output_ref)
+
+            # W2 projection
+            # (L, E, M, N) @ (L, E, N, K) -> (L, E, M, K)
+            torch_output_ref = torch_intermediate_ref @ torch_w2
+
+        # Calculate accuracy metrics for each layer and expert
+        for layer_id, expert_id in itertools.product(range(L), range(E)):
+            torch_layer_output = torch_output_ref[layer_id, expert_id, :, :]
+            tt_layer_output = tt_to_torch_outputs[layer_id, expert_id, :, :]
+
+            layer_metrics = get_accuracy_metrics(torch_layer_output, tt_layer_output)
+            all_accuracy_metrics[(layer_id, expert_id)] = layer_metrics
+
+    if dump_outputs:
+        torch.set_printoptions(profile="full")
+        var2filename = {
+            torch_w0_output_ref: "torch_w0_output_ref.txt",
+            torch_w1_output_ref: "torch_w1_output_ref.txt",
+            torch_intermediate_ref: "torch_intermediate_ref.txt",
+            torch_output_ref: "torch_output_ref.txt",
+            tt_to_torch_outputs: "tt_output_act.txt",
+        }
+
+        for var, filename in var2filename.items():
+            with open(filename, "w") as f:
+                f.write(str(var))
+
+    return all_accuracy_metrics
+
+
+# GPT-OSS dimensions: M=32, K=2880, N=2880, E=4, L=1
+SHAPE2TIME = {
+    (32, 2880, 2880, 4, 1): 300.0,
+}
+
+
+@pytest.mark.parametrize(
+    "device_params",
+    [
+        pytest.param(
+            {
+                "dispatch_core_axis": ttnn.DispatchCoreAxis.ROW,
+            },
+            id="dispatch_row",
+        )
+    ],
+    indirect=True,
+)
+@pytest.mark.parametrize(
+    "M, K, N, E, L",
+    SHAPE2TIME.keys(),
+)
+@pytest.mark.parametrize("check_accuracy", [True, False], ids=["check_accuracy_True", "check_accuracy_False"])
+@pytest.mark.parametrize("dump_outputs", [True, False], ids=["dump_outputs_True", "dump_outputs_False"])
+def test_moe_gpt(device, M, K, N, E, L, check_accuracy, dump_outputs):
+    accuracy_metrics = run_test_moe_gpt(
+        device,
+        M,
+        K,
+        N,
+        E,
+        L,
+        check_accuracy,
+        dump_outputs,
+    )
+
+    passing = True
+    for (layer_id, expert_id), metrics in accuracy_metrics.items():
+        if metrics["pcc"] < PCC_THRESHOLD:
+            passing = False
+            logger.warning(f"Layer {layer_id}, Expert {expert_id}: PCC={metrics['pcc']:.6f}")
+        else:
+            logger.info(f"Layer {layer_id}, Expert {expert_id}: PCC={metrics['pcc']:.6f} (Passed)")
+
+    assert passing, "Some experts in some layers did not pass the PCC check"
+
+
+@pytest.mark.parametrize(
+    "M, K, N, E, L",
+    SHAPE2TIME.keys(),
+)
+@pytest.mark.parametrize("check_accuracy", [True, False], ids=["check_accuracy_True", "check_accuracy_False"])
+@pytest.mark.parametrize("dump_outputs", [True, False], ids=["dump_outputs_True", "dump_outputs_False"])
+def test_moe_gpt_performance(M, K, N, E, L, check_accuracy, dump_outputs):
+    command = (
+        f"pytest tests/ttnn/nightly/unit_tests/operations/experimental/test_moe_gpt.py"
+        f"::test_moe_gpt[dump_outputs_{dump_outputs}-check_accuracy_{check_accuracy}"
+        f"-M={M}-K={K}-N={N}-E={E}-L={L}-dispatch_row]"
+    )
+    run_device_profiler(command, "ttnn_moe_gpt_performance", device_analysis_types=["device_kernel_duration"])
+
+    r = post_process_ops_log("ttnn_moe_gpt_performance", float_columns=["DEVICE KERNEL DURATION [ns]"])
+    duration_us = r["DEVICE KERNEL DURATION [ns]"].sum() / 1000.0
+    logger.info(f"Duration per layer: {duration_us / L} us")
+    logger.info(f"Duration per layer per expert: {duration_us / L / E} us")
+    logger.warning(f"Total Duration: {duration_us} us")
+
+    bytes_per_tile = 512 + 64  # bfloat4_b
+    tiles_per_txn = 10
+    num_cores = 12
+
+    Kt, Nt = math.ceil(K / ttnn.TILE_SIZE), math.ceil(N / ttnn.TILE_SIZE)
+    # W0/W1: 8 max tiles/core, 90 height
+    w0_w1_padded_tiles_per_core = 2 * MAX_W0_W1_TILES_PER_CORE * Kt  # 2 * 8 * 90 = 1440
+    # W2: 8 max tiles/core, 90 height
+    w2_padded_tiles_per_core = 2 * 4 * Nt  # 2 groups * 4 tiles * 90 = 720
+    total_padded_tiles_per_core = w0_w1_padded_tiles_per_core + w2_padded_tiles_per_core
+
+    total_bytes_transferred = L * E * num_cores * total_padded_tiles_per_core * bytes_per_tile
+    realized_bandwidth = int(total_bytes_transferred / (duration_us * 1000))
+    logger.warning(f"Realized Bandwidth: {realized_bandwidth} GB/s")
+
+    total_tiles_0_1 = Kt * Nt
+    total_tiles_2 = Nt * Kt
+    total_tiles_per_core = 2 * total_tiles_0_1 + total_tiles_2
+    total_bytes_used = L * E * total_tiles_per_core * bytes_per_tile
+    bandwidth = int(total_bytes_used / (duration_us * 1000))
+    logger.warning(f"Useful Bandwidth: {bandwidth} GB/s")
+
+    assert (
+        duration_us < SHAPE2TIME[(M, K, N, E, L)]
+    ), f"Performance {duration_us} us is greater than expected {SHAPE2TIME[(M, K, N, E, L)]} us"
+
+
+def post_process_ops_log(output_logs_subdir: str, float_columns: list[str]) -> dict[str, float]:
+    filename = get_latest_ops_log_filename(output_logs_subdir)
+
+    import pandas as pd
+
+    df = pd.read_csv(filename)
+    return {col: df[col].astype(float).to_numpy() for col in float_columns}

--- a/ttnn/cpp/ttnn/operations/experimental/moe_gpt/device/kernels/compute.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/moe_gpt/device/kernels/compute.cpp
@@ -11,9 +11,7 @@
 
 // Need these headers for running SFPU on PACK thread
 #ifdef TRISC_PACK
-#include "ckernel_sfpu_exp.h"
-#include "llk_math_eltwise_unary_sfpu_silu.h"
-#include "llk_math_eltwise_binary_sfpu_binop.h"
+#include "swiglu_sfpu.h"
 #endif
 
 void kernel_main() {
@@ -46,11 +44,12 @@ void kernel_main() {
     constexpr auto cb_c2s_out = tt::CBIndex::c_1;
 
     // Constants for MoEGPT
-    constexpr uint32_t num_w0_w1_tiles_h = moe_gpt_ring::NUM_W0_W1_TILES_H;
-    constexpr uint32_t num_w2_tiles_h = moe_gpt_ring::NUM_W2_TILES_H;
+    // GPT-OSS: K=2880 -> 90 tiles height, N=2880 -> 90 tiles
+    constexpr uint32_t num_w0_w1_tiles_h = moe_gpt_ring::NUM_W0_W1_TILES_H;  // 90
+    constexpr uint32_t num_w2_tiles_h = moe_gpt_ring::NUM_W2_TILES_H;        // 240
 
-    const uint32_t num_w0_w1_tiles_w = moe_gpt_ring::W0_W1_TILES_PER_CORE_PER_STEP_A[ring_core_id][0];
-    const uint32_t num_w2_tiles_w = moe_gpt_ring::W2_TILES_PER_CORE_A[ring_core_id];
+    const uint32_t num_w0_w1_tiles_w = moe_gpt_ring::W0_W1_TILES_PER_CORE_PER_STEP_A[ring_core_id][0];  // 7 or 8
+    const uint32_t num_w2_tiles_w = moe_gpt_ring::W2_TILES_PER_CORE_A[ring_core_id];                    // 7 or 8
 
     const uint32_t num_in2_tiles = num_w2_tiles_w;
     const uint32_t num_mm2_tiles = num_w2_tiles_w;
@@ -58,36 +57,37 @@ void kernel_main() {
     //-------------------------------------------------------------------------
     // W0 and W1 reading constants
     //-------------------------------------------------------------------------
-    constexpr uint32_t w0_w1_txns_per_block = moe_gpt_ring::W0_W1_TXNS_PER_BLOCK;
-    constexpr uint32_t w0_w1_tiles_per_txn = moe_gpt_ring::W0_W1_TILES_PER_TXN;
-    constexpr uint32_t w0_w1_tiles_per_block = w0_w1_tiles_per_txn * w0_w1_txns_per_block;  // 14 * 2 = 28
+    constexpr uint32_t w0_w1_txns_per_block = moe_gpt_ring::W0_W1_TXNS_PER_BLOCK;           // 2
+    constexpr uint32_t w0_w1_tiles_per_txn = moe_gpt_ring::W0_W1_TILES_PER_TXN;             // 10
+    constexpr uint32_t w0_w1_tiles_per_block = w0_w1_tiles_per_txn * w0_w1_txns_per_block;  // 10 * 2 = 20
+    // blocks to read for 2 output element tiles (covers full K height, 4 tiles wide per block):
+    // 4 * (90 / 10) / 2 = 4 * 9 / 2 = 18
     constexpr uint32_t w0_w1_blocks_per_two_elt_tile =
-        4 * (num_w0_w1_tiles_h / w0_w1_tiles_per_txn) / w0_w1_txns_per_block;  // 32
+        4 * (num_w0_w1_tiles_h / w0_w1_tiles_per_txn) / w0_w1_txns_per_block;  // 18
+    // blocks per expert = 18 * 8 / 2 = 72
     constexpr uint32_t w0_w1_blocks_per_expert =
-        w0_w1_blocks_per_two_elt_tile * moe_gpt_ring::IN2_TILES_PER_STEP_A /
-        2;  // 32 * 3 = 96
-            // 2 * num_w0_w1_tiles_w * num_w0_w1_tiles_h / w0_w1_tiles_per_block;  // (5|6 * 224) / 28 = 80|96
+        w0_w1_blocks_per_two_elt_tile * moe_gpt_ring::IN2_TILES_PER_STEP_A / 2;  // 72
 
     // W2 reading constants
-    constexpr uint32_t w2_txns_per_block = moe_gpt_ring::W2_TXNS_PER_BLOCK;
-    constexpr uint32_t w2_tiles_per_txn = moe_gpt_ring::W2_TILES_PER_TXN;
-    constexpr uint32_t w2_tiles_per_block = w2_tiles_per_txn * w2_txns_per_block;               // 14 * 2 = 28
-    constexpr uint32_t w2_txns_h = (num_w2_tiles_h + w2_tiles_per_txn - 1) / w2_tiles_per_txn;  // 5 (round up)
-    constexpr uint32_t w2_blocks_per_four_mm2_tile = 4 * w2_txns_h / w2_txns_per_block;         // 4 * 5 / 2 = 10
-    constexpr uint32_t w2_blocks_per_expert = moe_gpt_ring::W2_BLOCKS_PER_EXPERT;
+    constexpr uint32_t w2_txns_per_block = moe_gpt_ring::W2_TXNS_PER_BLOCK;                     // 2
+    constexpr uint32_t w2_tiles_per_txn = moe_gpt_ring::W2_TILES_PER_TXN;                       // 10
+    constexpr uint32_t w2_tiles_per_block = w2_tiles_per_txn * w2_txns_per_block;               // 10 * 2 = 20
+    constexpr uint32_t w2_txns_h = (num_w2_tiles_h + w2_tiles_per_txn - 1) / w2_tiles_per_txn;  // 90 / 10 = 9
+    // blocks for 4 output tiles: 4 * 9 / 2 = 18
+    constexpr uint32_t w2_blocks_per_four_mm2_tile = 4 * w2_txns_h / w2_txns_per_block;  // 18
+    constexpr uint32_t w2_blocks_per_expert = moe_gpt_ring::W2_BLOCKS_PER_EXPERT;        // 36
 
     //-------------------------------------------------------------------------
     // Ring setup
     //-------------------------------------------------------------------------
     // The number of times to repeat the all2all
-    constexpr uint32_t num_a2a_iters = moe_gpt_ring::NUM_A2A_ITERS_A;
+    constexpr uint32_t num_a2a_iters = moe_gpt_ring::NUM_A2A_ITERS_A;  // 2
 
     // The number of steps to take in the all2all is the number of cores
-    constexpr uint32_t num_a2a_steps_per_iter = moe_gpt_ring::NUM_CORES;
+    constexpr uint32_t num_a2a_steps_per_iter = moe_gpt_ring::NUM_CORES;  // 12
 
-    // The number of tiles to send in each step
-    // We send 6 tiles in each step, even though some cores in some steps may have only 5 valid ones
-    constexpr uint32_t tiles_per_step = moe_gpt_ring::IN2_TILES_PER_STEP_A;  // max(num_w0_w1_tiles_w)
+    // The number of tiles to send in each step (max of 7/8 = 8)
+    constexpr uint32_t tiles_per_step = moe_gpt_ring::IN2_TILES_PER_STEP_A;  // 8
 
     //-------------------------------------------------------------------------
     // Compute
@@ -95,7 +95,7 @@ void kernel_main() {
     // Pack is always configured to Float16_b
     pack_reconfig_data_format(cb_s2c_in2);
 
-    // Unpacker B is for input/activation and eltiwse inputs, so Float16_b
+    // Unpacker B is for input/activation and eltwise inputs, so Float16_b
     reconfig_data_format_srcb(cb_s2c_in);
 
     // Unpacker A is for W0,W1 and W2, so Bf4_b
@@ -104,8 +104,8 @@ void kernel_main() {
     // Initialize matmul for W0
     mm_block_init(cb_s2c_in, cb_r2c_w0_w1, cb_s2c_in2, /*transpose=*/false, /*ct_dim=*/4, /*rt_dim=*/1, /*kt_dim=*/1);
 
-    // Initialize SFPU for SILU and eltwise multiply
-    PACK((llk_math_eltwise_unary_sfpu_silu_init<true>()));
+    // Initialize SFPU for GPT-OSS SwiGLU activation
+    PACK((llk_math_eltwise_binary_sfpu_swiglu_init<true>()));
 
     //-------------------------------------------------------------------------
     // Expert loop
@@ -114,10 +114,23 @@ void kernel_main() {
     uint32_t out_offset_per_expert = 0;
     for (uint32_t expert_id = 0; expert_id < num_experts; ++expert_id) {
         //---------------------------------------------------------------------
+        // Cross-expert boundary synchronization
+        // For expert > 0, wait for dm1 to confirm that our predecessor's last
+        // A2A write (which targets buf 0) has completed, so it's safe to
+        // overwrite buf 0 with this expert's SwiGLU output.
+        //---------------------------------------------------------------------
+        if (expert_id > 0) {
+            cb_wait_front(cb_w2c_rdy, 1);
+            cb_pop_front(cb_w2c_rdy, 1);
+        }
+
+        //---------------------------------------------------------------------
         // Compute in @ {W0,W1}
+        // GPT-OSS: 8 tiles/core (max), processed 2 at a time -> 4 iterations
         //---------------------------------------------------------------------
         for (uint32_t tile_id = 0; tile_id < tiles_per_step; tile_id += 2) {
-            uint32_t in0_index = (expert_id & 1) ? num_w0_w1_tiles_h : 0;
+            uint32_t in0_index =
+                expert_id * num_w0_w1_tiles_h;  // expert 0: 0, expert 1: 90, expert 2: 180, expert 3: 270
 
             tile_regs_acquire();
             for (uint32_t block_id = 0; block_id < w0_w1_blocks_per_two_elt_tile; ++block_id) {
@@ -151,13 +164,12 @@ void kernel_main() {
             PACK(TT_SETC16(DEST_TARGET_REG_CFG_MATH_Offset_ADDR32, ckernel::packer::get_packer_dest_offset()));
 
             //---------------------------------------------------------------------
-            // Apply SILU activation and then eltwise multiply
+            // Apply GPT-OSS SwiGLU activation
+            // SwiGLU: (clamp(up)+1) * clamp(gate) * sigmoid(alpha * clamp(gate))
+            // Dest layout: [gate0, up0, gate1, up1] at tile indices [0, 1, 2, 3]
             //---------------------------------------------------------------------
-            PACK((llk_math_eltwise_unary_sfpu_silu<true, false>(0)));
-            PACK((llk_math_eltwise_unary_sfpu_silu<true, false>(2)));
-
-            PACK((llk_math_eltwise_binary_sfpu_binop<true, ckernel::BinaryOp::MUL>(0, 1, 0)));
-            PACK((llk_math_eltwise_binary_sfpu_binop<true, ckernel::BinaryOp::MUL>(2, 3, 2)));
+            PACK((llk_math_eltwise_binary_sfpu_swiglu<true, false>(0, 1, 0)));
+            PACK((llk_math_eltwise_binary_sfpu_swiglu<true, false>(2, 3, 2)));
 
             PACK(TTI_STALLWAIT(p_stall::STALL_PACK, p_stall::WAIT_SFPU));
 
@@ -172,14 +184,18 @@ void kernel_main() {
 
         //---------------------------------------------------------------------
         // Compute in2 @ W2 (in pairs of 4)
+        // GPT-OSS: W2 height=90, 18 blocks per iter, 2 iters
         //---------------------------------------------------------------------
-        uint32_t out_tile_index = (expert_id & 1) ? num_w0_w1_tiles_h : 0;
+        uint32_t out_tile_index =
+            expert_id * num_w0_w1_tiles_h;  // expert 0: 0, expert 1: 90, expert 2: 180, expert 3: 270
         for (uint32_t iter = 0; iter < num_a2a_iters; ++iter) {
             uint32_t dm1_step = 0;
             uint32_t dm1_tiles_remaining = moe_gpt_ring::W0_W1_TILES_PER_CORE_PER_STEP_A[ring_core_id][0];
             cb_wait_front(cb_w2c_rdy, 1);
 
-            uint32_t in2_offset = 0, in2_index = 0;
+            // 6-buffer cycling: each A2A step uses buf (step % 6).
+            // Matches dm1's scheme where step S reads from buf S % 6.
+            uint32_t in2_buf = 0, in2_offset = 0, in2_index = 0;
 
             tile_regs_acquire();
 
@@ -187,17 +203,12 @@ void kernel_main() {
                 cb_wait_front(cb_r2c_w2, w2_tiles_per_block);
 
                 for (uint32_t k = 0; k < w2_tiles_per_block; k += 4) {
-                    // The last block has only 4 tiles of interest, so we exit early.
-                    if ((block_id == (w2_blocks_per_four_mm2_tile - 1)) && (k == 4)) {
-                        cb_pop_front(cb_w2c_rdy, 1);
-                        break;
-                    }
-
                     if (dm1_tiles_remaining == 0) {
                         cb_pop_front(cb_w2c_rdy, 1);
                         cb_wait_front(cb_w2c_rdy, 1);
                         dm1_tiles_remaining = moe_gpt_ring::W0_W1_TILES_PER_CORE_PER_STEP_A[ring_core_id][++dm1_step];
-                        in2_offset = (in2_offset == tiles_per_step) ? 0 : tiles_per_step;
+                        in2_buf = (in2_buf >= 5) ? 0 : in2_buf + 1;  // 6 buffers: cycle 0..5
+                        in2_offset = in2_buf * tiles_per_step;
                         in2_index = in2_offset;
                     }
                     dm1_tiles_remaining--;
@@ -215,6 +226,12 @@ void kernel_main() {
                 }
                 cb_pop_front(cb_r2c_w2, w2_tiles_per_block);
             }
+
+            // Pop the last cb_w2c_rdy entry that was waited on but not popped.
+            // Each iter starts with cb_wait_front(cb_w2c_rdy) and has 11 internal
+            // pop+wait transitions for 12 total steps. Without this final pop,
+            // cb_w2c_rdy stays full and dm1 deadlocks on cb_reserve_back.
+            cb_pop_front(cb_w2c_rdy, 1);
 
             tile_regs_commit();
 

--- a/ttnn/cpp/ttnn/operations/experimental/moe_gpt/device/kernels/dm0.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/moe_gpt/device/kernels/dm0.cpp
@@ -65,11 +65,11 @@ void kernel_main() {
     constexpr uint32_t in2_tile_size = get_tile_size(cb_s2c_in2);
 
     // Constants for MoEGPT
-    constexpr uint32_t num_w0_w1_tiles_h = moe_gpt_ring::NUM_W0_W1_TILES_H;
-    constexpr uint32_t num_w2_tiles_h = moe_gpt_ring::NUM_W2_TILES_H;
+    constexpr uint32_t num_w0_w1_tiles_h = moe_gpt_ring::NUM_W0_W1_TILES_H;  // 90
+    constexpr uint32_t num_w2_tiles_h = moe_gpt_ring::NUM_W2_TILES_H;        // 240
 
-    const uint32_t num_w0_w1_tiles_w = moe_gpt_ring::W0_W1_TILES_PER_CORE_PER_STEP_A[ring_core_id][0];
-    const uint32_t num_w2_tiles_w = moe_gpt_ring::W2_TILES_PER_CORE_A[ring_core_id];
+    const uint32_t num_w0_w1_tiles_w = moe_gpt_ring::W0_W1_TILES_PER_CORE_PER_STEP_A[ring_core_id][0];  // 7 or 8
+    const uint32_t num_w2_tiles_w = moe_gpt_ring::W2_TILES_PER_CORE_A[ring_core_id];                    // 7 or 8
 
     const uint32_t num_in2_tiles = num_w2_tiles_w;
     const uint32_t num_mm2_tiles = num_w2_tiles_w;
@@ -77,22 +77,23 @@ void kernel_main() {
     //-------------------------------------------------------------------------
     // W0 and W1 reading constants
     //-------------------------------------------------------------------------
-    constexpr uint32_t w0_w1_txns_per_block = moe_gpt_ring::W0_W1_TXNS_PER_BLOCK;
-    constexpr uint32_t w0_w1_tiles_per_txn = moe_gpt_ring::W0_W1_TILES_PER_TXN;
-    constexpr uint32_t w0_w1_tiles_per_block = w0_w1_tiles_per_txn * w0_w1_txns_per_block;  // 14 * 2 = 28
+    constexpr uint32_t w0_w1_txns_per_block = moe_gpt_ring::W0_W1_TXNS_PER_BLOCK;           // 2
+    constexpr uint32_t w0_w1_tiles_per_txn = moe_gpt_ring::W0_W1_TILES_PER_TXN;             // 10
+    constexpr uint32_t w0_w1_tiles_per_block = w0_w1_tiles_per_txn * w0_w1_txns_per_block;  // 10 * 2 = 20
+    // 4 * (90 / 10) / 2 = 18
     constexpr uint32_t w0_w1_blocks_per_two_elt_tile =
-        4 * (num_w0_w1_tiles_h / w0_w1_tiles_per_txn) / w0_w1_txns_per_block;  // 32
+        4 * (num_w0_w1_tiles_h / w0_w1_tiles_per_txn) / w0_w1_txns_per_block;  // 18
+    // 18 * 8 / 2 = 72
     constexpr uint32_t w0_w1_blocks_per_expert =
-        w0_w1_blocks_per_two_elt_tile * moe_gpt_ring::IN2_TILES_PER_STEP_A / 2;  // 32 * 3 = 96
-    // 2 * num_w0_w1_tiles_w * num_w0_w1_tiles_h / w0_w1_tiles_per_block;  // (5|6 * 224) / 28 = 80|96
+        w0_w1_blocks_per_two_elt_tile * moe_gpt_ring::IN2_TILES_PER_STEP_A / 2;  // 72
 
     // W2 reading constants
-    constexpr uint32_t w2_txns_per_block = moe_gpt_ring::W2_TXNS_PER_BLOCK;
-    constexpr uint32_t w2_tiles_per_txn = moe_gpt_ring::W2_TILES_PER_TXN;
-    constexpr uint32_t w2_tiles_per_block = w2_tiles_per_txn * w2_txns_per_block;               // 14 * 2 = 28
-    constexpr uint32_t w2_txns_h = (num_w2_tiles_h + w2_tiles_per_txn - 1) / w2_tiles_per_txn;  // 5 (round up)
-    constexpr uint32_t w2_blocks_per_four_mm2_tile = 4 * w2_txns_h / w2_txns_per_block;         // 4 * 5 / 2 = 10
-    constexpr uint32_t w2_blocks_per_expert = moe_gpt_ring::W2_BLOCKS_PER_EXPERT;
+    constexpr uint32_t w2_txns_per_block = moe_gpt_ring::W2_TXNS_PER_BLOCK;                     // 2
+    constexpr uint32_t w2_tiles_per_txn = moe_gpt_ring::W2_TILES_PER_TXN;                       // 10
+    constexpr uint32_t w2_tiles_per_block = w2_tiles_per_txn * w2_txns_per_block;               // 10 * 2 = 20
+    constexpr uint32_t w2_txns_h = (num_w2_tiles_h + w2_tiles_per_txn - 1) / w2_tiles_per_txn;  // 90 / 10 = 9
+    constexpr uint32_t w2_blocks_per_four_mm2_tile = 4 * w2_txns_h / w2_txns_per_block;         // 4 * 9 / 2 = 18
+    constexpr uint32_t w2_blocks_per_expert = moe_gpt_ring::W2_BLOCKS_PER_EXPERT;               // 36
 
     //-------------------------------------------------------------------------
     // DRAM Reading constants
@@ -103,12 +104,16 @@ void kernel_main() {
     constexpr uint32_t w2_bytes_per_txn = w2_tiles_per_txn * w2_tile_size;
 
     // Offsets for layer_id
-    constexpr uint32_t w0_size_per_expert = num_w0_w1_tiles_h * 6 * w0_w1_tile_size;
+    // GPT-OSS: W0/W1 per expert = 90 height * 8 max width per core * tile_size (for W0 alone)
+    // w0_w1_total = 2 * that (interleaved W0+W1)
+    constexpr uint32_t w0_size_per_expert = num_w0_w1_tiles_h * 8 * w0_w1_tile_size;  // 90 * 8
     constexpr uint32_t w0_w1_total_size_per_expert = 2 * w0_size_per_expert;
     constexpr uint32_t w0_w1_total_size_per_layer = num_experts * w0_w1_total_size_per_expert;
     constexpr uint32_t w0_w1_layer_offset = layer_id * w0_w1_total_size_per_layer;
 
-    constexpr uint32_t w2_total_size_per_expert = 70 * 20 * w2_tile_size;  // We pad 64 to 70 tiles
+    // GPT-OSS: W2 per expert = 90 height * 8 max width per core * tile_size
+    // 90 height (no padding needed: 90/10=9 exact), 8 max tiles/core
+    constexpr uint32_t w2_total_size_per_expert = num_w2_tiles_h * 8 * w2_tile_size;  // 90 * 8
     constexpr uint32_t w2_total_size_per_layer = num_experts * w2_total_size_per_expert;
     constexpr uint32_t w2_layer_offset = layer_id * w2_total_size_per_layer;
 
@@ -125,7 +130,7 @@ void kernel_main() {
     const uint32_t w_cb_base_addr = get_write_ptr(cb_r2c_w0_w1);
 
     // Precompute slot addresses (avoid multiply in hot loop)
-    // Each slot holds 2 transactions (28 tiles)
+    // Each slot holds 1 block (20 tiles = 10 tiles/txn * 2 txns/block)
     const uint32_t slot_addr[NUM_SLOTS] = {
         w_cb_base_addr, w_cb_base_addr + w0_w1_bytes_per_block, w_cb_base_addr + 2 * w0_w1_bytes_per_block};
 

--- a/ttnn/cpp/ttnn/operations/experimental/moe_gpt/device/kernels/dm1.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/moe_gpt/device/kernels/dm1.cpp
@@ -51,8 +51,8 @@ void kernel_main() {
     constexpr uint32_t num_w0_w1_tiles_h = moe_gpt_ring::NUM_W0_W1_TILES_H;
     constexpr uint32_t num_w2_tiles_h = moe_gpt_ring::NUM_W2_TILES_H;
 
-    const uint32_t num_w0_w1_tiles_w = moe_gpt_ring::W0_W1_TILES_PER_CORE_PER_STEP_A[ring_core_id][0];
-    const uint32_t num_w2_tiles_w = moe_gpt_ring::W2_TILES_PER_CORE_A[ring_core_id];
+    const uint32_t num_w0_w1_tiles_w = moe_gpt_ring::W0_W1_TILES_PER_CORE_PER_STEP_A[ring_core_id][0];  // 7 or 8
+    const uint32_t num_w2_tiles_w = moe_gpt_ring::W2_TILES_PER_CORE_A[ring_core_id];                    // 7 or 8
 
     const uint32_t num_elt_tiles = num_w0_w1_tiles_w;
     const uint32_t num_in2_tiles = num_w2_tiles_w;
@@ -62,39 +62,54 @@ void kernel_main() {
     // Ring setup
     //-------------------------------------------------------------------------
     // The number of times to repeat the all2all
-    constexpr uint32_t num_a2a_iters = moe_gpt_ring::NUM_A2A_ITERS_A;
+    constexpr uint32_t num_a2a_iters = moe_gpt_ring::NUM_A2A_ITERS_A;  // 2
 
     // The number of steps to take in the all2all is the number of cores
-    constexpr uint32_t num_a2a_steps_per_iter = moe_gpt_ring::NUM_CORES;
+    constexpr uint32_t num_a2a_steps_per_iter = moe_gpt_ring::NUM_CORES;  // 12
 
-    // The number of tiles to send in each step
-    // We send 6 tiles in each step, even though some cores in some steps may have only 5 valid ones
-    constexpr uint32_t tiles_per_step = moe_gpt_ring::IN2_TILES_PER_STEP_A;  // max(num_w0_w1_tiles_w)
+    // The number of tiles to send in each step (max of 7/8 = 8 for GPT-OSS)
+    constexpr uint32_t tiles_per_step = moe_gpt_ring::IN2_TILES_PER_STEP_A;  // 8
 
     //-------------------------------------------------------------------------
     // Ring NoC setup
     //-------------------------------------------------------------------------
     uint32_t semaphore_addr = get_semaphore(ring_semaphore_id);
     volatile tt_l1_ptr uint32_t* my_semaphore_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(semaphore_addr);
+
     const uint64_t neighbor_semaphore_noc_addr =
         get_noc_addr(ring_neighbor_physical_x, ring_neighbor_physical_y, semaphore_addr);
 
-    // Size of each transfer in bytes
+    // Size of each transfer in bytes: 8 tiles * 2048 = 16384 bytes
     constexpr uint32_t a2a_xfer_bytes_per_step = tiles_per_step * in2_tile_size;
 
-    // Split into 2 packets
-    constexpr uint32_t a2a_packet_size = a2a_xfer_bytes_per_step / 2;
+    // NOC_MAX_BURST_SIZE = 8192 bytes on Wormhole. Split into packets of 4 tiles each
+    // (4 * 2048 = 8192 bytes = NOC_MAX_BURST_SIZE). 8 tiles / 4 tiles per packet = 2 packets.
+    constexpr uint32_t a2a_tiles_per_packet = 4;
+    constexpr uint32_t a2a_packet_size = a2a_tiles_per_packet * in2_tile_size;   // 8192
+    constexpr uint32_t a2a_num_packets = tiles_per_step / a2a_tiles_per_packet;  // 2
 
     // Source and destination addresses for the all2all
     const uint32_t local_base_addr = get_write_ptr(cb_s2c_in2);
     const uint64_t neighbor_base_addr =
         get_noc_addr(ring_neighbor_physical_x, ring_neighbor_physical_y, local_base_addr);
 
-    // Precompute buffer offsets
-    uint32_t LOCAL_BUFFER_OFFSET[num_a2a_steps_per_iter];
-    for (uint32_t i = 0; i < num_a2a_steps_per_iter; ++i) {
+    // 6 buffers for A2A intermediate data. 6 divides 12 (steps per iter),
+    // so buffer indices cycle back to 0 after a full ring rotation.
+    // 5 steps of slack between write and overwrite is sufficient for compute.
+    constexpr uint32_t NUM_A2A_BUFFERS = 6;
+    uint32_t LOCAL_BUFFER_OFFSET[NUM_A2A_BUFFERS];
+    for (uint32_t i = 0; i < NUM_A2A_BUFFERS; ++i) {
         LOCAL_BUFFER_OFFSET[i] = local_base_addr + i * a2a_xfer_bytes_per_step;
     }
+    // Reset semaphore to 0 for clean state on each invocation.
+    // When the program is cached and reused, the semaphore retains its value
+    // from the previous run. Resetting here is safe because:
+    // 1. The command queue guarantees all NOC activity from the previous
+    //    invocation has completed before this kernel starts.
+    // 2. All cores are waiting for cb_c2w_rdy (compute's SwiGLU) before
+    //    any ring activity begins, so no predecessor can write to our
+    //    semaphore before we reset it.
+    noc_semaphore_set(my_semaphore_ptr, 0);
     uint32_t semaphore_value = 0;
 
     // Set state for the data writes
@@ -113,8 +128,7 @@ void kernel_main() {
         cb_pop_front(cb_c2w_rdy, 1);
 
         // Take the data in cb_s2c_in2 and send it to the next core in the ring
-        // Ring synchronization: all cores participate regardless of whether they had CB work
-        // With 12 cores in a ring, we perform 12 steps so the signal propagates around the entire ring
+        // GPT-OSS: 2 A2A iterations x 12 steps = 24 rotations per expert
         for (uint32_t i = 0; i < num_a2a_iters; ++i) {
             for (uint32_t step = 0; step < num_a2a_steps_per_iter; ++step) {
                 // Wait for current data to be ready in cb_s2c_in2
@@ -125,14 +139,25 @@ void kernel_main() {
                 cb_reserve_back(cb_w2c_rdy, 1);
                 cb_push_back(cb_w2c_rdy, 1);
 
-                // Write 6 tiles from local cb_s2c_in2 to neighbor's cb_s2c_in2
-                // Double buffer offset: alternate between buffer 0 and buffer 1 based on step
-                const uint32_t local_src_addr = LOCAL_BUFFER_OFFSET[step & 1];
-                const uint64_t neighbor_dst_addr = LOCAL_BUFFER_OFFSET[!(step & 1)];
+                // Write 8 tiles from local cb_s2c_in2 to neighbor's cb_s2c_in2
+                // Buffer index cycles with modulo, resetting at each iteration.
+                const uint32_t src_buf = step % NUM_A2A_BUFFERS;
+                const uint32_t dst_buf = (step + 1) % NUM_A2A_BUFFERS;
+                const uint32_t local_src_addr = LOCAL_BUFFER_OFFSET[src_buf];
+                const uint64_t neighbor_dst_addr = LOCAL_BUFFER_OFFSET[dst_buf];
 
-                noc_async_write_one_packet_with_state</*posted=*/true>(local_src_addr, neighbor_dst_addr);
-                noc_async_write_one_packet_with_state</*posted=*/true>(
-                    local_src_addr + a2a_packet_size, neighbor_dst_addr + a2a_packet_size);
+                // Send as 2 packets of 4 tiles each (8192 bytes per packet)
+                for (uint32_t pkt = 0; pkt < a2a_num_packets; ++pkt) {
+                    uint32_t pkt_offset = pkt * a2a_packet_size;
+                    noc_async_write_one_packet_with_state</*posted=*/true>(
+                        local_src_addr + pkt_offset, neighbor_dst_addr + pkt_offset);
+                }
+
+                // Ensure all data packets are in the NOC before signaling readiness.
+                // Data writes (write_at_cmd_buf) and semaphore writes (write_at_cmd_buf)
+                // share the same command buffer, but without this flush the semaphore
+                // increment can overtake in-flight data packets at the destination.
+                noc_async_posted_writes_flushed();
 
                 // Signal neighbor that data is ready (increment their semaphore value)
                 noc_inline_dw_write_with_state<
@@ -145,6 +170,24 @@ void kernel_main() {
                 // Ensure writes have left the core before continuing
                 noc_async_posted_writes_flushed();
             }
+        }
+
+        // Cross-expert boundary barrier: after the ring loop, wait for the
+        // predecessor's FINAL write to our buf 0 before letting compute
+        // overwrite buf 0 with the next expert's SwiGLU.
+        //
+        // The predecessor's last A2A step (step 11, iter 1) writes to our
+        // dst_buf = (11+1)%12 = 0. The ring loop only waited for semaphore
+        // value (semaphore_value - 1) which confirms step 10's data, not
+        // step 11's. Here we wait for semaphore_value (set by ++semaphore_value
+        // on the last iteration), confirming the predecessor's step 11 write
+        // has landed at our L1.
+        if (expert_id < num_experts - 1) {
+            while ((*my_semaphore_ptr) < semaphore_value) {
+            };
+            // Signal compute that buf 0 is safe to overwrite
+            cb_reserve_back(cb_w2c_rdy, 1);
+            cb_push_back(cb_w2c_rdy, 1);
         }
     }
 }

--- a/ttnn/cpp/ttnn/operations/experimental/moe_gpt/device/kernels/moe_gpt_ring_common.h
+++ b/ttnn/cpp/ttnn/operations/experimental/moe_gpt/device/kernels/moe_gpt_ring_common.h
@@ -8,124 +8,129 @@
 #include <algorithm>
 
 //=============================================================================
-// MoEGPT Ring All-to-All Configuration
+// MoEGPT Ring All-to-All Configuration for GPT-OSS
 //
-// Two arrangements supported:
-// 1. Boundary-optimized: [6,6,5,5,5,5,5,5,6,6,5,5] - positions [0,1,8,9]
-//    Formula: ((source & 7) < 2) ? 6 : 5
-//    Best for dm0 block boundary alignment (9 boundary waits)
+// Dimensions:
+//   hidden_size (K) = 2880 -> 90 tiles
+//   intermediate_size (N) = 2880 -> 90 tiles
+//   experts/device = 4
 //
-// 2. Evenly distributed: [6,5,5,6,5,5,6,5,5,6,5,5] - positions [0,3,6,9]
-//    Formula: (source % 3 == 0) ? 6 : 5
-//    Simplest code pattern
+// W0/W1: [K, N] = [90, 90] tiles -> 7 or 8 tiles/core (90/12 = 7.5)
+// W2:    [N, K] = [90, 90] tiles -> 7 or 8 tiles/core (90/12 = 7.5)
+//
+// Both W0/W1 and W2 have the same distribution since K == N == 2880.
+// Boundary-optimized: cores {0,1,4,5,8,9} get 8 tiles, rest get 7.
 //=============================================================================
 
 namespace moe_gpt_ring {
 
 constexpr uint32_t NUM_CORES = 12;
 
-constexpr uint32_t NUM_W0_W1_TILES_H = 224;
-constexpr uint32_t NUM_W2_TILES_H = 64;
+// W0/W1 weight height in tiles: K / 32 = 2880 / 32 = 90
+constexpr uint32_t NUM_W0_W1_TILES_H = 90;
 
+// W2 weight height in tiles: N / 32 = 2880 / 32 = 90
+constexpr uint32_t NUM_W2_TILES_H = 90;
+
+// Transaction sizing for DRAM reads
+// Each transaction = 10 tiles of Bfp4_b = 10 * 576 = 5760 bytes (fits in 8KB NOC packet)
+// 10 is the largest factor of 90 that fits: 10 * 576 = 5760 < 8192
 constexpr uint32_t W0_W1_TXNS_PER_BLOCK = 2;
-constexpr uint32_t W0_W1_TILES_PER_TXN = 14;
+constexpr uint32_t W0_W1_TILES_PER_TXN = 10;
 
 constexpr uint32_t W2_TXNS_PER_BLOCK = 2;
-constexpr uint32_t W2_TILES_PER_TXN = 14;
+constexpr uint32_t W2_TILES_PER_TXN = 10;
 
-constexpr uint32_t W2_BLOCKS_PER_EXPERT = 50;
+// W2 blocks per expert = w2_blocks_per_four_mm2_tile * NUM_A2A_ITERS
+// = (4 * (90/10) / 2) * 2 = 18 * 2 = 36
+constexpr uint32_t W2_BLOCKS_PER_EXPERT = 36;
 
 //-----------------------------------------------------------------------------
-// Precomputed lookup tables (generated at compile time)
-// Use these if you prefer lookup over runtime computation
+// Precomputed lookup tables
+// W0/W1 width = 90 tiles / 12 cores = 7.5 -> 6 cores get 8, 6 cores get 7
+// Source tiles: {8,8,7,7,8,8,7,7,8,8,7,7}
+// Each row[core][step] = source_tiles[(core - step) mod 12]
 //-----------------------------------------------------------------------------
 
-// Boundary-optimized: tiles[core_id][step]
+// Boundary-optimized: cores {0,1,4,5,8,9} get 8 tiles
 constexpr uint32_t W0_W1_TILES_PER_CORE_PER_STEP_A[NUM_CORES][NUM_CORES] = {
     // Core 0: sources [0,11,10,9,8,7,6,5,4,3,2,1]
-    {6, 5, 5, 6, 6, 5, 5, 5, 5, 5, 5, 6},
+    {8, 7, 7, 8, 8, 7, 7, 8, 8, 7, 7, 8},
     // Core 1: sources [1,0,11,10,9,8,7,6,5,4,3,2]
-    {6, 6, 5, 5, 6, 6, 5, 5, 5, 5, 5, 5},
+    {8, 8, 7, 7, 8, 8, 7, 7, 8, 8, 7, 7},
     // Core 2: sources [2,1,0,11,10,9,8,7,6,5,4,3]
-    {5, 6, 6, 5, 5, 6, 6, 5, 5, 5, 5, 5},
+    {7, 8, 8, 7, 7, 8, 8, 7, 7, 8, 8, 7},
     // Core 3: sources [3,2,1,0,11,10,9,8,7,6,5,4]
-    {5, 5, 6, 6, 5, 5, 6, 6, 5, 5, 5, 5},
+    {7, 7, 8, 8, 7, 7, 8, 8, 7, 7, 8, 8},
     // Core 4: sources [4,3,2,1,0,11,10,9,8,7,6,5]
-    {5, 5, 5, 6, 6, 5, 5, 6, 6, 5, 5, 5},
+    {8, 7, 7, 8, 8, 7, 7, 8, 8, 7, 7, 8},
     // Core 5: sources [5,4,3,2,1,0,11,10,9,8,7,6]
-    {5, 5, 5, 5, 6, 6, 5, 5, 6, 6, 5, 5},
+    {8, 8, 7, 7, 8, 8, 7, 7, 8, 8, 7, 7},
     // Core 6: sources [6,5,4,3,2,1,0,11,10,9,8,7]
-    {5, 5, 5, 5, 5, 6, 6, 5, 5, 6, 6, 5},
+    {7, 8, 8, 7, 7, 8, 8, 7, 7, 8, 8, 7},
     // Core 7: sources [7,6,5,4,3,2,1,0,11,10,9,8]
-    {5, 5, 5, 5, 5, 5, 6, 6, 5, 5, 6, 6},
+    {7, 7, 8, 8, 7, 7, 8, 8, 7, 7, 8, 8},
     // Core 8: sources [8,7,6,5,4,3,2,1,0,11,10,9]
-    {6, 5, 5, 5, 5, 5, 5, 6, 6, 5, 5, 6},
+    {8, 7, 7, 8, 8, 7, 7, 8, 8, 7, 7, 8},
     // Core 9: sources [9,8,7,6,5,4,3,2,1,0,11,10]
-    {6, 6, 5, 5, 5, 5, 5, 5, 6, 6, 5, 5},
+    {8, 8, 7, 7, 8, 8, 7, 7, 8, 8, 7, 7},
     // Core 10: sources [10,9,8,7,6,5,4,3,2,1,0,11]
-    {5, 6, 6, 5, 5, 5, 5, 5, 5, 6, 6, 5},
+    {7, 8, 8, 7, 7, 8, 8, 7, 7, 8, 8, 7},
     // Core 11: sources [11,10,9,8,7,6,5,4,3,2,1,0]
-    {5, 5, 6, 6, 5, 5, 5, 5, 5, 5, 6, 6},
+    {7, 7, 8, 8, 7, 7, 8, 8, 7, 7, 8, 8},
 };
 
-// Evenly distributed: tiles[core_id][step]
+// Evenly distributed: cores {0,2,4,6,8,10} get 8 tiles
+// Source tiles: {8,7,8,7,8,7,8,7,8,7,8,7}
 constexpr uint32_t W0_W1_TILES_PER_CORE_PER_STEP_B[NUM_CORES][NUM_CORES] = {
-    // Core 0: pattern [6,5,5,6,5,5,6,5,5,6,5,5]
-    {6, 5, 5, 6, 5, 5, 6, 5, 5, 6, 5, 5},
-    // Core 1: pattern [5,6,5,5,6,5,5,6,5,5,6,5]
-    {5, 6, 5, 5, 6, 5, 5, 6, 5, 5, 6, 5},
-    // Core 2: pattern [5,5,6,5,5,6,5,5,6,5,5,6]
-    {5, 5, 6, 5, 5, 6, 5, 5, 6, 5, 5, 6},
-    // Core 3: same as Core 0
-    {6, 5, 5, 6, 5, 5, 6, 5, 5, 6, 5, 5},
-    // Core 4: same as Core 1
-    {5, 6, 5, 5, 6, 5, 5, 6, 5, 5, 6, 5},
-    // Core 5: same as Core 2
-    {5, 5, 6, 5, 5, 6, 5, 5, 6, 5, 5, 6},
-    // Core 6: same as Core 0
-    {6, 5, 5, 6, 5, 5, 6, 5, 5, 6, 5, 5},
-    // Core 7: same as Core 1
-    {5, 6, 5, 5, 6, 5, 5, 6, 5, 5, 6, 5},
-    // Core 8: same as Core 2
-    {5, 5, 6, 5, 5, 6, 5, 5, 6, 5, 5, 6},
-    // Core 9: same as Core 0
-    {6, 5, 5, 6, 5, 5, 6, 5, 5, 6, 5, 5},
-    // Core 10: same as Core 1
-    {5, 6, 5, 5, 6, 5, 5, 6, 5, 5, 6, 5},
-    // Core 11: same as Core 2
-    {5, 5, 6, 5, 5, 6, 5, 5, 6, 5, 5, 6},
+    {8, 7, 8, 7, 8, 7, 8, 7, 8, 7, 8, 7},  // Core 0
+    {7, 8, 7, 8, 7, 8, 7, 8, 7, 8, 7, 8},  // Core 1
+    {8, 7, 8, 7, 8, 7, 8, 7, 8, 7, 8, 7},  // Core 2
+    {7, 8, 7, 8, 7, 8, 7, 8, 7, 8, 7, 8},  // Core 3
+    {8, 7, 8, 7, 8, 7, 8, 7, 8, 7, 8, 7},  // Core 4
+    {7, 8, 7, 8, 7, 8, 7, 8, 7, 8, 7, 8},  // Core 5
+    {8, 7, 8, 7, 8, 7, 8, 7, 8, 7, 8, 7},  // Core 6
+    {7, 8, 7, 8, 7, 8, 7, 8, 7, 8, 7, 8},  // Core 7
+    {8, 7, 8, 7, 8, 7, 8, 7, 8, 7, 8, 7},  // Core 8
+    {7, 8, 7, 8, 7, 8, 7, 8, 7, 8, 7, 8},  // Core 9
+    {8, 7, 8, 7, 8, 7, 8, 7, 8, 7, 8, 7},  // Core 10
+    {7, 8, 7, 8, 7, 8, 7, 8, 7, 8, 7, 8},  // Core 11
 };
 
+// W2 tiles per core: 90 tiles / 12 cores = 7.5 -> 6 cores get 8, 6 cores get 7
+// Boundary-optimized: pairs at [0,1], [4,5], [8,9] get 8 tiles
 constexpr uint32_t W2_TILES_PER_CORE_A[NUM_CORES] = {
-    20,
-    20,
-    18,
-    18,
-    18,
-    18,
-    18,
-    18,
-    20,
-    20,
-    18,
-    18,
+    8,
+    8,
+    7,
+    7,
+    8,
+    8,
+    7,
+    7,
+    8,
+    8,
+    7,
+    7,
 };
 
+// Evenly distributed: alternating [0,2,4,6,8,10] get 8 tiles
 constexpr uint32_t W2_TILES_PER_CORE_B[NUM_CORES] = {
-    20,
-    18,
-    18,
-    20,
-    18,
-    18,
-    20,
-    18,
-    18,
-    20,
-    18,
-    18,
+    8,
+    7,
+    8,
+    7,
+    8,
+    7,
+    8,
+    7,
+    8,
+    7,
+    8,
+    7,
 };
 
+// IN2_TILES_PER_STEP = max of W0_W1 tiles per core per step = 8
 constexpr uint32_t IN2_TILES_PER_STEP_A = *std::max_element(
     W0_W1_TILES_PER_CORE_PER_STEP_A[0], W0_W1_TILES_PER_CORE_PER_STEP_A[0] + NUM_CORES, [](uint32_t a, uint32_t b) {
         return a < b;
@@ -136,6 +141,7 @@ constexpr uint32_t IN2_TILES_PER_STEP_B = *std::max_element(
         return a < b;
     });
 
+// NUM_A2A_ITERS = max(W2_TILES_PER_CORE) / 4 = 8 / 4 = 2
 constexpr uint32_t NUM_A2A_ITERS_A = *std::max_element(
                                          W2_TILES_PER_CORE_A,
                                          W2_TILES_PER_CORE_A + NUM_CORES,

--- a/ttnn/cpp/ttnn/operations/experimental/moe_gpt/device/kernels/swiglu_sfpu.h
+++ b/ttnn/cpp/ttnn/operations/experimental/moe_gpt/device/kernels/swiglu_sfpu.h
@@ -1,0 +1,136 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+//=============================================================================
+// GPT-OSS SwiGLU Activation for SFPU (runs on PACK thread)
+//
+// Formula:
+//   gate_clamped = clamp(gate, max=clamp_limit)
+//   up_clamped   = clamp(up, min=-clamp_limit, max=clamp_limit)
+//   result       = (up_clamped + 1) * gate_clamped * sigmoid(alpha * gate_clamped)
+//
+// Usage:
+//   // With default GPT-OSS config (alpha=1.702, clamp_limit=7.0):
+//   PACK((llk_math_eltwise_binary_sfpu_swiglu_init<true>()));
+//   PACK((llk_math_eltwise_binary_sfpu_swiglu<true, false>(gate, up, out)));
+//
+//   // With custom config:
+//   struct MyConfig { static constexpr float alpha = 1.0f; static constexpr float clamp_limit = 5.0f; };
+//   PACK((llk_math_eltwise_binary_sfpu_swiglu_init<true>()));
+//   PACK((llk_math_eltwise_binary_sfpu_swiglu<true, false, MyConfig>(gate, up, out)));
+//
+// This header is designed to be reusable across different models.
+// Include it from a compute kernel that runs SFPU on the PACK or MATH thread.
+//=============================================================================
+
+#if defined(TRISC_PACK) || defined(TRISC_MATH)
+
+#include "ckernel_sfpu_exp.h"
+#include "ckernel_sfpu_recip.h"
+#include "llk_math_eltwise_binary_sfpu_init.h"
+#include "llk_math_eltwise_binary_sfpu_params.h"
+
+namespace ckernel::sfpu {
+
+//-----------------------------------------------------------------------------
+// Configuration structs - add new models here
+//-----------------------------------------------------------------------------
+struct SwiGLUConfigGPTOSS {
+    static constexpr float alpha = 1.702f;
+    static constexpr float clamp_limit = 7.0f;
+};
+
+//-----------------------------------------------------------------------------
+// Sigmoid: sigmoid(x) = 1 / (1 + exp(-x))
+// Precision level matches dest accumulation mode.
+//-----------------------------------------------------------------------------
+template <bool is_fp32_dest_acc_en>
+sfpi_inline sfpi::vFloat _swiglu_sigmoid_(sfpi::vFloat x) {
+    sfpi::vFloat exp_neg_x;
+    if constexpr (is_fp32_dest_acc_en) {
+        exp_neg_x = _sfpu_exp_improved_<true>(-x);
+    } else {
+        exp_neg_x = _sfpu_exp_21f_<true>(-x);
+    }
+    sfpi::vFloat denominator = sfpi::vConst1 + exp_neg_x;
+    if constexpr (is_fp32_dest_acc_en) {
+        return _sfpu_reciprocal_<2>(denominator);
+    } else {
+        return _sfpu_reciprocal_<1>(denominator);
+    }
+}
+
+//-----------------------------------------------------------------------------
+// Core SwiGLU computation
+//-----------------------------------------------------------------------------
+template <bool is_fp32_dest_acc_en, int ITERATIONS = 8, class Config = SwiGLUConfigGPTOSS>
+inline void calculate_swiglu(const uint gate_tile_idx, const uint up_tile_idx, const uint out_tile_idx) {
+    constexpr float alpha = Config::alpha;
+    constexpr float clamp_limit = Config::clamp_limit;
+
+    constexpr uint dst_tile_size = 32;  // 32 rows per tile in SFPU addressing
+
+    for (int d = 0; d < ITERATIONS; d++) {
+        sfpi::vFloat gate = sfpi::dst_reg[gate_tile_idx * dst_tile_size];
+        sfpi::vFloat up = sfpi::dst_reg[up_tile_idx * dst_tile_size];
+
+        // Clamp gate: clamp(gate, max=clamp_limit)
+        v_if(gate > clamp_limit) { gate = clamp_limit; }
+        v_endif;
+
+        // Clamp up: clamp(up, min=-clamp_limit, max=clamp_limit)
+        v_if(up > clamp_limit) { up = clamp_limit; }
+        v_endif;
+        v_if(up < -clamp_limit) { up = -clamp_limit; }
+        v_endif;
+
+        // up = up + 1
+        up = up + sfpi::vConst1;
+
+        // sigmoid(alpha * gate)
+        sfpi::vFloat alpha_gate = gate * alpha;
+        sfpi::vFloat sig = _swiglu_sigmoid_<is_fp32_dest_acc_en>(alpha_gate);
+
+        // result = (up + 1) * gate * sigmoid(alpha * gate)
+        // Compute gate*sig first (bounded range, similar to SiLU), then multiply by up.
+        sfpi::vFloat glu = gate * sig;
+        sfpi::vFloat result = up * glu;
+
+        // Round to bf16 if not in fp32 dest accumulation mode
+        if constexpr (!is_fp32_dest_acc_en) {
+            result = sfpi::reinterpret<sfpi::vFloat>(sfpi::float_to_fp16b(result, 0));
+        }
+
+        sfpi::dst_reg[out_tile_idx * dst_tile_size] = result;
+        sfpi::dst_reg++;
+    }
+}
+
+template <bool APPROXIMATION_MODE>
+inline void swiglu_init() {
+    // SwiGLU uses sigmoid internally, which needs reciprocal table init.
+    _init_reciprocal_<false, false>();
+}
+
+}  // namespace ckernel::sfpu
+
+namespace ckernel {
+
+template <bool APPROXIMATE>
+inline void llk_math_eltwise_binary_sfpu_swiglu_init() {
+    llk_math_eltwise_binary_sfpu_init<SfpuType::unused, APPROXIMATE>(ckernel::sfpu::swiglu_init<APPROXIMATE>);
+}
+
+template <bool APPROXIMATE, bool is_fp32_dest_acc_en = false, class Config = ckernel::sfpu::SwiGLUConfigGPTOSS>
+inline void llk_math_eltwise_binary_sfpu_swiglu(
+    uint gate_tile, uint32_t up_tile, uint32_t out_tile, int vector_mode = VectorMode::RC) {
+    _llk_math_eltwise_binary_sfpu_params_<APPROXIMATE>(
+        ckernel::sfpu::calculate_swiglu<is_fp32_dest_acc_en, 8, Config>, gate_tile, up_tile, out_tile, vector_mode);
+}
+
+}  // namespace ckernel
+
+#endif  // TRISC_PACK || TRISC_MATH

--- a/ttnn/cpp/ttnn/operations/experimental/moe_gpt/device/moe_gpt_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/moe_gpt/device/moe_gpt_program_factory.cpp
@@ -29,26 +29,30 @@ MoEGPTProgramFactory::cached_program_t MoEGPTProgramFactory::create(
     const uint32_t num_cores = dram_bank2core_coords.size();
     auto all_cores = tt::tt_metal::CoreRangeSet(dram_bank2core_coords);
 
-    // CBs used in the MoEGPT operation
+    // CBs used in the MoEGPT operation (GPT-OSS dimensions: K=N=2880)
     /*
         ------------------------------------------------------------------------------------
         |     Name       |   CB Index    |   Dtype    | Tile? | Tiles/CB |  Total size (B) |
         ------------------------------------------------------------------------------------
-        | cb_r2c_w0      | CBIndex::c_0  | Bfp4_b     | true  |    14*6  |      48384      |
-        | cb_s2c_in(sh)  | CBIndex::c_1  | Float16_b  | true  |    224*2 |      917504     |
+        | cb_r2c_w0      | CBIndex::c_0  | Bfp4_b     | true  |  10*2*3  |      34560      |
+        | cb_s2c_in(sh)  | CBIndex::c_1  | Float16_b  | true  |   90*4   |      737280     |
         | cb_c2w_rdy     | CBIndex::c_2  | Float32    | false |    1     |      4          |
         | cb_w2c_rdy     | CBIndex::c_3  | Float32    | false |    1     |      4          |
-        | cb_s2c_in2     | CBIndex::c_4  | Float16_b  | true  |    6*2   |      24576      |
+        | cb_s2c_in2     | CBIndex::c_4  | Float16_b  | true  |   8*6    |      98304      |
         ------------------------------------------------------------------------------------
+        Total L1 ~= 530 KB (fits in 1.2 MB L1)
     */
 
     // Define the CB configuration as a tuple: name, CBIndex, DataFormat, tiles_per_cb
     // Note: cb_s2c_in is handled separately as it is sharded CB
+    // cb_r2c_w0: triple-buffered, each slot = W0_W1_TILES_PER_TXN * W0_W1_TXNS_PER_BLOCK = 10*2 = 20 tiles
+    // cb_s2c_in2: 6 buffers for A2A ring data. 6 divides 12 (steps per iter),
+    // giving 5 slots of slack between write and overwrite. Each slot = 8 tiles (IN2_TILES_PER_STEP).
     const std::vector<std::tuple<std::string, tt::CBIndex, tt::DataFormat, bool, uint32_t>> cb_specs0 = {
-        {"cb_r2c_w0", tt::CBIndex::c_0, tt::DataFormat::Bfp4_b, true, 14 * 6},
+        {"cb_r2c_w0", tt::CBIndex::c_0, tt::DataFormat::Bfp4_b, true, 10 * 2 * 3},
         {"cb_c2w_rdy", tt::CBIndex::c_2, tt::DataFormat::Float32, false, 1},
         {"cb_w2c_rdy", tt::CBIndex::c_3, tt::DataFormat::Float32, false, 1},
-        {"cb_s2c_in2", tt::CBIndex::c_4, tt::DataFormat::Float16_b, true, 6 * 2},
+        {"cb_s2c_in2", tt::CBIndex::c_4, tt::DataFormat::Float16_b, true, 8 * 6},
     };
 
     [[maybe_unused]] std::map<std::string, tt::tt_metal::CBHandle> cb_handles, cb_handles_sharded;
@@ -70,7 +74,7 @@ MoEGPTProgramFactory::cached_program_t MoEGPTProgramFactory::create(
              tt::CBIndex::c_1,
              tt::DataFormat::Float16_b,
              true,
-             224 * 2,
+             90 * 4,  // E=4 experts, each needs 90 tiles of input (K=2880/32=90)
              tensor_args.input_tensor.buffer()}};
 
     for (const auto& [name, index, data_format, is_tile, tiles_per_cb, p_buffer] : sharded_cb_specs) {


### PR DESCRIPTION
Port the moe_gpt fused expert kernel to GPT-OSS model dimensions (hidden=intermediate=2880, E=4 experts/device). Key changes:

- Replace SiLU+MUL activation with SwiGLU (swiglu_sfpu.h)
- Update all tile dimensions: K=N=90 tiles, 7-8 tiles/core (90/12)
- Fix semaphore reset for program caching correctness
- Add cross-expert boundary barrier for buf 0 safety
- Use 6-buffer A2A cycling scheme with 2 packets/step
- Add test, profiling scripts, and integration guide

Performance: 68.2 us/expert at 76% DRAM BW utilization.
Accuracy: PCC ~0.990 (threshold 0.984), 5/5 stable.

See docs/moe_gpt_gpt_oss_integration.md for full architecture docs.

### Ticket
Link to Github Issue

### Problem description
Provide context for the problem.

### What's changed
Describe the approach used to solve the problem.
Summarize the changes made and its impact.

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=handrews/gpt-oss-moe-fused-kernel)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:handrews/gpt-oss-moe-fused-kernel)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=handrews/gpt-oss-moe-fused-kernel)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:handrews/gpt-oss-moe-fused-kernel)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=handrews/gpt-oss-moe-fused-kernel)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:handrews/gpt-oss-moe-fused-kernel)
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=handrews/gpt-oss-moe-fused-kernel)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:handrews/gpt-oss-moe-fused-kernel)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=handrews/gpt-oss-moe-fused-kernel)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:handrews/gpt-oss-moe-fused-kernel)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=handrews/gpt-oss-moe-fused-kernel)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:handrews/gpt-oss-moe-fused-kernel)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
