### PR TITLE
Use HiFi4 Distributed RMSNorm without fp32 accumulation, fix doc + assert for op

### DIFF
--- a/models/demos/deepseek_v3/tt/rms_norm/distributed_rms_norm.py
+++ b/models/demos/deepseek_v3/tt/rms_norm/distributed_rms_norm.py
@@ -18,7 +18,13 @@ from models.demos.deepseek_v3.utils.config_dataclass import (
     RMSNormPostAllGatherConfig,
     RMSNormPreAllGatherConfig,
 )
-from models.demos.deepseek_v3.utils.config_helpers import USERS_PER_ROW, even_int_div, get_state_dicts, shard_and_save
+from models.demos.deepseek_v3.utils.config_helpers import (
+    COMPUTE_KERNEL_CONFIG_HIFI4_NOFP32_ACC,
+    USERS_PER_ROW,
+    even_int_div,
+    get_state_dicts,
+    shard_and_save,
+)
 from models.demos.deepseek_v3.utils.run_config import (
     MESH_DEVICE_STATE_DICT_KEY,
     ModelDecodeConfig,
@@ -129,6 +135,7 @@ class DistributedRMSNorm(RMSNormBase):
             "input_memory_config": memory_config,
             "rms_norm_pre_all_gather": RMSNormPreAllGatherConfig(
                 dtype=ttnn.bfloat16,
+                compute_kernel_config=COMPUTE_KERNEL_CONFIG_HIFI4_NOFP32_ACC,
             ),
             "all_gather": AllGatherAsyncConfig(
                 dim=3,
@@ -140,6 +147,7 @@ class DistributedRMSNorm(RMSNormBase):
                 epsilon=hf_config.rms_norm_eps,
                 weight=FromWeightConfig(MeshDeviceStub(mesh_device.shape)),
                 dtype=ttnn.bfloat16,
+                compute_kernel_config=COMPUTE_KERNEL_CONFIG_HIFI4_NOFP32_ACC,
             ),
         }
 

--- a/models/demos/deepseek_v3/tt/rms_norm/rms_norm.py
+++ b/models/demos/deepseek_v3/tt/rms_norm/rms_norm.py
@@ -10,7 +10,11 @@ from transformers.configuration_utils import PretrainedConfig
 import ttnn
 from models.demos.deepseek_v3.tt.rms_norm.rms_norm_base import RMSNormBase
 from models.demos.deepseek_v3.utils.config_dataclass import FromWeightConfig, MeshDeviceStub, RMSNormConfig
-from models.demos.deepseek_v3.utils.config_helpers import COMPUTE_KERNEL_CONFIG_LOFI, get_state_dicts, shard_and_save
+from models.demos.deepseek_v3.utils.config_helpers import (
+    COMPUTE_KERNEL_CONFIG_HIFI4_NOFP32_ACC,
+    get_state_dicts,
+    shard_and_save,
+)
 from models.demos.deepseek_v3.utils.run_config import (
     ModelDecodeConfig,
     ModelPrefillConfig,
@@ -54,7 +58,7 @@ class RMSNorm(RMSNormBase):
         return RMSNormConfig(
             epsilon=hf_config.rms_norm_eps,
             weight=FromWeightConfig(MeshDeviceStub(mesh_device.shape)),
-            compute_kernel_config=COMPUTE_KERNEL_CONFIG_LOFI,
+            compute_kernel_config=COMPUTE_KERNEL_CONFIG_HIFI4_NOFP32_ACC,
         )
 
     @classmethod
@@ -62,7 +66,7 @@ class RMSNorm(RMSNormBase):
         return RMSNormConfig(
             epsilon=hf_config.rms_norm_eps,
             weight=FromWeightConfig(MeshDeviceStub(mesh_device.shape)),
-            compute_kernel_config=COMPUTE_KERNEL_CONFIG_LOFI,
+            compute_kernel_config=COMPUTE_KERNEL_CONFIG_HIFI4_NOFP32_ACC,
         )
 
     @classmethod

--- a/models/demos/deepseek_v3/utils/config_helpers.py
+++ b/models/demos/deepseek_v3/utils/config_helpers.py
@@ -55,6 +55,13 @@ COMPUTE_KERNEL_CONFIG_HIFI4 = ttnn.WormholeComputeKernelConfig(
     packer_l1_acc=True,
 )
 
+COMPUTE_KERNEL_CONFIG_HIFI4_NOFP32_ACC = ttnn.WormholeComputeKernelConfig(
+    math_fidelity=ttnn.MathFidelity.HiFi4,
+    math_approx_mode=False,
+    fp32_dest_acc_en=False,
+    packer_l1_acc=True,
+)
+
 COMPUTE_KERNEL_CONFIG_HIFI2_NA = ttnn.WormholeComputeKernelConfig(
     math_fidelity=ttnn.MathFidelity.HiFi2,
     math_approx_mode=False,

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/layernorm_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/layernorm_device_operation.cpp
@@ -173,6 +173,12 @@ void LayerNormDeviceOperation::validate_on_program_cache_miss(
                 "Stats is expected to have E(x) for each device stacked in the last dimension");
         }
     }
