### PR TITLE
#28937: Update mish op

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_unary.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_unary.py
@@ -2144,3 +2144,25 @@ def test_unary_logical_not(device, torch_dtype, ttnn_dtype):
     golden_function = ttnn.get_golden_function(ttnn.logical_not)
     golden_tensor = golden_function(in_data, device=device)
     assert torch.equal(output_tensor, golden_tensor)
+
+
+@pytest.mark.parametrize("fast_and_approximate_mode", [True, False])
+@pytest.mark.parametrize(
+    "torch_dtype, ttnn_dtype",
+    [
+        (torch.bfloat16, ttnn.bfloat16),
+        (torch.float32, ttnn.float32),
+    ],
+)
+def test_unary_mish(torch_dtype, ttnn_dtype, fast_and_approximate_mode, device):
+    torch.manual_seed(0)
+    in_data = torch.empty((2, 32, 64), dtype=torch_dtype).uniform_(-20, 100)
+
+    input_tensor = ttnn.from_torch(in_data, dtype=ttnn_dtype, layout=ttnn.TILE_LAYOUT, device=device)
+    output_tensor = ttnn.mish(input_tensor, fast_and_approximate_mode=fast_and_approximate_mode)
+    output_tensor = ttnn.to_torch(output_tensor)
+
+    golden_function = ttnn.get_golden_function(ttnn.mish)
+    golden_tensor = golden_function(in_data)
+    golden_tensor = golden_tensor.to(output_tensor.dtype)
+    assert_allclose(golden_tensor, output_tensor, rtol=1e-05, atol=0.008)

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_utils.cpp
@@ -566,6 +566,8 @@ std::pair<std::string, std::string> get_op_init_and_func_parameterized(
                 fmt::format("hardmish_tile_init<{}u>();", (uint32_t)param0),
                 fmt::format("hardmish_tile<{1}u>({0});", idst, (uint32_t)param0)};
         }
+        case UnaryOpType::MISH:
+            return {};// MISH uses dedicated mish_kernel.cpp;
         case UnaryOpType::RSQRT: {
             return {"rsqrt_tile_init<false>();", fmt::format("rsqrt_tile<false, {1}>({0});", idst, param0_raw)};
         }
