### PR TITLE
Add model_configs.py file for blitz to track common settings

### DIFF
--- a/models/demos/deepseek_v3_b1/fused_ops/lm_head_sampling/op.py
+++ b/models/demos/deepseek_v3_b1/fused_ops/lm_head_sampling/op.py
@@ -255,9 +255,6 @@ class LMHeadSampling:
             int(ttnn.get_global_semaphore_address(global_stage2_semaphore)) if (enable_argmax and not skip_ccl) else 0
         )
 
-        # Calculate packet size and page info for CCL broadcast
-        packet_size_bytes = 14336  # 14 KB packets for (1, 7168) input
-
         # Get tile info from input tensor (use a sample device tensor)
         input_tensor_sample = input_tensors_per_device[0]
         in0_tile = input_tensor_sample.get_tile()
@@ -273,7 +270,6 @@ class LMHeadSampling:
         # CCL broadcast page info
         bcast_page_size_bytes = 32 * 32 * element_size  # interpret as 32x32 tile
         bcast_num_pages = input_shape[0] * input_shape[1] * element_size // bcast_page_size_bytes
-        num_pages_per_packet = packet_size_bytes // bcast_page_size_bytes
 
         # Matmul shape info from input and vocab tensors
         num_tiles_k = input_shape[1] // in0_tile.tile_shape[1]

--- a/models/demos/deepseek_v3_b1/fused_ops/moe/op.py
+++ b/models/demos/deepseek_v3_b1/fused_ops/moe/op.py
@@ -3728,7 +3728,7 @@ class MoeOp:
             reduce_offset += reduce_packet_size
 
             # CB 45: reduce_packet_header_cb (96 bytes)
-            reduce_packet_header_size = 96
+            reduce_packet_header_size = ttnn.get_tt_fabric_packet_header_size_bytes()
             reduce_cb_header_desc = ttnn.cb_descriptor_from_sharded_tensor(
                 routed_ctx.reduce_packet_header_cb,
                 out_buf,

--- a/models/demos/deepseek_v3_b1/fused_ops/moe_routed_expert/op.py
+++ b/models/demos/deepseek_v3_b1/fused_ops/moe_routed_expert/op.py
@@ -1245,7 +1245,7 @@ class MoeRoutedExpert:
             )
 
             reduce_payload_size_bytes = reduce_shard_elements * reduce_element_size
-            reduce_packet_header_size = 96
+            reduce_packet_header_size = ttnn.get_tt_fabric_packet_header_size_bytes()
             reduce_slot_size_bytes = reduce_packet_header_size + reduce_payload_size_bytes
 
             # Worker cores from final_output_tensor shard grid (same as gate_proj cores)
@@ -1950,7 +1950,7 @@ class MoeRoutedExpert:
                     device_cb_descriptors.append(reduce_cb_packet_desc)
 
                     # reduce_packet_header_cb (32): persistent packet header storage
-                    reduce_packet_header_size = 96  # Standard packet header size
+                    reduce_packet_header_size = ttnn.get_tt_fabric_packet_header_size_bytes()
                     reduce_cb_packet_header_desc = ttnn.CBDescriptor(
                         total_size=reduce_packet_header_size,
                         core_ranges=reduce_all_cores_set,

--- a/models/demos/deepseek_v3_b1/fused_ops/pre_sdpa/op.py
+++ b/models/demos/deepseek_v3_b1/fused_ops/pre_sdpa/op.py
@@ -261,9 +261,6 @@ class PreSDPA:
             barrier_sem_addr = ttnn.get_global_semaphore_address(barrier_semaphore)
             secondary_sync_sem_addr = ttnn.get_global_semaphore_address(secondary_sync_semaphore)
 
-        # Calculate packet size and page info for CCL broadcast
-        packet_size_bytes = 14336  # 14 KB packets for (1, 7168) input
-
         # Get tensor properties (use a sample device tensor)
         input_tensor_sample = input_tensors_per_device[0]
         input_shape = input_tensor_sample.shape
@@ -271,10 +268,8 @@ class PreSDPA:
 
         # CCL broadcast page info
         element_size = 2
-        tile_id_start = 0
         bcast_page_size_bytes = 32 * 32 * element_size  # interpret as 32x32 tile
         bcast_num_pages = input_shape[0] * input_shape[1] * element_size // bcast_page_size_bytes
-        num_pages_per_packet = packet_size_bytes // bcast_page_size_bytes
 
         # Interpret N 1x32 tiles as full 32x32 or 16x32 tiles
         # eg. [1, 7168] = 7 full 32x32 tiles

--- a/models/demos/deepseek_v3_b1/micro_ops/ccl_all_reduce/op.py
+++ b/models/demos/deepseek_v3_b1/micro_ops/ccl_all_reduce/op.py
@@ -143,7 +143,7 @@ class DeepseekMinimalAllReduce:
         compute_cb_temp = 7
 
         # Packet header size
-        packet_header_size_bytes = 32  # Size of one packet header
+        packet_header_size_bytes = ttnn.get_tt_fabric_packet_header_size_bytes()
 
         # Create mesh program descriptor
         mesh_program_descriptor = ttnn.MeshProgramDescriptor()

--- a/models/demos/deepseek_v3_b1/micro_ops/ccl_broadcast/op.py
+++ b/models/demos/deepseek_v3_b1/micro_ops/ccl_broadcast/op.py
@@ -81,9 +81,6 @@ class DeepseekMinimalBroadcast:
         barrier_sem_addr = ttnn.get_global_semaphore_address(barrier_semaphore)
         secondary_sync_sem_addr = ttnn.get_global_semaphore_address(secondary_sync_semaphore)
 
-        # Calculate packet size and page info
-        packet_size_bytes = 14336  # 14 KB packets for (1, 7168) input
-
         # Get tile info from input tensor
         input_tensor_sample = input_tensors_per_device[0]
         tile = input_tensor_sample.tile
@@ -97,7 +94,6 @@ class DeepseekMinimalBroadcast:
         shard_spec = input_tensor_sample.memory_config().shard_spec
         shard_width = shard_spec.shape[1]
         input_num_pages = shard_width // tile_width
-        num_pages_per_packet = packet_size_bytes // page_size_bytes
 
         # CB index
         src0_cb_index = 0

--- a/models/demos/deepseek_v3_b1/micro_ops/reduce_to_one_b1/op.py
+++ b/models/demos/deepseek_v3_b1/micro_ops/reduce_to_one_b1/op.py
@@ -376,7 +376,7 @@ class ReduceToOneB1:
             compute_tile_height * compute_tile_width
         )
 
-        packet_header_size_bytes = 96
+        packet_header_size_bytes = ttnn.get_tt_fabric_packet_header_size_bytes()
         slot_size_bytes = packet_header_size_bytes + payload_size_bytes
 
         # CB indices (matching C++ implementation)

--- a/models/demos/deepseek_v3_b1/model_configs.py
+++ b/models/demos/deepseek_v3_b1/model_configs.py
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import ttnn
+
+
+def create_fabric_router_config(max_payload_size):
+    """Helper to create FabricRouterConfig with custom max payload size."""
+    config = ttnn._ttnn.fabric.FabricRouterConfig()
+    config.max_packet_payload_size_bytes = max_payload_size
+    return config
+
+
+BLITZ_DEFAULT_FABRIC_ROUTER_CONFIG = create_fabric_router_config(15232)

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_broadcast_rms.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_broadcast_rms.py
@@ -11,12 +11,7 @@ from models.demos.deepseek_v3_b1.fused_ops.broadcast_rms.op import BroadcastRMSN
 from models.demos.deepseek_v3_b1.micro_ops.d2d_exchange.op import SocketInterface
 from models.demos.deepseek_v3_b1.micro_ops.host_io.op import HostInterface
 from models.demos.deepseek_v3_b1.micro_ops.host_io.utils import dtype_size
