### PR TITLE
add channel trimming support to fabric test infrastructure

### DIFF
--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_features.yaml
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_features.yaml
@@ -417,3 +417,28 @@ Tests:
           - destination:
               device: [0, [1, 0]]
               core: all
+
+  # ======================================================================================
+  # Test 16: Channel Trimming
+  # This demonstrates the channel trimming feature. When enabled, the test runs twice:
+  # first with fabric channel trimming capture enabled (recording which router channels
+  # are actually used), then with the fabric relaunched consuming the captured profile
+  # (optimizing router construction by disabling unused channels).
+  # For parameterized tests, all parametrizations share the same capture.
+  # ======================================================================================
+  - name: "ChannelTrimming"
+    fabric_setup:
+      topology: Linear
+      enable_channel_trimming: true
+
+    defaults:
+      ftype: unicast
+      ntype: unicast_write
+      size: 1024
+      num_packets: 100
+
+    senders:
+      - device: 0
+        patterns:
+          - destination:
+              device: 1

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_tt_fabric.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_tt_fabric.cpp
@@ -112,6 +112,8 @@ int main(int argc, char** argv) {
 
     cmdline_parser.apply_overrides(raw_test_configs);
 
+    raw_test_configs = tt::tt_fabric::fabric_tests::expand_channel_trimming(std::move(raw_test_configs));
+
     if (raw_test_configs.empty()) {
         log_fatal(tt::LogTest, "No test configurations loaded or generated. Exiting.");
         return 1;
@@ -177,7 +179,8 @@ int main(int argc, char** argv) {
             topology,
             fabric_tensix_config);
 
-        bool open_devices_success = test_context.open_devices(test_config.fabric_setup);
+        bool open_devices_success = test_context.open_devices(
+            test_config.fabric_setup, test_config.channel_trimming_mode);
         if (!open_devices_success) {
             log_warning(
                 tt::LogTest, "Skipping Test Group: {} due to unsupported fabric configuration", test_config.name);

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_common.hpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_common.hpp
@@ -11,6 +11,7 @@
 #include <optional>
 #include <random>
 #include <string>
+#include <filesystem>
 #include <cstdlib>
 
 #include <tt-metalium/experimental/fabric/mesh_graph.hpp>
@@ -147,7 +148,8 @@ public:
             local_mesh_id_, MeshScope::LOCAL);
     }
 
-    bool open_devices(const TestFabricSetup& fabric_setup) {
+    bool open_devices(const TestFabricSetup& fabric_setup,
+                      ChannelTrimmingMode channel_trimming_mode = ChannelTrimmingMode::NONE) {
         const auto& topology = fabric_setup.topology;
         const auto& fabric_tensix_config = fabric_setup.fabric_tensix_config.value();
 
@@ -195,15 +197,37 @@ public:
 
         if (new_fabric_config != current_fabric_config_ || fabric_tensix_config != current_fabric_tensix_config_ ||
             reliability_mode != current_fabric_reliability_mode_ ||
-            fabric_setup.max_packet_size != current_max_packet_size_) {
+            fabric_setup.max_packet_size != current_max_packet_size_ ||
+            channel_trimming_mode != current_channel_trimming_mode_) {
             if (are_devices_open_) {
                 log_info(tt::LogTest, "Closing devices and switching to new fabric config: {}", new_fabric_config);
                 close_devices();
             }
+            // Configure channel trimming rtoptions before opening devices
+            auto& rtoptions = tt::tt_metal::MetalContext::instance().rtoptions();
+            switch (channel_trimming_mode) {
+                case ChannelTrimmingMode::CAPTURE:
+                    rtoptions.set_enable_channel_trimming_capture(true);
+                    rtoptions.set_fabric_trimming_profile_path("");
+                    break;
+                case ChannelTrimmingMode::REPLAY: {
+                    rtoptions.set_enable_channel_trimming_capture(false);
+                    auto path = std::filesystem::path(rtoptions.get_logs_dir()) / "generated" / "reports" /
+                                "channel_trimming_capture.yaml";
+                    rtoptions.set_fabric_trimming_profile_path(path.string());
+                    break;
+                }
+                case ChannelTrimmingMode::NONE:
+                    rtoptions.set_enable_channel_trimming_capture(false);
+                    rtoptions.set_fabric_trimming_profile_path("");
+                    break;
+            }
+
             log_info(tt::LogTest, "Opening devices with fabric reliability mode: {}", reliability_mode);
             open_devices_internal(new_fabric_config, fabric_tensix_config, reliability_mode, fabric_setup);
 
             topology_ = topology;
+            current_channel_trimming_mode_ = channel_trimming_mode;
         } else {
             log_info(tt::LogTest, "Reusing existing device setup with fabric config: {}", current_fabric_config_);
         }
@@ -248,6 +272,7 @@ public:
         current_fabric_tensix_config_ = tt_fabric::FabricTensixConfig::DISABLED;
         current_fabric_reliability_mode_ = tt_fabric::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE;
         current_max_packet_size_ = std::nullopt;
+        current_channel_trimming_mode_ = ChannelTrimmingMode::NONE;
         are_devices_open_ = false;
     }
 
@@ -1749,6 +1774,7 @@ private:
     tt_fabric::FabricReliabilityMode current_fabric_reliability_mode_{
         tt_fabric::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE};
     std::optional<uint32_t> current_max_packet_size_{std::nullopt};
+    ChannelTrimmingMode current_channel_trimming_mode_{ChannelTrimmingMode::NONE};
     std::shared_ptr<MeshDevice> mesh_device_;
     std::shared_ptr<MeshWorkload> mesh_workload_;
     MeshId local_mesh_id_;

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_common.hpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_common.hpp
@@ -148,6 +148,27 @@ public:
             local_mesh_id_, MeshScope::LOCAL);
     }
 
