### PR TITLE
Update link to TT-NN Basic Examples Page

### DIFF
--- a/INSTALLING.md
+++ b/INSTALLING.md
@@ -193,7 +193,7 @@ All binaries support only Linux and distros with glibc 2.34 or newer.
   python3 -m ttnn.examples.usage.run_op_on_device
   ```
 
-- For more programming examples to try, visit Tenstorrent's [TT-NN Basic Examples Page](https://docs.tenstorrent.com/tt-metal/latest/ttnn/ttnn/usage.html#basic-examples) or get started with [Simple Kernels on TT-Metalium](https://docs.tenstorrent.com/tt-metal/latest/tt-metalium/tt_metal/examples/index.html)
+- For more programming examples to try, visit Tenstorrent's [TT-NN Basic Examples Page](https://docs.tenstorrent.com/tt-metal/latest/ttnn/ttnn/tutorials.html) or get started with [Simple Kernels on TT-Metalium](https://docs.tenstorrent.com/tt-metal/latest/tt-metalium/tt_metal/examples/index.html)
 
 
 ### Interested in Contributing?


### PR DESCRIPTION
Customer reported a broken link on the installation guide; updated to a more recent tutorials page to resolve 404. 