### PR TITLE
Fixed ttnn.prod crashing on 1D input with keepdim=False

### DIFF
--- a/ttnn/cpp/ttnn/operations/reduction/prod/prod.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/prod/prod.cpp
@@ -76,11 +76,22 @@ Tensor prod_impl(
     auto output_mem_config = memory_config.value_or(input_a.memory_config());
     const int size = static_cast<int>(input_a.logical_shape().rank());
 
+    TT_FATAL(size > 0, "Tensor has no dimensions");
+    TT_FATAL(
+        !dim.has_value() || (*dim >= -size && *dim <= size - 1),
+        "Dimension for prod is out of range (expected to be in range of [{}, {}]",
+        -size,
+        size - 1);
+
     const auto old_rank = input_a.logical_shape().rank();
     const ttnn::Shape& input_shape = input_a.logical_shape();
 
-    // If no dim is provided, compute the prod across all dimensions
-    if (!dim.has_value()) {
+    // If no dim is provided, compute the prod across all dimensions.
+    // Similarly, if the tensor has only one dimension, compute the prod across all dimensions
+    // (which is just the one dimension).
+    // Note that validation of the dim parameter above guarantees that, when dim is provided,
+    // it is the single valid dimension (0 or -1 for rank 1).
+    if (!dim.has_value() || old_rank == 1) {
         Tensor result = compute_prod_all(input_a, output_mem_config);
         if (keepdim) {
             // Reshape to have all dimensions (as many as the input rank) set to 1.
@@ -89,13 +100,6 @@ Tensor prod_impl(
         }
         return result;
     }
-
-    TT_FATAL(size > 0, "Tensor has no dimensions");
-    TT_FATAL(
-        *dim >= -size && *dim <= size - 1,
-        "Dimension for prod is out of range (expected to be in range of [{}, {}]",
-        -size,
-        size - 1);
 
     // For higher dimension Tensors, we need to squeeze to 4D to perform the reduction
     if (old_rank > 4) {

--- a/ttnn/cpp/ttnn/operations/reduction/prod/prod.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/prod/prod.cpp
@@ -79,7 +79,7 @@ Tensor prod_impl(
     TT_FATAL(size > 0, "Tensor has no dimensions");
     TT_FATAL(
         !dim.has_value() || (*dim >= -size && *dim <= size - 1),
-        "Dimension for prod is out of range (expected to be in range of [{}, {}]",
+        "Dimension for prod is out of range (expected to be in range of [{}, {}])",
         -size,
         size - 1);
 


### PR DESCRIPTION
### Ticket
#38218

### Problem description
When passing a 1D tensor to `ttnn.prod` with `keepdim=False`, it would crash with `TT_FATAL: Can't convert shape rank`.
This was root caused to the `prod_impl` function which "squeezes"/"unsqueezes" all input tensors to 4D. However, when the function eventually tries to squeeze the result back to 1D, it fails if the data is in Tile layout, because padded shape in tile layout is [1, 1, 32, 32], which cannot be squeezed to 1D (requirement for squeezing is that all dimensions that are being "squeezed" are 1), triggering the error.  

### What's changed
Rather than complicate the squeezing logic further, a simple solution was to move 1D tensor handling to use the `prod_all` method, which doesn't have the issue and is already used when `dim` was not provided, which for a 1D tensor has the same semantics as when dim is provided with just the one dimension.
Also updated unit tests to catch the issue and demonstrated that it fails before, and passes after the fix.

### Checklist

- [x] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=fplavec_38218_prod_rank_0)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:fplavec_38218_prod_rank_0)
- [x] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=fplavec_38218_prod_rank_0)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:fplavec_38218_prod_rank_0)
- [x] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=fplavec_38218_prod_rank_0)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:fplavec_38218_prod_rank_0)
- [x] New/Existing tests provide coverage for changes
