### PR TITLE
Fix MPWI LLK Signatures to Respect SFPU Semantics

### DIFF
--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_max_pool_indices.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_max_pool_indices.h
@@ -20,7 +20,8 @@ template <
     int ITERATIONS = 8,
     DataLayout layout = DataLayout::TILE,
     bool accumulate = false>
-inline void calculate_max_pool_with_indices(uint values_tile_idx, uint indices_tile_idx, uint chunk) {
+inline void calculate_max_pool_with_indices(
+    uint values_tile_idx, uint indices_tile_idx, uint unused_tile_idx, uint chunk) {
     if constexpr (num_rows <= 9) {
         _calculate_max_pool_with_indices_<APPROXIMATION_MODE, is_fp32_dest_acc_en, ITERATIONS, layout, accumulate>(
             values_tile_idx, indices_tile_idx, chunk);

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_max_pool_indices.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_max_pool_indices.h
@@ -29,6 +29,8 @@ inline void llk_math_eltwise_binary_sfpu_max_pool_with_indices(uint dst_index, u
             calculate_max_pool_with_indices<APPROXIMATE, is_fp32_dest_acc_en, num_rows, ITERATIONS, layout, accumulate>,
         dst_index,
         idx_index,
+        0 /* DST out unused, but required for _llk_math_eltwise_binary_sfpu_params_ */,
+        static_cast<int>(VectorMode::RC) /* vector_mode */,
         chunk);
 }
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_max_pool_indices.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_max_pool_indices.h
@@ -20,7 +20,8 @@ template <
     int ITERATIONS = 8,
     DataLayout layout = DataLayout::TILE,
     bool accumulate = false>
-inline void calculate_max_pool_with_indices(uint values_tile_idx, uint indices_tile_idx, uint chunk) {
+inline void calculate_max_pool_with_indices(
+    uint values_tile_idx, uint indices_tile_idx, uint unused_tile_idx, uint chunk) {
     if constexpr (num_rows <= 9) {
         _calculate_max_pool_with_indices_<APPROXIMATION_MODE, is_fp32_dest_acc_en, ITERATIONS, layout, accumulate>(
             values_tile_idx, indices_tile_idx, chunk);

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_max_pool_indices.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_max_pool_indices.h
@@ -29,6 +29,8 @@ inline void llk_math_eltwise_binary_sfpu_max_pool_with_indices(uint dst_index, u
             calculate_max_pool_with_indices<APPROXIMATE, is_fp32_dest_acc_en, num_rows, ITERATIONS, layout, accumulate>,
         dst_index,
         idx_index,
+        0 /* DST out unused, but required for _llk_math_eltwise_binary_sfpu_params_ */,
+        static_cast<int>(VectorMode::RC) /* vector_mode */,
         chunk);
 }
 


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/38349

### Problem description
MPWI fails a newly added LLK assert since chunk number is passed as dst_out to _llk_math_eltwise_binary_sfpu_params_ and exceeds the max dst index.

### What's changed
The parameters have been re-organized to pass 0 for dst_out as a default and to pass chunk as one of the general args.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes:
https://github.com/tenstorrent/tt-metal/actions/runs/22322476453
https://github.com/tenstorrent/tt-metal/actions/runs/22324467252 - with asserts, unrelated failures
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes:
https://github.com/tenstorrent/tt-metal/actions/runs/22322507065
- [x] [Nightly L2](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml) CI passes:
https://github.com/tenstorrent/tt-metal/actions/runs/22322507741
- [x] [Nightly Blackhole](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-nightly-tests.yaml) CI passes:
https://github.com/tenstorrent/tt-metal/actions/runs/22322509801
unrelated failures