### PR TITLE
Peak Memory Profiler

### DIFF
--- a/tt_metal/api/tt-metalium/allocator.hpp
+++ b/tt_metal/api/tt-metalium/allocator.hpp
@@ -20,6 +20,8 @@ struct Statistics {
     size_t largest_free_block_bytes = 0;
     // addresses (relative to bank) that can hold the largest_free_block_bytes
     std::vector<uint32_t> largest_free_block_addrs;
+    // Peak allocated bytes (per bank) since last reset
+    size_t peak_allocated_bytes = 0;
 };
 
 class Buffer;
@@ -51,6 +53,9 @@ public:
     // this helper function is made for reports.cpp in TTNN and act as a transient member function.
     size_t get_worker_l1_size() const;
     Statistics get_statistics(const BufferType& buffer_type) const;
+    // Reset peak allocated bytes watermark for the given buffer type.
+    // After reset, peak tracks from the current allocation level.
+    void reset_peak_allocated_bytes(const BufferType& buffer_type);
     // AllocatorState Methods
     // Extracts the current state of the allocator.
     AllocatorState extract_state() const;

--- a/tt_metal/api/tt-metalium/memory_reporter.hpp
+++ b/tt_metal/api/tt-metalium/memory_reporter.hpp
@@ -88,12 +88,19 @@ void DumpDeviceMemoryState(const IDevice* device, const std::string& prefix = ""
  * */
 MemoryView GetMemoryView(const IDevice* device, const BufferType& buffer_type);
 
+/**
+ * Reset the peak memory allocation watermark for the given buffer type.
+ * After reset, peak tracking restarts from the current allocation level.
+ */
+void ResetPeakMemoryAllocated(IDevice* device, const BufferType& buffer_type);
+
 struct MemoryView {
     std::uint64_t num_banks = 0;
     size_t total_bytes_per_bank = 0;
     size_t total_bytes_allocated_per_bank = 0;
     size_t total_bytes_free_per_bank = 0;
     size_t largest_contiguous_bytes_free_per_bank = 0;
+    size_t peak_bytes_allocated_per_bank = 0;
     MemoryBlockTable block_table;
 };
 

--- a/tt_metal/detail/reports/memory_reporter.cpp
+++ b/tt_metal/detail/reports/memory_reporter.cpp
@@ -168,11 +168,16 @@ MemoryView MemoryReporter::get_memory_view(const IDevice* device, const BufferTy
         .total_bytes_allocated_per_bank = stats.total_allocated_bytes,
         .total_bytes_free_per_bank = stats.total_free_bytes,
         .largest_contiguous_bytes_free_per_bank = stats.largest_free_block_bytes,
+        .peak_bytes_allocated_per_bank = stats.peak_allocated_bytes,
         .block_table = device->allocator_impl()->get_memory_block_table(buffer_type)};
 }
 
 MemoryView GetMemoryView(const IDevice* device, const BufferType& buffer_type) {
     return MemoryReporter::inst().get_memory_view(device, buffer_type);
+}
+
+void ResetPeakMemoryAllocated(IDevice* device, const BufferType& buffer_type) {
+    device->allocator()->reset_peak_allocated_bytes(buffer_type);
 }
 
 bool MemoryReporter::enabled() { return is_enabled_; }

--- a/tt_metal/impl/allocator/allocator.cpp
+++ b/tt_metal/impl/allocator/allocator.cpp
@@ -357,6 +357,19 @@ void AllocatorImpl::mark_allocations_safe() {
     allocations_unsafe_ = false;
 }
 
