### PR TITLE
Rearrange Ms pops

### DIFF
--- a/models/demos/deepseek_v3_b1/unified_kernels/sdpa_reduce_worker.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/sdpa_reduce_worker.hpp
@@ -247,9 +247,9 @@ ALWI void sdpa_tail_streaming(
         cb_push_back(cb_l_out, block_size);
     }
 
-    // Finalize the worker/neighbor MS without popping the previous-round MS.
+    // Postamble only — caller handles MS pops based on round context
+    // (R1 inputs are TRISC-owned, R2 prev MS is BRISC-owned)
     ckernel::sdpa_bcast_col_reuse_postamble();
-    cb_pop_front(cb_prev_max_sum, 1);
 }
 
 ALWI void sdpa_forward_data(
@@ -788,6 +788,14 @@ struct SdpaReduceWorker {
                 r1_neighbor_valid,
                 local_valid);
 
+            // Pop R1 input MS CBs — TRISC-owned, no BRISC race.
+            // cb_r1_neighbor_ms: incoming from neighbor, consumed only by TRISC
+            // cb_local_ms: BRISC reads via send_all() (L1 address, no cb_wait/pop)
+            // No cb_wait_front needed: NCRISC always pushes all MS CBs unconditionally
+            // (even for invalid neighbors with dummy data), so tiles are guaranteed present.
+            cb_pop_front(ComputeCT::cb_r1_neighbor_ms, 1);
+            cb_pop_front(ComputeCT::cb_local_ms, 1);
+
             // ROUND 2: reduce(r1_result, r2_neighbor) -> final output (normalized L)
             bool local_r1_valid = local_valid || r1_neighbor_valid;
             bool r2_neighbor_r1_valid = r2_neighbor_valid;
@@ -807,6 +815,11 @@ struct SdpaReduceWorker {
                 ComputeCT::cb_l_out,
                 r2_neighbor_r1_valid,
                 local_r1_valid);
+
+            // Pop R2 worker MS CB — incoming from neighbor, consumed only by TRISC.
+            // Do NOT pop cb_r1_result_ms — BRISC owns that pop (writer_impl line 668)
+            // after send_streaming() reads it for R2 forwarding.
+            cb_pop_front(ComputeCT::cb_r2_neighbor_ms, 1);
         }
 #endif  // COMPILE_FOR_TRISC
     };


### PR DESCRIPTION
Rearrange the Ms pops to avoid race with R2 Brisc send to neighbor and Trisc local compute.

### Ticket
Link to Github Issue

### Problem description
Provide context for the problem.

### What's changed
Describe the approach used to solve the problem.
Summarize the changes made and its impact.

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=ucheema/deepseek-bi-sdpa-reduce-race-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:ucheema/deepseek-bi-sdpa-reduce-race-fix)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ucheema/deepseek-bi-sdpa-reduce-race-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ucheema/deepseek-bi-sdpa-reduce-race-fix)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ucheema/deepseek-bi-sdpa-reduce-race-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ucheema/deepseek-bi-sdpa-reduce-race-fix)
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ucheema/deepseek-bi-sdpa-reduce-race-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ucheema/deepseek-bi-sdpa-reduce-race-fix)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ucheema/deepseek-bi-sdpa-reduce-race-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ucheema/deepseek-bi-sdpa-reduce-race-fix)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ucheema/deepseek-bi-sdpa-reduce-race-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ucheema/deepseek-bi-sdpa-reduce-race-fix)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
