### PR TITLE
Reduce GPT-OSS prefill DRAM pressure for stable low-latency up to 64k

### DIFF
--- a/models/demos/gpt_oss/demo/text_demo.py
+++ b/models/demos/gpt_oss/demo/text_demo.py
@@ -191,7 +191,7 @@ def prepare_gpt_oss_generator_args(
 )
 @run_for_wormhole_b0()
 @pytest.mark.parametrize(
-    "input_prompts, data_parallel, batch_size, repeat_batches, max_seq_len, max_generated_tokens, page_params, sampling_params, enable_decode_trace, enable_prefill_trace, warmup_prefill, users_row_sharded, long_context_mode, stop_at_eos",
+    "input_prompts, data_parallel, batch_size, repeat_batches, max_seq_len, max_generated_tokens, page_params, sampling_params, enable_decode_trace, enable_prefill_trace, warmup_prefill, users_row_sharded, long_context_mode, stop_at_eos, run_in_ci",
     [
         (
             "models/demos/gpt_oss/demo/sample_prompts/input_data_questions_prefill_128.json",  # input_prompts
@@ -208,6 +208,7 @@ def prepare_gpt_oss_generator_args(
             False,  # users_row_sharded
             False,  # long_context_mode
             True,  # stop_at_eos
+            True,  # run_in_ci
         ),
         (
             "models/tt_transformers/demo/sample_prompts/input_data_long_1k.json",  # input_prompts
@@ -224,6 +225,7 @@ def prepare_gpt_oss_generator_args(
             False,  # users_row_sharded
             False,  # long_context_mode
             True,  # stop_at_eos
+            True,  # run_in_ci
         ),
         (
             "models/tt_transformers/demo/sample_prompts/input_data_long_4k.json",  # input_prompts
@@ -240,56 +242,7 @@ def prepare_gpt_oss_generator_args(
             False,  # users_row_sharded
             False,  # long_context_mode
             True,  # stop_at_eos
-        ),
-        (
-            "models/demos/gpt_oss/demo/sample_prompts/input_data_questions_prefill_128.json",  # input_prompts
-            1,  # data_parallel
-            128,  # batch_size
-            1,  # repeat_batches
-            128 * 1024,  # max_seq_len
-            200,  # max_generated_tokens
-            {"page_block_size": 64, "page_max_num_blocks_per_dp": 128 * 1024 // 64},  # page_params
-            {"temperature": 0, "top_p": 0.08},  # sampling_params (greedy decoding)
-            True,  # enable_decode_trace
-            True,  # enable_prefill_trace
-            False,  # warmup_prefill
-            True,  # users_row_sharded
-            False,  # long_context_mode
-            True,  # stop_at_eos
-        ),
-        # Long-context mode: 1 user per row with 128k tokens, batch=128 for decode throughput
-        (
-            "models/tt_transformers/demo/sample_prompts/input_data_long_128k.json",  # input_prompts (128k prompt)
-            1,  # data_parallel
-            128,  # batch_size (32 per row, but only 1 real user per row)
-            1,  # repeat_batches
-            128 * 1024,  # max_seq_len (128k tokens)
-            50,  # max_generated_tokens (reduced for long context)
-            {"page_block_size": 64, "page_max_num_blocks_per_dp": 128 * 1024 // 64},  # 2048 blocks for 128k
-            {"temperature": 0, "top_p": 0.08},  # sampling_params (greedy decoding)
-            True,  # enable_decode_trace
-            False,  # enable_prefill_trace
-            False,  # warmup_prefill
-            True,  # users_row_sharded
-            True,  # long_context_mode - single user per row gets all page blocks
-            True,  # stop_at_eos
-        ),
-        # Long-context mode: short prefill, long decode
-        (
-            "models/demos/gpt_oss/demo/sample_prompts/input_data_questions_prefill_128.json",  # input_prompts (128 token prompt)
-            1,  # data_parallel
-            128,  # batch_size (32 per row, but only 1 real user per row)
-            1,  # repeat_batches
-            128 * 1024,  # max_seq_len (128k tokens)
-            130000,  # max_generated_tokens (reduced for long context)
-            {"page_block_size": 64, "page_max_num_blocks_per_dp": 128 * 1024 // 64},  # 2048 blocks for 128k
-            {"temperature": 0, "top_p": 0.08},  # sampling_params (greedy decoding)
-            True,  # enable_decode_trace
-            False,  # enable_prefill_trace
-            False,  # warmup_prefill
-            True,  # users_row_sharded
-            True,  # long_context_mode - single user per row gets all page blocks
-            False,  # stop_at_eos
+            False,  # run_in_ci
         ),
         (
             "models/tt_transformers/demo/sample_prompts/input_data_long_8k.json",  # input_prompts
@@ -306,6 +259,7 @@ def prepare_gpt_oss_generator_args(
             False,  # users_row_sharded
             False,  # long_context_mode
             False,  # stop_at_eos
+            False,  # run_in_ci
         ),
         (
             "models/tt_transformers/demo/sample_prompts/input_data_long_16k.json",  # input_prompts
@@ -322,6 +276,7 @@ def prepare_gpt_oss_generator_args(
             False,  # users_row_sharded
             False,  # long_context_mode
             False,  # stop_at_eos
+            False,  # run_in_ci
         ),
         (
             "models/tt_transformers/demo/sample_prompts/input_data_long_32k.json",  # input_prompts
@@ -338,6 +293,7 @@ def prepare_gpt_oss_generator_args(
             False,  # users_row_sharded
             False,  # long_context_mode
             False,  # stop_at_eos
+            False,  # run_in_ci
         ),
         (
             "models/tt_transformers/demo/sample_prompts/input_data_long_64k.json",  # input_prompts
@@ -354,6 +310,7 @@ def prepare_gpt_oss_generator_args(
             False,  # users_row_sharded
             False,  # long_context_mode
             False,  # stop_at_eos
+            True,  # run_in_ci
         ),
         # (
         #     "models/tt_transformers/demo/sample_prompts/input_data_long_128k.json",  # input_prompts
@@ -371,19 +328,72 @@ def prepare_gpt_oss_generator_args(
         #     False,  # long_context_mode
         #     False,  # stop_at_eos
         # ),
+        (
+            "models/demos/gpt_oss/demo/sample_prompts/input_data_questions_prefill_128.json",  # input_prompts
+            1,  # data_parallel
+            128,  # batch_size
+            1,  # repeat_batches
+            128 * 1024,  # max_seq_len
+            200,  # max_generated_tokens
+            {"page_block_size": 64, "page_max_num_blocks_per_dp": 128 * 1024 // 64},  # page_params
+            {"temperature": 0, "top_p": 0.08},  # sampling_params (greedy decoding)
+            True,  # enable_decode_trace
+            True,  # enable_prefill_trace
+            False,  # warmup_prefill
+            True,  # users_row_sharded
+            False,  # long_context_mode
+            True,  # stop_at_eos
+            True,  # run_in_ci
+        ),
+        # Long-context mode: 1 user per row with 128k tokens, batch=128 for decode throughput
+        (
+            "models/tt_transformers/demo/sample_prompts/input_data_long_128k.json",  # input_prompts (128k prompt)
+            1,  # data_parallel
+            128,  # batch_size (32 per row, but only 1 real user per row)
+            1,  # repeat_batches
+            128 * 1024,  # max_seq_len (128k tokens)
+            50,  # max_generated_tokens (reduced for long context)
+            {"page_block_size": 64, "page_max_num_blocks_per_dp": 128 * 1024 // 64},  # 2048 blocks for 128k
+            {"temperature": 0, "top_p": 0.08},  # sampling_params (greedy decoding)
+            True,  # enable_decode_trace
+            False,  # enable_prefill_trace
+            False,  # warmup_prefill
+            True,  # users_row_sharded
+            True,  # long_context_mode - single user per row gets all page blocks
+            True,  # stop_at_eos
+            False,  # run_in_ci
+        ),
+        # Long-context mode: short prefill, long decode
+        (
+            "models/demos/gpt_oss/demo/sample_prompts/input_data_questions_prefill_128.json",  # input_prompts (128 token prompt)
+            1,  # data_parallel
+            128,  # batch_size (32 per row, but only 1 real user per row)
+            1,  # repeat_batches
+            128 * 1024,  # max_seq_len (128k tokens)
+            130000,  # max_generated_tokens (reduced for long context)
+            {"page_block_size": 64, "page_max_num_blocks_per_dp": 128 * 1024 // 64},  # 2048 blocks for 128k
+            {"temperature": 0, "top_p": 0.08},  # sampling_params (greedy decoding)
+            True,  # enable_decode_trace
+            False,  # enable_prefill_trace
+            False,  # warmup_prefill
+            True,  # users_row_sharded
+            True,  # long_context_mode - single user per row gets all page blocks
+            False,  # stop_at_eos
+            False,  # run_in_ci
+        ),
     ],
     ids=[
         "prefill_128",
         "prefill_1k",
         "prefill_4k",
-        "batch128",
-        "long_context_128k",
-        "long_context_short_prefill_long_decode",
         "prefill_8k",
         "prefill_16k",
         "prefill_32k",
         "prefill_64k",
-        # "prefill_128k",
+        # "prefill_128k", # OOM
+        "batch128",
+        "long_context_128k",
+        "long_context_short_prefill_long_decode",
     ],
 )
 @parametrize_mesh_with_fabric()
@@ -405,6 +415,7 @@ def test_gpt_oss_demo(
     users_row_sharded,
     long_context_mode,
     stop_at_eos,
+    run_in_ci,
     is_ci_env,
     state_dict,
 ):
@@ -416,11 +427,8 @@ def test_gpt_oss_demo(
     if long_context_mode:
         assert batch_size >= mesh_shape[0], "Long-context mode requires batch_size >= number of mesh rows"
 
-    if mesh_shape[0] == 1 and max_seq_len > 16 * 1024:
-        pytest.skip(f"Prefill >16k demo skipped for single-row mesh since it doesn't fit in memory.")
-
-    if os.environ.get("CI", None) and long_context_mode:
-        pytest.skip(f"Long-context mode skipped for CI environment.")
+    if os.environ.get("CI", None) and not run_in_ci:
+        pytest.skip(f"This test configuration is skipped in CI.")
     mesh_device = mesh_device.create_submesh(ttnn.MeshShape(mesh_shape))
 
     # Use our refactored TestFactory for consistent setup

--- a/models/demos/gpt_oss/demo/text_demo.py
+++ b/models/demos/gpt_oss/demo/text_demo.py
@@ -518,10 +518,20 @@ def test_gpt_oss_demo(
         )
     if model_args[0].model_name.split("-")[-1] == "120b" and mesh_device.shape[0] == 1:
         if max([len(p) for p in real_prompts]) > 32 * 1024:
-            pytest.skip("120b model with mesh_shape (1, 8) and prefill > 32k is not supported. OOM error #38729")
-    if model_args[0].model_name.split("-")[-1] == "120b" and mesh_device.shape[0] == 8:
+            pytest.skip(
+                "120b model with mesh_shape (1, 8) and prefill > 32k is not supported. OOM error gh issue #38729"
+            )
+    if model_args[0].model_name.split("-")[-1] == "120b" and mesh_device.shape[0] == 4:
         if max([len(p) for p in real_prompts]) > 64 * 1024:
-            pytest.skip("120b model with mesh_shape (1, 8) and prefill > 64k is not supported. OOM error #38729")
+            pytest.skip(
+                "120b model with mesh_shape (4, 8) and prefill > 64k is not supported. OOM error gh issue #38728"
+            )
+    if model_args[0].model_name.split("-")[-1] == "20b" and mesh_device.shape[0] == 4:
+        if max([len(p) for p in real_prompts]) > 32 * 1024:
+            pytest.skip(
+                "20b model with mesh_shape (4, 8) and prefill > 32k is not supported. Determinstic hang gh issue #38751"
+            )
+
     if long_context_mode:
         # Expand to full batch: 1 real user + (users_per_row - 1) padding users per row
         # Padding users get minimal prompts (single token)

--- a/models/demos/gpt_oss/demo/text_demo.py
+++ b/models/demos/gpt_oss/demo/text_demo.py
@@ -312,22 +312,23 @@ def prepare_gpt_oss_generator_args(
             False,  # stop_at_eos
             True,  # run_in_ci
         ),
-        # (
-        #     "models/tt_transformers/demo/sample_prompts/input_data_long_128k.json",  # input_prompts
-        #     1,  # data_parallel
-        #     1,  # batch_size
-        #     1,  # repeat_batches
-        #     128 * 1024,  # max_seq_len
-        #     200,  # max_generated_tokens
-        #     {"page_block_size": 64, "page_max_num_blocks_per_dp": 128 * 1024 // 64},  # page_params
-        #     {"temperature": 0, "top_p": 0.08},  # sampling_params (greedy decoding),
-        #     True,  # enable_decode_trace
-        #     False,  # enable_prefill_trace
-        #     False,  # warmup_prefill
-        #     False,  # users_row_sharded
-        #     False,  # long_context_mode
-        #     False,  # stop_at_eos
-        # ),
+        (
+            "models/tt_transformers/demo/sample_prompts/input_data_long_128k.json",  # input_prompts
+            1,  # data_parallel
+            1,  # batch_size
+            1,  # repeat_batches
+            128 * 1024,  # max_seq_len
+            200,  # max_generated_tokens
+            {"page_block_size": 64, "page_max_num_blocks_per_dp": 128 * 1024 // 64},  # page_params
+            {"temperature": 0, "top_p": 0.08},  # sampling_params (greedy decoding),
+            True,  # enable_decode_trace
+            False,  # enable_prefill_trace
+            False,  # warmup_prefill
+            False,  # users_row_sharded
+            False,  # long_context_mode
+            False,  # stop_at_eos
+            True,  # run_in_ci
+        ),
         (
             "models/demos/gpt_oss/demo/sample_prompts/input_data_questions_prefill_128.json",  # input_prompts
             1,  # data_parallel
@@ -390,7 +391,7 @@ def prepare_gpt_oss_generator_args(
         "prefill_16k",
         "prefill_32k",
         "prefill_64k",
-        # "prefill_128k", # OOM
+        "prefill_128k",
         "batch128",
         "long_context_128k",
         "long_context_short_prefill_long_decode",
@@ -426,7 +427,6 @@ def test_gpt_oss_demo(
         )
     if long_context_mode:
         assert batch_size >= mesh_shape[0], "Long-context mode requires batch_size >= number of mesh rows"
-
     if os.environ.get("CI", None) and not run_in_ci:
         pytest.skip(f"This test configuration is skipped in CI.")
     mesh_device = mesh_device.create_submesh(ttnn.MeshShape(mesh_shape))
@@ -513,7 +513,12 @@ def test_gpt_oss_demo(
         raise ValueError(
             f"Invalid input prompts: {input_prompts}. Expected a list of prompts or a string path to a json file."
         )
-
+    if model_args[0].model_name.split("-")[-1] == "120b" and mesh_device.shape[0] == 1:
+        if max([len(p) for p in real_prompts]) > 32 * 1024:
+            pytest.skip("120b model with mesh_shape (1, 8) and prefill > 32k is not supported. OOM error #38729")
+    if model_args[0].model_name.split("-")[-1] == "120b" and mesh_device.shape[0] == 8:
+        if max([len(p) for p in real_prompts]) > 64 * 1024:
+            pytest.skip("120b model with mesh_shape (1, 8) and prefill > 64k is not supported. OOM error #38729")
     if long_context_mode:
         # Expand to full batch: 1 real user + (users_per_row - 1) padding users per row
         # Padding users get minimal prompts (single token)

--- a/models/demos/gpt_oss/demo/text_demo.py
+++ b/models/demos/gpt_oss/demo/text_demo.py
@@ -191,7 +191,7 @@ def prepare_gpt_oss_generator_args(
 )
 @run_for_wormhole_b0()
 @pytest.mark.parametrize(
-    "input_prompts, data_parallel, batch_size, repeat_batches, max_seq_len, max_generated_tokens, page_params, sampling_params, enable_decode_trace, enable_prefill_trace, users_row_sharded, long_context_mode, stop_at_eos",
+    "input_prompts, data_parallel, batch_size, repeat_batches, max_seq_len, max_generated_tokens, page_params, sampling_params, enable_decode_trace, enable_prefill_trace, warmup_prefill, users_row_sharded, long_context_mode, stop_at_eos",
     [
         (
             "models/demos/gpt_oss/demo/sample_prompts/input_data_questions_prefill_128.json",  # input_prompts
@@ -204,6 +204,7 @@ def prepare_gpt_oss_generator_args(
             {"temperature": 0, "top_p": 0.08},  # sampling_params (greedy decoding),
             True,  # enable_decode_trace
             True,  # enable_prefill_trace
+            False,  # warmup_prefill
             False,  # users_row_sharded
             False,  # long_context_mode
             True,  # stop_at_eos
@@ -219,6 +220,7 @@ def prepare_gpt_oss_generator_args(
             {"temperature": 0, "top_p": 0.08},  # sampling_params (greedy decoding)
             True,  # enable_decode_trace
             True,  # enable_prefill_trace
+            False,  # warmup_prefill
             False,  # users_row_sharded
             False,  # long_context_mode
             True,  # stop_at_eos
@@ -234,6 +236,7 @@ def prepare_gpt_oss_generator_args(
             {"temperature": 0, "top_p": 0.08},  # sampling_params (greedy decoding)
             True,  # enable_decode_trace
             True,  # enable_prefill_trace
+            False,  # warmup_prefill
             False,  # users_row_sharded
             False,  # long_context_mode
             True,  # stop_at_eos
@@ -249,6 +252,7 @@ def prepare_gpt_oss_generator_args(
             {"temperature": 0, "top_p": 0.08},  # sampling_params (greedy decoding)
             True,  # enable_decode_trace
             True,  # enable_prefill_trace
+            False,  # warmup_prefill
             True,  # users_row_sharded
             False,  # long_context_mode
             True,  # stop_at_eos
@@ -265,6 +269,7 @@ def prepare_gpt_oss_generator_args(
             {"temperature": 0, "top_p": 0.08},  # sampling_params (greedy decoding)
             True,  # enable_decode_trace
             False,  # enable_prefill_trace
+            False,  # warmup_prefill
             True,  # users_row_sharded
             True,  # long_context_mode - single user per row gets all page blocks
             True,  # stop_at_eos
@@ -281,6 +286,7 @@ def prepare_gpt_oss_generator_args(
             {"temperature": 0, "top_p": 0.08},  # sampling_params (greedy decoding)
             True,  # enable_decode_trace
             False,  # enable_prefill_trace
+            False,  # warmup_prefill
             True,  # users_row_sharded
             True,  # long_context_mode - single user per row gets all page blocks
             False,  # stop_at_eos
@@ -296,6 +302,7 @@ def prepare_gpt_oss_generator_args(
             {"temperature": 0, "top_p": 0.08},  # sampling_params (greedy decoding)
             True,  # enable_decode_trace
             True,  # enable_prefill_trace
+            False,  # warmup_prefill
             False,  # users_row_sharded
             False,  # long_context_mode
             False,  # stop_at_eos
@@ -311,6 +318,7 @@ def prepare_gpt_oss_generator_args(
             {"temperature": 0, "top_p": 0.08},  # sampling_params (greedy decoding)
             True,  # enable_decode_trace
             True,  # enable_prefill_trace
+            False,  # warmup_prefill
             False,  # users_row_sharded
             False,  # long_context_mode
             False,  # stop_at_eos
@@ -326,25 +334,27 @@ def prepare_gpt_oss_generator_args(
             {"temperature": 0, "top_p": 0.08},  # sampling_params (greedy decoding)
             True,  # enable_decode_trace
             True,  # enable_prefill_trace
+            False,  # warmup_prefill
             False,  # users_row_sharded
             False,  # long_context_mode
             False,  # stop_at_eos
         ),
-        # (
-        #     "models/tt_transformers/demo/sample_prompts/input_data_long_64k.json",  # input_prompts
-        #     1,  # data_parallel
-        #     1,  # batch_size
-        #     1,  # repeat_batches
-        #     64 * 1024,  # max_seq_len
-        #     200,  # max_generated_tokens
-        #     {"page_block_size": 64, "page_max_num_blocks_per_dp": 64 * 1024 // 64},  # page_params
-        #     {"temperature": 0, "top_p": 0.08},  # sampling_params (greedy decoding),
-        #     True,  # enable_decode_trace
-        #     True,  # enable_prefill_trace
-        #     False,  # users_row_sharded
-        #     True,  # long_context_mode
-        #     False,  # stop_at_eos
-        # ),
+        (
+            "models/tt_transformers/demo/sample_prompts/input_data_long_64k.json",  # input_prompts
+            1,  # data_parallel
+            1,  # batch_size
+            1,  # repeat_batches
+            64 * 1024,  # max_seq_len
+            200,  # max_generated_tokens
+            {"page_block_size": 64, "page_max_num_blocks_per_dp": 64 * 1024 // 64},  # page_params
+            {"temperature": 0, "top_p": 0.08},  # sampling_params (greedy decoding),
+            True,  # enable_decode_trace
+            False,  # enable_prefill_trace
+            False,  # warmup_prefill
+            False,  # users_row_sharded
+            False,  # long_context_mode
+            False,  # stop_at_eos
+        ),
         # (
         #     "models/tt_transformers/demo/sample_prompts/input_data_long_128k.json",  # input_prompts
         #     1,  # data_parallel
@@ -355,9 +365,10 @@ def prepare_gpt_oss_generator_args(
         #     {"page_block_size": 64, "page_max_num_blocks_per_dp": 128 * 1024 // 64},  # page_params
         #     {"temperature": 0, "top_p": 0.08},  # sampling_params (greedy decoding),
         #     True,  # enable_decode_trace
-        #     True,  # enable_prefill_trace
+        #     False,  # enable_prefill_trace
+        #     False,  # warmup_prefill
         #     False,  # users_row_sharded
-        #     True,  # long_context_mode
+        #     False,  # long_context_mode
         #     False,  # stop_at_eos
         # ),
     ],
@@ -371,8 +382,8 @@ def prepare_gpt_oss_generator_args(
         "prefill_8k",
         "prefill_16k",
         "prefill_32k",
-        # "prefill_64k", #OOM error
-        # "prefill_128k", #OOM error
+        "prefill_64k",
+        # "prefill_128k",
     ],
 )
 @parametrize_mesh_with_fabric()
@@ -390,6 +401,7 @@ def test_gpt_oss_demo(
     sampling_params,
     enable_decode_trace,
     enable_prefill_trace,
+    warmup_prefill,
     users_row_sharded,
     long_context_mode,
     stop_at_eos,
@@ -943,7 +955,7 @@ def test_gpt_oss_demo(
                 kv_cache=tt_kv_cache,
                 prompt_lens=decoding_pos,
                 enable_trace=enable_prefill_trace,
-                warmup_prefill=False,
+                warmup_prefill=warmup_prefill,
             )
             profiler.end(f"compile_prefill", iteration=batch_idx)
             logger.info("Finished prefill warmup")
@@ -956,7 +968,7 @@ def test_gpt_oss_demo(
                 kv_cache=tt_kv_cache,
                 prompt_lens=decoding_pos,
                 enable_trace=enable_prefill_trace,
-                warmup_prefill=False,
+                warmup_prefill=warmup_prefill,
             )
             prefilled_token = torch.argmax(logits, dim=-1)
             profiler.end(f"inference_prefill", iteration=batch_idx)

--- a/models/demos/gpt_oss/demo/text_demo.py
+++ b/models/demos/gpt_oss/demo/text_demo.py
@@ -302,7 +302,7 @@ def prepare_gpt_oss_generator_args(
             1,  # repeat_batches
             64 * 1024,  # max_seq_len
             200,  # max_generated_tokens
-            {"page_block_size": 64, "page_max_num_blocks_per_dp": 64 * 1024 // 64},  # page_params
+            {"page_block_size": 64, "page_max_num_blocks_per_dp": 128 * 1024 // 64},  # page_params
             {"temperature": 0, "top_p": 0.08},  # sampling_params (greedy decoding),
             True,  # enable_decode_trace
             False,  # enable_prefill_trace
@@ -329,6 +329,7 @@ def prepare_gpt_oss_generator_args(
             False,  # stop_at_eos
             True,  # run_in_ci
         ),
+        # Batch 128
         (
             "models/demos/gpt_oss/demo/sample_prompts/input_data_questions_prefill_128.json",  # input_prompts
             1,  # data_parallel
@@ -418,6 +419,7 @@ def test_gpt_oss_demo(
     stop_at_eos,
     run_in_ci,
     is_ci_env,
+    request,
     state_dict,
 ):
     """GPT-OSS demo using full tt_transformers generation pipeline"""
@@ -428,7 +430,8 @@ def test_gpt_oss_demo(
     if long_context_mode:
         assert batch_size >= mesh_shape[0], "Long-context mode requires batch_size >= number of mesh rows"
     if os.environ.get("CI", None) and not run_in_ci:
-        pytest.skip(f"This test configuration is skipped in CI.")
+        config_id = request.node.callspec.id if hasattr(request.node, "callspec") else request.node.name
+        pytest.skip(f"This test configuration is skipped in CI: {config_id}")
     mesh_device = mesh_device.create_submesh(ttnn.MeshShape(mesh_shape))
 
     # Use our refactored TestFactory for consistent setup

--- a/models/demos/gpt_oss/tests/unit/test_modules.py
+++ b/models/demos/gpt_oss/tests/unit/test_modules.py
@@ -944,6 +944,11 @@ def test_model(mesh_device, device_params, batch_size, seq_len, mode, mesh_shape
     from models.demos.gpt_oss.config import MeshConfig, ModeConfig
     from models.demos.gpt_oss.tt.model_config import ModelArgs
 
+    if mesh_shape[0] == 1 and batch_size > 1:
+        pytest.skip(
+            f"Skipping batch size {batch_size} for mesh shape {mesh_shape}. Only batch size 1 is supported for mesh shape (1, 8)."
+        )
+
     is_decode = mode == "decode"
 
     # Create submesh with specified shape

--- a/models/demos/gpt_oss/tests/unit/test_modules.py
+++ b/models/demos/gpt_oss/tests/unit/test_modules.py
@@ -779,7 +779,7 @@ def run_model_forward_test(
         local_batch_size = batch_size
 
     # Create CCL manager
-    ccl_manager = CCLManager(mesh_device)
+    ccl_manager = CCLManager(mesh_device, num_links=4 if mesh_device.shape[0] > 1 else 1)
 
     # Create TT model with meta format weights
     # Use throughput experts for row-sharded batches (batch > 32 on multi-row mesh)
@@ -864,14 +864,13 @@ def run_model_forward_test(
         )
 
     # Convert TT output to torch
-    mesh_composer_dims = (-2, 1) if is_row_sharded else (0, 1)
+    mesh_composer_dims = (-2, -1) if is_row_sharded else (0, -1)
     tt_logits_torch = ttnn.to_torch(
         tt_logits,
         mesh_composer=ttnn.ConcatMesh2dToTensor(
             mesh_device, dims=mesh_composer_dims, mesh_shape=tuple(mesh_device.shape)
         ),
     )
-
     # Slice to match reference shape
     tt_logits_torch = tt_logits_torch[0, 0]
 

--- a/models/demos/gpt_oss/tt/attention/prefill.py
+++ b/models/demos/gpt_oss/tt/attention/prefill.py
@@ -108,11 +108,16 @@ def prefill_forward(
             ttnn.experimental.paged_fill_cache(v_cache, v_fill, page_table_flat, batch_idx=0)
             k_fill.deallocate(True)
             v_fill.deallocate(True)
+            page_table_flat.deallocate(True)
         else:
             tt_k_sliced = tt_k[:, :, :page_len, :] if page_len < tt_k.shape[2] else tt_k
             tt_v_sliced = tt_v[:, :, :page_len, :] if page_len < tt_v.shape[2] else tt_v
             ttnn.experimental.paged_fill_cache(k_cache, tt_k_sliced, page_table, batch_idx=user_id)
             ttnn.experimental.paged_fill_cache(v_cache, tt_v_sliced, page_table, batch_idx=user_id)
+            if page_len < tt_k.shape[2]:
+                tt_k_sliced.deallocate(True)
+            if page_len < tt_v.shape[2]:
+                tt_v_sliced.deallocate(True)
 
     else:
         # Non-paged attention

--- a/models/demos/gpt_oss/tt/ccl.py
+++ b/models/demos/gpt_oss/tt/ccl.py
@@ -5,7 +5,7 @@ import ttnn
 
 
 class CCLManager:
-    def __init__(self, mesh_device, num_links=4, topology=ttnn.Topology.Ring):
+    def __init__(self, mesh_device, num_links, topology=ttnn.Topology.Ring):
         self.mesh_device = mesh_device
         self.num_links = num_links
         self.topology = topology

--- a/models/demos/gpt_oss/tt/experts/operations.py
+++ b/models/demos/gpt_oss/tt/experts/operations.py
@@ -68,9 +68,11 @@ def reduce_experts(expert_output):
 
 def apply_expert_parallel_allreduce(tensor, mesh_config, ccl_manager):
     """Apply expert parallel allreduce communication."""
-    return ttnn.all_reduce(
+    tensor_allreduced = ttnn.all_reduce(
         tensor, num_links=ccl_manager.num_links, topology=ttnn.Topology.Ring, cluster_axis=mesh_config.ep_axis
     )
+    tensor.deallocate(True)
+    return tensor_allreduced
 
 
 def apply_tensor_parallel_allreduce(tensor, mesh_config, mesh_device, seq_len, ccl_manager):
@@ -101,6 +103,8 @@ def apply_tensor_parallel_allreduce(tensor, mesh_config, mesh_device, seq_len, c
 
 def apply_sequence_parallel_allgather(tensor, mesh_config, ccl_manager):
     """Apply sequence parallel allgather communication."""
-    return ttnn.all_gather(
+    tensor_gathered = ttnn.all_gather(
         tensor, dim=-2, num_links=ccl_manager.num_links, topology=ttnn.Topology.Ring, cluster_axis=mesh_config.sp_axis
     )
+    tensor.deallocate(True)
+    return tensor_gathered


### PR DESCRIPTION
## Summary
- Deallocate large intermediate tensors earlier in GPT-OSS attention and experts prefill paths to reduce peak DRAM usage.
- Replace list-based accumulation in chunk/split prefill paths with streaming concatenation so intermediate outputs are freed promptly.
- Re-comment the `prefill_128k` demo test case/id in `text_demo.py` to keep the low-latency prefill test matrix aligned with currently stable coverage (up to `prefill_64k`).
- File issues and skip demo tests for hanging prefill case (20b on WH GLX > 32k prefill #38751)
- File issues and skip demo tests for OOM prefill case (120b on WH GLX > 64k prefill #38728 and T3K > 32k prefill #38729) 

## Why
These changes reduce avoidable DRAM residency from transient intermediates in the low-latency prefill path, enabling GPT-OSS low-latency prefill runs up to 64k reliably while leaving 128k disabled for now.

## Test plan
- [x] Run: `HF_MODEL=/proj_sw/user_dev/gpt-oss-weights/gpt-oss-120b pytest models/demos/gpt_oss/demo/text_demo.py -k "4x8 and prefill_64k" --timeout 9999`
- [x] Run: `HF_MODEL=/proj_sw/user_dev/gpt-oss-weights/gpt-oss-20b pytest models/demos/gpt_oss/demo/text_demo.py -k "4x8 and prefill_64k" --timeout 9999`
- [x] Confirm `prefill_128k` is not selected in the demo parametrization.


- [ ] [![(Galaxy) demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml/badge.svg?branch=handrews/gpt-oss-dram-dealloc-64k-prefill)](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml?query=branch:handrews/gpt-oss-dram-dealloc-64k-prefill)
- [ ] [![(T3K) T3000 demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml/badge.svg?branch=handrews/gpt-oss-dram-dealloc-64k-prefill)](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml?query=branch:handrews/gpt-oss-dram-dealloc-64k-prefill)
- [ ] [![(T3K) T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml/badge.svg?branch=handrews/gpt-oss-dram-dealloc-64k-prefill)](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml?query=branch:handrews/gpt-oss-dram-dealloc-64k-prefill)
- [ ] [![(Galaxy) unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-unit-tests.yaml/badge.svg?branch=handrews/gpt-oss-dram-dealloc-64k-prefill)](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-unit-tests.yaml?query=branch:handrews/gpt-oss-dram-dealloc-64k-prefill)
