### PR TITLE
#36020: Switch weights in pre_sdpa to use overlapped tensors

### DIFF
--- a/ttnn/api/ttnn/tensor/tensor_utils.hpp
+++ b/ttnn/api/ttnn/tensor/tensor_utils.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <cstdint>
+#include <optional>
 
 #include "ttnn/tensor/tensor.hpp"
 #include <tt-metalium/program_descriptors.hpp>
@@ -34,6 +35,9 @@ bool is_device_tensor(const Tensor& tensor);
  *
  * @param cb_index The CB ID to use for this circular buffer
  * @param tensor The sharded tensor to derive CB configuration from
+ * @param address_offset Byte offset from buffer base address for CB placement (default 0)
+ * @param total_size Total CB size in bytes (default 0 = use tensor's full bank size)
+ * @param core_ranges Optional CoreRangeSet override; if std::nullopt, uses the tensor's shard grid
  * @return CBDescriptor with all fields populated from the tensor
  *
  * Example usage (replaces manual calculation of all CB fields):
@@ -55,6 +59,10 @@ bool is_device_tensor(const Tensor& tensor);
  * @endcode
  */
 CBDescriptor cb_descriptor_from_sharded_tensor(
-    uint8_t cb_index, const Tensor& tensor, uint32_t address_offset = 0, uint32_t total_size = 0);
+    uint8_t cb_index,
+    const Tensor& tensor,
+    uint32_t address_offset = 0,
+    uint32_t total_size = 0,
+    const std::optional<CoreRangeSet>& core_ranges = std::nullopt);
 
 }  // namespace tt::tt_metal

--- a/ttnn/core/tensor/tensor_utils.cpp
+++ b/ttnn/core/tensor/tensor_utils.cpp
@@ -21,7 +21,11 @@ bool is_cpu_tensor(const Tensor& tensor) { return tensor.storage_type() == Stora
 bool is_device_tensor(const Tensor& tensor) { return tensor.storage_type() == StorageType::DEVICE; }
 
 CBDescriptor cb_descriptor_from_sharded_tensor(
-    uint8_t cb_index, const Tensor& tensor, uint32_t address_offset, uint32_t total_size) {
+    uint8_t cb_index,
+    const Tensor& tensor,
+    uint32_t address_offset,
+    uint32_t total_size,
+    const std::optional<CoreRangeSet>& core_ranges) {
     TT_FATAL(tensor.is_sharded(), "Tensor must be sharded to automatically create a CBDescriptor");
     TT_FATAL(
         (address_offset + total_size) <= tensor.buffer()->aligned_size_per_bank(),
@@ -31,7 +35,7 @@ CBDescriptor cb_descriptor_from_sharded_tensor(
 
     return CBDescriptor{
         .total_size = effective_total_size,
-        .core_ranges = tensor.shard_spec()->grid,
+        .core_ranges = core_ranges.value_or(tensor.shard_spec()->grid),
         .format_descriptors = {CBFormatDescriptor{
             .buffer_index = cb_index,
             .data_format = datatype_to_dataformat_converter(tensor.tensor_spec().tensor_layout().get_data_type()),

--- a/ttnn/cpp/ttnn-nanobind/program_descriptors.cpp
+++ b/ttnn/cpp/ttnn-nanobind/program_descriptors.cpp
@@ -378,6 +378,7 @@ void py_module_types(nb::module_& mod) {
         nb::arg("tensor"),
         nb::arg("address_offset") = 0,
         nb::arg("total_size") = 0,
+        nb::arg("core_ranges") = nb::none(),
         R"pbdoc(
             Create a CBDescriptor from a sharded tensor.
 
@@ -389,6 +390,7 @@ void py_module_types(nb::module_& mod) {
                 tensor: A sharded tensor to derive CB configuration from
                 address_offset: Byte offset from buffer base address for CB placement (default 0)
                 total_size: Total CB size in bytes (default 0 = use tensor's full bank size)
+                core_ranges: Optional CoreRangeSet override (default None = use tensor's shard grid)
 
             Returns:
                 CBDescriptor with all fields (total_size, core_ranges, format_descriptors, buffer)


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/36020)

### Problem description
Need to switch all tensors to use overlapped tensors so they match what they look like when fused.

### What's changed
- Add option to specify coreranges for cb descriptor for sharded tensors
- Flip matmuls and rmsnorm in pre_sdpa to use overlapped tensors
- Fix incorrect shuffling for kv_b2_proj

### Checklist

- [x] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=bliu/deepseek)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:bliu/deepseek): https://github.com/tenstorrent/tt-metal/actions/runs/22423839426
- [x] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=bliu/deepseek)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:bliu/deepseek): https://github.com/tenstorrent/tt-metal/actions/runs/22423846054
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=bliu/deepseek)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:bliu/deepseek)
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=bliu/deepseek)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:bliu/deepseek)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=bliu/deepseek)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:bliu/deepseek)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=bliu/deepseek)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:bliu/deepseek)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
