### PR TITLE
[tt-train] Replace `ttnn::SmallVector` with `ttsl::SmallVector` and enable deprecation warnings

### DIFF
--- a/tt-train/sources/ttml/CMakeLists.txt
+++ b/tt-train/sources/ttml/CMakeLists.txt
@@ -291,6 +291,15 @@ endforeach()
 # Define FLATBUFFERS_LARGE_SIZE to use uint64_t for size calculations (must be defined before any flatbuffers headers)
 target_compile_definitions(ttml PUBLIC FLATBUFFERS_LARGE_SIZE)
 
+# Re-enable deprecation warnings for this target (overrides parent -Wno-deprecated-declarations when built as subproject).
+# Deprecations are warnings only so the build does not fail on deprecated usage in included dependencies.
+target_compile_options(
+    ttml
+    PRIVATE
+        -Wdeprecated-declarations
+        -Wno-error=deprecated-declarations
+)
+
 target_link_libraries(
     ttml
     PUBLIC

--- a/tt-train/sources/ttml/metal/ops/layernorm_bw/layernorm_bw.cpp
+++ b/tt-train/sources/ttml/metal/ops/layernorm_bw/layernorm_bw.cpp
@@ -31,7 +31,7 @@ std::vector<std::optional<ttnn::Tensor>> layernorm_bw(
                     ttnn::Shape(
                         {tensor.logical_shape()[0] * tensor.logical_shape()[1] * tensor.logical_shape()[2],
                          tensor.logical_shape()[3]})),  // dgamma_components
-                /* dim_arg */ ttnn::SmallVector<int>{0},
+                /* dim_arg */ ttsl::SmallVector<int>{0},
                 /* keep_dim */ true,
                 /* output_mem_config */ std::nullopt,
                 /*compute_kernel_config */ core::ComputeKernelConfig::precise()),

