### PR TITLE
SDXL disable throttle when compiling encoders

### DIFF
--- a/models/experimental/stable_diffusion_xl_base/tests/pcc/test_sdxl_clip_encoders.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/pcc/test_sdxl_clip_encoders.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import time
-import os
+
 import pytest
 import torch
 from loguru import logger
@@ -42,7 +42,6 @@ def test_clip_encoder(
     reset_seeds,
 ) -> None:
     model_name_checkpoint = "stabilityai/stable-diffusion-xl-base-1.0"
-    os.environ.pop("TT_MM_THROTTLE_PERF", None)
 
     # Download model for CI v2
     model_location = model_location_generator(

--- a/models/experimental/stable_diffusion_xl_base/tests/pcc/test_sdxl_clip_encoders.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/pcc/test_sdxl_clip_encoders.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import time
-
+import os
 import pytest
 import torch
 from loguru import logger
@@ -42,6 +42,7 @@ def test_clip_encoder(
     reset_seeds,
 ) -> None:
     model_name_checkpoint = "stabilityai/stable-diffusion-xl-base-1.0"
+    os.environ.pop("TT_MM_THROTTLE_PERF", None)
 
     # Download model for CI v2
     model_location = model_location_generator(

--- a/models/experimental/stable_diffusion_xl_base/tests/test_sdxl_perf.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/test_sdxl_perf.py
@@ -174,7 +174,7 @@ def test_refiner_unet(
         ),
         (
             "pytest models/experimental/stable_diffusion_xl_base/tests/pcc/test_sdxl_clip_encoders.py::test_clip_encoder -k 'encoder_1'",
-            14_609_421,
+            13_112_562,
             "sdxl_clip_encoder_1",
             "sdxl_clip_encoder_1",
             CLIP_ENCODER_DEVICE_TEST_TOTAL_ITERATIONS,
@@ -184,7 +184,7 @@ def test_refiner_unet(
         ),
         (
             "pytest models/experimental/stable_diffusion_xl_base/tests/pcc/test_sdxl_clip_encoders.py::test_clip_encoder -k 'encoder_2'",
-            70_551_148,  # Note: this is an average value of 30 test runs due to high variability
+            63_591_763,  # Note: this is an average value of 30 test runs due to high variability
             "sdxl_clip_encoder_2",
             "sdxl_clip_encoder_2",
             CLIP_ENCODER_DEVICE_TEST_TOTAL_ITERATIONS,

--- a/models/experimental/stable_diffusion_xl_base/tests/test_sdxl_perf.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/test_sdxl_perf.py
@@ -209,7 +209,7 @@ def test_refiner_unet(
 def test_sdxl_perf_device(
     command, expected_device_perf_ns_per_iteration, subdir, model_name, num_iterations, batch_size, margin, comments
 ):
-    os.environ["TT_MM_THROTTLE_PERF"] = "5"
+    os.environ["TT_MM_THROTTLE_PERF"] = "0" if "clip_encoder" in command else "5"
     run_model_device_perf_test(
         command=command,
         expected_device_perf_ns_per_iteration=expected_device_perf_ns_per_iteration,

--- a/models/experimental/stable_diffusion_xl_base/tt/tt_sdxl_pipeline.py
+++ b/models/experimental/stable_diffusion_xl_base/tt/tt_sdxl_pipeline.py
@@ -335,6 +335,8 @@ class TtSDXLPipeline(LightweightModule):
             assert self.pipeline_config.encoders_on_device, "Host text encoders are used; compile is not needed"
             assert self.tt_text_encoder_2 is not None, "Text encoder is not loaded on the device"
 
+            logger.info("Disabling throttle before compiling encoders")
+            prev_throttle = os.environ.pop("TT_MM_THROTTLE_PERF", None)
             warmup_tt_text_encoders(
                 self.tt_text_encoder,
                 self.tt_text_encoder_2,
@@ -343,6 +345,9 @@ class TtSDXLPipeline(LightweightModule):
                 self.ttnn_device,
                 self.batch_size,
             )
+            if prev_throttle is not None:
+                os.environ["TT_MM_THROTTLE_PERF"] = prev_throttle
+                logger.info(f"Enabling throttle after compiling encoders, throttle level: {prev_throttle}")
 
             self.encoders_compiled = True
 


### PR DESCRIPTION
### Ticket
SDXL clip encoder perf regression #37840

### What's changed
- Throttle disabled for compiling text encoders
- Throttle is disabled for encoder pcc test and perf targets are reverted

avg gen time 100 images impovement `sdxl base N300 DP=2`:
"avg_gen_time": `9.153778705596924` -> `9.14365463733673`

### Checklist
- [x] Single-card) Frequent model and ttnn tests [link](https://github.com/tenstorrent/tt-metal/actions/runs/22438313531)
- [x] (Single-card) Device perf regressions]  [link](https://github.com/tenstorrent/tt-metal/actions/runs/22438345719) 
- [x] Nightly tt-metal L2 tests  [link](https://github.com/tenstorrent/tt-metal/actions/runs/22438408603)
