### PR TITLE
Improve accuracy when using float32 gate on fused minimal_matmul+addcmul

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/device/kernels/compute.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/device/kernels/compute.cpp
@@ -13,6 +13,9 @@
 #include "api/compute/eltwise_unary/eltwise_unary.h"
 #include "api/compute/eltwise_unary/binop_with_scalar.h"
 
+// DEBUG
+#include "api/compute/eltwise_binary_sfpu.h"
+
 void copy_block(uint32_t in_cb, uint32_t out_cb, uint32_t M_block_tiles, uint32_t N_block_tiles) {
     copy_tile_to_dst_init_short(in_cb);
     reconfig_data_format_srca(in_cb);
@@ -132,7 +135,12 @@ void add_bias_and_addcmul_block(
     cb_wait_front(intermediate_cb, out_block_num_tiles);
     cb_wait_front(ternary_b_cb, N_block_tiles);
 
+#ifndef TERNARY_B_IS_FLOAT32
     mul_bcast_rows_init_short(intermediate_cb, ternary_b_cb);
+#else
+    unary_bcast_init<BroadcastType::ROW>(ternary_b_cb, intermediate_cb);
+#endif  // TERNARY_B_IS_FLOAT32
+
     binop_with_scalar_tile_init();
     reconfig_data_format(intermediate_cb, ternary_b_cb);
     pack_reconfig_data_format(intermediate_cb);
@@ -142,8 +150,26 @@ void add_bias_and_addcmul_block(
         for (uint32_t n = 0; n < N_block_tiles; n++) {
             tile_regs_acquire();
 
+#ifndef TERNARY_B_IS_FLOAT32
+            // LLK BUG: unary_bcast gives bad values if mixing fp32_acc_to_dest=True and bfloat16 circular buffer
+            // (https://github.com/tenstorrent/tt-llk/issues/1338)
+            // Workaround is to use mul_tiles_bcast instead of unary_bcast/mul_binary_tile.
+
             // ternary_b_cb is [1, N], broadcast across M rows
             mul_tiles_bcast<BroadcastType::ROW>(intermediate_cb, ternary_b_cb, tile_id, n, DST_ID);
+#else
+            constexpr uint32_t TERNARY_B_CB_ID = 1;
+            unary_bcast_init<BroadcastType::ROW>(ternary_b_cb, intermediate_cb);
+
+            // ternary_b_cb is [1, N], broadcast across M rows
+            unary_bcast<BroadcastType::ROW>(ternary_b_cb, tile_id, TERNARY_B_CB_ID);
+
+            copy_tile_to_dst_init_short(intermediate_cb);
+            copy_tile(intermediate_cb, tile_id, DST_ID);
+
+            mul_binary_tile_init();
+            mul_binary_tile(DST_ID, TERNARY_B_CB_ID, DST_ID);
+#endif  // TERNARY_B_IS_FLOAT32
 
             mul_unary_tile(DST_ID, scalar_value);
 

--- a/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/device/kernels/compute.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/device/kernels/compute.cpp
@@ -162,7 +162,7 @@ void add_bias_and_addcmul_block(
             unary_bcast_init<BroadcastType::ROW>(ternary_b_cb, intermediate_cb);
 
             // ternary_b_cb is [1, N], broadcast across M rows
-            unary_bcast<BroadcastType::ROW>(ternary_b_cb, tile_id, TERNARY_B_DST_ID);
+            unary_bcast<BroadcastType::ROW>(ternary_b_cb, n, TERNARY_B_DST_ID);
 
             copy_tile_to_dst_init_short(intermediate_cb);
             copy_tile(intermediate_cb, tile_id, DST_ID);

--- a/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/device/kernels/compute.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/device/kernels/compute.cpp
@@ -12,8 +12,6 @@
 #include "api/compute/eltwise_unary/sfpu_split_includes.h"
 #include "api/compute/eltwise_unary/eltwise_unary.h"
 #include "api/compute/eltwise_unary/binop_with_scalar.h"
-
-// DEBUG
 #include "api/compute/eltwise_binary_sfpu.h"
 
 void copy_block(uint32_t in_cb, uint32_t out_cb, uint32_t M_block_tiles, uint32_t N_block_tiles) {

--- a/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/device/kernels/compute.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/device/kernels/compute.cpp
@@ -158,17 +158,17 @@ void add_bias_and_addcmul_block(
             // ternary_b_cb is [1, N], broadcast across M rows
             mul_tiles_bcast<BroadcastType::ROW>(intermediate_cb, ternary_b_cb, tile_id, n, DST_ID);
 #else
-            constexpr uint32_t TERNARY_B_CB_ID = 1;
+            constexpr uint32_t TERNARY_B_DST_ID = 1;
             unary_bcast_init<BroadcastType::ROW>(ternary_b_cb, intermediate_cb);
 
             // ternary_b_cb is [1, N], broadcast across M rows
-            unary_bcast<BroadcastType::ROW>(ternary_b_cb, tile_id, TERNARY_B_CB_ID);
+            unary_bcast<BroadcastType::ROW>(ternary_b_cb, tile_id, TERNARY_B_DST_ID);
 
             copy_tile_to_dst_init_short(intermediate_cb);
             copy_tile(intermediate_cb, tile_id, DST_ID);
 
             mul_binary_tile_init();
-            mul_binary_tile(DST_ID, TERNARY_B_CB_ID, DST_ID);
+            mul_binary_tile(DST_ID, TERNARY_B_DST_ID, DST_ID);
 #endif  // TERNARY_B_IS_FLOAT32
 
             mul_unary_tile(DST_ID, scalar_value);

--- a/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/device/kernels/compute.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/device/kernels/compute.cpp
@@ -151,7 +151,9 @@ void add_bias_and_addcmul_block(
 #ifndef TERNARY_B_IS_FLOAT32
             // LLK BUG: unary_bcast gives bad values if mixing fp32_acc_to_dest=True and bfloat16 circular buffer
             // (https://github.com/tenstorrent/tt-llk/issues/1338)
-            // Workaround is to use mul_tiles_bcast instead of unary_bcast/mul_binary_tile.
+            // To avoid the bug, we use:
+            // - unary_bcast/mul_binary_tile for fp32 (more accurate)
+            // - mul_tiles_bcast for bfloat16 (LLK bug workaround).
 
             // ternary_b_cb is [1, N], broadcast across M rows
             mul_tiles_bcast<BroadcastType::ROW>(intermediate_cb, ternary_b_cb, tile_id, n, DST_ID);

--- a/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/device/minimal_matmul_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/device/minimal_matmul_program_factory.cpp
@@ -382,6 +382,8 @@ MinimalMatmulProgramFactory::shared_variables_t minimal_matmul_factory_helper_co
         defines["FUSE_TERNARY"] = "1";
 
         // Workaround for LLK bug (https://github.com/tenstorrent/tt-llk/issues/1338)
+        // - If ternary_b / gate is float32 then use unary_bcast (row broadcast) + mul_binary_tile (accurate)
+        // - If ternary_b / gate is bfloat16 then use mul_tiles_bcast (row broadcast) (workaround)
         if (fused_ternary_input_b.value().dtype() == DataType::FLOAT32) {
             defines["TERNARY_B_IS_FLOAT32"] = "1";
         }

--- a/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/device/minimal_matmul_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/device/minimal_matmul_program_factory.cpp
@@ -601,7 +601,6 @@ MinimalMatmulProgramFactory::shared_variables_t minimal_matmul_factory_helper_co
             "fused_act_dst_id",
             output_tensors[0].dtype());
     }
-
     compute_defines.merge(compute_activation_defines);
     ttnn::operations::compute_throttle_utils::throttle_mm_perf(
         device->arch(), num_cores, compute_defines, ttnn::get_throttle_level(compute_kernel_config));

--- a/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/device/minimal_matmul_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/device/minimal_matmul_program_factory.cpp
@@ -380,6 +380,11 @@ MinimalMatmulProgramFactory::shared_variables_t minimal_matmul_factory_helper_co
 
     if (use_fused_ternary) {
         defines["FUSE_TERNARY"] = "1";
+
+        // Workaround for LLK bug (https://github.com/tenstorrent/tt-llk/issues/1338)
+        if (fused_ternary_input_b.value().dtype() == DataType::FLOAT32) {
+            defines["TERNARY_B_IS_FLOAT32"] = "1";
+        }
     }
 
     if (fuse_op) {
@@ -596,6 +601,7 @@ MinimalMatmulProgramFactory::shared_variables_t minimal_matmul_factory_helper_co
             "fused_act_dst_id",
             output_tensors[0].dtype());
     }
+
     compute_defines.merge(compute_activation_defines);
     ttnn::operations::compute_throttle_utils::throttle_mm_perf(
         device->arch(), num_cores, compute_defines, ttnn::get_throttle_level(compute_kernel_config));


### PR DESCRIPTION
### Ticket
#38657

### Problem description
Note: Waiting for #38373 to get merged first.  

Depending on how we set gate/ternary_b tensor data-type, we can get worse/equal accuracy than with bfloat16:

bfloat16: `PCC:  0.9999852035066615, 'relative_rmse': 0.008461126247817105`
float32. : `PCC: 0.999985569232651, 'relative_mse': 0.0104854871966534`

The reason this happens is because of `mul_tiles_bcast<BroadcastType::ROW>` uses the FPU, which truncates bit when using float32. 
Ideally, we'd like to use `unary_bcast_init<BroadcastType::ROW>` and do all computation on the SFPU. Unfortunately, a LLK bug prevents this for bfloat16 with fp32_acc_to_dest. ( https://github.com/tenstorrent/tt-llk/issues/1338 )

### What's changed

Adds define to kernel to switch between `mul_tiles_bcast` (bfloat16 gate/ternary_b) and `unary_bcast_init` (float32 gate/ternary_b). 

This improves accuracy with gate/ternary_b to:
float32 `PCC: 0.9999913616107378, 'relative_rmse': 0.0054299287872049025`

### Checklist

- [x] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=nmaurice/improve-fp32-matmul-addcmul-accuracy)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:nmaurice/improve-fp32-matmul-addcmul-accuracy)
- [x] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=nmaurice/improve-fp32-matmul-addcmul-accuracy)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:nmaurice/improve-fp32-matmul-addcmul-accuracy)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nmaurice/improve-fp32-matmul-addcmul-accuracy)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nmaurice/improve-fp32-matmul-addcmul-accuracy) (failures in main)
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nmaurice/improve-fp32-matmul-addcmul-accuracy)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nmaurice/improve-fp32-matmul-addcmul-accuracy)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nmaurice/improve-fp32-matmul-addcmul-accuracy)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nmaurice/improve-fp32-matmul-addcmul-accuracy)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nmaurice/improve-fp32-matmul-addcmul-accuracy)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nmaurice/improve-fp32-matmul-addcmul-accuracy)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
