### PR TITLE
Add prepare_rope module and commonize RoPE tensor creation across tests

### DIFF
--- a/models/demos/deepseek_v3_b1/prepare_rope.py
+++ b/models/demos/deepseek_v3_b1/prepare_rope.py
@@ -1,0 +1,138 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Prepare RoPE (Rotary Position Embedding) tensors for DeepSeek V3 B1 ops.
+
+Provides the transformation matrix and cos/sin tables in the layout expected by
+the pre-SDPA fused op and RopeSingleCore. See test_pre_sdpa.py and test_rope.py
+for how these tensors are consumed.
+"""
+
+from __future__ import annotations
+
+import torch
+
+import ttnn
+from models.demos.deepseek_v3.tt.rope import get_rot_transformation_mat  # re-exported for callers
+
+# RoPE dimensions (match test_pre_sdpa / pre-SDPA op)
+ROPE_HEAD_DIM = 64
+ROPE_TRANS_TILE = (32, 32)  # ttnn.TILE_SIZE x ttnn.TILE_SIZE
+
+# Grid constants for pre-SDPA trans_mat (match test_pre_sdpa)
+QNOPE_GRID_COLS = 8
+QROPE_GRID_COLS = 4
+MATMUL2_GRID_Y = 8
+KV_CACHE_BRANCH_START_OFFSET = (0, 8)
+
+
+def get_rope_trans_mat_core_range_set(device_grid_size: ttnn.CoreCoord) -> ttnn.CoreRangeSet:
+    """Build the core range set for the RoPE transformation matrix (pre-SDPA layout).
+
+    Combines qrope_grid (QROPE_GRID_COLS x MATMUL2_GRID_Y) and kv_cache_branch_rope_crs (2 cores).
+    Layout matches test_pre_sdpa.py so each core holds one [32, 32] shard.
+    """
+    qrope_grid = ttnn.CoreRange(
+        ttnn.CoreCoord(QNOPE_GRID_COLS, 0),
+        ttnn.CoreCoord(QNOPE_GRID_COLS + QROPE_GRID_COLS - 1, MATMUL2_GRID_Y - 1),
+    )
+    kv_ox, kv_oy = KV_CACHE_BRANCH_START_OFFSET
+    kv_cache_branch_rope_crs = ttnn.CoreRangeSet(
+        {
+            ttnn.CoreRange(
+                ttnn.CoreCoord(8 + kv_ox, kv_oy),
+                ttnn.CoreCoord(8 + kv_ox, 1 + kv_oy),
+            )
+        }
+    )
+    return kv_cache_branch_rope_crs.merge(ttnn.CoreRangeSet({qrope_grid}))
+
+
+def create_rope_trans_mat_tensor(device) -> ttnn.Tensor:
+    """Build the RoPE transformation matrix in pre-SDPA layout.
+
+    Returns a ttnn tensor: HEIGHT_SHARDED L1, one (32, 32) shard per core over
+    qrope_grid + kv_cache_branch_rope_crs, replicated on mesh. Layout matches
+    the pre-SDPA fused op (test_pre_sdpa.py).
+    """
+    device_grid_size = device.compute_with_storage_grid_size()
+    trans_mat_crs = get_rope_trans_mat_core_range_set(device_grid_size)
+    num_cores = trans_mat_crs.num_cores()
+
+    trans_mat = get_rot_transformation_mat().repeat(1, 1, num_cores, 1)
+    trans_shard_spec = ttnn.ShardSpec(
+        trans_mat_crs,
+        (ttnn.TILE_SIZE, ttnn.TILE_SIZE),
+        ttnn.ShardOrientation.ROW_MAJOR,
+    )
+    trans_mem_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, trans_shard_spec)
+    trans_tile = ttnn.Tile((ttnn.TILE_SIZE, ttnn.TILE_SIZE))
+    return ttnn.from_torch(
+        trans_mat.to(torch.bfloat16),
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        memory_config=trans_mem_config,
+        tile=trans_tile,
+        mesh_mapper=ttnn.ReplicateTensorToMesh(device),
+    )
+
+
+def get_cos_sin_torch(
+    max_seq_len: int,
+    head_dim: int = ROPE_HEAD_DIM,
+    base: float = 10000.0,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Return cos and sin tensors for RoPE in Meta-style format.
+
+    Shape: (cos, sin) each [1, 1, max_seq_len, head_dim].
+    Formula matches test_pre_sdpa.py and test_rope.py (base=10000, inv_freq, outer).
+    """
+    inv_freq = 1.0 / (base ** (torch.arange(0, head_dim, 2, dtype=torch.float32) / head_dim))
+    t = torch.arange(max_seq_len, dtype=torch.float32)
+    freqs = torch.outer(t, inv_freq)
+    cos = torch.stack((freqs.cos(), freqs.cos()), dim=-1).flatten(-2)
+    sin = torch.stack((freqs.sin(), freqs.sin()), dim=-1).flatten(-2)
+    cos = cos.unsqueeze(0).unsqueeze(0)
+    sin = sin.unsqueeze(0).unsqueeze(0)
+    return cos, sin
+
+
+def create_rope_cos_sin_ttnn(
+    device,
+    max_seq_len: int,
+    head_dim: int = ROPE_HEAD_DIM,
+    base: float = 10000.0,
+    tile: ttnn.Tile | None = None,
+) -> tuple[ttnn.Tensor, ttnn.Tensor]:
+    """Build RoPE cos/sin as ttnn tensors in pre-SDPA layout.
+
+    Returns (ttnn_cos, ttnn_sin): DRAM INTERLEAVED, replicated on mesh, shape
+    [1, 1, max_seq_len, head_dim]. Same layout used for QRoPE and KRoPE in
+    test_pre_sdpa.py (both can use this single pair).
+    """
+    if tile is None:
+        tile = ttnn.Tile([1, 32])
+    cos_torch, sin_torch = get_cos_sin_torch(max_seq_len, head_dim=head_dim, base=base)
+    dram_mem_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.DRAM)
+    ttnn_cos = ttnn.from_torch(
+        cos_torch.to(torch.bfloat16),
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        memory_config=dram_mem_config,
+        tile=tile,
+        mesh_mapper=ttnn.ReplicateTensorToMesh(device),
+    )
+    ttnn_sin = ttnn.from_torch(
+        sin_torch.to(torch.bfloat16),
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        memory_config=dram_mem_config,
+        tile=tile,
+        mesh_mapper=ttnn.ReplicateTensorToMesh(device),
+    )
+    return ttnn_cos, ttnn_sin

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_pre_sdpa.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_pre_sdpa.py
@@ -16,10 +16,14 @@ from loguru import logger
 
 import ttnn
 from models.common.utility_functions import comp_pcc
