### PR TITLE
Fix GPT-OSS test_model shape mismatch after lm_head padding

### DIFF
--- a/models/demos/gpt_oss/tests/unit/test_modules.py
+++ b/models/demos/gpt_oss/tests/unit/test_modules.py
@@ -878,6 +878,12 @@ def run_model_forward_test(
     # Reshape to match reference
     tt_logits_torch = tt_logits_torch.reshape(batch_size, seq_len, -1)
 
+    # Truncate to vocab_size — lm_head weight may be padded to padded_vocab_size
+    # for on-device sampling alignment, producing extra columns in the output.
+    vocab_size = config.vocab_size
+    if tt_logits_torch.shape[-1] > vocab_size:
+        tt_logits_torch = tt_logits_torch[:, :, :vocab_size]
+
     # Compare outputs
     passing, output = compare_tensors(tt_logits_torch, reference_logits, mesh_device, pcc_threshold=pcc_threshold)
     return passing, output


### PR DESCRIPTION
## Summary
- Fix `test_model` PCC comparison failure caused by lm_head weight padding introduced in #38320 (on-device sampling support)
- The lm_head weight is now padded to `padded_vocab_size` for device sampling alignment, so TT model output has extra columns (e.g. 201216 vs 201088) that don't exist in the HF reference
- Truncate TT logits to `config.vocab_size` before comparison

## Test plan
- [x] `pytest models/demos/gpt_oss/tests/unit/test_modules.py -k "test_model" -v` passes on Galaxy [4,8]
https://github.com/tenstorrent/tt-metal/actions/runs/22405164535