### PR TITLE
Refactor DispatchMemMap to take Hal as explicit constructor parameter

### DIFF
--- a/tt_metal/impl/context/metal_context.cpp
+++ b/tt_metal/impl/context/metal_context.cpp
@@ -207,9 +207,9 @@ void MetalContext::initialize(
     // Need DispatchMemMap for both dispatch core types
     tt_metal::DispatchSettings::initialize(*cluster_);
     dispatch_mem_map_[enchantum::to_underlying(CoreType::WORKER)] =
-        std::make_unique<DispatchMemMap>(CoreType::WORKER, num_hw_cqs);
+        std::make_unique<DispatchMemMap>(*hal_, CoreType::WORKER, num_hw_cqs);
     dispatch_mem_map_[enchantum::to_underlying(CoreType::ETH)] =
-        std::make_unique<DispatchMemMap>(CoreType::ETH, num_hw_cqs);
+        std::make_unique<DispatchMemMap>(*hal_, CoreType::ETH, num_hw_cqs);
     // Initialize debug servers. Attaching individual devices done below
     rtoptions_.resolve_fabric_node_ids_to_chip_ids(this->get_control_plane());
     if (rtoptions_.get_feature_enabled(tt::llrt::RunTimeDebugFeatureDprint)) {

--- a/tt_metal/impl/device/firmware/dispatch_kernel_initializer.cpp
+++ b/tt_metal/impl/device/firmware/dispatch_kernel_initializer.cpp
@@ -67,9 +67,9 @@ void DispatchKernelInitializer::init(
     devices_ = devices;
 
     dispatch_mem_map_[enchantum::to_underlying(CoreType::WORKER)] =
-        std::make_unique<tt::tt_metal::DispatchMemMap>(CoreType::WORKER, descriptor_->num_cqs());
+        std::make_unique<tt::tt_metal::DispatchMemMap>(descriptor_->hal(), CoreType::WORKER, descriptor_->num_cqs());
     dispatch_mem_map_[enchantum::to_underlying(CoreType::ETH)] =
-        std::make_unique<tt::tt_metal::DispatchMemMap>(CoreType::ETH, descriptor_->num_cqs());
+        std::make_unique<tt::tt_metal::DispatchMemMap>(descriptor_->hal(), CoreType::ETH, descriptor_->num_cqs());
 
     // Skip firmware initialization for mock devices
     if (descriptor_->is_mock_device()) {

--- a/tt_metal/impl/dispatch/dispatch_mem_map.cpp
+++ b/tt_metal/impl/dispatch/dispatch_mem_map.cpp
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <enchantum/enchantum.hpp>
-#include "fabric/fabric_edm_packet_header.hpp"
 #include <tt-metalium/tt_align.hpp>
 
 #include "dispatch_mem_map.hpp"
@@ -11,14 +10,13 @@
 #include "command_queue_common.hpp"
 #include <tt-metalium/experimental/fabric/control_plane.hpp>
 #include "dispatch_settings.hpp"
-#include "fabric/fabric_context.hpp"
+#include "llrt/hal.hpp"
 #include "hal_types.hpp"
-#include "impl/context/metal_context.hpp"
 #include <tt_stl/enum.hpp>
 
 namespace tt::tt_metal {
 
-DispatchMemMap::DispatchMemMap(const CoreType& core_type, const uint32_t num_hw_cqs) {
+DispatchMemMap::DispatchMemMap(const Hal& hal, const CoreType& core_type, const uint32_t num_hw_cqs) : hal_(hal) {
     this->reset(core_type, num_hw_cqs);
 }
 
@@ -62,25 +60,20 @@ uint32_t DispatchMemMap::get_device_command_queue_addr(const CommandQueueDeviceA
 
 uint32_t DispatchMemMap::get_host_command_queue_addr(const CommandQueueHostAddrType& host_addr) const {
     return ttsl::as_underlying_type<CommandQueueHostAddrType>(host_addr) *
-           tt::tt_metal::MetalContext::instance().hal().get_alignment(tt::tt_metal::HalMemType::HOST);
+           hal_.get_alignment(tt::tt_metal::HalMemType::HOST);
 }
 
 uint32_t DispatchMemMap::get_sync_offset(uint32_t index) const {
     TT_ASSERT(index < tt::tt_metal::DispatchSettings::DISPATCH_MESSAGE_ENTRIES);
-    uint32_t offset = index * MetalContext::instance().hal().get_alignment(HalMemType::L1);
+    uint32_t offset = index * hal_.get_alignment(HalMemType::L1);
     return offset;
 }
 
 uint32_t DispatchMemMap::get_dispatch_message_addr_start() const {
     // Address of the first dispatch message entry. Remaining entries are each offset by
     // get_noc_stream_reg_space_size() bytes.
-    return tt::tt_metal::MetalContext::instance().hal().get_noc_overlay_start_addr() +
-           (tt::tt_metal::MetalContext::instance().hal().get_noc_stream_reg_space_size() *
-            get_dispatch_stream_index(0)) +
-           (tt::tt_metal::MetalContext::instance()
-                .hal()
-                .get_noc_stream_remote_dest_buf_space_available_update_reg_index() *
-            sizeof(uint32_t));
+    return hal_.get_noc_overlay_start_addr() + (hal_.get_noc_stream_reg_space_size() * get_dispatch_stream_index(0)) +
+           (hal_.get_noc_stream_remote_dest_buf_space_available_update_reg_index() * sizeof(uint32_t));
 }
 
 uint32_t DispatchMemMap::get_dispatch_stream_index(uint32_t index) const {
@@ -109,9 +102,8 @@ void DispatchMemMap::reset(const CoreType& core_type, const uint32_t num_hw_cqs)
 
     const auto dispatch_buffer_block_size = settings.dispatch_size_;
     const auto [l1_base, l1_size] = get_device_l1_info(settings.core_type_);
-    const auto pcie_alignment =
-        tt::tt_metal::MetalContext::instance().hal().get_alignment(tt::tt_metal::HalMemType::HOST);
-    const auto l1_alignment = tt::tt_metal::MetalContext::instance().hal().get_alignment(tt::tt_metal::HalMemType::L1);
+    const auto pcie_alignment = hal_.get_alignment(tt::tt_metal::HalMemType::HOST);
+    const auto l1_alignment = hal_.get_alignment(tt::tt_metal::HalMemType::L1);
 
     TT_ASSERT(settings.prefetch_cmddat_q_size_ >= 2 * settings.prefetch_max_cmd_size_);
     TT_ASSERT(settings.prefetch_scratch_db_size_ % 2 == 0);
@@ -184,15 +176,15 @@ std::pair<uint32_t, uint32_t> DispatchMemMap::get_device_l1_info(const CoreType&
     uint32_t l1_base;
     uint32_t l1_size;
     if (core_type == CoreType::WORKER) {
-        l1_base = MetalContext::instance().hal().get_dev_addr(
+        l1_base = hal_.get_dev_addr(
             tt::tt_metal::HalProgrammableCoreType::TENSIX, tt::tt_metal::HalL1MemAddrType::DEFAULT_UNRESERVED);
-        l1_size = MetalContext::instance().hal().get_dev_size(
-            tt::tt_metal::HalProgrammableCoreType::TENSIX, tt::tt_metal::HalL1MemAddrType::BASE);
+        l1_size =
+            hal_.get_dev_size(tt::tt_metal::HalProgrammableCoreType::TENSIX, tt::tt_metal::HalL1MemAddrType::BASE);
     } else if (core_type == CoreType::ETH) {
-        l1_base = MetalContext::instance().hal().get_dev_addr(
+        l1_base = hal_.get_dev_addr(
             tt::tt_metal::HalProgrammableCoreType::IDLE_ETH, tt::tt_metal::HalL1MemAddrType::UNRESERVED);
-        l1_size = MetalContext::instance().hal().get_dev_size(
-            tt::tt_metal::HalProgrammableCoreType::IDLE_ETH, tt::tt_metal::HalL1MemAddrType::BASE);
+        l1_size =
+            hal_.get_dev_size(tt::tt_metal::HalProgrammableCoreType::IDLE_ETH, tt::tt_metal::HalL1MemAddrType::BASE);
     } else {
         TT_THROW("get_base_device_command_queue_addr not implemented for core type");
     }

--- a/tt_metal/impl/dispatch/dispatch_mem_map.hpp
+++ b/tt_metal/impl/dispatch/dispatch_mem_map.hpp
@@ -14,6 +14,7 @@
 
 namespace tt::tt_metal {
 enum class CommandQueueDeviceAddrType : uint8_t;
+class Hal;
 }  // namespace tt::tt_metal
 
 namespace tt::tt_metal {
@@ -24,13 +25,16 @@ namespace tt::tt_metal {
 // order. The size of each address type and L1 base is
 // set by DispatchSettings.
 //
+// IMPORTANT: DispatchMemMap stores a reference to a Hal object. Callers must
+// ensure the Hal outlives the DispatchMemMap instance.
+//
 class DispatchMemMap {
 public:
     DispatchMemMap& operator=(const DispatchMemMap&) = delete;
     DispatchMemMap& operator=(DispatchMemMap&& other) noexcept = delete;
     DispatchMemMap(const DispatchMemMap&) = delete;
     DispatchMemMap(DispatchMemMap&& other) noexcept = delete;
-    DispatchMemMap(const CoreType& core_type, uint32_t num_hw_cqs);
+    DispatchMemMap(const Hal& hal, const CoreType& core_type, uint32_t num_hw_cqs);
 
     uint32_t prefetch_q_entries() const;
 
@@ -92,6 +96,7 @@ private:
 
     DispatchSettings settings;
 
+    const Hal& hal_;
     uint32_t hw_cqs{0};  // 0 means uninitialized
     CoreType last_core_type{CoreType::WORKER};
 };

--- a/tt_metal/impl/dispatch/kernel_config/fd_kernel.hpp
+++ b/tt_metal/impl/dispatch/kernel_config/fd_kernel.hpp
@@ -117,9 +117,9 @@ public:
         get_max_num_eth_cores_(get_max_num_eth_cores),
         get_reads_dispatch_cores_(get_reads_dispatch_cores) {
         dispatch_mem_map_[enchantum::to_underlying(CoreType::WORKER)] =
-            std::make_unique<tt::tt_metal::DispatchMemMap>(CoreType::WORKER, descriptor.num_cqs());
+            std::make_unique<tt::tt_metal::DispatchMemMap>(descriptor.hal(), CoreType::WORKER, descriptor.num_cqs());
         dispatch_mem_map_[enchantum::to_underlying(CoreType::ETH)] =
-            std::make_unique<tt::tt_metal::DispatchMemMap>(CoreType::ETH, descriptor.num_cqs());
+            std::make_unique<tt::tt_metal::DispatchMemMap>(descriptor.hal(), CoreType::ETH, descriptor.num_cqs());
     }
     virtual ~FDKernel() = default;
 

--- a/tt_metal/impl/dispatch/topology.cpp
+++ b/tt_metal/impl/dispatch/topology.cpp
@@ -408,9 +408,9 @@ DispatchTopology::DispatchTopology(
     get_reads_dispatch_cores_(get_reads_dispatch_cores) {
     command_queue_compile_group_ = std::make_unique<detail::ProgramCompileGroup>();
     dispatch_mem_map_[enchantum::to_underlying(CoreType::WORKER)] =
-        std::make_unique<DispatchMemMap>(CoreType::WORKER, descriptor_.num_cqs());
+        std::make_unique<DispatchMemMap>(descriptor_.hal(), CoreType::WORKER, descriptor_.num_cqs());
     dispatch_mem_map_[enchantum::to_underlying(CoreType::ETH)] =
-        std::make_unique<DispatchMemMap>(CoreType::ETH, descriptor_.num_cqs());
+        std::make_unique<DispatchMemMap>(descriptor_.hal(), CoreType::ETH, descriptor_.num_cqs());
 }
 
 DispatchTopology::~DispatchTopology() { reset(); }


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/38395

### Problem description
JIT build requires knowing `dispatch_message_addr` at build time.  This value is computed by `get_dispatch_message_addr_start()`, which relies on the hal object in MetalContext.  This means it is always associated with the live device on host.

For offline build, we may want to compute dispatch_message_addr for different archs, so we will supply custom Hal (not in MetalContext).  For this to work, DispatchMemMap needs to be able to take any Hal.

### What's changed
- Require Hal in the constructor.
- Removed the dependency to `MetalContext::instance().hal()` in tt_metal/impl/dispatch/dispatch_mem_map.cpp


### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=ruizhang/dispatch_mem_map)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:ruizhang/dispatch_mem_map)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ruizhang/dispatch_mem_map)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ruizhang/dispatch_mem_map)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ruizhang/dispatch_mem_map)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ruizhang/dispatch_mem_map)
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ruizhang/dispatch_mem_map)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ruizhang/dispatch_mem_map)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ruizhang/dispatch_mem_map)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ruizhang/dispatch_mem_map)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ruizhang/dispatch_mem_map)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ruizhang/dispatch_mem_map)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
