### PR TITLE
Remove git hash from kernel JIT cache path

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -365,6 +365,7 @@ class CMakeBuild(build_ext):
             "third_party/tt_llk/**/*",
             "tools/profiler/**/*",
             "soc_descriptors/*.yaml",
+            "sfpi-version",
         ]
         copy_tree_with_patterns(build_dir / get_lib_dir(), self.build_lib + f"/ttnn/build/lib", lib_patterns)
         copy_tree_with_patterns(build_dir, self.build_lib + "/ttnn/build/lib", ["sfpi-version.json"])

--- a/tt_metal/CMakeLists.txt
+++ b/tt_metal/CMakeLists.txt
@@ -238,6 +238,8 @@ target_sources(
             kernels/dataflow/writer_unary.cpp
             kernels/dataflow/writer_unary_1.cpp
             ${TT_LLK_HEADERS}
+            # SFPI Version for kernel caching
+            sfpi-version
 )
 
 include(CheckFunctionExists)

--- a/tt_metal/jit_build/CMakeLists.txt
+++ b/tt_metal/jit_build/CMakeLists.txt
@@ -29,10 +29,6 @@ target_link_libraries(
         TT::Metalium::HostDevCommon
 )
 
-if(DEFINED VERSION_HASH)
-    target_compile_definitions(jit_build PRIVATE "-DGIT_COMMIT_HASH=\"${VERSION_HASH}\"")
-endif()
-
 if(ENABLE_FAKE_KERNELS_TARGET)
     add_subdirectory(fake_kernels_target)
 endif()

--- a/tt_metal/jit_build/build.cpp
+++ b/tt_metal/jit_build/build.cpp
@@ -130,6 +130,20 @@ void JitBuildEnv::init(
         TT_THROW("sfpi not found at {} or {}", sfpi_roots[0], sfpi_roots[1]);
     }
 
+    // Read the sfpi version file tracked in the repo.  This captures the
+    // toolchain version (e.g. "sfpi_version='7.25.0'", "sfpi_build='252'")
+    // so that upgrading sfpi invalidates the build cache.
+    std::string sfpi_version_contents;
+    {
+        std::string sfpi_version_path = this->root_ + "tt_metal/sfpi-version";
+        std::ifstream ifs(sfpi_version_path);
+        if (ifs.is_open()) {
+            std::ostringstream oss;
+            oss << ifs.rdbuf();
+            sfpi_version_contents = oss.str();
+        }
+    }
+
     // Flags
     string common_flags = "-std=c++17 -flto=auto -ffast-math -fno-exceptions ";
 
