### PR TITLE
Add --compiler flag and Fedora/RHEL support to build_metal.sh and install_dependencies.sh (#37907)

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -84,6 +84,46 @@
         "toolchainFile": "cmake/x86_64-linux-clang-20-libcpp-toolchain.cmake"
       },
       {
+        "name": "clang-19",
+        "inherits": "default",
+        "description": "Build with Clang 19",
+        "binaryDir": "${sourceDir}/.build/clang-19",
+        "cacheVariables": {
+          "BUILD_TT_TRAIN": {"value": "OFF"}
+        },
+        "toolchainFile": "cmake/x86_64-linux-clang-19-libstdcpp-toolchain.cmake"
+      },
+      {
+        "name": "clang-18",
+        "inherits": "default",
+        "description": "Build with Clang 18",
+        "binaryDir": "${sourceDir}/.build/clang-18",
+        "cacheVariables": {
+          "BUILD_TT_TRAIN": {"value": "OFF"}
+        },
+        "toolchainFile": "cmake/x86_64-linux-clang-18-libstdcpp-toolchain.cmake"
+      },
+      {
+        "name": "clang-17",
+        "inherits": "default",
+        "description": "Build with Clang 17",
+        "binaryDir": "${sourceDir}/.build/clang-17",
+        "cacheVariables": {
+          "BUILD_TT_TRAIN": {"value": "OFF"}
+        },
+        "toolchainFile": "cmake/x86_64-linux-clang-17-libstdcpp-toolchain.cmake"
+      },
+      {
+        "name": "gcc-13",
+        "inherits": "default",
+        "description": "Build with GCC 13",
+        "binaryDir": "${sourceDir}/.build/gcc-13",
+        "cacheVariables": {
+          "BUILD_TT_TRAIN": {"value": "OFF"}
+        },
+        "toolchainFile": "cmake/x86_64-linux-gcc-13-toolchain.cmake"
+      },
+      {
         "name": "gcc-system",
         "inherits": "default",
         "description": "Build with system GCC (unversioned gcc/g++)",
@@ -126,6 +166,30 @@
       {
         "name": "dev-gcc-system",
         "configurePreset": "gcc-system",
+        "configuration": "Release",
+        "targets": ["all"]
+      },
+      {
+        "name": "dev-clang-19",
+        "configurePreset": "clang-19",
+        "configuration": "Release",
+        "targets": ["all"]
+      },
+      {
+        "name": "dev-clang-18",
+        "configurePreset": "clang-18",
+        "configuration": "Release",
+        "targets": ["all"]
+      },
+      {
+        "name": "dev-clang-17",
+        "configurePreset": "clang-17",
+        "configuration": "Release",
+        "targets": ["all"]
+      },
+      {
+        "name": "dev-gcc-13",
+        "configurePreset": "gcc-13",
         "configuration": "Release",
         "targets": ["all"]
       },

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -82,6 +82,26 @@
           "BUILD_TT_TRAIN": {"value": "OFF"}
         },
         "toolchainFile": "cmake/x86_64-linux-clang-20-libcpp-toolchain.cmake"
+      },
+      {
+        "name": "gcc-system",
+        "inherits": "default",
+        "description": "Build with system GCC (unversioned gcc/g++)",
+        "binaryDir": "${sourceDir}/.build/gcc-system",
+        "cacheVariables": {
+          "BUILD_TT_TRAIN": {"value": "OFF"}
+        },
+        "toolchainFile": "cmake/x86_64-linux-gcc-toolchain.cmake"
+      },
+      {
+        "name": "clang-system",
+        "inherits": "default",
+        "description": "Build with system Clang (unversioned clang/clang++)",
+        "binaryDir": "${sourceDir}/.build/clang-system",
+        "cacheVariables": {
+          "BUILD_TT_TRAIN": {"value": "OFF"}
+        },
+        "toolchainFile": "cmake/x86_64-linux-clang-libstdcpp-toolchain.cmake"
       }
     ],
     "buildPresets": [

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -124,6 +124,18 @@
         "targets": ["all"]
       },
       {
+        "name": "dev-gcc-system",
+        "configurePreset": "gcc-system",
+        "configuration": "Release",
+        "targets": ["all"]
+      },
+      {
+        "name": "dev-clang-system",
+        "configurePreset": "clang-system",
+        "configuration": "Release",
+        "targets": ["all"]
+      },
+      {
         "name": "debug",
         "configurePreset": "default",
         "configuration": "Debug",

--- a/build_metal.sh
+++ b/build_metal.sh
@@ -50,8 +50,12 @@ use_compiler() {
     else
         cxx_compiler_path="$(command -v "$cxx")"
         # Derive C compiler: g++-13 → gcc-13, clang++-18 → clang-18
-        local cc="${cxx/++/}"
-        [[ "$cxx" == g++* ]] && cc="${cxx/g++/gcc}"
+        local cc
+        if [[ "$cxx" == g++* ]]; then
+            cc="${cxx/g++/gcc}"
+        else
+            cc="${cxx/++/}"
+        fi
         c_compiler_path="$(command -v "$cc")"
     fi
 }
@@ -88,12 +92,12 @@ show_help() {
     echo "  --cpm-source-cache               Set path to CPM Source Cache."
     echo "  --cpm-use-local-packages         Attempt to use locally installed dependencies."
     echo "  --ttnn-shared-sub-libs           Use shared libraries for ttnn."
+    echo "  --compiler compiler_name         Select compiler: clang (best available), gcc (best available), clang-20, clang-20-libcpp, gcc-12, gcc-14."
     echo "  --toolchain-path                 Set path to CMake toolchain file."
     echo "  --configure-only                 Only configure the project, do not build."
     echo "  --without-distributed            Disable distributed compute support (OpenMPI dependency). Enabled by default."
     echo "  --without-python-bindings        Disable Python bindings (ttnncpp will be available as standalone library, otherwise ttnn will include the cpp backend and the python bindings), Enabled by default"
     echo "  --enable-fake-kernels-target     Enable fake kernels target, to enable generation of compile_commands.json for the kernels to enable IDE support."
-    echo "  --compiler compiler_name         Select compiler: clang (best available), gcc (best available), clang-20, clang-20-libcpp, gcc-12, gcc-14."
     echo "  --enable-lto                     Enable Link Time Optimization (LTO) for Release/RelWithDebInfo builds."
 }
 

--- a/build_metal.sh
+++ b/build_metal.sh
@@ -110,7 +110,7 @@ show_help() {
     echo "  --cpm-source-cache               Set path to CPM Source Cache."
     echo "  --cpm-use-local-packages         Attempt to use locally installed dependencies."
     echo "  --ttnn-shared-sub-libs           Use shared libraries for ttnn."
-    echo "  --compiler compiler_name         Select compiler: clang (best available), gcc (best available), clang-20, clang-20-libcpp, gcc-12, gcc-14."
+    echo "  --compiler compiler_name         Select compiler (best available version if unversioned): ${COMPILER_FLAGS[*]}."
     echo "  --toolchain-path                 Set path to CMake toolchain file."
     echo "  --configure-only                 Only configure the project, do not build."
     echo "  --without-distributed            Disable distributed compute support (OpenMPI dependency). Enabled by default."

--- a/build_metal.sh
+++ b/build_metal.sh
@@ -74,6 +74,10 @@ use_compiler() {
         else
             cc="${cxx/++/}"
         fi
+        if ! command -v "$cc" >/dev/null 2>&1; then
+            echo "ERROR: C compiler '$cc' not found (derived from '$cxx')"
+            exit 1
+        fi
         c_compiler_path="$(command -v "$cc")"
     fi
 }

--- a/build_metal.sh
+++ b/build_metal.sh
@@ -22,22 +22,28 @@ GCC_SEARCH=(g++-14 g++-13 g++-12 g++)
 # Missing entry = no dedicated toolchain, use direct compiler path
 declare -A BINARY_TOOLCHAIN=(
     [clang++-20]=clang-20-libstdcpp
+    [clang++-19]=clang-19-libstdcpp
+    [clang++-18]=clang-18-libstdcpp
+    [clang++-17]=clang-17-libstdcpp
     [clang++]=clang-libstdcpp
     [g++-14]=gcc-14
+    [g++-13]=gcc-13
     [g++-12]=gcc-12
     [g++]=gcc
-    # clang++-19, clang++-18, clang++-17, g++-13: no dedicated toolchain,
-    # use_compiler() falls back to direct compiler path
 )
 
 # Valid --compiler flag values, in display order
-COMPILER_FLAGS=(clang gcc clang-20 clang-20-libcpp gcc-12 gcc-14)
+COMPILER_FLAGS=(clang gcc clang-20 clang-19 clang-18 clang-17 clang-20-libcpp gcc-14 gcc-13 gcc-12)
 
 # CLI flag → toolchain ID (for --compiler pinned versions)
 declare -A FLAG_TOOLCHAIN=(
     [clang-20]=clang-20-libstdcpp
+    [clang-19]=clang-19-libstdcpp
+    [clang-18]=clang-18-libstdcpp
+    [clang-17]=clang-17-libstdcpp
     [clang-20-libcpp]=clang-20-libcpp
     [gcc-14]=gcc-14
+    [gcc-13]=gcc-13
     [gcc-12]=gcc-12
 )
 

--- a/build_metal.sh
+++ b/build_metal.sh
@@ -14,17 +14,33 @@ elif [[ -v "$BUILD_ID" ]]; then
     VERSION="${BUILD_ID}"
 fi
 
-# Map a C++ compiler binary name to its CMake toolchain file.
-# Returns the path on stdout, or empty string if no matching toolchain exists.
-toolchain_for() {
-    case "$1" in
-        clang++-20) echo "cmake/x86_64-linux-clang-20-libstdcpp-toolchain.cmake";;
-        clang++)    echo "cmake/x86_64-linux-clang-libstdcpp-toolchain.cmake";;
-        g++-14)     echo "cmake/x86_64-linux-gcc-14-toolchain.cmake";;
-        g++-12)     echo "cmake/x86_64-linux-gcc-12-toolchain.cmake";;
-        g++)        echo "cmake/x86_64-linux-gcc-toolchain.cmake";;
-        *)          echo "";;
-    esac
+# Compiler search order (highest priority first) — defined ONCE
+CLANG_SEARCH=(clang++-20 clang++-19 clang++-18 clang++-17 clang++)
+GCC_SEARCH=(g++-14 g++-13 g++-12 g++)
+
+# Binary name → toolchain ID (used after find_compiler locates a binary)
+# Missing entry = no dedicated toolchain, use direct compiler path
+declare -A BINARY_TOOLCHAIN=(
+    [clang++-20]=clang-20-libstdcpp
+    [clang++]=clang-libstdcpp
+    [g++-14]=gcc-14
+    [g++-12]=gcc-12
+    [g++]=gcc
+    # clang++-19, clang++-18, clang++-17, g++-13: no dedicated toolchain,
+    # use_compiler() falls back to direct compiler path
+)
+
+# CLI flag → toolchain ID (for --compiler pinned versions)
+declare -A FLAG_TOOLCHAIN=(
+    [clang-20]=clang-20-libstdcpp
+    [clang-20-libcpp]=clang-20-libcpp
+    [gcc-14]=gcc-14
+    [gcc-12]=gcc-12
+)
+
+# Convert a short toolchain ID to the full cmake file path.
+toolchain_file() {
+    echo "cmake/x86_64-linux-${1}-toolchain.cmake"
 }
 
 # Find the first available binary from a list of candidates.
@@ -43,10 +59,9 @@ find_compiler() {
 # Uses toolchain file when one exists; falls back to direct compiler path.
 use_compiler() {
     local cxx="$1"
-    local tc
-    tc=$(toolchain_for "$cxx")
-    if [ -n "$tc" ]; then
-        toolchain_path="$tc"
+    local id="${BINARY_TOOLCHAIN[$cxx]:-}"
+    if [ -n "$id" ]; then
+        toolchain_path="$(toolchain_file "$id")"
     else
         cxx_compiler_path="$(command -v "$cxx")"
         # Derive C compiler: g++-13 → gcc-13, clang++-18 → clang-18
@@ -133,7 +148,7 @@ cxx_compiler_path=""
 cpm_source_cache=""
 c_compiler_path=""
 ttnn_shared_sub_libs="OFF"
-toolchain_path="cmake/x86_64-linux-clang-20-libstdcpp-toolchain.cmake"
+toolchain_path="$(toolchain_file clang-20-libstdcpp)"
 toolchain_path_explicitly_set=false
 compiler=""
 
@@ -280,23 +295,23 @@ done
 if [ "$compiler" != "" ]; then
     case "$compiler" in
         clang)
-            found=$(find_compiler clang++-20 clang++-19 clang++-18 clang++-17 clang++) \
+            found=$(find_compiler "${CLANG_SEARCH[@]}") \
                 || { echo "ERROR: No clang++ found in PATH."; exit 1; }
             echo "INFO: --compiler clang: found $found"
             use_compiler "$found";;
         gcc)
-            found=$(find_compiler g++-14 g++-13 g++-12 g++) \
+            found=$(find_compiler "${GCC_SEARCH[@]}") \
                 || { echo "ERROR: No g++ found in PATH."; exit 1; }
             echo "INFO: --compiler gcc: found $found"
             use_compiler "$found";;
-        clang-20)      toolchain_path="cmake/x86_64-linux-clang-20-libstdcpp-toolchain.cmake";;
-        clang-20-libcpp) toolchain_path="cmake/x86_64-linux-clang-20-libcpp-toolchain.cmake";;
-        gcc-12)        toolchain_path="cmake/x86_64-linux-gcc-12-toolchain.cmake";;
-        gcc-14)        toolchain_path="cmake/x86_64-linux-gcc-14-toolchain.cmake";;
         *)
-            echo "ERROR: Unknown compiler '$compiler'. Allowed: clang, gcc, clang-20, clang-20-libcpp, gcc-12, gcc-14."
-            show_help
-            exit 1;;
+            if [ -n "${FLAG_TOOLCHAIN[$compiler]:-}" ]; then
+                toolchain_path="$(toolchain_file "${FLAG_TOOLCHAIN[$compiler]}")"
+            else
+                echo "ERROR: Unknown compiler '$compiler'. Allowed: clang, gcc, ${!FLAG_TOOLCHAIN[*]}."
+                show_help
+                exit 1
+            fi;;
     esac
 fi
 
@@ -304,7 +319,7 @@ fi
 if [ "$compiler" = "" ] && [ "$cxx_compiler_path" = "" ] && [ "$toolchain_path_explicitly_set" = "false" ]; then
     if ! command -v clang++-20 >/dev/null 2>&1; then
         echo "WARNING: Default compiler 'clang++-20' not found in PATH."
-        found=$(find_compiler clang++-19 clang++-18 clang++-17 clang++ g++-14 g++-13 g++-12 g++) \
+        found=$(find_compiler "${CLANG_SEARCH[@]:1}" "${GCC_SEARCH[@]}") \
             || { echo "ERROR: No C++ compiler found. Install clang or gcc, or use --compiler/--cxx-compiler-path."; exit 1; }
         echo "INFO: Auto-selected $found"
         use_compiler "$found"

--- a/build_metal.sh
+++ b/build_metal.sh
@@ -14,6 +14,48 @@ elif [[ -v "$BUILD_ID" ]]; then
     VERSION="${BUILD_ID}"
 fi
 
+# Map a C++ compiler binary name to its CMake toolchain file.
+# Returns the path on stdout, or empty string if no matching toolchain exists.
+toolchain_for() {
+    case "$1" in
+        clang++-20) echo "cmake/x86_64-linux-clang-20-libstdcpp-toolchain.cmake";;
+        clang++)    echo "cmake/x86_64-linux-clang-libstdcpp-toolchain.cmake";;
+        g++-14)     echo "cmake/x86_64-linux-gcc-14-toolchain.cmake";;
+        g++-12)     echo "cmake/x86_64-linux-gcc-12-toolchain.cmake";;
+        g++)        echo "cmake/x86_64-linux-gcc-toolchain.cmake";;
+        *)          echo "";;
+    esac
+}
+
+# Find the first available binary from a list of candidates.
+# Returns the name on stdout; returns 1 if none found.
+find_compiler() {
+    for candidate in "$@"; do
+        if command -v "$candidate" >/dev/null 2>&1; then
+            echo "$candidate"
+            return 0
+        fi
+    done
+    return 1
+}
+
+# Set toolchain_path or cxx/c_compiler_path from a C++ binary name.
+# Uses toolchain file when one exists; falls back to direct compiler path.
+use_compiler() {
+    local cxx="$1"
+    local tc
+    tc=$(toolchain_for "$cxx")
+    if [ -n "$tc" ]; then
+        toolchain_path="$tc"
+    else
+        cxx_compiler_path="$(command -v "$cxx")"
+        # Derive C compiler: g++-13 → gcc-13, clang++-18 → clang-18
+        local cc="${cxx/++/}"
+        [[ "$cxx" == g++* ]] && cc="${cxx/g++/gcc}"
+        c_compiler_path="$(command -v "$cc")"
+    fi
+}
+
 # Function to display help
 show_help() {
     echo "Usage: $0 [options]..."
@@ -230,58 +272,23 @@ while true; do
     shift
 done
 
-# Map --compiler flag to toolchain file
+# Resolve --compiler flag to toolchain_path or cxx/c_compiler_path
 if [ "$compiler" != "" ]; then
     case "$compiler" in
         clang)
-            # Find the best available Clang (prefer newest versioned, fall back to unversioned)
-            found_compiler=""
-            for candidate in clang++-20 clang++-19 clang++-18 clang++-17 clang++; do
-                if command -v "$candidate" >/dev/null 2>&1; then
-                    found_compiler="$candidate"
-                    break
-                fi
-            done
-            if [ -z "$found_compiler" ]; then
-                echo "ERROR: No clang++ found in PATH."
-                exit 1
-            fi
-            echo "INFO: --compiler clang: found $found_compiler"
-            case "$found_compiler" in
-                clang++-20) toolchain_path="cmake/x86_64-linux-clang-20-libstdcpp-toolchain.cmake";;
-                clang++)    toolchain_path="cmake/x86_64-linux-clang-libstdcpp-toolchain.cmake";;
-                *)          cxx_compiler_path="$(command -v "$found_compiler")"
-                            c_compiler_path="$(command -v "${found_compiler/++/}")";;
-            esac;;
+            found=$(find_compiler clang++-20 clang++-19 clang++-18 clang++-17 clang++) \
+                || { echo "ERROR: No clang++ found in PATH."; exit 1; }
+            echo "INFO: --compiler clang: found $found"
+            use_compiler "$found";;
         gcc)
-            # Find the best available GCC (prefer newest versioned, fall back to unversioned)
-            found_compiler=""
-            for candidate in g++-14 g++-13 g++-12 g++; do
-                if command -v "$candidate" >/dev/null 2>&1; then
-                    found_compiler="$candidate"
-                    break
-                fi
-            done
-            if [ -z "$found_compiler" ]; then
-                echo "ERROR: No g++ found in PATH."
-                exit 1
-            fi
-            echo "INFO: --compiler gcc: found $found_compiler"
-            case "$found_compiler" in
-                g++-14) toolchain_path="cmake/x86_64-linux-gcc-14-toolchain.cmake";;
-                g++-12) toolchain_path="cmake/x86_64-linux-gcc-12-toolchain.cmake";;
-                g++)    toolchain_path="cmake/x86_64-linux-gcc-toolchain.cmake";;
-                *)      cxx_compiler_path="$(command -v "$found_compiler")"
-                        c_compiler_path="$(command -v "${found_compiler/g++/gcc}")";;
-            esac;;
-        clang-20)
-            toolchain_path="cmake/x86_64-linux-clang-20-libstdcpp-toolchain.cmake";;
-        clang-20-libcpp)
-            toolchain_path="cmake/x86_64-linux-clang-20-libcpp-toolchain.cmake";;
-        gcc-12)
-            toolchain_path="cmake/x86_64-linux-gcc-12-toolchain.cmake";;
-        gcc-14)
-            toolchain_path="cmake/x86_64-linux-gcc-14-toolchain.cmake";;
+            found=$(find_compiler g++-14 g++-13 g++-12 g++) \
+                || { echo "ERROR: No g++ found in PATH."; exit 1; }
+            echo "INFO: --compiler gcc: found $found"
+            use_compiler "$found";;
+        clang-20)      toolchain_path="cmake/x86_64-linux-clang-20-libstdcpp-toolchain.cmake";;
+        clang-20-libcpp) toolchain_path="cmake/x86_64-linux-clang-20-libcpp-toolchain.cmake";;
+        gcc-12)        toolchain_path="cmake/x86_64-linux-gcc-12-toolchain.cmake";;
+        gcc-14)        toolchain_path="cmake/x86_64-linux-gcc-14-toolchain.cmake";;
         *)
             echo "ERROR: Unknown compiler '$compiler'. Allowed: clang, gcc, clang-20, clang-20-libcpp, gcc-12, gcc-14."
             show_help
@@ -293,44 +300,10 @@ fi
 if [ "$compiler" = "" ] && [ "$cxx_compiler_path" = "" ] && [ "$toolchain_path_explicitly_set" = "false" ]; then
     if ! command -v clang++-20 >/dev/null 2>&1; then
         echo "WARNING: Default compiler 'clang++-20' not found in PATH."
-        # Search for best available Clang, then GCC
-        found_compiler=""
-        for candidate in clang++-19 clang++-18 clang++-17 clang++; do
-            if command -v "$candidate" >/dev/null 2>&1; then
-                found_compiler="$candidate"
-                break
-            fi
-        done
-        if [ -n "$found_compiler" ]; then
-            case "$found_compiler" in
-                clang++) toolchain_path="cmake/x86_64-linux-clang-libstdcpp-toolchain.cmake";;
-                *)       cxx_compiler_path="$(command -v "$found_compiler")"
-                         c_compiler_path="$(command -v "${found_compiler/++/}")";;
-            esac
-            echo "INFO: Auto-selected $found_compiler"
-        else
-            # No Clang found, try GCC
-            found_compiler=""
-            for candidate in g++-14 g++-13 g++-12 g++; do
-                if command -v "$candidate" >/dev/null 2>&1; then
-                    found_compiler="$candidate"
-                    break
-                fi
-            done
-            if [ -n "$found_compiler" ]; then
-                case "$found_compiler" in
-                    g++-14) toolchain_path="cmake/x86_64-linux-gcc-14-toolchain.cmake";;
-                    g++-12) toolchain_path="cmake/x86_64-linux-gcc-12-toolchain.cmake";;
-                    g++)    toolchain_path="cmake/x86_64-linux-gcc-toolchain.cmake";;
-                    *)      cxx_compiler_path="$(command -v "$found_compiler")"
-                            c_compiler_path="$(command -v "${found_compiler/g++/gcc}")";;
-                esac
-                echo "INFO: Auto-selected $found_compiler"
-            else
-                echo "ERROR: No C++ compiler found. Install clang or gcc, or use --compiler/--cxx-compiler-path."
-                exit 1
-            fi
-        fi
+        found=$(find_compiler clang++-19 clang++-18 clang++-17 clang++ g++-14 g++-13 g++-12 g++) \
+            || { echo "ERROR: No C++ compiler found. Install clang or gcc, or use --compiler/--cxx-compiler-path."; exit 1; }
+        echo "INFO: Auto-selected $found"
+        use_compiler "$found"
     fi
 fi
 

--- a/build_metal.sh
+++ b/build_metal.sh
@@ -308,7 +308,7 @@ if [ "$compiler" != "" ]; then
             if [ -n "${FLAG_TOOLCHAIN[$compiler]:-}" ]; then
                 toolchain_path="$(toolchain_file "${FLAG_TOOLCHAIN[$compiler]}")"
             else
-                echo "ERROR: Unknown compiler '$compiler'. Allowed: clang, gcc, ${!FLAG_TOOLCHAIN[*]}."
+                echo "ERROR: Unknown compiler '$compiler'. Allowed: clang, gcc, clang-20, clang-20-libcpp, gcc-12, gcc-14."
                 show_help
                 exit 1
             fi;;

--- a/build_metal.sh
+++ b/build_metal.sh
@@ -51,6 +51,7 @@ show_help() {
     echo "  --without-distributed            Disable distributed compute support (OpenMPI dependency). Enabled by default."
     echo "  --without-python-bindings        Disable Python bindings (ttnncpp will be available as standalone library, otherwise ttnn will include the cpp backend and the python bindings), Enabled by default"
     echo "  --enable-fake-kernels-target     Enable fake kernels target, to enable generation of compile_commands.json for the kernels to enable IDE support."
+    echo "  --compiler compiler_name         Select compiler: clang (best available), gcc (best available), clang-20, clang-20-libcpp, gcc-12, gcc-14."
     echo "  --enable-lto                     Enable Link Time Optimization (LTO) for Release/RelWithDebInfo builds."
 }
 
@@ -87,7 +88,8 @@ cpm_source_cache=""
 c_compiler_path=""
 ttnn_shared_sub_libs="OFF"
 toolchain_path="cmake/x86_64-linux-clang-20-libstdcpp-toolchain.cmake"
-
+toolchain_path_explicitly_set=false
+compiler=""
 
 configure_only="OFF"
 enable_distributed="ON"
@@ -129,6 +131,7 @@ cpm-use-local-packages
 c-compiler-path:
 ttnn-shared-sub-libs
 toolchain-path:
