### PR TITLE
[Deepseek Blitz] Pipleine integ w bcast moe

### DIFF
--- a/models/demos/deepseek_v3_b1/fused_ops/moe/moe_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/fused_ops/moe/moe_kernel.cpp
@@ -336,10 +336,14 @@ void kernel_main() {
             get_named_compile_time_arg_val("shared_residual_mcast_src_num_pages");
         unified_kernels::setup_sharded_buffer(shared_residual_mcast_src_cb, shared_residual_mcast_src_num_pages);
 #else
-        // Broadcast pkt_cb: tensor-backed input staging buffer
-        constexpr uint32_t bcast_pkt_cb = get_named_compile_time_arg_val("bcast_pkt_cb");
-        constexpr uint32_t bcast_num_pages = get_named_compile_time_arg_val("bcast_num_pages_to_read");
-        unified_kernels::setup_sharded_buffer(bcast_pkt_cb, bcast_num_pages);
+        // Broadcast pkt_cb: tensor-backed input staging buffer.
+        // Skip when using socket — BRISC signals the CB each iteration via socket recv + cb_push_back.
+        constexpr bool bcast_use_socket = get_named_compile_time_arg_val("bcast_use_socket") == 1;
+        if constexpr (!bcast_use_socket) {
+            constexpr uint32_t bcast_pkt_cb = get_named_compile_time_arg_val("bcast_pkt_cb");
+            constexpr uint32_t bcast_num_pages = get_named_compile_time_arg_val("bcast_num_pages_to_read");
+            unified_kernels::setup_sharded_buffer(bcast_pkt_cb, bcast_num_pages);
+        }
 #endif
     }
     if constexpr (Core::Routed::is_gate_mm_core) {
@@ -947,8 +951,12 @@ void kernel_main() {
                 get_named_compile_time_arg_val("bcast_pkt_cb"),
                 get_named_compile_time_arg_val("bcast_num_pages_to_read"),
                 get_named_compile_time_arg_val("bcast_is_sender"),
-                0>;
-            deepseek_b1_ops::Broadcast::ReaderArgs bcast_args{};
+                get_named_compile_time_arg_val("bcast_use_socket")>;
+            deepseek_b1_ops::Broadcast::ReaderArgs bcast_args{
+                get_common_arg_val<uint32_t>(0),  // socket_config_addr
+                get_common_arg_val<uint32_t>(1),  // socket_page_size
+                get_common_arg_val<uint32_t>(2),  // socket_num_pages
+            };
             deepseek_b1_ops::Broadcast::Op<BcastCTArgs, Core::is_sender_core> bcast_op;
             bcast_op(bcast_args);
 #else
@@ -986,6 +994,12 @@ void kernel_main() {
             rmsnorm(moe.routed.rmsnorm_args);
         }
 
+        // 1. RMSNorm Mcast: Broadcast normalized input from sender core to all receiver cores
+        {
+            DeviceZoneScopedN("MCAST");
+            mcast(moe.routed.mcast_args);
+        }
+
 #ifdef ENABLE_BCAST
         // Pop CB 25 after consumers (residual mcast + RMSNorm) are done,
         // so next iteration's setup_sharded_buffer can push new data
@@ -998,12 +1012,6 @@ void kernel_main() {
         }
 #endif
 #endif
-
-        // 1. RMSNorm Mcast: Broadcast normalized input from sender core to all receiver cores
-        {
-            DeviceZoneScopedN("MCAST");
-            mcast(moe.routed.mcast_args);
-        }
 
         // 2. Matmul + Activation: Routing matmul on gate_mm cores
         {

--- a/models/demos/deepseek_v3_b1/fused_ops/moe/op.py
+++ b/models/demos/deepseek_v3_b1/fused_ops/moe/op.py
@@ -697,6 +697,7 @@ class MoeRoutedExpertOp:
         bcast_intermediate_tensor=None,
         bcast_semaphores=None,
         bcast_sender_coord=None,
+        worker_core_grid: Optional[ttnn.CoreRangeSet] = None,
         # Semaphore IDs (caller-provided, see MoeOp for top-level definitions)
         mcast_data_sender_semaphore_id=0,
         mcast_data_receiver_semaphore_id=1,
@@ -734,10 +735,12 @@ class MoeRoutedExpertOp:
         mcast_grid = mcast_output_tensor.memory_config().shard_spec.grid
         num_gate_proj_cores = gate_proj_core_ranges.num_cores()
 
-        # Full device grid
-        full_device_grid = ttnn.CoreRangeSet(
-            [ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(device_grid_size.x - 1, device_grid_size.y - 1))]
-        )
+        # Worker core grid: default to full device grid unless caller overrides.
+        full_device_grid = worker_core_grid
+        if full_device_grid is None:
+            full_device_grid = ttnn.CoreRangeSet(
+                [ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(device_grid_size.x - 1, device_grid_size.y - 1))]
+            )
 
         expert_scale_mcast_sender_semaphore_id = mcast_data_sender_semaphore_id  # Reuse sender semaphore
 
@@ -2060,6 +2063,7 @@ class MoeSharedExpertOp:
         sender_core,
         sender_core_grid,
         mcast_grid,
+        num_dram_worker_cores,
         k_parallel=8,
         n_parallel=8,
         # Semaphore IDs (overridable, defaults match MoeOp layout)
@@ -2271,14 +2275,12 @@ class MoeSharedExpertOp:
             dst_tensor=shared_output_tensor,
             noc0_receiver_semaphore_id=output_gather_noc0_receiver_semaphore_id,
             noc1_receiver_semaphore_id=output_gather_noc1_receiver_semaphore_id,
+            use_explicit_sender_index=True,
         )
 
         # ==================================================================
         # Output Mcast (sender → all cores, DRAM cores receive into add_cb_in1)
         # ==================================================================
