### PR TITLE
Fix test_pad.py: cast output dtype to match input for uint16 compatibility

### DIFF
--- a/tests/ttnn/unit_tests/operations/data_movement/test_pad.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_pad.py
@@ -50,7 +50,7 @@ def test_pad_rm(device, n, c, h, w, padding, torch_padding, value, dtype):
 
     input_tensor = ttnn.from_torch(torch_input_tensor, layout=ttnn.ROW_MAJOR_LAYOUT, device=device, dtype=dtype)
     output_tensor = ttnn.pad(input_tensor, padding=padding, value=value)
-    output_tensor = ttnn.to_torch(output_tensor)
+    output_tensor = ttnn.to_torch(output_tensor).to(torch_input_tensor.dtype)
 
     assert output_tensor.shape == torch_output_tensor.shape
     assert torch.equal(torch_output_tensor, output_tensor)
@@ -153,7 +153,7 @@ def run_pad_rm_sharded(device, n, c, h, w, padding, torch_padding, value, shard_
 
     tt_output_tensor = ttnn.to_memory_config(tt_output_tensor, ttnn.L1_MEMORY_CONFIG)
     tt_output_tensor = ttnn.from_device(tt_output_tensor)
-    tt_output_tensor = ttnn.to_torch(tt_output_tensor)
+    tt_output_tensor = ttnn.to_torch(tt_output_tensor).to(torch_output_tensor.dtype)
 
     assert tt_output_tensor.shape == torch_output_tensor.shape
     assert torch.equal(torch_output_tensor, tt_output_tensor)
@@ -479,7 +479,7 @@ def test_pad_op(device, in_dtype, shape, padshape, use_multicore, layout, mem_co
 
     ttnn_input = ttnn.from_torch(torch_input, device=device, memory_config=mem_config, dtype=in_dtype, layout=layout)
     output_tt = ttnn.pad(ttnn_input, padshape, [0, 0, 0, 0], value=0, use_multicore=use_multicore)
-    output_tt = ttnn.to_torch(output_tt)
+    output_tt = ttnn.to_torch(output_tt).to(torch_input.dtype)
     assert output_tt.shape == torch.Size(padshape)
 
     shape_diff = list(map(lambda x, y: x - y, padshape, shape))


### PR DESCRIPTION
### Ticket
Fixes failures from nightly CI run https://github.com/tenstorrent/tt-metal/actions/runs/22430389826

### Problem description
PR #36660 ("Support uint16 and uint32 in to_torch") changed `ttnn.to_torch()` to return proper unsigned PyTorch types (`torch.uint16`, `torch.uint32`) instead of silently converting to signed variants. That PR updated ~20 test files but missed these nightly tests since they were not exercised by post-commit CI.

`random_torch_tensor` creates `torch.int16` reference tensors for `ttnn.uint16` (because PyTorch historically lacked unsigned int types). After #36660, `ttnn.to_torch()` returns `torch.uint16`, and `torch.equal()` fails with `RuntimeError: Promotion for uint16, uint32, uint64 types is not supported, attempted to promote Short and UInt16`.

### What's changed
Cast the output of `ttnn.to_torch()` to match the input tensor's dtype before comparison in three functions:
- `test_pad_rm`
- `run_pad_rm_sharded`
- `test_pad_op`

All values are non-negative and within range (generated with `randint(0, 2**15)` for uint16), so the cast is lossless.

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=jbauman/fix-test-pad-uint16)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:jbauman/fix-test-pad-uint16)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=jbauman/fix-test-pad-uint16)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:jbauman/fix-test-pad-uint16)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=jbauman/fix-test-pad-uint16)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jbauman/fix-test-pad-uint16)
- [x] New/Existing tests provide coverage for changes