@@ -763,7 +765,6 @@ std::pair<std::string, std::string> get_op_init_and_func_default(
         case UnaryOpType::HARDSIGMOID: return {"hardsigmoid_tile_init();", fmt::format("hardsigmoid_tile({});", idst)};
         case UnaryOpType::SOFTSIGN: return {"softsign_tile_init();", fmt::format("softsign_tile({});", idst)};
         case UnaryOpType::LGAMMA:
-        case UnaryOpType::MISH:
         case UnaryOpType::IDENTITY:
         case UnaryOpType::BITCAST:
             // Bitcast uses identity kernel (copy_tile + pack_tile) - no LLK needed
@@ -890,7 +891,10 @@ UnaryWithParam string_to_unary_with_param(const std::string& name) {
         return UnaryWithParam(UnaryOpType::HARDMISH, static_cast<float>(true));
     }
     if (name == "mish") {
-        return UnaryWithParam(UnaryOpType::MISH);
+        return UnaryWithParam(UnaryOpType::MISH, static_cast<float>(false));
+    }
+    if (name == "mish_approx") {
+        return UnaryWithParam(UnaryOpType::MISH, static_cast<float>(true));
     }
     TT_THROW("Unknown unary op: {}", name);
 }

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_utils.hpp
@@ -99,7 +99,8 @@ bool is_parametrized_type(T val) {
         case UnaryOpType::CLAMP_TSS:
         case UnaryOpType::SELU:
         case UnaryOpType::LOGIT:
-        case UnaryOpType::RPOW: return true;
+        case UnaryOpType::RPOW:
+        case UnaryOpType::MISH: return true;
         default: return false;
     }
     return false;

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/compute/mish_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/compute/mish_kernel.cpp
@@ -17,6 +17,8 @@
 void kernel_main() {
     uint32_t per_core_block_cnt = get_compile_time_arg_val(0);
     uint32_t per_core_block_dim = get_compile_time_arg_val(1);
+    const uint32_t approx_arg = get_arg_val<uint32_t>(0);
+    const bool use_approx = (approx_arg != 0u);
 
     constexpr auto cb_input = tt::CBIndex::c_0;
     constexpr auto cb_output = tt::CBIndex::c_2;
@@ -32,12 +34,19 @@ void kernel_main() {
             copy_tile_to_dst_init_short(cb_input);
             copy_tile(cb_input, 0, 0);
 
-            exp_tile_init<1u>();
-            exp_tile<1u>(0);
-            log1p_tile_init<true>();
-            log1p_tile<true>(0);
-            tanh_tile_init();
-            tanh_tile(0);
+            if (use_approx) {
+                exp_tile_init<true>();
+                exp_tile<true>(0);
+                log1p_tile_init<true>();
+                log1p_tile<true>(0);
+            } else {
+                exp_tile_init<false, true>();
+                exp_tile<false, true>(0);
+                log1p_tile_init<false>();
+                log1p_tile<false>(0);
+            }
+            tanh_tile_init<false>();
+            tanh_tile<false>(0);
 
 #ifdef INP_FLOAT32
             copy_tile(cb_input, 0, 1);

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_program_factory.cpp
@@ -127,6 +127,7 @@ UnaryProgramFactory::cached_program_t UnaryProgramFactory::create(
     if (!ops_chain[0].empty()) {
         switch (ops_chain[0].type()) {
             case UnaryOpType::HARDSHRINK:
+            case UnaryOpType::MISH:
                 packed_scalar1 = utils::pack_scalar_runtime_arg(ops_chain[0], 0, input.dtype());
                 break;
             case UnaryOpType::WHERE_TSS:
@@ -373,6 +374,7 @@ UnarySubCoreGridProgramFactory::cached_program_t UnarySubCoreGridProgramFactory:
     if (!ops_chain[0].empty()) {
         switch (ops_chain[0].type()) {
             case UnaryOpType::HARDSHRINK:
+            case UnaryOpType::MISH:
                 packed_scalar1 = utils::pack_scalar_runtime_arg(ops_chain[0], 0, input.dtype());
                 break;
             case UnaryOpType::WHERE_TSS:

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_sharded_program_factory.cpp
@@ -153,6 +153,7 @@ UnaryShardedProgramFactory::cached_program_t UnaryShardedProgramFactory::create(
     if (!ops_chain[0].empty()) {
         switch (ops_chain[0].type()) {
             case UnaryOpType::HARDSHRINK:
+            case UnaryOpType::MISH:
                 packed_scalar1 = utils::pack_scalar_runtime_arg(ops_chain[0], 0, input.dtype());
                 break;
             case UnaryOpType::WHERE_TSS:

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/unary.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/unary.cpp
@@ -152,6 +152,7 @@ template struct ExecuteUnaryWithFastAndApproximateMode<UnaryOpType::LOG2>;
 template struct ExecuteUnaryWithFastAndApproximateMode<UnaryOpType::LOG1P>;
 template struct ExecuteUnaryWithFastAndApproximateMode<UnaryOpType::RSQRT>;
 template struct ExecuteUnaryWithFastAndApproximateMode<UnaryOpType::SQRT>;
+template struct ExecuteUnaryWithFastAndApproximateMode<UnaryOpType::MISH>;
 
 template <UnaryOpType unary_op_type>
 Tensor ExecuteUnaryWithVectorAndFastAndApproximateMode<unary_op_type>::invoke(
@@ -396,15 +397,6 @@ Tensor Abs::invoke(
 
 Tensor Abs::invoke(const ComplexTensor& input_tensor, const MemoryConfig& output_mem_config) {
     return ttnn::hypot(input_tensor[0], input_tensor[1], output_mem_config);
-}
-
-Tensor Mish::invoke(
-    const Tensor& input_tensor,
-    const std::optional<MemoryConfig>& memory_config,
-    const std::optional<Tensor>& optional_output_tensor) {
-    UnaryOpType op_type = UnaryOpType::MISH;
-
-    return detail::unary_impl(input_tensor, {UnaryWithParam{op_type}}, memory_config, optional_output_tensor);
 }
 
 Tensor LogSigmoid::invoke(

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/unary.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/unary.hpp
@@ -246,13 +246,6 @@ struct AsymmetricBinop {
         const std::optional<Tensor>& optional_output_tensor = std::nullopt);
 };
 
-struct Mish {
-    static Tensor invoke(
-        const Tensor& input_tensor,
-        const std::optional<MemoryConfig>& memory_config = std::nullopt,
-        const std::optional<Tensor>& optional_output_tensor = std::nullopt);
-};
-
 struct Tanhshrink {
     static Tensor invoke(
         const Tensor& input_tensor,
@@ -504,7 +497,7 @@ REGISTER_UNARY_OPERATION_WITH_OPTIONAL_INTEGER_PARAMETER(round, ROUND, int32_t);
 constexpr auto identity = ttnn::register_operation<"ttnn::identity", ttnn::operations::unary::Identity>();
 constexpr auto abs = ttnn::register_operation<"ttnn::abs", ttnn::operations::unary::Abs>();
 constexpr auto eqz = ttnn::register_operation<"ttnn::eqz", ttnn::operations::unary::Eqz>();
-constexpr auto mish = ttnn::register_operation<"ttnn::mish", ttnn::operations::unary::Mish>();
+REGISTER_UNARY_OPERATION_WITH_FAST_AND_APPROXIMATE_MODE(mish, MISH);
 constexpr auto hardmish = ttnn::register_operation<"ttnn::hardmish", ttnn::operations::unary::Hardmish>();
 constexpr auto hardshrink = ttnn::register_operation<"ttnn::hardshrink", ttnn::operations::unary::Hardshrink>();
 constexpr auto logit = ttnn::register_operation<"ttnn::logit", ttnn::operations::unary::Logit>();

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/unary_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/unary_nanobind.cpp
@@ -2032,12 +2032,6 @@ void py_module(nb::module_& mod) {
         R"doc(BFLOAT16, BFLOAT8_B, FLOAT32)doc");
     bind_unary_operation(
         mod,
-        ttnn::mish,
-        R"doc(\mathrm{{output\_tensor}}_i = \verb|mish|(\mathrm{{input\_tensor}}_i))doc",
-        "[Supported range -20 to inf]",
-        R"doc(BFLOAT16, BFLOAT8_B, FLOAT32)doc");
-    bind_unary_operation(
-        mod,
         ttnn::hardmish,
         R"doc(\mathrm{{output\_tensor}}_i = \mathrm{{input\_tensor}}_i \times \frac{{\min(\max(\mathrm{{input\_tensor}}_i + 2.8, 0), 5)}}{{5}})doc",
         "[Supported range -20 to inf]",
@@ -2265,7 +2259,8 @@ void py_module(nb::module_& mod) {
     bind_unary_operation_with_fast_and_approximate_mode(mod, ttnn::log2, "", R"doc(BFLOAT16, BFLOAT8_B, FLOAT32)doc");
     bind_unary_operation_with_fast_and_approximate_mode(
         mod, ttnn::log1p, R"doc([Supported range: [-1, 1e7]])doc", R"doc(BFLOAT16, BFLOAT8_B, FLOAT32)doc");
-
+    bind_unary_operation_with_fast_and_approximate_mode(
+        mod, ttnn::mish, "[Supported range -20 to inf]", R"doc(BFLOAT16, BFLOAT8_B, FLOAT32)doc");
     // Unaries with float parameter
     bind_unary_composite_with_default_float(
         mod, ttnn::elu, "alpha", "The alpha parameter for the ELU function", 1.0f, R"doc(BFLOAT16, BFLOAT8_B)doc");


### PR DESCRIPTION
### Ticket
Link to Github Issue #28937 

### What's changed

- Introduced a more accurate version of the mish op.
- The new version improves numerical accuracy, with a slight performance degradation compared to the fast approximation version.

|Mode               | (1,1,32,32)     ns  | (1,1,1024,1024)  ns |
| -------------------- | ----------------- | ----------------- |
| fast approx = true   | 4241              | 47380             |
| fast approx = false  | 5751              | 71856             |
| **Perf Degradation** | **+35.6% slower** | **+51.7% slower** |

### Mish ULP Distribution Comparison

#### bfloat16

| ULP Range   | Current Version           | Accurate Version            |
|-------------|---------------------------|-----------------------------|
| ULP = 0     | 32,835 (50.1022%)         | 45,469 (69.3802%)           |
| ULP = 1     | 1,445 (2.2049%)              | 17,545 (26.7715%)           |
| ULP = 2     | 8,994 (13.7238%)              | 1,901 (2.9007%)             |
| ULP 3–10    | 21,267 (32.4509%)           | 526 (0.8026%)               |
| ULP 11–100  |  900 (1.3733%)        | 0 (0.0000%)                 |
| ULP > 100   | 95 (0.1450%)         | 95 (0.1450%)                |

#### float32

| ULP Range   | Current Version           | Accurate Version            |
|-------------|---------------------------|-----------------------------|
| ULP = 0     | 32,252 (49.2126%)         | 60,678 (92.5873%)           |
| ULP = 1     | 32 (0.0488%)              | 3,125 (4.7684%)             |
| ULP = 2     | 15 (0.0229%)              | 1,253 (1.9119%)             |
| ULP 3–10    | 24 (0.0366%)              | 471 (0.7187%)               |
| ULP 11–100  | 42 (0.0641%)              | 0 (0.0000%)                 |
| ULP > 100   | 33,171 (50.6149%)         | 9 (0.0137%)                 |


### Checklist

- [x] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=mouliraj/mish_update)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:mouliraj/mish_update)
- [x] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=mouliraj/mish_update)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:mouliraj/mish_update)
- [x] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mouliraj/mish_update)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mouliraj/mish_update)
- [x]  Single card Frequent model and ttnn tests 
- [x]  Single card Model Perf Test.
- [ ] Single card Device perf Test.

