### PR TITLE
De-templatize non-type-dependent code in device_operation launch pipeline

### DIFF
--- a/ttnn/CMakeLists.txt
+++ b/ttnn/CMakeLists.txt
@@ -127,6 +127,7 @@ target_sources(
         core/config.cpp
         core/core.cpp
         core/device.cpp
+        core/device_operation_detail.cpp
         core/distributed/api.cpp
         core/distributed/distributed_tensor.cpp
         core/distributed/distribution_mode.cpp
@@ -548,6 +549,7 @@ target_sources(
             api/ttnn/decorators.hpp
             api/ttnn/device.hpp
             api/ttnn/device_operation.hpp
+            api/ttnn/device_operation_detail.hpp
             api/ttnn/distributed/api.hpp
             api/ttnn/distributed/bidirectional_fabric_socket.hpp
             api/ttnn/distributed/create_socket.hpp

--- a/ttnn/api/ttnn/device_operation_detail.hpp
+++ b/ttnn/api/ttnn/device_operation_detail.hpp
@@ -1,0 +1,62 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <functional>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+#include <tt-metalium/mesh_coord.hpp>
+#include <tt_stl/small_vector.hpp>
+#include <ttnn/distributed/distributed_configs.hpp>
+
+namespace tt::tt_metal {
+class Tensor;
+namespace distributed {
+class MeshDevice;
+class MeshWorkload;
+}  // namespace distributed
+}  // namespace tt::tt_metal
+
+namespace ttnn::device_operation::detail {
+
+/**
+ * Non-template implementation of output placement and shape computation.
+ *
+ * This function computes the output tensor topology (placements and distribution shape)
+ * from a pre-extracted list of input tensors, avoiding the need to template on the
+ * operation's tensor_args_t type.
+ *
+ * Factored out of the template pipeline to reduce per-operation template instantiation cost.
+ */
+std::pair<
+    tt::stl::SmallVector<tt::tt_metal::distributed::MeshMapperConfig::Placement>,
+    tt::tt_metal::distributed::MeshShape>
+compute_output_placements_and_shape(
+    const std::vector<std::reference_wrapper<const tt::tt_metal::Tensor>>& tensors,
+    const tt::tt_metal::Tensor& first_tensor);
+
+/**
+ * Non-template implementation of mesh workload annotation for the inspector.
+ *
+ * Formats tensor arguments and emits annotation metadata without requiring
+ * the operation type template parameter.
+ */
+void emit_mesh_workload_annotation_impl(
+    tt::tt_metal::distributed::MeshWorkload& workload,
+    std::string_view operation_name,
+    const std::vector<std::reference_wrapper<const tt::tt_metal::Tensor>>& tensors);
+
+/**
+ * Non-template implementation of tensor coordinate extraction.
+ *
+ * Extracts and validates mesh coordinates from a pre-extracted list of input tensors.
+ */
+std::vector<tt::tt_metal::distributed::MeshCoordinate> extract_tensor_coordinates_impl(
+    const std::vector<std::reference_wrapper<const tt::tt_metal::Tensor>>& tensors,
+    tt::tt_metal::distributed::MeshDevice* mesh_device);
+
+}  // namespace ttnn::device_operation::detail

--- a/ttnn/core/device_operation_detail.cpp
+++ b/ttnn/core/device_operation_detail.cpp
@@ -1,0 +1,254 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttnn/device_operation_detail.hpp"
+
+#include <algorithm>
+#include <functional>
+#include <string_view>
+#include <unordered_map>
+#include <variant>
+#include <vector>
+
+#include <fmt/format.h>
+
+#include <tt-metalium/distributed.hpp>
+#include <tt-metalium/experimental/inspector.hpp>
+#include <tt-metalium/mesh_coord.hpp>
+#include <tt_stl/small_vector.hpp>
+
+#include "ttnn/distributed/types.hpp"
+#include "ttnn/tensor/tensor.hpp"
+
+namespace ttnn::device_operation::detail {
+
+// Bring mesh coordinate types into scope for readability.
+using MeshCoordinate = tt::tt_metal::distributed::MeshCoordinate;
+using MeshCoordinateRange = tt::tt_metal::distributed::MeshCoordinateRange;
+using MeshCoordinateRangeSet = tt::tt_metal::distributed::MeshCoordinateRangeSet;
+
+// ─────────────────────────────────────────────────────────────────────
+// compute_output_placements_and_shape
+// ─────────────────────────────────────────────────────────────────────
+//
+// Factored from the former template get_output_placements_and_shape<device_operation_t>.
+// The only reason it was templated was to call visit_object_of_type<Tensor> on tensor_args.
+// Callers now extract tensors first and pass them as a vector.
+
+static bool is_fully_replicated(const tt::tt_metal::Tensor& tensor) {
+    for (const auto& placement : tensor.tensor_topology().placements()) {
+        if (std::holds_alternative<tt::tt_metal::distributed::MeshMapperConfig::Shard>(placement)) {
+            return false;
+        }
+    }
+    return true;
+}
+
+std::pair<
+    tt::stl::SmallVector<tt::tt_metal::distributed::MeshMapperConfig::Placement>,
+    tt::tt_metal::distributed::MeshShape>
+compute_output_placements_and_shape(
+    const std::vector<std::reference_wrapper<const tt::tt_metal::Tensor>>& tensors,
+    const tt::tt_metal::Tensor& first_tensor) {
+    using Tensor = tt::tt_metal::Tensor;
+    using Placement = tt::tt_metal::distributed::MeshMapperConfig::Placement;
+    using Shard = tt::tt_metal::distributed::MeshMapperConfig::Shard;
+    using Replicate = tt::tt_metal::distributed::MeshMapperConfig::Replicate;
+
+    std::vector<std::reference_wrapper<const Tensor>> sharded_tensors;
+    for (const auto& tensor_ref : tensors) {
+        if (!is_fully_replicated(tensor_ref.get())) {
+            sharded_tensors.push_back(tensor_ref);
+        }
+    }
+
+    // Compute max distribution rank: use only sharded tensors if they exist, otherwise use all tensors (fully
+    // replicated)
+    size_t max_distribution_rank = 0;
+    if (!sharded_tensors.empty()) {
+        for (const auto& tensor_ref : sharded_tensors) {
+            max_distribution_rank =
+                std::max(max_distribution_rank, tensor_ref.get().tensor_topology().distribution_shape().dims());
+        }
+    } else {
+        max_distribution_rank = first_tensor.tensor_topology().distribution_shape().dims();
+    }
+
+    auto result_strides = tt::stl::SmallVector<uint32_t>(max_distribution_rank, 1);
+    auto result_placements = tt::stl::SmallVector<Placement>(max_distribution_rank, Replicate{});
+    std::unordered_map<int, int> shard_dim_to_distribution_dim;
+    bool dim_mismatch = false;
+
+    // TODO: #25340 - Add back logging / validation. Currently, this results in a lot of log spam.
+    constexpr bool kEnableLogging = false;
+    for (const auto& tensor_ref : tensors) {
+        const Tensor& tensor = tensor_ref.get();
+        // Augment output tensor distribution shape with the max strides of all input tensors with the max
+        // distribution rank
+        const auto& tensor_distribution_shape = tensor.tensor_topology().distribution_shape();
+        if (tensor_distribution_shape.dims() == max_distribution_rank) {
+            for (size_t i = 0; i < std::min(result_strides.size(), tensor_distribution_shape.dims()); i++) {
+                result_strides[i] = std::max(result_strides[i], tensor_distribution_shape[i]);
+            }
+
+            const auto& tensor_placements = tensor.tensor_topology().placements();
+            for (size_t i = 0; i < tensor_placements.size(); i++) {
+                Placement output_placement = result_placements[i];
+                if (std::holds_alternative<Shard>(tensor_placements[i])) {
+                    auto new_shard_placement = std::get<Shard>(tensor_placements[i]);
+
+                    // Only shard if the tensor dimension is not already sharded
+                    if (!shard_dim_to_distribution_dim.contains(new_shard_placement.dim)) {
+                        shard_dim_to_distribution_dim.insert({new_shard_placement.dim, static_cast<int>(i)});
+                        if (std::holds_alternative<Shard>(output_placement)) {
+                            auto existing_shard_placement = std::get<Shard>(output_placement);
+
+                            // If a different tensor dim is sharded across this distribution dim, keep the
+                            // earliest-seen shard dimension.
+                            if (new_shard_placement.dim != existing_shard_placement.dim && kEnableLogging) {
+                                log_warning(
+                                    tt::LogOp,
+                                    "Output tensor cannot shard different tensor dimensions across the same "
+                                    "distribution "
+                                    "dimension: tensor dims {} (kept) and {} (ignored) across distribution dim {}",
+                                    existing_shard_placement.dim,
+                                    new_shard_placement.dim,
+                                    i);
+                            }
+                            continue;
+                        }
+                        output_placement = new_shard_placement;
+                    } else if (
+                        shard_dim_to_distribution_dim.at(new_shard_placement.dim) != static_cast<int>(i) &&
+                        kEnableLogging) {
+                        log_warning(
+                            tt::LogOp,
+                            "Duplicate tensor shard dimension {} across distribution dim {} replaced with "
+                            "Replicate",
+                            new_shard_placement.dim,
+                            i);
+                    }
+                }
+                result_placements[i] = output_placement;
+            }
+        } else if (!is_fully_replicated(tensor)) {
+            dim_mismatch = true;
+        }
+    }
+    if (dim_mismatch && kEnableLogging) {
+        log_warning(
+            tt::LogOp,
+            "Input tensors have different distribution ranks, only imputing output tensor topology with tensors that "
+            "have the max distribution rank");
+    }
+    return {result_placements, tt::tt_metal::distributed::MeshShape(result_strides)};
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// emit_mesh_workload_annotation_impl
+// ─────────────────────────────────────────────────────────────────────
+
+void emit_mesh_workload_annotation_impl(
+    tt::tt_metal::distributed::MeshWorkload& workload,
+    std::string_view operation_name,
+    const std::vector<std::reference_wrapper<const tt::tt_metal::Tensor>>& tensors) {
+    if (tt::tt_metal::experimental::inspector::IsEnabled()) {
+        constexpr size_t TENSOR_ARGS_BUFFER_SIZE = 4096;
+        fmt::memory_buffer tensor_args_buffer;
+        tensor_args_buffer.reserve(TENSOR_ARGS_BUFFER_SIZE);
+
+        int index = 0;
+        for (const auto& tensor_ref : tensors) {
+            if (index > 0) {
+                fmt::format_to(std::back_inserter(tensor_args_buffer), ", ");
+            }
+            fmt::format_to(std::back_inserter(tensor_args_buffer), "[{}]: {}", index, tensor_ref.get());
+            index++;
+        }
+
+        tt::tt_metal::experimental::inspector::EmitMeshWorkloadAnnotation(
+            workload, operation_name, std::string_view(tensor_args_buffer.data(), tensor_args_buffer.size()));
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// extract_tensor_coordinates_impl
+// ─────────────────────────────────────────────────────────────────────
+
+// Checks if the MeshCoordinateRangeSet containing all coordinates in b is a subset of a.
+static bool is_subset_of(const std::vector<MeshCoordinate>& a, const std::vector<MeshCoordinate>& b) {
+    MeshCoordinateRangeSet a_set;
+    MeshCoordinateRangeSet b_set;
+
+    for (const auto& coord : a) {
+        a_set.merge(MeshCoordinateRange(coord));
+    }
+    for (const auto& coord : b) {
+        b_set.merge(MeshCoordinateRange(coord));
+    }
+
+    bool is_subset = false;
+    for (const auto& b_range : b_set.ranges()) {
+        is_subset = false;
+        for (const auto& a_range : a_set.ranges()) {
+            if (a_range.contains(b_range)) {
+                is_subset = true;
+                break;
+            }
+        }
+        if (not is_subset) {
+            return is_subset;
+        }
+    }
+    return is_subset;
+}
+
+std::vector<MeshCoordinate> extract_tensor_coordinates_impl(
+    const std::vector<std::reference_wrapper<const tt::tt_metal::Tensor>>& tensors,
+    tt::tt_metal::distributed::MeshDevice* mesh_device) {
+    using Tensor = tt::tt_metal::Tensor;
+
+    // If no tensor is found, return zero coordinate
+    if (tensors.empty()) {
+        if (mesh_device == nullptr) {
+            TT_THROW("No tensors found in tensor_args and no mesh_device provided to extract_tensor_coordinates");
+        }
+        return {MeshCoordinate::zero_coordinate(mesh_device->shape().dims())};
+    }
+
+    const Tensor& first_tensor = tensors.front().get();
+    std::vector<ttnn::MeshCoordinate> tensor_coordinates;
+    std::transform(
+        first_tensor.device_storage().coords.begin(),
+        first_tensor.device_storage().coords.end(),
+        std::back_inserter(tensor_coordinates),
+        [](const auto& coord) { return coord; });
+
+    // Verification Step: Assert if the tensors are placed on different coordinate ranges
+    // that do not overlap.
+    for (const auto& tensor_ref : tensors) {
+        const Tensor& tensor = tensor_ref.get();
+        if (tensor.device_storage().coords.size() != tensor_coordinates.size()) {
+            std::vector<ttnn::MeshCoordinate> tensor_mesh_coords;
+            std::transform(
+                tensor.device_storage().coords.begin(),
+                tensor.device_storage().coords.end(),
+                std::back_inserter(tensor_mesh_coords),
+                [](const auto& coord) { return coord; });
+            if (tensor_mesh_coords.size() < tensor_coordinates.size()) {
+                TT_ASSERT(
+                    is_subset_of(tensor_coordinates, tensor_mesh_coords),
+                    "Tensors are placed on different MeshCoordinate ranges that do not intersect.");
+                tensor_coordinates = std::move(tensor_mesh_coords);
+            } else {
+                TT_ASSERT(
+                    is_subset_of(tensor_mesh_coords, tensor_coordinates),
+                    "Tensors are placed on different MeshCoordinate ranges that do not intersect.");
+            }
+        }
+    }
+    return tensor_coordinates;
+}
+
+}  // namespace ttnn::device_operation::detail


### PR DESCRIPTION
### Ticket
N/A — build performance improvement

### Problem description

The `launch<device_operation_t>` template pipeline in `device_operation.hpp` and `mesh_device_operation_utils.hpp` is instantiated once per TTNN operation type (~213 instantiations). Profiling with `ClangBuildAnalyzer` (Clang 20, Unity + PCH enabled) showed this as one of the top compilation bottlenecks:

| Metric | Before | After | Change |
|--------|--------|-------|--------|
| `launch<$>` per-instantiation | 1,459ms | 1,086ms | **−25.6%** |
| `launch<$>` total (×213 ops) | 311s | 231s | **−80s** |
| Total frontend CPU-time | 9,201s | 9,079s | **−122s** |
| Total backend CPU-time | 7,311s | 7,184s | **−127s** |
| Total CPU-time | 16,513s | 16,263s | **−250s (−1.5%)** |

> **Note:** Wall-clock clean build time is currently unchanged because the critical path is dominated by `graph_argument_serializer.cpp` (~200s). The CPU-time savings will translate to wall-clock improvement once that bottleneck is resolved (in progress separately).

### What's changed

Several large functions inside the `launch<device_operation_t>` template were only parameterized on the operation type so they could call `visit_object_of_type<Tensor>()` for tensor extraction. The actual computation — placement imputation, coordinate validation, inspector annotation — operates entirely on concrete `Tensor` objects and does not depend on the operation type at all.

This PR factors that non-type-dependent code out of the templates into a compiled `.cpp` file:

**New files:**
- `ttnn/api/ttnn/device_operation_detail.hpp` — declarations
- `ttnn/core/device_operation_detail.cpp` — implementations

**Functions factored out:**
| Template (before) | Non-template (after) |
|---|---|
| `get_output_placements_and_shape<T>` | `detail::compute_output_placements_and_shape()` |
| `extract_tensor_coordinates<T>` | `detail::extract_tensor_coordinates_impl()` |
| `emit_mesh_workload_annotation<T>` | `detail::emit_mesh_workload_annotation_impl()` |

The thin template wrappers remain — they do only `visit_object_of_type<Tensor>()` to build a `vector<reference_wrapper<const Tensor>>`, then immediately delegate to the non-template implementation. This is a **type-erasing boundary**: the expensive work is compiled once instead of 213 times.

**Runtime performance impact:** None expected. The factored code was never type-dependent — it always operated on concrete `Tensor` objects. The hot path (kernel dispatch, compute) is untouched. LTO can inline these functions if the compiler determines it's beneficial.

### Checklist

- [x] [APC](https://github.com/tenstorrent/tt-metal/actions/runs/22462536840)
- [x] New/Existing tests provide coverage for changes (existing tests cover device_operation launch path)