### PR TITLE
Llama32 vision integration test changes

### DIFF
--- a/.github/workflows/pipeline-select-t3k.yaml
+++ b/.github/workflows/pipeline-select-t3k.yaml
@@ -99,7 +99,7 @@ on:
           - llama3
           - llama3 accuracy
           - llama3_70n90b accuracy
-           - llama3_90b
+          - llama3_90b
           # - llama3_70b # disabled in -impl file
           # - mixtral # disabled in -impl file
           - resnet

--- a/.github/workflows/pipeline-select-t3k.yaml
+++ b/.github/workflows/pipeline-select-t3k.yaml
@@ -99,7 +99,7 @@ on:
           - llama3
           - llama3 accuracy
           - llama3_70n90b accuracy
-          # - llama3_90b #Tier 3 model
+           - llama3_90b
           # - llama3_70b # disabled in -impl file
           # - mixtral # disabled in -impl file
           - resnet

--- a/.github/workflows/pipeline-select-t3k.yaml
+++ b/.github/workflows/pipeline-select-t3k.yaml
@@ -93,13 +93,13 @@ on:
           - ethernet
           - trace stress
           - falcon40b
-          - llama3.2-vision
-          - n300 mesh llama3.2-vision
-          - llama3.2-90b-vision
+          # - llama3.2-vision #Tier 3 models
+          # - n300 mesh llama3.2-vision #Tier 3 models
+          # - llama3.2-90b-vision #Tier 3 model
           - llama3
           - llama3 accuracy
           - llama3_70n90b accuracy
-          - llama3_90b
+          # - llama3_90b #Tier 3 model
           # - llama3_70b # disabled in -impl file
           # - mixtral # disabled in -impl file
           - resnet

--- a/.github/workflows/t3000-integration-tests.yaml
+++ b/.github/workflows/t3000-integration-tests.yaml
@@ -13,13 +13,13 @@ on:
           - tteager
           - trace stress
           - falcon40b
-          - llama3.2-vision
-          - n300 mesh llama3.2-vision
-          - llama3.2-90b-vision
+          # - llama3.2-vision # Tier 3 models
+          # - n300 mesh llama3.2-vision # Tier 3 models
+          # - llama3.2-90b-vision # Tier 3 models
           - llama3
           - llama3 accuracy
           - llama3_70n90b accuracy
-          - llama3_90b
+          # - llama3_90b # Tier 3 model
           - resnet
           - sd35_large
           - flux1

--- a/.github/workflows/t3000-integration-tests.yaml
+++ b/.github/workflows/t3000-integration-tests.yaml
@@ -19,7 +19,7 @@ on:
           - llama3
           - llama3 accuracy
           - llama3_70n90b accuracy
-          # - llama3_90b # Tier 3 model
+          - llama3_90b
           - resnet
           - sd35_large
           - flux1

