### PR TITLE
Fix dtype for sampled tokens in llama 70b

### DIFF
--- a/models/demos/llama3_70b_galaxy/tt/generator.py
+++ b/models/demos/llama3_70b_galaxy/tt/generator.py
@@ -362,7 +362,7 @@ class Generator(WarmupForwardMixin):
             if isinstance(tt_sampled, list):
                 tt_sampled = tt_sampled[0]
 
-            sampled_tokens = ttnn.to_torch(ttnn.get_device_tensors(tt_sampled)[0])
+            sampled_tokens = ttnn.to_torch(ttnn.get_device_tensors(tt_sampled)[0]).to(torch.int32)
 
             # sampled_tokens has 32 entries ordered by slot.
             sampled_tensor = sampled_tokens[0, 0, 0, :]  # Shape: [32]


### PR DESCRIPTION
```
            # sampled_tokens has 32 entries ordered by slot.
            sampled_tensor = sampled_tokens[0, 0, 0, :]  # Shape: [32]
>           output_toks = sampled_tensor[empty_slots]
E           RuntimeError: "index_cpu" not implemented for 'UInt32'
```

https://github.com/tenstorrent/tt-metal/actions/runs/22376320732/job/64768252583#step:7:2034

- [ ] [galaxy demo llama 70b](https://github.com/tenstorrent/tt-metal/actions/runs/22392600354)