### PR TITLE
Fix CB page size in untilize_with_unpadding for non-aligned row widths

### DIFF
--- a/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/factories/untilize_with_unpadding_multi_core_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/factories/untilize_with_unpadding_multi_core_sharded_program_factory.cpp
@@ -101,11 +101,14 @@ UntilizeWithUnpaddingMultiCoreShardedProgramFactory::create(
     uint32_t sharded_output_cb_index;
     CBHandle cb_sharded_output;
     if (out_sharded) {
+        // The kernel advances the write pointer by aligned_page_size (which may be
+        // larger than block_row_size due to buffer alignment padding), so the CB
+        // page size must match to avoid overflow.
         std::tie(sharded_output_cb_index, cb_sharded_output) = create_cb(
             tt::CBIndex::c_17,
             program,
             all_cores,
-            block_row_size,
+            aligned_page_size,
             num_output_rows_unpadded,
             output_cb_data_format,
             output.buffer());


### PR DESCRIPTION
## Summary
- Fix CB overflow in untilize_with_unpadding: CB page size did not account for alignment when row width is not NOC-aligned
- Found by watcher CB sanitize (#38424)

## Test plan
- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=pjosipovic/fix-cb-untilize-unpadding)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:pjosipovic/fix-cb-untilize-unpadding)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=pjosipovic/fix-cb-untilize-unpadding)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:pjosipovic/fix-cb-untilize-unpadding)

🤖 Generated with [Claude Code](https://claude.com/claude-code)