### PR TITLE
Only pass global_user_id for row-sharded models in prefill

### DIFF
--- a/models/tt_transformers/tt/generator.py
+++ b/models/tt_transformers/tt/generator.py
@@ -317,7 +317,8 @@ class Generator(WarmupForwardMixin):
                 seq_len - num_cached_tokens
             )  # Without the cached tokens, then padded
             local_kwargs = kwargs.copy()  # Avoid modifying original kwargs
-            local_kwargs["global_user_id"] = user_id  # Pass global user_id for row-sharded page table targeting
+            if getattr(self.model[model_id], "users_row_sharded", False):
+                local_kwargs["global_user_id"] = user_id  # Row-sharded models need this for page table targeting
             sampling_enabled = (
                 sampling_on_device_requested
                 and getattr(self.model[model_id], "_supports_on_device_sampling", False)


### PR DESCRIPTION
## Summary
- Fix regression from #38439 where `global_user_id` was unconditionally set in prefill kwargs, breaking models that don't accept it (tt_transformers, Gemma, etc.)
- Gate the assignment on `model.users_row_sharded` so only GPT-OSS high-batch (which needs it for page table row targeting) passes it through

## Problem
`local_kwargs["global_user_id"] = user_id` on line 320 of `generator.py` always sets `global_user_id` to a valid integer. The downstream chain (`_easy_trace_prefill` → `_capture_trace_prefill` → `prepare_prefill_inputs_trace`) was correctly written to only forward it when non-None, but since it was never None, every model received it — causing failures for models whose `prepare_inputs_prefill` doesn't accept a `global_user_id` parameter.

## Fix
```python
# Before (always set):
local_kwargs["global_user_id"] = user_id

# After (only for row-sharded models):
if getattr(self.model[model_id], "users_row_sharded", False):
    local_kwargs["global_user_id"] = user_id
```

## Test plan
- [ ] GPT-OSS high-batch prefill still works (row-sharded, needs global_user_id)
- [ ] tt_transformers / Llama / Gemma prefill works (not row-sharded, no global_user_id)