### PR TITLE
Adding additional DFB tests and an experimental api to bind DFB to kernels

### DIFF
--- a/tt_metal/api/tt-metalium/experimental/dataflow_buffer/dataflow_buffer.hpp
+++ b/tt_metal/api/tt-metalium/experimental/dataflow_buffer/dataflow_buffer.hpp
@@ -9,6 +9,7 @@
 
 #include <tt-metalium/core_coord.hpp>
 #include <tt-metalium/tile.hpp>
+#include <tt-metalium/kernel_types.hpp>
 
 #include "tt_metal/hw/inc/internal/dataflow_buffer_interface.h"
 
@@ -44,5 +45,9 @@ uint32_t CreateDataflowBuffer(
     Program& program,
     const std::variant<CoreCoord, CoreRange, CoreRangeSet>& core_spec,
     const DataflowBufferConfig& config);
+
+// Need to know which riscs the producer and consumer kernel run on to do tile counter and remapper allocation before a program is launched
+// This information may not be available to user at time of DFB creation so binding can be done explicitly after kernels are created
+void BindDataflowBufferToProducerConsumerKernels(Program& program, uint32_t dfb_id, KernelHandle producer_kernel_handle, KernelHandle consumer_kernel_handle);
 
 }  // namespace tt::tt_metal::experimental::dfb

--- a/tt_metal/hw/inc/internal/dataflow_buffer_interface.h
+++ b/tt_metal/hw/inc/internal/dataflow_buffer_interface.h
@@ -23,6 +23,8 @@ constexpr uint8_t NUM_REMAPPER_PAIRINGS = 64;
 constexpr uint8_t NUM_TXN_IDS = 4;
 constexpr uint8_t MAX_NUM_TILE_COUNTERS_TO_RR = 4;
 
+constexpr uint16_t TENSIX_RISC_OFFSET = 0x100;
+
 using PackedTileCounter = uint8_t;  // bits 5-6: tensix_id (2 bits), bits 0-4: counter_id (5 bits)
 
 // PackedTileCounter bit layout constants

--- a/tt_metal/impl/program/program_impl.hpp
+++ b/tt_metal/impl/program/program_impl.hpp
@@ -281,6 +281,8 @@ public:
 
     std::shared_ptr<CircularBufferImpl> get_circular_buffer(CBHandle cb_id) const;
 
+    std::shared_ptr<tt::tt_metal::experimental::dfb::detail::DataflowBufferImpl> get_dataflow_buffer(uint32_t dfb_id) const;
+
     // Ensures that statically allocated circular buffers do not grow into L1 buffer space
     void validate_circular_buffer_region(const IDevice* device);
     void validate_dataflow_buffer_region(const IDevice* device);


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/36899

### What's changed
Need to incrementally add DFB config tests being tracked [here](https://docs.google.com/spreadsheets/d/1MgSS7D0mwjHSPH2m879lDumbrRLUsEsvEysDOfQyOSo/edit?gid=231602419#gid=231602419)

Also adding an api to bind DFB to specific producer/consumer kernels so users don't need to query the riscs a kernel runs on 

### Checklist

- [x] New/Existing tests provide coverage for changes

