### PR TITLE
Fix LLK_ASSERT hits part 1

### DIFF
--- a/models/common/utility_functions.py
+++ b/models/common/utility_functions.py
@@ -1042,6 +1042,13 @@ def is_watcher_enabled():
     return (watcher is not None and watcher != "") or lightweight_asserts == "1"
 
 
+def is_llk_assert_enabled():
+    llk_assert = os.environ.get("TT_METAL_LLK_ASSERTS")
+    watcher = os.environ.get("TT_METAL_WATCHER")
+    lightweight_asserts = os.environ.get("TT_METAL_LIGHTWEIGHT_KERNEL_ASSERTS")
+    return ((watcher is not None and watcher != "") or lightweight_asserts == "1") and llk_assert == "1"
+
+
 def is_n300():
     return os.environ.get("MESH_DEVICE", "N150") == "N300"
 
@@ -1064,6 +1071,10 @@ def skip_for_wormhole_b0(reason_str="not a wormhole test"):
 
 def skip_with_watcher(reason_str="Test is not passing with watcher enabled"):
     return ti_skip(is_watcher_enabled(), reason=reason_str)
+
+
+def skip_with_llk_assert(reason_str="Test is not passing with LLK asserts enabled"):
+    return ti_skip(is_llk_assert_enabled(), reason=reason_str)
 
 
 def run_for_blackhole(reason_str="only runs for Blackhole"):

--- a/tests/ttnn/unit_tests/operations/matmul/test_matmul.py
+++ b/tests/ttnn/unit_tests/operations/matmul/test_matmul.py
@@ -38,6 +38,37 @@ def find_max_subblock(out_block_h, out_block_w):
     return best_h, best_w, max_product
 
 
+# Supported (transpose_tile, tile_w, tile_h, has_bias) combinations for tiny-tile matmul.
+# Excluded cases:
+#   - transpose_tile=True,  tile_w=16, any tile_h, any has_bias:
+#       in1=32x16 with transpose has no addr_mod handling in llk_math_matmul
+#   - transpose_tile=False, tile_w=16, tile_h=32, has_bias=True:
+#       Broadcast Row with 32x16 narrow tile not supported
+_TINY_TILE_SUPPORTED_COMBOS = frozenset(
+    # (transpose_tile, tile_w, tile_h, has_bias)
+    {
+        (False, 16, 16, False),
+        (False, 16, 16, True),
+        (False, 16, 32, False),
+        # (False, 16, 32, True) excluded
+        (False, 32, 16, False),
+        (False, 32, 16, True),
+        (False, 32, 32, False),
+        (False, 32, 32, True),
+        # (True, 16, *, *) all excluded
+        (True, 32, 16, False),
+        (True, 32, 16, True),
+        (True, 32, 32, False),
+        (True, 32, 32, True),
+    }
+)
+
+
+def is_tiny_tile_combo_supported(transpose_tile: bool, tile_w: int, tile_h: int, has_bias: bool = False) -> bool:
+    """Return True if the (transpose_tile, tile_w, tile_h, has_bias) combo is valid in tiny-tile matmul."""
+    return (transpose_tile, tile_w, tile_h, has_bias) in _TINY_TILE_SUPPORTED_COMBOS
+
+
 @pytest.mark.parametrize("n", [2])
 @pytest.mark.parametrize("c", [5])
 @pytest.mark.parametrize("h", [384])
