### PR TITLE
[QSR]: Add Watcher Assert Support for DMs

### DIFF
--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_assert.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_assert.cpp
@@ -82,11 +82,11 @@ static void RunTest(
                         // On Quasar, kernel runs on all 8 DMs but only dm_id executes the test;
                         // others exit early. This lets us verify assert works on each DM individually
                         uint32_t dm_id = static_cast<uint32_t>(processor.processor_type);
-                        assert_kernel = experimental::quasar::CreateKernel(
+                        assert_kernel = tt::tt_metal::experimental::quasar::CreateKernel(
                             program_,
                             kernel,
                             logical_core,
-                            experimental::quasar::QuasarDataMovementConfig{
+                            tt::tt_metal::experimental::quasar::QuasarDataMovementConfig{
                                 .num_processors_per_cluster = 8, .compile_args = {dm_id}});
                     } else {
                         DataMovementConfig dm_config{};
@@ -202,9 +202,9 @@ static void RunTest(
         std::string pattern = regex_escape(expected);
         const std::string placeholder = "on line 0";
         size_t pos = pattern.find(placeholder);
-        if (pos != std::string::npos) {
-            pattern.replace(pos, placeholder.length(), "on line \\d+");
-        }
+        ASSERT_NE(pos, std::string::npos)
+            << "Expected placeholder '" << placeholder << "' not found in escaped pattern: " << pattern;
+        pattern.replace(pos, placeholder.length(), "on line \\d+");
         EXPECT_TRUE(std::regex_match(exception, std::regex(pattern)))
             << "Expected pattern: " << pattern << "\nActual: " << exception;
     } else {

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_assert.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_assert.cpp
@@ -26,6 +26,7 @@
 #include <tt_stl/span.hpp>
 #include "impl/kernels/kernel.hpp"
 #include <tt-metalium/experimental/host_api.hpp>
+#include "impl/debug/debug_helpers.hpp"
 
 //////////////////////////////////////////////////////////////////////////////////////////
 // A test for checking watcher asserts.
@@ -63,8 +64,7 @@ static void RunTest(
     constexpr uint32_t line_num = 67;  // Note: this should match the assert line # in watcher_asserts.cpp
     const std::string kernel = "tests/tt_metal/tt_metal/test_kernels/misc/watcher_asserts.cpp";
 
-    // Depending on riscv type, choose one core to run the test on
-    // and set up the kernel on the correct risc
+    // Depending on riscv type, choose one core to run the test on (since the test hangs the board).
     CoreCoord logical_core, virtual_core;
     // Set up the kernel on the correct risc
     KernelHandle assert_kernel;
@@ -143,7 +143,7 @@ static void RunTest(
 
     // Run the kernel, don't expect an issue here.
     log_info(LogTest, "Running args that shouldn't assert...");
-    fixture->RunProgram(mesh_device, workload);
+    fixture->RunProgram(mesh_device, workload, true);
     log_info(LogTest, "Args did not assert!");
 
     // Write runtime args that should trip an assert.
@@ -156,37 +156,11 @@ static void RunTest(
 
     // We should be able to find the expected watcher error in the log as well,
     // expected error message depends on the risc we're running on and the assert type.
-    std::string_view core_str = (processor.core_type == HalProgrammableCoreType::ACTIVE_ETH) ? "acteth" : "worker";
-    std::string msg;
-
-    switch (assert_type) {
-        case dev_msgs::DebugAssertTripped:
-            msg = fmt::format(
-                "tripped an assert on line {}. Note that file name reporting is not yet implemented, and the reported "
-                "line number for the assert may be from a different file",
-                line_num);
-            break;
-
-        case dev_msgs::DebugAssertNCriscNOCReadsFlushedTripped:
-        case dev_msgs::DebugAssertNCriscNOCNonpostedWritesSentTripped:
-        case dev_msgs::DebugAssertNCriscNOCNonpostedAtomicsFlushedTripped:
-        case dev_msgs::DebugAssertNCriscNOCPostedWritesSentTripped: {
-            constexpr std::string_view barriers[] = {
-                "reads flushed", "non-posted writes sent", "non-posted atomics flushed", "posted writes sent"};
-            msg = fmt::format(
-                "detected an inter-kernel data race due to kernel completing with pending NOC transactions (missing "
-                "NOC {} barrier)",
-                barriers[assert_type - dev_msgs::DebugAssertNCriscNOCReadsFlushedTripped]);
-            break;
-        }
-        case dev_msgs::DebugAssertRtaOutOfBounds:
-        case dev_msgs::DebugAssertCrtaOutOfBounds:
-            msg = fmt::format(
-                "accessed {} runtime arg index out of bounds",
-                (assert_type == dev_msgs::DebugAssertRtaOutOfBounds) ? "unique" : "common");
-            break;
-
-        default: TT_THROW("Unhandled assert type {}", static_cast<int>(assert_type));
+    const std::string_view core_str =
+        (processor.core_type == HalProgrammableCoreType::ACTIVE_ETH) ? "acteth" : "worker";
+    const std::string msg = get_debug_assert_message(assert_type, line_num);
+    if (msg.empty()) {
+        TT_THROW("Unhandled assert type {}", static_cast<int>(assert_type));
     }
 
     // Combine everything in one final pass

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_assert.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_assert.cpp
@@ -25,6 +25,7 @@
 #include <tt-metalium/program.hpp>
 #include <tt_stl/span.hpp>
 #include "impl/kernels/kernel.hpp"
+#include <tt-metalium/experimental/host_api.hpp>
 
 //////////////////////////////////////////////////////////////////////////////////////////
 // A test for checking watcher asserts.
@@ -47,9 +48,7 @@ static std::string regex_escape(const std::string& s) {
 static void RunTest(
     MeshWatcherFixture* fixture,
     const std::shared_ptr<distributed::MeshDevice>& mesh_device,
-    HalProgrammableCoreType programmable_core_type,
-    HalProcessorClassType processor_class,
-    int processor_id,
+    HalProcessorIdentifier processor,
     dev_msgs::debug_assert_type_t assert_type = dev_msgs::DebugAssertTripped) {
     // Set up program
     distributed::MeshWorkload workload;
@@ -59,13 +58,60 @@ static void RunTest(
     workload.add_program(device_range, std::move(program));
     auto& program_ = workload.get_programs().at(device_range);
     auto* device = mesh_device->get_devices()[0];
+    const auto& hal = tt::tt_metal::MetalContext::instance().hal();
+    bool is_quasar = hal.get_arch() == tt::ARCH::QUASAR;
 
-    // Depending on riscv type, choose one core to run the test on (since the test hangs the board).
+    // Depending on riscv type, choose one core to run the test on
+    // and set up the kernel on the correct risc
     CoreCoord logical_core, virtual_core;
-    switch (programmable_core_type) {
+    // Set up the kernel on the correct risc
+    KernelHandle assert_kernel;
+    auto procesor_idx =
+        hal.get_processor_index(processor.core_type, processor.processor_class, processor.processor_type);
+    std::string risc = hal.get_processor_class_name(processor.core_type, procesor_idx, false).c_str();
+    switch (processor.core_type) {
         case HalProgrammableCoreType::TENSIX:
             logical_core = {0, 0};
             virtual_core = device->worker_core_from_logical_core(logical_core);
+            switch (processor.processor_class) {
+                case HalProcessorClassType::DM:
+                    if (is_quasar) {
+                        assert_kernel = experimental::quasar::CreateKernel(
+                            program_,
+                            "tests/tt_metal/tt_metal/test_kernels/misc/watcher_asserts.cpp",
+                            logical_core,
+                            experimental::quasar::QuasarDataMovementConfig{.num_processors_per_cluster = 8});
+                    } else {
+                        DataMovementConfig dm_config{};
+                        dm_config.processor = static_cast<tt_metal::DataMovementProcessor>(processor.processor_type);
+                        dm_config.noc = (processor.processor_type ==
+                                         enchantum::to_underlying(tt::tt_metal::DataMovementProcessor::RISCV_1))
+                                            ? tt_metal::NOC::RISCV_1_default
+                                            : tt_metal::NOC::RISCV_0_default;
+                        assert_kernel = CreateKernel(
+                            program_,
+                            "tests/tt_metal/tt_metal/test_kernels/misc/watcher_asserts.cpp",
+                            logical_core,
+                            dm_config);
+                    }
+                    break;
+                case HalProcessorClassType::COMPUTE:
+                    // TODO: Watcher features are temporarily skipped on Quasar until basic runtime bring-up is complete
+                    if (is_quasar && processor.processor_type >= 3) {
+                        return;
+                    }
+                    TT_FATAL(
+                        0 <= processor.processor_type && processor.processor_type < 3,
+                        "processor_id {} must be 0, 1, or 2 for COMPUTE",
+                        processor.processor_type);
+                    assert_kernel = CreateKernel(
+                        program_,
+                        "tests/tt_metal/tt_metal/test_kernels/misc/watcher_asserts.cpp",
+                        logical_core,
+                        ComputeConfig{.defines = {{fmt::format("TRISC{}", processor.processor_type), "1"}}});
+
+                    break;
+            }
             break;
         case HalProgrammableCoreType::ACTIVE_ETH:
             if (device->get_active_ethernet_cores(true).empty()) {
@@ -74,65 +120,6 @@ static void RunTest(
             }
             logical_core = *(device->get_active_ethernet_cores(true).begin());
             virtual_core = device->ethernet_core_from_logical_core(logical_core);
-            break;
-        case HalProgrammableCoreType::IDLE_ETH:
-            if (device->get_inactive_ethernet_cores().empty()) {
-                log_info(LogTest, "Skipping this test since device has no inactive ethernet cores.");
-                GTEST_SKIP();
-            }
-            logical_core = *(device->get_inactive_ethernet_cores().begin());
-            virtual_core = device->ethernet_core_from_logical_core(logical_core);
-            break;
-        case HalProgrammableCoreType::COUNT: TT_THROW("Unsupported programmable core type");
-    }
-    log_info(LogTest, "Running test on device {} core {}...", device->id(), virtual_core.str());
-
-    // Set up the kernel on the correct risc
-    KernelHandle assert_kernel;
-    std::string risc;
-    switch (programmable_core_type) {
-        case HalProgrammableCoreType::TENSIX:
-            switch (processor_class) {
-                case HalProcessorClassType::DM:
-                    switch (processor_id) {
-                        case 0:
-                            assert_kernel = CreateKernel(
-                                program_,
-                                "tests/tt_metal/tt_metal/test_kernels/misc/watcher_asserts.cpp",
-                                logical_core,
-                                DataMovementConfig{
-                                    .processor = tt_metal::DataMovementProcessor::RISCV_0,
-                                    .noc = tt_metal::NOC::RISCV_0_default});
-                            risc = "BRISC";
-                            break;
-                        case 1:
-                            assert_kernel = CreateKernel(
-                                program_,
-                                "tests/tt_metal/tt_metal/test_kernels/misc/watcher_asserts.cpp",
-                                logical_core,
-                                DataMovementConfig{
-                                    .processor = tt_metal::DataMovementProcessor::RISCV_1,
-                                    .noc = tt_metal::NOC::RISCV_1_default});
-                            risc = "NCRISC";
-                            break;
-                        default: TT_THROW("Unsupported DM processor id {}", processor_id);
-                    }
-                    break;
-                case HalProcessorClassType::COMPUTE:
-                    TT_FATAL(
-                        0 <= processor_id && processor_id < 3,
-                        "processor_id {} must be 0, 1, or 2 for COMPUTE",
-                        processor_id);
-                    assert_kernel = CreateKernel(
-                        program_,
-                        "tests/tt_metal/tt_metal/test_kernels/misc/watcher_asserts.cpp",
-                        logical_core,
-                        ComputeConfig{.defines = {{fmt::format("TRISC{}", processor_id), "1"}}});
-                    risc = fmt::format("TRISC{}", processor_id);
-                    break;
-            }
-            break;
-        case HalProgrammableCoreType::ACTIVE_ETH:
             assert_kernel = CreateKernel(
                 program_,
                 "tests/tt_metal/tt_metal/test_kernels/misc/watcher_asserts.cpp",
@@ -141,6 +128,12 @@ static void RunTest(
             risc = "erisc";
             break;
         case HalProgrammableCoreType::IDLE_ETH:
+            if (device->get_inactive_ethernet_cores().empty()) {
+                log_info(LogTest, "Skipping this test since device has no inactive ethernet cores.");
+                GTEST_SKIP();
+            }
+            logical_core = *(device->get_inactive_ethernet_cores().begin());
+            virtual_core = device->ethernet_core_from_logical_core(logical_core);
             assert_kernel = CreateKernel(
                 program_,
                 "tests/tt_metal/tt_metal/test_kernels/misc/watcher_asserts.cpp",
@@ -150,15 +143,16 @@ static void RunTest(
             break;
         case HalProgrammableCoreType::COUNT: TT_THROW("Unsupported programmable core type");
     }
+    log_info(LogTest, "Running test on device {} core {}[{}]...", device->id(), logical_core, virtual_core);
 
-    // Write runtime args that should not trip an assert.
-    const std::vector<uint32_t> safe_args = {3, 4, static_cast<uint32_t>(assert_type)};
-    SetRuntimeArgs(program_, assert_kernel, logical_core, safe_args);
+    // // Write runtime args that should not trip an assert.
+    // const std::vector<uint32_t> safe_args = {3, 4, static_cast<uint32_t>(assert_type)};
+    // SetRuntimeArgs(program_, assert_kernel, logical_core, safe_args);
 
-    // Run the kernel, don't expect an issue here.
-    log_info(LogTest, "Running args that shouldn't assert...");
-    fixture->RunProgram(mesh_device, workload, true);
-    log_info(LogTest, "Args did not assert!");
+    // // Run the kernel, don't expect an issue here.
+    // log_info(LogTest, "Running args that shouldn't assert...");
+    // fixture->RunProgram(mesh_device, workload, true);
+    // log_info(LogTest, "Args did not assert!");
 
     // Write runtime args that should trip an assert.
     const std::vector<uint32_t> unsafe_args = {3, 3, static_cast<uint32_t>(assert_type)};
@@ -173,10 +167,13 @@ static void RunTest(
     const std::string kernel = "tests/tt_metal/tt_metal/test_kernels/misc/watcher_asserts.cpp";
     std::string expected;
     if (assert_type == dev_msgs::DebugAssertTripped) {
-        std::string before_line = fmt::format(
-            "Device {} {} core(x={:2},y={:2}) virtual(x={:2},y={:2}): {} tripped an assert on line ",
+        const uint32_t line_num = 58;
+        expected = fmt::format(
+            "Device {} {} core(x={:2},y={:2}) virtual(x={:2},y={:2}): {} tripped an assert on line {}. "
+            "Note that file name reporting is not yet implemented, and the reported line number for the assert may be "
+            "from a different file. Current kernel: {}.",
             device->id(),
-            (programmable_core_type == HalProgrammableCoreType::ACTIVE_ETH) ? "acteth" : "worker",
+            (processor.core_type == HalProgrammableCoreType::ACTIVE_ETH) ? "acteth" : "worker",
             logical_core.x,
             logical_core.y,
             virtual_core.x,
@@ -204,7 +201,7 @@ static void RunTest(
             "kernel completing with pending NOC transactions (missing {} barrier). Current kernel: "
             "{}.",
             device->id(),
-            (programmable_core_type == HalProgrammableCoreType::ACTIVE_ETH) ? "acteth" : "worker",
+            (processor.core_type == HalProgrammableCoreType::ACTIVE_ETH) ? "acteth" : "worker",
             logical_core.x,
             logical_core.y,
             virtual_core.x,
@@ -230,9 +227,7 @@ static void RunTest(
 // Test parameters structure
 struct WatcherTestParams {
     std::string test_name;
-    HalProgrammableCoreType core_type;
-    HalProcessorClassType processor_class;
-    int processor_id;
+    HalProcessorIdentifier processor;
     dev_msgs::debug_assert_type_t assert_type = dev_msgs::DebugAssertTripped;
 };
 
@@ -243,22 +238,31 @@ TEST_P(WatcherAssertTest, TestWatcherAssert) {
 
     const auto& params = GetParam();
 
-    if (params.core_type == HalProgrammableCoreType::IDLE_ETH && !this->IsSlowDispatch()) {
+    // Skip if processor type is not available on this architecture
+    const auto& hal = MetalContext::instance().hal();
+    uint32_t core_type_index = hal.get_programmable_core_type_index(params.processor.core_type);
+    uint32_t available_processors =
+        hal.get_processor_types_count(core_type_index, static_cast<uint32_t>(params.processor.processor_class));
+    if (params.processor.processor_type >= available_processors) {
+        log_info(
+            tt::LogTest,
+            "Test {} requires processor type {} but only {} available.",
+            params.test_name,
+            params.processor.processor_type,
+            available_processors);
+        GTEST_SKIP();
+    }
+
+    if (params.processor.core_type == HalProgrammableCoreType::IDLE_ETH && !this->IsSlowDispatch()) {
         log_info(tt::LogTest, "FD-on-idle-eth not supported.");
         GTEST_SKIP();
     }
-    if (this->slow_dispatch_) {
+    if (this->slow_dispatch_ && (tt::tt_metal::MetalContext::instance().hal().get_arch() != tt::ARCH::QUASAR)) {
         GTEST_SKIP();
     }
     this->RunTestOnDevice(
         [&params](MeshWatcherFixture* fixture, const std::shared_ptr<distributed::MeshDevice>& mesh_device) {
-            RunTest(
-                fixture,
-                mesh_device,
-                params.core_type,
-                params.processor_class,
-                params.processor_id,
-                params.assert_type);
+            RunTest(fixture, mesh_device, params.processor, params.assert_type);
         },
         this->devices_[0]);
 }
@@ -272,26 +276,34 @@ INSTANTIATE_TEST_SUITE_P(
     WatcherAssertTests,
     WatcherAssertTest,
     ::testing::Values(
-        WatcherTestParams{"Brisc", TENSIX, DM, 0},
-        WatcherTestParams{"NCrisc", TENSIX, DM, 1},
-        WatcherTestParams{"Trisc0", TENSIX, COMPUTE, 0},
-        WatcherTestParams{"Trisc1", TENSIX, COMPUTE, 1},
-        WatcherTestParams{"Trisc2", TENSIX, COMPUTE, 2},
-        WatcherTestParams{"Erisc", ACTIVE_ETH, DM, 0},
-        WatcherTestParams{"IErisc", IDLE_ETH, DM, 0}),
+        WatcherTestParams{"Brisc", {TENSIX, DM, 0}},
+        WatcherTestParams{"NCrisc", {TENSIX, DM, 1}},
+        // DM2 to DM7 only run on Quasar
+        WatcherTestParams{"DM2", {TENSIX, DM, 2}},
+        WatcherTestParams{"DM3", {TENSIX, DM, 3}},
+        WatcherTestParams{"DM4", {TENSIX, DM, 4}},
+        WatcherTestParams{"DM5", {TENSIX, DM, 5}},
+        WatcherTestParams{"DM6", {TENSIX, DM, 6}},
+        WatcherTestParams{"DM7", {TENSIX, DM, 7}},
+        WatcherTestParams{"Trisc0", {TENSIX, COMPUTE, 0}},
+        WatcherTestParams{"Trisc1", {TENSIX, COMPUTE, 1}},
+        WatcherTestParams{"Trisc2", {TENSIX, COMPUTE, 2}},
+        WatcherTestParams{"Trisc3", {TENSIX, COMPUTE, 3}},  // Trisc3 only Runs on Quasar
+        WatcherTestParams{"Erisc", {ACTIVE_ETH, DM, 0}},
+        WatcherTestParams{"IErisc", {IDLE_ETH, DM, 0}}),
     [](const ::testing::TestParamInfo<WatcherTestParams>& info) { return info.param.test_name; });
 
 INSTANTIATE_TEST_SUITE_P(
     WatcherNonDefaultAssertTests,
     WatcherAssertTest,
     ::testing::Values(
-        WatcherTestParams{"Brisc", TENSIX, DM, 0, dev_msgs::DebugAssertTripped},
-        WatcherTestParams{"NCrisc", TENSIX, DM, 1, dev_msgs::DebugAssertNCriscNOCNonpostedAtomicsFlushedTripped},
-        WatcherTestParams{"Trisc0", TENSIX, COMPUTE, 0, dev_msgs::DebugAssertNCriscNOCNonpostedWritesSentTripped},
-        WatcherTestParams{"Trisc1", TENSIX, COMPUTE, 1, dev_msgs::DebugAssertNCriscNOCPostedWritesSentTripped},
-        WatcherTestParams{"Trisc2", TENSIX, COMPUTE, 2, dev_msgs::DebugAssertNCriscNOCReadsFlushedTripped},
-        WatcherTestParams{"Erisc", ACTIVE_ETH, DM, 0, dev_msgs::DebugAssertNCriscNOCNonpostedAtomicsFlushedTripped},
-        WatcherTestParams{"IErisc", IDLE_ETH, DM, 0, dev_msgs::DebugAssertNCriscNOCReadsFlushedTripped}),
+        WatcherTestParams{"Brisc", {TENSIX, DM, 0}, dev_msgs::DebugAssertTripped},
+        WatcherTestParams{"NCrisc", {TENSIX, DM, 1}, dev_msgs::DebugAssertNCriscNOCNonpostedAtomicsFlushedTripped},
+        WatcherTestParams{"Trisc0", {TENSIX, COMPUTE, 0}, dev_msgs::DebugAssertNCriscNOCNonpostedWritesSentTripped},
+        WatcherTestParams{"Trisc1", {TENSIX, COMPUTE, 1}, dev_msgs::DebugAssertNCriscNOCPostedWritesSentTripped},
+        WatcherTestParams{"Trisc2", {TENSIX, COMPUTE, 2}, dev_msgs::DebugAssertNCriscNOCReadsFlushedTripped},
+        WatcherTestParams{"Erisc", {ACTIVE_ETH, DM, 0}, dev_msgs::DebugAssertNCriscNOCNonpostedAtomicsFlushedTripped},
+        WatcherTestParams{"IErisc", {IDLE_ETH, DM, 0}, dev_msgs::DebugAssertNCriscNOCReadsFlushedTripped}),
     [](const ::testing::TestParamInfo<WatcherTestParams>& info) { return info.param.test_name; });
 
 }  // namespace

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_assert.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_assert.cpp
@@ -76,11 +76,13 @@ static void RunTest(
             switch (processor.processor_class) {
                 case HalProcessorClassType::DM:
                     if (is_quasar) {
+                        uint32_t dm_id = static_cast<uint32_t>(processor.processor_type);
                         assert_kernel = experimental::quasar::CreateKernel(
                             program_,
                             "tests/tt_metal/tt_metal/test_kernels/misc/watcher_asserts.cpp",
                             logical_core,
-                            experimental::quasar::QuasarDataMovementConfig{.num_processors_per_cluster = 8});
+                            experimental::quasar::QuasarDataMovementConfig{
+                                .num_processors_per_cluster = 8, .compile_args = {dm_id}});
                     } else {
                         DataMovementConfig dm_config{};
                         dm_config.processor = static_cast<tt_metal::DataMovementProcessor>(processor.processor_type);
@@ -97,8 +99,8 @@ static void RunTest(
                     break;
                 case HalProcessorClassType::COMPUTE:
                     // TODO: Watcher features are temporarily skipped on Quasar until basic runtime bring-up is complete
-                    if (is_quasar && processor.processor_type >= 3) {
-                        return;
+                    if (is_quasar) {
+                        GTEST_SKIP();
                     }
                     TT_FATAL(
                         0 <= processor.processor_type && processor.processor_type < 3,
@@ -167,7 +169,7 @@ static void RunTest(
     const std::string kernel = "tests/tt_metal/tt_metal/test_kernels/misc/watcher_asserts.cpp";
     std::string expected;
     if (assert_type == dev_msgs::DebugAssertTripped) {
-        const uint32_t line_num = 58;
+        const uint32_t line_num = 65;
         expected = fmt::format(
             "Device {} {} core(x={:2},y={:2}) virtual(x={:2},y={:2}): {} tripped an assert on line {}. "
             "Note that file name reporting is not yet implemented, and the reported line number for the assert may be "

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_assert.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_assert.cpp
@@ -79,6 +79,8 @@ static void RunTest(
             switch (processor.processor_class) {
                 case HalProcessorClassType::DM:
                     if (is_quasar) {
+                        // On Quasar, kernel runs on all 8 DMs but only dm_id executes the test;
+                        // others exit early. This lets us verify assert works on each DM individually
                         uint32_t dm_id = static_cast<uint32_t>(processor.processor_type);
                         assert_kernel = experimental::quasar::CreateKernel(
                             program_,
@@ -108,6 +110,7 @@ static void RunTest(
                         logical_core,
                         ComputeConfig{.defines = {{fmt::format("TRISC{}", processor.processor_type), "1"}}});
                     break;
+                default: TT_THROW("Unsupported processor class type for TENSIX");
             }
             break;
         case HalProgrammableCoreType::ACTIVE_ETH:
@@ -126,6 +129,8 @@ static void RunTest(
                 eth_config.eth_mode = Eth::IDLE;
             }
             assert_kernel = CreateKernel(program_, kernel, logical_core, eth_config);
+            // TODO: replace string literal "erisc" with hal.get_processor_class_name() after
+            // unifying all tests + watcher_device_reader::get_riscv_name() with same method
             risc = "erisc";
             break;
         }
@@ -169,8 +174,10 @@ static void RunTest(
     const std::string_view core_str =
         (processor.core_type == HalProgrammableCoreType::ACTIVE_ETH) ? "acteth" : "worker";
 
-    // Use dummy line number 0, then replace with \d+ for regex matching
-    const std::string msg = get_debug_assert_message(assert_type, 0);
+    // Don't hardcode line number, the ASSERT location in watcher_asserts.cpp kernel
+    // can shift as code changes. Use regex to match any line number for DebugAssertTripped
+    // (get_debug_assert_message defaults to line 0, which we replace with \d+ below)
+    const std::string msg = get_debug_assert_message(assert_type);
     ASSERT_FALSE(msg.empty()) << "Unhandled assert type " << static_cast<int>(assert_type);
 
     std::string expected = fmt::format(
@@ -186,9 +193,8 @@ static void RunTest(
         kernel);
 
     if (assert_type == dev_msgs::DebugAssertTripped) {
-        // For the assert tripped, use regex to match any line number instead of hardcoding
+        // Build regex pattern from string expected, replacing "on line 0" with "on line \d+"
         std::string pattern = regex_escape(expected);
-        // Replace dummy "on line 0" with "on line \d+" to match any number
         const std::string placeholder = "on line 0";
         size_t pos = pattern.find(placeholder);
         if (pos != std::string::npos) {
@@ -197,6 +203,7 @@ static void RunTest(
         EXPECT_TRUE(std::regex_match(exception, std::regex(pattern)))
             << "Expected pattern: " << pattern << "\nActual: " << exception;
     } else {
+        // Other assert types have fixed messages, exact match
         EXPECT_EQ(expected, exception);
     }
 }
@@ -231,8 +238,9 @@ TEST_P(WatcherAssertTest, TestWatcherAssert) {
         GTEST_SKIP();
     }
     // TODO: SD is only used for Quasar watcher assert tests. Remove once FD is enabled on quasar
-    if (this->slow_dispatch_ && (tt::tt_metal::MetalContext::instance().hal().get_arch() != tt::ARCH::QUASAR)) {
-        GTEST_SKIP() << "Slow dispatch watcher assert tests only run on Quasar";
+    if (this->slow_dispatch_ && (tt::tt_metal::MetalContext::instance().hal().get_arch() != tt::ARCH::QUASAR) &&
+        params.processor.core_type != HalProgrammableCoreType::IDLE_ETH) {
+        GTEST_SKIP() << "Slow dispatch watcher assert tests only run on Quasar (except IDLE_ETH)";
     }
     this->RunTestOnDevice(
         [&params](MeshWatcherFixture* fixture, const std::shared_ptr<distributed::MeshDevice>& mesh_device) {

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_assert.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_assert.cpp
@@ -60,6 +60,8 @@ static void RunTest(
     auto* device = mesh_device->get_devices()[0];
     const auto& hal = tt::tt_metal::MetalContext::instance().hal();
     bool is_quasar = hal.get_arch() == tt::ARCH::QUASAR;
+    constexpr uint32_t line_num = 67;  // Note: this should match the assert line # in watcher_asserts.cpp
+    const std::string kernel = "tests/tt_metal/tt_metal/test_kernels/misc/watcher_asserts.cpp";
 
     // Depending on riscv type, choose one core to run the test on
     // and set up the kernel on the correct risc
@@ -79,7 +81,7 @@ static void RunTest(
                         uint32_t dm_id = static_cast<uint32_t>(processor.processor_type);
                         assert_kernel = experimental::quasar::CreateKernel(
                             program_,
-                            "tests/tt_metal/tt_metal/test_kernels/misc/watcher_asserts.cpp",
+                            kernel,
                             logical_core,
                             experimental::quasar::QuasarDataMovementConfig{
                                 .num_processors_per_cluster = 8, .compile_args = {dm_id}});
@@ -90,11 +92,7 @@ static void RunTest(
                                          enchantum::to_underlying(tt::tt_metal::DataMovementProcessor::RISCV_1))
                                             ? tt_metal::NOC::RISCV_1_default
                                             : tt_metal::NOC::RISCV_0_default;
-                        assert_kernel = CreateKernel(
-                            program_,
-                            "tests/tt_metal/tt_metal/test_kernels/misc/watcher_asserts.cpp",
-                            logical_core,
-                            dm_config);
+                        assert_kernel = CreateKernel(program_, kernel, logical_core, dm_config);
                     }
                     break;
                 case HalProcessorClassType::COMPUTE:
@@ -108,10 +106,9 @@ static void RunTest(
                         processor.processor_type);
                     assert_kernel = CreateKernel(
                         program_,
-                        "tests/tt_metal/tt_metal/test_kernels/misc/watcher_asserts.cpp",
+                        kernel,
                         logical_core,
                         ComputeConfig{.defines = {{fmt::format("TRISC{}", processor.processor_type), "1"}}});
-
                     break;
             }
             break;
@@ -122,11 +119,7 @@ static void RunTest(
             }
             logical_core = *(device->get_active_ethernet_cores(true).begin());
             virtual_core = device->ethernet_core_from_logical_core(logical_core);
-            assert_kernel = CreateKernel(
-                program_,
-                "tests/tt_metal/tt_metal/test_kernels/misc/watcher_asserts.cpp",
-                logical_core,
-                EthernetConfig{.noc = tt_metal::NOC::NOC_0});
+            assert_kernel = CreateKernel(program_, kernel, logical_core, EthernetConfig{.noc = tt_metal::NOC::NOC_0});
             risc = "erisc";
             break;
         case HalProgrammableCoreType::IDLE_ETH:
@@ -137,24 +130,21 @@ static void RunTest(
             logical_core = *(device->get_inactive_ethernet_cores().begin());
             virtual_core = device->ethernet_core_from_logical_core(logical_core);
             assert_kernel = CreateKernel(
-                program_,
-                "tests/tt_metal/tt_metal/test_kernels/misc/watcher_asserts.cpp",
-                logical_core,
-                EthernetConfig{.eth_mode = Eth::IDLE, .noc = tt_metal::NOC::NOC_0});
+                program_, kernel, logical_core, EthernetConfig{.eth_mode = Eth::IDLE, .noc = tt_metal::NOC::NOC_0});
             risc = "erisc";
             break;
         case HalProgrammableCoreType::COUNT: TT_THROW("Unsupported programmable core type");
     }
     log_info(LogTest, "Running test on device {} core {}[{}]...", device->id(), logical_core, virtual_core);
 
-    // // Write runtime args that should not trip an assert.
-    // const std::vector<uint32_t> safe_args = {3, 4, static_cast<uint32_t>(assert_type)};
-    // SetRuntimeArgs(program_, assert_kernel, logical_core, safe_args);
+    // Write runtime args that should not trip an assert.
+    const std::vector<uint32_t> safe_args = {3, 4, static_cast<uint32_t>(assert_type)};
+    SetRuntimeArgs(program_, assert_kernel, logical_core, safe_args);
 
-    // // Run the kernel, don't expect an issue here.
-    // log_info(LogTest, "Running args that shouldn't assert...");
-    // fixture->RunProgram(mesh_device, workload, true);
-    // log_info(LogTest, "Args did not assert!");
+    // Run the kernel, don't expect an issue here.
+    log_info(LogTest, "Running args that shouldn't assert...");
+    fixture->RunProgram(mesh_device, workload);
+    log_info(LogTest, "Args did not assert!");
 
     // Write runtime args that should trip an assert.
     const std::vector<uint32_t> unsafe_args = {3, 3, static_cast<uint32_t>(assert_type)};
@@ -166,52 +156,51 @@ static void RunTest(
 
     // We should be able to find the expected watcher error in the log as well,
     // expected error message depends on the risc we're running on and the assert type.
-    const std::string kernel = "tests/tt_metal/tt_metal/test_kernels/misc/watcher_asserts.cpp";
-    std::string expected;
-    if (assert_type == dev_msgs::DebugAssertTripped) {
-        const uint32_t line_num = 65;
-        expected = fmt::format(
-            "Device {} {} core(x={:2},y={:2}) virtual(x={:2},y={:2}): {} tripped an assert on line {}. "
-            "Note that file name reporting is not yet implemented, and the reported line number for the assert may be "
-            "from a different file. Current kernel: {}.",
-            device->id(),
-            (processor.core_type == HalProgrammableCoreType::ACTIVE_ETH) ? "acteth" : "worker",
-            logical_core.x,
-            logical_core.y,
-            virtual_core.x,
-            virtual_core.y,
-            risc);
-        std::string after_line = fmt::format(
-            ". Note that file name reporting is not yet implemented, and the reported line number for the assert may "
-            "be from a different file. Current kernel: {}.",
-            kernel);
-        expected = regex_escape(before_line) + "\\d+" + regex_escape(after_line);
-    } else {
-        std::string barrier;
-        if (assert_type == dev_msgs::DebugAssertNCriscNOCNonpostedAtomicsFlushedTripped) {
-            barrier = "NOC non-posted atomics flushed";
-        } else if (assert_type == dev_msgs::DebugAssertNCriscNOCNonpostedWritesSentTripped) {
-            barrier = "NOC non-posted writes sent";
-        } else if (assert_type == dev_msgs::DebugAssertNCriscNOCPostedWritesSentTripped) {
-            barrier = "NOC posted writes sent";
-        } else if (assert_type == dev_msgs::DebugAssertNCriscNOCReadsFlushedTripped) {
-            barrier = "NOC reads flushed";
-        }
+    std::string_view core_str = (processor.core_type == HalProgrammableCoreType::ACTIVE_ETH) ? "acteth" : "worker";
+    std::string msg;
 
-        expected = fmt::format(
-            "Device {} {} core(x={:2},y={:2}) virtual(x={:2},y={:2}): {} detected an inter-kernel data race due to "
-            "kernel completing with pending NOC transactions (missing {} barrier). Current kernel: "
-            "{}.",
-            device->id(),
-            (processor.core_type == HalProgrammableCoreType::ACTIVE_ETH) ? "acteth" : "worker",
-            logical_core.x,
-            logical_core.y,
-            virtual_core.x,
-            virtual_core.y,
-            risc,
-            barrier,
-            kernel);
+    switch (assert_type) {
+        case dev_msgs::DebugAssertTripped:
+            msg = fmt::format(
+                "tripped an assert on line {}. Note that file name reporting is not yet implemented, and the reported "
+                "line number for the assert may be from a different file",
+                line_num);
+            break;
+
+        case dev_msgs::DebugAssertNCriscNOCReadsFlushedTripped:
+        case dev_msgs::DebugAssertNCriscNOCNonpostedWritesSentTripped:
+        case dev_msgs::DebugAssertNCriscNOCNonpostedAtomicsFlushedTripped:
+        case dev_msgs::DebugAssertNCriscNOCPostedWritesSentTripped: {
+            constexpr std::string_view barriers[] = {
+                "reads flushed", "non-posted writes sent", "non-posted atomics flushed", "posted writes sent"};
+            msg = fmt::format(
+                "detected an inter-kernel data race due to kernel completing with pending NOC transactions (missing "
+                "NOC {} barrier)",
+                barriers[assert_type - dev_msgs::DebugAssertNCriscNOCReadsFlushedTripped]);
+            break;
+        }
+        case dev_msgs::DebugAssertRtaOutOfBounds:
+        case dev_msgs::DebugAssertCrtaOutOfBounds:
+            msg = fmt::format(
+                "accessed {} runtime arg index out of bounds",
+                (assert_type == dev_msgs::DebugAssertRtaOutOfBounds) ? "unique" : "common");
+            break;
+
+        default: TT_THROW("Unhandled assert type {}", static_cast<int>(assert_type));
     }
+
+    // Combine everything in one final pass
+    std::string expected = fmt::format(
+        "Device {} {} core(x={:2},y={:2}) virtual(x={:2},y={:2}): {} {}. Current kernel: {}.",
+        device->id(),
+        core_str,
+        logical_core.x,
+        logical_core.y,
+        virtual_core.x,
+        virtual_core.y,
+        risc,
+        msg,
+        kernel);
 
     std::string exception;
     do {
@@ -259,6 +248,7 @@ TEST_P(WatcherAssertTest, TestWatcherAssert) {
         log_info(tt::LogTest, "FD-on-idle-eth not supported.");
         GTEST_SKIP();
     }
+    // TODO: SD is only used for Quasar watcher assert tests. Remove once FD is enabled on quasar
     if (this->slow_dispatch_ && (tt::tt_metal::MetalContext::instance().hal().get_arch() != tt::ARCH::QUASAR)) {
         GTEST_SKIP();
     }
@@ -301,9 +291,18 @@ INSTANTIATE_TEST_SUITE_P(
     ::testing::Values(
         WatcherTestParams{"Brisc", {TENSIX, DM, 0}, dev_msgs::DebugAssertTripped},
         WatcherTestParams{"NCrisc", {TENSIX, DM, 1}, dev_msgs::DebugAssertNCriscNOCNonpostedAtomicsFlushedTripped},
+        // DM2 to DM7 only run on Quasar
+        WatcherTestParams{"DM2", {TENSIX, DM, 2}, dev_msgs::DebugAssertTripped},
+        WatcherTestParams{"DM3", {TENSIX, DM, 3}, dev_msgs::DebugAssertNCriscNOCReadsFlushedTripped},
+        WatcherTestParams{"DM4", {TENSIX, DM, 4}, dev_msgs::DebugAssertNCriscNOCNonpostedWritesSentTripped},
+        WatcherTestParams{"DM5", {TENSIX, DM, 5}, dev_msgs::DebugAssertNCriscNOCNonpostedAtomicsFlushedTripped},
+        WatcherTestParams{"DM6", {TENSIX, DM, 6}, dev_msgs::DebugAssertRtaOutOfBounds},
+        WatcherTestParams{"DM7", {TENSIX, DM, 7}, dev_msgs::DebugAssertCrtaOutOfBounds},
         WatcherTestParams{"Trisc0", {TENSIX, COMPUTE, 0}, dev_msgs::DebugAssertNCriscNOCNonpostedWritesSentTripped},
         WatcherTestParams{"Trisc1", {TENSIX, COMPUTE, 1}, dev_msgs::DebugAssertNCriscNOCPostedWritesSentTripped},
         WatcherTestParams{"Trisc2", {TENSIX, COMPUTE, 2}, dev_msgs::DebugAssertNCriscNOCReadsFlushedTripped},
+        WatcherTestParams{
+            "Trisc3", {TENSIX, COMPUTE, 3}, dev_msgs::DebugAssertRtaOutOfBounds},  // Trisc3 only Runs on Quasar
         WatcherTestParams{"Erisc", {ACTIVE_ETH, DM, 0}, dev_msgs::DebugAssertNCriscNOCNonpostedAtomicsFlushedTripped},
         WatcherTestParams{"IErisc", {IDLE_ETH, DM, 0}, dev_msgs::DebugAssertNCriscNOCReadsFlushedTripped}),
     [](const ::testing::TestParamInfo<WatcherTestParams>& info) { return info.param.test_name; });

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_assert.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_assert.cpp
@@ -11,6 +11,8 @@
 #include <unordered_set>
 #include <variant>
 #include <vector>
+#include <thread>
+#include <chrono>
 
 #include <tt-metalium/distributed.hpp>
 #include <tt-metalium/core_coord.hpp>
@@ -61,16 +63,15 @@ static void RunTest(
     auto* device = mesh_device->get_devices()[0];
     const auto& hal = tt::tt_metal::MetalContext::instance().hal();
     bool is_quasar = hal.get_arch() == tt::ARCH::QUASAR;
-    constexpr uint32_t line_num = 67;  // Note: this should match the assert line # in watcher_asserts.cpp
     const std::string kernel = "tests/tt_metal/tt_metal/test_kernels/misc/watcher_asserts.cpp";
 
     // Depending on riscv type, choose one core to run the test on (since the test hangs the board).
     CoreCoord logical_core, virtual_core;
     // Set up the kernel on the correct risc
     KernelHandle assert_kernel;
-    auto procesor_idx =
+    auto processor_idx =
         hal.get_processor_index(processor.core_type, processor.processor_class, processor.processor_type);
-    std::string risc = hal.get_processor_class_name(processor.core_type, procesor_idx, false).c_str();
+    std::string risc = hal.get_processor_class_name(processor.core_type, processor_idx, false);
     switch (processor.core_type) {
         case HalProgrammableCoreType::TENSIX:
             logical_core = {0, 0};
@@ -98,12 +99,9 @@ static void RunTest(
                 case HalProcessorClassType::COMPUTE:
                     // TODO: Watcher features are temporarily skipped on Quasar until basic runtime bring-up is complete
                     if (is_quasar) {
-                        GTEST_SKIP();
+                        GTEST_SKIP() << "Compute kernel watcher tests skipped on Quasar until TRISC runtime bring-up "
+                                        "is complete";
                     }
-                    TT_FATAL(
-                        0 <= processor.processor_type && processor.processor_type < 3,
-                        "processor_id {} must be 0, 1, or 2 for COMPUTE",
-                        processor.processor_type);
                     assert_kernel = CreateKernel(
                         program_,
                         kernel,
@@ -113,26 +111,24 @@ static void RunTest(
             }
             break;
         case HalProgrammableCoreType::ACTIVE_ETH:
-            if (device->get_active_ethernet_cores(true).empty()) {
-                log_info(LogTest, "Skipping this test since device has no active ethernet cores.");
+        case HalProgrammableCoreType::IDLE_ETH: {
+            bool is_active = (processor.core_type == HalProgrammableCoreType::ACTIVE_ETH);
+            auto eth_cores =
+                is_active ? device->get_active_ethernet_cores(true) : device->get_inactive_ethernet_cores();
+            if (eth_cores.empty()) {
+                log_info(LogTest, "Skipping: device has no {} ethernet cores.", is_active ? "active" : "inactive");
                 GTEST_SKIP();
             }
-            logical_core = *(device->get_active_ethernet_cores(true).begin());
+            logical_core = *eth_cores.begin();
             virtual_core = device->ethernet_core_from_logical_core(logical_core);
-            assert_kernel = CreateKernel(program_, kernel, logical_core, EthernetConfig{.noc = tt_metal::NOC::NOC_0});
-            risc = "erisc";
-            break;
-        case HalProgrammableCoreType::IDLE_ETH:
-            if (device->get_inactive_ethernet_cores().empty()) {
-                log_info(LogTest, "Skipping this test since device has no inactive ethernet cores.");
-                GTEST_SKIP();
+            EthernetConfig eth_config{.noc = tt_metal::NOC::NOC_0};
+            if (!is_active) {
+                eth_config.eth_mode = Eth::IDLE;
             }
-            logical_core = *(device->get_inactive_ethernet_cores().begin());
-            virtual_core = device->ethernet_core_from_logical_core(logical_core);
-            assert_kernel = CreateKernel(
-                program_, kernel, logical_core, EthernetConfig{.eth_mode = Eth::IDLE, .noc = tt_metal::NOC::NOC_0});
+            assert_kernel = CreateKernel(program_, kernel, logical_core, eth_config);
             risc = "erisc";
             break;
+        }
         case HalProgrammableCoreType::COUNT: TT_THROW("Unsupported programmable core type");
     }
     log_info(LogTest, "Running test on device {} core {}[{}]...", device->id(), logical_core, virtual_core);
@@ -154,18 +150,31 @@ static void RunTest(
     log_info(LogTest, "Running args that should assert...");
     fixture->RunProgram(mesh_device, workload);
 
+    // Wait for watcher to catch the assert with a timeout of 5s
+    std::string exception;
+    constexpr auto timeout = std::chrono::milliseconds(5000);
+    auto start = std::chrono::steady_clock::now();
+    while (std::chrono::steady_clock::now() - start < timeout) {
+        exception = MetalContext::instance().watcher_server()->exception_message();
+        if (!exception.empty()) {
+            break;
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    }
+    ASSERT_FALSE(exception.empty()) << "Timeout (" << timeout.count() << "ms) waiting for watcher exception.\n"
+                                    << "Expected assert type: " << static_cast<int>(assert_type) << " on " << risc;
+
     // We should be able to find the expected watcher error in the log as well,
     // expected error message depends on the risc we're running on and the assert type.
     const std::string_view core_str =
         (processor.core_type == HalProgrammableCoreType::ACTIVE_ETH) ? "acteth" : "worker";
-    const std::string msg = get_debug_assert_message(assert_type, line_num);
-    if (msg.empty()) {
-        TT_THROW("Unhandled assert type {}", static_cast<int>(assert_type));
-    }
 
-    // Combine everything in one final pass
+    // Use dummy line number 0, then replace with \d+ for regex matching
+    const std::string msg = get_debug_assert_message(assert_type, 0);
+    ASSERT_FALSE(msg.empty()) << "Unhandled assert type " << static_cast<int>(assert_type);
+
     std::string expected = fmt::format(
-        "Device {} {} core(x={:2},y={:2}) virtual(x={:2},y={:2}): {} {}. Current kernel: {}.",
+        "Device {} {} core(x={:2},y={:2}) virtual(x={:2},y={:2}): {} {} Current kernel: {}.",
         device->id(),
         core_str,
         logical_core.x,
@@ -176,13 +185,17 @@ static void RunTest(
         msg,
         kernel);
 
-    std::string exception;
-    do {
-        exception = MetalContext::instance().watcher_server()->exception_message();
-    } while (exception.empty());
     if (assert_type == dev_msgs::DebugAssertTripped) {
-        EXPECT_TRUE(std::regex_match(exception, std::regex(expected)))
-            << "Expected pattern: " << expected << "\nActual: " << exception;
+        // For the assert tripped, use regex to match any line number instead of hardcoding
+        std::string pattern = regex_escape(expected);
+        // Replace dummy "on line 0" with "on line \d+" to match any number
+        const std::string placeholder = "on line 0";
+        size_t pos = pattern.find(placeholder);
+        if (pos != std::string::npos) {
+            pattern.replace(pos, placeholder.length(), "on line \\d+");
+        }
+        EXPECT_TRUE(std::regex_match(exception, std::regex(pattern)))
+            << "Expected pattern: " << pattern << "\nActual: " << exception;
     } else {
         EXPECT_EQ(expected, exception);
     }
@@ -209,13 +222,8 @@ TEST_P(WatcherAssertTest, TestWatcherAssert) {
     uint32_t available_processors =
         hal.get_processor_types_count(core_type_index, static_cast<uint32_t>(params.processor.processor_class));
     if (params.processor.processor_type >= available_processors) {
-        log_info(
-            tt::LogTest,
-            "Test {} requires processor type {} but only {} available.",
-            params.test_name,
-            params.processor.processor_type,
-            available_processors);
-        GTEST_SKIP();
+        GTEST_SKIP() << "Test " << params.test_name << " requires processor type " << params.processor.processor_type
+                     << " but only " << available_processors << " available on this architecture";
     }
 
     if (params.processor.core_type == HalProgrammableCoreType::IDLE_ETH && !this->IsSlowDispatch()) {
@@ -224,7 +232,7 @@ TEST_P(WatcherAssertTest, TestWatcherAssert) {
     }
     // TODO: SD is only used for Quasar watcher assert tests. Remove once FD is enabled on quasar
     if (this->slow_dispatch_ && (tt::tt_metal::MetalContext::instance().hal().get_arch() != tt::ARCH::QUASAR)) {
-        GTEST_SKIP();
+        GTEST_SKIP() << "Slow dispatch watcher assert tests only run on Quasar";
     }
     this->RunTestOnDevice(
         [&params](MeshWatcherFixture* fixture, const std::shared_ptr<distributed::MeshDevice>& mesh_device) {

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_assert.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_assert.cpp
@@ -129,9 +129,9 @@ static void RunTest(
                 eth_config.eth_mode = Eth::IDLE;
             }
             assert_kernel = CreateKernel(program_, kernel, logical_core, eth_config);
-            // TODO: replace string literal "erisc" with hal.get_processor_class_name() after
+            // TODO: replace string literals with hal.get_processor_class_name() after
             // unifying all tests + watcher_device_reader::get_riscv_name() with same method
-            risc = "erisc";
+            risc = is_active ? "erisc" : "ierisc";
             break;
         }
         case HalProgrammableCoreType::COUNT: TT_THROW("Unsupported programmable core type");
@@ -171,8 +171,13 @@ static void RunTest(
 
     // We should be able to find the expected watcher error in the log as well,
     // expected error message depends on the risc we're running on and the assert type.
-    const std::string_view core_str =
-        (processor.core_type == HalProgrammableCoreType::ACTIVE_ETH) ? "acteth" : "worker";
+    // TODO: replace below code snippet with helper after unifying all tests + watcher_device_reader
+    std::string core_str;
+    switch (processor.core_type) {
+        case HalProgrammableCoreType::ACTIVE_ETH: core_str = "acteth"; break;
+        case HalProgrammableCoreType::IDLE_ETH: core_str = "idleth"; break;
+        default: core_str = "worker";
+    }
 
     // Don't hardcode line number, the ASSERT location in watcher_asserts.cpp kernel
     // can shift as code changes. Use regex to match any line number for DebugAssertTripped
@@ -233,14 +238,19 @@ TEST_P(WatcherAssertTest, TestWatcherAssert) {
                      << " but only " << available_processors << " available on this architecture";
     }
 
-    if (params.processor.core_type == HalProgrammableCoreType::IDLE_ETH && !this->IsSlowDispatch()) {
-        log_info(tt::LogTest, "FD-on-idle-eth not supported.");
+    // Dispatch mode validation:
+    // - IDLE_ETH cores only support SD (FD not yet implemented)
+    // - TENSIX/ACTIVE_ETH cores: SD only used for Quasar watcher tests (TODO: Remove once FD enabled on Quasar)
+    bool is_idle_eth = (params.processor.core_type == HalProgrammableCoreType::IDLE_ETH);
+    bool is_quasar = (tt::tt_metal::MetalContext::instance().hal().get_arch() == tt::ARCH::QUASAR);
+    bool using_slow_dispatch = this->IsSlowDispatch();
+
+    if (is_idle_eth && !using_slow_dispatch) {
+        log_info(tt::LogTest, "IDLE_ETH requires Slow Dispatch (Fast Dispatch not yet supported).");
         GTEST_SKIP();
     }
-    // TODO: SD is only used for Quasar watcher assert tests. Remove once FD is enabled on quasar
-    if (this->slow_dispatch_ && (tt::tt_metal::MetalContext::instance().hal().get_arch() != tt::ARCH::QUASAR) &&
-        params.processor.core_type != HalProgrammableCoreType::IDLE_ETH) {
-        GTEST_SKIP() << "Slow dispatch watcher assert tests only run on Quasar (except IDLE_ETH)";
+    if (using_slow_dispatch && !is_quasar && !is_idle_eth) {
+        GTEST_SKIP() << "Slow Dispatch tests only run on Quasar or IDLE_ETH cores";
     }
     this->RunTestOnDevice(
         [&params](MeshWatcherFixture* fixture, const std::shared_ptr<distributed::MeshDevice>& mesh_device) {

--- a/tests/tt_metal/tt_metal/test_kernels/misc/watcher_asserts.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/misc/watcher_asserts.cpp
@@ -24,6 +24,7 @@ void kernel_main() {
     constexpr uint32_t dm_id = get_compile_time_arg_val(0);
     uint64_t cpu_index = 0;
     asm volatile("csrr %0, mhartid" : "=r"(cpu_index));
+    // On Quasar since all 8 kernels are launched: execute only the processor matching dm_id ; skip others
     if(dm_id != cpu_index)
         return;
 #endif
@@ -31,10 +32,10 @@ void kernel_main() {
 #if (defined(UCK_CHLKC_UNPACK) and defined(TRISC0)) or \
     (defined(UCK_CHLKC_MATH) and defined(TRISC1)) or \
     (defined(UCK_CHLKC_PACK) and defined(TRISC2)) or \
-    (defined(COMPILE_FOR_BRISC) || defined(COMPILE_FOR_NCRISC) || defined(COMPILE_FOR_ERISC) || defined(COMPILE_FOR_DM))
+    (defined(COMPILE_FOR_BRISC) or defined(COMPILE_FOR_NCRISC) or defined(COMPILE_FOR_ERISC) or defined(COMPILE_FOR_IDLE_ERISC) or defined(COMPILE_FOR_DM))
     WATCHER_RING_BUFFER_PUSH(a);
     WATCHER_RING_BUFFER_PUSH(b);
-#if defined(COMPILE_FOR_BRISC) or defined(COMPILE_FOR_NCRISC) or defined(COMPILE_FOR_ERISC) or defined(COMPILE_FOR_DM)
+#if defined(COMPILE_FOR_BRISC) or defined(COMPILE_FOR_NCRISC) or defined(COMPILE_FOR_ERISC) or defined(COMPILE_FOR_IDLE_ERISC) or defined(COMPILE_FOR_DM)
     //For Erisc do a dummy increment since there is no worker kernel that would increment dispatch message addr to signal compute kernel completion.
     if (a == b) {
         //We will assert later. This kernel will hang.
@@ -46,7 +47,7 @@ void kernel_main() {
         notify_dispatch_core_done(dispatch_addr, noc_index);
 
         // TODO: SD is only used for Quasar watcher assert tests. Remove once FD is enabled on quasar
-#if !defined(COMPILE_FOR_ERISC) && defined(COMPILE_FOR_DM)
+#if !defined(COMPILE_FOR_ERISC) and (defined(COMPILE_FOR_DM) or defined(COMPILE_FOR_IDLE_ERISC))
         go_message_in->signal = RUN_MSG_DONE;
 #endif
     }

--- a/tests/tt_metal/tt_metal/test_kernels/misc/watcher_asserts.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/misc/watcher_asserts.cpp
@@ -19,6 +19,7 @@ void kernel_main() {
     uint32_t a = get_arg_val<uint32_t>(0);
     uint32_t b = get_arg_val<uint32_t>(1);
     uint32_t assert_type = get_arg_val<uint32_t>(2);
+
 #if defined(COMPILE_FOR_DM)
     constexpr uint32_t dm_id = get_compile_time_arg_val(0);
     uint64_t cpu_index = 0;
@@ -56,12 +57,13 @@ void kernel_main() {
     *trisc_run = RUN_SYNC_MSG_DONE;
 #endif
 #endif
-
-// For slow dispatch
+    if (a == b) {
+    // TODO: SD is only used for Quasar watcher assert tests. Remove once FD is enabled on quasar
 #if !defined(COMPILE_FOR_ERISC) && defined(COMPILE_FOR_DM)
-    volatile tt_l1_ptr go_msg_t* go_message_ptr = GET_MAILBOX_ADDRESS_DEV(go_messages[0]);
-    go_message_ptr->signal = RUN_MSG_DONE;
+        volatile tt_l1_ptr go_msg_t* go_message_ptr = GET_MAILBOX_ADDRESS_DEV(go_messages[0]);
+        go_message_ptr->signal = RUN_MSG_DONE;
 #endif
+    }
     ASSERT(a != b, static_cast<debug_assert_type_t>(assert_type));
 
 #endif

--- a/tests/tt_metal/tt_metal/test_kernels/misc/watcher_asserts.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/misc/watcher_asserts.cpp
@@ -57,13 +57,13 @@ void kernel_main() {
     *trisc_run = RUN_SYNC_MSG_DONE;
 #endif
 #endif
-    if (a == b) {
     // TODO: SD is only used for Quasar watcher assert tests. Remove once FD is enabled on quasar
 #if !defined(COMPILE_FOR_ERISC) && defined(COMPILE_FOR_DM)
+    if (a == b) {
         volatile tt_l1_ptr go_msg_t* go_message_ptr = GET_MAILBOX_ADDRESS_DEV(go_messages[0]);
         go_message_ptr->signal = RUN_MSG_DONE;
-#endif
     }
+#endif
     ASSERT(a != b, static_cast<debug_assert_type_t>(assert_type));
 
 #endif

--- a/tests/tt_metal/tt_metal/test_kernels/misc/watcher_asserts.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/misc/watcher_asserts.cpp
@@ -43,12 +43,16 @@ void kernel_main() {
         //Dispatcher Kernel is able to finish.
         //Device Close () requires fast dispatch kernels to finish.
         volatile tt_l1_ptr go_msg_t* go_message_in = GET_MAILBOX_ADDRESS_DEV(go_messages[0]);
+
+        // Signal completion to dispatcher before assert hangs the kernel
+        // SD signaling: IDLE_ERISC (all archs) and Quasar DM require RUN_MSG_DONE
+        // TODO: Remove COMPILE_FOR_DM once FD is enabled on Quasar
+#if defined(COMPILE_FOR_IDLE_ERISC) or defined(COMPILE_FOR_DM)
+        go_message_in->signal = RUN_MSG_DONE;
+#else
+        // FD: ACTIVE_ETH, BRISC, NCRISC notify dispatcher via NOC
         uint64_t dispatch_addr = calculate_dispatch_addr(go_message_in);
         notify_dispatch_core_done(dispatch_addr, noc_index);
-
-        // TODO: SD is only used for Quasar watcher assert tests. Remove once FD is enabled on quasar
-#if !defined(COMPILE_FOR_ERISC) and (defined(COMPILE_FOR_DM) or defined(COMPILE_FOR_IDLE_ERISC))
-        go_message_in->signal = RUN_MSG_DONE;
 #endif
     }
 #else

--- a/tests/tt_metal/tt_metal/test_kernels/misc/watcher_asserts.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/misc/watcher_asserts.cpp
@@ -6,11 +6,12 @@
 #include "api/debug/assert.h"
 #include "api/debug/ring_buffer.h"
 #include "internal/firmware_common.h"
+#include "api/compile_time_args.h"
 
 /*
  * A test for the assert feature.
 */
-#if !defined(COMPILE_FOR_BRISC) && !defined(COMPILE_FOR_NCRISC) && !defined(COMPILE_FOR_ERISC) && !defined(COMPILE_FOR_DM)
+#if defined(COMPILE_FOR_TRISC)
 #include "api/compute/common.h"
 #endif
 
@@ -18,7 +19,13 @@ void kernel_main() {
     uint32_t a = get_arg_val<uint32_t>(0);
     uint32_t b = get_arg_val<uint32_t>(1);
     uint32_t assert_type = get_arg_val<uint32_t>(2);
-
+#if defined(COMPILE_FOR_DM)
+    constexpr uint32_t dm_id = get_compile_time_arg_val(0);
+    uint64_t cpu_index = 0;
+    asm volatile("csrr %0, mhartid" : "=r"(cpu_index));
+    if(dm_id != cpu_index)
+        return;
+#endif
     // Conditionally enable using defines for each trisc
 #if (defined(UCK_CHLKC_UNPACK) and defined(TRISC0)) or \
     (defined(UCK_CHLKC_MATH) and defined(TRISC1)) or \

--- a/tests/tt_metal/tt_metal/test_kernels/misc/watcher_asserts.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/misc/watcher_asserts.cpp
@@ -34,37 +34,30 @@ void kernel_main() {
     (defined(COMPILE_FOR_BRISC) || defined(COMPILE_FOR_NCRISC) || defined(COMPILE_FOR_ERISC) || defined(COMPILE_FOR_DM))
     WATCHER_RING_BUFFER_PUSH(a);
     WATCHER_RING_BUFFER_PUSH(b);
-#if defined(COMPILE_FOR_BRISC) or defined(COMPILE_FOR_NCRISC) or defined(COMPILE_FOR_ERISC)
+#if defined(COMPILE_FOR_BRISC) or defined(COMPILE_FOR_NCRISC) or defined(COMPILE_FOR_ERISC) or defined(COMPILE_FOR_DM)
     //For Erisc do a dummy increment since there is no worker kernel that would increment dispatch message addr to signal compute kernel completion.
     if (a == b) {
         //We will assert later. This kernel will hang.
         //Need to signal completion to dispatcher before hanging so that
         //Dispatcher Kernel is able to finish.
         //Device Close () requires fast dispatch kernels to finish.
-#if defined(COMPILE_FOR_ERISC)
-        tt_l1_ptr mailboxes_t* const mailboxes = (tt_l1_ptr mailboxes_t*)(eth_l1_mem::address_map::ERISC_MEM_MAILBOX_BASE);
-#else
-        tt_l1_ptr mailboxes_t* const mailboxes = (tt_l1_ptr mailboxes_t*)(MEM_MAILBOX_BASE);
-#endif
-        volatile go_msg_t* go_message_in = reinterpret_cast<volatile go_msg_t*>(&mailboxes->go_messages[mailboxes->go_message_index]);
+        volatile tt_l1_ptr go_msg_t* go_message_in = GET_MAILBOX_ADDRESS_DEV(go_messages[0]);
         uint64_t dispatch_addr = calculate_dispatch_addr(go_message_in);
         notify_dispatch_core_done(dispatch_addr, noc_index);
+
+        // TODO: SD is only used for Quasar watcher assert tests. Remove once FD is enabled on quasar
+#if !defined(COMPILE_FOR_ERISC) && defined(COMPILE_FOR_DM)
+        go_message_in->signal = RUN_MSG_DONE;
+#endif
     }
 #else
-#if defined(TRISC0) or defined(TRISC1) or defined(TRISC2)
+#if defined(COMPILE_FOR_TRISC)
     volatile tt_l1_ptr uint8_t * const trisc_run = &((tt_l1_ptr mailboxes_t*)(MEM_MAILBOX_BASE))
         ->subordinate_sync.map[COMPILE_FOR_TRISC + 1];  // first entry is for NCRISC
     *trisc_run = RUN_SYNC_MSG_DONE;
 #endif
 #endif
-    // TODO: SD is only used for Quasar watcher assert tests. Remove once FD is enabled on quasar
-#if !defined(COMPILE_FOR_ERISC) && defined(COMPILE_FOR_DM)
-    if (a == b) {
-        volatile tt_l1_ptr go_msg_t* go_message_ptr = GET_MAILBOX_ADDRESS_DEV(go_messages[0]);
-        go_message_ptr->signal = RUN_MSG_DONE;
-    }
-#endif
-    ASSERT(a != b, static_cast<debug_assert_type_t>(assert_type));
 
+    ASSERT(a != b, static_cast<debug_assert_type_t>(assert_type));
 #endif
 }

--- a/tests/tt_metal/tt_metal/test_kernels/misc/watcher_asserts.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/misc/watcher_asserts.cpp
@@ -5,11 +5,12 @@
 #include <cstdint>
 #include "api/debug/assert.h"
 #include "api/debug/ring_buffer.h"
+#include "internal/firmware_common.h"
 
 /*
  * A test for the assert feature.
 */
-#if !defined(COMPILE_FOR_BRISC) && !defined(COMPILE_FOR_NCRISC) && !defined(COMPILE_FOR_ERISC)
+#if !defined(COMPILE_FOR_BRISC) && !defined(COMPILE_FOR_NCRISC) && !defined(COMPILE_FOR_ERISC) && !defined(COMPILE_FOR_DM)
 #include "api/compute/common.h"
 #endif
 
@@ -22,7 +23,7 @@ void kernel_main() {
 #if (defined(UCK_CHLKC_UNPACK) and defined(TRISC0)) or \
     (defined(UCK_CHLKC_MATH) and defined(TRISC1)) or \
     (defined(UCK_CHLKC_PACK) and defined(TRISC2)) or \
-    (defined(COMPILE_FOR_BRISC) || defined(COMPILE_FOR_NCRISC) || defined(COMPILE_FOR_ERISC))
+    (defined(COMPILE_FOR_BRISC) || defined(COMPILE_FOR_NCRISC) || defined(COMPILE_FOR_ERISC) || defined(COMPILE_FOR_DM))
     WATCHER_RING_BUFFER_PUSH(a);
     WATCHER_RING_BUFFER_PUSH(b);
 #if defined(COMPILE_FOR_BRISC) or defined(COMPILE_FOR_NCRISC) or defined(COMPILE_FOR_ERISC)
@@ -37,20 +38,9 @@ void kernel_main() {
 #else
         tt_l1_ptr mailboxes_t* const mailboxes = (tt_l1_ptr mailboxes_t*)(MEM_MAILBOX_BASE);
 #endif
-        uint64_t dispatch_addr = NOC_XY_ADDR(
-            NOC_X(mailboxes->go_messages[mailboxes->go_message_index].master_x),
-            NOC_Y(mailboxes->go_messages[mailboxes->go_message_index].master_y),
-            DISPATCH_MESSAGE_ADDR + NOC_STREAM_REG_SPACE_SIZE * mailboxes->go_messages[mailboxes->go_message_index].dispatch_message_offset);
-        noc_fast_write_dw_inline<DM_DEDICATED_NOC>(
-                        noc_index,
-                        NCRISC_AT_CMD_BUF,
-                        1 << REMOTE_DEST_BUF_WORDS_FREE_INC,
-                        dispatch_addr,
-                        0xF,  // byte-enable
-                        NOC_UNICAST_WRITE_VC,
-                        false,  // mcast
-                        true    // posted
-                    );
+        volatile go_msg_t* go_message_in = reinterpret_cast<volatile go_msg_t*>(&mailboxes->go_messages[mailboxes->go_message_index]);
+        uint64_t dispatch_addr = calculate_dispatch_addr(go_message_in);
+        notify_dispatch_core_done(dispatch_addr, noc_index);
     }
 #else
 #if defined(TRISC0) or defined(TRISC1) or defined(TRISC2)
@@ -60,6 +50,12 @@ void kernel_main() {
 #endif
 #endif
 
+// For slow dispatch
+#if !defined(COMPILE_FOR_ERISC) && defined(COMPILE_FOR_DM)
+    volatile tt_l1_ptr go_msg_t* go_message_ptr = GET_MAILBOX_ADDRESS_DEV(go_messages[0]);
+    go_message_ptr->signal = RUN_MSG_DONE;
+#endif
     ASSERT(a != b, static_cast<debug_assert_type_t>(assert_type));
+
 #endif
 }

--- a/tt_metal/hw/inc/internal/firmware_common.h
+++ b/tt_metal/hw/inc/internal/firmware_common.h
@@ -127,10 +127,19 @@ uint32_t firmware_config_init(
         sem_l1_base[index] =
             (uint32_t tt_l1_ptr*)(kernel_config_base[index] + launch_msg_address->kernel_config.sem_offset[index]);
     }
+#ifdef ARCH_QUASAR
+    rta_l1_base = (uint32_t tt_l1_ptr*)(kernel_config_base[core_type_index] +
+                                        launch_msg_address->kernel_config.rta_offset[processor_index].rta_offset +
+                                        MEM_L1_UNCACHED_BASE);
+    crta_l1_base = (uint32_t tt_l1_ptr*)(kernel_config_base[core_type_index] +
+                                         launch_msg_address->kernel_config.rta_offset[processor_index].crta_offset +
+                                         MEM_L1_UNCACHED_BASE);
+#else
     rta_l1_base = (uint32_t tt_l1_ptr*)(kernel_config_base[core_type_index] +
                                         launch_msg_address->kernel_config.rta_offset[processor_index].rta_offset);
     crta_l1_base = (uint32_t tt_l1_ptr*)(kernel_config_base[core_type_index] +
                                          launch_msg_address->kernel_config.rta_offset[processor_index].crta_offset);
+#endif
 
 #if defined(WATCHER_ENABLED) && !defined(WATCHER_DISABLE_ASSERT)
 #ifdef ARCH_QUASAR

--- a/tt_metal/hw/inc/internal/firmware_common.h
+++ b/tt_metal/hw/inc/internal/firmware_common.h
@@ -127,9 +127,9 @@ uint32_t firmware_config_init(
         sem_l1_base[index] =
             (uint32_t tt_l1_ptr*)(kernel_config_base[index] + launch_msg_address->kernel_config.sem_offset[index]);
     }
+#ifdef ARCH_QUASAR
     // TODO: Remove MEM_L1_UNCACHED_BASE here and invalidate cache lines when cache invalidating
     // functionality is ready for Quasar
-#ifdef ARCH_QUASAR
     rta_l1_base = (uint32_t tt_l1_ptr*)(kernel_config_base[core_type_index] +
                                         launch_msg_address->kernel_config.rta_offset[processor_index].rta_offset +
                                         MEM_L1_UNCACHED_BASE);

--- a/tt_metal/hw/inc/internal/firmware_common.h
+++ b/tt_metal/hw/inc/internal/firmware_common.h
@@ -127,6 +127,8 @@ uint32_t firmware_config_init(
         sem_l1_base[index] =
             (uint32_t tt_l1_ptr*)(kernel_config_base[index] + launch_msg_address->kernel_config.sem_offset[index]);
     }
+    // TODO: Remove MEM_L1_UNCACHED_BASE here and invalidate cache lines when cache invalidating
+    // functionality is ready for Quasar
 #ifdef ARCH_QUASAR
     rta_l1_base = (uint32_t tt_l1_ptr*)(kernel_config_base[core_type_index] +
                                         launch_msg_address->kernel_config.rta_offset[processor_index].rta_offset +

--- a/tt_metal/impl/debug/debug_helpers.hpp
+++ b/tt_metal/impl/debug/debug_helpers.hpp
@@ -6,6 +6,7 @@
 
 #include <set>
 
+#include <fmt/format.h>
 #include <tt-metalium/experimental/fabric/control_plane.hpp>
 #include "llrt/core_descriptor.hpp"
 #include "hostdevcommon/dprint_common.h"
@@ -85,6 +86,33 @@ inline std::string_view get_core_type_name(CoreType ct) {
         case CoreType::IDLE_ETH: return "idle_eth";
         case CoreType::TENSIX: return "tensix";
         default: return "UNKNOWN";
+    }
+}
+
+// Returns the assert message portion for a given assert type (no trailing period).
+// For DebugAssertTripped, line_num is used in the message.
+inline std::string get_debug_assert_message(dev_msgs::debug_assert_type_t type, uint16_t line_num = 0) {
+    switch (type) {
+        case dev_msgs::DebugAssertTripped:
+            return fmt::format(
+                "tripped an assert on line {}. Note that file name reporting is not yet "
+                "implemented, and the reported line number for the assert may be from a different file",
+                line_num);
+        case dev_msgs::DebugAssertNCriscNOCReadsFlushedTripped:
+            return "detected an inter-kernel data race due to kernel completing with pending NOC "
+                   "transactions (missing NOC reads flushed barrier)";
+        case dev_msgs::DebugAssertNCriscNOCNonpostedWritesSentTripped:
+            return "detected an inter-kernel data race due to kernel completing with pending NOC "
+                   "transactions (missing NOC non-posted writes sent barrier)";
+        case dev_msgs::DebugAssertNCriscNOCNonpostedAtomicsFlushedTripped:
+            return "detected an inter-kernel data race due to kernel completing with pending NOC "
+                   "transactions (missing NOC non-posted atomics flushed barrier)";
+        case dev_msgs::DebugAssertNCriscNOCPostedWritesSentTripped:
+            return "detected an inter-kernel data race due to kernel completing with pending NOC "
+                   "transactions (missing NOC posted writes sent barrier)";
+        case dev_msgs::DebugAssertRtaOutOfBounds: return "accessed unique runtime arg index out of bounds";
+        case dev_msgs::DebugAssertCrtaOutOfBounds: return "accessed common runtime arg index out of bounds";
+        default: return "";  // Caller handles unknown types
     }
 }
 

--- a/tt_metal/impl/debug/debug_helpers.hpp
+++ b/tt_metal/impl/debug/debug_helpers.hpp
@@ -90,7 +90,8 @@ inline std::string_view get_core_type_name(CoreType ct) {
 }
 
 // Returns the assert message portion for a given assert type
-// For DebugAssertTripped, line_num is used in the message.
+// Returns empty string for unknown types (callers must handle this)
+// For DebugAssertTripped, line_num is used in the message
 inline std::string get_debug_assert_message(dev_msgs::debug_assert_type_t type, uint16_t line_num = 0) {
     switch (type) {
         case dev_msgs::DebugAssertTripped:
@@ -112,7 +113,7 @@ inline std::string get_debug_assert_message(dev_msgs::debug_assert_type_t type, 
                    "transactions (missing NOC posted writes sent barrier).";
         case dev_msgs::DebugAssertRtaOutOfBounds: return "accessed unique runtime arg index out of bounds.";
         case dev_msgs::DebugAssertCrtaOutOfBounds: return "accessed common runtime arg index out of bounds.";
-        default: return "";  // Unknown type
+        default: return "";
     }
 }
 

--- a/tt_metal/impl/debug/debug_helpers.hpp
+++ b/tt_metal/impl/debug/debug_helpers.hpp
@@ -89,30 +89,30 @@ inline std::string_view get_core_type_name(CoreType ct) {
     }
 }
 
-// Returns the assert message portion for a given assert type (no trailing period).
+// Returns the assert message portion for a given assert type
 // For DebugAssertTripped, line_num is used in the message.
 inline std::string get_debug_assert_message(dev_msgs::debug_assert_type_t type, uint16_t line_num = 0) {
     switch (type) {
         case dev_msgs::DebugAssertTripped:
             return fmt::format(
                 "tripped an assert on line {}. Note that file name reporting is not yet "
-                "implemented, and the reported line number for the assert may be from a different file",
+                "implemented, and the reported line number for the assert may be from a different file.",
                 line_num);
         case dev_msgs::DebugAssertNCriscNOCReadsFlushedTripped:
             return "detected an inter-kernel data race due to kernel completing with pending NOC "
-                   "transactions (missing NOC reads flushed barrier)";
+                   "transactions (missing NOC reads flushed barrier).";
         case dev_msgs::DebugAssertNCriscNOCNonpostedWritesSentTripped:
             return "detected an inter-kernel data race due to kernel completing with pending NOC "
-                   "transactions (missing NOC non-posted writes sent barrier)";
+                   "transactions (missing NOC non-posted writes sent barrier).";
         case dev_msgs::DebugAssertNCriscNOCNonpostedAtomicsFlushedTripped:
             return "detected an inter-kernel data race due to kernel completing with pending NOC "
-                   "transactions (missing NOC non-posted atomics flushed barrier)";
+                   "transactions (missing NOC non-posted atomics flushed barrier).";
         case dev_msgs::DebugAssertNCriscNOCPostedWritesSentTripped:
             return "detected an inter-kernel data race due to kernel completing with pending NOC "
-                   "transactions (missing NOC posted writes sent barrier)";
-        case dev_msgs::DebugAssertRtaOutOfBounds: return "accessed unique runtime arg index out of bounds";
-        case dev_msgs::DebugAssertCrtaOutOfBounds: return "accessed common runtime arg index out of bounds";
-        default: return "";  // Caller handles unknown types
+                   "transactions (missing NOC posted writes sent barrier).";
+        case dev_msgs::DebugAssertRtaOutOfBounds: return "accessed unique runtime arg index out of bounds.";
+        case dev_msgs::DebugAssertCrtaOutOfBounds: return "accessed common runtime arg index out of bounds.";
+        default: return "";  // Unknown type
     }
 }
 

--- a/tt_metal/impl/debug/watcher_device_reader.cpp
+++ b/tt_metal/impl/debug/watcher_device_reader.cpp
@@ -33,6 +33,7 @@
 #include "api/debug/ring_buffer.h"
 #include "impl/context/metal_context.hpp"
 #include "watcher_device_reader.hpp"
+#include "debug_helpers.hpp"
 #include <impl/debug/watcher_server.hpp>
 #include <llrt/tt_cluster.hpp>
 
@@ -744,54 +745,16 @@ void WatcherDeviceReader::Core::DumpAssertStatus() const {
     }
     std::string error_msg =
         fmt::format("{}: {} ", core_str_, get_riscv_name(programmable_core_type_, assert_status.which()));
-    switch (assert_status.tripped()) {
-        case dev_msgs::DebugAssertTripped: {
-            error_msg += fmt::format("tripped an assert on line {}.", assert_status.line_num());
-            // TODO: Get rid of this once #6098 is implemented.
-            error_msg +=
-                " Note that file name reporting is not yet implemented, and the reported line number for the assert "
-                "may be from a different file.";
-            break;
-        }
-        case dev_msgs::DebugAssertNCriscNOCReadsFlushedTripped: {
-            error_msg +=
-                "detected an inter-kernel data race due to kernel completing with pending NOC transactions (missing "
-                "NOC reads flushed barrier).";
-            break;
-        }
-        case dev_msgs::DebugAssertNCriscNOCNonpostedWritesSentTripped: {
-            error_msg +=
-                "detected an inter-kernel data race due to kernel completing with pending NOC transactions (missing "
-                "NOC non-posted writes sent barrier).";
-            break;
-        }
-        case dev_msgs::DebugAssertNCriscNOCNonpostedAtomicsFlushedTripped: {
-            error_msg +=
-                "detected an inter-kernel data race due to kernel completing with pending NOC transactions (missing "
-                "NOC non-posted atomics flushed barrier).";
-            break;
-        }
-        case dev_msgs::DebugAssertNCriscNOCPostedWritesSentTripped: {
-            error_msg +=
-                "detected an inter-kernel data race due to kernel completing with pending NOC transactions (missing "
-                "NOC posted writes sent barrier).";
-            break;
-        }
-        case dev_msgs::DebugAssertRtaOutOfBounds: {
-            error_msg += "accessed unique runtime arg index out of bounds.";
-            break;
-        }
-        case dev_msgs::DebugAssertCrtaOutOfBounds: {
-            error_msg += "accessed common runtime arg index out of bounds.";
-            break;
-        }
-        default:
-            LogRunningKernels();
-            TT_THROW(
-                "Watcher data corruption, noc assert state on core {} unknown failure code: {}.\n",
-                virtual_coord_.str(),
-                assert_status.tripped());
+    std::string assert_msg = get_debug_assert_message(
+        static_cast<dev_msgs::debug_assert_type_t>(assert_status.tripped()), assert_status.line_num());
+    if (assert_msg.empty()) {
+        LogRunningKernels();
+        TT_THROW(
+            "Watcher data corruption, noc assert state on core {} unknown failure code: {}.\n",
+            virtual_coord_.str(),
+            assert_status.tripped());
     }
+    error_msg += assert_msg + ".";
     error_msg += fmt::format(" Current kernel: {}.", GetKernelName(assert_status.which()));
     log_warning(tt::LogMetal, "Watcher stopped the device due to tripped assert, see watcher log for more details");
     log_warning(tt::LogMetal, "{}", error_msg);

--- a/tt_metal/impl/debug/watcher_device_reader.cpp
+++ b/tt_metal/impl/debug/watcher_device_reader.cpp
@@ -754,7 +754,7 @@ void WatcherDeviceReader::Core::DumpAssertStatus() const {
             virtual_coord_.str(),
             assert_status.tripped());
     }
-    error_msg += assert_msg + ".";
+    error_msg += assert_msg;
     error_msg += fmt::format(" Current kernel: {}.", GetKernelName(assert_status.which()));
     log_warning(tt::LogMetal, "Watcher stopped the device due to tripped assert, see watcher log for more details");
     log_warning(tt::LogMetal, "{}", error_msg);

--- a/tt_metal/jit_build/genfiles.cpp
+++ b/tt_metal/jit_build/genfiles.cpp
@@ -126,9 +126,9 @@ string transform_to_legacy_syntax(const string& source, const char* ns_name, con
 
     ostringstream result;
     result << preamble;
-    result << "namespace " << ns_name << " {\n";
+    result << "namespace " << ns_name << " {";
     result << function_part;
-    result << "\n}  // namespace " << ns_name << "\n";
+    result << "}  // namespace " << ns_name << "\n";
     return result.str();
 }
 }  // namespace simple_kernel_syntax

--- a/tt_metal/jit_build/genfiles.cpp
+++ b/tt_metal/jit_build/genfiles.cpp
@@ -126,9 +126,9 @@ string transform_to_legacy_syntax(const string& source, const char* ns_name, con
 
     ostringstream result;
     result << preamble;
-    result << "namespace " << ns_name << " {";
+    result << "namespace " << ns_name << " {\n";
     result << function_part;
-    result << "}  // namespace " << ns_name << "\n";
+    result << "\n}  // namespace " << ns_name << "\n";
     return result.str();
 }
 }  // namespace simple_kernel_syntax


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/38105

### Problem description
Bringup watcher asserts for all 8 DMs on Quasar.

### What's changed
- Extended `WatcherAssertTests/WatcherNonDefaultAssertTests` for Quasar DM kernel creation in `test_asserts.cpp`, targeting specific DM cores via `watcher_asserts.cpp`
- Consolidated HalProcessorIdentifier to simplify test parameterization across architectures                                 
- Added `get_debug_assert_message()` helper to share assert message logic between watcher reader and tests
- For Quasar, changed RTA/CRTA to use uncached memory for correct runtime arg access
- Fixed `IDLE_ETH` tests that were previously skipped due to overly broad slow dispatch skip logic

Note: Tests need to be extended for TRISCs/ERISC/IERISC once basic runtime support is complete on Quasar.

### Checklist

- [x] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=snadkarni/watcher_assert_quasar)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:snadkarni/watcher_assert_quasar)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=snadkarni/watcher_assert_quasar)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:snadkarni/watcher_assert_quasar)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=snadkarni/watcher_assert_quasar)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:snadkarni/watcher_assert_quasar)
- [x] New/Existing tests provide coverage for changes

Quasar emulator runs: https://gist.github.com/sidnadTT/0284cdcb2c0e413357c5e6432be17897


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=snadkarni/watcher_assert_quasar)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:snadkarni/watcher_assert_quasar)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=snadkarni/watcher_assert_quasar)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:snadkarni/watcher_assert_quasar)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=snadkarni/watcher_assert_quasar)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:snadkarni/watcher_assert_quasar)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
