### PR TITLE
Esmal/hf weight dequant

### DIFF
--- a/DEEPSEEK_WEIGHT_DEQUANTIZATION_PLAN.md
+++ b/DEEPSEEK_WEIGHT_DEQUANTIZATION_PLAN.md
@@ -181,6 +181,7 @@ Implemented arguments:
 - `--keep-scale-inv`: retain `*_scale_inv` keys.
 - `--overwrite`: allow writing into non-empty output directory.
 - `--max-output-shard-size-mb`: output shard flush budget (default `5120` = 5 GiB).
+- `--num-workers`: number of parallel source-shard conversion workers (default `1`).
 
 Behavior rules:
 
@@ -229,7 +230,8 @@ Preflight:
 ## Time
 
 - Dominated by tensor IO and dequantization compute.
-- Parallelism should be conservative in v1 to avoid memory spikes.
+- Worker-level source-shard parallelism is available via `--num-workers`.
+- Keep `--num-workers` conservative relative to host RAM and storage bandwidth.
 
 ## Validation Plan
 

--- a/DEEPSEEK_WEIGHT_DEQUANTIZATION_PLAN.md
+++ b/DEEPSEEK_WEIGHT_DEQUANTIZATION_PLAN.md
@@ -182,6 +182,7 @@ Implemented arguments:
 - `--overwrite`: allow writing into non-empty output directory.
 - `--max-output-shard-size-mb`: output shard flush budget (default `5120` = 5 GiB).
 - `--num-workers`: number of parallel source-shard conversion workers (default `1`).
+- `--resume`: reuse completed temporary shard outputs from prior interrupted runs.
 
 Behavior rules:
 

--- a/DEEPSEEK_WEIGHT_DEQUANTIZATION_PLAN.md
+++ b/DEEPSEEK_WEIGHT_DEQUANTIZATION_PLAN.md
@@ -1,0 +1,386 @@
+# DeepSeek Weight Dequantization Plan
+
+## Motivation
+
+We need a reliable way to convert DeepSeek-V3 Hugging Face checkpoints from mixed FP8+scale format into a dequantized safetensors checkpoint that:
+
+- keeps non-quantized tensors unchanged,
+- dequantizes quantized tensors using their `*_scale_inv` companions,
+- and writes a valid sharded safetensors checkpoint back to disk.
+
+The output must remain in standard HF safetensors layout so existing loaders continue to work.
+
+## Goals
+
+- Download a DeepSeek-V3-compatible checkpoint from Hugging Face (or use a local checkpoint).
+- Dequantize all tensors that have corresponding `*_scale_inv` tensors.
+- Preserve all other tensors unchanged except optional dtype normalization.
+- Write output as safetensors shards plus `model.safetensors.index.json`.
+- Keep memory bounded by processing shard-by-shard, not full-model materialization.
+- Provide deterministic, automatable validation.
+- Provide a fast test workflow that does not require full DeepSeek weights.
+
+## Current Status
+
+Implemented in:
+
+- `models/demos/deepseek_v3/scripts/dequantize_hf_checkpoint.py`
+- `models/demos/deepseek_v3/tests/test_deepseek_weight_dequantization.py`
+
+Current behavior is strict and fail-fast:
+
+- FP8 tensors must have matching `*_scale_inv` tensors.
+- Orphan scale tensors are rejected during preflight.
+- Index/shard mismatches are rejected before conversion starts.
+- Input and output directories must be different.
+
+## Non-goals
+
+- Changing tensor names or model architecture.
+- Repartitioning model parallel structure or reshaping tensors.
+- Producing TTNN cache artifacts.
+- Supporting arbitrary quantization schemes beyond DeepSeek’s FP8 + inverse-scale block dequantization.
+- Optimizing for maximum throughput in v1 over correctness and robustness.
+
+## Current Repo Primitives to Reuse
+
+- Dequantization primitive:
+  - `models/demos/deepseek_v3/utils/config_helpers.py` (`dequantize`).
+- Quantized-state helpers:
+  - `models/demos/deepseek_v3/utils/test_utils.py` (`add_inv_scale_to_state_dict`, `dequantize_state_dict`).
+- Lazy/indexed safetensors access pattern:
+  - `models/demos/deepseek_v3/utils/lazy_state_dict.py`.
+- HF download pattern:
+  - `scripts/download_hf_artifacts.py` (uses `snapshot_download`).
+
+Reusing these avoids diverging from existing DeepSeek logic in the repo.
+
+## Functional Requirements
+
+- Input modes:
+  - HF repo id (`--repo-id`) + optional token.
+  - Pre-downloaded local directory (`--input-dir`).
+- Output mode:
+  - Directory containing sharded safetensors and index JSON.
+- Dequantization behavior:
+  - For each key `k`, if `k_scale_inv` exists, dequantize `k`.
+  - By default, omit `*_scale_inv` tensors from output.
+  - Optionally retain `*_scale_inv` tensors via flag.
+- Dtype behavior:
+  - Default output dtype for dequantized tensors: `bfloat16`.
+  - Non-quantized tensors can be left unchanged by default.
+- Compatibility:
+  - Output directory should be consumable by standard HF safetensors loading.
+
+## Inputs and Outputs
+
+## Input Checkpoint Layout
+
+- `model.safetensors.index.json` with `weight_map`.
+- One or more shard files like `model-00001-of-000NN.safetensors`.
+- `config.json` with `quantization_config.weight_block_size`.
+- Optional tokenizer and metadata files.
+
+## Output Checkpoint Layout
+
+- Updated shard files in safetensors format.
+- Updated `model.safetensors.index.json`.
+- Copied config/tokenizer/auxiliary files from input.
+
+## Output Invariants
+
+- Every output tensor key maps to exactly one output shard.
+- Every entry in output `weight_map` exists on disk.
+- All dequantized tensors are no longer FP8 payload tensors.
+- If `--keep-scale-inv` is false, no `*_scale_inv` keys remain.
+
+## Dequantization Semantics
+
+Given:
+
+- quantized tensor `W`
+- inverse-scale tensor `S_inv`
+- block shape `[Bh, Bw]` from config
+
+Use the exact repo helper behavior:
+
+- repeat/interleave inverse scales to tensor resolution,
+- multiply elementwise in float,
+- crop to original shape,
+- cast to target dtype.
+
+This matches existing behavior in `dequantize(...)` and avoids algorithm drift.
+
+## High-level Architecture
+
+The converter is a host-only Python script:
+
+1. Resolve input checkpoint location.
+2. Read config + index metadata.
+3. Run preflight structural validation.
+4. Iterate shards in deterministic order.
+4. For each tensor key in shard:
+   - load source tensor lazily,
+   - load `*_scale_inv` lazily if needed (possibly from another shard),
+   - dequantize or pass-through,
+   - append to an incremental output buffer.
+5. Flush buffered output to safetensors shards by byte budget.
+6. Emit updated index JSON.
+7. Copy auxiliary non-weight files.
+
+## Data Access Strategy
+
+Use cached `safe_open` handles keyed by filename:
+
+- avoids reopening/mmap churn,
+- supports cross-shard `k` + `k_scale_inv` lookup,
+- keeps memory bounded to active tensors.
+
+No full-state-dict materialization is allowed in default flow.
+
+## Sharding Strategy
+
+Output shards are rebuilt by size budget:
+
+- Tensors are buffered and flushed when `--max-output-shard-size-mb` budget is reached.
+- Temporary shards are renamed into canonical names:
+  - `model-00001-of-000NN.safetensors`, etc.
+- `weight_map` is regenerated from emitted output keys.
+- `k_scale_inv` keys are dropped unless `--keep-scale-inv`.
+
+Benefits:
+
+- bounded output buffering memory,
+- deterministic, canonical shard naming,
+- robust behavior for very large checkpoints.
+
+## Index Rewrite Strategy
+
+Build new `weight_map` as keys are emitted.
+
+Output index fields:
+
+- `weight_map`: regenerated from emitted keys.
+- `metadata.total_size`: recomputed from output tensors.
+- preserve any unknown metadata fields where safe.
+
+## CLI Design
+
+Script:
+
+- `models/demos/deepseek_v3/scripts/dequantize_hf_checkpoint.py`
+
+Implemented arguments:
+
+- `--repo-id`: HF repo id, optional when `--input-dir` is provided.
+- `--input-dir`: local checkpoint path, optional when `--repo-id` is provided.
+- `--output-dir`: required.
+- `--hf-token`: optional.
+- `--cache-dir`: optional.
+- `--dtype`: `bfloat16|float16|float32` for dequantized tensors.
+- `--keep-scale-inv`: retain `*_scale_inv` keys.
+- `--overwrite`: allow writing into non-empty output directory.
+- `--max-output-shard-size-mb`: output shard flush budget (default `5120` = 5 GiB).
+
+Behavior rules:
+
+- exactly one of `--repo-id`, `--input-dir` is required.
+- input and output directories must be different.
+- fail fast on structural inconsistencies before conversion.
+- deterministic processing order.
+
+## Error Handling Policy
+
+Hard errors (default fail):
+
+- missing `model.safetensors.index.json`,
+- missing shard referenced by index,
+- index key not present in referenced shard,
+- orphan `*_scale_inv` without matching base key,
+- missing scale tensor when a quantized tensor is expected to dequantize,
+- non-FP8 tensor paired with `*_scale_inv`,
+- non-floating-point `*_scale_inv`,
+- incompatible tensor/scale dimensionality for block dequantization,
+- invalid output directory state without `--overwrite`.
+
+Soft handling:
+
+- none for missing-scale on FP8 tensors; conversion must fail to avoid silent corruption.
+
+## Performance and Resource Plan
+
+## Memory
+
+- Stream per tensor and per shard.
+- Keep small handle cache for source shards.
+- Bound output buffering with `--max-output-shard-size-mb`.
+- Avoid full checkpoint load.
+
+## Disk
+
+Expected output size can be significantly larger than FP8 input.
+
+Preflight:
+
+- estimate output bytes using source dtypes and target dtype policy,
+- compare with free disk space,
+- fail early with actionable error message.
+
+## Time
+
+- Dominated by tensor IO and dequantization compute.
+- Parallelism should be conservative in v1 to avoid memory spikes.
+
+## Validation Plan
+
+## Runtime Validation in Script
+
+- Preflight validation of index/shard consistency.
+- Strict FP8/scale pairing checks.
+- Tensor accounting summary logs (`seen`, `dequantized`, `passthrough`, `scales_kept`).
+- Emit regenerated index with recomputed `metadata.total_size`.
+
+## Automated Tests
+
+### 1) Unit: Synthetic Tiny Checkpoint (Primary Fast Path)
+
+Create a tiny synthetic DeepSeek-style checkpoint in temp dir:
+
+- include several quantized keys with `*_scale_inv`,
+- include several normal non-quantized keys,
+- split across 2+ shards,
+- include at least one cross-shard pair:
+  - `k` in shard A, `k_scale_inv` in shard B.
+
+Generation approach:
+
+- Build small torch tensors.
+- Use `add_inv_scale_to_state_dict(...)` for realistic quantized payload generation where possible.
+- Save shards with `safetensors.torch.save_file`.
+- Write index JSON with `weight_map`.
+
+Assertions:
+
+- converted keys match expected set,
+- dequantized values match `dequantize(...)` reference,
+- pass-through values unchanged,
+- output index valid,
+- `*_scale_inv` dropped/retained according to flag.
+
+### 2) Unit: Negative Cases
+
+- missing shard file referenced by index,
+- missing `k_scale_inv`,
+- orphan `k_scale_inv` without base tensor,
+- non-FP8 tensor with `k_scale_inv`,
+- index key missing in referenced shard,
+- input_dir == output_dir,
+- malformed block shape,
+- corrupt index JSON.
+
+### 3) Integration: Optional Small Real Model
+
+Optional smoke test using a small local HF checkpoint that has safetensors, only to verify CLI plumbing and index rewriting. This does not replace synthetic quantized tests.
+
+## Test Execution Note
+
+Because tests live under `models/demos/deepseek_v3/tests/`, they inherit DeepSeek collection hooks that require `MESH_DEVICE` to be set during collection. For host-only smoke tests, run:
+
+```bash
+MESH_DEVICE=N150 pytest -q models/demos/deepseek_v3/tests/test_deepseek_weight_dequantization.py
+```
+
+## Why Tiny Synthetic Checkpoints Are the Main Test Strategy
+
+Small public models usually do not use DeepSeek-style FP8+`_scale_inv` layout, so they cannot test the dequantization path. Synthetic checkpoints let us:
+
+- test the exact dequantization logic,
+- test cross-shard lookup edge cases,
+- and run quickly in CI.
+
+## Implementation Plan
+
+## Phase 1: Script Skeleton and IO
+
+- Add CLI parser and argument validation.
+- Add input resolver (`snapshot_download` or local path).
+- Add index/config loader.
+- Add output directory creation and metadata copy.
+
+## Phase 2: Dequantization Pipeline
+
+- Add shard handle cache.
+- Add tensor conversion loop.
+- Add shard writer and index rewrite.
+
+## Phase 3: Validation and Diagnostics
+
+- Add key accounting checks.
+- Add optional sampling-based numeric checks.
+- Add dry-run and disk preflight reporting.
+
+## Phase 4: Tests
+
+- Add synthetic checkpoint builder fixture.
+- Add core conversion tests.
+- Add failure-mode tests.
+
+## Phase 5: Documentation
+
+- Add usage examples to DeepSeek README or script docstring.
+- Add troubleshooting notes.
+
+## Acceptance Criteria
+
+- Script converts a synthetic sharded checkpoint end-to-end and passes tests.
+- Output checkpoint loads with safetensors and has valid index map.
+- Dequantized tensors numerically match reference dequantization.
+- Non-quantized tensors remain unchanged.
+- Script handles cross-shard scale lookup correctly.
+- Disk/missing-file failures are clear and actionable.
+
+## Example Commands
+
+Local checkpoint:
+
+```bash
+python models/demos/deepseek_v3/scripts/dequantize_hf_checkpoint.py \
+  --input-dir /path/to/deepseek-checkpoint \
+  --output-dir /path/to/deepseek-checkpoint-dequantized \
+  --max-output-shard-size-mb 5120
+```
+
+HF download + convert:
+
+```bash
+python models/demos/deepseek_v3/scripts/dequantize_hf_checkpoint.py \
+  --repo-id deepseek-ai/DeepSeek-R1-0528 \
+  --output-dir /path/to/dequantized-out \
+  --hf-token $HF_TOKEN
+```
+
+## Risks and Mitigations
+
+- Risk: output size explosion.
+  - Mitigation: preflight disk estimate and fail-fast.
+- Risk: cross-shard scale lookup bugs.
+  - Mitigation: explicit cross-shard synthetic tests.
+- Risk: behavior mismatch with existing DeepSeek dequantization.
+  - Mitigation: call existing `dequantize(...)` helper directly.
+- Risk: accidental metadata incompatibility.
+  - Mitigation: preserve non-conflicting metadata and validate index.
+
+## Open Questions
+
+- Should non-quantized tensors be cast to target dtype or remain original dtype by default?
+- Should `*_scale_inv` be retained by default for auditability, or dropped by default for size?
+- Should we support writing a single `model.safetensors` output mode in addition to sharded output?
+
+## Recommended Defaults for V1
+
+- Dequantize only tensors with matching `*_scale_inv`.
+- Drop `*_scale_inv` keys by default.
+- Cast dequantized tensors to `bfloat16`.
+- Leave non-quantized tensors unchanged.
+- Fail on missing scale for FP8 tensors.
+- Use output shard size budget of 5 GiB (`--max-output-shard-size-mb=5120`).