@@ -262,8 +293,8 @@ def test_matmul_reuse_config_sharded_fd_column(
 def test_matmul_reuse_config_sharded_tiny_tile(
     device, b, h, m, k, n, tile_h, tile_w, in0_sharded, in1_sharded, out_sharded, in1_dtype, transpose_tile
 ):
-    if transpose_tile and tile_w == 16 and is_llk_assert_enabled():
-        pytest.skip("in1=32x16 with transpose is not supported (no addr_mod handling) in llk_math_matmul.")
+    if not is_tiny_tile_combo_supported(transpose_tile, tile_w, tile_h) and is_llk_assert_enabled():
+        pytest.skip("Unsupported tiny-tile combination (see _TINY_TILE_SUPPORTED_COMBOS).")
 
     torch.manual_seed(0)
 
@@ -370,10 +401,8 @@ def pad_to_dram_banks(num, tile_w, lcm=32 * 12):
 def test_matmul_in1_dram_sharded_tiny_tile(
     mesh_device, k, n, has_bias, grid_size, tile_h, tile_w, in1_dtype, transpose_tile
 ):
-    if transpose_tile and tile_w == 16 and is_llk_assert_enabled():
-        pytest.skip("Combination of tile_w=16 and transpose_tile=True is not supported in llk_math_matmul.")
-    if not transpose_tile and tile_w == 16 and tile_h == 32 and has_bias and is_llk_assert_enabled():
-        pytest.skip("Broadcast Row with 32x16 narrow tile not supported.")
+    if not is_tiny_tile_combo_supported(transpose_tile, tile_w, tile_h, has_bias) and is_llk_assert_enabled():
+        pytest.skip("Unsupported tiny-tile combination (see _TINY_TILE_SUPPORTED_COMBOS).")
 
     # PCC issue when height not equal to tile height
     m = tile_h
@@ -825,10 +854,8 @@ def test_matmul_2d_tiny_tile(
     in1_dtype,
     transpose_tile,
 ):
-    if transpose_tile and tile_w == 16 and is_llk_assert_enabled():
-        pytest.skip("in1=32x16 with transpose is not supported (no addr_mod handling) in llk_math_matmul")
-    if not transpose_tile and tile_w == 16 and tile_h == 32 and has_bias and is_llk_assert_enabled():
-        pytest.skip("Broadcast Row with 32x16 narrow tile not supported.")
+    if not is_tiny_tile_combo_supported(transpose_tile, tile_w, tile_h, has_bias) and is_llk_assert_enabled():
+        pytest.skip("Unsupported tiny-tile combination (see _TINY_TILE_SUPPORTED_COMBOS).")
 
     for _ in range(2):
         run_matmul_2d_tiny_tile(
@@ -987,10 +1014,8 @@ def test_matmul_1d_tiny_tile(
     in1_dtype,
     transpose_tile,
 ):
-    if transpose_tile and tile_w == 16 and is_llk_assert_enabled():
-        pytest.skip("in1=32x16 with transpose is not supported (no addr_mod handling) in llk_math_matmul")
-    if not transpose_tile and tile_w == 16 and tile_h == 32 and has_bias and is_llk_assert_enabled():
-        pytest.skip("Broadcast Row with 32x16 narrow tile not supported.")
+    if not is_tiny_tile_combo_supported(transpose_tile, tile_w, tile_h, has_bias) and is_llk_assert_enabled():
+        pytest.skip("Unsupported tiny-tile combination (see _TINY_TILE_SUPPORTED_COMBOS).")
 
     for _ in range(2):
         run_matmul_1d_tiny_tile(

--- a/tests/ttnn/unit_tests/operations/matmul/test_matmul.py
+++ b/tests/ttnn/unit_tests/operations/matmul/test_matmul.py
@@ -263,9 +263,7 @@ def test_matmul_reuse_config_sharded_tiny_tile(
     device, b, h, m, k, n, tile_h, tile_w, in0_sharded, in1_sharded, out_sharded, in1_dtype, transpose_tile
 ):
     if transpose_tile and tile_w == 16 and is_llk_assert_enabled():
-        pytest.skip("in1=32x16 with transpose is not supported (no addr_mod handling) in llk_math_matmul")
-    if not transpose_tile and tile_w == 16 and tile_h == 32 and is_llk_assert_enabled():
-        pytest.skip("Known failure: tile_w=16, tile_h=32 without transpose")
+        pytest.skip("in1=32x16 with transpose is not supported (no addr_mod handling) in llk_math_matmul.")
 
     torch.manual_seed(0)
 
@@ -373,9 +371,9 @@ def test_matmul_in1_dram_sharded_tiny_tile(
     mesh_device, k, n, has_bias, grid_size, tile_h, tile_w, in1_dtype, transpose_tile
 ):
     if transpose_tile and tile_w == 16 and is_llk_assert_enabled():
-        pytest.skip("in1=32x16 with transpose is not supported (no addr_mod handling) in llk_math_matmul")
+        pytest.skip("Combination of tile_w=16 and transpose_tile=True is not supported in llk_math_matmul.")
     if not transpose_tile and tile_w == 16 and tile_h == 32 and has_bias and is_llk_assert_enabled():
-        pytest.skip("Known failure: tile_w=16, tile_h=32 with bias")
+        pytest.skip("Broadcast Row with 32x16 narrow tile not supported.")
 
     # PCC issue when height not equal to tile height
     m = tile_h
@@ -829,8 +827,8 @@ def test_matmul_2d_tiny_tile(
 ):
     if transpose_tile and tile_w == 16 and is_llk_assert_enabled():
         pytest.skip("in1=32x16 with transpose is not supported (no addr_mod handling) in llk_math_matmul")
-    if not transpose_tile and tile_w == 16 and tile_h == 32 and is_llk_assert_enabled():
-        pytest.skip("Known failure: tile_w=16, tile_h=32 without transpose")
+    if not transpose_tile and tile_w == 16 and tile_h == 32 and has_bias and is_llk_assert_enabled():
+        pytest.skip("Broadcast Row with 32x16 narrow tile not supported.")
 
     for _ in range(2):
         run_matmul_2d_tiny_tile(
@@ -991,8 +989,8 @@ def test_matmul_1d_tiny_tile(
 ):
     if transpose_tile and tile_w == 16 and is_llk_assert_enabled():
         pytest.skip("in1=32x16 with transpose is not supported (no addr_mod handling) in llk_math_matmul")
-    if not transpose_tile and tile_w == 16 and tile_h == 32 and is_llk_assert_enabled():
-        pytest.skip("Known failure: tile_w=16, tile_h=32 without transpose")
+    if not transpose_tile and tile_w == 16 and tile_h == 32 and has_bias and is_llk_assert_enabled():
+        pytest.skip("Broadcast Row with 32x16 narrow tile not supported.")
 
     for _ in range(2):
         run_matmul_1d_tiny_tile(

--- a/tests/ttnn/unit_tests/operations/matmul/test_matmul.py
+++ b/tests/ttnn/unit_tests/operations/matmul/test_matmul.py
@@ -10,7 +10,7 @@ import torch
 import math
 import ttnn
 
-from models.common.utility_functions import comp_pcc, is_blackhole, skip_for_blackhole
+from models.common.utility_functions import comp_pcc, is_blackhole, is_llk_assert_enabled, skip_for_blackhole
 from tests.ttnn.utils_for_testing import assert_with_pcc
 from ttnn.operations.activations import get_golden_function_for_activation
 
@@ -262,6 +262,11 @@ def test_matmul_reuse_config_sharded_fd_column(
 def test_matmul_reuse_config_sharded_tiny_tile(
     device, b, h, m, k, n, tile_h, tile_w, in0_sharded, in1_sharded, out_sharded, in1_dtype, transpose_tile
 ):
+    if transpose_tile and tile_w == 16 and is_llk_assert_enabled():
+        pytest.skip("in1=32x16 with transpose is not supported (no addr_mod handling) in llk_math_matmul")
+    if not transpose_tile and tile_w == 16 and tile_h == 32 and is_llk_assert_enabled():
+        pytest.skip("Known failure: tile_w=16, tile_h=32 without transpose")
+
     torch.manual_seed(0)
 
     grid_size = (b, h)
@@ -367,6 +372,11 @@ def pad_to_dram_banks(num, tile_w, lcm=32 * 12):
 def test_matmul_in1_dram_sharded_tiny_tile(
     mesh_device, k, n, has_bias, grid_size, tile_h, tile_w, in1_dtype, transpose_tile
 ):
+    if transpose_tile and tile_w == 16 and is_llk_assert_enabled():
+        pytest.skip("in1=32x16 with transpose is not supported (no addr_mod handling) in llk_math_matmul")
+    if not transpose_tile and tile_w == 16 and tile_h == 32 and has_bias and is_llk_assert_enabled():
+        pytest.skip("Known failure: tile_w=16, tile_h=32 with bias")
+
     # PCC issue when height not equal to tile height
     m = tile_h
     if is_blackhole():
@@ -817,6 +827,11 @@ def test_matmul_2d_tiny_tile(
     in1_dtype,
     transpose_tile,
 ):
+    if transpose_tile and tile_w == 16 and is_llk_assert_enabled():
+        pytest.skip("in1=32x16 with transpose is not supported (no addr_mod handling) in llk_math_matmul")
+    if not transpose_tile and tile_w == 16 and tile_h == 32 and is_llk_assert_enabled():
+        pytest.skip("Known failure: tile_w=16, tile_h=32 without transpose")
+
     for _ in range(2):
         run_matmul_2d_tiny_tile(
             device, m, k, n, has_bias, grid_size, tile_h, tile_w, in0_sharded, out_sharded, in1_dtype, transpose_tile
@@ -974,6 +989,11 @@ def test_matmul_1d_tiny_tile(
     in1_dtype,
     transpose_tile,
 ):
+    if transpose_tile and tile_w == 16 and is_llk_assert_enabled():
+        pytest.skip("in1=32x16 with transpose is not supported (no addr_mod handling) in llk_math_matmul")
+    if not transpose_tile and tile_w == 16 and tile_h == 32 and is_llk_assert_enabled():
+        pytest.skip("Known failure: tile_w=16, tile_h=32 without transpose")
+
     for _ in range(2):
         run_matmul_1d_tiny_tile(
             device, m, k, n, has_bias, grid_size, tile_h, tile_w, in0_sharded, out_sharded, in1_dtype, transpose_tile

--- a/tests/ttnn/unit_tests/operations/pool/test_mpwi.py
+++ b/tests/ttnn/unit_tests/operations/pool/test_mpwi.py
@@ -8,7 +8,6 @@ import math
 import pytest
 
 from tests.sweep_framework.sweep_utils.max_pool2d_with_indices_common import run_max_pool2d_with_indices
-from models.common.utility_functions import is_llk_assert_enabled
 
 
 @pytest.mark.parametrize("in_c", [1, 16, 24, 32, 40, 48, 56, 64])
@@ -253,9 +252,6 @@ def test_mpwi_general(device, ttnn_dtype, sharding_scheme, input_spec):
 )
 @pytest.mark.parametrize("ttnn_dtype", [ttnn.bfloat16])
 def test_mpwi_32_bit_index(device, ttnn_dtype, input_spec):
-    if input_spec == [2, 48, 300, 300, 9, 9, 2, 2, 4, 4, 1, 1, False] and is_llk_assert_enabled():
-        pytest.skip("Known failure for this input spec")
-
     (
         in_n,
         in_c,

--- a/tests/ttnn/unit_tests/operations/pool/test_mpwi.py
+++ b/tests/ttnn/unit_tests/operations/pool/test_mpwi.py
@@ -8,7 +8,7 @@ import math
 import pytest
 
 from tests.sweep_framework.sweep_utils.max_pool2d_with_indices_common import run_max_pool2d_with_indices
-from models.common.utility_functions import is_llk_assert_enabled, skip_with_llk_assert
+from models.common.utility_functions import is_llk_assert_enabled
 
 
 @pytest.mark.parametrize("in_c", [1, 16, 24, 32, 40, 48, 56, 64])

--- a/tests/ttnn/unit_tests/operations/pool/test_mpwi.py
+++ b/tests/ttnn/unit_tests/operations/pool/test_mpwi.py
@@ -8,6 +8,7 @@ import math
 import pytest
 
 from tests.sweep_framework.sweep_utils.max_pool2d_with_indices_common import run_max_pool2d_with_indices
+from models.common.utility_functions import is_llk_assert_enabled, skip_with_llk_assert
 
 
 @pytest.mark.parametrize("in_c", [1, 16, 24, 32, 40, 48, 56, 64])
@@ -252,6 +253,9 @@ def test_mpwi_general(device, ttnn_dtype, sharding_scheme, input_spec):
 )
 @pytest.mark.parametrize("ttnn_dtype", [ttnn.bfloat16])
 def test_mpwi_32_bit_index(device, ttnn_dtype, input_spec):
+    if input_spec == [2, 48, 300, 300, 9, 9, 2, 2, 4, 4, 1, 1, False] and is_llk_assert_enabled():
+        pytest.skip("Known failure for this input spec")
+
     (
         in_n,
         in_c,

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_pack_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_pack_api.h
@@ -116,7 +116,7 @@ inline void llk_pack_init(const std::uint32_t pack_output = 16, std::uint32_t nu
         "");
 
     _llk_pack_init_<untilize, zero_output, tilize>(
-        pack_dst_format[output_id], face_r_dim, tile_c_dim, num_faces, partial_face, narrow_tile, num_tiles);
+        pack_dst_format[output_id], pack_src_format[output_id], face_r_dim, num_faces, partial_face, narrow_tile);
 }
 
 template <bool out_of_order_output, bool untilize>

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_pack_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_pack_api.h
@@ -116,7 +116,14 @@ inline void llk_pack_init(const std::uint32_t pack_output = 16, std::uint32_t nu
         "");
 
     _llk_pack_init_<untilize, zero_output, tilize>(
-        pack_dst_format[output_id], pack_src_format[output_id], face_r_dim, num_faces, partial_face, narrow_tile);
+        pack_src_format[output_id],
+        pack_dst_format[output_id],
+        face_r_dim,
+        tile_c_dim,
+        num_faces,
+        partial_face,
+        narrow_tile,
+        num_tiles);
 }
 
 template <bool out_of_order_output, bool untilize>

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_pack_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_pack_api.h
@@ -116,7 +116,7 @@ inline void llk_pack_init(const std::uint32_t pack_output = 16, std::uint32_t nu
         "");
 
     _llk_pack_init_<untilize, zero_output, tilize>(
-        pack_src_format[output_id], pack_dst_format[output_id], face_r_dim, tile_c_dim, num_faces, partial_face, narrow_tile, num_tiles);
+        pack_dst_format[output_id], face_r_dim, tile_c_dim, num_faces, partial_face, narrow_tile, num_tiles);
 }
 
 template <bool out_of_order_output, bool untilize>

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_pack_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_pack_api.h
@@ -110,7 +110,7 @@ inline void llk_pack_init(const std::uint32_t pack_output = 16) {
         "");
 
     _llk_pack_init_<untilize, zero_output>(
-        pack_dst_format[output_id], pack_src_format[output_id], face_r_dim, num_faces, partial_face, narrow_tile);
+        pack_dst_format[output_id], face_r_dim, num_faces, partial_face, narrow_tile);
 }
 
 template <bool out_of_order_output, bool untilize>
