### PR TITLE
Add watcher circular buffer out-of-bounds sanitization

### DIFF
--- a/docs/source/tt-metalium/tools/watcher.rst
+++ b/docs/source/tt-metalium/tools/watcher.rst
@@ -15,6 +15,7 @@ of the device at the time of the hang. Watcher functionality includes:
 - Logged "waypoints" indicate which piece of code last executed on each RISC V
 - Sanitized NOC transactions prevent transactions with invalid coordinates or addresses from being submitted to the
   hardware and stops the offending RISC V via a soft hang
+- Circular buffer out-of-bounds detection for NOC transactions that touch an active CB
 - Memory corruption detection at address 0 of L1
 - Kernel paths and names of the currently executing kernel
 - Flags which indicate which RISC Vs are executing in the current kernel
@@ -47,6 +48,7 @@ Watcher features can be disabled individually using the following environment va
    export TT_METAL_WATCHER_DISABLE_WAYPOINT=1
    export TT_METAL_WATCHER_DISABLE_STACK_USAGE=1
    export TT_METAL_WATCHER_DISABLE_ETH_LINK_STATUS=1
+   export TT_METAL_WATCHER_DISABLE_CB_SANITIZE=1
 
    # This feature is opt-in, set the env var to enable it
    export TT_METAL_WATCHER_ENABLE_NOC_SANITIZE_LINKED_TRANSACTION=1
@@ -277,3 +279,26 @@ If the link is down, the kernel will hang and a message with the logical, virtua
 .. code-block::
 
     Device 0 acteth core(x= 0,y= 4) virtual(x=24,y=25): Watcher detected that active eth link on virtual core (x=24,y=25) (noc0 core: CoreCoord: (3, 1, ETH, NOC0)) went down after training.
+
+Circular Buffer Out-of-Bounds
+-----------------------------
+When NOC sanitization is enabled, the Watcher also checks that NOC read and write transactions which
+touch an active circular buffer stay within that buffer's allocated region. This catches cases where a
+kernel issues a NOC transfer that starts inside a CB but extends past its end, which can silently corrupt
+adjacent L1 memory.
+
+This check runs on BRISC and NCRISC only. It is enabled by default when the Watcher is on and can be
+disabled independently:
+
+.. code-block::
+
+   export TT_METAL_WATCHER_DISABLE_CB_SANITIZE=1
+
+If a violation is detected, the offending RISC V is stopped and an error is reported. Example output:
+
+.. code-block::
+
+    Device 0 worker core(x= 1,y= 0) virtual(x= 2,y= 2): NCRISC using noc0
+    tried to unicast read 112 bytes to local L1[0x17bce0] from Tensix core
+    w/ virtual coords (x=7,y=2) L1[addr=0x0017bf40]
+    (NOC transaction overflows a circular buffer).

