### PR TITLE
ci: Cache CPM source downloads to speed up CMake configure

### DIFF
--- a/.github/workflows/build-artifact.yaml
+++ b/.github/workflows/build-artifact.yaml
@@ -448,6 +448,14 @@ jobs:
           # ownership mismatch (host uid vs container root). Add /work to safe.directory.
           git config --global --add safe.directory /work
 
+      - name: 📦 Restore CPM source cache
+        uses: actions/cache@v4
+        with:
+          path: /work/.cpmcache
+          key: cpm-${{ hashFiles('third_party/CMakeLists.txt', 'tt_metal/third_party/umd/third_party/CMakeLists.txt', 'tt-train/cmake/dependencies.cmake') }}
+          restore-keys: |
+            cpm-
+
       - name: 🔧 CMake configure
         run: |
           set -eu # basic shell hygiene

--- a/.github/workflows/build-artifact.yaml
+++ b/.github/workflows/build-artifact.yaml
@@ -451,7 +451,7 @@ jobs:
       - name: 📦 Restore CPM source cache
         uses: actions/cache@v4
         with:
-          path: /work/.cpmcache
+          path: .cpmcache
           key: cpm-${{ hashFiles('third_party/CMakeLists.txt', 'tt_metal/third_party/umd/third_party/CMakeLists.txt', 'tt-train/cmake/dependencies.cmake') }}
           restore-keys: |
             cpm-

--- a/.github/workflows/wheels.yaml
+++ b/.github/workflows/wheels.yaml
@@ -76,6 +76,14 @@ jobs:
           fetch-depth: ${{ (startsWith(inputs.ref || github.ref, 'refs/tags/')) && 1 || 500 }}
           fetch-tags: true # Need tags for `git describe`
 
+      - name: 📦 Restore CPM source cache
+        uses: actions/cache@v4
+        with:
+          path: .cpmcache
+          key: cpm-${{ hashFiles('third_party/CMakeLists.txt', 'tt_metal/third_party/umd/third_party/CMakeLists.txt', 'tt-train/cmake/dependencies.cmake') }}
+          restore-keys: |
+            cpm-
+
       # Python for driving the build; not the version the wheel targets
       - name: Set up Python 3.12
         uses: actions/setup-python@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,6 @@ fallback_version = "0.0.0.dev0"
 
 [tool.cibuildwheel]
 skip = "*-musllinux_*"
-build-verbosity = 2
 
 [tool.uv]
 # Use "copy" mode instead of the default "hardlink" or "symlink" modes.


### PR DESCRIPTION
### Ticket
N/A — CI performance improvement

### Problem description
CMake configure in CI takes ~3 minutes, while compilation with ccache takes only ~43 seconds. Profiling shows the bulk of configure time is spent downloading and extracting CPM third-party sources (Boost ~32s, protobuf ~43s, plus dozens of smaller packages). Since CI runners are ephemeral, these downloads happen from scratch on every single build.

### What's changed
Added a `actions/cache@v4` step to `build-artifact.yaml` that caches `/work/.cpmcache` (the default `CPM_SOURCE_CACHE` location) between CI runs.

**Cache key strategy:**
- **Primary key** hashes the three files that define all `CPMAddPackage` calls: `third_party/CMakeLists.txt`, `tt_metal/third_party/umd/third_party/CMakeLists.txt`, and `tt-train/cmake/dependencies.cmake`.
- **Restore key** (`cpm-`) falls back to the latest available cache on a key miss, so when dependencies change, CPM only fetches the delta rather than re-downloading everything.

**No other changes required** — `CPM_SOURCE_CACHE` already defaults to `${CMAKE_SOURCE_DIR}/.cpmcache`, which resolves to `/work/.cpmcache` in CI. No new environment variables, no CMake changes.

**Expected impact:**
- First run (cold cache): no change (~3 min configure)
- Subsequent runs (warm cache): configure should drop to ~5–10 seconds
- Dependency version bump: restore stale cache + fetch delta, much faster than cold

### Checklist

First Run: https://github.com/tenstorrent/tt-metal/actions/runs/22325604505

Second Run: https://github.com/tenstorrent/tt-metal/actions/runs/22325120538

### Measured Impact

“Caching build intermediates reduced build time from 14:01 → 10:44 (-3:17, 23.4% faster) when both build jobs (normal build and wheel build) are considered.”

This was because of something like 77% improvement in CMake configuration time.