-        mcast_total_cores = mcast_grid.num_cores()
-        num_phantom_cores = sender_core.y  # col 12, rows 0..(sender.y-1)
-        num_dram_worker_cores = mcast_total_cores - num_matmul_cores - num_phantom_cores - 1
         output_mcast_params = MoeSharedExpertOp.setup_output_mcast(
             gather_dst_num_pages=output_gather_params["dst_num_pages"],
             tile_size=tile_1x32_size,
@@ -2573,7 +2575,7 @@ class MoeOp:
     # Gather sems overlap with mcast receiver sems (different physical cores).
     # noc1_num_senders=0 for all gathers, so only noc0 sem is used.
     MCAST_SENDER_SEM = 0
-    MCAST_DATA_RECEIVER_SEM = 1  # mcast grid; overlaps with DOWN_PROJ_GATHER_SEM on sender core
+    MCAST_DATA_RECEIVER_SEM = 13  # mcast grid; overlaps with DOWN_PROJ_GATHER_SEM on sender core
     DOWN_PROJ_GATHER_SEM = 1  # sender core
     RESIDUAL_MCAST_RECEIVER_SEM = 2  # mcast grid; overlaps with AG_GATHER_SEM on sender core
     AG_GATHER_SEM = 2  # sender core
@@ -2652,10 +2654,9 @@ class MoeOp:
             Dictionary with mcast parameters for compile-time args
         """
         # Get mcast grid bounds
-        mcast_ranges = list(mcast_grid.ranges())
-        mcast_grid_range = mcast_ranges[0]  # Single rectangular range
-        mcast_grid_start = mcast_grid_range.start
-        mcast_grid_end = mcast_grid_range.end
+        mcast_grid_bbox = mcast_grid.bounding_box()
+        mcast_grid_start = mcast_grid_bbox.start
+        mcast_grid_end = mcast_grid_bbox.end
 
         # Get NOC coordinates for mcast destination
         dest_noc_start_core = device.worker_core_from_logical_core(mcast_grid_start)
@@ -2982,6 +2983,11 @@ class MoeOp:
         bcast_intermediate_tensor=None,
         bcast_semaphores=None,
         bcast_sender_coord=None,
+        # Socket: when provided, sender device BRISC receives the bcast payload over socket
+        # instead of reading from a pre-loaded bcast_input_tensor.
+        socket=None,
+        # Optional worker-core grid override (used to avoid overlap with external micro-ops).
+        worker_core_grid: Optional[ttnn.CoreRangeSet] = None,
     ):
         """
         Execute the full fused MoE operation (routed + shared expert).
@@ -3041,6 +3047,7 @@ class MoeOp:
             bcast_intermediate_tensor=bcast_intermediate_tensor,
             bcast_semaphores=bcast_semaphores,
             bcast_sender_coord=bcast_sender_coord,
+            worker_core_grid=worker_core_grid,
             # Semaphore IDs from top-level
             mcast_data_sender_semaphore_id=MoeOp.MCAST_SENDER_SEM,
             mcast_data_receiver_semaphore_id=MoeOp.MCAST_DATA_RECEIVER_SEM,
@@ -3082,6 +3089,7 @@ class MoeOp:
             sender_core=routed_ctx.sender_core,
             sender_core_grid=routed_ctx.input_core_grid,
             mcast_grid=routed_ctx.mcast_grid,
+            num_dram_worker_cores=routed_ctx.gate_proj_core_ranges.num_cores(),
             k_parallel=shared_k_parallel,
             n_parallel=shared_n_parallel,
             # Semaphore IDs from top-level
@@ -3498,16 +3506,27 @@ class MoeOp:
                 if bcast_input_tensor is not None:
                     bcast_pkt_cb = 46
                     bcast_pkt_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(bcast_pkt_cb, bcast_input_tensor)
+                    bcast_pkt_cb_descriptor.format_descriptors[
+                        0
+                    ].tile = routed_ctx.rmsnorm_output_cb_descriptor.format_descriptors[0].tile
+                    bcast_pkt_cb_descriptor.format_descriptors[
+                        0
+                    ].page_size = routed_ctx.rmsnorm_output_cb_descriptor.format_descriptors[0].page_size
                     device_cb_descriptors.append(bcast_pkt_cb_descriptor)
 
                 # Broadcast per-device setup
                 bcast_fabric_node_id = None
                 bcast_dst_nodes = []
                 bcast_num_connections = 0
+                bcast_use_socket = False  # set inside enable_bcast when socket is provided
+                brisc_common_rt_args = []  # populated inside enable_bcast for socket mode
                 if enable_bcast:
                     bp = bcast_params
                     sender_row, sender_col = bp["sender_coord"]
                     bcast_is_sender = (row == sender_row) and (col == sender_col)
+                    # socket_page_size: size of ONE embedding payload (single-shot per iteration)
+                    bcast_socket_page_size = bp["page_size_bytes"] * bp["input_num_pages"]
+                    bcast_use_socket = socket is not None and bcast_is_sender
                     bcast_is_secondary_sender = routed_ctx.mesh_cols > 1 and (row == sender_row) and (col != sender_col)
                     bcast_has_secondary_target = bcast_is_sender and routed_ctx.mesh_cols > 1
 
@@ -3555,6 +3574,7 @@ class MoeOp:
                             ("bcast_range_hops_forward", bcast_range_hops_forward),
                             ("bcast_start_distance_in_hops_backward", bcast_start_distance_backward),
                             ("bcast_range_hops_backward", bcast_range_hops_backward),
+                            ("bcast_use_socket", int(bcast_use_socket)),
                         ]
                     )
 
