### PR TITLE
[skip ci] Exabox troubleshooting add more commands

### DIFF
--- a/tools/scaleout/exabox/TROUBLESHOOTING.md
+++ b/tools/scaleout/exabox/TROUBLESHOOTING.md
@@ -247,7 +247,10 @@ while attempting to start process rank 0.
 
 **Cause**: Node may have rebooted or had a transient issue.
 
-**Solution**: Run `sudo tt_reidle_downed_node.sh` on the login node to bring them back to idle.
+**Solution**: Run the following on the login node to bring them back to idle:
+```bash
+sudo /usr/local/bin/tt_reidle_downed_node.sh <hostname>
+```
 
 **Diagnosis**: Check `uptime` on the affected node. If uptime is low, the machine rebooted unexpectedly - may need further investigation.
 
@@ -302,7 +305,10 @@ If this issue persists, report to infra team to fix group synchronization.
 
 **Resolution steps**:
 1. Try a soft reboot first (faster than power cycle)
-2. If reboot doesn't help, try a full power cycle
+2. If reboot doesn't help, try a full power cycle:
+   ```bash
+   sudo ipmitool chassis power cycle
+   ```
 3. If still failing after power cycle, it's likely a hardware issue (often GDDR related)
 
 **Diagnosis**: If issue persists, have syseng check for GDDR BIST failures. Common signature: UBBx ASICy GDDRz failing BIST, related to CA.
@@ -403,6 +409,9 @@ pcieport 0000:c0:01.4: AER: aer_layer=Transaction Layer, aer_agent=Receiver ID
 **Cause**: Unknown - possibly something in SW or the handoff process during cluster bringup. Lower priority for debugging since power cycle resolves it.
 
 **Solution**: Power cycle the affected hosts via BMC. This clears the stall and allows cluster validation to proceed.
+```bash
+sudo ipmitool chassis power cycle
+```
 
 **Concern**: If this happens repeatedly on the same system after handoff to SW, it needs more investigation.
 
@@ -418,7 +427,11 @@ pcieport 0000:c0:01.4: AER: aer_layer=Transaction Layer, aer_agent=Receiver ID
 
 **Cause**: GDDR training failure on that specific chip.
 
-**Solution**: Try virtual AC power cycle first to see if it's recoverable. If GDDR issue persists after power cycle, it's a hardware problem that may require chip/board replacement.
+**Solution**: Try virtual AC power cycle first to see if it's recoverable:
+```bash
+sudo ipmitool chassis power cycle
+```
+If GDDR issue persists after power cycle, it's a hardware problem that may require chip/board replacement.
 
 ---
 
@@ -432,7 +445,10 @@ Example: bh-glx-c01u08 showing only 31 chips, missing tray_id=2, asic_location=7
 
 **Cause**: ASIC failed to initialize after software reboot. Software reboot (`tt-smi reset` or OS reboot) is not sufficient to recover the chip.
 
-**Solution**: Full power cycle via BMC (not just software reboot). Contact someone with BMC access to power cycle the machine.
+**Solution**: Full power cycle via BMC (not just software reboot). Contact someone with BMC access to power cycle the machine:
+```bash
+sudo ipmitool chassis power cycle
+```
 
 After power cycle, verify all 32 chips come up:
 ```bash
@@ -560,7 +576,10 @@ Physical Discovery found 12 missing port/cable connections:
 1. Identify the affected hosts and trays from the error output
 2. Have someone physically reseat the QSFP cables at the reported ports
 3. Re-run validation
-4. If still missing, power cycle both affected machines
+4. If still missing, power cycle both affected machines:
+   ```bash
+   sudo ipmitool chassis power cycle
+   ```
 5. If still missing after power cycle, swap the cable
 6. If issue persists after cable swap, escalate to syseng for hardware investigation
 
@@ -581,6 +600,9 @@ Example: Missing connections between c01u02 and c01u08 - physical cables checked
 2. If physical looks fine, it's likely a transient issue
 
 **Solution**: Power cycle both affected machines via BMC. This resolved ethernet connectivity issues on the 8x16 cluster.
+```bash
+sudo ipmitool chassis power cycle
+```
 
 ---
 
@@ -785,6 +807,9 @@ The error originates from `tt_metal/impl/device/device_manager.cpp` during `Devi
 **Cause**: Unknown - possibly firmware/driver interaction issue. The firmware team noted this is strange because they don't have anything that runs on the Tensixes. Each host was broken in the same way.
 
 **Solution**: Power cycle resolved the issue, though root cause remains unknown. This is concerning but not an immediate blocker.
+```bash
+sudo ipmitool chassis power cycle
+```
 
 **Debugging approach**: Start with debug on the SW side - do basic reads and writes over PCIe to ensure data lands in L1 as expected. Loop in syseng as needed depending on what you see.
 