+compiler:
 configure-only
 without-distributed
 without-python-bindings
@@ -210,7 +213,9 @@ while true; do
         --c-compiler-path)
             c_compiler_path="$2";shift;;
         --toolchain-path)
-            toolchain_path="$2";shift;;
+            toolchain_path="$2";toolchain_path_explicitly_set=true;shift;;
+        --compiler)
+            compiler="$2";shift;;
         --release)
             build_type="Release";;
         --development)
@@ -224,6 +229,110 @@ while true; do
     esac
     shift
 done
+
+# Map --compiler flag to toolchain file
+if [ "$compiler" != "" ]; then
+    case "$compiler" in
+        clang)
+            # Find the best available Clang (prefer newest versioned, fall back to unversioned)
+            found_compiler=""
+            for candidate in clang++-20 clang++-19 clang++-18 clang++-17 clang++; do
+                if command -v "$candidate" >/dev/null 2>&1; then
+                    found_compiler="$candidate"
+                    break
+                fi
+            done
+            if [ -z "$found_compiler" ]; then
+                echo "ERROR: No clang++ found in PATH."
+                exit 1
+            fi
+            echo "INFO: --compiler clang: found $found_compiler"
+            case "$found_compiler" in
+                clang++-20) toolchain_path="cmake/x86_64-linux-clang-20-libstdcpp-toolchain.cmake";;
+                clang++)    toolchain_path="cmake/x86_64-linux-clang-libstdcpp-toolchain.cmake";;
+                *)          cxx_compiler_path="$(command -v "$found_compiler")"
+                            c_compiler_path="$(command -v "${found_compiler/++/}")";;
+            esac;;
+        gcc)
+            # Find the best available GCC (prefer newest versioned, fall back to unversioned)
+            found_compiler=""
+            for candidate in g++-14 g++-13 g++-12 g++; do
+                if command -v "$candidate" >/dev/null 2>&1; then
+                    found_compiler="$candidate"
+                    break
+                fi
+            done
+            if [ -z "$found_compiler" ]; then
+                echo "ERROR: No g++ found in PATH."
+                exit 1
+            fi
+            echo "INFO: --compiler gcc: found $found_compiler"
+            case "$found_compiler" in
+                g++-14) toolchain_path="cmake/x86_64-linux-gcc-14-toolchain.cmake";;
+                g++-12) toolchain_path="cmake/x86_64-linux-gcc-12-toolchain.cmake";;
+                g++)    toolchain_path="cmake/x86_64-linux-gcc-toolchain.cmake";;
+                *)      cxx_compiler_path="$(command -v "$found_compiler")"
+                        c_compiler_path="$(command -v "${found_compiler/g++/gcc}")";;
+            esac;;
+        clang-20)
+            toolchain_path="cmake/x86_64-linux-clang-20-libstdcpp-toolchain.cmake";;
+        clang-20-libcpp)
+            toolchain_path="cmake/x86_64-linux-clang-20-libcpp-toolchain.cmake";;
+        gcc-12)
+            toolchain_path="cmake/x86_64-linux-gcc-12-toolchain.cmake";;
+        gcc-14)
+            toolchain_path="cmake/x86_64-linux-gcc-14-toolchain.cmake";;
+        *)
+            echo "ERROR: Unknown compiler '$compiler'. Allowed: clang, gcc, clang-20, clang-20-libcpp, gcc-12, gcc-14."
+            show_help
+            exit 1;;
+    esac
+fi
+
+# Auto-detect compiler when default clang-20 is unavailable and no explicit override
+if [ "$compiler" = "" ] && [ "$cxx_compiler_path" = "" ] && [ "$toolchain_path_explicitly_set" = "false" ]; then
+    if ! command -v clang++-20 >/dev/null 2>&1; then
+        echo "WARNING: Default compiler 'clang++-20' not found in PATH."
+        # Search for best available Clang, then GCC
+        found_compiler=""
+        for candidate in clang++-19 clang++-18 clang++-17 clang++; do
+            if command -v "$candidate" >/dev/null 2>&1; then
+                found_compiler="$candidate"
+                break
+            fi
+        done
+        if [ -n "$found_compiler" ]; then
+            case "$found_compiler" in
+                clang++) toolchain_path="cmake/x86_64-linux-clang-libstdcpp-toolchain.cmake";;
+                *)       cxx_compiler_path="$(command -v "$found_compiler")"
+                         c_compiler_path="$(command -v "${found_compiler/++/}")";;
+            esac
+            echo "INFO: Auto-selected $found_compiler"
+        else
+            # No Clang found, try GCC
+            found_compiler=""
+            for candidate in g++-14 g++-13 g++-12 g++; do
+                if command -v "$candidate" >/dev/null 2>&1; then
+                    found_compiler="$candidate"
+                    break
+                fi
+            done
+            if [ -n "$found_compiler" ]; then
+                case "$found_compiler" in
+                    g++-14) toolchain_path="cmake/x86_64-linux-gcc-14-toolchain.cmake";;
+                    g++-12) toolchain_path="cmake/x86_64-linux-gcc-12-toolchain.cmake";;
+                    g++)    toolchain_path="cmake/x86_64-linux-gcc-toolchain.cmake";;
+                    *)      cxx_compiler_path="$(command -v "$found_compiler")"
+                            c_compiler_path="$(command -v "${found_compiler/g++/gcc}")";;
+                esac
+                echo "INFO: Auto-selected $found_compiler"
+            else
+                echo "ERROR: No C++ compiler found. Install clang or gcc, or use --compiler/--cxx-compiler-path."
+                exit 1
+            fi
+        fi
+    fi
+fi
 
 # Check if there are unrecognized positional arguments left
 if [[ $# -gt 0 ]]; then

--- a/build_metal.sh
+++ b/build_metal.sh
@@ -30,6 +30,9 @@ declare -A BINARY_TOOLCHAIN=(
     # use_compiler() falls back to direct compiler path
 )
 
+# Valid --compiler flag values, in display order
+COMPILER_FLAGS=(clang gcc clang-20 clang-20-libcpp gcc-12 gcc-14)
+
 # CLI flag → toolchain ID (for --compiler pinned versions)
 declare -A FLAG_TOOLCHAIN=(
     [clang-20]=clang-20-libstdcpp
@@ -308,7 +311,7 @@ if [ "$compiler" != "" ]; then
             if [ -n "${FLAG_TOOLCHAIN[$compiler]:-}" ]; then
                 toolchain_path="$(toolchain_file "${FLAG_TOOLCHAIN[$compiler]}")"
             else
-                echo "ERROR: Unknown compiler '$compiler'. Allowed: clang, gcc, clang-20, clang-20-libcpp, gcc-12, gcc-14."
+                echo "ERROR: Unknown compiler '$compiler'. Allowed: ${COMPILER_FLAGS[*]}."
                 show_help
                 exit 1
             fi;;

--- a/cmake/x86_64-linux-clang-17-libstdcpp-toolchain.cmake
+++ b/cmake/x86_64-linux-clang-17-libstdcpp-toolchain.cmake
@@ -1,0 +1,20 @@
+set(CMAKE_SYSTEM_PROCESSOR "x86_64")
+
+set(CMAKE_C_COMPILER clang-17 CACHE INTERNAL "C compiler")
+
+set(CMAKE_CXX_COMPILER clang++-17 CACHE INTERNAL "C++ compiler")
+
+# Use for configure time
+set(ENABLE_LIBCXX FALSE CACHE INTERNAL "Using clang's libc++")
+
+# Our build is super slow; put a band-aid on it by choosing a linker that can cope better.
+# We really need to fix out code, though.
+find_program(MOLD ld.mold)
+if(MOLD)
+    set(CMAKE_LINKER_TYPE MOLD)
+else()
+    find_program(LLD ld.lld-17)
+    if(LLD)
+        set(CMAKE_LINKER_TYPE LLD)
+    endif()
+endif()

--- a/cmake/x86_64-linux-clang-18-libstdcpp-toolchain.cmake
+++ b/cmake/x86_64-linux-clang-18-libstdcpp-toolchain.cmake
@@ -1,0 +1,20 @@
+set(CMAKE_SYSTEM_PROCESSOR "x86_64")
+
+set(CMAKE_C_COMPILER clang-18 CACHE INTERNAL "C compiler")
+
+set(CMAKE_CXX_COMPILER clang++-18 CACHE INTERNAL "C++ compiler")
+
+# Use for configure time
+set(ENABLE_LIBCXX FALSE CACHE INTERNAL "Using clang's libc++")
+
+# Our build is super slow; put a band-aid on it by choosing a linker that can cope better.
+# We really need to fix out code, though.
+find_program(MOLD ld.mold)
+if(MOLD)
+    set(CMAKE_LINKER_TYPE MOLD)
+else()
+    find_program(LLD ld.lld-18)
+    if(LLD)
+        set(CMAKE_LINKER_TYPE LLD)
+    endif()
+endif()

--- a/cmake/x86_64-linux-clang-19-libstdcpp-toolchain.cmake
+++ b/cmake/x86_64-linux-clang-19-libstdcpp-toolchain.cmake
@@ -1,0 +1,20 @@
+set(CMAKE_SYSTEM_PROCESSOR "x86_64")
+
+set(CMAKE_C_COMPILER clang-19 CACHE INTERNAL "C compiler")
+
+set(CMAKE_CXX_COMPILER clang++-19 CACHE INTERNAL "C++ compiler")
+
+# Use for configure time
+set(ENABLE_LIBCXX FALSE CACHE INTERNAL "Using clang's libc++")
+
+# Our build is super slow; put a band-aid on it by choosing a linker that can cope better.
+# We really need to fix out code, though.
+find_program(MOLD ld.mold)
+if(MOLD)
+    set(CMAKE_LINKER_TYPE MOLD)
+else()
+    find_program(LLD ld.lld-19)
+    if(LLD)
+        set(CMAKE_LINKER_TYPE LLD)
+    endif()
+endif()

--- a/cmake/x86_64-linux-clang-libstdcpp-toolchain.cmake
+++ b/cmake/x86_64-linux-clang-libstdcpp-toolchain.cmake
@@ -1,0 +1,20 @@
+set(CMAKE_SYSTEM_PROCESSOR "x86_64")
+
+set(CMAKE_C_COMPILER clang CACHE INTERNAL "C compiler")
+
+set(CMAKE_CXX_COMPILER clang++ CACHE INTERNAL "C++ compiler")
+
+# Use for configure time
+set(ENABLE_LIBCXX FALSE CACHE INTERNAL "Using clang's libc++")
+
+# Our build is super slow; put a band-aid on it by choosing a linker that can cope better.
+# We really need to fix our code, though.
+find_program(MOLD ld.mold)
+if(MOLD)
+    set(CMAKE_LINKER_TYPE MOLD)
+else()
+    find_program(LLD ld.lld)
+    if(LLD)
+        set(CMAKE_LINKER_TYPE LLD)
+    endif()
+endif()

--- a/cmake/x86_64-linux-clang-libstdcpp-toolchain.cmake
+++ b/cmake/x86_64-linux-clang-libstdcpp-toolchain.cmake
@@ -8,7 +8,7 @@ set(CMAKE_CXX_COMPILER clang++ CACHE INTERNAL "C++ compiler")
 set(ENABLE_LIBCXX FALSE CACHE INTERNAL "Using clang's libc++")
 
 # Our build is super slow; put a band-aid on it by choosing a linker that can cope better.
-# We really need to fix our code, though.
+# We really need to fix out code, though.
 find_program(MOLD ld.mold)
 if(MOLD)
     set(CMAKE_LINKER_TYPE MOLD)

--- a/cmake/x86_64-linux-gcc-13-toolchain.cmake
+++ b/cmake/x86_64-linux-gcc-13-toolchain.cmake
@@ -1,0 +1,8 @@
+set(CMAKE_SYSTEM_PROCESSOR "x86_64")
+
+set(CMAKE_C_COMPILER gcc-13 CACHE INTERNAL "C compiler")
+
+set(CMAKE_CXX_COMPILER g++-13 CACHE INTERNAL "C++ compiler")
+
+# Use for configure time
+set(ENABLE_LIBCXX FALSE CACHE INTERNAL "Using clang's libc++")

--- a/cmake/x86_64-linux-gcc-toolchain.cmake
+++ b/cmake/x86_64-linux-gcc-toolchain.cmake
@@ -1,0 +1,8 @@
+set(CMAKE_SYSTEM_PROCESSOR "x86_64")
+
+set(CMAKE_C_COMPILER gcc CACHE INTERNAL "C compiler")
+
+set(CMAKE_CXX_COMPILER g++ CACHE INTERNAL "C++ compiler")
+
+# Use for configure time
+set(ENABLE_LIBCXX FALSE CACHE INTERNAL "Using clang's libc++")

--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -5,6 +5,9 @@
 
 set -e
 
+# Valid --compiler flag values (same as build_metal.sh)
+COMPILER_FLAGS=(clang gcc clang-20 clang-20-libcpp gcc-12 gcc-14)
+
 usage()
 {
     echo "Usage: sudo ./install_dependencies.sh [options]"
@@ -15,6 +18,7 @@ usage()
     echo "[--no-distributed]          Don't install distributed compute dependencies (OpenMPI)"
     echo "[--hugepages]               Install hugepages dependency"
     echo "[--sfpi]                    Install only SFPI package (minimal installation)"
+    echo "[--compiler name]           Select compiler: ${COMPILER_FLAGS[*]}."
     echo "[--source-only]             Loads functions into shell"
     exit 1
 }
@@ -308,34 +312,56 @@ prep_ubuntu_system() {
 
 prep_redhat_system() {
     echo "[INFO] Preparing Red Hat family system..."
-    # TODO: Implement Red Hat family system preparation
+
+    # Fedora has all packages in default repos
+    if [[ "$OS_ID" == "fedora" ]]; then
+        return
+    fi
+
+    # RHEL/Rocky/Alma: enable EPEL and CRB for devel packages
+    echo "[INFO] Installing EPEL repository..."
+    dnf install -y epel-release
+
+    echo "[INFO] Enabling CRB repository for development packages..."
+    dnf config-manager --set-enabled crb 2>/dev/null || \
+        dnf config-manager --set-enabled powertools 2>/dev/null || \
+        echo "[WARNING] Could not enable CRB/PowerTools repository"
 }
 
 # We currently have an affinity to clang as it is more thoroughly tested in CI
 # However g++-12 and later should also work
 
 install_llvm() {
-    # Only install LLVM on debian-based systems
-    if ! is_debian_based; then
-        echo "[WARNING] Skipping LLVM installation for non-debian distribution ($OS_ID)"
+    # Skip LLVM installation when user selected a GCC compiler
+    if [[ "$compiler" == gcc* ]]; then
+        echo "[INFO] Skipping LLVM installation (--compiler $compiler)"
         return
     fi
 
-    # Install LLVM 20:
-    # - clang-20: default toolchain for tt-metal (build_metal.sh) and tt-train
-    TEMP_DIR=$(mktemp -d)
-    wget -P $TEMP_DIR https://apt.llvm.org/llvm.sh
-    chmod u+x $TEMP_DIR/llvm.sh
+    if is_debian_based; then
+        # Install LLVM 20:
+        # - clang-20: default toolchain for tt-metal (build_metal.sh) and tt-train
+        TEMP_DIR=$(mktemp -d)
+        wget -P $TEMP_DIR https://apt.llvm.org/llvm.sh
+        chmod u+x $TEMP_DIR/llvm.sh
 
-    echo "[INFO] Checking if LLVM 20 is already installed..."
-    if command -v clang-20 &> /dev/null; then
-        echo "[INFO] LLVM 20 is already installed. Skipping installation."
-    else
-        echo "[INFO] Installing LLVM 20..."
-        $TEMP_DIR/llvm.sh 20
+        echo "[INFO] Checking if LLVM 20 is already installed..."
+        if command -v clang-20 &> /dev/null; then
+            echo "[INFO] LLVM 20 is already installed. Skipping installation."
+        else
+            echo "[INFO] Installing LLVM 20..."
+            $TEMP_DIR/llvm.sh 20
+        fi
+
+        rm -rf "$TEMP_DIR"
+    elif is_redhat_based; then
+        # LLVM/Clang is installed via the package list (llvm, clang, clang-tools-extra).
+        # Unlike Debian where we install a specific version (clang-20) from llvm.org,
+        # RedHat uses the distro-provided version.
+        local clang_version
+        clang_version=$(clang --version 2>/dev/null | head -1 || echo "not found")
+        echo "[INFO] Using distro-provided LLVM/Clang for $OS_ID: $clang_version"
     fi
-
-    rm -rf "$TEMP_DIR"
 }
 
 install_sfpi() {
@@ -396,8 +422,7 @@ install_mpi_ulfm() {
 
     # Check if OS is Ubuntu/Debian-based
     if ! is_debian_based; then
-        echo "[WARNING] MPI ULFM installation is currently only supported on Ubuntu/Debian-based distributions"
-        echo "[WARNING] This function needs to be expanded to support $OS_ID"
+        echo "[INFO] MPI ULFM is only available as a .deb package; skipping on $OS_ID"
         return
     fi
 
@@ -432,8 +457,7 @@ install_mpi_ulfm() {
 configure_hugepages() {
     # Check if OS is Ubuntu/Debian-based
     if ! is_debian_based; then
-        echo "[WARNING] Hugepages configuration is currently only supported on Ubuntu/Debian-based distributions"
-        echo "[WARNING] This function needs to be expanded to support $OS_ID"
+        echo "[INFO] Hugepages package is only available as a .deb package; skipping on $OS_ID"
         return
     fi
 
@@ -503,6 +527,7 @@ main() {
     distributed=1
     hugepages=0
     sfpi_only=0
+    compiler=""
 
     while [ $# -gt 0 ]; do
         case "$1" in
@@ -529,12 +554,33 @@ main() {
                 sfpi_only=1
                 shift
                 ;;
+            --compiler)
+                compiler="$2"
+                shift 2
+                continue
+                ;;
             *)
                 echo "Unknown option: $1"
                 usage
                 ;;
         esac
     done
+
+    # Validate --compiler flag
+    if [ -n "$compiler" ]; then
+        local valid=0
+        for flag in "${COMPILER_FLAGS[@]}"; do
+            if [ "$flag" = "$compiler" ]; then
+                valid=1
+                break
+            fi
+        done
+        if [ "$valid" -eq 0 ]; then
+            echo "[ERROR] Unknown compiler '$compiler'. Allowed: ${COMPILER_FLAGS[*]}."
+            exit 1
+        fi
+        echo "[INFO] Compiler selection: $compiler"
+    fi
 
     init_packages
 

--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -579,8 +579,7 @@ install_gcc_versioned() {
             fi
         fi
     elif is_redhat_based; then
-        # RedHat doesn't have versioned gcc packages (gcc-12, gcc-14)
-        echo "[WARNING] Versioned GCC packages are not available on $OS_ID"
+        echo "[WARNING] Versioned GCC packages (g++-${ver}) not found on $OS_ID"
     fi
 
     # Step 4: Fail (no official GCC binary tarballs exist)
@@ -674,58 +673,12 @@ verify_compiler() {
 # Print OS-specific list of available --compiler values. Called on failure.
 available_compilers_message() {
     echo ""
-    echo "Available compiler options for $OS_ID $OS_VERSION:"
+    echo "Valid --compiler values: ${COMPILER_FLAGS[*]}"
     echo ""
-    case "$OS_ID" in
-        ubuntu)
-            case "$OS_VERSION" in
-                22.04)
-                    echo "  --compiler clang-20        clang 20 (via apt.llvm.org)"
-                    echo "  --compiler clang-20-libcpp clang 20 + libc++ (via apt.llvm.org)"
-                    echo "  --compiler clang           system clang"
-                    echo "  --compiler gcc-12          g++ 12 (system)"
-                    echo "  --compiler gcc-14          g++ 14 (via Ubuntu Toolchain PPA)"
-                    echo "  --compiler gcc             system g++"
-                    ;;
-                24.04)
-                    echo "  --compiler clang-20        clang 20 (via apt.llvm.org)"
-                    echo "  --compiler clang-20-libcpp clang 20 + libc++ (via apt.llvm.org)"
-                    echo "  --compiler clang           system clang"
-                    echo "  --compiler gcc-14          g++ 14 (system)"
-                    echo "  --compiler gcc-12          g++ 12 (via Ubuntu Toolchain PPA)"
-                    echo "  --compiler gcc             system g++"
-                    ;;
-                *)
-                    echo "  (Ubuntu $OS_VERSION: check available packages)"
-                    ;;
-            esac
-            ;;
-        debian)
-            echo "  --compiler clang-20        clang 20 (via apt.llvm.org)"
-            echo "  --compiler clang-20-libcpp clang 20 + libc++ (via apt.llvm.org)"
-            echo "  --compiler clang           system clang"
-            echo "  --compiler gcc-12          g++ 12 (system on Debian 12)"
-            echo "  --compiler gcc             system g++"
-            echo "  NOTE: gcc-14 is NOT available on Debian 12"
-            ;;
-        fedora)
-            echo "  --compiler clang-20        clang 20 (via LLVM GitHub tarball, ~1.9 GB download)"
-            echo "  --compiler clang-20-libcpp clang 20 + libc++ (via LLVM GitHub tarball)"
-            echo "  --compiler clang           system clang"
-            echo "  --compiler gcc             system gcc"
-            echo "  NOTE: gcc-12, gcc-14 require version match with system gcc"
-            ;;
-        rocky|almalinux|rhel|centos)
-            echo "  --compiler clang-20        clang 20 (via LLVM GitHub tarball, ~1.9 GB download)"
-            echo "  --compiler clang-20-libcpp clang 20 + libc++ (via LLVM GitHub tarball)"
-            echo "  --compiler clang           system clang (EPEL)"
-            echo "  --compiler gcc             system gcc"
-            echo "  NOTE: gcc-12, gcc-14 are NOT available on $OS_ID"
-            ;;
-        *)
-            echo "  (check system packages for available compilers)"
-            ;;
-    esac
+    echo "The installer will try multiple methods to obtain the requested compiler"
+    echo "(system packages, external repos, binary tarballs). If a specific version"
+    echo "is not available on your platform, try '--compiler clang' or '--compiler gcc'"
+    echo "to use whatever version your system provides."
     echo ""
 }
 

--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -351,8 +351,8 @@ prep_redhat_system() {
     fi
 
     # RHEL/Rocky/Alma: enable EPEL and CRB for devel packages
-    echo "[INFO] Installing EPEL repository..."
-    dnf install -y epel-release
+    echo "[INFO] Installing EPEL repository and dnf plugins..."
+    dnf install -y epel-release dnf-plugins-core
 
     echo "[INFO] Enabling CRB repository for development packages..."
     dnf config-manager --set-enabled crb 2>/dev/null || \
@@ -651,6 +651,13 @@ verify_compiler() {
             expected_cxx="g++-14"; expected_cc="gcc-14" ;;
         gcc)
             if command -v g++ >/dev/null 2>&1; then
+                local gcc_major
+                gcc_major=$(get_compiler_major_version g++)
+                if [ -n "$gcc_major" ] && [ "$gcc_major" -lt 12 ] 2>/dev/null; then
+                    echo "[ERROR] GCC $gcc_major is too old. tt-metal requires GCC >= 12."
+                    echo "[ERROR] On this system, try '--compiler clang' instead."
+                    exit 1
+                fi
                 echo "[OK] Compiler verified: $(g++ --version 2>/dev/null | head -1)"
                 return 0
             fi
@@ -844,16 +851,23 @@ install() {
     install_packages
 
     # On RedHat, openmpi installs to /usr/lib64/openmpi/ and is not in PATH by default.
-    # Persist the paths so subsequent build steps (e.g., build_metal.sh in Docker) can find MPI.
+    # Create symlinks so MPI tools are available in all contexts (Docker RUN, non-login shells).
+    # Also set up /etc/profile.d for LD_LIBRARY_PATH and PKG_CONFIG_PATH in login shells.
     if is_redhat_based && [ "$distributed" -eq 1 ]; then
         if [ -d /usr/lib64/openmpi/bin ]; then
+            for bin in /usr/lib64/openmpi/bin/*; do
+                local name
+                name="$(basename "$bin")"
+                [ -e "/usr/local/bin/$name" ] || ln -s "$bin" "/usr/local/bin/$name"
+            done
+            echo "[INFO] Created symlinks for openmpi binaries in /usr/local/bin/"
+
             cat > /etc/profile.d/openmpi.sh << 'MPIEOF'
-export PATH="/usr/lib64/openmpi/bin:$PATH"
 export LD_LIBRARY_PATH="/usr/lib64/openmpi/lib:${LD_LIBRARY_PATH:-}"
 export PKG_CONFIG_PATH="/usr/lib64/openmpi/lib/pkgconfig:${PKG_CONFIG_PATH:-}"
 MPIEOF
             source /etc/profile.d/openmpi.sh
-            echo "[INFO] Configured openmpi paths in /etc/profile.d/openmpi.sh"
+            echo "[INFO] Configured openmpi library paths in /etc/profile.d/openmpi.sh"
         fi
     fi
 

--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -312,19 +312,21 @@ prep_ubuntu_system() {
         echo "deb http://apt.llvm.org/$OS_CODENAME/ llvm-toolchain-$OS_CODENAME-20 main" | tee /etc/apt/sources.list.d/llvm-20.list
     fi
 
-    # Add Kitware repository for latest CMake
-    # If the kitware-archive-keyring package has not been installed previously, manually obtain a copy of our signing key
-    test -f /usr/share/doc/kitware-archive-keyring/copyright || wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - | tee /usr/share/keyrings/kitware-archive-keyring.gpg >/dev/null
+    # Add Kitware repository for latest CMake (Ubuntu only — Kitware doesn't provide Debian repos)
+    if [[ "$OS_ID" == "ubuntu" ]]; then
+        # If the kitware-archive-keyring package has not been installed previously, manually obtain a copy of our signing key
+        test -f /usr/share/doc/kitware-archive-keyring/copyright || wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - | tee /usr/share/keyrings/kitware-archive-keyring.gpg >/dev/null
 
-    # Add the repository to sources list and update
-    echo "deb [signed-by=/usr/share/keyrings/kitware-archive-keyring.gpg] https://apt.kitware.com/ubuntu/ $OS_CODENAME main" | tee /etc/apt/sources.list.d/kitware.list >/dev/null
-    apt-get update
+        # Add the repository to sources list and update
+        echo "deb [signed-by=/usr/share/keyrings/kitware-archive-keyring.gpg] https://apt.kitware.com/ubuntu/ $OS_CODENAME main" | tee /etc/apt/sources.list.d/kitware.list >/dev/null
+        apt-get update
 
-    # If the kitware-archive-keyring package was not installed previously, remove the manually obtained key to make room for the package
-    test -f /usr/share/doc/kitware-archive-keyring/copyright || rm /usr/share/keyrings/kitware-archive-keyring.gpg
+        # If the kitware-archive-keyring package was not installed previously, remove the manually obtained key to make room for the package
+        test -f /usr/share/doc/kitware-archive-keyring/copyright || rm /usr/share/keyrings/kitware-archive-keyring.gpg
 
-    # Install the kitware-archive-keyring package to ensure that your keyring stays up to date as keys are rotated
-    apt-get install -y --no-install-recommends kitware-archive-keyring
+        # Install the kitware-archive-keyring package to ensure that your keyring stays up to date as keys are rotated
+        apt-get install -y --no-install-recommends kitware-archive-keyring
+    fi
 
     # Add GCC toolchain repository for specific g++ versions if needed
     if [[ "$OS_ID" == "ubuntu" ]]; then

--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -556,7 +556,7 @@ main() {
                 ;;
             --compiler)
                 compiler="$2"
-                shift
+                shift 2
                 ;;
             *)
                 echo "Unknown option: $1"

--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -590,7 +590,8 @@ install_gcc_versioned() {
     if is_debian_based; then
         # Step 2: Try distro repos
         echo "[INFO] Attempting to install g++-${ver} from apt..."
-        if DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends "g++-${ver}" 2>/dev/null; then
+        if DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends "g++-${ver}" 2>/dev/null \
+           && command -v "g++-${ver}" >/dev/null 2>&1; then
             return 0
         fi
         echo "[WARNING] g++-${ver} not available in configured repos"
@@ -602,7 +603,8 @@ install_gcc_versioned() {
                 add-apt-repository -y ppa:ubuntu-toolchain-r/test
                 apt-get update
             fi
-            if DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends "g++-${ver}" 2>/dev/null; then
+            if DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends "g++-${ver}" 2>/dev/null \
+               && command -v "g++-${ver}" >/dev/null 2>&1; then
                 return 0
             fi
         fi

--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -350,9 +350,11 @@ prep_redhat_system() {
         return
     fi
 
-    # RHEL/Rocky/Alma: enable EPEL and CRB for devel packages
+    # RHEL/Rocky/Alma/Oracle: enable EPEL and CRB for devel packages
     echo "[INFO] Installing EPEL repository and dnf plugins..."
-    dnf install -y epel-release dnf-plugins-core
+    dnf install -y epel-release dnf-plugins-core 2>/dev/null || \
+        dnf install -y oracle-epel-release-el10 dnf-plugins-core 2>/dev/null || \
+        echo "[WARNING] Could not install EPEL repository"
 
     echo "[INFO] Enabling CRB repository for development packages..."
     dnf config-manager --set-enabled crb 2>/dev/null || \

--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -31,7 +31,7 @@ detect_os() {
         . /etc/os-release
         OS_ID="$ID"
         OS_VERSION="$VERSION_ID"
-        OS_CODENAME="${UBUNTU_CODENAME:VERSION_CODENAME}"
+        OS_CODENAME="${UBUNTU_CODENAME:-$VERSION_CODENAME}"
         OS_ID_LIKE="$ID_LIKE"
     else
         echo "Error: /etc/os-release not found. Unsupported system."
@@ -839,6 +839,20 @@ install() {
 
     # Install core packages
     install_packages
+
+    # On RedHat, openmpi installs to /usr/lib64/openmpi/ and is not in PATH by default.
+    # Persist the paths so subsequent build steps (e.g., build_metal.sh in Docker) can find MPI.
+    if is_redhat_based && [ "$distributed" -eq 1 ]; then
+        if [ -d /usr/lib64/openmpi/bin ]; then
+            cat > /etc/profile.d/openmpi.sh << 'MPIEOF'
+export PATH="/usr/lib64/openmpi/bin:$PATH"
+export LD_LIBRARY_PATH="/usr/lib64/openmpi/lib:${LD_LIBRARY_PATH:-}"
+export PKG_CONFIG_PATH="/usr/lib64/openmpi/lib/pkgconfig:${PKG_CONFIG_PATH:-}"
+MPIEOF
+            source /etc/profile.d/openmpi.sh
+            echo "[INFO] Configured openmpi paths in /etc/profile.d/openmpi.sh"
+        fi
+    fi
 
     # Install specialized components
     install_sfpi

--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -8,8 +8,11 @@ set -e
 # Valid --compiler flag values (same as build_metal.sh)
 COMPILER_FLAGS=(clang gcc clang-20 clang-19 clang-18 clang-17 clang-20-libcpp gcc-14 gcc-13 gcc-12)
 
-# Pinned LLVM tarball version for non-Debian platforms (update on new patch releases)
+# Pinned LLVM tarball versions for non-Debian platforms (update on new patch releases)
 LLVM_TARBALL_VERSION_20="20.1.8"
+LLVM_TARBALL_VERSION_19="19.1.7"
+LLVM_TARBALL_VERSION_18="18.1.8"
+LLVM_TARBALL_VERSION_17="17.0.6"
 
 usage()
 {
@@ -378,8 +381,27 @@ install_llvm_from_tarball() {
         return 1
     fi
 
-    local tarball_name="LLVM-${full_version}-Linux-X64.tar.xz"
-    local tarball_url="https://github.com/llvm/llvm-project/releases/download/llvmorg-${full_version}/${tarball_name}"
+    # LLVM 19+ uses "LLVM-X.Y.Z-Linux-X64.tar.xz" naming.
+    # LLVM 17-18 uses "clang+llvm-X.Y.Z-x86_64-linux-gnu-ubuntu-*.tar.xz".
+    local tarball_name tarball_url
+    local base_url="https://github.com/llvm/llvm-project/releases/download/llvmorg-${full_version}"
+    if [ "$llvm_major" -ge 19 ]; then
+        tarball_name="LLVM-${full_version}-Linux-X64.tar.xz"
+    else
+        # Older releases have OS suffix; try common variants
+        for suffix in "x86_64-linux-gnu-ubuntu-22.04" "x86_64-linux-gnu-ubuntu-18.04" "x86_64-linux-gnu"; do
+            tarball_name="clang+llvm-${full_version}-${suffix}.tar.xz"
+            if curl -sfI "${base_url}/${tarball_name}" >/dev/null 2>&1; then
+                break
+            fi
+            tarball_name=""
+        done
+        if [ -z "$tarball_name" ]; then
+            echo "[ERROR] No LLVM ${full_version} tarball found for x86_64 Linux"
+            return 1
+        fi
+    fi
+    tarball_url="${base_url}/${tarball_name}"
 
     echo "[INFO] Downloading LLVM ${full_version} from GitHub releases..."
     echo "[INFO] URL: ${tarball_url}"

--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -6,7 +6,7 @@
 set -e
 
 # Valid --compiler flag values (same as build_metal.sh)
-COMPILER_FLAGS=(clang gcc clang-20 clang-20-libcpp gcc-12 gcc-14)
+COMPILER_FLAGS=(clang gcc clang-20 clang-19 clang-18 clang-17 clang-20-libcpp gcc-14 gcc-13 gcc-12)
 
 # Pinned LLVM tarball version for non-Debian platforms (update on new patch releases)
 LLVM_TARBALL_VERSION_20="20.1.8"
@@ -640,6 +640,12 @@ verify_compiler() {
     case "$comp" in
         clang-20|clang-20-libcpp)
             expected_cxx="clang++-20"; expected_cc="clang-20" ;;
+        clang-19)
+            expected_cxx="clang++-19"; expected_cc="clang-19" ;;
+        clang-18)
+            expected_cxx="clang++-18"; expected_cc="clang-18" ;;
+        clang-17)
+            expected_cxx="clang++-17"; expected_cc="clang-17" ;;
         clang)
             if command -v clang++ >/dev/null 2>&1; then
                 echo "[OK] Compiler verified: $(clang++ --version 2>/dev/null | head -1)"
@@ -648,10 +654,12 @@ verify_compiler() {
             echo "[ERROR] Verification failed: clang++ not found in PATH"
             exit 1
             ;;
-        gcc-12)
-            expected_cxx="g++-12"; expected_cc="gcc-12" ;;
         gcc-14)
             expected_cxx="g++-14"; expected_cc="gcc-14" ;;
+        gcc-13)
+            expected_cxx="g++-13"; expected_cc="gcc-13" ;;
+        gcc-12)
+            expected_cxx="g++-12"; expected_cc="gcc-12" ;;
         gcc)
             if command -v g++ >/dev/null 2>&1; then
                 local gcc_major
@@ -710,6 +718,15 @@ install_compiler() {
         clang-20)
             install_clang_versioned 20
             ;;
+        clang-19)
+            install_clang_versioned 19
+            ;;
+        clang-18)
+            install_clang_versioned 18
+            ;;
+        clang-17)
+            install_clang_versioned 17
+            ;;
         clang-20-libcpp)
             install_clang_versioned 20
             install_libcxx 20
@@ -717,11 +734,14 @@ install_compiler() {
         clang)
             install_clang_any
             ;;
-        gcc-12)
-            install_gcc_versioned 12
-            ;;
         gcc-14)
             install_gcc_versioned 14
+            ;;
+        gcc-13)
+            install_gcc_versioned 13
+            ;;
+        gcc-12)
+            install_gcc_versioned 12
             ;;
         gcc)
             install_gcc_any

--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -556,8 +556,7 @@ main() {
                 ;;
             --compiler)
                 compiler="$2"
-                shift 2
-                continue
+                shift
                 ;;
             *)
                 echo "Unknown option: $1"

--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -275,6 +275,7 @@ init_packages() {
                 "curl"
                 "vim-common" # Includes xxd
                 "patch" # Required by CPM PATCHES keyword
+                "zlib-devel" # Required by tt-train examples (-lz)
             )
             if [ "$distributed" -eq 1 ]; then
                 PACKAGES+=("openmpi" "openmpi-devel")

--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -8,6 +8,9 @@ set -e
 # Valid --compiler flag values (same as build_metal.sh)
 COMPILER_FLAGS=(clang gcc clang-20 clang-20-libcpp gcc-12 gcc-14)
 
+# Pinned LLVM tarball version for non-Debian platforms (update on new patch releases)
+LLVM_TARBALL_VERSION_20="20.1.8"
+
 usage()
 {
     echo "Usage: sudo ./install_dependencies.sh [options]"
@@ -99,6 +102,28 @@ is_supported_os() {
             fi
             ;;
     esac
+}
+
+# Extract the major version number from a compiler binary.
+# Usage: get_compiler_major_version g++   -> "14" (on Fedora 40)
+#        get_compiler_major_version clang -> "18"
+get_compiler_major_version() {
+    local binary="$1"
+    command -v "$binary" >/dev/null 2>&1 || return 1
+    "$binary" --version 2>/dev/null | grep -oP '\d+\.\d+' | head -1 | cut -d. -f1
+}
+
+# Create versioned symlinks in /usr/local/bin/ for unversioned system compilers.
+# Used when the system compiler IS the requested version but has no versioned binary name.
+# E.g., Fedora's g++ IS gcc-14 but the binary is just "g++".
+create_versioned_symlinks() {
+    local cc="$1" cxx="$2" ver="$3"
+    local cc_path cxx_path
+    cc_path=$(command -v "$cc") || return 1
+    cxx_path=$(command -v "$cxx") || return 1
+    ln -sf "$cc_path" "/usr/local/bin/${cc}-${ver}"
+    ln -sf "$cxx_path" "/usr/local/bin/${cxx}-${ver}"
+    echo "[INFO] Created symlinks: ${cc}-${ver} -> ${cc_path}, ${cxx}-${ver} -> ${cxx_path}"
 }
 
 update_package_cache() {
@@ -211,12 +236,14 @@ init_packages() {
                 "libstdc++6"
                 "libtbb-dev"
                 "libcapstone-dev"
-                "libc++-20-dev"
-                "libc++abi-20-dev"
                 "wget"
                 "curl"
                 "xxd"
             )
+            # libc++ packages only needed for default (backward compat) or clang-20-libcpp
+            if [ -z "$compiler" ] || [ "$compiler" = "clang-20-libcpp" ]; then
+                PACKAGES+=("libc++-20-dev" "libc++abi-20-dev")
+            fi
             if [ "$distributed" -eq 1 ]; then
                 PACKAGES+=("openmpi-bin" "libopenmpi-dev")
             fi
@@ -247,6 +274,7 @@ init_packages() {
                 "wget"
                 "curl"
                 "vim-common" # Includes xxd
+                "patch" # Required by CPM PATCHES keyword
             )
             if [ "$distributed" -eq 1 ]; then
                 PACKAGES+=("openmpi" "openmpi-devel")
@@ -277,11 +305,12 @@ prep_ubuntu_system() {
     apt-get update
     apt-get install -y --no-install-recommends ca-certificates gpg lsb-release wget software-properties-common gnupg jq
 
-    # Add LLVM repository for Clang 17
-    wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
-    echo "deb http://apt.llvm.org/$OS_CODENAME/ llvm-toolchain-$OS_CODENAME-17 main" | tee /etc/apt/sources.list.d/llvm-17.list
-    # Also v20
-    echo "deb http://apt.llvm.org/$OS_CODENAME/ llvm-toolchain-$OS_CODENAME-20 main" | tee /etc/apt/sources.list.d/llvm-20.list
+    # Add LLVM repository for Clang (skip when only GCC is needed)
+    if [[ "$compiler" != gcc* ]]; then
+        wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
+        echo "deb http://apt.llvm.org/$OS_CODENAME/ llvm-toolchain-$OS_CODENAME-17 main" | tee /etc/apt/sources.list.d/llvm-17.list
+        echo "deb http://apt.llvm.org/$OS_CODENAME/ llvm-toolchain-$OS_CODENAME-20 main" | tee /etc/apt/sources.list.d/llvm-20.list
+    fi
 
     # Add Kitware repository for latest CMake
     # If the kitware-archive-keyring package has not been installed previously, manually obtain a copy of our signing key
@@ -328,6 +357,67 @@ prep_redhat_system() {
         echo "[WARNING] Could not enable CRB/PowerTools repository"
 }
 
+# Download and install official LLVM binary tarball from GitHub releases.
+# Installs to /opt/llvm-XX/ and creates versioned symlinks in /usr/local/bin/
+# so that build_metal.sh toolchain files find clang-XX, clang++-XX, ld.lld-XX.
+install_llvm_from_tarball() {
+    local llvm_major="$1"
+    local install_dir="/opt/llvm-${llvm_major}"
+
+    # Look up the pinned full version for this major version
+    local version_var="LLVM_TARBALL_VERSION_${llvm_major}"
+    local full_version="${!version_var:-}"
+    if [ -z "$full_version" ]; then
+        echo "[ERROR] No pinned LLVM tarball version for major version ${llvm_major}"
+        return 1
+    fi
+
+    local tarball_name="LLVM-${full_version}-Linux-X64.tar.xz"
+    local tarball_url="https://github.com/llvm/llvm-project/releases/download/llvmorg-${full_version}/${tarball_name}"
+
+    echo "[INFO] Downloading LLVM ${full_version} from GitHub releases..."
+    echo "[INFO] URL: ${tarball_url}"
+    echo "[INFO] This is ~1.9 GB, may take several minutes..."
+
+    local temp_dir
+    temp_dir=$(mktemp -d)
+
+    if ! wget -q --show-progress -O "${temp_dir}/${tarball_name}" "$tarball_url"; then
+        echo "[ERROR] Failed to download LLVM tarball from ${tarball_url}"
+        rm -rf "$temp_dir"
+        return 1
+    fi
+
+    echo "[INFO] Extracting to ${install_dir}..."
+    mkdir -p "$install_dir"
+    tar -xf "${temp_dir}/${tarball_name}" -C "$install_dir" --strip-components=1
+    rm -rf "$temp_dir"
+
+    # Create versioned symlinks in /usr/local/bin/.
+    # The tarball contains unversioned binaries (clang, clang++, lld, etc.).
+    # build_metal.sh toolchain files expect versioned names (clang-20, clang++-20, ld.lld-20).
+    for bin in clang clang++ lld; do
+        if [ -f "${install_dir}/bin/${bin}" ]; then
+            ln -sf "${install_dir}/bin/${bin}" "/usr/local/bin/${bin}-${llvm_major}"
+            echo "[INFO] Symlink: /usr/local/bin/${bin}-${llvm_major} -> ${install_dir}/bin/${bin}"
+        fi
+    done
+
+    # ld.lld-20 is referenced by the clang-20 toolchain cmake file
+    if [ -f "${install_dir}/bin/ld.lld" ]; then
+        ln -sf "${install_dir}/bin/ld.lld" "/usr/local/bin/ld.lld-${llvm_major}"
+    fi
+
+    # Additional LLVM tools (not strictly required for build_metal.sh but useful)
+    for bin in llvm-ar llvm-ranlib llvm-nm llvm-objdump llvm-strip llvm-objcopy; do
+        if [ -f "${install_dir}/bin/${bin}" ]; then
+            ln -sf "${install_dir}/bin/${bin}" "/usr/local/bin/${bin}-${llvm_major}"
+        fi
+    done
+
+    echo "[OK] LLVM ${full_version} installed to ${install_dir} with versioned symlinks in /usr/local/bin/"
+}
+
 # We currently have an affinity to clang as it is more thoroughly tested in CI
 # However g++-12 and later should also work
 
@@ -362,6 +452,317 @@ install_llvm() {
         clang_version=$(clang --version 2>/dev/null | head -1 || echo "not found")
         echo "[INFO] Using distro-provided LLVM/Clang for $OS_ID: $clang_version"
     fi
+}
+
+# --- Compiler installation ladder functions ---
+# Each function tries sources in priority order and fails loudly if none work.
+
+# Install a specific version of clang (e.g., clang-20).
+# Ladder: already installed → version match → apt.llvm.org → llvm.sh → LLVM tarball → fail
+install_clang_versioned() {
+    local ver="$1"
+
+    # Step 0: Already installed?
+    if command -v "clang++-${ver}" >/dev/null 2>&1; then
+        echo "[INFO] clang++-${ver} already available in PATH"
+        return 0
+    fi
+
+    # Step 1: System clang matches requested version?
+    if command -v clang++ >/dev/null 2>&1; then
+        local sys_ver
+        sys_ver=$(get_compiler_major_version clang++)
+        if [ "$sys_ver" = "$ver" ]; then
+            echo "[INFO] System clang++ is version ${ver}, creating versioned symlinks"
+            create_versioned_symlinks clang clang++ "$ver"
+            return 0
+        fi
+    fi
+
+    if is_debian_based; then
+        # Step 2: Try apt package (from apt.llvm.org, set up by prep_ubuntu_system)
+        echo "[INFO] Installing clang-${ver} from apt repositories..."
+        if DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends "clang-${ver}" 2>/dev/null; then
+            return 0
+        fi
+        echo "[WARNING] apt package clang-${ver} not available, trying llvm.sh..."
+
+        # Step 3: Try llvm.sh script
+        local temp_dir
+        temp_dir=$(mktemp -d)
+        if wget -q -P "$temp_dir" https://apt.llvm.org/llvm.sh 2>/dev/null; then
+            chmod u+x "$temp_dir/llvm.sh"
+            if "$temp_dir/llvm.sh" "$ver"; then
+                rm -rf "$temp_dir"
+                return 0
+            fi
+        fi
+        rm -rf "$temp_dir"
+        echo "[WARNING] llvm.sh failed, trying LLVM GitHub tarball..."
+    fi
+
+    # Step 4 (Debian fallback) / Step 2 (RedHat): LLVM GitHub tarball
+    if install_llvm_from_tarball "$ver"; then
+        return 0
+    fi
+
+    # Step 5: Fail
+    echo "[ERROR] Failed to install clang-${ver} on $OS_ID $OS_VERSION"
+    available_compilers_message
+    return 1
+}
+
+# Install any available version of clang.
+# Ladder: check existing variants → apt/dnf package → fail
+install_clang_any() {
+    for candidate in clang++-20 clang++-19 clang++-18 clang++-17 clang++; do
+        if command -v "$candidate" >/dev/null 2>&1; then
+            echo "[INFO] Found existing $candidate"
+            return 0
+        fi
+    done
+
+    if is_debian_based; then
+        echo "[INFO] Installing system clang from apt..."
+        if DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends clang 2>/dev/null; then
+            return 0
+        fi
+    elif is_redhat_based; then
+        # clang should have been installed by install_packages (in PACKAGES list)
+        echo "[WARNING] clang not found after package installation"
+    fi
+
+    echo "[ERROR] Failed to install any clang version on $OS_ID $OS_VERSION"
+    available_compilers_message
+    return 1
+}
+
+# Install a specific version of GCC (e.g., gcc-14).
+# Ladder: already installed → version match → apt → Ubuntu Toolchain PPA → fail
+install_gcc_versioned() {
+    local ver="$1"
+
+    # Step 0: Already installed?
+    if command -v "g++-${ver}" >/dev/null 2>&1; then
+        echo "[INFO] g++-${ver} already available in PATH"
+        return 0
+    fi
+
+    # Step 1: System g++ matches requested version?
+    if command -v g++ >/dev/null 2>&1; then
+        local sys_ver
+        sys_ver=$(get_compiler_major_version g++)
+        if [ "$sys_ver" = "$ver" ]; then
+            echo "[INFO] System g++ is version ${ver}, creating versioned symlinks"
+            create_versioned_symlinks gcc g++ "$ver"
+            return 0
+        fi
+    fi
+
+    if is_debian_based; then
+        # Step 2: Try distro repos
+        echo "[INFO] Attempting to install g++-${ver} from apt..."
+        if DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends "g++-${ver}" 2>/dev/null; then
+            return 0
+        fi
+        echo "[WARNING] g++-${ver} not available in configured repos"
+
+        # Step 3: Try Ubuntu Toolchain PPA (Ubuntu only)
+        if [[ "$OS_ID" == "ubuntu" ]]; then
+            echo "[INFO] Trying Ubuntu Toolchain PPA for g++-${ver}..."
+            if ! grep -rq ubuntu-toolchain-r /etc/apt/sources.list.d/ 2>/dev/null; then
+                add-apt-repository -y ppa:ubuntu-toolchain-r/test
+                apt-get update
+            fi
+            if DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends "g++-${ver}" 2>/dev/null; then
+                return 0
+            fi
+        fi
+    elif is_redhat_based; then
+        # RedHat doesn't have versioned gcc packages (gcc-12, gcc-14)
+        echo "[WARNING] Versioned GCC packages are not available on $OS_ID"
+    fi
+
+    # Step 4: Fail (no official GCC binary tarballs exist)
+    echo "[ERROR] Failed to install gcc-${ver} on $OS_ID $OS_VERSION"
+    available_compilers_message
+    return 1
+}
+
+# Install any available version of GCC.
+# Ladder: check existing → already installed via PACKAGES → fail
+install_gcc_any() {
+    for candidate in g++-14 g++-13 g++-12 g++; do
+        if command -v "$candidate" >/dev/null 2>&1; then
+            echo "[INFO] Found existing $candidate"
+            return 0
+        fi
+    done
+
+    echo "[ERROR] No g++ found after package installation on $OS_ID $OS_VERSION"
+    available_compilers_message
+    return 1
+}
+
+# Install libc++ development packages for clang-20-libcpp.
+install_libcxx() {
+    local ver="$1"
+
+    if is_debian_based; then
+        echo "[INFO] Installing libc++ ${ver} development packages..."
+        if DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+            "libc++-${ver}-dev" "libc++abi-${ver}-dev" 2>/dev/null; then
+            return 0
+        fi
+        echo "[ERROR] Failed to install libc++-${ver}-dev"
+        return 1
+    elif is_redhat_based; then
+        # Check if libc++ is available from LLVM tarball installation
+        if [ -d "/opt/llvm-${ver}/include/c++/v1" ]; then
+            echo "[INFO] libc++ headers available from LLVM tarball at /opt/llvm-${ver}/"
+            return 0
+        fi
+        echo "[ERROR] libc++ ${ver} is not available on $OS_ID"
+        return 1
+    fi
+}
+
+# Verify that the requested compiler binary exists in PATH after installation.
+verify_compiler() {
+    local comp="$1"
+    local expected_cxx="" expected_cc=""
+
+    case "$comp" in
+        clang-20|clang-20-libcpp)
+            expected_cxx="clang++-20"; expected_cc="clang-20" ;;
+        clang)
+            if command -v clang++ >/dev/null 2>&1; then
+                echo "[OK] Compiler verified: $(clang++ --version 2>/dev/null | head -1)"
+                return 0
+            fi
+            echo "[ERROR] Verification failed: clang++ not found in PATH"
+            exit 1
+            ;;
+        gcc-12)
+            expected_cxx="g++-12"; expected_cc="gcc-12" ;;
+        gcc-14)
+            expected_cxx="g++-14"; expected_cc="gcc-14" ;;
+        gcc)
+            if command -v g++ >/dev/null 2>&1; then
+                echo "[OK] Compiler verified: $(g++ --version 2>/dev/null | head -1)"
+                return 0
+            fi
+            echo "[ERROR] Verification failed: g++ not found in PATH"
+            exit 1
+            ;;
+    esac
+
+    if [ -n "$expected_cxx" ]; then
+        if ! command -v "$expected_cxx" >/dev/null 2>&1; then
+            echo "[ERROR] Verification failed: $expected_cxx not found in PATH"
+            echo "[ERROR] PATH=$PATH"
+            exit 1
+        fi
+        if ! command -v "$expected_cc" >/dev/null 2>&1; then
+            echo "[ERROR] Verification failed: $expected_cc not found in PATH"
+            exit 1
+        fi
+        echo "[OK] Compiler verified: $($expected_cxx --version 2>/dev/null | head -1)"
+    fi
+}
+
+# Print OS-specific list of available --compiler values. Called on failure.
+available_compilers_message() {
+    echo ""
+    echo "Available compiler options for $OS_ID $OS_VERSION:"
+    echo ""
+    case "$OS_ID" in
+        ubuntu)
+            case "$OS_VERSION" in
+                22.04)
+                    echo "  --compiler clang-20        clang 20 (via apt.llvm.org)"
+                    echo "  --compiler clang-20-libcpp clang 20 + libc++ (via apt.llvm.org)"
+                    echo "  --compiler clang           system clang"
+                    echo "  --compiler gcc-12          g++ 12 (system)"
+                    echo "  --compiler gcc-14          g++ 14 (via Ubuntu Toolchain PPA)"
+                    echo "  --compiler gcc             system g++"
+                    ;;
+                24.04)
+                    echo "  --compiler clang-20        clang 20 (via apt.llvm.org)"
+                    echo "  --compiler clang-20-libcpp clang 20 + libc++ (via apt.llvm.org)"
+                    echo "  --compiler clang           system clang"
+                    echo "  --compiler gcc-14          g++ 14 (system)"
+                    echo "  --compiler gcc-12          g++ 12 (via Ubuntu Toolchain PPA)"
+                    echo "  --compiler gcc             system g++"
+                    ;;
+                *)
+                    echo "  (Ubuntu $OS_VERSION: check available packages)"
+                    ;;
+            esac
+            ;;
+        debian)
+            echo "  --compiler clang-20        clang 20 (via apt.llvm.org)"
+            echo "  --compiler clang-20-libcpp clang 20 + libc++ (via apt.llvm.org)"
+            echo "  --compiler clang           system clang"
+            echo "  --compiler gcc-12          g++ 12 (system on Debian 12)"
+            echo "  --compiler gcc             system g++"
+            echo "  NOTE: gcc-14 is NOT available on Debian 12"
+            ;;
+        fedora)
+            echo "  --compiler clang-20        clang 20 (via LLVM GitHub tarball, ~1.9 GB download)"
+            echo "  --compiler clang-20-libcpp clang 20 + libc++ (via LLVM GitHub tarball)"
+            echo "  --compiler clang           system clang"
+            echo "  --compiler gcc             system gcc"
+            echo "  NOTE: gcc-12, gcc-14 require version match with system gcc"
+            ;;
+        rocky|almalinux|rhel|centos)
+            echo "  --compiler clang-20        clang 20 (via LLVM GitHub tarball, ~1.9 GB download)"
+            echo "  --compiler clang-20-libcpp clang 20 + libc++ (via LLVM GitHub tarball)"
+            echo "  --compiler clang           system clang (EPEL)"
+            echo "  --compiler gcc             system gcc"
+            echo "  NOTE: gcc-12, gcc-14 are NOT available on $OS_ID"
+            ;;
+        *)
+            echo "  (check system packages for available compilers)"
+            ;;
+    esac
+    echo ""
+}
+
+# Main compiler installation orchestrator.
+# Routes to the appropriate ladder function based on the --compiler flag value.
+install_compiler() {
+    # No --compiler flag: preserve existing default behavior
+    if [ -z "$compiler" ]; then
+        install_llvm
+        return
+    fi
+
+    echo "[INFO] Installing requested compiler: $compiler"
+
+    case "$compiler" in
+        clang-20)
+            install_clang_versioned 20
+            ;;
+        clang-20-libcpp)
+            install_clang_versioned 20
+            install_libcxx 20
+            ;;
+        clang)
+            install_clang_any
+            ;;
+        gcc-12)
+            install_gcc_versioned 12
+            ;;
+        gcc-14)
+            install_gcc_versioned 14
+            ;;
+        gcc)
+            install_gcc_any
+            ;;
+    esac
+
+    verify_compiler "$compiler"
 }
 
 install_sfpi() {
@@ -488,7 +889,7 @@ install() {
 
     # Install specialized components
     install_sfpi
-    install_llvm
+    install_compiler
     install_mpi_ulfm
 
     # Configure system (hugepages, etc.) - only for baremetal if requested (not docker)

--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -358,8 +358,9 @@ prep_redhat_system() {
 
     echo "[INFO] Enabling CRB repository for development packages..."
     dnf config-manager --set-enabled crb 2>/dev/null || \
+        dnf config-manager --set-enabled ol10_codeready_builder 2>/dev/null || \
         dnf config-manager --set-enabled powertools 2>/dev/null || \
-        echo "[WARNING] Could not enable CRB/PowerTools repository"
+        echo "[WARNING] Could not enable CRB/CodeReady Builder repository"
 }
 
 # Download and install official LLVM binary tarball from GitHub releases.

--- a/test-plan-compiler-flag.md
+++ b/test-plan-compiler-flag.md
@@ -7,8 +7,8 @@ Branch: `ivoitovych/issue-37907-fix-fedora-toolchain-selection`
 
 This test plan covers all code paths introduced by the `--compiler` flag,
 compiler-to-toolchain mapping, and auto-detection fallback in `build_metal.sh`
-(tests 1–37), and the `--compiler` flag, `prep_redhat_system()`, `install_llvm()`
-rewrite, and warning fixes in `install_dependencies.sh` (tests 38–55).
+(tests 1–37, 59–60), and the `--compiler` flag, `prep_redhat_system()`, `install_llvm()`
+rewrite, and warning fixes in `install_dependencies.sh` (tests 38–58).
 
 `build_metal.sh` tests use `--configure-only` and PATH manipulation.
 `install_dependencies.sh` tests run in Docker containers (require root).
@@ -190,7 +190,22 @@ WARNING, ERROR).
 | # | Test | Container | Command | Expected output |
 |---|------|-----------|---------|-----------------|
 | 51 | Fedora: no extra repos | Fedora 40 | `./install_dependencies.sh --docker` | `[INFO] Preparing Red Hat family system...` then proceeds (no EPEL) |
-| 52 | Rocky: EPEL + CRB | Rocky 9 | `./install_dependencies.sh --docker` | `[INFO] Installing EPEL repository...`, `[INFO] Enabling CRB repository` |
+| 52 | AlmaLinux: EPEL + CRB | AlmaLinux 10 | `./install_dependencies.sh --docker` | `[INFO] Installing EPEL repository...`, `[INFO] Enabling CRB repository` |
+| 56 | Oracle Linux: Oracle EPEL + CRB | Oracle Linux 10 | `./install_dependencies.sh --docker` | `oracle-epel-release-el10` installed, `ol10_codeready_builder` enabled |
+
+## Section 15b: `verify_compiler()` — GCC version guard
+
+| # | Test | Container | Command | Expected output |
+|---|------|-----------|---------|-----------------|
+| 57 | GCC >= 12 passes | Ubuntu 22.04 (GCC 12) | `./install_dependencies.sh --docker --compiler gcc` | `[OK] Compiler verified:` |
+| 58 | GCC < 12 rejected | System with GCC 11 | `./install_dependencies.sh --docker --compiler gcc` | `[ERROR] GCC 11 is too old. tt-metal requires GCC >= 12.`, exit 1 |
+
+## Section 15c: `use_compiler()` — C compiler derivation check (build_metal.sh)
+
+| # | Test | PATH setup | Command | Expected output |
+|---|------|-----------|---------|-----------------|
+| 59 | Missing C compiler detected | Fake `g++` in PATH, no `gcc` | `--compiler gcc --configure-only` | `ERROR: C compiler 'gcc' not found (derived from 'g++')`, exit 1 |
+| 60 | Missing C compiler (clang) | Fake `clang++` in PATH, no `clang` | `--compiler clang --configure-only` | `ERROR: C compiler 'clang' not found (derived from 'clang++')`, exit 1 |
 
 ## Section 16: Warning fixes — MPI ULFM and hugepages
 
@@ -218,6 +233,7 @@ WARNING, ERROR).
 | `find_compiler()` search | 48–56 | 1–11, 18–26, 30–33 |
 | `use_compiler()` toolchain path | 60–64 | 1, 5, 7, 9–10, 21–22, 24–25 |
 | `use_compiler()` direct path | 65–75 | 2–4, 8, 18–20, 23 |
+| `use_compiler()` C compiler guard | 74–77 | 59–60 |
 | `--compiler clang` case | 292–296 | 1–6, 30–31 |
 | `--compiler gcc` case | 297–301 | 7–11, 32–33 |
 | `--compiler` pinned (FLAG_TOOLCHAIN) | 302–304 | 12–15 |
@@ -240,13 +256,15 @@ WARNING, ERROR).
 | `install_llvm()` RedHat: distro clang INFO | 48, 50 |
 | `install_llvm()` RedHat: skip on gcc | 49 |
 | `prep_redhat_system()` Fedora: no-op | 51 |
-| `prep_redhat_system()` RHEL/Rocky: EPEL+CRB | 52 |
+| `prep_redhat_system()` RHEL/Alma: EPEL+CRB | 52 |
+| `prep_redhat_system()` Oracle: EPEL+CRB | 56 |
+| `verify_compiler()` GCC >= 12 guard | 57–58 |
 | MPI ULFM warning → INFO | 53 |
 | Hugepages warning → INFO | 54 |
 | Help text | 55 |
 
 | Script | Tests |
 |--------|-------|
-| `build_metal.sh` | 37 |
-| `install_dependencies.sh` | 18 |
-| **Total** | **55 tests** |
+| `build_metal.sh` | 39 |
+| `install_dependencies.sh` | 21 |
+| **Total** | **60 tests** |

--- a/test-plan-compiler-flag.md
+++ b/test-plan-compiler-flag.md
@@ -35,78 +35,82 @@ SYSTEM_BIN="/usr/bin:/bin"
 # compiler-free base PATH. To hide everything, use EMPTY_DIR only.
 ```
 
-## Helper functions reference
+## Data tables and helper functions reference
 
-| Function | Lines | Purpose |
-|----------|-------|---------|
-| `toolchain_for()` | 19–28 | Map C++ binary name → toolchain file path |
-| `find_compiler()` | 32–40 | Find first available binary from candidate list |
-| `use_compiler()` | 44–61 | Set `toolchain_path` or `cxx/c_compiler_path` |
+| Symbol | Lines | Purpose |
+|--------|-------|---------|
+| `CLANG_SEARCH` | 18 | Clang binary search order |
+| `GCC_SEARCH` | 19 | GCC binary search order |
+| `BINARY_TOOLCHAIN` | 23–31 | Binary name → toolchain ID map |
+| `FLAG_TOOLCHAIN` | 34–39 | CLI flag → toolchain ID map |
+| `toolchain_file()` | 42–44 | Toolchain ID → full cmake path |
+| `find_compiler()` | 48–56 | Find first available binary from candidate list |
+| `use_compiler()` | 60–76 | Set `toolchain_path` or `cxx/c_compiler_path` |
 
-## Section 1: `--compiler` flag — Clang search (lines 277–281)
-
-| # | Test | PATH setup | Command | Expected output | Lines |
-|---|------|-----------|---------|-----------------|-------|
-| 1 | `--compiler clang` finds clang++-20 | Normal (has clang++-20) | `--compiler clang --configure-only` | `INFO: --compiler clang: found clang++-20`, TOOLCHAIN_FILE=`clang-20-libstdcpp` | 278, 281 → toolchain_for:21 |
-| 2 | `--compiler clang` finds clang++-19 | Fake clang++-19 only, no clang++-20 | `--compiler clang --configure-only` | `found clang++-19`, CMAKE_CXX_COMPILER=`.../clang++-19` | 278, 281 → use_compiler:51 |
-| 3 | `--compiler clang` finds clang++-18 | Fake clang++-18 only | `--compiler clang --configure-only` | `found clang++-18`, CMAKE_CXX_COMPILER | 278, 281 → use_compiler:51 |
-| 4 | `--compiler clang` finds clang++-17 | Fake clang++-17 only | `--compiler clang --configure-only` | `found clang++-17`, CMAKE_CXX_COMPILER | 278, 281 → use_compiler:51 |
-| 5 | `--compiler clang` finds unversioned clang++ | Fake clang++ only (no versioned) | `--compiler clang --configure-only` | `found clang++`, TOOLCHAIN_FILE=`clang-libstdcpp` | 278, 281 → toolchain_for:22 |
-| 6 | `--compiler clang` finds nothing | Empty PATH (no compilers) | `--compiler clang --configure-only` | `ERROR: No clang++ found in PATH.`, exit 1 | 278–279 |
-
-## Section 2: `--compiler` flag — GCC search (lines 282–286)
+## Section 1: `--compiler` flag — Clang search (lines 292–296)
 
 | # | Test | PATH setup | Command | Expected output | Lines |
 |---|------|-----------|---------|-----------------|-------|
-| 7 | `--compiler gcc` finds g++-14 | Fake g++-14 | `--compiler gcc --configure-only` | `found g++-14`, TOOLCHAIN_FILE=`gcc-14` | 283, 286 → toolchain_for:23 |
-| 8 | `--compiler gcc` finds g++-13 | Fake g++-13, no g++-14 | `--compiler gcc --configure-only` | `found g++-13`, CMAKE_CXX_COMPILER=`.../g++-13` | 283, 286 → use_compiler:51 |
-| 9 | `--compiler gcc` finds g++-12 | Fake g++-12, no g++-14/13 | `--compiler gcc --configure-only` | `found g++-12`, TOOLCHAIN_FILE=`gcc-12` | 283, 286 → toolchain_for:24 |
-| 10 | `--compiler gcc` finds unversioned g++ | Fake g++ only | `--compiler gcc --configure-only` | `found g++`, TOOLCHAIN_FILE=`gcc` | 283, 286 → toolchain_for:25 |
-| 11 | `--compiler gcc` finds nothing | Empty PATH (no compilers) | `--compiler gcc --configure-only` | `ERROR: No g++ found in PATH.`, exit 1 | 283–284 |
+| 1 | `--compiler clang` finds clang++-20 | Normal (has clang++-20) | `--compiler clang --configure-only` | `INFO: --compiler clang: found clang++-20`, TOOLCHAIN_FILE=`clang-20-libstdcpp` | 293, 296 → BINARY_TOOLCHAIN:24 |
+| 2 | `--compiler clang` finds clang++-19 | Fake clang++-19 only, no clang++-20 | `--compiler clang --configure-only` | `found clang++-19`, CMAKE_CXX_COMPILER=`.../clang++-19` | 293, 296 → use_compiler:66 |
+| 3 | `--compiler clang` finds clang++-18 | Fake clang++-18 only | `--compiler clang --configure-only` | `found clang++-18`, CMAKE_CXX_COMPILER | 293, 296 → use_compiler:66 |
+| 4 | `--compiler clang` finds clang++-17 | Fake clang++-17 only | `--compiler clang --configure-only` | `found clang++-17`, CMAKE_CXX_COMPILER | 293, 296 → use_compiler:66 |
+| 5 | `--compiler clang` finds unversioned clang++ | Fake clang++ only (no versioned) | `--compiler clang --configure-only` | `found clang++`, TOOLCHAIN_FILE=`clang-libstdcpp` | 293, 296 → BINARY_TOOLCHAIN:25 |
+| 6 | `--compiler clang` finds nothing | Empty PATH (no compilers) | `--compiler clang --configure-only` | `ERROR: No clang++ found in PATH.`, exit 1 | 293–294 |
 
-## Section 3: `--compiler` flag — Pinned versions (lines 287–290)
-
-| # | Test | PATH setup | Command | Expected output | Lines |
-|---|------|-----------|---------|-----------------|-------|
-| 12 | `--compiler clang-20` | Normal | `--compiler clang-20 --configure-only` | TOOLCHAIN_FILE=`clang-20-libstdcpp` | 287 |
-| 13 | `--compiler clang-20-libcpp` | Normal | `--compiler clang-20-libcpp --configure-only` | TOOLCHAIN_FILE=`clang-20-libcpp` | 288 |
-| 14 | `--compiler gcc-12` | Normal | `--compiler gcc-12 --configure-only` | TOOLCHAIN_FILE=`gcc-12` | 289 |
-| 15 | `--compiler gcc-14` | Normal | `--compiler gcc-14 --configure-only` | TOOLCHAIN_FILE=`gcc-14` | 290 |
-
-## Section 4: `--compiler` flag — Error handling (lines 291–294)
+## Section 2: `--compiler` flag — GCC search (lines 297–301)
 
 | # | Test | PATH setup | Command | Expected output | Lines |
 |---|------|-----------|---------|-----------------|-------|
-| 16 | `--compiler foobar` (unknown) | Normal | `--compiler foobar --configure-only` | `ERROR: Unknown compiler 'foobar'`, help text, exit 1 | 291–294 |
+| 7 | `--compiler gcc` finds g++-14 | Fake g++-14 | `--compiler gcc --configure-only` | `found g++-14`, TOOLCHAIN_FILE=`gcc-14` | 298, 301 → BINARY_TOOLCHAIN:26 |
+| 8 | `--compiler gcc` finds g++-13 | Fake g++-13, no g++-14 | `--compiler gcc --configure-only` | `found g++-13`, CMAKE_CXX_COMPILER=`.../g++-13` | 298, 301 → use_compiler:66 |
+| 9 | `--compiler gcc` finds g++-12 | Fake g++-12, no g++-14/13 | `--compiler gcc --configure-only` | `found g++-12`, TOOLCHAIN_FILE=`gcc-12` | 298, 301 → BINARY_TOOLCHAIN:27 |
+| 10 | `--compiler gcc` finds unversioned g++ | Fake g++ only | `--compiler gcc --configure-only` | `found g++`, TOOLCHAIN_FILE=`gcc` | 298, 301 → BINARY_TOOLCHAIN:28 |
+| 11 | `--compiler gcc` finds nothing | Empty PATH (no compilers) | `--compiler gcc --configure-only` | `ERROR: No g++ found in PATH.`, exit 1 | 298–299 |
 
-## Section 5: Auto-detection fallback — Clang found (lines 298–307)
+## Section 3: `--compiler` flag — Pinned versions (lines 302–304)
+
+| # | Test | PATH setup | Command | Expected output | Lines |
+|---|------|-----------|---------|-----------------|-------|
+| 12 | `--compiler clang-20` | Normal | `--compiler clang-20 --configure-only` | TOOLCHAIN_FILE=`clang-20-libstdcpp` | 303–304, FLAG_TOOLCHAIN:35 |
+| 13 | `--compiler clang-20-libcpp` | Normal | `--compiler clang-20-libcpp --configure-only` | TOOLCHAIN_FILE=`clang-20-libcpp` | 303–304, FLAG_TOOLCHAIN:36 |
+| 14 | `--compiler gcc-12` | Normal | `--compiler gcc-12 --configure-only` | TOOLCHAIN_FILE=`gcc-12` | 303–304, FLAG_TOOLCHAIN:38 |
+| 15 | `--compiler gcc-14` | Normal | `--compiler gcc-14 --configure-only` | TOOLCHAIN_FILE=`gcc-14` | 303–304, FLAG_TOOLCHAIN:37 |
+
+## Section 4: `--compiler` flag — Error handling (lines 305–309)
+
+| # | Test | PATH setup | Command | Expected output | Lines |
+|---|------|-----------|---------|-----------------|-------|
+| 16 | `--compiler foobar` (unknown) | Normal | `--compiler foobar --configure-only` | `ERROR: Unknown compiler 'foobar'`, help text, exit 1 | 305–309 |
+
+## Section 5: Auto-detection fallback — Clang found (lines 313–322)
 
 These tests run with NO `--compiler`, `--cxx-compiler-path`, or `--toolchain-path` flags.
 
 | # | Test | PATH setup | Command | Expected output | Lines |
 |---|------|-----------|---------|-----------------|-------|
-| 17 | No fallback (clang++-20 present) | Normal (has clang++-20) | `--configure-only` | TOOLCHAIN_FILE=`clang-20-libstdcpp`, NO warning | 300 (guard false) |
-| 18 | Fallback finds clang++-19 | Fake clang++-19, no clang++-20 | `--configure-only` | `WARNING`, `Auto-selected clang++-19`, CMAKE_CXX_COMPILER | 302, 305 → use_compiler:51 |
-| 19 | Fallback finds clang++-18 | Fake clang++-18 only | `--configure-only` | `Auto-selected clang++-18`, CMAKE_CXX_COMPILER | 302, 305 → use_compiler:51 |
-| 20 | Fallback finds clang++-17 | Fake clang++-17 only | `--configure-only` | `Auto-selected clang++-17`, CMAKE_CXX_COMPILER | 302, 305 → use_compiler:51 |
-| 21 | Fallback finds unversioned clang++ | Fake clang++ only | `--configure-only` | `Auto-selected clang++`, TOOLCHAIN_FILE=`clang-libstdcpp` | 302, 305 → toolchain_for:22 |
+| 17 | No fallback (clang++-20 present) | Normal (has clang++-20) | `--configure-only` | TOOLCHAIN_FILE=`clang-20-libstdcpp`, NO warning | 315 (guard false) |
+| 18 | Fallback finds clang++-19 | Fake clang++-19, no clang++-20 | `--configure-only` | `WARNING`, `Auto-selected clang++-19`, CMAKE_CXX_COMPILER | 317, 320 → use_compiler:66 |
+| 19 | Fallback finds clang++-18 | Fake clang++-18 only | `--configure-only` | `Auto-selected clang++-18`, CMAKE_CXX_COMPILER | 317, 320 → use_compiler:66 |
+| 20 | Fallback finds clang++-17 | Fake clang++-17 only | `--configure-only` | `Auto-selected clang++-17`, CMAKE_CXX_COMPILER | 317, 320 → use_compiler:66 |
+| 21 | Fallback finds unversioned clang++ | Fake clang++ only | `--configure-only` | `Auto-selected clang++`, TOOLCHAIN_FILE=`clang-libstdcpp` | 317, 320 → BINARY_TOOLCHAIN:25 |
 
-## Section 6: Auto-detection fallback — No Clang, GCC found (lines 298–307)
-
-| # | Test | PATH setup | Command | Expected output | Lines |
-|---|------|-----------|---------|-----------------|-------|
-| 22 | Fallback finds g++-14 (no clang) | Fake g++-14, no clang at all | `--configure-only` | `WARNING`, `Auto-selected g++-14`, TOOLCHAIN_FILE=`gcc-14` | 302, 305 → toolchain_for:23 |
-| 23 | Fallback finds g++-13 (no clang) | Fake g++-13 only | `--configure-only` | `Auto-selected g++-13`, CMAKE_CXX_COMPILER | 302, 305 → use_compiler:51 |
-| 24 | Fallback finds g++-12 (no clang) | Fake g++-12 only | `--configure-only` | `Auto-selected g++-12`, TOOLCHAIN_FILE=`gcc-12` | 302, 305 → toolchain_for:24 |
-| 25 | Fallback finds unversioned g++ (no clang) | Fake g++ only | `--configure-only` | `Auto-selected g++`, TOOLCHAIN_FILE=`gcc` | 302, 305 → toolchain_for:25 |
-
-## Section 7: Auto-detection fallback — Nothing found (lines 302–303)
+## Section 6: Auto-detection fallback — No Clang, GCC found (lines 313–322)
 
 | # | Test | PATH setup | Command | Expected output | Lines |
 |---|------|-----------|---------|-----------------|-------|
-| 26 | Fallback finds nothing | Empty PATH (no compilers) | `--configure-only` | `WARNING`, `ERROR: No C++ compiler found.`, exit 1 | 302–303 |
+| 22 | Fallback finds g++-14 (no clang) | Fake g++-14, no clang at all | `--configure-only` | `WARNING`, `Auto-selected g++-14`, TOOLCHAIN_FILE=`gcc-14` | 317, 320 → BINARY_TOOLCHAIN:26 |
+| 23 | Fallback finds g++-13 (no clang) | Fake g++-13 only | `--configure-only` | `Auto-selected g++-13`, CMAKE_CXX_COMPILER | 317, 320 → use_compiler:66 |
+| 24 | Fallback finds g++-12 (no clang) | Fake g++-12 only | `--configure-only` | `Auto-selected g++-12`, TOOLCHAIN_FILE=`gcc-12` | 317, 320 → BINARY_TOOLCHAIN:27 |
+| 25 | Fallback finds unversioned g++ (no clang) | Fake g++ only | `--configure-only` | `Auto-selected g++`, TOOLCHAIN_FILE=`gcc` | 317, 320 → BINARY_TOOLCHAIN:28 |
 
-## Section 8: Auto-detection guard conditions (line 299)
+## Section 7: Auto-detection fallback — Nothing found (lines 317–318)
+
+| # | Test | PATH setup | Command | Expected output | Lines |
+|---|------|-----------|---------|-----------------|-------|
+| 26 | Fallback finds nothing | Empty PATH (no compilers) | `--configure-only` | `WARNING`, `ERROR: No C++ compiler found.`, exit 1 | 317–318 |
+
+## Section 8: Auto-detection guard conditions (line 314)
 
 These verify that auto-detection is skipped when any explicit override is set.
 All tests run WITHOUT clang++-20 in PATH to ensure the fallback would trigger
@@ -118,13 +122,13 @@ if the guard didn't prevent it.
 | 28 | `--cxx-compiler-path` set skips auto-detect | `--cxx-compiler-path /usr/bin/g++ --configure-only` | CMAKE_CXX_COMPILER=`/usr/bin/g++`, NO warning | `cxx_compiler_path != ""` |
 | 29 | `--toolchain-path` set skips auto-detect | `--toolchain-path cmake/x86_64-linux-gcc-14-toolchain.cmake --configure-only` | TOOLCHAIN_FILE=`gcc-14`, NO warning | `toolchain_path_explicitly_set = true` |
 
-## Section 9: Search priority ordering (lines 278, 283)
+## Section 9: Search priority ordering (lines 18–19, via 293, 298)
 
 | # | Test | PATH setup | Expected | Verifies |
 |---|------|-----------|----------|----------|
-| 30 | clang++-20 preferred over clang++-19 | Both clang++-20 and clang++-19 present | `found clang++-20` | Descending order |
+| 30 | clang++-20 preferred over clang++-19 | Both clang++-20 and clang++-19 present | `found clang++-20` | CLANG_SEARCH descending order |
 | 31 | clang++-18 preferred over clang++ | Both clang++-18 and clang++ present | `found clang++-18` | Versioned before unversioned |
-| 32 | g++-14 preferred over g++-13 | Both g++-14 and g++-13 present | `found g++-14` | Descending order |
+| 32 | g++-14 preferred over g++-13 | Both g++-14 and g++-13 present | `found g++-14` | GCC_SEARCH descending order |
 | 33 | g++-12 preferred over g++ | Both g++-12 and g++ present | `found g++-12` | Versioned before unversioned |
 
 ## Section 10: Help text and CMake presets
@@ -134,30 +138,33 @@ if the guard didn't prevent it.
 | 34 | `--help` shows `--compiler` | `build_metal.sh --help` | Output contains `--compiler compiler_name` and lists `clang`, `gcc` |
 | 35 | CMakePresets.json valid | `cmake --list-presets 2>&1` | Output lists `gcc-system` and `clang-system` presets |
 
-## Section 11: `--toolchain-path` protection flag (line 257)
+## Section 11: `--toolchain-path` protection flag (line 272)
 
 | # | Test | Command | Expected | Verifies |
 |---|------|---------|----------|----------|
-| 36 | `--toolchain-path` sets explicit flag | `--toolchain-path cmake/x86_64-linux-gcc-toolchain.cmake --configure-only` (no clang++-20) | Uses `gcc-toolchain`, NO auto-detect override | `toolchain_path_explicitly_set=true` (line 257) |
-| 37 | Default has explicit flag false | `--configure-only` (with clang++-20) | Uses default `clang-20-libstdcpp` | `toolchain_path_explicitly_set=false` (line 135) |
+| 36 | `--toolchain-path` sets explicit flag | `--toolchain-path cmake/x86_64-linux-gcc-toolchain.cmake --configure-only` (no clang++-20) | Uses `gcc-toolchain`, NO auto-detect override | `toolchain_path_explicitly_set=true` (line 272) |
+| 37 | Default has explicit flag false | `--configure-only` (with clang++-20) | Uses default `clang-20-libstdcpp` | `toolchain_path_explicitly_set=false` (line 150) |
 
 ## Coverage Summary
 
 | Code section | Lines | Tests |
 |-------------|-------|-------|
-| `toolchain_for()` lookup | 19–28 | 1, 5, 7, 9–10, 21–22, 24–25 |
-| `find_compiler()` search | 32–40 | 1–11, 18–26, 30–33 |
-| `use_compiler()` toolchain path | 44–49 | 1, 5, 7, 9–10, 21–22, 24–25 |
-| `use_compiler()` direct path | 50–60 | 2–4, 8, 18–20, 23 |
-| `--compiler clang` case | 277–281 | 1–6, 30–31 |
-| `--compiler gcc` case | 282–286 | 7–11, 32–33 |
-| `--compiler` pinned versions | 287–290 | 12–15 |
-| `--compiler` error (unknown) | 291–294 | 16 |
-| Auto-detect: clang++-20 present | 299–300 | 17 |
-| Auto-detect: compiler fallback | 301–306 | 18–25 |
-| Auto-detect: nothing found | 302–303 | 26 |
-| Auto-detect: guard conditions | 299 | 27–29 |
-| `--toolchain-path` explicit flag | 135, 257 | 28–29, 36–37 |
-| Help text | 94 | 34 |
+| `CLANG_SEARCH` / `GCC_SEARCH` arrays | 18–19 | 1–11, 18–26, 30–33 |
+| `BINARY_TOOLCHAIN` map | 23–31 | 1, 5, 7, 9–10, 21–22, 24–25 |
+| `FLAG_TOOLCHAIN` map | 34–39 | 12–15 |
+| `toolchain_file()` | 42–44 | 1, 5, 7, 9–10, 12–15, 21–22, 24–25 |
+| `find_compiler()` search | 48–56 | 1–11, 18–26, 30–33 |
+| `use_compiler()` toolchain path | 60–64 | 1, 5, 7, 9–10, 21–22, 24–25 |
+| `use_compiler()` direct path | 65–75 | 2–4, 8, 18–20, 23 |
+| `--compiler clang` case | 292–296 | 1–6, 30–31 |
+| `--compiler gcc` case | 297–301 | 7–11, 32–33 |
+| `--compiler` pinned (FLAG_TOOLCHAIN) | 302–304 | 12–15 |
+| `--compiler` error (unknown) | 305–309 | 16 |
+| Auto-detect: clang++-20 present | 314–315 | 17 |
+| Auto-detect: compiler fallback | 316–321 | 18–25 |
+| Auto-detect: nothing found | 317–318 | 26 |
+| Auto-detect: guard conditions | 314 | 27–29 |
+| `--toolchain-path` explicit flag | 150, 272 | 28–29, 36–37 |
+| Help text | 109 | 34 |
 | CMakePresets.json | — | 35 |
 | **Total** | | **37 tests** |

--- a/test-plan-compiler-flag.md
+++ b/test-plan-compiler-flag.md
@@ -35,70 +35,78 @@ SYSTEM_BIN="/usr/bin:/bin"
 # compiler-free base PATH. To hide everything, use EMPTY_DIR only.
 ```
 
-## Section 1: `--compiler` flag — Clang search (lines 231–250)
+## Helper functions reference
+
+| Function | Lines | Purpose |
+|----------|-------|---------|
+| `toolchain_for()` | 19–28 | Map C++ binary name → toolchain file path |
+| `find_compiler()` | 32–40 | Find first available binary from candidate list |
+| `use_compiler()` | 44–61 | Set `toolchain_path` or `cxx/c_compiler_path` |
+
+## Section 1: `--compiler` flag — Clang search (lines 277–281)
 
 | # | Test | PATH setup | Command | Expected output | Lines |
 |---|------|-----------|---------|-----------------|-------|
-| 1 | `--compiler clang` finds clang++-20 | Normal (has clang++-20) | `--compiler clang --configure-only` | `INFO: --compiler clang: found clang++-20`, TOOLCHAIN_FILE=`clang-20-libstdcpp` | 246 |
-| 2 | `--compiler clang` finds clang++-19 | Fake clang++-19 only, no clang++-20 | `--compiler clang --configure-only` | `found clang++-19`, CMAKE_CXX_COMPILER=`.../clang++-19` | 248–249 |
-| 3 | `--compiler clang` finds clang++-18 | Fake clang++-18 only | `--compiler clang --configure-only` | `found clang++-18`, CMAKE_CXX_COMPILER | 248–249 |
-| 4 | `--compiler clang` finds clang++-17 | Fake clang++-17 only | `--compiler clang --configure-only` | `found clang++-17`, CMAKE_CXX_COMPILER | 248–249 |
-| 5 | `--compiler clang` finds unversioned clang++ | Fake clang++ only (no versioned) | `--compiler clang --configure-only` | `found clang++`, TOOLCHAIN_FILE=`clang-libstdcpp` | 247 |
-| 6 | `--compiler clang` finds nothing | Empty PATH (no compilers) | `--compiler clang --configure-only` | `ERROR: No clang++ found in PATH.`, exit 1 | 241–242 |
+| 1 | `--compiler clang` finds clang++-20 | Normal (has clang++-20) | `--compiler clang --configure-only` | `INFO: --compiler clang: found clang++-20`, TOOLCHAIN_FILE=`clang-20-libstdcpp` | 278, 281 → toolchain_for:21 |
+| 2 | `--compiler clang` finds clang++-19 | Fake clang++-19 only, no clang++-20 | `--compiler clang --configure-only` | `found clang++-19`, CMAKE_CXX_COMPILER=`.../clang++-19` | 278, 281 → use_compiler:51 |
+| 3 | `--compiler clang` finds clang++-18 | Fake clang++-18 only | `--compiler clang --configure-only` | `found clang++-18`, CMAKE_CXX_COMPILER | 278, 281 → use_compiler:51 |
+| 4 | `--compiler clang` finds clang++-17 | Fake clang++-17 only | `--compiler clang --configure-only` | `found clang++-17`, CMAKE_CXX_COMPILER | 278, 281 → use_compiler:51 |
+| 5 | `--compiler clang` finds unversioned clang++ | Fake clang++ only (no versioned) | `--compiler clang --configure-only` | `found clang++`, TOOLCHAIN_FILE=`clang-libstdcpp` | 278, 281 → toolchain_for:22 |
+| 6 | `--compiler clang` finds nothing | Empty PATH (no compilers) | `--compiler clang --configure-only` | `ERROR: No clang++ found in PATH.`, exit 1 | 278–279 |
 
-## Section 2: `--compiler` flag — GCC search (lines 254–271)
-
-| # | Test | PATH setup | Command | Expected output | Lines |
-|---|------|-----------|---------|-----------------|-------|
-| 7 | `--compiler gcc` finds g++-14 | Fake g++-14 | `--compiler gcc --configure-only` | `found g++-14`, TOOLCHAIN_FILE=`gcc-14` | 266 |
-| 8 | `--compiler gcc` finds g++-13 | Fake g++-13, no g++-14 | `--compiler gcc --configure-only` | `found g++-13`, CMAKE_CXX_COMPILER=`.../g++-13` | 269–270 |
-| 9 | `--compiler gcc` finds g++-12 | Fake g++-12, no g++-14/13 | `--compiler gcc --configure-only` | `found g++-12`, TOOLCHAIN_FILE=`gcc-12` | 267 |
-| 10 | `--compiler gcc` finds unversioned g++ | Fake g++ only | `--compiler gcc --configure-only` | `found g++`, TOOLCHAIN_FILE=`gcc` | 268 |
-| 11 | `--compiler gcc` finds nothing | Empty PATH (no compilers) | `--compiler gcc --configure-only` | `ERROR: No g++ found in PATH.`, exit 1 | 260–262 |
-
-## Section 3: `--compiler` flag — Pinned versions (lines 272–279)
+## Section 2: `--compiler` flag — GCC search (lines 282–286)
 
 | # | Test | PATH setup | Command | Expected output | Lines |
 |---|------|-----------|---------|-----------------|-------|
-| 12 | `--compiler clang-20` | Normal | `--compiler clang-20 --configure-only` | TOOLCHAIN_FILE=`clang-20-libstdcpp` | 273 |
-| 13 | `--compiler clang-20-libcpp` | Normal | `--compiler clang-20-libcpp --configure-only` | TOOLCHAIN_FILE=`clang-20-libcpp` | 274 |
-| 14 | `--compiler gcc-12` | Normal | `--compiler gcc-12 --configure-only` | TOOLCHAIN_FILE=`gcc-12` | 277 |
-| 15 | `--compiler gcc-14` | Normal | `--compiler gcc-14 --configure-only` | TOOLCHAIN_FILE=`gcc-14` | 278 |
+| 7 | `--compiler gcc` finds g++-14 | Fake g++-14 | `--compiler gcc --configure-only` | `found g++-14`, TOOLCHAIN_FILE=`gcc-14` | 283, 286 → toolchain_for:23 |
+| 8 | `--compiler gcc` finds g++-13 | Fake g++-13, no g++-14 | `--compiler gcc --configure-only` | `found g++-13`, CMAKE_CXX_COMPILER=`.../g++-13` | 283, 286 → use_compiler:51 |
+| 9 | `--compiler gcc` finds g++-12 | Fake g++-12, no g++-14/13 | `--compiler gcc --configure-only` | `found g++-12`, TOOLCHAIN_FILE=`gcc-12` | 283, 286 → toolchain_for:24 |
+| 10 | `--compiler gcc` finds unversioned g++ | Fake g++ only | `--compiler gcc --configure-only` | `found g++`, TOOLCHAIN_FILE=`gcc` | 283, 286 → toolchain_for:25 |
+| 11 | `--compiler gcc` finds nothing | Empty PATH (no compilers) | `--compiler gcc --configure-only` | `ERROR: No g++ found in PATH.`, exit 1 | 283–284 |
 
-## Section 4: `--compiler` flag — Error handling (lines 280–283)
+## Section 3: `--compiler` flag — Pinned versions (lines 287–290)
 
 | # | Test | PATH setup | Command | Expected output | Lines |
 |---|------|-----------|---------|-----------------|-------|
-| 16 | `--compiler foobar` (unknown) | Normal | `--compiler foobar --configure-only` | `ERROR: Unknown compiler 'foobar'`, help text, exit 1 | 280–283 |
+| 12 | `--compiler clang-20` | Normal | `--compiler clang-20 --configure-only` | TOOLCHAIN_FILE=`clang-20-libstdcpp` | 287 |
+| 13 | `--compiler clang-20-libcpp` | Normal | `--compiler clang-20-libcpp --configure-only` | TOOLCHAIN_FILE=`clang-20-libcpp` | 288 |
+| 14 | `--compiler gcc-12` | Normal | `--compiler gcc-12 --configure-only` | TOOLCHAIN_FILE=`gcc-12` | 289 |
+| 15 | `--compiler gcc-14` | Normal | `--compiler gcc-14 --configure-only` | TOOLCHAIN_FILE=`gcc-14` | 290 |
 
-## Section 5: Auto-detection fallback — Clang found (lines 287–305)
+## Section 4: `--compiler` flag — Error handling (lines 291–294)
+
+| # | Test | PATH setup | Command | Expected output | Lines |
+|---|------|-----------|---------|-----------------|-------|
+| 16 | `--compiler foobar` (unknown) | Normal | `--compiler foobar --configure-only` | `ERROR: Unknown compiler 'foobar'`, help text, exit 1 | 291–294 |
+
+## Section 5: Auto-detection fallback — Clang found (lines 298–307)
 
 These tests run with NO `--compiler`, `--cxx-compiler-path`, or `--toolchain-path` flags.
 
 | # | Test | PATH setup | Command | Expected output | Lines |
 |---|------|-----------|---------|-----------------|-------|
-| 17 | No fallback (clang++-20 present) | Normal (has clang++-20) | `--configure-only` | TOOLCHAIN_FILE=`clang-20-libstdcpp`, NO warning | 288 (guard false) |
-| 18 | Fallback finds clang++-19 | Fake clang++-19, no clang++-20 | `--configure-only` | `WARNING`, `Auto-selected clang++-19`, CMAKE_CXX_COMPILER | 302–303 |
-| 19 | Fallback finds clang++-18 | Fake clang++-18 only | `--configure-only` | `Auto-selected clang++-18`, CMAKE_CXX_COMPILER | 302–303 |
-| 20 | Fallback finds clang++-17 | Fake clang++-17 only | `--configure-only` | `Auto-selected clang++-17`, CMAKE_CXX_COMPILER | 302–303 |
-| 21 | Fallback finds unversioned clang++ | Fake clang++ only | `--configure-only` | `Auto-selected clang++`, TOOLCHAIN_FILE=`clang-libstdcpp` | 301 |
+| 17 | No fallback (clang++-20 present) | Normal (has clang++-20) | `--configure-only` | TOOLCHAIN_FILE=`clang-20-libstdcpp`, NO warning | 300 (guard false) |
+| 18 | Fallback finds clang++-19 | Fake clang++-19, no clang++-20 | `--configure-only` | `WARNING`, `Auto-selected clang++-19`, CMAKE_CXX_COMPILER | 302, 305 → use_compiler:51 |
+| 19 | Fallback finds clang++-18 | Fake clang++-18 only | `--configure-only` | `Auto-selected clang++-18`, CMAKE_CXX_COMPILER | 302, 305 → use_compiler:51 |
+| 20 | Fallback finds clang++-17 | Fake clang++-17 only | `--configure-only` | `Auto-selected clang++-17`, CMAKE_CXX_COMPILER | 302, 305 → use_compiler:51 |
+| 21 | Fallback finds unversioned clang++ | Fake clang++ only | `--configure-only` | `Auto-selected clang++`, TOOLCHAIN_FILE=`clang-libstdcpp` | 302, 305 → toolchain_for:22 |
 
-## Section 6: Auto-detection fallback — No Clang, GCC found (lines 306–323)
-
-| # | Test | PATH setup | Command | Expected output | Lines |
-|---|------|-----------|---------|-----------------|-------|
-| 22 | Fallback finds g++-14 (no clang) | Fake g++-14, no clang at all | `--configure-only` | `WARNING`, `Auto-selected g++-14`, TOOLCHAIN_FILE=`gcc-14` | 317 |
-| 23 | Fallback finds g++-13 (no clang) | Fake g++-13 only | `--configure-only` | `Auto-selected g++-13`, CMAKE_CXX_COMPILER | 320–321 |
-| 24 | Fallback finds g++-12 (no clang) | Fake g++-12 only | `--configure-only` | `Auto-selected g++-12`, TOOLCHAIN_FILE=`gcc-12` | 318 |
-| 25 | Fallback finds unversioned g++ (no clang) | Fake g++ only | `--configure-only` | `Auto-selected g++`, TOOLCHAIN_FILE=`gcc` | 319 |
-
-## Section 7: Auto-detection fallback — Nothing found (lines 324–326)
+## Section 6: Auto-detection fallback — No Clang, GCC found (lines 298–307)
 
 | # | Test | PATH setup | Command | Expected output | Lines |
 |---|------|-----------|---------|-----------------|-------|
-| 26 | Fallback finds nothing | Empty PATH (no compilers) | `--configure-only` | `WARNING`, `ERROR: No C++ compiler found.`, exit 1 | 325–326 |
+| 22 | Fallback finds g++-14 (no clang) | Fake g++-14, no clang at all | `--configure-only` | `WARNING`, `Auto-selected g++-14`, TOOLCHAIN_FILE=`gcc-14` | 302, 305 → toolchain_for:23 |
+| 23 | Fallback finds g++-13 (no clang) | Fake g++-13 only | `--configure-only` | `Auto-selected g++-13`, CMAKE_CXX_COMPILER | 302, 305 → use_compiler:51 |
+| 24 | Fallback finds g++-12 (no clang) | Fake g++-12 only | `--configure-only` | `Auto-selected g++-12`, TOOLCHAIN_FILE=`gcc-12` | 302, 305 → toolchain_for:24 |
+| 25 | Fallback finds unversioned g++ (no clang) | Fake g++ only | `--configure-only` | `Auto-selected g++`, TOOLCHAIN_FILE=`gcc` | 302, 305 → toolchain_for:25 |
 
-## Section 8: Auto-detection guard conditions (line 288)
+## Section 7: Auto-detection fallback — Nothing found (lines 302–303)
+
+| # | Test | PATH setup | Command | Expected output | Lines |
+|---|------|-----------|---------|-----------------|-------|
+| 26 | Fallback finds nothing | Empty PATH (no compilers) | `--configure-only` | `WARNING`, `ERROR: No C++ compiler found.`, exit 1 | 302–303 |
+
+## Section 8: Auto-detection guard conditions (line 299)
 
 These verify that auto-detection is skipped when any explicit override is set.
 All tests run WITHOUT clang++-20 in PATH to ensure the fallback would trigger
@@ -110,7 +118,7 @@ if the guard didn't prevent it.
 | 28 | `--cxx-compiler-path` set skips auto-detect | `--cxx-compiler-path /usr/bin/g++ --configure-only` | CMAKE_CXX_COMPILER=`/usr/bin/g++`, NO warning | `cxx_compiler_path != ""` |
 | 29 | `--toolchain-path` set skips auto-detect | `--toolchain-path cmake/x86_64-linux-gcc-14-toolchain.cmake --configure-only` | TOOLCHAIN_FILE=`gcc-14`, NO warning | `toolchain_path_explicitly_set = true` |
 
-## Section 9: Search priority ordering (lines 234, 254)
+## Section 9: Search priority ordering (lines 278, 283)
 
 | # | Test | PATH setup | Expected | Verifies |
 |---|------|-----------|----------|----------|
@@ -126,27 +134,30 @@ if the guard didn't prevent it.
 | 34 | `--help` shows `--compiler` | `build_metal.sh --help` | Output contains `--compiler compiler_name` and lists `clang`, `gcc` |
 | 35 | CMakePresets.json valid | `cmake --list-presets 2>&1` | Output lists `gcc-system` and `clang-system` presets |
 
-## Section 11: `--toolchain-path` protection flag (line 208)
+## Section 11: `--toolchain-path` protection flag (line 257)
 
 | # | Test | Command | Expected | Verifies |
 |---|------|---------|----------|----------|
-| 36 | `--toolchain-path` sets explicit flag | `--toolchain-path cmake/x86_64-linux-gcc-toolchain.cmake --configure-only` (no clang++-20) | Uses `gcc-toolchain`, NO auto-detect override | `toolchain_path_explicitly_set=true` |
-| 37 | Default has explicit flag false | `--configure-only` (with clang++-20) | Uses default `clang-20-libstdcpp` | `toolchain_path_explicitly_set=false` |
+| 36 | `--toolchain-path` sets explicit flag | `--toolchain-path cmake/x86_64-linux-gcc-toolchain.cmake --configure-only` (no clang++-20) | Uses `gcc-toolchain`, NO auto-detect override | `toolchain_path_explicitly_set=true` (line 257) |
+| 37 | Default has explicit flag false | `--configure-only` (with clang++-20) | Uses default `clang-20-libstdcpp` | `toolchain_path_explicitly_set=false` (line 135) |
 
 ## Coverage Summary
 
 | Code section | Lines | Tests |
 |-------------|-------|-------|
-| `--compiler clang` search | 231–250 | 1–6, 30–31 |
-| `--compiler gcc` search | 251–271 | 7–11, 32–33 |
-| `--compiler` pinned versions | 272–279 | 12–15 |
-| `--compiler` error (unknown) | 280–283 | 16 |
-| Auto-detect: clang++-20 present | 288 | 17 |
-| Auto-detect: clang fallback | 289–305 | 18–21 |
-| Auto-detect: gcc fallback | 306–323 | 22–25 |
-| Auto-detect: nothing found | 324–326 | 26 |
-| Auto-detect: guard conditions | 288 | 27–29 |
-| `--toolchain-path` explicit flag | 208 | 28–29, 36–37 |
-| Help text | 53 | 34 |
+| `toolchain_for()` lookup | 19–28 | 1, 5, 7, 9–10, 21–22, 24–25 |
+| `find_compiler()` search | 32–40 | 1–11, 18–26, 30–33 |
+| `use_compiler()` toolchain path | 44–49 | 1, 5, 7, 9–10, 21–22, 24–25 |
+| `use_compiler()` direct path | 50–60 | 2–4, 8, 18–20, 23 |
+| `--compiler clang` case | 277–281 | 1–6, 30–31 |
+| `--compiler gcc` case | 282–286 | 7–11, 32–33 |
+| `--compiler` pinned versions | 287–290 | 12–15 |
+| `--compiler` error (unknown) | 291–294 | 16 |
+| Auto-detect: clang++-20 present | 299–300 | 17 |
+| Auto-detect: compiler fallback | 301–306 | 18–25 |
+| Auto-detect: nothing found | 302–303 | 26 |
+| Auto-detect: guard conditions | 299 | 27–29 |
+| `--toolchain-path` explicit flag | 135, 257 | 28–29, 36–37 |
+| Help text | 94 | 34 |
 | CMakePresets.json | — | 35 |
 | **Total** | | **37 tests** |

--- a/test-plan-compiler-flag.md
+++ b/test-plan-compiler-flag.md
@@ -1,0 +1,152 @@
+# Test Plan: `--compiler` flag and auto-detection in `build_metal.sh`
+
+Issue: [#37907](https://github.com/tenstorrent/tt-metal/issues/37907)
+Branch: `ivoitovych/issue-37907-fix-fedora-toolchain-selection`
+
+## Overview
+
+This test plan achieves 100% branch coverage for all code paths introduced by the
+`--compiler` flag, compiler-to-toolchain mapping, and auto-detection fallback in
+`build_metal.sh`.
+
+All tests use `--configure-only` to avoid actual builds. Compiler visibility is
+controlled via `PATH` manipulation using temporary directories with fake compiler
+scripts.
+
+## Test Setup
+
+```bash
+# Create temp directory with fake compiler stubs
+FAKE_DIR=$(mktemp -d)
+EMPTY_DIR=$(mktemp -d)  # empty = no compilers at all
+
+# Create a fake compiler stub (repeat for each needed binary)
+create_fake() {
+    echo '#!/bin/sh' > "$FAKE_DIR/$1"
+    echo 'echo "fake $1"' >> "$FAKE_DIR/$1"
+    chmod +x "$FAKE_DIR/$1"
+}
+
+# Minimal PATH with only system essentials (bash, getopt, cmake, python3, etc.)
+# but no compilers. Adjust per system.
+SYSTEM_BIN="/usr/bin:/bin"
+
+# To hide all real compilers, prepend FAKE_DIR (with only desired stubs) to a
+# compiler-free base PATH. To hide everything, use EMPTY_DIR only.
+```
+
+## Section 1: `--compiler` flag — Clang search (lines 231–250)
+
+| # | Test | PATH setup | Command | Expected output | Lines |
+|---|------|-----------|---------|-----------------|-------|
+| 1 | `--compiler clang` finds clang++-20 | Normal (has clang++-20) | `--compiler clang --configure-only` | `INFO: --compiler clang: found clang++-20`, TOOLCHAIN_FILE=`clang-20-libstdcpp` | 246 |
+| 2 | `--compiler clang` finds clang++-19 | Fake clang++-19 only, no clang++-20 | `--compiler clang --configure-only` | `found clang++-19`, CMAKE_CXX_COMPILER=`.../clang++-19` | 248–249 |
+| 3 | `--compiler clang` finds clang++-18 | Fake clang++-18 only | `--compiler clang --configure-only` | `found clang++-18`, CMAKE_CXX_COMPILER | 248–249 |
+| 4 | `--compiler clang` finds clang++-17 | Fake clang++-17 only | `--compiler clang --configure-only` | `found clang++-17`, CMAKE_CXX_COMPILER | 248–249 |
+| 5 | `--compiler clang` finds unversioned clang++ | Fake clang++ only (no versioned) | `--compiler clang --configure-only` | `found clang++`, TOOLCHAIN_FILE=`clang-libstdcpp` | 247 |
+| 6 | `--compiler clang` finds nothing | Empty PATH (no compilers) | `--compiler clang --configure-only` | `ERROR: No clang++ found in PATH.`, exit 1 | 241–242 |
+
+## Section 2: `--compiler` flag — GCC search (lines 254–271)
+
+| # | Test | PATH setup | Command | Expected output | Lines |
+|---|------|-----------|---------|-----------------|-------|
+| 7 | `--compiler gcc` finds g++-14 | Fake g++-14 | `--compiler gcc --configure-only` | `found g++-14`, TOOLCHAIN_FILE=`gcc-14` | 266 |
+| 8 | `--compiler gcc` finds g++-13 | Fake g++-13, no g++-14 | `--compiler gcc --configure-only` | `found g++-13`, CMAKE_CXX_COMPILER=`.../g++-13` | 269–270 |
+| 9 | `--compiler gcc` finds g++-12 | Fake g++-12, no g++-14/13 | `--compiler gcc --configure-only` | `found g++-12`, TOOLCHAIN_FILE=`gcc-12` | 267 |
+| 10 | `--compiler gcc` finds unversioned g++ | Fake g++ only | `--compiler gcc --configure-only` | `found g++`, TOOLCHAIN_FILE=`gcc` | 268 |
+| 11 | `--compiler gcc` finds nothing | Empty PATH (no compilers) | `--compiler gcc --configure-only` | `ERROR: No g++ found in PATH.`, exit 1 | 260–262 |
+
+## Section 3: `--compiler` flag — Pinned versions (lines 272–279)
+
+| # | Test | PATH setup | Command | Expected output | Lines |
+|---|------|-----------|---------|-----------------|-------|
+| 12 | `--compiler clang-20` | Normal | `--compiler clang-20 --configure-only` | TOOLCHAIN_FILE=`clang-20-libstdcpp` | 273 |
+| 13 | `--compiler clang-20-libcpp` | Normal | `--compiler clang-20-libcpp --configure-only` | TOOLCHAIN_FILE=`clang-20-libcpp` | 274 |
+| 14 | `--compiler gcc-12` | Normal | `--compiler gcc-12 --configure-only` | TOOLCHAIN_FILE=`gcc-12` | 277 |
+| 15 | `--compiler gcc-14` | Normal | `--compiler gcc-14 --configure-only` | TOOLCHAIN_FILE=`gcc-14` | 278 |
+
+## Section 4: `--compiler` flag — Error handling (lines 280–283)
+
+| # | Test | PATH setup | Command | Expected output | Lines |
+|---|------|-----------|---------|-----------------|-------|
+| 16 | `--compiler foobar` (unknown) | Normal | `--compiler foobar --configure-only` | `ERROR: Unknown compiler 'foobar'`, help text, exit 1 | 280–283 |
+
+## Section 5: Auto-detection fallback — Clang found (lines 287–305)
+
+These tests run with NO `--compiler`, `--cxx-compiler-path`, or `--toolchain-path` flags.
+
+| # | Test | PATH setup | Command | Expected output | Lines |
+|---|------|-----------|---------|-----------------|-------|
+| 17 | No fallback (clang++-20 present) | Normal (has clang++-20) | `--configure-only` | TOOLCHAIN_FILE=`clang-20-libstdcpp`, NO warning | 288 (guard false) |
+| 18 | Fallback finds clang++-19 | Fake clang++-19, no clang++-20 | `--configure-only` | `WARNING`, `Auto-selected clang++-19`, CMAKE_CXX_COMPILER | 302–303 |
+| 19 | Fallback finds clang++-18 | Fake clang++-18 only | `--configure-only` | `Auto-selected clang++-18`, CMAKE_CXX_COMPILER | 302–303 |
+| 20 | Fallback finds clang++-17 | Fake clang++-17 only | `--configure-only` | `Auto-selected clang++-17`, CMAKE_CXX_COMPILER | 302–303 |
+| 21 | Fallback finds unversioned clang++ | Fake clang++ only | `--configure-only` | `Auto-selected clang++`, TOOLCHAIN_FILE=`clang-libstdcpp` | 301 |
+
+## Section 6: Auto-detection fallback — No Clang, GCC found (lines 306–323)
+
+| # | Test | PATH setup | Command | Expected output | Lines |
+|---|------|-----------|---------|-----------------|-------|
+| 22 | Fallback finds g++-14 (no clang) | Fake g++-14, no clang at all | `--configure-only` | `WARNING`, `Auto-selected g++-14`, TOOLCHAIN_FILE=`gcc-14` | 317 |
+| 23 | Fallback finds g++-13 (no clang) | Fake g++-13 only | `--configure-only` | `Auto-selected g++-13`, CMAKE_CXX_COMPILER | 320–321 |
+| 24 | Fallback finds g++-12 (no clang) | Fake g++-12 only | `--configure-only` | `Auto-selected g++-12`, TOOLCHAIN_FILE=`gcc-12` | 318 |
+| 25 | Fallback finds unversioned g++ (no clang) | Fake g++ only | `--configure-only` | `Auto-selected g++`, TOOLCHAIN_FILE=`gcc` | 319 |
+
+## Section 7: Auto-detection fallback — Nothing found (lines 324–326)
+
+| # | Test | PATH setup | Command | Expected output | Lines |
+|---|------|-----------|---------|-----------------|-------|
+| 26 | Fallback finds nothing | Empty PATH (no compilers) | `--configure-only` | `WARNING`, `ERROR: No C++ compiler found.`, exit 1 | 325–326 |
+
+## Section 8: Auto-detection guard conditions (line 288)
+
+These verify that auto-detection is skipped when any explicit override is set.
+All tests run WITHOUT clang++-20 in PATH to ensure the fallback would trigger
+if the guard didn't prevent it.
+
+| # | Test | Command | Expected output | Guard |
+|---|------|---------|-----------------|-------|
+| 27 | `--compiler` set skips auto-detect | `--compiler clang-20 --configure-only` | TOOLCHAIN_FILE=`clang-20`, NO warning | `compiler != ""` |
+| 28 | `--cxx-compiler-path` set skips auto-detect | `--cxx-compiler-path /usr/bin/g++ --configure-only` | CMAKE_CXX_COMPILER=`/usr/bin/g++`, NO warning | `cxx_compiler_path != ""` |
+| 29 | `--toolchain-path` set skips auto-detect | `--toolchain-path cmake/x86_64-linux-gcc-14-toolchain.cmake --configure-only` | TOOLCHAIN_FILE=`gcc-14`, NO warning | `toolchain_path_explicitly_set = true` |
+
+## Section 9: Search priority ordering (lines 234, 254)
+
+| # | Test | PATH setup | Expected | Verifies |
+|---|------|-----------|----------|----------|
+| 30 | clang++-20 preferred over clang++-19 | Both clang++-20 and clang++-19 present | `found clang++-20` | Descending order |
+| 31 | clang++-18 preferred over clang++ | Both clang++-18 and clang++ present | `found clang++-18` | Versioned before unversioned |
+| 32 | g++-14 preferred over g++-13 | Both g++-14 and g++-13 present | `found g++-14` | Descending order |
+| 33 | g++-12 preferred over g++ | Both g++-12 and g++ present | `found g++-12` | Versioned before unversioned |
+
+## Section 10: Help text and CMake presets
+
+| # | Test | Command | Expected |
+|---|------|---------|----------|
+| 34 | `--help` shows `--compiler` | `build_metal.sh --help` | Output contains `--compiler compiler_name` and lists `clang`, `gcc` |
+| 35 | CMakePresets.json valid | `cmake --list-presets 2>&1` | Output lists `gcc-system` and `clang-system` presets |
+
+## Section 11: `--toolchain-path` protection flag (line 208)
+
+| # | Test | Command | Expected | Verifies |
+|---|------|---------|----------|----------|
+| 36 | `--toolchain-path` sets explicit flag | `--toolchain-path cmake/x86_64-linux-gcc-toolchain.cmake --configure-only` (no clang++-20) | Uses `gcc-toolchain`, NO auto-detect override | `toolchain_path_explicitly_set=true` |
+| 37 | Default has explicit flag false | `--configure-only` (with clang++-20) | Uses default `clang-20-libstdcpp` | `toolchain_path_explicitly_set=false` |
+
+## Coverage Summary
+
+| Code section | Lines | Tests |
+|-------------|-------|-------|
+| `--compiler clang` search | 231–250 | 1–6, 30–31 |
+| `--compiler gcc` search | 251–271 | 7–11, 32–33 |
+| `--compiler` pinned versions | 272–279 | 12–15 |
+| `--compiler` error (unknown) | 280–283 | 16 |
+| Auto-detect: clang++-20 present | 288 | 17 |
+| Auto-detect: clang fallback | 289–305 | 18–21 |
+| Auto-detect: gcc fallback | 306–323 | 22–25 |
+| Auto-detect: nothing found | 324–326 | 26 |
+| Auto-detect: guard conditions | 288 | 27–29 |
+| `--toolchain-path` explicit flag | 208 | 28–29, 36–37 |
+| Help text | 53 | 34 |
+| CMakePresets.json | — | 35 |
+| **Total** | | **37 tests** |

--- a/test-plan-compiler-flag.md
+++ b/test-plan-compiler-flag.md
@@ -7,8 +7,9 @@ Branch: `ivoitovych/issue-37907-fix-fedora-toolchain-selection`
 
 This test plan covers all code paths introduced by the `--compiler` flag,
 compiler-to-toolchain mapping, and auto-detection fallback in `build_metal.sh`
-(tests 1–37, 59–60), and the `--compiler` flag, `prep_redhat_system()`, `install_llvm()`
-rewrite, and warning fixes in `install_dependencies.sh` (tests 38–58).
+(tests 1–41), and the `--compiler` flag, `prep_redhat_system()`, `install_llvm()`
+rewrite, LLVM tarball installation, versioned GCC installation, and warning fixes
+in `install_dependencies.sh` (tests 42–68).
 
 `build_metal.sh` tests use `--configure-only` and PATH manipulation.
 `install_dependencies.sh` tests run in Docker containers (require root).
@@ -45,76 +46,81 @@ SYSTEM_BIN="/usr/bin:/bin"
 |--------|-------|---------|
 | `CLANG_SEARCH` | 18 | Clang binary search order |
 | `GCC_SEARCH` | 19 | GCC binary search order |
-| `BINARY_TOOLCHAIN` | 23–31 | Binary name → toolchain ID map |
-| `FLAG_TOOLCHAIN` | 34–39 | CLI flag → toolchain ID map |
-| `toolchain_file()` | 42–44 | Toolchain ID → full cmake path |
-| `find_compiler()` | 48–56 | Find first available binary from candidate list |
-| `use_compiler()` | 60–76 | Set `toolchain_path` or `cxx/c_compiler_path` |
+| `BINARY_TOOLCHAIN` | 23–33 | Binary name → toolchain ID map (10 entries) |
+| `COMPILER_FLAGS` | 36 | Valid `--compiler` flag values |
+| `FLAG_TOOLCHAIN` | 39–48 | CLI flag → toolchain ID map (8 entries) |
+| `toolchain_file()` | 51–53 | Toolchain ID → full cmake path |
+| `find_compiler()` | 57–65 | Find first available binary from candidate list |
+| `use_compiler()` | 69–89 | Set `toolchain_path` or `cxx/c_compiler_path` |
 
-## Section 1: `--compiler` flag — Clang search (lines 292–296)
-
-| # | Test | PATH setup | Command | Expected output | Lines |
-|---|------|-----------|---------|-----------------|-------|
-| 1 | `--compiler clang` finds clang++-20 | Normal (has clang++-20) | `--compiler clang --configure-only` | `INFO: --compiler clang: found clang++-20`, TOOLCHAIN_FILE=`clang-20-libstdcpp` | 293, 296 → BINARY_TOOLCHAIN:24 |
-| 2 | `--compiler clang` finds clang++-19 | Fake clang++-19 only, no clang++-20 | `--compiler clang --configure-only` | `found clang++-19`, CMAKE_CXX_COMPILER=`.../clang++-19` | 293, 296 → use_compiler:66 |
-| 3 | `--compiler clang` finds clang++-18 | Fake clang++-18 only | `--compiler clang --configure-only` | `found clang++-18`, CMAKE_CXX_COMPILER | 293, 296 → use_compiler:66 |
-| 4 | `--compiler clang` finds clang++-17 | Fake clang++-17 only | `--compiler clang --configure-only` | `found clang++-17`, CMAKE_CXX_COMPILER | 293, 296 → use_compiler:66 |
-| 5 | `--compiler clang` finds unversioned clang++ | Fake clang++ only (no versioned) | `--compiler clang --configure-only` | `found clang++`, TOOLCHAIN_FILE=`clang-libstdcpp` | 293, 296 → BINARY_TOOLCHAIN:25 |
-| 6 | `--compiler clang` finds nothing | Empty PATH (no compilers) | `--compiler clang --configure-only` | `ERROR: No clang++ found in PATH.`, exit 1 | 293–294 |
-
-## Section 2: `--compiler` flag — GCC search (lines 297–301)
+## Section 1: `--compiler` flag — Clang search (lines 310–314)
 
 | # | Test | PATH setup | Command | Expected output | Lines |
 |---|------|-----------|---------|-----------------|-------|
-| 7 | `--compiler gcc` finds g++-14 | Fake g++-14 | `--compiler gcc --configure-only` | `found g++-14`, TOOLCHAIN_FILE=`gcc-14` | 298, 301 → BINARY_TOOLCHAIN:26 |
-| 8 | `--compiler gcc` finds g++-13 | Fake g++-13, no g++-14 | `--compiler gcc --configure-only` | `found g++-13`, CMAKE_CXX_COMPILER=`.../g++-13` | 298, 301 → use_compiler:66 |
-| 9 | `--compiler gcc` finds g++-12 | Fake g++-12, no g++-14/13 | `--compiler gcc --configure-only` | `found g++-12`, TOOLCHAIN_FILE=`gcc-12` | 298, 301 → BINARY_TOOLCHAIN:27 |
-| 10 | `--compiler gcc` finds unversioned g++ | Fake g++ only | `--compiler gcc --configure-only` | `found g++`, TOOLCHAIN_FILE=`gcc` | 298, 301 → BINARY_TOOLCHAIN:28 |
-| 11 | `--compiler gcc` finds nothing | Empty PATH (no compilers) | `--compiler gcc --configure-only` | `ERROR: No g++ found in PATH.`, exit 1 | 298–299 |
+| 1 | `--compiler clang` finds clang++-20 | Normal (has clang++-20) | `--compiler clang --configure-only` | `INFO: --compiler clang: found clang++-20`, TOOLCHAIN_FILE=`clang-20-libstdcpp` | 311, 314 → BINARY_TOOLCHAIN:24 |
+| 2 | `--compiler clang` finds clang++-19 | Fake clang++-19 only, no clang++-20 | `--compiler clang --configure-only` | `found clang++-19`, TOOLCHAIN_FILE=`clang-19-libstdcpp` | 311, 314 → BINARY_TOOLCHAIN:25 |
+| 3 | `--compiler clang` finds clang++-18 | Fake clang++-18 only | `--compiler clang --configure-only` | `found clang++-18`, TOOLCHAIN_FILE=`clang-18-libstdcpp` | 311, 314 → BINARY_TOOLCHAIN:26 |
+| 4 | `--compiler clang` finds clang++-17 | Fake clang++-17 only | `--compiler clang --configure-only` | `found clang++-17`, TOOLCHAIN_FILE=`clang-17-libstdcpp` | 311, 314 → BINARY_TOOLCHAIN:27 |
+| 5 | `--compiler clang` finds unversioned clang++ | Fake clang++ only (no versioned) | `--compiler clang --configure-only` | `found clang++`, TOOLCHAIN_FILE=`clang-libstdcpp` | 311, 314 → BINARY_TOOLCHAIN:28 |
+| 6 | `--compiler clang` finds nothing | Empty PATH (no compilers) | `--compiler clang --configure-only` | `ERROR: No clang++ found in PATH.`, exit 1 | 311–312 |
 
-## Section 3: `--compiler` flag — Pinned versions (lines 302–304)
-
-| # | Test | PATH setup | Command | Expected output | Lines |
-|---|------|-----------|---------|-----------------|-------|
-| 12 | `--compiler clang-20` | Normal | `--compiler clang-20 --configure-only` | TOOLCHAIN_FILE=`clang-20-libstdcpp` | 303–304, FLAG_TOOLCHAIN:35 |
-| 13 | `--compiler clang-20-libcpp` | Normal | `--compiler clang-20-libcpp --configure-only` | TOOLCHAIN_FILE=`clang-20-libcpp` | 303–304, FLAG_TOOLCHAIN:36 |
-| 14 | `--compiler gcc-12` | Normal | `--compiler gcc-12 --configure-only` | TOOLCHAIN_FILE=`gcc-12` | 303–304, FLAG_TOOLCHAIN:38 |
-| 15 | `--compiler gcc-14` | Normal | `--compiler gcc-14 --configure-only` | TOOLCHAIN_FILE=`gcc-14` | 303–304, FLAG_TOOLCHAIN:37 |
-
-## Section 4: `--compiler` flag — Error handling (lines 305–309)
+## Section 2: `--compiler` flag — GCC search (lines 315–319)
 
 | # | Test | PATH setup | Command | Expected output | Lines |
 |---|------|-----------|---------|-----------------|-------|
-| 16 | `--compiler foobar` (unknown) | Normal | `--compiler foobar --configure-only` | `ERROR: Unknown compiler 'foobar'`, help text, exit 1 | 305–309 |
+| 7 | `--compiler gcc` finds g++-14 | Fake g++-14 | `--compiler gcc --configure-only` | `found g++-14`, TOOLCHAIN_FILE=`gcc-14` | 316, 319 → BINARY_TOOLCHAIN:29 |
+| 8 | `--compiler gcc` finds g++-13 | Fake g++-13, no g++-14 | `--compiler gcc --configure-only` | `found g++-13`, TOOLCHAIN_FILE=`gcc-13` | 316, 319 → BINARY_TOOLCHAIN:30 |
+| 9 | `--compiler gcc` finds g++-12 | Fake g++-12, no g++-14/13 | `--compiler gcc --configure-only` | `found g++-12`, TOOLCHAIN_FILE=`gcc-12` | 316, 319 → BINARY_TOOLCHAIN:31 |
+| 10 | `--compiler gcc` finds unversioned g++ | Fake g++ only | `--compiler gcc --configure-only` | `found g++`, TOOLCHAIN_FILE=`gcc` | 316, 319 → BINARY_TOOLCHAIN:32 |
+| 11 | `--compiler gcc` finds nothing | Empty PATH (no compilers) | `--compiler gcc --configure-only` | `ERROR: No g++ found in PATH.`, exit 1 | 316–317 |
 
-## Section 5: Auto-detection fallback — Clang found (lines 313–322)
+## Section 3: `--compiler` flag — Pinned versions (lines 320–322)
+
+| # | Test | PATH setup | Command | Expected output | Lines |
+|---|------|-----------|---------|-----------------|-------|
+| 12 | `--compiler clang-20` | Normal | `--compiler clang-20 --configure-only` | TOOLCHAIN_FILE=`clang-20-libstdcpp` | 321–322, FLAG_TOOLCHAIN:40 |
+| 13 | `--compiler clang-19` | Normal | `--compiler clang-19 --configure-only` | TOOLCHAIN_FILE=`clang-19-libstdcpp` | 321–322, FLAG_TOOLCHAIN:41 |
+| 14 | `--compiler clang-18` | Normal | `--compiler clang-18 --configure-only` | TOOLCHAIN_FILE=`clang-18-libstdcpp` | 321–322, FLAG_TOOLCHAIN:42 |
+| 15 | `--compiler clang-17` | Normal | `--compiler clang-17 --configure-only` | TOOLCHAIN_FILE=`clang-17-libstdcpp` | 321–322, FLAG_TOOLCHAIN:43 |
+| 16 | `--compiler clang-20-libcpp` | Normal | `--compiler clang-20-libcpp --configure-only` | TOOLCHAIN_FILE=`clang-20-libcpp` | 321–322, FLAG_TOOLCHAIN:44 |
+| 17 | `--compiler gcc-14` | Normal | `--compiler gcc-14 --configure-only` | TOOLCHAIN_FILE=`gcc-14` | 321–322, FLAG_TOOLCHAIN:45 |
+| 18 | `--compiler gcc-13` | Normal | `--compiler gcc-13 --configure-only` | TOOLCHAIN_FILE=`gcc-13` | 321–322, FLAG_TOOLCHAIN:46 |
+| 19 | `--compiler gcc-12` | Normal | `--compiler gcc-12 --configure-only` | TOOLCHAIN_FILE=`gcc-12` | 321–322, FLAG_TOOLCHAIN:47 |
+
+## Section 4: `--compiler` flag — Error handling (lines 323–327)
+
+| # | Test | PATH setup | Command | Expected output | Lines |
+|---|------|-----------|---------|-----------------|-------|
+| 20 | `--compiler foobar` (unknown) | Normal | `--compiler foobar --configure-only` | `ERROR: Unknown compiler 'foobar'`, help text, exit 1 | 323–327 |
+
+## Section 5: Auto-detection fallback — Clang found (lines 331–340)
 
 These tests run with NO `--compiler`, `--cxx-compiler-path`, or `--toolchain-path` flags.
 
 | # | Test | PATH setup | Command | Expected output | Lines |
 |---|------|-----------|---------|-----------------|-------|
-| 17 | No fallback (clang++-20 present) | Normal (has clang++-20) | `--configure-only` | TOOLCHAIN_FILE=`clang-20-libstdcpp`, NO warning | 315 (guard false) |
-| 18 | Fallback finds clang++-19 | Fake clang++-19, no clang++-20 | `--configure-only` | `WARNING`, `Auto-selected clang++-19`, CMAKE_CXX_COMPILER | 317, 320 → use_compiler:66 |
-| 19 | Fallback finds clang++-18 | Fake clang++-18 only | `--configure-only` | `Auto-selected clang++-18`, CMAKE_CXX_COMPILER | 317, 320 → use_compiler:66 |
-| 20 | Fallback finds clang++-17 | Fake clang++-17 only | `--configure-only` | `Auto-selected clang++-17`, CMAKE_CXX_COMPILER | 317, 320 → use_compiler:66 |
-| 21 | Fallback finds unversioned clang++ | Fake clang++ only | `--configure-only` | `Auto-selected clang++`, TOOLCHAIN_FILE=`clang-libstdcpp` | 317, 320 → BINARY_TOOLCHAIN:25 |
+| 21 | No fallback (clang++-20 present) | Normal (has clang++-20) | `--configure-only` | TOOLCHAIN_FILE=`clang-20-libstdcpp`, NO warning | 333 (guard false) |
+| 22 | Fallback finds clang++-19 | Fake clang++-19, no clang++-20 | `--configure-only` | `WARNING`, `Auto-selected clang++-19`, TOOLCHAIN_FILE=`clang-19-libstdcpp` | 335, 338 → BINARY_TOOLCHAIN:25 |
+| 23 | Fallback finds clang++-18 | Fake clang++-18 only | `--configure-only` | `Auto-selected clang++-18`, TOOLCHAIN_FILE=`clang-18-libstdcpp` | 335, 338 → BINARY_TOOLCHAIN:26 |
+| 24 | Fallback finds clang++-17 | Fake clang++-17 only | `--configure-only` | `Auto-selected clang++-17`, TOOLCHAIN_FILE=`clang-17-libstdcpp` | 335, 338 → BINARY_TOOLCHAIN:27 |
+| 25 | Fallback finds unversioned clang++ | Fake clang++ only | `--configure-only` | `Auto-selected clang++`, TOOLCHAIN_FILE=`clang-libstdcpp` | 335, 338 → BINARY_TOOLCHAIN:28 |
 
-## Section 6: Auto-detection fallback — No Clang, GCC found (lines 313–322)
-
-| # | Test | PATH setup | Command | Expected output | Lines |
-|---|------|-----------|---------|-----------------|-------|
-| 22 | Fallback finds g++-14 (no clang) | Fake g++-14, no clang at all | `--configure-only` | `WARNING`, `Auto-selected g++-14`, TOOLCHAIN_FILE=`gcc-14` | 317, 320 → BINARY_TOOLCHAIN:26 |
-| 23 | Fallback finds g++-13 (no clang) | Fake g++-13 only | `--configure-only` | `Auto-selected g++-13`, CMAKE_CXX_COMPILER | 317, 320 → use_compiler:66 |
-| 24 | Fallback finds g++-12 (no clang) | Fake g++-12 only | `--configure-only` | `Auto-selected g++-12`, TOOLCHAIN_FILE=`gcc-12` | 317, 320 → BINARY_TOOLCHAIN:27 |
-| 25 | Fallback finds unversioned g++ (no clang) | Fake g++ only | `--configure-only` | `Auto-selected g++`, TOOLCHAIN_FILE=`gcc` | 317, 320 → BINARY_TOOLCHAIN:28 |
-
-## Section 7: Auto-detection fallback — Nothing found (lines 317–318)
+## Section 6: Auto-detection fallback — No Clang, GCC found (lines 331–340)
 
 | # | Test | PATH setup | Command | Expected output | Lines |
 |---|------|-----------|---------|-----------------|-------|
-| 26 | Fallback finds nothing | Empty PATH (no compilers) | `--configure-only` | `WARNING`, `ERROR: No C++ compiler found.`, exit 1 | 317–318 |
+| 26 | Fallback finds g++-14 (no clang) | Fake g++-14, no clang at all | `--configure-only` | `WARNING`, `Auto-selected g++-14`, TOOLCHAIN_FILE=`gcc-14` | 335, 338 → BINARY_TOOLCHAIN:29 |
+| 27 | Fallback finds g++-13 (no clang) | Fake g++-13 only | `--configure-only` | `Auto-selected g++-13`, TOOLCHAIN_FILE=`gcc-13` | 335, 338 → BINARY_TOOLCHAIN:30 |
+| 28 | Fallback finds g++-12 (no clang) | Fake g++-12 only | `--configure-only` | `Auto-selected g++-12`, TOOLCHAIN_FILE=`gcc-12` | 335, 338 → BINARY_TOOLCHAIN:31 |
+| 29 | Fallback finds unversioned g++ (no clang) | Fake g++ only | `--configure-only` | `Auto-selected g++`, TOOLCHAIN_FILE=`gcc` | 335, 338 → BINARY_TOOLCHAIN:32 |
 
-## Section 8: Auto-detection guard conditions (line 314)
+## Section 7: Auto-detection fallback — Nothing found (lines 335–336)
+
+| # | Test | PATH setup | Command | Expected output | Lines |
+|---|------|-----------|---------|-----------------|-------|
+| 30 | Fallback finds nothing | Empty PATH (no compilers) | `--configure-only` | `WARNING`, `ERROR: No C++ compiler found.`, exit 1 | 335–336 |
+
+## Section 8: Auto-detection guard conditions (line 332)
 
 These verify that auto-detection is skipped when any explicit override is set.
 All tests run WITHOUT clang++-20 in PATH to ensure the fallback would trigger
@@ -122,32 +128,32 @@ if the guard didn't prevent it.
 
 | # | Test | Command | Expected output | Guard |
 |---|------|---------|-----------------|-------|
-| 27 | `--compiler` set skips auto-detect | `--compiler clang-20 --configure-only` | TOOLCHAIN_FILE=`clang-20`, NO warning | `compiler != ""` |
-| 28 | `--cxx-compiler-path` set skips auto-detect | `--cxx-compiler-path /usr/bin/g++ --configure-only` | CMAKE_CXX_COMPILER=`/usr/bin/g++`, NO warning | `cxx_compiler_path != ""` |
-| 29 | `--toolchain-path` set skips auto-detect | `--toolchain-path cmake/x86_64-linux-gcc-14-toolchain.cmake --configure-only` | TOOLCHAIN_FILE=`gcc-14`, NO warning | `toolchain_path_explicitly_set = true` |
+| 31 | `--compiler` set skips auto-detect | `--compiler clang-20 --configure-only` | TOOLCHAIN_FILE=`clang-20-libstdcpp`, NO warning | `compiler != ""` |
+| 32 | `--cxx-compiler-path` set skips auto-detect | `--cxx-compiler-path /usr/bin/g++ --configure-only` | CMAKE_CXX_COMPILER=`/usr/bin/g++`, NO warning | `cxx_compiler_path != ""` |
+| 33 | `--toolchain-path` set skips auto-detect | `--toolchain-path cmake/x86_64-linux-gcc-14-toolchain.cmake --configure-only` | TOOLCHAIN_FILE=`gcc-14`, NO warning | `toolchain_path_explicitly_set = true` |
 
-## Section 9: Search priority ordering (lines 18–19, via 293, 298)
+## Section 9: Search priority ordering (lines 18–19, via 311, 316)
 
 | # | Test | PATH setup | Expected | Verifies |
 |---|------|-----------|----------|----------|
-| 30 | clang++-20 preferred over clang++-19 | Both clang++-20 and clang++-19 present | `found clang++-20` | CLANG_SEARCH descending order |
-| 31 | clang++-18 preferred over clang++ | Both clang++-18 and clang++ present | `found clang++-18` | Versioned before unversioned |
-| 32 | g++-14 preferred over g++-13 | Both g++-14 and g++-13 present | `found g++-14` | GCC_SEARCH descending order |
-| 33 | g++-12 preferred over g++ | Both g++-12 and g++ present | `found g++-12` | Versioned before unversioned |
+| 34 | clang++-20 preferred over clang++-19 | Both clang++-20 and clang++-19 present | `found clang++-20` | CLANG_SEARCH descending order |
+| 35 | clang++-18 preferred over clang++ | Both clang++-18 and clang++ present | `found clang++-18` | Versioned before unversioned |
+| 36 | g++-14 preferred over g++-13 | Both g++-14 and g++-13 present | `found g++-14` | GCC_SEARCH descending order |
+| 37 | g++-12 preferred over g++ | Both g++-12 and g++ present | `found g++-12` | Versioned before unversioned |
 
 ## Section 10: Help text and CMake presets
 
 | # | Test | Command | Expected |
 |---|------|---------|----------|
-| 34 | `--help` shows `--compiler` | `build_metal.sh --help` | Output contains `--compiler compiler_name` and lists `clang`, `gcc` |
-| 35 | CMakePresets.json valid | `cmake --list-presets 2>&1` | Output lists `gcc-system` and `clang-system` presets |
+| 38 | `--help` shows `--compiler` | `build_metal.sh --help` | Output contains `--compiler compiler_name` and lists `clang`, `gcc` |
+| 39 | CMakePresets.json valid | `cmake --list-presets 2>&1` | Output lists `gcc-system`, `gcc-13`, `clang-system`, `clang-19`, `clang-18`, `clang-17` presets |
 
-## Section 11: `--toolchain-path` protection flag (line 272)
+## Section 11: `--toolchain-path` protection flag (line 290)
 
 | # | Test | Command | Expected | Verifies |
 |---|------|---------|----------|----------|
-| 36 | `--toolchain-path` sets explicit flag | `--toolchain-path cmake/x86_64-linux-gcc-toolchain.cmake --configure-only` (no clang++-20) | Uses `gcc-toolchain`, NO auto-detect override | `toolchain_path_explicitly_set=true` (line 272) |
-| 37 | Default has explicit flag false | `--configure-only` (with clang++-20) | Uses default `clang-20-libstdcpp` | `toolchain_path_explicitly_set=false` (line 150) |
+| 40 | `--toolchain-path` sets explicit flag | `--toolchain-path cmake/x86_64-linux-gcc-toolchain.cmake --configure-only` (no clang++-20) | Uses `gcc-toolchain`, NO auto-detect override | `toolchain_path_explicitly_set=true` (line 290) |
+| 41 | Default has explicit flag false | `--configure-only` (with clang++-20) | Uses default `clang-20-libstdcpp` | `toolchain_path_explicitly_set=false` (line 165) |
 
 ---
 
@@ -161,64 +167,73 @@ WARNING, ERROR).
 
 | # | Test | Container | Command | Expected output |
 |---|------|-----------|---------|-----------------|
-| 38 | Valid `--compiler clang` | Ubuntu 22.04 | `./install_dependencies.sh --docker --compiler clang` | `[INFO] Compiler selection: clang`, LLVM 20 installed |
-| 39 | Valid `--compiler gcc` | Ubuntu 22.04 | `./install_dependencies.sh --docker --compiler gcc` | `[INFO] Compiler selection: gcc`, `[INFO] Skipping LLVM installation (--compiler gcc)` |
-| 40 | Valid `--compiler clang-20` | Ubuntu 22.04 | `./install_dependencies.sh --docker --compiler clang-20` | `[INFO] Compiler selection: clang-20`, LLVM 20 installed |
-| 41 | Valid `--compiler gcc-14` | Ubuntu 22.04 | `./install_dependencies.sh --docker --compiler gcc-14` | `[INFO] Compiler selection: gcc-14`, `[INFO] Skipping LLVM installation (--compiler gcc-14)` |
-| 42 | Invalid `--compiler foobar` | Ubuntu 22.04 | `./install_dependencies.sh --docker --compiler foobar` | `[ERROR] Unknown compiler 'foobar'. Allowed: clang gcc clang-20 clang-20-libcpp gcc-12 gcc-14.`, exit 1 |
-| 43 | Default (no --compiler) | Ubuntu 22.04 | `./install_dependencies.sh --docker` | LLVM 20 installed, no `[INFO] Compiler selection` |
+| 42 | Valid `--compiler clang` | Ubuntu 22.04 | `./install_dependencies.sh --docker --compiler clang` | `[INFO] Compiler selection: clang`, LLVM 20 installed |
+| 43 | Valid `--compiler gcc` | Ubuntu 22.04 | `./install_dependencies.sh --docker --compiler gcc` | `[INFO] Compiler selection: gcc`, `[INFO] Skipping LLVM installation (--compiler gcc)` |
+| 44 | Valid `--compiler clang-20` | Ubuntu 22.04 | `./install_dependencies.sh --docker --compiler clang-20` | `[INFO] Compiler selection: clang-20`, LLVM 20 installed |
+| 45 | Valid `--compiler gcc-14` | Ubuntu 22.04 | `./install_dependencies.sh --docker --compiler gcc-14` | `[INFO] Compiler selection: gcc-14`, `[INFO] Skipping LLVM installation (--compiler gcc-14)` |
+| 46 | Invalid `--compiler foobar` | Ubuntu 22.04 | `./install_dependencies.sh --docker --compiler foobar` | `[ERROR] Unknown compiler 'foobar'. Allowed: clang gcc clang-20 clang-19 clang-18 clang-17 clang-20-libcpp gcc-14 gcc-13 gcc-12.`, exit 1 |
+| 47 | Default (no --compiler) | Ubuntu 22.04 | `./install_dependencies.sh --docker` | LLVM 20 installed, no `[INFO] Compiler selection` |
 
 ## Section 13: `--compiler` flag — LLVM skip on GCC variants
 
 | # | Test | Container | Command | Expected output |
 |---|------|-----------|---------|-----------------|
-| 44 | `--compiler gcc` skips LLVM | Ubuntu 22.04 | `./install_dependencies.sh --docker --compiler gcc` | `[INFO] Skipping LLVM installation (--compiler gcc)` |
-| 45 | `--compiler gcc-12` skips LLVM | Ubuntu 22.04 | `./install_dependencies.sh --docker --compiler gcc-12` | `[INFO] Skipping LLVM installation (--compiler gcc-12)` |
-| 46 | `--compiler gcc-14` skips LLVM | Ubuntu 24.04 | `./install_dependencies.sh --docker --compiler gcc-14` | `[INFO] Skipping LLVM installation (--compiler gcc-14)` |
-| 47 | `--compiler clang-20-libcpp` installs LLVM | Ubuntu 22.04 | `./install_dependencies.sh --docker --compiler clang-20-libcpp` | LLVM 20 installed (no skip message) |
+| 48 | `--compiler gcc` skips LLVM | Ubuntu 22.04 | `./install_dependencies.sh --docker --compiler gcc` | `[INFO] Skipping LLVM installation (--compiler gcc)` |
+| 49 | `--compiler gcc-12` skips LLVM | Ubuntu 22.04 | `./install_dependencies.sh --docker --compiler gcc-12` | `[INFO] Skipping LLVM installation (--compiler gcc-12)` |
+| 50 | `--compiler gcc-14` skips LLVM | Ubuntu 24.04 | `./install_dependencies.sh --docker --compiler gcc-14` | `[INFO] Skipping LLVM installation (--compiler gcc-14)` |
+| 51 | `--compiler gcc-13` skips LLVM | Ubuntu 22.04 | `./install_dependencies.sh --docker --compiler gcc-13` | `[INFO] Skipping LLVM installation (--compiler gcc-13)` |
+| 52 | `--compiler clang-20-libcpp` installs LLVM | Ubuntu 22.04 | `./install_dependencies.sh --docker --compiler clang-20-libcpp` | LLVM 20 installed (no skip message) |
 
 ## Section 14: `install_llvm()` — RedHat messaging
 
 | # | Test | Container | Command | Expected output |
 |---|------|-----------|---------|-----------------|
-| 48 | Default on Fedora: distro clang | Fedora 40 | `./install_dependencies.sh --docker` | `[INFO] Using distro-provided LLVM/Clang for fedora:` (no WARNING) |
-| 49 | `--compiler gcc` on Fedora | Fedora 40 | `./install_dependencies.sh --docker --compiler gcc` | `[INFO] Skipping LLVM installation (--compiler gcc)` |
-| 50 | `--compiler clang` on Fedora | Fedora 40 | `./install_dependencies.sh --docker --compiler clang` | `[INFO] Using distro-provided LLVM/Clang for fedora:` |
+| 53 | Default on Fedora: distro clang | Fedora 40 | `./install_dependencies.sh --docker` | `[INFO] Using distro-provided LLVM/Clang for fedora:` (no WARNING) |
+| 54 | `--compiler gcc` on Fedora | Fedora 40 | `./install_dependencies.sh --docker --compiler gcc` | `[INFO] Skipping LLVM installation (--compiler gcc)` |
+| 55 | `--compiler clang` on Fedora | Fedora 40 | `./install_dependencies.sh --docker --compiler clang` | `[INFO] Using distro-provided LLVM/Clang for fedora:` |
 
-## Section 15: `prep_redhat_system()` — repo setup
-
-| # | Test | Container | Command | Expected output |
-|---|------|-----------|---------|-----------------|
-| 51 | Fedora: no extra repos | Fedora 40 | `./install_dependencies.sh --docker` | `[INFO] Preparing Red Hat family system...` then proceeds (no EPEL) |
-| 52 | AlmaLinux: EPEL + CRB | AlmaLinux 10 | `./install_dependencies.sh --docker` | `[INFO] Installing EPEL repository...`, `[INFO] Enabling CRB repository` |
-| 56 | Oracle Linux: Oracle EPEL + CRB | Oracle Linux 10 | `./install_dependencies.sh --docker` | `oracle-epel-release-el10` installed, `ol10_codeready_builder` enabled |
-
-## Section 15b: `verify_compiler()` — GCC version guard
+## Section 15: `install_llvm_from_tarball()` — LLVM tarball installation
 
 | # | Test | Container | Command | Expected output |
 |---|------|-----------|---------|-----------------|
-| 57 | GCC >= 12 passes | Ubuntu 22.04 (GCC 12) | `./install_dependencies.sh --docker --compiler gcc` | `[OK] Compiler verified:` |
-| 58 | GCC < 12 rejected | System with GCC 11 | `./install_dependencies.sh --docker --compiler gcc` | `[ERROR] GCC 11 is too old. tt-metal requires GCC >= 12.`, exit 1 |
+| 56 | `--compiler clang-20` installs LLVM 20 tarball | Fedora 40 | `./install_dependencies.sh --docker --compiler clang-20` | Downloads `LLVM-20.1.8-Linux-X64.tar.xz`, installs to `/usr/local/llvm-20` |
+| 57 | `--compiler clang-19` installs LLVM 19 tarball | Fedora 40 | `./install_dependencies.sh --docker --compiler clang-19` | Downloads `LLVM-19.1.7-Linux-X64.tar.xz`, installs to `/usr/local/llvm-19` |
+| 58 | `--compiler clang-17` installs LLVM 17 tarball | Fedora 40 | `./install_dependencies.sh --docker --compiler clang-17` | Downloads `clang+llvm-17.0.6-x86_64-linux-gnu-ubuntu-22.04.tar.xz` (old naming), installs to `/usr/local/llvm-17` |
 
-## Section 15c: `use_compiler()` — C compiler derivation check (build_metal.sh)
+## Section 16: `prep_redhat_system()` — repo setup
+
+| # | Test | Container | Command | Expected output |
+|---|------|-----------|---------|-----------------|
+| 59 | Fedora: no extra repos | Fedora 40 | `./install_dependencies.sh --docker` | `[INFO] Preparing Red Hat family system...` then proceeds (no EPEL) |
+| 60 | AlmaLinux: EPEL + CRB | AlmaLinux 10 | `./install_dependencies.sh --docker` | `[INFO] Installing EPEL repository...`, `[INFO] Enabling CRB repository` |
+| 61 | Oracle Linux: Oracle EPEL + CRB | Oracle Linux 10 | `./install_dependencies.sh --docker` | `oracle-epel-release-el10` installed, `ol10_codeready_builder` enabled |
+
+## Section 17: `verify_compiler()` — GCC version guard
+
+| # | Test | Container | Command | Expected output |
+|---|------|-----------|---------|-----------------|
+| 62 | GCC >= 12 passes | Ubuntu 22.04 (GCC 12) | `./install_dependencies.sh --docker --compiler gcc` | `[OK] Compiler verified:` |
+| 63 | GCC < 12 rejected | System with GCC 11 | `./install_dependencies.sh --docker --compiler gcc` | `[ERROR] GCC 11 is too old. tt-metal requires GCC >= 12.`, exit 1 |
+
+## Section 18: `use_compiler()` — C compiler derivation check (build_metal.sh)
 
 | # | Test | PATH setup | Command | Expected output |
 |---|------|-----------|---------|-----------------|
-| 59 | Missing C compiler detected | Fake `g++` in PATH, no `gcc` | `--compiler gcc --configure-only` | `ERROR: C compiler 'gcc' not found (derived from 'g++')`, exit 1 |
-| 60 | Missing C compiler (clang) | Fake `clang++` in PATH, no `clang` | `--compiler clang --configure-only` | `ERROR: C compiler 'clang' not found (derived from 'clang++')`, exit 1 |
+| 64 | Missing C compiler detected | Fake `g++` in PATH, no `gcc` | `--compiler gcc --configure-only` | `ERROR: C compiler 'gcc' not found (derived from 'g++')`, exit 1 |
+| 65 | Missing C compiler (clang) | Fake `clang++` in PATH, no `clang` | `--compiler clang --configure-only` | `ERROR: C compiler 'clang' not found (derived from 'clang++')`, exit 1 |
 
-## Section 16: Warning fixes — MPI ULFM and hugepages
+## Section 19: Warning fixes — MPI ULFM and hugepages
 
 | # | Test | Container | Command | Expected output |
 |---|------|-----------|---------|-----------------|
-| 53 | MPI ULFM on Fedora: INFO not WARNING | Fedora 40 | `./install_dependencies.sh --docker` | `[INFO] MPI ULFM is only available as a .deb package; skipping on fedora` |
-| 54 | Hugepages on Fedora: INFO not WARNING | Fedora 40 | `./install_dependencies.sh --docker --hugepages` | `[INFO] Hugepages package is only available as a .deb package; skipping on fedora` |
+| 66 | MPI ULFM on Fedora: INFO not WARNING | Fedora 40 | `./install_dependencies.sh --docker` | `[INFO] MPI ULFM is only available as a .deb package; skipping on fedora` |
+| 67 | Hugepages on Fedora: INFO not WARNING | Fedora 40 | `./install_dependencies.sh --docker --hugepages` | `[INFO] Hugepages package is only available as a .deb package; skipping on fedora` |
 
-## Section 17: Help text (install_dependencies.sh)
+## Section 20: Help text (install_dependencies.sh)
 
 | # | Test | Command | Expected output |
 |---|------|---------|-----------------|
-| 55 | `--help` shows `--compiler` | `./install_dependencies.sh --help` | Output contains `[--compiler name]` and lists `clang gcc clang-20 clang-20-libcpp gcc-12 gcc-14` |
+| 68 | `--help` shows `--compiler` | `./install_dependencies.sh --help` | Output contains `[--compiler name]` and lists `clang gcc clang-20 clang-19 clang-18 clang-17 clang-20-libcpp gcc-14 gcc-13 gcc-12` |
 
 ## Coverage Summary
 
@@ -226,45 +241,46 @@ WARNING, ERROR).
 
 | Code section | Lines | Tests |
 |-------------|-------|-------|
-| `CLANG_SEARCH` / `GCC_SEARCH` arrays | 18–19 | 1–11, 18–26, 30–33 |
-| `BINARY_TOOLCHAIN` map | 23–31 | 1, 5, 7, 9–10, 21–22, 24–25 |
-| `FLAG_TOOLCHAIN` map | 34–39 | 12–15 |
-| `toolchain_file()` | 42–44 | 1, 5, 7, 9–10, 12–15, 21–22, 24–25 |
-| `find_compiler()` search | 48–56 | 1–11, 18–26, 30–33 |
-| `use_compiler()` toolchain path | 60–64 | 1, 5, 7, 9–10, 21–22, 24–25 |
-| `use_compiler()` direct path | 65–75 | 2–4, 8, 18–20, 23 |
-| `use_compiler()` C compiler guard | 74–77 | 59–60 |
-| `--compiler clang` case | 292–296 | 1–6, 30–31 |
-| `--compiler gcc` case | 297–301 | 7–11, 32–33 |
-| `--compiler` pinned (FLAG_TOOLCHAIN) | 302–304 | 12–15 |
-| `--compiler` error (unknown) | 305–309 | 16 |
-| Auto-detect: clang++-20 present | 314–315 | 17 |
-| Auto-detect: compiler fallback | 316–321 | 18–25 |
-| Auto-detect: nothing found | 317–318 | 26 |
-| Auto-detect: guard conditions | 314 | 27–29 |
-| `--toolchain-path` explicit flag | 150, 272 | 28–29, 36–37 |
-| Help text | 109 | 34 |
-| CMakePresets.json | — | 35 |
+| `CLANG_SEARCH` / `GCC_SEARCH` arrays | 18–19 | 1–11, 22–30, 34–37 |
+| `BINARY_TOOLCHAIN` map | 23–33 | 1–5, 7–10, 22–29 |
+| `FLAG_TOOLCHAIN` map | 39–48 | 12–19 |
+| `toolchain_file()` | 51–53 | 1–5, 7–10, 12–19, 22–29 |
+| `find_compiler()` search | 57–65 | 1–11, 22–30, 34–37 |
+| `use_compiler()` toolchain path | 72–73 | 1–5, 7–10, 22–29 |
+| `use_compiler()` C compiler guard | 83–86 | 64–65 |
+| `--compiler clang` case | 310–314 | 1–6, 34–35 |
+| `--compiler gcc` case | 315–319 | 7–11, 36–37 |
+| `--compiler` pinned (FLAG_TOOLCHAIN) | 320–322 | 12–19 |
+| `--compiler` error (unknown) | 323–327 | 20 |
+| Auto-detect: clang++-20 present | 332–333 | 21 |
+| Auto-detect: compiler fallback | 334–339 | 22–29 |
+| Auto-detect: nothing found | 335–336 | 30 |
+| Auto-detect: guard conditions | 332 | 31–33 |
+| `--toolchain-path` explicit flag | 165, 290 | 32–33, 40–41 |
+| Help text | 123 | 38 |
+| CMakePresets.json | — | 39 |
 
 **`install_dependencies.sh`:**
 
 | Code section | Tests |
 |-------------|-------|
-| `COMPILER_FLAGS` array + validation | 38–43, 55 |
-| `--compiler gcc*` skips `install_llvm()` | 39, 41, 44–46 |
-| `--compiler clang*` installs LLVM | 38, 40, 47 |
-| `install_llvm()` RedHat: distro clang INFO | 48, 50 |
-| `install_llvm()` RedHat: skip on gcc | 49 |
-| `prep_redhat_system()` Fedora: no-op | 51 |
-| `prep_redhat_system()` RHEL/Alma: EPEL+CRB | 52 |
-| `prep_redhat_system()` Oracle: EPEL+CRB | 56 |
-| `verify_compiler()` GCC >= 12 guard | 57–58 |
-| MPI ULFM warning → INFO | 53 |
-| Hugepages warning → INFO | 54 |
-| Help text | 55 |
+| `COMPILER_FLAGS` array + validation | 42–47, 68 |
+| `--compiler gcc*` skips `install_llvm()` | 43, 45, 48–51 |
+| `--compiler clang*` installs LLVM | 42, 44, 52 |
+| `install_llvm()` RedHat: distro clang INFO | 53, 55 |
+| `install_llvm()` RedHat: skip on gcc | 54 |
+| `install_llvm_from_tarball()` LLVM 20/19 (new naming) | 56, 57 |
+| `install_llvm_from_tarball()` LLVM 17 (old naming) | 58 |
+| `prep_redhat_system()` Fedora: no-op | 59 |
+| `prep_redhat_system()` RHEL/Alma: EPEL+CRB | 60 |
+| `prep_redhat_system()` Oracle: EPEL+CRB | 61 |
+| `verify_compiler()` GCC >= 12 guard | 62–63 |
+| MPI ULFM warning → INFO | 66 |
+| Hugepages warning → INFO | 67 |
+| Help text | 68 |
 
 | Script | Tests |
 |--------|-------|
-| `build_metal.sh` | 39 |
-| `install_dependencies.sh` | 21 |
-| **Total** | **60 tests** |
+| `build_metal.sh` | 41 |
+| `install_dependencies.sh` | 27 |
+| **Total** | **68 tests** |

--- a/test-plan-compiler-flag.md
+++ b/test-plan-compiler-flag.md
@@ -1,13 +1,17 @@
-# Test Plan: `--compiler` flag and auto-detection in `build_metal.sh`
+# Test Plan: `--compiler` flag for `build_metal.sh` and `install_dependencies.sh`
 
 Issue: [#37907](https://github.com/tenstorrent/tt-metal/issues/37907)
 Branch: `ivoitovych/issue-37907-fix-fedora-toolchain-selection`
 
 ## Overview
 
-This test plan achieves 100% branch coverage for all code paths introduced by the
-`--compiler` flag, compiler-to-toolchain mapping, and auto-detection fallback in
-`build_metal.sh`.
+This test plan covers all code paths introduced by the `--compiler` flag,
+compiler-to-toolchain mapping, and auto-detection fallback in `build_metal.sh`
+(tests 1–37), and the `--compiler` flag, `prep_redhat_system()`, `install_llvm()`
+rewrite, and warning fixes in `install_dependencies.sh` (tests 38–55).
+
+`build_metal.sh` tests use `--configure-only` and PATH manipulation.
+`install_dependencies.sh` tests run in Docker containers (require root).
 
 All tests use `--configure-only` to avoid actual builds. Compiler visibility is
 controlled via `PATH` manipulation using temporary directories with fake compiler
@@ -145,7 +149,65 @@ if the guard didn't prevent it.
 | 36 | `--toolchain-path` sets explicit flag | `--toolchain-path cmake/x86_64-linux-gcc-toolchain.cmake --configure-only` (no clang++-20) | Uses `gcc-toolchain`, NO auto-detect override | `toolchain_path_explicitly_set=true` (line 272) |
 | 37 | Default has explicit flag false | `--configure-only` (with clang++-20) | Uses default `clang-20-libstdcpp` | `toolchain_path_explicitly_set=false` (line 150) |
 
+---
+
+# `install_dependencies.sh` tests
+
+All tests below run as root in Docker containers. Use `--docker` flag to avoid
+systemd-dependent steps. Verify behavior via output messages (grep for INFO,
+WARNING, ERROR).
+
+## Section 12: `--compiler` flag — validation (install_dependencies.sh)
+
+| # | Test | Container | Command | Expected output |
+|---|------|-----------|---------|-----------------|
+| 38 | Valid `--compiler clang` | Ubuntu 22.04 | `./install_dependencies.sh --docker --compiler clang` | `[INFO] Compiler selection: clang`, LLVM 20 installed |
+| 39 | Valid `--compiler gcc` | Ubuntu 22.04 | `./install_dependencies.sh --docker --compiler gcc` | `[INFO] Compiler selection: gcc`, `[INFO] Skipping LLVM installation (--compiler gcc)` |
+| 40 | Valid `--compiler clang-20` | Ubuntu 22.04 | `./install_dependencies.sh --docker --compiler clang-20` | `[INFO] Compiler selection: clang-20`, LLVM 20 installed |
+| 41 | Valid `--compiler gcc-14` | Ubuntu 22.04 | `./install_dependencies.sh --docker --compiler gcc-14` | `[INFO] Compiler selection: gcc-14`, `[INFO] Skipping LLVM installation (--compiler gcc-14)` |
+| 42 | Invalid `--compiler foobar` | Ubuntu 22.04 | `./install_dependencies.sh --docker --compiler foobar` | `[ERROR] Unknown compiler 'foobar'. Allowed: clang gcc clang-20 clang-20-libcpp gcc-12 gcc-14.`, exit 1 |
+| 43 | Default (no --compiler) | Ubuntu 22.04 | `./install_dependencies.sh --docker` | LLVM 20 installed, no `[INFO] Compiler selection` |
+
+## Section 13: `--compiler` flag — LLVM skip on GCC variants
+
+| # | Test | Container | Command | Expected output |
+|---|------|-----------|---------|-----------------|
+| 44 | `--compiler gcc` skips LLVM | Ubuntu 22.04 | `./install_dependencies.sh --docker --compiler gcc` | `[INFO] Skipping LLVM installation (--compiler gcc)` |
+| 45 | `--compiler gcc-12` skips LLVM | Ubuntu 22.04 | `./install_dependencies.sh --docker --compiler gcc-12` | `[INFO] Skipping LLVM installation (--compiler gcc-12)` |
+| 46 | `--compiler gcc-14` skips LLVM | Ubuntu 24.04 | `./install_dependencies.sh --docker --compiler gcc-14` | `[INFO] Skipping LLVM installation (--compiler gcc-14)` |
+| 47 | `--compiler clang-20-libcpp` installs LLVM | Ubuntu 22.04 | `./install_dependencies.sh --docker --compiler clang-20-libcpp` | LLVM 20 installed (no skip message) |
+
+## Section 14: `install_llvm()` — RedHat messaging
+
+| # | Test | Container | Command | Expected output |
+|---|------|-----------|---------|-----------------|
+| 48 | Default on Fedora: distro clang | Fedora 40 | `./install_dependencies.sh --docker` | `[INFO] Using distro-provided LLVM/Clang for fedora:` (no WARNING) |
+| 49 | `--compiler gcc` on Fedora | Fedora 40 | `./install_dependencies.sh --docker --compiler gcc` | `[INFO] Skipping LLVM installation (--compiler gcc)` |
+| 50 | `--compiler clang` on Fedora | Fedora 40 | `./install_dependencies.sh --docker --compiler clang` | `[INFO] Using distro-provided LLVM/Clang for fedora:` |
+
+## Section 15: `prep_redhat_system()` — repo setup
+
+| # | Test | Container | Command | Expected output |
+|---|------|-----------|---------|-----------------|
+| 51 | Fedora: no extra repos | Fedora 40 | `./install_dependencies.sh --docker` | `[INFO] Preparing Red Hat family system...` then proceeds (no EPEL) |
+| 52 | Rocky: EPEL + CRB | Rocky 9 | `./install_dependencies.sh --docker` | `[INFO] Installing EPEL repository...`, `[INFO] Enabling CRB repository` |
+
+## Section 16: Warning fixes — MPI ULFM and hugepages
+
+| # | Test | Container | Command | Expected output |
+|---|------|-----------|---------|-----------------|
+| 53 | MPI ULFM on Fedora: INFO not WARNING | Fedora 40 | `./install_dependencies.sh --docker` | `[INFO] MPI ULFM is only available as a .deb package; skipping on fedora` |
+| 54 | Hugepages on Fedora: INFO not WARNING | Fedora 40 | `./install_dependencies.sh --docker --hugepages` | `[INFO] Hugepages package is only available as a .deb package; skipping on fedora` |
+
+## Section 17: Help text (install_dependencies.sh)
+
+| # | Test | Command | Expected output |
+|---|------|---------|-----------------|
+| 55 | `--help` shows `--compiler` | `./install_dependencies.sh --help` | Output contains `[--compiler name]` and lists `clang gcc clang-20 clang-20-libcpp gcc-12 gcc-14` |
+
 ## Coverage Summary
+
+**`build_metal.sh`:**
 
 | Code section | Lines | Tests |
 |-------------|-------|-------|
@@ -167,4 +229,24 @@ if the guard didn't prevent it.
 | `--toolchain-path` explicit flag | 150, 272 | 28–29, 36–37 |
 | Help text | 109 | 34 |
 | CMakePresets.json | — | 35 |
-| **Total** | | **37 tests** |
+
+**`install_dependencies.sh`:**
+
+| Code section | Tests |
+|-------------|-------|
+| `COMPILER_FLAGS` array + validation | 38–43, 55 |
+| `--compiler gcc*` skips `install_llvm()` | 39, 41, 44–46 |
+| `--compiler clang*` installs LLVM | 38, 40, 47 |
+| `install_llvm()` RedHat: distro clang INFO | 48, 50 |
+| `install_llvm()` RedHat: skip on gcc | 49 |
+| `prep_redhat_system()` Fedora: no-op | 51 |
+| `prep_redhat_system()` RHEL/Rocky: EPEL+CRB | 52 |
+| MPI ULFM warning → INFO | 53 |
+| Hugepages warning → INFO | 54 |
+| Help text | 55 |
+
+| Script | Tests |
+|--------|-------|
+| `build_metal.sh` | 37 |
+| `install_dependencies.sh` | 18 |
+| **Total** | **55 tests** |

--- a/tt_metal/llrt/hal/codegen/codegen.py
+++ b/tt_metal/llrt/hal/codegen/codegen.py
@@ -8,15 +8,15 @@ import contextlib
 import re
 import sys
 from dataclasses import dataclass
-from typing import Dict, List, Optional, Set, TextIO, Union
+from typing import List, Dict, TextIO
 
 
 @dataclass
 class Field:
     name: str
     type: str
-    struct_idx: Optional[int]
-    array_size_idx: Optional[int]
+    struct_idx: int | None
+    array_size_idx: int | None
 
 
 @dataclass
@@ -66,7 +66,7 @@ class CodeGen:
         self.includes: List[str] = []
         self.enums: List[str] = []
         self.constants: List[str] = []
-        self.scalar_types: Set[str] = set(self.SCALAR_TYPES)
+        self.scalar_types: set[str] = set(self.SCALAR_TYPES)
         self.driver_ns = driver_ns
         self.driver_include_path = driver_include_path
         self.interface_ns = interface_ns
@@ -240,7 +240,7 @@ class CodeGen:
 
     def emit_field_traits(self, struct: Struct):
         for field_id, field in enumerate(struct.fields):
-            args: List[Union[str, int]] = [field.type, field_id]
+            args: List[str | int] = [field.type, field_id]
             if field.struct_idx is None:
                 scalar_or_struct = "Scalar"
             else:

--- a/tt_metal/llrt/hal/codegen/codegen.py
+++ b/tt_metal/llrt/hal/codegen/codegen.py
@@ -8,15 +8,15 @@ import contextlib
 import re
 import sys
 from dataclasses import dataclass
-from typing import List, Dict, TextIO
+from typing import Dict, List, Optional, Set, TextIO, Union
 
 
 @dataclass
 class Field:
     name: str
     type: str
-    struct_idx: int | None
-    array_size_idx: int | None
+    struct_idx: Optional[int]
+    array_size_idx: Optional[int]
 
 
 @dataclass
@@ -66,7 +66,7 @@ class CodeGen:
         self.includes: List[str] = []
         self.enums: List[str] = []
         self.constants: List[str] = []
-        self.scalar_types: set[str] = set(self.SCALAR_TYPES)
+        self.scalar_types: Set[str] = set(self.SCALAR_TYPES)
         self.driver_ns = driver_ns
         self.driver_include_path = driver_include_path
         self.interface_ns = interface_ns
@@ -240,7 +240,7 @@ class CodeGen:
 
     def emit_field_traits(self, struct: Struct):
         for field_id, field in enumerate(struct.fields):
-            args: List[str | int] = [field.type, field_id]
+            args: List[Union[str, int]] = [field.type, field_id]
             if field.struct_idx is None:
                 scalar_or_struct = "Scalar"
             else:


### PR DESCRIPTION
### Ticket
Fixes #37907

### Problem description
Building tt-metal on Fedora/RHEL fails due to three compounding problems:
1. `install_dependencies.sh` skips LLVM on non-Debian (`prep_redhat_system()` is a TODO stub, `install_llvm()` prints a misleading WARNING)
2. `build_metal.sh` defaults to `clang++-20`, only available on Debian/Ubuntu via `apt.llvm.org/llvm.sh`
3. Neither script has a `--compiler` flag — no way to coordinate compiler selection across the install and build steps

### What's changed

**`build_metal.sh` — new `--compiler` flag** with two modes:
- **Smart search** (`--compiler clang` / `--compiler gcc`): searches PATH for the best available version in descending order (e.g., `clang++-20 → 19 → 18 → 17 → clang++`) and selects the matching toolchain file or falls back to direct compiler path.
- **Pinned version** (`--compiler clang-20`, `clang-19`, `clang-18`, `clang-17`, `gcc-14`, `gcc-13`, `gcc-12`, etc.): selects a specific toolchain file directly.

**`build_metal.sh` — auto-detection fallback**: when no `--compiler`, `--cxx-compiler-path`, or `--toolchain-path` is specified and `clang++-20` is not found, the script automatically searches for available compilers and selects the best one, printing an INFO message.

**`build_metal.sh` — table-driven design**: compiler search lists, binary-to-toolchain mappings, and CLI flag mappings are centralized in arrays/maps at the top of the script (`CLANG_SEARCH`, `GCC_SEARCH`, `BINARY_TOOLCHAIN`, `FLAG_TOOLCHAIN`). The full toolchain path is derived from a short ID via a single `toolchain_file()` function. No compiler name or path string is duplicated.

**`install_dependencies.sh` — new `--compiler` flag**: accepts the same values as `build_metal.sh` (`clang`, `gcc`, `clang-20`, `clang-19`, `clang-18`, `clang-17`, `clang-20-libcpp`, `gcc-14`, `gcc-13`, `gcc-12`). Enables consistent compiler selection across both scripts:
```bash
./install_dependencies.sh --compiler gcc
./build_metal.sh --compiler gcc
```
When `--compiler gcc*` is selected, the expensive LLVM 20 download (~500MB) is skipped on Debian.

**`install_dependencies.sh` — LLVM tarball installation**: supports clang-17 through clang-20 via official LLVM release tarballs. Handles the naming format change between versions (LLVM 19+ uses `LLVM-X.Y.Z-Linux-X64.tar.xz`, LLVM 17-18 uses `clang+llvm-X.Y.Z-x86_64-linux-gnu-ubuntu-*.tar.xz`).

**`install_dependencies.sh` — versioned GCC installation**: on Debian/Ubuntu, tries the distro package first, then Ubuntu Toolchain PPA (`ppa:ubuntu-toolchain-r/test`), with `command -v` verification after each attempt to guard against apt virtual package resolution silently installing the wrong package.

**`install_dependencies.sh` — `prep_redhat_system()` implementation**: replaces the TODO stub. Fedora needs no extra repos (all packages in default repos). RHEL/Rocky/AlmaLinux get EPEL and CRB/PowerTools enabled; Oracle Linux gets `oracle-epel-release` and `ol10_codeready_builder`.

**`install_dependencies.sh` — `install_llvm()` rewrite**: on RedHat, reports distro-provided Clang version instead of the misleading `[WARNING] Skipping LLVM installation`. LLVM/Clang is already installed via the package list (`llvm`, `clang`, `clang-tools-extra`).

**`install_dependencies.sh` — warning fixes**: MPI ULFM and hugepages messages changed from `[WARNING] needs to be expanded to support` to `[INFO] only available as .deb package; skipping` — these are informational, not actionable.

**New toolchain files**:
- `cmake/x86_64-linux-gcc-toolchain.cmake` — unversioned `gcc`/`g++`
- `cmake/x86_64-linux-gcc-13-toolchain.cmake` — GCC 13
- `cmake/x86_64-linux-clang-libstdcpp-toolchain.cmake` — unversioned `clang`/`clang++` with libstdc++
- `cmake/x86_64-linux-clang-17-libstdcpp-toolchain.cmake` — Clang 17 with libstdc++
- `cmake/x86_64-linux-clang-18-libstdcpp-toolchain.cmake` — Clang 18 with libstdc++
- `cmake/x86_64-linux-clang-19-libstdcpp-toolchain.cmake` — Clang 19 with libstdc++

**New CMakePresets.json entries**: `gcc-system`, `gcc-13`, `clang-system`, `clang-19`, `clang-18`, `clang-17` configure presets with corresponding `dev-gcc-system`, `dev-gcc-13`, `dev-clang-system`, `dev-clang-19`, `dev-clang-18`, `dev-clang-17` build presets.

**Files changed:**
| File | Change |
|------|--------|
| `build_metal.sh` | `--compiler` flag, auto-detection, table-driven helper functions |
| `install_dependencies.sh` | `--compiler` flag, `prep_redhat_system()`, `install_llvm()` rewrite, LLVM tarball versioning, GCC PPA ladder, warning fixes |
| `cmake/x86_64-linux-gcc-toolchain.cmake` | New: unversioned GCC toolchain |
| `cmake/x86_64-linux-gcc-13-toolchain.cmake` | New: GCC 13 toolchain |
| `cmake/x86_64-linux-clang-libstdcpp-toolchain.cmake` | New: unversioned Clang+libstdc++ toolchain |
| `cmake/x86_64-linux-clang-17-libstdcpp-toolchain.cmake` | New: Clang 17+libstdc++ toolchain |
| `cmake/x86_64-linux-clang-18-libstdcpp-toolchain.cmake` | New: Clang 18+libstdc++ toolchain |
| `cmake/x86_64-linux-clang-19-libstdcpp-toolchain.cmake` | New: Clang 19+libstdc++ toolchain |
| `CMakePresets.json` | New: `gcc-system`, `gcc-13`, `clang-system`, `clang-19`, `clang-18`, `clang-17` presets (configure + build) |
| `test-plan-compiler-flag.md` | 68 test cases for 100% branch coverage |

**No behavioral change on Ubuntu** — when `clang++-20` is present, the default path is unchanged.

**Verification — full container builds** (install_dependencies.sh → build_metal.sh --build-all → create_venv.sh → tt-train standalone → tt-smi):

| | clang-20 (default) | clang-19 | clang-18 | clang-17 | gcc (system) | gcc-14 | gcc-13 | gcc-12 | clang-20-libcpp |
|---|---|---|---|---|---|---|---|---|---|
| **Ubuntu 22.04** | PASS+TEST | FAIL (⁑) | FAIL (⁑) | FAIL (⁑) | PASS | n/a | PASS | PASS | FAIL (\*) |
| **Ubuntu 24.04** | PASS+TEST | FAIL (⁑) | FAIL (⁑) | FAIL (⁑) | PASS | PASS | PASS | PASS+TEST | FAIL (\*) |
| **Fedora 40** | PASS+TEST | FAIL (⁑) | FAIL (⁑) | FAIL (⁑) | PASS+TEST | PASS+TEST | n/a (†) | n/a (†) | FAIL (‡) |
| **Fedora 42** | PASS+TEST | FAIL (⁑) | FAIL (⁑) | FAIL (⁑) | PASS+TEST | n/a (†) | n/a (†) | n/a (†) | FAIL (‡) |
| **Debian 12** | FAIL (\*\*) | FAIL (⁑) | FAIL (⁑) | FAIL (⁑) | FAIL (\*\*) | n/a | FAIL (\*\*) | FAIL (\*\*) | n/a |
| **AlmaLinux 10** | PASS+TEST | FAIL (⁑) | FAIL (⁑) | FAIL (⁑) | FAIL (\*\*\*) | n/a (†) | n/a (†) | n/a (†) | FAIL (‡) |
| **Oracle Linux 10** | PASS+TEST | FAIL (⁑) | FAIL (⁑) | FAIL (⁑) | PASS+TEST | n/a (†) | n/a (†) | n/a (†) | FAIL (‡) |

`PASS+TEST` = build succeeded AND ttml_tests verified on Blackhole p150a hardware (confirms working binaries).

(\*) clang-20-libcpp: tt-metal build passes; tt-train standalone link fails due to pre-existing ABI mismatch (libc++ vs libstdc++). Unrelated to this PR.

(\*\*) Debian 12: LLVM 20 `sfpi` package requires libstdc++ >= 12.3; Debian 12 ships 12.2. Not related to this PR.

(\*\*\*) AlmaLinux 10 + GCC: tt-metal HAL compilation error (`hal.hpp` fatal error). Pre-existing GCC compatibility issue, not related to this PR.

(†) No versioned GCC packages on Fedora/RHEL — only system GCC available. `--compiler gcc` uses the system version.

(‡) libc++ not available on non-Ubuntu distros. LLVM tarball provides headers but not shared libraries in a discoverable location. Only Ubuntu apt packages (`libc++-20-dev`, `libc++abi-20-dev`) work.

(⁑) Clang 17/18/19: build fails due to `-Wenum-constexpr-conversion` error in the `reflect` CPM dependency. This warning was made an error in clang-16, and relaxed back to a warning in clang-20. Pre-existing code issue, not related to this PR.

**Device test details** (ttml_tests on Blackhole p150a):

| Container | Result | Notes |
|---|---|---|
| AlmaLinux 10 clang-20 | 150/151 pass (33% of 455) | 1 failure, pre-existing |
| Fedora 42 clang-20 | 95/96 pass (21% of 455) | Crash on ReduceOpTest (pre-existing BH bug) |
| Fedora 40 GCC | 379/381 pass (84% of 455) | 2 failures (§) |
| Oracle Linux 10 clang-20 | 379/381 pass (84% of 455) | 2 failures (§) |
| Fedora 40 GCC-14 | 379/381 pass (84% of 455) | 2 failures (§) |
| Fedora 42 GCC | 95/96 pass (21% of 455) | Crash on ReduceOpTest (pre-existing BH bug) |
| Oracle Linux 10 GCC | 379/381 pass (84% of 455) | 2 failures (§) |
| Ubuntu 22.04 clang-20 | 379/381 pass (84% of 455) | 2 failures (§) |
| Fedora 40 clang-20 | 379/381 pass (84% of 455) | 2 failures (§) |
| Ubuntu 24.04 clang-20 | 379/381 pass (84% of 455) | 2 failures (§) |
| Ubuntu 24.04 GCC-12 | 379/381 pass (84% of 455) | 2 failures (§) |

(§) Same 2 pre-existing Blackhole failures across all tested containers: `TrivialTnnFixedTest.TestSamplingPositiveTemperatureWithMask` and `SoftmaxBackward/.../SoftmaxBackward_SubCoreGrid_Rectangular/bf16`. Not related to this PR.

63 cells in matrix, 49 tested: 17 PASS (12 with device tests), 32 FAIL (all pre-existing issues unrelated to this PR), 14 n/a. Verified using a [Docker-based container build tool](https://github.com/ivoitovych/tt-container/tree/feature/add-compiler-flag/cached) that runs the full pipeline (install_dependencies.sh → build_metal.sh --build-all → create_venv.sh → tt-train standalone → tt-smi) in a clean environment from scratch.

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=ivoitovych/issue-37907-fix-fedora-toolchain-selection-pr)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:ivoitovych/issue-37907-fix-fedora-toolchain-selection-pr)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ivoitovych/issue-37907-fix-fedora-toolchain-selection-pr)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ivoitovych/issue-37907-fix-fedora-toolchain-selection-pr)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ivoitovych/issue-37907-fix-fedora-toolchain-selection-pr)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ivoitovych/issue-37907-fix-fedora-toolchain-selection-pr)
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ivoitovych/issue-37907-fix-fedora-toolchain-selection-pr)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ivoitovych/issue-37907-fix-fedora-toolchain-selection-pr)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ivoitovych/issue-37907-fix-fedora-toolchain-selection-pr)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ivoitovych/issue-37907-fix-fedora-toolchain-selection-pr)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ivoitovych/issue-37907-fix-fedora-toolchain-selection-pr)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ivoitovych/issue-37907-fix-fedora-toolchain-selection-pr)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs











