### PR TITLE
Fix nightly CI test failures from to_torch unsigned dtype change

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/experimental/test_isin.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/test_isin.py
@@ -65,7 +65,7 @@ def test_isin_typical_predefined_data(elements, test_elements, dtype, layout, in
     ttnn_isin_result = ttnn.experimental.isin(elements_ttnn, test_elements_ttnn, invert=invert)
 
     # Assert - Compare results
-    torch_result_from_ttnn = ttnn.to_torch(ttnn_isin_result)
+    torch_result_from_ttnn = ttnn.to_torch(ttnn_isin_result).to(torch.int32)
     assert torch_isin_result.shape == torch_result_from_ttnn.shape
     assert torch_isin_result.count_nonzero() == torch_result_from_ttnn.count_nonzero()
     assert torch.equal(torch_isin_result != 0, torch_result_from_ttnn != 0)
@@ -98,7 +98,7 @@ def test_isin_random_data(elements_shape, test_elements_shape, invert, device):
     ttnn_isin_result = ttnn.experimental.isin(elements_ttnn, test_elements_ttnn, invert=invert)
 
     # Assert - Compare results
-    torch_result_from_ttnn = ttnn.to_torch(ttnn_isin_result)
+    torch_result_from_ttnn = ttnn.to_torch(ttnn_isin_result).to(torch.int32)
     assert torch_isin_result.shape == torch_result_from_ttnn.shape
     assert torch_isin_result.count_nonzero() == torch_result_from_ttnn.count_nonzero()
     assert torch.equal(torch_isin_result != 0, torch_result_from_ttnn != 0)
@@ -132,7 +132,7 @@ def test_isin_program_cache_and_random_data(
         ttnn_isin_result = ttnn.experimental.isin(elements_ttnn, test_elements_ttnn, invert=invert)
 
     # Assert - Compare results
-    torch_result_from_ttnn = ttnn.to_torch(ttnn_isin_result)
+    torch_result_from_ttnn = ttnn.to_torch(ttnn_isin_result).to(torch.int32)
     assert torch_isin_result.shape == torch_result_from_ttnn.shape
     assert torch_isin_result.count_nonzero() == torch_result_from_ttnn.count_nonzero()
     assert torch.equal(torch_isin_result != 0, torch_result_from_ttnn != 0)

--- a/tests/ttnn/unit_tests/operations/data_movement/test_embedding.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_embedding.py
@@ -13,7 +13,7 @@ def test_base_case(device):
     torch.manual_seed(1234)
     indices = ttnn.to_device(ttnn.from_torch(torch.tensor([[1, 2, 4, 5], [4, 3, 2, 9]]), dtype=ttnn.uint32), device)
     embedding_matrix = ttnn.to_device(ttnn.from_torch(torch.rand(10, 2), dtype=ttnn.bfloat16), device)
-    indices_torch = ttnn.to_torch(ttnn.from_device(indices))
+    indices_torch = ttnn.to_torch(ttnn.from_device(indices)).to(torch.long)
     embedding_matrix_torch = ttnn.to_torch(ttnn.from_device(embedding_matrix))
     expected_embeddings = torch.nn.functional.embedding(indices_torch, embedding_matrix_torch)
     embeddings = ttnn.embedding(indices, embedding_matrix)

--- a/tests/ttnn/unit_tests/operations/data_movement/test_pad.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_pad.py
@@ -50,7 +50,7 @@ def test_pad_rm(device, n, c, h, w, padding, torch_padding, value, dtype):
 
     input_tensor = ttnn.from_torch(torch_input_tensor, layout=ttnn.ROW_MAJOR_LAYOUT, device=device, dtype=dtype)
     output_tensor = ttnn.pad(input_tensor, padding=padding, value=value)
-    output_tensor = ttnn.to_torch(output_tensor)
+    output_tensor = ttnn.to_torch(output_tensor).to(torch_input_tensor.dtype)
 
     assert output_tensor.shape == torch_output_tensor.shape
     assert torch.equal(torch_output_tensor, output_tensor)
@@ -153,7 +153,7 @@ def run_pad_rm_sharded(device, n, c, h, w, padding, torch_padding, value, shard_
 
     tt_output_tensor = ttnn.to_memory_config(tt_output_tensor, ttnn.L1_MEMORY_CONFIG)
     tt_output_tensor = ttnn.from_device(tt_output_tensor)
-    tt_output_tensor = ttnn.to_torch(tt_output_tensor)
+    tt_output_tensor = ttnn.to_torch(tt_output_tensor).to(torch_output_tensor.dtype)
 
     assert tt_output_tensor.shape == torch_output_tensor.shape
     assert torch.equal(torch_output_tensor, tt_output_tensor)
@@ -479,7 +479,7 @@ def test_pad_op(device, in_dtype, shape, padshape, use_multicore, layout, mem_co
 
     ttnn_input = ttnn.from_torch(torch_input, device=device, memory_config=mem_config, dtype=in_dtype, layout=layout)
     output_tt = ttnn.pad(ttnn_input, padshape, [0, 0, 0, 0], value=0, use_multicore=use_multicore)
-    output_tt = ttnn.to_torch(output_tt)
+    output_tt = ttnn.to_torch(output_tt).to(torch_input.dtype)
     assert output_tt.shape == torch.Size(padshape)
 
     shape_diff = list(map(lambda x, y: x - y, padshape, shape))


### PR DESCRIPTION
### Ticket
Fixes failures from nightly CI run https://github.com/tenstorrent/tt-metal/actions/runs/22430389826

### Problem description
PR #36660 ("Support uint16 and uint32 in to_torch") changed `ttnn.to_torch()` to return proper unsigned PyTorch types (`torch.uint16`, `torch.uint32`) instead of silently converting to signed variants. That PR updated ~20 test files but missed several nightly tests since they weren't exercised by post-commit CI.

The three affected tests:
- **test_pad.py**: `random_torch_tensor` creates `torch.int16` references for `ttnn.uint16`. After #36660, `ttnn.to_torch()` returns `torch.uint16`, and `torch.equal()` fails with `RuntimeError: Promotion for uint16, uint32, uint64 types is not supported`.
- **test_embedding.py**: `ttnn.to_torch()` now returns `torch.uint32` for indices, but `torch.nn.functional.embedding` requires `Long` or `Int`, failing with `RuntimeError: Expected scalar type Long or Int but got CPUUInt32Type`.
- **test_isin.py**: `ttnn.to_torch()` returns `torch.uint32` for isin results, but `count_nonzero()` doesn't support `UInt32`, failing with `RuntimeError: "nonzero_count_cpu" not implemented for 'UInt32'`.

### What's changed
Cast the output of `ttnn.to_torch()` to an appropriate signed type before comparison/assertion in each test:
- **test_pad.py** (`test_pad_rm`, `run_pad_rm_sharded`, `test_pad_op`): cast to match the input tensor's dtype. Values are non-negative and in range, so the cast is lossless.
- **test_embedding.py** (`test_base_case`): cast indices to `torch.long`, the canonical index type for PyTorch.
- **test_isin.py** (`test_isin_typical_predefined_data`, `test_isin_random_data`, `test_isin_program_cache_and_random_data`): cast to `torch.int32`. Results are boolean-like (0 or 1), so the cast is lossless.

Supersedes #38705, #38706, #38707.

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=jbauman/fix-nightly-uint-dtype)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:jbauman/fix-nightly-uint-dtype)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=jbauman/fix-nightly-uint-dtype)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:jbauman/fix-nightly-uint-dtype)
- [x] New/Existing tests provide coverage for changes

Made with [Cursor](https://cursor.com)