### PR TITLE
Add DeepSeekV3 B1 unit tests to BH galaxy pipelines

### DIFF
--- a/.github/time_budget.yaml
+++ b/.github/time_budget.yaml
@@ -102,6 +102,7 @@ models:
     wh_n150: 30
     wh_n300: 30
     wh_galaxy: 30
+    bh_galaxy: 40
   unit:
     wh_llmbox: 295
     wh_llmbox_perf: 60

--- a/.github/workflows/galaxy-quick-impl.yaml
+++ b/.github/workflows/galaxy-quick-impl.yaml
@@ -283,3 +283,54 @@ jobs:
           path: /work
       - uses: tenstorrent/tt-metal/.github/actions/cleanup@main
         if: always()
+  quick-bh-glx-quick:
+    if: ${{ inputs.blackhole == true || inputs.scheduled == true }}
+    runs-on:
+      - topology-6u
+      - arch-blackhole
+      - ${{ inputs.extra-tag }}
+    container:
+      image: ${{ inputs.docker-image || 'docker-image-unresolved!'}}
+      env:
+        TT_METAL_HOME: /work
+        PYTHONPATH: /work
+        LD_LIBRARY_PATH: /work/build/lib
+        LOGURU_LEVEL: INFO
+        TT_METAL_ENABLE_ERISC_IRAM: 1
+        TT_METAL_SLOW_DISPATCH_MODE: 1
+      volumes:
+        - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
+        - /dev/hugepages-1G:/dev/hugepages-1G
+      options: --device /dev/tenstorrent
+    defaults:
+      run:
+        shell: bash
+        working-directory: /work # https://github.com/actions/runner/issues/878
+    steps:
+      - name: 🧬 Checkout Repository
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          path: docker-job
+      - name: ⬇️  Setup Job
+        uses: ./docker-job/.github/actions/setup-job
+        timeout-minutes: 10
+        with:
+          build-artifact-name: ${{ inputs.build-artifact-name }}
+          wheel-artifact-name: ${{ inputs.wheel-artifact-name }}
+      - name: Run DeepSeek V3 B1 MoE/MLP reduce tests
+        timeout-minutes: 20
+        run: |
+          pytest --timeout 600 models/demos/deepseek_v3_b1/tests/unit_tests/test_moe_mlp.py::test_mlp_with_reduce models/demos/deepseek_v3_b1/tests/unit_tests/test_moe_mlp.py::test_moe_fused_with_reduce
+      - uses: tenstorrent/tt-metal/.github/actions/slack-report@main
+        if: ${{ failure() }}
+        with:
+          slack_webhook_url: ${{ secrets.SLACK_METAL_INFRA_PIPELINE_STATUS_ALERT }}
+          owner: UJ45FEC7M # Allan Liu
+      - uses: tenstorrent/tt-metal/.github/actions/upload-artifact-with-job-uuid@main
+        timeout-minutes: 10
+        if: ${{ !cancelled() }}
+        with:
+          prefix: "test_reports_"
+      - uses: tenstorrent/tt-metal/.github/actions/cleanup@main
+        if: always()

--- a/models/demos/deepseek_v3_b1/fused_ops/moe_routed_expert/op.py
+++ b/models/demos/deepseek_v3_b1/fused_ops/moe_routed_expert/op.py
@@ -2024,8 +2024,8 @@ class MoeRoutedExpert:
                             break
 
                     # Build per-core BRISC args for reduce worker cores
-                    # Semaphore IDs start at 5 to avoid conflicts with existing semaphores (0-5)
-                    reduce_worker_fabric_sem_base = 5
+                    # Semaphore IDs start at 6 to avoid conflicts with expert semaphores (0-5)
+                    reduce_worker_fabric_sem_base = 6
                     reduce_brisc_per_core_args = []
                     for core in reduce_params["worker_cores_list"]:
                         fabric_core = reduce_params["column_to_fabric_core"][core.x]