@@ -222,11 +222,7 @@ inline void llk_pack_untilize(
             "");
 
         _llk_pack_untilize_<block_ct_dim, full_ct_dim, diagonal, narrow_row, row_num_datums, tile_dst_ct_offset>(
-            pack_tile_addr,
-            pack_dst_format[output_id],
-            face_r_dim,
-            num_faces,
-            block_rt * block_ct_dim + tile_dst_rt_offset);
+            pack_tile_addr, pack_dst_format[output_id], face_r_dim, 4, block_rt * block_ct_dim + tile_dst_rt_offset);
 
         pack_tile_addr += full_ct_dim * get_local_cb_interface(output_id).fifo_page_size;
     }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_pack_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_pack_api.h
@@ -110,7 +110,7 @@ inline void llk_pack_init(const std::uint32_t pack_output = 16) {
         "");
 
     _llk_pack_init_<untilize, zero_output>(
-        pack_dst_format[output_id], face_r_dim, num_faces, partial_face, narrow_tile);
+        pack_dst_format[output_id], pack_src_format[output_id], face_r_dim, num_faces, partial_face, narrow_tile);
 }
 
 template <bool out_of_order_output, bool untilize>


### PR DESCRIPTION
### Ticket
Main issue: #38346
Issues covered in this PR:
https://github.com/tenstorrent/tt-llk/issues/1341
#38348
#38349

