### PR TITLE
Removed BHPC priority runner for smoke tests

### DIFF
--- a/.github/workflows/smoke.yaml
+++ b/.github/workflows/smoke.yaml
@@ -31,10 +31,7 @@ on:
 jobs:
   smoke:
     timeout-minutes: 30
-    runs-on: >-
-      ${{
-       ( format('tt-ubuntu-2204-{0}-stable', inputs.runner))
-      }}
+    runs-on: ${{ format('tt-ubuntu-2204-{0}-stable', inputs.runner) }}
     container:
       image: ${{ (inputs.docker-image && (contains(inputs.runner, 'dedicated-merge-gate') && inputs.docker-image || format('harbor.ci.tenstorrent.net/{0}', inputs.docker-image))) || 'docker-image-unresolved!' }}
       env:

--- a/.github/workflows/smoke.yaml
+++ b/.github/workflows/smoke.yaml
@@ -33,9 +33,7 @@ jobs:
     timeout-minutes: 30
     runs-on: >-
       ${{
-        (github.workflow == 'Blackhole post-commit tests' && github.ref_name == 'main' && inputs.runner == 'P150b-viommu')
-          && 'tt-ubuntu-2204-p150b-viommu-post-commit'
-          || format('tt-ubuntu-2204-{0}-stable', inputs.runner)
+       ( format('tt-ubuntu-2204-{0}-stable', inputs.runner))
       }}
     container:
       image: ${{ (inputs.docker-image && (contains(inputs.runner, 'dedicated-merge-gate') && inputs.docker-image || format('harbor.ci.tenstorrent.net/{0}', inputs.docker-image))) || 'docker-image-unresolved!' }}


### PR DESCRIPTION
This runner was used to test the priority queue implementation, which proved successful. This is being removed now,  so all bhpc jobs will go back to using the regular p150b-viommu runner. Then we can rename the priority runner to have a postfix of "priority" instead of "post-commit", and use that priority runner in merge gate.