### PR TITLE
Enable Wan on 4x32 mesh

### DIFF
--- a/.github/workflows/galaxy-quick-impl.yaml
+++ b/.github/workflows/galaxy-quick-impl.yaml
@@ -176,6 +176,9 @@ jobs:
           pytest "tests/nightly/tg/ccl/test_all_broadcast.py::test_all_broadcast_trace[wormhole_b0-mesh_device0-device_params0-3-mem_config0-deepseek_1]" --timeout=300;
           pytest "tests/nightly/tg/ccl/test_all_reduce.py::test_line_all_reduce_on_TG_rows_post_commit[wormhole_b0-device_params0-ReduceType.Sum-8x4_grid-8-BufferType.DRAM-DataType.BFLOAT16-4-2-per_chip_output_shape0-Layout.TILE]" --timeout=300;
 
+          pytest tests/nightly/tg/ccl/test_neighbor_pad_async.py::test_neighbor_pad_async_1d -k "Wan_shape_1 and check" --timeout=300;
+          pytest tests/nightly/tg/ccl/test_neighbor_pad_async.py::test_neighbor_pad_async_2d -k "small_5d_h0w1 and wh_4x8_1link" --timeout=300;
+
           # Use Fabric Manager to initialize/teardown Fabric 2D and run all tests without initializing/tearing down fabric
           ./build/tools/scaleout/run_fabric_manager --mesh-shape 8x4 --fabric-config FABRIC_2D --initialize-fabric
           pytest "tests/scale_out/test_ccl_fabric_manager.py::test_all_to_all_combine_fabric_manager_8x4[wormhole_b0-dram_in_l1_out_axis0-bfloat16-None-num_links_4-2-dense-s2-7000-8-256-32-8x4_grid-False-fabric_manager_enabled_2d]" --timeout=300;

--- a/models/tt_dit/encoders/t5/model_t5.py
+++ b/models/tt_dit/encoders/t5/model_t5.py
@@ -8,6 +8,7 @@ import torch
 
 import ttnn
 
+from ...layers.embeddings import Embedding
 from ...layers.linear import ColParallelLinear, RowParallelLinear
 from ...layers.module import Module, ModuleList, Parameter
 from ...layers.normalization import RMSNorm
@@ -89,7 +90,7 @@ class T5Encoder(Module):
         self.ccl_manager = ccl_manager
         self.parallel_config = parallel_config
 
-        self.token_embeddings = TokenEmbeddings(config, self.mesh_device)
+        self.token_embeddings = Embedding(config.vocab_size, config.embed_dim, device=self.mesh_device)
         self.encoder = T5Stack(config, self.mesh_device, self.ccl_manager, self.parallel_config)
         self.final_layer_norm = T5RMSNorm(  # final layer norm
             embedding_dim=self.config.embed_dim,
@@ -458,20 +459,6 @@ def _relative_position_bucket(relative_position: torch.Tensor, num_buckets: int,
 
     relative_buckets += torch.where(is_small, relative_position, relative_position_if_large)
     return relative_buckets
-
-
-# TODO: Replace with Embedding layer from embeddings.py
-class TokenEmbeddings(Module):
-    def __init__(self, config: T5Config, mesh_device: ttnn.Device):
-        super().__init__()
-        self.config = config
-        self.mesh_device = mesh_device
-        self.weight = Parameter(
-            total_shape=[config.vocab_size, config.embed_dim], layout=ttnn.ROW_MAJOR_LAYOUT, device=self.mesh_device
-        )
-
-    def forward(self, prompt: ttnn.Tensor) -> ttnn.Tensor:
-        return ttnn.embedding(prompt, self.weight.data, layout=ttnn.TILE_LAYOUT)
 
 
 class RelativePositionEmbeddings(Module):

--- a/models/tt_dit/layers/embeddings.py
+++ b/models/tt_dit/layers/embeddings.py
@@ -527,11 +527,10 @@ class WanPatchEmbed(Module):
         """
 
         # Apply unfolded conv2d projection
-        latent_1BND = ttnn.linear(
+        latent_1BND = ttnn.experimental.minimal_matmul(
             latent_1BNI,
-            self.proj_weight.data,
-            bias=self.proj_bias.data,
-            dtype=ttnn.bfloat16,
+            weight_tensor=self.proj_weight.data,
+            bias_tensor=self.proj_bias.data,
             compute_kernel_config=self.compute_kernel_config,
         )
 

--- a/models/tt_dit/layers/linear.py
+++ b/models/tt_dit/layers/linear.py
@@ -58,10 +58,10 @@ class Linear(Module):
         if "bias" in state:
             state["bias"] = state["bias"].reshape(1, -1)
 
-    def forward(self, x: ttnn.Tensor, compute_kernel_config=None, dtype=None) -> ttnn.Tensor:
+    def forward(self, x: ttnn.Tensor, compute_kernel_config=None, dtype=None, default_block_size=None) -> ttnn.Tensor:
         M, K, N = x.padded_shape[-2], x.padded_shape[-1], self.weight.data.padded_shape[-1]
         core_grid = get_matmul_core_grid(self.mesh_device)
-        matmul_config = get_matmul_config(M, K, N, core_grid)
+        matmul_config = get_matmul_config(M, K, N, core_grid, default_block_size)
         output = ttnn.experimental.minimal_matmul(
             input_tensor=x,
             weight_tensor=self.weight.data,
@@ -180,7 +180,9 @@ class ColParallelLinear(Module):
                 bias = permute_for_swiglu(bias)
             state["bias"] = bias
 
-    def forward(self, x: ttnn.Tensor, compute_kernel_config=None) -> ttnn.Tensor | list[ttnn.Tensor]:
+    def forward(
+        self, x: ttnn.Tensor, compute_kernel_config=None, default_block_size=None
+    ) -> ttnn.Tensor | list[ttnn.Tensor]:
         """
         Expects x to be replicated.
         Return output fractured on columns.
@@ -198,7 +200,7 @@ class ColParallelLinear(Module):
 
         M, K, N = x.padded_shape[-2], x.padded_shape[-1], weight.padded_shape[-1]
         core_grid = get_matmul_core_grid(self.mesh_device)
-        matmul_config = get_matmul_config(M, K, N, core_grid)
+        matmul_config = get_matmul_config(M, K, N, core_grid, default_block_size)
 
         if self.chunks is not None:
             outputs = ttnn.experimental.minimal_matmul_split(
@@ -297,6 +299,7 @@ class RowParallelLinear(Module):
         *,
         compute_kernel_config=None,
         use_persistent_buffer: bool = True,
+        default_block_size: tuple = None,
     ) -> ttnn.Tensor:
         """
         Expects x to be column fractured.
@@ -314,7 +317,7 @@ class RowParallelLinear(Module):
 
         M, K, N = x.padded_shape[-2], x.padded_shape[-1], weight.padded_shape[-1]
         core_grid = get_matmul_core_grid(self.mesh_device)
-        matmul_config = get_matmul_config(M, K, N, core_grid)
+        matmul_config = get_matmul_config(M, K, N, core_grid, default_block_size)
         output = ttnn.experimental.minimal_matmul(
             input_tensor=x,
             weight_tensor=weight,

--- a/models/tt_dit/layers/linear.py
+++ b/models/tt_dit/layers/linear.py
@@ -8,7 +8,7 @@ import torch
 
 import ttnn
 
-from ..utils.matmul import get_matmul_config
+from ..utils.matmul import get_matmul_config, get_matmul_core_grid
 from .module import Module, Parameter
 
 MATH_FIDELITY = {
@@ -60,7 +60,7 @@ class Linear(Module):
 
     def forward(self, x: ttnn.Tensor, compute_kernel_config=None, dtype=None) -> ttnn.Tensor:
         M, K, N = x.padded_shape[-2], x.padded_shape[-1], self.weight.data.padded_shape[-1]
-        core_grid = self.mesh_device.compute_with_storage_grid_size()
+        core_grid = get_matmul_core_grid(self.mesh_device)
         matmul_config = get_matmul_config(M, K, N, core_grid)
         output = ttnn.experimental.minimal_matmul(
             input_tensor=x,
@@ -197,7 +197,7 @@ class ColParallelLinear(Module):
             weight = self.weight.data
 
         M, K, N = x.padded_shape[-2], x.padded_shape[-1], weight.padded_shape[-1]
-        core_grid = self.mesh_device.compute_with_storage_grid_size()
+        core_grid = get_matmul_core_grid(self.mesh_device)
         matmul_config = get_matmul_config(M, K, N, core_grid)
 
         if self.chunks is not None:
@@ -313,7 +313,7 @@ class RowParallelLinear(Module):
             weight = self.weight.data
 
         M, K, N = x.padded_shape[-2], x.padded_shape[-1], weight.padded_shape[-1]
-        core_grid = self.mesh_device.compute_with_storage_grid_size()
+        core_grid = get_matmul_core_grid(self.mesh_device)
         matmul_config = get_matmul_config(M, K, N, core_grid)
         output = ttnn.experimental.minimal_matmul(
             input_tensor=x,

--- a/models/tt_dit/layers/module.py
+++ b/models/tt_dit/layers/module.py
@@ -100,7 +100,6 @@ class Module(ABC):
         module_key_prefix: str,
         missing_keys: MutableSequence[str],
         unexpected_keys: MutableSequence[str],
-        on_host: bool,
     ) -> None:
         state_dict = dict(state_dict)
         self._prepare_torch_state(state_dict)
@@ -114,7 +113,6 @@ class Module(ABC):
                     module_key_prefix=f"{module_key_prefix}{name}.",
                     missing_keys=missing_keys,
                     unexpected_keys=unexpected_keys,
-                    on_host=on_host,
                 )
             except LoadingError:
                 raise
@@ -125,7 +123,7 @@ class Module(ABC):
         for name, parameter in self.named_parameters():
             if name in state_dict:
                 try:
-                    parameter.load_torch_tensor(state_dict.pop(name), on_host=on_host)
+                    parameter.load_torch_tensor(state_dict.pop(name))
                 except LoadingError as err:
                     msg = f"while loading '{module_key_prefix}{name}': {err}"
                     raise LoadingError(msg) from err
@@ -135,17 +133,12 @@ class Module(ABC):
         for name in state_dict:
             unexpected_keys.append(f"{module_key_prefix}{name}")
 
-    def load_torch_state_dict(
-        self, state_dict: Mapping[str, torch.Tensor], *, strict: bool = True, on_host: bool = False
-    ) -> IncompatibleKeys:
+    def load_torch_state_dict(self, state_dict: Mapping[str, torch.Tensor], *, strict: bool = True) -> IncompatibleKeys:
         """Load PyTorch state dict into module parameters.
 
         Args:
             state_dict: Mapping of parameter names to PyTorch tensors.
             strict: If `True`, raises ValueError on missing or unexpected keys.
-            on_host: If `True`, keeps tensors in host memory. This is used when saving the module
-                to disk, since for device tensors, every shard is currently stored to disk, even
-                for replicated tensors, leading to redundant copies of data.
 
         Returns:
             `IncompatibleKeys` containing lists of missing and unexpected keys.
@@ -154,11 +147,7 @@ class Module(ABC):
         unexpected_keys = []
 
         self._load_torch_state_dict_inner(
-            state_dict,
-            module_key_prefix="",
-            missing_keys=missing_keys,
-            unexpected_keys=unexpected_keys,
-            on_host=on_host,
+            state_dict, module_key_prefix="", missing_keys=missing_keys, unexpected_keys=unexpected_keys
         )
 
         if strict and (missing_keys or unexpected_keys):
@@ -376,13 +365,13 @@ class Parameter:
         self.on_host = on_host
         self._data = None
 
-    def load_torch_tensor(self, torch_tensor: torch.Tensor, /, *, on_host: bool = False) -> None:
+    def load_torch_tensor(self, torch_tensor: torch.Tensor, /) -> None:
         shape = tuple(torch_tensor.shape)
         if shape != self.total_shape:
             msg = f"expected tensor shape {self.total_shape}, got {shape}"
             raise LoadingError(msg)
 
-        data = tensor.from_torch(
+        self.data = tensor.from_torch(
             torch_tensor,
             device=self.device,
             layout=self.layout,
@@ -390,9 +379,8 @@ class Parameter:
             memory_config=self.memory_config,
             pad_value=self.pad_value,
             mesh_axes=self.mesh_axes,
-            on_host=self.on_host or on_host,
+            on_host=self.on_host,
         )
-        self._set_data(data, allow_on_host=on_host)
 
     def save(self, path: str | Path, /) -> None:
         ttnn.dump_tensor(path, self.data)
@@ -414,7 +402,8 @@ class Parameter:
 
     @data.setter
     def data(self, value: ttnn.Tensor) -> None:
-        self._set_data(value)
+        self._check_data(value)
+        self._data = value
 
     def deallocate(self) -> None:
         """Deallocate the parameter's device memory."""
@@ -422,15 +411,14 @@ class Parameter:
             ttnn.deallocate(self._data)
             self._data = None
 
-    def _set_data(self, value: ttnn.Tensor, *, allow_on_host: bool = False) -> None:
+    def _check_data(self, value: ttnn.Tensor) -> None:
         if self.on_host:
             if value.device() is not None:
                 msg = "expected host tensor, got device tensor"
                 raise LoadingError(msg)
         elif value.device() is None:
-            if not allow_on_host:
-                msg = "expected device tensor, got host tensor"
-                raise LoadingError(msg)
+            msg = "expected device tensor, got host tensor"
+            raise LoadingError(msg)
         elif value.device() != self.device:
             msg = "device mismatch"
             raise LoadingError(msg)
@@ -450,5 +438,3 @@ class Parameter:
         if value.shape != self.local_shape:
             msg = f"shape mismatch: expected {self.local_shape}, got {tuple(value.shape)}"
             raise LoadingError(msg)
-
-        self._data = value

--- a/models/tt_dit/layers/normalization.py
+++ b/models/tt_dit/layers/normalization.py
@@ -15,7 +15,15 @@ from .module import Module, Parameter
 
 
 class RMSNorm(Module):
-    def __init__(self, embedding_dim, norm_eps=1e-5, norm_elementwise_affine=True, bias=True, mesh_device=None):
+    def __init__(
+        self,
+        embedding_dim,
+        norm_eps=1e-5,
+        norm_elementwise_affine=True,
+        bias=True,
+        mesh_device=None,
+        dtype=ttnn.bfloat16,
+    ):
         super().__init__()
 
         # https://github.com/tenstorrent/tt-metal/issues/31216
@@ -28,8 +36,8 @@ class RMSNorm(Module):
         self.use_bias = norm_elementwise_affine and bias
 
         if norm_elementwise_affine:
-            self.weight = Parameter(total_shape=[1, embedding_dim], device=mesh_device)
-            self.bias = Parameter(total_shape=[1, embedding_dim], device=mesh_device) if bias else None
+            self.weight = Parameter(total_shape=[1, embedding_dim], device=mesh_device, dtype=dtype)
+            self.bias = Parameter(total_shape=[1, embedding_dim], device=mesh_device, dtype=dtype) if bias else None
         else:
             self.weight = None
             self.bias = None

--- a/models/tt_dit/models/transformers/wan2_2/attention_wan.py
+++ b/models/tt_dit/models/transformers/wan2_2/attention_wan.py
@@ -347,7 +347,7 @@ class WanAttention(Module):
                     num_links=self.ccl_manager.num_links,
                     cluster_axis=self.parallel_config.sequence_parallel.mesh_axis,
                     mesh_device=self.mesh_device,
-                    topology=ttnn.Topology.Linear,  # RJA always uses Linear topology
+                    topology=self.ccl_manager.topology,
                     subdevice_id=self.ccl_manager.ccl_sub_device_id,
                     ccl_core_grid_offset=(0, self.sdpa_worker_grid[1]),
                 )

--- a/models/tt_dit/models/transformers/wan2_2/attention_wan.py
+++ b/models/tt_dit/models/transformers/wan2_2/attention_wan.py
@@ -26,6 +26,7 @@ class WanAttention(Module):
         (False, 8, 4): (256, 256),
         (True, 2, 2): (128, 512),
         (True, 8, 4): (128, 512),
+        (True, 32, 4): (128, 128),
     }
     default_sdpa_chunk_size = (256, 256)
 

--- a/models/tt_dit/models/transformers/wan2_2/attention_wan.py
+++ b/models/tt_dit/models/transformers/wan2_2/attention_wan.py
@@ -14,7 +14,7 @@ from ....layers.module import Module
 from ....layers.normalization import DistributedRMSNorm
 from ....parallel.config import DiTParallelConfig
 from ....parallel.manager import CCLManager
-from ....utils.matmul import get_matmul_config
+from ....utils.matmul import get_matmul_config, get_matmul_core_grid
 from ....utils.substate import pop_substate, rename_substate
 from ....utils.tensor import bf16_tensor
 
@@ -232,7 +232,7 @@ class WanAttention(Module):
             weight = to_out.weight.data
 
         M, K, N_out = x.padded_shape[-2], x.padded_shape[-1], weight.padded_shape[-1]
-        core_grid = self.mesh_device.compute_with_storage_grid_size()
+        core_grid = get_matmul_core_grid(self.mesh_device)
         matmul_config = get_matmul_config(M, K, N_out, core_grid)
 
         output = ttnn.experimental.dit_minimal_matmul_addcmul_fused(

--- a/models/tt_dit/models/transformers/wan2_2/transformer_wan.py
+++ b/models/tt_dit/models/transformers/wan2_2/transformer_wan.py
@@ -22,7 +22,7 @@ from ....parallel.manager import CCLManager
 from ....utils.mochi import get_rot_transformation_mat
 from ....utils.padding import pad_vision_seq_parallel
 from ....utils.substate import pop_substate, rename_substate
-from ....utils.tensor import bf16_tensor, float32_tensor, from_torch
+from ....utils.tensor import bf16_tensor, float32_tensor, from_torch, unflatten
 from .attention_wan import WanAttention
 
 
@@ -421,8 +421,7 @@ class WanTransformer3DModel(Module):
         # TODO: Cleanup and move out of prepare_timestep_conditioning.
         timestep = float32_tensor(timestep.unsqueeze(1).unsqueeze(1).unsqueeze(1), device=self.mesh_device)
         tt_temb_11BD, tt_timestep_proj_1BTD = self.condition_embedder.forward_timestep(timestep, timestep_seq_len=None)
-        tt_timestep_proj_1BTD = ttnn.reshape(tt_timestep_proj_1BTD, list(tt_timestep_proj_1BTD.shape)[:-2] + [6, -1])
-
+        tt_timestep_proj_1BTD = unflatten(ttnn.squeeze(tt_timestep_proj_1BTD, -2), -1, (6, -1))
         logger.info(f"TT temb shape: {tt_temb_11BD.shape}")
         logger.info(f"TT timestep proj shape: {tt_timestep_proj_1BTD.shape}")
         return tt_temb_11BD, tt_timestep_proj_1BTD

--- a/models/tt_dit/models/transformers/wan2_2/transformer_wan.py
+++ b/models/tt_dit/models/transformers/wan2_2/transformer_wan.py
@@ -630,20 +630,3 @@ class WanTransformer3DModel(Module):
         )
 
         return spatial_1BNI
-
-    @staticmethod
-    def device_to_host(tt_tensor: ttnn.Tensor) -> torch.Tensor:
-        """Move a ttnn device tensor to a torch host tensor."""
-
-        mesh_device = tt_tensor.device()
-        view = mesh_device.get_view() if ttnn.using_distributed_env() else None
-        coords = list(tt_tensor.tensor_topology().mesh_coords())
-        device_tensors = ttnn.get_device_tensors(tt_tensor)
-
-        for coord, device_tensor in zip(coords, device_tensors):
-            if view is None or view.is_local(coord):
-                torch_tensor = ttnn.to_torch(device_tensor)
-                break
-
-        assert torch_tensor is not None, "Failed to get tensor"
-        return torch_tensor

--- a/models/tt_dit/models/transformers/wan2_2/transformer_wan.py
+++ b/models/tt_dit/models/transformers/wan2_2/transformer_wan.py
@@ -635,4 +635,16 @@ class WanTransformer3DModel(Module):
     @staticmethod
     def device_to_host(tt_tensor: ttnn.Tensor) -> torch.Tensor:
         """Move a ttnn device tensor to a torch host tensor."""
-        return ttnn.to_torch(ttnn.get_device_tensors(tt_tensor)[0])
+
+        mesh_device = tt_tensor.device()
+        view = mesh_device.get_view() if ttnn.using_distributed_env() else None
+        coords = list(tt_tensor.tensor_topology().mesh_coords())
+        device_tensors = ttnn.get_device_tensors(tt_tensor)
+
+        for coord, device_tensor in zip(coords, device_tensors):
+            if view is None or view.is_local(coord):
+                torch_tensor = ttnn.to_torch(device_tensor)
+                break
+
+        assert torch_tensor is not None, "Failed to get tensor"
+        return torch_tensor

--- a/models/tt_dit/models/vae/vae_mochi.py
+++ b/models/tt_dit/models/vae/vae_mochi.py
@@ -509,6 +509,9 @@ class CausalUpsampleBlock(Module):
         )
 
         self.reshard_time_map = {
+            80 * 100: 84,
+            160 * 200: 168,
+            320 * 400: 168,
             120 * 212: 84,
             240 * 424: 168,
             480 * 848: 168,

--- a/models/tt_dit/models/vae/vae_wan2_1.py
+++ b/models/tt_dit/models/vae/vae_wan2_1.py
@@ -10,6 +10,7 @@ import torch
 from loguru import logger
 
 import ttnn
+from models.common.utility_functions import is_blackhole
 
 from ...layers.linear import Linear
 from ...layers.module import Module, ModuleList, Parameter
@@ -18,7 +19,7 @@ from ...parallel.config import VaeHWParallelConfig
 from ...parallel.manager import CCLManager
 from ...utils.conv3d import _ntuple, aligned_channels, count_convs, get_conv3d_config, prepare_conv3d_weights
 from ...utils.substate import pop_substate, rename_substate
-from ...utils.tensor import bf16_tensor
+from ...utils.tensor import typed_tensor
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -49,6 +50,7 @@ class WanAttentionBlock(Module):
         mesh_device: ttnn.MeshDevice,
         parallel_config: VaeHWParallelConfig,
         ccl_manager: CCLManager,
+        dtype: ttnn.DataType = ttnn.bfloat16,
     ) -> None:
         super().__init__()
 
@@ -59,20 +61,23 @@ class WanAttentionBlock(Module):
 
         self.norm = RMSNorm(
             embedding_dim=dim,
-            norm_eps=1e-6,
+            norm_eps=1e-12,
             norm_elementwise_affine=True,
             bias=False,
             mesh_device=mesh_device,
+            dtype=dtype,
         )
         self.to_qkv = Linear(
             in_features=dim,
             out_features=dim * 3,
             mesh_device=mesh_device,
+            dtype=dtype,
         )
         self.proj = Linear(
             in_features=dim,
             out_features=dim,
             mesh_device=mesh_device,
+            dtype=dtype,
         )
 
         self.sdpa_compute_kernel_config = ttnn.init_device_compute_kernel_config(
@@ -122,71 +127,59 @@ class WanAttentionBlock(Module):
 
     def forward(self, x_BTHWC: ttnn.Tensor, logical_h: int) -> ttnn.Tensor:
         """
-        x_BTHWC: (B, T, H, W, C) fractured on H and W
+        x_BTHWC: (B, T, H, W, C) fractured on H and W, TILE layout
 
-        returns: (B, T, H, W, C) fractured on H and W
+        returns: (B, T, H, W, C) fractured on H and W, TILE layout
         """
         assert len(x_BTHWC.shape) == 5
-        assert x_BTHWC.layout == ttnn.ROW_MAJOR_LAYOUT
+        assert x_BTHWC.layout == ttnn.TILE_LAYOUT
         residual_BTHWC = x_BTHWC
 
         # Gather height and width for replicated attention
         if self.parallel_config.height_parallel.factor > 1:
-            x_BTHWC = ttnn.experimental.all_gather_async(
-                x_BTHWC,
-                persistent_output_buffer=self.ccl_manager.get_ag_ping_pong_buffer(
-                    x_BTHWC.shape, 2, self.parallel_config.height_parallel.mesh_axis
-                ),
-                dim=2,
-                multi_device_global_semaphore=self.ccl_manager.get_ag_ping_pong_semaphore(
-                    self.parallel_config.height_parallel.mesh_axis
-                ),
-                num_links=self.ccl_manager.num_links,
-                topology=self.ccl_manager.topology,
-                cluster_axis=self.parallel_config.height_parallel.mesh_axis,
+            x_BTHWC = self.ccl_manager.all_gather_persistent_buffer(
+                x_BTHWC, dim=2, mesh_axis=self.parallel_config.height_parallel.mesh_axis
             )
         if self.parallel_config.width_parallel.factor > 1:
-            x_BTHWC = ttnn.experimental.all_gather_async(
-                x_BTHWC,
-                persistent_output_buffer=self.ccl_manager.get_ag_ping_pong_buffer(
-                    x_BTHWC.shape, 3, self.parallel_config.width_parallel.mesh_axis
-                ),
-                dim=3,
-                multi_device_global_semaphore=self.ccl_manager.get_ag_ping_pong_semaphore(
-                    self.parallel_config.width_parallel.mesh_axis
-                ),
-                num_links=self.ccl_manager.num_links,
-                topology=self.ccl_manager.topology,
-                cluster_axis=self.parallel_config.width_parallel.mesh_axis,
+            x_BTHWC = self.ccl_manager.all_gather_persistent_buffer(
+                x_BTHWC, dim=3, mesh_axis=self.parallel_config.width_parallel.mesh_axis
             )
 
-        if logical_h % self.parallel_config.height_parallel.factor != 0:
-            """
-            H is padded, so slice it out before attention
-            """
-            padded_h = x_BTHWC.shape[2]
+        x_BTHWC = ttnn.to_layout(x_BTHWC, ttnn.ROW_MAJOR_LAYOUT)
+
+        padded_h = x_BTHWC.shape[2]
+        # Use > (not !=) to only slice when there are EXCESS padding rows (decoder upsample
+        # amplifies mesh_partition padding). The encoder's 1::2 downsampling creates a deficit
+        # (shape[2] * factor < logical_h) which must NOT trigger slicing.
+        if padded_h > logical_h:
             x_BTHWC = x_BTHWC[:, :, :logical_h, :, :]
         B, T, H, W, C = x_BTHWC.shape
         x_TNC = ttnn.reshape(x_BTHWC, (B * T, H * W, C))
         x_TNC = ttnn.to_layout(x_TNC, ttnn.TILE_LAYOUT)
         x_TNC = self.norm(x_TNC, compute_kernel_config=self.hifi4_compute_kernel_config)
-        x_TND = self.to_qkv(x_TNC, compute_kernel_config=self.mm_compute_kernel_config)
+        default_block_size = (2, 2, 2) if x_TNC.dtype == ttnn.float32 else (8, 8, 8)
+        x_TND = self.to_qkv(
+            x_TNC, compute_kernel_config=self.mm_compute_kernel_config, default_block_size=default_block_size
+        )
         q_THNC, k_THNC, v_THNC = ttnn.transformer.split_query_key_value_and_split_heads(
             x_TND, num_heads=1, transpose_key=False
         )
         out_THNC = ttnn.transformer.scaled_dot_product_attention(
-            q_THNC,
-            k_THNC,
-            v_THNC,
+            ttnn.typecast(q_THNC, ttnn.bfloat16) if q_THNC.dtype != ttnn.bfloat16 else q_THNC,
+            ttnn.typecast(k_THNC, ttnn.bfloat16) if k_THNC.dtype != ttnn.bfloat16 else k_THNC,
+            ttnn.typecast(v_THNC, ttnn.bfloat16) if v_THNC.dtype != ttnn.bfloat16 else v_THNC,
             is_causal=False,
             program_config=self.sdpa_program_config,
             compute_kernel_config=self.sdpa_compute_kernel_config,
         )
+        out_THNC = ttnn.typecast(out_THNC, q_THNC.dtype) if out_THNC.dtype != q_THNC.dtype else out_THNC
         out_TNC = ttnn.transformer.concatenate_heads(out_THNC)
-        out_TND = self.proj(out_TNC, compute_kernel_config=self.mm_compute_kernel_config)
+        out_TND = self.proj(
+            out_TNC, compute_kernel_config=self.mm_compute_kernel_config, default_block_size=default_block_size
+        )
         out_TND = ttnn.to_layout(out_TND, ttnn.ROW_MAJOR_LAYOUT)
 
-        if logical_h % self.parallel_config.height_parallel.factor != 0:
+        if padded_h > logical_h:
             """
             H should be padded to divide by H parallel factor.
             """
@@ -209,7 +202,8 @@ class WanAttentionBlock(Module):
                 out_BTHWC, dim=3, cluster_axis=self.parallel_config.width_parallel.mesh_axis
             )
 
-        return out_BTHWC + residual_BTHWC
+        out_BTHWC = ttnn.to_layout(out_BTHWC, ttnn.TILE_LAYOUT)
+        return ttnn.add(out_BTHWC, residual_BTHWC)
 
 
 class WanCausalConv3d(Module):
@@ -224,6 +218,7 @@ class WanCausalConv3d(Module):
         mesh_device: ttnn.MeshDevice,
         parallel_config: VaeHWParallelConfig,
         ccl_manager: CCLManager,
+        dtype: ttnn.DataType = ttnn.bfloat16,
     ) -> None:
         super().__init__()
 
@@ -242,6 +237,7 @@ class WanCausalConv3d(Module):
         self.mesh_device = mesh_device
         self.ccl_manager = ccl_manager
         self.parallel_config = parallel_config
+        self.dtype = dtype
 
         padding = _ntuple(padding, 3)
         external_padding = list(padding)
@@ -263,20 +259,23 @@ class WanCausalConv3d(Module):
             self.in_channels,
             self.out_channels,
             self.kernel_size,
+            dtype,
             grid_size=self.mesh_device.compute_with_storage_grid_size(),
         )
 
         self.compute_kernel_config = ttnn.init_device_compute_kernel_config(
             self.mesh_device.arch(),
-            math_fidelity=ttnn.MathFidelity.HiFi4,
+            math_fidelity=ttnn.MathFidelity.HiFi4
+            if (is_blackhole() or dtype == ttnn.float32)
+            else ttnn.MathFidelity.HiFi2,  # Do not use HiFi3/4 with fp32_dest_acc on WH due to accuracy issues.
             math_approx_mode=False,
             fp32_dest_acc_en=True,
             packer_l1_acc=False,
         )
 
         d = self.kernel_size[0] * self.kernel_size[1] * self.kernel_size[2] * self.in_channels
-        self.weight = Parameter(total_shape=[d, self.out_channels], device=mesh_device, pad_value=0)
-        self.bias = Parameter(total_shape=[1, self.out_channels], device=mesh_device, pad_value=0)
+        self.weight = Parameter(total_shape=[d, self.out_channels], device=mesh_device, pad_value=0, dtype=dtype)
+        self.bias = Parameter(total_shape=[1, self.out_channels], device=mesh_device, pad_value=0, dtype=dtype)
 
         self.mask_cache = {}
 
@@ -301,12 +300,13 @@ class WanCausalConv3d(Module):
             mask_shape = (1, 1, padded_h, 1, 1)
             mask = torch.ones(mask_shape)
             mask[:, :, logical_h:, :, :] = 0.0
-            mask = bf16_tensor(
+            mask = typed_tensor(
                 mask,
                 device=self.mesh_device,
                 layout=ttnn.ROW_MAJOR_LAYOUT,
                 mesh_axis=self.parallel_config.height_parallel.mesh_axis,
                 shard_dim=2,
+                dtype=self.dtype,
             )
             self.mask_cache[key] = mask
         return self.mask_cache[key]
@@ -318,11 +318,12 @@ class WanCausalConv3d(Module):
         cache_x_BTHWC: ttnn.Tensor | None = None,
     ) -> ttnn.Tensor:
         """
-        x_BTHWC: (B, T, H, W, C) fractured on H and W
+        x_BTHWC: (B, T, H, W, C) fractured on H and W, ROW_MAJOR layout
         cache_x_BTHWC: (B, T1, H, W, C) fractured on H and W
 
-        returns: (B, T, H, W, C) fractured on H and W
+        returns: (B, T, H, W, C) fractured on H and W, ROW_MAJOR layout
         """
+        assert x_BTHWC.layout == ttnn.ROW_MAJOR_LAYOUT, f"WanCausalConv3d expects ROW_MAJOR input, got {x_BTHWC.layout}"
         # NOTE: T padding is handled explicitly and depends on the cache
         t_front_padding = self.external_padding[0]
         if cache_x_BTHWC is not None and t_front_padding > 0:
@@ -336,10 +337,10 @@ class WanCausalConv3d(Module):
             x_BTNC = ttnn.pad(x_BTNC, [(0, 0), (t_front_padding, 0), (0, 0), (0, 0)], value=0.0)
             x_BTHWC = ttnn.reshape(x_BTNC, (B, T + t_front_padding, H, W, C))
 
-        if logical_h % self.parallel_config.height_parallel.factor != 0:
-            """
-            H is padded to divide by H parallel factor. Must zero out padded portion of H.
-            """
+        # Use > (not !=) to only mask when there are EXCESS padding rows (decoder upsample
+        # amplifies mesh_partition padding). The encoder's 1::2 downsampling creates a deficit
+        # (shape[2] * factor < logical_h) which must NOT trigger masking.
+        if x_BTHWC.shape[2] * self.parallel_config.height_parallel.factor > logical_h:
             mask = self.get_cached_mask(x_BTHWC, logical_h)
             x_BTHWC = ttnn.mul(x_BTHWC, mask)
 
@@ -390,14 +391,14 @@ class WanCausalConv3d(Module):
             stride=self.stride,
             padding=self.internal_padding,
             padding_mode="zeros",
-            dtype=ttnn.bfloat16,
+            dtype=self.dtype,
             compute_kernel_config=self.compute_kernel_config,
         )
 
-        if logical_h % self.parallel_config.height_parallel.factor != 0:
-            """
-            H is padded to divide by H parallel factor. Must zero out padded portion of H.
-            """
+        # Use > (not !=) to only mask when there are EXCESS padding rows (decoder upsample
+        # amplifies mesh_partition padding). The encoder's 1::2 downsampling creates a deficit
+        # (shape[2] * factor < logical_h) which must NOT trigger masking.
+        if x_BTHWC.shape[2] * self.parallel_config.height_parallel.factor > logical_h:
             mask = self.get_cached_mask(x_BTHWC, logical_h)
             x_BTHWC = ttnn.mul(x_BTHWC, mask)
         return x_BTHWC
@@ -412,6 +413,7 @@ class WanResidualBlock(Module):
         mesh_device: ttnn.MeshDevice,
         parallel_config: VaeHWParallelConfig,
         ccl_manager: CCLManager,
+        dtype: ttnn.DataType = ttnn.bfloat16,
     ) -> None:
         super().__init__()
 
@@ -421,10 +423,11 @@ class WanResidualBlock(Module):
 
         self.norm1 = RMSNorm(
             embedding_dim=in_dim,
-            norm_eps=1e-6,
+            norm_eps=1e-12,
             norm_elementwise_affine=True,
             bias=False,
             mesh_device=mesh_device,
+            dtype=dtype,
         )
         self.conv1 = WanCausalConv3d(
             in_channels=in_dim,
@@ -434,13 +437,15 @@ class WanResidualBlock(Module):
             mesh_device=mesh_device,
             ccl_manager=ccl_manager,
             parallel_config=parallel_config,
+            dtype=dtype,
         )
         self.norm2 = RMSNorm(
             embedding_dim=out_dim,
-            norm_eps=1e-6,
+            norm_eps=1e-12,
             norm_elementwise_affine=True,
             bias=False,
             mesh_device=mesh_device,
+            dtype=dtype,
         )
         self.conv2 = WanCausalConv3d(
             in_channels=out_dim,
@@ -450,6 +455,7 @@ class WanResidualBlock(Module):
             mesh_device=mesh_device,
             ccl_manager=ccl_manager,
             parallel_config=parallel_config,
+            dtype=dtype,
         )
 
         if in_dim != out_dim:
@@ -457,11 +463,21 @@ class WanResidualBlock(Module):
                 in_features=in_dim,
                 out_features=out_dim,
                 mesh_device=mesh_device,
+                dtype=dtype,
             )
         else:
             self.conv_shortcut = None
 
-        self.hifi4_compute_kernel_config = ttnn.init_device_compute_kernel_config(
+        self.matmul_compute_kernel_config = ttnn.init_device_compute_kernel_config(
+            self.mesh_device.arch(),
+            math_fidelity=ttnn.MathFidelity.HiFi4
+            if (is_blackhole() or dtype == ttnn.float32)
+            else ttnn.MathFidelity.HiFi2,  # Do not use HiFi3/4 with fp32_dest_acc on WH due to accuracy issues.
+            math_approx_mode=False,
+            fp32_dest_acc_en=True,
+            packer_l1_acc=False,
+        )
+        self.norm_compute_kernel_config = ttnn.init_device_compute_kernel_config(
             self.mesh_device.arch(),
             math_fidelity=ttnn.MathFidelity.HiFi4,
             math_approx_mode=False,
@@ -494,14 +510,14 @@ class WanResidualBlock(Module):
         feat_cache: list[ttnn.Tensor] | None = None,
         feat_idx: list[int] = [0],
     ) -> ttnn.Tensor:
-        x_tile_BTHWC = ttnn.to_layout(x_BTHWC, ttnn.TILE_LAYOUT)
+        assert x_BTHWC.layout == ttnn.TILE_LAYOUT, f"WanResidualBlock expects TILE input, got {x_BTHWC.layout}"
         h_tile_BTHWC = (
-            self.conv_shortcut(x_tile_BTHWC, compute_kernel_config=self.hifi4_compute_kernel_config)
+            self.conv_shortcut(x_BTHWC, compute_kernel_config=self.matmul_compute_kernel_config)
             if self.conv_shortcut is not None
-            else x_tile_BTHWC
+            else x_BTHWC
         )
-        x_norm_tile_BTHWC = self.norm1(x_tile_BTHWC, compute_kernel_config=self.hifi4_compute_kernel_config)
-        x_silu_tile_BTHWC = ttnn.silu(x_norm_tile_BTHWC)  # NOTE: potential correctness issue
+        x_norm_tile_BTHWC = self.norm1(x_BTHWC, compute_kernel_config=self.norm_compute_kernel_config)
+        x_silu_tile_BTHWC = ttnn.silu(x_norm_tile_BTHWC)
         x_BTHWC = ttnn.to_layout(x_silu_tile_BTHWC, ttnn.ROW_MAJOR_LAYOUT)
 
         # Cached conv
@@ -522,8 +538,8 @@ class WanResidualBlock(Module):
             x_conv_BTHWC = self.conv1(x_BTHWC, logical_h)
 
         x_tile_BTHWC = ttnn.to_layout(x_conv_BTHWC, ttnn.TILE_LAYOUT)
-        x_norm_tile_BTHWC = self.norm2(x_tile_BTHWC, compute_kernel_config=self.hifi4_compute_kernel_config)
-        x_silu_tile_BTHWC = ttnn.silu(x_norm_tile_BTHWC)  # NOTE: potential correctness issue
+        x_norm_tile_BTHWC = self.norm2(x_tile_BTHWC, compute_kernel_config=self.norm_compute_kernel_config)
+        x_silu_tile_BTHWC = ttnn.silu(x_norm_tile_BTHWC)
         x_BTHWC = ttnn.to_layout(x_silu_tile_BTHWC, ttnn.ROW_MAJOR_LAYOUT)
 
         # Cached conv
@@ -546,8 +562,7 @@ class WanResidualBlock(Module):
         # Add residual
         x_tile_BTHWC = ttnn.to_layout(x_conv_BTHWC, ttnn.TILE_LAYOUT)
         x_tile_BTHWC = ttnn.add(h_tile_BTHWC, x_tile_BTHWC)
-        x_BTHWC = ttnn.to_layout(x_tile_BTHWC, ttnn.ROW_MAJOR_LAYOUT)
-        return x_BTHWC
+        return x_tile_BTHWC
 
 
 class WanMidBlock(Module):
@@ -559,6 +574,7 @@ class WanMidBlock(Module):
         mesh_device: ttnn.MeshDevice,
         parallel_config: VaeHWParallelConfig,
         ccl_manager: CCLManager,
+        dtype: ttnn.DataType = ttnn.bfloat16,
     ) -> None:
         super().__init__()
 
@@ -574,6 +590,7 @@ class WanMidBlock(Module):
                 mesh_device=mesh_device,
                 ccl_manager=ccl_manager,
                 parallel_config=parallel_config,
+                dtype=dtype,
             )
         )
 
@@ -584,6 +601,7 @@ class WanMidBlock(Module):
                     mesh_device=mesh_device,
                     ccl_manager=ccl_manager,
                     parallel_config=parallel_config,
+                    dtype=dtype,
                 )
             )
             resnets.append(
@@ -593,6 +611,7 @@ class WanMidBlock(Module):
                     mesh_device=mesh_device,
                     ccl_manager=ccl_manager,
                     parallel_config=parallel_config,
+                    dtype=dtype,
                 )
             )
 
@@ -606,6 +625,7 @@ class WanMidBlock(Module):
         feat_cache: list[ttnn.Tensor] | None = None,
         feat_idx: list[int] = [0],
     ) -> ttnn.Tensor:
+        assert x_BTHWC.layout == ttnn.TILE_LAYOUT, f"WanMidBlock expects TILE input, got {x_BTHWC.layout}"
         x_res_BTHWC = self.resnets[0](x_BTHWC, logical_h, feat_cache, feat_idx)
         x_BTHWC = x_res_BTHWC
         for i in range(len(self.attentions)):
@@ -630,6 +650,7 @@ class WanConv2d(Module):
         mesh_device: ttnn.MeshDevice,
         parallel_config: VaeHWParallelConfig,
         ccl_manager: CCLManager,
+        dtype: ttnn.DataType = ttnn.bfloat16,
     ) -> None:
         super().__init__()
 
@@ -645,6 +666,7 @@ class WanConv2d(Module):
         self.mesh_device = mesh_device
         self.ccl_manager = ccl_manager
         self.parallel_config = parallel_config
+        self.dtype = dtype
 
         padding = _ntuple(padding, 3)
         external_padding = list(padding)
@@ -666,21 +688,24 @@ class WanConv2d(Module):
             self.in_channels,
             self.out_channels,
             self.kernel_size,
+            dtype,
             grid_size=self.mesh_device.compute_with_storage_grid_size(),
         )
         logger.info(f"Loaded conv_config: {self.conv_config}")
 
         self.compute_kernel_config = ttnn.init_device_compute_kernel_config(
             self.mesh_device.arch(),
-            math_fidelity=ttnn.MathFidelity.HiFi4,
+            math_fidelity=ttnn.MathFidelity.HiFi4
+            if (is_blackhole() or dtype == ttnn.float32)
+            else ttnn.MathFidelity.HiFi2,  # Do not use HiFi3/4 with fp32_dest_acc on WH due to accuracy issues.
             math_approx_mode=False,
             fp32_dest_acc_en=True,
             packer_l1_acc=False,
         )
 
         d = self.kernel_size[0] * self.kernel_size[1] * self.kernel_size[2] * self.in_channels
-        self.weight = Parameter(total_shape=[d, self.out_channels], device=mesh_device, pad_value=0)
-        self.bias = Parameter(total_shape=[1, self.out_channels], device=mesh_device, pad_value=0)
+        self.weight = Parameter(total_shape=[d, self.out_channels], device=mesh_device, pad_value=0, dtype=dtype)
+        self.bias = Parameter(total_shape=[1, self.out_channels], device=mesh_device, pad_value=0, dtype=dtype)
 
         self.mask_cache = {}
 
@@ -698,21 +723,23 @@ class WanConv2d(Module):
             mask_shape = (1, 1, padded_h, 1, 1)
             mask = torch.ones(mask_shape)
             mask[:, :, logical_h:, :, :] = 0.0
-            mask = bf16_tensor(
+            mask = typed_tensor(
                 mask,
                 device=self.mesh_device,
                 layout=ttnn.ROW_MAJOR_LAYOUT,
                 mesh_axis=self.parallel_config.height_parallel.mesh_axis,
                 shard_dim=2,
+                dtype=self.dtype,
             )
             self.mask_cache[key] = mask
         return self.mask_cache[key]
 
     def forward(self, x_BTHWC: ttnn.Tensor, logical_h: int) -> ttnn.Tensor:
-        if logical_h % self.parallel_config.height_parallel.factor != 0:
-            """
-            H is padded to divide by H parallel factor. Must zero out padded portion of H.
-            """
+        assert x_BTHWC.layout == ttnn.ROW_MAJOR_LAYOUT, f"WanConv2d expects ROW_MAJOR input, got {x_BTHWC.layout}"
+        # Use > (not !=) to only mask when there are EXCESS padding rows (decoder upsample
+        # amplifies mesh_partition padding). The encoder's 1::2 downsampling creates a deficit
+        # (shape[2] * factor < logical_h) which must NOT trigger masking.
+        if x_BTHWC.shape[2] * self.parallel_config.height_parallel.factor > logical_h:
             mask = self.get_cached_mask(x_BTHWC, logical_h)
             x_BTHWC = ttnn.mul(x_BTHWC, mask)
 
@@ -763,14 +790,14 @@ class WanConv2d(Module):
             stride=self.stride,
             padding=self.internal_padding,
             padding_mode="zeros",
-            dtype=ttnn.bfloat16,
+            dtype=self.dtype,
             compute_kernel_config=self.compute_kernel_config,
         )
 
-        if logical_h % self.parallel_config.height_parallel.factor != 0:
-            """
-            H is padded to divide by H parallel factor. Must zero out padded portion of H.
-            """
+        # Use > (not !=) to only mask when there are EXCESS padding rows (decoder upsample
+        # amplifies mesh_partition padding). The encoder's 1::2 downsampling creates a deficit
+        # (shape[2] * factor < logical_h) which must NOT trigger masking.
+        if x_BTHWC.shape[2] * self.parallel_config.height_parallel.factor > logical_h:
             mask = self.get_cached_mask(x_BTHWC, logical_h)
             x_BTHWC = ttnn.mul(x_BTHWC, mask)
         return x_BTHWC
@@ -786,6 +813,7 @@ class WanResample(Module):
         mesh_device: ttnn.MeshDevice,
         parallel_config: VaeHWParallelConfig,
         ccl_manager: CCLManager,
+        dtype: ttnn.DataType = ttnn.bfloat16,
     ) -> None:
         super().__init__()
 
@@ -804,6 +832,7 @@ class WanResample(Module):
             mesh_device=mesh_device,
             ccl_manager=ccl_manager,
             parallel_config=parallel_config,
+            dtype=dtype,
         )
 
         self.is_upsample = "upsample" in mode
@@ -819,6 +848,7 @@ class WanResample(Module):
                 mesh_device=mesh_device,
                 ccl_manager=ccl_manager,
                 parallel_config=parallel_config,
+                dtype=dtype,
             )
 
     def _prepare_torch_state(self, state: dict[str, torch.Tensor]) -> None:
@@ -831,6 +861,7 @@ class WanResample(Module):
         feat_cache: list[ttnn.Tensor] | None = None,
         feat_idx: list[int] = [0],
     ) -> tuple[ttnn.Tensor, int]:
+        assert x_BTHWC.layout == ttnn.ROW_MAJOR_LAYOUT, f"WanResample expects ROW_MAJOR input, got {x_BTHWC.layout}"
         B, T, H, W, C = x_BTHWC.shape
         if self.is_3d and self.is_upsample:  # upsample3d
             if feat_cache is not None:
@@ -915,6 +946,7 @@ class WanUpBlock(Module):
         mesh_device: ttnn.MeshDevice,
         parallel_config: VaeHWParallelConfig,
         ccl_manager: CCLManager,
+        dtype: ttnn.DataType = ttnn.bfloat16,
     ) -> None:
         super().__init__()
 
@@ -938,6 +970,7 @@ class WanUpBlock(Module):
                     mesh_device=mesh_device,
                     ccl_manager=ccl_manager,
                     parallel_config=parallel_config,
+                    dtype=dtype,
                 )
             )
             current_dim = out_dim
@@ -951,6 +984,7 @@ class WanUpBlock(Module):
                 mesh_device=mesh_device,
                 ccl_manager=ccl_manager,
                 parallel_config=parallel_config,
+                dtype=dtype,
             )
 
     def _prepare_torch_state(self, state: dict[str, torch.Tensor]) -> None:
@@ -967,8 +1001,9 @@ class WanUpBlock(Module):
             x_res_BTHWC = resnet(x_BTHWC, logical_h, feat_cache, feat_idx)
             x_BTHWC = x_res_BTHWC
         if self.upsamplers is not None:
+            x_BTHWC = ttnn.to_layout(x_BTHWC, ttnn.ROW_MAJOR_LAYOUT)
             x_upsampled_BTHWC, logical_h = self.upsamplers(x_BTHWC, logical_h, feat_cache, feat_idx)
-            x_BTHWC = x_upsampled_BTHWC
+            x_BTHWC = ttnn.to_layout(x_upsampled_BTHWC, ttnn.TILE_LAYOUT)
         return x_BTHWC, logical_h
 
 
@@ -987,6 +1022,7 @@ class WanDecoder3d(Module):
         mesh_device: ttnn.MeshDevice,
         parallel_config: VaeHWParallelConfig,
         ccl_manager: CCLManager,
+        dtype: ttnn.DataType = ttnn.bfloat16,
     ) -> None:
         super().__init__()
 
@@ -1013,6 +1049,7 @@ class WanDecoder3d(Module):
             mesh_device=mesh_device,
             ccl_manager=ccl_manager,
             parallel_config=parallel_config,
+            dtype=dtype,
         )
 
         # middle blocks
@@ -1022,6 +1059,7 @@ class WanDecoder3d(Module):
             mesh_device=mesh_device,
             ccl_manager=ccl_manager,
             parallel_config=parallel_config,
+            dtype=dtype,
         )
 
         # upsample blocks
@@ -1050,16 +1088,18 @@ class WanDecoder3d(Module):
                 mesh_device=mesh_device,
                 ccl_manager=ccl_manager,
                 parallel_config=parallel_config,
+                dtype=dtype,
             )
             self.up_blocks.append(up_block)
 
         # output blocks
         self.norm_out = RMSNorm(
             embedding_dim=out_dim,
-            norm_eps=1e-6,
+            norm_eps=1e-12,
             norm_elementwise_affine=True,
             bias=False,
             mesh_device=mesh_device,
+            dtype=dtype,
         )
         self.conv_out = WanCausalConv3d(
             out_dim,
@@ -1069,6 +1109,7 @@ class WanDecoder3d(Module):
             mesh_device=mesh_device,
             ccl_manager=ccl_manager,
             parallel_config=parallel_config,
+            dtype=dtype,
         )
 
     def _prepare_torch_state(self, state: dict[str, torch.Tensor]) -> None:
@@ -1098,18 +1139,17 @@ class WanDecoder3d(Module):
         else:
             x_BTHWC = self.conv_in(x_BTHWC, logical_h)
 
+        x_BTHWC = ttnn.to_layout(x_BTHWC, ttnn.TILE_LAYOUT)
+
         ## middle
         x_BTHWC = self.mid_block(x_BTHWC, logical_h, feat_cache, feat_idx)
-        # DEBUG
-        # return x_BTHWC
 
         ## upsamples
         for up_block in self.up_blocks:
             x_BTHWC, logical_h = up_block(x_BTHWC, logical_h, feat_cache, feat_idx)
 
         ## head
-        x_tile_BTHWC = ttnn.to_layout(x_BTHWC, ttnn.TILE_LAYOUT)
-        x_norm_tile_BTHWC = self.norm_out(x_tile_BTHWC)
+        x_norm_tile_BTHWC = self.norm_out(x_BTHWC)
         x_silu_tile_BTHWC = ttnn.silu(x_norm_tile_BTHWC)
         x_BTHWC = ttnn.to_layout(x_silu_tile_BTHWC, ttnn.ROW_MAJOR_LAYOUT)
 
@@ -1181,6 +1221,7 @@ class WanDecoder(Module):
         mesh_device: ttnn.MeshDevice,
         parallel_config: VaeHWParallelConfig,
         ccl_manager: CCLManager,
+        dtype: ttnn.DataType = ttnn.bfloat16,
     ) -> None:
         super().__init__()
 
@@ -1193,12 +1234,14 @@ class WanDecoder(Module):
         self.mesh_device = mesh_device
         self.ccl_manager = ccl_manager
         self.parallel_config = parallel_config
+        self.dtype = dtype
 
         # Linear for post_quant_conv
         self.post_quant_conv = Linear(
             in_features=aligned_channels(z_dim),
             out_features=aligned_channels(z_dim),
             mesh_device=mesh_device,
+            dtype=dtype,
         )
 
         self.decoder = WanDecoder3d(
@@ -1213,6 +1256,7 @@ class WanDecoder(Module):
             mesh_device=mesh_device,
             ccl_manager=ccl_manager,
             parallel_config=parallel_config,
+            dtype=dtype,
         )
 
         self.cached_conv_count = count_convs(self.decoder)
@@ -1275,6 +1319,7 @@ class WanEncoder3D(Module):
         mesh_device=None,
         ccl_manager=None,
         parallel_config=None,
+        dtype: ttnn.DataType = ttnn.bfloat16,
     ) -> None:
         super().__init__()
 
@@ -1302,6 +1347,7 @@ class WanEncoder3D(Module):
             mesh_device=mesh_device,
             ccl_manager=ccl_manager,
             parallel_config=parallel_config,
+            dtype=dtype,
         )
 
         # downsample blocks.
@@ -1315,6 +1361,7 @@ class WanEncoder3D(Module):
                         mesh_device=mesh_device,
                         ccl_manager=ccl_manager,
                         parallel_config=parallel_config,
+                        dtype=dtype,
                     )
                 )
                 if scale in attn_scales:
@@ -1324,6 +1371,7 @@ class WanEncoder3D(Module):
                             mesh_device=mesh_device,
                             ccl_manager=ccl_manager,
                             parallel_config=parallel_config,
+                            dtype=dtype,
                         )
                     )
                 in_dim = out_dim
@@ -1338,18 +1386,29 @@ class WanEncoder3D(Module):
                         mesh_device=mesh_device,
                         ccl_manager=ccl_manager,
                         parallel_config=parallel_config,
+                        dtype=dtype,
                     )
                 )
                 scale /= 2.0
 
         # middle blocks
         self.mid_block = WanMidBlock(
-            dim=out_dim, num_layers=1, mesh_device=mesh_device, ccl_manager=ccl_manager, parallel_config=parallel_config
+            dim=out_dim,
+            num_layers=1,
+            mesh_device=mesh_device,
+            ccl_manager=ccl_manager,
+            parallel_config=parallel_config,
+            dtype=dtype,
         )
 
         # output blocks
         self.norm_out = RMSNorm(
-            embedding_dim=out_dim, norm_eps=1e-6, norm_elementwise_affine=True, bias=False, mesh_device=mesh_device
+            embedding_dim=out_dim,
+            norm_eps=1e-12,
+            norm_elementwise_affine=True,
+            bias=False,
+            mesh_device=mesh_device,
+            dtype=dtype,
         )
         self.conv_out = WanCausalConv3d(
             out_dim,
@@ -1359,6 +1418,7 @@ class WanEncoder3D(Module):
             mesh_device=mesh_device,
             ccl_manager=ccl_manager,
             parallel_config=parallel_config,
+            dtype=dtype,
         )
 
     def _prepare_torch_state(self, state: dict[str, torch.Tensor]) -> None:
@@ -1386,10 +1446,14 @@ class WanEncoder3D(Module):
         else:
             x_BTHWC = self.conv_in(x_BTHWC, logical_h)
 
+        x_BTHWC = ttnn.to_layout(x_BTHWC, ttnn.TILE_LAYOUT)
+
         ## downsamples
         for down_block in self.down_blocks:
             if isinstance(down_block, WanResample):
+                x_BTHWC = ttnn.to_layout(x_BTHWC, ttnn.ROW_MAJOR_LAYOUT)
                 x_BTHWC, logical_h = down_block(x_BTHWC, logical_h, feat_cache, feat_idx)
+                x_BTHWC = ttnn.to_layout(x_BTHWC, ttnn.TILE_LAYOUT)
             elif isinstance(down_block, WanResidualBlock):
                 x_BTHWC = down_block(x_BTHWC, logical_h, feat_cache, feat_idx)
             elif isinstance(down_block, WanAttentionBlock):
@@ -1401,8 +1465,7 @@ class WanEncoder3D(Module):
         x_BTHWC = self.mid_block(x_BTHWC, logical_h, feat_cache, feat_idx)
 
         ## head
-        x_tile_BTHWC = ttnn.to_layout(x_BTHWC, ttnn.TILE_LAYOUT)
-        x_norm_tile_BTHWC = self.norm_out(x_tile_BTHWC)
+        x_norm_tile_BTHWC = self.norm_out(x_BTHWC)
         x_silu_tile_BTHWC = ttnn.silu(x_norm_tile_BTHWC)
         x_BTHWC = ttnn.to_layout(x_silu_tile_BTHWC, ttnn.ROW_MAJOR_LAYOUT)
 
@@ -1435,6 +1498,7 @@ class WanEncoder(Module):
         mesh_device=None,
         ccl_manager=None,
         parallel_config=None,
+        dtype: ttnn.DataType = ttnn.bfloat16,
     ) -> None:
         super().__init__()
 
@@ -1452,12 +1516,14 @@ class WanEncoder(Module):
             mesh_device=mesh_device,
             ccl_manager=ccl_manager,
             parallel_config=parallel_config,
+            dtype=dtype,
         )
         # Linear for quant_conv
         self.quant_conv = Linear(
             in_features=aligned_channels(self.out_channels),
             out_features=aligned_channels(self.out_channels),
             mesh_device=mesh_device,
+            dtype=dtype,
         )
         self.cached_conv_count = count_convs(self.encoder)
 

--- a/models/tt_dit/models/vae/vae_wan2_1.py
+++ b/models/tt_dit/models/vae/vae_wan2_1.py
@@ -343,51 +343,42 @@ class WanCausalConv3d(Module):
             mask = self.get_cached_mask(x_BTHWC, logical_h)
             x_BTHWC = ttnn.mul(x_BTHWC, mask)
 
-        # Height halo
-        if self.external_padding[1] > 0 and self.parallel_config.height_parallel.factor > 1:
-            ttnn.synchronize_device(x_BTHWC.device())
-            x_BTHWC = ttnn.experimental.neighbor_pad_async(
-                x_BTHWC,
-                dim=2,
-                padding_left=self.external_padding[1],
-                padding_right=self.external_padding[1],
-                padding_mode="zeros",
-                cluster_axis=self.parallel_config.height_parallel.mesh_axis,
-                # neighbor_pad only needs one final semaphore, so index into ag semahpore list
-                final_semaphore=self.ccl_manager.get_ag_ping_pong_semaphore(
-                    self.parallel_config.height_parallel.mesh_axis
-                )[0],
-                barrier_semaphore=self.ccl_manager.get_barrier_semaphore(
-                    self.parallel_config.height_parallel.mesh_axis
-                ),
-                num_links=get_neighbor_pad_num_links(self.ccl_manager, x_BTHWC, 2),
-                topology=self.ccl_manager.topology,
-            )
-            ttnn.synchronize_device(x_BTHWC.device())
+        # Halo exchange (height and/or width padding)
+        h_pad_needed = self.external_padding[1] > 0 and self.parallel_config.height_parallel.factor > 1
+        w_pad_needed = self.external_padding[2] > 0 and self.parallel_config.width_parallel.factor > 1
 
-        # Width halo
-        if self.external_padding[2] > 0 and self.parallel_config.width_parallel.factor > 1:
-            # TODO: Fix validation in neighbor_pad_async to allow halo on dim3
-            x_THWC = ttnn.squeeze(x_BTHWC, dim=0)
-            ttnn.synchronize_device(x_THWC.device())
-            x_THWC = ttnn.experimental.neighbor_pad_async(
-                x_THWC,
-                dim=2,
-                padding_left=self.external_padding[2],
-                padding_right=self.external_padding[2],
+        if h_pad_needed or w_pad_needed:
+            dims, pad_left, pad_right = [], [], []
+            axes, neighbor_sems, links = [], [], []
+            if h_pad_needed:
+                dims.append(2)
+                pad_left.append(self.external_padding[1])
+                pad_right.append(self.external_padding[1])
+                axes.append(self.parallel_config.height_parallel.mesh_axis)
+                neighbor_sems.append(
+                    self.ccl_manager.get_np_ping_pong_semaphore(self.parallel_config.height_parallel.mesh_axis)
+                )
+                links.append(get_neighbor_pad_num_links(self.ccl_manager, x_BTHWC, 2))
+            if w_pad_needed:
+                dims.append(3)
+                pad_left.append(self.external_padding[2])
+                pad_right.append(self.external_padding[2])
+                axes.append(self.parallel_config.width_parallel.mesh_axis)
+                neighbor_sems.append(
+                    self.ccl_manager.get_np_ping_pong_semaphore(self.parallel_config.width_parallel.mesh_axis)
+                )
+                links.append(get_neighbor_pad_num_links(self.ccl_manager, x_BTHWC, 3))
+
+            x_BTHWC = self.ccl_manager.neighbor_pad_persistent_buffer(
+                x_BTHWC,
+                dims=dims,
+                pad_left=pad_left,
+                pad_right=pad_right,
                 padding_mode="zeros",
-                cluster_axis=self.parallel_config.width_parallel.mesh_axis,
-                # neighbor_pad only needs one final semaphore, so index into ag semahpore list
-                final_semaphore=self.ccl_manager.get_ag_ping_pong_semaphore(
-                    self.parallel_config.width_parallel.mesh_axis
-                )[0],
-                barrier_semaphore=self.ccl_manager.get_barrier_semaphore(self.parallel_config.width_parallel.mesh_axis),
-                num_links=get_neighbor_pad_num_links(self.ccl_manager, x_THWC, 2),
-                # memory_config=mem_config_output,
-                topology=self.ccl_manager.topology,
+                axes=axes,
+                neighbor_sems=neighbor_sems,
+                num_links=links,
             )
-            ttnn.synchronize_device(x_THWC.device())
-            x_BTHWC = ttnn.unsqueeze(x_THWC, dim=0)
 
         x_BTHWC = ttnn.experimental.conv3d(
             input_tensor=x_BTHWC,
@@ -725,51 +716,42 @@ class WanConv2d(Module):
             mask = self.get_cached_mask(x_BTHWC, logical_h)
             x_BTHWC = ttnn.mul(x_BTHWC, mask)
 
-        # Height halo
-        if self.external_padding[1] > 0 and self.parallel_config.height_parallel.factor > 1:
-            ttnn.synchronize_device(x_BTHWC.device())
-            x_BTHWC = ttnn.experimental.neighbor_pad_async(
+        # Halo exchange (height and/or width padding)
+        h_pad_needed = self.external_padding[1] > 0 and self.parallel_config.height_parallel.factor > 1
+        w_pad_needed = self.external_padding[2] > 0 and self.parallel_config.width_parallel.factor > 1
+
+        if h_pad_needed or w_pad_needed:
+            dims, pad_left, pad_right = [], [], []
+            axes, neighbor_sems, links = [], [], []
+            if h_pad_needed:
+                dims.append(2)
+                pad_left.append(self.external_padding[1])
+                pad_right.append(self.external_padding[1])
+                axes.append(self.parallel_config.height_parallel.mesh_axis)
+                neighbor_sems.append(
+                    self.ccl_manager.get_np_ping_pong_semaphore(self.parallel_config.height_parallel.mesh_axis)
+                )
+                links.append(get_neighbor_pad_num_links(self.ccl_manager, x_BTHWC, 2))
+            if w_pad_needed:
+                dims.append(3)
+                pad_left.append(self.external_padding[2])
+                pad_right.append(self.external_padding[2])
+                axes.append(self.parallel_config.width_parallel.mesh_axis)
+                neighbor_sems.append(
+                    self.ccl_manager.get_np_ping_pong_semaphore(self.parallel_config.width_parallel.mesh_axis)
+                )
+                links.append(get_neighbor_pad_num_links(self.ccl_manager, x_BTHWC, 3))
+
+            x_BTHWC = self.ccl_manager.neighbor_pad_persistent_buffer(
                 x_BTHWC,
-                dim=2,
-                padding_left=self.external_padding[1],
-                padding_right=self.external_padding[1],
+                dims=dims,
+                pad_left=pad_left,
+                pad_right=pad_right,
                 padding_mode="zeros",
-                cluster_axis=self.parallel_config.height_parallel.mesh_axis,
-                # neighbor_pad only needs one final semaphore, so index into ag semahpore list
-                final_semaphore=self.ccl_manager.get_ag_ping_pong_semaphore(
-                    self.parallel_config.height_parallel.mesh_axis
-                )[0],
-                barrier_semaphore=self.ccl_manager.get_barrier_semaphore(
-                    self.parallel_config.height_parallel.mesh_axis
-                ),
-                num_links=get_neighbor_pad_num_links(self.ccl_manager, x_BTHWC, 2),
-                # memory_config=mem_config_output,
-                topology=self.ccl_manager.topology,
+                axes=axes,
+                neighbor_sems=neighbor_sems,
+                num_links=links,
             )
-            ttnn.synchronize_device(x_BTHWC.device())
-        # Width halo
-        if self.external_padding[2] > 0 and self.parallel_config.width_parallel.factor > 1:
-            # TODO: Fix validation in neighbor_pad_async to allow halo on dim3
-            x_THWC = ttnn.squeeze(x_BTHWC, dim=0)
-            ttnn.synchronize_device(x_THWC.device())
-            x_THWC = ttnn.experimental.neighbor_pad_async(
-                x_THWC,
-                dim=2,
-                padding_left=self.external_padding[2],
-                padding_right=self.external_padding[2],
-                padding_mode="zeros",
-                cluster_axis=self.parallel_config.width_parallel.mesh_axis,
-                # neighbor_pad only needs one final semaphore, so index into ag semahpore list
-                final_semaphore=self.ccl_manager.get_ag_ping_pong_semaphore(
-                    self.parallel_config.width_parallel.mesh_axis
-                )[0],
-                barrier_semaphore=self.ccl_manager.get_barrier_semaphore(self.parallel_config.width_parallel.mesh_axis),
-                num_links=get_neighbor_pad_num_links(self.ccl_manager, x_THWC, 2),
-                # memory_config=mem_config_output,
-                topology=self.ccl_manager.topology,
-            )
-            ttnn.synchronize_device(x_THWC.device())
-            x_BTHWC = ttnn.unsqueeze(x_THWC, dim=0)
 
         x_BTHWC = ttnn.experimental.conv3d(
             input_tensor=x_BTHWC,

--- a/models/tt_dit/parallel/config.py
+++ b/models/tt_dit/parallel/config.py
@@ -99,19 +99,19 @@ def vae_neighbor_pad(
     secondary_cluster_axis=None,
     secondary_mesh_shape=None,
 ) -> ttnn.Tensor:
-    global_semaphore = ccl_manager.get_np_ping_pong_semaphore(cluster_axis)
+    neighbor_semaphore = ccl_manager.get_np_ping_pong_semaphore(cluster_axis)
     barrier_semaphore = ccl_manager.get_barrier_semaphore(cluster_axis)
 
     x_pad = ttnn.experimental.neighbor_pad_async(
         x,
-        dim=dim,
-        padding_left=padding_left,
-        padding_right=padding_right,
-        padding_mode=padding_mode,
-        cluster_axis=cluster_axis,
-        final_semaphore=global_semaphore,
-        barrier_semaphore=barrier_semaphore,
-        num_links=ccl_manager.num_links,
+        [dim],
+        [padding_left],
+        [padding_right],
+        padding_mode,
+        [cluster_axis],
+        [neighbor_semaphore],
+        [barrier_semaphore],
+        num_links=[ccl_manager.num_links],
         topology=ttnn.Topology.Linear,
         secondary_cluster_axis=secondary_cluster_axis,
         secondary_mesh_shape=secondary_mesh_shape,

--- a/models/tt_dit/parallel/manager.py
+++ b/models/tt_dit/parallel/manager.py
@@ -6,7 +6,7 @@ import torch
 
 import ttnn
 
-from ..utils.tensor import bf16_tensor
+from ..utils.tensor import bf16_tensor, local_device_to_torch
 
 
 class CCLManager:
@@ -398,4 +398,4 @@ class CCLManager:
                     use_hyperparams=True,
                     use_persistent_buffer=use_persistent_buffer,
                 )
-        return ttnn.to_torch(ttnn.get_device_tensors(device_tensor)[0])
+        return local_device_to_torch(device_tensor)

--- a/models/tt_dit/parallel/manager.py
+++ b/models/tt_dit/parallel/manager.py
@@ -235,6 +235,113 @@ class CCLManager:
         self.barrier_idx[mesh_axis] = (cur_idx + 1) % 2
         return self.barrier_semaphores[mesh_axis][cur_idx]
 
+    def get_np_ping_pong_buffer(self, input_shape, dims, pad_left, pad_right, dtype=ttnn.bfloat16):
+        """
+        Get or create ping pong buffers for neighbor pad operations.
+        Caches buffers based on output shape and dtype.
+
+        Args:
+            input_shape: Input tensor shape
+            dims: List of dimensions being padded
+            pad_left: List of left padding amounts per dim
+            pad_right: List of right padding amounts per dim
+            dtype: Tensor dtype
+
+        Returns:
+            Current ping pong buffer (alternates between two buffers)
+        """
+        output_shape = list(input_shape)
+        for i, dim in enumerate(dims):
+            output_shape[dim] += pad_left[i] + pad_right[i]
+
+        cache_key = ("np", tuple(output_shape), dtype)
+
+        if cache_key not in self._ping_pong_buffer_cache:
+            ttnn.synchronize_device(self.mesh_device)
+            buffers = []
+            for _ in range(2):
+                output_buffer = ttnn.from_torch(
+                    torch.zeros(output_shape),
+                    layout=ttnn.ROW_MAJOR_LAYOUT,
+                    dtype=dtype,
+                    memory_config=ttnn.DRAM_MEMORY_CONFIG,
+                    device=self.mesh_device,
+                )
+                buffers.append(output_buffer)
+
+            self._ping_pong_buffer_cache[cache_key] = buffers
+            self._ping_pong_buffer_indices[cache_key] = 0
+            ttnn.synchronize_device(self.mesh_device)
+
+        current_idx = self._ping_pong_buffer_indices[cache_key]
+        self._ping_pong_buffer_indices[cache_key] = 1 - current_idx
+
+        return self._ping_pong_buffer_cache[cache_key][current_idx]
+
+    def neighbor_pad_persistent_buffer(
+        self,
+        tensor: ttnn.Tensor,
+        /,
+        *,
+        dims: list,
+        pad_left: list,
+        pad_right: list,
+        padding_mode: str,
+        axes: list,
+        neighbor_sems: list,
+        num_links: list,
+    ) -> ttnn.Tensor:
+        """
+        Helper function to neighbor-pad a tensor with a persistent output buffer.
+        """
+        return self.neighbor_pad(
+            tensor,
+            dims=dims,
+            pad_left=pad_left,
+            pad_right=pad_right,
+            padding_mode=padding_mode,
+            axes=axes,
+            neighbor_sems=neighbor_sems,
+            num_links=num_links,
+            use_persistent_buffer=True,
+        )
+
+    def neighbor_pad(
+        self,
+        tensor: ttnn.Tensor,
+        /,
+        *,
+        dims: list,
+        pad_left: list,
+        pad_right: list,
+        padding_mode: str,
+        axes: list,
+        neighbor_sems: list,
+        num_links: list,
+        use_persistent_buffer: bool = False,
+    ) -> ttnn.Tensor:
+        barrier_sem = self.get_barrier_semaphore(axes[0])
+
+        persistent_buf = None
+        if use_persistent_buffer:
+            persistent_buf = self.get_np_ping_pong_buffer(
+                tensor.shape, dims, pad_left, pad_right, dtype=tensor.get_dtype()
+            )
+
+        return ttnn.experimental.neighbor_pad_async(
+            tensor,
+            dims,
+            pad_left,
+            pad_right,
+            padding_mode,
+            axes,
+            neighbor_sems,
+            [barrier_sem],
+            num_links=num_links,
+            topology=self.topology,
+            persistent_output_buffer=persistent_buf,
+        )
+
     def reset_global_semaphores(self):
         """Reset all global semaphores to 0"""
         for axis in [0, 1]:

--- a/models/tt_dit/parallel/manager.py
+++ b/models/tt_dit/parallel/manager.py
@@ -375,3 +375,27 @@ class CCLManager:
             "num_workers_per_link": 2,
             "num_buffers_per_channel": 2,
         }
+
+    # TODO: Merge with utils.tensor.to_torch
+    def device_to_host(
+        self, tensor: ttnn.Tensor, mesh_dims: list[int], use_persistent_buffer: bool = True
+    ) -> torch.Tensor:
+        """Move a ttnn device tensor to a torch host tensor.
+        Args:
+            tensor: The ttnn tensor to move to host
+            mesh_dims: The dimension to gather per mesh axis. use None to skip gathering for that mesh axis. e.g [None,2] will gather along the second dimension for the mesh axis 1.
+            use_persistent_buffer: Whether to use a persistent buffer for the all gather operation.
+        Returns:
+            The torch host tensor
+        """
+        device_tensor = ttnn.to_layout(tensor, ttnn.TILE_LAYOUT)  # Workaround for bug in Row Major layout
+        for mesh_axis, mesh_dim in enumerate(mesh_dims):
+            if mesh_dim is not None:
+                device_tensor = self.all_gather(
+                    device_tensor,
+                    dim=mesh_dim,
+                    mesh_axis=mesh_axis,
+                    use_hyperparams=True,
+                    use_persistent_buffer=use_persistent_buffer,
+                )
+        return ttnn.to_torch(ttnn.get_device_tensors(device_tensor)[0])

--- a/models/tt_dit/pipelines/wan/pipeline_wan.py
+++ b/models/tt_dit/pipelines/wan/pipeline_wan.py
@@ -259,8 +259,7 @@ class WanPipeline(DiffusionPipeline, WanLoraLoaderMixin):
             self.transformer.set_unload_set(self.transformer_2)
             self.transformer_2.set_unload_set(self.transformer, self.tt_umt5_encoder)
 
-        # setup dynamic loading. Transformer1, VAE, and Text Encoder can coexist on device for all currently supported configuration
-        # Cache warmup: Load in reverse order of use to ensure the first models stay loaded before call.
+        # Cache warmup: Load in reverse order of use to ensure the earliest required models stay loaded before call.
         self._prepare_transformer2()
         self._prepare_transformer1()
         self._prepare_text_encoder()
@@ -1005,12 +1004,7 @@ class WanPipeline(DiffusionPipeline, WanLoraLoaderMixin):
             concat_dims = [None, None]
             concat_dims[self.vae_parallel_config.height_parallel.mesh_axis] = 3
             concat_dims[self.vae_parallel_config.width_parallel.mesh_axis] = 4
-            video_torch = ttnn.to_torch(
-                tt_video_BCTHW,
-                mesh_composer=ttnn.ConcatMesh2dToTensor(
-                    self.mesh_device, mesh_shape=tuple(self.mesh_device.shape), dims=concat_dims
-                ),
-            )
+            video_torch = self.vae_ccl_manager.device_to_host(tt_video_BCTHW, concat_dims)
             video_torch = video_torch[:, :, :, :new_logical_h, :]
 
             video = self.video_processor.postprocess_video(video_torch, output_type=output_type)

--- a/models/tt_dit/pipelines/wan/pipeline_wan.py
+++ b/models/tt_dit/pipelines/wan/pipeline_wan.py
@@ -396,6 +396,7 @@ class WanPipeline(DiffusionPipeline, WanLoraLoaderMixin):
             parallel_config=self.parallel_config,
             mesh_shape=tuple(self.mesh_device.shape),
             get_torch_state_dict=lambda: self.torch_transformer.state_dict(),
+            create_cache=False,
         )
 
     def _prepare_transformer2(self):
@@ -406,6 +407,7 @@ class WanPipeline(DiffusionPipeline, WanLoraLoaderMixin):
             parallel_config=self.parallel_config,
             mesh_shape=tuple(self.mesh_device.shape),
             get_torch_state_dict=lambda: self.torch_transformer_2.state_dict(),
+            create_cache=False,
         )
 
     def _prepare_vae(self):

--- a/models/tt_dit/pipelines/wan/pipeline_wan.py
+++ b/models/tt_dit/pipelines/wan/pipeline_wan.py
@@ -961,15 +961,18 @@ class WanPipeline(DiffusionPipeline, WanLoraLoaderMixin):
                 # call the callback, if provided
                 if i == len(timesteps) - 1 or ((i + 1) > num_warmup_steps and (i + 1) % self.scheduler.order == 0):
                     progress_bar.update()
-        if profiler:
-            profiler.end("denoising", profiler_iteration)
-
-        self._current_timestep = None
-
+        
         # Postprocess spatial output
         latents = current_model.postprocess_spatial_output_host(
             permuted_latent, F=latent_frames, H=latent_height, W=latent_width, N=patchified_seqlen
         )
+        
+        if profiler:
+            profiler.end("denoising", profiler_iteration)
+            profiler.start("vae", profiler_iteration)
+
+        self._current_timestep = None
+
 
         if not output_type == "latent":
             latents = latents.to(self.vae.dtype)
@@ -998,9 +1001,9 @@ class WanPipeline(DiffusionPipeline, WanLoraLoaderMixin):
                     self.vae_parallel_config.width_parallel.mesh_axis: 3,
                 },
             )
-            with profiler("vae", profiler_iteration) if profiler else nullcontext():
-                self._prepare_vae()
-                tt_video_BCTHW, new_logical_h = self.tt_vae(tt_latents_BTHWC, logical_h)
+
+            self._prepare_vae()
+            tt_video_BCTHW, new_logical_h = self.tt_vae(tt_latents_BTHWC, logical_h)
 
             concat_dims = [None, None]
             concat_dims[self.vae_parallel_config.height_parallel.mesh_axis] = 3
@@ -1016,6 +1019,9 @@ class WanPipeline(DiffusionPipeline, WanLoraLoaderMixin):
             video = self.video_processor.postprocess_video(video_torch, output_type=output_type)
         else:
             video = latents
+            
+        if profiler:
+            profiler.end("vae", profiler_iteration)
 
         # Offload all models
         # self.maybe_free_model_hooks()

--- a/models/tt_dit/pipelines/wan/pipeline_wan.py
+++ b/models/tt_dit/pipelines/wan/pipeline_wan.py
@@ -33,7 +33,7 @@ from ...parallel.config import DiTParallelConfig, EncoderParallelConfig, Paralle
 from ...parallel.manager import CCLManager
 from ...utils import cache
 from ...utils.conv3d import conv_pad_height, conv_pad_in_channels
-from ...utils.tensor import bf16_tensor_2dshard, local_device_to_torch
+from ...utils.tensor import local_device_to_torch, typed_tensor_2dshard
 
 EXAMPLE_DOC_STRING = """
     Examples:
@@ -135,6 +135,7 @@ class WanPipeline(DiffusionPipeline, WanLoraLoaderMixin):
         topology: ttnn.Topology = ttnn.Topology.Linear,
         is_fsdp: bool = True,
         model_type: str = "t2v",
+        vae_dtype: ttnn.DataType = ttnn.bfloat16,
     ):
         super().__init__()
 
@@ -249,6 +250,7 @@ class WanPipeline(DiffusionPipeline, WanLoraLoaderMixin):
             mesh_device=self.mesh_device,
             ccl_manager=self.vae_ccl_manager,
             parallel_config=self.vae_parallel_config,
+            dtype=vae_dtype,
         )
 
         if self.dynamic_load:
@@ -988,7 +990,7 @@ class WanPipeline(DiffusionPipeline, WanLoraLoaderMixin):
             tt_latents_BTHWC, logical_h = conv_pad_height(
                 tt_latents_BTHWC, self.vae_parallel_config.height_parallel.factor
             )
-            tt_latents_BTHWC = bf16_tensor_2dshard(
+            tt_latents_BTHWC = typed_tensor_2dshard(
                 tt_latents_BTHWC,
                 self.mesh_device,
                 layout=ttnn.ROW_MAJOR_LAYOUT,
@@ -996,6 +998,7 @@ class WanPipeline(DiffusionPipeline, WanLoraLoaderMixin):
                     self.vae_parallel_config.height_parallel.mesh_axis: 2,
                     self.vae_parallel_config.width_parallel.mesh_axis: 3,
                 },
+                dtype=self.tt_vae.dtype,
             )
 
             self._prepare_vae()

--- a/models/tt_dit/pipelines/wan/pipeline_wan.py
+++ b/models/tt_dit/pipelines/wan/pipeline_wan.py
@@ -33,7 +33,7 @@ from ...parallel.config import DiTParallelConfig, EncoderParallelConfig, Paralle
 from ...parallel.manager import CCLManager
 from ...utils import cache
 from ...utils.conv3d import conv_pad_height, conv_pad_in_channels
-from ...utils.tensor import bf16_tensor_2dshard
+from ...utils.tensor import bf16_tensor_2dshard, local_device_to_torch
 
 EXAMPLE_DOC_STRING = """
     Examples:
@@ -940,7 +940,7 @@ class WanPipeline(DiffusionPipeline, WanLoraLoaderMixin):
                     )
 
                 # Move result to host for scheduler step
-                permuted_noise_pred = current_model.device_to_host(permuted_noise_pred_tt)
+                permuted_noise_pred = local_device_to_torch(permuted_noise_pred_tt)
 
                 # compute the previous noisy sample x_t -> x_t-1
                 permuted_latent = self.scheduler.step(permuted_noise_pred, t, permuted_latent, return_dict=False)[0]

--- a/models/tt_dit/pipelines/wan/pipeline_wan.py
+++ b/models/tt_dit/pipelines/wan/pipeline_wan.py
@@ -313,6 +313,14 @@ class WanPipeline(DiffusionPipeline, WanLoraLoaderMixin):
                 "topology": ttnn.Topology.Ring,
                 "is_fsdp": False,
             }
+            device_configs[(4, 32)] = {
+                "sp_axis": 1,
+                "tp_axis": 0,
+                "num_links": 2,
+                "dynamic_load": False,
+                "topology": ttnn.Topology.Ring,
+                "is_fsdp": False,
+            }
             config = device_configs[tuple(mesh_device.shape)]
         else:
             device_configs[(2, 4)] = {

--- a/models/tt_dit/pipelines/wan/pipeline_wan.py
+++ b/models/tt_dit/pipelines/wan/pipeline_wan.py
@@ -396,7 +396,6 @@ class WanPipeline(DiffusionPipeline, WanLoraLoaderMixin):
             parallel_config=self.parallel_config,
             mesh_shape=tuple(self.mesh_device.shape),
             get_torch_state_dict=lambda: self.torch_transformer.state_dict(),
-            create_cache=False,
         )
 
     def _prepare_transformer2(self):
@@ -407,7 +406,6 @@ class WanPipeline(DiffusionPipeline, WanLoraLoaderMixin):
             parallel_config=self.parallel_config,
             mesh_shape=tuple(self.mesh_device.shape),
             get_torch_state_dict=lambda: self.torch_transformer_2.state_dict(),
-            create_cache=False,
         )
 
     def _prepare_vae(self):
@@ -961,18 +959,17 @@ class WanPipeline(DiffusionPipeline, WanLoraLoaderMixin):
                 # call the callback, if provided
                 if i == len(timesteps) - 1 or ((i + 1) > num_warmup_steps and (i + 1) % self.scheduler.order == 0):
                     progress_bar.update()
-        
+
         # Postprocess spatial output
         latents = current_model.postprocess_spatial_output_host(
             permuted_latent, F=latent_frames, H=latent_height, W=latent_width, N=patchified_seqlen
         )
-        
+
         if profiler:
             profiler.end("denoising", profiler_iteration)
             profiler.start("vae", profiler_iteration)
 
         self._current_timestep = None
-
 
         if not output_type == "latent":
             latents = latents.to(self.vae.dtype)
@@ -1019,7 +1016,7 @@ class WanPipeline(DiffusionPipeline, WanLoraLoaderMixin):
             video = self.video_processor.postprocess_video(video_torch, output_type=output_type)
         else:
             video = latents
-            
+
         if profiler:
             profiler.end("vae", profiler_iteration)
 

--- a/models/tt_dit/tests/conftest.py
+++ b/models/tt_dit/tests/conftest.py
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+
+import torch
+from loguru import logger
+
+num_torch_threads = max(1, os.cpu_count())
+logger.info(f"Setting torch num_threads to {num_torch_threads}")
+torch.set_num_threads(num_torch_threads)

--- a/models/tt_dit/tests/encoders/umt5/test_umt5.py
+++ b/models/tt_dit/tests/encoders/umt5/test_umt5.py
@@ -3,11 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import os
-import sys
 import time
-from pathlib import Path
-
-sys.path.append(str(Path(__file__).resolve().parents[6]))
 
 import pytest
 import torch
@@ -18,52 +14,91 @@ from transformers.models.umt5.modeling_umt5 import UMT5EncoderModel
 
 import ttnn
 from models.perf.benchmarking_utils import BenchmarkProfiler
-from models.tt_dit.encoders.t5.model_t5 import RelativePositionEmbeddings as TT_UMT5RelativePositionEmbeddings
-from models.tt_dit.encoders.t5.model_t5 import TokenEmbeddings as TT_UMT5TokenEmbeddings
-from models.tt_dit.encoders.umt5.model_umt5 import UMT5Config as TT_UMT5Config
-from models.tt_dit.encoders.umt5.model_umt5 import UMT5Encoder as TT_UMT5Encoder
-from models.tt_dit.parallel.config import EncoderParallelConfig, ParallelFactor
-from models.tt_dit.parallel.manager import CCLManager
-from models.tt_dit.utils import cache
-from models.tt_dit.utils.check import assert_quality
+
+from ....encoders.t5.model_t5 import RelativePositionEmbeddings as TT_UMT5RelativePositionEmbeddings
+from ....encoders.umt5.model_umt5 import UMT5Config as TT_UMT5Config
+from ....encoders.umt5.model_umt5 import UMT5Encoder as TT_UMT5Encoder
+from ....layers.embeddings import Embedding
+from ....parallel.config import EncoderParallelConfig, ParallelFactor
+from ....parallel.manager import CCLManager
+from ....utils import cache
+from ....utils.check import assert_quality
+
+# Shared device configuration for UMT5 tests to reduce code duplication and ensure we are using consistent device configurations.
 
 
-@pytest.mark.parametrize(
-    "mesh_device,submesh_shape, num_links",
-    [[(2, 4), (1, 4), 1], [(4, 8), (1, 8), 4], [(4, 8), (1, 8), 2]],
-    ids=["t3k", "glx", "bh_glx"],
-    indirect=["mesh_device"],
-)
-@pytest.mark.parametrize(
-    "device_params, topology",
-    [[{"l1_small_size": 8192, "fabric_config": ttnn.FabricConfig.FABRIC_1D}, ttnn.Topology.Linear]],
-    indirect=["device_params"],
-)
+def umt5_device_config(func):
+    """Decorator to apply standard UMT5 device/mesh parametrization to tests."""
+    func = pytest.mark.parametrize(
+        "dit_unit_test",
+        [{"1": True, "0": False}.get(os.environ.get("DIT_UNIT_TEST"), False)],
+    )(func)
+    func = pytest.mark.parametrize(
+        "mesh_device, num_links, max_execution_time",
+        [[(2, 4), 1, 0.13], [(4, 8), 4, 0.1], [(4, 8), 2, 0.1]],
+        ids=["t3k", "wh_glx", "bh_glx"],
+        indirect=["mesh_device", "num_links"],
+    )(func)
+    func = pytest.mark.parametrize(
+        "device_params",
+        [{"fabric_config": ttnn.FabricConfig.FABRIC_1D}],
+        indirect=True,
+    )(func)
+    return func
+
+
+@pytest.fixture
+def num_links(request):
+    return request.param
+
+
+@pytest.fixture
+def parallel_config_and_ccl_manager(mesh_device, num_links):
+    parallel_config = EncoderParallelConfig(
+        tensor_parallel=ParallelFactor(factor=mesh_device.shape[1], mesh_axis=1),
+    )
+    ccl_manager = CCLManager(
+        mesh_device=mesh_device,
+        num_links=num_links,
+        topology=ttnn.Topology.Linear,
+    )
+    return parallel_config, ccl_manager
+
+
+def get_random_weights_model() -> UMT5EncoderModel:
+    hf_config = HF_UMT5Config(
+        d_model=4096,
+        d_ff=10240,
+        num_heads=64,
+        num_layers=24,
+        num_decoder_layers=0,
+        relative_attention_max_distance=128,
+        relative_attention_num_buckets=32,
+        feed_forward_proj="gated-gelu",
+        output_past=True,
+    )
+    return UMT5EncoderModel(hf_config)
+
+
+@umt5_device_config
 def test_umt5_embeddings(
     *,
     mesh_device: ttnn.Device,
-    submesh_shape: ttnn.MeshShape,
-    topology: ttnn.Topology,
-    num_links: int,
+    parallel_config_and_ccl_manager: tuple,
+    dit_unit_test: bool,
+    max_execution_time: float,
 ) -> None:
-    parent_mesh_shape = tuple(mesh_device.shape)
-    if any(x[0] < x[1] for x in zip(parent_mesh_shape, submesh_shape)):
-        pytest.skip("submesh shape is larger than parent mesh shape, skipping")
-    encoder_submesh = mesh_device  # mesh_device.create_submesh(ttnn.MeshShape(*submesh_shape))
-    print(f"Running on submesh {encoder_submesh.shape} of parent mesh {mesh_device.shape}")
+    torch.manual_seed(0)
 
-    parallel_config = EncoderParallelConfig(
-        tensor_parallel=ParallelFactor(factor=encoder_submesh.shape[1], mesh_axis=1),
-    )
-    ccl_manager = CCLManager(
-        mesh_device=encoder_submesh,
-        num_links=num_links,
-        topology=topology,
-    )
+    parallel_config, ccl_manager = parallel_config_and_ccl_manager
 
-    model_name_checkpoint = f"Wan-AI/Wan2.2-T2V-A14B-Diffusers"
-
-    hf_model = UMT5EncoderModel.from_pretrained(model_name_checkpoint, subfolder="text_encoder", local_files_only=True)
+    if dit_unit_test:
+        hf_model = get_random_weights_model()
+    else:
+        model_name_checkpoint = f"Wan-AI/Wan2.2-T2V-A14B-Diffusers"
+        hf_model = UMT5EncoderModel.from_pretrained(
+            model_name_checkpoint, subfolder="text_encoder", local_files_only=True
+        )
 
     hf_model.eval()
 
@@ -79,14 +114,13 @@ def test_umt5_embeddings(
     logger.info(f"layer_norm_epsilon: {hf_model.config.layer_norm_epsilon}")
 
     max_prompt_length = 512
-    torch.manual_seed(0)
     tokens = torch.randint(hf_model.config.vocab_size, [1, max_prompt_length])
 
     tt_prompt = ttnn.from_torch(
         tokens,
         layout=ttnn.TILE_LAYOUT,
-        device=encoder_submesh,
-        mesh_mapper=ttnn.ReplicateTensorToMesh(encoder_submesh),
+        device=mesh_device,
+        mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device),
     )
 
     # === TT-DiT UMT5 ====
@@ -105,11 +139,9 @@ def test_umt5_embeddings(
 
     state_dict = hf_model.state_dict()
 
-    tt_token_embed = TT_UMT5TokenEmbeddings(config, encoder_submesh)
+    tt_token_embed = Embedding(config.vocab_size, config.embed_dim, device=mesh_device)
     tt_token_embed.load_torch_state_dict({"weight": state_dict["encoder.embed_tokens.weight"]})
-    tt_relative_position_embed = TT_UMT5RelativePositionEmbeddings(
-        config, encoder_submesh, ccl_manager, parallel_config
-    )
+    tt_relative_position_embed = TT_UMT5RelativePositionEmbeddings(config, mesh_device, ccl_manager, parallel_config)
     tt_relative_position_embed.load_torch_state_dict(
         {"weight": state_dict["encoder.block.0.layer.0.SelfAttention.relative_attention_bias.weight"]}
     )
@@ -139,98 +171,54 @@ def test_umt5_embeddings(
     # convert mesh tensor to torch tensor for pcc
     # since weights are replicated, can get the tensor from any single device
     tt_embeddings_output_torch = ttnn.to_torch(ttnn.get_device_tensors(tt_embeddings_output)[0])
-    mesh_shape = list(encoder_submesh.shape)
+    mesh_shape = list(mesh_device.shape)
     mesh_shape[1 - parallel_config.tensor_parallel.mesh_axis] = 1
 
     tt_position_bias_torch = ttnn.to_torch(
         tt_position_bias,
         mesh_composer=ttnn.create_mesh_composer(
-            encoder_submesh, ttnn.MeshComposerConfig([0, 1], ttnn.MeshShape(mesh_shape))
+            mesh_device, ttnn.MeshComposerConfig([0, 1], ttnn.MeshShape(mesh_shape))
         ),  # [0,1] is the mesh dimensions to concatenate. Set replicated dimensions to 1.
     )
 
     logger.info(f"TT embeddings execution time: {tt_execution_time:.4f} seconds")
     logger.info(f"HF embeddings execution time: {hf_execution_time:.4f} seconds")
 
-    assert_quality(hf_token_embeddings, tt_embeddings_output_torch, pcc=0.99)
-    assert_quality(hf_position_bias, tt_position_bias_torch, pcc=0.99)
+    assert_quality(hf_token_embeddings, tt_embeddings_output_torch, pcc=(1.0 - 1e-5), relative_rmse=0.005)
+    assert_quality(hf_position_bias, tt_position_bias_torch, pcc=(1.0 - 1e-5), relative_rmse=0.005)
 
 
-@pytest.mark.parametrize(
-    "dit_unit_test",
-    [{"1": True, "0": False}.get(os.environ.get("DIT_UNIT_TEST"), False)],
-)
-@pytest.mark.parametrize(
-    "mesh_device,submesh_shape, num_links",
-    [[(2, 4), (1, 4), 1], [(4, 8), (1, 8), 4], [(4, 8), (1, 8), 2]],
-    ids=["t3k", "wh_glx", "bh_glx"],
-    indirect=["mesh_device"],
-)
-@pytest.mark.parametrize(
-    "device_params, topology",
-    [[{"l1_small_size": 8192, "fabric_config": ttnn.FabricConfig.FABRIC_1D}, ttnn.Topology.Linear]],
-    indirect=["device_params"],
-)
+@umt5_device_config
 def test_umt5_encoder(
     *,
     mesh_device: ttnn.Device,
-    submesh_shape: ttnn.MeshShape,
-    num_links: int,
-    topology: ttnn.Topology,
+    parallel_config_and_ccl_manager: tuple,
     dit_unit_test: bool,
+    max_execution_time: float,
 ) -> None:
-    parent_mesh_shape = tuple(mesh_device.shape)
-    if any(x[0] < x[1] for x in zip(parent_mesh_shape, submesh_shape)):
-        pytest.skip("submesh shape is larger than parent mesh shape, skipping")
-    encoder_submesh = mesh_device  # mesh_device.create_submesh(ttnn.MeshShape(*submesh_shape))
-    print(f"Running on submesh {encoder_submesh.shape} of parent mesh {mesh_device.shape}")
+    torch.manual_seed(0)
 
-    parallel_config = EncoderParallelConfig(
-        tensor_parallel=ParallelFactor(factor=encoder_submesh.shape[1], mesh_axis=1),
-    )
-    ccl_manager = CCLManager(
-        mesh_device=encoder_submesh,
-        num_links=num_links,
-        topology=topology,
-    )
+    parallel_config, ccl_manager = parallel_config_and_ccl_manager
 
     model_name_checkpoint = f"Wan-AI/Wan2.2-T2V-A14B-Diffusers"
 
     if dit_unit_test:
-        # Config for t5-xxl with minimal layers
-        hf_config = HF_UMT5Config(
-            d_model=4096,
-            d_ff=10240,
-            num_heads=64,
-            num_layers=2,
-            num_decoder_layers=2,
-            feed_forward_proj="gated-gelu",
-            output_past=True,
-        )
-        hf_model = UMT5EncoderModel(hf_config)
+        hf_model = get_random_weights_model()
     else:
         hf_model = UMT5EncoderModel.from_pretrained(
             model_name_checkpoint, subfolder="text_encoder", local_files_only=False
         )
     hf_model.eval()
 
-    logger.info("=== HuggingFace UMT5 Config ===")
-    logger.info(f"vocab_size: {hf_model.config.vocab_size}")
-    logger.info(f"hidden_size: {hf_model.config.d_model}")
-    logger.info(f"intermediate_size: {hf_model.config.d_ff}")
-    logger.info(f"d_kv: {hf_model.config.d_kv}")
-    logger.info(f"num_attention_heads: {hf_model.config.num_heads}")
-    logger.info(f"num_hidden_layers: {hf_model.config.num_layers}")
-    logger.info(f"relative_attention_num_buckets: {hf_model.config.relative_attention_num_buckets}")
-    logger.info(f"relative_attention_max_distance: {hf_model.config.relative_attention_max_distance}")
-    logger.info(f"layer_norm_epsilon: {hf_model.config.layer_norm_epsilon}")
-
     max_prompt_length = 512
-    torch.manual_seed(0)
+
     prompt = [
-        "A close-up of a beautiful butterfly landing on a flower, wings gently moving in the breeze.",
-        "Negative prompt: A close-up of a beautiful butterfly landing on a flower, wings gently moving in the breeze.",
+        "A Roman general standing on a battlefield at dawn, torn red cape blowing in the wind, distant soldiers forming ranks, painterly brushwork in the style of Caravaggio, chiaroscuro lighting, epic composition",
+        "色调艳丽，过曝，静态，细节模糊不清，字幕，风格，作品，画作，画面，静止，整体发灰，最差质量，低质量，JPEG压缩残留，丑陋的，残缺的，多余的手指，画得不好的手部，画得不好的脸部，畸形的，毁容的，形态畸形的肢体，手指融合，静止不动的画面，杂乱的背景，三条腿，背景人很多，倒着走",
     ]
+    total_prompts = len(prompt)
+    num_devices = mesh_device.shape[1 - parallel_config.tensor_parallel.mesh_axis]
+    prompt += [" "] * ((num_devices - (total_prompts % num_devices)) % num_devices)
     tokenizer = AutoTokenizer.from_pretrained(model_name_checkpoint, subfolder="tokenizer", trust_remote_code=True)
     text_inputs = tokenizer(
         prompt,
@@ -243,20 +231,25 @@ def test_umt5_encoder(
     )
     text_input_ids, mask = text_inputs.input_ids, text_inputs.attention_mask
 
+    dims = [None, None]
+    DP_axis = 1 - parallel_config.tensor_parallel.mesh_axis
+    dims[DP_axis] = 0
+    mesh_mapper = ttnn.ShardTensor2dMesh(mesh_device, mesh_shape=tuple(mesh_device.shape), dims=dims)
+
     tt_prompt = ttnn.from_torch(
         text_input_ids,
         dtype=ttnn.uint32,
         layout=ttnn.TILE_LAYOUT,
-        device=encoder_submesh,
-        mesh_mapper=ttnn.ReplicateTensorToMesh(encoder_submesh),
+        device=mesh_device,
+        mesh_mapper=mesh_mapper,
     )
 
     tt_mask = ttnn.from_torch(
         mask,
         dtype=ttnn.bfloat16,
         layout=ttnn.TILE_LAYOUT,
-        device=encoder_submesh,
-        mesh_mapper=ttnn.ReplicateTensorToMesh(encoder_submesh),
+        device=mesh_device,
+        mesh_mapper=mesh_mapper,
     )
 
     # === TT-DiT UMT5 ====
@@ -273,25 +266,27 @@ def test_umt5_encoder(
         relative_attention_max_distance=hf_model.config.relative_attention_max_distance,
     )
 
-    tt_encoder = TT_UMT5Encoder(config, encoder_submesh, ccl_manager, parallel_config)
-    # tt_encoder.load_torch_state_dict(hf_model.state_dict())
+    tt_encoder = TT_UMT5Encoder(config, mesh_device, ccl_manager, parallel_config)
     cache.load_model(
         tt_encoder,
         model_name=model_name_checkpoint,
         subfolder="text_encoder",
         parallel_config=parallel_config,
-        mesh_shape=tuple(encoder_submesh.shape),
+        mesh_shape=tuple(mesh_device.shape),
         get_torch_state_dict=lambda: hf_model.state_dict(),
     )
 
-    # time TT model inference only
-    # with warmup
+    # warmup
     tt_output = tt_encoder(tt_prompt, attention_mask=tt_mask)
+    ttnn.synchronize_device(mesh_device)  # wait for all operations to complete
     benchmark_profiler = BenchmarkProfiler()
     num_runs = 10
     for i in range(num_runs):
         with benchmark_profiler("tt_umt5_encoder", i):
             tt_output = tt_encoder(tt_prompt, attention_mask=tt_mask)[-1]
+            tt_output = ccl_manager.all_gather(tt_output, dim=0, mesh_axis=DP_axis, use_hyperparams=True)
+            # wait for all operations to complete to get correct dispatch + execution time
+            ttnn.synchronize_device(mesh_device)
 
     # get HF reference outputs
     with torch.no_grad():
@@ -300,6 +295,9 @@ def test_umt5_encoder(
     # # convert mesh tensor to torch tensor for pcc
     # # since weights are replicated, can get the tensor from any single device
     tt_output_torch = ttnn.to_torch(ttnn.get_device_tensors(tt_output)[0])
-    tt_execution_time_b = benchmark_profiler.get_duration_average("tt_umt5_encoder")
-    logger.info(f"TT encoder execution time benchmark: {tt_execution_time_b:.4f} seconds")
-    assert_quality(hf_outputs, tt_output_torch, pcc=0.99)
+    tt_execution_time = benchmark_profiler.get_duration_average("tt_umt5_encoder")
+    logger.info(f"TT encoder execution time benchmark: {tt_execution_time:.4f} seconds")
+    assert_quality(hf_outputs[:total_prompts], tt_output_torch[:total_prompts], pcc=0.99, relative_rmse=0.06)
+    # assert (
+    #    tt_execution_time < max_execution_time
+    # ), f"TT Encoder execution time {tt_execution_time:.4f} seconds is greater than the max {max_execution_time} seconds"

--- a/models/tt_dit/tests/models/mochi/test_transformer_mochi.py
+++ b/models/tt_dit/tests/models/mochi/test_transformer_mochi.py
@@ -495,7 +495,7 @@ def test_mochi_transformer_model_caching(
         is_fsdp=True,
     )
     start = time.time()
-    tt_model.load_torch_state_dict(torch_model.state_dict(), on_host=True)
+    tt_model.load_torch_state_dict(torch_model.state_dict())
     end = time.time()
     logger.info(f"Time taken to load state dict: {end - start} seconds")
 

--- a/models/tt_dit/tests/models/sd35/test_transformer_sd35.py
+++ b/models/tt_dit/tests/models/sd35/test_transformer_sd35.py
@@ -460,7 +460,7 @@ def test_sd35_transformer_model_caching(
         padding_config=padding_config,
     )
     start = time.time()
-    tt_model.load_torch_state_dict(torch_model.state_dict(), on_host=True)
+    tt_model.load_torch_state_dict(torch_model.state_dict())
     end = time.time()
     logger.info(f"Time taken to load state dict: {end - start} seconds")
 

--- a/models/tt_dit/tests/models/wan2_2/test_performance_wan.py
+++ b/models/tt_dit/tests/models/wan2_2/test_performance_wan.py
@@ -230,6 +230,9 @@ def test_pipeline_performance(
     logger.info("Running performance measurement iterations...")
     num_perf_runs = 1  # For now use 1 prompt to minimize test time.
 
+    ttnn.synchronize_device(mesh_device)
+    ttnn.distributed_context_barrier()
+
     for i in range(num_perf_runs):
         logger.info(f"Performance run {i+1}/{num_perf_runs}...")
 

--- a/models/tt_dit/tests/models/wan2_2/test_performance_wan.py
+++ b/models/tt_dit/tests/models/wan2_2/test_performance_wan.py
@@ -119,7 +119,7 @@ def wan_pipeline_metrics_condimg(mesh_device, width, height, model_type):
         "1x8sp0tp1",
         "wh_4x8sp1tp0",
         "bh_4x8sp1tp0",
-        "bh_quad_4x32_sp1tp0",
+        "bh_4x32sp1tp0",
     ],
     indirect=["mesh_device", "device_params"],
 )

--- a/models/tt_dit/tests/models/wan2_2/test_performance_wan.py
+++ b/models/tt_dit/tests/models/wan2_2/test_performance_wan.py
@@ -102,6 +102,7 @@ def wan_pipeline_metrics_condimg(mesh_device, width, height, model_type):
         [(4, 8), (4, 8), 1, 0, 4, False, ring_params, ttnn.Topology.Ring, True],
         # BH (linear) on 4x8
         [(4, 8), (4, 8), 1, 0, 2, False, ring_params, ttnn.Topology.Ring, False],
+        [(4, 32), (4, 32), 1, 0, 2, False, ring_params, ttnn.Topology.Ring, False],
     ],
     ids=[
         "2x2sp0tp1",
@@ -109,6 +110,7 @@ def wan_pipeline_metrics_condimg(mesh_device, width, height, model_type):
         "1x8sp0tp1",
         "wh_4x8sp1tp0",
         "bh_4x8sp1tp0",
+        "bh_quad_4x32_sp1tp0",
     ],
     indirect=["mesh_device", "device_params"],
 )

--- a/models/tt_dit/tests/models/wan2_2/test_performance_wan.py
+++ b/models/tt_dit/tests/models/wan2_2/test_performance_wan.py
@@ -68,6 +68,15 @@ def t2v_metrics(mesh_device, height):
             "vae": 10.0,
             "total": 449.3,
         }
+    elif tuple(mesh_device.shape) == (4, 32):
+        assert is_blackhole(), "4x32 is only supported for blackhole"
+        assert height == 720, "4x32 is only supported for 720p"
+        expected_metrics = {
+            "encoder": 115.0,
+            "denoising": 120.0,
+            "vae": 20.0,
+            "total": 255.0,
+        }
     else:
         assert False, f"Unknown mesh device for performance comparison: {mesh_device}"
     return expected_metrics

--- a/models/tt_dit/tests/models/wan2_2/test_performance_wan.py
+++ b/models/tt_dit/tests/models/wan2_2/test_performance_wan.py
@@ -270,8 +270,11 @@ def test_pipeline_performance(
     frames = frames[0]
     try:
         if not is_ci_env:
-            export_to_video(frames, f"wan_output_video_{model_type}.mp4", fps=16)
-            print(f"✓ Saved video to: wan_output_video_{model_type}.mp4")
+            if int(ttnn.distributed_context_get_rank()) == 0:
+                export_to_video(frames, f"wan_output_video_{model_type}.mp4", fps=16)
+                print(f"✓ Saved video to: wan_output_video_{model_type}.mp4")
+            else:
+                print(f"Skipping video export on rank {ttnn.distributed_context_get_rank()}")
     except AttributeError as e:
         logger.info(f"AttributeError: {e}")
 

--- a/models/tt_dit/tests/models/wan2_2/test_performance_wan.py
+++ b/models/tt_dit/tests/models/wan2_2/test_performance_wan.py
@@ -40,16 +40,16 @@ def t2v_metrics(mesh_device, height):
         if is_blackhole():
             expected_metrics = {
                 "encoder": 0.1,
-                "denoising": 185.0,
-                "vae": 8.0,
-                "total": 208.0,
+                "denoising": 162.0,
+                "vae": 7.0,
+                "total": 168.0,
             }
         else:
             expected_metrics = {
                 "encoder": 0.1,
-                "denoising": 440.0,
-                "vae": 8.0,
-                "total": 463.0,
+                "denoising": 370.0,
+                "vae": 7.0,
+                "total": 375.0,
             }
     elif tuple(mesh_device.shape) == (2, 2):
         assert height == 480, "2x2 is only supported for 480p"

--- a/models/tt_dit/tests/models/wan2_2/test_performance_wan.py
+++ b/models/tt_dit/tests/models/wan2_2/test_performance_wan.py
@@ -249,6 +249,7 @@ def test_pipeline_performance(
                     num_inference_steps=num_inference_steps,
                     profiler=benchmark_profiler,
                     profiler_iteration=i,
+                    seed=42,
                 )
 
         logger.info(f"  Run {i+1} completed in {benchmark_profiler.get_duration('run', i):.2f}s")

--- a/models/tt_dit/tests/models/wan2_2/test_pipeline_wan.py
+++ b/models/tt_dit/tests/models/wan2_2/test_pipeline_wan.py
@@ -29,7 +29,7 @@ from ....utils.test import line_params, ring_params
         "2x4sp0tp1",
         "wh_4x8sp1tp0",
         "bh_4x8sp1tp0",
-        "bh_quad_4x32_sp1tp0",
+        "bh_4x32sp1tp0",
     ],
     indirect=["mesh_device", "device_params"],
 )

--- a/models/tt_dit/tests/models/wan2_2/test_pipeline_wan.py
+++ b/models/tt_dit/tests/models/wan2_2/test_pipeline_wan.py
@@ -113,14 +113,10 @@ def test_pipeline_inference(
     # Remove batch dimension
     frames = frames[0]
     try:
-        import os
-
-        if os.environ.get("OMPI_COMM_WORLD_RANK") is not None and os.environ.get("OMPI_COMM_WORLD_RANK") != "0":
-            print(
-                f"In an MPI environment and my rank {os.environ.get('OMPI_COMM_WORLD_RANK')} != 0, skipping video export"
-            )
-        else:
+        if int(ttnn.distributed_context_get_rank()) == 0:
             export_to_video(frames, "wan_output_video.mp4", fps=16)
             print("✓ Saved video to: wan_output_video.mp4")
+        else:
+            print(f"Skipping video export on rank {ttnn.distributed_context_get_rank()}")
     except AttributeError as e:
         print(f"AttributeError: {e}")

--- a/models/tt_dit/tests/models/wan2_2/test_pipeline_wan.py
+++ b/models/tt_dit/tests/models/wan2_2/test_pipeline_wan.py
@@ -22,12 +22,14 @@ from ....utils.test import line_params, ring_params
         [(4, 8), (4, 8), 1, 0, 4, False, ring_params, ttnn.Topology.Ring, True],
         # BH (linear) on 4x8
         [(4, 8), (4, 8), 1, 0, 2, False, line_params, ttnn.Topology.Linear, False],
+        [(4, 32), (4, 32), 1, 0, 2, False, ring_params, ttnn.Topology.Ring, False],
     ],
     ids=[
         "2x2sp0tp1",
         "2x4sp0tp1",
         "wh_4x8sp1tp0",
         "bh_4x8sp1tp0",
+        "bh_quad_4x32_sp1tp0",
     ],
     indirect=["mesh_device", "device_params"],
 )
@@ -78,6 +80,7 @@ def test_pipeline_inference(
 
     seed = 42
     # Run inference
+    seed = 42
     with torch.no_grad():
         result = pipeline(
             prompt=prompt,
@@ -110,7 +113,14 @@ def test_pipeline_inference(
     # Remove batch dimension
     frames = frames[0]
     try:
-        export_to_video(frames, "wan_output_video.mp4", fps=16)
-        print("✓ Saved video to: wan_output_video.mp4")
+        import os
+
+        if os.environ.get("OMPI_COMM_WORLD_RANK") is not None and os.environ.get("OMPI_COMM_WORLD_RANK") != "0":
+            print(
+                f"In an MPI environment and my rank {os.environ.get('OMPI_COMM_WORLD_RANK')} != 0, skipping video export"
+            )
+        else:
+            export_to_video(frames, "wan_output_video.mp4", fps=16)
+            print("✓ Saved video to: wan_output_video.mp4")
     except AttributeError as e:
         print(f"AttributeError: {e}")

--- a/models/tt_dit/tests/models/wan2_2/test_transformer_wan.py
+++ b/models/tt_dit/tests/models/wan2_2/test_transformer_wan.py
@@ -89,6 +89,7 @@ def _make_wan_transformer(*, mesh_device, ccl_manager, parallel_config, is_fsdp,
         pytest.param((4, 8), (4, 8), 1, 0, 4, ring_params, ttnn.Topology.Ring, True, id="wh_4x8sp1tp0"),
         pytest.param((4, 8), (4, 8), 1, 0, 2, ring_params, ttnn.Topology.Ring, False, id="ring_bh_4x8sp1tp0"),
         pytest.param((4, 8), (4, 8), 1, 0, 2, line_params, ttnn.Topology.Linear, False, id="line_bh_4x8sp1tp0"),
+        pytest.param((4, 32), (4, 32), 1, 0, 2, ring_params, ttnn.Topology.Ring, False, id="bh_4x32sp1tp0"),
     ],
     indirect=["mesh_device", "device_params"],
 )
@@ -113,6 +114,7 @@ def test_wan_transformer_block(
     prompt_seq_len: int,
     is_fsdp: bool,
     topology: ttnn.Topology,
+    reset_seeds,
 ) -> None:
     MIN_PCC = 0.999_500
     MAX_RMSE = 0.032

--- a/models/tt_dit/tests/models/wan2_2/test_transformer_wan.py
+++ b/models/tt_dit/tests/models/wan2_2/test_transformer_wan.py
@@ -18,7 +18,7 @@ from ....parallel.manager import CCLManager
 from ....utils.check import assert_quality
 from ....utils.mochi import get_rot_transformation_mat, stack_cos_sin
 from ....utils.padding import pad_vision_seq_parallel
-from ....utils.tensor import bf16_tensor, bf16_tensor_2dshard, from_torch
+from ....utils.tensor import bf16_tensor, bf16_tensor_2dshard, from_torch, local_device_to_torch
 from ....utils.test import line_params, ring_params
 
 # ---------------------------------------------------------------------------
@@ -391,7 +391,7 @@ def test_wan_transformer_inner_step(
         N=N,
         timestep_torch=timestep_input,
     )
-    tt_output_1BNI = tt_model.device_to_host(tt_output_1BNI_tt)
+    tt_output_1BNI = local_device_to_torch(tt_output_1BNI_tt)
     tt_output = tt_model.postprocess_spatial_output_host(tt_output_1BNI, T, H, W, N)
     del tt_model
 

--- a/models/tt_dit/tests/models/wan2_2/test_transformer_wan.py
+++ b/models/tt_dit/tests/models/wan2_2/test_transformer_wan.py
@@ -96,9 +96,9 @@ def _make_wan_transformer(*, mesh_device, ccl_manager, parallel_config, is_fsdp,
 @pytest.mark.parametrize(
     ("B", "T", "H", "W", "prompt_seq_len"),
     [
-        pytest.param(1, 31, 40, 80, 118, id="5b-720p"),
-        pytest.param(1, 21, 60, 104, 118, id="14b-480p"),
-        pytest.param(1, 21, 90, 160, 118, id="14b-720p"),
+        pytest.param(1, 31, 40, 80, 512, id="5b-720p"),
+        pytest.param(1, 21, 60, 104, 512, id="14b-480p"),
+        pytest.param(1, 21, 90, 160, 512, id="14b-720p"),
     ],
 )
 def test_wan_transformer_block(

--- a/models/tt_dit/tests/models/wan2_2/test_transformer_wan.py
+++ b/models/tt_dit/tests/models/wan2_2/test_transformer_wan.py
@@ -365,7 +365,7 @@ def test_wan_transformer_inner_step(
         num_layers=1,
     )
     start = time.time()
-    tt_model.load_torch_state_dict(torch_model.state_dict(), on_host=True)
+    tt_model.load_torch_state_dict(torch_model.state_dict())
     end = time.time()
     logger.info(f"Time taken to load state dict: {end - start} seconds")
 

--- a/models/tt_dit/tests/models/wan2_2/test_vae_wan2_1.py
+++ b/models/tt_dit/tests/models/wan2_2/test_vae_wan2_1.py
@@ -1039,12 +1039,14 @@ def test_wan_upblock(mesh_device, B, in_dim, out_dim, T, H, W, mode, num_res_blo
         ((1, 8), 0, 1, 1),
         ((1, 4), 1, 0, 1),
         ((4, 8), 0, 1, 4),
+        ((4, 32), 0, 1, 2),
     ],
     ids=[
         "2x4_h0_w1",
         "1x8_h0_w1",
         "1x4_h1_w0",
         "4x8_h0_w1",
+        "bh_quad_4x32_h0_w1",
     ],
     indirect=["mesh_device"],
 )

--- a/models/tt_dit/tests/models/wan2_2/test_vae_wan2_1.py
+++ b/models/tt_dit/tests/models/wan2_2/test_vae_wan2_1.py
@@ -29,7 +29,7 @@ from ....parallel.config import ParallelFactor, VaeHWParallelConfig
 from ....parallel.manager import CCLManager
 from ....utils.check import assert_quality
 from ....utils.conv3d import conv_pad_height, conv_pad_in_channels, conv_unpad_height, count_convs
-from ....utils.tensor import bf16_tensor_2dshard
+from ....utils.tensor import bf16_tensor_2dshard, typed_tensor_2dshard
 
 
 def setup_hooks(model):
@@ -266,10 +266,16 @@ def test_wan_rmsnorm(device, B, C, T, H, W, images, mean, std):
     ],
     indirect=["mesh_device"],
 )
+@pytest.mark.parametrize(
+    "dtype",
+    [ttnn.DataType.BFLOAT16, ttnn.DataType.FLOAT32],
+    ids=["bf16", "f32"],
+)
 @pytest.mark.parametrize("device_params", [{"fabric_config": ttnn.FabricConfig.FABRIC_1D}], indirect=True)
-def test_wan_attention(mesh_device, B, C, T, H, W, mean, std, h_axis, w_axis, reset_seeds):
+def test_wan_attention(mesh_device, B, C, T, H, W, mean, std, h_axis, w_axis, dtype, reset_seeds):
     from diffusers.models.autoencoders.autoencoder_kl_wan import WanAttentionBlock as TorchWanAttentionBlock
 
+    tt_input_dtype = ttnn.bfloat16 if dtype == ttnn.DataType.BFLOAT16 else ttnn.float32
     torch_dtype = torch.float32
     torch_model = TorchWanAttentionBlock(dim=C)
     torch_model.eval()
@@ -285,6 +291,7 @@ def test_wan_attention(mesh_device, B, C, T, H, W, mean, std, h_axis, w_axis, re
         mesh_device=mesh_device,
         parallel_config=parallel_config,
         ccl_manager=ccl_manager,
+        dtype=dtype,
     )
     tt_model.load_torch_state_dict(torch_model.state_dict())
 
@@ -294,14 +301,20 @@ def test_wan_attention(mesh_device, B, C, T, H, W, mean, std, h_axis, w_axis, re
     if logical_h != tt_input_tensor.shape[2]:
         logger.info(f"padding from {logical_h} to {tt_input_tensor.shape[2]}")
 
-    tt_input_tensor = bf16_tensor_2dshard(
-        tt_input_tensor, mesh_device, layout=ttnn.ROW_MAJOR_LAYOUT, shard_mapping={h_axis: 2, w_axis: 3}
+    tt_input_tensor = typed_tensor_2dshard(
+        tt_input_tensor,
+        mesh_device,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        shard_mapping={h_axis: 2, w_axis: 3},
+        dtype=tt_input_dtype,
     )
+    tt_input_tensor = ttnn.to_layout(tt_input_tensor, ttnn.TILE_LAYOUT)
 
     with torch.no_grad():
         torch_output = torch_model(torch_input_tensor)
     tt_output = tt_model(tt_input_tensor, logical_h=logical_h)
 
+    tt_output = ttnn.to_layout(tt_output, ttnn.ROW_MAJOR_LAYOUT)
     concat_dims = [None, None]
     concat_dims[h_axis] = 2
     concat_dims[w_axis] = 3
@@ -364,12 +377,18 @@ def test_wan_attention(mesh_device, B, C, T, H, W, mean, std, h_axis, w_axis, re
     ],
     indirect=["mesh_device"],
 )
+@pytest.mark.parametrize(
+    "dtype",
+    [ttnn.DataType.BFLOAT16, ttnn.DataType.FLOAT32],
+    ids=["bf16", "f32"],
+)
 @pytest.mark.parametrize("device_params", [{"fabric_config": ttnn.FabricConfig.FABRIC_1D}], indirect=True)
 def test_wan_conv3d(
-    mesh_device, B, C_in, C_out, T, H, W, kernel_size, stride, padding, cache_len, mean, std, h_axis, w_axis
+    mesh_device, B, C_in, C_out, T, H, W, kernel_size, stride, padding, cache_len, mean, std, h_axis, w_axis, dtype
 ):
     from diffusers.models.autoencoders.autoencoder_kl_wan import WanCausalConv3d as TorchWanCausalConv3d
 
+    tt_input_dtype = ttnn.bfloat16 if dtype == ttnn.DataType.BFLOAT16 else ttnn.float32
     torch_dtype = torch.float32
     torch_model = TorchWanCausalConv3d(
         in_channels=C_in, out_channels=C_out, kernel_size=kernel_size, stride=stride, padding=padding
@@ -390,6 +409,7 @@ def test_wan_conv3d(
         padding=padding,
         ccl_manager=ccl_manager,
         parallel_config=parallel_config,
+        dtype=dtype,
     )
     tt_model.load_torch_state_dict(torch_model.state_dict())
 
@@ -399,8 +419,12 @@ def test_wan_conv3d(
     tt_input_tensor, logical_h = conv_pad_height(tt_input_tensor, parallel_config.height_parallel.factor)
     if logical_h != tt_input_tensor.shape[2]:
         logger.info(f"padding from {logical_h} to {tt_input_tensor.shape[2]}")
-    tt_input_tensor = bf16_tensor_2dshard(
-        tt_input_tensor, mesh_device, layout=ttnn.ROW_MAJOR_LAYOUT, shard_mapping={h_axis: 2, w_axis: 3}
+    tt_input_tensor = typed_tensor_2dshard(
+        tt_input_tensor,
+        mesh_device,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        shard_mapping={h_axis: 2, w_axis: 3},
+        dtype=tt_input_dtype,
     )
     logger.info(f"torch_input_tensor.shape: {torch_input_tensor.shape}")
     logger.info(f"tt_input_tensor.shape: {tt_input_tensor.shape}")
@@ -410,8 +434,12 @@ def test_wan_conv3d(
         tt_cache_tensor = torch_cache_tensor.permute(0, 2, 3, 4, 1)
         tt_cache_tensor = conv_pad_in_channels(tt_cache_tensor)
         tt_cache_tensor, logical_h = conv_pad_height(tt_cache_tensor, parallel_config.height_parallel.factor)
-        tt_cache_tensor = bf16_tensor_2dshard(
-            tt_cache_tensor, mesh_device, layout=ttnn.ROW_MAJOR_LAYOUT, shard_mapping={h_axis: 2, w_axis: 3}
+        tt_cache_tensor = typed_tensor_2dshard(
+            tt_cache_tensor,
+            mesh_device,
+            layout=ttnn.ROW_MAJOR_LAYOUT,
+            shard_mapping={h_axis: 2, w_axis: 3},
+            dtype=tt_input_dtype,
         )
     else:
         torch_cache_tensor = tt_cache_tensor = None
@@ -484,10 +512,16 @@ def test_wan_conv3d(
     ],
     indirect=["mesh_device"],
 )
+@pytest.mark.parametrize(
+    "dtype",
+    [ttnn.DataType.BFLOAT16, ttnn.DataType.FLOAT32],
+    ids=["bf16", "f32"],
+)
 @pytest.mark.parametrize("device_params", [{"fabric_config": ttnn.FabricConfig.FABRIC_1D}], indirect=True)
-def test_wan_residual_block(mesh_device, B, in_dim, out_dim, T, H, W, cache_len, mean, std, h_axis, w_axis):
+def test_wan_residual_block(mesh_device, B, in_dim, out_dim, T, H, W, cache_len, mean, std, h_axis, w_axis, dtype):
     from diffusers.models.autoencoders.autoencoder_kl_wan import WanResidualBlock as TorchWanResidualBlock
 
+    tt_input_dtype = ttnn.bfloat16 if dtype == ttnn.DataType.BFLOAT16 else ttnn.float32
     torch_dtype = torch.float32
     torch_model = TorchWanResidualBlock(
         in_dim=in_dim,
@@ -506,6 +540,7 @@ def test_wan_residual_block(mesh_device, B, in_dim, out_dim, T, H, W, cache_len,
         mesh_device=mesh_device,
         ccl_manager=ccl_manager,
         parallel_config=parallel_config,
+        dtype=dtype,
     )
     tt_model.load_torch_state_dict(torch_model.state_dict())
 
@@ -514,9 +549,14 @@ def test_wan_residual_block(mesh_device, B, in_dim, out_dim, T, H, W, cache_len,
     tt_input_tensor, logical_h = conv_pad_height(tt_input_tensor, parallel_config.height_parallel.factor)
     if logical_h != tt_input_tensor.shape[2]:
         logger.info(f"padding from {logical_h} to {tt_input_tensor.shape[2]}")
-    tt_input_tensor = bf16_tensor_2dshard(
-        tt_input_tensor, mesh_device, layout=ttnn.ROW_MAJOR_LAYOUT, shard_mapping={h_axis: 2, w_axis: 3}
+    tt_input_tensor = typed_tensor_2dshard(
+        tt_input_tensor,
+        mesh_device,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        shard_mapping={h_axis: 2, w_axis: 3},
+        dtype=tt_input_dtype,
     )
+    tt_input_tensor = ttnn.to_layout(tt_input_tensor, ttnn.TILE_LAYOUT)
     logger.info(f"torch_input_tensor.shape: {torch_input_tensor.shape}")
     logger.info(f"tt_input_tensor.shape: {tt_input_tensor.shape}")
 
@@ -530,11 +570,19 @@ def test_wan_residual_block(mesh_device, B, in_dim, out_dim, T, H, W, cache_len,
         tt_cache_tensor_2 = torch_cache_tensor_2.permute(0, 2, 3, 4, 1)
         tt_cache_tensor_1, _ = conv_pad_height(tt_cache_tensor_1, parallel_config.height_parallel.factor)
         tt_cache_tensor_2, _ = conv_pad_height(tt_cache_tensor_2, parallel_config.height_parallel.factor)
-        tt_cache_tensor_1 = bf16_tensor_2dshard(
-            tt_cache_tensor_1, mesh_device, layout=ttnn.ROW_MAJOR_LAYOUT, shard_mapping={h_axis: 2, w_axis: 3}
+        tt_cache_tensor_1 = typed_tensor_2dshard(
+            tt_cache_tensor_1,
+            mesh_device,
+            layout=ttnn.ROW_MAJOR_LAYOUT,
+            shard_mapping={h_axis: 2, w_axis: 3},
+            dtype=tt_input_dtype,
         )
-        tt_cache_tensor_2 = bf16_tensor_2dshard(
-            tt_cache_tensor_2, mesh_device, layout=ttnn.ROW_MAJOR_LAYOUT, shard_mapping={h_axis: 2, w_axis: 3}
+        tt_cache_tensor_2 = typed_tensor_2dshard(
+            tt_cache_tensor_2,
+            mesh_device,
+            layout=ttnn.ROW_MAJOR_LAYOUT,
+            shard_mapping={h_axis: 2, w_axis: 3},
+            dtype=tt_input_dtype,
         )
         tt_feat_cache = [tt_cache_tensor_1, tt_cache_tensor_2]
         tt_feat_idx = [0]
@@ -558,6 +606,7 @@ def test_wan_residual_block(mesh_device, B, in_dim, out_dim, T, H, W, cache_len,
         feat_idx=tt_feat_idx,
     )
 
+    tt_output = ttnn.to_layout(tt_output, ttnn.ROW_MAJOR_LAYOUT)
     concat_dims = [None, None]
     concat_dims[h_axis] = 2
     concat_dims[w_axis] = 3
@@ -593,11 +642,19 @@ def test_wan_residual_block(mesh_device, B, in_dim, out_dim, T, H, W, cache_len,
     ],
 )
 @pytest.mark.parametrize("cache_len", [None, 1, 2], ids=["cache_none", "cache_1", "cache_2"])
-@pytest.mark.parametrize("mean, std", [(0, 1)])
+@pytest.mark.parametrize(
+    "mean, std, MIN_PCC, MAX_RMSE",
+    [
+        (0, 1, 0.999_900, 0.008),
+        (0, 0.1, 0.999_900, 0.014),
+    ],
+    ids=["std=1", "std=0.1"],
+)
 @pytest.mark.parametrize(
     "mesh_device, h_axis, w_axis",
     [
         ((1, 1), 0, 1),
+        ((2, 1), 0, 1),
         ((2, 4), 0, 1),
         ((2, 4), 1, 0),
         ((1, 8), 0, 1),
@@ -606,6 +663,7 @@ def test_wan_residual_block(mesh_device, B, in_dim, out_dim, T, H, W, cache_len,
     ],
     ids=[
         "1x1_h0_w1",
+        "2x1_h0_w1",
         "2x4_h0_w1",
         "2x4_h1_w0",
         "1x8_h0_w1",
@@ -614,10 +672,17 @@ def test_wan_residual_block(mesh_device, B, in_dim, out_dim, T, H, W, cache_len,
     ],
     indirect=["mesh_device"],
 )
+@pytest.mark.parametrize(
+    "dtype",
+    [ttnn.DataType.BFLOAT16, ttnn.DataType.FLOAT32],
+    ids=["bf16", "f32"],
+)
 @pytest.mark.parametrize("device_params", [{"fabric_config": ttnn.FabricConfig.FABRIC_1D}], indirect=True)
-def test_wan_mid_block(mesh_device, B, dim, T, H, W, cache_len, mean, std, h_axis, w_axis):
+def test_wan_mid_block(mesh_device, B, dim, T, H, W, cache_len, mean, std, h_axis, w_axis, dtype, MIN_PCC, MAX_RMSE):
     from diffusers.models.autoencoders.autoencoder_kl_wan import WanMidBlock as TorchWanMidBlock
 
+    torch.manual_seed(0)
+    tt_input_dtype = ttnn.bfloat16 if dtype == ttnn.DataType.BFLOAT16 else ttnn.float32
     torch_dtype = torch.float32
     torch_model = TorchWanMidBlock(
         dim=dim,
@@ -634,6 +699,7 @@ def test_wan_mid_block(mesh_device, B, dim, T, H, W, cache_len, mean, std, h_axi
         mesh_device=mesh_device,
         ccl_manager=ccl_manager,
         parallel_config=parallel_config,
+        dtype=dtype,
     )
     tt_model.load_torch_state_dict(torch_model.state_dict())
 
@@ -644,23 +710,33 @@ def test_wan_mid_block(mesh_device, B, dim, T, H, W, cache_len, mean, std, h_axi
     tt_input_tensor, logical_h = conv_pad_height(tt_input_tensor, parallel_config.height_parallel.factor)
     if logical_h != tt_input_tensor.shape[2]:
         logger.info(f"padding from {logical_h} to {tt_input_tensor.shape[2]}")
-    tt_input_tensor = bf16_tensor_2dshard(
-        tt_input_tensor, mesh_device, layout=ttnn.ROW_MAJOR_LAYOUT, shard_mapping={h_axis: 2, w_axis: 3}
+    tt_input_tensor = typed_tensor_2dshard(
+        tt_input_tensor,
+        mesh_device,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        shard_mapping={h_axis: 2, w_axis: 3},
+        dtype=tt_input_dtype,
     )
+    tt_input_tensor = ttnn.to_layout(tt_input_tensor, ttnn.TILE_LAYOUT)
 
     torch_feat_cache = []
     tt_feat_cache = []
     torch_feat_idx = [0]
     tt_feat_idx = [0]
     for i in range(num_convs):
+        torch.manual_seed(0)
         if cache_len is not None:
             torch_cache_tensor = torch.randn(B, dim, cache_len, H, W, dtype=torch_dtype) * std + mean
             torch_feat_cache.append(torch_cache_tensor)
 
             tt_cache_tensor = torch_cache_tensor.permute(0, 2, 3, 4, 1)
             tt_cache_tensor, _ = conv_pad_height(tt_cache_tensor, parallel_config.height_parallel.factor)
-            tt_cache_tensor = bf16_tensor_2dshard(
-                tt_cache_tensor, mesh_device, layout=ttnn.ROW_MAJOR_LAYOUT, shard_mapping={h_axis: 2, w_axis: 3}
+            tt_cache_tensor = typed_tensor_2dshard(
+                tt_cache_tensor,
+                mesh_device,
+                layout=ttnn.ROW_MAJOR_LAYOUT,
+                shard_mapping={h_axis: 2, w_axis: 3},
+                dtype=tt_input_dtype,
             )
             tt_feat_cache.append(tt_cache_tensor)
 
@@ -682,6 +758,7 @@ def test_wan_mid_block(mesh_device, B, dim, T, H, W, cache_len, mean, std, h_axi
         feat_idx=tt_feat_idx,
     )
 
+    tt_output = ttnn.to_layout(tt_output, ttnn.ROW_MAJOR_LAYOUT)
     concat_dims = [None, None]
     concat_dims[h_axis] = 2
     concat_dims[w_axis] = 3
@@ -693,7 +770,7 @@ def test_wan_mid_block(mesh_device, B, dim, T, H, W, cache_len, mean, std, h_axi
     tt_output_torch = tt_output_torch.permute(0, 4, 1, 2, 3)
 
     logger.info(f"checking output")
-    assert_quality(torch_output, tt_output_torch, pcc=0.999_900, relative_rmse=0.008)
+    assert_quality(torch_output, tt_output_torch, pcc=MIN_PCC, relative_rmse=MAX_RMSE)
 
     for i in range(len(tt_feat_cache)):
         tt_feat_cache[i] = ttnn.to_torch(
@@ -793,7 +870,7 @@ def test_wan_resample(mesh_device, B, dim, T, H, W, mode, resample_out_dim, cach
     )
     if logical_h != tt_input_tensor.shape[2]:
         logger.info(f"padding from {logical_h} to {tt_input_tensor.shape[2]}")
-    tt_input_tensor = bf16_tensor_2dshard(
+    tt_input_tensor = typed_tensor_2dshard(
         tt_input_tensor, mesh_device, layout=ttnn.ROW_MAJOR_LAYOUT, shard_mapping={h_axis: 2, w_axis: 3}
     )
 
@@ -898,10 +975,17 @@ def test_wan_resample(mesh_device, B, dim, T, H, W, mode, resample_out_dim, cach
     ],
     indirect=["mesh_device"],
 )
+@pytest.mark.parametrize(
+    "dtype",
+    [ttnn.DataType.BFLOAT16, ttnn.DataType.FLOAT32],
+    ids=["bf16", "f32"],
+)
 @pytest.mark.parametrize("device_params", [{"fabric_config": ttnn.FabricConfig.FABRIC_1D}], indirect=True)
-def test_wan_upblock(mesh_device, B, in_dim, out_dim, T, H, W, mode, num_res_blocks, mean, std, h_axis, w_axis):
+def test_wan_upblock(mesh_device, B, in_dim, out_dim, T, H, W, mode, num_res_blocks, mean, std, h_axis, w_axis, dtype):
     from diffusers.models.autoencoders.autoencoder_kl_wan import WanUpBlock as TorchWanUpBlock
 
+    torch.manual_seed(0)
+    tt_input_dtype = ttnn.bfloat16 if dtype == ttnn.DataType.BFLOAT16 else ttnn.float32
     torch_dtype = torch.float32
     torch_model = TorchWanUpBlock(
         in_dim=in_dim,
@@ -924,6 +1008,7 @@ def test_wan_upblock(mesh_device, B, in_dim, out_dim, T, H, W, mode, num_res_blo
         mesh_device=mesh_device,
         ccl_manager=ccl_manager,
         parallel_config=parallel_config,
+        dtype=dtype,
     )
     tt_model.load_torch_state_dict(torch_model.state_dict())
 
@@ -943,9 +1028,14 @@ def test_wan_upblock(mesh_device, B, in_dim, out_dim, T, H, W, mode, num_res_blo
         tt_input_tensor, logical_h = conv_pad_height(tt_input_tensor, parallel_config.height_parallel.factor)
         if logical_h != tt_input_tensor.shape[2]:
             logger.info(f"padding from {logical_h} to {tt_input_tensor.shape[2]}")
-        tt_input_tensor = bf16_tensor_2dshard(
-            tt_input_tensor, mesh_device, layout=ttnn.ROW_MAJOR_LAYOUT, shard_mapping={h_axis: 2, w_axis: 3}
+        tt_input_tensor = typed_tensor_2dshard(
+            tt_input_tensor,
+            mesh_device,
+            layout=ttnn.ROW_MAJOR_LAYOUT,
+            shard_mapping={h_axis: 2, w_axis: 3},
+            dtype=tt_input_dtype,
         )
+        tt_input_tensor = ttnn.to_layout(tt_input_tensor, ttnn.TILE_LAYOUT)
 
         logger.info(f"running torch model")
         with torch.no_grad():
@@ -963,6 +1053,7 @@ def test_wan_upblock(mesh_device, B, in_dim, out_dim, T, H, W, mode, num_res_blo
             feat_idx=tt_feat_idx,
         )
 
+        tt_output = ttnn.to_layout(tt_output, ttnn.ROW_MAJOR_LAYOUT)
         concat_dims = [None, None]
         concat_dims[h_axis] = 2
         concat_dims[w_axis] = 3
@@ -1011,11 +1102,12 @@ def test_wan_upblock(mesh_device, B, in_dim, out_dim, T, H, W, mode, num_res_blo
             if isinstance(tt_feat_cache[i], str) and tt_feat_cache[i] == "Rep":
                 tt_feat_cache[i] = tt_feat_cache_host[i]
             else:
-                tt_feat_cache[i] = bf16_tensor_2dshard(
+                tt_feat_cache[i] = typed_tensor_2dshard(
                     tt_feat_cache_host[i],
                     mesh_device,
                     layout=ttnn.ROW_MAJOR_LAYOUT,
                     shard_mapping={h_axis: 2, w_axis: 3},
+                    dtype=tt_input_dtype,
                 )
 
 
@@ -1033,9 +1125,18 @@ def test_wan_upblock(mesh_device, B, in_dim, out_dim, T, H, W, mode, num_res_blo
 @pytest.mark.parametrize("mean, std", [(0, 1)])
 @pytest.mark.parametrize("check_cache", [True])
 @pytest.mark.parametrize(
+    "dtype, MIN_PCC, MAX_RMSE",
+    [
+        (ttnn.DataType.FLOAT32, 0.999_905, 0.014),
+        (ttnn.DataType.BFLOAT16, 0.999_410, 0.035),
+    ],
+    ids=["f32", "bf16"],
+)
+@pytest.mark.parametrize(
     "mesh_device, h_axis, w_axis, num_links",
     [
         ((2, 4), 0, 1, 1),
+        ((2, 4), 1, 0, 1),
         ((1, 8), 0, 1, 1),
         ((1, 4), 1, 0, 1),
         ((4, 8), 0, 1, 4),
@@ -1043,6 +1144,7 @@ def test_wan_upblock(mesh_device, B, in_dim, out_dim, T, H, W, mode, num_res_blo
     ],
     ids=[
         "2x4_h0_w1",
+        "2x4_h1_w0",
         "1x8_h0_w1",
         "1x4_h1_w0",
         "4x8_h0_w1",
@@ -1051,10 +1153,14 @@ def test_wan_upblock(mesh_device, B, in_dim, out_dim, T, H, W, mode, num_res_blo
     indirect=["mesh_device"],
 )
 @pytest.mark.parametrize("device_params", [{"fabric_config": ttnn.FabricConfig.FABRIC_1D}], indirect=True)
-def test_wan_decoder3d(mesh_device, B, C, T, H, W, mean, std, h_axis, w_axis, num_links, check_cache):
+def test_wan_decoder3d(
+    mesh_device, B, C, T, H, W, mean, std, h_axis, w_axis, num_links, check_cache, dtype, MIN_PCC, MAX_RMSE
+):
     from diffusers.models.autoencoders.autoencoder_kl_wan import WanDecoder3d as TorchWanDecoder3d
 
-    # mesh_device.disable_and_clear_program_cache()
+    torch.manual_seed(0)
+    tt_input_dtype = ttnn.bfloat16 if dtype == ttnn.DataType.BFLOAT16 else ttnn.float32
+
     torch_dtype = torch.float32
     base_dim = 96
     z_dim = 16
@@ -1066,9 +1172,6 @@ def test_wan_decoder3d(mesh_device, B, C, T, H, W, mean, std, h_axis, w_axis, nu
     dropout = 0.0
     out_channels = 3
     is_residual = False
-
-    MIN_PCC = 0.99 if tuple(mesh_device.shape)[h_axis] == 4 else 0.997
-    MAX_RMSE = 0.12 if tuple(mesh_device.shape)[h_axis] == 4 else 0.08
 
     torch_model = TorchWanDecoder3d(
         dim=base_dim,
@@ -1101,6 +1204,7 @@ def test_wan_decoder3d(mesh_device, B, C, T, H, W, mean, std, h_axis, w_axis, nu
         mesh_device=mesh_device,
         ccl_manager=ccl_manager,
         parallel_config=parallel_config,
+        dtype=dtype,
     )
     tt_model.load_torch_state_dict(torch_model.state_dict())
 
@@ -1111,6 +1215,8 @@ def test_wan_decoder3d(mesh_device, B, C, T, H, W, mean, std, h_axis, w_axis, nu
 
     # Run 4 times to get models to create their own caches
     for i in range(3):
+        torch.manual_seed(0)
+
         torch_feat_idx = [0]
         tt_feat_idx = [0]
         logger.info(f"running test iteration {i}")
@@ -1119,8 +1225,12 @@ def test_wan_decoder3d(mesh_device, B, C, T, H, W, mean, std, h_axis, w_axis, nu
         tt_input_tensor = torch_input_tensor.permute(0, 2, 3, 4, 1)
         tt_input_tensor = conv_pad_in_channels(tt_input_tensor)
         tt_input_tensor, logical_h = conv_pad_height(tt_input_tensor, parallel_config.height_parallel.factor)
-        tt_input_tensor = bf16_tensor_2dshard(
-            tt_input_tensor, mesh_device, layout=ttnn.ROW_MAJOR_LAYOUT, shard_mapping={h_axis: 2, w_axis: 3}
+        tt_input_tensor = typed_tensor_2dshard(
+            tt_input_tensor,
+            mesh_device,
+            layout=ttnn.ROW_MAJOR_LAYOUT,
+            shard_mapping={h_axis: 2, w_axis: 3},
+            dtype=tt_input_dtype,
         )
 
         logger.info(f"running torch model")
@@ -1208,11 +1318,12 @@ def test_wan_decoder3d(mesh_device, B, C, T, H, W, mean, std, h_axis, w_axis, nu
             if isinstance(tt_feat_cache[j], str) and tt_feat_cache[j] == "Rep":
                 tt_feat_cache[j] = tt_feat_cache_host[j]
             else:
-                tt_feat_cache[j] = bf16_tensor_2dshard(
+                tt_feat_cache[j] = typed_tensor_2dshard(
                     tt_feat_cache_host[j],
                     mesh_device,
                     layout=ttnn.ROW_MAJOR_LAYOUT,
                     shard_mapping={h_axis: 2, w_axis: 3},
+                    dtype=tt_input_dtype,
                 )
 
 
@@ -1232,6 +1343,14 @@ def test_wan_decoder3d(mesh_device, B, C, T, H, W, mean, std, h_axis, w_axis, nu
 @pytest.mark.parametrize("mean, std", [(0, 1)])
 @pytest.mark.parametrize("real_weights", [True, False], ids=["real_weights", "fake_weights"])
 @pytest.mark.parametrize("skip_check", [True, False], ids=["skip_check", "check_output"])
+@pytest.mark.parametrize(
+    "dtype, MIN_PCC, MAX_RMSE",
+    [
+        (ttnn.DataType.FLOAT32, 0.999_945, 0.012),
+        (ttnn.DataType.BFLOAT16, 0.999_000, 0.046),
+    ],
+    ids=["f32", "bf16"],
+)
 @pytest.mark.parametrize(
     "mesh_device, h_axis, w_axis, num_links",
     [
@@ -1257,8 +1376,13 @@ def test_wan_decoder3d(mesh_device, B, C, T, H, W, mean, std, h_axis, w_axis, nu
     indirect=["mesh_device"],
 )
 @pytest.mark.parametrize("device_params", [{"fabric_config": ttnn.FabricConfig.FABRIC_1D}], indirect=True)
-def test_wan_decoder(mesh_device, B, C, T, H, W, mean, std, h_axis, w_axis, num_links, real_weights, skip_check):
+def test_wan_decoder(
+    mesh_device, B, C, T, H, W, mean, std, h_axis, w_axis, num_links, real_weights, skip_check, dtype, MIN_PCC, MAX_RMSE
+):
     from diffusers.models.autoencoders.autoencoder_kl_wan import AutoencoderKLWan as TorchAutoencoderKLWan
+
+    torch.manual_seed(0)
+    tt_input_dtype = ttnn.bfloat16 if dtype == ttnn.DataType.BFLOAT16 else ttnn.float32
 
     torch_dtype = torch.float32
     base_dim = 96
@@ -1304,6 +1428,7 @@ def test_wan_decoder(mesh_device, B, C, T, H, W, mean, std, h_axis, w_axis, num_
         mesh_device=mesh_device,
         ccl_manager=ccl_manager,
         parallel_config=parallel_config,
+        dtype=dtype,
     )
     tt_model.load_torch_state_dict(torch_model.state_dict())
 
@@ -1313,8 +1438,12 @@ def test_wan_decoder(mesh_device, B, C, T, H, W, mean, std, h_axis, w_axis, num_
     tt_input_tensor, logical_h = conv_pad_height(tt_input_tensor, parallel_config.height_parallel.factor)
     if logical_h != tt_input_tensor.shape[2]:
         logger.info(f"padding from {logical_h} to {tt_input_tensor.shape[2]}")
-    tt_input_tensor = bf16_tensor_2dshard(
-        tt_input_tensor, mesh_device, layout=ttnn.ROW_MAJOR_LAYOUT, shard_mapping={h_axis: 2, w_axis: 3}
+    tt_input_tensor = typed_tensor_2dshard(
+        tt_input_tensor,
+        mesh_device,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        shard_mapping={h_axis: 2, w_axis: 3},
+        dtype=tt_input_dtype,
     )
 
     logger.info(f"running tt model")
@@ -1352,7 +1481,7 @@ def test_wan_decoder(mesh_device, B, C, T, H, W, mean, std, h_axis, w_axis, num_
         if new_logical_h != tt_output_torch.shape[3]:
             tt_output_torch = tt_output_torch[:, :, :, :new_logical_h, :]
             logger.warning(f"Trimmed tt_output_torch to {tt_output_torch.shape}")
-        assert_quality(torch_output, tt_output_torch, pcc=0.998_000, relative_rmse=0.08)
+        assert_quality(torch_output, tt_output_torch, pcc=MIN_PCC, relative_rmse=MAX_RMSE)
     else:
         logger.warning("Skipping check")
 
@@ -1390,7 +1519,6 @@ def test_wan_decoder(mesh_device, B, C, T, H, W, mean, std, h_axis, w_axis, num_
 def test_wan_encoder3d(mesh_device, B, C, T, H, W, mean, std, h_axis, w_axis, num_links, check_cache):
     from diffusers.models.autoencoders.autoencoder_kl_wan import WanEncoder3d as TorchWanEncoder3D
 
-    # mesh_device.disable_and_clear_program_cache()
     in_channels = C
     torch_dtype = torch.float32
     base_dim = 96
@@ -1435,8 +1563,9 @@ def test_wan_encoder3d(mesh_device, B, C, T, H, W, mean, std, h_axis, w_axis, nu
         mesh_device=mesh_device,
         ccl_manager=ccl_manager,
         parallel_config=parallel_config,
+        dtype=ttnn.bfloat16,
     )
-    tt_model.load_state_dict(torch_model.state_dict())
+    tt_model.load_torch_state_dict(torch_model.state_dict())
 
     num_convs = count_convs(tt_model)
 
@@ -1641,8 +1770,9 @@ def test_wan_encoder(mesh_device, B, C, T, H, W, mean, std, h_axis, w_axis, num_
         mesh_device=mesh_device,
         ccl_manager=ccl_manager,
         parallel_config=parallel_config,
+        dtype=ttnn.bfloat16,
     )
-    tt_model.load_state_dict(torch_model.state_dict())
+    tt_model.load_torch_state_dict(torch_model.state_dict())
 
     torch_input_tensor = torch.randn(B, C, T, H, W, dtype=torch_dtype) * std + mean
     tt_input_tensor = torch_input_tensor.permute(0, 2, 3, 4, 1)

--- a/models/tt_dit/tests/unit/test_embeddings.py
+++ b/models/tt_dit/tests/unit/test_embeddings.py
@@ -704,23 +704,29 @@ def test_wan_patch_embed(
 
 
 @pytest.mark.parametrize(
-    "mesh_device, device_params",
-    [[(4, 8), {"fabric_config": ttnn.FabricConfig.FABRIC_1D_RING}]],
-    indirect=["mesh_device", "device_params"],
-)
-@pytest.mark.parametrize(
     ("B, seq_len, embed_dim"),
     [
         (1, 512, 4096),  # Wan2.2
     ],
+)
+@pytest.mark.parametrize(
+    "mesh_device, num_links",
+    [[(2, 4), 1], [(4, 8), 4], [(4, 8), 2]],
+    ids=["t3k", "wh_glx", "bh_glx"],
+    indirect=["mesh_device"],
+)
+@pytest.mark.parametrize(
+    "device_params",
+    [{"fabric_config": ttnn.FabricConfig.FABRIC_1D}],
+    indirect=True,
 )
 def test_wan_time_text_image_embedding(
     mesh_device: ttnn.MeshDevice,
     B: int,
     seq_len: int,
     embed_dim: int,
+    num_links: int,
 ) -> None:
-    # mesh_device = mesh_device.create_submesh(ttnn.MeshShape(2, 1))
     torch_dtype = torch.float32
     torch.manual_seed(12334)
     # Create Torch model
@@ -739,8 +745,8 @@ def test_wan_time_text_image_embedding(
     mesh_axis = 1
     ccl_manager = CCLManager(
         mesh_device=mesh_device,
-        num_links=4,
-        topology=ttnn.Topology.Ring,
+        num_links=num_links,
+        topology=ttnn.Topology.Linear,
     )
 
     # Create TT model
@@ -797,13 +803,12 @@ def test_wan_time_text_image_embedding(
     )
 
     assert_quality(temb_torch, tt_temb_torch, pcc=0.9999, relative_rmse=0.005)  # expected RMSE =0.3%
-    assert_quality(
-        encoder_hidden_states_torch,
-        tt_encoder_hidden_states_torch,
-        pcc=0.9999,
-        relative_rmse=0.01,  # expected RMSE =0.8%
-    )  # Investigate slightly lower PCC and higher RMSE when compared to using Wantransformer.context_embedder
     assert_quality(timestep_proj_torch, tt_timestep_proj_torch, pcc=0.9999, relative_rmse=0.005)  # expected RMSE =0.4%
+
+    # Investigate slightly lower PCC and higher RMSE when compared to using Wantransformer.context_embedder
+    assert_quality(
+        encoder_hidden_states_torch, tt_encoder_hidden_states_torch, pcc=0.9999, relative_rmse=0.01
+    )  # expected RMSE =0.8%
 
 
 @pytest.mark.parametrize("mesh_device", [(1, 1), (1, 2)], indirect=["mesh_device"])

--- a/models/tt_dit/utils/cache.py
+++ b/models/tt_dit/utils/cache.py
@@ -110,14 +110,11 @@ def load_model(
         raise MissingCacheError(cache_dir)
 
     logger.info("Cache does not exist. Loading PyTorch state dict.")
-    # Create host tensors when creating the cache to circumvent the issue that replicated device
-    # tensors lead to redundant copies when saved to disk.
-    tt_model.load_torch_state_dict(get_torch_state_dict(), on_host=create_cache)
+    tt_model.load_torch_state_dict(get_torch_state_dict())
 
     if create_cache:
         logger.info(f"Writing cache to '{cache_dir}'.")
         tt_model.save(cache_dir)
-        tt_model.load(cache_dir)  # move to device
 
 
 def model_cache_dir(

--- a/models/tt_dit/utils/cache.py
+++ b/models/tt_dit/utils/cache.py
@@ -112,6 +112,10 @@ def load_model(
     logger.info("Cache does not exist. Loading PyTorch state dict.")
     tt_model.load_torch_state_dict(get_torch_state_dict())
 
+    # If distributed, ensure that all processes have completed the check whether cache_dir exists,
+    # before any rank might proceed to create that dir to save.
+    ttnn.distributed_context_barrier()
+
     if create_cache:
         logger.info(f"Writing cache to '{cache_dir}'.")
         tt_model.save(cache_dir)

--- a/models/tt_dit/utils/cache.py
+++ b/models/tt_dit/utils/cache.py
@@ -10,6 +10,8 @@ from typing import TYPE_CHECKING, NamedTuple
 
 from loguru import logger
 
+import ttnn
+
 from ..layers.module import Module
 
 if TYPE_CHECKING:
@@ -99,11 +101,13 @@ def load_model(
             "To use caching, set the TT_DIT_CACHE_DIR environment variable."
         )
         tt_model.load_torch_state_dict(get_torch_state_dict())
+        ttnn.distributed_context_barrier()
         return
 
     if Path(cache_dir).is_dir():
         logger.info(f"loading cache at '{cache_dir}'.")
         tt_model.load(cache_dir)
+        ttnn.distributed_context_barrier()
         return
 
     if get_torch_state_dict is None:

--- a/models/tt_dit/utils/conv3d.py
+++ b/models/tt_dit/utils/conv3d.py
@@ -22,20 +22,24 @@ def _ntuple(x, n):
     return tuple(repeat(x, n))
 
 
-def get_conv3d_config(in_channels, out_channels, kernel_size, grid_size):
-    config_to_blocking = {
-        # (in_channels, out_channels, kernel_size) -> (C_in_block, C_out_block, T_out_block, H_out_block, W_out_block)
-        (96, 32, (3, 3, 3)): (96, 32, 1, 32, 2),
-        (192, 96, (1, 3, 3)): (192, 96, 1, 4, 4),
-        (96, 96, (3, 3, 3)): (96, 96, 1, 32, 2),
-        (384, 192, (1, 3, 3)): (192, 96, 1, 16, 1),
-        (192, 192, (3, 3, 3)): (96, 96, 1, 64, 1),
-        (32, 384, (3, 3, 3)): (32, 384, 1, 8, 8),
-        # (16, 384, (3, 3, 3)): (16, 32, 1, 1, 1),
-        (192, 384, (3, 3, 3)): (96, 128, 1, 32, 1),
-        (384, 384, (3, 3, 3)): (128, 128, 1, 16, 2),
-        (384, 768, (3, 3, 3)): (128, 128, 1, 16, 2),
-    }
+def get_conv3d_config(in_channels, out_channels, kernel_size, weights_dtype, grid_size):
+    if weights_dtype == ttnn.float32:
+        # Use smaller block size to reduce memory use.
+        config_to_blocking = {(in_channels, out_channels, kernel_size): (32, 32, 1, 1, 1)}
+    else:
+        config_to_blocking = {
+            # (in_channels, out_channels, kernel_size) -> (C_in_block, C_out_block, T_out_block, H_out_block, W_out_block)
+            (96, 32, (3, 3, 3)): (96, 32, 1, 32, 2),
+            (192, 96, (1, 3, 3)): (192, 96, 1, 4, 4),
+            (96, 96, (3, 3, 3)): (96, 96, 1, 32, 2),
+            (384, 192, (1, 3, 3)): (192, 96, 1, 16, 1),
+            (192, 192, (3, 3, 3)): (96, 96, 1, 64, 1),
+            (32, 384, (3, 3, 3)): (32, 384, 1, 8, 8),
+            # (16, 384, (3, 3, 3)): (16, 32, 1, 1, 1),
+            (192, 384, (3, 3, 3)): (96, 128, 1, 32, 1),
+            (384, 384, (3, 3, 3)): (128, 128, 1, 8, 2),
+            (384, 768, (3, 3, 3)): (128, 128, 1, 16, 2),
+        }
 
     blocking = config_to_blocking.get((in_channels, out_channels, kernel_size), None)
     if blocking is None:
@@ -46,7 +50,7 @@ def get_conv3d_config(in_channels, out_channels, kernel_size, grid_size):
     else:
         C_in_block, C_out_block, T_out_block, H_out_block, W_out_block = blocking
     return ttnn.Conv3dConfig(
-        weights_dtype=ttnn.bfloat16,
+        weights_dtype=weights_dtype,
         output_layout=ttnn.ROW_MAJOR_LAYOUT,
         T_out_block=T_out_block,
         W_out_block=W_out_block,

--- a/models/tt_dit/utils/matmul.py
+++ b/models/tt_dit/utils/matmul.py
@@ -103,6 +103,21 @@ grid_12_10_configs = {
 }
 
 
+_BH_GALAXY_MIN_DEVICES = 32
+_BH_GALAXY_MAX_CORE_GRID = (11, 10)
+
+
+def get_matmul_core_grid(mesh_device):
+    """Return the compute core grid, clamped to 11x10 on Blackhole Galaxy (power constraint)."""
+    core_grid = mesh_device.compute_with_storage_grid_size()
+    if mesh_device.get_num_devices() >= _BH_GALAXY_MIN_DEVICES:
+        core_grid = ttnn.CoreCoord(
+            min(core_grid.x, _BH_GALAXY_MAX_CORE_GRID[0]),
+            min(core_grid.y, _BH_GALAXY_MAX_CORE_GRID[1]),
+        )
+    return core_grid
+
+
 def get_matmul_config(M, K, N, core_grid):
     # Default to 8x8x8 with subblock 2x2 when unknown
     subblock_h = 2

--- a/models/tt_dit/utils/matmul.py
+++ b/models/tt_dit/utils/matmul.py
@@ -130,7 +130,7 @@ def get_matmul_core_grid(mesh_device):
     return core_grid
 
 
-def get_matmul_config(M, K, N, core_grid):
+def get_matmul_config(M, K, N, core_grid, default_block_size=None):
     # Default to 8x8x8 with subblock 2x2 when unknown
     subblock_h = 2
     subblock_w = 2
@@ -162,7 +162,7 @@ def get_matmul_config(M, K, N, core_grid):
             config_tuple = config_tuple[:3]
 
     if config_tuple is None:
-        M_block_size, K_block_size, N_block_size = 8, 8, 8
+        M_block_size, K_block_size, N_block_size = default_block_size if default_block_size is not None else (8, 8, 8)
 
         M_tiles = math.ceil(M / 32)
         N_tiles = math.ceil(N / 32)

--- a/models/tt_dit/utils/matmul.py
+++ b/models/tt_dit/utils/matmul.py
@@ -102,6 +102,18 @@ grid_12_10_configs = {
     (9472, 3456, 5120): (8, 4, 8, (1, 2)),
 }
 
+grid_11_10_configs = {
+    (512, 5120, 2560): (2, 5, 8, (1, 4)),
+    (2368, 5120, 3840): (4, 8, 12, (1, 4)),
+    (2368, 5120, 1280): (8, 4, 4, (1, 4)),
+    (2368, 5120, 3456): (8, 2, 12, (2, 2)),
+    (2368, 3456, 5120): (4, 4, 8, (1, 4)),
+    (9472, 5120, 3840): (16, 4, 4, (1, 4)),
+    (9472, 5120, 1280): (16, 8, 4, (1, 4)),
+    (9472, 5120, 3456): (16, 8, 4, (1, 4)),
+    (9472, 3456, 5120): (16, 3, 4, (1, 4)),
+}
+
 
 _BH_GALAXY_MIN_DEVICES = 32
 _BH_GALAXY_MAX_CORE_GRID = (11, 10)
@@ -140,6 +152,11 @@ def get_matmul_config(M, K, N, core_grid):
             config_tuple = config_tuple[:3]
     elif getattr(core_grid, "x", None) == 12 and getattr(core_grid, "y", None) == 10:
         config_tuple = grid_12_10_configs.get((M, K, N))
+        if config_tuple is not None:
+            subblock_h, subblock_w = config_tuple[3]
+            config_tuple = config_tuple[:3]
+    elif getattr(core_grid, "x", None) == 11 and getattr(core_grid, "y", None) == 10:
+        config_tuple = grid_11_10_configs.get((M, K, N))
         if config_tuple is not None:
             subblock_h, subblock_w = config_tuple[3]
             config_tuple = config_tuple[:3]

--- a/models/tt_dit/utils/tensor.py
+++ b/models/tt_dit/utils/tensor.py
@@ -74,8 +74,8 @@ def bf16_tensor_host(
     )
 
 
-def bf16_tensor_2dshard(
-    x: torch.Tensor, device: ttnn.Device, shard_mapping: dict[int, int], layout=ttnn.TILE_LAYOUT
+def typed_tensor_2dshard(
+    x: torch.Tensor, device: ttnn.Device, shard_mapping: dict[int, int], layout=ttnn.TILE_LAYOUT, dtype=ttnn.bfloat16
 ) -> ttnn.Tensor:
     assert len(shard_mapping) == 2
     assert all(0 <= k <= 1 and 0 <= v < len(x.shape) for k, v in shard_mapping.items())
@@ -86,11 +86,20 @@ def bf16_tensor_2dshard(
     return ttnn.from_torch(
         x,
         layout=layout,
-        dtype=ttnn.bfloat16,
+        dtype=dtype,
         memory_config=ttnn.DRAM_MEMORY_CONFIG,
         device=device,
         mesh_mapper=mesh_mapper,
     )
+
+
+def bf16_tensor_2dshard(
+    x: torch.Tensor,
+    device: ttnn.Device,
+    shard_mapping: dict[int, int],
+    layout=ttnn.TILE_LAYOUT,
+) -> ttnn.Tensor:
+    return typed_tensor_2dshard(x, device, shard_mapping, layout, dtype=ttnn.bfloat16)
 
 
 def from_torch(

--- a/models/tt_dit/utils/tensor.py
+++ b/models/tt_dit/utils/tensor.py
@@ -215,6 +215,27 @@ def _invert_placements(placements: Sequence[int | None], *, output_rank: int) ->
     return tuple(out)
 
 
+def local_device_to_torch(tt_tensor: ttnn.Tensor) -> torch.Tensor:
+    """Convert a ttnn device tensor to a torch tensor by reading from the local device.
+
+    In a distributed environment, iterates over the mesh coordinates to find the
+    tensor shard that belongs to the local device before calling ``ttnn.to_torch``.
+    """
+    mesh_device = tt_tensor.device()
+    view = mesh_device.get_view() if ttnn.using_distributed_env() else None
+    coords = list(tt_tensor.tensor_topology().mesh_coords())
+    device_tensors = ttnn.get_device_tensors(tt_tensor)
+
+    torch_tensor = None
+    for coord, device_tensor in zip(coords, device_tensors):
+        if view is None or view.is_local(coord):
+            torch_tensor = ttnn.to_torch(device_tensor)
+            break
+
+    assert torch_tensor is not None, "Failed to find local device tensor"
+    return torch_tensor
+
+
 def upsample(
     x: ttnn.Tensor,
     /,

--- a/tests/nightly/t3000/ccl/test_neighbor_pad_async.py
+++ b/tests/nightly/t3000/ccl/test_neighbor_pad_async.py
@@ -5,16 +5,54 @@
 import torch
 import pytest
 import math
-import os
 from loguru import logger
 import ttnn
 from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import comp_equal, comp_pcc
-from models.common.utility_functions import skip_for_blackhole
 
 from ttnn import ShardTensor2dMesh, ConcatMesh2dToTensor
 
 
-def run_neighbor_pad_impl(
+def pad_chunks_along_dim(chunks, dim, padding_left, padding_right, padding_mode="zeros"):
+    """
+    Pad each chunk with neighbor data along *dim*.  At boundaries, use zeros
+    or replicate the edge value depending on *padding_mode*.
+
+    Returns a list of padded chunks (same length as *chunks*).
+    """
+    n = len(chunks)
+    padded = []
+    for i in range(n):
+        chunk = chunks[i]
+        # Left padding
+        left_parts = []
+        for p in range(padding_left):
+            if i == 0:
+                if padding_mode == "zeros":
+                    left_parts.append(torch.zeros_like(torch.narrow(chunk, dim, 0, 1)))
+                else:
+                    left_parts.append(torch.narrow(chunk, dim, 0, 1))
+            else:
+                left_parts.append(torch.narrow(chunks[i - 1], dim, chunks[i - 1].shape[dim] - padding_left + p, 1))
+        # Right padding
+        right_parts = []
+        for p in range(padding_right):
+            if i == n - 1:
+                if padding_mode == "zeros":
+                    right_parts.append(torch.zeros_like(torch.narrow(chunk, dim, 0, 1)))
+                else:
+                    right_parts.append(torch.narrow(chunk, dim, chunk.shape[dim] - 1, 1))
+            else:
+                right_parts.append(torch.narrow(chunks[i + 1], dim, p, 1))
+        padded.append(torch.cat(left_parts + [chunk] + right_parts, dim=dim))
+    return padded
+
+
+# ---------------------------------------------------------------------------
+# 1D neighbor pad
+# ---------------------------------------------------------------------------
+
+
+def run_neighbor_pad_1d_impl(
     mesh_device,
     input_shape,
     halo_shard_dim,
@@ -31,6 +69,7 @@ def run_neighbor_pad_impl(
     enable_trace,
     neighbor_pad_topology,
     num_iters,
+    use_persistent_output_buffer=False,
 ):
     torch.manual_seed(0)
 
@@ -52,8 +91,9 @@ def run_neighbor_pad_impl(
     mesh_device.set_sub_device_stall_group(sub_device_stall_group)
 
     # create global semaphore handles
-    ccl_semaphore_handles = [ttnn.create_global_semaphore(mesh_device, ccl_sub_device_crs, 0) for _ in range(num_iters)]
-
+    neighbor_semaphore_handles = [
+        ttnn.create_global_semaphore(mesh_device, ccl_sub_device_crs, 0) for _ in range(num_iters)
+    ]
     barrier_semaphore_handles = [
         ttnn.create_global_semaphore(mesh_device, ccl_sub_device_crs, 0) for _ in range(num_iters)
     ]
@@ -74,44 +114,30 @@ def run_neighbor_pad_impl(
         * mesh_device.shape[1 - cluster_axis]
     )
 
+    # Create persistent output buffer if requested
+    persistent_output_buffer = None
+    if use_persistent_output_buffer:
+        num_chunks = mesh_device.shape[cluster_axis]
+        output_shape = list(input_shape)
+        output_shape[halo_shard_dim] += num_chunks * (padding_left + padding_right)
+        dims = [None, None]
+        dims[cluster_axis] = halo_shard_dim
+        dims[1 - cluster_axis] = other_shard_dim
+        persistent_output_buffer = ttnn.from_torch(
+            torch.zeros(output_shape).bfloat16(),
+            device=mesh_device,
+            layout=layout,
+            dtype=input_dtype,
+            memory_config=mem_config_output,
+            mesh_mapper=ShardTensor2dMesh(mesh_device, mesh_shape=tuple(mesh_device.shape), dims=dims),
+        )
+
     for i in range(num_iters):
         input_tensor = torch.rand(input_shape).bfloat16()
         num_chunks = mesh_device.shape[cluster_axis]
-        chunks = torch.chunk(input_tensor, num_chunks, halo_shard_dim)
-        np_output_tensor = []
-        # pad left
-        if padding_mode == "zeros":
-            slice_shape = list(chunks[0].shape)
-            slice_shape[halo_shard_dim] = 1
-            first_slice_front = torch.zeros(slice_shape)
-        else:
-            first_slice_front = torch.narrow(chunks[0], halo_shard_dim, 0, 1)
-        first_slice = torch.cat((first_slice_front, chunks[0]), dim=halo_shard_dim)
-        np_output_tensor.append(first_slice)
-        for p in range(padding_left - 1):
-            np_output_tensor[0] = torch.cat((first_slice_front, np_output_tensor[0]), dim=halo_shard_dim)
-        for k in range(1, num_chunks):
-            prev_halo = torch.narrow(
-                chunks[k - 1], halo_shard_dim, chunks[k - 1].shape[halo_shard_dim] - padding_left, padding_left
-            )
-            np_output_tensor.append(torch.cat((prev_halo, chunks[k]), dim=halo_shard_dim))
-
-        # pad right
-        if padding_mode == "zeros":
-            slice_shape = list(np_output_tensor[num_chunks - 1].shape)
-            slice_shape[halo_shard_dim] = 1
-            last_slice_back = torch.zeros(slice_shape)
-        else:
-            last_slice_size = np_output_tensor[num_chunks - 1].shape[halo_shard_dim]
-            last_slice_back = torch.narrow(np_output_tensor[num_chunks - 1], halo_shard_dim, last_slice_size - 1, 1)
-        for p in range(padding_right):
-            np_output_tensor[num_chunks - 1] = torch.cat(
-                (np_output_tensor[num_chunks - 1], last_slice_back), dim=halo_shard_dim
-            )
-        for k in range(0, num_chunks - 1):
-            next_halo = torch.narrow(chunks[k + 1], halo_shard_dim, 0, padding_right)
-            np_output_tensor[k] = torch.cat((np_output_tensor[k], next_halo), dim=halo_shard_dim)
-        np_output_tensor_goldens_list.append(torch.cat(np_output_tensor, dim=halo_shard_dim))
+        chunks = list(torch.chunk(input_tensor, num_chunks, halo_shard_dim))
+        padded = pad_chunks_along_dim(chunks, halo_shard_dim, padding_left, padding_right, padding_mode)
+        np_output_tensor_goldens_list.append(torch.cat(padded, dim=halo_shard_dim))
 
         dims = [None, None]
         dims[cluster_axis] = halo_shard_dim
@@ -128,24 +154,34 @@ def run_neighbor_pad_impl(
         input_tensor_mesh_list.append(input_tensor_mesh)
 
     ##### Perform the TT ops #####
-    tt_neighbor_pad_out_tensor_list = []
 
     def run_op(i):
-        tt_neighbor_pad_out_tensor = ttnn.experimental.neighbor_pad_async(
+        return ttnn.experimental.neighbor_pad_async(
             input_tensor_mesh_list[i],
-            dim=halo_shard_dim,
-            padding_left=padding_left,
-            padding_right=padding_right,
-            padding_mode=padding_mode,
-            cluster_axis=cluster_axis,
-            final_semaphore=ccl_semaphore_handles[i],
-            barrier_semaphore=barrier_semaphore_handles[i],
-            num_links=num_links,
+            [halo_shard_dim],
+            [padding_left],
+            [padding_right],
+            padding_mode,
+            [cluster_axis],
+            [neighbor_semaphore_handles[i]],
+            [barrier_semaphore_handles[i]],
+            num_links=[num_links],
             memory_config=mem_config_output,
             topology=neighbor_pad_topology,
+            persistent_output_buffer=persistent_output_buffer,
         )
 
-        return tt_neighbor_pad_out_tensor
+    def verify(tt_out_tensor, golden_idx):
+        tt_np_out = ttnn.from_device(tt_out_tensor)
+        dims[cluster_axis] = halo_shard_dim
+        dims[1 - cluster_axis] = other_shard_dim
+        tt_np_out = ttnn.to_torch(
+            tt_np_out,
+            mesh_composer=ConcatMesh2dToTensor(mesh_device, mesh_shape=tuple(mesh_device.shape), dims=dims),
+        )
+        eq, output = comp_pcc(tt_np_out, np_output_tensor_goldens_list[golden_idx], 1)
+        logger.info(f"{output}, iteration {golden_idx}")
+        assert eq, f"{golden_idx} FAILED np: {output}"
 
     if enable_trace:
         # Compile the op
@@ -164,54 +200,196 @@ def run_neighbor_pad_impl(
         for i in range(num_iters):
             ttnn.execute_trace(mesh_device, trace_id, cq_id=0, blocking=False)
             ttnn.synchronize_device(mesh_device, sub_device_ids=sub_device_stall_group)
-            tt_neighbor_pad_out_tensor_list.append(tt_neighbor_pad_out_tensor)
+            verify(tt_neighbor_pad_out_tensor, 0)
         logger.info(f"Done executing trace")
     else:
         for i in range(num_iters):
             tt_neighbor_pad_out_tensor = run_op(i)
-            tt_neighbor_pad_out_tensor_list.append(tt_neighbor_pad_out_tensor)
-
-            logger.info(f"Waiting for op")
             ttnn.synchronize_device(mesh_device, sub_device_ids=sub_device_stall_group)
-            logger.info(f"Done op")
-
+            verify(tt_neighbor_pad_out_tensor, i)
             logger.info(f"Done iteration {i}")
-
-    for i in range(num_iters):
-        tt_np_out_tensor = tt_neighbor_pad_out_tensor_list[i]
-        torch_np_out_tensor = np_output_tensor_goldens_list[i if not enable_trace else 0]
-        tt_np_out = ttnn.from_device(tt_np_out_tensor)
-        dims[cluster_axis] = halo_shard_dim
-        dims[1 - cluster_axis] = other_shard_dim
-        tt_np_out = ttnn.to_torch(
-            tt_np_out,
-            mesh_composer=ConcatMesh2dToTensor(mesh_device, mesh_shape=tuple(mesh_device.shape), dims=dims),
-        )
-        eq, output = comp_pcc(tt_np_out, torch_np_out_tensor, 1)
-        logger.info(f"{output}, iteration {i}")
-        assert eq, f"{i} FAILED np: {output}"
 
     mesh_device.reset_sub_device_stall_group()
     mesh_device.clear_loaded_sub_device_manager()
 
 
-@skip_for_blackhole("Requires wormhole_b0 to run")
-@pytest.mark.timeout(900)  # test is slow so bump up the default timeout
-@pytest.mark.parametrize("mesh_device", [(1, 4)], indirect=True)
+# ---------------------------------------------------------------------------
+# 2D neighbor pad
+# ---------------------------------------------------------------------------
+
+
+def compute_2d_pad_golden(input_tensor, mesh_shape, h_dim, w_dim, h_axis, w_axis, pH, pW, padding_mode="zeros"):
+    """
+    Compute per-device golden output for 2D neighbor pad.
+    Pads h_dim along h_axis, then w_dim along w_axis.
+    Returns dict mapping (mesh_row, mesh_col) -> expected per-device tensor.
+    """
+    h_factor = mesh_shape[h_axis]
+    w_factor = mesh_shape[w_axis]
+
+    # Step 1: Chunk along H, pad H boundaries
+    h_chunks = list(torch.chunk(input_tensor, h_factor, dim=h_dim))
+    h_padded = pad_chunks_along_dim(h_chunks, h_dim, pH, pH, padding_mode)
+
+    # Step 2: For each H chunk, chunk along W and pad W boundaries
+    goldens = {}
+    for h_idx in range(h_factor):
+        w_chunks = list(torch.chunk(h_padded[h_idx], w_factor, dim=w_dim))
+        w_padded = pad_chunks_along_dim(w_chunks, w_dim, pW, pW, padding_mode)
+        for w_idx in range(w_factor):
+            key = (h_idx, w_idx) if h_axis == 0 else (w_idx, h_idx)
+            goldens[key] = w_padded[w_idx]
+
+    return goldens
+
+
+def run_neighbor_pad_2d_impl(
+    mesh_device,
+    input_shape,
+    h_dim,
+    w_dim,
+    h_axis,
+    w_axis,
+    pH,
+    pW,
+    padding_mode,
+    num_links,
+    input_dtype,
+    topology,
+    use_persistent_output_buffer=False,
+):
+    """Run fused 2D neighbor pad and compare per-device against golden."""
+    mesh_shape = tuple(mesh_device.shape)
+    h_factor = mesh_shape[h_axis]
+    w_factor = mesh_shape[w_axis]
+
+    assert input_shape[h_dim] % h_factor == 0, f"H dim {input_shape[h_dim]} not divisible by {h_factor}"
+    assert input_shape[w_dim] % w_factor == 0, f"W dim {input_shape[w_dim]} not divisible by {w_factor}"
+
+    torch.manual_seed(42)
+    input_tensor = torch.rand(input_shape).bfloat16()
+    goldens = compute_2d_pad_golden(input_tensor, mesh_shape, h_dim, w_dim, h_axis, w_axis, pH, pW, padding_mode)
+
+    # Sub-device setup
+    compute_grid_size = mesh_device.compute_with_storage_grid_size()
+    ccl_sub_device_crs = ttnn.CoreRangeSet(
+        {ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(compute_grid_size.x - 1, compute_grid_size.y - 1))}
+    )
+    worker_sub_device = ttnn.SubDevice([ccl_sub_device_crs])
+    worker_sub_device_id = ttnn.SubDeviceId(0)
+    sub_device_stall_group = [worker_sub_device_id]
+    sub_device_manager = mesh_device.create_sub_device_manager([worker_sub_device], 0)
+    mesh_device.load_sub_device_manager(sub_device_manager)
+    mesh_device.set_sub_device_stall_group(sub_device_stall_group)
+
+    # Semaphores
+    h_neighbor_sem = ttnn.create_global_semaphore(mesh_device, ccl_sub_device_crs, 0)
+    w_neighbor_sem = ttnn.create_global_semaphore(mesh_device, ccl_sub_device_crs, 0)
+    barrier_sem = ttnn.create_global_semaphore(mesh_device, ccl_sub_device_crs, 0)
+
+    # Shard input to mesh
+    dims = [None, None]
+    dims[h_axis] = h_dim
+    dims[w_axis] = w_dim
+    mem_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.DRAM)
+
+    # Create persistent output buffer if requested
+    persistent_output_buffer = None
+    if use_persistent_output_buffer:
+        output_shape = list(input_shape)
+        output_shape[h_dim] += h_factor * (pH + pH)
+        output_shape[w_dim] += w_factor * (pW + pW)
+        persistent_output_buffer = ttnn.from_torch(
+            torch.zeros(output_shape).bfloat16(),
+            device=mesh_device,
+            layout=ttnn.ROW_MAJOR_LAYOUT,
+            dtype=input_dtype,
+            memory_config=mem_config,
+            mesh_mapper=ShardTensor2dMesh(mesh_device, mesh_shape=mesh_shape, dims=dims),
+        )
+
+    input_tensor_mesh = ttnn.from_torch(
+        input_tensor,
+        device=mesh_device,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        dtype=input_dtype,
+        memory_config=mem_config,
+        mesh_mapper=ShardTensor2dMesh(mesh_device, mesh_shape=mesh_shape, dims=dims),
+    )
+
+    # Run fused 2D neighbor pad
+    output_tensor = ttnn.experimental.neighbor_pad_async(
+        input_tensor_mesh,
+        [h_dim, w_dim],
+        [pH, pW],
+        [pH, pW],
+        padding_mode,
+        [h_axis, w_axis],
+        [h_neighbor_sem, w_neighbor_sem],
+        [barrier_sem],
+        num_links=[num_links, num_links],
+        memory_config=mem_config,
+        topology=topology,
+        persistent_output_buffer=persistent_output_buffer,
+    )
+    ttnn.synchronize_device(mesh_device, sub_device_ids=sub_device_stall_group)
+
+    # Compare per-device
+    output_host = ttnn.from_device(output_tensor)
+    device_tensors = ttnn.get_device_tensors(output_host)
+
+    for row in range(mesh_shape[0]):
+        for col in range(mesh_shape[1]):
+            device_idx = row * mesh_shape[1] + col
+            dev_tensor = ttnn.to_torch(device_tensors[device_idx])
+            golden = goldens[(row, col)]
+
+            assert (
+                dev_tensor.shape == golden.shape
+            ), f"Device ({row},{col}): shape mismatch: got {dev_tensor.shape}, expected {golden.shape}"
+            eq, output = comp_equal(dev_tensor, golden)
+            assert eq, f"Device ({row},{col}): {output}"
+
+    mesh_device.reset_sub_device_stall_group()
+    mesh_device.clear_loaded_sub_device_manager()
+
+
+# ---------------------------------------------------------------------------
+# 1D tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.timeout(900)
+@pytest.mark.parametrize("mesh_device", [(2, 4)], indirect=True)
 @pytest.mark.parametrize("num_links", [1], ids=["1link"])
 @pytest.mark.parametrize(
-    "input_shape, halo_shard_dim, other_shard_dim, layout, input_dtype, padding_left, padding_right, padding_mode, cluster_axis, enable_trace, num_iters",
+    "input_shape, halo_shard_dim, other_shard_dim, layout, input_dtype, padding_left, padding_right, padding_mode, cluster_axis, enable_trace, num_iters, use_persistent_output_buffer",
     [
-        ([28, 60, 106, 768], 0, 2, ttnn.ROW_MAJOR_LAYOUT, ttnn.bfloat16, 2, 0, "replicate", 1, True, 10),  # perf
-        ([82, 120, 212, 512], 0, 2, ttnn.ROW_MAJOR_LAYOUT, ttnn.bfloat16, 2, 0, "replicate", 1, False, 1),  # check
-        ([28, 60, 106, 768], 2, 0, ttnn.ROW_MAJOR_LAYOUT, ttnn.bfloat16, 2, 2, "replicate", 1, True, 10),  # perf
-        ([28, 60, 106, 768], 2, 0, ttnn.ROW_MAJOR_LAYOUT, ttnn.bfloat16, 2, 2, "zeros", 1, False, 1),  # check
+        ([28, 60, 106, 768], 0, 2, ttnn.ROW_MAJOR_LAYOUT, ttnn.bfloat16, 2, 0, "replicate", 1, True, 10, False),  # perf
+        (
+            [82, 120, 212, 512],
+            0,
+            2,
+            ttnn.ROW_MAJOR_LAYOUT,
+            ttnn.bfloat16,
+            2,
+            0,
+            "replicate",
+            1,
+            False,
+            1,
+            False,
+        ),  # check
+        ([28, 60, 106, 768], 2, 0, ttnn.ROW_MAJOR_LAYOUT, ttnn.bfloat16, 2, 2, "replicate", 1, True, 10, False),  # perf
+        ([28, 60, 106, 768], 2, 0, ttnn.ROW_MAJOR_LAYOUT, ttnn.bfloat16, 2, 2, "zeros", 1, False, 1, False),  # check
+        ([8, 12, 16, 32], 2, 0, ttnn.ROW_MAJOR_LAYOUT, ttnn.bfloat16, 1, 1, "zeros", 1, False, 2, True),  # persistent
     ],
     ids=[
         "mochi_vae_1-perf",
         "mochi_vae_2-check",
         "replicate_width_dim-perf",
         "zeros_width_dim-check",
+        "persistent_buffer",
     ],
 )
 @pytest.mark.parametrize(
@@ -231,7 +409,7 @@ def run_neighbor_pad_impl(
     indirect=["device_params"],
     ids=["fabric_linear"],
 )
-def test_neighbor_pad_async(
+def test_neighbor_pad_async_1d(
     mesh_device,
     input_shape,
     halo_shard_dim,
@@ -248,8 +426,9 @@ def test_neighbor_pad_async(
     enable_trace,
     neighbor_pad_topology,
     num_iters,
+    use_persistent_output_buffer,
 ):
-    run_neighbor_pad_impl(
+    run_neighbor_pad_1d_impl(
         mesh_device,
         input_shape=input_shape,
         halo_shard_dim=halo_shard_dim,
@@ -266,4 +445,76 @@ def test_neighbor_pad_async(
         enable_trace=enable_trace,
         neighbor_pad_topology=neighbor_pad_topology,
         num_iters=num_iters,
+        use_persistent_output_buffer=use_persistent_output_buffer,
+    )
+
+
+# ---------------------------------------------------------------------------
+# 2D tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.timeout(120)
+@pytest.mark.parametrize("mesh_device", [(2, 4)], ids=["2x4"], indirect=True)
+@pytest.mark.parametrize(
+    "input_shape, h_dim, w_dim, h_axis, w_axis, pH, pW, use_persistent_output_buffer",
+    [
+        # 5D: [B, T, H, W, C] — H along axis 0, W along axis 1
+        ([1, 2, 8, 16, 32], 2, 3, 0, 1, 1, 1, False),
+        ([1, 3, 10, 16, 32], 2, 3, 0, 1, 1, 1, False),
+        # VAE conv_0 shape (full H=90, W=160)
+        ([1, 3, 90, 160, 32], 2, 3, 0, 1, 1, 1, False),
+        # Flipped axes: H along axis 1, W along axis 0
+        ([1, 2, 16, 8, 32], 2, 3, 1, 0, 1, 1, False),
+        # 4D tensor [B, H, W, C]
+        ([2, 8, 16, 32], 1, 2, 0, 1, 1, 1, False),
+        # Larger channel dim
+        ([1, 2, 10, 16, 384], 2, 3, 0, 1, 1, 1, False),
+        # Padding > 1
+        ([1, 2, 8, 16, 32], 2, 3, 0, 1, 2, 2, False),
+        # Persistent output buffer
+        ([1, 2, 8, 16, 32], 2, 3, 0, 1, 1, 1, True),
+    ],
+    ids=[
+        "small_5d_h0w1",
+        "medium_5d_h0w1",
+        "vae_conv0_h0w1",
+        "small_5d_h1w0",
+        "small_4d_h0w1",
+        "medium_5d_largeC",
+        "small_5d_pad2",
+        "small_5d_persistent",
+    ],
+)
+@pytest.mark.parametrize(
+    "device_params",
+    [{"fabric_config": ttnn.FabricConfig.FABRIC_1D}],
+    indirect=True,
+)
+def test_neighbor_pad_async_2d(
+    mesh_device,
+    input_shape,
+    h_dim,
+    w_dim,
+    h_axis,
+    w_axis,
+    pH,
+    pW,
+    use_persistent_output_buffer,
+    device_params,
+):
+    run_neighbor_pad_2d_impl(
+        mesh_device,
+        input_shape=list(input_shape),
+        h_dim=h_dim,
+        w_dim=w_dim,
+        h_axis=h_axis,
+        w_axis=w_axis,
+        pH=pH,
+        pW=pW,
+        padding_mode="zeros",
+        num_links=1,
+        input_dtype=ttnn.bfloat16,
+        topology=ttnn.Topology.Linear,
+        use_persistent_output_buffer=use_persistent_output_buffer,
     )

--- a/tests/nightly/tg/ccl/test_neighbor_pad_async.py
+++ b/tests/nightly/tg/ccl/test_neighbor_pad_async.py
@@ -5,11 +5,10 @@
 
 import pytest
 import ttnn
-from models.common.utility_functions import skip_for_blackhole
-from tests.nightly.t3000.ccl.test_neighbor_pad_async import run_neighbor_pad_impl
+from models.common.utility_functions import is_blackhole
+from tests.nightly.t3000.ccl.test_neighbor_pad_async import run_neighbor_pad_1d_impl, run_neighbor_pad_2d_impl
 
 
-@skip_for_blackhole("Requires wormhole_b0 to run")
 @pytest.mark.timeout(200)
 @pytest.mark.parametrize("mesh_device", [(4, 8)], indirect=True)
 @pytest.mark.parametrize(
@@ -21,31 +20,32 @@ from tests.nightly.t3000.ccl.test_neighbor_pad_async import run_neighbor_pad_imp
     ids=["perf", "check"],
 )
 @pytest.mark.parametrize(
-    "input_shape, halo_shard_dim, other_shard_dim, layout, input_dtype, padding_left, padding_right, padding_mode, cluster_axis, num_links, skip_for_ci_env",
+    "input_shape, halo_shard_dim, other_shard_dim, layout, input_dtype, padding_left, padding_right, padding_mode, cluster_axis, num_links, skip_for_ci_env, use_persistent_output_buffer",
     [
-        ([1, 3, 23 * 4, 20 * 8, 32], 2, 3, ttnn.ROW_MAJOR_LAYOUT, ttnn.bfloat16, 1, 1, "zeros", 0, 3, False),
-        ([3, 25 * 4, 20 * 8, 32], 2, 1, ttnn.ROW_MAJOR_LAYOUT, ttnn.bfloat16, 1, 1, "zeros", 1, 4, False),
-        ([1, 3, 23 * 4, 20 * 8, 384], 2, 3, ttnn.ROW_MAJOR_LAYOUT, ttnn.bfloat16, 1, 1, "zeros", 0, 3, False),
-        ([3, 25 * 4, 20 * 8, 384], 2, 1, ttnn.ROW_MAJOR_LAYOUT, ttnn.bfloat16, 1, 1, "zeros", 1, 4, False),
-        ([1, 2, 46 * 4, 40 * 8, 384], 2, 3, ttnn.ROW_MAJOR_LAYOUT, ttnn.bfloat16, 1, 1, "zeros", 0, 2, False),
-        ([2, 48 * 4, 40 * 8, 384], 2, 1, ttnn.ROW_MAJOR_LAYOUT, ttnn.bfloat16, 1, 1, "zeros", 1, 4, False),
-        ([1, 4, 46 * 4, 40 * 8, 192], 2, 3, ttnn.ROW_MAJOR_LAYOUT, ttnn.bfloat16, 1, 1, "zeros", 0, 4, True),
-        ([4, 48 * 4, 40 * 8, 192], 2, 1, ttnn.ROW_MAJOR_LAYOUT, ttnn.bfloat16, 1, 1, "zeros", 1, 4, True),
-        ([1, 4, 46 * 4, 40 * 8, 384], 2, 3, ttnn.ROW_MAJOR_LAYOUT, ttnn.bfloat16, 1, 1, "zeros", 0, 4, True),
-        ([4, 48 * 4, 40 * 8, 384], 2, 1, ttnn.ROW_MAJOR_LAYOUT, ttnn.bfloat16, 1, 1, "zeros", 1, 4, True),
-        ([1, 4, 92 * 4, 80 * 8, 384], 2, 3, ttnn.ROW_MAJOR_LAYOUT, ttnn.bfloat16, 1, 1, "zeros", 0, 4, True),
-        ([4, 94 * 4, 80 * 8, 384], 2, 1, ttnn.ROW_MAJOR_LAYOUT, ttnn.bfloat16, 1, 1, "zeros", 1, 4, True),
-        ([1, 6, 92 * 4, 80 * 8, 192], 2, 3, ttnn.ROW_MAJOR_LAYOUT, ttnn.bfloat16, 1, 1, "zeros", 0, 4, True),
-        ([6, 94 * 4, 80 * 8, 192], 2, 1, ttnn.ROW_MAJOR_LAYOUT, ttnn.bfloat16, 1, 1, "zeros", 1, 4, True),
-        ([1, 4, 184 * 4, 160 * 8, 192], 2, 3, ttnn.ROW_MAJOR_LAYOUT, ttnn.bfloat16, 1, 1, "zeros", 0, 4, True),
-        ([4, 186 * 4, 160 * 8, 192], 2, 1, ttnn.ROW_MAJOR_LAYOUT, ttnn.bfloat16, 1, 1, "zeros", 1, 4, True),
-        ([1, 6, 184 * 4, 160 * 8, 96], 2, 3, ttnn.ROW_MAJOR_LAYOUT, ttnn.bfloat16, 1, 1, "zeros", 0, 4, True),
-        ([6, 186 * 4, 160 * 8, 96], 2, 1, ttnn.ROW_MAJOR_LAYOUT, ttnn.bfloat16, 1, 1, "zeros", 1, 4, True),
-        ([28, 5, 106, 32], 0, 2, ttnn.ROW_MAJOR_LAYOUT, ttnn.bfloat16, 2, 0, "replicate", 1, 1, False),
-        ([28, 5, 106, 32], 2, 0, ttnn.ROW_MAJOR_LAYOUT, ttnn.bfloat16, 2, 2, "replicate", 1, 1, False),
-        ([28, 5, 106, 32], 2, 0, ttnn.ROW_MAJOR_LAYOUT, ttnn.bfloat16, 2, 2, "zeros", 1, 1, False),
-        ([28, 60, 106, 768], 0, 2, ttnn.ROW_MAJOR_LAYOUT, ttnn.bfloat16, 2, 0, "replicate", 1, 1, True),
-        ([82, 120, 212, 512], 0, 2, ttnn.ROW_MAJOR_LAYOUT, ttnn.bfloat16, 2, 0, "replicate", 1, 1, True),
+        ([1, 3, 23 * 4, 20 * 8, 32], 2, 3, ttnn.ROW_MAJOR_LAYOUT, ttnn.bfloat16, 1, 1, "zeros", 0, 3, False, False),
+        ([3, 25 * 4, 20 * 8, 32], 2, 1, ttnn.ROW_MAJOR_LAYOUT, ttnn.bfloat16, 1, 1, "zeros", 1, 4, False, False),
+        ([1, 3, 23 * 4, 20 * 8, 384], 2, 3, ttnn.ROW_MAJOR_LAYOUT, ttnn.bfloat16, 1, 1, "zeros", 0, 3, False, False),
+        ([3, 25 * 4, 20 * 8, 384], 2, 1, ttnn.ROW_MAJOR_LAYOUT, ttnn.bfloat16, 1, 1, "zeros", 1, 4, False, False),
+        ([1, 2, 46 * 4, 40 * 8, 384], 2, 3, ttnn.ROW_MAJOR_LAYOUT, ttnn.bfloat16, 1, 1, "zeros", 0, 2, False, False),
+        ([2, 48 * 4, 40 * 8, 384], 2, 1, ttnn.ROW_MAJOR_LAYOUT, ttnn.bfloat16, 1, 1, "zeros", 1, 4, False, False),
+        ([1, 4, 46 * 4, 40 * 8, 192], 2, 3, ttnn.ROW_MAJOR_LAYOUT, ttnn.bfloat16, 1, 1, "zeros", 0, 4, True, False),
+        ([4, 48 * 4, 40 * 8, 192], 2, 1, ttnn.ROW_MAJOR_LAYOUT, ttnn.bfloat16, 1, 1, "zeros", 1, 4, True, False),
+        ([1, 4, 46 * 4, 40 * 8, 384], 2, 3, ttnn.ROW_MAJOR_LAYOUT, ttnn.bfloat16, 1, 1, "zeros", 0, 4, True, False),
+        ([4, 48 * 4, 40 * 8, 384], 2, 1, ttnn.ROW_MAJOR_LAYOUT, ttnn.bfloat16, 1, 1, "zeros", 1, 4, True, False),
+        ([1, 4, 92 * 4, 80 * 8, 384], 2, 3, ttnn.ROW_MAJOR_LAYOUT, ttnn.bfloat16, 1, 1, "zeros", 0, 4, True, False),
+        ([4, 94 * 4, 80 * 8, 384], 2, 1, ttnn.ROW_MAJOR_LAYOUT, ttnn.bfloat16, 1, 1, "zeros", 1, 4, True, False),
+        ([1, 6, 92 * 4, 80 * 8, 192], 2, 3, ttnn.ROW_MAJOR_LAYOUT, ttnn.bfloat16, 1, 1, "zeros", 0, 4, True, False),
+        ([6, 94 * 4, 80 * 8, 192], 2, 1, ttnn.ROW_MAJOR_LAYOUT, ttnn.bfloat16, 1, 1, "zeros", 1, 4, True, False),
+        ([1, 4, 184 * 4, 160 * 8, 192], 2, 3, ttnn.ROW_MAJOR_LAYOUT, ttnn.bfloat16, 1, 1, "zeros", 0, 4, True, False),
+        ([4, 186 * 4, 160 * 8, 192], 2, 1, ttnn.ROW_MAJOR_LAYOUT, ttnn.bfloat16, 1, 1, "zeros", 1, 4, True, False),
+        ([1, 6, 184 * 4, 160 * 8, 96], 2, 3, ttnn.ROW_MAJOR_LAYOUT, ttnn.bfloat16, 1, 1, "zeros", 0, 4, True, False),
+        ([6, 186 * 4, 160 * 8, 96], 2, 1, ttnn.ROW_MAJOR_LAYOUT, ttnn.bfloat16, 1, 1, "zeros", 1, 4, True, False),
+        ([28, 5, 106, 32], 0, 2, ttnn.ROW_MAJOR_LAYOUT, ttnn.bfloat16, 2, 0, "replicate", 1, 1, False, False),
+        ([28, 5, 106, 32], 2, 0, ttnn.ROW_MAJOR_LAYOUT, ttnn.bfloat16, 2, 2, "replicate", 1, 1, False, False),
+        ([28, 5, 106, 32], 2, 0, ttnn.ROW_MAJOR_LAYOUT, ttnn.bfloat16, 2, 2, "zeros", 1, 1, False, False),
+        ([28, 60, 106, 768], 0, 2, ttnn.ROW_MAJOR_LAYOUT, ttnn.bfloat16, 2, 0, "replicate", 1, 1, True, False),
+        ([82, 120, 212, 512], 0, 2, ttnn.ROW_MAJOR_LAYOUT, ttnn.bfloat16, 2, 0, "replicate", 1, 1, True, False),
+        ([1, 3, 23 * 4, 20 * 8, 32], 2, 3, ttnn.ROW_MAJOR_LAYOUT, ttnn.bfloat16, 1, 1, "zeros", 0, 3, False, True),
     ],
     ids=[
         "Wan_shape_1",
@@ -71,6 +71,7 @@ from tests.nightly.t3000.ccl.test_neighbor_pad_async import run_neighbor_pad_imp
         "zeros_W_dim",
         "mochi_shape_1",
         "mochi_shape_2",
+        "persistent_buffer",
     ],
 )
 @pytest.mark.parametrize(
@@ -90,7 +91,7 @@ from tests.nightly.t3000.ccl.test_neighbor_pad_async import run_neighbor_pad_imp
     indirect=["device_params"],
     ids=["fabric_linear"],
 )
-def test_neighbor_pad_async_nightly(
+def test_neighbor_pad_async_1d(
     mesh_device,
     input_shape,
     halo_shard_dim,
@@ -109,12 +110,16 @@ def test_neighbor_pad_async_nightly(
     num_iters,
     is_ci_env,
     skip_for_ci_env,
+    use_persistent_output_buffer,
 ):
     if is_ci_env:
         if skip_for_ci_env:
             pytest.skip("Skipping certain shapes in CI to reduce pipeline time")
 
-    run_neighbor_pad_impl(
+    if is_blackhole() and num_links > 2:
+        pytest.skip("Skipping num_links > 2 on BH (only 2 ethernet channels available)")
+
+    run_neighbor_pad_1d_impl(
         mesh_device,
         input_shape=input_shape,
         halo_shard_dim=halo_shard_dim,
@@ -131,4 +136,92 @@ def test_neighbor_pad_async_nightly(
         enable_trace=enable_trace,
         neighbor_pad_topology=neighbor_pad_topology,
         num_iters=num_iters,
+        use_persistent_output_buffer=use_persistent_output_buffer,
+    )
+
+
+# ---------------------------------------------------------------------------
+# 2D tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.timeout(120)
+@pytest.mark.parametrize(
+    "mesh_device, num_links",
+    [
+        [(4, 8), 1],
+        [(4, 8), 4],
+        [(4, 8), 1],
+        [(4, 8), 2],
+    ],
+    ids=[
+        "wh_4x8_1link",
+        "wh_4x8_4link",
+        "bh_4x8_1link",
+        "bh_4x8_2link",
+    ],
+    indirect=["mesh_device"],
+)
+@pytest.mark.parametrize(
+    "input_shape, h_dim, w_dim, h_axis, w_axis, pH, pW, use_persistent_output_buffer",
+    [
+        # 5D: [B, T, H, W, C] — H along axis 0, W along axis 1
+        ([1, 2, 8, 16, 32], 2, 3, 0, 1, 1, 1, False),
+        ([1, 3, 12, 16, 32], 2, 3, 0, 1, 1, 1, False),
+        # VAE conv_0 shape (full H=90, W=160)
+        ([1, 3, 92, 160, 32], 2, 3, 0, 1, 1, 1, False),
+        # Flipped axes: H along axis 1, W along axis 0
+        ([1, 2, 16, 8, 32], 2, 3, 1, 0, 1, 1, False),
+        # 4D tensor [B, H, W, C]
+        ([2, 8, 16, 32], 1, 2, 0, 1, 1, 1, False),
+        # Larger channel dim
+        ([1, 2, 8, 16, 384], 2, 3, 0, 1, 1, 1, False),
+        # Padding > 1
+        ([1, 2, 8, 16, 32], 2, 3, 0, 1, 2, 2, False),
+        # Persistent output buffer
+        ([1, 2, 8, 16, 32], 2, 3, 0, 1, 1, 1, True),
+    ],
+    ids=[
+        "small_5d_h0w1",
+        "medium_5d_h0w1",
+        "vae_conv0_h0w1",
+        "small_5d_h1w0",
+        "small_4d_h0w1",
+        "small_5d_largeC",
+        "small_5d_pad2",
+        "small_5d_persistent",
+    ],
+)
+@pytest.mark.parametrize(
+    "device_params",
+    [{"fabric_config": ttnn.FabricConfig.FABRIC_1D}],
+    indirect=True,
+)
+def test_neighbor_pad_async_2d(
+    mesh_device,
+    input_shape,
+    h_dim,
+    w_dim,
+    h_axis,
+    w_axis,
+    pH,
+    pW,
+    num_links,
+    use_persistent_output_buffer,
+    device_params,
+):
+    run_neighbor_pad_2d_impl(
+        mesh_device,
+        input_shape=list(input_shape),
+        h_dim=h_dim,
+        w_dim=w_dim,
+        h_axis=h_axis,
+        w_axis=w_axis,
+        pH=pH,
+        pW=pW,
+        padding_mode="zeros",
+        num_links=num_links,
+        input_dtype=ttnn.bfloat16,
+        topology=ttnn.Topology.Linear,
+        use_persistent_output_buffer=use_persistent_output_buffer,
     )

--- a/tests/scripts/t3000/run_t3000_integration_tests.sh
+++ b/tests/scripts/t3000/run_t3000_integration_tests.sh
@@ -428,7 +428,7 @@ run_t3000_mochi_tests() {
   echo "LOG_METAL: Running run_t3000_mochi_tests"
 
   export TT_DIT_CACHE_DIR="/tmp/TT_DIT_CACHE"
-  FAKE_DEVICE=T3K pytest models/tt_dit/tests/models/mochi/test_vae_mochi.py -k "decoder and 1link-load_dit-large_latent or conv3d_1x1x1 or -1link-l768" --timeout=3600; fail+=$?
+  FAKE_DEVICE=T3K pytest models/tt_dit/tests/models/mochi/test_vae_mochi.py -k "decoder and 1link-load_dit-small_latent or conv3d_1x1x1 or -1link-l768" --timeout=1500; fail+=$?
   pytest models/tt_dit/tests/models/mochi/test_attention_mochi.py -k "short_seq"; fail+=$?
   pytest models/tt_dit/tests/models/mochi/test_transformer_mochi.py -k "1x8 or 2x4 and short_seq and not yes_load_cache and not model_caching"; fail+=$?
 

--- a/tests/scripts/t3000/run_t3000_unit_tests.sh
+++ b/tests/scripts/t3000/run_t3000_unit_tests.sh
@@ -660,7 +660,7 @@ run_t3000_tt_dit_tests() {
   DIT_UNIT_TEST=1 pytest models/tt_dit/tests/models/flux1/test_transformer_flux1.py::test_transformer -k 2x4sp0tp1 ; fail+=$?
 
   #DITs Wan2.2 VAE
-  pytest models/tt_dit/tests/models/wan2_2/test_vae_wan2_1.py::test_wan_decoder[wormhole_b0-device_params0-2x4_h1_w0-check_output-fake_weights-0-1-_1f-480p] ; fail+=$?
+  pytest models/tt_dit/tests/models/wan2_2/test_vae_wan2_1.py::test_wan_decoder[wormhole_b0-device_params0-2x4_h1_w0-bf16-check_output-fake_weights-0-1-_1f-480p] ; fail+=$?
 
   #DITs Wan2.2 Transformer
   DIT_UNIT_TEST=1 pytest models/tt_dit/tests/models/wan2_2/test_transformer_wan.py::test_wan_transformer_model[wormhole_b0-short_seq-2x4sp0tp1-True] ; fail+=$?

--- a/tests/scripts/t3000/run_t3000_unit_tests.sh
+++ b/tests/scripts/t3000/run_t3000_unit_tests.sh
@@ -618,6 +618,10 @@ run_t3000_ccl_tests() {
   # fabric 2d test on cluster axis 0 - Re-enable this test when we have more T3K availability
   # pytest tests/nightly/t3000/ccl/test_all_to_all_combine.py::test_all_to_all_combine_no_trace[wormhole_b0-DataType.BFLOAT16-None-dram-dram-2-random-True-2-7000-8-8-8-fabric_2d_axis_0]
 
+  # neighbor pad: 1D correctness check + 2D correctness check
+  pytest tests/nightly/t3000/ccl/test_neighbor_pad_async.py::test_neighbor_pad_async_1d -k "zeros_width_dim-check"
+  pytest tests/nightly/t3000/ccl/test_neighbor_pad_async.py::test_neighbor_pad_async_2d -k "small_5d_h0w1"
+
   # Record the end time
   end_time=$(date +%s)
   duration=$((end_time - start_time))

--- a/tests/scripts/t3000/run_t3000_unit_tests.sh
+++ b/tests/scripts/t3000/run_t3000_unit_tests.sh
@@ -634,8 +634,17 @@ run_t3000_tt_dit_tests() {
 
   echo "LOG_METAL: Running run_t3000_tt_dit_tests"
 
+  #Timestep Encoding (Currently used in Wan2.2)
+  pytest models/tt_dit/tests/unit/test_embeddings.py::test_timestep_encoding ; fail+=$?
+
+  #Wan2.2 Time Text Image Embedding
+  pytest models/tt_dit/tests/unit/test_embeddings.py::test_wan_time_text_image_embedding  -k "t3k" ; fail+=$?
+
   #T5 Encoder
-  DIT_UNIT_TEST=1 pytest models/tt_dit/tests/encoders/t5/test_t5_full.py::test_t5_encoder[wormhole_b0-device_params0-Topology.Linear-1x4-t3k-large-True] ; fail+=$?
+  DIT_UNIT_TEST=1 pytest models/tt_dit/tests/encoders/t5/test_t5_full.py::test_t5_encoder -k "t3k" ; fail+=$?
+
+  #UMT5 Encoder
+  DIT_UNIT_TEST=1 pytest models/tt_dit/tests/encoders/umt5/test_umt5.py -k "t3k" ; fail+=$?
 
   #Clip Encoder
   DIT_UNIT_TEST=1 pytest models/tt_dit/tests/encoders/clip/test_clip_full_projection.py -k 1x4-t3k ; fail+=$?

--- a/tests/scripts/tg/run_tg_frequent_tests.sh
+++ b/tests/scripts/tg/run_tg_frequent_tests.sh
@@ -70,6 +70,8 @@ run_tg_tests() {
     pytest models/tt_dit/tests/models/wan2_2/test_attention_wan.py -k "wh_4x8sp1tp0"; fail+=$?
     pytest models/tt_dit/tests/models/wan2_2/test_transformer_wan.py -k "transformer_block and wh_4x8sp1tp0 or short_seq-wh_4x8sp1tp0 and not yes_load_cache and not model_caching"; fail+=$?
     pytest models/tt_dit/tests/models/wan2_2/test_vae_wan2_1.py -k "(test_wan_decoder or test_wan_encoder) and 4x8 and real_weights and check_output and _1f"; fail+=$?
+    pytest models/tt_dit/tests/encoders/umt5/test_umt5.py -k "wh_glx" ; fail+=$?
+    pytest models/tt_dit/tests/unit/test_embeddings.py::test_wan_time_text_image_embedding  -k "wh_glx" ; fail+=$?
 
   elif [[ "$1" == "qwenimage" ]]; then
     echo "LOG_METAL: running QwenImage run_tg_frequent_tests"

--- a/ttnn/core/tensor/flatbuffer/tensor_flatbuffer.cpp
+++ b/ttnn/core/tensor/flatbuffer/tensor_flatbuffer.cpp
@@ -22,6 +22,7 @@
 #include <tt-metalium/serialized_descriptors/mesh_coordinate_generated.h>
 #include "tensor_generated.h"
 
+#include <map>
 #include <vector>
 #include <cstdint>
 #include <unordered_map>
@@ -166,9 +167,15 @@ flatbuffers::Offset<ttnn::flatbuffer::Tensor> to_flatbuffer(
 
     const auto& host_storage = tensor.host_storage();
 
+    // Deduplicate replicated shards: two shards are duplicates if their coordinates differ only
+    // along Replicate dimensions. The deduplication key is the vector of coordinates at sharded
+    // dimensions only.
+    const auto& placements = tensor.tensor_topology().placements();
+
     std::vector<flatbuffers::Offset<ttnn::flatbuffer::TensorShard>> shards_vector;
     // Used to deduplicate buffer addresses for replicated tensor data.
     std::unordered_map<const std::byte*, uint64_t> buffer_to_offset;
+    std::map<ttsl::SmallVector<uint32_t>, uint64_t> dedup_key_to_offset;
     uint64_t next_buffer_offset = 0;
     for (const auto& coord : host_storage.buffer().shard_coords()) {
         // Iterate over local populated shards.
@@ -177,13 +184,26 @@ flatbuffers::Offset<ttnn::flatbuffer::Tensor> to_flatbuffer(
             const std::size_t buffer_size = buffer->view_bytes().size();
 
             uint64_t shard_buffer_offset = next_buffer_offset;
-            if (auto [it, inserted] = buffer_to_offset.try_emplace(buffer_address, shard_buffer_offset); inserted) {
-                // Encountered a new buffer, add it to the buffers vector.
-                next_buffer_offset += buffer_size;
-                buffers.push_back(*buffer);
-            } else {
-                // Point to the existing buffer.
+
+            // If two shards share the same buffer, they are identical.
+            if (auto it = buffer_to_offset.find(buffer_address); it != buffer_to_offset.end()) {
                 shard_buffer_offset = it->second;
+            } else {
+                // Shards whose coordinates differ only along replicated dimensions are identical.
+                ttsl::SmallVector<uint32_t> key;
+                for (size_t dim = 0; dim < placements.size(); ++dim) {
+                    if (std::holds_alternative<tt::tt_metal::distributed::MeshMapperConfig::Shard>(placements[dim])) {
+                        key.push_back(coord[dim]);
+                    }
+                }
+                if (auto [kit, inserted] = dedup_key_to_offset.try_emplace(std::move(key), shard_buffer_offset);
+                    inserted) {
+                    next_buffer_offset += buffer_size;
+                    buffers.push_back(*buffer);
+                } else {
+                    shard_buffer_offset = kit->second;
+                }
+                buffer_to_offset.emplace(buffer_address, shard_buffer_offset);
             }
 
             auto inline_storage = ttnn::flatbuffer::InlineFileStorage(shard_buffer_offset, buffer_size);

--- a/ttnn/cpp/ttnn/operations/ccl/ccl_common.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/ccl_common.cpp
@@ -1675,8 +1675,7 @@ std::vector<Shape4D<uint32_t>> GenericWrappedTensorSlicerV2::create_worker_slice
     return worker_slice_shapes;
 }
 
-void validate_fabric_2d_dynamic_config(Topology topology) {
-    TT_FATAL(topology != Topology::Ring, "Fabric 2D dynamic is not supported for ring topology");
+void validate_fabric_2d_dynamic_config() {
     auto physical_mesh_shapes = tt::tt_fabric::get_physical_mesh_shapes();
     TT_FATAL(
         physical_mesh_shapes.size() == 1,
@@ -1719,7 +1718,6 @@ std::tuple<size_t, size_t, bool> get_forward_backward_configuration(
 }
 
 std::tuple<std::array<uint32_t, 2>, std::array<uint32_t, 2>> get_forward_backward_line_unicast_configuration(
-    Topology topology,
     const MeshCoordinate& /*src_device_coord*/,
     const std::optional<MeshCoordinate>& forward_device_coord,
     const std::optional<MeshCoordinate>& backward_device_coord,
@@ -1728,8 +1726,8 @@ std::tuple<std::array<uint32_t, 2>, std::array<uint32_t, 2>> get_forward_backwar
     std::array<uint32_t, 2> backward_args = {};
 
     auto fabric_config = tt::tt_fabric::GetFabricConfig();
-    if (fabric_config == tt::tt_fabric::FabricConfig::FABRIC_2D) {
-        validate_fabric_2d_dynamic_config(topology);
+    if (tt::tt_fabric::is_2d_fabric_config(fabric_config)) {
+        validate_fabric_2d_dynamic_config();
         if (forward_device_coord) {
             auto forward_device_fabric_node_id = mesh_device->get_fabric_node_id(forward_device_coord.value());
             forward_args[0] = *forward_device_fabric_node_id.mesh_id;
@@ -1777,7 +1775,6 @@ std::tuple<uint32_t, uint32_t> get_forward_backward_line_mcast_distance(
 }
 
 std::tuple<std::array<uint32_t, 6>, std::array<uint32_t, 6>> get_forward_backward_line_mcast_configuration(
-    Topology topology,
     const MeshCoordinate& src_device_coord,
     const std::optional<MeshCoordinate>& forward_device_coord,
     const std::optional<MeshCoordinate>& backward_device_coord,
@@ -1790,8 +1787,8 @@ std::tuple<std::array<uint32_t, 6>, std::array<uint32_t, 6>> get_forward_backwar
     // May be uplifted to an op parameter if needed
     auto fabric_config = tt::tt_fabric::GetFabricConfig();
 
-    if (fabric_config == tt::tt_fabric::FabricConfig::FABRIC_2D) {
-        validate_fabric_2d_dynamic_config(topology);
+    if (tt::tt_fabric::is_2d_fabric_config(fabric_config)) {
+        validate_fabric_2d_dynamic_config();
         auto src_fabric_node_id = mesh_device->get_fabric_node_id(src_device_coord);
         auto set_mcast_args = [&src_fabric_node_id](
                                   std::array<uint32_t, 6>& args,

--- a/ttnn/cpp/ttnn/operations/ccl/ccl_common.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/ccl_common.hpp
@@ -739,7 +739,6 @@ std::tuple<size_t, size_t, bool> get_forward_backward_configuration(
 
 // Forward/backward devices are assumed to be neighbors for 1D fabric for now
 std::tuple<std::array<uint32_t, 2>, std::array<uint32_t, 2>> get_forward_backward_line_unicast_configuration(
-    Topology topology,
     const distributed::MeshCoordinate& src_device_coord,
     const std::optional<distributed::MeshCoordinate>& forward_device_coord,
     const std::optional<distributed::MeshCoordinate>& backward_device_coord,
@@ -750,7 +749,6 @@ std::tuple<uint32_t, uint32_t> get_forward_backward_line_mcast_distance(
 
 // Forward/backward devices are assumed to be neighbors for 1D fabric for now
 std::tuple<std::array<uint32_t, 6>, std::array<uint32_t, 6>> get_forward_backward_line_mcast_configuration(
-    Topology topology,
     const distributed::MeshCoordinate& src_device_coord,
     const std::optional<distributed::MeshCoordinate>& forward_device_coord,
     const std::optional<distributed::MeshCoordinate>& backward_device_coord,

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_default_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_default_program_factory.cpp
@@ -305,9 +305,8 @@ AllGatherProgramArtifacts build_all_gather_async_minimal_default_program_artifac
     auto [num_targets_forward, num_targets_backward] =
         ccl::get_forward_backward_line_mcast_distance(ring_size, ring_index, topology, false);
     auto [unicast_forward_args, unicast_backward_args] = ccl::get_forward_backward_line_unicast_configuration(
-        topology, sender_device_coord, forward_coord, backward_coord, mesh_device);
+        sender_device_coord, forward_coord, backward_coord, mesh_device);
     auto [barrier_mcast_forward_args, barrier_mcast_backward_args] = ccl::get_forward_backward_line_mcast_configuration(
-        topology,
         sender_device_coord,
         forward_coord,
         backward_coord,

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_default_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_default_program_factory.cpp
@@ -481,15 +481,30 @@ AllGatherProgramArtifacts build_all_gather_async_minimal_default_program_artifac
         (input_tensor_shape.rank() == 2) ? map_2d_to_4d() : map_nd_to_4d();
 
     uint32_t single_batch_head_num_pages = input_tensor_num_pages / batch_head_size;
-    TT_FATAL(!(input_tensor_shape[-1] % TILE_WIDTH), "Input tensor width must be a multiple of TILE_WIDTH");
-    TT_FATAL(!(output_tensor_shape[-1] % TILE_WIDTH), "Output tensor width must be a multiple of TILE_WIDTH");
-    uint32_t TILE_WIDTH = 32;
+    constexpr uint32_t TILE_SIZE = 32;
+    // Only check tile alignment for the dimension being all-gathered
+    uint32_t rank = input_tensor_shape.rank();
+    if (dim == rank - 1) {
+        TT_FATAL(
+            !(input_tensor_shape[-1] % TILE_SIZE),
+            "Input tensor width must be tile-aligned when all-gathering along width");
+        TT_FATAL(
+            !(output_tensor_shape[-1] % TILE_SIZE),
+            "Output tensor width must be tile-aligned when all-gathering along width");
+    } else if (dim == rank - 2) {
+        TT_FATAL(
+            !(input_tensor_shape[-2] % TILE_SIZE),
+            "Input tensor height must be tile-aligned when all-gathering along height");
+        TT_FATAL(
+            !(output_tensor_shape[-2] % TILE_SIZE),
+            "Output tensor height must be tile-aligned when all-gathering along height");
+    }
 
-    uint32_t input_tensor_Wt = input_tensor_shape[-1] / TILE_WIDTH;
-    uint32_t input_tensor_Ht = input_tensor_shape[-2] / TILE_WIDTH;
+    uint32_t input_tensor_Wt = input_tensor_shape[-1] / TILE_SIZE;
+    uint32_t input_tensor_Ht = input_tensor_shape[-2] / TILE_SIZE;
 
-    uint32_t output_tensor_Wt = output_tensor_shape[-1] / TILE_WIDTH;
-    uint32_t output_tensor_Ht = output_tensor_shape[-2] / TILE_WIDTH;
+    uint32_t output_tensor_Wt = output_tensor_shape[-1] / TILE_SIZE;
+    uint32_t output_tensor_Ht = output_tensor_shape[-2] / TILE_SIZE;
 
     auto num_full_size_channels = num_workers_per_direction;
     auto num_header_only_channels = 0;

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_llama_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_llama_sharded_program_factory.cpp
@@ -80,13 +80,7 @@ LlamaShardedMeshWorkloadFactory::cached_program_t LlamaShardedMeshWorkloadFactor
     auto [num_targets_forward, num_targets_backward] =
         get_forward_backward_line_mcast_distance(ring_size, ring_index, topology, true);
     auto [forward_args, backward_args] = get_forward_backward_line_mcast_configuration(
-        topology,
-        sender_device_coord,
-        forward_coord,
-        backward_coord,
-        num_targets_forward,
-        num_targets_backward,
-        mesh_device);
+        sender_device_coord, forward_coord, backward_coord, num_targets_forward, num_targets_backward, mesh_device);
 
     // Get worker cores, assuming 1 worker per link
     uint32_t num_workers_per_link = 1;

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce_async/device/all_reduce_async_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce_async/device/all_reduce_async_program_factory.cpp
@@ -170,7 +170,7 @@ AllReduceAsyncMeshWorkloadFactory::cached_program_t AllReduceAsyncMeshWorkloadFa
     auto [num_targets_forward, num_targets_backward] =
         ttnn::ccl::get_forward_backward_line_mcast_distance(ring_size, device_index, topology, true);
     auto [forward_args, backward_args] = ttnn::ccl::get_forward_backward_line_mcast_configuration(
-        topology, coord, forward_coord, backward_coord, num_targets_forward, num_targets_backward, mesh_device);
+        coord, forward_coord, backward_coord, num_targets_forward, num_targets_backward, mesh_device);
 
     // Tensor Info
     [[maybe_unused]] const auto input_tensor_num_pages = input_tensor.buffer()->num_pages();

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_async/device/kernels/local_copy_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_async/device/kernels/local_copy_reader.cpp
@@ -1,17 +1,16 @@
 // SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
-//
+
 #include "api/dataflow/dataflow_api.h"
 #include <tt-metalium/buffer_types.hpp>
 #include <cstdint>
-#include <utility>
-//
+
 using address_t = uint32_t;
-//
+
 constexpr uint32_t cb_output_id = get_compile_time_arg_val(0);
 constexpr uint32_t stick_size = get_compile_time_arg_val(1);
-//
+
 void kernel_main() {
     // Args
     uint32_t arg_idx = 0;
@@ -23,11 +22,11 @@ void kernel_main() {
     const uint32_t rows_count = get_arg_val<uint32_t>(arg_idx++);
     const uint32_t num_sticks_to_read = get_arg_val<uint32_t>(arg_idx++);
     const uint32_t num_sticks_per_halo_dim = get_arg_val<uint32_t>(arg_idx++);
-    //
+
     constexpr auto src_args = TensorAccessorArgs<2>();
     uint32_t read_size = stick_size;
     const auto src_accessor = TensorAccessor(src_args, input_tensor_address, stick_size);
-    //
+
     for (uint32_t s = 0; s < rows_count; s++) {
         const uint32_t linear_row = total_rows_start + s;  // [0 .. outer_dim_size*input_halo_dim_size)
         const uint32_t outer_idx = linear_row / input_halo_dim_size;

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_async/device/kernels/local_copy_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_async/device/kernels/local_copy_writer.cpp
@@ -1,17 +1,18 @@
 // SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
-//
+
 #include "api/dataflow/dataflow_api.h"
 #include <tt-metalium/buffer_types.hpp>
 #include <cstdint>
-#include <utility>
-//
+
 using address_t = uint32_t;
-//
+
 constexpr uint32_t cb_output_id = get_compile_time_arg_val(0);
 constexpr uint32_t stick_size = get_compile_time_arg_val(1);
-//
+// TensorAccessorArgs at index 2 (variable length)
+constexpr auto dst_args = TensorAccessorArgs<2>();
+
 void kernel_main() {
     // Args
     uint32_t arg_idx = 0;
@@ -25,11 +26,21 @@ void kernel_main() {
     const uint32_t padding_left = get_arg_val<uint32_t>(arg_idx++);
     const uint32_t num_sticks_to_read = get_arg_val<uint32_t>(arg_idx++);
     const uint32_t num_sticks_per_halo_dim = get_arg_val<uint32_t>(arg_idx++);
-    //
+    // Phase 2 barrier signal targets (0 for 1D, >0 for 2D)
+    // Max targets = pad2_num_links * 2 directions (up to 8 W fabric cores)
+    constexpr uint32_t MAX_PHASE2_SIGNAL_TARGETS = 8;
+    const uint32_t num_phase2_signal_targets = get_arg_val<uint32_t>(arg_idx++);
+    uint8_t signal_noc_x[MAX_PHASE2_SIGNAL_TARGETS];
+    uint8_t signal_noc_y[MAX_PHASE2_SIGNAL_TARGETS];
+    uint32_t barrier_sem_addr[MAX_PHASE2_SIGNAL_TARGETS];
+    for (uint32_t t = 0; t < MAX_PHASE2_SIGNAL_TARGETS; t++) {
+        signal_noc_x[t] = get_arg_val<uint32_t>(arg_idx++);
+        signal_noc_y[t] = get_arg_val<uint32_t>(arg_idx++);
+        barrier_sem_addr[t] = get_arg_val<uint32_t>(arg_idx++);
+    }
 
-    constexpr auto dst_args = TensorAccessorArgs<2>();
     const auto dst_accessor = TensorAccessor(dst_args, output_tensor_address, stick_size);
-    //
+
     for (uint32_t s = 0; s < rows_count; s++) {
         const uint32_t linear_row = total_rows_start + s;  // [0 .. outer_dim_size*input_halo_dim_size)
         const uint32_t outer_idx = linear_row / input_halo_dim_size;
@@ -47,5 +58,13 @@ void kernel_main() {
             cb_pop_front(cb_output_id, 1);
         }
     }
+    noc_async_write_barrier();
+
+    // Signal Phase 2 W fabric reader cores that Phase 1 writes are complete
+    for (uint32_t t = 0; t < num_phase2_signal_targets; t++) {
+        uint64_t sem_noc_addr = get_noc_addr(signal_noc_x[t], signal_noc_y[t], barrier_sem_addr[t]);
+        noc_semaphore_inc(sem_noc_addr, 1);
+    }
+    // Ensure sem inc signals are delivered before kernel exits.
     noc_async_write_barrier();
 }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_async/device/kernels/minimal_default_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_async/device/kernels/minimal_default_reader.cpp
@@ -3,15 +3,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "api/dataflow/dataflow_api.h"
-#include <tt-metalium/buffer_types.hpp>
-#include "ttnn/operations/ccl/kernel_common/worker_sync_utils.hpp"
-#include "ttnn/operations/ccl/ccl_host_types.hpp"
 #include <cstdint>
-#include <utility>
 
 using address_t = uint32_t;
-using tt::tt_metal::BufferType;
-using ttnn::ccl::Topology;
 
 constexpr bool is_first_chip = get_compile_time_arg_val(0);
 constexpr bool is_last_chip = get_compile_time_arg_val(1);
@@ -19,6 +13,12 @@ constexpr uint32_t cb_output_id = get_compile_time_arg_val(2);
 constexpr bool direction = get_compile_time_arg_val(3);
 constexpr bool is_padding_zeros = get_compile_time_arg_val(4);
 constexpr uint32_t stick_size = get_compile_time_arg_val(5);
+// Input TensorAccessorArgs at index 6 (variable length)
+constexpr auto src_ct_args = TensorAccessorArgs<6>();
+constexpr uint32_t ct_after_src = src_ct_args.next_compile_time_args_offset();
+// L1 intermediate config
+constexpr bool use_l1_intermediate = get_compile_time_arg_val(ct_after_src);
+constexpr uint32_t recv_cb_id = get_compile_time_arg_val(ct_after_src + 1);
 
 template <uint32_t stick_size_bytes>
 inline void zeroPad(uint32_t cb_output_id) {
@@ -52,11 +52,10 @@ void kernel_main() {
     const uint32_t padding = get_arg_val<uint32_t>(arg_idx++);
     const uint32_t num_sticks_to_read = get_arg_val<uint32_t>(arg_idx++);
     const uint32_t num_sticks_per_halo_dim = get_arg_val<uint32_t>(arg_idx++);
-    size_t out_ready_sem = get_arg_val<uint32_t>(arg_idx++);
+    size_t h_neighbor_sem = get_arg_val<uint32_t>(arg_idx++);
 
-    constexpr auto src_args = TensorAccessorArgs<6>();
     uint32_t read_size = stick_size;
-    const auto src_accessor = TensorAccessor(src_args, input_tensor_address, stick_size);
+    const auto src_accessor = TensorAccessor(src_ct_args, input_tensor_address, stick_size);
 
     uint32_t outer_dim_offset = outer_dim_offset_start_id;
     for (uint32_t outer_dim = 0; outer_dim < outer_dim_size; outer_dim++) {
@@ -120,10 +119,38 @@ void kernel_main() {
         outer_dim_offset += (num_sticks_per_halo_dim * input_halo_dim_size);
     }
 
-    // Check that the semaphore is received
+    // Incoming H halo data from neighbor
     if (!is_first_chip) {
-        noc_semaphore_wait_min(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(out_ready_sem), outer_dim_size);
-    }
+        if constexpr (use_l1_intermediate) {
+            // L1 intermediate: fabric delivered H halo data to our L1 recv buffer.
+            // Push it into CB for the paired writer to write to output DRAM.
+            uint32_t recv_buf_addr = get_write_ptr(recv_cb_id);
+            uint32_t buf_offset = 0;  // Accumulates across all outer_dims (no L1 reuse)
 
-    noc_semaphore_set(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(out_ready_sem), 0);
+            for (uint32_t od = 0; od < outer_dim_size; od++) {
+                // Wait for this outer_dim's data using cumulative count.
+                // Using cumulative waits (od+1) instead of resetting to 0 each iteration
+                // avoids a race where the writer sends multiple sem incs before the reader
+                // processes them — resetting to 0 would discard pending incs and cause a hang.
+                noc_semaphore_wait_min(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(h_neighbor_sem), od + 1);
+
+                for (uint32_t pad_id = 0; pad_id < padding; pad_id++) {
+                    for (uint32_t iter = 0; iter < num_sticks_to_read; iter++) {
+                        cb_reserve_back(cb_output_id, 1);
+                        uint32_t dst_l1_addr = get_write_ptr(cb_output_id);
+                        noc_async_read(get_noc_addr(recv_buf_addr + buf_offset), dst_l1_addr, stick_size);
+                        noc_async_read_barrier();
+                        cb_push_back(cb_output_id, 1);
+                        buf_offset += stick_size;
+                    }
+                }
+            }
+            // Reset after all waits are complete (safe: no more fabric increments expected)
+            noc_semaphore_set(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(h_neighbor_sem), 0);
+        } else {
+            // 1D case: fabric wrote directly to DRAM; just wait for all outer_dims
+            noc_semaphore_wait_min(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(h_neighbor_sem), outer_dim_size);
+            noc_semaphore_set(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(h_neighbor_sem), 0);
+        }
+    }
 }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_async/device/kernels/minimal_default_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_async/device/kernels/minimal_default_writer.cpp
@@ -13,12 +13,12 @@
 #include "tt_metal/fabric/hw/inc/tt_fabric_status.h"
 #include "tt_metal/fabric/hw/inc/packet_header_pool.h"
 #include "cpp/ttnn/operations/ccl/common/kernels/minimal_ccl_common.hpp"
+#include "tt_metal/fabric/hw/inc/linear/api.h"
 #include <cstdint>
 #include <utility>
 
 using address_t = uint32_t;
-using tt::tt_metal::BufferType;
-using ttnn::ccl::Topology;
+using namespace tt::tt_fabric::linear::experimental;
 
 constexpr bool is_first_chip = get_compile_time_arg_val(0);
 constexpr bool is_last_chip = get_compile_time_arg_val(1);
@@ -26,6 +26,19 @@ constexpr uint32_t cb_output_id = get_compile_time_arg_val(2);
 constexpr bool direction = get_compile_time_arg_val(3);
 constexpr bool is_padding_zeros = get_compile_time_arg_val(4);
 constexpr uint32_t stick_size = get_compile_time_arg_val(5);
+// Output TensorAccessorArgs start at index 6 (variable length)
+constexpr auto dst_ct_args = TensorAccessorArgs<6>();
+constexpr uint32_t ct_after_dst = dst_ct_args.next_compile_time_args_offset();
+constexpr bool use_l1_intermediate = get_compile_time_arg_val(ct_after_dst);
+constexpr uint32_t recv_cb_id = get_compile_time_arg_val(ct_after_dst + 1);
+constexpr bool handle_incoming_writes = get_compile_time_arg_val(ct_after_dst + 2);
+constexpr bool is_w_fabric_writer = get_compile_time_arg_val(ct_after_dst + 3);
+// Unicast route info: {dst_mesh_id, distance_in_hops} for 1D, {mesh_id, chip_id} for 2D
+constexpr auto unicast_route_info = ccl_routing_utils::get_line_unicast_route_info_from_args<ct_after_dst + 4>();
+// Barrier multicast route info (6 args) and ring_size for full-mesh startup barrier
+constexpr auto barrier_multicast_route_info =
+    ccl_routing_utils::get_line_multicast_route_info_from_args<ct_after_dst + 6>();
+constexpr uint32_t ring_size = get_compile_time_arg_val(ct_after_dst + 12);
 
 void kernel_main() {
     ///////////////////////////////////////////////////
@@ -44,65 +57,107 @@ void kernel_main() {
     const uint32_t padding_left = get_arg_val<uint32_t>(arg_idx++);
     const uint32_t num_sticks_to_read = get_arg_val<uint32_t>(arg_idx++);
     const uint32_t num_sticks_per_halo_dim = get_arg_val<uint32_t>(arg_idx++);
-    const uint8_t out_ready_sem_noc0_x = get_arg_val<uint32_t>(arg_idx++);
-    const uint8_t out_ready_sem_noc0_y = get_arg_val<uint32_t>(arg_idx++);
-    size_t out_ready_sem = get_arg_val<uint32_t>(arg_idx++);
+    const uint8_t neighbor_sem_noc0_x = get_arg_val<uint32_t>(arg_idx++);
+    const uint8_t neighbor_sem_noc0_y = get_arg_val<uint32_t>(arg_idx++);
+    size_t neighbor_sem = get_arg_val<uint32_t>(arg_idx++);
     bool use_barrier_sem = get_arg_val<uint32_t>(arg_idx++);
     const uint8_t barrier_sem_noc0_x = get_arg_val<uint32_t>(arg_idx++);
     const uint8_t barrier_sem_noc0_y = get_arg_val<uint32_t>(arg_idx++);
     size_t barrier_sem = get_arg_val<uint32_t>(arg_idx++);
-    const uint32_t target_device_offset = get_arg_val<uint32_t>(arg_idx++);
-    const uint32_t opposite_target_device_offset = get_arg_val<uint32_t>(arg_idx++);
+
+    // Phase 2 barrier signal targets (0 for 1D, >0 for 2D)
+    // Max targets = pad2_num_links * 2 directions (up to 8 W fabric cores)
+    constexpr uint32_t MAX_PHASE2_SIGNAL_TARGETS = 8;
+    const uint32_t num_phase2_signal_targets = get_arg_val<uint32_t>(arg_idx++);
+    uint8_t signal_noc_x[MAX_PHASE2_SIGNAL_TARGETS];
+    uint8_t signal_noc_y[MAX_PHASE2_SIGNAL_TARGETS];
+    uint32_t signal_sem_addr[MAX_PHASE2_SIGNAL_TARGETS];
+    for (uint32_t st = 0; st < MAX_PHASE2_SIGNAL_TARGETS; st++) {
+        signal_noc_x[st] = get_arg_val<uint32_t>(arg_idx++);
+        signal_noc_y[st] = get_arg_val<uint32_t>(arg_idx++);
+        signal_sem_addr[st] = get_arg_val<uint32_t>(arg_idx++);
+    }
     size_t arg_for_fab = arg_idx;
     auto fabric_connection = FabricConnectionManager::build_from_args(arg_for_fab);
 
-    uint32_t read_size = stick_size;
-    constexpr auto dst_args = TensorAccessorArgs<6>();
-    const auto dst_accessor = TensorAccessor(dst_args, output_tensor_address, stick_size);
+    const auto dst_accessor = TensorAccessor(dst_ct_args, output_tensor_address, stick_size);
 
-    // pre-populate packet headers
+    // L1 intermediate: discover the recv CB base address (same on neighbor device due to identical program)
+    uint32_t recv_buf_base = 0;
+    if constexpr (use_l1_intermediate) {
+        recv_buf_base = get_write_ptr(recv_cb_id);
+    }
+
+    // pre-populate packet headers with proper routing
     auto pkt_hdr = PacketHeaderPool::allocate_header();
-    pkt_hdr->to_chip_unicast(target_device_offset);
+    ccl_routing_utils::fabric_set_line_unicast_route(pkt_hdr, unicast_route_info);
     auto pkt_hdr_sem_inc = PacketHeaderPool::allocate_header();
 
-    fabric_connection.open();
+    // H writers: always open fabric at start (for data transfer in main loop).
+    // W writers: open at start only when startup barrier is enabled (defer data transfer until CB ready).
+    bool fabric_opened = false;
+    if (!is_w_fabric_writer || use_barrier_sem) {
+        fabric_connection.open();
+        fabric_opened = true;
+    }
 
-    // Barrier semaphore
+    // Startup barrier: full-mesh multicast sync.
+    // H writers: sync with all H-axis devices (same column).
+    // W writers: sync with all W-axis devices (same row).
+    // Together these transitively synchronize all devices in the mesh,
+    // ensuring the previous dispatch has completed before new fabric data is sent.
+    // Each direction's writer multicasts atomic inc to both same-direction and opposite-direction
+    // cores on all reachable devices. Every core waits for ring_size-1 total increments.
     if (use_barrier_sem) {
         auto pkt_hdr_barrier_sem_inc = PacketHeaderPool::allocate_header();
 
-        if (!is_last_chip) {
-            // unicast output ready semaphore
-            uint64_t barrier_sem_noc_addr_in_pkt =
-                safe_get_noc_addr(barrier_sem_noc0_x, barrier_sem_noc0_y, barrier_sem, 0);
-            pkt_hdr_barrier_sem_inc->to_noc_unicast_atomic_inc(tt::tt_fabric::NocUnicastAtomicIncCommandHeader{
-                barrier_sem_noc_addr_in_pkt, static_cast<uint32_t>(1)});  // increment 1
-            // Write the unicast packet
-            if (direction) {
-                if (fabric_connection.has_backward_connection()) {
-                    fabric_connection.get_backward_connection().wait_for_empty_write_slot();
-                    pkt_hdr_barrier_sem_inc->to_chip_unicast(opposite_target_device_offset);
-                    fabric_connection.get_backward_connection().send_payload_flush_blocking_from_address(
-                        (uint32_t)pkt_hdr_barrier_sem_inc, sizeof(PACKET_HEADER_TYPE));
-                }
+        if constexpr (!is_last_chip) {
+            // Set up multicast routing and atomic inc state
+            ccl_routing_utils::fabric_set_line_multicast_route(pkt_hdr_barrier_sem_inc, barrier_multicast_route_info);
+            fabric_multicast_noc_unicast_atomic_inc_set_state<
+                UnicastAtomicIncUpdateMask::Val | UnicastAtomicIncUpdateMask::Flush>(
+                pkt_hdr_barrier_sem_inc,
+                static_cast<uint8_t>(barrier_multicast_route_info.start_distance_in_hops),
+                static_cast<uint8_t>(barrier_multicast_route_info.range_hops),
+                tt::tt_fabric::NocUnicastAtomicIncCommandHeader{0, static_cast<uint32_t>(1)});
+
+            // Multicast to same-direction cores on all reachable devices
+            uint64_t same_dir_noc_addr = safe_get_noc_addr(neighbor_sem_noc0_x, neighbor_sem_noc0_y, barrier_sem, 0);
+            if constexpr (direction) {
+                fabric_multicast_noc_unicast_atomic_inc_with_state<UnicastAtomicIncUpdateMask::DstAddr>(
+                    &fabric_connection.get_backward_connection(),
+                    pkt_hdr_barrier_sem_inc,
+                    tt::tt_fabric::NocUnicastAtomicIncCommandHeader{same_dir_noc_addr, 0});
             } else {
-                if (fabric_connection.has_forward_connection()) {
-                    fabric_connection.get_forward_connection().wait_for_empty_write_slot();
-                    pkt_hdr_barrier_sem_inc->to_chip_unicast(opposite_target_device_offset);
-                    fabric_connection.get_forward_connection().send_payload_flush_blocking_from_address(
-                        (uint32_t)pkt_hdr_barrier_sem_inc, sizeof(PACKET_HEADER_TYPE));
-                }
+                fabric_multicast_noc_unicast_atomic_inc_with_state<UnicastAtomicIncUpdateMask::DstAddr>(
+                    &fabric_connection.get_forward_connection(),
+                    pkt_hdr_barrier_sem_inc,
+                    tt::tt_fabric::NocUnicastAtomicIncCommandHeader{same_dir_noc_addr, 0});
             }
-            noc_async_writes_flushed();
+
+            // Multicast to opposite-direction cores on all reachable devices
+            uint64_t opp_dir_noc_addr = safe_get_noc_addr(barrier_sem_noc0_x, barrier_sem_noc0_y, barrier_sem, 0);
+            if constexpr (direction) {
+                fabric_multicast_noc_unicast_atomic_inc_with_state<UnicastAtomicIncUpdateMask::DstAddr>(
+                    &fabric_connection.get_backward_connection(),
+                    pkt_hdr_barrier_sem_inc,
+                    tt::tt_fabric::NocUnicastAtomicIncCommandHeader{opp_dir_noc_addr, 0});
+            } else {
+                fabric_multicast_noc_unicast_atomic_inc_with_state<UnicastAtomicIncUpdateMask::DstAddr>(
+                    &fabric_connection.get_forward_connection(),
+                    pkt_hdr_barrier_sem_inc,
+                    tt::tt_fabric::NocUnicastAtomicIncCommandHeader{opp_dir_noc_addr, 0});
+            }
         }
 
-        if (!is_last_chip) {
-            noc_semaphore_wait_min(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(barrier_sem), 1);
+        if constexpr (ring_size > 1) {
+            noc_semaphore_wait_min(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(barrier_sem), ring_size - 1);
         }
         noc_semaphore_set(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(barrier_sem), 0);
     }
 
     uint32_t outer_dim_offset = outer_dim_offset_start_id;
+    uint32_t l1_buf_offset = 0;  // L1 intermediate: accumulates across all outer_dims (no reuse)
     for (uint32_t outer_dim = 0; outer_dim < outer_dim_size; outer_dim++) {
         if (is_first_chip) {
             if (!is_padding_zeros) {
@@ -116,6 +171,12 @@ void kernel_main() {
                 dst_stick_id += outer_dim_offset;
                 for (uint32_t iter = 0; iter < num_sticks_to_read; ++iter) {
                     cb_wait_front(cb_output_id, 1);
+                    if constexpr (is_w_fabric_writer) {
+                        if (!fabric_opened) {
+                            fabric_connection.open();
+                            fabric_opened = true;
+                        }
+                    }
                     uint32_t l1_read_addr = get_read_ptr(cb_output_id);
 
                     for (uint32_t pad_id = 0; pad_id < padding; pad_id++) {
@@ -137,6 +198,12 @@ void kernel_main() {
                 }
                 dst_stick_id += outer_dim_offset;
                 cb_wait_front(cb_output_id, 1);
+                if constexpr (is_w_fabric_writer) {
+                    if (!fabric_opened) {
+                        fabric_connection.open();
+                        fabric_opened = true;
+                    }
+                }
                 uint32_t l1_read_addr = get_read_ptr(cb_output_id);
                 for (uint32_t iter = 0; iter < num_sticks_to_read; ++iter) {
                     for (uint32_t pad_id = 0; pad_id < padding; pad_id++) {
@@ -165,9 +232,23 @@ void kernel_main() {
                 dst_stick_id += outer_dim_offset;
                 for (uint32_t iter = 0; iter < num_sticks_to_read; ++iter) {
                     cb_wait_front(cb_output_id, 1);
+                    if constexpr (is_w_fabric_writer) {
+                        if (!fabric_opened) {
+                            fabric_connection.open();
+                            fabric_opened = true;
+                        }
+                    }
                     uint32_t l1_read_addr = get_read_ptr(cb_output_id);
 
-                    uint64_t dst_noc_addr = get_noc_addr(dst_stick_id, dst_accessor, 0, 0);
+                    uint64_t dst_noc_addr;
+                    if constexpr (use_l1_intermediate) {
+                        // Target the receiver core's L1 buffer instead of DRAM
+                        dst_noc_addr = safe_get_noc_addr(
+                            neighbor_sem_noc0_x, neighbor_sem_noc0_y, recv_buf_base + l1_buf_offset, 0);
+                        l1_buf_offset += stick_size;
+                    } else {
+                        dst_noc_addr = get_noc_addr(dst_stick_id, dst_accessor, 0, 0);
+                    }
 
                     pkt_hdr->to_noc_unicast_write(tt::tt_fabric::NocUnicastCommandHeader{dst_noc_addr}, stick_size);
                     if (direction) {
@@ -193,20 +274,20 @@ void kernel_main() {
             }
 
             // unicast output ready semaphore
-            uint64_t out_ready_sem_noc_addr_in_pkt =
-                safe_get_noc_addr(out_ready_sem_noc0_x, out_ready_sem_noc0_y, out_ready_sem, 0);
+            uint64_t neighbor_sem_noc_addr_in_pkt =
+                safe_get_noc_addr(neighbor_sem_noc0_x, neighbor_sem_noc0_y, neighbor_sem, 0);
             pkt_hdr_sem_inc->to_noc_unicast_atomic_inc(tt::tt_fabric::NocUnicastAtomicIncCommandHeader{
-                out_ready_sem_noc_addr_in_pkt, static_cast<uint32_t>(1)});  // increment 1
+                neighbor_sem_noc_addr_in_pkt, static_cast<uint32_t>(1)});  // increment 1
             // Write the unicast packet
             if (direction) {
                 fabric_connection.get_backward_connection().wait_for_empty_write_slot();
-                pkt_hdr_sem_inc->to_chip_unicast(target_device_offset);
+                ccl_routing_utils::fabric_set_line_unicast_route(pkt_hdr_sem_inc, unicast_route_info);
                 fabric_connection.get_backward_connection().send_payload_flush_blocking_from_address(
                     (uint32_t)pkt_hdr_sem_inc, sizeof(PACKET_HEADER_TYPE));
 
             } else {
                 fabric_connection.get_forward_connection().wait_for_empty_write_slot();
-                pkt_hdr_sem_inc->to_chip_unicast(target_device_offset);
+                ccl_routing_utils::fabric_set_line_unicast_route(pkt_hdr_sem_inc, unicast_route_info);
                 fabric_connection.get_forward_connection().send_payload_flush_blocking_from_address(
                     (uint32_t)pkt_hdr_sem_inc, sizeof(PACKET_HEADER_TYPE));
             }
@@ -218,7 +299,52 @@ void kernel_main() {
         outer_dim_offset += (num_sticks_per_halo_dim * output_halo_dim_size);
     }
 
-    fabric_connection.close();
+    // Ensure all DRAM writes from main loop are complete.
+    noc_async_write_barrier();
 
+    // Incoming writes: pop sticks that the paired reader pushed from its L1 recv buffer
+    // (fabric-delivered padding from neighbor) and write to output DRAM.
+    // Used by both H fabric writers (incoming H halo) and W fabric writers (incoming W padding).
+    if constexpr (handle_incoming_writes) {
+        if (!is_first_chip) {
+            uint32_t inc_offset = outer_dim_offset_start_id;
+            for (uint32_t od = 0; od < outer_dim_size; od++) {
+                for (uint32_t pad_id = 0; pad_id < padding; pad_id++) {
+                    uint32_t row_offset;
+                    if (direction) {
+                        row_offset = (output_halo_dim_size - padding + pad_id) * num_sticks_per_halo_dim;
+                    } else {
+                        row_offset = pad_id * num_sticks_per_halo_dim;
+                    }
+                    uint32_t dst_stick_id = inc_offset + row_offset + stick_start_id;
+
+                    for (uint32_t iter = 0; iter < num_sticks_to_read; iter++) {
+                        cb_wait_front(cb_output_id, 1);
+                        uint32_t l1_read_addr = get_read_ptr(cb_output_id);
+                        uint64_t dst_noc_addr = get_noc_addr(dst_stick_id, dst_accessor);
+                        noc_async_write(l1_read_addr, dst_noc_addr, stick_size);
+
+                        noc_async_write_barrier();
+                        cb_pop_front(cb_output_id, 1);
+                        dst_stick_id++;
+                    }
+                }
+                inc_offset += num_sticks_per_halo_dim * output_halo_dim_size;
+            }
+        }
+    }
+
+    // Close fabric connection.
+    if (fabric_opened) {
+        noc_async_write_barrier();
+        fabric_connection.close();
+    }
+
+    // Signal Phase 2 AFTER fabric close and all work is complete.
+    noc_async_write_barrier();
+    for (uint32_t st = 0; st < num_phase2_signal_targets; st++) {
+        uint64_t sem_noc_addr = get_noc_addr(signal_noc_x[st], signal_noc_y[st], signal_sem_addr[st]);
+        noc_semaphore_inc(sem_noc_addr, 1);
+    }
     noc_async_write_barrier();
 }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_async/device/kernels/phase2_w_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_async/device/kernels/phase2_w_reader.cpp
@@ -1,0 +1,141 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Phase 2 W fabric reader for fused 2D neighbor pad.
+// Reads W boundary sticks directly from the output DRAM tensor (written by Phase 1)
+// instead of from an L1 boundary buffer. Phase 1 cores call noc_async_write_barrier()
+// before signaling the Phase 2 barrier semaphore, guaranteeing DRAM writes are committed.
+//
+// DRAM writes are handled by the paired writer (minimal_default_writer).
+
+#include "api/dataflow/dataflow_api.h"
+#include <tt-metalium/buffer_types.hpp>
+#include <cstdint>
+
+using address_t = uint32_t;
+
+constexpr bool is_first_chip = get_compile_time_arg_val(0);
+constexpr bool is_last_chip = get_compile_time_arg_val(1);
+constexpr uint32_t cb_output_id = get_compile_time_arg_val(2);
+constexpr bool direction = get_compile_time_arg_val(3);
+constexpr bool is_padding_zeros = get_compile_time_arg_val(4);
+constexpr uint32_t stick_size = get_compile_time_arg_val(5);
+// Output TensorAccessorArgs start at index 6 (variable length)
+constexpr auto dst_args = TensorAccessorArgs<6>();
+constexpr uint32_t ct_after_dst = dst_args.next_compile_time_args_offset();
+constexpr uint32_t recv_cb_id = get_compile_time_arg_val(ct_after_dst);
+
+template <uint32_t stick_size_bytes>
+inline void zeroPad(uint32_t cb_id) {
+    constexpr uint32_t num_full_reads = stick_size_bytes / MEM_ZEROS_SIZE;
+    constexpr uint32_t partial_read_size = stick_size_bytes % MEM_ZEROS_SIZE;
+    const uint64_t zeros_noc_addr = get_noc_addr(MEM_ZEROS_BASE);
+    uint32_t cb_write_addr = get_write_ptr(cb_id);
+
+    for (uint32_t i = 0; i < num_full_reads; ++i) {
+        noc_async_read(zeros_noc_addr, cb_write_addr, MEM_ZEROS_SIZE);
+        cb_write_addr += MEM_ZEROS_SIZE;
+    }
+    if (partial_read_size > 0) {
+        noc_async_read(zeros_noc_addr, cb_write_addr, partial_read_size);
+    }
+}
+
+void kernel_main() {
+    uint32_t arg_idx = 0;
+    const uint32_t outer_dim_size = get_arg_val<uint32_t>(arg_idx++);
+    const uint32_t outer_dim_start = get_arg_val<uint32_t>(arg_idx++);
+    const uint32_t padding = get_arg_val<uint32_t>(arg_idx++);
+    const uint32_t barrier_sem_addr = get_arg_val<uint32_t>(arg_idx++);
+    const uint32_t barrier_count = get_arg_val<uint32_t>(arg_idx++);
+    const uint32_t w_neighbor_sem_addr = get_arg_val<uint32_t>(arg_idx++);
+    const address_t output_tensor_address = get_arg_val<address_t>(arg_idx++);
+    const uint32_t output_row_width = get_arg_val<uint32_t>(arg_idx++);
+    const uint32_t pad2_left = get_arg_val<uint32_t>(arg_idx++);
+    const uint32_t num_interior_sticks = get_arg_val<uint32_t>(arg_idx++);
+
+    const auto dst_accessor = TensorAccessor(dst_args, output_tensor_address, stick_size);
+
+    // Wait for Phase 1 to complete.
+    if (barrier_count > 0) {
+        noc_semaphore_wait_min(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(barrier_sem_addr), barrier_count);
+        noc_semaphore_set(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(barrier_sem_addr), 0);
+    }
+
+    // Main loop: read boundary sticks from output DRAM → CB for the paired writer.
+    for (uint32_t outer_dim = 0; outer_dim < outer_dim_size; outer_dim++) {
+        uint32_t row_base = (outer_dim_start + outer_dim) * output_row_width;
+
+        if (is_first_chip) {
+            if (!is_padding_zeros) {
+                // Read one boundary stick from output DRAM; writer replicates it to all padding columns.
+                // direction=0: leftmost interior, direction=1: rightmost interior
+                uint32_t col;
+                if (direction) {
+                    col = pad2_left + num_interior_sticks - 1;
+                } else {
+                    col = pad2_left;
+                }
+                cb_reserve_back(cb_output_id, 1);
+                uint32_t dst_l1_addr = get_write_ptr(cb_output_id);
+                noc_async_read(get_noc_addr(row_base + col, dst_accessor), dst_l1_addr, stick_size);
+                noc_async_read_barrier();
+                cb_push_back(cb_output_id, 1);
+            } else {
+                cb_reserve_back(cb_output_id, 1);
+                zeroPad<stick_size>(cb_output_id);
+                noc_async_read_barrier();
+                cb_push_back(cb_output_id, 1);
+            }
+        }
+
+        if (!is_last_chip) {
+            // Read boundary sticks from output DRAM to send to neighbor
+            for (uint32_t pad_id = padding; pad_id > 0; pad_id--) {
+                uint32_t col;
+                if (direction) {
+                    // Send leftmost boundary: interior column (padding - pad_id)
+                    col = pad2_left + (padding - pad_id);
+                } else {
+                    // Send rightmost boundary: interior column (W - pad_id)
+                    col = pad2_left + num_interior_sticks - pad_id;
+                }
+                cb_reserve_back(cb_output_id, 1);
+                uint32_t dst_l1_addr = get_write_ptr(cb_output_id);
+                noc_async_read(get_noc_addr(row_base + col, dst_accessor), dst_l1_addr, stick_size);
+                noc_async_read_barrier();
+                cb_push_back(cb_output_id, 1);
+            }
+        }
+    }
+
+    // Incoming W padding from neighbor: wait for fabric data in L1 recv buffer, push to CB.
+    // The paired writer will pop from CB and write to output DRAM.
+    // Use per-outer_dim incremental sem waiting (matching H reader pattern) — each
+    // outer_dim's data is confirmed delivered before reading, rather than waiting
+    // for all at once. Uses cumulative waits (od+1) to avoid race where multiple
+    // sem_incs arrive between iterations.
+    if (!is_first_chip) {
+        volatile tt_l1_ptr uint32_t* w_neighbor_sem_ptr =
+            reinterpret_cast<volatile tt_l1_ptr uint32_t*>(w_neighbor_sem_addr);
+
+        uint32_t recv_buf_addr = get_write_ptr(recv_cb_id);
+        uint32_t buf_offset = 0;
+        for (uint32_t od = 0; od < outer_dim_size; od++) {
+            // Wait for this outer_dim's data using cumulative count
+            noc_semaphore_wait_min(w_neighbor_sem_ptr, od + 1);
+
+            for (uint32_t pad_id = 0; pad_id < padding; pad_id++) {
+                cb_reserve_back(cb_output_id, 1);
+                uint32_t dst_l1_addr = get_write_ptr(cb_output_id);
+                noc_async_read(get_noc_addr(recv_buf_addr + buf_offset), dst_l1_addr, stick_size);
+                noc_async_read_barrier();
+                cb_push_back(cb_output_id, 1);
+                buf_offset += stick_size;
+            }
+        }
+        // Reset after all waits complete (safe: no more fabric increments expected)
+        noc_semaphore_set(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(w_neighbor_sem_addr), 0);
+    }
+}

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_async/device/neighbor_pad_async_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_async/device/neighbor_pad_async_device_operation.cpp
@@ -14,7 +14,12 @@ using namespace tt::tt_metal;
 namespace ttnn::experimental::prim {
 void NeighborPadAsyncDeviceOperation::validate_on_program_cache_miss(
     const operation_attributes_t& args, const tensor_args_t& tensor_args) {
-    TT_FATAL(args.dim < 3, "Error, neighbor pad currently only supports padding non last dim, provided {}", args.dim);
+    const auto input_rank = tensor_args.input_tensor.padded_shape().size();
+    TT_FATAL(
+        args.dim < input_rank - 1,
+        "Error, neighbor pad only supports padding non-last dim, provided dim={} for rank-{} tensor",
+        args.dim,
+        input_rank);
 
     TT_FATAL(
         tensor_args.input_tensor.layout() == Layout::ROW_MAJOR,
@@ -71,6 +76,60 @@ void NeighborPadAsyncDeviceOperation::validate_on_program_cache_miss(
             args.secondary_mesh_shape.value().at(1),
             target_ring_size);
     }
+
+    // Validate secondary padding dimension (2D padding)
+    if (args.pad_dim2.has_value()) {
+        uint32_t dim2 = args.pad_dim2.value();
+        TT_FATAL(
+            dim2 < input_rank - 1,
+            "Secondary pad dim must be a non-last dim, provided dim2={} for rank-{} tensor",
+            dim2,
+            input_rank);
+        TT_FATAL(dim2 != args.dim, "Secondary pad dim {} must differ from primary pad dim {}", dim2, args.dim);
+        TT_FATAL(dim2 > args.dim, "Secondary pad dim {} must be greater than primary pad dim {}", dim2, args.dim);
+        TT_FATAL(
+            args.pad2_left <= input_tensor_shape[dim2] && args.pad2_right <= input_tensor_shape[dim2],
+            "Secondary padding values {} or {} exceed input tensor dim {} size {}.",
+            args.pad2_left,
+            args.pad2_right,
+            dim2,
+            input_tensor_shape[dim2]);
+        TT_FATAL(args.pad2_cluster_axis.has_value(), "pad2_cluster_axis required when pad_dim2 is set");
+        TT_FATAL(args.pad2_num_links > 0, "pad2_num_links must be > 0 when pad_dim2 is set");
+    }
+
+    // Validate preallocated output buffer if provided
+    if (tensor_args.preallocated_output.has_value()) {
+        const auto& output_tensor = tensor_args.preallocated_output.value();
+        TT_FATAL(output_tensor.storage_type() == StorageType::DEVICE, "Preallocated output tensor must be on device.");
+        TT_FATAL(
+            output_tensor.layout() == tensor_args.input_tensor.layout(),
+            "Preallocated output tensor layout {} must match input tensor layout {}.",
+            output_tensor.layout(),
+            tensor_args.input_tensor.layout());
+        TT_FATAL(
+            output_tensor.dtype() == tensor_args.input_tensor.dtype(),
+            "Preallocated output tensor dtype {} must match input tensor dtype {}.",
+            output_tensor.dtype(),
+            tensor_args.input_tensor.dtype());
+        TT_FATAL(
+            output_tensor.tensor_spec().page_config() == tensor_args.input_tensor.tensor_spec().page_config(),
+            "Preallocated output tensor page config must match input tensor page config.");
+        TT_FATAL(
+            output_tensor.memory_config() == args.output_mem_config,
+            "Preallocated output tensor memory config must match output_mem_config.");
+
+        auto expected_shape = tensor_args.input_tensor.logical_shape();
+        expected_shape[args.dim] += (args.padding_left + args.padding_right);
+        if (args.pad_dim2.has_value()) {
+            expected_shape[args.pad_dim2.value()] += (args.pad2_left + args.pad2_right);
+        }
+        TT_FATAL(
+            output_tensor.logical_shape() == expected_shape,
+            "Preallocated output tensor shape {} must match expected output shape {}.",
+            output_tensor.logical_shape(),
+            expected_shape);
+    }
 }
 
 TensorSpec NeighborPadAsyncDeviceOperation::compute_output_specs(
@@ -78,6 +137,9 @@ TensorSpec NeighborPadAsyncDeviceOperation::compute_output_specs(
     const auto& input_tensor = tensor_args.input_tensor;
     auto shape = input_tensor.logical_shape();
     shape[args.dim] += (args.padding_left + args.padding_right);
+    if (args.pad_dim2.has_value()) {
+        shape[args.pad_dim2.value()] += (args.pad2_left + args.pad2_right);
+    }
     return TensorSpec(
         shape, TensorLayout(input_tensor.dtype(), input_tensor.tensor_spec().page_config(), args.output_mem_config));
 }
@@ -106,6 +168,11 @@ tt::stl::hash::hash_t NeighborPadAsyncDeviceOperation::compute_program_hash(
         args.ring_size,
         args.secondary_cluster_axis,
         args.secondary_mesh_shape,
+        args.pad_dim2,
+        args.pad2_left,
+        args.pad2_right,
+        args.pad2_cluster_axis,
+        args.pad2_num_links,
         tensor_args);
 }
 
@@ -120,19 +187,25 @@ Tensor neighbor_pad_async(
     uint32_t padding_right,
     const std::string& padding_mode,
     uint32_t cluster_axis,
-    const GlobalSemaphore& final_semaphore,
+    const GlobalSemaphore& h_neighbor_semaphore,
+    const GlobalSemaphore& w_neighbor_semaphore,
     const GlobalSemaphore& barrier_semaphore,
     std::optional<size_t> num_preferred_links,
     const std::optional<MemoryConfig>& memory_config,
     std::optional<ttnn::ccl::Topology> topology,
     std::optional<uint32_t> secondary_cluster_axis,
-    const std::optional<std::vector<uint32_t>>& secondary_mesh_shape) {
+    const std::optional<std::vector<uint32_t>>& secondary_mesh_shape,
+    std::optional<uint32_t> pad_dim2,
+    uint32_t pad2_left,
+    uint32_t pad2_right,
+    std::optional<uint32_t> pad2_cluster_axis,
+    std::optional<size_t> pad2_num_links,
+    const std::optional<Tensor>& persistent_output_buffer) {
     using OperationType = ttnn::experimental::prim::NeighborPadAsyncDeviceOperation;
 
     auto* mesh_device = input_tensor.device();
-    uint32_t num_devices;
     const auto& mesh_view = mesh_device->get_view();
-    num_devices = (cluster_axis == 0) ? mesh_view.num_rows() : mesh_view.num_cols();
+    uint32_t num_devices = (cluster_axis == 0) ? mesh_view.num_rows() : mesh_view.num_cols();
 
     TT_FATAL(num_devices > 1, "neighbor_pad_async op will only work for num_devices > 1, but has {}", num_devices);
 
@@ -144,16 +217,24 @@ Tensor neighbor_pad_async(
         padding_right,
         padding_mode,
         cluster_axis,
-        final_semaphore,
+        h_neighbor_semaphore,
+        w_neighbor_semaphore,
         barrier_semaphore,
         num_preferred_links.value_or(1),
         memory_config.value_or(input_tensor.memory_config()),
         topology_,
         num_devices,
         secondary_cluster_axis,
-        secondary_mesh_shape);
+        secondary_mesh_shape,
+        pad_dim2,
+        pad2_left,
+        pad2_right,
+        pad2_cluster_axis,
+        pad2_num_links.value_or(0),
+        persistent_output_buffer.has_value());
 
-    auto tensor_args = OperationType::tensor_args_t{.input_tensor = input_tensor, .preallocated_output = std::nullopt};
+    auto tensor_args =
+        OperationType::tensor_args_t{.input_tensor = input_tensor, .preallocated_output = persistent_output_buffer};
 
     return ttnn::device_operation::launch<OperationType>(operation_attributes, tensor_args);
 }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_async/device/neighbor_pad_async_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_async/device/neighbor_pad_async_device_operation.hpp
@@ -39,12 +39,19 @@ Tensor neighbor_pad_async(
     uint32_t padding_right,
     const std::string& padding_mode,
     uint32_t cluster_axis,
-    const GlobalSemaphore& final_semaphore,
+    const GlobalSemaphore& h_neighbor_semaphore,
+    const GlobalSemaphore& w_neighbor_semaphore,
     const GlobalSemaphore& barrier_semaphore,
     std::optional<size_t> num_preferred_links,
     const std::optional<MemoryConfig>& memory_config,
     std::optional<ttnn::ccl::Topology> topology,
     std::optional<uint32_t> secondary_cluster_axis,
-    const std::optional<std::vector<uint32_t>>& secondary_mesh_shape);
+    const std::optional<std::vector<uint32_t>>& secondary_mesh_shape,
+    std::optional<uint32_t> pad_dim2 = std::nullopt,
+    uint32_t pad2_left = 0,
+    uint32_t pad2_right = 0,
+    std::optional<uint32_t> pad2_cluster_axis = std::nullopt,
+    std::optional<size_t> pad2_num_links = std::nullopt,
+    const std::optional<Tensor>& persistent_output_buffer = std::nullopt);
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_async/device/neighbor_pad_async_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_async/device/neighbor_pad_async_device_operation_types.hpp
@@ -20,14 +20,23 @@ struct NeighborPadAsyncParams {
     uint32_t padding_right = 0;
     std::string padding_mode;
     uint32_t cluster_axis = 0;
-    GlobalSemaphore final_semaphore;    // Not default constructible
-    GlobalSemaphore barrier_semaphore;  // Not default constructible
+    GlobalSemaphore h_neighbor_semaphore;  // Not default constructible
+    GlobalSemaphore w_neighbor_semaphore;  // Not default constructible
+    GlobalSemaphore barrier_semaphore;     // Not default constructible
     uint32_t num_links = 0;
     MemoryConfig output_mem_config;
     ttnn::ccl::Topology topology;
     uint32_t ring_size = 0;
     std::optional<uint32_t> secondary_cluster_axis;
     std::optional<std::vector<uint32_t>> secondary_mesh_shape;
+
+    // Secondary dimension for 2D padding (optional)
+    std::optional<uint32_t> pad_dim2;
+    uint32_t pad2_left = 0;
+    uint32_t pad2_right = 0;
+    std::optional<uint32_t> pad2_cluster_axis;
+    uint32_t pad2_num_links = 0;
+    bool using_persistent_buffers = false;
 
     // Constructor required because GlobalSemaphore is not default constructible
     NeighborPadAsyncParams(
@@ -36,27 +45,41 @@ struct NeighborPadAsyncParams {
         uint32_t padding_right,
         const std::string& padding_mode,
         uint32_t cluster_axis,
-        const GlobalSemaphore& final_semaphore,
+        const GlobalSemaphore& h_neighbor_semaphore,
+        const GlobalSemaphore& w_neighbor_semaphore,
         const GlobalSemaphore& barrier_semaphore,
         uint32_t num_links,
         MemoryConfig output_mem_config,
         ttnn::ccl::Topology topology,
         uint32_t ring_size,
         std::optional<uint32_t> secondary_cluster_axis,
-        const std::optional<std::vector<uint32_t>>& secondary_mesh_shape) :
+        const std::optional<std::vector<uint32_t>>& secondary_mesh_shape,
+        std::optional<uint32_t> pad_dim2 = std::nullopt,
+        uint32_t pad2_left = 0,
+        uint32_t pad2_right = 0,
+        std::optional<uint32_t> pad2_cluster_axis = std::nullopt,
+        uint32_t pad2_num_links = 0,
+        bool using_persistent_buffers = false) :
         dim(dim),
         padding_left(padding_left),
         padding_right(padding_right),
         padding_mode(padding_mode),
         cluster_axis(cluster_axis),
-        final_semaphore(final_semaphore),
+        h_neighbor_semaphore(h_neighbor_semaphore),
+        w_neighbor_semaphore(w_neighbor_semaphore),
         barrier_semaphore(barrier_semaphore),
         num_links(num_links),
         output_mem_config(std::move(output_mem_config)),
         topology(topology),
         ring_size(ring_size),
         secondary_cluster_axis(secondary_cluster_axis),
-        secondary_mesh_shape(secondary_mesh_shape ? std::make_optional(*secondary_mesh_shape) : std::nullopt) {}
+        secondary_mesh_shape(secondary_mesh_shape ? std::make_optional(*secondary_mesh_shape) : std::nullopt),
+        pad_dim2(pad_dim2),
+        pad2_left(pad2_left),
+        pad2_right(pad2_right),
+        pad2_cluster_axis(pad2_cluster_axis),
+        pad2_num_links(pad2_num_links),
+        using_persistent_buffers(using_persistent_buffers) {}
 
     auto attributes() const {
         using tt::stl::reflection::Attribute;
@@ -66,7 +89,8 @@ struct NeighborPadAsyncParams {
         attrs.emplace_back("padding_right", padding_right);
         attrs.emplace_back("padding_mode", padding_mode);
         attrs.emplace_back("cluster_axis", cluster_axis);
-        attrs.emplace_back("final_semaphore", final_semaphore);
+        attrs.emplace_back("h_neighbor_semaphore", h_neighbor_semaphore);
+        attrs.emplace_back("w_neighbor_semaphore", w_neighbor_semaphore);
         attrs.emplace_back("barrier_semaphore", barrier_semaphore);
         attrs.emplace_back("num_links", num_links);
         attrs.emplace_back("output_mem_config", output_mem_config);
@@ -74,6 +98,12 @@ struct NeighborPadAsyncParams {
         attrs.emplace_back("ring_size", ring_size);
         attrs.emplace_back("secondary_cluster_axis", secondary_cluster_axis);
         attrs.emplace_back("secondary_mesh_shape", secondary_mesh_shape);
+        attrs.emplace_back("pad_dim2", pad_dim2);
+        attrs.emplace_back("pad2_left", pad2_left);
+        attrs.emplace_back("pad2_right", pad2_right);
+        attrs.emplace_back("pad2_cluster_axis", pad2_cluster_axis);
+        attrs.emplace_back("pad2_num_links", pad2_num_links);
+        attrs.emplace_back("using_persistent_buffers", using_persistent_buffers);
         return attrs;
     }
 };

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_async/device/neighbor_pad_async_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_async/device/neighbor_pad_async_program_factory.cpp
@@ -37,6 +37,11 @@ NeighborPadAsyncMeshWorkloadFactory::cached_mesh_workload_t NeighborPadAsyncMesh
     tt::tt_metal::distributed::MeshWorkload mesh_workload;
     std::unordered_map<ttnn::MeshCoordinateRange, shared_variables_t> shared_variables;
 
+    // Synchronize all devices before dispatching neighbor_pad programs.
+    // This ensures all previous fabric-initiated writes (from prior ops) have completed.
+    auto* mesh_device = tensor_args.input_tensor.device();
+    tt::tt_metal::distributed::Synchronize(mesh_device, std::nullopt, {});
+
     // Create programs for each coordinate in tensor_coords
     for (const auto& mesh_coord_range : tensor_coords.ranges()) {
         for (const auto& mesh_coord : mesh_coord_range) {
@@ -75,14 +80,20 @@ void NeighborPadAsyncMeshWorkloadFactory::override_runtime_arguments(
                 auto& worker_reader_runtime_args = reader_runtime_args[core.x][core.y];
                 worker_reader_runtime_args[0] = input.buffer()->address();
                 worker_reader_runtime_args[1] = output.buffer()->address();
-                worker_reader_runtime_args[9] = operation_attributes.final_semaphore.address();
+                worker_reader_runtime_args[9] = operation_attributes.h_neighbor_semaphore.address();
 
                 // writer
                 auto& worker_writer_runtime_args = writer_runtime_args[core.x][core.y];
                 worker_writer_runtime_args[0] = input.buffer()->address();
                 worker_writer_runtime_args[1] = output.buffer()->address();
-                worker_writer_runtime_args[13] = operation_attributes.final_semaphore.address();
+                worker_writer_runtime_args[13] = operation_attributes.h_neighbor_semaphore.address();
+                worker_writer_runtime_args[14] = true;  // always enable startup barrier
                 worker_writer_runtime_args[17] = operation_attributes.barrier_semaphore.address();
+                // Phase 2 signal target sem addresses: 8 targets starting at index 19,
+                // sem addr at offset +2 within each 3-element group
+                for (uint32_t s = 0; s < 8; s++) {
+                    worker_writer_runtime_args[19 + (s * 3) + 2] = operation_attributes.barrier_semaphore.address();
+                }
 
                 core_idx++;
             }
@@ -100,10 +111,63 @@ void NeighborPadAsyncMeshWorkloadFactory::override_runtime_arguments(
             auto& worker_writer_runtime_args = writer_runtime_args[core.x][core.y];
             worker_writer_runtime_args[0] = input.buffer()->address();
             worker_writer_runtime_args[1] = output.buffer()->address();
+            // Phase 2 signal target sem addresses: 8 targets starting at index 11,
+            // sem addr at offset +2 within each 3-element group
+            for (uint32_t s = 0; s < 8; s++) {
+                worker_writer_runtime_args[11 + (s * 3) + 2] = operation_attributes.barrier_semaphore.address();
+            }
+        }
+
+        // W fabric workers (Phase 2, for 2D padding)
+        for (size_t i = 0; i < shared_vars.w_reader_kernel_ids.size(); ++i) {
+            CoreCoord core = shared_vars.w_fabric_core_coords[i];
+
+            // W reader (indices shifted +1 due to outer_dim_start at [1])
+            auto& reader_runtime_args = GetRuntimeArgs(program, shared_vars.w_reader_kernel_ids[i]);
+            auto& w_reader_args = reader_runtime_args[core.x][core.y];
+            w_reader_args[3] = operation_attributes.barrier_semaphore.address();
+            w_reader_args[5] = operation_attributes.w_neighbor_semaphore.address();
+            w_reader_args[6] = output.buffer()->address();
+
+            // W writer
+            auto& writer_runtime_args = GetRuntimeArgs(program, shared_vars.w_writer_kernel_ids[i]);
+            auto& w_writer_args = writer_runtime_args[core.x][core.y];
+            w_writer_args[0] = output.buffer()->address();
+            w_writer_args[1] = output.buffer()->address();
+            w_writer_args[13] = operation_attributes.w_neighbor_semaphore.address();
+            w_writer_args[14] = true;  // use_barrier_semaphore (W-axis startup barrier)
+            // Use h_neighbor_semaphore (not barrier_semaphore) — W reader on same core uses
+            // barrier_semaphore for Phase 2 barrier, so they must use different addresses.
+            w_writer_args[17] = operation_attributes.h_neighbor_semaphore.address();
         }
     }
 }
 
+// Fused 2D NeighborPad Algorithm (single op, two phases):
+//
+// Input: [B,T,H,W,C] fractured across 2D mesh (H across rows, W across columns)
+// Output: [B,T,H+2pH,W+2pW,C]
+//
+// Phase 0 — Startup barrier (multicast sync across all devices):
+//   H fabric writers multicast barrier with all H-axis devices (same column).
+//   W fabric writers multicast barrier with all W-axis devices (same row).
+//   Together these transitively synchronize all devices, ensuring the previous
+//   dispatch has completed before any new fabric data is sent.
+//
+// Phase 1 — Interior copy + H halo exchange (all ~120 cores active):
+//   Local copy cores: read input sticks → write to output DRAM at (h+pH, w+pW) offset.
+//   H fabric writer (BRISC): self-pad zeros/replicate to output DRAM for H pad rows,
+//     send H boundary data to neighbor via fabric.
+//   H fabric reader (NCRISC): receive H halo from fabric → L1 → output DRAM.
+//   All Phase 1 cores (local copy writers, H fabric writers, and H fabric readers)
+//     signal Phase 2 barrier on completion.
+//
+// Phase 2 — W halo exchange (2–8 W fabric cores, i.e. 2 × pad2_num_links):
+//   W reader: waits on Phase 2 barrier, then reads W boundary sticks from output DRAM
+//     (safe because Phase 1 calls noc_async_write_barrier() before signaling the barrier).
+//     Sends to neighbor via fabric or self-pads. Receives from neighbor → L1 → CB.
+//   W writer: pops from CB, writes self-pad and incoming W padding to output DRAM,
+//     sends W boundary data to neighbor via fabric.
 NeighborPadAsyncMeshWorkloadFactory::cached_program_t NeighborPadAsyncMeshWorkloadFactory::create_at(
     const NeighborPadAsyncParams& operation_attributes,
     const ttnn::MeshCoordinate& mesh_coordinate,
@@ -132,7 +196,10 @@ NeighborPadAsyncMeshWorkloadFactory::cached_program_t NeighborPadAsyncMeshWorklo
     Buffer* output_buffer = tensor_return_value.buffer();
 
     // Get OP Config, topology config
-    uint32_t page_size = tensor_args.input_tensor.buffer()->page_size();
+    // Use the buffer's aligned page size (architecture-specific: 32B on WH, 64B on BH).
+    // The interleaved address generator spaces pages at aligned_page_size intervals,
+    // so NOC transfers must use this size to avoid sub-minimum or misaligned reads.
+    uint32_t page_size = input_buffer->aligned_page_size();
     uint32_t num_sticks_per_halo_dim = 1;
     for (size_t d = operation_attributes.dim + 1; d < input_tensor_shape.size() - 1; d++) {
         num_sticks_per_halo_dim *= input_tensor_shape[d];
@@ -152,7 +219,7 @@ NeighborPadAsyncMeshWorkloadFactory::cached_program_t NeighborPadAsyncMeshWorklo
     if (operation_attributes.secondary_cluster_axis.has_value()) {
         // secondary_cluster_axis==1, devices on row
         // secondary_mesh_shape(0) == number of rows, (1) is number of cols
-        uint32_t secondary_cluster_axis_val = operation_attributes.secondary_cluster_axis.value_or((uint32_t)0);
+        uint32_t secondary_cluster_axis_val = operation_attributes.secondary_cluster_axis.value();
         uint32_t row_index = device_index / operation_attributes.secondary_mesh_shape.value().at(1);
         uint32_t col_index = device_index % operation_attributes.secondary_mesh_shape.value().at(1);
         if (secondary_cluster_axis_val) {
@@ -187,10 +254,94 @@ NeighborPadAsyncMeshWorkloadFactory::cached_program_t NeighborPadAsyncMeshWorklo
         }
     }
 
+    log_trace(
+        tt::LogOp,
+        "NeighborPad H-fabric: mesh_coord=({},{}), device_index={}, src_node_id={}, "
+        "fwd_offset={}, bwd_offset={}, is_first={}, is_last={}, cluster_axis={}",
+        mesh_coordinate[0],
+        mesh_coordinate[1],
+        device_index,
+        mesh_device->get_fabric_node_id(mesh_coordinate),
+        forward_device_offset,
+        backward_device_offset,
+        is_first_device,
+        is_last_device,
+        operation_attributes.cluster_axis);
+    if (forward_coord.has_value()) {
+        log_trace(
+            tt::LogOp,
+            "  forward_coord=({},{}), fwd_node_id={}",
+            (*forward_coord)[0],
+            (*forward_coord)[1],
+            mesh_device->get_fabric_node_id(forward_coord.value()));
+    }
+    if (backward_coord.has_value()) {
+        log_trace(
+            tt::LogOp,
+            "  backward_coord=({},{}), bwd_node_id={}",
+            (*backward_coord)[0],
+            (*backward_coord)[1],
+            mesh_device->get_fabric_node_id(backward_coord.value()));
+    }
+
     bool is_padding_zeros = operation_attributes.padding_mode == "zeros";
+    const bool is_2d = operation_attributes.pad_dim2.has_value();
+
+    // For 2D padding: compute secondary dimension metrics
+    uint32_t output_num_sticks_per_halo_dim = num_sticks_per_halo_dim;  // default: same as input
+    uint32_t writer_stick_start_id = 0;
+    uint32_t writer_num_sticks_to_read = num_sticks_per_halo_dim;
+    if (is_2d) {
+        // The output has extra W padding, so its row width is wider
+        output_num_sticks_per_halo_dim =
+            num_sticks_per_halo_dim + operation_attributes.pad2_left + operation_attributes.pad2_right;
+        writer_stick_start_id = operation_attributes.pad2_left;
+    }
 
     // Get worker cores
-    CoreCoord core_grid(operation_attributes.num_links * 2, 1);
+    constexpr uint32_t MAX_PAD2_NUM_LINKS = 4;  // kernel arrays sized for pad2_num_links * 2 = 8 targets
+
+    // Cap num_links and pad2_num_links so total fabric cores fit within the device compute grid width.
+    // WH has 8x8 logical grid vs BH's 14x10, so large link counts can exceed the grid.
+    auto compute_grid_size = mesh_device->compute_with_storage_grid_size();
+    uint32_t num_links = operation_attributes.num_links;
+    uint32_t pad2_num_links = operation_attributes.pad2_num_links;
+    uint32_t total_fabric_cores = (num_links * 2) + (is_2d ? pad2_num_links * 2 : 0);
+    if (total_fabric_cores > compute_grid_size.x) {
+        // Reduce pad2_num_links first (W-fabric), then num_links (H-fabric) if still too many
+        uint32_t max_total = compute_grid_size.x;
+        uint32_t h_cores = num_links * 2;
+        if (is_2d) {
+            uint32_t available_for_w = (max_total > h_cores) ? (max_total - h_cores) : 0;
+            pad2_num_links = available_for_w / 2;
+            if (pad2_num_links == 0) {
+                // H-fabric alone exceeds grid, reduce num_links too
+                pad2_num_links = 1;
+                num_links = (max_total - 2) / 2;  // reserve 2 cores for 1 W link
+            }
+        } else {
+            num_links = max_total / 2;
+        }
+        log_warning(
+            tt::LogOp,
+            "neighbor_pad_async: Capped num_links from {} to {} and pad2_num_links from {} to {} "
+            "to fit device compute grid width {}",
+            operation_attributes.num_links,
+            num_links,
+            operation_attributes.pad2_num_links,
+            pad2_num_links,
+            compute_grid_size.x);
+    }
+
+    uint32_t num_h_fabric_cores = num_links * 2;
+    uint32_t num_w_fabric_cores = is_2d ? (pad2_num_links * 2) : 0;
+    TT_FATAL(
+        pad2_num_links <= MAX_PAD2_NUM_LINKS,
+        "pad2_num_links ({}) exceeds maximum supported ({}). Kernel Phase 2 signal target arrays are sized for {}.",
+        pad2_num_links,
+        MAX_PAD2_NUM_LINKS,
+        MAX_PAD2_NUM_LINKS * 2);
+    CoreCoord core_grid(num_h_fabric_cores, 1);
     auto [num_cores, worker_core_ranges, core_group_1, core_group_2, dims_per_core_group_1, dims_per_core_group_2] =
         (operation_attributes.dim > 0) ? split_work_to_cores(core_grid, outer_dim_size * 2)
                                        : split_work_to_cores(core_grid, num_sticks_per_halo_dim * 2);
@@ -209,12 +360,127 @@ NeighborPadAsyncMeshWorkloadFactory::cached_program_t NeighborPadAsyncMeshWorklo
             .set_page_size(sender_cb_index, l1_scratch_cb_page_size_bytes);
     CreateCircularBuffer(program, worker_core_ranges, cb_sender_config);
 
+    // L1 receive buffer for 2D padding: fabric-delivered H halo data arrives here
+    // instead of going directly to DRAM, so the reader can copy it with proper barriers.
+    // Buffer must hold ALL outer_dims' sticks (no per-outer_dim reuse) because the
+    // fabric pipeline can deliver data for outer_dim N+1 before the reader finishes
+    // copying outer_dim N.
+    uint32_t recv_cb_index = tt::CB::c_in1;
+    if (is_2d) {
+        uint32_t max_padding = std::max(operation_attributes.padding_left, operation_attributes.padding_right);
+        uint32_t max_outer_dims_per_core = dims_per_core_group_1;
+        uint32_t recv_total_sticks = max_outer_dims_per_core * max_padding * writer_num_sticks_to_read;
+        uint32_t recv_buf_size = recv_total_sticks * page_size;
+        if (recv_buf_size > 0) {
+            CircularBufferConfig recv_cb_config =
+                CircularBufferConfig(recv_buf_size, {{recv_cb_index, df}}).set_page_size(recv_cb_index, page_size);
+            CreateCircularBuffer(program, worker_core_ranges, recv_cb_config);
+        }
+    }
+
+    // Phase 2 W-axis setup (for 2D padding)
+    std::vector<CoreCoord> w_fabric_logical_cores;
+    std::vector<CoreCoord> w_fabric_virtual_cores;
+    CoreRangeSet w_fabric_core_range;
+    bool is_first_w_device = true;
+    bool is_last_w_device = true;
+    uint32_t w_forward_device_offset = 0;
+    uint32_t w_backward_device_offset = 0;
+    std::optional<MeshCoordinate> w_forward_coord;
+    std::optional<MeshCoordinate> w_backward_coord;
+    uint32_t w_outer_dim_size = 0;
+    uint32_t max_w_padding = 0;
+    uint32_t w_rows_per_link = 0;
+    uint32_t w_extra_rows = 0;
+
+    if (is_2d) {
+        // W-axis device topology
+        w_forward_coord = ::ttnn::ccl::get_physical_neighbor_from_physical_coord(
+            tensor_args.input_tensor,
+            mesh_coordinate,
+            1,
+            ttnn::ccl::Topology::Linear,
+            operation_attributes.pad2_cluster_axis);
+        w_backward_coord = ::ttnn::ccl::get_physical_neighbor_from_physical_coord(
+            tensor_args.input_tensor,
+            mesh_coordinate,
+            -1,
+            ttnn::ccl::Topology::Linear,
+            operation_attributes.pad2_cluster_axis);
+
+        is_first_w_device = !w_backward_coord.has_value();
+        is_last_w_device = !w_forward_coord.has_value();
+        // W neighbors are physically adjacent (same row, adjacent columns) = 1 physical hop.
+        // The fabric chain chip_id difference can be much larger (e.g., 4 on a 4x8 mesh),
+        // but the EDM routing uses physical hops along the selected direction, NOT chain hops.
+        // Using the chain distance would cause packets to overshoot the target.
+        if (w_forward_coord.has_value()) {
+            w_forward_device_offset = 1;
+        }
+        if (w_backward_coord.has_value()) {
+            w_backward_device_offset = 1;
+        }
+
+        log_trace(
+            tt::LogOp,
+            "NeighborPad W-fabric: mesh_coord=({},{}), "
+            "w_fwd_offset={}, w_bwd_offset={}, is_first_w={}, is_last_w={}",
+            mesh_coordinate[0],
+            mesh_coordinate[1],
+            w_forward_device_offset,
+            w_backward_device_offset,
+            is_first_w_device,
+            is_last_w_device);
+
+        // W fabric core coordinates (placed after H fabric cores in first row)
+        for (uint32_t i = 0; i < num_w_fabric_cores; i++) {
+            CoreCoord wc = {num_h_fabric_cores + i, 0};
+            w_fabric_logical_cores.push_back(wc);
+            w_fabric_virtual_cores.push_back(mesh_device->worker_core_from_logical_core(wc));
+        }
+        w_fabric_core_range =
+            CoreRangeSet(CoreRange({num_h_fabric_cores, 0}, {num_h_fabric_cores + num_w_fabric_cores - 1, 0}));
+
+        // Phase 2 processes all rows of the H-padded output tensor
+        w_outer_dim_size = outer_dim_size * output_halo_dim_size;
+        max_w_padding = std::max(operation_attributes.pad2_left, operation_attributes.pad2_right);
+
+        // CB and recv buffer on W fabric cores
+        CreateCircularBuffer(program, w_fabric_core_range, cb_sender_config);
+
+        // L1 recv buffer on W fabric cores: fabric-delivered W padding data arrives here
+        // instead of going directly to DRAM. With multi-link, each link processes a subset
+        // of rows, so buffer is sized for the max per-link portion (not full w_outer_dim_size).
+        w_rows_per_link = w_outer_dim_size / pad2_num_links;
+        w_extra_rows = w_outer_dim_size % pad2_num_links;
+        uint32_t max_w_link_rows = w_rows_per_link + (w_extra_rows > 0 ? 1 : 0);
+        uint32_t w_recv_total_sticks = max_w_link_rows * max_w_padding;
+        uint32_t w_recv_buf_size = w_recv_total_sticks * page_size;
+        if (w_recv_buf_size > 0) {
+            CircularBufferConfig w_recv_cb_config =
+                CircularBufferConfig(w_recv_buf_size, {{recv_cb_index, df}}).set_page_size(recv_cb_index, page_size);
+            CreateCircularBuffer(program, w_fabric_core_range, w_recv_cb_config);
+        }
+    }
+
+    // Compute H fabric unicast route configuration (for compile-time args)
+    auto [h_unicast_forward_args, h_unicast_backward_args] =
+        ::ttnn::ccl::get_forward_backward_line_unicast_configuration(
+            mesh_coordinate, forward_coord, backward_coord, mesh_device);
+
+    // Compute H fabric multicast barrier route configuration
+    auto [num_targets_forward, num_targets_backward] = ::ttnn::ccl::get_forward_backward_line_mcast_distance(
+        operation_attributes.ring_size, device_index, operation_attributes.topology, false);
+    auto [h_mcast_forward_args, h_mcast_backward_args] = ::ttnn::ccl::get_forward_backward_line_mcast_configuration(
+        mesh_coordinate, forward_coord, backward_coord, num_targets_forward, num_targets_backward, mesh_device);
+
     // KERNEL CREATION
     std::vector<KernelHandle> reader_kernel_ids;
     std::vector<KernelHandle> writer_kernel_ids;
     uint32_t num_directions = 2;
     uint32_t link_offset_start_id = 0;
-    for (uint32_t link = 0; link < operation_attributes.num_links; link++) {
+    uint32_t writer_link_offset_start_id = 0;  // separate offset for writer (uses output row width)
+    for (uint32_t link = 0; link < num_links; link++) {
         uint32_t link_dims_to_read = 0;
 
         // direction 0 means pad left (top), 1 means pad right (bottom)
@@ -240,6 +506,8 @@ NeighborPadAsyncMeshWorkloadFactory::cached_program_t NeighborPadAsyncMeshWorklo
                 is_padding_zeros,
                 page_size};
             TensorAccessorArgs(*input_buffer).append_to(reader_kernel_config.compile_args);
+            reader_kernel_config.compile_args.push_back(is_2d ? 1 : 0);              // use_l1_intermediate
+            reader_kernel_config.compile_args.push_back(is_2d ? recv_cb_index : 0);  // recv_cb_id
             auto worker_reader_kernel_id = CreateKernel(
                 program,
                 "ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_async/device/kernels/"
@@ -258,9 +526,8 @@ NeighborPadAsyncMeshWorkloadFactory::cached_program_t NeighborPadAsyncMeshWorklo
                 (operation_attributes.dim > 0) ? link_dims_to_read : outer_dim_size,  // outer_dim_size
                 direction ? operation_attributes.padding_right : operation_attributes.padding_left,  // padding
                 (operation_attributes.dim == 0) ? link_dims_to_read : num_sticks_per_halo_dim,  // num_sticks_to_read
-                num_sticks_per_halo_dim,                        // num_sticks_per_halo_dim
-                operation_attributes.final_semaphore.address()  // out_ready_sem_bank_addr (absolute address)
-            };
+                num_sticks_per_halo_dim,  // num_sticks_per_halo_dim
+                operation_attributes.h_neighbor_semaphore.address()};
             SetRuntimeArgs(program, worker_reader_kernel_id, {core}, reader_rt_args);
 
             // Writer
@@ -273,6 +540,20 @@ NeighborPadAsyncMeshWorkloadFactory::cached_program_t NeighborPadAsyncMeshWorklo
                 is_padding_zeros,
                 page_size};
             TensorAccessorArgs(*output_buffer).append_to(writer_kernel_config.compile_args);
+            writer_kernel_config.compile_args.push_back(is_2d ? 1 : 0);              // use_l1_intermediate
+            writer_kernel_config.compile_args.push_back(is_2d ? recv_cb_index : 0);  // recv_cb_id
+            writer_kernel_config.compile_args.push_back(
+                is_2d ? 1 : 0);                              // handle_incoming_writes (H writer: yes for 2D)
+            writer_kernel_config.compile_args.push_back(0);  // is_w_fabric_writer (H writer: false)
+            // Unicast route args: select forward or backward based on direction
+            const auto& h_unicast_args = direction ? h_unicast_backward_args : h_unicast_forward_args;
+            writer_kernel_config.compile_args.insert(
+                writer_kernel_config.compile_args.end(), h_unicast_args.begin(), h_unicast_args.end());
+            // Barrier multicast route info (6 args) and ring_size for full-mesh startup barrier
+            const auto& h_mcast_args = direction ? h_mcast_backward_args : h_mcast_forward_args;
+            writer_kernel_config.compile_args.insert(
+                writer_kernel_config.compile_args.end(), h_mcast_args.begin(), h_mcast_args.end());
+            writer_kernel_config.compile_args.push_back(operation_attributes.ring_size);
             auto worker_writer_kernel_id = CreateKernel(
                 program,
                 "ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_async/device/kernels/"
@@ -281,28 +562,49 @@ NeighborPadAsyncMeshWorkloadFactory::cached_program_t NeighborPadAsyncMeshWorklo
                 writer_kernel_config);
             writer_kernel_ids.push_back(worker_writer_kernel_id);
 
+            // For 2D case, H fabric writer uses output row width and W offset
+            uint32_t h_writer_num_sticks_per_halo_dim =
+                is_2d ? output_num_sticks_per_halo_dim : num_sticks_per_halo_dim;
+            uint32_t h_writer_stick_start =
+                (operation_attributes.dim == 0) ? link_offset_start_id : writer_stick_start_id;
+            uint32_t h_writer_num_sticks_to_read =
+                (operation_attributes.dim == 0) ? link_dims_to_read : writer_num_sticks_to_read;
+
             std::vector<uint32_t> writer_rt_args = {
                 tensor_args.input_tensor.buffer()->address(),  // input_tensor_address
                 tensor_return_value.buffer()->address(),       // output_tensor_address
-                (operation_attributes.dim > 0) ? link_offset_start_id * output_halo_dim_size
-                                               : outer_dim_size - 1,  // link_offset_start_id
-                (operation_attributes.dim == 0) ? link_offset_start_id : 0,
+                (operation_attributes.dim > 0) ? writer_link_offset_start_id * output_halo_dim_size
+                                               : outer_dim_size - 1,                  // link_offset_start_id
+                h_writer_stick_start,                                                 // stick_start_id
                 input_halo_dim_size,                                                  // input_halo_dim_size
                 output_halo_dim_size,                                                 // output_halo_dim_size
                 (operation_attributes.dim > 0) ? link_dims_to_read : outer_dim_size,  // outer_dim_size
                 direction ? operation_attributes.padding_right : operation_attributes.padding_left,  // padding
                 operation_attributes.padding_left,                                                   // padding left
-                (operation_attributes.dim == 0) ? link_dims_to_read : num_sticks_per_halo_dim,  // num_sticks_to_read
-                num_sticks_per_halo_dim,                         // num_sticks_per_halo_dim
-                virtual_core.x,                                  // out_ready_sem_noc0_x
-                virtual_core.y,                                  // out_ready_sem_noc0_y
-                operation_attributes.final_semaphore.address(),  // out_ready_sem_bank_addr (absolute address)
-                true,                                            // use_barrier_semaphore
-                virtual_opposite_core.x,                         // barrier_sem_noc0_x
-                virtual_opposite_core.y,                         // barrier_sem_noc0_y
-                operation_attributes.barrier_semaphore.address(),
-                direction ? backward_device_offset : forward_device_offset,
-                direction ? backward_device_offset : forward_device_offset};
+                h_writer_num_sticks_to_read,                          // num_sticks_to_read
+                h_writer_num_sticks_per_halo_dim,                     // num_sticks_per_halo_dim
+                virtual_core.x,                                       // neighbor_sem_noc0_x
+                virtual_core.y,                                       // neighbor_sem_noc0_y
+                operation_attributes.h_neighbor_semaphore.address(),  // neighbor_sem_bank_addr
+                true,                                                 // use_barrier_semaphore
+                virtual_opposite_core.x,                              // barrier_sem_noc0_x
+                virtual_opposite_core.y,                              // barrier_sem_noc0_y
+                operation_attributes.barrier_semaphore.address()};
+            // Phase 2 signal targets (W fabric reader cores for 2D padding)
+            // Max targets = pad2_num_links * 2 directions (up to 8 W fabric cores)
+            constexpr uint32_t MAX_PHASE2_SIGNAL_TARGETS = 8;
+            writer_rt_args.push_back(is_2d ? num_w_fabric_cores : 0);
+            for (uint32_t s = 0; s < MAX_PHASE2_SIGNAL_TARGETS; s++) {
+                if (is_2d && s < num_w_fabric_cores) {
+                    writer_rt_args.push_back(w_fabric_virtual_cores[s].x);
+                    writer_rt_args.push_back(w_fabric_virtual_cores[s].y);
+                    writer_rt_args.push_back(operation_attributes.barrier_semaphore.address());
+                } else {
+                    writer_rt_args.push_back(0);
+                    writer_rt_args.push_back(0);
+                    writer_rt_args.push_back(0);
+                }
+            }
             if (direction) {
                 writer_rt_args.push_back(false);
                 writer_rt_args.push_back(backward_coord.has_value());
@@ -327,8 +629,11 @@ NeighborPadAsyncMeshWorkloadFactory::cached_program_t NeighborPadAsyncMeshWorklo
         }
         if (operation_attributes.dim > 0) {
             link_offset_start_id += (link_dims_to_read * num_sticks_per_halo_dim);
+            // Writer offset uses output row width (wider for 2D due to W padding)
+            writer_link_offset_start_id += (link_dims_to_read * output_num_sticks_per_halo_dim);
         } else {
             link_offset_start_id += link_dims_to_read;
+            writer_link_offset_start_id += link_dims_to_read;
         }
     }
 
@@ -337,9 +642,11 @@ NeighborPadAsyncMeshWorkloadFactory::cached_program_t NeighborPadAsyncMeshWorklo
     std::vector<KernelHandle> local_writer_kernel_ids;
     std::vector<CoreCoord> local_copy_core_coords;
     {
-        auto compute_grid = mesh_device->compute_with_storage_grid_size();
-        CoreRangeSet all_cores(CoreRange({0, 0}, {compute_grid.x - 1, compute_grid.y - 1}));
+        CoreRangeSet all_cores(CoreRange({0, 0}, {compute_grid_size.x - 1, compute_grid_size.y - 1}));
         CoreRangeSet fabric_cores = worker_core_ranges;
+        if (is_2d) {
+            fabric_cores = fabric_cores.merge(w_fabric_core_range);
+        }
         CoreRangeSet local_copy_cores = all_cores.subtract(fabric_cores);
 
         if (!local_copy_cores.empty()) {
@@ -405,25 +712,215 @@ NeighborPadAsyncMeshWorkloadFactory::cached_program_t NeighborPadAsyncMeshWorklo
                 local_writer_kernel_ids.push_back(local_writer_kernel_id);
 
                 // Writer runtime args
-                const uint32_t writer_total_rows_start = unit_offset;
-                const uint32_t writer_stick_start_id = 0;
-                const uint32_t writer_rows_count = units_for_core;
-                const uint32_t writer_num_sticks_to_read = num_sticks_per_halo_dim;
+                const uint32_t lw_total_rows_start = unit_offset;
+                const uint32_t lw_rows_count = units_for_core;
 
                 std::vector<uint32_t> local_writer_rt_args = {
                     tensor_args.input_tensor.buffer()->address(),  // input_tensor_address (unused by writer)
                     tensor_return_value.buffer()->address(),       // output_tensor_address
-                    writer_total_rows_start,
-                    writer_stick_start_id,
+                    lw_total_rows_start,
+                    writer_stick_start_id,  // pad2_left for 2D, 0 for 1D
                     input_halo_dim_size,
                     output_halo_dim_size,
-                    writer_rows_count,
+                    lw_rows_count,
                     operation_attributes.padding_left,
-                    writer_num_sticks_to_read,
-                    num_sticks_per_halo_dim};
+                    writer_num_sticks_to_read,        // original W sticks per row
+                    output_num_sticks_per_halo_dim};  // W+2pW for 2D, W for 1D
+                // Phase 2 signal targets (W fabric reader cores for 2D padding)
+                // Max targets = pad2_num_links * 2 directions (up to 8 W fabric cores)
+                constexpr uint32_t MAX_PHASE2_SIGNAL_TARGETS = 8;
+                local_writer_rt_args.push_back(is_2d ? num_w_fabric_cores : 0);
+                for (uint32_t s = 0; s < MAX_PHASE2_SIGNAL_TARGETS; s++) {
+                    if (is_2d && s < num_w_fabric_cores) {
+                        local_writer_rt_args.push_back(w_fabric_virtual_cores[s].x);
+                        local_writer_rt_args.push_back(w_fabric_virtual_cores[s].y);
+                        local_writer_rt_args.push_back(operation_attributes.barrier_semaphore.address());
+                    } else {
+                        local_writer_rt_args.push_back(0);
+                        local_writer_rt_args.push_back(0);
+                        local_writer_rt_args.push_back(0);
+                    }
+                }
                 SetRuntimeArgs(program, local_writer_kernel_id, {logical_core}, local_writer_rt_args);
 
                 unit_offset += units_for_core;
+            }
+        }
+    }
+
+    // Phase 2: W fabric kernel creation (for 2D padding)
+    std::vector<KernelHandle> w_reader_kernel_ids;
+    std::vector<KernelHandle> w_writer_kernel_ids;
+    if (is_2d) {
+        // Each H fabric writer and local copy writer signals Phase 2 exactly once,
+        // after ALL their work is complete (main loop + handle_incoming_writes).
+        uint32_t barrier_count = static_cast<uint32_t>(writer_kernel_ids.size() + local_writer_kernel_ids.size());
+        log_trace(
+            tt::LogOp,
+            "NeighborPad2D: barrier_count={} (h_writers={} local_writers={}), "
+            "w_outer_dim_size={}, is_first_h={}, is_last_h={}, is_first_w={}, is_last_w={}, "
+            "output_row_width={}, num_interior_sticks={}, pad2_left={}",
+            barrier_count,
+            writer_kernel_ids.size(),
+            local_writer_kernel_ids.size(),
+            w_outer_dim_size,
+            is_first_device,
+            is_last_device,
+            is_first_w_device,
+            is_last_w_device,
+            output_num_sticks_per_halo_dim,
+            num_sticks_per_halo_dim,
+            operation_attributes.pad2_left);
+
+        // W-axis startup barrier: compute ring size, device index, and multicast routes.
+        // W writers use this barrier to synchronize with all W-axis devices (same row),
+        // ensuring the previous dispatch has completed before sending new fabric data.
+        const auto& mesh_view_w = mesh_device->get_view();
+        uint32_t w_ring_size =
+            (operation_attributes.pad2_cluster_axis.value() == 0) ? mesh_view_w.num_rows() : mesh_view_w.num_cols();
+        uint32_t w_device_index = ::ttnn::ccl::get_linearized_index_from_physical_coord(
+            tensor_args.input_tensor, mesh_coordinate, operation_attributes.pad2_cluster_axis);
+        auto [w_num_targets_forward, w_num_targets_backward] = ::ttnn::ccl::get_forward_backward_line_mcast_distance(
+            w_ring_size, w_device_index, operation_attributes.topology, false);
+        auto [w_mcast_forward_args, w_mcast_backward_args] = ::ttnn::ccl::get_forward_backward_line_mcast_configuration(
+            mesh_coordinate,
+            w_forward_coord,
+            w_backward_coord,
+            w_num_targets_forward,
+            w_num_targets_backward,
+            mesh_device);
+
+        for (uint32_t w_link = 0; w_link < pad2_num_links; w_link++) {
+            // Per-link work distribution: split w_outer_dim_size rows across pad2_num_links
+            uint32_t w_link_start = (w_link * w_rows_per_link) + std::min(w_link, w_extra_rows);
+            uint32_t w_link_count = w_rows_per_link + (w_link < w_extra_rows ? 1 : 0);
+            log_trace(
+                tt::LogOp,
+                "NeighborPad2D W-link {}: start={}, count={} (of {})",
+                w_link,
+                w_link_start,
+                w_link_count,
+                w_outer_dim_size);
+
+            for (uint32_t w_direction = 0; w_direction < 2; w_direction++) {
+                uint32_t w_core_idx = (w_link * 2) + w_direction;
+                CoreCoord w_core = w_fabric_logical_cores[w_core_idx];
+                CoreCoord w_virtual_core = w_fabric_virtual_cores[w_core_idx];
+
+                // Phase 2 W reader kernel — reads boundary sticks from output DRAM.
+                auto w_reader_kernel_config = ReaderDataMovementConfig{};
+                w_reader_kernel_config.compile_args = {
+                    w_direction ? is_last_w_device : is_first_w_device,  // is_first_chip
+                    w_direction ? is_first_w_device : is_last_w_device,  // is_last_chip
+                    sender_cb_index,                                     // cb_output_id
+                    w_direction,                                         // direction
+                    is_padding_zeros,
+                    page_size};  // stick_size
+                TensorAccessorArgs(*output_buffer).append_to(w_reader_kernel_config.compile_args);
+                w_reader_kernel_config.compile_args.push_back(recv_cb_index);  // recv_cb_id
+                auto w_reader_kernel_id = CreateKernel(
+                    program,
+                    "ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_async/device/kernels/"
+                    "phase2_w_reader.cpp",
+                    {w_core},
+                    w_reader_kernel_config);
+                w_reader_kernel_ids.push_back(w_reader_kernel_id);
+
+                std::vector<uint32_t> w_reader_rt_args = {
+                    w_link_count,  // outer_dim_size (per-link)
+                    w_link_start,  // outer_dim_start (per-link)
+                    w_direction ? operation_attributes.pad2_right : operation_attributes.pad2_left,  // padding
+                    operation_attributes.barrier_semaphore.address(),                                // barrier_sem_addr
+                    barrier_count,
+                    operation_attributes.w_neighbor_semaphore.address(),
+                    tensor_return_value.buffer()->address(),  // output_tensor_address
+                    output_num_sticks_per_halo_dim,           // output_row_width (W + 2*pW)
+                    operation_attributes.pad2_left,           // pad2_left
+                    num_sticks_per_halo_dim};                 // num_interior_sticks (W)
+                SetRuntimeArgs(program, w_reader_kernel_id, {w_core}, w_reader_rt_args);
+
+                // Phase 2 W writer kernel (reuses minimal_default_writer)
+                auto w_writer_kernel_config = WriterDataMovementConfig{};
+                w_writer_kernel_config.compile_args = {
+                    w_direction ? is_last_w_device : is_first_w_device,
+                    w_direction ? is_first_w_device : is_last_w_device,
+                    sender_cb_index,
+                    w_direction,
+                    is_padding_zeros,
+                    page_size};
+                TensorAccessorArgs(*output_buffer).append_to(w_writer_kernel_config.compile_args);
+                w_writer_kernel_config.compile_args.push_back(1);              // use_l1_intermediate
+                w_writer_kernel_config.compile_args.push_back(recv_cb_index);  // recv_cb_id
+                w_writer_kernel_config.compile_args.push_back(1);              // handle_incoming_writes (W writer: yes)
+                w_writer_kernel_config.compile_args.push_back(1);              // is_w_fabric_writer (W writer: true)
+                // W fabric unicast route args: manually constructed with actual hop distances
+                // (standard get_forward_backward_line_unicast_configuration hardcodes distance=1 for 1D)
+                uint32_t w_device_offset = w_direction ? w_backward_device_offset : w_forward_device_offset;
+                w_writer_kernel_config.compile_args.push_back(0);                // dst_mesh_id (unused for 1D)
+                w_writer_kernel_config.compile_args.push_back(w_device_offset);  // distance_in_hops
+                // W barrier multicast route info (6 args) + ring_size for W-axis startup barrier
+                const auto& w_mcast_args = w_direction ? w_mcast_backward_args : w_mcast_forward_args;
+                w_writer_kernel_config.compile_args.insert(
+                    w_writer_kernel_config.compile_args.end(), w_mcast_args.begin(), w_mcast_args.end());
+                w_writer_kernel_config.compile_args.push_back(w_ring_size);
+                auto w_writer_kernel_id = CreateKernel(
+                    program,
+                    "ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_async/device/kernels/"
+                    "minimal_default_writer.cpp",
+                    {w_core},
+                    w_writer_kernel_config);
+                w_writer_kernel_ids.push_back(w_writer_kernel_id);
+
+                std::vector<uint32_t> w_writer_rt_args = {
+                    tensor_return_value.buffer()->address(),        // input_tensor_address (unused)
+                    tensor_return_value.buffer()->address(),        // output_tensor_address
+                    w_link_start * output_num_sticks_per_halo_dim,  // outer_dim_offset_start_id (per-link)
+                    0,                                              // stick_start_id
+                    num_sticks_per_halo_dim,                        // input_halo_dim_size (unused by writer)
+                    output_num_sticks_per_halo_dim,                 // output_halo_dim_size = W'
+                    w_link_count,                                   // outer_dim_size (per-link)
+                    w_direction ? operation_attributes.pad2_right : operation_attributes.pad2_left,  // padding
+                    operation_attributes.pad2_left,                                                  // padding_left
+                    1,                 // num_sticks_to_read
+                    1,                 // num_sticks_per_halo_dim
+                    w_virtual_core.x,  // neighbor_sem_noc0_x
+                    w_virtual_core.y,  // neighbor_sem_noc0_y
+                    operation_attributes.w_neighbor_semaphore.address(),
+                    true,  // use_barrier_semaphore (W writers: W-axis startup barrier)
+                    w_fabric_virtual_cores[(w_link * 2) + (1 - w_direction)].x,  // barrier_sem_noc0_x (opp W dir)
+                    w_fabric_virtual_cores[(w_link * 2) + (1 - w_direction)].y,  // barrier_sem_noc0_y (opp W dir)
+                    // Use h_neighbor_semaphore (not barrier_semaphore) for W startup barrier:
+                    // W reader (NCRISC) on the same core uses barrier_semaphore for Phase 2 barrier.
+                    // Using the same address would cause cross-contamination of increment counts.
+                    operation_attributes.h_neighbor_semaphore.address()};  // barrier_sem
+                // No Phase 2 signal targets (W writers ARE Phase 2)
+                constexpr uint32_t MAX_PHASE2_SIGNAL_TARGETS = 8;
+                w_writer_rt_args.push_back(0);
+                for (uint32_t s = 0; s < MAX_PHASE2_SIGNAL_TARGETS * 3; s++) {
+                    w_writer_rt_args.push_back(0);
+                }
+                // Fabric connection args: W neighbors are physically adjacent (1 hop via E/W
+                // ethernet), so append_fabric_connection_rt_args correctly finds them.
+                if (w_direction) {
+                    w_writer_rt_args.push_back(false);
+                    w_writer_rt_args.push_back(w_backward_coord.has_value());
+                    if (w_backward_coord.has_value()) {
+                        const auto src_fabric_node_id = mesh_device->get_fabric_node_id(mesh_coordinate);
+                        const auto dst_fabric_node_id = mesh_device->get_fabric_node_id(w_backward_coord.value());
+                        tt::tt_fabric::append_fabric_connection_rt_args(
+                            src_fabric_node_id, dst_fabric_node_id, w_link, program, {w_core}, w_writer_rt_args);
+                    }
+                } else {
+                    w_writer_rt_args.push_back(w_forward_coord.has_value());
+                    if (w_forward_coord.has_value()) {
+                        const auto src_fabric_node_id = mesh_device->get_fabric_node_id(mesh_coordinate);
+                        const auto dst_fabric_node_id = mesh_device->get_fabric_node_id(w_forward_coord.value());
+                        tt::tt_fabric::append_fabric_connection_rt_args(
+                            src_fabric_node_id, dst_fabric_node_id, w_link, program, {w_core}, w_writer_rt_args);
+                    }
+                    w_writer_rt_args.push_back(false);
+                }
+                SetRuntimeArgs(program, w_writer_kernel_id, {w_core}, w_writer_rt_args);
             }
         }
     }
@@ -436,8 +933,12 @@ NeighborPadAsyncMeshWorkloadFactory::cached_program_t NeighborPadAsyncMeshWorklo
             .local_reader_kernel_ids = std::move(local_reader_kernel_ids),
             .local_writer_kernel_ids = std::move(local_writer_kernel_ids),
             .local_copy_core_coords = std::move(local_copy_core_coords),
-            .num_links = operation_attributes.num_links,
-            .num_directions = num_directions});
+            .num_links = num_links,
+            .num_directions = num_directions,
+            .w_reader_kernel_ids = std::move(w_reader_kernel_ids),
+            .w_writer_kernel_ids = std::move(w_writer_kernel_ids),
+            .w_fabric_core_coords = std::move(w_fabric_logical_cores),
+            .num_w_links = is_2d ? pad2_num_links : 0});
 }
 
 }  // namespace ttnn::experimental::prim

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_async/device/neighbor_pad_async_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_async/device/neighbor_pad_async_program_factory.hpp
@@ -19,6 +19,11 @@ struct NeighborPadAsyncSharedVariables {
     std::vector<tt::tt_metal::CoreCoord> local_copy_core_coords;  // logical coords used for local copy
     uint32_t num_links = 0;
     uint32_t num_directions = 0;  // Always 2 (left/right padding)
+    // Phase 2 W fabric cores (for 2D padding)
+    std::vector<tt::tt_metal::KernelHandle> w_reader_kernel_ids;
+    std::vector<tt::tt_metal::KernelHandle> w_writer_kernel_ids;
+    std::vector<tt::tt_metal::CoreCoord> w_fabric_core_coords;
+    uint32_t num_w_links = 0;
 };
 
 struct NeighborPadAsyncMeshWorkloadFactory {

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_async/neighbor_pad_async.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_async/neighbor_pad_async.cpp
@@ -9,32 +9,86 @@ namespace ttnn::operations::experimental::ccl {
 
 ttnn::Tensor ExecuteNeighborPadAsync::invoke(
     const ttnn::Tensor& input_tensor,
-    int32_t dim,
-    uint32_t padding_left,
-    uint32_t padding_right,
+    std::vector<int32_t> dim,
+    std::vector<uint32_t> padding_left,
+    std::vector<uint32_t> padding_right,
     const std::string& padding_mode,
-    uint32_t cluster_axis,
-    const GlobalSemaphore& final_semaphore,
-    const GlobalSemaphore& barrier_semaphore,
-    std::optional<size_t> num_preferred_links,
+    std::vector<uint32_t> cluster_axis,
+    std::vector<GlobalSemaphore> neighbor_semaphore,
+    std::vector<GlobalSemaphore> barrier_semaphore,
+    const std::optional<std::vector<size_t>>& num_preferred_links,
     const std::optional<MemoryConfig>& memory_config,
     std::optional<ttnn::ccl::Topology> topology,
     std::optional<uint32_t> secondary_cluster_axis,
-    const std::optional<std::vector<uint32_t>>& secondary_mesh_shape) {
+    const std::optional<std::vector<uint32_t>>& secondary_mesh_shape,
+    const std::optional<ttnn::Tensor>& persistent_output_buffer) {
+    TT_FATAL(!dim.empty() && dim.size() <= 2, "dim must have 1 or 2 elements, got {}", dim.size());
+    const size_t num_dims = dim.size();
+    for (size_t i = 0; i < num_dims; i++) {
+        TT_FATAL(dim[i] >= 0, "dim[{}] must be non-negative, got {}", i, dim[i]);
+    }
+    TT_FATAL(
+        padding_left.size() == num_dims,
+        "padding_left size ({}) must match dim size ({})",
+        padding_left.size(),
+        num_dims);
+    TT_FATAL(
+        padding_right.size() == num_dims,
+        "padding_right size ({}) must match dim size ({})",
+        padding_right.size(),
+        num_dims);
+    TT_FATAL(
+        cluster_axis.size() == num_dims,
+        "cluster_axis size ({}) must match dim size ({})",
+        cluster_axis.size(),
+        num_dims);
+    TT_FATAL(!neighbor_semaphore.empty(), "neighbor_semaphore must not be empty");
+    TT_FATAL(!barrier_semaphore.empty(), "barrier_semaphore must not be empty");
+
+    std::vector<size_t> links = num_preferred_links.value_or(std::vector<size_t>(num_dims, 1));
+
+    // neighbor_semaphore[0] is always the H (primary) neighbor semaphore.
+    // neighbor_semaphore[1] is the W (secondary) neighbor semaphore for 2D padding.
+    // For 1D padding, reuse [0] as the W semaphore (it won't be used).
+    const auto& h_neighbor_sem = neighbor_semaphore[0];
+    const auto& w_neighbor_sem = neighbor_semaphore.size() >= 2 ? neighbor_semaphore[1] : neighbor_semaphore[0];
+
+    // Unpack secondary dimension if present
+    std::optional<uint32_t> pad_dim2;
+    uint32_t pad2_left = 0;
+    uint32_t pad2_right = 0;
+    std::optional<uint32_t> pad2_cluster_axis;
+    std::optional<size_t> pad2_num_links;
+
+    if (dim.size() == 2) {
+        pad_dim2 = static_cast<uint32_t>(dim[1]);
+        pad2_left = padding_left[1];
+        pad2_right = padding_right[1];
+        pad2_cluster_axis = cluster_axis[1];
+        pad2_num_links = links.size() >= 2 ? links[1] : 1;
+    }
+
     return ttnn::prim::neighbor_pad_async(
         input_tensor,
-        dim,
-        padding_left,
-        padding_right,
+        dim[0],
+        padding_left[0],
+        padding_right[0],
         padding_mode,
-        cluster_axis,
-        final_semaphore,
-        barrier_semaphore,
-        num_preferred_links,
+        cluster_axis[0],
+        h_neighbor_sem,
+        w_neighbor_sem,
+        barrier_semaphore[0],
+        links[0],
         memory_config,
         topology,
         secondary_cluster_axis,
-        secondary_mesh_shape);
+        secondary_mesh_shape,
+        pad_dim2,
+        pad2_left,
+        pad2_right,
+        pad2_cluster_axis,
+        pad2_num_links,
+        persistent_output_buffer);
 }
 
 }  // namespace ttnn::operations::experimental::ccl

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_async/neighbor_pad_async.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_async/neighbor_pad_async.hpp
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <vector>
+
 #include "ttnn/decorators.hpp"
 #include "ttnn/operations/ccl/ccl_host_datastructures.hpp"
 #include "ttnn/global_semaphore.hpp"
@@ -14,18 +16,19 @@ namespace operations::experimental::ccl {
 struct ExecuteNeighborPadAsync {
     static ttnn::Tensor invoke(
         const ttnn::Tensor& input_tensor,
-        int32_t dim,
-        uint32_t padding_left,
-        uint32_t padding_right,
+        std::vector<int32_t> dim,
+        std::vector<uint32_t> padding_left,
+        std::vector<uint32_t> padding_right,
         const std::string& padding_mode,
-        uint32_t cluster_axis,
-        const GlobalSemaphore& final_semaphore,
-        const GlobalSemaphore& barrier_semaphore,
-        std::optional<size_t> num_preferred_links = std::nullopt,
+        std::vector<uint32_t> cluster_axis,
+        std::vector<GlobalSemaphore> neighbor_semaphore,
+        std::vector<GlobalSemaphore> barrier_semaphore,
+        const std::optional<std::vector<size_t>>& num_preferred_links = std::nullopt,
         const std::optional<MemoryConfig>& memory_config = std::nullopt,
         std::optional<ttnn::ccl::Topology> topology = std::nullopt,
         std::optional<uint32_t> secondary_cluster_axis = std::nullopt,
-        const std::optional<std::vector<uint32_t>>& secondary_mesh_shape = std::nullopt);
+        const std::optional<std::vector<uint32_t>>& secondary_mesh_shape = std::nullopt,
+        const std::optional<ttnn::Tensor>& persistent_output_buffer = std::nullopt);
 };
 
 }  // namespace operations::experimental::ccl

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_async/neighbor_pad_async_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_async/neighbor_pad_async_nanobind.cpp
@@ -8,6 +8,7 @@
 
 #include <nanobind/nanobind.h>
 #include <nanobind/stl/optional.h>
+#include <nanobind/stl/vector.h>
 
 #include "ttnn-nanobind/decorators.hpp"
 #include "ttnn/operations/experimental/ccl/neighbor_pad_async/neighbor_pad_async.hpp"
@@ -32,14 +33,15 @@ void bind_neighbor_pad_async_op(nb::module_& mod, const ccl_operation_t& operati
             nb::arg("padding_right"),
             nb::arg("padding_mode"),
             nb::arg("cluster_axis"),
-            nb::arg("final_semaphore"),
+            nb::arg("neighbor_semaphore"),
             nb::arg("barrier_semaphore"),
             nb::kw_only(),
-            nb::arg("num_links") = 1,
+            nb::arg("num_links") = nb::none(),
             nb::arg("memory_config") = nb::none(),
-            nb::arg("topology") = ttnn::ccl::Topology::Linear,  // TODO_NANOBIND: cast?
+            nb::arg("topology") = ttnn::ccl::Topology::Linear,
             nb::arg("secondary_cluster_axis") = nb::none(),
-            nb::arg("secondary_mesh_shape") = nb::none()});
+            nb::arg("secondary_mesh_shape") = nb::none(),
+            nb::arg("persistent_output_buffer") = nb::none()});
 }
 
 }  // namespace
@@ -50,20 +52,23 @@ void bind_neighbor_pad_async(nb::module_& mod) {
         ttnn::experimental::neighbor_pad_async,
         R"doc(
 
-        Performs a halo-padding operation on multi-device input tensor, where the padding values come from the neighbor device's tensor when available, or as specified by padding mode when no neighbor device is present.
+        Performs a halo-padding operation on multi-device input tensor, where the padding values come from the neighbor device's tensor when available, or as specified by padding mode when no neighbor device is present. Supports 1D padding (single dim) or fused 2D padding (two dims in one dispatch).
 
         Args:
             input_tensor (ttnn.Tensor): multi-device tensor.
-            dim (int): Dimension to pad on.
-            padding_left (uint): How much to pad to the left (top).
-            padding_right (uint): How much to pad to the right (bottom).
-            padding_mode (string): replicate, constant, reflect.
-            cluster_axis (int): Provided a MeshTensor, the axis corresponding to MeshDevice to perform the neighbor_pad operation on.
+            dim (List[int]): Dimensions to pad on. Length 1 for 1D, length 2 for fused 2D (e.g., [2] or [2, 3]).
+            padding_left (List[uint]): How much to pad to the left, one per dim.
+            padding_right (List[uint]): How much to pad to the right, one per dim.
+            padding_mode (string): zeros, replicate.
+            cluster_axis (List[int]): Cluster axes for each padding dim.
+            neighbor_semaphore (List[GlobalSemaphore]): Neighbor semaphores, one per dim. Length 1 for 1D (H only), length 2 for fused 2D ([H, W]).
+            barrier_semaphore (List[GlobalSemaphore]): Barrier semaphores (length 1).
 
         Keyword Args:
-            num_links (int, optional): Number of links to use for the neighbor_pad operation. Defaults to `1`.
+            num_links (List[int], optional): Number of links per dim. Defaults to `[1, ...]`.
             memory_config (ttnn.MemoryConfig, optional): Memory configuration for the operation. Defaults to `input tensor memory config`.
             topology (ttnn.Topology, optional): The topology configuration to run the operation in. Valid options are Ring and Linear. Defaults to `ttnn.Topology.Linear`.
+            persistent_output_buffer (ttnn.Tensor, optional): Pre-allocated output buffer. When provided, skips the H writer startup barrier since the output buffer is guaranteed to exist on all devices. Defaults to `None`.
 
         Returns:
             ttnn.Tensor: the padded output tensor.

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/reduce_scatter_minimal_async_program.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/reduce_scatter_minimal_async_program.cpp
@@ -624,9 +624,9 @@ ReduceScatterProgramArtifacts build_ring_reduce_scatter_minimal_async_program_ar
     // Get OP Config, topology config
     uint32_t page_size = input_tensor.buffer()->page_size();
     auto [unicast_forward_args, unicast_backward_args] = ccl::get_forward_backward_line_unicast_configuration(
-        topology, sender_device_coord, forward_coord, backward_coord, mesh_device);
+        sender_device_coord, forward_coord, backward_coord, mesh_device);
     auto [mcast_forward_args, mcast_backward_args] = ccl::get_forward_backward_line_mcast_configuration(
-        topology, sender_device_coord, forward_coord, backward_coord, ring_size - 1, ring_size - 1, mesh_device);
+        sender_device_coord, forward_coord, backward_coord, ring_size - 1, ring_size - 1, mesh_device);
 
     const auto [all_core_range, all_cores] =
         choose_worker_cores(num_links, num_cores_per_link, mesh_device, sub_device_id, core_grid_offset);
@@ -1248,17 +1248,11 @@ ReduceScatterProgramArtifacts build_line_reduce_scatter_minimal_async_program_ar
     // Get OP Config, topology config
     uint32_t page_size = input_tensor.buffer()->page_size();
     auto [unicast_forward_args, unicast_backward_args] = ccl::get_forward_backward_line_unicast_configuration(
-        topology, sender_device_coord, forward_coord, backward_coord, mesh_device);
+        sender_device_coord, forward_coord, backward_coord, mesh_device);
     auto [num_targets_forward, num_targets_backward] =
         ccl::get_forward_backward_line_mcast_distance(ring_size, ring_index, topology, true);
     auto [mcast_forward_args, mcast_backward_args] = ccl::get_forward_backward_line_mcast_configuration(
-        topology,
-        sender_device_coord,
-        forward_coord,
-        backward_coord,
-        num_targets_forward,
-        num_targets_backward,
-        mesh_device);
+        sender_device_coord, forward_coord, backward_coord, num_targets_forward, num_targets_backward, mesh_device);
 
     uint32_t num_cores_per_link =
         operations::experimental::ccl::detail::reduce_scatter_minimal_async_core_count_per_link(

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/strided_all_gather_async/device/strided_all_gather_async_program.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/strided_all_gather_async/device/strided_all_gather_async_program.cpp
@@ -312,7 +312,7 @@ StridedAllGatherAsyncProgramFactory::strided_all_gather_async_minimal_default_he
     auto [num_targets_forward, num_targets_backward] =
         ttnn::ccl::get_forward_backward_line_mcast_distance(ring_size, ring_index, topology, false);
     auto [unicast_forward_args, unicast_backward_args] = ttnn::ccl::get_forward_backward_line_unicast_configuration(
-        topology, sender_device_coord, forward_coord, backward_coord, mesh_device);
+        sender_device_coord, forward_coord, backward_coord, mesh_device);
 
     const auto [all_core_range, all_cores] =
         ttnn::ccl::choose_worker_cores(num_links, num_cores_per_link, mesh_device, std::nullopt, core_grid_offset);

--- a/ttnn/cpp/ttnn/operations/experimental/conv3d/device/conv3d_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/conv3d/device/conv3d_device_operation.cpp
@@ -49,11 +49,15 @@ void Conv3dDeviceOperation::validate_on_program_cache_miss(
 
     // input and weight must both be interleaved, bfloat16
     TT_FATAL(!input_tensor_a.memory_config().is_sharded(), "Activation tensor must be interleaved.");
-    TT_FATAL(input_tensor_a.dtype() == DataType::BFLOAT16, "Activation tensor must be bfloat16.");
+    TT_FATAL(
+        input_tensor_a.dtype() == DataType::BFLOAT16 || input_tensor_a.dtype() == DataType::FLOAT32,
+        "Activation tensor must be bfloat16 of float32.");
 
     const auto& weight_tensor = tensor_args.weight_tensor;
     TT_FATAL(!weight_tensor.memory_config().is_sharded(), "Weight tensor must be interleaved.");
-    TT_FATAL(weight_tensor.dtype() == DataType::BFLOAT16, "Weight tensor must be bfloat16.");
+    TT_FATAL(
+        weight_tensor.dtype() == DataType::BFLOAT16 || weight_tensor.dtype() == DataType::FLOAT32,
+        "Weight tensor must be bfloat16 or float32.");
     TT_FATAL(weight_tensor.layout() == Layout::TILE, "Weight tensor must be tile.");
 
     if (tensor_args.bias_tensor.has_value()) {
@@ -61,7 +65,9 @@ void Conv3dDeviceOperation::validate_on_program_cache_miss(
         TT_FATAL(!bias_tensor.memory_config().is_sharded(), "Bias tensor must be interleaved.");
         TT_FATAL(bias_tensor.layout() == Layout::TILE, "Bias tensor must be tiled.");
         TT_FATAL(
-            bias_tensor.dtype() == DataType::BFLOAT16, "Bias tensor must be bfloat16. got {}", bias_tensor.dtype());
+            bias_tensor.dtype() == DataType::BFLOAT16 || bias_tensor.dtype() == DataType::FLOAT32,
+            "Bias tensor must be bfloat16 or float32. got {}",
+            bias_tensor.dtype());
         TT_FATAL(
             bias_tensor.logical_shape().size() == 2,
             "Bias tensor must have 2 dimensions. got {}",

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_program_factory.cpp
@@ -135,8 +135,10 @@ RingJointSDPAProgramFactory::cached_program_t RingJointSDPAProgramFactory::creat
 
     auto [num_targets_forward, num_targets_backward, dynamic_alternate] = ccl::get_forward_backward_configuration(
         args.all_gather_operation_attributes.ring_size, device_index, args.all_gather_operation_attributes.topology);
+    if (args.all_gather_operation_attributes.topology == ttnn::ccl::Topology::Ring && device_index % 2 == 0) {
+        std::swap(num_targets_forward, num_targets_backward);
+    }
 
-    // This is how ring_joint_sdpa expects the number of forward and backward writes
     uint32_t forward_writes_expected, backward_writes_expected;
     if (args.all_gather_operation_attributes.topology == ttnn::ccl::Topology::Linear) {
         forward_writes_expected = num_targets_backward;
@@ -145,8 +147,8 @@ RingJointSDPAProgramFactory::cached_program_t RingJointSDPAProgramFactory::creat
         TT_FATAL(
             args.all_gather_operation_attributes.topology == ttnn::ccl::Topology::Ring,
             "Topology must be Linear or Ring");
-        forward_writes_expected = num_targets_forward - 1;
-        backward_writes_expected = num_targets_backward - 1;
+        forward_writes_expected = num_targets_forward;
+        backward_writes_expected = num_targets_backward;
     }
     // Minimally use matmul fused op signaler
     sdpa_fused_op_signaler->init_all_gather(


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Provide context for the problem.

### What's changed
Describe the approach used to solve the problem.
Summarize the changes made and its impact.

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:{{branch_name}})
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:{{branch_name}})
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:{{branch_name}})
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:{{branch_name}})
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:{{branch_name}})
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:{{branch_name}})
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
