### PR TITLE
Fix BH APC on BH prefetcher tests for single card 

### DIFF
--- a/models/tt_transformers/tt/prefetcher.py
+++ b/models/tt_transformers/tt/prefetcher.py
@@ -78,7 +78,7 @@ def is_prefetcher_supported(model_name: str, num_devices: int, ring_size: int = 
         return False
     TILE_SIZE, MAX_CB_PAGES = 32, 65535
     BYTES_PER_TILE_BFP8 = 1088  # bfloat8_b tile size in bytes
-    MAX_L1_PER_BANK = {4: 1000000, 8: 1000000, 1: 550000}.get(num_devices, 850000)
+    MAX_L1_PER_BANK = {4: 1000000, 8: 1000000}.get(num_devices, 850000)
     kv_heads_divisible = VERIFIED_MODEL_CONFIGS[verified_model_name]["n_kv_heads"] % num_devices == 0
     dim, hidden_dim = (
         VERIFIED_MODEL_CONFIGS[verified_model_name]["dim"],

--- a/models/tt_transformers/tt/prefetcher.py
+++ b/models/tt_transformers/tt/prefetcher.py
@@ -78,7 +78,7 @@ def is_prefetcher_supported(model_name: str, num_devices: int, ring_size: int = 
         return False
     TILE_SIZE, MAX_CB_PAGES = 32, 65535
     BYTES_PER_TILE_BFP8 = 1088  # bfloat8_b tile size in bytes
-    MAX_L1_PER_BANK = {4: 1000000, 8: 1000000, 1: 650000}.get(num_devices, 850000)
+    MAX_L1_PER_BANK = {4: 1000000, 8: 1000000, 1: 550000}.get(num_devices, 850000)
     kv_heads_divisible = VERIFIED_MODEL_CONFIGS[verified_model_name]["n_kv_heads"] % num_devices == 0
     dim, hidden_dim = (
         VERIFIED_MODEL_CONFIGS[verified_model_name]["dim"],

--- a/models/tt_transformers/tt/prefetcher.py
+++ b/models/tt_transformers/tt/prefetcher.py
@@ -78,7 +78,7 @@ def is_prefetcher_supported(model_name: str, num_devices: int, ring_size: int = 
         return False
     TILE_SIZE, MAX_CB_PAGES = 32, 65535
     BYTES_PER_TILE_BFP8 = 1088  # bfloat8_b tile size in bytes
-    MAX_L1_PER_BANK = 1000000 if num_devices == 4 or num_devices == 8 else 850000
+    MAX_L1_PER_BANK = {4: 1000000, 8: 1000000, 1: 650000}.get(num_devices, 850000)
     kv_heads_divisible = VERIFIED_MODEL_CONFIGS[verified_model_name]["n_kv_heads"] % num_devices == 0
     dim, hidden_dim = (
         VERIFIED_MODEL_CONFIGS[verified_model_name]["dim"],

--- a/tests/ttnn/unit_tests/operations/transformers/test_prefetcher_BH.py
+++ b/tests/ttnn/unit_tests/operations/transformers/test_prefetcher_BH.py
@@ -645,7 +645,7 @@ def test_prefetcher_BH(
         model_name, mesh_device.get_num_devices(), num_receiver_cores * 8
     ) or mesh_device.get_num_devices() not in [2, 4, 8]:
         pytest.skip(
-            f"Model {model_name} does not fit in global CB with {mesh_device.get_num_devices()} devices and num_receiver_cores={num_receiver_cores}"
+            f"Model {model_name} does not fit in global CB with {mesh_device.get_num_devices()} devices and num_receiver_cores={num_receiver_cores}. DRAM Prefetcher is only supported on multi device configurations with 2, 4, or 8 devices."
         )
     logger.info(
         f"Testing DRAM Prefetcher + Ring Matmul for model {model_name} with dimensions: {VERIFIED_MODEL_CONFIGS[model_name]}"

--- a/tests/ttnn/unit_tests/operations/transformers/test_prefetcher_BH.py
+++ b/tests/ttnn/unit_tests/operations/transformers/test_prefetcher_BH.py
@@ -587,7 +587,6 @@ def run_prefetcher_all_matmuls(
     "mesh_device",
     [
         {
-            "P150": (1, 1),
             "P300": (1, 2),
             "P150x4": (1, 4),
             "P150x8": (1, 8),
@@ -642,7 +641,9 @@ def test_prefetcher_BH(
     - FF2: TP on hidden_dim dimension (K-sharded)
     """
     mesh_shape = tuple(mesh_device.shape)
-    if not is_prefetcher_supported(model_name, mesh_device.get_num_devices(), num_receiver_cores * 8):
+    if not is_prefetcher_supported(
+        model_name, mesh_device.get_num_devices(), num_receiver_cores * 8
+    ) or mesh_device.get_num_devices() not in [2, 4, 8]:
         pytest.skip(
             f"Model {model_name} does not fit in global CB with {mesh_device.get_num_devices()} devices and num_receiver_cores={num_receiver_cores}"
         )


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/actions/runs/22367994944/job/64740058536

### Problem description
It was not clear that the `test_prefetcher_BH.py` test was added to BH APC and single cards were running this test (expectation was bh nightly unit tests only run this test for multi card > 2 and those were all passing when this [PR](https://github.com/tenstorrent/tt-metal/pull/37999/) merged). We skip prefetcher usage for single cards since that was not an intended support configuration for now.

### What's changed
- skip single device support

### Checklist
- [x] [BH APC](https://github.com/tenstorrent/tt-metal/actions/runs/22405032870)