### PR TITLE
Update SDPA Reduce to use position_id and per_device_chunk_size

### DIFF
--- a/models/demos/deepseek_v3_b1/fused_ops/post_sdpa/kernels/post_sdpa_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/fused_ops/post_sdpa/kernels/post_sdpa_kernel.cpp
@@ -356,8 +356,8 @@ void kernel_main() {
                 get_named_compile_time_arg_val("sdpa_l_chunk_size_bytes"),
                 get_named_compile_time_arg_val("sdpa_num_l_chunks"),
                 get_named_compile_time_arg_val("sdpa_tiles_per_l_chunk"),
-                0,
-                0>;  // position_enabled=0, per_device_chunk_size=0 (not used in post_sdpa)
+                get_named_compile_time_arg_val("sdpa_position_enabled"),
+                get_named_compile_time_arg_val("sdpa_per_device_chunk_size")>;
 
             // Dummy WriterCT and ComputeCT - not used by NCRISC but needed for Op template
             using WriterCTArgs = Worker::WriterCTArgs<0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0>;
@@ -418,9 +418,9 @@ void kernel_main() {
                 get_named_compile_time_arg_val("sdpa_scale_fp32"),
                 get_named_compile_time_arg_val("sdpa_tiles_per_l_chunk"),
                 get_named_compile_time_arg_val("sdpa_num_l_chunks"),
-                0,
-                0,   // position_enabled=0, per_device_chunk_size=0 (not used in post_sdpa)
-                1>;  // final_reduction=1 (always normalize in post_sdpa)
+                get_named_compile_time_arg_val("sdpa_position_enabled"),
+                get_named_compile_time_arg_val("sdpa_per_device_chunk_size"),
+                1>;  // final_reduction=1 (always normalize in post_sdpa, untilize constraint)
 
             // Note: compute_kernel_hw_startup already called at top of TRISC block
             Worker::Op<ReaderCTArgs, WriterCTArgs, ComputeCTArgs> sdpa_worker;

--- a/models/demos/deepseek_v3_b1/fused_ops/post_sdpa/kernels/post_sdpa_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/fused_ops/post_sdpa/kernels/post_sdpa_kernel.cpp
@@ -357,7 +357,7 @@ void kernel_main() {
                 get_named_compile_time_arg_val("sdpa_num_l_chunks"),
                 get_named_compile_time_arg_val("sdpa_tiles_per_l_chunk"),
                 0,
-                0>;  // cb_position=0, position_enabled=0 (not used in post_sdpa)
+                0>;  // position_enabled=0, per_device_chunk_size=0 (not used in post_sdpa)
 
             // Dummy WriterCT and ComputeCT - not used by NCRISC but needed for Op template
             using WriterCTArgs = Worker::WriterCTArgs<0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0>;
@@ -419,7 +419,7 @@ void kernel_main() {
                 get_named_compile_time_arg_val("sdpa_tiles_per_l_chunk"),
                 get_named_compile_time_arg_val("sdpa_num_l_chunks"),
                 0,
-                0,   // cb_position=0, position_enabled=0 (not used in post_sdpa)
+                0,   // position_enabled=0, per_device_chunk_size=0 (not used in post_sdpa)
                 1>;  // final_reduction=1 (always normalize in post_sdpa)
 
             // Note: compute_kernel_hw_startup already called at top of TRISC block

--- a/models/demos/deepseek_v3_b1/micro_ops/sdpa_reduce_to_all/kernels/sdpa_reduce_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/micro_ops/sdpa_reduce_to_all/kernels/sdpa_reduce_kernel.cpp
@@ -43,8 +43,8 @@ void kernel_main() {
             get_named_compile_time_arg_val("l_chunk_size_bytes"),
             get_named_compile_time_arg_val("num_l_chunks"),
             get_named_compile_time_arg_val("tiles_per_l_chunk"),
-            get_named_compile_time_arg_val("cb_position"),
-            get_named_compile_time_arg_val("position_enabled")>;
+            get_named_compile_time_arg_val("position_enabled"),
+            get_named_compile_time_arg_val("per_device_chunk_size")>;
 
         // Dummy WriterCT and ComputeCT - not used by NCRISC but needed for Op template
         using WriterCTArgs = Worker::WriterCTArgs<0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0>;
@@ -136,8 +136,8 @@ void kernel_main() {
             get_named_compile_time_arg_val("scale_fp32"),
             get_named_compile_time_arg_val("tiles_per_l_chunk"),
             get_named_compile_time_arg_val("num_l_chunks"),
-            get_named_compile_time_arg_val("cb_position"),
             get_named_compile_time_arg_val("position_enabled"),
+            get_named_compile_time_arg_val("per_device_chunk_size"),
             get_named_compile_time_arg_val("final_reduction")>;
 
         // Initialize compute engine for unified kernel


### PR DESCRIPTION
Initial positional reduce support used a flag per device, 4 flags for 4 devices to determine whether a device has valid data to reduce or not.
The updated approach replaces the flag with common values of position_id and per_device_chunk_size.
Every device looks at these and determines whether it has valid data to reduce or not.

### Ticket
Link to Github Issue

### Problem description
Provide context for the problem.

### What's changed
Describe the approach used to solve the problem.
Summarize the changes made and its impact.

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:{{branch_name}})
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:{{branch_name}})
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:{{branch_name}})
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:{{branch_name}})
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:{{branch_name}})
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:{{branch_name}})
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
