### PR TITLE
Move moe core helper function to experimental namespace

### DIFF
--- a/tests/nightly/tg/ccl/moe/test_moe_compute_6U.py
+++ b/tests/nightly/tg/ccl/moe/test_moe_compute_6U.py
@@ -1360,7 +1360,7 @@ def test_moe_compute(
         }
     )
 
-    output_shard_cores = ttnn.get_moe_combine_cores(mesh_device)
+    output_shard_cores = ttnn.experimental.get_moe_combine_cores(mesh_device)
     per_expert_tokens_all_passed = True
     activation_all_passed = True
     e_t_all_passed = True

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/moe_compute_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/moe_compute_nanobind.cpp
@@ -75,7 +75,7 @@ void bind_moe_compute(nb::module_& mod) {
 
 void bind_get_moe_combine_cores(nb::module_& mod) {
     const auto* doc = R"doc(Return the ordered list of cores assigned to A2A Combine for the MoE module flow )doc";
-    ttnn::bind_function<"get_moe_combine_cores">(
+    ttnn::bind_function<"get_moe_combine_cores", "ttnn.experimental.">(
         mod,
         doc,
         // Overload 1: single split_size (int64_t)


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/38713

### Problem description
MoE helper function should be in experimental namespace

### What's changed
Move MoE core helper function experimental namespace.

### Checklist

- [ ] [![All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg?branch=amorrison/fix-moe-helper-namespace-violation)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml?query=branch:amorrison/fix-moe-helper-namespace-violation)
- [ ] [![Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=amorrison/fix-moe-helper-namespace-violation)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:amorrison/fix-moe-helper-namespace-violation)
- [ ] [![cpp-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=amorrison/fix-moe-helper-namespace-violation)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:amorrison/fix-moe-helper-namespace-violation)
- [ ] New/Existing tests provide coverage for changes


- [ ] [![(Galaxy) Choose your pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=amorrison/fix-moe-helper-namespace-violation)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:amorrison/fix-moe-helper-namespace-violation)
