### PR TITLE
Fix ttnn.tilize crash in TTPenalties for small batch sizes

### DIFF
--- a/models/common/sampling/tt_penalties.py
+++ b/models/common/sampling/tt_penalties.py
@@ -84,7 +84,10 @@ class TTPenalties(LightweightModule):
         super().__init__()
         self.mesh_device = mesh_device
         self.cluster_shape = mesh_device.shape
-        self.max_batch_size = getattr(args, "max_batch_size", 32)
+        # Floor at 32 so that ROW_MAJOR [batch, vocab] buffers passed to
+        # ttnn.tilize always have physical_volume divisible by TILE_HW
+        # (32*32 = 1024).  32 * V is 1024-aligned for any 32-aligned V.
+        self.max_batch_size = max(getattr(args, "max_batch_size", 32), 32)
 
         padded_vocab_size = getattr(args, "padded_vocab_size", None)
         self.vocab_size = padded_vocab_size if padded_vocab_size is not None else args.vocab_size


### PR DESCRIPTION
ttnn.tilize requires physical_volume % TILE_HW (1024) == 0. For ROW_MAJOR [B, V] tensors, volume = B * V. With batch=1 and Llama vocab_size=128256: 1 * 128256 = 128256, and 128256 % 1024 = 256 != 0.

Floor max_batch_size at 32 (matching the original hardcoded value before #37847) so that 32 * V is always 1024-aligned for any 32-aligned vocab size.

Fixes T3K and Galaxy Llama demo crashes introduced by #37847.

https://github.com/tenstorrent/tt-metal/actions/runs/22345923803/job/64661470375