### PR TITLE
Q and K mcast optimizations

### DIFF
--- a/models/demos/deepseek_v3_b1/fused_ops/pre_sdpa/kernels/pre_sdpa_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/fused_ops/pre_sdpa/kernels/pre_sdpa_kernel.cpp
@@ -190,11 +190,12 @@ uint32_t per_core_rta_arg_idx = 0;
     // Senders write to intermediate CB, then compute tilizes to output CB
     // 3-phase synchronization: nope_phase1, nope_phase2, rope semaphores
     constexpr uint32_t cqh_receiver_in_cb = get_named_compile_time_arg_val("cqh_receiver_in_cb");
+    using CreateQHeadsCTArgs = deepseek_b1_ops::CreateQHeads::SenderCTArgs<
+        get_named_compile_time_arg_val("cqh_qnope_data_size_bytes"),
+        get_named_compile_time_arg_val("cqh_qrope_head_size_bytes")>;
     deepseek_b1_ops::CreateQHeads::SenderArgs create_q_heads_args{
         0,  // sender_grid_start_x (logical 0)
         0,  // sender_grid_start_y (logical 0)
-        get_named_compile_time_arg_val("cqh_qnope_data_size_bytes"),
-        get_named_compile_time_arg_val("cqh_qrope_head_size_bytes"),
         get_named_compile_time_arg_val("cqh_head_stride_bytes"),
         get_named_compile_time_arg_val("cqh_qnope_cols"),
         get_named_compile_time_arg_val("cqh_qnope_src_cb"),
@@ -271,38 +272,23 @@ uint32_t per_core_rta_arg_idx = 0;
             .cur_batch = get_arg_val<uint32_t>(per_core_rta_arg_idx++),
             .core_num_in_reduce = get_arg_val<uint32_t>(per_core_rta_arg_idx++),
             .is_mcast_sender = get_arg_val<uint32_t>(per_core_rta_arg_idx++),
-            .is_output_core = get_arg_val<uint32_t>(per_core_rta_arg_idx++),
-            .output_core_noc_x = get_arg_val<uint32_t>(per_core_rta_arg_idx++),
-            .output_core_noc_y = get_arg_val<uint32_t>(per_core_rta_arg_idx++),
             .mcast_start_x = get_arg_val<uint32_t>(per_core_rta_arg_idx++),
             .mcast_start_y = get_arg_val<uint32_t>(per_core_rta_arg_idx++),
-            .mcast_end_x = get_arg_val<uint32_t>(per_core_rta_arg_idx++),
-            .mcast_end_y = get_arg_val<uint32_t>(per_core_rta_arg_idx++),
             .vc = get_arg_val<uint32_t>(per_core_rta_arg_idx++),
             .St = get_named_compile_time_arg_val("St"),
             .DHt = get_named_compile_time_arg_val("DHt"),
             .Sk_chunk_t = get_named_compile_time_arg_val("Sk_chunk_t"),
             .num_cores_per_head = get_named_compile_time_arg_val("num_cores_per_head"),
             .k_chunk_size = get_named_compile_time_arg_val("k_chunk_size"),
-            .num_mcast_dests = get_named_compile_time_arg_val("num_mcast_dests"),
             .mcast_semaphore_addr = get_named_compile_time_arg_val("mla_mcast_semaphore_addr"),
             .k_page_size = get_named_compile_time_arg_val("k_page_size"),
             .k_num_pages = get_named_compile_time_arg_val("k_num_pages"),
-            .q_chunk_size_bytes = get_named_compile_time_arg_val("q_chunk_size_bytes"),
-            .full_grid_mcast_start_x = get_named_compile_time_arg_val("full_grid_mcast_start_x"),
-            .full_grid_mcast_start_y = get_named_compile_time_arg_val("full_grid_mcast_start_y"),
-            .full_grid_mcast_end_x = get_named_compile_time_arg_val("full_grid_mcast_end_x"),
-            .full_grid_mcast_end_y = get_named_compile_time_arg_val("full_grid_mcast_end_y"),
-            .full_grid_mcast_num_dests = get_named_compile_time_arg_val("full_grid_mcast_num_dests"),
-            .q_input_mcast_semaphore_addr = get_named_compile_time_arg_val("mla_q_input_mcast_semaphore_addr"),
             .ncrisc_brisc_sync_semaphore_addr = get_named_compile_time_arg_val("mla_ncrisc_brisc_sync_semaphore_addr"),
             .receiver_ready_semaphore_addr = get_named_compile_time_arg_val("mla_receiver_ready_semaphore_addr"),
             .kv_cache_cur_pos_ready_semaphore_addr =
                 get_named_compile_time_arg_val("mla_kv_cache_cur_pos_ready_semaphore_addr"),
             .kv_cache_cur_pos_ready_value = get_named_compile_time_arg_val("mla_kv_cache_cur_pos_ready_value"),
             .cb_k_in = get_named_compile_time_arg_val("mla_k_in_cb"),
-            .cb_q_in = get_named_compile_time_arg_val("mla_q_in_cb"),
-            .cb_compute_in = get_named_compile_time_arg_val("mla_compute_in_cb"),
         };
     }
 
@@ -379,6 +365,7 @@ uint32_t per_core_rta_arg_idx = 0;
     };
 
     // BRISC: Receiver args for SDPA input cores
