### PR TITLE
Run DeepSeekV3 B1 BH APC in slow dispatch mode

### DIFF
--- a/.github/workflows/ops-post-commit.yaml
+++ b/.github/workflows/ops-post-commit.yaml
@@ -80,8 +80,9 @@ jobs:
       matrix:
         default-ops-tests:
           [[
-            { name: "wormhole_b0 sdxl op tests", cmd: "pytest --timeout 300 models/experimental/stable_diffusion_xl_base/tests/test_sdxl_op_unit_test_perf.py -k \"_performance\" -xv --tb=short", merge_gate: false, arch: "wormhole_b0", timeout: 5 },
-            { name: "blackhole deepseek blitz op tests", cmd: "pytest --timeout 600 -m \"not skip_post_commit\" models/demos/deepseek_v3_b1/tests/unit_tests/", merge_gate: false, arch: "blackhole", timeout: 20 }
+            { name: "wormhole_b0 sdxl op tests", cmd: "pytest --timeout 300 models/experimental/stable_diffusion_xl_base/tests/test_sdxl_op_unit_test_perf.py -k \"_performance\" -xv --tb=short", merge_gate: false, arch: "wormhole_b0", timeout: 5, slow_dispatch: false },
+            { name: "blackhole deepseek blitz op tests (slow dispatch)", cmd: "pytest --timeout 600 -m \"not skip_post_commit\" models/demos/deepseek_v3_b1/tests/unit_tests/", merge_gate: false, arch: "blackhole", timeout: 20, slow_dispatch: true },
+            { name: "blackhole deepseek blitz op tests (fast dispatch)", cmd: "pytest --timeout 600 -m \"not skip_post_commit\" models/demos/deepseek_v3_b1/tests/unit_tests/", merge_gate: false, arch: "blackhole", timeout: 20, slow_dispatch: false }
           ]]
     steps:
       - name: Compute tests
@@ -151,6 +152,9 @@ jobs:
         env:
           TRACY_NO_INVARIANT_CHECK: 1
         run: |
+          if [ "${{ matrix.test-group.slow_dispatch }}" = "true" ]; then
+            export TT_METAL_SLOW_DISPATCH_MODE=1
+          fi
           ${{ matrix.test-group.cmd }}
 
           # Device perf branch

--- a/models/demos/deepseek_v3_b1/model.py
+++ b/models/demos/deepseek_v3_b1/model.py
@@ -155,7 +155,7 @@ class DeepSeekV3:
             return
         if self._prefill_active:
             logger.debug(f"Terminating prefill host I/O")
-            self._host_io_prefill.terminate()
+            self._host_io_prefill.terminate(sync_devices=True)
             self._prefill_active = False
         logger.debug(f"Switching to decode host I/O")
         self._host_io_decode.run()
@@ -222,8 +222,8 @@ class DeepSeekV3:
     def stop(self) -> None:
         """Clean shutdown of whichever mock decoder (prefill or decode) is active."""
         if self._prefill_active:
-            self._host_io_prefill.terminate()
+            self._host_io_prefill.terminate(sync_devices=True)
             self._prefill_active = False
         if self._decode_active:
-            self._host_io_decode.terminate()
+            self._host_io_decode.terminate(sync_devices=True)
             self._decode_active = False

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_create_q_heads.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_create_q_heads.py
@@ -43,6 +43,7 @@ Per-receiver data layout (8 heads per receiver):
         ((1, 512), (2, 64), None),  # Auto NOC routing - selects best single NOC
     ],
 )
+@pytest.mark.requires_grid_size((12, 8))
 def test_create_q_heads(device, qnope_shard_shape, qrope_shard_shape, noc):
     """Test TTNN create Q heads operation from 12x8 cores to 4x2 cores"""
     # Qnope: 8 columns x 8 rows (cols 0-7)
@@ -51,11 +52,6 @@ def test_create_q_heads(device, qnope_shard_shape, qrope_shard_shape, noc):
     qrope_grid = ttnn.CoreRange(ttnn.CoreCoord(8, 0), ttnn.CoreCoord(11, 7))
     # Receiver: 4 columns x 2 rows at (0-3, 1-2)
     receiver_grid = ttnn.CoreRange(ttnn.CoreCoord(0, 1), ttnn.CoreCoord(3, 2))
