### PR TITLE
Coarse mock-up for Metal 2.0 host APIs

### DIFF
--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api_mockup/example_usage/simple_dfb_example.cpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api_mockup/example_usage/simple_dfb_example.cpp
@@ -1,0 +1,208 @@
+////////////////////////////////////////////////////////////
+// Simple Program with multi-threaded kernels and local DFBs.
+
+// This is a trivial example, intended mainly to illustrate the 
+// new DFB syntax. It has only one type of worker.
+// ////////////////////////////////////////////////////////////
+
+
+// Note: The overloaded meaning of "core" is especially confusing 
+// on Quasar! We reserve the term "core" for RISC-V cores.
+// We'll  use the term "Node" for the physical NOC endpoints.
+
+
+
+////////////////////////////////////////////////////////////
+// Basis worker nodes
+////////////////////////////////////////////////////////////
+
+// All the nodes in this set will be identically configured.
+NodeRange type1_nodes = NodeRange(NodeCoord{0, 0}, NodeCoord{3, 1});
+
+
+//-------------------
+// Dataflow Buffers
+
+// Basic local DFB (DM -> compute)
+DataflowBufferSpec compute_feeder_dfb_spec{   
+    .identifier = "compute_feeder", 
+    .target_nodes = {
+        .nodes = type1_nodes,
+        // for remote DFB, the producer-consumer map would be here.
+    }
+    .backing_memory = {
+        .entry_size = 32, // bytes
+        .num_entries = 8
+    }
+    // Endpoint info is specified when the DFB is bound to a kernel.
+};
+
+// Basic local DFB (compute -> DM)
+DataflowBufferSpec compute_output_dfb_spec{   
+    .identifier = "compute_output",
+    .target_nodes = {
+        .nodes = type1_nodes,
+    }
+    .backing_memory = {
+        .entry_size = 32, // bytes
+        .num_entries = 8
+    },
+    // Endpoint info is specified when the DFB is bound to a kernel.
+};
+
+////////////////////////////////////////////////////////////
+// Kernels
+////////////////////////////////////////////////////////////
+
+// Reader kernel
+KernelSpec reader_kernel_spec{
+    .identifier = "reader_kernel",
+    .source = "reader_kernel.cpp",
+    .target_nodes = {         
+        .nodes = type1_nodes, 
+        .num_threads = 4,      
+    }
+    .compiler_options = {
+        .include_paths = {"../somewhere/my_kernels"}
+    },
+    .dfb_bindings = {
+        DFBBinding{.dfb_id = "compute_feeder", 
+                   .local_accessor_name = "dfb_out", 
+                   .endpoint_type = DFBEndpointType::PRODUCER,
+                   .access_pattern = DFBAccessPattern::STRIDED}
+    },
+    .kernel_args_spec = {
+        // Coming soon...
+    },
+    .hardware_config = Gen2DataMovementConfig{};
+};
+
+
+// Compute kernel
+KernelSpec consumer_kernel_spec{
+    .source = "compute_kernel.cpp",
+    .target_nodes = {          // different from Option 2
+        .nodes = type1_nodes, 
+        .num_threads = 4,
+    }
+    .compiler_options = {
+        .include_paths = {"../somewhere/my_kernels"}
+    },
+    .dfb_bindings = {
+        DFBBinding{.dfb_id = "compute_feeder", 
+                   .local_accessor_name = "dfb_in",  
+                   .endpoint_type = DFBEndpointType::CONSUMER,
+                   .access_pattern = DFBAccessPattern::BLOCKED}
+        DFBBinding{.dfb_id = "compute_output", 
+                   .local_accessor_name = "dfb_out", 
+                   .endpoint_type = DFBEndpointType::PRODUCER,
+                   .access_pattern = DFBAccessPattern::STRIDED}
+    },
+    .kernel_args_spec = {
+        // Coming soon...
+    },  
+    .hardware_config = Gen2TensixComputeConfig{}; // just accept defaults
+};
+
+// Writer kernel
+KernelSpec writer_kernel_spec{
+    .source = "writer_kernel.cpp",
+    .target_nodes = {       
+        .nodes = type1_nodes, 
+        .num_threads = 4,
+    }
+    .compiler_options = {
+        .include_paths = {"../somewhere/my_kernels"}
+    },
+    .dfb_bindings = {
+        DFBBinding{.dfb_id = "compute_output", 
+                   .local_accessor_name = "dfb_in", 
+                   .endpoint_type = DFBEndpointType::CONSUMER,
+                   .access_pattern = DFBAccessPattern::STRIDED}
+    },
+    .kernel_args_spec = {
+        // Coming soon...
+    },
+    .hardware_config = Gen2DataMovementConfig{};
+};
+
+////////////////////////////////////////////////////////////
+// Program
+////////////////////////////////////////////////////////////
+
+// Create a worker spec for this node type
+WorkerSpec type1_worker_spec{
+    .kernels = { 
+        reader_kernel_spec,
+        compute_kernel_spec,
+        writer_kernel_spec,
+    },
+    .dataflow_buffers = {
+        compute_feeder_dfb_spec,
+        compute_output_dfb_spec,
+    }
+    .nodes = type1_nodes,
+};
+
+// Note: A KernelSpec, DataflowBufferSpec, and SemaphoreSpec can be used in multiple
+//   WorkerSpecs. But, all of the WorkerSpec's constituent objects target nodes must
+//   include the WorkerSpec's target nodes.
+//   This is enforced by the legality check in the Program constructor.
+
+
+// The ProgramSpec just holds a vector of WorkerSpecs.
+ProgramSpec program_spec{
+    .workers = {
+        type1_worker_spec
+    }
+};
+
+
+// Create the program object
+Program simple_program(simple_program_spec);
+// Alternatively, we could just pass in a vector of WorkerSpecs directly.
+// Program simple_program({worker_type1_spec, worker_type2_spec, ...});
+
+// Add to MeshWorkload 
+// This is a transfer of ownership -- note the std::move!
+MeshWorklad mesh_workload;
+mesh_workload.add_program(target_device_range, std::move(simple_program));
+
+// This is dumb... should change it to:
+// my_mesh_workload.add_program(target_device_range, simple_program_spec);
+
+
+////////////////////////////////////////////////////////////
+// Program run parameters
+////////////////////////////////////////////////////////////
+
+ProgramRunParams program_run_params{
+    .kernel_run_params = {
+        KernelRunParams{.kernel_id = "reader_kernel",
+                        .runtime_args = {/*TODO*/},
+                        .common_runtime_args = {/*TODO*/},
+                        {.kernel_id = "compute_kernel",
+                         .runtime_args = {/*TODO*/  },
+                         .common_runtime_args = {/*TODO*/},
+                        },
+                        {.kernel_id = "writer_kernel",
+                         .runtime_args = {/*TODO*/},
+                         .common_runtime_args = {/*TODO*/},
+                        },
+    }
+    // No DFB run params needed
+    // (Only used in rare/niche use cases.)
+};
+
+// The syntax to retrieve the program is a bit clunky....
+auto& programs = mesh_workload.get_programs();
+auto& [coord_range, program] = *programs.begin(); 
+
+
+// The descriptor-based syntax is nice, but it performs a copy of
+// the kernel runtime arguments vector into the dispatch buffer.
+program.set_run_parameters(program_run_params);
+
+// Alternative, you can use more verbose APIs to construct
+// the runtime arguments vector in place. (TBD)
+

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api_mockup/header_stubs/dataflow_buffer_spec.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api_mockup/header_stubs/dataflow_buffer_spec.hpp
@@ -9,17 +9,16 @@ struct DataflowBufferSpec {
     // DFB identifier
     // A handle used to reference this DFB within the ProgramSpec
     std::variant<DFBid, DFBName> unique_id;  
-    // TODO -- I'm strongly considering removing the string option. 
-    // It spews icky variants everywhere, for little advantage. You'd just use a named variable as a handle anyways.
+    // (I intend to remove either the string or uint32_t option. Having both is annoying. Thoughts?)
 
     // Target nodes
     using Nodes = std::variant<NodeCoord, NodeRange, NodeRangeSet>
     Nodes target_nodes;
 
     // Backing memory
-    uint32_t entry_size;   // in bytes
+    uint32_t entry_size;  // in bytes
     uint32_t num_entries;  
-    // Note: It is possible to override these per-Program execution (via program execution parameters).
+    // Note: It is possible to override these per-Program execution (via ProgramRunParams).
 
     // Endpoint info 
     // Configuring a DFB requires endpoint-specific info.
@@ -39,7 +38,7 @@ struct DataflowBufferSpec {
     // A "remote DFB" has its producer and consumer kernels on different nodes.
     // For a remote DFB, you must specify the producer-consumer map.
     bool is_remote_dfb = false;
-    using ProducerConsumerMap = std::vector<std::pair<NodeCoord, NodeRangeSet>>;
+    using ProducerConsumerMap = std::vector<std::pair<NodeCoord, NodeCoord>>;
     std::optional<ProducerConsumerMap> producer_consumer_map = std::nullopt;
 
 

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api_mockup/header_stubs/dataflow_buffer_spec.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api_mockup/header_stubs/dataflow_buffer_spec.hpp
@@ -1,0 +1,88 @@
+typedef DFBid = uint_32;
+typedef DFBName = std::string;
+enum class DFBAccessPattern {STRIDED, BLOCKED, CONTIGUOUS};
+struct TileDescriptor;
+
+
+struct DataflowBufferSpec { 
+
+    // DFB identifier
+    // A handle used to reference this DFB within the ProgramSpec
+    std::variant<DFBid, DFBName> unique_id;  
+    // TODO -- I'm strongly considering removing the string option. 
+    // It spews icky variants everywhere, for little advantage. You'd just use a named variable as a handle anyways.
+
+    // Target nodes
+    using Nodes = std::variant<NodeCoord, NodeRange, NodeRangeSet>
+    Nodes target_nodes;
+
+    // Backing memory
+    uint32_t entry_size;   // in bytes
+    uint32_t num_entries;  
+    // Note: It is possible to override these per-Program execution (via program execution parameters).
+
+    // Endpoint info 
+    // Configuring a DFB requires endpoint-specific info.
+    // This is specified when the DFB is bound to a kernel:
+    //   - Producer and consumer kernel identity
+    //   - Number of producer threads, number of consumer threads
+    //   - Producer and consumer access patterns
+
+    // Entry format (optional)
+    // Optional metadata; used to pass entry type info from host to kernel
+    std::optional<TileDescriptor> tile_format_metadata;
+    std::optional<DataFormat> data_format_metadata;
+
+    // Remote DFB
+    // A DFB is "local" by default. Its producer and consumer kernels are on the same node, 
+    // sharing common L1 memory.
+    // A "remote DFB" has its producer and consumer kernels on different nodes.
+    // For a remote DFB, you must specify the producer-consumer map.
+    bool is_remote_dfb = false;
+    using ProducerConsumerMap = std::vector<std::pair<NodeCoord, NodeRangeSet>>;
+    std::optional<ProducerConsumerMap> producer_consumer_map = std::nullopt;
+
+
+    //////////////////////////////
+    // Advanced options
+    //////////////////////////////
+
+    // Build DFB on borrowed memory 
+    // Instead of program-scope memory allocation, the DFB is built on user-allocated memory (buffer or tensor)
+    // If uses_borrowed_memory is true, you must pass a BufferView or MeshTensorView as a program execution parameter
+    // (The user is responsible for ensuring the memory is valid for the duration of the Program execution.)
+    bool uses_borrowed_memory = false;
+    // Note: The borrowed memory itself is specified as a program execution parameter.
+
+
+    // Alias two or more DFBs
+    // Aliased DFBs are logically distinct, but physically share the same backing memory.
+    // All aliased DFBs must have size and target nodes, and must mutually declare each other as aliases.
+    // (Aliased DFBs offer NO guarantees against data clobbering; the kernel author must ensure safety.)
+    using DFBIdentifiers = std::vector<std::variant<DFBid, std::string>>;
+    std::optional<DFBIdentifiers> alias_with = std::nullopt; 
+       
+    
+    // Disable implicit sync
+    // Implicit sync is handled via ISR (available on Gen2 only) 
+    // Disabling may be useful in niche cases for fine tuning performance or performance debug.
+    bool disable_implicit_sync = false;  
+
+};
+
+
+// Stolen from program_descriptors.hpp
+struct TileDescriptor {
+    TileDescriptor() = default;
+    TileDescriptor(const Tile& tile);
+    TileDescriptor(uint32_t height, uint32_t width, bool transpose) :
+        height(height), width(width), transpose(transpose) {}
+
+    uint32_t height = constants::TILE_HEIGHT;
+    uint32_t width = constants::TILE_WIDTH;
+    bool transpose = false;
+
+    bool operator==(const TileDescriptor& other) const {
+        return height == other.height && width == other.width && transpose == other.transpose;
+    }
+};

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api_mockup/header_stubs/kernel_spec.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api_mockup/header_stubs/kernel_spec.hpp
@@ -12,31 +12,23 @@ struct KernelSpec {
     // Kernel identifier
     // A handle used to reference this kernel within the ProgramSpec
     std::variant<KernelID, KernelName> unique_id;
-    // TODO -- I'm strongly considering removing the string option. 
-
+    // (I intend to remove either the string or uint32_t option. Having both is annoying. Thoughts?)
 
     // Kernel source
     std::string source;
-
     enum class SourceType { FILE_PATH, SOURCE_CODE };
     SourceType  source_type = SourceType::FILE_PATH;
 
-    
     // Target nodes
     // The set of device nodes on which the kernel will run
     using Nodes = std::variant<NodeCoord, NodeRange, NodeRangeSet>;
     Nodes target_nodes;
     
-
     // Threading
     // Number of kernel threads (this can be specified globally or per-node)
     uint8_t num_threads = 1;
-
     using ThreadNodeMap = std::unordered_map<Nodes, uint8_t>; // node -> number of kernel threads
     std::optional<ThreadNodeMap> thread_node_map = std::nullopt;
-        // Hmm... @Almeet, if we want to allow different num_threads per-node, any DFB bound to 
-        // the kernel will have different per-node num_producers or num_consumers....
-        // Should we go back to forcing separate KernelSpec for this case?
 
 
     ///////////////////////////////////////////////////////////////////
@@ -74,26 +66,22 @@ struct KernelSpec {
         std::variant<DFBid, DFBName> dfb_id;  // identify the DFB within the ProgramSpec
         std::string local_accessor_name;      // DFB accessor name (used in the kernel source code, via DFBAccessor)
         DFBEndpointType endpoint_type;        // producer, consumer, or relay
-        DFBAccessPattern access_pattern;      // strided, blocked, contiguous
+        DFBAccessPattern access_pattern;      // strided, blocked, or contiguous
     };
     std::vector<DFBBinding> dfb_bindings;
 
 
-    // TODO -- GlobalDataflowBuffer bindings
-    // TODO -- Socket bindings (might replace GlobalDataflowBuffer?)
-
-
     // Semaphore bindings
-    // (TODO -- needs additional vetting)
     struct SemaphoreBinding {
         std::variant<SemaphoreID, std::string> semaphore_id; // identify the semaphore within the ProgramSpec
-        std::string local_accessor_name;                     // semaphore accessor name (used in the kernel source code)
+        std::string accessor_name;                           // semaphore accessor name (used in the kernel source code)
     };
     std::vector<SemaphoreBinding> semaphore_bindings;
 
 
     // TODO -- GlobalSemaphore bindings
-
+    // TODO -- GlobalDataflowBuffer bindings
+    // TODO -- Socket bindings (might replace GlobalDataflowBuffer?)
 
 
     //////////////////////////////////////////////////////////////////////////////

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api_mockup/header_stubs/kernel_spec.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api_mockup/header_stubs/kernel_spec.hpp
@@ -1,0 +1,199 @@
+
+enum class DFBAccessPattern {STRIDED, BLOCKED, CONTIGUOUS}; // this appears twice, fix it
+typedef KernelID = uint_32;
+typedef KernelName = std::string;
+
+struct KernelSpec {
+
+    ///////////////////////////////////////////////////////////////////
+    // Basic kernel info
+    ///////////////////////////////////////////////////////////////////
+
+    // Kernel identifier
+    // A handle used to reference this kernel within the ProgramSpec
+    std::variant<KernelID, KernelName> unique_id;
+    // TODO -- I'm strongly considering removing the string option. 
+
+
+    // Kernel source
+    std::string source;
+
+    enum class SourceType { FILE_PATH, SOURCE_CODE };
+    SourceType  source_type = SourceType::FILE_PATH;
+
+    
+    // Target nodes
+    // The set of device nodes on which the kernel will run
+    using Nodes = std::variant<NodeCoord, NodeRange, NodeRangeSet>;
+    Nodes target_nodes;
+    
+
+    // Threading
+    // Number of kernel threads (this can be specified globally or per-node)
+    uint8_t num_threads = 1;
+
+    using ThreadNodeMap = std::unordered_map<Nodes, uint8_t>; // node -> number of kernel threads
+    std::optional<ThreadNodeMap> thread_node_map = std::nullopt;
+        // Hmm... @Almeet, if we want to allow different num_threads per-node, any DFB bound to 
+        // the kernel will have different per-node num_producers or num_consumers....
+        // Should we go back to forcing separate KernelSpec for this case?
+
+
+    ///////////////////////////////////////////////////////////////////
+    // Kernel compiler options
+    // Passed to the kernel compiler at Program creation
+    ///////////////////////////////////////////////////////////////////
+    struct CompilerOptions {
+        using IncludePaths = std::vector<std::string>;
+        using Defines = std::vector<std::pair<std::string, std::string>>;
+        using Macros = std::vector<std::string>;
+
+        IncludePaths include_paths = {};   // -I <path>
+        Defines defines = {};              // -D <name>=<value>
+        OptLevel opt_level = OptLevel::O2; // -O<level>
+        // Can add more options here as needed
+    };
+    CompilerOptions compiler_options = {};
+
+
+    ///////////////////////////////////////////////////////////////////
+    // Resource bindings
+    // Bindings (unlike arguments) are immutable Program parameters
+    //////////////////////////////////////////////////////////////////
+
+    // Compile time argument bindings
+    // CTAs are bound at Program creation; they cannot be changed between Program executions
+    using CompileTimeArgBindings = std::unordered_map<std::string, uint32_t>;
+    CompileTimeArgBindings compile_time_arg_bindings;
+        // TODO -- We want to permit arbitrary POD types, including user-defined structs.
+
+
+    // DFB bindings
+    enum class DFBEndpointType { PRODUCER, CONSUMER, RELAY };
+    struct DFBBinding {
+        std::variant<DFBid, DFBName> dfb_id;  // identify the DFB within the ProgramSpec
+        std::string local_accessor_name;      // DFB accessor name (used in the kernel source code, via DFBAccessor)
+        DFBEndpointType endpoint_type;        // producer, consumer, or relay
+        DFBAccessPattern access_pattern;      // strided, blocked, contiguous
+    };
+    std::vector<DFBBinding> dfb_bindings;
+
+
+    // TODO -- GlobalDataflowBuffer bindings
+    // TODO -- Socket bindings (might replace GlobalDataflowBuffer?)
+
+
+    // Semaphore bindings
+    // (TODO -- needs additional vetting)
+    struct SemaphoreBinding {
+        std::variant<SemaphoreID, std::string> semaphore_id; // identify the semaphore within the ProgramSpec
+        std::string local_accessor_name;                     // semaphore accessor name (used in the kernel source code)
+    };
+    std::vector<SemaphoreBinding> semaphore_bindings;
+
+
+    // TODO -- GlobalSemaphore bindings
+
+
+
+    //////////////////////////////////////////////////////////////////////////////
+    // Runtime argument schema
+    // RTAs and CTAs are declared here
+    // (Their values are set as program execution parameters)
+    //////////////////////////////////////////////////////////////////////////////
+
+    // "Legacy" specification for runtime and common runtime arguments
+    // (No support for named or typed arguments; just a vector of uint32_t)
+    // Recall that "Spec" represents the immutable aspect of the Program -- 
+    // for legacy-style kernel arguments, only the number of RTAs and CRTAs are specified. 
+    // The argument VALUES are set as program execution parameters.
+    struct LegaryKernelArgumentsSpec {
+        using NumRTAsPerNode = std::vector<std::pair<NodeCoord, size_t>>; // {node, num_rtas}
+        NumRTAsPerNode num_runtime_args_per_node;
+        size_t num_common_runtime_args
+    };
+    LegacyKernelArgumentsSpec legacy_kernel_args_spec;
+    
+    // "New" specification for runtime and common runtime arguments
+    // Supports:
+    //   - named and typed arguments, including user-defined structs
+    //   - additional varargs
+    struct KernelArgumentsSpec {
+        // TODO
+    };
+    NewKernelArgumentsSpec new_kernel_args_spec;
+
+};
+
+
+struct ComputeKernelSpec : public KernelSpec {
+    // Everything in the base KernelSpec, plus:
+
+    //////////////////////////////////////////////////////////////////////////////
+    // Hardware resource configuration
+    // Compute kernels control Tensix hardware resources
+    //////////////////////////////////////////////////////////////////////////////
+
+    // We will need architecture-specific variants for the hardware resource configs.
+    // (It's possible that Quasar compute config will be identical to Gen1...)
+    // (If so, we'll merge them.)
+
+    // You can provide a Gen1 config, a Gen2 config, or both.
+    // If your host code is intended to be architecture-agnostic, provide both.
+
+    struct Gen1TensixComputeConfig {
+        MathFidelity math_fidelity = MathFidelity::HiFi4;
+        bool fp32_dest_acc_en = false;
+        bool dst_full_sync_en = false;
+        bool bfp8_pack_precise = false;
+        bool math_approx_mode = false;
+
+        // "Unpack to dest" mode must be specified on a per-DFB basis
+        using UnpackToDestMode = std::pair<std::variant<DFBid, std::string>, UnpackToDestMode>; 
+        std::vector<UnpackToDestMode> unpack_to_dest_mode = {}; // empty vector means default mode
+    };
+    std::optional<Gen1TensixComputeConfig> gen1_tensix_compute_config = std::nullopt;
+    
+
+    // Currently looking identical to Gen1... but we'll see!
+    struct Gen2TensixComputeConfig {
+        MathFidelity math_fidelity = MathFidelity::HiFi4;
+        bool fp32_dest_acc_en = false;
+        bool dst_full_sync_en = false;
+        bool bfp8_pack_precise = false;
+        bool math_approx_mode = false;
+
+        // "Unpack to dest" mode must be specified on a per-DFB basis
+        using UnpackToDestMode = std::pair<std::variant<DFBid, std::string>, UnpackToDestMode>; 
+        std::vector<UnpackToDestMode> unpack_to_dest_mode = {}; // empty vector means default mode
+    };
+    std::optional<Gen2TensixComputeConfig> gen2_tensix_compute_config = std::nullopt;
+
+};
+
+struct DataMovementKernelSpec : public KernelSpec {
+    // Everything in the base KernelSpec, plus:
+
+    //////////////////////////////////////////////////////////////////////////////
+    // Hardware resource configuration
+    // Compute kernels control Tensix hardware resources
+    //////////////////////////////////////////////////////////////////////////////
+
+    // We will need architecture-specific variants for the hardware resource configs.
+
+    // You can provide either a Gen1 config, a Gen2 config, or both.
+    // If your host code is intended to run on Gen1 or Gen2, you should provide both.
+
+    struct Gen1DataMovementConfig {
+        DataMovementProcessor processor = DataMovementProcessor::RISCV_0;  // TODO: Paul wanted to be rid of this
+        NOC noc = NOC::RISCV_0_default;                                    // TODO: This too
+        NOC_MODE noc_mode = NOC_MODE::DM_DEDICATED_NOC;
+    };
+
+    struct Gen2DataMovementConfig {
+        // TODO
+        //   The user doesn't specify the DM processor; the runtime chooses.
+        //   There's only one NOC.
+        //   Is there anything in here?
+    };
+};

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api_mockup/header_stubs/program.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api_mockup/header_stubs/program.hpp
@@ -1,0 +1,83 @@
+// Program object semantics
+//   - unique ownership
+//   - moveable, non-copyable
+//   - RAII semantics
+//
+// Invariant: A constructed Program is always valid.
+//  - All legality checks are performed at construction time
+//    (including JIT compilation of kernels)
+
+
+// Future plan:
+//   The Program object is a user-managed RAII object... but only for 10 seconds.
+//   When you add your Program to a MeshWorkload, you transfer ownership to the MeshWorkload.
+//   The Program object's lifetime is that of its containing MeshWorkload.
+//   The current Program has a broken ownership model. It only pretends that you can own it.
+// 
+//   Instead, the MeshWorkload API should directly take the ProgramSpec, and construct the 
+//   Program object internally:
+// 
+//      my_mesh_workload.add_program(device_range, ProgramSpec{...});
+// 
+//   Then the ownership model is clean and obvious.
+//   All the Program public APIs below would then be accessed via the MeshWorkload.
+//   And, we could potentially implement an automatic TTNN-style program cache.
+
+
+
+class Program {
+public:
+    ///////////////////////////////////////////////////////////////
+    // Construction
+    ///////////////////////////////////////////////////////////////
+
+    // Program constructor:
+    //   - Program attributes (defined by the ProgramSpec) are immutable after construction.
+    //   - Performs legality checks on the ProgramSpec
+    //   - All Program creation work (including kernel JIT compilation) is performed at construction time.
+    //     (Not at enqueue time, as previously done.)
+    //   - Throws if construction fails
+    explicit Program(const ProgramSpec& spec);
+
+    // Destructor frees all resources 
+    // Program object owns host-side, device-mapped memory resources only.
+    ~Program();  
+
+    // Program is moveable, but non-copyable
+    Program(const Program&) = delete;                 
+    Program& operator=(const Program&) = delete;     
+    Program(Program&&) noexcept = default;            
+    Program& operator=(Program&&) noexcept = default; 
+
+
+
+    ///////////////////////////////////////////////////////////////
+    // Parameterization
+    ///////////////////////////////////////////////////////////////
+
+    // Single descriptor API for program execution parameters
+    void set_run_parameters(const ProgramRunParams& parameters);
+
+    // Alternative APIs for setting the program execution parameters
+    // These enable a minor optimization -- arguments can be constructed in-place,
+    // within the existing Program's dispatch data structures (e.g., kernel arguments).
+    // This is a slightly clunkier API, but it saves copying data at runtime.
+    void set_runtime_arguments(...);
+    void set_common_runtime_arguments(...);
+    void set_dfb_size_parameters(...);
+    void set_dfb_borrowed_memory_parameters(...);
+
+
+    ///////////////////////////////////////////////////////////////
+    // Program ID assignment
+    // Optional; can be used in tracing and testing.
+    ///////////////////////////////////////////////////////////////
+    using ProgramId = std::uint64_t;
+    void set_runtime_id(ProgramId id);
+    ProgramId get_runtime_id() const;
+
+
+private:
+    std::shared_ptr<detail::ProgramImpl> internal_;
+};
+

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api_mockup/header_stubs/program_spec.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api_mockup/header_stubs/program_spec.hpp
@@ -1,0 +1,71 @@
+// WorkerSpec describes the configuration of a worker node.
+struct WorkerSpec {
+    // Kernels, DFBs, and semaphores associated with this worker
+    // (They must all have compatible target nodes)
+    std::vector<KernelSpec> kernels;
+    std::vector<DataflowBufferSpec> dataflow_buffers;
+    std::vector<SemaphoreSpec> semaphores;
+
+    // The set of nodes this worker will run on
+    std::variant<NodeCoord, NodeRange, NodeRangeSet> nodes;
+};
+
+
+// ProgramSpec describes the immutable aspect of the Program,
+// its defining "structure".
+struct ProgramSpec {
+    std::vector<WorkerSpec> workers;
+}
+
+
+// ProgramRunParams describes the mutable properties of a Program.
+// Analogous to function arguments, these are specified for each Program execution.
+struct ProgramRunParams {
+
+    ////////////////////////////////////////////////////////////////////////
+    // Kernel runtime arguments (legacy style)
+    ////////////////////////////////////////////////////////////////////////
+    struct KernelRunParams {
+        // Kernel identifier
+        std::variant<KernelID, KernelName> kernel_id;
+
+        // Runtime arguments (specified per-node)
+        using NodeRuntimeArgs = std::vector<uint32_t>; 
+        using RuntimeArgs = std::vector<std::pair<CoreCoord, NodeRuntimeArgs>>; 
+        RuntimeArgs runtime_args;
+
+        // Common runtime arguments (shared by all cores of a kernel)
+        using CommonRuntimeArgs = std::vector<uint32_t>; 
+        CommonRuntimeArgs common_runtime_args;
+    };
+    std::vector<KernelRunParams> kernel_run_params;
+
+    ////////////////////////////////////////////////////////////////////////
+    // Kernel runtime arguments (new)
+    ////////////////////////////////////////////////////////////////////////
+    
+    // TODO
+
+
+    ////////////////////////////////////////////////////////////////////////
+    // DFB parameters (optional, advanced use cases)
+    ////////////////////////////////////////////////////////////////////////
+
+    struct DFBRunParams {
+        // DFB identifier
+        std::variant<DFBid, DFBName> dfb_id;
+
+        // DFB size overrides
+        // The DFB size specified in the ProgramSpec can be (optionally) overridden per Program execution.
+        std::optional<uint32_t> entry_size = std::nullopt;        
+        std::optional<uint32_t> num_entries = std::nullopt;
+
+        // DFB borrowed memory
+        // For DFBs build on borrowed memory, the underlying memory is passed (as a non-owning view). 
+        // (If the DFB is not build on borrowed memory, specifying the borrowed memory will throw an error.)
+        using BorrowedMemory = std::variant<BufferView, MeshTensorView>;
+        std::optional<BorrowedMemory> borrowed_memory = std::nullopt;
+    };
+
+};
+

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api_mockup/header_stubs/semaphore_spec.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api_mockup/header_stubs/semaphore_spec.hpp
@@ -1,0 +1,30 @@
+typedef Semaphoreid = uint_32;
+typedef SemaphoreName = std::string;
+
+struct SemaphoreSpec { 
+
+    // Semaphore identifier
+    // A handle used to reference this Semaphore within the ProgramSpec
+    std::variant<Semaphoreid, SemaphoreName> unique_id;  
+    // (I'm considering removing either the string or uint32_t option. Both is annoying. Thoughts?)
+
+    // Target nodes
+    using Nodes = std::variant<NodeCoord, NodeRange, NodeRangeSet>
+    Nodes target_nodes;
+
+
+    //////////////////////////////
+    // Advanced options
+    //////////////////////////////
+
+    // Initial value
+    // NOTE: Setting a non-zero initial value is not supported on Gen2 architectures.
+    // Runtime wants to deprecate this feature for ALL architectures
+    uint32_t initial_value = 0;  
+
+    // Backing memory
+    // NOTE: Register-backed semaphores are only supported on Gen2 architectures.
+    enum class SemaphoreMemoryType { L1, Register };
+    SemaphoreMemoryType memory_type = SemaphoreMemoryType::L1;
+
+};


### PR DESCRIPTION
## Description
This is a crude mock-up for the "Metal 2.0" host APIs for Program specification. It's here just to give reviewers of the specification document (TT internal only [link](https://docs.google.com/document/d/1J3wsD63iKn9QWN38OiHoBU-W9cP36ZjXXHk0mIC3h9o/edit?usp=sharing)) a flavor of how things might look.

There are two separate goals for the new APIs:

1. Support next-gen architecture (Quasar and derivatives)
2. Address chronic API pain points


## To Do
 - Augment examples with a more complex use case.
 - Still need to flesh out new APIs for named & typed kernel arguments.
 - Need to flesh out & mock-up device-side APIs for symmetric argument retrieval, new accessors.
