### PR TITLE
Fix hitting LLK_ASSERT in _llk_unpack_tilize_

### DIFF
--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_tilize_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_tilize_api.h
@@ -32,10 +32,8 @@ inline void llk_unpack_tilize_uninit(const std::uint32_t operand, const std::uin
     _llk_unpack_tilize_uninit_((uint)unpack_dst_format[operand_id], num_faces, face_r_dim);
 }
 
-inline void llk_unpack_tilize(std::uint32_t operand, std::uint32_t tile_index, std::uint32_t block_ct_dim) {
+inline void llk_unpack_tilize(std::uint32_t operand, std::uint32_t tile_index, std::uint32_t /* unused block_ct_dim*/) {
     std::uint32_t operand_id = get_operand_id(operand);
-    const std::uint32_t face_r_dim = get_operand_face_r_dim(operand_id);
-    const std::uint32_t num_faces = get_operand_num_faces(operand_id);
     const bool narrow_tile = get_operand_narrow_tile(operand_id);
 
     std::uint32_t base_address =
@@ -47,9 +45,9 @@ inline void llk_unpack_tilize(std::uint32_t operand, std::uint32_t tile_index, s
         tile_index,
         unpack_src_format[operand_id],
         unpack_dst_format[operand_id],
-        block_ct_dim,
-        face_r_dim,
-        num_faces,
+        0,
+        16,
+        4,
         narrow_tile);
     WAYPOINT("UPTD");
 }
@@ -59,7 +57,7 @@ inline void llk_unpack_tilize_block(std::uint32_t operand, std::uint32_t block_c
     // i.e. input_tile_index % block_c_tiles == 0
     input_tile_index = input_tile_index % block_c_tiles + (input_tile_index / block_c_tiles) * block_c_tiles * TILE_R_DIM;
     for (std::uint32_t tile_index = 0; tile_index < block_c_tiles; tile_index++) {
-        llk_unpack_tilize(operand, input_tile_index + tile_index, block_c_tiles);
+        llk_unpack_tilize(operand, input_tile_index + tile_index, 0);
     }
 }
 

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_tilize_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_tilize_api.h
@@ -45,9 +45,9 @@ inline void llk_unpack_tilize(std::uint32_t operand, std::uint32_t tile_index, s
         tile_index,
         unpack_src_format[operand_id],
         unpack_dst_format[operand_id],
-        0,
-        16,
-        4,
+        0 /* unused block_ct_dim*/,
+        FACE_R_DIM /* unused face_r_dim*/,
+        4 /* unused num_faces */,
         narrow_tile);
     WAYPOINT("UPTD");
 }
@@ -57,7 +57,7 @@ inline void llk_unpack_tilize_block(std::uint32_t operand, std::uint32_t block_c
     // i.e. input_tile_index % block_c_tiles == 0
     input_tile_index = input_tile_index % block_c_tiles + (input_tile_index / block_c_tiles) * block_c_tiles * TILE_R_DIM;
     for (std::uint32_t tile_index = 0; tile_index < block_c_tiles; tile_index++) {
-        llk_unpack_tilize(operand, input_tile_index + tile_index, 0);
+        llk_unpack_tilize(operand, input_tile_index + tile_index, 0 /* unused block_ct_dim*/);
     }
 }
 


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/38523

### Problem description
LLK_ASSERT was hit during testing tilize_block. Issue described here: https://github.com/tenstorrent/tt-metal/issues/38028
The reason why the assert was hit is that LLK_ASSERT was added to verify that unused parameter is truly treated like unused, which was not the case in llk_unpack_tilize.

### What's changed
In llk_unpack_tilize, passed default value arguments which align with _llk_unpack_tilize_ asserts.

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=ndivnic/fix_assert_hit_for_llk_unpack_tilize_api)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:ndivnic/fix_assert_hit_for_llk_unpack_tilize_api)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ndivnic/fix_assert_hit_for_llk_unpack_tilize_api)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ndivnic/fix_assert_hit_for_llk_unpack_tilize_api)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ndivnic/fix_assert_hit_for_llk_unpack_tilize_api)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ndivnic/fix_assert_hit_for_llk_unpack_tilize_api)
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ndivnic/fix_assert_hit_for_llk_unpack_tilize_api)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ndivnic/fix_assert_hit_for_llk_unpack_tilize_api)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ndivnic/fix_assert_hit_for_llk_unpack_tilize_api)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ndivnic/fix_assert_hit_for_llk_unpack_tilize_api)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ndivnic/fix_assert_hit_for_llk_unpack_tilize_api)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ndivnic/fix_assert_hit_for_llk_unpack_tilize_api)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
