### PR TITLE
Disable GPTOSS with Prefill32k and above on T3K due to OOM

### DIFF
--- a/models/demos/gpt_oss/demo/text_demo.py
+++ b/models/demos/gpt_oss/demo/text_demo.py
@@ -404,6 +404,9 @@ def test_gpt_oss_demo(
     if long_context_mode:
         assert batch_size >= mesh_shape[0], "Long-context mode requires batch_size >= number of mesh rows"
 
+    if mesh_shape[0] == 1 and max_seq_len > 16 * 1024:
+        pytest.skip(f"Prefill >16k demo skipped for single-row mesh since it doesn't fit in memory.")
+
     if os.environ.get("CI", None) and long_context_mode:
         pytest.skip(f"Long-context mode skipped for CI environment.")
     mesh_device = mesh_device.create_submesh(ttnn.MeshShape(mesh_shape))


### PR DESCRIPTION
### Problem description
OOM Error on GPT OSS for seqlen greater than 16k on a 1x8 Mesh.

### What's changed
Disabled failing tests.

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=smanoj/disable_t3k_prefill32k)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:smanoj/disable_t3k_prefill32k)

- [x] New/Existing tests provide coverage for changes

- [x] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml/badge.svg?branch=smanoj/disable_t3k_prefill32k)](https://github.com/tenstorrent/tt-metal/actions/runs/22392724087)
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) 

- [ ] [![(Galaxy) Unit Tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-unit-tests.yaml/badge.svg?branch=smanoj/disable_t3k_prefill32k)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:smanoj/disable_t3k_prefill32k)
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) 
