### PR TITLE
[WATCHER] Different watcher sampling values cause different test duration which shouldn't be the case

### DIFF
--- a/tt_metal/impl/debug/watcher_server.cpp
+++ b/tt_metal/impl/debug/watcher_server.cpp
@@ -535,10 +535,14 @@ void WatcherServer::Impl::poll_watcher_data() {
         // Wait for the interval, but check stop flag frequently to exit early
         constexpr auto poll_interval = std::chrono::milliseconds(100);
         auto remaining = sleep_duration;
-        while (remaining > std::chrono::milliseconds(0) && !stop_server_.load()) {
+        while (remaining > std::chrono::milliseconds(0)) {
             auto wait_time = std::min(remaining, poll_interval);
             std::unique_lock<std::mutex> lock(watch_mutex_);
-            stop_server_cv_.wait_for(lock, wait_time);
+            // wait_for with predicate returns true if stop requested, false on timeout
+            // Only decrement remaining on timeout (predicate handles spurious wakeups internally)
+            if (stop_server_cv_.wait_for(lock, wait_time, [&] { return stop_server_.load(); })) {
+                break;
+            }
             remaining -= wait_time;
         }
         if (stop_server_.load()) {

--- a/tt_metal/impl/debug/watcher_server.cpp
+++ b/tt_metal/impl/debug/watcher_server.cpp
@@ -519,9 +519,6 @@ void WatcherServer::Impl::poll_watcher_data() {
 
     while (true) {
         std::unique_lock<std::mutex> lock(watch_mutex_);
-        if (stop_server_cv_.wait_for(lock, sleep_duration, [&] { return stop_server_.load(); })) {
-            break;
-        }
 
         fprintf(logfile_, "-----\n");
         fprintf(logfile_, "Dump #%d at %.3lfs\n", dump_count_.load(), get_elapsed_secs());
@@ -544,6 +541,10 @@ void WatcherServer::Impl::poll_watcher_data() {
         fprintf(logfile_, "Dump #%d completed at %.3lfs\n", dump_count_.load(), get_elapsed_secs());
         fflush(logfile_);
         dump_count_++;
+
+        if (stop_server_cv_.wait_for(lock, sleep_duration, [&] { return stop_server_.load(); })) {
+            break;
+        }
     }
 
     log_info(LogLLRuntime, "Watcher thread stopped watching...");

--- a/tt_metal/impl/debug/watcher_server.cpp
+++ b/tt_metal/impl/debug/watcher_server.cpp
@@ -145,14 +145,6 @@ void WatcherServer::Impl::detach_devices() {
     }
 
     if (server_thread_) {
-        // Let one full watcher dump happen so we can catch anything between the last scheduled dump and teardown.
-        // Don't do this in test mode, to keep the tests running quickly.
-        if (!MetalContext::instance().rtoptions().get_test_mode_enabled() and !server_killed_due_to_error_) {
-            int target_count = dump_count() + 1;
-            while (dump_count() < target_count) {
-                ;
-            }
-        }
         // Signal the server thread to finish
         stop_server_ = true;
         stop_server_cv_.notify_all();
@@ -518,8 +510,6 @@ void WatcherServer::Impl::poll_watcher_data() {
     log_info(LogLLRuntime, "Watcher server initialized, disabled features: {}", disabled_features);
 
     while (true) {
-        std::unique_lock<std::mutex> lock(watch_mutex_);
-
         fprintf(logfile_, "-----\n");
         fprintf(logfile_, "Dump #%d at %.3lfs\n", dump_count_.load(), get_elapsed_secs());
 
@@ -542,7 +532,16 @@ void WatcherServer::Impl::poll_watcher_data() {
         fflush(logfile_);
         dump_count_++;
 
-        if (stop_server_cv_.wait_for(lock, sleep_duration, [&] { return stop_server_.load(); })) {
+        // Wait for the interval, but check stop flag frequently to exit early
+        constexpr auto poll_interval = std::chrono::milliseconds(100);
+        auto remaining = sleep_duration;
+        while (remaining > std::chrono::milliseconds(0) && !stop_server_.load()) {
+            auto wait_time = std::min(remaining, poll_interval);
+            std::unique_lock<std::mutex> lock(watch_mutex_);
+            stop_server_cv_.wait_for(lock, wait_time);
+            remaining -= wait_time;
+        }
+        if (stop_server_.load()) {
             break;
         }
     }


### PR DESCRIPTION
### Ticket
[#38533](https://github.com/tenstorrent/tt-metal/issues/38533)

### Problem description
When defined a sampling period as TT_METAL_WATCHER=x watcher logging loop first sleeps for x seconds which is an integer value so no less than 1s and then does the first sample checking if it caught any issues. For the tests that last less than 1s we need to wait for at least one sampling period before realization that the test finished. This gives us unnecessary overhead in test execution with pipelines with watcher enabled. 

### What's changed
1. Instead of blocking at the beginning of the loop for sampling duration, the blocking happens at the end of the loop. That gives us the first sample at t=0 and the next one again at t=sampling period + delta t resulting in speedup in tests that are shorter than minimal sampling period value.
2. Removed a wait for dump_count+1 samples since we added one at the beginning of the while loop 
3. Partitioning the sleep period into bunch of smaller sleep cycles in quants of 100ms to check if we received test finished information and stop request stop request in the meantime

Results: Whichever sampling period is set we have the same test duration and always have at least one log so nothing is missed and the execution is sped up.

### Checklist

- [x] [![apc debug nightly](https://github.com/tenstorrent/tt-metal/actions/workflows/apc-nightly-debug.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/runs/22394382333?query=branch:{{branch_name}})
- [x] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/runs/22394899356?query=branch:{{branch_name}})
- [x] [![L2 Nightly](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/runs/22478019661?query=branch:{{branch_name}})
