### PR TITLE
Fix rotary embedding test in L2 Nightly

### DIFF
--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_rotary_embedding_llama.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_rotary_embedding_llama.py
@@ -577,7 +577,7 @@ def test_rotary_embedding_llama_with_program_cache(
 
     num_ops = 2  # 2 * rope
     if mode == "decode":
-        # RopeSetup stores cos/sin in ROW MAJOR layout (no untilize is needed in embedding)
+        # RotarySetup stores cos/sin in ROW MAJOR layout (no untilize is needed in embedding)
         num_ops += 3  # embedding + transpose + interleaved_to_sharded
 
         if batch % ttnn.TILE_SIZE != 0:

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_rotary_embedding_llama.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_rotary_embedding_llama.py
@@ -577,7 +577,8 @@ def test_rotary_embedding_llama_with_program_cache(
 
     num_ops = 2  # 2 * rope
     if mode == "decode":
-        num_ops += 4  # untilize cos/sin + embedding + transpose + interleaved_to_sharded
+        # RopeSetup stores cos/sin in ROW MAJOR layout (no untilize is needed in embedding)
+        num_ops += 3  # embedding + transpose + interleaved_to_sharded
 
         if batch % ttnn.TILE_SIZE != 0:
             num_ops += 1  # slice

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_rotary_embedding_llama_fused_qk.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_rotary_embedding_llama_fused_qk.py
@@ -129,7 +129,7 @@ def test_rotary_embedding_llama_fused_qk_with_program_cache(
 
         cache_tensors.append(test_tensor)
 
-    num_ops = 5  # untilize cos/sin + embedding + fused_qk_rope + transpose + interleaved_to_sharded
+    num_ops = 4  # cos/sin + embedding + fused_qk_rope + transpose + interleaved_to_sharded
 
     if (batch * 2) % ttnn.TILE_SIZE != 0:
         num_ops += 1  # slice


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/38712#event-23127025081

### Problem description
change number of ops incremented since untilize is not called in embedding, cos sin matrices are stored in row major already

### What's changed
num ops 4 to 3

### Checklist
- [ ] [L2 nightly](https://github.com/tenstorrent/tt-metal/actions/runs/22736493294)