--- a/tt-train/sources/ttml/metal/ops/rmsnorm_bw/rmsnorm_bw.cpp
+++ b/tt-train/sources/ttml/metal/ops/rmsnorm_bw/rmsnorm_bw.cpp
@@ -27,7 +27,7 @@ std::vector<std::optional<ttnn::Tensor>> rmsnorm_bw(
         result[0],
         ttnn::sum(
             result[1],
-            /* dim_arg */ ttnn::SmallVector<int>{0, 1, 2},
+            /* dim_arg */ ttsl::SmallVector<int>{0, 1, 2},
             /* keep_dim */ true,
             /* output_mem_config */ std::nullopt,
             /*compute_kernel_config */ core::ComputeKernelConfig::precise())  // [B,1,S,C] -> [1,1,1,C]

--- a/tt-train/sources/ttml/models/common/transformer_common.cpp
+++ b/tt-train/sources/ttml/models/common/transformer_common.cpp
@@ -127,15 +127,15 @@ const uint32_t KvCache::update_prefill(
         new_tokens <= key_tensor.logical_shape()[-2], "New tokens must be less than or equal to the sequence length");
     const auto cache_shape = k_cache.logical_shape();
 
-    const ttnn::SmallVector<uint32_t> step = {1, 1, 1, 1};
-    const ttnn::SmallVector<uint32_t> token_start = {0, 0, 0, 0};
-    const ttnn::SmallVector<uint32_t> kv_end = {kv_shape[0], kv_shape[1], new_tokens, kv_shape[3]};
+    const ttsl::SmallVector<uint32_t> step = {1, 1, 1, 1};
+    const ttsl::SmallVector<uint32_t> token_start = {0, 0, 0, 0};
+    const ttsl::SmallVector<uint32_t> kv_end = {kv_shape[0], kv_shape[1], new_tokens, kv_shape[3]};
 
     const tt::tt_metal::Tensor& new_key = ttnn::slice(key_tensor, token_start, kv_end, step);
     const tt::tt_metal::Tensor& new_value = ttnn::slice(value_tensor, token_start, kv_end, step);
 
-    const ttnn::SmallVector<uint32_t> cache_start = {0, 0, 0, 0};
-    const ttnn::SmallVector<uint32_t> cache_end = {cache_shape[0], cache_shape[1], new_tokens, cache_shape[3]};
+    const ttsl::SmallVector<uint32_t> cache_start = {0, 0, 0, 0};
+    const ttsl::SmallVector<uint32_t> cache_end = {cache_shape[0], cache_shape[1], new_tokens, cache_shape[3]};
 
     ttnn::experimental::slice_write(new_key, k_cache, cache_start, cache_end, step);
     ttnn::experimental::slice_write(new_value, v_cache, cache_start, cache_end, step);
@@ -154,15 +154,15 @@ const uint32_t KvCache::update_decode(
     const auto kv_shape = key_tensor.logical_shape();
     TT_FATAL(new_tokens <= kv_shape[-2], "New tokens must be less than or equal to the sequence length");
 
-    const ttnn::SmallVector<uint32_t> step = {1, 1, 1, 1};
-    const ttnn::SmallVector<uint32_t> token_start = {0, 0, 0, 0};
-    const ttnn::SmallVector<uint32_t> kv_end = {kv_shape[0], kv_shape[1], new_tokens, kv_shape[3]};
+    const ttsl::SmallVector<uint32_t> step = {1, 1, 1, 1};
+    const ttsl::SmallVector<uint32_t> token_start = {0, 0, 0, 0};
+    const ttsl::SmallVector<uint32_t> kv_end = {kv_shape[0], kv_shape[1], new_tokens, kv_shape[3]};
 
     const tt::tt_metal::Tensor& new_key = ttnn::slice(key_tensor, token_start, kv_end, step);
     const tt::tt_metal::Tensor& new_value = ttnn::slice(value_tensor, token_start, kv_end, step);
 
-    const ttnn::SmallVector<uint32_t> cache_start = {0, 0, cache_position, 0};
-    const ttnn::SmallVector<uint32_t> cache_end = {
+    const ttsl::SmallVector<uint32_t> cache_start = {0, 0, cache_position, 0};
+    const ttsl::SmallVector<uint32_t> cache_end = {
         cache_shape[0], cache_shape[1], cache_position + new_tokens, cache_shape[3]};
 
     ttnn::experimental::slice_write(new_key, k_cache, cache_start, cache_end, step);

--- a/tt-train/sources/ttml/models/llama.cpp
+++ b/tt-train/sources/ttml/models/llama.cpp
@@ -194,7 +194,7 @@ ttml::autograd::TensorPtr Llama::operator()(
     if (padded_seq_len != actual_seq_len) {
         // Pad the sequence dimension (last dimension) with zeros
         // Create a new tensor instead of modifying in-place
-        ttnn::SmallVector<ttnn::operations::data_movement::PadSpecDim> padding = {
+        ttsl::SmallVector<ttnn::operations::data_movement::PadSpecDim> padding = {
             {0, 0},                               // batch dimension
             {0, 0},                               // first spatial dimension
             {0, 0},                               // second spatial dimension
@@ -211,13 +211,13 @@ ttml::autograd::TensorPtr Llama::operator()(
     if (padded_seq_len != actual_seq_len) {
         // Slice back to original sequence length (sequence dimension is now at index 2)
         // Create a new tensor instead of modifying in-place
-        ttnn::SmallVector<uint32_t> slice_start = {0, 0, 0, 0};
-        ttnn::SmallVector<uint32_t> slice_end = {
+        ttsl::SmallVector<uint32_t> slice_start = {0, 0, 0, 0};
+        ttsl::SmallVector<uint32_t> slice_end = {
             tok_emb_out->get_value().logical_shape()[0],
             tok_emb_out->get_value().logical_shape()[1],
             actual_seq_len,
             tok_emb_out->get_value().logical_shape()[3]};
-        ttnn::SmallVector<uint32_t> step = {1, 1, 1, 1};
+        ttsl::SmallVector<uint32_t> step = {1, 1, 1, 1};
         auto out_tensor = ttnn::slice(tok_emb_out->get_value(), slice_start, slice_end, step);
         out = autograd::create_tensor(out_tensor);
     }

--- a/tt-train/sources/ttml/modules/grouped_query_attention.cpp
+++ b/tt-train/sources/ttml/modules/grouped_query_attention.cpp
@@ -86,12 +86,12 @@ ttml::autograd::TensorPtr GroupedQueryAttention::operator()(
     const auto& k_cache = kv_cache->get_k_cache(layer_idx);
     const auto& v_cache = kv_cache->get_v_cache(layer_idx);
 
-    const ttnn::SmallVector<uint32_t> step = {1, 1, 1, 1};
-    const ttnn::SmallVector<uint32_t> token_start = {0, 0, 0, 0};
+    const ttsl::SmallVector<uint32_t> step = {1, 1, 1, 1};
+    const ttsl::SmallVector<uint32_t> token_start = {0, 0, 0, 0};
     const auto cache_shape = k_cache.logical_shape();
     // Use mask's key sequence length (last dimension) which is padded_whole_len
     // This matches the key sequence length expected by the attention operation
-    const ttnn::SmallVector<uint32_t> token_end = {
+    const ttsl::SmallVector<uint32_t> token_end = {
         cache_shape[0], cache_shape[1], mask->get_value().logical_shape()[-1], cache_shape[3]};
 
     const tt::tt_metal::Tensor& k_cache_slice = ttnn::slice(k_cache, token_start, token_end, step);

--- a/tt-train/sources/ttml/ops/binary_ops.cpp
+++ b/tt-train/sources/ttml/ops/binary_ops.cpp
@@ -41,8 +41,8 @@ bool was_broadcasted(const autograd::TensorPtr& input, const ttnn::Tensor& grad)
     return false;
 }
 
-ttnn::SmallVector<int64_t> get_broadcast_dimensions(const autograd::TensorPtr& input, const ttnn::Tensor& grad) {
-    ttnn::SmallVector<int64_t> broadcast_dims;
+ttsl::SmallVector<int64_t> get_broadcast_dimensions(const autograd::TensorPtr& input, const ttnn::Tensor& grad) {
+    ttsl::SmallVector<int64_t> broadcast_dims;
     auto input_shape = input->get_value().logical_shape();
     auto grad_shape = grad.logical_shape();
     for (size_t i = 0; i < input_shape.size(); ++i) {

--- a/tt-train/sources/ttml/ops/layernorm_op.cpp
+++ b/tt-train/sources/ttml/ops/layernorm_op.cpp
@@ -154,7 +154,7 @@ autograd::TensorPtr composite_layernorm(
 
         auto dgamma = ttnn::moreh_sum(
             ttnn::multiply(dout, normalized_tensor),
-            /* dim */ ttnn::SmallVector<int64_t>{0, 1, 2},
+            /* dim */ ttsl::SmallVector<int64_t>{0, 1, 2},
             /* keep_dim */ true,
             /* output */ std::nullopt,
             /* output_mem_config */ std::nullopt,
@@ -200,7 +200,7 @@ autograd::TensorPtr composite_layernorm(
         if (beta_opt.has_value()) {
             auto dbeta = ttnn::moreh_sum(
                 dout,
-                /* dim */ ttnn::SmallVector<int64_t>{0, 1, 2},
+                /* dim */ ttsl::SmallVector<int64_t>{0, 1, 2},
                 /* keep_dim */ true,
                 /* output */ std::nullopt,
                 /* output_mem_config */ std::nullopt,

--- a/tt-train/sources/ttml/ops/reshape_op.cpp
+++ b/tt-train/sources/ttml/ops/reshape_op.cpp
@@ -17,7 +17,7 @@ autograd::TensorPtr reshape(const autograd::TensorPtr& tensor, std::span<uint32_
 
     // Convert span to SmallVector for ttnn::Shape construction
     // ttnn::Shape expects SmallVector<uint32_t> (which is the Container type)
-    ttnn::SmallVector<uint32_t> shape_vec(shape.begin(), shape.end());
+    ttsl::SmallVector<uint32_t> shape_vec(shape.begin(), shape.end());
 
     // Construct ttnn::Shape from SmallVector
     ttnn::Shape ttnn_shape(shape_vec);

--- a/tt-train/sources/ttml/ops/rmsnorm_op.cpp
+++ b/tt-train/sources/ttml/ops/rmsnorm_op.cpp
@@ -224,7 +224,7 @@ autograd::TensorPtr rmsnorm_composite(
             false);  // [B,1,S,C] x [B,1,S,1] -> [B,1,S,C] (bcast); checked by add_grad
         auto dL_dg = ttnn::sum(
             dL_dg_components,
-            /* dim_arg */ ttnn::SmallVector<int>{0, 1, 2},
+            /* dim_arg */ ttsl::SmallVector<int>{0, 1, 2},
             /* keep_dim */ true,
             /* output_mem_config */ std::nullopt,
             /*compute_kernel_config */ core::ComputeKernelConfig::precise());  // [B,1,S,C] -> [1,1,1,C]

--- a/tt-train/sources/ttml/ops/rope_op.cpp
+++ b/tt-train/sources/ttml/ops/rope_op.cpp
@@ -135,9 +135,9 @@ autograd::TensorPtr rope(
 
     if (token_position > 0U) {
         auto pos = token_position;
-        ttnn::SmallVector<uint32_t> start = {0, 0, pos, 0};
-        ttnn::SmallVector<uint32_t> end = {1, 1, pos + seq_len, head_dim};
-        ttnn::SmallVector<uint32_t> step = {1, 1, 1, 1};
+        ttsl::SmallVector<uint32_t> start = {0, 0, pos, 0};
+        ttsl::SmallVector<uint32_t> end = {1, 1, pos + seq_len, head_dim};
+        ttsl::SmallVector<uint32_t> step = {1, 1, 1, 1};
 
         cos_cache_to_use = ttnn::slice(params.cos_cache, start, end, step);
         sin_cache_to_use = ttnn::slice(params.sin_cache, start, end, step);

--- a/tt-train/sources/ttml/serialization/serialization.cpp
+++ b/tt-train/sources/ttml/serialization/serialization.cpp
@@ -61,7 +61,7 @@ inline void from_bytes(std::span<const uint8_t> bytes, ttnn::Shape& value) {
             << " Actual: " << bytes.size() << ", type: " << typeid(ttnn::Shape).name();
         throw std::invalid_argument(oss.str());
     }
-    ttnn::SmallVector<uint32_t> data(bytes.size() / sizeof(uint32_t));
+    ttsl::SmallVector<uint32_t> data(bytes.size() / sizeof(uint32_t));
     std::memcpy(data.data(), bytes.data(), bytes.size());
     value = ttnn::Shape(std::move(data));
 }

--- a/tt-train/tests/model/gpt2s_test.cpp
+++ b/tt-train/tests/model/gpt2s_test.cpp
@@ -13,8 +13,8 @@
 enum class ExpectedResult { OK, ERROR };
 
 struct MatmulInput {
-    ttnn::SmallVector<uint32_t> shape_a;
-    ttnn::SmallVector<uint32_t> shape_b;
+    ttsl::SmallVector<uint32_t> shape_a;
+    ttsl::SmallVector<uint32_t> shape_b;
     bool transpose_a{false};
     bool transpose_b{false};
 };

--- a/tt-train/tests/ops/cross_entropy_bw_op_test.cpp
+++ b/tt-train/tests/ops/cross_entropy_bw_op_test.cpp
@@ -92,7 +92,7 @@ TEST_F(CrossEntropyBackwardTest, CrossEntropyBackward_Batch) {
     using namespace ttml;
 
     const uint32_t N = 1U, C = 1U, H = 91U, W = 187U;
-    const auto shape = ttnn::SmallVector<uint32_t>{N, C, H, W};
+    const auto shape = ttsl::SmallVector<uint32_t>{N, C, H, W};
 
     std::random_device rd;
     std::mt19937 gen(42);
@@ -137,7 +137,7 @@ TEST_F(CrossEntropyBackwardTest, CrossEntropyBackward_Large_Batch) {
     using namespace ttml;
 
     const uint32_t N = 64U, C = 1U, H = 1024, W = 1024U;
-    const auto shape = ttnn::SmallVector<uint32_t>{N, C, H, W};
+    const auto shape = ttsl::SmallVector<uint32_t>{N, C, H, W};
 
     std::random_device rd;
     std::mt19937 gen(42);
@@ -182,7 +182,7 @@ TEST_F(CrossEntropyBackwardTest, CrossEntropyBackward_Large_Backward) {
     using namespace ttml;
 
     const uint32_t N = 1U, C = 1U, H = 32U, W = 128007U;
-    const auto shape = ttnn::SmallVector<uint32_t>{N, C, H, W};
+    const auto shape = ttsl::SmallVector<uint32_t>{N, C, H, W};
 
     std::random_device rd;
     std::mt19937 gen(42);
@@ -231,7 +231,7 @@ TEST_F(CrossEntropyBackwardTest, NIGHTLY_CrossEntropyBackward_Huge_Backward) {
     using namespace ttml;
 
     const uint32_t N = 64U, C = 1U, H = 64, W = 128000U;
-    const auto shape = ttnn::SmallVector<uint32_t>{N, C, H, W};
+    const auto shape = ttsl::SmallVector<uint32_t>{N, C, H, W};
 
     std::random_device rd;
     std::mt19937 gen(42);
@@ -276,7 +276,7 @@ TEST_F(CrossEntropyBackwardTest, CrossEntropyForwardBackward_ReduceMeanVsNone) {
     using namespace ttml;
 
     const uint32_t N = 5U, C = 1U, H = 91U, W = 187U;
-    const auto shape = ttnn::SmallVector<uint32_t>{N, C, H, W};
+    const auto shape = ttsl::SmallVector<uint32_t>{N, C, H, W};
 
     std::random_device rd;
     std::mt19937 gen(42);

--- a/tt-train/tests/ops/cross_entropy_fw_op_test.cpp
+++ b/tt-train/tests/ops/cross_entropy_fw_op_test.cpp
@@ -103,7 +103,7 @@ TEST_F(CrossEntropyForwardTest, CrossEntropyForward_Batch) {
     using namespace ttml;
 
     const uint32_t N = 2U, C = 1U, H = 91U, W = 157U;
-    const auto shape = ttnn::SmallVector<uint32_t>{N, C, H, W};
+    const auto shape = ttsl::SmallVector<uint32_t>{N, C, H, W};
 
     std::mt19937 gen(42);
     xt::xarray<float> input_tensor = xt::empty<float>({N, C, H, W});
@@ -142,7 +142,7 @@ TEST_F(CrossEntropyForwardTest, CrossEntropyForward_Large_Batch) {
     using namespace ttml;
 
     const uint32_t N = 64U, C = 1U, H = 1017U, W = 1018U;
-    const auto shape = ttnn::SmallVector<uint32_t>{N, C, H, W};
+    const auto shape = ttsl::SmallVector<uint32_t>{N, C, H, W};
 
     std::mt19937 gen(42);
     xt::xarray<float> input_tensor = xt::empty<float>({N, C, H, W});
@@ -181,7 +181,7 @@ TEST_F(CrossEntropyForwardTest, CrossEntropyForward_Large_Forward) {
     using namespace ttml;
 
     const uint32_t N = 1U, C = 1U, H = 1U, W = 65536U;
-    const auto shape = ttnn::SmallVector<size_t>{N, C, H, W};
+    const auto shape = ttsl::SmallVector<size_t>{N, C, H, W};
 
     std::mt19937 gen(42);
     xt::xarray<float> input_tensor = xt::empty<float>({N, C, H, W});
@@ -224,7 +224,7 @@ TEST_F(CrossEntropyForwardTest, NIGHTLY_CrossEntropyForward_Huge_Forward) {
     using namespace ttml;
 
     const uint32_t N = 64U, C = 1U, H = 32U, W = 128000U;
-    const auto shape = ttnn::SmallVector<size_t>{N, C, H, W};
+    const auto shape = ttsl::SmallVector<size_t>{N, C, H, W};
 
     std::mt19937 gen(42);
     xt::xarray<float> input_tensor = xt::empty<float>({N, C, H, W});

--- a/tt-train/tests/ops/softmax_test.cpp
+++ b/tt-train/tests/ops/softmax_test.cpp
@@ -47,7 +47,7 @@ TEST_F(SoftmaxTest, SoftmaxTest_Batch) {
     using namespace ttml;
 
     const uint32_t N = 64U, C = 1U, H = 59U, W = 197U;
-    const auto shape = ttnn::SmallVector<uint32_t>{N, C, H, W};
+    const auto shape = ttsl::SmallVector<uint32_t>{N, C, H, W};
     int32_t dim = 3U;
 
     xt::xarray<float> input_tensor = xt::empty<float>({N, C, H, W});
@@ -77,7 +77,7 @@ TEST_F(SoftmaxTest, SoftmaxTest_Big_Batch) {
     using namespace ttml;
 
     const uint32_t N = 1U, C = 1U, H = 32U, W = 128007U;
-    const auto shape = ttnn::SmallVector<uint32_t>{N, C, H, W};
+    const auto shape = ttsl::SmallVector<uint32_t>{N, C, H, W};
     int32_t dim = 3U;
 
     xt::xarray<float> input_tensor = xt::empty<float>({N, C, H, W});
@@ -108,7 +108,7 @@ TEST_F(SoftmaxTest, NIGHTLY_SoftmaxTest_Huge_Batch) {
     using namespace ttml;
 
     const uint32_t N = 64U, C = 1U, H = 32U, W = 128000U;
-    const auto shape = ttnn::SmallVector<uint32_t>{N, C, H, W};
+    const auto shape = ttsl::SmallVector<uint32_t>{N, C, H, W};
     int32_t dim = 3U;
 
     xt::xarray<float> input_tensor = xt::empty<float>({N, C, H, W});
@@ -135,7 +135,7 @@ TEST_F(SoftmaxTest, SoftmaxTest_Large_Values) {
     using namespace ttml;
 
     const uint32_t N = 1U, C = 1U, H = 1U, W = 256U;
-    const auto shape = ttnn::SmallVector<uint32_t>{N, C, H, W};
+    const auto shape = ttsl::SmallVector<uint32_t>{N, C, H, W};
     int32_t dim = 3U;
 
     xt::xarray<float> input_tensor = {

--- a/tt-train/tests/ttnn_fixed/slice_op_test.cpp
+++ b/tt-train/tests/ttnn_fixed/slice_op_test.cpp
@@ -30,9 +30,9 @@ TEST_F(SliceOpTest, Slice_BROKEN) {
 
     // Example: slice out the last row, columns 1 to 5
 
-    ttnn::SmallVector<uint32_t> step = {1U, 1U, 1U, 1U};
-    ttnn::SmallVector<uint32_t> start_index = {0U, 0U, H - 1, 1U};
-    ttnn::SmallVector<uint32_t> end_index = {N, C, H, 5U};
+    ttsl::SmallVector<uint32_t> step = {1U, 1U, 1U, 1U};
+    ttsl::SmallVector<uint32_t> start_index = {0U, 0U, H - 1, 1U};
+    ttsl::SmallVector<uint32_t> end_index = {N, C, H, 5U};
 
     // Expected output: shape {1, 1, 1, 4}, values from a(0,0,H-1,1) to a(0,0,H-1,4)
     xt::xarray<float> b = {{{{a(0, 0, H - 1, 1), a(0, 0, H - 1, 2), a(0, 0, H - 1, 3), a(0, 0, H - 1, 4)}}}};


### PR DESCRIPTION
Made-with: Cursor

### Ticket
N/A

### Problem description
`ttnn::SmallVector` is deprecated in favor of `ttsl::SmallVector` (see `tt_stl/tt_stl/small_vector.hpp`). tt-train still used `ttnn::SmallVector` in several sources and tests, and when building as an tt-metal subproject, deprecation warnings were hidden because the top-level CMake sets `-Wno-deprecated-declarations` globally, so these usages were not visible.

### What's changed
- **Code:** Replaced all `ttnn::SmallVector` usages with `ttsl::SmallVector` across tt-train sources and tests (models, modules, ops, serialization, metal ops, and tests).
- **Build:** For the ttml target, added `-Wdeprecated-declarations` so deprecation warnings are reported when building as an tt-metal subproject (overriding the parent’s `-Wno-deprecated-declarations`). Added `-Wno-error=deprecated-declarations` so deprecations in included dependencies (e.g. ttnn headers using `tt::stl`) do not fail the build; they remain as warnings only.

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=mdragula/fix_depracted_small_vector)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:mdragula/fix_depracted_small_vector)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=mdragula/fix_depracted_small_vector)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:mdragula/fix_depracted_small_vector)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mdragula/fix_depracted_small_vector)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mdragula/fix_depracted_small_vector)
- [ ] New/Existing tests provide coverage for changes