### PR TITLE
Fix missing image_resolution parametrize in SDXL demo test (#38617)

### DIFF
--- a/models/experimental/stable_diffusion_xl_base/demo/demo_base_and_refiner.py
+++ b/models/experimental/stable_diffusion_xl_base/demo/demo_base_and_refiner.py
@@ -285,6 +285,13 @@ def run_demo_inference(
     ],
     ids=["default_additional_parameters"],
 )
+@pytest.mark.parametrize(
+    "image_resolution",
+    [
+        (1024, 1024),
+    ],
+    ids=["1024x1024"],
+)
 def test_demo_base_and_refiner(
     validate_fabric_compatibility,
     mesh_device,


### PR DESCRIPTION
## Problem

Running `pytest models/experimental/stable_diffusion_xl_base/demo/demo_base_and_refiner.py` crashes because `test_demo_base_and_refiner` expects `image_resolution` as a parameter but there is no `@pytest.mark.parametrize` decorator for it, causing pytest to fail with a missing fixture error.

## Fix

Added `@pytest.mark.parametrize` for `image_resolution` with only `(1024, 1024)` since the base+refiner demo does not support 512x512 resolution.

This follows the same pattern used by the VAE sub-module tests (e.g., `test_module_tt_autoencoder_kl.py`, `test_module_tt_attention.py`, etc.), which include both resolutions but use `pytest.skip` for 512x512.

## Testing

The fix ensures `pytest` can collect and execute the test without crashing on the missing parameter.

Fixes #38617