@@ -2095,7 +2095,7 @@ class MoeRoutedExpert:
                 # Add worker→fabric semaphores if reduce is enabled
                 if enable_reduce_to_one:
                     fabric_core_set = ttnn.CoreRangeSet([ttnn.CoreRange(c, c) for c in reduce_params["fabric_cores"]])
-                    reduce_worker_fabric_sem_base = 5
+                    reduce_worker_fabric_sem_base = 6
                     for worker_idx in range(reduce_params["num_workers_per_column"]):
                         sem_desc = ttnn.SemaphoreDescriptor(
                             id=reduce_worker_fabric_sem_base + worker_idx,

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_ccl_all_reduce.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_ccl_all_reduce.py
@@ -19,6 +19,7 @@ from loguru import logger
 from tracy import signpost
 
 import ttnn
+from models.common.utility_functions import is_slow_dispatch
 from models.demos.deepseek_v3_b1.micro_ops.ccl_all_reduce.op import DeepseekMinimalAllReduce
 from models.perf.benchmarking_utils import BenchmarkProfiler
 
@@ -71,6 +72,8 @@ def test_ccl_all_reduce(
     num_warmup_iter,
     num_iter,
 ):
+    if is_slow_dispatch():
+        pytest.skip("Trace not supported for slow dispatch")
     # Validate mesh size
     if mesh_device.shape[0] * mesh_device.shape[1] < num_devices:
         pytest.skip("Test requires more devices than are available on this platform")

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_ccl_broadcast.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_ccl_broadcast.py
@@ -17,6 +17,7 @@ from loguru import logger
 from tracy import signpost
 
 import ttnn
+from models.common.utility_functions import is_slow_dispatch
 from models.demos.deepseek_v3_b1.micro_ops.ccl_broadcast.op import DeepseekMinimalBroadcast
 from models.perf.benchmarking_utils import BenchmarkProfiler
 
@@ -75,6 +76,8 @@ def test_ccl_broadcast_dual_axis(
     num_iters,
     num_warmup_iter,
 ):
+    if is_slow_dispatch():
+        pytest.skip("Trace not supported for slow dispatch")
     num_devices = mesh_rows * mesh_cols
 
     # Validate mesh size

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_lm_head_sampling.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_lm_head_sampling.py
@@ -58,6 +58,8 @@ def _is_lm_head_sampling_perf_enabled():
 def test_lm_head_sampling_fused_argmax_mesh_4x2_axis_x_perf(
     bh_2d_mesh_device, use_fp32, final_mesh_coord, num_iters, num_warmup_iters
 ):
+    if is_slow_dispatch():
+        pytest.skip("Trace not supported for slow dispatch")
     mesh_rows, mesh_cols = 4, 2
     num_devices = mesh_rows * mesh_cols
     if bh_2d_mesh_device.shape[0] * bh_2d_mesh_device.shape[1] < num_devices:

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_moe_mlp.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_moe_mlp.py
@@ -608,10 +608,11 @@ def test_moe_fused_with_reduce(bh_2d_mesh_device, use_hardcoded_expert_index):
 
     sdpa_out_interm_shard_height = 40
     sdpa_out_interm_shard_width = 544
+    device_grid_size = submesh.compute_with_storage_grid_size()
     full_device_grid = ttnn.CoreRangeSet(
-        {ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(device_grid.x - 1, device_grid.y - 1))}
+        {ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(device_grid_size.x - 1, device_grid_size.y - 1))}
     )
-    num_full_cores = device_grid.x * device_grid.y
+    num_full_cores = device_grid_size.x * device_grid_size.y
     sdpa_out_interm_shard_spec = ttnn.ShardSpec(
         full_device_grid,
         (sdpa_out_interm_shard_height, sdpa_out_interm_shard_width),
@@ -970,10 +971,11 @@ def test_mlp_with_reduce(bh_2d_mesh_device):
 
     sdpa_out_interm_shard_height = 40
     sdpa_out_interm_shard_width = 544
+    device_grid_size = submesh.compute_with_storage_grid_size()
     full_device_grid = ttnn.CoreRangeSet(
-        {ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(device_grid.x - 1, device_grid.y - 1))}
+        {ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(device_grid_size.x - 1, device_grid_size.y - 1))}
     )
