### PR TITLE
Fix test_embedding.py: cast indices to torch.long for embedding lookup

### DIFF
--- a/tests/ttnn/unit_tests/operations/data_movement/test_embedding.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_embedding.py
@@ -13,7 +13,7 @@ def test_base_case(device):
     torch.manual_seed(1234)
     indices = ttnn.to_device(ttnn.from_torch(torch.tensor([[1, 2, 4, 5], [4, 3, 2, 9]]), dtype=ttnn.uint32), device)
     embedding_matrix = ttnn.to_device(ttnn.from_torch(torch.rand(10, 2), dtype=ttnn.bfloat16), device)
-    indices_torch = ttnn.to_torch(ttnn.from_device(indices))
+    indices_torch = ttnn.to_torch(ttnn.from_device(indices)).to(torch.long)
     embedding_matrix_torch = ttnn.to_torch(ttnn.from_device(embedding_matrix))
     expected_embeddings = torch.nn.functional.embedding(indices_torch, embedding_matrix_torch)
     embeddings = ttnn.embedding(indices, embedding_matrix)


### PR DESCRIPTION
### Ticket
Fixes failures from nightly CI run https://github.com/tenstorrent/tt-metal/actions/runs/22430389826

### Problem description
PR #36660 ("Support uint16 and uint32 in to_torch") changed `ttnn.to_torch()` to return proper unsigned PyTorch types instead of silently converting to signed variants. That PR updated ~20 test files but missed these nightly tests since they were not exercised by post-commit CI.

After #36660, `ttnn.to_torch()` returns `torch.uint32` for `ttnn.uint32` tensors. `torch.nn.functional.embedding` requires `Long` or `Int` indices, so `test_base_case` fails with `RuntimeError: Expected tensor for argument #1 'indices' to have one of the following scalar types: Long, Int; but got CPUUInt32Type instead`.

### What's changed
Cast `indices_torch` to `torch.long` before passing to `torch.nn.functional.embedding`. The indices are small positive integers, so the cast is lossless. `torch.long` is the canonical type for index tensors in PyTorch.

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=jbauman/fix-test-embedding-uint32)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:jbauman/fix-test-embedding-uint32)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=jbauman/fix-test-embedding-uint32)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:jbauman/fix-test-embedding-uint32)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=jbauman/fix-test-embedding-uint32)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jbauman/fix-test-embedding-uint32)
- [x] New/Existing tests provide coverage for changes