### PR TITLE
Add CB reconfig for DeepSeek Blitz MOE/MLP

### DIFF
--- a/models/demos/deepseek_v3_b1/fused_ops/moe/moe_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/fused_ops/moe/moe_kernel.cpp
@@ -905,6 +905,13 @@ void kernel_main() {
     constexpr uint32_t num_iterations = get_named_compile_time_arg_val("num_iterations");
 
     auto moe_body = [&]() {
+#if defined(RECONFIG_MOE_CBS) && !defined(UCK_CHLKC_MATH)
+        {
+            constexpr uint32_t cb_config_l1_addr = get_named_compile_time_arg_val("reconfig_cb_config_l1_addr");
+            uint32_t tt_l1_ptr* cb_config = reinterpret_cast<uint32_t tt_l1_ptr*>(cb_config_l1_addr);
+            unified_kernels::reconfig_cb_interfaces(cb_config);
+        }
+#endif  // RECONFIG_MOE_CBS && !UCK_CHLKC_MATH
         // 0. Residual Mcast: Broadcast input as residual to mcast receiver cores (pop_src=false)
         {
             DeviceZoneScopedN("RESIDUAL_MCAST");

--- a/models/demos/deepseek_v3_b1/fused_ops/moe/moe_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/fused_ops/moe/moe_kernel.cpp
@@ -315,59 +315,49 @@ void kernel_main() {
         } shared;
     } moe;
 
-    // Setup sharded persistent buffers (imperative — outside struct)
-    if constexpr (Core::is_sender_core) {
-        // RMSNorm gamma weights (tensor-backed)
-        constexpr uint32_t rmsnorm_gamma_cb = get_named_compile_time_arg_val("rmsnorm_gamma_cb");
-        constexpr uint32_t rmsnorm_gamma_num_pages = get_named_compile_time_arg_val("rmsnorm_gamma_num_pages");
-        unified_kernels::setup_sharded_buffer(rmsnorm_gamma_cb, rmsnorm_gamma_num_pages);
-
+    // Setup all tensor-backed sharded buffers (marks pre-loaded tiles as ready)
+    auto setup_all_sharded_buffers = [&]() {
+        if constexpr (Core::is_sender_core) {
+            unified_kernels::setup_sharded_buffer(
+                get_named_compile_time_arg_val("rmsnorm_gamma_cb"),
+                get_named_compile_time_arg_val("rmsnorm_gamma_num_pages"));
 #ifdef ENABLE_ROUTING
-        constexpr uint32_t gate_bias_cb = get_named_compile_time_arg_val("gate_bias_cb");
-        constexpr uint32_t gate_input_indices_cb = get_named_compile_time_arg_val("gate_input_indices_cb");
-        unified_kernels::setup_sharded_buffer(gate_bias_cb, 1);
-        unified_kernels::setup_sharded_buffer(gate_input_indices_cb, 1);
-#endif  // ENABLE_ROUTING
-
-        // Residual mcast source (pre-RMSNorm input on sender, tensor-backed)
-        constexpr uint32_t shared_residual_mcast_src_cb =
-            get_named_compile_time_arg_val("shared_residual_mcast_src_cb");
-        constexpr uint32_t shared_residual_mcast_src_num_pages =
-            get_named_compile_time_arg_val("shared_residual_mcast_src_num_pages");
-        unified_kernels::setup_sharded_buffer(shared_residual_mcast_src_cb, shared_residual_mcast_src_num_pages);
-    }
+            unified_kernels::setup_sharded_buffer(get_named_compile_time_arg_val("gate_bias_cb"), 1);
+            unified_kernels::setup_sharded_buffer(get_named_compile_time_arg_val("gate_input_indices_cb"), 1);
+#endif
+            unified_kernels::setup_sharded_buffer(
+                get_named_compile_time_arg_val("shared_residual_mcast_src_cb"),
+                get_named_compile_time_arg_val("shared_residual_mcast_src_num_pages"));
+        }
 #ifdef ENABLE_ROUTING
-    if constexpr (Core::Routed::is_gate_mm_core) {
-        constexpr uint32_t gate_mm_in1 = get_named_compile_time_arg_val("gate_mm_in1");
-        constexpr uint32_t gate_mm_k_num_tiles = get_named_compile_time_arg_val("gate_mm_k_num_tiles");
-        constexpr uint32_t gate_mm_out_w = get_named_compile_time_arg_val("gate_mm_out_w");
-        unified_kernels::setup_sharded_buffer(gate_mm_in1, gate_mm_k_num_tiles * gate_mm_out_w);
-    }
-#endif  // ENABLE_ROUTING
-    if constexpr (Core::Routed::is_gate_proj_core) {
-        constexpr uint32_t mul_cb_in1 = get_named_compile_time_arg_val("mul_cb_in1");
-        constexpr uint32_t mul_num_tiles = get_named_compile_time_arg_val("mul_num_tiles");
-        unified_kernels::setup_sharded_buffer(mul_cb_in1, mul_num_tiles);
-
-        constexpr uint32_t add_cb_in0 = get_named_compile_time_arg_val("add_cb_in0");
-        constexpr uint32_t add_cb_in0_wait_tiles = get_named_compile_time_arg_val("add_cb_in0_wait_tiles");
-        unified_kernels::setup_sharded_buffer(add_cb_in0, add_cb_in0_wait_tiles);
-
-        // NOTE: add_cb_in1 is NOT setup here — it is populated by the shared expert's Output Mcast
-    }
-    if constexpr (Core::Shared::is_compute_core) {
-        constexpr uint32_t shared_gu_weights_cb = get_named_compile_time_arg_val("shared_gu_weights_cb");
-        constexpr uint32_t shared_gu_weights_num_pages = get_named_compile_time_arg_val("shared_gu_weights_num_pages");
-        unified_kernels::setup_sharded_buffer(shared_gu_weights_cb, shared_gu_weights_num_pages);
-    }
-    if constexpr (Core::Shared::is_mcast_receiver_core) {
-        constexpr uint32_t shared_down_in1 = get_named_compile_time_arg_val("shared_down_matmul_in1");
-        constexpr uint32_t shared_down_k = get_named_compile_time_arg_val("shared_down_matmul_k_num_tiles");
-        constexpr uint32_t shared_down_w = get_named_compile_time_arg_val("shared_down_matmul_out_w_per_core");
-        unified_kernels::setup_sharded_buffer(shared_down_in1, shared_down_k * shared_down_w);
-
-        // NOTE: shared_residual_cb is no longer pre-loaded — it is populated by the Residual Mcast (step 0)
-    }
+        if constexpr (Core::Routed::is_gate_mm_core) {
+            unified_kernels::setup_sharded_buffer(
+                get_named_compile_time_arg_val("gate_mm_in1"),
+                get_named_compile_time_arg_val("gate_mm_k_num_tiles") *
+                    get_named_compile_time_arg_val("gate_mm_out_w"));
+        }
+#endif
+        if constexpr (Core::Routed::is_gate_proj_core) {
+            unified_kernels::setup_sharded_buffer(
+                get_named_compile_time_arg_val("mul_cb_in1"), get_named_compile_time_arg_val("mul_num_tiles"));
+            unified_kernels::setup_sharded_buffer(
+                get_named_compile_time_arg_val("add_cb_in0"), get_named_compile_time_arg_val("add_cb_in0_wait_tiles"));
+        }
+        if constexpr (Core::Shared::is_compute_core) {
+            unified_kernels::setup_sharded_buffer(
+                get_named_compile_time_arg_val("shared_gu_weights_cb"),
+                get_named_compile_time_arg_val("shared_gu_weights_num_pages"));
+        }
+        if constexpr (Core::Shared::is_mcast_receiver_core) {
+            unified_kernels::setup_sharded_buffer(
+                get_named_compile_time_arg_val("shared_down_matmul_in1"),
+                get_named_compile_time_arg_val("shared_down_matmul_k_num_tiles") *
+                    get_named_compile_time_arg_val("shared_down_matmul_out_w_per_core"));
+        }
+    };
+#ifndef RECONFIG_MOE_CBS
+    setup_all_sharded_buffers();
+#endif
 
 #elif defined(COMPILE_FOR_BRISC)
 
@@ -911,6 +901,9 @@ void kernel_main() {
             uint32_t tt_l1_ptr* cb_config = reinterpret_cast<uint32_t tt_l1_ptr*>(cb_config_l1_addr);
             unified_kernels::reconfig_cb_interfaces(cb_config);
         }
+#if defined(COMPILE_FOR_NCRISC)
+        setup_all_sharded_buffers();
+#endif
 #endif  // RECONFIG_MOE_CBS && !UCK_CHLKC_MATH
         // 0. Residual Mcast: Broadcast input as residual to mcast receiver cores (pop_src=false)
         {

--- a/models/demos/deepseek_v3_b1/fused_ops/moe/moe_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/fused_ops/moe/moe_kernel.cpp
@@ -90,6 +90,13 @@ struct Core {
 };
 
 void kernel_main() {
+#if defined(RECONFIG_MOE_CBS) && !defined(UCK_CHLKC_MATH)
+    {
+        constexpr uint32_t cb_config_l1_addr = get_named_compile_time_arg_val("reconfig_cb_config_l1_addr");
+        uint32_t tt_l1_ptr* cb_config = reinterpret_cast<uint32_t tt_l1_ptr*>(cb_config_l1_addr);
+        unified_kernels::reconfig_cb_interfaces(cb_config);
+    }
+#endif
 // ============================================================================
 // Compile-time args — grouped into Moe::Routed / Moe::Shared structs
 // ============================================================================

--- a/models/demos/deepseek_v3_b1/fused_ops/moe/op.py
+++ b/models/demos/deepseek_v3_b1/fused_ops/moe/op.py
@@ -41,6 +41,95 @@ from models.demos.deepseek_v3_b1.unified_kernel_descriptor import (
 from models.demos.deepseek_v3_b1.utils import build_cb_reconfig_tensor, float_to_uint32, record_cb_metadata
 
 
+class MoeCB:
+    """CB ID constants for the fused MoE op (single source of truth).
+
+    All routed + shared expert CB IDs are defined here, grouped by tile dimension
+    for dense packing (fewer gaps → faster setup_local_cb_read_write_interfaces).
+    To reorder CB IDs, change values here only.
+    """
+
+    # ── 1x32 tiles (IDs 0-16) ──
+    GATE_MM_INPUT = 0  # also mcast dst for gate_proj/up_proj input
+    GATE_MM_OUTPUT = 1  # routing-only
+    GATE_PROJ_IN1 = 2  # DRAM matmul in1, shared with up_proj
+    GATE_PROJ_OUT = 3
+    UP_PROJ_IN1 = 2  # alias: same as GATE_PROJ_IN1
+    UP_PROJ_OUT = 4
+    DOWN_PROJ_GATHER_DST = 5
+    DOWN_PROJ_MCAST_DST = 6
+    DOWN_PROJ_IN1 = 7  # DRAM matmul in1, aliases GATE_PROJ_IN1 address
+    DOWN_PROJ_OUT = 8
+    RESIDUAL_MCAST_SRC = 9  # tensor-backed, sender core
+    RESIDUAL_MCAST_DST = 10
+    RMSNORM_GAMMA = 11  # tensor-backed, sender core
+    SHARED_GU_OUT = 12
+    SHARED_DOWN_MCAST_DST = 13
+    SHARED_DOWN_OUT = 14
+    SHARED_RESIDUAL_ADD_OUT = 15
+    SHARED_OUTPUT_GATHER_DST = 16
+
+    # ── 1x16 tiles (IDs 17-20, routing-only) ──
+    GATE_PROJ_INDEX = 17
+    MUL_SCALAR_SRC = 18
+    GATE_OUTPUT = 19
+    GATE_OUTPUT_INDICES = 20
+
+    # ── 16x16 tiles (IDs 21-31) ──
+    MUL_IN0 = 21  # aliases UP_PROJ_OUT address
+    MUL_IN1 = 22  # aliases GATE_PROJ_OUT address
+    MUL_OUT = 23
+    SHARED_GROUP1 = 24  # gate gather dst on sender
+    SHARED_GROUP2 = 25  # up gather dst on sender
+    SHARED_INTERMED = 26  # gated reduce intermediate on sender
+    SHARED_MCAST_SRC = 27  # gated reduce output on sender
+    GATE_INPUT = 28  # routing-only
+    MUL_SCALAR = 29  # routing-only
+    GATE_BIAS = 30  # routing-only, tensor-backed
+    GATE_INDICES = 31  # routing-only, tensor-backed
+
+    # ── 32x32 tiles (IDs 32-45) ──
+    RMSNORM_OUTPUT = 32
+    ADD_IN0 = 33  # aliases DOWN_PROJ_OUT address
+    ADD_IN1 = 34
+    ADD_OUT = 35
+    GATE_MM_WEIGHTS = 36  # routing-only, tensor-backed
+    SHARED_GU_WEIGHTS = 37  # tensor-backed, compute cores
+    SHARED_DOWN_IN1 = 38  # tensor-backed, matmul cores
+    # Reduce CBs (32x32)
+    REDUCE_LOCAL = ADD_OUT  # aliases add output
+    REDUCE_R1 = 39
+    REDUCE_R2 = 40
+    REDUCE_R3 = 41
+    REDUCE_OUTPUT = 42
+    REDUCE_SCRATCH = 43
+    REDUCE_PACKET = 44
+    REDUCE_PACKET_HEADER = 45
+
+
+class MoeSem:
+    """Semaphore ID constants for the fused MoE op.
+
+    Gather sems overlap with mcast receiver sems (different physical cores).
+    noc1_num_senders=0 for all gathers, so only noc0 sem is used.
+    """
+
+    MCAST_SENDER = 0
+    MCAST_DATA_RECEIVER = 1  # mcast grid; overlaps with DOWN_PROJ_GATHER on sender
+    DOWN_PROJ_GATHER = 1  # sender core
+    RESIDUAL_MCAST_RECEIVER = 2  # mcast grid; overlaps with AG_GATHER on sender
+    AG_GATHER = 2  # sender core
+    SHARED_DOWN_MCAST_RECEIVER = 3  # mcast grid; overlaps with BG_GATHER on sender
+    BG_GATHER = 3  # sender core
+    SHARED_OUTPUT_MCAST_RECEIVER = 4  # mcast grid; overlaps with OUTPUT_GATHER on sender
+    OUTPUT_GATHER = 4  # sender core
+    # MoE-only mcast receivers (separate, not overlapped)
+    EXPERT_SCALE_MCAST_RECEIVER = 5
+    INDEX_MCAST_RECEIVER = 6
+    DOWN_PROJ_MCAST_RECEIVER = 7
+    REDUCE_WORKER_FABRIC_BASE = 8  # on fabric cores only (8, 9, 10, 11 per worker slot)
+
+
 @dataclass
 class MoeContext:
     """Top-level context for the fused MoE op. Hides routed/shared split from op()."""
@@ -785,50 +874,49 @@ class MoeRoutedExpertOp:
         expert_scale_mcast_sender_semaphore_id = mcast_data_sender_semaphore_id  # Reuse sender semaphore
 
         # ==================================================================
-        # CB indices
+        # CB indices (from MoeOp class constants)
         # ==================================================================
-        rmsnorm_output_cb = 0
-        gate_mm_input_cb = 1  # Also used as mcast destination for gate_proj/up_proj input
-        gate_proj_cb_in1 = 9
-        gate_proj_cb_out = 11
-        up_proj_cb_in1 = gate_proj_cb_in1  # Shared CB: same buffer, kernel resets pointers between uses
-        up_proj_cb_mm_out = 12
-        mul_cb_in0 = 13
-        mul_cb_in1 = 14
-        mul_cb_out = 15
-        down_proj_gather_dst_cb = 16
-        down_proj_mcast_dst_cb = 17
-        down_proj_cb_in1 = 18
-        down_proj_cb_out = 19
-        add_cb_in0 = 22
-        add_cb_in1 = 23
-        add_cb_out = 24
+        rmsnorm_output_cb = MoeCB.RMSNORM_OUTPUT
+        gate_mm_input_cb = MoeCB.GATE_MM_INPUT
+        gate_proj_cb_in1 = MoeCB.GATE_PROJ_IN1
+        gate_proj_cb_out = MoeCB.GATE_PROJ_OUT
+        up_proj_cb_in1 = MoeCB.UP_PROJ_IN1
+        up_proj_cb_mm_out = MoeCB.UP_PROJ_OUT
+        mul_cb_in0 = MoeCB.MUL_IN0
+        mul_cb_in1 = MoeCB.MUL_IN1
+        mul_cb_out = MoeCB.MUL_OUT
+        down_proj_gather_dst_cb = MoeCB.DOWN_PROJ_GATHER_DST
+        down_proj_mcast_dst_cb = MoeCB.DOWN_PROJ_MCAST_DST
+        down_proj_cb_in1 = MoeCB.DOWN_PROJ_IN1
+        down_proj_cb_out = MoeCB.DOWN_PROJ_OUT
+        add_cb_in0 = MoeCB.ADD_IN0
+        add_cb_in1 = MoeCB.ADD_IN1
+        add_cb_out = MoeCB.ADD_OUT
 
         # Routing-only CB indices (0 when routing disabled)
-        gate_mm_weights_cb = 2 if enable_routing else 0
-        gate_mm_output_cb = 3 if enable_routing else 0
-        gate_input_cb = 4 if enable_routing else 0
-        gate_bias_cb = 5 if enable_routing else 0
-        gate_indices_cb = 6 if enable_routing else 0
-        gate_output_cb = 7 if enable_routing else 0
-        gate_output_indices_cb = 8 if enable_routing else 0
-        gate_proj_cb_index = 10 if enable_routing else 0
-        mul_cb_scalar_src = 20 if enable_routing else 0
-        mul_cb_scalar = 21 if enable_routing else 0
-        # ReduceToOne CBs (for multi-device reduce)
-        # Must be after shared expert CBs (25-38) to avoid conflicts
-        reduce_local_cb = add_cb_out  # Local data CB (same as add_cb_out for fusion)
-        reduce_received_cb_r1 = 39  # Round 1: receives LEAF data
-        reduce_received_cb_r2 = 40  # Round 2: receives ROOT3 data
-        reduce_received_cb_r3 = 41  # Round 3: receives ROOT2 data
-        reduce_output_cb = 42  # Final reduced output
-        reduce_scratch_cb = 43  # Scratch for compute
-        reduce_packet_cb = 44  # Scratch for sending packets
-        reduce_packet_header_cb = 45  # Packet header (persistent)
-        # Shared expert CBs (defined in MoeSharedExpertOp)
-        residual_mcast_src_cb = MoeSharedExpertOp.RESIDUAL_MCAST_SRC_CB
-        residual_mcast_dst_cb = MoeSharedExpertOp.RESIDUAL_MCAST_DST_CB
-        rmsnorm_gamma_cb = MoeSharedExpertOp.RMSNORM_GAMMA_CB
+        gate_mm_weights_cb = MoeCB.GATE_MM_WEIGHTS if enable_routing else 0
+        gate_mm_output_cb = MoeCB.GATE_MM_OUTPUT if enable_routing else 0
+        gate_input_cb = MoeCB.GATE_INPUT if enable_routing else 0
+        gate_bias_cb = MoeCB.GATE_BIAS if enable_routing else 0
+        gate_indices_cb = MoeCB.GATE_INDICES if enable_routing else 0
+        gate_output_cb = MoeCB.GATE_OUTPUT if enable_routing else 0
+        gate_output_indices_cb = MoeCB.GATE_OUTPUT_INDICES if enable_routing else 0
+        gate_proj_cb_index = MoeCB.GATE_PROJ_INDEX if enable_routing else 0
+        mul_cb_scalar_src = MoeCB.MUL_SCALAR_SRC if enable_routing else 0
+        mul_cb_scalar = MoeCB.MUL_SCALAR if enable_routing else 0
+        # ReduceToOne CBs
+        reduce_local_cb = MoeCB.REDUCE_LOCAL
+        reduce_received_cb_r1 = MoeCB.REDUCE_R1
+        reduce_received_cb_r2 = MoeCB.REDUCE_R2
+        reduce_received_cb_r3 = MoeCB.REDUCE_R3
+        reduce_output_cb = MoeCB.REDUCE_OUTPUT
+        reduce_scratch_cb = MoeCB.REDUCE_SCRATCH
+        reduce_packet_cb = MoeCB.REDUCE_PACKET
+        reduce_packet_header_cb = MoeCB.REDUCE_PACKET_HEADER
+        # Shared expert CBs
+        residual_mcast_src_cb = MoeCB.RESIDUAL_MCAST_SRC
+        residual_mcast_dst_cb = MoeCB.RESIDUAL_MCAST_DST
+        rmsnorm_gamma_cb = MoeCB.RMSNORM_GAMMA
 
         # ==================================================================
         # RMSNorm tile reinterpretation (compute kernel needs 32x32 or 16x32 tiles)
@@ -1824,9 +1912,9 @@ class MoeSharedExpertOp:
     """
 
     # CB indices for shared expert CBs referenced by routed expert setup
-    RESIDUAL_MCAST_SRC_CB = 25  # raw input on sender (residual mcast source)
-    RESIDUAL_MCAST_DST_CB = 26  # residual destination on mcast grid
-    RMSNORM_GAMMA_CB = 27  # RMSNorm gamma weights on sender
+    RESIDUAL_MCAST_SRC_CB = MoeCB.RESIDUAL_MCAST_SRC
+    RESIDUAL_MCAST_DST_CB = MoeCB.RESIDUAL_MCAST_DST
+    RMSNORM_GAMMA_CB = MoeCB.RMSNORM_GAMMA
 
     # ========================================================================
     # Setup APIs
@@ -2148,20 +2236,20 @@ class MoeSharedExpertOp:
         """
 
         # ==================================================================
-        # CB indices
+        # CB indices (from MoeOp class constants)
         # ==================================================================
-        shared_gu_weights_cb = 28
-        shared_gu_out_cb = 29
-        shared_group1_cb = 30  # gate gather dst on sender
-        shared_group2_cb = 31  # up gather dst on sender
-        shared_intermed_cb = 32  # gated reduce intermediate on sender
-        shared_mcast_src_cb = 33  # gated reduce output on sender
-        shared_residual_cb = MoeSharedExpertOp.RESIDUAL_MCAST_DST_CB  # = residual_mcast_dst_cb
-        shared_down_mcast_dst_cb = 34  # down mcast destination (gated reduce output → all 130 cores)
-        shared_down_matmul_in1_cb = 35  # down proj weights (112 matmul cores, tensor-backed)
-        shared_down_matmul_out_cb = 36  # down proj matmul output (112 matmul cores, tensor-backed)
-        shared_residual_add_out_cb = 37  # residual add output (112 matmul cores, tensor-backed)
-        shared_output_gather_dst_cb = 38  # output gather destination (sender core, tensor-backed)
+        shared_gu_weights_cb = MoeCB.SHARED_GU_WEIGHTS
+        shared_gu_out_cb = MoeCB.SHARED_GU_OUT
+        shared_group1_cb = MoeCB.SHARED_GROUP1
+        shared_group2_cb = MoeCB.SHARED_GROUP2
+        shared_intermed_cb = MoeCB.SHARED_INTERMED
+        shared_mcast_src_cb = MoeCB.SHARED_MCAST_SRC
+        shared_residual_cb = MoeCB.RESIDUAL_MCAST_DST
+        shared_down_mcast_dst_cb = MoeCB.SHARED_DOWN_MCAST_DST
+        shared_down_matmul_in1_cb = MoeCB.SHARED_DOWN_IN1
+        shared_down_matmul_out_cb = MoeCB.SHARED_DOWN_OUT
+        shared_residual_add_out_cb = MoeCB.SHARED_RESIDUAL_ADD_OUT
+        shared_output_gather_dst_cb = MoeCB.SHARED_OUTPUT_GATHER_DST
 
         # ==================================================================
         # Dimensions
@@ -2599,23 +2687,20 @@ class MoeOp:
     single unified kernel invocation.
     """
 
-    # Semaphore IDs (top-level definition)
-    # Gather sems overlap with mcast receiver sems (different physical cores).
-    # noc1_num_senders=0 for all gathers, so only noc0 sem is used.
-    MCAST_SENDER_SEM = 0
-    MCAST_DATA_RECEIVER_SEM = 1  # mcast grid; overlaps with DOWN_PROJ_GATHER_SEM on sender core
-    DOWN_PROJ_GATHER_SEM = 1  # sender core
-    RESIDUAL_MCAST_RECEIVER_SEM = 2  # mcast grid; overlaps with AG_GATHER_SEM on sender core
-    AG_GATHER_SEM = 2  # sender core
-    SHARED_DOWN_MCAST_RECEIVER_SEM = 3  # mcast grid; overlaps with BG_GATHER_SEM on sender core
-    BG_GATHER_SEM = 3  # sender core
-    SHARED_OUTPUT_MCAST_RECEIVER_SEM = 4  # mcast grid; overlaps with OUTPUT_GATHER_SEM on sender core
-    OUTPUT_GATHER_SEM = 4  # sender core
-    # MoE-only mcast receivers (separate, not overlapped)
-    EXPERT_SCALE_MCAST_RECEIVER_SEM = 5
-    INDEX_MCAST_RECEIVER_SEM = 6
-    DOWN_PROJ_MCAST_RECEIVER_SEM = 7
-    REDUCE_WORKER_FABRIC_SEM_BASE = 8  # on fabric cores only (8, 9, 10, 11 per worker slot)
+    # Semaphore IDs (from MoeSem class constants)
+    MCAST_SENDER_SEM = MoeSem.MCAST_SENDER
+    MCAST_DATA_RECEIVER_SEM = MoeSem.MCAST_DATA_RECEIVER
+    DOWN_PROJ_GATHER_SEM = MoeSem.DOWN_PROJ_GATHER
+    RESIDUAL_MCAST_RECEIVER_SEM = MoeSem.RESIDUAL_MCAST_RECEIVER
+    AG_GATHER_SEM = MoeSem.AG_GATHER
+    SHARED_DOWN_MCAST_RECEIVER_SEM = MoeSem.SHARED_DOWN_MCAST_RECEIVER
+    BG_GATHER_SEM = MoeSem.BG_GATHER
+    SHARED_OUTPUT_MCAST_RECEIVER_SEM = MoeSem.SHARED_OUTPUT_MCAST_RECEIVER
+    OUTPUT_GATHER_SEM = MoeSem.OUTPUT_GATHER
+    EXPERT_SCALE_MCAST_RECEIVER_SEM = MoeSem.EXPERT_SCALE_MCAST_RECEIVER
+    INDEX_MCAST_RECEIVER_SEM = MoeSem.INDEX_MCAST_RECEIVER
+    DOWN_PROJ_MCAST_RECEIVER_SEM = MoeSem.DOWN_PROJ_MCAST_RECEIVER
+    REDUCE_WORKER_FABRIC_SEM_BASE = MoeSem.REDUCE_WORKER_FABRIC_BASE
 
     # ------------------------------------------------------------------
     # Shared utility setup APIs (used by both routed and shared experts)

--- a/models/demos/deepseek_v3_b1/fused_ops/moe/op.py
+++ b/models/demos/deepseek_v3_b1/fused_ops/moe/op.py
@@ -49,54 +49,59 @@ class MoeCB:
     To reorder CB IDs, change values here only.
     """
 
-    # ── 1x32 tiles (IDs 0-16) ──
+    # ── 1x32, bfloat16 (IDs 0-12) ──
     GATE_MM_INPUT = 0  # also mcast dst for gate_proj/up_proj input
     GATE_MM_OUTPUT = 1  # routing-only
-    GATE_PROJ_IN1 = 2  # DRAM matmul in1, shared with up_proj
-    GATE_PROJ_OUT = 3
-    UP_PROJ_IN1 = 2  # alias: same as GATE_PROJ_IN1
-    UP_PROJ_OUT = 4
-    DOWN_PROJ_GATHER_DST = 5
-    DOWN_PROJ_MCAST_DST = 6
-    DOWN_PROJ_IN1 = 7  # DRAM matmul in1, aliases GATE_PROJ_IN1 address
-    DOWN_PROJ_OUT = 8
-    RESIDUAL_MCAST_SRC = 9  # tensor-backed, sender core
-    RESIDUAL_MCAST_DST = 10
-    RMSNORM_GAMMA = 11  # tensor-backed, sender core
-    SHARED_GU_OUT = 12
-    SHARED_DOWN_MCAST_DST = 13
-    SHARED_DOWN_OUT = 14
-    SHARED_RESIDUAL_ADD_OUT = 15
-    SHARED_OUTPUT_GATHER_DST = 16
+    GATE_PROJ_OUT = 2
+    UP_PROJ_OUT = 3
+    DOWN_PROJ_GATHER_DST = 4
+    DOWN_PROJ_MCAST_DST = 5
+    DOWN_PROJ_OUT = 6
+    RESIDUAL_MCAST_DST = 7
+    SHARED_GU_OUT = 8
+    SHARED_DOWN_MCAST_DST = 9
+    SHARED_DOWN_OUT = 10
+    SHARED_RESIDUAL_ADD_OUT = 11
+    SHARED_OUTPUT_GATHER_DST = 12
 
-    # ── 1x16 tiles (IDs 17-20, routing-only) ──
-    GATE_PROJ_INDEX = 17
-    MUL_SCALAR_SRC = 18
-    GATE_OUTPUT = 19
-    GATE_OUTPUT_INDICES = 20
+    # ── 1x16, bfloat16 (routing-only) ──
+    GATE_PROJ_INDEX = 13
+    MUL_SCALAR_SRC = 14
+    GATE_OUTPUT = 15
+    # ── 1x16, uint16 (routing-only) ──
+    GATE_OUTPUT_INDICES = 16
 
-    # ── 16x16 tiles (IDs 21-31) ──
-    MUL_IN0 = 21  # aliases UP_PROJ_OUT address
-    MUL_IN1 = 22  # aliases GATE_PROJ_OUT address
-    MUL_OUT = 23
-    SHARED_GROUP1 = 24  # gate gather dst on sender
-    SHARED_GROUP2 = 25  # up gather dst on sender
-    SHARED_INTERMED = 26  # gated reduce intermediate on sender
-    SHARED_MCAST_SRC = 27  # gated reduce output on sender
-    GATE_INPUT = 28  # routing-only
-    MUL_SCALAR = 29  # routing-only
-    GATE_BIAS = 30  # routing-only, tensor-backed
-    GATE_INDICES = 31  # routing-only, tensor-backed
+    # ── 16x16, bfloat16 ──
+    MUL_IN0 = 17  # aliases UP_PROJ_OUT address
+    MUL_IN1 = 18  # aliases GATE_PROJ_OUT address
+    MUL_OUT = 19
+    SHARED_GROUP1 = 20  # gate gather dst on sender
+    SHARED_GROUP2 = 21  # up gather dst on sender
+    SHARED_INTERMED = 22  # gated reduce intermediate on sender
+    SHARED_MCAST_SRC = 23  # gated reduce output on sender
+    GATE_INPUT = 24  # routing-only
+    MUL_SCALAR = 25  # routing-only
+    GATE_BIAS = 26  # routing-only, tensor-backed
+    # ── 16x16, uint16 (routing-only) ──
+    GATE_INDICES = 27  # routing-only, tensor-backed
 
-    # ── 32x32 tiles (IDs 32-45) ──
-    RMSNORM_OUTPUT = 32
-    ADD_IN0 = 33  # aliases DOWN_PROJ_OUT address
-    ADD_IN1 = 34
-    ADD_OUT = 35
-    GATE_MM_WEIGHTS = 36  # routing-only, tensor-backed
-    SHARED_GU_WEIGHTS = 37  # tensor-backed, compute cores
-    SHARED_DOWN_IN1 = 38  # tensor-backed, matmul cores
-    # Reduce CBs (32x32)
+    # ── 32x32, bfloat16 ──
+    RMSNORM_OUTPUT = 28
+    ADD_IN0 = 29  # aliases DOWN_PROJ_OUT address
+    ADD_IN1 = 30
+    ADD_OUT = 31
+
+    # ── Runtime-dependent tile/format (tensor-backed, from weight/activation tensors) ──
+    GATE_PROJ_IN1 = 32  # DRAM matmul in1 (bfloat4_b 32x32 in prod)
+    UP_PROJ_IN1 = 32  # alias: same as GATE_PROJ_IN1
+    DOWN_PROJ_IN1 = 33  # DRAM matmul in1, aliases GATE_PROJ_IN1 address
+    RESIDUAL_MCAST_SRC = 34  # reinterpreted tile (32x32 or 16x32)
+    RMSNORM_GAMMA = 35  # reinterpreted tile (32x32 or 16x32)
+    GATE_MM_WEIGHTS = 36  # routing-only
+    SHARED_GU_WEIGHTS = 37  # compute cores
+    SHARED_DOWN_IN1 = 38  # matmul cores
+
+    # ── 32x32, bfloat16 — Reduce CBs ──
     REDUCE_LOCAL = ADD_OUT  # aliases add output
     REDUCE_R1 = 39
     REDUCE_R2 = 40
@@ -312,7 +317,8 @@ class _MoeRoutedExpertContext:
     reduce_packet_cb: int = 0
     reduce_packet_header_cb: int = 0
     reduce_params: dict = None
-    # Pre-built CB descriptors for reduce scratch/packet/header (set by _overlap_cbs_with_sdpa_buffer)
+    # Pre-built CB descriptors for reduce (set by _overlap_cbs_with_sdpa_buffer)
+    reduce_received_cb_descriptors: list = None  # CBs 39-42 (r1, r2, r3, output)
     reduce_scratch_cb_descriptor: Any = None
     reduce_packet_cb_descriptor: Any = None
     reduce_packet_header_cb_descriptor: Any = None
@@ -1810,6 +1816,13 @@ class MoeRoutedExpertOp:
             ctx.residual_mcast_params["dst_cb_descriptor"],
             ctx.rmsnorm_gamma_cb_descriptor,
         ]
+
+        # Reduce CBs (39-45)
+        if ctx.enable_reduce_to_one and ctx.reduce_received_cb_descriptors:
+            descriptors += ctx.reduce_received_cb_descriptors
+            descriptors.append(ctx.reduce_scratch_cb_descriptor)
+            descriptors.append(ctx.reduce_packet_cb_descriptor)
+            descriptors.append(ctx.reduce_packet_header_cb_descriptor)
 
         return descriptors
 
@@ -3732,6 +3745,25 @@ class MoeOp:
             ]
             routed_ctx.reduce_packet_header_cb_descriptor = reduce_cb_header_desc
 
+            # CB 39-42: reduce received/output CBs (tensor-backed, same L1 address on all devices)
+            reduce_payload = routed_ctx.reduce_params["payload_size_bytes"]
+            routed_ctx.reduce_received_cb_descriptors = []
+            for cb_id, tensor in [
+                (routed_ctx.reduce_received_cb_r1, routed_ctx.reduce_params["intermediate_r1_per_device"][0]),
+                (routed_ctx.reduce_received_cb_r2, routed_ctx.reduce_params["intermediate_r2_per_device"][0]),
+                (routed_ctx.reduce_received_cb_r3, routed_ctx.reduce_params["intermediate_r3_per_device"][0]),
+                (routed_ctx.reduce_output_cb, routed_ctx.reduce_params["output_per_device"][0]),
+            ]:
+                desc = ttnn.cb_descriptor_from_sharded_tensor(cb_id, tensor)
+                desc.core_ranges = reduce_all_cores_set
+                desc.total_size = reduce_payload
+                desc.format_descriptors = [
+                    ttnn.CBFormatDescriptor(
+                        buffer_index=cb_id, data_format=ttnn.bfloat16, page_size=reduce_payload, tile=reduce_tile_desc
+                    )
+                ]
+                routed_ctx.reduce_received_cb_descriptors.append(desc)
+
     def _build_reduce_per_device(self, reduce_root_coord, coord, row, col, chip_id):
         """Apply reduce-to-one modifications to per-device state (self.device_*). No-op when reduce disabled."""
         ctx = self.ctx
@@ -3753,41 +3785,11 @@ class MoeOp:
 
         dest_fabric_node_id = mesh_device.get_fabric_node_id(dest_coord)
 
-        # Per-device tensors
+        # Per-device tensors (L1 address is same on all devices, used for dst_l1_addr below)
         r1_tensor = reduce_params["intermediate_r1_per_device"][chip_id]
         r2_tensor = reduce_params["intermediate_r2_per_device"][chip_id]
         r3_tensor = reduce_params["intermediate_r3_per_device"][chip_id]
         out_tensor = reduce_params["output_per_device"][chip_id]
-
-        # CB descriptors for reduce receive buffers (39-42)
-        reduce_all_cores_set = ttnn.CoreRangeSet(
-            [ttnn.CoreRange(c, c) for c in reduce_params["worker_cores_list"]]
-            + [ttnn.CoreRange(c, c) for c in reduce_params["fabric_cores"]]
-        )
-        reduce_tile_desc = ttnn.TileDescriptor(32, 32)
-        reduce_payload = reduce_params["payload_size_bytes"]
-        reduce_dtype = ttnn.bfloat16
-
-        for cb_id, tensor in [
-            (routed_ctx.reduce_received_cb_r1, r1_tensor),
-            (routed_ctx.reduce_received_cb_r2, r2_tensor),
-            (routed_ctx.reduce_received_cb_r3, r3_tensor),
-            (routed_ctx.reduce_output_cb, out_tensor),
-        ]:
-            desc = ttnn.cb_descriptor_from_sharded_tensor(cb_id, tensor)
-            desc.core_ranges = reduce_all_cores_set
-            desc.total_size = reduce_payload
-            desc.format_descriptors = [
-                ttnn.CBFormatDescriptor(
-                    buffer_index=cb_id, data_format=reduce_dtype, page_size=reduce_payload, tile=reduce_tile_desc
-                )
-            ]
-            self.device_cb_descs.append(desc)
-
-        # Scratch/packet/header CBs (43-45): pre-built by _overlap_cbs_with_sdpa_buffer
-        self.device_cb_descs.append(routed_ctx.reduce_scratch_cb_descriptor)
-        self.device_cb_descs.append(routed_ctx.reduce_packet_cb_descriptor)
-        self.device_cb_descs.append(routed_ctx.reduce_packet_header_cb_descriptor)
 
         # Destination L1 address depends on role
         if device_role == MESH_LEAF:
@@ -4092,13 +4094,30 @@ class MoeOp:
         self.ncrisc_common_rt_args = []
 
     def _build_cb_descriptors(self):
-        """Build combined CB descriptors for routed + shared expert."""
+        """Build combined CB descriptors for routed + shared expert + reduce."""
         cb_descriptors = []
         cb_descriptors += MoeRoutedExpertOp._build_cb_descriptors(self.ctx.routed_ctx)
         cb_descriptors += MoeSharedExpertOp._build_cb_descriptors(self.ctx.shared_ctx)
         if self.ctx.reconfig_moe_cbs:
             self.cb_metadata = record_cb_metadata(cb_descriptors)
         return cb_descriptors
+
+    def _build_dummy_cb_descs(self):
+        """Build dummy CB descriptors — only preserve format_descriptors.
+
+        Everything else is dummied out. No buffer pointer, no address offset,
+        minimal total_size, full device grid for core_ranges.
+        The reconfig tensor provides the real config at kernel start.
+        """
+        full_grid = self.ctx.full_device_grid
+        dummy_descs = []
+        for desc in self.cb_descriptors:
+            dummy_desc = ttnn.CBDescriptor()
+            dummy_desc.total_size = desc.format_descriptors[0].page_size
+            dummy_desc.core_ranges = full_grid
+            dummy_desc.format_descriptors = desc.format_descriptors
+            dummy_descs.append(dummy_desc)
+        return dummy_descs
 
     def _build_cb_reconfig_tensor(self):
         """Build L1-sharded CB reconfig tensor using shared utility."""
@@ -4223,6 +4242,7 @@ class MoeOp:
         self.cb_descriptors = self._build_cb_descriptors()
         if self.ctx.reconfig_moe_cbs:
             self._build_cb_reconfig_tensor()
+            self.dummy_cb_descs = self._build_dummy_cb_descs()
         self.unified_core_descs, self.per_core_descs = self._build_core_descriptors()
         self.semaphore_descriptors = self._build_semaphore_descriptors()
         self.io_tensors = self._build_io_tensors()
@@ -4391,7 +4411,8 @@ class MoeOp:
 
                 program = ttnn.ProgramDescriptor(
                     kernels=kernel_result.kernels,
-                    cbs=moe.device_cb_descs,
+                    # Note: for final fusion with MLA, cbs should kept as empty and let MLA create the CBs. (unless MLA is not covering all CBs creation that's used by MOE)
+                    cbs=moe.dummy_cb_descs if ctx.reconfig_moe_cbs else moe.device_cb_descs,
                     semaphores=moe.device_sem_descs,
                 )
 

--- a/models/demos/deepseek_v3_b1/fused_ops/moe/op.py
+++ b/models/demos/deepseek_v3_b1/fused_ops/moe/op.py
@@ -38,7 +38,7 @@ from models.demos.deepseek_v3_b1.unified_kernel_descriptor import (
     UnifiedCompileTimeCoreDescriptor,
     UnifiedKernelDescriptor,
 )
-from models.demos.deepseek_v3_b1.utils import float_to_uint32
+from models.demos.deepseek_v3_b1.utils import build_cb_reconfig_tensor, float_to_uint32, record_cb_metadata
 
 
 @dataclass
@@ -83,6 +83,9 @@ class MoeContext:
     # RMSNorm runtime args (common across all devices)
     rmsnorm_epsilon_packed: int = 0
     rmsnorm_scalar_packed: int = 0
+
+    # CB reconfig
+    reconfig_moe_cbs: bool = False
 
 
 @dataclass
@@ -3867,6 +3870,7 @@ class MoeOp:
         reduce_output_tensor=None,
         reduce_semaphores=None,
         reduce_root_coord=None,
+        reconfig_moe_cbs=False,
     ):
         """Setup both routed and shared expert contexts, then overlap CBs with SDPA buffers."""
         routed_ctx = MoeRoutedExpertOp._setup_dimensions(
@@ -3957,6 +3961,7 @@ class MoeOp:
             mesh_cols=routed_ctx.mesh_cols,
             enable_routing=routed_ctx.enable_routing,
             enable_reduce_to_one=routed_ctx.enable_reduce_to_one,
+            reconfig_moe_cbs=reconfig_moe_cbs,
             # IO tensors
             gate_mm_weights_tensor=gate_mm_weights_tensor,
             gate_bias_tensor=gate_bias_tensor,
@@ -4006,7 +4011,15 @@ class MoeOp:
         cb_descriptors = []
         cb_descriptors += MoeRoutedExpertOp._build_cb_descriptors(self.ctx.routed_ctx)
         cb_descriptors += MoeSharedExpertOp._build_cb_descriptors(self.ctx.shared_ctx)
+        if self.ctx.reconfig_moe_cbs:
+            self.cb_metadata = record_cb_metadata(cb_descriptors)
         return cb_descriptors
+
+    def _build_cb_reconfig_tensor(self):
+        """Build L1-sharded CB reconfig tensor using shared utility."""
+        self.reconfig_tensor = build_cb_reconfig_tensor(
+            self.cb_metadata, self.ctx.full_device_grid, self.ctx.mesh_device
+        )
 
     def _build_core_descriptors(self):
         """Build combined core descriptors for routed + shared expert."""
@@ -4098,6 +4111,8 @@ class MoeOp:
             ctx.sdpa_kv_cache_buffer,
             ctx.sdpa_out_interm_buffer,
         ]
+        if ctx.reconfig_moe_cbs:
+            io_tensors += [self.reconfig_tensor]
         if ctx.enable_reduce_to_one:
             io_tensors += [
                 ctx.reduce_intermediate_tensors[0],
@@ -4114,11 +4129,15 @@ class MoeOp:
             defines += [("ENABLE_ROUTING", "1")]
         if self.ctx.enable_reduce_to_one:
             defines += [("ENABLE_REDUCE_TO_ONE", "1")]
+        if self.ctx.reconfig_moe_cbs:
+            defines += [("RECONFIG_MOE_CBS", "1")]
         return defines
 
     def _build_descriptors(self):
         """Build all shared (non-per-device) descriptors and store on self."""
         self.cb_descriptors = self._build_cb_descriptors()
+        if self.ctx.reconfig_moe_cbs:
+            self._build_cb_reconfig_tensor()
         self.unified_core_descs, self.per_core_descs = self._build_core_descriptors()
         self.semaphore_descriptors = self._build_semaphore_descriptors()
         self.io_tensors = self._build_io_tensors()
@@ -4131,6 +4150,12 @@ class MoeOp:
         self.brisc_args = []
         self.trisc_args = []
         self._append_compile_time_args(chip_id, num_iterations, self.ncrisc_args, self.brisc_args, self.trisc_args)
+
+        if self.ctx.reconfig_moe_cbs:
+            addr = self.reconfig_tensor.buffer_address()
+            self.ncrisc_args.append(("reconfig_cb_config_l1_addr", addr))
+            self.brisc_args.append(("reconfig_cb_config_l1_addr", addr))
+            self.trisc_args.append(("reconfig_cb_config_l1_addr", addr))
 
         self.device_cb_descs = list(self.cb_descriptors)
         self.device_sem_descs = list(self.semaphore_descriptors)
@@ -4175,6 +4200,8 @@ class MoeOp:
         reduce_output_tensor: Optional[ttnn.Tensor] = None,
         reduce_semaphores: Optional[list] = None,
         reduce_root_coord: Optional[ttnn.MeshCoordinate] = None,
+        # CB reconfig for fusion with preceding op
+        reconfig_moe_cbs=False,
     ):
         """
         Execute the full fused MoE operation (routed + shared expert).
@@ -4200,6 +4227,8 @@ class MoeOp:
             reduce_output_tensor: (Optional) Final reduced output tensor on ROOT1 device
             reduce_semaphores: (Optional) List of 4 global semaphores for reduce synchronization
             reduce_root_coord: (Optional) MeshCoordinate of ROOT1 device
+            reconfig_moe_cbs: If True, create a per-core CB config tensor and reconfigure
+                CBs at kernel start (for fusion with a preceding op)
 
         Returns:
             (gate_output_scores_tensor, gate_output_indices_tensor, final_output_tensor or reduce_output_tensor)
@@ -4233,6 +4262,7 @@ class MoeOp:
             reduce_output_tensor=reduce_output_tensor,
             reduce_semaphores=reduce_semaphores,
             reduce_root_coord=reduce_root_coord,
+            reconfig_moe_cbs=reconfig_moe_cbs,
         )
 
         # ==================================================================

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_moe_mlp.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_moe_mlp.py
@@ -413,7 +413,7 @@ def extract_routed_expert_output(
     "use_hardcoded_expert_index",
     [True, pytest.param(False, marks=pytest.mark.skip_post_commit)],
 )
-@pytest.mark.parametrize("reconfig_moe_cbs", [True])
+@pytest.mark.parametrize("reconfig_moe_cbs", [True, False])
 @pytest.mark.requires_grid_size((13, 10))
 def test_moe_fused(device, use_hardcoded_expert_index, reconfig_moe_cbs):
     """Test fused MoE: run both routed expert and shared expert, validate combined output."""
@@ -561,7 +561,7 @@ def test_moe_fused(device, use_hardcoded_expert_index, reconfig_moe_cbs):
     ids=["fabric_2d"],
 )
 @pytest.mark.parametrize("use_hardcoded_expert_index", [True, pytest.param(False, marks=pytest.mark.skip_post_commit)])
-@pytest.mark.parametrize("reconfig_moe_cbs", [True])
+@pytest.mark.parametrize("reconfig_moe_cbs", [True, False])
 @pytest.mark.requires_grid_size((13, 10))
 def test_moe_fused_with_reduce(bh_2d_mesh_device, use_hardcoded_expert_index, reconfig_moe_cbs):
     """
@@ -807,7 +807,7 @@ def test_moe_fused_with_reduce(bh_2d_mesh_device, use_hardcoded_expert_index, re
 # ============================================================================
 # Test: Fused MoE with enable_routing=False (dense MLP mode)
 # ============================================================================
-@pytest.mark.parametrize("reconfig_moe_cbs", [True])
+@pytest.mark.parametrize("reconfig_moe_cbs", [True, False])
 @pytest.mark.requires_grid_size((13, 10))
 def test_mlp(device, reconfig_moe_cbs):
     """Test MoeOp with enable_routing=False: same as MLP, no routing logic."""
@@ -928,7 +928,7 @@ def test_mlp(device, reconfig_moe_cbs):
     indirect=["device_params"],
     ids=["fabric_2d"],
 )
-@pytest.mark.parametrize("reconfig_moe_cbs", [True])
+@pytest.mark.parametrize("reconfig_moe_cbs", [True, False])
 @pytest.mark.requires_grid_size((13, 10))
 def test_mlp_with_reduce(bh_2d_mesh_device, reconfig_moe_cbs):
     """

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_moe_mlp.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_moe_mlp.py
@@ -595,6 +595,7 @@ def test_moe_fused_with_reduce(bh_2d_mesh_device, use_hardcoded_expert_index, re
     s = create_shared_expert_tensors(submesh, M, K, mcast_grid, mesh_mapper=mesh_mapper)
 
     # ── Create SDPA buffers for CB memory overlap (required by fused MoE) ──
+    device_grid_size = submesh.compute_with_storage_grid_size()
     kv_cache_shard_height = 256
     kvpe_dim = 576
     num_mcast_cores = len(ttnn.corerange_to_cores(mcast_grid))
@@ -612,9 +613,9 @@ def test_moe_fused_with_reduce(bh_2d_mesh_device, use_hardcoded_expert_index, re
     sdpa_out_interm_shard_height = 40
     sdpa_out_interm_shard_width = 544
     full_device_grid = ttnn.CoreRangeSet(
-        {ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(device_grid.x - 1, device_grid.y - 1))}
+        {ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(device_grid_size.x - 1, device_grid_size.y - 1))}
     )
-    num_full_cores = device_grid.x * device_grid.y
+    num_full_cores = device_grid_size.x * device_grid_size.y
     sdpa_out_interm_shard_spec = ttnn.ShardSpec(
         full_device_grid,
         (sdpa_out_interm_shard_height, sdpa_out_interm_shard_width),
@@ -961,6 +962,7 @@ def test_mlp_with_reduce(bh_2d_mesh_device, reconfig_moe_cbs):
     s = create_shared_expert_tensors(submesh, M, K, mcast_grid, mesh_mapper=mesh_mapper)
 
     # ── Create SDPA buffers for CB memory overlap ──
+    device_grid_size = submesh.compute_with_storage_grid_size()
     kv_cache_shard_height = 256
     kvpe_dim = 576
     num_mcast_cores = len(ttnn.corerange_to_cores(mcast_grid))
@@ -978,9 +980,9 @@ def test_mlp_with_reduce(bh_2d_mesh_device, reconfig_moe_cbs):
     sdpa_out_interm_shard_height = 40
     sdpa_out_interm_shard_width = 544
     full_device_grid = ttnn.CoreRangeSet(
-        {ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(device_grid.x - 1, device_grid.y - 1))}
+        {ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(device_grid_size.x - 1, device_grid_size.y - 1))}
     )
-    num_full_cores = device_grid.x * device_grid.y
+    num_full_cores = device_grid_size.x * device_grid_size.y
     sdpa_out_interm_shard_spec = ttnn.ShardSpec(
         full_device_grid,
         (sdpa_out_interm_shard_height, sdpa_out_interm_shard_width),

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_moe_mlp.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_moe_mlp.py
@@ -413,8 +413,9 @@ def extract_routed_expert_output(
     "use_hardcoded_expert_index",
     [True, pytest.param(False, marks=pytest.mark.skip_post_commit)],
 )
+@pytest.mark.parametrize("reconfig_moe_cbs", [True])
 @pytest.mark.requires_grid_size((13, 10))
-def test_moe_fused(device, use_hardcoded_expert_index):
+def test_moe_fused(device, use_hardcoded_expert_index, reconfig_moe_cbs):
     """Test fused MoE: run both routed expert and shared expert, validate combined output."""
 
     M = 1
@@ -493,9 +494,10 @@ def test_moe_fused(device, use_hardcoded_expert_index):
         sdpa_kv_cache_buffer=sdpa_kv_cache_buffer,
         sdpa_out_interm_buffer=sdpa_out_interm_buffer,
         num_iterations=num_iterations,
+        reconfig_moe_cbs=reconfig_moe_cbs,
     )
     ttnn.synchronize_device(device)
-    logger.info(f"Fused routed+shared gate/up: {num_iterations} iterations completed")
+    logger.info(f"Fused routed+shared gate/up: {num_iterations} iterations completed (reconfig={reconfig_moe_cbs})")
 
     # Read back routed expert results
     output_scores_torch = ttnn.to_torch(ttnn_result_scores)
@@ -559,8 +561,9 @@ def test_moe_fused(device, use_hardcoded_expert_index):
     ids=["fabric_2d"],
 )
 @pytest.mark.parametrize("use_hardcoded_expert_index", [True, pytest.param(False, marks=pytest.mark.skip_post_commit)])
+@pytest.mark.parametrize("reconfig_moe_cbs", [True])
 @pytest.mark.requires_grid_size((13, 10))
-def test_moe_fused_with_reduce(bh_2d_mesh_device, use_hardcoded_expert_index):
+def test_moe_fused_with_reduce(bh_2d_mesh_device, use_hardcoded_expert_index, reconfig_moe_cbs):
     """
     Test fused MoE with reduce_to_one on 4x2 mesh.
 
@@ -713,6 +716,7 @@ def test_moe_fused_with_reduce(bh_2d_mesh_device, use_hardcoded_expert_index):
         sdpa_kv_cache_buffer=sdpa_kv_cache_buffer,
         sdpa_out_interm_buffer=sdpa_out_interm_buffer,
         num_iterations=num_iterations,
+        reconfig_moe_cbs=reconfig_moe_cbs,
         # ReduceToOne parameters
         reduce_intermediate_tensors=intermediate_tensors,
         reduce_output_tensor=reduce_output_tensor,
@@ -720,7 +724,7 @@ def test_moe_fused_with_reduce(bh_2d_mesh_device, use_hardcoded_expert_index):
         reduce_root_coord=ttnn.MeshCoordinate(root_coord),
     )
     ttnn.synchronize_device(submesh)
-    logger.info(f"Fused MoE with reduce: {num_iterations} iterations completed")
+    logger.info(f"Fused MoE with reduce: {num_iterations} iterations completed (reconfig={reconfig_moe_cbs})")
 
     # ── Verify results ──
     # Read gate scores/indices from device (needed for per-device golden)
@@ -803,8 +807,9 @@ def test_moe_fused_with_reduce(bh_2d_mesh_device, use_hardcoded_expert_index):
 # ============================================================================
 # Test: Fused MoE with enable_routing=False (dense MLP mode)
 # ============================================================================
+@pytest.mark.parametrize("reconfig_moe_cbs", [True])
 @pytest.mark.requires_grid_size((13, 10))
-def test_mlp(device):
+def test_mlp(device, reconfig_moe_cbs):
     """Test MoeOp with enable_routing=False: same as MLP, no routing logic."""
 
     M = 1
@@ -877,9 +882,10 @@ def test_mlp(device):
         sdpa_kv_cache_buffer=sdpa_kv_cache_buffer,
         sdpa_out_interm_buffer=sdpa_out_interm_buffer,
         num_iterations=num_iterations,
+        reconfig_moe_cbs=reconfig_moe_cbs,
     )
     ttnn.synchronize_device(device)