--- a/models/tt_transformers/tests/multimodal/test_llama_cross_attention_transformer_text.py
+++ b/models/tt_transformers/tests/multimodal/test_llama_cross_attention_transformer_text.py
@@ -225,7 +225,7 @@ def test_cross_attention_transformer_text_inference(
 
         TEXT_ONLY = False
 
-        if mode == "prefill":
+        if mode == Mode.PREFILL:
             T = get_ref_model_logits(
                 i,
                 position_ids=position_ids.unsqueeze(0).expand(batch, -1),
@@ -421,7 +421,7 @@ def test_cross_attention_transformer_text_inference(
         assert passing, f"PCC value is lower than {pcc_required} for some of the outputs. Check Warnings!"
         prev_pos = cur_pos
 
-        if mode == "prefill":
+        if mode == Mode.PREFILL:
             tt_xattn_cache_torch = [
                 ttnn.to_torch(x, mesh_composer=ttnn.ConcatMeshToTensor(mesh_device, dim=1)).view(
                     batch,

--- a/tests/pipeline_reorg/t3k_integration_tests.yaml
+++ b/tests/pipeline_reorg/t3k_integration_tests.yaml
@@ -37,32 +37,32 @@
   team: models
   model-name: falcon40b
 
-- name: t3k_llama3.2-vision_tests
-  cmd: run_t3000_llama3.2-11b-vision_freq_tests
-  skus:
-    wh_llmbox:
-      timeout: 20
-  owner_id: U03FJB5TM5Y # Colman Glagovich
-  team: models
-  model-name: llama3.2-vision
+#- name: t3k_llama3.2-vision_tests
+#  cmd: run_t3000_llama3.2-11b-vision_freq_tests
+#  skus:
+#    wh_llmbox:
+#      timeout: 20
+#  owner_id: U03FJB5TM5Y # Colman Glagovich
+#  team: models
+#  model-name: llama3.2-vision
 
-- name: t3k_n300_mesh_llama3.2-vision_tests
-  cmd: run_t3000_spoof_n300_llama3.2-11b-vision_freq_tests
-  skus:
-    wh_llmbox:
-      timeout: 20
-  owner_id: U03FJB5TM5Y # Colman Glagovich
-  team: models
-  model-name: n300 mesh llama3.2-vision
+#- name: t3k_n300_mesh_llama3.2-vision_tests
+#  cmd: run_t3000_spoof_n300_llama3.2-11b-vision_freq_tests
+#  skus:
+#    wh_llmbox:
+#      timeout: 20
+#  owner_id: U03FJB5TM5Y # Colman Glagovich
+#  team: models
+#  model-name: n300 mesh llama3.2-vision
 
-- name: t3k_llama3.2-90b-vision_tests
-  cmd: run_t3000_llama3.2-90b-vision_freq_tests
-  skus:
-    wh_llmbox:
-      timeout: 20
-  owner_id: U07RY6B5FLJ # Gongyu Wang
-  team: models
-  model-name: llama3.2-90b-vision
+#- name: t3k_llama3.2-90b-vision_tests
+#  cmd: run_t3000_llama3.2-90b-vision_freq_tests
+#  skus:
+#    wh_llmbox:
+#      timeout: 20
+#  owner_id: U07RY6B5FLJ # Gongyu Wang
+#  team: models
+#  model-name: llama3.2-90b-vision
 
 - name: t3k_llama3_tests
   cmd: run_t3000_llama3_tests
@@ -91,14 +91,14 @@
   team: models
   model-name: llama3_70n90b accuracy
 
-- name: t3k_llama3_90b_tests
-  cmd: run_t3000_llama3_90b_tests
-  skus:
-    wh_llmbox:
-      timeout: 30
-  owner_id: U07RY6B5FLJ # Gongyu Wang
-  team: models
-  model-name: llama3_90b
+#- name: t3k_llama3_90b_tests
+#  cmd: run_t3000_llama3_90b_tests
+#  skus:
+#    wh_llmbox:
+#      timeout: 30
+#  owner_id: U07RY6B5FLJ # Gongyu Wang
+#  team: models
+#  model-name: llama3_90b
 
 - name: t3k_resnet_tests
   cmd: run_t3000_resnet_tests

--- a/tests/pipeline_reorg/t3k_integration_tests.yaml
+++ b/tests/pipeline_reorg/t3k_integration_tests.yaml
@@ -91,14 +91,14 @@
   team: models
   model-name: llama3_70n90b accuracy
 
-#- name: t3k_llama3_90b_tests
-#  cmd: run_t3000_llama3_90b_tests
-#  skus:
-#    wh_llmbox:
-#      timeout: 30
-#  owner_id: U07RY6B5FLJ # Gongyu Wang
-#  team: models
-#  model-name: llama3_90b
+- name: t3k_llama3_90b_tests
+  cmd: run_t3000_llama3_90b_tests
+  skus:
+    wh_llmbox:
+      timeout: 30
+  owner_id: U07RY6B5FLJ # Gongyu Wang
+  team: models
+  model-name: llama3_90b
 
 - name: t3k_resnet_tests
   cmd: run_t3000_resnet_tests

--- a/tests/scripts/t3000/run_t3000_integration_tests.sh
+++ b/tests/scripts/t3000/run_t3000_integration_tests.sh
@@ -30,16 +30,17 @@ run_t3000_llama3_tests() {
   echo "LOG_METAL: Running run_t3000_llama3_tests"
 
   # Llama3.2-1B
-  llama1b=meta-llama/Llama-3.2-1B-Instruct
+  #llama1b=meta-llama/Llama-3.2-1B-Instruct
   # Llama3.2-3B
-  llama3b=meta-llama/Llama-3.2-3B-Instruct
+  #llama3b=meta-llama/Llama-3.2-3B-Instruct
   # Llama3.1-8B
   llama8b=meta-llama/Llama-3.1-8B-Instruct
   # Llama3.2-11B
-  llama11b=meta-llama/Llama-3.2-11B-Vision-Instruct
+  #llama11b=meta-llama/Llama-3.2-11B-Vision-Instruct
 
   # Run test model for llama3 - 1B, 3B, 8B and 11B weights
-  for hf_model in "$llama1b" "$llama3b" "$llama8b" "$llama11b"; do
+  # Removed 1B, 3B, and 11B tests for now to reduce possibility of 8B model hanging
+  for hf_model in "$llama8b"; do
     tt_cache=$TT_CACHE_HOME/$hf_model
     HF_MODEL=$hf_model TT_CACHE_PATH=$tt_cache pytest models/tt_transformers/tests/test_model.py -k full ; fail+=$?
     HF_MODEL=$hf_model TT_CACHE_PATH=$tt_cache pytest models/tt_transformers/tests/test_model_prefill.py ; fail+=$?
@@ -47,8 +48,8 @@ run_t3000_llama3_tests() {
   done
 
   # Run chunked prefill test for llama3-1B
-  tt_cache_llama1b=$TT_CACHE_HOME/$llama1b
-  HF_MODEL=$llama1b TT_CACHE_PATH=$tt_cache_llama1b pytest models/tt_transformers/tests/test_chunked_generation.py; fail+=$?
+  #tt_cache_llama1b=$TT_CACHE_HOME/$llama1b
+  #HF_MODEL=$llama1b TT_CACHE_PATH=$tt_cache_llama1b pytest models/tt_transformers/tests/test_chunked_generation.py; fail+=$?
 
   # Record the end time
   end_time=$(date +%s)
@@ -81,27 +82,28 @@ run_t3000_llama3_70b_tests() {
   fi
 }
 
-run_t3000_llama3_90b_tests() {
+#
+#run_t3000_llama3_90b_tests() {
   # Record the start time
-  fail=0
-  start_time=$(date +%s)
+#  fail=0
+#  start_time=$(date +%s)
 
-  echo "LOG_METAL: Running run_t3000_llama3_90b_tests"
+#  echo "LOG_METAL: Running run_t3000_llama3_90b_tests"
 
   # Run test_model (decode and prefill) for llama3 70B
-  llama90b=meta-llama/Llama-3.2-90B-Vision-Instruct
-  tt_cache_llama90b=$TT_CACHE_HOME/$llama90b
-  HF_MODEL=$llama90b TT_CACHE_PATH=$tt_cache_llama90b pytest models/tt_transformers/tests/test_model.py -k quick ; fail+=$?
-  HF_MODEL=$llama90b TT_CACHE_PATH=$tt_cache_llama90b pytest models/tt_transformers/tests/test_model_prefill.py -k "performance and 1layer" ; fail+=$?
+#  llama90b=meta-llama/Llama-3.2-90B-Vision-Instruct
+#  tt_cache_llama90b=$TT_CACHE_HOME/$llama90b
+#  HF_MODEL=$llama90b TT_CACHE_PATH=$tt_cache_llama90b pytest models/tt_transformers/tests/test_model.py -k quick ; fail+=$?
+#  HF_MODEL=$llama90b TT_CACHE_PATH=$tt_cache_llama90b pytest models/tt_transformers/tests/test_model_prefill.py -k "performance and 1layer" ; fail+=$?
 
   # Record the end time
-  end_time=$(date +%s)
-  duration=$((end_time - start_time))
-  echo "LOG_METAL: run_t3000_llama3_90b_tests $duration seconds to complete"
-  if [[ $fail -ne 0 ]]; then
-    exit 1
-  fi
-}
+#  end_time=$(date +%s)
+#  duration=$((end_time - start_time))
+#  echo "LOG_METAL: run_t3000_llama3_90b_tests $duration seconds to complete"
+#  if [[ $fail -ne 0 ]]; then
+#    exit 1
+# fi
+#}
 
 run_t3000_llama3_accuracy_tests() {
   # Record the start time
@@ -111,16 +113,17 @@ run_t3000_llama3_accuracy_tests() {
   echo "LOG_METAL: Running run_t3000_llama3_accuracy_tests"
 
   # Llama3.2-1B
-  llama1b=meta-llama/Llama-3.2-1B-Instruct
+  #llama1b=meta-llama/Llama-3.2-1B-Instruct
   # Llama3.2-3B
-  llama3b=meta-llama/Llama-3.2-3B-Instruct
+  #llama3b=meta-llama/Llama-3.2-3B-Instruct
   # Llama3.1-8B
   llama8b=meta-llama/Llama-3.1-8B-Instruct
   # Llama3.2-11B
-  llama11b=meta-llama/Llama-3.2-11B-Vision-Instruct
+  #llama11b=meta-llama/Llama-3.2-11B-Vision-Instruct
 
   # Run test accuracy llama3 - 1B, 3B, 8B, and 11B weights
-  for hf_model in "$llama1b" "$llama3b" "$llama8b" "$llama11b" ; do
+  # Removed 1B, 3B, and 11B tests for now to reduce possibility of 8B model hanging
+  for hf_model in "$llama8b" ; do
     tt_cache=$TT_CACHE_HOME/$hf_model
     HF_MODEL=$hf_model TT_CACHE_PATH=$tt_cache pytest models/tt_transformers/demo/simple_text_demo.py -k "performance and ci-token-matching" ; fail+=$?
     echo "LOG_METAL: Llama3 accuracy tests for $hf_model completed"
@@ -140,15 +143,16 @@ run_t3000_llama3_70n90b_accuracy_tests() {
   fail=0
   start_time=$(date +%s)
 
-  echo "LOG_METAL: Running run_t3000_llama3_accuracy_tests"
+  echo "LOG_METAL: Running run_t3000_llama3_70n90b_accuracy_tests"
 
   # Llama3.1-70B
   llama70b=meta-llama/Llama-3.1-70B-Instruct
   # Llama3.2-90B
-  llama90b=meta-llama/Llama-3.2-90B-Vision-Instruct
+  #llama90b=meta-llama/Llama-3.2-90B-Vision-Instruct
 
-  # Run test accuracy llama3 - 1B, 3B, 8B, 11B and 70B weights
-  for hf_model in "$llama70b" "$llama90b"; do
+  # Run test accuracy llama3 - 70B and 90B weights
+  # Removed 90B tests for now to reduce possibility of 8B model hanging
+  for hf_model in "$llama70b"; do
     tt_cache=$TT_CACHE_HOME/$hf_model
     HF_MODEL=$hf_model TT_CACHE_PATH=$tt_cache pytest models/tt_transformers/demo/simple_text_demo.py -k "performance and ci-token-matching" --timeout 4200 ; fail+=$?
     echo "LOG_METAL: Llama3 accuracy tests for $hf_model completed"
@@ -157,87 +161,87 @@ run_t3000_llama3_70n90b_accuracy_tests() {
   # Record the end time
   end_time=$(date +%s)
   duration=$((end_time - start_time))
-  echo "LOG_METAL: run_t3000_llama3_accuracy_tests $duration seconds to complete"
+  echo "LOG_METAL: run_t3000_llama3_70n90b_accuracy_tests $duration seconds to complete"
   if [[ $fail -ne 0 ]]; then
     exit 1
   fi
 }
 
-run_t3000_llama3.2-11b-vision_freq_tests() {
+#run_t3000_llama3.2-11b-vision_freq_tests() {
   # Record the start time
-  fail=0
-  start_time=$(date +%s)
+#  fail=0
+#  start_time=$(date +%s)
 
-  echo "LOG_METAL: Running run_t3000_llama3.2-11b-vision_freq_tests"
+#  echo "LOG_METAL: Running run_t3000_llama3.2-11b-vision_freq_tests"
 
   # Llama3.2-11B
-  llama11b=meta-llama/Llama-3.2-11B-Vision-Instruct
-  tt_cache_llama11b=$TT_CACHE_HOME/$llama11b
+#  llama11b=meta-llama/Llama-3.2-11B-Vision-Instruct
+#  tt_cache_llama11b=$TT_CACHE_HOME/$llama11b
 
-  HF_MODEL=$llama11b TT_CACHE_PATH=$tt_cache_llama11b  pytest models/tt_transformers/tests/multimodal/test_llama_image_transformer.py ; fail+=$?
-  HF_MODEL=$llama11b TT_CACHE_PATH=$tt_cache_llama11b pytest models/tt_transformers/tests/multimodal/test_llama_vision_encoder.py ; fail+=$?
-  HF_MODEL=$llama11b TT_CACHE_PATH=$tt_cache_llama11b pytest models/tt_transformers/tests/multimodal/test_llama_cross_attention_transformer_text.py ; fail+=$?
-  HF_MODEL=$llama11b TT_CACHE_PATH=$tt_cache_llama11b pytest models/tt_transformers/tests/multimodal/test_llama_cross_attention_transformer_vision.py ; fail+=$?
+#  HF_MODEL=$llama11b TT_CACHE_PATH=$tt_cache_llama11b  pytest models/tt_transformers/tests/multimodal/test_llama_image_transformer.py ; fail+=$?
+#  HF_MODEL=$llama11b TT_CACHE_PATH=$tt_cache_llama11b pytest models/tt_transformers/tests/multimodal/test_llama_vision_encoder.py ; fail+=$?
+#  HF_MODEL=$llama11b TT_CACHE_PATH=$tt_cache_llama11b pytest models/tt_transformers/tests/multimodal/test_llama_cross_attention_transformer_text.py ; fail+=$?
+#  HF_MODEL=$llama11b TT_CACHE_PATH=$tt_cache_llama11b pytest models/tt_transformers/tests/multimodal/test_llama_cross_attention_transformer_vision.py ; fail+=$?
 
   # Record the end time
-  end_time=$(date +%s)
-  duration=$((end_time - start_time))
-  echo "LOG_METAL: run_t3000_llama3.2-11b-vision_freq_tests $duration seconds to complete"
-  if [[ $fail -ne 0 ]]; then
-    exit 1
-  fi
-}
+#  end_time=$(date +%s)
+#  duration=$((end_time - start_time))
+#  echo "LOG_METAL: run_t3000_llama3.2-11b-vision_freq_tests $duration seconds to complete"
+#  if [[ $fail -ne 0 ]]; then
+#    exit 1
+#  fi
+#}
 
-run_t3000_spoof_n300_llama3.2-11b-vision_freq_tests() {
+#run_t3000_spoof_n300_llama3.2-11b-vision_freq_tests() {
   # Record the start time
-  fail=0
-  start_time=$(date +%s)
+#  fail=0
+#  start_time=$(date +%s)
 
-  echo "LOG_METAL: Running run_t3000_spoof_n300_llama3.2-11b-vision_freq_tests"
+#  echo "LOG_METAL: Running run_t3000_spoof_n300_llama3.2-11b-vision_freq_tests"
 
   # Llama3.2-11B
-  llama11b=meta-llama/Llama-3.2-11B-Vision-Instruct
-  tt_cache_llama11b=$TT_CACHE_HOME/$llama11b
+#  llama11b=meta-llama/Llama-3.2-11B-Vision-Instruct
+#  tt_cache_llama11b=$TT_CACHE_HOME/$llama11b
   # Use MESH_DEVICE env variable to run on an N300 mesh
-  mesh_device=N300
+#  mesh_device=N300
 
-  MESH_DEVICE=$mesh_device HF_MODEL=$llama11b TT_CACHE_PATH=$tt_cache_llama11b pytest models/tt_transformers/tests/multimodal/test_llama_image_transformer.py ; fail+=$?
-  MESH_DEVICE=$mesh_device HF_MODEL=$llama11b TT_CACHE_PATH=$tt_cache_llama11b pytest models/tt_transformers/tests/multimodal/test_llama_vision_encoder.py ; fail+=$?
-  MESH_DEVICE=$mesh_device HF_MODEL=$llama11b TT_CACHE_PATH=$tt_cache_llama11b pytest models/tt_transformers/tests/multimodal/test_llama_cross_attention_transformer_text.py ; fail+=$?
-  MESH_DEVICE=$mesh_device HF_MODEL=$llama11b TT_CACHE_PATH=$tt_cache_llama11b pytest models/tt_transformers/tests/multimodal/test_llama_cross_attention_transformer_vision.py ; fail+=$?
+#  MESH_DEVICE=$mesh_device HF_MODEL=$llama11b TT_CACHE_PATH=$tt_cache_llama11b pytest models/tt_transformers/tests/multimodal/test_llama_image_transformer.py ; fail+=$?
+#  MESH_DEVICE=$mesh_device HF_MODEL=$llama11b TT_CACHE_PATH=$tt_cache_llama11b pytest models/tt_transformers/tests/multimodal/test_llama_vision_encoder.py ; fail+=$?
+#  MESH_DEVICE=$mesh_device HF_MODEL=$llama11b TT_CACHE_PATH=$tt_cache_llama11b pytest models/tt_transformers/tests/multimodal/test_llama_cross_attention_transformer_text.py ; fail+=$?
+#  MESH_DEVICE=$mesh_device HF_MODEL=$llama11b TT_CACHE_PATH=$tt_cache_llama11b pytest models/tt_transformers/tests/multimodal/test_llama_cross_attention_transformer_vision.py ; fail+=$?
 
   # Record the end time
-  end_time=$(date +%s)
-  duration=$((end_time - start_time))
-  echo "LOG_METAL: run_t3000_spoof_n300_llama3.2-11b-vision_freq_tests $duration seconds to complete"
-  if [[ $fail -ne 0 ]]; then
-    exit 1
-  fi
-}
+#  end_time=$(date +%s)
+#  duration=$((end_time - start_time))
+#  echo "LOG_METAL: run_t3000_spoof_n300_llama3.2-11b-vision_freq_tests $duration seconds to complete"
+#  if [[ $fail -ne 0 ]]; then
+#    exit 1
+#  fi
+#}
 
-run_t3000_llama3.2-90b-vision_freq_tests() {
+#run_t3000_llama3.2-90b-vision_freq_tests() {
   # Record the start time
-  fail=0
-  start_time=$(date +%s)
+#  fail=0
+#  start_time=$(date +%s)
 
-  echo "LOG_METAL: Running run_t3000_llama3.2-90b-vision_freq_tests"
+#  echo "LOG_METAL: Running run_t3000_llama3.2-90b-vision_freq_tests"
 
   # Llama3.2-90B -- use repacked weights when acceptable for faster testing
-  llama90b=meta-llama/Llama-3.2-90B-Vision-Instruct
-  tt_cache_llama90b=$TT_CACHE_HOME/$llama90b
-  HF_MODEL=$llama90b TT_CACHE_PATH=$tt_cache_llama90b pytest models/tt_transformers/tests/multimodal/test_llama_cross_attention_transformer_text.py --timeout 2400; fail+=$?
-  HF_MODEL=$llama90b TT_CACHE_PATH=$tt_cache_llama90b pytest models/tt_transformers/tests/multimodal/test_llama_image_transformer.py ; fail+=$?
-  HF_MODEL=$llama90b TT_CACHE_PATH=$tt_cache_llama90b pytest models/tt_transformers/tests/multimodal/test_llama_vision_encoder.py ; fail+=$?
-  HF_MODEL=$llama90b TT_CACHE_PATH=$tt_cache_llama90b pytest models/tt_transformers/tests/multimodal/test_llama_cross_attention_transformer_vision.py ; fail+=$?
+#  llama90b=meta-llama/Llama-3.2-90B-Vision-Instruct
+#  tt_cache_llama90b=$TT_CACHE_HOME/$llama90b
+#  HF_MODEL=$llama90b TT_CACHE_PATH=$tt_cache_llama90b pytest models/tt_transformers/tests/multimodal/test_llama_cross_attention_transformer_text.py --timeout 2400; fail+=$?
+#  HF_MODEL=$llama90b TT_CACHE_PATH=$tt_cache_llama90b pytest models/tt_transformers/tests/multimodal/test_llama_image_transformer.py ; fail+=$?
+#  HF_MODEL=$llama90b TT_CACHE_PATH=$tt_cache_llama90b pytest models/tt_transformers/tests/multimodal/test_llama_vision_encoder.py ; fail+=$?
+#  HF_MODEL=$llama90b TT_CACHE_PATH=$tt_cache_llama90b pytest models/tt_transformers/tests/multimodal/test_llama_cross_attention_transformer_vision.py ; fail+=$?
 
   # Record the end time
-  end_time=$(date +%s)
-  duration=$((end_time - start_time))
-  echo "LOG_METAL: run_t3000_llama3.2-90b-vision_freq_tests $duration seconds to complete"
-  if [[ $fail -ne 0 ]]; then
-    exit 1
-  fi
-}
+#  end_time=$(date +%s)
+#  duration=$((end_time - start_time))
+#  echo "LOG_METAL: run_t3000_llama3.2-90b-vision_freq_tests $duration seconds to complete"
+#  if [[ $fail -ne 0 ]]; then
+#    exit 1
+#  fi
+#}
 
 
 run_t3000_mistral_tests() {
@@ -424,7 +428,7 @@ run_t3000_mochi_tests() {
   echo "LOG_METAL: Running run_t3000_mochi_tests"
 
   export TT_DIT_CACHE_DIR="/tmp/TT_DIT_CACHE"
-  FAKE_DEVICE=T3K pytest models/tt_dit/tests/models/mochi/test_vae_mochi.py -k "decoder and 1link-load_dit-large_latent or conv3d_1x1x1 or -1link-l768" --timeout=1500; fail+=$?
+  FAKE_DEVICE=T3K pytest models/tt_dit/tests/models/mochi/test_vae_mochi.py -k "decoder and 1link-load_dit-large_latent or conv3d_1x1x1 or -1link-l768" --timeout=3600; fail+=$?
   pytest models/tt_dit/tests/models/mochi/test_attention_mochi.py -k "short_seq"; fail+=$?
   pytest models/tt_dit/tests/models/mochi/test_transformer_mochi.py -k "1x8 or 2x4 and short_seq and not yes_load_cache and not model_caching"; fail+=$?
 
@@ -457,20 +461,20 @@ run_t3000_tests() {
   run_t3000_llama3_70b_tests
 
   # Run llama3-90b tests
-  run_t3000_llama3_90b_tests
+  #run_t3000_llama3_90b_tests
 
   # Run llama3 accuracy tests
   run_t3000_llama3_accuracy_tests
   run_t3000_llama3_70n90b_accuracy_tests
 
   # Run Llama3.2-11B Vision tests
-  run_t3000_llama3.2-11b-vision_freq_tests
+  #run_t3000_llama3.2-11b-vision_freq_tests
 
   # Run Llama3.2-11B Vision tests on spoofed N300
-  run_t3000_spoof_n300_llama3.2-11b-vision_freq_tests
+  #run_t3000_spoof_n300_llama3.2-11b-vision_freq_tests
 
   # Run Llama3.2-90B Vision tests
-  run_t3000_llama3.2-90b-vision_freq_tests
+  #run_t3000_llama3.2-90b-vision_freq_tests
 
   # Run mistral tests
   run_t3000_mistral_tests

--- a/tests/scripts/t3000/run_t3000_integration_tests.sh
+++ b/tests/scripts/t3000/run_t3000_integration_tests.sh
@@ -82,28 +82,28 @@ run_t3000_llama3_70b_tests() {
   fi
 }
 
-#
-#run_t3000_llama3_90b_tests() {
+
+run_t3000_llama3_90b_tests() {
   # Record the start time
-#  fail=0
-#  start_time=$(date +%s)
+  fail=0
+  start_time=$(date +%s)
 
-#  echo "LOG_METAL: Running run_t3000_llama3_90b_tests"
+  echo "LOG_METAL: Running run_t3000_llama3_90b_tests"
 
-  # Run test_model (decode and prefill) for llama3 70B
-#  llama90b=meta-llama/Llama-3.2-90B-Vision-Instruct
-#  tt_cache_llama90b=$TT_CACHE_HOME/$llama90b
-#  HF_MODEL=$llama90b TT_CACHE_PATH=$tt_cache_llama90b pytest models/tt_transformers/tests/test_model.py -k quick ; fail+=$?
-#  HF_MODEL=$llama90b TT_CACHE_PATH=$tt_cache_llama90b pytest models/tt_transformers/tests/test_model_prefill.py -k "performance and 1layer" ; fail+=$?
+  # Run test_model (decode and prefill) for llama3 90B
+  llama90b=meta-llama/Llama-3.2-90B-Vision-Instruct
+  tt_cache_llama90b=$TT_CACHE_HOME/$llama90b
+  HF_MODEL=$llama90b TT_CACHE_PATH=$tt_cache_llama90b pytest models/tt_transformers/tests/test_model.py -k quick ; fail+=$?
+  HF_MODEL=$llama90b TT_CACHE_PATH=$tt_cache_llama90b pytest models/tt_transformers/tests/test_model_prefill.py -k "performance and 1layer" ; fail+=$?
 
   # Record the end time
-#  end_time=$(date +%s)
-#  duration=$((end_time - start_time))
-#  echo "LOG_METAL: run_t3000_llama3_90b_tests $duration seconds to complete"
-#  if [[ $fail -ne 0 ]]; then
-#    exit 1
-# fi
-#}
+  end_time=$(date +%s)
+  duration=$((end_time - start_time))
+  echo "LOG_METAL: run_t3000_llama3_90b_tests $duration seconds to complete"
+  if [[ $fail -ne 0 ]]; then
+    exit 1
+ fi
+}
 
 run_t3000_llama3_accuracy_tests() {
   # Record the start time
@@ -461,7 +461,7 @@ run_t3000_tests() {
   run_t3000_llama3_70b_tests
 
   # Run llama3-90b tests
-  #run_t3000_llama3_90b_tests
+  run_t3000_llama3_90b_tests
 
   # Run llama3 accuracy tests
   run_t3000_llama3_accuracy_tests


### PR DESCRIPTION
### Problem description
These Llama vision tests were failing:
https://github.com/tenstorrent/tt-metal/actions/runs/22205524462/job/64228933766#logs
https://github.com/tenstorrent/tt-metal/actions/runs/22205524462/job/64228933765#logs
https://github.com/tenstorrent/tt-metal/actions/runs/22205524462/job/64228933734#logs
https://github.com/tenstorrent/tt-metal/actions/runs/22205524462/job/64228933781#logs

Fix was needed for these tests

### What's changed
The fix for Llama3 vision models is in the PR but it was also decided that Llama vision model test should be commented out because they are Tier 3 models. This also includes Llama 3.2 1B, 3B and 11B models so the integration tests for them are also commented out.