### PR TITLE
[MODELS] Updating the perf target to variety of models for BH

### DIFF
--- a/models/demos/vision/classification/resnet50/blackhole/tests/test_perf_device_resnet50.py
+++ b/models/demos/vision/classification/resnet50/blackhole/tests/test_perf_device_resnet50.py
@@ -14,7 +14,7 @@ from models.demos.vision.classification.resnet50.ttnn_resnet.tests.common.perf_d
     "batch_size, test, expected_perf",
     [
         [16, "True-DataType.BFLOAT8_B-DataType.BFLOAT8_B-MathFidelity.LoFi-16-device_params0", 10610.0],
-        [32, "True-DataType.BFLOAT8_B-DataType.BFLOAT8_B-MathFidelity.LoFi-32-device_params0", 15480.0],
+        [32, "True-DataType.BFLOAT8_B-DataType.BFLOAT8_B-MathFidelity.LoFi-32-device_params0", 12960.0],
     ],
 )
 def test_perf_device(batch_size, test, expected_perf):

--- a/models/demos/vision/classification/vit/blackhole/tests/test_vit_device_perf.py
+++ b/models/demos/vision/classification/vit/blackhole/tests/test_vit_device_perf.py
@@ -23,6 +23,10 @@ def test_vit_device_ops(
     device,
     batch_size,
 ):
+    num_cores = device.compute_with_storage_grid_size().x * device.compute_with_storage_grid_size().y
+    if num_cores < 120:
+        pytest.skip(f"ViT requires at least 120 cores but device has {num_cores}")
+
     torch.manual_seed(0)
 
     test_infra = create_test_infra(device, batch_size, use_random_input_tensor=True)
@@ -51,6 +55,9 @@ def test_vit_device_ops(
 )
 @pytest.mark.models_device_performance_bare_metal
 def test_vit_perf_device(batch_size, expected_kernel_samples_per_sec):
+    # TODO: This test requires 120 cores but P150 has only 110.
+    # The inner test (test_vit_device_ops) will skip on P150.
+    # Consider removing vit from P150 device perf tests or creating a P150-specific config.
     command = f"pytest models/demos/vision/classification/vit/blackhole/tests/test_vit_device_perf.py::test_vit_device_ops[{batch_size}-device_params0]"
     cols = ["DEVICE FW", "DEVICE KERNEL", "DEVICE BRISC KERNEL"]
 

--- a/models/demos/vision/classification/vit/blackhole/tests/test_vit_device_perf.py
+++ b/models/demos/vision/classification/vit/blackhole/tests/test_vit_device_perf.py
@@ -23,10 +23,6 @@ def test_vit_device_ops(
     device,
     batch_size,
 ):
-    num_cores = device.compute_with_storage_grid_size().x * device.compute_with_storage_grid_size().y
-    if num_cores < 120:
-        pytest.skip(f"ViT requires at least 120 cores but device has {num_cores}")
-
     torch.manual_seed(0)
 
     test_infra = create_test_infra(device, batch_size, use_random_input_tensor=True)
@@ -55,9 +51,6 @@ def test_vit_device_ops(
 )
 @pytest.mark.models_device_performance_bare_metal
 def test_vit_perf_device(batch_size, expected_kernel_samples_per_sec):
-    # TODO: This test requires 120 cores but P150 has only 110.
-    # The inner test (test_vit_device_ops) will skip on P150.
-    # Consider removing vit from P150 device perf tests or creating a P150-specific config.
     command = f"pytest models/demos/vision/classification/vit/blackhole/tests/test_vit_device_perf.py::test_vit_device_ops[{batch_size}-device_params0]"
     cols = ["DEVICE FW", "DEVICE KERNEL", "DEVICE BRISC KERNEL"]
 

