### PR TITLE
Enable on-device sampling for GPT-OSS on Galaxy mesh

### DIFF
--- a/models/demos/gpt_oss/demo/text_demo.py
+++ b/models/demos/gpt_oss/demo/text_demo.py
@@ -26,6 +26,7 @@ import torch
 from loguru import logger
 
 import ttnn
+from models.common.sampling import SamplingParams
 from models.common.utility_functions import run_for_wormhole_b0
 from models.demos.gpt_oss.tests.test_factory import TestFactory, parametrize_mesh_with_fabric
 
@@ -39,7 +40,6 @@ from models.tt_transformers.tt.common import (
     copy_host_to_device,
     get_padded_prefill_len,
     preprocess_inputs_prefill,
-    sample_host,
 )
 
 # Import specific utilities from tt_transformers
@@ -433,6 +433,15 @@ def test_gpt_oss_demo(
     generator = Generator(model, model_args, mesh_device, processor=processor, tokenizer=tokenizer)
 
     profiler.end(f"generator_setup", iteration=batch_idx)
+
+    # Create on-device sampling params
+    SAMPLING_BATCH_SIZE = 32
+    greedy = sampling_params["temperature"] == 0
+    device_sampling_params = SamplingParams(
+        temperature=[sampling_params["temperature"]] * SAMPLING_BATCH_SIZE,
+        top_k=[1] * SAMPLING_BATCH_SIZE if greedy else [40] * SAMPLING_BATCH_SIZE,
+        top_p=[1.0] * SAMPLING_BATCH_SIZE if greedy else [sampling_params["top_p"]] * SAMPLING_BATCH_SIZE,
+    )
 
     # Prepare input prompts
     logger.info(f"Reading inputs...")
@@ -953,21 +962,14 @@ def test_gpt_oss_demo(
             else:
                 profiler.start(f"inference_decode_time_{iteration}", iteration=batch_idx)
 
-            # Decode forward (matching tt_transformers call)
-            logits, _ = generator.decode_forward(
+            # Decode forward with on-device sampling
+            out_tok, _ = generator.decode_forward(
                 out_tok,
                 current_pos,
                 enable_trace=enable_decode_trace,
                 page_table=page_table,
                 kv_cache=tt_kv_cache,
-            )
-
-            # Sample next token (reusing tt_transformers sampling)
-            _, out_tok = sample_host(
-                logits,
-                temperature=sampling_params["temperature"],
-                top_p=sampling_params["top_p"],
-                on_host=True,
+                sampling_params=device_sampling_params,
             )
 
             if iteration == 0:

--- a/models/demos/gpt_oss/tt/model.py
+++ b/models/demos/gpt_oss/tt/model.py
@@ -3,8 +3,10 @@
 
 
 import torch
+from loguru import logger
 
 import ttnn
+from models.common.sampling.generator import SamplingGenerator
 from models.common.utility_functions import nearest_32
 from models.demos.gpt_oss.config import MeshConfig, Mode, ModeConfig
 from models.demos.gpt_oss.utils.general_utils import get_cache_file_name
@@ -105,7 +107,7 @@ class Model:
         self.vocab_size = hf_config.vocab_size
         self.hf_config = hf_config
         # hf_config.num_hidden_layers = 1
-        self.core_grid = ttnn.CoreCoord(8, 8)
+        self.core_grid = mesh_device.compute_with_storage_grid_size()
         self.head_dim = hf_config.head_dim
         self.max_local_batch_size = max_local_batch_size
         self.users_row_sharded = users_row_sharded
@@ -181,6 +183,62 @@ class Model:
             mesh_mapper=self.mesh_config.column_parallel(mesh_device),
         )
 
+        # Initialize on-device sampling (supported when per-device vocab fits in 64K)
+        sampling_splits = mesh_device.shape[1]
+        self._supports_on_device_sampling = self.vocab_size // sampling_splits <= 64 * 1024
+        self._prefill_sampling_active = False
+        # sampling_dp: number of independent sampling groups (one per mesh row for row-sharded users)
+        self.sampling_dp = mesh_device.shape[0] if users_row_sharded else 1
+        if self._supports_on_device_sampling:
+            # tt_ccl=None makes TTSampling fall back to ttnn.all_gather() which works on [4,8] meshes
+            self.sampling = SamplingGenerator(
+                args=self.args if hasattr(self, "args") else self._make_sampling_args(hf_config, mesh_device),
+                mesh_device=mesh_device,
+                tt_ccl=None,
+                enable_internal_trace=False,
+            )
+            # Hook reset_sampling_params to set prefill flag — Generator calls this
+            # before prefill forward; tells _forward_layers_and_head to skip TP all-gather
+            _orig_reset = self.sampling.reset_sampling_params
+
+            def _reset_with_flag(params, _orig=_orig_reset):
+                _orig(params)
+                self._prefill_sampling_active = True
+
+            self.sampling.reset_sampling_params = _reset_with_flag
+            logger.info(f"On-device sampling initialized (vocab_size={self.vocab_size}, splits={sampling_splits})")
+        else:
+            self.sampling = None
+
+    def _make_sampling_args(self, hf_config, mesh_device):
+        """Create a minimal args object for SamplingGenerator/TTSampling."""
+
+        class _SamplingArgs:
+            pass
+
+        args = _SamplingArgs()
+        args.vocab_size = hf_config.vocab_size
+        num_tp = mesh_device.shape[1]
+        # padded_vocab_size: per-device vocab must be tile-aligned (multiple of 32)
+        # for TTPenalties scatter operations
+        per_device_vocab = ((args.vocab_size + num_tp - 1) // num_tp + 31) // 32 * 32
+        args.padded_vocab_size = per_device_vocab * num_tp
+        self._sampling_vocab_pad = per_device_vocab - (args.vocab_size + num_tp - 1) // num_tp
+        args.cluster_shape = tuple(mesh_device.shape)
+        args.sampling_all_gather_axis = 1
+        args.num_devices = mesh_device.get_num_devices()
+        args.is_galaxy = mesh_device.shape[0] > 1
+        args.model_config = {}  # No SAMPLING_AG_CONFIG → regular sampling path always used
+        # sampling_dp: number of independent sampling groups (one per mesh row)
+        # Only use row-sharded sampling when users_row_sharded is active
+        args.sampling_dp = self.sampling_dp
+        return args
+
+    def _increment_decode_positions_device(self, current_pos, rot_mat_idxs):
+        """On-device position increment for traced decode loops with sampling."""
+        ttnn.plus_one(current_pos, skip_negative_entries=True)
+        ttnn.plus_one(rot_mat_idxs)
+
     @classmethod
     def create_transformer_compatible(
         cls,
@@ -243,6 +301,7 @@ class Model:
         get_last_token=-1,
         is_decode=True,
         user_id=0,
+        sampling_on_device=False,
         batch_size=1,
     ):
         """
@@ -304,14 +363,19 @@ class Model:
         hidden_states = self.norm(hidden_states)
         logits = ttnn.matmul(hidden_states, self.lm_head_weight, dtype=ttnn.bfloat8_b)
         hidden_states.deallocate(True)
-        # TP all-gather if using tensor parallelism
+        # Skip TP all-gather when sampling is active — TTSampling handles its own all-gather
+        skip_gather = sampling_on_device or self._prefill_sampling_active
+        self._prefill_sampling_active = False
         config = self.mesh_config.get_config(mode)
-        if config.tp > 1:
+        if config.tp > 1 and not skip_gather:
             logits_gathered = self.mesh_config.allgather(
                 logits, self.ccl_manager, axis=self.mesh_config.tp_axis, dim=-1
             )
             logits.deallocate(True)
             logits = logits_gathered
+        elif skip_gather and getattr(self, "_sampling_vocab_pad", 0) > 0:
+            # Pad per-device logits to tile-aligned vocab size for TTPenalties
+            logits = ttnn.pad(logits, padding=[(0, 0), (0, 0), (0, 0), (0, self._sampling_vocab_pad)], value=0.0)
 
         return logits
 
@@ -329,8 +393,15 @@ class Model:
         Decode forward pass - processes single tokens.
         Matches tt-transformers interface where rot_mat_idxs are used for on-device RoPE lookup.
         """
-        # Embed tokens
-        input_embeds = ttnn.embedding(tokens, self.embedding_weight, layout=ttnn.TILE_LAYOUT, dtype=ttnn.bfloat8_b)
+        # For non-row-sharded b<32, token buffer is padded to 32 — only embed real tokens
+        actual_batch = current_pos.shape[-1]
+        if not self.users_row_sharded and tokens.shape[-1] > actual_batch:
+            tokens_for_embed = tokens[:, :, :, :actual_batch]
+        else:
+            tokens_for_embed = tokens
+        input_embeds = ttnn.embedding(
+            tokens_for_embed, self.embedding_weight, layout=ttnn.TILE_LAYOUT, dtype=ttnn.bfloat8_b
+        )
         input_embeds = ttnn.unsqueeze(input_embeds, 0)
         # Get RoPE embeddings via on-device embedding lookup (matches tt-transformers)
         rope_mats = self.rope_setup.get_rot_mats(self.get_tt_pos_idx(rot_mat_idxs))
@@ -343,9 +414,20 @@ class Model:
             page_table=page_table,
             kv_cache=kv_cache,
             is_decode=True,
+            sampling_on_device=sampling_on_device,
         )
-        # Return logits and None for log-probs for compatibility with generator interface
-        # TODO: Add log-probs return value once sampling_on_device is supported
+
+        if sampling_on_device and self.sampling is not None:
+            # Pad logits batch to 32 (TTSampling requirement) before split-trace or sampling
+            batch_dim = out.shape[-2]
+            if batch_dim < 32:
+                out = ttnn.pad(out, padding=[(0, 0), (0, 0), (0, 32 - batch_dim), (0, 0)], value=0.0)
+            self._increment_decode_positions_device(current_pos, rot_mat_idxs)
+            if capture_sampling_trace:
+                return out
+            tt_toks, tt_log_probs = self.sampling.sample(out, tt_out_tok=tokens, enable_trace=False)
+            return tt_toks, tt_log_probs
+
         return out, None
 
     def ttnn_prefill_forward(
@@ -467,7 +549,9 @@ class Model:
             current_pos = current_pos.unsqueeze(0)
         assert current_pos.shape[0] == B, "Batch size mismatch"
 
-        # Convert tokens to TTNN format
+        # Pad token buffer to 32 for non-row-sharded b<32 (TTSampling requirement)
+        if not self.users_row_sharded and tokens.view(-1).shape[-1] < 32:
+            tokens = torch.nn.functional.pad(tokens.view(-1), (0, 32 - len(tokens.view(-1))), "constant", 0)
         if self.users_row_sharded:
             mesh_mapper = ttnn.ShardTensor2dMesh(self.mesh_device, dims=(0, None), mesh_shape=self.mesh_device.shape)
         else:
@@ -624,11 +708,12 @@ class Model:
             tt_chunk_page_table,
         )
 
-    def process_output_decode(self, tt_out, B, S=1, is_tokens=False):
+    def process_output_decode(self, tt_out, B, S=1, is_tokens=False, is_log_probs=False):
         """Process decode output and convert to torch tensors"""
         concat_out = self.concat_device_output(tt_out)
-        if is_tokens:
-            return concat_out[:B, 0]  # [batch_size]
+        if is_tokens or is_log_probs:
+            # Token IDs or log probs: shape [1, 1, B] or [1, 1, 1, B] -> [B]
+            return concat_out.reshape(-1)[:B]
 
         torch_out = concat_out[:, 0, :, :]  # [1, 1, B, vocab_size]
         # TODO: this view is dangerous, forces bad tensor shapes to work but we get garbage outputs if they're wrong

--- a/models/demos/gpt_oss/tt/model.py
+++ b/models/demos/gpt_oss/tt/model.py
@@ -173,18 +173,30 @@ class Model:
             tensor_cache_path=get_cache_file_name(tensor_cache_path, "norm"),
             mesh_config=self.mesh_config,
         )
+        # Pad lm_head vocab dimension to padded_vocab_size BEFORE column-parallel sharding.
+        # TTSampling._create_indices_tensors uses padded_per_device as the stride for device
+        # offset calculation: global_idx = device_id * padded_per_device + local_idx.
+        # If we shard at unpadded boundaries and pad after, the offsets are wrong for devices 1+.
+        # Pre-sharding padding ensures device shard boundaries match the offset stride.
+        sampling_splits = mesh_device.shape[1]
+        per_device_padded = (((self.vocab_size + sampling_splits - 1) // sampling_splits + 31) // 32) * 32
+        padded_vocab_size = per_device_padded * sampling_splits
+        lm_head_weight = substate(state_dict, "lm_head")["weight"].transpose(0, 1)  # [hidden, vocab]
+        if lm_head_weight.shape[1] < padded_vocab_size:
+            lm_head_weight = torch.nn.functional.pad(
+                lm_head_weight, (0, padded_vocab_size - lm_head_weight.shape[1]), "constant", 0
+            )
         self.lm_head_weight = ttnn.as_tensor(
-            substate(state_dict, "lm_head")["weight"].transpose(0, 1),
+            lm_head_weight,
             device=mesh_device,
             layout=ttnn.TILE_LAYOUT,
             dtype=ttnn.bfloat8_b,
-            cache_file_name=get_cache_file_name(tensor_cache_path, "lm_head_sharded.weight"),
+            cache_file_name=get_cache_file_name(tensor_cache_path, "lm_head_padded.weight"),
             memory_config=ttnn.DRAM_MEMORY_CONFIG,
             mesh_mapper=self.mesh_config.column_parallel(mesh_device),
         )
 
         # Initialize on-device sampling (supported when per-device vocab fits in 64K)
-        sampling_splits = mesh_device.shape[1]
         self._supports_on_device_sampling = self.vocab_size // sampling_splits <= 64 * 1024
         self._prefill_sampling_active = False
         # sampling_dp: number of independent sampling groups (one per mesh row for row-sharded users)
@@ -220,10 +232,11 @@ class Model:
         args.vocab_size = hf_config.vocab_size
         num_tp = mesh_device.shape[1]
         # padded_vocab_size: per-device vocab must be tile-aligned (multiple of 32)
-        # for TTPenalties scatter operations
+        # for TTPenalties scatter operations.
+        # The lm_head weight is padded to this size BEFORE column-parallel sharding,
+        # so device shard boundaries align with TTSampling device offset strides.
         per_device_vocab = ((args.vocab_size + num_tp - 1) // num_tp + 31) // 32 * 32
         args.padded_vocab_size = per_device_vocab * num_tp
-        self._sampling_vocab_pad = per_device_vocab - (args.vocab_size + num_tp - 1) // num_tp
         args.cluster_shape = tuple(mesh_device.shape)
         args.sampling_all_gather_axis = 1
         args.num_devices = mesh_device.get_num_devices()
@@ -373,9 +386,9 @@ class Model:
             )
             logits.deallocate(True)
             logits = logits_gathered
-        elif skip_gather and getattr(self, "_sampling_vocab_pad", 0) > 0:
-            # Pad per-device logits to tile-aligned vocab size for TTPenalties
-            logits = ttnn.pad(logits, padding=[(0, 0), (0, 0), (0, 0), (0, self._sampling_vocab_pad)], value=0.0)
+        # No post-matmul padding needed: the lm_head weight is pre-padded to
+        # padded_vocab_size before column-parallel sharding, so each device's
+        # matmul output is already tile-aligned (per_device_padded width).
 
         return logits
 

--- a/models/demos/gpt_oss/tt/model.py
+++ b/models/demos/gpt_oss/tt/model.py
@@ -178,8 +178,12 @@ class Model:
         # offset calculation: global_idx = device_id * padded_per_device + local_idx.
         # If we shard at unpadded boundaries and pad after, the offsets are wrong for devices 1+.
         # Pre-sharding padding ensures device shard boundaries match the offset stride.
+        # Round per-device width to next power of 2 so ttnn.topk can use its multi-core path
+        # (bitonic sort requires power-of-2 width). Without this, topk falls back to single-core
+        # and takes ~14ms instead of being parallelized across many cores.
         sampling_splits = mesh_device.shape[1]
         per_device_padded = (((self.vocab_size + sampling_splits - 1) // sampling_splits + 31) // 32) * 32
+        per_device_padded = 1 << (per_device_padded - 1).bit_length()  # next power of 2
         padded_vocab_size = per_device_padded * sampling_splits
         lm_head_weight = substate(state_dict, "lm_head")["weight"].transpose(0, 1)  # [hidden, vocab]
         if lm_head_weight.shape[1] < padded_vocab_size:
@@ -191,7 +195,7 @@ class Model:
             device=mesh_device,
             layout=ttnn.TILE_LAYOUT,
             dtype=ttnn.bfloat8_b,
-            cache_file_name=get_cache_file_name(tensor_cache_path, "lm_head_padded.weight"),
+            cache_file_name=get_cache_file_name(tensor_cache_path, "lm_head_padded_pow2.weight"),
             memory_config=ttnn.DRAM_MEMORY_CONFIG,
             mesh_mapper=self.mesh_config.column_parallel(mesh_device),
         )
@@ -231,11 +235,12 @@ class Model:
         args = _SamplingArgs()
         args.vocab_size = hf_config.vocab_size
         num_tp = mesh_device.shape[1]
-        # padded_vocab_size: per-device vocab must be tile-aligned (multiple of 32)
-        # for TTPenalties scatter operations.
+        # padded_vocab_size: per-device vocab rounded to next power of 2 to enable
+        # multi-core topk (bitonic sort requires power-of-2 width).
         # The lm_head weight is padded to this size BEFORE column-parallel sharding,
         # so device shard boundaries align with TTSampling device offset strides.
         per_device_vocab = ((args.vocab_size + num_tp - 1) // num_tp + 31) // 32 * 32
+        per_device_vocab = 1 << (per_device_vocab - 1).bit_length()  # next power of 2
         args.padded_vocab_size = per_device_vocab * num_tp
         args.cluster_shape = tuple(mesh_device.shape)
         args.sampling_all_gather_axis = 1


### PR DESCRIPTION
## Summary
- Enable on-device sampling for GPT-OSS models on Galaxy [4,8] mesh, replacing host-side sampling with TTSampling
- Fix lm_head vocab offset bug where device shard boundaries didn't match TTSampling offset strides
- Pad per-device vocab to next power of 2 to enable multi-core topk (bitonic sort requires pow2 width), achieving a **34x speedup** on the sampling step (14ms → 0.4ms)

## Changes
**`models/demos/gpt_oss/tt/model.py`**
- Initialize `SamplingGenerator` with proper args for Galaxy [4,8] mesh topology
- Pad lm_head weight to `padded_vocab_size` **before** column-parallel sharding so device shard boundaries align with TTSampling device offset strides
- Round per-device vocab width to next power of 2 (25152 → 32768) to enable multi-core topk
- Skip TP all-gather when on-device sampling is active (TTSampling handles its own gather)
- Add `_increment_decode_positions_device` for traced decode loops
- Handle batch padding to 32 (TTSampling requirement)
- Fix token output processing for sampling output shape

**`models/demos/gpt_oss/demo/text_demo.py`**
- Switch from host-side `sample_host()` to on-device `SamplingParams` passed to `decode_forward()`

## Performance (120B, Galaxy 4x8, greedy decoding)

| Metric | Batch=1 | Batch=128 |
|--------|---------|-----------|
| **t/s/u** | 19.52 | 11.75 |
| **Throughput** | 19.52 t/s | 1504 t/s |
| Decode latency | 51ms | 85ms |

## Test plan
- [x] 120B batch=1 demo PASSED (prefill_128, mesh_4x8)
- [x] 120B batch=128 demo PASSED (mesh_4x8)
- [x] 20B batch=1 demo PASSED (5/5 tests)
- [x] 20B batch=128 demo PASSED (5/5 tests)
- [x] Output quality verified (coherent, factually correct responses)