@@ -801,6 +826,9 @@ The error originates from `tt_metal/impl/device/device_manager.cpp` during `Devi
 **Cause**: Under investigation.
 
 **Workaround**: Power cycle and retry. Issue is intermittent.
+```bash
+sudo ipmitool chassis power cycle
+```
 
 ---
 

--- a/tools/scaleout/exabox/TROUBLESHOOTING.md
+++ b/tools/scaleout/exabox/TROUBLESHOOTING.md
@@ -45,11 +45,11 @@ Real issues encountered and their solutions.
 
 ---
 
-# Contacts & Escalation
+## Contacts & Escalation
 
 When you encounter issues that require escalation, use the following contacts and channels:
 
-## Slack Channels
+### Slack Channels
 
 - **`#exabox-infra`** - Primary channel for Exabox cluster issues
   - Report hardware problems (bad cables, missing connections, DRAM failures)
@@ -57,7 +57,7 @@ When you encounter issues that require escalation, use the following contacts an
   - Coordinate cluster access and reservations
   - General cluster health issues
 
-## Teams
+### Teams
 
 - **Systems Engineering (syseng)** - Hardware and firmware issues
   - GDDR failures and ASIC issues
@@ -76,7 +76,7 @@ When you encounter issues that require escalation, use the following contacts an
   - BMC access and remote management
   - Cluster configuration and deployment
 
-## Specific Contacts
+### Specific Contacts
 
 - **@tt-asaigal or @jpanasiukTT** - MPI and Docker setup issues
   - `mpi-docker` configuration problems
@@ -87,7 +87,7 @@ When you encounter issues that require escalation, use the following contacts an
 
 ---
 
-# General Debugging Tips
+## General Debugging Tips
 
 **Before diving into specific issues:**
 
@@ -101,7 +101,7 @@ When you encounter issues that require escalation, use the following contacts an
 **Useful commands:**
 
 | Command | Purpose |
-|---------|---------|
+| --------- | --------- |
 | `tt-smi -l` | List visible devices |
 | `tt-smi -r` | Reset devices (3.1.1+, preferred) |
 | `tt-smi -glx_reset` | Galaxy reset (deprecated as of 3.1.1, use `-r`) |
@@ -123,11 +123,13 @@ When you encounter issues that require escalation, use the following contacts an
 **Analyzing validation logs:**
 
 After running `run_validation.sh`, use the analysis script:
+
 ```bash
 python3 tools/scaleout/exabox/analyze_validation_results.py validation_output/
 ```
 
 For additional details (host summary, error messages, timeline):
+
 ```bash
 python3 tools/scaleout/exabox/analyze_validation_results.py validation_output/ --all
 ```
@@ -135,7 +137,7 @@ python3 tools/scaleout/exabox/analyze_validation_results.py validation_output/ -
 The script categorizes each log file and gives you a summary with success rate, plus actionable recommendations. Here's what each category means and where to look next:
 
 | Category | What it means | Next steps |