+    void setup_channel_trimming_rtoptions(ChannelTrimmingMode channel_trimming_mode) {
+        auto& rtoptions = tt::tt_metal::MetalContext::instance().rtoptions();
+        switch (channel_trimming_mode) {
+            case ChannelTrimmingMode::CAPTURE:
+                rtoptions.set_enable_channel_trimming_capture(true);
+                rtoptions.set_fabric_trimming_profile_path("");
+                break;
+            case ChannelTrimmingMode::REPLAY: {
+                rtoptions.set_enable_channel_trimming_capture(false);
+                auto path = std::filesystem::path(rtoptions.get_logs_dir()) / "generated" / "reports" /
+                            "channel_trimming_capture.yaml";
+                rtoptions.set_fabric_trimming_profile_path(path.string());
+                break;
+            }
+            case ChannelTrimmingMode::NONE:
+                rtoptions.set_enable_channel_trimming_capture(false);
+                rtoptions.set_fabric_trimming_profile_path("");
+                break;
+        }
+    }
+
     bool open_devices(const TestFabricSetup& fabric_setup,
                       ChannelTrimmingMode channel_trimming_mode = ChannelTrimmingMode::NONE) {
         const auto& topology = fabric_setup.topology;
@@ -203,25 +224,8 @@ public:
                 log_info(tt::LogTest, "Closing devices and switching to new fabric config: {}", new_fabric_config);
                 close_devices();
             }
-            // Configure channel trimming rtoptions before opening devices
-            auto& rtoptions = tt::tt_metal::MetalContext::instance().rtoptions();
-            switch (channel_trimming_mode) {
-                case ChannelTrimmingMode::CAPTURE:
-                    rtoptions.set_enable_channel_trimming_capture(true);
-                    rtoptions.set_fabric_trimming_profile_path("");
-                    break;
-                case ChannelTrimmingMode::REPLAY: {
-                    rtoptions.set_enable_channel_trimming_capture(false);
-                    auto path = std::filesystem::path(rtoptions.get_logs_dir()) / "generated" / "reports" /
-                                "channel_trimming_capture.yaml";
-                    rtoptions.set_fabric_trimming_profile_path(path.string());
-                    break;
-                }
-                case ChannelTrimmingMode::NONE:
-                    rtoptions.set_enable_channel_trimming_capture(false);
-                    rtoptions.set_fabric_trimming_profile_path("");
-                    break;
-            }
+
+            setup_channel_trimming_rtoptions(channel_trimming_mode);
 
             log_info(tt::LogTest, "Opening devices with fabric reliability mode: {}", reliability_mode);
             open_devices_internal(new_fabric_config, fabric_tensix_config, reliability_mode, fabric_setup);

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_common_types.hpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_common_types.hpp
@@ -128,6 +128,9 @@ enum class HighLevelTrafficPattern {
     SequentialAllToAll,
 };
 