-from models.demos.deepseek_v3.tt.rope import get_rot_transformation_mat
 from models.demos.deepseek_v3_b1.blitz_decode_weights import shuffle_weights_for_interleaved_qnope_qrope
 from models.demos.deepseek_v3_b1.fused_ops.pre_sdpa.op import PreSDPA
 from models.demos.deepseek_v3_b1.micro_ops.flash_mla.op import FlashMLADecode
+from models.demos.deepseek_v3_b1.prepare_rope import (
+    create_rope_cos_sin_ttnn,
+    create_rope_trans_mat_tensor,
+    get_cos_sin_torch,
+)
 
 
 def create_fabric_router_config(max_payload_size):
@@ -296,18 +300,8 @@ def test_pre_sdpa(
     max_seq_len = 8192
     position_ids = torch.tensor([position_id])  # [batch]
 
-    # Create cos/sin matrices in Meta-style format
-    base = 10000.0
-    inv_freq = 1.0 / (base ** (torch.arange(0, QROPE_HEAD_DIM, 2, dtype=torch.float32) / QROPE_HEAD_DIM))
-    t = torch.arange(max_seq_len, dtype=torch.float32)
-    freqs = torch.outer(t, inv_freq)
-
-    # Meta-style: stack [cos(t), cos(t)] interleaved
-    torch_cos = torch.stack((freqs.cos(), freqs.cos()), dim=-1).flatten(-2)  # [max_seq_len, qrope_head_dim]
-    torch_sin = torch.stack((freqs.sin(), freqs.sin()), dim=-1).flatten(-2)  # [max_seq_len, qrope_head_dim]
-
-    # Transformation matrix for RoPE
-    torch_trans_mat = get_rot_transformation_mat()  # [1, 1, 32, 32]
+    # Cos/sin in Meta-style format [1, 1, max_seq_len, 64] (used for golden and ttnn)
+    torch_cos, torch_sin = get_cos_sin_torch(max_seq_len)
 
     # ========================================================================
     # Create TTNN tensors
@@ -504,62 +498,9 @@ def test_pre_sdpa(
         mesh_mapper=ttnn.ReplicateTensorToMesh(submesh),
     )
 
-    # RoPE tensors
-    qrope_grid = ttnn.CoreRange(
-        ttnn.CoreCoord(QNOPE_GRID_COLS, 0), ttnn.CoreCoord(QNOPE_GRID_COLS + QROPE_GRID_COLS - 1, matmul2_grid_y - 1)
-    )
-
-    # QRoPE cos/sin: DRAM INTERLEAVED (all qrope cores read full head_dim)
-    # Shape: [1, 1, max_seq_len, qrope_head_dim]
-    qrope_cos_full = torch_cos.unsqueeze(0).unsqueeze(0)  # [1, 1, max_seq_len, 64]
-    qrope_sin_full = torch_sin.unsqueeze(0).unsqueeze(0)  # [1, 1, max_seq_len, 64]
-
-    qrope_dram_mem_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.DRAM)
-
-    ttnn_qrope_cos = ttnn.from_torch(
-        qrope_cos_full,
-        dtype=ttnn.bfloat16,
-        layout=ttnn.TILE_LAYOUT,
-        device=submesh,
-        memory_config=qrope_dram_mem_config,
-        tile=tile,
-        mesh_mapper=ttnn.ReplicateTensorToMesh(submesh),
-    )
-
-    ttnn_qrope_sin = ttnn.from_torch(
-        qrope_sin_full,
-        dtype=ttnn.bfloat16,
-        layout=ttnn.TILE_LAYOUT,
-        device=submesh,
-        memory_config=qrope_dram_mem_config,
-        tile=tile,
-        mesh_mapper=ttnn.ReplicateTensorToMesh(submesh),
-    )
-
-    # Trans_mat: [1, 1, 32, 32] - repeat for all qrope cores
-    # Each core gets full [32, 32] transformation matrix (reused for all heads)
-    trans_mat_replicated = torch_trans_mat.repeat(
-        1, 1, qrope_num_cores + kv_cache_branch_rope_crs.num_cores(), 1
-    )  # [1, 1, 32, 32]
-    trans_mat_crs = kv_cache_branch_rope_crs.merge(ttnn.CoreRangeSet({qrope_grid}))
-    trans_tile = ttnn.Tile((ttnn.TILE_SIZE, ttnn.TILE_SIZE))
-    trans_shard_shape = (ttnn.TILE_SIZE, ttnn.TILE_SIZE)  # [32, 32] per core
-    trans_shard_spec = ttnn.ShardSpec(
-        trans_mat_crs,
-        trans_shard_shape,
-        ttnn.ShardOrientation.ROW_MAJOR,
-    )
-    trans_mem_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, trans_shard_spec)
-
-    ttnn_trans_mat = ttnn.from_torch(
-        trans_mat_replicated,
-        dtype=ttnn.bfloat16,
-        layout=ttnn.TILE_LAYOUT,
-        device=submesh,
-        memory_config=trans_mem_config,
-        tile=trans_tile,
-        mesh_mapper=ttnn.ReplicateTensorToMesh(submesh),
-    )
+    # RoPE tensors (commonized with prepare_rope)
+    ttnn_qrope_cos, ttnn_qrope_sin = create_rope_cos_sin_ttnn(submesh, max_seq_len, tile=tile)
+    ttnn_trans_mat = create_rope_trans_mat_tensor(submesh)
 
     # KV Cache Branch
     torch_dkv_matmul_weights = torch.randn(dkv_matmul_weights_shape, dtype=torch.bfloat16)
