### PR TITLE
Fix unordered_map::at crash in resharding for idle cores (#36477)

### DIFF
--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/reshard_program_factory_generic.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/reshard_program_factory_generic.cpp
@@ -723,7 +723,14 @@ ttnn::device_operation::ProgramArtifacts ReshardGenericFactory::create_program_a
         if (diff_width) {
             auto output_core_to_page_range_pair =
                 detail::get_core_page_ranges_diff_width(input_buffer, output_buffer, input);
-            const auto& page_stride_vector = output_core_to_page_range_pair.at(core);
+            // create_stride_of_strides_ret_map drops any core whose stride list is empty, so a
+            // core that receives no pages is absent here and .at() throws (see #36477). It still
+            // needs runtime args, and the builders below emit a well-formed zero-range set from
+            // an empty vector.
+            static const std::vector<detail::CompressedStrideBlock> kNoStrideBlocks;
+            const auto it = output_core_to_page_range_pair.find(core);
+            const auto& page_stride_vector =
+                (it != output_core_to_page_range_pair.end()) ? it->second : kNoStrideBlocks;
             auto args_0 = detail::get_runtime_args_for_given_ranges_diff_width(
                 page_stride_vector, 0, 0, tt::div_up(static_cast<uint32_t>(page_stride_vector.size()), 2u));
             auto args_1 = detail::get_runtime_args_for_given_ranges_diff_width(
@@ -735,7 +742,13 @@ ttnn::device_operation::ProgramArtifacts ReshardGenericFactory::create_program_a
             writer_args.push_back(std::move(args_1));
         } else {
             auto output_core_to_page_range_pair = detail::get_core_page_ranges(input_buffer, output_buffer);
-            const auto& page_stride_vector = output_core_to_page_range_pair.at(core);
+            // create_map_for_reshard seeds an entry for every core in the output buffer's page
+            // mapping, but this loop walks the worker cores from
+            // get_optimal_worker_cores_for_sharded_tensor, which need not be the same set. Look
+            // the core up tolerantly rather than throwing when the two diverge.
+            static const std::vector<detail::PageStride> kNoPageStrides;
+            const auto it = output_core_to_page_range_pair.find(core);
+            const auto& page_stride_vector = (it != output_core_to_page_range_pair.end()) ? it->second : kNoPageStrides;
             auto args_0 = detail::get_runtime_args_for_given_ranges(
                 page_stride_vector, 0, 0, tt::div_up(static_cast<uint32_t>(page_stride_vector.size()), 2u));
             // offset is equivalent to number of pages output in previous risc core

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/reshard_program_factory_generic.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/reshard_program_factory_generic.cpp
@@ -738,7 +738,14 @@ ProgramDescriptor ReshardGenericFactory::create_descriptor(
         if (input_buffer->page_size() != output_buffer->page_size()) {
             auto output_core_to_page_range_pair =
                 detail::get_core_page_ranges_diff_width(input_buffer, output_buffer, input);
-            const auto& page_stride_vector = output_core_to_page_range_pair.at(core);
+            // create_stride_of_strides_ret_map drops any core whose stride list is empty, so a
+            // core that receives no pages is absent here and .at() throws (see #36477). It still
+            // needs runtime args, and the builder below emits a well-formed zero-range set from
+            // an empty vector.
+            static const std::vector<detail::CompressedStrideBlock> kNoStrideBlocks;
+            const auto it = output_core_to_page_range_pair.find(core);
+            const auto& page_stride_vector =
+                (it != output_core_to_page_range_pair.end()) ? it->second : kNoStrideBlocks;
             runtime_args_0 = detail::get_runtime_args_for_given_ranges_diff_width(
                 physical_core_coords,
                 page_stride_vector,
@@ -756,7 +763,13 @@ ProgramDescriptor ReshardGenericFactory::create_descriptor(
                 page_stride_vector.size());
         } else {
             auto output_core_to_page_range_pair = detail::get_core_page_ranges(input_buffer, output_buffer);
-            const auto& page_stride_vector = output_core_to_page_range_pair.at(core);
+            // create_map_for_reshard seeds an entry for every core in the output buffer's page
+            // mapping, but this loop walks the worker cores from
+            // get_optimal_worker_cores_for_sharded_tensor, which need not be the same set. Look
+            // the core up tolerantly rather than throwing when the two diverge.
+            static const std::vector<detail::PageStride> kNoPageStrides;
+            const auto it = output_core_to_page_range_pair.find(core);
+            const auto& page_stride_vector = (it != output_core_to_page_range_pair.end()) ? it->second : kNoPageStrides;
             runtime_args_0 = detail::get_runtime_args_for_given_ranges(
                 physical_core_coords,
                 page_stride_vector,


### PR DESCRIPTION
## Problem

When resharding from HEIGHT_SHARDED to BLOCK_SHARDED on the same core grid, `.at(core)` throws `unordered_map::at` because idle cores in the output grid aren't present in the page mapping.

## Root Cause

In `ReshardGenericFactory::create()`, the code iterates over all output cores and calls `.at(core)` on the page stride map. When some output cores are idle (no pages mapped to them), this crashes.

## Fix

**File:** `	tnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/reshard_program_factory_generic.cpp`

1. **Replace `.at(core)` with `.find()` + empty vector fallback** in both same-width and diff-width resharding paths (lines ~704 and ~722)
2. **Remove early `continue` for empty page_strides** in `create_stride_of_strides_ret_map`  idle cores need entries in the compressed stride map even if they have zero pages

## Testing

The reporter (@thienlubos) confirmed this fix resolves the issue (see #36477 comments).

Fixes #36477