### PR TITLE
[skip ci] Limit step summary to 5 errors per workflow to fix 1024k size limit

### DIFF
--- a/.github/workflows/aggregate-workflow-data.yaml
+++ b/.github/workflows/aggregate-workflow-data.yaml
@@ -268,33 +268,33 @@ jobs:
         id: slack-report
         uses: ./.github/actions/slack-report-analyze-workflow-data
         with:
-          channel_id: ${{ secrets.SLACK_METAL_INFRA_CHANNEL_ID }}
+          channel_id: 'C09EC0QNSB0'
           regressed_workflows: ${{ needs.analyze-data.outputs.regressed_workflows }}
           alert_all_message: ${{ needs.analyze-data.outputs.alert_all_message }}
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
 
-  trigger-auto-triage:
-    needs: [analyze-data, handle-failures]
-    if: ${{ always() && needs.analyze-data.result == 'success' && fromJson(needs.analyze-data.outputs.regressed_workflows) != '[]' }}
-    runs-on: ubuntu-latest
-    permissions:
-      actions: write
-      contents: read
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          sparse-checkout: .github/actions
-          sparse-checkout-cone-mode: true
-      - name: Install dependencies
-        working-directory: .github/actions/trigger-auto-triage-for-regressions
-        run: npm install
-      - name: Trigger auto-triage for regressed jobs
-        uses: ./.github/actions/trigger-auto-triage-for-regressions
-        with:
-          regressed_workflows: ${{ needs.analyze-data.outputs.regressed_workflows }}
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          slack_ts: ${{ needs.handle-failures.outputs.slack_ts }}
-          slack_channel_id: ${{ secrets.SLACK_METAL_INFRA_CHANNEL_ID }}
-          slack_bot_token: ${{ secrets.SLACK_BOT_TOKEN }}
-          send-slack-message: true
+  # trigger-auto-triage:
+  #   needs: [analyze-data, handle-failures]
+  #   if: ${{ always() && needs.analyze-data.result == 'success' && fromJson(needs.analyze-data.outputs.regressed_workflows) != '[]' }}
+  #   runs-on: ubuntu-latest
+  #   permissions:
+  #     actions: write
+  #     contents: read
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #       with:
+  #         sparse-checkout: .github/actions
+  #         sparse-checkout-cone-mode: true
+  #     - name: Install dependencies
+  #       working-directory: .github/actions/trigger-auto-triage-for-regressions
+  #       run: npm install
+  #     - name: Trigger auto-triage for regressed jobs
+  #       uses: ./.github/actions/trigger-auto-triage-for-regressions
+  #       with:
+  #         regressed_workflows: ${{ needs.analyze-data.outputs.regressed_workflows }}
+  #         github_token: ${{ secrets.GITHUB_TOKEN }}
+  #         slack_ts: ${{ needs.handle-failures.outputs.slack_ts }}
+  #         slack_channel_id: ${{ secrets.SLACK_METAL_INFRA_CHANNEL_ID }}
+  #         slack_bot_token: ${{ secrets.SLACK_BOT_TOKEN }}
+  #         send-slack-message: true

--- a/.github/workflows/aggregate-workflow-data.yaml
+++ b/.github/workflows/aggregate-workflow-data.yaml
@@ -268,33 +268,33 @@ jobs:
         id: slack-report
         uses: ./.github/actions/slack-report-analyze-workflow-data
         with:
-          channel_id: 'C09EC0QNSB0'
+          channel_id: ${{ secrets.SLACK_METAL_INFRA_CHANNEL_ID }}
           regressed_workflows: ${{ needs.analyze-data.outputs.regressed_workflows }}
           alert_all_message: ${{ needs.analyze-data.outputs.alert_all_message }}
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
 
-  # trigger-auto-triage:
-  #   needs: [analyze-data, handle-failures]
-  #   if: ${{ always() && needs.analyze-data.result == 'success' && fromJson(needs.analyze-data.outputs.regressed_workflows) != '[]' }}
-  #   runs-on: ubuntu-latest
-  #   permissions:
-  #     actions: write
-  #     contents: read
-  #   steps:
-  #     - uses: actions/checkout@v4
-  #       with:
-  #         sparse-checkout: .github/actions
-  #         sparse-checkout-cone-mode: true
-  #     - name: Install dependencies
-  #       working-directory: .github/actions/trigger-auto-triage-for-regressions
-  #       run: npm install
-  #     - name: Trigger auto-triage for regressed jobs
-  #       uses: ./.github/actions/trigger-auto-triage-for-regressions
-  #       with:
-  #         regressed_workflows: ${{ needs.analyze-data.outputs.regressed_workflows }}
-  #         github_token: ${{ secrets.GITHUB_TOKEN }}
-  #         slack_ts: ${{ needs.handle-failures.outputs.slack_ts }}
-  #         slack_channel_id: ${{ secrets.SLACK_METAL_INFRA_CHANNEL_ID }}
-  #         slack_bot_token: ${{ secrets.SLACK_BOT_TOKEN }}
-  #         send-slack-message: true
+  trigger-auto-triage:
+    needs: [analyze-data, handle-failures]
+    if: ${{ always() && needs.analyze-data.result == 'success' && fromJson(needs.analyze-data.outputs.regressed_workflows) != '[]' }}
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          sparse-checkout: .github/actions
+          sparse-checkout-cone-mode: true
+      - name: Install dependencies
+        working-directory: .github/actions/trigger-auto-triage-for-regressions
+        run: npm install
+      - name: Trigger auto-triage for regressed jobs
+        uses: ./.github/actions/trigger-auto-triage-for-regressions
+        with:
+          regressed_workflows: ${{ needs.analyze-data.outputs.regressed_workflows }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          slack_ts: ${{ needs.handle-failures.outputs.slack_ts }}
+          slack_channel_id: ${{ secrets.SLACK_METAL_INFRA_CHANNEL_ID }}
+          slack_bot_token: ${{ secrets.SLACK_BOT_TOKEN }}
+          send-slack-message: true


### PR DESCRIPTION
## Summary
Limits error snippets shown in the `$GITHUB_STEP_SUMMARY` to the first 5 per workflow file, preventing the upload from exceeding GitHub's 1024KB limit.

The full list of errors is still stored in the `workflow-status-changes` artifact, so no data is lost.

## Changes
- Added `MAX_ERRORS_PER_WORKFLOW_IN_SUMMARY = 5` in `lib/reporting.js`
- Both **Regressions** and **Still Failing** sections now show only the first 5 errors, with an overflow note ("Showing first 5 of N errors; full list in artifacts.") when there are more

## Proof it works
https://github.com/tenstorrent/tt-metal/actions/runs/22313040680

Made with [Cursor](https://cursor.com)