@@ -611,31 +552,8 @@ def test_pre_sdpa(
         mesh_mapper=ttnn.ReplicateTensorToMesh(submesh),
     )
 
-    # KRoPE cos/sin: DRAM INTERLEAVED (each krope core reads its width slice)
-    krope_num_cores = kv_cache_branch_rope_crs.num_cores()
-    krope_cos_full = torch_cos.unsqueeze(0).unsqueeze(0)  # [1, 1, max_seq_len, 64]
-    krope_sin_full = torch_sin.unsqueeze(0).unsqueeze(0)  # [1, 1, max_seq_len, 64]
-
-    krope_dram_mem_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.DRAM)
-
-    ttnn_krope_cos = ttnn.from_torch(
-        krope_cos_full,
-        dtype=ttnn.bfloat16,
-        layout=ttnn.TILE_LAYOUT,
-        device=submesh,
-        memory_config=krope_dram_mem_config,
-        tile=tile,
-        mesh_mapper=ttnn.ReplicateTensorToMesh(submesh),
-    )
-    ttnn_krope_sin = ttnn.from_torch(
-        krope_sin_full,
-        dtype=ttnn.bfloat16,
-        layout=ttnn.TILE_LAYOUT,
-        device=submesh,
-        memory_config=krope_dram_mem_config,
-        tile=tile,
-        mesh_mapper=ttnn.ReplicateTensorToMesh(submesh),
-    )
+    # KRoPE uses same cos/sin as QRoPE (same layout, replicated)
+    ttnn_krope_cos, ttnn_krope_sin = ttnn_qrope_cos, ttnn_qrope_sin
 
     position_replicated = torch.full((device_grid_size.x * device_grid_size.y, 1), position_id, dtype=torch.int32)
     pos_core_grid = ttnn.CoreRangeSet(
@@ -754,6 +672,9 @@ def test_pre_sdpa(
 
     # Golden uses unshuffled weights (sequential output: all QNOPE, then all QROPE).
     # Full tensor with num_tp * 64 heads; output is split per-TP for comparison.
+    # Golden expects cos/sin [max_seq_len, head_dim]
+    torch_cos_2d = torch_cos.squeeze(0).squeeze(0)
+    torch_sin_2d = torch_sin.squeeze(0).squeeze(0)
     _, _, torch_sdpa_expected_full, torch_kv_cache_expected = PreSDPA.golden(
         torch_input,
         torch_gamma,
@@ -761,8 +682,8 @@ def test_pre_sdpa(
         torch_rmsnorm2_gamma,
         torch_matmul2_weights_full_unshuffled,
         torch_matmul3_weights,
-        torch_sin,
-        torch_cos,
+        torch_sin_2d,
+        torch_cos_2d,
         position_ids,
         torch_dkv_matmul_weights,
         torch_dkv_rmsnorm_gamma,

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_prepare_rope.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_prepare_rope.py
@@ -1,0 +1,122 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Tests for prepare_rope: RoPE transformation matrix and cos/sin creation.
+
+Validates that prepared tensors match the layout and structure expected by
+test_rope.py and test_pre_sdpa.py (pre-SDPA op).
+"""
+
+import pytest
+import torch
+
+import ttnn
+from models.demos.deepseek_v3_b1.prepare_rope import (
+    ROPE_HEAD_DIM,
+    create_rope_trans_mat_tensor,
+    get_cos_sin_torch,
+    get_rope_trans_mat_core_range_set,
+    get_rot_transformation_mat,
+)
+
+
+def test_rotation_matrix_structure():
+    """
+    Test that the rotation transformation matrix has the correct structure.
+
+    The transformation matrix swaps adjacent pairs with sign changes:
+    For input [a, b, c, d, ...], rotation gives [-b, a, -d, c, ...]
+    No device required.
+    """
+    trans_mat = get_rot_transformation_mat()
+
+    assert trans_mat.shape == (1, 1, 32, 32), f"Expected shape (1, 1, 32, 32), got {trans_mat.shape}"
+
+    mat = trans_mat[0, 0]
+    for i in range(0, 32, 2):
+        assert mat[i, i + 1] == 1, f"Expected mat[{i}, {i+1}] = 1"
+        assert mat[i + 1, i] == -1, f"Expected mat[{i+1}, {i}] = -1"
+
+
+def test_rope_trans_mat_core_range_set():
+    """Test that the core range set for trans_mat has the expected size (qrope + kv_rope cores)."""
+    # Grid large enough for pre-SDPA layout (12 cols, 10 rows for qrope 8-11,0-7 and kv_rope 8,8-9)
+    device_grid_size = ttnn.CoreCoord(12, 10)
+    crs = get_rope_trans_mat_core_range_set(device_grid_size)
+    num_cores = crs.num_cores()
+    # qrope_grid: 4*8 = 32, kv_cache_branch_rope_crs: 2 cores
+    assert num_cores == 34, f"Expected 34 cores for trans_mat, got {num_cores}"
+
+
+@pytest.mark.parametrize(
+    "device_params",
+    [{"fabric_config": ttnn.FabricConfig.FABRIC_2D}],
+    indirect=True,
+)
+def test_create_rope_trans_mat_tensor_pre_sdpa_layout(bh_2d_mesh_device):
+    """Test that create_rope_trans_mat_tensor returns a tensor with pre-SDPA layout (HEIGHT_SHARDED L1, 32x32 per core)."""
+    device_grid_size = bh_2d_mesh_device.compute_with_storage_grid_size()
+    if device_grid_size.x < 12:
+        pytest.skip(
+            f"Device grid {device_grid_size.x}x{device_grid_size.y} too small; "
+            "pre-SDPA trans_mat requires at least 12 columns"
+        )
+
+    submesh = bh_2d_mesh_device.create_submesh(ttnn.MeshShape((1, 1)))
+    trans_mat = create_rope_trans_mat_tensor(submesh)
+
+    assert trans_mat is not None
+    # Memory config: HEIGHT_SHARDED, L1
+    mem_config = trans_mat.memory_config()
+    assert mem_config.memory_layout == ttnn.TensorMemoryLayout.HEIGHT_SHARDED
+    assert mem_config.buffer_type == ttnn.BufferType.L1
+
+    # Shard shape should be (32, 32) per core (API may return list or tuple)
+    shard_spec = mem_config.shard_spec
+    assert tuple(shard_spec.shape) == (32, 32), f"Expected shard shape (32, 32), got {shard_spec.shape}"
+
+    # Core set size should match get_rope_trans_mat_core_range_set
+    crs = get_rope_trans_mat_core_range_set(device_grid_size)
+    assert shard_spec.grid.num_cores() == crs.num_cores()
+
+
+def test_get_cos_sin_torch_shape():
+    """Test that get_cos_sin_torch returns tensors with shape [1, 1, max_seq_len, 64]."""
+    max_seq_len = 8192
+    cos, sin = get_cos_sin_torch(max_seq_len)
+
+    assert cos.shape == (
+        1,
+        1,
+        max_seq_len,
+        ROPE_HEAD_DIM,
+    ), f"Expected cos shape (1, 1, {max_seq_len}, 64), got {cos.shape}"
+    assert sin.shape == (
+        1,
+        1,
+        max_seq_len,
+        ROPE_HEAD_DIM,
+    ), f"Expected sin shape (1, 1, {max_seq_len}, 64), got {sin.shape}"
+
+
+def test_get_cos_sin_torch_formula():
+    """Test that cos/sin values match the Meta-style formula (base=10000, inv_freq, outer)."""
+    max_seq_len = 128
+    base = 10000.0
+    head_dim = ROPE_HEAD_DIM
+
+    cos, sin = get_cos_sin_torch(max_seq_len, head_dim=head_dim, base=base)
+
+    # Recompute with same formula as in get_cos_sin_torch
+    inv_freq = 1.0 / (base ** (torch.arange(0, head_dim, 2, dtype=torch.float32) / head_dim))
+    t = torch.arange(max_seq_len, dtype=torch.float32)
+    freqs = torch.outer(t, inv_freq)
+    expected_cos = torch.stack((freqs.cos(), freqs.cos()), dim=-1).flatten(-2)
+    expected_sin = torch.stack((freqs.sin(), freqs.sin()), dim=-1).flatten(-2)
+
+    cos_squeezed = cos.squeeze(0).squeeze(0)
+    sin_squeezed = sin.squeeze(0).squeeze(0)
+    torch.testing.assert_close(cos_squeezed.float(), expected_cos)
+    torch.testing.assert_close(sin_squeezed.float(), expected_sin)

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_rope.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_rope.py
@@ -15,8 +15,8 @@ from loguru import logger
 import ttnn
 from models.common.utility_functions import comp_pcc
 from models.demos.deepseek_v3.reference.modeling_deepseek import DeepseekV3YarnRotaryEmbedding
-from models.demos.deepseek_v3.tt.rope import get_rot_transformation_mat
 from models.demos.deepseek_v3_b1.micro_ops.rope.op import RopeSingleCore
+from models.demos.deepseek_v3_b1.prepare_rope import get_cos_sin_torch, get_rot_transformation_mat
 
 
 @pytest.mark.parametrize(
@@ -50,15 +50,10 @@ def test_rope_decode(device, batch, num_heads, head_dim, position_id, grid_size,
     # Create position IDs [batch] - use fixed position for reproducibility
     position_ids = torch.tensor([position_id])  # positions 0, 1, 2, ...
 
-    # Create cos/sin matrices in Meta-style format
-    base = 10000.0
-    inv_freq = 1.0 / (base ** (torch.arange(0, head_dim, 2, dtype=torch.float32) / head_dim))
-    t = torch.arange(max_seq_len, dtype=torch.float32)
-    freqs = torch.outer(t, inv_freq)
-
-    # Meta-style: stack [cos(t), cos(t)] interleaved
-    cos = torch.stack((freqs.cos(), freqs.cos()), dim=-1).flatten(-2)  # [max_seq_len, head_dim]
-    sin = torch.stack((freqs.sin(), freqs.sin()), dim=-1).flatten(-2)  # [max_seq_len, head_dim]
+    # Cos/sin in Meta-style format [max_seq_len, head_dim] (from prepare_rope)
+    cos_4d, sin_4d = get_cos_sin_torch(max_seq_len, head_dim=head_dim)
+    cos = cos_4d.squeeze(0).squeeze(0)
+    sin = sin_4d.squeeze(0).squeeze(0)
 
     # Reference output (original shape for comparison)
     position_ids_expanded = position_ids.unsqueeze(1)  # [batch, 1]


### PR DESCRIPTION
### Summary

Introduce a shared RoPE preparation module (prepare_rope.py) and use it in pre-SDPA and RopeSingleCore tests so RoPE transformation matrix and cos/sin creation live in one place.

### Checklist

- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/22400727499/job/64850422832)