### PR TITLE
SDXL Increase unet loop timeout

### DIFF
--- a/models/experimental/stable_diffusion_xl_base/tests/pcc/test_unet_loop.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/pcc/test_unet_loop.py
@@ -332,7 +332,7 @@ def run_unet_inference(ttnn_device, is_ci_env, image_resolution, prompts, num_in
     "prompt",
     (("An astronaut riding a green horse"),),
 )
-@pytest.mark.timeout(3000)
+@pytest.mark.timeout(3300)
 def test_unet_loop(
     device,
     is_ci_env,


### PR DESCRIPTION
### Ticket
SDXL L2 Nightly Unet_Loop Fail #37548

### Problem description
SDXL unet_loop test failed in L2 nightly due to hitting the 3000s timeout on machine `tt-metal-ci-vm-14`

### What's changed
Timeout increased to prevent flaky fail again

### Checklist
- [x] [Nightly tt-metal L2 tests #3681](https://github.com/tenstorrent/tt-metal/actions/runs/22403715523) passed✅

