### PR TITLE
implement new naming convention for storing ttnn weight files

### DIFF
--- a/models/demos/deepseek_v3/tests/test_decoder_block.py
+++ b/models/demos/deepseek_v3/tests/test_decoder_block.py
@@ -135,6 +135,9 @@ def run_test_forward_pass_decoder2d(
         cache_path,
         mesh_device,
         force_recalculate_weight_config,
+        test_name="test_decoder_block",
+        real_weights=module_path is not None,
+        layer_id=module_path,
     )
     model_config = get_model_config(DecoderBlockClass, mode, hf_config_short, mesh_device)
     model_state = DecoderBlockClass.create_state(

--- a/models/demos/deepseek_v3/tests/test_embedding.py
+++ b/models/demos/deepseek_v3/tests/test_embedding.py
@@ -88,7 +88,14 @@ def test_embedding_forward_pass(
     # Generate module configs and state
     logger.info("Setting up TTNN configs")
     weight_config = get_test_weight_config(
-        EmbeddingClass, hf_config, (state_dict,), cache_path, mesh_device, force_recalculate_weight_config
+        EmbeddingClass,
+        hf_config,
+        (state_dict,),
+        cache_path,
+        mesh_device,
+        force_recalculate_weight_config,
+        test_name="test_embedding",
+        real_weights=not generate_reference_io,
     )
     model_config = get_model_config(EmbeddingClass, mode, hf_config, mesh_device)
     model_state = EmbeddingClass.create_state(hf_config, mesh_device, ccl)

--- a/models/demos/deepseek_v3/tests/test_lm_head.py
+++ b/models/demos/deepseek_v3/tests/test_lm_head.py
@@ -79,7 +79,14 @@ def test_forward_pass(
     torch_input = pad_or_trim_seq_len(torch_input, mode, seq_len)
 
     weight_config = get_test_weight_config(
-        LMHead, hf_config, (state_dict,), cache_path, mesh_device, force_recalculate=False
+        LMHead,
+        hf_config,
+        (state_dict,),
+        cache_path,
+        mesh_device,
+        force_recalculate=False,
+        test_name="test_lm_head",
+        real_weights=False,
     )
     model_config = get_model_config(LMHead, mode, hf_config, mesh_device, 3)
     model_state = LMHead.create_state(hf_config, mesh_device, ccl)

--- a/models/demos/deepseek_v3/tests/test_lm_head1d.py
+++ b/models/demos/deepseek_v3/tests/test_lm_head1d.py
@@ -70,7 +70,14 @@ def test_forward_pass(
     reference_output = reference_model(torch_input)
 
     weight_config = get_test_weight_config(
-        LMHead1D, hf_config, (state_dict,), cache_path, mesh_device, force_recalculate=False
+        LMHead1D,
+        hf_config,
+        (state_dict,),
+        cache_path,
+        mesh_device,
+        force_recalculate=False,
+        test_name="test_lm_head1d",
+        real_weights=False,
     )
     model_config = get_model_config(LMHead1D, mode, mesh_device)
     model_state = LMHead1D.create_state(mesh_device, ccl)

--- a/models/demos/deepseek_v3/tests/test_mla.py
+++ b/models/demos/deepseek_v3/tests/test_mla.py
@@ -232,6 +232,9 @@ def run_test_forward_pass_mla2d(
         cache_path,
         mesh_device,
         force_recalculate_weight_config,
+        test_name="test_mla",
+        real_weights=module_path is not None,
+        layer_id=module_path,
     )
     model_config = get_model_config(MLA2D, mode, hf_config_short, mesh_device)
     model_state = MLA2D.create_state(hf_config_short, paged_config, mesh_device, ccl, paged_input_cache)

--- a/models/demos/deepseek_v3/tests/test_mlp.py
+++ b/models/demos/deepseek_v3/tests/test_mlp.py
@@ -183,7 +183,15 @@ def test_forward_pass(
 
     # Generate module configs and state
     weight_config = get_test_weight_config(
-        MLPClass, hf_config, (state_dict,) * num_module_layers, cache_path, mesh_device, force_recalculate_weight_config
+        MLPClass,
+        hf_config,
+        (state_dict,) * num_module_layers,
+        cache_path,
+        mesh_device,
+        force_recalculate_weight_config,
+        test_name="test_mlp",
+        real_weights=module_path is not None,
+        layer_id=module_path,
     )
     model_config = get_model_config(MLPClass, mode, hf_config, mesh_device)
     model_state = MLPClass.create_state(hf_config, mesh_device, ccl)

--- a/models/demos/deepseek_v3/tests/test_model.py
+++ b/models/demos/deepseek_v3/tests/test_model.py
@@ -439,7 +439,14 @@ def run_test_forward_pass_dpmodel(
         )
 
     weight_config = get_test_weight_config(
-        RowBatchedModel, hf_config_short, (state_dict,), cache_path, mesh_device, force_recalculate_weight_config
+        RowBatchedModel,
+        hf_config_short,
+        (state_dict,),
+        cache_path,
+        mesh_device,
+        force_recalculate_weight_config,
+        test_name="test_model",
+        real_weights=True,
     )
     model_config = get_model_config(RowBatchedModel, mode, hf_config_short, mesh_device)
     model_state = RowBatchedModel.create_state(hf_config_short, paged_config, mesh_device, ccl, paged_input_caches)

--- a/models/demos/deepseek_v3/tests/test_moe.py
+++ b/models/demos/deepseek_v3/tests/test_moe.py
@@ -85,7 +85,14 @@ def test_forward_pass(
         reference_output = reference_model(torch_input)
 
     weight_config = get_test_weight_config(
-        MoE, hf_config, (state_dict,), cache_path, mesh_device, force_recalculate=False
+        MoE,
+        hf_config,
+        (state_dict,),
+        cache_path,
+        mesh_device,
+        force_recalculate=False,
+        test_name="test_moe",
+        real_weights=False,
     )
 
     # Generate appropriate config using utility function

--- a/models/demos/deepseek_v3/tests/test_moe_experts.py
+++ b/models/demos/deepseek_v3/tests/test_moe_experts.py
@@ -118,7 +118,15 @@ def test_forward_pass(
         reference_model.load_state_dict(dequantize_state_dict(state_dict, hf_config))
 
     weight_config = get_test_weight_config(
-        TTExperts, hf_config, (state_dict,), cache_path, mesh_device, force_recalculate_weight_config
+        TTExperts,
+        hf_config,
+        (state_dict,),
+        cache_path,
+        mesh_device,
+        force_recalculate_weight_config,
+        test_name="test_moe_experts",
+        real_weights=weight_type == "real",
+        layer_id=module_path,
     )
     model_config = get_model_config(TTExperts, mode, hf_config, mesh_device)
     model_state = TTExperts.create_state(hf_config, mesh_device)

--- a/models/demos/deepseek_v3/tests/test_moe_gate.py
+++ b/models/demos/deepseek_v3/tests/test_moe_gate.py
@@ -53,7 +53,14 @@ def test_forward_pass(
     hf_state_dict = reference_model.state_dict()
 
     weight_config = get_test_weight_config(
-        MoEGate, hf_config, (hf_state_dict,), cache_path, mesh_device, force_recalculate=False
+        MoEGate,
+        hf_config,
+        (hf_state_dict,),
+        cache_path,
+        mesh_device,
+        force_recalculate=False,
+        test_name="test_moe_gate",
+        real_weights=False,
     )
 
     # Generate appropriate config using utility function

--- a/models/demos/deepseek_v3/tests/test_rms_norm.py
+++ b/models/demos/deepseek_v3/tests/test_rms_norm.py
@@ -103,6 +103,9 @@ def test_forward_pass(
         cache_path,
         mesh_device,
         force_recalculate_weight_config,
+        test_name="test_rms_norm",
+        real_weights=reference_layernorm_path is not None,
+        layer_id=reference_layernorm_path if reference_layernorm_path is not None else hf_config_size_attr,
     )
     model_config = get_model_config(RMSNormClass, mode, hf_config, mesh_device)
     model_state = RMSNormClass.create_state(

--- a/models/demos/deepseek_v3/utils/test_utils.py
+++ b/models/demos/deepseek_v3/utils/test_utils.py
@@ -686,7 +686,7 @@ def get_test_weight_config(
         weight_config_id = "/".join(parts)
     else:
         weight_config_id = os.environ.get("PYTEST_CURRENT_TEST", "unknown_test")
-    per_test_weight_cache_path = cache_path / "new_tests_cache" / weight_config_id
+    per_test_weight_cache_path = cache_path / "tests_cache" / weight_config_id
     return get_weight_config(
         ModuleClass, hf_config, state_dicts, per_test_weight_cache_path, mesh_device, force_recalculate
     )

--- a/models/demos/deepseek_v3/utils/test_utils.py
+++ b/models/demos/deepseek_v3/utils/test_utils.py
@@ -648,9 +648,45 @@ def get_test_weight_config(
     cache_path: Path,
     mesh_device: ttnn.Device,
     force_recalculate: bool,
+    *,
+    test_name: str | None = None,
+    real_weights: bool = True,
+    layer_id: str | int | None = None,
 ) -> Any:
-    """Get the weight config, either by loading from cache or recalculating."""
-    per_test_weight_cache_path = cache_path / "tests_cache" / os.environ.get("PYTEST_CURRENT_TEST")
+    """Get the weight config, either by loading from cache or recalculating.
+
+    When ``test_name`` is provided the cache sub-directory is derived from
+    weight-relevant parameters only (``test_name``, ``ModuleClass``,
+    ``real_weights``, ``layer_id``).  Runtime parameters that do **not**
+    affect weight conversion (mode, seq_len, batch_size, position_ids, …)
+    are intentionally excluded so that e.g. decode and prefill variants share
+    the same cached weights.
+
+    ``num_hidden_layers`` and ``mesh_shape`` are already captured by
+    :func:`get_weight_config` in its internal sub-path, so they are not
+    needed here either.
+
+    When ``test_name`` is ``None`` the function falls back to
+    ``PYTEST_CURRENT_TEST`` for backward compatibility.
+
+    Args:
+        test_name: Test file name (e.g. ``"test_embedding"``).
+        real_weights: ``True`` when using real model weights,
+            ``False`` for randomly-initialised weights.
+        layer_id: Identifies which layer / sub-module the weights come from.
+            Typically a module-path string (``"model.layers.0.mlp"``), an
+            integer layer index, or a descriptive qualifier for random weights
+            (``"kv_lora_rank"``).  ``None`` when no further distinction is
+            needed.
+    """
+    if test_name is not None:
+        parts = [test_name, ModuleClass.__name__, "real" if real_weights else "random"]
+        if layer_id is not None:
+            parts.append(str(layer_id))
+        weight_config_id = "/".join(parts)
+    else:
+        weight_config_id = os.environ.get("PYTEST_CURRENT_TEST", "unknown_test")
+    per_test_weight_cache_path = cache_path / "new_tests_cache" / weight_config_id
     return get_weight_config(
         ModuleClass, hf_config, state_dicts, per_test_weight_cache_path, mesh_device, force_recalculate
     )

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,5 @@
 [pytest]
-timeout = 300
+timeout = 5600
 minversion = 7.2
 addopts = --import-mode=importlib -vvs -rA --durations=0 --junitxml=generated/test_reports/most_recent_tests.xml
 empty_parameter_set_mark = skip

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,5 @@
 [pytest]
-timeout = 5600
+timeout = 300
 minversion = 7.2
 addopts = --import-mode=importlib -vvs -rA --durations=0 --junitxml=generated/test_reports/most_recent_tests.xml
 empty_parameter_set_mark = skip


### PR DESCRIPTION
This PR implements a new naming convention for storing ttnn weight files in DeepSeek V3 tests. The new convention organizes cached weights by test identity (test name, module class, weight type, and layer ID) rather than including runtime parameters like mode, sequence length, and batch size. This allows different test variants (e.g., decode and prefill modes) to share the same cached weights, improving cache efficiency and reducing storage requirements.

Changes:

Modified get_test_weight_config() to accept new keyword-only parameters (test_name, real_weights, layer_id) for constructing semantic cache paths
Changed cache directory from "tests_cache" to "new_tests_cache" to distinguish the new naming scheme
Updated all 11 test files that use get_test_weight_config() to provide the new parameters