### PR TITLE
Assert teardown order

### DIFF
--- a/tt_metal/impl/device/device_manager.cpp
+++ b/tt_metal/impl/device/device_manager.cpp
@@ -693,10 +693,11 @@ bool DeviceManager::close_devices(const std::vector<IDevice*>& devices, bool /*s
     }
 
     // Order matters
-    initializers_[DispatchKernelInitializer::key]->teardown();
-    initializers_[FabricFirmwareInitializer::key]->teardown();
-    initializers_[ProfilerInitializer::key]->teardown();
-    initializers_[CommandQueueInitializer::key]->teardown();
+    initializers_[DispatchKernelInitializer::key]->teardown(init_done_);
+    initializers_[FabricFirmwareInitializer::key]->teardown(init_done_);
+    initializers_[ProfilerInitializer::key]->teardown(init_done_);
+    initializers_[CommandQueueInitializer::key]->teardown(init_done_);
+    TT_FATAL(init_done_.empty(), "All firmware initializers must remove themselves from init_done_ during teardown");
 
     initializers_[DispatchKernelInitializer::key]->post_teardown();
     initializers_[FabricFirmwareInitializer::key]->post_teardown();
@@ -723,6 +724,7 @@ DeviceManager::~DeviceManager() {
     }
     this->devices_.clear();
     init_done_.clear();
+    TT_FATAL(init_done_.empty(), "All firmware initializers must remove themselves from init_done_ during teardown");
     initializers_.clear();
     descriptor_.reset();
 }

--- a/tt_metal/impl/device/device_manager.cpp
+++ b/tt_metal/impl/device/device_manager.cpp
@@ -693,12 +693,19 @@ bool DeviceManager::close_devices(const std::vector<IDevice*>& devices, bool /*s
     }
 
     // Order matters
+    TT_ASSERT(init_done_.contains(DispatchKernelInitializer::key));
     initializers_[DispatchKernelInitializer::key]->teardown(init_done_);
-    initializers_[FabricFirmwareInitializer::key]->teardown(init_done_);
-    initializers_[ProfilerInitializer::key]->teardown(init_done_);
-    initializers_[CommandQueueInitializer::key]->teardown(init_done_);
-    TT_FATAL(init_done_.empty(), "All firmware initializers must remove themselves from init_done_ during teardown");
 
+    TT_ASSERT(init_done_.contains(FabricFirmwareInitializer::key));
+    initializers_[FabricFirmwareInitializer::key]->teardown(init_done_);
+
+    TT_ASSERT(init_done_.contains(ProfilerInitializer::key));
+    initializers_[ProfilerInitializer::key]->teardown(init_done_);
+
+    TT_ASSERT(init_done_.contains(CommandQueueInitializer::key));
+    initializers_[CommandQueueInitializer::key]->teardown(init_done_);
+
+    TT_FATAL(init_done_.empty(), "All firmware initializers must remove themselves from init_done_ during teardown");
     initializers_[DispatchKernelInitializer::key]->post_teardown();
     initializers_[FabricFirmwareInitializer::key]->post_teardown();
     initializers_[ProfilerInitializer::key]->post_teardown();

--- a/tt_metal/impl/device/firmware/command_queue_initializer.cpp
+++ b/tt_metal/impl/device/firmware/command_queue_initializer.cpp
@@ -59,9 +59,19 @@ void CommandQueueInitializer::init(
 
 void CommandQueueInitializer::configure() {}
 
-void CommandQueueInitializer::teardown() {
+void CommandQueueInitializer::teardown(std::unordered_set<InitializerKey>& init_done) {
+    TT_FATAL(
+        !init_done.contains(InitializerKey::Dispatch),
+        "CommandQueueInitializer must be torn down after DispatchKernelInitializer");
+    TT_FATAL(
+        !init_done.contains(InitializerKey::Fabric),
+        "CommandQueueInitializer must be torn down after FabricFirmwareInitializer");
+    TT_FATAL(
+        !init_done.contains(InitializerKey::Profiler),
+        "CommandQueueInitializer must be torn down after ProfilerInitializer");
     devices_.clear();
     initialized_ = false;
+    init_done.erase(key);
 }
 
 bool CommandQueueInitializer::is_initialized() const { return initialized_; }

--- a/tt_metal/impl/device/firmware/command_queue_initializer.hpp
+++ b/tt_metal/impl/device/firmware/command_queue_initializer.hpp
@@ -16,7 +16,7 @@ public:
 
     void init(const std::vector<Device*>& devices, const std::unordered_set<InitializerKey>& init_done) override;
     void configure() override;
-    void teardown() override;
+    void teardown(std::unordered_set<InitializerKey>& init_done) override;
     bool is_initialized() const override;
 
 private:

--- a/tt_metal/impl/device/firmware/dispatch_kernel_initializer.cpp
+++ b/tt_metal/impl/device/firmware/dispatch_kernel_initializer.cpp
@@ -97,13 +97,16 @@ void DispatchKernelInitializer::configure() {
     initialized_ = true;
 }
 
-void DispatchKernelInitializer::teardown() {
+void DispatchKernelInitializer::teardown(std::unordered_set<InitializerKey>& init_done) {
+    // Dispatch is torn down first; no prior teardown order to assert.
     if (!using_fast_dispatch()) {
+        init_done.erase(key);
         return;
     }
 
     // Mock devices don't have sysmem_manager, skip FD teardown
     if (descriptor_->is_mock_device()) {
+        init_done.erase(key);
         return;
     }
 
@@ -114,6 +117,7 @@ void DispatchKernelInitializer::teardown() {
 
     devices_.clear();
     initialized_ = false;
+    init_done.erase(key);
 }
 
 bool DispatchKernelInitializer::is_initialized() const { return initialized_; }

--- a/tt_metal/impl/device/firmware/dispatch_kernel_initializer.hpp
+++ b/tt_metal/impl/device/firmware/dispatch_kernel_initializer.hpp
@@ -26,7 +26,7 @@ public:
 
     void init(const std::vector<Device*>& devices, const std::unordered_set<InitializerKey>& init_done) override;
     void configure() override;
-    void teardown() override;
+    void teardown(std::unordered_set<InitializerKey>& init_done) override;
     // Returns true if fast dispatch is enabled and has been configured
     bool is_initialized() const override;
     const std::unordered_set<CoreCoord>& get_virtual_dispatch_cores(ChipId dev_id) const;

--- a/tt_metal/impl/device/firmware/fabric_firmware_initializer.cpp
+++ b/tt_metal/impl/device/firmware/fabric_firmware_initializer.cpp
@@ -62,10 +62,14 @@ void FabricFirmwareInitializer::configure() {
     initialized_ = true;
 }
 
-void FabricFirmwareInitializer::teardown() {
+void FabricFirmwareInitializer::teardown(std::unordered_set<InitializerKey>& init_done) {
+    TT_FATAL(
+        !init_done.contains(InitializerKey::Dispatch),
+        "FabricFirmwareInitializer must be torn down after DispatchKernelInitializer");
     if (!has_flag(descriptor_->fabric_manager(), tt_fabric::FabricManagerMode::TERMINATE_FABRIC)) {
         devices_.clear();
         initialized_ = false;
+        init_done.erase(key);
         return;
     }
 
@@ -73,6 +77,7 @@ void FabricFirmwareInitializer::teardown() {
     if (!tt_fabric::is_tt_fabric_config(fabric_config)) {
         devices_.clear();
         initialized_ = false;
+        init_done.erase(key);
         return;
     }
 
@@ -123,6 +128,7 @@ void FabricFirmwareInitializer::teardown() {
 
     devices_.clear();
     initialized_ = false;
+    init_done.erase(key);
 }
 
 void FabricFirmwareInitializer::post_teardown() {

--- a/tt_metal/impl/device/firmware/fabric_firmware_initializer.hpp
+++ b/tt_metal/impl/device/firmware/fabric_firmware_initializer.hpp
@@ -23,7 +23,7 @@ public:
     void init(const std::vector<Device*>& devices, [[maybe_unused]] const std::unordered_set<InitializerKey>& init_done)
         override;
     void configure() override;
-    void teardown() override;
+    void teardown(std::unordered_set<InitializerKey>& init_done) override;
     void post_teardown() override;
     bool is_initialized() const override;
 

--- a/tt_metal/impl/device/firmware/firmware_initializer.hpp
+++ b/tt_metal/impl/device/firmware/firmware_initializer.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <memory>
+#include <unordered_set>
 #include <vector>
 
 #include <llrt/rtoptions.hpp>
@@ -40,7 +41,7 @@ public:
     // This is called after all init calls have completed
     virtual void configure() = 0;
 
-    virtual void teardown() = 0;
+    virtual void teardown(std::unordered_set<InitializerKey>& init_done) = 0;
 
     // This is called after all teardown calls have completed and devices have been closed
     virtual void post_teardown();

--- a/tt_metal/impl/device/firmware/profiler_initializer.hpp
+++ b/tt_metal/impl/device/firmware/profiler_initializer.hpp
@@ -21,7 +21,7 @@ public:
 
     void init(const std::vector<Device*>& devices, const std::unordered_set<InitializerKey>& init_done) override;
     void configure() override;
-    void teardown() override;
+    void teardown(std::unordered_set<InitializerKey>& init_done) override;
     void post_teardown() override;
     bool is_initialized() const override;
 


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/37247

### Problem description
The init/teardown order is complicated so we have asserts to ensure the init order is correct, but we don't have asserts for the teardown order

### What's changed
Add assertions
Assert all initializers have cleared their init key

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=nhuang/assert-teardown-order)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:nhuang/assert-teardown-order)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=nhuang/assert-teardown-order)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:nhuang/assert-teardown-order)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nhuang/assert-teardown-order)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nhuang/assert-teardown-order)
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nhuang/assert-teardown-order)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nhuang/assert-teardown-order)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nhuang/assert-teardown-order)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nhuang/assert-teardown-order)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nhuang/assert-teardown-order)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nhuang/assert-teardown-order)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
