### PR TITLE
Fix timeout for partial submesh tests

### DIFF
--- a/.github/time_budget.yaml
+++ b/.github/time_budget.yaml
@@ -91,7 +91,7 @@ scaleout:
   e2e:
     wh_llmbox: 20
   unit:
-    wh_llmbox: 15
+    wh_llmbox: 20
   integration:
     wh_llmbox: 30
 

--- a/tests/pipeline_reorg/t3k_unit_tests.yaml
+++ b/tests/pipeline_reorg/t3k_unit_tests.yaml
@@ -219,6 +219,6 @@
   cmd: run_t3000_ttnn_multiprocess_slow_tests
   skus:
     wh_llmbox:
-      timeout: 10
+      timeout: 5
   owner_id: U09BZ5Q33LK # Piotr Stankiewicz
   team: scaleout


### PR DESCRIPTION
### Problem description
Timeout budget validation for newly added tests fails.

### What's changed
Increase timeout budged to account for newly added tests.

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=p1-0tr/fix-partial-submesh-test-timeout)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:p1-0tr/fix-partial-submesh-test-timeout)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=p1-0tr/fix-partial-submesh-test-timeout)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:p1-0tr/fix-partial-submesh-test-timeout)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=p1-0tr/fix-partial-submesh-test-timeout)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:p1-0tr/fix-partial-submesh-test-timeout)
- [ ] New/Existing tests provide coverage for changes