### PR TITLE
Fix teardown of partial distributed submesh

### DIFF
--- a/tests/tt_metal/distributed/multiprocess/test_sanity.cpp
+++ b/tests/tt_metal/distributed/multiprocess/test_sanity.cpp
@@ -233,4 +233,14 @@ TEST_F(BigMeshDualRankTest2x4, SubmeshCreationMultipleSubmeshes) {
     }
 }
 
+TEST(UnitMeshesDualRankTest2x4, UnitMeshesCreation) {
+    auto device_ids_set = tt::tt_metal::MetalContext::instance().get_cluster().user_exposed_chip_ids();
+    std::vector<int> device_ids(device_ids_set.begin(), device_ids_set.end());
+    auto devs = tt::tt_metal::distributed::MeshDevice::create_unit_meshes(device_ids);
+    for (auto& [_, dev] : devs) {
+        ASSERT_NE(dev, nullptr);
+        EXPECT_EQ(dev->shape(), MeshShape(1, 1));
+    }
+}
+
 }  // namespace tt::tt_metal::distributed

--- a/tt_metal/distributed/mesh_device.cpp
+++ b/tt_metal/distributed/mesh_device.cpp
@@ -192,6 +192,9 @@ const std::map<ChipId, IDevice*>& MeshDeviceImpl::ScopedDevices::opened_local_de
 const std::vector<MaybeRemote<IDevice*>>& MeshDeviceImpl::ScopedDevices::root_devices() const { return devices_; }
 
 uint8_t MeshDeviceImpl::num_hw_cqs() const {
+    if (view_->get_devices().empty()) {
+        return 0;
+    }
     return validate_and_get_reference_value(
         this->get_devices(), [](const auto* device) { return device->num_hw_cqs(); });
 }
@@ -204,6 +207,10 @@ bool MeshDeviceImpl::is_initialized() const {
     }
     if (!scoped_devices_) {
         return false;
+    }
+    // Has to report as initialized so that teardown runs for inactive mesh devices.
+    if (view_->get_devices().empty()) {
+        return true;
     }
     return validate_and_get_reference_value(
         this->get_devices(), [](const auto* device) { return device->is_initialized(); });
@@ -239,9 +246,10 @@ MeshDeviceImpl::MeshDeviceImpl(
     reader_thread_pool_(create_default_thread_pool(extract_locals(scoped_devices_->root_devices()))),
     program_cache_(std::make_unique<program_cache::detail::ProgramCache>()) {
     Inspector::mesh_device_created(this, parent_mesh_ ? std::make_optional(parent_mesh_->id()) : std::nullopt);
-    const auto& mpi_context = MetalContext::instance().global_distributed_context();
+    const auto& mpi_context =
+        tt::tt_metal::MetalContext::instance().get_control_plane().get_distributed_context(view_->mesh_id());
     distributed_context_ =
-        mpi_context.split(distributed::multihost::Color(id()), distributed::multihost::Key(*mpi_context.rank()));
+        mpi_context->split(distributed::multihost::Color(id()), distributed::multihost::Key(*mpi_context->rank()));
 }
 
 std::shared_ptr<MeshDevice> MeshDevice::create(
@@ -1163,7 +1171,9 @@ bool MeshDeviceImpl::initialize_impl(
             distributed::multihost::Color(1), distributed::multihost::Key(*distributed_context_->rank()));
         mesh_command_queues_.push_back(
             std::make_unique<DummyMeshCommandQueue>(pimpl_wrapper, 0, std::bind(&MeshDeviceImpl::lock_api, this)));
-        return false;
+        Inspector::mesh_device_initialized(this);
+        is_internal_state_initialized = true;
+        return true;
     }
 
     active_distributed_context_ = distributed_context_->split(


### PR DESCRIPTION
### Problem description
In cases where a (sub)mesh spans only part of a distributed system, MeshDevices are created on each rank to represent it. Currently the MeshDevice instances which hold no physical resources (are "inactive") report their internal state as not initialized. This causes issues with teardown.

### What's changed
So modify the MeshDevice class such that "inactive" instances are treated as initialized, and participate in teardown as expected (barriers in MeshDevice::close match accross active and inactive instances). Also, make sure the MeshDevice distributed context is derived from the mesh specific distributed context, rather than the global one.
