### PR TITLE
Fix pre-sdpa with broadcast

### DIFF
--- a/models/demos/deepseek_v3_b1/fused_ops/pre_sdpa/kernels/pre_sdpa_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/fused_ops/pre_sdpa/kernels/pre_sdpa_kernel.cpp
@@ -70,6 +70,7 @@ void kernel_main() {
 // Named compile-time args: rmsnorm reader, mcast receiver, matmul reader, gather sender
 // Runtime args: []
 // ============================================================================
+uint32_t per_core_rta_arg_idx = 0;
 #if defined(COMPILE_FOR_NCRISC)
     // CTArgs type aliases (required for Op templates)
     // CCL Broadcast CTArgs type alias
@@ -107,7 +108,7 @@ void kernel_main() {
             get_common_arg_val<uint32_t>(10),  // ring_index
             get_common_arg_val<uint32_t>(11),  // secondary_sync_sem
             get_common_arg_val<uint32_t>(12),  // num_connections (computed from len(dst_nodes))
-            get_common_arg_val<uint32_t>(13),  // per core fabric args start index
+            per_core_rta_arg_idx,
         };
     }
 
@@ -262,12 +263,11 @@ void kernel_main() {
 
     deepseek_b1_ops::KVCacheUpdate::ReaderArgs kv_cache_update_args{};
 
-    uint32_t per_core_rta_arg_idx = 0;
     deepseek_b1_ops::FlashMLADecode::ReaderArgs flash_mla_args;
     if constexpr (Core::is_mla_core) {
         flash_mla_args = {
-            .k_addr = get_common_arg_val<uint32_t>(14),
-            .pos_addr = get_common_arg_val<uint32_t>(15),
+            .k_addr = get_common_arg_val<uint32_t>(13),
+            .pos_addr = get_common_arg_val<uint32_t>(14),
             .cur_batch = get_arg_val<uint32_t>(per_core_rta_arg_idx++),
             .core_num_in_reduce = get_arg_val<uint32_t>(per_core_rta_arg_idx++),
             .is_mcast_sender = get_arg_val<uint32_t>(per_core_rta_arg_idx++),
@@ -464,7 +464,6 @@ void kernel_main() {
             get_named_compile_time_arg_val("kv_cache_cur_pos_ready_semaphore_addr"),
     };
 
-    uint32_t per_core_rta_arg_idx = 0;
     deepseek_b1_ops::FlashMLADecode::WriterArgs flash_mla_args;
     if constexpr (Core::is_mla_core) {
         constexpr uint32_t num_tree_reduction_steps = get_named_compile_time_arg_val("num_tree_reduction_steps");
@@ -695,7 +694,6 @@ void kernel_main() {
         .kv_cache_output_cb = get_common_arg_val<uint32_t>(5),
         .kv_cache_intermed_cb = get_common_arg_val<uint32_t>(6),
     };
-    uint32_t per_core_rta_arg_idx = 0;
     deepseek_b1_ops::FlashMLADecode::ComputeArgs flash_mla_args;
     if constexpr (Core::is_mla_core) {
         constexpr uint32_t num_tree_reduction_steps = get_named_compile_time_arg_val("num_tree_reduction_steps");

--- a/models/demos/deepseek_v3_b1/fused_ops/pre_sdpa/op.py
+++ b/models/demos/deepseek_v3_b1/fused_ops/pre_sdpa/op.py
@@ -2158,7 +2158,7 @@ class PreSDPA:
                 # ================================================================
                 if skip_ccl:
                     # Single-device mode: empty broadcast args
-                    ncrisc_bcast_common_args = [0] * 14
+                    ncrisc_bcast_common_args = [0] * 13
                     dst_nodes = []
                     fabric_node_id = None
                 else:
@@ -2201,7 +2201,6 @@ class PreSDPA:
                         ring_index,
                         int(secondary_sync_sem_addr),
                         num_connections,
-                        len(mla_brisc_per_core_args),
                     ]
 
                 # RoPE DRAM address args (per-device)

--- a/models/demos/deepseek_v3_b1/unified_kernels/flash_mla.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/flash_mla.hpp
@@ -285,7 +285,6 @@ struct FlashMLADecode {
                 reinterpret_cast<volatile tt_l1_ptr uint32_t*>(args.kv_cache_cur_pos_ready_semaphore_addr);
 
             // Wait for KV cache cur pos ready
-            // TODO: add this back
             if constexpr (IsKVCacheUpdateCore) {
                 noc_semaphore_wait(kv_cache_cur_pos_ready_semaphore_ptr, args.kv_cache_cur_pos_ready_value - 1);
             } else {


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Pre-sdpa with sdpa fusion messed with the runtime args of the optional fused broadcast.

### What's changed
Fix the runtime args for fused broadcast.

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=aho/bcast)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:aho/bcast)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=aho/bcast)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:aho/bcast)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=aho/bcast)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:aho/bcast)
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=aho/bcast)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:aho/bcast)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=aho/bcast)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:aho/bcast)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=aho/bcast)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:aho/bcast)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
