### PR TITLE
Fix BFLOAT4_B support for logical_not unary op

### DIFF
--- a/.github/workflows/t3000-unit-tests-impl.yaml
+++ b/.github/workflows/t3000-unit-tests-impl.yaml
@@ -85,7 +85,7 @@ jobs:
       volumes:
         - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
         - /dev/hugepages-1G:/dev/hugepages-1G
-        - /mnt/MLPerf:/mnt/MLPerf:rw
+        - /mnt/MLPerf:/mnt/MLPerf:ro
       options: "--device /dev/tenstorrent"
     defaults:
       run:

--- a/.github/workflows/t3000-unit-tests-impl.yaml
+++ b/.github/workflows/t3000-unit-tests-impl.yaml
@@ -85,7 +85,7 @@ jobs:
       volumes:
         - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
         - /dev/hugepages-1G:/dev/hugepages-1G
-        - /mnt/MLPerf:/mnt/MLPerf:ro
+        - /mnt/MLPerf:/mnt/MLPerf:rw
       options: "--device /dev/tenstorrent"
     defaults:
       run:

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_macros.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_macros.h
@@ -172,20 +172,22 @@
         ckernel::sfpu::FN<APPROXIMATE, ITER, FP32, FAST_APPROX, LEGACY_COMPAT>, DST_IDX, (int)VectorMode::MODE)
 
 // For kernels whose functor takes three template parameters (e.g., <APPROXIMATE, DATA_FORMAT, ITERATIONS>).
-#define SFPU_UNARY_KERNEL_THREE_TEMPLATE_ARGS_FN(FN, APPROXIMATE, DATA_FORMAT, ITERATIONS, DST_IDX, MODE)           \
-    static_assert(                                                                                                  \
-        DATA_FORMAT == DataFormat::Float32 || DATA_FORMAT == DataFormat::Float16_b ||                               \
-            DATA_FORMAT == DataFormat::Int32 || DATA_FORMAT == DataFormat::UInt32 ||                                \
-            DATA_FORMAT == DataFormat::UInt16 || DATA_FORMAT == DataFormat::Bfp8_b,                                 \
-        "Unsupported data format. Supported data formats are: Float32, Float16_b, Int32, UInt32, UInt16, Bfp8_b."); \
-    constexpr InstrModLoadStore INSTRUCTION_MODE =                                                                  \
-        (DATA_FORMAT == DataFormat::Float32 || DATA_FORMAT == DataFormat::Float16_b ||                              \
-         DATA_FORMAT == DataFormat::Bfp8_b)                                                                         \
-            ? InstrModLoadStore::DEFAULT                                                                            \
-        : (DATA_FORMAT == DataFormat::UInt16)                                     ? InstrModLoadStore::LO16         \
-        : (DATA_FORMAT == DataFormat::Int32 || DATA_FORMAT == DataFormat::UInt32) ? InstrModLoadStore::INT32        \
-                                                                                  : InstrModLoadStore::DEFAULT;     \
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(                                                              \
+#define SFPU_UNARY_KERNEL_THREE_TEMPLATE_ARGS_FN(FN, APPROXIMATE, DATA_FORMAT, ITERATIONS, DST_IDX, MODE)          \
+    static_assert(                                                                                                 \
+        DATA_FORMAT == DataFormat::Float32 || DATA_FORMAT == DataFormat::Float16_b ||                              \
+            DATA_FORMAT == DataFormat::Int32 || DATA_FORMAT == DataFormat::UInt32 ||                               \
+            DATA_FORMAT == DataFormat::UInt16 || DATA_FORMAT == DataFormat::Bfp8_b ||                              \
+            DATA_FORMAT == DataFormat::Bfp4_b,                                                                     \
+        "Unsupported data format. Supported data formats are: Float32, Float16_b, Int32, UInt32, UInt16, Bfp8_b, " \
+        "Bfp4_b.");                                                                                                \
+    constexpr InstrModLoadStore INSTRUCTION_MODE =                                                                 \
+        (DATA_FORMAT == DataFormat::Float32 || DATA_FORMAT == DataFormat::Float16_b ||                             \
+         DATA_FORMAT == DataFormat::Bfp8_b || DATA_FORMAT == DataFormat::Bfp4_b)                                   \
+            ? InstrModLoadStore::DEFAULT                                                                           \
+        : (DATA_FORMAT == DataFormat::UInt16)                                     ? InstrModLoadStore::LO16        \
+        : (DATA_FORMAT == DataFormat::Int32 || DATA_FORMAT == DataFormat::UInt32) ? InstrModLoadStore::INT32       \
+                                                                                  : InstrModLoadStore::DEFAULT;    \
+    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(                                                             \
         ckernel::sfpu::FN<APPROXIMATE, INSTRUCTION_MODE, ITERATIONS>, DST_IDX, (int)VectorMode::MODE);
 
 // For the compare with zero ops (eqz, nez, ltz, gtz, lez, gez)

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_macros.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_macros.h
@@ -172,20 +172,22 @@
         ckernel::sfpu::FN<APPROXIMATE, ITER, FP32, FAST_APPROX, LEGACY_COMPAT>, DST_IDX, (int)VectorMode::MODE)
 
 // For kernels whose functor takes three template parameters (e.g., <APPROXIMATE, DATA_FORMAT, ITERATIONS>).
