### PR TITLE
Add causal mask support to fused SDPA in ttml

### DIFF
--- a/tt-train/sources/ttml/ops/scaled_dot_product_attention.cpp
+++ b/tt-train/sources/ttml/ops/scaled_dot_product_attention.cpp
@@ -246,13 +246,15 @@ autograd::TensorPtr scaled_dot_product_attention_fused(
     const autograd::TensorPtr& key,
     const autograd::TensorPtr& value,
     const std::optional<autograd::TensorPtr>& mask,
-    float dropout_probability) {
+    float dropout_probability,
+    bool causal) {
     validate_qkv_shapes(query, key, value);
 
     // Get mask tensor if provided
     // Kernels support (1, 1, S, S) mask shape - same mask for all batches/heads
     std::optional<ttnn::Tensor> mask_tensor = std::nullopt;
-    ttml::metal::AttentionMaskType mask_type = ttml::metal::AttentionMaskType::None;
+    ttml::metal::AttentionMaskType mask_type =
+        causal ? ttml::metal::AttentionMaskType::Causal : ttml::metal::AttentionMaskType::None;
     if (mask.has_value()) {
         mask_tensor = mask.value()->get_value();
         mask_type = ttml::metal::AttentionMaskType::Arbitrary;
@@ -303,6 +305,7 @@ autograd::TensorPtr scaled_dot_product_attention_fused(
 
     return out;
 }
+
 
 autograd::TensorPtr scaled_sigmoid_dot_product_attention(
     const autograd::TensorPtr& query,

--- a/tt-train/sources/ttml/ops/scaled_dot_product_attention.hpp
+++ b/tt-train/sources/ttml/ops/scaled_dot_product_attention.hpp
@@ -16,12 +16,14 @@ autograd::TensorPtr scaled_dot_product_attention(
 
 // Fused implementation using custom sdpa_fw and sdpa_bw kernels
 // More efficient than composite implementation for training
+// When causal=true and no mask provided, generates causal mask on-device
 autograd::TensorPtr scaled_dot_product_attention_fused(
     const autograd::TensorPtr& query,
     const autograd::TensorPtr& key,
     const autograd::TensorPtr& value,
     const std::optional<autograd::TensorPtr>& mask = std::nullopt,
-    float dropout_probability = 0.0F);
+    float dropout_probability = 0.0F,
+    bool causal = false);
 
 autograd::TensorPtr scaled_sigmoid_dot_product_attention(
     const autograd::TensorPtr& query,


### PR DESCRIPTION
## Summary
- Add `bool causal` parameter to `scaled_dot_product_attention_fused` in ttml
- When `causal=true`, uses `AttentionMaskType::Causal` for on-device causal mask generation instead of requiring an external mask tensor
- Defaults to `false` for backward compatibility

## Motivation
Decoder-only transformer training always uses causal attention. The fused SDPA kernel already supports `AttentionMaskType::Causal` internally, but the ttml API had no way to request it — requiring users to allocate and transfer an explicit causal mask tensor. This parameter exposes the existing kernel capability through the public API.

## Changes
- `tt-train/sources/ttml/ops/scaled_dot_product_attention.hpp`: Add `bool causal = false` parameter
- `tt-train/sources/ttml/ops/scaled_dot_product_attention.cpp`: Set `AttentionMaskType::Causal` when `causal=true` and no explicit mask provided

## Test plan
- [ ] Verify fused SDPA with `causal=true` produces same results as explicit causal mask
- [ ] Verify `causal=false` (default) behavior unchanged
- [ ] Run Motif 0.8B MoE training with fused causal SDPA on Wormhole