### PR TITLE
Fix SDPA decode tree-reduction off-by-one for power-of-2 core counts

### DIFF
--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/sdpa_decode_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/sdpa_decode_program_factory.cpp
@@ -218,7 +218,8 @@ SdpaDecodeProgramFactory::cached_program_t SdpaDecodeProgramFactory::create(
     //// recalculate num_cores_per_batch based on num_active_cores
     num_cores_per_batch = num_active_cores / B;
     // Calculate tree reduction parameters
-    uint32_t num_tree_reduction_rounds = 32 - __builtin_clz(num_cores_per_head);  // ceil(log2(num_cores_per_head))
+    uint32_t num_tree_reduction_rounds =
+        (num_cores_per_head <= 1) ? 0 : (32 - __builtin_clz(num_cores_per_head - 1));  // ceil(log2(num_cores_per_head))
     log_debug(tt::LogOp, "Tree reduction enabled: num_tree_reduction_rounds: {}", num_tree_reduction_rounds);
 
     TT_FATAL(


### PR DESCRIPTION
## Summary
- Fixes #38521: The tree-reduction round count formula `32 - __builtin_clz(n)` computes `floor(log2(n)) + 1`, not `ceil(log2(n))`. For power-of-2 core counts (e.g. 64 on WH 8x8) these differ by 1, causing a `TT_FATAL` assertion because the computed rounds exceed `MAX_TREE_REDUCTION_ROUNDS`.
- Fix: `(n <= 1) ? 0 : (32 - __builtin_clz(n - 1))` which correctly computes `ceil(log2(n))`.
- Adds a regression test that exercises the full device grid with b=1, nkv=1 to trigger the power-of-2 path.

## Test plan
- [x] Regression test: `test_sdpa_decode_tree_reduction_power_of_2_regression`

## CI Runs
- **WH post-commit (All post-commit tests):** https://github.com/tenstorrent/tt-metal/actions/runs/22417328588
- **BH post-commit (Blackhole post-commit tests):** https://github.com/tenstorrent/tt-metal/actions/runs/22417329967
- **Nightly L2 (sdpa only):** https://github.com/tenstorrent/tt-metal/actions/runs/22417373782