--- a/models/demos/vision/generative/stable_diffusion/wormhole/tests/test_perf.py
+++ b/models/demos/vision/generative/stable_diffusion/wormhole/tests/test_perf.py
@@ -421,7 +421,7 @@ def test_stable_diffusion_perf(
 @pytest.mark.models_device_performance_bare_metal
 @pytest.mark.parametrize(
     "expected_kernel_samples_per_second",
-    ((13.2) if is_wormhole_b0() else (21.0),),
+    ((13.2) if is_wormhole_b0() else (22.0),),
 )
 def test_stable_diffusion_device_perf(expected_kernel_samples_per_second):
     subdir = "ttnn_stable_diffusion"
@@ -451,7 +451,7 @@ def test_stable_diffusion_device_perf(expected_kernel_samples_per_second):
 @pytest.mark.models_device_performance_bare_metal
 @pytest.mark.parametrize(
     "expected_kernel_samples_per_second",
-    ((2.95) if is_wormhole_b0() else (4.10),),
+    ((2.95) if is_wormhole_b0() else (4.75),),
 )
 def test_stable_diffusion_vae_device_perf(expected_kernel_samples_per_second):
     subdir = "ttnn_stable_diffusion_vae"

--- a/models/demos/vision/segmentation/vgg_unet/blackhole/tests/perf/test_perf_vgg_unet.py
+++ b/models/demos/vision/segmentation/vgg_unet/blackhole/tests/perf/test_perf_vgg_unet.py
@@ -11,7 +11,7 @@ from models.perf.device_perf_utils import check_device_perf, prep_device_perf_re
 @pytest.mark.parametrize(
     "batch_size, expected_perf",
     [
-        [1, 488],
+        [1, 472],
     ],
 )
 @pytest.mark.models_device_performance_bare_metal

--- a/models/experimental/functional_unet/tests/test_unet_perf.py
+++ b/models/experimental/functional_unet/tests/test_unet_perf.py
@@ -129,7 +129,7 @@ def run_multi_iteration_perf_test(test_func, num_runs, *args, **kwargs) -> Perfo
 @pytest.mark.models_device_performance_bare_metal
 @pytest.mark.parametrize(
     "batch, groups, expected_device_perf_fps",
-    ((1, 4, 1632.0) if is_wormhole_b0() else (1, 4, 2875.5),),
+    ((1, 4, 1632.0) if is_wormhole_b0() else (1, 4, 3125.0),),
 )
 def test_unet_perf_device(batch: int, groups: int, expected_device_perf_fps: float):
     command = f"pytest models/experimental/functional_unet/tests/test_unet_perf.py::test_unet_model"

--- a/tests/ttnn/perf_tests/operations/conv/test_conv2d_device_perf.py
+++ b/tests/ttnn/perf_tests/operations/conv/test_conv2d_device_perf.py
@@ -30,7 +30,7 @@ CONV_PERF_CONFIGS = [
         "act_block_h_override": 0, "act_block_w_div": 1,
         "enable_activation_reuse": False, "enable_act_double_buffer": False,
         "enable_weights_double_buffer": False, "fp32_accum": False,
-        "perf_targets": {"wh": 67, "bh_p150": 25},
+        "perf_targets": {"wh": 67, "bh_p150": 28},
     },
     # HEIGHT SHARDED, Unet - dm bound (activation reuse)
     {


### PR DESCRIPTION
### Problem description
Updating the firmware version to CI devices caused a bunch of models to be outside of the perf targets. This fw comes with harvesting one more column which causes perf drops throughout the models. Therefore values have been updated according to mean values of multiple runs on BH P150. Some of the models experienced perf increase.

### What's changed                                                            
<google-sheets-html-origin><!--td {border: 1px solid #cccccc;}br {mso-data-placement:same-cell;}-->
Test | Actual Value | New Target | Old target
-- | -- | -- | --
conv2d DURATION | 27.279 µs | 28 µs |  25 µs
vgg_unet FPS | 471.97 | 472 |  488
functional_unet FPS | 3126.14 | 3125 | 2875.5
SD 1.4. FPS | 21.72 | 22 | 21
SD 1.4. VAE FPS | 4.77 | 4.75 | 4.1
resnet50 batch32 FPS | 12962.9 | 12960 | 15480

- [x] [(Single-card) Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/runs/22357296598)