+    using CreateQHeadsCTArgs = deepseek_b1_ops::CreateQHeads::ReceiverCTArgs;
     deepseek_b1_ops::CreateQHeads::ReceiverArgs create_q_heads_args{
         get_named_compile_time_arg_val("cqh_nope_phase1_semaphore_addr"),
         get_named_compile_time_arg_val("cqh_nope_phase2_semaphore_addr"),
@@ -469,7 +456,10 @@ uint32_t per_core_rta_arg_idx = 0;
         constexpr uint32_t num_tree_reduction_steps = get_named_compile_time_arg_val("num_tree_reduction_steps");
         uint32_t cur_batch = get_arg_val<uint32_t>(per_core_rta_arg_idx++);
         uint32_t core_num_in_reduce = get_arg_val<uint32_t>(per_core_rta_arg_idx++);
+        uint32_t is_output_core = get_arg_val<uint32_t>(per_core_rta_arg_idx++);
         uint32_t is_mcast_sender = get_arg_val<uint32_t>(per_core_rta_arg_idx++);
+        uint32_t output_core_noc_x = get_arg_val<uint32_t>(per_core_rta_arg_idx++);
+        uint32_t output_core_noc_y = get_arg_val<uint32_t>(per_core_rta_arg_idx++);
         uint32_t mcast_start_x = get_arg_val<uint32_t>(per_core_rta_arg_idx++);
         uint32_t mcast_start_y = get_arg_val<uint32_t>(per_core_rta_arg_idx++);
         uint32_t mcast_end_x = get_arg_val<uint32_t>(per_core_rta_arg_idx++);
@@ -481,7 +471,10 @@ uint32_t per_core_rta_arg_idx = 0;
             .pos_addr = get_common_arg_val<uint32_t>(1),
             .cur_batch = cur_batch,
             .core_num_in_reduce = core_num_in_reduce,
+            .is_output_core = is_output_core,
             .is_mcast_sender = is_mcast_sender,
+            .output_core_noc_x = output_core_noc_x,
+            .output_core_noc_y = output_core_noc_y,
             .mcast_start_x = mcast_start_x,
             .mcast_start_y = mcast_start_y,
             .mcast_end_x = mcast_end_x,
@@ -491,15 +484,22 @@ uint32_t per_core_rta_arg_idx = 0;
             .num_cores_per_head = get_named_compile_time_arg_val("num_cores_per_head"),
             .reducer_semaphore_addr = get_named_compile_time_arg_val("mla_reducer_semaphore_addr"),
             .k_chunk_size = get_named_compile_time_arg_val("k_chunk_size"),
-            .q_tile_height = get_named_compile_time_arg_val("q_tile_height"),
+            .q_chunk_size_bytes = get_named_compile_time_arg_val("q_chunk_size_bytes"),
             .DHt = get_named_compile_time_arg_val("DHt"),
             .num_mcast_dests = get_named_compile_time_arg_val("num_mcast_dests"),
+            .full_grid_mcast_start_x = get_named_compile_time_arg_val("full_grid_mcast_start_x"),
+            .full_grid_mcast_start_y = get_named_compile_time_arg_val("full_grid_mcast_start_y"),
+            .full_grid_mcast_end_x = get_named_compile_time_arg_val("full_grid_mcast_end_x"),
+            .full_grid_mcast_end_y = get_named_compile_time_arg_val("full_grid_mcast_end_y"),
+            .full_grid_mcast_num_dests = get_named_compile_time_arg_val("full_grid_mcast_num_dests"),
+            .q_input_mcast_semaphore_addr = get_named_compile_time_arg_val("mla_q_input_mcast_semaphore_addr"),
             .mcast_semaphore_addr = get_named_compile_time_arg_val("mla_mcast_semaphore_addr"),
             .ncrisc_brisc_sync_semaphore_addr = get_named_compile_time_arg_val("mla_ncrisc_brisc_sync_semaphore_addr"),
             .k_num_pages = get_named_compile_time_arg_val("k_num_pages"),
             .num_tree_reduction_steps = num_tree_reduction_steps,
             .receiver_ready_semaphore_addr = get_named_compile_time_arg_val("mla_receiver_ready_semaphore_addr"),
             .cb_k_in = get_named_compile_time_arg_val("mla_k_in_cb"),
+            .cb_q_in = get_named_compile_time_arg_val("mla_q_in_cb"),
             .cb_out_in = get_named_compile_time_arg_val("mla_out_in_cb"),
             .cb_ms_in = get_named_compile_time_arg_val("mla_ms_in_cb"),
             .cb_out_ms = get_named_compile_time_arg_val("mla_out_ms_cb"),
@@ -627,6 +627,7 @@ uint32_t per_core_rta_arg_idx = 0;
     };
 
     // CreateQHeads compute args (tilization on SDPA input cores)
+    using CreateQHeadsCTArgs = deepseek_b1_ops::CreateQHeads::ComputeCTArgs;
     deepseek_b1_ops::CreateQHeads::ComputeArgs create_q_heads_args{
         get_named_compile_time_arg_val("cqh_receiver_in_cb"),
         get_named_compile_time_arg_val("cqh_out_cb"),
@@ -699,10 +700,8 @@ uint32_t per_core_rta_arg_idx = 0;
         constexpr uint32_t num_tree_reduction_steps = get_named_compile_time_arg_val("num_tree_reduction_steps");
         uint32_t do_reduce = get_arg_val<uint32_t>(per_core_rta_arg_idx++);
         uint32_t do_output = get_arg_val<uint32_t>(per_core_rta_arg_idx++);
-        uint32_t cur_head = get_arg_val<uint32_t>(per_core_rta_arg_idx++);
         uint32_t cur_batch = get_arg_val<uint32_t>(per_core_rta_arg_idx++);
         uint32_t core_num_in_reduce = get_arg_val<uint32_t>(per_core_rta_arg_idx++);
-        uint32_t core_num_in_output = get_arg_val<uint32_t>(per_core_rta_arg_idx++);
         uint32_t is_sender_after_reduce = get_arg_val<uint32_t>(per_core_rta_arg_idx++);
         tt_l1_ptr uint32_t* tree_reduction_info = (tt_l1_ptr uint32_t*)(get_arg_addr(per_core_rta_arg_idx));
         per_core_rta_arg_idx += num_tree_reduction_steps * 2;
@@ -711,10 +710,8 @@ uint32_t per_core_rta_arg_idx = 0;
             .pos_addr = get_common_arg_val<uint32_t>(7),
             .do_reduce = do_reduce,
             .do_output = do_output,
-            .cur_head = cur_head,
             .cur_batch = cur_batch,
             .core_num_in_reduce = core_num_in_reduce,
-            .core_num_in_output = core_num_in_output,
             .is_sender_after_reduce = is_sender_after_reduce,
             .tree_reduction_info = tree_reduction_info,
             .k_chunk_size = get_named_compile_time_arg_val("k_chunk_size"),
@@ -725,7 +722,6 @@ uint32_t per_core_rta_arg_idx = 0;
 
     using FlashMLACTArgs = deepseek_b1_ops::FlashMLADecode::ComputeCTArgs<
         get_named_compile_time_arg_val("mla_q_in_cb"),
-        get_named_compile_time_arg_val("mla_compute_in_cb"),
         get_named_compile_time_arg_val("mla_k_in_cb"),
         get_named_compile_time_arg_val("mla_interm_out_cb"),
         get_named_compile_time_arg_val("mla_interm_ms_cb"),
@@ -959,8 +955,9 @@ uint32_t per_core_rta_arg_idx = 0;
             // - IsReceiverCore: is_sdpa_input_core
             // - pop_src: true (pop source CB after sending)
             constexpr bool is_create_q_heads_sender = Core::is_qnope_core || Core::is_qrope_core;
-            deepseek_b1_ops::CreateQHeads::Op<is_create_q_heads_sender, Core::is_sdpa_input_core, false, true>
-                create_q_heads;
+            deepseek_b1_ops::CreateQHeads::
+                Op<CreateQHeadsCTArgs, is_create_q_heads_sender, Core::is_sdpa_input_core, false, true>
+                    create_q_heads;
             create_q_heads(create_q_heads_args);
         }
     }

--- a/models/demos/deepseek_v3_b1/fused_ops/pre_sdpa/op.py
+++ b/models/demos/deepseek_v3_b1/fused_ops/pre_sdpa/op.py
@@ -523,8 +523,6 @@ class PreSDPA:
         cb_page_size = tile_size
 
         # CB indices (grouped by stage)
-        # CB indices for CCL broadcast (use separate CBs to avoid conflicts)
-        bcast_pkt_cb = 35  # Packet buffer for CCL broadcast
         input_cb = 0
         gamma_cb = 1
         rmsnorm_output_cb = 2
@@ -575,6 +573,9 @@ class PreSDPA:
         mla_out_o_cb = 40  # Output O CB for MLA
         mla_out_ms_cb = 41  # Output MS CB for MLA
         mla_out_final_cb = 42  # Output final CB for MLA
+
+        # CB indices for CCL broadcast (use separate CBs to avoid conflicts)
+        bcast_pkt_cb = 43  # Packet buffer for CCL broadcast
 
         # RMSNorm2 parameters (for 1536 element input using 16x32 tiles)
         rmsnorm2_numel = 1536

--- a/models/demos/deepseek_v3_b1/fused_ops/pre_sdpa/op.py
+++ b/models/demos/deepseek_v3_b1/fused_ops/pre_sdpa/op.py
@@ -567,15 +567,14 @@ class PreSDPA:
 
         # MLA parameters
         mla_q_in_cb = create_q_heads_out_cb  # In for MLA q heads