-#define SFPU_UNARY_KERNEL_THREE_TEMPLATE_ARGS_FN(FN, APPROXIMATE, DATA_FORMAT, ITERATIONS, DST_IDX, MODE)           \
-    static_assert(                                                                                                  \
-        DATA_FORMAT == DataFormat::Float32 || DATA_FORMAT == DataFormat::Float16_b ||                               \
-            DATA_FORMAT == DataFormat::Int32 || DATA_FORMAT == DataFormat::UInt32 ||                                \
-            DATA_FORMAT == DataFormat::UInt16 || DATA_FORMAT == DataFormat::Bfp8_b,                                 \
-        "Unsupported data format. Supported data formats are: Float32, Float16_b, Int32, UInt32, UInt16, Bfp8_b."); \
-    constexpr InstrModLoadStore INSTRUCTION_MODE =                                                                  \
-        (DATA_FORMAT == DataFormat::Float32 || DATA_FORMAT == DataFormat::Float16_b ||                              \
-         DATA_FORMAT == DataFormat::Bfp8_b)                                                                         \
-            ? InstrModLoadStore::DEFAULT                                                                            \
-        : (DATA_FORMAT == DataFormat::UInt16)                                     ? InstrModLoadStore::LO16         \
-        : (DATA_FORMAT == DataFormat::Int32 || DATA_FORMAT == DataFormat::UInt32) ? InstrModLoadStore::INT32        \
-                                                                                  : InstrModLoadStore::DEFAULT;     \
-    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(                                                              \
+#define SFPU_UNARY_KERNEL_THREE_TEMPLATE_ARGS_FN(FN, APPROXIMATE, DATA_FORMAT, ITERATIONS, DST_IDX, MODE)          \
+    static_assert(                                                                                                 \
+        DATA_FORMAT == DataFormat::Float32 || DATA_FORMAT == DataFormat::Float16_b ||                              \
+            DATA_FORMAT == DataFormat::Int32 || DATA_FORMAT == DataFormat::UInt32 ||                               \
+            DATA_FORMAT == DataFormat::UInt16 || DATA_FORMAT == DataFormat::Bfp8_b ||                              \
+            DATA_FORMAT == DataFormat::Bfp4_b,                                                                     \
+        "Unsupported data format. Supported data formats are: Float32, Float16_b, Int32, UInt32, UInt16, Bfp8_b, " \
+        "Bfp4_b.");                                                                                                \
+    constexpr InstrModLoadStore INSTRUCTION_MODE =                                                                 \
+        (DATA_FORMAT == DataFormat::Float32 || DATA_FORMAT == DataFormat::Float16_b ||                             \
+         DATA_FORMAT == DataFormat::Bfp8_b || DATA_FORMAT == DataFormat::Bfp4_b)                                   \
+            ? InstrModLoadStore::DEFAULT                                                                           \
+        : (DATA_FORMAT == DataFormat::UInt16)                                     ? InstrModLoadStore::LO16        \
+        : (DATA_FORMAT == DataFormat::Int32 || DATA_FORMAT == DataFormat::UInt32) ? InstrModLoadStore::INT32       \
+                                                                                  : InstrModLoadStore::DEFAULT;    \
+    _llk_math_eltwise_unary_sfpu_params_<APPROXIMATE>(                                                             \
         ckernel::sfpu::FN<APPROXIMATE, INSTRUCTION_MODE, ITERATIONS>, DST_IDX, (int)VectorMode::MODE);
 
 // For the compare with zero ops (eqz, nez, ltz, gtz, lez, gez)

--- a/tt_metal/hw/inc/api/compute/eltwise_unary/logical_not.h
+++ b/tt_metal/hw/inc/api/compute/eltwise_unary/logical_not.h
@@ -19,7 +19,7 @@ namespace ckernel {
  * available on the compute engine.
  *
  * @tparam data_format Template argument specifying the data type.
- * Supported data formats are: DataFormat::Int32, DataFormat::UInt32, DataFormat::UInt16, DataFormat::Float32, DataFormat::Float16_b, DataFormat::Bfp8_b.
+ * Supported data formats are: DataFormat::Int32, DataFormat::UInt32, DataFormat::UInt16, DataFormat::Float32, DataFormat::Float16_b, DataFormat::Bfp8_b, DataFormat::Bfp4_b.
  *
  * Return value: None
  *

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_utils.cpp
@@ -609,6 +609,7 @@ std::pair<std::string, std::string> get_op_init_and_func_default(
                 case DataType::FLOAT32: data_format = "Float32"; break;
                 case DataType::BFLOAT16: data_format = "Float16_b"; break;
                 case DataType::BFLOAT8_B: data_format = "Bfp8_b"; break;
+                case DataType::BFLOAT4_B: data_format = "Bfp4_b"; break;
                 default: TT_THROW("Unsupported data format for logical not unary: {}", input_dtype);
             }
             return {


### PR DESCRIPTION
### Ticket
Link to failed CI: https://github.com/tenstorrent/tt-metal/actions/runs/22428070470/job/64941237989

### Problem description
The `test_comp_allclose_ttnn_native[1x1-tile_bf4b]` test was failing with:
```
Unsupported data format for logical not unary: DataType::BFLOAT4_B
```

### Root Cause
Commit `482d9470ae3` ("#37464: Update unary LLK Tile API's (#37703)") refactored the `LOGICAL_NOT_UNARY` op from using runtime conditionals to a template-based approach with compile-time data format selection. The old code had a fallback for unsupported dtypes:
```cpp
return {"logical_not_unary_tile_init();", fmt::format("logical_not_unary_tile({});", idst)};  // FALLBACK
```

The new code uses an explicit whitelist in a switch statement:
```cpp
switch (input_dtype.value()) {
    case DataType::INT32: data_format = "Int32"; break;
    case DataType::UINT32: data_format = "UInt32"; break;
    case DataType::UINT16: data_format = "UInt16"; break;
    case DataType::FLOAT32: data_format = "Float32"; break;
    case DataType::BFLOAT16: data_format = "Float16_b"; break;
    case DataType::BFLOAT8_B: data_format = "Bfp8_b"; break;
    default: TT_THROW("Unsupported data format for logical not unary: {}", input_dtype);
}
```

`BFLOAT4_B` was omitted from this whitelist, causing the test failure when running with bfloat4_b dtype.

### What's changed
Added `BFLOAT4_B` ("Bfp4_b") support to the `LOGICAL_NOT_UNARY` op across both architectures:

1. **ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_utils.cpp** - Added `BFLOAT4_B` case to the data format switch
2. **tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_macros.h** - Added `Bfp4_b` to static_assert whitelist and INSTRUCTION_MODE mapping
3. **tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_macros.h** - Same fix for blackhole architecture
4. **tt_metal/hw/inc/api/compute/eltwise_unary/logical_not.h** - Updated documentation to include Bfp4_b

### Why this fix is correct
The kernel implementation (`ckernel_sfpu_logical_not.h`) uses `INSTRUCTION_MODE` (not specific data format) to determine load/store behavior. Both `Bfp8_b` and `Bfp4_b` map to `InstrModLoadStore::DEFAULT`, which means they use the same generic block-float instruction path. The kernel validates only the instruction mode at compile time, not the specific block-float format.

### Checklist
- [x] New/Existing tests provide coverage for changes (test_comp_allclose_ttnn_native[1x1-tile_bf4b] now passes)
  - https://github.com/tenstorrent/tt-metal/actions/runs/22454425797
- [x] Local testing confirms fix works (4/4 tests passed)
- [x] revert [9f75eba](https://github.com/tenstorrent/tt-metal/pull/38656/commits/9f75eba645cfd80ecbbd3eb139ae6bba9f6538f1)

Made with [Cursor](https://cursor.com)