### PR TITLE
Fix ds_r1_qwen CI timeout by increasing pytest timeout from 600s to 1200s

### DIFF
--- a/tests/scripts/single_card/run_single_card_demo_tests.sh
+++ b/tests/scripts/single_card/run_single_card_demo_tests.sh
@@ -75,10 +75,10 @@ run_qwen25_vl_perfunc() {
 
 run_ds_r1_qwen_func() {
   ds_r1_qwen_14b=deepseek-ai/DeepSeek-R1-Distill-Qwen-14B
-  HF_MODEL=$ds_r1_qwen_14b MESH_DEVICE=N300 $PYTEST_CMD --timeout 600 models/tt_transformers/demo/simple_text_demo.py -k performance-ci-1
+  HF_MODEL=$ds_r1_qwen_14b MESH_DEVICE=N300 $PYTEST_CMD --timeout 1200 models/tt_transformers/demo/simple_text_demo.py -k performance-ci-1
 
   ds_r1_qwen_1_5b=deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B
-  HF_MODEL=$ds_r1_qwen_1_5b MESH_DEVICE=N300 $PYTEST_CMD --timeout 600 models/experimental/tt_transformers_v2/ds_r1_qwen.py
+  HF_MODEL=$ds_r1_qwen_1_5b MESH_DEVICE=N300 $PYTEST_CMD --timeout 1200 models/experimental/tt_transformers_v2/ds_r1_qwen.py
 }
 
 run_gemma3_func() {


### PR DESCRIPTION
### Ticket
N/A - Fixes CI failure in single-card demo tests

### Problem description
The `ds_r1_qwen-N300-func` CI job has been failing with a pytest timeout error:
```
FAILED ... - Failed: Timeout (>600.0s) from pytest-timeout.
```

Failed CI run: https://github.com/tenstorrent/tt-metal/actions/runs/22455352909/job/65036217973

### Root Cause Analysis
The initial suspicion was the Pydantic V1 deprecation warning in `models/common/llama_models.py`. However, after analyzing the full error log, this was a **red herring** - just a warning that appears during normal test execution, not the actual error.

The real issue is that the DeepSeek-R1-Distill-Qwen model tests take longer than 600 seconds (10 minutes) to complete. The test was still in the middle of model initialization (specifically creating sharded tensors in `ttnn.from_torch` for the MLP weights) when pytest killed it due to timeout.

### What's changed
- Increased pytest timeout for both ds_r1_qwen tests from 600s to 1200s (20 minutes):
  - `DeepSeek-R1-Distill-Qwen-14B` test via `simple_text_demo.py`
  - `DeepSeek-R1-Distill-Qwen-1.5B` test via `ds_r1_qwen.py`

### Checklist
- [x] ds_r1_qwen test specifically passes with new timeout
  - https://github.com/tenstorrent/tt-metal/actions/runs/22461561800 