-
-    # Check device grid size
-    device_grid = device.compute_with_storage_grid_size()
-    if device_grid.x < 12 or device_grid.y < 8:
-        pytest.skip(f"Device grid {device_grid.x}x{device_grid.y} too small for 12x8 sender grid")
 
     # Calculate dimensions
     qnope_rows = qnope_grid.end.y - qnope_grid.start.y + 1  # 8

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_gated_local_reduce_down_proj.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_gated_local_reduce_down_proj.py
@@ -42,12 +42,9 @@ from models.demos.deepseek_v3_b1.fused_ops.shared_expert.op import SharedExpertO
         (8, 256, 64, ttnn.bfloat8_b),  # 8 collections, 64+64 A/B grid, N=7168
     ],
 )
+@pytest.mark.requires_grid_size((13, 10))
 def test_gated_local_reduce_down_proj(device, tiles_per_k, K, N_per_core, weights_dtype):
     """Test fused input gather + gated local reduce + down projection."""
-
-    device_grid = device.compute_with_storage_grid_size()
-    if device_grid.x < 13 or device_grid.y < 10:
-        pytest.skip(f"Device grid {device_grid.x}x{device_grid.y} too small for 13x10")
 
     N = N_per_core * DownProj.NUM_MATMUL_CORES  # 112 cores
     k_num_tiles = K // 32

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_gather.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_gather.py
@@ -348,7 +348,8 @@ def get_gate_up_core_assignment():
 
 
 @pytest.mark.parametrize("dtype", [ttnn.bfloat16, ttnn.bfloat8_b, ttnn.bfloat4_b])
-def test_gather_gate_up_parallel_pattern(device, dtype):
+@pytest.mark.requires_grid_size((13, 10))
+def test_gather_gate_up_parallel_pattern(device, check_requires_grid_size, dtype):
     """
     Test two parallel gathers from the Gate/Up A/B split pattern.
 
@@ -364,13 +365,6 @@ def test_gather_gate_up_parallel_pattern(device, dtype):
     The dtype parametrization validates tile-based size calculation for BFP formats
     (bfloat8_b, bfloat4_b) which have exponent headers.
     """
-    device_grid_x = device.compute_with_storage_grid_size().x
-    device_grid_y = device.compute_with_storage_grid_size().y
-
-    # Need at least 13x10 grid for full pattern
-    if device_grid_x < 13 or device_grid_y < 10:
-        pytest.skip(f"Device grid too small (need 13x10, got {device_grid_x}x{device_grid_y})")
-
     # Get core assignments
     a_cores, b_cores = get_gate_up_core_assignment()
     m_core = ttnn.CoreCoord(12, 9)  # Mcast/Reduce core

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_mcast_112_core_down.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_mcast_112_core_down.py
@@ -38,14 +38,12 @@ from models.demos.deepseek_v3_b1.fused_ops.down_proj.op import DownProj
         # (1, 7168, 64, ttnn.bfloat4_b),  # bfloat4 weights
     ],
 )
+@pytest.mark.requires_grid_size((13, 10))
 def test_down_proj_112_core(device, M, K, N_per_core, weights_dtype):
     """Test down projection with mcast1 -> mcast2 -> matmul -> add -> gather on 112 scattered cores"""
 
     device_grid = device.compute_with_storage_grid_size()
     logger.info(f"Device grid: {device_grid.x}x{device_grid.y}")
-
-    if device_grid.x < 13 or device_grid.y < 10:
-        pytest.skip(f"Device grid {device_grid.x}x{device_grid.y} too small for 13x10")
 
     N = N_per_core * DownProj.NUM_MATMUL_CORES  # 112 cores
 

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_model.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_model.py
@@ -22,7 +22,7 @@ from models.demos.deepseek_v3_b1.demo.runtime import TokenCodec, create_model
 
 @pytest.mark.parametrize("loopback_mode", [True, False])
 @pytest.mark.parametrize("batch_size", [1])
