### PR TITLE
Pipeline reorg ttnn post commit

### DIFF
--- a/.github/time_budget.yaml
+++ b/.github/time_budget.yaml
@@ -67,6 +67,10 @@ metal_infra:
 # Current time budgets are based on sums of existing tests.
 # No official decision has been made yet for division of budgets per team.
 ttnn:
+  sanity:
+    wh_n300_civ2: 520
+    bh_p100: 520
+    bh_p150b_civ2: 520
   unit:
     wh_llmbox: 50
   e2e:

--- a/.github/time_budget.yaml
+++ b/.github/time_budget.yaml
@@ -67,10 +67,6 @@ metal_infra:
 # Current time budgets are based on sums of existing tests.
 # No official decision has been made yet for division of budgets per team.
 ttnn:
-  sanity:
-    wh_n300_civ2: 520
-    bh_p100: 520
-    bh_p150b_civ2: 520
   unit:
     wh_llmbox: 50
   e2e:

--- a/.github/time_budget.yaml
+++ b/.github/time_budget.yaml
@@ -68,9 +68,9 @@ metal_infra:
 # No official decision has been made yet for division of budgets per team.
 ttnn:
   sanity:
-    wh_n300_civ2: 520
-    bh_p100: 520
-    bh_p150b_civ2: 520
+    wh_n300_civ2: 535
+    bh_p100: 535
+    bh_p150b_civ2: 535
   unit:
     wh_llmbox: 50
   e2e:

--- a/.github/workflows/all-post-commit-workflows.yaml
+++ b/.github/workflows/all-post-commit-workflows.yaml
@@ -225,6 +225,7 @@ jobs:
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
       enable-watcher: ${{ inputs.enable-watcher || false }}
+      timeout-minutes-override: ${{ inputs.enable-watcher && 240 || 0 }}
       enable-lightweight-kernel-asserts: ${{ inputs.enable-lightweight-kernel-asserts || false }}
       enable-llk-asserts: ${{ inputs.enable-llk-asserts || false }}
       ref: ${{ inputs.ref || github.sha }}

--- a/.github/workflows/all-post-commit-workflows.yaml
+++ b/.github/workflows/all-post-commit-workflows.yaml
@@ -172,6 +172,8 @@ jobs:
     uses: ./.github/workflows/build-artifact.yaml
     permissions:
       packages: write
+      contents: read
+      actions: read
     secrets: inherit
     with:
       build-type: ${{ inputs.build-type || 'Release' }}
@@ -181,6 +183,7 @@ jobs:
       skip-tt-train: false
       enable-lto: ${{ inputs.enable-lto || false }}
       ref: ${{ inputs.ref || github.sha }}
+      use-artifacts-from-run: 22425884273
 
   tests-to-run:
     runs-on: ubuntu-latest

--- a/.github/workflows/all-post-commit-workflows.yaml
+++ b/.github/workflows/all-post-commit-workflows.yaml
@@ -172,8 +172,6 @@ jobs:
     uses: ./.github/workflows/build-artifact.yaml
     permissions:
       packages: write
-      contents: read
-      actions: read
     secrets: inherit
     with:
       build-type: ${{ inputs.build-type || 'Release' }}
@@ -183,7 +181,6 @@ jobs:
       skip-tt-train: false
       enable-lto: ${{ inputs.enable-lto || false }}
       ref: ${{ inputs.ref || github.sha }}
-      use-artifacts-from-run: 22425884273
 
   tests-to-run:
     runs-on: ubuntu-latest

--- a/.github/workflows/all-post-commit-workflows.yaml
+++ b/.github/workflows/all-post-commit-workflows.yaml
@@ -215,16 +215,24 @@ jobs:
   ttnn-unit-tests:
     needs: [build-artifact, tests-to-run]
     secrets: inherit
+    strategy:
+      fail-fast: false
+      matrix:
+        test-group: [
+          { arch: wormhole_b0, runner-label: N300 }
+        ]
     if: ${{ needs.tests-to-run.outputs.ttnn-unit-tests == 'true' }}
     uses: ./.github/workflows/ttnn-post-commit.yaml
     with:
-      enabled-skus: "wh_n300_civ2"
+      arch: ${{ matrix.test-group.arch }}
+      runner-label: ${{ matrix.test-group.runner-label }}
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
       enable-watcher: ${{ inputs.enable-watcher || false }}
       enable-lightweight-kernel-asserts: ${{ inputs.enable-lightweight-kernel-asserts || false }}
       enable-llk-asserts: ${{ inputs.enable-llk-asserts || false }}
       ref: ${{ inputs.ref || github.sha }}
+      timeout: ${{ inputs.enable-watcher && 240 || 40 }}
 
   # FD Model Tests
   models-unit-tests:

--- a/.github/workflows/all-post-commit-workflows.yaml
+++ b/.github/workflows/all-post-commit-workflows.yaml
@@ -215,24 +215,16 @@ jobs:
   ttnn-unit-tests:
     needs: [build-artifact, tests-to-run]
     secrets: inherit
-    strategy:
-      fail-fast: false
-      matrix:
-        test-group: [
-          { arch: wormhole_b0, runner-label: N300 }
-        ]
     if: ${{ needs.tests-to-run.outputs.ttnn-unit-tests == 'true' }}
     uses: ./.github/workflows/ttnn-post-commit.yaml
     with:
-      arch: ${{ matrix.test-group.arch }}
-      runner-label: ${{ matrix.test-group.runner-label }}
+      enabled-skus: "wh_n300_civ2"
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
       enable-watcher: ${{ inputs.enable-watcher || false }}
       enable-lightweight-kernel-asserts: ${{ inputs.enable-lightweight-kernel-asserts || false }}
       enable-llk-asserts: ${{ inputs.enable-llk-asserts || false }}
       ref: ${{ inputs.ref || github.sha }}
-      timeout: ${{ inputs.enable-watcher && 240 || 40 }}
 
   # FD Model Tests
   models-unit-tests:

--- a/.github/workflows/blackhole-post-commit.yaml
+++ b/.github/workflows/blackhole-post-commit.yaml
@@ -205,9 +205,7 @@ jobs:
       matrix:
         test-group: ${{ fromJson(needs.generate-matrix.outputs.civ2-matrix) }}
     with:
-      arch: blackhole
-      runner-label: ${{ matrix.test-group }}
-      timeout: ${{ (inputs.enable-watcher && 120) || 40 }}
+      enabled-skus: ${{ (matrix.test-group == 'P100' || matrix.test-group == 'P100a') && 'bh_p100' || 'bh_p150b_civ2' }}
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
       enable-watcher: ${{ inputs.enable-watcher || false }}

--- a/.github/workflows/blackhole-post-commit.yaml
+++ b/.github/workflows/blackhole-post-commit.yaml
@@ -143,8 +143,6 @@ jobs:
     uses: ./.github/workflows/build-artifact.yaml
     permissions:
       packages: write
-      contents: read
-      actions: read
     secrets: inherit
     with:
       build-type: ${{ inputs.build-type || 'Release' }}
@@ -153,7 +151,6 @@ jobs:
       platform: ${{ inputs.platform || 'Ubuntu 22.04' }}
       build-umd-tests: true
       enable-lto: ${{ inputs.enable-lto || false }}
-      use-artifacts-from-run: 22425884273
   run-profiler-regression:
     needs: [build-artifact, generate-matrix]
     uses: ./.github/workflows/run-profiler-regression.yaml

--- a/.github/workflows/blackhole-post-commit.yaml
+++ b/.github/workflows/blackhole-post-commit.yaml
@@ -205,7 +205,9 @@ jobs:
       matrix:
         test-group: ${{ fromJson(needs.generate-matrix.outputs.civ2-matrix) }}
     with:
-      enabled-skus: ${{ (matrix.test-group == 'P100' || matrix.test-group == 'P100a') && 'bh_p100' || 'bh_p150b_civ2' }}
+      arch: blackhole
+      runner-label: ${{ matrix.test-group }}
+      timeout: ${{ (inputs.enable-watcher && 120) || 40 }}
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
       enable-watcher: ${{ inputs.enable-watcher || false }}

--- a/.github/workflows/blackhole-post-commit.yaml
+++ b/.github/workflows/blackhole-post-commit.yaml
@@ -143,6 +143,8 @@ jobs:
     uses: ./.github/workflows/build-artifact.yaml
     permissions:
       packages: write
