### PR TITLE
Refactor DeepSeekV3 B1 weight preparation 

### DIFF
--- a/models/demos/deepseek_v3_b1/demo/README.md
+++ b/models/demos/deepseek_v3_b1/demo/README.md
@@ -6,16 +6,29 @@ The demo runs prefill + decode over `DeepSeekV3` sockets and streams decoded tex
 
 ## Requirements
 
-Assuming your environment is configured correctly:
+- **Mesh shape:** The demo requires a **4×2** mesh. The CLI will fail at startup if the mesh shape does not match.
+- Slow dispatch mode must be enabled (see below).
 
-1. Enable slow dispatch mode:
+## Running the demo on single galaxy
+
+From the repo root (`tt-metal/`), run the following. Do this after every `tt-smi -glx_reset`:
 
 ```bash
 export TT_METAL_SLOW_DISPATCH_MODE=1
+export TT_METAL_HOME=$PWD
+tt-smi -glx_reset
+python tests/tt_metal/tt_fabric/utils/generate_rank_bindings.py
+tt-run --rank-binding bh_4x2_multi_mesh_rank_binding.yaml  \
+    python -m models.demos.deepseek_v3_b1.demo.cli --cache-path /mnt/models/deepseek-ai/deepseek_v3_b1_cache --layer-id-offset 4
 ```
 
-2. Run the demo:
+Adjust `--cache-path` to your prepared weight cache location and `--layer-id-offset` as needed. You can also pass `--prompt` and `--max-new-tokens`, for example:
+
+## Running the demo on single-pod:
 
 ```bash
-python -m models.demos.deepseek_v3_b1.demo.cli --prompt "Once upon a time" --max-new-tokens 128
+./tools/scaleout/exabox/recover_4x32.sh bh-glx-d06u08,bh-glx-d06u02,bh-glx-d05u08,bh-glx-d05u02 # Modify with your 4 hosts
+python3 models/demos/deepseek_v3_b1/scaleout_configs/generate_blitz_decode_pipeline_configs.py models/demos/deepseek_v3_b1/scaleout_configs/blitz_pipeline_config_single_pod.yaml # Generate pipeline config for 1 pod
+tt-run --mpi-args "--map-by rankfile:file=blitz_decode_pipeline_rank_file_single_pod --bind-to hwt:overload-allowed --host bh-glx-d05u02:4,bh-glx-d05u08:4,bh-glx-d06u02:4,bh-glx-d06u08:4 --tag-output" --rank-binding blitz_decode_pipeline_rank_binding_single_pod.yaml \
+    python -m models.demos.deepseek_v3_b1.demo.cli --cache-path /mnt/models/deepseek-ai/deepseek_v3_b1_cache --layer-id-offset 4
 ```

--- a/models/demos/deepseek_v3_b1/demo/cli.py
+++ b/models/demos/deepseek_v3_b1/demo/cli.py
@@ -5,18 +5,90 @@
 from __future__ import annotations
 
 import argparse
+import contextlib
+import os
 import sys
+from pathlib import Path
 from typing import TextIO
 
 from loguru import logger
 from transformers import AutoTokenizer
 
 import ttnn
+from conftest import bh_2d_mesh_device_context
 from models.common.utility_functions import is_slow_dispatch
 from models.demos.deepseek_v3_b1.demo.runner import GenerationResult, run_generation
 from models.demos.deepseek_v3_b1.demo.runtime import TokenCodec, create_model
+from models.demos.deepseek_v3_b1.prepare_weights import (
+    DeepSeekV3Weights,
+    MoERoutedExpertWeights,
+    load_layer,
+    load_moe_routed_experts_from_cache,
+)
 
 DEFAULT_TOKENIZER = "deepseek-ai/DeepSeek-V3"
+FIRST_K_DENSE_REPLACE = 3
+# Each layer is loaded onto a separate (4, 2) submesh; full mesh is (4, 2*num_layers).
+SUBMESH_SHAPE = (4, 2)
+
+
+@contextlib.contextmanager
+def enable_fast_dispatch_mode(device):
+    """Stub: will switch device to fast dispatch mode. Currently a no-op."""
+    yield
+
+
+@contextlib.contextmanager
+def open_mesh_device_with_submeshes(num_layers: int):
+    """Open mesh device using bh_2d_mesh_device_context and create (4, 2) submeshes.
+
+    Yields (mesh_device, submeshes). Ensures at least num_layers submeshes exist.
+    Same setup as generate_cache.py.
+    """
+    if not os.environ.get("TT_METAL_FABRIC_ROUTER_SYNC_TIMEOUT_MS"):
+        os.environ["TT_METAL_FABRIC_ROUTER_SYNC_TIMEOUT_MS"] = "30000"
+        logger.info("Set TT_METAL_FABRIC_ROUTER_SYNC_TIMEOUT_MS=30000 (fabric init may be slow)")
+    device_params = {"fabric_config": ttnn.FabricConfig.FABRIC_2D}
+    logger.info("Opening mesh device (via bh_2d_mesh_device_context)...")
+    with bh_2d_mesh_device_context(device_params) as mesh_device:
+        submeshes = mesh_device.create_submeshes(ttnn.MeshShape(*SUBMESH_SHAPE))
+        if len(submeshes) < num_layers:
+            raise RuntimeError(
+                f"Mesh has {len(submeshes)} (4x2) submeshes but num_layers={num_layers}; "
+                f"need at least {num_layers}*8 devices (e.g. 8 for 1 layer, 32 for 4 layers)"
+            )
+        logger.info("Mesh has {} (4x2) submeshes", len(submeshes))
+        yield mesh_device, submeshes
+
+
+def load_weights_from_cache(
+    cache_path: Path,
+    mesh_device: ttnn.MeshDevice,
+    submeshes: list,
+    num_layers: int,
+) -> DeepSeekV3Weights:
+    """Load weights from cache: routed experts in fast-dispatch phase, then all layers on their submesh."""
+    # Phase 1: Fast dispatch -- load routed experts for MoE layers (each on its submesh)
+    preloaded_experts: dict[int, MoERoutedExpertWeights] = {}
+    with ttnn.device.setup_fast_dispatch(mesh_device):
+        for layer_idx in range(FIRST_K_DENSE_REPLACE, num_layers):
+            preloaded_experts[layer_idx] = load_moe_routed_experts_from_cache(
+                cache_path, submeshes[layer_idx], layer_idx
+            )
+
+    # Phase 2: Slow dispatch -- load each layer onto its (4, 2) submesh
+    layers = []
+    for layer_idx in range(num_layers):
+        layer = load_layer(
+            cache_path,
+            submeshes[layer_idx],
+            layer_idx,
+            preloaded_routed_experts=preloaded_experts.get(layer_idx),
+        )
+        layers.append(layer)
+    weights = DeepSeekV3Weights(layers=layers)
+    logger.info("Loaded {} layers from cache (one per submesh)", len(weights.layers))
+    return weights
 
 
 def create_parser() -> argparse.ArgumentParser:
@@ -35,8 +107,18 @@ def create_parser() -> argparse.ArgumentParser:
         default=True,
         help="Use HostInterface loopback path (recommended for current B1 bring-up)",
     )
-    parser.add_argument("--mesh-height", type=int, default=1, help="Mesh height for open_mesh_device")
-    parser.add_argument("--mesh-width", type=int, default=1, help="Mesh width for open_mesh_device")
+    parser.add_argument(
+        "--cache-path",
+        type=Path,
+        required=True,
+        help="Path to the weight cache directory (contains layer_NNN/ subdirs)",
+    )
+    parser.add_argument(
+        "--num-layers",
+        type=int,
+        default=1,
+        help="Number of decoder layers to load from cache",
+    )
     return parser
 
 
@@ -50,16 +132,15 @@ def run_demo(
     max_new_tokens: int,
     tokenizer_name_or_path: str,
     loopback_mode: bool,
-    mesh_height: int,
-    mesh_width: int,
+    cache_path: Path,
+    num_layers: int,
     output_stream: TextIO,
 ) -> GenerationResult:
     logger.info(
-        "Starting DeepSeek V3 B1 demo (max_new_tokens={}, loopback_mode={}, mesh_shape={}x{})",
+        "Starting DeepSeek V3 B1 demo (max_new_tokens={}, loopback_mode={}, num_layers={})",
         max_new_tokens,
         loopback_mode,
-        mesh_height,
-        mesh_width,
+        num_layers,
     )
     if not is_slow_dispatch():
         raise RuntimeError(
@@ -80,10 +161,10 @@ def run_demo(
         output_stream.write(text)
         output_stream.flush()
 
-    mesh_device: ttnn.MeshDevice | None = None
-    try:
-        logger.info("Opening mesh device")
-        mesh_device = ttnn.open_mesh_device(mesh_shape=ttnn.MeshShape(mesh_height, mesh_width))
+    with open_mesh_device_with_submeshes(num_layers) as (mesh_device, submeshes):
+        weights = load_weights_from_cache(cache_path, mesh_device, submeshes, num_layers)
+        breakpoint()
+
         logger.info("Creating DeepSeekV3 model")
         model = create_model(mesh_device=mesh_device, batch_size=1, loopback_mode=loopback_mode)
         logger.info("Running prefill + decode")
@@ -102,10 +183,6 @@ def run_demo(
             len(result.generated_token_ids),
         )
         return result
-    finally:
-        if mesh_device is not None:
-            logger.info("Closing mesh device")
-            ttnn.close_mesh_device(mesh_device)
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -117,8 +194,8 @@ def main(argv: list[str] | None = None) -> int:
         max_new_tokens=args.max_new_tokens,
         tokenizer_name_or_path=args.tokenizer,
         loopback_mode=args.loopback_mode,
-        mesh_height=args.mesh_height,
-        mesh_width=args.mesh_width,
+        cache_path=args.cache_path,
+        num_layers=args.num_layers,
         output_stream=sys.stdout,
     )
     print(file=sys.stdout, flush=True)

--- a/models/demos/deepseek_v3_b1/demo/cli.py
+++ b/models/demos/deepseek_v3_b1/demo/cli.py
@@ -11,7 +11,6 @@ import sys
 from pathlib import Path
 from typing import TextIO
 
-import torch
 from loguru import logger
 from transformers import AutoTokenizer
 
@@ -21,15 +20,21 @@ from models.common.utility_functions import is_slow_dispatch
 from models.demos.deepseek_v3_b1.demo.runner import GenerationResult, run_generation
 from models.demos.deepseek_v3_b1.demo.runtime import TokenCodec, create_model
 from models.demos.deepseek_v3_b1.prepare_weights import (
-    MoERoutedExpertWeights,
-    load_layer,
-    load_moe_routed_experts_from_cache,
+    DeepSeekV3DenseLayerWeights,
+    DeepSeekV3EmbeddingLayerWeights,
+    DeepSeekV3LMHeadWeights,
+    DeepSeekV3MoELayerWeights,
+    load_dense_decoder_layer,
+    load_embedding_weights,
+    load_lm_head_weights,
+    load_moe_decoder_layer,
+    load_moe_routed_experts,
 )
 
 DEFAULT_TOKENIZER = "deepseek-ai/DeepSeek-V3"
 FIRST_K_DENSE_REPLACE = 3
 
-SUBMESH_SHAPE = (4, 2)
+EXPECTED_PIPELINE_STAGE_MESH_SHAPE = (4, 2)
 
 
 @contextlib.contextmanager
@@ -37,10 +42,13 @@ def open_mesh_device():
     """Open mesh device using bh_2d_mesh_device_context."""
     if not os.environ.get("TT_METAL_FABRIC_ROUTER_SYNC_TIMEOUT_MS"):
         os.environ["TT_METAL_FABRIC_ROUTER_SYNC_TIMEOUT_MS"] = "30000"
-        logger.info("Set TT_METAL_FABRIC_ROUTER_SYNC_TIMEOUT_MS=30000 (fabric init may be slow)")
     device_params = {"fabric_config": ttnn.FabricConfig.FABRIC_2D}
     logger.info("Opening mesh device...")
     with bh_2d_mesh_device_context(device_params) as mesh_device:
+        mesh_shape = (mesh_device.shape[0], mesh_device.shape[1])
+        assert (
+            mesh_shape == EXPECTED_PIPELINE_STAGE_MESH_SHAPE
+        ), f"Demo requires a {EXPECTED_PIPELINE_STAGE_MESH_SHAPE[0]}x{EXPECTED_PIPELINE_STAGE_MESH_SHAPE[1]} mesh; got {mesh_shape[0]}x{mesh_shape[1]}"
         logger.info(f"Mesh device opened (id={mesh_device.get_system_mesh_id()}, shape={mesh_device.shape})")
         yield mesh_device
 
@@ -62,49 +70,29 @@ def load_weights_from_cache(
     cache_path: Path,
     mesh_device: ttnn.MeshDevice,
     layer_offset: int,
-) -> DeepSeekV3LayerWeights:
-    """Load weights from cache: routed experts in fast-dispatch phase, then all layers on their submesh."""
+) -> (
+    DeepSeekV3EmbeddingLayerWeights | DeepSeekV3DenseLayerWeights | DeepSeekV3MoELayerWeights | DeepSeekV3LMHeadWeights
+):
+    """Load weights from cache (embedding, decoder layer, or lm_head)."""
     mesh_id = mesh_device.get_system_mesh_id() + layer_offset
     assert (
         mesh_id >= SYSTEM_MESH_ID_EMBEDDING and mesh_id <= SYSTEM_MESH_ID_LM_HEAD
     ), f"Mesh ID must be between {SYSTEM_MESH_ID_EMBEDDING} and {SYSTEM_MESH_ID_LM_HEAD} but got {mesh_id}"
     if mesh_id == SYSTEM_MESH_ID_EMBEDDING:
-        # TODO: Load embedding weights from the cache
         logger.info("Loading embedding weights from cache")
-        embedding_shape = (129280, 7168)
-        embedding_tensor = ttnn.from_torch(
-            torch.rand(embedding_shape), dtype=ttnn.bfloat16, layout=ttnn.ROW_MAJOR_LAYOUT
-        )
-        embedding_tensor = ttnn.to_device(embedding_tensor, mesh_device, memory_config=ttnn.DRAM_MEMORY_CONFIG)
-        return DeepSeekV3EmbeddingLayerWeights(embedding=embedding_tensor)
+        return load_embedding_weights(cache_path, mesh_device)
     elif mesh_id == SYSTEM_MESH_ID_LM_HEAD:
         logger.info("Loading LM head weights from cache")
-        # TODO: Load LM head weights from the cache
-        lm_head_shape = (129280, 7168)
-        lm_head_tensor = ttnn.from_torch(torch.rand(lm_head_shape), dtype=ttnn.bfloat16, layout=ttnn.ROW_MAJOR_LAYOUT)
-        lm_head_tensor = ttnn.to_device(lm_head_tensor, mesh_device, memory_config=ttnn.DRAM_MEMORY_CONFIG)
-        return DeepSeekV3LMHeadWeights(lm_head=lm_head_tensor)
+        return load_lm_head_weights(cache_path, mesh_device)
     else:
-        # Get the correct layer ID given the mesh ID
         layer_id = decoder_layer_id_from_mesh_id(mesh_id)
-
         is_moe = layer_id >= FIRST_K_DENSE_REPLACE
         logger.info(f"Loading {'moe' if is_moe else 'dense'} layer weights from cache")
-
-        preloaded_experts: MoERoutedExpertWeights | None = None
         if is_moe:
-            # Phase 1: Fast dispatch -- load routed experts for MoE layers (each on its submesh)
             with ttnn.device.setup_fast_dispatch(mesh_device):
-                preloaded_experts = load_moe_routed_experts_from_cache(cache_path, mesh_device, layer_id)
-
-        # Phase 2: Slow dispatch -- load each layer onto its (4, 2) submesh
-        layer = load_layer(
-            cache_path,
-            mesh_device,
-            layer_id,
-            preloaded_routed_experts=preloaded_experts,
-        )
-        return layer
+                preloaded_experts = load_moe_routed_experts(cache_path, mesh_device, layer_id)
+            return load_moe_decoder_layer(cache_path, mesh_device, layer_id, preloaded_routed_experts=preloaded_experts)
+        return load_dense_decoder_layer(cache_path, mesh_device, layer_id)
 
 
 def create_parser() -> argparse.ArgumentParser:

--- a/models/demos/deepseek_v3_b1/demo/cli.py
+++ b/models/demos/deepseek_v3_b1/demo/cli.py
@@ -11,6 +11,7 @@ import sys
 from pathlib import Path
 from typing import TextIO
 
+import torch
 from loguru import logger
 from transformers import AutoTokenizer
 
