### PR TITLE
Revert Dispatch Init Changes

### DIFF
--- a/tt_metal/distributed/dispatch_context.cpp
+++ b/tt_metal/distributed/dispatch_context.cpp
@@ -11,11 +11,11 @@
 #include "impl/context/metal_context.hpp"
 #include "impl/device/device_manager.hpp"
 #include "impl/device/device_impl.hpp"
+#include "impl/dispatch/topology.hpp"
 #include "impl/dispatch/cq_shared_state.hpp"
 #include "llrt/hal/generated/dev_msgs.hpp"
 #include "llrt/rtoptions.hpp"
 #include "llrt/llrt.hpp"
-#include "tt_cluster.hpp"
 
 namespace tt::tt_metal::experimental {
 
@@ -53,8 +53,8 @@ void DispatchContext::initialize_fast_dispatch(distributed::MeshDevice* mesh_dev
         dev->init_command_queue_host();
     }
     // Query the number of command queues requested
-    device_manager->initialize_dispatch_firmware(/*force_recreate_topology=*/true);
-    tt::tt_metal::MetalContext::instance().rtoptions().set_fast_dispatch(fast_dispatch_enabled_);
+    populate_fd_kernels(active_devices, num_hw_cqs);
+    device_manager->initialize_dispatch_firmware();
 
     auto& mesh_device_impl = mesh_device->impl();
     mesh_device_impl.mesh_command_queues_.clear();
@@ -98,7 +98,7 @@ void DispatchContext::terminate_fast_dispatch(distributed::MeshDevice* mesh_devi
     }
 
     for (const auto& dev : active_devices) {
-        auto dispatch_cores = device_manager->get_virtual_dispatch_cores(dev->id());
+        auto dispatch_cores = tt::tt_metal::get_virtual_dispatch_cores(dev->id());
         tt::llrt::internal_::wait_until_cores_done(dev->id(), dev_msgs::RUN_MSG_GO, dispatch_cores, 0);
     }
 

--- a/tt_metal/fabric/fabric_builder.cpp
+++ b/tt_metal/fabric/fabric_builder.cpp
@@ -35,7 +35,6 @@ FabricBuilder::FabricBuilder(
 void FabricBuilder::discover_channels() {
     const auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
     const bool is_2D_routing = fabric_context_.is_2D_routing_enabled();
-    bool is_galaxy_cluster = tt_metal::MetalContext::instance().get_cluster().is_galaxy_cluster();
 
     auto is_dispatch_link = [&](chan_id_t eth_chan, uint32_t dispatch_link_idx) {
         auto link_idx = control_plane.get_routing_plane_id(local_node_, eth_chan);
@@ -69,8 +68,8 @@ void FabricBuilder::discover_channels() {
         channels_by_direction_[direction] = active_eth_chans;
 
         // Identify and cache dispatch links
-        uint32_t dispatch_link_idx = tt::tt_metal::RelayMux::get_dispatch_link_index(
-            control_plane, is_galaxy_cluster, local_node_, neighbor_fabric_node_id, device_);
+        uint32_t dispatch_link_idx =
+            tt::tt_metal::RelayMux::get_dispatch_link_index(local_node_, neighbor_fabric_node_id, device_);
         for (const auto& eth_chan : active_eth_chans) {
             if (is_dispatch_link(eth_chan, dispatch_link_idx)) {
                 dispatch_links_.insert(eth_chan);

--- a/tt_metal/fabric/fabric_tensix_builder.cpp
+++ b/tt_metal/fabric/fabric_tensix_builder.cpp
@@ -44,7 +44,6 @@ void FabricTensixDatamoverConfig::find_min_max_eth_channels(const std::vector<tt
 
     auto device_id = all_active_devices.front()->id();
     const auto& control_plane = tt_metal::MetalContext::instance().get_control_plane();
-    bool is_galaxy_cluster = tt_metal::MetalContext::instance().get_cluster().is_galaxy_cluster();
     has_dispatch_tunnel_ = device_has_dispatch_tunnel(device_id);
 
     for (const auto& device : all_active_devices) {
@@ -76,8 +75,8 @@ void FabricTensixDatamoverConfig::find_min_max_eth_channels(const std::vector<tt
         std::vector<chan_id_t> non_dispatch_active_channels;
         std::set<routing_plane_id_t> non_dispatch_routing_planes;
         for (const auto& [direction, remote_fabric_node_id] : chip_neighbors) {
-            dispatch_link_idx_ = tt_metal::RelayMux::get_dispatch_link_index(
-                control_plane, is_galaxy_cluster, fabric_node_id, remote_fabric_node_id, device);
+            dispatch_link_idx_ =
+                tt_metal::RelayMux::get_dispatch_link_index(fabric_node_id, remote_fabric_node_id, device);
 
             for (const auto& eth_chan : active_fabric_eth_channels[direction]) {
                 auto link_idx = control_plane.get_routing_plane_id(fabric_node_id, eth_chan);

--- a/tt_metal/impl/context/context_descriptor.hpp
+++ b/tt_metal/impl/context/context_descriptor.hpp
@@ -56,31 +56,6 @@ public:
         fabric_manager_(fabric_manager),
         router_config_(router_config) {}
 
-    const Hal& hal() const { return *hal_; }
-    Cluster& cluster() const { return *cluster_; }
-    const llrt::RunTimeOptions& rtoptions() const { return *rtoptions_; }
-
-    int num_cqs() const { return num_cqs_; }
-    int l1_small_size() const { return l1_small_size_; }
-    int trace_region_size() const { return trace_region_size_; }
-    int worker_l1_size() const { return worker_l1_size_; }
-    const DispatchCoreConfig& dispatch_core_config() const { return dispatch_core_config_; }
-    bool is_mock_device() const { return !mock_cluster_desc_path_.empty(); }
-    std::string_view mock_cluster_desc_path() const { return mock_cluster_desc_path_; }
-    const tt::stl::Span<const std::uint32_t>& l1_bank_remap() const { return l1_bank_remap_; }
-
-    tt::tt_fabric::FabricConfig fabric_config() const { return fabric_config_; }
-    tt::tt_fabric::FabricReliabilityMode reliability_mode() const { return reliability_mode_; }
-    std::optional<uint8_t> num_routing_planes() const { return num_routing_planes_; }
-    tt::tt_fabric::FabricTensixConfig fabric_tensix_config() const { return fabric_tensix_config_; }
-    tt::tt_fabric::FabricUDMMode fabric_udm_mode() const { return fabric_udm_mode_; }
-    tt::tt_fabric::FabricManagerMode fabric_manager() const { return fabric_manager_; }
-    const tt::tt_fabric::FabricRouterConfig& router_config() const { return router_config_; }
-
-private:
-    friend class MetalContext;
-    friend class DeviceManager;
-
     // Intended for internal use by MetalContext to pass in HAL/Cluster/RuntimeOptions dependencies for init
     ContextDescriptor(
         const Hal& hal,
@@ -117,6 +92,31 @@ private:
         router_config_(router_config) {}
 
     ContextDescriptor() = default;
+
+    const Hal& hal() const { return *hal_; }
+    Cluster& cluster() const { return *cluster_; }
+    const llrt::RunTimeOptions& rtoptions() const { return *rtoptions_; }
+
+    int num_cqs() const { return num_cqs_; }
+    int l1_small_size() const { return l1_small_size_; }
+    int trace_region_size() const { return trace_region_size_; }
+    int worker_l1_size() const { return worker_l1_size_; }
+    const DispatchCoreConfig& dispatch_core_config() const { return dispatch_core_config_; }
+    bool is_mock_device() const { return !mock_cluster_desc_path_.empty(); }
+    std::string_view mock_cluster_desc_path() const { return mock_cluster_desc_path_; }
+    const tt::stl::Span<const std::uint32_t>& l1_bank_remap() const { return l1_bank_remap_; }
+
+    tt::tt_fabric::FabricConfig fabric_config() const { return fabric_config_; }
+    tt::tt_fabric::FabricReliabilityMode reliability_mode() const { return reliability_mode_; }
+    std::optional<uint8_t> num_routing_planes() const { return num_routing_planes_; }
+    tt::tt_fabric::FabricTensixConfig fabric_tensix_config() const { return fabric_tensix_config_; }
+    tt::tt_fabric::FabricUDMMode fabric_udm_mode() const { return fabric_udm_mode_; }
+    tt::tt_fabric::FabricManagerMode fabric_manager() const { return fabric_manager_; }
+    const tt::tt_fabric::FabricRouterConfig& router_config() const { return router_config_; }
+
+private:
+    friend class MetalContext;
+    friend class DeviceManager;
 
     // Dependencies
     const Hal* hal_ = nullptr;

--- a/tt_metal/impl/context/metal_context.cpp
+++ b/tt_metal/impl/context/metal_context.cpp
@@ -291,6 +291,13 @@ void MetalContext::initialize(
         }
     }
 
+    // Populate FD topology across all devices
+    if (rtoptions_.get_fast_dispatch()) {
+        std::set<ChipId> all_devices_set(all_devices.begin(), all_devices.end());
+        // TODO: enable this when dispatch init/teardown moves to MetalContext
+        // populate_fd_kernels(all_devices_set, num_hw_cqs);
+    }
+
     // Set internal routing for active ethernet cores, this is required for our FW to run
     if (has_flag(MetalContext::instance().get_fabric_manager(), tt_fabric::FabricManagerMode::INIT_FABRIC) &&
         cluster_->get_target_device_type() != tt::TargetDevice::Mock) {
@@ -550,9 +557,9 @@ void MetalContext::teardown_dispatch_state() {
             mem_map.reset();
         }
     }
-    device_manager_->reset_dispatch_topology();
     dispatch_query_manager_.reset();
     dispatch_core_manager_.reset();
+    tt::tt_metal::reset_topology_state();
 }
 
 void MetalContext::initialize_base_objects() {
@@ -947,7 +954,7 @@ tt_fabric::FabricUDMMode MetalContext::get_fabric_udm_mode() const { return fabr
 tt_fabric::FabricManagerMode MetalContext::get_fabric_manager() const { return fabric_manager_; }
 
 std::shared_ptr<ContextDescriptor> MetalContext::create_context_descriptor(
-    int num_hw_cqs, size_t l1_small_size, size_t trace_region_size, size_t worker_l1_size) {
+    int num_hw_cqs, size_t l1_small_size, size_t trace_region_size, size_t worker_l1_size) const {
     return std::make_shared<ContextDescriptor>(
         *hal_,
         *cluster_,
@@ -1145,12 +1152,8 @@ void MetalContext::reset_cores(ChipId device_id) {
 }
 
 void MetalContext::assert_cores(ChipId device_id) {
-    std::unordered_set<CoreCoord> dispatch_cores;
-    std::unordered_set<CoreCoord> routing_cores;
-    if (device_manager_) {
-        dispatch_cores = device_manager_->get_virtual_dispatch_cores(device_id);
-        routing_cores = device_manager_->get_virtual_dispatch_routing_cores(device_id);
-    }
+    auto dispatch_cores = get_virtual_dispatch_cores(device_id);
+    auto routing_cores = get_virtual_dispatch_routing_cores(device_id);
 
     // Assert riscs on Tensix
     CoreCoord grid_size = cluster_->get_soc_desc(device_id).get_grid_size(CoreType::TENSIX);

--- a/tt_metal/impl/context/metal_context.cpp
+++ b/tt_metal/impl/context/metal_context.cpp
@@ -948,7 +948,7 @@ tt_fabric::FabricManagerMode MetalContext::get_fabric_manager() const { return f
 
 std::shared_ptr<ContextDescriptor> MetalContext::create_context_descriptor(
     int num_hw_cqs, size_t l1_small_size, size_t trace_region_size, size_t worker_l1_size) {
-    return std::shared_ptr<ContextDescriptor>(new ContextDescriptor(
+    return std::make_shared<ContextDescriptor>(
         *hal_,
         *cluster_,
         rtoptions_,
@@ -964,7 +964,7 @@ std::shared_ptr<ContextDescriptor> MetalContext::create_context_descriptor(
         worker_l1_size,
         dispatch_core_config_,
         l1_bank_remap_,
-        rtoptions_.get_mock_cluster_desc_path()));
+        rtoptions_.get_mock_cluster_desc_path());
 }
 
 void MetalContext::construct_control_plane(const std::filesystem::path& mesh_graph_desc_path) {

--- a/tt_metal/impl/context/metal_context.hpp
+++ b/tt_metal/impl/context/metal_context.hpp
@@ -77,7 +77,7 @@ public:
     bool is_device_manager_initialized() const { return device_manager_ != nullptr; }
 
     std::shared_ptr<ContextDescriptor> create_context_descriptor(
-        int num_hw_cqs, size_t l1_small_size, size_t trace_region_size, size_t worker_l1_size);
+        int num_hw_cqs, size_t l1_small_size, size_t trace_region_size, size_t worker_l1_size) const;
 
     std::unique_ptr<NOCDebugState>& noc_debug_state() { return noc_debug_state_; }
 

--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -162,7 +162,7 @@ std::unique_ptr<AllocatorImpl> Device::initialize_allocator(
 
 // Writes issue and completion queue pointers to device and in sysmem and loads fast dispatch program onto dispatch
 // cores
-void Device::configure_command_queue_programs(DispatchTopology* dispatch_topology) {
+void Device::configure_command_queue_programs() {
     ChipId device_id = this->id();
     ChipId mmio_device_id = tt::tt_metal::MetalContext::instance().get_cluster().get_associated_mmio_device(device_id);
 
@@ -219,10 +219,7 @@ void Device::configure_command_queue_programs(DispatchTopology* dispatch_topolog
     }
 
     // Write device-side cq pointers
-    TT_ASSERT(
-        dispatch_topology != nullptr,
-        "Dispatch topology required for configure_command_queue_programs (fast dispatch)");
-    dispatch_topology->configure_dispatch_cores(this);
+    configure_dispatch_cores(this);
 
     // Run the cq program
     command_queue_program.impl().finalize_offsets(this);
@@ -245,11 +242,10 @@ void Device::init_command_queue_host() {
     }
 }
 
-void Device::init_command_queue_device_with_topology(DispatchTopology* topo) {
-    TT_ASSERT(topo != nullptr, "Dispatch topology required for init_command_queue_device_with_topology");
-    this->command_queue_programs_.push_back(topo->get_compiled_cq_program(this));
+void Device::init_command_queue_device() {
+    this->command_queue_programs_.push_back(get_compiled_cq_program(this));
     TT_ASSERT(this->command_queue_programs_.size() == 1);
-    this->configure_command_queue_programs(topo);
+    this->configure_command_queue_programs();
     Program& command_queue_program = *this->command_queue_programs_[0];
 
     // Write 0 to all workers launch message read pointer. Need to do this since dispatch cores are written new on each
@@ -351,8 +347,6 @@ void Device::init_command_queue_device_with_topology(DispatchTopology* topo) {
         hw_cq->set_go_signal_noc_data_and_dispatch_sems(num_sub_devices(), noc_mcast_unicast_data);
     }
 }
-
-void Device::init_command_queue_device() { TT_FATAL(false, "Call init_command_queue_device_with_topology instead"); }
 
 bool Device::compile_fabric() {
     fabric_program_ = tt::tt_fabric::create_and_compile_fabric_program(this);

--- a/tt_metal/impl/device/device_impl.hpp
+++ b/tt_metal/impl/device/device_impl.hpp
@@ -22,7 +22,6 @@
 namespace tt::tt_metal {
 class SubDeviceManagerTracker;
 class AllocatorImpl;
-class DispatchTopology;
 
 namespace experimental {
 class DispatchContext;
@@ -134,8 +133,6 @@ public:
     void init_command_queue_host() override;
     void init_command_queue_device() override;
 
-    void init_command_queue_device_with_topology(DispatchTopology* topology);
-
     bool compile_fabric() override;
     void configure_fabric() override;
     // Puts device into reset
@@ -197,7 +194,7 @@ private:
         size_t worker_l1_unreserved_start,
         tt::stl::Span<const std::uint32_t> l1_bank_remap = {});
 
-    void configure_command_queue_programs(DispatchTopology* topology);
+    void configure_command_queue_programs();
 
     // NOLINTNEXTLINE(readability-make-member-function-const)
     void mark_allocations_unsafe();

--- a/tt_metal/impl/device/device_manager.cpp
+++ b/tt_metal/impl/device/device_manager.cpp
@@ -12,7 +12,6 @@
 #include <tt_stl/assert.hpp>
 #include <tt-logger/tt-logger.hpp>
 #include <tt_metal.hpp>
-#include "dispatch/dispatch_query_manager.hpp"
 #include "fabric/fabric_host_utils.hpp"
 #include "impl/context/metal_context.hpp"
 #include "impl/context/context_descriptor.hpp"
@@ -271,8 +270,6 @@ void DeviceManager::open_devices(const std::vector<ChipId>& device_ids) {
             fabric_config = tt::tt_fabric::FabricConfig::FABRIC_1D;
             tt::tt_fabric::SetFabricConfig(
                 fabric_config, tt::tt_fabric::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE, 1);
-            // Update the fabric config in the descriptor
-            descriptor_->fabric_config_ = fabric_config;
             // Call initialize again because previously it was a no-op
             tt::tt_metal::MetalContext::instance().initialize_fabric_config();
             log_info(
@@ -285,7 +282,6 @@ void DeviceManager::open_devices(const std::vector<ChipId>& device_ids) {
             tt::tt_fabric::SetFabricConfig(
                 fabric_config, tt::tt_fabric::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE, 1);
         }
-        descriptor_->reliability_mode_ = tt::tt_fabric::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE;
         log_info(tt::LogMetal, "Dispatch on {} with {} Command Queues\n", fabric_config, num_hw_cqs_);
     }
 
@@ -294,6 +290,9 @@ void DeviceManager::open_devices(const std::vector<ChipId>& device_ids) {
 
     // Initialize fabric tensix datamover config after devices are added to the pool
     tt::tt_metal::MetalContext::instance().initialize_fabric_tensix_datamover_config();
+
+    descriptor_ = tt::tt_metal::MetalContext::instance().create_context_descriptor(
+        num_hw_cqs_, l1_small_size_, trace_region_size_, worker_l1_size_);
 
     init_firmware_on_active_devices();
 }
@@ -405,11 +404,9 @@ void DeviceManager::add_devices_to_pool(const std::vector<ChipId>& device_ids) {
         }
     }
 
-    std::vector<Device*> activated_devices;
     for (const auto& device_id : devices_to_activate) {
         if (not this->is_device_active(device_id)) {
             this->activate_device(device_id);
-            activated_devices.push_back(this->get_device(device_id));
         }
     }
 
@@ -435,14 +432,9 @@ void DeviceManager::add_devices_to_pool(const std::vector<ChipId>& device_ids) {
         }
     }
 
-    // populate_fd_kernels_only needs to be done before Fabric initialization.
-    // It allocates dispatch cores to dispatch_core_manager.
-    auto dispatch_kernel_initializer =
-        std::make_unique<DispatchKernelInitializer>(descriptor_, MetalContext::instance().get_dispatch_core_manager());
-    if (!activated_devices.empty()) {
-        dispatch_kernel_initializer->populate_fd_kernels_only(activated_devices);
+    if (this->using_fast_dispatch_ && !devices_to_activate.empty()) {
+        populate_fd_kernels(devices_to_activate, this->num_hw_cqs_);
     }
-    initializers_[DispatchKernelInitializer::key] = std::move(dispatch_kernel_initializer);
 }
 
 void DeviceManager::initialize_profiler() {
@@ -470,6 +462,7 @@ void DeviceManager::initialize_fabric_and_dispatch_fw() {
     initializers_[FabricFirmwareInitializer::key]->init(active_devices, init_done_);
     init_done_.insert(FabricFirmwareInitializer::key);
 
+    initializers_[DispatchKernelInitializer::key] = std::make_unique<DispatchKernelInitializer>(descriptor_);
     initializers_[DispatchKernelInitializer::key]->init(active_devices, init_done_);
     init_done_.insert(DispatchKernelInitializer::key);
 
@@ -479,48 +472,16 @@ void DeviceManager::initialize_fabric_and_dispatch_fw() {
     log_trace(tt::LogMetal, "Fabric and Dispatch Firmware initialized");
 }
 
-void DeviceManager::reset_dispatch_topology() {
-    initializers_.erase(DispatchKernelInitializer::key);
-    init_done_.insert(DispatchKernelInitializer::key);
-}
-
-void DeviceManager::initialize_dispatch_firmware(bool force_recreate_topology) {
+void DeviceManager::initialize_dispatch_firmware() {
     // This function is used by DispatchContext for manual FD setup.
-    // It will re initialize the dispatch firmware on the active devices after it was manually disabled
+    // It will re initialize the dispatch firmware on the active devices as they were manually
+    // disabled
     auto active_devices = this->get_all_active_devices_impl();
     init_done_.erase(DispatchKernelInitializer::key);
-    if (force_recreate_topology) {
-        reset_dispatch_topology();
-    }
+    initializers_[DispatchKernelInitializer::key] = std::make_unique<DispatchKernelInitializer>(descriptor_);
     initializers_[DispatchKernelInitializer::key]->init(active_devices, init_done_);
     initializers_[DispatchKernelInitializer::key]->configure();
     init_done_.insert(DispatchKernelInitializer::key);
-}
-
-const std::unordered_set<CoreCoord>& DeviceManager::get_virtual_dispatch_cores(ChipId dev_id) const {
-    if (!initializers_.contains(DispatchKernelInitializer::key)) {
-        // Dispatch firmware is not initialized in minimal mode
-        return this->empty_container_;
-    }
-    auto* dispatch_kernel_initializer =
-        dynamic_cast<DispatchKernelInitializer*>(initializers_.at(DispatchKernelInitializer::key).get());
-    TT_ASSERT(
-        dispatch_kernel_initializer != nullptr,
-        "Expected DispatchKernelInitializer but got different FirmwareInitializer subclass");
-    return dispatch_kernel_initializer->get_virtual_dispatch_cores(dev_id);
-}
-
-const std::unordered_set<CoreCoord>& DeviceManager::get_virtual_dispatch_routing_cores(ChipId dev_id) const {
-    if (!initializers_.contains(DispatchKernelInitializer::key)) {
-        // Dispatch firmware is not initialized in minimal mode
-        return this->empty_container_;
-    }
-    auto* dispatch_kernel_initializer =
-        dynamic_cast<DispatchKernelInitializer*>(initializers_.at(DispatchKernelInitializer::key).get());
-    TT_ASSERT(
-        dispatch_kernel_initializer != nullptr,
-        "Expected DispatchKernelInitializer but got different FirmwareInitializer subclass");
-    return dispatch_kernel_initializer->get_virtual_dispatch_routing_cores(dev_id);
 }
 
 void DeviceManager::init_firmware_on_active_devices() {
@@ -672,6 +633,9 @@ bool DeviceManager::close_devices(const std::vector<IDevice*>& devices, bool /*s
     initializers_[ProfilerInitializer::key]->post_teardown();
     initializers_[CommandQueueInitializer::key]->post_teardown();
 
+    init_done_.clear();
+    initializers_.clear();
+
     bool pass = true;
     for (const auto& dev_id : devices_to_close) {
         auto* dev = this->get_active_device(dev_id);
@@ -691,9 +655,9 @@ DeviceManager::~DeviceManager() {
         }
     }
     this->devices_.clear();
+    TT_ASSERT(init_done_.empty(), "Init done set is not empty. Devices not properly teared down.");
     init_done_.clear();
     initializers_.clear();
-    descriptor_.reset();
 }
 }  // namespace tt_metal
 }  // namespace tt

--- a/tt_metal/impl/device/device_manager.cpp
+++ b/tt_metal/impl/device/device_manager.cpp
@@ -13,7 +13,6 @@
 #include <tt-logger/tt-logger.hpp>
 #include <tt_metal.hpp>
 #include "dispatch/dispatch_query_manager.hpp"
-#include "dprint_server.hpp"
 #include "fabric/fabric_host_utils.hpp"
 #include "impl/context/metal_context.hpp"
 #include "impl/context/context_descriptor.hpp"
@@ -438,19 +437,8 @@ void DeviceManager::add_devices_to_pool(const std::vector<ChipId>& device_ids) {
 
     // populate_fd_kernels_only needs to be done before Fabric initialization.
     // It allocates dispatch cores to dispatch_core_manager.
-    auto dispatch_kernel_initializer = std::make_unique<DispatchKernelInitializer>(
-        descriptor_,
-        MetalContext::instance().get_dispatch_core_manager(),
-        this,
-        []() -> tt::tt_fabric::ControlPlane& { return MetalContext::instance().get_control_plane(); },
-        []() -> const tt::tt_metal::DispatchQueryManager& {
-            return MetalContext::instance().get_dispatch_query_manager();
-        },
-        [this]() { return static_cast<uint32_t>(this->get_max_num_eth_cores_across_all_devices()); },
-        [](ChipId id) {
-            auto& s = MetalContext::instance().dprint_server();
-            return s && s.get() && s->reads_dispatch_cores(id);
-        });
+    auto dispatch_kernel_initializer =
+        std::make_unique<DispatchKernelInitializer>(descriptor_, MetalContext::instance().get_dispatch_core_manager());
     if (!activated_devices.empty()) {
         dispatch_kernel_initializer->populate_fd_kernels_only(activated_devices);
     }

--- a/tt_metal/impl/device/device_manager.hpp
+++ b/tt_metal/impl/device/device_manager.hpp
@@ -24,7 +24,6 @@ class IDevice;
 class FirmwareInitializer;
 enum class InitializerKey;
 
-// Initializes and Teardowns device firmware
 class DeviceManager {
 public:
     ~DeviceManager();
@@ -50,14 +49,8 @@ public:
     // Called by the mesh device
     void initialize_profiler();
     void initialize_fabric_and_dispatch_fw();
-    // Initialize dispatch firmware (compile + configure device CQs). This may be used by dispatchcontext to
-    // re-enable fast dispatch after it was disabled at runtime.
-    void initialize_dispatch_firmware(bool force_recreate_topology);
-    void reset_dispatch_topology();
     // API needed due to Issue #19729
     std::size_t get_max_num_eth_cores_across_all_devices() const;
-    const std::unordered_set<CoreCoord>& get_virtual_dispatch_cores(ChipId dev_id) const;
-    const std::unordered_set<CoreCoord>& get_virtual_dispatch_routing_cores(ChipId dev_id) const;
 
 private:
     uint8_t num_hw_cqs_{};
@@ -74,7 +67,6 @@ private:
     std::vector<std::unique_ptr<Device>> devices_;
 
     bool skip_remote_devices_{};
-    const std::unordered_set<CoreCoord> empty_container_;
 
     std::shared_ptr<ContextDescriptor> descriptor_;
     std::map<InitializerKey, std::unique_ptr<FirmwareInitializer>> initializers_;
@@ -92,6 +84,9 @@ private:
     void add_devices_to_pool(const std::vector<ChipId>& device_ids);
     Device* get_device(ChipId id) const;
     std::vector<Device*> get_all_active_devices_impl() const;
+
+    // Initialize dispatch firmware (compile + configure device CQs).
+    void initialize_dispatch_firmware();
 
     friend class experimental::DispatchContext;
 };

--- a/tt_metal/impl/device/firmware/dispatch_kernel_initializer.cpp
+++ b/tt_metal/impl/device/firmware/dispatch_kernel_initializer.cpp
@@ -9,10 +9,8 @@
 #include <llrt/tt_cluster.hpp>
 #include <tt_metal.hpp>
 #include "common/executor.hpp"
-#include "device/firmware/firmware_initializer.hpp"
+#include "device/firmware/fabric_firmware_initializer.hpp"
 #include "impl/context/context_descriptor.hpp"
-#include "impl/dispatch/dispatch_mem_map.hpp"
-#include "impl/dispatch/dispatch_core_manager.hpp"
 #include "device/device_impl.hpp"
 
 #include "dispatch/topology.hpp"
@@ -26,19 +24,6 @@ void wait_until_cores_done(
 
 namespace tt::tt_metal {
 
-DispatchKernelInitializer::DispatchKernelInitializer(
-    std::shared_ptr<const ContextDescriptor> descriptor, dispatch_core_manager& dispatch_core_manager) :
-    FirmwareInitializer(std::move(descriptor)), dispatch_core_manager_(dispatch_core_manager) {
-    dispatch_topology_ = std::make_unique<tt::tt_metal::DispatchTopology>(*descriptor_, dispatch_core_manager_);
-}
-
-void DispatchKernelInitializer::populate_fd_kernels_only(const std::vector<Device*>& devices) {
-    if (!using_fast_dispatch() || devices.empty()) {
-        return;
-    }
-    dispatch_topology_->populate_fd_kernels(devices, descriptor_->num_cqs());
-}
-
 void DispatchKernelInitializer::init(
     const std::vector<Device*>& devices, [[maybe_unused]] const std::unordered_set<InitializerKey>& init_done) {
     if (!using_fast_dispatch()) {
@@ -47,26 +32,22 @@ void DispatchKernelInitializer::init(
 
     devices_ = devices;
 
-    dispatch_mem_map_[enchantum::to_underlying(CoreType::WORKER)] =
-        std::make_unique<tt::tt_metal::DispatchMemMap>(CoreType::WORKER, descriptor_->num_cqs());
-    dispatch_mem_map_[enchantum::to_underlying(CoreType::ETH)] =
-        std::make_unique<tt::tt_metal::DispatchMemMap>(CoreType::ETH, descriptor_->num_cqs());
-
     // Skip firmware initialization for mock devices
     if (descriptor_->is_mock_device()) {
         log_info(tt::LogMetal, "Skipping dispatch firmware initialization for mock devices");
         return;
     }
 
-    // Dispatch requires Fabric, Profiler, and Command Queue
     TT_ASSERT(
-        init_done.contains(InitializerKey::Fabric), "Fabric firmware must be initialized before dispatch firmware");
-    TT_ASSERT(
-        init_done.contains(InitializerKey::Profiler), "Profiler firmware must be initialized before dispatch firmware");
-    TT_ASSERT(
-        init_done.contains(InitializerKey::CommandQueue),
-        "Host-side command queue firmware must be initialized before dispatch firmware");
-    compile_dispatch_kernels();
+        init_done.contains(FabricFirmwareInitializer::key),
+        "Fabric firmware must be initialized before dispatch firmware");
+
+    // Compile dispatch kernels if using fast dispatch.
+    // Note: Host-side init (profiler buffer clear, CQ host init) is a prerequisite
+    // that must be performed by the caller before this point.
+    if (using_fast_dispatch()) {
+        compile_dispatch_kernels();
+    }
 }
 
 void DispatchKernelInitializer::configure() {
@@ -100,6 +81,8 @@ void DispatchKernelInitializer::teardown() {
 bool DispatchKernelInitializer::is_initialized() const { return initialized_; }
 
 void DispatchKernelInitializer::compile_dispatch_kernels() {
+    // Compile dispatch firmware: populate static args, create CQ programs, compile.
+
     if (descriptor_->is_mock_device()) {
         return;
     }
@@ -111,14 +94,14 @@ void DispatchKernelInitializer::compile_dispatch_kernels() {
         }
 
         auto tunnels_from_mmio = cluster_.get_tunnels_from_mmio_device(dev->id());
-        dispatch_topology_->populate_cq_static_args(dev);
+        populate_cq_static_args(dev);
         for (const auto& tunnel : tunnels_from_mmio) {
             for (uint32_t ts = tunnel.size() - 1; ts > 0; ts--) {
                 uint32_t mmio_controlled_device_id = tunnel[ts];
                 auto it = std::find_if(
                     devices_.begin(), devices_.end(), [&](IDevice* d) { return d->id() == mmio_controlled_device_id; });
                 if (it != devices_.end()) {
-                    dispatch_topology_->populate_cq_static_args(*it);
+                    populate_cq_static_args(*it);
                 }
             }
         }
@@ -130,7 +113,7 @@ void DispatchKernelInitializer::compile_dispatch_kernels() {
             continue;
         }
 
-        dispatch_topology_->create_cq_program(dev);
+        create_cq_program(dev);
         auto tunnels_from_mmio = cluster_.get_tunnels_from_mmio_device(dev->id());
         for (const auto& tunnel : tunnels_from_mmio) {
             for (uint32_t ts = tunnel.size() - 1; ts > 0; ts--) {
@@ -138,14 +121,14 @@ void DispatchKernelInitializer::compile_dispatch_kernels() {
                 auto it = std::find_if(
                     devices_.begin(), devices_.end(), [&](IDevice* d) { return d->id() == mmio_controlled_device_id; });
                 if (it != devices_.end()) {
-                    dispatch_topology_->create_cq_program(*it);
+                    create_cq_program(*it);
                 }
             }
         }
     }
 
     // Compile all programs
-    dispatch_topology_->compile_cq_programs();
+    compile_cq_programs();
 }
 
 void DispatchKernelInitializer::init_device_command_queues() {
@@ -163,7 +146,7 @@ void DispatchKernelInitializer::init_device_command_queues() {
         ChipId mmio_device_id = dev->id();
         events.emplace_back(detail::async([this, dev, mmio_device_id]() {
             auto tunnels_from_mmio = cluster_.get_tunnels_from_mmio_device(mmio_device_id);
-            dev->init_command_queue_device_with_topology(dispatch_topology_.get());
+            dev->init_command_queue_device();
             log_debug(tt::LogMetal, "Command Queue initialized on Device {}", dev->id());
             for (const auto& tunnel : tunnels_from_mmio) {
                 for (uint32_t ts = tunnel.size() - 1; ts > 0; ts--) {
@@ -172,8 +155,8 @@ void DispatchKernelInitializer::init_device_command_queues() {
                         return d->id() == mmio_controlled_device_id;
                     });
                     if (it != devices_.end()) {
-                        (*it)->init_command_queue_device_with_topology(dispatch_topology_.get());
-                        log_debug(tt::LogMetal, "Command Queue initialized on Device {}", (*it)->id());
+                        (*it)->init_command_queue_device();
+                        log_info(tt::LogMetal, "Command Queue initialized on Device {}", (*it)->id());
                     }
                 }
             }
@@ -193,15 +176,6 @@ void DispatchKernelInitializer::terminate_command_queues() {
             cq.terminate();
         }
     }
-}
-
-const std::unordered_set<CoreCoord>& DispatchKernelInitializer::get_virtual_dispatch_cores(ChipId dev_id) const {
-    return dispatch_topology_->get_virtual_dispatch_cores(dev_id);
-}
-
-const std::unordered_set<CoreCoord>& DispatchKernelInitializer::get_virtual_dispatch_routing_cores(
-    ChipId dev_id) const {
-    return dispatch_topology_->get_virtual_dispatch_routing_cores(dev_id);
 }
 
 void DispatchKernelInitializer::wait_for_dispatch_cores() const {
@@ -229,7 +203,7 @@ void DispatchKernelInitializer::wait_for_dispatch_cores() const {
 
 void DispatchKernelInitializer::process_termination_signals() const {
     for (auto* dev : devices_) {
-        const auto& info = dispatch_topology_->get_registered_termination_cores(dev->id());
+        const auto& info = get_registered_termination_cores(dev->id());
         for (const auto& core_to_terminate : info) {
             std::vector<uint32_t> val{core_to_terminate.val};
             detail::WriteToDeviceL1(

--- a/tt_metal/impl/device/firmware/dispatch_kernel_initializer.cpp
+++ b/tt_metal/impl/device/firmware/dispatch_kernel_initializer.cpp
@@ -27,28 +27,9 @@ void wait_until_cores_done(
 namespace tt::tt_metal {
 
 DispatchKernelInitializer::DispatchKernelInitializer(
-    std::shared_ptr<const ContextDescriptor> descriptor,
-    dispatch_core_manager& dispatch_core_manager,
-    DeviceManager* device_manager,
-    const GetControlPlaneFn& get_control_plane,
-    const GetDispatchQueryManagerFn& get_dispatch_query_manager,
-    const GetMaxNumEthCoresFn& get_max_num_eth_cores,
-    const GetReadsDispatchCoresFn& get_reads_dispatch_cores) :
-    FirmwareInitializer(std::move(descriptor)),
-    dispatch_core_manager_(dispatch_core_manager),
-    device_manager_(device_manager),
-    get_control_plane_(get_control_plane),
-    get_dispatch_query_manager_(get_dispatch_query_manager),
-    get_max_num_eth_cores_(get_max_num_eth_cores),
-    get_reads_dispatch_cores_(get_reads_dispatch_cores) {
-    dispatch_topology_ = std::make_unique<tt::tt_metal::DispatchTopology>(
-        *descriptor_,
-        dispatch_core_manager_,
-        device_manager_,
-        get_control_plane_,
-        get_dispatch_query_manager_,
-        get_max_num_eth_cores_,
-        get_reads_dispatch_cores_);
+    std::shared_ptr<const ContextDescriptor> descriptor, dispatch_core_manager& dispatch_core_manager) :
+    FirmwareInitializer(std::move(descriptor)), dispatch_core_manager_(dispatch_core_manager) {
+    dispatch_topology_ = std::make_unique<tt::tt_metal::DispatchTopology>(*descriptor_, dispatch_core_manager_);
 }
 
 void DispatchKernelInitializer::populate_fd_kernels_only(const std::vector<Device*>& devices) {

--- a/tt_metal/impl/device/firmware/dispatch_kernel_initializer.hpp
+++ b/tt_metal/impl/device/firmware/dispatch_kernel_initializer.hpp
@@ -5,7 +5,6 @@
 #pragma once
 
 #include "dispatch/dispatch_mem_map.hpp"
-#include "dispatch/kernel_config/fd_kernel.hpp"
 #include "dispatch/topology.hpp"
 #include "firmware_initializer.hpp"
 
@@ -16,13 +15,7 @@ public:
     static constexpr InitializerKey key = InitializerKey::Dispatch;
 
     DispatchKernelInitializer(
-        std::shared_ptr<const ContextDescriptor> descriptor,
-        dispatch_core_manager& dispatch_core_manager,
-        DeviceManager* device_manager,
-        const GetControlPlaneFn& get_control_plane = {},
-        const GetDispatchQueryManagerFn& get_dispatch_query_manager = {},
-        const GetMaxNumEthCoresFn& get_max_num_eth_cores = {},
-        const GetReadsDispatchCoresFn& get_reads_dispatch_cores = {});
+        std::shared_ptr<const ContextDescriptor> descriptor, dispatch_core_manager& dispatch_core_manager);
 
     void init(const std::vector<Device*>& devices, const std::unordered_set<InitializerKey>& init_done) override;
     void configure() override;
@@ -53,11 +46,6 @@ private:
     std::unique_ptr<tt::tt_metal::DispatchTopology> dispatch_topology_;
     std::array<std::unique_ptr<DispatchMemMap>, static_cast<size_t>(CoreType::COUNT)> dispatch_mem_map_;
     dispatch_core_manager& dispatch_core_manager_;
-    DeviceManager* device_manager_ = nullptr;
-    GetControlPlaneFn get_control_plane_;
-    GetDispatchQueryManagerFn get_dispatch_query_manager_;
-    GetMaxNumEthCoresFn get_max_num_eth_cores_;
-    GetReadsDispatchCoresFn get_reads_dispatch_cores_;
 };
 
 }  // namespace tt::tt_metal

--- a/tt_metal/impl/device/firmware/dispatch_kernel_initializer.hpp
+++ b/tt_metal/impl/device/firmware/dispatch_kernel_initializer.hpp
@@ -4,8 +4,6 @@
 
 #pragma once
 
-#include "dispatch/dispatch_mem_map.hpp"
-#include "dispatch/topology.hpp"
 #include "firmware_initializer.hpp"
 
 namespace tt::tt_metal {
@@ -14,19 +12,13 @@ class DispatchKernelInitializer final : public FirmwareInitializer {
 public:
     static constexpr InitializerKey key = InitializerKey::Dispatch;
 
-    DispatchKernelInitializer(
-        std::shared_ptr<const ContextDescriptor> descriptor, dispatch_core_manager& dispatch_core_manager);
+    using FirmwareInitializer::FirmwareInitializer;
 
     void init(const std::vector<Device*>& devices, const std::unordered_set<InitializerKey>& init_done) override;
     void configure() override;
     void teardown() override;
     // Returns true if fast dispatch is enabled and has been configured
     bool is_initialized() const override;
-    const std::unordered_set<CoreCoord>& get_virtual_dispatch_cores(ChipId dev_id) const;
-    const std::unordered_set<CoreCoord>& get_virtual_dispatch_routing_cores(ChipId dev_id) const;
-
-    // Populate the FD kernels only. This will cause dispatch cores to be allocated in dispatch_core_manager
-    void populate_fd_kernels_only(const std::vector<Device*>& devices);
 
 private:
     void compile_dispatch_kernels();
@@ -43,9 +35,6 @@ private:
 
     std::vector<Device*> devices_;
     bool initialized_ = false;
-    std::unique_ptr<tt::tt_metal::DispatchTopology> dispatch_topology_;
-    std::array<std::unique_ptr<DispatchMemMap>, static_cast<size_t>(CoreType::COUNT)> dispatch_mem_map_;
-    dispatch_core_manager& dispatch_core_manager_;
 };
 
 }  // namespace tt::tt_metal

--- a/tt_metal/impl/dispatch/kernel_config/dispatch.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/dispatch.cpp
@@ -21,7 +21,7 @@
 #include "dispatch_s.hpp"
 #include "hal_types.hpp"
 #include "prefetch.hpp"
-#include "context/context_descriptor.hpp"
+#include "context/metal_context.hpp"
 #include "debug/inspector/inspector.hpp"
 #include <umd/device/types/xy_pair.hpp>
 #include "dispatch/system_memory_manager.hpp"
@@ -40,25 +40,9 @@ DispatchKernel::DispatchKernel(
     uint8_t cq_id,
     noc_selection_t noc_selection,
     bool h_variant,
-    bool d_variant,
-    const ContextDescriptor& descriptor,
-    dispatch_core_manager& dispatch_core_manager,
-    const GetControlPlaneFn& get_control_plane,
-    const GetDispatchQueryManagerFn& get_dispatch_query_manager,
-    const GetMaxNumEthCoresFn& get_max_num_eth_cores,
-    const GetReadsDispatchCoresFn& get_reads_dispatch_cores) :
-    FDKernel(
-        node_id,
-        device_id,
-        servicing_device_id,
-        cq_id,
-        noc_selection,
-        descriptor,
-        dispatch_core_manager,
-        get_control_plane,
-        get_dispatch_query_manager,
-        get_max_num_eth_cores,
-        get_reads_dispatch_cores) {
+    bool d_variant) :
+    FDKernel(node_id, device_id, servicing_device_id, cq_id, noc_selection) {
+    auto& core_manager = MetalContext::instance().get_dispatch_core_manager();  // Not thread safe
     TT_FATAL(
         noc_selection.downstream_noc == tt_metal::k_dispatch_downstream_noc,
         "Invalid downstream NOC specified for Dispatcher kernel");
@@ -67,18 +51,18 @@ DispatchKernel::DispatchKernel(
         "Dispatcher kernel cannot have identical upstream and downstream NOCs.");
     static_config_.is_h_variant = h_variant;
     static_config_.is_d_variant = d_variant;
-    uint16_t channel = descriptor.cluster().get_assigned_channel_for_device(device_id);
+    uint16_t channel = MetalContext::instance().get_cluster().get_assigned_channel_for_device(device_id);
 
     DispatchWorkerType type = DISPATCH;
     if (h_variant && d_variant) {
-        this->logical_core_ = dispatch_core_manager.dispatcher_core(device_id, channel, cq_id);
+        this->logical_core_ = core_manager.dispatcher_core(device_id, channel, cq_id);
         type = DISPATCH_HD;
     } else if (h_variant) {
-        channel = descriptor.cluster().get_assigned_channel_for_device(servicing_device_id);
-        this->logical_core_ = dispatch_core_manager.dispatcher_core(servicing_device_id, channel, cq_id);
+        channel = MetalContext::instance().get_cluster().get_assigned_channel_for_device(servicing_device_id);
+        this->logical_core_ = core_manager.dispatcher_core(servicing_device_id, channel, cq_id);
         type = DISPATCH_H;
     } else if (d_variant) {
-        this->logical_core_ = dispatch_core_manager.dispatcher_d_core(device_id, channel, cq_id);
+        this->logical_core_ = core_manager.dispatcher_d_core(device_id, channel, cq_id);
         type = DISPATCH_D;
     }
     this->kernel_type_ = FDKernelType::DISPATCH;
@@ -88,9 +72,9 @@ DispatchKernel::DispatchKernel(
 }
 
 void DispatchKernel::GenerateStaticConfigs() {
-    uint16_t channel = descriptor_.cluster().get_assigned_channel_for_device(device_->id());
+    uint16_t channel = MetalContext::instance().get_cluster().get_assigned_channel_for_device(device_->id());
     uint8_t cq_id_ = this->cq_id_;
-    const auto& my_dispatch_constants = *dispatch_mem_map_[enchantum::to_underlying(GetCoreType())].get();
+    const auto& my_dispatch_constants = MetalContext::instance().dispatch_mem_map(GetCoreType());
 
     // May be zero if not using dispatch on fabric
     static_config_.fabric_header_rb_base =
@@ -130,12 +114,14 @@ void DispatchKernel::GenerateStaticConfigs() {
         static_config_.max_num_worker_sems = DispatchSettings::DISPATCH_MESSAGE_ENTRIES;
         static_config_.max_num_go_signal_noc_data_entries = DispatchSettings::DISPATCH_GO_SIGNAL_NOC_DATA_ENTRIES;
         static_config_.mcast_go_signal_addr =
-            descriptor_.hal().get_dev_addr(HalProgrammableCoreType::TENSIX, HalL1MemAddrType::GO_MSG);
+            MetalContext::instance().hal().get_dev_addr(HalProgrammableCoreType::TENSIX, HalL1MemAddrType::GO_MSG);
         static_config_.unicast_go_signal_addr =
-            (descriptor_.hal().get_programmable_core_type_index(HalProgrammableCoreType::ACTIVE_ETH) != -1)
-                ? descriptor_.hal().get_dev_addr(HalProgrammableCoreType::ACTIVE_ETH, HalL1MemAddrType::GO_MSG)
+            (MetalContext::instance().hal().get_programmable_core_type_index(HalProgrammableCoreType::ACTIVE_ETH) != -1)
+                ? MetalContext::instance().hal().get_dev_addr(
+                      HalProgrammableCoreType::ACTIVE_ETH, HalL1MemAddrType::GO_MSG)
                 : 0;
-        static_config_.distributed_dispatcher = get_dispatch_query_manager_ref().distributed_dispatcher();
+        static_config_.distributed_dispatcher =
+            MetalContext::instance().get_dispatch_query_manager().distributed_dispatcher();
         static_config_.first_stream_used = my_dispatch_constants.get_dispatch_stream_index(0);
 
         static_config_.host_completion_q_wr_ptr =
@@ -148,7 +134,7 @@ void DispatchKernel::GenerateStaticConfigs() {
             my_dispatch_constants.get_device_command_queue_addr(CommandQueueDeviceAddrType::DISPATCH_PROGRESS);
     } else if (static_config_.is_h_variant.value()) {
         // DISPATCH_H services a remote chip, and so has a different channel
-        channel = descriptor_.cluster().get_assigned_channel_for_device(servicing_device_id_);
+        channel = MetalContext::instance().get_cluster().get_assigned_channel_for_device(servicing_device_id_);
         uint32_t cq_start = my_dispatch_constants.get_host_command_queue_addr(CommandQueueHostAddrType::UNRESERVED);
         uint32_t cq_size = device_->sysmem_manager().get_cq_size();
         uint32_t command_queue_start_addr = get_absolute_cq_offset(channel, cq_id_, cq_size);
@@ -212,12 +198,14 @@ void DispatchKernel::GenerateStaticConfigs() {
         static_config_.max_num_worker_sems = DispatchSettings::DISPATCH_MESSAGE_ENTRIES;
         static_config_.max_num_go_signal_noc_data_entries = DispatchSettings::DISPATCH_GO_SIGNAL_NOC_DATA_ENTRIES;
         static_config_.mcast_go_signal_addr =
-            descriptor_.hal().get_dev_addr(HalProgrammableCoreType::TENSIX, HalL1MemAddrType::GO_MSG);
+            MetalContext::instance().hal().get_dev_addr(HalProgrammableCoreType::TENSIX, HalL1MemAddrType::GO_MSG);
         static_config_.unicast_go_signal_addr =
-            (descriptor_.hal().get_programmable_core_type_index(HalProgrammableCoreType::ACTIVE_ETH) != -1)
-                ? descriptor_.hal().get_dev_addr(HalProgrammableCoreType::ACTIVE_ETH, HalL1MemAddrType::GO_MSG)
+            (MetalContext::instance().hal().get_programmable_core_type_index(HalProgrammableCoreType::ACTIVE_ETH) != -1)
+                ? MetalContext::instance().hal().get_dev_addr(
+                      HalProgrammableCoreType::ACTIVE_ETH, HalL1MemAddrType::GO_MSG)
                 : 0;
-        static_config_.distributed_dispatcher = get_dispatch_query_manager_ref().distributed_dispatcher();
+        static_config_.distributed_dispatcher =
+            MetalContext::instance().get_dispatch_query_manager().distributed_dispatcher();
         static_config_.first_stream_used = my_dispatch_constants.get_dispatch_stream_index(0);
 
         static_config_.host_completion_q_wr_ptr =
@@ -234,7 +222,8 @@ void DispatchKernel::GenerateStaticConfigs() {
 
     if (!is_hd()) {
         create_edm_connection_sems(edm_connection_attributes_);
-        static_config_.is_2d_fabric = tt::tt_fabric::is_2d_fabric_config(get_control_plane_ref().get_fabric_config());
+        const auto& fabric_context = MetalContext::instance().get_control_plane().get_fabric_context();
+        static_config_.is_2d_fabric = fabric_context.is_2D_routing_enabled();
     } else {
         static_config_.is_2d_fabric = false;
     }
@@ -270,14 +259,14 @@ void DispatchKernel::GenerateDependentConfigs() {
             dependent_config_.prefetch_h_local_downstream_sem_addr = 0;
         } else {
             dependent_config_.split_prefetch = true;
-            dependent_config_.prefetch_h_noc_xy = descriptor_.hal().noc_xy_encoding(
+            dependent_config_.prefetch_h_noc_xy = MetalContext::instance().hal().noc_xy_encoding(
                 prefetch_kernel->GetVirtualCore().x, prefetch_kernel->GetVirtualCore().y);
             dependent_config_.prefetch_h_local_downstream_sem_addr =
                 prefetch_kernel->GetStaticConfig().my_downstream_cb_sem_id;
         }
 
         // Downstream
-        if (get_dispatch_query_manager_ref().dispatch_s_enabled()) {
+        if (MetalContext::instance().get_dispatch_query_manager().dispatch_s_enabled()) {
             TT_ASSERT(downstream_kernels_.size() == 1);
             auto* dispatch_s_kernel = dynamic_cast<DispatchSKernel*>(downstream_kernels_[0]);
             TT_ASSERT(dispatch_s_kernel);
@@ -302,9 +291,8 @@ void DispatchKernel::GenerateDependentConfigs() {
             dependent_config_.upstream_logical_core = dispatch_d->GetLogicalCore();
             dependent_config_.upstream_dispatch_cb_sem_id = dispatch_d->GetStaticConfig().my_downstream_cb_sem_id;
             dependent_config_.upstream_sync_sem = 0;  // Unused
-            dependent_config_.num_hops = tt_metal::get_num_hops(descriptor_, device_id_, dispatch_d->GetDeviceId());
-            assemble_2d_fabric_packet_header_args(
-                this->dependent_config_, GetDeviceId(), dispatch_d->GetDeviceId(), get_control_plane_ref());
+            dependent_config_.num_hops = tt_metal::get_num_hops(device_id_, dispatch_d->GetDeviceId());
+            assemble_2d_fabric_packet_header_args(this->dependent_config_, GetDeviceId(), dispatch_d->GetDeviceId());
         } else {
             TT_FATAL(false, "Unimplemented path");
         }
@@ -320,7 +308,7 @@ void DispatchKernel::GenerateDependentConfigs() {
                 TT_ASSERT(prefetch_h_kernel && prefetch_h_kernel->GetStaticConfig().is_h_variant.value());
                 TT_ASSERT(!found_prefetch_h, "DISPATCH_H has multiple downstream PREFETCH_H kernels.");
                 found_prefetch_h = true;
-                dependent_config_.prefetch_h_noc_xy = descriptor_.hal().noc_xy_encoding(
+                dependent_config_.prefetch_h_noc_xy = MetalContext::instance().hal().noc_xy_encoding(
                     prefetch_h_kernel->GetVirtualCore().x, prefetch_h_kernel->GetVirtualCore().y);
                 dependent_config_.prefetch_h_local_downstream_sem_addr =
                     prefetch_h_kernel->GetStaticConfig().my_downstream_cb_sem_id;
@@ -363,7 +351,7 @@ void DispatchKernel::GenerateDependentConfigs() {
             dependent_config_.prefetch_h_local_downstream_sem_addr = 0;
         } else {
             dependent_config_.split_prefetch = true;
-            dependent_config_.prefetch_h_noc_xy = descriptor_.hal().noc_xy_encoding(
+            dependent_config_.prefetch_h_noc_xy = MetalContext::instance().hal().noc_xy_encoding(
                 prefetch_kernel->GetVirtualCore().x, prefetch_kernel->GetVirtualCore().y);
             dependent_config_.prefetch_h_local_downstream_sem_addr =
                 prefetch_kernel->GetStaticConfig().my_downstream_cb_sem_id;
@@ -388,10 +376,9 @@ void DispatchKernel::GenerateDependentConfigs() {
                 dependent_config_.downstream_cb_size = dispatch_h_kernel->GetDispatchBufferSize();
                 dependent_config_.downstream_cb_base = dispatch_h_kernel->GetStaticConfig().dispatch_cb_base;
                 dependent_config_.downstream_cb_sem_id = dispatch_h_kernel->GetStaticConfig().my_dispatch_cb_sem_id;
-                dependent_config_.num_hops =
-                    tt_metal::get_num_hops(descriptor_, dispatch_h_kernel->GetDeviceId(), device_id_);
+                dependent_config_.num_hops = tt_metal::get_num_hops(dispatch_h_kernel->GetDeviceId(), device_id_);
                 assemble_2d_fabric_packet_header_args(
-                    this->dependent_config_, GetDeviceId(), dispatch_h_kernel->GetDeviceId(), get_control_plane_ref());
+                    this->dependent_config_, GetDeviceId(), dispatch_h_kernel->GetDeviceId());
                 found_dispatch_h = true;
             } else if (auto* relay_mux = dynamic_cast<RelayMux*>(ds_kernel)) {
                 TT_ASSERT(!found_relay_mux, "DISPATCH_D has multiple downstream RELAY_MUX kernels.");
@@ -407,7 +394,7 @@ void DispatchKernel::GenerateDependentConfigs() {
         }
 
         TT_FATAL(
-            !get_dispatch_query_manager_ref().dispatch_s_enabled() || found_dispatch_s,
+            !MetalContext::instance().get_dispatch_query_manager().dispatch_s_enabled() || found_dispatch_s,
             "dispatch_d is missing dispatch_s downstream");
         TT_FATAL(found_dispatch_h, "Path not implemented for dispatch_d. dispatch_h in downstream is required");
 
@@ -427,9 +414,13 @@ void DispatchKernel::CreateKernel() {
     // num_physical_ethernet_cores is the number of actual available ethernet cores on the current device.
     // virtualize_num_eth_cores is set if the number of virtual cores is greater than the number of actual
     // ethernet cores in the chip.
-    uint32_t num_virtual_active_eth_cores = get_max_num_eth_cores();
+    uint32_t num_virtual_active_eth_cores =
+        MetalContext::instance().device_manager()->get_max_num_eth_cores_across_all_devices();
     uint32_t num_physical_active_eth_cores =
-        get_control_plane_ref().get_active_ethernet_cores(device_->id(), /*skip_reserved_tunnel_cores*/ true).size();
+        MetalContext::instance()
+            .get_control_plane()
+            .get_active_ethernet_cores(device_->id(), /*skip_reserved_tunnel_cores*/ true)
+            .size();
     bool virtualize_num_eth_cores = num_virtual_active_eth_cores > num_physical_active_eth_cores;
 
     const auto& compute_grid_size = device_->compute_with_storage_grid_size();
@@ -440,13 +431,12 @@ void DispatchKernel::CreateKernel() {
 
     std::vector<uint32_t> compile_args = {};
 
-    auto my_virtual_core = get_virtual_core_coord(descriptor_, logical_core_, GetCoreType());
-    auto upstream_virtual_core =
-        get_virtual_core_coord(descriptor_, dependent_config_.upstream_logical_core.value(), GetCoreType());
+    auto my_virtual_core = get_virtual_core_coord(logical_core_, GetCoreType());
+    auto upstream_virtual_core = get_virtual_core_coord(dependent_config_.upstream_logical_core.value(), GetCoreType());
     auto downstream_virtual_core =
-        get_virtual_core_coord(descriptor_, dependent_config_.downstream_logical_core.value(), GetCoreType());
+        get_virtual_core_coord(dependent_config_.downstream_logical_core.value(), GetCoreType());
     auto downstream_s_virtual_core =
-        get_virtual_core_coord(descriptor_, dependent_config_.downstream_s_logical_core.value(), GetCoreType());
+        get_virtual_core_coord(dependent_config_.downstream_s_logical_core.value(), GetCoreType());
 
     auto my_virtual_noc_coords = device_->virtual_noc0_coordinate(noc_selection_.non_dispatch_noc, my_virtual_core);
     auto upstream_virtual_noc_coords =
@@ -561,7 +551,7 @@ void DispatchKernel::CreateKernel() {
 void DispatchKernel::ConfigureCore() {
     // For all dispatchers, need to clear the dispatch message
     std::vector<uint32_t> zero = {0x0};
-    const auto& my_dispatch_constants = *this->dispatch_mem_map_[enchantum::to_underlying(GetCoreType())].get();
+    const auto& my_dispatch_constants = MetalContext::instance().dispatch_mem_map(GetCoreType());
     uint32_t dispatch_s_sync_sem_base_addr =
         my_dispatch_constants.get_device_command_queue_addr(CommandQueueDeviceAddrType::DISPATCH_S_SYNC_SEM);
     for (uint32_t i = 0; i < DispatchSettings::DISPATCH_MESSAGE_ENTRIES; i++) {

--- a/tt_metal/impl/dispatch/kernel_config/dispatch.hpp
+++ b/tt_metal/impl/dispatch/kernel_config/dispatch.hpp
@@ -12,7 +12,7 @@
 #include "dispatch/kernel_config/relay_mux.hpp"
 #include "fd_kernel.hpp"
 #include <tt-metalium/experimental/fabric/mesh_graph.hpp>
-#include "impl/context/context_descriptor.hpp"
+#include "impl/context/metal_context.hpp"
 #include "tt_metal/impl/dispatch/topology.hpp"
 #include <umd/device/types/xy_pair.hpp>
 
@@ -99,13 +99,7 @@ public:
         uint8_t cq_id,
         noc_selection_t noc_selection,
         bool h_variant,
-        bool d_variant,
-        const ContextDescriptor& descriptor,
-        dispatch_core_manager& dispatch_core_manager,
-        const GetControlPlaneFn& get_control_plane = {},
-        const GetDispatchQueryManagerFn& get_dispatch_query_manager = {},
-        const GetMaxNumEthCoresFn& get_max_num_eth_cores = {},
-        const GetReadsDispatchCoresFn& get_reads_dispatch_cores = {});
+        bool d_variant);
 
     void CreateKernel() override;
 

--- a/tt_metal/impl/dispatch/kernel_config/dispatch_s.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/dispatch_s.cpp
@@ -19,7 +19,7 @@
 #include "dispatch/dispatch_settings.hpp"
 #include "hal_types.hpp"
 #include "prefetch.hpp"
-#include "context/context_descriptor.hpp"
+#include "context/metal_context.hpp"
 #include "debug/inspector/inspector.hpp"
 #include <umd/device/types/core_coordinates.hpp>
 #include <umd/device/types/xy_pair.hpp>
@@ -31,31 +31,11 @@
 using namespace tt::tt_metal;
 
 DispatchSKernel::DispatchSKernel(
-    int node_id,
-    ChipId device_id,
-    ChipId servicing_device_id,
-    uint8_t cq_id,
-    noc_selection_t noc_selection,
-    const ContextDescriptor& descriptor,
-    dispatch_core_manager& dispatch_core_manager,
-    const GetControlPlaneFn& get_control_plane,
-    const GetDispatchQueryManagerFn& get_dispatch_query_manager,
-    const GetMaxNumEthCoresFn& get_max_num_eth_cores,
-    const GetReadsDispatchCoresFn& get_reads_dispatch_cores) :
-    FDKernel(
-        node_id,
-        device_id,
-        servicing_device_id,
-        cq_id,
-        noc_selection,
-        descriptor,
-        dispatch_core_manager,
-        get_control_plane,
-        get_dispatch_query_manager,
-        get_max_num_eth_cores,
-        get_reads_dispatch_cores) {
-    uint16_t channel = descriptor.cluster().get_assigned_channel_for_device(device_id);
-    this->logical_core_ = dispatch_core_manager.dispatcher_s_core(device_id, channel, cq_id_);
+    int node_id, ChipId device_id, ChipId servicing_device_id, uint8_t cq_id, noc_selection_t noc_selection) :
+    FDKernel(node_id, device_id, servicing_device_id, cq_id, noc_selection) {
+    uint16_t channel = MetalContext::instance().get_cluster().get_assigned_channel_for_device(device_id);
+    this->logical_core_ =
+        MetalContext::instance().get_dispatch_core_manager().dispatcher_s_core(device_id, channel, cq_id_);
     this->kernel_type_ = FDKernelType::DISPATCH;
     // Log dispatch_s core info based on virtual core to inspector
     auto virtual_core = this->GetVirtualCore();
@@ -63,10 +43,10 @@ DispatchSKernel::DispatchSKernel(
 }
 
 void DispatchSKernel::GenerateStaticConfigs() {
-    const auto& my_dispatch_constants = *dispatch_mem_map_[enchantum::to_underlying(GetCoreType())].get();
+    const auto& my_dispatch_constants = MetalContext::instance().dispatch_mem_map(GetCoreType());
 
     uint32_t dispatch_s_buffer_base = 0xff;
-    if (get_dispatch_query_manager_ref().dispatch_s_enabled()) {
+    if (MetalContext::instance().get_dispatch_query_manager().dispatch_s_enabled()) {
         uint32_t dispatch_buffer_base = my_dispatch_constants.dispatch_buffer_base();
         if (GetCoreType() == CoreType::WORKER) {
             // dispatch_s is on the same Tensix core as dispatch_d. Shared resources. Offset CB start idx.
@@ -88,12 +68,13 @@ void DispatchSKernel::GenerateStaticConfigs() {
     // used by dispatch_d to signal that dispatch_s can send go signal
 
     static_config_.mcast_go_signal_addr =
-        descriptor_.hal().get_dev_addr(HalProgrammableCoreType::TENSIX, HalL1MemAddrType::GO_MSG);
+        MetalContext::instance().hal().get_dev_addr(HalProgrammableCoreType::TENSIX, HalL1MemAddrType::GO_MSG);
     static_config_.unicast_go_signal_addr =
-        (descriptor_.hal().get_programmable_core_type_index(HalProgrammableCoreType::ACTIVE_ETH) != -1)
-            ? descriptor_.hal().get_dev_addr(HalProgrammableCoreType::ACTIVE_ETH, HalL1MemAddrType::GO_MSG)
+        (MetalContext::instance().hal().get_programmable_core_type_index(HalProgrammableCoreType::ACTIVE_ETH) != -1)
+            ? MetalContext::instance().hal().get_dev_addr(HalProgrammableCoreType::ACTIVE_ETH, HalL1MemAddrType::GO_MSG)
             : 0;
-    static_config_.distributed_dispatcher = get_dispatch_query_manager_ref().distributed_dispatcher();
+    static_config_.distributed_dispatcher =
+        MetalContext::instance().get_dispatch_query_manager().distributed_dispatcher();
     static_config_.first_stream_used = my_dispatch_constants.get_dispatch_stream_index(0);
     static_config_.max_num_worker_sems = DispatchSettings::DISPATCH_MESSAGE_ENTRIES;
     static_config_.max_num_go_signal_noc_data_entries = DispatchSettings::DISPATCH_GO_SIGNAL_NOC_DATA_ENTRIES;
@@ -122,9 +103,13 @@ void DispatchSKernel::CreateKernel() {
     // num_physical_ethernet_cores is the number of actual available ethernet cores on the current device.
     // virtualize_num_eth_cores is set if the number of virtual cores is greater than the number of actual
     // ethernet cores in the chip.
-    uint32_t num_virtual_active_eth_cores = get_max_num_eth_cores();
+    uint32_t num_virtual_active_eth_cores =
+        MetalContext::instance().device_manager()->get_max_num_eth_cores_across_all_devices();
     uint32_t num_physical_active_eth_cores =
-        get_control_plane_ref().get_active_ethernet_cores(device_->id(), /*skip_reserved_tunnel_cores*/ true).size();
+        MetalContext::instance()
+            .get_control_plane()
+            .get_active_ethernet_cores(device_->id(), /*skip_reserved_tunnel_cores*/ true)
+            .size();
     bool virtualize_num_eth_cores = num_virtual_active_eth_cores > num_physical_active_eth_cores;
 
     const auto& compute_grid_size = device_->compute_with_storage_grid_size();
@@ -182,12 +167,12 @@ void DispatchSKernel::CreateKernel() {
 }
 
 void DispatchSKernel::ConfigureCore() {
-    if (!get_dispatch_query_manager_ref().distributed_dispatcher()) {
+    if (!MetalContext::instance().get_dispatch_query_manager().distributed_dispatcher()) {
         return;
     }
     // Just need to clear the dispatch message
     std::vector<uint32_t> zero = {0x0};
-    const auto& my_dispatch_constants = *dispatch_mem_map_[enchantum::to_underlying(GetCoreType())].get();
+    const auto& my_dispatch_constants = MetalContext::instance().dispatch_mem_map(GetCoreType());
     uint32_t dispatch_s_sync_sem_base_addr =
         my_dispatch_constants.get_device_command_queue_addr(CommandQueueDeviceAddrType::DISPATCH_S_SYNC_SEM);
     for (uint32_t i = 0; i < DispatchSettings::DISPATCH_MESSAGE_ENTRIES; i++) {

--- a/tt_metal/impl/dispatch/kernel_config/dispatch_s.hpp
+++ b/tt_metal/impl/dispatch/kernel_config/dispatch_s.hpp
@@ -6,7 +6,7 @@
 #include <optional>
 
 #include "fd_kernel.hpp"
-#include "impl/context/context_descriptor.hpp"
+#include "impl/context/metal_context.hpp"
 #include <umd/device/types/xy_pair.hpp>
 
 namespace tt::tt_metal {
@@ -35,17 +35,7 @@ struct dispatch_s_dependent_config_t {
 class DispatchSKernel : public FDKernel {
 public:
     DispatchSKernel(
-        int node_id,
-        ChipId device_id,
-        ChipId servicing_device_id,
-        uint8_t cq_id,
-        noc_selection_t noc_selection,
-        const ContextDescriptor& descriptor,
-        dispatch_core_manager& dispatch_core_manager,
-        const GetControlPlaneFn& get_control_plane = {},
-        const GetDispatchQueryManagerFn& get_dispatch_query_manager = {},
-        const GetMaxNumEthCoresFn& get_max_num_eth_cores = {},
-        const GetReadsDispatchCoresFn& get_reads_dispatch_cores = {});
+        int node_id, ChipId device_id, ChipId servicing_device_id, uint8_t cq_id, noc_selection_t noc_selection);
 
     void CreateKernel() override;
     void GenerateStaticConfigs() override;

--- a/tt_metal/impl/dispatch/kernel_config/fd_kernel.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/fd_kernel.cpp
@@ -4,7 +4,6 @@
 
 #include "fd_kernel.hpp"
 
-#include <tt-metalium/experimental/fabric/control_plane.hpp>
 #include <host_api.hpp>
 #include <utility>
 #include <variant>
@@ -18,15 +17,16 @@
 #include "hal_types.hpp"
 #include "kernel_types.hpp"
 #include "prefetch.hpp"
-#include "impl/context/context_descriptor.hpp"
+#include "impl/context/metal_context.hpp"
 #include <umd/device/types/core_coordinates.hpp>
 #include <impl/debug/dprint_server.hpp>
 
 using namespace tt::tt_metal;
 
-ChipId FDKernel::GetUpstreamDeviceId(const ContextDescriptor& descriptor, ChipId device_id) {
-    ChipId mmio_device_id = descriptor.cluster().get_associated_mmio_device(device_id);
-    for (auto tunnel : descriptor.cluster().get_tunnels_from_mmio_device(mmio_device_id)) {
+ChipId FDKernel::GetUpstreamDeviceId(ChipId device_id) {
+    ChipId mmio_device_id = tt::tt_metal::MetalContext::instance().get_cluster().get_associated_mmio_device(device_id);
+    for (auto tunnel :
+         tt::tt_metal::MetalContext::instance().get_cluster().get_tunnels_from_mmio_device(mmio_device_id)) {
         for (int idx = 0; idx < tunnel.size(); idx++) {
             if (tunnel[idx] == device_id) {
                 // MMIO device doesn't have an upsream, just return itself
@@ -38,9 +38,9 @@ ChipId FDKernel::GetUpstreamDeviceId(const ContextDescriptor& descriptor, ChipId
     return device_id;
 }
 
-ChipId FDKernel::GetDownstreamDeviceId(const ContextDescriptor& descriptor, ChipId device_id, int tunnel) {
-    ChipId mmio_device_id = descriptor.cluster().get_associated_mmio_device(device_id);
-    auto tunnels = descriptor.cluster().get_tunnels_from_mmio_device(mmio_device_id);
+ChipId FDKernel::GetDownstreamDeviceId(ChipId device_id, int tunnel) {
+    ChipId mmio_device_id = tt::tt_metal::MetalContext::instance().get_cluster().get_associated_mmio_device(device_id);
+    auto tunnels = tt::tt_metal::MetalContext::instance().get_cluster().get_tunnels_from_mmio_device(mmio_device_id);
     if (tunnel < -1 || tunnel >= static_cast<int>(tunnels.size())) {
         TT_THROW("Tunnel {} is out of range. {} tunnels exist", tunnel, tunnels.size());
     }
@@ -63,9 +63,10 @@ ChipId FDKernel::GetDownstreamDeviceId(const ContextDescriptor& descriptor, Chip
     return device_id;
 }
 
-uint32_t FDKernel::GetTunnelStop(const ContextDescriptor& descriptor, ChipId device_id) {
-    ChipId mmio_device_id = descriptor.cluster().get_associated_mmio_device(device_id);
-    for (auto tunnel : descriptor.cluster().get_tunnels_from_mmio_device(mmio_device_id)) {
+uint32_t FDKernel::GetTunnelStop(ChipId device_id) {
+    ChipId mmio_device_id = tt::tt_metal::MetalContext::instance().get_cluster().get_associated_mmio_device(device_id);
+    for (auto tunnel :
+         tt::tt_metal::MetalContext::instance().get_cluster().get_tunnels_from_mmio_device(mmio_device_id)) {
         for (uint32_t idx = 0; idx < tunnel.size(); idx++) {
             if (tunnel[idx] == device_id) {
                 return idx;
@@ -76,21 +77,6 @@ uint32_t FDKernel::GetTunnelStop(const ContextDescriptor& descriptor, ChipId dev
     return 0;
 }
 
-tt::tt_fabric::ControlPlane& FDKernel::get_control_plane_ref() const {
-    TT_ASSERT(static_cast<bool>(get_control_plane_), "Control plane accessor not set (required when fabric is used)");
-    return get_control_plane_();
-}
-
-const DispatchQueryManager& FDKernel::get_dispatch_query_manager_ref() const {
-    TT_ASSERT(static_cast<bool>(get_dispatch_query_manager_), "Dispatch query manager accessor not set");
-    return get_dispatch_query_manager_();
-}
-
-uint32_t FDKernel::get_max_num_eth_cores() const {
-    TT_ASSERT(static_cast<bool>(get_max_num_eth_cores_), "Max num eth cores accessor not set");
-    return get_max_num_eth_cores_();
-}
-
 FDKernel* FDKernel::Generate(
     int node_id,
     ChipId device_id,
@@ -98,169 +84,52 @@ FDKernel* FDKernel::Generate(
     uint8_t cq_id,
     noc_selection_t noc_selection,
     DispatchWorkerType type,
-    const ContextDescriptor& descriptor,
-    dispatch_core_manager& dispatch_core_manager,
-    int tunnel_index,
-    const GetControlPlaneFn& get_control_plane,
-    const GetDispatchQueryManagerFn& get_dispatch_query_manager,
-    const GetMaxNumEthCoresFn& get_max_num_eth_cores,
-    const GetReadsDispatchCoresFn& get_reads_dispatch_cores) {
+    int tunnel_index) {
     switch (type) {
         case PREFETCH_HD:
-            return new PrefetchKernel(
-                node_id,
-                device_id,
-                servicing_device_id,
-                cq_id,
-                noc_selection,
-                true,
-                true,
-                descriptor,
-                dispatch_core_manager,
-                get_control_plane,
-                get_dispatch_query_manager,
-                get_max_num_eth_cores,
-                get_reads_dispatch_cores);
+            return new PrefetchKernel(node_id, device_id, servicing_device_id, cq_id, noc_selection, true, true);
         case PREFETCH_H:
-            return new PrefetchKernel(
-                node_id,
-                device_id,
-                servicing_device_id,
-                cq_id,
-                noc_selection,
-                true,
-                false,
-                descriptor,
-                dispatch_core_manager,
-                get_control_plane,
-                get_dispatch_query_manager,
-                get_max_num_eth_cores,
-                get_reads_dispatch_cores);
+            return new PrefetchKernel(node_id, device_id, servicing_device_id, cq_id, noc_selection, true, false);
         case PREFETCH_D:
-            return new PrefetchKernel(
-                node_id,
-                device_id,
-                servicing_device_id,
-                cq_id,
-                noc_selection,
-                false,
-                true,
-                descriptor,
-                dispatch_core_manager,
-                get_control_plane,
-                get_dispatch_query_manager,
-                get_max_num_eth_cores,
-                get_reads_dispatch_cores);
+            return new PrefetchKernel(node_id, device_id, servicing_device_id, cq_id, noc_selection, false, true);
         case DISPATCH_HD:
-            return new DispatchKernel(
-                node_id,
-                device_id,
-                servicing_device_id,
-                cq_id,
-                noc_selection,
-                true,
-                true,
-                descriptor,
-                dispatch_core_manager,
-                get_control_plane,
-                get_dispatch_query_manager,
-                get_max_num_eth_cores,
-                get_reads_dispatch_cores);
+            return new DispatchKernel(node_id, device_id, servicing_device_id, cq_id, noc_selection, true, true);
         case DISPATCH_H:
-            return new DispatchKernel(
-                node_id,
-                device_id,
-                servicing_device_id,
-                cq_id,
-                noc_selection,
-                true,
-                false,
-                descriptor,
-                dispatch_core_manager,
-                get_control_plane,
-                get_dispatch_query_manager,
-                get_max_num_eth_cores,
-                get_reads_dispatch_cores);
+            return new DispatchKernel(node_id, device_id, servicing_device_id, cq_id, noc_selection, true, false);
         case DISPATCH_D:
-            return new DispatchKernel(
-                node_id,
-                device_id,
-                servicing_device_id,
-                cq_id,
-                noc_selection,
-                false,
-                true,
-                descriptor,
-                dispatch_core_manager,
-                get_control_plane,
-                get_dispatch_query_manager,
-                get_max_num_eth_cores,
-                get_reads_dispatch_cores);
-        case DISPATCH_S:
-            return new DispatchSKernel(
-                node_id,
-                device_id,
-                servicing_device_id,
-                cq_id,
-                noc_selection,
-                descriptor,
-                dispatch_core_manager,
-                get_control_plane,
-                get_dispatch_query_manager,
-                get_max_num_eth_cores,
-                get_reads_dispatch_cores);
+            return new DispatchKernel(node_id, device_id, servicing_device_id, cq_id, noc_selection, false, true);
+        case DISPATCH_S: return new DispatchSKernel(node_id, device_id, servicing_device_id, cq_id, noc_selection);
         case FABRIC_MUX:
             return new tt::tt_metal::RelayMux(
-                node_id,
-                device_id,
-                servicing_device_id,
-                cq_id,
-                noc_selection,
-                false,
-                tunnel_index,
-                descriptor,
-                dispatch_core_manager,
-                get_control_plane,
-                get_reads_dispatch_cores);
+                node_id, device_id, servicing_device_id, cq_id, noc_selection, false, tunnel_index);
         case RETURN_FABRIC_MUX:
             return new tt::tt_metal::RelayMux(
-                node_id,
-                device_id,
-                servicing_device_id,
-                cq_id,
-                noc_selection,
-                true,
-                tunnel_index,
-                descriptor,
-                dispatch_core_manager,
-                get_control_plane,
-                get_reads_dispatch_cores);
+                node_id, device_id, servicing_device_id, cq_id, noc_selection, true, tunnel_index);
         default: TT_FATAL(false, "Unrecognized dispatch kernel type: {}.", type); return nullptr;
     }
 }
 
-uint32_t FDKernel::get_programmable_core_type_index(
-    const ContextDescriptor& descriptor, CoreType dispatch_core_type, bool is_active_eth_core) {
+uint32_t FDKernel::get_programmable_core_type_index(CoreType dispatch_core_type, bool is_active_eth_core) {
     // TODO(#22895): Too many core types. Consolidate programmable_core_type_index with ProgrammableCoreType and
     // CoreType
     uint32_t programmable_core_type_index;
     if (dispatch_core_type == CoreType::WORKER) {
         programmable_core_type_index =
-            descriptor.hal().get_programmable_core_type_index(HalProgrammableCoreType::TENSIX);
+            MetalContext::instance().hal().get_programmable_core_type_index(HalProgrammableCoreType::TENSIX);
     } else if (is_active_eth_core) {
         programmable_core_type_index =
-            descriptor.hal().get_programmable_core_type_index(HalProgrammableCoreType::ACTIVE_ETH);
+            MetalContext::instance().hal().get_programmable_core_type_index(HalProgrammableCoreType::ACTIVE_ETH);
     } else {
         programmable_core_type_index =
-            descriptor.hal().get_programmable_core_type_index(HalProgrammableCoreType::IDLE_ETH);
+            MetalContext::instance().hal().get_programmable_core_type_index(HalProgrammableCoreType::IDLE_ETH);
     }
 
     return programmable_core_type_index;
 }
 
-CoreCoord FDKernel::get_virtual_core_coord(
-    const ContextDescriptor& descriptor, const tt_cxy_pair& logical_cxy, const CoreType& core_type) {
-    return descriptor.cluster().get_virtual_coordinate_from_logical_coordinates(logical_cxy, core_type);
+CoreCoord FDKernel::get_virtual_core_coord(const tt_cxy_pair& logical_cxy, const CoreType& core_type) {
+    const auto& cluster = tt::tt_metal::MetalContext::instance().get_cluster();
+    return cluster.get_virtual_coordinate_from_logical_coordinates(logical_cxy, core_type);
 }
 
 KernelHandle FDKernel::configure_kernel_variant(
@@ -271,8 +140,7 @@ KernelHandle FDKernel::configure_kernel_variant(
     bool send_to_brisc,
     bool force_watcher_no_inline,
     KernelBuildOptLevel opt_level) {
-    uint32_t programmable_core_type_index =
-        get_programmable_core_type_index(descriptor_, GetCoreType(), is_active_eth_core);
+    uint32_t programmable_core_type_index = get_programmable_core_type_index(GetCoreType(), is_active_eth_core);
 
     std::map<std::string, std::string> defines = {
         {"DISPATCH_KERNEL", "1"},
@@ -281,15 +149,16 @@ KernelHandle FDKernel::configure_kernel_variant(
     if (force_watcher_no_inline) {
         defines.insert({"WATCHER_NOINLINE", std::to_string(force_watcher_no_inline)});
     }
-    const auto& rt_options = descriptor_.rtoptions();
+    auto& rt_options = tt::tt_metal::MetalContext::instance().rtoptions();
     if (rt_options.watcher_dispatch_disabled()) {
         defines["FORCE_WATCHER_OFF"] = "1";
     }
-    if (!(get_reads_dispatch_cores_ && get_reads_dispatch_cores_(device_->id()))) {
+    if (!(MetalContext::instance().dprint_server() and
+          MetalContext::instance().dprint_server()->reads_dispatch_cores(device_->id()))) {
         defines["FORCE_DPRINT_OFF"] = "1";
     }
     defines.insert(defines_in.begin(), defines_in.end());
-    if (descriptor_.cluster().is_galaxy_cluster()) {
+    if (MetalContext::instance().get_cluster().is_galaxy_cluster()) {
         // TG specific fabric routing
         // TODO: https://github.com/tenstorrent/tt-metal/issues/24413
         defines["GALAXY_CLUSTER"] = "1";

--- a/tt_metal/impl/dispatch/kernel_config/fd_kernel.hpp
+++ b/tt_metal/impl/dispatch/kernel_config/fd_kernel.hpp
@@ -6,23 +6,20 @@
 
 #include <tt-metalium/program.hpp>
 #include <tt-metalium/kernel_types.hpp>
-#include <cstdint>
-#include <functional>
+#include <stdint.h>
 #include <map>
 #include <string>
 #include <vector>
 
 #include <tt_stl/assert.hpp>
 #include "core_coord.hpp"
-#include "impl/context/context_descriptor.hpp"
+#include "impl/context/metal_context.hpp"
 #include "impl/dispatch/dispatch_core_common.hpp"
 #include <umd/device/types/xy_pair.hpp>
 #include <umd/device/types/core_coordinates.hpp>
 #include <tt_stl/tt_stl/reflection.hpp>
 #include <impl/dispatch/dispatch_core_manager.hpp>
-#include <impl/dispatch/dispatch_query_manager.hpp>
 #include <llrt/tt_cluster.hpp>
-#include <impl/dispatch/dispatch_mem_map.hpp>
 
 namespace tt::tt_metal {
 
@@ -82,45 +79,16 @@ static std::vector<std::string> dispatch_kernel_file_names = {
     ""                                                             // COUNT
 };
 
-// Use getters because they may be recreated between calls to Generate() and ConfigureCore()
-// E.g., Changing fabric mode from Disabled to Enabled constructs a new control plane
-using GetControlPlaneFn = std::function<tt::tt_fabric::ControlPlane&()>;
-using GetDispatchQueryManagerFn = std::function<const DispatchQueryManager&()>;
-using GetMaxNumEthCoresFn = std::function<uint32_t()>;
-using GetReadsDispatchCoresFn = std::function<bool(ChipId)>;
-
 // Top-level class describing a Fast Dispatch Kernel (kernel running on a specific core). All FD kernels should inherit
 // from this class and implement the virtual functions as required.
 class FDKernel {
 public:
-    FDKernel(
-        int node_id,
-        ChipId device_id,
-        ChipId servicing_device_id,
-        uint8_t cq_id,
-        noc_selection_t noc_selection,
-        const ContextDescriptor& descriptor,
-        dispatch_core_manager& dispatch_core_manager,
-        const GetControlPlaneFn& get_control_plane = {},
-        const GetDispatchQueryManagerFn& get_dispatch_query_manager = {},
-        const GetMaxNumEthCoresFn& get_max_num_eth_cores = {},
-        const GetReadsDispatchCoresFn& get_reads_dispatch_cores = {}) :
+    FDKernel(int node_id, ChipId device_id, ChipId servicing_device_id, uint8_t cq_id, noc_selection_t noc_selection) :
         device_id_(device_id),
         servicing_device_id_(servicing_device_id),
         node_id_(node_id),
         cq_id_(cq_id),
-        noc_selection_(noc_selection),
-        descriptor_(descriptor),
-        dispatch_core_manager_(dispatch_core_manager),
-        get_control_plane_(get_control_plane),
-        get_dispatch_query_manager_(get_dispatch_query_manager),
-        get_max_num_eth_cores_(get_max_num_eth_cores),
-        get_reads_dispatch_cores_(get_reads_dispatch_cores) {
-        dispatch_mem_map_[enchantum::to_underlying(CoreType::WORKER)] =
-            std::make_unique<tt::tt_metal::DispatchMemMap>(CoreType::WORKER, descriptor.num_cqs());
-        dispatch_mem_map_[enchantum::to_underlying(CoreType::ETH)] =
-            std::make_unique<tt::tt_metal::DispatchMemMap>(CoreType::ETH, descriptor.num_cqs());
-    }
+        noc_selection_(noc_selection) {}
     virtual ~FDKernel() = default;
 
     // Populate the static configs for this kernel (ones that do not depend on configs from other kernels), including
@@ -150,34 +118,29 @@ public:
         uint8_t cq_id,
         noc_selection_t noc_selection,
         tt::tt_metal::DispatchWorkerType type,
-        const ContextDescriptor& descriptor,
-        dispatch_core_manager& dispatch_core_manager,
-        int tunnel_index = -1,
-        const GetControlPlaneFn& get_control_plane = {},
-        const GetDispatchQueryManagerFn& get_dispatch_query_manager = {},
-        const GetMaxNumEthCoresFn& get_max_num_eth_cores = {},
-        const GetReadsDispatchCoresFn& get_reads_dispatch_cores = {});
+        int tunnel_index = -1);
 
     // Translate DispatchCoreType to programmable core type index
-    static uint32_t get_programmable_core_type_index(
-        const ContextDescriptor& descriptor, CoreType dispatch_core_type, bool is_active_eth_core = false);
+    static uint32_t get_programmable_core_type_index(CoreType dispatch_core_type, bool is_active_eth_core = false);
 
     // Translate core coord using the chip_id from the logical_cxy
     //
     // IDevice::virtual_core_from_logical_core uses the chip_id of the device instance whereas this function uses the
     // chip_id specified in the logical coordinate.
-    static CoreCoord get_virtual_core_coord(
-        const ContextDescriptor& descriptor, const tt_cxy_pair& logical_cxy, const CoreType& core_type);
+    static CoreCoord get_virtual_core_coord(const tt_cxy_pair& logical_cxy, const CoreType& core_type);
 
     // Register another kernel as upstream/downstream of this one
     void AddUpstreamKernel(FDKernel* upstream) { upstream_kernels_.push_back(upstream); }
     void AddDownstreamKernel(FDKernel* downstream) { downstream_kernels_.push_back(downstream); }
 
-    virtual CoreType GetCoreType() const { return dispatch_core_manager_.get_dispatch_core_type(); }
+    virtual CoreType GetCoreType() const {
+        return tt::tt_metal::MetalContext::instance().get_dispatch_core_manager().get_dispatch_core_type();
+    }
     FDKernelType GetKernelType() const { return kernel_type_; }
     tt_cxy_pair GetLogicalCore() const { return logical_core_; }
     tt_cxy_pair GetVirtualCore() const {
-        return descriptor_.cluster().get_virtual_coordinate_from_logical_coordinates(logical_core_, GetCoreType());
+        return tt::tt_metal::MetalContext::instance().get_cluster().get_virtual_coordinate_from_logical_coordinates(
+            logical_core_, GetCoreType());
     }
     ChipId GetDeviceId() const { return device_id_; }  // Since this->device may not exist yet
     int GetNodeId() const { return node_id_; }
@@ -188,10 +151,6 @@ public:
     int GetDownstreamPort(FDKernel* other) const { return GetPort(other, this->downstream_kernels_); }
     void AddDevice(tt::tt_metal::IDevice* device) { device_ = device; }
     void AddProgram(tt::tt_metal::Program* program) { program_ = program; }
-
-    tt::tt_fabric::ControlPlane& get_control_plane_ref() const;
-    const DispatchQueryManager& get_dispatch_query_manager_ref() const;
-    uint32_t get_max_num_eth_cores() const;
 
 protected:
     // Attributes for an EDM client to connect to the router
@@ -220,11 +179,11 @@ protected:
     }
 
     // Helper function to get upstream device in the tunnel from current device, not valid for mmio
-    static ChipId GetUpstreamDeviceId(const ContextDescriptor& descriptor, ChipId device_id);
+    static ChipId GetUpstreamDeviceId(ChipId device_id);
     // Helper function to get downstream device in the tunnel from current device
-    static ChipId GetDownstreamDeviceId(const ContextDescriptor& descriptor, ChipId device_id, int tunnel = -1);
+    static ChipId GetDownstreamDeviceId(ChipId device_id, int tunnel = -1);
     // Helper function to get the tunnel stop index of current device
-    static uint32_t GetTunnelStop(const ContextDescriptor& descriptor, ChipId device_id);
+    static uint32_t GetTunnelStop(ChipId device_id);
     // Create and populate semaphores for the EDM connection
     void create_edm_connection_sems(FDKernelEdmConnectionAttributes& attributes);
     IDevice* device_ = nullptr;  // Set at configuration time by AddDeviceAndProgram()
@@ -242,13 +201,6 @@ protected:
     std::vector<FDKernel*> downstream_kernels_;
 
     std::vector<uint32_t> runtime_args_;
-    const ContextDescriptor& descriptor_;
-    dispatch_core_manager& dispatch_core_manager_;
-    GetControlPlaneFn get_control_plane_;
-    GetDispatchQueryManagerFn get_dispatch_query_manager_;
-    GetMaxNumEthCoresFn get_max_num_eth_cores_;
-    GetReadsDispatchCoresFn get_reads_dispatch_cores_;
-    std::array<std::unique_ptr<DispatchMemMap>, static_cast<size_t>(CoreType::COUNT)> dispatch_mem_map_;
 };
 
 }  // namespace tt::tt_metal

--- a/tt_metal/impl/dispatch/kernel_config/prefetch.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/prefetch.cpp
@@ -24,7 +24,7 @@
 #include <tt-metalium/experimental/fabric/fabric_edm_types.hpp>
 #include <tt-metalium/experimental/fabric/fabric_types.hpp>
 #include "hal_types.hpp"
-#include "impl/context/context_descriptor.hpp"
+#include "impl/context/metal_context.hpp"
 #include "impl/debug/inspector/inspector.hpp"
 #include <umd/device/types/core_coordinates.hpp>
 #include <umd/device/types/xy_pair.hpp>
@@ -42,39 +42,24 @@ PrefetchKernel::PrefetchKernel(
     uint8_t cq_id,
     noc_selection_t noc_selection,
     bool h_variant,
-    bool d_variant,
-    const ContextDescriptor& descriptor,
-    dispatch_core_manager& dispatch_core_manager,
-    const GetControlPlaneFn& get_control_plane,
-    const GetDispatchQueryManagerFn& get_dispatch_query_manager,
-    const GetMaxNumEthCoresFn& get_max_num_eth_cores,
-    const GetReadsDispatchCoresFn& get_reads_dispatch_cores) :
-    FDKernel(
-        node_id,
-        device_id,
-        servicing_device_id,
-        cq_id,
-        noc_selection,
-        descriptor,
-        dispatch_core_manager,
-        get_control_plane,
-        get_dispatch_query_manager,
-        get_max_num_eth_cores,
-        get_reads_dispatch_cores) {
+    bool d_variant) :
+    FDKernel(node_id, device_id, servicing_device_id, cq_id, noc_selection) {
+    auto& core_manager = tt::tt_metal::MetalContext::instance().get_dispatch_core_manager();  // Not thread safe
     static_config_.is_h_variant = h_variant;
     static_config_.is_d_variant = d_variant;
-    uint16_t channel = descriptor.cluster().get_assigned_channel_for_device(device_id);
+    uint16_t channel = tt::tt_metal::MetalContext::instance().get_cluster().get_assigned_channel_for_device(device_id);
 
     DispatchWorkerType type = PREFETCH;
     if (h_variant && d_variant) {
-        this->logical_core_ = dispatch_core_manager.prefetcher_core(device_id, channel, cq_id);
+        this->logical_core_ = core_manager.prefetcher_core(device_id, channel, cq_id);
         type = PREFETCH_HD;
     } else if (h_variant) {
-        channel = descriptor_.cluster().get_assigned_channel_for_device(servicing_device_id);
-        this->logical_core_ = dispatch_core_manager.prefetcher_core(servicing_device_id, channel, cq_id);
+        channel =
+            tt::tt_metal::MetalContext::instance().get_cluster().get_assigned_channel_for_device(servicing_device_id);
+        this->logical_core_ = core_manager.prefetcher_core(servicing_device_id, channel, cq_id);
         type = PREFETCH_H;
     } else if (d_variant) {
-        this->logical_core_ = dispatch_core_manager.prefetcher_d_core(device_id, channel, cq_id);
+        this->logical_core_ = core_manager.prefetcher_d_core(device_id, channel, cq_id);
         type = PREFETCH_D;
     }
     this->kernel_type_ = FDKernelType::DISPATCH;
@@ -84,9 +69,10 @@ PrefetchKernel::PrefetchKernel(
 }
 
 void PrefetchKernel::GenerateStaticConfigs() {
-    uint16_t channel = descriptor_.cluster().get_assigned_channel_for_device(device_->id());
+    uint16_t channel =
+        tt::tt_metal::MetalContext::instance().get_cluster().get_assigned_channel_for_device(device_->id());
     uint8_t cq_id_ = this->cq_id_;
-    const auto& my_dispatch_constants = *dispatch_mem_map_[enchantum::to_underlying(GetCoreType())].get();
+    const auto& my_dispatch_constants = MetalContext::instance().dispatch_mem_map(GetCoreType());
     auto l1_size = my_dispatch_constants.get_prefetcher_l1_size();
     // May be zero if not using dispatch on fabric
     static_config_.fabric_header_rb_base =
@@ -96,7 +82,8 @@ void PrefetchKernel::GenerateStaticConfigs() {
         my_dispatch_constants.get_device_command_queue_addr(CommandQueueDeviceAddrType::FABRIC_SYNC_STATUS);
 
     if (static_config_.is_h_variant.value() && this->static_config_.is_d_variant.value()) {
-        bool is_mock = descriptor_.cluster().get_target_device_type() == tt::TargetDevice::Mock;
+        bool is_mock =
+            tt::tt_metal::MetalContext::instance().get_cluster().get_target_device_type() == tt::TargetDevice::Mock;
         uint32_t cq_start = my_dispatch_constants.get_host_command_queue_addr(CommandQueueHostAddrType::UNRESERVED);
         uint32_t cq_size = is_mock ? 0x10000 : device_->sysmem_manager().get_cq_size();
         uint32_t command_queue_start_addr = get_absolute_cq_offset(channel, cq_id_, cq_size);
@@ -133,7 +120,7 @@ void PrefetchKernel::GenerateStaticConfigs() {
         static_config_.cmddat_q_blocks = DispatchSettings::PREFETCH_D_BUFFER_BLOCKS;
 
         uint32_t dispatch_s_buffer_base = 0xff;
-        if (get_dispatch_query_manager_ref().dispatch_s_enabled()) {
+        if (MetalContext::instance().get_dispatch_query_manager().dispatch_s_enabled()) {
             uint32_t dispatch_buffer_base = my_dispatch_constants.dispatch_buffer_base();
             if (GetCoreType() == CoreType::WORKER) {
                 // dispatch_s is on the same Tensix core as dispatch_d. Shared resources. Offset CB start idx.
@@ -152,7 +139,8 @@ void PrefetchKernel::GenerateStaticConfigs() {
         static_config_.dispatch_s_cb_log_page_size = DispatchSettings::DISPATCH_S_BUFFER_LOG_PAGE_SIZE;
     } else if (static_config_.is_h_variant.value()) {
         // PREFETCH_H services a remote chip, and so has a different channel
-        channel = descriptor_.cluster().get_assigned_channel_for_device(servicing_device_id_);
+        channel =
+            tt::tt_metal::MetalContext::instance().get_cluster().get_assigned_channel_for_device(servicing_device_id_);
         uint32_t cq_start = my_dispatch_constants.get_host_command_queue_addr(CommandQueueHostAddrType::UNRESERVED);
         uint32_t cq_size = device_->sysmem_manager().get_cq_size();
         uint32_t command_queue_start_addr = get_absolute_cq_offset(channel, cq_id_, cq_size);
@@ -208,7 +196,7 @@ void PrefetchKernel::GenerateStaticConfigs() {
         static_config_.cmddat_q_base = my_dispatch_constants.dispatch_buffer_base();
         static_config_.cmddat_q_size = my_dispatch_constants.prefetch_d_buffer_size();
 
-        uint32_t pcie_alignment = descriptor_.hal().get_alignment(HalMemType::HOST);
+        uint32_t pcie_alignment = MetalContext::instance().hal().get_alignment(HalMemType::HOST);
         static_config_.scratch_db_base = (my_dispatch_constants.dispatch_buffer_base() +
                                           my_dispatch_constants.prefetch_d_buffer_size() + pcie_alignment - 1) &
                                          (~(pcie_alignment - 1));
@@ -240,9 +228,10 @@ void PrefetchKernel::GenerateStaticConfigs() {
         static_config_.my_dispatch_s_cb_sem_id = tt::tt_metal::CreateSemaphore(
             *program_, logical_core_, my_dispatch_constants.dispatch_s_buffer_pages(), GetCoreType());
         static_config_.dispatch_s_buffer_size = my_dispatch_constants.dispatch_s_buffer_size();
-        static_config_.dispatch_s_cb_log_page_size = get_dispatch_query_manager_ref().dispatch_s_enabled()
-                                                         ? DispatchSettings::DISPATCH_S_BUFFER_LOG_PAGE_SIZE
-                                                         : DispatchSettings::DISPATCH_BUFFER_LOG_PAGE_SIZE;
+        static_config_.dispatch_s_cb_log_page_size =
+            MetalContext::instance().get_dispatch_query_manager().dispatch_s_enabled()
+                ? DispatchSettings::DISPATCH_S_BUFFER_LOG_PAGE_SIZE
+                : DispatchSettings::DISPATCH_BUFFER_LOG_PAGE_SIZE;
     } else {
         TT_FATAL(false, "PrefetchKernel must be one of (or both) H and D variants");
     }
@@ -257,7 +246,8 @@ void PrefetchKernel::GenerateStaticConfigs() {
 
     if (!is_hd()) {
         create_edm_connection_sems(edm_connection_attributes_);
-        static_config_.is_2d_fabric = tt::tt_fabric::is_2d_fabric_config(get_control_plane_ref().get_fabric_config());
+        const auto& fabric_context = tt::tt_metal::MetalContext::instance().get_control_plane().get_fabric_context();
+        static_config_.is_2d_fabric = fabric_context.is_2D_routing_enabled();
     } else {
         static_config_.is_2d_fabric = false;
     }
@@ -271,7 +261,7 @@ void PrefetchKernel::GenerateDependentConfigs() {
         dependent_config_.upstream_cb_sem_id = 0;  // Used in prefetch_d only
 
         // Downstream
-        if (get_dispatch_query_manager_ref().dispatch_s_enabled()) {
+        if (MetalContext::instance().get_dispatch_query_manager().dispatch_s_enabled()) {
             TT_ASSERT(downstream_kernels_.size() == 2);
         } else {
             TT_ASSERT(downstream_kernels_.size() == 1);
@@ -300,7 +290,7 @@ void PrefetchKernel::GenerateDependentConfigs() {
                 TT_FATAL(false, "Unrecognized downstream kernel.");
             }
         }
-        if (get_dispatch_query_manager_ref().dispatch_s_enabled()) {
+        if (MetalContext::instance().get_dispatch_query_manager().dispatch_s_enabled()) {
             // Should have found dispatch_s in the downstream kernels
             TT_ASSERT(found_dispatch && found_dispatch_s);
         } else {
@@ -338,10 +328,9 @@ void PrefetchKernel::GenerateDependentConfigs() {
                     DispatchSettings::DISPATCH_BUFFER_LOG_PAGE_SIZE);
                 dependent_config_.downstream_cb_log_page_size = DispatchSettings::PREFETCH_D_BUFFER_LOG_PAGE_SIZE;
                 dependent_config_.downstream_cb_pages = prefetch_d->GetStaticConfig().cmddat_q_pages;
-                dependent_config_.num_hops =
-                    tt::tt_metal::get_num_hops(descriptor_, device_id_, prefetch_d->GetDeviceId());
+                dependent_config_.num_hops = tt::tt_metal::get_num_hops(device_id_, prefetch_d->GetDeviceId());
                 assemble_2d_fabric_packet_header_args(
-                    this->dependent_config_, GetDeviceId(), prefetch_d->GetDeviceId(), get_control_plane_ref());
+                    this->dependent_config_, GetDeviceId(), prefetch_d->GetDeviceId());
             } else if (auto* fabric_mux = dynamic_cast<tt::tt_metal::RelayMux*>(ds_kernel)) {
                 constexpr tt::tt_fabric::FabricMuxChannelType ch_type =
                     tt::tt_fabric::FabricMuxChannelType::FULL_SIZE_CHANNEL;
@@ -360,9 +349,8 @@ void PrefetchKernel::GenerateDependentConfigs() {
         if (auto* prefetch_h = dynamic_cast<PrefetchKernel*>(upstream_kernels_[0])) {
             dependent_config_.upstream_logical_core = prefetch_h->GetLogicalCore();
             dependent_config_.upstream_cb_sem_id = prefetch_h->GetStaticConfig().my_downstream_cb_sem_id;
-            dependent_config_.num_hops = tt::tt_metal::get_num_hops(descriptor_, prefetch_h->GetDeviceId(), device_id_);
-            assemble_2d_fabric_packet_header_args(
-                this->dependent_config_, GetDeviceId(), prefetch_h->GetDeviceId(), get_control_plane_ref());
+            dependent_config_.num_hops = tt::tt_metal::get_num_hops(prefetch_h->GetDeviceId(), device_id_);
+            assemble_2d_fabric_packet_header_args(this->dependent_config_, GetDeviceId(), prefetch_h->GetDeviceId());
         } else {
             TT_FATAL(false, "Path not implemented");
         }
@@ -403,7 +391,7 @@ void PrefetchKernel::GenerateDependentConfigs() {
         }
         // No check needed for found relay mux. A direct connection to PREFETCH_H on the same core
         // is possible (used in test prefetcher) and does not need tunneling.
-        if (get_dispatch_query_manager_ref().dispatch_s_enabled()) {
+        if (MetalContext::instance().get_dispatch_query_manager().dispatch_s_enabled()) {
             // Should have found dispatch_s in the downstream kernels
             TT_ASSERT(found_dispatch && found_dispatch_s);
         } else {
@@ -411,7 +399,7 @@ void PrefetchKernel::GenerateDependentConfigs() {
             TT_ASSERT(found_dispatch && !found_dispatch_s);
             dependent_config_.downstream_s_logical_core = UNUSED_LOGICAL_CORE;
             dependent_config_.downstream_dispatch_s_cb_sem_id =
-                get_dispatch_query_manager_ref().dispatch_s_enabled()
+                MetalContext::instance().get_dispatch_query_manager().dispatch_s_enabled()
                     ? UNUSED_SEM_ID
                     : 1;  // Just to make it match previous implementation
         }
@@ -434,13 +422,12 @@ void PrefetchKernel::InitializeRuntimeArgsValues() {
 }
 
 void PrefetchKernel::CreateKernel() {
-    auto my_virtual_core = get_virtual_core_coord(descriptor_, logical_core_, GetCoreType());
-    auto upstream_virtual_core =
-        get_virtual_core_coord(descriptor_, dependent_config_.upstream_logical_core.value(), GetCoreType());
+    auto my_virtual_core = get_virtual_core_coord(logical_core_, GetCoreType());
+    auto upstream_virtual_core = get_virtual_core_coord(dependent_config_.upstream_logical_core.value(), GetCoreType());
     auto downstream_virtual_core =
-        get_virtual_core_coord(descriptor_, dependent_config_.downstream_logical_core.value(), GetCoreType());
+        get_virtual_core_coord(dependent_config_.downstream_logical_core.value(), GetCoreType());
     auto downstream_s_virtual_core =
-        get_virtual_core_coord(descriptor_, dependent_config_.downstream_s_logical_core.value(), GetCoreType());
+        get_virtual_core_coord(dependent_config_.downstream_s_logical_core.value(), GetCoreType());
 
     auto my_virtual_noc_coords = device_->virtual_noc0_coordinate(noc_selection_.non_dispatch_noc, my_virtual_core);
     auto upstream_virtual_noc_coords =
@@ -551,7 +538,8 @@ void PrefetchKernel::CreateKernel() {
         true,
         // TEMP: Disable function inlining on Prefetcher when watcher is enabled but no_inline is not specified to
         // respect code space
-        descriptor_.rtoptions().get_watcher_enabled() && (not descriptor_.rtoptions().get_watcher_noinline()),
+        tt::tt_metal::MetalContext::instance().rtoptions().get_watcher_enabled() &&
+            (not tt::tt_metal::MetalContext::instance().rtoptions().get_watcher_noinline()),
         optimization_level);
 }
 
@@ -559,8 +547,9 @@ void PrefetchKernel::ConfigureCore() {
     // Only H-type prefetchers need L1 configuration
     if (static_config_.is_h_variant.value()) {
         // Initialize the FetchQ
-        uint16_t channel = descriptor_.cluster().get_assigned_channel_for_device(device_->id());
-        const auto& my_dispatch_constants = *dispatch_mem_map_[enchantum::to_underlying(GetCoreType())].get();
+        uint16_t channel =
+            tt::tt_metal::MetalContext::instance().get_cluster().get_assigned_channel_for_device(device_->id());
+        const auto& my_dispatch_constants = MetalContext::instance().dispatch_mem_map(GetCoreType());
         uint32_t cq_start = my_dispatch_constants.get_host_command_queue_addr(CommandQueueHostAddrType::UNRESERVED);
         uint32_t cq_size = device_->sysmem_manager().get_cq_size();
         std::vector<uint32_t> prefetch_q(my_dispatch_constants.prefetch_q_entries(), 0);

--- a/tt_metal/impl/dispatch/kernel_config/prefetch.hpp
+++ b/tt_metal/impl/dispatch/kernel_config/prefetch.hpp
@@ -10,7 +10,7 @@
 #include "core_coord.hpp"
 #include "fd_kernel.hpp"
 #include <tt-metalium/experimental/fabric/mesh_graph.hpp>
-#include "impl/context/context_descriptor.hpp"
+#include "impl/context/metal_context.hpp"
 #include <umd/device/types/xy_pair.hpp>
 #include <umd/device/types/cluster_descriptor_types.hpp>
 #include "dispatch/kernel_config/relay_mux.hpp"
@@ -97,13 +97,7 @@ public:
         uint8_t cq_id,
         noc_selection_t noc_selection,
         bool h_variant,
-        bool d_variant,
-        const ContextDescriptor& descriptor,
-        dispatch_core_manager& dispatch_core_manager,
-        const GetControlPlaneFn& get_control_plane = {},
-        const GetDispatchQueryManagerFn& get_dispatch_query_manager = {},
-        const GetMaxNumEthCoresFn& get_max_num_eth_cores = {},
-        const GetReadsDispatchCoresFn& get_reads_dispatch_cores = {});
+        bool d_variant);
 
     void CreateKernel() override;
 

--- a/tt_metal/impl/dispatch/kernel_config/relay_mux.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/relay_mux.cpp
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "relay_mux.hpp"
-#include "context/context_descriptor.hpp"
+#include "context/metal_context.hpp"
 #include "dispatch/kernel_config/fd_kernel.hpp"
 #include "dispatch_core_common.hpp"
 #include "fabric/fabric_host_utils.hpp"
@@ -24,21 +24,23 @@ void RelayMux::GenerateStaticConfigs() {
     uint32_t l1_size = 0;
 
     if (GetCoreType() == CoreType::WORKER) {
-        l1_base = descriptor_.hal().get_dev_addr(
+        l1_base = tt::tt_metal::MetalContext::instance().hal().get_dev_addr(
             tt::tt_metal::HalProgrammableCoreType::TENSIX, tt::tt_metal::HalL1MemAddrType::DEFAULT_UNRESERVED);
-        l1_size = descriptor_.hal().get_dev_size(
+        l1_size = tt::tt_metal::MetalContext::instance().hal().get_dev_size(
             tt::tt_metal::HalProgrammableCoreType::TENSIX, tt::tt_metal::HalL1MemAddrType::BASE);
     } else {
-        l1_base = descriptor_.hal().get_dev_addr(
+        l1_base = MetalContext::instance().hal().get_dev_addr(
             tt::tt_metal::HalProgrammableCoreType::IDLE_ETH, tt::tt_metal::HalL1MemAddrType::UNRESERVED);
-        l1_size = descriptor_.hal().get_dev_size(
+        l1_size = MetalContext::instance().hal().get_dev_size(
             tt::tt_metal::HalProgrammableCoreType::IDLE_ETH, tt::tt_metal::HalL1MemAddrType::BASE);
     }
     static_config_.buffer_base_address =
-        tt::align(l1_base, descriptor_.hal().get_alignment(tt::tt_metal::HalMemType::L1));
+        tt::align(l1_base, tt::tt_metal::MetalContext::instance().hal().get_alignment(tt::tt_metal::HalMemType::L1));
 
-    const uint16_t channel = descriptor_.cluster().get_assigned_channel_for_device(device_->id());
-    logical_core_ = dispatch_core_manager_.fabric_mux_core(device_->id(), channel, this->cq_id_, tunnel_id_);
+    const uint16_t channel =
+        tt::tt_metal::MetalContext::instance().get_cluster().get_assigned_channel_for_device(device_->id());
+    logical_core_ = MetalContext::instance().get_dispatch_core_manager().fabric_mux_core(
+        device_->id(), channel, this->cq_id_, tunnel_id_);
 
     // Count number of value kernels that need the channels
     const auto kernels_requiring_full_size_channel =
@@ -54,7 +56,7 @@ void RelayMux::GenerateStaticConfigs() {
     static_config_.num_full_size_channels = kernels_requiring_full_size_channel;
     static_config_.num_header_only_channels = kernels_requiring_header_only_channel;
 
-    const auto& control_plane = get_control_plane_ref();
+    const auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
     const auto& fabric_context = control_plane.get_fabric_context();
 
     // Buffer size for the Mux must matching downstream fabric router size
@@ -88,20 +90,15 @@ void RelayMux::GenerateStaticConfigs() {
     TT_FATAL(!(d2h_ && device_->is_mmio_capable()), "There is no D2H (return path) for MMIO devices");
     if (d2h_) {
         // Get the device which is upstream
-        destination_device_id = tt::tt_metal::FDKernel::GetUpstreamDeviceId(descriptor_, device_id_);
+        destination_device_id = tt::tt_metal::FDKernel::GetUpstreamDeviceId(device_id_);
     } else {
         // Get the device which is downstream on the specified tunnel
-        destination_device_id = tt::tt_metal::FDKernel::GetDownstreamDeviceId(descriptor_, device_id_, tunnel_id_);
+        destination_device_id = tt::tt_metal::FDKernel::GetDownstreamDeviceId(device_id_, tunnel_id_);
     }
     const auto src_fabric_node_id = tt::tt_fabric::get_fabric_node_id_from_physical_chip_id(device_id_);
     const auto dst_fabric_node_id = tt::tt_fabric::get_fabric_node_id_from_physical_chip_id(destination_device_id);
 
-    auto link_index = get_dispatch_link_index(
-        get_control_plane_ref(),
-        descriptor_.cluster().is_galaxy_cluster(),
-        src_fabric_node_id,
-        dst_fabric_node_id,
-        device_);
+    auto link_index = get_dispatch_link_index(src_fabric_node_id, dst_fabric_node_id, device_);
     log_debug(
         tt::LogMetal,
         "RelayMux Device:{}, HeaderCh:{}, FullCh:{}, FullB:{}, Logical:{}, Virtual: {}, D2H: {} Channel Size: {}, Num "
@@ -171,8 +168,9 @@ void assemble_fabric_mux_client_config_args(
         fabric_mux->GetMuxKernelConfig()->get_channel_credits_stream_id(ch_type, ch_index);
 }
 
-int get_num_hops(const ContextDescriptor& descriptor, ChipId mmio_dev_id, ChipId downstream_dev_id) {
-    const auto dev_mmio_device_id = descriptor.cluster().get_associated_mmio_device(mmio_dev_id);
+int get_num_hops(ChipId mmio_dev_id, ChipId downstream_dev_id) {
+    const auto dev_mmio_device_id =
+        tt::tt_metal::MetalContext::instance().get_cluster().get_associated_mmio_device(mmio_dev_id);
 
     if (dev_mmio_device_id != mmio_dev_id) {
         TT_THROW(
@@ -181,7 +179,8 @@ int get_num_hops(const ContextDescriptor& descriptor, ChipId mmio_dev_id, ChipId
             dev_mmio_device_id);
     }
 
-    auto tunnels_from_mmio = descriptor.cluster().get_tunnels_from_mmio_device(mmio_dev_id);
+    auto tunnels_from_mmio =
+        tt::tt_metal::MetalContext::instance().get_cluster().get_tunnels_from_mmio_device(mmio_dev_id);
 
     constexpr size_t k_MaxTunnelSize = 5;  // 4 remote + 1 mmio
     for (const auto& tunnel : tunnels_from_mmio) {
@@ -202,12 +201,10 @@ int get_num_hops(const ContextDescriptor& descriptor, ChipId mmio_dev_id, ChipId
 }
 
 uint32_t RelayMux::get_dispatch_link_index(
-    const tt_fabric::ControlPlane& control_plane,
-    bool is_galaxy_cluster,
-    tt::tt_fabric::FabricNodeId src_fabric_node_id,
-    tt::tt_fabric::FabricNodeId dst_fabric_node_id,
-    IDevice* device) {
-    if (is_galaxy_cluster && device->is_mmio_capable()) {
+    tt::tt_fabric::FabricNodeId src_fabric_node_id, tt::tt_fabric::FabricNodeId dst_fabric_node_id, IDevice* device) {
+    const auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
+
+    if (tt::tt_metal::MetalContext::instance().get_cluster().is_galaxy_cluster() && device->is_mmio_capable()) {
         const auto forwarding_direction =
             control_plane.get_forwarding_direction(src_fabric_node_id, dst_fabric_node_id);
         TT_FATAL(

--- a/tt_metal/impl/dispatch/kernel_config/relay_mux.hpp
+++ b/tt_metal/impl/dispatch/kernel_config/relay_mux.hpp
@@ -8,7 +8,6 @@
 #include <optional>
 #include "fabric/fabric_edm_packet_header.hpp"
 #include "fd_kernel.hpp"
-#include "impl/context/context_descriptor.hpp"
 #include "tt_metal/impl/dispatch/system_memory_manager.hpp"
 #include <tt-metalium/experimental/fabric/control_plane.hpp>
 #include <tt-metalium/experimental/fabric/fabric.hpp>
@@ -72,25 +71,8 @@ public:
         uint8_t cq_id,
         noc_selection_t noc_selection,
         bool d2h,
-        int tunnel_index,
-        const ContextDescriptor& descriptor,
-        dispatch_core_manager& dispatch_core_manager,
-        const GetControlPlaneFn& get_control_plane,
-        const GetReadsDispatchCoresFn& get_reads_dispatch_cores) :
-        FDKernel(
-            node_id,
-            device_id,
-            servicing_device_id,
-            cq_id,
-            noc_selection,
-            descriptor,
-            dispatch_core_manager,
-            get_control_plane,
-            {},
-            {},
-            get_reads_dispatch_cores),
-        d2h_{d2h},
-        tunnel_id_{tunnel_index} {
+        int tunnel_index) :
+        FDKernel(node_id, device_id, servicing_device_id, cq_id, noc_selection), d2h_{d2h}, tunnel_id_{tunnel_index} {
         TT_FATAL(tunnel_id_ >= 0, "Relay Mux Tunnel Index must be >= 0");
         kernel_type_ = FDKernelType::ROUTING;
     }
@@ -121,8 +103,6 @@ public:
 
     // Get the link index used by dispatch for coordination with fabric tensix
     static uint32_t get_dispatch_link_index(
-        const tt_fabric::ControlPlane& control_plane,
-        bool is_galaxy_cluster,
         tt::tt_fabric::FabricNodeId src_fabric_node_id,
         tt::tt_fabric::FabricNodeId dst_fabric_node_id,
         IDevice* device);
@@ -137,16 +117,12 @@ void assemble_fabric_mux_client_config_args(
 
 // Helper function to calculate number of hops from a mmio device to downstream device
 // The two devices must be along the same tunnel.
-int get_num_hops(const ContextDescriptor& descriptor, ChipId mmio_dev_id, ChipId downstream_dev_id);
+int get_num_hops(ChipId mmio_dev_id, ChipId downstream_dev_id);
 
-// Helper function to assemble args specific to the 2D fabric header (takes control plane directly; no
-// ContextDescriptor).
+// Helper function to assemble args specific to the 2D fabric header
 template <typename Configuration>
-void assemble_2d_fabric_packet_header_args(
-    Configuration& config,
-    int my_device_id,
-    int destination_device_id,
-    const tt::tt_fabric::ControlPlane& control_plane) {
+void assemble_2d_fabric_packet_header_args(Configuration& config, int my_device_id, int destination_device_id) {
+    const auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
     const auto& src_fabric_node_id = control_plane.get_fabric_node_id_from_physical_chip_id(my_device_id);
     const auto& dst_fabric_node_id = control_plane.get_fabric_node_id_from_physical_chip_id(destination_device_id);
     const auto& forwarding_direction = control_plane.get_forwarding_direction(src_fabric_node_id, dst_fabric_node_id);

--- a/tt_metal/impl/dispatch/topology.cpp
+++ b/tt_metal/impl/dispatch/topology.cpp
@@ -4,6 +4,7 @@
 
 #include "topology.hpp"
 
+#include "context/metal_context.hpp"
 #include "device/device_manager.hpp"
 #include <host_api.hpp>
 #include <enchantum/enchantum.hpp>
@@ -391,21 +392,8 @@ static const std::vector<DispatchKernelNode> galaxy_nine_chip_arch_2cq_fabric = 
 };
 // clang-format on
 
-DispatchTopology::DispatchTopology(
-    const ContextDescriptor& descriptor,
-    dispatch_core_manager& dispatch_core_manager,
-    DeviceManager* device_manager,
-    const GetControlPlaneFn& get_control_plane,
-    const GetDispatchQueryManagerFn& get_dispatch_query_manager,
-    const GetMaxNumEthCoresFn& get_max_num_eth_cores,
-    const GetReadsDispatchCoresFn& get_reads_dispatch_cores) :
-    descriptor_(descriptor),
-    dispatch_core_manager_(dispatch_core_manager),
-    device_manager_(device_manager),
-    get_control_plane_(get_control_plane),
-    get_dispatch_query_manager_(get_dispatch_query_manager),
-    get_max_num_eth_cores_(get_max_num_eth_cores),
-    get_reads_dispatch_cores_(get_reads_dispatch_cores) {
+DispatchTopology::DispatchTopology(const ContextDescriptor& descriptor, dispatch_core_manager& dispatch_core_manager) :
+    descriptor_(descriptor), dispatch_core_manager_(dispatch_core_manager) {
     command_queue_compile_group_ = std::make_unique<detail::ProgramCompileGroup>();
     dispatch_mem_map_[enchantum::to_underlying(CoreType::WORKER)] =
         std::make_unique<DispatchMemMap>(CoreType::WORKER, descriptor_.num_cqs());
@@ -444,8 +432,9 @@ std::vector<DispatchKernelNode> DispatchTopology::generate_nodes(
     auto populate_single_device = [&]() {
         if (num_hw_cqs == 1) {
             return single_chip_arch_1cq;
-        }
-        if (this->get_dispatch_query_manager_().dispatch_s_enabled()) {
+        }  // TODO: determine whether dispatch_s is inserted at this level, instead of inside
+           // Device::dispatch_s_enabled().
+        if (this->dispatch_core_manager_.get_dispatch_core_type() == CoreType::WORKER) {
             return single_chip_arch_2cq_dispatch_s;
         }
         return single_chip_arch_2cq;
@@ -594,13 +583,7 @@ void DispatchTopology::populate_fd_kernels(const std::vector<DispatchKernelNode>
             node.cq_id,
             node.noc_selection,
             node.kernel_type,
-            descriptor_,
-            dispatch_core_manager_,
-            node.tunnel_index,
-            get_control_plane_,
-            get_dispatch_query_manager_,
-            get_max_num_eth_cores_,
-            get_reads_dispatch_cores_));
+            node.tunnel_index));
         if (descriptor_.cluster().get_associated_mmio_device(node.device_id) == node.device_id) {
             mmio_device_ids.insert(node.device_id);
         }
@@ -755,14 +738,14 @@ void DispatchTopology::configure_dispatch_cores(Device* device) {
     std::vector<uint32_t> zero = {0x0};
 
     // Need to set up for all devices serviced by an mmio chip
-    TT_ASSERT(device_manager_ != nullptr, "DeviceManager required for configure_dispatch_cores");
     if (device->is_mmio_capable()) {
         for (ChipId serviced_device_id : descriptor_.cluster().get_devices_controlled_by_mmio_device(device->id())) {
             uint16_t channel = descriptor_.cluster().get_assigned_channel_for_device(serviced_device_id);
             for (uint8_t cq_id = 0; cq_id < device->num_hw_cqs(); cq_id++) {
                 tt_cxy_pair completion_q_writer_location =
                     this->dispatch_core_manager_.completion_queue_writer_core(serviced_device_id, channel, cq_id);
-                IDevice* mmio_device = device_manager_->get_active_device(completion_q_writer_location.chip);
+                IDevice* mmio_device =
+                    MetalContext::instance().device_manager()->get_active_device(completion_q_writer_location.chip);
                 uint32_t completion_q_wr_ptr =
                     my_dispatch_constants.get_device_command_queue_addr(CommandQueueDeviceAddrType::COMPLETION_Q_WR);
                 uint32_t completion_q_rd_ptr =

--- a/tt_metal/impl/dispatch/topology.cpp
+++ b/tt_metal/impl/dispatch/topology.cpp
@@ -4,7 +4,6 @@
 
 #include "topology.hpp"
 
-#include "context/metal_context.hpp"
 #include "device/device_manager.hpp"
 #include <host_api.hpp>
 #include <enchantum/enchantum.hpp>
@@ -23,6 +22,7 @@
 #include "core_coord.hpp"
 #include "data_types.hpp"
 #include "device.hpp"
+#include "context/metal_context.hpp"
 #include "dispatch_core_common.hpp"
 #include "kernel_config/fd_kernel.hpp"
 #include "program/program_impl.hpp"
@@ -392,23 +392,19 @@ static const std::vector<DispatchKernelNode> galaxy_nine_chip_arch_2cq_fabric = 
 };
 // clang-format on
 
-DispatchTopology::DispatchTopology(const ContextDescriptor& descriptor, dispatch_core_manager& dispatch_core_manager) :
-    descriptor_(descriptor), dispatch_core_manager_(dispatch_core_manager) {
-    command_queue_compile_group_ = std::make_unique<detail::ProgramCompileGroup>();
-    dispatch_mem_map_[enchantum::to_underlying(CoreType::WORKER)] =
-        std::make_unique<DispatchMemMap>(CoreType::WORKER, descriptor_.num_cqs());
-    dispatch_mem_map_[enchantum::to_underlying(CoreType::ETH)] =
-        std::make_unique<DispatchMemMap>(CoreType::ETH, descriptor_.num_cqs());
-}
+// TODO: Move into MetalContext or DeviceManager.
+std::vector<FDKernel*> node_id_to_kernel;
+detail::ProgramCompileGroup command_queue_compile_group;
+std::unordered_map<ChipId, std::unordered_set<CoreCoord>> dispatch_cores;
+std::unordered_map<ChipId, std::unordered_set<CoreCoord>> routing_cores;
+std::unordered_map<ChipId, std::unordered_set<CoreCoord>> empty_cores;
+std::unordered_map<ChipId, std::unordered_set<TerminationInfo>> termination_info;
 
-DispatchTopology::~DispatchTopology() { reset(); }
-
-// Helper to automatically generate dispatch nodes given devices + num hw CQs + detection of card type.
-std::vector<DispatchKernelNode> DispatchTopology::generate_nodes(
-    const std::set<ChipId>& device_ids, uint32_t num_hw_cqs) const {
+// Helper function to automatically generate dispatch nodes given devices + num hw CQs + detection of card type.
+std::vector<DispatchKernelNode> generate_nodes(const std::set<ChipId>& device_ids, uint32_t num_hw_cqs) {
     // Select/generate the right input table, depends on (1) board [detected from total # of devices], and (2) number
     // of active devices. TODO: read this out of YAML instead of the structs above?
-    uint32_t total_devices = descriptor_.cluster().number_of_devices();
+    uint32_t total_devices = MetalContext::instance().get_cluster().number_of_devices();
     TT_ASSERT(
         total_devices == 1 or total_devices == 2 or total_devices == 4 or total_devices == 8 or total_devices == 32 or
             total_devices == 36,
@@ -421,7 +417,7 @@ std::vector<DispatchKernelNode> DispatchTopology::generate_nodes(
     std::set<ChipId> mmio_devices;
     std::set<ChipId> remote_devices;
     for (auto id : device_ids) {
-        if (descriptor_.cluster().get_associated_mmio_device(id) == id) {
+        if (MetalContext::instance().get_cluster().get_associated_mmio_device(id) == id) {
             mmio_devices.insert(id);
         } else {
             remote_devices.insert(id);
@@ -434,7 +430,7 @@ std::vector<DispatchKernelNode> DispatchTopology::generate_nodes(
             return single_chip_arch_1cq;
         }  // TODO: determine whether dispatch_s is inserted at this level, instead of inside
            // Device::dispatch_s_enabled().
-        if (this->dispatch_core_manager_.get_dispatch_core_type() == CoreType::WORKER) {
+        if (MetalContext::instance().get_dispatch_core_manager().get_dispatch_core_type() == CoreType::WORKER) {
             return single_chip_arch_2cq_dispatch_s;
         }
         return single_chip_arch_2cq;
@@ -456,7 +452,7 @@ std::vector<DispatchKernelNode> DispatchTopology::generate_nodes(
     } else {
         // Need to handle N300/T3000 separately from TG/TGG since they have different templates/tunnel depths
         // If using fabric, upstream would have already initalized to the proper config for dispatch
-        if (descriptor_.cluster().is_galaxy_cluster()) {
+        if (MetalContext::instance().get_cluster().is_galaxy_cluster()) {
             // For Galaxy, we always init all remote devices associated with an mmio device.
             std::vector<DispatchKernelNode> nodes_for_one_mmio =
                 (num_hw_cqs == 1) ? galaxy_nine_chip_arch_1cq_fabric : galaxy_nine_chip_arch_2cq_fabric;
@@ -465,7 +461,8 @@ std::vector<DispatchKernelNode> DispatchTopology::generate_nodes(
                 // Need a mapping from templated device id (1-8) to actual device id (from the tunnel)
                 std::vector<ChipId> template_id_to_device_id;
                 template_id_to_device_id.push_back(mmio_device_id);
-                for (const auto& tunnel : descriptor_.cluster().get_tunnels_from_mmio_device(mmio_device_id)) {
+                for (const auto& tunnel :
+                     MetalContext::instance().get_cluster().get_tunnels_from_mmio_device(mmio_device_id)) {
                     TT_ASSERT(tunnel.size() == 5, "Galaxy expected 4-deep tunnels.");
                     for (auto remote_device_id : tunnel) {
                         if (remote_device_id != mmio_device_id) {
@@ -508,7 +505,7 @@ std::vector<DispatchKernelNode> DispatchTopology::generate_nodes(
                 ChipId remote_device_id{};
                 bool found_remote = false;
                 for (auto id : remote_devices) {
-                    if (descriptor_.cluster().get_associated_mmio_device(id) == mmio_device_id) {
+                    if (MetalContext::instance().get_cluster().get_associated_mmio_device(id) == mmio_device_id) {
                         remote_device_id = id;
                         found_remote = true;
                         break;
@@ -548,7 +545,10 @@ std::vector<DispatchKernelNode> DispatchTopology::generate_nodes(
     return nodes;
 }
 
-void DispatchTopology::populate_fd_kernels(const std::vector<Device*>& devices, uint32_t num_hw_cqs) {
+// Populate node_id_to_kernel and set up kernel objects. Do this once at the beginning since they (1) don't need a valid
+// Device until fields are populated, (2) need to be connected to kernel objects for devices that aren't created yet,
+// and (3) the table to choose depends on total number of devices, not know at Device creation.
+void populate_fd_kernels(const std::vector<IDevice*>& devices, uint32_t num_hw_cqs) {
     std::set<ChipId> device_ids;
     for (const auto& device : devices) {
         device_ids.insert(device->id());
@@ -556,27 +556,27 @@ void DispatchTopology::populate_fd_kernels(const std::vector<Device*>& devices, 
     populate_fd_kernels(generate_nodes(device_ids, num_hw_cqs));
 }
 
-void DispatchTopology::populate_fd_kernels(const std::set<ChipId>& device_ids, uint32_t num_hw_cqs) {
+void populate_fd_kernels(const std::set<ChipId>& device_ids, uint32_t num_hw_cqs) {
     populate_fd_kernels(generate_nodes(device_ids, num_hw_cqs));
 }
 
-void DispatchTopology::populate_fd_kernels(const std::vector<DispatchKernelNode>& nodes) {
+void populate_fd_kernels(const std::vector<DispatchKernelNode>& nodes) {
     // If we already had nodes from a previous run, clear them (since we could have a different # of devices or CQs).
-    if (!node_id_to_kernel_.empty()) {
-        for (auto& kernel : node_id_to_kernel_) {
+    if (!node_id_to_kernel.empty()) {
+        for (auto& kernel : node_id_to_kernel) {
             delete kernel;
         }
-        node_id_to_kernel_.clear();
-        command_queue_compile_group_->clear();
+        node_id_to_kernel.clear();
+        command_queue_compile_group.clear();
     }
 
     // Read the input table, create configs for each node + track mmio devices and number of cqs.
     std::unordered_set<ChipId> mmio_device_ids;
     std::unordered_set<uint8_t> hw_cq_ids;
-    node_id_to_kernel_.reserve(nodes.size());
+    node_id_to_kernel.reserve(nodes.size());
     for (const auto& node : nodes) {
-        TT_ASSERT(node_id_to_kernel_.size() == node.id);
-        node_id_to_kernel_.emplace_back(FDKernel::Generate(
+        TT_ASSERT(node_id_to_kernel.size() == node.id);
+        node_id_to_kernel.emplace_back(FDKernel::Generate(
             node.id,
             node.device_id,
             node.servicing_device_id,
@@ -584,7 +584,7 @@ void DispatchTopology::populate_fd_kernels(const std::vector<DispatchKernelNode>
             node.noc_selection,
             node.kernel_type,
             node.tunnel_index));
-        if (descriptor_.cluster().get_associated_mmio_device(node.device_id) == node.device_id) {
+        if (MetalContext::instance().get_cluster().get_associated_mmio_device(node.device_id) == node.device_id) {
             mmio_device_ids.insert(node.device_id);
         }
         hw_cq_ids.insert(node.cq_id);
@@ -596,21 +596,21 @@ void DispatchTopology::populate_fd_kernels(const std::vector<DispatchKernelNode>
         for (int idx = 0; idx < node.upstream_ids.size(); idx++) {
             if (node.upstream_ids[idx] >= 0) {
                 TT_ASSERT(
-                    node.upstream_ids[idx] < node_id_to_kernel_.size(),
+                    node.upstream_ids[idx] < node_id_to_kernel.size(),
                     "Upstream kernel id {} out of bounds (max = {})",
                     node.upstream_ids[idx],
-                    node_id_to_kernel_.size());
-                node_id_to_kernel_.at(node.id)->AddUpstreamKernel(node_id_to_kernel_.at(node.upstream_ids[idx]));
+                    node_id_to_kernel.size());
+                node_id_to_kernel.at(node.id)->AddUpstreamKernel(node_id_to_kernel.at(node.upstream_ids[idx]));
             }
         }
         for (int idx = 0; idx < node.downstream_ids.size(); idx++) {
             if (node.downstream_ids[idx] >= 0) {
                 TT_ASSERT(
-                    node.downstream_ids[idx] < node_id_to_kernel_.size(),
+                    node.downstream_ids[idx] < node_id_to_kernel.size(),
                     "Downstream kernel id {} out of bounds (max = {})",
                     node.downstream_ids[idx],
-                    node_id_to_kernel_.size());
-                node_id_to_kernel_.at(node.id)->AddDownstreamKernel(node_id_to_kernel_.at(node.downstream_ids[idx]));
+                    node_id_to_kernel.size());
+                node_id_to_kernel.at(node.id)->AddDownstreamKernel(node_id_to_kernel.at(node.downstream_ids[idx]));
             }
         }
     }
@@ -619,7 +619,7 @@ void DispatchTopology::populate_fd_kernels(const std::vector<DispatchKernelNode>
     std::map<ChipId, uint32_t> device_id_to_tunnel_stop;
     std::map<ChipId, std::vector<ChipId>> mmio_device_id_to_serviced_devices;
     for (auto mmio_device_id : mmio_device_ids) {
-        if (descriptor_.cluster().get_associated_mmio_device(mmio_device_id) != mmio_device_id) {
+        if (MetalContext::instance().get_cluster().get_associated_mmio_device(mmio_device_id) != mmio_device_id) {
             continue;
         }
 
@@ -628,7 +628,7 @@ void DispatchTopology::populate_fd_kernels(const std::vector<DispatchKernelNode>
             mmio_device_id_to_serviced_devices[mmio_device_id].push_back(mmio_device_id);
         }
         std::vector<ChipId> remote_devices;
-        for (auto tunnel : descriptor_.cluster().get_tunnels_from_mmio_device(mmio_device_id)) {
+        for (auto tunnel : MetalContext::instance().get_cluster().get_tunnels_from_mmio_device(mmio_device_id)) {
             for (uint32_t tunnel_stop = 0; tunnel_stop < tunnel.size(); tunnel_stop++) {
                 ChipId remote_device_id = tunnel[tunnel_stop];
                 device_id_to_tunnel_stop[remote_device_id] = tunnel_stop;
@@ -645,13 +645,13 @@ void DispatchTopology::populate_fd_kernels(const std::vector<DispatchKernelNode>
     }
 }
 
-void DispatchTopology::populate_cq_static_args(Device* device) {
+void populate_cq_static_args(IDevice* device) {
     TT_ASSERT(
-        !node_id_to_kernel_.empty(),
+        !node_id_to_kernel.empty(),
         "Tried to populate static args on nodes without the nodes populated (need to run populate_fd_kernels()");
     // First pass, add device/program to all kernels for this device and generate static configs.
     auto cq_program_ptr = std::make_unique<Program>();
-    for (auto* node_and_kernel : node_id_to_kernel_) {
+    for (auto* node_and_kernel : node_id_to_kernel) {
         // GetDeviceId() uses Id from topology as IDevice* is not present yet
         if (node_and_kernel->GetDeviceId() == device->id()) {
             node_and_kernel->AddDevice(device);
@@ -663,17 +663,18 @@ void DispatchTopology::populate_cq_static_args(Device* device) {
     }
 
     // Move program into the storage for later steps
-    command_queue_compile_group_->add_program(device, std::move(cq_program_ptr));
+    command_queue_compile_group.add_program(device, std::move(cq_program_ptr));
 }
 
-void DispatchTopology::create_cq_program(Device* device) {
+void create_cq_program(IDevice* device) {
     TT_FATAL(
-        command_queue_compile_group_->contains(device),
+        command_queue_compile_group.contains(device),
         "Tried to create and compile CQ program on device {} without static args populated (need to run "
         "populate_cq_static_args())",
         device->id());
+    empty_cores.clear();
     // Third pass, populate dependent configs, runtime configs, and create kernels for each node
-    for (auto* node_and_kernel : node_id_to_kernel_) {
+    for (auto* node_and_kernel : node_id_to_kernel) {
         if (node_and_kernel->GetDeviceId() == device->id()) {
             node_and_kernel->GenerateDependentConfigs();
             node_and_kernel->InitializeRuntimeArgsValues();
@@ -683,14 +684,14 @@ void DispatchTopology::create_cq_program(Device* device) {
     }
 
     // Register core coordinates for this device
-    for (auto* node_and_kernel : node_id_to_kernel_) {
+    for (auto* node_and_kernel : node_id_to_kernel) {
         if (node_and_kernel->GetDeviceId() != device->id()) {
             continue;
         }
 
         switch (node_and_kernel->GetKernelType()) {
-            case FDKernelType::DISPATCH: dispatch_cores_[device->id()].insert(node_and_kernel->GetVirtualCore()); break;
-            case FDKernelType::ROUTING: routing_cores_[device->id()].insert(node_and_kernel->GetVirtualCore()); break;
+            case FDKernelType::DISPATCH: dispatch_cores[device->id()].insert(node_and_kernel->GetVirtualCore()); break;
+            case FDKernelType::ROUTING: routing_cores[device->id()].insert(node_and_kernel->GetVirtualCore()); break;
             case FDKernelType::VIRTUAL:
                 // Not a real kernel
                 break;
@@ -705,45 +706,48 @@ void DispatchTopology::create_cq_program(Device* device) {
     }
 
     // Register termination info
-    for (auto* node_and_kernel : node_id_to_kernel_) {
+    for (auto* node_and_kernel : node_id_to_kernel) {
         if (node_and_kernel->GetDeviceId() != device->id()) {
             continue;
         }
 
         const auto& info = node_and_kernel->GetTerminationInfo();
         if (info.has_value()) {
-            termination_info_[device->id()].insert(info.value());
+            termination_info[device->id()].insert(info.value());
         }
     }
 }
 
-void DispatchTopology::compile_cq_programs() {
-    command_queue_compile_group_->compile_all(/*force_slow_dispatch=*/true);
+void compile_cq_programs() {
+    command_queue_compile_group.compile_all(/*force_slow_dispatch=*/true);
 
     // Write runtime args to device
-    command_queue_compile_group_->write_runtime_args(/*force_slow_dispatch=*/true);
+    command_queue_compile_group.write_runtime_args(/*force_slow_dispatch=*/true);
 }
 
-std::unique_ptr<Program> DispatchTopology::get_compiled_cq_program(Device* device) {
-    return command_queue_compile_group_->remove_program(device);
+std::unique_ptr<Program> get_compiled_cq_program(IDevice* device) {
+    return command_queue_compile_group.remove_program(device);
 }
 
-void DispatchTopology::configure_dispatch_cores(Device* device) {
+void configure_dispatch_cores(IDevice* device) {
     // Set up completion_queue_writer core. This doesn't actually have a kernel so keep it out of the struct and config
     // it here. TODO: should this be in the struct?
-    CoreType dispatch_core_type = this->dispatch_core_manager_.get_dispatch_core_type();
-    const auto& my_dispatch_constants = *dispatch_mem_map_[enchantum::to_underlying(dispatch_core_type)];
+    CoreType dispatch_core_type = MetalContext::instance().get_dispatch_core_manager().get_dispatch_core_type();
+    const auto& my_dispatch_constants = MetalContext::instance().dispatch_mem_map();
     uint32_t cq_start = my_dispatch_constants.get_host_command_queue_addr(CommandQueueHostAddrType::UNRESERVED);
     uint32_t cq_size = device->sysmem_manager().get_cq_size();
     std::vector<uint32_t> zero = {0x0};
 
     // Need to set up for all devices serviced by an mmio chip
     if (device->is_mmio_capable()) {
-        for (ChipId serviced_device_id : descriptor_.cluster().get_devices_controlled_by_mmio_device(device->id())) {
-            uint16_t channel = descriptor_.cluster().get_assigned_channel_for_device(serviced_device_id);
+        for (ChipId serviced_device_id :
+             MetalContext::instance().get_cluster().get_devices_controlled_by_mmio_device(device->id())) {
+            uint16_t channel =
+                MetalContext::instance().get_cluster().get_assigned_channel_for_device(serviced_device_id);
             for (uint8_t cq_id = 0; cq_id < device->num_hw_cqs(); cq_id++) {
                 tt_cxy_pair completion_q_writer_location =
-                    this->dispatch_core_manager_.completion_queue_writer_core(serviced_device_id, channel, cq_id);
+                    MetalContext::instance().get_dispatch_core_manager().completion_queue_writer_core(
+                        serviced_device_id, channel, cq_id);
                 IDevice* mmio_device =
                     MetalContext::instance().device_manager()->get_active_device(completion_q_writer_location.chip);
                 uint32_t completion_q_wr_ptr =
@@ -780,43 +784,45 @@ void DispatchTopology::configure_dispatch_cores(Device* device) {
         }
     }
     // Configure cores for all nodes corresponding to this device
-    for (auto& kernel : node_id_to_kernel_) {
+    for (auto& kernel : node_id_to_kernel) {
         if (kernel->GetDeviceId() == device->id()) {
             kernel->ConfigureCore();
         }
     }
 }
 
-const std::unordered_set<CoreCoord>& DispatchTopology::get_virtual_dispatch_cores(ChipId dev_id) const {
-    if (!dispatch_cores_.contains(dev_id)) {
-        return this->empty_container_;
+const std::unordered_set<CoreCoord>& get_virtual_dispatch_cores(ChipId dev_id) {
+    if (!dispatch_cores.contains(dev_id)) {
+        return empty_cores[dev_id];
     }
-    return dispatch_cores_.at(dev_id);
+    return dispatch_cores[dev_id];
 }
 
-const std::unordered_set<CoreCoord>& DispatchTopology::get_virtual_dispatch_routing_cores(ChipId dev_id) const {
-    if (!routing_cores_.contains(dev_id)) {
-        return this->empty_container_;
+const std::unordered_set<CoreCoord>& get_virtual_dispatch_routing_cores(ChipId dev_id) {
+    if (!routing_cores.contains(dev_id)) {
+        return empty_cores[dev_id];
     }
-    return routing_cores_.at(dev_id);
+    return routing_cores[dev_id];
 }
 
-const std::unordered_set<TerminationInfo>& DispatchTopology::get_registered_termination_cores(ChipId dev_id) const {
-    if (!termination_info_.contains(dev_id)) {
-        return this->empty_termination_info_container_;
+const std::unordered_set<TerminationInfo>& get_registered_termination_cores(ChipId dev_id) {
+    if (!termination_info.contains(dev_id)) {
+        termination_info[dev_id] = {};
     }
-    return termination_info_.at(dev_id);
+    return termination_info.at(dev_id);
 }
 
-void DispatchTopology::reset() {
-    for (auto& kernel : node_id_to_kernel_) {
+void reset_topology_state() {
+    // TODO: https://github.com/tenstorrent/tt-metal/issues/24439
+    for (auto& kernel : node_id_to_kernel) {
         delete kernel;
     }
-    node_id_to_kernel_.clear();
-    command_queue_compile_group_->clear();
-    dispatch_cores_.clear();
-    routing_cores_.clear();
-    termination_info_.clear();
+    node_id_to_kernel.clear();
+    command_queue_compile_group.clear();
+    dispatch_cores.clear();
+    routing_cores.clear();
+    empty_cores.clear();
+    termination_info.clear();
 }
 
 }  // namespace tt::tt_metal

--- a/tt_metal/impl/dispatch/topology.hpp
+++ b/tt_metal/impl/dispatch/topology.hpp
@@ -5,7 +5,6 @@
 #pragma once
 
 #include <device.hpp>
-#include <functional>
 #include <memory>
 #include <set>
 #include <unordered_map>
@@ -19,10 +18,6 @@
 #include "tt_metal/impl/dispatch/kernel_config/fd_kernel.hpp"
 #include "tt_metal/impl/dispatch/dispatch_core_common.hpp"
 #include "tt_metal/impl/context/context_descriptor.hpp"
-
-namespace tt::tt_fabric {
-class ControlPlane;
-}
 
 namespace tt {
 class Cluster;
@@ -58,14 +53,7 @@ struct DispatchKernelNode {
 
 class DispatchTopology {
 public:
-    explicit DispatchTopology(
-        const ContextDescriptor& descriptor,
-        dispatch_core_manager& dispatch_core_manager,
-        DeviceManager* device_manager,
-        const GetControlPlaneFn& get_control_plane = {},
-        const GetDispatchQueryManagerFn& get_dispatch_query_manager = {},
-        const GetMaxNumEthCoresFn& get_max_num_eth_cores = {},
-        const GetReadsDispatchCoresFn& get_reads_dispatch_cores = {});
+    explicit DispatchTopology(const ContextDescriptor& descriptor, dispatch_core_manager& dispatch_core_manager);
     ~DispatchTopology();
 
     void populate_fd_kernels(const std::vector<Device*>& devices, uint32_t num_hw_cqs);
@@ -89,11 +77,6 @@ private:
 
     const ContextDescriptor& descriptor_;
     dispatch_core_manager& dispatch_core_manager_;
-    DeviceManager* device_manager_;
-    GetControlPlaneFn get_control_plane_;
-    GetDispatchQueryManagerFn get_dispatch_query_manager_;
-    GetMaxNumEthCoresFn get_max_num_eth_cores_;
-    GetReadsDispatchCoresFn get_reads_dispatch_cores_;
     std::unique_ptr<DispatchMemMap> dispatch_mem_map_[enchantum::to_underlying(CoreType::COUNT)];
     std::vector<FDKernel*> node_id_to_kernel_;
     std::unique_ptr<detail::ProgramCompileGroup> command_queue_compile_group_;

--- a/tt_metal/impl/dispatch/topology.hpp
+++ b/tt_metal/impl/dispatch/topology.hpp
@@ -7,32 +7,17 @@
 #include <device.hpp>
 #include <memory>
 #include <set>
-#include <unordered_map>
-#include <unordered_set>
 #include <vector>
 
 #include "core_coord.hpp"
 #include "data_types.hpp"
-#include "device/device_impl.hpp"
 #include "tt-metalium/program.hpp"
 #include "tt_metal/impl/dispatch/kernel_config/fd_kernel.hpp"
 #include "tt_metal/impl/dispatch/dispatch_core_common.hpp"
-#include "tt_metal/impl/context/context_descriptor.hpp"
-
-namespace tt {
-class Cluster;
-}
-
-namespace tt::tt_metal::detail {
-class ProgramCompileGroup;
-}
 
 namespace tt::tt_metal {
 
 class IDevice;
-class DeviceManager;
-class DispatchMemMap;
-class dispatch_core_manager;
 enum DispatchWorkerType : uint32_t;
 
 // NOC ID used by dispatch kernels to communicate with downstream cores. This parameter
@@ -51,40 +36,40 @@ struct DispatchKernelNode {
     int tunnel_index{-1};             // Tunnel index
 };
 
-class DispatchTopology {
-public:
-    explicit DispatchTopology(const ContextDescriptor& descriptor, dispatch_core_manager& dispatch_core_manager);
-    ~DispatchTopology();
+// Create FD kernels for all given device ids. Creates all objects, but need to call create_and_compile_cq_program() use
+// a created Device to fill out the settings. First version automatically generates the topology based on devices, num
+// cqs, and detected board. Second version uses the topology passed in.
+void populate_fd_kernels(const std::vector<IDevice*>& devices, uint32_t num_hw_cqs);
+void populate_fd_kernels(const std::set<ChipId>& device_ids, uint32_t num_hw_cqs);
+void populate_fd_kernels(const std::vector<DispatchKernelNode>& nodes);
 
-    void populate_fd_kernels(const std::vector<Device*>& devices, uint32_t num_hw_cqs);
-    void populate_fd_kernels(const std::set<ChipId>& device_ids, uint32_t num_hw_cqs);
-    void populate_fd_kernels(const std::vector<DispatchKernelNode>& nodes);
+// Populate the static arguments for a device.
+// Prerequisites: Must call populate_fd_kernels
+void populate_cq_static_args(IDevice* device);
 
-    void populate_cq_static_args(Device* device);
-    void create_cq_program(Device* device);
-    void compile_cq_programs();
-    std::unique_ptr<Program> get_compiled_cq_program(Device* device);
-    void configure_dispatch_cores(Device* device);
+// Fill out all settings for FD kernels on the given device, and add them to a Program and return it.
+// Prerequisites: Must call populate_cq_static_args
+void create_cq_program(tt::tt_metal::IDevice* device);
 
-    const std::unordered_set<CoreCoord>& get_virtual_dispatch_cores(ChipId dev_id) const;
-    const std::unordered_set<CoreCoord>& get_virtual_dispatch_routing_cores(ChipId dev_id) const;
-    const std::unordered_set<TerminationInfo>& get_registered_termination_cores(ChipId dev_id) const;
+// Compile all command queue programs created by create_and_compile_cq_program()
+void compile_cq_programs();
 
-    void reset();
+// Get the compiled command queue program for a given device
+std::unique_ptr<tt::tt_metal::Program> get_compiled_cq_program(tt::tt_metal::IDevice* device);
 
-private:
-    std::vector<DispatchKernelNode> generate_nodes(const std::set<ChipId>& device_ids, uint32_t num_hw_cqs) const;
+// Perform additional configuration (writing to specific L1 addresses, etc.) for FD kernels on this device.
+void configure_dispatch_cores(tt::tt_metal::IDevice* device);
 
-    const ContextDescriptor& descriptor_;
-    dispatch_core_manager& dispatch_core_manager_;
-    std::unique_ptr<DispatchMemMap> dispatch_mem_map_[enchantum::to_underlying(CoreType::COUNT)];
-    std::vector<FDKernel*> node_id_to_kernel_;
-    std::unique_ptr<detail::ProgramCompileGroup> command_queue_compile_group_;
-    std::unordered_map<ChipId, std::unordered_set<CoreCoord>> dispatch_cores_;
-    std::unordered_map<ChipId, std::unordered_set<CoreCoord>> routing_cores_;
-    std::unordered_map<ChipId, std::unordered_set<TerminationInfo>> termination_info_;
-    const std::unordered_set<CoreCoord> empty_container_;
-    const std::unordered_set<TerminationInfo> empty_termination_info_container_;
-};
+// Return the virtual dispatch cores running on a given device
+const std::unordered_set<CoreCoord>& get_virtual_dispatch_cores(ChipId dev_id);
+
+// Return the virtual cores used for dispatch routing/tunneling on a given device
+const std::unordered_set<CoreCoord>& get_virtual_dispatch_routing_cores(ChipId dev_id);
+
+// Return the set of termination targets that were registered for this device
+const std::unordered_set<tt::tt_metal::TerminationInfo>& get_registered_termination_cores(ChipId dev_id);
+
+// Must be called at the end of the application to cleanup any static state allocated by this module.
+void reset_topology_state();
 
 }  // namespace tt::tt_metal


### PR DESCRIPTION
### Ticket
N/A

### Problem description
Revert as it exposed an issue

### What's changed
Revert

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=nhuang/rev)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:nhuang/rev)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=nhuang/rev)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:nhuang/rev)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nhuang/rev)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nhuang/rev)
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nhuang/rev)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nhuang/rev)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nhuang/rev)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nhuang/rev)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nhuang/rev)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nhuang/rev)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