+      contents: read
+      actions: read
     secrets: inherit
     with:
       build-type: ${{ inputs.build-type || 'Release' }}
@@ -151,6 +153,7 @@ jobs:
       platform: ${{ inputs.platform || 'Ubuntu 22.04' }}
       build-umd-tests: true
       enable-lto: ${{ inputs.enable-lto || false }}
+      use-artifacts-from-run: 22425884273
   run-profiler-regression:
     needs: [build-artifact, generate-matrix]
     uses: ./.github/workflows/run-profiler-regression.yaml

--- a/.github/workflows/blackhole-post-commit.yaml
+++ b/.github/workflows/blackhole-post-commit.yaml
@@ -212,6 +212,7 @@ jobs:
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
       enable-watcher: ${{ inputs.enable-watcher || false }}
+      timeout-minutes-override: ${{ inputs.enable-watcher && 120 || 0 }}
   ops-unit-tests:
     needs: [build-artifact, generate-matrix]
     secrets: inherit

--- a/.github/workflows/merge-gate.yaml
+++ b/.github/workflows/merge-gate.yaml
@@ -292,19 +292,12 @@ jobs:
             needs.find-changes.outputs.tt-nn-changed == 'true' ||
             needs.find-changes.outputs.tt-metalium-or-tt-nn-tests-changed == 'true'
         }}
-    strategy:
-      fail-fast: false
-      matrix:
-        test-group: [
-          { arch: wormhole_b0, runner-label: N300 }
-        ]
     uses: ./.github/workflows/ttnn-post-commit.yaml
     secrets: inherit
     with:
+      enabled-skus: "wh_n300_civ2"
       docker-image: ${{ needs.build.outputs.dev-docker-image }}
       wheel-artifact-name: ${{ needs.build.outputs.wheel-artifact-name }}
-      arch: ${{ matrix.test-group.arch }}
-      runner-label: ${{ matrix.test-group.runner-label }}
       merge-gate-call: true
 
   # TT-CNN Unit tests

--- a/.github/workflows/merge-gate.yaml
+++ b/.github/workflows/merge-gate.yaml
@@ -115,8 +115,6 @@ jobs:
     uses: ./.github/workflows/build-artifact.yaml
     permissions:
       packages: write
-      contents: read
-      actions: read
     secrets: inherit
     with:
       build-type: Release
@@ -130,7 +128,6 @@ jobs:
       basic-dev-docker-image: ${{ needs.docker-images.outputs.ubuntu-2204-basic-dev-tag }}
       basic-ttnn-runtime-docker-image: ${{ needs.docker-images.outputs.ubuntu-2204-basic-ttnn-runtime-tag }}
       manylinux-docker-image: ${{ needs.docker-images.outputs.manylinux-tag }}
-      use-artifacts-from-run: 22425884273
 
   build-tsan:
     if: ${{ github.ref_name == 'main' ||

--- a/.github/workflows/merge-gate.yaml
+++ b/.github/workflows/merge-gate.yaml
@@ -292,12 +292,19 @@ jobs:
             needs.find-changes.outputs.tt-nn-changed == 'true' ||
             needs.find-changes.outputs.tt-metalium-or-tt-nn-tests-changed == 'true'
         }}
+    strategy:
+      fail-fast: false
+      matrix:
+        test-group: [
+          { arch: wormhole_b0, runner-label: N300 }
+        ]
     uses: ./.github/workflows/ttnn-post-commit.yaml
     secrets: inherit
     with:
-      enabled-skus: "wh_n300_civ2"
       docker-image: ${{ needs.build.outputs.dev-docker-image }}
       wheel-artifact-name: ${{ needs.build.outputs.wheel-artifact-name }}
+      arch: ${{ matrix.test-group.arch }}
+      runner-label: ${{ matrix.test-group.runner-label }}
       merge-gate-call: true
 
   # TT-CNN Unit tests

--- a/.github/workflows/merge-gate.yaml
+++ b/.github/workflows/merge-gate.yaml
@@ -115,6 +115,8 @@ jobs:
     uses: ./.github/workflows/build-artifact.yaml
     permissions:
       packages: write
+      contents: read
+      actions: read
     secrets: inherit
     with:
       build-type: Release
@@ -128,6 +130,7 @@ jobs:
       basic-dev-docker-image: ${{ needs.docker-images.outputs.ubuntu-2204-basic-dev-tag }}
       basic-ttnn-runtime-docker-image: ${{ needs.docker-images.outputs.ubuntu-2204-basic-ttnn-runtime-tag }}
       manylinux-docker-image: ${{ needs.docker-images.outputs.manylinux-tag }}
