### PR TITLE
#38134: Shape type for `ttnn.sort` fix.

### DIFF
--- a/tests/ttnn/unit_tests/operations/data_movement/test_sort.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_sort.py
@@ -30,6 +30,7 @@ TILE_WIDTH = 32
         ([1, 64, 64], 2, False),
         ([1, 64], 0, False),
         ([1, 64], 1, True),
+        ([237], 0, False),
     ],
 )
 def test_sort_standard(shape, dim, descending, device):
@@ -48,7 +49,7 @@ def test_sort_standard(shape, dim, descending, device):
     assert list(ttnn_sort_values.shape) == shape
     assert list(ttnn_sort_indices.shape) == shape
 
-    if len(shape) == 0 or len(shape) == 1:
+    if len(shape) == 0 or (len(shape) == 1 and shape[0] == 1):
         assert torch_sort_values == ttnn.to_torch(ttnn_sort_values)
         assert torch_sort_indices == ttnn.to_torch(ttnn_sort_indices)
     else:

--- a/ttnn/cpp/ttnn/operations/data_movement/sort/sort.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sort/sort.cpp
@@ -163,7 +163,7 @@ std::vector<Tensor> ExecuteSort::invoke(
     const std::optional<MemoryConfig>& memory_config,
     std::optional<std::tuple<Tensor&, Tensor&>> optional_output_tensors) {
     const ttnn::Shape& original_lshape = input_tensor.logical_shape();
-    auto rank = input_tensor.padded_shape().rank();
+    const auto rank = input_tensor.logical_shape().rank();
 
     // Check for early exit for scalar or empty tensors tensors
     if ((original_lshape == ttnn::Shape{}) || (original_lshape == ttnn::Shape{1})) {


### PR DESCRIPTION
### Ticket

#38134

### Problem description
`ttnn.sort` was failing on one of the models due to corner case issue with shape type.

### What's changed
- Added failing case to tests,
- changed shape type in implementation.

### Checklist

- [x] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=mgajewskiTT/38134-bug-report-ttnnsort-fails-with-cant-convert-shape-rank-on-1d-tensors)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:mgajewskiTT/38134-bug-report-ttnnsort-fails-with-cant-convert-shape-rank-on-1d-tensors)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=mgajewskiTT/38134-bug-report-ttnnsort-fails-with-cant-convert-shape-rank-on-1d-tensors)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:mgajewskiTT/38134-bug-report-ttnnsort-fails-with-cant-convert-shape-rank-on-1d-tensors)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mgajewskiTT/38134-bug-report-ttnnsort-fails-with-cant-convert-shape-rank-on-1d-tensors)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mgajewskiTT/38134-bug-report-ttnnsort-fails-with-cant-convert-shape-rank-on-1d-tensors)
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mgajewskiTT/38134-bug-report-ttnnsort-fails-with-cant-convert-shape-rank-on-1d-tensors)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mgajewskiTT/38134-bug-report-ttnnsort-fails-with-cant-convert-shape-rank-on-1d-tensors)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mgajewskiTT/38134-bug-report-ttnnsort-fails-with-cant-convert-shape-rank-on-1d-tensors)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mgajewskiTT/38134-bug-report-ttnnsort-fails-with-cant-convert-shape-rank-on-1d-tensors)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mgajewskiTT/38134-bug-report-ttnnsort-fails-with-cant-convert-shape-rank-on-1d-tensors)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mgajewskiTT/38134-bug-report-ttnnsort-fails-with-cant-convert-shape-rank-on-1d-tensors)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
