### PR TITLE
Remove reflection.hpp from tt_metal public API headers

### DIFF
--- a/tt_metal/CMakeLists.txt
+++ b/tt_metal/CMakeLists.txt
@@ -262,7 +262,6 @@ target_link_libraries(
         TracyClient
         nlohmann_json::nlohmann_json
         TT::Metalium::HostDevCommon
-        Reflect::Reflect
         TT::STL
         tt-logger::tt-logger
         ${EXECINFO_LIB}
@@ -278,6 +277,7 @@ target_link_libraries(
         FlatBuffers::FlatBuffers
         TT::Metalium::Logging
         TT::ScaleoutTools
+        Reflect::Reflect
 )
 
 target_precompile_headers(tt_metal REUSE_FROM TT::CommonPCH)

--- a/tt_metal/api/tt-metalium/buffer.hpp
+++ b/tt_metal/api/tt-metalium/buffer.hpp
@@ -5,7 +5,6 @@
 #pragma once
 
 #include <nlohmann/json_fwd.hpp>
-#include <tt_stl/concepts.hpp>
 #include <array>
 #include <atomic>
 #include <condition_variable>

--- a/tt_metal/api/tt-metalium/core_coord.hpp
+++ b/tt_metal/api/tt-metalium/core_coord.hpp
@@ -7,7 +7,6 @@
 #include <fmt/base.h>
 #include <nlohmann/json.hpp>
 #include <stdint.h>
-#include <tt_stl/reflection.hpp>
 #include <tt_stl/span.hpp>
 #include <algorithm>
 #include <cstddef>
@@ -19,12 +18,12 @@
 
 #include <umd/device/types/xy_pair.hpp>
 
-namespace tt::stl::json {
+namespace ttsl::json {
 template <typename T>
 struct from_json_t;
 template <typename T>
 struct to_json_t;
-}  // namespace tt::stl::json
+}  // namespace ttsl::json
 
 namespace tt::tt_metal {
 

--- a/tt_metal/api/tt-metalium/dispatch_core_common.hpp
+++ b/tt_metal/api/tt-metalium/dispatch_core_common.hpp
@@ -7,7 +7,6 @@
 #include <tt_stl/assert.hpp>
 #include <tt-metalium/core_coord.hpp>
 #include <tt-metalium/data_types.hpp>
-#include <tt_stl/reflection.hpp>
 
 namespace tt::tt_metal {
 
@@ -49,9 +48,7 @@ namespace std {
 
 template <>
 struct hash<tt::tt_metal::DispatchCoreConfig> {
-    std::size_t operator()(const tt::tt_metal::DispatchCoreConfig& dispatch_core_config) const {
-        return tt::stl::hash::hash_objects_with_default_seed(dispatch_core_config.attribute_values());
-    }
+    std::size_t operator()(const tt::tt_metal::DispatchCoreConfig& dispatch_core_config) const;
 };
 
 }  // namespace std

--- a/tt_metal/api/tt-metalium/experimental/fabric/fabric_types.hpp
+++ b/tt_metal/api/tt-metalium/experimental/fabric/fabric_types.hpp
@@ -9,7 +9,6 @@
 #include <ostream>
 #include <optional>
 #include <tt_stl/strong_type.hpp>
-#include <tt_stl/reflection.hpp>
 
 #include <fmt/format.h>
 

--- a/tt_metal/api/tt-metalium/experimental/fabric/mesh_graph.hpp
+++ b/tt_metal/api/tt-metalium/experimental/fabric/mesh_graph.hpp
@@ -7,7 +7,6 @@
 #include <tt_stl/assert.hpp>
 #include <tt-metalium/mesh_coord.hpp>
 #include <tt-metalium/experimental/fabric/fabric_types.hpp>
-#include <tt_stl/reflection.hpp>
 #include <tt_stl/indestructible.hpp>
 #include <umd/device/types/arch.hpp>                      // tt::ARCH
 #include <umd/device/types/cluster_descriptor_types.hpp>  // ChipId
@@ -64,7 +63,9 @@ struct RouterEdge {
 struct hash_pair {
     template <class T1, class T2>
     size_t operator()(const std::pair<T1, T2>& p) const {
-        return tt::stl::hash::hash_objects(std::hash<T1>{}(p.first), std::hash<T2>{}(p.second));
+        size_t seed = std::hash<T1>{}(p.first);
+        seed ^= std::hash<T2>{}(p.second) + 0x9e3779b9 + (seed << 6) + (seed >> 2);
+        return seed;
     }
 };
 

--- a/tt_metal/api/tt-metalium/experimental/tensor/spec/memory_config/memory_config.hpp
+++ b/tt_metal/api/tt-metalium/experimental/tensor/spec/memory_config/memory_config.hpp
@@ -12,10 +12,16 @@
 #include <tt-metalium/mesh_buffer.hpp>
 #include <tt-metalium/device.hpp>
 #include <tt-metalium/tt_backend_api_types.hpp>
-#include <tt_stl/reflection.hpp>
 #include <tt_stl/span.hpp>
 
 #include <tt-metalium/experimental/tensor/tensor_types.hpp>
+
+namespace ttsl::json {
+template <typename T>
+struct to_json_t;
+template <typename T>
+struct from_json_t;
+}  // namespace ttsl::json
 
 namespace tt::tt_metal {
 

--- a/tt_metal/api/tt-metalium/mesh_coord.hpp
+++ b/tt_metal/api/tt-metalium/mesh_coord.hpp
@@ -9,7 +9,6 @@
 #include <type_traits>
 #include <vector>
 
-#include <tt_stl/reflection.hpp>
 #include <tt_stl/assert.hpp>
 #include <tt-metalium/shape_base.hpp>
 #include <tt-metalium/maybe_remote.hpp>
@@ -573,23 +572,17 @@ struct tuple_element<1, tt::tt_metal::distributed::detail::MeshCoordinateValuePr
 
 template <>
 struct hash<tt::tt_metal::distributed::MeshCoordinate> {
-    size_t operator()(const tt::tt_metal::distributed::MeshCoordinate& coord) const noexcept {
-        return tt::stl::hash::hash_objects_with_default_seed(coord.attribute_values());
-    }
+    size_t operator()(const tt::tt_metal::distributed::MeshCoordinate& coord) const noexcept;
 };
 
 template <>
 struct hash<tt::tt_metal::distributed::MeshCoordinateRange> {
-    size_t operator()(const tt::tt_metal::distributed::MeshCoordinateRange& range) const noexcept {
-        return tt::stl::hash::hash_objects_with_default_seed(range.attribute_values());
-    }
+    size_t operator()(const tt::tt_metal::distributed::MeshCoordinateRange& range) const noexcept;
 };
 
 template <>
 struct hash<tt::tt_metal::distributed::MeshCoordinateRangeSet> {
-    size_t operator()(const tt::tt_metal::distributed::MeshCoordinateRangeSet& range_set) const noexcept {
-        return tt::stl::hash::hash_objects_with_default_seed(range_set.attribute_values());
-    }
+    size_t operator()(const tt::tt_metal::distributed::MeshCoordinateRangeSet& range_set) const noexcept;
 };
 
 }  // namespace std

--- a/tt_metal/common/mesh_coord.cpp
+++ b/tt_metal/common/mesh_coord.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <tt_stl/assert.hpp>
+#include <tt_stl/reflection.hpp>
 
 #include <boost/move/utility_core.hpp>
 #include <mesh_coord.hpp>
@@ -660,3 +661,18 @@ std::ostream& operator<<(std::ostream& os, const MeshCoordinateRangeSet& range_s
 }
 
 }  // namespace tt::tt_metal::distributed
+
+size_t std::hash<tt::tt_metal::distributed::MeshCoordinate>::operator()(
+    const tt::tt_metal::distributed::MeshCoordinate& coord) const noexcept {
+    return tt::stl::hash::hash_objects_with_default_seed(coord.attribute_values());
+}
+
+size_t std::hash<tt::tt_metal::distributed::MeshCoordinateRange>::operator()(
+    const tt::tt_metal::distributed::MeshCoordinateRange& range) const noexcept {
+    return tt::stl::hash::hash_objects_with_default_seed(range.attribute_values());
+}
+
+size_t std::hash<tt::tt_metal::distributed::MeshCoordinateRangeSet>::operator()(
+    const tt::tt_metal::distributed::MeshCoordinateRangeSet& range_set) const noexcept {
+    return tt::stl::hash::hash_objects_with_default_seed(range_set.attribute_values());
+}

--- a/tt_metal/impl/dispatch/dispatch_core_common.cpp
+++ b/tt_metal/impl/dispatch/dispatch_core_common.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "impl/dispatch/dispatch_core_common.hpp"
+#include <tt_stl/reflection.hpp>
 #include "impl/context/metal_context.hpp"
 #include <umd/device/types/arch.hpp>
 #include <umd/device/types/core_coordinates.hpp>
@@ -33,3 +34,8 @@ DispatchCoreConfig get_dispatch_core_config() {
 }
 
 }  // namespace tt::tt_metal
+
+std::size_t std::hash<tt::tt_metal::DispatchCoreConfig>::operator()(
+    const tt::tt_metal::DispatchCoreConfig& dispatch_core_config) const {
+    return tt::stl::hash::hash_objects_with_default_seed(dispatch_core_config.attribute_values());
+}

--- a/ttnn/cpp/ttnn/operations/transformer/transformer_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/transformer_nanobind.cpp
@@ -6,6 +6,7 @@
 
 #include <cstddef>
 #include <optional>
+#include <tt_stl/reflection.hpp>
 
 #include <nanobind/nanobind.h>
 #include <nanobind/stl/optional.h>


### PR DESCRIPTION
### Ticket
Related to #37344 (alternative, minimal, tt_metal focused approach)

### Problem description
`<reflect>` (via `tt_stl/reflection.hpp`) is exposed as a public dependency of tt_metal through its API headers (When it never needed to be). This leaks implementation details into the public interface and forces all consumers of `libtt_metal.so` to depend on `<reflect>`, even when they do not use reflection.

### What's changed
Removed all direct `#include <tt_stl/reflection.hpp>` and `#include <tt_stl/concepts.hpp>` from tt_metal API headers, without modifying tt_stl itself.

**API header changes:**
- `core_coord.hpp` — Removed `reflection.hpp` include, added `ttsl::json` forward declarations
- `buffer.hpp` — Removed `concepts.hpp` include
- `dispatch_core_common.hpp` — Removed `reflection.hpp` include, made `std::hash<DispatchCoreConfig>` declaration-only
- `mesh_coord.hpp` — Removed `reflection.hpp` include, made 3 `std::hash` specializations declaration-only
- `fabric_types.hpp` — Removed unused `reflection.hpp` include
- `mesh_graph.hpp` — Removed `reflection.hpp` include, replaced `hash_pair` with standalone hash combine
- `memory_config.hpp` — Removed `reflection.hpp` include, added `ttsl::json` forward declarations

**Implementation moved to .cpp files:**
- `dispatch_core_common.cpp` — `std::hash<DispatchCoreConfig>` implementation
- `mesh_coord.cpp` — `std::hash<MeshCoordinate>`, `std::hash<MeshCoordinateRange>`, `std::hash<MeshCoordinateRangeSet>` implementations

**CMake:**
- `tt_metal/CMakeLists.txt` — Moved `Reflect::Reflect` from PUBLIC to PRIVATE

**Downstream fix:**
- `ttnn/transformer_nanobind.cpp` — Added explicit `#include <tt_stl/reflection.hpp>` (was relying on transitive include)

Note: `tt_stl` is unchanged. `Reflect::Reflect` remains transitively available through `TT::STL` for consumers that need it.

### Checklist
- [ ] [All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/runs/22375845256)
- [x] New/Existing tests provide coverage for changes