+      use-artifacts-from-run: 22425884273
 
   build-tsan:
     if: ${{ github.ref_name == 'main' ||

--- a/.github/workflows/ttnn-post-commit.yaml
+++ b/.github/workflows/ttnn-post-commit.yaml
@@ -3,10 +3,16 @@ name: "[internal] ttnn unit tests impl"
 on:
   workflow_call:
     inputs:
-      enabled-skus:
+      arch:
         required: true
         type: string
-        description: "Comma-separated SKUs (e.g. wh_n300_civ2). Maps to runs_on via .github/sku_config.yaml."
+      runner-label:
+        required: true
+        type: string
+      timeout:
+        required: false
+        type: number
+        default: 40
       docker-image:
         required: true
         type: string
@@ -37,70 +43,94 @@ on:
         default: ""
         description: "Commit SHA to test (default: HEAD)"
 
+  workflow_dispatch:
+    inputs:
+      arch:
+        required: true
+        type: choice
+        options:
+          - wormhole_b0
+          - blackhole
+      runner-label:
+        required: true
+        type: choice
+        options:
+          - N150
+          - N300
+          - BH
+      timeout:
+        required: false
+        type: number
+        default: 40
+      docker-image:
+        required: true
+        type: string
+      wheel-artifact-name:
+        required: true
+        type: string
+      merge-gate-call:
+        required: false
+        type: boolean
+        default: false
+
 jobs:
-  load-test-matrix:
+  define-ttnn-tests:
     runs-on: ubuntu-latest
-    outputs:
-      matrix: ${{ steps.filter-matrix.outputs.matrix }}
     env:
-      TESTS_YAML_PATH: ./tests/pipeline_reorg/ttnn-tests.yaml
+      TTNN_TESTS_YAML: tests/pipeline_reorg/ttnn-tests.yaml
+    outputs:
+      ttnn-tests: ${{ steps.compute-tests.outputs.ttnn-tests }}
     steps:
-      - name: Checkout the repository
+      - name: Checkout repository for test definitions
         uses: actions/checkout@v4
         with:
           ref: ${{ inputs.ref || github.sha }}
-          sparse-checkout: |
-            .github
-            tests/pipeline_reorg
-          sparse-checkout-cone-mode: true
+          sparse-checkout: ${{ env.TTNN_TESTS_YAML }}
+          sparse-checkout-cone-mode: false
 
-      - name: Install dependencies
+      - name: Compute tests
+        shell: bash
+        id: compute-tests
         run: |
-          pip3 install PyYAML
+          set -euo pipefail
 
-      - name: Verify test timeouts against budget
-        run: |
-          set -e
-          python3 .github/scripts/utils/verify_time_budget.py \
-            ${{ env.TESTS_YAML_PATH }} \
-            ./.github/time_budget.yaml \
-            "sanity"
+          # Read test definitions from shared YAML file
+          echo "[info] Reading test definitions from $TTNN_TESTS_YAML"
+          default_ttnn_tests=$(yq -o=json '.tests' "$TTNN_TESTS_YAML")
+          echo "[info] Loaded tests:"
+          echo "$default_ttnn_tests" | jq
 
-      - name: Build test matrix based on enabled SKUs
-        id: build-matrix
-        run: |
-          python3 .github/scripts/utils/prepare_test_matrix.py \
-            ${{ env.TESTS_YAML_PATH }} \
-            "${{ inputs.enabled-skus }}" \
-            ./.github/sku_config.yaml
+          # Filter based on merge-gate-call input
+          requested_ttnn_tests=$(jq --argjson merge_gate_call "${{ inputs.merge-gate-call }}" \
+            '[.[] | select(.merge_gate == $merge_gate_call)]' <<< "$default_ttnn_tests")
+          echo "[info] After filtering for merge_gate=${{ inputs.merge-gate-call }}: $requested_ttnn_tests"
 
-      - name: Filter matrix by merge_gate
-        id: filter-matrix
-        run: |
-          merge_gate="${{ inputs.merge-gate-call }}"
-          matrix='${{ steps.build-matrix.outputs.matrix }}'
-          filtered=$(echo "$matrix" | jq -c --argjson mg "$merge_gate" 'map(select((.merge_gate // false) == $mg))')
-          len=$(echo "$filtered" | jq 'length')
-          if [ "$len" -eq 0 ]; then
-            echo "::error::No tests left after filtering for merge_gate=$merge_gate"
-            exit 1
-          fi
-          echo "matrix<<EOF" >> "$GITHUB_OUTPUT"
-          echo "$filtered" >> "$GITHUB_OUTPUT"
-          echo "EOF" >> "$GITHUB_OUTPUT"
-
+          # Check that we have a valid test list that's not empty
+          echo "$requested_ttnn_tests" | jq -e 'if type != "array" then error("Not a valid JSON array") elif length == 0 then error("Test list is empty") else . end' && echo "Valid test configs"
+          echo "ttnn-tests=$(echo $requested_ttnn_tests | tr -d '\n')" >> "$GITHUB_OUTPUT"
+          echo "[info] Showing GITHUB_OUTPUT"
+          cat "$GITHUB_OUTPUT"
   ttnn:
-    needs: load-test-matrix
+    needs: define-ttnn-tests
     strategy:
+      # Do not fail-fast because we need to ensure all tests go to completion
+      # so we try not to get hanging machines
       fail-fast: false
       matrix:
-        test-group: ${{ fromJson(needs.load-test-matrix.outputs.matrix) }}
-    name: ${{ matrix.test-group.name }}
-    runs-on: ${{ matrix.test-group.runs_on }}
+        os: ["ubuntu-22.04"]
+        test-group: ${{ fromJSON(needs.define-ttnn-tests.outputs.ttnn-tests) }}
+    name: ${{ matrix.test-group.name }} ${{ inputs.arch }} ${{ inputs.runner-label }}
+    runs-on: >-
+      ${{
+        (inputs.runner-label == 'P100') && fromJSON(format('["in-service", "cloud-virtual-machine", "{0}"]', inputs.runner-label))
+        || ((inputs.runner-label == 'P150b') && format('tt-ubuntu-2204-{0}-stable', inputs.runner-label))
+        || format('tt-ubuntu-2204-{0}-viommu-stable', inputs.runner-label)
+      }}
     environment: ${{ github.ref == 'refs/heads/main' && 'mainline' || '' }}
     container:
-      image: ${{ matrix.test-group.sku != 'bh_p100' && format('harbor.ci.tenstorrent.net/{0}', inputs.docker-image) || inputs.docker-image || 'docker-image-unresolved!'}}
+      image: ${{ ((inputs.runner-label != 'P100') && format('harbor.ci.tenstorrent.net/{0}', inputs.docker-image)) || inputs.docker-image || 'docker-image-unresolved!' }}
       env:
+        ARCH_NAME: ${{ inputs.arch }}
         LOGURU_LEVEL: INFO
         PYTHONPATH: /work
       volumes:
@@ -138,7 +168,7 @@ jobs:
           echo "TTNN_CONFIG_OVERRIDES={\"enable_fast_runtime_mode\": false}" >> $GITHUB_ENV
 
       - name: ${{ matrix.test-group.name }} tests
-        timeout-minutes: ${{ matrix.test-group.timeout }}
+        timeout-minutes: ${{ inputs.timeout }}
         run: |
           ${{ matrix.test-group.cmd }}
 
@@ -153,7 +183,7 @@ jobs:
         if: ${{ failure() }}
         with:
           slack_webhook_url: ${{ secrets.SLACK_METAL_INFRA_PIPELINE_STATUS_ALERT }}
-          owner: ${{ matrix.test-group.owner_id }}
+          owner: U06CXU895AP # Michael Chiou
 
       - uses: tenstorrent/tt-metal/.github/actions/upload-artifact-with-job-uuid@main
         timeout-minutes: 10

--- a/.github/workflows/ttnn-post-commit.yaml
+++ b/.github/workflows/ttnn-post-commit.yaml
@@ -3,16 +3,10 @@ name: "[internal] ttnn unit tests impl"
 on:
   workflow_call:
     inputs:
-      arch:
+      enabled-skus:
         required: true
         type: string
-      runner-label:
-        required: true
-        type: string
-      timeout:
-        required: false
-        type: number
-        default: 40
+        description: "Comma-separated SKUs (e.g. wh_n300_civ2). Maps to runs_on via .github/sku_config.yaml."
       docker-image:
         required: true
         type: string
@@ -43,94 +37,70 @@ on:
         default: ""
         description: "Commit SHA to test (default: HEAD)"
 
-  workflow_dispatch:
-    inputs:
-      arch:
-        required: true
-        type: choice
-        options:
-          - wormhole_b0
-          - blackhole
-      runner-label:
-        required: true
-        type: choice
-        options:
-          - N150
-          - N300
-          - BH
-      timeout:
-        required: false
-        type: number
-        default: 40
-      docker-image:
-        required: true
-        type: string
-      wheel-artifact-name:
-        required: true
-        type: string
-      merge-gate-call:
-        required: false
-        type: boolean
-        default: false
-
 jobs:
-  define-ttnn-tests:
+  load-test-matrix:
     runs-on: ubuntu-latest
-    env:
-      TTNN_TESTS_YAML: tests/pipeline_reorg/ttnn-tests.yaml
     outputs:
-      ttnn-tests: ${{ steps.compute-tests.outputs.ttnn-tests }}
+      matrix: ${{ steps.filter-matrix.outputs.matrix }}
+    env:
+      TESTS_YAML_PATH: ./tests/pipeline_reorg/ttnn-tests.yaml
     steps:
-      - name: Checkout repository for test definitions
+      - name: Checkout the repository
         uses: actions/checkout@v4
         with:
           ref: ${{ inputs.ref || github.sha }}
-          sparse-checkout: ${{ env.TTNN_TESTS_YAML }}
-          sparse-checkout-cone-mode: false
+          sparse-checkout: |
+            .github
+            tests/pipeline_reorg
+          sparse-checkout-cone-mode: true
 
-      - name: Compute tests
-        shell: bash
-        id: compute-tests
+      - name: Install dependencies
         run: |
-          set -euo pipefail
+          pip3 install PyYAML
 
-          # Read test definitions from shared YAML file
-          echo "[info] Reading test definitions from $TTNN_TESTS_YAML"
-          default_ttnn_tests=$(yq -o=json '.tests' "$TTNN_TESTS_YAML")
-          echo "[info] Loaded tests:"
-          echo "$default_ttnn_tests" | jq
+      - name: Verify test timeouts against budget
+        run: |
+          set -e
+          python3 .github/scripts/utils/verify_time_budget.py \
+            ${{ env.TESTS_YAML_PATH }} \
+            ./.github/time_budget.yaml \
+            "sanity"
 
-          # Filter based on merge-gate-call input
-          requested_ttnn_tests=$(jq --argjson merge_gate_call "${{ inputs.merge-gate-call }}" \
-            '[.[] | select(.merge_gate == $merge_gate_call)]' <<< "$default_ttnn_tests")
-          echo "[info] After filtering for merge_gate=${{ inputs.merge-gate-call }}: $requested_ttnn_tests"
+      - name: Build test matrix based on enabled SKUs
+        id: build-matrix
+        run: |
+          python3 .github/scripts/utils/prepare_test_matrix.py \
+            ${{ env.TESTS_YAML_PATH }} \
+            "${{ inputs.enabled-skus }}" \
+            ./.github/sku_config.yaml
 
-          # Check that we have a valid test list that's not empty
-          echo "$requested_ttnn_tests" | jq -e 'if type != "array" then error("Not a valid JSON array") elif length == 0 then error("Test list is empty") else . end' && echo "Valid test configs"
-          echo "ttnn-tests=$(echo $requested_ttnn_tests | tr -d '\n')" >> "$GITHUB_OUTPUT"
-          echo "[info] Showing GITHUB_OUTPUT"
-          cat "$GITHUB_OUTPUT"
+      - name: Filter matrix by merge_gate
+        id: filter-matrix
+        run: |
+          merge_gate="${{ inputs.merge-gate-call }}"
+          matrix='${{ steps.build-matrix.outputs.matrix }}'
+          filtered=$(echo "$matrix" | jq -c --argjson mg "$merge_gate" 'map(select((.merge_gate // false) == $mg))')
+          len=$(echo "$filtered" | jq 'length')
+          if [ "$len" -eq 0 ]; then
+            echo "::error::No tests left after filtering for merge_gate=$merge_gate"
+            exit 1
+          fi
+          echo "matrix<<EOF" >> "$GITHUB_OUTPUT"
+          echo "$filtered" >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
+
   ttnn:
-    needs: define-ttnn-tests
+    needs: load-test-matrix
     strategy:
-      # Do not fail-fast because we need to ensure all tests go to completion
-      # so we try not to get hanging machines
       fail-fast: false
       matrix:
-        os: ["ubuntu-22.04"]
-        test-group: ${{ fromJSON(needs.define-ttnn-tests.outputs.ttnn-tests) }}
-    name: ${{ matrix.test-group.name }} ${{ inputs.arch }} ${{ inputs.runner-label }}
-    runs-on: >-
-      ${{
-        (inputs.runner-label == 'P100') && fromJSON(format('["in-service", "cloud-virtual-machine", "{0}"]', inputs.runner-label))
-        || ((inputs.runner-label == 'P150b') && format('tt-ubuntu-2204-{0}-stable', inputs.runner-label))
-        || format('tt-ubuntu-2204-{0}-viommu-stable', inputs.runner-label)
-      }}
+        test-group: ${{ fromJson(needs.load-test-matrix.outputs.matrix) }}
+    name: ${{ matrix.test-group.name }}
+    runs-on: ${{ matrix.test-group.runs_on }}
     environment: ${{ github.ref == 'refs/heads/main' && 'mainline' || '' }}
     container:
-      image: ${{ ((inputs.runner-label != 'P100') && format('harbor.ci.tenstorrent.net/{0}', inputs.docker-image)) || inputs.docker-image || 'docker-image-unresolved!' }}
+      image: ${{ matrix.test-group.sku != 'bh_p100' && format('harbor.ci.tenstorrent.net/{0}', inputs.docker-image) || inputs.docker-image || 'docker-image-unresolved!'}}
       env:
-        ARCH_NAME: ${{ inputs.arch }}
         LOGURU_LEVEL: INFO
         PYTHONPATH: /work
       volumes:
@@ -168,7 +138,7 @@ jobs:
           echo "TTNN_CONFIG_OVERRIDES={\"enable_fast_runtime_mode\": false}" >> $GITHUB_ENV
 
       - name: ${{ matrix.test-group.name }} tests
-        timeout-minutes: ${{ inputs.timeout }}
+        timeout-minutes: ${{ matrix.test-group.timeout }}
         run: |
           ${{ matrix.test-group.cmd }}
 
@@ -183,7 +153,7 @@ jobs:
         if: ${{ failure() }}
         with:
           slack_webhook_url: ${{ secrets.SLACK_METAL_INFRA_PIPELINE_STATUS_ALERT }}
-          owner: U06CXU895AP # Michael Chiou
+          owner: ${{ matrix.test-group.owner_id }}
 
       - uses: tenstorrent/tt-metal/.github/actions/upload-artifact-with-job-uuid@main
         timeout-minutes: 10

--- a/.github/workflows/ttnn-post-commit.yaml
+++ b/.github/workflows/ttnn-post-commit.yaml
@@ -36,6 +36,11 @@ on:
         type: string
         default: ""
         description: "Commit SHA to test (default: HEAD)"
+      timeout-minutes-override:
+        required: false
+        type: number
+        default: 0
+        description: "If > 0, skip time budget verification and use this as job timeout (e.g. 240 for APC watcher, 120 for BHPC watcher)."
 
 jobs:
   load-test-matrix:
@@ -59,6 +64,7 @@ jobs:
           pip3 install PyYAML
 
       - name: Verify test timeouts against budget
+        if: ${{ inputs.timeout-minutes-override == 0 }}
         run: |
           set -e
           python3 .github/scripts/utils/verify_time_budget.py \
@@ -138,7 +144,7 @@ jobs:
           echo "TTNN_CONFIG_OVERRIDES={\"enable_fast_runtime_mode\": false}" >> $GITHUB_ENV
 
       - name: ${{ matrix.test-group.name }} tests
-        timeout-minutes: ${{ matrix.test-group.timeout }}
+        timeout-minutes: ${{ inputs.timeout-minutes-override > 0 && inputs.timeout-minutes-override || matrix.test-group.timeout }}
         run: |
           ${{ matrix.test-group.cmd }}
 

--- a/.github/workflows/ttsim.yaml
+++ b/.github/workflows/ttsim.yaml
@@ -157,30 +157,37 @@ jobs:
     outputs:
       ttnn-tests: ${{ steps.compute-tests.outputs.ttnn-tests }}
     steps:
-      # Note: This checkout is needed because this is a separate job that runs before ttnn-pytests.
-      # Each job runs in a fresh environment, so we can't reuse the checkout from ttnn-pytests.
-      # We use sparse checkout to efficiently fetch only the test definitions YAML file.
       - name: Checkout repository for test definitions
         uses: actions/checkout@v4
         with:
-          sparse-checkout: ${{ env.TTNN_TESTS_YAML }}
-          sparse-checkout-cone-mode: false
+          sparse-checkout: |
+            .github
+            tests/pipeline_reorg
+          sparse-checkout-cone-mode: true
 
       - name: Compute TTSim-compatible tests
         shell: bash
         id: compute-tests
         run: |
           set -euo pipefail
-
-          # Read test definitions from shared YAML file and filter for ttsim-compatible tests
-          echo "[info] Reading test definitions from $TTNN_TESTS_YAML"
-          ttsim_tests=$(yq -o=json '.tests | [.[] | select(.ttsim == true)]' "$TTNN_TESTS_YAML")
-          echo "[info] TTSim-compatible tests:"
-          echo "$ttsim_tests" | jq
-
-          # Check that we have a valid test list
-          echo "$ttsim_tests" | jq -e 'if type != "array" then error("Not a valid JSON array") elif length == 0 then error("Test list is empty") else . end' && echo "Valid test configs"
-          echo "ttnn-tests=$(echo $ttsim_tests | tr -d '\n')" >> "$GITHUB_OUTPUT"
+          pip3 install -q PyYAML
+          python3 - "${{ env.TTNN_TESTS_YAML }}" "$GITHUB_OUTPUT" << 'PY'
+          import json, sys, yaml
+          path, out_path = sys.argv[1], sys.argv[2]
+          with open(path) as f:
+              tests = yaml.safe_load(f)
+          # TTSim runs all tests on ubuntu-latest; ignore skus and timeouts from YAML, use fixed timeout.
+          TTSIM_TIMEOUT_MINUTES = 15
+          entries = []
+          for t in tests:
+              if not t.get("ttsim") or not t.get("cmd"):
+                  continue
+              entries.append({"name": t.get("name", "Unnamed Test"), "cmd": t.get("cmd", ""), "timeout": TTSIM_TIMEOUT_MINUTES})
+          if not entries:
+              raise SystemExit("No TTSim-compatible TTNN tests found (ttsim: true)")
+          with open(out_path, "a") as f:
+              f.write("ttnn-tests<<EOF\n" + json.dumps(entries) + "\nEOF\n")
+          PY
 
   # ---------------------------------------------------------------------------
   # TTNN Pytests on TTSim (uses shared test definitions)
@@ -215,7 +222,6 @@ jobs:
       volumes:
         - ${{ github.workspace }}:/work
       env:
-        ARCH_NAME: ${{ matrix.arch.name }}
         TT_METAL_SIMULATOR_HOME: /work/sim
         TT_METAL_SIMULATOR: /work/sim/libttsim.so
         TT_METAL_SLOW_DISPATCH_MODE: 1

--- a/.github/workflows/ttsim.yaml
+++ b/.github/workflows/ttsim.yaml
@@ -157,37 +157,30 @@ jobs:
     outputs:
       ttnn-tests: ${{ steps.compute-tests.outputs.ttnn-tests }}
     steps:
+      # Note: This checkout is needed because this is a separate job that runs before ttnn-pytests.
+      # Each job runs in a fresh environment, so we can't reuse the checkout from ttnn-pytests.
+      # We use sparse checkout to efficiently fetch only the test definitions YAML file.
       - name: Checkout repository for test definitions
         uses: actions/checkout@v4
         with:
-          sparse-checkout: |
-            .github
-            tests/pipeline_reorg
-          sparse-checkout-cone-mode: true
+          sparse-checkout: ${{ env.TTNN_TESTS_YAML }}
+          sparse-checkout-cone-mode: false
 
       - name: Compute TTSim-compatible tests
         shell: bash
         id: compute-tests
         run: |
           set -euo pipefail
-          pip3 install -q PyYAML
-          python3 - "${{ env.TTNN_TESTS_YAML }}" "$GITHUB_OUTPUT" << 'PY'
-          import json, sys, yaml
-          path, out_path = sys.argv[1], sys.argv[2]
-          with open(path) as f:
-              tests = yaml.safe_load(f)
-          # TTSim runs all tests on ubuntu-latest; ignore skus and timeouts from YAML, use fixed timeout.
-          TTSIM_TIMEOUT_MINUTES = 15
-          entries = []
-          for t in tests:
-              if not t.get("ttsim") or not t.get("cmd"):
-                  continue
-              entries.append({"name": t.get("name", "Unnamed Test"), "cmd": t.get("cmd", ""), "timeout": TTSIM_TIMEOUT_MINUTES})
-          if not entries:
-              raise SystemExit("No TTSim-compatible TTNN tests found (ttsim: true)")
-          with open(out_path, "a") as f:
-              f.write("ttnn-tests<<EOF\n" + json.dumps(entries) + "\nEOF\n")
-          PY
+
+          # Read test definitions from shared YAML file and filter for ttsim-compatible tests
+          echo "[info] Reading test definitions from $TTNN_TESTS_YAML"
+          ttsim_tests=$(yq -o=json '.tests | [.[] | select(.ttsim == true)]' "$TTNN_TESTS_YAML")
+          echo "[info] TTSim-compatible tests:"
+          echo "$ttsim_tests" | jq
+
+          # Check that we have a valid test list
+          echo "$ttsim_tests" | jq -e 'if type != "array" then error("Not a valid JSON array") elif length == 0 then error("Test list is empty") else . end' && echo "Valid test configs"
+          echo "ttnn-tests=$(echo $ttsim_tests | tr -d '\n')" >> "$GITHUB_OUTPUT"
 
   # ---------------------------------------------------------------------------
   # TTNN Pytests on TTSim (uses shared test definitions)
@@ -222,6 +215,7 @@ jobs:
       volumes:
         - ${{ github.workspace }}:/work
       env:
+        ARCH_NAME: ${{ matrix.arch.name }}
         TT_METAL_SIMULATOR_HOME: /work/sim
         TT_METAL_SIMULATOR: /work/sim/libttsim.so
         TT_METAL_SLOW_DISPATCH_MODE: 1

--- a/.github/workflows/ttsim.yaml
+++ b/.github/workflows/ttsim.yaml
@@ -177,7 +177,7 @@ jobs:
           with open(path) as f:
               tests = yaml.safe_load(f)
           # TTSim runs all tests on ubuntu-latest; ignore skus and timeouts from YAML, use fixed timeout.
-          TTSIM_TIMEOUT_MINUTES = 15
+          TTSIM_TIMEOUT_MINUTES = 20
           entries = []
           for t in tests:
               if not t.get("ttsim") or not t.get("cmd"):

--- a/tests/pipeline_reorg/ttnn-tests.yaml
+++ b/tests/pipeline_reorg/ttnn-tests.yaml
@@ -5,135 +5,194 @@
 #   - ttnn-post-commit.yaml (hardware CI)
 #   - ttsim.yaml (simulator CI)
 #
-# Each test group can have the following fields:
-#   - name: Display name for the test group (required)
-#   - cmd: The pytest command to run (required)
-#   - timeout: GHA job-level timeout in minutes (required)
-#   - merge_gate: If true, run during merge-gate (default: false)
-#   - ttsim: If true, can run on TTSim simulator (default: true)
-#   - fast_runtime_mode_off: If true, disable fast runtime mode (default: false)
+# Each entry: name, cmd, skus: { <sku>: { timeout: N } }, team, owner_id.
+# Optional: merge_gate (filter in workflow), ttsim (for TTSim), fast_runtime_mode_off.
 # =============================================================================
 
-tests:
-  # ---------------------------------------------------------------------------
-  # Example tests
-  # ---------------------------------------------------------------------------
-  - name: "ttnn example tests"
-    cmd: "./tests/scripts/run_ttnn_examples.sh"
-    timeout: 15
-    merge_gate: true
-    ttsim: false  # Examples use features not supported in simulator
+- name: "ttnn example tests"
+  cmd: "./tests/scripts/run_ttnn_examples.sh"
+  skus:
+    wh_n300_civ2:
+      timeout: 40
+    bh_p100:
+      timeout: 40
+    bh_p150b_civ2:
+      timeout: 40
+  team: ttnn
+  owner_id: U076Z1JJUQZ # Artem Yerofieiev
+  merge_gate: true
+  ttsim: false
 
-  # ---------------------------------------------------------------------------
-  # Eltwise operation tests (split into 5 groups for parallelization)
-  # ---------------------------------------------------------------------------
-  - name: "ttnn eltwise group 1"
-    cmd: 'pytest --timeout 300 tests/ttnn/unit_tests/operations/eltwise -xv --splits 5 --group 1 -m "not disable_fast_runtime_mode"'
-    timeout: 15
-    merge_gate: false
-    ttsim: true
+- name: "ttnn eltwise group 1"
+  cmd: 'pytest --timeout 300 tests/ttnn/unit_tests/operations/eltwise -xv --splits 5 --group 1 -m "not disable_fast_runtime_mode"'
+  skus:
+    wh_n300_civ2:
+      timeout: 40
+    bh_p100:
+      timeout: 40
+    bh_p150b_civ2:
+      timeout: 40
+  team: ttnn
+  owner_id: U08411R54Q2 # Chris Maryan
+  merge_gate: false
+  ttsim: true
 
-  - name: "ttnn eltwise group 2"
-    cmd: 'pytest --timeout 300 tests/ttnn/unit_tests/operations/eltwise -xv --splits 5 --group 2 -m "not disable_fast_runtime_mode"'
-    timeout: 15
-    merge_gate: false
-    ttsim: true
+- name: "ttnn eltwise group 2"
+  cmd: 'pytest --timeout 300 tests/ttnn/unit_tests/operations/eltwise -xv --splits 5 --group 2 -m "not disable_fast_runtime_mode"'
+  skus:
+    wh_n300_civ2:
+      timeout: 40
+    bh_p100:
+      timeout: 40
+    bh_p150b_civ2:
+      timeout: 40
+  team: ttnn
+  owner_id: U08411R54Q2 # Chris Maryan
+  merge_gate: false
+  ttsim: true
 
-  - name: "ttnn eltwise group 3"
-    cmd: 'pytest --timeout 300 tests/ttnn/unit_tests/operations/eltwise -xv --splits 5 --group 3 -m "not disable_fast_runtime_mode"'
-    timeout: 15
-    merge_gate: false
-    ttsim: true
+- name: "ttnn eltwise group 3"
+  cmd: 'pytest --timeout 300 tests/ttnn/unit_tests/operations/eltwise -xv --splits 5 --group 3 -m "not disable_fast_runtime_mode"'
+  skus:
+    wh_n300_civ2:
+      timeout: 40
+    bh_p100:
+      timeout: 40
+    bh_p150b_civ2:
+      timeout: 40
+  team: ttnn
+  owner_id: U08411R54Q2 # Chris Maryan
+  merge_gate: false
+  ttsim: true
 
-  - name: "ttnn eltwise group 4"
-    cmd: 'pytest --timeout 300 tests/ttnn/unit_tests/operations/eltwise -xv --splits 5 --group 4 -m "not disable_fast_runtime_mode"'
-    timeout: 15
-    merge_gate: false
-    ttsim: true
+- name: "ttnn eltwise group 4"
+  cmd: 'pytest --timeout 300 tests/ttnn/unit_tests/operations/eltwise -xv --splits 5 --group 4 -m "not disable_fast_runtime_mode"'
+  skus:
+    wh_n300_civ2:
+      timeout: 40
+    bh_p100:
+      timeout: 40
+    bh_p150b_civ2:
+      timeout: 40
+  team: ttnn
+  owner_id: U08411R54Q2 # Chris Maryan
+  merge_gate: false
+  ttsim: true
 
-  - name: "ttnn eltwise group 5"
-    cmd: 'pytest --timeout 300 tests/ttnn/unit_tests/operations/eltwise -xv --splits 5 --group 5 -m "not disable_fast_runtime_mode"'
-    timeout: 15
-    merge_gate: false
-    ttsim: true
+- name: "ttnn eltwise group 5"
+  cmd: 'pytest --timeout 300 tests/ttnn/unit_tests/operations/eltwise -xv --splits 5 --group 5 -m "not disable_fast_runtime_mode"'
+  skus:
+    wh_n300_civ2:
+      timeout: 40
+    bh_p100:
+      timeout: 40
+    bh_p150b_civ2:
+      timeout: 40
+  team: ttnn
+  owner_id: U08411R54Q2 # Chris Maryan
+  merge_gate: false
+  ttsim: true
 
-  # ---------------------------------------------------------------------------
-  # Convolution tests
-  # ---------------------------------------------------------------------------
-  - name: "ttnn conv group"
-    cmd: 'pytest --timeout 300 tests/ttnn/unit_tests/operations/conv -xv -m "not disable_fast_runtime_mode"'
-    timeout: 15
-    merge_gate: false
-    ttsim: true
+- name: "ttnn conv group"
+  cmd: 'pytest --timeout 300 tests/ttnn/unit_tests/operations/conv -xv -m "not disable_fast_runtime_mode"'
+  skus:
+    wh_n300_civ2:
+      timeout: 40
+    bh_p100:
+      timeout: 40
+    bh_p150b_civ2:
+      timeout: 40
+  team: ttnn
+  owner_id: U085GDCAZTN # Pavle Josipovic
+  merge_gate: false
+  ttsim: true
 
-  # ---------------------------------------------------------------------------
-  # Pooling tests
-  # ---------------------------------------------------------------------------
-  - name: "ttnn pool group"
-    cmd: 'pytest --timeout 300 tests/ttnn/unit_tests/operations/pool -xv -m "not disable_fast_runtime_mode"'
-    timeout: 15
-    merge_gate: false
-    ttsim: true
+- name: "ttnn pool group"
+  cmd: 'pytest --timeout 300 tests/ttnn/unit_tests/operations/pool -xv -m "not disable_fast_runtime_mode"'
+  skus:
+    wh_n300_civ2:
+      timeout: 40
+    bh_p100:
+      timeout: 40
+    bh_p150b_civ2:
+      timeout: 40
+  team: ttnn
+  owner_id: U085GDCAZTN # Pavle Josipovic
+  merge_gate: false
+  ttsim: true
 
-  # ---------------------------------------------------------------------------
-  # Matrix multiplication tests
-  # ---------------------------------------------------------------------------
-  - name: "ttnn matmul group"
-    cmd: 'pytest --timeout 300 tests/ttnn/unit_tests/operations/matmul -xv -m "not disable_fast_runtime_mode"'
-    timeout: 15
-    merge_gate: false
-    ttsim: true
+- name: "ttnn matmul group"
+  cmd: 'pytest --timeout 300 tests/ttnn/unit_tests/operations/matmul -xv -m "not disable_fast_runtime_mode"'
+  skus:
+    wh_n300_civ2:
+      timeout: 40
+    bh_p100:
+      timeout: 40
+    bh_p150b_civ2:
+      timeout: 40
+  team: ttnn
+  owner_id: U084B1CES7M # Borys Bradel
+  merge_gate: false
+  ttsim: true
 
-  # ---------------------------------------------------------------------------
-  # Fused operation tests
-  # ---------------------------------------------------------------------------
-  - name: "ttnn fused group"
-    cmd: 'pytest --timeout 300 tests/ttnn/unit_tests/operations/fused -xv -m "not disable_fast_runtime_mode"'
-    timeout: 15
-    merge_gate: false
-    ttsim: true
+- name: "ttnn fused group"
+  cmd: 'pytest --timeout 300 tests/ttnn/unit_tests/operations/fused -xv -m "not disable_fast_runtime_mode"'
+  skus:
+    wh_n300_civ2:
+      timeout: 40
+    bh_p100:
+      timeout: 40
+    bh_p150b_civ2:
+      timeout: 40
+  team: ttnn
+  owner_id: U084B1CES7M # Borys Bradel
+  merge_gate: false
+  ttsim: true
 
-  # ---------------------------------------------------------------------------
-  # Transformer operation tests
-  # ---------------------------------------------------------------------------
-  - name: "ttnn transformers group"
-    cmd: 'pytest --timeout 300 tests/ttnn/unit_tests/operations/transformers -xv -m "not disable_fast_runtime_mode"'
-    timeout: 15
-    merge_gate: false
-    ttsim: true
+- name: "ttnn transformers group"
+  cmd: 'pytest --timeout 300 tests/ttnn/unit_tests/operations/transformers -xv -m "not disable_fast_runtime_mode"'
+  skus:
+    wh_n300_civ2:
+      timeout: 40
+    bh_p100:
+      timeout: 40
+    bh_p150b_civ2:
+      timeout: 40
+  team: ttnn
+  owner_id: U06UEFWB4P9 # Colman Glagovich
+  merge_gate: false
+  ttsim: true
 
-  # ---------------------------------------------------------------------------
-  # SDPA / MLA operation tests
-  # ---------------------------------------------------------------------------
-  - name: "ttnn sdpa group"
-    cmd: 'pytest --timeout 300 tests/ttnn/unit_tests/operations/sdpa -xv -m "not disable_fast_runtime_mode"'
-    timeout: 15
-    merge_gate: false
-    ttsim: false  # SDPA tests require device
+- name: "ttnn sdpa group"
+  cmd: 'pytest --timeout 300 tests/ttnn/unit_tests/operations/sdpa -xv -m "not disable_fast_runtime_mode"'
+  timeout: 15
+  merge_gate: false
+  ttsim: false  # SDPA tests require device
 
-  # ---------------------------------------------------------------------------
-  # Reduce and misc operation tests
-  # ---------------------------------------------------------------------------
-  - name: "ttnn reduce and misc ops group"
-    cmd: 'pytest --timeout 300 tests/ttnn/unit_tests/operations/reduce tests/ttnn/unit_tests/operations/debug -xv -m "not disable_fast_runtime_mode"'
-    timeout: 15
-    merge_gate: false
-    ttsim: true
+- name: "ttnn reduce and misc ops group"
+  cmd: 'pytest --timeout 300 tests/ttnn/unit_tests/operations/reduce tests/ttnn/unit_tests/operations/debug -xv -m "not disable_fast_runtime_mode"'
+  skus:
+    wh_n300_civ2:
+      timeout: 40
+    bh_p100:
+      timeout: 40
+    bh_p150b_civ2:
+      timeout: 40
+  team: ttnn
+  owner_id: U084B1CES7M # Borys Bradel
+  merge_gate: false
+  ttsim: true
 
-  # ---------------------------------------------------------------------------
-  # Core TTNN unit tests
-  # ---------------------------------------------------------------------------
-  - name: "core ttnn unit test group"
-    cmd: 'pytest --timeout 300 tests/ttnn/unit_tests/base_functionality tests/ttnn/unit_tests/benchmarks tests/ttnn/unit_tests/tensor -xv -m "not disable_fast_runtime_mode"'
-    timeout: 15
-    merge_gate: false
-    ttsim: true
-
-  # ---------------------------------------------------------------------------
-  # Fast runtime mode off tests (commented out in original)
-  # ---------------------------------------------------------------------------
-  # - name: "ttnn fast runtime off"
-  #   cmd: 'pytest --timeout 300 tests/ttnn/unit_tests -xv -m requires_fast_runtime_mode_off'
-  #   merge_gate: false
-  #   fast_runtime_mode_off: true
-  #   ttsim: false
+- name: "core ttnn unit test group"
+  cmd: 'pytest --timeout 300 tests/ttnn/unit_tests/base_functionality tests/ttnn/unit_tests/benchmarks tests/ttnn/unit_tests/tensor -xv -m "not disable_fast_runtime_mode"'
+  skus:
+    wh_n300_civ2:
+      timeout: 40
+    bh_p100:
+      timeout: 40
+    bh_p150b_civ2:
+      timeout: 40
+  team: ttnn
+  owner_id: U076Z1JJUQZ # Artem Yerofieiev
+  merge_gate: false
+  ttsim: true

--- a/tests/pipeline_reorg/ttnn-tests.yaml
+++ b/tests/pipeline_reorg/ttnn-tests.yaml
@@ -172,6 +172,8 @@
       timeout: 15
     bh_p150b_civ2:
       timeout: 15
+  team: ttnn
+  owner_id: U085GDCAZTN # Pavle Josipovic
   merge_gate: false
   ttsim: false  # SDPA tests require device
 

--- a/tests/pipeline_reorg/ttnn-tests.yaml
+++ b/tests/pipeline_reorg/ttnn-tests.yaml
@@ -5,194 +5,135 @@
 #   - ttnn-post-commit.yaml (hardware CI)
 #   - ttsim.yaml (simulator CI)
 #
-# Each entry: name, cmd, skus: { <sku>: { timeout: N } }, team, owner_id.
-# Optional: merge_gate (filter in workflow), ttsim (for TTSim), fast_runtime_mode_off.
+# Each test group can have the following fields:
+#   - name: Display name for the test group (required)
+#   - cmd: The pytest command to run (required)
+#   - timeout: GHA job-level timeout in minutes (required)
+#   - merge_gate: If true, run during merge-gate (default: false)
+#   - ttsim: If true, can run on TTSim simulator (default: true)
+#   - fast_runtime_mode_off: If true, disable fast runtime mode (default: false)
 # =============================================================================
 
-- name: "ttnn example tests"
-  cmd: "./tests/scripts/run_ttnn_examples.sh"
-  skus:
-    wh_n300_civ2:
-      timeout: 40
-    bh_p100:
-      timeout: 40
-    bh_p150b_civ2:
-      timeout: 40
-  team: ttnn
-  owner_id: U076Z1JJUQZ # Artem Yerofieiev
-  merge_gate: true
-  ttsim: false
+tests:
+  # ---------------------------------------------------------------------------
+  # Example tests
+  # ---------------------------------------------------------------------------
+  - name: "ttnn example tests"
+    cmd: "./tests/scripts/run_ttnn_examples.sh"
+    timeout: 15
+    merge_gate: true
+    ttsim: false  # Examples use features not supported in simulator
 
-- name: "ttnn eltwise group 1"
-  cmd: 'pytest --timeout 300 tests/ttnn/unit_tests/operations/eltwise -xv --splits 5 --group 1 -m "not disable_fast_runtime_mode"'
-  skus:
-    wh_n300_civ2:
-      timeout: 40
-    bh_p100:
-      timeout: 40
-    bh_p150b_civ2:
-      timeout: 40
-  team: ttnn
-  owner_id: U08411R54Q2 # Chris Maryan
-  merge_gate: false
-  ttsim: true
+  # ---------------------------------------------------------------------------
+  # Eltwise operation tests (split into 5 groups for parallelization)
+  # ---------------------------------------------------------------------------
+  - name: "ttnn eltwise group 1"
+    cmd: 'pytest --timeout 300 tests/ttnn/unit_tests/operations/eltwise -xv --splits 5 --group 1 -m "not disable_fast_runtime_mode"'
+    timeout: 15
+    merge_gate: false
+    ttsim: true
 
-- name: "ttnn eltwise group 2"
-  cmd: 'pytest --timeout 300 tests/ttnn/unit_tests/operations/eltwise -xv --splits 5 --group 2 -m "not disable_fast_runtime_mode"'
-  skus:
-    wh_n300_civ2:
-      timeout: 40
-    bh_p100:
-      timeout: 40
-    bh_p150b_civ2:
-      timeout: 40
-  team: ttnn
-  owner_id: U08411R54Q2 # Chris Maryan
-  merge_gate: false
-  ttsim: true
+  - name: "ttnn eltwise group 2"
+    cmd: 'pytest --timeout 300 tests/ttnn/unit_tests/operations/eltwise -xv --splits 5 --group 2 -m "not disable_fast_runtime_mode"'
+    timeout: 15
+    merge_gate: false
+    ttsim: true
 
-- name: "ttnn eltwise group 3"
-  cmd: 'pytest --timeout 300 tests/ttnn/unit_tests/operations/eltwise -xv --splits 5 --group 3 -m "not disable_fast_runtime_mode"'
-  skus:
-    wh_n300_civ2:
-      timeout: 40
-    bh_p100:
-      timeout: 40
-    bh_p150b_civ2:
-      timeout: 40
-  team: ttnn
-  owner_id: U08411R54Q2 # Chris Maryan
-  merge_gate: false
-  ttsim: true
+  - name: "ttnn eltwise group 3"
+    cmd: 'pytest --timeout 300 tests/ttnn/unit_tests/operations/eltwise -xv --splits 5 --group 3 -m "not disable_fast_runtime_mode"'
+    timeout: 15
+    merge_gate: false
+    ttsim: true
 
-- name: "ttnn eltwise group 4"
-  cmd: 'pytest --timeout 300 tests/ttnn/unit_tests/operations/eltwise -xv --splits 5 --group 4 -m "not disable_fast_runtime_mode"'
-  skus:
-    wh_n300_civ2:
-      timeout: 40
-    bh_p100:
-      timeout: 40
-    bh_p150b_civ2:
-      timeout: 40
-  team: ttnn
-  owner_id: U08411R54Q2 # Chris Maryan
-  merge_gate: false
-  ttsim: true
+  - name: "ttnn eltwise group 4"
+    cmd: 'pytest --timeout 300 tests/ttnn/unit_tests/operations/eltwise -xv --splits 5 --group 4 -m "not disable_fast_runtime_mode"'
+    timeout: 15
+    merge_gate: false
+    ttsim: true
 
-- name: "ttnn eltwise group 5"
-  cmd: 'pytest --timeout 300 tests/ttnn/unit_tests/operations/eltwise -xv --splits 5 --group 5 -m "not disable_fast_runtime_mode"'
-  skus:
-    wh_n300_civ2:
-      timeout: 40
-    bh_p100:
-      timeout: 40
-    bh_p150b_civ2:
-      timeout: 40
-  team: ttnn
-  owner_id: U08411R54Q2 # Chris Maryan
-  merge_gate: false
-  ttsim: true
+  - name: "ttnn eltwise group 5"
+    cmd: 'pytest --timeout 300 tests/ttnn/unit_tests/operations/eltwise -xv --splits 5 --group 5 -m "not disable_fast_runtime_mode"'
+    timeout: 15
+    merge_gate: false
+    ttsim: true
 
-- name: "ttnn conv group"
-  cmd: 'pytest --timeout 300 tests/ttnn/unit_tests/operations/conv -xv -m "not disable_fast_runtime_mode"'
-  skus:
-    wh_n300_civ2:
-      timeout: 40
-    bh_p100:
-      timeout: 40
-    bh_p150b_civ2:
-      timeout: 40
-  team: ttnn
-  owner_id: U085GDCAZTN # Pavle Josipovic
-  merge_gate: false
-  ttsim: true
+  # ---------------------------------------------------------------------------
+  # Convolution tests
+  # ---------------------------------------------------------------------------
+  - name: "ttnn conv group"
+    cmd: 'pytest --timeout 300 tests/ttnn/unit_tests/operations/conv -xv -m "not disable_fast_runtime_mode"'
+    timeout: 15
+    merge_gate: false
+    ttsim: true
 
-- name: "ttnn pool group"
-  cmd: 'pytest --timeout 300 tests/ttnn/unit_tests/operations/pool -xv -m "not disable_fast_runtime_mode"'
-  skus:
-    wh_n300_civ2:
-      timeout: 40
-    bh_p100:
-      timeout: 40
-    bh_p150b_civ2:
-      timeout: 40
-  team: ttnn
-  owner_id: U085GDCAZTN # Pavle Josipovic
-  merge_gate: false
-  ttsim: true
+  # ---------------------------------------------------------------------------
+  # Pooling tests
+  # ---------------------------------------------------------------------------
+  - name: "ttnn pool group"
+    cmd: 'pytest --timeout 300 tests/ttnn/unit_tests/operations/pool -xv -m "not disable_fast_runtime_mode"'
+    timeout: 15
+    merge_gate: false
+    ttsim: true
 
-- name: "ttnn matmul group"
-  cmd: 'pytest --timeout 300 tests/ttnn/unit_tests/operations/matmul -xv -m "not disable_fast_runtime_mode"'
-  skus:
-    wh_n300_civ2:
-      timeout: 40
-    bh_p100:
-      timeout: 40
-    bh_p150b_civ2:
-      timeout: 40
-  team: ttnn
-  owner_id: U084B1CES7M # Borys Bradel
-  merge_gate: false
-  ttsim: true
+  # ---------------------------------------------------------------------------
+  # Matrix multiplication tests
+  # ---------------------------------------------------------------------------
+  - name: "ttnn matmul group"
+    cmd: 'pytest --timeout 300 tests/ttnn/unit_tests/operations/matmul -xv -m "not disable_fast_runtime_mode"'
+    timeout: 15
+    merge_gate: false
+    ttsim: true
 
-- name: "ttnn fused group"
-  cmd: 'pytest --timeout 300 tests/ttnn/unit_tests/operations/fused -xv -m "not disable_fast_runtime_mode"'
-  skus:
-    wh_n300_civ2:
-      timeout: 40
-    bh_p100:
-      timeout: 40
-    bh_p150b_civ2:
-      timeout: 40
-  team: ttnn
-  owner_id: U084B1CES7M # Borys Bradel
-  merge_gate: false
-  ttsim: true
+  # ---------------------------------------------------------------------------
+  # Fused operation tests
+  # ---------------------------------------------------------------------------
+  - name: "ttnn fused group"
+    cmd: 'pytest --timeout 300 tests/ttnn/unit_tests/operations/fused -xv -m "not disable_fast_runtime_mode"'
+    timeout: 15
+    merge_gate: false
+    ttsim: true
 
-- name: "ttnn transformers group"
-  cmd: 'pytest --timeout 300 tests/ttnn/unit_tests/operations/transformers -xv -m "not disable_fast_runtime_mode"'
-  skus:
-    wh_n300_civ2:
-      timeout: 40
-    bh_p100:
-      timeout: 40
-    bh_p150b_civ2:
-      timeout: 40
-  team: ttnn
-  owner_id: U06UEFWB4P9 # Colman Glagovich
-  merge_gate: false
-  ttsim: true
+  # ---------------------------------------------------------------------------
+  # Transformer operation tests
+  # ---------------------------------------------------------------------------
+  - name: "ttnn transformers group"
+    cmd: 'pytest --timeout 300 tests/ttnn/unit_tests/operations/transformers -xv -m "not disable_fast_runtime_mode"'
+    timeout: 15
+    merge_gate: false
+    ttsim: true
 
-- name: "ttnn sdpa group"
-  cmd: 'pytest --timeout 300 tests/ttnn/unit_tests/operations/sdpa -xv -m "not disable_fast_runtime_mode"'
-  timeout: 15
-  merge_gate: false
-  ttsim: false  # SDPA tests require device
+  # ---------------------------------------------------------------------------
+  # SDPA / MLA operation tests
+  # ---------------------------------------------------------------------------
+  - name: "ttnn sdpa group"
+    cmd: 'pytest --timeout 300 tests/ttnn/unit_tests/operations/sdpa -xv -m "not disable_fast_runtime_mode"'
+    timeout: 15
+    merge_gate: false
+    ttsim: false  # SDPA tests require device
 
-- name: "ttnn reduce and misc ops group"
-  cmd: 'pytest --timeout 300 tests/ttnn/unit_tests/operations/reduce tests/ttnn/unit_tests/operations/debug -xv -m "not disable_fast_runtime_mode"'
-  skus:
-    wh_n300_civ2:
-      timeout: 40
-    bh_p100:
-      timeout: 40
-    bh_p150b_civ2:
-      timeout: 40
-  team: ttnn
-  owner_id: U084B1CES7M # Borys Bradel
-  merge_gate: false
-  ttsim: true
+  # ---------------------------------------------------------------------------
+  # Reduce and misc operation tests
+  # ---------------------------------------------------------------------------
+  - name: "ttnn reduce and misc ops group"
+    cmd: 'pytest --timeout 300 tests/ttnn/unit_tests/operations/reduce tests/ttnn/unit_tests/operations/debug -xv -m "not disable_fast_runtime_mode"'
+    timeout: 15
+    merge_gate: false
+    ttsim: true
 
-- name: "core ttnn unit test group"
-  cmd: 'pytest --timeout 300 tests/ttnn/unit_tests/base_functionality tests/ttnn/unit_tests/benchmarks tests/ttnn/unit_tests/tensor -xv -m "not disable_fast_runtime_mode"'
-  skus:
-    wh_n300_civ2:
-      timeout: 40
-    bh_p100:
-      timeout: 40
-    bh_p150b_civ2:
-      timeout: 40
-  team: ttnn
-  owner_id: U076Z1JJUQZ # Artem Yerofieiev
-  merge_gate: false
-  ttsim: true
+  # ---------------------------------------------------------------------------
+  # Core TTNN unit tests
+  # ---------------------------------------------------------------------------
+  - name: "core ttnn unit test group"
+    cmd: 'pytest --timeout 300 tests/ttnn/unit_tests/base_functionality tests/ttnn/unit_tests/benchmarks tests/ttnn/unit_tests/tensor -xv -m "not disable_fast_runtime_mode"'
+    timeout: 15
+    merge_gate: false
+    ttsim: true
+
+  # ---------------------------------------------------------------------------
+  # Fast runtime mode off tests (commented out in original)
+  # ---------------------------------------------------------------------------
+  # - name: "ttnn fast runtime off"
+  #   cmd: 'pytest --timeout 300 tests/ttnn/unit_tests -xv -m requires_fast_runtime_mode_off'
+  #   merge_gate: false
+  #   fast_runtime_mode_off: true
+  #   ttsim: false

--- a/tests/pipeline_reorg/ttnn-tests.yaml
+++ b/tests/pipeline_reorg/ttnn-tests.yaml
@@ -165,7 +165,13 @@
 
 - name: "ttnn sdpa group"
   cmd: 'pytest --timeout 300 tests/ttnn/unit_tests/operations/sdpa -xv -m "not disable_fast_runtime_mode"'
-  timeout: 15
+  skus:
+    wh_n300_civ2:
+      timeout: 15
+    bh_p100:
+      timeout: 15
+    bh_p150b_civ2:
+      timeout: 15
   merge_gate: false
   ttsim: false  # SDPA tests require device
 


### PR DESCRIPTION
Change part of APC (ttnn post commit) to use [reorganized pipeline](https://tenstorrent.atlassian.net/wiki/spaces/MI6/pages/1396506680/Proposed+pipeline+and+test+organization+changes) format.

- add `sanity` category of tests in `time_budget.yaml`, to be used by all APC (soon renamed sanity) tests
- updates ttnn post commit to use test yaml with mandatory sku, team, owner fields
- assigns team and owner based on my best guess. removed @ttmchiou for slack notification of failing tests.
- require ttnn post commit tests to adhere to time budgets except for watcher and ttsim
- remove unused `ARCH_NAME`s
- removes workflow dispatch of ttnn post commit as the pipeline was disabled for manual dispatch for months
- changes callers of ttnn post commit (APC, BHPC, merge gate) to pass in `enabled-skus` 
- ttsim changed to ignore skus and timeouts defined in the test yaml, keeping original functionality

Note:
- APC still runs ttnn post commit ONLY on n300s, BHPC runs ttnn post commit on P100s or P150s depending on input
- merge gate only runs ttnn examples and only on n300, same as before
- the merge gate flag in `tests/pipeline_reorg/ttnn-tests.yaml` will be removed in a later PR because tests should not be repeated between merge gate and APC
- ttsim has a hardcoded timeout of 20 minutes for now, which was the default timeout before this change. ttsim time budgets will be revisited in a later PR.

This PR does not affect how the pipelines are used.



**About pipeline reorg:**

Devs should only have to interface with tests/pipeline_reorg/*tests.yaml
to add their tests instead of adding them directly to the github actions
workflow files.

Tests are subject to a team budget .github/time_budget.yaml that
dictates budgets per team, per pipeline, per SKU aka machine type (eg.
n150, t3k, p150, etc).

Team names and budgets are in flux - please message me if you have any
concerns.

Testing:
- [x] APC: https://github.com/tenstorrent/tt-metal/actions/runs/22426747567/job/64936564479
- [x] BHPC (P100 and P150): https://github.com/tenstorrent/tt-metal/actions/runs/22427050146
- [x] Merge gate: https://github.com/tenstorrent/tt-metal/actions/runs/22426793168
- [x] APC watcher: https://github.com/tenstorrent/tt-metal/actions/runs/22428155386