### PR TITLE
[DM] NoC Estimator Data movement tests

### DIFF
--- a/tests/tt_metal/tt_metal/data_movement/README.md
+++ b/tests/tt_metal/tt_metal/data_movement/README.md
@@ -55,7 +55,7 @@ Both API versions run the same test cases but use different underlying implement
 | Transaction ID              | 600-602, 610-611                | Tests the usage and effects of transaction IDs in NOC transactions.                     |
 | PCIe Read Bandwidth         | 603                             | Measures PCIe read bandwidth from host memory to L1 on a single Tensix core.            |
 | NOC API Latency             | 700-706                         | Measures latency (cycles) of NOC API calls using experimental dataflow 2.0 API.         |
-| NOC Estimator               | 800-814                         | Comprehensive bandwidth sweeps for NOC estimation across all patterns and mechanisms.    |
+| NOC Estimator               | 800-817                         | Comprehensive bandwidth sweeps for NOC estimation across all patterns and mechanisms.    |
 
 
 ## Running Tests

--- a/tests/tt_metal/tt_metal/data_movement/README.md
+++ b/tests/tt_metal/tt_metal/data_movement/README.md
@@ -55,6 +55,7 @@ Both API versions run the same test cases but use different underlying implement
 | Transaction ID              | 600-602, 610-611                | Tests the usage and effects of transaction IDs in NOC transactions.                     |
 | PCIe Read Bandwidth         | 603                             | Measures PCIe read bandwidth from host memory to L1 on a single Tensix core.            |
 | NOC API Latency             | 700-706                         | Measures latency (cycles) of NOC API calls using experimental dataflow 2.0 API.         |
+| NOC Estimator               | 800-814                         | Comprehensive bandwidth sweeps for NOC estimation across all patterns and mechanisms.    |
 
 
 ## Running Tests

--- a/tests/tt_metal/tt_metal/data_movement/noc_estimator_tests/README.md
+++ b/tests/tt_metal/tt_metal/data_movement/noc_estimator_tests/README.md
@@ -1,0 +1,101 @@
+# NOC Estimator Tests
+
+Comprehensive performance sweep tests designed to generate profiling data for the NoC estimator. These tests systematically exercise every major NOC communication pattern across a wide range of transaction sizes, grid configurations, and transfer mechanisms to produce the data needed for accurate latency/bandwidth prediction.
+
+## Dispatch Mode
+All tests use **fast dispatch** via `GenericMeshDeviceFixture`.
+
+## NOC API
+- **L1 kernels** use the experimental device 2.0 NOC API (`experimental::Noc`, `experimental::UnicastEndpoint`, `experimental::MulticastEndpoint`).
+- **DRAM kernels** use `TensorAccessor` with the experimental 2.0 NOC API. Buffers are allocated via `CreateBuffer(InterleavedBufferConfig)` on the host.
+
+## Test Cases
+
+### L1 Tests
+
+| Test Name                    | ID  | Pattern          | Description                                                       |
+|------------------------------|-----|------------------|-------------------------------------------------------------------|
+| NocEstimatorL1OneToOne       | 800 | One to One       | Unicast write between two Tensix cores.                           |
+| NocEstimatorL1OneFromOne     | 801 | One from One     | Unicast read between two Tensix cores.                            |
+| NocEstimatorL1OneToAll       | 802 | One to All       | One core writes to a grid (unicast, multicast, multicast linked). |
+| NocEstimatorL1OneFromAll     | 803 | One from All     | One core reads from all cores in the grid.                        |
+| NocEstimatorL1AllToAll       | 804 | All to All       | Every core in a grid writes to every other core.                  |
+| NocEstimatorL1AllFromAll     | 805 | All from All     | Every core in a grid reads from every other core.                 |
+| NocEstimatorL1OneToRow       | 806 | One to Row       | One core writes to an entire row (unicast/multicast).             |
+| NocEstimatorL1RowToRow       | 807 | Row to Row       | Every core in a row writes to every core in the row.              |
+| NocEstimatorL1OneToColumn    | 808 | One to Column    | One core writes to an entire column (unicast/multicast).          |
+| NocEstimatorL1ColumnToColumn | 809 | Column to Column | Every core in a column writes to every core in the column.        |
+
+### DRAM Read Tests
+
+| Test Name                             | ID  | Layout      | Cores     | Description                                        |
+|---------------------------------------|-----|-------------|-----------|----------------------------------------------------|
+| NocEstimatorDRAMShardedOneFromOne     | 810 | Sharded     | 1 core    | Single core reads from one dedicated DRAM bank.    |
+| NocEstimatorDRAMShardedAllFromAll     | 811 | Sharded     | Full grid | Every core reads from its assigned bank.           |
+| NocEstimatorDRAMInterleavedOneFromAll | 812 | Interleaved | 1 core    | Single core reads, cycling through all DRAM banks. |
+| NocEstimatorDRAMInterleavedAllFromAll | 813 | Interleaved | Full grid | Every core reads, each cycling through all banks.  |
+
+### DRAM Write Tests
+
+| Test Name                            | ID  | Layout      | Cores     | Description                                         |
+|--------------------------------------|-----|-------------|-----------|-----------------------------------------------------|
+| NocEstimatorDRAMShardedOneToOne      | 814 | Sharded     | 1 core    | Single core writes to one dedicated DRAM bank.      |
+| NocEstimatorDRAMShardedAllToAll      | 815 | Sharded     | Full grid | Every core writes to its assigned bank.             |
+| NocEstimatorDRAMInterleavedOneToAll  | 816 | Interleaved | 1 core    | Single core writes, cycling through all DRAM banks. |
+| NocEstimatorDRAMInterleavedAllToAll  | 817 | Interleaved | Full grid | Every core writes, each cycling through all banks.  |
+
+DRAM read and write tests run in isolation (one kernel per core) to avoid L1 contention. All DRAM tests sweep both NOC_0 and NOC_1.
+
+## Sweep Parameters
+
+Each test sweeps over a combination of the following parameters:
+
+| Parameter              | Values                                      | Description                                                    |
+| ---------------------- | ------------------------------------------- | -------------------------------------------------------------- |
+| `num_of_transactions`  | 1, 4, 16, 64, 256                           | Number of NOC transactions issued per destination.             |
+| `pages_per_transaction`| 1, 2, 4, ..., up to arch-dependent max      | Pages per transaction (transaction size = pages x page size).  |
+| `bytes_per_page`       | Architecture-dependent (derived at runtime) | Bytes per page, based on physical L1/DRAM constraints.         |
+| `same_axis`            | true, false                                 | Whether source and destination are on the same NOC axis.       |
+| `stateful`             | true, false                                 | Whether to use stateful writes/reads (set_state + with_state). |
+| `loopback`             | true, false                                 | Whether the master core is inside the multicast rectangle.     |
+| `mechanism`            | Unicast, Multicast, Multicast Linked        | NOC transfer mechanism.                                        |
+| `grid_size`            | 2x2, 3x3, 5x5, 8x8, full device grid        | Grid dimensions for multi-core patterns.                       |
+
+Not all parameter combinations apply to every test. For example, `same_axis` only applies to single-core patterns, `loopback` only applies to multicast patterns, and stateful unicast writes are constrained to sub-packet sizes (8 KB on Wormhole, 16 KB on Blackhole).
+
+## Profiler Metadata
+
+Each kernel logs structured metadata via `DeviceTimestampedData` for post-processing by the profiler and Python analysis scripts. The logged fields are:
+- Test ID, NOC index, number of transactions, transaction size
+- Memory type (L1/DRAM interleaved/DRAM sharded), mechanism (unicast/multicast/multicast linked), pattern
+- Number of subordinates, same axis, stateful, loopback
+
+## Kernels
+
+| Kernel       | File                       | Processor | Description                                                              |
+|--------------|----------------------------|-----------|--------------------------------------------------------------------------|
+| L1 Writer    | `kernels/writer.cpp`       | RISCV_0   | Unicast single/multi, multicast, and multicast linked L1 writes.         |
+| L1 Reader    | `kernels/reader.cpp`       | RISCV_1   | Single-source and multi-source L1 reads.                                 |
+| DRAM Reader  | `kernels/dram_reader.cpp`  | RISCV_1   | Reads from DRAM to L1; interleaved (round-robin) or sharded (fixed bank).|
+| DRAM Writer  | `kernels/dram_writer.cpp`  | RISCV_0   | Writes from L1 to DRAM; interleaved or sharded.                          |
+| Log Helpers  | `kernels/log_helpers.hpp`  | --        | Shared constants and `log_estimator_metadata` helper.                    |
+| Barrier Sync | `kernels/barrier_sync.hpp` | --        | Global barrier synchronization for multi-core DRAM tests.                |
+
+## Running Tests
+
+```bash
+# Build
+./build_metal.sh --build-tests
+
+# Run all NOC estimator tests, increase timeout due to the large number of tests being run
+./build/test/tt_metal/unit_tests_data_movement --timeout=1800 --gtest_filter="*NocEstimator*"
+
+# Run a single test
+./build/test/tt_metal/unit_tests_data_movement --gtest_filter="*NocEstimatorL1OneToOne*"
+
+# Run only DRAM tests
+./build/test/tt_metal/unit_tests_data_movement --gtest_filter="*NocEstimatorDRAM*"
+
+# Run only row/column tests
+./build/test/tt_metal/unit_tests_data_movement --gtest_filter="*NocEstimatorL1*Row*:*NocEstimatorL1*Column*"
+```

--- a/tests/tt_metal/tt_metal/data_movement/noc_estimator_tests/README.md
+++ b/tests/tt_metal/tt_metal/data_movement/noc_estimator_tests/README.md
@@ -87,15 +87,7 @@ Each kernel logs structured metadata via `DeviceTimestampedData` for post-proces
 # Build
 ./build_metal.sh --build-tests
 
-# Run all NOC estimator tests, increase timeout due to the large number of tests being run
-./build/test/tt_metal/unit_tests_data_movement --timeout=1800 --gtest_filter="*NocEstimator*"
+# Run all NOC estimator tests, --report flag is for generating csv reports
+pytest tests/tt_metal/tt_metal/data_movement/python/test_data_movement.py --timeout=1800 --gtest-filter="NocEstimator" --report
 