-@pytest.mark.parametrize("prompt_length", [1, 8, 64, 128])
+@pytest.mark.parametrize("prompt_length", [1, 64, 128])
 @pytest.mark.parametrize("num_decode_steps", [1, 16, 32])
 def test_prefill_and_decode(
     mesh_device: ttnn.MeshDevice,

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_moe_mlp.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_moe_mlp.py
@@ -413,12 +413,9 @@ def extract_routed_expert_output(
     "use_hardcoded_expert_index",
     [True, pytest.param(False, marks=pytest.mark.skip_post_commit)],
 )
+@pytest.mark.requires_grid_size((13, 10))
 def test_moe_fused(device, use_hardcoded_expert_index):
     """Test fused MoE: run both routed expert and shared expert, validate combined output."""
-
-    device_grid = device.compute_with_storage_grid_size()
-    if device_grid.x < 13 or device_grid.y < 10:
-        pytest.skip(f"Device grid {device_grid.x}x{device_grid.y} too small for 13x10")
 
     M = 1
     K = 7168
@@ -562,6 +559,7 @@ def test_moe_fused(device, use_hardcoded_expert_index):
     ids=["fabric_2d"],
 )
 @pytest.mark.parametrize("use_hardcoded_expert_index", [True, pytest.param(False, marks=pytest.mark.skip_post_commit)])
+@pytest.mark.requires_grid_size((13, 10))
 def test_moe_fused_with_reduce(bh_2d_mesh_device, use_hardcoded_expert_index):
     """
     Test fused MoE with reduce_to_one on 4x2 mesh.
@@ -578,10 +576,6 @@ def test_moe_fused_with_reduce(bh_2d_mesh_device, use_hardcoded_expert_index):
 
     submesh = bh_2d_mesh_device.create_submesh(ttnn.MeshShape((4, 2)))
     logger.info(f"Created submesh with shape: {submesh.shape}")
-
-    device_grid = submesh.compute_with_storage_grid_size()
-    if device_grid.x < 13 or device_grid.y < 10:
-        pytest.skip(f"Device grid {device_grid.x}x{device_grid.y} too small for 13x10")
 
     M = 1
     K = 7168
@@ -809,12 +803,9 @@ def test_moe_fused_with_reduce(bh_2d_mesh_device, use_hardcoded_expert_index):
 # ============================================================================
 # Test: Fused MoE with enable_routing=False (dense MLP mode)
 # ============================================================================
+@pytest.mark.requires_grid_size((13, 10))
 def test_mlp(device):
     """Test MoeOp with enable_routing=False: same as MLP, no routing logic."""
-
-    device_grid = device.compute_with_storage_grid_size()
-    if device_grid.x < 13 or device_grid.y < 10:
-        pytest.skip(f"Device grid {device_grid.x}x{device_grid.y} too small for 13x10")
 
     M = 1
     K = 7168
@@ -931,6 +922,7 @@ def test_mlp(device):
     indirect=["device_params"],
     ids=["fabric_2d"],
 )
+@pytest.mark.requires_grid_size((13, 10))
 def test_mlp_with_reduce(bh_2d_mesh_device):
     """
     Test MoeOp with enable_routing=False and reduce_to_one on 4x2 mesh.
@@ -948,10 +940,6 @@ def test_mlp_with_reduce(bh_2d_mesh_device):
 
     submesh = bh_2d_mesh_device.create_submesh(ttnn.MeshShape((4, 2)))
     logger.info(f"Created submesh with shape: {submesh.shape}")
