### PR TITLE
Fix CB size in reshard_same_width to cover full local shard

### DIFF
--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/reshard_program_factory_same_width.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/reshard_program_factory_same_width.cpp
@@ -56,7 +56,7 @@ ReshardSameWidthFactory<local_is_output>::cached_program_t ReshardSameWidthFacto
     if (remote_unit_size_padded != unit_size || local_unit_size_padded != unit_size) {
         unaligned = true;
     }
-    const uint32_t total_size = std::min(local_units_per_shard, remote_units_per_shard) * unit_size;
+    const uint32_t total_size = local_units_per_shard * unit_size;
     const std::string kernel_name =
         local_is_output
             ? "ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/reshard_same_width_reader.cpp"


### PR DESCRIPTION
## Summary
- Fix CB overflow in reshard_same_width: CB was sized to min(local, remote) * unit_size but kernel writes at offsets based on local_units_per_shard
- Size CB to local_units_per_shard * unit_size to match the underlying buffer layout
- Found by watcher CB sanitize (#38424)

## Repro
```bash
TT_METAL_WATCHER=1 pytest tests/ttnn/unit_tests/operations/conv/data_movement/test_fold_op.py::test_fold_sharded -x
```

## Test plan
- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=pjosipovic/fix-cb-reshard-same-width)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:pjosipovic/fix-cb-reshard-same-width)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=pjosipovic/fix-cb-reshard-same-width)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:pjosipovic/fix-cb-reshard-same-width)

🤖 Generated with [Claude Code](https://claude.com/claude-code)