### PR TITLE
Updating long seq len tests to include 32K prefill test_model for Deepseek 671B model

### DIFF
--- a/.github/workflows/galaxy-deepseek-tests-impl.yaml
+++ b/.github/workflows/galaxy-deepseek-tests-impl.yaml
@@ -122,7 +122,7 @@ jobs:
         run: |
           uv pip install -r models/demos/deepseek_v3/reference/deepseek/requirements.txt
           DEEPSEEK_MAX_SEQ_LEN_OVERRIDE=16384 pytest models/demos/deepseek_v3/tests/test_mla.py -k "mode_decode" --timeout 900 --durations=0
-          DEEPSEEK_MAX_SEQ_LEN_OVERRIDE=16384 pytest models/demos/deepseek_v3/tests/test_decoder_block.py -k "mode_decode" --timeout 2400 --durations=0
+          DEEPSEEK_MAX_SEQ_LEN_OVERRIDE=12288 pytest models/demos/deepseek_v3/tests/test_decoder_block.py -k "mode_decode" --timeout 2400 --durations=0
           # TODO: set DEEPSEEK_MAX_SEQ_LEN_OVERRIDE to large value if test does not get killed in CI.
           DEEPSEEK_MAX_SEQ_LEN_OVERRIDE=1024 pytest models/demos/deepseek_v3/tests/test_model.py -k "mode_decode" --timeout 1250 --durations=0
           DEEPSEEK_MAX_SEQ_LEN_OVERRIDE=32768 pytest models/demos/deepseek_v3/tests/test_model.py -k "mode_prefill" --timeout 1250 --durations=0

--- a/.github/workflows/galaxy-deepseek-tests-impl.yaml
+++ b/.github/workflows/galaxy-deepseek-tests-impl.yaml
@@ -121,10 +121,11 @@ jobs:
         timeout-minutes: ${{ matrix.test-group.timeout }}
         run: |
           uv pip install -r models/demos/deepseek_v3/reference/deepseek/requirements.txt
-          DEEPSEEK_MAX_SEQ_LEN_OVERRIDE=16384 pytest models/demos/deepseek_v3/tests/test_mla.py --timeout 900 --durations=0
-          DEEPSEEK_MAX_SEQ_LEN_OVERRIDE=12288 pytest models/demos/deepseek_v3/tests/test_decoder_block.py --timeout 2400 --durations=0
+          DEEPSEEK_MAX_SEQ_LEN_OVERRIDE=16384 pytest models/demos/deepseek_v3/tests/test_mla.py -k "mode_decode" --timeout 900 --durations=0
+          DEEPSEEK_MAX_SEQ_LEN_OVERRIDE=16384 pytest models/demos/deepseek_v3/tests/test_decoder_block.py -k "mode_decode" --timeout 2400 --durations=0
           # TODO: set DEEPSEEK_MAX_SEQ_LEN_OVERRIDE to large value if test does not get killed in CI.
-          DEEPSEEK_MAX_SEQ_LEN_OVERRIDE=1024 pytest models/demos/deepseek_v3/tests/test_model.py --timeout 2500 --durations=0
+          DEEPSEEK_MAX_SEQ_LEN_OVERRIDE=1024 pytest models/demos/deepseek_v3/tests/test_model.py -k "mode_decode" --timeout 1250 --durations=0
+          DEEPSEEK_MAX_SEQ_LEN_OVERRIDE=32768 pytest models/demos/deepseek_v3/tests/test_model.py -k "mode_prefill" --timeout 1250 --durations=0
       - uses: tenstorrent/tt-metal/.github/actions/slack-report@main
         if: ${{ failure() }}
         with:


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Prefill MoE tests are only being tested up to 1k.

### What's changed
Updating long seq len tests to include 32K prefill test_model (tests all modules for 32K prefill).
No change needed for overall CI time because of reference model output caching.

### Checklist
[![DeepSeek Tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-deepseek-tests.yaml/badge.svg?branch=ds-long-seq-CI)](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-deepseek-tests.yaml?query=branch:ds-long-seq-CI)