### PR TITLE
Fix test_host_io uint32 type promotion after to_torch change

### DIFF
--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_host_io.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_host_io.py
@@ -83,7 +83,7 @@ def test_host_io_loopback(mesh_device, tensor_size_bytes, fifo_size, num_iterati
         h2d_socket.write_tensor(input_tensor)
         d2h_socket.read_tensor(output_tensor)
 
-        result_torch = ttnn.to_torch(output_tensor)
+        result_torch = ttnn.to_torch(output_tensor).to(torch.int32)
         match = torch.equal(torch_input, result_torch)
         assert match, f"H2D → D2H loopback data mismatch!\nExpected: {torch_input}\nGot: {result_torch}"
 
@@ -376,7 +376,7 @@ def test_multi_stage_pipeline_loopback(mesh_device, tensor_size_bytes, fifo_size
         h2d_socket.write_tensor(input_tensor)
         d2h_socket.read_tensor(output_tensor)
 
-        result_torch = ttnn.to_torch(output_tensor)
+        result_torch = ttnn.to_torch(output_tensor).to(torch.int32)
         match = torch.equal(torch_input, result_torch)
         assert match, f"H2D → D2H loopback data mismatch!\nExpected: {torch_input}\nGot: {result_torch}"
 


### PR DESCRIPTION
### Ticket

Fixes BH nightly pipeline failures in `test_host_io_loopback` on P300-viommu (14 test variants).

### Problem description

PR #36660 ("Support uint16 and uint32 in to_torch") changed `ttnn.to_torch()` to return `torch.uint32` for UInt32 tensors instead of `torch.int32`. This breaks `test_host_io_loopback` and `test_multi_stage_pipeline_loopback` which compare the uint32 output against `torch.int32` reference tensors:

```
RuntimeError: Promotion for uint16, uint32, uint64 types is not supported, attempted to promote Int and UInt32
```

### What's changed

Cast `ttnn.to_torch()` results to `torch.int32` before comparison with reference tensors, matching the pattern used in #38416 for similar fixes to `test_binary_maximum` and `test_binary_minimum`.

### Results

**BEFORE:** [blackhole P300-viommu Host IO fast unit test (viommu only) — FAIL](https://github.com/tenstorrent/tt-metal/actions/runs/22342231661/job/64648879394)
**AFTER:** [blackhole P300-viommu Host IO fast unit test (viommu only) — PASS](https://github.com/tenstorrent/tt-metal/actions/runs/22348257321/job/64669375661)

### Checklist

- [ ] Blackhole nightly pipeline: https://github.com/tenstorrent/tt-metal/actions/runs/22348257321