### PR TITLE
Fix BH OOM issue in vLLM nightly

### DIFF
--- a/models/tt_transformers/tt/model.py
+++ b/models/tt_transformers/tt/model.py
@@ -165,6 +165,7 @@ class Transformer(LightweightModule):
         if lm_head_input_mem_cfg.is_sharded():
             logits = ttnn.interleaved_to_sharded(logits, lm_head_input_mem_cfg)
         logits = self.lm_head(logits)
+        logits = ttnn.to_layout(logits, layout=ttnn.ROW_MAJOR_LAYOUT, memory_config=ttnn.DRAM_MEMORY_CONFIG)
         return logits
 
     def process_hidden_states_after_prefill_trace(self, hidden_states, last_token_idx):
@@ -648,4 +649,6 @@ class Transformer(LightweightModule):
             x = ttnn.to_memory_config(x, self.args.get_lm_head_input_mem_config(mode, self.prefetcher))
 
         x = self.lm_head(x)
+        if mode == Mode.PREFILL:
+            x = ttnn.to_layout(x, layout=ttnn.ROW_MAJOR_LAYOUT, memory_config=ttnn.DRAM_MEMORY_CONFIG)
         return x

--- a/models/tt_transformers/tt/model.py
+++ b/models/tt_transformers/tt/model.py
@@ -165,7 +165,7 @@ class Transformer(LightweightModule):
         if lm_head_input_mem_cfg.is_sharded():
             logits = ttnn.interleaved_to_sharded(logits, lm_head_input_mem_cfg)
         logits = self.lm_head(logits)
-        logits = ttnn.to_layout(logits, layout=ttnn.ROW_MAJOR_LAYOUT, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+        logits = ttnn.to_memory_config(logits, memory_config=ttnn.DRAM_MEMORY_CONFIG)
         return logits
 
     def process_hidden_states_after_prefill_trace(self, hidden_states, last_token_idx):
@@ -650,5 +650,5 @@ class Transformer(LightweightModule):
 
         x = self.lm_head(x)
         if mode == Mode.PREFILL:
-            x = ttnn.to_layout(x, layout=ttnn.ROW_MAJOR_LAYOUT, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+            x = ttnn.to_memory_config(x, memory_config=ttnn.DRAM_MEMORY_CONFIG)
         return x


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/37398#event-23002876137

### Problem description
BH LB OOM in vLLM nightly during prefill 
During merge stable changes back to main [PR](https://github.com/tenstorrent/tt-metal/commit/d406ab4dd798ad1937a94f98620314a812d38366#diff-b8e9d3e7ac8948e28a97398f2e39b5a2d596f3cecad4298e9209f04d8be0832e), these code blocks were removed which increased L1 usage and there was not justified reasoning behind this removal:
```
in process_hidden_states_after_prefill_trace
        if mode == "prefill":
            x = ttnn.to_layout(x, layout=ttnn.ROW_MAJOR_LAYOUT, memory_config=ttnn.DRAM_MEMORY_CONFIG)
            # x = ttnn.to_memory_config(x, memory_config=ttnn.DRAM_MEMORY_CONFIG)

in process_logits_after_prefill_trace
        logits = ttnn.to_layout(logits, layout=ttnn.ROW_MAJOR_LAYOUT, memory_config=ttnn.DRAM_MEMORY_CONFIG)
```

### What's changed
Move logits to dram after lm head for prefill

### Checklist
- [APC](https://github.com/tenstorrent/tt-metal/actions/runs/22368268170) passing
- [BH APC](https://github.com/tenstorrent/tt-metal/actions/runs/22368317566) passing, failures irrelevant 
- [vLLM nightly](https://github.com/tenstorrent/tt-metal/actions/runs/22364631607/job/64728448393) passing, failures are irrelevant 
- [T3K demo](https://github.com/tenstorrent/tt-metal/actions/runs/22369892323)
- [BH multicard demo](https://github.com/tenstorrent/tt-metal/actions/runs/22363592534) passing