+void AllocatorImpl::reset_peak_allocated_bytes(const BufferType& buffer_type) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    switch (buffer_type) {
+        case BufferType::DRAM: dram_manager_->reset_peak_allocated_bytes(); break;
+        case BufferType::L1: l1_manager_->reset_peak_allocated_bytes(); break;
+        case BufferType::L1_SMALL: l1_small_manager_->reset_peak_allocated_bytes(); break;
+        case BufferType::TRACE: trace_buffer_manager_->reset_peak_allocated_bytes(); break;
+        default: {
+            TT_THROW("Unsupported buffer type!");
+        }
+    }
+}
+
 void AllocatorImpl::begin_dram_high_water_mark_tracking() {
     std::lock_guard<std::mutex> lock(mutex_);
     dram_manager_->begin_high_water_mark_tracking();
@@ -519,6 +532,10 @@ DeviceAddr Allocator::get_base_allocator_addr(const HalMemType& mem_type) const 
 uint32_t Allocator::get_alignment(BufferType buffer_type) const { return impl->get_alignment(buffer_type); }
 
 Statistics Allocator::get_statistics(const BufferType& buffer_type) const { return impl->get_statistics(buffer_type); }
+
+void Allocator::reset_peak_allocated_bytes(const BufferType& buffer_type) {
+    impl->reset_peak_allocated_bytes(buffer_type);
+}
 
 AllocatorState Allocator::extract_state() const { return impl->extract_state(); }
 

--- a/tt_metal/impl/allocator/allocator.hpp
+++ b/tt_metal/impl/allocator/allocator.hpp
@@ -74,6 +74,10 @@ public:
     void mark_allocations_unsafe();
     void mark_allocations_safe();
 
+    // Reset peak allocated bytes watermark for the given buffer type.
+    // After reset, peak tracks from the current allocation level.
+    void reset_peak_allocated_bytes(const BufferType& buffer_type);
+
     // High water mark tracking for DRAM allocations during trace capture
     // Delegates to BankManager to account for banking properly
     void begin_dram_high_water_mark_tracking();

--- a/tt_metal/impl/allocator/bank_manager.cpp
+++ b/tt_metal/impl/allocator/bank_manager.cpp
@@ -435,6 +435,10 @@ uint64_t BankManager::allocate_buffer(
         }
         allocated_buffers_[allocator_id.get()].insert(address.value());
 
+        // Track peak allocated bytes
+        current_allocated_bytes_ += size_per_bank;
+        peak_allocated_bytes_ = std::max(peak_allocated_bytes_, current_allocated_bytes_);
+
         // Track allocation high water mark
         if (tracking_high_water_mark_) {
             // Calculate end address in interleaved space: address + size_per_bank
@@ -500,6 +504,10 @@ uint64_t BankManager::allocate_buffer(
     TT_FATAL(address.has_value(), "Allocator failed to place at chosen address {}", chosen.value());
     allocated_buffers_[allocator_id.get()].insert(address.value());
 
+    // Track peak allocated bytes
+    current_allocated_bytes_ += size_per_bank;
+    peak_allocated_bytes_ = std::max(peak_allocated_bytes_, current_allocated_bytes_);
+
     // Track allocation high water mark
     if (tracking_high_water_mark_) {
         // Calculate end address in interleaved space: address + size_per_bank
@@ -518,11 +526,11 @@ void BankManager::deallocate_buffer(DeviceAddr address, BankManager::AllocatorDe
     auto* alloc = this->get_allocator_from_id(allocator_id);
     TT_FATAL(alloc, "Allocator not initialized!");
 
-    // Track deletion high water mark - remember the extent of buffers being freed
-    if (tracking_high_water_mark_) {
-        auto size_opt = alloc->get_allocation_size(address);
-        if (size_opt.has_value()) {
-            // Update deletion high water mark with the end address of the buffer being deallocated
+    // Track peak allocated bytes and deletion high water mark before deallocation
+    auto size_opt = alloc->get_allocation_size(address);
+    if (size_opt.has_value()) {
+        current_allocated_bytes_ -= std::min(current_allocated_bytes_, static_cast<size_t>(size_opt.value()));
+        if (tracking_high_water_mark_) {
             DeviceAddr end_address = address + size_opt.value();
             deletion_high_water_mark_ = std::max(deletion_high_water_mark_, end_address);
         }
@@ -544,6 +552,7 @@ void BankManager::deallocate_all() {
         allocated_buffers_[allocator_id.get()].clear();
         allocated_ranges_cache_[allocator_id.get()].reset();
     }
+    current_allocated_bytes_ = 0;
 }
 
 void BankManager::clear() {
@@ -554,6 +563,8 @@ void BankManager::clear() {
         }
         allocated_ranges_cache_[allocator_id.get()].reset();
     }
+    current_allocated_bytes_ = 0;
+    peak_allocated_bytes_ = 0;
 }
 
 BankManager& BankManager::operator=(BankManager&& that) noexcept {
@@ -565,6 +576,8 @@ BankManager& BankManager::operator=(BankManager&& that) noexcept {
     alignment_bytes_ = that.alignment_bytes_;
     allocator_dependencies_ = std::move(that.allocator_dependencies_);
     allocated_ranges_cache_ = std::move(that.allocated_ranges_cache_);
+    current_allocated_bytes_ = that.current_allocated_bytes_;
+    peak_allocated_bytes_ = that.peak_allocated_bytes_;
     return *this;
 }
 
@@ -584,7 +597,9 @@ std::optional<DeviceAddr> BankManager::lowest_occupied_address(
 
 Statistics BankManager::get_statistics(BankManager::AllocatorDependencies::AllocatorID allocator_id) const {
     const auto* alloc = this->get_allocator_from_id(allocator_id);
-    return alloc ? alloc->get_statistics() : Statistics();
+    auto stats = alloc ? alloc->get_statistics() : Statistics();
+    stats.peak_allocated_bytes = peak_allocated_bytes_;
+    return stats;
 }
 
 void BankManager::begin_high_water_mark_tracking() {
@@ -605,6 +620,8 @@ DeviceAddr BankManager::get_high_water_mark() const {
 DeviceAddr BankManager::get_allocation_high_water_mark() const { return allocation_high_water_mark_; }
 
 DeviceAddr BankManager::get_deletion_high_water_mark() const { return deletion_high_water_mark_; }
+
+void BankManager::reset_peak_allocated_bytes() { peak_allocated_bytes_ = current_allocated_bytes_; }
 
 void BankManager::dump_blocks(std::ostream& out, BankManager::AllocatorDependencies::AllocatorID allocator_id) const {
     const auto* alloc = this->get_allocator_from_id(allocator_id);

--- a/tt_metal/impl/allocator/bank_manager.hpp
+++ b/tt_metal/impl/allocator/bank_manager.hpp
@@ -132,6 +132,10 @@ public:
     DeviceAddr get_allocation_high_water_mark() const;
     DeviceAddr get_deletion_high_water_mark() const;
 
+    // Peak allocated bytes tracking (always-on, per bank)
+    // Resets peak to the current allocated level
+    void reset_peak_allocated_bytes();
+
     // AllocatorState Methods
     // Extracts the state of the given allocator.
     AllocatorState::BufferTypeState extract_state(
@@ -179,6 +183,10 @@ private:
     bool tracking_high_water_mark_ = false;
     DeviceAddr allocation_high_water_mark_ = 0;
     DeviceAddr deletion_high_water_mark_ = 0;
+
+    // Peak allocated bytes tracking (always-on, per bank)
+    size_t current_allocated_bytes_ = 0;
+    size_t peak_allocated_bytes_ = 0;
 
     /*********************************
      * Allocator-independent methods *

--- a/ttnn/cpp/ttnn-nanobind/device.cpp
+++ b/ttnn/cpp/ttnn-nanobind/device.cpp
@@ -141,6 +141,7 @@ void py_device_module_types(nb::module_& m_device) {
         .def_ro(
             "largest_contiguous_bytes_free_per_bank",
             &tt::tt_metal::detail::MemoryView::largest_contiguous_bytes_free_per_bank)
+        .def_ro("peak_bytes_allocated_per_bank", &tt::tt_metal::detail::MemoryView::peak_bytes_allocated_per_bank)
         .def_ro("block_table", &tt::tt_metal::detail::MemoryView::block_table);
 }
 
@@ -446,6 +447,25 @@ void device_module(nb::module_& m_device) {
         nb::arg("device").noconvert(),
         nb::arg("buffer_type").noconvert(),
         get_memory_view_doc.data());
+
+    constexpr std::string_view reset_peak_memory_doc = R"doc(
+        Reset the peak memory allocation watermark for the given buffer type.
+        After reset, peak tracking restarts from the current allocation level.
+    )doc";
+    m_device.def(
+        "ResetPeakMemoryAllocated",
+        &tt::tt_metal::detail::ResetPeakMemoryAllocated,
+        nb::arg("device").noconvert(),
+        nb::arg("buffer_type").noconvert(),
+        reset_peak_memory_doc.data());
+    m_device.def(
+        "ResetPeakMemoryAllocated",
+        [](MeshDevice* device, const BufferType& buffer_type) {
+            tt::tt_metal::detail::ResetPeakMemoryAllocated(device, buffer_type);
+        },
+        nb::arg("device").noconvert(),
+        nb::arg("buffer_type").noconvert(),
+        reset_peak_memory_doc.data());
 
     constexpr std::string_view synchronize_device_doc = R"doc(
                 Synchronize the device with host by waiting for all operations to complete.

--- a/ttnn/ttnn/__init__.py
+++ b/ttnn/ttnn/__init__.py
@@ -281,6 +281,7 @@ from ttnn.device import (
     synchronize_device,
     dump_device_memory_state,
     get_memory_view,
+    reset_peak_memory_allocated,
     get_max_worker_l1_unreserved_size,
     get_optimal_dram_bank_to_logical_worker_assignment,
     enable_asynchronous_slow_dispatch,

--- a/ttnn/ttnn/device.py
+++ b/ttnn/ttnn/device.py
@@ -275,6 +275,10 @@ def get_memory_view(device, buffer_type):
     return ttnn._ttnn.device.GetMemoryView(device, buffer_type)
 
 
+def reset_peak_memory_allocated(device, buffer_type):
+    ttnn._ttnn.device.ResetPeakMemoryAllocated(device, buffer_type)
+
+
 pad_to_tile_shape = ttnn._ttnn.device.pad_to_tile_shape
 
 SubDevice = ttnn._ttnn.device.SubDevice


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/38514)

### Problem description
vLLM determines KV cache capacity using allocator peak (high-watermark) memory statistics to account for transient memory spikes during model execution.

Currently, TT-Metal exposes only instantaneous memory usage through Python APIs, which makes it impossible to observe peak allocator pressure over the runtime of a model. As a result, KV cache sizing is either conservative or inaccurate.

### What's changed
This PR introduces allocator-level peak memory watermark tracking in TT-Metal and exposes it through Python APIs.

**Key changes**
1. Track maximum allocated/reserved memory within the allocator
2. Update peak values on allocation paths
3. Add Python APIs to query and reset peak memory counters

**Impact**
1. Enables accurate runtime peak memory measurement
2. Improves KV cache sizing for vLLM

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=peak-mem-profiler)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:peak-mem-profiler)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=peak-mem-profiler)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:peak-mem-profiler)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=peak-mem-profiler)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:peak-mem-profiler)
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=peak-mem-profiler)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:peak-mem-profiler)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=peak-mem-profiler)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:peak-mem-profiler)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=peak-mem-profiler)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:peak-mem-profiler)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