-
-
-def create_fabric_router_config(max_payload_size):
-    config = ttnn._ttnn.fabric.FabricRouterConfig()
-    config.max_packet_payload_size_bytes = max_payload_size
-    return config
+from models.demos.deepseek_v3_b1.model_configs import BLITZ_DEFAULT_FABRIC_ROUTER_CONFIG
 
 
 @pytest.mark.parametrize(
@@ -44,7 +39,7 @@ def create_fabric_router_config(max_payload_size):
     [
         {
             "fabric_config": ttnn.FabricConfig.FABRIC_2D,
-            "fabric_router_config": create_fabric_router_config(15232),
+            "fabric_router_config": BLITZ_DEFAULT_FABRIC_ROUTER_CONFIG,
             "trace_region_size": 573440,
         }
     ],

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_ccl_all_reduce.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_ccl_all_reduce.py
@@ -20,14 +20,8 @@ from tracy import signpost
 
 import ttnn
 from models.demos.deepseek_v3_b1.micro_ops.ccl_all_reduce.op import DeepseekMinimalAllReduce
+from models.demos.deepseek_v3_b1.model_configs import BLITZ_DEFAULT_FABRIC_ROUTER_CONFIG
 from models.perf.benchmarking_utils import BenchmarkProfiler
-
-
-def create_fabric_router_config(max_payload_size):
-    """Helper to create FabricRouterConfig with custom max payload size."""
-    config = ttnn._ttnn.fabric.FabricRouterConfig()
-    config.max_packet_payload_size_bytes = max_payload_size
-    return config
 
 
 @pytest.mark.parametrize(
@@ -51,7 +45,7 @@ def create_fabric_router_config(max_payload_size):
     [
         {
             "fabric_config": ttnn.FabricConfig.FABRIC_2D,
-            "fabric_router_config": create_fabric_router_config(15232),
+            "fabric_router_config": BLITZ_DEFAULT_FABRIC_ROUTER_CONFIG,
             "trace_region_size": 573440,
         }
     ],

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_ccl_broadcast.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_ccl_broadcast.py
@@ -18,14 +18,8 @@ from tracy import signpost
 
 import ttnn
 from models.demos.deepseek_v3_b1.micro_ops.ccl_broadcast.op import DeepseekMinimalBroadcast
+from models.demos.deepseek_v3_b1.model_configs import BLITZ_DEFAULT_FABRIC_ROUTER_CONFIG
 from models.perf.benchmarking_utils import BenchmarkProfiler
-
-
-def create_fabric_router_config(max_payload_size):
-    """Helper to create FabricRouterConfig with custom max payload size."""
-    config = ttnn._ttnn.fabric.FabricRouterConfig()
-    config.max_packet_payload_size_bytes = max_payload_size
-    return config
 
 
 @pytest.mark.parametrize(
@@ -53,7 +47,7 @@ def create_fabric_router_config(max_payload_size):
     [
         {
             "fabric_config": ttnn.FabricConfig.FABRIC_2D,
-            "fabric_router_config": create_fabric_router_config(15232),
+            "fabric_router_config": BLITZ_DEFAULT_FABRIC_ROUTER_CONFIG,
             "trace_region_size": 573440,
         }
     ],

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_host_io.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_host_io.py
@@ -15,13 +15,7 @@ from models.common.utility_functions import is_slow_dispatch
 from models.demos.deepseek_v3_b1.micro_ops.d2d_exchange.op import SocketInterface
 from models.demos.deepseek_v3_b1.micro_ops.host_io.op import HostInterface
 from models.demos.deepseek_v3_b1.micro_ops.host_io.utils import dtype_size, ttnn_dtype_from_torch_dtype
-
-
-def create_fabric_router_config(max_payload_size):
-    """Helper to create FabricRouterConfig with custom max payload size."""
-    config = ttnn._ttnn.fabric.FabricRouterConfig()
-    config.max_packet_payload_size_bytes = max_payload_size
-    return config
+from models.demos.deepseek_v3_b1.model_configs import create_fabric_router_config
 
 
 @pytest.mark.parametrize(

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_lm_head_sampling.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_lm_head_sampling.py
@@ -26,13 +26,8 @@ from models.common.utility_functions import is_slow_dispatch
 from models.demos.deepseek_v3_b1.fused_ops.lm_head_sampling.op import LMHeadSampling
 from models.demos.deepseek_v3_b1.micro_ops.d2d_exchange.op import SocketInterface
 from models.demos.deepseek_v3_b1.micro_ops.host_io.op import HostInterface
+from models.demos.deepseek_v3_b1.model_configs import BLITZ_DEFAULT_FABRIC_ROUTER_CONFIG
 from models.perf.benchmarking_utils import BenchmarkProfiler
-
-
-def create_fabric_router_config(max_payload_size):
-    config = ttnn._ttnn.fabric.FabricRouterConfig()
-    config.max_packet_payload_size_bytes = max_payload_size
-    return config
 
 
 def _is_lm_head_sampling_perf_enabled():
@@ -49,7 +44,7 @@ def _is_lm_head_sampling_perf_enabled():
     [
         {
             "fabric_config": ttnn.FabricConfig.FABRIC_2D,
-            "fabric_router_config": create_fabric_router_config(15232),
+            "fabric_router_config": BLITZ_DEFAULT_FABRIC_ROUTER_CONFIG,
             "trace_region_size": 1163264,
         }
     ],
@@ -344,7 +339,7 @@ def test_lm_head_sampling_fused_argmax_mesh_4x2_axis_x_perf(
     [
         {
             "fabric_config": ttnn.FabricConfig.FABRIC_2D,
-            "fabric_router_config": create_fabric_router_config(15232),
+            "fabric_router_config": BLITZ_DEFAULT_FABRIC_ROUTER_CONFIG,
             "trace_region_size": 573440,
         }
     ],
@@ -507,7 +502,7 @@ def test_lm_head_sampling_fused_argmax_single_device(
     [
         {
             "fabric_config": ttnn.FabricConfig.FABRIC_2D,
-            "fabric_router_config": create_fabric_router_config(15232),
+            "fabric_router_config": BLITZ_DEFAULT_FABRIC_ROUTER_CONFIG,
             "trace_region_size": 573440,
         }
     ],
@@ -691,7 +686,7 @@ def test_lm_head_sampling_fused_argmax_single_device_d2h(
     [
         {
             "fabric_config": ttnn.FabricConfig.FABRIC_2D,
-            "fabric_router_config": create_fabric_router_config(15232),
+            "fabric_router_config": BLITZ_DEFAULT_FABRIC_ROUTER_CONFIG,
             "trace_region_size": 573440,
         }
     ],
@@ -914,7 +909,7 @@ def test_lm_head_sampling_fused_argmax_mesh_4x2_axis_x(
     [
         {
             "fabric_config": ttnn.FabricConfig.FABRIC_2D,
-            "fabric_router_config": create_fabric_router_config(15232),
+            "fabric_router_config": BLITZ_DEFAULT_FABRIC_ROUTER_CONFIG,
             "trace_region_size": 573440,
         }
     ],
@@ -1156,7 +1151,7 @@ def test_lm_head_sampling_fused_argmax_mesh_4x2_axis_x_d2h(
     [
         {
             "fabric_config": ttnn.FabricConfig.FABRIC_2D,
-            "fabric_router_config": create_fabric_router_config(15232),
+            "fabric_router_config": BLITZ_DEFAULT_FABRIC_ROUTER_CONFIG,
             "trace_region_size": 573440,
         }
     ],

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_moe_mlp.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_moe_mlp.py
@@ -22,6 +22,7 @@ from models.demos.deepseek_v3_b1.blitz_decode_weights import BlitzDecodeWeights
 from models.demos.deepseek_v3_b1.fused_ops.down_proj.op import DownProj
 from models.demos.deepseek_v3_b1.fused_ops.moe.op import MoeOp
 from models.demos.deepseek_v3_b1.fused_ops.shared_expert.op import SharedExpertOp
+from models.demos.deepseek_v3_b1.model_configs import BLITZ_DEFAULT_FABRIC_ROUTER_CONFIG
 
 
 # ============================================================================
@@ -556,7 +557,14 @@ def test_moe_fused(device, use_hardcoded_expert_index, reconfig_moe_cbs):
 @skip_for_wormhole_b0("This test is for blackhole")
 @pytest.mark.parametrize(
     "device_params",
-    [({"fabric_config": ttnn.FabricConfig.FABRIC_2D})],
+    [
+        (
+            {
+                "fabric_config": ttnn.FabricConfig.FABRIC_2D,
+                "fabric_router_config": BLITZ_DEFAULT_FABRIC_ROUTER_CONFIG,
+            }
+        )
+    ],
     indirect=["device_params"],
     ids=["fabric_2d"],
 )
@@ -925,7 +933,14 @@ def test_mlp(device, reconfig_moe_cbs):
 @skip_for_wormhole_b0("This test is for blackhole")
 @pytest.mark.parametrize(
     "device_params",
-    [({"fabric_config": ttnn.FabricConfig.FABRIC_2D})],
+    [
+        (
+            {
+                "fabric_config": ttnn.FabricConfig.FABRIC_2D,
+                "fabric_router_config": BLITZ_DEFAULT_FABRIC_ROUTER_CONFIG,
+            }
+        )
+    ],
     indirect=["device_params"],
     ids=["fabric_2d"],
 )

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_moe_routed_expert.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_moe_routed_expert.py
@@ -24,6 +24,7 @@ import ttnn
 from models.common.utility_functions import comp_pcc, skip_for_wormhole_b0
 from models.demos.deepseek_v3_b1.blitz_decode_weights import BlitzDecodeWeights
 from models.demos.deepseek_v3_b1.fused_ops.moe_routed_expert.op import MoeRoutedExpert
+from models.demos.deepseek_v3_b1.model_configs import BLITZ_DEFAULT_FABRIC_ROUTER_CONFIG
 
 
 @pytest.mark.parametrize("use_hardcoded_expert_index", [True, pytest.param(False, marks=pytest.mark.skip_post_commit)])
@@ -565,7 +566,15 @@ def test_moe_routed_expert(device, use_hardcoded_expert_index):
 @skip_for_wormhole_b0("This test is for blackhole")
 @pytest.mark.parametrize(
     "device_params",
-    [({"fabric_config": ttnn.FabricConfig.FABRIC_2D, "trace_region_size": 573440})],
+    [
+        (
+            {
+                "fabric_config": ttnn.FabricConfig.FABRIC_2D,
+                "trace_region_size": 573440,
+                "fabric_router_config": BLITZ_DEFAULT_FABRIC_ROUTER_CONFIG,
+            }
+        )
+    ],
     indirect=["device_params"],
     ids=["fabric_2d"],
 )

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_post_sdpa.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_post_sdpa.py
@@ -42,13 +42,7 @@ from models.common.utility_functions import comp_pcc
 from models.demos.deepseek_v3_b1.fused_ops.post_sdpa.op import PostSDPA
 from models.demos.deepseek_v3_b1.micro_ops.flash_mla.op import FlashMLADecode
 from models.demos.deepseek_v3_b1.micro_ops.sdpa_reduce_to_all.op import SdpaReduceToAll
-
-
-def create_fabric_router_config(max_payload_size):
-    """Helper to create FabricRouterConfig with custom max payload size."""
-    config = ttnn._ttnn.fabric.FabricRouterConfig()
-    config.max_packet_payload_size_bytes = max_payload_size
-    return config
+from models.demos.deepseek_v3_b1.model_configs import BLITZ_DEFAULT_FABRIC_ROUTER_CONFIG
 
 
 def _round_up(value: int, alignment: int) -> int:
@@ -106,7 +100,7 @@ def compute_forwarder_scratch_size(
     [
         {
             "fabric_config": ttnn.FabricConfig.FABRIC_2D_TORUS_X,
-            "fabric_router_config": create_fabric_router_config(15232),
+            "fabric_router_config": BLITZ_DEFAULT_FABRIC_ROUTER_CONFIG,
         }
     ],
     indirect=True,
@@ -584,7 +578,7 @@ def test_post_sdpa(
     [
         {
             "fabric_config": ttnn.FabricConfig.FABRIC_2D_TORUS_X,
-            "fabric_router_config": create_fabric_router_config(15232),
+            "fabric_router_config": BLITZ_DEFAULT_FABRIC_ROUTER_CONFIG,
         }
     ],
     indirect=True,

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_pre_sdpa.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_pre_sdpa.py
@@ -20,12 +20,7 @@ from models.demos.deepseek_v3.tt.rope import get_rot_transformation_mat
 from models.demos.deepseek_v3_b1.blitz_decode_weights import BlitzDecodeWeights
 from models.demos.deepseek_v3_b1.fused_ops.pre_sdpa.op import PreSDPA
 from models.demos.deepseek_v3_b1.micro_ops.flash_mla.op import FlashMLADecode
-
-
-def create_fabric_router_config(max_payload_size):
-    config = ttnn._ttnn.fabric.FabricRouterConfig()
-    config.max_packet_payload_size_bytes = max_payload_size
-    return config
+from models.demos.deepseek_v3_b1.model_configs import BLITZ_DEFAULT_FABRIC_ROUTER_CONFIG
 
 
 @pytest.mark.parametrize(
@@ -48,7 +43,7 @@ def create_fabric_router_config(max_payload_size):
     [
         {
             "fabric_config": ttnn.FabricConfig.FABRIC_2D,
-            "fabric_router_config": create_fabric_router_config(15232),
+            "fabric_router_config": BLITZ_DEFAULT_FABRIC_ROUTER_CONFIG,
             "trace_region_size": 573440,
         }
     ],

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_reduce_to_one_b1.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_reduce_to_one_b1.py
@@ -16,14 +16,8 @@ from tracy import signpost
 import ttnn
 from models.common.utility_functions import skip_for_wormhole_b0
 from models.demos.deepseek_v3_b1.micro_ops.reduce_to_one_b1.op import ReduceToOneB1
+from models.demos.deepseek_v3_b1.model_configs import BLITZ_DEFAULT_FABRIC_ROUTER_CONFIG
 from models.perf.benchmarking_utils import BenchmarkProfiler
-
-
-def create_fabric_router_config(max_payload_size):
-    """Helper to create FabricRouterConfig with custom max payload size."""
-    config = ttnn._ttnn.fabric.FabricRouterConfig()
-    config.max_packet_payload_size_bytes = max_payload_size
-    return config
 
 
 def setup_reduce_to_one_test(mesh_device):
@@ -329,7 +323,14 @@ def run_reduce_to_one_with_trace(mesh_device):
 @skip_for_wormhole_b0("This test is for blackhole")
 @pytest.mark.parametrize(
     "device_params",
-    [({"fabric_config": ttnn.FabricConfig.FABRIC_1D, "fabric_router_config": create_fabric_router_config(15232)})],
+    [
+        (
+            {
+                "fabric_config": ttnn.FabricConfig.FABRIC_1D,
+                "fabric_router_config": BLITZ_DEFAULT_FABRIC_ROUTER_CONFIG,
+            }
+        )
+    ],
     indirect=["device_params"],
     ids=["fabric_1d"],
 )
@@ -341,7 +342,14 @@ def test_reduce_to_one_1d(bh_2d_mesh_device):
 @skip_for_wormhole_b0("This test is for blackhole")
 @pytest.mark.parametrize(
     "device_params",
-    [({"fabric_config": ttnn.FabricConfig.FABRIC_2D, "fabric_router_config": create_fabric_router_config(15232)})],
+    [
+        (
+            {
+                "fabric_config": ttnn.FabricConfig.FABRIC_2D,
+                "fabric_router_config": BLITZ_DEFAULT_FABRIC_ROUTER_CONFIG,
+            }
+        )
+    ],
     indirect=["device_params"],
     ids=["fabric_2d"],
 )
@@ -358,8 +366,8 @@ def test_reduce_to_one_2d(bh_2d_mesh_device):
         (
             {
                 "fabric_config": ttnn.FabricConfig.FABRIC_1D,
+                "fabric_router_config": BLITZ_DEFAULT_FABRIC_ROUTER_CONFIG,
                 "trace_region_size": 425984,
-                "fabric_router_config": create_fabric_router_config(15232),
             }
         )
     ],
@@ -378,8 +386,8 @@ def test_reduce_to_one_with_trace_1d(bh_2d_mesh_device):
         (
             {
                 "fabric_config": ttnn.FabricConfig.FABRIC_2D,
+                "fabric_router_config": BLITZ_DEFAULT_FABRIC_ROUTER_CONFIG,
                 "trace_region_size": 425984,
-                "fabric_router_config": create_fabric_router_config(15232),
             }
         )
     ],

--- a/models/demos/deepseek_v3_b1/unified_kernels/broadcast.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/broadcast.hpp
@@ -258,11 +258,9 @@ struct Broadcast {
                     // between iterations will naturally sync the devices, but wait_min is a
                     // pragmatic choice to streamline standalone testing.
                     if (args.wait_output_semaphore) {
-                        WATCHER_RING_BUFFER_PUSH(0xA1);
                         volatile tt_l1_ptr uint32_t* sem_ptr =
                             reinterpret_cast<volatile tt_l1_ptr uint32_t*>(args.out_ready_sem_bank_addr);
                         noc_semaphore_wait_min(sem_ptr, args.out_ready_sem_wait_value);
-                        WATCHER_RING_BUFFER_PUSH(0xA2);
                     }
 
                     // 4. global semaphore reset
@@ -277,11 +275,9 @@ struct Broadcast {
                     // Secondary sender: wait for data from primary sender, then broadcast along primary axis
                     // First wait for data to arrive from primary sender
                     if (args.wait_output_semaphore) {
-                        WATCHER_RING_BUFFER_PUSH(0xB1);
                         volatile tt_l1_ptr uint32_t* sem_ptr =
                             reinterpret_cast<volatile tt_l1_ptr uint32_t*>(args.out_ready_sem_bank_addr);
                         noc_semaphore_wait_min(sem_ptr, args.out_ready_sem_wait_value);
-                        WATCHER_RING_BUFFER_PUSH(0xB2);
                     }
 
                     // Reset semaphore after receiving data
@@ -312,11 +308,9 @@ struct Broadcast {
                 } else {
                     // Receiver: wait for data from broadcaster
                     if (args.wait_output_semaphore) {
-                        WATCHER_RING_BUFFER_PUSH(0xC1);
                         volatile tt_l1_ptr uint32_t* sem_ptr =
                             reinterpret_cast<volatile tt_l1_ptr uint32_t*>(args.out_ready_sem_bank_addr);
                         noc_semaphore_wait_min(sem_ptr, args.out_ready_sem_wait_value);
-                        WATCHER_RING_BUFFER_PUSH(0xC2);
                     }
 
                     // Reset global semaphore


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
We are hardcoding different packet header sizes and max packet sizes across different ops/tests.

### What's changed
Update hardcoded packet headers to ttnn.get_tt_fabric_packet_header_size_bytes().
Update 

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:{{branch_name}})
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:{{branch_name}})
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:{{branch_name}})
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:{{branch_name}})
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:{{branch_name}})
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch={{branch_name}})](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:{{branch_name}})
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
