### PR TITLE
[tt-train] Gate-up fused SwiGLU forward (2-step) + path choice

### DIFF
--- a/tt-train/sources/ttml/CMakeLists.txt
+++ b/tt-train/sources/ttml/CMakeLists.txt
@@ -163,7 +163,7 @@ set(METAL_OPS_FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/metal/ops/swiglu_fw/swiglu_fw.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/metal/ops/swiglu_fw/device/swiglu_fw_device_operation.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/metal/ops/swiglu_fw/device/swiglu_fw_program_factory.cpp
-    # SwiGLU Gate-Up (Design A Step 1: M = SiLU(X@W1) * (X@W3))
+    # SwiGLU Gate-Up: M = SiLU(X@W1) * (X@W3)
     ${CMAKE_CURRENT_SOURCE_DIR}/metal/ops/swiglu_gate_up/swiglu_gate_up.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/metal/ops/swiglu_gate_up/device/swiglu_gate_up_device_operation.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/metal/ops/swiglu_gate_up/device/swiglu_gate_up_program_factory.cpp

--- a/tt-train/sources/ttml/CMakeLists.txt
+++ b/tt-train/sources/ttml/CMakeLists.txt
@@ -163,6 +163,10 @@ set(METAL_OPS_FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/metal/ops/swiglu_fw/swiglu_fw.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/metal/ops/swiglu_fw/device/swiglu_fw_device_operation.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/metal/ops/swiglu_fw/device/swiglu_fw_program_factory.cpp
+    # SwiGLU Gate-Up (Design A Step 1: M = SiLU(X@W1) * (X@W3))
+    ${CMAKE_CURRENT_SOURCE_DIR}/metal/ops/swiglu_gate_up/swiglu_gate_up.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/metal/ops/swiglu_gate_up/device/swiglu_gate_up_device_operation.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/metal/ops/swiglu_gate_up/device/swiglu_gate_up_program_factory.cpp
     # AdamW Optimizer (consolidated: supports both half and full precision)
     ${CMAKE_CURRENT_SOURCE_DIR}/metal/optimizers/adamw/adamw.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/metal/optimizers/adamw/device/adamw_device_operation.cpp

--- a/tt-train/sources/ttml/metal/common/compute_utils.hpp
+++ b/tt-train/sources/ttml/metal/common/compute_utils.hpp
@@ -46,34 +46,46 @@ inline void pack_and_push_block(const uint32_t cb_output, const uint32_t block_s
 
 /**
  * Pack a block of tiles from consecutive DEST registers (0..num_tiles-1) to a CB at
- * out-of-order indices (dst_start_index + 0, ..., dst_start_index + num_tiles - 1).
+ * out-of-order indices (dst_start_index, ..., dst_start_index + num_tiles - 1).
+ * Does NOT reserve or push; caller must cb_reserve_back / cb_push_back as needed.
+ * Does NOT change pack reconfig; caller is responsible for data format and L1 state.
+ * Use this when writing directly into a CB (e.g. storing matmul results without
+ * hardware L1 accumulation). For L1 accumulation, use pack_l1_acc_block().
+ * NOTE: Call after tile_regs_commit().
+ *
+ * @param cb_idx Output circular buffer (already reserved by caller)
+ * @param num_tiles Number of tiles to pack (consecutive registers 0..num_tiles-1)
+ * @param dst_start_index First output tile index in the reserved CB region
+ */
+inline void pack_block_to_cb(const uint32_t cb_idx, const uint32_t num_tiles, const uint32_t dst_start_index) {
+    tile_regs_wait();
+    for (uint32_t block_idx = 0; block_idx < num_tiles; ++block_idx) {
+        pack_tile</* out_of_order_output = */ true>(block_idx, cb_idx, dst_start_index + block_idx);
+    }
+    tile_regs_release();
+}
+
+/**
+ * Pack a block of tiles from consecutive DEST registers (0..num_tiles-1) into a CB
+ * using L1 accumulation. Configures pack_reconfig_data_format and pack_reconfig_l1_acc;
+ * first_block selects zero accumulator (true) vs accumulate (false).
  * Does NOT reserve or push; caller must cb_reserve_back / cb_push_back as needed.
  * NOTE: Call after tile_regs_commit().
  *
  * @param cb_idx Output circular buffer (already reserved by caller when accumulating)
- * @param first_block When use_l1_acc is true: true = zero accumulator, false = accumulate
+ * @param first_block true = zero accumulator before packing, false = accumulate into existing
  * @param num_tiles Number of tiles to pack (consecutive registers 0..num_tiles-1)
  * @param dst_start_index First output tile index in the reserved CB region
- * @param use_l1_acc If true, set pack_reconfig_data_format and pack_reconfig_l1_acc.
- *                  If false, do not touch reconfig (caller manages it).
  */
 inline void pack_l1_acc_block(
-    const uint32_t cb_idx,
-    const bool first_block,
-    const uint32_t num_tiles,
-    const uint32_t dst_start_index,
-    const bool use_l1_acc = true) {
+    const uint32_t cb_idx, const bool first_block, const uint32_t num_tiles, const uint32_t dst_start_index) {
     tile_regs_wait();
-    if (use_l1_acc) {
-        pack_reconfig_data_format(cb_idx);
-        pack_reconfig_l1_acc(first_block ? 0 : 1U);
-    }
+    pack_reconfig_data_format(cb_idx);
+    pack_reconfig_l1_acc(first_block ? 0 : 1U);
     for (uint32_t block_idx = 0; block_idx < num_tiles; ++block_idx) {
         pack_tile</* out_of_order_output = */ true>(block_idx, cb_idx, dst_start_index + block_idx);
     }
-    if (use_l1_acc) {
-        pack_reconfig_l1_acc(0);
-    }
+    pack_reconfig_l1_acc(0);
     tile_regs_release();
 }
 

--- a/tt-train/sources/ttml/metal/common/compute_utils.hpp
+++ b/tt-train/sources/ttml/metal/common/compute_utils.hpp
@@ -45,26 +45,35 @@ inline void pack_and_push_block(const uint32_t cb_output, const uint32_t block_s
 }
 
 /**
- * Pack a block of tiles from consecutive DEST registers to a CB using L1 accumulation.
- * Does NOT reserve or push; caller must cb_reserve_back once before the first block and
- * cb_push_back once after all blocks are accumulated.
- * NOTE: Call after tile_regs_commit(). Waits for tile regs inside (same as other pack helpers).
- * Uses pack_tile with out_of_order_output so each tile writes to its CB index (dst_start_index + block_idx).
+ * Pack a block of tiles from consecutive DEST registers (0..num_tiles-1) to a CB at
+ * out-of-order indices (dst_start_index + 0, ..., dst_start_index + num_tiles - 1).
+ * Does NOT reserve or push; caller must cb_reserve_back / cb_push_back as needed.
+ * NOTE: Call after tile_regs_commit().
  *
- * @param cb_idx Output circular buffer (already reserved by caller for full accumulation)
- * @param first_block true for the first block (zero accumulator), false to accumulate into existing CB data
+ * @param cb_idx Output circular buffer (already reserved by caller when accumulating)
+ * @param first_block When use_l1_acc is true: true = zero accumulator, false = accumulate
  * @param num_tiles Number of tiles to pack (consecutive registers 0..num_tiles-1)
  * @param dst_start_index First output tile index in the reserved CB region
+ * @param use_l1_acc If true, set pack_reconfig_data_format and pack_reconfig_l1_acc.
+ *                  If false, do not touch reconfig (caller manages it).
  */
 inline void pack_l1_acc_block(
-    const uint32_t cb_idx, const bool first_block, const uint32_t num_tiles, const uint32_t dst_start_index) {
+    const uint32_t cb_idx,
+    const bool first_block,
+    const uint32_t num_tiles,
+    const uint32_t dst_start_index,
+    const bool use_l1_acc = true) {
     tile_regs_wait();
-    pack_reconfig_data_format(cb_idx);
-    pack_reconfig_l1_acc(first_block ? 0 : 1U);
+    if (use_l1_acc) {
+        pack_reconfig_data_format(cb_idx);
+        pack_reconfig_l1_acc(first_block ? 0 : 1U);
+    }
     for (uint32_t block_idx = 0; block_idx < num_tiles; ++block_idx) {
         pack_tile</* out_of_order_output = */ true>(block_idx, cb_idx, dst_start_index + block_idx);
     }
-    pack_reconfig_l1_acc(0);
+    if (use_l1_acc) {
+        pack_reconfig_l1_acc(0);
+    }
     tile_regs_release();
 }
 

--- a/tt-train/sources/ttml/metal/common/program_utils.hpp
+++ b/tt-train/sources/ttml/metal/common/program_utils.hpp
@@ -9,6 +9,11 @@
 
 #include "metal/ttnn_all_includes.hpp"
 
+/** Round \p val up to the next multiple of \p multiple. */
+inline constexpr uint32_t round_up(uint32_t val, uint32_t multiple) {
+    return ((val + multiple - 1U) / multiple) * multiple;
+}
+
 inline uint32_t get_block_size(uint32_t num_inner, const uint32_t max_block_size = 4U) {
     for (uint32_t block_size = max_block_size; block_size > 1U; block_size--) {
         if (num_inner % block_size == 0) {  // if num_inner is divisible by block_size - choose this block_size

--- a/tt-train/sources/ttml/metal/ops/swiglu_fw/swiglu_fw.cpp
+++ b/tt-train/sources/ttml/metal/ops/swiglu_fw/swiglu_fw.cpp
@@ -10,7 +10,12 @@ namespace ttml::metal {
 
 ttnn::Tensor swiglu_fw(
     const ttnn::Tensor& input_tensor, const ttnn::Tensor& w1, const ttnn::Tensor& w2, const ttnn::Tensor& w3) {
-    return ttnn::prim::ttml_swiglu_fw(input_tensor, w1, w2, w3, std::nullopt);
+    return ttnn::prim::ttml_swiglu_fw(
+        input_tensor,  // [B, 1, S, C]
+        w1,            // [1, 1, C, H]
+        w2,            // [1, 1, H, C]
+        w3,            // [1, 1, C, H]
+        std::nullopt);
 }
 
 }  // namespace ttml::metal

--- a/tt-train/sources/ttml/metal/ops/swiglu_fw/swiglu_fw.cpp
+++ b/tt-train/sources/ttml/metal/ops/swiglu_fw/swiglu_fw.cpp
@@ -4,12 +4,26 @@
 
 #include "swiglu_fw.hpp"
 
+#include <ttnn/operations/matmul/matmul.hpp>
+
 #include "device/swiglu_fw_device_operation.hpp"
+#include "metal/ops/swiglu_gate_up/swiglu_gate_up.hpp"
 
 namespace ttml::metal {
 
 ttnn::Tensor swiglu_fw(
-    const ttnn::Tensor& input_tensor, const ttnn::Tensor& w1, const ttnn::Tensor& w2, const ttnn::Tensor& w3) {
+    const ttnn::Tensor& input_tensor,
+    const ttnn::Tensor& w1,
+    const ttnn::Tensor& w2,
+    const ttnn::Tensor& w3,
+    bool use_two_phases) {
+    if (use_two_phases) {
+        // Design A: 2-step pipeline
+        // Step 1: M = SiLU(X @ W1) * (X @ W3) — custom fused gate-up kernel
+        ttnn::Tensor M = swiglu_gate_up(input_tensor, w1, w3);
+        // Step 2: Y = M @ W2 — standard matmul
+        return ttnn::matmul(M, w2);
+    }
     return ttnn::prim::ttml_swiglu_fw(
         input_tensor,  // [B, 1, S, C]
         w1,            // [1, 1, C, H]

--- a/tt-train/sources/ttml/metal/ops/swiglu_fw/swiglu_fw.cpp
+++ b/tt-train/sources/ttml/metal/ops/swiglu_fw/swiglu_fw.cpp
@@ -4,10 +4,13 @@
 
 #include "swiglu_fw.hpp"
 
+#include <ttnn/operations/eltwise/binary/binary.hpp>
+#include <ttnn/operations/eltwise/unary/unary.hpp>
 #include <ttnn/operations/matmul/matmul.hpp>
 
 #include "device/swiglu_fw_device_operation.hpp"
 #include "metal/ops/swiglu_gate_up/swiglu_gate_up.hpp"
+#include "ttnn_fixed/matmuls.hpp"
 
 namespace ttml::metal {
 
@@ -16,20 +19,34 @@ ttnn::Tensor swiglu_fw(
     const ttnn::Tensor& w1,
     const ttnn::Tensor& w2,
     const ttnn::Tensor& w3,
-    bool use_two_phases) {
-    if (use_two_phases) {
-        // Design A: 2-step pipeline
-        // Step 1: M = SiLU(X @ W1) * (X @ W3) — custom fused gate-up kernel
-        ttnn::Tensor M = swiglu_gate_up(input_tensor, w1, w3);
-        // Step 2: Y = M @ W2 — standard matmul
-        return ttnn::matmul(M, w2);
+    SwigluFwPath path) {
+    switch (path) {
+        case SwigluFwPath::Composite: {
+            // This path is used when TTML_SWIGLU_PATH=composite_metal (LlamaMLP calls ops::swiglu
+            // with path=Composite, which invokes this block). Same math as LlamaMLP composite:
+            // silu(X@W1), X@W3, mul, then (result)@W2; for perf comparison.
+            auto xw1 = ttnn_fixed::matmul(input_tensor, w1);
+            auto xw3 = ttnn_fixed::matmul(input_tensor, w3);
+            auto swished = ttnn::silu(xw1);
+            auto gated = ttnn::multiply(swished, xw3);
+            return ttnn_fixed::matmul(gated, w2);
+        }
+        case SwigluFwPath::GateUp: {
+            // Design A: 2-step pipeline
+            // Step 1: M = SiLU(X @ W1) * (X @ W3) — custom fused gate-up kernel
+            ttnn::Tensor M = swiglu_gate_up(input_tensor, w1, w3);
+            // Step 2: Y = M @ W2 — standard matmul
+            return ttnn::matmul(M, w2);
+        }
+        case SwigluFwPath::FullFusion:
+            return ttnn::prim::ttml_swiglu_fw(
+                input_tensor,  // [B, 1, S, C]
+                w1,            // [1, 1, C, H]
+                w2,            // [1, 1, H, C]
+                w3,            // [1, 1, C, H]
+                std::nullopt);
     }
-    return ttnn::prim::ttml_swiglu_fw(
-        input_tensor,  // [B, 1, S, C]
-        w1,            // [1, 1, C, H]
-        w2,            // [1, 1, H, C]
-        w3,            // [1, 1, C, H]
-        std::nullopt);
+    __builtin_unreachable();
 }
 
 }  // namespace ttml::metal

--- a/tt-train/sources/ttml/metal/ops/swiglu_fw/swiglu_fw.cpp
+++ b/tt-train/sources/ttml/metal/ops/swiglu_fw/swiglu_fw.cpp
@@ -31,8 +31,8 @@ ttnn::Tensor swiglu_fw(
             return ttnn_fixed::matmul(gated, w2);
         }
         case SwigluFwPath::GateUp: {
-            // Design A: 2-step pipeline
-            // Step 1: M = SiLU(X @ W1) * (X @ W3) — custom fused gate-up kernel
+            // 2-step pipeline:
+            // Step 1: M = SiLU(X @ W1) * (X @ W3) — fused gate-up kernel
             ttnn::Tensor M = swiglu_gate_up(input_tensor, w1, w3);
             // Step 2: Y = M @ W2 — standard matmul
             return ttnn::matmul(M, w2);

--- a/tt-train/sources/ttml/metal/ops/swiglu_fw/swiglu_fw.cpp
+++ b/tt-train/sources/ttml/metal/ops/swiglu_fw/swiglu_fw.cpp
@@ -4,48 +4,13 @@
 
 #include "swiglu_fw.hpp"
 
-#include <ttnn/operations/eltwise/binary/binary.hpp>
-#include <ttnn/operations/eltwise/unary/unary.hpp>
-#include <ttnn/operations/matmul/matmul.hpp>
-
 #include "device/swiglu_fw_device_operation.hpp"
-#include "metal/ops/swiglu_gate_up/swiglu_gate_up.hpp"
-#include "ttnn_fixed/matmuls.hpp"
 
 namespace ttml::metal {
 
 ttnn::Tensor swiglu_fw(
-    const ttnn::Tensor& input_tensor,
-    const ttnn::Tensor& w1,
-    const ttnn::Tensor& w2,
-    const ttnn::Tensor& w3,
-    SwigluFwPath path) {
-    switch (path) {
-        case SwigluFwPath::Composite: {
-            // Composite path: performs the same math as LlamaMLP composite.
-            // silu(X@W1), X@W3, multiply, then (result)@W2; used for performance comparison.
-            auto xw1 = ttnn_fixed::matmul(input_tensor, w1);
-            auto xw3 = ttnn_fixed::matmul(input_tensor, w3);
-            auto swished = ttnn::silu(xw1);
-            auto gated = ttnn::multiply(swished, xw3);
-            return ttnn_fixed::matmul(gated, w2);
-        }
-        case SwigluFwPath::GateUp: {
-            // 2-step pipeline:
-            // Step 1: M = SiLU(X @ W1) * (X @ W3) — fused gate-up kernel
-            ttnn::Tensor M = swiglu_gate_up(input_tensor, w1, w3);
-            // Step 2: Y = M @ W2 — standard matmul
-            return ttnn::matmul(M, w2);
-        }
-        case SwigluFwPath::FullFusion:
-            return ttnn::prim::ttml_swiglu_fw(
-                input_tensor,  // [B, 1, S, C]
-                w1,            // [1, 1, C, H]
-                w2,            // [1, 1, H, C]
-                w3,            // [1, 1, C, H]
-                std::nullopt);
-    }
-    __builtin_unreachable();
+    const ttnn::Tensor& input_tensor, const ttnn::Tensor& w1, const ttnn::Tensor& w2, const ttnn::Tensor& w3) {
+    return ttnn::prim::ttml_swiglu_fw(input_tensor, w1, w2, w3, std::nullopt);
 }
 
 }  // namespace ttml::metal

--- a/tt-train/sources/ttml/metal/ops/swiglu_fw/swiglu_fw.cpp
+++ b/tt-train/sources/ttml/metal/ops/swiglu_fw/swiglu_fw.cpp
@@ -22,9 +22,8 @@ ttnn::Tensor swiglu_fw(
     SwigluFwPath path) {
     switch (path) {
         case SwigluFwPath::Composite: {
-            // This path is used when TTML_SWIGLU_PATH=composite_metal (LlamaMLP calls ops::swiglu
-            // with path=Composite, which invokes this block). Same math as LlamaMLP composite:
-            // silu(X@W1), X@W3, mul, then (result)@W2; for perf comparison.
+            // Composite path: performs the same math as LlamaMLP composite.
+            // silu(X@W1), X@W3, multiply, then (result)@W2; used for performance comparison.
             auto xw1 = ttnn_fixed::matmul(input_tensor, w1);
             auto xw3 = ttnn_fixed::matmul(input_tensor, w3);
             auto swished = ttnn::silu(xw1);

--- a/tt-train/sources/ttml/metal/ops/swiglu_fw/swiglu_fw.hpp
+++ b/tt-train/sources/ttml/metal/ops/swiglu_fw/swiglu_fw.hpp
@@ -8,30 +8,15 @@
 
 namespace ttml::metal {
 
-// SwiGLU forward operation: Y = (SiLU(X @ W1) * (X @ W3)) @ W2
-//
-// Paths:
-//   GateUp:     Fused gate-up kernel + matmul(M, W2). Best when M fits in L1.
-//   FullFusion: Single fused kernel (legacy).
-//   Composite:  Same op sequence as LlamaMLP: matmul, silu, matmul, mul, matmul.
-//               For perf comparison with llama_block composite.
+// Full-fusion SwiGLU forward: Y = (SiLU(X @ W1) * (X @ W3)) @ W2 in a single fused kernel.
+// Path selection (Composite, GateUp, FullFusion) lives in ttml::ops::swiglu (swiglu_op.cpp).
 //
 // Args:
-//   input_tensor: Input tensor [B, 1, S, embed_dim]
-//   w1: Gate projection weights [1, 1, embed_dim, hidden_dim]
-//   w2: Down projection weights [1, 1, hidden_dim, embed_dim]
-//   w3: Up projection weights [1, 1, embed_dim, hidden_dim]
-//   path: Which implementation to use (default: GateUp).
-//
+//   input_tensor: [B, 1, S, embed_dim]
+//   w1, w2, w3: Gate, down, up projections [1, 1, embed_dim, hidden_dim] etc.
 // Returns:
 //   Output tensor [B, 1, S, embed_dim]
-enum class SwigluFwPath { Composite, GateUp, FullFusion };
-
 ttnn::Tensor swiglu_fw(
-    const ttnn::Tensor& input_tensor,
-    const ttnn::Tensor& w1,
-    const ttnn::Tensor& w2,
-    const ttnn::Tensor& w3,
-    SwigluFwPath path = SwigluFwPath::GateUp);
+    const ttnn::Tensor& input_tensor, const ttnn::Tensor& w1, const ttnn::Tensor& w2, const ttnn::Tensor& w3);
 
 }  // namespace ttml::metal

--- a/tt-train/sources/ttml/metal/ops/swiglu_fw/swiglu_fw.hpp
+++ b/tt-train/sources/ttml/metal/ops/swiglu_fw/swiglu_fw.hpp
@@ -19,10 +19,16 @@ namespace ttml::metal {
 //   w1: Gate projection weights [1, 1, embed_dim, hidden_dim]
 //   w2: Down projection weights [1, 1, hidden_dim, embed_dim]
 //   w3: Up projection weights [1, 1, embed_dim, hidden_dim]
+//   use_two_phases: If true (default), use Design A (gate-up kernel + matmul(M, W2));
+//                   if false, use the legacy single fused kernel.
 //
 // Returns:
 //   Output tensor [B, 1, S, embed_dim]
 ttnn::Tensor swiglu_fw(
-    const ttnn::Tensor& input_tensor, const ttnn::Tensor& w1, const ttnn::Tensor& w2, const ttnn::Tensor& w3);
+    const ttnn::Tensor& input_tensor,
+    const ttnn::Tensor& w1,
+    const ttnn::Tensor& w2,
+    const ttnn::Tensor& w3,
+    bool use_two_phases = true);
 
 }  // namespace ttml::metal

--- a/tt-train/sources/ttml/metal/ops/swiglu_fw/swiglu_fw.hpp
+++ b/tt-train/sources/ttml/metal/ops/swiglu_fw/swiglu_fw.hpp
@@ -10,25 +10,28 @@ namespace ttml::metal {
 
 // SwiGLU forward operation: Y = (SiLU(X @ W1) * (X @ W3)) @ W2
 //
-// Uses dual-NOC architecture with dynamic W2 prefetching for optimal performance.
-// Requires M row (hidden_dim tiles) to fit in L1. For large hidden_dim, use
-// sufficient tensor parallelism (TP) or fall back to composite ops.
+// Paths:
+//   GateUp:     Fused gate-up kernel + matmul(M, W2). Best when M fits in L1.
+//   FullFusion: Single fused kernel (legacy).
+//   Composite:  Same op sequence as LlamaMLP: matmul, silu, matmul, mul, matmul.
+//               For perf comparison with llama_block composite.
 //
 // Args:
 //   input_tensor: Input tensor [B, 1, S, embed_dim]
 //   w1: Gate projection weights [1, 1, embed_dim, hidden_dim]
 //   w2: Down projection weights [1, 1, hidden_dim, embed_dim]
 //   w3: Up projection weights [1, 1, embed_dim, hidden_dim]
-//   use_two_phases: If true (default), use Design A (gate-up kernel + matmul(M, W2));
-//                   if false, use the legacy single fused kernel.
+//   path: Which implementation to use (default: GateUp).
 //
 // Returns:
 //   Output tensor [B, 1, S, embed_dim]
+enum class SwigluFwPath { Composite, GateUp, FullFusion };
+
 ttnn::Tensor swiglu_fw(
     const ttnn::Tensor& input_tensor,
     const ttnn::Tensor& w1,
     const ttnn::Tensor& w2,
     const ttnn::Tensor& w3,
-    bool use_two_phases = true);
+    SwigluFwPath path = SwigluFwPath::GateUp);
 
 }  // namespace ttml::metal

--- a/tt-train/sources/ttml/metal/ops/swiglu_gate_up/device/kernels/compute/swiglu_gate_up_compute.cpp
+++ b/tt-train/sources/ttml/metal/ops/swiglu_gate_up/device/kernels/compute/swiglu_gate_up_compute.cpp
@@ -8,9 +8,7 @@
 #include "api/compute/cb_api.h"
 #include "api/compute/common.h"
 #include "api/compute/compute_kernel_api.h"
-#include "api/compute/copy_dest_values.h"
 #include "api/compute/eltwise_binary.h"
-#include "api/compute/eltwise_binary_sfpu.h"
 #include "api/compute/eltwise_unary/eltwise_unary.h"
 #include "api/compute/matmul.h"
 #include "api/compute/pack.h"
@@ -18,18 +16,43 @@
 #include "api/compute/tile_move_copy.h"
 #include "tt-train/sources/ttml/metal/common/compute_utils.hpp"
 
-// ============================================================================
-// SwiGLU Gate-Up Compute Kernel — M sub-blocking only.
-// One N-block of weights (W1/W3) per load; no N-block batching.
+// ----------------------------------------------------------------------
+// SwiGLU Gate-Up Compute Kernel (XW1, XW3, then M = SiLU(XW1) * XW3)
+//
+// Phase A: XW1[r,:], XW3[r,:] accumulated across K-blocks using L1 acc
+//          directly into cb_xw1_acc / cb_xw3_acc. One N-block of W1/W3
+//          at a time; block_h M-rows per sync (M sub-blocking only).
+// Phase B: M[r, :] = SiLU(XW1[r, :]) * XW3[r, :] for block_h rows, pack to cb_m_out.
+// ----------------------------------------------------------------------
+//
+// ========================= Compute kernel structure =========================
+// for m_block in m_blocks:
+//   reserve cb_xw1_acc, cb_xw3_acc  (block_h * per_core_N_rounded tiles each)
+//   for k_block in k_blocks:
+//     load X[m_block, k_block]  # block_h rows × block_size K tiles
+//     for n_block in n_blocks:
+//       load W1[k_block, n_block]
+//       for r in block_h:
+//         XW1[r, n_block] += X[r, k_block] @ W1[k_block, n_block]   # L1 acc
+//       load W3[k_block, n_block]
+//       for r in block_h:
+//         XW3[r, n_block] += X[r, k_block] @ W3[k_block, n_block]   # L1 acc
+//   push cb_xw1_acc, cb_xw3_acc
+//   for r in block_h:
+//     for n in per_core_N:
+//       M[r, n] = SiLU(XW1[r, n]) * XW3[r, n]
+//   pop cb_xw1_acc, cb_xw3_acc
 // ============================================================================
 
 constexpr uint32_t per_core_N = get_compile_time_arg_val(0);
-constexpr uint32_t per_core_N_rounded = get_compile_time_arg_val(1);
-constexpr uint32_t block_size = get_compile_time_arg_val(2);
-constexpr uint32_t Wt = get_compile_time_arg_val(3);
-constexpr uint32_t num_n_blocks = get_compile_time_arg_val(4);
-constexpr uint32_t block_h = get_compile_time_arg_val(5);
-constexpr uint32_t num_m_blocks = get_compile_time_arg_val(6);
+constexpr uint32_t block_size = get_compile_time_arg_val(1);
+constexpr uint32_t Wt = get_compile_time_arg_val(2);
+constexpr uint32_t block_h = get_compile_time_arg_val(3);
+constexpr uint32_t num_m_blocks = get_compile_time_arg_val(4);
+
+// Derived from per_core_N and block_size (single source of truth).
+constexpr uint32_t per_core_N_rounded = ((per_core_N + block_size - 1U) / block_size) * block_size;
+constexpr uint32_t num_n_blocks = per_core_N_rounded / block_size;
 
 constexpr uint32_t tiles_per_n_block = block_size * block_size;
 constexpr uint32_t x_tiles_per_block = block_h * block_size;
@@ -42,10 +65,12 @@ constexpr auto cb_w3_idx = tt::CBIndex::c_2;
 constexpr auto cb_xw1_acc_idx = tt::CBIndex::c_3;
 constexpr auto cb_xw3_acc_idx = tt::CBIndex::c_4;
 constexpr auto cb_m_out_idx = tt::CBIndex::c_5;
+constexpr auto cb_sigmoid_idx = tt::CBIndex::c_6;
+constexpr auto cb_silu_idx = tt::CBIndex::c_7;
 
 // Matmul one row: multiply X row by one N-block of weights in CB.
 // in1_stride: distance between consecutive K-rows in CB (= block_size).
-inline void matmul_one_row_fast(
+inline void matmul_one_row(
     const tt::CBIndex cb_x_idx,
     const tt::CBIndex cb_w_idx,
     const tt::CBIndex cb_acc_idx,
@@ -74,26 +99,44 @@ inline void matmul_one_row_fast(
     }
 
     tile_regs_commit();
-    tile_regs_wait();
-    for (uint32_t t = 0U; t < block_size; ++t) {
-        pack_tile</* out_of_order_output = */ true>(t, cb_acc_idx, acc_offset + t);
-    }
-    tile_regs_release();
+    pack_l1_acc_block(
+        static_cast<uint32_t>(cb_acc_idx), /*first_block=*/false, block_size, acc_offset, /*use_l1_acc=*/false);
 }
 
-inline void compute_silu_tile(uint32_t tile_offset, uint32_t base_reg) {
-    copy_tile_init(cb_xw1_acc_idx);
-    copy_tile(cb_xw1_acc_idx, tile_offset, base_reg);
-    copy_tile_init(cb_xw3_acc_idx);
-    copy_tile(cb_xw3_acc_idx, tile_offset, base_reg + 1U);
+inline void compute_sigmoid(uint32_t tile_offset, uint32_t current_block_size) {
+    tile_regs_acquire();
+    for (uint32_t block_idx = 0U; block_idx < current_block_size; ++block_idx) {
+        copy_tile_init(cb_xw1_acc_idx);
+        copy_tile(cb_xw1_acc_idx, tile_offset + block_idx, block_idx);
+        sigmoid_tile_init();
+        sigmoid_tile(block_idx);
+    }
+    tile_regs_commit();
+    pack_and_push_block(cb_sigmoid_idx, block_size);
+}
 
-    copy_dest_values_init();
-    copy_dest_values(base_reg, base_reg + 2U);
-    sigmoid_tile_init();
-    sigmoid_tile(base_reg + 2U);
-    mul_binary_tile_init();
-    mul_binary_tile(base_reg, base_reg + 2U, base_reg);
-    mul_binary_tile(base_reg, base_reg + 1U, base_reg);
+inline void compute_silu(uint32_t tile_offset, uint32_t current_block_size) {
+    cb_wait_front(cb_sigmoid_idx, block_size);
+    tile_regs_acquire();
+    for (uint32_t block_idx = 0U; block_idx < current_block_size; ++block_idx) {
+        mul_tiles_init(cb_xw1_acc_idx, cb_sigmoid_idx);
+        mul_tiles(cb_xw1_acc_idx, cb_sigmoid_idx, tile_offset + block_idx, block_idx, block_idx);
+    }
+    tile_regs_commit();
+    pack_and_push_block(cb_silu_idx, block_size);
+    cb_pop_front(cb_sigmoid_idx, block_size);
+}
+
+inline void compute_m(uint32_t tile_offset, uint32_t current_block_size) {
+    cb_wait_front(cb_silu_idx, block_size);
+    tile_regs_acquire();
+    for (uint32_t block_idx = 0U; block_idx < current_block_size; ++block_idx) {
+        mul_tiles_init(cb_silu_idx, cb_xw3_acc_idx);
+        mul_tiles(cb_silu_idx, cb_xw3_acc_idx, block_idx, tile_offset + block_idx, block_idx);
+    }
+    tile_regs_commit();
+    pack_and_push_block(cb_m_out_idx, block_size);
+    cb_pop_front(cb_silu_idx, block_size);
 }
 
 // Process one N-block of weights for one weight matrix (W1 or W3).
@@ -109,7 +152,7 @@ inline void matmul_rows_for_one_n_block(
     pack_reconfig_l1_acc(first_k_block ? 0 : 1U);
 
     for (uint32_t m_sub = 0U; m_sub < block_h; ++m_sub) {
-        matmul_one_row_fast(
+        matmul_one_row(
             cb_in0_idx,
             cb_w_idx,
             cb_acc_idx,
@@ -162,28 +205,13 @@ void kernel_main() {
         for (uint32_t m_sub = 0U; m_sub < block_h; ++m_sub) {
             const uint32_t row_offset = m_sub * per_core_N_rounded;
 
-            for (uint32_t n_block_start = 0U; n_block_start < per_core_N; n_block_start += block_size) {
-                const uint32_t n_block_size = std::min(block_size, per_core_N - n_block_start);
+            for (uint32_t col = 0U; col < per_core_N_rounded; col += block_size) {
+                const uint32_t current_block_size = std::min(block_size, per_core_N - col);
+                const uint32_t tile_offset = row_offset + col;
 
-                uint32_t n = 0U;
-                for (; n + 1U < n_block_size; n += 2U) {
-                    tile_regs_acquire();
-                    compute_silu_tile(row_offset + n_block_start + n, 0U);
-                    compute_silu_tile(row_offset + n_block_start + n + 1U, 1U);
-                    tile_regs_commit();
-                    pack_and_push_block(cb_m_out_idx, 2U);
-                }
-                if (n < n_block_size) {
-                    tile_regs_acquire();
-                    compute_silu_tile(row_offset + n_block_start + n, 0U);
-                    tile_regs_commit();
-                    pack_and_push(0U, cb_m_out_idx);
-                }
-                if (n_block_size < block_size) {
-                    tile_regs_acquire();
-                    tile_regs_commit();
-                    pack_and_push_block(cb_m_out_idx, block_size - n_block_size);
-                }
+                compute_sigmoid(tile_offset, current_block_size);
+                compute_silu(tile_offset, current_block_size);
+                compute_m(tile_offset, current_block_size);
             }
         }
 

--- a/tt-train/sources/ttml/metal/ops/swiglu_gate_up/device/kernels/compute/swiglu_gate_up_compute.cpp
+++ b/tt-train/sources/ttml/metal/ops/swiglu_gate_up/device/kernels/compute/swiglu_gate_up_compute.cpp
@@ -205,9 +205,10 @@ void kernel_main() {
         for (uint32_t m_sub = 0U; m_sub < block_h; ++m_sub) {
             const uint32_t row_offset = m_sub * per_core_N_rounded;
 
-            for (uint32_t col = 0U; col < per_core_N_rounded; col += block_size) {
-                const uint32_t current_block_size = std::min(block_size, per_core_N - col);
-                const uint32_t tile_offset = row_offset + col;
+            for (uint32_t n_block = 0U; n_block < num_n_blocks; ++n_block) {
+                const uint32_t n_block_offset = n_block * block_size;
+                const uint32_t current_block_size = std::min(block_size, per_core_N - n_block_offset);
+                const uint32_t tile_offset = row_offset + n_block_offset;
 
                 compute_sigmoid(tile_offset, current_block_size);
                 compute_silu(tile_offset, current_block_size);

--- a/tt-train/sources/ttml/metal/ops/swiglu_gate_up/device/kernels/compute/swiglu_gate_up_compute.cpp
+++ b/tt-train/sources/ttml/metal/ops/swiglu_gate_up/device/kernels/compute/swiglu_gate_up_compute.cpp
@@ -19,12 +19,8 @@
 #include "tt-train/sources/ttml/metal/common/compute_utils.hpp"
 
 // ============================================================================
-// SwiGLU Gate-Up Compute Kernel (Design A Step 1) — with M sub-blocking
-//   and N-block batching to reduce sync overhead.
-//
-// Weight CB layout (per batch): n_blocks_per_batch N-blocks loaded together.
-// Each CB row (K-tile) has n_blocks_per_batch * block_size weight tiles.
-// K-step stride through CB = n_blocks_per_batch * block_size (full row width).
+// SwiGLU Gate-Up Compute Kernel — M sub-blocking only.
+// One N-block of weights (W1/W3) per load; no N-block batching.
 // ============================================================================
 
 constexpr uint32_t per_core_N = get_compile_time_arg_val(0);
@@ -34,15 +30,11 @@ constexpr uint32_t Wt = get_compile_time_arg_val(3);
 constexpr uint32_t num_n_blocks = get_compile_time_arg_val(4);
 constexpr uint32_t block_h = get_compile_time_arg_val(5);
 constexpr uint32_t num_m_blocks = get_compile_time_arg_val(6);
-constexpr uint32_t n_blocks_per_batch = get_compile_time_arg_val(7);
-constexpr uint32_t num_n_batch_iters = get_compile_time_arg_val(8);
 
 constexpr uint32_t tiles_per_n_block = block_size * block_size;
-constexpr uint32_t tiles_per_receive = n_blocks_per_batch * tiles_per_n_block;
 constexpr uint32_t x_tiles_per_block = block_h * block_size;
 constexpr uint32_t acc_tiles_total = block_h * per_core_N_rounded;
-// CB row width: tiles in one K-row when n_blocks_per_batch N-blocks are loaded.
-constexpr uint32_t in1_k_stride = n_blocks_per_batch * block_size;
+constexpr uint32_t in1_k_stride = block_size;
 
 constexpr auto cb_in0_idx = tt::CBIndex::c_0;
 constexpr auto cb_w1_idx = tt::CBIndex::c_1;
@@ -52,8 +44,7 @@ constexpr auto cb_xw3_acc_idx = tt::CBIndex::c_4;
 constexpr auto cb_m_out_idx = tt::CBIndex::c_5;
 
 // Matmul one row: multiply X row by one N-block of weights in CB.
-// in1_start: offset to first tile of this N-block in K-row 0 of the CB.
-// in1_stride: distance between consecutive K-rows in CB (= n_blocks_per_batch * block_size).
+// in1_stride: distance between consecutive K-rows in CB (= block_size).
 inline void matmul_one_row_fast(
     const tt::CBIndex cb_x_idx,
     const tt::CBIndex cb_w_idx,
@@ -105,13 +96,11 @@ inline void compute_silu_tile(uint32_t tile_offset, uint32_t base_reg) {
     mul_binary_tile(base_reg, base_reg + 1U, base_reg);
 }
 
-// Process a batch of N-blocks for one weight matrix (W1 or W3).
-// Hoists mm_block_init_short and pack_reconfig once per batch.
-inline void matmul_rows_for_weight_batch(
+// Process one N-block of weights for one weight matrix (W1 or W3).
+inline void matmul_rows_for_one_n_block(
     const tt::CBIndex cb_w_idx,
     const tt::CBIndex cb_acc_idx,
-    const uint32_t n_batch_start,
-    const uint32_t n_blocks_in_batch,
+    const uint32_t n_block_offset,
     const uint32_t k_block_size,
     const bool first_k_block) {
     mm_block_init_short(
@@ -119,21 +108,16 @@ inline void matmul_rows_for_weight_batch(
     pack_reconfig_data_format(cb_acc_idx);
     pack_reconfig_l1_acc(first_k_block ? 0 : 1U);
 
-    for (uint32_t blk = 0U; blk < n_blocks_in_batch; ++blk) {
-        const uint32_t n_offset = (n_batch_start + blk) * block_size;
-        const uint32_t in1_start = blk * block_size;
-
-        for (uint32_t m_sub = 0U; m_sub < block_h; ++m_sub) {
-            matmul_one_row_fast(
-                cb_in0_idx,
-                cb_w_idx,
-                cb_acc_idx,
-                m_sub * block_size,
-                m_sub * per_core_N_rounded + n_offset,
-                in1_start,
-                in1_k_stride,
-                k_block_size);
-        }
+    for (uint32_t m_sub = 0U; m_sub < block_h; ++m_sub) {
+        matmul_one_row_fast(
+            cb_in0_idx,
+            cb_w_idx,
+            cb_acc_idx,
+            m_sub * block_size,
+            m_sub * per_core_N_rounded + n_block_offset,
+            /*in1_start=*/0U,
+            in1_k_stride,
+            k_block_size);
     }
 
     pack_reconfig_l1_acc(0);
@@ -153,19 +137,16 @@ void kernel_main() {
 
             cb_wait_front(cb_in0_idx, x_tiles_per_block);
 
-            for (uint32_t n_batch = 0U; n_batch < num_n_batch_iters; ++n_batch) {
-                const uint32_t n_batch_start = n_batch * n_blocks_per_batch;
-                const uint32_t n_blocks_in_batch = std::min(n_blocks_per_batch, num_n_blocks - n_batch_start);
+            for (uint32_t n_block = 0U; n_block < num_n_blocks; ++n_block) {
+                const uint32_t n_block_offset = n_block * block_size;
 
-                cb_wait_front(cb_w1_idx, tiles_per_receive);
-                matmul_rows_for_weight_batch(
-                    cb_w1_idx, cb_xw1_acc_idx, n_batch_start, n_blocks_in_batch, k_block_size, first_k_block);
-                cb_pop_front(cb_w1_idx, tiles_per_receive);
+                cb_wait_front(cb_w1_idx, tiles_per_n_block);
+                matmul_rows_for_one_n_block(cb_w1_idx, cb_xw1_acc_idx, n_block_offset, k_block_size, first_k_block);
+                cb_pop_front(cb_w1_idx, tiles_per_n_block);
 
-                cb_wait_front(cb_w3_idx, tiles_per_receive);
-                matmul_rows_for_weight_batch(
-                    cb_w3_idx, cb_xw3_acc_idx, n_batch_start, n_blocks_in_batch, k_block_size, first_k_block);
-                cb_pop_front(cb_w3_idx, tiles_per_receive);
+                cb_wait_front(cb_w3_idx, tiles_per_n_block);
+                matmul_rows_for_one_n_block(cb_w3_idx, cb_xw3_acc_idx, n_block_offset, k_block_size, first_k_block);
+                cb_pop_front(cb_w3_idx, tiles_per_n_block);
             }
 
             cb_pop_front(cb_in0_idx, x_tiles_per_block);

--- a/tt-train/sources/ttml/metal/ops/swiglu_gate_up/device/kernels/compute/swiglu_gate_up_compute.cpp
+++ b/tt-train/sources/ttml/metal/ops/swiglu_gate_up/device/kernels/compute/swiglu_gate_up_compute.cpp
@@ -1,0 +1,175 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <algorithm>
+#include <cstdint>
+
+#include "api/compute/cb_api.h"
+#include "api/compute/common.h"
+#include "api/compute/compute_kernel_api.h"
+#include "api/compute/copy_dest_values.h"
+#include "api/compute/eltwise_binary.h"
+#include "api/compute/eltwise_binary_sfpu.h"
+#include "api/compute/eltwise_unary/eltwise_unary.h"
+#include "api/compute/matmul.h"
+#include "api/compute/pack.h"
+#include "api/compute/reconfig_data_format.h"
+#include "api/compute/tile_move_copy.h"
+#include "tt-train/sources/ttml/metal/common/compute_utils.hpp"
+
+// ============================================================================
+// SwiGLU Gate-Up Compute Kernel (Design A Step 1)
+//
+// Computes M = SiLU(X @ W1) * (X @ W3) using 2D multicast matmul tiling.
+//
+// Each core (r, c) in the R×C grid computes its block:
+//   XW1[per_core_M, per_core_N] = X[per_core_M, K] @ W1[K, per_core_N]
+//   XW3[per_core_M, per_core_N] = X[per_core_M, K] @ W3[K, per_core_N]
+//   M[per_core_M, per_core_N] = SiLU(XW1) * XW3
+//
+// Loop structure (per M tile-row):
+//   for k_block in K_blocks:
+//     wait X[K_block_size]
+//     for n_sub in N_blocks:
+//       wait W1[K_block_size × block_size], matmul → acc XW1[n_sub]
+//       wait W3[K_block_size × block_size], matmul → acc XW3[n_sub]
+//     pop X
+//   SiLU(XW1) * XW3 → M
+// ============================================================================
+
+constexpr uint32_t per_core_M = get_compile_time_arg_val(0);
+constexpr uint32_t per_core_N = get_compile_time_arg_val(1);
+constexpr uint32_t per_core_N_rounded = get_compile_time_arg_val(2);
+constexpr uint32_t block_size = get_compile_time_arg_val(3);
+constexpr uint32_t Wt = get_compile_time_arg_val(4);
+constexpr uint32_t num_n_blocks = get_compile_time_arg_val(5);
+
+constexpr uint32_t tiles_per_batch = block_size * block_size;
+
+constexpr auto cb_in0_idx = tt::CBIndex::c_0;
+constexpr auto cb_w1_idx = tt::CBIndex::c_1;
+constexpr auto cb_w3_idx = tt::CBIndex::c_2;
+constexpr auto cb_xw1_acc_idx = tt::CBIndex::c_3;
+constexpr auto cb_xw3_acc_idx = tt::CBIndex::c_4;
+constexpr auto cb_m_out_idx = tt::CBIndex::c_5;
+
+// Accumulate X @ W into the accumulation CB using packer L1 accumulation.
+inline void matmul_accumulate_l1(
+    const tt::CBIndex cb_x_idx,
+    const tt::CBIndex cb_w_idx,
+    const tt::CBIndex cb_acc_idx,
+    const uint32_t n_block_offset,
+    const uint32_t k_block_size,
+    const bool first_k_block) {
+    tile_regs_acquire();
+
+    cb_wait_front(cb_w_idx, tiles_per_batch);
+
+    mm_block_init_short(
+        cb_x_idx, cb_w_idx, /*transpose=*/false, /*ct_dim=*/block_size, /*rt_dim=*/1U, /*kt_dim=*/k_block_size);
+
+    uint32_t in0_index = 0U;
+    uint32_t in1_index = 0U;
+    for (uint32_t k = 0U; k < k_block_size; ++k) {
+        matmul_block(
+            cb_x_idx,
+            cb_w_idx,
+            in0_index,
+            in1_index,
+            /*dst_index=*/0U,
+            /*transpose=*/false,
+            /*ct_dim=*/block_size,
+            /*rt_dim=*/1U,
+            /*kt_dim=*/k_block_size);
+        in0_index++;
+        in1_index += block_size;
+    }
+
+    cb_pop_front(cb_w_idx, tiles_per_batch);
+
+    tile_regs_commit();
+    pack_l1_acc_block(cb_acc_idx, first_k_block, block_size, n_block_offset);
+}
+
+// Process a single SiLU tile: M = SiLU(XW1) * XW3 = (XW1 * sigmoid(XW1)) * XW3
+// Uses 3 consecutive DST registers starting at base_reg: [xw1, xw3, scratch]
+inline void compute_silu_tile(uint32_t tile_offset, uint32_t base_reg) {
+    copy_tile_init(cb_xw1_acc_idx);
+    copy_tile(cb_xw1_acc_idx, tile_offset, base_reg);
+    copy_tile_init(cb_xw3_acc_idx);
+    copy_tile(cb_xw3_acc_idx, tile_offset, base_reg + 1U);
+
+    copy_dest_values_init();
+    copy_dest_values(base_reg, base_reg + 2U);  // scratch = XW1
+    sigmoid_tile_init();
+    sigmoid_tile(base_reg + 2U);  // scratch = sigmoid(XW1)
+    mul_binary_tile_init();
+    mul_binary_tile(base_reg, base_reg + 2U, base_reg);  // base = XW1 * sigmoid = SiLU
+    mul_binary_tile(base_reg, base_reg + 1U, base_reg);  // base = SiLU * XW3 = M
+}
+
+void kernel_main() {
+    init_sfpu(cb_in0_idx, cb_m_out_idx);
+    binary_op_init_common(cb_in0_idx, cb_w1_idx, cb_m_out_idx);
+
+    for (uint32_t m = 0U; m < per_core_M; ++m) {
+        // ---- Accumulate XW1 and XW3 for this M tile-row ----
+        cb_reserve_back(cb_xw1_acc_idx, per_core_N_rounded);
+        cb_reserve_back(cb_xw3_acc_idx, per_core_N_rounded);
+
+        for (uint32_t k_block_start = 0U; k_block_start < Wt; k_block_start += block_size) {
+            const uint32_t k_block_size = std::min(block_size, Wt - k_block_start);
+            const bool first_k_block = (k_block_start == 0U);
+
+            cb_wait_front(cb_in0_idx, block_size);
+
+            for (uint32_t n_sub = 0U; n_sub < num_n_blocks; ++n_sub) {
+                uint32_t n_offset = n_sub * block_size;
+
+                matmul_accumulate_l1(cb_in0_idx, cb_w1_idx, cb_xw1_acc_idx, n_offset, k_block_size, first_k_block);
+
+                matmul_accumulate_l1(cb_in0_idx, cb_w3_idx, cb_xw3_acc_idx, n_offset, k_block_size, first_k_block);
+            }
+
+            cb_pop_front(cb_in0_idx, block_size);
+        }
+
+        cb_push_back(cb_xw1_acc_idx, per_core_N_rounded);
+        cb_push_back(cb_xw3_acc_idx, per_core_N_rounded);
+
+        // ---- SiLU fusion: M = SiLU(XW1) * XW3 ----
+        cb_wait_front(cb_xw1_acc_idx, per_core_N_rounded);
+        cb_wait_front(cb_xw3_acc_idx, per_core_N_rounded);
+
+        for (uint32_t n_block_start = 0U; n_block_start < per_core_N; n_block_start += block_size) {
+            const uint32_t n_block_size = std::min(block_size, per_core_N - n_block_start);
+
+            uint32_t n = 0U;
+            // Batched: process 2 tiles per acquire/commit when possible
+            for (; n + 1U < n_block_size; n += 2U) {
+                tile_regs_acquire();
+                compute_silu_tile(n_block_start + n, 0U);
+                compute_silu_tile(n_block_start + n + 1U, 1U);
+                tile_regs_commit();
+                pack_and_push_block(cb_m_out_idx, 2U);
+            }
+            if (n < n_block_size) {
+                tile_regs_acquire();
+                compute_silu_tile(n_block_start + n, 0U);
+                tile_regs_commit();
+                pack_and_push(0U, cb_m_out_idx);
+            }
+
+            // Pad to block_size if needed
+            if (n_block_size < block_size) {
+                tile_regs_acquire();
+                tile_regs_commit();
+                pack_and_push_block(cb_m_out_idx, block_size - n_block_size);
+            }
+        }
+
+        cb_pop_front(cb_xw1_acc_idx, per_core_N_rounded);
+        cb_pop_front(cb_xw3_acc_idx, per_core_N_rounded);
+    }
+}

--- a/tt-train/sources/ttml/metal/ops/swiglu_gate_up/device/kernels/compute/swiglu_gate_up_compute.cpp
+++ b/tt-train/sources/ttml/metal/ops/swiglu_gate_up/device/kernels/compute/swiglu_gate_up_compute.cpp
@@ -20,13 +20,11 @@
 
 // ============================================================================
 // SwiGLU Gate-Up Compute Kernel (Design A Step 1) — with M sub-blocking
+//   and N-block batching to reduce sync overhead.
 //
-// Outer loop iterates over M-blocks of block_h rows. For each M-block, the
-// full K-loop runs once, reusing weight tiles across all block_h M rows.
-// This amortizes weight DRAM reads by block_h×.
-//
-// Performance-critical: mm_block_init_short and pack_reconfig_* are hoisted
-// out of the per-row loop to avoid redundant hardware reconfiguration.
+// Weight CB layout (per batch): n_blocks_per_batch N-blocks loaded together.
+// Each CB row (K-tile) has n_blocks_per_batch * block_size weight tiles.
+// K-step stride through CB = n_blocks_per_batch * block_size (full row width).
 // ============================================================================
 
 constexpr uint32_t per_core_N = get_compile_time_arg_val(0);
@@ -36,10 +34,15 @@ constexpr uint32_t Wt = get_compile_time_arg_val(3);
 constexpr uint32_t num_n_blocks = get_compile_time_arg_val(4);
 constexpr uint32_t block_h = get_compile_time_arg_val(5);
 constexpr uint32_t num_m_blocks = get_compile_time_arg_val(6);
+constexpr uint32_t n_blocks_per_batch = get_compile_time_arg_val(7);
+constexpr uint32_t num_n_batch_iters = get_compile_time_arg_val(8);
 
-constexpr uint32_t tiles_per_batch = block_size * block_size;
+constexpr uint32_t tiles_per_n_block = block_size * block_size;
+constexpr uint32_t tiles_per_receive = n_blocks_per_batch * tiles_per_n_block;
 constexpr uint32_t x_tiles_per_block = block_h * block_size;
 constexpr uint32_t acc_tiles_total = block_h * per_core_N_rounded;
+// CB row width: tiles in one K-row when n_blocks_per_batch N-blocks are loaded.
+constexpr uint32_t in1_k_stride = n_blocks_per_batch * block_size;
 
 constexpr auto cb_in0_idx = tt::CBIndex::c_0;
 constexpr auto cb_w1_idx = tt::CBIndex::c_1;
@@ -48,18 +51,22 @@ constexpr auto cb_xw1_acc_idx = tt::CBIndex::c_3;
 constexpr auto cb_xw3_acc_idx = tt::CBIndex::c_4;
 constexpr auto cb_m_out_idx = tt::CBIndex::c_5;
 
-// Matmul one row and pack to L1 accumulator — no init_short, no pack reconfig.
+// Matmul one row: multiply X row by one N-block of weights in CB.
+// in1_start: offset to first tile of this N-block in K-row 0 of the CB.
+// in1_stride: distance between consecutive K-rows in CB (= n_blocks_per_batch * block_size).
 inline void matmul_one_row_fast(
     const tt::CBIndex cb_x_idx,
     const tt::CBIndex cb_w_idx,
     const tt::CBIndex cb_acc_idx,
     const uint32_t x_row_offset,
     const uint32_t acc_offset,
+    const uint32_t in1_start,
+    const uint32_t in1_stride,
     const uint32_t k_block_size) {
     tile_regs_acquire();
 
     uint32_t in0_index = x_row_offset;
-    uint32_t in1_index = 0U;
+    uint32_t in1_index = in1_start;
     for (uint32_t k = 0U; k < k_block_size; ++k) {
         matmul_block(
             cb_x_idx,
@@ -72,7 +79,7 @@ inline void matmul_one_row_fast(
             /*rt_dim=*/1U,
             /*kt_dim=*/k_block_size);
         in0_index++;
-        in1_index += block_size;
+        in1_index += in1_stride;
     }
 
     tile_regs_commit();
@@ -98,12 +105,13 @@ inline void compute_silu_tile(uint32_t tile_offset, uint32_t base_reg) {
     mul_binary_tile(base_reg, base_reg + 1U, base_reg);
 }
 
-// Process block_h rows of matmul for one weight matrix (W1 or W3).
-// Hoists mm_block_init_short and pack_reconfig outside the row loop.
-inline void matmul_rows_for_weight(
+// Process a batch of N-blocks for one weight matrix (W1 or W3).
+// Hoists mm_block_init_short and pack_reconfig once per batch.
+inline void matmul_rows_for_weight_batch(
     const tt::CBIndex cb_w_idx,
     const tt::CBIndex cb_acc_idx,
-    const uint32_t n_offset,
+    const uint32_t n_batch_start,
+    const uint32_t n_blocks_in_batch,
     const uint32_t k_block_size,
     const bool first_k_block) {
     mm_block_init_short(
@@ -111,9 +119,21 @@ inline void matmul_rows_for_weight(
     pack_reconfig_data_format(cb_acc_idx);
     pack_reconfig_l1_acc(first_k_block ? 0 : 1U);
 
-    for (uint32_t m_sub = 0U; m_sub < block_h; ++m_sub) {
-        matmul_one_row_fast(
-            cb_in0_idx, cb_w_idx, cb_acc_idx, m_sub * block_size, m_sub * per_core_N_rounded + n_offset, k_block_size);
+    for (uint32_t blk = 0U; blk < n_blocks_in_batch; ++blk) {
+        const uint32_t n_offset = (n_batch_start + blk) * block_size;
+        const uint32_t in1_start = blk * block_size;
+
+        for (uint32_t m_sub = 0U; m_sub < block_h; ++m_sub) {
+            matmul_one_row_fast(
+                cb_in0_idx,
+                cb_w_idx,
+                cb_acc_idx,
+                m_sub * block_size,
+                m_sub * per_core_N_rounded + n_offset,
+                in1_start,
+                in1_k_stride,
+                k_block_size);
+        }
     }
 
     pack_reconfig_l1_acc(0);
@@ -133,16 +153,19 @@ void kernel_main() {
 
             cb_wait_front(cb_in0_idx, x_tiles_per_block);
 
-            for (uint32_t n_sub = 0U; n_sub < num_n_blocks; ++n_sub) {
-                const uint32_t n_offset = n_sub * block_size;
+            for (uint32_t n_batch = 0U; n_batch < num_n_batch_iters; ++n_batch) {
+                const uint32_t n_batch_start = n_batch * n_blocks_per_batch;
+                const uint32_t n_blocks_in_batch = std::min(n_blocks_per_batch, num_n_blocks - n_batch_start);
 
-                cb_wait_front(cb_w1_idx, tiles_per_batch);
-                matmul_rows_for_weight(cb_w1_idx, cb_xw1_acc_idx, n_offset, k_block_size, first_k_block);
-                cb_pop_front(cb_w1_idx, tiles_per_batch);
+                cb_wait_front(cb_w1_idx, tiles_per_receive);
+                matmul_rows_for_weight_batch(
+                    cb_w1_idx, cb_xw1_acc_idx, n_batch_start, n_blocks_in_batch, k_block_size, first_k_block);
+                cb_pop_front(cb_w1_idx, tiles_per_receive);
 
-                cb_wait_front(cb_w3_idx, tiles_per_batch);
-                matmul_rows_for_weight(cb_w3_idx, cb_xw3_acc_idx, n_offset, k_block_size, first_k_block);
-                cb_pop_front(cb_w3_idx, tiles_per_batch);
+                cb_wait_front(cb_w3_idx, tiles_per_receive);
+                matmul_rows_for_weight_batch(
+                    cb_w3_idx, cb_xw3_acc_idx, n_batch_start, n_blocks_in_batch, k_block_size, first_k_block);
+                cb_pop_front(cb_w3_idx, tiles_per_receive);
             }
 
             cb_pop_front(cb_in0_idx, x_tiles_per_block);

--- a/tt-train/sources/ttml/metal/ops/swiglu_gate_up/device/kernels/compute/swiglu_gate_up_compute.cpp
+++ b/tt-train/sources/ttml/metal/ops/swiglu_gate_up/device/kernels/compute/swiglu_gate_up_compute.cpp
@@ -99,8 +99,7 @@ inline void matmul_one_row(
     }
 
     tile_regs_commit();
-    pack_l1_acc_block(
-        static_cast<uint32_t>(cb_acc_idx), /*first_block=*/false, block_size, acc_offset, /*use_l1_acc=*/false);
+    pack_block_to_cb(static_cast<uint32_t>(cb_acc_idx), block_size, acc_offset);
 }
 
 inline void compute_sigmoid(uint32_t tile_offset, uint32_t current_block_size) {

--- a/tt-train/sources/ttml/metal/ops/swiglu_gate_up/device/kernels/compute/swiglu_gate_up_compute.cpp
+++ b/tt-train/sources/ttml/metal/ops/swiglu_gate_up/device/kernels/compute/swiglu_gate_up_compute.cpp
@@ -19,33 +19,24 @@
 #include "tt-train/sources/ttml/metal/common/compute_utils.hpp"
 
 // ============================================================================
-// SwiGLU Gate-Up Compute Kernel (Design A Step 1)
+// SwiGLU Gate-Up Compute Kernel (Design A Step 1) — with M sub-blocking
 //
-// Computes M = SiLU(X @ W1) * (X @ W3) using 2D multicast matmul tiling.
-//
-// Each core (r, c) in the R×C grid computes its block:
-//   XW1[per_core_M, per_core_N] = X[per_core_M, K] @ W1[K, per_core_N]
-//   XW3[per_core_M, per_core_N] = X[per_core_M, K] @ W3[K, per_core_N]
-//   M[per_core_M, per_core_N] = SiLU(XW1) * XW3
-//
-// Loop structure (per M tile-row):
-//   for k_block in K_blocks:
-//     wait X[K_block_size]
-//     for n_sub in N_blocks:
-//       wait W1[K_block_size × block_size], matmul → acc XW1[n_sub]
-//       wait W3[K_block_size × block_size], matmul → acc XW3[n_sub]
-//     pop X
-//   SiLU(XW1) * XW3 → M
+// Outer loop iterates over M-blocks of block_h rows. For each M-block, the
+// full K-loop runs once, reusing weight tiles across all block_h M rows.
+// This amortizes weight DRAM reads by block_h×.
 // ============================================================================
 
-constexpr uint32_t per_core_M = get_compile_time_arg_val(0);
-constexpr uint32_t per_core_N = get_compile_time_arg_val(1);
-constexpr uint32_t per_core_N_rounded = get_compile_time_arg_val(2);
-constexpr uint32_t block_size = get_compile_time_arg_val(3);
-constexpr uint32_t Wt = get_compile_time_arg_val(4);
-constexpr uint32_t num_n_blocks = get_compile_time_arg_val(5);
+constexpr uint32_t per_core_N = get_compile_time_arg_val(0);
+constexpr uint32_t per_core_N_rounded = get_compile_time_arg_val(1);
+constexpr uint32_t block_size = get_compile_time_arg_val(2);
+constexpr uint32_t Wt = get_compile_time_arg_val(3);
+constexpr uint32_t num_n_blocks = get_compile_time_arg_val(4);
+constexpr uint32_t block_h = get_compile_time_arg_val(5);
+constexpr uint32_t num_m_blocks = get_compile_time_arg_val(6);
 
 constexpr uint32_t tiles_per_batch = block_size * block_size;
+constexpr uint32_t x_tiles_per_block = block_h * block_size;
+constexpr uint32_t acc_tiles_total = block_h * per_core_N_rounded;
 
 constexpr auto cb_in0_idx = tt::CBIndex::c_0;
 constexpr auto cb_w1_idx = tt::CBIndex::c_1;
@@ -54,22 +45,20 @@ constexpr auto cb_xw1_acc_idx = tt::CBIndex::c_3;
 constexpr auto cb_xw3_acc_idx = tt::CBIndex::c_4;
 constexpr auto cb_m_out_idx = tt::CBIndex::c_5;
 
-// Accumulate X @ W into the accumulation CB using packer L1 accumulation.
-inline void matmul_accumulate_l1(
+inline void matmul_one_row(
     const tt::CBIndex cb_x_idx,
     const tt::CBIndex cb_w_idx,
     const tt::CBIndex cb_acc_idx,
-    const uint32_t n_block_offset,
+    const uint32_t x_row_offset,
+    const uint32_t acc_offset,
     const uint32_t k_block_size,
     const bool first_k_block) {
     tile_regs_acquire();
 
-    cb_wait_front(cb_w_idx, tiles_per_batch);
-
     mm_block_init_short(
         cb_x_idx, cb_w_idx, /*transpose=*/false, /*ct_dim=*/block_size, /*rt_dim=*/1U, /*kt_dim=*/k_block_size);
 
-    uint32_t in0_index = 0U;
+    uint32_t in0_index = x_row_offset;
     uint32_t in1_index = 0U;
     for (uint32_t k = 0U; k < k_block_size; ++k) {
         matmul_block(
@@ -86,14 +75,10 @@ inline void matmul_accumulate_l1(
         in1_index += block_size;
     }
 
-    cb_pop_front(cb_w_idx, tiles_per_batch);
-
     tile_regs_commit();
-    pack_l1_acc_block(cb_acc_idx, first_k_block, block_size, n_block_offset);
+    pack_l1_acc_block(cb_acc_idx, first_k_block, block_size, acc_offset);
 }
 
-// Process a single SiLU tile: M = SiLU(XW1) * XW3 = (XW1 * sigmoid(XW1)) * XW3
-// Uses 3 consecutive DST registers starting at base_reg: [xw1, xw3, scratch]
 inline void compute_silu_tile(uint32_t tile_offset, uint32_t base_reg) {
     copy_tile_init(cb_xw1_acc_idx);
     copy_tile(cb_xw1_acc_idx, tile_offset, base_reg);
@@ -101,75 +86,99 @@ inline void compute_silu_tile(uint32_t tile_offset, uint32_t base_reg) {
     copy_tile(cb_xw3_acc_idx, tile_offset, base_reg + 1U);
 
     copy_dest_values_init();
-    copy_dest_values(base_reg, base_reg + 2U);  // scratch = XW1
+    copy_dest_values(base_reg, base_reg + 2U);
     sigmoid_tile_init();
-    sigmoid_tile(base_reg + 2U);  // scratch = sigmoid(XW1)
+    sigmoid_tile(base_reg + 2U);
     mul_binary_tile_init();
-    mul_binary_tile(base_reg, base_reg + 2U, base_reg);  // base = XW1 * sigmoid = SiLU
-    mul_binary_tile(base_reg, base_reg + 1U, base_reg);  // base = SiLU * XW3 = M
+    mul_binary_tile(base_reg, base_reg + 2U, base_reg);
+    mul_binary_tile(base_reg, base_reg + 1U, base_reg);
 }
 
 void kernel_main() {
     init_sfpu(cb_in0_idx, cb_m_out_idx);
     binary_op_init_common(cb_in0_idx, cb_w1_idx, cb_m_out_idx);
 
-    for (uint32_t m = 0U; m < per_core_M; ++m) {
-        // ---- Accumulate XW1 and XW3 for this M tile-row ----
-        cb_reserve_back(cb_xw1_acc_idx, per_core_N_rounded);
-        cb_reserve_back(cb_xw3_acc_idx, per_core_N_rounded);
+    for (uint32_t mb = 0U; mb < num_m_blocks; ++mb) {
+        cb_reserve_back(cb_xw1_acc_idx, acc_tiles_total);
+        cb_reserve_back(cb_xw3_acc_idx, acc_tiles_total);
 
         for (uint32_t k_block_start = 0U; k_block_start < Wt; k_block_start += block_size) {
             const uint32_t k_block_size = std::min(block_size, Wt - k_block_start);
             const bool first_k_block = (k_block_start == 0U);
 
-            cb_wait_front(cb_in0_idx, block_size);
+            cb_wait_front(cb_in0_idx, x_tiles_per_block);
 
             for (uint32_t n_sub = 0U; n_sub < num_n_blocks; ++n_sub) {
-                uint32_t n_offset = n_sub * block_size;
+                const uint32_t n_offset = n_sub * block_size;
 
-                matmul_accumulate_l1(cb_in0_idx, cb_w1_idx, cb_xw1_acc_idx, n_offset, k_block_size, first_k_block);
+                // W1: read once, reuse across all block_h M rows
+                cb_wait_front(cb_w1_idx, tiles_per_batch);
+                for (uint32_t m_sub = 0U; m_sub < block_h; ++m_sub) {
+                    matmul_one_row(
+                        cb_in0_idx,
+                        cb_w1_idx,
+                        cb_xw1_acc_idx,
+                        m_sub * block_size,
+                        m_sub * per_core_N_rounded + n_offset,
+                        k_block_size,
+                        first_k_block);
+                }
+                cb_pop_front(cb_w1_idx, tiles_per_batch);
 
-                matmul_accumulate_l1(cb_in0_idx, cb_w3_idx, cb_xw3_acc_idx, n_offset, k_block_size, first_k_block);
+                // W3: read once, reuse across all block_h M rows
+                cb_wait_front(cb_w3_idx, tiles_per_batch);
+                for (uint32_t m_sub = 0U; m_sub < block_h; ++m_sub) {
+                    matmul_one_row(
+                        cb_in0_idx,
+                        cb_w3_idx,
+                        cb_xw3_acc_idx,
+                        m_sub * block_size,
+                        m_sub * per_core_N_rounded + n_offset,
+                        k_block_size,
+                        first_k_block);
+                }
+                cb_pop_front(cb_w3_idx, tiles_per_batch);
             }
 
-            cb_pop_front(cb_in0_idx, block_size);
+            cb_pop_front(cb_in0_idx, x_tiles_per_block);
         }
 
-        cb_push_back(cb_xw1_acc_idx, per_core_N_rounded);
-        cb_push_back(cb_xw3_acc_idx, per_core_N_rounded);
+        cb_push_back(cb_xw1_acc_idx, acc_tiles_total);
+        cb_push_back(cb_xw3_acc_idx, acc_tiles_total);
 
-        // ---- SiLU fusion: M = SiLU(XW1) * XW3 ----
-        cb_wait_front(cb_xw1_acc_idx, per_core_N_rounded);
-        cb_wait_front(cb_xw3_acc_idx, per_core_N_rounded);
+        // ---- SiLU fusion: M = SiLU(XW1) * XW3 for all block_h rows ----
+        cb_wait_front(cb_xw1_acc_idx, acc_tiles_total);
+        cb_wait_front(cb_xw3_acc_idx, acc_tiles_total);
 
-        for (uint32_t n_block_start = 0U; n_block_start < per_core_N; n_block_start += block_size) {
-            const uint32_t n_block_size = std::min(block_size, per_core_N - n_block_start);
+        for (uint32_t m_sub = 0U; m_sub < block_h; ++m_sub) {
+            const uint32_t row_offset = m_sub * per_core_N_rounded;
 
-            uint32_t n = 0U;
-            // Batched: process 2 tiles per acquire/commit when possible
-            for (; n + 1U < n_block_size; n += 2U) {
-                tile_regs_acquire();
-                compute_silu_tile(n_block_start + n, 0U);
-                compute_silu_tile(n_block_start + n + 1U, 1U);
-                tile_regs_commit();
-                pack_and_push_block(cb_m_out_idx, 2U);
-            }
-            if (n < n_block_size) {
-                tile_regs_acquire();
-                compute_silu_tile(n_block_start + n, 0U);
-                tile_regs_commit();
-                pack_and_push(0U, cb_m_out_idx);
-            }
+            for (uint32_t n_block_start = 0U; n_block_start < per_core_N; n_block_start += block_size) {
+                const uint32_t n_block_size = std::min(block_size, per_core_N - n_block_start);
 
-            // Pad to block_size if needed
-            if (n_block_size < block_size) {
-                tile_regs_acquire();
-                tile_regs_commit();
-                pack_and_push_block(cb_m_out_idx, block_size - n_block_size);
+                uint32_t n = 0U;
+                for (; n + 1U < n_block_size; n += 2U) {
+                    tile_regs_acquire();
+                    compute_silu_tile(row_offset + n_block_start + n, 0U);
+                    compute_silu_tile(row_offset + n_block_start + n + 1U, 1U);
+                    tile_regs_commit();
+                    pack_and_push_block(cb_m_out_idx, 2U);
+                }
+                if (n < n_block_size) {
+                    tile_regs_acquire();
+                    compute_silu_tile(row_offset + n_block_start + n, 0U);
+                    tile_regs_commit();
+                    pack_and_push(0U, cb_m_out_idx);
+                }
+                if (n_block_size < block_size) {
+                    tile_regs_acquire();
+                    tile_regs_commit();
+                    pack_and_push_block(cb_m_out_idx, block_size - n_block_size);
+                }
             }
         }
 
-        cb_pop_front(cb_xw1_acc_idx, per_core_N_rounded);
-        cb_pop_front(cb_xw3_acc_idx, per_core_N_rounded);
+        cb_pop_front(cb_xw1_acc_idx, acc_tiles_total);
+        cb_pop_front(cb_xw3_acc_idx, acc_tiles_total);
     }
 }

--- a/tt-train/sources/ttml/metal/ops/swiglu_gate_up/device/kernels/compute/swiglu_gate_up_compute.cpp
+++ b/tt-train/sources/ttml/metal/ops/swiglu_gate_up/device/kernels/compute/swiglu_gate_up_compute.cpp
@@ -24,6 +24,9 @@
 // Outer loop iterates over M-blocks of block_h rows. For each M-block, the
 // full K-loop runs once, reusing weight tiles across all block_h M rows.
 // This amortizes weight DRAM reads by block_h×.
+//
+// Performance-critical: mm_block_init_short and pack_reconfig_* are hoisted
+// out of the per-row loop to avoid redundant hardware reconfiguration.
 // ============================================================================
 
 constexpr uint32_t per_core_N = get_compile_time_arg_val(0);
@@ -45,18 +48,15 @@ constexpr auto cb_xw1_acc_idx = tt::CBIndex::c_3;
 constexpr auto cb_xw3_acc_idx = tt::CBIndex::c_4;
 constexpr auto cb_m_out_idx = tt::CBIndex::c_5;
 
-inline void matmul_one_row(
+// Matmul one row and pack to L1 accumulator — no init_short, no pack reconfig.
+inline void matmul_one_row_fast(
     const tt::CBIndex cb_x_idx,
     const tt::CBIndex cb_w_idx,
     const tt::CBIndex cb_acc_idx,
     const uint32_t x_row_offset,
     const uint32_t acc_offset,
-    const uint32_t k_block_size,
-    const bool first_k_block) {
+    const uint32_t k_block_size) {
     tile_regs_acquire();
-
-    mm_block_init_short(
-        cb_x_idx, cb_w_idx, /*transpose=*/false, /*ct_dim=*/block_size, /*rt_dim=*/1U, /*kt_dim=*/k_block_size);
 
     uint32_t in0_index = x_row_offset;
     uint32_t in1_index = 0U;
@@ -76,7 +76,11 @@ inline void matmul_one_row(
     }
 
     tile_regs_commit();
-    pack_l1_acc_block(cb_acc_idx, first_k_block, block_size, acc_offset);
+    tile_regs_wait();
+    for (uint32_t t = 0U; t < block_size; ++t) {
+        pack_tile</* out_of_order_output = */ true>(t, cb_acc_idx, acc_offset + t);
+    }
+    tile_regs_release();
 }
 
 inline void compute_silu_tile(uint32_t tile_offset, uint32_t base_reg) {
@@ -92,6 +96,27 @@ inline void compute_silu_tile(uint32_t tile_offset, uint32_t base_reg) {
     mul_binary_tile_init();
     mul_binary_tile(base_reg, base_reg + 2U, base_reg);
     mul_binary_tile(base_reg, base_reg + 1U, base_reg);
+}
+
+// Process block_h rows of matmul for one weight matrix (W1 or W3).
+// Hoists mm_block_init_short and pack_reconfig outside the row loop.
+inline void matmul_rows_for_weight(
+    const tt::CBIndex cb_w_idx,
+    const tt::CBIndex cb_acc_idx,
+    const uint32_t n_offset,
+    const uint32_t k_block_size,
+    const bool first_k_block) {
+    mm_block_init_short(
+        cb_in0_idx, cb_w_idx, /*transpose=*/false, /*ct_dim=*/block_size, /*rt_dim=*/1U, /*kt_dim=*/k_block_size);
+    pack_reconfig_data_format(cb_acc_idx);
+    pack_reconfig_l1_acc(first_k_block ? 0 : 1U);
+
+    for (uint32_t m_sub = 0U; m_sub < block_h; ++m_sub) {
+        matmul_one_row_fast(
+            cb_in0_idx, cb_w_idx, cb_acc_idx, m_sub * block_size, m_sub * per_core_N_rounded + n_offset, k_block_size);
+    }
+
+    pack_reconfig_l1_acc(0);
 }
 
 void kernel_main() {
@@ -111,32 +136,12 @@ void kernel_main() {
             for (uint32_t n_sub = 0U; n_sub < num_n_blocks; ++n_sub) {
                 const uint32_t n_offset = n_sub * block_size;
 
-                // W1: read once, reuse across all block_h M rows
                 cb_wait_front(cb_w1_idx, tiles_per_batch);
-                for (uint32_t m_sub = 0U; m_sub < block_h; ++m_sub) {
-                    matmul_one_row(
-                        cb_in0_idx,
-                        cb_w1_idx,
-                        cb_xw1_acc_idx,
-                        m_sub * block_size,
-                        m_sub * per_core_N_rounded + n_offset,
-                        k_block_size,
-                        first_k_block);
-                }
+                matmul_rows_for_weight(cb_w1_idx, cb_xw1_acc_idx, n_offset, k_block_size, first_k_block);
                 cb_pop_front(cb_w1_idx, tiles_per_batch);
 
-                // W3: read once, reuse across all block_h M rows
                 cb_wait_front(cb_w3_idx, tiles_per_batch);
-                for (uint32_t m_sub = 0U; m_sub < block_h; ++m_sub) {
-                    matmul_one_row(
-                        cb_in0_idx,
-                        cb_w3_idx,
-                        cb_xw3_acc_idx,
-                        m_sub * block_size,
-                        m_sub * per_core_N_rounded + n_offset,
-                        k_block_size,
-                        first_k_block);
-                }
+                matmul_rows_for_weight(cb_w3_idx, cb_xw3_acc_idx, n_offset, k_block_size, first_k_block);
                 cb_pop_front(cb_w3_idx, tiles_per_batch);
             }
 

--- a/tt-train/sources/ttml/metal/ops/swiglu_gate_up/device/kernels/dataflow/reader_in0_receiver.cpp
+++ b/tt-train/sources/ttml/metal/ops/swiglu_gate_up/device/kernels/dataflow/reader_in0_receiver.cpp
@@ -6,7 +6,7 @@
 // IN0 Receiver (RISCV_1) — Non-left-column cores
 //
 // Receives block_h rows of X tiles via row multicast from the left-column
-// sender. Outer loop iterates num_m_blocks × num_k_blocks times.
+// sender. Outer loop over m_blocks, inner loop over k_blocks.
 // ============================================================================
 
 #include "api/dataflow/dataflow_api.h"
@@ -21,7 +21,7 @@ constexpr uint32_t num_m_blocks = get_compile_time_arg_val(3);
 constexpr uint32_t in0_mcast_sender_semaphore_id = get_compile_time_arg_val(4);
 constexpr uint32_t in0_mcast_receiver_semaphore_id = get_compile_time_arg_val(5);
 
-constexpr uint32_t x_tiles_per_recv = block_h * block_size;
+constexpr uint32_t x_tiles_per_block = block_h * block_size;
 constexpr uint32_t num_k_blocks = (Wt + block_size - 1U) / block_size;
 
 void kernel_main() {
@@ -37,9 +37,9 @@ void kernel_main() {
     const uint64_t sender_semaphore_noc_addr = get_noc_addr(sender_noc_x, sender_noc_y, mcast_sender_semaphore_addr);
 
     for (uint32_t mb = 0U; mb < num_m_blocks; ++mb) {
-        for (uint32_t k = 0U; k < num_k_blocks; ++k) {
+        for (uint32_t k_block = 0U; k_block < num_k_blocks; ++k_block) {
             mcast_receiver_reserve_and_receive(
-                cb_in0_idx, x_tiles_per_recv, receiver_sem_ptr, sender_semaphore_noc_addr);
+                cb_in0_idx, x_tiles_per_block, receiver_sem_ptr, sender_semaphore_noc_addr);
         }
     }
 }

--- a/tt-train/sources/ttml/metal/ops/swiglu_gate_up/device/kernels/dataflow/reader_in0_receiver.cpp
+++ b/tt-train/sources/ttml/metal/ops/swiglu_gate_up/device/kernels/dataflow/reader_in0_receiver.cpp
@@ -1,0 +1,42 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// ============================================================================
+// IN0 Receiver (RISCV_1) — Non-left-column cores
+//
+// Receives X tiles via row multicast from the left-column sender.
+// ============================================================================
+
+#include "api/dataflow/dataflow_api.h"
+#include "tt-train/sources/ttml/metal/common/dataflow_utils.hpp"
+
+constexpr auto cb_in0_idx = tt::CBIndex::c_0;
+
+constexpr uint32_t block_size = get_compile_time_arg_val(0);
+constexpr uint32_t Wt = get_compile_time_arg_val(1);
+constexpr uint32_t per_core_M = get_compile_time_arg_val(2);
+constexpr uint32_t num_n_blocks = get_compile_time_arg_val(3);
+constexpr uint32_t in0_mcast_sender_semaphore_id = get_compile_time_arg_val(4);
+constexpr uint32_t in0_mcast_receiver_semaphore_id = get_compile_time_arg_val(5);
+
+void kernel_main() {
+    uint32_t ra = 0U;
+    const uint32_t sender_noc_x = get_arg_val<uint32_t>(ra++);
+    const uint32_t sender_noc_y = get_arg_val<uint32_t>(ra++);
+
+    const uint32_t mcast_sender_semaphore_addr = get_semaphore(in0_mcast_sender_semaphore_id);
+    const uint32_t mcast_receiver_semaphore_addr = get_semaphore(in0_mcast_receiver_semaphore_id);
+
+    volatile tt_l1_ptr uint32_t* receiver_sem_ptr =
+        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(mcast_receiver_semaphore_addr);
+    const uint64_t sender_semaphore_noc_addr = get_noc_addr(sender_noc_x, sender_noc_y, mcast_sender_semaphore_addr);
+
+    const uint32_t num_k_blocks = (Wt + block_size - 1U) / block_size;
+
+    for (uint32_t m = 0U; m < per_core_M; ++m) {
+        for (uint32_t k = 0U; k < num_k_blocks; ++k) {
+            mcast_receiver_reserve_and_receive(cb_in0_idx, block_size, receiver_sem_ptr, sender_semaphore_noc_addr);
+        }
+    }
+}

--- a/tt-train/sources/ttml/metal/ops/swiglu_gate_up/device/kernels/dataflow/reader_in0_receiver.cpp
+++ b/tt-train/sources/ttml/metal/ops/swiglu_gate_up/device/kernels/dataflow/reader_in0_receiver.cpp
@@ -5,7 +5,8 @@
 // ============================================================================
 // IN0 Receiver (RISCV_1) — Non-left-column cores
 //
-// Receives X tiles via row multicast from the left-column sender.
+// Receives block_h rows of X tiles via row multicast from the left-column
+// sender. Outer loop iterates num_m_blocks × num_k_blocks times.
 // ============================================================================
 
 #include "api/dataflow/dataflow_api.h"
@@ -15,10 +16,13 @@ constexpr auto cb_in0_idx = tt::CBIndex::c_0;
 
 constexpr uint32_t block_size = get_compile_time_arg_val(0);
 constexpr uint32_t Wt = get_compile_time_arg_val(1);
-constexpr uint32_t per_core_M = get_compile_time_arg_val(2);
-constexpr uint32_t num_n_blocks = get_compile_time_arg_val(3);
+constexpr uint32_t block_h = get_compile_time_arg_val(2);
+constexpr uint32_t num_m_blocks = get_compile_time_arg_val(3);
 constexpr uint32_t in0_mcast_sender_semaphore_id = get_compile_time_arg_val(4);
 constexpr uint32_t in0_mcast_receiver_semaphore_id = get_compile_time_arg_val(5);
+
+constexpr uint32_t x_tiles_per_recv = block_h * block_size;
+constexpr uint32_t num_k_blocks = (Wt + block_size - 1U) / block_size;
 
 void kernel_main() {
     uint32_t ra = 0U;
@@ -32,11 +36,10 @@ void kernel_main() {
         reinterpret_cast<volatile tt_l1_ptr uint32_t*>(mcast_receiver_semaphore_addr);
     const uint64_t sender_semaphore_noc_addr = get_noc_addr(sender_noc_x, sender_noc_y, mcast_sender_semaphore_addr);
 
-    const uint32_t num_k_blocks = (Wt + block_size - 1U) / block_size;
-
-    for (uint32_t m = 0U; m < per_core_M; ++m) {
+    for (uint32_t mb = 0U; mb < num_m_blocks; ++mb) {
         for (uint32_t k = 0U; k < num_k_blocks; ++k) {
-            mcast_receiver_reserve_and_receive(cb_in0_idx, block_size, receiver_sem_ptr, sender_semaphore_noc_addr);
+            mcast_receiver_reserve_and_receive(
+                cb_in0_idx, x_tiles_per_recv, receiver_sem_ptr, sender_semaphore_noc_addr);
         }
     }
 }

--- a/tt-train/sources/ttml/metal/ops/swiglu_gate_up/device/kernels/dataflow/reader_in0_sender.cpp
+++ b/tt-train/sources/ttml/metal/ops/swiglu_gate_up/device/kernels/dataflow/reader_in0_sender.cpp
@@ -1,0 +1,122 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// ============================================================================
+// IN0 Sender (RISCV_1) — Left column cores
+//
+// Reads X tiles from DRAM and multicasts across the row to all C cores.
+// Each left-column core handles its row's M tile-rows.
+//
+// Loop structure:
+//   for m in per_core_M:
+//     for k_block in K_blocks:
+//       for n_sub in num_n_blocks:  (sync with compute's N inner loop)
+//         read X[m, k_block] from DRAM, multicast across row
+// ============================================================================
+
+#include <algorithm>
+
+#include "api/dataflow/dataflow_api.h"
+#include "tt-train/sources/ttml/metal/common/dataflow_utils.hpp"
+
+constexpr auto cb_in0_idx = tt::CBIndex::c_0;
+
+constexpr uint32_t block_size = get_compile_time_arg_val(0);
+constexpr uint32_t Wt = get_compile_time_arg_val(1);
+constexpr uint32_t per_core_M = get_compile_time_arg_val(2);
+constexpr uint32_t num_n_blocks = get_compile_time_arg_val(3);
+constexpr uint32_t in0_mcast_sender_semaphore_id = get_compile_time_arg_val(4);
+constexpr uint32_t in0_mcast_receiver_semaphore_id = get_compile_time_arg_val(5);
+
+void kernel_main() {
+    uint32_t ra = 0U;
+    const uint32_t x_address = get_arg_val<uint32_t>(ra++);
+    const uint32_t m_start = get_arg_val<uint32_t>(ra++);
+    const uint32_t actual_m_tiles = get_arg_val<uint32_t>(ra++);
+    const uint32_t mcast_dest_noc_start_x = get_arg_val<uint32_t>(ra++);
+    const uint32_t mcast_dest_noc_start_y = get_arg_val<uint32_t>(ra++);
+    const uint32_t mcast_dest_noc_end_x = get_arg_val<uint32_t>(ra++);
+    const uint32_t mcast_dest_noc_end_y = get_arg_val<uint32_t>(ra++);
+    const uint32_t num_receivers = get_arg_val<uint32_t>(ra++);
+
+    const uint32_t tile_bytes = get_tile_size(cb_in0_idx);
+    const uint32_t mcast_sender_semaphore_addr = get_semaphore(in0_mcast_sender_semaphore_id);
+    const uint32_t mcast_receiver_semaphore_addr = get_semaphore(in0_mcast_receiver_semaphore_id);
+
+    constexpr auto x_args = TensorAccessorArgs<6>();
+    const auto x_addr_gen = TensorAccessor(x_args, x_address, tile_bytes);
+
+    volatile tt_l1_ptr uint32_t* sender_sem_ptr =
+        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(mcast_sender_semaphore_addr);
+    volatile tt_l1_ptr uint32_t* receiver_sem_ptr =
+        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(mcast_receiver_semaphore_addr);
+
+    const McastLoopbackConfig mcast_cfg = {
+        .sender_sem_ptr = sender_sem_ptr,
+        .receiver_sem_ptr = receiver_sem_ptr,
+        .receiver_sem_addr = mcast_receiver_semaphore_addr,
+        .noc_start_x = mcast_dest_noc_start_x,
+        .noc_start_y = mcast_dest_noc_start_y,
+        .noc_end_x = mcast_dest_noc_end_x,
+        .noc_end_y = mcast_dest_noc_end_y,
+        .num_receivers = num_receivers,
+    };
+
+    for (uint32_t m = 0U; m < per_core_M; ++m) {
+        const uint32_t m_row = std::min(m_start + m, m_start + actual_m_tiles - 1U);
+        const uint32_t x_row_start = m_row * Wt;
+
+        for (uint32_t k_block_start = 0U; k_block_start < Wt; k_block_start += block_size) {
+            const uint32_t k_block_size = std::min(block_size, Wt - k_block_start);
+
+            if (num_receivers > 0U) {
+                mcast_sender_wait_for_receivers(sender_sem_ptr, num_receivers);
+                cb_reserve_back(cb_in0_idx, block_size);
+                uint32_t l1_addr = get_write_ptr(cb_in0_idx);
+                for (uint32_t t = 0U; t < k_block_size; ++t) {
+                    uint64_t noc_addr = x_addr_gen.get_noc_addr(x_row_start + k_block_start + t);
+                    noc_async_read(noc_addr, l1_addr, tile_bytes);
+                    l1_addr += tile_bytes;
+                }
+                // Pad remaining slots with last valid tile
+                if (k_block_size < block_size) {
+                    uint64_t pad_addr = x_addr_gen.get_noc_addr(x_row_start + k_block_start + k_block_size - 1U);
+                    for (uint32_t t = k_block_size; t < block_size; ++t) {
+                        noc_async_read(pad_addr, l1_addr, tile_bytes);
+                        l1_addr += tile_bytes;
+                    }
+                }
+                noc_async_read_barrier();
+                mcast_sender_send_data_loopback(
+                    get_write_ptr(cb_in0_idx),
+                    mcast_dest_noc_start_x,
+                    mcast_dest_noc_start_y,
+                    mcast_dest_noc_end_x,
+                    mcast_dest_noc_end_y,
+                    block_size * tile_bytes,
+                    num_receivers + 1U);
+                mcast_sender_signal_receivers_loopback(
+                    receiver_sem_ptr,
+                    mcast_receiver_semaphore_addr,
+                    mcast_dest_noc_start_x,
+                    mcast_dest_noc_start_y,
+                    mcast_dest_noc_end_x,
+                    mcast_dest_noc_end_y,
+                    num_receivers + 1U);
+                cb_push_back(cb_in0_idx, block_size);
+            } else {
+                // Single column — no multicast, just read locally
+                cb_reserve_back(cb_in0_idx, block_size);
+                uint32_t l1_addr = get_write_ptr(cb_in0_idx);
+                for (uint32_t t = 0U; t < k_block_size; ++t) {
+                    uint64_t noc_addr = x_addr_gen.get_noc_addr(x_row_start + k_block_start + t);
+                    noc_async_read(noc_addr, l1_addr, tile_bytes);
+                    l1_addr += tile_bytes;
+                }
+                noc_async_read_barrier();
+                cb_push_back(cb_in0_idx, block_size);
+            }
+        }
+    }
+}

--- a/tt-train/sources/ttml/metal/ops/swiglu_gate_up/device/kernels/dataflow/reader_in0_sender.cpp
+++ b/tt-train/sources/ttml/metal/ops/swiglu_gate_up/device/kernels/dataflow/reader_in0_sender.cpp
@@ -5,14 +5,8 @@
 // ============================================================================
 // IN0 Sender (RISCV_1) — Left column cores
 //
-// Reads X tiles from DRAM and multicasts across the row to all C cores.
-// Each left-column core handles its row's M tile-rows.
-//
-// Loop structure:
-//   for m in per_core_M:
-//     for k_block in K_blocks:
-//       for n_sub in num_n_blocks:  (sync with compute's N inner loop)
-//         read X[m, k_block] from DRAM, multicast across row
+// Reads block_h rows of X tiles from DRAM per K-block and multicasts across
+// the row. Outer loop iterates num_m_blocks times.
 // ============================================================================
 
 #include <algorithm>
@@ -24,10 +18,12 @@ constexpr auto cb_in0_idx = tt::CBIndex::c_0;
 
 constexpr uint32_t block_size = get_compile_time_arg_val(0);
 constexpr uint32_t Wt = get_compile_time_arg_val(1);
-constexpr uint32_t per_core_M = get_compile_time_arg_val(2);
-constexpr uint32_t num_n_blocks = get_compile_time_arg_val(3);
+constexpr uint32_t block_h = get_compile_time_arg_val(2);
+constexpr uint32_t num_m_blocks = get_compile_time_arg_val(3);
 constexpr uint32_t in0_mcast_sender_semaphore_id = get_compile_time_arg_val(4);
 constexpr uint32_t in0_mcast_receiver_semaphore_id = get_compile_time_arg_val(5);
+
+constexpr uint32_t x_tiles_per_send = block_h * block_size;
 
 void kernel_main() {
     uint32_t ra = 0U;
@@ -63,28 +59,30 @@ void kernel_main() {
         .num_receivers = num_receivers,
     };
 
-    for (uint32_t m = 0U; m < per_core_M; ++m) {
-        const uint32_t m_row = std::min(m_start + m, m_start + actual_m_tiles - 1U);
-        const uint32_t x_row_start = m_row * Wt;
-
+    for (uint32_t mb = 0U; mb < num_m_blocks; ++mb) {
         for (uint32_t k_block_start = 0U; k_block_start < Wt; k_block_start += block_size) {
             const uint32_t k_block_size = std::min(block_size, Wt - k_block_start);
 
             if (num_receivers > 0U) {
                 mcast_sender_wait_for_receivers(sender_sem_ptr, num_receivers);
-                cb_reserve_back(cb_in0_idx, block_size);
+                cb_reserve_back(cb_in0_idx, x_tiles_per_send);
                 uint32_t l1_addr = get_write_ptr(cb_in0_idx);
-                for (uint32_t t = 0U; t < k_block_size; ++t) {
-                    uint64_t noc_addr = x_addr_gen.get_noc_addr(x_row_start + k_block_start + t);
-                    noc_async_read(noc_addr, l1_addr, tile_bytes);
-                    l1_addr += tile_bytes;
-                }
-                // Pad remaining slots with last valid tile
-                if (k_block_size < block_size) {
-                    uint64_t pad_addr = x_addr_gen.get_noc_addr(x_row_start + k_block_start + k_block_size - 1U);
-                    for (uint32_t t = k_block_size; t < block_size; ++t) {
-                        noc_async_read(pad_addr, l1_addr, tile_bytes);
+
+                for (uint32_t m_sub = 0U; m_sub < block_h; ++m_sub) {
+                    uint32_t m = mb * block_h + m_sub;
+                    uint32_t m_row = std::min(m_start + m, m_start + actual_m_tiles - 1U);
+                    uint32_t x_row_start = m_row * Wt;
+                    for (uint32_t t = 0U; t < k_block_size; ++t) {
+                        uint64_t noc_addr = x_addr_gen.get_noc_addr(x_row_start + k_block_start + t);
+                        noc_async_read(noc_addr, l1_addr, tile_bytes);
                         l1_addr += tile_bytes;
+                    }
+                    if (k_block_size < block_size) {
+                        uint64_t pad_addr = x_addr_gen.get_noc_addr(x_row_start + k_block_start + k_block_size - 1U);
+                        for (uint32_t t = k_block_size; t < block_size; ++t) {
+                            noc_async_read(pad_addr, l1_addr, tile_bytes);
+                            l1_addr += tile_bytes;
+                        }
                     }
                 }
                 noc_async_read_barrier();
@@ -94,7 +92,7 @@ void kernel_main() {
                     mcast_dest_noc_start_y,
                     mcast_dest_noc_end_x,
                     mcast_dest_noc_end_y,
-                    block_size * tile_bytes,
+                    x_tiles_per_send * tile_bytes,
                     num_receivers + 1U);
                 mcast_sender_signal_receivers_loopback(
                     receiver_sem_ptr,
@@ -104,18 +102,29 @@ void kernel_main() {
                     mcast_dest_noc_end_x,
                     mcast_dest_noc_end_y,
                     num_receivers + 1U);
-                cb_push_back(cb_in0_idx, block_size);
+                cb_push_back(cb_in0_idx, x_tiles_per_send);
             } else {
-                // Single column — no multicast, just read locally
-                cb_reserve_back(cb_in0_idx, block_size);
+                cb_reserve_back(cb_in0_idx, x_tiles_per_send);
                 uint32_t l1_addr = get_write_ptr(cb_in0_idx);
-                for (uint32_t t = 0U; t < k_block_size; ++t) {
-                    uint64_t noc_addr = x_addr_gen.get_noc_addr(x_row_start + k_block_start + t);
-                    noc_async_read(noc_addr, l1_addr, tile_bytes);
-                    l1_addr += tile_bytes;
+                for (uint32_t m_sub = 0U; m_sub < block_h; ++m_sub) {
+                    uint32_t m = mb * block_h + m_sub;
+                    uint32_t m_row = std::min(m_start + m, m_start + actual_m_tiles - 1U);
+                    uint32_t x_row_start = m_row * Wt;
+                    for (uint32_t t = 0U; t < k_block_size; ++t) {
+                        uint64_t noc_addr = x_addr_gen.get_noc_addr(x_row_start + k_block_start + t);
+                        noc_async_read(noc_addr, l1_addr, tile_bytes);
+                        l1_addr += tile_bytes;
+                    }
+                    if (k_block_size < block_size) {
+                        uint64_t pad_addr = x_addr_gen.get_noc_addr(x_row_start + k_block_start + k_block_size - 1U);
+                        for (uint32_t t = k_block_size; t < block_size; ++t) {
+                            noc_async_read(pad_addr, l1_addr, tile_bytes);
+                            l1_addr += tile_bytes;
+                        }
+                    }
                 }
                 noc_async_read_barrier();
-                cb_push_back(cb_in0_idx, block_size);
+                cb_push_back(cb_in0_idx, x_tiles_per_send);
             }
         }
     }

--- a/tt-train/sources/ttml/metal/ops/swiglu_gate_up/device/kernels/dataflow/reader_in0_sender.cpp
+++ b/tt-train/sources/ttml/metal/ops/swiglu_gate_up/device/kernels/dataflow/reader_in0_sender.cpp
@@ -6,7 +6,7 @@
 // IN0 Sender (RISCV_1) — Left column cores
 //
 // Reads block_h rows of X tiles from DRAM per K-block and multicasts across
-// the row. Outer loop iterates num_m_blocks times.
+// the row. Outer loop over m_blocks, inner loop over k_blocks.
 // ============================================================================
 
 #include <algorithm>
@@ -23,7 +23,8 @@ constexpr uint32_t num_m_blocks = get_compile_time_arg_val(3);
 constexpr uint32_t in0_mcast_sender_semaphore_id = get_compile_time_arg_val(4);
 constexpr uint32_t in0_mcast_receiver_semaphore_id = get_compile_time_arg_val(5);
 
-constexpr uint32_t x_tiles_per_send = block_h * block_size;
+constexpr uint32_t x_tiles_per_block = block_h * block_size;
+constexpr uint32_t num_k_blocks = (Wt + block_size - 1U) / block_size;
 
 void kernel_main() {
     uint32_t ra = 0U;
@@ -60,12 +61,13 @@ void kernel_main() {
     };
 
     for (uint32_t mb = 0U; mb < num_m_blocks; ++mb) {
-        for (uint32_t k_block_start = 0U; k_block_start < Wt; k_block_start += block_size) {
+        for (uint32_t k_block = 0U; k_block < num_k_blocks; ++k_block) {
+            const uint32_t k_block_start = k_block * block_size;
             const uint32_t k_block_size = std::min(block_size, Wt - k_block_start);
 
             if (num_receivers > 0U) {
                 mcast_sender_wait_for_receivers(sender_sem_ptr, num_receivers);
-                cb_reserve_back(cb_in0_idx, x_tiles_per_send);
+                cb_reserve_back(cb_in0_idx, x_tiles_per_block);
                 uint32_t l1_addr = get_write_ptr(cb_in0_idx);
 
                 for (uint32_t m_sub = 0U; m_sub < block_h; ++m_sub) {
@@ -92,7 +94,7 @@ void kernel_main() {
                     mcast_dest_noc_start_y,
                     mcast_dest_noc_end_x,
                     mcast_dest_noc_end_y,
-                    x_tiles_per_send * tile_bytes,
+                    x_tiles_per_block * tile_bytes,
                     num_receivers + 1U);
                 mcast_sender_signal_receivers_loopback(
                     receiver_sem_ptr,
@@ -102,9 +104,9 @@ void kernel_main() {
                     mcast_dest_noc_end_x,
                     mcast_dest_noc_end_y,
                     num_receivers + 1U);
-                cb_push_back(cb_in0_idx, x_tiles_per_send);
+                cb_push_back(cb_in0_idx, x_tiles_per_block);
             } else {
-                cb_reserve_back(cb_in0_idx, x_tiles_per_send);
+                cb_reserve_back(cb_in0_idx, x_tiles_per_block);
                 uint32_t l1_addr = get_write_ptr(cb_in0_idx);
                 for (uint32_t m_sub = 0U; m_sub < block_h; ++m_sub) {
                     uint32_t m = mb * block_h + m_sub;
@@ -124,7 +126,7 @@ void kernel_main() {
                     }
                 }
                 noc_async_read_barrier();
-                cb_push_back(cb_in0_idx, x_tiles_per_send);
+                cb_push_back(cb_in0_idx, x_tiles_per_block);
             }
         }
     }

--- a/tt-train/sources/ttml/metal/ops/swiglu_gate_up/device/kernels/dataflow/reader_in1_receiver_writer.cpp
+++ b/tt-train/sources/ttml/metal/ops/swiglu_gate_up/device/kernels/dataflow/reader_in1_receiver_writer.cpp
@@ -7,6 +7,8 @@
 //
 // Outer loop iterates num_m_blocks times. For each m_block, receives W1/W3
 // weight batches ONCE, then writes block_h rows of M tiles to DRAM.
+//
+// N-block batching: receives n_blocks_per_batch N-blocks per multicast.
 // ============================================================================
 
 #include <algorithm>
@@ -26,10 +28,13 @@ constexpr uint32_t num_m_blocks = get_compile_time_arg_val(4);
 constexpr uint32_t per_core_N = get_compile_time_arg_val(5);
 constexpr uint32_t per_core_N_rounded = get_compile_time_arg_val(6);
 constexpr uint32_t num_n_blocks = get_compile_time_arg_val(7);
-constexpr uint32_t in1_mcast_sender_semaphore_id = get_compile_time_arg_val(8);
-constexpr uint32_t in1_mcast_receiver_semaphore_id = get_compile_time_arg_val(9);
+constexpr uint32_t n_blocks_per_batch = get_compile_time_arg_val(8);
+constexpr uint32_t num_n_batch_iters = get_compile_time_arg_val(9);
+constexpr uint32_t in1_mcast_sender_semaphore_id = get_compile_time_arg_val(10);
+constexpr uint32_t in1_mcast_receiver_semaphore_id = get_compile_time_arg_val(11);
 
-constexpr uint32_t tiles_per_batch = block_size * block_size;
+constexpr uint32_t tiles_per_n_block = block_size * block_size;
+constexpr uint32_t tiles_per_receive = n_blocks_per_batch * tiles_per_n_block;
 constexpr uint32_t num_k_blocks = (Wt + block_size - 1U) / block_size;
 
 void kernel_main() {
@@ -46,7 +51,7 @@ void kernel_main() {
     const uint32_t mcast_sender_semaphore_addr = get_semaphore(in1_mcast_sender_semaphore_id);
     const uint32_t mcast_receiver_semaphore_addr = get_semaphore(in1_mcast_receiver_semaphore_id);
 
-    constexpr auto m_args = TensorAccessorArgs<10>();
+    constexpr auto m_args = TensorAccessorArgs<12>();
     const auto m_addr_gen = TensorAccessor(m_args, m_address, tile_bytes);
 
     volatile tt_l1_ptr uint32_t* receiver_sem_ptr =
@@ -54,13 +59,13 @@ void kernel_main() {
     const uint64_t sender_semaphore_noc_addr = get_noc_addr(sender_noc_x, sender_noc_y, mcast_sender_semaphore_addr);
 
     for (uint32_t mb = 0U; mb < num_m_blocks; ++mb) {
-        // ---- Receive W1/W3 for all K-blocks (once per m_block) ----
+        // ---- Receive W1/W3 for all K-blocks (once per m_block), batched N-blocks ----
         for (uint32_t k = 0U; k < num_k_blocks; ++k) {
-            for (uint32_t n_sub = 0U; n_sub < num_n_blocks; ++n_sub) {
+            for (uint32_t n_batch = 0U; n_batch < num_n_batch_iters; ++n_batch) {
                 mcast_receiver_reserve_and_receive(
-                    cb_w1_idx, tiles_per_batch, receiver_sem_ptr, sender_semaphore_noc_addr);
+                    cb_w1_idx, tiles_per_receive, receiver_sem_ptr, sender_semaphore_noc_addr);
                 mcast_receiver_reserve_and_receive(
-                    cb_w3_idx, tiles_per_batch, receiver_sem_ptr, sender_semaphore_noc_addr);
+                    cb_w3_idx, tiles_per_receive, receiver_sem_ptr, sender_semaphore_noc_addr);
             }
         }
 

--- a/tt-train/sources/ttml/metal/ops/swiglu_gate_up/device/kernels/dataflow/reader_in1_receiver_writer.cpp
+++ b/tt-train/sources/ttml/metal/ops/swiglu_gate_up/device/kernels/dataflow/reader_in1_receiver_writer.cpp
@@ -5,8 +5,8 @@
 // ============================================================================
 // IN1 Receiver + M Writer (RISCV_0) — Non-top-row cores
 //
-// Outer loop iterates num_m_blocks times. For each m_block, receives W1/W3
-// one N-block at a time, then writes block_h rows of M tiles to DRAM.
+// Outer loop over m_blocks. Inner: over k_blocks then n_blocks (receive W1/W3);
+// then write block_h rows of M to DRAM.
 // ============================================================================
 
 #include <algorithm>
@@ -24,11 +24,11 @@ constexpr uint32_t hidden_Wt = get_compile_time_arg_val(2);
 constexpr uint32_t block_h = get_compile_time_arg_val(3);
 constexpr uint32_t num_m_blocks = get_compile_time_arg_val(4);
 constexpr uint32_t per_core_N = get_compile_time_arg_val(5);
-constexpr uint32_t per_core_N_rounded = get_compile_time_arg_val(6);
-constexpr uint32_t num_n_blocks = get_compile_time_arg_val(7);
-constexpr uint32_t in1_mcast_sender_semaphore_id = get_compile_time_arg_val(8);
-constexpr uint32_t in1_mcast_receiver_semaphore_id = get_compile_time_arg_val(9);
+constexpr uint32_t in1_mcast_sender_semaphore_id = get_compile_time_arg_val(6);
+constexpr uint32_t in1_mcast_receiver_semaphore_id = get_compile_time_arg_val(7);
 
+constexpr uint32_t per_core_N_rounded = ((per_core_N + block_size - 1U) / block_size) * block_size;
+constexpr uint32_t num_n_blocks = per_core_N_rounded / block_size;
 constexpr uint32_t tiles_per_n_block = block_size * block_size;
 constexpr uint32_t num_k_blocks = (Wt + block_size - 1U) / block_size;
 
@@ -46,7 +46,7 @@ void kernel_main() {
     const uint32_t mcast_sender_semaphore_addr = get_semaphore(in1_mcast_sender_semaphore_id);
     const uint32_t mcast_receiver_semaphore_addr = get_semaphore(in1_mcast_receiver_semaphore_id);
 
-    constexpr auto m_args = TensorAccessorArgs<10>();
+    constexpr auto m_args = TensorAccessorArgs<8>();
     const auto m_addr_gen = TensorAccessor(m_args, static_cast<size_t>(m_address), tile_bytes);
 
     volatile tt_l1_ptr uint32_t* receiver_sem_ptr =
@@ -54,8 +54,8 @@ void kernel_main() {
     const uint64_t sender_semaphore_noc_addr = get_noc_addr(sender_noc_x, sender_noc_y, mcast_sender_semaphore_addr);
 
     for (uint32_t mb = 0U; mb < num_m_blocks; ++mb) {
-        // ---- Receive W1/W3 for all K-blocks (once per m_block), one N-block per receive ----
-        for (uint32_t k = 0U; k < num_k_blocks; ++k) {
+        // ---- Receive W1/W3 for all k_blocks (once per m_block), one n_block per receive ----
+        for (uint32_t k_block = 0U; k_block < num_k_blocks; ++k_block) {
             for (uint32_t n_block = 0U; n_block < num_n_blocks; ++n_block) {
                 mcast_receiver_reserve_and_receive(
                     cb_w1_idx, tiles_per_n_block, receiver_sem_ptr, sender_semaphore_noc_addr);

--- a/tt-train/sources/ttml/metal/ops/swiglu_gate_up/device/kernels/dataflow/reader_in1_receiver_writer.cpp
+++ b/tt-train/sources/ttml/metal/ops/swiglu_gate_up/device/kernels/dataflow/reader_in1_receiver_writer.cpp
@@ -1,0 +1,92 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// ============================================================================
+// IN1 Receiver + M Writer (RISCV_0) — Non-top-row cores
+//
+// Receives W1/W3 weight tiles via column multicast from the top-row sender.
+// After compute produces M tiles, writes them to DRAM.
+//
+// Loop structure:
+//   for m in per_core_M:
+//     for k_block in K_blocks:
+//       for n_sub in num_n_blocks:
+//         receive W1 batch, push to CB
+//         receive W3 batch, push to CB
+//     write M[m, 0:actual_n_tiles] to DRAM
+// ============================================================================
+
+#include <algorithm>
+
+#include "api/dataflow/dataflow_api.h"
+#include "tt-train/sources/ttml/metal/common/dataflow_utils.hpp"
+
+constexpr auto cb_w1_idx = tt::CBIndex::c_1;
+constexpr auto cb_w3_idx = tt::CBIndex::c_2;
+constexpr auto cb_m_out_idx = tt::CBIndex::c_5;
+
+constexpr uint32_t block_size = get_compile_time_arg_val(0);
+constexpr uint32_t Wt = get_compile_time_arg_val(1);
+constexpr uint32_t hidden_Wt = get_compile_time_arg_val(2);
+constexpr uint32_t per_core_M = get_compile_time_arg_val(3);
+constexpr uint32_t per_core_N = get_compile_time_arg_val(4);
+constexpr uint32_t per_core_N_rounded = get_compile_time_arg_val(5);
+constexpr uint32_t num_n_blocks = get_compile_time_arg_val(6);
+constexpr uint32_t in1_mcast_sender_semaphore_id = get_compile_time_arg_val(7);
+constexpr uint32_t in1_mcast_receiver_semaphore_id = get_compile_time_arg_val(8);
+
+constexpr uint32_t tiles_per_batch = block_size * block_size;
+
+void kernel_main() {
+    uint32_t ra = 0U;
+    const uint32_t m_address = get_arg_val<uint32_t>(ra++);
+    const uint32_t m_start = get_arg_val<uint32_t>(ra++);
+    const uint32_t n_start = get_arg_val<uint32_t>(ra++);
+    const uint32_t actual_m_tiles = get_arg_val<uint32_t>(ra++);
+    const uint32_t actual_n_tiles = get_arg_val<uint32_t>(ra++);
+    const uint32_t sender_noc_x = get_arg_val<uint32_t>(ra++);
+    const uint32_t sender_noc_y = get_arg_val<uint32_t>(ra++);
+
+    const uint32_t tile_bytes = get_tile_size(cb_w1_idx);
+    const uint32_t mcast_sender_semaphore_addr = get_semaphore(in1_mcast_sender_semaphore_id);
+    const uint32_t mcast_receiver_semaphore_addr = get_semaphore(in1_mcast_receiver_semaphore_id);
+
+    constexpr auto m_args = TensorAccessorArgs<9>();
+    const auto m_addr_gen = TensorAccessor(m_args, m_address, tile_bytes);
+
+    volatile tt_l1_ptr uint32_t* receiver_sem_ptr =
+        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(mcast_receiver_semaphore_addr);
+    const uint64_t sender_semaphore_noc_addr = get_noc_addr(sender_noc_x, sender_noc_y, mcast_sender_semaphore_addr);
+
+    const uint32_t num_k_blocks = (Wt + block_size - 1U) / block_size;
+
+    for (uint32_t m = 0U; m < per_core_M; ++m) {
+        // ---- Receive W1/W3 for all K-blocks and N-sub-blocks ----
+        for (uint32_t k = 0U; k < num_k_blocks; ++k) {
+            for (uint32_t n_sub = 0U; n_sub < num_n_blocks; ++n_sub) {
+                mcast_receiver_reserve_and_receive(
+                    cb_w1_idx, tiles_per_batch, receiver_sem_ptr, sender_semaphore_noc_addr);
+                mcast_receiver_reserve_and_receive(
+                    cb_w3_idx, tiles_per_batch, receiver_sem_ptr, sender_semaphore_noc_addr);
+            }
+        }
+
+        // ---- Write M tiles to DRAM ----
+        if (m < actual_m_tiles) {
+            const uint32_t m_row = m_start + m;
+            cb_wait_front(cb_m_out_idx, per_core_N_rounded);
+            uint32_t l1_read_addr = get_read_ptr(cb_m_out_idx);
+            for (uint32_t n = 0U; n < actual_n_tiles; ++n) {
+                uint32_t tile_idx = m_row * hidden_Wt + n_start + n;
+                noc_async_write_page(tile_idx, m_addr_gen, l1_read_addr);
+                l1_read_addr += tile_bytes;
+            }
+            noc_async_write_barrier();
+            cb_pop_front(cb_m_out_idx, per_core_N_rounded);
+        } else {
+            cb_wait_front(cb_m_out_idx, per_core_N_rounded);
+            cb_pop_front(cb_m_out_idx, per_core_N_rounded);
+        }
+    }
+}

--- a/tt-train/sources/ttml/metal/ops/swiglu_gate_up/device/kernels/dataflow/reader_in1_receiver_writer.cpp
+++ b/tt-train/sources/ttml/metal/ops/swiglu_gate_up/device/kernels/dataflow/reader_in1_receiver_writer.cpp
@@ -5,16 +5,8 @@
 // ============================================================================
 // IN1 Receiver + M Writer (RISCV_0) — Non-top-row cores
 //
-// Receives W1/W3 weight tiles via column multicast from the top-row sender.
-// After compute produces M tiles, writes them to DRAM.
-//
-// Loop structure:
-//   for m in per_core_M:
-//     for k_block in K_blocks:
-//       for n_sub in num_n_blocks:
-//         receive W1 batch, push to CB
-//         receive W3 batch, push to CB
-//     write M[m, 0:actual_n_tiles] to DRAM
+// Outer loop iterates num_m_blocks times. For each m_block, receives W1/W3
+// weight batches ONCE, then writes block_h rows of M tiles to DRAM.
 // ============================================================================
 
 #include <algorithm>
@@ -29,14 +21,16 @@ constexpr auto cb_m_out_idx = tt::CBIndex::c_5;
 constexpr uint32_t block_size = get_compile_time_arg_val(0);
 constexpr uint32_t Wt = get_compile_time_arg_val(1);
 constexpr uint32_t hidden_Wt = get_compile_time_arg_val(2);
-constexpr uint32_t per_core_M = get_compile_time_arg_val(3);
-constexpr uint32_t per_core_N = get_compile_time_arg_val(4);
-constexpr uint32_t per_core_N_rounded = get_compile_time_arg_val(5);
-constexpr uint32_t num_n_blocks = get_compile_time_arg_val(6);
-constexpr uint32_t in1_mcast_sender_semaphore_id = get_compile_time_arg_val(7);
-constexpr uint32_t in1_mcast_receiver_semaphore_id = get_compile_time_arg_val(8);
+constexpr uint32_t block_h = get_compile_time_arg_val(3);
+constexpr uint32_t num_m_blocks = get_compile_time_arg_val(4);
+constexpr uint32_t per_core_N = get_compile_time_arg_val(5);
+constexpr uint32_t per_core_N_rounded = get_compile_time_arg_val(6);
+constexpr uint32_t num_n_blocks = get_compile_time_arg_val(7);
+constexpr uint32_t in1_mcast_sender_semaphore_id = get_compile_time_arg_val(8);
+constexpr uint32_t in1_mcast_receiver_semaphore_id = get_compile_time_arg_val(9);
 
 constexpr uint32_t tiles_per_batch = block_size * block_size;
+constexpr uint32_t num_k_blocks = (Wt + block_size - 1U) / block_size;
 
 void kernel_main() {
     uint32_t ra = 0U;
@@ -52,17 +46,15 @@ void kernel_main() {
     const uint32_t mcast_sender_semaphore_addr = get_semaphore(in1_mcast_sender_semaphore_id);
     const uint32_t mcast_receiver_semaphore_addr = get_semaphore(in1_mcast_receiver_semaphore_id);
 
-    constexpr auto m_args = TensorAccessorArgs<9>();
+    constexpr auto m_args = TensorAccessorArgs<10>();
     const auto m_addr_gen = TensorAccessor(m_args, m_address, tile_bytes);
 
     volatile tt_l1_ptr uint32_t* receiver_sem_ptr =
         reinterpret_cast<volatile tt_l1_ptr uint32_t*>(mcast_receiver_semaphore_addr);
     const uint64_t sender_semaphore_noc_addr = get_noc_addr(sender_noc_x, sender_noc_y, mcast_sender_semaphore_addr);
 
-    const uint32_t num_k_blocks = (Wt + block_size - 1U) / block_size;
-
-    for (uint32_t m = 0U; m < per_core_M; ++m) {
-        // ---- Receive W1/W3 for all K-blocks and N-sub-blocks ----
+    for (uint32_t mb = 0U; mb < num_m_blocks; ++mb) {
+        // ---- Receive W1/W3 for all K-blocks (once per m_block) ----
         for (uint32_t k = 0U; k < num_k_blocks; ++k) {
             for (uint32_t n_sub = 0U; n_sub < num_n_blocks; ++n_sub) {
                 mcast_receiver_reserve_and_receive(
@@ -72,20 +64,20 @@ void kernel_main() {
             }
         }
 
-        // ---- Write M tiles to DRAM ----
-        if (m < actual_m_tiles) {
-            const uint32_t m_row = m_start + m;
+        // ---- Write block_h rows of M to DRAM ----
+        for (uint32_t m_sub = 0U; m_sub < block_h; ++m_sub) {
+            uint32_t m = mb * block_h + m_sub;
             cb_wait_front(cb_m_out_idx, per_core_N_rounded);
-            uint32_t l1_read_addr = get_read_ptr(cb_m_out_idx);
-            for (uint32_t n = 0U; n < actual_n_tiles; ++n) {
-                uint32_t tile_idx = m_row * hidden_Wt + n_start + n;
-                noc_async_write_page(tile_idx, m_addr_gen, l1_read_addr);
-                l1_read_addr += tile_bytes;
+            if (m < actual_m_tiles) {
+                uint32_t m_row = m_start + m;
+                uint32_t l1_read_addr = get_read_ptr(cb_m_out_idx);
+                for (uint32_t n = 0U; n < actual_n_tiles; ++n) {
+                    uint32_t tile_idx = m_row * hidden_Wt + n_start + n;
+                    noc_async_write_page(tile_idx, m_addr_gen, l1_read_addr);
+                    l1_read_addr += tile_bytes;
+                }
+                noc_async_write_barrier();
             }
-            noc_async_write_barrier();
-            cb_pop_front(cb_m_out_idx, per_core_N_rounded);
-        } else {
-            cb_wait_front(cb_m_out_idx, per_core_N_rounded);
             cb_pop_front(cb_m_out_idx, per_core_N_rounded);
         }
     }

--- a/tt-train/sources/ttml/metal/ops/swiglu_gate_up/device/kernels/dataflow/reader_in1_receiver_writer.cpp
+++ b/tt-train/sources/ttml/metal/ops/swiglu_gate_up/device/kernels/dataflow/reader_in1_receiver_writer.cpp
@@ -6,9 +6,7 @@
 // IN1 Receiver + M Writer (RISCV_0) — Non-top-row cores
 //
 // Outer loop iterates num_m_blocks times. For each m_block, receives W1/W3
-// weight batches ONCE, then writes block_h rows of M tiles to DRAM.
-//
-// N-block batching: receives n_blocks_per_batch N-blocks per multicast.
+// one N-block at a time, then writes block_h rows of M tiles to DRAM.
 // ============================================================================
 
 #include <algorithm>
@@ -28,13 +26,10 @@ constexpr uint32_t num_m_blocks = get_compile_time_arg_val(4);
 constexpr uint32_t per_core_N = get_compile_time_arg_val(5);
 constexpr uint32_t per_core_N_rounded = get_compile_time_arg_val(6);
 constexpr uint32_t num_n_blocks = get_compile_time_arg_val(7);
-constexpr uint32_t n_blocks_per_batch = get_compile_time_arg_val(8);
-constexpr uint32_t num_n_batch_iters = get_compile_time_arg_val(9);
-constexpr uint32_t in1_mcast_sender_semaphore_id = get_compile_time_arg_val(10);
-constexpr uint32_t in1_mcast_receiver_semaphore_id = get_compile_time_arg_val(11);
+constexpr uint32_t in1_mcast_sender_semaphore_id = get_compile_time_arg_val(8);
+constexpr uint32_t in1_mcast_receiver_semaphore_id = get_compile_time_arg_val(9);
 
 constexpr uint32_t tiles_per_n_block = block_size * block_size;
-constexpr uint32_t tiles_per_receive = n_blocks_per_batch * tiles_per_n_block;
 constexpr uint32_t num_k_blocks = (Wt + block_size - 1U) / block_size;
 
 void kernel_main() {
@@ -51,21 +46,21 @@ void kernel_main() {
     const uint32_t mcast_sender_semaphore_addr = get_semaphore(in1_mcast_sender_semaphore_id);
     const uint32_t mcast_receiver_semaphore_addr = get_semaphore(in1_mcast_receiver_semaphore_id);
 
-    constexpr auto m_args = TensorAccessorArgs<12>();
-    const auto m_addr_gen = TensorAccessor(m_args, m_address, tile_bytes);
+    constexpr auto m_args = TensorAccessorArgs<10>();
+    const auto m_addr_gen = TensorAccessor(m_args, static_cast<size_t>(m_address), tile_bytes);
 
     volatile tt_l1_ptr uint32_t* receiver_sem_ptr =
         reinterpret_cast<volatile tt_l1_ptr uint32_t*>(mcast_receiver_semaphore_addr);
     const uint64_t sender_semaphore_noc_addr = get_noc_addr(sender_noc_x, sender_noc_y, mcast_sender_semaphore_addr);
 
     for (uint32_t mb = 0U; mb < num_m_blocks; ++mb) {
-        // ---- Receive W1/W3 for all K-blocks (once per m_block), batched N-blocks ----
+        // ---- Receive W1/W3 for all K-blocks (once per m_block), one N-block per receive ----
         for (uint32_t k = 0U; k < num_k_blocks; ++k) {
-            for (uint32_t n_batch = 0U; n_batch < num_n_batch_iters; ++n_batch) {
+            for (uint32_t n_block = 0U; n_block < num_n_blocks; ++n_block) {
                 mcast_receiver_reserve_and_receive(
-                    cb_w1_idx, tiles_per_receive, receiver_sem_ptr, sender_semaphore_noc_addr);
+                    cb_w1_idx, tiles_per_n_block, receiver_sem_ptr, sender_semaphore_noc_addr);
                 mcast_receiver_reserve_and_receive(
-                    cb_w3_idx, tiles_per_receive, receiver_sem_ptr, sender_semaphore_noc_addr);
+                    cb_w3_idx, tiles_per_n_block, receiver_sem_ptr, sender_semaphore_noc_addr);
             }
         }
 

--- a/tt-train/sources/ttml/metal/ops/swiglu_gate_up/device/kernels/dataflow/reader_in1_sender_writer.cpp
+++ b/tt-train/sources/ttml/metal/ops/swiglu_gate_up/device/kernels/dataflow/reader_in1_sender_writer.cpp
@@ -5,9 +5,8 @@
 // ============================================================================
 // IN1 Sender + M Writer (RISCV_0) — Top row cores
 //
-// Outer loop iterates num_m_blocks times. For each m_block, reads and
-// multicasts W1/W3 one N-block at a time (reused by compute across block_h M
-// rows), then writes block_h rows of M tiles to DRAM.
+// Outer loop over m_blocks. Inner: over k_blocks then n_blocks (read and
+// multicast W1/W3); then write block_h rows of M to DRAM.
 // ============================================================================
 
 #include <algorithm>
@@ -25,12 +24,13 @@ constexpr uint32_t hidden_Wt = get_compile_time_arg_val(2);
 constexpr uint32_t block_h = get_compile_time_arg_val(3);
 constexpr uint32_t num_m_blocks = get_compile_time_arg_val(4);
 constexpr uint32_t per_core_N = get_compile_time_arg_val(5);
-constexpr uint32_t per_core_N_rounded = get_compile_time_arg_val(6);
-constexpr uint32_t num_n_blocks = get_compile_time_arg_val(7);
-constexpr uint32_t in1_mcast_sender_semaphore_id = get_compile_time_arg_val(8);
-constexpr uint32_t in1_mcast_receiver_semaphore_id = get_compile_time_arg_val(9);
+constexpr uint32_t in1_mcast_sender_semaphore_id = get_compile_time_arg_val(6);
+constexpr uint32_t in1_mcast_receiver_semaphore_id = get_compile_time_arg_val(7);
 
+constexpr uint32_t per_core_N_rounded = ((per_core_N + block_size - 1U) / block_size) * block_size;
+constexpr uint32_t num_n_blocks = per_core_N_rounded / block_size;
 constexpr uint32_t tiles_per_n_block = block_size * block_size;
+constexpr uint32_t num_k_blocks = (Wt + block_size - 1U) / block_size;
 constexpr uint32_t cb_row_width = block_size;
 
 void kernel_main() {
@@ -52,7 +52,7 @@ void kernel_main() {
     const uint32_t mcast_sender_semaphore_addr = get_semaphore(in1_mcast_sender_semaphore_id);
     const uint32_t mcast_receiver_semaphore_addr = get_semaphore(in1_mcast_receiver_semaphore_id);
 
-    constexpr auto w1_args = TensorAccessorArgs<10>();
+    constexpr auto w1_args = TensorAccessorArgs<8>();
     constexpr auto w3_args = TensorAccessorArgs<w1_args.next_compile_time_args_offset()>();
     constexpr auto m_args = TensorAccessorArgs<w3_args.next_compile_time_args_offset()>();
     const auto w1_addr_gen = TensorAccessor(w1_args, static_cast<size_t>(w1_address), tile_bytes);
@@ -76,12 +76,14 @@ void kernel_main() {
     };
 
     for (uint32_t mb = 0U; mb < num_m_blocks; ++mb) {
-        // ---- Send W1/W3 for all K-blocks (once per m_block) ----
-        for (uint32_t k_block_start = 0U; k_block_start < Wt; k_block_start += block_size) {
+        // ---- Send W1/W3 for all k_blocks (once per m_block), one n_block at a time ----
+        for (uint32_t k_block = 0U; k_block < num_k_blocks; ++k_block) {
+            const uint32_t k_block_start = k_block * block_size;
             const uint32_t k_block_size = std::min(block_size, Wt - k_block_start);
 
             for (uint32_t n_block = 0U; n_block < num_n_blocks; ++n_block) {
-                const uint32_t n_offset = n_start + n_block * block_size;
+                const uint32_t n_block_offset = n_block * block_size;
+                const uint32_t n_offset = n_start + n_block_offset;
                 const uint32_t valid_tiles_per_row = std::min(block_size, hidden_Wt - n_offset);
                 const uint32_t w_tile_start = k_block_start * hidden_Wt + n_offset;
 

--- a/tt-train/sources/ttml/metal/ops/swiglu_gate_up/device/kernels/dataflow/reader_in1_sender_writer.cpp
+++ b/tt-train/sources/ttml/metal/ops/swiglu_gate_up/device/kernels/dataflow/reader_in1_sender_writer.cpp
@@ -5,16 +5,9 @@
 // ============================================================================
 // IN1 Sender + M Writer (RISCV_0) — Top row cores
 //
-// Reads W1/W3 weight tiles from DRAM and multicasts down the column to all
-// R cores. After compute produces M tiles, writes them to DRAM.
-//
-// Loop structure:
-//   for m in per_core_M:
-//     for k_block in K_blocks:
-//       for n_sub in num_n_blocks:
-//         read W1[k_block, n_sub], multicast down column
-//         read W3[k_block, n_sub], multicast down column
-//     write M[m, 0:actual_n_tiles] to DRAM
+// Outer loop iterates num_m_blocks times. For each m_block, reads and
+// multicasts W1/W3 weight batches ONCE (reused by compute across block_h M
+// rows), then writes block_h rows of M tiles to DRAM.
 // ============================================================================
 
 #include <algorithm>
@@ -29,12 +22,13 @@ constexpr auto cb_m_out_idx = tt::CBIndex::c_5;
 constexpr uint32_t block_size = get_compile_time_arg_val(0);
 constexpr uint32_t Wt = get_compile_time_arg_val(1);
 constexpr uint32_t hidden_Wt = get_compile_time_arg_val(2);
-constexpr uint32_t per_core_M = get_compile_time_arg_val(3);
-constexpr uint32_t per_core_N = get_compile_time_arg_val(4);
-constexpr uint32_t per_core_N_rounded = get_compile_time_arg_val(5);
-constexpr uint32_t num_n_blocks = get_compile_time_arg_val(6);
-constexpr uint32_t in1_mcast_sender_semaphore_id = get_compile_time_arg_val(7);
-constexpr uint32_t in1_mcast_receiver_semaphore_id = get_compile_time_arg_val(8);
+constexpr uint32_t block_h = get_compile_time_arg_val(3);
+constexpr uint32_t num_m_blocks = get_compile_time_arg_val(4);
+constexpr uint32_t per_core_N = get_compile_time_arg_val(5);
+constexpr uint32_t per_core_N_rounded = get_compile_time_arg_val(6);
+constexpr uint32_t num_n_blocks = get_compile_time_arg_val(7);
+constexpr uint32_t in1_mcast_sender_semaphore_id = get_compile_time_arg_val(8);
+constexpr uint32_t in1_mcast_receiver_semaphore_id = get_compile_time_arg_val(9);
 
 constexpr uint32_t tiles_per_batch = block_size * block_size;
 
@@ -57,7 +51,7 @@ void kernel_main() {
     const uint32_t mcast_sender_semaphore_addr = get_semaphore(in1_mcast_sender_semaphore_id);
     const uint32_t mcast_receiver_semaphore_addr = get_semaphore(in1_mcast_receiver_semaphore_id);
 
-    constexpr auto w1_args = TensorAccessorArgs<9>();
+    constexpr auto w1_args = TensorAccessorArgs<10>();
     constexpr auto w3_args = TensorAccessorArgs<w1_args.next_compile_time_args_offset()>();
     constexpr auto m_args = TensorAccessorArgs<w3_args.next_compile_time_args_offset()>();
     const auto w1_addr_gen = TensorAccessor(w1_args, w1_address, tile_bytes);
@@ -80,7 +74,8 @@ void kernel_main() {
         .num_receivers = num_receivers,
     };
 
-    for (uint32_t m = 0U; m < per_core_M; ++m) {
+    for (uint32_t mb = 0U; mb < num_m_blocks; ++mb) {
+        // ---- Send W1/W3 for all K-blocks (once per m_block) ----
         for (uint32_t k_block_start = 0U; k_block_start < Wt; k_block_start += block_size) {
             const uint32_t k_block_size = std::min(block_size, Wt - k_block_start);
 
@@ -89,20 +84,18 @@ void kernel_main() {
                 const uint32_t n_block_size = std::min(block_size, hidden_Wt - n_offset);
                 const uint32_t w_tile_start = k_block_start * hidden_Wt + n_offset;
 
-                // W1 batch
                 mcast_sender_read_batched_rows_and_send_loopback(
                     cb_w1_idx,
                     w1_addr_gen,
                     w_tile_start,
-                    block_size,    // tiles_per_row (padded to block_size)
-                    block_size,    // num_rows (padded to block_size)
-                    n_block_size,  // valid_tiles_per_row
-                    k_block_size,  // valid_num_rows
-                    hidden_Wt,     // row_stride
+                    block_size,
+                    block_size,
+                    n_block_size,
+                    k_block_size,
+                    hidden_Wt,
                     tile_bytes,
                     mcast_cfg);
 
-                // W3 batch
                 mcast_sender_read_batched_rows_and_send_loopback(
                     cb_w3_idx,
                     w3_addr_gen,
@@ -117,20 +110,20 @@ void kernel_main() {
             }
         }
 
-        if (m < actual_m_tiles) {
-            const uint32_t m_row = m_start + m;
+        // ---- Write block_h rows of M to DRAM ----
+        for (uint32_t m_sub = 0U; m_sub < block_h; ++m_sub) {
+            uint32_t m = mb * block_h + m_sub;
             cb_wait_front(cb_m_out_idx, per_core_N_rounded);
-            uint32_t l1_read_addr = get_read_ptr(cb_m_out_idx);
-            for (uint32_t n = 0U; n < actual_n_tiles; ++n) {
-                uint32_t tile_idx = m_row * hidden_Wt + n_start + n;
-                noc_async_write_page(tile_idx, m_addr_gen, l1_read_addr);
-                l1_read_addr += tile_bytes;
+            if (m < actual_m_tiles) {
+                uint32_t m_row = m_start + m;
+                uint32_t l1_read_addr = get_read_ptr(cb_m_out_idx);
+                for (uint32_t n = 0U; n < actual_n_tiles; ++n) {
+                    uint32_t tile_idx = m_row * hidden_Wt + n_start + n;
+                    noc_async_write_page(tile_idx, m_addr_gen, l1_read_addr);
+                    l1_read_addr += tile_bytes;
+                }
+                noc_async_write_barrier();
             }
-            noc_async_write_barrier();
-            cb_pop_front(cb_m_out_idx, per_core_N_rounded);
-        } else {
-            // Padding row: consume M tiles from compute but don't write
-            cb_wait_front(cb_m_out_idx, per_core_N_rounded);
             cb_pop_front(cb_m_out_idx, per_core_N_rounded);
         }
     }

--- a/tt-train/sources/ttml/metal/ops/swiglu_gate_up/device/kernels/dataflow/reader_in1_sender_writer.cpp
+++ b/tt-train/sources/ttml/metal/ops/swiglu_gate_up/device/kernels/dataflow/reader_in1_sender_writer.cpp
@@ -1,0 +1,137 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// ============================================================================
+// IN1 Sender + M Writer (RISCV_0) — Top row cores
+//
+// Reads W1/W3 weight tiles from DRAM and multicasts down the column to all
+// R cores. After compute produces M tiles, writes them to DRAM.
+//
+// Loop structure:
+//   for m in per_core_M:
+//     for k_block in K_blocks:
+//       for n_sub in num_n_blocks:
+//         read W1[k_block, n_sub], multicast down column
+//         read W3[k_block, n_sub], multicast down column
+//     write M[m, 0:actual_n_tiles] to DRAM
+// ============================================================================
+
+#include <algorithm>
+
+#include "api/dataflow/dataflow_api.h"
+#include "tt-train/sources/ttml/metal/common/dataflow_utils.hpp"
+
+constexpr auto cb_w1_idx = tt::CBIndex::c_1;
+constexpr auto cb_w3_idx = tt::CBIndex::c_2;
+constexpr auto cb_m_out_idx = tt::CBIndex::c_5;
+
+constexpr uint32_t block_size = get_compile_time_arg_val(0);
+constexpr uint32_t Wt = get_compile_time_arg_val(1);
+constexpr uint32_t hidden_Wt = get_compile_time_arg_val(2);
+constexpr uint32_t per_core_M = get_compile_time_arg_val(3);
+constexpr uint32_t per_core_N = get_compile_time_arg_val(4);
+constexpr uint32_t per_core_N_rounded = get_compile_time_arg_val(5);
+constexpr uint32_t num_n_blocks = get_compile_time_arg_val(6);
+constexpr uint32_t in1_mcast_sender_semaphore_id = get_compile_time_arg_val(7);
+constexpr uint32_t in1_mcast_receiver_semaphore_id = get_compile_time_arg_val(8);
+
+constexpr uint32_t tiles_per_batch = block_size * block_size;
+
+void kernel_main() {
+    uint32_t ra = 0U;
+    const uint32_t w1_address = get_arg_val<uint32_t>(ra++);
+    const uint32_t w3_address = get_arg_val<uint32_t>(ra++);
+    const uint32_t m_address = get_arg_val<uint32_t>(ra++);
+    const uint32_t m_start = get_arg_val<uint32_t>(ra++);
+    const uint32_t n_start = get_arg_val<uint32_t>(ra++);
+    const uint32_t actual_m_tiles = get_arg_val<uint32_t>(ra++);
+    const uint32_t actual_n_tiles = get_arg_val<uint32_t>(ra++);
+    const uint32_t mcast_dest_noc_start_x = get_arg_val<uint32_t>(ra++);
+    const uint32_t mcast_dest_noc_start_y = get_arg_val<uint32_t>(ra++);
+    const uint32_t mcast_dest_noc_end_x = get_arg_val<uint32_t>(ra++);
+    const uint32_t mcast_dest_noc_end_y = get_arg_val<uint32_t>(ra++);
+    const uint32_t num_receivers = get_arg_val<uint32_t>(ra++);
+
+    const uint32_t tile_bytes = get_tile_size(cb_w1_idx);
+    const uint32_t mcast_sender_semaphore_addr = get_semaphore(in1_mcast_sender_semaphore_id);
+    const uint32_t mcast_receiver_semaphore_addr = get_semaphore(in1_mcast_receiver_semaphore_id);
+
+    constexpr auto w1_args = TensorAccessorArgs<9>();
+    constexpr auto w3_args = TensorAccessorArgs<w1_args.next_compile_time_args_offset()>();
+    constexpr auto m_args = TensorAccessorArgs<w3_args.next_compile_time_args_offset()>();
+    const auto w1_addr_gen = TensorAccessor(w1_args, w1_address, tile_bytes);
+    const auto w3_addr_gen = TensorAccessor(w3_args, w3_address, tile_bytes);
+    const auto m_addr_gen = TensorAccessor(m_args, m_address, tile_bytes);
+
+    volatile tt_l1_ptr uint32_t* sender_sem_ptr =
+        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(mcast_sender_semaphore_addr);
+    volatile tt_l1_ptr uint32_t* receiver_sem_ptr =
+        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(mcast_receiver_semaphore_addr);
+
+    const McastLoopbackConfig mcast_cfg = {
+        .sender_sem_ptr = sender_sem_ptr,
+        .receiver_sem_ptr = receiver_sem_ptr,
+        .receiver_sem_addr = mcast_receiver_semaphore_addr,
+        .noc_start_x = mcast_dest_noc_start_x,
+        .noc_start_y = mcast_dest_noc_start_y,
+        .noc_end_x = mcast_dest_noc_end_x,
+        .noc_end_y = mcast_dest_noc_end_y,
+        .num_receivers = num_receivers,
+    };
+
+    for (uint32_t m = 0U; m < per_core_M; ++m) {
+        for (uint32_t k_block_start = 0U; k_block_start < Wt; k_block_start += block_size) {
+            const uint32_t k_block_size = std::min(block_size, Wt - k_block_start);
+
+            for (uint32_t n_sub = 0U; n_sub < num_n_blocks; ++n_sub) {
+                const uint32_t n_offset = n_start + n_sub * block_size;
+                const uint32_t n_block_size = std::min(block_size, hidden_Wt - n_offset);
+                const uint32_t w_tile_start = k_block_start * hidden_Wt + n_offset;
+
+                // W1 batch
+                mcast_sender_read_batched_rows_and_send_loopback(
+                    cb_w1_idx,
+                    w1_addr_gen,
+                    w_tile_start,
+                    block_size,    // tiles_per_row (padded to block_size)
+                    block_size,    // num_rows (padded to block_size)
+                    n_block_size,  // valid_tiles_per_row
+                    k_block_size,  // valid_num_rows
+                    hidden_Wt,     // row_stride
+                    tile_bytes,
+                    mcast_cfg);
+
+                // W3 batch
+                mcast_sender_read_batched_rows_and_send_loopback(
+                    cb_w3_idx,
+                    w3_addr_gen,
+                    w_tile_start,
+                    block_size,
+                    block_size,
+                    n_block_size,
+                    k_block_size,
+                    hidden_Wt,
+                    tile_bytes,
+                    mcast_cfg);
+            }
+        }
+
+        if (m < actual_m_tiles) {
+            const uint32_t m_row = m_start + m;
+            cb_wait_front(cb_m_out_idx, per_core_N_rounded);
+            uint32_t l1_read_addr = get_read_ptr(cb_m_out_idx);
+            for (uint32_t n = 0U; n < actual_n_tiles; ++n) {
+                uint32_t tile_idx = m_row * hidden_Wt + n_start + n;
+                noc_async_write_page(tile_idx, m_addr_gen, l1_read_addr);
+                l1_read_addr += tile_bytes;
+            }
+            noc_async_write_barrier();
+            cb_pop_front(cb_m_out_idx, per_core_N_rounded);
+        } else {
+            // Padding row: consume M tiles from compute but don't write
+            cb_wait_front(cb_m_out_idx, per_core_N_rounded);
+            cb_pop_front(cb_m_out_idx, per_core_N_rounded);
+        }
+    }
+}

--- a/tt-train/sources/ttml/metal/ops/swiglu_gate_up/device/kernels/dataflow/reader_in1_sender_writer.cpp
+++ b/tt-train/sources/ttml/metal/ops/swiglu_gate_up/device/kernels/dataflow/reader_in1_sender_writer.cpp
@@ -6,11 +6,8 @@
 // IN1 Sender + M Writer (RISCV_0) — Top row cores
 //
 // Outer loop iterates num_m_blocks times. For each m_block, reads and
-// multicasts W1/W3 weight batches ONCE (reused by compute across block_h M
+// multicasts W1/W3 one N-block at a time (reused by compute across block_h M
 // rows), then writes block_h rows of M tiles to DRAM.
-//
-// N-block batching: sends n_blocks_per_batch N-blocks per multicast to reduce
-// sync overhead. The CB row contains n_blocks_per_batch * block_size tiles.
 // ============================================================================
 
 #include <algorithm>
@@ -30,14 +27,11 @@ constexpr uint32_t num_m_blocks = get_compile_time_arg_val(4);
 constexpr uint32_t per_core_N = get_compile_time_arg_val(5);
 constexpr uint32_t per_core_N_rounded = get_compile_time_arg_val(6);
 constexpr uint32_t num_n_blocks = get_compile_time_arg_val(7);
-constexpr uint32_t n_blocks_per_batch = get_compile_time_arg_val(8);
-constexpr uint32_t num_n_batch_iters = get_compile_time_arg_val(9);
-constexpr uint32_t in1_mcast_sender_semaphore_id = get_compile_time_arg_val(10);
-constexpr uint32_t in1_mcast_receiver_semaphore_id = get_compile_time_arg_val(11);
+constexpr uint32_t in1_mcast_sender_semaphore_id = get_compile_time_arg_val(8);
+constexpr uint32_t in1_mcast_receiver_semaphore_id = get_compile_time_arg_val(9);
 
 constexpr uint32_t tiles_per_n_block = block_size * block_size;
-constexpr uint32_t tiles_per_send = n_blocks_per_batch * tiles_per_n_block;
-constexpr uint32_t cb_row_width = n_blocks_per_batch * block_size;
+constexpr uint32_t cb_row_width = block_size;
 
 void kernel_main() {
     uint32_t ra = 0U;
@@ -58,12 +52,12 @@ void kernel_main() {
     const uint32_t mcast_sender_semaphore_addr = get_semaphore(in1_mcast_sender_semaphore_id);
     const uint32_t mcast_receiver_semaphore_addr = get_semaphore(in1_mcast_receiver_semaphore_id);
 
-    constexpr auto w1_args = TensorAccessorArgs<12>();
+    constexpr auto w1_args = TensorAccessorArgs<10>();
     constexpr auto w3_args = TensorAccessorArgs<w1_args.next_compile_time_args_offset()>();
     constexpr auto m_args = TensorAccessorArgs<w3_args.next_compile_time_args_offset()>();
-    const auto w1_addr_gen = TensorAccessor(w1_args, w1_address, tile_bytes);
-    const auto w3_addr_gen = TensorAccessor(w3_args, w3_address, tile_bytes);
-    const auto m_addr_gen = TensorAccessor(m_args, m_address, tile_bytes);
+    const auto w1_addr_gen = TensorAccessor(w1_args, static_cast<size_t>(w1_address), tile_bytes);
+    const auto w3_addr_gen = TensorAccessor(w3_args, static_cast<size_t>(w3_address), tile_bytes);
+    const auto m_addr_gen = TensorAccessor(m_args, static_cast<size_t>(m_address), tile_bytes);
 
     volatile tt_l1_ptr uint32_t* sender_sem_ptr =
         reinterpret_cast<volatile tt_l1_ptr uint32_t*>(mcast_sender_semaphore_addr);
@@ -86,11 +80,9 @@ void kernel_main() {
         for (uint32_t k_block_start = 0U; k_block_start < Wt; k_block_start += block_size) {
             const uint32_t k_block_size = std::min(block_size, Wt - k_block_start);
 
-            for (uint32_t n_batch = 0U; n_batch < num_n_batch_iters; ++n_batch) {
-                const uint32_t n_batch_start = n_batch * n_blocks_per_batch;
-                const uint32_t n_blocks_in_batch = std::min(n_blocks_per_batch, num_n_blocks - n_batch_start);
-                const uint32_t n_offset = n_start + n_batch_start * block_size;
-                const uint32_t valid_tiles_per_row = std::min(n_blocks_in_batch * block_size, hidden_Wt - n_offset);
+            for (uint32_t n_block = 0U; n_block < num_n_blocks; ++n_block) {
+                const uint32_t n_offset = n_start + n_block * block_size;
+                const uint32_t valid_tiles_per_row = std::min(block_size, hidden_Wt - n_offset);
                 const uint32_t w_tile_start = k_block_start * hidden_Wt + n_offset;
 
                 mcast_sender_read_batched_rows_and_send_loopback(

--- a/tt-train/sources/ttml/metal/ops/swiglu_gate_up/device/kernels/dataflow/reader_in1_sender_writer.cpp
+++ b/tt-train/sources/ttml/metal/ops/swiglu_gate_up/device/kernels/dataflow/reader_in1_sender_writer.cpp
@@ -8,6 +8,9 @@
 // Outer loop iterates num_m_blocks times. For each m_block, reads and
 // multicasts W1/W3 weight batches ONCE (reused by compute across block_h M
 // rows), then writes block_h rows of M tiles to DRAM.
+//
+// N-block batching: sends n_blocks_per_batch N-blocks per multicast to reduce
+// sync overhead. The CB row contains n_blocks_per_batch * block_size tiles.
 // ============================================================================
 
 #include <algorithm>
@@ -27,10 +30,14 @@ constexpr uint32_t num_m_blocks = get_compile_time_arg_val(4);
 constexpr uint32_t per_core_N = get_compile_time_arg_val(5);
 constexpr uint32_t per_core_N_rounded = get_compile_time_arg_val(6);
 constexpr uint32_t num_n_blocks = get_compile_time_arg_val(7);
-constexpr uint32_t in1_mcast_sender_semaphore_id = get_compile_time_arg_val(8);
-constexpr uint32_t in1_mcast_receiver_semaphore_id = get_compile_time_arg_val(9);
+constexpr uint32_t n_blocks_per_batch = get_compile_time_arg_val(8);
+constexpr uint32_t num_n_batch_iters = get_compile_time_arg_val(9);
+constexpr uint32_t in1_mcast_sender_semaphore_id = get_compile_time_arg_val(10);
+constexpr uint32_t in1_mcast_receiver_semaphore_id = get_compile_time_arg_val(11);
 
-constexpr uint32_t tiles_per_batch = block_size * block_size;
+constexpr uint32_t tiles_per_n_block = block_size * block_size;
+constexpr uint32_t tiles_per_send = n_blocks_per_batch * tiles_per_n_block;
+constexpr uint32_t cb_row_width = n_blocks_per_batch * block_size;
 
 void kernel_main() {
     uint32_t ra = 0U;
@@ -51,7 +58,7 @@ void kernel_main() {
     const uint32_t mcast_sender_semaphore_addr = get_semaphore(in1_mcast_sender_semaphore_id);
     const uint32_t mcast_receiver_semaphore_addr = get_semaphore(in1_mcast_receiver_semaphore_id);
 
-    constexpr auto w1_args = TensorAccessorArgs<10>();
+    constexpr auto w1_args = TensorAccessorArgs<12>();
     constexpr auto w3_args = TensorAccessorArgs<w1_args.next_compile_time_args_offset()>();
     constexpr auto m_args = TensorAccessorArgs<w3_args.next_compile_time_args_offset()>();
     const auto w1_addr_gen = TensorAccessor(w1_args, w1_address, tile_bytes);
@@ -79,18 +86,20 @@ void kernel_main() {
         for (uint32_t k_block_start = 0U; k_block_start < Wt; k_block_start += block_size) {
             const uint32_t k_block_size = std::min(block_size, Wt - k_block_start);
 
-            for (uint32_t n_sub = 0U; n_sub < num_n_blocks; ++n_sub) {
-                const uint32_t n_offset = n_start + n_sub * block_size;
-                const uint32_t n_block_size = std::min(block_size, hidden_Wt - n_offset);
+            for (uint32_t n_batch = 0U; n_batch < num_n_batch_iters; ++n_batch) {
+                const uint32_t n_batch_start = n_batch * n_blocks_per_batch;
+                const uint32_t n_blocks_in_batch = std::min(n_blocks_per_batch, num_n_blocks - n_batch_start);
+                const uint32_t n_offset = n_start + n_batch_start * block_size;
+                const uint32_t valid_tiles_per_row = std::min(n_blocks_in_batch * block_size, hidden_Wt - n_offset);
                 const uint32_t w_tile_start = k_block_start * hidden_Wt + n_offset;
 
                 mcast_sender_read_batched_rows_and_send_loopback(
                     cb_w1_idx,
                     w1_addr_gen,
                     w_tile_start,
+                    cb_row_width,
                     block_size,
-                    block_size,
-                    n_block_size,
+                    valid_tiles_per_row,
                     k_block_size,
                     hidden_Wt,
                     tile_bytes,
@@ -100,9 +109,9 @@ void kernel_main() {
                     cb_w3_idx,
                     w3_addr_gen,
                     w_tile_start,
+                    cb_row_width,
                     block_size,
-                    block_size,
-                    n_block_size,
+                    valid_tiles_per_row,
                     k_block_size,
                     hidden_Wt,
                     tile_bytes,

--- a/tt-train/sources/ttml/metal/ops/swiglu_gate_up/device/swiglu_gate_up_device_operation.cpp
+++ b/tt-train/sources/ttml/metal/ops/swiglu_gate_up/device/swiglu_gate_up_device_operation.cpp
@@ -1,0 +1,122 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "swiglu_gate_up_device_operation.hpp"
+
+#include <enchantum/enchantum.hpp>
+
+#include "ttnn/device_operation.hpp"
+
+namespace ttml::metal::ops::swiglu_gate_up::device {
+
+void SwiGLUGateUpDeviceOperation::validate_on_program_cache_miss(
+    const operation_attributes_t& args, const tensor_args_t& tensor_args) {
+    auto check_tensor = [](const ttnn::Tensor& tensor, const std::string& name) {
+        TT_FATAL(
+            tensor.storage_type() == tt::tt_metal::StorageType::DEVICE,
+            "SwiGLUGateUp operation requires {} to be on Device. Input storage type: {}",
+            name,
+            enchantum::to_string(tensor.storage_type()));
+
+        TT_FATAL(
+            tensor.buffer() != nullptr,
+            "Operands to SwiGLUGateUp need to be allocated in buffers on the device. Buffer is null. Tensor name {}",
+            name);
+
+        TT_FATAL(
+            tensor.layout() == tt::tt_metal::Layout::TILE,
+            "SwiGLUGateUp operation requires tensor to be in Tile layout. {} tensor layout: {}",
+            name,
+            enchantum::to_string(tensor.layout()));
+
+        TT_FATAL(
+            tensor.dtype() == tt::tt_metal::DataType::BFLOAT16,
+            "SwiGLUGateUp operation requires tensor to be of BFLOAT16 data type. {} tensor data type: {}",
+            name,
+            enchantum::to_string(tensor.dtype()));
+
+        TT_FATAL(
+            tensor.memory_config().memory_layout() == ttnn::TensorMemoryLayout::INTERLEAVED,
+            "SwiGLUGateUp operation requires Interleaved memory layout. {} memory layout: `{}`",
+            name,
+            enchantum::to_string(tensor.memory_config().memory_layout()));
+    };
+
+    const auto& input_tensor = tensor_args.input;
+    const auto& w1 = tensor_args.w1;
+    const auto& w3 = tensor_args.w3;
+
+    check_tensor(input_tensor, "Input");
+    check_tensor(w1, "W1");
+    check_tensor(w3, "W3");
+
+    const auto& input_shape = input_tensor.logical_shape();
+    const auto& w1_shape = w1.logical_shape();
+    const auto& w3_shape = w3.logical_shape();
+
+    TT_FATAL(input_shape.rank() == 4U, "Input tensor must be 4D");
+
+    uint32_t embed_dim = input_shape[-1];
+    uint32_t hidden_dim = w1_shape[-1];
+
+    TT_FATAL(
+        w1_shape[-2] == embed_dim, "W1 shape mismatch: W1[-2]={} must equal input[-1]={}.", w1_shape[-2], embed_dim);
+    TT_FATAL(
+        w3_shape[-2] == embed_dim && w3_shape[-1] == hidden_dim,
+        "W3 shape mismatch: W3={} must match W1={}. Both should be [embed, hidden].",
+        w3_shape,
+        w1_shape);
+
+    TT_FATAL(embed_dim % tt::constants::TILE_WIDTH == 0, "Embed dimension must be multiple of TILE_WIDTH");
+    TT_FATAL(hidden_dim % tt::constants::TILE_WIDTH == 0, "Hidden dimension must be multiple of TILE_WIDTH");
+}
+
+spec_return_value_t SwiGLUGateUpDeviceOperation::compute_output_specs(
+    const operation_attributes_t& args, const tensor_args_t& tensor_args) {
+    const auto& input_shape = tensor_args.input.logical_shape();
+    const auto& w1_shape = tensor_args.w1.logical_shape();
+
+    // Output M has shape [B, 1, S, hidden_dim]
+    ttnn::Shape output_shape({input_shape[0], input_shape[1], input_shape[2], w1_shape[3]});
+
+    spec_return_value_t output_specs;
+    output_specs.reserve(1U);
+    output_specs.emplace_back(
+        output_shape,
+        tt::tt_metal::TensorLayout(
+            tensor_args.input.dtype(), tt::tt_metal::Layout::TILE, tensor_args.input.memory_config()));
+
+    return output_specs;
+}
+
+tensor_return_value_t SwiGLUGateUpDeviceOperation::create_output_tensors(
+    const operation_attributes_t& args, const tensor_args_t& tensor_args) {
+    spec_return_value_t output_specs = compute_output_specs(args, tensor_args);
+    return create_device_tensor(output_specs[0], tensor_args.input.device());
+}
+
+ttsl::hash::hash_t SwiGLUGateUpDeviceOperation::compute_program_hash(
+    const operation_attributes_t& args, const tensor_args_t& tensor_args) {
+    const auto& input = tensor_args.input;
+    const auto& w1 = tensor_args.w1;
+    const auto& w3 = tensor_args.w3;
+    return tt::tt_metal::operation::hash_operation<SwiGLUGateUpDeviceOperation>(
+        args, input.dtype(), input.logical_shape(), w1.dtype(), w1.logical_shape(), w3.dtype(), w3.logical_shape());
+}
+
+}  // namespace ttml::metal::ops::swiglu_gate_up::device
+
+namespace ttnn::prim {
+
+ttml::metal::ops::swiglu_gate_up::device::SwiGLUGateUpDeviceOperation::tensor_return_value_t ttml_swiglu_gate_up(
+    const ttnn::Tensor& input_tensor, const ttnn::Tensor& w1, const ttnn::Tensor& w3) {
+    using OperationType = ttml::metal::ops::swiglu_gate_up::device::SwiGLUGateUpDeviceOperation;
+
+    auto operation_attributes = OperationType::operation_attributes_t{};
+    auto tensor_args = OperationType::tensor_args_t{.input = input_tensor, .w1 = w1, .w3 = w3};
+
+    return ttnn::device_operation::launch<OperationType>(operation_attributes, tensor_args);
+}
+
+}  // namespace ttnn::prim

--- a/tt-train/sources/ttml/metal/ops/swiglu_gate_up/device/swiglu_gate_up_device_operation.cpp
+++ b/tt-train/sources/ttml/metal/ops/swiglu_gate_up/device/swiglu_gate_up_device_operation.cpp
@@ -25,6 +25,12 @@ void SwiGLUGateUpDeviceOperation::validate_on_program_cache_miss(
             name);
 
         TT_FATAL(
+            tensor.buffer()->buffer_type() == tt::tt_metal::BufferType::DRAM,
+            "SwiGLUGateUp operation requires {} buffer to be in DRAM. Buffer type: {}",
+            name,
+            enchantum::to_string(tensor.buffer()->buffer_type()));
+
+        TT_FATAL(
             tensor.layout() == tt::tt_metal::Layout::TILE,
             "SwiGLUGateUp operation requires tensor to be in Tile layout. {} tensor layout: {}",
             name,
@@ -56,6 +62,8 @@ void SwiGLUGateUpDeviceOperation::validate_on_program_cache_miss(
     const auto& w3_shape = w3.logical_shape();
 
     TT_FATAL(input_shape.rank() == 4U, "Input tensor must be 4D");
+    TT_FATAL(w1_shape.rank() == 4U, "W1 tensor must be 4D [1, 1, embed, hidden]. W1 shape: {}", w1_shape);
+    TT_FATAL(w3_shape.rank() == 4U, "W3 tensor must be 4D [1, 1, embed, hidden]. W3 shape: {}", w3_shape);
 
     uint32_t embed_dim = input_shape[-1];
     uint32_t hidden_dim = w1_shape[-1];

--- a/tt-train/sources/ttml/metal/ops/swiglu_gate_up/device/swiglu_gate_up_device_operation.hpp
+++ b/tt-train/sources/ttml/metal/ops/swiglu_gate_up/device/swiglu_gate_up_device_operation.hpp
@@ -1,0 +1,38 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <optional>
+
+#include "metal/ttnn_all_includes.hpp"
+#include "swiglu_gate_up_device_operation_types.hpp"
+#include "swiglu_gate_up_program_factory.hpp"
+
+namespace ttml::metal::ops::swiglu_gate_up::device {
+
+struct SwiGLUGateUpDeviceOperation {
+    using operation_attributes_t = ttml::metal::ops::swiglu_gate_up::device::operation_attributes_t;
+    using tensor_args_t = ttml::metal::ops::swiglu_gate_up::device::tensor_args_t;
+    using spec_return_value_t = ttml::metal::ops::swiglu_gate_up::device::spec_return_value_t;
+    using tensor_return_value_t = ttml::metal::ops::swiglu_gate_up::device::tensor_return_value_t;
+    using program_factory_t = std::variant<SwiGLUGateUpProgramFactory>;
+
+    static void validate_on_program_cache_miss(const operation_attributes_t&, const tensor_args_t&);
+
+    static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
+
+    static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
+
+    static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
+};
+
+}  // namespace ttml::metal::ops::swiglu_gate_up::device
+
+namespace ttnn::prim {
+
+ttml::metal::ops::swiglu_gate_up::device::SwiGLUGateUpDeviceOperation::tensor_return_value_t ttml_swiglu_gate_up(
+    const ttnn::Tensor& input_tensor, const ttnn::Tensor& w1, const ttnn::Tensor& w3);
+
+}  // namespace ttnn::prim

--- a/tt-train/sources/ttml/metal/ops/swiglu_gate_up/device/swiglu_gate_up_device_operation_types.hpp
+++ b/tt-train/sources/ttml/metal/ops/swiglu_gate_up/device/swiglu_gate_up_device_operation_types.hpp
@@ -1,0 +1,23 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "metal/ttnn_all_includes.hpp"
+
+namespace ttml::metal::ops::swiglu_gate_up::device {
+
+struct operation_attributes_t {};
+
+struct tensor_args_t {
+    ttnn::Tensor input;
+    ttnn::Tensor w1;
+    ttnn::Tensor w3;
+};
+
+using spec_return_value_t = std::vector<ttnn::TensorSpec>;
+
+using tensor_return_value_t = ttnn::Tensor;
+
+}  // namespace ttml::metal::ops::swiglu_gate_up::device

--- a/tt-train/sources/ttml/metal/ops/swiglu_gate_up/device/swiglu_gate_up_program_factory.cpp
+++ b/tt-train/sources/ttml/metal/ops/swiglu_gate_up/device/swiglu_gate_up_program_factory.cpp
@@ -29,6 +29,8 @@ constexpr auto kCbW3Index = tt::CBIndex::c_2;      // W3 batch (double-buffered)
 constexpr auto kCbXW1AccIndex = tt::CBIndex::c_3;  // XW1 accumulation (L1 acc target)
 constexpr auto kCbXW3AccIndex = tt::CBIndex::c_4;  // XW3 accumulation (L1 acc target)
 constexpr auto kCbMOutIndex = tt::CBIndex::c_5;    // M output tiles
+constexpr auto kCbSigmoidIndex = tt::CBIndex::c_6;  // sigmoid(XW1) intermediate
+constexpr auto kCbSiluIndex = tt::CBIndex::c_7;     // SiLU(XW1) intermediate
 
 constexpr uint32_t kBlockSize = 4U;
 constexpr uint32_t kTilesPerBatch = kBlockSize * kBlockSize;
@@ -92,8 +94,9 @@ SwiGLUGateUpProgramFactory::cached_program_t SwiGLUGateUpProgramFactory::create(
 
     // block_h: number of M tile-rows processed per K-loop pass.
     // Larger block_h amortizes weight reads across more M rows.
-    // L1 = (2*block_h*kBlockSize + 4*kTilesPerBatch + 3*block_h*per_core_N_rounded) * tile_size
-    uint32_t baseline_weight_l1 = 4U * kTilesPerBatch * single_tile_size;
+    // L1 = (2*block_h*kBlockSize + 4*kTilesPerBatch + 4*kBlockSize + 3*block_h*per_core_N_rounded) * tile_size
+    //       ^-- X (dbl-buf)         ^-- W1+W3 (dbl-buf)  ^-- sigmoid+silu (dbl-buf)  ^-- xw1_acc+xw3_acc+m_out
+    uint32_t baseline_weight_l1 = (4U * kTilesPerBatch + 4U * kBlockSize) * single_tile_size;
     uint32_t per_row_l1 = (2U * kBlockSize + 3U * per_core_N_rounded) * single_tile_size;
     uint32_t max_block_h =
         (kL1UsableBytes > baseline_weight_l1) ? (kL1UsableBytes - baseline_weight_l1) / per_row_l1 : 1U;
@@ -150,6 +153,11 @@ SwiGLUGateUpProgramFactory::cached_program_t SwiGLUGateUpProgramFactory::create(
         create_circular_buffer(program, all_cores_set, kCbXW3AccIndex, data_format, single_tile_size, acc_cb_tiles);
     [[maybe_unused]] auto cb_m_out =
         create_circular_buffer(program, all_cores_set, kCbMOutIndex, data_format, single_tile_size, m_out_cb_tiles);
+    constexpr uint32_t kTwiceBlockSize = 2U * kBlockSize;
+    [[maybe_unused]] auto cb_sigmoid =
+        create_circular_buffer(program, all_cores_set, kCbSigmoidIndex, data_format, single_tile_size, kTwiceBlockSize);
+    [[maybe_unused]] auto cb_silu =
+        create_circular_buffer(program, all_cores_set, kCbSiluIndex, data_format, single_tile_size, kTwiceBlockSize);
 
     // -------------------------------------------------------------------------
     // 5) Create semaphores (4 for 2D multicast)
@@ -273,10 +281,8 @@ SwiGLUGateUpProgramFactory::cached_program_t SwiGLUGateUpProgramFactory::create(
     // -------------------------------------------------------------------------
     std::vector<uint32_t> compute_ct_args = {
         per_core_N,
-        per_core_N_rounded,
         kBlockSize,
         Wt,
-        num_n_blocks,
         block_h,
         num_m_blocks,
     };

--- a/tt-train/sources/ttml/metal/ops/swiglu_gate_up/device/swiglu_gate_up_program_factory.cpp
+++ b/tt-train/sources/ttml/metal/ops/swiglu_gate_up/device/swiglu_gate_up_program_factory.cpp
@@ -4,8 +4,6 @@
 
 #include "swiglu_gate_up_program_factory.hpp"
 
-#include <common/tt_rounding.h>
-
 #include <algorithm>
 #include <tt-metalium/data_types.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
@@ -86,7 +84,7 @@ SwiGLUGateUpProgramFactory::cached_program_t SwiGLUGateUpProgramFactory::create(
 
     uint32_t per_core_M = (total_M_tiles + num_cores_r - 1U) / num_cores_r;
     uint32_t per_core_N = (hidden_Wt + num_cores_c - 1U) / num_cores_c;
-    uint32_t per_core_N_rounded = ll_api::round_up_to<uint32_t, uint32_t>(per_core_N, kBlockSize);
+    uint32_t per_core_N_rounded = round_up(per_core_N, kBlockSize);
 
     // block_h: number of M tile-rows processed per K-loop pass.
     // Larger block_h amortizes weight reads across more M rows.

--- a/tt-train/sources/ttml/metal/ops/swiglu_gate_up/device/swiglu_gate_up_program_factory.cpp
+++ b/tt-train/sources/ttml/metal/ops/swiglu_gate_up/device/swiglu_gate_up_program_factory.cpp
@@ -4,6 +4,8 @@
 
 #include "swiglu_gate_up_program_factory.hpp"
 
+#include <tt_metal/common/tt_rounding.h>
+
 #include <algorithm>
 #include <tt-metalium/data_types.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
@@ -46,10 +48,6 @@ constexpr uint32_t kIn1SenderMAddrIdx = 2U;
 // Runtime arg indices for IN1 receiver+writer
 constexpr uint32_t kIn1ReceiverMAddrIdx = 0U;
 
-uint32_t round_up(uint32_t val, uint32_t multiple) {
-    return ((val + multiple - 1U) / multiple) * multiple;
-}
-
 }  // namespace
 
 namespace ttml::metal::ops::swiglu_gate_up::device {
@@ -88,7 +86,7 @@ SwiGLUGateUpProgramFactory::cached_program_t SwiGLUGateUpProgramFactory::create(
 
     uint32_t per_core_M = (total_M_tiles + num_cores_r - 1U) / num_cores_r;
     uint32_t per_core_N = (hidden_Wt + num_cores_c - 1U) / num_cores_c;
-    uint32_t per_core_N_rounded = round_up(per_core_N, kBlockSize);
+    uint32_t per_core_N_rounded = ll_api::round_up_to<uint32_t, uint32_t>(per_core_N, kBlockSize);
 
     // block_h: number of M tile-rows processed per K-loop pass.
     // Larger block_h amortizes weight reads across more M rows.

--- a/tt-train/sources/ttml/metal/ops/swiglu_gate_up/device/swiglu_gate_up_program_factory.cpp
+++ b/tt-train/sources/ttml/metal/ops/swiglu_gate_up/device/swiglu_gate_up_program_factory.cpp
@@ -1,0 +1,416 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "swiglu_gate_up_program_factory.hpp"
+
+#include <algorithm>
+#include <tt-metalium/data_types.hpp>
+#include <tt-metalium/tensor_accessor_args.hpp>
+
+#include "metal/common/program_utils.hpp"
+
+namespace {
+
+constexpr auto kIn0SenderKernelPath =
+    "tt-train/sources/ttml/metal/ops/swiglu_gate_up/device/kernels/dataflow/reader_in0_sender.cpp";
+constexpr auto kIn0ReceiverKernelPath =
+    "tt-train/sources/ttml/metal/ops/swiglu_gate_up/device/kernels/dataflow/reader_in0_receiver.cpp";
+constexpr auto kIn1SenderWriterKernelPath =
+    "tt-train/sources/ttml/metal/ops/swiglu_gate_up/device/kernels/dataflow/reader_in1_sender_writer.cpp";
+constexpr auto kIn1ReceiverWriterKernelPath =
+    "tt-train/sources/ttml/metal/ops/swiglu_gate_up/device/kernels/dataflow/reader_in1_receiver_writer.cpp";
+constexpr auto kComputeKernelPath =
+    "tt-train/sources/ttml/metal/ops/swiglu_gate_up/device/kernels/compute/swiglu_gate_up_compute.cpp";
+
+constexpr auto kCbIn0Index = tt::CBIndex::c_0;     // X tiles (double-buffered)
+constexpr auto kCbW1Index = tt::CBIndex::c_1;      // W1 batch (double-buffered)
+constexpr auto kCbW3Index = tt::CBIndex::c_2;      // W3 batch (double-buffered)
+constexpr auto kCbXW1AccIndex = tt::CBIndex::c_3;  // XW1 accumulation (L1 acc target)
+constexpr auto kCbXW3AccIndex = tt::CBIndex::c_4;  // XW3 accumulation (L1 acc target)
+constexpr auto kCbMOutIndex = tt::CBIndex::c_5;    // M output tiles
+
+constexpr uint32_t kBlockSize = 4U;
+constexpr uint32_t kTilesPerBatch = kBlockSize * kBlockSize;
+
+// Runtime arg indices for IN0 sender
+constexpr uint32_t kIn0SenderXAddrIdx = 0U;
+
+// Runtime arg indices for IN1 sender+writer
+constexpr uint32_t kIn1SenderW1AddrIdx = 0U;
+constexpr uint32_t kIn1SenderW3AddrIdx = 1U;
+constexpr uint32_t kIn1SenderMAddrIdx = 2U;
+
+// Runtime arg indices for IN1 receiver+writer
+constexpr uint32_t kIn1ReceiverMAddrIdx = 0U;
+
+uint32_t round_up(uint32_t val, uint32_t multiple) {
+    return ((val + multiple - 1U) / multiple) * multiple;
+}
+
+}  // namespace
+
+namespace ttml::metal::ops::swiglu_gate_up::device {
+
+SwiGLUGateUpProgramFactory::cached_program_t SwiGLUGateUpProgramFactory::create(
+    const operation_attributes_t& args, const tensor_args_t& tensor_args, tensor_return_value_t& output) {
+    const auto& input = tensor_args.input;
+    const auto& w1 = tensor_args.w1;
+    const auto& w3 = tensor_args.w3;
+
+    auto* device = input.device();
+    tt::tt_metal::Program program{};
+
+    tt::DataFormat data_format = datatype_to_dataformat_converter(input.dtype());
+    uint32_t single_tile_size = tt::tile_size(data_format);
+
+    // -------------------------------------------------------------------------
+    // 1) Compute dimensions
+    // -------------------------------------------------------------------------
+    auto padded_shape = input.padded_shape();
+    TT_FATAL(padded_shape.rank() == 4U, "Input tensor must be 4D");
+    uint32_t Wt = padded_shape[-1] / tt::constants::TILE_WIDTH;  // K dimension in tiles
+    uint32_t Ht = padded_shape[-2] / tt::constants::TILE_HEIGHT;
+    uint32_t NC = padded_shape[0] * padded_shape[1];
+    uint32_t total_M_tiles = NC * Ht;
+
+    uint32_t hidden_dim = w1.logical_shape()[-1];
+    uint32_t hidden_Wt = hidden_dim / tt::constants::TILE_WIDTH;  // N dimension in tiles
+
+    // -------------------------------------------------------------------------
+    // 2) Determine 2D core grid: R rows × C columns
+    // -------------------------------------------------------------------------
+    auto grid_size = device->compute_with_storage_grid_size();
+    uint32_t num_cores_r = std::min(static_cast<uint32_t>(grid_size.y), total_M_tiles);
+    uint32_t num_cores_c = std::min(static_cast<uint32_t>(grid_size.x), hidden_Wt);
+
+    uint32_t per_core_M = (total_M_tiles + num_cores_r - 1U) / num_cores_r;
+    uint32_t per_core_N = (hidden_Wt + num_cores_c - 1U) / num_cores_c;
+    uint32_t per_core_N_rounded = round_up(per_core_N, kBlockSize);
+    uint32_t num_n_blocks = per_core_N_rounded / kBlockSize;
+
+    // -------------------------------------------------------------------------
+    // 3) Build core ranges
+    // -------------------------------------------------------------------------
+    auto all_cores = tt::tt_metal::CoreRange({0, 0}, {num_cores_c - 1U, num_cores_r - 1U});
+    tt::tt_metal::CoreRangeSet all_cores_set({all_cores});
+
+    // Left column: IN0 senders (x=0)
+    auto left_column = tt::tt_metal::CoreRange({0, 0}, {0, num_cores_r - 1U});
+    tt::tt_metal::CoreRangeSet left_column_set({left_column});
+
+    // Non-left columns: IN0 receivers (x>0)
+    tt::tt_metal::CoreRangeSet non_left_column_set;
+    if (num_cores_c > 1U) {
+        auto non_left = tt::tt_metal::CoreRange({1, 0}, {num_cores_c - 1U, num_cores_r - 1U});
+        non_left_column_set = tt::tt_metal::CoreRangeSet({non_left});
+    }
+
+    // Top row: IN1 senders (y=0)
+    auto top_row = tt::tt_metal::CoreRange({0, 0}, {num_cores_c - 1U, 0});
+    tt::tt_metal::CoreRangeSet top_row_set({top_row});
+
+    // Non-top rows: IN1 receivers (y>0)
+    tt::tt_metal::CoreRangeSet non_top_row_set;
+    if (num_cores_r > 1U) {
+        auto non_top = tt::tt_metal::CoreRange({0, 1}, {num_cores_c - 1U, num_cores_r - 1U});
+        non_top_row_set = tt::tt_metal::CoreRangeSet({non_top});
+    }
+
+    // -------------------------------------------------------------------------
+    // 4) Allocate circular buffers
+    // -------------------------------------------------------------------------
+    uint32_t x_cb_tiles = 2U * kBlockSize;      // double-buffered
+    uint32_t w_cb_tiles = 2U * kTilesPerBatch;  // double-buffered
+    uint32_t acc_cb_tiles = per_core_N_rounded;
+    uint32_t m_out_cb_tiles = per_core_N_rounded;
+
+    [[maybe_unused]] auto cb_in0 =
+        create_circular_buffer(program, all_cores_set, kCbIn0Index, data_format, single_tile_size, x_cb_tiles);
+    [[maybe_unused]] auto cb_w1 =
+        create_circular_buffer(program, all_cores_set, kCbW1Index, data_format, single_tile_size, w_cb_tiles);
+    [[maybe_unused]] auto cb_w3 =
+        create_circular_buffer(program, all_cores_set, kCbW3Index, data_format, single_tile_size, w_cb_tiles);
+    [[maybe_unused]] auto cb_xw1_acc =
+        create_circular_buffer(program, all_cores_set, kCbXW1AccIndex, data_format, single_tile_size, acc_cb_tiles);
+    [[maybe_unused]] auto cb_xw3_acc =
+        create_circular_buffer(program, all_cores_set, kCbXW3AccIndex, data_format, single_tile_size, acc_cb_tiles);
+    [[maybe_unused]] auto cb_m_out =
+        create_circular_buffer(program, all_cores_set, kCbMOutIndex, data_format, single_tile_size, m_out_cb_tiles);
+
+    // -------------------------------------------------------------------------
+    // 5) Create semaphores (4 for 2D multicast)
+    // -------------------------------------------------------------------------
+    auto in0_mcast_sender_semaphore_id = tt::tt_metal::CreateSemaphore(program, all_cores_set, 0U);
+    auto in0_mcast_receiver_semaphore_id = tt::tt_metal::CreateSemaphore(program, all_cores_set, 0U);
+    auto in1_mcast_sender_semaphore_id = tt::tt_metal::CreateSemaphore(program, all_cores_set, 0U);
+    auto in1_mcast_receiver_semaphore_id = tt::tt_metal::CreateSemaphore(program, all_cores_set, 0U);
+
+    // -------------------------------------------------------------------------
+    // 6) NOC selection (match matmul 2D mcast pattern)
+    // -------------------------------------------------------------------------
+    tt::tt_metal::NOC in0_noc = tt::tt_metal::detail::preferred_noc_for_dram_write(device->arch());
+    tt::tt_metal::NOC in1_noc = tt::tt_metal::detail::preferred_noc_for_dram_read(device->arch());
+
+    // -------------------------------------------------------------------------
+    // 7) Get buffer pointers
+    // -------------------------------------------------------------------------
+    auto* input_buffer = input.buffer();
+    auto* w1_buffer = w1.buffer();
+    auto* w3_buffer = w3.buffer();
+    auto* m_buffer = output.buffer();
+
+    // -------------------------------------------------------------------------
+    // 8) Create dataflow kernels
+    // -------------------------------------------------------------------------
+
+    // --- RISCV_1: IN0 sender (left column) ---
+    std::vector<uint32_t> in0_sender_ct_args = {
+        kBlockSize,
+        Wt,
+        per_core_M,
+        num_n_blocks,
+        in0_mcast_sender_semaphore_id,
+        in0_mcast_receiver_semaphore_id,
+    };
+    tt::tt_metal::TensorAccessorArgs(input_buffer).append_to(in0_sender_ct_args);
+    auto in0_sender_kernel_id = tt::tt_metal::CreateKernel(
+        program,
+        kIn0SenderKernelPath,
+        left_column_set,
+        tt::tt_metal::DataMovementConfig{
+            .processor = tt::tt_metal::DataMovementProcessor::RISCV_1,
+            .noc = in0_noc,
+            .compile_args = in0_sender_ct_args});
+
+    // --- RISCV_1: IN0 receiver (non-left columns) ---
+    tt::tt_metal::KernelHandle in0_receiver_kernel_id = 0;
+    if (num_cores_c > 1U) {
+        std::vector<uint32_t> in0_receiver_ct_args = {
+            kBlockSize,
+            Wt,
+            per_core_M,
+            num_n_blocks,
+            in0_mcast_sender_semaphore_id,
+            in0_mcast_receiver_semaphore_id,
+        };
+        in0_receiver_kernel_id = tt::tt_metal::CreateKernel(
+            program,
+            kIn0ReceiverKernelPath,
+            non_left_column_set,
+            tt::tt_metal::DataMovementConfig{
+                .processor = tt::tt_metal::DataMovementProcessor::RISCV_1,
+                .noc = in0_noc,
+                .compile_args = in0_receiver_ct_args});
+    }
+
+    // --- RISCV_0: IN1 sender + M writer (top row) ---
+    std::vector<uint32_t> in1_sender_writer_ct_args = {
+        kBlockSize,
+        Wt,
+        hidden_Wt,
+        per_core_M,
+        per_core_N,
+        per_core_N_rounded,
+        num_n_blocks,
+        in1_mcast_sender_semaphore_id,
+        in1_mcast_receiver_semaphore_id,
+    };
+    tt::tt_metal::TensorAccessorArgs(w1_buffer).append_to(in1_sender_writer_ct_args);
+    tt::tt_metal::TensorAccessorArgs(w3_buffer).append_to(in1_sender_writer_ct_args);
+    tt::tt_metal::TensorAccessorArgs(m_buffer).append_to(in1_sender_writer_ct_args);
+    auto in1_sender_writer_kernel_id = tt::tt_metal::CreateKernel(
+        program,
+        kIn1SenderWriterKernelPath,
+        top_row_set,
+        tt::tt_metal::DataMovementConfig{
+            .processor = tt::tt_metal::DataMovementProcessor::RISCV_0,
+            .noc = in1_noc,
+            .compile_args = in1_sender_writer_ct_args});
+
+    // --- RISCV_0: IN1 receiver + M writer (non-top rows) ---
+    tt::tt_metal::KernelHandle in1_receiver_writer_kernel_id = 0;
+    if (num_cores_r > 1U) {
+        std::vector<uint32_t> in1_receiver_writer_ct_args = {
+            kBlockSize,
+            Wt,
+            hidden_Wt,
+            per_core_M,
+            per_core_N,
+            per_core_N_rounded,
+            num_n_blocks,
+            in1_mcast_sender_semaphore_id,
+            in1_mcast_receiver_semaphore_id,
+        };
+        tt::tt_metal::TensorAccessorArgs(m_buffer).append_to(in1_receiver_writer_ct_args);
+        in1_receiver_writer_kernel_id = tt::tt_metal::CreateKernel(
+            program,
+            kIn1ReceiverWriterKernelPath,
+            non_top_row_set,
+            tt::tt_metal::DataMovementConfig{
+                .processor = tt::tt_metal::DataMovementProcessor::RISCV_0,
+                .noc = in1_noc,
+                .compile_args = in1_receiver_writer_ct_args});
+    }
+
+    // -------------------------------------------------------------------------
+    // 9) Create compute kernel
+    // -------------------------------------------------------------------------
+    std::vector<uint32_t> compute_ct_args = {
+        per_core_M,
+        per_core_N,
+        per_core_N_rounded,
+        kBlockSize,
+        Wt,
+        num_n_blocks,
+    };
+    auto compute_kernel_id = create_compute_kernel(
+        program, all_cores_set, compute_ct_args, {}, kComputeKernelPath, /*fp32_dest_acc_en=*/true);
+
+    // -------------------------------------------------------------------------
+    // 10) Assign runtime args per core
+    // -------------------------------------------------------------------------
+    for (uint32_t r = 0U; r < num_cores_r; ++r) {
+        for (uint32_t c = 0U; c < num_cores_c; ++c) {
+            tt::tt_metal::CoreCoord core = {c, r};
+
+            uint32_t m_start = r * per_core_M;
+            uint32_t n_start = c * per_core_N;
+            uint32_t actual_m_tiles = std::min(per_core_M, total_M_tiles - m_start);
+            uint32_t actual_n_tiles = std::min(per_core_N, hidden_Wt - n_start);
+
+            bool is_in0_sender = (c == 0U);
+            bool is_in1_sender = (r == 0U);
+
+            // --- RISCV_1: IN0 sender or receiver ---
+            if (is_in0_sender) {
+                // Row multicast range: IN0 runs on in0_noc (RISCV_1).
+                // On Wormhole NOC_1, coordinates are inverted relative to
+                // worker_core_from_logical_core (NOC_0 space).  Pass the
+                // end-of-row as "start" and start-of-row as "end" so that
+                // after NOC_1 inversion the rectangle is valid (start ≤ end).
+                auto row_lo_phys = device->worker_core_from_logical_core({0, r});
+                auto row_hi_phys = device->worker_core_from_logical_core({num_cores_c - 1U, r});
+                uint32_t num_in0_receivers = num_cores_c - 1U;
+
+                SetRuntimeArgs(
+                    program,
+                    in0_sender_kernel_id,
+                    core,
+                    {input_buffer->address(),
+                     m_start,
+                     actual_m_tiles,
+                     static_cast<uint32_t>(row_hi_phys.x),
+                     static_cast<uint32_t>(row_hi_phys.y),
+                     static_cast<uint32_t>(row_lo_phys.x),
+                     static_cast<uint32_t>(row_lo_phys.y),
+                     num_in0_receivers});
+            } else {
+                // IN0 receiver: needs sender's physical coords for semaphore
+                auto sender_phys = device->worker_core_from_logical_core({0, r});
+                SetRuntimeArgs(
+                    program,
+                    in0_receiver_kernel_id,
+                    core,
+                    {static_cast<uint32_t>(sender_phys.x), static_cast<uint32_t>(sender_phys.y)});
+            }
+
+            // --- RISCV_0: IN1 sender+writer or receiver+writer ---
+            if (is_in1_sender) {
+                // Compute column multicast range
+                auto col_start_phys = device->worker_core_from_logical_core({c, 0});
+                auto col_end_phys = device->worker_core_from_logical_core({c, num_cores_r - 1U});
+                uint32_t num_in1_receivers = num_cores_r - 1U;
+
+                SetRuntimeArgs(
+                    program,
+                    in1_sender_writer_kernel_id,
+                    core,
+                    {w1_buffer->address(),
+                     w3_buffer->address(),
+                     m_buffer->address(),
+                     m_start,
+                     n_start,
+                     actual_m_tiles,
+                     actual_n_tiles,
+                     static_cast<uint32_t>(col_start_phys.x),
+                     static_cast<uint32_t>(col_start_phys.y),
+                     static_cast<uint32_t>(col_end_phys.x),
+                     static_cast<uint32_t>(col_end_phys.y),
+                     num_in1_receivers});
+            } else {
+                // IN1 receiver+writer: needs sender's physical coords
+                auto sender_phys = device->worker_core_from_logical_core({c, 0});
+                SetRuntimeArgs(
+                    program,
+                    in1_receiver_writer_kernel_id,
+                    core,
+                    {m_buffer->address(),
+                     m_start,
+                     n_start,
+                     actual_m_tiles,
+                     actual_n_tiles,
+                     static_cast<uint32_t>(sender_phys.x),
+                     static_cast<uint32_t>(sender_phys.y)});
+            }
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // 11) Return cached program
+    // -------------------------------------------------------------------------
+    return cached_program_t{
+        std::move(program),
+        {in0_sender_kernel_id,
+         in0_receiver_kernel_id,
+         in1_sender_writer_kernel_id,
+         in1_receiver_writer_kernel_id,
+         compute_kernel_id,
+         num_cores_r,
+         num_cores_c,
+         per_core_M,
+         per_core_N}};
+}
+
+void SwiGLUGateUpProgramFactory::override_runtime_arguments(
+    cached_program_t& cached_program,
+    const operation_attributes_t& operation_attributes,
+    const tensor_args_t& tensor_args,
+    tensor_return_value_t& output) {
+    auto& program = cached_program.program;
+    auto& sv = cached_program.shared_variables;
+
+    auto* input_buffer = tensor_args.input.buffer();
+    auto* w1_buffer = tensor_args.w1.buffer();
+    auto* w3_buffer = tensor_args.w3.buffer();
+    auto* m_buffer = output.buffer();
+
+    auto& in0_sender_args = GetRuntimeArgs(program, sv.in0_sender_kernel_id);
+    auto& in1_sender_writer_args = GetRuntimeArgs(program, sv.in1_sender_writer_kernel_id);
+    auto& in1_receiver_writer_args = GetRuntimeArgs(program, sv.in1_receiver_writer_kernel_id);
+
+    for (uint32_t r = 0U; r < sv.num_cores_r; ++r) {
+        for (uint32_t c = 0U; c < sv.num_cores_c; ++c) {
+            tt::tt_metal::CoreCoord core = {c, r};
+            bool is_in0_sender = (c == 0U);
+            bool is_in1_sender = (r == 0U);
+
+            if (is_in0_sender) {
+                auto& rt_args = in0_sender_args[core.x][core.y];
+                rt_args[kIn0SenderXAddrIdx] = input_buffer->address();
+            }
+
+            if (is_in1_sender) {
+                auto& rt_args = in1_sender_writer_args[core.x][core.y];
+                rt_args[kIn1SenderW1AddrIdx] = w1_buffer->address();
+                rt_args[kIn1SenderW3AddrIdx] = w3_buffer->address();
+                rt_args[kIn1SenderMAddrIdx] = m_buffer->address();
+            } else {
+                auto& rt_args = in1_receiver_writer_args[core.x][core.y];
+                rt_args[kIn1ReceiverMAddrIdx] = m_buffer->address();
+            }
+        }
+    }
+}
+
+}  // namespace ttml::metal::ops::swiglu_gate_up::device

--- a/tt-train/sources/ttml/metal/ops/swiglu_gate_up/device/swiglu_gate_up_program_factory.cpp
+++ b/tt-train/sources/ttml/metal/ops/swiglu_gate_up/device/swiglu_gate_up_program_factory.cpp
@@ -4,7 +4,7 @@
 
 #include "swiglu_gate_up_program_factory.hpp"
 
-#include <tt_metal/common/tt_rounding.h>
+#include <common/tt_rounding.h>
 
 #include <algorithm>
 #include <tt-metalium/data_types.hpp>

--- a/tt-train/sources/ttml/metal/ops/swiglu_gate_up/device/swiglu_gate_up_program_factory.cpp
+++ b/tt-train/sources/ttml/metal/ops/swiglu_gate_up/device/swiglu_gate_up_program_factory.cpp
@@ -93,11 +93,21 @@ SwiGLUGateUpProgramFactory::cached_program_t SwiGLUGateUpProgramFactory::create(
     // block_h: number of M tile-rows processed per K-loop pass.
     // Larger block_h amortizes weight reads across more M rows.
     // L1 = (2*block_h*kBlockSize + 4*kTilesPerBatch + 3*block_h*per_core_N_rounded) * tile_size
-    uint32_t fixed_l1 = 4U * kTilesPerBatch * single_tile_size;
+    uint32_t baseline_weight_l1 = 4U * kTilesPerBatch * single_tile_size;
     uint32_t per_row_l1 = (2U * kBlockSize + 3U * per_core_N_rounded) * single_tile_size;
-    uint32_t max_block_h = (kL1UsableBytes > fixed_l1) ? (kL1UsableBytes - fixed_l1) / per_row_l1 : 1U;
+    uint32_t max_block_h =
+        (kL1UsableBytes > baseline_weight_l1) ? (kL1UsableBytes - baseline_weight_l1) / per_row_l1 : 1U;
     uint32_t block_h = std::clamp(max_block_h, 1U, per_core_M);
     uint32_t num_m_blocks = (per_core_M + block_h - 1U) / block_h;
+
+    // n_blocks_per_batch: batch multiple N-blocks per weight load to reduce sync points.
+    // Use leftover L1 (after block_h rows + baseline weight CBs) for larger weight CBs.
+    // Each extra N-block costs 4 * kTilesPerBatch * tile_size (W1+W3 double-buffered).
+    uint32_t shape_dependent_l1 = per_row_l1 * block_h + baseline_weight_l1;
+    uint32_t remaining_l1 = (kL1UsableBytes > shape_dependent_l1) ? (kL1UsableBytes - shape_dependent_l1) : 0U;
+    uint32_t extra_n_blocks = remaining_l1 / (4U * kTilesPerBatch * single_tile_size);
+    uint32_t n_blocks_per_batch = std::clamp(1U + extra_n_blocks, 1U, num_n_blocks);
+    uint32_t num_n_batch_iters = (num_n_blocks + n_blocks_per_batch - 1U) / n_blocks_per_batch;
 
     // -------------------------------------------------------------------------
     // 3) Build core ranges
@@ -131,7 +141,7 @@ SwiGLUGateUpProgramFactory::cached_program_t SwiGLUGateUpProgramFactory::create(
     // 4) Allocate circular buffers
     // -------------------------------------------------------------------------
     uint32_t x_cb_tiles = 2U * block_h * kBlockSize;         // double-buffered, block_h rows
-    uint32_t w_cb_tiles = 2U * kTilesPerBatch;               // double-buffered (unchanged)
+    uint32_t w_cb_tiles = 2U * n_blocks_per_batch * kTilesPerBatch;  // double-buffered, N-block batching
     uint32_t acc_cb_tiles = block_h * per_core_N_rounded;    // block_h rows of accumulators
     uint32_t m_out_cb_tiles = block_h * per_core_N_rounded;  // block_h rows of M output
 
@@ -224,6 +234,8 @@ SwiGLUGateUpProgramFactory::cached_program_t SwiGLUGateUpProgramFactory::create(
         per_core_N,
         per_core_N_rounded,
         num_n_blocks,
+        n_blocks_per_batch,
+        num_n_batch_iters,
         in1_mcast_sender_semaphore_id,
         in1_mcast_receiver_semaphore_id,
     };
@@ -251,6 +263,8 @@ SwiGLUGateUpProgramFactory::cached_program_t SwiGLUGateUpProgramFactory::create(
             per_core_N,
             per_core_N_rounded,
             num_n_blocks,
+            n_blocks_per_batch,
+            num_n_batch_iters,
             in1_mcast_sender_semaphore_id,
             in1_mcast_receiver_semaphore_id,
         };
@@ -276,6 +290,8 @@ SwiGLUGateUpProgramFactory::cached_program_t SwiGLUGateUpProgramFactory::create(
         num_n_blocks,
         block_h,
         num_m_blocks,
+        n_blocks_per_batch,
+        num_n_batch_iters,
     };
     auto compute_kernel_id = create_compute_kernel(
         program, all_cores_set, compute_ct_args, {}, kComputeKernelPath, /*fp32_dest_acc_en=*/true);

--- a/tt-train/sources/ttml/metal/ops/swiglu_gate_up/device/swiglu_gate_up_program_factory.cpp
+++ b/tt-train/sources/ttml/metal/ops/swiglu_gate_up/device/swiglu_gate_up_program_factory.cpp
@@ -100,14 +100,7 @@ SwiGLUGateUpProgramFactory::cached_program_t SwiGLUGateUpProgramFactory::create(
     uint32_t block_h = std::clamp(max_block_h, 1U, per_core_M);
     uint32_t num_m_blocks = (per_core_M + block_h - 1U) / block_h;
 
-    // n_blocks_per_batch: batch multiple N-blocks per weight load to reduce sync points.
-    // Use leftover L1 (after block_h rows + baseline weight CBs) for larger weight CBs.
-    // Each extra N-block costs 4 * kTilesPerBatch * tile_size (W1+W3 double-buffered).
-    uint32_t shape_dependent_l1 = per_row_l1 * block_h + baseline_weight_l1;
-    uint32_t remaining_l1 = (kL1UsableBytes > shape_dependent_l1) ? (kL1UsableBytes - shape_dependent_l1) : 0U;
-    uint32_t extra_n_blocks = remaining_l1 / (4U * kTilesPerBatch * single_tile_size);
-    uint32_t n_blocks_per_batch = std::clamp(1U + extra_n_blocks, 1U, num_n_blocks);
-    uint32_t num_n_batch_iters = (num_n_blocks + n_blocks_per_batch - 1U) / n_blocks_per_batch;
+    // One N-block of weights per load (no batching); simplifies code with no perf gain on target shapes.
 
     // -------------------------------------------------------------------------
     // 3) Build core ranges
@@ -141,7 +134,7 @@ SwiGLUGateUpProgramFactory::cached_program_t SwiGLUGateUpProgramFactory::create(
     // 4) Allocate circular buffers
     // -------------------------------------------------------------------------
     uint32_t x_cb_tiles = 2U * block_h * kBlockSize;         // double-buffered, block_h rows
-    uint32_t w_cb_tiles = 2U * n_blocks_per_batch * kTilesPerBatch;  // double-buffered, N-block batching
+    uint32_t w_cb_tiles = 2U * kTilesPerBatch;               // double-buffered, one N-block
     uint32_t acc_cb_tiles = block_h * per_core_N_rounded;    // block_h rows of accumulators
     uint32_t m_out_cb_tiles = block_h * per_core_N_rounded;  // block_h rows of M output
 
@@ -234,8 +227,6 @@ SwiGLUGateUpProgramFactory::cached_program_t SwiGLUGateUpProgramFactory::create(
         per_core_N,
         per_core_N_rounded,
         num_n_blocks,
-        n_blocks_per_batch,
-        num_n_batch_iters,
         in1_mcast_sender_semaphore_id,
         in1_mcast_receiver_semaphore_id,
     };
@@ -263,8 +254,6 @@ SwiGLUGateUpProgramFactory::cached_program_t SwiGLUGateUpProgramFactory::create(
             per_core_N,
             per_core_N_rounded,
             num_n_blocks,
-            n_blocks_per_batch,
-            num_n_batch_iters,
             in1_mcast_sender_semaphore_id,
             in1_mcast_receiver_semaphore_id,
         };
@@ -290,8 +279,6 @@ SwiGLUGateUpProgramFactory::cached_program_t SwiGLUGateUpProgramFactory::create(
         num_n_blocks,
         block_h,
         num_m_blocks,
-        n_blocks_per_batch,
-        num_n_batch_iters,
     };
     auto compute_kernel_id = create_compute_kernel(
         program, all_cores_set, compute_ct_args, {}, kComputeKernelPath, /*fp32_dest_acc_en=*/true);

--- a/tt-train/sources/ttml/metal/ops/swiglu_gate_up/device/swiglu_gate_up_program_factory.cpp
+++ b/tt-train/sources/ttml/metal/ops/swiglu_gate_up/device/swiglu_gate_up_program_factory.cpp
@@ -34,7 +34,6 @@ constexpr auto kCbSiluIndex = tt::CBIndex::c_7;     // SiLU(XW1) intermediate
 
 constexpr uint32_t kBlockSize = 4U;
 constexpr uint32_t kTilesPerBatch = kBlockSize * kBlockSize;
-constexpr uint32_t kL1UsableBytes = 1300U * 1024U;
 
 // Runtime arg indices for IN0 sender
 constexpr uint32_t kIn0SenderXAddrIdx = 0U;
@@ -90,16 +89,17 @@ SwiGLUGateUpProgramFactory::cached_program_t SwiGLUGateUpProgramFactory::create(
     uint32_t per_core_M = (total_M_tiles + num_cores_r - 1U) / num_cores_r;
     uint32_t per_core_N = (hidden_Wt + num_cores_c - 1U) / num_cores_c;
     uint32_t per_core_N_rounded = round_up(per_core_N, kBlockSize);
-    uint32_t num_n_blocks = per_core_N_rounded / kBlockSize;
 
     // block_h: number of M tile-rows processed per K-loop pass.
     // Larger block_h amortizes weight reads across more M rows.
     // L1 = (2*block_h*kBlockSize + 4*kTilesPerBatch + 4*kBlockSize + 3*block_h*per_core_N_rounded) * tile_size
     //       ^-- X (dbl-buf)         ^-- W1+W3 (dbl-buf)  ^-- sigmoid+silu (dbl-buf)  ^-- xw1_acc+xw3_acc+m_out
+    const uint32_t available_L1_in_bytes =
+        device->l1_size_per_core() - device->allocator()->get_base_allocator_addr(tt::tt_metal::HalMemType::L1);
     uint32_t baseline_weight_l1 = (4U * kTilesPerBatch + 4U * kBlockSize) * single_tile_size;
     uint32_t per_row_l1 = (2U * kBlockSize + 3U * per_core_N_rounded) * single_tile_size;
     uint32_t max_block_h =
-        (kL1UsableBytes > baseline_weight_l1) ? (kL1UsableBytes - baseline_weight_l1) / per_row_l1 : 1U;
+        (available_L1_in_bytes > baseline_weight_l1) ? (available_L1_in_bytes - baseline_weight_l1) / per_row_l1 : 1U;
     uint32_t block_h = std::clamp(max_block_h, 1U, per_core_M);
     uint32_t num_m_blocks = (per_core_M + block_h - 1U) / block_h;
 
@@ -233,8 +233,6 @@ SwiGLUGateUpProgramFactory::cached_program_t SwiGLUGateUpProgramFactory::create(
         block_h,
         num_m_blocks,
         per_core_N,
-        per_core_N_rounded,
-        num_n_blocks,
         in1_mcast_sender_semaphore_id,
         in1_mcast_receiver_semaphore_id,
     };
@@ -260,8 +258,6 @@ SwiGLUGateUpProgramFactory::cached_program_t SwiGLUGateUpProgramFactory::create(
             block_h,
             num_m_blocks,
             per_core_N,
-            per_core_N_rounded,
-            num_n_blocks,
             in1_mcast_sender_semaphore_id,
             in1_mcast_receiver_semaphore_id,
         };

--- a/tt-train/sources/ttml/metal/ops/swiglu_gate_up/device/swiglu_gate_up_program_factory.cpp
+++ b/tt-train/sources/ttml/metal/ops/swiglu_gate_up/device/swiglu_gate_up_program_factory.cpp
@@ -32,6 +32,7 @@ constexpr auto kCbMOutIndex = tt::CBIndex::c_5;    // M output tiles
 
 constexpr uint32_t kBlockSize = 4U;
 constexpr uint32_t kTilesPerBatch = kBlockSize * kBlockSize;
+constexpr uint32_t kL1UsableBytes = 1300U * 1024U;
 
 // Runtime arg indices for IN0 sender
 constexpr uint32_t kIn0SenderXAddrIdx = 0U;
@@ -89,6 +90,15 @@ SwiGLUGateUpProgramFactory::cached_program_t SwiGLUGateUpProgramFactory::create(
     uint32_t per_core_N_rounded = round_up(per_core_N, kBlockSize);
     uint32_t num_n_blocks = per_core_N_rounded / kBlockSize;
 
+    // block_h: number of M tile-rows processed per K-loop pass.
+    // Larger block_h amortizes weight reads across more M rows.
+    // L1 = (2*block_h*kBlockSize + 4*kTilesPerBatch + 3*block_h*per_core_N_rounded) * tile_size
+    uint32_t fixed_l1 = 4U * kTilesPerBatch * single_tile_size;
+    uint32_t per_row_l1 = (2U * kBlockSize + 3U * per_core_N_rounded) * single_tile_size;
+    uint32_t max_block_h = (kL1UsableBytes > fixed_l1) ? (kL1UsableBytes - fixed_l1) / per_row_l1 : 1U;
+    uint32_t block_h = std::clamp(max_block_h, 1U, per_core_M);
+    uint32_t num_m_blocks = (per_core_M + block_h - 1U) / block_h;
+
     // -------------------------------------------------------------------------
     // 3) Build core ranges
     // -------------------------------------------------------------------------
@@ -120,10 +130,10 @@ SwiGLUGateUpProgramFactory::cached_program_t SwiGLUGateUpProgramFactory::create(
     // -------------------------------------------------------------------------
     // 4) Allocate circular buffers
     // -------------------------------------------------------------------------
-    uint32_t x_cb_tiles = 2U * kBlockSize;      // double-buffered
-    uint32_t w_cb_tiles = 2U * kTilesPerBatch;  // double-buffered
-    uint32_t acc_cb_tiles = per_core_N_rounded;
-    uint32_t m_out_cb_tiles = per_core_N_rounded;
+    uint32_t x_cb_tiles = 2U * block_h * kBlockSize;         // double-buffered, block_h rows
+    uint32_t w_cb_tiles = 2U * kTilesPerBatch;               // double-buffered (unchanged)
+    uint32_t acc_cb_tiles = block_h * per_core_N_rounded;    // block_h rows of accumulators
+    uint32_t m_out_cb_tiles = block_h * per_core_N_rounded;  // block_h rows of M output
 
     [[maybe_unused]] auto cb_in0 =
         create_circular_buffer(program, all_cores_set, kCbIn0Index, data_format, single_tile_size, x_cb_tiles);
@@ -168,8 +178,8 @@ SwiGLUGateUpProgramFactory::cached_program_t SwiGLUGateUpProgramFactory::create(
     std::vector<uint32_t> in0_sender_ct_args = {
         kBlockSize,
         Wt,
-        per_core_M,
-        num_n_blocks,
+        block_h,
+        num_m_blocks,
         in0_mcast_sender_semaphore_id,
         in0_mcast_receiver_semaphore_id,
     };
@@ -189,8 +199,8 @@ SwiGLUGateUpProgramFactory::cached_program_t SwiGLUGateUpProgramFactory::create(
         std::vector<uint32_t> in0_receiver_ct_args = {
             kBlockSize,
             Wt,
-            per_core_M,
-            num_n_blocks,
+            block_h,
+            num_m_blocks,
             in0_mcast_sender_semaphore_id,
             in0_mcast_receiver_semaphore_id,
         };
@@ -209,7 +219,8 @@ SwiGLUGateUpProgramFactory::cached_program_t SwiGLUGateUpProgramFactory::create(
         kBlockSize,
         Wt,
         hidden_Wt,
-        per_core_M,
+        block_h,
+        num_m_blocks,
         per_core_N,
         per_core_N_rounded,
         num_n_blocks,
@@ -235,7 +246,8 @@ SwiGLUGateUpProgramFactory::cached_program_t SwiGLUGateUpProgramFactory::create(
             kBlockSize,
             Wt,
             hidden_Wt,
-            per_core_M,
+            block_h,
+            num_m_blocks,
             per_core_N,
             per_core_N_rounded,
             num_n_blocks,
@@ -257,12 +269,13 @@ SwiGLUGateUpProgramFactory::cached_program_t SwiGLUGateUpProgramFactory::create(
     // 9) Create compute kernel
     // -------------------------------------------------------------------------
     std::vector<uint32_t> compute_ct_args = {
-        per_core_M,
         per_core_N,
         per_core_N_rounded,
         kBlockSize,
         Wt,
         num_n_blocks,
+        block_h,
+        num_m_blocks,
     };
     auto compute_kernel_id = create_compute_kernel(
         program, all_cores_set, compute_ct_args, {}, kComputeKernelPath, /*fp32_dest_acc_en=*/true);

--- a/tt-train/sources/ttml/metal/ops/swiglu_gate_up/device/swiglu_gate_up_program_factory.hpp
+++ b/tt-train/sources/ttml/metal/ops/swiglu_gate_up/device/swiglu_gate_up_program_factory.hpp
@@ -1,0 +1,38 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "metal/ttnn_all_includes.hpp"
+#include "swiglu_gate_up_device_operation_types.hpp"
+
+namespace ttml::metal::ops::swiglu_gate_up::device {
+
+struct SwiGLUGateUpProgramFactory {
+    struct shared_variables_t {
+        tt::tt_metal::KernelHandle in0_sender_kernel_id;
+        tt::tt_metal::KernelHandle in0_receiver_kernel_id;
+        tt::tt_metal::KernelHandle in1_sender_writer_kernel_id;
+        tt::tt_metal::KernelHandle in1_receiver_writer_kernel_id;
+        tt::tt_metal::KernelHandle compute_kernel_id;
+        uint32_t num_cores_r{};
+        uint32_t num_cores_c{};
+        uint32_t per_core_M{};
+        uint32_t per_core_N{};
+    };
+    using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
+
+    static cached_program_t create(
+        const operation_attributes_t& operation_attributes,
+        const tensor_args_t& tensor_args,
+        tensor_return_value_t& tensor_return_value);
+
+    static void override_runtime_arguments(
+        cached_program_t& cached_program,
+        const operation_attributes_t& operation_attributes,
+        const tensor_args_t& tensor_args,
+        tensor_return_value_t& tensor_return_value);
+};
+
+}  // namespace ttml::metal::ops::swiglu_gate_up::device

--- a/tt-train/sources/ttml/metal/ops/swiglu_gate_up/swiglu_gate_up.cpp
+++ b/tt-train/sources/ttml/metal/ops/swiglu_gate_up/swiglu_gate_up.cpp
@@ -1,0 +1,15 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "swiglu_gate_up.hpp"
+
+#include "device/swiglu_gate_up_device_operation.hpp"
+
+namespace ttml::metal {
+
+ttnn::Tensor swiglu_gate_up(const ttnn::Tensor& input_tensor, const ttnn::Tensor& w1, const ttnn::Tensor& w3) {
+    return ttnn::prim::ttml_swiglu_gate_up(input_tensor, w1, w3);
+}
+
+}  // namespace ttml::metal

--- a/tt-train/sources/ttml/metal/ops/swiglu_gate_up/swiglu_gate_up.hpp
+++ b/tt-train/sources/ttml/metal/ops/swiglu_gate_up/swiglu_gate_up.hpp
@@ -8,8 +8,7 @@
 
 namespace ttml::metal {
 
-// SwiGLU Gate-Up operation (Design A Step 1):
-//   M = SiLU(X @ W1) * (X @ W3)
+// SwiGLU Gate-Up: M = SiLU(X @ W1) * (X @ W3)
 //
 // Uses 2D multicast matmul tiling for efficient DRAM bandwidth utilization.
 // X is read once per K-block and shared across both W1 and W3 matmuls.

--- a/tt-train/sources/ttml/metal/ops/swiglu_gate_up/swiglu_gate_up.hpp
+++ b/tt-train/sources/ttml/metal/ops/swiglu_gate_up/swiglu_gate_up.hpp
@@ -1,0 +1,26 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "metal/ttnn_all_includes.hpp"
+
+namespace ttml::metal {
+
+// SwiGLU Gate-Up operation (Design A Step 1):
+//   M = SiLU(X @ W1) * (X @ W3)
+//
+// Uses 2D multicast matmul tiling for efficient DRAM bandwidth utilization.
+// X is read once per K-block and shared across both W1 and W3 matmuls.
+//
+// Args:
+//   input_tensor: Input tensor [B, 1, S, embed_dim]
+//   w1: Gate projection weights [1, 1, embed_dim, hidden_dim]
+//   w3: Up projection weights [1, 1, embed_dim, hidden_dim]
+//
+// Returns:
+//   M tensor [B, 1, S, hidden_dim]
+ttnn::Tensor swiglu_gate_up(const ttnn::Tensor& input_tensor, const ttnn::Tensor& w1, const ttnn::Tensor& w3);
+
+}  // namespace ttml::metal

--- a/tt-train/sources/ttml/ops/swiglu_op.cpp
+++ b/tt-train/sources/ttml/ops/swiglu_op.cpp
@@ -4,12 +4,17 @@
 
 #include "swiglu_op.hpp"
 
+#include <tt-logger/tt-logger.hpp>
 #include <ttnn/operations/eltwise/binary/binary.hpp>
+#include <ttnn/operations/eltwise/unary/unary.hpp>
+#include <ttnn/operations/matmul/matmul.hpp>
 
 #include "autograd/auto_context.hpp"
 #include "autograd/graph_utils.hpp"
 #include "autograd/tensor.hpp"
 #include "metal/operations.hpp"
+#include "metal/ops/swiglu_fw/swiglu_fw.hpp"
+#include "metal/ops/swiglu_gate_up/swiglu_gate_up.hpp"
 #include "ops/binary_ops.hpp"
 #include "ops/unary_ops.hpp"
 #include "ttnn/operations/creation.hpp"
@@ -19,6 +24,10 @@
 #include "ttnn_fixed/matmuls.hpp"
 
 namespace ttml::ops {
+
+// GateUp = production default. Composite and FullFusion kept for further tests and development.
+// FullFusion saves memory (no materialized M) but runtime is heavily suboptimal.
+constexpr SwigluFwPath kDefaultSwigluFwPath = SwigluFwPath::GateUp;
 
 autograd::TensorPtr swiglu(
     const autograd::TensorPtr& tensor,
@@ -30,8 +39,34 @@ autograd::TensorPtr swiglu(
         throw std::runtime_error("swiglu only supports rank-4 input tensors.");
     }
 
-    ttnn::Tensor swiglu_fw_result =
-        ttml::metal::swiglu_fw(tensor->get_value(), w1->get_value(), w2->get_value(), w3->get_value());
+    ttnn::Tensor swiglu_fw_result;
+    switch (kDefaultSwigluFwPath) {
+        case SwigluFwPath::Composite: {
+            // Same math as LlamaMLP composite. Kept for further tests and development.
+            log_warning(tt::LogOp, "SwiGLU Composite path (for tests and development). Default is GateUp (2-step).");
+            auto xw1 = ttnn_fixed::matmul(tensor->get_value(), w1->get_value());
+            auto xw3 = ttnn_fixed::matmul(tensor->get_value(), w3->get_value());
+            auto swished = ttnn::silu(xw1);
+            auto gated = ttnn::multiply(swished, xw3);
+            swiglu_fw_result = ttnn_fixed::matmul(gated, w2->get_value());
+            break;
+        }
+        case SwigluFwPath::GateUp: {
+            // 2-step: fused gate-up then matmul(M, W2).
+            ttnn::Tensor M = ttml::metal::swiglu_gate_up(tensor->get_value(), w1->get_value(), w3->get_value());
+            swiglu_fw_result = ttnn::matmul(M, w2->get_value());
+            break;
+        }
+        case SwigluFwPath::FullFusion:
+            // FullFusion saves memory (no materialized M) but runtime is heavily suboptimal.
+            log_warning(
+                tt::LogOp,
+                "SwiGLU FullFusion path (saves memory, runtime suboptimal). Do NOT use in production. "
+                "Use GateUp (2-step) for production.");
+            swiglu_fw_result =
+                ttml::metal::swiglu_fw(tensor->get_value(), w1->get_value(), w2->get_value(), w3->get_value());
+            break;
+    }
     auto out = autograd::create_tensor(swiglu_fw_result);
 
     autograd::GradFunction grad = [tensor, w1, w2, w3, out]() {

--- a/tt-train/sources/ttml/ops/swiglu_op.hpp
+++ b/tt-train/sources/ttml/ops/swiglu_op.hpp
@@ -5,9 +5,15 @@
 #pragma once
 
 #include "autograd/tensor.hpp"
-#include "metal/ops/swiglu_fw/swiglu_fw.hpp"
 
 namespace ttml::ops {
+
+// SwiGLU forward path. We keep all three for further tests and development:
+//   GateUp (2-step): Production default. Fused gate-up kernel + matmul(M, W2).
+//   Composite: Unfused matmul/silu/mul/matmul; same as LlamaMLP composite. Kept for tests and development.
+//   FullFusion: Single fused kernel. Saves memory (no materialized M) but runtime is heavily suboptimal;
+//               kept for tests and development, must NOT be used in production.
+enum class SwigluFwPath { Composite, GateUp, FullFusion };
 
 autograd::TensorPtr swiglu(
     const autograd::TensorPtr& tensor,

--- a/tt-train/sources/ttml/ops/swiglu_op.hpp
+++ b/tt-train/sources/ttml/ops/swiglu_op.hpp
@@ -4,14 +4,11 @@
 
 #pragma once
 
-#include <optional>
-
 #include "autograd/tensor.hpp"
 #include "metal/ops/swiglu_fw/swiglu_fw.hpp"
 
 namespace ttml::ops {
 
-// When path is nullopt, uses get_swiglu_path() (env TTML_SWIGLU_PATH).
 autograd::TensorPtr swiglu(
     const autograd::TensorPtr& tensor,
     const autograd::TensorPtr& w1,

--- a/tt-train/sources/ttml/ops/swiglu_op.hpp
+++ b/tt-train/sources/ttml/ops/swiglu_op.hpp
@@ -4,10 +4,14 @@
 
 #pragma once
 
+#include <optional>
+
 #include "autograd/tensor.hpp"
+#include "metal/ops/swiglu_fw/swiglu_fw.hpp"
 
 namespace ttml::ops {
 
+// When path is nullopt, uses get_swiglu_path() (env TTML_SWIGLU_PATH).
 autograd::TensorPtr swiglu(
     const autograd::TensorPtr& tensor,
     const autograd::TensorPtr& w1,


### PR DESCRIPTION
## Ticket
[Feature Request] SwiGLU forward and backward functions - https://github.com/tenstorrent/tt-metal/issues/14195

## Context

This PR **implements the 2-step gate_up fused SwiGLU forward** and exposes it behind a path selector so we can run it alongside the existing composite and full-fusion paths until a fused backward is ready; options will be trimmed later (e.g. drop full fusion, then reassess gate_up vs composite).

**Why 2-step.** The legacy single fused kernel has two structural limits: (1) weights are re-read from DRAM for every tile-row, giving a low arithmetic-intensity ceiling (~32 FLOPs/byte), and (2) all weight traffic goes through a single sender core, so bandwidth does not scale. On small hidden (e.g. NanoLLaMA) it is fast; on large hidden (e.g. TinyLlama) it becomes **~290% slower** than composite. Improving that further inside the same kernel would require a major redesign. The 2-step split instead does: **Step 1** — fused gate-up `M = SiLU(X@W1) * (X@W3)` with matmul-style 2D multicast (one read of W1/W3 per phase, weights distributed across cores), then **Step 2** — `Y = M@W2` via the existing `ttnn::matmul`. That gives much higher theoretical arithmetic intensity (weights read once per phase rather than per row) and reuses the optimized matmul for the second step. On NanoLLaMA we see **22.7% faster** per block than composite; on TinyLlama the gate_up step still has overhead (sync and double weight stream) so we are ~16% slower than composite, but we avoid the catastrophic full-fusion slowdown.

**Path choice.** Callers can select **Composite** (metal matmul + silu + mul + matmul, for comparison), **GateUp** (the new 2-step), or **FullFusion** (legacy single kernel) via env/config at the call site. Default is GateUp. Backward is unchanged: a single custom backward in `swiglu_op.cpp` that recomputes intermediates for all paths using `ops::swiglu`.


## Problem description

The existing fused SwiGLU forward (single kernel) is fast on NanoLLaMA but **~290% slower** than composite on TinyLlama (per-block: 17.37 ms vs 4.49 ms). We need a fused forward that scales to large hidden. The 2-step gate_up fusion addresses this by using 2D multicast and a separate matmul for the down projection; the path selector allows us to keep composite and full fusion available until we have a fused backward and can reduce the set of options.

## What's changed

- **Gate-up fused forward (2-step):** Step 1 is the existing `swiglu_gate_up(X,W1,W3)` kernel (fused gate-up with 2D multicast); Step 2 is `ttnn::matmul(M,W2)`. This path is the main addition.
- **`ttml::metal::swiglu_fw`:** Added `SwigluFwPath` enum (`Composite`, `GateUp`, `FullFusion`) and a switch so callers can choose the implementation. `Composite` runs metal matmul + silu + mul + matmul; `GateUp` runs the 2-step above; `FullFusion` calls `ttnn::prim::ttml_swiglu_fw`. Default is GateUp.
- **`ttml::ops::swiglu`:** Calls `metal::swiglu_fw(..., path)` with default path; path selection for training is at the call site (e.g. LlamaMLP via env/config).
- No changes to backward or to the gate_up / full_fusion kernel implementations in this PR; this PR adds the forward dispatch and the metal composite path so all three can be compared.

## Performance

**Methodology:** Forward-only runs (backward disabled where noted). Per-block times from profiler markers (e.g. `LlamaMLP_fused_begin` / `_end` or `composite_swiglu_begin` / `_end`) or Tracy CSV. One SwiGLU per transformer block.

### Per-block SwiGLU time (device kernel duration)

| Impl      | Model     | Avg per block (ms) | vs Composite |
|-----------|-----------|--------------------|--------------|
| Composite | NanoLLaMA | 4.285              | —            |
| Composite | TinyLLaMA | 4.488              | —            |
| 2-step (GateUp) | NanoLLaMA | **3.260**   | **22.7% faster** |
| 2-step (GateUp) | TinyLLaMA | **5.208**   | ~16% slower  |
| FullFusion (legacy) | NanoLLaMA | 3.349  | 21.9% faster |
| FullFusion (legacy) | TinyLLaMA | 17.370 | ~290% slower |

GateUp (2-step) is faster than composite on NanoLLaMA and slower on TinyLlama; the gap on TinyLlama is in the gate_up kernel (4.45 ms) vs composite W1+SiLU+W3+mul (3.31 ms), with W2 matmul faster in 2-step (0.77 ms vs 1.12 ms). FullFusion is fast on NanoLLaMA but severely slow on TinyLlama.

### Per-op breakdown (TinyLLaMA)

| Path      | Op                          | Duration |
|-----------|-----------------------------|----------|
| 2-step    | SwiGLUGateUpDeviceOperation | 4.450 ms |
| 2-step    | MatmulDeviceOperation (W2)  | 0.766 ms |
| Composite | Matmul (W1), SiLU, Matmul (W3), mul, Matmul (W2) | 1.38 + 0.33 + 1.36 + 0.23 + 1.12 ms |

## Memory

**Methodology:** FORWARD_PASS segment change = activations (when grads enabled: net DRAM held for backward). **Segment Peak (forward)** = max DRAM during forward; **Allocations (forward)** = total DRAM allocated during forward. From training logs, `tt-train/scripts/analyze_memory.py`. When backward recomputes intermediates (current `swiglu_op` backward), the metric that shows fusion advantage is Segment Peak (forward), not end-of-forward retained activations.

### NanoLLaMA (grads enabled, default runner)

| Run         | Activations (MB) | Segment Peak (fwd) MB | Allocations (fwd) MB |
|-------------|------------------|------------------------|------------------------|
| composite   | 2,068.64         | 2,070.73               | 3,368.46               |
| gate_up     | 1,300.62         | 1,307.73               | 2,792.44               |
| full_fusion | 1,300.62         | 1,307.73               | 2,600.45               |

Fused paths (gate_up, full_fusion) reduce Segment Peak (forward) by ~37% and allocation volume by ~17–23% vs composite. Gate_up and full_fusion share the same custom backward (recompute), so retained activations are equal even though gate_up materializes M in the forward.

### TinyLlama (6 and 12 blocks; extrapolation to 22 blocks)

TinyLlama 22-block does not fit on n300; runs used 6- and 12-block configs, then linear extrapolation.

**Measured (Segment Peak and Allocations during FORWARD_PASS):**

| num_blocks | Run         | Segment Peak (fwd) MB | Allocations (fwd) MB |
|------------|-------------|------------------------|------------------------|
| 6          | composite   | 3,023.80               | 7,597.17              |
| 6          | gate_up     | 2,583.78               | 7,201.15              |
| 6          | full_fusion | 2,583.78               | 7,069.15              |
| 12         | composite   | 5,647.30               | 15,176.67             |
| 12         | gate_up     | 4,679.28               | 14,384.65             |
| 12         | full_fusion | 4,679.28               | 14,120.65             |

**Extrapolated to 22 blocks (linear in num_blocks):**

| Path        | Segment Peak (fwd) MB | Allocations (fwd) MB |
|-------------|------------------------|------------------------|
| composite   | ~10,020                | ~26,806                |
| gate_up     | ~8,161                 | ~26,357                |
| full_fusion | ~8,161                 | ~25,873                |

Predicted gain at 22 blocks (fused vs composite): Segment Peak (forward) ~1,859 MB lower (~18.6%); Allocations (forward) full_fusion ~933 MB lower, gate_up ~449 MB lower.

## Summary

- **Gate-up fusion (2-step):** Implemented and exposed as the **GateUp** path: Step 1 fused gate-up kernel + Step 2 `ttnn::matmul(M,W2)`. **Path choice:** `ttml::metal::swiglu_fw` supports **Composite**, **GateUp**, and **FullFusion** (legacy); default is GateUp. Options will be trimmed once fused backward is in place.
- **Perf:** NanoLLaMA — GateUp 3.26 ms/block (22.7% faster than composite 4.29 ms). TinyLLaMA — GateUp 5.21 ms/block (~16% slower than composite 4.49 ms); FullFusion remains ~290% slower on TinyLLaMA.
- **Memory:** Fused paths reduce Segment Peak (forward) and Allocations (forward) vs composite (e.g. NanoLLaMA ~37% lower peak; TinyLlama 22-block extrapolated ~18.6% lower peak). Backward currently recomputes intermediates; path choice is intended to be reduced later.

## Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=mdragula/2_steps_swiglu_fw)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch=mdragula/2_steps_swiglu_fw)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=mdragula/2_steps_swiglu_fw)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch=mdragula/2_steps_swiglu_fw)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mdragula/2_steps_swiglu_fw)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch=mdragula/2_steps_swiglu_fw)
- [x] New/Existing tests provide coverage for changes
