### PR TITLE
Fix prefill trace assert for row-sharded models missing global_user_id

### DIFF
--- a/models/demos/gpt_oss/tt/model.py
+++ b/models/demos/gpt_oss/tt/model.py
@@ -584,7 +584,7 @@ class Model:
         return tokens, current_pos_tt, rope_idxs, page_table
 
     def prepare_prefill_inputs_trace(
-        self, tokens, start_pos=0, page_table=None, chunk_page_table=None, last_token_idx=None
+        self, tokens, start_pos=0, page_table=None, chunk_page_table=None, last_token_idx=None, **kwargs
     ):
         """Prepare inputs on host so we later send them to device"""
         host_inputs = self.prepare_inputs_prefill(
@@ -594,6 +594,7 @@ class Model:
             chunk_page_table=chunk_page_table,
             trace_enabled=True,
             last_token_idx=last_token_idx,
+            **kwargs,
         )
         return host_inputs
 

--- a/models/tt_transformers/tt/generator.py
+++ b/models/tt_transformers/tt/generator.py
@@ -146,8 +146,12 @@ class Generator(WarmupForwardMixin):
         page_table=None,
         kv_cache=None,
         model_id=-1,
+        global_user_id=None,
     ):
-        host_inputs = self.model[model_id].prepare_prefill_inputs_trace(prefill_ids, page_table=page_table)
+        prefill_kwargs = {"page_table": page_table}
+        if global_user_id is not None:
+            prefill_kwargs["global_user_id"] = global_user_id
+        host_inputs = self.model[model_id].prepare_prefill_inputs_trace(prefill_ids, **prefill_kwargs)
         # These matrices will actually be pointing to the whole cos_matrix and sin_matrix that was allocated on device in the RotarySetup class
         tt_rot_mats_prefill_global = host_inputs[1]
         tt_rot_mats_prefill_local = host_inputs[2]
@@ -191,6 +195,7 @@ class Generator(WarmupForwardMixin):
         prefill_seq_len=None,
         **kwargs,
     ):
+        global_user_id = kwargs.get("global_user_id", None)
         trace_key = f"{prefill_seq_len}_{model_id}"
         if self.trace_id_prefill[trace_key] is None:
             trace_id, tt_out_trace, *device_inputs = self._capture_trace_prefill(
@@ -198,6 +203,7 @@ class Generator(WarmupForwardMixin):
                 page_table=page_table,
                 kv_cache=kv_cache,
                 model_id=model_id,
+                global_user_id=global_user_id,
             )
             self.trace_id_prefill[trace_key] = trace_id
             self.trace_inputs_prefill[trace_key] = device_inputs
@@ -210,6 +216,7 @@ class Generator(WarmupForwardMixin):
             prefill_ids,
             page_table=page_table,
             model_id=model_id,
+            global_user_id=global_user_id,
         )
 
         return tt_out_trace
@@ -223,8 +230,12 @@ class Generator(WarmupForwardMixin):
         user_id=0,
         page_table=None,
         model_id=-1,
+        global_user_id=None,
     ):
-        host_inputs = self.model[model_id].prepare_prefill_inputs_trace(prefill_ids, page_table=page_table)
+        prefill_kwargs = {"page_table": page_table}
+        if global_user_id is not None:
+            prefill_kwargs["global_user_id"] = global_user_id
+        host_inputs = self.model[model_id].prepare_prefill_inputs_trace(prefill_ids, **prefill_kwargs)
         host_inputs = (host_inputs[0], host_inputs[3], host_inputs[4])
 
         device_inputs = copy_host_to_device(


### PR DESCRIPTION
## Summary
- The trace prefill path (`_easy_trace_prefill` → `_capture_trace_prefill` → `prepare_prefill_inputs_trace` → `prepare_inputs_prefill`) was not forwarding `global_user_id`, causing an AssertionError in gpt-oss highbatch: *"global_user_id is required for single-user row-sharded prefill to target the correct mesh row"*
- Thread `global_user_id` through the trace prefill chain conditionally — only pass it to `prepare_prefill_inputs_trace` when set, so models that don't accept it (tt_transformers, Gemma, etc.) are unaffected

Ref: https://github.com/tenstorrent/tt-metal/actions/runs/22319355093/job/64574339655#step:17:481

vllm nightly: https://github.com/tenstorrent/tt-metal/actions/runs/22352783186