--- a/models/demos/deepseek_v3/scripts/dequantize_hf_checkpoint.py
+++ b/models/demos/deepseek_v3/scripts/dequantize_hf_checkpoint.py
@@ -1,0 +1,512 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+from collections import defaultdict
+from pathlib import Path
+from typing import Any
+
+import torch
+from loguru import logger
+from safetensors import safe_open
+from safetensors.torch import save_file
+
+FP8_DTYPES: tuple[torch.dtype, ...] = (torch.float8_e4m3fn,)
+if hasattr(torch, "float8_e5m2"):
+    FP8_DTYPES = FP8_DTYPES + (torch.float8_e5m2,)
+
+
+def format_bytes(num_bytes: int) -> str:
+    units = ("B", "KiB", "MiB", "GiB", "TiB")
+    value = float(num_bytes)
+    unit = units[0]
+    for unit in units:
+        if value < 1024.0 or unit == units[-1]:
+            break
+        value /= 1024.0
+    return f"{value:.2f} {unit}"
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=("Download (optional), dequantize, and rewrite a DeepSeek-style sharded " "safetensors checkpoint.")
+    )
+    parser.add_argument(
+        "--repo-id",
+        type=str,
+        default=None,
+        help="Hugging Face repo id (use this OR --input-dir).",
+    )
+    parser.add_argument(
+        "--input-dir",
+        type=Path,
+        default=None,
+        help="Local checkpoint directory containing model.safetensors.index.json.",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        required=True,
+        help="Output directory for the dequantized safetensors checkpoint.",
+    )
+    parser.add_argument(
+        "--hf-token",
+        type=str,
+        default=None,
+        help="Optional Hugging Face token for gated/private repos.",
+    )
+    parser.add_argument(
+        "--cache-dir",
+        type=Path,
+        default=None,
+        help="Optional HF cache directory used when --repo-id is provided.",
+    )
+    parser.add_argument(
+        "--dtype",
+        choices=("bfloat16", "float16", "float32"),
+        default="bfloat16",
+        help="Output dtype for dequantized tensors only.",
+    )
+    parser.add_argument(
+        "--keep-scale-inv",
+        action="store_true",
+        help="Keep *_scale_inv tensors in output.",
+    )
+    parser.add_argument(
+        "--overwrite",
+        action="store_true",
+        help="Allow writing into a non-empty output directory.",
+    )
+    parser.add_argument(
+        "--max-output-shard-size-mb",
+        type=int,
+        default=5120,
+        help=(
+            "Maximum size in MiB for each output safetensors shard. "
+            "Lower values reduce peak host memory usage during conversion."
+        ),
+    )
+    return parser.parse_args()
+
+
+def parse_torch_dtype(dtype: str) -> torch.dtype:
+    mapping = {
+        "bfloat16": torch.bfloat16,
+        "float16": torch.float16,
+        "float32": torch.float32,
+    }
+    return mapping[dtype]
+
+
+def validate_args(args: argparse.Namespace) -> None:
+    has_repo = args.repo_id is not None
+    has_input = args.input_dir is not None
+    if has_repo == has_input:
+        raise ValueError("Provide exactly one of --repo-id or --input-dir.")
+    if args.max_output_shard_size_mb <= 0:
+        raise ValueError("--max-output-shard-size-mb must be > 0.")
+
+
+def resolve_input_dir(args: argparse.Namespace) -> Path:
+    if args.input_dir is not None:
+        input_dir = args.input_dir.expanduser().resolve()
+        if not input_dir.is_dir():
+            raise FileNotFoundError(f"--input-dir does not exist or is not a directory: {input_dir}")
+        logger.info(f"Using local input checkpoint: {input_dir}")
+        return input_dir
+
+    try:
+        from huggingface_hub import snapshot_download
+    except ImportError as exc:
+        raise ImportError(
+            "huggingface_hub is required when using --repo-id. " "Install it or pass --input-dir instead."
+        ) from exc
+
+    logger.info(f"Downloading checkpoint from HF repo: {args.repo_id}")
+    input_dir = Path(
+        snapshot_download(
+            repo_id=args.repo_id,
+            token=args.hf_token,
+            cache_dir=str(args.cache_dir) if args.cache_dir is not None else None,
+            ignore_patterns="original/*",
+            allow_patterns=["*.safetensors", "*.json", "*.model", "*.txt"],
+        )
+    ).resolve()
+    logger.info(f"Downloaded to: {input_dir}")
+    return input_dir
+
+
+def prepare_output_dir(output_dir: Path, overwrite: bool) -> Path:
+    output_dir = output_dir.expanduser().resolve()
+    if output_dir.exists() and any(output_dir.iterdir()) and not overwrite:
+        raise FileExistsError(
+            f"Output directory is not empty: {output_dir}. "
+            "Use --overwrite to allow writing into an existing non-empty directory."
+        )
+    output_dir.mkdir(parents=True, exist_ok=True)
+    logger.info(f"Using output directory: {output_dir}")
+    return output_dir
+
+
+def load_index(index_path: Path) -> dict[str, Any]:
+    if not index_path.is_file():
+        raise FileNotFoundError(f"Missing index file: {index_path}")
+    with index_path.open("r", encoding="utf-8") as f:
+        index_obj = json.load(f)
+    if "weight_map" not in index_obj or not isinstance(index_obj["weight_map"], dict):
+        raise ValueError(f"Invalid index file (missing dict weight_map): {index_path}")
+    logger.info("Loaded checkpoint index: " f"{len(index_obj['weight_map'])} tensor entries from {index_path}")
+    return index_obj
+
+
+def load_block_shape(config_path: Path) -> tuple[int, ...]:
+    if not config_path.is_file():
+        raise FileNotFoundError(f"Missing config file: {config_path}")
+    with config_path.open("r", encoding="utf-8") as f:
+        config = json.load(f)
+    try:
+        block_shape = tuple(config["quantization_config"]["weight_block_size"])
+    except (TypeError, KeyError) as exc:
+        raise ValueError("config.json missing quantization_config.weight_block_size") from exc
+    if not block_shape or any((not isinstance(v, int) or v <= 0) for v in block_shape):
+        raise ValueError(f"Invalid block shape: {block_shape}")
+    logger.info(f"Using quantization block shape: {block_shape}")
+    return block_shape
+
+
+def build_keys_by_file(weight_map: dict[str, str]) -> dict[str, list[str]]:
+    keys_by_file: dict[str, list[str]] = defaultdict(list)
+    for key, filename in weight_map.items():
+        if not isinstance(key, str) or not key:
+            raise ValueError(f"Invalid key in weight_map: {key!r}")
+        if not isinstance(filename, str) or not filename:
+            raise ValueError(f"Invalid shard filename in weight_map for key '{key}': {filename!r}")
+        keys_by_file[filename].append(key)
+    return keys_by_file
+
+
+def validate_input_output_paths(input_dir: Path, output_dir: Path) -> None:
+    if input_dir.resolve() == output_dir.resolve():
+        raise ValueError(f"Input and output directories must be different. Got: {input_dir}")
+
+
+def preflight_validate_checkpoint_structure(
+    model_dir: Path,
+    weight_map: dict[str, str],
+    keys_by_file: dict[str, list[str]],
+) -> None:
+    if not weight_map:
+        raise ValueError("Checkpoint index has no tensor entries in weight_map.")
+
+    logger.info("Running checkpoint preflight validation")
+
+    index_key_set = set(weight_map.keys())
+    # Require every scale tensor to have a corresponding base tensor.
+    for key in index_key_set:
+        if key.endswith("_scale_inv"):
+            base_key = key[: -len("_scale_inv")]
+            if base_key not in index_key_set:
+                raise ValueError(
+                    f"Found scale tensor without matching base tensor: '{key}' "
+                    f"(expected '{base_key}' in weight_map)"
+                )
+
+    missing_shards: list[str] = []
+    missing_keys_in_shard: list[tuple[str, str]] = []
+    unindexed_key_count = 0
+    for shard_name, shard_keys in sorted(keys_by_file.items()):
+        shard_path = model_dir / shard_name
+        if not shard_path.is_file():
+            missing_shards.append(shard_name)
+            continue
+        with safe_open(shard_path, framework="pt", device="cpu") as handle:
+            available = set(handle.keys())
+            for key in shard_keys:
+                if key not in available:
+                    missing_keys_in_shard.append((shard_name, key))
+            # Not fatal but useful: report keys physically present but not indexed.
+            unindexed_key_count += len(available - index_key_set)
+
+    if missing_shards:
+        raise FileNotFoundError("Index references missing shard files: " + ", ".join(missing_shards))
+    if missing_keys_in_shard:
+        examples = ", ".join(f"{k} @ {s}" for s, k in missing_keys_in_shard[:5])
+        raise KeyError(f"Index references keys that are missing in the referenced shard(s). Examples: {examples}")
+    if unindexed_key_count > 0:
+        logger.warning(
+            f"Detected {unindexed_key_count} tensor key(s) present in shard files but absent from index weight_map"
+        )
+    logger.info("Checkpoint preflight validation passed")
+
+
+class ShardTensorReader:
+    def __init__(self, model_dir: Path, weight_map: dict[str, str]):
+        self._model_dir = model_dir
+        self._weight_map = weight_map
+        self._handles: dict[str, Any] = {}
+
+    def get_tensor(self, key: str) -> torch.Tensor:
+        if key not in self._weight_map:
+            raise KeyError(f"Tensor key missing from weight_map: {key}")
+        shard_name = self._weight_map[key]
+        shard_path = self._model_dir / shard_name
+        if not shard_path.is_file():
+            raise FileNotFoundError(f"Shard file not found for key '{key}': {shard_path}")
+        handle = self._handles.get(shard_name)
+        if handle is None:
+            logger.info(f"Opening source shard: {shard_name}")
+            handle = safe_open(shard_path, framework="pt", device="cpu")
+            self._handles[shard_name] = handle
+        return handle.get_tensor(key)
+
+    def close(self) -> None:
+        for handle in self._handles.values():
+            close_fn = getattr(handle, "close", None)
+            if callable(close_fn):
+                close_fn()
+        self._handles.clear()
+
+
+def dequantize_tensor(tensor: torch.Tensor, inv_scale: torch.Tensor, block_shape: tuple[int, ...]) -> torch.Tensor:
+    # Keep this equivalent to DeepSeek helper logic while avoiding ttnn imports.
+    if tensor.ndim != inv_scale.ndim:
+        raise ValueError(f"Tensor and inverse scale must have same ndim, got {tensor.ndim} and {inv_scale.ndim}")
+    if len(block_shape) != tensor.ndim:
+        raise ValueError(
+            f"Block shape rank mismatch, got len(block_shape)={len(block_shape)} and tensor.ndim={tensor.ndim}"
+        )
+    if any(inv_scale.shape[i] * block_shape[i] < tensor.shape[i] for i in range(tensor.ndim)):
+        raise ValueError(
+            "Inverse scale shape does not cover tensor shape: "
+            f"tensor={tuple(tensor.shape)}, inv_scale={tuple(inv_scale.shape)}, block_shape={block_shape}"
+        )
+
+    expanded = inv_scale
+    for i, block_dim in enumerate(block_shape):
+        expanded = expanded.repeat_interleave(block_dim, dim=i)
+
+    slices = tuple(slice(0, size) for size in tensor.shape)
+    return tensor.float() * expanded[slices].float()
+
+
+def copy_auxiliary_files(input_dir: Path, output_dir: Path) -> None:
+    copied_files = 0
+    for path in sorted(input_dir.iterdir()):
+        if not path.is_file():
+            continue
+        if path.suffix == ".safetensors":
+            continue
+        if path.name == "model.safetensors.index.json":
+            continue
+        shutil.copy2(path, output_dir / path.name)
+        copied_files += 1
+    logger.info(f"Copied {copied_files} auxiliary files to output directory")
+
+
+class BufferedShardWriter:
+    """
+    Incremental output writer that bounds memory by flushing tensor batches
+    once a byte budget is reached.
+    """
+
+    def __init__(self, output_dir: Path, max_shard_size_bytes: int):
+        self.output_dir = output_dir
+        self.max_shard_size_bytes = max_shard_size_bytes
+        self._buffer: dict[str, torch.Tensor] = {}
+        self._buffer_bytes = 0
+        self._tmp_shard_names: list[str] = []
+        self._tmp_shard_keys: list[list[str]] = []
+        self._next_tmp_idx = 1
+        self.total_size_bytes = 0
+        logger.info("Configured output shard flushing: " f"max_output_shard_size={format_bytes(max_shard_size_bytes)}")
+
+    @staticmethod
+    def _tensor_nbytes(tensor: torch.Tensor) -> int:
+        return tensor.numel() * tensor.element_size()
+
+    def add_tensor(self, key: str, tensor: torch.Tensor) -> None:
+        tensor_bytes = self._tensor_nbytes(tensor)
+
+        if self._buffer and self._buffer_bytes + tensor_bytes > self.max_shard_size_bytes:
+            self._flush()
+
+        self._buffer[key] = tensor
+        self._buffer_bytes += tensor_bytes
+        self.total_size_bytes += tensor_bytes
+
+        if self._buffer_bytes >= self.max_shard_size_bytes:
+            self._flush()
+
+    def _flush(self) -> None:
+        if not self._buffer:
+            return
+
+        tmp_name = f".tmp-model-{self._next_tmp_idx:05d}.safetensors"
+        flushed_tensors = len(self._buffer)
+        flushed_bytes = self._buffer_bytes
+        save_file(self._buffer, str(self.output_dir / tmp_name))
+        self._tmp_shard_names.append(tmp_name)
+        self._tmp_shard_keys.append(list(self._buffer.keys()))
+        self._next_tmp_idx += 1
+        self._buffer.clear()
+        self._buffer_bytes = 0
+        logger.info(
+            f"Flushed temporary output shard {tmp_name}: " f"{flushed_tensors} tensors, {format_bytes(flushed_bytes)}"
+        )
+
+    def finalize(self) -> dict[str, str]:
+        self._flush()
+
+        num_shards = len(self._tmp_shard_names)
+        if num_shards == 0:
+            logger.info("No output tensors were produced.")
+            return {}
+
+        output_weight_map: dict[str, str] = {}
+        for idx, (tmp_name, keys) in enumerate(zip(self._tmp_shard_names, self._tmp_shard_keys), start=1):
+            final_name = f"model-{idx:05d}-of-{num_shards:05d}.safetensors"
+            (self.output_dir / tmp_name).replace(self.output_dir / final_name)
+            logger.info(f"Finalized output shard: {final_name} ({len(keys)} tensors)")
+            for key in keys:
+                output_weight_map[key] = final_name
+
+        return output_weight_map
+
+
+def convert_checkpoint(
+    input_dir: Path,
+    output_dir: Path,
+    out_dtype: torch.dtype,
+    keep_scale_inv: bool,
+    max_output_shard_size_bytes: int,
+) -> None:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    validate_input_output_paths(input_dir, output_dir)
+
+    index_path = input_dir / "model.safetensors.index.json"
+    config_path = input_dir / "config.json"
+    index_obj = load_index(index_path)
+    block_shape = load_block_shape(config_path)
+    weight_map: dict[str, str] = index_obj["weight_map"]
+    keys_by_file = build_keys_by_file(weight_map)
+    preflight_validate_checkpoint_structure(input_dir, weight_map, keys_by_file)
+    logger.info(f"Discovered {len(keys_by_file)} source shard files")
+
+    reader = ShardTensorReader(input_dir, weight_map)
+    writer = BufferedShardWriter(output_dir=output_dir, max_shard_size_bytes=max_output_shard_size_bytes)
+    total_seen = 0
+    total_dequantized = 0
+    total_scales_kept = 0
+    total_passthrough = 0
+
+    try:
+        shard_names = sorted(keys_by_file.keys())
+        for shard_idx, shard_name in enumerate(shard_names, start=1):
+            keys = keys_by_file[shard_name]
+            logger.info(f"[{shard_idx}/{len(shard_names)}] Processing {shard_name} ({len(keys)} tensors)")
+            shard_seen = 0
+            shard_dequantized = 0
+            shard_scales_kept = 0
+            shard_passthrough = 0
+
+            for key in keys:
+                shard_seen += 1
+                total_seen += 1
+                if key.endswith("_scale_inv"):
+                    if keep_scale_inv:
+                        scale_tensor = reader.get_tensor(key)
+                        writer.add_tensor(key, scale_tensor)
+                        shard_scales_kept += 1
+                        total_scales_kept += 1
+                    continue
+
+                tensor = reader.get_tensor(key)
+                scale_key = f"{key}_scale_inv"
+
+                if scale_key in weight_map:
+                    if tensor.dtype not in FP8_DTYPES:
+                        raise ValueError(
+                            f"Tensor '{key}' has a scale tensor '{scale_key}' but dtype is {tensor.dtype}; "
+                            "expected FP8 payload for dequantization."
+                        )
+                    inv_scale = reader.get_tensor(scale_key)
+                    if not inv_scale.dtype.is_floating_point:
+                        raise ValueError(f"Scale tensor '{scale_key}' must be floating point, got {inv_scale.dtype}")
+                    tensor_out = dequantize_tensor(tensor, inv_scale, block_shape).to(out_dtype)
+                    shard_dequantized += 1
+                    total_dequantized += 1
+                else:
+                    is_fp8 = tensor.dtype in FP8_DTYPES
+                    if is_fp8:
+                        logger.error(f"Missing inverse-scale for FP8 tensor: {key} (expected {scale_key})")
+                        raise KeyError(f"Missing inverse-scale tensor '{scale_key}' for float8 tensor '{key}'.")
+                    tensor_out = tensor
+                    shard_passthrough += 1
+                    total_passthrough += 1
+
+                writer.add_tensor(key, tensor_out)
+            logger.info(
+                f"Completed {shard_name}: seen={shard_seen}, "
+                f"dequantized={shard_dequantized}, passthrough={shard_passthrough}, "
+                f"scales_kept={shard_scales_kept}"
+            )
+    finally:
+        reader.close()
+
+    output_weight_map = writer.finalize()
+    output_total_size = writer.total_size_bytes
+
+    output_index = dict(index_obj)
+    output_index["weight_map"] = output_weight_map
+    metadata = dict(index_obj.get("metadata", {}))
+    metadata["total_size"] = output_total_size
+    output_index["metadata"] = metadata
+
+    with (output_dir / "model.safetensors.index.json").open("w", encoding="utf-8") as f:
+        json.dump(output_index, f, indent=2)
+        f.write("\n")
+
+    copy_auxiliary_files(input_dir, output_dir)
+
+    logger.info(
+        "Conversion completed: "
+        f"written={len(output_weight_map)} tensors, total_size={format_bytes(output_total_size)} "
+        f"(raw={output_total_size} bytes), output={output_dir}"
+    )
+    logger.info(
+        "Tensor accounting summary: "
+        f"seen={total_seen}, dequantized={total_dequantized}, "
+        f"passthrough={total_passthrough}, scales_kept={total_scales_kept}"
+    )
+
+
+def main() -> None:
+    args = parse_args()
+    validate_args(args)
+
+    input_dir = resolve_input_dir(args)
+    output_dir = prepare_output_dir(args.output_dir, overwrite=args.overwrite)
+    out_dtype = parse_torch_dtype(args.dtype)
+    logger.info(
+        "Starting checkpoint conversion with options: "
+        f"dtype={args.dtype}, keep_scale_inv={args.keep_scale_inv}, "
+        f"max_output_shard_size_mb={args.max_output_shard_size_mb}"
+    )
+
+    convert_checkpoint(
+        input_dir=input_dir,
+        output_dir=output_dir,
+        out_dtype=out_dtype,
+        keep_scale_inv=args.keep_scale_inv,
+        max_output_shard_size_bytes=args.max_output_shard_size_mb * 1024 * 1024,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/models/demos/deepseek_v3/scripts/dequantize_hf_checkpoint.py
+++ b/models/demos/deepseek_v3/scripts/dequantize_hf_checkpoint.py
@@ -20,6 +20,8 @@ from loguru import logger
 from safetensors import safe_open
 from safetensors.torch import save_file
 
+from models.demos.deepseek_v3.utils.dequantize import dequantize_tensor
+
 FP8_DTYPES: tuple[torch.dtype, ...] = (torch.float8_e4m3fn,)
 if hasattr(torch, "float8_e5m2"):
     FP8_DTYPES = FP8_DTYPES + (torch.float8_e5m2,)
@@ -315,28 +317,6 @@ class ShardTensorReader:
             if callable(close_fn):
                 close_fn()
         self._handles.clear()
-
-
-def dequantize_tensor(tensor: torch.Tensor, inv_scale: torch.Tensor, block_shape: tuple[int, ...]) -> torch.Tensor:
-    # Keep this equivalent to DeepSeek helper logic while avoiding ttnn imports.
-    if tensor.ndim != inv_scale.ndim:
-        raise ValueError(f"Tensor and inverse scale must have same ndim, got {tensor.ndim} and {inv_scale.ndim}")
-    if len(block_shape) != tensor.ndim:
-        raise ValueError(
-            f"Block shape rank mismatch, got len(block_shape)={len(block_shape)} and tensor.ndim={tensor.ndim}"
-        )
-    if any(inv_scale.shape[i] * block_shape[i] < tensor.shape[i] for i in range(tensor.ndim)):
-        raise ValueError(
-            "Inverse scale shape does not cover tensor shape: "
-            f"tensor={tuple(tensor.shape)}, inv_scale={tuple(inv_scale.shape)}, block_shape={block_shape}"
-        )
-
-    expanded = inv_scale
-    for i, block_dim in enumerate(block_shape):
-        expanded = expanded.repeat_interleave(block_dim, dim=i)
-
-    slices = tuple(slice(0, size) for size in tensor.shape)
-    return tensor.float() * expanded[slices].float()
 
 
 def copy_auxiliary_files(input_dir: Path, output_dir: Path) -> None:

--- a/models/demos/deepseek_v3/scripts/dequantize_hf_checkpoint.py
+++ b/models/demos/deepseek_v3/scripts/dequantize_hf_checkpoint.py
@@ -9,7 +9,8 @@ import argparse
 import concurrent.futures
 import json
 import shutil
-from collections import defaultdict
+import time
+from collections import OrderedDict, defaultdict
 from pathlib import Path
 from typing import Any
 
@@ -226,10 +227,15 @@ def preflight_validate_checkpoint_structure(
                     f"(expected '{base_key}' in weight_map)"
                 )
 
+    total_shards = len(keys_by_file)
+    logger.info(f"Preflight: validating {total_shards} shard file(s)")
+
     missing_shards: list[str] = []
     missing_keys_in_shard: list[tuple[str, str]] = []
     unindexed_key_count = 0
-    for shard_name, shard_keys in sorted(keys_by_file.items()):
+    preflight_started = time.monotonic()
+    last_progress_log = preflight_started
+    for shard_idx, (shard_name, shard_keys) in enumerate(sorted(keys_by_file.items()), start=1):
         shard_path = model_dir / shard_name
         if not shard_path.is_file():
             missing_shards.append(shard_name)
@@ -241,6 +247,15 @@ def preflight_validate_checkpoint_structure(
                     missing_keys_in_shard.append((shard_name, key))
             # Not fatal but useful: report keys physically present but not indexed.
             unindexed_key_count += len(available - index_key_set)
+
+        now = time.monotonic()
+        if now - last_progress_log >= 10.0:
+            elapsed = now - preflight_started
+            logger.info(
+                f"Preflight progress: {shard_idx}/{total_shards} shards checked "
+                f"({(100.0 * shard_idx / total_shards):.1f}%), elapsed={elapsed:.1f}s"
+            )
+            last_progress_log = now
 
     if missing_shards:
         raise FileNotFoundError("Index references missing shard files: " + ", ".join(missing_shards))
@@ -255,10 +270,13 @@ def preflight_validate_checkpoint_structure(
 
 
 class ShardTensorReader:
-    def __init__(self, model_dir: Path, weight_map: dict[str, str]):
+    def __init__(self, model_dir: Path, weight_map: dict[str, str], max_open_handles: int = 32):
+        if max_open_handles <= 0:
+            raise ValueError("max_open_handles must be > 0.")
         self._model_dir = model_dir
         self._weight_map = weight_map
-        self._handles: dict[str, Any] = {}
+        self._max_open_handles = max_open_handles
+        self._handles: OrderedDict[str, Any] = OrderedDict()
 
     def get_tensor(self, key: str) -> torch.Tensor:
         if key not in self._weight_map:
@@ -269,9 +287,17 @@ class ShardTensorReader:
             raise FileNotFoundError(f"Shard file not found for key '{key}': {shard_path}")
         handle = self._handles.get(shard_name)
         if handle is None:
+            while len(self._handles) >= self._max_open_handles:
+                evicted_shard, evicted_handle = self._handles.popitem(last=False)
+                close_fn = getattr(evicted_handle, "close", None)
+                if callable(close_fn):
+                    close_fn()
+                logger.debug(f"Evicted cached source shard handle: {evicted_shard}")
             logger.info(f"Opening source shard: {shard_name}")
             handle = safe_open(shard_path, framework="pt", device="cpu")
             self._handles[shard_name] = handle
+        else:
+            self._handles.move_to_end(shard_name)
         return handle.get_tensor(key)
 
     def close(self) -> None:
@@ -418,6 +444,9 @@ def process_source_shard(
     shard_dequantized = 0
     shard_scales_kept = 0
     shard_passthrough = 0
+    started = time.monotonic()
+    last_progress_log = started
+    total_keys = len(keys)
     try:
         for key in keys:
             shard_seen += 1
@@ -442,6 +471,7 @@ def process_source_shard(
                     raise ValueError(f"Scale tensor '{scale_key}' must be floating point, got {inv_scale.dtype}")
                 tensor_out = dequantize_tensor(tensor, inv_scale, block_shape).to(out_dtype)
                 shard_dequantized += 1
+                del inv_scale
             else:
                 is_fp8 = tensor.dtype in FP8_DTYPES
                 if is_fp8:
@@ -451,6 +481,19 @@ def process_source_shard(
                 shard_passthrough += 1
 
             writer.add_tensor(key, tensor_out)
+            del tensor
+            del tensor_out
+
+            now = time.monotonic()
+            if now - last_progress_log >= 10.0:
+                elapsed = now - started
+                logger.info(
+                    f"[worker {shard_idx}] progress {shard_seen}/{total_keys} "
+                    f"({(100.0 * shard_seen / total_keys):.1f}%), "
+                    f"dequantized={shard_dequantized}, passthrough={shard_passthrough}, "
+                    f"scales_kept={shard_scales_kept}, elapsed={elapsed:.1f}s"
+                )
+                last_progress_log = now
     finally:
         reader.close()
 
@@ -494,6 +537,12 @@ def convert_checkpoint(
     preflight_validate_checkpoint_structure(input_dir, weight_map, keys_by_file)
     logger.info(f"Discovered {len(keys_by_file)} source shard files")
     logger.info(f"Conversion worker mode: num_workers={num_workers}")
+    per_worker_output_buffer_bytes = max(1, max_output_shard_size_bytes // num_workers)
+    logger.info(
+        "Effective per-worker output buffer cap: "
+        f"{format_bytes(per_worker_output_buffer_bytes)} "
+        f"(global target shard size {format_bytes(max_output_shard_size_bytes)})"
+    )
     shard_names = sorted(keys_by_file.keys())
     work_items = [(idx, name, keys_by_file[name]) for idx, name in enumerate(shard_names, start=1)]
     logger.info(f"Number of work items: {len(work_items)}")
@@ -512,7 +561,7 @@ def convert_checkpoint(
                     block_shape=block_shape,
                     out_dtype=out_dtype,
                     keep_scale_inv=keep_scale_inv,
-                    max_output_shard_size_bytes=max_output_shard_size_bytes,
+                    max_output_shard_size_bytes=per_worker_output_buffer_bytes,
                 )
             )
     else:
@@ -529,7 +578,7 @@ def convert_checkpoint(
                     block_shape,
                     out_dtype,
                     keep_scale_inv,
-                    max_output_shard_size_bytes,
+                    per_worker_output_buffer_bytes,
                 )
                 for idx, name, keys in work_items
             ]

--- a/models/demos/deepseek_v3/scripts/dequantize_hf_checkpoint.py
+++ b/models/demos/deepseek_v3/scripts/dequantize_hf_checkpoint.py
@@ -6,6 +6,7 @@
 from __future__ import annotations
 
 import argparse
+import concurrent.futures
 import json
 import shutil
 from collections import defaultdict
@@ -92,6 +93,12 @@ def parse_args() -> argparse.Namespace:
             "Lower values reduce peak host memory usage during conversion."
         ),
     )
+    parser.add_argument(
+        "--num-workers",
+        type=int,
+        default=1,
+        help="Number of parallel source-shard conversion workers. Use 1 for sequential mode.",
+    )
     return parser.parse_args()
 
 
@@ -111,6 +118,8 @@ def validate_args(args: argparse.Namespace) -> None:
         raise ValueError("Provide exactly one of --repo-id or --input-dir.")
     if args.max_output_shard_size_mb <= 0:
         raise ValueError("--max-output-shard-size-mb must be > 0.")
+    if args.num_workers <= 0:
+        raise ValueError("--num-workers must be > 0.")
 
 
 def resolve_input_dir(args: argparse.Namespace) -> Path:
@@ -315,9 +324,10 @@ class BufferedShardWriter:
     once a byte budget is reached.
     """
 
-    def __init__(self, output_dir: Path, max_shard_size_bytes: int):
+    def __init__(self, output_dir: Path, max_shard_size_bytes: int, temp_prefix: str = ".tmp-model"):
         self.output_dir = output_dir
         self.max_shard_size_bytes = max_shard_size_bytes
+        self.temp_prefix = temp_prefix
         self._buffer: dict[str, torch.Tensor] = {}
         self._buffer_bytes = 0
         self._tmp_shard_names: list[str] = []
@@ -347,7 +357,7 @@ class BufferedShardWriter:
         if not self._buffer:
             return
 
-        tmp_name = f".tmp-model-{self._next_tmp_idx:05d}.safetensors"
+        tmp_name = f"{self.temp_prefix}-{self._next_tmp_idx:05d}.safetensors"
         flushed_tensors = len(self._buffer)
         flushed_bytes = self._buffer_bytes
         save_file(self._buffer, str(self.output_dir / tmp_name))
@@ -360,23 +370,106 @@ class BufferedShardWriter:
             f"Flushed temporary output shard {tmp_name}: " f"{flushed_tensors} tensors, {format_bytes(flushed_bytes)}"
         )
 
-    def finalize(self) -> dict[str, str]:
+    def collect_tmp_entries(self) -> list[tuple[str, list[str]]]:
         self._flush()
+        return list(zip(self._tmp_shard_names, self._tmp_shard_keys))
 
-        num_shards = len(self._tmp_shard_names)
-        if num_shards == 0:
-            logger.info("No output tensors were produced.")
-            return {}
+    def finalize(self) -> dict[str, str]:
+        return finalize_output_shards(self.output_dir, self.collect_tmp_entries())
 
-        output_weight_map: dict[str, str] = {}
-        for idx, (tmp_name, keys) in enumerate(zip(self._tmp_shard_names, self._tmp_shard_keys), start=1):
-            final_name = f"model-{idx:05d}-of-{num_shards:05d}.safetensors"
-            (self.output_dir / tmp_name).replace(self.output_dir / final_name)
-            logger.info(f"Finalized output shard: {final_name} ({len(keys)} tensors)")
-            for key in keys:
-                output_weight_map[key] = final_name
 
-        return output_weight_map
+def finalize_output_shards(output_dir: Path, tmp_entries: list[tuple[str, list[str]]]) -> dict[str, str]:
+    num_shards = len(tmp_entries)
+    if num_shards == 0:
+        logger.info("No output tensors were produced.")
+        return {}
+
+    output_weight_map: dict[str, str] = {}
+    for idx, (tmp_name, keys) in enumerate(tmp_entries, start=1):
+        final_name = f"model-{idx:05d}-of-{num_shards:05d}.safetensors"
+        (output_dir / tmp_name).replace(output_dir / final_name)
+        logger.info(f"Finalized output shard: {final_name} ({len(keys)} tensors)")
+        for key in keys:
+            output_weight_map[key] = final_name
+    return output_weight_map
+
+
+def process_source_shard(
+    shard_idx: int,
+    shard_name: str,
+    keys: list[str],
+    input_dir: Path,
+    output_dir: Path,
+    weight_map: dict[str, str],
+    block_shape: tuple[int, ...],
+    out_dtype: torch.dtype,
+    keep_scale_inv: bool,
+    max_output_shard_size_bytes: int,
+) -> dict[str, Any]:
+    logger.info(f"[worker {shard_idx}] start {shard_name} ({len(keys)} tensor entries)")
+    reader = ShardTensorReader(input_dir, weight_map)
+    writer = BufferedShardWriter(
+        output_dir=output_dir,
+        max_shard_size_bytes=max_output_shard_size_bytes,
+        temp_prefix=f".tmp-s{shard_idx:05d}",
+    )
+
+    shard_seen = 0
+    shard_dequantized = 0
+    shard_scales_kept = 0
+    shard_passthrough = 0
+    try:
+        for key in keys:
+            shard_seen += 1
+            if key.endswith("_scale_inv"):
+                if keep_scale_inv:
+                    scale_tensor = reader.get_tensor(key)
+                    writer.add_tensor(key, scale_tensor)
+                    shard_scales_kept += 1
+                continue
+
+            tensor = reader.get_tensor(key)
+            scale_key = f"{key}_scale_inv"
+
+            if scale_key in weight_map:
+                if tensor.dtype not in FP8_DTYPES:
+                    raise ValueError(
+                        f"Tensor '{key}' has a scale tensor '{scale_key}' but dtype is {tensor.dtype}; "
+                        "expected FP8 payload for dequantization."
+                    )
+                inv_scale = reader.get_tensor(scale_key)
+                if not inv_scale.dtype.is_floating_point:
+                    raise ValueError(f"Scale tensor '{scale_key}' must be floating point, got {inv_scale.dtype}")
+                tensor_out = dequantize_tensor(tensor, inv_scale, block_shape).to(out_dtype)
+                shard_dequantized += 1
+            else:
+                is_fp8 = tensor.dtype in FP8_DTYPES
+                if is_fp8:
+                    logger.error(f"Missing inverse-scale for FP8 tensor: {key} (expected {scale_key})")
+                    raise KeyError(f"Missing inverse-scale tensor '{scale_key}' for float8 tensor '{key}'.")
+                tensor_out = tensor
+                shard_passthrough += 1
+
+            writer.add_tensor(key, tensor_out)
+    finally:
+        reader.close()
+
+    tmp_entries = writer.collect_tmp_entries()
+    logger.info(
+        f"[worker {shard_idx}] completed {shard_name}: seen={shard_seen}, "
+        f"dequantized={shard_dequantized}, passthrough={shard_passthrough}, "
+        f"scales_kept={shard_scales_kept}, tmp_shards={len(tmp_entries)}"
+    )
+    return {
+        "shard_idx": shard_idx,
+        "shard_name": shard_name,
+        "tmp_entries": tmp_entries,
+        "total_size_bytes": writer.total_size_bytes,
+        "seen": shard_seen,
+        "dequantized": shard_dequantized,
+        "passthrough": shard_passthrough,
+        "scales_kept": shard_scales_kept,
+    }
 
 
 def convert_checkpoint(
@@ -385,7 +478,10 @@ def convert_checkpoint(
     out_dtype: torch.dtype,
     keep_scale_inv: bool,
     max_output_shard_size_bytes: int,
+    num_workers: int = 1,
 ) -> None:
+    if num_workers <= 0:
+        raise ValueError("num_workers must be > 0.")
     output_dir.mkdir(parents=True, exist_ok=True)
     validate_input_output_paths(input_dir, output_dir)
 
@@ -397,70 +493,65 @@ def convert_checkpoint(
     keys_by_file = build_keys_by_file(weight_map)
     preflight_validate_checkpoint_structure(input_dir, weight_map, keys_by_file)
     logger.info(f"Discovered {len(keys_by_file)} source shard files")
+    logger.info(f"Conversion worker mode: num_workers={num_workers}")
+    shard_names = sorted(keys_by_file.keys())
+    work_items = [(idx, name, keys_by_file[name]) for idx, name in enumerate(shard_names, start=1)]
+    logger.info(f"Number of work items: {len(work_items)}")
 
-    reader = ShardTensorReader(input_dir, weight_map)
-    writer = BufferedShardWriter(output_dir=output_dir, max_shard_size_bytes=max_output_shard_size_bytes)
+    results: list[dict[str, Any]] = []
+    if num_workers == 1:
+        for idx, name, keys in work_items:
+            results.append(
+                process_source_shard(
+                    shard_idx=idx,
+                    shard_name=name,
+                    keys=keys,
+                    input_dir=input_dir,
+                    output_dir=output_dir,
+                    weight_map=weight_map,
+                    block_shape=block_shape,
+                    out_dtype=out_dtype,
+                    keep_scale_inv=keep_scale_inv,
+                    max_output_shard_size_bytes=max_output_shard_size_bytes,
+                )
+            )
+    else:
+        with concurrent.futures.ThreadPoolExecutor(max_workers=num_workers) as executor:
+            futures = [
+                executor.submit(
+                    process_source_shard,
+                    idx,
+                    name,
+                    keys,
+                    input_dir,
+                    output_dir,
+                    weight_map,
+                    block_shape,
+                    out_dtype,
+                    keep_scale_inv,
+                    max_output_shard_size_bytes,
+                )
+                for idx, name, keys in work_items
+            ]
+            for future in concurrent.futures.as_completed(futures):
+                results.append(future.result())
+
+    results.sort(key=lambda r: r["shard_idx"])
+    tmp_entries: list[tuple[str, list[str]]] = []
     total_seen = 0
     total_dequantized = 0
     total_scales_kept = 0
     total_passthrough = 0
+    output_total_size = 0
+    for result in results:
+        tmp_entries.extend(result["tmp_entries"])
+        total_seen += result["seen"]
+        total_dequantized += result["dequantized"]
+        total_passthrough += result["passthrough"]
+        total_scales_kept += result["scales_kept"]
+        output_total_size += result["total_size_bytes"]
 
-    try:
-        shard_names = sorted(keys_by_file.keys())
-        for shard_idx, shard_name in enumerate(shard_names, start=1):
-            keys = keys_by_file[shard_name]
-            logger.info(f"[{shard_idx}/{len(shard_names)}] Processing {shard_name} ({len(keys)} tensors)")
-            shard_seen = 0
-            shard_dequantized = 0
-            shard_scales_kept = 0
-            shard_passthrough = 0
-
-            for key in keys:
-                shard_seen += 1
-                total_seen += 1
-                if key.endswith("_scale_inv"):
-                    if keep_scale_inv:
-                        scale_tensor = reader.get_tensor(key)
-                        writer.add_tensor(key, scale_tensor)
-                        shard_scales_kept += 1
-                        total_scales_kept += 1
-                    continue
-
-                tensor = reader.get_tensor(key)
-                scale_key = f"{key}_scale_inv"
-
-                if scale_key in weight_map:
-                    if tensor.dtype not in FP8_DTYPES:
-                        raise ValueError(
-                            f"Tensor '{key}' has a scale tensor '{scale_key}' but dtype is {tensor.dtype}; "
-                            "expected FP8 payload for dequantization."
-                        )
-                    inv_scale = reader.get_tensor(scale_key)
-                    if not inv_scale.dtype.is_floating_point:
-                        raise ValueError(f"Scale tensor '{scale_key}' must be floating point, got {inv_scale.dtype}")
-                    tensor_out = dequantize_tensor(tensor, inv_scale, block_shape).to(out_dtype)
-                    shard_dequantized += 1
-                    total_dequantized += 1
-                else:
-                    is_fp8 = tensor.dtype in FP8_DTYPES
-                    if is_fp8:
-                        logger.error(f"Missing inverse-scale for FP8 tensor: {key} (expected {scale_key})")
-                        raise KeyError(f"Missing inverse-scale tensor '{scale_key}' for float8 tensor '{key}'.")
-                    tensor_out = tensor
-                    shard_passthrough += 1
-                    total_passthrough += 1
-
-                writer.add_tensor(key, tensor_out)
-            logger.info(
-                f"Completed {shard_name}: seen={shard_seen}, "
-                f"dequantized={shard_dequantized}, passthrough={shard_passthrough}, "
-                f"scales_kept={shard_scales_kept}"
-            )
-    finally:
-        reader.close()
-
-    output_weight_map = writer.finalize()
-    output_total_size = writer.total_size_bytes
+    output_weight_map = finalize_output_shards(output_dir, tmp_entries)
 
     output_index = dict(index_obj)
     output_index["weight_map"] = output_weight_map
@@ -496,7 +587,8 @@ def main() -> None:
     logger.info(
         "Starting checkpoint conversion with options: "
         f"dtype={args.dtype}, keep_scale_inv={args.keep_scale_inv}, "
-        f"max_output_shard_size_mb={args.max_output_shard_size_mb}"
+        f"max_output_shard_size_mb={args.max_output_shard_size_mb}, "
+        f"num_workers={args.num_workers}"
     )
 
     convert_checkpoint(
@@ -505,6 +597,7 @@ def main() -> None:
         out_dtype=out_dtype,
         keep_scale_inv=args.keep_scale_inv,
         max_output_shard_size_bytes=args.max_output_shard_size_mb * 1024 * 1024,
+        num_workers=args.num_workers,
     )
 
 

--- a/models/demos/deepseek_v3/scripts/dequantize_hf_checkpoint.py
+++ b/models/demos/deepseek_v3/scripts/dequantize_hf_checkpoint.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import argparse
 import concurrent.futures
+import hashlib
 import json
 import shutil
 import time
@@ -99,6 +100,14 @@ def parse_args() -> argparse.Namespace:
         type=int,
         default=1,
         help="Number of parallel source-shard conversion workers. Use 1 for sequential mode.",
+    )
+    parser.add_argument(
+        "--resume",
+        action="store_true",
+        help=(
+            "Reuse completed temporary shard outputs from a previous interrupted run when compatible "
+            "per-shard manifests are present in --output-dir."
+        ),
     )
     return parser.parse_args()
 
@@ -404,6 +413,248 @@ class BufferedShardWriter:
         return finalize_output_shards(self.output_dir, self.collect_tmp_entries())
 
 
+def _source_keys_digest(keys: list[str]) -> str:
+    h = hashlib.sha256()
+    for key in keys:
+        h.update(key.encode("utf-8"))
+        h.update(b"\n")
+    return h.hexdigest()
+
+
+def source_shard_manifest_path(output_dir: Path, shard_idx: int) -> Path:
+    return output_dir / f".tmp-s{shard_idx:05d}.manifest.json"
+
+
+def expected_output_keys_for_source_shard(source_keys: list[str], keep_scale_inv: bool) -> list[str]:
+    output_keys: list[str] = []
+    for key in source_keys:
+        if key.endswith("_scale_inv"):
+            if keep_scale_inv:
+                output_keys.append(key)
+        else:
+            output_keys.append(key)
+    return output_keys
+
+
+def _safetensors_dtype_nbytes(dtype_name: str) -> int:
+    mapping = {
+        "BOOL": 1,
+        "U8": 1,
+        "I8": 1,
+        "F8_E4M3FN": 1,
+        "F8_E5M2": 1,
+        "F16": 2,
+        "BF16": 2,
+        "U16": 2,
+        "I16": 2,
+        "F32": 4,
+        "U32": 4,
+        "I32": 4,
+        "F64": 8,
+        "U64": 8,
+        "I64": 8,
+    }
+    if dtype_name not in mapping:
+        raise ValueError(f"Unsupported safetensors dtype in legacy tmp recovery: {dtype_name}")
+    return mapping[dtype_name]
+
+
+def maybe_recover_source_shard_from_legacy_tmp_files(
+    output_dir: Path,
+    shard_idx: int,
+    shard_name: str,
+    source_keys: list[str],
+    weight_map: dict[str, str],
+    keep_scale_inv: bool,
+) -> dict[str, Any] | None:
+    pattern = f".tmp-s{shard_idx:05d}-*.safetensors"
+    tmp_paths = sorted(output_dir.glob(pattern))
+    if not tmp_paths:
+        return None
+
+    expected_keys = expected_output_keys_for_source_shard(source_keys, keep_scale_inv)
+    expected_key_set = set(expected_keys)
+    observed_key_set: set[str] = set()
+    tmp_entries: list[tuple[str, list[str]]] = []
+    total_size_bytes = 0
+
+    for tmp_path in tmp_paths:
+        try:
+            with safe_open(tmp_path, framework="pt", device="cpu") as handle:
+                keys = list(handle.keys())
+                for key in keys:
+                    tensor_slice = handle.get_slice(key)
+                    shape = tensor_slice.get_shape()
+                    dtype_name = str(tensor_slice.get_dtype())
+                    numel = 1
+                    for dim in shape:
+                        numel *= dim
+                    total_size_bytes += numel * _safetensors_dtype_nbytes(dtype_name)
+        except Exception as exc:
+            logger.warning(
+                f"Failed to read legacy tmp shard {tmp_path.name} for source shard {shard_name}: {exc}. "
+                "Reprocessing shard."
+            )
+            return None
+        if not keys:
+            logger.warning(f"Legacy tmp shard {tmp_path.name} has no tensors for source shard {shard_name}")
+            return None
+        for key in keys:
+            if key in observed_key_set:
+                logger.warning(
+                    f"Legacy tmp shards contain duplicate key '{key}' for source shard {shard_name}; reprocessing."
+                )
+                return None
+            observed_key_set.add(key)
+        tmp_entries.append((tmp_path.name, keys))
+
+    if observed_key_set != expected_key_set:
+        logger.warning(
+            f"Legacy tmp shard coverage mismatch for source shard {shard_name}: "
+            f"expected={len(expected_key_set)} key(s), observed={len(observed_key_set)} key(s). Reprocessing."
+        )
+        return None
+
+    logger.info(
+        f"Recovered source shard {shard_idx} ({shard_name}) from legacy tmp files "
+        f"({len(tmp_entries)} file(s), {len(observed_key_set)} key(s))"
+    )
+    dequantized = sum(1 for key in source_keys if not key.endswith("_scale_inv") and f"{key}_scale_inv" in weight_map)
+    passthrough = sum(
+        1 for key in source_keys if not key.endswith("_scale_inv") and f"{key}_scale_inv" not in weight_map
+    )
+    scales_kept = sum(1 for key in source_keys if key.endswith("_scale_inv") and keep_scale_inv)
+    return {
+        "shard_idx": shard_idx,
+        "shard_name": shard_name,
+        "tmp_entries": tmp_entries,
+        "total_size_bytes": total_size_bytes,
+        "seen": len(source_keys),
+        "dequantized": dequantized,
+        "passthrough": passthrough,
+        "scales_kept": scales_kept,
+    }
+
+
+def write_source_shard_manifest(
+    output_dir: Path,
+    result: dict[str, Any],
+    source_keys: list[str],
+    out_dtype: torch.dtype,
+    keep_scale_inv: bool,
+) -> None:
+    manifest_path = source_shard_manifest_path(output_dir, result["shard_idx"])
+    manifest = {
+        "version": 1,
+        "shard_idx": result["shard_idx"],
+        "shard_name": result["shard_name"],
+        "source_key_count": len(source_keys),
+        "source_key_digest": _source_keys_digest(source_keys),
+        "out_dtype": str(out_dtype),
+        "keep_scale_inv": bool(keep_scale_inv),
+        "tmp_entries": [{"tmp_name": n, "keys": ks} for n, ks in result["tmp_entries"]],
+        "total_size_bytes": int(result["total_size_bytes"]),
+        "seen": int(result["seen"]),
+        "dequantized": int(result["dequantized"]),
+        "passthrough": int(result["passthrough"]),
+        "scales_kept": int(result["scales_kept"]),
+    }
+
+    tmp_manifest_path = Path(str(manifest_path) + ".tmp")
+    with tmp_manifest_path.open("w", encoding="utf-8") as f:
+        json.dump(manifest, f, indent=2)
+        f.write("\n")
+    tmp_manifest_path.replace(manifest_path)
+
+
+def maybe_load_source_shard_manifest(
+    output_dir: Path,
+    shard_idx: int,
+    shard_name: str,
+    source_keys: list[str],
+    weight_map: dict[str, str],
+    out_dtype: torch.dtype,
+    keep_scale_inv: bool,
+) -> dict[str, Any] | None:
+    manifest_path = source_shard_manifest_path(output_dir, shard_idx)
+    if not manifest_path.is_file():
+        return maybe_recover_source_shard_from_legacy_tmp_files(
+            output_dir=output_dir,
+            shard_idx=shard_idx,
+            shard_name=shard_name,
+            source_keys=source_keys,
+            weight_map=weight_map,
+            keep_scale_inv=keep_scale_inv,
+        )
+
+    try:
+        with manifest_path.open("r", encoding="utf-8") as f:
+            manifest = json.load(f)
+    except Exception as exc:
+        logger.warning(f"Failed to parse resume manifest {manifest_path}: {exc}. Reprocessing shard.")
+        return None
+
+    if manifest.get("version") != 1:
+        logger.warning(f"Unsupported resume manifest version in {manifest_path}. Reprocessing shard.")
+        return None
+    if manifest.get("shard_idx") != shard_idx or manifest.get("shard_name") != shard_name:
+        logger.warning(f"Resume manifest mismatch for shard {shard_name} in {manifest_path}. Reprocessing shard.")
+        return None
+    if manifest.get("source_key_count") != len(source_keys):
+        logger.warning(f"Resume manifest key count mismatch for shard {shard_name}. Reprocessing shard.")
+        return None
+    if manifest.get("source_key_digest") != _source_keys_digest(source_keys):
+        logger.warning(f"Resume manifest key digest mismatch for shard {shard_name}. Reprocessing shard.")
+        return None
+    if manifest.get("out_dtype") != str(out_dtype) or manifest.get("keep_scale_inv") != bool(keep_scale_inv):
+        logger.warning(f"Resume manifest conversion options mismatch for shard {shard_name}. Reprocessing shard.")
+        return None
+
+    tmp_entries_obj = manifest.get("tmp_entries")
+    if not isinstance(tmp_entries_obj, list):
+        logger.warning(f"Resume manifest tmp_entries missing/invalid for shard {shard_name}. Reprocessing shard.")
+        return None
+
+    tmp_entries: list[tuple[str, list[str]]] = []
+    for entry in tmp_entries_obj:
+        if not isinstance(entry, dict):
+            logger.warning(f"Resume manifest entry malformed for shard {shard_name}. Reprocessing shard.")
+            return None
+        tmp_name = entry.get("tmp_name")
+        keys = entry.get("keys")
+        if not isinstance(tmp_name, str) or not isinstance(keys, list) or any(not isinstance(k, str) for k in keys):
+            logger.warning(f"Resume manifest entry malformed for shard {shard_name}. Reprocessing shard.")
+            return None
+        if not (output_dir / tmp_name).is_file():
+            logger.warning(
+                f"Resume manifest references missing temporary shard {tmp_name} for {shard_name}. Reprocessing shard."
+            )
+            return None
+        tmp_entries.append((tmp_name, keys))
+
+    return {
+        "shard_idx": shard_idx,
+        "shard_name": shard_name,
+        "tmp_entries": tmp_entries,
+        "total_size_bytes": int(manifest.get("total_size_bytes", 0)),
+        "seen": int(manifest.get("seen", 0)),
+        "dequantized": int(manifest.get("dequantized", 0)),
+        "passthrough": int(manifest.get("passthrough", 0)),
+        "scales_kept": int(manifest.get("scales_kept", 0)),
+    }
+
+
+def cleanup_source_shard_manifests(output_dir: Path, shard_indices: list[int]) -> None:
+    cleaned = 0
+    for shard_idx in shard_indices:
+        path = source_shard_manifest_path(output_dir, shard_idx)
+        if path.exists():
+            path.unlink()
+            cleaned += 1
+    if cleaned:
+        logger.info(f"Removed {cleaned} resume manifest file(s)")
+
+
 def finalize_output_shards(output_dir: Path, tmp_entries: list[tuple[str, list[str]]]) -> dict[str, str]:
     num_shards = len(tmp_entries)
     if num_shards == 0:
@@ -522,6 +773,7 @@ def convert_checkpoint(
     keep_scale_inv: bool,
     max_output_shard_size_bytes: int,
     num_workers: int = 1,
+    resume: bool = False,
 ) -> None:
     if num_workers <= 0:
         raise ValueError("num_workers must be > 0.")
@@ -548,26 +800,56 @@ def convert_checkpoint(
     logger.info(f"Number of work items: {len(work_items)}")
 
     results: list[dict[str, Any]] = []
-    if num_workers == 1:
+    pending_work_items: list[tuple[int, str, list[str]]] = []
+    if resume:
+        resumed = 0
         for idx, name, keys in work_items:
-            results.append(
-                process_source_shard(
-                    shard_idx=idx,
-                    shard_name=name,
-                    keys=keys,
-                    input_dir=input_dir,
-                    output_dir=output_dir,
-                    weight_map=weight_map,
-                    block_shape=block_shape,
-                    out_dtype=out_dtype,
-                    keep_scale_inv=keep_scale_inv,
-                    max_output_shard_size_bytes=per_worker_output_buffer_bytes,
-                )
+            resumed_result = maybe_load_source_shard_manifest(
+                output_dir=output_dir,
+                shard_idx=idx,
+                shard_name=name,
+                source_keys=keys,
+                weight_map=weight_map,
+                out_dtype=out_dtype,
+                keep_scale_inv=keep_scale_inv,
             )
+            if resumed_result is None:
+                pending_work_items.append((idx, name, keys))
+            else:
+                results.append(resumed_result)
+                resumed += 1
+                logger.info(f"Resuming shard {idx}/{len(work_items)} from existing tmp outputs: {name}")
+        logger.info(f"Resume scan complete: resumed={resumed}, pending={len(pending_work_items)}")
+    else:
+        pending_work_items = work_items
+
+    if num_workers == 1:
+        for idx, name, keys in pending_work_items:
+            result = process_source_shard(
+                shard_idx=idx,
+                shard_name=name,
+                keys=keys,
+                input_dir=input_dir,
+                output_dir=output_dir,
+                weight_map=weight_map,
+                block_shape=block_shape,
+                out_dtype=out_dtype,
+                keep_scale_inv=keep_scale_inv,
+                max_output_shard_size_bytes=per_worker_output_buffer_bytes,
+            )
+            write_source_shard_manifest(
+                output_dir=output_dir,
+                result=result,
+                source_keys=keys,
+                out_dtype=out_dtype,
+                keep_scale_inv=keep_scale_inv,
+            )
+            results.append(result)
     else:
         with concurrent.futures.ThreadPoolExecutor(max_workers=num_workers) as executor:
-            futures = [
-                executor.submit(
+            futures: dict[concurrent.futures.Future[dict[str, Any]], tuple[int, list[str]]] = {}
+            for idx, name, keys in pending_work_items:
+                future = executor.submit(
                     process_source_shard,
                     idx,
                     name,
@@ -580,10 +862,25 @@ def convert_checkpoint(
                     keep_scale_inv,
                     per_worker_output_buffer_bytes,
                 )
-                for idx, name, keys in work_items
-            ]
+                futures[future] = (idx, keys)
+
             for future in concurrent.futures.as_completed(futures):
-                results.append(future.result())
+                idx, keys = futures[future]
+                result = future.result()
+                write_source_shard_manifest(
+                    output_dir=output_dir,
+                    result=result,
+                    source_keys=keys,
+                    out_dtype=out_dtype,
+                    keep_scale_inv=keep_scale_inv,
+                )
+                results.append(result)
+
+    if len(results) != len(work_items):
+        raise RuntimeError(
+            f"Internal error: expected {len(work_items)} shard result(s), got {len(results)}. "
+            "Some source shards were not converted or resumed."
+        )
 
     results.sort(key=lambda r: r["shard_idx"])
     tmp_entries: list[tuple[str, list[str]]] = []
@@ -613,6 +910,7 @@ def convert_checkpoint(
         f.write("\n")
 
     copy_auxiliary_files(input_dir, output_dir)
+    cleanup_source_shard_manifests(output_dir, [r["shard_idx"] for r in results])
 
     logger.info(
         "Conversion completed: "
@@ -637,7 +935,7 @@ def main() -> None:
         "Starting checkpoint conversion with options: "
         f"dtype={args.dtype}, keep_scale_inv={args.keep_scale_inv}, "
         f"max_output_shard_size_mb={args.max_output_shard_size_mb}, "
-        f"num_workers={args.num_workers}"
+        f"num_workers={args.num_workers}, resume={args.resume}"
     )
 
     convert_checkpoint(
@@ -647,6 +945,7 @@ def main() -> None:
         keep_scale_inv=args.keep_scale_inv,
         max_output_shard_size_bytes=args.max_output_shard_size_mb * 1024 * 1024,
         num_workers=args.num_workers,
+        resume=args.resume,
     )
 
 

--- a/models/demos/deepseek_v3/scripts/validate_dequantized_checkpoint.py
+++ b/models/demos/deepseek_v3/scripts/validate_dequantized_checkpoint.py
@@ -1,0 +1,425 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import argparse
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+import torch
+from loguru import logger
+from safetensors import safe_open
+
+from models.demos.deepseek_v3.scripts.dequantize_hf_checkpoint import (
+    build_keys_by_file,
+    dequantize_tensor,
+    load_block_shape,
+    load_index,
+)
+
+
+def _safetensors_dtype_to_torch(dtype_str: str) -> torch.dtype:
+    """Map safetensors dtype string (e.g. from get_slice(key).get_dtype()) to torch.dtype."""
+    m = {
+        "F32": torch.float32,
+        "F16": torch.float16,
+        "BF16": torch.bfloat16,
+        "F8_E4M3": torch.float8_e4m3fn,
+        "F8_E5M2": getattr(torch, "float8_e5m2", None),
+    }
+    out = m.get((dtype_str or "").upper())
+    if out is None:
+        raise ValueError(f"Unsupported safetensors dtype for validation: {dtype_str!r}")
+    return out
+
+
+def _is_fp8_safetensors_dtype(dtype_str: str) -> bool:
+    s = (dtype_str or "").upper()
+    return s in ("F8_E4M3", "F8_E5M2")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Validate a dequantized checkpoint against the original quantized checkpoint.",
+    )
+    parser.add_argument(
+        "--original-dir",
+        type=Path,
+        required=True,
+        help="Directory containing the original (quantized) checkpoint and model.safetensors.index.json.",
+    )
+    parser.add_argument(
+        "--dequantized-dir",
+        type=Path,
+        required=True,
+        help="Directory containing the dequantized checkpoint to validate.",
+    )
+    parser.add_argument(
+        "--check-values",
+        action="store_true",
+        help="Load tensors and verify numerical correctness (passthrough equality, dequantized allclose).",
+    )
+    parser.add_argument(
+        "--keep-scale-inv",
+        action="store_true",
+        help="Expect *_scale_inv tensors in the dequantized checkpoint (must match dequantize script flag).",
+    )
+    parser.add_argument(
+        "--rtol",
+        type=float,
+        default=1e-2,
+        help="Relative tolerance for dequantized tensor comparison (default: 1e-2).",
+    )
+    parser.add_argument(
+        "--atol",
+        type=float,
+        default=1e-3,
+        help="Absolute tolerance for dequantized tensor comparison (default: 1e-3).",
+    )
+    return parser.parse_args()
+
+
+def _collect_metadata_from_checkpoint(
+    model_dir: Path,
+    weight_map: dict[str, str],
+    keys_by_file: dict[str, list[str]],
+) -> dict[str, tuple[tuple[int, ...], str]]:
+    """For each key in weight_map, collect (shape, dtype_str) from shards using lazy get_slice."""
+    result: dict[str, tuple[tuple[int, ...], str]] = {}
+    total = len(keys_by_file)
+    started = time.monotonic()
+    last_log = started
+    for shard_idx, (shard_name, keys) in enumerate(sorted(keys_by_file.items()), start=1):
+        shard_path = model_dir / shard_name
+        if not shard_path.is_file():
+            raise FileNotFoundError(f"Shard not found: {shard_path}")
+        with safe_open(shard_path, framework="pt", device="cpu") as handle:
+            for key in keys:
+                sl = handle.get_slice(key)
+                shape = tuple(sl.get_shape())
+                dtype_str = sl.get_dtype()
+                result[key] = (shape, dtype_str)
+        now = time.monotonic()
+        if now - last_log >= 10.0:
+            logger.info(
+                f"Metadata progress: {shard_idx}/{total} shards "
+                f"({100.0 * shard_idx / total:.1f}%), elapsed={now - started:.1f}s"
+            )
+            last_log = now
+    return result
+
+
+def _check_shard_files_exist(model_dir: Path, weight_map: dict[str, str]) -> list[str]:
+    """Return list of missing shard filenames."""
+    shard_names = set(weight_map.values())
+    return [s for s in shard_names if not (model_dir / s).is_file()]
+
+
+def run_metadata_checks(
+    original_dir: Path,
+    dequantized_dir: Path,
+    keep_scale_inv: bool,
+) -> dict[str, Any]:
+    """Run tier-1 metadata-only checks. Returns a result dict with pass/fail and details."""
+    index_path_orig = original_dir / "model.safetensors.index.json"
+    index_path_deq = dequantized_dir / "model.safetensors.index.json"
+    config_path_orig = original_dir / "config.json"
+
+    result: dict[str, Any] = {
+        "key_completeness": {"passed": False, "missing_keys": []},
+        "scale_key_handling": {"passed": False, "message": ""},
+        "no_extra_keys": {"passed": False, "extra_keys": []},
+        "shape_preservation": {"passed": False, "mismatches": []},
+        "dtype_correctness": {"passed": False, "mismatches": []},
+        "shard_files_exist": {"passed": False, "missing_shards": []},
+        "all_passed": False,
+    }
+
+    orig_index = load_index(index_path_orig)
+    deq_index = load_index(index_path_deq)
+    block_shape = load_block_shape(config_path_orig)
+    orig_weight_map: dict[str, str] = orig_index["weight_map"]
+    deq_weight_map: dict[str, str] = deq_index["weight_map"]
+
+    orig_keys = set(orig_weight_map.keys())
+    orig_base_keys = {k for k in orig_keys if not k.endswith("_scale_inv")}
+    orig_scale_keys = orig_keys - orig_base_keys
+    deq_keys = set(deq_weight_map.keys())
+
+    # 1. Key completeness: every non-_scale_inv key from original exists in dequantized
+    missing = sorted(orig_base_keys - deq_keys)
+    result["key_completeness"]["missing_keys"] = missing
+    result["key_completeness"]["passed"] = len(missing) == 0
+
+    # 2. Scale key handling
+    if keep_scale_inv:
+        missing_scales = sorted(orig_scale_keys - deq_keys)
+        if missing_scales:
+            result["scale_key_handling"][
+                "message"
+            ] = f"Expected scale_inv keys in dequantized checkpoint but missing: {missing_scales[:5]}{'...' if len(missing_scales) > 5 else ''}"
+        else:
+            result["scale_key_handling"]["passed"] = True
+            result["scale_key_handling"]["message"] = "All scale_inv keys present"
+    else:
+        present_scales = sorted(deq_keys & orig_scale_keys)
+        if present_scales:
+            result["scale_key_handling"][
+                "message"
+            ] = f"Dequantized checkpoint should not contain scale_inv keys but has: {present_scales[:5]}{'...' if len(present_scales) > 5 else ''}"
+        else:
+            result["scale_key_handling"]["passed"] = True
+            result["scale_key_handling"]["message"] = "No scale_inv keys in dequantized (expected)"
+
+    # 3. No extra keys
+    allowed_deq = orig_base_keys | (orig_scale_keys if keep_scale_inv else set())
+    extra = sorted(deq_keys - allowed_deq)
+    result["no_extra_keys"]["extra_keys"] = extra
+    result["no_extra_keys"]["passed"] = len(extra) == 0
+
+    # 4 & 5. Shape and dtype
+    keys_by_file_orig = build_keys_by_file(orig_weight_map)
+    keys_by_file_deq = build_keys_by_file(deq_weight_map)
+    orig_meta = _collect_metadata_from_checkpoint(original_dir, orig_weight_map, keys_by_file_orig)
+    deq_meta = _collect_metadata_from_checkpoint(dequantized_dir, deq_weight_map, keys_by_file_deq)
+
+    keys_to_compare = orig_base_keys & deq_keys
+    shape_mismatches = []
+    dtype_mismatches = []
+    fp8_dtypes = (torch.float8_e4m3fn, getattr(torch, "float8_e5m2", None))
+    for key in sorted(keys_to_compare):
+        orig_shape, orig_dtype_str = orig_meta[key]
+        deq_shape, deq_dtype_str = deq_meta[key]
+        if orig_shape != deq_shape:
+            shape_mismatches.append((key, orig_shape, deq_shape))
+        orig_is_fp8 = _is_fp8_safetensors_dtype(orig_dtype_str)
+        try:
+            deq_torch_dtype = _safetensors_dtype_to_torch(deq_dtype_str)
+        except ValueError:
+            dtype_mismatches.append((key, orig_dtype_str, deq_dtype_str, "unsupported dtype"))
+            continue
+        if orig_is_fp8:
+            if not (deq_torch_dtype.is_floating_point and deq_torch_dtype not in fp8_dtypes):
+                dtype_mismatches.append((key, orig_dtype_str, deq_dtype_str, "expected float (dequantized)"))
+        else:
+            try:
+                orig_torch = _safetensors_dtype_to_torch(orig_dtype_str)
+                if deq_torch_dtype != orig_torch:
+                    dtype_mismatches.append((key, orig_dtype_str, deq_dtype_str, "passthrough dtype must match"))
+            except ValueError:
+                pass
+
+    result["shape_preservation"]["mismatches"] = shape_mismatches
+    result["shape_preservation"]["passed"] = len(shape_mismatches) == 0
+    result["dtype_correctness"]["mismatches"] = dtype_mismatches
+    result["dtype_correctness"]["passed"] = len(dtype_mismatches) == 0
+
+    # 6. Shard file existence (dequantized)
+    missing_shards = _check_shard_files_exist(dequantized_dir, deq_weight_map)
+    result["shard_files_exist"]["missing_shards"] = missing_shards
+    result["shard_files_exist"]["passed"] = len(missing_shards) == 0
+
+    result["all_passed"] = (
+        result["key_completeness"]["passed"]
+        and result["scale_key_handling"]["passed"]
+        and result["no_extra_keys"]["passed"]
+        and result["shape_preservation"]["passed"]
+        and result["dtype_correctness"]["passed"]
+        and result["shard_files_exist"]["passed"]
+    )
+    result["orig_meta"] = orig_meta
+    result["deq_meta"] = deq_meta
+    result["block_shape"] = block_shape
+    result["orig_weight_map"] = orig_weight_map
+    result["deq_weight_map"] = deq_weight_map
+    result["orig_base_keys"] = orig_base_keys
+    result["orig_scale_keys"] = orig_scale_keys
+    return result
+
+
+class _ShardReader:
+    """Lazy reader that opens shards on demand and caches handles."""
+
+    def __init__(self, model_dir: Path, weight_map: dict[str, str]):
+        self._model_dir = model_dir
+        self._weight_map = weight_map
+        self._handles: dict[str, Any] = {}
+
+    def get_tensor(self, key: str) -> torch.Tensor:
+        if key not in self._weight_map:
+            raise KeyError(key)
+        shard_name = self._weight_map[key]
+        if shard_name not in self._handles:
+            path = self._model_dir / shard_name
+            self._handles[shard_name] = safe_open(path, framework="pt", device="cpu")
+        return self._handles[shard_name].get_tensor(key)
+
+    def close(self) -> None:
+        for h in self._handles.values():
+            close_fn = getattr(h, "close", None)
+            if callable(close_fn):
+                close_fn()
+        self._handles.clear()
+
+
+def run_value_checks(
+    meta_result: dict[str, Any],
+    original_dir: Path,
+    dequantized_dir: Path,
+    rtol: float,
+    atol: float,
+) -> dict[str, Any]:
+    """Run tier-2 value checks. meta_result must contain orig_meta, deq_meta, block_shape, weight_maps, orig_base_keys."""
+    value_result: dict[str, Any] = {
+        "passthrough_ok": [],
+        "passthrough_fail": [],
+        "dequantized_ok": [],
+        "dequantized_fail": [],
+        "all_passed": False,
+    }
+    orig_reader = _ShardReader(original_dir, meta_result["orig_weight_map"])
+    deq_reader = _ShardReader(dequantized_dir, meta_result["deq_weight_map"])
+    block_shape = meta_result["block_shape"]
+    orig_meta = meta_result["orig_meta"]
+    deq_meta = meta_result["deq_meta"]
+    orig_base_keys = meta_result["orig_base_keys"]
+    keys_to_check = orig_base_keys & set(deq_meta.keys())
+    total = len(keys_to_check)
+    started = time.monotonic()
+    last_log = started
+    try:
+        for idx, key in enumerate(sorted(keys_to_check)):
+            orig_shape, orig_dtype_str = orig_meta[key]
+            orig_is_fp8 = _is_fp8_safetensors_dtype(orig_dtype_str)
+            orig_t = orig_reader.get_tensor(key)
+            deq_t = deq_reader.get_tensor(key)
+            if not orig_is_fp8:
+                if torch.equal(orig_t, deq_t):
+                    value_result["passthrough_ok"].append(key)
+                else:
+                    value_result["passthrough_fail"].append(key)
+            else:
+                scale_key = f"{key}_scale_inv"
+                inv_scale = orig_reader.get_tensor(scale_key)
+                expected = dequantize_tensor(orig_t, inv_scale, block_shape).to(deq_t.dtype)
+                if torch.allclose(deq_t.float(), expected.float(), rtol=rtol, atol=atol):
+                    value_result["dequantized_ok"].append(key)
+                else:
+                    value_result["dequantized_fail"].append(key)
+            now = time.monotonic()
+            if now - last_log >= 10.0:
+                logger.info(
+                    f"Value check progress: {idx + 1}/{total} "
+                    f"({100.0 * (idx + 1) / total:.1f}%), elapsed={now - started:.1f}s"
+                    f"passthrough_fail={len(value_result['passthrough_fail'])}, dequantized_fail={len(value_result['dequantized_fail'])}"
+                )
+                last_log = now
+    finally:
+        orig_reader.close()
+        deq_reader.close()
+
+    value_result["all_passed"] = (
+        len(value_result["passthrough_fail"]) == 0 and len(value_result["dequantized_fail"]) == 0
+    )
+    return value_result
+
+
+def print_summary(meta_result: dict[str, Any], value_result: dict[str, Any] | None) -> None:
+    """Print structured summary to stderr/log."""
+    logger.info("=" * 60)
+    logger.info("VALIDATION SUMMARY")
+    logger.info("=" * 60)
+
+    def section(name: str, passed: bool, details: str = ""):
+        status = "PASS" if passed else "FAIL"
+        logger.info(f"  [{status}] {name}")
+        if details:
+            logger.info(f"         {details}")
+
+    section("Key completeness", meta_result["key_completeness"]["passed"])
+    if meta_result["key_completeness"]["missing_keys"]:
+        mk = meta_result["key_completeness"]["missing_keys"]
+        logger.info(f"         Missing: {mk[:10]}{'...' if len(mk) > 10 else ''}")
+
+    section(
+        "Scale key handling", meta_result["scale_key_handling"]["passed"], meta_result["scale_key_handling"]["message"]
+    )
+    section("No extra keys", meta_result["no_extra_keys"]["passed"])
+    if meta_result["no_extra_keys"]["extra_keys"]:
+        ek = meta_result["no_extra_keys"]["extra_keys"]
+        logger.info(f"         Extra: {ek[:10]}{'...' if len(ek) > 10 else ''}")
+
+    section("Shape preservation", meta_result["shape_preservation"]["passed"])
+    for key, o, d in meta_result["shape_preservation"]["mismatches"][:5]:
+        logger.info(f"         {key}: orig{o} vs deq{d}")
+    if len(meta_result["shape_preservation"]["mismatches"]) > 5:
+        logger.info(f"         ... and {len(meta_result['shape_preservation']['mismatches']) - 5} more")
+
+    section("Dtype correctness", meta_result["dtype_correctness"]["passed"])
+    for tup in meta_result["dtype_correctness"]["mismatches"][:5]:
+        logger.info(f"         {tup[0]}: orig={tup[1]} deq={tup[2]} ({tup[3]})")
+    if len(meta_result["dtype_correctness"]["mismatches"]) > 5:
+        logger.info(f"         ... and {len(meta_result['dtype_correctness']['mismatches']) - 5} more")
+
+    section("Shard files exist", meta_result["shard_files_exist"]["passed"])
+    if meta_result["shard_files_exist"]["missing_shards"]:
+        logger.info(f"         Missing: {meta_result['shard_files_exist']['missing_shards']}")
+
+    meta_ok = meta_result["all_passed"]
+    logger.info("-" * 60)
+    logger.info(f"  Metadata checks: {'PASS' if meta_ok else 'FAIL'}")
+
+    if value_result is not None:
+        section("Passthrough tensor equality", len(value_result["passthrough_fail"]) == 0)
+        if value_result["passthrough_fail"]:
+            pf = value_result["passthrough_fail"]
+            logger.info(f"         Failed: {pf[:5]}{'...' if len(pf) > 5 else ''}")
+        section("Dequantized tensor correctness", len(value_result["dequantized_fail"]) == 0)
+        if value_result["dequantized_fail"]:
+            df = value_result["dequantized_fail"]
+            logger.info(f"         Failed: {df[:5]}{'...' if len(df) > 5 else ''}")
+        logger.info(f"  Value checks: {'PASS' if value_result['all_passed'] else 'FAIL'}")
+    logger.info("=" * 60)
+
+
+def main() -> int:
+    args = parse_args()
+    original_dir = args.original_dir.expanduser().resolve()
+    dequantized_dir = args.dequantized_dir.expanduser().resolve()
+    if not original_dir.is_dir():
+        logger.error(f"Original directory does not exist: {original_dir}")
+        return 1
+    if not dequantized_dir.is_dir():
+        logger.error(f"Dequantized directory does not exist: {dequantized_dir}")
+        return 1
+    if original_dir == dequantized_dir:
+        logger.error("Original and dequantized directories must be different")
+        return 1
+
+    logger.info(f"Original checkpoint: {original_dir}")
+    logger.info(f"Dequantized checkpoint: {dequantized_dir}")
+    logger.info(f"Keep scale_inv: {args.keep_scale_inv}, Check values: {args.check_values}")
+
+    meta_result = run_metadata_checks(original_dir, dequantized_dir, args.keep_scale_inv)
+    value_result = None
+    if args.check_values and meta_result["all_passed"]:
+        value_result = run_value_checks(meta_result, original_dir, dequantized_dir, args.rtol, args.atol)
+    elif args.check_values and not meta_result["all_passed"]:
+        logger.warning("Skipping value checks because metadata checks failed")
+
+    print_summary(meta_result, value_result)
+
+    if not meta_result["all_passed"]:
+        return 1
+    if value_result is not None and not value_result["all_passed"]:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/models/demos/deepseek_v3/scripts/validate_dequantized_checkpoint.py
+++ b/models/demos/deepseek_v3/scripts/validate_dequantized_checkpoint.py
@@ -15,12 +15,8 @@ import torch
 from loguru import logger
 from safetensors import safe_open
 
-from models.demos.deepseek_v3.scripts.dequantize_hf_checkpoint import (
-    build_keys_by_file,
-    dequantize_tensor,
-    load_block_shape,
-    load_index,
-)
+from models.demos.deepseek_v3.scripts.dequantize_hf_checkpoint import build_keys_by_file, load_block_shape, load_index
+from models.demos.deepseek_v3.utils.dequantize import dequantize_tensor
 
 
 def _safetensors_dtype_to_torch(dtype_str: str) -> torch.dtype:

--- a/models/demos/deepseek_v3/tests/test_deepseek_weight_dequantization.py
+++ b/models/demos/deepseek_v3/tests/test_deepseek_weight_dequantization.py
@@ -90,6 +90,7 @@ def test_convert_checkpoint_dequantizes_and_drops_scale_inv(tmp_path: Path):
         out_dtype=torch.bfloat16,
         keep_scale_inv=False,
         max_output_shard_size_bytes=1024 * 1024,
+        num_workers=2,
     )
 
     index = json.loads((output_dir / "model.safetensors.index.json").read_text(encoding="utf-8"))
@@ -244,4 +245,20 @@ def test_convert_checkpoint_same_input_and_output_raises(tmp_path: Path):
             out_dtype=torch.bfloat16,
             keep_scale_inv=False,
             max_output_shard_size_bytes=1024 * 1024,
+        )
+
+
+def test_convert_checkpoint_num_workers_must_be_positive(tmp_path: Path):
+    input_dir = tmp_path / "input_ckpt"
+    output_dir = tmp_path / "output_ckpt"
+    _write_tiny_checkpoint(input_dir)
+
+    with pytest.raises(ValueError, match="num_workers must be > 0"):
+        convert_checkpoint(
+            input_dir=input_dir,
+            output_dir=output_dir,
+            out_dtype=torch.bfloat16,
+            keep_scale_inv=False,
+            max_output_shard_size_bytes=1024 * 1024,
+            num_workers=0,
         )

--- a/models/demos/deepseek_v3/tests/test_deepseek_weight_dequantization.py
+++ b/models/demos/deepseek_v3/tests/test_deepseek_weight_dequantization.py
@@ -9,6 +9,7 @@ import pytest
 import torch
 from safetensors.torch import load_file, save_file
 
+import models.demos.deepseek_v3.scripts.dequantize_hf_checkpoint as dequant_script
 from models.demos.deepseek_v3.scripts.dequantize_hf_checkpoint import convert_checkpoint
 
 
@@ -262,3 +263,148 @@ def test_convert_checkpoint_num_workers_must_be_positive(tmp_path: Path):
             max_output_shard_size_bytes=1024 * 1024,
             num_workers=0,
         )
+
+
+def test_convert_checkpoint_resume_reuses_existing_tmp_outputs(tmp_path: Path, monkeypatch):
+    input_dir = tmp_path / "input_ckpt"
+    output_dir = tmp_path / "output_ckpt"
+    quantized_weight, scale_inv, _normal_weight = _write_tiny_checkpoint(input_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    index_obj = dequant_script.load_index(input_dir / "model.safetensors.index.json")
+    weight_map = index_obj["weight_map"]
+    keys_by_file = dequant_script.build_keys_by_file(weight_map)
+    shard_names = sorted(keys_by_file.keys())
+    shard_1_name = shard_names[0]
+    shard_1_keys = keys_by_file[shard_1_name]
+    block_shape = dequant_script.load_block_shape(input_dir / "config.json")
+
+    shard_1_result = dequant_script.process_source_shard(
+        shard_idx=1,
+        shard_name=shard_1_name,
+        keys=shard_1_keys,
+        input_dir=input_dir,
+        output_dir=output_dir,
+        weight_map=weight_map,
+        block_shape=block_shape,
+        out_dtype=torch.bfloat16,
+        keep_scale_inv=False,
+        max_output_shard_size_bytes=1024 * 1024,
+    )
+    dequant_script.write_source_shard_manifest(
+        output_dir=output_dir,
+        result=shard_1_result,
+        source_keys=shard_1_keys,
+        out_dtype=torch.bfloat16,
+        keep_scale_inv=False,
+    )
+
+    original_process_source_shard = dequant_script.process_source_shard
+
+    def _process_source_shard_with_guard(*args, **kwargs):
+        shard_idx = kwargs.get("shard_idx")
+        if shard_idx is None and args:
+            shard_idx = args[0]
+        if shard_idx == 1:
+            raise AssertionError("Shard 1 should have been resumed, not regenerated.")
+        return original_process_source_shard(*args, **kwargs)
+
+    monkeypatch.setattr(dequant_script, "process_source_shard", _process_source_shard_with_guard)
+
+    convert_checkpoint(
+        input_dir=input_dir,
+        output_dir=output_dir,
+        out_dtype=torch.bfloat16,
+        keep_scale_inv=False,
+        max_output_shard_size_bytes=1024 * 1024,
+        num_workers=1,
+        resume=True,
+    )
+
+    index = json.loads((output_dir / "model.safetensors.index.json").read_text(encoding="utf-8"))
+    expected = _expected_dequantized(quantized_weight, scale_inv, (2, 2)).to(torch.bfloat16)
+    out_dequant = _load_tensor_from_output(output_dir, index, "model.layers.0.mlp.gate_proj.weight")
+    torch.testing.assert_close(out_dequant, expected, rtol=0, atol=0)
+
+    assert not dequant_script.source_shard_manifest_path(output_dir, 1).exists()
+
+
+def test_convert_checkpoint_resume_recovers_legacy_tmp_outputs_without_manifest(tmp_path: Path, monkeypatch):
+    input_dir = tmp_path / "input_ckpt"
+    output_dir = tmp_path / "output_ckpt"
+    quantized_weight, scale_inv, _normal_weight = _write_tiny_checkpoint(input_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    index_obj = dequant_script.load_index(input_dir / "model.safetensors.index.json")
+    weight_map = index_obj["weight_map"]
+    keys_by_file = dequant_script.build_keys_by_file(weight_map)
+    shard_names = sorted(keys_by_file.keys())
+    shard_1_name = shard_names[0]
+    shard_1_keys = keys_by_file[shard_1_name]
+    block_shape = dequant_script.load_block_shape(input_dir / "config.json")
+
+    # Simulate a legacy crashed run that wrote tmp output shards but no resume manifest.
+    dequant_script.process_source_shard(
+        shard_idx=1,
+        shard_name=shard_1_name,
+        keys=shard_1_keys,
+        input_dir=input_dir,
+        output_dir=output_dir,
+        weight_map=weight_map,
+        block_shape=block_shape,
+        out_dtype=torch.bfloat16,
+        keep_scale_inv=False,
+        max_output_shard_size_bytes=1024 * 1024,
+    )
+
+    original_process_source_shard = dequant_script.process_source_shard
+
+    def _process_source_shard_with_guard(*args, **kwargs):
+        shard_idx = kwargs.get("shard_idx")
+        if shard_idx is None and args:
+            shard_idx = args[0]
+        if shard_idx == 1:
+            raise AssertionError("Shard 1 should have been recovered from legacy tmp files.")
+        return original_process_source_shard(*args, **kwargs)
+
+    monkeypatch.setattr(dequant_script, "process_source_shard", _process_source_shard_with_guard)
+
+    convert_checkpoint(
+        input_dir=input_dir,
+        output_dir=output_dir,
+        out_dtype=torch.bfloat16,
+        keep_scale_inv=False,
+        max_output_shard_size_bytes=1024 * 1024,
+        num_workers=1,
+        resume=True,
+    )
+
+    index = json.loads((output_dir / "model.safetensors.index.json").read_text(encoding="utf-8"))
+    expected = _expected_dequantized(quantized_weight, scale_inv, (2, 2)).to(torch.bfloat16)
+    out_dequant = _load_tensor_from_output(output_dir, index, "model.layers.0.mlp.gate_proj.weight")
+    torch.testing.assert_close(out_dequant, expected, rtol=0, atol=0)
+
+
+def test_convert_checkpoint_resume_ignores_corrupt_legacy_tmp_files(tmp_path: Path):
+    input_dir = tmp_path / "input_ckpt"
+    output_dir = tmp_path / "output_ckpt"
+    quantized_weight, scale_inv, _normal_weight = _write_tiny_checkpoint(input_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    # Simulate a crashed writer that left a truncated/corrupt tmp safetensors file.
+    (output_dir / ".tmp-s00001-00001.safetensors").write_bytes(b"not-a-valid-safetensors-file")
+
+    convert_checkpoint(
+        input_dir=input_dir,
+        output_dir=output_dir,
+        out_dtype=torch.bfloat16,
+        keep_scale_inv=False,
+        max_output_shard_size_bytes=1024 * 1024,
+        num_workers=1,
+        resume=True,
+    )
+
+    index = json.loads((output_dir / "model.safetensors.index.json").read_text(encoding="utf-8"))
+    expected = _expected_dequantized(quantized_weight, scale_inv, (2, 2)).to(torch.bfloat16)
+    out_dequant = _load_tensor_from_output(output_dir, index, "model.layers.0.mlp.gate_proj.weight")
+    torch.testing.assert_close(out_dequant, expected, rtol=0, atol=0)

--- a/models/demos/deepseek_v3/tests/test_deepseek_weight_dequantization.py
+++ b/models/demos/deepseek_v3/tests/test_deepseek_weight_dequantization.py
@@ -1,0 +1,247 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import json
+from pathlib import Path
+
+import pytest
+import torch
+from safetensors.torch import load_file, save_file
+
+from models.demos.deepseek_v3.scripts.dequantize_hf_checkpoint import convert_checkpoint
+
+
+def _write_config(model_dir: Path, block_shape: tuple[int, int]) -> None:
+    (model_dir / "config.json").write_text(
+        json.dumps({"quantization_config": {"weight_block_size": list(block_shape)}}),
+        encoding="utf-8",
+    )
+
+
+def _write_index(model_dir: Path, weight_map: dict[str, str]) -> None:
+    (model_dir / "model.safetensors.index.json").write_text(
+        json.dumps({"metadata": {"total_size": 0}, "weight_map": weight_map}),
+        encoding="utf-8",
+    )
+
+
+def _write_tiny_checkpoint(model_dir: Path) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    model_dir.mkdir(parents=True, exist_ok=True)
+    _write_config(model_dir, block_shape=(2, 2))
+
+    quantized_weight = torch.tensor(
+        [[0.5, -1.0, 1.25], [2.0, -2.5, 3.0]],
+        dtype=torch.float8_e4m3fn,
+    )
+    scale_inv = torch.tensor([[2.0, 4.0]], dtype=torch.float32)
+    normal_weight = torch.arange(6, dtype=torch.float32).reshape(2, 3)
+
+    shard_1 = "model-00001-of-00002.safetensors"
+    shard_2 = "model-00002-of-00002.safetensors"
+
+    save_file(
+        {
+            "model.layers.0.mlp.gate_proj.weight": quantized_weight,
+            "model.norm.weight": normal_weight,
+        },
+        str(model_dir / shard_1),
+    )
+    save_file(
+        {"model.layers.0.mlp.gate_proj.weight_scale_inv": scale_inv},
+        str(model_dir / shard_2),
+    )
+
+    _write_index(
+        model_dir,
+        {
+            "model.layers.0.mlp.gate_proj.weight": shard_1,
+            "model.norm.weight": shard_1,
+            "model.layers.0.mlp.gate_proj.weight_scale_inv": shard_2,
+        },
+    )
+
+    # Auxiliary file must be copied to output.
+    (model_dir / "tokenizer.json").write_text('{"ok": true}', encoding="utf-8")
+
+    return quantized_weight, scale_inv, normal_weight
+
+
+def _expected_dequantized(weight: torch.Tensor, scale_inv: torch.Tensor, block_shape: tuple[int, int]) -> torch.Tensor:
+    expanded = scale_inv
+    for dim, block_dim in enumerate(block_shape):
+        expanded = expanded.repeat_interleave(block_dim, dim=dim)
+    return weight.float() * expanded[: weight.shape[0], : weight.shape[1]].float()
+
+
+def _load_tensor_from_output(output_dir: Path, index: dict, key: str) -> torch.Tensor:
+    shard_name = index["weight_map"][key]
+    return load_file(str(output_dir / shard_name))[key]
+
+
+def test_convert_checkpoint_dequantizes_and_drops_scale_inv(tmp_path: Path):
+    input_dir = tmp_path / "input_ckpt"
+    output_dir = tmp_path / "output_ckpt"
+    quantized_weight, scale_inv, normal_weight = _write_tiny_checkpoint(input_dir)
+
+    convert_checkpoint(
+        input_dir=input_dir,
+        output_dir=output_dir,
+        out_dtype=torch.bfloat16,
+        keep_scale_inv=False,
+        max_output_shard_size_bytes=1024 * 1024,
+    )
+
+    index = json.loads((output_dir / "model.safetensors.index.json").read_text(encoding="utf-8"))
+
+    assert "model.layers.0.mlp.gate_proj.weight_scale_inv" not in index["weight_map"]
+
+    expected = _expected_dequantized(quantized_weight, scale_inv, (2, 2)).to(torch.bfloat16)
+    out_dequant = _load_tensor_from_output(output_dir, index, "model.layers.0.mlp.gate_proj.weight")
+    out_normal = _load_tensor_from_output(output_dir, index, "model.norm.weight")
+    torch.testing.assert_close(out_dequant, expected, rtol=0, atol=0)
+    torch.testing.assert_close(out_normal, normal_weight, rtol=0, atol=0)
+    assert out_dequant.dtype == torch.bfloat16
+
+    # Auxiliary files are copied.
+    assert (output_dir / "tokenizer.json").is_file()
+
+
+def test_convert_checkpoint_keeps_scale_inv_when_requested(tmp_path: Path):
+    input_dir = tmp_path / "input_ckpt"
+    output_dir = tmp_path / "output_ckpt"
+    _quantized_weight, scale_inv, _normal_weight = _write_tiny_checkpoint(input_dir)
+
+    convert_checkpoint(
+        input_dir=input_dir,
+        output_dir=output_dir,
+        out_dtype=torch.bfloat16,
+        keep_scale_inv=True,
+        max_output_shard_size_bytes=1024 * 1024,
+    )
+
+    index = json.loads((output_dir / "model.safetensors.index.json").read_text(encoding="utf-8"))
+    assert "model.layers.0.mlp.gate_proj.weight_scale_inv" in index["weight_map"]
+
+    output_scale = _load_tensor_from_output(output_dir, index, "model.layers.0.mlp.gate_proj.weight_scale_inv")
+    torch.testing.assert_close(output_scale, scale_inv, rtol=0, atol=0)
+
+
+def test_convert_checkpoint_missing_scale_inv_raises(tmp_path: Path):
+    input_dir = tmp_path / "input_missing_scale"
+    input_dir.mkdir(parents=True, exist_ok=True)
+    _write_config(input_dir, block_shape=(2, 2))
+
+    quantized_weight = torch.tensor([[1.0, 0.5], [-1.0, 2.0]], dtype=torch.float8_e4m3fn)
+    shard_1 = "model-00001-of-00001.safetensors"
+    save_file({"model.layers.0.self_attn.q_a_proj.weight": quantized_weight}, str(input_dir / shard_1))
+    _write_index(
+        input_dir,
+        {
+            "model.layers.0.self_attn.q_a_proj.weight": shard_1,
+        },
+    )
+
+    output_fail = tmp_path / "output_fail"
+    with pytest.raises(KeyError, match="Missing inverse-scale tensor"):
+        convert_checkpoint(
+            input_dir=input_dir,
+            output_dir=output_fail,
+            out_dtype=torch.bfloat16,
+            keep_scale_inv=False,
+            max_output_shard_size_bytes=1024 * 1024,
+        )
+
+
+def test_convert_checkpoint_orphan_scale_inv_raises(tmp_path: Path):
+    input_dir = tmp_path / "input_orphan_scale"
+    input_dir.mkdir(parents=True, exist_ok=True)
+    _write_config(input_dir, block_shape=(2, 2))
+
+    scale = torch.ones((1, 1), dtype=torch.float32)
+    shard = "model-00001-of-00001.safetensors"
+    save_file({"model.layers.0.mlp.gate_proj.weight_scale_inv": scale}, str(input_dir / shard))
+    _write_index(
+        input_dir,
+        {
+            "model.layers.0.mlp.gate_proj.weight_scale_inv": shard,
+        },
+    )
+
+    with pytest.raises(ValueError, match="scale tensor without matching base tensor"):
+        convert_checkpoint(
+            input_dir=input_dir,
+            output_dir=tmp_path / "output_orphan_scale",
+            out_dtype=torch.bfloat16,
+            keep_scale_inv=False,
+            max_output_shard_size_bytes=1024 * 1024,
+        )
+
+
+def test_convert_checkpoint_non_fp8_tensor_with_scale_raises(tmp_path: Path):
+    input_dir = tmp_path / "input_non_fp8_scale"
+    input_dir.mkdir(parents=True, exist_ok=True)
+    _write_config(input_dir, block_shape=(2, 2))
+
+    shard = "model-00001-of-00001.safetensors"
+    save_file(
+        {
+            "model.layers.0.self_attn.q_a_proj.weight": torch.ones((2, 2), dtype=torch.float32),
+            "model.layers.0.self_attn.q_a_proj.weight_scale_inv": torch.ones((1, 1), dtype=torch.float32),
+        },
+        str(input_dir / shard),
+    )
+    _write_index(
+        input_dir,
+        {
+            "model.layers.0.self_attn.q_a_proj.weight": shard,
+            "model.layers.0.self_attn.q_a_proj.weight_scale_inv": shard,
+        },
+    )
+
+    with pytest.raises(ValueError, match="expected FP8 payload"):
+        convert_checkpoint(
+            input_dir=input_dir,
+            output_dir=tmp_path / "output_non_fp8_scale",
+            out_dtype=torch.bfloat16,
+            keep_scale_inv=False,
+            max_output_shard_size_bytes=1024 * 1024,
+        )
+
+
+def test_convert_checkpoint_index_key_missing_in_shard_raises(tmp_path: Path):
+    input_dir = tmp_path / "input_bad_index"
+    input_dir.mkdir(parents=True, exist_ok=True)
+    _write_config(input_dir, block_shape=(2, 2))
+
+    shard = "model-00001-of-00001.safetensors"
+    save_file({"model.norm.weight": torch.ones((2, 2), dtype=torch.float32)}, str(input_dir / shard))
+    _write_index(
+        input_dir,
+        {
+            "model.layers.0.mlp.gate_proj.weight": shard,  # not present in shard payload
+        },
+    )
+
+    with pytest.raises(KeyError, match="missing in the referenced shard"):
+        convert_checkpoint(
+            input_dir=input_dir,
+            output_dir=tmp_path / "output_bad_index",
+            out_dtype=torch.bfloat16,
+            keep_scale_inv=False,
+            max_output_shard_size_bytes=1024 * 1024,
+        )
+
+
+def test_convert_checkpoint_same_input_and_output_raises(tmp_path: Path):
+    input_dir = tmp_path / "same_io"
+    _write_tiny_checkpoint(input_dir)
+
+    with pytest.raises(ValueError, match="Input and output directories must be different"):
+        convert_checkpoint(
+            input_dir=input_dir,
+            output_dir=input_dir,
+            out_dtype=torch.bfloat16,
+            keep_scale_inv=False,
+            max_output_shard_size_bytes=1024 * 1024,
+        )

--- a/models/demos/deepseek_v3/tests/test_dequantize.py
+++ b/models/demos/deepseek_v3/tests/test_dequantize.py
@@ -11,6 +11,7 @@ from models.demos.deepseek_v3.utils.dequantize import dequantize_tensor
 
 
 def _reference_dequantize(tensor: torch.Tensor, inv_scale: torch.Tensor, block_shape: tuple[int, ...]) -> torch.Tensor:
+    """Naive reference implementation of dequantization that uses `repeat_interleave`"""
     expanded = inv_scale
     for dim, block_dim in enumerate(block_shape):
         expanded = expanded.repeat_interleave(block_dim, dim=dim)
@@ -30,11 +31,11 @@ def _reference_dequantize(tensor: torch.Tensor, inv_scale: torch.Tensor, block_s
 def test_dequantize_tensor_matches_reference(
     shape: tuple[int, ...], block_shape: tuple[int, ...], input_dtype: torch.dtype
 ):
-    torch.manual_seed(sum(shape) + sum(block_shape) + int(input_dtype == torch.bfloat16))
+    torch.manual_seed(1234)
     inv_shape = tuple(math.ceil(shape[i] / block_shape[i]) for i in range(len(shape)))
 
-    quantized = torch.randn(shape, dtype=torch.float32).to(input_dtype)
-    inv_scale = torch.randn(inv_shape, dtype=torch.float32)
+    quantized = torch.rand(shape, dtype=torch.float32).to(input_dtype)
+    inv_scale = torch.rand(inv_shape, dtype=torch.float32)
 
     expected = _reference_dequantize(quantized, inv_scale, block_shape)
     actual = dequantize_tensor(quantized, inv_scale, block_shape)

--- a/models/demos/deepseek_v3/tests/test_dequantize.py
+++ b/models/demos/deepseek_v3/tests/test_dequantize.py
@@ -1,0 +1,51 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import math
+
+import pytest
+import torch
+
+from models.demos.deepseek_v3.utils.dequantize import dequantize_tensor
+
+
+def _reference_dequantize(tensor: torch.Tensor, inv_scale: torch.Tensor, block_shape: tuple[int, ...]) -> torch.Tensor:
+    expanded = inv_scale
+    for dim, block_dim in enumerate(block_shape):
+        expanded = expanded.repeat_interleave(block_dim, dim=dim)
+    slices = tuple(slice(0, size) for size in tensor.shape)
+    return tensor.float() * expanded[slices].float()
+
+
+@pytest.mark.parametrize(
+    "shape,block_shape,input_dtype",
+    [
+        ((130, 257), (128, 128), torch.float8_e4m3fn),  # non-divisible in both dims
+        ((512, 1024), (128, 128), torch.float8_e4m3fn),  # exactly divisible
+        ((63, 65), (32, 32), torch.float8_e4m3fn),  # small non-divisible
+        ((5, 7, 9), (2, 3, 4), torch.float8_e4m3fn),  # rank-3 coverage
+    ],
+)
+def test_dequantize_tensor_matches_reference(
+    shape: tuple[int, ...], block_shape: tuple[int, ...], input_dtype: torch.dtype
+):
+    torch.manual_seed(sum(shape) + sum(block_shape) + int(input_dtype == torch.bfloat16))
+    inv_shape = tuple(math.ceil(shape[i] / block_shape[i]) for i in range(len(shape)))
+
+    quantized = torch.randn(shape, dtype=torch.float32).to(input_dtype)
+    inv_scale = torch.randn(inv_shape, dtype=torch.float32)
+
+    expected = _reference_dequantize(quantized, inv_scale, block_shape)
+    actual = dequantize_tensor(quantized, inv_scale, block_shape)
+
+    assert actual.dtype == torch.float32
+    assert torch.allclose(actual, expected, atol=1e-6, rtol=1e-6)
+
+
+def test_dequantize_tensor_rejects_invalid_rank():
+    quantized = torch.randn((2, 3), dtype=torch.float32).to(torch.float8_e4m3fn)
+    inv_scale = torch.randn((1,), dtype=torch.float32)
+
+    with pytest.raises(ValueError, match="same ndim"):
+        dequantize_tensor(quantized, inv_scale, (2, 2))

--- a/models/demos/deepseek_v3/utils/config_helpers.py
+++ b/models/demos/deepseek_v3/utils/config_helpers.py
@@ -15,6 +15,7 @@ from loguru import logger
 
 import ttnn
 from models.demos.deepseek_v3.utils.config_dataclass import SavedWeight
+from models.demos.deepseek_v3.utils.dequantize import dequantize_tensor
 from models.demos.deepseek_v3.utils.lazy_state_dict import LazyStateDict
 
 # Constants
@@ -494,11 +495,7 @@ def dequantize(tensor: torch.Tensor, inv_scale: torch.Tensor, block_shape: Seque
     assert len(block_shape) == tensor.ndim and all(
         inv_scale.shape[i] * block_shape[i] >= tensor.shape[i] for i in range(tensor.ndim)
     )
-    for i, block_dim in enumerate(block_shape):
-        inv_scale = inv_scale.repeat_interleave(block_dim, dim=i)
-    tensor = tensor.float() * inv_scale[tuple(slice(0, s) for s in tensor.shape)].float()
-    del inv_scale
-    return tensor
+    return dequantize_tensor(tensor, inv_scale, block_shape)
 
 
 def get_state_dicts(

--- a/models/demos/deepseek_v3/utils/dequantize.py
+++ b/models/demos/deepseek_v3/utils/dequantize.py
@@ -13,8 +13,15 @@ def dequantize_tensor(tensor: torch.Tensor, inv_scale: torch.Tensor, block_shape
     """
     Dequantize a tensor using block-wise inverse scales.
 
-    This implementation avoids materializing a fully expanded inverse-scale tensor
-    via repeat_interleave and instead applies scales with broadcasted block views.
+    Performance notes:
+    - Avoids `repeat_interleave` over `inv_scale`, which would materialize a huge
+      expanded scale tensor and significantly increase peak memory.
+    - Uses reshape+broadcast to apply scales per block, so scale expansion stays
+      virtual and the only dense payload is the output tensor itself.
+    - Uses in-place multiply on a view (`mul_`) to reduce temporary allocations
+      and memory bandwidth pressure.
+    - Pads only when needed for non-divisible shapes, then slices back to the
+      original shape.
     """
     if tensor.ndim != inv_scale.ndim:
         raise ValueError(f"Tensor and inverse scale must have same ndim, got {tensor.ndim} and {inv_scale.ndim}")
@@ -34,6 +41,8 @@ def dequantize_tensor(tensor: torch.Tensor, inv_scale: torch.Tensor, block_shape
 
     out = tensor.float()
     if padded_shape != original_shape:
+        # Only allocate a padded buffer when block coverage extends past the
+        # original tensor shape (tail blocks on non-divisible dimensions).
         padded = torch.zeros(padded_shape, dtype=out.dtype)
         padded[original_slices] = out
         out = padded
@@ -45,6 +54,8 @@ def dequantize_tensor(tensor: torch.Tensor, inv_scale: torch.Tensor, block_shape
         interleaved_shape.extend([blocks, block_dim])
         scale_broadcast_shape.extend([blocks, 1])
 
+    # Reshape into [blocks, block_size, ...] and apply broadcasted scales in
+    # place, avoiding explicit per-element scale expansion.
     out_view = out.reshape(*interleaved_shape)
     out_view.mul_(inv_scale.float().reshape(*scale_broadcast_shape))
     out = out_view.reshape(*padded_shape)

--- a/models/demos/deepseek_v3/utils/dequantize.py
+++ b/models/demos/deepseek_v3/utils/dequantize.py
@@ -1,0 +1,51 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from typing import Sequence
+
+import torch
+
+
+def dequantize_tensor(tensor: torch.Tensor, inv_scale: torch.Tensor, block_shape: Sequence[int]) -> torch.Tensor:
+    """
+    Dequantize a tensor using block-wise inverse scales.
+
+    This implementation avoids materializing a fully expanded inverse-scale tensor
+    via repeat_interleave and instead applies scales with broadcasted block views.
+    """
+    if tensor.ndim != inv_scale.ndim:
+        raise ValueError(f"Tensor and inverse scale must have same ndim, got {tensor.ndim} and {inv_scale.ndim}")
+    if len(block_shape) != tensor.ndim:
+        raise ValueError(
+            f"Block shape rank mismatch, got len(block_shape)={len(block_shape)} and tensor.ndim={tensor.ndim}"
+        )
+    if any(inv_scale.shape[i] * block_shape[i] < tensor.shape[i] for i in range(tensor.ndim)):
+        raise ValueError(
+            "Inverse scale shape does not cover tensor shape: "
+            f"tensor={tuple(tensor.shape)}, inv_scale={tuple(inv_scale.shape)}, block_shape={tuple(block_shape)}"
+        )
+
+    original_shape = tuple(tensor.shape)
+    padded_shape = tuple(inv_scale.shape[i] * block_shape[i] for i in range(tensor.ndim))
+    original_slices = tuple(slice(0, size) for size in original_shape)
+
+    out = tensor.float()
+    if padded_shape != original_shape:
+        padded = torch.zeros(padded_shape, dtype=out.dtype)
+        padded[original_slices] = out
+        out = padded
+
+    interleaved_shape: list[int] = []
+    scale_broadcast_shape: list[int] = []
+    for dim, block_dim in enumerate(block_shape):
+        blocks = inv_scale.shape[dim]
+        interleaved_shape.extend([blocks, block_dim])
+        scale_broadcast_shape.extend([blocks, 1])
+
+    out_view = out.reshape(*interleaved_shape)
+    out_view.mul_(inv_scale.float().reshape(*scale_broadcast_shape))
+    out = out_view.reshape(*padded_shape)
+    return out[original_slices]


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Provide context for the problem.

### What's changed
Describe the approach used to solve the problem.
Summarize the changes made and its impact.

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:{{branch_name}})
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:{{branch_name}})
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:{{branch_name}})
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:{{branch_name}})
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:{{branch_name}})
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:{{branch_name}})
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