+// Channel trimming mode for test config expansion
+enum class ChannelTrimmingMode { NONE, CAPTURE, REPLAY };
+
 struct TestFabricSetup {
     tt::tt_fabric::Topology topology{0};
     std::optional<tt_fabric::FabricTensixConfig> fabric_tensix_config;
@@ -135,6 +138,7 @@ struct TestFabricSetup {
     uint32_t num_links{};
     std::optional<std::string> torus_config;  // For Torus topology: "X", "Y", or "XY"
     std::optional<uint32_t> max_packet_size;  // Custom max packet size for router
+    bool enable_channel_trimming = false;     // When true, test is expanded into CAPTURE + REPLAY phases
 };
 
 struct HighLevelPatternConfig {
@@ -167,6 +171,7 @@ struct ParsedTestConfig {
     uint32_t seed{};
     uint32_t num_top_level_iterations = 1;  // Number of times to repeat a built test
     bool from_sequential_pattern = false;  // True if this test was expanded from a sequential high-level pattern
+    ChannelTrimmingMode channel_trimming_mode = ChannelTrimmingMode::NONE;
 };
 
 struct TestConfig {
@@ -192,6 +197,7 @@ struct TestConfig {
     bool skip_packet_validation = false;  // Enable benchmark mode in sender and receiver kernels (skips validation)
     uint32_t seed{};
     bool from_sequential_pattern = false;  // True if this test was expanded from a sequential high-level pattern
+    ChannelTrimmingMode channel_trimming_mode = ChannelTrimmingMode::NONE;
 };
 
 // Latency test results structure (parallel to bandwidth results)

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_config.hpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_config.hpp
@@ -230,6 +230,9 @@ struct ParsedYamlConfig {
     std::optional<PhysicalMeshConfig> physical_mesh_config;
 };
 
+// Expands configs with enable_channel_trimming into consecutive CAPTURE + REPLAY pairs.
+std::vector<ParsedTestConfig> expand_channel_trimming(std::vector<ParsedTestConfig> configs);
+
 template <typename TrafficPatternType>
 inline TrafficPatternType merge_patterns(const TrafficPatternType& base, const TrafficPatternType& specific) {
     TrafficPatternType merged;

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_context.hpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_context.hpp
@@ -47,6 +47,7 @@ using TestConfig = tt::tt_fabric::fabric_tests::TestConfig;
 using TestFabricSetup = tt::tt_fabric::fabric_tests::TestFabricSetup;
 using TrafficParameters = tt::tt_fabric::fabric_tests::TrafficParameters;
 using PerformanceTestMode = tt::tt_fabric::fabric_tests::PerformanceTestMode;
+using ChannelTrimmingMode = tt::tt_fabric::fabric_tests::ChannelTrimmingMode;
 using TestTrafficConfig = tt::tt_fabric::fabric_tests::TestTrafficConfig;
 using TestTrafficSenderConfig = tt::tt_fabric::fabric_tests::TestTrafficSenderConfig;
 using TestTrafficReceiverConfig = tt::tt_fabric::fabric_tests::TestTrafficReceiverConfig;
@@ -121,7 +122,10 @@ public:
 
     void process_traffic_config(TestConfig& config);
 
-    bool open_devices(const TestFabricSetup& fabric_setup) { return fixture_->open_devices(fabric_setup); }
+    bool open_devices(const TestFabricSetup& fabric_setup,
+                      ChannelTrimmingMode channel_trimming_mode = ChannelTrimmingMode::NONE) {
+        return fixture_->open_devices(fabric_setup, channel_trimming_mode);
+    }
 
     void compile_programs();
 

--- a/tt_metal/fabric/CMakeLists.txt
+++ b/tt_metal/fabric/CMakeLists.txt
@@ -57,6 +57,7 @@ target_sources(
         builder/router_connection_mapping.cpp
         channel_trimming_export.cpp
         channel_trimming_import.cpp
+        channel_trimming_io.cpp
         channel_trimming_report.cpp
         fabric.cpp
         fabric_init.cpp

--- a/tt_metal/fabric/CMakeLists.txt
+++ b/tt_metal/fabric/CMakeLists.txt
@@ -57,6 +57,7 @@ target_sources(
         builder/router_connection_mapping.cpp
         channel_trimming_export.cpp
         channel_trimming_import.cpp
+        channel_trimming_report.cpp
         fabric.cpp
         fabric_init.cpp
         fabric_host_utils.cpp

--- a/tt_metal/fabric/channel_trimming_io.cpp
+++ b/tt_metal/fabric/channel_trimming_io.cpp
@@ -1,0 +1,41 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "channel_trimming_io.hpp"
+
+#include <tt_stl/assert.hpp>
+
+namespace tt::tt_fabric {
+
+ChipId parse_chip_key(const std::string& key) {
+    constexpr auto prefix = std::string_view("chip_");
+    TT_FATAL(
+        key.size() > prefix.size() && key.substr(0, prefix.size()) == prefix,
+        "Invalid chip key in trimming profile: '{}'",
+        key);
+    return static_cast<ChipId>(std::stoi(key.substr(prefix.size())));
+}
+
+chan_id_t parse_eth_channel_key(const std::string& key) {
+    constexpr auto prefix = std::string_view("eth_channel_");
+    TT_FATAL(
+        key.size() > prefix.size() && key.substr(0, prefix.size()) == prefix,
+        "Invalid eth channel key in trimming profile: '{}'",
+        key);
+    return static_cast<chan_id_t>(std::stoi(key.substr(prefix.size())));
+}
+
+uint16_t parse_hex_bitfield(const std::string& str) { return static_cast<uint16_t>(std::stoul(str, nullptr, 16)); }
+
+std::vector<std::string> collect_map_keys(const YAML::Node& map_node) {
+    std::vector<std::string> keys;
+    for (auto it = map_node.begin(); it != map_node.end(); ++it) {
+        if (it->first.IsScalar()) {
+            keys.push_back(it->first.as<std::string>());
+        }
+    }
+    return keys;
+}
+
+}  // namespace tt::tt_fabric

--- a/tt_metal/fabric/channel_trimming_io.hpp
+++ b/tt_metal/fabric/channel_trimming_io.hpp
@@ -1,0 +1,32 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#include <umd/device/types/cluster_descriptor_types.hpp>  // ChipId
+#include <hostdevcommon/fabric_common.h>                  // chan_id_t
+#include <yaml-cpp/yaml.h>
+
+namespace tt::tt_fabric {
+
+// Parse "chip_N" → N
+ChipId parse_chip_key(const std::string& key);
+
+// Parse "eth_channel_N" → N
+chan_id_t parse_eth_channel_key(const std::string& key);
+
+// Parse hex string like "0x001F" → uint16_t
+uint16_t parse_hex_bitfield(const std::string& str);
+
+// Collect all scalar keys from a YAML map node into a vector.
+// Must be done before any operator[] lookups on the map's children, because
+// yaml-cpp's operator[] mutates the underlying node (inserting null entries)
+// which corrupts in-progress iteration.
+std::vector<std::string> collect_map_keys(const YAML::Node& map_node);
+
+}  // namespace tt::tt_fabric

--- a/tt_metal/fabric/channel_trimming_report.cpp
+++ b/tt_metal/fabric/channel_trimming_report.cpp
@@ -1,0 +1,262 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "channel_trimming_report.hpp"
+
+#include <algorithm>
+#include <bit>
+#include <string>
+#include <vector>
+
+#include <tt-logger/tt-logger.hpp>
+#include <tt_stl/assert.hpp>
+#include <yaml-cpp/yaml.h>
+
+#include "tt_metal/fabric/builder/fabric_builder_config.hpp"
+
+namespace tt::tt_fabric {
+
+namespace {
+
+// Parse "chip_N" → N
+ChipId parse_chip_key(const std::string& key) {
+    constexpr auto prefix = std::string_view("chip_");
+    TT_FATAL(
+        key.size() > prefix.size() && key.substr(0, prefix.size()) == prefix,
+        "Invalid chip key in trimming profile: '{}'",
+        key);
+    return static_cast<ChipId>(std::stoi(key.substr(prefix.size())));
+}
+
+// Parse "eth_channel_N" → N
+chan_id_t parse_eth_channel_key(const std::string& key) {
+    constexpr auto prefix = std::string_view("eth_channel_");
+    TT_FATAL(
+        key.size() > prefix.size() && key.substr(0, prefix.size()) == prefix,
+        "Invalid eth channel key in trimming profile: '{}'",
+        key);
+    return static_cast<chan_id_t>(std::stoi(key.substr(prefix.size())));
+}
+
+// Parse hex string like "0x001F" → uint16_t
+uint16_t parse_hex_bitfield(const std::string& str) {
+    return static_cast<uint16_t>(std::stoul(str, nullptr, 16));
+}
+
+// Collect all scalar keys from a YAML map node into a vector.
+// Must be done before any operator[] lookups on the map's children, because
+// yaml-cpp's operator[] mutates the underlying node (inserting null entries)
+// which corrupts in-progress iteration.
+std::vector<std::string> collect_map_keys(const YAML::Node& map_node) {
+    std::vector<std::string> keys;
+    for (auto it = map_node.begin(); it != map_node.end(); ++it) {
+        if (it->first.IsScalar()) {
+            keys.push_back(it->first.as<std::string>());
+        }
+    }
+    return keys;
+}
+
+// Returns {expected_sender_channels, expected_receiver_channels} for a router
+// given the fabric topology, VC1 presence, and the router's direction string from the YAML.
+//
+// Channel counts from builder_config:
+//   Z direction (always has VC1):  9 sender, 2 receiver
+//   2D with VC1:                   8 sender, 2 receiver
+//   2D without VC1 (VC0 only):    4 sender, 1 receiver
+//   1D:                            2 sender, 1 receiver
+std::pair<uint32_t, uint32_t> get_expected_channels(
+    Topology topology, const std::string& direction, bool has_vc1) {
+    if (direction == "Z") {
+        // Z routers always have both VCs
+        return {builder_config::num_sender_channels_z_router, builder_config::num_receiver_channels_z_router};
+    }
+    if (is_2D_topology(topology)) {
+        if (has_vc1) {
+            return {builder_config::num_sender_channels_2d, builder_config::num_receiver_channels_2d};
+        }
+        // VC0 only: Worker + 3 mesh directions = 4 sender, 1 receiver
+        return {builder_config::num_sender_channels_2d_mesh, builder_config::num_receiver_channels_1d};
+    }
+    // 1D topologies: Linear, Ring, NeighborExchange
+    return {builder_config::num_sender_channels_1d, builder_config::num_receiver_channels_1d};
+}
+
+// Count set bits in the lowest `n_bits` of a bitfield.
+uint32_t count_used_bits(uint16_t bitfield, uint32_t n_bits) {
+    uint16_t mask = (n_bits >= 16) ? 0xFFFF : static_cast<uint16_t>((1u << n_bits) - 1);
+    return static_cast<uint32_t>(std::popcount(static_cast<uint16_t>(bitfield & mask)));
+}
+
+// Helper to log a single histogram with full-block bar characters.
+void log_histogram(const char* label, const char* x_axis_label, const std::vector<uint32_t>& hist) {
+    log_debug(tt::LogFabric, "  {} ({} -> router count):", label, x_axis_label);
+    for (size_t i = 0; i < hist.size(); i++) {
+        if (hist[i] == 0) {
+            continue;
+        }
+        std::string bars;
+        for (uint32_t b = 0; b < hist[i]; b++) {
+            bars += "\u2588";  // U+2588 FULL BLOCK
+        }
+        log_debug(tt::LogFabric, "    {:>2}: {}  ({} routers)", i, bars, hist[i]);
+    }
+}
+
+}  // namespace
+
+void generate_and_log_channel_trimming_report(const std::string& yaml_path, Topology topology, bool has_vc1) {
+    YAML::Node root = YAML::LoadFile(yaml_path);
+    if (!root["channel_trimming_capture"]) {
+        log_warning(tt::LogFabric, "Channel trimming report: YAML missing 'channel_trimming_capture' key");
+        return;
+    }
+
+    const auto& capture = root["channel_trimming_capture"];
+    std::vector<RouterTrimmingStats> stats;
+
+    auto chip_keys = collect_map_keys(capture);
+    for (const auto& chip_key : chip_keys) {
+        ChipId chip_id = parse_chip_key(chip_key);
+        const auto& channels = capture[chip_key];
+
+        auto chan_keys = collect_map_keys(channels);
+        for (const auto& chan_key : chan_keys) {
+            chan_id_t eth_chan = parse_eth_channel_key(chan_key);
+            const auto& chan_data = channels[chan_key];
+
+            std::string direction = chan_data["direction"] ? chan_data["direction"].as<std::string>() : "UNKNOWN";
+
+            auto [expected_sender, expected_receiver] = get_expected_channels(topology, direction, has_vc1);
+
+            uint16_t sender_bitfield = 0;
+            if (chan_data["sender_channel_used_bitfield"]) {
+                sender_bitfield = parse_hex_bitfield(chan_data["sender_channel_used_bitfield"].as<std::string>());
+            }
+
+            uint16_t receiver_bitfield = 0;
+            if (chan_data["receiver_channel_data_forwarded_bitfield"]) {
+                receiver_bitfield =
+                    parse_hex_bitfield(chan_data["receiver_channel_data_forwarded_bitfield"].as<std::string>());
+            }
+
+            stats.push_back(RouterTrimmingStats{
+                .chip_id = chip_id,
+                .eth_chan = eth_chan,
+                .total_sender_channels = expected_sender,
+                .used_sender_channels = count_used_bits(sender_bitfield, expected_sender),
+                .total_receiver_channels = expected_receiver,
+                .used_receiver_channels = count_used_bits(receiver_bitfield, expected_receiver),
+            });
+        }
+    }
+
+    if (stats.empty()) {
+        log_info(tt::LogFabric, "Channel Trimming Report: no routers found in profile");
+        return;
+    }
+
+    // Compute summary stats
+    uint32_t total_sender_removed = 0, total_sender_available = 0;
+    uint32_t total_receiver_removed = 0, total_receiver_available = 0;
+    uint32_t min_sender_removed = UINT32_MAX, max_sender_removed = 0;
+    uint32_t min_receiver_removed = UINT32_MAX, max_receiver_removed = 0;
+    uint32_t min_aggregate_removed = UINT32_MAX, max_aggregate_removed = 0;
+    uint32_t total_aggregate_removed = 0, total_aggregate_available = 0;
+
+    // Removed histograms
+    std::vector<uint32_t> sender_removed_hist;
+    std::vector<uint32_t> receiver_removed_hist;
+    std::vector<uint32_t> aggregate_removed_hist;
+
+    // Instantiated (used) histograms
+    std::vector<uint32_t> sender_instantiated_hist;
+    std::vector<uint32_t> receiver_instantiated_hist;
+    std::vector<uint32_t> aggregate_instantiated_hist;
+
+    auto grow_and_increment = [](std::vector<uint32_t>& hist, uint32_t bucket) {
+        if (bucket >= hist.size()) {
+            hist.resize(bucket + 1, 0);
+        }
+        hist[bucket]++;
+    };
+
+    for (const auto& s : stats) {
+        uint32_t sr = s.sender_channels_removed();
+        uint32_t rr = s.receiver_channels_removed();
+        uint32_t ar = s.total_channels_removed();
+
+        total_sender_removed += sr;
+        total_sender_available += s.total_sender_channels;
+        total_receiver_removed += rr;
+        total_receiver_available += s.total_receiver_channels;
+        total_aggregate_removed += ar;
+        total_aggregate_available += s.total_sender_channels + s.total_receiver_channels;
+
+        min_sender_removed = std::min(min_sender_removed, sr);
+        max_sender_removed = std::max(max_sender_removed, sr);
+        min_receiver_removed = std::min(min_receiver_removed, rr);
+        max_receiver_removed = std::max(max_receiver_removed, rr);
+        min_aggregate_removed = std::min(min_aggregate_removed, ar);
+        max_aggregate_removed = std::max(max_aggregate_removed, ar);
+
+        grow_and_increment(sender_removed_hist, sr);
+        grow_and_increment(receiver_removed_hist, rr);
+        grow_and_increment(aggregate_removed_hist, ar);
+
+        grow_and_increment(sender_instantiated_hist, s.used_sender_channels);
+        grow_and_increment(receiver_instantiated_hist, s.used_receiver_channels);
+        uint32_t total_instantiated = s.used_sender_channels + s.used_receiver_channels;
+        grow_and_increment(aggregate_instantiated_hist, total_instantiated);
+    }
+
+    size_t n = stats.size();
+    double avg_sender = static_cast<double>(total_sender_removed) / n;
+    double avg_receiver = static_cast<double>(total_receiver_removed) / n;
+    double avg_aggregate = static_cast<double>(total_aggregate_removed) / n;
+
+    // Log the report
+    log_info(
+        tt::LogFabric,
+        "Channel Trimming Report ({} routers profiled, topology={}, vc1={}):",
+        n,
+        topology,
+        has_vc1 ? "enabled" : "disabled");
+    log_info(
+        tt::LogFabric,
+        "  Sender channels:    removed min={}  max={}  avg={:.1f}  total={}/{}",
+        min_sender_removed,
+        max_sender_removed,
+        avg_sender,
+        total_sender_removed,
+        total_sender_available);
+    log_info(
+        tt::LogFabric,
+        "  Receiver channels:  removed min={}  max={}  avg={:.1f}  total={}/{}",
+        min_receiver_removed,
+        max_receiver_removed,
+        avg_receiver,
+        total_receiver_removed,
+        total_receiver_available);
+    log_info(
+        tt::LogFabric,
+        "  Aggregate:          removed min={}  max={}  avg={:.1f}  total={}/{}",
+        min_aggregate_removed,
+        max_aggregate_removed,
+        avg_aggregate,
+        total_aggregate_removed,
+        total_aggregate_available);
+
+    // Channels removed histograms
+    log_histogram("Sender removed", "channels removed", sender_removed_hist);
+    log_histogram("Receiver removed", "channels removed", receiver_removed_hist);
+    log_histogram("Aggregate removed", "channels removed", aggregate_removed_hist);
+
+    // Channels instantiated histograms
+    log_histogram("Sender instantiated", "channels kept", sender_instantiated_hist);
+    log_histogram("Receiver instantiated", "channels kept", receiver_instantiated_hist);
+    log_histogram("Aggregate instantiated", "channels kept", aggregate_instantiated_hist);
+}
+
+}  // namespace tt::tt_fabric

--- a/tt_metal/fabric/channel_trimming_report.cpp
+++ b/tt_metal/fabric/channel_trimming_report.cpp
@@ -14,49 +14,11 @@
 #include <yaml-cpp/yaml.h>
 
 #include "tt_metal/fabric/builder/fabric_builder_config.hpp"
+#include "tt_metal/fabric/channel_trimming_io.hpp"
 
 namespace tt::tt_fabric {
 
 namespace {
-
-// Parse "chip_N" → N
-ChipId parse_chip_key(const std::string& key) {
-    constexpr auto prefix = std::string_view("chip_");
-    TT_FATAL(
-        key.size() > prefix.size() && key.substr(0, prefix.size()) == prefix,
-        "Invalid chip key in trimming profile: '{}'",
-        key);
-    return static_cast<ChipId>(std::stoi(key.substr(prefix.size())));
-}
-
-// Parse "eth_channel_N" → N
-chan_id_t parse_eth_channel_key(const std::string& key) {
-    constexpr auto prefix = std::string_view("eth_channel_");
-    TT_FATAL(
-        key.size() > prefix.size() && key.substr(0, prefix.size()) == prefix,
-        "Invalid eth channel key in trimming profile: '{}'",
-        key);
-    return static_cast<chan_id_t>(std::stoi(key.substr(prefix.size())));
-}
-
-// Parse hex string like "0x001F" → uint16_t
-uint16_t parse_hex_bitfield(const std::string& str) {
-    return static_cast<uint16_t>(std::stoul(str, nullptr, 16));
-}
-
-// Collect all scalar keys from a YAML map node into a vector.
-// Must be done before any operator[] lookups on the map's children, because
-// yaml-cpp's operator[] mutates the underlying node (inserting null entries)
-// which corrupts in-progress iteration.
-std::vector<std::string> collect_map_keys(const YAML::Node& map_node) {
-    std::vector<std::string> keys;
-    for (auto it = map_node.begin(); it != map_node.end(); ++it) {
-        if (it->first.IsScalar()) {
-            keys.push_back(it->first.as<std::string>());
-        }
-    }
-    return keys;
-}
 
 // Returns {expected_sender_channels, expected_receiver_channels} for a router
 // given the fabric topology, VC1 presence, and the router's direction string from the YAML.

--- a/tt_metal/fabric/channel_trimming_report.hpp
+++ b/tt_metal/fabric/channel_trimming_report.hpp
@@ -1,0 +1,34 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+#include <string>
+
+#include <umd/device/types/cluster_descriptor_types.hpp>  // ChipId
+#include <hostdevcommon/fabric_common.h>                   // chan_id_t
+#include <tt-metalium/experimental/fabric/fabric_edm_types.hpp>
+
+namespace tt::tt_fabric {
+
+struct RouterTrimmingStats {
+    ChipId chip_id;
+    chan_id_t eth_chan;
+    uint32_t total_sender_channels;
+    uint32_t used_sender_channels;
+    uint32_t total_receiver_channels;
+    uint32_t used_receiver_channels;
+
+    uint32_t sender_channels_removed() const { return total_sender_channels - used_sender_channels; }
+    uint32_t receiver_channels_removed() const { return total_receiver_channels - used_receiver_channels; }
+    uint32_t total_channels_removed() const { return sender_channels_removed() + receiver_channels_removed(); }
+};
+
+// Parse a channel trimming capture YAML and log a summary report.
+// Topology and has_vc1 are used to infer expected channel counts per router direction.
+// Summary stats are logged at INFO; histograms at DEBUG.
+void generate_and_log_channel_trimming_report(const std::string& yaml_path, Topology topology, bool has_vc1);
+
+}  // namespace tt::tt_fabric

--- a/tt_metal/fabric/fabric_builder_context.cpp
+++ b/tt_metal/fabric/fabric_builder_context.cpp
@@ -6,6 +6,7 @@
 #include "tt_metal/fabric/fabric_context.hpp"
 #include "tt_metal/fabric/fabric_router_channel_mapping.hpp"
 #include "tt_metal/fabric/channel_trimming_import.hpp"
+#include "tt_metal/fabric/channel_trimming_report.hpp"
 #include "impl/context/metal_context.hpp"
 #include <tt-metalium/experimental/fabric/control_plane.hpp>
 #include <tt-metalium/host_api.hpp>
@@ -70,6 +71,12 @@ FabricBuilderContext::FabricBuilderContext(const FabricContext& fabric_context) 
     }
 
     this->intermesh_vc_config_ = this->compute_intermesh_vc_config();
+
+    // Log trimming report after intermesh config is known (VC1 affects expected channel counts)
+    if (rtoptions.has_fabric_trimming_profile()) {
+        const auto& path = rtoptions.get_fabric_trimming_profile_path();
+        generate_and_log_channel_trimming_report(path, fabric_context.get_fabric_topology(), intermesh_vc_config_.requires_vc1);
+    }
 
     // Compute max channel counts for this fabric instance
     compute_max_channel_counts();

--- a/tt_metal/llrt/rtoptions.hpp
+++ b/tt_metal/llrt/rtoptions.hpp
@@ -659,6 +659,7 @@ public:
     // Channel trimming profile import path
     bool has_fabric_trimming_profile() const { return !fabric_trimming_profile_path.empty(); }
     const std::string& get_fabric_trimming_profile_path() const { return fabric_trimming_profile_path; }
+    void set_fabric_trimming_profile_path(const std::string& path) { fabric_trimming_profile_path = path; }
 
     // Reliability mode override accessor
     std::optional<tt::tt_fabric::FabricReliabilityMode> get_reliability_mode() const { return reliability_mode; }


### PR DESCRIPTION
The fabric router channel trimming feature code was added and unit tested in https://github.com/tenstorrent/tt-metal/pull/38029. 

This PR enables the support to test this feature in the fabric test infrastructure. To enable in a test, add `enable_channel_trimming: true` to the fabric config.

For example:
```
    fabric_setup:
      topology: Linear
      enable_channel_trimming: true
```

This will run the test twice. First it will run all paramatrizations in a "profile"/"capture". The second pass will be consume the profile data and re-launch fabric with optimizations applied where possible (e.g. if a channel is never used, it will be disabled and compiled away). Note that option forces fabric recompile, so it is recommended to avoid using this option in the middle of a test sequence that would otherwise use the same (i.e. no recompile) fabric config.

Mechanically, the two passes are implemented by duplicating the ` ParsedTestConfig` in a small pre-process step, which keeps the rest of the test loop unchanged.

Closes https://github.com/tenstorrent/tt-metal/issues/38057

### Checklist

- [x] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=snijjar/update-fabric-test-infra-to-suopport-channel-trimming-issue-38057)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:snijjar/update-fabric-test-infra-to-suopport-channel-trimming-issue-38057)
- [x] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=snijjar/update-fabric-test-infra-to-suopport-channel-trimming-issue-38057)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:snijjar/update-fabric-test-infra-to-suopport-channel-trimming-issue-38057)
- [x] Fabric Tests: https://github.com/tenstorrent/tt-metal/actions/runs/22311409744


