### PR TITLE
DeepSeek Blitz Broadcast internal looping 

### DIFF
--- a/models/demos/deepseek_v3_b1/micro_ops/ccl_broadcast/kernels/ccl_broadcast_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/micro_ops/ccl_broadcast/kernels/ccl_broadcast_kernel.cpp
@@ -65,6 +65,14 @@ void kernel_main() {
 #endif
 
     // Execute ccl broadcast op
-    Broadcast::Op<BcastCTArgs, true> bcast;
-    bcast(bcast_args);
+    constexpr uint32_t num_iterations = get_named_compile_time_arg_val("num_iterations");
+
+    auto body = [&]() {
+        Broadcast::Op<BcastCTArgs, true> bcast;
+        bcast(bcast_args);
+    };
+
+    for (uint32_t i = 0; i < num_iterations; i++) {
+        body();
+    }
 }

--- a/models/demos/deepseek_v3_b1/micro_ops/ccl_broadcast/op.py
+++ b/models/demos/deepseek_v3_b1/micro_ops/ccl_broadcast/op.py
@@ -45,6 +45,7 @@ class DeepseekMinimalBroadcast:
         cluster_axis=0,
         secondary_cluster_axis=None,
         num_links=1,
+        num_iterations=1,
     ):
         """
         Execute broadcast operation using generic_op.
@@ -182,6 +183,7 @@ class DeepseekMinimalBroadcast:
                     if name not in _seen_ct:
                         _seen_ct.add(name)
                         union_named_compile_time_args.append((name, val))
+                union_named_compile_time_args.append(("num_iterations", num_iterations))
 
                 # Determine fabric connections
                 fabric_node_id = mesh_device.get_fabric_node_id(coord)

--- a/models/demos/deepseek_v3_b1/unified_kernels/broadcast.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/broadcast.hpp
@@ -251,6 +251,12 @@ struct Broadcast {
                     noc_semaphore_inc(out_ready_sem_noc_addr, 1);
 
                     // 3. wait for mcast output ready semaphore
+                    // NOTE: We use wait_min instead of wait+reset to handle the case where broadcast
+                    // is async and a fast device increments the semaphore multiple times before a slow
+                    // device observes it. With wait+reset the slow device could miss an increment and
+                    // hang. In a real decoder this shouldn't be a problem because other ops
+                    // between iterations will naturally sync the devices, but wait_min is a
+                    // pragmatic choice to streamline standalone testing.
                     if (args.wait_output_semaphore) {
                         WATCHER_RING_BUFFER_PUSH(0xA1);
                         volatile tt_l1_ptr uint32_t* sem_ptr =

--- a/models/demos/deepseek_v3_b1/unified_kernels/broadcast.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/broadcast.hpp
@@ -163,6 +163,9 @@ struct Broadcast {
 
                 constexpr uint32_t secondary_connection_idx = num_primary_connections;
 
+                // Reset pool so broadcast can be called across loop iterations
+                PacketHeaderPool::reset();
+
                 auto sem_route_id = PacketHeaderPool::allocate_header_n(num_primary_connections);
                 auto fused_route_id = PacketHeaderPool::allocate_header_n(num_primary_connections);
                 // Allocate separate route for secondary axis unicast (if applicable)
@@ -252,14 +255,14 @@ struct Broadcast {
                         WATCHER_RING_BUFFER_PUSH(0xA1);
                         volatile tt_l1_ptr uint32_t* sem_ptr =
                             reinterpret_cast<volatile tt_l1_ptr uint32_t*>(args.out_ready_sem_bank_addr);
-                        noc_semaphore_wait(sem_ptr, args.out_ready_sem_wait_value);
+                        noc_semaphore_wait_min(sem_ptr, args.out_ready_sem_wait_value);
                         WATCHER_RING_BUFFER_PUSH(0xA2);
                     }
 
                     // 4. global semaphore reset
                     if (args.reset_global_semaphore) {
-                        noc_semaphore_set(
-                            reinterpret_cast<volatile tt_l1_ptr uint32_t*>(args.out_ready_sem_bank_addr), 0);
+                        unified_kernels::semaphore_dec(
+                            reinterpret_cast<volatile tt_l1_ptr uint32_t*>(args.out_ready_sem_bank_addr));
                     }
                     noc_async_writes_flushed();
                     cb_pop_front(CTArgs::cb0_id, CTArgs::num_pages_to_read);
@@ -271,14 +274,14 @@ struct Broadcast {
                         WATCHER_RING_BUFFER_PUSH(0xB1);
                         volatile tt_l1_ptr uint32_t* sem_ptr =
                             reinterpret_cast<volatile tt_l1_ptr uint32_t*>(args.out_ready_sem_bank_addr);
-                        noc_semaphore_wait(sem_ptr, args.out_ready_sem_wait_value);
+                        noc_semaphore_wait_min(sem_ptr, args.out_ready_sem_wait_value);
                         WATCHER_RING_BUFFER_PUSH(0xB2);
                     }
 
                     // Reset semaphore after receiving data
                     if (args.reset_global_semaphore) {
-                        noc_semaphore_set(
-                            reinterpret_cast<volatile tt_l1_ptr uint32_t*>(args.out_ready_sem_bank_addr), 0);
+                        unified_kernels::semaphore_dec(
+                            reinterpret_cast<volatile tt_l1_ptr uint32_t*>(args.out_ready_sem_bank_addr));
                     }
 
                     // broadcast the received data along the primary axis
@@ -306,14 +309,14 @@ struct Broadcast {
                         WATCHER_RING_BUFFER_PUSH(0xC1);
                         volatile tt_l1_ptr uint32_t* sem_ptr =
                             reinterpret_cast<volatile tt_l1_ptr uint32_t*>(args.out_ready_sem_bank_addr);
-                        noc_semaphore_wait(sem_ptr, args.out_ready_sem_wait_value);
+                        noc_semaphore_wait_min(sem_ptr, args.out_ready_sem_wait_value);
                         WATCHER_RING_BUFFER_PUSH(0xC2);
                     }
 
                     // Reset global semaphore
                     if (args.reset_global_semaphore) {
-                        noc_semaphore_set(
-                            reinterpret_cast<volatile tt_l1_ptr uint32_t*>(args.out_ready_sem_bank_addr), 0);
+                        unified_kernels::semaphore_dec(
+                            reinterpret_cast<volatile tt_l1_ptr uint32_t*>(args.out_ready_sem_bank_addr));
                     }
                 }
                 if constexpr (CTArgs::is_secondary_sender || CTArgs::is_sender) {

--- a/models/demos/deepseek_v3_b1/unified_kernels/kernel_utils.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/kernel_utils.hpp
@@ -66,6 +66,11 @@ FORCE_INLINE void setup_sharded_buffer(uint32_t cb_id, uint32_t num_tiles) {
     cb_push_back(cb_id, num_tiles);
 }
 
+// Atomic semaphore decrement (for global semaphore reset across iterations)
+FORCE_INLINE void semaphore_dec(volatile tt_l1_ptr uint32_t* sem_addr) {
+    __atomic_fetch_sub(sem_addr, 1, __ATOMIC_RELAXED);
+}
+
 #endif
 
 }  // namespace unified_kernels

--- a/models/demos/deepseek_v3_b1/unified_kernels/reduce_to_one_b1.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/reduce_to_one_b1.hpp
@@ -42,9 +42,6 @@
 
 namespace deepseek_b1_ops {
 
-// Atomic semaphore decrement by 1
-inline void semaphore_dec(volatile tt_l1_ptr uint32_t* sem_addr) { __atomic_fetch_sub(sem_addr, 1, __ATOMIC_RELAXED); }
-
 // Device roles
 constexpr uint32_t MESH_LEAF = 0;
 constexpr uint32_t MESH_ROOT3 = 1;
@@ -221,7 +218,7 @@ struct ReduceToOneB1 {
                 volatile tt_l1_ptr uint32_t* recv_sem1_ptr =
                     reinterpret_cast<volatile tt_l1_ptr uint32_t*>(args.recv_sem_round1);
                 noc_semaphore_wait_min(recv_sem1_ptr, 1);
-                semaphore_dec(recv_sem1_ptr);
+                unified_kernels::semaphore_dec(recv_sem1_ptr);
                 cb_push_back(CTArgs::received_cb_r1, CTArgs::num_tiles);
             }
 
@@ -231,7 +228,7 @@ struct ReduceToOneB1 {
                 volatile tt_l1_ptr uint32_t* recv_sem2_ptr =
                     reinterpret_cast<volatile tt_l1_ptr uint32_t*>(args.recv_sem_round2);
                 noc_semaphore_wait_min(recv_sem2_ptr, 1);
-                semaphore_dec(recv_sem2_ptr);
+                unified_kernels::semaphore_dec(recv_sem2_ptr);
                 cb_push_back(CTArgs::received_cb_r2, CTArgs::num_tiles);
             }
 
@@ -241,7 +238,7 @@ struct ReduceToOneB1 {
                 volatile tt_l1_ptr uint32_t* recv_sem3_ptr =
                     reinterpret_cast<volatile tt_l1_ptr uint32_t*>(args.recv_sem_round3);
                 noc_semaphore_wait_min(recv_sem3_ptr, 1);
-                semaphore_dec(recv_sem3_ptr);
+                unified_kernels::semaphore_dec(recv_sem3_ptr);
                 cb_push_back(CTArgs::received_cb_r3, CTArgs::num_tiles);
             }
 
@@ -281,7 +278,7 @@ struct ReduceToOneB1 {
                     volatile tt_l1_ptr uint32_t* worker_sem_ptr =
                         reinterpret_cast<volatile tt_l1_ptr uint32_t*>(worker_sem_addr[worker]);
                     noc_semaphore_wait_min(worker_sem_ptr, 1);
-                    semaphore_dec(worker_sem_ptr);
+                    unified_kernels::semaphore_dec(worker_sem_ptr);
 
                     fabric_sender.wait_for_empty_write_slot();
                     fabric_sender.send_payload_without_header_non_blocking_from_address(

--- a/tt_metal/fabric/hw/inc/packet_header_pool.h
+++ b/tt_metal/fabric/hw/inc/packet_header_pool.h
@@ -37,6 +37,12 @@ public:
     // {route_id: [header_ptr, num_headers]}
     static std::pair<volatile tt_l1_ptr PACKET_HEADER_TYPE*, uint8_t> header_table[HEADER_GROUP_SIZE_PER_RISC];
 
+    // Reset pool to initial state — allows re-allocation across loop iterations
+    FORCE_INLINE static void reset() {
+        current_offset_ = risc_pool_start;
+        route_id_ = 0;
+    }
+
     FORCE_INLINE static volatile tt_l1_ptr PACKET_HEADER_TYPE* allocate_header(uint8_t num_headers = 1) {
         ASSERT(current_offset_ + HEADER_SIZE * num_headers <= risc_pool_end);
         if (current_offset_ + HEADER_SIZE * num_headers > risc_pool_end) {


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
we need to test out the internal looping for DeepSeek fused ops, broadcast currently doesn't support that.

### What's changed
reset fabric header pool, otherwise it hangs for over allocation.
use RISCV atomic instruction to decrement l1 counter, so that when looping some devices are way too slow, it won't cause a hang (not a real case for full decoder, but maybe a case for partial graph)

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:{{branch_name}})
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:{{branch_name}})
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:{{branch_name}})
- [ ] New/Existing tests provide coverage for changes