--- a/tt_metal/hw/firmware/src/tt-1xx/brisc.cc
+++ b/tt_metal/hw/firmware/src/tt-1xx/brisc.cc
@@ -482,6 +482,14 @@ int main() {
             if (enables & (1u << index)) {
                 // Split 64-bit CB mask into 32-bit halves for efficient RISC-V processing
                 // Wormhole: lower half only (TRISC memory constraint), Blackhole: both halves
+
+#if defined(WATCHER_ENABLED) && !defined(WATCHER_DISABLE_CB_SANITIZE)
+                // Zero all CB interfaces so stale entries from previous programs
+                // don't cause false positives in the CB sanitize check.
+                for (uint32_t i = 0; i < NUM_CIRCULAR_BUFFERS; i++) {
+                    get_local_cb_interface(i).fifo_size = 0;
+                }
+#endif
                 uint64_t local_cb_mask = launch_msg_address->kernel_config.local_cb_mask;
                 uint32_t local_cb_mask_low = static_cast<uint32_t>(local_cb_mask & 0xFFFFFFFFULL);
                 setup_local_cb_read_write_interfaces<true, true, false, false>(cb_l1_base, 0, local_cb_mask_low);

--- a/tt_metal/hw/firmware/src/tt-1xx/ncrisc.cc
+++ b/tt_metal/hw/firmware/src/tt-1xx/ncrisc.cc
@@ -143,6 +143,14 @@ int main(int argc, char* argv[]) {
             (uint32_t tt_l1_ptr*)(kernel_config_base + launch_msg->kernel_config.local_cb_offset);
         // Split 64-bit CB mask into 32-bit halves for efficient RISC-V processing
         // Wormhole: lower half only (TRISC memory constraint), Blackhole: both halves
+
+#if defined(WATCHER_ENABLED) && !defined(WATCHER_DISABLE_CB_SANITIZE)
+        // Zero all CB interfaces so stale entries from previous programs
+        // don't cause false positives in the CB sanitize check.
+        for (uint32_t i = 0; i < NUM_CIRCULAR_BUFFERS; i++) {
+            get_local_cb_interface(i).fifo_size = 0;
+        }
+#endif
         uint64_t local_cb_mask = launch_msg->kernel_config.local_cb_mask;
         uint32_t local_cb_mask_low = static_cast<uint32_t>(local_cb_mask & 0xFFFFFFFFULL);
         setup_local_cb_read_write_interfaces<true, true, false, false>(cb_l1_base, 0, local_cb_mask_low);

--- a/tt_metal/hw/inc/hostdev/dev_msgs.h
+++ b/tt_metal/hw/inc/hostdev/dev_msgs.h
@@ -241,6 +241,7 @@ enum debug_sanitize_noc_return_code_enum {
     DebugSanitizeL1AddrOverflow = 14,
     DebugSanitizeEthSrcL1AddrOverflow = 15,
     DebugSanitizeEthDestL1AddrOverflow = 16,
+    DebugSanitizeCBOutOfBounds = 17,
 };
 
 struct debug_assert_msg_t {

--- a/tt_metal/hw/inc/internal/debug/sanitize.h
+++ b/tt_metal/hw/inc/internal/debug/sanitize.h
@@ -32,6 +32,9 @@
 #include "noc_parameters.h"
 #include "noc_nonblocking_api.h"
 #include "eth_l1_address_map.h"
+#if !defined(WATCHER_DISABLE_CB_SANITIZE)
+#include "internal/circular_buffer_interface.h"
+#endif
 
 // A couple defines for specifying read/write and multi/unicast
 #define DEBUG_SANITIZE_NOC_READ true
@@ -224,6 +227,36 @@ inline uint16_t debug_valid_eth_addr(uint64_t addr, uint64_t len, bool write) {
 #endif
     return DebugSanitizeOK;
 }
+
+#if !defined(WATCHER_DISABLE_CB_SANITIZE) && !defined(COMPILE_FOR_ERISC) && !defined(COMPILE_FOR_IDLE_ERISC)
+// Check whether an L1 address range [l1_addr, l1_addr+len) that falls within a
+// circular buffer stays within that buffer's allocated region.  Only runs on
+// BRISC/NCRISC where cb_addr_shift == 0 (addresses are in bytes).
+// Relies on unused CBs having fifo_size == 0 (cleared at kernel startup).
+inline uint16_t debug_valid_cb_addr(uint32_t l1_addr, uint32_t len) {
+    for (uint32_t i = 0; i < NUM_CIRCULAR_BUFFERS; i++) {
+        LocalCBInterface& cb = get_local_cb_interface(i);
+        if (cb.fifo_size == 0) {
+            continue;  // unused CB
+        }
+
+        uint32_t cb_start = cb.fifo_limit - cb.fifo_size;
+        uint32_t cb_end = cb.fifo_limit;
+
+        // Check if l1_addr falls inside this CB's region
+        if (l1_addr >= cb_start && l1_addr < cb_end) {
+            // Address is in this CB – verify the full transfer fits
+            // Use 64-bit arithmetic to avoid overflow on the end address.
+            if (static_cast<uint64_t>(l1_addr) + len > cb_end) {
+                return DebugSanitizeCBOutOfBounds;
+            }
+            return DebugSanitizeOK;
+        }
+    }
+    // Address is not inside any known CB; other checks will validate it.
+    return DebugSanitizeOK;
+}
+#endif  // !WATCHER_DISABLE_CB_SANITIZE && !COMPILE_FOR_ERISC
 
 // Note:
 //  - this isn't racy w/ the host so long as invalid is written last
@@ -466,6 +499,19 @@ void debug_sanitize_noc_and_worker_addr(
                 DebugSanitizeNocAlignment);
         }
     }
+
+#if !defined(WATCHER_DISABLE_CB_SANITIZE) && !defined(COMPILE_FOR_ERISC) && !defined(COMPILE_FOR_IDLE_ERISC)
+    // Check local L1 address against CB bounds (both read and write directions).
+    debug_sanitize_post_addr_and_hang(
+        noc_id,
+        noc_addr,
+        worker_addr,
+        len,
+        multicast,
+        dir,
+        DEBUG_SANITIZE_NOC_LOCAL,
+        debug_valid_cb_addr(worker_addr, len));
+#endif
 }
 
 void debug_throw_on_dram_addr(uint8_t noc_id, uint64_t addr, uint32_t len) {

--- a/tt_metal/impl/debug/watcher_device_reader.cpp
+++ b/tt_metal/impl/debug/watcher_device_reader.cpp
@@ -710,6 +710,10 @@ void WatcherDeviceReader::Core::DumpNocSanitizeStatus(int noc) const {
             error_msg = get_l1_target_str(programmable_core_type_, san);
             error_msg += " (ethernet send with L1 source overflow).";
             break;
+        case dev_msgs::DebugSanitizeCBOutOfBounds:
+            error_msg = get_noc_target_str(reader_.device_id, programmable_core_type_, noc, san);
+            error_msg += " (NOC transaction overflows a circular buffer).";
+            break;
         default:
             error_msg = fmt::format(
                 "Watcher unexpected data corruption, noc debug state on core {}, unknown failure code: {}",

--- a/tt_metal/llrt/rtoptions.cpp
+++ b/tt_metal/llrt/rtoptions.cpp
@@ -148,6 +148,7 @@ enum class EnvVarID {
     TT_METAL_WATCHER_DISABLE_WAYPOINT,                        // Disable watcher waypoint feature
     TT_METAL_WATCHER_DISABLE_DISPATCH,                        // Disable watcher dispatch feature
     TT_METAL_WATCHER_DISABLE_ETH,                             // Disable watcher on ethernet cores
+    TT_METAL_WATCHER_DISABLE_CB_SANITIZE,                     // Disable watcher circular buffer sanitization
     TT_METAL_WATCHER_ENABLE_NOC_SANITIZE_LINKED_TRANSACTION,  // Enable NoC linked transaction sanitization
 
     // ========================================
@@ -1053,6 +1054,14 @@ void RunTimeOptions::HandleEnvVar(EnvVarID id, const char* value) {
             this->watcher_disabled_features.insert(this->watcher_eth_str);
             break;
 
+        // TT_METAL_WATCHER_DISABLE_CB_SANITIZE
+        // Disables watcher circular buffer out-of-bounds sanitization when set to any value.
+        // Default: enabled
+        // Usage: export TT_METAL_WATCHER_DISABLE_CB_SANITIZE=1
+        case EnvVarID::TT_METAL_WATCHER_DISABLE_CB_SANITIZE:
+            this->watcher_disabled_features.insert(this->watcher_cb_sanitize_str);
+            break;
+
         // TT_METAL_WATCHER_ENABLE_NOC_SANITIZE_LINKED_TRANSACTION
         // Enables NoC sanitization for linked transactions to catch more subtle errors.
         // Default: false (linked transaction sanitization disabled)
@@ -1346,7 +1355,8 @@ void RunTimeOptions::ParseWatcherEnv() {
         watcher_stack_usage_str,
         watcher_dispatch_str,
         watcher_eth_str,
-        watcher_eth_link_status_str};
+        watcher_eth_link_status_str,
+        watcher_cb_sanitize_str};
     for (const std::string& feature : all_features) {
         std::string env_var("TT_METAL_WATCHER_DISABLE_");
         env_var += feature;
@@ -1708,6 +1718,7 @@ std::string RunTimeOptions::get_watcher_hash() const {
     hash_str += std::to_string(watcher_feature_disabled(watcher_stack_usage_str));
     hash_str += std::to_string(watcher_feature_disabled(watcher_dispatch_str));
     hash_str += std::to_string(watcher_feature_disabled(watcher_eth_str));
+    hash_str += std::to_string(watcher_feature_disabled(watcher_cb_sanitize_str));
     hash_str += std::to_string(get_watcher_noc_sanitize_linked_transaction());
     hash_str += std::to_string(get_watcher_enabled());
     hash_str += std::to_string(get_lightweight_kernel_asserts());

--- a/tt_metal/llrt/rtoptions.hpp
+++ b/tt_metal/llrt/rtoptions.hpp
@@ -384,6 +384,7 @@ public:
     bool watcher_dispatch_disabled() const { return watcher_feature_disabled(watcher_dispatch_str); }
     bool watcher_eth_disabled() const { return watcher_feature_disabled(watcher_eth_str); }
     bool watcher_eth_link_status_disabled() const { return watcher_feature_disabled(watcher_eth_link_status_str); }
+    bool watcher_cb_sanitize_disabled() const { return watcher_feature_disabled(watcher_cb_sanitize_str); }
 
     bool get_lightweight_kernel_asserts() const { return lightweight_kernel_asserts; }
     void set_lightweight_kernel_asserts(bool enabled) { lightweight_kernel_asserts = enabled; }
@@ -755,6 +756,7 @@ private:
     const std::string watcher_eth_link_status_str = "ETH_LINK_STATUS";
     const std::string watcher_sanitize_read_only_l1_str = "SANITIZE_READ_ONLY_L1";
     const std::string watcher_sanitize_write_only_l1_str = "SANITIZE_WRITE_ONLY_L1";
+    const std::string watcher_cb_sanitize_str = "CB_SANITIZE";
     std::set<std::string> watcher_disabled_features;
     bool watcher_feature_disabled(const std::string& name) const { return watcher_disabled_features.contains(name); }
 };


### PR DESCRIPTION
## Summary
- Add a new watcher debug feature that checks NOC transactions against circular buffer boundaries
- When a noc_async_read/write touches an L1 address inside an active CB, verify the full transfer stays within the CB's allocated region
- New error code DebugSanitizeCBOutOfBounds, host-side reporting, disable via TT_METAL_WATCHER_DISABLE_CB_SANITIZE=1
- Documentation added to docs/source/tt-metalium/tools/watcher.rst

## Test plan
- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=pjosipovic/watcher-cb-oob-sanitize)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:pjosipovic/watcher-cb-oob-sanitize)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=pjosipovic/watcher-cb-oob-sanitize)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:pjosipovic/watcher-cb-oob-sanitize)
- [ ] [Nightly tt-metal L2 tests](https://github.com/tenstorrent/tt-metal/actions/runs/22452055814)

🤖 Generated with [Claude Code](https://claude.com/claude-code)