### PR TITLE
Integrate Optimized Decode Reduce Scatter into Deepseek

### DIFF
--- a/models/demos/deepseek_v3/demo/demo.py
+++ b/models/demos/deepseek_v3/demo/demo.py
@@ -13,12 +13,9 @@ from loguru import logger
 
 import ttnn
 from models.demos.deepseek_v3.tt.generator import DeepseekGenerator as DeepseekGeneratorDP
+from models.demos.deepseek_v3.tt.model.row_batched_model import get_fabric_config
 from models.demos.deepseek_v3.utils.hf_model_utils import load_tokenizer
 from models.demos.deepseek_v3.utils.test_utils import system_name_to_mesh_shape
-
-optimal_topology = (
-    ttnn.FabricConfig.FABRIC_1D_RING if (os.getenv("USE_TORUS_MODE") is not None) else ttnn.FabricConfig.FABRIC_1D
-)
 
 
 def _print_performance_metrics(results: dict) -> None:
@@ -303,7 +300,7 @@ def run_demo(
         raise ValueError("Environment variable $MESH_DEVICE is not set. Please set it to DUAL, QUAD, or TG.")
     mesh_shape = system_name_to_mesh_shape(requested_system_name.upper())
     logger.info(f"Selected MESH_DEVICE: '{requested_system_name}' - mesh shape will be set to: {mesh_shape}")
-    fabric_config = optimal_topology
+    fabric_config = get_fabric_config()
     logger.info(f"Setting fabric config to {fabric_config} for demo run")
     ttnn.set_fabric_config(fabric_config, ttnn.FabricReliabilityMode.RELAXED_INIT)
 

--- a/models/demos/deepseek_v3/tests/fused_op_unit_tests/test_decode_reduce_scatter.py
+++ b/models/demos/deepseek_v3/tests/fused_op_unit_tests/test_decode_reduce_scatter.py
@@ -76,7 +76,7 @@ def run_decode_reduce_scatter_deepseek_impl(
         tt_pre_rs_reduction_output = ttnn.experimental.deepseek_moe_fast_reduce_nc(
             tt_input_tensor_mesh_list[i],
             dim=pre_rs_reduction_dim,
-            split_size=int(pre_rs_reduction_input_shape[-1] / num_devices),
+            split_size=pre_rs_reduction_input_shape[-1] // num_devices,
             output_memory_config=rs_input_memory_config,
         )
 

--- a/models/demos/deepseek_v3/tests/fused_op_unit_tests/test_decode_reduce_scatter.py
+++ b/models/demos/deepseek_v3/tests/fused_op_unit_tests/test_decode_reduce_scatter.py
@@ -1,0 +1,238 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import torch
+from loguru import logger
+
+import ttnn
+from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import comp_pcc
+
+
+def run_decode_reduce_scatter_deepseek_impl(
+    mesh_device,
+    num_devices,
+    dtype,
+    layout,
+    pre_rs_reduction_dim,
+    pre_rs_reduction_input_shape,
+    sum_input_memory_config,
+    rs_input_memory_config,
+    rs_output_memory_config,
+    rs_dim,
+    rs_num_links=1,
+    rs_topology=None,
+    rs_cluster_axis=None,
+    enable_trace=True,
+    num_iters=1,
+):
+    torch.manual_seed(0)
+
+    worker_sub_device_id = ttnn.SubDeviceId(0)
+    sub_device_stall_group = [worker_sub_device_id]
+    mesh_device.set_sub_device_stall_group(sub_device_stall_group)
+
+    tt_input_tensor_mesh_list = []
+    torch_input_tensor_list = []
+
+    for i in range(num_iters):
+        pre_rs_reduction_global_input_shape = pre_rs_reduction_input_shape[:]
+        pre_rs_reduction_global_input_shape[rs_dim] *= num_devices
+        pre_rs_reduction_input_tensor = torch.rand(pre_rs_reduction_global_input_shape).bfloat16()
+        input_tensors = torch.chunk(pre_rs_reduction_input_tensor, num_devices, rs_dim)
+        torch_input_tensor_list.append(input_tensors)
+
+        input_tensor_mesh = ttnn.from_torch(
+            pre_rs_reduction_input_tensor,
+            device=mesh_device,
+            layout=layout,
+            dtype=dtype,
+            memory_config=sum_input_memory_config,
+            mesh_mapper=ttnn.create_mesh_mapper(
+                mesh_device,
+                ttnn.MeshMapperConfig(
+                    [ttnn.PlacementReplicate(), ttnn.PlacementShard(rs_dim)], ttnn.MeshShape(1, num_devices)
+                ),
+            ),
+        )
+
+        tt_input_tensor_mesh_list.append(input_tensor_mesh)
+
+    ##### Perform torch ops #####
+    torch_reduce_scatter_output_list = []
+    for i in range(num_iters):
+        pre_rs_reduction_output = [torch.sum(t, dim=0, keepdim=True) for t in torch_input_tensor_list[i]]
+        reduce_output = torch.sum(torch.stack(pre_rs_reduction_output), dim=0)
+        scatter_output = torch.chunk(reduce_output, num_devices, rs_dim)
+        torch_reduce_scatter_output_list.append(scatter_output)
+
+    ##### Perform the TT ops #####
+    tt_reduce_scatter_output_list = []
+
+    def run_op(i):
+        tt_pre_rs_reduction_output = ttnn.experimental.deepseek_moe_fast_reduce_nc(
+            tt_input_tensor_mesh_list[i],
+            dim=pre_rs_reduction_dim,
+            split_size=int(pre_rs_reduction_input_shape[-1] / num_devices),
+            output_memory_config=rs_input_memory_config,
+        )
+
+        tt_reduce_scatter_output_tensor = ttnn.experimental.deepseek_moe_reduce_scatter(
+            tt_pre_rs_reduction_output,
+            output_memory_config=rs_output_memory_config,
+            dim=rs_dim,
+            num_links=rs_num_links,
+            topology=rs_topology,
+            cluster_axis=rs_cluster_axis,
+        )
+
+        return tt_reduce_scatter_output_tensor
+
+    if enable_trace:
+        # Compile the op
+        tt_reduce_scatter_output_trace_list = []
+        for i in range(num_iters):
+            tt_reduce_scatter_output_tensor = run_op(i)
+        logger.info(f"Done compiling Op")
+
+        # Capture the trace
+        trace_id = ttnn.begin_trace_capture(mesh_device, cq_id=0)
+        for i in range(num_iters):
+            tt_reduce_scatter_output_tensor = run_op(i)
+            tt_reduce_scatter_output_trace_list.append(tt_reduce_scatter_output_tensor)
+        ttnn.end_trace_capture(mesh_device, trace_id, cq_id=0)
+        logger.info(f"Done capturing trace")
+
+        # Execute trace
+        ttnn.execute_trace(mesh_device, trace_id, cq_id=0, blocking=False)
+        logger.info(f"Done executing trace")
+
+        # Synchronize the devices
+        ttnn.synchronize_device(mesh_device, sub_device_ids=sub_device_stall_group)
+        for tt_tensor in tt_reduce_scatter_output_trace_list:
+            tt_rs_out = ttnn.from_device(tt_tensor)
+            tt_rs_out = ttnn.to_torch(tt_rs_out, mesh_composer=ttnn.ConcatMeshToTensor(mesh_device, dim=rs_dim))
+            tt_tensor.deallocate(True)
+            tt_reduce_scatter_output_list.append(tt_rs_out)
+    else:
+        for i in range(num_iters):
+            tt_reduce_scatter_output_tensor = run_op(i)
+            tt_rs_out = ttnn.from_device(tt_reduce_scatter_output_tensor)
+            tt_rs_out = ttnn.to_torch(tt_rs_out, mesh_composer=ttnn.ConcatMeshToTensor(mesh_device, dim=rs_dim))
+            tt_reduce_scatter_output_tensor.deallocate(True)
+            tt_reduce_scatter_output_list.append(tt_rs_out)
+
+            logger.info(f"Waiting for op")
+            ttnn.synchronize_device(mesh_device, sub_device_ids=sub_device_stall_group)
+            logger.info(f"Done op")
+
+            logger.info(f"Done iteration {i}")
+
+    for i in range(num_iters):
+        tt_rs_out = tt_reduce_scatter_output_list[i]
+        torch_rs_out_tensor = torch_reduce_scatter_output_list[i]
+
+        torch_rs_out = torch.cat(torch_rs_out_tensor, rs_dim)
+        eq, output = comp_pcc(tt_rs_out, torch_rs_out)
+
+        logger.info(f"{output}, iteration {i}")
+        assert eq, f"{i} FAILED: {output}"
+
+    mesh_device.reset_sub_device_stall_group()
+
+
+@pytest.mark.requires_device(["TG"])
+@pytest.mark.parametrize("mesh_device", [pytest.param((8, 4), id="8x4_grid")], indirect=True)
+@pytest.mark.parametrize("num_devices, cluster_axis", [(8, 1)])
+@pytest.mark.parametrize("dtype, layout", [(ttnn.bfloat16, ttnn.TILE_LAYOUT)])
+@pytest.mark.parametrize("pre_rs_reduction_dim", [(0)])
+@pytest.mark.parametrize(
+    "pre_rs_reduction_input_shape, sum_input_memory_config, rs_input_memory_config, rs_output_memory_config, rs_dim, rs_num_links",
+    [
+        (
+            [8, 1, 32, 7168],
+            ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.L1),
+            ttnn.MemoryConfig(
+                ttnn.BufferType.L1,
+                ttnn.NdShardSpec(
+                    ttnn.Shape([1, 1, 32, 128]),
+                    ttnn.CoreRangeSet(
+                        [
+                            ttnn.CoreRange(ttnn.CoreCoord(2, 0), ttnn.CoreCoord(2, 0)),
+                            ttnn.CoreRange(ttnn.CoreCoord(2, 5), ttnn.CoreCoord(2, 5)),
+                            ttnn.CoreRange(ttnn.CoreCoord(3, 0), ttnn.CoreCoord(3, 0)),
+                            ttnn.CoreRange(ttnn.CoreCoord(3, 5), ttnn.CoreCoord(3, 5)),
+                            ttnn.CoreRange(ttnn.CoreCoord(6, 0), ttnn.CoreCoord(6, 0)),
+                            ttnn.CoreRange(ttnn.CoreCoord(6, 5), ttnn.CoreCoord(6, 5)),
+                            ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(0, 0)),
+                        ]
+                    ),
+                    ttnn.ShardOrientation.ROW_MAJOR,
+                    ttnn.ShardDistributionStrategy.ROUND_ROBIN_1D,
+                ),
+            ),
+            ttnn.MemoryConfig(
+                ttnn.BufferType.L1,
+                ttnn.NdShardSpec(
+                    ttnn.Shape([1, 1, 32, 32]),
+                    ttnn.CoreRangeSet([ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(3, 6))]),
+                    ttnn.ShardOrientation.ROW_MAJOR,
+                    ttnn.ShardDistributionStrategy.ROUND_ROBIN_1D,
+                ),
+            ),
+            3,
+            4,
+        ),
+    ],
+)
+@pytest.mark.parametrize(
+    "device_params, rs_topology",
+    [
+        (
+            {
+                "fabric_config": ttnn.FabricConfig.FABRIC_1D_RING,
+                "dispatch_core_axis": ttnn.DispatchCoreAxis.COL,
+                "trace_region_size": 1531456,
+            },
+            ttnn.Topology.Ring,
+        ),
+    ],
+    indirect=["device_params"],
+    ids=["fabric_ring"],
+)
+@pytest.mark.parametrize("enable_trace, num_iters", [(True, 10)])
+def test_decode_reduce_scatter(
+    mesh_device,
+    num_devices,
+    cluster_axis,
+    dtype,
+    layout,
+    pre_rs_reduction_dim,
+    pre_rs_reduction_input_shape,
+    sum_input_memory_config,
+    rs_input_memory_config,
+    rs_output_memory_config,
+    rs_dim,
+    rs_num_links,
+    rs_topology,
+    enable_trace,
+    num_iters,
+):
+    run_decode_reduce_scatter_deepseek_impl(
+        mesh_device=mesh_device,
+        num_devices=num_devices,
+        dtype=dtype,
+        layout=layout,
+        pre_rs_reduction_dim=pre_rs_reduction_dim,
+        pre_rs_reduction_input_shape=pre_rs_reduction_input_shape,
+        sum_input_memory_config=sum_input_memory_config,
+        rs_input_memory_config=rs_input_memory_config,
+        rs_output_memory_config=rs_output_memory_config,
+        rs_dim=rs_dim,
+        rs_num_links=rs_num_links,
+        rs_topology=rs_topology,
+        rs_cluster_axis=cluster_axis,
+        enable_trace=enable_trace,
+        num_iters=num_iters,
+    )