@@ -281,6 +295,7 @@ void JitBuildEnv::init(
     hasher.update(cflags_);
     hasher.update(lflags_);
     hasher.update(defines_);
+    hasher.update(sfpi_version_contents);
     build_key_ = hasher.digest();
 
     this->out_firmware_root_ = fmt::format("{}{}/firmware/", this->out_root_, build_key_);
@@ -441,7 +456,8 @@ bool JitBuildState::build_state_matches(const string& out_dir) const {
 }
 
 void JitBuildState::write_build_state_hash(const string& out_dir) const {
-    std::ofstream file(out_dir + string(BUILD_STATE_HASH_FILE));
+    jit_build::utils::FileRenamer tmp(out_dir + string(BUILD_STATE_HASH_FILE));
+    std::ofstream file(tmp.path());
     file << build_state_hash_;
 }
 

--- a/tt_metal/jit_build/build.cpp
+++ b/tt_metal/jit_build/build.cpp
@@ -548,17 +548,13 @@ bool JitBuildState::need_compile(const string& out_dir, const string& obj) const
 }
 
 std::bitset<JitBuildState::kMaxBuildBitset> JitBuildState::compile(
-    const string& out_dir, const JitBuildSettings* settings) const {
+    const string& out_dir, const JitBuildSettings* settings, bool state_changed) const {
     // ZoneScoped;
     TT_FATAL(
         this->srcs_.size() <= kMaxBuildBitset,
         "Number of source files ({}) exceeds kMaxBuildBitset ({})",
         this->srcs_.size(),
         kMaxBuildBitset);
-
-    // Check if build parameters (flags, defines, includes populated by HAL, etc.) have changed.
-    // If so, all objects in this directory must be recompiled regardless of file-level dependency status.
-    bool state_changed = !build_state_matches(out_dir);
 
     std::bitset<kMaxBuildBitset> compiled;
     std::vector<std::shared_future<void>> events;
@@ -581,8 +577,7 @@ std::bitset<JitBuildState::kMaxBuildBitset> JitBuildState::compile(
 
 bool JitBuildState::need_link(const string& out_dir) const {
     std::string elf_path = out_dir + this->target_name_ + ".elf";
-    return !fs::exists(elf_path) || !build_state_matches(out_dir) ||
-           !jit_build::dependencies_up_to_date(out_dir, elf_path);
+    return !fs::exists(elf_path) || !jit_build::dependencies_up_to_date(out_dir, elf_path);
 }
 
 void JitBuildState::link(const string& out_dir, const JitBuildSettings* settings, const string& link_objs) const {
@@ -683,7 +678,12 @@ void JitBuildState::build(const JitBuildSettings* settings, std::span<const JitB
     const size_t num_objs = this->objs_.size();
 
     fs::create_directories(out_dir);
-    auto compiled = compile(out_dir, settings);
+
+    // Check build state once: if build parameters (flags, defines, includes from HAL, etc.)
+    // have changed, force full recompilation and relinking.
+    bool state_changed = !build_state_matches(out_dir);
+
+    auto compiled = compile(out_dir, settings, state_changed);
 
     string link_objs;
     // Populate link_objs once only when anything needs to be linked
@@ -710,7 +710,7 @@ void JitBuildState::build(const JitBuildSettings* settings, std::span<const JitB
     for (const auto* target : link_targets) {
         string target_out_dir = fmt::format("{}{}{}/", target->out_path_, kernel_name, target->target_name_);
         fs::create_directories(target_out_dir);
-        if (compiled.any() || target->need_link(target_out_dir)) {
+        if (state_changed || compiled.any() || target->need_link(target_out_dir)) {
             populate_link_objs();
             target->link(target_out_dir, settings, link_objs);
             if (target->is_fw_) {

--- a/tt_metal/jit_build/build.cpp
+++ b/tt_metal/jit_build/build.cpp
@@ -740,12 +740,6 @@ void JitBuildState::build(const JitBuildSettings* settings, std::span<const JitB
         }
     }
 
-    // Record the build state used for compilation so that future runs can detect
-    // when compile-affecting flags (cflags, defines, includes from HAL, etc.) change.
-    if (compiled.any()) {
-        write_build_state_hash(out_dir);
-    }
-
     // `extract_zone_src_locations` must be called every time, because it writes to a global file
     // that gets cleared in each run.
     extract_zone_src_locations(out_dir);

--- a/tt_metal/jit_build/build.cpp
+++ b/tt_metal/jit_build/build.cpp
@@ -68,12 +68,6 @@ void write_successful_jit_build_marker(const JitBuildState& build, const JitBuil
     std::ofstream file(out_dir + SUCCESSFUL_JIT_BUILD_MARKER_FILE_NAME);
 }
 
-void check_built_dir(const std::filesystem::path& dir_path, const std::filesystem::path& git_hash_path) {
-    if (dir_path.compare(git_hash_path) != 0) {
-        std::filesystem::remove_all(dir_path);
-    }
-}
-
 void hard_link_or_copy(const std::filesystem::path& target, const std::filesystem::path& link) {
     std::error_code ec;
     std::filesystem::create_hard_link(target, link, ec);
@@ -107,24 +101,6 @@ void JitBuildEnv::init(
 
     this->arch_ = arch;
     this->max_cbs_ = max_cbs;
-
-#ifndef GIT_COMMIT_HASH
-    log_info(tt::LogBuildKernels, "GIT_COMMIT_HASH not found");
-#else
-    std::string git_hash(GIT_COMMIT_HASH);
-
-    std::filesystem::path git_hash_path(this->out_root_ + git_hash);
-    std::filesystem::path root_path(this->out_root_);
-    if ((not rtoptions.get_skip_deleting_built_cache()) && std::filesystem::exists(root_path)) {
-        std::ranges::for_each(std::filesystem::directory_iterator{root_path}, [&git_hash_path](const auto& dir_entry) {
-            check_built_dir(dir_entry.path(), git_hash_path);
-        });
-    } else {
-        log_info(tt::LogBuildKernels, "Skipping deleting built cache");
-    }
-
-    this->out_root_ = this->out_root_ + git_hash + "/";
-#endif
 
     // Tools
     const static bool use_ccache = std::getenv("TT_METAL_CCACHE_KERNEL_SUPPORT") != nullptr;

--- a/tt_metal/jit_build/build.cpp
+++ b/tt_metal/jit_build/build.cpp
@@ -395,6 +395,54 @@ JitBuildState::JitBuildState(const JitBuildEnv& env, const JitBuiltStateConfig& 
     // Note the preceding slash which defies convention as this gets appended to
     // the kernel name used as a path which doesn't have a slash
     this->target_full_path_ = "/" + this->target_name_ + "/" + this->target_name_ + ".elf";
+
+    // Compute a hash of all effective compilation/linking parameters.
+    // This captures HAL-populated flags (defines, includes, common_flags, linker_flags, etc.)
+    // that are not part of the env-level build_key_.  When any of these change between runs
+    // (e.g. after a code change that modifies HAL output), the hash changes and cached
+    // objects are invalidated, preventing stale binaries from being reused.
+    {
+        tt::FNV1a hasher;
+        hasher.update(env_.gpp_);
+        hasher.update(cflags_);
+        hasher.update(defines_);
+        hasher.update(includes_);
+        hasher.update(lflags_);
+        hasher.update(linker_script_);
+        hasher.update(extra_link_objs_);
+        for (const auto& src : srcs_) {
+            hasher.update(src);
+        }
+        hasher.update(default_compile_opt_level_);
+        hasher.update(default_linker_opt_level_);
+        build_state_hash_ = hasher.digest();
+    }
+}
+
+static constexpr std::string_view BUILD_STATE_HASH_FILE = ".build_state";
+
+bool JitBuildState::build_state_matches(const string& out_dir) const {
+    std::ifstream file(out_dir + string(BUILD_STATE_HASH_FILE));
+    if (!file.is_open()) {
+        return false;
+    }
+    uint64_t stored_hash{};
+    file >> stored_hash;
+    if (file.fail() || stored_hash != build_state_hash_) {
+        log_debug(
+            tt::LogBuildKernels,
+            "Build state hash mismatch in {}: stored={}, current={}",
+            out_dir,
+            stored_hash,
+            build_state_hash_);
+        return false;
+    }
+    return true;
+}
+
+void JitBuildState::write_build_state_hash(const string& out_dir) const {
+    std::ofstream file(out_dir + string(BUILD_STATE_HASH_FILE));
+    file << build_state_hash_;
 }
 
 void JitBuildState::compile_one(const string& out_dir, const JitBuildSettings* settings, size_t src_index) const {
@@ -492,10 +540,14 @@ std::bitset<JitBuildState::kMaxBuildBitset> JitBuildState::compile(
         this->srcs_.size(),
         kMaxBuildBitset);
 
+    // Check if build parameters (flags, defines, includes populated by HAL, etc.) have changed.
+    // If so, all objects in this directory must be recompiled regardless of file-level dependency status.
+    bool state_changed = !build_state_matches(out_dir);
+
     std::bitset<kMaxBuildBitset> compiled;
     std::vector<std::shared_future<void>> events;
     for (size_t i = 0; i < this->srcs_.size(); ++i) {
-        if (need_compile(out_dir, this->objs_[i])) {
+        if (state_changed || need_compile(out_dir, this->objs_[i])) {
             compiled.set(i);
             launch_build_step([this, &out_dir, settings, i] { this->compile_one(out_dir, settings, i); }, events);
         } else {
@@ -513,7 +565,8 @@ std::bitset<JitBuildState::kMaxBuildBitset> JitBuildState::compile(
 
 bool JitBuildState::need_link(const string& out_dir) const {
     std::string elf_path = out_dir + this->target_name_ + ".elf";
-    return !fs::exists(elf_path) || !jit_build::dependencies_up_to_date(out_dir, elf_path);
+    return !fs::exists(elf_path) || !build_state_matches(out_dir) ||
+           !jit_build::dependencies_up_to_date(out_dir, elf_path);
 }
 
 void JitBuildState::link(const string& out_dir, const JitBuildSettings* settings, const string& link_objs) const {
@@ -647,6 +700,9 @@ void JitBuildState::build(const JitBuildSettings* settings, std::span<const JitB
             if (target->is_fw_) {
                 target->weaken(target_out_dir);
             }
+            // Record the build state used for linking so that future runs can detect
+            // when link-affecting flags (lflags, linker script, etc.) change.
+            target->write_build_state_hash(target_out_dir);
         }
     }
 
@@ -666,6 +722,12 @@ void JitBuildState::build(const JitBuildSettings* settings, std::span<const JitB
                 fs::remove(src_path);
             }
         }
+    }
+
+    // Record the build state used for compilation so that future runs can detect
+    // when compile-affecting flags (cflags, defines, includes from HAL, etc.) change.
+    if (compiled.any()) {
+        write_build_state_hash(out_dir);
     }
 
     // `extract_zone_src_locations` must be called every time, because it writes to a global file

--- a/tt_metal/jit_build/build.hpp
+++ b/tt_metal/jit_build/build.hpp
@@ -128,9 +128,17 @@ protected:
     // Used when JitBuildSettings is not provided
     std::string default_linker_opt_level_;
 
+    // Hash of all effective compilation/linking parameters (including HAL-populated flags).
+    // Used to detect when build flags change between runs so that stale cached objects
+    // are not reused.  Written to a ".build_state" file in the output directory.
+    uint64_t build_state_hash_{};
+
     // Upper bound for compile objects.
     // Current max obj count is 2 -- very sufficient for now.
     static constexpr size_t kMaxBuildBitset = 64;
+
+    bool build_state_matches(const std::string& out_dir) const;
+    void write_build_state_hash(const std::string& out_dir) const;
 
     bool need_compile(const std::string& out_dir, const std::string& obj) const;
     std::bitset<kMaxBuildBitset> compile(const std::string& out_dir, const JitBuildSettings* settings) const;

--- a/tt_metal/jit_build/build.hpp
+++ b/tt_metal/jit_build/build.hpp
@@ -141,7 +141,8 @@ protected:
     void write_build_state_hash(const std::string& out_dir) const;
 
     bool need_compile(const std::string& out_dir, const std::string& obj) const;
-    std::bitset<kMaxBuildBitset> compile(const std::string& out_dir, const JitBuildSettings* settings) const;
+    std::bitset<kMaxBuildBitset> compile(
+        const std::string& out_dir, const JitBuildSettings* settings, bool state_changed) const;
     void compile_one(const std::string& out_dir, const JitBuildSettings* settings, size_t src_index) const;
     bool need_link(const std::string& out_dir) const;
     void link(const std::string& out_dir, const JitBuildSettings* settings, const std::string& link_objs) const;

--- a/tt_metal/llrt/rtoptions.cpp
+++ b/tt_metal/llrt/rtoptions.cpp
@@ -70,38 +70,37 @@ enum class EnvVarID {
     // ========================================
     // DEBUG & TESTING
     // ========================================
-    TT_METAL_WATCHER_TEST_MODE,          // Enable watcher test mode
-    TT_METAL_KERNEL_MAP,                 // Enable kernel build mapping
-    TT_METAL_DISPATCH_DATA_COLLECTION,   // Enable dispatch debug data collection
-    TT_METAL_GTEST_ETH_DISPATCH,         // Use Ethernet cores for dispatch in tests
-    TT_METAL_SKIP_LOADING_FW,            // Skip firmware loading
-    TT_METAL_SKIP_DELETING_BUILT_CACHE,  // Skip cache deletion on cleanup
-    TT_METAL_DISABLE_XIP_DUMP,           // Disable XIP dump
+    TT_METAL_WATCHER_TEST_MODE,         // Enable watcher test mode
+    TT_METAL_KERNEL_MAP,                // Enable kernel build mapping
+    TT_METAL_DISPATCH_DATA_COLLECTION,  // Enable dispatch debug data collection
+    TT_METAL_GTEST_ETH_DISPATCH,        // Use Ethernet cores for dispatch in tests
+    TT_METAL_SKIP_LOADING_FW,           // Skip firmware loading
+    TT_METAL_DISABLE_XIP_DUMP,          // Disable XIP dump
 
     // ========================================
     // HARDWARE CONFIGURATION
     // ========================================
-    TT_METAL_ENABLE_HW_CACHE_INVALIDATION,  // Enable HW cache invalidation
-    TT_METAL_DISABLE_RELAXED_MEM_ORDERING,  // Disable relaxed memory ordering
-    TT_METAL_ENABLE_GATHERING,              // Enable instruction gathering
-    TT_METAL_FABRIC_BW_TELEMETRY,           // Enable fabric bandwidth telemetry
-    TT_METAL_FABRIC_TELEMETRY,              // Enable fabric telemetry
-    TT_FABRIC_PROFILE_RX_CH_FWD,            // Enable fabric RX channel forwarding profiling
-    TT_METAL_ENABLE_CHANNEL_TRIMMING_CAPTURE, // Enable channel trimming resource usage capture
-    TT_METAL_FABRIC_TRIMMING_PROFILE,         // Path to channel trimming profile YAML for import
-    TT_METAL_FORCE_REINIT,                  // Force context reinitialization
-    TT_METAL_DISABLE_FABRIC_TWO_ERISC,      // Disable fabric 2-ERISC mode
-    TT_METAL_LOG_KERNELS_COMPILE_COMMANDS,  // Log kernel compilation commands
-    TT_METAL_SLOW_DISPATCH_MODE,            // Use slow dispatch mode
-    TT_METAL_SKIP_ETH_CORES_WITH_RETRAIN,   // Skip Ethernet cores during retrain
-    TT_METAL_VALIDATE_PROGRAM_BINARIES,     // Validate kernel binary integrity
-    TT_METAL_DISABLE_DMA_OPS,               // Disable DMA operations
-    TT_METAL_ENABLE_ERISC_IRAM,             // Enable ERISC IRAM (inverted logic)
-    RELIABILITY_MODE,                       // Fabric reliability mode (strict/relaxed)
-    TT_METAL_DISABLE_MULTI_AERISC,          // Disable multi-erisc mode (inverted logic, enabled by default)
-    TT_METAL_USE_MGD_2_0,                   // Use mesh graph descriptor 2.0
-    TT_METAL_FORCE_JIT_COMPILE,             // Force JIT compilation
-    TT_METAL_DISABLE_SFPLOADMACRO,          // Disable use of SFPLOADMACRO instructions
+    TT_METAL_ENABLE_HW_CACHE_INVALIDATION,     // Enable HW cache invalidation
+    TT_METAL_DISABLE_RELAXED_MEM_ORDERING,     // Disable relaxed memory ordering
+    TT_METAL_ENABLE_GATHERING,                 // Enable instruction gathering
+    TT_METAL_FABRIC_BW_TELEMETRY,              // Enable fabric bandwidth telemetry
+    TT_METAL_FABRIC_TELEMETRY,                 // Enable fabric telemetry
+    TT_FABRIC_PROFILE_RX_CH_FWD,               // Enable fabric RX channel forwarding profiling
+    TT_METAL_ENABLE_CHANNEL_TRIMMING_CAPTURE,  // Enable channel trimming resource usage capture
+    TT_METAL_FABRIC_TRIMMING_PROFILE,          // Path to channel trimming profile YAML for import
+    TT_METAL_FORCE_REINIT,                     // Force context reinitialization
+    TT_METAL_DISABLE_FABRIC_TWO_ERISC,         // Disable fabric 2-ERISC mode
+    TT_METAL_LOG_KERNELS_COMPILE_COMMANDS,     // Log kernel compilation commands
+    TT_METAL_SLOW_DISPATCH_MODE,               // Use slow dispatch mode
+    TT_METAL_SKIP_ETH_CORES_WITH_RETRAIN,      // Skip Ethernet cores during retrain
+    TT_METAL_VALIDATE_PROGRAM_BINARIES,        // Validate kernel binary integrity
+    TT_METAL_DISABLE_DMA_OPS,                  // Disable DMA operations
+    TT_METAL_ENABLE_ERISC_IRAM,                // Enable ERISC IRAM (inverted logic)
+    RELIABILITY_MODE,                          // Fabric reliability mode (strict/relaxed)
+    TT_METAL_DISABLE_MULTI_AERISC,             // Disable multi-erisc mode (inverted logic, enabled by default)
+    TT_METAL_USE_MGD_2_0,                      // Use mesh graph descriptor 2.0
+    TT_METAL_FORCE_JIT_COMPILE,                // Force JIT compilation
+    TT_METAL_DISABLE_SFPLOADMACRO,             // Disable use of SFPLOADMACRO instructions
 
     // ========================================
     // PROFILING & PERFORMANCE
@@ -503,12 +502,6 @@ void RunTimeOptions::HandleEnvVar(EnvVarID id, const char* value) {
         // Default: false (load firmware)
         // Usage: export TT_METAL_SKIP_LOADING_FW=1
         case EnvVarID::TT_METAL_SKIP_LOADING_FW: this->skip_loading_fw = true; break;
-
-        // TT_METAL_SKIP_DELETING_BUILT_CACHE
-        // Skip deleting built cache files on cleanup.
-        // Default: false (delete cache)
-        // Usage: export TT_METAL_SKIP_DELETING_BUILT_CACHE=1
-        case EnvVarID::TT_METAL_SKIP_DELETING_BUILT_CACHE: this->skip_deleting_built_cache = true; break;
 
         // ========================================
         // HARDWARE CONFIGURATION

--- a/tt_metal/llrt/rtoptions.hpp
+++ b/tt_metal/llrt/rtoptions.hpp
@@ -217,8 +217,6 @@ class RunTimeOptions {
 
     tt_metal::DispatchCoreType dispatch_core_type = tt_metal::DispatchCoreType::WORKER;
 
-    bool skip_deleting_built_cache = false;
-
     std::filesystem::path simulator_path = "";
 
     bool erisc_iram_enabled = false;
@@ -584,8 +582,6 @@ public:
     bool get_gathering_enabled() const { return this->enable_gathering; }
 
     tt_metal::DispatchCoreConfig get_dispatch_core_config() const;
-
-    bool get_skip_deleting_built_cache() const { return skip_deleting_built_cache; }
 
     bool get_simulator_enabled() const { return runtime_target_device_ == TargetDevice::Simulator; }
     const std::filesystem::path& get_simulator_path() const { return simulator_path; }


### PR DESCRIPTION
### Ticket
Related to #37869 (Enable kernel ccache)

### Problem description
The kernel JIT build cache organizes compiled artifacts under `~/.cache/tt-metal-cache/<git-hash>/<build-key>/...`. On startup, `JitBuildEnv::init()` iterates all directories under the cache root and **deletes every directory that does not match the current git commit hash**.

This has two consequences:
1. **Every new commit nukes the entire local kernel cache**, forcing full recompilation of all kernels — even when kernel sources have not changed at all.
2. **Cross-commit caching is impossible**, which makes ccache+Redis layer less effective for CI (PR #37869). On ephemeral CI runners the local cache is always empty.

The content-based `.dephash` invalidation system (`tt_metal/jit_build/depend.cpp`) already correctly handles staleness by hashing the actual content of source files and headers. However, some compilation flags — specifically those populated by HAL via `HalJitBuildQueryInterface` (defines, includes, common_flags, linker_flags, etc.) — were **not** captured by any cache invalidation mechanism. Previously the git-hash-based cache partitioning masked this gap, since any code change produced a new git hash and a fresh cache directory.

### What's changed

#### 1. Remove git hash from kernel JIT cache path

- **`tt_metal/jit_build/build.cpp`**: Removed the `#ifdef GIT_COMMIT_HASH` block in `JitBuildEnv::init()` that (a) deleted all cache directories not matching the current git hash, and (b) appended the git hash to `out_root_`. Also removed the now-unused `check_built_dir()` helper.
- **`tt_metal/jit_build/CMakeLists.txt`**: Removed the `GIT_COMMIT_HASH` compile definition — no longer consumed.
- **`tt_metal/llrt/rtoptions.hpp`** / **`tt_metal/llrt/rtoptions.cpp`**: Removed `skip_deleting_built_cache` field, its getter, the `TT_METAL_SKIP_DELETING_BUILT_CACHE` env var enum entry and handler — this was only used by the removed git-hash purging logic.

The cache path is now: `~/.cache/tt-metal-cache/<build_key>/kernels/...`

#### 2. Capture all build flags in a `.build_state` hash

To close the gap left by removing the git hash, a new `build_state_hash_` (FNV1a) is computed at the end of `JitBuildState` construction from **all effective compilation and linking parameters**, including HAL-populated flags that are not part of the env-level `build_key_`:

- Compiler path (`gpp_`)
- `cflags_`, `defines_`, `includes_` (after HAL additions)
- `lflags_`, `linker_script_`, `extra_link_objs_` (after HAL additions)
- All source file paths (`srcs_`)
- Default optimization levels

This hash is:

- **Written** to a `.build_state` file in the output directory after successful compilation/linking.
- **Checked** before reusing cached objects:
  - In `compile()` — a mismatch forces recompilation of all objects in the directory.
  - In `need_link()` — a mismatch forces relinking.

This complements the existing `.dephash` system: **`.dephash` detects source file content changes; `.build_state` detects flag/parameter changes.** Together they ensure the JIT cache is never stale, regardless of which git commit is checked out.

### Files changed

| File | Change |
|------|--------|
| `tt_metal/jit_build/build.cpp` | Remove git-hash cache purging and path; add `build_state_hash_` computation, `build_state_matches()`, `write_build_state_hash()`; check state in `compile()` and `need_link()`; write state after successful build |
| `tt_metal/jit_build/build.hpp` | Add `build_state_hash_` member, `build_state_matches()` and `write_build_state_hash()` declarations |
| `tt_metal/jit_build/CMakeLists.txt` | Remove `GIT_COMMIT_HASH` compile definition |
| `tt_metal/llrt/rtoptions.hpp` | Remove `skip_deleting_built_cache` field and getter |
| `tt_metal/llrt/rtoptions.cpp` | Remove `TT_METAL_SKIP_DELETING_BUILT_CACHE` env var handling |

### Checklist

- [x] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=blozano/remove-git-hash-from-kernel-cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:blozano/remove-git-hash-from-kernel-cache)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=blozano/remove-git-hash-from-kernel-cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:blozano/remove-git-hash-from-kernel-cache)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=blozano/remove-git-hash-from-kernel-cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:blozano/remove-git-hash-from-kernel-cache)
- [ ] New/Existing tests provide coverage for changes