### PR TITLE
[skip ci] #38306: add a note about a hardware bug in WH for matmul

### DIFF
--- a/ttnn/cpp/ttnn/operations/matmul/matmul_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/matmul_nanobind.cpp
@@ -654,6 +654,8 @@ void py_module(nb::module_& mod) {
           compute_kernel_config, output values can rarely be off by a negative power of two (e.g. -128).
           This bug happens most frequently at HiFi4, and in decreasing frequency as math fidelity is reduced (e.g. HiFi3, HiFi2, LoFi).
           This bug can happen when the original mantissa contains all 1.
+          If affected, consider either disabling fp32_acc_to_dest, if that does not impact numerical stability
+          in your use case, or decreasing fidelity.
 
         Args:
             input_tensor_a (ttnn.Tensor): the first tensor to be multiplied. Needs to be on the device.

--- a/ttnn/cpp/ttnn/operations/matmul/matmul_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/matmul_nanobind.cpp
@@ -650,6 +650,10 @@ void py_module(nb::module_& mod) {
         - Note: If optional output tensor is specified, then dtype and memory config need to be checked as follows:
           - if they are default then they should be set based on optional output tensor
           - if the are not default then they should be compared and if there is a difference an error is reported
+        - Note: Due to a hardware bug on Wormhole (fixed on Blackhole), when fp32_acc_to_dest is enabled in the
+          compute_kernel_config, output values can rarely be off by a negative power of two (e.g. -128).
+          This bug happens most frequently at HiFi4, and in decreasing frequency as math fidelity is reduced (e.g. HiFi3, HiFi2, LoFi).
+          This bug can happen when the original mantissa contains all 1.
 
         Args:
             input_tensor_a (ttnn.Tensor): the first tensor to be multiplied. Needs to be on the device.


### PR DESCRIPTION
### Ticket
Link to Github Issue #38306

### Problem description
WH has a HW bug that manifests when fp32 acc is enabled for matmul.

### What's changed
Add a note about the bug, when it occurs, and what can be done to mitigate it.

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=bbradel-38306_fp32note)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:bbradel-38306_fp32note)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=bbradel-38306_fp32note)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:bbradel-38306_fp32note)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=bbradel-38306_fp32note)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:bbradel-38306_fp32note)
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=bbradel-38306_fp32note)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:bbradel-38306_fp32note)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=bbradel-38306_fp32note)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:bbradel-38306_fp32note)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=bbradel-38306_fp32note)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:bbradel-38306_fp32note)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