-        mla_compute_in_cb = 35  # Input CB for MLA all cores
-        mla_k_in_cb = 36  # Input CB for MLA
-        mla_interm_out_cb = 37  # Intermediate output CB for MLA
-        mla_interm_ms_cb = 38  # Intermediate MS CB for MLA
-        mla_out_in_cb = 39  # Output input CB for MLA
-        mla_ms_in_cb = 40  # Output MS CB for MLA
-        mla_out_o_cb = 41  # Output O CB for MLA
-        mla_out_ms_cb = 42  # Output MS CB for MLA
-        mla_out_final_cb = 43  # Output final CB for MLA
+        mla_k_in_cb = 35  # Input CB for MLA
+        mla_interm_out_cb = 36  # Intermediate output CB for MLA
+        mla_interm_ms_cb = 37  # Intermediate MS CB for MLA
+        mla_out_in_cb = 38  # Output input CB for MLA
+        mla_ms_in_cb = 39  # Output MS CB for MLA
+        mla_out_o_cb = 40  # Output O CB for MLA
+        mla_out_ms_cb = 41  # Output MS CB for MLA
+        mla_out_final_cb = 42  # Output final CB for MLA
 
         # RMSNorm2 parameters (for 1536 element input using 16x32 tiles)
         rmsnorm2_numel = 1536
@@ -1198,18 +1197,23 @@ class PreSDPA:
             ("num_cores_per_head", num_cores_per_head),
             ("mla_reducer_semaphore_addr", mla_reducer_semaphore_addr),
             ("k_chunk_size", k_chunk_size),
-            ("q_tile_height", Q_TILE_HEIGHT),
+            ("q_chunk_size_bytes", q_chunk_size_bytes),
             ("DHt", DHt),
             ("num_mcast_dests", num_mcast_dests),
-            ("mla_mcast_semaphore_addr", mla_mcast_semaphore_addr),
+            ("full_grid_mcast_start_x", mcast_dest_noc_start_core.x),
+            ("full_grid_mcast_start_y", mcast_dest_noc_start_core.y),
+            ("full_grid_mcast_end_x", mcast_dest_noc_end_core.x),
+            ("full_grid_mcast_end_y", mcast_dest_noc_end_core.y),
+            ("full_grid_mcast_num_dests", mcast_num_cores - 1),
             ("mla_q_input_mcast_semaphore_addr", mla_q_input_mcast_semaphore_addr),
+            ("mla_mcast_semaphore_addr", mla_mcast_semaphore_addr),
             ("k_num_pages", k_num_pages),
             ("k_page_size", k_page_size),
-            ("k_num_pages", k_num_pages),
             ("num_tree_reduction_steps", optimized_mla_grid.NUM_TREE_REDUCTION_STEPS),
             ("mla_receiver_ready_semaphore_addr", mla_receiver_ready_semaphore_addr),
             ("mla_ncrisc_brisc_sync_semaphore_addr", mla_ncrisc_brisc_sync_semaphore_addr),
             ("mla_k_in_cb", mla_k_in_cb),
+            ("mla_q_in_cb", mla_q_in_cb),
             ("mla_out_in_cb", mla_out_in_cb),
             ("mla_ms_in_cb", mla_ms_in_cb),
             ("mla_out_o_cb", mla_out_o_cb),
@@ -1221,23 +1225,13 @@ class PreSDPA:
             ("Sk_chunk_t", Sk_chunk_t),
             ("num_cores_per_head", num_cores_per_head),
             ("k_chunk_size", k_chunk_size),
-            ("num_mcast_dests", num_mcast_dests),
             ("mla_mcast_semaphore_addr", mla_mcast_semaphore_addr),
             ("k_page_size", k_page_size),
             ("k_num_pages", k_num_pages),
-            ("q_chunk_size_bytes", q_chunk_size_bytes),
-            ("full_grid_mcast_start_x", mcast_dest_noc_start_core.x),
-            ("full_grid_mcast_start_y", mcast_dest_noc_start_core.y),
-            ("full_grid_mcast_end_x", mcast_dest_noc_end_core.x),
-            ("full_grid_mcast_end_y", mcast_dest_noc_end_core.y),
-            ("full_grid_mcast_num_dests", mcast_num_cores - 1),
-            ("mla_q_input_mcast_semaphore_addr", mla_q_input_mcast_semaphore_addr),
             ("mla_ncrisc_brisc_sync_semaphore_addr", mla_ncrisc_brisc_sync_semaphore_addr),
             ("mla_receiver_ready_semaphore_addr", mla_receiver_ready_semaphore_addr),
             ("mla_kv_cache_cur_pos_ready_semaphore_addr", mla_kv_cache_cur_pos_ready_semaphore_addr),
             ("mla_kv_cache_cur_pos_ready_value", kv_cache_update_grid.num_cores()),
