### PR TITLE
[QSR]: Update dfbs handling in finalizing offsets to match cbs and avoid the need for a DFB getter

### DIFF
--- a/tt_metal/api/tt-metalium/experimental/dataflow_buffer/dataflow_buffer.hpp
+++ b/tt_metal/api/tt-metalium/experimental/dataflow_buffer/dataflow_buffer.hpp
@@ -8,25 +8,34 @@
 #include <variant>
 
 #include <tt-metalium/core_coord.hpp>
+#include <tt-metalium/tile.hpp>
 
 #include "tt_metal/hw/inc/internal/dataflow_buffer_interface.h"
 
-namespace tt::tt_metal {
+namespace tt {
+enum class DataFormat : uint8_t;
+namespace tt_metal {
 class Program;
-}
+}  // namespace tt_metal
+}  // namespace tt
 
 namespace tt::tt_metal::experimental::dfb {
+
+// Alias to avoid ambiguous 'experimental' when used inside tt::tt_metal::experimental
+using AccessPattern = ::experimental::AccessPattern;
 
 struct DataflowBufferConfig {
     uint32_t entry_size = 0;
     uint32_t num_entries = 0;
     uint16_t producer_risc_mask = 0x0;  // bits 0-7 = DM riscs, bits 8-15 = Tensix riscs
     uint8_t num_producers = 1;
-    ::experimental::AccessPattern pap = ::experimental::AccessPattern::STRIDED;
+    AccessPattern pap = AccessPattern::STRIDED;
     uint16_t consumer_risc_mask = 0x0;  // bits 0-7 = DM riscs, bits 8-15 = Tensix riscs
     uint8_t num_consumers = 1;
-    ::experimental::AccessPattern cap = ::experimental::AccessPattern::STRIDED;
+    AccessPattern cap = AccessPattern::STRIDED;
     bool enable_implicit_sync = false;
+    DataFormat data_format = tt::DataFormat::Float16_b;
+    std::optional<Tile> tile = std::nullopt;
 };
 
 // Note: This API and the DataflowBufferConfig are placeholder only, the final DataflowBuffer APIs will conform with

--- a/tt_metal/distributed/mesh_workload.cpp
+++ b/tt_metal/distributed/mesh_workload.cpp
@@ -410,15 +410,6 @@ void MeshWorkloadImpl::finalize_offsets(MeshDevice* mesh_device) {
         return this->semaphores();
     };
 
-    // TODO: Add dataflow buffer support to MeshWorkload
-    static const std::vector<std::shared_ptr<tt::tt_metal::experimental::dfb::detail::DataflowBufferImpl>>
-        empty_dataflow_buffers;
-    tt::tt_metal::detail::DataflowBuffersGetter dataflow_buffers_getter =
-        []() -> const std::vector<std::shared_ptr<tt::tt_metal::experimental::dfb::detail::DataflowBufferImpl>>& {
-        return empty_dataflow_buffers;
-    };
-
-    // Create a span with all programs
     std::vector<tt::tt_metal::detail::ProgramImpl*> program_impls;
     program_impls.reserve(programs_.size());
     for (auto& [_, program] : programs_) {
@@ -427,7 +418,7 @@ void MeshWorkloadImpl::finalize_offsets(MeshDevice* mesh_device) {
     tt::stl::Span<tt::tt_metal::detail::ProgramImpl*> programs(program_impls.data(), program_impls.size());
 
     this->max_program_kernels_sizeB_ = tt::tt_metal::detail::ProgramImpl::finalize_program_offsets(
-        mesh_device, kernels_getter, kernel_groups_getter, semaphores_getter, dataflow_buffers_getter, programs);
+        mesh_device, kernels_getter, kernel_groups_getter, semaphores_getter, programs);
 
     set_finalized();
 }

--- a/tt_metal/impl/program/program_impl.hpp
+++ b/tt_metal/impl/program/program_impl.hpp
@@ -142,8 +142,6 @@ struct ProgramOffsetsState {
 using KernelsGetter = std::function<std::unordered_map<KernelHandle, std::shared_ptr<Kernel>>&(uint32_t index)>;
 using KernelGroupsGetter = std::function<std::vector<std::shared_ptr<KernelGroup>>&(uint32_t index)>;
 using SemaphoresGetter = std::function<const std::vector<Semaphore>&()>;
-using DataflowBuffersGetter =
-    std::function<const std::vector<std::shared_ptr<tt::tt_metal::experimental::dfb::detail::DataflowBufferImpl>>&()>;
 
 // Internal class for holding a group of programs for parallel compilation.
 class ProgramCompileGroup {
@@ -197,6 +195,8 @@ public:
     std::size_t num_kernels() const;
     std::span<const std::shared_ptr<CircularBufferImpl>> circular_buffers() const;
     const std::vector<Semaphore>& semaphores() const;
+    const std::vector<std::shared_ptr<tt::tt_metal::experimental::dfb::detail::DataflowBufferImpl>>& dataflow_buffers()
+        const;
     KernelGroup* kernels_on_core(const CoreCoord& core, uint32_t programmable_core_type_index);
     std::vector<std::shared_ptr<KernelGroup>>& get_kernel_groups(uint32_t programmable_core_type_index);
     std::unordered_map<KernelHandle, std::shared_ptr<Kernel>>& get_kernels(uint32_t programmable_core_type_index);
@@ -207,6 +207,7 @@ public:
     std::vector<CoreRange> circular_buffers_unique_coreranges() const;
     std::vector<std::shared_ptr<tt::tt_metal::experimental::dfb::detail::DataflowBufferImpl>> dataflow_buffers_on_core(
         const CoreCoord& core) const;
+    std::vector<std::shared_ptr<tt::tt_metal::experimental::dfb::detail::DataflowBufferImpl>> dataflow_buffers_on_corerange(const CoreRange& cr) const;
     std::vector<std::reference_wrapper<const Semaphore>> semaphores_on_core(
         const CoreCoord& core, CoreType core_type) const;
     void init_semaphores(
@@ -261,7 +262,6 @@ public:
         const KernelsGetter& kernels_getter,
         const KernelGroupsGetter& kernel_groups_getter,
         const SemaphoresGetter& semaphores_getter,
-        const DataflowBuffersGetter& dataflow_buffers_getter,
         tt::stl::Span<ProgramImpl*> programs);
 
     std::vector<uint32_t>& get_program_config_sizes() noexcept { return program_config_sizes_; }
@@ -407,7 +407,11 @@ private:
 
     void set_cb_data_fmt(const std::vector<CoreRange>& crs, JitBuildOptions& build_options) const;
 
+    void set_dfb_data_fmt(const std::vector<CoreRange>& crs, JitBuildOptions& build_options) const;
+
     void set_cb_tile_dims(const std::vector<CoreRange>& crs, JitBuildOptions& build_options) const;
+
+    void set_dfb_tile_dims(const std::vector<CoreRange>& crs, JitBuildOptions& build_options) const;
 
     void update_kernel_groups(uint32_t programmable_core_type_index);
 


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/36890

### What's changed
DFBs were not properly hooked into mesh workloads, uplifted to use the same mechanism as CBs to finalize offsets. Difference between the two is to finalize the dfb config sizes in ring buffer, the actual DFB object is needed since the config is variable in size

### Checklist

- [x] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=abhullar/dfb-mw)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:abhullar/dfb-mw)
- [ ] New/Existing tests provide coverage for changes (these are included in https://github.com/tenstorrent/tt-metal/pull/38303)