-|----------|---------------|------------|
+| ---------- | --------------- | ------------ |
 | **Healthy links** | All links passed validation | Good to go |
 | **Unhealthy links** | Data mismatch, CRC errors, or retrains detected | Check the FAULTY LINKS REPORT in the log. Same channel failing repeatedly = bad cable. Scattered failures = try power cycle. See [Data Mismatch During Traffic Tests](#data-mismatch-during-traffic-tests) |
 | **Missing connections** | Links in FSD not found (port or channel level) | Check cables are seated. Verify correct FSD file. See [QSFP Connections Missing](#qsfp-connections-missing-between-hosts) or [UMD Firmware Version Mismatch](#umd-firmware-version-mismatch---links-not-detected) or [Hostname Not Found in FSD](#hostname-not-found-in-fsd) |
@@ -153,6 +155,7 @@ The script categorizes each log file and gives you a summary with success rate, 
 For current validation results and baseline expectations, see the [Physical Validation Results spreadsheet](https://docs.google.com/spreadsheets/d/1lg6cG0TovYqwJtn6kkm5Fb1erQHH9p-p8NIUL279V0U/edit?pli=1&gid=489670889#gid=489670889).
 
 As a general guide for the current BH Exabox clusters:
+
 - **80%+ success rate** (40+/50): Typically indicates a usable cluster, counts as physical validation pass
 - **<80%**: May indicate hardware issues - check for consistent failure patterns, may need cable swap or hardware investigation
 
@@ -161,7 +164,7 @@ As a general guide for the current BH Exabox clusters:
 **Manual log inspection - error strings to grep for:**
 
 | Pattern | Meaning |
-|---------|---------|
+| --------- | --------- |
 | `All Detected Links are healthy` | Success - all links passed |
 | `Found Unhealthy Links` | Link failures detected |
 | `Timeout (10000 ms) waiting for physical cores` | Cores hung, need power cycle |
@@ -172,6 +175,7 @@ As a general guide for the current BH Exabox clusters:
 **mpi-docker wrapper:**
 
 The scripts use `mpi-docker` to run MPI jobs inside Docker containers. Run `./tools/scaleout/exabox/mpi-docker --help` for usage. Key options:
+
 - `--image <image>` - Docker image to use
 - `--host <hosts>` - comma-separated host list
 - `--empty-entrypoint` - use for most test containers
@@ -179,6 +183,7 @@ The scripts use `mpi-docker` to run MPI jobs inside Docker containers. Run `./to
 **Understanding validation output:**
 
 The validation tool compares discovered state (GSD) against expected state (FSD). Missing connections mean:
+
 - **Channel missing**: Individual ethernet link not trained
 - **Port missing**: Physical cable/port issue (check cables first)
 
@@ -186,24 +191,24 @@ When you see missing ports between the same host pair, start with physical inspe
 
 ---
 
-# Setup & Access
+## Setup & Access
 
-## SSH Agent Forwarding for MPI
+### SSH Agent Forwarding for MPI
 
 MPI tasks require passwordless SSH between hosts using ssh-agent forwarding.
 
 For detailed SSH setup instructions, see the [SSH Setup section in the README](./README.md#ssh-setup).
 
-
-
 ---
 
-## Tests Fail with "Permission denied" on tt-metal-cache
+### Tests Fail with "Permission denied" on tt-metal-cache
 
 **Symptom**: Running tests with your personal account fails with:
-```
+
+```text
 cannot map elf file into memory: Permission denied
 ```
+
 Error points to `/tmp/tt-metal-cache/...`
 
 **Cause**: The `/tmp/tt-metal-cache` directory was created by a different user (e.g., local-syseng) from a previous test run, or there's an issue in `mpi-docker` configuration.
@@ -216,10 +221,11 @@ Error points to `/tmp/tt-metal-cache/...`
 
 ---
 
-## Recovery Script Fails with "could not access or execute an executable"
+### Recovery Script Fails with "could not access or execute an executable"
 
 **Symptom**: Running `recover_4x32.sh` or `recover_8x16.sh` fails with:
-```
+
+```text
 mpirun was unable to launch the specified application as it could not access
 or execute an executable:
 
@@ -232,6 +238,7 @@ while attempting to start process rank 0.
 **Cause**: The `recover_*.sh` scripts run binaries directly on the host (not via Docker) and require a local build of tt-metal. Unlike the Docker-based scripts (`run_validation.sh`, `run_fabric_tests.sh`), they don't use containers.
 
 **Solution**:
+
 - **Build tt-metal first** - See [Quick Health Check](./README.md#quick-health-check-for-developers) for build instructions
 - **Or use Docker-based validation** - Run `./run_validation.sh --hosts <hosts> --image <docker-image>` which doesn't require a build
 
@@ -239,15 +246,16 @@ while attempting to start process rank 0.
 
 ---
 
-# SLURM Issues
+## SLURM Issues
 
-## SLURM Nodes Showing Down
+### SLURM Nodes Showing Down
 
 **Symptom**: `sinfo` shows nodes as "down" instead of "idle".
 
 **Cause**: Node may have rebooted or had a transient issue.
 
 **Solution**: Run the following on the login node to bring them back to idle:
+
 ```bash
 sudo /usr/local/bin/tt_reidle_downed_node.sh <hostname>
 ```
@@ -256,12 +264,13 @@ sudo /usr/local/bin/tt_reidle_downed_node.sh <hostname>
 
 ---
 
-## tt-smi Reset Requires Sudo Password in SLURM Session
+### tt-smi Reset Requires Sudo Password in SLURM Session
 
 **Note**: This issue only affects the deprecated `tt-smi -glx_reset` command. Use `tt-smi -r` (available in tt-smi 3.1.1+) instead, which doesn't require sudo.
 
 **Symptom**: Running `tt-smi -glx_reset` via mpirun in a SLURM session fails with:
-```
+
+```text
 IPMI command failed: sudo: a terminal is required to read the password
 ```
 
@@ -272,6 +281,7 @@ Running `groups` in the SLURM session shows wrong groups (e.g., another user's g
 **Solution**: Use `tt-smi -r` instead (available in tt-smi 3.1.1+), which doesn't require sudo and works in SLURM sessions.
 
 **Legacy workaround** (if stuck on older tt-smi): SSH directly to the galaxy node (not via srun) and run the reset:
+
 ```bash
 ssh <your-username>@<galaxy-host>.exabox.tenstorrent.com
 tt-smi -glx_reset
@@ -281,7 +291,7 @@ If this issue persists, report to infra team to fix group synchronization.
 
 ---
 
-## Hanging on PCIe Device Lock
+### Hanging on PCIe Device Lock
 
 **Symptom**: Your workload hangs trying to acquire a lock on a PCIe device, even though you have a SLURM reservation.
 
@@ -293,9 +303,9 @@ If this issue persists, report to infra team to fix group synchronization.
 
 ---
 
-# Reset & Power Issues
+## Reset & Power Issues
 
-## tt-smi Reset Fails with ARC Timeout
+### tt-smi Reset Fails with ARC Timeout
 
 **Note**: As of tt-smi 3.1.1, use `tt-smi -r` for resets. The `-glx_reset` option is deprecated. The new reset goes through the driver instead of BMC, doesn't need sudo, and works in docker/VMs.
 
@@ -304,42 +314,50 @@ If this issue persists, report to infra team to fix group synchronization.
 **Cause**: Can be transient or caused by underlying GDDR issues on a specific chip.
 
 **Resolution steps**:
+
 1. Try a soft reboot first (faster than power cycle)
 2. If reboot doesn't help, try a full power cycle:
+
    ```bash
    sudo ipmitool chassis power cycle
    ```
+
 3. If still failing after power cycle, it's likely a hardware issue (often GDDR related)
 
 **Diagnosis**: If issue persists, have syseng check for GDDR BIST failures. Common signature: UBBx ASICy GDDRz failing BIST, related to CA.
 
 **Solution for GDDR BIST failure**:
+
 - Syseng may attempt to revive with debug firmware reload
 - If no improvement, UBB tray swap required
 
 ---
 
-## AICLK Timeout During Chip Initialization
+### AICLK Timeout During Chip Initialization
 
 **Symptom**: Validation or chip initialization fails with a message like:
-```
+
+```text
 Waiting for AICLK value to settle failed on timeout after <timeout_ms>. Expected to see <target_aiclk>, last value observed <aiclk>. This can be due to possible overheating of the chip or other issues. ASIC temperature: <temp>
 ```
 
 This error originates from UMD during chip initialization (`tt_metal/third_party/umd/device/chip/chip.cpp`).
 
 **Cause**: The AICLK (AI Clock) failed to stabilize to the expected frequency. This has been observed across multiple systems and can indicate:
+
 - Bad firmware state on the affected chip
 - Hardware issues with the ASIC
 - Chip overheating (check the reported ASIC temperature)
 
 **Resolution steps**:
+
 1. Check the ASIC temperature in the error message - if abnormally high, allow cooldown
 2. Try a reset with `tt-smi -r`
 3. If issue persists, try a soft reboot of the host
 4. If still failing after reboot, escalate to Systems Engineering
 
 **Escalation**: This issue should be escalated to **Systems Engineering** as it often indicates:
+
 - Bad firmware requiring reflash
 - Hardware issues requiring further diagnosis
 - Potential need for UBB tray replacement
@@ -348,18 +366,20 @@ Report the error message (including the expected AICLK, observed value, and temp
 
 ---
 
-## Machine Won't Power On After BMC Power Cycle
+### Machine Won't Power On After BMC Power Cycle
 
 **Symptom**: After remote power cycle, machine doesn't come back up. BMC shows it going back to "Off" state immediately.
 
 BMC logs example:
-```
+
+```text
 Jan 08 02:27:58 s7tk power-control[4462]: Host0: Moving to "Wait for Power Supply Power OK" state
 Jan 08 02:28:58 s7tk power-control[4462]: Host0: Moving to "Off" state
 ```
 
 ipmitool shows UBB tray POST failures:
-```
+
+```text
 ipmitool -I lanplus -H <bmc-ip> -U root -P '<password>' sel elist
 62bf | 01/07/2026 | 13:36:05 MST | Processor UBB3_ASIC0_Stat | FRB2/Hang in POST failure | Asserted
 62c0 | 01/07/2026 | 13:36:05 MST | Processor UBB3_ASIC1_Stat | FRB2/Hang in POST failure | Asserted
@@ -369,6 +389,7 @@ ipmitool -I lanplus -H <bmc-ip> -U root -P '<password>' sel elist
 **Cause**: PDU circuit breaker tripped due to di/dt (current spike during power cycling).
 
 **Solution**:
+
 1. Physically check the PDU - look for tripped circuit breakers
 2. Reset the breaker
 3. Power cycle the machine again
@@ -379,12 +400,13 @@ This requires physical access to the datacenter.
 
 ---
 
-## Machine Rebooted with PCIe Errors
+### Machine Rebooted with PCIe Errors
 
 **Symptom**: Machine unexpectedly reboots. Kernel logs (dmesg) show PCIe hardware errors.
 
 Example from kernel logs:
-```
+
+```text
 [Hardware Error]:  fru_text: PcieError
 [Hardware Error]:   section_type: PCIe error
 [Hardware Error]:   port_type: 4, root port
@@ -400,7 +422,7 @@ pcieport 0000:c0:01.4: AER: aer_layer=Transaction Layer, aer_agent=Receiver ID
 
 ---
 
-## Tensix Stall Issue (Requires Power Cycle)
+### Tensix Stall Issue (Requires Power Cycle)
 
 **Symptom**: Cluster validation or tests hang on tensix operations. Multiple hosts affected in the same way.
 
@@ -409,6 +431,7 @@ pcieport 0000:c0:01.4: AER: aer_layer=Transaction Layer, aer_agent=Receiver ID
 **Cause**: Unknown - possibly something in SW or the handoff process during cluster bringup. Lower priority for debugging since power cycle resolves it.
 
 **Solution**: Power cycle the affected hosts via BMC. This clears the stall and allows cluster validation to proceed.
+
 ```bash
 sudo ipmitool chassis power cycle
 ```
@@ -417,9 +440,9 @@ sudo ipmitool chassis power cycle
 
 ---
 
-# Hardware Issues (GDDR/ASIC)
+## Hardware Issues (GDDR/ASIC)
 
-## GDDR Issue on Chip
+### GDDR Issue on Chip
 
 **Symptom**: One chip showing GDDR issues in tt-smi. Example: UBB2 ASIC8 having GDDR issue.
 
@@ -428,14 +451,16 @@ sudo ipmitool chassis power cycle
 **Cause**: GDDR training failure on that specific chip.
 
 **Solution**: Try virtual AC power cycle first to see if it's recoverable:
+
 ```bash
 sudo ipmitool chassis power cycle
 ```
+
 If GDDR issue persists after power cycle, it's a hardware problem that may require chip/board replacement.
 
 ---
 
-## Missing ASIC After Reboot
+### Missing ASIC After Reboot
 
 **Symptom**: Only 31 chips visible after `tt-smi reset` instead of 32. One ASIC doesn't come up.
 
@@ -446,18 +471,20 @@ Example: bh-glx-c01u08 showing only 31 chips, missing tray_id=2, asic_location=7
 **Cause**: ASIC failed to initialize after software reboot. Software reboot (`tt-smi reset` or OS reboot) is not sufficient to recover the chip.
 
 **Solution**: Full power cycle via BMC (not just software reboot). Contact someone with BMC access to power cycle the machine:
+
 ```bash
 sudo ipmitool chassis power cycle
 ```
 
 After power cycle, verify all 32 chips come up:
+
 ```bash
 tt-smi -l  # should show 32 devices
 ```
 
 ---
 
-## Do NOT Update Firmware on Cluster Machines
+### Do NOT Update Firmware on Cluster Machines
 
 **Warning**: Exabox cluster machines are currently running debug firmware (built off 19.3.1 with debug eth fw not merged to main).
 
@@ -467,12 +494,13 @@ tt-smi -l  # should show 32 devices
 
 ---
 
-# Ethernet & Connectivity
+## Ethernet & Connectivity
 
-## Hostname Not Found in FSD
+### Hostname Not Found in FSD
 
 **Symptom**: Validation crashes with a `std::runtime_error` indicating a hostname is not found in the Factory System Descriptor (FSD):
-```
+
+```text
 terminate called after throwing an instance of 'std::runtime_error'
   what():  Hostname not found in FSD: bh-glx-d03u02
 [bh-glx-d04u08:00001] *** Process received signal ***
@@ -482,6 +510,7 @@ terminate called after throwing an instance of 'std::runtime_error'
 This error typically appears across multiple MPI ranks with the same hostname mentioned.
 
 **Cause**: The FSD file being used doesn't include all the hosts in the current cluster topology. This happens when:
+
 - Running validation on a different cluster than the FSD was created for
 - The FSD file wasn't updated after cluster reconfiguration
 - Using a template FSD without customizing hostnames
@@ -503,11 +532,13 @@ This error typically appears across multiple MPI ranks with the same hostname me
 3. **Update the script or use a custom command**:
 
    Option A - Modify the recovery script temporarily:
+
    ```bash
    # Edit recover_4x32.sh and change the --factory-descriptor-path to the correct FSD
    ```
 
    Option B - Run the validation command directly with the correct FSD:
+
    ```bash
    mpirun --host <hosts> tt-smi -r
    sleep 30
@@ -522,19 +553,21 @@ This error typically appears across multiple MPI ranks with the same hostname me
 
 ---
 
-## UMD Firmware Version Mismatch - Links Not Detected
+### UMD Firmware Version Mismatch - Links Not Detected
 
 **Symptom**: Validation reports massive numbers of missing connections (e.g., 180 missing port/cable connections). Every single Trace and Linking Board connection appears to not be trained. However, when checked with the eth status script, all ports show `PORT_UP` and `LINK_TRAIN_PASS`.
 
 Example validation output:
-```
+
+```text
 Physical Discovery found 180 missing port/cable connections:
   - PhysicalPortEndpoint{hostname='bh-glx-c01u02', ... port_type=TRACE, port_id=1} <-> ...
   - PhysicalPortEndpoint{hostname='bh-glx-c01u02', ... port_type=TRACE, port_id=3} <-> ...
 ```
 
 But eth script shows ports are actually up:
-```
+
+```text
 eth_postcode    - PASS
 serdes_postcode - PASS
 macpcs_postcode - PASS
@@ -545,7 +578,8 @@ train_status - LINK_TRAIN_PASS
 **Cause**: UMD only checks major.minor firmware version, ignoring patch version. If ERISC FW is a patch build (e.g., 1.7.103 when UMD expects 1.7.1 for FW Bundle 19.3.0), UMD ignores the links entirely.
 
 UMD log showing the mismatch:
-```
+
+```text
 2026-01-05 23:41:02.445 | info | UMD | Firmware bundle version 19.3.0 on the system is newer than the latest fully tested version 19.1.0 for blackhole architecture.
 ```
 
@@ -557,12 +591,13 @@ The root cause was that patch builds (like 1.7.103) didn't update the version nu
 
 ---
 
-## QSFP Connections Missing Between Hosts
+### QSFP Connections Missing Between Hosts
 
 **Symptom**: Validation shows missing QSFP_DD port connections between specific hosts. All missing connections are between the same pair of machines.
 
 Example output:
-```
+
+```text
 Physical Discovery found 12 missing port/cable connections:
   - PhysicalPortEndpoint{hostname='bh-glx-c01u08', ... tray_id=3, port_type=QSFP_DD, port_id=1} <-> PhysicalPortEndpoint{hostname='bh-glx-c02u08', ... tray_id=4, port_type=QSFP_DD, port_id=1}
   - PhysicalPortEndpoint{hostname='bh-glx-c01u08', ... tray_id=3, port_type=QSFP_DD, port_id=2} <-> ...
@@ -577,9 +612,11 @@ Physical Discovery found 12 missing port/cable connections:
 2. Have someone physically reseat the QSFP cables at the reported ports
 3. Re-run validation
 4. If still missing, power cycle both affected machines:
+
    ```bash
    sudo ipmitool chassis power cycle
    ```
+
 5. If still missing after power cycle, swap the cable
 6. If issue persists after cable swap, escalate to syseng for hardware investigation
 
@@ -587,7 +624,7 @@ In the example above, QSFPs on C02U08 were found to be down. Reseating the cable
 
 ---
 
-## Transient Ethernet Connectivity Loss
+### Transient Ethernet Connectivity Loss
 
 **Symptom**: Missing connections between hosts that were previously stable. Ethernet was working earlier but now shows missing links.
 
@@ -596,17 +633,19 @@ Example: Missing connections between c01u02 and c01u08 - physical cables checked
 **Cause**: Transient issue - links failed to train after some event (reset, temperature change, etc.) but no physical damage.
 
 **Diagnosis**:
+
 1. Check physical connectivity first (cables seated properly)
 2. If physical looks fine, it's likely a transient issue
 
 **Solution**: Power cycle both affected machines via BMC. This resolved ethernet connectivity issues on the 8x16 cluster.
+
 ```bash
 sudo ipmitool chassis power cycle
 ```
 
 ---
 
-## Z Ports Showing Down
+### Z Ports Showing Down
 
 **Symptom**: Diagnostic script shows all Z ports (ETH10+) are down.
 
@@ -618,37 +657,41 @@ Only investigate if Z ports are supposed to be connected in your topology.
 
 ---
 
-## Trace Connections Hanging After Reset (~30% Failure Rate)
+### Trace Connections Hanging After Reset (~30% Failure Rate)
 
 **Symptom**: Physical validation tests show ~70% pass rate. Trace connections on certain hosts hang after some resets. Consistent failure signature across runs.
 
 **Root Cause**: ERISC 0 (responsible for link recovery through base FW) was also running user TX/RX kernels. The BH context switch mechanism does not run link recovery when called. If a link failed training or dynamically went down, recovery never gets invoked while user kernels are running.
 
 **Solution**:
+
 1. Switch execution to ERISC 1 only (single ERISC mode)
 2. Add 5 second delay after each `tt-smi reset` to wait for training to stabilize
 
 **Result**: With single ERISC + 5s delay after reset, 48/50 runs passed physical validation (96%).
 
 **Remaining issues**:
+
 - If links take long to stabilize post-reset, they can be reported as missing. Try longer sleeps.
 - Occasional data mismatches still occur (under investigation)
 
 **Long-term fix**: Fabric team adding coordinated context switch with link recovery API. Until then, run validation and fabric tests with single ERISC.
 
 **Environment variable**: To force single ERISC mode:
+
 ```bash
 export TT_METAL_DISABLE_MULTI_AERISC=1
 ```
 
 ---
 
-# Fabric Tests
+## Fabric Tests
 
-## Fabric Test Fails with "Graph could not fit in physical topology"
+### Fabric Test Fails with "Graph could not fit in physical topology"
 
 **Symptom**: Running `run_fabric_tests.sh --config 4x32` fails with:
-```
+
+```text
 TT_FATAL: Graph specified in MGD could not fit in the discovered physical topology for mesh 0.
 Could not find valid mapping for mesh 0 under the given constraints.
 Logical graph may not fit in the physical topology.
@@ -664,10 +707,12 @@ The error originates from `tt_metal/fabric/topology_mapper.cpp` during `Topology
 2. **Host ordering mismatch** - If physical validation passed but fabric tests fail with this error, hosts were passed in the wrong order to MPI.
 
 **Diagnosing the cause**:
+
 ```bash
 # Run physical validation first
 ./run_validation.sh --hosts <hosts> --image <docker-image>
 ```
+
 - If validation shows missing connections → Fix the hardware/cabling issue first
 - If validation passes (all links healthy) → It's a host ordering issue, continue below
 
@@ -678,7 +723,8 @@ In a 4x32 pod, the 4 Galaxies are connected in a ring: `1 <-> 2 <-> 3 <-> 4 <-> 
 When you pass hostnames to MPI in an arbitrary order, MPI assigns rank values that may not respect the physical connectivity. For example, if hosts 1 & 3 are placed adjacent in "MPI space" (consecutive ranks), the fabric test assumes they must be physically connected. When it validates against actual connectivity and finds no physical links between them, it fails.
 
 **Visual representation of 4x32 connectivity:**
-```
+
+```text
     Host 1 -------- Host 2
        |              |
        |              |
@@ -694,12 +740,14 @@ Hosts are connected in a ring: 1-2, 2-3, 3-4, 4-1. There are no diagonal connect
 3. Pass hosts in ring order: `1,2,3,4` (not `1,3,2,4` or any other order)
 
 **Example**: For a pod with hosts `b02u08`, `b02u02`, `b09u02`, `b09u08`:
+
 - Log onto `b02u08` (Host 1)
 - Run: `./run_fabric_tests.sh --config 4x32 --hosts b02u08,b02u02,b09u02,b09u08 --image <docker-image>`
 
 The host order must follow the physical ring topology.
 
 **How to determine the correct order**:
+
 1. Check the cabling diagram or FSD for your pod
 2. Identify which hosts are directly connected via QSFP cables
 3. Order them so consecutive hosts in your list are physically connected
@@ -707,6 +755,7 @@ The host order must follow the physical ring topology.
 **Long-term fix**: Automatic mesh placement and rank binding is being developed to eliminate this manual ordering requirement (TT-Distributed infrastructure improvement).
 
 **Diagnostic**: If you're unsure about connectivity, run physical validation first:
+
 ```bash
 ./run_validation.sh --hosts <hosts> --image <docker-image>
 ```
@@ -715,10 +764,11 @@ The validation output shows which hosts have physical connections to each other.
 
 ---
 
-## Fabric Test Fails with "Failed to initialize FW"
+### Fabric Test Fails with "Failed to initialize FW"
 
 **Symptom**: Fabric test fails during device initialization with:
-```
+
+```text
 TT_THROW: Device 31: Timeout (10000 ms) waiting for physical cores to finish: (x=2,y=10)
 TT_THROW: Device 31 init: failed to initialize FW! Try resetting the board.
 ```
@@ -732,6 +782,7 @@ The error originates from `tt_metal/impl/context/metal_context.cpp` during `Meta
 **Solution**:
 
 1. **Immediate fix**: Reset the cluster and retry:
+
    ```bash
    mpirun --host <hosts> tt-smi -r
    sleep 30
@@ -739,6 +790,7 @@ The error originates from `tt_metal/impl/context/metal_context.cpp` during `Meta
    ```
 
 2. **For automated pipelines**: Always run a distributed reset and physical validation before starting fabric tests:
+
    ```bash
    # Reset all hosts
    mpirun --host <hosts> tt-smi -r
@@ -755,10 +807,11 @@ The error originates from `tt_metal/impl/context/metal_context.cpp` during `Meta
 
 ---
 
-## Fabric Router Sync Timeout
+### Fabric Router Sync Timeout
 
 **Symptom**: Fabric test fails during mesh device creation with:
-```
+
+```text
 TT_THROW: Fabric Router Sync: Timeout after 10000 ms. Device 0: Expected status 0xa2b2c2d2, got 0xa1b1c1d1
 ```
 
@@ -767,6 +820,7 @@ The error originates from `tt_metal/impl/device/device_manager.cpp` during `Devi
 **Context**: This can happen even after resetting the cards. The status value `0xa1b1c1d1` indicates the sync handshake started but didn't complete (expected `0xa2b2c2d2`).
 
 **Cause**: Handshakes over Ethernet links during fabric initialization failed. This happens when:
+
 - A link or its peer is down
 - Links didn't fully train after reset
 - Reset sleep time was insufficient
@@ -774,12 +828,15 @@ The error originates from `tt_metal/impl/device/device_manager.cpp` during `Devi
 **Solution**:
 
 1. **Run physical validation first**: This catches unhealthy links before attempting fabric tests:
+
    ```bash
    ./run_validation.sh --hosts <hosts> --image <docker-image>
    ```
+
    If validation shows missing connections or unhealthy links, fix those issues before running fabric tests.
 
 2. **For automated pipelines**: Add physical validation as a pre-check and implement retry logic:
+
    ```bash
    # Reset and wait
    mpirun --host <hosts> tt-smi -r
@@ -796,9 +853,9 @@ The error originates from `tt_metal/impl/device/device_manager.cpp` during `Devi
 
 ---
 
-# Tensix & Validation
+## Tensix & Validation
 
-## Tensix Cores Unresponsive During Validation
+### Tensix Cores Unresponsive During Validation
 
 **Symptom**: Traffic tests that load management firmware onto tensix and ethernet cores fail. SW reports all tensix cores as unresponsive across all hosts. The workload waits for a response as part of initialization (by polling) and never gets it.
 
@@ -807,6 +864,7 @@ The error originates from `tt_metal/impl/device/device_manager.cpp` during `Devi
 **Cause**: Unknown - possibly firmware/driver interaction issue. The firmware team noted this is strange because they don't have anything that runs on the Tensixes. Each host was broken in the same way.
 
 **Solution**: Power cycle resolved the issue, though root cause remains unknown. This is concerning but not an immediate blocker.
+
 ```bash
 sudo ipmitool chassis power cycle
 ```
@@ -819,25 +877,27 @@ sudo ipmitool chassis power cycle
 
 ---
 
-## Intermittent Tensix Cores Hung at Device Startup
+### Intermittent Tensix Cores Hung at Device Startup
 
 **Symptom**: Arbitrary tensix cores are hung/unresponsive at device startup. Happens intermittently.
 
 **Cause**: Under investigation.
 
 **Workaround**: Power cycle and retry. Issue is intermittent.
+
 ```bash
 sudo ipmitool chassis power cycle
 ```
 
 ---
 
-## Data Mismatch During Traffic Tests
+### Data Mismatch During Traffic Tests
 
 **Symptom**: Validation reports data mismatch - data sent doesn't match data received. Can occur even when all links show as trained.
 
 Example from logs:
-```
+
+```text
 8 words of data mismatch
 ```
 
@@ -847,30 +907,33 @@ Example from logs:
 
 ---
 
-# ERISC & Firmware
+## ERISC & Firmware
 
-## ERISC Workarounds and Known Issues
+### ERISC Workarounds and Known Issues
 
 Reference for ERISC-related issues discovered during bringup (from GitHub issue #25427):
 
-**ND hangs during init (Mailbox API to Metal FW)**
+#### ND hangs during init (Mailbox API to Metal FW)
+
 - Went away after shifting binaries by 32 bytes
 - Workaround: Once RISC gets to metal FW, save registers and soft reset both ERISC0 and ERISC1
 - Suspected cause: Stuck data in the instruction cache (i$)
 - Code: `tt_metal/hw/firmware/src/tt-1xx/active_erisc.cc` lines 117-195
 
-**Interrupts causing retrain counts to increase**
+#### Interrupts causing retrain counts to increase
+
 - Interrupts were disabled as workaround
 - Code: `tt_metal/hw/firmware/src/tt-1xx/active_erisc.cc` line 203
 
-**NOC usage conflicts**
+#### NOC usage conflicts
+
 - Base FW runs on ERISC0 and uses NOC0
 - Kernel creation API enforces: ERISC0 uses NOC0, ERISC1 uses NOC1
 - This prevents conflicts between base FW and user kernels
 
 ---
 
-## Single ERISC Fabric Workloads Hang Immediately
+### Single ERISC Fabric Workloads Hang Immediately
 
 **Symptom**: When running fabric workloads with single ERISC mode (`TT_METAL_DISABLE_MULTI_AERISC=1`), the workload hangs immediately.
 


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
The Exabox troubleshooting guide referenced power cycle and SLURM node recovery actions without providing the actual commands to run. Engineers following the guide had to know or look up the exact commands separately, slowing down incident response.
Also markdown lint showed like 40 errors its probs not optimal.

### What's changed
Added concrete, copy-pasteable commands to all relevant sections of TROUBLESHOOTING.md, fixed errors!