@@ -20,7 +21,6 @@ from models.common.utility_functions import is_slow_dispatch
 from models.demos.deepseek_v3_b1.demo.runner import GenerationResult, run_generation
 from models.demos.deepseek_v3_b1.demo.runtime import TokenCodec, create_model
 from models.demos.deepseek_v3_b1.prepare_weights import (
-    DeepSeekV3Weights,
     MoERoutedExpertWeights,
     load_layer,
     load_moe_routed_experts_from_cache,
@@ -28,67 +28,83 @@ from models.demos.deepseek_v3_b1.prepare_weights import (
 
 DEFAULT_TOKENIZER = "deepseek-ai/DeepSeek-V3"
 FIRST_K_DENSE_REPLACE = 3
-# Each layer is loaded onto a separate (4, 2) submesh; full mesh is (4, 2*num_layers).
+
 SUBMESH_SHAPE = (4, 2)
 
 
 @contextlib.contextmanager
-def enable_fast_dispatch_mode(device):
-    """Stub: will switch device to fast dispatch mode. Currently a no-op."""
-    yield
-
-
-@contextlib.contextmanager
-def open_mesh_device_with_submeshes(num_layers: int):
-    """Open mesh device using bh_2d_mesh_device_context and create (4, 2) submeshes.
-
-    Yields (mesh_device, submeshes). Ensures at least num_layers submeshes exist.
-    Same setup as generate_cache.py.
-    """
+def open_mesh_device():
+    """Open mesh device using bh_2d_mesh_device_context."""
     if not os.environ.get("TT_METAL_FABRIC_ROUTER_SYNC_TIMEOUT_MS"):
         os.environ["TT_METAL_FABRIC_ROUTER_SYNC_TIMEOUT_MS"] = "30000"
         logger.info("Set TT_METAL_FABRIC_ROUTER_SYNC_TIMEOUT_MS=30000 (fabric init may be slow)")
     device_params = {"fabric_config": ttnn.FabricConfig.FABRIC_2D}
-    logger.info("Opening mesh device (via bh_2d_mesh_device_context)...")
+    logger.info("Opening mesh device...")
     with bh_2d_mesh_device_context(device_params) as mesh_device:
-        submeshes = mesh_device.create_submeshes(ttnn.MeshShape(*SUBMESH_SHAPE))
-        if len(submeshes) < num_layers:
-            raise RuntimeError(
-                f"Mesh has {len(submeshes)} (4x2) submeshes but num_layers={num_layers}; "
-                f"need at least {num_layers}*8 devices (e.g. 8 for 1 layer, 32 for 4 layers)"
-            )
-        logger.info("Mesh has {} (4x2) submeshes", len(submeshes))
-        yield mesh_device, submeshes
+        logger.info(f"Mesh device opened (id={mesh_device.get_system_mesh_id()}, shape={mesh_device.shape})")
+        yield mesh_device
+
+
+def decoder_layer_id_from_mesh_id(mesh_id: int) -> int:
+    """
+    Layer ID is the index of the layer in the original model (i.e. layer 0-3 are dense layers, layer 4-60 are MoE layers)
+    The mesh ID is the pipeline stage index (0 is embedding, 1-3 are dense layers, 4-61 are MoE, and 62 is LM head + sampling)
+    """
+    assert mesh_id > 0 and mesh_id <= 61, f"Cannot get layer ID from mesh ID: {mesh_id}"
+    return mesh_id - 1
+
+
+SYSTEM_MESH_ID_EMBEDDING = 0
+SYSTEM_MESH_ID_LM_HEAD = 62
 
 
 def load_weights_from_cache(
     cache_path: Path,
     mesh_device: ttnn.MeshDevice,
-    submeshes: list,
-    num_layers: int,
-) -> DeepSeekV3Weights:
+    layer_offset: int,
+) -> DeepSeekV3LayerWeights:
     """Load weights from cache: routed experts in fast-dispatch phase, then all layers on their submesh."""
-    # Phase 1: Fast dispatch -- load routed experts for MoE layers (each on its submesh)
-    preloaded_experts: dict[int, MoERoutedExpertWeights] = {}
-    with ttnn.device.setup_fast_dispatch(mesh_device):
-        for layer_idx in range(FIRST_K_DENSE_REPLACE, num_layers):
-            preloaded_experts[layer_idx] = load_moe_routed_experts_from_cache(
-                cache_path, submeshes[layer_idx], layer_idx
-            )
+    mesh_id = mesh_device.get_system_mesh_id() + layer_offset
+    assert (
+        mesh_id >= SYSTEM_MESH_ID_EMBEDDING and mesh_id <= SYSTEM_MESH_ID_LM_HEAD
+    ), f"Mesh ID must be between {SYSTEM_MESH_ID_EMBEDDING} and {SYSTEM_MESH_ID_LM_HEAD} but got {mesh_id}"
+    if mesh_id == SYSTEM_MESH_ID_EMBEDDING:
+        # TODO: Load embedding weights from the cache
+        logger.info("Loading embedding weights from cache")
+        embedding_shape = (129280, 7168)
+        embedding_tensor = ttnn.from_torch(
+            torch.rand(embedding_shape), dtype=ttnn.bfloat16, layout=ttnn.ROW_MAJOR_LAYOUT
+        )
+        embedding_tensor = ttnn.to_device(embedding_tensor, mesh_device, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+        return DeepSeekV3EmbeddingLayerWeights(embedding=embedding_tensor)
+    elif mesh_id == SYSTEM_MESH_ID_LM_HEAD:
+        logger.info("Loading LM head weights from cache")
+        # TODO: Load LM head weights from the cache
+        lm_head_shape = (129280, 7168)
+        lm_head_tensor = ttnn.from_torch(torch.rand(lm_head_shape), dtype=ttnn.bfloat16, layout=ttnn.ROW_MAJOR_LAYOUT)
+        lm_head_tensor = ttnn.to_device(lm_head_tensor, mesh_device, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+        return DeepSeekV3LMHeadWeights(lm_head=lm_head_tensor)
+    else:
+        # Get the correct layer ID given the mesh ID
+        layer_id = decoder_layer_id_from_mesh_id(mesh_id)
 
-    # Phase 2: Slow dispatch -- load each layer onto its (4, 2) submesh
-    layers = []
-    for layer_idx in range(num_layers):
+        is_moe = layer_id >= FIRST_K_DENSE_REPLACE
+        logger.info(f"Loading {'moe' if is_moe else 'dense'} layer weights from cache")
+
+        preloaded_experts: MoERoutedExpertWeights | None = None
+        if is_moe:
+            # Phase 1: Fast dispatch -- load routed experts for MoE layers (each on its submesh)
+            with ttnn.device.setup_fast_dispatch(mesh_device):
+                preloaded_experts = load_moe_routed_experts_from_cache(cache_path, mesh_device, layer_id)
+
+        # Phase 2: Slow dispatch -- load each layer onto its (4, 2) submesh
         layer = load_layer(
             cache_path,
-            submeshes[layer_idx],
-            layer_idx,
-            preloaded_routed_experts=preloaded_experts.get(layer_idx),
+            mesh_device,
+            layer_id,
+            preloaded_routed_experts=preloaded_experts,
         )
-        layers.append(layer)
-    weights = DeepSeekV3Weights(layers=layers)
-    logger.info("Loaded {} layers from cache (one per submesh)", len(weights.layers))
-    return weights
+        return layer
 
 
 def create_parser() -> argparse.ArgumentParser:
@@ -114,10 +130,10 @@ def create_parser() -> argparse.ArgumentParser:
         help="Path to the weight cache directory (contains layer_NNN/ subdirs)",
     )
     parser.add_argument(
-        "--num-layers",
+        "--layer-id-offset",
         type=int,
-        default=1,
-        help="Number of decoder layers to load from cache",
+        default=0,
+        help="Layer ID offset (default 0)",
     )
     return parser
 
@@ -133,14 +149,14 @@ def run_demo(
     tokenizer_name_or_path: str,
     loopback_mode: bool,
     cache_path: Path,
-    num_layers: int,
+    layer_id_offset: int = 0,
     output_stream: TextIO,
 ) -> GenerationResult:
     logger.info(
-        "Starting DeepSeek V3 B1 demo (max_new_tokens={}, loopback_mode={}, num_layers={})",
+        "Starting DeepSeek V3 B1 demo (max_new_tokens={}, loopback_mode={}, layer_id_offset={})",
         max_new_tokens,
         loopback_mode,
-        num_layers,
+        layer_id_offset,
     )
     if not is_slow_dispatch():
         raise RuntimeError(
@@ -161,9 +177,10 @@ def run_demo(
         output_stream.write(text)
         output_stream.flush()
 
-    with open_mesh_device_with_submeshes(num_layers) as (mesh_device, submeshes):
-        weights = load_weights_from_cache(cache_path, mesh_device, submeshes, num_layers)
-        breakpoint()
+    with open_mesh_device() as mesh_device:
+        weights = load_weights_from_cache(cache_path, mesh_device, layer_id_offset)
+        logger.info("Weights loaded!")
+        return None
 
         logger.info("Creating DeepSeekV3 model")
         model = create_model(mesh_device=mesh_device, batch_size=1, loopback_mode=loopback_mode)
@@ -195,7 +212,7 @@ def main(argv: list[str] | None = None) -> int:
         tokenizer_name_or_path=args.tokenizer,
         loopback_mode=args.loopback_mode,
         cache_path=args.cache_path,
-        num_layers=args.num_layers,
+        layer_id_offset=args.layer_id_offset,
         output_stream=sys.stdout,
     )
     print(file=sys.stdout, flush=True)

--- a/models/demos/deepseek_v3_b1/prepare_weights.py
+++ b/models/demos/deepseek_v3_b1/prepare_weights.py
@@ -9,7 +9,7 @@ Takes full HuggingFace state dict tensors (full logical shapes for the target
 mesh), applies key mapping, transpose, and kv_b split, then passes to
 BlitzDecodeWeights which fuses and shards onto the mesh.
 
-Supports save_weights / load_weights for offline preparation and runtime load.
+Supports per-layer save/load (save_decoder_layer, load_dense_decoder_layer, load_moe_decoder_layer) and embedding/lm_head save/load for offline preparation and runtime load.
 """
 
 from __future__ import annotations
@@ -35,6 +35,11 @@ _DTYPE_TO_STR = {
     ttnn.DataType.BFLOAT16: "BFLOAT16",
 }
 _STR_TO_DTYPE = {v: k for k, v in _DTYPE_TO_STR.items()}
+
+# MoE gate bias: HEIGHT_SHARDED on sender core (10, 9), tile [16, 16]
+_MOE_SENDER_CORE = ttnn.CoreCoord(10, 9)
+_MOE_SENDER_CORE_GRID = ttnn.CoreRangeSet([ttnn.CoreRange(_MOE_SENDER_CORE, _MOE_SENDER_CORE)])
+_GATE_BIAS_TILE = ttnn.Tile([16, 16])
 
 # Fusion group name per field (for grouping by fused_tensor)
 _FIELD_TO_FUSION_GROUP: dict[str, str] = {
@@ -69,6 +74,7 @@ class AttentionWeights:
     ffn_norm: OverlappedTensor
     kv_b1_proj: OverlappedTensor
     kv_b2_proj: OverlappedTensor
+    gate_bias: ttnn.Tensor | None  # e_score_correction_bias for MoE only
 
 
 @dataclass
@@ -152,6 +158,9 @@ class DeepSeekV3MoELayerWeights:
     kv_norm: OverlappedTensor
     ffn_norm: OverlappedTensor
 
+    # MoE gate e_score_correction_bias (standalone)
+    gate_bias: ttnn.Tensor
+
     # From get_tt_kv_b12_proj_weights
     kv_b1_proj: OverlappedTensor
     kv_b2_proj: OverlappedTensor
@@ -176,21 +185,10 @@ class DeepSeekV3EmbeddingLayerWeights:
 
 @dataclass
 class DeepSeekV3LMHeadWeights:
-    """Weights for the LM head."""
+    """Weights for the LM head and final RMSNorm."""
 
     lm_head: ttnn.Tensor
-
-
-DeepSeekV3LayerWeights = (
-    DeepSeekV3DenseLayerWeights | DeepSeekV3MoELayerWeights | DeepSeekV3EmbeddingLayerWeights | DeepSeekV3LMHeadWeights
-)
-
-
-@dataclass
-class DeepSeekV3Weights:
-    """Container for all prepared (fused) layer weights."""
-
-    layers: list[DeepSeekV3LayerWeights]
+    final_norm: ttnn.Tensor  # model.norm.weight, (1, 7168)
 
 
 # Constants for kv_b_proj split (HF stores one matrix; we split into kv_b1 and kv_b2).
@@ -206,6 +204,29 @@ _KV_B_PROJ_HEAD_DIM = _QK_NOPE_HEAD_DIM + _V_HEAD_DIM  # 256
 def _key(layer_idx: int, suffix: str) -> str:
     """State dict key under model.layers.{layer_idx}."""
     return f"model.layers.{layer_idx}.{suffix}"
+
+
+def create_gate_bias_tensor(raw_tensor: torch.Tensor, device) -> ttnn.Tensor:
+    """Build gate_bias (e_score_correction_bias) as HEIGHT_SHARDED on sender core, replicated across mesh.
+
+    raw_tensor: shape (256,) from state dict (model.layers.{i}.mlp.gate.e_score_correction_bias).
+    Returns ttnn.Tensor with layout expected by MoE op: (16, 16) on sender core (10, 9), tile 16x16.
+    """
+    gate_bias_reshaped = raw_tensor.reshape(16, 16).T.contiguous().to(torch.bfloat16)
+    gate_bias_mem_config = ttnn.MemoryConfig(
+        ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+        ttnn.BufferType.L1,
+        ttnn.ShardSpec(_MOE_SENDER_CORE_GRID, (16, 16), ttnn.ShardOrientation.ROW_MAJOR),
+    )
+    return ttnn.from_torch(
+        gate_bias_reshaped,
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        device=None,
+        memory_config=gate_bias_mem_config,
+        tile=_GATE_BIAS_TILE,
+        mesh_mapper=ttnn.ReplicateTensorToMesh(device),
+    )
 
 
 def _split_kv_b_proj(kv_b_proj: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
@@ -257,7 +278,7 @@ def _get_layer_raw_tensors(
         norms         | input_layernorm, q_a_layernorm, etc. | (7168,), …    | unsqueeze(0)| (1, 7168), …
 
     MoE-only (gate_mm, shared_gate_proj, shared_up_proj) are read in
-    prepare_moe_decoder_layer_weights.
+    prepare_moe_layer_weights.
 
     Returns:
         (q_a, q_b, kv_a, kv_b1, kv_b2, o_proj, attn_norm, q_norm, kv_norm, ffn_norm).
@@ -302,6 +323,9 @@ def prepare_attention_weights(
             o_proj, gate_mm, attn_norm, q_norm, kv_norm, ffn_norm, move_to_device=False
         )
         o_proj_ot, gate_mm_ot, attn_norm_ot, q_norm_ot, kv_norm_ot, ffn_norm_ot = o_norms
+        gate_bias_tt = create_gate_bias_tensor(
+            state_dict[_key(layer_idx, "mlp.gate.e_score_correction_bias")], bdw._device
+        )
         logger.debug("  convert o_proj_gate_mm_norms (MoE): {:.3f}s", time.perf_counter() - t0)
         return AttentionWeights(
             q_a_proj=q_a_proj,
@@ -315,6 +339,7 @@ def prepare_attention_weights(
             ffn_norm=ffn_norm_ot,
             kv_b1_proj=kv_b1_proj,
             kv_b2_proj=kv_b2_proj,
+            gate_bias=gate_bias_tt,
         )
     else:
         gate_mm_dummy = torch.zeros(7168, 256, dtype=torch.bfloat16, device=next(iter(state_dict.values())).device)
@@ -335,6 +360,7 @@ def prepare_attention_weights(
             ffn_norm=ffn_norm_ot,
             kv_b1_proj=kv_b1_proj,
             kv_b2_proj=kv_b2_proj,
+            gate_bias=None,
         )
 
 
@@ -425,7 +451,7 @@ def prepare_routed_expert_weights(
         )
 
 
-def prepare_dense_decoder_layer_weights(
+def prepare_dense_layer_weights(
     bdw: BlitzDecodeWeights,
     state_dict: dict[str, torch.Tensor],
     layer_idx: int,
@@ -458,7 +484,7 @@ def prepare_dense_decoder_layer_weights(
     logger.info("  dense layer {} done in {:.3f}s", layer_idx, time.perf_counter() - t0)
 
 
-def prepare_moe_decoder_layer_weights(
+def prepare_moe_layer_weights(
     bdw: BlitzDecodeWeights,
     state_dict: dict[str, torch.Tensor],
     layer_idx: int,
@@ -474,6 +500,7 @@ def prepare_moe_decoder_layer_weights(
         bdw, state_dict, layer_idx, is_moe=True, num_routed_experts=num_routed_experts
     )
     assert isinstance(attn.gate_mm, OverlappedTensor)
+    assert attn.gate_bias is not None
     assert isinstance(routed, MoERoutedExpertWeights)
     return DeepSeekV3MoELayerWeights(
         q_a_proj=attn.q_a_proj,
@@ -485,6 +512,7 @@ def prepare_moe_decoder_layer_weights(
         q_norm=attn.q_norm,
         kv_norm=attn.kv_norm,
         ffn_norm=attn.ffn_norm,
+        gate_bias=attn.gate_bias,
         kv_b1_proj=attn.kv_b1_proj,
         kv_b2_proj=attn.kv_b2_proj,
         shared_gate_proj=shared.shared_gate_proj,
@@ -497,85 +525,176 @@ def prepare_moe_decoder_layer_weights(
     logger.info("  MoE layer {} done in {:.3f}s", layer_idx, time.perf_counter() - t0)
 
 
-def prepare_weights(
+def prepare_embedding_weights(
     state_dict: dict[str, torch.Tensor],
     device,
-    num_layers: int = 61,
-    first_k_dense_replace: int = 3,
-    num_routed_experts: int = NUM_ROUTED_EXPERTS,
-) -> DeepSeekV3Weights:
-    """Build fused weights from a HuggingFace-style state dict.
-
-    State dict should use full logical HF shapes when device is a mesh (e.g. 4x2);
-    internally we shard them across the mesh.
-
-    Args:
-        state_dict: Weights keyed by model.layers.{i}.self_attn.*, model.layers.{i}.mlp.*, etc.
-        device: MeshDevice to place weights on.
-        num_layers: Total number of layers (default 61).
-        first_k_dense_replace: Number of dense layers before MoE (default 3).
-        num_routed_experts: Number of MoE routed experts per layer (default NUM_ROUTED_EXPERTS).
-
-    Returns:
-        DeepSeekV3Weights with one entry per layer; dense vs MoE type by layer index.
-    """
-    logger.info(
-        "Preparing full model weights ({} layers, dense 0..{}, MoE {}..{})...",
-        num_layers,
-        first_k_dense_replace - 1,
-        first_k_dense_replace,
-        num_layers - 1,
+) -> DeepSeekV3EmbeddingLayerWeights:
+    """Prepare embedding weights from state dict (model.embed_tokens.weight)."""
+    logger.info("Preparing embedding weights...")
+    w = state_dict["model.embed_tokens.weight"]
+    assert w.shape == (129280, 7168), f"Expected embedding shape (129280, 7168), got {w.shape}"
+    embedding_tt = ttnn.from_torch(
+        w.contiguous(),
+        dtype=ttnn.bfloat16,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        device=None,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        mesh_mapper=ttnn.ReplicateTensorToMesh(device),
     )
-    total_t0 = time.perf_counter()
-    bdw = BlitzDecodeWeights(device)
-    layers: list[DeepSeekV3LayerWeights] = []
-
-    for i in range(num_layers):
-        is_moe = i >= first_k_dense_replace
-        if is_moe:
-            layers.append(prepare_moe_decoder_layer_weights(bdw, state_dict, i, num_routed_experts=num_routed_experts))
-        else:
-            layers.append(prepare_dense_decoder_layer_weights(bdw, state_dict, i))
-
-    logger.info("All {} layers prepared in {:.3f}s", num_layers, time.perf_counter() - total_t0)
-    return DeepSeekV3Weights(layers=layers)
+    return DeepSeekV3EmbeddingLayerWeights(embedding=embedding_tt)
 
 
-def _deallocate_tt_tensor(t: ttnn.Tensor, seen: set[int]) -> None:
-    """Deallocate a single ttnn.Tensor if not already deallocated (by id)."""
-    fid = id(t)
-    if fid not in seen:
-        seen.add(fid)
-        ttnn.deallocate(t, force=True)
+def save_embedding_weights(
+    weights: DeepSeekV3EmbeddingLayerWeights,
+    path: str | Path,
+    *,
+    hf_model_name: str = "",
+    hf_state_dict_name: str = "",
+    device_mesh_shape: tuple[int, int] = (1, 1),
+) -> None:
+    """Save embedding weights to <path>/embedding/."""
+    path = Path(path)
+    emb_dir = path / "embedding"
+    emb_dir.mkdir(parents=True, exist_ok=True)
+    logger.info("Dump embedding weights...")
+    ttnn.dump_tensor(emb_dir / "embedding.tensorbin", weights.embedding)
+    logger.info("Dump manifest...")
+    manifest = {
+        "version": _MANIFEST_VERSION,
+        "hf_model_name": hf_model_name,
+        "hf_state_dict_name": hf_state_dict_name,
+        "device_mesh_shape": list(device_mesh_shape),
+    }
+    with open(emb_dir / "manifest.json", "w") as f:
+        json.dump(manifest, f, indent=2)
 
 
-def deallocate_weights(weights: DeepSeekV3Weights) -> None:
-    """Release device memory for all fused tensors in prepared weights.
+def load_embedding_weights(path: str | Path, device) -> DeepSeekV3EmbeddingLayerWeights:
+    """Load embedding weights from <path>/embedding/."""
+    path = Path(path)
+    emb_dir = path / "embedding"
+    if not emb_dir.is_dir():
+        raise FileNotFoundError(f"Embedding dir not found: {emb_dir}")
+    embedding = ttnn.load_tensor(emb_dir / "embedding.tensorbin", device=device)
+    return DeepSeekV3EmbeddingLayerWeights(embedding=embedding)
 
-    Call this before loading a new set of weights onto the same device to avoid
-    OOM (the original and loaded weights would otherwise both reside on device).
+
+# LM head: HF keeps full vocab (129280, 7168). Prepare shards vocab (N) across the mesh (TP=mesh size)
+# and uses the same per-device L1 WIDTH_SHARDED layout as test_lm_head_sampling (101 matmul cores).
+
+_LM_HEAD_K = 7168
+_LM_HEAD_VOCAB_SIZE = 129280
+_LM_HEAD_NUM_MATMUL_CORES = 101
+_LM_HEAD_MATMUL_CORE_GRID = ttnn.CoreRangeSet(
+    [
+        ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(9, 9)),
+        ttnn.CoreRange(ttnn.CoreCoord(10, 0), ttnn.CoreCoord(10, 0)),
+    ]
+)
+_LM_HEAD_B_TILE = ttnn.Tile([32, 32])
+_LM_HEAD_A_TILE = ttnn.Tile([1, 32])
+_LM_HEAD_N_PER_CORE = 160
+_LM_HEAD_MCAST_CORE = ttnn.CoreCoord(10, 9)
+_LM_HEAD_MCAST_CORE_GRID = ttnn.CoreRangeSet([ttnn.CoreRange(_LM_HEAD_MCAST_CORE, _LM_HEAD_MCAST_CORE)])
+
+
+def prepare_lm_head_weights(
+    state_dict: dict[str, torch.Tensor],
+    device,
+) -> DeepSeekV3LMHeadWeights:
+    """Prepare LM head and final norm weights from state dict.
+
+    device must be the mesh device (e.g. 4x2 submesh). The LM head weight matrix is sharded
+    along the vocabulary dimension (TP = mesh size). Per-device layout matches the LM head
+    sampling op: WIDTH_SHARDED in L1 across 101 matmul cores with shard shape (7168, N_per_core).
     """
-    seen: set[int] = set()
-    for layer in weights.layers:
-        for _name, ot in _layer_overlapped_tensor_fields(layer):
-            fid = id(ot.fused_tensor)
-            if fid not in seen:
-                seen.add(fid)
-                ttnn.deallocate(ot.fused_tensor, force=True)
-        if hasattr(layer, "shared_down_proj"):
-            _deallocate_tt_tensor(getattr(layer, "shared_down_proj"), seen)
-        if isinstance(layer, DeepSeekV3MoELayerWeights):
-            for t in layer.routed_gate_proj:
-                _deallocate_tt_tensor(t, seen)
-            for t in layer.routed_up_proj:
-                _deallocate_tt_tensor(t, seen)
-            for t in layer.routed_down_proj:
-                _deallocate_tt_tensor(t, seen)
-        else:
-            assert isinstance(layer, DeepSeekV3DenseLayerWeights)
-            _deallocate_tt_tensor(layer.routed_gate_proj, seen)
-            _deallocate_tt_tensor(layer.routed_up_proj, seen)
-            _deallocate_tt_tensor(layer.routed_down_proj, seen)
+    # lm_head.weight: HF (vocab_size, hidden_size) = (129280, 7168) -> (7168, 129280) for matmul
+    lm_w = state_dict["lm_head.weight"]
+    assert lm_w.shape == (
+        _LM_HEAD_VOCAB_SIZE,
+        _LM_HEAD_K,
+    ), f"Expected lm_head shape ({_LM_HEAD_VOCAB_SIZE}, {_LM_HEAD_K}), got {lm_w.shape}"
+
+    lm_head_shard_shape = (_LM_HEAD_K, _LM_HEAD_N_PER_CORE)
+    lm_head_shard_spec = ttnn.ShardSpec(
+        _LM_HEAD_MATMUL_CORE_GRID,
+        lm_head_shard_shape,
+        ttnn.ShardOrientation.ROW_MAJOR,
+    )
+    lm_head_mem_config = ttnn.MemoryConfig(
+        ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+        ttnn.BufferType.L1,
+        lm_head_shard_spec,
+    )
+    mesh_mapper = ttnn.ShardTensorToMesh(device, dim=1)
+    lm_head_tt = ttnn.from_torch(
+        lm_w.T.contiguous(),
+        dtype=ttnn.bfloat8_b,
+        layout=ttnn.TILE_LAYOUT,
+        device=None,
+        memory_config=lm_head_mem_config,
+        mesh_mapper=mesh_mapper,
+        tile=_LM_HEAD_B_TILE,
+    )
+
+    # model.norm.weight: (7168,) -> (1, 7168), HEIGHT_SHARDED on the mcast core
+    norm_w = state_dict["model.norm.weight"]
+    assert norm_w.shape == (7168,), f"Expected final norm shape (7168,), got {norm_w.shape}"
+
+    norm_mem_config = ttnn.MemoryConfig(
+        ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+        ttnn.BufferType.L1,
+        ttnn.ShardSpec(_LM_HEAD_MCAST_CORE_GRID, (1, _LM_HEAD_K), ttnn.ShardOrientation.ROW_MAJOR),
+    )
+    final_norm_tt = ttnn.from_torch(
+        norm_w.unsqueeze(0).contiguous(),
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        tile=_LM_HEAD_A_TILE,
+        device=None,
+        memory_config=norm_mem_config,
+        mesh_mapper=ttnn.ReplicateTensorToMesh(device),
+    )
+    return DeepSeekV3LMHeadWeights(lm_head=lm_head_tt, final_norm=final_norm_tt)
+
+
+def save_lm_head_weights(
+    weights: DeepSeekV3LMHeadWeights,
+    path: str | Path,
+    *,
+    hf_model_name: str = "",
+    hf_state_dict_name: str = "",
+    device_mesh_shape: tuple[int, int] = (1, 1),
+) -> None:
+    """Save LM head and final norm weights to <path>/lm_head/."""
+    path = Path(path)
+    lm_dir = path / "lm_head"
+    lm_dir.mkdir(parents=True, exist_ok=True)
+    ttnn.dump_tensor(lm_dir / "lm_head.tensorbin", weights.lm_head)
+    ttnn.dump_tensor(lm_dir / "final_norm.tensorbin", weights.final_norm)
+    manifest = {
+        "version": _MANIFEST_VERSION,
+        "hf_model_name": hf_model_name,
+        "hf_state_dict_name": hf_state_dict_name,
+        "device_mesh_shape": list(device_mesh_shape),
+    }
+    with open(lm_dir / "manifest.json", "w") as f:
+        json.dump(manifest, f, indent=2)
+
+
+def load_lm_head_weights(path: str | Path, device) -> DeepSeekV3LMHeadWeights:
+    """Load LM head and final norm weights from <path>/lm_head/.
+
+    device must be the mesh device (same shape as used for prepare_lm_head_weights) so the
+    loaded LM head has the same vocab-dim sharding (TP = mesh size).
+    """
+    path = Path(path)
+    lm_dir = path / "lm_head"
+    if not lm_dir.is_dir():
+        raise FileNotFoundError(f"LM head dir not found: {lm_dir}")
+    lm_head = ttnn.load_tensor(lm_dir / "lm_head.tensorbin", device=device)
+    final_norm = ttnn.load_tensor(lm_dir / "final_norm.tensorbin", device=device)
+    return DeepSeekV3LMHeadWeights(lm_head=lm_head, final_norm=final_norm)
 
 
 def _core_range_set_to_list(crs: ttnn.CoreRangeSet) -> list[list[list[int]]]:
@@ -634,7 +753,7 @@ def _overlapped_tensor_from_dict(
 
 
 def _layer_overlapped_tensor_fields(
-    layer: DeepSeekV3LayerWeights,
+    layer: DeepSeekV3DenseLayerWeights | DeepSeekV3MoELayerWeights,
 ) -> list[tuple[str, OverlappedTensor]]:
     """Return (field_name, OverlappedTensor) for every OverlappedTensor field on the layer."""
     out = []
@@ -744,6 +863,9 @@ def save_attention_weights(
         field_tuples.append(("gate_mm", attn.gate_mm))
     new_groups = _dump_overlapped_fusion_groups(layer_dir, field_tuples)
     manifest.setdefault("fusion_groups", {}).update(new_groups)
+    if attn.gate_bias is not None:
+        ttnn.dump_tensor(layer_dir / "gate_bias.tensorbin", attn.gate_bias)
+        manifest.setdefault("standalone_tensors", {})["gate_bias"] = "gate_bias.tensorbin"
     with open(layer_dir / "manifest.json", "w") as f:
         json.dump(manifest, f, indent=2)
     logger.debug("  save_attention_weights: {:.3f}s", time.perf_counter() - t0)
@@ -844,8 +966,8 @@ def save_routed_expert_weights(
         json.dump(manifest, f, indent=2)
 
 
-def save_layer(
-    layer: DeepSeekV3LayerWeights,
+def save_decoder_layer(
+    layer: DeepSeekV3DenseLayerWeights | DeepSeekV3MoELayerWeights,
     path: str | Path,
     layer_idx: int,
     *,
@@ -862,7 +984,7 @@ def save_layer(
     layer_dir = path / f"layer_{layer_idx:03d}"
     logger.info(f"Saving layer {layer_idx} to {layer_dir}...")
     is_moe = isinstance(layer, DeepSeekV3MoELayerWeights)
-    save_layer_t0 = time.perf_counter()
+    save_decoder_layer_t0 = time.perf_counter()
     attn = AttentionWeights(
         q_a_proj=layer.q_a_proj,
         q_b_proj=layer.q_b_proj,
@@ -875,6 +997,7 @@ def save_layer(
         ffn_norm=layer.ffn_norm,
         kv_b1_proj=layer.kv_b1_proj,
         kv_b2_proj=layer.kv_b2_proj,
+        gate_bias=getattr(layer, "gate_bias", None),
     )
     shared = SharedExpertWeights(
         shared_gate_proj=layer.shared_gate_proj,
@@ -920,20 +1043,23 @@ def save_layer(
         hf_state_dict_name=hf_state_dict_name,
         device_mesh_shape=device_mesh_shape,
     )
-    logger.info(f"  save_layer total: {time.perf_counter() - save_layer_t0:.3f}s")
+    logger.info(f"  save_decoder_layer total: {time.perf_counter() - save_decoder_layer_t0:.3f}s")
 
 
-def load_moe_routed_experts_from_cache(
+def load_moe_routed_experts(
     path: str | Path,
     device,
     layer_idx: int,
     *,
     num_experts: int = NUM_ROUTED_EXPERTS,
 ) -> MoERoutedExpertWeights:
-    """Load only the routed expert weights for an MoE layer from cache (fast-dispatch-safe).
+    """Load only the routed expert weights for an MoE layer from cache.
 
-    Reads experts/e_NNN/{gate,up,down}_proj.tensorbin. Use this in fast dispatch mode
-    before loading the rest of the layer in slow dispatch via load_layer(..., preloaded_routed_experts=...).
+    Reads experts/e_NNN/{gate,up,down}_proj.tensorbin. Since setup_fast_dispatch can
+    only be used once per program, call this under setup_fast_dispatch and pass the
+    result to load_moe_decoder_layer(..., preloaded_routed_experts=...). If you do
+    not use fast dispatch, omit preloaded_routed_experts and load_moe_decoder_layer
+    will load experts from disk in the current dispatch mode.
     """
     path = Path(path)
     layer_dir = path / f"layer_{layer_idx:03d}"
@@ -978,17 +1104,95 @@ def load_moe_routed_experts_from_cache(
     )
 
 
-def load_layer(
+def load_dense_decoder_layer(
+    path: str | Path,
+    device,
+    layer_idx: int,
+) -> DeepSeekV3DenseLayerWeights:
+    """Deserialize a dense decoder layer from <path>/layer_{layer_idx:03d}/."""
+    path = Path(path)
+    layer_dir = path / f"layer_{layer_idx:03d}"
+    manifest_path = layer_dir / "manifest.json"
+    if not manifest_path.exists():
+        raise FileNotFoundError(f"Missing manifest: {manifest_path}")
+
+    with open(manifest_path) as f:
+        manifest = json.load(f)
+
+    if manifest.get("version", 0) > _MANIFEST_VERSION:
+        raise ValueError(f"Unsupported manifest version: {manifest.get('version')}")
+
+    if manifest.get("layer_type") != "dense":
+        raise ValueError(f"Layer {layer_idx} is not dense (layer_type={manifest.get('layer_type')})")
+
+    fusion_groups = manifest["fusion_groups"]
+    load_t0 = time.perf_counter()
+    logger.info("Loading layer {} (dense) from disk...", layer_idx)
+
+    q_ab = fusion_groups["q_ab_kv_a"]
+    fused_q = ttnn.load_tensor(layer_dir / q_ab["tensorbin"], device=device)
+    q_a_proj = _overlapped_tensor_from_dict(fused_q, q_ab["fields"]["q_a_proj"])
+    q_b_proj = _overlapped_tensor_from_dict(fused_q, q_ab["fields"]["q_b_proj"])
+    kv_a_proj = _overlapped_tensor_from_dict(fused_q, q_ab["fields"]["kv_a_proj"])
+
+    o_grp = fusion_groups["o_proj_gate_mm_norms"]
+    fused_o = ttnn.load_tensor(layer_dir / o_grp["tensorbin"], device=device)
+    o_proj = _overlapped_tensor_from_dict(fused_o, o_grp["fields"]["o_proj"])
+    attn_norm = _overlapped_tensor_from_dict(fused_o, o_grp["fields"]["attn_norm"])
+    q_norm = _overlapped_tensor_from_dict(fused_o, o_grp["fields"]["q_norm"])
+    kv_norm = _overlapped_tensor_from_dict(fused_o, o_grp["fields"]["kv_norm"])
+    ffn_norm = _overlapped_tensor_from_dict(fused_o, o_grp["fields"]["ffn_norm"])
+
+    kv_grp = fusion_groups["kv_b12"]
+    fused_kv = ttnn.load_tensor(layer_dir / kv_grp["tensorbin"], device=device)
+    kv_b1_proj = _overlapped_tensor_from_dict(fused_kv, kv_grp["fields"]["kv_b1_proj"])
+    kv_b2_proj = _overlapped_tensor_from_dict(fused_kv, kv_grp["fields"]["kv_b2_proj"])
+
+    gu_grp = fusion_groups["gate_up"]
+    fused_gu = ttnn.load_tensor(layer_dir / gu_grp["tensorbin"], device=device)
+    shared_gate_proj = _overlapped_tensor_from_dict(fused_gu, gu_grp["fields"]["shared_gate_proj"])
+    shared_up_proj = _overlapped_tensor_from_dict(fused_gu, gu_grp["fields"]["shared_up_proj"])
+
+    standalone = manifest.get("standalone_tensors", {})
+    shared_down_proj = ttnn.load_tensor(layer_dir / standalone["shared_down_proj"], device=device)
+    routed_gate_proj = ttnn.load_tensor(layer_dir / standalone["routed_gate_proj"], device=device)
+    routed_up_proj = ttnn.load_tensor(layer_dir / standalone["routed_up_proj"], device=device)
+    routed_down_proj = ttnn.load_tensor(layer_dir / standalone["routed_down_proj"], device=device)
+    logger.info("  layer {} loaded in {:.3f}s", layer_idx, time.perf_counter() - load_t0)
+
+    return DeepSeekV3DenseLayerWeights(
+        q_a_proj=q_a_proj,
+        q_b_proj=q_b_proj,
+        kv_a_proj=kv_a_proj,
+        o_proj=o_proj,
+        attn_norm=attn_norm,
+        q_norm=q_norm,
+        kv_norm=kv_norm,
+        ffn_norm=ffn_norm,
+        kv_b1_proj=kv_b1_proj,
+        kv_b2_proj=kv_b2_proj,
+        shared_gate_proj=shared_gate_proj,
+        shared_up_proj=shared_up_proj,
+        shared_down_proj=shared_down_proj,
+        routed_gate_proj=routed_gate_proj,
+        routed_up_proj=routed_up_proj,
+        routed_down_proj=routed_down_proj,
+    )
+
+
+def load_moe_decoder_layer(
     path: str | Path,
     device,
     layer_idx: int,
     *,
     preloaded_routed_experts: MoERoutedExpertWeights | None = None,
-) -> DeepSeekV3LayerWeights:
-    """Deserialize a single layer from <path>/layer_{layer_idx:03d}/.
+) -> DeepSeekV3MoELayerWeights:
+    """Deserialize an MoE decoder layer from <path>/layer_{layer_idx:03d}/.
 
-    For MoE layers, if preloaded_routed_experts is provided, expert tensors are not
-    loaded from disk (use after load_moe_routed_experts_from_cache in fast dispatch).
+    If preloaded_routed_experts is provided (e.g. from load_moe_routed_experts under
+    setup_fast_dispatch, which can only be used once per program), those experts are
+    used. Otherwise routed experts are loaded from disk in the current dispatch mode.
+    Fusion groups and standalone tensors are always loaded in the current dispatch mode.
     """
     path = Path(path)
     layer_dir = path / f"layer_{layer_idx:03d}"
@@ -1002,173 +1206,66 @@ def load_layer(
     if manifest.get("version", 0) > _MANIFEST_VERSION:
         raise ValueError(f"Unsupported manifest version: {manifest.get('version')}")
 
-    layer_type = manifest["layer_type"]
+    if manifest.get("layer_type") != "moe":
+        raise ValueError(f"Layer {layer_idx} is not MoE (layer_type={manifest.get('layer_type')})")
+
     fusion_groups = manifest["fusion_groups"]
     load_t0 = time.perf_counter()
-    logger.info("Loading layer {} ({}) from disk...", layer_idx, layer_type)
+    logger.info("Loading layer {} (moe) from disk...", layer_idx)
 
-    if layer_type == "dense":
-        q_ab = fusion_groups["q_ab_kv_a"]
-        fused_q = ttnn.load_tensor(layer_dir / q_ab["tensorbin"], device=device)
-        q_a_proj = _overlapped_tensor_from_dict(fused_q, q_ab["fields"]["q_a_proj"])
-        q_b_proj = _overlapped_tensor_from_dict(fused_q, q_ab["fields"]["q_b_proj"])
-        kv_a_proj = _overlapped_tensor_from_dict(fused_q, q_ab["fields"]["kv_a_proj"])
+    if preloaded_routed_experts is None:
+        preloaded_routed_experts = load_moe_routed_experts(path, device, layer_idx)
 
-        o_grp = fusion_groups["o_proj_gate_mm_norms"]
-        fused_o = ttnn.load_tensor(layer_dir / o_grp["tensorbin"], device=device)
-        o_proj = _overlapped_tensor_from_dict(fused_o, o_grp["fields"]["o_proj"])
-        attn_norm = _overlapped_tensor_from_dict(fused_o, o_grp["fields"]["attn_norm"])
-        q_norm = _overlapped_tensor_from_dict(fused_o, o_grp["fields"]["q_norm"])
-        kv_norm = _overlapped_tensor_from_dict(fused_o, o_grp["fields"]["kv_norm"])
-        ffn_norm = _overlapped_tensor_from_dict(fused_o, o_grp["fields"]["ffn_norm"])
+    q_ab = fusion_groups["q_ab_kv_a"]
+    fused_q = ttnn.load_tensor(layer_dir / q_ab["tensorbin"], device=device)
+    q_a_proj = _overlapped_tensor_from_dict(fused_q, q_ab["fields"]["q_a_proj"])
+    q_b_proj = _overlapped_tensor_from_dict(fused_q, q_ab["fields"]["q_b_proj"])
+    kv_a_proj = _overlapped_tensor_from_dict(fused_q, q_ab["fields"]["kv_a_proj"])
 
-        kv_grp = fusion_groups["kv_b12"]
-        fused_kv = ttnn.load_tensor(layer_dir / kv_grp["tensorbin"], device=device)
-        kv_b1_proj = _overlapped_tensor_from_dict(fused_kv, kv_grp["fields"]["kv_b1_proj"])
-        kv_b2_proj = _overlapped_tensor_from_dict(fused_kv, kv_grp["fields"]["kv_b2_proj"])
+    o_grp = fusion_groups["o_proj_gate_mm_norms"]
+    fused_o = ttnn.load_tensor(layer_dir / o_grp["tensorbin"], device=device)
+    o_proj = _overlapped_tensor_from_dict(fused_o, o_grp["fields"]["o_proj"])
+    gate_mm = _overlapped_tensor_from_dict(fused_o, o_grp["fields"]["gate_mm"])
+    attn_norm = _overlapped_tensor_from_dict(fused_o, o_grp["fields"]["attn_norm"])
+    q_norm = _overlapped_tensor_from_dict(fused_o, o_grp["fields"]["q_norm"])
+    kv_norm = _overlapped_tensor_from_dict(fused_o, o_grp["fields"]["kv_norm"])
+    ffn_norm = _overlapped_tensor_from_dict(fused_o, o_grp["fields"]["ffn_norm"])
 
-        gu_grp = fusion_groups["gate_up"]
-        fused_gu = ttnn.load_tensor(layer_dir / gu_grp["tensorbin"], device=device)
-        shared_gate_proj = _overlapped_tensor_from_dict(fused_gu, gu_grp["fields"]["shared_gate_proj"])
-        shared_up_proj = _overlapped_tensor_from_dict(fused_gu, gu_grp["fields"]["shared_up_proj"])
+    kv_grp = fusion_groups["kv_b12"]
+    fused_kv = ttnn.load_tensor(layer_dir / kv_grp["tensorbin"], device=device)
+    kv_b1_proj = _overlapped_tensor_from_dict(fused_kv, kv_grp["fields"]["kv_b1_proj"])
+    kv_b2_proj = _overlapped_tensor_from_dict(fused_kv, kv_grp["fields"]["kv_b2_proj"])
 
-        standalone = manifest.get("standalone_tensors", {})
-        shared_down_proj = ttnn.load_tensor(layer_dir / standalone["shared_down_proj"], device=device)
-        routed_gate_proj = ttnn.load_tensor(layer_dir / standalone["routed_gate_proj"], device=device)
-        routed_up_proj = ttnn.load_tensor(layer_dir / standalone["routed_up_proj"], device=device)
-        routed_down_proj = ttnn.load_tensor(layer_dir / standalone["routed_down_proj"], device=device)
-        logger.info("  layer {} loaded in {:.3f}s", layer_idx, time.perf_counter() - load_t0)
+    gu_grp = fusion_groups["gate_up"]
+    fused_gu = ttnn.load_tensor(layer_dir / gu_grp["tensorbin"], device=device)
+    shared_gate_proj = _overlapped_tensor_from_dict(fused_gu, gu_grp["fields"]["shared_gate_proj"])
+    shared_up_proj = _overlapped_tensor_from_dict(fused_gu, gu_grp["fields"]["shared_up_proj"])
 
-        return DeepSeekV3DenseLayerWeights(
-            q_a_proj=q_a_proj,
-            q_b_proj=q_b_proj,
-            kv_a_proj=kv_a_proj,
-            o_proj=o_proj,
-            attn_norm=attn_norm,
-            q_norm=q_norm,
-            kv_norm=kv_norm,
-            ffn_norm=ffn_norm,
-            kv_b1_proj=kv_b1_proj,
-            kv_b2_proj=kv_b2_proj,
-            shared_gate_proj=shared_gate_proj,
-            shared_up_proj=shared_up_proj,
-            shared_down_proj=shared_down_proj,
-            routed_gate_proj=routed_gate_proj,
-            routed_up_proj=routed_up_proj,
-            routed_down_proj=routed_down_proj,
-        )
-    else:
-        q_ab = fusion_groups["q_ab_kv_a"]
-        fused_q = ttnn.load_tensor(layer_dir / q_ab["tensorbin"], device=device)
-        q_a_proj = _overlapped_tensor_from_dict(fused_q, q_ab["fields"]["q_a_proj"])
-        q_b_proj = _overlapped_tensor_from_dict(fused_q, q_ab["fields"]["q_b_proj"])
-        kv_a_proj = _overlapped_tensor_from_dict(fused_q, q_ab["fields"]["kv_a_proj"])
+    standalone = manifest.get("standalone_tensors", {})
+    shared_down_proj = ttnn.load_tensor(layer_dir / standalone["shared_down_proj"], device=device)
+    gate_bias = ttnn.load_tensor(layer_dir / standalone["gate_bias"], device=device)
+    routed_gate_proj = preloaded_routed_experts.routed_gate_proj
+    routed_up_proj = preloaded_routed_experts.routed_up_proj
+    routed_down_proj = preloaded_routed_experts.routed_down_proj
+    logger.info("  layer {} loaded in {:.3f}s", layer_idx, time.perf_counter() - load_t0)
 
-        o_grp = fusion_groups["o_proj_gate_mm_norms"]
-        fused_o = ttnn.load_tensor(layer_dir / o_grp["tensorbin"], device=device)
-        o_proj = _overlapped_tensor_from_dict(fused_o, o_grp["fields"]["o_proj"])
-        gate_mm = _overlapped_tensor_from_dict(fused_o, o_grp["fields"]["gate_mm"])
-        attn_norm = _overlapped_tensor_from_dict(fused_o, o_grp["fields"]["attn_norm"])
-        q_norm = _overlapped_tensor_from_dict(fused_o, o_grp["fields"]["q_norm"])
-        kv_norm = _overlapped_tensor_from_dict(fused_o, o_grp["fields"]["kv_norm"])
-        ffn_norm = _overlapped_tensor_from_dict(fused_o, o_grp["fields"]["ffn_norm"])
-
-        kv_grp = fusion_groups["kv_b12"]
-        fused_kv = ttnn.load_tensor(layer_dir / kv_grp["tensorbin"], device=device)
-        kv_b1_proj = _overlapped_tensor_from_dict(fused_kv, kv_grp["fields"]["kv_b1_proj"])
-        kv_b2_proj = _overlapped_tensor_from_dict(fused_kv, kv_grp["fields"]["kv_b2_proj"])
-
-        gu_grp = fusion_groups["gate_up"]
-        fused_gu = ttnn.load_tensor(layer_dir / gu_grp["tensorbin"], device=device)
-        shared_gate_proj = _overlapped_tensor_from_dict(fused_gu, gu_grp["fields"]["shared_gate_proj"])
-        shared_up_proj = _overlapped_tensor_from_dict(fused_gu, gu_grp["fields"]["shared_up_proj"])
-
-        standalone = manifest.get("standalone_tensors", {})
-        shared_down_proj = ttnn.load_tensor(layer_dir / standalone["shared_down_proj"], device=device)
-        if preloaded_routed_experts is not None:
-            routed_gate_proj = preloaded_routed_experts.routed_gate_proj
-            routed_up_proj = preloaded_routed_experts.routed_up_proj
-            routed_down_proj = preloaded_routed_experts.routed_down_proj
-            logger.info("  layer {} loaded in {:.3f}s", layer_idx, time.perf_counter() - load_t0)
-        else:
-            num_experts = manifest.get("routed_experts", {}).get("num_experts", NUM_ROUTED_EXPERTS)
-            logger.info("  loading {} routed experts from disk (this may be slow)...", num_experts)
-            experts_t0 = time.perf_counter()
-            experts_dir = layer_dir / "experts"
-            routed_gate_proj = []
-            routed_up_proj = []
-            routed_down_proj = []
-            for e in range(num_experts):
-                if e > 0 and e % 64 == 0:
-                    logger.debug("  loaded experts 0..{}", e - 1)
-                expert_dir = experts_dir / f"e_{e:03d}"
-                routed_gate_proj.append(ttnn.load_tensor(expert_dir / "gate_proj.tensorbin", device=device))
-                routed_up_proj.append(ttnn.load_tensor(expert_dir / "up_proj.tensorbin", device=device))
-                routed_down_proj.append(ttnn.load_tensor(expert_dir / "down_proj.tensorbin", device=device))
-            logger.info(
-                "  layer {} loaded in {:.3f}s (routed experts: {:.3f}s)",
-                layer_idx,
-                time.perf_counter() - load_t0,
-                time.perf_counter() - experts_t0,
-            )
-
-        return DeepSeekV3MoELayerWeights(
-            q_a_proj=q_a_proj,
-            q_b_proj=q_b_proj,
-            kv_a_proj=kv_a_proj,
-            o_proj=o_proj,
-            gate_mm=gate_mm,
-            attn_norm=attn_norm,
-            q_norm=q_norm,
-            kv_norm=kv_norm,
-            ffn_norm=ffn_norm,
-            kv_b1_proj=kv_b1_proj,
-            kv_b2_proj=kv_b2_proj,
-            shared_gate_proj=shared_gate_proj,
-            shared_up_proj=shared_up_proj,
-            shared_down_proj=shared_down_proj,
-            routed_gate_proj=routed_gate_proj,
-            routed_up_proj=routed_up_proj,
-            routed_down_proj=routed_down_proj,
-        )
-
-
-def save_weights(
-    weights: DeepSeekV3Weights,
-    path: str | Path,
-    *,
-    hf_model_name: str,
-    hf_state_dict_name: str,
-    device_mesh_shape: tuple[int, int] = (1, 1),
-) -> None:
-    """Serialize all layers to disk. Convenience wrapper around save_layer."""
-    path = Path(path)
-    num_layers = len(weights.layers)
-    logger.info("Saving all {} layers to {}...", num_layers, path)
-    total_t0 = time.perf_counter()
-    for layer_idx, layer in enumerate(weights.layers):
-        save_layer(
-            layer,
-            path,
-            layer_idx,
-            hf_model_name=hf_model_name,
-            hf_state_dict_name=hf_state_dict_name,
-            device_mesh_shape=device_mesh_shape,
-        )
-    logger.info("All {} layers saved in {:.3f}s", num_layers, time.perf_counter() - total_t0)
-
-
-def load_weights(
-    path: str | Path,
-    device,
-    num_layers: int = 61,
-) -> DeepSeekV3Weights:
-    """Deserialize layers from disk. Convenience wrapper: load_layer for each index."""
-    path = Path(path)
-    if not path.is_dir():
-        raise FileNotFoundError(f"Weights path is not a directory: {path}")
-    logger.info("Loading all {} layers from {}...", num_layers, path)
-    total_t0 = time.perf_counter()
-    layers = [load_layer(path, device, i) for i in range(num_layers)]
-    logger.info("All {} layers loaded in {:.3f}s", num_layers, time.perf_counter() - total_t0)
-    return DeepSeekV3Weights(layers=layers)
+    return DeepSeekV3MoELayerWeights(
+        q_a_proj=q_a_proj,
+        q_b_proj=q_b_proj,
+        kv_a_proj=kv_a_proj,
+        o_proj=o_proj,
+        gate_mm=gate_mm,
+        attn_norm=attn_norm,
+        q_norm=q_norm,
+        kv_norm=kv_norm,
+        ffn_norm=ffn_norm,
+        gate_bias=gate_bias,
+        kv_b1_proj=kv_b1_proj,
+        kv_b2_proj=kv_b2_proj,
+        shared_gate_proj=shared_gate_proj,
+        shared_up_proj=shared_up_proj,
+        shared_down_proj=shared_down_proj,
+        routed_gate_proj=routed_gate_proj,
+        routed_up_proj=routed_up_proj,
+        routed_down_proj=routed_down_proj,
+    )

--- a/models/demos/deepseek_v3_b1/prepare_weights.py
+++ b/models/demos/deepseek_v3_b1/prepare_weights.py
@@ -907,12 +907,73 @@ def save_layer(
     logger.info(f"  save_layer total: {time.perf_counter() - save_layer_t0:.3f}s")
 
 
+def load_moe_routed_experts_from_cache(
+    path: str | Path,
+    device,
+    layer_idx: int,
+    *,
+    num_experts: int = NUM_ROUTED_EXPERTS,
+) -> MoERoutedExpertWeights:
+    """Load only the routed expert weights for an MoE layer from cache (fast-dispatch-safe).
+
+    Reads experts/e_NNN/{gate,up,down}_proj.tensorbin. Use this in fast dispatch mode
+    before loading the rest of the layer in slow dispatch via load_layer(..., preloaded_routed_experts=...).
+    """
+    path = Path(path)
+    layer_dir = path / f"layer_{layer_idx:03d}"
+    manifest_path = layer_dir / "manifest.json"
+    if not manifest_path.exists():
+        raise FileNotFoundError(f"Missing manifest: {manifest_path}")
+    with open(manifest_path) as f:
+        manifest = json.load(f)
+    if manifest.get("layer_type") != "moe":
+        raise ValueError(f"Layer {layer_idx} is not MoE (layer_type={manifest.get('layer_type')})")
+    num_experts = manifest.get("routed_experts", {}).get("num_experts", num_experts)
+    experts_dir = layer_dir / "experts"
+    logger.info("Loading {} routed experts for layer {} from cache...", num_experts, layer_idx)
+    t0 = time.perf_counter()
+    routed_gate_proj = []
+    routed_up_proj = []
+    routed_down_proj = []
+    for e in range(num_experts):
+        if e > 0 and e % 64 == 0:
+            logger.debug("  loaded experts 0..{}", e - 1)
+        expert_dir = experts_dir / f"e_{e:03d}"
+        t_load_gate_t0 = time.perf_counter()
+        routed_gate_proj.append(ttnn.load_tensor(expert_dir / "gate_proj.tensorbin", device=device))
+        t_load_gate = time.perf_counter() - t_load_gate_t0
+
+        t_load_up_t0 = time.perf_counter()
+        routed_up_proj.append(ttnn.load_tensor(expert_dir / "up_proj.tensorbin", device=device))
+        t_load_up = time.perf_counter() - t_load_up_t0
+
+        t_load_down_t0 = time.perf_counter()
+        routed_down_proj.append(ttnn.load_tensor(expert_dir / "down_proj.tensorbin", device=device))
+        t_load_down = time.perf_counter() - t_load_down_t0
+
+        logger.debug(
+            f"    Loaded expert {e}: gate_proj.tensorbin in {t_load_gate:.3f}s, up_proj.tensorbin in {t_load_up:.3f}s, down_proj.tensorbin in {t_load_down:.3f}s"
+        )
+    logger.info("  routed experts for layer {} loaded in {:.3f}s", layer_idx, time.perf_counter() - t0)
+    return MoERoutedExpertWeights(
+        routed_gate_proj=routed_gate_proj,
+        routed_up_proj=routed_up_proj,
+        routed_down_proj=routed_down_proj,
+    )
+
+
 def load_layer(
     path: str | Path,
     device,
     layer_idx: int,
+    *,
+    preloaded_routed_experts: MoERoutedExpertWeights | None = None,
 ) -> DeepSeekV3LayerWeights:
-    """Deserialize a single layer from <path>/layer_{layer_idx:03d}/."""
+    """Deserialize a single layer from <path>/layer_{layer_idx:03d}/.
+
+    For MoE layers, if preloaded_routed_experts is provided, expert tensors are not
+    loaded from disk (use after load_moe_routed_experts_from_cache in fast dispatch).
+    """
     path = Path(path)
     layer_dir = path / f"layer_{layer_idx:03d}"
     manifest_path = layer_dir / "manifest.json"
@@ -1008,26 +1069,32 @@ def load_layer(
 
         standalone = manifest.get("standalone_tensors", {})
         shared_down_proj = ttnn.load_tensor(layer_dir / standalone["shared_down_proj"], device=device)
-        num_experts = manifest.get("routed_experts", {}).get("num_experts", NUM_ROUTED_EXPERTS)
-        logger.info("  loading {} routed experts from disk (this may be slow)...", num_experts)
-        experts_t0 = time.perf_counter()
-        experts_dir = layer_dir / "experts"
-        routed_gate_proj = []
-        routed_up_proj = []
-        routed_down_proj = []
-        for e in range(num_experts):
-            if e > 0 and e % 64 == 0:
-                logger.debug("  loaded experts 0..{}", e - 1)
-            expert_dir = experts_dir / f"e_{e:03d}"
-            routed_gate_proj.append(ttnn.load_tensor(expert_dir / "gate_proj.tensorbin", device=device))
-            routed_up_proj.append(ttnn.load_tensor(expert_dir / "up_proj.tensorbin", device=device))
-            routed_down_proj.append(ttnn.load_tensor(expert_dir / "down_proj.tensorbin", device=device))
-        logger.info(
-            "  layer {} loaded in {:.3f}s (routed experts: {:.3f}s)",
-            layer_idx,
-            time.perf_counter() - load_t0,
-            time.perf_counter() - experts_t0,
-        )
+        if preloaded_routed_experts is not None:
+            routed_gate_proj = preloaded_routed_experts.routed_gate_proj
+            routed_up_proj = preloaded_routed_experts.routed_up_proj
+            routed_down_proj = preloaded_routed_experts.routed_down_proj
+            logger.info("  layer {} loaded in {:.3f}s", layer_idx, time.perf_counter() - load_t0)
+        else:
+            num_experts = manifest.get("routed_experts", {}).get("num_experts", NUM_ROUTED_EXPERTS)
+            logger.info("  loading {} routed experts from disk (this may be slow)...", num_experts)
+            experts_t0 = time.perf_counter()
+            experts_dir = layer_dir / "experts"
+            routed_gate_proj = []
+            routed_up_proj = []
+            routed_down_proj = []
+            for e in range(num_experts):
+                if e > 0 and e % 64 == 0:
+                    logger.debug("  loaded experts 0..{}", e - 1)
+                expert_dir = experts_dir / f"e_{e:03d}"
+                routed_gate_proj.append(ttnn.load_tensor(expert_dir / "gate_proj.tensorbin", device=device))
+                routed_up_proj.append(ttnn.load_tensor(expert_dir / "up_proj.tensorbin", device=device))
+                routed_down_proj.append(ttnn.load_tensor(expert_dir / "down_proj.tensorbin", device=device))
+            logger.info(
+                "  layer {} loaded in {:.3f}s (routed experts: {:.3f}s)",
+                layer_idx,
+                time.perf_counter() - load_t0,
+                time.perf_counter() - experts_t0,
+            )
 
         return DeepSeekV3MoELayerWeights(
             q_a_proj=q_a_proj,

--- a/models/demos/deepseek_v3_b1/prepare_weights.py
+++ b/models/demos/deepseek_v3_b1/prepare_weights.py
@@ -167,7 +167,23 @@ class DeepSeekV3MoELayerWeights:
     routed_down_proj: list[ttnn.Tensor]
 
 
-DeepSeekV3LayerWeights = DeepSeekV3DenseLayerWeights | DeepSeekV3MoELayerWeights
+@dataclass
+class DeepSeekV3EmbeddingLayerWeights:
+    """Weights for the embedding layer."""
+
+    embedding: ttnn.Tensor
+
+
+@dataclass
+class DeepSeekV3LMHeadWeights:
+    """Weights for the LM head."""
+
+    lm_head: ttnn.Tensor
+
+
+DeepSeekV3LayerWeights = (
+    DeepSeekV3DenseLayerWeights | DeepSeekV3MoELayerWeights | DeepSeekV3EmbeddingLayerWeights | DeepSeekV3LMHeadWeights
+)
 
 
 @dataclass

--- a/models/demos/deepseek_v3_b1/prepare_weights.py
+++ b/models/demos/deepseek_v3_b1/prepare_weights.py
@@ -370,6 +370,7 @@ def prepare_shared_expert_weights(
     layer_idx: int,
     *,
     is_moe: bool,
+    move_to_device: bool = False,
 ) -> SharedExpertWeights:
     """Prepare shared expert weights (gate_up fusion group + shared_down_proj) for one layer."""
     logger.debug("Converting shared expert weights for layer {} (is_moe={})", layer_idx, is_moe)
@@ -379,14 +380,14 @@ def prepare_shared_expert_weights(
         shared_up = state_dict[_key(layer_idx, "mlp.shared_experts.up_proj.weight")].T.contiguous()
         shared_down = state_dict[_key(layer_idx, "mlp.shared_experts.down_proj.weight")].T.contiguous()
         shared_gate_proj, shared_up_proj, shared_down_proj = bdw.get_tt_moe_shared_expert_weights(
-            shared_gate, shared_up, shared_down, move_to_device=False
+            shared_gate, shared_up, shared_down, move_to_device=move_to_device
         )
     else:
         mlp_gate = state_dict[_key(layer_idx, "mlp.gate_proj.weight")].T.contiguous()
         mlp_up = state_dict[_key(layer_idx, "mlp.up_proj.weight")].T.contiguous()
         mlp_down = state_dict[_key(layer_idx, "mlp.down_proj.weight")].T.contiguous()
         shared_gate_proj, shared_up_proj, shared_down_proj = bdw.get_tt_mlp_shared_expert_weights(
-            mlp_gate, mlp_up, mlp_down, move_to_device=False
+            mlp_gate, mlp_up, mlp_down, move_to_device=move_to_device
         )
     logger.debug("  shared expert weights done in {:.3f}s", time.perf_counter() - t0)
     return SharedExpertWeights(

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/conftest.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/conftest.py
@@ -1,0 +1,89 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Fixtures for deepseek_v3_b1 unit tests (e.g. real HuggingFace weights)."""
+
+import os
+from pathlib import Path
+from typing import Literal, NamedTuple
+
+import pytest
+import torch
+
+import ttnn
+from models.demos.deepseek_v3.utils.lazy_state_dict import LazyStateDict
+from models.demos.deepseek_v3_b1.blitz_decode_weights import BlitzDecodeWeights
+from models.demos.deepseek_v3_b1.prepare_weights import SharedExpertWeights, prepare_shared_expert_weights
+
+
+def _state_dict_key(layer_idx: int, suffix: str) -> str:
+    """State dict key under model.layers.{layer_idx}."""
+    return f"model.layers.{layer_idx}.{suffix}"
+
+
+class SharedExpertWeightBundle(NamedTuple):
+    """Bundle of prepared shared-expert weights on device and raw torch tensors for golden."""
+
+    weights: SharedExpertWeights
+    torch_gate: torch.Tensor
+    torch_up: torch.Tensor
+    torch_down: torch.Tensor
+
+
+@pytest.fixture(scope="session")
+def get_model_decoder_weight(hf_state_dict):
+    """Return a callable to load model decoder weights onto a mesh device by layer and weight name.
+
+    Weights are always prepared and moved to the given mesh_device.
+
+    Usage:
+        get = get_model_decoder_weight
+        bundle = get(layer_idx=3, weight_name="shared_expert", mesh_device=submesh)
+
+    Supported weight_name: "shared_expert".
+    """
+    state_dict = hf_state_dict
+
+    def get(
+        layer_idx: int,
+        weight_name: Literal["shared_expert"],
+        mesh_device: ttnn.MeshDevice,
+    ):
+        if weight_name == "shared_expert":
+            torch_gate = state_dict[_state_dict_key(layer_idx, "mlp.shared_experts.gate_proj.weight")].T.contiguous()
+            torch_up = state_dict[_state_dict_key(layer_idx, "mlp.shared_experts.up_proj.weight")].T.contiguous()
+            torch_down = state_dict[_state_dict_key(layer_idx, "mlp.shared_experts.down_proj.weight")].T.contiguous()
+            bdw = BlitzDecodeWeights(mesh_device)
+            weights = prepare_shared_expert_weights(bdw, state_dict, layer_idx, is_moe=True, move_to_device=True)
+            return SharedExpertWeightBundle(
+                weights=weights,
+                torch_gate=torch_gate,
+                torch_up=torch_up,
+                torch_down=torch_down,
+            )
+        raise ValueError(f"Unknown weight_name: {weight_name!r}")
+
+    return get
+
+
+@pytest.fixture(scope="session")
+def hf_model_path():
+    """Path to HuggingFace model directory (model.safetensors.index.json).
+
+    Skips when DEEPSEEK_V3_HF_MODEL is not set or when the index file is missing.
+    """
+    raw = os.getenv("DEEPSEEK_V3_HF_MODEL")
+    if not raw or not raw.strip():
+        pytest.skip("DEEPSEEK_V3_HF_MODEL is not set; skip real-weights tests")
+    path = Path(raw.strip()).resolve()
+    index_path = path / "model.safetensors.index.json"
+    if not index_path.is_file():
+        pytest.skip(f"model.safetensors.index.json not found at {index_path}")
+    return path
+
+
+@pytest.fixture(scope="session")
+def hf_state_dict(hf_model_path):
+    """Session-scoped LazyStateDict over the HuggingFace model for real-weights tests."""
+    return LazyStateDict(hf_model_path)

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_demo.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_demo.py
@@ -6,7 +6,19 @@ from __future__ import annotations
 
 import pytest
 
+import ttnn
+from models.common.utility_functions import is_slow_dispatch
+from models.demos.deepseek_v3_b1.demo.cli import FIRST_K_DENSE_REPLACE, enable_fast_dispatch_mode
 from models.demos.deepseek_v3_b1.demo.runner import run_generation
+from models.demos.deepseek_v3_b1.prepare_weights import (
+    DeepSeekV3DenseLayerWeights,
+    DeepSeekV3Weights,
+    deallocate_weights,
+    load_layer,
+    load_moe_routed_experts_from_cache,
+    prepare_weights,
+    save_layer,
+)
 
 
 class FakeTokenizer:
@@ -174,3 +186,70 @@ def test_demo_decode_stress_64k_tokens(mesh_device) -> None:
     assert result.generated_token_ids[0] == tokenizer.bos_token_id
     assert result.generated_token_ids[-1] == tokenizer.bos_token_id
     assert model.position == 1 + max_new_tokens
+
+
+@pytest.mark.parametrize(
+    "device_params",
+    [{"fabric_config": ttnn.FabricConfig.FABRIC_2D}],
+    indirect=True,
+)
+def test_demo_weight_loading_from_cache_4x2(bh_2d_mesh_device, tmp_path):
+    """Test the demo's two-phase weight loading: create a one-layer dense cache, then run the same load path as run_demo and assert weights are loaded."""
+    from models.demos.deepseek_v3_b1.tests.unit_tests.test_prepare_weights import (
+        _layer_state_dict,
+        _skip_unless_4x2_mesh,
+    )
+
+    _skip_unless_4x2_mesh(bh_2d_mesh_device)
+    if not is_slow_dispatch():
+        pytest.skip("Demo weight loading requires slow dispatch")
+
+    # Same as CLI: full mesh split into (4, 2) submeshes; layer i goes on submeshes[i]
+    submeshes = bh_2d_mesh_device.create_submeshes(ttnn.MeshShape(4, 2))
+    assert len(submeshes) >= 1, "Need at least one (4,2) submesh"
+    submesh0 = submeshes[0]
+    cache_path = tmp_path
+
+    # Create minimal cache: one dense layer on submesh 0 (same pattern as test_prepare_weights)
+    state = _layer_state_dict(0, is_moe=False)
+    weights = prepare_weights(
+        state,
+        submesh0,
+        num_layers=1,
+        first_k_dense_replace=1,
+    )
+    save_layer(
+        weights.layers[0],
+        cache_path,
+        0,
+        hf_model_name="test-demo-weight-load",
+        hf_state_dict_name="test.safetensors",
+        device_mesh_shape=(4, 2),
+    )
+    deallocate_weights(weights)
+
+    # Run the same two-phase loading logic as run_demo() (each layer on its submesh)
+    num_layers = 1
+    preloaded_experts = {}
+    with enable_fast_dispatch_mode(bh_2d_mesh_device):
+        for layer_idx in range(FIRST_K_DENSE_REPLACE, num_layers):
+            preloaded_experts[layer_idx] = load_moe_routed_experts_from_cache(
+                cache_path, submeshes[layer_idx], layer_idx
+            )
+
+    layers = []
+    for layer_idx in range(num_layers):
+        layer = load_layer(
+            cache_path,
+            submeshes[layer_idx],
+            layer_idx,
+            preloaded_routed_experts=preloaded_experts.get(layer_idx),
+        )
+        layers.append(layer)
+    loaded_weights = DeepSeekV3Weights(layers=layers)
+
+    assert len(loaded_weights.layers) == 1
+    assert isinstance(loaded_weights.layers[0], DeepSeekV3DenseLayerWeights)
+    layer0 = loaded_weights.layers[0]
+    assert layer0.q_a_proj.tensor_shape == (3584, 3072)
+    assert layer0.o_proj.tensor_shape == (8192, 7168)

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_demo.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_demo.py
@@ -8,16 +8,33 @@ import pytest
 
 import ttnn
 from models.common.utility_functions import is_slow_dispatch
-from models.demos.deepseek_v3_b1.demo.cli import FIRST_K_DENSE_REPLACE, enable_fast_dispatch_mode
+from models.demos.deepseek_v3_b1.blitz_decode_weights import BlitzDecodeWeights
+from models.demos.deepseek_v3_b1.demo.cli import (
+    FIRST_K_DENSE_REPLACE,
+    SYSTEM_MESH_ID_EMBEDDING,
+    SYSTEM_MESH_ID_LM_HEAD,
+    load_weights_from_cache,
+)
 from models.demos.deepseek_v3_b1.demo.runner import run_generation
 from models.demos.deepseek_v3_b1.prepare_weights import (
     DeepSeekV3DenseLayerWeights,
-    DeepSeekV3Weights,
-    deallocate_weights,
-    load_layer,
-    load_moe_routed_experts_from_cache,
-    prepare_weights,
-    save_layer,
+    DeepSeekV3EmbeddingLayerWeights,
+    DeepSeekV3LMHeadWeights,
+    DeepSeekV3MoELayerWeights,
+    prepare_dense_layer_weights,
+    prepare_embedding_weights,
+    prepare_lm_head_weights,
+    prepare_moe_layer_weights,
+    save_decoder_layer,
+    save_embedding_weights,
+    save_lm_head_weights,
+)
+from models.demos.deepseek_v3_b1.tests.unit_tests.test_prepare_weights import (
+    NUM_ROUTED_EXPERTS,
+    _add_global_weights,
+    _deallocate_layer,
+    _layer_state_dict,
+    _skip_unless_4x2_mesh,
 )
 
 
@@ -144,6 +161,71 @@ def test_run_generation_rejects_negative_max_new_tokens():
     assert not model.stopped
 
 
+@pytest.mark.parametrize(
+    "device_params",
+    [{"fabric_config": ttnn.FabricConfig.FABRIC_2D}],
+    indirect=True,
+)
+@pytest.mark.parametrize(
+    "layer_offset",
+    [
+        SYSTEM_MESH_ID_EMBEDDING,
+        FIRST_K_DENSE_REPLACE - 1,
+        FIRST_K_DENSE_REPLACE,
+        SYSTEM_MESH_ID_LM_HEAD,
+    ],
+)
+def test_load_weights_from_cache(bh_2d_mesh_device, tmp_path, layer_offset):
+    """Load weights from cache for embedding, last dense, first MoE, and LM head (4x2 submesh)."""
+    _skip_unless_4x2_mesh(bh_2d_mesh_device)
+    if not is_slow_dispatch():
+        pytest.skip("load_weights_from_cache requires slow dispatch")
+    submesh = bh_2d_mesh_device.create_submesh(ttnn.MeshShape((4, 2)))
+    manifest_kw = dict(
+        hf_model_name="test-demo-load",
+        hf_state_dict_name="test.safetensors",
+        device_mesh_shape=(4, 2),
+    )
+
+    if layer_offset == SYSTEM_MESH_ID_EMBEDDING or layer_offset == SYSTEM_MESH_ID_LM_HEAD:
+        state = {}
+        _add_global_weights(state)
+        embedding_weights = prepare_embedding_weights(state, submesh)
+        lm_head_weights = prepare_lm_head_weights(state, submesh)
+        save_embedding_weights(embedding_weights, tmp_path, **manifest_kw)
+        save_lm_head_weights(lm_head_weights, tmp_path, **manifest_kw)
+        ttnn.deallocate(embedding_weights.embedding, force=True)
+        ttnn.deallocate(lm_head_weights.lm_head, force=True)
+        ttnn.deallocate(lm_head_weights.final_norm, force=True)
+    elif layer_offset == FIRST_K_DENSE_REPLACE - 1:
+        state = _layer_state_dict(0, is_moe=False)
+        bdw = BlitzDecodeWeights(submesh)
+        layer = prepare_dense_layer_weights(bdw, state, 0)
+        save_decoder_layer(layer, tmp_path, 1, **manifest_kw)
+        _deallocate_layer(layer)
+    elif layer_offset == FIRST_K_DENSE_REPLACE:
+        state = _layer_state_dict(0, is_moe=True, seed=43)
+        bdw = BlitzDecodeWeights(submesh)
+        layer = prepare_moe_layer_weights(bdw, state, 0, num_routed_experts=NUM_ROUTED_EXPERTS)
+        save_decoder_layer(layer, tmp_path, 2, **manifest_kw)
+        _deallocate_layer(layer)
+
+    result = load_weights_from_cache(tmp_path, submesh, layer_offset)
+
+    if layer_offset == SYSTEM_MESH_ID_EMBEDDING:
+        assert isinstance(result, DeepSeekV3EmbeddingLayerWeights)
+        assert result.embedding is not None
+    elif layer_offset == SYSTEM_MESH_ID_LM_HEAD:
+        assert isinstance(result, DeepSeekV3LMHeadWeights)
+        assert result.lm_head is not None
+        assert result.final_norm is not None
+    elif layer_offset == FIRST_K_DENSE_REPLACE - 1:
+        assert isinstance(result, DeepSeekV3DenseLayerWeights)
+    else:
+        assert layer_offset == FIRST_K_DENSE_REPLACE
+        assert isinstance(result, DeepSeekV3MoELayerWeights)
+
+
 class _LoopbackTokenizer:
     bos_token_id = 1
 
@@ -186,70 +268,3 @@ def test_demo_decode_stress_64k_tokens(mesh_device) -> None:
     assert result.generated_token_ids[0] == tokenizer.bos_token_id
     assert result.generated_token_ids[-1] == tokenizer.bos_token_id
     assert model.position == 1 + max_new_tokens
-
-
-@pytest.mark.parametrize(
-    "device_params",
-    [{"fabric_config": ttnn.FabricConfig.FABRIC_2D}],
-    indirect=True,
-)
-def test_demo_weight_loading_from_cache_4x2(bh_2d_mesh_device, tmp_path):
-    """Test the demo's two-phase weight loading: create a one-layer dense cache, then run the same load path as run_demo and assert weights are loaded."""
-    from models.demos.deepseek_v3_b1.tests.unit_tests.test_prepare_weights import (
-        _layer_state_dict,
-        _skip_unless_4x2_mesh,
-    )
-
-    _skip_unless_4x2_mesh(bh_2d_mesh_device)
-    if not is_slow_dispatch():
-        pytest.skip("Demo weight loading requires slow dispatch")
-
-    # Same as CLI: full mesh split into (4, 2) submeshes; layer i goes on submeshes[i]
-    submeshes = bh_2d_mesh_device.create_submeshes(ttnn.MeshShape(4, 2))
-    assert len(submeshes) >= 1, "Need at least one (4,2) submesh"
-    submesh0 = submeshes[0]
-    cache_path = tmp_path
-
-    # Create minimal cache: one dense layer on submesh 0 (same pattern as test_prepare_weights)
-    state = _layer_state_dict(0, is_moe=False)
-    weights = prepare_weights(
-        state,
-        submesh0,
-        num_layers=1,
-        first_k_dense_replace=1,
-    )
-    save_layer(
-        weights.layers[0],
-        cache_path,
-        0,
-        hf_model_name="test-demo-weight-load",
-        hf_state_dict_name="test.safetensors",
-        device_mesh_shape=(4, 2),
-    )
-    deallocate_weights(weights)
-
-    # Run the same two-phase loading logic as run_demo() (each layer on its submesh)
-    num_layers = 1
-    preloaded_experts = {}
-    with enable_fast_dispatch_mode(bh_2d_mesh_device):
-        for layer_idx in range(FIRST_K_DENSE_REPLACE, num_layers):
-            preloaded_experts[layer_idx] = load_moe_routed_experts_from_cache(
-                cache_path, submeshes[layer_idx], layer_idx
-            )
-
-    layers = []
-    for layer_idx in range(num_layers):
-        layer = load_layer(
-            cache_path,
-            submeshes[layer_idx],
-            layer_idx,
-            preloaded_routed_experts=preloaded_experts.get(layer_idx),
-        )
-        layers.append(layer)
-    loaded_weights = DeepSeekV3Weights(layers=layers)
-
-    assert len(loaded_weights.layers) == 1
-    assert isinstance(loaded_weights.layers[0], DeepSeekV3DenseLayerWeights)
-    layer0 = loaded_weights.layers[0]
-    assert layer0.q_a_proj.tensor_shape == (3584, 3072)
-    assert layer0.o_proj.tensor_shape == (8192, 7168)

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_pre_sdpa.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_pre_sdpa.py
@@ -55,6 +55,7 @@ def create_fabric_router_config(max_payload_size):
     indirect=True,
 )
 @pytest.mark.parametrize("noc_mode", [ttnn.NOC_MODE.DM_DYNAMIC_NOC])
+@pytest.mark.requires_grid_size((13, 10))
 def test_pre_sdpa(
     bh_2d_mesh_device,
     mesh_rows,

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_prepare_weights.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_prepare_weights.py
@@ -31,6 +31,7 @@ from models.demos.deepseek_v3_b1.prepare_weights import (
     SharedExpertWeights,
     deallocate_weights,
     load_layer,
+    load_moe_routed_experts_from_cache,
     prepare_attention_weights,
     prepare_routed_expert_weights,
     prepare_shared_expert_weights,
@@ -797,6 +798,70 @@ def test_save_load_moe_layer_single_layer_4x2(bh_2d_mesh_device, tmp_path):
         assert layer.routed_down_proj[e].shape == orig.routed_down_proj[e].shape
 
     assert id(layer.shared_gate_proj.fused_tensor) == id(layer.shared_up_proj.fused_tensor)
+    _assert_layer_on_device_with_topology(layer)
+
+
+@pytest.mark.parametrize(
+    "device_params",
+    [{"fabric_config": ttnn.FabricConfig.FABRIC_2D}],
+    indirect=True,
+)
+def test_load_layer_with_preloaded_routed_experts_4x2(bh_2d_mesh_device, tmp_path):
+    """Prepare+save an MoE layer, load routed experts via load_moe_routed_experts_from_cache, then load_layer(..., preloaded_routed_experts=...) and verify the assembled layer matches."""
+    _skip_unless_4x2_mesh(bh_2d_mesh_device)
+    if not is_slow_dispatch():
+        pytest.skip("load_layer requires slow dispatch")
+    submesh = bh_2d_mesh_device.create_submesh(ttnn.MeshShape((4, 2)))
+
+    state = _layer_state_dict(0, is_moe=True, seed=43)
+    weights = prepare_weights(
+        state,
+        submesh,
+        num_layers=1,
+        first_k_dense_replace=0,
+        num_routed_experts=NUM_ROUTED_EXPERTS,
+    )
+    orig = weights.layers[0]
+    assert isinstance(orig, DeepSeekV3MoELayerWeights)
+    save_layer(
+        orig,
+        tmp_path,
+        0,
+        hf_model_name="test-moe-model-4x2",
+        hf_state_dict_name="test-moe-state-dict.safetensors",
+        device_mesh_shape=(4, 2),
+    )
+    deallocate_weights(weights)
+
+    preloaded = load_moe_routed_experts_from_cache(tmp_path, submesh, 0)
+    assert len(preloaded.routed_gate_proj) == NUM_ROUTED_EXPERTS
+    assert len(preloaded.routed_up_proj) == NUM_ROUTED_EXPERTS
+    assert len(preloaded.routed_down_proj) == NUM_ROUTED_EXPERTS
+
+    layer = load_layer(
+        tmp_path, submesh, 0, preloaded_routed_experts=preloaded
+    )  # This requires slow dispatch, so test must run in this mode
+    assert isinstance(layer, DeepSeekV3MoELayerWeights)
+    # Expected shapes (same as test_prepare_moe_layer_single_layer_4x2)
+    assert layer.q_a_proj.tensor_shape == (3584, 3072)
+    assert layer.q_b_proj.tensor_shape == (1536, 12288)
+    assert layer.kv_a_proj.tensor_shape == (7168, 576)
+    assert layer.o_proj.tensor_shape == (8192, 7168)
+    assert layer.gate_mm.tensor_shape == (7168, 256)
+    assert layer.attn_norm.tensor_shape == (1, 7168)
+    assert layer.shared_gate_proj.tensor_shape == (7168, 256)
+    assert layer.shared_up_proj.tensor_shape == (7168, 256)
+    assert len(layer.routed_gate_proj) == NUM_ROUTED_EXPERTS
+    assert len(layer.routed_up_proj) == NUM_ROUTED_EXPERTS
+    assert len(layer.routed_down_proj) == NUM_ROUTED_EXPERTS
+    # Routed experts came from preloaded (same count and on device)
+    for e in range(NUM_ROUTED_EXPERTS):
+        assert layer.routed_gate_proj[e].shape == preloaded.routed_gate_proj[e].shape
+        assert layer.routed_up_proj[e].shape == preloaded.routed_up_proj[e].shape
+        assert layer.routed_down_proj[e].shape == preloaded.routed_down_proj[e].shape
+        _assert_on_device(layer.routed_gate_proj[e])
+        _assert_on_device(layer.routed_up_proj[e])
+        _assert_on_device(layer.routed_down_proj[e])
     _assert_layer_on_device_with_topology(layer)
 
 

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_prepare_weights.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_prepare_weights.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 """
-Tests for prepare_weights: building DeepSeekV3Weights from a state dict (4x2 mesh only).
+Tests for prepare_weights: per-layer prepare/save/load on 4x2 mesh.
 
 - test_prepare_dense_layer_single_layer_4x2 / test_prepare_moe_layer_single_layer_4x2: one layer on 4x2 mesh.
 - test_save_load_dense_layer_single_layer_4x2 / test_save_load_moe_layer_single_layer_4x2: save then load one layer on 4x2 submesh.
@@ -25,22 +25,68 @@ from models.demos.deepseek_v3_b1.blitz_decode_weights import BlitzDecodeWeights,
 from models.demos.deepseek_v3_b1.prepare_weights import (
     AttentionWeights,
     DeepSeekV3DenseLayerWeights,
+    DeepSeekV3EmbeddingLayerWeights,
+    DeepSeekV3LMHeadWeights,
     DeepSeekV3MoELayerWeights,
     DenseRoutedExpertWeights,
     MoERoutedExpertWeights,
     SharedExpertWeights,
-    deallocate_weights,
-    load_layer,
-    load_moe_routed_experts_from_cache,
+    load_dense_decoder_layer,
+    load_embedding_weights,
+    load_lm_head_weights,
+    load_moe_decoder_layer,
     prepare_attention_weights,
+    prepare_dense_layer_weights,
+    prepare_embedding_weights,
+    prepare_lm_head_weights,
+    prepare_moe_layer_weights,
     prepare_routed_expert_weights,
     prepare_shared_expert_weights,
-    prepare_weights,
     save_attention_weights,
-    save_layer,
+    save_decoder_layer,
+    save_embedding_weights,
+    save_lm_head_weights,
     save_routed_expert_weights,
     save_shared_expert_weights,
 )
+
+
+def _deallocate_layer(layer: DeepSeekV3DenseLayerWeights | DeepSeekV3MoELayerWeights) -> None:
+    """Deallocate all tensors in a single decoder layer (for tests that save then load)."""
+    seen: set[int] = set()
+    for f in (
+        "q_a_proj",
+        "q_b_proj",
+        "kv_a_proj",
+        "o_proj",
+        "attn_norm",
+        "q_norm",
+        "kv_norm",
+        "ffn_norm",
+        "kv_b1_proj",
+        "kv_b2_proj",
+        "shared_gate_proj",
+        "shared_up_proj",
+    ):
+        ot = getattr(layer, f, None)
+        if ot is not None and hasattr(ot, "fused_tensor"):
+            fid = id(ot.fused_tensor)
+            if fid not in seen:
+                seen.add(fid)
+                ttnn.deallocate(ot.fused_tensor, force=True)
+    ttnn.deallocate(layer.shared_down_proj, force=True)
+    if isinstance(layer, DeepSeekV3MoELayerWeights):
+        ttnn.deallocate(layer.gate_bias, force=True)
+        for t in layer.routed_gate_proj:
+            ttnn.deallocate(t, force=True)
+        for t in layer.routed_up_proj:
+            ttnn.deallocate(t, force=True)
+        for t in layer.routed_down_proj:
+            ttnn.deallocate(t, force=True)
+    else:
+        ttnn.deallocate(layer.routed_gate_proj, force=True)
+        ttnn.deallocate(layer.routed_up_proj, force=True)
+        ttnn.deallocate(layer.routed_down_proj, force=True)
 
 
 def _core_range_set_to_tuples(crs):
@@ -129,6 +175,7 @@ def _assert_layer_on_device_with_topology(
         _assert_topology(layer.routed_down_proj, _PLACEMENTS_SHARD_0_1)
     else:
         assert isinstance(layer, DeepSeekV3MoELayerWeights)
+        _assert_topology(layer.gate_bias, _PLACEMENTS_REPLICATE)
         for e in range(len(layer.routed_gate_proj)):
             _assert_on_device(layer.routed_gate_proj[e])
             _assert_on_device(layer.routed_up_proj[e])
@@ -189,6 +236,9 @@ def _layer_state_dict(
     }
     if is_moe:
         state[f"model.layers.{layer_idx}.mlp.gate.weight"] = torch.randn(256, 7168, generator=g, dtype=torch.bfloat16)
+        state[f"model.layers.{layer_idx}.mlp.gate.e_score_correction_bias"] = torch.randn(
+            256, generator=g, dtype=torch.bfloat16
+        )
         state[f"model.layers.{layer_idx}.mlp.shared_experts.gate_proj.weight"] = torch.randn(
             *shared_hf, generator=g, dtype=torch.bfloat16
         )
@@ -223,6 +273,14 @@ def _layer_state_dict(
             7168, 18432, generator=g, dtype=torch.bfloat16
         )
     return state
+
+
+def _add_global_weights(state: dict[str, torch.Tensor], seed: int = 42) -> None:
+    """Add embedding, final norm, and lm_head to state (in place)."""
+    g = torch.Generator().manual_seed(seed)
+    state["model.embed_tokens.weight"] = torch.randn(129280, 7168, generator=g, dtype=torch.bfloat16)
+    state["model.norm.weight"] = torch.randn(7168, generator=g, dtype=torch.bfloat16)
+    state["lm_head.weight"] = torch.randn(129280, 7168, generator=g, dtype=torch.bfloat16)
 
 
 @pytest.mark.parametrize(
@@ -261,6 +319,8 @@ def test_prepare_attention_weights_moe_4x2(bh_2d_mesh_device):
     attn = prepare_attention_weights(bdw, state, 0, is_moe=True)
     assert attn.gate_mm is not None
     assert attn.gate_mm.tensor_shape == (7168, 256)
+    assert attn.gate_bias is not None
+    assert attn.gate_bias.shape == (16, 16)
     assert attn.q_a_proj.tensor_shape == (3584, 3072)
     assert attn.o_proj.tensor_shape == (8192, 7168)
 
@@ -341,14 +401,14 @@ def test_prepare_routed_expert_weights_moe_4x2(bh_2d_mesh_device):
     indirect=True,
 )
 def test_incremental_save_load_dense_4x2(bh_2d_mesh_device, tmp_path):
-    """Save dense layer on 4x2 via separate save_attention_weights, save_shared_expert_weights, save_routed_expert_weights; load_layer and verify."""
+    """Save dense layer on 4x2 via separate save_attention_weights, save_shared_expert_weights, save_routed_expert_weights; load_dense_decoder_layer and verify."""
     _skip_unless_4x2_mesh(bh_2d_mesh_device)
     if not is_slow_dispatch():
-        pytest.skip("load_layer requires slow dispatch")
+        pytest.skip("load_dense_decoder_layer requires slow dispatch")
     submesh = bh_2d_mesh_device.create_submesh(ttnn.MeshShape((4, 2)))
     state = _layer_state_dict(0, is_moe=False)
-    weights = prepare_weights(state, submesh, num_layers=1, first_k_dense_replace=1)
-    layer = weights.layers[0]
+    bdw = BlitzDecodeWeights(submesh)
+    layer = prepare_dense_layer_weights(bdw, state, 0)
     assert isinstance(layer, DeepSeekV3DenseLayerWeights)
     attn = AttentionWeights(
         q_a_proj=layer.q_a_proj,
@@ -362,6 +422,7 @@ def test_incremental_save_load_dense_4x2(bh_2d_mesh_device, tmp_path):
         ffn_norm=layer.ffn_norm,
         kv_b1_proj=layer.kv_b1_proj,
         kv_b2_proj=layer.kv_b2_proj,
+        gate_bias=None,
     )
     shared = SharedExpertWeights(
         shared_gate_proj=layer.shared_gate_proj,
@@ -382,8 +443,8 @@ def test_incremental_save_load_dense_4x2(bh_2d_mesh_device, tmp_path):
     save_shared_expert_weights(shared, tmp_path, 0, is_moe=False, **manifest_kw)
     save_routed_expert_weights(routed, tmp_path, 0, is_moe=False, **manifest_kw)
     expected_routed_shape = layer.routed_gate_proj.shape
-    deallocate_weights(weights)
-    loaded = load_layer(tmp_path, submesh, 0)
+    _deallocate_layer(layer)
+    loaded = load_dense_decoder_layer(tmp_path, submesh, 0)
     assert isinstance(loaded, DeepSeekV3DenseLayerWeights)
     _assert_overlapped_tensors_match(layer.q_a_proj, loaded.q_a_proj)
     _assert_overlapped_tensors_match(layer.shared_gate_proj, loaded.shared_gate_proj)
@@ -397,20 +458,14 @@ def test_incremental_save_load_dense_4x2(bh_2d_mesh_device, tmp_path):
     indirect=True,
 )
 def test_incremental_save_load_moe_4x2(bh_2d_mesh_device, tmp_path):
-    """Save MoE layer on 4x2 via separate save_attention_weights, save_shared_expert_weights, save_routed_expert_weights; load_layer and verify."""
+    """Save MoE layer on 4x2 via separate save_attention_weights, save_shared_expert_weights, save_routed_expert_weights; load_moe_decoder_layer and verify."""
     _skip_unless_4x2_mesh(bh_2d_mesh_device)
     if not is_slow_dispatch():
-        pytest.skip("load_layer requires slow dispatch")
+        pytest.skip("load_moe_decoder_layer requires slow dispatch")
     submesh = bh_2d_mesh_device.create_submesh(ttnn.MeshShape((4, 2)))
     state = _layer_state_dict(0, is_moe=True, seed=43)
-    weights = prepare_weights(
-        state,
-        submesh,
-        num_layers=1,
-        first_k_dense_replace=0,
-        num_routed_experts=NUM_ROUTED_EXPERTS,
-    )
-    layer = weights.layers[0]
+    bdw = BlitzDecodeWeights(submesh)
+    layer = prepare_moe_layer_weights(bdw, state, 0, num_routed_experts=NUM_ROUTED_EXPERTS)
     assert isinstance(layer, DeepSeekV3MoELayerWeights)
     attn = AttentionWeights(
         q_a_proj=layer.q_a_proj,
@@ -424,6 +479,7 @@ def test_incremental_save_load_moe_4x2(bh_2d_mesh_device, tmp_path):
         ffn_norm=layer.ffn_norm,
         kv_b1_proj=layer.kv_b1_proj,
         kv_b2_proj=layer.kv_b2_proj,
+        gate_bias=layer.gate_bias,
     )
     shared = SharedExpertWeights(
         shared_gate_proj=layer.shared_gate_proj,
@@ -444,10 +500,11 @@ def test_incremental_save_load_moe_4x2(bh_2d_mesh_device, tmp_path):
     save_shared_expert_weights(shared, tmp_path, 0, is_moe=True, **manifest_kw)
     save_routed_expert_weights(routed, tmp_path, 0, is_moe=True, **manifest_kw)
     expected_routed_expert_shape = layer.routed_gate_proj[0].shape
-    deallocate_weights(weights)
-    loaded = load_layer(tmp_path, submesh, 0)
+    _deallocate_layer(layer)
+    loaded = load_moe_decoder_layer(tmp_path, submesh, 0)
     assert isinstance(loaded, DeepSeekV3MoELayerWeights)
     _assert_overlapped_tensors_match(layer.gate_mm, loaded.gate_mm)
+    assert loaded.gate_bias.shape == layer.gate_bias.shape
     _assert_overlapped_tensors_match(layer.shared_gate_proj, loaded.shared_gate_proj)
     assert len(loaded.routed_gate_proj) == NUM_ROUTED_EXPERTS
     assert loaded.routed_gate_proj[0].shape == expected_routed_expert_shape
@@ -474,6 +531,7 @@ def test_dump_load_routed_expert_weights_4x2(bh_2d_mesh_device, tmp_path):
     _skip_unless_4x2_mesh(bh_2d_mesh_device)
     submesh = bh_2d_mesh_device.create_submesh(ttnn.MeshShape((4, 2)))
 
+    logger.info("Testing dump/load round-trip for MoE routed expert weights on 4x2 mesh...")
     gate_stacked, up_stacked, down_stacked = _moe_routed_expert_stacked_tensors(seed=43)
     bdw = BlitzDecodeWeights(submesh)
     routed_gate_proj, routed_up_proj, routed_down_proj = bdw.get_tt_moe_routed_expert_weights(
@@ -490,6 +548,7 @@ def test_dump_load_routed_expert_weights_4x2(bh_2d_mesh_device, tmp_path):
     experts_dir = layer_dir / "experts"
     experts_dir.mkdir(parents=True, exist_ok=True)
     for e in range(NUM_ROUTED_EXPERTS):
+        logger.info("Dumping expert {}...", e)
         expert_dir = experts_dir / f"e_{e:03d}"
         expert_dir.mkdir(parents=True, exist_ok=True)
         ttnn.dump_tensor(expert_dir / "gate_proj.tensorbin", routed_gate_proj[e])
@@ -505,6 +564,7 @@ def test_dump_load_routed_expert_weights_4x2(bh_2d_mesh_device, tmp_path):
     t0 = time.perf_counter()
     for e in range(NUM_ROUTED_EXPERTS):
         expert_dir = experts_dir / f"e_{e:03d}"
+        logger.info("Loading expert {}...", e)
         routed_gate_proj.append(ttnn.load_tensor(expert_dir / "gate_proj.tensorbin", device=submesh))
         routed_up_proj.append(ttnn.load_tensor(expert_dir / "up_proj.tensorbin", device=submesh))
         routed_down_proj.append(ttnn.load_tensor(expert_dir / "down_proj.tensorbin", device=submesh))
@@ -536,17 +596,11 @@ def test_prepare_dense_layer_single_layer_4x2(bh_2d_mesh_device):
     _skip_unless_4x2_mesh(bh_2d_mesh_device)
     submesh = bh_2d_mesh_device.create_submesh(ttnn.MeshShape((4, 2)))
     state = _layer_state_dict(0, is_moe=False)
+    bdw = BlitzDecodeWeights(submesh)
     t0 = time.perf_counter()
-    weights = prepare_weights(
-        state,
-        submesh,
-        num_layers=1,
-        first_k_dense_replace=1,
-    )
+    layer = prepare_dense_layer_weights(bdw, state, 0)
     elapsed = time.perf_counter() - t0
-    logger.info("prepare_weights (1 dense layer, 4x2 mesh): {:.3f} s", elapsed)
-    assert len(weights.layers) == 1
-    layer = weights.layers[0]
+    logger.info("prepare_dense_layer_weights (1 dense layer, 4x2 mesh): {:.3f} s", elapsed)
     assert isinstance(layer, DeepSeekV3DenseLayerWeights)
     assert layer.q_a_proj.tensor_shape == (3584, 3072)
     assert layer.q_b_proj.tensor_shape == (1536, 12288)
@@ -574,16 +628,15 @@ def test_save_load_dense_layer_single_layer_4x2(bh_2d_mesh_device, tmp_path):
     """Save one dense layer (4x2 submesh) to disk, load it back, assert metadata and fused-tensor sharing."""
     _skip_unless_4x2_mesh(bh_2d_mesh_device)
     if not is_slow_dispatch():
-        pytest.skip("load_layer requires slow dispatch")
+        pytest.skip("load_dense_decoder_layer requires slow dispatch")
     submesh = bh_2d_mesh_device.create_submesh(ttnn.MeshShape((4, 2)))
 
     state = _layer_state_dict(0, is_moe=False)
+    bdw = BlitzDecodeWeights(submesh)
     t0 = time.perf_counter()
-    weights = prepare_weights(state, submesh, num_layers=1, first_k_dense_replace=1)
+    orig = prepare_dense_layer_weights(bdw, state, 0)
     elapsed = time.perf_counter() - t0
-    logger.info("prepare_weights (1 dense layer, 4x2 mesh): {:.3f} s", elapsed)
-    assert len(weights.layers) == 1
-    orig = weights.layers[0]
+    logger.info("prepare_dense_layer_weights (1 dense layer, 4x2 mesh): {:.3f} s", elapsed)
     assert isinstance(orig, DeepSeekV3DenseLayerWeights)
     assert orig.q_a_proj.tensor_shape == (3584, 3072)
     assert orig.q_b_proj.tensor_shape == (1536, 12288)
@@ -605,7 +658,7 @@ def test_save_load_dense_layer_single_layer_4x2(bh_2d_mesh_device, tmp_path):
     q_ab_kv_a_fused = orig.q_a_proj.fused_tensor
     _ = q_ab_kv_a_fused.shape
     logger.info("Early access: got shape {}", q_ab_kv_a_fused.shape)
-    save_layer(
+    save_decoder_layer(
         orig,
         tmp_path,
         0,
@@ -624,11 +677,11 @@ def test_save_load_dense_layer_single_layer_4x2(bh_2d_mesh_device, tmp_path):
     assert (layer_dir / "routed_up_proj.tensorbin").exists()
     assert (layer_dir / "routed_down_proj.tensorbin").exists()
 
-    deallocate_weights(weights)
+    _deallocate_layer(orig)
     t0 = time.perf_counter()
-    layer = load_layer(tmp_path, submesh, 0)
+    layer = load_dense_decoder_layer(tmp_path, submesh, 0)
     elapsed = time.perf_counter() - t0
-    logger.info("load_layer (dense, 4x2 submesh): {:.3f} s", elapsed)
+    logger.info("load_dense_decoder_layer (dense, 4x2 submesh): {:.3f} s", elapsed)
     assert isinstance(layer, DeepSeekV3DenseLayerWeights)
 
     _assert_overlapped_tensors_match(orig.q_a_proj, layer.q_a_proj)
@@ -665,27 +718,21 @@ def test_prepare_moe_layer_single_layer_4x2(bh_2d_mesh_device):
     _skip_unless_4x2_mesh(bh_2d_mesh_device)
     submesh = bh_2d_mesh_device.create_submesh(ttnn.MeshShape((4, 2)))
     state = _layer_state_dict(0, is_moe=True, seed=43)
+    bdw = BlitzDecodeWeights(submesh)
     logger.info(f"State dict prepared")
     t0 = time.perf_counter()
     logger.info(f"Preparing weights...")
-    weights = prepare_weights(
-        state,
-        submesh,
-        num_layers=1,
-        first_k_dense_replace=0,
-        num_routed_experts=NUM_ROUTED_EXPERTS,
-    )
+    layer = prepare_moe_layer_weights(bdw, state, 0, num_routed_experts=NUM_ROUTED_EXPERTS)
     logger.info(f"Weights prepared")
     elapsed = time.perf_counter() - t0
-    logger.info("prepare_weights (1 MoE layer, 4x2 mesh): {:.3f} s", elapsed)
-    assert len(weights.layers) == 1
-    layer = weights.layers[0]
+    logger.info("prepare_moe_layer_weights (1 MoE layer, 4x2 mesh): {:.3f} s", elapsed)
     assert isinstance(layer, DeepSeekV3MoELayerWeights)
     assert layer.q_a_proj.tensor_shape == (3584, 3072)
     assert layer.q_b_proj.tensor_shape == (1536, 12288)
     assert layer.kv_a_proj.tensor_shape == (7168, 576)
     assert layer.o_proj.tensor_shape == (8192, 7168)
     assert layer.gate_mm.tensor_shape == (7168, 256)
+    assert layer.gate_bias.shape == (16, 16)
     assert layer.attn_norm.tensor_shape == (1, 7168)
     assert layer.q_norm.tensor_shape == (1, 1536)
     assert layer.kv_norm.tensor_shape == (1, 512)
@@ -709,28 +756,22 @@ def test_save_load_moe_layer_single_layer_4x2(bh_2d_mesh_device, tmp_path):
     """Save one MoE layer (4x2 submesh) to disk, load it back, assert metadata and fused-tensor sharing."""
     _skip_unless_4x2_mesh(bh_2d_mesh_device)
     if not is_slow_dispatch():
-        pytest.skip("load_layer requires slow dispatch")
+        pytest.skip("load_moe_decoder_layer requires slow dispatch")
     submesh = bh_2d_mesh_device.create_submesh(ttnn.MeshShape((4, 2)))
 
     state = _layer_state_dict(0, is_moe=True, seed=43)
+    bdw = BlitzDecodeWeights(submesh)
     t0 = time.perf_counter()
-    weights = prepare_weights(
-        state,
-        submesh,
-        num_layers=1,
-        first_k_dense_replace=0,
-        num_routed_experts=NUM_ROUTED_EXPERTS,
-    )
+    orig = prepare_moe_layer_weights(bdw, state, 0, num_routed_experts=NUM_ROUTED_EXPERTS)
     elapsed = time.perf_counter() - t0
-    logger.info("prepare_weights (1 MoE layer, 4x2 mesh): {:.3f} s", elapsed)
-    assert len(weights.layers) == 1
-    orig = weights.layers[0]
+    logger.info("prepare_moe_layer_weights (1 MoE layer, 4x2 mesh): {:.3f} s", elapsed)
     assert isinstance(orig, DeepSeekV3MoELayerWeights)
     assert orig.q_a_proj.tensor_shape == (3584, 3072)
     assert orig.q_b_proj.tensor_shape == (1536, 12288)
     assert orig.kv_a_proj.tensor_shape == (7168, 576)
     assert orig.o_proj.tensor_shape == (8192, 7168)
     assert orig.gate_mm.tensor_shape == (7168, 256)
+    assert orig.gate_bias.shape == (16, 16)
     assert orig.attn_norm.tensor_shape == (1, 7168)
     assert orig.q_norm.tensor_shape == (1, 1536)
     assert orig.kv_norm.tensor_shape == (1, 512)
@@ -748,7 +789,7 @@ def test_save_load_moe_layer_single_layer_4x2(bh_2d_mesh_device, tmp_path):
     q_ab_kv_a_fused = orig.q_a_proj.fused_tensor
     _ = q_ab_kv_a_fused.shape
     logger.info("Early access: got shape {}", q_ab_kv_a_fused.shape)
-    save_layer(
+    save_decoder_layer(
         orig,
         tmp_path,
         0,
@@ -760,6 +801,7 @@ def test_save_load_moe_layer_single_layer_4x2(bh_2d_mesh_device, tmp_path):
     assert (tmp_path / "layer_000" / "manifest.json").exists()
     layer_dir = tmp_path / "layer_000"
     assert (layer_dir / "gate_up.tensorbin").exists()
+    assert (layer_dir / "gate_bias.tensorbin").exists()
     assert (layer_dir / "shared_down_proj.tensorbin").exists()
     experts_dir = layer_dir / "experts"
     for e in range(NUM_ROUTED_EXPERTS):
@@ -768,11 +810,11 @@ def test_save_load_moe_layer_single_layer_4x2(bh_2d_mesh_device, tmp_path):
         assert (expert_dir / "up_proj.tensorbin").exists()
         assert (expert_dir / "down_proj.tensorbin").exists()
 
-    deallocate_weights(weights)
+    _deallocate_layer(orig)
     t0 = time.perf_counter()
-    layer = load_layer(tmp_path, submesh, 0)
+    layer = load_moe_decoder_layer(tmp_path, submesh, 0)
     elapsed = time.perf_counter() - t0
-    logger.info("load_layer (moe, 4x2 submesh): {:.3f} s", elapsed)
+    logger.info("load_moe_decoder_layer (moe, 4x2 submesh): {:.3f} s", elapsed)
     assert isinstance(layer, DeepSeekV3MoELayerWeights)
 
     _assert_overlapped_tensors_match(orig.q_a_proj, layer.q_a_proj)
@@ -780,6 +822,7 @@ def test_save_load_moe_layer_single_layer_4x2(bh_2d_mesh_device, tmp_path):
     _assert_overlapped_tensors_match(orig.kv_a_proj, layer.kv_a_proj)
     _assert_overlapped_tensors_match(orig.o_proj, layer.o_proj)
     _assert_overlapped_tensors_match(orig.gate_mm, layer.gate_mm)
+    assert layer.gate_bias.shape == orig.gate_bias.shape
     _assert_overlapped_tensors_match(orig.attn_norm, layer.attn_norm)
     _assert_overlapped_tensors_match(orig.q_norm, layer.q_norm)
     _assert_overlapped_tensors_match(orig.kv_norm, layer.kv_norm)
@@ -806,24 +849,18 @@ def test_save_load_moe_layer_single_layer_4x2(bh_2d_mesh_device, tmp_path):
     [{"fabric_config": ttnn.FabricConfig.FABRIC_2D}],
     indirect=True,
 )
-def test_load_layer_with_preloaded_routed_experts_4x2(bh_2d_mesh_device, tmp_path):
-    """Prepare+save an MoE layer, load routed experts via load_moe_routed_experts_from_cache, then load_layer(..., preloaded_routed_experts=...) and verify the assembled layer matches."""
+def test_load_moe_decoder_layer_4x2(bh_2d_mesh_device, tmp_path):
+    """Prepare+save an MoE layer, then load via load_moe_decoder_layer (fast-dispatch for experts is internal) and verify."""
     _skip_unless_4x2_mesh(bh_2d_mesh_device)
     if not is_slow_dispatch():
-        pytest.skip("load_layer requires slow dispatch")
+        pytest.skip("load_moe_decoder_layer requires slow dispatch")
     submesh = bh_2d_mesh_device.create_submesh(ttnn.MeshShape((4, 2)))
 
     state = _layer_state_dict(0, is_moe=True, seed=43)
-    weights = prepare_weights(
-        state,
-        submesh,
-        num_layers=1,
-        first_k_dense_replace=0,
-        num_routed_experts=NUM_ROUTED_EXPERTS,
-    )
-    orig = weights.layers[0]
+    bdw = BlitzDecodeWeights(submesh)
+    orig = prepare_moe_layer_weights(bdw, state, 0, num_routed_experts=NUM_ROUTED_EXPERTS)
     assert isinstance(orig, DeepSeekV3MoELayerWeights)
-    save_layer(
+    save_decoder_layer(
         orig,
         tmp_path,
         0,
@@ -831,38 +868,114 @@ def test_load_layer_with_preloaded_routed_experts_4x2(bh_2d_mesh_device, tmp_pat
         hf_state_dict_name="test-moe-state-dict.safetensors",
         device_mesh_shape=(4, 2),
     )
-    deallocate_weights(weights)
+    _deallocate_layer(orig)
 
-    preloaded = load_moe_routed_experts_from_cache(tmp_path, submesh, 0)
-    assert len(preloaded.routed_gate_proj) == NUM_ROUTED_EXPERTS
-    assert len(preloaded.routed_up_proj) == NUM_ROUTED_EXPERTS
-    assert len(preloaded.routed_down_proj) == NUM_ROUTED_EXPERTS
-
-    layer = load_layer(
-        tmp_path, submesh, 0, preloaded_routed_experts=preloaded
-    )  # This requires slow dispatch, so test must run in this mode
+    layer = load_moe_decoder_layer(tmp_path, submesh, 0)
     assert isinstance(layer, DeepSeekV3MoELayerWeights)
-    # Expected shapes (same as test_prepare_moe_layer_single_layer_4x2)
     assert layer.q_a_proj.tensor_shape == (3584, 3072)
     assert layer.q_b_proj.tensor_shape == (1536, 12288)
     assert layer.kv_a_proj.tensor_shape == (7168, 576)
     assert layer.o_proj.tensor_shape == (8192, 7168)
     assert layer.gate_mm.tensor_shape == (7168, 256)
+    assert layer.gate_bias.shape == (16, 16)
     assert layer.attn_norm.tensor_shape == (1, 7168)
     assert layer.shared_gate_proj.tensor_shape == (7168, 256)
     assert layer.shared_up_proj.tensor_shape == (7168, 256)
     assert len(layer.routed_gate_proj) == NUM_ROUTED_EXPERTS
     assert len(layer.routed_up_proj) == NUM_ROUTED_EXPERTS
     assert len(layer.routed_down_proj) == NUM_ROUTED_EXPERTS
-    # Routed experts came from preloaded (same count and on device)
     for e in range(NUM_ROUTED_EXPERTS):
-        assert layer.routed_gate_proj[e].shape == preloaded.routed_gate_proj[e].shape
-        assert layer.routed_up_proj[e].shape == preloaded.routed_up_proj[e].shape
-        assert layer.routed_down_proj[e].shape == preloaded.routed_down_proj[e].shape
         _assert_on_device(layer.routed_gate_proj[e])
         _assert_on_device(layer.routed_up_proj[e])
         _assert_on_device(layer.routed_down_proj[e])
     _assert_layer_on_device_with_topology(layer)
+
+
+@pytest.mark.parametrize(
+    "device_params",
+    [{"fabric_config": ttnn.FabricConfig.FABRIC_2D}],
+    indirect=True,
+)
+def test_prepare_embedding_weights_4x2(bh_2d_mesh_device):
+    """Prepare embedding weights on 4x2 mesh; verify shape. Tensors stay on host until load_embedding_weights."""
+    _skip_unless_4x2_mesh(bh_2d_mesh_device)
+    submesh = bh_2d_mesh_device.create_submesh(ttnn.MeshShape((4, 2)))
+    state = {}
+    _add_global_weights(state)
+    weights = prepare_embedding_weights(state, submesh)
+    assert isinstance(weights, DeepSeekV3EmbeddingLayerWeights)
+    assert weights.embedding.shape is not None
+    assert weights.embedding.shape == (
+        129280,
+        7168,
+    ), f"Expected embedding shape (129280, 7168), got {weights.embedding.shape}"
+
+
+@pytest.mark.parametrize(
+    "device_params",
+    [{"fabric_config": ttnn.FabricConfig.FABRIC_2D}],
+    indirect=True,
+)
+def test_prepare_lm_head_weights_4x2(bh_2d_mesh_device):
+    """Prepare LM head and final norm weights on 4x2 mesh; verify shapes. LM head is vocab-sharded on device (TP=8)."""
+    _skip_unless_4x2_mesh(bh_2d_mesh_device)
+    submesh = bh_2d_mesh_device.create_submesh(ttnn.MeshShape((4, 2)))
+    state = {}
+    _add_global_weights(state)
+    weights = prepare_lm_head_weights(state, submesh)
+    assert isinstance(weights, DeepSeekV3LMHeadWeights)
+    assert weights.lm_head.shape is not None
+    assert weights.lm_head.shape == (7168, 16160), f"Expected lm_head shape (7168, 16160), got {weights.lm_head.shape}"
+    assert weights.final_norm.shape is not None
+    assert weights.final_norm.shape == (1, 7168), f"Expected final_norm shape (1, 7168), got {weights.final_norm.shape}"
+
+
+@pytest.mark.parametrize(
+    "device_params",
+    [{"fabric_config": ttnn.FabricConfig.FABRIC_2D}],
+    indirect=True,
+)
+def test_save_load_embedding_and_lm_head_weights_4x2(bh_2d_mesh_device, tmp_path):
+    """Save embedding and LM head (with final norm) to disk, load both back, verify on device."""
+    _skip_unless_4x2_mesh(bh_2d_mesh_device)
+    if not is_slow_dispatch():
+        pytest.skip("load requires slow dispatch")
+    submesh = bh_2d_mesh_device.create_submesh(ttnn.MeshShape((4, 2)))
+    state = {}
+    _add_global_weights(state)
+    logger.info("Preparing embedding weights...")
+    embedding_weights = prepare_embedding_weights(state, submesh)
+    logger.info("Preparing LM head weights...")
+    lm_head_weights = prepare_lm_head_weights(state, submesh)
+    expected_embedding_shape = embedding_weights.embedding.shape
+    expected_lm_shape = lm_head_weights.lm_head.shape
+    expected_norm_shape = lm_head_weights.final_norm.shape
+
+    logger.info("Saving embedding...")
+    save_embedding_weights(embedding_weights, tmp_path, hf_model_name="test", hf_state_dict_name="test.safetensors")
+    logger.info("Saving LM head weights...")
+    save_lm_head_weights(
+        lm_head_weights,
+        tmp_path,
+        hf_model_name="test",
+        hf_state_dict_name="test.safetensors",
+        device_mesh_shape=(4, 2),
+    )
+    ttnn.deallocate(embedding_weights.embedding, force=True)
+    ttnn.deallocate(lm_head_weights.lm_head, force=True)
+    ttnn.deallocate(lm_head_weights.final_norm, force=True)
+
+    logger.info("Loading embedding weights...")
+    loaded_embedding = load_embedding_weights(tmp_path, submesh)
+    assert loaded_embedding.embedding.shape == expected_embedding_shape
+    _assert_on_device(loaded_embedding.embedding)
+
+    logger.info("Loading LM head weights...")
+    loaded_lm_head = load_lm_head_weights(tmp_path, submesh)
+    assert loaded_lm_head.lm_head.shape == expected_lm_shape
+    assert loaded_lm_head.final_norm.shape == expected_norm_shape
+    _assert_on_device(loaded_lm_head.lm_head)
+    _assert_on_device(loaded_lm_head.final_norm)
 
 
 @pytest.mark.skip(reason="Too slow for CI; use for manual multi-submesh validation")
@@ -878,7 +991,7 @@ def test_load_4_layers_across_4_submeshes_4x2(bh_2d_mesh_device, tmp_path):
     Each layer is prepared on its own submesh to avoid OOM. Layers 0,1,2 are dense, layer 3 is MoE.
     """
     if not is_slow_dispatch():
-        pytest.skip("load_layer requires slow dispatch")
+        pytest.skip("load_dense_decoder_layer/load_moe_decoder_layer require slow dispatch")
     num_submeshes = 4
     devices_per_submesh = 4 * 2
     num_devices_required = num_submeshes * devices_per_submesh  # 32
@@ -889,57 +1002,49 @@ def test_load_4_layers_across_4_submeshes_4x2(bh_2d_mesh_device, tmp_path):
         )
     submeshes = bh_2d_mesh_device.create_submeshes(ttnn.MeshShape((4, 2)))
     assert len(submeshes) >= num_submeshes, f"Expected at least {num_submeshes} submeshes"
-    submesh0 = submeshes[0]
 
     num_layers = 4
     first_k_dense_replace = 3  # layers 0,1,2 dense; layer 3 MoE
     for layer_idx in range(num_layers):
         is_moe = layer_idx >= first_k_dense_replace
         submesh = submeshes[layer_idx]
-        state = _layer_state_dict(
-            layer_idx,
-            is_moe=is_moe,
-            seed=42 + layer_idx,
-        )
-        # prepare_weights always looks up model.layers.0.* when num_layers=1; remap keys
-        state_for_prepare = {k.replace(f"model.layers.{layer_idx}.", "model.layers.0."): v for k, v in state.items()}
-        # first_k_dense_replace so the single layer (index 0) is dense or MoE
-        first_k = 1 if layer_idx < first_k_dense_replace else 0
+        bdw = BlitzDecodeWeights(submesh)
+        # State for "layer 0" (prepare_*_layer_weights take layer_idx for key lookup)
+        state = _layer_state_dict(0, is_moe=is_moe, seed=42 + layer_idx)
         t0 = time.perf_counter()
-        weights = prepare_weights(
-            state_for_prepare,
-            submesh,
-            num_layers=1,
-            first_k_dense_replace=first_k,
-            num_routed_experts=NUM_ROUTED_EXPERTS,
-        )
+        if is_moe:
+            layer = prepare_moe_layer_weights(bdw, state, 0, num_routed_experts=NUM_ROUTED_EXPERTS)
+        else:
+            layer = prepare_dense_layer_weights(bdw, state, 0)
         elapsed = time.perf_counter() - t0
         logger.info(
-            "prepare_weights (layer %d, %s, on submesh %d): {:.3f} s",
+            "prepare (layer %d, %s, on submesh %d): {:.3f} s",
             layer_idx,
             "moe" if is_moe else "dense",
             layer_idx,
             elapsed,
         )
-        assert len(weights.layers) == 1
-        save_layer(
-            weights.layers[0],
+        save_decoder_layer(
+            layer,
             tmp_path,
             layer_idx,
             hf_model_name="test-4layer-model",
             hf_state_dict_name="test-4layer-state-dict.safetensors",
             device_mesh_shape=(4, 2),
         )
-        deallocate_weights(weights)
+        _deallocate_layer(layer)
 
     loaded = []
     t0 = time.time()
     for layer_idx in range(num_layers):
         submesh = submeshes[layer_idx]
-        layer = load_layer(tmp_path, submesh, layer_idx)
+        if layer_idx >= first_k_dense_replace:
+            layer = load_moe_decoder_layer(tmp_path, submesh, layer_idx)
+        else:
+            layer = load_dense_decoder_layer(tmp_path, submesh, layer_idx)
         loaded.append(layer)
     elapsed = time.time() - t0
-    logger.info(f"load_layer (4 layers, 4x2 submesh): {elapsed:.3f} s")
+    logger.info("load_decoder_layer (4 layers, 4x2 submesh): %s s", elapsed)
 
     assert isinstance(loaded[0], DeepSeekV3DenseLayerWeights)
     assert isinstance(loaded[1], DeepSeekV3DenseLayerWeights)


### PR DESCRIPTION
### Problem description

- Weight preparation and demo loading were built around a single-process, full-model flow (`prepare_weights()` / `load_weights()` / `save_weights()` and a monolithic `load_layer()`), which does not match multi-host pipeline staging where each host loads only its pipeline stage (embedding, certain decoder layers, or LM head).
- Embedding, gate bias (`e_score_correction_bias`), and LM head were not fully supported in the cache layout or in the demo's load path.
- The demo did not load weights from the prepared cache; it only opened a mesh and assumed a different integration point.

### What's changed

#### Prepare weights – per-layer API and new weight types

- Replaced the full-model API with a **per-layer API**:
  - **Save:** `save_decoder_layer()` (replaces `save_layer()`).
  - **Load:** `load_dense_decoder_layer()`, `load_moe_decoder_layer()`, and `load_moe_routed_experts()` (replaces single `load_layer()`).
  - **Prepare:** `prepare_dense_layer_weights()` and `prepare_moe_layer_weights()` (replacing the old prepare names used inside a single `prepare_weights()`).
- Removed `DeepSeekV3Weights`, `prepare_weights()`, `save_weights()`, and `load_weights()`; the demo and cache pipeline now use the per-layer save/load and the new embedding/LM head functions below.
- **Embedding:** Added `DeepSeekV3EmbeddingLayerWeights`, `prepare_embedding_weights()`, `save_embedding_weights()`, and `load_embedding_weights()`; cache layout uses `<path>/embedding/`.
- **LM head:** Added `DeepSeekV3LMHeadWeights`, `prepare_lm_head_weights()`, `save_lm_head_weights()`, and `load_lm_head_weights()` (vocab-sharded, 101 matmul cores, WIDTH_SHARDED L1); cache layout uses `<path>/lm_head/`.
- **Gate bias:** Added handling for MoE `e_score_correction_bias`: `create_gate_bias_tensor()` (HEIGHT_SHARDED on sender core), stored in attention manifest as `gate_bias.tensorbin`, and included in `AttentionWeights` / `DeepSeekV3MoELayerWeights`.
- **MoE expert loading:** `load_moe_routed_experts()` can be called under `setup_fast_dispatch`; the result is passed into `load_moe_decoder_layer(..., preloaded_routed_experts=...)` so experts are loaded once in fast dispatch and the rest of the layer in the current (e.g. slow) dispatch. Added debug profiling (timing) for each expert's gate/up/down load in `load_moe_routed_experts()`.
- All prepare functions accept an optional `move_to_device` for consistency.
- Net result: simpler structure and roughly ~500 lines removed from prepare_weights, generate_cache, and tests.

#### Generate cache

- **`generate_cache.py`** supports new modes **`embedding`** and **`lm_head`** (no `--layer-num`). Verify and generate paths for `<path>/embedding/` and `<path>/lm_head/` with `prepare_embedding_weights` / `save_embedding_weights` and `prepare_lm_head_weights` / `save_lm_head_weights`. Docstring and CLI help updated.

#### Demo CLI – multi-host and cache loading

- Demo now **loads weights from the prepared cache**: `load_weights_from_cache(cache_path, mesh_device, layer_offset)` returns embedding, decoder-layer, or LM head weights based on `mesh_id = get_system_mesh_id() + layer_offset` (embedding = 0, decoder = 1–61, LM head = 62).
- **Multi-host:** Each process opens the mesh via `open_mesh_device()` (using `bh_2d_mesh_device_context`) and loads only its slice; no single-process submesh iteration. `decoder_layer_id_from_mesh_id()` maps mesh ID to layer index (0–3 dense, 4–60 MoE).
- CLI: **`--cache-path`** (required) and **`--layer-id-offset`** replace `--mesh-height` / `--mesh-width`. Mesh shape is fixed to **4×2**; the CLI asserts this at startup.
- README updated with single-galaxy and single-pod run instructions (`tt-run`, rank bindings, `--cache-path`, `--layer-id-offset`).
- Generation path is temporarily stubbed after weights load (placeholder for full prefill/decode wiring).

#### Use real weights in shared expert tests

- **conftest:** Added session-scoped fixtures for real HuggingFace weights: `hf_model_path` (from `DEEPSEEK_V3_HF_MODEL`), `hf_state_dict` (lazy state dict), and `get_model_decoder_weight(layer_idx, weight_name, mesh_device)` returning a `SharedExpertWeightBundle` (prepared `SharedExpertWeights` on device plus raw torch gate/up/down for golden).
- **test_shared_expert:** Added `test_shared_expert_real_weights`, which runs the shared expert op on a 4×2 mesh using prepared weights from the HF model and validates output with per-device PCC against a torch golden. Skips when `DEEPSEEK_V3_HF_MODEL` is not set.

### Checklist

- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/22445522281/job/65003494834)
- [x] [Blackhole Post commit (with skips)]()
