### PR TITLE
Remove circular dependency between DispatchMemMap and MetalContext

### DIFF
--- a/tests/tt_metal/tt_metal/dispatch/dispatch_util/test_dispatch_settings.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_util/test_dispatch_settings.cpp
@@ -18,42 +18,17 @@
 
 namespace tt::tt_metal {
 
-// Loop through test_func for WORKER, ETH X 1, 2 CQs
-void ForEachCoreTypeXHWCQs(const std::function<void(const CoreType& core_type, const uint32_t num_hw_cqs)>& test_func) {
-    const auto core_types_to_test = std::array<CoreType, 2>{CoreType::WORKER, CoreType::ETH};
-    const auto num_hw_cqs_to_test = std::array<uint32_t, 2>{1, 2};
-
-    for (const auto& core_type : core_types_to_test) {
-        if (core_type == CoreType::ETH && MetalContext::instance().hal().get_programmable_core_type_index(
-                                              tt::tt_metal::HalProgrammableCoreType::IDLE_ETH) == -1) {
-            // This device does not have the eth core
-            log_info(tt::LogTest, "IDLE_ETH core type is not on this device");
-            continue;
-        }
-        for (const auto& num_hw_cqs : num_hw_cqs_to_test) {
-            test_func(core_type, num_hw_cqs);
-        }
-    }
-}
+static constexpr uint32_t default_l1_alignment = 16;
 
 TEST(DispatchSettingsTest, TestDispatchSettingsDefaultUnsupportedCoreType) {
-    DispatchSettings::initialize(
-        tt::tt_metal::MetalContext::instance().get_cluster(), tt::tt_metal::MetalContext::instance().hal());
     const auto unsupported_core = CoreType::ARC;
-    EXPECT_THROW(DispatchSettings::get(unsupported_core, 1), std::runtime_error);
-}
-
-TEST(DispatchSettingsTest, TestDispatchSettingsMissingArgs) {
-    DispatchSettings settings;
-    EXPECT_THROW(settings.build(), std::runtime_error);
+    EXPECT_THROW(DispatchSettings(1, unsupported_core, false, default_l1_alignment), std::runtime_error);
 }
 
 TEST(DispatchSettingsTest, TestDispatchSettingsEq) {
     const uint32_t hw_cqs = 2;
-    DispatchSettings::initialize(
-        tt::tt_metal::MetalContext::instance().get_cluster(), tt::tt_metal::MetalContext::instance().hal());
-    auto settings = DispatchSettings::get(CoreType::WORKER, hw_cqs);
-    auto settings_2 = settings; // Copy
+    DispatchSettings settings(hw_cqs, CoreType::WORKER, false, default_l1_alignment);
+    DispatchSettings settings_2 = settings;  // Copy
     EXPECT_EQ(settings, settings_2);
     settings_2.dispatch_size_ += 1;
     EXPECT_NE(settings, settings_2);
@@ -64,9 +39,7 @@ TEST(DispatchSettingsTest, TestDispatchSettingsSetPrefetchDBuffer) {
     const uint32_t expected_buffer_bytes = 0xcafe;
     const uint32_t expected_page_count =
         expected_buffer_bytes / (1 << DispatchSettings::PREFETCH_D_BUFFER_LOG_PAGE_SIZE);
-    DispatchSettings::initialize(
-        tt::tt_metal::MetalContext::instance().get_cluster(), tt::tt_metal::MetalContext::instance().hal());
-    auto settings = DispatchSettings::get(CoreType::WORKER, hw_cqs);
+    DispatchSettings settings(hw_cqs, CoreType::WORKER, false, default_l1_alignment);
     settings.prefetch_d_buffer_size(expected_buffer_bytes);
     EXPECT_EQ(settings.prefetch_d_buffer_size_, expected_buffer_bytes);
     EXPECT_EQ(settings.prefetch_d_pages_, expected_page_count);
@@ -76,9 +49,7 @@ TEST(DispatchSettingsTest, TestDispatchSettingsSetPrefetchQBuffer) {
     const uint32_t hw_cqs = 2;
     const uint32_t expected_buffer_entries = 0x1000;
     const uint32_t expected_buffer_bytes = expected_buffer_entries * sizeof(DispatchSettings::prefetch_q_entry_type);
-    DispatchSettings::initialize(
-        tt::tt_metal::MetalContext::instance().get_cluster(), tt::tt_metal::MetalContext::instance().hal());
-    auto settings = DispatchSettings::get(CoreType::WORKER, hw_cqs);
+    DispatchSettings settings(hw_cqs, CoreType::WORKER, false, default_l1_alignment);
     settings.prefetch_q_entries(expected_buffer_entries);
     EXPECT_EQ(settings.prefetch_q_entries_, expected_buffer_entries);
     EXPECT_EQ(settings.prefetch_q_size_, expected_buffer_bytes);
@@ -88,9 +59,7 @@ TEST(DispatchSettingsTest, TestDispatchSettingsSetDispatchBuffer) {
     const uint32_t hw_cqs = 2;
     const uint32_t expected_buffer_bytes = 0x2000;
     const uint32_t expected_page_count = expected_buffer_bytes / (1 << DispatchSettings::DISPATCH_BUFFER_LOG_PAGE_SIZE);
-    DispatchSettings::initialize(
-        tt::tt_metal::MetalContext::instance().get_cluster(), tt::tt_metal::MetalContext::instance().hal());
-    auto settings = DispatchSettings::get(CoreType::WORKER, hw_cqs);
+    DispatchSettings settings(hw_cqs, CoreType::WORKER, false, default_l1_alignment);
     settings.dispatch_size(expected_buffer_bytes);
     EXPECT_EQ(settings.dispatch_size_, expected_buffer_bytes);
     EXPECT_EQ(settings.dispatch_pages_, expected_page_count);
@@ -101,69 +70,10 @@ TEST(DispatchSettingsTest, TestDispatchSettingsSetDispatchSBuffer) {
     const uint32_t expected_buffer_bytes = 0x2000;
     const uint32_t expected_page_count =
         expected_buffer_bytes / (1 << DispatchSettings::DISPATCH_S_BUFFER_LOG_PAGE_SIZE);
-    DispatchSettings::initialize(
-        tt::tt_metal::MetalContext::instance().get_cluster(), tt::tt_metal::MetalContext::instance().hal());
-    auto settings = DispatchSettings::get(CoreType::WORKER, hw_cqs);
+    DispatchSettings settings(hw_cqs, CoreType::WORKER, false, default_l1_alignment);
     settings.dispatch_s_buffer_size(expected_buffer_bytes);
     EXPECT_EQ(settings.dispatch_s_buffer_size_, expected_buffer_bytes);
     EXPECT_EQ(settings.dispatch_s_buffer_pages_, expected_page_count);
-}
-
-TEST(DispatchSettingsTest, TestDispatchSettingsMutations) {
-    if (MetalContext::instance().hal().get_programmable_core_type_index(
-            tt::tt_metal::HalProgrammableCoreType::IDLE_ETH) == -1) {
-        // This device does not have the eth core
-        log_info(tt::LogTest, "Test not supported on this device");
-        return;
-    }
-    const auto core_type = CoreType::WORKER;
-    const uint32_t hw_cqs = 1;
-    const uint32_t prefetch_d_size = 0x1000;
-    const uint32_t cmddat_size = 0x2000;
-    const uint32_t dispatch_s_size = 32;
-    const uint32_t dispatch_size = 4096;
-    const uint32_t max_cmd_size = 1024;
-    const uint32_t prefetch_q_entries = 512;
-    const uint32_t scratch_db_size = 5120;
-
-    DispatchSettings::initialize(
-        tt::tt_metal::MetalContext::instance().get_cluster(), tt::tt_metal::MetalContext::instance().hal());
-    auto& settings = DispatchSettings::get(core_type, hw_cqs);
-    DispatchSettings original_settings = settings;  // Copy the original to be restored later
-
-    EXPECT_EQ(settings.core_type_, core_type);
-
-    // Modify settings
-    settings.prefetch_q_entries(prefetch_q_entries);
-    settings.prefetch_d_buffer_size(prefetch_d_size);
-    settings.prefetch_cmddat_q_size(cmddat_size);
-    settings.dispatch_s_buffer_size(dispatch_s_size);
-    settings.prefetch_max_cmd_size(max_cmd_size);
-    settings.prefetch_scratch_db_size(scratch_db_size);
-    settings.dispatch_size(dispatch_size);
-
-    // Change instance
-    // Check they are not the same
-    auto& settings_2 = DispatchSettings::get(CoreType::ETH, hw_cqs);
-    EXPECT_NE(settings_2.prefetch_q_entries_, prefetch_q_entries);
-    EXPECT_NE(settings_2.prefetch_d_buffer_size_, prefetch_d_size);
-    EXPECT_NE(settings_2.prefetch_cmddat_q_size_, cmddat_size);
-    EXPECT_NE(settings_2.dispatch_s_buffer_size_, dispatch_s_size);
-    EXPECT_NE(settings_2.prefetch_max_cmd_size_, max_cmd_size);
-    EXPECT_NE(settings_2.prefetch_scratch_db_size_, scratch_db_size);
-    EXPECT_NE(settings_2.dispatch_size_, dispatch_size);
-
-    // Change back to the instance that we modified
-    auto& settings_3 = DispatchSettings::get(core_type, hw_cqs);
-    EXPECT_EQ(settings_3.prefetch_q_entries_, prefetch_q_entries);
-    EXPECT_EQ(settings_3.prefetch_d_buffer_size_, prefetch_d_size);
-    EXPECT_EQ(settings_3.prefetch_cmddat_q_size_, cmddat_size);
-    EXPECT_EQ(settings_3.dispatch_s_buffer_size_, dispatch_s_size);
-    EXPECT_EQ(settings_3.prefetch_max_cmd_size_, max_cmd_size);
-    EXPECT_EQ(settings_3.prefetch_scratch_db_size_, scratch_db_size);
-    EXPECT_EQ(settings_3.dispatch_size_, dispatch_size);
-
-    DispatchSettings::initialize(original_settings);
 }
 
 }  // namespace tt::tt_metal

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_util/test_dispatch_settings.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_util/test_dispatch_settings.cpp
@@ -37,7 +37,8 @@ void ForEachCoreTypeXHWCQs(const std::function<void(const CoreType& core_type, c
 }
 
 TEST(DispatchSettingsTest, TestDispatchSettingsDefaultUnsupportedCoreType) {
-    DispatchSettings::initialize(tt::tt_metal::MetalContext::instance().get_cluster());
+    DispatchSettings::initialize(
+        tt::tt_metal::MetalContext::instance().get_cluster(), tt::tt_metal::MetalContext::instance().hal());
     const auto unsupported_core = CoreType::ARC;
     EXPECT_THROW(DispatchSettings::get(unsupported_core, 1), std::runtime_error);
 }
@@ -49,7 +50,8 @@ TEST(DispatchSettingsTest, TestDispatchSettingsMissingArgs) {
 
 TEST(DispatchSettingsTest, TestDispatchSettingsEq) {
     const uint32_t hw_cqs = 2;
-    DispatchSettings::initialize(tt::tt_metal::MetalContext::instance().get_cluster());
+    DispatchSettings::initialize(
+        tt::tt_metal::MetalContext::instance().get_cluster(), tt::tt_metal::MetalContext::instance().hal());
     auto settings = DispatchSettings::get(CoreType::WORKER, hw_cqs);
     auto settings_2 = settings; // Copy
     EXPECT_EQ(settings, settings_2);
@@ -62,7 +64,8 @@ TEST(DispatchSettingsTest, TestDispatchSettingsSetPrefetchDBuffer) {
     const uint32_t expected_buffer_bytes = 0xcafe;
     const uint32_t expected_page_count =
         expected_buffer_bytes / (1 << DispatchSettings::PREFETCH_D_BUFFER_LOG_PAGE_SIZE);
-    DispatchSettings::initialize(tt::tt_metal::MetalContext::instance().get_cluster());
+    DispatchSettings::initialize(
+        tt::tt_metal::MetalContext::instance().get_cluster(), tt::tt_metal::MetalContext::instance().hal());
     auto settings = DispatchSettings::get(CoreType::WORKER, hw_cqs);
     settings.prefetch_d_buffer_size(expected_buffer_bytes);
     EXPECT_EQ(settings.prefetch_d_buffer_size_, expected_buffer_bytes);
@@ -73,7 +76,8 @@ TEST(DispatchSettingsTest, TestDispatchSettingsSetPrefetchQBuffer) {
     const uint32_t hw_cqs = 2;
     const uint32_t expected_buffer_entries = 0x1000;
     const uint32_t expected_buffer_bytes = expected_buffer_entries * sizeof(DispatchSettings::prefetch_q_entry_type);
-    DispatchSettings::initialize(tt::tt_metal::MetalContext::instance().get_cluster());
+    DispatchSettings::initialize(
+        tt::tt_metal::MetalContext::instance().get_cluster(), tt::tt_metal::MetalContext::instance().hal());
     auto settings = DispatchSettings::get(CoreType::WORKER, hw_cqs);
     settings.prefetch_q_entries(expected_buffer_entries);
     EXPECT_EQ(settings.prefetch_q_entries_, expected_buffer_entries);
@@ -84,7 +88,8 @@ TEST(DispatchSettingsTest, TestDispatchSettingsSetDispatchBuffer) {
     const uint32_t hw_cqs = 2;
     const uint32_t expected_buffer_bytes = 0x2000;
     const uint32_t expected_page_count = expected_buffer_bytes / (1 << DispatchSettings::DISPATCH_BUFFER_LOG_PAGE_SIZE);
-    DispatchSettings::initialize(tt::tt_metal::MetalContext::instance().get_cluster());
+    DispatchSettings::initialize(
+        tt::tt_metal::MetalContext::instance().get_cluster(), tt::tt_metal::MetalContext::instance().hal());
     auto settings = DispatchSettings::get(CoreType::WORKER, hw_cqs);
     settings.dispatch_size(expected_buffer_bytes);
     EXPECT_EQ(settings.dispatch_size_, expected_buffer_bytes);
@@ -96,7 +101,8 @@ TEST(DispatchSettingsTest, TestDispatchSettingsSetDispatchSBuffer) {
     const uint32_t expected_buffer_bytes = 0x2000;
     const uint32_t expected_page_count =
         expected_buffer_bytes / (1 << DispatchSettings::DISPATCH_S_BUFFER_LOG_PAGE_SIZE);
-    DispatchSettings::initialize(tt::tt_metal::MetalContext::instance().get_cluster());
+    DispatchSettings::initialize(
+        tt::tt_metal::MetalContext::instance().get_cluster(), tt::tt_metal::MetalContext::instance().hal());
     auto settings = DispatchSettings::get(CoreType::WORKER, hw_cqs);
     settings.dispatch_s_buffer_size(expected_buffer_bytes);
     EXPECT_EQ(settings.dispatch_s_buffer_size_, expected_buffer_bytes);
@@ -120,7 +126,8 @@ TEST(DispatchSettingsTest, TestDispatchSettingsMutations) {
     const uint32_t prefetch_q_entries = 512;
     const uint32_t scratch_db_size = 5120;
 
-    DispatchSettings::initialize(tt::tt_metal::MetalContext::instance().get_cluster());
+    DispatchSettings::initialize(
+        tt::tt_metal::MetalContext::instance().get_cluster(), tt::tt_metal::MetalContext::instance().hal());
     auto& settings = DispatchSettings::get(core_type, hw_cqs);
     DispatchSettings original_settings = settings;  // Copy the original to be restored later
 

--- a/tt_metal/impl/context/metal_context.cpp
+++ b/tt_metal/impl/context/metal_context.cpp
@@ -202,14 +202,13 @@ void MetalContext::initialize(
     dispatch_timeout_detection_processed_ = false;
 
     // Initialize dispatch state
+    bool is_galaxy_cluster = cluster_->is_galaxy_cluster();
     dispatch_core_manager_ = std::make_unique<dispatch_core_manager>(dispatch_core_config, num_hw_cqs);
     dispatch_query_manager_ = std::make_unique<DispatchQueryManager>(num_hw_cqs);
-    // Need DispatchMemMap for both dispatch core types
-    tt_metal::DispatchSettings::initialize(*cluster_, hal());
     dispatch_mem_map_[enchantum::to_underlying(CoreType::WORKER)] =
-        std::make_unique<DispatchMemMap>(CoreType::WORKER, num_hw_cqs, hal());
+        std::make_unique<DispatchMemMap>(CoreType::WORKER, num_hw_cqs, hal(), is_galaxy_cluster);
     dispatch_mem_map_[enchantum::to_underlying(CoreType::ETH)] =
-        std::make_unique<DispatchMemMap>(CoreType::ETH, num_hw_cqs, hal());
+        std::make_unique<DispatchMemMap>(CoreType::ETH, num_hw_cqs, hal(), is_galaxy_cluster);
     // Initialize debug servers. Attaching individual devices done below
     rtoptions_.resolve_fabric_node_ids_to_chip_ids(this->get_control_plane());
     if (rtoptions_.get_feature_enabled(tt::llrt::RunTimeDebugFeatureDprint)) {

--- a/tt_metal/impl/context/metal_context.cpp
+++ b/tt_metal/impl/context/metal_context.cpp
@@ -205,7 +205,7 @@ void MetalContext::initialize(
     dispatch_core_manager_ = std::make_unique<dispatch_core_manager>(dispatch_core_config, num_hw_cqs);
     dispatch_query_manager_ = std::make_unique<DispatchQueryManager>(num_hw_cqs);
     // Need DispatchMemMap for both dispatch core types
-    tt_metal::DispatchSettings::initialize(*cluster_);
+    tt_metal::DispatchSettings::initialize(*cluster_, hal());
     dispatch_mem_map_[enchantum::to_underlying(CoreType::WORKER)] =
         std::make_unique<DispatchMemMap>(CoreType::WORKER, num_hw_cqs, hal());
     dispatch_mem_map_[enchantum::to_underlying(CoreType::ETH)] =

--- a/tt_metal/impl/context/metal_context.cpp
+++ b/tt_metal/impl/context/metal_context.cpp
@@ -207,9 +207,9 @@ void MetalContext::initialize(
     // Need DispatchMemMap for both dispatch core types
     tt_metal::DispatchSettings::initialize(*cluster_);
     dispatch_mem_map_[enchantum::to_underlying(CoreType::WORKER)] =
-        std::make_unique<DispatchMemMap>(CoreType::WORKER, num_hw_cqs);
+        std::make_unique<DispatchMemMap>(CoreType::WORKER, num_hw_cqs, hal());
     dispatch_mem_map_[enchantum::to_underlying(CoreType::ETH)] =
-        std::make_unique<DispatchMemMap>(CoreType::ETH, num_hw_cqs);
+        std::make_unique<DispatchMemMap>(CoreType::ETH, num_hw_cqs, hal());
     // Initialize debug servers. Attaching individual devices done below
     rtoptions_.resolve_fabric_node_ids_to_chip_ids(this->get_control_plane());
     if (rtoptions_.get_feature_enabled(tt::llrt::RunTimeDebugFeatureDprint)) {

--- a/tt_metal/impl/device/firmware/dispatch_kernel_initializer.cpp
+++ b/tt_metal/impl/device/firmware/dispatch_kernel_initializer.cpp
@@ -67,9 +67,9 @@ void DispatchKernelInitializer::init(
     devices_ = devices;
 
     dispatch_mem_map_[enchantum::to_underlying(CoreType::WORKER)] =
-        std::make_unique<tt::tt_metal::DispatchMemMap>(CoreType::WORKER, descriptor_->num_cqs());
+        std::make_unique<tt::tt_metal::DispatchMemMap>(CoreType::WORKER, descriptor_->num_cqs(), descriptor_->hal());
     dispatch_mem_map_[enchantum::to_underlying(CoreType::ETH)] =
-        std::make_unique<tt::tt_metal::DispatchMemMap>(CoreType::ETH, descriptor_->num_cqs());
+        std::make_unique<tt::tt_metal::DispatchMemMap>(CoreType::ETH, descriptor_->num_cqs(), descriptor_->hal());
 
     // Skip firmware initialization for mock devices
     if (descriptor_->is_mock_device()) {

--- a/tt_metal/impl/device/firmware/dispatch_kernel_initializer.cpp
+++ b/tt_metal/impl/device/firmware/dispatch_kernel_initializer.cpp
@@ -66,10 +66,11 @@ void DispatchKernelInitializer::init(
 
     devices_ = devices;
 
-    dispatch_mem_map_[enchantum::to_underlying(CoreType::WORKER)] =
-        std::make_unique<tt::tt_metal::DispatchMemMap>(CoreType::WORKER, descriptor_->num_cqs(), descriptor_->hal());
-    dispatch_mem_map_[enchantum::to_underlying(CoreType::ETH)] =
-        std::make_unique<tt::tt_metal::DispatchMemMap>(CoreType::ETH, descriptor_->num_cqs(), descriptor_->hal());
+    bool is_galaxy_cluster = descriptor_->cluster().is_galaxy_cluster();
+    dispatch_mem_map_[enchantum::to_underlying(CoreType::WORKER)] = std::make_unique<tt::tt_metal::DispatchMemMap>(
+        CoreType::WORKER, descriptor_->num_cqs(), descriptor_->hal(), is_galaxy_cluster);
+    dispatch_mem_map_[enchantum::to_underlying(CoreType::ETH)] = std::make_unique<tt::tt_metal::DispatchMemMap>(
+        CoreType::ETH, descriptor_->num_cqs(), descriptor_->hal(), is_galaxy_cluster);
 
     // Skip firmware initialization for mock devices
     if (descriptor_->is_mock_device()) {

--- a/tt_metal/impl/dispatch/dispatch_mem_map.cpp
+++ b/tt_metal/impl/dispatch/dispatch_mem_map.cpp
@@ -3,28 +3,26 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <enchantum/enchantum.hpp>
-#include "fabric/fabric_edm_packet_header.hpp"
 #include <tt-metalium/tt_align.hpp>
 
 #include "dispatch_mem_map.hpp"
 #include <tt_stl/assert.hpp>
 #include "command_queue_common.hpp"
 #include "dispatch_settings.hpp"
+#include "hal_types.hpp"
 #include "llrt/hal.hpp"
 #include <tt_stl/enum.hpp>
 
 namespace tt::tt_metal {
 
-DispatchMemMap::DispatchMemMap(const CoreType& core_type, const uint32_t num_hw_cqs, const Hal& hal) :
+DispatchMemMap::DispatchMemMap(const CoreType& core_type, uint32_t num_hw_cqs, const Hal& hal, bool is_galaxy_cluster) :
+    settings(DispatchSettings(num_hw_cqs, core_type, is_galaxy_cluster, hal.get_alignment(HalMemType::L1))),
     host_alignment_(hal.get_alignment(HalMemType::HOST)),
     l1_alignment_(hal.get_alignment(HalMemType::L1)),
     noc_overlay_start_addr_(hal.get_noc_overlay_start_addr()),
     noc_stream_reg_space_size_(hal.get_noc_stream_reg_space_size()),
     noc_stream_remote_dest_buf_space_available_update_reg_index_(
         hal.get_noc_stream_remote_dest_buf_space_available_update_reg_index()) {
-    const auto dispatch_settings = DispatchSettings::get(core_type, num_hw_cqs);
-    this->settings = dispatch_settings;
-
     uint32_t l1_base;
     uint32_t l1_size;
     if (core_type == CoreType::WORKER) {

--- a/tt_metal/impl/dispatch/dispatch_mem_map.cpp
+++ b/tt_metal/impl/dispatch/dispatch_mem_map.cpp
@@ -9,109 +9,40 @@
 #include "dispatch_mem_map.hpp"
 #include <tt_stl/assert.hpp>
 #include "command_queue_common.hpp"
-#include <tt-metalium/experimental/fabric/control_plane.hpp>
 #include "dispatch_settings.hpp"
-#include "fabric/fabric_context.hpp"
-#include "hal_types.hpp"
-#include "impl/context/metal_context.hpp"
+#include "llrt/hal.hpp"
 #include <tt_stl/enum.hpp>
 
 namespace tt::tt_metal {
 
-DispatchMemMap::DispatchMemMap(const CoreType& core_type, const uint32_t num_hw_cqs) {
-    this->reset(core_type, num_hw_cqs);
-}
-
-uint32_t DispatchMemMap::prefetch_q_entries() const { return settings.prefetch_q_entries_; }
-
-uint32_t DispatchMemMap::prefetch_q_size() const { return settings.prefetch_q_size_; }
-
-uint32_t DispatchMemMap::max_prefetch_command_size() const { return settings.prefetch_max_cmd_size_; }
-
-uint32_t DispatchMemMap::cmddat_q_base() const { return cmddat_q_base_; }
-
-uint32_t DispatchMemMap::cmddat_q_size() const { return settings.prefetch_cmddat_q_size_; }
-
-uint32_t DispatchMemMap::scratch_db_base() const { return scratch_db_base_; }
-
-uint32_t DispatchMemMap::scratch_db_size() const { return settings.prefetch_scratch_db_size_; }
-
-uint32_t DispatchMemMap::ringbuffer_size() const { return settings.prefetch_ringbuffer_size_; }
-
-uint32_t DispatchMemMap::dispatch_buffer_block_size_pages() const { return dispatch_buffer_block_size_pages_; }
-
-uint32_t DispatchMemMap::dispatch_buffer_base() const { return dispatch_buffer_base_; }
-
-uint32_t DispatchMemMap::dispatch_buffer_pages() const { return settings.dispatch_pages_; }
-
-uint32_t DispatchMemMap::prefetch_d_buffer_size() const { return settings.prefetch_d_buffer_size_; }
-
-uint32_t DispatchMemMap::prefetch_d_buffer_pages() const { return settings.prefetch_d_pages_; }
-
-uint32_t DispatchMemMap::dispatch_s_buffer_size() const { return settings.dispatch_s_buffer_size_; }
-
-uint32_t DispatchMemMap::dispatch_s_buffer_pages() const {
-    return settings.dispatch_s_buffer_size_ / (1 << tt::tt_metal::DispatchSettings::DISPATCH_S_BUFFER_LOG_PAGE_SIZE);
-}
-
-uint32_t DispatchMemMap::get_device_command_queue_addr(const CommandQueueDeviceAddrType& device_addr_type) const {
-    uint32_t index = ttsl::as_underlying_type<CommandQueueDeviceAddrType>(device_addr_type);
-    TT_ASSERT(index < this->device_cq_addrs_.size());
-    return device_cq_addrs_[index];
-}
-
-uint32_t DispatchMemMap::get_host_command_queue_addr(const CommandQueueHostAddrType& host_addr) const {
-    return ttsl::as_underlying_type<CommandQueueHostAddrType>(host_addr) *
-           tt::tt_metal::MetalContext::instance().hal().get_alignment(tt::tt_metal::HalMemType::HOST);
-}
-
-uint32_t DispatchMemMap::get_sync_offset(uint32_t index) const {
-    TT_ASSERT(index < tt::tt_metal::DispatchSettings::DISPATCH_MESSAGE_ENTRIES);
-    uint32_t offset = index * MetalContext::instance().hal().get_alignment(HalMemType::L1);
-    return offset;
-}
-
-uint32_t DispatchMemMap::get_dispatch_message_addr_start() const {
-    // Address of the first dispatch message entry. Remaining entries are each offset by
-    // get_noc_stream_reg_space_size() bytes.
-    return tt::tt_metal::MetalContext::instance().hal().get_noc_overlay_start_addr() +
-           (tt::tt_metal::MetalContext::instance().hal().get_noc_stream_reg_space_size() *
-            get_dispatch_stream_index(0)) +
-           (tt::tt_metal::MetalContext::instance()
-                .hal()
-                .get_noc_stream_remote_dest_buf_space_available_update_reg_index() *
-            sizeof(uint32_t));
-}
-
-uint32_t DispatchMemMap::get_dispatch_stream_index(uint32_t index) const {
-    if (last_core_type == CoreType::WORKER) {
-        // There are 64 streams. CBs use entries 8-39.
-        return 48u + index;
-    }
-    if (last_core_type == CoreType::ETH) {
-        // There are 32 streams.
-        return 16u + index;
-    }
-    TT_THROW("get_dispatch_starting_stream_index not implemented for core type");
-}
-
-uint8_t DispatchMemMap::get_dispatch_message_update_offset(uint32_t index) const {
-    TT_ASSERT(index < tt::tt_metal::DispatchSettings::DISPATCH_MESSAGES_MAX_OFFSET);
-    return index;
-}
-
-// Reset the instance using the settings for the core_type and num_hw_cqs.
-void DispatchMemMap::reset(const CoreType& core_type, const uint32_t num_hw_cqs) {
+DispatchMemMap::DispatchMemMap(const CoreType& core_type, const uint32_t num_hw_cqs, const Hal& hal) :
+    host_alignment_(hal.get_alignment(HalMemType::HOST)),
+    l1_alignment_(hal.get_alignment(HalMemType::L1)),
+    noc_overlay_start_addr_(hal.get_noc_overlay_start_addr()),
+    noc_stream_reg_space_size_(hal.get_noc_stream_reg_space_size()),
+    noc_stream_remote_dest_buf_space_available_update_reg_index_(
+        hal.get_noc_stream_remote_dest_buf_space_available_update_reg_index()) {
     const auto dispatch_settings = DispatchSettings::get(core_type, num_hw_cqs);
     this->settings = dispatch_settings;
-    last_core_type = settings.core_type_;
-    hw_cqs = settings.num_hw_cqs_;
+
+    uint32_t l1_base;
+    uint32_t l1_size;
+    if (core_type == CoreType::WORKER) {
+        l1_base = hal.get_dev_addr(HalProgrammableCoreType::TENSIX, HalL1MemAddrType::DEFAULT_UNRESERVED);
+        l1_size = hal.get_dev_size(HalProgrammableCoreType::TENSIX, HalL1MemAddrType::BASE);
+        dispatch_stream_base_ = 48u;  // 64 streams; CBs use entries 8-39
+    } else if (core_type == CoreType::ETH) {
+        l1_base = hal.get_dev_addr(HalProgrammableCoreType::IDLE_ETH, HalL1MemAddrType::UNRESERVED);
+        l1_size = hal.get_dev_size(HalProgrammableCoreType::IDLE_ETH, HalL1MemAddrType::BASE);
+        dispatch_stream_base_ = 16u;  // 32 streams
+    } else {
+        TT_THROW("DispatchMemMap not implemented for core type");
+    }
+    l1_size_ = l1_size;
 
     const auto dispatch_buffer_block_size = settings.dispatch_size_;
-    const auto [l1_base, l1_size] = get_device_l1_info(settings.core_type_);
-    const auto pcie_alignment =
-        tt::tt_metal::MetalContext::instance().hal().get_alignment(tt::tt_metal::HalMemType::HOST);
-    const auto l1_alignment = tt::tt_metal::MetalContext::instance().hal().get_alignment(tt::tt_metal::HalMemType::L1);
+    const auto pcie_alignment = host_alignment_;
+    const auto l1_alignment = l1_alignment_;
 
     TT_ASSERT(settings.prefetch_cmddat_q_size_ >= 2 * settings.prefetch_max_cmd_size_);
     TT_ASSERT(settings.prefetch_scratch_db_size_ % 2 == 0);
@@ -133,8 +64,6 @@ void DispatchMemMap::reset(const CoreType& core_type, const uint32_t num_hw_cqs)
         } else if (dev_addr_type == CommandQueueDeviceAddrType::FABRIC_HEADER_RB) {
             // At this point fabric context is not initialized yet
             // Hardcode to 128B (more than enough space) for now
-            // const auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
-            // const auto& fabric_context = control_plane.get_fabric_context();
             device_cq_addr_sizes_[dev_addr_idx] = tt::tt_metal::DispatchSettings::FABRIC_HEADER_RB_ENTRIES * 128;
         } else if (
             dev_addr_type == CommandQueueDeviceAddrType::FABRIC_SYNC_STATUS ||
@@ -180,29 +109,67 @@ void DispatchMemMap::reset(const CoreType& core_type, const uint32_t num_hw_cqs)
     TT_ASSERT(dispatch_cb_end < l1_size);
 }
 
-std::pair<uint32_t, uint32_t> DispatchMemMap::get_device_l1_info(const CoreType& core_type) const {
-    uint32_t l1_base;
-    uint32_t l1_size;
-    if (core_type == CoreType::WORKER) {
-        l1_base = MetalContext::instance().hal().get_dev_addr(
-            tt::tt_metal::HalProgrammableCoreType::TENSIX, tt::tt_metal::HalL1MemAddrType::DEFAULT_UNRESERVED);
-        l1_size = MetalContext::instance().hal().get_dev_size(
-            tt::tt_metal::HalProgrammableCoreType::TENSIX, tt::tt_metal::HalL1MemAddrType::BASE);
-    } else if (core_type == CoreType::ETH) {
-        l1_base = MetalContext::instance().hal().get_dev_addr(
-            tt::tt_metal::HalProgrammableCoreType::IDLE_ETH, tt::tt_metal::HalL1MemAddrType::UNRESERVED);
-        l1_size = MetalContext::instance().hal().get_dev_size(
-            tt::tt_metal::HalProgrammableCoreType::IDLE_ETH, tt::tt_metal::HalL1MemAddrType::BASE);
-    } else {
-        TT_THROW("get_base_device_command_queue_addr not implemented for core type");
-    }
+uint32_t DispatchMemMap::prefetch_q_entries() const { return settings.prefetch_q_entries_; }
 
-    return {l1_base, l1_size};
+uint32_t DispatchMemMap::prefetch_q_size() const { return settings.prefetch_q_size_; }
+
+uint32_t DispatchMemMap::max_prefetch_command_size() const { return settings.prefetch_max_cmd_size_; }
+
+uint32_t DispatchMemMap::cmddat_q_base() const { return cmddat_q_base_; }
+
+uint32_t DispatchMemMap::cmddat_q_size() const { return settings.prefetch_cmddat_q_size_; }
+
+uint32_t DispatchMemMap::scratch_db_base() const { return scratch_db_base_; }
+
+uint32_t DispatchMemMap::scratch_db_size() const { return settings.prefetch_scratch_db_size_; }
+
+uint32_t DispatchMemMap::ringbuffer_size() const { return settings.prefetch_ringbuffer_size_; }
+
+uint32_t DispatchMemMap::dispatch_buffer_block_size_pages() const { return dispatch_buffer_block_size_pages_; }
+
+uint32_t DispatchMemMap::dispatch_buffer_base() const { return dispatch_buffer_base_; }
+
+uint32_t DispatchMemMap::dispatch_buffer_pages() const { return settings.dispatch_pages_; }
+
+uint32_t DispatchMemMap::prefetch_d_buffer_size() const { return settings.prefetch_d_buffer_size_; }
+
+uint32_t DispatchMemMap::prefetch_d_buffer_pages() const { return settings.prefetch_d_pages_; }
+
+uint32_t DispatchMemMap::dispatch_s_buffer_size() const { return settings.dispatch_s_buffer_size_; }
+
+uint32_t DispatchMemMap::dispatch_s_buffer_pages() const {
+    return settings.dispatch_s_buffer_size_ / (1 << tt::tt_metal::DispatchSettings::DISPATCH_S_BUFFER_LOG_PAGE_SIZE);
 }
 
-uint32_t DispatchMemMap::get_prefetcher_l1_size() const {
-    auto [l1_base, l1_size] = this->get_device_l1_info(this->settings.core_type_);
-    return l1_size;
+uint32_t DispatchMemMap::get_device_command_queue_addr(const CommandQueueDeviceAddrType& device_addr_type) const {
+    uint32_t index = ttsl::as_underlying_type<CommandQueueDeviceAddrType>(device_addr_type);
+    TT_ASSERT(index < this->device_cq_addrs_.size());
+    return device_cq_addrs_[index];
 }
+
+uint32_t DispatchMemMap::get_host_command_queue_addr(const CommandQueueHostAddrType& host_addr) const {
+    return ttsl::as_underlying_type<CommandQueueHostAddrType>(host_addr) * host_alignment_;
+}
+
+uint32_t DispatchMemMap::get_sync_offset(uint32_t index) const {
+    TT_ASSERT(index < tt::tt_metal::DispatchSettings::DISPATCH_MESSAGE_ENTRIES);
+    return index * l1_alignment_;
+}
+
+uint32_t DispatchMemMap::get_dispatch_message_addr_start() const {
+    // Address of the first dispatch message entry. Remaining entries are each offset by
+    // noc_stream_reg_space_size bytes.
+    return noc_overlay_start_addr_ + (noc_stream_reg_space_size_ * get_dispatch_stream_index(0)) +
+           (noc_stream_remote_dest_buf_space_available_update_reg_index_ * sizeof(uint32_t));
+}
+
+uint32_t DispatchMemMap::get_dispatch_stream_index(uint32_t index) const { return dispatch_stream_base_ + index; }
+
+uint8_t DispatchMemMap::get_dispatch_message_update_offset(uint32_t index) const {
+    TT_ASSERT(index < tt::tt_metal::DispatchSettings::DISPATCH_MESSAGES_MAX_OFFSET);
+    return index;
+}
+
+uint32_t DispatchMemMap::get_prefetcher_l1_size() const { return l1_size_; }
 
 }  // namespace tt::tt_metal

--- a/tt_metal/impl/dispatch/dispatch_mem_map.hpp
+++ b/tt_metal/impl/dispatch/dispatch_mem_map.hpp
@@ -4,8 +4,7 @@
 
 #pragma once
 
-#include <stdint.h>
-#include <utility>
+#include <cstdint>
 #include <vector>
 
 #include <umd/device/types/core_coordinates.hpp>
@@ -31,8 +30,8 @@ public:
     DispatchMemMap& operator=(DispatchMemMap&& other) noexcept = delete;
     DispatchMemMap(const DispatchMemMap&) = delete;
     DispatchMemMap(DispatchMemMap&& other) noexcept = delete;
-    // Uses hal only during init; does not hold the HAL.
-    DispatchMemMap(const CoreType& core_type, uint32_t num_hw_cqs, const Hal& hal);
+    // Create a DispatchMemMap
+    DispatchMemMap(const CoreType& core_type, uint32_t num_hw_cqs, const Hal& hal, bool is_galaxy_cluster);
 
     uint32_t prefetch_q_entries() const;
 

--- a/tt_metal/impl/dispatch/dispatch_mem_map.hpp
+++ b/tt_metal/impl/dispatch/dispatch_mem_map.hpp
@@ -13,6 +13,7 @@
 #include "dispatch_settings.hpp"
 
 namespace tt::tt_metal {
+class Hal;
 enum class CommandQueueDeviceAddrType : uint8_t;
 }  // namespace tt::tt_metal
 
@@ -30,7 +31,8 @@ public:
     DispatchMemMap& operator=(DispatchMemMap&& other) noexcept = delete;
     DispatchMemMap(const DispatchMemMap&) = delete;
     DispatchMemMap(DispatchMemMap&& other) noexcept = delete;
-    DispatchMemMap(const CoreType& core_type, uint32_t num_hw_cqs);
+    // Uses hal only during init; does not hold the HAL.
+    DispatchMemMap(const CoreType& core_type, uint32_t num_hw_cqs, const Hal& hal);
 
     uint32_t prefetch_q_entries() const;
 
@@ -78,11 +80,6 @@ public:
     uint32_t get_prefetcher_l1_size() const;
 
 private:
-    // Reset the instance using the settings for the core_type and num_hw_cqs.
-    void reset(const CoreType& core_type, uint32_t num_hw_cqs);
-
-    std::pair<uint32_t, uint32_t> get_device_l1_info(const CoreType& core_type) const;
-
     uint32_t cmddat_q_base_ = 0;
     uint32_t scratch_db_base_ = 0;
     uint32_t dispatch_buffer_base_ = 0;
@@ -92,8 +89,13 @@ private:
 
     DispatchSettings settings;
 
-    uint32_t hw_cqs{0};  // 0 means uninitialized
-    CoreType last_core_type{CoreType::WORKER};
+    uint32_t host_alignment_ = 0;
+    uint32_t l1_alignment_ = 0;
+    uint32_t l1_size_ = 0;
+    uint32_t noc_overlay_start_addr_ = 0;
+    uint32_t noc_stream_reg_space_size_ = 0;
+    uint32_t noc_stream_remote_dest_buf_space_available_update_reg_index_ = 0;
+    uint32_t dispatch_stream_base_ = 0;
 };
 
 }  // namespace tt::tt_metal

--- a/tt_metal/impl/dispatch/dispatch_settings.hpp
+++ b/tt_metal/impl/dispatch/dispatch_settings.hpp
@@ -10,6 +10,7 @@
 #include <string>
 #include <unordered_map>
 #include <vector>
+#include "llrt/hal.hpp"
 
 namespace tt {
 class Cluster;
@@ -23,25 +24,8 @@ class Hal;
 //
 class DispatchSettings {
 public:
-    // Returns the default settings for WORKER cores
-    static DispatchSettings worker_defaults(const tt::Cluster& cluster, uint32_t num_hw_cqs, uint32_t l1_alignment);
-
-    // Returns the default settings for ETH cores
-    static DispatchSettings eth_defaults(const tt::Cluster& cluster, uint32_t num_hw_cqs, uint32_t l1_alignment);
-
-    // Returns the default settings
-    static DispatchSettings defaults(
-        const CoreType& core_type, const tt::Cluster& cluster, uint32_t num_hw_cqs, uint32_t l1_alignment);
-
-    // Returns the settings for a core type and number hw cqs. The values can be modified, but customization must occur
-    // before command queue kernels are created.
-    static DispatchSettings& get(const CoreType& core_type, uint32_t num_hw_cqs);
-
-    // Reset the settings. Uses hal only to read L1 alignment; does not hold the HAL.
-    static void initialize(const tt::Cluster& cluster, const Hal& hal);
-
-    // Reset the settings for a core type and number hw cqs to the provided settings
-    static void initialize(const DispatchSettings& other);
+    explicit DispatchSettings(
+        uint32_t num_hw_cqs, const CoreType& core_type, bool is_galaxy_cluster, uint32_t l1_alignment);
 
     bool operator==(const DispatchSettings& other) const;
 
@@ -171,6 +155,10 @@ public:
     uint32_t dispatch_s_buffer_pages_{};  // dispatch_s_buffer_size_ / DISPATCH_S_BUFFER_LOG_PAGE_SIZE
 
     CoreType core_type_{0};  // Which core this settings is for
+
+private:
+    void init_worker_defaults(uint32_t num_hw_cqs, bool is_galaxy_cluster, uint32_t l1_alignment);
+    void init_eth_defaults(uint32_t num_hw_cqs, uint32_t l1_alignment);
 };
 
 // Convenience type alias for arrays of `DISPATCH_MESSAGE_ENTRIES` size.

--- a/tt_metal/impl/dispatch/dispatch_settings.hpp
+++ b/tt_metal/impl/dispatch/dispatch_settings.hpp
@@ -16,6 +16,7 @@ class Cluster;
 }
 
 namespace tt::tt_metal {
+class Hal;
 
 //
 // Dispatch Kernel Settings
@@ -23,20 +24,21 @@ namespace tt::tt_metal {
 class DispatchSettings {
 public:
     // Returns the default settings for WORKER cores
-    static DispatchSettings worker_defaults(const tt::Cluster& cluster, uint32_t num_hw_cqs);
+    static DispatchSettings worker_defaults(const tt::Cluster& cluster, uint32_t num_hw_cqs, uint32_t l1_alignment);
 
     // Returns the default settings for ETH cores
-    static DispatchSettings eth_defaults(const tt::Cluster& cluster, uint32_t num_hw_cqs);
+    static DispatchSettings eth_defaults(const tt::Cluster& cluster, uint32_t num_hw_cqs, uint32_t l1_alignment);
 
     // Returns the default settings
-    static DispatchSettings defaults(const CoreType& core_type, const tt::Cluster& cluster, uint32_t num_hw_cqs);
+    static DispatchSettings defaults(
+        const CoreType& core_type, const tt::Cluster& cluster, uint32_t num_hw_cqs, uint32_t l1_alignment);
 
     // Returns the settings for a core type and number hw cqs. The values can be modified, but customization must occur
     // before command queue kernels are created.
     static DispatchSettings& get(const CoreType& core_type, uint32_t num_hw_cqs);
 
-    // Reset the settings
-    static void initialize(const tt::Cluster& cluster);
+    // Reset the settings. Uses hal only to read L1 alignment; does not hold the HAL.
+    static void initialize(const tt::Cluster& cluster, const Hal& hal);
 
     // Reset the settings for a core type and number hw cqs to the provided settings
     static void initialize(const DispatchSettings& other);

--- a/tt_metal/impl/dispatch/kernel_config/fd_kernel.hpp
+++ b/tt_metal/impl/dispatch/kernel_config/fd_kernel.hpp
@@ -116,10 +116,11 @@ public:
         get_dispatch_query_manager_(get_dispatch_query_manager),
         get_max_num_eth_cores_(get_max_num_eth_cores),
         get_reads_dispatch_cores_(get_reads_dispatch_cores) {
-        dispatch_mem_map_[enchantum::to_underlying(CoreType::WORKER)] =
-            std::make_unique<tt::tt_metal::DispatchMemMap>(CoreType::WORKER, descriptor.num_cqs(), descriptor.hal());
-        dispatch_mem_map_[enchantum::to_underlying(CoreType::ETH)] =
-            std::make_unique<tt::tt_metal::DispatchMemMap>(CoreType::ETH, descriptor.num_cqs(), descriptor.hal());
+        bool is_galaxy_cluster = descriptor_.cluster().is_galaxy_cluster();
+        dispatch_mem_map_[enchantum::to_underlying(CoreType::WORKER)] = std::make_unique<tt::tt_metal::DispatchMemMap>(
+            CoreType::WORKER, descriptor.num_cqs(), descriptor.hal(), is_galaxy_cluster);
+        dispatch_mem_map_[enchantum::to_underlying(CoreType::ETH)] = std::make_unique<tt::tt_metal::DispatchMemMap>(
+            CoreType::ETH, descriptor.num_cqs(), descriptor.hal(), is_galaxy_cluster);
     }
     virtual ~FDKernel() = default;
 

--- a/tt_metal/impl/dispatch/kernel_config/fd_kernel.hpp
+++ b/tt_metal/impl/dispatch/kernel_config/fd_kernel.hpp
@@ -117,9 +117,9 @@ public:
         get_max_num_eth_cores_(get_max_num_eth_cores),
         get_reads_dispatch_cores_(get_reads_dispatch_cores) {
         dispatch_mem_map_[enchantum::to_underlying(CoreType::WORKER)] =
-            std::make_unique<tt::tt_metal::DispatchMemMap>(CoreType::WORKER, descriptor.num_cqs());
+            std::make_unique<tt::tt_metal::DispatchMemMap>(CoreType::WORKER, descriptor.num_cqs(), descriptor.hal());
         dispatch_mem_map_[enchantum::to_underlying(CoreType::ETH)] =
-            std::make_unique<tt::tt_metal::DispatchMemMap>(CoreType::ETH, descriptor.num_cqs());
+            std::make_unique<tt::tt_metal::DispatchMemMap>(CoreType::ETH, descriptor.num_cqs(), descriptor.hal());
     }
     virtual ~FDKernel() = default;
 

--- a/tt_metal/impl/dispatch/topology.cpp
+++ b/tt_metal/impl/dispatch/topology.cpp
@@ -408,9 +408,9 @@ DispatchTopology::DispatchTopology(
     get_reads_dispatch_cores_(get_reads_dispatch_cores) {
     command_queue_compile_group_ = std::make_unique<detail::ProgramCompileGroup>();
     dispatch_mem_map_[enchantum::to_underlying(CoreType::WORKER)] =
-        std::make_unique<DispatchMemMap>(CoreType::WORKER, descriptor_.num_cqs());
+        std::make_unique<DispatchMemMap>(CoreType::WORKER, descriptor_.num_cqs(), descriptor_.hal());
     dispatch_mem_map_[enchantum::to_underlying(CoreType::ETH)] =
-        std::make_unique<DispatchMemMap>(CoreType::ETH, descriptor_.num_cqs());
+        std::make_unique<DispatchMemMap>(CoreType::ETH, descriptor_.num_cqs(), descriptor_.hal());
 }
 
 DispatchTopology::~DispatchTopology() { reset(); }

--- a/tt_metal/impl/dispatch/topology.cpp
+++ b/tt_metal/impl/dispatch/topology.cpp
@@ -407,10 +407,11 @@ DispatchTopology::DispatchTopology(
     get_max_num_eth_cores_(get_max_num_eth_cores),
     get_reads_dispatch_cores_(get_reads_dispatch_cores) {
     command_queue_compile_group_ = std::make_unique<detail::ProgramCompileGroup>();
+    bool is_galaxy_cluster = descriptor_.cluster().is_galaxy_cluster();
     dispatch_mem_map_[enchantum::to_underlying(CoreType::WORKER)] =
-        std::make_unique<DispatchMemMap>(CoreType::WORKER, descriptor_.num_cqs(), descriptor_.hal());
+        std::make_unique<DispatchMemMap>(CoreType::WORKER, descriptor_.num_cqs(), descriptor_.hal(), is_galaxy_cluster);
     dispatch_mem_map_[enchantum::to_underlying(CoreType::ETH)] =
-        std::make_unique<DispatchMemMap>(CoreType::ETH, descriptor_.num_cqs(), descriptor_.hal());
+        std::make_unique<DispatchMemMap>(CoreType::ETH, descriptor_.num_cqs(), descriptor_.hal(), is_galaxy_cluster);
 }
 
 DispatchTopology::~DispatchTopology() { reset(); }

--- a/tt_metal/impl/dispatch/util/dispatch_settings.cpp
+++ b/tt_metal/impl/dispatch/util/dispatch_settings.cpp
@@ -33,45 +33,26 @@ static_assert(
     "DISPATCH_MESSAGES_MAX_OFFSET does not match the maximum value of go_msg_t::dispatch_message_offset. "
     "Fix the value in dispatch_settings.hpp");
 
-namespace {
-
-struct DispatchSettingsContainerKey {
-    CoreType core_type;
-    uint32_t num_hw_cqs;
-
-    bool operator==(const DispatchSettingsContainerKey& other) const {
-        return core_type == other.core_type && num_hw_cqs == other.num_hw_cqs;
+DispatchSettings::DispatchSettings(
+    uint32_t num_hw_cqs, const CoreType& core_type, bool is_galaxy_cluster, uint32_t l1_alignment) {
+    switch (core_type) {
+        case CoreType::WORKER: init_worker_defaults(num_hw_cqs, is_galaxy_cluster, l1_alignment); break;
+        case CoreType::ETH: init_eth_defaults(num_hw_cqs, l1_alignment); break;
+        default: TT_THROW("init_defaults not implemented for core type {}", enchantum::to_string(core_type));
     }
-};
-
-struct DispatchSettingsContainerKeyHasher {
-    size_t operator()(const DispatchSettingsContainerKey& k) const {
-        const auto h1 = std::hash<uint32_t>{}(static_cast<int>(k.core_type));
-        const auto h2 = std::hash<uint32_t>{}(k.num_hw_cqs);
-        return h1 ^ (h2 << 1);
-    }
-};
-
-using DispatchSettingsContainer =
-    std::unordered_map<DispatchSettingsContainerKey, DispatchSettings, DispatchSettingsContainerKeyHasher>;
-
-DispatchSettingsContainer& get_store() {
-    static DispatchSettingsContainer store;
-    return store;
+    this->core_type_ = core_type;
+    this->num_hw_cqs_ = num_hw_cqs;
 }
-}  // namespace
 
-DispatchSettings DispatchSettings::worker_defaults(
-    const tt::Cluster& cluster, const uint32_t num_hw_cqs, const uint32_t l1_alignment) {
+void DispatchSettings::init_worker_defaults(uint32_t num_hw_cqs, bool is_galaxy_cluster, uint32_t l1_alignment) {
     uint32_t prefetch_q_entries;
-    if (cluster.is_galaxy_cluster()) {
+    if (is_galaxy_cluster) {
         prefetch_q_entries = 1532 / num_hw_cqs;
     } else {
         prefetch_q_entries = 1534;
     }
 
-    return DispatchSettings()
-        .num_hw_cqs(num_hw_cqs)
+    this->num_hw_cqs(num_hw_cqs)
         .core_type(CoreType::WORKER)
         .prefetch_q_entries(prefetch_q_entries)
         .prefetch_max_cmd_size(128_KB)
@@ -88,10 +69,8 @@ DispatchSettings DispatchSettings::worker_defaults(
         .build();
 }
 
-DispatchSettings DispatchSettings::eth_defaults(
-    const tt::Cluster& /*cluster*/, const uint32_t num_hw_cqs, const uint32_t l1_alignment) {
-    return DispatchSettings()
-        .num_hw_cqs(num_hw_cqs)
+void DispatchSettings::init_eth_defaults(uint32_t num_hw_cqs, uint32_t l1_alignment) {
+    this->num_hw_cqs(num_hw_cqs)
         .core_type(CoreType::ETH)
         .prefetch_q_entries(128)
         .prefetch_max_cmd_size(32_KB)
@@ -106,22 +85,6 @@ DispatchSettings DispatchSettings::eth_defaults(
         .with_alignment(l1_alignment)
 
         .build();
-}
-
-DispatchSettings DispatchSettings::defaults(
-    const CoreType& core_type, const tt::Cluster& cluster, const uint32_t num_hw_cqs, const uint32_t l1_alignment) {
-    if (!num_hw_cqs) {
-        TT_THROW("0 CQs is invalid");
-    }
-
-    if (core_type == CoreType::WORKER) {
-        return worker_defaults(cluster, num_hw_cqs, l1_alignment);
-    }
-    if (core_type == CoreType::ETH) {
-        return eth_defaults(cluster, num_hw_cqs, l1_alignment);
-    }
-
-    TT_THROW("Default settings for core_type {} is not implemented", enchantum::to_string(core_type));
 }
 
 std::vector<std::string> DispatchSettings::get_errors() const {
@@ -161,38 +124,6 @@ DispatchSettings& DispatchSettings::build() {
         return *this;
     }
     TT_THROW("Validation errors in dispatch_settings. Call validate() for a list of errors");
-}
-
-// Returns the settings for a core type and number hw cqs. The values can be modified, but customization must occur
-// before command queue kernels are created.
-DispatchSettings& DispatchSettings::get(const CoreType& core_type, const uint32_t num_hw_cqs) {
-    DispatchSettingsContainerKey k{core_type, num_hw_cqs};
-    auto& store = get_store();
-    if (!store.contains(k)) {
-        TT_THROW(
-            "DispatchSettings is not initialized for CoreType {}, {} CQs", enchantum::to_string(core_type), num_hw_cqs);
-    }
-    return store[k];
-}
-
-// Reset the settings
-void DispatchSettings::initialize(const tt::Cluster& cluster, const Hal& hal) {
-    const uint32_t l1_alignment = hal.get_alignment(HalMemType::L1);
-    static constexpr std::array<CoreType, 2> k_SupportedCoreTypes{CoreType::ETH, CoreType::WORKER};
-    auto& store = get_store();
-    for (const auto& core_type : k_SupportedCoreTypes) {
-        for (uint32_t hw_cqs = 1; hw_cqs <= MAX_NUM_HW_CQS; ++hw_cqs) {
-            DispatchSettingsContainerKey k{core_type, hw_cqs};
-            store[k] = DispatchSettings::defaults(core_type, cluster, hw_cqs, l1_alignment);
-        }
-    }
-}
-
-// Reset the settings for a core type and number hw cqs to the provided settings
-void DispatchSettings::initialize(const DispatchSettings& other) {
-    auto& store = get_store();
-    DispatchSettingsContainerKey k{other.core_type_, other.num_hw_cqs_};
-    store[k] = other;
 }
 
 bool DispatchSettings::operator==(const DispatchSettings& other) const {

--- a/tt_metal/impl/dispatch/util/dispatch_settings.cpp
+++ b/tt_metal/impl/dispatch/util/dispatch_settings.cpp
@@ -13,7 +13,7 @@
 #include <tt_stl/assert.hpp>
 #include "fmt/base.h"
 #include "hal_types.hpp"
-#include "impl/context/metal_context.hpp"
+#include "llrt/hal.hpp"
 #include "dispatch/dispatch_settings.hpp"
 #include "size_literals.hpp"
 #include "tt_metal/impl/dispatch/kernels/cq_commands.hpp"
@@ -61,7 +61,8 @@ DispatchSettingsContainer& get_store() {
 }
 }  // namespace
 
-DispatchSettings DispatchSettings::worker_defaults(const tt::Cluster& cluster, const uint32_t num_hw_cqs) {
+DispatchSettings DispatchSettings::worker_defaults(
+    const tt::Cluster& cluster, const uint32_t num_hw_cqs, const uint32_t l1_alignment) {
     uint32_t prefetch_q_entries;
     if (cluster.is_galaxy_cluster()) {
         prefetch_q_entries = 1532 / num_hw_cqs;
@@ -82,12 +83,13 @@ DispatchSettings DispatchSettings::worker_defaults(const tt::Cluster& cluster, c
         .dispatch_size(512_KB)
         .dispatch_s_buffer_size(32_KB)
 
-        .with_alignment(MetalContext::instance().hal().get_alignment(HalMemType::L1))
+        .with_alignment(l1_alignment)
 
         .build();
 }
 
-DispatchSettings DispatchSettings::eth_defaults(const tt::Cluster& /*cluster*/, const uint32_t num_hw_cqs) {
+DispatchSettings DispatchSettings::eth_defaults(
+    const tt::Cluster& /*cluster*/, const uint32_t num_hw_cqs, const uint32_t l1_alignment) {
     return DispatchSettings()
         .num_hw_cqs(num_hw_cqs)
         .core_type(CoreType::ETH)
@@ -101,22 +103,22 @@ DispatchSettings DispatchSettings::eth_defaults(const tt::Cluster& /*cluster*/, 
         .dispatch_size(128_KB)
         .dispatch_s_buffer_size(32_KB)
 
-        .with_alignment(MetalContext::instance().hal().get_alignment(HalMemType::L1))
+        .with_alignment(l1_alignment)
 
         .build();
 }
 
 DispatchSettings DispatchSettings::defaults(
-    const CoreType& core_type, const tt::Cluster& cluster, const uint32_t num_hw_cqs) {
+    const CoreType& core_type, const tt::Cluster& cluster, const uint32_t num_hw_cqs, const uint32_t l1_alignment) {
     if (!num_hw_cqs) {
         TT_THROW("0 CQs is invalid");
     }
 
     if (core_type == CoreType::WORKER) {
-        return worker_defaults(cluster, num_hw_cqs);
+        return worker_defaults(cluster, num_hw_cqs, l1_alignment);
     }
     if (core_type == CoreType::ETH) {
-        return eth_defaults(cluster, num_hw_cqs);
+        return eth_defaults(cluster, num_hw_cqs, l1_alignment);
     }
 
     TT_THROW("Default settings for core_type {} is not implemented", enchantum::to_string(core_type));
@@ -174,13 +176,14 @@ DispatchSettings& DispatchSettings::get(const CoreType& core_type, const uint32_
 }
 
 // Reset the settings
-void DispatchSettings::initialize(const tt::Cluster& cluster) {
+void DispatchSettings::initialize(const tt::Cluster& cluster, const Hal& hal) {
+    const uint32_t l1_alignment = hal.get_alignment(HalMemType::L1);
     static constexpr std::array<CoreType, 2> k_SupportedCoreTypes{CoreType::ETH, CoreType::WORKER};
     auto& store = get_store();
     for (const auto& core_type : k_SupportedCoreTypes) {
         for (uint32_t hw_cqs = 1; hw_cqs <= MAX_NUM_HW_CQS; ++hw_cqs) {
             DispatchSettingsContainerKey k{core_type, hw_cqs};
-            store[k] = DispatchSettings::defaults(core_type, cluster, hw_cqs);
+            store[k] = DispatchSettings::defaults(core_type, cluster, hw_cqs, l1_alignment);
         }
     }
 }


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/37247

### Problem description
- Fragile code. MetalContext needs DispatchMemMap but DispatchMemMap itself needs MetalContext
- Singleton is not needed

### What's changed
- Remove circular dependency
- Removed the static state from DispatchSettings

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=nhuang/mem-map)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:nhuang/mem-map)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=nhuang/mem-map)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:nhuang/mem-map)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nhuang/mem-map)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nhuang/mem-map)
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nhuang/mem-map)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nhuang/mem-map)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nhuang/mem-map)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nhuang/mem-map)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nhuang/mem-map)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nhuang/mem-map)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