-            ("mla_q_in_cb", mla_q_in_cb),
-            ("mla_compute_in_cb", mla_compute_in_cb),
             ("mla_k_in_cb", mla_k_in_cb),
         ]
         mla_trisc_named_compile_time_args = [
@@ -1253,7 +1247,6 @@ class PreSDPA:
             ("num_tree_reduction_steps", optimized_mla_grid.NUM_TREE_REDUCTION_STEPS),
             ("dst_size", mla_dst_size),
             ("mla_q_in_cb", mla_q_in_cb),
-            ("mla_compute_in_cb", mla_compute_in_cb),
             ("mla_k_in_cb", mla_k_in_cb),
             ("mla_interm_out_cb", mla_interm_out_cb),
             ("mla_interm_ms_cb", mla_interm_ms_cb),
@@ -1926,15 +1919,6 @@ class PreSDPA:
                 mla_intermed_output_tiles = out0_t * optimized_mla_grid.NUM_TREE_REDUCTION_STEPS
                 mla_intermed_ms_tiles = PNHt * optimized_mla_grid.NUM_TREE_REDUCTION_STEPS
 
-                mla_cb_descriptors.append(
-                    ttnn.CBDescriptor(
-                        total_size=q_tiles * q_tile_size,
-                        core_ranges=mla_core_grid,
-                        format_descriptors=[
-                            ttnn.CBFormatDescriptor(mla_compute_in_cb, q_df, q_tile_size, q_tile_descriptor)
-                        ],
-                    )
-                )
                 # cb_k_in: K input (full tile)
                 mla_cb_descriptors.append(
                     ttnn.CBDescriptor(
@@ -2071,13 +2055,8 @@ class PreSDPA:
                                 cur_batch,
                                 core_num_in_reduce,
                                 is_mcast_sender,
-                                is_output_core,
-                                output_core_noc_x,
-                                output_core_noc_y,
                                 mcast_start_x,
                                 mcast_start_y,
-                                mcast_end_x,
-                                mcast_end_y,
                                 vc,
                             ],
                         )
@@ -2092,7 +2071,10 @@ class PreSDPA:
                     mla_brisc_args = [
                         cur_batch,
                         core_num_in_reduce,
+                        is_output_core,
                         is_mcast_sender,
+                        output_core_noc_x,
+                        output_core_noc_y,
                         mcast_start_x,
                         mcast_start_y,
                         mcast_end_x,
@@ -2110,10 +2092,8 @@ class PreSDPA:
                     mla_trisc_args = [
                         do_reduce,
                         is_output_core,
-                        0,  # cur_head (always 0, num_heads_per_core=1)
                         cur_batch,
                         core_num_in_reduce,
-                        core_num_in_output,
                         is_sender_after_reduce,
                     ]
                     for role_code, partner_s_block_idx, partner_x, partner_y in tree_reduction_info:

--- a/models/demos/deepseek_v3_b1/micro_ops/flash_mla/kernels/flash_mla_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/micro_ops/flash_mla/kernels/flash_mla_kernel.cpp
@@ -19,30 +19,17 @@ void kernel_main() {
         .cur_batch = get_arg_val<uint32_t>(arg_idx++),
         .core_num_in_reduce = get_arg_val<uint32_t>(arg_idx++),
         .is_mcast_sender = get_arg_val<uint32_t>(arg_idx++),
-        .is_output_core = get_arg_val<uint32_t>(arg_idx++),
-        .output_core_noc_x = get_arg_val<uint32_t>(arg_idx++),
-        .output_core_noc_y = get_arg_val<uint32_t>(arg_idx++),
         .mcast_start_x = get_arg_val<uint32_t>(arg_idx++),
         .mcast_start_y = get_arg_val<uint32_t>(arg_idx++),
-        .mcast_end_x = get_arg_val<uint32_t>(arg_idx++),
-        .mcast_end_y = get_arg_val<uint32_t>(arg_idx++),
         .vc = get_arg_val<uint32_t>(arg_idx++),
         .St = get_named_compile_time_arg_val("St"),
         .DHt = get_named_compile_time_arg_val("DHt"),
         .Sk_chunk_t = get_named_compile_time_arg_val("Sk_chunk_t"),
         .num_cores_per_head = get_named_compile_time_arg_val("num_cores_per_head"),
         .k_chunk_size = get_named_compile_time_arg_val("k_chunk_size"),
-        .num_mcast_dests = get_named_compile_time_arg_val("num_mcast_dests"),
         .mcast_semaphore_addr = get_semaphore(get_named_compile_time_arg_val("mcast_semaphore_id")),
         .k_page_size = get_named_compile_time_arg_val("k_page_size"),
         .k_num_pages = get_named_compile_time_arg_val("k_num_pages"),
-        .q_chunk_size_bytes = get_named_compile_time_arg_val("q_chunk_size_bytes"),
-        .full_grid_mcast_start_x = get_named_compile_time_arg_val("full_grid_mcast_start_x"),
-        .full_grid_mcast_start_y = get_named_compile_time_arg_val("full_grid_mcast_start_y"),
-        .full_grid_mcast_end_x = get_named_compile_time_arg_val("full_grid_mcast_end_x"),
-        .full_grid_mcast_end_y = get_named_compile_time_arg_val("full_grid_mcast_end_y"),
-        .full_grid_mcast_num_dests = get_named_compile_time_arg_val("full_grid_mcast_num_dests"),
-        .q_input_mcast_semaphore_addr = get_semaphore(get_named_compile_time_arg_val("q_input_mcast_semaphore_id")),
         .ncrisc_brisc_sync_semaphore_addr =
             get_semaphore(get_named_compile_time_arg_val("ncrisc_brisc_sync_semaphore_id")),
         .receiver_ready_semaphore_addr = get_semaphore(get_named_compile_time_arg_val("receiver_ready_semaphore_id")),
@@ -50,8 +37,6 @@ void kernel_main() {
             get_semaphore(get_named_compile_time_arg_val("kv_cache_cur_pos_ready_semaphore_id")),
         .kv_cache_cur_pos_ready_value = get_named_compile_time_arg_val("kv_cache_cur_pos_ready_value"),
         .cb_k_in = get_named_compile_time_arg_val("cb_k_in"),
-        .cb_q_in = get_named_compile_time_arg_val("cb_q_in"),
-        .cb_compute_in = get_named_compile_time_arg_val("cb_compute_in"),
     };
 
     using FlashMLACTArgs = deepseek_b1_ops::FlashMLADecode::ReaderCTArgs;
@@ -61,7 +46,10 @@ void kernel_main() {
     uint32_t arg_idx = 0;
     uint32_t cur_batch = get_arg_val<uint32_t>(arg_idx++);
     uint32_t core_num_in_reduce = get_arg_val<uint32_t>(arg_idx++);
+    uint32_t is_output_core = get_arg_val<uint32_t>(arg_idx++);
     uint32_t is_mcast_sender = get_arg_val<uint32_t>(arg_idx++);
+    uint32_t output_core_noc_x = get_arg_val<uint32_t>(arg_idx++);
+    uint32_t output_core_noc_y = get_arg_val<uint32_t>(arg_idx++);
     uint32_t mcast_start_x = get_arg_val<uint32_t>(arg_idx++);
     uint32_t mcast_start_y = get_arg_val<uint32_t>(arg_idx++);
     uint32_t mcast_end_x = get_arg_val<uint32_t>(arg_idx++);
@@ -73,7 +61,10 @@ void kernel_main() {
         .pos_addr = get_common_arg_val<uint32_t>(0),
         .cur_batch = cur_batch,
         .core_num_in_reduce = core_num_in_reduce,
+        .is_output_core = is_output_core,
         .is_mcast_sender = is_mcast_sender,
+        .output_core_noc_x = output_core_noc_x,
+        .output_core_noc_y = output_core_noc_y,
         .mcast_start_x = mcast_start_x,
         .mcast_start_y = mcast_start_y,
         .mcast_end_x = mcast_end_x,
@@ -83,9 +74,15 @@ void kernel_main() {
         .num_cores_per_head = get_named_compile_time_arg_val("num_cores_per_head"),
         .reducer_semaphore_addr = get_semaphore(get_named_compile_time_arg_val("reducer_semaphore_id")),
         .k_chunk_size = get_named_compile_time_arg_val("k_chunk_size"),
-        .q_tile_height = get_named_compile_time_arg_val("q_tile_height"),
+        .q_chunk_size_bytes = get_named_compile_time_arg_val("q_chunk_size_bytes"),
         .DHt = get_named_compile_time_arg_val("DHt"),
         .num_mcast_dests = get_named_compile_time_arg_val("num_mcast_dests"),
+        .full_grid_mcast_start_x = get_named_compile_time_arg_val("full_grid_mcast_start_x"),
+        .full_grid_mcast_start_y = get_named_compile_time_arg_val("full_grid_mcast_start_y"),
+        .full_grid_mcast_end_x = get_named_compile_time_arg_val("full_grid_mcast_end_x"),
+        .full_grid_mcast_end_y = get_named_compile_time_arg_val("full_grid_mcast_end_y"),
+        .full_grid_mcast_num_dests = get_named_compile_time_arg_val("full_grid_mcast_num_dests"),
+        .q_input_mcast_semaphore_addr = get_semaphore(get_named_compile_time_arg_val("q_input_mcast_semaphore_id")),
         .mcast_semaphore_addr = get_semaphore(get_named_compile_time_arg_val("mcast_semaphore_id")),
         .ncrisc_brisc_sync_semaphore_addr =
             get_semaphore(get_named_compile_time_arg_val("ncrisc_brisc_sync_semaphore_id")),
@@ -93,6 +90,7 @@ void kernel_main() {
         .num_tree_reduction_steps = num_tree_reduction_steps,
         .receiver_ready_semaphore_addr = get_semaphore(get_named_compile_time_arg_val("receiver_ready_semaphore_id")),
         .cb_k_in = get_named_compile_time_arg_val("cb_k_in"),
+        .cb_q_in = get_named_compile_time_arg_val("cb_q_in"),
         .cb_out_in = get_named_compile_time_arg_val("cb_out_in"),
         .cb_ms_in = get_named_compile_time_arg_val("cb_ms_in"),
         .cb_out_ms = get_named_compile_time_arg_val("cb_out_ms"),
@@ -108,10 +106,8 @@ void kernel_main() {
     uint32_t arg_idx = 0;
     uint32_t do_reduce = get_arg_val<uint32_t>(arg_idx++);
     uint32_t do_output = get_arg_val<uint32_t>(arg_idx++);
-    uint32_t cur_head = get_arg_val<uint32_t>(arg_idx++);
     uint32_t cur_batch = get_arg_val<uint32_t>(arg_idx++);
     uint32_t core_num_in_reduce = get_arg_val<uint32_t>(arg_idx++);
-    uint32_t core_num_in_output = get_arg_val<uint32_t>(arg_idx++);
     uint32_t is_sender_after_reduce = get_arg_val<uint32_t>(arg_idx++);
     tt_l1_ptr uint32_t* tree_reduction_info = (tt_l1_ptr uint32_t*)(get_arg_addr(arg_idx));
     arg_idx += num_tree_reduction_steps * 2;
@@ -120,10 +116,8 @@ void kernel_main() {
         .pos_addr = get_common_arg_val<uint32_t>(0),
         .do_reduce = do_reduce,
         .do_output = do_output,
-        .cur_head = cur_head,
         .cur_batch = cur_batch,
         .core_num_in_reduce = core_num_in_reduce,
-        .core_num_in_output = core_num_in_output,
         .is_sender_after_reduce = is_sender_after_reduce,
         .tree_reduction_info = tree_reduction_info,
         .k_chunk_size = get_named_compile_time_arg_val("k_chunk_size"),
@@ -133,7 +127,6 @@ void kernel_main() {
 
     using FlashMLACTArgs = deepseek_b1_ops::FlashMLADecode::ComputeCTArgs<
         get_named_compile_time_arg_val("cb_q_in"),
-        get_named_compile_time_arg_val("cb_compute_in"),
         get_named_compile_time_arg_val("cb_k_in"),
         get_named_compile_time_arg_val("cb_interm_out"),
         get_named_compile_time_arg_val("cb_interm_ms"),
@@ -146,7 +139,7 @@ void kernel_main() {
     deepseek_compute_kernel_init();
 #endif
 
-#if defined(COMPILE_FOR_NCRISC)
+#if defined(COMPILE_FOR_BRISC)
     if (args.is_output_core == 1) {
         unified_kernels::setup_sharded_buffer(args.cb_q_in, args.DHt);
     }

--- a/models/demos/deepseek_v3_b1/unified_kernels/flash_mla.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/flash_mla.hpp
@@ -377,11 +377,11 @@ struct FlashMLADecode {
                     }
                 } else {
                     // wait for 8 q heads
-                    uint32_t q_addr = get_read_ptr(args.cb_q_in);
-                    uint64_t q_noc_addr = get_noc_addr(args.output_core_noc_x, args.output_core_noc_y, q_addr);
+                    uint64_t q_noc_addr =
+                        get_noc_addr(args.output_core_noc_x, args.output_core_noc_y, get_read_ptr(args.cb_q_in));
                     cb_reserve_back(args.cb_q_in, q_chunk_tiles);
                     noc_semaphore_wait(q_input_mcast_semaphore_ptr, 1);
-                    noc_async_read(q_noc_addr, q_addr, args.q_chunk_size_bytes, READ_NOC_INDEX);
+                    noc_async_read(q_noc_addr, get_write_ptr(args.cb_q_in), args.q_chunk_size_bytes, READ_NOC_INDEX);
                     noc_async_read_barrier(READ_NOC_INDEX);
                     cb_push_back(args.cb_q_in, q_chunk_tiles);
                 }

--- a/models/demos/deepseek_v3_b1/unified_kernels/flash_mla.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/flash_mla.hpp
@@ -20,6 +20,10 @@
 #include "api/compute/eltwise_unary/exp.h"
 #endif
 
+#if defined(COMPILE_FOR_BRISC) || defined(COMPILE_FOR_NCRISC)
+static_assert(noc_mode == DM_DYNAMIC_NOC, "Flash MLA Decode kernel only supports DM_DYNAMIC_NOC");
+#endif
+
 // ============================================================================
 // NCRISC helpers
 // ============================================================================
@@ -74,7 +78,6 @@ struct FlashMLADecode {
 
     template <
         uint32_t cb_q_in_,
-        uint32_t cb_compute_in_,
         uint32_t cb_k_in_,
         uint32_t cb_interm_out_,
         uint32_t cb_interm_ms_,
@@ -85,7 +88,6 @@ struct FlashMLADecode {
         uint32_t cb_out_final_>
     struct ComputeCTArgs {
         static constexpr uint32_t cb_q_in = cb_q_in_;
-        static constexpr uint32_t cb_compute_in = cb_compute_in_;
         static constexpr uint32_t cb_k_in = cb_k_in_;
         static constexpr uint32_t cb_interm_out = cb_interm_out_;
         static constexpr uint32_t cb_interm_ms = cb_interm_ms_;
@@ -102,44 +104,32 @@ struct FlashMLADecode {
         uint32_t cur_batch;
         uint32_t core_num_in_reduce;
         uint32_t is_mcast_sender;
-        uint32_t is_output_core;
-        uint32_t output_core_noc_x;
-        uint32_t output_core_noc_y;
         uint32_t mcast_start_x;
         uint32_t mcast_start_y;
-        uint32_t mcast_end_x;
-        uint32_t mcast_end_y;
         uint32_t vc;
         uint32_t St;
         uint32_t DHt;
         uint32_t Sk_chunk_t;
         uint32_t num_cores_per_head;
         uint32_t k_chunk_size;
-        uint32_t num_mcast_dests;
         uint32_t mcast_semaphore_addr;
         uint32_t k_page_size;
         uint32_t k_num_pages;
-        uint32_t q_chunk_size_bytes;
-        uint32_t full_grid_mcast_start_x;
-        uint32_t full_grid_mcast_start_y;
-        uint32_t full_grid_mcast_end_x;
-        uint32_t full_grid_mcast_end_y;
-        uint32_t full_grid_mcast_num_dests;
-        uint32_t q_input_mcast_semaphore_addr;
         uint32_t ncrisc_brisc_sync_semaphore_addr;
         uint32_t receiver_ready_semaphore_addr;
         uint32_t kv_cache_cur_pos_ready_semaphore_addr;
         uint32_t kv_cache_cur_pos_ready_value;
         uint32_t cb_k_in;
-        uint32_t cb_q_in;
-        uint32_t cb_compute_in;
     };
 
     struct WriterArgs {
         uint32_t pos_addr;
         uint32_t cur_batch;
         uint32_t core_num_in_reduce;
+        uint32_t is_output_core;
         uint32_t is_mcast_sender;
+        uint32_t output_core_noc_x;
+        uint32_t output_core_noc_y;
         uint32_t mcast_start_x;
         uint32_t mcast_start_y;
         uint32_t mcast_end_x;
@@ -149,15 +139,22 @@ struct FlashMLADecode {
         uint32_t num_cores_per_head;
         uint32_t reducer_semaphore_addr;
         uint32_t k_chunk_size;
-        uint32_t q_tile_height;
+        uint32_t q_chunk_size_bytes;
         uint32_t DHt;
         uint32_t num_mcast_dests;
+        uint32_t full_grid_mcast_start_x;
+        uint32_t full_grid_mcast_start_y;
+        uint32_t full_grid_mcast_end_x;
+        uint32_t full_grid_mcast_end_y;
+        uint32_t full_grid_mcast_num_dests;
+        uint32_t q_input_mcast_semaphore_addr;
         uint32_t mcast_semaphore_addr;
         uint32_t ncrisc_brisc_sync_semaphore_addr;
         uint32_t k_num_pages;
         uint32_t num_tree_reduction_steps;
         uint32_t receiver_ready_semaphore_addr;
         uint32_t cb_k_in;
+        uint32_t cb_q_in;
         uint32_t cb_out_in;
         uint32_t cb_ms_in;
         uint32_t cb_out_ms;
@@ -167,10 +164,8 @@ struct FlashMLADecode {
         uint32_t pos_addr;
         uint32_t do_reduce;
         uint32_t do_output;
-        uint32_t cur_head;
         uint32_t cur_batch;
         uint32_t core_num_in_reduce;
-        uint32_t core_num_in_output;
         uint32_t is_sender_after_reduce;
         tt_l1_ptr uint32_t* tree_reduction_info;
         uint32_t k_chunk_size;
@@ -198,6 +193,8 @@ struct FlashMLADecode {
 // NCRISC (Reader)
 // ====================================================================
 #if defined(COMPILE_FOR_NCRISC)
+            constexpr uint8_t READ_NOC_INDEX = 0;
+            constexpr uint8_t ATOMIC_NOC_INDEX = 1;
             constexpr auto k_tensor_args = TensorAccessorArgs<0>();
 
             const bool is_mcast_sender = args.is_mcast_sender == 1;
@@ -205,40 +202,6 @@ struct FlashMLADecode {
             volatile tt_l1_ptr uint32_t* pos_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(args.pos_addr);
             uint32_t cur_pos = pos_ptr[0];
 
-            const bool is_output_core = args.is_output_core == 1;
-
-            const uint32_t q_chunk_tiles = args.DHt;
-
-            volatile tt_l1_ptr uint32_t* q_input_mcast_semaphore_ptr =
-                reinterpret_cast<volatile tt_l1_ptr uint32_t*>(args.q_input_mcast_semaphore_addr);
-            {
-                DeviceZoneScopedN("reader-q-read");
-                uint64_t q_read_addr =
-                    get_noc_addr(args.output_core_noc_x, args.output_core_noc_y, get_read_ptr(args.cb_q_in));
-                uint32_t q_write_ptr = get_write_ptr(args.cb_compute_in);
-                if (is_output_core) {
-                    cb_wait_front(args.cb_q_in, q_chunk_tiles);
-                    uint64_t q_input_mcast_sem_noc_addr = get_noc_multicast_addr<noc_index>(
-                        args.full_grid_mcast_start_x,
-                        args.full_grid_mcast_start_y,
-                        args.full_grid_mcast_end_x,
-                        args.full_grid_mcast_end_y,
-                        args.q_input_mcast_semaphore_addr);
-                    noc_semaphore_inc_multicast(q_input_mcast_sem_noc_addr, 1, args.full_grid_mcast_num_dests);
-                    // 7 is number of cores per block - 1, since multicast is only sent to other cores in the block
-                    noc_semaphore_wait(q_input_mcast_semaphore_ptr, 7);
-                    noc_async_atomic_barrier();
-                } else {
-                    // wait for 8 q heads
-                    noc_semaphore_wait(q_input_mcast_semaphore_ptr, 8);
-                }
-                noc_semaphore_set(q_input_mcast_semaphore_ptr, 0);
-
-                cb_reserve_back(args.cb_compute_in, q_chunk_tiles);
-                noc_async_read(q_read_addr, q_write_ptr, args.q_chunk_size_bytes);
-                noc_async_read_barrier();
-                cb_push_back(args.cb_compute_in, q_chunk_tiles);
-            }
             auto [k_num_chunks, k_chunk_start, k_chunk_end] = get_runtime_args(
                 cur_pos, args.cur_batch, args.core_num_in_reduce, args.num_cores_per_head, args.k_chunk_size);
             (void)k_num_chunks;
@@ -270,15 +233,15 @@ struct FlashMLADecode {
 
             volatile tt_l1_ptr uint32_t* receiver_ready_semaphore_ptr =
                 reinterpret_cast<volatile tt_l1_ptr uint32_t*>(args.receiver_ready_semaphore_addr);
-            const uint64_t sender_receiver_ready_noc_addr =
-                get_noc_addr(args.mcast_start_x, args.mcast_start_y, args.receiver_ready_semaphore_addr);
+            const uint64_t sender_receiver_ready_noc_addr = get_noc_addr(
+                args.mcast_start_x, args.mcast_start_y, args.receiver_ready_semaphore_addr, ATOMIC_NOC_INDEX);
 
             constexpr uint32_t kv_batch = 0;
 
             if (is_mcast_sender) {
                 const uint32_t shard_id = kv_batch * num_chunks_per_batch + k_chunk_start;
                 uint64_t k_src_noc_addr = get_shard_noc_addr_helper(k_reader, shard_id);
-                noc_async_read_one_packet_set_state<true>(k_src_noc_addr, args.k_page_size, args.vc);
+                noc_async_read_one_packet_set_state<true>(k_src_noc_addr, args.k_page_size, args.vc, READ_NOC_INDEX);
             }
 
             volatile tt_l1_ptr uint32_t* kv_cache_cur_pos_ready_semaphore_ptr =
@@ -300,7 +263,7 @@ struct FlashMLADecode {
                     if (is_mcast_sender) {
                         DeviceZoneScopedN("mcast-sender-sharded-read");
                         // Previous multicasts could have put trids into a non-zero state, so reset the barrier counter
-                        reset_noc_trid_barrier_counter(NOC_CLEAR_OUTSTANDING_REQ_MASK, noc_index);
+                        reset_noc_trid_barrier_counter(NOC_CLEAR_OUTSTANDING_REQ_MASK, READ_NOC_INDEX);
                         const uint32_t shard_id = kv_batch * num_chunks_per_batch + k_chunk;
                         uint64_t k_src_noc_addr = get_shard_noc_addr_helper(k_reader, shard_id);
 
@@ -317,9 +280,9 @@ struct FlashMLADecode {
                         noc_semaphore_wait(ncrisc_brisc_sync_curr_ptr, 0);
                         *k_write_curr_ptr_shared = k_write_ptr;
                         for (uint32_t i = 0; i < NUM_TRIDS && pages_issued < args.k_num_pages; ++i) {
-                            noc_async_read_set_trid(curr_trid);
+                            noc_async_read_set_trid(curr_trid, READ_NOC_INDEX);
                             noc_async_read_one_packet_with_state_with_trid(
-                                src_base_addr, src_offset, dst_addr, curr_trid);
+                                src_base_addr, src_offset, dst_addr, curr_trid, READ_NOC_INDEX);
                             src_offset += args.k_page_size;
                             dst_addr += args.k_page_size;
                             curr_trid = (curr_trid % NUM_TRIDS) + 1;
@@ -327,14 +290,14 @@ struct FlashMLADecode {
                         }
 
                         while (pages_completed < args.k_num_pages) {
-                            noc_async_read_barrier_with_trid(wait_trid);
+                            noc_async_read_barrier_with_trid(wait_trid, READ_NOC_INDEX);
                             *ncrisc_brisc_sync_curr_ptr += 1;
                             pages_completed++;
 
                             if (pages_issued < args.k_num_pages) {
-                                noc_async_read_set_trid(curr_trid);
+                                noc_async_read_set_trid(curr_trid, READ_NOC_INDEX);
                                 noc_async_read_one_packet_with_state_with_trid(
-                                    src_base_addr, src_offset, dst_addr, curr_trid);
+                                    src_base_addr, src_offset, dst_addr, curr_trid, READ_NOC_INDEX);
                                 src_offset += args.k_page_size;
                                 dst_addr += args.k_page_size;
                                 curr_trid = (curr_trid % NUM_TRIDS) + 1;
@@ -348,7 +311,7 @@ struct FlashMLADecode {
                         std::swap(k_write_curr_ptr_shared, k_write_next_ptr_shared);
                     } else {
                         DeviceZoneScopedN("mcast-receiver-signal-ready");
-                        noc_semaphore_inc(sender_receiver_ready_noc_addr, 1);
+                        noc_semaphore_inc(sender_receiver_ready_noc_addr, 1, ATOMIC_NOC_INDEX);
 
                         noc_semaphore_wait(mcast_semaphore_ptr, MCAST_VALID);
                         noc_semaphore_set(mcast_semaphore_ptr, MCAST_INVALID);
@@ -363,7 +326,11 @@ struct FlashMLADecode {
 // BRISC (Writer)
 // ====================================================================
 #elif defined(COMPILE_FOR_BRISC)
-            constexpr uint8_t MCAST_NOC = 0;
+            constexpr uint8_t MCAST_NOC_INDEX = 0;
+            constexpr uint8_t READ_NOC_INDEX = 1;
+            constexpr uint8_t WRITE_NOC_INDEX = 1;
+            constexpr uint8_t ATOMIC_NOC_INDEX = 1;
+
             constexpr uint32_t k_page_size = CTArgs::k_page_size;
             constexpr uint32_t vDHt = CTArgs::vDHt;
             constexpr uint32_t cb_out_o = CTArgs::cb_out_o;
@@ -373,7 +340,53 @@ struct FlashMLADecode {
             constexpr uint32_t o_write_size = out_chunk_tiles * tile_bytes_intermed;
             constexpr uint32_t ms_write_size = tile_bytes_intermed;
 
+            const uint32_t q_chunk_tiles = args.DHt;
+
+            volatile tt_l1_ptr uint32_t* q_input_mcast_semaphore_ptr =
+                reinterpret_cast<volatile tt_l1_ptr uint32_t*>(args.q_input_mcast_semaphore_addr);
+
             const bool is_mcast_sender = args.is_mcast_sender == 1;
+            const bool is_output_core = args.is_output_core == 1;
+
+            {
+                DeviceZoneScopedN("reader-q-read");
+                if (is_output_core) {
+                    cb_wait_front(args.cb_q_in, q_chunk_tiles);
+                    if (is_mcast_sender) {
+                        noc_semaphore_wait(q_input_mcast_semaphore_ptr, args.num_mcast_dests);
+                        uint64_t q_input_mcast_sem_noc_addr = get_noc_multicast_addr<MCAST_NOC_INDEX>(
+                            args.full_grid_mcast_start_x,
+                            args.full_grid_mcast_start_y,
+                            args.full_grid_mcast_end_x,
+                            args.full_grid_mcast_end_y,
+                            args.q_input_mcast_semaphore_addr);
+                        noc_semaphore_inc_multicast(
+                            q_input_mcast_sem_noc_addr, 1, args.full_grid_mcast_num_dests, MCAST_NOC_INDEX);
+                        // This is needed because we need to wait for all transactions before resetting the trids
+                        // Could move it later but don't think it makes much difference
+                        noc_async_atomic_barrier(MCAST_NOC_INDEX);
+                    } else {
+                        const uint64_t sender_receiver_ready_noc_addr = get_noc_addr(
+                            args.mcast_start_x,
+                            args.mcast_start_y,
+                            args.q_input_mcast_semaphore_addr,
+                            ATOMIC_NOC_INDEX);
+                        noc_semaphore_inc(sender_receiver_ready_noc_addr, 1, ATOMIC_NOC_INDEX);
+                        noc_async_atomic_barrier(ATOMIC_NOC_INDEX);
+                        noc_semaphore_wait(q_input_mcast_semaphore_ptr, 1);
+                    }
+                } else {
+                    // wait for 8 q heads
+                    uint32_t q_addr = get_read_ptr(args.cb_q_in);
+                    uint64_t q_noc_addr = get_noc_addr(args.output_core_noc_x, args.output_core_noc_y, q_addr);
+                    cb_reserve_back(args.cb_q_in, q_chunk_tiles);
+                    noc_semaphore_wait(q_input_mcast_semaphore_ptr, 1);
+                    noc_async_read(q_noc_addr, q_addr, args.q_chunk_size_bytes, READ_NOC_INDEX);
+                    noc_async_read_barrier(READ_NOC_INDEX);
+                    cb_push_back(args.cb_q_in, q_chunk_tiles);
+                }
+                noc_semaphore_set(q_input_mcast_semaphore_ptr, 0);
+            }
 
             volatile tt_l1_ptr uint32_t* pos_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(args.pos_addr);
             uint32_t cur_pos = pos_ptr[0];
@@ -389,9 +402,6 @@ struct FlashMLADecode {
             // KV Cache Multicast (page-level pipelining)
             // =================================================================
             if (is_mcast_sender) {
-                const uint32_t k_tile_bytes = get_tile_size(args.cb_k_in);
-                const uint32_t k_chunk_tiles = args.Sk_chunk_t * args.DHt;
-
                 volatile tt_l1_ptr uint32_t* mcast_semaphore_ptr =
                     reinterpret_cast<volatile tt_l1_ptr uint32_t*>(args.mcast_semaphore_addr);
 
@@ -407,13 +417,11 @@ struct FlashMLADecode {
                 volatile tt_l1_ptr uint32_t* receiver_ready_semaphore_ptr =
                     reinterpret_cast<volatile tt_l1_ptr uint32_t*>(args.receiver_ready_semaphore_addr);
 
-                const uint64_t mcast_noc_addr = get_noc_multicast_addr<MCAST_NOC>(
+                const uint64_t mcast_noc_addr = get_noc_multicast_addr<MCAST_NOC_INDEX>(
                     args.mcast_start_x, args.mcast_start_y, args.mcast_end_x, args.mcast_end_y, 0);
                 const uint64_t mcast_sem_addr = mcast_noc_addr | args.mcast_semaphore_addr;
 
                 noc_semaphore_set(mcast_semaphore_ptr, 1);
-
-                static_assert(k_page_size <= NOC_MAX_BURST_SIZE, "k_page_size must be less than NOC_MAX_BURST_SIZE");
 
                 for (uint32_t k_chunk = k_chunk_start; k_chunk < k_chunk_end; k_chunk += args.num_cores_per_head) {
                     DeviceZoneScopedN("mcast-sender-multicast");
@@ -428,24 +436,24 @@ struct FlashMLADecode {
                     noc_semaphore_set(receiver_ready_semaphore_ptr, 0);
 
                     noc_async_write_multicast<k_page_size>(
-                        page_addr, mcast_dest_addr, k_page_size, args.num_mcast_dests, false, MCAST_NOC);
+                        page_addr, mcast_dest_addr, k_page_size, args.num_mcast_dests, false, MCAST_NOC_INDEX);
 
                     for (uint32_t page = 1; page < args.k_num_pages; ++page) {
                         page_addr += k_page_size;
                         mcast_dest_addr = mcast_noc_addr | page_addr;
                         noc_semaphore_wait_min(ncrisc_brisc_sync_curr_ptr, page + 1);
                         noc_async_write_multicast<k_page_size>(
-                            page_addr, mcast_dest_addr, k_page_size, args.num_mcast_dests, false, MCAST_NOC);
+                            page_addr, mcast_dest_addr, k_page_size, args.num_mcast_dests, false, MCAST_NOC_INDEX);
                     }
 
                     noc_semaphore_set_multicast(
-                        args.mcast_semaphore_addr, mcast_sem_addr, args.num_mcast_dests, false, MCAST_NOC);
-                    noc_async_writes_flushed(MCAST_NOC);
+                        args.mcast_semaphore_addr, mcast_sem_addr, args.num_mcast_dests, false, MCAST_NOC_INDEX);
+                    noc_async_writes_flushed(MCAST_NOC_INDEX);
                     *ncrisc_brisc_sync_curr_ptr = 0;
                     std::swap(ncrisc_brisc_sync_curr_ptr, ncrisc_brisc_sync_next_ptr);
                     std::swap(k_write_curr_ptr_shared, k_write_next_ptr_shared);
                 }
-                noc_async_write_barrier(MCAST_NOC);
+                noc_async_write_barrier(MCAST_NOC_INDEX);
             }
 
             // =================================================================
@@ -479,23 +487,24 @@ struct FlashMLADecode {
                         DeviceZoneScopedN("tree-reduction-sender");
                         cb_wait_front(cb_out_o, out_chunk_tiles);
                         cb_wait_front(args.cb_out_ms, 1);
-                        uint64_t output_write_coord = get_noc_addr(partner_x, partner_y, 0);
+                        uint64_t output_write_coord = get_noc_addr(partner_x, partner_y, 0, WRITE_NOC_INDEX);
                         uint64_t output_write_addr = output_write_coord | (cb_ms_in_base_addr + step * ms_write_size);
 
                         noc_async_write<ms_write_size, false, /*posted=*/true>(
-                            get_read_ptr(args.cb_out_ms), output_write_addr, ms_write_size);
+                            get_read_ptr(args.cb_out_ms), output_write_addr, ms_write_size, WRITE_NOC_INDEX);
 
                         output_write_addr = output_write_coord | (cb_out_in_base_addr + step * o_write_size);
                         noc_async_write<o_write_size, false, /*posted=*/true>(
-                            get_read_ptr(cb_out_o), output_write_addr, o_write_size);
+                            get_read_ptr(cb_out_o), output_write_addr, o_write_size, WRITE_NOC_INDEX);
 
                         uint64_t partner_semaphore_addr = output_write_coord | args.reducer_semaphore_addr;
-                        noc_semaphore_inc(partner_semaphore_addr, step_semaphore_inc<bits_per_step>(step));
+                        noc_semaphore_inc(
+                            partner_semaphore_addr, step_semaphore_inc<bits_per_step>(step), WRITE_NOC_INDEX);
 
-                        noc_async_posted_writes_flushed();
+                        noc_async_posted_writes_flushed(WRITE_NOC_INDEX);
                         cb_pop_front(args.cb_out_ms, 1);
                         cb_pop_front(cb_out_o, out_chunk_tiles);
-                        noc_async_atomic_barrier();
+                        noc_async_atomic_barrier(WRITE_NOC_INDEX);
                         break;
 
                     } else if (role_code == 2) {
@@ -527,7 +536,6 @@ struct FlashMLADecode {
             constexpr uint32_t scale_fp32 = get_named_compile_time_arg_val("scale_fp32");
             constexpr uint32_t dst_size = get_named_compile_time_arg_val("dst_size");
             constexpr uint32_t cb_q_in = CTArgs::cb_q_in;
-            constexpr uint32_t cb_compute_in = CTArgs::cb_compute_in;
             constexpr uint32_t cb_k_in = CTArgs::cb_k_in;
             constexpr uint32_t cb_interm_out = CTArgs::cb_interm_out;
             constexpr uint32_t cb_interm_ms = CTArgs::cb_interm_ms;
@@ -554,10 +562,10 @@ struct FlashMLADecode {
             MATH(ckernel::t6_semaphore_init(ckernel::semaphore::FPU_SFPU, 0, 1));
             PACK(ckernel::t6_semaphore_init(SFPU_FPU, 0, 1));
             PACK((llk_math_sfpu_sdpa_reduce_row_init<false, DST_ACCUM_MODE, DataFormat::Float16_b>()));
-            reconfig_data_format<false, true>(cb_k_in, cb_compute_in);
+            reconfig_data_format<false, true>(cb_k_in, cb_q_in);
             pack_reconfig_data_format<true>(cb_out_o);
             PACK(SFPU_TEMPLATE_INIT_KERNEL(exponential, sfpu::exp_init, true, true, scale_fp32, true));
-            sdpa_custom_mm_block_init_short<transpose_k>(cb_compute_in, cb_k_in, cb_out_o, Sk_chunk_t);
+            sdpa_custom_mm_block_init_short<transpose_k>(cb_q_in, cb_k_in, cb_out_o, Sk_chunk_t);
 
             volatile tt_l1_ptr uint32_t* pos_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(args.pos_addr);
             uint32_t cur_pos = pos_ptr[0];
@@ -605,7 +613,7 @@ struct FlashMLADecode {
                 sdpa_ms_cb = cb_out_ms;
             }
             uint32_t num_chunks = (k_chunk_end - k_chunk_start + args.num_cores_per_head - 1) / args.num_cores_per_head;
-            cb_wait_front(cb_compute_in, q_chunk_tiles);
+            cb_wait_front(cb_q_in, q_chunk_tiles);
             cb_reserve_back(sdpa_output_cb, vDHt);
             cb_reserve_back(sdpa_ms_cb, Sq_chunk_t);
             tile_regs_acquire();
@@ -620,7 +628,7 @@ struct FlashMLADecode {
                     transpose_v,
                     packed_tile_size,
                     exp_approx_mode>(
-                    cb_compute_in,
+                    cb_q_in,
                     cb_k_in,
                     sdpa_output_cb,
                     mm1_dst_offset,
@@ -637,7 +645,7 @@ struct FlashMLADecode {
                 cb_push_back(sdpa_ms_cb, Sq_chunk_t);
             } else {
                 compute_sdpa_recip<out_chunk_tiles, exp_approx_mode, scale_bf16>(
-                    cb_compute_in, sum_dst_offset, corr_exp_dst_offset, mm2_dst_offset);
+                    cb_q_in, sum_dst_offset, corr_exp_dst_offset, mm2_dst_offset);
             }
             for (uint32_t i = 0; i < out_chunk_tiles; i += 2) {
                 PACK(t6_semaphore_wait_on_zero<p_stall::STALL_PACK>(semaphore::FPU_SFPU));
@@ -673,10 +681,7 @@ struct FlashMLADecode {
                 }
             }
 
-            cb_pop_front(cb_compute_in, q_chunk_tiles);
-            if (do_output) {
-                cb_pop_front(cb_q_in, q_chunk_tiles);
-            }
+            cb_pop_front(cb_q_in, q_chunk_tiles);
 #endif
         }
     };


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Mcast of semaphore was added to signal Q was ready to flash mla when it was integrated to pre-sdpa. These were overlapping mcasts on the same noc, which added a significant increase in duration. 

### What's changed
Switch to having one mcaster of Q ready signal, and the other cores that hold Q will signal the mcaster when data is ready with a sem inc on NOC1, since the mcaster is to the top left of the Q cores.
Move Q mcast from NCRISC which does KV cache streaming to BRISC, so that KV cache streaming of first chunk can begin and happen in parallel with Q mcast instead of being serialized.
Move atomic incs of KV receivers from NOC0 to NOC1. This avoids noc conflicts with KV mcast/KV reads which are on NOC0, and is also more optimal since the mcast core is to the top left of the receiver cores.

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=aho/optimizations)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:aho/optimizations)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=aho/optimizations)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:aho/optimizations)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=aho/optimizations)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:aho/optimizations)
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=aho/optimizations)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:aho/optimizations)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=aho/optimizations)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:aho/optimizations)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=aho/optimizations)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:aho/optimizations)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