-
-    device_grid = submesh.compute_with_storage_grid_size()
-    if device_grid.x < 13 or device_grid.y < 10:
-        pytest.skip(f"Device grid {device_grid.x}x{device_grid.y} too small for 13x10")
 
     M = 1
     K = 7168

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_post_sdpa.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_post_sdpa.py
@@ -119,6 +119,7 @@ def compute_forwarder_scratch_size(
 @pytest.mark.parametrize("cluster_axis", [1])
 @pytest.mark.parametrize("fuse_residual_add", [False, True])
 @pytest.mark.parametrize("ccl_enabled", [True, False], ids=["ccl_on", "ccl_off"])
+@pytest.mark.requires_grid_size((13, 10))
 def test_post_sdpa(
     bh_2d_mesh_device,
     mesh_rows,
@@ -596,6 +597,7 @@ def test_post_sdpa(
 @pytest.mark.parametrize("cluster_axis", [1])
 @pytest.mark.parametrize("fuse_residual_add", [False])
 @pytest.mark.parametrize("position_id", [500, 1500, 2500, 3500], ids=["pos500", "pos1500", "pos2500", "pos3500"])
+@pytest.mark.requires_grid_size((13, 10))
 def test_post_sdpa_with_sdpa_phase(
     bh_2d_mesh_device,
     mesh_rows,

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_sampling.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_sampling.py
@@ -39,9 +39,6 @@ def _mesh_device_index(final_mesh_coord, mesh_device):
 def _run_sampling_argmax_single_device_101_cores(device, seed: int, final_core_idx: int):
     grid_size = device.compute_with_storage_grid_size()
     all_device_cores = [ttnn.CoreCoord(x, y) for y in range(grid_size.y) for x in range(grid_size.x)]
-    if len(all_device_cores) < 101:
-        pytest.skip(f"Need at least 101 cores, found {len(all_device_cores)}")
-
     active_cores = all_device_cores[:101]
     core_grid = ttnn.CoreRangeSet({ttnn.CoreRange(core, core) for core in active_cores})
     assert 0 <= final_core_idx < len(active_cores), f"final_core_idx={final_core_idx} out of range"
@@ -139,6 +136,7 @@ def _run_sampling_argmax_single_device_101_cores(device, seed: int, final_core_i
         (4242, 73),  # non-boundary core
     ],
 )
+@pytest.mark.requires_grid_size(101)
 def test_sampling_argmax_single_device_101_cores(device, seed, final_core_idx):
     """
     Test k=1 sampling (argmax path) for a single device and 101 cores.
@@ -163,6 +161,7 @@ def test_sampling_argmax_single_device_101_cores(device, seed, final_core_idx):
     ],
 )
 @pytest.mark.skip(reason="Skipping 2x2 tests as they only work on quiet box")
+@pytest.mark.requires_grid_size(101)
 def test_sampling_argmax_mesh_2x2_axis_x(mesh_device, final_mesh_coord, seed, final_core_idx):
     """
     Mesh extension test:
@@ -172,9 +171,6 @@ def test_sampling_argmax_mesh_2x2_axis_x(mesh_device, final_mesh_coord, seed, fi
     """
     grid_size = mesh_device.compute_with_storage_grid_size()
     all_device_cores = [ttnn.CoreCoord(x, y) for y in range(grid_size.y) for x in range(grid_size.x)]
-    if len(all_device_cores) < 101:
-        pytest.skip(f"Need at least 101 cores, found {len(all_device_cores)}")
-
     active_cores = all_device_cores[:101]
     core_grid = ttnn.CoreRangeSet({ttnn.CoreRange(core, core) for core in active_cores})
     assert 0 <= final_core_idx < len(active_cores), f"final_core_idx={final_core_idx} out of range"
@@ -317,6 +313,7 @@ def _is_sampling_perf_enabled():
 )
 @pytest.mark.skip(reason="Skipping 2x2 tests as they only work on quiet box")
 @pytest.mark.parametrize("num_iters,num_warmup_iters", [(30, 10)])
+@pytest.mark.requires_grid_size(101)
 def test_sampling_argmax_mesh_2x2_axis_x_perf(mesh_device, num_iters, num_warmup_iters):
     """
     Performance test for mesh sampling with:
@@ -332,9 +329,6 @@ def test_sampling_argmax_mesh_2x2_axis_x_perf(mesh_device, num_iters, num_warmup
 
     grid_size = mesh_device.compute_with_storage_grid_size()
     all_device_cores = [ttnn.CoreCoord(x, y) for y in range(grid_size.y) for x in range(grid_size.x)]
-    if len(all_device_cores) < 101:
-        pytest.skip(f"Need at least 101 cores, found {len(all_device_cores)}")
-
     active_cores = all_device_cores[:101]
     core_grid = ttnn.CoreRangeSet({ttnn.CoreRange(core, core) for core in active_cores})
     final_core = active_cores[final_core_idx]
@@ -526,6 +520,7 @@ def test_sampling_argmax_mesh_2x2_axis_x_perf(mesh_device, num_iters, num_warmup
         ((2, 0), 4242, 73, 7),  # force winner off device 0
     ],
 )
+@pytest.mark.requires_grid_size(101)
 def test_sampling_argmax_mesh_4x2_axis_x(mesh_device, final_mesh_coord, seed, final_core_idx, forced_winner_device_idx):
     """
     Mesh extension test on 4x2 only:
@@ -534,9 +529,6 @@ def test_sampling_argmax_mesh_4x2_axis_x(mesh_device, final_mesh_coord, seed, fi
     """
     grid_size = mesh_device.compute_with_storage_grid_size()
     all_device_cores = [ttnn.CoreCoord(x, y) for y in range(grid_size.y) for x in range(grid_size.x)]
-    if len(all_device_cores) < 101:
-        pytest.skip(f"Need at least 101 cores, found {len(all_device_cores)}")
-
     active_cores = all_device_cores[:101]
     core_grid = ttnn.CoreRangeSet({ttnn.CoreRange(core, core) for core in active_cores})
     assert 0 <= final_core_idx < len(active_cores), f"final_core_idx={final_core_idx} out of range"
@@ -673,6 +665,7 @@ def test_sampling_argmax_mesh_4x2_axis_x(mesh_device, final_mesh_coord, seed, fi
 @pytest.mark.parametrize(
     "final_mesh_coord", [(1, 1), (1, 0), (2, 1), (2, 0)], ids=["top-right", "top-left", "bottom-right", "bottom-left"]
 )
+@pytest.mark.requires_grid_size(101)
 def test_sampling_argmax_mesh_4x2_axis_x_perf(mesh_device, num_iters, num_warmup_iters, final_mesh_coord):
     """
     Performance test for mesh(4x2) sampling with:
@@ -687,9 +680,6 @@ def test_sampling_argmax_mesh_4x2_axis_x_perf(mesh_device, num_iters, num_warmup
 
     grid_size = mesh_device.compute_with_storage_grid_size()
     all_device_cores = [ttnn.CoreCoord(x, y) for y in range(grid_size.y) for x in range(grid_size.x)]
-    if len(all_device_cores) < 101:
-        pytest.skip(f"Need at least 101 cores, found {len(all_device_cores)}")
-
     active_cores = all_device_cores[:101]
     core_grid = ttnn.CoreRangeSet({ttnn.CoreRange(core, core) for core in active_cores})
     final_core = active_cores[final_core_idx]

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_shared_expert.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_shared_expert.py
@@ -37,12 +37,9 @@ from models.demos.deepseek_v3_b1.fused_ops.shared_expert.op import SharedExpertO
         (7168, 64, ttnn.bfloat4_b),  # bfloat4 weights
     ],
 )
+@pytest.mark.requires_grid_size((13, 10))
 def test_shared_expert(device, K_gate, N_per_core, weights_dtype):
     """Test shared expert: activation → gate/up matmul → gated reduce → down proj + bias."""
-
-    device_grid = device.compute_with_storage_grid_size()
-    if device_grid.x < 13 or device_grid.y < 10:
-        pytest.skip(f"Device grid {device_grid.x}x{device_grid.y} too small for 13x10")
 
     M = 1
     cfg = GATE_UP_PROJ_SINGLE_DEVICE_OVERLAP_SPEC

--- a/pytest.ini
+++ b/pytest.ini
@@ -17,6 +17,7 @@ markers =
     model_perf_t3000: mark model silicon tests for performance on t3000 bare metal
     model_perf_tg: mark model silicon tests for performance on tg bare metal
     requires_fast_runtime_mode_off: mark tests which require fast runtime mode to be off: validation, logging, tracing
+    requires_grid_size(min_x, min_y) or min_cores: skip if device worker grid (compute_with_storage_grid_size) is smaller; pass (min_x, min_y) tuple or single int for min total cores
     use_module_device(device_params): use module-scoped device fixture for faster test execution. Pass device_params as positional dict or keyword arg.
 filterwarnings =
     ignore:record_property is incompatible with junit_family:pytest.PytestWarning


### PR DESCRIPTION
### Ticket

- https://github.com/tenstorrent/tt-metal/issues/38549

### Summary

- BH post-commit: add separate slow- and fast-dispatch jobs for B1 unit tests.
- Add `requires_grid_size` mark + autouse fixture for device worker grid; supports device, bh_2d_mesh_device, and mesh_device.
- DeepSeek v3 B1 tests updated to use the mark instead of ad-hoc skips; post_sdpa tests guarded so they no longer run on 110-core devices and fail.

### Checklist

- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/22410938156/job/64885837918)
