### PR TITLE
Restore logical_matches_physical fast path in pytensor

### DIFF
--- a/ttnn/cpp/ttnn-nanobind/pytensor.cpp
+++ b/ttnn/cpp/ttnn-nanobind/pytensor.cpp
@@ -208,9 +208,13 @@ RowMajorHostBuffer convert_to_row_major_host_buffer(const Tensor& tt_tensor, con
             return RowMajorHostBuffer::create_padded(std::move(host_buffer), tensor_spec);
         }
 
-        // Previous impl only copied if data needed transformation. Instead *always* copy
-        // because the HostBuffer will be returned directly to the other python frameworks
-        // wrapped in an ndarray
+        // No modifications needed; directly return buffer.
+        // Ownership is safe: the HostBuffer shallow copy in convert_tt_tensor_to_framework_tensor
+        // increments the MemoryPin ref count, and the nb::capsule ensures the data stays alive
+        // as long as the Python ndarray exists.
+        if (logical_matches_physical(tensor_spec)) {
+            return RowMajorHostBuffer::create_logical(std::move(host_buffer), tensor_spec);
+        }
 
         auto logical_data = tensor_impl::decode_tensor_data(host_buffer.view_as<const T>(), tensor_spec);
         return RowMajorHostBuffer::create_logical(HostBuffer(std::move(logical_data)), tensor_spec);


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/36313

### Problem description
Commit 6ae67088c9 ("Fix pytensor ownership", #35010) introduced a **20% TTFT regression** on BH LoudBox for Llama3-8B.

That commit removed the fast path in `convert_to_row_major_host_buffer()` that skipped `decode_tensor_data` when `logical_matches_physical(tensor_spec)` was true (ROW_MAJOR layout with logical 2D shape == physical shape). This forced every `to_torch()`/`to_numpy()` call through a full data copy + allocation even when no data transformation was needed — which is the common case for Llama3-8B inference.

The removal was motivated by ownership concerns, but the ownership is actually safe:
1. `HostBuffer` uses `MemoryPin` (backed by `shared_ptr`) for reference counting
2. In `convert_tt_tensor_to_framework_tensor`, the shallow `HostBuffer` copy increments the `MemoryPin` ref count
3. The `nb::capsule` properly destroys the heap `HostBuffer` when the Python ndarray is GC'd (ref count--)
4. `rv_policy::take_ownership` (also from that commit) correctly transfers the ndarray to Python

The data lives as long as any `HostBuffer` copy holds a `MemoryPin` reference, and the capsule guarantees this.

### What's changed
Restored the `logical_matches_physical` check that was removed in #35010. When the tensor data is already in the correct format (ROW_MAJOR, logical matches physical), we skip the redundant `decode_tensor_data` call and return the buffer directly.

All other improvements from #35010 are preserved:
- `rv_policy::take_ownership` (correct for ndarray transfer)
- Simplified `convert_tt_tensor_to_framework_tensor` (no more unused policy parameter)
- Dead code removal in `parse_external_operation`

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=blozano/fix-pytensor-ttft-regression)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:blozano/fix-pytensor-ttft-regression)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=blozano/fix-pytensor-ttft-regression)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:blozano/fix-pytensor-ttft-regression)
- [ ] New/Existing tests provide coverage for changes

#### Model tests

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=blozano/fix-pytensor-ttft-regression)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:blozano/fix-pytensor-ttft-regression)
  - [ ] `models-mandatory` preset (Device perf regressions + Frequent model and ttnn tests)
