### PR TITLE
Fix test_isin.py: cast UInt32 result to int32 before count_nonzero

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/experimental/test_isin.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/test_isin.py
@@ -65,7 +65,7 @@ def test_isin_typical_predefined_data(elements, test_elements, dtype, layout, in
     ttnn_isin_result = ttnn.experimental.isin(elements_ttnn, test_elements_ttnn, invert=invert)
 
     # Assert - Compare results
-    torch_result_from_ttnn = ttnn.to_torch(ttnn_isin_result)
+    torch_result_from_ttnn = ttnn.to_torch(ttnn_isin_result).to(torch.int32)
     assert torch_isin_result.shape == torch_result_from_ttnn.shape
     assert torch_isin_result.count_nonzero() == torch_result_from_ttnn.count_nonzero()
     assert torch.equal(torch_isin_result != 0, torch_result_from_ttnn != 0)
@@ -98,7 +98,7 @@ def test_isin_random_data(elements_shape, test_elements_shape, invert, device):
     ttnn_isin_result = ttnn.experimental.isin(elements_ttnn, test_elements_ttnn, invert=invert)
 
     # Assert - Compare results
-    torch_result_from_ttnn = ttnn.to_torch(ttnn_isin_result)
+    torch_result_from_ttnn = ttnn.to_torch(ttnn_isin_result).to(torch.int32)
     assert torch_isin_result.shape == torch_result_from_ttnn.shape
     assert torch_isin_result.count_nonzero() == torch_result_from_ttnn.count_nonzero()
     assert torch.equal(torch_isin_result != 0, torch_result_from_ttnn != 0)
@@ -132,7 +132,7 @@ def test_isin_program_cache_and_random_data(
         ttnn_isin_result = ttnn.experimental.isin(elements_ttnn, test_elements_ttnn, invert=invert)
 
     # Assert - Compare results
-    torch_result_from_ttnn = ttnn.to_torch(ttnn_isin_result)
+    torch_result_from_ttnn = ttnn.to_torch(ttnn_isin_result).to(torch.int32)
     assert torch_isin_result.shape == torch_result_from_ttnn.shape
     assert torch_isin_result.count_nonzero() == torch_result_from_ttnn.count_nonzero()
     assert torch.equal(torch_isin_result != 0, torch_result_from_ttnn != 0)


### PR DESCRIPTION
### Ticket
Fixes failures from nightly CI run https://github.com/tenstorrent/tt-metal/actions/runs/22430389826

### Problem description
PR #36660 ("Support uint16 and uint32 in to_torch") changed `ttnn.to_torch()` to return proper unsigned PyTorch types instead of silently converting to signed variants. That PR updated ~20 test files but missed these nightly tests since they were not exercised by post-commit CI.

After #36660, `ttnn.to_torch()` returns `torch.uint32` for isin results. PyTorch's `count_nonzero()` does not support `UInt32` tensors, so the test assertions fail with `RuntimeError: "nonzero_count_cpu" not implemented for 'UInt32'`.

### What's changed
Cast the result of `ttnn.to_torch()` to `torch.int32` before performing assertions in all three test functions (`test_isin_typical_predefined_data`, `test_isin_random_data`, `test_isin_program_cache_and_random_data`). The isin results are boolean-like (0 or 1), so the cast is lossless.

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=jbauman/fix-test-isin-uint32)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:jbauman/fix-test-isin-uint32)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=jbauman/fix-test-isin-uint32)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:jbauman/fix-test-isin-uint32)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=jbauman/fix-test-isin-uint32)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jbauman/fix-test-isin-uint32)
- [x] New/Existing tests provide coverage for changes