### PR TITLE
Fix trace_region_size for test_reduce_to_root_with_trace after semantic change

### DIFF
--- a/tests/ttnn/unit_tests/operations/ccl/blackhole_CI/box/nightly/test_reduce_to_root_trace.py
+++ b/tests/ttnn/unit_tests/operations/ccl/blackhole_CI/box/nightly/test_reduce_to_root_trace.py
@@ -91,7 +91,7 @@ def compute_reference_reduce_to_root(
 @pytest.mark.parametrize(
     "device_params",
     [
-        ({"fabric_config": ttnn.FabricConfig.FABRIC_1D, "trace_region_size": 225280}),
+        ({"fabric_config": ttnn.FabricConfig.FABRIC_1D, "trace_region_size": 294912}),
     ],
     indirect=["device_params"],
     ids=["fabric_1d_linear_trace"],


### PR DESCRIPTION
### Ticket

Fixes nightly BH pipeline failures in `test_reduce_to_root_with_trace` across all hardware configs (LoudBox 8xP150, QuietBox 2xP300, LLMBox 4xP150).

### Problem description

PR #35271 changed `trace_region_size` semantics from per-DRAM-bank to per-device total. The `test_reduce_to_root_with_trace` test allocates `trace_region_size: 225280` but the actual trace buffer required is 294912B, causing:

```
TT_FATAL @ mesh_trace.cpp:184: mesh_cq.device()->get_trace_buffers_size() <= trace_region_size
Creating trace buffers of size 294912B on MeshDevice 31, but only 225280B is allocated for trace region.
```

This started failing in the Feb 24 08:13 nightly run (first run after #35271 merged) and reproduced on all 3 hardware configs:
- [LoudBox](https://github.com/tenstorrent/tt-metal/actions/runs/22342231661/job/64648878651)
- [QB-GE](https://github.com/tenstorrent/tt-metal/actions/runs/22342231661/job/64648882221)
- [LLMBox](https://github.com/tenstorrent/tt-metal/actions/runs/22342231661/job/64648882332)

Similar to #38430 which fixes the same issue for Vanilla UNet.

### What's changed

Bump `trace_region_size` from 225280 to 294912 in `test_reduce_to_root_trace.py` to match actual trace buffer requirements under the new per-device semantics.

### Checklist

- [ ] Blackhole nightly pipeline triggered: https://github.com/tenstorrent/tt-metal/actions/runs/22347960066