### PR TITLE
Fix d2d kernel

### DIFF
--- a/models/demos/deepseek_v3_b1/micro_ops/d2d_exchange/kernels/d2d_exchange_multiple_senders.cpp
+++ b/models/demos/deepseek_v3_b1/micro_ops/d2d_exchange/kernels/d2d_exchange_multiple_senders.cpp
@@ -42,12 +42,6 @@ FORCE_INLINE bool socket_wait_for_pages_with_termination(
     return true;
 }
 
-FORCE_INLINE void write_data_to_local_core_with_ack(
-    SocketSenderInterface& sender_socket, uint32_t l1_read_addr, uint64_t dst_addr, uint32_t write_size) {
-    noc_async_write(l1_read_addr, dst_addr, write_size);
-    noc_async_writes_flushed();
-}
-
 FORCE_INLINE void write_data_to_remote_core_with_ack(
     tt::tt_fabric::WorkerToFabricEdmSender& fabric_connection,
     volatile tt_l1_ptr PACKET_HEADER_TYPE* packet_header_addr,
@@ -72,18 +66,17 @@ FORCE_INLINE void send_pages_over_socket(
     uint64_t downstream_bytes_sent_noc_addr,
     uint32_t l1_read_addr,
     uint64_t dst_addr) {
-    if constexpr (use_fabric_on_sender) {
-        for (uint32_t i = 0; i < num_whole_fabric_packets_link_0; ++i) {
-            write_data_to_remote_core_with_ack(
-                downstream_fabric_connection,
-                downstream_data_packet_header_addr,
-                l1_read_addr,
-                dst_addr,
-                downstream_bytes_sent_noc_addr,
-                whole_packet_size);
-            l1_read_addr += whole_packet_size;
-            dst_addr += whole_packet_size;
-        }
+    for (uint32_t i = 0; i < num_whole_fabric_packets_link_0; ++i) {
+        write_data_to_remote_core_with_ack(
+            downstream_fabric_connection,
+            downstream_data_packet_header_addr,
+            l1_read_addr,
+            dst_addr,
+            downstream_bytes_sent_noc_addr,
+            whole_packet_size);
+        l1_read_addr += whole_packet_size;
+        dst_addr += whole_packet_size;
+    }
 
         for (uint32_t i = 0; i < num_whole_fabric_packets_link_1; ++i) {
             write_data_to_remote_core_with_ack(
@@ -106,9 +99,6 @@ FORCE_INLINE void send_pages_over_socket(
                 downstream_bytes_sent_noc_addr,
                 partial_packet_size);
         }
-    } else {
-        write_data_to_local_core_with_ack(sender_socket, l1_read_addr, dst_addr, upstream_page_size);
-    }
 }
 
 void kernel_main() {
@@ -169,52 +159,74 @@ void kernel_main() {
         fabric_set_unicast_route(downstream_data_packet_header_addr_2, downstream_enc);
     }
 
-    uint32_t bytes_accumulated = 0;
+    while (true) {
+        uint32_t bytes_accumulated = 0;
+        bool terminated = false;
 
-    socket_reserve_pages(sender_socket, 1);
+        socket_reserve_pages(sender_socket, 1);
 
-    // Collect data from all upstream sockets into a single larger page
-    // Process num_upstream_sockets pages (one from each worker) for reduce-to-one
-    for (uint32_t i = 0; i < num_upstream_sockets; i++) {
-        // Wait for pages in current upstream socket with termination checks
-        if (!socket_wait_for_pages_with_termination(receiver_sockets[i], 1, termination_semaphore)) {
+        // Collect data from all upstream sockets into a single larger page
+        // Process num_upstream_sockets pages (one from each worker) for reduce-to-one
+        for (uint32_t i = 0; i < num_upstream_sockets; i++) {
+            // Wait for pages in current upstream socket with termination checks
+            if (!socket_wait_for_pages_with_termination(receiver_sockets[i], 1, termination_semaphore)) {
+                terminated = true;
+                break;
+            }
+
+            auto l1_read_addr = receiver_sockets[i].read_ptr;
+            // Calculate offset within the downstream buffer for this socket's data
+            uint32_t skt_offset = bytes_accumulated;
+            uint32_t dst_l1_addr = downstream_fifo_l1_addr + sender_socket.write_ptr + skt_offset;
+            uint64_t dst_addr =
+                get_noc_addr(downstream_enc.d2d.downstream_noc_x, downstream_enc.d2d.downstream_noc_y, dst_l1_addr);
+
+            // accumulation phase
+            noc_async_write(l1_read_addr, dst_addr, upstream_page_size);
+            noc_async_writes_flushed();
+
+            socket_pop_pages(receiver_sockets[i], 1);
+            socket_notify_sender(receiver_sockets[i]);
+
+            invalidate_l1_cache();
+
+            // Update accumulation offset
+            bytes_accumulated += upstream_page_size;
+        }
+
+        // Check if we should exit due to termination
+        if (terminated) {
             break;
         }
 
-        auto l1_read_addr = receiver_sockets[i].read_ptr;
-        // Calculate offset within the downstream buffer for this socket's data
-        uint32_t skt_offset = bytes_accumulated;
-        uint32_t dst_l1_addr = downstream_fifo_l1_addr + sender_socket.write_ptr + skt_offset;
-        uint64_t dst_addr =
-            get_noc_addr(downstream_enc.d2d.downstream_noc_x, downstream_enc.d2d.downstream_noc_y, dst_l1_addr);
+        // Now send the accumulated page once (14,336 bytes total from all 8 workers)
+        if (bytes_accumulated >= sender_page_size) {
+            // If using fabric, send the accumulated data via fabric in chunks
+            if constexpr (use_fabric_on_sender) {
+                uint32_t l1_read_addr = downstream_fifo_l1_addr + sender_socket.write_ptr;
+                uint64_t dst_addr = get_noc_addr(
+                    downstream_enc.d2d.downstream_noc_x,
+                    downstream_enc.d2d.downstream_noc_y,
+                    downstream_fifo_l1_addr + sender_socket.write_ptr);
 
-        send_pages_over_socket(
-            sender_socket,
-            downstream_fabric_connection,
-            downstream_fabric_connection_2,
-            downstream_data_packet_header_addr,
-            downstream_data_packet_header_addr_2,
-            downstream_bytes_sent_noc_addr,
-            l1_read_addr,
-            dst_addr);
-
-        socket_pop_pages(receiver_sockets[i], 1);
-
-        socket_notify_sender(receiver_sockets[i]);
+                send_pages_over_socket(
+                    sender_socket,
+                    downstream_fabric_connection,
+                    downstream_fabric_connection_2,
+                    downstream_data_packet_header_addr,
+                    downstream_data_packet_header_addr_2,
+                    downstream_bytes_sent_noc_addr,
+                    l1_read_addr,
+                    dst_addr);
+            }
+            // if not using fabric: Data already accumulated in downstream buffer via noc_async_write
+            // Just push the page to the socket
+            socket_push_pages(sender_socket, 1);
+            socket_notify_receiver(sender_socket);
+        }
 
         invalidate_l1_cache();
-
-        // Update accumulation
-        bytes_accumulated += upstream_page_size;
     }
-
-    // Push the aggregated page after collecting all worker data
-    if (bytes_accumulated >= sender_page_size) {
-        socket_push_pages(sender_socket, 1);
-        socket_notify_receiver(sender_socket);
-    }
-
-    invalidate_l1_cache();
 
     update_socket_config(sender_socket);
     for (uint32_t i = 0; i < num_upstream_sockets; i++) {

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_reduce_to_one_b1_with_d2d1_d2h.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_reduce_to_one_b1_with_d2d1_d2h.py
@@ -220,9 +220,15 @@ def test_reduce_to_one_b1_with_d2d1_d2h(
     )
     logger.info("Created HostInterface for D2H on EXIT device")
 
-    # Allocate D2D_0's output core
-    d2d0_output_core = ttnn.CoreCoord(12, 9)  # Free core on ROOT1 device
-    d2d0_output_mesh_core = ttnn.MeshCoreCoord(root_coord, d2d0_output_core)
+    d2d0_infra_temp = ReduceToOneB1.create_d2d0_infrastructure(
+        submesh_device,
+        root_coord,
+        shard_cores,
+        payload_size_bytes,  # Per-worker page size
+        None,
+    )
+    d2d0_core = d2d0_infra_temp["d2d0_core"]  # Get actual D2D_0 core
+    d2d0_output_mesh_core = ttnn.MeshCoreCoord(root_coord, d2d0_core)
 
     socket_interface = SocketInterface(
         aggregated_size_bytes,  # page_size
@@ -238,17 +244,8 @@ def test_reduce_to_one_b1_with_d2d1_d2h(
     )
     logger.info("Created SocketInterface for D2D_1 cross-device forwarding (ROOT1 → EXIT)")
 
-    # Create D2D_0 infrastructure
-    # Pass the sender socket [0] from SocketInterface's upstream socket pair
-    # This is the socket that D2D_0 will write to
-    d2d0_downstream_socket = socket_interface.get_upstream_socket()  # Get sender socket [0]
-    d2d0_infra = ReduceToOneB1.create_d2d0_infrastructure(
-        submesh_device,
-        root_coord,
-        shard_cores,
-        payload_size_bytes,  # Per-worker page size
-        d2d0_downstream_socket,
-    )
+    d2d0_infra_temp["d2d0_downstream_socket"] = socket_interface.get_upstream_socket()
+    d2d0_infra = d2d0_infra_temp
     logger.info(f"Created D2D_0 infrastructure with aggregator at core {d2d0_infra['d2d0_core']}")
 
     logger.info("\n=== Running Reduce-to-One with integrated D2D_0 ===")


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Provide context for the problem.

### What's changed
Fix d2d kernel with multiple senders: send a single socket page

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=nardo/d2d_kernel)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:nardo/d2d_kernel)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=nardo/d2d_kernel)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:nardo/d2d_kernel)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nardo/d2d_kernel)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nardo/d2d_kernel)
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nardo/d2d_kernel)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nardo/d2d_kernel)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nardo/d2d_kernel)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nardo/d2d_kernel)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nardo/d2d_kernel)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nardo/d2d_kernel)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
