### PR TITLE
Replace hardcoded packet header sizes with runtime API in DeepSeek B1 ops

### DIFF
--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_reduce_to_one_b1.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_reduce_to_one_b1.py
@@ -19,6 +19,13 @@ from models.demos.deepseek_v3_b1.micro_ops.reduce_to_one_b1.op import ReduceToOn
 from models.perf.benchmarking_utils import BenchmarkProfiler
 
 
+def create_fabric_router_config(max_payload_size):
+    """Helper to create FabricRouterConfig with custom max payload size."""
+    config = ttnn._ttnn.fabric.FabricRouterConfig()
+    config.max_packet_payload_size_bytes = max_payload_size
+    return config
+
+
 def setup_reduce_to_one_test(mesh_device):
     """Common setup for reduce_to_one tests. Returns test configuration."""
     # Log mesh device info
@@ -322,7 +329,7 @@ def run_reduce_to_one_with_trace(mesh_device):
 @skip_for_wormhole_b0("This test is for blackhole")
 @pytest.mark.parametrize(
     "device_params",
-    [({"fabric_config": ttnn.FabricConfig.FABRIC_1D})],
+    [({"fabric_config": ttnn.FabricConfig.FABRIC_1D, "fabric_router_config": create_fabric_router_config(15232)})],
     indirect=["device_params"],
     ids=["fabric_1d"],
 )
@@ -334,7 +341,7 @@ def test_reduce_to_one_1d(bh_2d_mesh_device):
 @skip_for_wormhole_b0("This test is for blackhole")
 @pytest.mark.parametrize(
     "device_params",
-    [({"fabric_config": ttnn.FabricConfig.FABRIC_2D})],
+    [({"fabric_config": ttnn.FabricConfig.FABRIC_2D, "fabric_router_config": create_fabric_router_config(15232)})],
     indirect=["device_params"],
     ids=["fabric_2d"],
 )
@@ -347,7 +354,15 @@ def test_reduce_to_one_2d(bh_2d_mesh_device):
 @skip_for_wormhole_b0("This test is for blackhole")
 @pytest.mark.parametrize(
     "device_params",
-    [({"fabric_config": ttnn.FabricConfig.FABRIC_1D, "trace_region_size": 425984})],
+    [
+        (
+            {
+                "fabric_config": ttnn.FabricConfig.FABRIC_1D,
+                "trace_region_size": 425984,
+                "fabric_router_config": create_fabric_router_config(15232),
+            }
+        )
+    ],
     indirect=["device_params"],
     ids=["fabric_1d_trace"],
 )
@@ -359,7 +374,15 @@ def test_reduce_to_one_with_trace_1d(bh_2d_mesh_device):
 @skip_for_wormhole_b0("This test is for blackhole")
 @pytest.mark.parametrize(
     "device_params",
-    [({"fabric_config": ttnn.FabricConfig.FABRIC_2D, "trace_region_size": 425984})],
+    [
+        (
+            {
+                "fabric_config": ttnn.FabricConfig.FABRIC_2D,
+                "trace_region_size": 425984,
+                "fabric_router_config": create_fabric_router_config(15232),
+            }
+        )
+    ],
     indirect=["device_params"],
     ids=["fabric_2d_trace"],
 )


### PR DESCRIPTION
## Summary

Replace hardcoded packet header sizes (`32`, `256`) with `ttnn.get_tt_fabric_packet_header_size_bytes()` in the DeepSeek B1 PostSDPA op and add max packet payload config to reduce-to-one tests.

Closes #38598

## Changes

### `models/demos/deepseek_v3_b1/fused_ops/post_sdpa/op.py`

- **CCL packet header**: `ccl_packet_header_size_bytes = 32` → `ttnn.get_tt_fabric_packet_header_size_bytes()`. The CCL all-reduce kernels use `sizeof(PACKET_HEADER_TYPE)` (96 bytes for 2D routing), so the CB was undersized.
- **SDPA forwarder slot size**: `sdpa_fwd_slot_size = 256 + ...` → `ttnn.get_tt_fabric_packet_header_size_bytes() + ...`
- **SDPA packet slot CB**: Hardcoded `256` for `page_size` and `total_size` → `2 * ttnn.get_tt_fabric_packet_header_size_bytes()`

### `models/demos/deepseek_v3_b1/tests/unit_tests/test_reduce_to_one_b1.py`

- Add `fabric_router_config` with `max_packet_payload_size_bytes=15232` (Blackhole max) to all four test parametrizations, enabling single-packet transfers for the `[1, 7168]` bfloat16 tensor (14336 bytes).