-    logger.info(f"MoeOp no-routing: {num_iterations} iterations completed")
+    logger.info(f"MoeOp no-routing: {num_iterations} iterations completed (reconfig={reconfig_moe_cbs})")
 
     # ── Read back and validate ──
     output_final_torch = ttnn.to_torch(ttnn_result_final)
@@ -922,8 +928,9 @@ def test_mlp(device):
     indirect=["device_params"],
     ids=["fabric_2d"],
 )
+@pytest.mark.parametrize("reconfig_moe_cbs", [True])
 @pytest.mark.requires_grid_size((13, 10))
-def test_mlp_with_reduce(bh_2d_mesh_device):
+def test_mlp_with_reduce(bh_2d_mesh_device, reconfig_moe_cbs):
     """
     Test MoeOp with enable_routing=False and reduce_to_one on 4x2 mesh.
 
@@ -1069,13 +1076,14 @@ def test_mlp_with_reduce(bh_2d_mesh_device):
         sdpa_kv_cache_buffer=sdpa_kv_cache_buffer,
         sdpa_out_interm_buffer=sdpa_out_interm_buffer,
         num_iterations=num_iterations,
+        reconfig_moe_cbs=reconfig_moe_cbs,
         reduce_intermediate_tensors=intermediate_tensors,
         reduce_output_tensor=reduce_output_tensor,
         reduce_semaphores=reduce_semaphores,
         reduce_root_coord=ttnn.MeshCoordinate(root_coord),
     )
     ttnn.synchronize_device(submesh)
-    logger.info(f"MoeOp no-routing with reduce: {num_iterations} iterations completed")
+    logger.info(f"MoeOp no-routing with reduce: {num_iterations} iterations completed (reconfig={reconfig_moe_cbs})")
 
     # ── Verify results ──
     # Compute per-device golden with per-device TP shards of shared expert weights

--- a/models/demos/deepseek_v3_b1/unified_kernels/kernel_utils.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/kernel_utils.hpp
@@ -74,6 +74,23 @@ FORCE_INLINE void semaphore_dec(volatile tt_l1_ptr uint32_t* sem_addr) {
 #endif
 
 // ============================================================================
+// Cross-RISC synchronization
+// ============================================================================
+
+// Synchronization barrier using an atomic L1 semaphore.
+// NCRISC waits for BR + TR0 + TR2 (3 RISCs) to signal done, then resets.
+// Other RISCs (BR, TR0, TR2) atomically increment and proceed.
+FORCE_INLINE void sync_riscs(volatile uint32_t tt_l1_ptr* sem_addr) {
+#if defined(COMPILE_FOR_BRISC) || defined(UCK_CHLKC_UNPACK) || defined(UCK_CHLKC_PACK)
+    __atomic_fetch_add(sem_addr, 1, __ATOMIC_RELAXED);
+#elif defined(COMPILE_FOR_NCRISC)
+    while (__atomic_load_n(sem_addr, __ATOMIC_RELAXED) < 3) {
+    }
+    *sem_addr = 0;
+#endif
+}
+
+// ============================================================================
 // CB reconfig utilities
 // ============================================================================
 
@@ -90,76 +107,67 @@ FORCE_INLINE void semaphore_dec(volatile tt_l1_ptr uint32_t* sem_addr) {
 //   NCRISC/BRISC:  read=true,  write=true
 //   TRISC0/unpack: read=true,  write=false
 //   TRISC2/pack:   read=false, write=true
+template <bool do_read, bool do_write, bool do_reset_stream_regs>
+FORCE_INLINE void reconfig_cbs_for_mask(uint32_t tt_l1_ptr* cb_config, uint32_t mask, uint32_t start_cb) {
+    uint32_t cb = start_cb;
+    while (mask) {
+        if (mask & 1) {
+            uint32_t base = cb * 4;
+            uint32_t fifo_addr = cb_config[base + 0] >> cb_addr_shift;
+            uint32_t fifo_size = cb_config[base + 1] >> cb_addr_shift;
+            uint32_t fifo_num_pages = cb_config[base + 2];
+            uint32_t fifo_page_size = cb_config[base + 3] >> cb_addr_shift;
+
+            LocalCBInterface& iface = get_local_cb_interface(cb);
+            if constexpr (do_read) {
+                iface.fifo_rd_ptr = fifo_addr;
+            }
+            if constexpr (do_write) {
+                iface.fifo_wr_ptr = fifo_addr;
+                iface.fifo_num_pages = fifo_num_pages;
+            }
+            iface.fifo_size = fifo_size;
+            iface.fifo_limit = fifo_addr + fifo_size;
+            iface.fifo_page_size = fifo_page_size;
+            iface.tiles_acked_received_init = 0;
+
+            if constexpr (do_reset_stream_regs) {
+                *get_cb_tiles_received_ptr(cb) = 0;
+                *get_cb_tiles_acked_ptr(cb) = 0;
+            }
+        }
+        mask >>= 1;
+        cb++;
+    }
+}
+
 FORCE_INLINE void reconfig_cb_interfaces(uint32_t tt_l1_ptr* cb_config) {
-#if defined(COMPILE_FOR_NCRISC) || defined(COMPILE_FOR_BRISC)
+#if defined(COMPILE_FOR_NCRISC)
     constexpr bool do_read = true;
     constexpr bool do_write = true;
+    constexpr bool do_reset_stream_regs = true;
+#elif defined(COMPILE_FOR_BRISC)
+    constexpr bool do_read = true;
+    constexpr bool do_write = true;
+    constexpr bool do_reset_stream_regs = false;
 #elif defined(UCK_CHLKC_UNPACK)
     constexpr bool do_read = true;
     constexpr bool do_write = false;
+    constexpr bool do_reset_stream_regs = false;
 #elif defined(UCK_CHLKC_PACK)
     constexpr bool do_read = false;
     constexpr bool do_write = true;
+    constexpr bool do_reset_stream_regs = false;
 #else
     constexpr bool do_read = false;
     constexpr bool do_write = false;
+    constexpr bool do_reset_stream_regs = false;
 #endif
-    uint32_t cb_mask_low = cb_config[256];
-    uint32_t cb_mask_high = cb_config[257];
 
-    // Process lower 32 CBs (0-31)
-    uint32_t mask = cb_mask_low;
-    uint32_t cb = 0;
-    while (mask) {
-        if (mask & 1) {
-            uint32_t base = cb * 4;
-            uint32_t fifo_addr = cb_config[base + 0] >> cb_addr_shift;
-            uint32_t fifo_size = cb_config[base + 1] >> cb_addr_shift;
-            uint32_t fifo_num_pages = cb_config[base + 2];
-            uint32_t fifo_page_size = cb_config[base + 3] >> cb_addr_shift;
+    sync_riscs(reinterpret_cast<volatile uint32_t tt_l1_ptr*>(&cb_config[258]));
 
-            LocalCBInterface& iface = get_local_cb_interface(cb);
-            if constexpr (do_read) {
-                iface.fifo_rd_ptr = fifo_addr;
-            }
-            if constexpr (do_write) {
-                iface.fifo_wr_ptr = fifo_addr;
-                iface.fifo_num_pages = fifo_num_pages;
-            }
-            iface.fifo_size = fifo_size;
-            iface.fifo_limit = fifo_addr + fifo_size;
-            iface.fifo_page_size = fifo_page_size;
-        }
-        mask >>= 1;
-        cb++;
-    }
-
-    // Process upper 32 CBs (32-63)
-    mask = cb_mask_high;
-    cb = 32;
-    while (mask) {
-        if (mask & 1) {
-            uint32_t base = cb * 4;
-            uint32_t fifo_addr = cb_config[base + 0] >> cb_addr_shift;
-            uint32_t fifo_size = cb_config[base + 1] >> cb_addr_shift;
-            uint32_t fifo_num_pages = cb_config[base + 2];
-            uint32_t fifo_page_size = cb_config[base + 3] >> cb_addr_shift;
-
-            LocalCBInterface& iface = get_local_cb_interface(cb);
-            if constexpr (do_read) {
-                iface.fifo_rd_ptr = fifo_addr;
-            }
-            if constexpr (do_write) {
-                iface.fifo_wr_ptr = fifo_addr;
-                iface.fifo_num_pages = fifo_num_pages;
-            }
-            iface.fifo_size = fifo_size;
-            iface.fifo_limit = fifo_addr + fifo_size;
-            iface.fifo_page_size = fifo_page_size;
-        }
-        mask >>= 1;
-        cb++;
-    }
+    reconfig_cbs_for_mask<do_read, do_write, do_reset_stream_regs>(cb_config, cb_config[256], 0);
+    reconfig_cbs_for_mask<do_read, do_write, do_reset_stream_regs>(cb_config, cb_config[257], 32);
 }
 
 }  // namespace unified_kernels

--- a/models/demos/deepseek_v3_b1/unified_kernels/kernel_utils.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/kernel_utils.hpp
@@ -77,16 +77,33 @@ FORCE_INLINE void semaphore_dec(volatile tt_l1_ptr uint32_t* sem_addr) {
 // Cross-RISC synchronization
 // ============================================================================
 
-// Synchronization barrier using an atomic L1 semaphore.
-// NCRISC waits for BR + TR0 + TR2 (3 RISCs) to signal done, then resets.
-// Other RISCs (BR, TR0, TR2) atomically increment and proceed.
-FORCE_INLINE void sync_riscs(volatile uint32_t tt_l1_ptr* sem_addr) {
+// Full cross-RISC synchronization barrier using two atomic L1 semaphores.
+// sem_addr[0] = phase 1 (others → NC), sem_addr[1] = phase 2 (NC → others)
+//
+// Usage:
+//   sync_riscs_enter(sem);   // BR/TR0/TR2 signal done, NC waits for all 3
+//   // ... NC does exclusive work (stream reg reset, setup_sharded_buffer) ...
+//   sync_riscs_exit(sem);    // NC signals done, BR/TR0/TR2 wait then proceed
+
+// Phase 1: BR/TR0/TR2 signal done → NC waits for all 3
+FORCE_INLINE void sync_riscs_enter(volatile uint32_t tt_l1_ptr* sem_addr) {
 #if defined(COMPILE_FOR_BRISC) || defined(UCK_CHLKC_UNPACK) || defined(UCK_CHLKC_PACK)
-    __atomic_fetch_add(sem_addr, 1, __ATOMIC_RELAXED);
+    __atomic_fetch_add(&sem_addr[0], 1, __ATOMIC_RELAXED);
 #elif defined(COMPILE_FOR_NCRISC)
-    while (__atomic_load_n(sem_addr, __ATOMIC_RELAXED) < 3) {
+    while (__atomic_load_n(&sem_addr[0], __ATOMIC_RELAXED) < 3) {
     }
-    *sem_addr = 0;
+    sem_addr[0] = 0;
+#endif
+}
+
+// Phase 2: NC signals done → BR/TR0/TR2 wait then proceed
+FORCE_INLINE void sync_riscs_exit(volatile uint32_t tt_l1_ptr* sem_addr) {
+#if defined(COMPILE_FOR_NCRISC)
+    __atomic_fetch_add(&sem_addr[1], 3, __ATOMIC_RELAXED);
+#elif defined(COMPILE_FOR_BRISC) || defined(UCK_CHLKC_UNPACK) || defined(UCK_CHLKC_PACK)
+    while (__atomic_load_n(&sem_addr[1], __ATOMIC_RELAXED) == 0) {
+    }
+    __atomic_fetch_sub(&sem_addr[1], 1, __ATOMIC_RELAXED);
 #endif
 }
 
@@ -164,10 +181,13 @@ FORCE_INLINE void reconfig_cb_interfaces(uint32_t tt_l1_ptr* cb_config) {
     constexpr bool do_reset_stream_regs = false;
 #endif
 
-    sync_riscs(reinterpret_cast<volatile uint32_t tt_l1_ptr*>(&cb_config[258]));
+    volatile uint32_t tt_l1_ptr* reconfig_sem = reinterpret_cast<volatile uint32_t tt_l1_ptr*>(&cb_config[258]);
+    sync_riscs_enter(reconfig_sem);
 
     reconfig_cbs_for_mask<do_read, do_write, do_reset_stream_regs>(cb_config, cb_config[256], 0);
     reconfig_cbs_for_mask<do_read, do_write, do_reset_stream_regs>(cb_config, cb_config[257], 32);
+
+    sync_riscs_exit(reconfig_sem);
 }
 
 }  // namespace unified_kernels

--- a/models/demos/deepseek_v3_b1/unified_kernels/kernel_utils.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/kernel_utils.hpp
@@ -77,13 +77,16 @@ FORCE_INLINE void semaphore_dec(volatile tt_l1_ptr uint32_t* sem_addr) {
 // Cross-RISC synchronization
 // ============================================================================
 
-// Full cross-RISC synchronization barrier using two atomic L1 semaphores.
-// sem_addr[0] = phase 1 (others → NC), sem_addr[1] = phase 2 (NC → others)
+// Two-phase cross-RISC synchronization barrier using atomic L1 semaphores.
+// Used by reconfig_cb_interfaces to ensure NC resets stream regs only after
+// all other RISCs (BR/TR0/TR2) have completed prior work.
 //
-// Usage:
-//   sync_riscs_enter(sem);   // BR/TR0/TR2 signal done, NC waits for all 3
-//   // ... NC does exclusive work (stream reg reset, setup_sharded_buffer) ...
-//   sync_riscs_exit(sem);    // NC signals done, BR/TR0/TR2 wait then proceed
+// Phase 1 (enter): BR/TR0/TR2 signal done → NC waits for all 3, then proceeds.
+// Phase 2 (exit):  NC signals done → BR/TR0/TR2 wait, then all proceed together.
+//
+// Safe for repeated use: the full MoE body executes between exit and the next
+// enter, so sem[0] is always 0 when the next iteration's enter begins.
+// sem[0] reset is non-atomic but safe because others are blocked on sem[1].
 
 // Phase 1: BR/TR0/TR2 signal done → NC waits for all 3
 FORCE_INLINE void sync_riscs_enter(volatile uint32_t tt_l1_ptr* sem_addr) {
@@ -112,8 +115,8 @@ FORCE_INLINE void sync_riscs_exit(volatile uint32_t tt_l1_ptr* sem_addr) {
 // ============================================================================
 
 // Minimal CB reconfig: reset fifo pointers from a config tensor in L1.
-// Only sets fifo_rd_ptr, fifo_wr_ptr, fifo_size, fifo_limit, fifo_page_size, fifo_num_pages.
-// Does NOT touch tiles_acked_received_init or fifo_wr_tile_ptr.
+// Sets fifo_rd_ptr, fifo_wr_ptr, fifo_size, fifo_limit, fifo_page_size, fifo_num_pages,
+// tiles_acked_received_init, and fifo_wr_tile_ptr. Also resets stream regs on NCRISC.
 //
 // Config tensor layout per core (264 uint32):
 //   Words 0-255: 64 CB configs, 4 words each [addr, size, num_pages, page_size] (bytes)

--- a/models/demos/deepseek_v3_b1/unified_kernels/kernel_utils.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/kernel_utils.hpp
@@ -73,4 +73,93 @@ FORCE_INLINE void semaphore_dec(volatile tt_l1_ptr uint32_t* sem_addr) {
 
 #endif
 
+// ============================================================================
+// CB reconfig utilities
+// ============================================================================
+
+// Minimal CB reconfig: reset fifo pointers from a config tensor in L1.
+// Only sets fifo_rd_ptr, fifo_wr_ptr, fifo_size, fifo_limit, fifo_page_size, fifo_num_pages.
+// Does NOT touch tiles_acked_received_init or fifo_wr_tile_ptr.
+//
+// Config tensor layout per core (264 uint32):
+//   Words 0-255: 64 CB configs, 4 words each [addr, size, num_pages, page_size] (bytes)
+//   Word 256:    cb_mask_low  (bits 0-31)
+//   Word 257:    cb_mask_high (bits 32-63)
+//
+// read/write flags follow firmware convention per RISC:
+//   NCRISC/BRISC:  read=true,  write=true
+//   TRISC0/unpack: read=true,  write=false
+//   TRISC2/pack:   read=false, write=true
+FORCE_INLINE void reconfig_cb_interfaces(uint32_t tt_l1_ptr* cb_config) {
+#if defined(COMPILE_FOR_NCRISC) || defined(COMPILE_FOR_BRISC)
+    constexpr bool do_read = true;
+    constexpr bool do_write = true;
+#elif defined(UCK_CHLKC_UNPACK)
+    constexpr bool do_read = true;
+    constexpr bool do_write = false;
+#elif defined(UCK_CHLKC_PACK)
+    constexpr bool do_read = false;
+    constexpr bool do_write = true;
+#else
+    constexpr bool do_read = false;
+    constexpr bool do_write = false;
+#endif
+    uint32_t cb_mask_low = cb_config[256];
+    uint32_t cb_mask_high = cb_config[257];
+
+    // Process lower 32 CBs (0-31)
+    uint32_t mask = cb_mask_low;
+    uint32_t cb = 0;
+    while (mask) {
+        if (mask & 1) {
+            uint32_t base = cb * 4;
+            uint32_t fifo_addr = cb_config[base + 0] >> cb_addr_shift;
+            uint32_t fifo_size = cb_config[base + 1] >> cb_addr_shift;
+            uint32_t fifo_num_pages = cb_config[base + 2];
+            uint32_t fifo_page_size = cb_config[base + 3] >> cb_addr_shift;
+
+            LocalCBInterface& iface = get_local_cb_interface(cb);
+            if constexpr (do_read) {
+                iface.fifo_rd_ptr = fifo_addr;
+            }
+            if constexpr (do_write) {
+                iface.fifo_wr_ptr = fifo_addr;
+                iface.fifo_num_pages = fifo_num_pages;
+            }
+            iface.fifo_size = fifo_size;
+            iface.fifo_limit = fifo_addr + fifo_size;
+            iface.fifo_page_size = fifo_page_size;
+        }
+        mask >>= 1;
+        cb++;
+    }
+
+    // Process upper 32 CBs (32-63)
+    mask = cb_mask_high;
+    cb = 32;
+    while (mask) {
+        if (mask & 1) {
+            uint32_t base = cb * 4;
+            uint32_t fifo_addr = cb_config[base + 0] >> cb_addr_shift;
+            uint32_t fifo_size = cb_config[base + 1] >> cb_addr_shift;
+            uint32_t fifo_num_pages = cb_config[base + 2];
+            uint32_t fifo_page_size = cb_config[base + 3] >> cb_addr_shift;
+
+            LocalCBInterface& iface = get_local_cb_interface(cb);
+            if constexpr (do_read) {
+                iface.fifo_rd_ptr = fifo_addr;
+            }
+            if constexpr (do_write) {
+                iface.fifo_wr_ptr = fifo_addr;
+                iface.fifo_num_pages = fifo_num_pages;
+            }
+            iface.fifo_size = fifo_size;
+            iface.fifo_limit = fifo_addr + fifo_size;
+            iface.fifo_page_size = fifo_page_size;
+        }
+        mask >>= 1;
+        cb++;
+    }
+}
+
 }  // namespace unified_kernels

--- a/models/demos/deepseek_v3_b1/utils.py
+++ b/models/demos/deepseek_v3_b1/utils.py
@@ -100,7 +100,8 @@ def build_cb_reconfig_tensor(cb_metadata, full_device_grid, mesh_device):
                        Zeros for unused CBs.
         Words 256:     cb_mask_low  (bits 0-31)
         Words 257:     cb_mask_high (bits 32-63)
-        Words 258-263: padding (zeros)
+        Words 258-259: cross-RISC sync semaphores (initialized to 0, used at runtime)
+        Words 260-263: reserved (zeros)
 
     Args:
         cb_metadata: dict mapping cb_id → (addr, total_size, num_pages, page_size, core_ranges)

--- a/models/demos/deepseek_v3_b1/utils.py
+++ b/models/demos/deepseek_v3_b1/utils.py
@@ -60,3 +60,99 @@ def cb_descriptor_from_overlapped_tensor(
         )
     ]
     return cb_desc
+
+
+def record_cb_metadata(cb_descriptors):
+    """
+    Extract per-CB config metadata from a list of CBDescriptors.
+
+    Args:
+        cb_descriptors: List of ttnn.CBDescriptor objects
+
+    Returns:
+        dict mapping cb_id → (addr, total_size, num_pages, page_size, core_ranges)
+    """
+    import ttnn
+
+    cb_metadata = {}
+    for desc in cb_descriptors:
+        for fmt in desc.format_descriptors:
+            cb_id = fmt.buffer_index
+            addr = ttnn.get_cb_address(desc)
+            total_size = desc.total_size
+            page_size = fmt.page_size
+            num_pages = total_size // page_size
+            cb_metadata[cb_id] = (addr, total_size, num_pages, page_size, desc.core_ranges)
+    return cb_metadata
+
+
+def build_cb_reconfig_tensor(cb_metadata, full_device_grid, mesh_device):
+    """
+    Build an L1-sharded tensor containing per-core CB config data for reconfig.
+
+    When fusing kernels, the preceding op leaves its own CB configuration in firmware.
+    This function creates a tensor that the fused kernel reads at startup to reconfigure
+    its CB read/write interfaces via setup_local_cb_read_write_interfaces().
+
+    Per-core layout (264 uint32 = 1056 bytes, 32B-aligned):
+        Words 0-255:   64 CB configs, 4 words each:
+                       [addr_bytes, size_bytes, num_pages, page_size_bytes]
+                       Zeros for unused CBs.
+        Words 256:     cb_mask_low  (bits 0-31)
+        Words 257:     cb_mask_high (bits 32-63)
+        Words 258-263: padding (zeros)
+
+    Args:
+        cb_metadata: dict mapping cb_id → (addr, total_size, num_pages, page_size, core_ranges)
+        full_device_grid: CoreRangeSet covering all cores on the device
+        mesh_device: Device or MeshDevice to place the tensor on
+
+    Returns:
+        ttnn.Tensor: HEIGHT_SHARDED L1 tensor with 1 shard (264 uint32) per core
+    """
+    import torch
+
+    import ttnn
+
+    all_cores = ttnn.corerange_to_cores(full_device_grid, row_wise=True)
+    num_cores = len(all_cores)
+
+    # Build (x, y) → index map for fast lookup
+    core_to_idx = {(c.x, c.y): idx for idx, c in enumerate(all_cores)}
+
+    # 264 words per core: 64 CBs * 4 words + 2 mask words + 6 padding
+    WORDS_PER_CORE = 264
+    config = torch.zeros((num_cores, WORDS_PER_CORE), dtype=torch.uint32)
+
+    for cb_id, (addr, total_size, num_pages, page_size, core_ranges) in cb_metadata.items():
+        cb_cores = ttnn.corerange_to_cores(core_ranges, row_wise=True)
+        for core in cb_cores:
+            key = (core.x, core.y)
+            if key not in core_to_idx:
+                continue
+            core_idx = core_to_idx[key]
+            base = cb_id * 4
+            config[core_idx, base + 0] = addr
+            config[core_idx, base + 1] = total_size
+            config[core_idx, base + 2] = num_pages
+            config[core_idx, base + 3] = page_size
+            if cb_id < 32:
+                config[core_idx, 256] |= 1 << cb_id
+            else:
+                config[core_idx, 257] |= 1 << (cb_id - 32)
+
+    num_devices = mesh_device.get_num_devices() if hasattr(mesh_device, "get_num_devices") else 1
+    mesh_mapper = ttnn.ReplicateTensorToMesh(mesh_device) if num_devices > 1 else None
+    from_torch_kwargs = {"mesh_mapper": mesh_mapper} if mesh_mapper else {}
+
+    shard_spec = ttnn.ShardSpec(full_device_grid, (1, WORDS_PER_CORE), ttnn.ShardOrientation.ROW_MAJOR)
+    mem_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, shard_spec)
+
+    return ttnn.from_torch(
+        config,
+        dtype=ttnn.uint32,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        device=mesh_device,
+        memory_config=mem_config,
+        **from_torch_kwargs,
+    )

--- a/ttnn/api/ttnn/tensor/tensor_utils.hpp
+++ b/ttnn/api/ttnn/tensor/tensor_utils.hpp
@@ -65,4 +65,17 @@ CBDescriptor cb_descriptor_from_sharded_tensor(
     uint32_t total_size = 0,
     const std::optional<CoreRangeSet>& core_ranges = std::nullopt);
 
+/**
+ * @brief Get the L1 byte address of a CB descriptor.
+ *
+ * Returns buffer->address() + address_offset when a buffer is present,
+ * or just address_offset when no buffer is set (manually placed CB).
+ */
+inline uint32_t get_cb_address(const CBDescriptor& desc) {
+    if (desc.buffer == nullptr) {
+        return desc.address_offset;
+    }
+    return desc.buffer->address() + desc.address_offset;
+}
+
 }  // namespace tt::tt_metal

--- a/ttnn/cpp/ttnn-nanobind/program_descriptors.cpp
+++ b/ttnn/cpp/ttnn-nanobind/program_descriptors.cpp
@@ -412,6 +412,24 @@ void py_module_types(nb::module_& mod) {
                 The tensor must be sharded (have a shard specification), otherwise this will raise an error.
         )pbdoc");
 
+    // Helper function for getting the L1 byte address of a CB descriptor
+    mod.def(
+        "get_cb_address",
+        &tt::tt_metal::get_cb_address,
+        nb::arg("descriptor"),
+        R"pbdoc(
+            Get the L1 byte address of a CB descriptor.
+
+            Returns buffer base address + address_offset when a buffer is present,
+            or just address_offset when no buffer is set (manually placed CB).
+
+            Args:
+                descriptor: A CBDescriptor to get the address from
+
+            Returns:
+                The L1 byte address of the circular buffer
+        )pbdoc");
+
     // Bind KernelDescriptor related types
     nb::class_<tt::tt_metal::ReaderConfigDescriptor>(mod, "ReaderConfigDescriptor", R"pbdoc(
         Configuration descriptor for reader components in a kernel.

--- a/ttnn/ttnn/__init__.py
+++ b/ttnn/ttnn/__init__.py
@@ -266,6 +266,7 @@ from ttnn.types import (
     MeshProgramDescriptor,
     merge_program_descriptors,
     cb_descriptor_from_sharded_tensor,
+    get_cb_address,
     TensorAccessorArgs,
 )
 

--- a/ttnn/ttnn/types.py
+++ b/ttnn/ttnn/types.py
@@ -109,5 +109,6 @@ ProgramDescriptor = ttnn._ttnn.program_descriptor.ProgramDescriptor
 MeshProgramDescriptor = ttnn._ttnn.program_descriptor.MeshProgramDescriptor
 merge_program_descriptors = ttnn._ttnn.program_descriptor.merge_program_descriptors
 cb_descriptor_from_sharded_tensor = ttnn._ttnn.program_descriptor.cb_descriptor_from_sharded_tensor
+get_cb_address = ttnn._ttnn.program_descriptor.get_cb_address
 
 TensorAccessorArgs = ttnn._ttnn.tensor_accessor_args.TensorAccessorArgs


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/38563)

### Problem description
reconfigure CBs with a meta data tensor, so that we can overlap CB usage between MLA and MOE

### What's changed
create the cb descriptors on op.py, then only feed in dummy cb desctoptors to program (for testing the CB reconfigured actually works)

Kernel side use a RISC atomic sync to sync between BR/NC/TR, then NC reset stream reg, BR/NC/TR all reset its own CB interface with meta data tensor.

Reconfigure the CBs for each loop iterations. 

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=yugao/moe17)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:yugao/moe17)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=yugao/moe17)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:yugao/moe17)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=yugao/moe17)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:yugao/moe17)
- [ ] New/Existing tests provide coverage for changes