-# Run a single test
-./build/test/tt_metal/unit_tests_data_movement --gtest_filter="*NocEstimatorL1OneToOne*"
-
-# Run only DRAM tests
-./build/test/tt_metal/unit_tests_data_movement --gtest_filter="*NocEstimatorDRAM*"
-
-# Run only row/column tests
-./build/test/tt_metal/unit_tests_data_movement --gtest_filter="*NocEstimatorL1*Row*:*NocEstimatorL1*Column*"
 ```

--- a/tests/tt_metal/tt_metal/data_movement/noc_estimator_tests/kernels/barrier_sync.hpp
+++ b/tests/tt_metal/tt_metal/data_movement/noc_estimator_tests/kernels/barrier_sync.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/tests/tt_metal/tt_metal/data_movement/noc_estimator_tests/kernels/barrier_sync.hpp
+++ b/tests/tt_metal/tt_metal/data_movement/noc_estimator_tests/kernels/barrier_sync.hpp
@@ -1,0 +1,50 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <stdint.h>
+#include "api/dataflow/dataflow_api.h"
+
+/**
+ * @brief Wait for all cores to reach the barrier before proceeding.
+ *
+ * This implements a global barrier synchronization where:
+ * 1. Each core increments a semaphore on the coordinator core
+ * 2. Each core polls the coordinator's semaphore until it equals num_cores
+ * 3. Once all cores have arrived, they all proceed simultaneously
+ *
+ * @param barrier_sem_id      Semaphore ID (call get_semaphore() to get L1 address)
+ * @param barrier_coord_x     Physical X coordinate of the coordinator core
+ * @param barrier_coord_y     Physical Y coordinate of the coordinator core
+ * @param num_cores           Total number of cores participating in the barrier
+ * @param local_scratch_addr  Local L1 address for polling scratch space (4 bytes)
+ */
+FORCE_INLINE void barrier_sync(
+    uint32_t barrier_sem_id,
+    uint32_t barrier_coord_x,
+    uint32_t barrier_coord_y,
+    uint32_t num_cores,
+    uint32_t local_scratch_addr) {
+    // Get the L1 address of the barrier semaphore (same logical address on all cores)
+    uint32_t barrier_sem_addr = get_semaphore(barrier_sem_id);
+
+    // Get NOC address of coordinator's barrier semaphore
+    uint64_t barrier_noc_addr = get_noc_addr(barrier_coord_x, barrier_coord_y, barrier_sem_addr);
+
+    // Increment the coordinator's semaphore to signal this core has arrived
+    noc_semaphore_inc(barrier_noc_addr, 1);
+    noc_async_atomic_barrier();
+
+    // Poll the coordinator's semaphore until all cores have arrived
+    // We read from the coordinator's L1 into our local scratch space
+    volatile tt_l1_ptr uint32_t* local_poll_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(local_scratch_addr);
+    *local_poll_ptr = 0;
+
+    while (*local_poll_ptr < num_cores) {
+        // Read coordinator's semaphore value into local memory
+        noc_async_read(barrier_noc_addr, local_scratch_addr, sizeof(uint32_t));
+        noc_async_read_barrier();
+    }
+}

--- a/tests/tt_metal/tt_metal/data_movement/noc_estimator_tests/kernels/dram_reader.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/noc_estimator_tests/kernels/dram_reader.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/tests/tt_metal/tt_metal/data_movement/noc_estimator_tests/kernels/dram_reader.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/noc_estimator_tests/kernels/dram_reader.cpp
@@ -3,44 +3,60 @@
 // SPDX-License-Identifier: Apache-2.0
 
 // DRAM read kernel for NOC estimator tests.
-// Reads from DRAM bank(s) to local L1 in round-robin order.
-// When num_banks=1, behaves as single-bank read.
-// Sets a semaphore when done to signal the DRAM writer kernel.
+// Uses TensorAccessor with experimental Noc 2.0 API.
+// Supports interleaved (round-robin across banks) and sharded (fixed bank per core) modes.
 
 #include "api/dataflow/dataflow_api.h"
+#include "api/tensor/tensor_accessor.h"
+#include "experimental/tensor.h"
+#include "experimental/endpoints.h"
+#include "barrier_sync.hpp"
 #include "log_helpers.hpp"
 
 void kernel_main() {
-    constexpr uint32_t local_l1_addr = get_compile_time_arg_val(0);
-    constexpr uint32_t dram_addr = get_compile_time_arg_val(1);
-    constexpr uint32_t num_of_transactions = get_compile_time_arg_val(2);
-    constexpr uint32_t bytes_per_transaction = get_compile_time_arg_val(3);
-    constexpr uint32_t test_id = get_compile_time_arg_val(4);
-    constexpr uint32_t sem_id = get_compile_time_arg_val(5);
-    constexpr uint32_t num_banks = get_compile_time_arg_val(6);
+    constexpr uint32_t num_of_transactions = get_compile_time_arg_val(0);
+    constexpr uint32_t page_size_bytes = get_compile_time_arg_val(1);
+    constexpr uint32_t test_id = get_compile_time_arg_val(2);
+    constexpr uint32_t sem_id = get_compile_time_arg_val(3);
+    constexpr uint32_t memory_type = get_compile_time_arg_val(4);
+    constexpr uint32_t mechanism = get_compile_time_arg_val(5);
+    constexpr uint32_t pattern = get_compile_time_arg_val(6);
+    constexpr uint32_t num_pages = get_compile_time_arg_val(7);
 
-    // Metadata args
-    constexpr uint32_t memory_type = get_compile_time_arg_val(7);
-    constexpr uint32_t mechanism = get_compile_time_arg_val(8);
-    constexpr uint32_t pattern = get_compile_time_arg_val(9);
+    // TensorAccessorArgs appended starting at compile arg index 8
+    auto accessor_args = TensorAccessorArgs<8>();
 
-    constexpr bool dram = true;
+    uint32_t src_buffer_addr = get_arg_val<uint32_t>(0);
+    uint32_t l1_write_addr = get_arg_val<uint32_t>(1);
+    uint32_t start_page = get_arg_val<uint32_t>(2);
+    // Barrier args
+    uint32_t barrier_sem_id = get_arg_val<uint32_t>(3);
+    uint32_t barrier_coord_x = get_arg_val<uint32_t>(4);
+    uint32_t barrier_coord_y = get_arg_val<uint32_t>(5);
+    uint32_t num_cores = get_arg_val<uint32_t>(6);
+    uint32_t local_scratch_addr = get_arg_val<uint32_t>(7);
 
-    uint32_t sem_addr = get_semaphore(sem_id);
-    auto sem_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(sem_addr);
+    auto s = TensorAccessor(accessor_args, src_buffer_addr, page_size_bytes);
+
+    experimental::Noc noc(noc_index);
+    experimental::UnicastEndpoint unicast_ep;
+
+    barrier_sync(barrier_sem_id, barrier_coord_x, barrier_coord_y, num_cores, local_scratch_addr);
 
     {
         DeviceZoneScopedN("RISCV1");
         for (uint32_t i = 0; i < num_of_transactions; i++) {
-            uint32_t bank = i % num_banks;
-            uint64_t dram_noc_addr = get_noc_addr_from_bank_id<dram>(bank, dram_addr);
-            noc_async_read(dram_noc_addr, local_l1_addr, bytes_per_transaction);
+            uint32_t page_id;
+            if constexpr (memory_type == MEMORY_TYPE_DRAM_SHARDED) {
+                page_id = start_page;
+            } else {
+                page_id = (start_page + i) % num_pages;
+            }
+            noc.async_read(s, unicast_ep, page_size_bytes, {.page_id = page_id}, {.addr = l1_write_addr});
         }
-        noc_async_read_barrier();
+        noc.async_read_barrier();
     }
 
-    noc_semaphore_set(sem_ptr, 1);
-
     log_estimator_metadata(
-        test_id, noc_index, num_of_transactions, bytes_per_transaction, memory_type, mechanism, pattern, 0, 0, 0, 0);
+        test_id, noc.get_noc_id(), num_of_transactions, page_size_bytes, memory_type, mechanism, pattern, 0, 0, 0, 0);
 }

--- a/tests/tt_metal/tt_metal/data_movement/noc_estimator_tests/kernels/dram_reader.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/noc_estimator_tests/kernels/dram_reader.cpp
@@ -3,21 +3,21 @@
 // SPDX-License-Identifier: Apache-2.0
 
 // DRAM read kernel for NOC estimator tests.
-// Reads from a DRAM bank to local L1. Sets a semaphore when done
-// to signal the DRAM writer kernel.
+// Reads from DRAM bank(s) to local L1 in round-robin order.
+// When num_banks=1, behaves as single-bank read.
+// Sets a semaphore when done to signal the DRAM writer kernel.
 
 #include "api/dataflow/dataflow_api.h"
-#include "api/debug/dprint.h"
 #include "log_helpers.hpp"
 
 void kernel_main() {
     constexpr uint32_t local_l1_addr = get_compile_time_arg_val(0);
     constexpr uint32_t dram_addr = get_compile_time_arg_val(1);
-    constexpr uint32_t dram_channel = get_compile_time_arg_val(2);
-    constexpr uint32_t num_of_transactions = get_compile_time_arg_val(3);
-    constexpr uint32_t bytes_per_transaction = get_compile_time_arg_val(4);
-    constexpr uint32_t test_id = get_compile_time_arg_val(5);
-    constexpr uint32_t sem_id = get_compile_time_arg_val(6);
+    constexpr uint32_t num_of_transactions = get_compile_time_arg_val(2);
+    constexpr uint32_t bytes_per_transaction = get_compile_time_arg_val(3);
+    constexpr uint32_t test_id = get_compile_time_arg_val(4);
+    constexpr uint32_t sem_id = get_compile_time_arg_val(5);
+    constexpr uint32_t num_banks = get_compile_time_arg_val(6);
 
     // Metadata args
     constexpr uint32_t memory_type = get_compile_time_arg_val(7);
@@ -25,7 +25,6 @@ void kernel_main() {
     constexpr uint32_t pattern = get_compile_time_arg_val(9);
 
     constexpr bool dram = true;
-    uint64_t dram_noc_addr = get_noc_addr_from_bank_id<dram>(dram_channel, dram_addr);
 
     uint32_t sem_addr = get_semaphore(sem_id);
     auto sem_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(sem_addr);
@@ -33,12 +32,13 @@ void kernel_main() {
     {
         DeviceZoneScopedN("RISCV1");
         for (uint32_t i = 0; i < num_of_transactions; i++) {
+            uint32_t bank = i % num_banks;
+            uint64_t dram_noc_addr = get_noc_addr_from_bank_id<dram>(bank, dram_addr);
             noc_async_read(dram_noc_addr, local_l1_addr, bytes_per_transaction);
         }
         noc_async_read_barrier();
     }
 
-    // Signal the writer kernel that data is ready in L1
     noc_semaphore_set(sem_ptr, 1);
 
     log_estimator_metadata(

--- a/tests/tt_metal/tt_metal/data_movement/noc_estimator_tests/kernels/dram_reader.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/noc_estimator_tests/kernels/dram_reader.cpp
@@ -1,0 +1,46 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// DRAM read kernel for NOC estimator tests.
+// Reads from a DRAM bank to local L1. Sets a semaphore when done
+// to signal the DRAM writer kernel.
+
+#include "api/dataflow/dataflow_api.h"
+#include "api/debug/dprint.h"
+#include "log_helpers.hpp"
+
+void kernel_main() {
+    constexpr uint32_t local_l1_addr = get_compile_time_arg_val(0);
+    constexpr uint32_t dram_addr = get_compile_time_arg_val(1);
+    constexpr uint32_t dram_channel = get_compile_time_arg_val(2);
+    constexpr uint32_t num_of_transactions = get_compile_time_arg_val(3);
+    constexpr uint32_t bytes_per_transaction = get_compile_time_arg_val(4);
+    constexpr uint32_t test_id = get_compile_time_arg_val(5);
+    constexpr uint32_t sem_id = get_compile_time_arg_val(6);
+
+    // Metadata args
+    constexpr uint32_t memory_type = get_compile_time_arg_val(7);
+    constexpr uint32_t mechanism = get_compile_time_arg_val(8);
+    constexpr uint32_t pattern = get_compile_time_arg_val(9);
+
+    constexpr bool dram = true;
+    uint64_t dram_noc_addr = get_noc_addr_from_bank_id<dram>(dram_channel, dram_addr);
+
+    uint32_t sem_addr = get_semaphore(sem_id);
+    auto sem_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(sem_addr);
+
+    {
+        DeviceZoneScopedN("RISCV1");
+        for (uint32_t i = 0; i < num_of_transactions; i++) {
+            noc_async_read(dram_noc_addr, local_l1_addr, bytes_per_transaction);
+        }
+        noc_async_read_barrier();
+    }
+
+    // Signal the writer kernel that data is ready in L1
+    noc_semaphore_set(sem_ptr, 1);
+
+    log_estimator_metadata(
+        test_id, noc_index, num_of_transactions, bytes_per_transaction, memory_type, mechanism, pattern, 0, 0, 0, 0);
+}

--- a/tests/tt_metal/tt_metal/data_movement/noc_estimator_tests/kernels/dram_writer.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/noc_estimator_tests/kernels/dram_writer.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/tests/tt_metal/tt_metal/data_movement/noc_estimator_tests/kernels/dram_writer.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/noc_estimator_tests/kernels/dram_writer.cpp
@@ -3,20 +3,21 @@
 // SPDX-License-Identifier: Apache-2.0
 
 // DRAM write kernel for NOC estimator tests.
-// Waits for semaphore from reader, then writes from local L1 to a DRAM bank.
+// Waits for semaphore from reader, then writes from local L1 to
+// DRAM bank(s) in round-robin order.
+// When num_banks=1, behaves as single-bank write.
 
 #include "api/dataflow/dataflow_api.h"
-#include "api/debug/dprint.h"
 #include "log_helpers.hpp"
 
 void kernel_main() {
     constexpr uint32_t local_l1_addr = get_compile_time_arg_val(0);
     constexpr uint32_t dram_addr = get_compile_time_arg_val(1);
-    constexpr uint32_t dram_channel = get_compile_time_arg_val(2);
-    constexpr uint32_t num_of_transactions = get_compile_time_arg_val(3);
-    constexpr uint32_t bytes_per_transaction = get_compile_time_arg_val(4);
-    constexpr uint32_t test_id = get_compile_time_arg_val(5);
-    constexpr uint32_t sem_id = get_compile_time_arg_val(6);
+    constexpr uint32_t num_of_transactions = get_compile_time_arg_val(2);
+    constexpr uint32_t bytes_per_transaction = get_compile_time_arg_val(3);
+    constexpr uint32_t test_id = get_compile_time_arg_val(4);
+    constexpr uint32_t sem_id = get_compile_time_arg_val(5);
+    constexpr uint32_t num_banks = get_compile_time_arg_val(6);
 
     // Metadata args
     constexpr uint32_t memory_type = get_compile_time_arg_val(7);
@@ -24,17 +25,17 @@ void kernel_main() {
     constexpr uint32_t pattern = get_compile_time_arg_val(9);
 
     constexpr bool dram = true;
-    uint64_t dram_noc_addr = get_noc_addr_from_bank_id<dram>(dram_channel, dram_addr);
 
     uint32_t sem_addr = get_semaphore(sem_id);
     auto sem_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(sem_addr);
 
-    // Wait for the reader kernel to finish loading data into L1
     noc_semaphore_wait(sem_ptr, 1);
 
     {
         DeviceZoneScopedN("RISCV0");
         for (uint32_t i = 0; i < num_of_transactions; i++) {
+            uint32_t bank = i % num_banks;
+            uint64_t dram_noc_addr = get_noc_addr_from_bank_id<dram>(bank, dram_addr);
             noc_async_write(local_l1_addr, dram_noc_addr, bytes_per_transaction);
         }
         noc_async_write_barrier();

--- a/tests/tt_metal/tt_metal/data_movement/noc_estimator_tests/kernels/dram_writer.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/noc_estimator_tests/kernels/dram_writer.cpp
@@ -1,0 +1,45 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// DRAM write kernel for NOC estimator tests.
+// Waits for semaphore from reader, then writes from local L1 to a DRAM bank.
+
+#include "api/dataflow/dataflow_api.h"
+#include "api/debug/dprint.h"
+#include "log_helpers.hpp"
+
+void kernel_main() {
+    constexpr uint32_t local_l1_addr = get_compile_time_arg_val(0);
+    constexpr uint32_t dram_addr = get_compile_time_arg_val(1);
+    constexpr uint32_t dram_channel = get_compile_time_arg_val(2);
+    constexpr uint32_t num_of_transactions = get_compile_time_arg_val(3);
+    constexpr uint32_t bytes_per_transaction = get_compile_time_arg_val(4);
+    constexpr uint32_t test_id = get_compile_time_arg_val(5);
+    constexpr uint32_t sem_id = get_compile_time_arg_val(6);
+
+    // Metadata args
+    constexpr uint32_t memory_type = get_compile_time_arg_val(7);
+    constexpr uint32_t mechanism = get_compile_time_arg_val(8);
+    constexpr uint32_t pattern = get_compile_time_arg_val(9);
+
+    constexpr bool dram = true;
+    uint64_t dram_noc_addr = get_noc_addr_from_bank_id<dram>(dram_channel, dram_addr);
+
+    uint32_t sem_addr = get_semaphore(sem_id);
+    auto sem_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(sem_addr);
+
+    // Wait for the reader kernel to finish loading data into L1
+    noc_semaphore_wait(sem_ptr, 1);
+
+    {
+        DeviceZoneScopedN("RISCV0");
+        for (uint32_t i = 0; i < num_of_transactions; i++) {
+            noc_async_write(local_l1_addr, dram_noc_addr, bytes_per_transaction);
+        }
+        noc_async_write_barrier();
+    }
+
+    log_estimator_metadata(
+        test_id, noc_index, num_of_transactions, bytes_per_transaction, memory_type, mechanism, pattern, 0, 0, 0, 0);
+}

--- a/tests/tt_metal/tt_metal/data_movement/noc_estimator_tests/kernels/dram_writer.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/noc_estimator_tests/kernels/dram_writer.cpp
@@ -3,44 +3,60 @@
 // SPDX-License-Identifier: Apache-2.0
 
 // DRAM write kernel for NOC estimator tests.
-// Waits for semaphore from reader, then writes from local L1 to
-// DRAM bank(s) in round-robin order.
-// When num_banks=1, behaves as single-bank write.
+// Uses TensorAccessor with experimental Noc 2.0 API.
+// Supports interleaved (round-robin across banks) and sharded (fixed bank per core) modes.
 
 #include "api/dataflow/dataflow_api.h"
+#include "api/tensor/tensor_accessor.h"
+#include "experimental/tensor.h"
+#include "experimental/endpoints.h"
+#include "barrier_sync.hpp"
 #include "log_helpers.hpp"
 
 void kernel_main() {
-    constexpr uint32_t local_l1_addr = get_compile_time_arg_val(0);
-    constexpr uint32_t dram_addr = get_compile_time_arg_val(1);
-    constexpr uint32_t num_of_transactions = get_compile_time_arg_val(2);
-    constexpr uint32_t bytes_per_transaction = get_compile_time_arg_val(3);
-    constexpr uint32_t test_id = get_compile_time_arg_val(4);
-    constexpr uint32_t sem_id = get_compile_time_arg_val(5);
-    constexpr uint32_t num_banks = get_compile_time_arg_val(6);
+    constexpr uint32_t num_of_transactions = get_compile_time_arg_val(0);
+    constexpr uint32_t page_size_bytes = get_compile_time_arg_val(1);
+    constexpr uint32_t test_id = get_compile_time_arg_val(2);
+    constexpr uint32_t sem_id = get_compile_time_arg_val(3);
+    constexpr uint32_t memory_type = get_compile_time_arg_val(4);
+    constexpr uint32_t mechanism = get_compile_time_arg_val(5);
+    constexpr uint32_t pattern = get_compile_time_arg_val(6);
+    constexpr uint32_t num_pages = get_compile_time_arg_val(7);
 
-    // Metadata args
-    constexpr uint32_t memory_type = get_compile_time_arg_val(7);
-    constexpr uint32_t mechanism = get_compile_time_arg_val(8);
-    constexpr uint32_t pattern = get_compile_time_arg_val(9);
+    // TensorAccessorArgs appended starting at compile arg index 8
+    auto accessor_args = TensorAccessorArgs<8>();
 
-    constexpr bool dram = true;
+    uint32_t dst_buffer_addr = get_arg_val<uint32_t>(0);
+    uint32_t l1_read_addr = get_arg_val<uint32_t>(1);
+    uint32_t start_page = get_arg_val<uint32_t>(2);
+    // Barrier args
+    uint32_t barrier_sem_id = get_arg_val<uint32_t>(3);
+    uint32_t barrier_coord_x = get_arg_val<uint32_t>(4);
+    uint32_t barrier_coord_y = get_arg_val<uint32_t>(5);
+    uint32_t num_cores = get_arg_val<uint32_t>(6);
+    uint32_t local_scratch_addr = get_arg_val<uint32_t>(7);
 
-    uint32_t sem_addr = get_semaphore(sem_id);
-    auto sem_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(sem_addr);
+    auto s = TensorAccessor(accessor_args, dst_buffer_addr, page_size_bytes);
 
-    noc_semaphore_wait(sem_ptr, 1);
+    experimental::Noc noc(noc_index);
+    experimental::UnicastEndpoint unicast_ep;
+
+    barrier_sync(barrier_sem_id, barrier_coord_x, barrier_coord_y, num_cores, local_scratch_addr);
 
     {
         DeviceZoneScopedN("RISCV0");
         for (uint32_t i = 0; i < num_of_transactions; i++) {
-            uint32_t bank = i % num_banks;
-            uint64_t dram_noc_addr = get_noc_addr_from_bank_id<dram>(bank, dram_addr);
-            noc_async_write(local_l1_addr, dram_noc_addr, bytes_per_transaction);
+            uint32_t page_id;
+            if constexpr (memory_type == MEMORY_TYPE_DRAM_SHARDED) {
+                page_id = start_page;
+            } else {
+                page_id = (start_page + i) % num_pages;
+            }
+            noc.async_write(unicast_ep, s, page_size_bytes, {.addr = l1_read_addr}, {.page_id = page_id});
         }
-        noc_async_write_barrier();
+        noc.async_write_barrier();
     }
 
     log_estimator_metadata(
-        test_id, noc_index, num_of_transactions, bytes_per_transaction, memory_type, mechanism, pattern, 0, 0, 0, 0);
+        test_id, noc.get_noc_id(), num_of_transactions, page_size_bytes, memory_type, mechanism, pattern, 0, 0, 0, 0);
 }

--- a/tests/tt_metal/tt_metal/data_movement/noc_estimator_tests/kernels/log_helpers.hpp
+++ b/tests/tt_metal/tt_metal/data_movement/noc_estimator_tests/kernels/log_helpers.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/tests/tt_metal/tt_metal/data_movement/noc_estimator_tests/kernels/log_helpers.hpp
+++ b/tests/tt_metal/tt_metal/data_movement/noc_estimator_tests/kernels/log_helpers.hpp
@@ -1,0 +1,63 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "api/debug/dprint.h"
+
+// Memory type
+constexpr uint32_t MEMORY_TYPE_L1 = 0;
+constexpr uint32_t MEMORY_TYPE_DRAM = 1;
+
+// Mechanism
+constexpr uint32_t MECHANISM_UNICAST = 0;
+constexpr uint32_t MECHANISM_MULTICAST = 1;
+constexpr uint32_t MECHANISM_MULTICAST_LINKED = 2;
+
+// Pattern
+constexpr uint32_t PATTERN_ONE_TO_ONE = 0;
+constexpr uint32_t PATTERN_ONE_FROM_ONE = 1;
+constexpr uint32_t PATTERN_ONE_TO_ALL = 2;
+constexpr uint32_t PATTERN_ONE_FROM_ALL = 3;
+constexpr uint32_t PATTERN_ALL_TO_ALL = 4;
+constexpr uint32_t PATTERN_ALL_FROM_ALL = 5;
+constexpr uint32_t PATTERN_ONE_TO_ROW = 6;
+constexpr uint32_t PATTERN_ROW_TO_ROW = 7;
+constexpr uint32_t PATTERN_ONE_TO_COLUMN = 8;
+constexpr uint32_t PATTERN_COLUMN_TO_COLUMN = 9;
+
+// Writer kernel modes
+constexpr uint32_t WRITER_MODE_UNICAST_SINGLE = 0;
+constexpr uint32_t WRITER_MODE_UNICAST_MULTI = 1;
+constexpr uint32_t WRITER_MODE_MULTICAST = 2;
+constexpr uint32_t WRITER_MODE_MULTICAST_LINKED = 3;
+
+// Reader kernel modes
+constexpr uint32_t READER_MODE_SINGLE = 0;
+constexpr uint32_t READER_MODE_MULTI = 1;
+
+FORCE_INLINE void log_estimator_metadata(
+    uint32_t test_id,
+    uint32_t noc_idx,
+    uint32_t num_transactions,
+    uint32_t transaction_size_bytes,
+    uint32_t memory_type,
+    uint32_t mechanism,
+    uint32_t pattern,
+    uint32_t num_subordinates,
+    uint32_t same_axis,
+    uint32_t stateful,
+    uint32_t loopback) {
+    DeviceTimestampedData("Test id", test_id);
+    DeviceTimestampedData("Number of transactions", num_transactions);
+    DeviceTimestampedData("Transaction size in bytes", transaction_size_bytes);
+    DeviceTimestampedData("NoC Index", noc_idx);
+    DeviceTimestampedData("Memory type", memory_type);
+    DeviceTimestampedData("Mechanism", mechanism);
+    DeviceTimestampedData("Pattern", pattern);
+    DeviceTimestampedData("Number of subordinates", num_subordinates);
+    DeviceTimestampedData("Same axis", same_axis);
+    DeviceTimestampedData("Stateful", stateful);
+    DeviceTimestampedData("Loopback", loopback);
+}

--- a/tests/tt_metal/tt_metal/data_movement/noc_estimator_tests/kernels/log_helpers.hpp
+++ b/tests/tt_metal/tt_metal/data_movement/noc_estimator_tests/kernels/log_helpers.hpp
@@ -6,7 +6,8 @@
 
 // Memory type
 constexpr uint32_t MEMORY_TYPE_L1 = 0;
-constexpr uint32_t MEMORY_TYPE_DRAM = 1;
+constexpr uint32_t MEMORY_TYPE_DRAM_INTERLEAVED = 1;
+constexpr uint32_t MEMORY_TYPE_DRAM_SHARDED = 2;
 
 // Mechanism
 constexpr uint32_t MECHANISM_UNICAST = 0;

--- a/tests/tt_metal/tt_metal/data_movement/noc_estimator_tests/kernels/log_helpers.hpp
+++ b/tests/tt_metal/tt_metal/data_movement/noc_estimator_tests/kernels/log_helpers.hpp
@@ -4,8 +4,6 @@
 
 #pragma once
 
-#include "api/debug/dprint.h"
-
 // Memory type
 constexpr uint32_t MEMORY_TYPE_L1 = 0;
 constexpr uint32_t MEMORY_TYPE_DRAM = 1;

--- a/tests/tt_metal/tt_metal/data_movement/noc_estimator_tests/kernels/reader.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/noc_estimator_tests/kernels/reader.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/tests/tt_metal/tt_metal/data_movement/noc_estimator_tests/kernels/reader.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/noc_estimator_tests/kernels/reader.cpp
@@ -9,7 +9,6 @@
 
 #include "api/dataflow/dataflow_api.h"
 #include "experimental/endpoints.h"
-#include "api/debug/dprint.h"
 #include "log_helpers.hpp"
 
 void kernel_main() {

--- a/tests/tt_metal/tt_metal/data_movement/noc_estimator_tests/kernels/reader.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/noc_estimator_tests/kernels/reader.cpp
@@ -1,0 +1,136 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Unified L1 read kernel for NOC estimator tests.
+// Supports single source and multi source read modes.
+// stateful=true uses set_state+with_state, stateful=false uses async_read.
+// All modes use the experimental Noc API.
+
+#include "api/dataflow/dataflow_api.h"
+#include "experimental/endpoints.h"
+#include "api/debug/dprint.h"
+#include "log_helpers.hpp"
+
+void kernel_main() {
+    // ============ Compile-time arguments ============
+    constexpr uint32_t local_addr = get_compile_time_arg_val(0);
+    constexpr uint32_t num_of_transactions = get_compile_time_arg_val(1);
+    constexpr uint32_t bytes_per_transaction = get_compile_time_arg_val(2);
+    constexpr uint32_t test_id = get_compile_time_arg_val(3);
+    constexpr uint32_t mode = get_compile_time_arg_val(4);
+    constexpr uint32_t num_subordinates = get_compile_time_arg_val(5);
+    constexpr uint32_t stateful = get_compile_time_arg_val(6);
+    constexpr uint32_t num_virtual_channels = get_compile_time_arg_val(7);
+
+    // Metadata args (for logging only)
+    constexpr uint32_t memory_type = get_compile_time_arg_val(8);
+    constexpr uint32_t mechanism = get_compile_time_arg_val(9);
+    constexpr uint32_t pattern = get_compile_time_arg_val(10);
+    constexpr uint32_t same_axis = get_compile_time_arg_val(11);
+    constexpr uint32_t loopback_meta = get_compile_time_arg_val(12);
+
+    experimental::Noc noc(noc_index);
+    experimental::UnicastEndpoint unicast_ep;
+
+    // ============ MODE 0: READ SINGLE (one_from_one) ============
+    if constexpr (mode == READER_MODE_SINGLE) {
+        // Runtime args: source core coordinates
+        uint32_t src_x = get_arg_val<uint32_t>(0);
+        uint32_t src_y = get_arg_val<uint32_t>(1);
+
+        if constexpr (stateful) {
+            {
+                DeviceZoneScopedN("RISCV1");
+                noc.set_async_read_state(
+                    unicast_ep, bytes_per_transaction, {.noc_x = src_x, .noc_y = src_y, .addr = local_addr});
+                for (uint32_t i = 0; i < num_of_transactions; i++) {
+                    noc.async_read_with_state(
+                        unicast_ep,
+                        unicast_ep,
+                        bytes_per_transaction,
+                        {.noc_x = src_x, .noc_y = src_y, .addr = local_addr},
+                        {.addr = local_addr});
+                }
+                noc.async_read_barrier();
+            }
+        } else {
+            {
+                DeviceZoneScopedN("RISCV1");
+                for (uint32_t i = 0; i < num_of_transactions; i++) {
+                    uint32_t vc = i % num_virtual_channels;
+                    noc.async_read(
+                        unicast_ep,
+                        unicast_ep,
+                        bytes_per_transaction,
+                        {.noc_x = src_x, .noc_y = src_y, .addr = local_addr},
+                        {.addr = local_addr},
+                        vc);
+                }
+                noc.async_read_barrier();
+            }
+        }
+
+        log_estimator_metadata(
+            test_id,
+            noc.get_noc_id(),
+            num_of_transactions,
+            bytes_per_transaction,
+            memory_type,
+            mechanism,
+            pattern,
+            0,
+            same_axis,
+            stateful,
+            loopback_meta);
+    }
+    // ============ MODE 1: READ MULTI (one_from_all, all_from_all) ============
+    else if constexpr (mode == READER_MODE_MULTI) {
+        {
+            DeviceZoneScopedN("RISCV1");
+            for (uint32_t sub = 0; sub < num_subordinates; sub++) {
+                uint32_t src_x = get_arg_val<uint32_t>(sub * 2);
+                uint32_t src_y = get_arg_val<uint32_t>(sub * 2 + 1);
+
+                if constexpr (stateful) {
+                    noc.set_async_read_state(
+                        unicast_ep, bytes_per_transaction, {.noc_x = src_x, .noc_y = src_y, .addr = local_addr});
+
+                    for (uint32_t i = 0; i < num_of_transactions; i++) {
+                        noc.async_read_with_state(
+                            unicast_ep,
+                            unicast_ep,
+                            bytes_per_transaction,
+                            {.noc_x = src_x, .noc_y = src_y, .addr = local_addr},
+                            {.addr = local_addr});
+                    }
+                } else {
+                    for (uint32_t i = 0; i < num_of_transactions; i++) {
+                        uint32_t vc = i % num_virtual_channels;
+                        noc.async_read(
+                            unicast_ep,
+                            unicast_ep,
+                            bytes_per_transaction,
+                            {.noc_x = src_x, .noc_y = src_y, .addr = local_addr},
+                            {.addr = local_addr},
+                            vc);
+                    }
+                }
+            }
+            noc.async_read_barrier();
+        }
+
+        log_estimator_metadata(
+            test_id,
+            noc.get_noc_id(),
+            num_of_transactions * num_subordinates,
+            bytes_per_transaction,
+            memory_type,
+            mechanism,
+            pattern,
+            num_subordinates,
+            same_axis,
+            stateful,
+            loopback_meta);
+    }
+}

--- a/tests/tt_metal/tt_metal/data_movement/noc_estimator_tests/kernels/writer.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/noc_estimator_tests/kernels/writer.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/tests/tt_metal/tt_metal/data_movement/noc_estimator_tests/kernels/writer.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/noc_estimator_tests/kernels/writer.cpp
@@ -9,7 +9,6 @@
 
 #include "api/dataflow/dataflow_api.h"
 #include "experimental/endpoints.h"
-#include "api/debug/dprint.h"
 #include "log_helpers.hpp"
 
 void kernel_main() {

--- a/tests/tt_metal/tt_metal/data_movement/noc_estimator_tests/kernels/writer.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/noc_estimator_tests/kernels/writer.cpp
@@ -1,0 +1,254 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Unified L1 write kernel for NOC estimator tests.
+// Supports unicast single/multi, multicast, and multicast linked modes.
+// For unicast modes: stateful=true uses set_state+with_state, stateful=false uses async_write.
+// For multicast modes: always uses async_write_multicast (no stateful variant exists).
+
+#include "api/dataflow/dataflow_api.h"
+#include "experimental/endpoints.h"
+#include "api/debug/dprint.h"
+#include "log_helpers.hpp"
+
+void kernel_main() {
+    // ============ Compile-time arguments ============
+    // Common args
+    constexpr uint32_t src_addr = get_compile_time_arg_val(0);
+    constexpr uint32_t dst_addr = get_compile_time_arg_val(1);
+    constexpr uint32_t num_of_transactions = get_compile_time_arg_val(2);
+    constexpr uint32_t bytes_per_transaction = get_compile_time_arg_val(3);
+    constexpr uint32_t test_id = get_compile_time_arg_val(4);
+    constexpr uint32_t mode = get_compile_time_arg_val(5);
+    constexpr uint32_t num_subordinates = get_compile_time_arg_val(6);
+    constexpr uint32_t stateful = get_compile_time_arg_val(7);
+    constexpr uint32_t num_virtual_channels = get_compile_time_arg_val(8);
+
+    // Multicast-specific args (unused modes set to 0)
+    constexpr uint32_t loopback = get_compile_time_arg_val(9);
+    uint32_t mcast_start_x = get_compile_time_arg_val(10);
+    uint32_t mcast_start_y = get_compile_time_arg_val(11);
+    uint32_t mcast_end_x = get_compile_time_arg_val(12);
+    uint32_t mcast_end_y = get_compile_time_arg_val(13);
+
+    // Unicast single: packed destination coordinate
+    constexpr uint32_t packed_dest_coord = get_compile_time_arg_val(14);
+
+    // Metadata args (for logging only, not used in kernel logic)
+    constexpr uint32_t memory_type = get_compile_time_arg_val(15);
+    constexpr uint32_t mechanism = get_compile_time_arg_val(16);
+    constexpr uint32_t pattern = get_compile_time_arg_val(17);
+    constexpr uint32_t same_axis = get_compile_time_arg_val(18);
+    constexpr uint32_t loopback_meta = get_compile_time_arg_val(19);
+
+    experimental::Noc noc(noc_index);
+    experimental::UnicastEndpoint unicast_ep;
+    experimental::MulticastEndpoint multicast_ep;
+
+    // ============ MODE 0: UNICAST SINGLE (one_to_one) ============
+    if constexpr (mode == WRITER_MODE_UNICAST_SINGLE) {
+        constexpr uint32_t dest_x = packed_dest_coord >> 16;
+        constexpr uint32_t dest_y = packed_dest_coord & 0xFFFF;
+
+        if constexpr (stateful) {
+            {
+                DeviceZoneScopedN("RISCV0");
+                noc.set_async_write_state(
+                    unicast_ep, bytes_per_transaction, {.noc_x = dest_x, .noc_y = dest_y, .addr = dst_addr});
+                for (uint32_t i = 0; i < num_of_transactions; i++) {
+                    noc.async_write_with_state(
+                        unicast_ep,
+                        unicast_ep,
+                        bytes_per_transaction,
+                        {.addr = src_addr},
+                        {.noc_x = dest_x, .noc_y = dest_y, .addr = dst_addr});
+                }
+                noc.async_write_barrier();
+            }
+        } else {
+            {
+                DeviceZoneScopedN("RISCV0");
+                for (uint32_t i = 0; i < num_of_transactions; i++) {
+                    uint32_t vc = i % num_virtual_channels;
+                    noc.async_write(
+                        unicast_ep,
+                        unicast_ep,
+                        bytes_per_transaction,
+                        {.addr = src_addr},
+                        {.noc_x = dest_x, .noc_y = dest_y, .addr = dst_addr},
+                        vc);
+                }
+                noc.async_write_barrier();
+            }
+        }
+
+        log_estimator_metadata(
+            test_id,
+            noc.get_noc_id(),
+            num_of_transactions,
+            bytes_per_transaction,
+            memory_type,
+            mechanism,
+            pattern,
+            0,
+            same_axis,
+            stateful,
+            loopback_meta);
+    }
+    // ============ MODE 1: UNICAST MULTI (one_to_all unicast, all_to_all) ============
+    else if constexpr (mode == WRITER_MODE_UNICAST_MULTI) {
+        {
+            DeviceZoneScopedN("RISCV0");
+            for (uint32_t sub = 0; sub < num_subordinates; sub++) {
+                uint32_t dest_packed = get_arg_val<uint32_t>(sub);
+                uint32_t dest_x = dest_packed >> 16;
+                uint32_t dest_y = dest_packed & 0xFFFF;
+
+                if constexpr (stateful) {
+                    noc.set_async_write_state(
+                        unicast_ep, bytes_per_transaction, {.noc_x = dest_x, .noc_y = dest_y, .addr = dst_addr});
+                    for (uint32_t i = 0; i < num_of_transactions; i++) {
+                        noc.async_write_with_state(
+                            unicast_ep,
+                            unicast_ep,
+                            bytes_per_transaction,
+                            {.addr = src_addr},
+                            {.noc_x = dest_x, .noc_y = dest_y, .addr = dst_addr});
+                    }
+                } else {
+                    for (uint32_t i = 0; i < num_of_transactions; i++) {
+                        // uint32_t vc = i % num_virtual_channels;
+                        noc.async_write(
+                            unicast_ep,
+                            unicast_ep,
+                            bytes_per_transaction,
+                            {.addr = src_addr},
+                            {.noc_x = dest_x, .noc_y = dest_y, .addr = dst_addr},
+                            0);
+                    }
+                }
+            }
+            noc.async_write_barrier();
+        }
+
+        log_estimator_metadata(
+            test_id,
+            noc.get_noc_id(),
+            num_of_transactions * num_subordinates,
+            bytes_per_transaction,
+            memory_type,
+            mechanism,
+            pattern,
+            num_subordinates,
+            same_axis,
+            stateful,
+            loopback_meta);
+    }
+    // ============ MODE 2: MULTICAST (non-linked) ============
+    else if constexpr (mode == WRITER_MODE_MULTICAST) {
+        if (noc_index == 1) {
+            uint32_t tmp;
+            tmp = mcast_start_x;
+            mcast_start_x = mcast_end_x;
+            mcast_end_x = tmp;
+            tmp = mcast_start_y;
+            mcast_start_y = mcast_end_y;
+            mcast_end_y = tmp;
+        }
+
+        constexpr experimental::Noc::McastMode mcast_mode =
+            loopback ? experimental::Noc::McastMode::INCLUDE_SRC : experimental::Noc::McastMode::EXCLUDE_SRC;
+
+        {
+            DeviceZoneScopedN("RISCV0");
+            for (uint32_t i = 0; i < num_of_transactions; i++) {
+                noc.async_write_multicast<mcast_mode>(
+                    unicast_ep,
+                    multicast_ep,
+                    bytes_per_transaction,
+                    num_subordinates,
+                    {.addr = src_addr},
+                    {.noc_x_start = mcast_start_x,
+                     .noc_y_start = mcast_start_y,
+                     .noc_x_end = mcast_end_x,
+                     .noc_y_end = mcast_end_y,
+                     .addr = dst_addr});
+            }
+            noc.async_write_barrier();
+        }
+
+        log_estimator_metadata(
+            test_id,
+            noc.get_noc_id(),
+            num_of_transactions,
+            bytes_per_transaction,
+            memory_type,
+            mechanism,
+            pattern,
+            num_subordinates,
+            same_axis,
+            stateful,
+            loopback_meta);
+    }
+    // ============ MODE 3: MULTICAST LINKED ============
+    else if constexpr (mode == WRITER_MODE_MULTICAST_LINKED) {
+        if (noc_index == 1) {
+            uint32_t tmp;
+            tmp = mcast_start_x;
+            mcast_start_x = mcast_end_x;
+            mcast_end_x = tmp;
+            tmp = mcast_start_y;
+            mcast_start_y = mcast_end_y;
+            mcast_end_y = tmp;
+        }
+
+        constexpr experimental::Noc::McastMode mcast_mode =
+            loopback ? experimental::Noc::McastMode::INCLUDE_SRC : experimental::Noc::McastMode::EXCLUDE_SRC;
+
+        {
+            DeviceZoneScopedN("RISCV0");
+            // All but the last packet: linked=true to reserve the VC path
+            for (uint32_t i = 0; i < num_of_transactions - 1; i++) {
+                noc.async_write_multicast<mcast_mode>(
+                    unicast_ep,
+                    multicast_ep,
+                    bytes_per_transaction,
+                    num_subordinates,
+                    {.addr = src_addr},
+                    {.noc_x_start = mcast_start_x,
+                     .noc_y_start = mcast_start_y,
+                     .noc_x_end = mcast_end_x,
+                     .noc_y_end = mcast_end_y,
+                     .addr = dst_addr},
+                    true);  // linked
+            }
+            // Last packet: unlinked to release the VC
+            noc.async_write_multicast<mcast_mode>(
+                unicast_ep,
+                multicast_ep,
+                bytes_per_transaction,
+                num_subordinates,
+                {.addr = src_addr},
+                {.noc_x_start = mcast_start_x,
+                 .noc_y_start = mcast_start_y,
+                 .noc_x_end = mcast_end_x,
+                 .noc_y_end = mcast_end_y,
+                 .addr = dst_addr});
+            noc.async_write_barrier();
+        }
+
+        log_estimator_metadata(
+            test_id,
+            noc.get_noc_id(),
+            num_of_transactions,
+            bytes_per_transaction,
+            memory_type,
+            mechanism,
+            pattern,
+            num_subordinates,
+            same_axis,
+            stateful,
+            loopback_meta);
+    }
+}

--- a/tests/tt_metal/tt_metal/data_movement/noc_estimator_tests/test_noc_estimator.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/noc_estimator_tests/test_noc_estimator.cpp
@@ -10,7 +10,9 @@
 #include <tt-metalium/distributed.hpp>
 #include <tt-metalium/mesh_coord.hpp>
 #include <tt-metalium/host_api.hpp>
+#include <tt-metalium/tensor_accessor_args.hpp>
 #include <distributed/mesh_device_impl.hpp>
+#include <algorithm>
 
 namespace tt::tt_metal {
 
@@ -43,7 +45,8 @@ enum class NocMechanism : uint32_t {
 
 enum class MemoryType : uint32_t {
     L1 = 0,
-    DRAM = 1,
+    DRAM_INTERLEAVED = 1,
+    DRAM_SHARDED = 2,
 };
 
 // Writer kernel modes (must match log_helpers.hpp constants)
@@ -599,105 +602,33 @@ static bool run_many_to_many_multicast(
     return true;
 }
 
-// Handles DRAM read+write (reader on RISCV_1, writer on RISCV_0, synchronized by semaphore)
-static bool run_dram(const shared_ptr<distributed::MeshDevice>& mesh_device, const NocEstimatorConfig& cfg) {
-    IDevice* device = mesh_device->impl().get_device(0);
-    Program program = CreateProgram();
+enum class DramDirection { READ, WRITE };
 
-    const size_t bytes_per_txn = cfg.pages_per_transaction * cfg.bytes_per_page;
-
-    CoreCoord core_coord = {0, 0};
-    CoreRangeSet core_set({CoreRange(core_coord)});
-
-    // DRAM and L1 addresses
-    DramAddressInfo dram_info = unit_tests::dm::get_dram_address_and_size();
-    uint32_t input_dram_addr = dram_info.base_address;
-    uint32_t output_dram_addr = input_dram_addr + (uint32_t)bytes_per_txn;
-
-    L1AddressInfo l1_info = unit_tests::dm::get_l1_address_and_size(mesh_device, core_coord);
-    uint32_t l1_addr = l1_info.base_address;
-
-    uint32_t sem_id = CreateSemaphore(program, core_set, 0);
-
-    // DRAM metadata args
-    uint32_t mem_type = (uint32_t)MemoryType::DRAM;
-    uint32_t mech = (uint32_t)NocMechanism::UNICAST;
-
-    uint32_t num_banks = 1;
-
-    // Reader kernel (RISCV_1): reads from DRAM input to L1
-    vector<uint32_t> reader_args = {
-        l1_addr,
-        input_dram_addr,
-        cfg.num_of_transactions,
-        (uint32_t)bytes_per_txn,
-        cfg.test_id,
-        sem_id,
-        num_banks,
-        mem_type,
-        mech,
-        (uint32_t)NocPattern::ONE_FROM_ONE};
-
-    CreateKernel(
-        program,
-        KERNELS_DIR + "dram_reader.cpp",
-        core_coord,
-        DataMovementConfig{
-            .processor = DataMovementProcessor::RISCV_1, .noc = NOC::RISCV_1_default, .compile_args = reader_args});
-
-    // Writer kernel (RISCV_0): writes from L1 to DRAM output
-    vector<uint32_t> writer_args = {
-        l1_addr,
-        output_dram_addr,
-        cfg.num_of_transactions,
-        (uint32_t)bytes_per_txn,
-        cfg.test_id,
-        sem_id,
-        num_banks,
-        mem_type,
-        mech,
-        (uint32_t)NocPattern::ONE_TO_ONE};
-
-    CreateKernel(
-        program,
-        KERNELS_DIR + "dram_writer.cpp",
-        core_coord,
-        DataMovementConfig{
-            .processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default, .compile_args = writer_args});
-
-    log_info(LogTest, "Running Test ID: {}, Run ID: {}", cfg.test_id, unit_tests::dm::runtime_host_id);
-    program.set_runtime_id(unit_tests::dm::runtime_host_id++);
-
-    auto packed_input = make_test_data(bytes_per_txn);
-    auto packed_golden = packed_input;
-
-    detail::WriteToDeviceDRAMChannel(device, cfg.dram_channel, input_dram_addr, packed_input);
-    MetalContext::instance().get_cluster().dram_barrier(device->id());
-
-    execute_program(mesh_device, std::move(program));
-
-    vector<uint32_t> packed_output;
-    detail::ReadFromDeviceDRAMChannel(
-        device, cfg.dram_channel, output_dram_addr, (uint32_t)bytes_per_txn, packed_output);
-
-    bool is_equal = (packed_output == packed_golden);
-    if (!is_equal) {
-        log_error(LogTest, "DRAM Equality Check failed for test_id {}", cfg.test_id);
-    }
-    return is_equal;
-}
-
-// Handles interleaved DRAM read+write where each core cycles through ALL DRAM banks in round-robin.
-// Used for both one_from_all (1 core) and all_from_all (N cores) DRAM patterns.
-static bool run_dram_interleaved(
+// Unified DRAM run function using TensorAccessor + experimental Noc 2.0 API.
+// Launches reader OR writer kernel in isolation (no dual-kernel L1 contention).
+// For interleaved mode: each core cycles through all banks via sequential page IDs.
+// For sharded mode: each core reads/writes only the page(s) mapping to its dedicated bank.
+static bool run_dram_accessor(
     const shared_ptr<distributed::MeshDevice>& mesh_device,
     const NocEstimatorConfig& cfg,
-    const vector<CoreCoord>& cores) {
+    const vector<CoreCoord>& cores,
+    const vector<uint32_t>& bank_assignments,
+    DramDirection direction) {
     IDevice* device = mesh_device->impl().get_device(0);
     Program program = CreateProgram();
 
     const size_t bytes_per_txn = cfg.pages_per_transaction * cfg.bytes_per_page;
     uint32_t num_dram_banks = (uint32_t)device->num_dram_channels();
+    uint32_t num_cores = (uint32_t)cores.size();
+
+    uint32_t num_pages = num_dram_banks;
+
+    InterleavedBufferConfig buf_config{
+        .device = device,
+        .size = (size_t)num_pages * bytes_per_txn,
+        .page_size = (uint32_t)bytes_per_txn,
+        .buffer_type = BufferType::DRAM};
+    auto dram_buffer = CreateBuffer(buf_config);
 
     std::set<CoreRange> core_ranges;
     for (auto& c : cores) {
@@ -705,97 +636,75 @@ static bool run_dram_interleaved(
     }
     CoreRangeSet core_set(core_ranges);
 
-    DramAddressInfo dram_info = unit_tests::dm::get_dram_address_and_size();
-    uint32_t input_dram_addr = dram_info.base_address;
-    uint32_t output_dram_addr = input_dram_addr + (uint32_t)bytes_per_txn;
-
     L1AddressInfo l1_info = unit_tests::dm::get_l1_address_and_size(mesh_device, cores[0]);
     uint32_t l1_addr = l1_info.base_address;
 
-    uint32_t sem_id = CreateSemaphore(program, core_set, 0);
+    uint32_t barrier_sem_id = CreateSemaphore(program, core_set, 0);
 
-    uint32_t mem_type = (uint32_t)MemoryType::DRAM;
+    CoreCoord coordinator_phys = device->worker_core_from_logical_core(cores[0]);
+    uint32_t local_scratch_addr = l1_addr + (uint32_t)bytes_per_txn;
+
+    uint32_t mem_type = (uint32_t)cfg.memory_type;
     uint32_t mech = (uint32_t)NocMechanism::UNICAST;
 
-    // Reader pattern matches cfg; writer uses the corresponding write pattern
-    NocPattern writer_pattern =
-        (cfg.pattern == NocPattern::ONE_FROM_ALL) ? NocPattern::ONE_TO_ALL : NocPattern::ALL_TO_ALL;
+    bool is_read = (direction == DramDirection::READ);
+    string kernel_file = is_read ? "dram_reader.cpp" : "dram_writer.cpp";
+    auto processor = is_read ? DataMovementProcessor::RISCV_1 : DataMovementProcessor::RISCV_0;
 
-    vector<uint32_t> reader_compile_args = {
-        l1_addr,
-        input_dram_addr,
-        cfg.num_of_transactions,
-        (uint32_t)bytes_per_txn,
-        cfg.test_id,
-        sem_id,
-        num_dram_banks,
-        mem_type,
-        mech,
-        (uint32_t)cfg.pattern};
+    vector<uint32_t> compile_args = {
+        cfg.num_of_transactions,  // 0
+        (uint32_t)bytes_per_txn,  // 1
+        cfg.test_id,              // 2
+        0,                        // 3 (sem_id unused)
+        mem_type,                 // 4
+        mech,                     // 5
+        (uint32_t)cfg.pattern,    // 6
+        num_pages,                // 7
+    };
+    TensorAccessorArgs(*dram_buffer).append_to(compile_args);
 
-    CreateKernel(
+    auto kernel = CreateKernel(
         program,
-        KERNELS_DIR + "dram_reader.cpp",
+        KERNELS_DIR + kernel_file,
         core_set,
-        DataMovementConfig{
-            .processor = DataMovementProcessor::RISCV_1,
-            .noc = NOC::RISCV_1_default,
-            .compile_args = reader_compile_args});
+        DataMovementConfig{.processor = processor, .noc = cfg.noc_id, .compile_args = compile_args});
 
-    vector<uint32_t> writer_compile_args = {
-        l1_addr,
-        output_dram_addr,
-        cfg.num_of_transactions,
-        (uint32_t)bytes_per_txn,
-        cfg.test_id,
-        sem_id,
-        num_dram_banks,
-        mem_type,
-        mech,
-        (uint32_t)writer_pattern};
-
-    CreateKernel(
-        program,
-        KERNELS_DIR + "dram_writer.cpp",
-        core_set,
-        DataMovementConfig{
-            .processor = DataMovementProcessor::RISCV_0,
-            .noc = NOC::RISCV_0_default,
-            .compile_args = writer_compile_args});
+    for (size_t i = 0; i < cores.size(); i++) {
+        uint32_t start_page = bank_assignments[i];
+        vector<uint32_t> rt_args = {
+            dram_buffer->address(),
+            l1_addr,
+            start_page,
+            barrier_sem_id,
+            coordinator_phys.x,
+            coordinator_phys.y,
+            num_cores,
+            local_scratch_addr};
+        SetRuntimeArgs(program, kernel, cores[i], rt_args);
+    }
 
     log_info(LogTest, "Running Test ID: {}, Run ID: {}", cfg.test_id, unit_tests::dm::runtime_host_id);
     program.set_runtime_id(unit_tests::dm::runtime_host_id++);
 
-    auto packed_input = make_test_data(bytes_per_txn);
-    auto packed_golden = packed_input;
-
-    // Write same input data to all DRAM banks (each bank gets the same content)
-    for (uint32_t bank = 0; bank < num_dram_banks; bank++) {
-        detail::WriteToDeviceDRAMChannel(device, bank, input_dram_addr, packed_input);
+    // For reads: fill DRAM buffer with test data so the kernel has something to read.
+    // For writes: fill L1 source region via DRAM buffer init (data will be overwritten by kernel).
+    auto page_data = make_test_data(bytes_per_txn);
+    vector<uint32_t> full_input;
+    full_input.reserve(num_pages * page_data.size());
+    for (uint32_t p = 0; p < num_pages; p++) {
+        full_input.insert(full_input.end(), page_data.begin(), page_data.end());
     }
+    detail::WriteToBuffer(dram_buffer, full_input);
     MetalContext::instance().get_cluster().dram_barrier(device->id());
 
     execute_program(mesh_device, std::move(program));
 
-    // Verify output from banks that were written to (round-robin covers up to num_banks)
-    uint32_t banks_to_verify = cfg.num_of_transactions < num_dram_banks ? cfg.num_of_transactions : num_dram_banks;
-    for (uint32_t bank = 0; bank < banks_to_verify; bank++) {
-        vector<uint32_t> packed_output;
-        detail::ReadFromDeviceDRAMChannel(device, bank, output_dram_addr, (uint32_t)bytes_per_txn, packed_output);
-        if (packed_output != packed_golden) {
-            log_error(LogTest, "DRAM Interleaved Equality Check failed for test_id {}, bank {}", cfg.test_id, bank);
-            return false;
-        }
-    }
     return true;
 }
 
 // ============ DISPATCH ============
 
 static bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const NocEstimatorConfig& cfg) {
-    if (cfg.memory_type == MemoryType::DRAM) {
-        return run_dram(mesh_device, cfg);
-    }
     switch (cfg.pattern) {
         case NocPattern::ONE_TO_ONE:
         case NocPattern::ONE_FROM_ONE: return run_single_core(mesh_device, cfg);
@@ -1053,111 +962,194 @@ static void sweep_all_from_all(const shared_ptr<distributed::MeshDevice>& mesh_d
     }
 }
 
-static void sweep_dram(const shared_ptr<distributed::MeshDevice>& mesh_device, uint32_t test_id) {
+// ============ DRAM ACCESSOR SWEEP FUNCTIONS ============
+
+// Helper: run a DRAM accessor sweep with the given cores, bank assignments, and direction.
+// Sweeps both NOC_0 and NOC_1 for each configuration.
+static void dram_accessor_sweep(
+    const shared_ptr<distributed::MeshDevice>& mesh_device,
+    uint32_t test_id,
+    NocPattern pattern,
+    MemoryType memory_type,
+    const vector<CoreCoord>& cores,
+    const vector<uint32_t>& bank_assignments,
+    DramDirection direction) {
     auto [bytes_per_page, max_bytes, max_pages] = unit_tests::dm::compute_physical_constraints(mesh_device);
 
+    log_info(LogTest, "Cores: {}", cores);
     uint32_t max_transactions = 256;
     uint32_t max_pages_per_txn = 256;
 
-    for (uint32_t num_txn = 1; num_txn <= max_transactions; num_txn *= 4) {
-        for (uint32_t pages = 1; pages <= max_pages_per_txn; pages *= 2) {
-            if (num_txn * pages * bytes_per_page >= max_bytes) {
-                continue;
+    for (NOC noc : {NOC::NOC_0, NOC::NOC_1}) {
+        for (uint32_t num_txn = 1; num_txn <= max_transactions; num_txn *= 4) {
+            for (uint32_t pages = 1; pages <= max_pages_per_txn; pages *= 2) {
+                if (num_txn * pages * bytes_per_page >= max_bytes) {
+                    continue;
+                }
+
+                NocEstimatorConfig cfg = {
+                    .test_id = test_id,
+                    .pattern = pattern,
+                    .mechanism = NocMechanism::UNICAST,
+                    .memory_type = memory_type,
+                    .num_of_transactions = num_txn,
+                    .pages_per_transaction = pages,
+                    .bytes_per_page = bytes_per_page,
+                    .noc_id = noc,
+                };
+                EXPECT_TRUE(run_dram_accessor(mesh_device, cfg, cores, bank_assignments, direction));
             }
-
-            NocEstimatorConfig cfg = {
-                .test_id = test_id,
-                .pattern = NocPattern::ONE_TO_ONE,
-                .mechanism = NocMechanism::UNICAST,
-                .memory_type = MemoryType::DRAM,
-                .num_of_transactions = num_txn,
-                .pages_per_transaction = pages,
-                .bytes_per_page = bytes_per_page,
-            };
-            EXPECT_TRUE(run_dm(mesh_device, cfg));
-        }
-    }
-}
-
-// ============ MULTI-BANK DRAM SWEEP FUNCTIONS ============
-
-// Single core reading/writing ALL DRAM banks in round-robin (interleaved access pattern).
-// Measures how well one core can utilize multi-bank parallelism.
-static void sweep_dram_one_from_all(const shared_ptr<distributed::MeshDevice>& mesh_device, uint32_t test_id) {
-    auto [bytes_per_page, max_bytes, max_pages] = unit_tests::dm::compute_physical_constraints(mesh_device);
-
-    vector<CoreCoord> cores = {{0, 0}};
-
-    uint32_t max_transactions = 256;
-    uint32_t max_pages_per_txn = 256;
-
-    for (uint32_t num_txn = 1; num_txn <= max_transactions; num_txn *= 4) {
-        for (uint32_t pages = 1; pages <= max_pages_per_txn; pages *= 2) {
-            if (num_txn * pages * bytes_per_page >= max_bytes) {
-                continue;
-            }
-
-            NocEstimatorConfig cfg = {
-                .test_id = test_id,
-                .pattern = NocPattern::ONE_FROM_ALL,
-                .mechanism = NocMechanism::UNICAST,
-                .memory_type = MemoryType::DRAM,
-                .num_of_transactions = num_txn,
-                .pages_per_transaction = pages,
-                .bytes_per_page = bytes_per_page,
-            };
-            EXPECT_TRUE(run_dram_interleaved(mesh_device, cfg, cores));
         }
     }
 
     ReadMeshDeviceProfilerResults(*mesh_device);
 }
 
-// Multiple diagonal cores, each reading/writing ALL DRAM banks in round-robin.
-// Measures aggregate bandwidth when multiple cores contend for the same banks.
-static void sweep_dram_all_from_all(const shared_ptr<distributed::MeshDevice>& mesh_device, uint32_t test_id) {
-    auto [bytes_per_page, max_bytes, max_pages] = unit_tests::dm::compute_physical_constraints(mesh_device);
+// Helpers to build core/bank lists for sharded multi-core and interleaved all-core patterns
+static void get_sharded_all_cores(
+    const shared_ptr<distributed::MeshDevice>& mesh_device,
+    vector<CoreCoord>& cores,
+    vector<uint32_t>& bank_assignments) {
     IDevice* device = mesh_device->impl().get_device(0);
     CoreCoord device_grid = device->compute_with_storage_grid_size();
     uint32_t num_dram_banks = (uint32_t)device->num_dram_channels();
-
-    // Place one core per diagonal position, capped at the number of DRAM banks
-    uint32_t num_cores = (uint32_t)device_grid.x;
-    if ((uint32_t)device_grid.y < num_cores) {
-        num_cores = (uint32_t)device_grid.y;
-    }
-    if (num_dram_banks < num_cores) {
-        num_cores = num_dram_banks;
-    }
-
-    vector<CoreCoord> cores;
-    for (uint32_t i = 0; i < num_cores; i++) {
-        cores.push_back(CoreCoord(i, i));
-    }
-
-    uint32_t max_transactions = 256;
-    uint32_t max_pages_per_txn = 256;
-
-    for (uint32_t num_txn = 1; num_txn <= max_transactions; num_txn *= 4) {
-        for (uint32_t pages = 1; pages <= max_pages_per_txn; pages *= 2) {
-            if (num_txn * pages * bytes_per_page >= max_bytes) {
-                continue;
-            }
-
-            NocEstimatorConfig cfg = {
-                .test_id = test_id,
-                .pattern = NocPattern::ALL_FROM_ALL,
-                .mechanism = NocMechanism::UNICAST,
-                .memory_type = MemoryType::DRAM,
-                .num_of_transactions = num_txn,
-                .pages_per_transaction = pages,
-                .bytes_per_page = bytes_per_page,
-            };
-            EXPECT_TRUE(run_dram_interleaved(mesh_device, cfg, cores));
+    for (uint32_t y = 0; y < device_grid.y; y++) {
+        for (uint32_t x = 0; x < device_grid.x; x++) {
+            cores.push_back(CoreCoord(x, y));
+            bank_assignments.push_back((y * device_grid.x + x) % num_dram_banks);
         }
     }
+}
 
-    ReadMeshDeviceProfilerResults(*mesh_device);
+static void get_all_cores(
+    const shared_ptr<distributed::MeshDevice>& mesh_device,
+    vector<CoreCoord>& cores,
+    vector<uint32_t>& bank_assignments) {
+    IDevice* device = mesh_device->impl().get_device(0);
+    CoreCoord device_grid = device->compute_with_storage_grid_size();
+    uint32_t num_dram_banks = (uint32_t)device->num_dram_channels();
+    for (uint32_t y = 0; y < device_grid.y; y++) {
+        for (uint32_t x = 0; x < device_grid.x; x++) {
+            cores.push_back(CoreCoord(x, y));
+            bank_assignments.push_back((y * device_grid.x + x) % num_dram_banks);
+        }
+    }
+}
+
+// ---- READ sweeps ----
+
+static void sweep_dram_sharded_one_from_one(const shared_ptr<distributed::MeshDevice>& mesh_device, uint32_t test_id) {
+    vector<CoreCoord> cores = {{0, 0}};
+    vector<uint32_t> bank_assignments = {0};
+    dram_accessor_sweep(
+        mesh_device,
+        test_id,
+        NocPattern::ONE_FROM_ONE,
+        MemoryType::DRAM_SHARDED,
+        cores,
+        bank_assignments,
+        DramDirection::READ);
+}
+
+static void sweep_dram_sharded_all_from_all(const shared_ptr<distributed::MeshDevice>& mesh_device, uint32_t test_id) {
+    vector<CoreCoord> cores;
+    vector<uint32_t> bank_assignments;
+    get_sharded_all_cores(mesh_device, cores, bank_assignments);
+    dram_accessor_sweep(
+        mesh_device,
+        test_id,
+        NocPattern::ALL_FROM_ALL,
+        MemoryType::DRAM_SHARDED,
+        cores,
+        bank_assignments,
+        DramDirection::READ);
+}
+
+static void sweep_dram_interleaved_one_from_all(
+    const shared_ptr<distributed::MeshDevice>& mesh_device, uint32_t test_id) {
+    vector<CoreCoord> cores = {{0, 0}};
+    vector<uint32_t> bank_assignments = {0};
+    dram_accessor_sweep(
+        mesh_device,
+        test_id,
+        NocPattern::ONE_FROM_ALL,
+        MemoryType::DRAM_INTERLEAVED,
+        cores,
+        bank_assignments,
+        DramDirection::READ);
+}
+
+static void sweep_dram_interleaved_all_from_all(
+    const shared_ptr<distributed::MeshDevice>& mesh_device, uint32_t test_id) {
+    vector<CoreCoord> cores;
+    vector<uint32_t> bank_assignments;
+    get_all_cores(mesh_device, cores, bank_assignments);
+    dram_accessor_sweep(
+        mesh_device,
+        test_id,
+        NocPattern::ALL_FROM_ALL,
+        MemoryType::DRAM_INTERLEAVED,
+        cores,
+        bank_assignments,
+        DramDirection::READ);
+}
+
+// ---- WRITE sweeps ----
+
+static void sweep_dram_sharded_one_to_one(const shared_ptr<distributed::MeshDevice>& mesh_device, uint32_t test_id) {
+    vector<CoreCoord> cores = {{0, 0}};
+    vector<uint32_t> bank_assignments = {0};
+    dram_accessor_sweep(
+        mesh_device,
+        test_id,
+        NocPattern::ONE_TO_ONE,
+        MemoryType::DRAM_SHARDED,
+        cores,
+        bank_assignments,
+        DramDirection::WRITE);
+}
+
+static void sweep_dram_sharded_all_to_all(const shared_ptr<distributed::MeshDevice>& mesh_device, uint32_t test_id) {
+    vector<CoreCoord> cores;
+    vector<uint32_t> bank_assignments;
+    get_sharded_all_cores(mesh_device, cores, bank_assignments);
+    dram_accessor_sweep(
+        mesh_device,
+        test_id,
+        NocPattern::ALL_TO_ALL,
+        MemoryType::DRAM_SHARDED,
+        cores,
+        bank_assignments,
+        DramDirection::WRITE);
+}
+
+static void sweep_dram_interleaved_one_to_all(
+    const shared_ptr<distributed::MeshDevice>& mesh_device, uint32_t test_id) {
+    vector<CoreCoord> cores = {{0, 0}};
+    vector<uint32_t> bank_assignments = {0};
+    dram_accessor_sweep(
+        mesh_device,
+        test_id,
+        NocPattern::ONE_TO_ALL,
+        MemoryType::DRAM_INTERLEAVED,
+        cores,
+        bank_assignments,
+        DramDirection::WRITE);
+}
+
+static void sweep_dram_interleaved_all_to_all(
+    const shared_ptr<distributed::MeshDevice>& mesh_device, uint32_t test_id) {
+    vector<CoreCoord> cores;
+    vector<uint32_t> bank_assignments;
+    get_all_cores(mesh_device, cores, bank_assignments);
+    dram_accessor_sweep(
+        mesh_device,
+        test_id,
+        NocPattern::ALL_TO_ALL,
+        MemoryType::DRAM_INTERLEAVED,
+        cores,
+        bank_assignments,
+        DramDirection::WRITE);
 }
 
 // ============ ROW / COLUMN SWEEP FUNCTIONS ============
@@ -1388,6 +1380,7 @@ static void sweep_column_to_column(const shared_ptr<distributed::MeshDevice>& me
 
 // ============ TEST CASES ============
 
+// ---- L1 tests (800-809) ----
 TEST_F(GenericMeshDeviceFixture, NIGHTLY_NocEstimatorL1OneToOne) {
     unit_tests::dm::noc_estimator::sweep_one_to_one(get_mesh_device(), 800);
 }
@@ -1412,34 +1405,54 @@ TEST_F(GenericMeshDeviceFixture, NIGHTLY_NocEstimatorL1AllFromAll) {
     unit_tests::dm::noc_estimator::sweep_all_from_all(get_mesh_device(), 805);
 }
 
-TEST_F(GenericMeshDeviceFixture, NIGHTLY_NocEstimatorDRAM) {
-    unit_tests::dm::noc_estimator::sweep_dram(get_mesh_device(), 806);
-}
-
-TEST_F(GenericMeshDeviceFixture, NIGHTLY_NocEstimatorDRAMOneFromAll) {
-    unit_tests::dm::noc_estimator::sweep_dram_one_from_all(get_mesh_device(), 811);
-}
-
-TEST_F(GenericMeshDeviceFixture, NIGHTLY_NocEstimatorDRAMAllFromAll) {
-    unit_tests::dm::noc_estimator::sweep_dram_all_from_all(get_mesh_device(), 812);
-}
-
-// ============ ROW / COLUMN TESTS ============
-
 TEST_F(GenericMeshDeviceFixture, NIGHTLY_NocEstimatorL1OneToRow) {
-    unit_tests::dm::noc_estimator::sweep_one_to_row(get_mesh_device(), 807);
+    unit_tests::dm::noc_estimator::sweep_one_to_row(get_mesh_device(), 806);
 }
 
 TEST_F(GenericMeshDeviceFixture, NIGHTLY_NocEstimatorL1RowToRow) {
-    unit_tests::dm::noc_estimator::sweep_row_to_row(get_mesh_device(), 808);
+    unit_tests::dm::noc_estimator::sweep_row_to_row(get_mesh_device(), 807);
 }
 
 TEST_F(GenericMeshDeviceFixture, NIGHTLY_NocEstimatorL1OneToColumn) {
-    unit_tests::dm::noc_estimator::sweep_one_to_column(get_mesh_device(), 809);
+    unit_tests::dm::noc_estimator::sweep_one_to_column(get_mesh_device(), 808);
 }
 
 TEST_F(GenericMeshDeviceFixture, NIGHTLY_NocEstimatorL1ColumnToColumn) {
-    unit_tests::dm::noc_estimator::sweep_column_to_column(get_mesh_device(), 810);
+    unit_tests::dm::noc_estimator::sweep_column_to_column(get_mesh_device(), 809);
+}
+
+// ---- DRAM Read tests (810-813) ----
+TEST_F(GenericMeshDeviceFixture, NIGHTLY_NocEstimatorDRAMShardedOneFromOne) {
+    unit_tests::dm::noc_estimator::sweep_dram_sharded_one_from_one(get_mesh_device(), 810);
+}
+
+TEST_F(GenericMeshDeviceFixture, NIGHTLY_NocEstimatorDRAMShardedAllFromAll) {
+    unit_tests::dm::noc_estimator::sweep_dram_sharded_all_from_all(get_mesh_device(), 811);
+}
+
+TEST_F(GenericMeshDeviceFixture, NIGHTLY_NocEstimatorDRAMInterleavedOneFromAll) {
+    unit_tests::dm::noc_estimator::sweep_dram_interleaved_one_from_all(get_mesh_device(), 812);
+}
+
+TEST_F(GenericMeshDeviceFixture, NIGHTLY_NocEstimatorDRAMInterleavedAllFromAll) {
+    unit_tests::dm::noc_estimator::sweep_dram_interleaved_all_from_all(get_mesh_device(), 813);
+}
+
+// ---- DRAM Write tests (814-817) ----
+TEST_F(GenericMeshDeviceFixture, NIGHTLY_NocEstimatorDRAMShardedOneToOne) {
+    unit_tests::dm::noc_estimator::sweep_dram_sharded_one_to_one(get_mesh_device(), 814);
+}
+
+TEST_F(GenericMeshDeviceFixture, NIGHTLY_NocEstimatorDRAMShardedAllToAll) {
+    unit_tests::dm::noc_estimator::sweep_dram_sharded_all_to_all(get_mesh_device(), 815);
+}
+
+TEST_F(GenericMeshDeviceFixture, NIGHTLY_NocEstimatorDRAMInterleavedOneToAll) {
+    unit_tests::dm::noc_estimator::sweep_dram_interleaved_one_to_all(get_mesh_device(), 816);
+}
+
+TEST_F(GenericMeshDeviceFixture, NIGHTLY_NocEstimatorDRAMInterleavedAllToAll) {
+    unit_tests::dm::noc_estimator::sweep_dram_interleaved_all_to_all(get_mesh_device(), 817);
 }
 
 }  // namespace tt::tt_metal

--- a/tests/tt_metal/tt_metal/data_movement/noc_estimator_tests/test_noc_estimator.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/noc_estimator_tests/test_noc_estimator.cpp
@@ -1,0 +1,1251 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "multi_device_fixture.hpp"
+#include "tt_metal/test_utils/comparison.hpp"
+#include "tt_metal/test_utils/stimulus.hpp"
+#include "tt_metal/test_utils/print_helpers.hpp"
+#include "dm_common.hpp"
+#include <tt-metalium/distributed.hpp>
+#include <tt-metalium/mesh_coord.hpp>
+#include <tt-metalium/host_api.hpp>
+#include <distributed/mesh_device_impl.hpp>
+
+namespace tt::tt_metal {
+
+using namespace std;
+using namespace tt;
+using namespace test_utils;
+
+namespace unit_tests::dm::noc_estimator {
+
+// ============ ENUMS ============
+
+enum class NocPattern : uint32_t {
+    ONE_TO_ONE = 0,
+    ONE_FROM_ONE = 1,
+    ONE_TO_ALL = 2,
+    ONE_FROM_ALL = 3,
+    ALL_TO_ALL = 4,
+    ALL_FROM_ALL = 5,
+    ONE_TO_ROW = 6,
+    ROW_TO_ROW = 7,
+    ONE_TO_COLUMN = 8,
+    COLUMN_TO_COLUMN = 9,
+};
+
+enum class NocMechanism : uint32_t {
+    UNICAST = 0,
+    MULTICAST = 1,
+    MULTICAST_LINKED = 2,
+};
+
+enum class MemoryType : uint32_t {
+    L1 = 0,
+    DRAM = 1,
+};
+
+// Writer kernel modes (must match log_helpers.hpp constants)
+constexpr uint32_t WRITER_MODE_UNICAST_SINGLE = 0;
+constexpr uint32_t WRITER_MODE_UNICAST_MULTI = 1;
+constexpr uint32_t WRITER_MODE_MULTICAST = 2;
+constexpr uint32_t WRITER_MODE_MULTICAST_LINKED = 3;
+
+// Reader kernel modes
+constexpr uint32_t READER_MODE_SINGLE = 0;
+constexpr uint32_t READER_MODE_MULTI = 1;
+
+// ============ CONFIG ============
+
+struct NocEstimatorConfig {
+    uint32_t test_id = 0;
+
+    NocPattern pattern = NocPattern::ONE_TO_ONE;
+    NocMechanism mechanism = NocMechanism::UNICAST;
+    MemoryType memory_type = MemoryType::L1;
+
+    // Transaction parameters (the sweep axes)
+    uint32_t num_of_transactions = 1;
+    uint32_t pages_per_transaction = 1;
+    uint32_t bytes_per_page = 32;
+
+    // Grid parameters
+    CoreCoord master_start_coord = {0, 0};
+    CoreCoord master_grid_size = {1, 1};
+    CoreCoord sub_start_coord = {0, 0};
+    CoreCoord sub_grid_size = {1, 1};
+
+    // Behavioral flags
+    bool same_axis = true;
+    bool stateful = false;
+    bool loopback = false;
+    NOC noc_id = NOC::NOC_0;
+    uint32_t num_virtual_channels = 1;
+
+    // DRAM-specific
+    uint32_t dram_channel = 0;
+
+    // Future extensibility:
+    // bool posted = false;
+};
+
+// ============ HELPERS ============
+
+static bool is_write_pattern(NocPattern p) {
+    return p == NocPattern::ONE_TO_ONE || p == NocPattern::ONE_TO_ALL || p == NocPattern::ALL_TO_ALL ||
+           p == NocPattern::ONE_TO_ROW || p == NocPattern::ROW_TO_ROW || p == NocPattern::ONE_TO_COLUMN ||
+           p == NocPattern::COLUMN_TO_COLUMN;
+}
+
+static const std::string KERNELS_DIR = "tests/tt_metal/tt_metal/data_movement/noc_estimator/kernels/";
+
+static vector<uint32_t> make_writer_compile_args(
+    const NocEstimatorConfig& cfg,
+    uint32_t src_addr,
+    uint32_t dst_addr,
+    uint32_t bytes_per_txn,
+    uint32_t writer_mode,
+    uint32_t num_subs,
+    uint32_t packed_dest = 0,
+    uint32_t mcast_sx = 0,
+    uint32_t mcast_sy = 0,
+    uint32_t mcast_ex = 0,
+    uint32_t mcast_ey = 0) {
+    return {
+        src_addr,                   // 0
+        dst_addr,                   // 1
+        cfg.num_of_transactions,    // 2
+        bytes_per_txn,              // 3
+        cfg.test_id,                // 4
+        writer_mode,                // 5
+        num_subs,                   // 6
+        (uint32_t)cfg.stateful,     // 7
+        cfg.num_virtual_channels,   // 8
+        (uint32_t)cfg.loopback,     // 9
+        mcast_sx,                   // 10
+        mcast_sy,                   // 11
+        mcast_ex,                   // 12
+        mcast_ey,                   // 13
+        packed_dest,                // 14
+        (uint32_t)cfg.memory_type,  // 15
+        (uint32_t)cfg.mechanism,    // 16
+        (uint32_t)cfg.pattern,      // 17
+        (uint32_t)cfg.same_axis,    // 18
+        (uint32_t)cfg.loopback,     // 19
+    };
+}
+
+static vector<uint32_t> make_reader_compile_args(
+    const NocEstimatorConfig& cfg,
+    uint32_t local_addr,
+    uint32_t bytes_per_txn,
+    uint32_t reader_mode,
+    uint32_t num_subs) {
+    return {
+        local_addr,                 // 0
+        cfg.num_of_transactions,    // 1
+        bytes_per_txn,              // 2
+        cfg.test_id,                // 3
+        reader_mode,                // 4
+        num_subs,                   // 5
+        (uint32_t)cfg.stateful,     // 6
+        cfg.num_virtual_channels,   // 7
+        (uint32_t)cfg.memory_type,  // 8
+        (uint32_t)cfg.mechanism,    // 9
+        (uint32_t)cfg.pattern,      // 10
+        (uint32_t)cfg.same_axis,    // 11
+        (uint32_t)cfg.loopback,     // 12
+    };
+}
+
+static void execute_program(const shared_ptr<distributed::MeshDevice>& mesh_device, Program program) {
+    auto mesh_workload = distributed::MeshWorkload();
+    vector<uint32_t> coord_data = {0, 0};
+    auto target_devices = distributed::MeshCoordinateRange(distributed::MeshCoordinate(coord_data));
+    mesh_workload.add_program(target_devices, std::move(program));
+
+    auto& cq = mesh_device->mesh_command_queue();
+    distributed::EnqueueMeshWorkload(cq, mesh_workload, false);
+    Finish(cq);
+}
+
+static vector<uint32_t> make_test_data(size_t bytes) {
+    uint32_t num_elements = bytes / sizeof(bfloat16);
+    return generate_packed_uniform_random_vector<uint32_t, bfloat16>(
+        -100.0f, 100.0f, num_elements, chrono::system_clock::now().time_since_epoch().count());
+}
+
+// ============ PATTERN-SPECIFIC RUN FUNCTIONS ============
+
+// Handles ONE_TO_ONE (write) and ONE_FROM_ONE (read)
+static bool run_single_core(const shared_ptr<distributed::MeshDevice>& mesh_device, const NocEstimatorConfig& cfg) {
+    IDevice* device = mesh_device->impl().get_device(0);
+    Program program = CreateProgram();
+
+    const size_t bytes_per_txn = cfg.pages_per_transaction * cfg.bytes_per_page;
+
+    // Core coordinates based on same_axis
+    CoreCoord master_coord = {0, 0};
+    CoreCoord sub_coord = cfg.same_axis ? CoreCoord{0, 1} : CoreCoord{1, 1};
+
+    // L1 address validation
+    L1AddressInfo master_l1 = unit_tests::dm::get_l1_address_and_size(mesh_device, master_coord);
+    L1AddressInfo sub_l1 = unit_tests::dm::get_l1_address_and_size(mesh_device, sub_coord);
+    if (master_l1.base_address != sub_l1.base_address || master_l1.size != sub_l1.size) {
+        log_error(LogTest, "Mismatch in L1 address or size between master and subordinate cores");
+        return false;
+    }
+    if (master_l1.size < bytes_per_txn) {
+        log_error(LogTest, "Insufficient L1 size for the test configuration");
+        return false;
+    }
+    uint32_t l1_base = master_l1.base_address;
+
+    CoreCoord phys_sub = device->worker_core_from_logical_core(sub_coord);
+    uint32_t packed_sub = (phys_sub.x << 16) | (phys_sub.y & 0xFFFF);
+
+    bool is_write = is_write_pattern(cfg.pattern);
+
+    if (is_write) {
+        auto compile_args = make_writer_compile_args(
+            cfg, l1_base, l1_base, (uint32_t)bytes_per_txn, WRITER_MODE_UNICAST_SINGLE, 0, packed_sub);
+        CreateKernel(
+            program,
+            KERNELS_DIR + "writer.cpp",
+            master_coord,
+            DataMovementConfig{
+                .processor = DataMovementProcessor::RISCV_0, .noc = cfg.noc_id, .compile_args = compile_args});
+    } else {
+        auto compile_args = make_reader_compile_args(cfg, l1_base, (uint32_t)bytes_per_txn, READER_MODE_SINGLE, 0);
+        CoreRangeSet master_set({CoreRange(master_coord)});
+        auto kernel = CreateKernel(
+            program,
+            KERNELS_DIR + "reader.cpp",
+            master_set,
+            DataMovementConfig{
+                .processor = DataMovementProcessor::RISCV_1,
+                .noc = NOC::RISCV_1_default,
+                .compile_args = compile_args});
+        SetRuntimeArgs(program, kernel, master_set, {phys_sub.x, phys_sub.y});
+    }
+
+    log_info(LogTest, "Running Test ID: {}, Run ID: {}", cfg.test_id, unit_tests::dm::runtime_host_id);
+    program.set_runtime_id(unit_tests::dm::runtime_host_id++);
+
+    auto packed_input = make_test_data(bytes_per_txn);
+    auto packed_golden = packed_input;
+
+    if (is_write) {
+        detail::WriteToDeviceL1(device, master_coord, l1_base, packed_input);
+    } else {
+        detail::WriteToDeviceL1(device, sub_coord, l1_base, packed_input);
+    }
+    MetalContext::instance().get_cluster().l1_barrier(device->id());
+
+    execute_program(mesh_device, std::move(program));
+
+    vector<uint32_t> packed_output;
+    if (is_write) {
+        detail::ReadFromDeviceL1(device, sub_coord, l1_base, bytes_per_txn, packed_output);
+    } else {
+        detail::ReadFromDeviceL1(device, master_coord, l1_base, bytes_per_txn, packed_output);
+    }
+
+    bool is_equal = (packed_output == packed_golden);
+    if (!is_equal) {
+        log_error(LogTest, "Equality Check failed for test_id {}", cfg.test_id);
+    }
+    return is_equal;
+}
+
+// Handles ONE_TO_ALL (write, unicast/multicast) and ONE_FROM_ALL (read)
+static bool run_one_to_many(const shared_ptr<distributed::MeshDevice>& mesh_device, const NocEstimatorConfig& cfg) {
+    IDevice* device = mesh_device->impl().get_device(0);
+    Program program = CreateProgram();
+
+    const size_t bytes_per_txn = cfg.pages_per_transaction * cfg.bytes_per_page;
+    bool is_write = is_write_pattern(cfg.pattern);
+
+    // Master core
+    CoreCoord mst_coord = cfg.master_start_coord;
+    CoreRangeSet mst_set({CoreRange(mst_coord)});
+
+    // Subordinate grid
+    CoreCoord sub_start = cfg.sub_start_coord;
+    CoreCoord sub_end = CoreCoord(sub_start.x + cfg.sub_grid_size.x - 1, sub_start.y + cfg.sub_grid_size.y - 1);
+    CoreRangeSet sub_set({CoreRange(sub_start, sub_end)});
+
+    bool is_multicast = (cfg.mechanism == NocMechanism::MULTICAST || cfg.mechanism == NocMechanism::MULTICAST_LINKED);
+    if (!is_multicast) {
+        // For unicast: master sends to each subordinate individually, exclude itself
+        sub_set = sub_set.subtract(mst_set);
+    }
+    // For multicast: master placement determines loopback behavior.
+    //   loopback=true  → master inside rectangle, INCLUDE_SRC
+    //   loopback=false → master outside rectangle, EXCLUDE_SRC
+    uint32_t num_subs = sub_set.num_cores();
+    auto sub_core_list = corerange_to_cores(sub_set);
+
+    // L1 addresses
+    L1AddressInfo mst_l1 = unit_tests::dm::get_l1_address_and_size(mesh_device, mst_coord);
+    if (mst_l1.size < bytes_per_txn) {
+        log_error(LogTest, "Insufficient L1 size");
+        return false;
+    }
+    uint32_t mst_l1_addr = mst_l1.base_address;
+    uint32_t sub_l1_addr = cfg.loopback ? mst_l1_addr : mst_l1_addr + (uint32_t)bytes_per_txn;
+
+    if (is_write) {
+        uint32_t writer_mode;
+
+        if (is_multicast) {
+            writer_mode = (cfg.mechanism == NocMechanism::MULTICAST_LINKED) ? WRITER_MODE_MULTICAST_LINKED
+                                                                            : WRITER_MODE_MULTICAST;
+            CoreCoord sub_phys_start = device->worker_core_from_logical_core(sub_start);
+            CoreCoord sub_phys_end = device->worker_core_from_logical_core(sub_end);
+
+            auto compile_args = make_writer_compile_args(
+                cfg,
+                mst_l1_addr,
+                sub_l1_addr,
+                (uint32_t)bytes_per_txn,
+                writer_mode,
+                num_subs,
+                0,
+                sub_phys_start.x,
+                sub_phys_start.y,
+                sub_phys_end.x,
+                sub_phys_end.y);
+
+            CreateKernel(
+                program,
+                KERNELS_DIR + "writer.cpp",
+                mst_set,
+                DataMovementConfig{
+                    .processor = DataMovementProcessor::RISCV_0, .noc = cfg.noc_id, .compile_args = compile_args});
+        } else {
+            // Unicast multi: pack subordinate physical coordinates as runtime args
+            writer_mode = WRITER_MODE_UNICAST_MULTI;
+            auto compile_args =
+                make_writer_compile_args(cfg, mst_l1_addr, sub_l1_addr, (uint32_t)bytes_per_txn, writer_mode, num_subs);
+
+            auto kernel = CreateKernel(
+                program,
+                KERNELS_DIR + "writer.cpp",
+                mst_set,
+                DataMovementConfig{
+                    .processor = DataMovementProcessor::RISCV_0, .noc = cfg.noc_id, .compile_args = compile_args});
+
+            vector<uint32_t> rt_args;
+            for (auto& core : sub_core_list) {
+                CoreCoord phys = device->worker_core_from_logical_core(core);
+                rt_args.push_back((phys.x << 16) | (phys.y & 0xFFFF));
+            }
+            SetRuntimeArgs(program, kernel, mst_set, rt_args);
+        }
+    } else {
+        // ONE_FROM_ALL: read from all subordinates
+        auto compile_args =
+            make_reader_compile_args(cfg, mst_l1.base_address, (uint32_t)bytes_per_txn, READER_MODE_MULTI, num_subs);
+        auto kernel = CreateKernel(
+            program,
+            KERNELS_DIR + "reader.cpp",
+            mst_set,
+            DataMovementConfig{
+                .processor = DataMovementProcessor::RISCV_1,
+                .noc = NOC::RISCV_1_default,
+                .compile_args = compile_args});
+
+        vector<uint32_t> rt_args;
+        for (auto& core : sub_core_list) {
+            CoreCoord phys = device->worker_core_from_logical_core(core);
+            rt_args.push_back(phys.x);
+            rt_args.push_back(phys.y);
+        }
+        SetRuntimeArgs(program, kernel, mst_set, rt_args);
+    }
+
+    log_info(LogTest, "Running Test ID: {}, Run ID: {}", cfg.test_id, unit_tests::dm::runtime_host_id);
+    program.set_runtime_id(unit_tests::dm::runtime_host_id++);
+
+    auto packed_input = make_test_data(bytes_per_txn);
+    auto packed_golden = packed_input;
+
+    if (is_write) {
+        detail::WriteToDeviceL1(device, mst_coord, mst_l1_addr, packed_input);
+    } else {
+        for (auto& core : sub_core_list) {
+            detail::WriteToDeviceL1(device, core, mst_l1.base_address, packed_input);
+        }
+    }
+    MetalContext::instance().get_cluster().l1_barrier(device->id());
+
+    execute_program(mesh_device, std::move(program));
+
+    if (is_write) {
+        for (auto& core : sub_core_list) {
+            vector<uint32_t> packed_output;
+            detail::ReadFromDeviceL1(device, core, sub_l1_addr, bytes_per_txn, packed_output);
+            if (packed_output != packed_golden) {
+                log_error(LogTest, "Equality Check failed for test_id {}", cfg.test_id);
+                return false;
+            }
+        }
+    } else {
+        vector<uint32_t> packed_output;
+        detail::ReadFromDeviceL1(device, mst_coord, mst_l1.base_address, bytes_per_txn, packed_output);
+        if (packed_output != packed_golden) {
+            log_error(LogTest, "Equality Check failed for test_id {}", cfg.test_id);
+            return false;
+        }
+    }
+    return true;
+}
+
+// Handles ALL_TO_ALL (write) and ALL_FROM_ALL (read)
+static bool run_all_pattern(const shared_ptr<distributed::MeshDevice>& mesh_device, const NocEstimatorConfig& cfg) {
+    IDevice* device = mesh_device->impl().get_device(0);
+    Program program = CreateProgram();
+
+    const size_t bytes_per_txn = cfg.pages_per_transaction * cfg.bytes_per_page;
+    bool is_write = is_write_pattern(cfg.pattern);
+
+    // Master grid
+    CoreCoord mst_start = cfg.master_start_coord;
+    CoreCoord mst_end = CoreCoord(mst_start.x + cfg.master_grid_size.x - 1, mst_start.y + cfg.master_grid_size.y - 1);
+    CoreRangeSet mst_set({CoreRange(mst_start, mst_end)});
+    auto mst_core_list = corerange_to_cores(mst_set);
+
+    // Subordinate grid
+    CoreCoord sub_start = cfg.sub_start_coord;
+    CoreCoord sub_end = CoreCoord(sub_start.x + cfg.sub_grid_size.x - 1, sub_start.y + cfg.sub_grid_size.y - 1);
+    CoreRangeSet sub_set({CoreRange(sub_start, sub_end)});
+    uint32_t num_subs = sub_set.num_cores();
+    auto sub_core_list = corerange_to_cores(sub_set);
+
+    // L1 addresses (offset to avoid overlap between master source and subordinate destination)
+    L1AddressInfo l1_info = unit_tests::dm::get_l1_address_and_size(mesh_device, mst_start);
+    if (l1_info.size < 2 * bytes_per_txn) {
+        log_error(LogTest, "Insufficient L1 size");
+        return false;
+    }
+    uint32_t mst_l1_addr = l1_info.base_address;
+    uint32_t sub_l1_addr = mst_l1_addr + (uint32_t)bytes_per_txn;
+
+    // Subordinate physical coordinates
+    vector<uint32_t> sub_worker_coords;
+    for (auto& core : sub_core_list) {
+        CoreCoord phys = device->worker_core_from_logical_core(core);
+        if (is_write) {
+            sub_worker_coords.push_back((phys.x << 16) | (phys.y & 0xFFFF));
+        } else {
+            sub_worker_coords.push_back(phys.x);
+            sub_worker_coords.push_back(phys.y);
+        }
+    }
+
+    if (is_write) {
+        auto compile_args = make_writer_compile_args(
+            cfg, mst_l1_addr, sub_l1_addr, (uint32_t)bytes_per_txn, WRITER_MODE_UNICAST_MULTI, num_subs);
+        auto kernel = CreateKernel(
+            program,
+            KERNELS_DIR + "writer.cpp",
+            mst_set,
+            DataMovementConfig{
+                .processor = DataMovementProcessor::RISCV_0, .noc = cfg.noc_id, .compile_args = compile_args});
+        SetRuntimeArgs(program, kernel, mst_set, sub_worker_coords);
+    } else {
+        auto compile_args =
+            make_reader_compile_args(cfg, mst_l1_addr, (uint32_t)bytes_per_txn, READER_MODE_MULTI, num_subs);
+        auto kernel = CreateKernel(
+            program,
+            KERNELS_DIR + "reader.cpp",
+            mst_set,
+            DataMovementConfig{
+                .processor = DataMovementProcessor::RISCV_1,
+                .noc = NOC::RISCV_1_default,
+                .compile_args = compile_args});
+        SetRuntimeArgs(program, kernel, mst_set, sub_worker_coords);
+    }
+
+    log_info(LogTest, "Running Test ID: {}, Run ID: {}", cfg.test_id, unit_tests::dm::runtime_host_id);
+    program.set_runtime_id(unit_tests::dm::runtime_host_id++);
+
+    auto packed_input = make_test_data(bytes_per_txn);
+    auto packed_golden = packed_input;
+
+    if (is_write) {
+        // Write source data to master cores at mst_l1_addr
+        for (auto& core : mst_core_list) {
+            detail::WriteToDeviceL1(device, core, mst_l1_addr, packed_input);
+        }
+    } else {
+        // Write source data to subordinate cores at mst_l1_addr
+        // (reader kernel reads from local_addr = mst_l1_addr on remote cores)
+        for (auto& core : sub_core_list) {
+            detail::WriteToDeviceL1(device, core, mst_l1_addr, packed_input);
+        }
+    }
+    MetalContext::instance().get_cluster().l1_barrier(device->id());
+
+    execute_program(mesh_device, std::move(program));
+
+    if (is_write) {
+        for (auto& core : sub_core_list) {
+            vector<uint32_t> packed_output;
+            detail::ReadFromDeviceL1(device, core, sub_l1_addr, bytes_per_txn, packed_output);
+            if (packed_output != packed_golden) {
+                log_error(LogTest, "Equality Check failed for test_id {}", cfg.test_id);
+                return false;
+            }
+        }
+    } else {
+        // Reader writes to local_addr = mst_l1_addr on each master core
+        for (auto& core : mst_core_list) {
+            vector<uint32_t> packed_output;
+            detail::ReadFromDeviceL1(device, core, mst_l1_addr, bytes_per_txn, packed_output);
+            if (packed_output != packed_golden) {
+                log_error(LogTest, "Equality Check failed for test_id {}", cfg.test_id);
+                return false;
+            }
+        }
+    }
+    return true;
+}
+
+// Handles ROW_TO_ROW / COLUMN_TO_COLUMN with multicast:
+// All masters in the row/column multicast to the same rectangle (the row/column).
+// Masters and subordinates overlap; loopback should be true (INCLUDE_SRC).
+static bool run_many_to_many_multicast(
+    const shared_ptr<distributed::MeshDevice>& mesh_device, const NocEstimatorConfig& cfg) {
+    IDevice* device = mesh_device->impl().get_device(0);
+    Program program = CreateProgram();
+
+    const size_t bytes_per_txn = cfg.pages_per_transaction * cfg.bytes_per_page;
+
+    // Master grid
+    CoreCoord mst_start = cfg.master_start_coord;
+    CoreCoord mst_end = CoreCoord(mst_start.x + cfg.master_grid_size.x - 1, mst_start.y + cfg.master_grid_size.y - 1);
+    CoreRangeSet mst_set({CoreRange(mst_start, mst_end)});
+    auto mst_core_list = corerange_to_cores(mst_set);
+
+    // Subordinate grid (same as master for row_to_row / column_to_column)
+    CoreCoord sub_start = cfg.sub_start_coord;
+    CoreCoord sub_end = CoreCoord(sub_start.x + cfg.sub_grid_size.x - 1, sub_start.y + cfg.sub_grid_size.y - 1);
+    CoreRangeSet sub_set({CoreRange(sub_start, sub_end)});
+    uint32_t num_subs = sub_set.num_cores();
+    auto sub_core_list = corerange_to_cores(sub_set);
+
+    // L1 addresses
+    L1AddressInfo l1_info = unit_tests::dm::get_l1_address_and_size(mesh_device, mst_start);
+    if (l1_info.size < 2 * bytes_per_txn) {
+        log_error(LogTest, "Insufficient L1 size");
+        return false;
+    }
+    uint32_t mst_l1_addr = l1_info.base_address;
+    uint32_t sub_l1_addr = cfg.loopback ? mst_l1_addr : mst_l1_addr + (uint32_t)bytes_per_txn;
+
+    // All masters multicast to the same sub rectangle
+    uint32_t writer_mode =
+        (cfg.mechanism == NocMechanism::MULTICAST_LINKED) ? WRITER_MODE_MULTICAST_LINKED : WRITER_MODE_MULTICAST;
+
+    CoreCoord sub_phys_start = device->worker_core_from_logical_core(sub_start);
+    CoreCoord sub_phys_end = device->worker_core_from_logical_core(sub_end);
+
+    auto compile_args = make_writer_compile_args(
+        cfg,
+        mst_l1_addr,
+        sub_l1_addr,
+        (uint32_t)bytes_per_txn,
+        writer_mode,
+        num_subs,
+        0,
+        sub_phys_start.x,
+        sub_phys_start.y,
+        sub_phys_end.x,
+        sub_phys_end.y);
+
+    CreateKernel(
+        program,
+        KERNELS_DIR + "writer.cpp",
+        mst_set,
+        DataMovementConfig{
+            .processor = DataMovementProcessor::RISCV_0, .noc = cfg.noc_id, .compile_args = compile_args});
+
+    log_info(LogTest, "Running Test ID: {}, Run ID: {}", cfg.test_id, unit_tests::dm::runtime_host_id);
+    program.set_runtime_id(unit_tests::dm::runtime_host_id++);
+
+    auto packed_input = make_test_data(bytes_per_txn);
+    auto packed_golden = packed_input;
+
+    // Write source data to all master cores
+    for (auto& core : mst_core_list) {
+        detail::WriteToDeviceL1(device, core, mst_l1_addr, packed_input);
+    }
+    MetalContext::instance().get_cluster().l1_barrier(device->id());
+
+    execute_program(mesh_device, std::move(program));
+
+    // Verify all subordinate cores
+    for (auto& core : sub_core_list) {
+        vector<uint32_t> packed_output;
+        detail::ReadFromDeviceL1(device, core, sub_l1_addr, bytes_per_txn, packed_output);
+        if (packed_output != packed_golden) {
+            log_error(LogTest, "Equality Check failed for test_id {}", cfg.test_id);
+            return false;
+        }
+    }
+    return true;
+}
+
+// Handles DRAM read+write (reader on RISCV_1, writer on RISCV_0, synchronized by semaphore)
+static bool run_dram(const shared_ptr<distributed::MeshDevice>& mesh_device, const NocEstimatorConfig& cfg) {
+    IDevice* device = mesh_device->impl().get_device(0);
+    Program program = CreateProgram();
+
+    const size_t bytes_per_txn = cfg.pages_per_transaction * cfg.bytes_per_page;
+
+    CoreCoord core_coord = {0, 0};
+    CoreRangeSet core_set({CoreRange(core_coord)});
+
+    // DRAM and L1 addresses
+    DramAddressInfo dram_info = unit_tests::dm::get_dram_address_and_size();
+    uint32_t input_dram_addr = dram_info.base_address;
+    uint32_t output_dram_addr = input_dram_addr + (uint32_t)bytes_per_txn;
+
+    L1AddressInfo l1_info = unit_tests::dm::get_l1_address_and_size(mesh_device, core_coord);
+    uint32_t l1_addr = l1_info.base_address;
+
+    uint32_t sem_id = CreateSemaphore(program, core_set, 0);
+
+    // DRAM metadata args
+    uint32_t mem_type = (uint32_t)MemoryType::DRAM;
+    uint32_t mech = (uint32_t)NocMechanism::UNICAST;
+
+    // Reader kernel (RISCV_1): reads from DRAM input to L1
+    vector<uint32_t> reader_args = {
+        l1_addr,
+        input_dram_addr,
+        cfg.dram_channel,
+        cfg.num_of_transactions,
+        (uint32_t)bytes_per_txn,
+        cfg.test_id,
+        sem_id,
+        mem_type,
+        mech,
+        (uint32_t)NocPattern::ONE_FROM_ONE};
+
+    CreateKernel(
+        program,
+        KERNELS_DIR + "dram_reader.cpp",
+        core_coord,
+        DataMovementConfig{
+            .processor = DataMovementProcessor::RISCV_1, .noc = NOC::RISCV_1_default, .compile_args = reader_args});
+
+    // Writer kernel (RISCV_0): writes from L1 to DRAM output
+    vector<uint32_t> writer_args = {
+        l1_addr,
+        output_dram_addr,
+        cfg.dram_channel,
+        cfg.num_of_transactions,
+        (uint32_t)bytes_per_txn,
+        cfg.test_id,
+        sem_id,
+        mem_type,
+        mech,
+        (uint32_t)NocPattern::ONE_TO_ONE};
+
+    CreateKernel(
+        program,
+        KERNELS_DIR + "dram_writer.cpp",
+        core_coord,
+        DataMovementConfig{
+            .processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default, .compile_args = writer_args});
+
+    log_info(LogTest, "Running Test ID: {}, Run ID: {}", cfg.test_id, unit_tests::dm::runtime_host_id);
+    program.set_runtime_id(unit_tests::dm::runtime_host_id++);
+
+    auto packed_input = make_test_data(bytes_per_txn);
+    auto packed_golden = packed_input;
+
+    detail::WriteToDeviceDRAMChannel(device, cfg.dram_channel, input_dram_addr, packed_input);
+    MetalContext::instance().get_cluster().dram_barrier(device->id());
+
+    execute_program(mesh_device, std::move(program));
+
+    vector<uint32_t> packed_output;
+    detail::ReadFromDeviceDRAMChannel(
+        device, cfg.dram_channel, output_dram_addr, (uint32_t)bytes_per_txn, packed_output);
+
+    bool is_equal = (packed_output == packed_golden);
+    if (!is_equal) {
+        log_error(LogTest, "DRAM Equality Check failed for test_id {}", cfg.test_id);
+    }
+    return is_equal;
+}
+
+// ============ DISPATCH ============
+
+static bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const NocEstimatorConfig& cfg) {
+    if (cfg.memory_type == MemoryType::DRAM) {
+        return run_dram(mesh_device, cfg);
+    }
+    switch (cfg.pattern) {
+        case NocPattern::ONE_TO_ONE:
+        case NocPattern::ONE_FROM_ONE: return run_single_core(mesh_device, cfg);
+        case NocPattern::ONE_TO_ALL:
+        case NocPattern::ONE_FROM_ALL:
+        case NocPattern::ONE_TO_ROW:
+        case NocPattern::ONE_TO_COLUMN: return run_one_to_many(mesh_device, cfg);
+        case NocPattern::ALL_TO_ALL:
+        case NocPattern::ALL_FROM_ALL: return run_all_pattern(mesh_device, cfg);
+        case NocPattern::ROW_TO_ROW:
+        case NocPattern::COLUMN_TO_COLUMN: {
+            bool is_multicast =
+                (cfg.mechanism == NocMechanism::MULTICAST || cfg.mechanism == NocMechanism::MULTICAST_LINKED);
+            if (is_multicast) {
+                return run_many_to_many_multicast(mesh_device, cfg);
+            }
+            return run_all_pattern(mesh_device, cfg);
+        }
+        default: log_error(LogTest, "Unknown pattern"); return false;
+    }
+}
+
+// ============ SWEEP HELPERS ============
+
+// Returns NOC packet size: 8KB for WH, 16KB for BH
+// Stateful unicast writes are only valid for transfers smaller than one packet
+static uint32_t get_noc_packet_size(IDevice* device) {
+    return device->arch() == ARCH::BLACKHOLE ? 16 * 1024 : 8 * 1024;
+}
+
+static void packet_sizes_sweep(const shared_ptr<distributed::MeshDevice>& mesh_device, NocEstimatorConfig base_cfg) {
+    auto [bytes_per_page, max_bytes, max_pages] = unit_tests::dm::compute_physical_constraints(mesh_device);
+    IDevice* device = mesh_device->impl().get_device(0);
+
+    uint32_t max_transactions = 256;
+    uint32_t max_pages_per_txn = device->arch() == ARCH::BLACKHOLE ? 1024 : 2048;
+
+    base_cfg.bytes_per_page = bytes_per_page;
+
+    for (uint32_t num_txn = 1; num_txn <= max_transactions; num_txn *= 4) {
+        for (uint32_t pages = 1; pages <= max_pages_per_txn; pages *= 2) {
+            if (pages > max_pages) {
+                continue;
+            }
+            base_cfg.num_of_transactions = num_txn;
+            base_cfg.pages_per_transaction = pages;
+            EXPECT_TRUE(run_dm(mesh_device, base_cfg));
+        }
+    }
+
+    // Flush profiler DRAM buffer to prevent overflow across many sweep iterations
+    ReadMeshDeviceProfilerResults(*mesh_device);
+}
+
+// Stateful sweep for unicast writes - constrained to packets smaller than max stateful size
+static void packet_sizes_sweep_stateful_write(
+    const shared_ptr<distributed::MeshDevice>& mesh_device, NocEstimatorConfig base_cfg) {
+    auto [bytes_per_page, max_bytes, max_pages] = unit_tests::dm::compute_physical_constraints(mesh_device);
+    IDevice* device = mesh_device->impl().get_device(0);
+
+    uint32_t max_transactions = 256;
+    uint32_t noc_packet_size = get_noc_packet_size(device);
+    uint32_t max_stateful_pages = noc_packet_size / bytes_per_page;
+
+    base_cfg.bytes_per_page = bytes_per_page;
+    base_cfg.stateful = true;
+
+    for (uint32_t num_txn = 1; num_txn <= max_transactions; num_txn *= 4) {
+        for (uint32_t pages = 1; pages < max_stateful_pages; pages *= 2) {
+            if (pages > max_pages) {
+                continue;
+            }
+            base_cfg.num_of_transactions = num_txn;
+            base_cfg.pages_per_transaction = pages;
+            EXPECT_TRUE(run_dm(mesh_device, base_cfg));
+        }
+    }
+
+    // Flush profiler DRAM buffer to prevent overflow across many sweep iterations
+    ReadMeshDeviceProfilerResults(*mesh_device);
+}
+
+// ============ SWEEP FUNCTIONS ============
+
+static void sweep_one_to_one(const shared_ptr<distributed::MeshDevice>& mesh_device, uint32_t test_id) {
+    for (bool same_axis : {true, false}) {
+        for (bool stateful : {true, false}) {
+            NocEstimatorConfig cfg = {
+                .test_id = test_id,
+                .pattern = NocPattern::ONE_TO_ONE,
+                .mechanism = NocMechanism::UNICAST,
+                .memory_type = MemoryType::L1,
+                .same_axis = same_axis,
+                .stateful = stateful,
+            };
+            packet_sizes_sweep(mesh_device, cfg);
+        }
+    }
+}
+
+static void sweep_one_from_one(const shared_ptr<distributed::MeshDevice>& mesh_device, uint32_t test_id) {
+    for (bool same_axis : {true, false}) {
+        for (bool stateful : {true, false}) {
+            NocEstimatorConfig cfg = {
+                .test_id = test_id,
+                .pattern = NocPattern::ONE_FROM_ONE,
+                .mechanism = NocMechanism::UNICAST,
+                .memory_type = MemoryType::L1,
+                .same_axis = same_axis,
+                .stateful = stateful,
+            };
+            packet_sizes_sweep(mesh_device, cfg);
+        }
+    }
+}
+
+static void sweep_one_to_all(const shared_ptr<distributed::MeshDevice>& mesh_device, uint32_t test_id) {
+    IDevice* device = mesh_device->impl().get_device(0);
+    CoreCoord device_grid = device->compute_with_storage_grid_size();
+
+    struct GridConfig {
+        CoreCoord size;
+    };
+    vector<GridConfig> grids = {{{2, 2}}, {{3, 3}}, {{5, 5}}, {{8, 8}}, {device_grid}};
+
+    for (auto& grid : grids) {
+        // Skip grid sizes larger than device grid
+        if (grid.size.x > device_grid.x || grid.size.y > device_grid.y) {
+            continue;
+        }
+        bool is_full_grid = (grid.size.x >= device_grid.x && grid.size.y >= device_grid.y);
+
+        // Unicast: master outside the sub grid (no loopback concept for unicast)
+        // For full device grid, master must be inside since there's no core outside
+        {
+            NocEstimatorConfig cfg = {
+                .test_id = test_id,
+                .pattern = NocPattern::ONE_TO_ALL,
+                .mechanism = NocMechanism::UNICAST,
+                .memory_type = MemoryType::L1,
+                .master_start_coord = is_full_grid ? CoreCoord(0, 0) : CoreCoord(grid.size.x, 0),
+                .sub_start_coord = {0, 0},
+                .sub_grid_size = grid.size,
+            };
+            packet_sizes_sweep(mesh_device, cfg);
+
+            // Stateful unicast (only valid for small packets)
+            packet_sizes_sweep_stateful_write(mesh_device, cfg);
+        }
+
+        // Multicast and multicast linked: sweep loopback
+        for (auto mechanism : {NocMechanism::MULTICAST, NocMechanism::MULTICAST_LINKED}) {
+            // Loopback = true: master inside the multicast rectangle (INCLUDE_SRC)
+            {
+                NocEstimatorConfig cfg = {
+                    .test_id = test_id,
+                    .pattern = NocPattern::ONE_TO_ALL,
+                    .mechanism = mechanism,
+                    .memory_type = MemoryType::L1,
+                    .master_start_coord = {0, 0},
+                    .sub_start_coord = {0, 0},
+                    .sub_grid_size = grid.size,
+                    .loopback = true,
+                };
+                packet_sizes_sweep(mesh_device, cfg);
+            }
+
+            // Loopback = false: master outside the multicast rectangle (EXCLUDE_SRC)
+            // Skip for full device grid since there is no core outside the rectangle
+            if (!is_full_grid) {
+                NocEstimatorConfig cfg = {
+                    .test_id = test_id,
+                    .pattern = NocPattern::ONE_TO_ALL,
+                    .mechanism = mechanism,
+                    .memory_type = MemoryType::L1,
+                    .master_start_coord = CoreCoord(grid.size.x, 0),
+                    .sub_start_coord = {0, 0},
+                    .sub_grid_size = grid.size,
+                    .loopback = false,
+                };
+                packet_sizes_sweep(mesh_device, cfg);
+            }
+        }
+    }
+}
+
+static void sweep_one_from_all(const shared_ptr<distributed::MeshDevice>& mesh_device, uint32_t test_id) {
+    IDevice* device = mesh_device->impl().get_device(0);
+    CoreCoord device_grid = device->compute_with_storage_grid_size();
+
+    // Sweep stateful for reads (reads can always use stateful with UNICAST)
+    for (bool stateful : {false, true}) {
+        NocEstimatorConfig cfg = {
+            .test_id = test_id,
+            .pattern = NocPattern::ONE_FROM_ALL,
+            .mechanism = NocMechanism::UNICAST,
+            .memory_type = MemoryType::L1,
+            .sub_start_coord = {0, 0},
+            .sub_grid_size = device_grid,
+            .stateful = stateful,
+        };
+        packet_sizes_sweep(mesh_device, cfg);
+    }
+}
+
+static void sweep_all_to_all(const shared_ptr<distributed::MeshDevice>& mesh_device, uint32_t test_id) {
+    IDevice* device = mesh_device->impl().get_device(0);
+    CoreCoord device_grid = device->compute_with_storage_grid_size();
+
+    vector<CoreCoord> grid_sizes = {{2, 2}, {3, 3}, {5, 5}, {8, 8}, device_grid};
+
+    for (auto& grid_size : grid_sizes) {
+        // Skip grid sizes larger than device grid
+        if (grid_size.x > device_grid.x || grid_size.y > device_grid.y) {
+            continue;
+        }
+
+        NocEstimatorConfig cfg = {
+            .test_id = test_id,
+            .pattern = NocPattern::ALL_TO_ALL,
+            .mechanism = NocMechanism::UNICAST,
+            .memory_type = MemoryType::L1,
+            .master_start_coord = {0, 0},
+            .master_grid_size = grid_size,
+            .sub_start_coord = {0, 0},
+            .sub_grid_size = grid_size,
+        };
+        packet_sizes_sweep(mesh_device, cfg);
+    }
+}
+
+static void sweep_all_from_all(const shared_ptr<distributed::MeshDevice>& mesh_device, uint32_t test_id) {
+    IDevice* device = mesh_device->impl().get_device(0);
+    CoreCoord device_grid = device->compute_with_storage_grid_size();
+
+    vector<CoreCoord> grid_sizes = {{2, 2}, {3, 3}, {5, 5}, {8, 8}, device_grid};
+
+    for (auto& grid_size : grid_sizes) {
+        // Skip grid sizes larger than device grid
+        if (grid_size.x > device_grid.x || grid_size.y > device_grid.y) {
+            continue;
+        }
+
+        NocEstimatorConfig cfg = {
+            .test_id = test_id,
+            .pattern = NocPattern::ALL_FROM_ALL,
+            .mechanism = NocMechanism::UNICAST,
+            .memory_type = MemoryType::L1,
+            .master_start_coord = {0, 0},
+            .master_grid_size = grid_size,
+            .sub_start_coord = {0, 0},
+            .sub_grid_size = grid_size,
+        };
+        packet_sizes_sweep(mesh_device, cfg);
+    }
+}
+
+static void sweep_dram(const shared_ptr<distributed::MeshDevice>& mesh_device, uint32_t test_id) {
+    auto [bytes_per_page, max_bytes, max_pages] = unit_tests::dm::compute_physical_constraints(mesh_device);
+
+    uint32_t max_transactions = 256;
+    uint32_t max_pages_per_txn = 256;
+
+    for (uint32_t num_txn = 1; num_txn <= max_transactions; num_txn *= 4) {
+        for (uint32_t pages = 1; pages <= max_pages_per_txn; pages *= 2) {
+            if (num_txn * pages * bytes_per_page >= max_bytes) {
+                continue;
+            }
+
+            NocEstimatorConfig cfg = {
+                .test_id = test_id,
+                .pattern = NocPattern::ONE_TO_ONE,
+                .mechanism = NocMechanism::UNICAST,
+                .memory_type = MemoryType::DRAM,
+                .num_of_transactions = num_txn,
+                .pages_per_transaction = pages,
+                .bytes_per_page = bytes_per_page,
+            };
+            EXPECT_TRUE(run_dm(mesh_device, cfg));
+        }
+    }
+}
+
+// ============ ROW / COLUMN SWEEP FUNCTIONS ============
+
+static void sweep_one_to_row(const shared_ptr<distributed::MeshDevice>& mesh_device, uint32_t test_id) {
+    IDevice* device = mesh_device->impl().get_device(0);
+    CoreCoord device_grid = device->compute_with_storage_grid_size();
+
+    // Unicast: master at (0, 0), sends individually to each core in the row
+    {
+        NocEstimatorConfig cfg = {
+            .test_id = test_id,
+            .pattern = NocPattern::ONE_TO_ROW,
+            .mechanism = NocMechanism::UNICAST,
+            .memory_type = MemoryType::L1,
+            .master_start_coord = {0, 0},
+            .sub_start_coord = {0, 0},
+            .sub_grid_size = {device_grid.x, 1},
+        };
+        packet_sizes_sweep(mesh_device, cfg);
+
+        // Stateful unicast (only valid for small packets)
+        packet_sizes_sweep_stateful_write(mesh_device, cfg);
+    }
+
+    // Multicast and multicast linked: sweep loopback
+    for (auto mechanism : {NocMechanism::MULTICAST, NocMechanism::MULTICAST_LINKED}) {
+        // Loopback = true: master inside the row (INCLUDE_SRC)
+        {
+            NocEstimatorConfig cfg = {
+                .test_id = test_id,
+                .pattern = NocPattern::ONE_TO_ROW,
+                .mechanism = mechanism,
+                .memory_type = MemoryType::L1,
+                .master_start_coord = {0, 0},
+                .sub_start_coord = {0, 0},
+                .sub_grid_size = {device_grid.x, 1},
+                .loopback = true,
+            };
+            packet_sizes_sweep(mesh_device, cfg);
+        }
+
+        // Loopback = false: master outside the row (EXCLUDE_SRC)
+        // Master at row 1, multicasting to row 0
+        if (device_grid.y > 1) {
+            NocEstimatorConfig cfg = {
+                .test_id = test_id,
+                .pattern = NocPattern::ONE_TO_ROW,
+                .mechanism = mechanism,
+                .memory_type = MemoryType::L1,
+                .master_start_coord = {0, 1},
+                .sub_start_coord = {0, 0},
+                .sub_grid_size = {device_grid.x, 1},
+                .loopback = false,
+            };
+            packet_sizes_sweep(mesh_device, cfg);
+        }
+    }
+}
+
+static void sweep_row_to_row(const shared_ptr<distributed::MeshDevice>& mesh_device, uint32_t test_id) {
+    IDevice* device = mesh_device->impl().get_device(0);
+    CoreCoord device_grid = device->compute_with_storage_grid_size();
+
+    // Unicast: every core in the row sends individually to every core in the row
+    {
+        NocEstimatorConfig cfg = {
+            .test_id = test_id,
+            .pattern = NocPattern::ROW_TO_ROW,
+            .mechanism = NocMechanism::UNICAST,
+            .memory_type = MemoryType::L1,
+            .master_start_coord = {0, 0},
+            .master_grid_size = {device_grid.x, 1},
+            .sub_start_coord = {0, 0},
+            .sub_grid_size = {device_grid.x, 1},
+        };
+        packet_sizes_sweep(mesh_device, cfg);
+    }
+
+    // Multicast and multicast linked: sweep loopback
+    for (auto mechanism : {NocMechanism::MULTICAST, NocMechanism::MULTICAST_LINKED}) {
+        // Loopback = true: masters inside the multicast row (INCLUDE_SRC)
+        {
+            NocEstimatorConfig cfg = {
+                .test_id = test_id,
+                .pattern = NocPattern::ROW_TO_ROW,
+                .mechanism = mechanism,
+                .memory_type = MemoryType::L1,
+                .master_start_coord = {0, 0},
+                .master_grid_size = {device_grid.x, 1},
+                .sub_start_coord = {0, 0},
+                .sub_grid_size = {device_grid.x, 1},
+                .loopback = true,
+            };
+            packet_sizes_sweep(mesh_device, cfg);
+        }
+
+        // Loopback = false: masters in row 1, multicasting to row 0 (EXCLUDE_SRC)
+        if (device_grid.y > 1) {
+            NocEstimatorConfig cfg = {
+                .test_id = test_id,
+                .pattern = NocPattern::ROW_TO_ROW,
+                .mechanism = mechanism,
+                .memory_type = MemoryType::L1,
+                .master_start_coord = {0, 1},
+                .master_grid_size = {device_grid.x, 1},
+                .sub_start_coord = {0, 0},
+                .sub_grid_size = {device_grid.x, 1},
+                .loopback = false,
+            };
+            packet_sizes_sweep(mesh_device, cfg);
+        }
+    }
+}
+
+static void sweep_one_to_column(const shared_ptr<distributed::MeshDevice>& mesh_device, uint32_t test_id) {
+    IDevice* device = mesh_device->impl().get_device(0);
+    CoreCoord device_grid = device->compute_with_storage_grid_size();
+
+    // Unicast: master at (0, 0), sends individually to each core in the column
+    {
+        NocEstimatorConfig cfg = {
+            .test_id = test_id,
+            .pattern = NocPattern::ONE_TO_COLUMN,
+            .mechanism = NocMechanism::UNICAST,
+            .memory_type = MemoryType::L1,
+            .master_start_coord = {0, 0},
+            .sub_start_coord = {0, 0},
+            .sub_grid_size = {1, device_grid.y},
+        };
+        packet_sizes_sweep(mesh_device, cfg);
+
+        // Stateful unicast (only valid for small packets)
+        packet_sizes_sweep_stateful_write(mesh_device, cfg);
+    }
+
+    // Multicast and multicast linked: sweep loopback
+    for (auto mechanism : {NocMechanism::MULTICAST, NocMechanism::MULTICAST_LINKED}) {
+        // Loopback = true: master inside the column (INCLUDE_SRC)
+        {
+            NocEstimatorConfig cfg = {
+                .test_id = test_id,
+                .pattern = NocPattern::ONE_TO_COLUMN,
+                .mechanism = mechanism,
+                .memory_type = MemoryType::L1,
+                .master_start_coord = {0, 0},
+                .sub_start_coord = {0, 0},
+                .sub_grid_size = {1, device_grid.y},
+                .loopback = true,
+            };
+            packet_sizes_sweep(mesh_device, cfg);
+        }
+
+        // Loopback = false: master outside the column (EXCLUDE_SRC)
+        // Master at column 1, multicasting to column 0
+        if (device_grid.x > 1) {
+            NocEstimatorConfig cfg = {
+                .test_id = test_id,
+                .pattern = NocPattern::ONE_TO_COLUMN,
+                .mechanism = mechanism,
+                .memory_type = MemoryType::L1,
+                .master_start_coord = {1, 0},
+                .sub_start_coord = {0, 0},
+                .sub_grid_size = {1, device_grid.y},
+                .loopback = false,
+            };
+            packet_sizes_sweep(mesh_device, cfg);
+        }
+    }
+}
+
+static void sweep_column_to_column(const shared_ptr<distributed::MeshDevice>& mesh_device, uint32_t test_id) {
+    IDevice* device = mesh_device->impl().get_device(0);
+    CoreCoord device_grid = device->compute_with_storage_grid_size();
+
+    // Unicast: every core in the column sends individually to every core in the column
+    {
+        NocEstimatorConfig cfg = {
+            .test_id = test_id,
+            .pattern = NocPattern::COLUMN_TO_COLUMN,
+            .mechanism = NocMechanism::UNICAST,
+            .memory_type = MemoryType::L1,
+            .master_start_coord = {0, 0},
+            .master_grid_size = {1, device_grid.y},
+            .sub_start_coord = {0, 0},
+            .sub_grid_size = {1, device_grid.y},
+        };
+        packet_sizes_sweep(mesh_device, cfg);
+    }
+
+    // Multicast and multicast linked: sweep loopback
+    for (auto mechanism : {NocMechanism::MULTICAST, NocMechanism::MULTICAST_LINKED}) {
+        // Loopback = true: masters inside the multicast column (INCLUDE_SRC)
+        {
+            NocEstimatorConfig cfg = {
+                .test_id = test_id,
+                .pattern = NocPattern::COLUMN_TO_COLUMN,
+                .mechanism = mechanism,
+                .memory_type = MemoryType::L1,
+                .master_start_coord = {0, 0},
+                .master_grid_size = {1, device_grid.y},
+                .sub_start_coord = {0, 0},
+                .sub_grid_size = {1, device_grid.y},
+                .loopback = true,
+            };
+            packet_sizes_sweep(mesh_device, cfg);
+        }
+
+        // Loopback = false: masters in column 1, multicasting to column 0 (EXCLUDE_SRC)
+        if (device_grid.x > 1) {
+            NocEstimatorConfig cfg = {
+                .test_id = test_id,
+                .pattern = NocPattern::COLUMN_TO_COLUMN,
+                .mechanism = mechanism,
+                .memory_type = MemoryType::L1,
+                .master_start_coord = {1, 0},
+                .master_grid_size = {1, device_grid.y},
+                .sub_start_coord = {0, 0},
+                .sub_grid_size = {1, device_grid.y},
+                .loopback = false,
+            };
+            packet_sizes_sweep(mesh_device, cfg);
+        }
+    }
+}
+
+}  // namespace unit_tests::dm::noc_estimator
+
+// ============ TEST CASES ============
+
+TEST_F(GenericMeshDeviceFixture, NIGHTLY_NocEstimatorL1OneToOne) {
+    unit_tests::dm::noc_estimator::sweep_one_to_one(get_mesh_device(), 800);
+}
+
+TEST_F(GenericMeshDeviceFixture, NIGHTLY_NocEstimatorL1OneFromOne) {
+    unit_tests::dm::noc_estimator::sweep_one_from_one(get_mesh_device(), 801);
+}
+
+TEST_F(GenericMeshDeviceFixture, NIGHTLY_NocEstimatorL1OneToAll) {
+    unit_tests::dm::noc_estimator::sweep_one_to_all(get_mesh_device(), 802);
+}
+
+TEST_F(GenericMeshDeviceFixture, NIGHTLY_NocEstimatorL1OneFromAll) {
+    unit_tests::dm::noc_estimator::sweep_one_from_all(get_mesh_device(), 803);
+}
+
+TEST_F(GenericMeshDeviceFixture, NIGHTLY_NocEstimatorL1AllToAll) {
+    unit_tests::dm::noc_estimator::sweep_all_to_all(get_mesh_device(), 804);
+}
+
+TEST_F(GenericMeshDeviceFixture, NIGHTLY_NocEstimatorL1AllFromAll) {
+    unit_tests::dm::noc_estimator::sweep_all_from_all(get_mesh_device(), 805);
+}
+
+TEST_F(GenericMeshDeviceFixture, NIGHTLY_NocEstimatorDRAM) {
+    unit_tests::dm::noc_estimator::sweep_dram(get_mesh_device(), 806);
+}
+
+// ============ ROW / COLUMN TESTS ============
+
+TEST_F(GenericMeshDeviceFixture, NIGHTLY_NocEstimatorL1OneToRow) {
+    unit_tests::dm::noc_estimator::sweep_one_to_row(get_mesh_device(), 807);
+}
+
+TEST_F(GenericMeshDeviceFixture, NIGHTLY_NocEstimatorL1RowToRow) {
+    unit_tests::dm::noc_estimator::sweep_row_to_row(get_mesh_device(), 808);
+}
+
+TEST_F(GenericMeshDeviceFixture, NIGHTLY_NocEstimatorL1OneToColumn) {
+    unit_tests::dm::noc_estimator::sweep_one_to_column(get_mesh_device(), 809);
+}
+
+TEST_F(GenericMeshDeviceFixture, NIGHTLY_NocEstimatorL1ColumnToColumn) {
+    unit_tests::dm::noc_estimator::sweep_column_to_column(get_mesh_device(), 810);
+}
+
+}  // namespace tt::tt_metal

--- a/tests/tt_metal/tt_metal/data_movement/noc_estimator_tests/test_noc_estimator.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/noc_estimator_tests/test_noc_estimator.cpp
@@ -976,7 +976,6 @@ static void dram_accessor_sweep(
     DramDirection direction) {
     auto [bytes_per_page, max_bytes, max_pages] = unit_tests::dm::compute_physical_constraints(mesh_device);
 
-    log_info(LogTest, "Cores: {}", cores);
     uint32_t max_transactions = 256;
     uint32_t max_pages_per_txn = 256;
 

--- a/tests/tt_metal/tt_metal/data_movement/noc_estimator_tests/test_noc_estimator.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/noc_estimator_tests/test_noc_estimator.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -292,12 +292,22 @@ static bool run_one_to_many(const shared_ptr<distributed::MeshDevice>& mesh_devi
 
     // L1 addresses
     L1AddressInfo mst_l1 = unit_tests::dm::get_l1_address_and_size(mesh_device, mst_coord);
-    if (mst_l1.size < bytes_per_txn) {
-        log_error(LogTest, "Insufficient L1 size");
+    // Need space for both source and destination regions in non-loopback case.
+    uint32_t required_l1_bytes = (uint32_t)bytes_per_txn * (cfg.loopback ? 1u : 2u);
+    if (mst_l1.size < required_l1_bytes) {
+        log_error(LogTest, "Insufficient L1 size on master core");
         return false;
     }
     uint32_t mst_l1_addr = mst_l1.base_address;
     uint32_t sub_l1_addr = cfg.loopback ? mst_l1_addr : mst_l1_addr + (uint32_t)bytes_per_txn;
+    // Validate that a representative subordinate core also has enough L1.
+    if (!cfg.loopback && !sub_core_list.empty()) {
+        L1AddressInfo sub_l1 = unit_tests::dm::get_l1_address_and_size(mesh_device, sub_core_list.front());
+        if (sub_l1.size < required_l1_bytes) {
+            log_error(LogTest, "Insufficient L1 size on subordinate core");
+            return false;
+        }
+    }
 
     if (is_write) {
         uint32_t writer_mode;
@@ -631,7 +641,7 @@ static bool run_dram_accessor(
     auto dram_buffer = CreateBuffer(buf_config);
 
     std::set<CoreRange> core_ranges;
-    for (auto& c : cores) {
+    for (const auto& c : cores) {
         core_ranges.insert(CoreRange(c));
     }
     CoreRangeSet core_set(core_ranges);
@@ -982,7 +992,7 @@ static void dram_accessor_sweep(
     for (NOC noc : {NOC::NOC_0, NOC::NOC_1}) {
         for (uint32_t num_txn = 1; num_txn <= max_transactions; num_txn *= 4) {
             for (uint32_t pages = 1; pages <= max_pages_per_txn; pages *= 2) {
-                if (num_txn * pages * bytes_per_page >= max_bytes) {
+                if (pages * bytes_per_page >= max_bytes) {
                     continue;
                 }
 
@@ -1002,22 +1012,6 @@ static void dram_accessor_sweep(
     }
 
     ReadMeshDeviceProfilerResults(*mesh_device);
-}
-
-// Helpers to build core/bank lists for sharded multi-core and interleaved all-core patterns
-static void get_sharded_all_cores(
-    const shared_ptr<distributed::MeshDevice>& mesh_device,
-    vector<CoreCoord>& cores,
-    vector<uint32_t>& bank_assignments) {
-    IDevice* device = mesh_device->impl().get_device(0);
-    CoreCoord device_grid = device->compute_with_storage_grid_size();
-    uint32_t num_dram_banks = (uint32_t)device->num_dram_channels();
-    for (uint32_t y = 0; y < device_grid.y; y++) {
-        for (uint32_t x = 0; x < device_grid.x; x++) {
-            cores.push_back(CoreCoord(x, y));
-            bank_assignments.push_back((y * device_grid.x + x) % num_dram_banks);
-        }
-    }
 }
 
 static void get_all_cores(
@@ -1053,7 +1047,7 @@ static void sweep_dram_sharded_one_from_one(const shared_ptr<distributed::MeshDe
 static void sweep_dram_sharded_all_from_all(const shared_ptr<distributed::MeshDevice>& mesh_device, uint32_t test_id) {
     vector<CoreCoord> cores;
     vector<uint32_t> bank_assignments;
-    get_sharded_all_cores(mesh_device, cores, bank_assignments);
+    get_all_cores(mesh_device, cores, bank_assignments);
     dram_accessor_sweep(
         mesh_device,
         test_id,
@@ -1111,7 +1105,7 @@ static void sweep_dram_sharded_one_to_one(const shared_ptr<distributed::MeshDevi
 static void sweep_dram_sharded_all_to_all(const shared_ptr<distributed::MeshDevice>& mesh_device, uint32_t test_id) {
     vector<CoreCoord> cores;
     vector<uint32_t> bank_assignments;
-    get_sharded_all_cores(mesh_device, cores, bank_assignments);
+    get_all_cores(mesh_device, cores, bank_assignments);
     dram_accessor_sweep(
         mesh_device,
         test_id,

--- a/tests/tt_metal/tt_metal/data_movement/noc_estimator_tests/test_noc_estimator.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/noc_estimator_tests/test_noc_estimator.cpp
@@ -98,7 +98,7 @@ static bool is_write_pattern(NocPattern p) {
            p == NocPattern::COLUMN_TO_COLUMN;
 }
 
-static const std::string KERNELS_DIR = "tests/tt_metal/tt_metal/data_movement/noc_estimator/kernels/";
+static const std::string KERNELS_DIR = "tests/tt_metal/tt_metal/data_movement/noc_estimator_tests/kernels/";
 
 static vector<uint32_t> make_writer_compile_args(
     const NocEstimatorConfig& cfg,
@@ -623,15 +623,17 @@ static bool run_dram(const shared_ptr<distributed::MeshDevice>& mesh_device, con
     uint32_t mem_type = (uint32_t)MemoryType::DRAM;
     uint32_t mech = (uint32_t)NocMechanism::UNICAST;
 
+    uint32_t num_banks = 1;
+
     // Reader kernel (RISCV_1): reads from DRAM input to L1
     vector<uint32_t> reader_args = {
         l1_addr,
         input_dram_addr,
-        cfg.dram_channel,
         cfg.num_of_transactions,
         (uint32_t)bytes_per_txn,
         cfg.test_id,
         sem_id,
+        num_banks,
         mem_type,
         mech,
         (uint32_t)NocPattern::ONE_FROM_ONE};
@@ -647,11 +649,11 @@ static bool run_dram(const shared_ptr<distributed::MeshDevice>& mesh_device, con
     vector<uint32_t> writer_args = {
         l1_addr,
         output_dram_addr,
-        cfg.dram_channel,
         cfg.num_of_transactions,
         (uint32_t)bytes_per_txn,
         cfg.test_id,
         sem_id,
+        num_banks,
         mem_type,
         mech,
         (uint32_t)NocPattern::ONE_TO_ONE};
@@ -683,6 +685,109 @@ static bool run_dram(const shared_ptr<distributed::MeshDevice>& mesh_device, con
         log_error(LogTest, "DRAM Equality Check failed for test_id {}", cfg.test_id);
     }
     return is_equal;
+}
+
+// Handles interleaved DRAM read+write where each core cycles through ALL DRAM banks in round-robin.
+// Used for both one_from_all (1 core) and all_from_all (N cores) DRAM patterns.
+static bool run_dram_interleaved(
+    const shared_ptr<distributed::MeshDevice>& mesh_device,
+    const NocEstimatorConfig& cfg,
+    const vector<CoreCoord>& cores) {
+    IDevice* device = mesh_device->impl().get_device(0);
+    Program program = CreateProgram();
+
+    const size_t bytes_per_txn = cfg.pages_per_transaction * cfg.bytes_per_page;
+    uint32_t num_dram_banks = (uint32_t)device->num_dram_channels();
+
+    std::set<CoreRange> core_ranges;
+    for (auto& c : cores) {
+        core_ranges.insert(CoreRange(c));
+    }
+    CoreRangeSet core_set(core_ranges);
+
+    DramAddressInfo dram_info = unit_tests::dm::get_dram_address_and_size();
+    uint32_t input_dram_addr = dram_info.base_address;
+    uint32_t output_dram_addr = input_dram_addr + (uint32_t)bytes_per_txn;
+
+    L1AddressInfo l1_info = unit_tests::dm::get_l1_address_and_size(mesh_device, cores[0]);
+    uint32_t l1_addr = l1_info.base_address;
+
+    uint32_t sem_id = CreateSemaphore(program, core_set, 0);
+
+    uint32_t mem_type = (uint32_t)MemoryType::DRAM;
+    uint32_t mech = (uint32_t)NocMechanism::UNICAST;
+
+    // Reader pattern matches cfg; writer uses the corresponding write pattern
+    NocPattern writer_pattern =
+        (cfg.pattern == NocPattern::ONE_FROM_ALL) ? NocPattern::ONE_TO_ALL : NocPattern::ALL_TO_ALL;
+
+    vector<uint32_t> reader_compile_args = {
+        l1_addr,
+        input_dram_addr,
+        cfg.num_of_transactions,
+        (uint32_t)bytes_per_txn,
+        cfg.test_id,
+        sem_id,
+        num_dram_banks,
+        mem_type,
+        mech,
+        (uint32_t)cfg.pattern};
+
+    CreateKernel(
+        program,
+        KERNELS_DIR + "dram_reader.cpp",
+        core_set,
+        DataMovementConfig{
+            .processor = DataMovementProcessor::RISCV_1,
+            .noc = NOC::RISCV_1_default,
+            .compile_args = reader_compile_args});
+
+    vector<uint32_t> writer_compile_args = {
+        l1_addr,
+        output_dram_addr,
+        cfg.num_of_transactions,
+        (uint32_t)bytes_per_txn,
+        cfg.test_id,
+        sem_id,
+        num_dram_banks,
+        mem_type,
+        mech,
+        (uint32_t)writer_pattern};
+
+    CreateKernel(
+        program,
+        KERNELS_DIR + "dram_writer.cpp",
+        core_set,
+        DataMovementConfig{
+            .processor = DataMovementProcessor::RISCV_0,
+            .noc = NOC::RISCV_0_default,
+            .compile_args = writer_compile_args});
+
+    log_info(LogTest, "Running Test ID: {}, Run ID: {}", cfg.test_id, unit_tests::dm::runtime_host_id);
+    program.set_runtime_id(unit_tests::dm::runtime_host_id++);
+
+    auto packed_input = make_test_data(bytes_per_txn);
+    auto packed_golden = packed_input;
+
+    // Write same input data to all DRAM banks (each bank gets the same content)
+    for (uint32_t bank = 0; bank < num_dram_banks; bank++) {
+        detail::WriteToDeviceDRAMChannel(device, bank, input_dram_addr, packed_input);
+    }
+    MetalContext::instance().get_cluster().dram_barrier(device->id());
+
+    execute_program(mesh_device, std::move(program));
+
+    // Verify output from banks that were written to (round-robin covers up to num_banks)
+    uint32_t banks_to_verify = cfg.num_of_transactions < num_dram_banks ? cfg.num_of_transactions : num_dram_banks;
+    for (uint32_t bank = 0; bank < banks_to_verify; bank++) {
+        vector<uint32_t> packed_output;
+        detail::ReadFromDeviceDRAMChannel(device, bank, output_dram_addr, (uint32_t)bytes_per_txn, packed_output);
+        if (packed_output != packed_golden) {
+            log_error(LogTest, "DRAM Interleaved Equality Check failed for test_id {}, bank {}", cfg.test_id, bank);
+            return false;
+        }
+    }
+    return true;
 }
 
 // ============ DISPATCH ============
@@ -974,6 +1079,87 @@ static void sweep_dram(const shared_ptr<distributed::MeshDevice>& mesh_device, u
     }
 }
 
+// ============ MULTI-BANK DRAM SWEEP FUNCTIONS ============
+
+// Single core reading/writing ALL DRAM banks in round-robin (interleaved access pattern).
+// Measures how well one core can utilize multi-bank parallelism.
+static void sweep_dram_one_from_all(const shared_ptr<distributed::MeshDevice>& mesh_device, uint32_t test_id) {
+    auto [bytes_per_page, max_bytes, max_pages] = unit_tests::dm::compute_physical_constraints(mesh_device);
+
+    vector<CoreCoord> cores = {{0, 0}};
+
+    uint32_t max_transactions = 256;
+    uint32_t max_pages_per_txn = 256;
+
+    for (uint32_t num_txn = 1; num_txn <= max_transactions; num_txn *= 4) {
+        for (uint32_t pages = 1; pages <= max_pages_per_txn; pages *= 2) {
+            if (num_txn * pages * bytes_per_page >= max_bytes) {
+                continue;
+            }
+
+            NocEstimatorConfig cfg = {
+                .test_id = test_id,
+                .pattern = NocPattern::ONE_FROM_ALL,
+                .mechanism = NocMechanism::UNICAST,
+                .memory_type = MemoryType::DRAM,
+                .num_of_transactions = num_txn,
+                .pages_per_transaction = pages,
+                .bytes_per_page = bytes_per_page,
+            };
+            EXPECT_TRUE(run_dram_interleaved(mesh_device, cfg, cores));
+        }
+    }
+
+    ReadMeshDeviceProfilerResults(*mesh_device);
+}
+
+// Multiple diagonal cores, each reading/writing ALL DRAM banks in round-robin.
+// Measures aggregate bandwidth when multiple cores contend for the same banks.
+static void sweep_dram_all_from_all(const shared_ptr<distributed::MeshDevice>& mesh_device, uint32_t test_id) {
+    auto [bytes_per_page, max_bytes, max_pages] = unit_tests::dm::compute_physical_constraints(mesh_device);
+    IDevice* device = mesh_device->impl().get_device(0);
+    CoreCoord device_grid = device->compute_with_storage_grid_size();
+    uint32_t num_dram_banks = (uint32_t)device->num_dram_channels();
+
+    // Place one core per diagonal position, capped at the number of DRAM banks
+    uint32_t num_cores = (uint32_t)device_grid.x;
+    if ((uint32_t)device_grid.y < num_cores) {
+        num_cores = (uint32_t)device_grid.y;
+    }
+    if (num_dram_banks < num_cores) {
+        num_cores = num_dram_banks;
+    }
+
+    vector<CoreCoord> cores;
+    for (uint32_t i = 0; i < num_cores; i++) {
+        cores.push_back(CoreCoord(i, i));
+    }
+
+    uint32_t max_transactions = 256;
+    uint32_t max_pages_per_txn = 256;
+
+    for (uint32_t num_txn = 1; num_txn <= max_transactions; num_txn *= 4) {
+        for (uint32_t pages = 1; pages <= max_pages_per_txn; pages *= 2) {
+            if (num_txn * pages * bytes_per_page >= max_bytes) {
+                continue;
+            }
+
+            NocEstimatorConfig cfg = {
+                .test_id = test_id,
+                .pattern = NocPattern::ALL_FROM_ALL,
+                .mechanism = NocMechanism::UNICAST,
+                .memory_type = MemoryType::DRAM,
+                .num_of_transactions = num_txn,
+                .pages_per_transaction = pages,
+                .bytes_per_page = bytes_per_page,
+            };
+            EXPECT_TRUE(run_dram_interleaved(mesh_device, cfg, cores));
+        }
+    }
+
+    ReadMeshDeviceProfilerResults(*mesh_device);
+}
+
 // ============ ROW / COLUMN SWEEP FUNCTIONS ============
 
 static void sweep_one_to_row(const shared_ptr<distributed::MeshDevice>& mesh_device, uint32_t test_id) {
@@ -1228,6 +1414,14 @@ TEST_F(GenericMeshDeviceFixture, NIGHTLY_NocEstimatorL1AllFromAll) {
 
 TEST_F(GenericMeshDeviceFixture, NIGHTLY_NocEstimatorDRAM) {
     unit_tests::dm::noc_estimator::sweep_dram(get_mesh_device(), 806);
+}
+
+TEST_F(GenericMeshDeviceFixture, NIGHTLY_NocEstimatorDRAMOneFromAll) {
+    unit_tests::dm::noc_estimator::sweep_dram_one_from_all(get_mesh_device(), 811);
+}
+
+TEST_F(GenericMeshDeviceFixture, NIGHTLY_NocEstimatorDRAMAllFromAll) {
+    unit_tests::dm::noc_estimator::sweep_dram_all_from_all(get_mesh_device(), 812);
 }
 
 // ============ ROW / COLUMN TESTS ============

--- a/tests/tt_metal/tt_metal/data_movement/python/stats_collector.py
+++ b/tests/tt_metal/tt_metal/data_movement/python/stats_collector.py
@@ -209,18 +209,19 @@ class StatsCollector:
                 test_name = self.test_id_to_name.get(test_id, "")
                 for test_type, config in self.test_type_attributes.items():
                     if test_type.replace("_", " ").title() in test_name:
+                        value_mappings = config.get("value_mappings", {})
                         for key, value in config["attributes"].items():
-                            agg_data[value] = attributes.get(key)
+                            raw_val = attributes.get(key)
+                            # Apply value mapping if one exists for this attribute
+                            if key in value_mappings and raw_val in value_mappings[key]:
+                                agg_data[value] = value_mappings[key][raw_val]
+                            else:
+                                agg_data[value] = raw_val
                         # For multicast, create a grid dimension string
                         if test_type == "multicast_schemes":
                             grid_x = attributes.get("Subordinate Grid Size X", "N/A")
                             grid_y = attributes.get("Subordinate Grid Size Y", "N/A")
                             agg_data["grid_dimensions"] = f"{grid_x} x {grid_y}"
-
-                num_subordinates = attributes.get("Number of subordinates", 0)
-                same_axis = attributes.get("Same axis", 0)
-                agg_data["num_subordinates"] = num_subordinates
-                agg_data["same_axis"] = same_axis
 
                 agg[run_host_id] = agg_data
 

--- a/tests/tt_metal/tt_metal/data_movement/python/stats_reporter.py
+++ b/tests/tt_metal/tt_metal/data_movement/python/stats_reporter.py
@@ -99,13 +99,16 @@ class StatsReporter:
                     "Number of Transactions",
                 ]
 
+                # Architecture is always included (known from the host side)
+                header.append("Architecture")
+
                 # Add metadata columns for NOC estimator consumption
                 # All metadata fields are automatically included (except 'name' and 'comment')
                 if test_metadata is not None:
                     # Standard metadata fields in specific order for csv_reader.cpp compatibility
                     standard_fields = ["architecture", "mechanism", "memory_type", "pattern"]
                     for field in standard_fields:
-                        if field in test_metadata:
+                        if field in test_metadata and field != "architecture":
                             column_name = self.metadata_loader.metadata_field_to_column_name(field)
                             header.append(column_name)
 
@@ -165,6 +168,9 @@ class StatsReporter:
                             run_stats.get("num_transactions"),
                         ]
 
+                        # Architecture is always included
+                        row.append(self.arch.lower())
+
                         # Add metadata columns
                         if test_metadata is not None:
                             # Standard metadata fields in specific order
@@ -180,11 +186,6 @@ class StatsReporter:
                             )
                             for field in optional_fields:
                                 value = test_metadata[field]
-                                # If we have profiled data and it's not set in the test_information
-                                if field == "num_subordinates" and value == "":
-                                    value = run_stats.get("num_subordinates", 0)
-                                if field == "same_axis" and value == "":
-                                    value = bool(run_stats.get("same_axis", 0))
                                 row.append(value)
                         row.extend(
                             [

--- a/tests/tt_metal/tt_metal/data_movement/python/test_data_movement.py
+++ b/tests/tt_metal/tt_metal/data_movement/python/test_data_movement.py
@@ -8,6 +8,7 @@ import os
 import csv
 import sys
 import yaml
+import pytest
 from loguru import logger  # type: ignore
 from matplotlib.gridspec import GridSpec
 import itertools
@@ -94,6 +95,7 @@ def profile_dm_tests(verbose=False, gtest_filter=None):
     os.system(cmd)
 
 
+@pytest.mark.timeout(1200)  # 20 minutes timeout
 def test_data_movement(
     no_profile: bool,
     verbose_log: bool,

--- a/tests/tt_metal/tt_metal/data_movement/python/test_data_movement.py
+++ b/tests/tt_metal/tt_metal/data_movement/python/test_data_movement.py
@@ -95,7 +95,6 @@ def profile_dm_tests(verbose=False, gtest_filter=None):
     os.system(cmd)
 
 
-@pytest.mark.timeout(1200)  # 20 minutes timeout
 def test_data_movement(
     no_profile: bool,
     verbose_log: bool,

--- a/tests/tt_metal/tt_metal/data_movement/python/test_data_movement.py
+++ b/tests/tt_metal/tt_metal/data_movement/python/test_data_movement.py
@@ -8,7 +8,6 @@ import os
 import csv
 import sys
 import yaml
-import pytest
 from loguru import logger  # type: ignore
 from matplotlib.gridspec import GridSpec
 import itertools

--- a/tests/tt_metal/tt_metal/data_movement/python/test_mappings/test_information.yaml
+++ b/tests/tt_metal/tt_metal/data_movement/python/test_mappings/test_information.yaml
@@ -752,3 +752,10 @@ tests:
 
   810:
     name: "Noc Estimator - L1 Column to Column"
+
+  811:
+    name: "Noc Estimator - DRAM One from All"
+
+  812:
+    name: "Noc Estimator - DRAM All from All"
+    bandwidth_mode: "combined"

--- a/tests/tt_metal/tt_metal/data_movement/python/test_mappings/test_information.yaml
+++ b/tests/tt_metal/tt_metal/data_movement/python/test_mappings/test_information.yaml
@@ -739,23 +739,41 @@ tests:
     name: "Noc Estimator - L1 All from All"
 
   806:
-    name: "Noc Estimator - DRAM"
-
-  807:
     name: "Noc Estimator - L1 One to Row"
 
-  808:
+  807:
     name: "Noc Estimator - L1 Row to Row"
 
-  809:
+  808:
     name: "Noc Estimator - L1 One to Column"
 
-  810:
+  809:
     name: "Noc Estimator - L1 Column to Column"
 
+  810:
+    name: "Noc Estimator - DRAM Sharded One from One"
+
   811:
-    name: "Noc Estimator - DRAM One from All"
+    name: "Noc Estimator - DRAM Sharded All from All"
+    bandwidth_mode: "combined"
 
   812:
-    name: "Noc Estimator - DRAM All from All"
+    name: "Noc Estimator - DRAM Interleaved One from All"
+
+  813:
+    name: "Noc Estimator - DRAM Interleaved All from All"
+    bandwidth_mode: "combined"
+
+  814:
+    name: "Noc Estimator - DRAM Sharded One to One"
+
+  815:
+    name: "Noc Estimator - DRAM Sharded All to All"
+    bandwidth_mode: "combined"
+
+  816:
+    name: "Noc Estimator - DRAM Interleaved One to All"
+
+  817:
+    name: "Noc Estimator - DRAM Interleaved All to All"
     bandwidth_mode: "combined"

--- a/tests/tt_metal/tt_metal/data_movement/python/test_mappings/test_information.yaml
+++ b/tests/tt_metal/tt_metal/data_movement/python/test_mappings/test_information.yaml
@@ -8,10 +8,6 @@
 # - name: Human-readable test name
 # - comment: (optional) Additional notes about test behavior and performance
 #
-# Additional metadata fields for NOC estimator consumption:
-# These fields are required for tests that generate CSV reports used by the NOC estimator
-# for offline model training. Only "Packet Sizes" tests need these fields.
-#
 # Required fields for packet sizes tests:
 #   - memory_type: Memory type being accessed
 #       Values: "l1" | "dram"
@@ -19,15 +15,6 @@
 #       Values: "unicast" | "multicast"
 #   - pattern: Communication pattern between cores
 #       Values: "one_to_one" | "one_from_one" | "one_to_all" | "one_from_all" | "all_to_all" | "all_from_all"
-#
-# Optional fields supported by the estimator:
-#   - num_subordinates: Number of destination cores (for *_to_all patterns with fixed grid sizes)
-#       Examples: 4 (for 2x2), 25 (for 5x5)
-#       Omit for tests with variable grid sizes or non-*_to_all patterns
-#       Leave empty to use real kernel data (num_subordinates = "")
-#   - same_axis: Whether the source and destination core share one axis
-#       Examples: true for (0,0)->(0,5), false for (0,0)->(2,2)
-#       Leave empty to use real kernel data (same_axis = "")
 #
 # Bandwidth calculation mode:
 #   - bandwidth_mode: How bandwidth is calculated and reported
@@ -80,77 +67,63 @@ tests:
     memory_type: "l1"
     mechanism: "unicast"
     pattern: "one_to_all"
-    num_subordinates: ""
 
   7:
     name: "One to All Unicast 5x5 Packet Sizes"
     memory_type: "l1"
     mechanism: "unicast"
     pattern: "one_to_all"
-    num_subordinates: ""
 
   8:
     name: "One to All Unicast Packet Sizes"
     memory_type: "l1"
     mechanism: "unicast"
     pattern: "one_to_all"
-    num_subordinates: ""
 
   9:
     name: "One to All Multicast 2x2 Packet Sizes"
     memory_type: "l1"
     mechanism: "multicast"
     pattern: "one_to_all"
-    num_subordinates: ""
 
   10:
     name: "One to All Multicast 5x5 Packet Sizes"
     memory_type: "l1"
     mechanism: "multicast"
     pattern: "one_to_all"
-    num_subordinates: ""
 
   11:
     name: "One to All Multicast Packet Sizes"
     memory_type: "l1"
     mechanism: "multicast"
     pattern: "one_to_all"
-    num_subordinates: ""
 
   12:
     name: "One to All Multicast Linked 2x2 Packet Sizes"
     memory_type: "l1"
     mechanism: "multicast"
     pattern: "one_to_all"
-    num_subordinates: ""
-    linked: true
 
   13:
     name: "One to All Multicast Linked 5x5 Packet Sizes"
     memory_type: "l1"
     mechanism: "multicast"
     pattern: "one_to_all"
-    num_subordinates: ""
-    linked: true
 
   14:
     name: "One to All Multicast Linked Packet Sizes"
     memory_type: "l1"
     mechanism: "multicast"
     pattern: "one_to_all"
-    num_subordinates: ""
-    linked: true
 
   15:
     name: "One from All Packet Sizes"
     memory_type: "l1"
     mechanism: "unicast"
     pattern: "one_from_all"
-    num_subordinates: ""
 
   16:
     name: "Loopback Packet Sizes"
-    # TODO issue #35917
 
   17:
     name: "Reshard Hardcoded Small"
@@ -240,7 +213,6 @@ tests:
 
   40:
     name: "DRAM Packet Sizes 2.0"
-    # TODO issue #35917
 
   50:
     name: "One to One Directed Ideal"
@@ -307,11 +279,9 @@ tests:
 
   80:
     name: "One Packet Read Sizes"
-    # TODO issue #35917
 
   81:
     name: "One Packet Write Sizes"
-    # TODO issue #35917
 
   82:
     name: "One Packet Read Directed Ideal"
@@ -347,7 +317,6 @@ tests:
   111:
     name: "Multi Interleaved Sizes"
     bandwidth_mode: "combined"
-    # TODO issue #35917
 
   112:
     name: "Multi Interleaved Read Directed Ideal"
@@ -367,7 +336,6 @@ tests:
   115:
     name: "Multi Interleaved Write Sizes"
     bandwidth_mode: "combined"
-    # TODO issue #35917
 
   116:
     name: "Multi Interleaved 2x2 Directed Ideal"
@@ -376,7 +344,6 @@ tests:
   117:
     name: "Multi Interleaved 2x2 Sizes"
     bandwidth_mode: "combined"
-    # TODO issue #35917
 
   118:
     name: "Multi Interleaved 2x2 Read Directed Ideal"
@@ -385,7 +352,6 @@ tests:
   119:
     name: "Multi Interleaved 2x2 Read Sizes"
     bandwidth_mode: "combined"
-    # TODO issue #35917
 
   120:
     name: "Multi Interleaved 2x2 Write Directed Ideal"
@@ -394,7 +360,6 @@ tests:
   121:
     name: "Multi Interleaved 2x2 Write Sizes"
     bandwidth_mode: "combined"
-    # TODO issue #35917
 
   122:
     name: "Multi Interleaved 6x6 Directed Ideal"
@@ -403,7 +368,6 @@ tests:
   123:
     name: "Multi Interleaved 6x6 Sizes"
     bandwidth_mode: "combined"
-    # TODO issue #35917
 
   124:
     name: "Multi Interleaved 6x6 Read Directed Ideal"
@@ -412,7 +376,6 @@ tests:
   125:
     name: "Multi Interleaved 6x6 Read Sizes"
     bandwidth_mode: "combined"
-    # TODO issue #35917
 
   126:
     name: "Multi Interleaved 6x6 Write Directed Ideal"
@@ -421,7 +384,6 @@ tests:
   127:
     name: "Multi Interleaved 6x6 Write Sizes"
     bandwidth_mode: "combined"
-    # TODO issue #35917
 
   140:
     name: "Core Bidirectional Directed Ideal Same Kernel"
@@ -443,11 +405,9 @@ tests:
 
   146:
     name: "Core Bidirectional Packet Sizes Same Kernel"
-    # TODO issue #35917
 
   147:
     name: "Core Bidirectional Packet Sizes Different Kernels"
-    # TODO issue #35917
 
   148:
     name: "Core Bidirectional Custom"
@@ -562,7 +522,6 @@ tests:
     memory_type: "l1"
     mechanism: "unicast"
     pattern: "all_from_all"
-    num_subordinates: ""
 
   312:
     name: "All from All 2x2 From 1x1 Directed Ideal"
@@ -760,3 +719,36 @@ tests:
       covering all compute cores in the device.
       Important: Since the multicast is transferring a lot of data, the NoC gets congested quickly.
       Because of this, for larger number of transactions, the noc api latency is increasing.
+
+  800:
+    name: "Noc Estimator - L1 One to One"
+
+  801:
+    name: "Noc Estimator - L1 One from One"
+
+  802:
+    name: "Noc Estimator - L1 One to All"
+
+  803:
+    name: "Noc Estimator - L1 One from All"
+
+  804:
+    name: "Noc Estimator - L1 All to All"
+
+  805:
+    name: "Noc Estimator - L1 All from All"
+
+  806:
+    name: "Noc Estimator - DRAM"
+
+  807:
+    name: "Noc Estimator - L1 One to Row"
+
+  808:
+    name: "Noc Estimator - L1 Row to Row"
+
+  809:
+    name: "Noc Estimator - L1 One to Column"
+
+  810:
+    name: "Noc Estimator - L1 Column to Column"

--- a/tests/tt_metal/tt_metal/data_movement/python/test_mappings/test_type_attributes.yaml
+++ b/tests/tt_metal/tt_metal/data_movement/python/test_mappings/test_type_attributes.yaml
@@ -15,3 +15,42 @@ direct_write:
     "Same value": "same_value"
     "NoC Index": "noc_index"
     "Stateful": "stateful"
+noc_estimator:
+  attributes:
+    "Memory type": "memory_type"
+    "Mechanism": "mechanism"
+    "Pattern": "pattern"
+    "Same axis": "same_axis"
+    "Stateful": "stateful"
+    "Loopback": "loopback"
+    "Number of subordinates": "num_subordinates"
+    "NoC Index": "noc_index"
+  value_mappings:
+    "Memory type":
+      0: "L1"
+      1: "DRAM"
+    "Mechanism":
+      0: "unicast"
+      1: "multicast"
+      2: "multicast_linked"
+    "Pattern":
+      0: "one_to_one"
+      1: "one_from_one"
+      2: "one_to_all"
+      3: "one_from_all"
+      4: "all_to_all"
+      5: "all_from_all"
+      6: "one_to_row"
+      7: "row_to_row"
+      8: "one_to_column"
+      9: "column_to_column"
+
+    "Same axis":
+      0: false
+      1: true
+    "Stateful":
+      0: false
+      1: true
+    "Loopback":
+      0: false
+      1: true

--- a/tests/tt_metal/tt_metal/data_movement/python/test_mappings/test_type_attributes.yaml
+++ b/tests/tt_metal/tt_metal/data_movement/python/test_mappings/test_type_attributes.yaml
@@ -28,7 +28,8 @@ noc_estimator:
   value_mappings:
     "Memory type":
       0: "L1"
-      1: "DRAM"
+      1: "DRAM Sharded"
+      2: "DRAM Interleaved"
     "Mechanism":
       0: "unicast"
       1: "multicast"

--- a/tests/tt_metal/tt_metal/data_movement/python/test_mappings/test_type_attributes.yaml
+++ b/tests/tt_metal/tt_metal/data_movement/python/test_mappings/test_type_attributes.yaml
@@ -28,8 +28,8 @@ noc_estimator:
   value_mappings:
     "Memory type":
       0: "L1"
-      1: "DRAM Sharded"
-      2: "DRAM Interleaved"
+      1: "DRAM Interleaved"
+      2: "DRAM Sharded"
     "Mechanism":
       0: "unicast"
       1: "multicast"

--- a/tests/tt_metal/tt_metal/data_movement/sources.cmake
+++ b/tests/tt_metal/tt_metal/data_movement/sources.cmake
@@ -27,4 +27,5 @@ set(UNIT_TESTS_DATA_MOVEMENT_SRC
     atomics/test_atomic_semaphore_bandwidth.cpp
     multicast_atomics/test_multicast_atomic_semaphore.cpp
     noc_api_latency/test_noc_api_latency.cpp
+    noc_estimator_tests/test_noc_estimator.cpp
 )


### PR DESCRIPTION
### Ticket
Link to [Github Issue](https://github.com/orgs/tenstorrent/projects/135/views/10?pane=issue&itemId=149853163&issue=tenstorrent%7Ctt-metal%7C35917)

### Problem description
NOC estimator needs comprehensive performance data across all major communication patterns (unicast, multicast, L1 core-to-core, DRAM transfers) to build accurate latency models.


### What's changed
Added a complete NOC estimator test suite under `noc_estimator_tests/` that exercises every major pattern with configurable sweep parameters. The test framework uses the experimental 2.0 NOC API with `TensorAccessor` for `DRAM` access, and isolates read and write operations to separate kernels running on `RISCV_0` and `RISCV_1` to eliminate `L1` contention artifacts.
The suite covers `L1` patterns (single-core, one-to-many, all-to-all, row/column variants) and `DRAM` patterns (sharded and interleaved access, with reads and writes tested separately). `L1` tests use `800-809`, `DRAM` reads use `810-813`, and DRAM writes use `814-817`. A companion documentation file explains what each pattern measures without referencing specific test IDs.


### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=nstamatovic/noc_estimator_tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:nstamatovic/noc_estimator_tests)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=nstamatovic/noc_estimator_tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:nstamatovic/noc_estimator_tests)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nstamatovic/noc_estimator_tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nstamatovic/noc_estimator_tests)
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nstamatovic/noc_estimator_tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nstamatovic/noc_estimator_tests)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nstamatovic/noc_estimator_tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nstamatovic/noc_estimator_tests)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nstamatovic/noc_estimator_tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nstamatovic/noc_estimator_tests)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
