### PR TITLE
Move ControlPlane construction helpers out of MetalContext

### DIFF
--- a/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_fabric_apis.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_fabric_apis.cpp
@@ -45,12 +45,6 @@
 
 namespace tt::tt_fabric::fabric_router_tests {
 
-// hack to let topology.cpp to know the binary is a unit test
-// https://github.com/tenstorrent/tt-metal/issues/20000
-// TODO: delete this once tt_fabric_api.h fully support low latency feature
-extern "C" bool isFabricUnitTest();
-bool isFabricUnitTest() { return true; }
-
 using tt::tt_metal::HalProgrammableCoreType;
 using tt::tt_metal::KernelHandle;
 using tt::tt_metal::ShardOrientation;

--- a/tt_metal/fabric/fabric_init.cpp
+++ b/tt_metal/fabric/fabric_init.cpp
@@ -8,9 +8,14 @@
 #include "tt_metal/fabric/fabric_context.hpp"
 #include "tt_metal/fabric/fabric_builder_context.hpp"
 #include "tt_metal/fabric/fabric_builder.hpp"
+#include <tt-metalium/experimental/fabric/fabric_types.hpp>
 #include <tt-metalium/experimental/fabric/control_plane.hpp>
+#include <tt-metalium/distributed_context.hpp>
 #include "impl/context/metal_context.hpp"
 #include "llrt/metal_soc_descriptor.hpp"
+#include "llrt/tt_cluster.hpp"
+#include "llrt/rtoptions.hpp"
+#include "llrt/hal.hpp"
 
 // hack for test_basic_fabric_apis.cpp
 // https://github.com/tenstorrent/tt-metal/issues/20000
@@ -19,6 +24,85 @@ extern "C" bool isFabricUnitTest() __attribute__((weak));
 bool isFabricUnitTest() { return false; }
 
 namespace tt::tt_fabric {
+
+std::unique_ptr<tt::tt_fabric::ControlPlane> construct_control_plane(
+    const std::filesystem::path& mesh_graph_desc_path,
+    tt::Cluster& cluster,
+    const ::tt::llrt::RunTimeOptions& rtoptions,
+    const ::tt::tt_metal::Hal& hal,
+    const tt_metal::distributed::multihost::DistributedContext& distributed_context,
+    const tt_fabric::FabricConfig& fabric_config,
+    const tt_fabric::FabricReliabilityMode& fabric_reliability_mode,
+    const tt_fabric::FabricTensixConfig& fabric_tensix_config,
+    const tt_fabric::FabricUDMMode& fabric_udm_mode,
+    const tt_fabric::FabricRouterConfig& fabric_router_config,
+    const tt_fabric::FabricManagerMode& fabric_manager,
+    const std::map<tt_fabric::FabricNodeId, ChipId>& logical_mesh_chip_id_to_physical_chip_id_mapping) {
+    if (!logical_mesh_chip_id_to_physical_chip_id_mapping.empty()) {
+        log_info(tt::LogDistributed, "Using custom Fabric Node Id to physical chip mapping.");
+        return std::make_unique<tt::tt_fabric::ControlPlane>(
+            cluster,
+            rtoptions,
+            hal,
+            distributed_context,
+            mesh_graph_desc_path.string(),
+            logical_mesh_chip_id_to_physical_chip_id_mapping,
+            fabric_config,
+            fabric_reliability_mode,
+            fabric_tensix_config,
+            fabric_udm_mode,
+            fabric_router_config,
+            fabric_manager);
+    }
+
+    return std::make_unique<tt::tt_fabric::ControlPlane>(
+        cluster,
+        rtoptions,
+        hal,
+        distributed_context,
+        mesh_graph_desc_path.string(),
+        fabric_config,
+        fabric_reliability_mode,
+        fabric_tensix_config,
+        fabric_udm_mode,
+        fabric_router_config,
+        fabric_manager);
+}
+
+std::unique_ptr<tt::tt_fabric::ControlPlane> construct_control_plane(
+    tt::Cluster& cluster,
+    const ::tt::llrt::RunTimeOptions& rtoptions,
+    const ::tt::tt_metal::Hal& hal,
+    const tt_metal::distributed::multihost::DistributedContext& distributed_context,
+    const tt_fabric::FabricConfig& fabric_config,
+    const tt_fabric::FabricReliabilityMode& fabric_reliability_mode,
+    const tt_fabric::FabricTensixConfig& fabric_tensix_config,
+    const tt_fabric::FabricUDMMode& fabric_udm_mode,
+    const tt_fabric::FabricRouterConfig& fabric_router_config,
+    const tt_fabric::FabricManagerMode& fabric_manager,
+    const std::map<tt_fabric::FabricNodeId, ChipId>& logical_mesh_chip_id_to_physical_chip_id_mapping) {
+    // Use auto-discovery to generate mesh graph from physical system descriptor
+    // This uses MeshGraph::generate_from_physical_system_descriptor which internally
+    // uses map_mesh_to_physical to find a valid mapping
+    if (!logical_mesh_chip_id_to_physical_chip_id_mapping.empty()) {
+        log_warning(
+            tt::LogDistributed,
+            "Custom Fabric Node Id to physical chip mapping provided but no mesh graph descriptor path. "
+            "Mapping will be ignored. Please provide a custom mesh graph descriptor path for custom logical to "
+            "physical mapping.");
+    }
+    return std::make_unique<tt::tt_fabric::ControlPlane>(
+        cluster,
+        rtoptions,
+        hal,
+        distributed_context,
+        fabric_config,
+        fabric_reliability_mode,
+        fabric_tensix_config,
+        fabric_udm_mode,
+        fabric_router_config,
+        fabric_manager);
+}
 
 std::unique_ptr<tt::tt_metal::Program> create_and_compile_tt_fabric_program(tt::tt_metal::IDevice* device) {
     auto fabric_program_ptr = std::make_unique<tt::tt_metal::Program>();

--- a/tt_metal/fabric/fabric_init.cpp
+++ b/tt_metal/fabric/fabric_init.cpp
@@ -17,12 +17,6 @@
 #include "llrt/rtoptions.hpp"
 #include "llrt/hal.hpp"
 
-// hack for test_basic_fabric_apis.cpp
-// https://github.com/tenstorrent/tt-metal/issues/20000
-// TODO: delete this once tt_fabric_api.h fully support low latency feature
-extern "C" bool isFabricUnitTest() __attribute__((weak));
-bool isFabricUnitTest() { return false; }
-
 namespace tt::tt_fabric {
 
 std::unique_ptr<tt::tt_fabric::ControlPlane> construct_control_plane(
@@ -91,6 +85,7 @@ std::unique_ptr<tt::tt_fabric::ControlPlane> construct_control_plane(
             "Mapping will be ignored. Please provide a custom mesh graph descriptor path for custom logical to "
             "physical mapping.");
     }
+    log_info(tt::LogDistributed, "Constructing control plane using auto-discovery (no mesh graph descriptor).");
     return std::make_unique<tt::tt_fabric::ControlPlane>(
         cluster,
         rtoptions,

--- a/tt_metal/fabric/fabric_init.hpp
+++ b/tt_metal/fabric/fabric_init.hpp
@@ -6,8 +6,45 @@
 
 #include "device.hpp"
 #include "tt_metal.hpp"
+#include <tt-metalium/experimental/fabric/control_plane.hpp>
+#include <tt-metalium/experimental/fabric/fabric_types.hpp>
+#include <tt-metalium/distributed_context.hpp>
+#include "llrt/tt_cluster.hpp"
+#include "llrt/rtoptions.hpp"
+#include "llrt/hal.hpp"
 
 namespace tt::tt_fabric {
+
+// Construct control plane using MGD
+std::unique_ptr<tt::tt_fabric::ControlPlane> construct_control_plane(
+    const std::filesystem::path& mesh_graph_desc_path,
+    tt::Cluster& cluster,
+    const ::tt::llrt::RunTimeOptions& rtoptions,
+    const ::tt::tt_metal::Hal& hal,
+    const tt_metal::distributed::multihost::DistributedContext& distributed_context,
+    const tt_fabric::FabricConfig& fabric_config = tt_fabric::FabricConfig::DISABLED,
+    const tt_fabric::FabricReliabilityMode& fabric_reliability_mode =
+        tt_fabric::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE,
+    const tt_fabric::FabricTensixConfig& fabric_tensix_config = tt_fabric::FabricTensixConfig::DISABLED,
+    const tt_fabric::FabricUDMMode& fabric_udm_mode = tt_fabric::FabricUDMMode::DISABLED,
+    const tt_fabric::FabricRouterConfig& fabric_router_config = tt_fabric::FabricRouterConfig{},
+    const tt_fabric::FabricManagerMode& fabric_manager = tt_fabric::FabricManagerMode::DEFAULT,
+    const std::map<tt_fabric::FabricNodeId, ChipId>& logical_mesh_chip_id_to_physical_chip_id_mapping = {});
+
+// Construct control plane using auto-discovery
+std::unique_ptr<tt::tt_fabric::ControlPlane> construct_control_plane(
+    tt::Cluster& cluster,
+    const ::tt::llrt::RunTimeOptions& rtoptions,
+    const ::tt::tt_metal::Hal& hal,
+    const tt_metal::distributed::multihost::DistributedContext& distributed_context,
+    const tt_fabric::FabricConfig& fabric_config = tt_fabric::FabricConfig::DISABLED,
+    const tt_fabric::FabricReliabilityMode& fabric_reliability_mode =
+        tt_fabric::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE,
+    const tt_fabric::FabricTensixConfig& fabric_tensix_config = tt_fabric::FabricTensixConfig::DISABLED,
+    const tt_fabric::FabricUDMMode& fabric_udm_mode = tt_fabric::FabricUDMMode::DISABLED,
+    const tt_fabric::FabricRouterConfig& fabric_router_config = tt_fabric::FabricRouterConfig{},
+    const tt_fabric::FabricManagerMode& fabric_manager = tt_fabric::FabricManagerMode::DEFAULT,
+    const std::map<tt_fabric::FabricNodeId, ChipId>& logical_mesh_chip_id_to_physical_chip_id_mapping = {});
 
 // Compile fabric kernels needed to support scaleout systems.
 std::unique_ptr<tt::tt_metal::Program> create_and_compile_fabric_program(tt::tt_metal::IDevice* device);

--- a/tt_metal/impl/context/metal_context.cpp
+++ b/tt_metal/impl/context/metal_context.cpp
@@ -21,6 +21,7 @@
 #include "hal_types.hpp"
 #include "fabric/channel_trimming_export.hpp"
 #include "fabric/fabric_host_utils.hpp"
+#include "fabric/fabric_init.hpp"
 #include "allocator/allocator.hpp"
 #include "allocator/l1_banking_allocator.hpp"
 #include "debug/dprint_server.hpp"
@@ -826,9 +827,6 @@ void MetalContext::teardown_fabric_config() {
     this->fabric_config_ = tt_fabric::FabricConfig::DISABLED;
     this->cluster_->configure_ethernet_cores_for_fabric_routers(this->fabric_config_);
     this->num_fabric_active_routing_planes_ = 0;
-    // if (!rtoptions_.get_erisc_iram_env_var_enabled()) {
-    //     rtoptions_.set_erisc_iram_enabled(false);
-    // }
     // Stub control plane for mock devices will make this a no-op
     this->get_control_plane().clear_fabric_context();
 }
@@ -984,63 +982,6 @@ std::shared_ptr<ContextDescriptor> MetalContext::create_context_descriptor(
         rtoptions_.get_mock_cluster_desc_path()));
 }
 
-void MetalContext::construct_control_plane(const std::filesystem::path& mesh_graph_desc_path) {
-    if (!logical_mesh_chip_id_to_physical_chip_id_mapping_.empty()) {
-        log_info(tt::LogDistributed, "Using custom Fabric Node Id to physical chip mapping.");
-        control_plane_ = std::make_unique<tt::tt_fabric::ControlPlane>(
-            *this->cluster_,
-            this->rtoptions_,
-            *hal_,
-            *distributed_context_,
-            mesh_graph_desc_path.string(),
-            logical_mesh_chip_id_to_physical_chip_id_mapping_,
-            this->fabric_config_,
-            this->fabric_reliability_mode_,
-            this->fabric_tensix_config_,
-            this->fabric_udm_mode_,
-            this->fabric_router_config_,
-            this->fabric_manager_);
-    } else {
-        control_plane_ = std::make_unique<tt::tt_fabric::ControlPlane>(
-            *this->cluster_,
-            this->rtoptions_,
-            *hal_,
-            *distributed_context_,
-            mesh_graph_desc_path.string(),
-            this->fabric_config_,
-            this->fabric_reliability_mode_,
-            this->fabric_tensix_config_,
-            this->fabric_udm_mode_,
-            this->fabric_router_config_,
-            this->fabric_manager_);
-    }
-}
-
-void MetalContext::construct_control_plane() {
-    // Use auto-discovery to generate mesh graph from physical system descriptor
-    // This uses MeshGraph::generate_from_physical_system_descriptor which internally
-    // uses map_mesh_to_physical to find a valid mapping
-    if (!logical_mesh_chip_id_to_physical_chip_id_mapping_.empty()) {
-        log_warning(
-            tt::LogDistributed,
-            "Custom Fabric Node Id to physical chip mapping provided but no mesh graph descriptor path. "
-            "Mapping will be ignored. Please provide a custom mesh graph descriptor path for custom logical to "
-            "physical mapping.");
-    }
-    log_info(tt::LogDistributed, "Constructing control plane using auto-discovery (no mesh graph descriptor).");
-    control_plane_ = std::make_unique<tt::tt_fabric::ControlPlane>(
-        *this->cluster_,
-        this->rtoptions_,
-        *hal_,
-        *distributed_context_,
-        this->fabric_config_,
-        this->fabric_reliability_mode_,
-        this->fabric_tensix_config_,
-        this->fabric_udm_mode_,
-        this->fabric_router_config_,
-        this->fabric_manager_);
-}
-
 void MetalContext::initialize_control_plane() {
     std::lock_guard<std::mutex> lock(control_plane_mutex_);
     initialize_control_plane_impl();
@@ -1056,14 +997,37 @@ void MetalContext::initialize_control_plane_impl() {
             mesh_graph_desc_path.string());
 
         log_info(tt::LogDistributed, "Using custom mesh graph descriptor: {}", mesh_graph_desc_path.string());
-        this->construct_control_plane(mesh_graph_desc_path);
+        control_plane_ = tt::tt_fabric::construct_control_plane(
+            mesh_graph_desc_path,
+            *cluster_,
+            rtoptions_,
+            *hal_,
+            *distributed_context_,
+            fabric_config_,
+            fabric_reliability_mode_,
+            fabric_tensix_config_,
+            fabric_udm_mode_,
+            fabric_router_config_,
+            fabric_manager_,
+            logical_mesh_chip_id_to_physical_chip_id_mapping_);
         return;
     }
     // If no custom mesh graph descriptor use auto discovery to generate mesh graph
     log_info(tt::LogDistributed, "Using auto discovery to generate mesh graph.");
 
     if (*distributed_context_->size() == 1) {
-        this->construct_control_plane();
+        control_plane_ = tt::tt_fabric::construct_control_plane(
+            *cluster_,
+            rtoptions_,
+            *hal_,
+            *distributed_context_,
+            fabric_config_,
+            fabric_reliability_mode_,
+            fabric_tensix_config_,
+            fabric_udm_mode_,
+            fabric_router_config_,
+            fabric_manager_,
+            logical_mesh_chip_id_to_physical_chip_id_mapping_);
     } else {
         auto cluster_type = cluster_->get_cluster_type();
         auto fabric_type = tt::tt_fabric::get_fabric_type(this->fabric_config_, cluster_->is_ubb_galaxy());
@@ -1078,7 +1042,19 @@ void MetalContext::initialize_control_plane_impl() {
             std::filesystem::exists(mesh_graph_desc_path),
             "Mesh graph descriptor file not found: {}",
             mesh_graph_desc_path.string());
-        this->construct_control_plane(mesh_graph_desc_path);
+        control_plane_ = tt::tt_fabric::construct_control_plane(
+            mesh_graph_desc_path,
+            *cluster_,
+            rtoptions_,
+            *hal_,
+            *distributed_context_,
+            fabric_config_,
+            fabric_reliability_mode_,
+            fabric_tensix_config_,
+            fabric_udm_mode_,
+            fabric_router_config_,
+            fabric_manager_,
+            logical_mesh_chip_id_to_physical_chip_id_mapping_);
     }
 }
 

--- a/tt_metal/impl/context/metal_context.hpp
+++ b/tt_metal/impl/context/metal_context.hpp
@@ -169,8 +169,6 @@ private:
     void clear_l1_state(ChipId device_id);
     void clear_dram_state(ChipId device_id);
     void clear_launch_messages_on_eth_cores(ChipId device_id);
-    void construct_control_plane(const std::filesystem::path& mesh_graph_desc_path);
-    void construct_control_plane();
 
     // Reinitialize dispatch managers when transitioning dispatch modes (SD<->FD)
     // This updates cached dispatch/compute core allocations to match current dispatch mode


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/37246
https://github.com/tenstorrent/tt-metal/issues/20000

### Problem description
Control Plane init logic does not belong in MetalContext

### What's changed
- Move init helpers to fabric_init.cpp
- Delete unused extern in fabric_init.cpp

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=nhuang/move-control-plane-init)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:nhuang/move-control-plane-init)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=nhuang/move-control-plane-init)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:nhuang/move-control-plane-init)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nhuang/move-control-plane-init)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nhuang/move-control-plane-init)
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nhuang/move-control-plane-init)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nhuang/move-control-plane-init)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nhuang/move-control-plane-init)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nhuang/move-control-plane-init)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nhuang/move-control-plane-init)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nhuang/move-control-plane-init)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
