### PR TITLE
[skip ci] Fix over-triaging: remove unreliable file path fallback and cap auto-triage per workflow

### DIFF
--- a/.github/actions/analyze-workflow-data/analyze-workflow-data.js
+++ b/.github/actions/analyze-workflow-data/analyze-workflow-data.js
@@ -6,6 +6,7 @@
 // See: https://docs.github.com/en/rest/actions/workflow-runs?apiVersion=2022-11-28
 
 // These are all node.js modules needed for the action to work
+// dummy comment to trigger a github change
 const core = require('@actions/core'); // Core utilities for I/O
 const github = require('@actions/github'); // GitHub API client
 const fs = require('fs'); // File system operations

--- a/.github/actions/analyze-workflow-data/lib/error-processing.js
+++ b/.github/actions/analyze-workflow-data/lib/error-processing.js
@@ -431,26 +431,10 @@ async function fetchErrorSnippetsForRun(runId, maxSnippets = 50, logsDirPath = u
               }
               core.info(`[OTHER LOGS] Using ${jobsMap.size} job name(s) from GitHub API for run ${runId} (no URLs - old format)`);
             } else {
-              // Fallback: extract job names from file paths (legacy method, less reliable)
-              const files = Array.isArray(logsListData.files) ? logsListData.files : [];
-              core.info(`[OTHER LOGS] No API job names found, falling back to file path extraction: ${files.length} files`);
-              for (const filePath of files) {
-                try {
-                  // Parse the path to extract job name
-                  // Expected format: extract/<step>_<job-name>/<file>.txt
-                  const parts = filePath.split(path.sep);
-                  if (parts.length >= 2) {
-                    const folderName = parts[1];
-                    let jobName = folderName.replace(/^\d+_/, '');
-                    jobName = jobName.replace(/\.txt$/i, '');
-                    jobName = jobName.replace(/\s+_\s+/g, ' / ').trim();
-                    if (jobName) {
-                      jobsMap.set(jobName, '');
-                    }
-                  }
-                } catch (_) { /* ignore */ }
-              }
-              core.info(`[OTHER LOGS] Extracted ${jobsMap.size} job name(s) from file paths for run ${runId}`);
+              // No API job names available - skip file path extraction as it cannot
+              // distinguish passing from failing jobs and produces false positives.
+              // Fall through to the annotations path instead.
+              core.info(`[OTHER LOGS] No API job names found for run ${runId}, skipping file path extraction (unreliable). Will fall through to annotations.`);
             }
 
             // Create snippets with job names and URLs

--- a/.github/actions/trigger-auto-triage-for-regressions/index.js
+++ b/.github/actions/trigger-auto-triage-for-regressions/index.js
@@ -2,6 +2,8 @@ const core = require('@actions/core');
 const github = require('@actions/github');
 const https = require('https');
 
+const MAX_JOBS_PER_WORKFLOW = 5;
+
 /**
  * Send a Slack message to a thread
  * @param {string} channelId - Slack channel ID
@@ -98,11 +100,11 @@ async function run() {
         .replace(/^\.github\/workflows\//, '')
         .replace(/\.ya?ml$/i, '');
 
-      const failingJobs = workflow.failing_jobs || [];
+      const allFailingJobs = workflow.failing_jobs || [];
 
-      core.info(`Processing workflow: ${workflowFileName} with ${failingJobs.length} failing job(s)`);
+      core.info(`Processing workflow: ${workflowFileName} with ${allFailingJobs.length} failing job(s)`);
 
-      if (failingJobs.length === 0) {
+      if (allFailingJobs.length === 0) {
         core.warning(`No failing jobs found for workflow: ${workflowFileName}`);
 
         // Send Slack notification if credentials are available
@@ -116,6 +118,20 @@ async function run() {
           }
         }
         continue;
+      }
+
+      const failingJobs = allFailingJobs.slice(0, MAX_JOBS_PER_WORKFLOW);
+      if (allFailingJobs.length > MAX_JOBS_PER_WORKFLOW) {
+        core.warning(`Workflow ${workflowFileName} has ${allFailingJobs.length} failing jobs, capping auto-triage to first ${MAX_JOBS_PER_WORKFLOW} to control cost`);
+        if (slackTs && slackChannelId && slackBotToken) {
+          try {
+            const skipped = allFailingJobs.length - MAX_JOBS_PER_WORKFLOW;
+            const message = `⚠️ \`${workflowFileName}\` has ${allFailingJobs.length} failing jobs. Auto-triage capped to ${MAX_JOBS_PER_WORKFLOW} jobs (${skipped} skipped). This usually indicates a systemic issue or shared root cause.`;
+            await sendSlackMessage(slackChannelId, slackBotToken, message, slackTs);
+          } catch (error) {
+            core.warning(`Failed to send Slack cap notification: ${error.message}`);
+          }
+        }
       }
 
       for (const job of failingJobs) {


### PR DESCRIPTION
## Summary
- Remove the legacy file path extraction fallback in `fetchErrorSnippetsForRun` that was treating **all** log files in a workflow run zip as evidence of failing jobs. When `logs-list.json` lacked API-sourced job names (e.g. from cached older data), this fallback extracted job names from every `.txt` file in the zip—including logs from passing jobs—causing auto-triage to trigger for dozens of jobs that had actually passed.
- Add a `MAX_JOBS_PER_WORKFLOW = 5` safety cap in `trigger-auto-triage-for-regressions` to prevent runaway auto-triage dispatches, with a Slack notification when the cap is hit.

## Context
[Aggregate Workflow Data run #14888](https://github.com/tenstorrent/tt-metal/actions/runs/22325361135) triggered auto-triage on ~20 passing jobs in "All post-commit tests" because the file path extraction fallback produced false positives. The only actually failing job (T3000 fast tests) wasn't even detected.

## Test plan
- [x] Verified the file path fallback was the code path taken (logs showed `No API job names found, falling back to file path extraction: 29 files`)
- [ ] Monitor next few aggregate workflow runs to confirm regressions are detected correctly without false positives
- [ ] Verify the cap works if a genuine multi-job regression occurs

Made with [Cursor](https://cursor.com)