### PR TITLE
use raw values for TRISCs, they are claculated in qa_hal.c

### DIFF
--- a/tt_metal/hw/firmware/src/tt-2xx/trisc.cc
+++ b/tt_metal/hw/firmware/src/tt-2xx/trisc.cc
@@ -66,7 +66,6 @@ tt_l1_ptr mailboxes_t* const mailboxes = (tt_l1_ptr mailboxes_t*)(MEM_MAILBOX_BA
 
 #if !defined(UCK_CHLKC_MATH)
 uint32_t tt_l1_ptr* cb_l1_base __attribute__((used));
-thread_local CBInterface cb_interface[NUM_CIRCULAR_BUFFERS] __attribute__((used));
 #endif
 
 #if defined(UCK_CHLKC_UNPACK)

--- a/tt_metal/hw/toolchain/crt0.S
+++ b/tt_metal/hw/toolchain/crt0.S
@@ -21,13 +21,12 @@ _start:
 	addi	tp,tp,%lo(__local_base)
 	lui	sp,%hi(__local_stride)
 	addi	sp,sp,%lo(__local_stride)
-#ifdef COMPILE_FOR_TRISC
-	csrr	s2, 0xBC2
-#else
+// for TRISCs __local_base and __local_stride already have the correct value in internal memory
+#ifndef COMPILE_FOR_TRISC
 	csrr	s2,mhartid
-#endif
 	mul	s2,sp,s2
 	add	tp,tp,s2
+#endif
 	add	sp,tp,sp
 
 	/* Enter high-level start.  */

--- a/tt_metal/hw/toolchain/crt0.S
+++ b/tt_metal/hw/toolchain/crt0.S
@@ -21,7 +21,7 @@ _start:
 	addi	tp,tp,%lo(__local_base)
 	lui	sp,%hi(__local_stride)
 	addi	sp,sp,%lo(__local_stride)
-// for TRISCs __local_base and __local_stride already have the correct value in internal memory
+// for TRISCs __local_base and __local_stride are already set by the linker to the correct internal memory addresses
 #ifndef COMPILE_FOR_TRISC
 	csrr	s2,mhartid
 	mul	s2,sp,s2


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/38156)

### Problem description
TRISCs stack and thread pointers were pointing to non-existent memory regions because we used calculations that were right for DM cores - which have only a single FW executable and share memory, but TRISC have separate executables (within NEO), and separate internal memory (for each NEO)

### What's changed
On TRISC we're using internal memory for TLS and stack. Each Neo has its own internal memory for that, so different threads can use same memory address without overstepping the other Neos. We already calculated the correct values in qa_hal.cc, but each core was adding on top of that the offset calculation that is used for DM cores, so the end result was wrong values. I changed the calculation per-core to only occur on DM cores.

### Checklist
NOTE: changes only touch Quasar code
- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=ayaacob/fix_trisc_stacks)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:ayaacob/fix_trisc_stacks)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ayaacob/fix_trisc_stacks)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ayaacob/fix_trisc_stacks)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ayaacob/fix_trisc_stacks)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ayaacob/fix_trisc_stacks)
- [x] manual running Quasar test