### Problem description
Current state - APC workflow is green by default, but when LLK_ASSERTS are enabled, it hits a lot of them causing a lot of red tests.
Adding new LLK_ASSERTS is more difficult due to the fact that tests are already hitting existing asserts and verifying new ones can't be done easily.

### What's changed
This PR is fixing several classes of issues:
1. BH and WH llk_pack_init calling wrong implementation of _llk_pack_init_ - causing assert hits
2. WH llk_pack_untilize sending num_faces parameter to _llk_pack_untilize_ even though this parameter is not used
3. test_matmul.py - in this test, some of created test configurations are not supported by LLK for tiny tiles causing assert hits - these tests are skipped when LLK_ASSERTS are enabled.
4. test_mpwi.py - has SFPU function which does not comply with LLK API for binary SFPU functions - functionally this test is working, but it is breaking LLK API contract - these tests are skipped when LLK_ASSERTS are enabled.

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=ndivnic/fix_hitting_LLK_ASSERT_1)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:ndivnic/fix_hitting_LLK_ASSERT_1)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ndivnic/fix_hitting_LLK_ASSERT_1)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ndivnic/fix_hitting_LLK_ASSERT_1)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ndivnic/fix_hitting_LLK_ASSERT_1)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ndivnic/fix_hitting_LLK_ASSERT_1)
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ndivnic/fix_hitting_LLK_ASSERT_1)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ndivnic/fix_hitting_LLK_ASSERT_1)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ndivnic/fix_hitting_LLK_ASSERT_1)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ndivnic/fix_hitting_LLK_ASSERT_1)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ndivnic/fix_hitting_LLK_ASSERT_1)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ndivnic/fix_hitting_LLK_ASSERT_1)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
