### PR TITLE
refactor: Replace positional CT args with named CT args in fabric ERISC router

### DIFF
--- a/tt_metal/fabric/compute_mesh_router_builder.cpp
+++ b/tt_metal/fabric/compute_mesh_router_builder.cpp
@@ -664,10 +664,10 @@ void ComputeMeshRouterBuilder::create_kernel(tt::tt_metal::Program& program, con
         auto [ct_args, named_ct_args] = erisc_builder_->get_compile_time_args(risc_id);
 
         const auto is_master_risc_core = (eth_chan == ctx.master_router_chan) && (risc_id == 0);
-        ct_args.push_back(is_master_risc_core);
-        ct_args.push_back(ctx.master_router_chan);
-        ct_args.push_back(ctx.num_local_fabric_routers);
-        ct_args.push_back(ctx.router_channels_mask);
+        named_ct_args["IS_LOCAL_HANDSHAKE_MASTER"] = is_master_risc_core;
+        named_ct_args["LOCAL_HANDSHAKE_MASTER_ETH_CHAN"] = ctx.master_router_chan;
+        named_ct_args["NUM_LOCAL_EDMS"] = ctx.num_local_fabric_routers;
+        named_ct_args["EDM_CHANNELS_MASK"] = ctx.router_channels_mask;
 
         // Determine processor
         auto proc = static_cast<tt::tt_metal::DataMovementProcessor>(risc_id);

--- a/tt_metal/fabric/erisc_datamover_builder.cpp
+++ b/tt_metal/fabric/erisc_datamover_builder.cpp
@@ -265,8 +265,10 @@ FabricEriscDatamoverConfig::FabricEriscDatamoverConfig(Topology topology) : topo
     // Allocate channel trimming capture buffer (conditionally enabled)
     if (rtoptions.get_enable_channel_trimming_capture()) {
         this->datapath_usage_l1_address = next_l1_addr;
-        this->datapath_usage_buffer_size =
-            sizeof(tt::tt_fabric::FabricDatapathUsageL1Results<true, builder_config::num_max_receiver_channels, builder_config::num_max_sender_channels>);
+        this->datapath_usage_buffer_size = sizeof(tt::tt_fabric::FabricDatapathUsageL1Results<
+                                                  true,
+                                                  builder_config::num_max_receiver_channels,
+                                                  builder_config::num_max_sender_channels>);
         next_l1_addr += this->datapath_usage_buffer_size;
     } else {
         this->datapath_usage_l1_address = 0;
@@ -857,36 +859,36 @@ void FabricEriscDatamoverBuilder::configure_telemetry_settings() {
 }
 
 void FabricEriscDatamoverBuilder::get_telemetry_compile_time_args(
-    uint32_t risc_id, std::vector<uint32_t>& ct_args) const {
+    uint32_t risc_id, std::unordered_map<std::string, uint32_t>& named_args) const {
     const auto& risc_config = config.risc_configs[risc_id];
     const bool telemetry_enabled = risc_config.telemetry_enabled();
 
     auto& rtoptions = tt::tt_metal::MetalContext::instance().rtoptions();
-    ct_args.push_back(static_cast<uint32_t>(telemetry_enabled));
+    named_args["ENABLE_FABRIC_TELEMETRY"] = static_cast<uint32_t>(telemetry_enabled);
 
     // Add telemetry statistic mask (per ERISC)
     const uint8_t stats_mask = telemetry_enabled ? risc_config.telemetry_stats_mask() : 0;
-    ct_args.push_back(static_cast<uint32_t>(stats_mask));
+    named_args["FABRIC_TELEMETRY_STATS_MASK"] = static_cast<uint32_t>(stats_mask);
 
     uint32_t bw_telemetry_mode = static_cast<uint32_t>(rtoptions.get_enable_fabric_bw_telemetry() ? 1 : 0);
-    ct_args.push_back(bw_telemetry_mode);
+    named_args["PERF_TELEMETRY_MODE"] = bw_telemetry_mode;
 
     // Add telemetry buffer address (16B aligned)
-    ct_args.push_back(static_cast<uint32_t>(config.perf_telemetry_buffer_address));
+    named_args["PERF_TELEMETRY_BUFFER_ADDR"] = static_cast<uint32_t>(config.perf_telemetry_buffer_address);
 
     // Add code profiling arguments (conditionally enabled)
     if (rtoptions.get_enable_fabric_code_profiling_rx_ch_fwd()) {
         // Enable RECEIVER_CHANNEL_FORWARD timer (bit 0)
         uint32_t code_profiling_enabled_timers =
             static_cast<uint32_t>(CodeProfilingTimerType::RECEIVER_CHANNEL_FORWARD);
-        ct_args.push_back(code_profiling_enabled_timers);
+        named_args["CODE_PROFILING_ENABLED_TIMERS"] = code_profiling_enabled_timers;
 
         // Add code profiling buffer address (16B aligned)
-        ct_args.push_back(static_cast<uint32_t>(config.code_profiling_buffer_address));
+        named_args["CODE_PROFILING_BUFFER_ADDR"] = static_cast<uint32_t>(config.code_profiling_buffer_address);
     } else {
         // Code profiling disabled - add zeros
-        ct_args.push_back(0);  // No timers enabled
-        ct_args.push_back(0);  // No buffer address
+        named_args["CODE_PROFILING_ENABLED_TIMERS"] = 0;
+        named_args["CODE_PROFILING_BUFFER_ADDR"] = 0;
     }
 }
 
@@ -905,7 +907,8 @@ void FabricEriscDatamoverBuilder::get_telemetry_compile_time_args(
  * 8) a receiver channel to pool type mapping is passed as compile time args
  */
 
-FabricEriscDatamoverBuilder::CompileTimeArgs FabricEriscDatamoverBuilder::get_compile_time_args(uint32_t risc_id) const {
+FabricEriscDatamoverBuilder::CompileTimeArgs FabricEriscDatamoverBuilder::get_compile_time_args(
+    uint32_t risc_id) const {
     TT_ASSERT(this->local_fabric_node_id != this->peer_fabric_node_id);
 
     // Tie break policy for selecting the handshake master:
@@ -996,17 +999,7 @@ FabricEriscDatamoverBuilder::CompileTimeArgs FabricEriscDatamoverBuilder::get_co
         sender_channel_to_check);
     TT_FATAL(receiver_channel_num_buffers > 0, "Receiver channel num buffers must be greater than 0");
 
-    const auto& stream_ids = StreamRegAssignments::get_all_stream_ids();
     constexpr bool enable_risc_cpu_data_cache = false;
-    auto ct_args = std::vector<uint32_t>(stream_ids.begin(), stream_ids.end());
-    ct_args.push_back(0xFFEE0001);
-
-    // Maximum channel counts from builder_config
-    ct_args.push_back(builder_config::num_max_sender_channels);
-    ct_args.push_back(builder_config::num_max_receiver_channels);
-
-    // add the downstream tensix connection arg here, num_downstream_tensix_connections
-    ct_args.push_back(this->num_downstream_tensix_connections);
 
     // Compute edge-facing flags for this ethernet core/channel
     const auto [is_intermesh_router_on_edge, is_intramesh_router_on_edge] =
@@ -1019,9 +1012,6 @@ FabricEriscDatamoverBuilder::CompileTimeArgs FabricEriscDatamoverBuilder::get_co
     // Get actual VC1 downstream EDM count from adapter (only relevant for multi-mesh 2D routing)
     uint32_t num_vc1_downstream_edms =
         needs_vc1 ? this->receiver_channel_to_downstream_adapter->get_downstream_edm_count_for_vc(1) : 0;
-    // unsure which one we should prefer at the moment
-    // bool z_routers_enabled = fabric_context.get_builder_context().get_intermesh_vc_config().router_type ==
-    // IntermeshRouterType::Z_INTERMESH;
     bool z_router_enabled = fabric_context.has_z_router_on_device(control_plane, local_fabric_node_id);
 
     log_debug(
@@ -1063,211 +1053,210 @@ FabricEriscDatamoverBuilder::CompileTimeArgs FabricEriscDatamoverBuilder::get_co
     auto actual_sender_channels_vc1 = actual_sender_channels_per_vc_.has_value()
                                           ? actual_sender_channels_per_vc_.value()[1]
                                           : config.num_used_sender_channels_per_vc[1];
-    const std::vector<uint32_t> main_args_part1 = {
-        static_cast<uint32_t>(num_sender_channels),
-        static_cast<uint32_t>(num_receiver_channels),
-        static_cast<uint32_t>(config.num_fwd_paths),
-        num_vc0_downstream_edms,
-        num_vc1_downstream_edms,
-        static_cast<uint32_t>(this->wait_for_host_signal ? 1 : 0),
 
-        static_cast<uint32_t>(this->firmware_context_switch_interval),
-        this->fuse_receiver_flush_and_completion_ptr,
-        fabric_context.need_deadlock_avoidance_support(this->direction_),
-        this->is_inter_mesh,  // Whether this router connects different meshes (determines VC crossover)
-        is_handshake_master,
-        static_cast<uint32_t>(this->handshake_address),
-        static_cast<uint32_t>(this->channel_buffer_size),
-        this->has_tensix_extension,
-        this->enable_first_level_ack,  // VC0 first level ack (for Ring/Torus)
-        false,                         // VC1 first level ack (always false - VC1 doesn't use bubble flow control)
-        enable_risc_cpu_data_cache,
-        z_router_enabled,
-        vc0_downstream_edm_size,  // VC0_DOWNSTREAM_EDM_SIZE: array size for VC0 downstream EDMs
-        vc1_downstream_edm_size,  // VC1_DOWNSTREAM_EDM_SIZE: array size for VC1 downstream EDMs
-        // Actual sender channel counts per VC for this router (may differ from MAX)
-        static_cast<uint32_t>(actual_sender_channels_vc0),   // ACTUAL_VC0_SENDER_CHANNELS
-        static_cast<uint32_t>(actual_sender_channels_vc1)};  // ACTUAL_VC1_SENDER_CHANNELS
-
-    const std::vector<uint32_t> main_args_part2 = {
-        static_cast<uint32_t>(config.sender_channels_worker_conn_info_base_address[0]),
-        static_cast<uint32_t>(config.sender_channels_worker_conn_info_base_address[1]),
-        static_cast<uint32_t>(config.sender_channels_worker_conn_info_base_address[2]),
-        static_cast<uint32_t>(config.sender_channels_worker_conn_info_base_address[3]),
-        static_cast<uint32_t>(config.sender_channels_worker_conn_info_base_address[4]),
-        static_cast<uint32_t>(config.sender_channels_worker_conn_info_base_address[5]),
-        static_cast<uint32_t>(config.sender_channels_worker_conn_info_base_address[6]),
-        static_cast<uint32_t>(config.sender_channels_worker_conn_info_base_address[7]),
-        static_cast<uint32_t>(config.sender_channels_worker_conn_info_base_address[8]),  // 9th channel for Z routers
-
-        static_cast<uint32_t>(this->termination_signal_ptr),
-        static_cast<uint32_t>(this->edm_local_sync_ptr),
-        static_cast<uint32_t>(this->edm_local_tensix_sync_ptr),
-        static_cast<uint32_t>(this->edm_status_ptr),
-
-        static_cast<uint32_t>(config.notify_worker_of_read_counter_update_src_address),
-        0x7a9b3c4d,  // DELETEME Issue #33360 special tag marker to catch incorrect ct args
-
-        this->is_sender_channel_serviced_[risc_id][0],
-        this->is_sender_channel_serviced_[risc_id][1],
-        this->is_sender_channel_serviced_[risc_id][2],
-        this->is_sender_channel_serviced_[risc_id][3],
-        this->is_sender_channel_serviced_[risc_id][4],
-        this->is_sender_channel_serviced_[risc_id][5],
-        this->is_sender_channel_serviced_[risc_id][6],
-        this->is_sender_channel_serviced_[risc_id][7],
-        this->is_sender_channel_serviced_[risc_id][8],  // 9th sender channel for Z routers
-        this->is_receiver_channel_serviced_[risc_id][0],
-        this->is_receiver_channel_serviced_[risc_id][1],
-        config.risc_configs[risc_id].enable_handshake(),
-        config.risc_configs[risc_id].enable_context_switch(),
-        config.risc_configs[risc_id].enable_interrupts(),
-        static_cast<uint32_t>(config.sender_txq_id),
-        static_cast<uint32_t>(config.receiver_txq_id),
-        static_cast<uint32_t>(config.risc_configs[risc_id].iterations_between_ctx_switch_and_teardown_checks()),
-        fabric_context.is_2D_routing_enabled(),
-        this->direction_,
-        soc_desc.get_num_eth_channels(),
-
-        eth_txq_spin_wait_send_next_data,
-        eth_txq_spin_wait_receiver_send_completion_ack,
-        default_num_eth_txq_data_packet_accept_ahead,
-
-        default_handshake_context_switch_timeout,
-        static_cast<uint32_t>(
-            this->firmware_context_switch_type == FabricEriscDatamoverContextSwitchType::WAIT_FOR_IDLE),
-        my_eth_channel_,
-
-        risc_id,
-        static_cast<uint32_t>(this->get_configured_risc_count()),
-
-        update_pkt_hdr_on_rx_ch,
-
-        requires_forced_assignment_to_noc1(),
-        is_intermesh_router_on_edge,
-        is_intramesh_router_on_edge,
-
-        // Special marker to help with identifying misalignment bugs
-        0x00c0ffee};
-
-    // Add first part of main arguments to ct_args
-    ct_args.insert(ct_args.end(), main_args_part1.begin(), main_args_part1.end());
-
-    // Conditionally add remote channel info when skip_src_ch_id_update is true
-    // (these values are used to initialize src channel IDs once, rather than updating them dynamically)
-    if (skip_src_ch_id_update) {
-        ct_args.push_back(remote_worker_sender_channel);
-    }
-
-    // Add UDM mode flag and relay buffer count
-    ct_args.push_back(this->udm_mode ? 1 : 0);
-    if (this->udm_mode) {
-        ct_args.push_back(this->local_tensix_relay_num_buffers);
-    }
-
-    // special tag
-    ct_args.push_back(0xabcd9876);
-
-    // Emit pool data via multi-pool coordinator (steps 1-4 of schema: special tag, num_pools, pool_types, individual
-    // pool CT args)
-    config.multi_pool_allocator->emit_ct_args(
-        ct_args, actual_sender_channels_vc0, actual_sender_channels_vc1, num_receiver_channels);
-
-    // Emit channel-to-pool mappings (steps 5-8 of schema)
-    ct_args.push_back(0xabaddad8);
-    config.channel_to_pool_mapping->emit_ct_args(ct_args);
-
-    // Emit remote channel pool data (for remote_receiver_channels initialization)
-    // Create a multi-pool for remote channels, following the same pattern as local channels
-    ct_args.push_back(0xabaddad6);
-
-    // Create remote multi-pool allocator with the remote channels allocator
-    TT_FATAL(config.remote_channels_allocator != nullptr, "Remote channels allocator must be non-null");
-    MultiPoolChannelAllocator remote_multi_pool_allocator(
-        {config.remote_channels_allocator}, {FabricChannelPoolType::STATIC});
-
-    // Emit remote channel pool data via multi-pool coordinator
-    remote_multi_pool_allocator.emit_ct_args(ct_args, 0, 0, num_receiver_channels);
-
-    config.remote_channel_to_pool_mapping->emit_ct_args(ct_args);
-
-    ct_args.push_back(0xabaddad7);
-    receiver_channel_to_downstream_adapter->emit_ct_args(ct_args, config.num_fwd_paths);
-    ct_args.push_back(0xabaddad9);
-
-    // Add second part of main arguments to ct_args
-    ct_args.insert(ct_args.end(), main_args_part2.begin(), main_args_part2.end());
-
-    for (size_t i = 0; i < num_sender_channels; i++) {
-        ct_args.push_back(this->sender_channel_connection_liveness_check_disable_array[i]);
-    }
-
-    for (size_t i = 0; i < num_sender_channels; i++) {
-        ct_args.push_back(this->sender_channel_is_traffic_injection_channel_array.at(i));
-    }
-
-    // Sender channel args
-    for (size_t i = 0; i < num_sender_channels; i++) {
-        ct_args.push_back(config.sender_channel_ack_noc_ids[i]);
-    }
-
-    // Populate the sender ack cmd buf ids for each datapath
-    for (size_t i = 0; i < num_sender_channels; i++) {
-        ct_args.push_back(config.sender_channel_ack_cmd_buf_ids[i]);
-    }
-
-    for (size_t i = 0; i < num_receiver_channels; i++) {
-        ct_args.push_back(config.receiver_channel_forwarding_noc_ids[i]);
-    }
-    for (size_t i = 0; i < num_receiver_channels; i++) {
-        ct_args.push_back(
-            config.receiver_channel_forwarding_data_cmd_buf_ids[i]);  // maps to
-                                                                      // receiver_channel_forwarding_data_cmd_buf_ids
-    }
-    for (size_t i = 0; i < num_receiver_channels; i++) {
-        ct_args.push_back(
-            config.receiver_channel_forwarding_sync_cmd_buf_ids[i]);  // maps to
-                                                                      // receiver_channel_forwarding_sync_cmd_buf_ids
-    }
-    for (size_t i = 0; i < num_receiver_channels; i++) {
-        // TODO: pass this to the tranmission file
-        ct_args.push_back(
-            config.receiver_channel_local_write_noc_ids[i]);  // maps to receiver_channel_local_write_noc_ids
-    }
-    for (size_t i = 0; i < num_receiver_channels; i++) {
-        ct_args.push_back(
-            config.receiver_channel_local_write_cmd_buf_ids[i]);  // maps to receiver_channel_local_write_cmd_buf_ids
-    }
-    ct_args.push_back(config.edm_noc_vc);
-
-    // Special marker to help with identifying misalignment bugs
-    ct_args.push_back(0x10c0ffee);
-
-    get_telemetry_compile_time_args(risc_id, ct_args);
-
-    // Special marker 2
-    ct_args.push_back(0x20c0ffee);
-
-    bool multi_txq_enabled = config.sender_txq_id != config.receiver_txq_id;
-    if (multi_txq_enabled) {
-        ct_args.push_back(config.to_sender_channel_remote_ack_counters_base_addr);
-        ct_args.push_back(config.to_sender_channel_remote_completion_counters_base_addr);
-        ct_args.push_back(config.receiver_channel_remote_ack_counters_base_addr);
-        ct_args.push_back(config.receiver_channel_remote_completion_counters_base_addr);
-    }
-
-    ct_args.push_back(0x30c0ffee);
-
-    // Build named compile-time args for channel trimming capture
+    // ===== Build named compile-time args (all non-pool/channel-mapping args) =====
     std::unordered_map<std::string, uint32_t> named_args;
+
+    // --- Stream IDs ---
+    const auto& stream_ids = StreamRegAssignments::get_all_stream_ids();
+    named_args["TO_RECEIVER_0_PKTS_SENT_ID"] = stream_ids[0];
+    named_args["TO_RECEIVER_1_PKTS_SENT_ID"] = stream_ids[1];
+    named_args["TO_SENDER_0_PKTS_ACKED_ID"] = stream_ids[2];
+    named_args["TO_SENDER_1_PKTS_ACKED_ID"] = stream_ids[3];
+    named_args["TO_SENDER_2_PKTS_ACKED_ID"] = stream_ids[4];
+    named_args["TO_SENDER_3_PKTS_ACKED_ID"] = stream_ids[5];
+    named_args["TO_SENDER_0_PKTS_COMPLETED_ID"] = stream_ids[6];
+    named_args["TO_SENDER_1_PKTS_COMPLETED_ID"] = stream_ids[7];
+    named_args["TO_SENDER_2_PKTS_COMPLETED_ID"] = stream_ids[8];
+    named_args["TO_SENDER_3_PKTS_COMPLETED_ID"] = stream_ids[9];
+    named_args["TO_SENDER_4_PKTS_COMPLETED_ID"] = stream_ids[10];
+    named_args["TO_SENDER_5_PKTS_COMPLETED_ID"] = stream_ids[11];
+    named_args["TO_SENDER_6_PKTS_COMPLETED_ID"] = stream_ids[12];
+    named_args["TO_SENDER_7_PKTS_COMPLETED_ID"] = stream_ids[13];
+    named_args["VC0_FREE_SLOTS_FROM_DOWNSTREAM_EDGE_1_STREAM_ID"] = stream_ids[14];
+    named_args["VC0_FREE_SLOTS_FROM_DOWNSTREAM_EDGE_2_STREAM_ID"] = stream_ids[15];
+    named_args["VC0_FREE_SLOTS_FROM_DOWNSTREAM_EDGE_3_STREAM_ID"] = stream_ids[16];
+    named_args["VC0_FREE_SLOTS_FROM_DOWNSTREAM_EDGE_4_STREAM_ID"] = stream_ids[17];
+    named_args["VC1_FREE_SLOTS_FROM_DOWNSTREAM_EDGE_1_STREAM_ID"] = stream_ids[18];
+    named_args["VC1_FREE_SLOTS_FROM_DOWNSTREAM_EDGE_2_STREAM_ID"] = stream_ids[19];
+    named_args["VC1_FREE_SLOTS_FROM_DOWNSTREAM_EDGE_3_STREAM_ID"] = stream_ids[20];
+    named_args["VC1_FREE_SLOTS_FROM_DOWNSTREAM_EDGE_4_STREAM_ID"] = stream_ids[21];
+    named_args["SENDER_CHANNEL_0_FREE_SLOTS_STREAM_ID"] = stream_ids[22];
+    named_args["SENDER_CHANNEL_1_FREE_SLOTS_STREAM_ID"] = stream_ids[23];
+    named_args["SENDER_CHANNEL_2_FREE_SLOTS_STREAM_ID"] = stream_ids[24];
+    named_args["SENDER_CHANNEL_3_FREE_SLOTS_STREAM_ID"] = stream_ids[25];
+    named_args["SENDER_CHANNEL_4_FREE_SLOTS_STREAM_ID"] = stream_ids[26];
+    named_args["SENDER_CHANNEL_5_FREE_SLOTS_STREAM_ID"] = stream_ids[27];
+    named_args["SENDER_CHANNEL_6_FREE_SLOTS_STREAM_ID"] = stream_ids[28];
+    named_args["SENDER_CHANNEL_7_FREE_SLOTS_STREAM_ID"] = stream_ids[29];
+    named_args["TENSIX_RELAY_LOCAL_FREE_SLOTS_STREAM_ID"] = stream_ids[30];
+    named_args["MULTI_RISC_TEARDOWN_SYNC_STREAM_ID"] = stream_ids[31];
+    named_args["ETH_RETRAIN_LINK_SYNC_STREAM_ID"] = stream_ids[32];
+
+    // --- Max channel counts ---
+    named_args["MAX_NUM_SENDER_CHANNELS"] = builder_config::num_max_sender_channels;
+    named_args["MAX_NUM_RECEIVER_CHANNELS"] = builder_config::num_max_receiver_channels;
+
+    // --- Downstream tensix connections ---
+    named_args["NUM_DS_OR_LOCAL_TENSIX_CONNECTIONS"] = this->num_downstream_tensix_connections;
+
+    // --- Main configuration args ---
+    named_args["NUM_SENDER_CHANNELS"] = static_cast<uint32_t>(num_sender_channels);
+    named_args["NUM_RECEIVER_CHANNELS"] = static_cast<uint32_t>(num_receiver_channels);
+    named_args["NUM_DOWNSTREAM_CHANNELS"] = static_cast<uint32_t>(config.num_fwd_paths);
+    named_args["NUM_DOWNSTREAM_SENDERS_VC0"] = num_vc0_downstream_edms;
+    named_args["NUM_DOWNSTREAM_SENDERS_VC1"] = num_vc1_downstream_edms;
+    named_args["WAIT_FOR_HOST_SIGNAL"] = static_cast<uint32_t>(this->wait_for_host_signal ? 1 : 0);
+    named_args["SWITCH_INTERVAL"] = static_cast<uint32_t>(this->firmware_context_switch_interval);
+    named_args["FUSE_RECEIVER_FLUSH_AND_COMPLETION_PTR"] = this->fuse_receiver_flush_and_completion_ptr;
+    named_args["ENABLE_DEADLOCK_AVOIDANCE"] = fabric_context.need_deadlock_avoidance_support(this->direction_);
+    named_args["IS_INTERMESH_ROUTER"] = this->is_inter_mesh;
+    named_args["IS_HANDSHAKE_SENDER"] = is_handshake_master;
+    named_args["HANDSHAKE_ADDR"] = static_cast<uint32_t>(this->handshake_address);
+    named_args["CHANNEL_BUFFER_SIZE"] = static_cast<uint32_t>(this->channel_buffer_size);
+    named_args["FABRIC_TENSIX_EXTENSION_MUX_MODE"] = this->has_tensix_extension;
+    named_args["ENABLE_FIRST_LEVEL_ACK_VC0"] = this->enable_first_level_ack;
+    named_args["ENABLE_FIRST_LEVEL_ACK_VC1"] = 0;  // VC1 does not use bubble flow control
+    named_args["ENABLE_RISC_CPU_DATA_CACHE"] = enable_risc_cpu_data_cache;
+    named_args["Z_ROUTER_ENABLED"] = z_router_enabled;
+    named_args["VC0_DOWNSTREAM_EDM_SIZE"] = vc0_downstream_edm_size;
+    named_args["VC1_DOWNSTREAM_EDM_SIZE"] = vc1_downstream_edm_size;
+    named_args["ACTUAL_VC0_SENDER_CHANNELS"] = static_cast<uint32_t>(actual_sender_channels_vc0);
+    named_args["ACTUAL_VC1_SENDER_CHANNELS"] = static_cast<uint32_t>(actual_sender_channels_vc1);
+
+    // --- Remote channel info (always emitted; 0 when inactive) ---
+    named_args["SKIP_SRC_CH_ID_UPDATE"] = skip_src_ch_id_update ? 1 : 0;
+    named_args["REMOTE_WORKER_SENDER_CHANNEL"] = remote_worker_sender_channel;
+
+    // --- UDM mode (always emitted; 0 when inactive) ---
+    named_args["UDM_MODE"] = this->udm_mode ? 1 : 0;
+    named_args["LOCAL_RELAY_NUM_BUFFERS"] = this->udm_mode ? this->local_tensix_relay_num_buffers : 0;
+
+    // --- Sender channel connection info addresses (always emit MAX entries) ---
+    for (size_t i = 0; i < builder_config::num_max_sender_channels; i++) {
+        named_args["LOCAL_SENDER_CH_CONN_INFO_ADDR_" + std::to_string(i)] =
+            static_cast<uint32_t>(config.sender_channels_worker_conn_info_base_address[i]);
+    }
+
+    // --- Status pointers ---
+    named_args["TERMINATION_SIGNAL_ADDR"] = static_cast<uint32_t>(this->termination_signal_ptr);
+    named_args["EDM_LOCAL_SYNC_PTR_ADDR"] = static_cast<uint32_t>(this->edm_local_sync_ptr);
+    named_args["EDM_LOCAL_TENSIX_SYNC_PTR_ADDR"] = static_cast<uint32_t>(this->edm_local_tensix_sync_ptr);
+    named_args["EDM_STATUS_PTR_ADDR"] = static_cast<uint32_t>(this->edm_status_ptr);
+    named_args["NOTIFY_WORKER_OF_READ_COUNTER_UPDATE_SRC_ADDR"] =
+        static_cast<uint32_t>(config.notify_worker_of_read_counter_update_src_address);
+
+    // --- Channel servicing flags (always emit MAX entries) ---
+    for (size_t i = 0; i < builder_config::num_max_sender_channels; i++) {
+        named_args["IS_SENDER_CHANNEL_SERVICED_" + std::to_string(i)] =
+            static_cast<uint32_t>(this->is_sender_channel_serviced_[risc_id][i]);
+    }
+    for (size_t i = 0; i < builder_config::num_max_receiver_channels; i++) {
+        named_args["IS_RECEIVER_CHANNEL_SERVICED_" + std::to_string(i)] =
+            static_cast<uint32_t>(this->is_receiver_channel_serviced_[risc_id][i]);
+    }
+
+    // --- RISC configuration ---
+    named_args["ENABLE_ETHERNET_HANDSHAKE"] = config.risc_configs[risc_id].enable_handshake();
+    named_args["ENABLE_CONTEXT_SWITCH"] = config.risc_configs[risc_id].enable_context_switch();
+    named_args["ENABLE_INTERRUPTS"] = config.risc_configs[risc_id].enable_interrupts();
+    named_args["SENDER_TXQ_ID"] = static_cast<uint32_t>(config.sender_txq_id);
+    named_args["RECEIVER_TXQ_ID"] = static_cast<uint32_t>(config.receiver_txq_id);
+    named_args["ITERATIONS_BETWEEN_CTX_SWITCH_AND_TEARDOWN_CHECKS"] =
+        static_cast<uint32_t>(config.risc_configs[risc_id].iterations_between_ctx_switch_and_teardown_checks());
+    named_args["IS_2D_FABRIC"] = fabric_context.is_2D_routing_enabled();
+    named_args["MY_DIRECTION"] = this->direction_;
+    named_args["NUM_ETH_PORTS"] = soc_desc.get_num_eth_channels();
+
+    // --- ETH TXQ configuration ---
+    named_args["ETH_TXQ_SPIN_WAIT_SEND_NEXT_DATA"] = eth_txq_spin_wait_send_next_data;
+    named_args["ETH_TXQ_SPIN_WAIT_RECEIVER_SEND_COMPLETION_ACK"] = eth_txq_spin_wait_receiver_send_completion_ack;
+    named_args["DEFAULT_NUM_ETH_TXQ_DATA_PACKET_ACCEPT_AHEAD"] = default_num_eth_txq_data_packet_accept_ahead;
+    named_args["DEFAULT_HANDSHAKE_CONTEXT_SWITCH_TIMEOUT"] = default_handshake_context_switch_timeout;
+    named_args["IDLE_CONTEXT_SWITCHING"] = static_cast<uint32_t>(
+        this->firmware_context_switch_type == FabricEriscDatamoverContextSwitchType::WAIT_FOR_IDLE);
+    named_args["MY_ETH_CHANNEL"] = my_eth_channel_;
+    named_args["MY_ERISC_ID"] = risc_id;
+    named_args["NUM_ACTIVE_ERISCS"] = static_cast<uint32_t>(this->get_configured_risc_count());
+    named_args["UPDATE_PKT_HDR_ON_RX_CH"] = update_pkt_hdr_on_rx_ch;
+    named_args["FORCE_ALL_PATHS_TO_USE_SAME_NOC"] = requires_forced_assignment_to_noc1();
+    named_args["IS_INTERMESH_ROUTER_ON_EDGE"] = is_intermesh_router_on_edge;
+    named_args["IS_INTRAMESH_ROUTER_ON_EDGE"] = is_intramesh_router_on_edge;
+
+    // --- Sender channel per-channel arrays (always emit MAX entries; 0 for unused) ---
+    for (size_t i = 0; i < builder_config::num_max_sender_channels; i++) {
+        named_args["SENDER_CH_LIVE_CHECK_SKIP_" + std::to_string(i)] =
+            (i < num_sender_channels)
+                ? static_cast<uint32_t>(this->sender_channel_connection_liveness_check_disable_array[i])
+                : 0;
+    }
+    for (size_t i = 0; i < builder_config::num_max_sender_channels; i++) {
+        named_args["SENDER_CH_IS_INJECTION_" + std::to_string(i)] =
+            (i < num_sender_channels)
+                ? static_cast<uint32_t>(this->sender_channel_is_traffic_injection_channel_array.at(i))
+                : 0;
+    }
+    for (size_t i = 0; i < builder_config::num_max_sender_channels; i++) {
+        named_args["SENDER_CH_ACK_NOC_ID_" + std::to_string(i)] =
+            (i < num_sender_channels) ? static_cast<uint32_t>(config.sender_channel_ack_noc_ids[i]) : 0;
+    }
+    for (size_t i = 0; i < builder_config::num_max_sender_channels; i++) {
+        named_args["SENDER_CH_ACK_CMD_BUF_ID_" + std::to_string(i)] =
+            (i < num_sender_channels) ? static_cast<uint32_t>(config.sender_channel_ack_cmd_buf_ids[i]) : 0;
+    }
+
+    // --- Receiver channel per-channel arrays (always emit MAX entries; 0 for unused) ---
+    for (size_t i = 0; i < builder_config::num_max_receiver_channels; i++) {
+        named_args["RX_CH_FWD_NOC_ID_" + std::to_string(i)] =
+            (i < num_receiver_channels) ? static_cast<uint32_t>(config.receiver_channel_forwarding_noc_ids[i]) : 0;
+    }
+    for (size_t i = 0; i < builder_config::num_max_receiver_channels; i++) {
+        named_args["RX_CH_FWD_DATA_CMD_BUF_ID_" + std::to_string(i)] =
+            (i < num_receiver_channels) ? static_cast<uint32_t>(config.receiver_channel_forwarding_data_cmd_buf_ids[i])
+                                        : 0;
+    }
+    for (size_t i = 0; i < builder_config::num_max_receiver_channels; i++) {
+        named_args["RX_CH_FWD_SYNC_CMD_BUF_ID_" + std::to_string(i)] =
+            (i < num_receiver_channels) ? static_cast<uint32_t>(config.receiver_channel_forwarding_sync_cmd_buf_ids[i])
+                                        : 0;
+    }
+    for (size_t i = 0; i < builder_config::num_max_receiver_channels; i++) {
+        named_args["RX_CH_LOCAL_WRITE_NOC_ID_" + std::to_string(i)] =
+            (i < num_receiver_channels) ? static_cast<uint32_t>(config.receiver_channel_local_write_noc_ids[i]) : 0;
+    }
+    for (size_t i = 0; i < builder_config::num_max_receiver_channels; i++) {
+        named_args["RX_CH_LOCAL_WRITE_CMD_BUF_ID_" + std::to_string(i)] =
+            (i < num_receiver_channels) ? static_cast<uint32_t>(config.receiver_channel_local_write_cmd_buf_ids[i]) : 0;
+    }
+    named_args["EDM_NOC_VC"] = config.edm_noc_vc;
+
+    // --- Telemetry ---
+    get_telemetry_compile_time_args(risc_id, named_args);
+
+    // --- Multi-TXQ credit counters (always emitted; 0 when inactive) ---
+    bool multi_txq_enabled = config.sender_txq_id != config.receiver_txq_id;
+    named_args["TO_SENDER_REMOTE_ACK_COUNTERS_BASE_ADDR"] =
+        multi_txq_enabled ? static_cast<uint32_t>(config.to_sender_channel_remote_ack_counters_base_addr) : 0;
+    named_args["TO_SENDER_REMOTE_COMPLETION_COUNTERS_BASE_ADDR"] =
+        multi_txq_enabled ? static_cast<uint32_t>(config.to_sender_channel_remote_completion_counters_base_addr) : 0;
+    named_args["LOCAL_RECEIVER_ACK_COUNTERS_BASE_ADDR"] =
+        multi_txq_enabled ? static_cast<uint32_t>(config.receiver_channel_remote_ack_counters_base_addr) : 0;
+    named_args["LOCAL_RECEIVER_COMPLETION_COUNTERS_BASE_ADDR"] =
+        multi_txq_enabled ? static_cast<uint32_t>(config.receiver_channel_remote_completion_counters_base_addr) : 0;
+
+    // --- Host signal args (defaults; compute_mesh_router_builder overrides when wait_for_host_signal) ---
+    named_args["IS_LOCAL_HANDSHAKE_MASTER"] = 0;
+    named_args["LOCAL_HANDSHAKE_MASTER_ETH_CHAN"] = 0;
+    named_args["NUM_LOCAL_EDMS"] = 0;
+    named_args["EDM_CHANNELS_MASK"] = 0;
+
+    // --- Channel trimming (named args) ---
     bool enable_capture = config.datapath_usage_l1_address != 0;
     named_args["ENABLE_CHANNEL_TRIMMING_RESOURCE_USAGE_CAPTURE"] = enable_capture ? 1 : 0;
     if (enable_capture) {
         named_args["RESOURCE_USAGE_CAPTURE_OUTPUT_L1_ADDRESS"] =
             static_cast<uint32_t>(config.datapath_usage_l1_address);
     }
-
-    // Named compile-time args for channel trimming profile import (RX forwarding disable)
     if (channel_trimming_overrides_.has_value()) {
         named_args["DISABLE_RX_CH0_FORWARDING"] =
             channel_trimming_overrides_->is_receiver_channel_data_forwarded(0) ? 0 : 1;
@@ -1294,6 +1283,31 @@ FabricEriscDatamoverBuilder::CompileTimeArgs FabricEriscDatamoverBuilder::get_co
     }
     named_args["SENDER_CREDIT_AMORTIZATION_FREQUENCY"] = sender_amort_freq;
     named_args["RECEIVER_CREDIT_AMORTIZATION_FREQUENCY"] = receiver_amort_freq;
+
+    // ===== Build positional args (pool/channel-mapping/downstream data only) =====
+    // Pool data now starts at index 0 in the positional vector.
+    std::vector<uint32_t> ct_args;
+
+    // Emit pool data via multi-pool coordinator
+    config.multi_pool_allocator->emit_ct_args(
+        ct_args, actual_sender_channels_vc0, actual_sender_channels_vc1, num_receiver_channels);
+
+    // Emit channel-to-pool mappings
+    ct_args.push_back(0xabaddad8);
+    config.channel_to_pool_mapping->emit_ct_args(ct_args);
+
+    // Emit remote channel pool data (for remote_receiver_channels initialization)
+    ct_args.push_back(0xabaddad6);
+    TT_FATAL(config.remote_channels_allocator != nullptr, "Remote channels allocator must be non-null");
+    MultiPoolChannelAllocator remote_multi_pool_allocator(
+        {config.remote_channels_allocator}, {FabricChannelPoolType::STATIC});
+    remote_multi_pool_allocator.emit_ct_args(ct_args, 0, 0, num_receiver_channels);
+    config.remote_channel_to_pool_mapping->emit_ct_args(ct_args);
+
+    // Downstream sender data
+    ct_args.push_back(0xabaddad7);
+    receiver_channel_to_downstream_adapter->emit_ct_args(ct_args, config.num_fwd_paths);
+    ct_args.push_back(0xabaddad9);
 
     return {std::move(ct_args), std::move(named_args)};
 }

--- a/tt_metal/fabric/erisc_datamover_builder.cpp
+++ b/tt_metal/fabric/erisc_datamover_builder.cpp
@@ -25,6 +25,7 @@
 #include <optional>
 #include <unordered_set>
 #include <vector>
+#include <fmt/format.h>
 
 #include "tt_metal/fabric/builder/fabric_static_sized_channels_allocator.hpp"
 #include "tt_metal/fabric/builder/fabric_remote_channels_allocator.hpp"
@@ -1134,7 +1135,7 @@ FabricEriscDatamoverBuilder::CompileTimeArgs FabricEriscDatamoverBuilder::get_co
 
     // --- Sender channel connection info addresses (always emit MAX entries) ---
     for (size_t i = 0; i < builder_config::num_max_sender_channels; i++) {
-        named_args["LOCAL_SENDER_CH_CONN_INFO_ADDR_" + std::to_string(i)] =
+        named_args[fmt::format("LOCAL_SENDER_CH_{}_CONN_INFO_ADDR", i)] =
             static_cast<uint32_t>(config.sender_channels_worker_conn_info_base_address[i]);
     }
 
@@ -1148,11 +1149,11 @@ FabricEriscDatamoverBuilder::CompileTimeArgs FabricEriscDatamoverBuilder::get_co
 
     // --- Channel servicing flags (always emit MAX entries) ---
     for (size_t i = 0; i < builder_config::num_max_sender_channels; i++) {
-        named_args["IS_SENDER_CHANNEL_SERVICED_" + std::to_string(i)] =
+        named_args[fmt::format("IS_SENDER_CHANNEL_{}_SERVICED", i)] =
             static_cast<uint32_t>(this->is_sender_channel_serviced_[risc_id][i]);
     }
     for (size_t i = 0; i < builder_config::num_max_receiver_channels; i++) {
-        named_args["IS_RECEIVER_CHANNEL_SERVICED_" + std::to_string(i)] =
+        named_args[fmt::format("IS_RECEIVER_CHANNEL_{}_SERVICED", i)] =
             static_cast<uint32_t>(this->is_receiver_channel_serviced_[risc_id][i]);
     }
 
@@ -1185,47 +1186,47 @@ FabricEriscDatamoverBuilder::CompileTimeArgs FabricEriscDatamoverBuilder::get_co
 
     // --- Sender channel per-channel arrays (always emit MAX entries; 0 for unused) ---
     for (size_t i = 0; i < builder_config::num_max_sender_channels; i++) {
-        named_args["SENDER_CH_LIVE_CHECK_SKIP_" + std::to_string(i)] =
+        named_args[fmt::format("SENDER_CH_{}_LIVE_CHECK_SKIP", i)] =
             (i < num_sender_channels)
                 ? static_cast<uint32_t>(this->sender_channel_connection_liveness_check_disable_array[i])
                 : 0;
     }
     for (size_t i = 0; i < builder_config::num_max_sender_channels; i++) {
-        named_args["SENDER_CH_IS_INJECTION_" + std::to_string(i)] =
+        named_args[fmt::format("SENDER_CH_{}_IS_INJECTION", i)] =
             (i < num_sender_channels)
                 ? static_cast<uint32_t>(this->sender_channel_is_traffic_injection_channel_array.at(i))
                 : 0;
     }
     for (size_t i = 0; i < builder_config::num_max_sender_channels; i++) {
-        named_args["SENDER_CH_ACK_NOC_ID_" + std::to_string(i)] =
+        named_args[fmt::format("SENDER_CH_{}_ACK_NOC_ID", i)] =
             (i < num_sender_channels) ? static_cast<uint32_t>(config.sender_channel_ack_noc_ids[i]) : 0;
     }
     for (size_t i = 0; i < builder_config::num_max_sender_channels; i++) {
-        named_args["SENDER_CH_ACK_CMD_BUF_ID_" + std::to_string(i)] =
+        named_args[fmt::format("SENDER_CH_{}_ACK_CMD_BUF_ID", i)] =
             (i < num_sender_channels) ? static_cast<uint32_t>(config.sender_channel_ack_cmd_buf_ids[i]) : 0;
     }
 
     // --- Receiver channel per-channel arrays (always emit MAX entries; 0 for unused) ---
     for (size_t i = 0; i < builder_config::num_max_receiver_channels; i++) {
-        named_args["RX_CH_FWD_NOC_ID_" + std::to_string(i)] =
+        named_args[fmt::format("RX_CH_{}_FWD_NOC_ID", i)] =
             (i < num_receiver_channels) ? static_cast<uint32_t>(config.receiver_channel_forwarding_noc_ids[i]) : 0;
     }
     for (size_t i = 0; i < builder_config::num_max_receiver_channels; i++) {
-        named_args["RX_CH_FWD_DATA_CMD_BUF_ID_" + std::to_string(i)] =
+        named_args[fmt::format("RX_CH_{}_FWD_DATA_CMD_BUF_ID", i)] =
             (i < num_receiver_channels) ? static_cast<uint32_t>(config.receiver_channel_forwarding_data_cmd_buf_ids[i])
                                         : 0;
     }
     for (size_t i = 0; i < builder_config::num_max_receiver_channels; i++) {
-        named_args["RX_CH_FWD_SYNC_CMD_BUF_ID_" + std::to_string(i)] =
+        named_args[fmt::format("RX_CH_{}_FWD_SYNC_CMD_BUF_ID", i)] =
             (i < num_receiver_channels) ? static_cast<uint32_t>(config.receiver_channel_forwarding_sync_cmd_buf_ids[i])
                                         : 0;
     }
     for (size_t i = 0; i < builder_config::num_max_receiver_channels; i++) {
-        named_args["RX_CH_LOCAL_WRITE_NOC_ID_" + std::to_string(i)] =
+        named_args[fmt::format("RX_CH_{}_LOCAL_WRITE_NOC_ID", i)] =
             (i < num_receiver_channels) ? static_cast<uint32_t>(config.receiver_channel_local_write_noc_ids[i]) : 0;
     }
     for (size_t i = 0; i < builder_config::num_max_receiver_channels; i++) {
-        named_args["RX_CH_LOCAL_WRITE_CMD_BUF_ID_" + std::to_string(i)] =
+        named_args[fmt::format("RX_CH_{}_LOCAL_WRITE_CMD_BUF_ID", i)] =
             (i < num_receiver_channels) ? static_cast<uint32_t>(config.receiver_channel_local_write_cmd_buf_ids[i]) : 0;
     }
     named_args["EDM_NOC_VC"] = config.edm_noc_vc;

--- a/tt_metal/fabric/erisc_datamover_builder.hpp
+++ b/tt_metal/fabric/erisc_datamover_builder.hpp
@@ -541,7 +541,7 @@ public:
     [[nodiscard]] CompileTimeArgs get_compile_time_args(uint32_t risc_id) const;
 
     // Helper for `get_compile_time_args`
-    void get_telemetry_compile_time_args(uint32_t risc_id, std::vector<uint32_t>& ct_args) const;
+    void get_telemetry_compile_time_args(uint32_t risc_id, std::unordered_map<std::string, uint32_t>& named_args) const;
 
     [[nodiscard]] std::vector<uint32_t> get_runtime_args() const;
 

--- a/tt_metal/fabric/hw/inc/edm_fabric/fabric_erisc_router_ct_args.hpp
+++ b/tt_metal/fabric/hw/inc/edm_fabric/fabric_erisc_router_ct_args.hpp
@@ -252,15 +252,15 @@ static_assert(
 // ============================================================================
 // Sender channel connection info addresses (named args)
 // ============================================================================
-constexpr size_t local_sender_channel_0_connection_info_addr = NAMED_CT_ARG("LOCAL_SENDER_CH_CONN_INFO_ADDR_0");
-constexpr size_t local_sender_channel_1_connection_info_addr = NAMED_CT_ARG("LOCAL_SENDER_CH_CONN_INFO_ADDR_1");
-constexpr size_t local_sender_channel_2_connection_info_addr = NAMED_CT_ARG("LOCAL_SENDER_CH_CONN_INFO_ADDR_2");
-constexpr size_t local_sender_channel_3_connection_info_addr = NAMED_CT_ARG("LOCAL_SENDER_CH_CONN_INFO_ADDR_3");
-constexpr size_t local_sender_channel_4_connection_info_addr = NAMED_CT_ARG("LOCAL_SENDER_CH_CONN_INFO_ADDR_4");
-constexpr size_t local_sender_channel_5_connection_info_addr = NAMED_CT_ARG("LOCAL_SENDER_CH_CONN_INFO_ADDR_5");
-constexpr size_t local_sender_channel_6_connection_info_addr = NAMED_CT_ARG("LOCAL_SENDER_CH_CONN_INFO_ADDR_6");
-constexpr size_t local_sender_channel_7_connection_info_addr = NAMED_CT_ARG("LOCAL_SENDER_CH_CONN_INFO_ADDR_7");
-constexpr size_t local_sender_channel_8_connection_info_addr = NAMED_CT_ARG("LOCAL_SENDER_CH_CONN_INFO_ADDR_8");
+constexpr size_t local_sender_channel_0_connection_info_addr = NAMED_CT_ARG("LOCAL_SENDER_CH_0_CONN_INFO_ADDR");
+constexpr size_t local_sender_channel_1_connection_info_addr = NAMED_CT_ARG("LOCAL_SENDER_CH_1_CONN_INFO_ADDR");
+constexpr size_t local_sender_channel_2_connection_info_addr = NAMED_CT_ARG("LOCAL_SENDER_CH_2_CONN_INFO_ADDR");
+constexpr size_t local_sender_channel_3_connection_info_addr = NAMED_CT_ARG("LOCAL_SENDER_CH_3_CONN_INFO_ADDR");
+constexpr size_t local_sender_channel_4_connection_info_addr = NAMED_CT_ARG("LOCAL_SENDER_CH_4_CONN_INFO_ADDR");
+constexpr size_t local_sender_channel_5_connection_info_addr = NAMED_CT_ARG("LOCAL_SENDER_CH_5_CONN_INFO_ADDR");
+constexpr size_t local_sender_channel_6_connection_info_addr = NAMED_CT_ARG("LOCAL_SENDER_CH_6_CONN_INFO_ADDR");
+constexpr size_t local_sender_channel_7_connection_info_addr = NAMED_CT_ARG("LOCAL_SENDER_CH_7_CONN_INFO_ADDR");
+constexpr size_t local_sender_channel_8_connection_info_addr = NAMED_CT_ARG("LOCAL_SENDER_CH_8_CONN_INFO_ADDR");
 
 // ============================================================================
 // Status pointers
@@ -281,19 +281,19 @@ constexpr uint32_t notify_worker_of_read_counter_update_src_address =
 // Channel servicing flags
 // ============================================================================
 constexpr std::array<bool, MAX_NUM_SENDER_CHANNELS> is_sender_channel_serviced = {
-    static_cast<bool>(NAMED_CT_ARG("IS_SENDER_CHANNEL_SERVICED_0")),
-    static_cast<bool>(NAMED_CT_ARG("IS_SENDER_CHANNEL_SERVICED_1")),
-    static_cast<bool>(NAMED_CT_ARG("IS_SENDER_CHANNEL_SERVICED_2")),
-    static_cast<bool>(NAMED_CT_ARG("IS_SENDER_CHANNEL_SERVICED_3")),
-    static_cast<bool>(NAMED_CT_ARG("IS_SENDER_CHANNEL_SERVICED_4")),
-    static_cast<bool>(NAMED_CT_ARG("IS_SENDER_CHANNEL_SERVICED_5")),
-    static_cast<bool>(NAMED_CT_ARG("IS_SENDER_CHANNEL_SERVICED_6")),
-    static_cast<bool>(NAMED_CT_ARG("IS_SENDER_CHANNEL_SERVICED_7")),
-    static_cast<bool>(NAMED_CT_ARG("IS_SENDER_CHANNEL_SERVICED_8")),
+    static_cast<bool>(NAMED_CT_ARG("IS_SENDER_CHANNEL_0_SERVICED")),
+    static_cast<bool>(NAMED_CT_ARG("IS_SENDER_CHANNEL_1_SERVICED")),
+    static_cast<bool>(NAMED_CT_ARG("IS_SENDER_CHANNEL_2_SERVICED")),
+    static_cast<bool>(NAMED_CT_ARG("IS_SENDER_CHANNEL_3_SERVICED")),
+    static_cast<bool>(NAMED_CT_ARG("IS_SENDER_CHANNEL_4_SERVICED")),
+    static_cast<bool>(NAMED_CT_ARG("IS_SENDER_CHANNEL_5_SERVICED")),
+    static_cast<bool>(NAMED_CT_ARG("IS_SENDER_CHANNEL_6_SERVICED")),
+    static_cast<bool>(NAMED_CT_ARG("IS_SENDER_CHANNEL_7_SERVICED")),
+    static_cast<bool>(NAMED_CT_ARG("IS_SENDER_CHANNEL_8_SERVICED")),
 };
 constexpr std::array<bool, MAX_NUM_RECEIVER_CHANNELS> is_receiver_channel_serviced = {
-    static_cast<bool>(NAMED_CT_ARG("IS_RECEIVER_CHANNEL_SERVICED_0")),
-    static_cast<bool>(NAMED_CT_ARG("IS_RECEIVER_CHANNEL_SERVICED_1")),
+    static_cast<bool>(NAMED_CT_ARG("IS_RECEIVER_CHANNEL_0_SERVICED")),
+    static_cast<bool>(NAMED_CT_ARG("IS_RECEIVER_CHANNEL_1_SERVICED")),
 };
 
 // ============================================================================
@@ -351,15 +351,15 @@ constexpr bool is_intramesh_router_on_edge = NAMED_CT_ARG("IS_INTRAMESH_ROUTER_O
 // Arrays are sized to NUM_SENDER_CHANNELS, built from MAX-sized intermediaries.
 // ============================================================================
 static constexpr std::array<bool, MAX_NUM_SENDER_CHANNELS> sender_ch_live_check_skip_all_ = {
-    static_cast<bool>(NAMED_CT_ARG("SENDER_CH_LIVE_CHECK_SKIP_0")),
-    static_cast<bool>(NAMED_CT_ARG("SENDER_CH_LIVE_CHECK_SKIP_1")),
-    static_cast<bool>(NAMED_CT_ARG("SENDER_CH_LIVE_CHECK_SKIP_2")),
-    static_cast<bool>(NAMED_CT_ARG("SENDER_CH_LIVE_CHECK_SKIP_3")),
-    static_cast<bool>(NAMED_CT_ARG("SENDER_CH_LIVE_CHECK_SKIP_4")),
-    static_cast<bool>(NAMED_CT_ARG("SENDER_CH_LIVE_CHECK_SKIP_5")),
-    static_cast<bool>(NAMED_CT_ARG("SENDER_CH_LIVE_CHECK_SKIP_6")),
-    static_cast<bool>(NAMED_CT_ARG("SENDER_CH_LIVE_CHECK_SKIP_7")),
-    static_cast<bool>(NAMED_CT_ARG("SENDER_CH_LIVE_CHECK_SKIP_8")),
+    static_cast<bool>(NAMED_CT_ARG("SENDER_CH_0_LIVE_CHECK_SKIP")),
+    static_cast<bool>(NAMED_CT_ARG("SENDER_CH_1_LIVE_CHECK_SKIP")),
+    static_cast<bool>(NAMED_CT_ARG("SENDER_CH_2_LIVE_CHECK_SKIP")),
+    static_cast<bool>(NAMED_CT_ARG("SENDER_CH_3_LIVE_CHECK_SKIP")),
+    static_cast<bool>(NAMED_CT_ARG("SENDER_CH_4_LIVE_CHECK_SKIP")),
+    static_cast<bool>(NAMED_CT_ARG("SENDER_CH_5_LIVE_CHECK_SKIP")),
+    static_cast<bool>(NAMED_CT_ARG("SENDER_CH_6_LIVE_CHECK_SKIP")),
+    static_cast<bool>(NAMED_CT_ARG("SENDER_CH_7_LIVE_CHECK_SKIP")),
+    static_cast<bool>(NAMED_CT_ARG("SENDER_CH_8_LIVE_CHECK_SKIP")),
 };
 constexpr std::array<bool, NUM_SENDER_CHANNELS> sender_ch_live_check_skip =
     take_first_n_elements<NUM_SENDER_CHANNELS, MAX_NUM_SENDER_CHANNELS, bool>(sender_ch_live_check_skip_all_);
@@ -369,15 +369,15 @@ constexpr std::array<bool, NUM_SENDER_CHANNELS> sender_ch_live_check_skip =
 // sender channels that receive traffic from a "turn" (e.g. an EAST channel receiving traffic from NORTH)
 // This attribute is necessary to support bubble flow control.
 static constexpr std::array<bool, MAX_NUM_SENDER_CHANNELS> sender_channel_is_traffic_injection_channel_all_ = {
-    static_cast<bool>(NAMED_CT_ARG("SENDER_CH_IS_INJECTION_0")),
-    static_cast<bool>(NAMED_CT_ARG("SENDER_CH_IS_INJECTION_1")),
-    static_cast<bool>(NAMED_CT_ARG("SENDER_CH_IS_INJECTION_2")),
-    static_cast<bool>(NAMED_CT_ARG("SENDER_CH_IS_INJECTION_3")),
-    static_cast<bool>(NAMED_CT_ARG("SENDER_CH_IS_INJECTION_4")),
-    static_cast<bool>(NAMED_CT_ARG("SENDER_CH_IS_INJECTION_5")),
-    static_cast<bool>(NAMED_CT_ARG("SENDER_CH_IS_INJECTION_6")),
-    static_cast<bool>(NAMED_CT_ARG("SENDER_CH_IS_INJECTION_7")),
-    static_cast<bool>(NAMED_CT_ARG("SENDER_CH_IS_INJECTION_8")),
+    static_cast<bool>(NAMED_CT_ARG("SENDER_CH_0_IS_INJECTION")),
+    static_cast<bool>(NAMED_CT_ARG("SENDER_CH_1_IS_INJECTION")),
+    static_cast<bool>(NAMED_CT_ARG("SENDER_CH_2_IS_INJECTION")),
+    static_cast<bool>(NAMED_CT_ARG("SENDER_CH_3_IS_INJECTION")),
+    static_cast<bool>(NAMED_CT_ARG("SENDER_CH_4_IS_INJECTION")),
+    static_cast<bool>(NAMED_CT_ARG("SENDER_CH_5_IS_INJECTION")),
+    static_cast<bool>(NAMED_CT_ARG("SENDER_CH_6_IS_INJECTION")),
+    static_cast<bool>(NAMED_CT_ARG("SENDER_CH_7_IS_INJECTION")),
+    static_cast<bool>(NAMED_CT_ARG("SENDER_CH_8_IS_INJECTION")),
 };
 constexpr std::array<bool, NUM_SENDER_CHANNELS> sender_channel_is_traffic_injection_channel =
     take_first_n_elements<NUM_SENDER_CHANNELS, MAX_NUM_SENDER_CHANNELS, bool>(
@@ -385,29 +385,29 @@ constexpr std::array<bool, NUM_SENDER_CHANNELS> sender_channel_is_traffic_inject
 constexpr size_t BUBBLE_FLOW_CONTROL_INJECTION_SENDER_CHANNEL_MIN_FREE_SLOTS = 2;
 
 static constexpr std::array<size_t, MAX_NUM_SENDER_CHANNELS> sender_channel_ack_noc_ids_all_ = {
-    static_cast<size_t>(NAMED_CT_ARG("SENDER_CH_ACK_NOC_ID_0")),
-    static_cast<size_t>(NAMED_CT_ARG("SENDER_CH_ACK_NOC_ID_1")),
-    static_cast<size_t>(NAMED_CT_ARG("SENDER_CH_ACK_NOC_ID_2")),
-    static_cast<size_t>(NAMED_CT_ARG("SENDER_CH_ACK_NOC_ID_3")),
-    static_cast<size_t>(NAMED_CT_ARG("SENDER_CH_ACK_NOC_ID_4")),
-    static_cast<size_t>(NAMED_CT_ARG("SENDER_CH_ACK_NOC_ID_5")),
-    static_cast<size_t>(NAMED_CT_ARG("SENDER_CH_ACK_NOC_ID_6")),
-    static_cast<size_t>(NAMED_CT_ARG("SENDER_CH_ACK_NOC_ID_7")),
-    static_cast<size_t>(NAMED_CT_ARG("SENDER_CH_ACK_NOC_ID_8")),
+    static_cast<size_t>(NAMED_CT_ARG("SENDER_CH_0_ACK_NOC_ID")),
+    static_cast<size_t>(NAMED_CT_ARG("SENDER_CH_1_ACK_NOC_ID")),
+    static_cast<size_t>(NAMED_CT_ARG("SENDER_CH_2_ACK_NOC_ID")),
+    static_cast<size_t>(NAMED_CT_ARG("SENDER_CH_3_ACK_NOC_ID")),
+    static_cast<size_t>(NAMED_CT_ARG("SENDER_CH_4_ACK_NOC_ID")),
+    static_cast<size_t>(NAMED_CT_ARG("SENDER_CH_5_ACK_NOC_ID")),
+    static_cast<size_t>(NAMED_CT_ARG("SENDER_CH_6_ACK_NOC_ID")),
+    static_cast<size_t>(NAMED_CT_ARG("SENDER_CH_7_ACK_NOC_ID")),
+    static_cast<size_t>(NAMED_CT_ARG("SENDER_CH_8_ACK_NOC_ID")),
 };
 constexpr std::array<size_t, NUM_SENDER_CHANNELS> sender_channel_ack_noc_ids =
     take_first_n_elements<NUM_SENDER_CHANNELS, MAX_NUM_SENDER_CHANNELS, size_t>(sender_channel_ack_noc_ids_all_);
 
 static constexpr std::array<uint8_t, MAX_NUM_SENDER_CHANNELS> sender_channel_ack_cmd_buf_ids_all_ = {
-    static_cast<uint8_t>(NAMED_CT_ARG("SENDER_CH_ACK_CMD_BUF_ID_0")),
-    static_cast<uint8_t>(NAMED_CT_ARG("SENDER_CH_ACK_CMD_BUF_ID_1")),
-    static_cast<uint8_t>(NAMED_CT_ARG("SENDER_CH_ACK_CMD_BUF_ID_2")),
-    static_cast<uint8_t>(NAMED_CT_ARG("SENDER_CH_ACK_CMD_BUF_ID_3")),
-    static_cast<uint8_t>(NAMED_CT_ARG("SENDER_CH_ACK_CMD_BUF_ID_4")),
-    static_cast<uint8_t>(NAMED_CT_ARG("SENDER_CH_ACK_CMD_BUF_ID_5")),
-    static_cast<uint8_t>(NAMED_CT_ARG("SENDER_CH_ACK_CMD_BUF_ID_6")),
-    static_cast<uint8_t>(NAMED_CT_ARG("SENDER_CH_ACK_CMD_BUF_ID_7")),
-    static_cast<uint8_t>(NAMED_CT_ARG("SENDER_CH_ACK_CMD_BUF_ID_8")),
+    static_cast<uint8_t>(NAMED_CT_ARG("SENDER_CH_0_ACK_CMD_BUF_ID")),
+    static_cast<uint8_t>(NAMED_CT_ARG("SENDER_CH_1_ACK_CMD_BUF_ID")),
+    static_cast<uint8_t>(NAMED_CT_ARG("SENDER_CH_2_ACK_CMD_BUF_ID")),
+    static_cast<uint8_t>(NAMED_CT_ARG("SENDER_CH_3_ACK_CMD_BUF_ID")),
+    static_cast<uint8_t>(NAMED_CT_ARG("SENDER_CH_4_ACK_CMD_BUF_ID")),
+    static_cast<uint8_t>(NAMED_CT_ARG("SENDER_CH_5_ACK_CMD_BUF_ID")),
+    static_cast<uint8_t>(NAMED_CT_ARG("SENDER_CH_6_ACK_CMD_BUF_ID")),
+    static_cast<uint8_t>(NAMED_CT_ARG("SENDER_CH_7_ACK_CMD_BUF_ID")),
+    static_cast<uint8_t>(NAMED_CT_ARG("SENDER_CH_8_ACK_CMD_BUF_ID")),
 };
 constexpr std::array<uint8_t, NUM_SENDER_CHANNELS> sender_channel_ack_cmd_buf_ids =
     take_first_n_elements<NUM_SENDER_CHANNELS, MAX_NUM_SENDER_CHANNELS, uint8_t>(sender_channel_ack_cmd_buf_ids_all_);
@@ -416,40 +416,40 @@ constexpr std::array<uint8_t, NUM_SENDER_CHANNELS> sender_channel_ack_cmd_buf_id
 // Receiver channel per-channel arrays
 // ============================================================================
 static constexpr std::array<size_t, MAX_NUM_RECEIVER_CHANNELS> receiver_channel_forwarding_noc_ids_all_ = {
-    static_cast<size_t>(NAMED_CT_ARG("RX_CH_FWD_NOC_ID_0")),
-    static_cast<size_t>(NAMED_CT_ARG("RX_CH_FWD_NOC_ID_1")),
+    static_cast<size_t>(NAMED_CT_ARG("RX_CH_0_FWD_NOC_ID")),
+    static_cast<size_t>(NAMED_CT_ARG("RX_CH_1_FWD_NOC_ID")),
 };
 constexpr std::array<size_t, NUM_RECEIVER_CHANNELS> receiver_channel_forwarding_noc_ids =
     take_first_n_elements<NUM_RECEIVER_CHANNELS, MAX_NUM_RECEIVER_CHANNELS, size_t>(
         receiver_channel_forwarding_noc_ids_all_);
 
 static constexpr std::array<uint8_t, MAX_NUM_RECEIVER_CHANNELS> receiver_channel_forwarding_data_cmd_buf_ids_all_ = {
-    static_cast<uint8_t>(NAMED_CT_ARG("RX_CH_FWD_DATA_CMD_BUF_ID_0")),
-    static_cast<uint8_t>(NAMED_CT_ARG("RX_CH_FWD_DATA_CMD_BUF_ID_1")),
+    static_cast<uint8_t>(NAMED_CT_ARG("RX_CH_0_FWD_DATA_CMD_BUF_ID")),
+    static_cast<uint8_t>(NAMED_CT_ARG("RX_CH_1_FWD_DATA_CMD_BUF_ID")),
 };
 constexpr std::array<uint8_t, NUM_RECEIVER_CHANNELS> receiver_channel_forwarding_data_cmd_buf_ids =
     take_first_n_elements<NUM_RECEIVER_CHANNELS, MAX_NUM_RECEIVER_CHANNELS, uint8_t>(
         receiver_channel_forwarding_data_cmd_buf_ids_all_);
 
 static constexpr std::array<uint8_t, MAX_NUM_RECEIVER_CHANNELS> receiver_channel_forwarding_sync_cmd_buf_ids_all_ = {
-    static_cast<uint8_t>(NAMED_CT_ARG("RX_CH_FWD_SYNC_CMD_BUF_ID_0")),
-    static_cast<uint8_t>(NAMED_CT_ARG("RX_CH_FWD_SYNC_CMD_BUF_ID_1")),
+    static_cast<uint8_t>(NAMED_CT_ARG("RX_CH_0_FWD_SYNC_CMD_BUF_ID")),
+    static_cast<uint8_t>(NAMED_CT_ARG("RX_CH_1_FWD_SYNC_CMD_BUF_ID")),
 };
 constexpr std::array<uint8_t, NUM_RECEIVER_CHANNELS> receiver_channel_forwarding_sync_cmd_buf_ids =
     take_first_n_elements<NUM_RECEIVER_CHANNELS, MAX_NUM_RECEIVER_CHANNELS, uint8_t>(
         receiver_channel_forwarding_sync_cmd_buf_ids_all_);
 
 static constexpr std::array<size_t, MAX_NUM_RECEIVER_CHANNELS> receiver_channel_local_write_noc_ids_all_ = {
-    static_cast<size_t>(NAMED_CT_ARG("RX_CH_LOCAL_WRITE_NOC_ID_0")),
-    static_cast<size_t>(NAMED_CT_ARG("RX_CH_LOCAL_WRITE_NOC_ID_1")),
+    static_cast<size_t>(NAMED_CT_ARG("RX_CH_0_LOCAL_WRITE_NOC_ID")),
+    static_cast<size_t>(NAMED_CT_ARG("RX_CH_1_LOCAL_WRITE_NOC_ID")),
 };
 constexpr std::array<size_t, NUM_RECEIVER_CHANNELS> receiver_channel_local_write_noc_ids =
     take_first_n_elements<NUM_RECEIVER_CHANNELS, MAX_NUM_RECEIVER_CHANNELS, size_t>(
         receiver_channel_local_write_noc_ids_all_);
 
 static constexpr std::array<uint8_t, MAX_NUM_RECEIVER_CHANNELS> receiver_channel_local_write_cmd_buf_ids_all_ = {
-    static_cast<uint8_t>(NAMED_CT_ARG("RX_CH_LOCAL_WRITE_CMD_BUF_ID_0")),
-    static_cast<uint8_t>(NAMED_CT_ARG("RX_CH_LOCAL_WRITE_CMD_BUF_ID_1")),
+    static_cast<uint8_t>(NAMED_CT_ARG("RX_CH_0_LOCAL_WRITE_CMD_BUF_ID")),
+    static_cast<uint8_t>(NAMED_CT_ARG("RX_CH_1_LOCAL_WRITE_CMD_BUF_ID")),
 };
 constexpr std::array<uint8_t, NUM_RECEIVER_CHANNELS> receiver_channel_local_write_cmd_buf_ids =
     take_first_n_elements<NUM_RECEIVER_CHANNELS, MAX_NUM_RECEIVER_CHANNELS, uint8_t>(

--- a/tt_metal/fabric/hw/inc/edm_fabric/fabric_erisc_router_ct_args.hpp
+++ b/tt_metal/fabric/hw/inc/edm_fabric/fabric_erisc_router_ct_args.hpp
@@ -8,7 +8,7 @@
 #include "api/dataflow/dataflow_api.h"
 
 #include "tt_metal/fabric/hw/inc/edm_fabric/compile_time_arg_tmp.hpp"
-#include "tt_metal/fabric/hw/inc/edm_fabric/fabric_router_elastic_channels_ct_args.hpp"
+// NOTE: fabric_router_elastic_channels_ct_args.hpp removed - elastic channels not yet emitted from host
 #include "tt_metal/fabric/hw/inc/edm_fabric/fabric_trimming.hpp"
 #include "tt_metal/fabric/hw/inc/edm_fabric/telemetry/fabric_bandwidth_telemetry.hpp"
 #include "tt_metal/fabric/hw/inc/edm_fabric/telemetry/fabric_code_profiling.hpp"
@@ -19,97 +19,85 @@
 #include <array>
 #include <utility>
 
+// Convenience macro for named compile-time arg lookup
+#define NAMED_CT_ARG(name) get_named_compile_time_arg_val(name)
+
 // CHANNEL CONSTANTS
 // ETH TXQ SELECTION
 
 constexpr size_t NUM_ROUTER_CARDINAL_DIRECTIONS = 4;
 
-constexpr bool SPECIAL_MARKER_CHECK_ENABLED = true;
-
-// Stream IDs from compile time arguments (first 28 arguments)
-constexpr size_t STREAM_ID_ARGS_START_IDX = 0;
-constexpr uint32_t to_receiver_0_pkts_sent_id = get_compile_time_arg_val(STREAM_ID_ARGS_START_IDX + 0);
-constexpr uint32_t to_receiver_1_pkts_sent_id = get_compile_time_arg_val(STREAM_ID_ARGS_START_IDX + 1);
-constexpr uint32_t to_sender_0_pkts_acked_id = get_compile_time_arg_val(STREAM_ID_ARGS_START_IDX + 2);
-constexpr uint32_t to_sender_1_pkts_acked_id = get_compile_time_arg_val(STREAM_ID_ARGS_START_IDX + 3);
-constexpr uint32_t to_sender_2_pkts_acked_id = get_compile_time_arg_val(STREAM_ID_ARGS_START_IDX + 4);
-constexpr uint32_t to_sender_3_pkts_acked_id = get_compile_time_arg_val(STREAM_ID_ARGS_START_IDX + 5);
-constexpr uint32_t to_sender_0_pkts_completed_id = get_compile_time_arg_val(STREAM_ID_ARGS_START_IDX + 6);
-constexpr uint32_t to_sender_1_pkts_completed_id = get_compile_time_arg_val(STREAM_ID_ARGS_START_IDX + 7);
-constexpr uint32_t to_sender_2_pkts_completed_id = get_compile_time_arg_val(STREAM_ID_ARGS_START_IDX + 8);
-constexpr uint32_t to_sender_3_pkts_completed_id = get_compile_time_arg_val(STREAM_ID_ARGS_START_IDX + 9);
-constexpr uint32_t to_sender_4_pkts_completed_id = get_compile_time_arg_val(STREAM_ID_ARGS_START_IDX + 10);
-constexpr uint32_t to_sender_5_pkts_completed_id = get_compile_time_arg_val(STREAM_ID_ARGS_START_IDX + 11);
-constexpr uint32_t to_sender_6_pkts_completed_id = get_compile_time_arg_val(STREAM_ID_ARGS_START_IDX + 12);
-constexpr uint32_t to_sender_7_pkts_completed_id = get_compile_time_arg_val(STREAM_ID_ARGS_START_IDX + 13);
+// ============================================================================
+// Stream IDs (from named compile-time arguments)
+// ============================================================================
+constexpr uint32_t to_receiver_0_pkts_sent_id = NAMED_CT_ARG("TO_RECEIVER_0_PKTS_SENT_ID");
+constexpr uint32_t to_receiver_1_pkts_sent_id = NAMED_CT_ARG("TO_RECEIVER_1_PKTS_SENT_ID");
+constexpr uint32_t to_sender_0_pkts_acked_id = NAMED_CT_ARG("TO_SENDER_0_PKTS_ACKED_ID");
+constexpr uint32_t to_sender_1_pkts_acked_id = NAMED_CT_ARG("TO_SENDER_1_PKTS_ACKED_ID");
+constexpr uint32_t to_sender_2_pkts_acked_id = NAMED_CT_ARG("TO_SENDER_2_PKTS_ACKED_ID");
+constexpr uint32_t to_sender_3_pkts_acked_id = NAMED_CT_ARG("TO_SENDER_3_PKTS_ACKED_ID");
+constexpr uint32_t to_sender_0_pkts_completed_id = NAMED_CT_ARG("TO_SENDER_0_PKTS_COMPLETED_ID");
+constexpr uint32_t to_sender_1_pkts_completed_id = NAMED_CT_ARG("TO_SENDER_1_PKTS_COMPLETED_ID");
+constexpr uint32_t to_sender_2_pkts_completed_id = NAMED_CT_ARG("TO_SENDER_2_PKTS_COMPLETED_ID");
+constexpr uint32_t to_sender_3_pkts_completed_id = NAMED_CT_ARG("TO_SENDER_3_PKTS_COMPLETED_ID");
+constexpr uint32_t to_sender_4_pkts_completed_id = NAMED_CT_ARG("TO_SENDER_4_PKTS_COMPLETED_ID");
+constexpr uint32_t to_sender_5_pkts_completed_id = NAMED_CT_ARG("TO_SENDER_5_PKTS_COMPLETED_ID");
+constexpr uint32_t to_sender_6_pkts_completed_id = NAMED_CT_ARG("TO_SENDER_6_PKTS_COMPLETED_ID");
+constexpr uint32_t to_sender_7_pkts_completed_id = NAMED_CT_ARG("TO_SENDER_7_PKTS_COMPLETED_ID");
 constexpr uint32_t vc_0_free_slots_from_downstream_edge_1_stream_id =
-    get_compile_time_arg_val(STREAM_ID_ARGS_START_IDX + 14);
+    NAMED_CT_ARG("VC0_FREE_SLOTS_FROM_DOWNSTREAM_EDGE_1_STREAM_ID");
 constexpr uint32_t vc_0_free_slots_from_downstream_edge_2_stream_id =
-    get_compile_time_arg_val(STREAM_ID_ARGS_START_IDX + 15);
+    NAMED_CT_ARG("VC0_FREE_SLOTS_FROM_DOWNSTREAM_EDGE_2_STREAM_ID");
 constexpr uint32_t vc_0_free_slots_from_downstream_edge_3_stream_id =
-    get_compile_time_arg_val(STREAM_ID_ARGS_START_IDX + 16);
+    NAMED_CT_ARG("VC0_FREE_SLOTS_FROM_DOWNSTREAM_EDGE_3_STREAM_ID");
 constexpr uint32_t vc_0_free_slots_from_downstream_edge_4_stream_id =
-    get_compile_time_arg_val(STREAM_ID_ARGS_START_IDX + 17);
+    NAMED_CT_ARG("VC0_FREE_SLOTS_FROM_DOWNSTREAM_EDGE_4_STREAM_ID");
 constexpr uint32_t vc_1_free_slots_from_downstream_edge_1_stream_id =
-    get_compile_time_arg_val(STREAM_ID_ARGS_START_IDX + 18);
+    NAMED_CT_ARG("VC1_FREE_SLOTS_FROM_DOWNSTREAM_EDGE_1_STREAM_ID");
 constexpr uint32_t vc_1_free_slots_from_downstream_edge_2_stream_id =
-    get_compile_time_arg_val(STREAM_ID_ARGS_START_IDX + 19);
+    NAMED_CT_ARG("VC1_FREE_SLOTS_FROM_DOWNSTREAM_EDGE_2_STREAM_ID");
 constexpr uint32_t vc_1_free_slots_from_downstream_edge_3_stream_id =
-    get_compile_time_arg_val(STREAM_ID_ARGS_START_IDX + 20);
+    NAMED_CT_ARG("VC1_FREE_SLOTS_FROM_DOWNSTREAM_EDGE_3_STREAM_ID");
 constexpr uint32_t vc_1_free_slots_from_downstream_edge_4_stream_id =
-    get_compile_time_arg_val(STREAM_ID_ARGS_START_IDX + 21);
-constexpr uint32_t sender_channel_0_free_slots_stream_id = get_compile_time_arg_val(STREAM_ID_ARGS_START_IDX + 22);
-constexpr uint32_t sender_channel_1_free_slots_stream_id = get_compile_time_arg_val(STREAM_ID_ARGS_START_IDX + 23);
-constexpr uint32_t sender_channel_2_free_slots_stream_id = get_compile_time_arg_val(STREAM_ID_ARGS_START_IDX + 24);
-constexpr uint32_t sender_channel_3_free_slots_stream_id = get_compile_time_arg_val(STREAM_ID_ARGS_START_IDX + 25);
-constexpr uint32_t sender_channel_4_free_slots_stream_id = get_compile_time_arg_val(STREAM_ID_ARGS_START_IDX + 26);
-constexpr uint32_t sender_channel_5_free_slots_stream_id = get_compile_time_arg_val(STREAM_ID_ARGS_START_IDX + 27);
-constexpr uint32_t sender_channel_6_free_slots_stream_id = get_compile_time_arg_val(STREAM_ID_ARGS_START_IDX + 28);
-constexpr uint32_t sender_channel_7_free_slots_stream_id = get_compile_time_arg_val(STREAM_ID_ARGS_START_IDX + 29);
-constexpr uint32_t tensix_relay_local_free_slots_stream_id = get_compile_time_arg_val(STREAM_ID_ARGS_START_IDX + 30);
-constexpr uint32_t MULTI_RISC_TEARDOWN_SYNC_STREAM_ID = get_compile_time_arg_val(STREAM_ID_ARGS_START_IDX + 31);
-constexpr uint32_t ETH_RETRAIN_LINK_SYNC_STREAM_ID = get_compile_time_arg_val(STREAM_ID_ARGS_START_IDX + 32);
+    NAMED_CT_ARG("VC1_FREE_SLOTS_FROM_DOWNSTREAM_EDGE_4_STREAM_ID");
+constexpr uint32_t sender_channel_0_free_slots_stream_id = NAMED_CT_ARG("SENDER_CHANNEL_0_FREE_SLOTS_STREAM_ID");
+constexpr uint32_t sender_channel_1_free_slots_stream_id = NAMED_CT_ARG("SENDER_CHANNEL_1_FREE_SLOTS_STREAM_ID");
+constexpr uint32_t sender_channel_2_free_slots_stream_id = NAMED_CT_ARG("SENDER_CHANNEL_2_FREE_SLOTS_STREAM_ID");
+constexpr uint32_t sender_channel_3_free_slots_stream_id = NAMED_CT_ARG("SENDER_CHANNEL_3_FREE_SLOTS_STREAM_ID");
+constexpr uint32_t sender_channel_4_free_slots_stream_id = NAMED_CT_ARG("SENDER_CHANNEL_4_FREE_SLOTS_STREAM_ID");
+constexpr uint32_t sender_channel_5_free_slots_stream_id = NAMED_CT_ARG("SENDER_CHANNEL_5_FREE_SLOTS_STREAM_ID");
+constexpr uint32_t sender_channel_6_free_slots_stream_id = NAMED_CT_ARG("SENDER_CHANNEL_6_FREE_SLOTS_STREAM_ID");
+constexpr uint32_t sender_channel_7_free_slots_stream_id = NAMED_CT_ARG("SENDER_CHANNEL_7_FREE_SLOTS_STREAM_ID");
+constexpr uint32_t tensix_relay_local_free_slots_stream_id = NAMED_CT_ARG("TENSIX_RELAY_LOCAL_FREE_SLOTS_STREAM_ID");
+constexpr uint32_t MULTI_RISC_TEARDOWN_SYNC_STREAM_ID = NAMED_CT_ARG("MULTI_RISC_TEARDOWN_SYNC_STREAM_ID");
+constexpr uint32_t ETH_RETRAIN_LINK_SYNC_STREAM_ID = NAMED_CT_ARG("ETH_RETRAIN_LINK_SYNC_STREAM_ID");
 
-// Special marker after stream IDs
-constexpr size_t STREAM_IDS_END_MARKER_IDX = STREAM_ID_ARGS_START_IDX + 33;
-constexpr size_t STREAM_IDS_END_MARKER = 0xFFEE0001;
-static_assert(
-    !SPECIAL_MARKER_CHECK_ENABLED || get_compile_time_arg_val(STREAM_IDS_END_MARKER_IDX) == STREAM_IDS_END_MARKER,
-    "Stream IDs end marker not found. This implies some arguments were misaligned between host and device. Double "
-    "check the CT args.");
-
-// Maximum channel counts (from builder_config::num_max_sender_channels and builder_config::num_max_receiver_channels)
-constexpr size_t MAX_NUM_SENDER_CHANNELS_IDX = STREAM_IDS_END_MARKER_IDX + 1;
-constexpr size_t MAX_NUM_SENDER_CHANNELS = get_compile_time_arg_val(MAX_NUM_SENDER_CHANNELS_IDX);
-constexpr size_t MAX_NUM_RECEIVER_CHANNELS_IDX = MAX_NUM_SENDER_CHANNELS_IDX + 1;
-constexpr size_t MAX_NUM_RECEIVER_CHANNELS = get_compile_time_arg_val(MAX_NUM_RECEIVER_CHANNELS_IDX);
+// ============================================================================
+// Maximum channel counts
+// ============================================================================
+constexpr size_t MAX_NUM_SENDER_CHANNELS = NAMED_CT_ARG("MAX_NUM_SENDER_CHANNELS");
+constexpr size_t MAX_NUM_RECEIVER_CHANNELS = NAMED_CT_ARG("MAX_NUM_RECEIVER_CHANNELS");
 // VC0 and VC1 channel counts depend on router type:
 // Z_ROUTER: 5 VC0 + 4 VC1 = 9 total
 // MESH: 4 VC0 + 4 VC1 = 8 total (with some unused)
-// These are computed from MAX_NUM_SENDER_CHANNELS
-constexpr size_t MAX_NUM_SENDER_CHANNELS_VC0 = (MAX_NUM_SENDER_CHANNELS >= 9) ? 5 : 4;  // 5 if Z router, else 4
-constexpr size_t MAX_NUM_SENDER_CHANNELS_VC1 = MAX_NUM_SENDER_CHANNELS - MAX_NUM_SENDER_CHANNELS_VC0;  // Remainder
+constexpr size_t MAX_NUM_SENDER_CHANNELS_VC0 = (MAX_NUM_SENDER_CHANNELS >= 9) ? 5 : 4;
+constexpr size_t MAX_NUM_SENDER_CHANNELS_VC1 = MAX_NUM_SENDER_CHANNELS - MAX_NUM_SENDER_CHANNELS_VC0;
 constexpr size_t VC1_SENDER_CHANNEL_START = MAX_NUM_SENDER_CHANNELS_VC0;
 
-// Downstream tensix connections argument (after stream IDs, marker, and max channel counts)
-constexpr size_t NUM_DS_OR_LOCAL_TENSIX_CONNECTIONS_IDX = MAX_NUM_RECEIVER_CHANNELS_IDX + 1;
-constexpr uint32_t num_ds_or_local_tensix_connections =
-    get_compile_time_arg_val(NUM_DS_OR_LOCAL_TENSIX_CONNECTIONS_IDX);
+// ============================================================================
+// Downstream tensix connections
+// ============================================================================
+constexpr uint32_t num_ds_or_local_tensix_connections = NAMED_CT_ARG("NUM_DS_OR_LOCAL_TENSIX_CONNECTIONS");
 
-// Main configuration arguments (after stream IDs, marker, max channel counts, and downstream tensix connections)
-constexpr size_t SENDER_CHANNEL_NOC_CONFIG_START_IDX = NUM_DS_OR_LOCAL_TENSIX_CONNECTIONS_IDX + 1;
-constexpr size_t NUM_SENDER_CHANNELS = get_compile_time_arg_val(SENDER_CHANNEL_NOC_CONFIG_START_IDX);
-constexpr size_t NUM_RECEIVER_CHANNELS_CT_ARG_IDX = SENDER_CHANNEL_NOC_CONFIG_START_IDX + 1;
-constexpr size_t NUM_RECEIVER_CHANNELS = get_compile_time_arg_val(NUM_RECEIVER_CHANNELS_CT_ARG_IDX);
-constexpr size_t NUM_FORWARDING_PATHS_CT_ARG_IDX = NUM_RECEIVER_CHANNELS_CT_ARG_IDX + 1;
-constexpr size_t NUM_DOWNSTREAM_CHANNELS = get_compile_time_arg_val(NUM_FORWARDING_PATHS_CT_ARG_IDX);
-constexpr size_t NUM_DOWNSTREAM_SENDERS_VC0_CT_ARG_IDX = NUM_FORWARDING_PATHS_CT_ARG_IDX + 1;
-constexpr size_t NUM_DOWNSTREAM_SENDERS_VC0 = get_compile_time_arg_val(NUM_DOWNSTREAM_SENDERS_VC0_CT_ARG_IDX);
-constexpr size_t NUM_DOWNSTREAM_SENDERS_VC1_CT_ARG_IDX = NUM_DOWNSTREAM_SENDERS_VC0_CT_ARG_IDX + 1;
-constexpr size_t NUM_DOWNSTREAM_SENDERS_VC1 = get_compile_time_arg_val(NUM_DOWNSTREAM_SENDERS_VC1_CT_ARG_IDX);
-constexpr size_t wait_for_host_signal_IDX = NUM_DOWNSTREAM_SENDERS_VC1_CT_ARG_IDX + 1;
-constexpr bool wait_for_host_signal = get_compile_time_arg_val(wait_for_host_signal_IDX);
-constexpr size_t MAIN_CT_ARGS_START_IDX = wait_for_host_signal_IDX + 1;
+// ============================================================================
+// Main configuration
+// ============================================================================
+constexpr size_t NUM_SENDER_CHANNELS = NAMED_CT_ARG("NUM_SENDER_CHANNELS");
+constexpr size_t NUM_RECEIVER_CHANNELS = NAMED_CT_ARG("NUM_RECEIVER_CHANNELS");
+constexpr size_t NUM_DOWNSTREAM_CHANNELS = NAMED_CT_ARG("NUM_DOWNSTREAM_CHANNELS");
+constexpr size_t NUM_DOWNSTREAM_SENDERS_VC0 = NAMED_CT_ARG("NUM_DOWNSTREAM_SENDERS_VC0");
+constexpr size_t NUM_DOWNSTREAM_SENDERS_VC1 = NAMED_CT_ARG("NUM_DOWNSTREAM_SENDERS_VC1");
+constexpr bool wait_for_host_signal = NAMED_CT_ARG("WAIT_FOR_HOST_SIGNAL");
 
 static_assert(
     NUM_RECEIVER_CHANNELS <= NUM_SENDER_CHANNELS,
@@ -120,31 +108,19 @@ static_assert(
 static_assert(
     NUM_SENDER_CHANNELS <= MAX_NUM_SENDER_CHANNELS,
     "NUM_SENDER_CHANNELS must be less than or equal to MAX_NUM_SENDER_CHANNELS");
-static_assert(
-    wait_for_host_signal_IDX == 42,
-    "wait_for_host_signal_IDX must be 41 (32 stream IDs + 1 marker + 2 max channel counts + 1 tensix connections + 6 "
-    "config args: num_sender_channels, num_receiver_channels, num_fwd_paths, num_downstream_senders_vc0, "
-    "num_downstream_senders_vc1, wait_for_host_signal)");
-static_assert(
-    get_compile_time_arg_val(wait_for_host_signal_IDX) == 0 || get_compile_time_arg_val(wait_for_host_signal_IDX) == 1,
-    "wait_for_host_signal must be 0 or 1");
-static_assert(
-    MAIN_CT_ARGS_START_IDX == 43,
-    "MAIN_CT_ARGS_START_IDX must be 42 (32 stream IDs + 1 marker + 2 max channel counts + 1 tensix connections + 6 "
-    "config args: num_sender_channels, num_receiver_channels, num_fwd_paths, num_downstream_senders_vc0, "
-    "num_downstream_senders_vc1, wait_for_host_signal)");
+static_assert(wait_for_host_signal == 0 || wait_for_host_signal == 1, "wait_for_host_signal must be 0 or 1");
 
 constexpr uint32_t SWITCH_INTERVAL =
 #ifndef DEBUG_PRINT_ENABLED
-    get_compile_time_arg_val(MAIN_CT_ARGS_START_IDX + 0);
+    NAMED_CT_ARG("SWITCH_INTERVAL");
 #else
     0;
 #endif
-constexpr bool fuse_receiver_flush_and_completion_ptr = get_compile_time_arg_val(MAIN_CT_ARGS_START_IDX + 1);
-constexpr bool enable_deadlock_avoidance = get_compile_time_arg_val(MAIN_CT_ARGS_START_IDX + 2);
-constexpr bool is_intermesh_router = get_compile_time_arg_val(MAIN_CT_ARGS_START_IDX + 3);
-constexpr bool is_handshake_sender = get_compile_time_arg_val(MAIN_CT_ARGS_START_IDX + 4) != 0;
-constexpr size_t handshake_addr = get_compile_time_arg_val(MAIN_CT_ARGS_START_IDX + 5);
+constexpr bool fuse_receiver_flush_and_completion_ptr = NAMED_CT_ARG("FUSE_RECEIVER_FLUSH_AND_COMPLETION_PTR");
+constexpr bool enable_deadlock_avoidance = NAMED_CT_ARG("ENABLE_DEADLOCK_AVOIDANCE");
+constexpr bool is_intermesh_router = NAMED_CT_ARG("IS_INTERMESH_ROUTER");
+constexpr bool is_handshake_sender = NAMED_CT_ARG("IS_HANDSHAKE_SENDER") != 0;
+constexpr size_t handshake_addr = NAMED_CT_ARG("HANDSHAKE_ADDR");
 
 static_assert(fuse_receiver_flush_and_completion_ptr == 1, "fuse_receiver_flush_and_completion_ptr must be 0");
 
@@ -160,55 +136,42 @@ constexpr size_t worker_info_offset_past_connection_semaphore = 32;
 // This `channel_buffer_size` includes packet headers in the size.
 // This should be renamed to channel_slot_size_bytes to avoid confusion/ambiguity:
 //   "is it the payload size or does it include the packet header size?"
-constexpr size_t channel_buffer_size = get_compile_time_arg_val(MAIN_CT_ARGS_START_IDX + 6);
-constexpr bool fabric_tensix_extension_mux_mode = get_compile_time_arg_val(MAIN_CT_ARGS_START_IDX + 7);
+constexpr size_t channel_buffer_size = NAMED_CT_ARG("CHANNEL_BUFFER_SIZE");
+constexpr bool fabric_tensix_extension_mux_mode = NAMED_CT_ARG("FABRIC_TENSIX_EXTENSION_MUX_MODE");
 constexpr bool skip_src_ch_id_update = fabric_tensix_extension_mux_mode;
 
-constexpr bool ENABLE_FIRST_LEVEL_ACK_VC0 = get_compile_time_arg_val(MAIN_CT_ARGS_START_IDX + 8);
-constexpr bool ENABLE_FIRST_LEVEL_ACK_VC1 = get_compile_time_arg_val(MAIN_CT_ARGS_START_IDX + 9);
-constexpr bool ENABLE_RISC_CPU_DATA_CACHE = get_compile_time_arg_val(MAIN_CT_ARGS_START_IDX + 10);
-constexpr bool z_router_enabled = get_compile_time_arg_val(MAIN_CT_ARGS_START_IDX + 11);
-constexpr size_t VC0_DOWNSTREAM_EDM_SIZE = get_compile_time_arg_val(MAIN_CT_ARGS_START_IDX + 12);
-constexpr size_t VC1_DOWNSTREAM_EDM_SIZE = get_compile_time_arg_val(MAIN_CT_ARGS_START_IDX + 13);
-constexpr size_t ACTUAL_VC0_SENDER_CHANNELS = get_compile_time_arg_val(MAIN_CT_ARGS_START_IDX + 14);
-constexpr size_t ACTUAL_VC1_SENDER_CHANNELS = get_compile_time_arg_val(MAIN_CT_ARGS_START_IDX + 15);
+constexpr bool ENABLE_FIRST_LEVEL_ACK_VC0 = NAMED_CT_ARG("ENABLE_FIRST_LEVEL_ACK_VC0");
+constexpr bool ENABLE_FIRST_LEVEL_ACK_VC1 = NAMED_CT_ARG("ENABLE_FIRST_LEVEL_ACK_VC1");
+constexpr bool ENABLE_RISC_CPU_DATA_CACHE = NAMED_CT_ARG("ENABLE_RISC_CPU_DATA_CACHE");
+constexpr bool z_router_enabled = NAMED_CT_ARG("Z_ROUTER_ENABLED");
+constexpr size_t VC0_DOWNSTREAM_EDM_SIZE = NAMED_CT_ARG("VC0_DOWNSTREAM_EDM_SIZE");
+constexpr size_t VC1_DOWNSTREAM_EDM_SIZE = NAMED_CT_ARG("VC1_DOWNSTREAM_EDM_SIZE");
+constexpr size_t ACTUAL_VC0_SENDER_CHANNELS = NAMED_CT_ARG("ACTUAL_VC0_SENDER_CHANNELS");
+constexpr size_t ACTUAL_VC1_SENDER_CHANNELS = NAMED_CT_ARG("ACTUAL_VC1_SENDER_CHANNELS");
 
-constexpr size_t REMOTE_CHANNEL_INFO_START_IDX = MAIN_CT_ARGS_START_IDX + 16;
-constexpr size_t remote_worker_sender_channel =
-    conditional_get_compile_time_arg<skip_src_ch_id_update, REMOTE_CHANNEL_INFO_START_IDX>();
+// Remote channel info (always available; 0 when inactive)
+constexpr size_t remote_worker_sender_channel = NAMED_CT_ARG("REMOTE_WORKER_SENDER_CHANNEL");
 
-constexpr size_t UDM_MODE_IDX = REMOTE_CHANNEL_INFO_START_IDX + (skip_src_ch_id_update ? 1 : 0);
-constexpr bool udm_mode = get_compile_time_arg_val(UDM_MODE_IDX) != 0;
+// UDM mode (always available; 0 when inactive)
+constexpr bool udm_mode = NAMED_CT_ARG("UDM_MODE") != 0;
+constexpr uint32_t LOCAL_RELAY_NUM_BUFFERS = NAMED_CT_ARG("LOCAL_RELAY_NUM_BUFFERS");
 
-constexpr size_t LOCAL_TENSIX_RELAY_INFO_START_IDX = UDM_MODE_IDX + 1;
-constexpr uint32_t LOCAL_RELAY_NUM_BUFFERS =
-    conditional_get_compile_time_arg<udm_mode, LOCAL_TENSIX_RELAY_INFO_START_IDX>();
+// ============================================================================
+// Pool collection (positional args, starting at index 0)
+// ============================================================================
+constexpr size_t CHANNEL_POOL_COLLECTION_IDX = 0;
 
-constexpr size_t ANOTHER_SPECIAL_TAG = 0xabcd9876;
-constexpr size_t ANOTHER_SPECIAL_TAG_IDX = LOCAL_TENSIX_RELAY_INFO_START_IDX + (udm_mode ? 1 : 0);
-static_assert(
-    get_compile_time_arg_val(ANOTHER_SPECIAL_TAG_IDX) == ANOTHER_SPECIAL_TAG,
-    "ANOTHER_SPECIAL_TAG not found. This implies some arguments were misaligned between host and device. Double check the CT args.");
-
-// ========== NEW MULTI-POOL CHANNEL PARSING ==========
-// Parse channel pool collection (replaces old static-only parsing)
-constexpr size_t CHANNEL_POOL_COLLECTION_IDX = ANOTHER_SPECIAL_TAG_IDX + 1;
-
-// For now, we only support single static pool configuration for backward compatibility
-// Pool CT args structure:
-//   - num_pools (1 arg)
-//   - pool_types[] (1 arg for single pool)
-//   - Static pool data (23 args): 5 sender buffers + 2 receiver buffers + 2 remote receiver buffers +
-//                                  5 sender addrs + 4 receiver addrs + 5 remote sender addrs
-// Total: 1 + 1 + 23 = 25 args
 using channel_pools_args =
     ChannelPoolCollection<CHANNEL_POOL_COLLECTION_IDX, NUM_SENDER_CHANNELS, NUM_RECEIVER_CHANNELS>;
 constexpr size_t NUM_POOLS = channel_pools_args::num_channel_pools;
+
 // Parse channel-to-pool mappings (after all pool data)
-constexpr size_t CHANNEL_MAPPINGS_START_SPECIAL_TAG_IDX  = CHANNEL_POOL_COLLECTION_IDX + channel_pools_args::GET_NUM_ARGS_CONSUMED();
+constexpr size_t CHANNEL_MAPPINGS_START_SPECIAL_TAG_IDX =
+    CHANNEL_POOL_COLLECTION_IDX + channel_pools_args::GET_NUM_ARGS_CONSUMED();
 static_assert(
     get_compile_time_arg_val(CHANNEL_MAPPINGS_START_SPECIAL_TAG_IDX) == 0xabaddad8,
-    "CHANNEL_MAPPINGS_START_SPECIAL_TAG_IDX not found. This implies some arguments were misaligned between host and device. Double check the CT args.");
+    "CHANNEL_MAPPINGS_START_SPECIAL_TAG_IDX not found. This implies some arguments were misaligned between host and "
+    "device. Double check the CT args.");
 
 constexpr size_t CHANNEL_MAPPINGS_START_IDX = CHANNEL_MAPPINGS_START_SPECIAL_TAG_IDX + 1;
 constexpr std::array<size_t, NUM_SENDER_CHANNELS> SENDER_TO_POOL_IDX = channel_pools_args::sender_channel_to_pool_index;
@@ -216,25 +179,34 @@ constexpr std::array<FabricChannelPoolType, NUM_SENDER_CHANNELS> SENDER_TO_POOL_
     FabricChannelPoolType,
     CHANNEL_MAPPINGS_START_IDX + NUM_SENDER_CHANNELS,
     NUM_SENDER_CHANNELS>();
-static_assert(all_elements_satisfy(SENDER_TO_POOL_TYPE, [](FabricChannelPoolType pool_type) { return pool_type <= FabricChannelPoolType::ELASTIC; }), "SENDER_TO_POOL_TYPE must be less than or equal to FabricChannelPoolType::ELASTIC");
-constexpr std::array<size_t, NUM_RECEIVER_CHANNELS> RECEIVER_TO_POOL_IDX = channel_pools_args::receiver_channel_to_pool_index;
-static_assert(all_elements_satisfy(RECEIVER_TO_POOL_IDX, [](size_t pool_idx) { return pool_idx < NUM_POOLS; }), "RECEIVER_TO_POOL_IDX must be less than NUM_POOLS");
+static_assert(
+    all_elements_satisfy(
+        SENDER_TO_POOL_TYPE,
+        [](FabricChannelPoolType pool_type) { return pool_type <= FabricChannelPoolType::ELASTIC; }),
+    "SENDER_TO_POOL_TYPE must be less than or equal to FabricChannelPoolType::ELASTIC");
+constexpr std::array<size_t, NUM_RECEIVER_CHANNELS> RECEIVER_TO_POOL_IDX =
+    channel_pools_args::receiver_channel_to_pool_index;
+static_assert(
+    all_elements_satisfy(RECEIVER_TO_POOL_IDX, [](size_t pool_idx) { return pool_idx < NUM_POOLS; }),
+    "RECEIVER_TO_POOL_IDX must be less than NUM_POOLS");
 constexpr std::array<FabricChannelPoolType, NUM_RECEIVER_CHANNELS> RECEIVER_TO_POOL_TYPE = fill_array_with_next_n_args<
     FabricChannelPoolType,
-
     // We accidentally double emit the *_TO_POOL_TYPE arrays so we skip past some unused args
     CHANNEL_MAPPINGS_START_IDX + (2 * NUM_SENDER_CHANNELS) + NUM_RECEIVER_CHANNELS,
     NUM_RECEIVER_CHANNELS>();
-static_assert(all_elements_satisfy(RECEIVER_TO_POOL_TYPE, [](FabricChannelPoolType pool_type) { return pool_type <= FabricChannelPoolType::ELASTIC; }));
+static_assert(all_elements_satisfy(RECEIVER_TO_POOL_TYPE, [](FabricChannelPoolType pool_type) {
+    return pool_type <= FabricChannelPoolType::ELASTIC;
+}));
 
 // Parse remote channel pool data (after channel-to-pool mappings)
-constexpr size_t REMOTE_CHANNEL_POOL_START_MARKER_IDX = CHANNEL_MAPPINGS_START_IDX + 2 * (NUM_SENDER_CHANNELS + NUM_RECEIVER_CHANNELS);
+constexpr size_t REMOTE_CHANNEL_POOL_START_MARKER_IDX =
+    CHANNEL_MAPPINGS_START_IDX + 2 * (NUM_SENDER_CHANNELS + NUM_RECEIVER_CHANNELS);
 static_assert(
     get_compile_time_arg_val(REMOTE_CHANNEL_POOL_START_MARKER_IDX) == 0xabaddad6,
-    "Remote channel pool start marker not found. This implies some arguments were misaligned between host and device. Double check the CT args.");
+    "Remote channel pool start marker not found. This implies some arguments were misaligned between host and device. "
+    "Double check the CT args.");
 
 // Parse remote channel pool collection (follows same structure as local channels)
-// The remote multi-pool allocator emits pool data in the same format as local channels
 constexpr size_t REMOTE_CHANNEL_POOL_IDX = REMOTE_CHANNEL_POOL_START_MARKER_IDX + 1;
 using eth_remote_channel_pools_args = ChannelPoolCollection<REMOTE_CHANNEL_POOL_IDX, 0, NUM_RECEIVER_CHANNELS>;
 
@@ -258,7 +230,8 @@ constexpr size_t DOWNSTREAM_SENDER_NUM_BUFFERS_SPECIAL_TAG_IDX =
     REMOTE_CHANNEL_MAPPINGS_START_IDX + 2 * NUM_RECEIVER_CHANNELS;
 static_assert(
     get_compile_time_arg_val(DOWNSTREAM_SENDER_NUM_BUFFERS_SPECIAL_TAG_IDX) == 0xabaddad7,
-    "DOWNSTREAM_SENDER_NUM_BUFFERS_SPECIAL_TAG_IDX not found. This implies some arguments were misaligned between host and device. Double check the CT args.");
+    "DOWNSTREAM_SENDER_NUM_BUFFERS_SPECIAL_TAG_IDX not found. This implies some arguments were misaligned between host "
+    "and device. Double check the CT args.");
 
 // Downstream sender num buffers comes after channel mappings
 // Sized to MAX_NUM_RECEIVER_CHANNELS (one per VC) to match host side array
@@ -273,155 +246,221 @@ constexpr size_t ANOTHER_SPECIAL_TAG_2 = 0xabaddad9;
 constexpr size_t ANOTHER_SPECIAL_TAG_2_IDX = DOWNSTREAM_SENDER_NUM_BUFFERS_IDX + MAX_NUM_RECEIVER_CHANNELS;
 static_assert(
     get_compile_time_arg_val(ANOTHER_SPECIAL_TAG_2_IDX) == ANOTHER_SPECIAL_TAG_2,
-    "ANOTHER_SPECIAL_TAG_2 not found. This implies some arguments were misaligned between host and device. Double check the CT args.");
+    "ANOTHER_SPECIAL_TAG_2 not found. This implies some arguments were misaligned between host and device. Double "
+    "check the CT args.");
 
-constexpr size_t MAIN_CT_ARGS_IDX_1 = ANOTHER_SPECIAL_TAG_2_IDX + 1;
-constexpr size_t local_sender_channel_0_connection_info_addr = get_compile_time_arg_val(MAIN_CT_ARGS_IDX_1 + 0);
-constexpr size_t local_sender_channel_1_connection_info_addr = get_compile_time_arg_val(MAIN_CT_ARGS_IDX_1 + 1);
-constexpr size_t local_sender_channel_2_connection_info_addr = get_compile_time_arg_val(MAIN_CT_ARGS_IDX_1 + 2);
-constexpr size_t local_sender_channel_3_connection_info_addr = get_compile_time_arg_val(MAIN_CT_ARGS_IDX_1 + 3);
-constexpr size_t local_sender_channel_4_connection_info_addr = get_compile_time_arg_val(MAIN_CT_ARGS_IDX_1 + 4);
-constexpr size_t local_sender_channel_5_connection_info_addr = get_compile_time_arg_val(MAIN_CT_ARGS_IDX_1 + 5);
-constexpr size_t local_sender_channel_6_connection_info_addr = get_compile_time_arg_val(MAIN_CT_ARGS_IDX_1 + 6);
-constexpr size_t local_sender_channel_7_connection_info_addr = get_compile_time_arg_val(MAIN_CT_ARGS_IDX_1 + 7);
-constexpr size_t local_sender_channel_8_connection_info_addr =
-    get_compile_time_arg_val(MAIN_CT_ARGS_IDX_1 + 8);  // 9th channel for Z routers
+// ============================================================================
+// Sender channel connection info addresses (named args)
+// ============================================================================
+constexpr size_t local_sender_channel_0_connection_info_addr = NAMED_CT_ARG("LOCAL_SENDER_CH_CONN_INFO_ADDR_0");
+constexpr size_t local_sender_channel_1_connection_info_addr = NAMED_CT_ARG("LOCAL_SENDER_CH_CONN_INFO_ADDR_1");
+constexpr size_t local_sender_channel_2_connection_info_addr = NAMED_CT_ARG("LOCAL_SENDER_CH_CONN_INFO_ADDR_2");
+constexpr size_t local_sender_channel_3_connection_info_addr = NAMED_CT_ARG("LOCAL_SENDER_CH_CONN_INFO_ADDR_3");
+constexpr size_t local_sender_channel_4_connection_info_addr = NAMED_CT_ARG("LOCAL_SENDER_CH_CONN_INFO_ADDR_4");
+constexpr size_t local_sender_channel_5_connection_info_addr = NAMED_CT_ARG("LOCAL_SENDER_CH_CONN_INFO_ADDR_5");
+constexpr size_t local_sender_channel_6_connection_info_addr = NAMED_CT_ARG("LOCAL_SENDER_CH_CONN_INFO_ADDR_6");
+constexpr size_t local_sender_channel_7_connection_info_addr = NAMED_CT_ARG("LOCAL_SENDER_CH_CONN_INFO_ADDR_7");
+constexpr size_t local_sender_channel_8_connection_info_addr = NAMED_CT_ARG("LOCAL_SENDER_CH_CONN_INFO_ADDR_8");
 
+// ============================================================================
+// Status pointers
+// ============================================================================
 // TODO: CONVERT TO SEMAPHORE
-constexpr size_t MAIN_CT_ARGS_IDX_2 = MAIN_CT_ARGS_IDX_1 + MAX_NUM_SENDER_CHANNELS;
-constexpr uint32_t termination_signal_addr = get_compile_time_arg_val(MAIN_CT_ARGS_IDX_2);
-constexpr uint32_t edm_local_sync_ptr_addr =
-    wait_for_host_signal ? get_compile_time_arg_val(MAIN_CT_ARGS_IDX_2 + 1) : 0;
-constexpr uint32_t edm_local_tensix_sync_ptr_addr = get_compile_time_arg_val(MAIN_CT_ARGS_IDX_2 + 2);
-constexpr uint32_t edm_status_ptr_addr = get_compile_time_arg_val(MAIN_CT_ARGS_IDX_2 + 3);
+constexpr uint32_t termination_signal_addr = NAMED_CT_ARG("TERMINATION_SIGNAL_ADDR");
+constexpr uint32_t edm_local_sync_ptr_addr = wait_for_host_signal ? NAMED_CT_ARG("EDM_LOCAL_SYNC_PTR_ADDR") : 0;
+constexpr uint32_t edm_local_tensix_sync_ptr_addr = NAMED_CT_ARG("EDM_LOCAL_TENSIX_SYNC_PTR_ADDR");
+constexpr uint32_t edm_status_ptr_addr = NAMED_CT_ARG("EDM_STATUS_PTR_ADDR");
 
 // for blackhole we need to disable the noc flush in inline writes to L1 for better perf. For wormhole this flag is not
 // used.
 constexpr bool enable_read_counter_update_noc_flush = false;
-constexpr uint32_t notify_worker_of_read_counter_update_src_address = get_compile_time_arg_val(MAIN_CT_ARGS_IDX_2 + 4);
-constexpr size_t NOTIFY_WORKER_SRC_ADDR_MARKER_IDX = MAIN_CT_ARGS_IDX_2 + 5;
-constexpr size_t NOTIFY_WORKER_SRC_ADDR_MARKER = 0x7A9B3C4D;
-static_assert(
-    !SPECIAL_MARKER_CHECK_ENABLED ||
-        get_compile_time_arg_val(NOTIFY_WORKER_SRC_ADDR_MARKER_IDX) == NOTIFY_WORKER_SRC_ADDR_MARKER,
-    "Notify worker marker not found. This implies some arguments were misaligned between host and device. Double "
-    "check the CT args.");
+constexpr uint32_t notify_worker_of_read_counter_update_src_address =
+    NAMED_CT_ARG("NOTIFY_WORKER_OF_READ_COUNTER_UPDATE_SRC_ADDR");
 
-constexpr size_t sender_channel_serviced_args_idx = MAIN_CT_ARGS_IDX_2 + 6;
-constexpr std::array<bool, MAX_NUM_SENDER_CHANNELS> is_sender_channel_serviced =
-    fill_array_with_next_n_args<bool, sender_channel_serviced_args_idx, MAX_NUM_SENDER_CHANNELS>();
-constexpr size_t receiver_channel_serviced_args_idx =
-    sender_channel_serviced_args_idx + is_sender_channel_serviced.size();
-constexpr std::array<bool, MAX_NUM_RECEIVER_CHANNELS> is_receiver_channel_serviced =
-    fill_array_with_next_n_args<bool, receiver_channel_serviced_args_idx, MAX_NUM_RECEIVER_CHANNELS>();
-constexpr size_t MAIN_CT_ARGS_IDX_5 = receiver_channel_serviced_args_idx + is_receiver_channel_serviced.size();
+// ============================================================================
+// Channel servicing flags
+// ============================================================================
+constexpr std::array<bool, MAX_NUM_SENDER_CHANNELS> is_sender_channel_serviced = {
+    static_cast<bool>(NAMED_CT_ARG("IS_SENDER_CHANNEL_SERVICED_0")),
+    static_cast<bool>(NAMED_CT_ARG("IS_SENDER_CHANNEL_SERVICED_1")),
+    static_cast<bool>(NAMED_CT_ARG("IS_SENDER_CHANNEL_SERVICED_2")),
+    static_cast<bool>(NAMED_CT_ARG("IS_SENDER_CHANNEL_SERVICED_3")),
+    static_cast<bool>(NAMED_CT_ARG("IS_SENDER_CHANNEL_SERVICED_4")),
+    static_cast<bool>(NAMED_CT_ARG("IS_SENDER_CHANNEL_SERVICED_5")),
+    static_cast<bool>(NAMED_CT_ARG("IS_SENDER_CHANNEL_SERVICED_6")),
+    static_cast<bool>(NAMED_CT_ARG("IS_SENDER_CHANNEL_SERVICED_7")),
+    static_cast<bool>(NAMED_CT_ARG("IS_SENDER_CHANNEL_SERVICED_8")),
+};
+constexpr std::array<bool, MAX_NUM_RECEIVER_CHANNELS> is_receiver_channel_serviced = {
+    static_cast<bool>(NAMED_CT_ARG("IS_RECEIVER_CHANNEL_SERVICED_0")),
+    static_cast<bool>(NAMED_CT_ARG("IS_RECEIVER_CHANNEL_SERVICED_1")),
+};
 
-constexpr bool enable_ethernet_handshake = get_compile_time_arg_val(MAIN_CT_ARGS_IDX_5) != 0;
-constexpr bool enable_context_switch = get_compile_time_arg_val(MAIN_CT_ARGS_IDX_5 + 1) != 0;
-constexpr bool enable_interrupts = get_compile_time_arg_val(MAIN_CT_ARGS_IDX_5 + 2) != 0;
-constexpr size_t sender_txq_id = get_compile_time_arg_val(MAIN_CT_ARGS_IDX_5 + 3);
-constexpr size_t receiver_txq_id = get_compile_time_arg_val(MAIN_CT_ARGS_IDX_5 + 4);
+// ============================================================================
+// RISC configuration
+// ============================================================================
+constexpr bool enable_ethernet_handshake = NAMED_CT_ARG("ENABLE_ETHERNET_HANDSHAKE") != 0;
+constexpr bool enable_context_switch = NAMED_CT_ARG("ENABLE_CONTEXT_SWITCH") != 0;
+constexpr bool enable_interrupts = NAMED_CT_ARG("ENABLE_INTERRUPTS") != 0;
+constexpr size_t sender_txq_id = NAMED_CT_ARG("SENDER_TXQ_ID");
+constexpr size_t receiver_txq_id = NAMED_CT_ARG("RECEIVER_TXQ_ID");
 constexpr bool multi_txq_enabled = sender_txq_id != receiver_txq_id;
 
-constexpr size_t iterations_between_ctx_switch_and_teardown_checks = get_compile_time_arg_val(MAIN_CT_ARGS_IDX_5 + 5);
-constexpr size_t is_2d_fabric = get_compile_time_arg_val(MAIN_CT_ARGS_IDX_5 + 6);
-constexpr size_t my_direction = get_compile_time_arg_val(MAIN_CT_ARGS_IDX_5 + 7);
-constexpr size_t num_eth_ports = get_compile_time_arg_val(MAIN_CT_ARGS_IDX_5 + 8);
+constexpr size_t iterations_between_ctx_switch_and_teardown_checks =
+    NAMED_CT_ARG("ITERATIONS_BETWEEN_CTX_SWITCH_AND_TEARDOWN_CHECKS");
+constexpr size_t is_2d_fabric = NAMED_CT_ARG("IS_2D_FABRIC");
+constexpr size_t my_direction = NAMED_CT_ARG("MY_DIRECTION");
+constexpr size_t num_eth_ports = NAMED_CT_ARG("NUM_ETH_PORTS");
 
 // If true, the sender channel will spin inside send_next_data until the eth_txq is not busy, rather than checking
 // eth_txq_is_busy() being false as a prerequisite for sending the next packet
-constexpr bool ETH_TXQ_SPIN_WAIT_SEND_NEXT_DATA = get_compile_time_arg_val(MAIN_CT_ARGS_IDX_5 + 9) != 0;
-constexpr bool ETH_TXQ_SPIN_WAIT_RECEIVER_SEND_COMPLETION_ACK = get_compile_time_arg_val(MAIN_CT_ARGS_IDX_5 + 10) != 0;
+constexpr bool ETH_TXQ_SPIN_WAIT_SEND_NEXT_DATA = NAMED_CT_ARG("ETH_TXQ_SPIN_WAIT_SEND_NEXT_DATA") != 0;
+constexpr bool ETH_TXQ_SPIN_WAIT_RECEIVER_SEND_COMPLETION_ACK =
+    NAMED_CT_ARG("ETH_TXQ_SPIN_WAIT_RECEIVER_SEND_COMPLETION_ACK") != 0;
 
-constexpr size_t DEFAULT_NUM_ETH_TXQ_DATA_PACKET_ACCEPT_AHEAD = get_compile_time_arg_val(MAIN_CT_ARGS_IDX_5 + 11);
+constexpr size_t DEFAULT_NUM_ETH_TXQ_DATA_PACKET_ACCEPT_AHEAD =
+    NAMED_CT_ARG("DEFAULT_NUM_ETH_TXQ_DATA_PACKET_ACCEPT_AHEAD");
 
 // Context switch timeouts
 constexpr size_t DEFAULT_HANDSHAKE_CONTEXT_SWITCH_TIMEOUT =
 #ifndef DEBUG_PRINT_ENABLED
-    get_compile_time_arg_val(MAIN_CT_ARGS_IDX_5 + 12);
+    NAMED_CT_ARG("DEFAULT_HANDSHAKE_CONTEXT_SWITCH_TIMEOUT");
 #else
     128;
 #endif
-constexpr bool IDLE_CONTEXT_SWITCHING = get_compile_time_arg_val(MAIN_CT_ARGS_IDX_5 + 13) != 0;
+constexpr bool IDLE_CONTEXT_SWITCHING = NAMED_CT_ARG("IDLE_CONTEXT_SWITCHING") != 0;
 
-constexpr size_t MY_ETH_CHANNEL = get_compile_time_arg_val(MAIN_CT_ARGS_IDX_5 + 14);
+constexpr size_t MY_ETH_CHANNEL = NAMED_CT_ARG("MY_ETH_CHANNEL");
 
-constexpr size_t MY_ERISC_ID = get_compile_time_arg_val(MAIN_CT_ARGS_IDX_5 + 15);
-constexpr size_t NUM_ACTIVE_ERISCS = get_compile_time_arg_val(MAIN_CT_ARGS_IDX_5 + 16);
+constexpr size_t MY_ERISC_ID = NAMED_CT_ARG("MY_ERISC_ID");
+constexpr size_t NUM_ACTIVE_ERISCS = NAMED_CT_ARG("NUM_ACTIVE_ERISCS");
 static_assert(MY_ERISC_ID < NUM_ACTIVE_ERISCS, "MY_ERISC_ID must be less than NUM_ACTIVE_ERISCS");
 
 // Defines if packet header updates (as the packet header traverses its route) are done on the receiver side or the
 // sender side. If true, then the receiver channel updates the packet header before forwarding it. If false, the sender
 // channel updates the packet header before sending it over Ethernet.
-constexpr bool UPDATE_PKT_HDR_ON_RX_CH = get_compile_time_arg_val(MAIN_CT_ARGS_IDX_5 + 17) != 0;
+constexpr bool UPDATE_PKT_HDR_ON_RX_CH = NAMED_CT_ARG("UPDATE_PKT_HDR_ON_RX_CH") != 0;
 
-constexpr bool FORCE_ALL_PATHS_TO_USE_SAME_NOC = get_compile_time_arg_val(MAIN_CT_ARGS_IDX_5 + 18) != 0;
+constexpr bool FORCE_ALL_PATHS_TO_USE_SAME_NOC = NAMED_CT_ARG("FORCE_ALL_PATHS_TO_USE_SAME_NOC") != 0;
 
-constexpr bool is_intermesh_router_on_edge = get_compile_time_arg_val(MAIN_CT_ARGS_IDX_5 + 19) != 0;
-constexpr bool is_intramesh_router_on_edge = get_compile_time_arg_val(MAIN_CT_ARGS_IDX_5 + 20) != 0;
+constexpr bool is_intermesh_router_on_edge = NAMED_CT_ARG("IS_INTERMESH_ROUTER_ON_EDGE") != 0;
+constexpr bool is_intramesh_router_on_edge = NAMED_CT_ARG("IS_INTRAMESH_ROUTER_ON_EDGE") != 0;
 
-constexpr size_t SPECIAL_MARKER_0_IDX = MAIN_CT_ARGS_IDX_5 + 21;
-constexpr size_t SPECIAL_MARKER_0 = 0x00c0ffee;
-static_assert(
-    !SPECIAL_MARKER_CHECK_ENABLED || get_compile_time_arg_val(SPECIAL_MARKER_0_IDX) == SPECIAL_MARKER_0,
-    "Special marker 0 not found. This implies some arguments were misaligned between host and device. Double check the "
-    "CT args.");
-
-constexpr size_t SKIP_LIVENESS_CHECK_ARG_IDX = SPECIAL_MARKER_0_IDX + SPECIAL_MARKER_CHECK_ENABLED;
+// ============================================================================
+// Sender channel per-channel arrays
+// Arrays are sized to NUM_SENDER_CHANNELS, built from MAX-sized intermediaries.
+// ============================================================================
+static constexpr std::array<bool, MAX_NUM_SENDER_CHANNELS> sender_ch_live_check_skip_all_ = {
+    static_cast<bool>(NAMED_CT_ARG("SENDER_CH_LIVE_CHECK_SKIP_0")),
+    static_cast<bool>(NAMED_CT_ARG("SENDER_CH_LIVE_CHECK_SKIP_1")),
+    static_cast<bool>(NAMED_CT_ARG("SENDER_CH_LIVE_CHECK_SKIP_2")),
+    static_cast<bool>(NAMED_CT_ARG("SENDER_CH_LIVE_CHECK_SKIP_3")),
+    static_cast<bool>(NAMED_CT_ARG("SENDER_CH_LIVE_CHECK_SKIP_4")),
+    static_cast<bool>(NAMED_CT_ARG("SENDER_CH_LIVE_CHECK_SKIP_5")),
+    static_cast<bool>(NAMED_CT_ARG("SENDER_CH_LIVE_CHECK_SKIP_6")),
+    static_cast<bool>(NAMED_CT_ARG("SENDER_CH_LIVE_CHECK_SKIP_7")),
+    static_cast<bool>(NAMED_CT_ARG("SENDER_CH_LIVE_CHECK_SKIP_8")),
+};
 constexpr std::array<bool, NUM_SENDER_CHANNELS> sender_ch_live_check_skip =
-    fill_array_with_next_n_args<bool, SKIP_LIVENESS_CHECK_ARG_IDX, NUM_SENDER_CHANNELS>();
+    take_first_n_elements<NUM_SENDER_CHANNELS, MAX_NUM_SENDER_CHANNELS, bool>(sender_ch_live_check_skip_all_);
 
 // A channel is a "traffic injection channel" if it is a sender channel that is adding *new*
 // traffic to this dimension/ring. Examples include channels service worker traffic and
 // sender channels that receive traffic from a "turn" (e.g. an EAST channel receiving traffic from NORTH)
 // This attribute is necessary to support bubble flow control.
-constexpr size_t SENDER_CHANNEL_IS_INJECTION_CHANNEL_START_IDX = SKIP_LIVENESS_CHECK_ARG_IDX + NUM_SENDER_CHANNELS;
+static constexpr std::array<bool, MAX_NUM_SENDER_CHANNELS> sender_channel_is_traffic_injection_channel_all_ = {
+    static_cast<bool>(NAMED_CT_ARG("SENDER_CH_IS_INJECTION_0")),
+    static_cast<bool>(NAMED_CT_ARG("SENDER_CH_IS_INJECTION_1")),
+    static_cast<bool>(NAMED_CT_ARG("SENDER_CH_IS_INJECTION_2")),
+    static_cast<bool>(NAMED_CT_ARG("SENDER_CH_IS_INJECTION_3")),
+    static_cast<bool>(NAMED_CT_ARG("SENDER_CH_IS_INJECTION_4")),
+    static_cast<bool>(NAMED_CT_ARG("SENDER_CH_IS_INJECTION_5")),
+    static_cast<bool>(NAMED_CT_ARG("SENDER_CH_IS_INJECTION_6")),
+    static_cast<bool>(NAMED_CT_ARG("SENDER_CH_IS_INJECTION_7")),
+    static_cast<bool>(NAMED_CT_ARG("SENDER_CH_IS_INJECTION_8")),
+};
 constexpr std::array<bool, NUM_SENDER_CHANNELS> sender_channel_is_traffic_injection_channel =
-    fill_array_with_next_n_args<bool, SENDER_CHANNEL_IS_INJECTION_CHANNEL_START_IDX, NUM_SENDER_CHANNELS>();
+    take_first_n_elements<NUM_SENDER_CHANNELS, MAX_NUM_SENDER_CHANNELS, bool>(
+        sender_channel_is_traffic_injection_channel_all_);
 constexpr size_t BUBBLE_FLOW_CONTROL_INJECTION_SENDER_CHANNEL_MIN_FREE_SLOTS = 2;
 
-constexpr size_t SENDER_CHANNEL_ACK_NOC_IDS_START_IDX =
-    SENDER_CHANNEL_IS_INJECTION_CHANNEL_START_IDX + NUM_SENDER_CHANNELS;
-constexpr size_t SENDER_CHANNEL_ACK_CMD_BUF_IDS_START_IDX = SENDER_CHANNEL_ACK_NOC_IDS_START_IDX + NUM_SENDER_CHANNELS;
+static constexpr std::array<size_t, MAX_NUM_SENDER_CHANNELS> sender_channel_ack_noc_ids_all_ = {
+    static_cast<size_t>(NAMED_CT_ARG("SENDER_CH_ACK_NOC_ID_0")),
+    static_cast<size_t>(NAMED_CT_ARG("SENDER_CH_ACK_NOC_ID_1")),
+    static_cast<size_t>(NAMED_CT_ARG("SENDER_CH_ACK_NOC_ID_2")),
+    static_cast<size_t>(NAMED_CT_ARG("SENDER_CH_ACK_NOC_ID_3")),
+    static_cast<size_t>(NAMED_CT_ARG("SENDER_CH_ACK_NOC_ID_4")),
+    static_cast<size_t>(NAMED_CT_ARG("SENDER_CH_ACK_NOC_ID_5")),
+    static_cast<size_t>(NAMED_CT_ARG("SENDER_CH_ACK_NOC_ID_6")),
+    static_cast<size_t>(NAMED_CT_ARG("SENDER_CH_ACK_NOC_ID_7")),
+    static_cast<size_t>(NAMED_CT_ARG("SENDER_CH_ACK_NOC_ID_8")),
+};
 constexpr std::array<size_t, NUM_SENDER_CHANNELS> sender_channel_ack_noc_ids =
-    fill_array_with_next_n_args<size_t, SENDER_CHANNEL_ACK_NOC_IDS_START_IDX, NUM_SENDER_CHANNELS>();
+    take_first_n_elements<NUM_SENDER_CHANNELS, MAX_NUM_SENDER_CHANNELS, size_t>(sender_channel_ack_noc_ids_all_);
+
+static constexpr std::array<uint8_t, MAX_NUM_SENDER_CHANNELS> sender_channel_ack_cmd_buf_ids_all_ = {
+    static_cast<uint8_t>(NAMED_CT_ARG("SENDER_CH_ACK_CMD_BUF_ID_0")),
+    static_cast<uint8_t>(NAMED_CT_ARG("SENDER_CH_ACK_CMD_BUF_ID_1")),
+    static_cast<uint8_t>(NAMED_CT_ARG("SENDER_CH_ACK_CMD_BUF_ID_2")),
+    static_cast<uint8_t>(NAMED_CT_ARG("SENDER_CH_ACK_CMD_BUF_ID_3")),
+    static_cast<uint8_t>(NAMED_CT_ARG("SENDER_CH_ACK_CMD_BUF_ID_4")),
+    static_cast<uint8_t>(NAMED_CT_ARG("SENDER_CH_ACK_CMD_BUF_ID_5")),
+    static_cast<uint8_t>(NAMED_CT_ARG("SENDER_CH_ACK_CMD_BUF_ID_6")),
+    static_cast<uint8_t>(NAMED_CT_ARG("SENDER_CH_ACK_CMD_BUF_ID_7")),
+    static_cast<uint8_t>(NAMED_CT_ARG("SENDER_CH_ACK_CMD_BUF_ID_8")),
+};
 constexpr std::array<uint8_t, NUM_SENDER_CHANNELS> sender_channel_ack_cmd_buf_ids =
-    fill_array_with_next_n_args<uint8_t, SENDER_CHANNEL_ACK_CMD_BUF_IDS_START_IDX, NUM_SENDER_CHANNELS>();
+    take_first_n_elements<NUM_SENDER_CHANNELS, MAX_NUM_SENDER_CHANNELS, uint8_t>(sender_channel_ack_cmd_buf_ids_all_);
 
-constexpr size_t RX_CH_FWD_NOC_IDS_START_IDX = SENDER_CHANNEL_ACK_CMD_BUF_IDS_START_IDX + NUM_SENDER_CHANNELS;
-constexpr size_t RX_CH_FWD_DATA_CMD_BUF_IDS_START_IDX = RX_CH_FWD_NOC_IDS_START_IDX + NUM_RECEIVER_CHANNELS;
-constexpr size_t RX_CH_FWD_SYNC_CMD_BUF_IDS_START_IDX = RX_CH_FWD_DATA_CMD_BUF_IDS_START_IDX + NUM_RECEIVER_CHANNELS;
-constexpr size_t RX_CH_LOCAL_WRITE_NOC_ID_IDX = RX_CH_FWD_SYNC_CMD_BUF_IDS_START_IDX + NUM_RECEIVER_CHANNELS;
-constexpr size_t RX_CH_LOCAL_WRITE_CMD_BUF_ID_IDX = RX_CH_LOCAL_WRITE_NOC_ID_IDX + NUM_RECEIVER_CHANNELS;
-
+// ============================================================================
+// Receiver channel per-channel arrays
+// ============================================================================
+static constexpr std::array<size_t, MAX_NUM_RECEIVER_CHANNELS> receiver_channel_forwarding_noc_ids_all_ = {
+    static_cast<size_t>(NAMED_CT_ARG("RX_CH_FWD_NOC_ID_0")),
+    static_cast<size_t>(NAMED_CT_ARG("RX_CH_FWD_NOC_ID_1")),
+};
 constexpr std::array<size_t, NUM_RECEIVER_CHANNELS> receiver_channel_forwarding_noc_ids =
-    fill_array_with_next_n_args<size_t, RX_CH_FWD_NOC_IDS_START_IDX, NUM_RECEIVER_CHANNELS>();
+    take_first_n_elements<NUM_RECEIVER_CHANNELS, MAX_NUM_RECEIVER_CHANNELS, size_t>(
+        receiver_channel_forwarding_noc_ids_all_);
+
+static constexpr std::array<uint8_t, MAX_NUM_RECEIVER_CHANNELS> receiver_channel_forwarding_data_cmd_buf_ids_all_ = {
+    static_cast<uint8_t>(NAMED_CT_ARG("RX_CH_FWD_DATA_CMD_BUF_ID_0")),
+    static_cast<uint8_t>(NAMED_CT_ARG("RX_CH_FWD_DATA_CMD_BUF_ID_1")),
+};
 constexpr std::array<uint8_t, NUM_RECEIVER_CHANNELS> receiver_channel_forwarding_data_cmd_buf_ids =
-    fill_array_with_next_n_args<uint8_t, RX_CH_FWD_DATA_CMD_BUF_IDS_START_IDX, NUM_RECEIVER_CHANNELS>();
+    take_first_n_elements<NUM_RECEIVER_CHANNELS, MAX_NUM_RECEIVER_CHANNELS, uint8_t>(
+        receiver_channel_forwarding_data_cmd_buf_ids_all_);
+
+static constexpr std::array<uint8_t, MAX_NUM_RECEIVER_CHANNELS> receiver_channel_forwarding_sync_cmd_buf_ids_all_ = {
+    static_cast<uint8_t>(NAMED_CT_ARG("RX_CH_FWD_SYNC_CMD_BUF_ID_0")),
+    static_cast<uint8_t>(NAMED_CT_ARG("RX_CH_FWD_SYNC_CMD_BUF_ID_1")),
+};
 constexpr std::array<uint8_t, NUM_RECEIVER_CHANNELS> receiver_channel_forwarding_sync_cmd_buf_ids =
-    fill_array_with_next_n_args<uint8_t, RX_CH_FWD_SYNC_CMD_BUF_IDS_START_IDX, NUM_RECEIVER_CHANNELS>();
+    take_first_n_elements<NUM_RECEIVER_CHANNELS, MAX_NUM_RECEIVER_CHANNELS, uint8_t>(
+        receiver_channel_forwarding_sync_cmd_buf_ids_all_);
+
+static constexpr std::array<size_t, MAX_NUM_RECEIVER_CHANNELS> receiver_channel_local_write_noc_ids_all_ = {
+    static_cast<size_t>(NAMED_CT_ARG("RX_CH_LOCAL_WRITE_NOC_ID_0")),
+    static_cast<size_t>(NAMED_CT_ARG("RX_CH_LOCAL_WRITE_NOC_ID_1")),
+};
 constexpr std::array<size_t, NUM_RECEIVER_CHANNELS> receiver_channel_local_write_noc_ids =
-    fill_array_with_next_n_args<size_t, RX_CH_LOCAL_WRITE_NOC_ID_IDX, NUM_RECEIVER_CHANNELS>();
+    take_first_n_elements<NUM_RECEIVER_CHANNELS, MAX_NUM_RECEIVER_CHANNELS, size_t>(
+        receiver_channel_local_write_noc_ids_all_);
+
+static constexpr std::array<uint8_t, MAX_NUM_RECEIVER_CHANNELS> receiver_channel_local_write_cmd_buf_ids_all_ = {
+    static_cast<uint8_t>(NAMED_CT_ARG("RX_CH_LOCAL_WRITE_CMD_BUF_ID_0")),
+    static_cast<uint8_t>(NAMED_CT_ARG("RX_CH_LOCAL_WRITE_CMD_BUF_ID_1")),
+};
 constexpr std::array<uint8_t, NUM_RECEIVER_CHANNELS> receiver_channel_local_write_cmd_buf_ids =
-    fill_array_with_next_n_args<uint8_t, RX_CH_LOCAL_WRITE_CMD_BUF_ID_IDX, NUM_RECEIVER_CHANNELS>();
+    take_first_n_elements<NUM_RECEIVER_CHANNELS, MAX_NUM_RECEIVER_CHANNELS, uint8_t>(
+        receiver_channel_local_write_cmd_buf_ids_all_);
 
-// TODO: Add a special marker in CT args so we don't misalign unintentionally
-constexpr size_t EDM_NOC_VC_IDX = RX_CH_LOCAL_WRITE_CMD_BUF_ID_IDX + NUM_RECEIVER_CHANNELS;
-constexpr size_t SPECIAL_MARKER_1_IDX = EDM_NOC_VC_IDX + 1;
-constexpr size_t SPECIAL_MARKER_1 = 0x10c0ffee;
-static_assert(
-    !SPECIAL_MARKER_CHECK_ENABLED || get_compile_time_arg_val(SPECIAL_MARKER_1_IDX) == SPECIAL_MARKER_1,
-    "Special marker 1 not found. This implies some arguments were misaligned between host and device. Double check the "
-    "CT args.");
-
-///////////////////////////////////////////////
+// ============================================================================
 // Telemetry
-constexpr size_t PERF_TELEMETRY_MODE_IDX = SPECIAL_MARKER_1_IDX + SPECIAL_MARKER_CHECK_ENABLED;
+// ============================================================================
+constexpr bool ENABLE_FABRIC_TELEMETRY = static_cast<bool>(NAMED_CT_ARG("ENABLE_FABRIC_TELEMETRY"));
 
-constexpr bool ENABLE_FABRIC_TELEMETRY = static_cast<bool>(get_compile_time_arg_val(PERF_TELEMETRY_MODE_IDX));
-
-constexpr uint8_t FABRIC_TELEMETRY_STATS_MASK =
-    static_cast<uint8_t>(get_compile_time_arg_val(PERF_TELEMETRY_MODE_IDX + 1));
+constexpr uint8_t FABRIC_TELEMETRY_STATS_MASK = static_cast<uint8_t>(NAMED_CT_ARG("FABRIC_TELEMETRY_STATS_MASK"));
 constexpr bool FABRIC_TELEMETRY_ROUTER_STATE =
     ENABLE_FABRIC_TELEMETRY &&
     ((FABRIC_TELEMETRY_STATS_MASK & static_cast<uint8_t>(DynamicStatistics::ROUTER_STATE)) != 0);
@@ -438,34 +477,22 @@ constexpr bool FABRIC_TELEMETRY_ANY_DYNAMIC_STAT = FABRIC_TELEMETRY_ROUTER_STATE
                                                    FABRIC_TELEMETRY_HEARTBEAT_TX || FABRIC_TELEMETRY_HEARTBEAT_RX;
 
 constexpr PerfTelemetryRecorderType perf_telemetry_mode =
-    static_cast<PerfTelemetryRecorderType>(get_compile_time_arg_val(PERF_TELEMETRY_MODE_IDX + 2));
+    static_cast<PerfTelemetryRecorderType>(NAMED_CT_ARG("PERF_TELEMETRY_MODE"));
 
-constexpr size_t PERF_TELEMETRY_BUFFER_ADDR_IDX = PERF_TELEMETRY_MODE_IDX + 3;
-constexpr size_t perf_telemetry_buffer_addr = get_compile_time_arg_val(PERF_TELEMETRY_BUFFER_ADDR_IDX);
+constexpr size_t perf_telemetry_buffer_addr = NAMED_CT_ARG("PERF_TELEMETRY_BUFFER_ADDR");
 
-
-///////////////////////////////////////////////
+// ============================================================================
 // Code Profiling
-constexpr size_t CODE_PROFILING_ENABLED_TIMERS_IDX = PERF_TELEMETRY_BUFFER_ADDR_IDX + 1;
-constexpr uint32_t code_profiling_enabled_timers_bitfield = get_compile_time_arg_val(CODE_PROFILING_ENABLED_TIMERS_IDX);
+// ============================================================================
+constexpr uint32_t code_profiling_enabled_timers_bitfield = NAMED_CT_ARG("CODE_PROFILING_ENABLED_TIMERS");
+constexpr size_t code_profiling_buffer_base_addr = NAMED_CT_ARG("CODE_PROFILING_BUFFER_ADDR");
 
-constexpr size_t CODE_PROFILING_BUFFER_ADDR_IDX = CODE_PROFILING_ENABLED_TIMERS_IDX + 1;
-constexpr size_t code_profiling_buffer_base_addr = get_compile_time_arg_val(CODE_PROFILING_BUFFER_ADDR_IDX);
-
-constexpr size_t SPECIAL_MARKER_2A_IDX = CODE_PROFILING_BUFFER_ADDR_IDX + 1;
-constexpr size_t SPECIAL_MARKER_2A = 0x20c0ffee;
-static_assert(
-    !SPECIAL_MARKER_CHECK_ENABLED || get_compile_time_arg_val(SPECIAL_MARKER_2A_IDX) == SPECIAL_MARKER_2A,
-    "Special marker 2A not found. This implies some arguments were misaligned between host and device. Double check the "
-    "CT args.");
-
-constexpr size_t TO_SENDER_CREDIT_COUNTERS_START_IDX = SPECIAL_MARKER_2A_IDX + SPECIAL_MARKER_CHECK_ENABLED;
-
-constexpr size_t to_sender_remote_ack_counters_base_address =
-    conditional_get_compile_time_arg<multi_txq_enabled, TO_SENDER_CREDIT_COUNTERS_START_IDX>();
-
+// ============================================================================
+// Multi-TXQ credit counters (always available; 0 when inactive)
+// ============================================================================
+constexpr size_t to_sender_remote_ack_counters_base_address = NAMED_CT_ARG("TO_SENDER_REMOTE_ACK_COUNTERS_BASE_ADDR");
 constexpr size_t to_sender_remote_completion_counters_base_address =
-    conditional_get_compile_time_arg<multi_txq_enabled, TO_SENDER_CREDIT_COUNTERS_START_IDX + 1>();
+    NAMED_CT_ARG("TO_SENDER_REMOTE_COMPLETION_COUNTERS_BASE_ADDR");
 
 // To optimize for CPU bottleneck instructions, instead of sending acks individually, based on the specific credit
 // addresses, the router instead will send all credits at once. This eliminates a handful of instructions per ack. This
@@ -474,11 +501,9 @@ constexpr size_t to_sender_remote_completion_counters_base_address =
 constexpr size_t to_senders_credits_base_address =
     std::min(to_sender_remote_ack_counters_base_address, to_sender_remote_completion_counters_base_address);
 
-constexpr size_t local_receiver_ack_counters_base_address =
-    conditional_get_compile_time_arg<multi_txq_enabled, TO_SENDER_CREDIT_COUNTERS_START_IDX + 2>();
-
+constexpr size_t local_receiver_ack_counters_base_address = NAMED_CT_ARG("LOCAL_RECEIVER_ACK_COUNTERS_BASE_ADDR");
 constexpr size_t local_receiver_completion_counters_base_address =
-    conditional_get_compile_time_arg<multi_txq_enabled, TO_SENDER_CREDIT_COUNTERS_START_IDX + 3>();
+    NAMED_CT_ARG("LOCAL_RECEIVER_COMPLETION_COUNTERS_BASE_ADDR");
 
 constexpr size_t local_receiver_credits_base_address =
     std::min(local_receiver_ack_counters_base_address, local_receiver_completion_counters_base_address);
@@ -505,24 +530,16 @@ static_assert(
     !multi_txq_enabled || local_receiver_completion_counters_base_address != 0,
     "local_receiver_completion_counters_base_address must be valid");
 
-constexpr size_t SPECIAL_MARKER_3_IDX = TO_SENDER_CREDIT_COUNTERS_START_IDX + (multi_txq_enabled ? 4 : 0);
-constexpr size_t SPECIAL_MARKER_3 = 0x30c0ffee;
-static_assert(
-    !SPECIAL_MARKER_CHECK_ENABLED || get_compile_time_arg_val(SPECIAL_MARKER_3_IDX) == SPECIAL_MARKER_3,
-    "Special marker 2 not found. This implies some arguments were misaligned between host and device. Double check the "
-    "CT args.");
-
-constexpr size_t HOST_SIGNAL_ARGS_START_IDX = SPECIAL_MARKER_3_IDX + SPECIAL_MARKER_CHECK_ENABLED;
-// static_assert(HOST_SIGNAL_ARGS_START_IDX == 56, "HOST_SIGNAL_ARGS_START_IDX must be 56");
+// ============================================================================
+// Host signal args (named; always available, 0 when wait_for_host_signal is false)
+// ============================================================================
 // TODO: Add type safe getter
 constexpr bool is_local_handshake_master =
-    bool(conditional_get_compile_time_arg<wait_for_host_signal, HOST_SIGNAL_ARGS_START_IDX + 0>());
+    wait_for_host_signal ? (NAMED_CT_ARG("IS_LOCAL_HANDSHAKE_MASTER") != 0) : false;
 constexpr uint32_t local_handshake_master_eth_chan =
-    conditional_get_compile_time_arg<wait_for_host_signal, HOST_SIGNAL_ARGS_START_IDX + 1>();
-constexpr uint32_t num_local_edms =
-    conditional_get_compile_time_arg<wait_for_host_signal, HOST_SIGNAL_ARGS_START_IDX + 2>();
-constexpr uint32_t edm_channels_mask =
-    conditional_get_compile_time_arg<wait_for_host_signal, HOST_SIGNAL_ARGS_START_IDX + 3>();
+    wait_for_host_signal ? NAMED_CT_ARG("LOCAL_HANDSHAKE_MASTER_ETH_CHAN") : 0;
+constexpr uint32_t num_local_edms = wait_for_host_signal ? NAMED_CT_ARG("NUM_LOCAL_EDMS") : 0;
+constexpr uint32_t edm_channels_mask = wait_for_host_signal ? NAMED_CT_ARG("EDM_CHANNELS_MASK") : 0;
 
 template <size_t SLOT_SIZE_BYTES, size_t PACKET_HEADER_SIZE_BYTES>
 struct BufferSlot {
@@ -532,11 +549,6 @@ struct BufferSlot {
 };
 
 using buffer_slot = BufferSlot<channel_buffer_size, sizeof(PACKET_HEADER_TYPE)>;
-
-constexpr uint32_t ELASTIC_CHANNELS_CT_ARG_START_IDX = HOST_SIGNAL_ARGS_START_IDX + 4;
-using FWDED_SENDER_ELASTIC_CHANNELS_INFO =
-    tt::tt_fabric::elastic_channels::RouterElasticChannelsCtArgs<ELASTIC_CHANNELS_CT_ARG_START_IDX, buffer_slot::size_bytes>;
-
 
 constexpr size_t NUM_FORWARDED_SENDER_CHANNELS = NUM_SENDER_CHANNELS - 1;
 
@@ -606,7 +618,7 @@ static constexpr uint8_t worker_handshake_noc = sender_channel_ack_noc_ids[0];
 constexpr bool local_chip_noc_equals_downstream_noc =
     receiver_channel_forwarding_noc_ids[0] == receiver_channel_local_write_noc_ids[0];
 static constexpr uint8_t local_chip_data_cmd_buf = receiver_channel_local_write_cmd_buf_ids[0];
-static constexpr uint8_t forward_and_local_write_noc_vc = get_compile_time_arg_val(EDM_NOC_VC_IDX);
+static constexpr uint8_t forward_and_local_write_noc_vc = NAMED_CT_ARG("EDM_NOC_VC");
 
 // ----------------------------------------------------------------------------- //
 // --------------------------------- PLACEHOLDER ------------------------------- //
@@ -620,8 +632,7 @@ constexpr std::array<bool, NUM_SENDER_CHANNELS> IS_ELASTIC_SENDER_CHANNEL =
 template <typename ChannelPoolCollection, auto& ChannelToPoolIndex, size_t ChannelIdx>
 constexpr size_t get_channel_num_slots() {
     constexpr size_t pool_idx = ChannelToPoolIndex[ChannelIdx];
-    constexpr auto pool_type = static_cast<FabricChannelPoolType>(
-        ChannelPoolCollection::channel_pool_types[pool_idx]);
+    constexpr auto pool_type = static_cast<FabricChannelPoolType>(ChannelPoolCollection::channel_pool_types[pool_idx]);
 
     // If static pool, extract num_slots; otherwise default to 0
     if constexpr (pool_type == FabricChannelPoolType::STATIC) {
@@ -636,8 +647,7 @@ constexpr size_t get_channel_num_slots() {
 template <typename ChannelPoolCollection, auto& ChannelToPoolIndex, size_t ChannelIdx>
 constexpr size_t get_channel_remote_num_slots() {
     constexpr size_t pool_idx = ChannelToPoolIndex[ChannelIdx];
-    constexpr auto pool_type = static_cast<FabricChannelPoolType>(
-        ChannelPoolCollection::channel_pool_types[pool_idx]);
+    constexpr auto pool_type = static_cast<FabricChannelPoolType>(ChannelPoolCollection::channel_pool_types[pool_idx]);
 
     // If static pool, extract remote_num_slots; otherwise default to 0
     if constexpr (pool_type == FabricChannelPoolType::STATIC) {
@@ -700,13 +710,14 @@ constexpr std::array<size_t, NUM_RECEIVER_CHANNELS> REMOTE_RECEIVER_NUM_BUFFERS_
 constexpr bool disable_rx_ch0_forwarding = get_named_compile_time_arg_val("DISABLE_RX_CH0_FORWARDING") != 0;
 constexpr bool disable_rx_ch1_forwarding = get_named_compile_time_arg_val("DISABLE_RX_CH1_FORWARDING") != 0;
 constexpr std::array<bool, MAX_NUM_RECEIVER_CHANNELS> is_receiver_channel_forwarding_disabled = {
-    disable_rx_ch0_forwarding,
-    disable_rx_ch1_forwarding
-};
+    disable_rx_ch0_forwarding, disable_rx_ch1_forwarding};
 
-
-constexpr bool ENABLE_CHANNEL_TRIMMING_RESOURCE_USAGE_CAPTURE = get_named_compile_time_arg_val("ENABLE_CHANNEL_TRIMMING_RESOURCE_USAGE_CAPTURE");
-constexpr size_t RESOURCE_USAGE_CAPTURE_OUTPUT_L1_ADDRESS = ENABLE_CHANNEL_TRIMMING_RESOURCE_USAGE_CAPTURE ? get_named_compile_time_arg_val("RESOURCE_USAGE_CAPTURE_OUTPUT_L1_ADDRESS") : 0;
+constexpr bool ENABLE_CHANNEL_TRIMMING_RESOURCE_USAGE_CAPTURE =
+    get_named_compile_time_arg_val("ENABLE_CHANNEL_TRIMMING_RESOURCE_USAGE_CAPTURE");
+constexpr size_t RESOURCE_USAGE_CAPTURE_OUTPUT_L1_ADDRESS =
+    ENABLE_CHANNEL_TRIMMING_RESOURCE_USAGE_CAPTURE
+        ? get_named_compile_time_arg_val("RESOURCE_USAGE_CAPTURE_OUTPUT_L1_ADDRESS")
+        : 0;
 
 using ChannelTrimmingUsagePtr = tt::tt_fabric::FabricDatapathUsageL1Ptr<
     ENABLE_CHANNEL_TRIMMING_RESOURCE_USAGE_CAPTURE,


### PR DESCRIPTION
## Summary

Migrate compile-time arguments in the ERISC fabric router from positional `get_compile_time_arg_val(IDX)` to named `get_named_compile_time_arg_val("NAME")` for improved readability and robustness against argument reordering.

## Problem

The previous approach used positional indices (e.g., `get_compile_time_arg_val(42)`) with long chains of index calculations and special alignment markers. This was:
- **Hard to read**: Argument meanings were obscured behind numeric indices
- **Error-prone**: Adding or removing arguments shifted all subsequent indices
- **Fragile**: Required magic-number markers (e.g., `0xFFEE0001`, `0xabcd9876`, `0x00c0ffee`) to detect misalignment

## Solution

### Design Principles
1. **Positional vector shrinks**: Only channel pool collection data remains in `compile_args`. All other args move to `named_compile_args`.
2. **Pool data starts at index 0**: With non-pool args removed, `CHANNEL_POOL_COLLECTION_IDX = 0`.
3. **Always emit conditional args**: Instead of conditionally omitting args, always emit all args with a default of `0` when inactive. This eliminates `conditional_get_compile_time_arg` and avoids `constexpr` evaluation issues.
4. **Array naming**: Array elements use indexed names (e.g., `"SENDER_CH_0_ACK_NOC_ID"` through `"SENDER_CH_8_ACK_NOC_ID"`).
5. **Markers removed**: Alignment markers for non-pool sections become unnecessary and are deleted.

### Files Changed
- **`erisc_datamover_builder.cpp`**: Move ~100 scalar and array args from positional `ct_args` vector to `named_args` map.
- **`erisc_datamover_builder.hpp`**: Update `get_telemetry_compile_time_args` signature.
- **`compute_mesh_router_builder.cpp`**: Convert host-signal args to named args.
- **`fabric_erisc_router_ct_args.hpp`**: Replace all positional lookups with `NAMED_CT_ARG("NAME")` macro.

### What's NOT Changed
- Channel pool collection (`ChannelPoolCollection`, `StaticChannelPool`, `ElasticChannelPool`) remains positional — these use variable-length serialization that is inherently positional.