+
+    if (operation_attributes.norm_type == LayerNormType::RMSNORM) {
+        TT_FATAL(
+            !operation_attributes.compute_kernel_config.fp32_dest_acc_en,
+            "fp32_dest_acc_en is not supported for RMSNorm");
+    }
     std::visit(
         [&](const auto& program_config) {
             using ProgramConfigType = std::decay_t<decltype(program_config)>;

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/layernorm_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/layernorm_device_operation.cpp
@@ -174,10 +174,11 @@ void LayerNormDeviceOperation::validate_on_program_cache_miss(
         }
     }
 
-    if (operation_attributes.norm_type == LayerNormType::RMSNORM) {
+    if (operation_attributes.norm_type == LayerNormType::RMSNORM &&
+        operation_attributes.distributed_norm_stage != DistributedLayerNormStage::NOT_DISTRIBUTED) {
         TT_FATAL(
             !operation_attributes.compute_kernel_config.fp32_dest_acc_en,
-            "fp32_dest_acc_en is not supported for RMSNorm");
+            "fp32_dest_acc_en is not supported for distributed RMSNorm");
     }
     std::visit(
         [&](const auto& program_config) {

--- a/ttnn/cpp/ttnn/operations/normalization/rmsnorm/rmsnorm_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/rmsnorm/rmsnorm_nanobind.cpp
@@ -102,7 +102,6 @@ void bind_normalization_rms_norm(nb::module_& mod) {
             - If the `weight`/`bias` tensors are ROW_MAJOR layout: last padded dim must be TILE_WIDTH.
             - If the :attr:`input_tensor` is sharded, the :attr:`output` must also be sharded. In that case, the
               :attr:`output` memory layout and buffer type must match the :attr:`input_tensor`'s memory configuration.
-            - FP32 destination accumulation is not supported (`compute_kernel_config.fp32_dest_acc_en` must be false).
         )doc";
 
     ttnn::bind_function<"rms_norm">(

--- a/ttnn/cpp/ttnn/operations/normalization/rmsnorm/rmsnorm_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/rmsnorm/rmsnorm_nanobind.cpp
@@ -102,6 +102,7 @@ void bind_normalization_rms_norm(nb::module_& mod) {
             - If the `weight`/`bias` tensors are ROW_MAJOR layout: last padded dim must be TILE_WIDTH.
             - If the :attr:`input_tensor` is sharded, the :attr:`output` must also be sharded. In that case, the
               :attr:`output` memory layout and buffer type must match the :attr:`input_tensor`'s memory configuration.
+            - FP32 destination accumulation is not supported (`compute_kernel_config.fp32_dest_acc_en` must be false).
         )doc";
 
     ttnn::bind_function<"rms_norm">(

--- a/ttnn/cpp/ttnn/operations/normalization/rmsnorm_distributed/rmsnorm_distributed_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/rmsnorm_distributed/rmsnorm_distributed_nanobind.cpp
@@ -74,6 +74,7 @@ void bind_normalization_rmsnorm_pre_all_gather_operation(nb::module_& mod) {
                 - All tensors must be on-device.
                 - Unsharded inputs must be interleaved
                 - Sharded inputs cannot be height-sharded, padded height must equal TILE_HEIGHT (32). If :attr:`residual_input_tensor` is provided, it must match input's padded shape and sharding.
+                - FP32 destination accumulation is not supported (`compute_kernel_config.fp32_dest_acc_en` must be false).
               )doc",
         ttnn::nanobind_arguments_t{
             nb::arg("input_tensor"),
@@ -156,6 +157,7 @@ void bind_normalization_rmsnorm_post_all_gather_operation(nb::module_& mod) {
                   - The last padded dim of :attr:`stats` must be a multiple of TILE_WIDTH, and its first three padded dims must match :attr:`input_tensor`.
                   - If :attr:`weight` (gamma) is provided, :attr:`bias` (beta) must also be provided. Gamma and beta must have the same layout. If this is ROW_MAJOR, last padded dim must be TILE_WIDTH.
                   - Sharded runs: inputs cannot be height-sharded; padded height must equal TILE_HEIGHT (32). When sharded, :attr:`stats` must be sharded across one core.
+                  - FP32 destination accumulation is not supported (`compute_kernel_config.fp32_dest_acc_en` must be false).
         )doc",
         ttnn::nanobind_arguments_t{
             nb::arg("input_tensor"),


### PR DESCRIPTION
## Summary
- Switch DeepSeek RMSNorm to HiFi4 compute (no fp32 dest acc) for standard and distributed paths.
- Enforce the fp32 dest-acc restriction only for distributed RMSNorm (pre/post all-gather) and document it in the distributed RMSNorm docs.

## Testing
- DeepSeek Galaxy workflow triggered via `gh workflow run galaxy-deepseek-tests.yaml --ref ds-5ee91a8d731`
- Custom test dispatch: `pytest tests/ttnn/nightly/unit_tests/operations/fused/test_layernorm.py -k "rms_norm" -x -vv`

## CI Badge
[![DeepSeek Galaxy Tests (ds-5ee91a8d731)](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-deepseek-tests.yaml/badge.svg?branch=ds-5ee91a8d731)](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-deepseek-tests.yaml?query=branch%3Ads-5ee91a8d731)
[![Custom test dispatch (ds-5ee91a8d731)](https://github.com/tenstorrent/tt-metal/actions/workflows/test-dispatch.yaml/badge.svg?branch=ds-5ee91a8d731)](https://github.com/tenstorrent/tt-metal/actions/workflows/test-dispatch.yaml?query=branch%3Ads-5ee91a8d731)
