### PR TITLE
Fix test_binary_maximum uint32 comparison after to_torch unsigned type change

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_maximum.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_maximum.py
@@ -63,7 +63,7 @@ def test_binary_max_int32(input_shapes, low_a, high_a, low_b, high_b, ttnn_dtype
         memory_config=ttnn.DRAM_MEMORY_CONFIG,
     )
     tt_result = ttnn.maximum(tt_in_a, tt_in_b)
-    output_tensor = ttnn.to_torch(tt_result)
+    output_tensor = ttnn.to_torch(tt_result).to(torch.int32)
     assert torch.equal(golden, output_tensor)
 
 
@@ -116,7 +116,7 @@ def test_binary_max_fill_val_int32(input_shapes, input_a_val, input_b_val, ttnn_
     )
 
     tt_result = ttnn.maximum(tt_in_a, tt_in_b)
-    output_tensor = ttnn.to_torch(tt_result)
+    output_tensor = ttnn.to_torch(tt_result).to(torch.int32)
     assert torch.equal(golden, output_tensor)
 
 
@@ -178,7 +178,7 @@ def test_binary_max_int32_bcast(input_shape_a, input_shape_b, low_a, high_a, low
         memory_config=ttnn.DRAM_MEMORY_CONFIG,
     )
     tt_result = ttnn.maximum(tt_in_a, tt_in_b, use_legacy=None)
-    output_tensor = ttnn.to_torch(tt_result)
+    output_tensor = ttnn.to_torch(tt_result).to(torch.int32)
     assert torch.equal(golden, output_tensor)
 
 
@@ -247,7 +247,7 @@ def test_binary_max_int32_opt(input_shapes, low_a, high_a, low_b, high_b, ttnn_d
     )
 
     ttnn.maximum(tt_in_a, tt_in_b, output_tensor=tt_out, queue_id=cq_id)
-    output_tensor = ttnn.to_torch(tt_out)
+    output_tensor = ttnn.to_torch(tt_out).to(torch.int32)
     assert torch.equal(golden, output_tensor)
 
 

--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_minimum.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_minimum.py
@@ -63,7 +63,7 @@ def test_binary_min_int32(input_shapes, low_a, high_a, low_b, high_b, ttnn_dtype
         memory_config=ttnn.DRAM_MEMORY_CONFIG,
     )
     tt_result = ttnn.minimum(tt_in_a, tt_in_b)
-    output_tensor = ttnn.to_torch(tt_result)
+    output_tensor = ttnn.to_torch(tt_result).to(torch.int32)
     assert torch.equal(golden, output_tensor)
 
 
@@ -116,7 +116,7 @@ def test_binary_min_fill_val_int32(input_shapes, input_a_val, input_b_val, ttnn_
     )
 
     tt_result = ttnn.minimum(tt_in_a, tt_in_b)
-    output_tensor = ttnn.to_torch(tt_result)
+    output_tensor = ttnn.to_torch(tt_result).to(torch.int32)
     assert torch.equal(golden, output_tensor)
 
 
@@ -176,7 +176,7 @@ def test_binary_min_int32_bcast(input_shape_a, input_shape_b, low_a, high_a, low
         memory_config=ttnn.DRAM_MEMORY_CONFIG,
     )
     tt_result = ttnn.minimum(tt_in_a, tt_in_b, use_legacy=None)
-    output_tensor = ttnn.to_torch(tt_result)
+    output_tensor = ttnn.to_torch(tt_result).to(torch.int32)
     assert torch.equal(golden, output_tensor)
 
 
@@ -246,7 +246,7 @@ def test_binary_min_int32_opt(input_shapes, low_a, high_a, low_b, high_b, ttnn_d
     )
 
     ttnn.minimum(tt_in_a, tt_in_b, output_tensor=tt_out, queue_id=cq_id)
-    output_tensor = ttnn.to_torch(tt_out)
+    output_tensor = ttnn.to_torch(tt_out).to(torch.int32)
     assert torch.equal(golden, output_tensor)
 
 


### PR DESCRIPTION
### Ticket

https://github.com/tenstorrent/tt-metal/issues/31150

### Problem description

PR #36660 ("Support uint16 and uint32 in to_torch") changed `ttnn.to_torch()` to return unsigned PyTorch dtypes (`torch.uint32`) for unsigned TTNN tensors. However, `tests/ttnn/unit_tests/operations/eltwise/test_binary_maximum.py` was missed during the test updates. This caused a CI failure in the `ttnn eltwise group 2 wormhole_b0 N300` job:

```
RuntimeError: Promotion for uint16, uint32, uint64 types is not supported, attempted to promote Int and UInt32
```

The error occurs because `torch.equal()` cannot compare `int32` (golden) with `uint32` (output from `to_torch`) tensors — PyTorch does not support type promotion for unsigned integer types.

**Failed CI run:** https://github.com/tenstorrent/tt-metal/actions/runs/22332128453/job/64621057925

### What's changed

Added `.to(torch.int32)` to all `ttnn.to_torch()` calls in the 4 int32/uint32 test functions in `test_binary_maximum.py`:

- `test_binary_max_int32` (line 66)
- `test_binary_max_fill_val_int32` (line 119)
- `test_binary_max_int32_bcast` (line 181)
- `test_binary_max_int32_opt` (line 250)

This matches the identical fix pattern used throughout PR #36660 in other test files (e.g., `test_binary_comp_init.py`, `test_argmax.py`, `test_unary.py`).

### Checklist

- [x] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=fix/test-binary-maximum-uint32-to-torch)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:fix/test-binary-maximum-uint32-to-torch)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=fix/test-binary-maximum-uint32-to-torch)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:fix/test-binary-maximum-uint32-to-torch)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=fix/test-binary-maximum-uint32-to-torch)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:fix/test-binary-maximum-uint32-to-torch)
- [x] New/Existing tests provide coverage for changes
