### PR TITLE
Break `small_vector.hpp` dependency on reflection.hpp

### DIFF
--- a/tests/tt_eager/tensors/test_host_device_loopback.cpp
+++ b/tests/tt_eager/tensors/test_host_device_loopback.cpp
@@ -4,6 +4,7 @@
 
 #include <cerrno>
 #include <fmt/base.h>
+#include <tt_stl/reflection.hpp>
 #include <tt-metalium/constants.hpp>
 #include <cstring>
 #include <exception>

--- a/tests/tt_metal/distributed/multiprocess/test_sanity.cpp
+++ b/tests/tt_metal/distributed/multiprocess/test_sanity.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <fmt/base.h>
+#include <numeric>
 #include <gtest/gtest.h>
 #include <gmock/gmock.h>
 

--- a/tests/tt_metal/multihost/fabric_tests/mesh_socket_test_context.cpp
+++ b/tests/tt_metal/multihost/fabric_tests/mesh_socket_test_context.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "tests/tt_metal/multihost/fabric_tests/mesh_socket_test_context.hpp"
+#include <tt_stl/reflection.hpp>
 #include "tests/tt_metal/multihost/fabric_tests/socket_send_recv_utils.hpp"
 
 #include <algorithm>

--- a/tests/tt_metal/multihost/fabric_tests/mesh_socket_yaml_parser.cpp
+++ b/tests/tt_metal/multihost/fabric_tests/mesh_socket_yaml_parser.cpp
@@ -4,6 +4,7 @@
 
 #include <fstream>
 #include <sstream>
+#include <tt_stl/reflection.hpp>
 #include <algorithm>
 #include <random>
 #include <set>

--- a/tests/tt_metal/tt_fabric/common/fabric_command_interface.cpp
+++ b/tests/tt_metal/tt_fabric/common/fabric_command_interface.cpp
@@ -1,6 +1,8 @@
 // SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
 // SPDX-License-Identifier: Apache-2.0
 
+#include <tt_stl/reflection.hpp>
+
 #include "fabric_command_interface.hpp"
 #include <tt-metalium/experimental/fabric/control_plane.hpp>
 #include "impl/context/metal_context.hpp"

--- a/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_1d_fabric.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_1d_fabric.cpp
@@ -4,6 +4,7 @@
 
 #include <chrono>
 #include <gtest/gtest.h>
+#include <tt_stl/reflection.hpp>
 #include <cstdint>
 #include <tt-metalium/experimental/fabric/control_plane.hpp>
 #include "hostdevcommon/fabric_common.h"

--- a/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_fabric_mux.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_fabric_mux.cpp
@@ -4,9 +4,11 @@
 
 #include <chrono>
 #include <gtest/gtest.h>
+#include <tt_stl/reflection.hpp>
 #include <cstdint>
 #include <vector>
 #include <algorithm>
+#include <numeric>
 #include <unordered_map>
 #include <string_view>
 #include <tt-metalium/experimental/fabric/control_plane.hpp>

--- a/tests/tt_metal/tt_fabric/system_health/test_system_health.cpp
+++ b/tests/tt_metal/tt_fabric/system_health/test_system_health.cpp
@@ -11,6 +11,7 @@
 #include <utility>
 
 #include <tt-logger/tt-logger.hpp>
+#include <tt_stl/reflection.hpp>
 #include <tt-metalium/experimental/fabric/control_plane.hpp>
 #include <tt-metalium/experimental/fabric/mesh_graph.hpp>
 #include "impl/context/metal_context.hpp"

--- a/tests/tt_metal/tt_metal/common/multi_device_fixture.hpp
+++ b/tests/tt_metal/tt_metal/common/multi_device_fixture.hpp
@@ -9,6 +9,7 @@
 
 #include <tt-metalium/experimental/fabric/fabric.hpp>
 #include <tt-metalium/host_api.hpp>
+#include <tt_stl/reflection.hpp>
 #include "llrt.hpp"
 #include "impl/context/metal_context.hpp"
 #include <tt-metalium/mesh_device.hpp>

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_event/test_EnqueueWaitForEvent.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_event/test_EnqueueWaitForEvent.cpp
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <tt_stl/reflection.hpp>
 #include <chrono>
 #include <fmt/base.h>
 #include <cstdint>

--- a/tests/tt_metal/tt_metal/integration/matmul/test_matmul_X_tile.cpp
+++ b/tests/tt_metal/tt_metal/integration/matmul/test_matmul_X_tile.cpp
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <tt_stl/reflection.hpp>
 #include <chrono>
 #include <fmt/base.h>
 #include <gtest/gtest.h>

--- a/tests/tt_metal/tt_metal/integration/matmul/test_matmul_large_block.cpp
+++ b/tests/tt_metal/tt_metal/integration/matmul/test_matmul_large_block.cpp
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <tt_stl/reflection.hpp>
 #include <chrono>
 #include <fmt/base.h>
 #include <gtest/gtest.h>

--- a/tests/tt_metal/tt_metal/llk/test_broadcast.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_broadcast.cpp
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <tt_stl/reflection.hpp>
 #include <chrono>
 #include <fmt/base.h>
 #include <gtest/gtest.h>

--- a/tests/tt_metal/tt_metal/llk/test_reduce.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_reduce.cpp
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <tt_stl/reflection.hpp>
 #include <chrono>
 #include <fmt/base.h>
 #include <gtest/gtest.h>

--- a/tests/tt_metal/tt_metal/llk/test_single_core_binary_compute.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_single_core_binary_compute.cpp
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <tt_stl/reflection.hpp>
 #include <chrono>
 #include <fmt/base.h>
 #include <gtest/gtest.h>