--- a/models/demos/deepseek_v3/tests/fused_op_unit_tests/test_decode_reduce_scatter.py
+++ b/models/demos/deepseek_v3/tests/fused_op_unit_tests/test_decode_reduce_scatter.py
@@ -2,6 +2,8 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
+import os
+
 import pytest
 import torch
 from loguru import logger
@@ -143,6 +145,10 @@ def run_decode_reduce_scatter_deepseek_impl(
 
 
 @pytest.mark.requires_device(["TG"])
+@pytest.mark.skipif(
+    (os.getenv("USE_TORUS_MODE") is None),
+    reason=f"Requires ring fabric",
+)
 @pytest.mark.parametrize("mesh_device", [pytest.param((8, 4), id="8x4_grid")], indirect=True)
 @pytest.mark.parametrize("num_devices, cluster_axis", [(8, 1)])
 @pytest.mark.parametrize("dtype, layout", [(ttnn.bfloat16, ttnn.TILE_LAYOUT)])

--- a/models/demos/deepseek_v3/tests/test_decoder_block.py
+++ b/models/demos/deepseek_v3/tests/test_decoder_block.py
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 
-import os
 from pathlib import Path
 
 import pytest
@@ -18,6 +17,7 @@ from models.demos.deepseek_v3.tt.decoder_block.decoder_block_2d_base import Deco
 from models.demos.deepseek_v3.tt.decoder_block.moe_decoder_block_2d import MoEDecoderBlock2D
 from models.demos.deepseek_v3.tt.mla.mla1d import MLA1D
 from models.demos.deepseek_v3.tt.mla.mla2d import MLA2D
+from models.demos.deepseek_v3.tt.model.row_batched_model import get_fabric_config
 from models.demos.deepseek_v3.utils.config_helpers import USERS_PER_ROW, sub_state_dict
 from models.demos.deepseek_v3.utils.run_config import create_run_config
 from models.demos.deepseek_v3.utils.test_utils import (
@@ -30,10 +30,6 @@ from models.demos.deepseek_v3.utils.test_utils import (
     paged_cache_from_torch,
     run_reference_with_attention,
     torch_cache_from_transformers_single_layer,
-)
-
-fabric_config = (
-    ttnn.FabricConfig.FABRIC_1D_RING if (os.getenv("USE_TORUS_MODE") is not None) else ttnn.FabricConfig.FABRIC_1D
 )
 
 
@@ -90,6 +86,7 @@ def generate_reference_io(
 
 def run_test_forward_pass_decoder2d(
     DecoderBlockClass: type[DecoderBlock2DBase],
+    fabric_config,
     module_path,
     reference_layer_idx,
     mode,
@@ -144,7 +141,7 @@ def run_test_forward_pass_decoder2d(
         real_weights=module_path is not None,
         layer_id=module_path,
     )
-    model_config = get_model_config(DecoderBlockClass, mode, hf_config_short, mesh_device)
+    model_config = get_model_config(DecoderBlockClass, mode, hf_config_short, mesh_device, fabric_config)
     model_state = DecoderBlockClass.create_state(
         hf_config_short,
         paged_config,
@@ -216,7 +213,7 @@ optimal_topology = (
 @pytest.mark.parametrize(
     "device_params",
     [
-        {"fabric_config": fabric_config},
+        {"fabric_config": get_fabric_config()},
     ],
     indirect=True,
 )
@@ -260,6 +257,7 @@ optimal_topology = (
 )
 def test_forward_pass(
     DecoderBlockClass: type[DecoderBlock2DBase],
+    device_params,
     module_path,
     reference_layer_idx,
     mode,
@@ -281,6 +279,7 @@ def test_forward_pass(
 
     test_closure(
         DecoderBlockClass,
+        device_params["fabric_config"],
         module_path,
         reference_layer_idx,
         mode,

--- a/models/demos/deepseek_v3/tests/test_decoder_block.py
+++ b/models/demos/deepseek_v3/tests/test_decoder_block.py
@@ -32,6 +32,10 @@ from models.demos.deepseek_v3.utils.test_utils import (
     torch_cache_from_transformers_single_layer,
 )
 
+fabric_config = (
+    ttnn.FabricConfig.FABRIC_1D_RING if (os.getenv("USE_TORUS_MODE") is not None) else ttnn.FabricConfig.FABRIC_1D
+)
+
 
 def generate_reference_io(
     model_path: Path,
@@ -212,9 +216,7 @@ optimal_topology = (
 @pytest.mark.parametrize(
     "device_params",
     [
-        {
-            "fabric_config": optimal_topology,
-        }
+        {"fabric_config": fabric_config},
     ],
     indirect=True,
 )

--- a/models/demos/deepseek_v3/tests/test_decoder_block.py
+++ b/models/demos/deepseek_v3/tests/test_decoder_block.py
@@ -204,10 +204,6 @@ TEST_CASES, TEST_IDS = build_test_cases_and_ids(
     include_decode_random_pos_ids=True,  # include decode random position_ids case
 )
 
-optimal_topology = (
-    ttnn.FabricConfig.FABRIC_1D_RING if (os.getenv("USE_TORUS_MODE") is not None) else ttnn.FabricConfig.FABRIC_1D
-)
-
 
 @pytest.mark.timeout(900)
 @pytest.mark.parametrize(

--- a/models/demos/deepseek_v3/tests/test_mla.py
+++ b/models/demos/deepseek_v3/tests/test_mla.py
@@ -2,7 +2,6 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
-import os
 from pathlib import Path
 
 import pytest
@@ -15,6 +14,7 @@ from models.common.utility_functions import comp_pcc
 from models.demos.deepseek_v3.reference.modeling_deepseek import DeepseekV3Attention
 from models.demos.deepseek_v3.tests.pytest_utils import DEFAULT_PREFILL_SEQ_LEN, build_test_cases_and_ids
 from models.demos.deepseek_v3.tt.mla.mla2d import MLA2D
+from models.demos.deepseek_v3.tt.model.row_batched_model import get_fabric_config
 from models.demos.deepseek_v3.utils.config_helpers import USERS_PER_ROW, sub_state_dict
 from models.demos.deepseek_v3.utils.run_config import create_run_config
 from models.demos.deepseek_v3.utils.test_utils import (
@@ -352,16 +352,11 @@ TEST_CASES, TEST_IDS = build_test_cases_and_ids(
 )
 
 
-optimal_topology = (
-    ttnn.FabricConfig.FABRIC_1D_RING if (os.getenv("USE_TORUS_MODE") is not None) else ttnn.FabricConfig.FABRIC_1D
-)
-
-
 @pytest.mark.parametrize(
     "device_params",
     [
         {
-            "fabric_config": optimal_topology,
+            "fabric_config": get_fabric_config(),
         }
     ],
     indirect=True,

--- a/models/demos/deepseek_v3/tests/test_mlp.py
+++ b/models/demos/deepseek_v3/tests/test_mlp.py
@@ -151,6 +151,7 @@ _prefill_seq_len = int(_max_seq_len_env) if _max_seq_len_env is not None else DE
     ],
 )
 def test_forward_pass(
+    device_params,
     MLPClass,
     module_path,
     mode,
@@ -193,7 +194,7 @@ def test_forward_pass(
         real_weights=module_path is not None,
         layer_id=module_path,
     )
-    model_config = get_model_config(MLPClass, mode, hf_config, mesh_device)
+    model_config = get_model_config(MLPClass, mode, hf_config, mesh_device, device_params["fabric_config"])
     model_state = MLPClass.create_state(hf_config, mesh_device, ccl)
     run_config = create_run_config(model_config, weight_config, model_state)
 

--- a/models/demos/deepseek_v3/tests/test_model.py
+++ b/models/demos/deepseek_v3/tests/test_model.py
@@ -3,6 +3,7 @@
 
 import errno
 import hashlib
+import os
 import re
 import tempfile
 from pathlib import Path
@@ -36,6 +37,10 @@ REFERENCE_OUTPUT_CACHE_LEGACY_FILENAME = f"{REFERENCE_OUTPUT_CACHE_FILE_PREFIX}.
 PCC_REQUIRED_PREFILL = 0.97
 PCC_REQUIRED_DECODE = 0.97
 REFERENCE_ENTRY_VERSION = 1
+
+fabric_config = (
+    ttnn.FabricConfig.FABRIC_1D_RING if (os.getenv("USE_TORUS_MODE") is not None) else ttnn.FabricConfig.FABRIC_1D
+)
 
 
 def _default_reference_cache_dir(cache_path: Path) -> Path:
@@ -528,7 +533,7 @@ TEST_CASES, TEST_IDS = build_test_cases_and_ids(
 @pytest.mark.parametrize(
     "device_params",
     [
-        {"fabric_config": ttnn.FabricConfig.FABRIC_1D},
+        {"fabric_config": fabric_config},
     ],
     indirect=True,
 )

--- a/models/demos/deepseek_v3/tests/test_model.py
+++ b/models/demos/deepseek_v3/tests/test_model.py
@@ -3,7 +3,6 @@
 
 import errno
 import hashlib
-import os
 import re
 import tempfile
 from pathlib import Path
@@ -37,10 +36,6 @@ REFERENCE_OUTPUT_CACHE_LEGACY_FILENAME = f"{REFERENCE_OUTPUT_CACHE_FILE_PREFIX}.
 PCC_REQUIRED_PREFILL = 0.97
 PCC_REQUIRED_DECODE = 0.97
 REFERENCE_ENTRY_VERSION = 1
-
-fabric_config = (
-    ttnn.FabricConfig.FABRIC_1D_RING if (os.getenv("USE_TORUS_MODE") is not None) else ttnn.FabricConfig.FABRIC_1D
-)
 
 
 def _default_reference_cache_dir(cache_path: Path) -> Path:
@@ -533,7 +528,7 @@ TEST_CASES, TEST_IDS = build_test_cases_and_ids(
 @pytest.mark.parametrize(
     "device_params",
     [
-        {"fabric_config": fabric_config},
+        {"fabric_config": get_fabric_config()},
     ],
     indirect=True,
 )

--- a/models/demos/deepseek_v3/tests/test_model.py
+++ b/models/demos/deepseek_v3/tests/test_model.py
@@ -16,7 +16,7 @@ import ttnn
 from models.demos.deepseek_v3.reference.modeling_deepseek import DeepseekV3ForCausalLM
 from models.demos.deepseek_v3.tests.pytest_utils import DEFAULT_PREFILL_SEQ_LEN, build_test_cases_and_ids
 from models.demos.deepseek_v3.tt.mla.mla2d import MLA2D
-from models.demos.deepseek_v3.tt.model.row_batched_model import RowBatchedModel
+from models.demos.deepseek_v3.tt.model.row_batched_model import RowBatchedModel, get_fabric_config
 from models.demos.deepseek_v3.utils.config_helpers import USERS_PER_ROW, sub_state_dict
 from models.demos.deepseek_v3.utils.run_config import create_run_config
 from models.demos.deepseek_v3.utils.test_utils import (

--- a/models/demos/deepseek_v3/tests/test_moe.py
+++ b/models/demos/deepseek_v3/tests/test_moe.py
@@ -11,6 +11,7 @@ from loguru import logger
 import ttnn
 from models.demos.deepseek_v3.reference.modeling_deepseek import DeepseekV3MoE
 from models.demos.deepseek_v3.tests.pytest_utils import DEFAULT_PREFILL_SEQ_LEN
+from models.demos.deepseek_v3.tt.model.row_batched_model import get_fabric_config
 from models.demos.deepseek_v3.tt.moe import MoE
 from models.demos.deepseek_v3.utils.run_config import create_run_config
 from models.demos.deepseek_v3.utils.test_utils import (
@@ -19,10 +20,6 @@ from models.demos.deepseek_v3.utils.test_utils import (
     get_model_config,
     get_test_weight_config,
     run_module_forward,
-)
-
-fabric_config = (
-    ttnn.FabricConfig.FABRIC_1D_RING if (os.getenv("USE_TORUS_MODE") is not None) else ttnn.FabricConfig.FABRIC_1D
 )
 
 
@@ -43,7 +40,7 @@ _prefill_seq_len = int(_max_seq_len_env) if _max_seq_len_env is not None else DE
 @pytest.mark.parametrize(
     "device_params",
     [
-        {"fabric_config": fabric_config},
+        {"fabric_config": get_fabric_config()},
     ],
     indirect=True,
 )
@@ -61,6 +58,7 @@ _prefill_seq_len = int(_max_seq_len_env) if _max_seq_len_env is not None else DE
     ],
 )
 def test_forward_pass(
+    device_params,
     mode,
     num_tokens,
     set_deterministic_env,
@@ -100,7 +98,9 @@ def test_forward_pass(
     )
 
     # Generate appropriate config using utility function
-    model_config = get_model_config(MoE, mode, hf_config, mesh_device, topk_fallback=topk_fallback)
+    model_config = get_model_config(
+        MoE, mode, hf_config, mesh_device, device_params["fabric_config"], topk_fallback=topk_fallback
+    )
 
     # Create a new model state with CCL
     model_state = MoE.create_state(hf_config, mesh_device, ccl)

--- a/models/demos/deepseek_v3/tests/test_moe.py
+++ b/models/demos/deepseek_v3/tests/test_moe.py
@@ -21,6 +21,10 @@ from models.demos.deepseek_v3.utils.test_utils import (
     run_module_forward,
 )
 
+fabric_config = (
+    ttnn.FabricConfig.FABRIC_1D_RING if (os.getenv("USE_TORUS_MODE") is not None) else ttnn.FabricConfig.FABRIC_1D
+)
+
 
 @pytest.fixture
 def reference_model(hf_config):
@@ -39,7 +43,7 @@ _prefill_seq_len = int(_max_seq_len_env) if _max_seq_len_env is not None else DE
 @pytest.mark.parametrize(
     "device_params",
     [
-        {"fabric_config": ttnn.FabricConfig.FABRIC_1D},
+        {"fabric_config": fabric_config},
     ],
     indirect=True,
 )

--- a/models/demos/deepseek_v3/tt/decoder_block/decoder_block_2d.py
+++ b/models/demos/deepseek_v3/tt/decoder_block/decoder_block_2d.py
@@ -36,16 +36,18 @@ class DecoderBlock2D(DecoderBlock2DBase):
         cls,
         hf_config: PretrainedConfig,
         mesh_device: ttnn.MeshDevice,
+        fabric_config: ttnn.FabricConfig,
     ) -> ModelPrefillConfig:
-        return NonExpert.prefill_model_config(hf_config, mesh_device)
+        return NonExpert.prefill_model_config(hf_config, mesh_device, fabric_config)
 
     @classmethod
     def decode_mlp_config(
         cls,
         hf_config: PretrainedConfig,
         mesh_device: ttnn.MeshDevice,
+        fabric_config: ttnn.FabricConfig,
     ) -> ModelDecodeConfig:
-        return NonExpert.decode_model_config(hf_config, mesh_device)
+        return NonExpert.decode_model_config(hf_config, mesh_device, fabric_config)
 
     @classmethod
     def create_mlp_state(

--- a/models/demos/deepseek_v3/tt/decoder_block/decoder_block_base.py
+++ b/models/demos/deepseek_v3/tt/decoder_block/decoder_block_base.py
@@ -110,6 +110,7 @@ class DecoderBlockBase(SharedStateAddOn, AbstractModule):
         cls,
         hf_config: PretrainedConfig,
         mesh_device: ttnn.MeshDevice,
+        fabric_config: ttnn.FabricConfig,
     ) -> ModelPrefillConfig:
         """
         Prefill configuration for the MLP component of the decoder layer.
@@ -136,6 +137,7 @@ class DecoderBlockBase(SharedStateAddOn, AbstractModule):
         cls,
         hf_config: PretrainedConfig,
         mesh_device: ttnn.MeshDevice,
+        fabric_config: ttnn.FabricConfig,
     ) -> ModelDecodeConfig:
         """
         Decode configuration for the MLP component of the decoder layer.

--- a/models/demos/deepseek_v3/tt/decoder_block/decoder_block_base.py
+++ b/models/demos/deepseek_v3/tt/decoder_block/decoder_block_base.py
@@ -28,6 +28,7 @@ class DecoderBlockBase(SharedStateAddOn, AbstractModule):
         cls,
         hf_config: PretrainedConfig,
         mesh_device: ttnn.MeshDevice,
+        fabric_config: ttnn.FabricConfig,
     ) -> ModelPrefillConfig:
         mla_norm_config = DistributedRMSNorm.prefill_model_config(hf_config, mesh_device)
         mlp_norm_config = DistributedRMSNorm.prefill_model_config(hf_config, mesh_device)
@@ -42,7 +43,7 @@ class DecoderBlockBase(SharedStateAddOn, AbstractModule):
             "mlp_norm_reshard": ReshardConfig(memory_config=mlp_norm_config["input_memory_config"]),
             "mlp_norm": mlp_norm_config,
             "mlp_reshard": ReshardConfig(memory_config=ttnn.DRAM_MEMORY_CONFIG),
-            "mlp": cls.prefill_mlp_config(hf_config, mesh_device),
+            "mlp": cls.prefill_mlp_config(hf_config, mesh_device, fabric_config),
         }
 
     @classmethod
@@ -50,12 +51,13 @@ class DecoderBlockBase(SharedStateAddOn, AbstractModule):
         cls,
         hf_config: PretrainedConfig,
         mesh_device: ttnn.MeshDevice,
+        fabric_config: ttnn.FabricConfig,
     ) -> ModelDecodeConfig:
         mla_norm_config = DistributedRMSNorm.decode_model_config(hf_config, mesh_device)
         mlp_norm_config = DistributedRMSNorm.decode_model_config(hf_config, mesh_device)
 
         mla_config = cls.decode_mla_config(hf_config, mesh_device)
-        mlp_config = cls.decode_mlp_config(hf_config, mesh_device)
+        mlp_config = cls.decode_mlp_config(hf_config, mesh_device, fabric_config)
 
         # Get the input_memory_config for the mlp_reshard
         # For MoE blocks, input_memory_config is nested inside shared_expert

--- a/models/demos/deepseek_v3/tt/decoder_block/moe_decoder_block_2d.py
+++ b/models/demos/deepseek_v3/tt/decoder_block/moe_decoder_block_2d.py
@@ -22,6 +22,10 @@ from models.demos.deepseek_v3.utils.run_config import (
     WeightConfig,
 )
 
+fabric_config = (
+    ttnn.FabricConfig.FABRIC_1D_RING if (os.getenv("USE_TORUS_MODE") is not None) else ttnn.FabricConfig.FABRIC_1D
+)
+
 
 class MoEDecoderBlock2D(DecoderBlock2DBase):
     @classmethod
@@ -93,14 +97,8 @@ class MoEDecoderBlock2D(DecoderBlock2DBase):
         }
 
     @classmethod
-    def _forward_mlp_common(
-        cls,
-        x: ttnn.Tensor,
-        cfg: RunPrefillConfig | RunDecodeConfig,
-        moe_forward_fn,
-        shared_expert_forward_fn,
-    ) -> ttnn.Tensor:
-        """Common implementation for forward_mlp_prefill and forward_mlp_decode."""
+    @abstractmethod
+    def forward_mlp_prefill(cls, x: ttnn.Tensor, cfg: RunPrefillConfig) -> ttnn.Tensor:
         # Handle all_gather if input is TP-sharded
         hidden_size = cfg["moe"]["hidden_size"]
         tp_size = cfg["moe"]["mesh_device"].shape[1]
@@ -118,14 +116,17 @@ class MoEDecoderBlock2D(DecoderBlock2DBase):
             assert False, f"Expected TP-sharded input with dim {hidden_size // tp_size}, got dim {x_dim}"
 
         # Run both MoE and SharedExpert with the same gathered input
-        mlp_out = moe_forward_fn(x_gathered, cfg["moe"])
+        mlp_out = MoE.forward_prefill(x_gathered, cfg["moe"])
         # SharedExpert now always expects collective ops to be handled by caller
-        shared_expert_out = shared_expert_forward_fn(x_gathered, cfg["shared_expert"])
+        shared_expert_out = SharedExpert.forward_prefill(x_gathered, cfg["shared_expert"])
 
-        # Add outputs first, then reduce_scatter the combined result
-        combined_out = ttnn.add(mlp_out, shared_expert_out)
+        # We sum the experts from MoE along with SharedExpert inside a single reduce by concatting first, instead
+        # of a reduce on the MoE experts followed by an add with the SharedExpert. This enables us to use
+        # the optimized reduce_scatter.
+        combined_out = ttnn.concat([mlp_out, shared_expert_out], dim=0)
         ttnn.deallocate(mlp_out)
         ttnn.deallocate(shared_expert_out)
+        combined_out = ttnn.sum(combined_out, dim=0, keepdim=True)
 
         # Handle reduce_scatter if input was TP-sharded
         if x_dim == hidden_size // tp_size:
@@ -147,10 +148,70 @@ class MoEDecoderBlock2D(DecoderBlock2DBase):
 
     @classmethod
     @abstractmethod
-    def forward_mlp_prefill(cls, x: ttnn.Tensor, cfg: RunPrefillConfig) -> ttnn.Tensor:
-        return cls._forward_mlp_common(x, cfg, MoE.forward_prefill, SharedExpert.forward_prefill)
-
-    @classmethod
-    @abstractmethod
     def forward_mlp_decode(cls, x: ttnn.Tensor, cfg: RunDecodeConfig) -> ttnn.Tensor:
-        return cls._forward_mlp_common(x, cfg, MoE.forward_decode, SharedExpert.forward_decode)
+        # Handle all_gather if input is TP-sharded
+        hidden_size = cfg["moe"]["hidden_size"]
+        tp_size = cfg["moe"]["mesh_device"].shape[1]
+        x_dim = x.shape[-1]
+
+        if x_dim == hidden_size // tp_size:
+            # Input is TP-sharded, need to gather
+            # Use MoE's all_gather config which outputs the correct memory layout for MoEGate
+            ccl_moe = cfg["moe"]["ccl"]
+            x_gathered = ttnn.experimental.all_gather_async(
+                x, **ccl_moe.populate_all_gather_runtime_args(cfg["moe"]["revert_tp"])
+            )
+        else:
+            # Should always be TP-sharded at this point
+            assert False, f"Expected TP-sharded input with dim {hidden_size // tp_size}, got dim {x_dim}"
+
+        # Run both MoE and SharedExpert with the same gathered input
+        mlp_out = MoE.forward_decode(x_gathered, cfg["moe"])
+        # SharedExpert now always expects collective ops to be handled by caller
+        shared_expert_out = SharedExpert.forward_decode(x_gathered, cfg["shared_expert"])
+
+        # We sum the experts from MoE along with SharedExpert inside a single reduce by concatting first, instead
+        # of a reduce on the MoE experts followed by an add with the SharedExpert. This enables us to use
+        # the optimized reduce_scatter.
+        combined_out = ttnn.concat([mlp_out, shared_expert_out], dim=0)
+        ttnn.deallocate(mlp_out)
+        ttnn.deallocate(shared_expert_out)
+
+        # Handle reduce_scatter if input was TP-sharded
+        if x_dim == hidden_size // tp_size:
+            # Single reduce_scatter on combined output using MoE's config for consistency
+            ccl_moe = cfg["moe"]["ccl"]
+
+            if fabric_config == ttnn.FabricConfig.FABRIC_1D_RING:
+                summed_experts = ttnn.experimental.deepseek_moe_fast_reduce_nc(
+                    combined_out,
+                    dim=0,
+                    split_size=combined_out[-1] // tp_size,
+                    output_memory_config=cfg["moe"]["ring_sum_experts_output_memory_config"],
+                )
+                ttnn.deallocate(combined_out)
+                output = ttnn.experimental.deepseek_moe_reduce_scatter(
+                    summed_experts, cfg["moe"]["ring_final_output_reduce_scatter"]
+                )
+            else:
+                summed_experts = ttnn.sum(
+                    combined_out, dim=0, keepdim=True, memory_config=cfg["moe"]["sum_experts_output_memory_config"]
+                )
+                ttnn.deallocate(combined_out)
+                output = ttnn.experimental.reduce_scatter_minimal_async(
+                    summed_experts,
+                    **ccl.populate_reduce_scatter_runtime_args(cfg["moe"]["final_output_reduce_scatter"]),
+                )
+
+            # Cleanup gathered tensor
+            if x_gathered is not x:
+                ttnn.deallocate(x_gathered)
+        else:
+            output = ttnn.sum(
+                combined_out, dim=0, keepdim=True, memory_config=cfg["moe"]["sum_experts_output_memory_config"]
+            )
+
+            # Should always be TP-sharded at this point
+            assert False, f"Expected TP-sharded input with dim {hidden_size // tp_size}, got dim {x_dim}"
+
+        return output

--- a/models/demos/deepseek_v3/tt/decoder_block/moe_decoder_block_2d.py
+++ b/models/demos/deepseek_v3/tt/decoder_block/moe_decoder_block_2d.py
@@ -121,7 +121,7 @@ class MoEDecoderBlock2D(DecoderBlock2DBase):
         # SharedExpert now always expects collective ops to be handled by caller
         shared_expert_out = SharedExpert.forward_prefill(x_gathered, cfg["shared_expert"])
 
-        mlp_out = ttnn.sum(combined_out, dim=0, keepdim=True)
+        mlp_out = ttnn.sum(mlp_out, dim=0, keepdim=True)
         combined_out = ttnn.add(mlp_out, shared_expert_out)
         ttnn.deallocate(mlp_out)
         ttnn.deallocate(shared_expert_out)

--- a/models/demos/deepseek_v3/tt/decoder_block/moe_decoder_block_2d.py
+++ b/models/demos/deepseek_v3/tt/decoder_block/moe_decoder_block_2d.py
@@ -179,11 +179,11 @@ class MoEDecoderBlock2D(DecoderBlock2DBase):
             # Single reduce_scatter on combined output using MoE's config for consistency
             ccl_moe = cfg["moe"]["ccl"]
 
-            if cfg["moe"]["fabric_config"] == ttnn.FabricConfig.FABRIC_1D_RING:
+            if cfg["moe"]["fabric_config"] == ttnn.FabricConfig.FABRIC_1D_RING and tp_size == 8:
                 summed_experts = ttnn.experimental.deepseek_moe_fast_reduce_nc(
                     combined_out,
                     dim=0,
-                    split_size=int(combined_out.shape[-1] // tp_size),
+                    split_size=combined_out.shape[-1] // tp_size,
                     output_memory_config=cfg["moe"]["ring_sum_experts_output_memory_config"],
                 )
                 ttnn.deallocate(combined_out)

--- a/models/demos/deepseek_v3/tt/decoder_block/moe_decoder_block_2d.py
+++ b/models/demos/deepseek_v3/tt/decoder_block/moe_decoder_block_2d.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC.
 # SPDX-License-Identifier: Apache-2.0
 
+import os
 from abc import abstractmethod
 from pathlib import Path
 
@@ -120,13 +121,10 @@ class MoEDecoderBlock2D(DecoderBlock2DBase):
         # SharedExpert now always expects collective ops to be handled by caller
         shared_expert_out = SharedExpert.forward_prefill(x_gathered, cfg["shared_expert"])
 
-        # We sum the experts from MoE along with SharedExpert inside a single reduce by concatting first, instead
-        # of a reduce on the MoE experts followed by an add with the SharedExpert. This enables us to use
-        # the optimized reduce_scatter.
-        combined_out = ttnn.concat([mlp_out, shared_expert_out], dim=0)
+        mlp_out = ttnn.sum(combined_out, dim=0, keepdim=True)
+        combined_out = ttnn.add(mlp_out, shared_expert_out)
         ttnn.deallocate(mlp_out)
         ttnn.deallocate(shared_expert_out)
-        combined_out = ttnn.sum(combined_out, dim=0, keepdim=True)
 
         # Handle reduce_scatter if input was TP-sharded
         if x_dim == hidden_size // tp_size:
@@ -173,6 +171,7 @@ class MoEDecoderBlock2D(DecoderBlock2DBase):
         # We sum the experts from MoE along with SharedExpert inside a single reduce by concatting first, instead
         # of a reduce on the MoE experts followed by an add with the SharedExpert. This enables us to use
         # the optimized reduce_scatter.
+        shared_expert_out = ttnn.to_memory_config(shared_expert_out, ttnn.L1_MEMORY_CONFIG)
         combined_out = ttnn.concat([mlp_out, shared_expert_out], dim=0)
         ttnn.deallocate(mlp_out)
         ttnn.deallocate(shared_expert_out)
@@ -187,12 +186,12 @@ class MoEDecoderBlock2D(DecoderBlock2DBase):
                 summed_experts = ttnn.experimental.deepseek_moe_fast_reduce_nc(
                     combined_out,
                     dim=0,
-                    split_size=int(combined_out[-1] // tp_size),
+                    split_size=int(combined_out.shape[-1] // tp_size),
                     output_memory_config=cfg["moe"]["ring_sum_experts_output_memory_config"],
                 )
                 ttnn.deallocate(combined_out)
                 output = ttnn.experimental.deepseek_moe_reduce_scatter(
-                    summed_experts, cfg["moe"]["ring_final_output_reduce_scatter"]
+                    summed_experts, **cfg["moe"]["ring_final_output_reduce_scatter"]
                 )
             else:
                 summed_experts = ttnn.sum(

--- a/models/demos/deepseek_v3/tt/decoder_block/moe_decoder_block_2d.py
+++ b/models/demos/deepseek_v3/tt/decoder_block/moe_decoder_block_2d.py
@@ -201,17 +201,13 @@ class MoEDecoderBlock2D(DecoderBlock2DBase):
                 ttnn.deallocate(combined_out)
                 output = ttnn.experimental.reduce_scatter_minimal_async(
                     summed_experts,
-                    **ccl.populate_reduce_scatter_runtime_args(cfg["moe"]["final_output_reduce_scatter"]),
+                    **ccl_moe.populate_reduce_scatter_runtime_args(cfg["moe"]["final_output_reduce_scatter"]),
                 )
 
             # Cleanup gathered tensor
             if x_gathered is not x:
                 ttnn.deallocate(x_gathered)
         else:
-            output = ttnn.sum(
-                combined_out, dim=0, keepdim=True, memory_config=cfg["moe"]["sum_experts_output_memory_config"]
-            )
-
             # Should always be TP-sharded at this point
             assert False, f"Expected TP-sharded input with dim {hidden_size // tp_size}, got dim {x_dim}"
 

--- a/models/demos/deepseek_v3/tt/decoder_block/moe_decoder_block_2d.py
+++ b/models/demos/deepseek_v3/tt/decoder_block/moe_decoder_block_2d.py
@@ -1,7 +1,6 @@
 # SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC.
 # SPDX-License-Identifier: Apache-2.0
 
-import os
 from abc import abstractmethod
 from pathlib import Path
 
@@ -21,10 +20,6 @@ from models.demos.deepseek_v3.utils.run_config import (
     RunDecodeConfig,
     RunPrefillConfig,
     WeightConfig,
-)
-
-fabric_config = (
-    ttnn.FabricConfig.FABRIC_1D_RING if (os.getenv("USE_TORUS_MODE") is not None) else ttnn.FabricConfig.FABRIC_1D
 )
 
 
@@ -54,10 +49,11 @@ class MoEDecoderBlock2D(DecoderBlock2DBase):
         cls,
         hf_config: PretrainedConfig,
         mesh_device: ttnn.MeshDevice,
+        fabric_config: ttnn.FabricConfig,
     ) -> ModelPrefillConfig:
         return {
-            "shared_expert": SharedExpert.prefill_model_config(hf_config, mesh_device),
-            "moe": MoE.prefill_model_config(hf_config, mesh_device),
+            "shared_expert": SharedExpert.prefill_model_config(hf_config, mesh_device, fabric_config),
+            "moe": MoE.prefill_model_config(hf_config, mesh_device, fabric_config),
         }
 
     @classmethod
@@ -66,10 +62,11 @@ class MoEDecoderBlock2D(DecoderBlock2DBase):
         cls,
         hf_config: PretrainedConfig,
         mesh_device: ttnn.MeshDevice,
+        fabric_config: ttnn.FabricConfig,
     ) -> ModelDecodeConfig:
         return {
-            "shared_expert": SharedExpert.decode_model_config(hf_config, mesh_device),
-            "moe": MoE.decode_model_config(hf_config, mesh_device),
+            "shared_expert": SharedExpert.decode_model_config(hf_config, mesh_device, fabric_config),
+            "moe": MoE.decode_model_config(hf_config, mesh_device, fabric_config),
         }
 
     @classmethod
@@ -182,7 +179,7 @@ class MoEDecoderBlock2D(DecoderBlock2DBase):
             # Single reduce_scatter on combined output using MoE's config for consistency
             ccl_moe = cfg["moe"]["ccl"]
 
-            if fabric_config == ttnn.FabricConfig.FABRIC_1D_RING:
+            if cfg["moe"]["fabric_config"] == ttnn.FabricConfig.FABRIC_1D_RING:
                 summed_experts = ttnn.experimental.deepseek_moe_fast_reduce_nc(
                     combined_out,
                     dim=0,

--- a/models/demos/deepseek_v3/tt/decoder_block/moe_decoder_block_2d.py
+++ b/models/demos/deepseek_v3/tt/decoder_block/moe_decoder_block_2d.py
@@ -177,7 +177,6 @@ class MoEDecoderBlock2D(DecoderBlock2DBase):
         # Handle reduce_scatter if input was TP-sharded
         if x_dim == hidden_size // tp_size:
             # Single reduce_scatter on combined output using MoE's config for consistency
-            ccl_moe = cfg["moe"]["ccl"]
 
             if cfg["moe"]["fabric_config"] == ttnn.FabricConfig.FABRIC_1D_RING and tp_size == 8:
                 summed_experts = ttnn.experimental.deepseek_moe_fast_reduce_nc(
@@ -191,6 +190,8 @@ class MoEDecoderBlock2D(DecoderBlock2DBase):
                     summed_experts, **cfg["moe"]["ring_final_output_reduce_scatter"]
                 )
             else:
+                ccl_moe = cfg["moe"]["ccl"]
+
                 summed_experts = ttnn.sum(
                     combined_out, dim=0, keepdim=True, memory_config=cfg["moe"]["sum_experts_output_memory_config"]
                 )

--- a/models/demos/deepseek_v3/tt/decoder_block/moe_decoder_block_2d.py
+++ b/models/demos/deepseek_v3/tt/decoder_block/moe_decoder_block_2d.py
@@ -121,7 +121,7 @@ class MoEDecoderBlock2D(DecoderBlock2DBase):
         # SharedExpert now always expects collective ops to be handled by caller
         shared_expert_out = SharedExpert.forward_prefill(x_gathered, cfg["shared_expert"])
 
-        mlp_out = ttnn.sum(mlp_out, dim=0, keepdim=True)
+        mlp_out = ttnn.sum(mlp_out, dim=0, keepdim=True, memory_config=cfg["moe"]["sum_experts_output_memory_config"])
         combined_out = ttnn.add(mlp_out, shared_expert_out)
         ttnn.deallocate(mlp_out)
         ttnn.deallocate(shared_expert_out)

--- a/models/demos/deepseek_v3/tt/decoder_block/moe_decoder_block_2d.py
+++ b/models/demos/deepseek_v3/tt/decoder_block/moe_decoder_block_2d.py
@@ -177,6 +177,7 @@ class MoEDecoderBlock2D(DecoderBlock2DBase):
         ttnn.deallocate(mlp_out)
         ttnn.deallocate(shared_expert_out)
 
+        # Handle summing experts
         # Handle reduce_scatter if input was TP-sharded
         if x_dim == hidden_size // tp_size:
             # Single reduce_scatter on combined output using MoE's config for consistency
@@ -186,7 +187,7 @@ class MoEDecoderBlock2D(DecoderBlock2DBase):
                 summed_experts = ttnn.experimental.deepseek_moe_fast_reduce_nc(
                     combined_out,
                     dim=0,
-                    split_size=combined_out[-1] // tp_size,
+                    split_size=int(combined_out[-1] // tp_size),
                     output_memory_config=cfg["moe"]["ring_sum_experts_output_memory_config"],
                 )
                 ttnn.deallocate(combined_out)

--- a/models/demos/deepseek_v3/tt/mlp/mlp.py
+++ b/models/demos/deepseek_v3/tt/mlp/mlp.py
@@ -154,7 +154,9 @@ class MLP(AbstractModule):
             return dim, hidden_dim
 
     @classmethod
-    def prefill_model_config(cls, hf_config: PretrainedConfig, mesh_device: ttnn.Device) -> ModelPrefillConfig:
+    def prefill_model_config(
+        cls, hf_config: PretrainedConfig, mesh_device: ttnn.Device, fabric_config: ttnn.FabricConfig
+    ) -> ModelPrefillConfig:
         """Generate prefill configuration for this module.
 
         Args:
@@ -215,6 +217,7 @@ class MLP(AbstractModule):
         cls,
         hf_config: PretrainedConfig,
         mesh_device: ttnn.Device,
+        fabric_config: ttnn.FabricConfig,
         input_num_cores: int | None = None,
         output_num_cores: int | None = None,
     ) -> ModelDecodeConfig:

--- a/models/demos/deepseek_v3/tt/model/row_batched_model.py
+++ b/models/demos/deepseek_v3/tt/model/row_batched_model.py
@@ -34,7 +34,7 @@ from models.demos.deepseek_v3.utils.shared_state_addon import SharedStateAddOn
 from models.tt_transformers.tt.common import PagedAttentionConfig
 
 
-def get_fabric_config(cls):
+def get_fabric_config():
     return (
         ttnn.FabricConfig.FABRIC_1D_RING if (os.getenv("USE_TORUS_MODE") is not None) else ttnn.FabricConfig.FABRIC_1D
     )

--- a/models/demos/deepseek_v3/tt/model/row_batched_model.py
+++ b/models/demos/deepseek_v3/tt/model/row_batched_model.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import itertools
+import os
 from pathlib import Path
 from typing import Any, Sequence
 
@@ -31,6 +32,12 @@ from models.demos.deepseek_v3.utils.run_config import (
 )
 from models.demos.deepseek_v3.utils.shared_state_addon import SharedStateAddOn
 from models.tt_transformers.tt.common import PagedAttentionConfig
+
+
+def get_fabric_config(cls):
+    return (
+        ttnn.FabricConfig.FABRIC_1D_RING if (os.getenv("USE_TORUS_MODE") is not None) else ttnn.FabricConfig.FABRIC_1D
+    )
 
 
 class RowBatchedModel(SharedStateAddOn, AbstractModule):
@@ -99,12 +106,14 @@ class RowBatchedModel(SharedStateAddOn, AbstractModule):
                 DecoderBlock2D.prefill_model_config(
                     hf_config,
                     mesh_device,
+                    get_fabric_config(),
                 )
             ],
             "moe_decoder_block": [
                 MoEDecoderBlock2D.prefill_model_config(
                     hf_config,
                     mesh_device,
+                    get_fabric_config(),
                 )
             ],
             "norm": DistributedRMSNorm.prefill_model_config(hf_config, mesh_device),
@@ -125,12 +134,14 @@ class RowBatchedModel(SharedStateAddOn, AbstractModule):
                 DecoderBlock2D.decode_model_config(
                     hf_config,
                     mesh_device,
+                    get_fabric_config(),
                 )
             ],
             "moe_decoder_block": [
                 MoEDecoderBlock2D.decode_model_config(
                     hf_config,
                     mesh_device,
+                    get_fabric_config(),
                 )
             ],
             "norm_reshard": ReshardConfig(memory_config=norm_config["input_memory_config"]),

--- a/models/demos/deepseek_v3/tt/moe.py
+++ b/models/demos/deepseek_v3/tt/moe.py
@@ -1,7 +1,6 @@
 # SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC.
 # SPDX-License-Identifier: Apache-2.0
 
-import os
 from pathlib import Path
 
 import torch
@@ -33,10 +32,6 @@ from models.demos.deepseek_v3.utils.run_config import (
     WeightConfig,
 )
 from models.demos.deepseek_v3.utils.shared_state_addon import SharedStateAddOn
-
-fabric_config = (
-    ttnn.FabricConfig.FABRIC_1D_RING if (os.getenv("USE_TORUS_MODE") is not None) else ttnn.FabricConfig.FABRIC_1D
-)
 
 
 class MoE(SharedStateAddOn, AbstractModule):
@@ -145,6 +140,7 @@ class MoE(SharedStateAddOn, AbstractModule):
         cls,
         hf_config: PretrainedConfig,
         mesh_device: ttnn.Device,
+        fabric_config: ttnn.FabricConfig,
         mode: str,
         topk_fallback: bool = False,
     ) -> ModelDecodeConfig | ModelPrefillConfig:
@@ -182,6 +178,7 @@ class MoE(SharedStateAddOn, AbstractModule):
             return {
                 "mesh_device": MeshDeviceStub(mesh_device.shape),
                 "num_devices": mesh_device.get_num_devices(),
+                "fabric_config": fabric_config,
                 "num_experts_per_device": num_experts_per_device,
                 "hidden_size": hf_config.hidden_size,
                 "num_experts_per_tok": hf_config.num_experts_per_tok,
@@ -230,6 +227,7 @@ class MoE(SharedStateAddOn, AbstractModule):
             return {
                 "mesh_device": MeshDeviceStub(mesh_device.shape),
                 "num_devices": mesh_device.get_num_devices(),
+                "fabric_config": fabric_config,
                 "num_experts_per_device": num_experts_per_device,
                 "hidden_size": hf_config.hidden_size,
                 "num_experts_per_tok": hf_config.num_experts_per_tok,
@@ -262,15 +260,23 @@ class MoE(SharedStateAddOn, AbstractModule):
 
     @classmethod
     def decode_model_config(
-        cls, hf_config: PretrainedConfig, mesh_device: ttnn.Device, topk_fallback: bool = False
+        cls,
+        hf_config: PretrainedConfig,
+        mesh_device: ttnn.Device,
+        fabric_config: ttnn.FabricConfig,
+        topk_fallback: bool = False,
     ) -> ModelDecodeConfig:
-        return cls.model_config(hf_config, mesh_device, "decode", topk_fallback=topk_fallback)
+        return cls.model_config(hf_config, mesh_device, fabric_config, "decode", topk_fallback=topk_fallback)
 
     @classmethod
     def prefill_model_config(
-        cls, hf_config: PretrainedConfig, mesh_device: ttnn.Device, topk_fallback: bool = False
+        cls,
+        hf_config: PretrainedConfig,
+        mesh_device: ttnn.Device,
+        fabric_config: ttnn.FabricConfig,
+        topk_fallback: bool = False,
     ) -> ModelPrefillConfig:
-        return cls.model_config(hf_config, mesh_device, "prefill", topk_fallback=topk_fallback)
+        return cls.model_config(hf_config, mesh_device, fabric_config, "prefill", topk_fallback=topk_fallback)
 
     @classmethod
     def forward(cls, x: ttnn.Tensor, cfg: RunDecodeConfig | RunPrefillConfig) -> ttnn.Tensor:
@@ -521,7 +527,7 @@ class MoE(SharedStateAddOn, AbstractModule):
             ccl = cfg["ccl"]
             tp_size = cfg["mesh_device"].shape[1]
 
-            if fabric_config == ttnn.FabricConfig.FABRIC_1D_RING:
+            if cfg["fabric_config"] == ttnn.FabricConfig.FABRIC_1D_RING:
                 output = ttnn.experimental.deepseek_moe_fast_reduce_nc(
                     output,
                     dim=0,

--- a/models/demos/deepseek_v3/tt/moe.py
+++ b/models/demos/deepseek_v3/tt/moe.py
@@ -492,6 +492,27 @@ class MoE(SharedStateAddOn, AbstractModule):
     def _fwd_all_gather(cls, x: ttnn.Tensor, cfg: RunDecodeConfig | RunPrefillConfig) -> ttnn.Tensor:
         return ttnn.experimental.all_gather_async(x, **cfg["ccl"].populate_all_gather_runtime_args(cfg["revert_tp"]))
 
+    def _fwd_reduce_scatter(
+        cls, post_combine_output_tensor: ttnn.Tensor, cfg: RunDecodeConfig | RunPrefillConfig, ccl: CCL
+    ) -> ttnn.Tensor:
+        # Use standard reduce_scatter (composite fallback) to avoid shard shape constraints
+        # encountered by the minimal async path in some decode configurations.
+        rs_cfg = cfg["final_output_reduce_scatter"]
+        rs_kwargs = {
+            "dim": rs_cfg["dim"],
+            "cluster_axis": rs_cfg.get("cluster_axis"),
+            "subdevice_id": rs_cfg.get("subdevice_id"),
+            "memory_config": rs_cfg.get("memory_config"),
+            "intermediate_memory_config": rs_cfg.get("intermediate_memory_config"),
+            "num_links": rs_cfg.get("num_links"),
+            "topology": rs_cfg.get("topology"),
+            "chunks_per_sync": rs_cfg.get("chunks_per_sync"),
+            "num_workers_per_link": rs_cfg.get("num_workers_per_link"),
+            "num_buffers_per_channel": rs_cfg.get("num_buffers_per_channel"),
+        }
+        rs_kwargs = {k: v for k, v in rs_kwargs.items() if v is not None}
+        return ttnn.reduce_scatter(post_combine_output_tensor, **rs_kwargs)
+
     @classmethod
     def forward_prefill(
         cls, x: ttnn.Tensor, cfg: RunPrefillConfig, handle_tensor_parallel: bool = False
@@ -507,9 +528,7 @@ class MoE(SharedStateAddOn, AbstractModule):
         if handle_tensor_parallel:
             ccl = cfg["ccl"]
             output = ttnn.sum(output, dim=0, keepdim=True, memory_config=cfg["sum_experts_output_memory_config"])
-            output = ttnn.experimental.reduce_scatter_minimal_async(
-                output, **ccl.populate_reduce_scatter_runtime_args(cfg["final_output_reduce_scatter"])
-            )
+            output = cls._fwd_reduce_scatter(output, cfg, ccl)
 
         return output
 
@@ -539,8 +558,6 @@ class MoE(SharedStateAddOn, AbstractModule):
                 )
             else:
                 output = ttnn.sum(output, dim=0, keepdim=True, memory_config=cfg["sum_experts_output_memory_config"])
-                output = ttnn.experimental.reduce_scatter_minimal_async(
-                    output, **ccl.populate_reduce_scatter_runtime_args(cfg["final_output_reduce_scatter"])
-                )
+                output = cls._fwd_reduce_scatter(output, cfg, ccl)
 
         return output

--- a/models/demos/deepseek_v3/tt/moe.py
+++ b/models/demos/deepseek_v3/tt/moe.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC.
 # SPDX-License-Identifier: Apache-2.0
 
+import os
 from pathlib import Path
 
 import torch
@@ -228,7 +229,7 @@ class MoE(SharedStateAddOn, AbstractModule):
                 "ring_final_output_reduce_scatter": DeepseekMoEReduceScatterConfig(
                     cluster_axis=1,
                     dim=3,
-                    memory_config=input_output_memory_config,
+                    output_memory_config=input_output_memory_config,
                 ),
                 "revert_tp": AllGatherAsyncConfig(
                     mesh_device=MeshDeviceStub(mesh_device.shape),
@@ -543,10 +544,12 @@ class MoE(SharedStateAddOn, AbstractModule):
                 output = ttnn.experimental.deepseek_moe_fast_reduce_nc(
                     output,
                     dim=0,
-                    split_size=int(output[-1] // tp_size),
+                    split_size=int(output.shape[-1] // tp_size),
                     output_memory_config=cfg["ring_sum_experts_output_memory_config"],
                 )
-                output = ttnn.experimental.deepseek_moe_reduce_scatter(output, cfg["ring_final_output_reduce_scatter"])
+                output = ttnn.experimental.deepseek_moe_reduce_scatter(
+                    output, **cfg["ring_final_output_reduce_scatter"]
+                )
             else:
                 output = ttnn.sum(output, dim=0, keepdim=True, memory_config=cfg["sum_experts_output_memory_config"])
                 output = ttnn.experimental.reduce_scatter_minimal_async(

--- a/models/demos/deepseek_v3/tt/moe.py
+++ b/models/demos/deepseek_v3/tt/moe.py
@@ -178,27 +178,6 @@ class MoE(SharedStateAddOn, AbstractModule):
                 use_height_and_width_as_shard_shape=True,
             )
 
-            NUM_DECODE_RS_SHARD_CORES = 7
-            ring_sum_experts_output_memory_config = ttnn.MemoryConfig(
-                ttnn.BufferType.L1,
-                ttnn.NdShardSpec(
-                    ttnn.Shape([1, 1, USERS_PER_ROW, HIDDEN_SIZE // TP_SIZE // NUM_DECODE_RS_SHARD_CORES]),
-                    ttnn.CoreRangeSet(
-                        [
-                            ttnn.CoreRange(ttnn.CoreCoord(2, 0), ttnn.CoreCoord(2, 0)),
-                            ttnn.CoreRange(ttnn.CoreCoord(2, 5), ttnn.CoreCoord(2, 5)),
-                            ttnn.CoreRange(ttnn.CoreCoord(3, 0), ttnn.CoreCoord(3, 0)),
-                            ttnn.CoreRange(ttnn.CoreCoord(3, 5), ttnn.CoreCoord(3, 5)),
-                            ttnn.CoreRange(ttnn.CoreCoord(6, 0), ttnn.CoreCoord(6, 0)),
-                            ttnn.CoreRange(ttnn.CoreCoord(6, 5), ttnn.CoreCoord(6, 5)),
-                            ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(0, 0)),
-                        ]
-                    ),
-                    ttnn.ShardOrientation.ROW_MAJOR,
-                    ttnn.ShardDistributionStrategy.ROUND_ROBIN_1D,
-                ),
-            )
-
             # Construct the config
             return {
                 "mesh_device": MeshDeviceStub(mesh_device.shape),
@@ -225,7 +204,9 @@ class MoE(SharedStateAddOn, AbstractModule):
                     dim=3,
                     memory_config=input_output_memory_config,
                 ),
-                "ring_sum_experts_output_memory_config": ring_sum_experts_output_memory_config,
+                "ring_sum_experts_output_memory_config": DeepseekMoEReduceScatterConfig.create_default_input_memory_config(
+                    USERS_PER_ROW, HIDDEN_SIZE, TP_SIZE
+                ),
                 "ring_final_output_reduce_scatter": DeepseekMoEReduceScatterConfig(
                     cluster_axis=1,
                     dim=3,

--- a/models/demos/deepseek_v3/tt/moe.py
+++ b/models/demos/deepseek_v3/tt/moe.py
@@ -534,7 +534,7 @@ class MoE(SharedStateAddOn, AbstractModule):
         # Run the forward pass
         output = cls.forward(x, cfg)
 
-        # Handle sum_experts reduce_scatter if tensor parallel is enabled
+        # Handle sum_experts annd reduce_scatter if tensor parallel is enabled
         if handle_tensor_parallel:
             ccl = cfg["ccl"]
             tp_size = cfg["mesh_device"].shape[1]
@@ -543,7 +543,7 @@ class MoE(SharedStateAddOn, AbstractModule):
                 output = ttnn.experimental.deepseek_moe_fast_reduce_nc(
                     output,
                     dim=0,
-                    split_size=output[-1] // tp_size,
+                    split_size=int(output[-1] // tp_size),
                     output_memory_config=cfg["ring_sum_experts_output_memory_config"],
                 )
                 output = ttnn.experimental.deepseek_moe_reduce_scatter(output, cfg["ring_final_output_reduce_scatter"])

--- a/models/demos/deepseek_v3/tt/moe.py
+++ b/models/demos/deepseek_v3/tt/moe.py
@@ -15,6 +15,7 @@ from models.demos.deepseek_v3.utils.config_dataclass import (
     AllGatherAsyncConfig,
     AllToAllCombineConfig,
     AllToAllDispatchConfig,
+    DeepseekMoEReduceScatterConfig,
     MeshDeviceStub,
     MulConfig,
     ReduceScatterAsyncMinimalConfig,
@@ -31,6 +32,10 @@ from models.demos.deepseek_v3.utils.run_config import (
     WeightConfig,
 )
 from models.demos.deepseek_v3.utils.shared_state_addon import SharedStateAddOn
+
+fabric_config = (
+    ttnn.FabricConfig.FABRIC_1D_RING if (os.getenv("USE_TORUS_MODE") is not None) else ttnn.FabricConfig.FABRIC_1D
+)
 
 
 class MoE(SharedStateAddOn, AbstractModule):
@@ -172,6 +177,27 @@ class MoE(SharedStateAddOn, AbstractModule):
                 use_height_and_width_as_shard_shape=True,
             )
 
+            NUM_DECODE_RS_SHARD_CORES = 7
+            ring_sum_experts_output_memory_config = ttnn.MemoryConfig(
+                ttnn.BufferType.L1,
+                ttnn.NdShardSpec(
+                    ttnn.Shape([1, 1, USERS_PER_ROW, HIDDEN_SIZE // TP_SIZE // NUM_DECODE_RS_SHARD_CORES]),
+                    ttnn.CoreRangeSet(
+                        [
+                            ttnn.CoreRange(ttnn.CoreCoord(2, 0), ttnn.CoreCoord(2, 0)),
+                            ttnn.CoreRange(ttnn.CoreCoord(2, 5), ttnn.CoreCoord(2, 5)),
+                            ttnn.CoreRange(ttnn.CoreCoord(3, 0), ttnn.CoreCoord(3, 0)),
+                            ttnn.CoreRange(ttnn.CoreCoord(3, 5), ttnn.CoreCoord(3, 5)),
+                            ttnn.CoreRange(ttnn.CoreCoord(6, 0), ttnn.CoreCoord(6, 0)),
+                            ttnn.CoreRange(ttnn.CoreCoord(6, 5), ttnn.CoreCoord(6, 5)),
+                            ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(0, 0)),
+                        ]
+                    ),
+                    ttnn.ShardOrientation.ROW_MAJOR,
+                    ttnn.ShardDistributionStrategy.ROUND_ROBIN_1D,
+                ),
+            )
+
             # Construct the config
             return {
                 "mesh_device": MeshDeviceStub(mesh_device.shape),
@@ -192,7 +218,14 @@ class MoE(SharedStateAddOn, AbstractModule):
                 "output_memory_config": input_output_memory_config,
                 "all_to_all_dispatch": AllToAllDispatchConfig(cluster_axis=0, memory_config=memory_config),
                 "all_to_all_combine": AllToAllCombineConfig(cluster_axis=0, memory_config=memory_config),
+                "sum_experts_output_memory_config": memory_config,
                 "final_output_reduce_scatter": ReduceScatterAsyncMinimalConfig(
+                    cluster_axis=1,
+                    dim=3,
+                    memory_config=input_output_memory_config,
+                ),
+                "ring_sum_experts_output_memory_config": ring_sum_experts_output_memory_config,
+                "ring_final_output_reduce_scatter": DeepseekMoEReduceScatterConfig(
                     cluster_axis=1,
                     dim=3,
                     memory_config=input_output_memory_config,
@@ -231,6 +264,7 @@ class MoE(SharedStateAddOn, AbstractModule):
                 "output_memory_config": memory_config,
                 "all_to_all_dispatch": AllToAllDispatchConfig(cluster_axis=0, memory_config=memory_config),
                 "all_to_all_combine": AllToAllCombineConfig(cluster_axis=0, memory_config=memory_config),
+                "sum_experts_output_memory_config": memory_config,
                 "final_output_reduce_scatter": ReduceScatterAsyncMinimalConfig(
                     cluster_axis=1,
                     dim=3,
@@ -331,7 +365,7 @@ class MoE(SharedStateAddOn, AbstractModule):
             seq_len,
         )
 
-        # Note: reduce_scatter is handled by the caller (decoder block or test)
+        # Note: sum_experts and reduce_scatter is handled by the caller (decoder block or test)
 
         return post_combine_output_tensor
 
@@ -453,7 +487,6 @@ class MoE(SharedStateAddOn, AbstractModule):
             )
             ttnn.deallocate(topk_weights_chunk)
 
-            post_combine_output_tensor = ttnn.sum(post_combine_output_tensor, dim=0, keepdim=True)
             output_chunks.append(post_combine_output_tensor)
 
         if len(output_chunks) == 1:
@@ -466,28 +499,6 @@ class MoE(SharedStateAddOn, AbstractModule):
         ttnn.deallocate(x_rm)
         ttnn.deallocate(topk_experts_indices_rm)
         return post_combine_output_tensor
-
-    @classmethod
-    def _fwd_reduce_scatter(
-        cls, post_combine_output_tensor: ttnn.Tensor, cfg: RunDecodeConfig | RunPrefillConfig, ccl: CCL
-    ) -> ttnn.Tensor:
-        # Use standard reduce_scatter (composite fallback) to avoid shard shape constraints
-        # encountered by the minimal async path in some decode configurations.
-        rs_cfg = cfg["final_output_reduce_scatter"]
-        rs_kwargs = {
-            "dim": rs_cfg["dim"],
-            "cluster_axis": rs_cfg.get("cluster_axis"),
-            "subdevice_id": rs_cfg.get("subdevice_id"),
-            "memory_config": rs_cfg.get("memory_config"),
-            "intermediate_memory_config": rs_cfg.get("intermediate_memory_config"),
-            "num_links": rs_cfg.get("num_links"),
-            "topology": rs_cfg.get("topology"),
-            "chunks_per_sync": rs_cfg.get("chunks_per_sync"),
-            "num_workers_per_link": rs_cfg.get("num_workers_per_link"),
-            "num_buffers_per_channel": rs_cfg.get("num_buffers_per_channel"),
-        }
-        rs_kwargs = {k: v for k, v in rs_kwargs.items() if v is not None}
-        return ttnn.reduce_scatter(post_combine_output_tensor, **rs_kwargs)
 
     @classmethod
     def _fwd_all_gather(cls, x: ttnn.Tensor, cfg: RunDecodeConfig | RunPrefillConfig) -> ttnn.Tensor:
@@ -504,10 +515,13 @@ class MoE(SharedStateAddOn, AbstractModule):
         # Run the forward pass
         output = cls.forward(x, cfg)
 
-        # Handle reduce_scatter if tensor parallel is enabled
+        # Handle sum_experts and reduce_scatter if tensor parallel is enabled
         if handle_tensor_parallel:
             ccl = cfg["ccl"]
-            output = cls._fwd_reduce_scatter(output, cfg, ccl)
+            output = ttnn.sum(output, dim=0, keepdim=True, memory_config=cfg["sum_experts_output_memory_config"])
+            output = ttnn.experimental.reduce_scatter_minimal_async(
+                output, **ccl.populate_reduce_scatter_runtime_args(cfg["final_output_reduce_scatter"])
+            )
 
         return output
 
@@ -520,9 +534,23 @@ class MoE(SharedStateAddOn, AbstractModule):
         # Run the forward pass
         output = cls.forward(x, cfg)
 
-        # Handle reduce_scatter if tensor parallel is enabled
+        # Handle sum_experts reduce_scatter if tensor parallel is enabled
         if handle_tensor_parallel:
             ccl = cfg["ccl"]
-            output = cls._fwd_reduce_scatter(output, cfg, ccl)
+            tp_size = cfg["mesh_device"].shape[1]
+
+            if fabric_config == ttnn.FabricConfig.FABRIC_1D_RING:
+                output = ttnn.experimental.deepseek_moe_fast_reduce_nc(
+                    output,
+                    dim=0,
+                    split_size=output[-1] // tp_size,
+                    output_memory_config=cfg["ring_sum_experts_output_memory_config"],
+                )
+                output = ttnn.experimental.deepseek_moe_reduce_scatter(output, cfg["ring_final_output_reduce_scatter"])
+            else:
+                output = ttnn.sum(output, dim=0, keepdim=True, memory_config=cfg["sum_experts_output_memory_config"])
+                output = ttnn.experimental.reduce_scatter_minimal_async(
+                    output, **ccl.populate_reduce_scatter_runtime_args(cfg["final_output_reduce_scatter"])
+                )
 
         return output

--- a/models/demos/deepseek_v3/tt/moe.py
+++ b/models/demos/deepseek_v3/tt/moe.py
@@ -527,11 +527,11 @@ class MoE(SharedStateAddOn, AbstractModule):
             ccl = cfg["ccl"]
             tp_size = cfg["mesh_device"].shape[1]
 
-            if cfg["fabric_config"] == ttnn.FabricConfig.FABRIC_1D_RING:
+            if cfg["fabric_config"] == ttnn.FabricConfig.FABRIC_1D_RING and tp_size == 8:
                 output = ttnn.experimental.deepseek_moe_fast_reduce_nc(
                     output,
                     dim=0,
-                    split_size=int(output.shape[-1] // tp_size),
+                    split_size=output.shape[-1] // tp_size,
                     output_memory_config=cfg["ring_sum_experts_output_memory_config"],
                 )
                 output = ttnn.experimental.deepseek_moe_reduce_scatter(

--- a/models/demos/deepseek_v3/tt/moe.py
+++ b/models/demos/deepseek_v3/tt/moe.py
@@ -535,7 +535,7 @@ class MoE(SharedStateAddOn, AbstractModule):
         # Run the forward pass
         output = cls.forward(x, cfg)
 
-        # Handle sum_experts annd reduce_scatter if tensor parallel is enabled
+        # Handle sum_experts and reduce_scatter if tensor parallel is enabled
         if handle_tensor_parallel:
             ccl = cfg["ccl"]
             tp_size = cfg["mesh_device"].shape[1]

--- a/models/demos/deepseek_v3/tt/moe.py
+++ b/models/demos/deepseek_v3/tt/moe.py
@@ -492,6 +492,7 @@ class MoE(SharedStateAddOn, AbstractModule):
     def _fwd_all_gather(cls, x: ttnn.Tensor, cfg: RunDecodeConfig | RunPrefillConfig) -> ttnn.Tensor:
         return ttnn.experimental.all_gather_async(x, **cfg["ccl"].populate_all_gather_runtime_args(cfg["revert_tp"]))
 
+    @classmethod
     def _fwd_reduce_scatter(
         cls, post_combine_output_tensor: ttnn.Tensor, cfg: RunDecodeConfig | RunPrefillConfig, ccl: CCL
     ) -> ttnn.Tensor:

--- a/models/demos/deepseek_v3/utils/config_dataclass.py
+++ b/models/demos/deepseek_v3/utils/config_dataclass.py
@@ -212,10 +212,22 @@ class DeepseekMoEReduceScatterConfig(OpConfigBase):
     ) -> ttnn.MemoryConfig:
         NUM_DECODE_RS_SHARD_CORES = 7
 
+        if hidden_size % tp_size != 0:
+            raise ValueError(
+                f"DeepseekMoEReduceScatterConfig.create_default_input_memory_config: hidden_size ({hidden_size}) must be divisible by tp_size ({tp_size})"
+            )
+        slice_size = hidden_size // tp_size
+
+        if slice_size % NUM_DECODE_RS_SHARD_CORES != 0:
+            raise ValueError(
+                f"DeepseekMoEReduceScatterConfig.create_default_input_memory_config: slice_size ({slice_size}) must be divisible by number of op worker cores ({NUM_DECODE_RS_SHARD_CORES})"
+            )
+        per_core_shard_width = slice_size // NUM_DECODE_RS_SHARD_CORES
+
         return ttnn.MemoryConfig(
             ttnn.BufferType.L1,
             ttnn.NdShardSpec(
-                ttnn.Shape([1, 1, users_per_row, hidden_size // tp_size // NUM_DECODE_RS_SHARD_CORES]),
+                ttnn.Shape([1, 1, users_per_row, per_core_shard_width]),
                 ttnn.CoreRangeSet(
                     [
                         ttnn.CoreRange(ttnn.CoreCoord(2, 0), ttnn.CoreCoord(2, 0)),

--- a/models/demos/deepseek_v3/utils/config_dataclass.py
+++ b/models/demos/deepseek_v3/utils/config_dataclass.py
@@ -206,6 +206,32 @@ class ReduceScatterAsyncMinimalConfig(OpConfigBase):
 class DeepseekMoEReduceScatterConfig(OpConfigBase):
     """Common parameters for a ttnn.experimental.deepseek_moe_reduce_scatter op"""
 
+    @classmethod
+    def create_default_input_memory_config(
+        cls, users_per_row: int, hidden_size: int, tp_size: int
+    ) -> ttnn.MemoryConfig:
+        NUM_DECODE_RS_SHARD_CORES = 7
+
+        return ttnn.MemoryConfig(
+            ttnn.BufferType.L1,
+            ttnn.NdShardSpec(
+                ttnn.Shape([1, 1, users_per_row, hidden_size // tp_size // NUM_DECODE_RS_SHARD_CORES]),
+                ttnn.CoreRangeSet(
+                    [
+                        ttnn.CoreRange(ttnn.CoreCoord(2, 0), ttnn.CoreCoord(2, 0)),
+                        ttnn.CoreRange(ttnn.CoreCoord(2, 5), ttnn.CoreCoord(2, 5)),
+                        ttnn.CoreRange(ttnn.CoreCoord(3, 0), ttnn.CoreCoord(3, 0)),
+                        ttnn.CoreRange(ttnn.CoreCoord(3, 5), ttnn.CoreCoord(3, 5)),
+                        ttnn.CoreRange(ttnn.CoreCoord(6, 0), ttnn.CoreCoord(6, 0)),
+                        ttnn.CoreRange(ttnn.CoreCoord(6, 5), ttnn.CoreCoord(6, 5)),
+                        ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(0, 0)),
+                    ]
+                ),
+                ttnn.ShardOrientation.ROW_MAJOR,
+                ttnn.ShardDistributionStrategy.ROUND_ROBIN_1D,
+            ),
+        )
+
     output_memory_config: ttnn.MemoryConfig
     dim: int
     num_links: int = 4

--- a/models/demos/deepseek_v3/utils/config_dataclass.py
+++ b/models/demos/deepseek_v3/utils/config_dataclass.py
@@ -203,6 +203,17 @@ class ReduceScatterAsyncMinimalConfig(OpConfigBase):
 
 
 @dataclass
+class DeepseekMoEReduceScatterConfig(OpConfigBase):
+    """Common parameters for a ttnn.experimental.deepseek_moe_reduce_scatter op"""
+
+    output_memory_config: ttnn.MemoryConfig
+    dim: int
+    num_links: int = 4
+    topology: ttnn.Topology = ttnn.Topology.Ring
+    cluster_axis: int | None = None
+
+
+@dataclass
 class PointToPointConfig(OpConfigBase):
     """Common parameters for a ttnn.point_to_point op"""
 

--- a/tests/nightly/tg/ccl/test_deepseek_moe_reduce_scatter_6U.py
+++ b/tests/nightly/tg/ccl/test_deepseek_moe_reduce_scatter_6U.py
@@ -86,7 +86,18 @@ from tests.nightly.t3000.ccl.test_deepseek_moe_reduce_scatter import run_deepsee
                 ttnn.BufferType.L1,
                 ttnn.NdShardSpec(
                     ttnn.Shape([1, 1, 32, 128]),
-                    ttnn.CoreRangeSet([ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(7, 0))]),
+                    ttnn.CoreRangeSet(
+                        [
+                            ttnn.CoreRange(ttnn.CoreCoord(2, 0), ttnn.CoreCoord(2, 0)),
+                            ttnn.CoreRange(ttnn.CoreCoord(2, 5), ttnn.CoreCoord(2, 5)),
+                            ttnn.CoreRange(ttnn.CoreCoord(3, 0), ttnn.CoreCoord(3, 0)),
+                            ttnn.CoreRange(ttnn.CoreCoord(3, 5), ttnn.CoreCoord(3, 5)),
+                            ttnn.CoreRange(ttnn.CoreCoord(6, 0), ttnn.CoreCoord(6, 0)),
+                            ttnn.CoreRange(ttnn.CoreCoord(6, 5), ttnn.CoreCoord(6, 5)),
+                            ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(0, 0)),
+                            ttnn.CoreRange(ttnn.CoreCoord(0, 5), ttnn.CoreCoord(0, 5)),
+                        ]
+                    ),
                     ttnn.ShardOrientation.ROW_MAJOR,
                     ttnn.ShardDistributionStrategy.ROUND_ROBIN_1D,
                 ),
@@ -110,8 +121,8 @@ from tests.nightly.t3000.ccl.test_deepseek_moe_reduce_scatter import run_deepsee
                             ttnn.CoreRange(ttnn.CoreCoord(3, 5), ttnn.CoreCoord(3, 5)),
                             ttnn.CoreRange(ttnn.CoreCoord(6, 0), ttnn.CoreCoord(6, 0)),
                             ttnn.CoreRange(ttnn.CoreCoord(6, 5), ttnn.CoreCoord(6, 5)),
-                            ttnn.CoreRange(ttnn.CoreCoord(7, 0), ttnn.CoreCoord(7, 0)),
-                            # ttnn.CoreRange(ttnn.CoreCoord(7, 5), ttnn.CoreCoord(7, 5)), # hypothetical final core
+                            ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(0, 0)),
+                            # ttnn.CoreRange(ttnn.CoreCoord(0, 5), ttnn.CoreCoord(0, 5)), # hypothetical final core
                         ]
                     ),
                     ttnn.ShardOrientation.ROW_MAJOR,
@@ -143,7 +154,14 @@ from tests.nightly.t3000.ccl.test_deepseek_moe_reduce_scatter import run_deepsee
 @pytest.mark.parametrize(
     "device_params, rs_topology",
     [
-        ({"fabric_config": ttnn.FabricConfig.FABRIC_1D_RING, "trace_region_size": 1531456}, ttnn.Topology.Ring),
+        (
+            {
+                "fabric_config": ttnn.FabricConfig.FABRIC_1D_RING,
+                "dispatch_core_axis": ttnn.DispatchCoreAxis.COL,
+                "trace_region_size": 1531456,
+            },
+            ttnn.Topology.Ring,
+        ),
     ],
     indirect=["device_params"],
     ids=["fabric_ring"],

--- a/tests/nightly/tg/ccl/test_deepseek_moe_reduce_scatter_6U.py
+++ b/tests/nightly/tg/ccl/test_deepseek_moe_reduce_scatter_6U.py
@@ -122,7 +122,6 @@ from tests.nightly.t3000.ccl.test_deepseek_moe_reduce_scatter import run_deepsee
                             ttnn.CoreRange(ttnn.CoreCoord(6, 0), ttnn.CoreCoord(6, 0)),
                             ttnn.CoreRange(ttnn.CoreCoord(6, 5), ttnn.CoreCoord(6, 5)),
                             ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(0, 0)),
-                            # ttnn.CoreRange(ttnn.CoreCoord(0, 5), ttnn.CoreCoord(0, 5)), # hypothetical final core
                         ]
                     ),
                     ttnn.ShardOrientation.ROW_MAJOR,

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/deepseek_moe_reduce_scatter/device/deepseek_moe_reduce_scatter_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/deepseek_moe_reduce_scatter/device/deepseek_moe_reduce_scatter_program_factory.cpp
@@ -35,7 +35,7 @@ CoreCoord choose_additional_core(
         CoreCoord(2, 5),
         CoreCoord(3, 5),
         CoreCoord(6, 5),
-        CoreCoord(7, 5),
+        CoreCoord(0, 5),
     };
 
     // try optimal core first

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/deepseek_moe_fast_reduce_nc/device/deepseek_moe_fast_reduce_nc_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/deepseek_moe_fast_reduce_nc/device/deepseek_moe_fast_reduce_nc_program_factory.cpp
@@ -284,7 +284,7 @@ void DeepseekMoEFastReduceNCProgramFactory::override_runtime_arguments(
 
         auto& writer_kernel_args = writer_kernel_args_by_core[core.x][core.y];
         const uint32_t output_tensor_start_idx = 4;
-        for (unsigned j = 0; j < output_tensors.size() - 1; ++j) {
+        for (unsigned j = 0; j < output_tensors.size(); ++j) {
             writer_kernel_args[output_tensor_start_idx + j] = output_tensors.at(j).buffer()->address();
         }
     }


### PR DESCRIPTION
### Ticket
Part of https://github.com/tenstorrent/tt-metal/issues/37288

### What's changed
- Integrate optimized RS designed for decode specific shape 
- Measured performance is ~25 us
  - Expected to drop another 1-5 us following an optimization by the fabric team
 - Requirements to use optimized op:
   - 1D_Ring fabric config
   - Previous op must write it's output to a custom configuration that the reduce_scatter can then ingest - `deepseek_moe_fast_reduce_nc` was designed explicitly for this and must run immediately before the reduce scatter
   
Deepseek pipeline: https://github.com/tenstorrent/tt-metal/actions/runs/22929253564

Testing:
- Ran the following deepseek to confirm the model with line fabric still functions correctly
  - https://github.com/tenstorrent/tt-metal/actions/runs/22506905412
- Ran the following tests locally with ring fabric manually enabled:
  - `pytest models/demos/deepseek_v3/tests/test_moe.py -k decode`
  - `pytest models/demos/deepseek_v3/tests/test_decoder_block.py -k decode`
  - `pytest models/demos/deepseek_v3/tests/test_model.py -k decode`

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=grechsteiner/rs-integration)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:grechsteiner/rs-integration)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=grechsteiner/rs-integration)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:grechsteiner/rs-integration)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=grechsteiner/rs-integration)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:grechsteiner/rs-integration)
- [ ] New/Existing tests provide coverage for changes


#### Model tests

If your changes cover model-related code, you should run tests corresponding to affected models and platforms (Single card, T3K, Galaxy). "Choose your pipeline" workflows facilitate running multiple kinds of tests in a single run. Each offers `models-mandatory` and `models-extended` presets.
The former includes a minimal set of tests, to be run always. The latter extends that with additional ones - use your best judgement in deciding which is the most appropriate for your PR.

- [ ] [![(Single) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=grechsteiner/rs-integration)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:grechsteiner/rs-integration)
  - [ ] `models-mandatory` preset (runs: [Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) and [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(T3K) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=grechsteiner/rs-integration)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:grechsteiner/rs-integration)
  - [ ] `models-mandatory` preset (runs: [Unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-model-perf-tests.yaml) tests)
  - [ ] other selection - specify runs

- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=grechsteiner/rs-integration)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:grechsteiner/rs-integration)
  - [ ] `models-mandatory` preset (runs: [Quick tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-quick.yaml))
  - [ ] `models-extended` preset (runs: the mandatory tests, plus [Demo](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-demo-tests.yaml) and [Model perf](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml) tests)
  - [ ] other selection - specify runs