@@ -3563,8 +3583,18 @@ class MoeOp:
                         [
                             ("bcast_num_pages_to_read", bp["input_num_pages"]),
                             ("bcast_is_sender", int(bcast_is_sender)),
+                            ("bcast_use_socket", int(bcast_use_socket)),
                         ]
                     )
+
+                    # BRISC common runtime args: socket config for sender, zeros for all others.
+                    # Position 0/1/2 map to socket_config_addr / socket_page_size / socket_num_pages
+                    # in the BRISC Broadcast::ReaderArgs (get_common_arg_val(0/1/2)).
+                    brisc_common_rt_args = [
+                        int(socket.get_config_buffer_address()) if bcast_use_socket else 0,
+                        int(bcast_socket_page_size) if bcast_use_socket else 0,
+                        1 if bcast_use_socket else 0,  # single-shot: one full embedding per iteration
+                    ]
 
                     # NCRISC common runtime args for broadcast writer
                     bcast_ncrisc_common_rt_args = [
@@ -3646,6 +3676,8 @@ class MoeOp:
                     kernel_defines.append(("ENABLE_REDUCE_TO_ONE", "1"))
                 if enable_bcast:
                     kernel_defines.append(("ENABLE_BCAST", "1"))
+                    if bcast_use_socket:
+                        kernel_defines.append(("ENABLE_SOCKET_READER", "1"))
 
                 # Create unified kernel
                 unified_kernel = UnifiedKernelDescriptor(
@@ -3655,6 +3687,7 @@ class MoeOp:
                     brisc_named_compile_time_args=brisc_args,
                     trisc_named_compile_time_args=trisc_args,
                     ncrisc_common_runtime_args=ncrisc_common_rt_args,
+                    brisc_common_runtime_args=brisc_common_rt_args,
                     trisc_common_runtime_args=[
                         routed_ctx.rmsnorm_epsilon_packed,
                         routed_ctx.rmsnorm_scalar_packed,
@@ -3669,6 +3702,7 @@ class MoeOp:
                     per_core_compile_time_descriptors=device_per_core_ct_descs,
                     per_core_runtime_args_descriptor=device_runtime_args_descriptor,
                     defines=kernel_defines,
+                    noc_mode=ttnn.NOC_MODE.DM_DYNAMIC_NOC,
                 )
 
                 kernel_result = unified_kernel.get_kernel_descriptors()

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_bcast_moe_two_stage_pipeline.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_bcast_moe_two_stage_pipeline.py
@@ -1,0 +1,407 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Two-stage pipeline integration test for socket-fed bcast + MoE fused op.
+
+Stage 0:
+  host token -> fused embedding (HostInterface) -> cross-stage D2D
+Stage 1:
+  entry D2D receiver -> moe sender core socket input -> bcast + fused MoE
+  (reduce-to-one included)
+Stage 2+ (if applicable):
+  passive forwarding, no downstream op
+"""
+
+import pytest
+import torch
+from loguru import logger
+
+import ttnn
+from models.common.utility_functions import is_slow_dispatch
+from models.demos.deepseek_v3_b1.fused_ops.moe.op import MoeOp
+from models.demos.deepseek_v3_b1.micro_ops.host_io.utils import dtype_size
+from models.demos.deepseek_v3_b1.micro_ops.pipeline_block.op import PipelineBlock
+from models.demos.deepseek_v3_b1.tests.unit_tests.test_moe import (
+    create_routed_expert_tensors,
+    create_shared_expert_tensors,
+)
+
+
+def create_fabric_router_config(max_payload_size):
+    config = ttnn._ttnn.fabric.FabricRouterConfig()
+    config.max_packet_payload_size_bytes = max_payload_size
+    return config
+
+
+def build_worker_grid_excluding_core(device_grid_size, excluded_core):
+    max_x = device_grid_size.x - 1
+    max_y = device_grid_size.y - 1
+    ranges = []
+
+    if excluded_core.y > 0:
+        ranges.append(ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(max_x, excluded_core.y - 1)))
+    if excluded_core.y < max_y:
+        ranges.append(ttnn.CoreRange(ttnn.CoreCoord(0, excluded_core.y + 1), ttnn.CoreCoord(max_x, max_y)))
+    if excluded_core.x > 0:
+        ranges.append(
+            ttnn.CoreRange(ttnn.CoreCoord(0, excluded_core.y), ttnn.CoreCoord(excluded_core.x - 1, excluded_core.y))
+        )
+    if excluded_core.x < max_x:
+        ranges.append(
+            ttnn.CoreRange(ttnn.CoreCoord(excluded_core.x + 1, excluded_core.y), ttnn.CoreCoord(max_x, excluded_core.y))
+        )
+
+    return ttnn.CoreRangeSet(ranges)
+
+
+@pytest.mark.parametrize(
+    "mesh_device",
+    [(4, 2)],
+    indirect=True,
+)
+@pytest.mark.parametrize(
+    "device_params",
+    [
+        {
+            "fabric_config": ttnn.FabricConfig.FABRIC_2D,
+            "fabric_router_config": create_fabric_router_config(15232),
+            "trace_region_size": 573440,
+        }
+    ],
+    indirect=True,
+)
+@pytest.mark.parametrize("vocab_size, embedding_dim", [(64, 7168)])
+@pytest.mark.parametrize("token_id", [0, 31, 63])
+def test_bcast_moe_two_stage_pipeline(mesh_device, vocab_size, embedding_dim, token_id):
+    if not is_slow_dispatch():
+        pytest.skip("Skipping test in fast dispatch mode")
+
+    ttnn.enable_asynchronous_slow_dispatch(mesh_device)
+
+    my_mesh_id = mesh_device.get_system_mesh_id()
+    num_procs = int(ttnn.distributed_context_get_size())
+    if num_procs < 2:
+        pytest.skip(f"Requires at least 2 distributed processes, got {num_procs}")
+
+    device_grid = mesh_device.compute_with_storage_grid_size()
+    if device_grid.x < 13 or device_grid.y < 10:
+        pytest.skip(f"Device grid {device_grid.x}x{device_grid.y} too small for MoE (need >= 13x10)")
+
+    pipeline_config = ttnn._ttnn.operations.experimental.generate_blitz_decode_pipeline(mesh_device)
+    assert len(pipeline_config) == num_procs + 1
+
+    is_stage0 = my_mesh_id == 0
+    is_stage1 = my_mesh_id == 1
+
+    M = 1
+    K = embedding_dim
+    # Hardcoded test/prod placement:
+    # pipeline core is excluded from MoE worker grid; MoE sender/mcaster is at (12, 9).
+    pipeline_core = ttnn.CoreCoord(12, 8)
+    moe_sender_core = ttnn.CoreCoord(12, 9)
+    moe_worker_core_grid = build_worker_grid_excluding_core(device_grid, pipeline_core)
+
+    token_size_bytes = 64
+    embedding_size_bytes = K * dtype_size(ttnn.bfloat16)
+    embedding_fifo_size = embedding_size_bytes * 2
+
+    # Deterministic embedding table: row i = arange offset by i*K
+    torch_embedding = torch.arange(vocab_size * K, dtype=torch.float32).reshape(1, 1, vocab_size, K).to(torch.bfloat16)
+
+    # ── Pipeline block setup ──────────────────────────────────────────────────
+    if is_stage0:
+        embedding_tensor = ttnn.from_torch(
+            torch_embedding,
+            dtype=ttnn.bfloat16,
+            layout=ttnn.ROW_MAJOR_LAYOUT,
+        )
+        embedding_tensor = ttnn.to_device(embedding_tensor, mesh_device, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+        pipeline_block = PipelineBlock(
+            mesh_device,
+            pipeline_core,
+            upstream_d2d_socket_fifo_size=embedding_fifo_size,
+            downstream_d2d_socket_fifo_size=embedding_fifo_size,
+            upstream_d2d_socket_page_size=embedding_size_bytes,
+            downstream_d2d_socket_page_size=embedding_size_bytes,
+            h2d_socket_fifo_size=token_size_bytes * 2,
+            d2h_socket_fifo_size=embedding_fifo_size,
+            d2h_socket_page_size=embedding_size_bytes,
+            embedding_tensor=embedding_tensor,
+        )
+    elif is_stage1:
+        stage_entry_device = pipeline_config[my_mesh_id].entry_node_coord
+        pipeline_block = PipelineBlock(
+            mesh_device,
+            pipeline_core,
+            upstream_d2d_socket_fifo_size=embedding_fifo_size,
+            downstream_d2d_socket_fifo_size=embedding_fifo_size,
+            upstream_d2d_socket_page_size=embedding_size_bytes,
+            downstream_d2d_socket_page_size=embedding_size_bytes,
+            entry_node_downstream=ttnn.MeshCoreCoord(stage_entry_device, moe_sender_core),
+            # Detach stage-1 exit from the MoE socket chain
+            exit_node_upstream=ttnn.MeshCoreCoord(stage_entry_device, pipeline_core),
+        )
+    else:
+        # Passive forwarding for rank >= 2
+        pipeline_block = PipelineBlock(
+            mesh_device,
+            pipeline_core,
+            upstream_d2d_socket_fifo_size=embedding_fifo_size,
+            downstream_d2d_socket_fifo_size=embedding_fifo_size,
+            upstream_d2d_socket_page_size=embedding_size_bytes,
+            downstream_d2d_socket_page_size=embedding_size_bytes,
+        )
+
+    logger.info(f"[rank={my_mesh_id}] pipeline block created")
+
+    # ── Stage 1: MoE tensor setup ─────────────────────────────────────────────
+    result_scores = None
+    result_indices = None
+    result_output = None
+
+    if is_stage1:
+        mesh_mapper = ttnn.ReplicateTensorToMesh(mesh_device)
+        r = create_routed_expert_tensors(
+            mesh_device,
+            use_hardcoded_expert_index=True,
+            mesh_mapper=mesh_mapper,
+            input_core=moe_sender_core,
+            mcast_output_core_grid=moe_worker_core_grid,
+        )
+        mcast_grid = r["ttnn_mcast_output"].memory_config().shard_spec.grid
+        gate_proj_grid = r["gate_proj_output"].memory_config().shard_spec.grid
+        gate_proj_cores = ttnn.corerange_to_cores(gate_proj_grid, row_wise=True)
+        worker_cores = {(c.x, c.y) for c in ttnn.corerange_to_cores(moe_worker_core_grid, row_wise=True)}
+        assert all(
+            (c.x, c.y) in worker_cores for c in gate_proj_cores
+        ), "gate_proj worker cores must stay inside MoE worker_core_grid"
+        s = create_shared_expert_tensors(mesh_device, M, K, mcast_grid, mesh_mapper=mesh_mapper)
+
+        # Bcast tensors: bcast_input_tensor backs bcast_pkt_cb (CB 46).
+        # Socket writes the received embedding directly here each iteration.
+        # bcast_intermediate_tensor is the broadcast destination (CB 25 backing).
+        tile_1x32 = ttnn.Tile([1, 32])
+        input_core_grid = r["ttnn_residual_mcast_src"].memory_config().shard_spec.grid
+        bcast_shard_spec = ttnn.ShardSpec(input_core_grid, (M, K), ttnn.ShardOrientation.ROW_MAJOR)
+        bcast_mem_config = ttnn.MemoryConfig(
+            ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, bcast_shard_spec
+        )
+        bcast_input_tensor = ttnn.from_torch(
+            torch.zeros((M, K), dtype=torch.bfloat16),
+            dtype=ttnn.bfloat16,
+            layout=ttnn.TILE_LAYOUT,
+            device=mesh_device,
+            memory_config=bcast_mem_config,
+            tile=tile_1x32,
+            mesh_mapper=mesh_mapper,
+        )
+        bcast_intermediate_tensor = r["ttnn_residual_mcast_src"]
+
+        # Global semaphores for bcast sync (3) and reduce sync (4)
+        num_cores = device_grid.x * device_grid.y
+        available_cores = ttnn.num_cores_to_corerangeset(num_cores, device_grid, row_wise=True)
+        ttnn.synchronize_device(mesh_device)
+        bcast_semaphores = [ttnn.create_global_semaphore(mesh_device, available_cores, 0) for _ in range(3)]
+        ttnn.synchronize_device(mesh_device)
+
+        # ReduceToOne tensors — same setup as test_moe_fused_with_bcast
+        root_coord = (1, 1)
+        final_output_total_width = r["final_output_total_width"]
+        final_output_mem_config = r["final_output_mem_config"]
+        reduce_mesh_mapper_config = ttnn.MeshMapperConfig(
+            [ttnn.PlacementShard(0), ttnn.PlacementShard(1)], mesh_device.shape
+        )
+        reduce_mesh_mapper = ttnn.create_mesh_mapper(mesh_device, reduce_mesh_mapper_config)
+
+        reduce_intermediate_tensors = []
+        for _ in range(3):
+            reduce_intermediate_tensors.append(
+                ttnn.from_torch(
+                    torch.zeros([4, 2, final_output_total_width], dtype=torch.bfloat16),
+                    dtype=ttnn.bfloat16,
+                    layout=ttnn.TILE_LAYOUT,
+                    device=mesh_device,
+                    memory_config=final_output_mem_config,
+                    tile=tile_1x32,
+                    mesh_mapper=reduce_mesh_mapper,
+                )
+            )
+
+        reduce_output_core = moe_sender_core
+        reduce_output_shard_grid = ttnn.CoreRangeSet({ttnn.CoreRange(reduce_output_core, reduce_output_core)})
+        reduce_output_mem_config = ttnn.MemoryConfig(
+            ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+            ttnn.BufferType.L1,
+            ttnn.ShardSpec(reduce_output_shard_grid, (1, final_output_total_width), ttnn.ShardOrientation.ROW_MAJOR),
+        )
+        reduce_output_tensor = ttnn.from_torch(
+            torch.zeros([4, 2, final_output_total_width], dtype=torch.bfloat16),
+            dtype=ttnn.bfloat16,
+            layout=ttnn.TILE_LAYOUT,
+            device=mesh_device,
+            memory_config=reduce_output_mem_config,
+            tile=tile_1x32,
+            mesh_mapper=reduce_mesh_mapper,
+        )
+
+        ttnn.synchronize_device(mesh_device)
+        reduce_semaphores = [ttnn.create_global_semaphore(mesh_device, available_cores, 0) for _ in range(4)]
+        ttnn.synchronize_device(mesh_device)
+
+        # recv_socket: the downstream socket of the entry node, delivering the embedding
+        # to moe_sender_core on this device. bcast_sender_coord must be the sender *device* coord.
+        recv_socket = pipeline_block.get_downstream_socket()
+        sender_coord = recv_socket.get_active_cores()[0].device_coord
+        bcast_sender_coord = stage_entry_device
+
+    # ── Launch pipeline programs ──────────────────────────────────────────────
+    pipeline_block.run()
+    logger.info(f"[rank={my_mesh_id}] pipeline programs launched")
+
+    # Ensure all stages are launched before injecting the token
+    ttnn.distributed_context_barrier()
+
+    if is_stage0:
+        token_size_datums = token_size_bytes // dtype_size(ttnn.uint32)
+        torch_token = torch.zeros(1, token_size_datums, dtype=torch.uint32)
+        torch_token[0, 0] = token_id
+        token_tensor = ttnn.from_torch(torch_token, dtype=ttnn.uint32, layout=ttnn.ROW_MAJOR_LAYOUT)
+        pipeline_block.write_token(token_tensor)
+        logger.info(f"[rank=0] token {token_id} injected")
+
+    # Ensure token is injected before stage-1 enters potentially blocking op launch
+    ttnn.distributed_context_barrier()
+
+    if is_stage1:
+        logger.info("[rank=1] launching MoE bcast + socket (num_iterations=1)")
+        result_scores, result_indices, result_output = MoeOp.op(
+            r["ttnn_rmsnorm_output"],
+            r["ttnn_mcast_output"],
+            r["ttnn_gate_mm_weights"],
+            r["ttnn_gate_mm_output"],
+            r["ttnn_gate_input"],
+            r["ttnn_gate_bias"],
+            r["ttnn_gate_indices"],
+            r["gate_output_scores_tensor"],
+            r["gate_output_indices_tensor"],
+            r["expert_index_tensor"],
+            r["expert_scale_tensor"],
+            r["gate_proj_weights"],
+            r["gate_proj_output"],
+            r["up_proj_weights"],
+            r["up_proj_mm_out_tensor"],
+            r["fused_output_tensor"],
+            r["down_proj_gather_output_tensor"],
+            r["down_proj_mcast_output_tensor"],
+            r["down_proj_weights"],
+            r["down_proj_output"],
+            s["ttnn_output_mcast_dst"],
+            r["final_output_tensor"],
+            r["gate_proj_in1_buf_tensor"],
+            r["down_proj_in1_buf_tensor"],
+            r["mul_scalar_buf_tensor"],
+            rmsnorm_gamma_tensor=r["ttnn_rmsnorm_gamma"],
+            shared_residual_mcast_src_tensor=r["ttnn_residual_mcast_src"],
+            shared_gate_weights_overlapped=s["shared_gate_weights_overlapped"],
+            shared_up_weights_overlapped=s["shared_up_weights_overlapped"],
+            shared_residual_mcast_dst_tensor=r["ttnn_residual_mcast_dst"],
+            shared_down_mcast_dst_tensor=s["ttnn_down_mcast_dst"],
+            shared_down_weights_tensor=s["ttnn_down_weights"],
+            shared_output_tensor=s["ttnn_output"],
+            shared_ag_gather_dst_tensor=s["ttnn_ag_gather_dst"],
+            shared_bg_gather_dst_tensor=s["ttnn_bg_gather_dst"],
+            shared_gu_out_tensor=s["ttnn_gu_out"],
+            shared_intermed_tensor=s["ttnn_intermed"],
+            shared_down_mcast_src_tensor=s["ttnn_down_mcast_src"],
+            shared_down_matmul_out_tensor=s["ttnn_down_matmul_out"],
+            shared_residual_add_out_tensor=s["ttnn_residual_add_out"],
+            shared_k_parallel=s["k_parallel"],
+            shared_n_parallel=s["n_parallel"],
+            use_hardcoded_expert_index=True,
+            num_iterations=1,
+            reduce_intermediate_tensors=reduce_intermediate_tensors,
+            reduce_output_tensor=None,
+            reduce_semaphores=reduce_semaphores,
+            reduce_root_coord=ttnn.MeshCoordinate(root_coord),
+            bcast_input_tensor=bcast_input_tensor,
+            bcast_intermediate_tensor=bcast_intermediate_tensor,
+            bcast_semaphores=bcast_semaphores,
+            bcast_sender_coord=bcast_sender_coord,
+            socket=recv_socket,
+            worker_core_grid=moe_worker_core_grid,
+        )
+        logger.info("[rank=1] MoE completed")
+
+    ttnn.distributed_context_barrier()
+
+    pipeline_block.terminate()
+    logger.info(f"[rank={my_mesh_id}] programs terminated")
+
+    # ── Stage 1: validate ─────────────────────────────────────────────────────
+    if is_stage1:
+        mesh_rows, mesh_cols = mesh_device.shape
+        num_devices = mesh_rows * mesh_cols
+        K_down = s["K_down"]
+
+        # 1. Grab the exact row from the embedding table for this token
+        torch_input_row = torch_embedding[0, 0, token_id : token_id + 1, :]
+
+        # 2. Reconstruct expected output per device
+        device_gate_indices = ttnn.to_torch(result_indices, mesh_composer=ttnn.ConcatMeshToTensor(mesh_device, dim=0))
+        device_gate_scores = ttnn.to_torch(result_scores, mesh_composer=ttnn.ConcatMeshToTensor(mesh_device, dim=0))
+        result_output_torch = ttnn.to_torch(result_output, mesh_composer=ttnn.ConcatMeshToTensor(mesh_device, dim=0))
+
+        # We validate the output of the rank 1 device itself (the stage entry device)
+        device_idx = stage_entry_device[0] * mesh_cols + stage_entry_device[1]
+
+        # 1. Grab the exact row from the embedding table for this token
+        torch_input_row = torch_embedding[0, 0, token_id : token_id + 1, :]
+
+        # 3. Get local MoE properties
+        actual_expert_idx = device_idx
+        actual_expert_scale = device_gate_scores[0].flatten()[device_idx].float()
+
+        shared_gate_shard = s["torch_gate_weights"][:, device_idx * K_down : (device_idx + 1) * K_down]
+        shared_up_shard = s["torch_up_weights"][:, device_idx * K_down : (device_idx + 1) * K_down]
+        shared_down_shard = s["torch_down_weights"][device_idx * K_down : (device_idx + 1) * K_down, :]
+
+        # 4. Compute Golden MoE for this device only
+        _, _, expected_final = MoeOp.golden(
+            torch_input_row,
+            r["torch_gate_mm_weights"],
+            r["torch_bias"],
+            shared_gate_weights=shared_gate_shard,
+            shared_up_weights=shared_up_shard,
+            shared_down_weights=shared_down_shard,
+            gate_proj_weights_dict=r["expert_weights_dict"],
+            up_proj_weights_dict=r["up_proj_weights_dict"],
+            down_proj_weights_dict=r["down_proj_weights_dict"],
+            eps=r["gate_eps"],
+            scaling_factor=r["gate_scaling_factor"],
+            use_hardcoded_expert_index=True,
+            hardcoded_expert_index=actual_expert_idx,
+            explicit_expert_scale=actual_expert_scale,
+            rmsnorm_gamma=r["torch_rmsnorm_gamma"],
+            rmsnorm_epsilon=1e-6,
+        )
+
+        # 5. Extract valid data (strip padding) from the raw result tensor
+        actual_final = result_output_torch[device_idx]
+        from models.demos.deepseek_v3_b1.tests.unit_tests.test_moe import extract_routed_expert_output
+
+        actual_valid = extract_routed_expert_output(
+            actual_final.unsqueeze(0),
+            r["num_gate_proj_cores"],
+            r["final_output_width_per_core"],
+            r["per_core_down_proj_N"],
+        )
+
+        # 6. PCC Comparison
+        from models.demos.deepseek_v3_b1.tests.unit_tests.test_moe import comp_pcc
+
+        passing, pcc_msg = comp_pcc(expected_final.flatten(), actual_valid.flatten(), 0.97)
+        logger.info(f"Pipeline Stage 1 Device {device_idx} PCC: {pcc_msg}")
+        assert passing, f"Pipeline Stage 1 Device {device_idx} failed PCC: {pcc_msg}"
+
+        logger.info("bcast + MoE two-stage pipeline test passed (non-reduced output)!")

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_moe.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_moe.py
@@ -274,7 +274,13 @@ def create_shared_expert_tensors(device, M, K_gate, mcast_grid, mesh_mapper=None
 # ============================================================================
 # Helper: create all routed-expert tensors
 # ============================================================================
-def create_routed_expert_tensors(device, use_hardcoded_expert_index, mesh_mapper=None):
+def create_routed_expert_tensors(
+    device,
+    use_hardcoded_expert_index,
+    mesh_mapper=None,
+    input_core=None,
+    mcast_output_core_grid=None,
+):
     """
     Create all tensors needed for MoE routed expert test.
     Directly extracted from the working inline test setup.
@@ -283,6 +289,8 @@ def create_routed_expert_tensors(device, use_hardcoded_expert_index, mesh_mapper
         device: TT device or mesh device
         use_hardcoded_expert_index: Whether to use hardcoded expert index (1 expert vs 256)
         mesh_mapper: Optional mesh mapper for multi-device replication
+        input_core: Optional sender/input core override. Defaults to (grid_x - 1, 9).
+        mcast_output_core_grid: Optional mcast destination grid override. Defaults to rectangle [(0,0) -> input_core].
 
     Returns:
         dict with all ttnn tensors, torch tensors, expert dicts, and dimensions.
@@ -325,7 +333,7 @@ def create_routed_expert_tensors(device, use_hardcoded_expert_index, mesh_mapper
 
     # Input tensor: sharded on sender core OUTSIDE the compute grid
     device_grid_size = device.compute_with_storage_grid_size()
-    input_core = ttnn.CoreCoord(device_grid_size.x - 1, 9)
+    input_core = input_core if input_core is not None else ttnn.CoreCoord(device_grid_size.x - 1, 9)
     input_core_grid = ttnn.CoreRangeSet([ttnn.CoreRange(input_core, input_core)])
     input_shard_spec = ttnn.ShardSpec(
         input_core_grid,
@@ -384,8 +392,13 @@ def create_routed_expert_tensors(device, use_hardcoded_expert_index, mesh_mapper
     gate_proj_core_ranges = ttnn.CoreRangeSet([ttnn.CoreRange(core, core) for core in gate_proj_worker_cores])
     num_gate_proj_cores = len(gate_proj_worker_cores)
 
-    # Mcast output tensor: sharded on rectangular grid from (0,0) to sender core
-    mcast_output_core_grid = ttnn.CoreRangeSet([ttnn.CoreRange(ttnn.CoreCoord(0, 0), input_core)])
+    # Mcast output tensor: default rectangular grid from (0,0) to sender core.
+    # Tests can override this to exclude reserved pipeline cores.
+    mcast_output_core_grid = (
+        mcast_output_core_grid
+        if mcast_output_core_grid is not None
+        else ttnn.CoreRangeSet([ttnn.CoreRange(ttnn.CoreCoord(0, 0), input_core)])
+    )
     mcast_output_shard_spec = ttnn.ShardSpec(
         mcast_output_core_grid,
         (M, K),

--- a/models/demos/deepseek_v3_b1/unified_kernels/broadcast.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/broadcast.hpp
@@ -136,11 +136,16 @@ struct Broadcast {
                         set_receiver_socket_page_size(recv, args.socket_page_size);
                         socket_wait_for_pages(recv, args.socket_num_pages);
                         cb_reserve_back(CTArgs::cb0_id, CTArgs::num_pages_to_read);
-                        tt_memmove<true, false, false, 0>(
-                            get_write_ptr(CTArgs::cb0_id), recv.read_ptr, args.socket_page_size);
+                        // tt_memmove<true, false, false, 0>(
+                        //     get_write_ptr(CTArgs::cb0_id), recv.read_ptr, args.socket_page_size);
+                        invalidate_l1_cache();
+                        memmove(
+                            (void*)(get_write_ptr(CTArgs::cb0_id)),
+                            (void*)(recv.read_ptr),
+                            (size_t)(args.socket_page_size));
                         cb_push_back(CTArgs::cb0_id, CTArgs::num_pages_to_read);
                         socket_pop_pages(recv, args.socket_num_pages);
-                        socket_notify_sender(recv);
+                        socket_notify_sender(recv, 1 - noc_index);
                         update_socket_config(recv);
                     } else {
 #endif

--- a/tt_metal/hw/inc/api/socket_api.h
+++ b/tt_metal/hw/inc/api/socket_api.h
@@ -354,7 +354,7 @@ FORCE_INLINE void fabric_socket_notify_sender_stateful(
         (uint32_t)fabric_header_addr, sizeof(PACKET_HEADER_TYPE));
 }
 
-void socket_notify_sender(const SocketReceiverInterface& socket) {
+void socket_notify_sender(const SocketReceiverInterface& socket, uint8_t noc = noc_index) {
     if (socket.is_h2d) {
         volatile tt_l1_ptr receiver_socket_md* socket_config =
             reinterpret_cast<volatile tt_l1_ptr receiver_socket_md*>(socket.config_addr);
@@ -368,7 +368,7 @@ void socket_notify_sender(const SocketReceiverInterface& socket) {
     } else {
         auto upstream_bytes_acked_noc_addr =
             get_noc_addr(socket.d2d.upstream_noc_x, socket.d2d.upstream_noc_y, socket.d2d.upstream_bytes_acked_addr);
-        noc_inline_dw_write(upstream_bytes_acked_noc_addr, socket.bytes_acked);
+        noc_inline_dw_write(upstream_bytes_acked_noc_addr, socket.bytes_acked, 0xF, noc);
     }
 }
 


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Provide context for the problem.

### What's changed
Describe the approach used to solve the problem.
Summarize the changes made and its impact.

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=aagarwal/pipleine-integ-w-bcast-moe)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:aagarwal/pipleine-integ-w-bcast-moe)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=aagarwal/pipleine-integ-w-bcast-moe)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:aagarwal/pipleine-integ-w-bcast-moe)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=aagarwal/pipleine-integ-w-bcast-moe)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:aagarwal/pipleine-integ-w-bcast-moe)
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=aagarwal/pipleine-integ-w-bcast-moe)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:aagarwal/pipleine-integ-w-bcast-moe)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=aagarwal/pipleine-integ-w-bcast-moe)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:aagarwal/pipleine-integ-w-bcast-moe)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=aagarwal/pipleine-integ-w-bcast-moe)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:aagarwal/pipleine-integ-w-bcast-moe)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