--- a/tests/tt_metal/tt_metal/llk/test_unary_broadcast.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_unary_broadcast.cpp
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <tt_stl/reflection.hpp>
 #include <chrono>
 #include <fmt/base.h>
 #include <gtest/gtest.h>

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/1_compute_mm/test_compute_mm.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/1_compute_mm/test_compute_mm.cpp
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <tt_stl/reflection.hpp>
 #include <chrono>
 #include <cerrno>
 #include <fmt/base.h>

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_tt_fabric.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_tt_fabric.cpp
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <tt_stl/reflection.hpp>
 #include <vector>
 #include <string>
 #include <unordered_map>

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_telemetry_manager.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_telemetry_manager.cpp
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <tt_stl/reflection.hpp>
 #include "tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_telemetry_manager.hpp"
 
 #include <array>

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_bandwidth_profiler.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_bandwidth_profiler.cpp
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <tt_stl/reflection.hpp>
 #include "tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_bandwidth_profiler.hpp"
 
 #include <algorithm>

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_bandwidth_results.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_bandwidth_results.cpp
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
+#include <tt_stl/reflection.hpp>
 #include "tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_bandwidth_results.hpp"
 
 #include <algorithm>

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_code_profiler.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_code_profiler.cpp
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <tt_stl/reflection.hpp>
 #include "tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_code_profiler.hpp"
 
 #include <array>

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_common_types.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_common_types.cpp
@@ -2,6 +2,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <tt_stl/reflection.hpp>
+#include <enchantum/enchantum.hpp>
 #include "tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_common_types.hpp"
 
 namespace tt::tt_fabric::fabric_tests {

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_config.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_config.cpp
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <tt_stl/reflection.hpp>
 #include "tt_fabric_test_config.hpp"
 #include <optional>
 #include <variant>

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_context.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_context.cpp
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <tt_stl/reflection.hpp>
 #include "tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_context.hpp"
 
 #include "impl/context/metal_context.hpp"

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_device_setup.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_device_setup.cpp
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <tt_stl/reflection.hpp>
 #include "tt_fabric_test_device_setup.hpp"
 
 namespace tt::tt_fabric::fabric_tests {

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_eth_readback.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_eth_readback.cpp
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <tt_stl/reflection.hpp>
 #include "tt_fabric_test_eth_readback.hpp"
 #include "impl/context/metal_context.hpp"
 

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_latency_results.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_latency_results.cpp
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <tt_stl/reflection.hpp>
 #include "tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_latency_results.hpp"
 
 #include <algorithm>

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_progress_monitor.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_progress_monitor.cpp
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <tt_stl/reflection.hpp>
 #include "tt_fabric_test_progress_monitor.hpp"
 
 #include <iomanip>

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_results.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/tt_fabric_test_results.cpp
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <tt_stl/reflection.hpp>
 #include <algorithm>
 #include <chrono>
 #include <cmath>

--- a/tests/tt_metal/tt_metal/test_transpose_hc.cpp
+++ b/tests/tt_metal/tt_metal/test_transpose_hc.cpp
@@ -2,11 +2,13 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <tt_stl/reflection.hpp>
 #include "common/device_fixture.hpp"
 
 #include <algorithm>
 #include <cmath>
 #include <cstdint>
+#include <numeric>
 #include <vector>
 
 #include <tt-metalium/bfloat16.hpp>

--- a/tests/ttnn/benchmark/cpp/operations/ternary/benchmark_where.cpp
+++ b/tests/ttnn/benchmark/cpp/operations/ternary/benchmark_where.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <benchmark/benchmark.h>
+#include <tt_stl/reflection.hpp>
 #include "ttnn/operations/experimental/where/where.hpp"
 #include "ttnn/operations/eltwise/ternary/ternary.hpp"
 #include "ttnn/device.hpp"

--- a/tests/ttnn/unit_tests/gtests/tensor/test_tensor_nd_sharding.cpp
+++ b/tests/ttnn/unit_tests/gtests/tensor/test_tensor_nd_sharding.cpp
@@ -3,6 +3,7 @@
 
 #include "gtest/gtest.h"
 
+#include <tt_stl/reflection.hpp>
 #include "ttnn/tensor/host_buffer/functions.hpp"
 #include "ttnn/tensor/tensor.hpp"
 #include "ttnn/operations/eltwise/binary/binary.hpp"

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -146,6 +146,9 @@ if(reflect_ADDED)
     add_library(reflect INTERFACE)
     add_library(Reflect::Reflect ALIAS reflect)
     target_include_directories(reflect SYSTEM INTERFACE "$<BUILD_INTERFACE:${reflect_SOURCE_DIR}>")
+    # Disable reflect's built-in static_assert self-tests.  They use unqualified
+    # `detail::` which is ambiguous when fmt::detail is also in scope.
+    target_compile_definitions(reflect INTERFACE NTEST)
 
     target_sources(
         reflect

--- a/tt-train/sources/ttml/nanobind/nb_util.hpp
+++ b/tt-train/sources/ttml/nanobind/nb_util.hpp
@@ -6,6 +6,8 @@
 
 #include <nanobind/ndarray.h>
 
+#include <source_location>
+
 #include "nb_fwd.hpp"
 #include "ttnn/distributed/distributed_tensor.hpp"
 #include "ttnn/tensor/tensor.hpp"

--- a/tt_metal/api/tt-metalium/experimental/fabric/mesh_graph.hpp
+++ b/tt_metal/api/tt-metalium/experimental/fabric/mesh_graph.hpp
@@ -13,6 +13,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <functional>
+#include <map>
 #include <string>
 #include <unordered_map>
 #include <utility>

--- a/tt_metal/api/tt-metalium/experimental/fabric/topology_mapper_utils.hpp
+++ b/tt_metal/api/tt-metalium/experimental/fabric/topology_mapper_utils.hpp
@@ -449,6 +449,6 @@ struct fmt::formatter<tt::tt_metal::experimental::tt_fabric::PhysicalExitNode> {
     auto format(const tt::tt_metal::experimental::tt_fabric::PhysicalExitNode& exit_node, format_context& ctx) const
         -> format_context::iterator {
         return fmt::format_to(
-            ctx.out(), "PhysicalExitNode(mesh_id={}, asic_id={})", exit_node.mesh_id.get(), exit_node.asic_id);
+            ctx.out(), "PhysicalExitNode(mesh_id={}, asic_id={})", exit_node.mesh_id.get(), exit_node.asic_id.get());
     }
 };

--- a/tt_metal/api/tt-metalium/experimental/tensor/tensor_types.hpp
+++ b/tt_metal/api/tt-metalium/experimental/tensor/tensor_types.hpp
@@ -53,7 +53,7 @@ consteval DataType convert_to_data_type() {
     } else if constexpr (std::is_same_v<T, ::bfloat16>) {
         return DataType::BFLOAT16;
     } else {
-        static_assert(tt::stl::concepts::always_false_v<T>, "Unsupported DataType!");
+        static_assert(sizeof(T) == 0, "Unsupported DataType!");
     }
 }
 

--- a/tt_metal/api/tt-metalium/graph_tracking.hpp
+++ b/tt_metal/api/tt-metalium/graph_tracking.hpp
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include <nlohmann/json.hpp>
+#include <nlohmann/json_fwd.hpp>
 #include <stdint.h>
 #include <any>
 #include <array>
@@ -12,7 +12,6 @@
 #include <memory>
 #include <mutex>
 #include <span>
-#include <sstream>
 #include <string>
 #include <string_view>
 #include <unordered_set>
@@ -36,92 +35,11 @@ struct TrackedArgument {
     std::string (*to_string_fn)(const std::any&);
 };
 
-// Serialization helpers for graph argument tracking.
-// The templates below rely on symbols from tt_stl/reflection.hpp (ttsl::reflection,
-// ttsl::is_specialization_v, ttsl::concepts::Reflectable, reflect::*).  These are
-// intentionally NOT included here to avoid pulling heavyweight headers into every
-// translation unit that includes graph_tracking.hpp.  The symbols are resolved at
-// template instantiation time via transitive includes in the calling TUs.
-namespace graph_detail {
-
-template <typename MemberT>
-void serialize_member(std::ostringstream& oss, const MemberT& member) {
-    if constexpr (std::is_enum_v<MemberT>) {
-        ttsl::reflection::operator<<(oss, member);
-    } else if constexpr (ttsl::is_specialization_v<MemberT, std::vector>) {
-        oss << "{";
-        for (size_t i = 0; i < member.size(); ++i) {
-            if (i > 0) {
-                oss << ", ";
-            }
-            serialize_member(oss, member[i]);
-        }
-        oss << "}";
-    } else if constexpr (ttsl::is_specialization_v<MemberT, std::optional>) {
-        if (member.has_value()) {
-            serialize_member(oss, member.value());
-        } else {
-            oss << "std::nullopt";
-        }
-    } else if constexpr (ttsl::is_specialization_v<MemberT, std::reference_wrapper>) {
-        serialize_member(oss, member.get());
-    } else if constexpr (ttsl::is_specialization_v<MemberT, std::pair>) {
-        oss << "{";
-        serialize_member(oss, member.first);
-        oss << ", ";
-        serialize_member(oss, member.second);
-        oss << "}";
-    } else if constexpr (requires { oss << member; }) {
-        oss << member;
-    } else if constexpr (ttsl::concepts::Reflectable<MemberT>) {
-        oss << reflect::type_name<MemberT>() << "(";
-        reflect::for_each(
-            [&oss, &member](auto I) {
-                if constexpr (I > 0) {
-                    oss << ", ";
-                }
-                serialize_member(oss, reflect::get<I>(member));
-            },
-            member);
-        oss << ")";
-    } else {
-        oss << "<" << reflect::type_name<MemberT>() << ">";
-    }
-}
-
-}  // namespace graph_detail
-
+// Forward declaration only – the definition lives in ttnn/graph/graph_serialization.hpp
+// which pulls in <reflect> and tt_stl/reflection.hpp.  This keeps the public API header
+// free of those heavyweight dependencies.
 template <typename T>
-std::string serialize_tracked_arg(const std::any& a) {
-    std::ostringstream oss;
-    const auto& ref = std::any_cast<const std::reference_wrapper<T>&>(a);
-    const auto& val = ref.get();
-    using CleanT = std::remove_cv_t<T>;
-
-    // Guard against incomplete types (e.g. forward-declared MeshCommandQueue)
-    // so that type traits below are never evaluated on them.
-    if constexpr (!requires { sizeof(CleanT); }) {
-        oss << "<incomplete type>";
-    } else if constexpr (ttsl::is_specialization_v<CleanT, std::vector>) {
-        ttsl::reflection::operator<<(oss, val);
-    } else if constexpr (requires { oss << val; }) {
-        oss << val;
-    } else if constexpr (ttsl::concepts::Reflectable<CleanT>) {
-        oss << reflect::type_name<CleanT>() << "(";
-        reflect::for_each(
-            [&oss, &val](auto I) {
-                if constexpr (I > 0) {
-                    oss << ", ";
-                }
-                graph_detail::serialize_member(oss, reflect::get<I>(val));
-            },
-            val);
-        oss << ")";
-    } else {
-        oss << "<" << reflect::type_name<T>() << ">";
-    }
-    return oss.str();
-}
+std::string serialize_tracked_arg(const std::any& a);
 
 class IGraphProcessor {
 public:
@@ -155,7 +73,7 @@ public:
 
     virtual void begin_capture(RunMode /*mode*/){};
 
-    virtual nlohmann::json end_capture() { return nullptr; };
+    virtual nlohmann::json end_capture();
 
     virtual ~IGraphProcessor() = default;
 };

--- a/tt_metal/api/tt-metalium/mesh_coord.hpp
+++ b/tt_metal/api/tt-metalium/mesh_coord.hpp
@@ -447,8 +447,8 @@ MeshContainer<T>::MeshContainer(const MeshShape& shape, std::vector<T> values) :
     shape_(shape), coord_range_(shape), values_(std::move(values)) {
     TT_FATAL(
         shape.mesh_size() == values_.size(),
-        "Shape and values size mismatch; shape: {}, values: {}",
-        shape,
+        "Shape and values size mismatch; shape mesh_size: {}, values size: {}",
+        shape.mesh_size(),
         values_.size());
 }
 

--- a/tt_metal/api/tt-metalium/program_descriptors.hpp
+++ b/tt_metal/api/tt-metalium/program_descriptors.hpp
@@ -133,7 +133,7 @@ struct ProgramDescriptor {
     KernelDescriptors kernels;
     SemaphoreDescriptors semaphores;
     CBDescriptors cbs;
-    std::optional<ttsl::hash::hash_t> custom_program_hash;
+    std::optional<std::uint64_t> custom_program_hash;
 
     std::optional<uint32_t> find_available_semaphore_id(const CoreCoord& core, CoreType core_type) const;
 };
@@ -153,9 +153,7 @@ ProgramDescriptor merge_program_descriptors(const std::vector<ProgramDescriptor>
 namespace std {
 template <>
 struct hash<tt::tt_metal::TileDescriptor> {
-    std::size_t operator()(const tt::tt_metal::TileDescriptor& tile_desc) const noexcept {
-        return tt::stl::hash::hash_objects_with_default_seed(tile_desc.height, tile_desc.width, tile_desc.transpose);
-    }
+    std::size_t operator()(const tt::tt_metal::TileDescriptor& tile_desc) const noexcept;
 };
 }  // namespace std
 

--- a/tt_metal/api/tt-metalium/shape.hpp
+++ b/tt_metal/api/tt-metalium/shape.hpp
@@ -75,6 +75,16 @@ std::size_t compute_flat_indices(tt::stl::Span<const uint32_t> indices, tt::stl:
 
 }  // namespace tt::tt_metal
 
+// Forward declarations of json trait templates (avoids pulling in reflection.hpp)
+namespace ttsl::json {
+template <typename T>
+struct to_json_t;
+template <typename T>
+struct from_json_t;
+}  // namespace ttsl::json
+
+#include <nlohmann/json_fwd.hpp>
+
 template <>
 struct ttsl::json::to_json_t<tt::tt_metal::Shape> {
     nlohmann::json operator()(const tt::tt_metal::Shape& shape) const;

--- a/tt_metal/common/shape.cpp
+++ b/tt_metal/common/shape.cpp
@@ -5,6 +5,7 @@
 #include "shape.hpp"
 
 #include <tt_stl/assert.hpp>
+#include <tt_stl/reflection.hpp>
 #include <tt_stl/small_vector.hpp>
 #include <functional>
 #include <numeric>

--- a/tt_metal/detail/reports/memory_reporter.cpp
+++ b/tt_metal/detail/reports/memory_reporter.cpp
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <tt_stl/reflection.hpp>
 #include "tt_metal/detail/reports/memory_reporter.hpp"
 
 #include <cstdint>

--- a/tt_metal/distributed/dispatch_context.cpp
+++ b/tt_metal/distributed/dispatch_context.cpp
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <tt_stl/reflection.hpp>
 #include <tt-metalium/experimental/dispatch_context.hpp>
 #include <tt-metalium/mesh_device.hpp>
 #include <tt-metalium/distributed_context.hpp>

--- a/tt_metal/distributed/distributed.cpp
+++ b/tt_metal/distributed/distributed.cpp
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <tt_stl/reflection.hpp>
 #include <tt-metalium/distributed.hpp>
 #include <utility>
 

--- a/tt_metal/distributed/distributed_coordinate_translator.cpp
+++ b/tt_metal/distributed/distributed_coordinate_translator.cpp
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <tt_stl/reflection.hpp>
 #include "tt_metal/distributed/distributed_coordinate_translator.hpp"
 
 #include <tt_stl/assert.hpp>

--- a/tt_metal/distributed/fd_mesh_command_queue.cpp
+++ b/tt_metal/distributed/fd_mesh_command_queue.cpp
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <tt_stl/reflection.hpp>
 #include "fd_mesh_command_queue.hpp"
 
 #include <tracy/Tracy.hpp>

--- a/tt_metal/distributed/mesh_command_queue_base.cpp
+++ b/tt_metal/distributed/mesh_command_queue_base.cpp
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <tt_stl/reflection.hpp>
 #include "mesh_command_queue_base.hpp"
 
 #include <mesh_device.hpp>

--- a/tt_metal/distributed/mesh_device.cpp
+++ b/tt_metal/distributed/mesh_device.cpp
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <tt_stl/reflection.hpp>
 #include <initializer_list>
 #include <tt-logger/tt-logger.hpp>
 #include <mesh_command_queue.hpp>

--- a/tt_metal/distributed/mesh_device_view.cpp
+++ b/tt_metal/distributed/mesh_device_view.cpp
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <tt_stl/reflection.hpp>
 #include <mesh_device.hpp>
 #include <mesh_device_view.hpp>
 #include "mesh_device_view_impl.hpp"

--- a/tt_metal/distributed/mesh_socket.cpp
+++ b/tt_metal/distributed/mesh_socket.cpp
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <tt_stl/reflection.hpp>
 #include "tt_metal/distributed/mesh_socket_utils.hpp"
 #include "impl/context/metal_context.hpp"
 #include <tt-metalium/distributed_context.hpp>

--- a/tt_metal/distributed/mesh_socket_utils.cpp
+++ b/tt_metal/distributed/mesh_socket_utils.cpp
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <tt_stl/reflection.hpp>
 #include "tt_metal/distributed/mesh_socket_utils.hpp"
 #include "tt_metal/distributed/mesh_socket_serialization.hpp"
 #include <tt-metalium/experimental/fabric/control_plane.hpp>

--- a/tt_metal/distributed/mesh_workload.cpp
+++ b/tt_metal/distributed/mesh_workload.cpp
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <tt_stl/reflection.hpp>
 #include <mesh_buffer.hpp>
 #include <mesh_command_queue.hpp>
 #include <mesh_workload.hpp>

--- a/tt_metal/distributed/mesh_workload_utils.cpp
+++ b/tt_metal/distributed/mesh_workload_utils.cpp
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <tt_stl/reflection.hpp>
 #include "device.hpp"
 #include "impl/context/metal_context.hpp"
 #include "dispatch/kernels/cq_commands.hpp"

--- a/tt_metal/distributed/sd_mesh_command_queue.cpp
+++ b/tt_metal/distributed/sd_mesh_command_queue.cpp
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <tt_stl/reflection.hpp>
 #include "sd_mesh_command_queue.hpp"
 #include "impl/context/metal_context.hpp"
 #include "tt_metal/common/thread_pool.hpp"

--- a/tt_metal/distributed/system_mesh.cpp
+++ b/tt_metal/distributed/system_mesh.cpp
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <tt_stl/reflection.hpp>
 #include <cstdint>
 #include <system_mesh.hpp>
 #include <tt-metalium/mesh_device_view.hpp>

--- a/tt_metal/distributed/system_mesh_translation_map.cpp
+++ b/tt_metal/distributed/system_mesh_translation_map.cpp
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <tt_stl/reflection.hpp>
 #include "tt_metal/distributed/system_mesh_translation_map.hpp"
 
 #include <unordered_set>

--- a/tt_metal/fabric/builder/fabric_builder_config.cpp
+++ b/tt_metal/fabric/builder/fabric_builder_config.cpp
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <tt_stl/reflection.hpp>
 #include "fabric_builder_config.hpp"
 #include "fabric_tensix_builder_impl.hpp"
 #include "tt_metal/fabric/fabric_context.hpp"

--- a/tt_metal/fabric/builder/fabric_static_sized_channels_allocator.cpp
+++ b/tt_metal/fabric/builder/fabric_static_sized_channels_allocator.cpp
@@ -11,6 +11,7 @@
 #include <enchantum/enchantum.hpp>
 #include <tt_stl/indestructible.hpp>
 #include <tt_stl/assert.hpp>
+#include <tt_stl/reflection.hpp>
 #include <algorithm>
 #include <numeric>
 

--- a/tt_metal/fabric/builder/router_connection_mapping.hpp
+++ b/tt_metal/fabric/builder/router_connection_mapping.hpp
@@ -5,6 +5,7 @@
 
 #include <cstdint>
 #include <map>
+#include <numeric>
 #include <optional>
 #include <vector>
 

--- a/tt_metal/fabric/erisc_datamover_builder.cpp
+++ b/tt_metal/fabric/erisc_datamover_builder.cpp
@@ -6,6 +6,7 @@
 
 #include <cstdint>
 #include <tt_stl/assert.hpp>
+#include <tt_stl/reflection.hpp>
 #include <tt-metalium/experimental/fabric/control_plane.hpp>
 #include <tt-metalium/device.hpp>
 #include "erisc_datamover_builder.hpp"

--- a/tt_metal/fabric/fabric.cpp
+++ b/tt_metal/fabric/fabric.cpp
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <tt_stl/reflection.hpp>
 #include <cstdint>
 #include <tt-metalium/core_coord.hpp>
 #include "erisc_datamover_builder.hpp"

--- a/tt_metal/fabric/fabric_builder_context.cpp
+++ b/tt_metal/fabric/fabric_builder_context.cpp
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <tt_stl/reflection.hpp>
 #include "tt_metal/fabric/fabric_builder_context.hpp"
 #include "tt_metal/fabric/fabric_context.hpp"
 #include "tt_metal/fabric/fabric_router_channel_mapping.hpp"

--- a/tt_metal/fabric/mesh_graph_descriptor.cpp
+++ b/tt_metal/fabric/mesh_graph_descriptor.cpp
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <tt_stl/reflection.hpp>
 #include <stdexcept>
 #include <fstream>
 #include <sstream>

--- a/tt_metal/graph/graph_tracking.cpp
+++ b/tt_metal/graph/graph_tracking.cpp
@@ -4,6 +4,7 @@
 
 #include <graph_tracking.hpp>
 
+#include <nlohmann/json.hpp>
 #include <tt_stl/assert.hpp>
 
 namespace tt::tt_metal {
@@ -12,6 +13,8 @@ class IDevice;
 }  // namespace tt::tt_metal
 
 namespace tt::tt_metal {
+
+nlohmann::json IGraphProcessor::end_capture() { return nullptr; }
 
 GraphTracker& GraphTracker::instance() {
     static GraphTracker tracker;

--- a/tt_metal/impl/context/metal_context.cpp
+++ b/tt_metal/impl/context/metal_context.cpp
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <tt_stl/reflection.hpp>
 #include <cstdint>
 #include <filesystem>
 #include <algorithm>

--- a/tt_metal/impl/dataflow_buffer/dataflow_buffer.cpp
+++ b/tt_metal/impl/dataflow_buffer/dataflow_buffer.cpp
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <tt_stl/reflection.hpp>
 #include <tt-metalium/experimental/dataflow_buffer/dataflow_buffer.hpp>
 
 #include <algorithm>

--- a/tt_metal/impl/debug/dprint_server.cpp
+++ b/tt_metal/impl/debug/dprint_server.cpp
@@ -28,6 +28,7 @@
 #include <tt-logger/tt-logger.hpp>
 #include "impl/data_format/blockfloat_common.hpp"
 #include <tt_stl/assert.hpp>
+#include <tt_stl/reflection.hpp>
 #include <umd/device/types/core_coordinates.hpp>
 #include <umd/device/soc_descriptor.hpp>
 #include <umd/device/types/xy_pair.hpp>

--- a/tt_metal/impl/debug/inspector/data.cpp
+++ b/tt_metal/impl/debug/inspector/data.cpp
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <tt_stl/reflection.hpp>
 #include "data.hpp"
 #include <stdexcept>
 #include "rpc_server_controller.hpp"

--- a/tt_metal/impl/debug/inspector/inspector.cpp
+++ b/tt_metal/impl/debug/inspector/inspector.cpp
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <tt_stl/reflection.hpp>
 #include "inspector.hpp"
 #include "impl/context/metal_context.hpp"
 #include "impl/debug/inspector/data.hpp"

--- a/tt_metal/impl/debug/inspector/logger.cpp
+++ b/tt_metal/impl/debug/inspector/logger.cpp
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <tt_stl/reflection.hpp>
 #include "impl/debug/inspector/logger.hpp"
 #include "impl/debug/inspector/types.hpp"
 #include "impl/context/metal_context.hpp"

--- a/tt_metal/impl/debug/noc_logging.cpp
+++ b/tt_metal/impl/debug/noc_logging.cpp
@@ -11,6 +11,7 @@
 #include <string>
 
 #include <tt_stl/assert.hpp>
+#include <tt_stl/reflection.hpp>
 #include "core_coord.hpp"
 #include "debug_helpers.hpp"
 #include "hostdevcommon/dprint_common.h"

--- a/tt_metal/impl/debug/watcher_device_reader.cpp
+++ b/tt_metal/impl/debug/watcher_device_reader.cpp
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <tt_stl/reflection.hpp>
 #include <algorithm>
 #include <cstddef>
 #include <cstdint>

--- a/tt_metal/impl/debug/watcher_server.cpp
+++ b/tt_metal/impl/debug/watcher_server.cpp
@@ -21,6 +21,7 @@
 #include <vector>
 
 #include <tt_stl/assert.hpp>
+#include <tt_stl/reflection.hpp>
 #include "core_coord.hpp"
 #include "api/debug/ring_buffer.h"
 #include "debug_helpers.hpp"

--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <tt_stl/reflection.hpp>
 #include "device_impl.hpp"
 
 #include <core_descriptor.hpp>

--- a/tt_metal/impl/device/firmware/fabric_firmware_initializer.cpp
+++ b/tt_metal/impl/device/firmware/fabric_firmware_initializer.cpp
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <tt_stl/reflection.hpp>
 #include "fabric_firmware_initializer.hpp"
 
 #include <chrono>

--- a/tt_metal/impl/dispatch/data_collection.cpp
+++ b/tt_metal/impl/dispatch/data_collection.cpp
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <tt_stl/reflection.hpp>
 #include "data_collection.hpp"
 
 #include <cstdint>

--- a/tt_metal/impl/dispatch/data_collector.cpp
+++ b/tt_metal/impl/dispatch/data_collector.cpp
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <tt_stl/reflection.hpp>
 #include "data_collector.hpp"
 #include <enchantum/enchantum.hpp>
 #include <enchantum/generators.hpp>

--- a/tt_metal/impl/dispatch/debug_tools.cpp
+++ b/tt_metal/impl/dispatch/debug_tools.cpp
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <tt_stl/reflection.hpp>
 #include "debug_tools.hpp"
 
 #include <cstdint>

--- a/tt_metal/impl/dispatch/hardware_command_queue.cpp
+++ b/tt_metal/impl/dispatch/hardware_command_queue.cpp
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <tt_stl/reflection.hpp>
 #include "hardware_command_queue.hpp"
 
 #include <device.hpp>

--- a/tt_metal/impl/dispatch/host_runtime_commands.cpp
+++ b/tt_metal/impl/dispatch/host_runtime_commands.cpp
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <tt_stl/reflection.hpp>
 #include <tt_stl/assert.hpp>
 #include <buffer.hpp>
 #include <event.hpp>

--- a/tt_metal/impl/dispatch/system_memory_manager.cpp
+++ b/tt_metal/impl/dispatch/system_memory_manager.cpp
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <tt_stl/reflection.hpp>
 #include "impl/context/metal_context.hpp"
 #include "system_memory_manager.hpp"
 #include <tt-metalium/tt_align.hpp>

--- a/tt_metal/impl/experimental/udm/mesh_builder.cpp
+++ b/tt_metal/impl/experimental/udm/mesh_builder.cpp
@@ -5,6 +5,7 @@
 #include <tt-metalium/experimental/udm/mesh_builder.hpp>
 #include <tt-metalium/experimental/udm/mesh_utils.hpp>
 #include <tt_stl/assert.hpp>
+#include <tt_stl/reflection.hpp>
 #include <tt-metalium/mesh_coord.hpp>
 #include <tt-metalium/experimental/fabric/routing_table_generator.hpp>
 #include <unordered_map>

--- a/tt_metal/impl/experimental/udm/mesh_kernel.cpp
+++ b/tt_metal/impl/experimental/udm/mesh_kernel.cpp
@@ -7,6 +7,7 @@
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/hal.hpp>
 #include <tt_stl/assert.hpp>
+#include <tt_stl/reflection.hpp>
 #include <umd/device/types/arch.hpp>
 
 namespace tt::tt_metal::experimental::udm {

--- a/tt_metal/impl/experimental/udm/mesh_program.cpp
+++ b/tt_metal/impl/experimental/udm/mesh_program.cpp
@@ -6,6 +6,7 @@
 #include <tt-metalium/experimental/udm/mesh_builder.hpp>
 #include <tt-metalium/host_api.hpp>
 #include <tt_stl/assert.hpp>
+#include <tt_stl/reflection.hpp>
 
 namespace tt::tt_metal::experimental::udm {
 

--- a/tt_metal/impl/lightmetal/lightmetal_capture.cpp
+++ b/tt_metal/impl/lightmetal/lightmetal_capture.cpp
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <tt_stl/reflection.hpp>
 #include <tt-logger/tt-logger.hpp>
 #include <tt_stl/assert.hpp>
 #include "lightmetal/lightmetal_capture.hpp"

--- a/tt_metal/impl/profiler/profiler.cpp
+++ b/tt_metal/impl/profiler/profiler.cpp
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <tt_stl/reflection.hpp>
 #include "core_coord.hpp"
 #include <common/TracyTTDeviceData.hpp>
 #include <device.hpp>

--- a/tt_metal/impl/program/dispatch.cpp
+++ b/tt_metal/impl/program/dispatch.cpp
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <tt_stl/reflection.hpp>
 #include "tt_metal/impl/program/dispatch.hpp"
 
 #include <mesh_workload.hpp>

--- a/tt_metal/impl/program/program_command_sequence.hpp
+++ b/tt_metal/impl/program/program_command_sequence.hpp
@@ -9,6 +9,7 @@
 
 #include "llrt/hal.hpp"
 #include "tt_metal/impl/dispatch/device_command.hpp"
+#include <numeric>
 
 struct CQDispatchWritePackedCmd;
 

--- a/tt_metal/impl/program/program_descriptors.cpp
+++ b/tt_metal/impl/program/program_descriptors.cpp
@@ -7,6 +7,7 @@
 
 #include "impl/buffers/semaphore.hpp"
 #include "tt_stl/overloaded.hpp"
+#include <tt_stl/reflection.hpp>
 
 #include <set>
 
@@ -119,3 +120,8 @@ ProgramDescriptor merge_program_descriptors(const std::vector<ProgramDescriptor>
 }
 
 }  // namespace tt::tt_metal
+
+std::size_t std::hash<tt::tt_metal::TileDescriptor>::operator()(
+    const tt::tt_metal::TileDescriptor& tile_desc) const noexcept {
+    return tt::stl::hash::hash_objects_with_default_seed(tile_desc.height, tile_desc.width, tile_desc.transpose);
+}

--- a/tt_metal/impl/sub_device/sub_device.cpp
+++ b/tt_metal/impl/sub_device/sub_device.cpp
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <tt_stl/reflection.hpp>
 #include <tt_stl/assert.hpp>
 #include <core_coord.hpp>
 #include <sub_device.hpp>

--- a/tt_metal/impl/sub_device/sub_device_manager.cpp
+++ b/tt_metal/impl/sub_device/sub_device_manager.cpp
@@ -18,6 +18,7 @@
 #include "llrt/hal.hpp"
 #include "dispatch/dispatch_settings.hpp"
 #include <tt_stl/strong_type.hpp>
+#include <tt_stl/reflection.hpp>
 #include "sub_device_manager.hpp"
 #include "impl/context/metal_context.hpp"
 #include "impl/allocator/allocator_types.hpp"

--- a/tt_metal/impl/sub_device/sub_device_manager_tracker.cpp
+++ b/tt_metal/impl/sub_device/sub_device_manager_tracker.cpp
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <tt_stl/reflection.hpp>
 #include <allocator.hpp>
 #include <buffer_types.hpp>
 #include <device.hpp>

--- a/tt_metal/impl/tensor/spec/layout/page_config.cpp
+++ b/tt_metal/impl/tensor/spec/layout/page_config.cpp
@@ -2,9 +2,11 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <tt_stl/reflection.hpp>
 #include <tt-metalium/experimental/tensor/spec/layout/page_config.hpp>
 
 #include <tt-metalium/shape2d.hpp>
+#include <numeric>
 
 namespace tt::tt_metal {
 

--- a/tt_metal/impl/tensor/spec/layout/tensor_layout.cpp
+++ b/tt_metal/impl/tensor/spec/layout/tensor_layout.cpp
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <tt_stl/reflection.hpp>
 #include <tt-metalium/experimental/tensor/spec/layout/tensor_layout.hpp>
 
 #include <tt-metalium/allocator.hpp>

--- a/tt_metal/impl/tensor/topology/tensor_topology.cpp
+++ b/tt_metal/impl/tensor/topology/tensor_topology.cpp
@@ -4,6 +4,8 @@
 
 #include <tt-metalium/experimental/tensor/topology/tensor_topology.hpp>
 
+#include <tt_stl/reflection.hpp>
+
 namespace tt::tt_metal {
 
 TensorTopology TensorTopology::create_fully_replicated_tensor_topology(

--- a/tt_metal/llrt/hal/tt-1xx/hal_1xx_common.cpp
+++ b/tt_metal/llrt/hal/tt-1xx/hal_1xx_common.cpp
@@ -2,6 +2,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <tt_stl/reflection.hpp>
+
 #include "hal_1xx_common.hpp"
 #include "hal_types.hpp"
 #include "rtoptions.hpp"

--- a/tt_metal/llrt/hal/tt-2xx/hal_2xx_common.cpp
+++ b/tt_metal/llrt/hal/tt-2xx/hal_2xx_common.cpp
@@ -2,6 +2,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <tt_stl/reflection.hpp>
+
 #include "hal_2xx_common.hpp"
 #include "rtoptions.hpp"
 #include <enchantum/enchantum.hpp>

--- a/tt_metal/llrt/tt_cluster.cpp
+++ b/tt_metal/llrt/tt_cluster.cpp
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <tt_stl/reflection.hpp>
 #include "tt_cluster.hpp"
 #include "llrt/rtoptions.hpp"
 

--- a/tt_metal/programming_examples/vecadd_sharding/vecadd_sharding.cpp
+++ b/tt_metal/programming_examples/vecadd_sharding/vecadd_sharding.cpp
@@ -16,6 +16,7 @@
 #include "tt-metalium/buffer_types.hpp"
 #include "tt-metalium/constants.hpp"
 #include <tt-metalium/distributed.hpp>
+#include <tt_stl/reflection.hpp>
 
 #include <cstddef>
 #include <cstdint>

--- a/tt_stl/tt_stl/reflection.hpp
+++ b/tt_stl/tt_stl/reflection.hpp
@@ -23,6 +23,7 @@
 #include <filesystem>
 
 #include <tt_stl/concepts.hpp>
+#include <tt_stl/small_vector.hpp>
 #include <nlohmann/json.hpp>
 #include <enchantum/scoped.hpp>
 #include <tt_stl/type_name.hpp>
@@ -933,6 +934,23 @@ struct get_first_object_of_type_t<T> {
 };
 
 }  // namespace reflection
+
+// operator<< for SmallVector lives in namespace ttsl (same as SmallVector)
+// so that ADL finds it from any call site.
+template <typename T, std::size_t PREALLOCATED_SIZE>
+std::ostream& operator<<(std::ostream& os, const SmallVector<T, PREALLOCATED_SIZE>& vec) {
+    os << "SmallVector([";
+    for (std::size_t i = 0; i < vec.size(); ++i) {
+        if (i > 0) {
+            os << ", ";
+        }
+        using ttsl::reflection::operator<<;
+        os << vec[i];
+    }
+    os << "])";
+    return os;
+}
+
 }  // namespace ttsl
 
 template <typename T>
@@ -1090,6 +1108,19 @@ struct fmt::formatter<T> {
         using ttsl::reflection::operator<<;
         std::stringstream ss;
         ss << object;
+        return fmt::format_to(ctx.out(), "{}", ss.str());
+    }
+};
+
+template <typename T, size_t PREALLOCATED_SIZE>
+struct fmt::formatter<ttsl::SmallVector<T, PREALLOCATED_SIZE>> {
+    constexpr auto parse(format_parse_context& ctx) -> format_parse_context::iterator { return ctx.end(); }
+
+    auto format(const ttsl::SmallVector<T, PREALLOCATED_SIZE>& vector, format_context& ctx) const
+        -> format_context::iterator {
+        using ttsl::reflection::operator<<;
+        std::stringstream ss;
+        ss << vector;
         return fmt::format_to(ctx.out(), "{}", ss.str());
     }
 };
@@ -1286,7 +1317,20 @@ void hash_combine(std::size_t& seed, const T& value) {
 }
 
 }  // namespace hash
+}  // namespace ttsl
 
+template <typename T, size_t PREALLOCATED_SIZE>
+struct std::hash<ttsl::SmallVector<T, PREALLOCATED_SIZE>> {
+    size_t operator()(const ttsl::SmallVector<T, PREALLOCATED_SIZE>& vec) const noexcept {
+        size_t hash = 0;
+        for (const auto& element : vec) {
+            hash = ttsl::hash::detail::hash_objects(hash, element);
+        }
+        return hash;
+    }
+};
+
+namespace ttsl {
 namespace json {
 
 template <typename T>
@@ -1608,6 +1652,28 @@ struct from_json_t<T> {
             },
             object);
         return object;
+    }
+};
+
+template <typename T, size_t PREALLOCATED_SIZE>
+struct to_json_t<ttsl::SmallVector<T, PREALLOCATED_SIZE>> {
+    nlohmann::json operator()(const ttsl::SmallVector<T, PREALLOCATED_SIZE>& vector) const {
+        nlohmann::json json_array = nlohmann::json::array();
+        for (const auto& element : vector) {
+            json_array.push_back(to_json(element));
+        }
+        return json_array;
+    }
+};
+
+template <typename T, size_t PREALLOCATED_SIZE>
+struct from_json_t<ttsl::SmallVector<T, PREALLOCATED_SIZE>> {
+    ttsl::SmallVector<T, PREALLOCATED_SIZE> operator()(const nlohmann::json& json_object) const {
+        ttsl::SmallVector<T, PREALLOCATED_SIZE> vector;
+        for (const auto& element : json_object) {
+            vector.push_back(from_json<T>(element));
+        }
+        return vector;
     }
 };
 

--- a/tt_stl/tt_stl/reflection.hpp
+++ b/tt_stl/tt_stl/reflection.hpp
@@ -1125,8 +1125,7 @@ struct fmt::formatter<ttsl::SmallVector<T, PREALLOCATED_SIZE>> {
     }
 };
 
-namespace ttsl {
-namespace hash {
+namespace ttsl::hash {
 
 namespace detail {
 template <typename T, typename = std::void_t<>>
@@ -1316,8 +1315,7 @@ void hash_combine(std::size_t& seed, const T& value) {
     seed ^= hasher(value) + 0x9e3779b9 + (seed << 6) + (seed >> 2);
 }
 
-}  // namespace hash
-}  // namespace ttsl
+}  // namespace ttsl::hash
 
 template <typename T, size_t PREALLOCATED_SIZE>
 struct std::hash<ttsl::SmallVector<T, PREALLOCATED_SIZE>> {
@@ -1330,8 +1328,7 @@ struct std::hash<ttsl::SmallVector<T, PREALLOCATED_SIZE>> {
     }
 };
 
-namespace ttsl {
-namespace json {
+namespace ttsl::json {
 
 template <typename T>
     requires std::is_integral_v<T> or std::is_floating_point_v<T> or std::is_enum_v<T>
@@ -1684,8 +1681,7 @@ struct to_json_t {
     }
 };
 
-}  // namespace json
-}  // namespace ttsl
+}  // namespace ttsl::json
 
 namespace tt {
 namespace [[deprecated("Use ttsl namespace instead")]] stl {

--- a/tt_stl/tt_stl/small_vector.hpp
+++ b/tt_stl/tt_stl/small_vector.hpp
@@ -6,8 +6,6 @@
 
 #include <tt_stl/llvm/llvm_small_vector.hpp>
 
-#include <tt_stl/reflection.hpp>
-
 namespace ttsl {
 
 static constexpr size_t SMALL_VECTOR_SIZE = 8;
@@ -17,26 +15,7 @@ struct SmallVector : public ttsl::detail::llvm::SmallVector<T, PREALLOCATED_SIZE
     using ttsl::detail::llvm::SmallVector<T, PREALLOCATED_SIZE>::SmallVector;
 };
 
-template <typename Stream, typename T, std::size_t PREALLOCATED_SIZE>
-Stream& operator<<(Stream& os, const SmallVector<T, PREALLOCATED_SIZE>& vec) {
-    os << "SmallVector([";
-    for (auto i = 0; i < vec.size(); ++i) {
-        if (i > 0) {
-            os << ", ";
-        }
-        using ttsl::reflection::operator<<;
-        os << vec[i];
-    }
-    os << "])";
-    return os;
-}
-
 }  // namespace ttsl
-
-namespace ttnn {
-template <typename T, size_t PREALLOCATED_SIZE = ttsl::SMALL_VECTOR_SIZE>
-using SmallVector [[deprecated("Use ttsl::SmallVector instead")]] = tt::stl::SmallVector<T, PREALLOCATED_SIZE>;
-}
 
 namespace tt {
 namespace [[deprecated("Use ttsl namespace instead")]] stl {
@@ -44,47 +23,7 @@ using namespace ::ttsl;
 }  // namespace stl
 }  // namespace tt
 
-template <typename T, size_t PREALLOCATED_SIZE>
-struct std::hash<ttsl::SmallVector<T, PREALLOCATED_SIZE>> {
-    size_t operator()(const ttsl::SmallVector<T, PREALLOCATED_SIZE>& vec) const noexcept {
-        size_t hash = 0;
-        for (const auto& element : vec) {
-            hash = ttsl::hash::detail::hash_objects(hash, element);
-        }
-        return hash;
-    }
-};
-
-template <typename T, size_t PREALLOCATED_SIZE>
-struct fmt::formatter<ttsl::SmallVector<T, PREALLOCATED_SIZE>> {
-    constexpr auto parse(format_parse_context& ctx) -> format_parse_context::iterator { return ctx.end(); }
-
-    auto format(const ttsl::SmallVector<T, PREALLOCATED_SIZE>& vector, format_context& ctx) const
-        -> format_context::iterator {
-        std::stringstream ss;
-        ss << vector;
-        return fmt::format_to(ctx.out(), "{}", ss.str());
-    }
-};
-
-template <typename T, size_t PREALLOCATED_SIZE>
-struct ttsl::json::to_json_t<ttsl::SmallVector<T, PREALLOCATED_SIZE>> {
-    nlohmann::json operator()(const ttsl::SmallVector<T, PREALLOCATED_SIZE>& vector) const {
-        nlohmann::json json_array = nlohmann::json::array();
-        for (const auto& element : vector) {
-            json_array.push_back(to_json(element));
-        }
-        return json_array;
-    }
-};
-
-template <typename T, size_t PREALLOCATED_SIZE>
-struct ttsl::json::from_json_t<ttsl::SmallVector<T, PREALLOCATED_SIZE>> {
-    ttsl::SmallVector<T, PREALLOCATED_SIZE> operator()(const nlohmann::json& json_object) const {
-        ttsl::SmallVector<T, PREALLOCATED_SIZE> vector;
-        for (const auto& element : json_object) {
-            vector.push_back(from_json<T>(element));
-        }
-        return vector;
-    }
-};
+namespace ttnn {
+template <typename T, size_t PREALLOCATED_SIZE = ttsl::SMALL_VECTOR_SIZE>
+using SmallVector [[deprecated("Use ttsl::SmallVector instead")]] = ttsl::SmallVector<T, PREALLOCATED_SIZE>;
+}

--- a/ttnn/CMakeLists.txt
+++ b/ttnn/CMakeLists.txt
@@ -556,6 +556,7 @@ target_sources(
             api/ttnn/global_circular_buffer.hpp
             api/ttnn/global_semaphore.hpp
             api/ttnn/graph/graph_consts.hpp
+            api/ttnn/graph/graph_serialization.hpp
             api/ttnn/graph/graph_operation_queries.hpp
             api/ttnn/graph/graph_processor.hpp
             api/ttnn/graph/graph_nanobind.hpp

--- a/ttnn/api/ttnn/device_operation.hpp
+++ b/ttnn/api/ttnn/device_operation.hpp
@@ -17,9 +17,8 @@
 #include <tt-metalium/program_cache.hpp>
 #include <tracy/Tracy.hpp>
 #include "tools/profiler/op_profiler.hpp"
-#include <tt_stl/reflection.hpp>
 #include <tt_stl/concepts.hpp>
-#include <tt-metalium/graph_tracking.hpp>
+#include "ttnn/graph/graph_serialization.hpp"
 #include "ttnn/graph/graph_processor.hpp"
 #include "ttnn/core.hpp"
 #include "ttnn/distributed/api.hpp"

--- a/ttnn/api/ttnn/graph/graph_query_op_constraints.hpp
+++ b/ttnn/api/ttnn/graph/graph_query_op_constraints.hpp
@@ -11,6 +11,7 @@
 
 #include <nlohmann/json.hpp>
 #include <tt-logger/tt-logger.hpp>
+#include <tt_stl/reflection.hpp>
 #include <tuple>
 #include <variant>
 #include "ttnn/graph/graph_processor.hpp"

--- a/ttnn/api/ttnn/graph/graph_serialization.hpp
+++ b/ttnn/api/ttnn/graph/graph_serialization.hpp
@@ -1,0 +1,104 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Serialization helpers for graph argument tracking.
+//
+// These templates use symbols from <reflect> and tt_stl/reflection.hpp, which
+// are intentionally kept OUT of the public tt-metalium API header
+// (graph_tracking.hpp).  Only code that needs to *instantiate*
+// GraphTracker::track_function_start – i.e. ttnn operation implementations –
+// should include this header.
+
+#pragma once
+
+#include <sstream>
+#include <any>
+#include <functional>
+
+#include <tt_stl/reflection.hpp>
+#include <tt-metalium/graph_tracking.hpp>
+
+namespace tt::tt_metal {
+namespace graph_detail {
+
+template <typename MemberT>
+void serialize_member(std::ostringstream& oss, const MemberT& member) {
+    if constexpr (std::is_enum_v<MemberT>) {
+        ttsl::reflection::operator<<(oss, member);
+    } else if constexpr (ttsl::is_specialization_v<MemberT, std::vector>) {
+        oss << "{";
+        for (size_t i = 0; i < member.size(); ++i) {
+            if (i > 0) {
+                oss << ", ";
+            }
+            serialize_member(oss, member[i]);
+        }
+        oss << "}";
+    } else if constexpr (ttsl::is_specialization_v<MemberT, std::optional>) {
+        if (member.has_value()) {
+            serialize_member(oss, member.value());
+        } else {
+            oss << "std::nullopt";
+        }
+    } else if constexpr (ttsl::is_specialization_v<MemberT, std::reference_wrapper>) {
+        serialize_member(oss, member.get());
+    } else if constexpr (ttsl::is_specialization_v<MemberT, std::pair>) {
+        oss << "{";
+        serialize_member(oss, member.first);
+        oss << ", ";
+        serialize_member(oss, member.second);
+        oss << "}";
+    } else if constexpr (requires { oss << member; }) {
+        oss << member;
+    } else if constexpr (ttsl::concepts::Reflectable<MemberT>) {
+        oss << reflect::type_name<MemberT>() << "(";
+        reflect::for_each(
+            [&oss, &member](auto I) {
+                if constexpr (I > 0) {
+                    oss << ", ";
+                }
+                serialize_member(oss, reflect::get<I>(member));
+            },
+            member);
+        oss << ")";
+    } else {
+        oss << "<" << reflect::type_name<MemberT>() << ">";
+    }
+}
+
+}  // namespace graph_detail
+
+template <typename T>
+std::string serialize_tracked_arg(const std::any& a) {
+    std::ostringstream oss;
+    const auto& ref = std::any_cast<const std::reference_wrapper<T>&>(a);
+    const auto& val = ref.get();
+    using CleanT = std::remove_cv_t<T>;
+
+    // Guard against incomplete types (e.g. forward-declared MeshCommandQueue)
+    // so that type traits below are never evaluated on them.
+    if constexpr (!requires { sizeof(CleanT); }) {
+        oss << "<incomplete type>";
+    } else if constexpr (ttsl::is_specialization_v<CleanT, std::vector>) {
+        ttsl::reflection::operator<<(oss, val);
+    } else if constexpr (requires { oss << val; }) {
+        oss << val;
+    } else if constexpr (ttsl::concepts::Reflectable<CleanT>) {
+        oss << reflect::type_name<CleanT>() << "(";
+        reflect::for_each(
+            [&oss, &val](auto I) {
+                if constexpr (I > 0) {
+                    oss << ", ";
+                }
+                graph_detail::serialize_member(oss, reflect::get<I>(val));
+            },
+            val);
+        oss << ")";
+    } else {
+        oss << "<" << reflect::type_name<T>() << ">";
+    }
+    return oss.str();
+}
+
+}  // namespace tt::tt_metal

--- a/ttnn/api/ttnn/graph/levelized_graph.hpp
+++ b/ttnn/api/ttnn/graph/levelized_graph.hpp
@@ -10,6 +10,7 @@
 
 #include <string>
 #include <vector>
+#include <ranges>
 
 namespace ttnn::graph {
 

--- a/ttnn/api/ttnn/mesh_device_operation_utils.hpp
+++ b/ttnn/api/ttnn/mesh_device_operation_utils.hpp
@@ -12,6 +12,7 @@
 #include <tt-metalium/experimental/inspector.hpp>
 #include <tt-metalium/program_cache.hpp>
 #include <tt_stl/overloaded.hpp>
+#include <tt_stl/reflection.hpp>
 
 #include "ttnn/core.hpp"
 #include "ttnn/distributed/types.hpp"

--- a/ttnn/api/ttnn/tensor/host_buffer/functions.hpp
+++ b/ttnn/api/ttnn/tensor/host_buffer/functions.hpp
@@ -31,7 +31,7 @@ void validate_datatype(const Tensor& tensor) {
     } else if constexpr (std::is_same_v<BaseType, uint8_t>) {
         TT_FATAL(tensor.dtype() == DataType::UINT8, "Incorrect data type {}", tensor.dtype());
     } else {
-        static_assert(tt::stl::concepts::always_false_v<BaseType>, "Unsupported DataType");
+        static_assert(sizeof(BaseType) == 0, "Unsupported DataType");
     }
 }
 

--- a/ttnn/core/device_operation_detail.cpp
+++ b/ttnn/core/device_operation_detail.cpp
@@ -2,6 +2,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <tt_stl/reflection.hpp>
+
 #include "ttnn/device_operation_detail.hpp"
 
 #include <algorithm>

--- a/ttnn/core/distributed/api.cpp
+++ b/ttnn/core/distributed/api.cpp
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <tt_stl/reflection.hpp>
 #include "ttnn/distributed/api.hpp"
 
 #include <memory>

--- a/ttnn/core/distributed/create_socket.cpp
+++ b/ttnn/core/distributed/create_socket.cpp
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <tt_stl/reflection.hpp>
 #include "ttnn/distributed/create_socket.hpp"
 #include "ttnn/distributed/bidirectional_fabric_socket.hpp"
 #include "ttnn/distributed/fabric_socket.hpp"

--- a/ttnn/core/distributed/distributed_nanobind.cpp
+++ b/ttnn/core/distributed/distributed_nanobind.cpp
@@ -4,6 +4,7 @@
 
 #include "ttnn/distributed/distributed_nanobind.hpp"
 
+#include <tt_stl/reflection.hpp>
 #include <cstddef>
 #include <memory>
 #include <optional>

--- a/ttnn/core/distributed/distributed_tensor.cpp
+++ b/ttnn/core/distributed/distributed_tensor.cpp
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <tt_stl/reflection.hpp>
 #include <tt_stl/assert.hpp>
 #include <tt-metalium/distributed_host_buffer.hpp>
 #include <tt-metalium/shape.hpp>

--- a/ttnn/core/distributed/host_ccl.cpp
+++ b/ttnn/core/distributed/host_ccl.cpp
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <tt_stl/reflection.hpp>
 #include "ttnn/distributed/host_ccl.hpp"
 
 #include <tt_stl/assert.hpp>

--- a/ttnn/core/graph/graph_processor.cpp
+++ b/ttnn/core/graph/graph_processor.cpp
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <tt_stl/reflection.hpp>
 #include "ttnn/graph/graph_processor.hpp"
 #include "ttnn/graph/graph_consts.hpp"
 #include "ttnn/types.hpp"

--- a/ttnn/core/graph/levelized_graph.cpp
+++ b/ttnn/core/graph/levelized_graph.cpp
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <tt_stl/reflection.hpp>
 #include "ttnn/graph/levelized_graph.hpp"
 #include "ttnn/graph/graph_consts.hpp"
 #include <nlohmann/json.hpp>

--- a/ttnn/core/tensor/host_buffer/functions.cpp
+++ b/ttnn/core/tensor/host_buffer/functions.cpp
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <tt_stl/reflection.hpp>
 #include <vector>
 
 #include <ttnn/tensor/host_buffer/functions.hpp>

--- a/ttnn/core/tensor/py_to_tt_tensor.cpp
+++ b/ttnn/core/tensor/py_to_tt_tensor.cpp
@@ -8,7 +8,7 @@
 #include "ttnn/operations/copy/typecast/typecast.hpp"
 #include "ttnn/operations/core/core.hpp"
 
-#include <tt-metalium/graph_tracking.hpp>
+#include "ttnn/graph/graph_serialization.hpp"
 
 #include <tracy/Tracy.hpp>
 

--- a/ttnn/core/tensor/tensor_impl.cpp
+++ b/ttnn/core/tensor/tensor_impl.cpp
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 // SPDX-License-Identifier: Apache-2.0
 
+#include <tt_stl/reflection.hpp>
 #include <fmt/format.h>
 #include <optional>
 

--- a/ttnn/core/tensor/tensor_ops.cpp
+++ b/ttnn/core/tensor/tensor_ops.cpp
@@ -18,7 +18,7 @@
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/math.hpp>
 #include <tracy/Tracy.hpp>
-#include <tt-metalium/graph_tracking.hpp>
+#include "ttnn/graph/graph_serialization.hpp"
 
 namespace {
 

--- a/ttnn/core/tensor/tensor_ops.cpp
+++ b/ttnn/core/tensor/tensor_ops.cpp
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <tt_stl/reflection.hpp>
 #include "tensor/tensor_ops.hpp"
 
 #include "ttnn/common/queue_id.hpp"

--- a/ttnn/core/tensor/to_string.cpp
+++ b/ttnn/core/tensor/to_string.cpp
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
+#include <tt_stl/reflection.hpp>
 #include "ttnn/tensor/to_string.hpp"
 #include "ttnn/tensor/tensor.hpp"
 #include "ttnn/distributed/api.hpp"

--- a/ttnn/core/tensor/to_string.cpp
+++ b/ttnn/core/tensor/to_string.cpp
@@ -8,7 +8,7 @@
 #include "ttnn/tensor/tensor_ops.hpp"
 #include "ttnn/tensor/tensor_utils.hpp"
 
-#include <tt-metalium/graph_tracking.hpp>
+#include "ttnn/graph/graph_serialization.hpp"
 
 namespace ttnn {
 

--- a/ttnn/core/tensor/xtensor/partition.cpp
+++ b/ttnn/core/tensor/xtensor/partition.cpp
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <tt_stl/reflection.hpp>
 #include "tensor/xtensor/partition.hpp"
 
 #include <type_traits>

--- a/ttnn/cpp/ttnn-nanobind/global_semaphore.cpp
+++ b/ttnn/cpp/ttnn-nanobind/global_semaphore.cpp
@@ -4,6 +4,7 @@
 
 #include "global_semaphore.hpp"
 
+#include <tt_stl/reflection.hpp>
 #include <cstdint>
 
 #include <nanobind/nanobind.h>

--- a/ttnn/cpp/ttnn-nanobind/pytensor.cpp
+++ b/ttnn/cpp/ttnn-nanobind/pytensor.cpp
@@ -45,7 +45,7 @@
 
 #include "ttnn/tensor/tensor_utils.hpp"
 #include "ttnn/tensor/types.hpp"
-#include <tt-metalium/graph_tracking.hpp>
+#include "ttnn/graph/graph_serialization.hpp"
 #include <tt-metalium/host_buffer.hpp>
 #include <tt_stl/overloaded.hpp>
 #include <tt_stl/span.hpp>

--- a/ttnn/cpp/ttnn/operations/cb_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/cb_utils.hpp
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <numeric>
+
 #include <tt-metalium/host_api.hpp>
 
 namespace tt::tt_metal {

--- a/ttnn/cpp/ttnn/operations/ccl/common/host/moe_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/common/host/moe_utils.cpp
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <tt_stl/reflection.hpp>
 #include <array>
 #include <limits>
 #include <utility>

--- a/ttnn/cpp/ttnn/operations/ccl/common/types/ccl_types_args_emitters.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/common/types/ccl_types_args_emitters.cpp
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <tt_stl/reflection.hpp>
 #include "ttnn/operations/ccl/common/types/ccl_types_args_emitters.hpp"
 #include <tt-metalium/buffer_types.hpp>
 #include "ttnn/tensor/tensor.hpp"

--- a/ttnn/cpp/ttnn/operations/ccl/sharding_addrgen_helper.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/sharding_addrgen_helper.cpp
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <tt_stl/reflection.hpp>
 #include <tt-metalium/host_api.hpp>
 #include "ttnn/tensor/tensor.hpp"
 #include "ttnn/operations/ccl/sharding_addrgen_helper.hpp"

--- a/ttnn/cpp/ttnn/operations/conv/conv_transpose2d/prepare_conv_transpose2d_weights.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv_transpose2d/prepare_conv_transpose2d_weights.cpp
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <tt_stl/reflection.hpp>
 #include "ttnn/operations/conv/conv_transpose2d/prepare_conv_transpose2d_weights.hpp"
 
 #include <cstdint>

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize/device/factories/untilize_multi_core_block_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize/device/factories/untilize_multi_core_block_program_factory.cpp
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <tt_stl/reflection.hpp>
 #include "ttnn/operations/cb_utils.hpp"
 #include "ttnn/operations/math.hpp"
 #include "ttnn/common/constants.hpp"

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize/device/factories/untilize_multi_core_input_and_output_nd_shard_type_and_shard_spec_identical_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize/device/factories/untilize_multi_core_input_and_output_nd_shard_type_and_shard_spec_identical_program_factory.cpp
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <tt_stl/reflection.hpp>
 #include "ttnn/operations/cb_utils.hpp"
 #include "ttnn/operations/math.hpp"
 #include "ttnn/common/constants.hpp"

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize/device/factories/untilize_multi_core_input_and_output_shard_type_and_shard_spec_identical_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize/device/factories/untilize_multi_core_input_and_output_shard_type_and_shard_spec_identical_program_factory.cpp
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <tt_stl/reflection.hpp>
 #include "ttnn/operations/cb_utils.hpp"
 #include "ttnn/operations/math.hpp"
 #include "ttnn/common/constants.hpp"

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize/device/factories/untilize_multi_core_parallelize_column_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize/device/factories/untilize_multi_core_parallelize_column_program_factory.cpp
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <tt_stl/reflection.hpp>
 #include "ttnn/operations/cb_utils.hpp"
 #include "ttnn/operations/math.hpp"
 #include "ttnn/common/constants.hpp"

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize/device/factories/untilize_multi_core_sub_core_grids_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize/device/factories/untilize_multi_core_sub_core_grids_program_factory.cpp
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC.
 //
 // SPDX-License-Identifier: Apache-2.0
+#include <tt_stl/reflection.hpp>
 #include "ttnn/operations/cb_utils.hpp"
 #include "ttnn/operations/math.hpp"
 #include "ttnn/common/constants.hpp"

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize/device/factories/untilize_single_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize/device/factories/untilize_single_core_program_factory.cpp
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <tt_stl/reflection.hpp>
 #include "ttnn/operations/cb_utils.hpp"
 #include "ttnn/operations/math.hpp"
 #include "ttnn/common/constants.hpp"

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_device_operation_types.hpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once
+#include <tt_stl/reflection.hpp>
 
 #include <cstdint>
 #include <optional>

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_concat_heads_fused/device/all_gather_concat_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_concat_heads_fused/device/all_gather_concat_device_operation_types.hpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once
+#include <tt_stl/reflection.hpp>
 
 #include "ttnn/tensor/tensor.hpp"
 #include "ttnn/operations/ccl/ccl_common.hpp"

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce_async/device/all_reduce_async_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce_async/device/all_reduce_async_device_operation_types.hpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once
+#include <tt_stl/reflection.hpp>
 
 #include <cstdint>
 #include <optional>

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_async/device/all_to_all_async_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_async/device/all_to_all_async_device_operation_types.hpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once
+#include <tt_stl/reflection.hpp>
 
 #include "ttnn/tensor/tensor.hpp"
 #include "ttnn/operations/ccl/ccl_host_datastructures.hpp"

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/deepseek_moe_reduce_scatter/device/deepseek_moe_reduce_scatter_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/deepseek_moe_reduce_scatter/device/deepseek_moe_reduce_scatter_device_operation_types.hpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once
+#include <tt_stl/reflection.hpp>
 
 #include <cstdint>
 #include <optional>

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/llama_all_gather_matmul_async/device/llama_all_gather_matmul_async_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/llama_all_gather_matmul_async/device/llama_all_gather_matmul_async_device_operation_types.hpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once
+#include <tt_stl/reflection.hpp>
 
 #include <cstdint>
 #include <optional>

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe/selective_reduce_combine/device/selective_reduce_combine_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe/selective_reduce_combine/device/selective_reduce_combine_device_operation_types.hpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once
+#include <tt_stl/reflection.hpp>
 
 #include <cstdint>
 #include <optional>

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/moe_compute_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/moe_compute_device_operation_types.hpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once
+#include <tt_stl/reflection.hpp>
 
 #include <cstdint>
 #include <optional>

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_async/device/neighbor_pad_async_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_async/device/neighbor_pad_async_device_operation_types.hpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once
+#include <tt_stl/reflection.hpp>
 
 #include <optional>
 #include <string>

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/reduce_scatter_minimal_async_op_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/reduce_scatter_minimal_async_op_device_operation_types.hpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once
+#include <tt_stl/reflection.hpp>
 
 #include <cstdint>
 #include <optional>

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/rms_allgather/device/rms_allgather_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/rms_allgather/device/rms_allgather_device_operation_types.hpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once
+#include <tt_stl/reflection.hpp>
 
 #include <optional>
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/send_recv_async/recv_async/device/recv_async_op_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/send_recv_async/recv_async/device/recv_async_op_device_operation_types.hpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once
+#include <tt_stl/reflection.hpp>
 
 #include <vector>
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/send_recv_async/send_async/device/send_async_op_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/send_recv_async/send_async/device/send_async_op_device_operation_types.hpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once
+#include <tt_stl/reflection.hpp>
 
 #include <vector>
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/slice_reshard_async/device/slice_reshard_async_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/slice_reshard_async/device/slice_reshard_async_device_operation_types.hpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once
+#include <tt_stl/reflection.hpp>
 
 #include <utility>
 #include <cstdint>

--- a/ttnn/cpp/ttnn/operations/experimental/where/device/where_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/where/device/where_device_operation_types.hpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 
+#include <tt_stl/reflection.hpp>
 #include "ttnn/tensor/types.hpp"
 #include "ttnn/tensor/tensor.hpp"
 #include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_helper_functions.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_helper_functions.cpp
@@ -2,9 +2,11 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <tt_stl/reflection.hpp>
 #include "moreh_helper_functions.hpp"
 
 #include <enchantum/enchantum.hpp>
+#include <numeric>
 #include <utility>
 
 #include <tt-metalium/constants.hpp>

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/batch_norm_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/batch_norm_utils.cpp
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <tt_stl/reflection.hpp>
 #include "batch_norm_utils.hpp"
 #include "ttnn/tensor/tensor.hpp"
 #include <tt_stl/assert.hpp>

--- a/ttnn/cpp/ttnn/operations/pool/grid_sample/grid_sample_prepare_grid.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/grid_sample/grid_sample_prepare_grid.cpp
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <tt_stl/reflection.hpp>
 #include "grid_sample_prepare_grid.hpp"
 
 #include "ttnn/tensor/tensor.hpp"


### PR DESCRIPTION
## Summary

Closes https://github.com/tenstorrent/tt-metal/issues/38819

As requested by @wenbinlyuTT 💯 

Removes `#include <tt_stl/reflection.hpp>` from `small_vector.hpp`, making it a lightweight header (~30 lines). SmallVector specializations (`operator<<`, `fmt::formatter`, `std::hash`, json `to/from`) are moved into `reflection.hpp`.

## Motivation

`small_vector.hpp` was included in 373 translation units. Each inclusion pulled in `reflection.hpp`, which transitively includes `<reflect>`, `<nlohmann/json.hpp>`, and heavy template machinery. Profiling showed this was costing **~400 CPU-seconds** per clean build.

After this change:
- `small_vector.hpp` is a ~30 line header with no heavy dependencies
- `reflection.hpp` total cost dropped by **~113 CPU-seconds (-11.8%)**  
- tt-metal's public API (`tt_metal/api/`) no longer depends on `reflection.hpp`, `concepts.hpp`, or the `<reflect>` library

## Justification
Your public API is a contract. When someone writes `#include <tt-metalium/mesh_coord.hpp>`, they're asking to use your mesh coordinate type. They shouldn't be forced to compile `<reflect>` (a template metaprogramming library that introspects aggregate fields), `<nlohmann/json.hpp>` (a 25,000+ line header with heavy template instantiation), or `<enchantum>` just because your internal implementation happens to use those for serialization and debugging.
  
The practical costs you're imposing on customers:
- Compile time: Every translation unit that touches your API pays the parse/instantiate cost of those heavy headers, even if they never serialize anything
- Dependency management: Customers must fetch, version-match, and maintain transitive dependencies they never asked for
- Fragility: A version bump in reflect or nlohmann/json can break customer builds that don't even use JSON

## Key Changes

1. **`tt_stl/small_vector.hpp`**: Stripped to just the SmallVector class definition
2. **`tt_stl/reflection.hpp`**: Now contains all SmallVector specializations (operator<<, fmt::formatter, std::hash, json traits)
3. **`tt_metal/api/` headers**: Removed all includes of `reflection.hpp` and `concepts.hpp`:
   - `shape.hpp`: Forward-declares json traits, definitions moved to `shape.cpp`
   - `program_descriptors.hpp`: Hash impl moved to `program_descriptors.cpp`
   - `tensor_types.hpp`: Replaced `always_false_v<T>` with `sizeof(T) == 0`
4. **`validate_includes.py`**: Added check to ban `reflection.hpp` and `concepts.hpp` from `tt_metal/api/` headers
5. **`third_party/CMakeLists.txt`**: Added `NTEST` define to `reflect` target to fix `fmt::detail` ambiguity
6. **~100 .cpp files**: Added explicit `#include <tt_stl/reflection.hpp>` (first include) to fix transitive dependency breakages

## Future Work
- Make lesser use of reflection in private metal code
- Its almost always just there for formatting objects (even enums!) in log statements.
- Maybe split reflection by function
  - formatters
  - hashers
  - serializers 

## Testing

- ✅ Full build with PCH + Unity (default)
- ✅ Full build **without** PCH and **without** Unity builds (`--disable-pch --disable-unity-builds`)
- ✅ All pre-commit hooks pass
- ✅ `validate-metalium-includes` passes
- [x] [All Post Commit Tests Pass](https://github.com/tenstorrent/tt-metal/actions/runs/22470799948)