-    num_full_cores = device_grid.x * device_grid.y
+    num_full_cores = device_grid_size.x * device_grid_size.y
     sdpa_out_interm_shard_spec = ttnn.ShardSpec(
         full_device_grid,
         (sdpa_out_interm_shard_height, sdpa_out_interm_shard_width),

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_reduce_to_one_b1.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_reduce_to_one_b1.py
@@ -14,7 +14,7 @@ from loguru import logger
 from tracy import signpost
 
 import ttnn
-from models.common.utility_functions import skip_for_wormhole_b0
+from models.common.utility_functions import is_slow_dispatch, skip_for_wormhole_b0
 from models.demos.deepseek_v3_b1.micro_ops.reduce_to_one_b1.op import ReduceToOneB1
 from models.perf.benchmarking_utils import BenchmarkProfiler
 
@@ -246,6 +246,8 @@ def run_reduce_to_one(mesh_device, num_iterations=1):
 
 def run_reduce_to_one_with_trace(mesh_device):
     """Run reduce_to_one test with trace capture and replay."""
+    if is_slow_dispatch():
+        pytest.skip("Trace not supported for slow dispatch")
     print(f"\n=== Testing reduce_to_one with trace ===")
 
     config = setup_reduce_to_one_test(mesh_device)

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_sampling.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_sampling.py
@@ -10,6 +10,7 @@ from loguru import logger
 from tracy import signpost
 
 import ttnn
+from models.common.utility_functions import is_slow_dispatch
 from models.demos.deepseek_v3_b1.micro_ops.sampling.op import SamplingOp
 from models.perf.benchmarking_utils import BenchmarkProfiler
 
@@ -323,6 +324,8 @@ def test_sampling_argmax_mesh_2x2_axis_x_perf(mesh_device, num_iters, num_warmup
     - double-buffered semaphores,
     - per-iteration persistent output/scratch buffers.
     """
+    if is_slow_dispatch():
+        pytest.skip("Trace not supported for slow dispatch")
     seed = 2005
     final_core_idx = 100
     final_mesh_coord = (1, 1)
@@ -675,6 +678,8 @@ def test_sampling_argmax_mesh_4x2_axis_x_perf(mesh_device, num_iters, num_warmup
     - double-buffered semaphores,
     - per-iteration persistent output/scratch buffers.
     """
+    if is_slow_dispatch():
+        pytest.skip("Trace not supported for slow dispatch")
     seed = 2005
     final_core_idx = 100
 

--- a/models/demos/deepseek_v3_b1/unified_kernels/sdpa_reduce_worker.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/sdpa_reduce_worker.hpp
@@ -47,7 +47,7 @@ using tt::data_movement::common::tt_memmove;
 #include <cstdint>
 
 // Include SDPA LLK APIs for srcB reuse pattern and sdpa_tail reduction
-#include "models/demos/deepseek_v3_b1/kernel_includes/tt_metal/include/compute_kernel_api/sdpa.h"
+#include "../kernel_includes/tt_metal/include/compute_kernel_api/sdpa.h"
 #endif
 
 namespace deepseek_b1_ops {

--- a/tests/pipeline_reorg/galaxy_e2e_tests.yaml
+++ b/tests/pipeline_reorg/galaxy_e2e_tests.yaml
@@ -99,4 +99,4 @@
     bh_galaxy:
       timeout: 40
   owner_id: U06ECNVR0EN # Evan Smal
-  team: fabric
+  team: models

--- a/tests/pipeline_reorg/galaxy_e2e_tests.yaml
+++ b/tests/pipeline_reorg/galaxy_e2e_tests.yaml
@@ -94,7 +94,12 @@
   team: fabric
 
 - name: BH Galaxy DeepSeek V3 B1 unit tests
-  cmd: TT_METAL_SLOW_DISPATCH_MODE=1 pytest --timeout 600 -m "not skip_post_commit" models/demos/deepseek_v3_b1/tests/unit_tests/
+  cmd: |
+    export TT_METAL_SLOW_DISPATCH_MODE=1
+    pytest --timeout 600 -m "not skip_post_commit" \
+      models/demos/deepseek_v3_b1/tests/unit_tests/test_moe_mlp.py \
+      models/demos/deepseek_v3_b1/tests/unit_tests/pre_sdpa.py \
+      models/demos/deepseek_v3_b1/tests/unit_tests/post_sdpa.py
   skus:
     bh_galaxy:
       timeout: 40

--- a/tests/pipeline_reorg/galaxy_e2e_tests.yaml
+++ b/tests/pipeline_reorg/galaxy_e2e_tests.yaml
@@ -96,10 +96,12 @@
 - name: BH Galaxy DeepSeek V3 B1 unit tests
   cmd: |
     export TT_METAL_SLOW_DISPATCH_MODE=1
+    export TT_METAL_FABRIC_ROUTER_SYNC_TIMEOUT_MS=120000
     pytest --timeout 600 -m "not skip_post_commit" \
       models/demos/deepseek_v3_b1/tests/unit_tests/test_moe_mlp.py \
-      models/demos/deepseek_v3_b1/tests/unit_tests/pre_sdpa.py \
-      models/demos/deepseek_v3_b1/tests/unit_tests/post_sdpa.py
+      models/demos/deepseek_v3_b1/tests/unit_tests/test_pre_sdpa.py \
+      models/demos/deepseek_v3_b1/tests/unit_tests/test_post_sdpa.py \
+      models/demos/deepseek_v3_b1/tests/unit_tests/test_moe_routed_expert.py
   skus:
     bh_galaxy:
       timeout: 40

--- a/tests/pipeline_reorg/galaxy_e2e_tests.yaml
+++ b/tests/pipeline_reorg/galaxy_e2e_tests.yaml
@@ -92,3 +92,11 @@
       timeout: 10
   owner_id: U08UBDUKH6Z # Neel Nyamagoudar
   team: fabric
+
+- name: BH Galaxy DeepSeek V3 B1 unit tests
+  cmd: TT_METAL_SLOW_DISPATCH_MODE=1 pytest --timeout 600 -m "not skip_post_commit" models/demos/deepseek_v3_b1/tests/unit_tests/
+  skus:
+    bh_galaxy:
+      timeout: 40
+  owner_id: U06ECNVR0EN # Evan Smal
+  team: fabric


### PR DESCRIPTION
### Summary

DeepSeekV3 B1 unit tests to the following BH galaxy pipelines:
1. (Galaxy) quick: runs fused MoE decoder layer test
2. (Galaxy) e2e tests: runs subset of all B1 unit tests

We don't run all B1 unit tests in CI due to a shortage of BH galaxy machines in CI at the moment.

Small changes required to get the pipeline green:

- [x] Include path issue with SDPA in `test_sdpa_reduce_to_all`: https://github.com/tenstorrent/tt-metal/actions/runs/22445734547/job/65000442501#step:7:2984
- [x] Missing `device_grid` variable https://github.com/tenstorrent/tt-metal/actions/runs/22450467743/job/65018111421#step:7:728
- [x] Fix `Always | TT_THROW: Trace not supported for slow dispatch`

### Checklist

- [x] Galaxy Quick: https://github.com/tenstorrent/tt-metal/actions/runs/22453198256
- [x] Galaxy E2E: https://github.com/tenstorrent/tt-metal/actions/runs/22463928421
