### PR TITLE
Make Conv3dConfig optional with conservative default blocking

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/conv3d/conv3d.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/conv3d/conv3d.hpp
@@ -18,7 +18,7 @@ ttnn::Tensor conv3d(
     const ttnn::Tensor& input_tensor,
     const ttnn::Tensor& weight_tensor,
     const std::optional<ttnn::Tensor>& bias_tensor,
-    const ttnn::experimental::prim::Conv3dConfig& config,
+    const std::optional<ttnn::experimental::prim::Conv3dConfig>& config,
     tt::tt_metal::DataType dtype_,
     uint32_t output_channels_,
     const std::array<uint32_t, 3>& kernel_size_,

--- a/ttnn/cpp/ttnn/operations/experimental/conv3d/conv3d_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/conv3d/conv3d_nanobind.cpp
@@ -35,7 +35,7 @@ void bind_conv3d(nb::module_& mod) {
         Args:
             input_tensor (ttnn.Tensor): Input tensor.
             weight_tensor (ttnn.Tensor): Weight tensor.
-            config (ttnn.Conv3dConfig): Configuration for the Conv3D operation.
+            config (ttnn.Conv3dConfig, optional): Configuration for the Conv3D operation. If not provided, conservative default blocking is used.
 
         Keyword Args:
             bias_tensor (ttnn.Tensor, optional): Bias tensor.
@@ -50,7 +50,7 @@ void bind_conv3d(nb::module_& mod) {
         nb::arg("input_tensor"),
         nb::arg("weight_tensor"),
         nb::arg("bias_tensor") = nb::none(),
-        nb::arg("config"),
+        nb::arg("config") = nb::none(),
         nb::arg("dtype"),
         nb::arg("output_channels"),
         nb::arg("kernel_size"),


### PR DESCRIPTION
## Summary
- Makes `Conv3dConfig` an optional parameter in the conv3d API (C++ and Python) so tt-mlir can call conv3d without manually specifying hardware-specific blocking
- When no config is provided, uses conservative defaults: spatial blocks (1,1,1), C_out_block=32, full C_in (no reduction), full device grid
- Adds `test_conv3d_no_config` tests verifying auto-blocking correctness (PCC >= 0.999)

Closes #35436

## Test plan
- [x] All 262 existing conv3d tests pass (no regressions)
- [x] 3 new `test_conv3d_no_config` parametrized tests pass
- [ ] [WH post-commit](https://github.com/tenstorrent/tt-metal/actions/runs/22418788557)
- [ ] [BH post-commit](https://github.com/tenstorrent/tt-metal/actions/runs/22418789926)

🤖 Generated with [Claude Code](https://claude.com/claude-code)