### PR TITLE
Fix vanilla UNet trace region size after trace_region_size semantics …

### DIFF
--- a/models/demos/vision/segmentation/vanilla_unet/tt/common.py
+++ b/models/demos/vision/segmentation/vanilla_unet/tt/common.py
@@ -10,7 +10,7 @@ import ttnn
 from models.demos.vision.segmentation.vanilla_unet.reference.model import UNet
 
 VANILLA_UNET_L1_SMALL_SIZE = 12 * 8192
-VANILLA_UNET_TRACE_SIZE = 258048
+VANILLA_UNET_TRACE_SIZE = 294912
 VANILLA_UNET_PCC_WH = 0.97700
 
 


### PR DESCRIPTION
### Problem description

https://github.com/tenstorrent/tt-metal/actions/runs/22340798884

Commit b258fd2804 changed trace_region_size semantics from per-DRAM-bank to per-device total, and updated VANILLA_UNET_TRACE_SIZE to 258048. However, the actual trace buffer required by the model is 294912B, causing a TT_FATAL in mesh_trace.cpp when end_trace_capture is called.

Set VANILLA_UNET_TRACE_SIZE = 294912

### Checklist
https://github.com/tenstorrent/tt-metal/actions/runs/22344503852 ✅ 

