### PR TITLE
Remove 5-layer model unit test to reduce CI timeout

### DIFF
--- a/models/demos/gpt_oss/tests/unit/test_modules.py
+++ b/models/demos/gpt_oss/tests/unit/test_modules.py
@@ -910,10 +910,9 @@ def run_model_forward_test(
 )
 @pytest.mark.parametrize(
     "num_layers",
-    [1, 5],
+    [1],
     ids=[
         "1_layer",
-        "5_layers",
     ],
 )
 def test_model(mesh_device, device_params, batch_size, seq_len, mode, mesh_shape, num_layers, reset_seeds):


### PR DESCRIPTION
## Summary
- Remove the `num_layers=5` variant from `test_model` in GPT-OSS unit tests
- The 5-layer test takes significant CI time without testing additional functionality beyond the 1-layer variant
- This helps keep the unit test suite within timeout limits

## Test plan
- [ ] Verify remaining `test_model` tests still pass with `num_layers=1`
- [ ] Confirm CI pipeline completes within timeout

🤖 Generated with [Claude Code](https://claude.com/claude-code)