### PR TITLE
Fix tile/face terminology in tensor layout documentation

### DIFF
--- a/docs/source/ttnn/ttnn/tensor.rst
+++ b/docs/source/ttnn/ttnn/tensor.rst
@@ -84,7 +84,7 @@ You can create tile layout tensors using any creation function (e.g. :ref:`ttnn.
     >>> print(t.layout)
     Layout.TILE
 
-Data inside the tile isn't contiguous. Each tile is split into faces ("sub-tiles"). By default, tile size is 32x32, and face size is 16x16 -- 4 faces per tile and each tile lies one after another contiguously in memory in row-major fashion (i.e., face0->face1->face2->face3 on the picture below)
+Data inside the tile isn't contiguous. Each tile is split into faces ("sub-tiles"). By default, tile size is 32x32, and face size is 16x16 -- 4 faces per tile and each face lies one after another contiguously in memory in row-major fashion (i.e., face0->face1->face2->face3 on the picture below)
 
 .. figure:: images/tile_faces.png
     :align: center

--- a/tech_reports/tensor_layouts/tensor_layouts.md
+++ b/tech_reports/tensor_layouts/tensor_layouts.md
@@ -57,7 +57,7 @@ In a tiled tensor, pages are represented as 2D tiles, with the default tile size
 The hardware architecture supports tile shapes of `32x32` , `16x32` , `4x32`, `2x32`, `1x32`. **However currently TT-Metalium only supports 32x32, with limited functionality for 16x32 in some ops such as matmul**
 
 #### 3.2.2 Faces
-Data inside the tile isn't contiguous. Each tile is split into faces ("sub-tiles"). By default, tile size is 32x32, and face size is 16x16 -- 4 faces per tile and each tile lies one after another contiguously in memory in row-major fashion (i.e., face0->face1->face2->face3 on the picture below)
+Data inside the tile isn't contiguous. Each tile is split into faces ("sub-tiles"). By default, tile size is 32x32, and face size is 16x16 -- 4 faces per tile and each face lies one after another contiguously in memory in row-major fashion (i.e., face0->face1->face2->face3 on the picture below)
 
 The reason for using faces is that the matrix engine natively multiplies 16x16 matrices, and tile multiplication is decomposed into multiple face multiplications.
 


### PR DESCRIPTION
Correct text from "each tile lies one after another contiguously in memory" to "each face lies one after another contiguously in memory" since tiles are not contiguous, but faces within tiles are laid out contiguously.

### Ticket
N/A

### Problem description
error in documentation

### What's changed
small documentation change

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=jjovicic/doc-change)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:jjovicic/doc-change)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=jjovicic/doc-change)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:jjovicic/doc-change)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=jjovicic/doc-change)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jjovicic/doc-change)
- [x] New/Existing tests provide coverage for changes